### PR TITLE
docs: replace QuickDapp with Hono/Bun, add PGlite live queries, MCP endpoint, skill file, and migration system

### DIFF
--- a/.dev/api.md
+++ b/.dev/api.md
@@ -1998,3 +1998,63 @@ Every mutating operation writes to `audit_log`. Standard action names:
 | `budget.warning` | agent | Agent hits 80% budget |
 | `budget.exceeded` | agent | Agent hits 100% budget |
 | `budget.reset` | agent | Monthly budget reset |
+
+---
+
+## MCP Endpoint
+
+Hezo exposes an MCP (Model Context Protocol) endpoint for external AI agents to discover and invoke Hezo operations programmatically.
+
+### `POST /mcp`
+
+Streamable HTTP MCP endpoint. Uses `@modelcontextprotocol/sdk` with the `McpServer` class. Supports bidirectional messaging with optional Server-Sent Events (SSE) for streaming responses.
+
+**Authentication:** Same as REST API — local trusted, Better Auth session, or API key (`Authorization: Bearer hezo_<key>`).
+
+**Capabilities:**
+- `tools` — Hezo registers all operations as MCP tools
+- `listChanged` — tool list can change dynamically (e.g. when plugins register new tools)
+
+**Registered tools:**
+
+| Tool | Description | Key Parameters |
+|------|-------------|----------------|
+| `list_companies` | List all companies | — |
+| `create_company` | Create a new company | `name`, `mission` |
+| `list_issues` | List issues with filtering | `company_id`, `project_id?`, `status?`, `assignee?` |
+| `create_issue` | Create a new issue | `company_id`, `project_id`, `title`, `description?`, `priority?` |
+| `update_issue` | Update an issue | `issue_id`, `status?`, `assignee?`, `priority?` |
+| `list_agents` | List agents in a company | `company_id` |
+| `hire_agent` | Create a new agent | `company_id`, `title`, `role_description`, `reports_to?` |
+| `post_comment` | Post a comment on an issue | `issue_id`, `content`, `content_type?` |
+| `list_comments` | List comments on an issue | `issue_id` |
+| `approve_request` | Approve a pending approval | `approval_id`, `scope?` |
+| `deny_request` | Deny a pending approval | `approval_id`, `reason?` |
+| `list_approvals` | List pending approvals | `company_id`, `type?` |
+| `search_kb` | Search knowledge base documents | `company_id`, `query` |
+| `update_kb_doc` | Create or update a KB document | `company_id`, `slug`, `title`, `content` |
+| `get_cost_summary` | Get cost breakdown | `company_id`, `group_by?` |
+| `list_projects` | List projects in a company | `company_id` |
+| `list_secrets` | List secret names (not values) | `company_id`, `project_id?` |
+
+MCP tools call the same business logic layer as REST endpoints. Additional tools are registered dynamically when plugins are activated.
+
+---
+
+## Skill File
+
+### `GET /skill.md`
+
+Returns a Markdown document that teaches external AI agents how to interact with Hezo. This is the primary onboarding mechanism for AI-to-AI integration.
+
+**Response:** `Content-Type: text/markdown`
+
+The skill file is dynamically generated at startup from the registered MCP tool definitions and includes:
+- Overview of Hezo and its purpose
+- Available MCP tools with parameter schemas and descriptions
+- Common workflows (create issue → assign agent → monitor → approve)
+- REST API endpoint summary (fallback for agents without MCP support)
+- Authentication setup instructions (API key creation)
+- Example interactions
+
+The same content is also committed to the repo at `.claude/skills/hezo/SKILL.md` for local Claude Code discovery.

--- a/.dev/connect-spec.md
+++ b/.dev/connect-spec.md
@@ -443,6 +443,6 @@ hezo --connect-url https://connect.hezo.ai --connect-api-key hc_abc123
 # Use self-hosted
 hezo --connect-url https://my-connect.example.com
 
-# Disable Hezo Connect entirely (manual credentials only)
-hezo --no-connect
+# Local development (default: Hezo Connect at http://localhost:4100)
+hezo
 ```

--- a/.dev/implementation-phases.md
+++ b/.dev/implementation-phases.md
@@ -10,9 +10,10 @@
 **Goal:** A working Hezo server that can create companies, manage agents, run heartbeats, and execute work via issue tickets. Includes Hezo Connect (self-hosted, GitHub only) so that repos can be validated and cloned via OAuth from the start.
 
 **What's included:**
-- QuickDapp server with PGlite database
+- Hono server (TypeScript) with PGlite (NodeFS filesystem persistence) and live queries
+- `bun build --compile` for single executable binary output (cross-platform)
 - Master key lifecycle (generate, store canary, verify on startup)
-- Schema migration runner (all tables from `schema_migration.sql`)
+- Migration system with `_migrations` tracking table, numbered SQL files (`001_initial_schema.sql`)
 - Company CRUD (create, update, delete, list, clone)
 - Issue prefix + Linear-style identifiers (ACME-42)
 - Agent CRUD (hire, update, pause, resume, terminate)
@@ -43,6 +44,9 @@
 - Structured options (clickable choice cards)
 - Tool call tracing
 - WebSocket real-time events
+- PGlite live queries for frontend real-time data reactivity (`live.query()`, `live.changes()`)
+- MCP endpoint (Streamable HTTP at `/mcp`) — exposes Hezo operations as MCP tools for external AI agents
+- Skill file served at `GET /skill.md` — teaches AI agents how to interact with Hezo
 - Hezo Connect server (self-hosted mode, GitHub only):
   - Standalone Bun/Hono HTTP server running alongside the main Hezo app
   - GitHub OAuth flow: initiation, consent redirect, callback with browser redirect
@@ -57,7 +61,7 @@
   - Repo access validation: test GitHub API access before saving repo
   - Board inbox `oauth_request` items when GitHub not connected
   - Connected platforms UI in company settings
-- React frontend (bundled into binary):
+- React frontend (bundled into binary via `bun build --compile`):
   - Company list + creation
   - Issue list + detail (Comments tab + Live Chat tab)
   - Agent list + detail + hire form
@@ -86,7 +90,6 @@
 - No file attachments
 - No session compaction
 - No Telegram notifications
-- No MCP server config
 - No MPP payments
 
 **Auth:** `local_trusted` mode only — no login required, single user.
@@ -211,7 +214,7 @@
 
 | Phase | Focus | Key Deliverable |
 |-------|-------|----------------|
-| 1 | Core server + agents + GitHub OAuth | Working orchestration platform with Claude Code agents and GitHub repo validation via Hezo Connect |
+| 1 | Core server + agents + GitHub OAuth + MCP | Working orchestration platform with Claude Code agents, GitHub repo validation via Hezo Connect, MCP endpoint, and skill file |
 | 2 | Auth + sessions | Multi-user, long-running agent support |
 | 3 | Adapters + plugins | Gemini support, extensibility |
 | 4 | Full platform integrations | All OAuth platforms, centrally hosted Connect, MCP auto-registration |

--- a/.dev/implementation-phases.md
+++ b/.dev/implementation-phases.md
@@ -2,211 +2,361 @@
 
 > Hezo is a large system. This document breaks implementation into ordered phases,
 > each delivering a working, testable increment. Later phases build on earlier ones.
+> Each phase has a "How to test" section describing concrete validation steps.
+>
+> **Testing is mandatory in every phase.** Unit tests (Vitest), integration tests
+> (Vitest + PGlite template database pattern), and E2E tests (Playwright for UI,
+> Vitest for API) are built alongside the features they test.
 
 ---
 
-## Phase 1: Core Server + Agent Orchestration
+## Phase 0: Hezo Connect (Self-Hosted, GitHub Only)
 
-**Goal:** A working Hezo server that can create companies, manage agents, run heartbeats, and execute work via issue tickets. Includes Hezo Connect (self-hosted, GitHub only) so that repos can be validated and cloned via OAuth from the start.
+**Goal:** A standalone OAuth relay that can handle GitHub OAuth flows. First thing built, independently testable, no dependency on the main Hezo app. Lives in `packages/connect`.
 
 **What's included:**
-- Hono server (TypeScript) with PGlite (NodeFS filesystem persistence) and live queries
-- `bun build --compile` for single executable binary output (cross-platform)
-- Master key lifecycle (generate, store canary, verify on startup)
-- Migration system with `_migrations` tracking table, numbered SQL files (`001_initial_schema.sql`)
-- Company CRUD (create, update, delete, list, clone)
-- Issue prefix + Linear-style identifiers (ACME-42)
-- Agent CRUD (hire, update, pause, resume, terminate)
-- 9 built-in role templates auto-created on company setup (DevOps starts idle)
-- Org chart with reporting lines
-- Project + repo management with GitHub OAuth validation (see below)
-- Issue CRUD with full status state machine (backlog → open → in_progress → review → blocked → done → closed → cancelled)
-- Issue comments (text, options, preview, trace, system)
-- Sub-issues and delegation (org-chart enforced)
-- @-mentions in comments with agent notifications
-- Heartbeat engine: wakeup queue, coalescing, timer ticks
-- Issue execution locking (SELECT FOR UPDATE)
-- Orphan detection and auto-retry
-- Agent runtime: `claude_code` adapter (subprocess in company container)
-- Company Docker container lifecycle (provision, start, stop, rebuild) + agent subprocess management
-- Git worktrees for parallel work
-- Host filesystem layout (~/.hezo/)
-- Per-agent and per-company budgets with atomic debit
-- Cost tracking (per agent, per issue, per project)
-- Audit log (append-only)
-- Secrets management (AES-256-GCM encryption, grants, approval flow)
-- Approval system (secret_access, hire, strategy, plan_review, kb_update)
-- Knowledge base (CRUD, agent proposals, revision history)
-- Company preferences (board working style, agent-driven updates, revision history)
-- Project-level shared documents (tech spec, implementation plan, research, UI decisions, marketing plan)
-- Persistent live chat (per-issue, @-mention agents, WebSocket)
-- HTML previews (agent writes to shared workspace volume, served via proxy)
-- Structured options (clickable choice cards)
-- Tool call tracing
-- WebSocket real-time events
-- PGlite live queries for frontend real-time data reactivity (`live.query()`, `live.changes()`)
-- MCP endpoint (Streamable HTTP at `/mcp`) — exposes Hezo operations as MCP tools for external AI agents
-- Skill file served at `GET /skill.md` — teaches AI agents how to interact with Hezo
-- Hezo Connect server (self-hosted mode, GitHub only):
-  - Standalone Bun/Hono HTTP server running alongside the main Hezo app
-  - GitHub OAuth flow: initiation, consent redirect, callback with browser redirect
-  - State parameter signing (HMAC-SHA256) for CSRF prevention
-  - Token delivery via browser redirect (not server-to-server POST)
-  - Stateless — no database, in-memory state map for in-flight OAuth nonces
-  - Dev GitHub OAuth app setup
-- GitHub OAuth integration in the main Hezo app:
-  - `POST /connections/github/start` — generate auth URL with signed state
-  - `GET /oauth/callback` — receive tokens via query params, encrypt, store
-  - `connected_platforms` record creation
-  - Repo access validation: test GitHub API access before saving repo
-  - Board inbox `oauth_request` items when GitHub not connected
-  - Connected platforms UI in company settings
-- React frontend (bundled into binary via `bun build --compile`):
-  - Company list + creation
-  - Issue list + detail (Comments tab + Live Chat tab)
-  - Agent list + detail + hire form
-  - Org chart view
-  - Project + repo management
-  - Approval inbox
-  - Board inbox (notifications)
-  - Knowledge base viewer/editor
-  - Company preferences editor
-  - Project documents tab (per-project)
-  - Secrets vault
-  - Cost dashboard
-  - Audit log viewer
-  - Settings page (including connected platforms)
+- Standalone Bun/Hono HTTP server (port 4100 by default)
+- 3 endpoints:
+  - `GET /health` — returns `{ "ok": true }`
+  - `GET /auth/github/start?callback=...&state=...` — redirects to GitHub OAuth consent screen with signed state
+  - `GET /auth/github/callback` — exchanges auth code for token, redirects back to caller with token in query params
+- HMAC-SHA256 state parameter signing for CSRF prevention
+- In-memory nonce map for in-flight OAuth flows (no database)
+- Token delivery via browser redirect (not server-to-server POST)
+- Environment config: `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, `STATE_SIGNING_KEY`
 
-**What's NOT included:**
-- No centrally hosted Hezo Connect (connect.hezo.ai) — self-hosted only
-- No non-GitHub platform connections (Gmail, Stripe, etc. — Phase 4)
-- No auto-registration of platforms as MCP servers (Phase 4)
-- No token refresh lifecycle (Phase 4)
-- No agent-initiated OAuth link requests (Phase 4)
-- No multi-user auth (localhost trusted mode only)
-- No plugin system
-- No Gemini/Codex adapters (Claude Code only)
-- No staging/production deployment pipeline
-- No file attachments
-- No session compaction
-- No Telegram notifications
-- No MPP payments
+**How to test:**
+- `curl localhost:4100/health` returns 200
+- Open `localhost:4100/auth/github/start?callback=http://localhost:3000/test&state=...` in browser — redirects to GitHub consent
+- After authorizing, browser redirects back to callback URL with `access_token` and `state` params
+- Invalid/tampered state params are rejected
+- Unit tests for state signing and nonce management
 
-**Auth:** `local_trusted` mode only — no login required, single user.
-
-**Agent credentials:** GitHub access is handled via OAuth (Hezo Connect). Other credentials (API keys, etc.) are manually configured via the secrets vault.
-
-**Testing:** Vitest for unit/integration, Playwright for E2E. Template database pattern for test isolation.
+**Depends on:** Nothing
 
 ---
 
-## Phase 2: Multi-User Auth + Session Compaction
+## Phase 1: Foundation
 
-**Goal:** Multiple board members can log in, collaborate on the same company, and agents can work on long-running tasks without context window blowup.
+**Goal:** A running Hono server with an embedded database, migration system, master key, and CLI argument parsing. No business logic yet. Lives in `packages/server` with shared types in `packages/shared`.
 
 **What's included:**
-- Better Auth integration (email/password, sessions)
-- Login / register pages
-- Company memberships (owner, member)
-- Invites (email + code, 7-day expiry)
-- `authenticated` deployment mode
-- Account settings page
-- Session management and compaction:
-  - `agent_task_sessions` table
-  - Per-adapter compaction policies
-  - Handoff markdown generation
-  - Usage normalization (delta computation)
-- File attachments (upload, download, issue linking, local storage)
+- Hono server (TypeScript)
+- PGlite with NodeFS filesystem persistence at `~/.hezo/pgdata`
+- Migration runner: reads numbered SQL files, tracks in `_migrations` table, runs on startup
+- `001_initial_schema.sql` applied on first run
+- Master key lifecycle: auto-generate on first run (display in terminal), web UI prompt on subsequent runs, `--master-key` CLI override
+- CLI parsing: `--data-dir`, `--master-key`, `--port`, `--connect-url`, `--connect-api-key`
+- Sensible defaults: port 3100, connect-url `http://localhost:4100`, data-dir `~/.hezo/`
+- `GET /health` endpoint
+- Test infrastructure: Vitest config, template database pattern, port allocation utility
+
+**How to test:**
+- `hezo --port 3100` starts server, prints master key on first run
+- `hezo --master-key <key> --port 3100` verifies key and starts
+- Wrong master key refuses to start
+- `curl localhost:3100/health` returns 200
+- PGlite data persists at `~/.hezo/pgdata` between restarts
+- Migration table shows `001_initial_schema.sql` as applied
+
+**Depends on:** Nothing
+
+---
+
+## Phase 2: Core CRUD
+
+**Goal:** Full REST API for all core entities. No Docker, no agents running, no OAuth — all testable with curl.
+
+**What's included:**
+- Company types CRUD (create, list, get, update, delete)
+  - Built-in "Software Development" type seeded on first run
+- Company CRUD (create from company type, update, delete, list)
+  - Company email field
+  - Issue prefix and auto-derived identifiers
+- Agent CRUD (create/hire, update, pause, resume, terminate, list)
+  - Agents auto-created from company type on company creation
+  - Custom role creation with arbitrary titles/prompts
+  - Org chart with `reports_to` hierarchy
+- Project CRUD (create, update, delete, list)
+- Issue CRUD (create, update, delete, list, status transitions)
+  - Atomic issue numbering (`next_issue_number()`)
+  - Linear-style identifiers (ACME-42)
+  - Issue work ownership fields
+  - Sub-issues and `blocked_by`
+- Comment CRUD (create, list) with all content types (text, options, preview, trace, system)
+- Secrets vault (create, list, revoke — encrypted with master key)
+- Secret grants (create, revoke)
+- Approvals (create, approve, deny, list)
+- Cost entries (create, list, budget queries)
+  - `debit_agent_budget()` atomic function
+- API keys (create, list, revoke)
+- Board API authentication: `local_trusted` mode (localhost only)
+
+**How to test:**
+- Create a company type, then create a company from it — 9 agents auto-created
+- Full CRUD cycle for every entity via curl
+- Issue status state machine enforced (invalid transitions rejected)
+- Issue identifiers auto-generated correctly (ACME-1, ACME-2, ...)
+- Budget debit works atomically
+- Secret values encrypted in DB, decrypted on read
+- Comprehensive Vitest suite covering all endpoints
 
 **Depends on:** Phase 1
 
 ---
 
-## Phase 3: More Adapters + Plugin System
+## Phase 3: GitHub Integration
 
-**Goal:** Agents can use Gemini (and other runtimes), and the platform is extensible via plugins.
+**Goal:** Connect Phase 0 (Hezo Connect) to the main app. OAuth callback, token storage, repo validation.
 
 **What's included:**
-- Gemini adapter (subprocess, Gemini CLI)
-- `bash` adapter refinements
-- `http` adapter refinements
-- Plugin system:
-  - Worker thread isolation
-  - Capability-gated APIs (state, events, tools, http, secrets, cron)
-  - Plugin lifecycle (install → enable → running ↔ disabled → uninstall)
-  - Crash recovery with exponential backoff
-  - `@hezo/plugin-sdk` package
-  - Local plugin loading (filesystem path)
-  - Plugin management UI (install, configure, enable/disable)
-- Plugin registry (plugins.hezo.ai):
-  - Browse and search
-  - Ratings and reviews
-  - Download counts, verified publishers
-  - Version management
-  - Self-hosted registry support (`--plugin-registry-url`)
+- `POST /connections/github/start` — generates auth URL via Hezo Connect
+- `GET /oauth/callback` — receives token, encrypts, stores in `connected_platforms`
+- Repo CRUD with GitHub access validation (API check with OAuth token before saving)
+- Repo cloning via HTTPS + OAuth token
+- Company-level `.claude/` folder setup and symlinks
+- Board inbox `oauth_request` items when GitHub not connected
+- Connected platforms management (connect, disconnect)
 
-**Depends on:** Phase 2
+**How to test:**
+- Start Hezo Connect (Phase 0) on port 4100 and main app on port 3100
+- Connect a GitHub account via the OAuth flow
+- Add a repo — system validates access via GitHub API
+- Invalid repo URL or no access returns clear error
+- Repo is cloned to correct filesystem path
+- Token is encrypted in secrets table
+
+**Depends on:** Phase 0, Phase 2
 
 ---
 
-## Phase 4: Full Platform Integrations
+## Phase 4: Agent Execution
 
-**Goal:** Extend Hezo Connect beyond GitHub to support all platforms, add centrally hosted mode, and enable MCP auto-registration.
+**Goal:** Agents can actually run. Docker containers per project, subprocesses, heartbeats, worktrees, budget enforcement.
 
 **What's included:**
-- Hezo Connect — centrally hosted mode (connect.hezo.ai):
-  - API key system for Hezo instances
-  - Account management (email/password, dashboard)
-  - Usage tracking and billing infrastructure
-  - Rate limiting and abuse prevention
-- Additional platform OAuth support:
-  - Gmail: agent email send/receive
-  - GitLab: repo access, CI/CD pipelines
-  - Stripe: payments, subscriptions, invoices
-  - PostHog: analytics queries, feature flags
-  - Railway: deploy, environment management
-  - Vercel: deployments, domains, env vars
-  - DigitalOcean: droplets, databases, apps
-  - X (Twitter): post tweets, read timeline
-- Token refresh lifecycle:
-  - Automatic access token refresh using stored refresh tokens
-  - Expired connection detection and board notification
-  - Manual refresh endpoint for intervention
-- Auto-registration of connected platforms as company-level MCP servers
-- Agent-initiated OAuth link requests (24-hour validity, board inbox + ticket comment)
-- MCP server configuration (company-level + agent-level, merged at runtime)
-- Connection lifecycle management (health checks, disconnect, re-authorize)
+- Project Docker container lifecycle (provision, start, stop, rebuild via Docker Engine API)
+  - One container per project (all repos checked out inside)
+  - Dev port forwarding for preview access
+- Agent subprocess management (`claude_code` adapter: subprocess in project container via `docker exec`)
+- Git worktrees for parallel agent work
+- Heartbeat engine: wakeup queue, coalescing, timer ticks
+- Issue work ownership (claim on start, release on complete/reassign/pause)
+- Orphan detection and auto-retry
+- Per-agent and per-company budget enforcement with atomic debit
+- Cost tracking (per agent, per issue, per project)
+- Tool call tracing
+- Host filesystem layout (`~/.hezo/companies/{id}/projects/{id}/...`)
+- Agent JWT authentication for Agent API
+
+**How to test:**
+- Create a project — Docker container provisioned automatically
+- Assign an issue to an agent — agent subprocess starts in project container
+- Multiple agents work on different issues simultaneously (separate worktrees)
+- Budget exceeded pauses agent with system comment
+- Container crash detected and reported
+- Orphaned work re-queued after failure
+- Dev port forwarding accessible from host browser
 
 **Depends on:** Phase 3
 
 ---
 
-## Phase 5: Deployment Pipeline + Notifications
+## Phase 5: Knowledge + Observability
 
-**Goal:** Agents can deploy to staging/production, and board members get notified via Telegram.
+**Goal:** KB, preferences, project docs, audit log, live queries, WebSocket events, live chat, previews.
 
 **What's included:**
-- Staging environment management:
-  - Auto-deploy on push to main
-  - Neon database for staging
-  - GitHub Actions workflow generation
-  - Deploy status reporting back to Hezo
-- Production deployment:
-  - `deploy_production` approval gate
-  - Commit diff + staging verification before approval
-  - Deploy execution after board approval
-- DevOps Engineer activation flow (board sets to active when ready)
-- Telegram notifications:
-  - Per-user Telegram bot integration
-  - Configurable in account settings
-  - Notifications for inbox items (approvals, escalations, budget alerts, etc.)
-- MPP (Machine Payments Protocol):
-  - Wallet config per company
-  - `mppx` CLI in company container
-  - Autonomous HTTP 402 payment flow
-  - Cost tracking integration
+- Knowledge base CRUD (documents, revisions, agent proposals, approval flow)
+- Company preferences (document, revisions, agent-driven updates)
+- Project-level shared documents (tech spec, implementation plan, research, UI decisions, marketing plan)
+- Audit log (append-only, never updated/deleted)
+- PGlite live queries for frontend data reactivity (`live.query()`, `live.changes()`)
+- WebSocket real-time events (agent lifecycle, container status, live chat)
+- Persistent live chat (per-issue, @-mention agents)
+- HTML previews (agent writes to workspace volume, served via proxy)
+- Structured options (clickable choice cards)
+
+**How to test:**
+- Create KB doc, agent proposes edit, board approves — revision history correct
+- Audit log entries created for all significant actions
+- Tool calls visible in issue thread
+- WebSocket events fire on agent status changes
+- Live chat session persists across page reloads
+- Preview URL serves agent-generated HTML
+- Live query updates frontend without page refresh
 
 **Depends on:** Phase 4
+
+---
+
+## Phase 6: MCP + Skill File
+
+**Goal:** External AI agents can interact with Hezo via MCP or by reading the skill file.
+
+**What's included:**
+- MCP endpoint (Streamable HTTP at `POST /mcp`)
+  - All Board API operations exposed as MCP tools
+  - Authentication via API key or local trusted
+- Skill file at `GET /skill.md`
+  - Dynamically generated from registered MCP tool definitions
+  - Also committed to repo at `.claude/skills/hezo/SKILL.md`
+
+**How to test:**
+- Connect an MCP client to `localhost:3100/mcp` — tools listed and callable
+- Create an issue via MCP `create_issue` tool call — verified in DB
+- `curl localhost:3100/skill.md` returns valid Markdown listing all current tools
+- API key auth required for MCP when in `authenticated` mode
+
+**Depends on:** Phase 5
+
+---
+
+## Phase 7: React Frontend
+
+**Goal:** All UI screens, bundled into the binary via `bun build --compile`.
+
+**What's included:**
+- Company list + creation (select company type)
+- Company workspace: Issues, Agents, Projects, Org Chart, KB, Settings tabs
+- Issue detail (Comments tab + Live Chat tab)
+- Agent detail + hire form (including custom role creation)
+- Approval inbox + board inbox
+- Secrets vault UI
+- Cost dashboard
+- Audit log viewer
+- Settings page (connected platforms, company email, MCP servers, preferences)
+- Project detail with Documents tab and Dev Preview link
+- PGlite React hooks (`useLiveQuery`, `useLiveIncrementalQuery`) for real-time data
+- Master key entry screen (shown on startup when key not provided via CLI)
+- `bun build --compile` producing single self-contained binary
+- Playwright E2E tests covering all major UI flows
+
+**How to test:**
+- Build binary, run it, open browser — all screens render
+- Create/edit/delete operations work from UI
+- Live data updates without page refresh (live queries)
+- Board inbox shows pending approvals with one-click actions
+- Org chart displays correct hierarchy
+- Dev preview link opens running project in new tab
+- Playwright tests pass
+
+**Depends on:** Phase 6
+
+---
+
+## Phase 8: Multi-User Auth + Company Email
+
+**Goal:** Better Auth, company email invites, multiple board members, session compaction.
+
+**What's included:**
+- Better Auth integration:
+  - Email/password signup and login
+  - GitHub OAuth login for board members (via Hezo Connect)
+  - GitLab OAuth login for board members (via Hezo Connect)
+  - Session cookies
+- `authenticated` deployment mode
+- Login / register pages (with OAuth buttons)
+- Company memberships (owner, member)
+- Invite system:
+  - Email invites sent from company email address
+  - Invite link with unique token, 7-day expiry
+  - Recipient authenticates via email/password, GitHub OAuth, or GitLab OAuth
+- Instance admin (first user)
+- Account settings page
+- Session compaction:
+  - `agent_task_sessions` table
+  - Per-adapter compaction policies
+  - Handoff markdown generation
+- File attachments (upload, download, issue linking, local storage)
+
+**How to test:**
+- Create account with email/password, log in, access company
+- Create account via GitHub OAuth, log in, access company
+- Invite a user by email — email sent from company address — recipient joins via link
+- Multiple board members collaborate on same company
+- Unauthorized access rejected in authenticated mode
+- Session compaction triggers after token threshold
+
+**Depends on:** Phase 7
+
+---
+
+## Phase 9: Adapters + Plugins
+
+**Goal:** Non-Claude-Code agent runtimes and the plugin system.
+
+**What's included:**
+- Gemini adapter (subprocess, Gemini CLI)
+- Codex adapter
+- `bash` adapter refinements
+- `http` adapter refinements
+- Plugin system:
+  - Worker thread isolation
+  - Capability-gated APIs (state, events, tools, http, secrets, cron)
+  - Plugin lifecycle (install, enable, disable, uninstall)
+  - Crash recovery with exponential backoff
+  - `@hezo/plugin-sdk` package
+  - Local plugin loading (filesystem path)
+  - Plugin management UI
+- Plugin registry (plugins.hezo.ai):
+  - Browse, search, ratings, version management
+  - Self-hosted registry support (`--plugin-registry-url`)
+
+**How to test:**
+- Create agent with Gemini runtime — executes via Gemini CLI
+- Install a test plugin — runs in worker thread, can read/write state
+- Plugin crash is recovered with backoff
+- Plugin capabilities enforced (unauthorized API access blocked)
+
+**Depends on:** Phase 8
+
+---
+
+## Phase 10: Full Platform Integrations
+
+**Goal:** Extend Hezo Connect beyond GitHub to all supported platforms. Centrally hosted mode.
+
+**What's included:**
+- Hezo Connect — centrally hosted mode (connect.hezo.ai):
+  - API key system for Hezo instances
+  - Account management, usage tracking, billing infrastructure
+  - Rate limiting and abuse prevention
+- Additional platform OAuth: Gmail, GitLab, Stripe, PostHog, Railway, Vercel, DigitalOcean, X
+- Token refresh lifecycle (automatic refresh, expiry detection, board notification)
+- Auto-registration of connected platforms as company-level MCP servers
+- Agent-initiated OAuth link requests (24-hour validity, board inbox + ticket comment)
+- MCP server configuration (company-level + agent-level, merged at runtime)
+- Connection lifecycle management (health checks, disconnect, re-authorize)
+
+**How to test:**
+- Connect Gmail, Stripe, etc. via OAuth flow
+- Token auto-refreshes before expiry
+- Expired connection triggers board notification
+- Connected platform appears as MCP server for agents
+
+**Depends on:** Phase 9
+
+---
+
+## Phase 11: Deploy + Notifications
+
+**Goal:** Agents can deploy to staging/production. Board members receive Telegram notifications.
+
+**What's included:**
+- Staging environment management (auto-deploy on push to main, Neon DB, GitHub Actions)
+- Production deployment with `deploy_production` approval gate
+- DevOps Engineer activation flow (board sets to active when ready)
+- Telegram notifications (per-user, configurable in account settings, deep links)
+- MPP (Machine Payments Protocol): wallet config, `mppx` CLI, autonomous HTTP 402 flow
+
+**How to test:**
+- Agent pushes to main — staging auto-deploys
+- Production deploy requires board approval — deploy executes after approval
+- Telegram notification received for pending approval with working deep link
+- MPP payment flow completes for HTTP 402 responses
+
+**Depends on:** Phase 10
 
 ---
 
@@ -214,10 +364,17 @@
 
 | Phase | Focus | Key Deliverable |
 |-------|-------|----------------|
-| 1 | Core server + agents + GitHub OAuth + MCP | Working orchestration platform with Claude Code agents, GitHub repo validation via Hezo Connect, MCP endpoint, and skill file |
-| 2 | Auth + sessions | Multi-user, long-running agent support |
-| 3 | Adapters + plugins | Gemini support, extensibility |
-| 4 | Full platform integrations | All OAuth platforms, centrally hosted Connect, MCP auto-registration |
-| 5 | Deploy + notifications | Staging/production pipeline, Telegram |
+| 0 | Hezo Connect | Standalone GitHub OAuth relay, independently testable |
+| 1 | Foundation | Hono + PGlite + migrations + master key + CLI |
+| 2 | Core CRUD | Companies (with types), agents, issues, projects — all via REST |
+| 3 | GitHub Integration | OAuth flow, token storage, repo validation and cloning |
+| 4 | Agent Execution | Docker per project, subprocesses, heartbeats, worktrees, budgets |
+| 5 | Knowledge + Observability | KB, preferences, project docs, audit log, live queries, WebSocket |
+| 6 | MCP + Skill File | MCP endpoint at `/mcp`, skill file at `/skill.md` |
+| 7 | React Frontend | All UI screens, bundled into single binary |
+| 8 | Multi-User Auth | Better Auth (email + OAuth), invites, memberships, session compaction |
+| 9 | Adapters + Plugins | Gemini/Codex adapters, plugin system |
+| 10 | Full Platform Integrations | All OAuth platforms, centrally hosted Connect |
+| 11 | Deploy + Notifications | Staging/production pipeline, Telegram, MPP |
 
-Each phase produces a usable system. Phase 1 alone is a functional product — a single user can create companies, hire agents, assign work, and watch agents execute via the web UI.
+Each phase produces a testable increment. Phase 0 can be built and verified in isolation. Phases 1–2 give a working API server testable entirely with curl. Phase 4 is where agents first run. Phase 7 adds the visual UI. Phase 8 enables team usage.

--- a/.dev/schema.md
+++ b/.dev/schema.md
@@ -1,18 +1,19 @@
 # Data Model — Design Decisions
 
-## 34 tables, 3 functions
+## 35 tables, 3 functions
 
 | Table | Purpose | Key relationships |
 |-------|---------|-------------------|
 | `system_meta` | Key-value config store. Holds master key canary. | Standalone. |
 | `users` | Board members (Better Auth managed). Email, password hash, name. | Standalone (auth). |
 | `sessions` | Better Auth session tokens. | belongs to user |
-| `companies` | Top-level tenant. Has `issue_prefix`, `mcp_servers` (JSONB), `mpp_config` (JSONB), company-level budget. | Parent of everything. |
+| `company_types` | Company blueprints (recipes). Default agent configs, KB docs, preferences as JSONB snapshots. | Referenced by companies. |
+| `companies` | Top-level tenant. Has `email`, `company_type_id`, `issue_prefix`, `mcp_servers` (JSONB), `mpp_config` (JSONB), company-level budget. | Parent of everything. |
 | `company_memberships` | Links users to companies. Roles: `owner`, `member`. | links user ↔ company |
 | `invites` | Pending invitations for new board members. | belongs to company |
 | `api_keys` | Company-scoped keys for external orchestrators. Stored bcrypt-hashed. | belongs to company |
 | `agents` | A role in the org chart. Self-referential `reports_to`. Has `slug` for @-mentions, `mcp_servers` (JSONB). | belongs to company |
-| `projects` | Group of related work under a company. | belongs to company |
+| `projects` | Group of related work under a company. Has Docker container config, dev ports. | belongs to company |
 | `repos` | Git repo (GitHub only). Short name for @-mentions. | belongs to project |
 | `issues` | Ticket. Must have a project. Linear-style `identifier` (e.g. `ACME-42`). Execution lock fields. | belongs to company + project, assigned to agent |
 | `issue_comments` | Thread entries. Polymorphic via `content_type` + `content` JSONB. | belongs to issue |
@@ -131,7 +132,7 @@ job (or heartbeat check) compares this to the current month boundary and resets
 ### Preview files (not in DB)
 
 HTML previews are ephemeral filesystem artifacts, not DB records. The agent writes
-to `/workspace/{project}/.previews/{agent_id}/` inside the company container, which is
+to `/workspace/.previews/{agent_id}/` inside the project container, which is
 visible on the host via the shared workspace volume at:
 ```
 ~/.hezo/companies/{slug}/projects/{project}/.previews/{agent_id}/
@@ -193,7 +194,7 @@ subprocess runtime configuration.
 
 The wallet private key is not stored in `mpp_config` — it lives in the
 `secrets` table, referenced by `wallet_key_secret_name`. When MPP is enabled,
-the company container gets `mppx` CLI and wallet credentials are injected into agent subprocesses. Every MPP
+the project container gets `mppx` CLI and wallet credentials are injected into agent subprocesses. Every MPP
 payment is reported as a tool call cost and debited against the agent's budget
 via the same `debit_agent_budget()` atomic function.
 
@@ -212,16 +213,16 @@ This ensures the user never lands on an empty company.
 
 ### Company cloning
 
-`POST /companies` accepts an optional `clone_from_company_id`. When set, the
-server copies:
-- All `kb_docs` rows (with new company_id, `last_updated_by_agent_id` set to NULL)
-- All `agents` rows (new IDs, same titles/prompts/org hierarchy, `budget_used_cents`
-  reset to 0, company container provisioned fresh)
-- Company-level `mcp_servers` array
-- `mpp_config` structure (with `enabled: false` — wallet keys must be set up fresh)
+`POST /companies` requires a `company_type_id`. The server clones from the
+selected company type:
+- Creates `agents` rows from `company_types.agents_config` (new IDs, `budget_used_cents`
+  reset to 0)
+- Creates `kb_docs` rows from `company_types.kb_docs_config`
+- Creates `company_preferences` row from `company_types.preferences_config`
+- Copies `mcp_servers` array from company type
+- Copies `mpp_config` structure (with `enabled: false` — wallet keys must be set up fresh)
 
-Also copied: `company_preferences` row (with `last_updated_by_agent_id` set to
-NULL) so the cloned company inherits the board's established working style.
+Project containers are provisioned when projects are created (not at company creation).
 
 NOT copied: projects, repos, issues, secrets, cost_entries, audit_log, api_keys,
 secret_grants, approvals, connected_platforms, project_docs. Platform connections
@@ -347,13 +348,15 @@ all companies. Issues have an `identifier` column computed as
 human-facing reference for issues — used in UI, API responses, @-mentions
 (`#ACME-42`), and git branch names.
 
-### Issue execution locking
+### Issue work ownership
 
-When an agent starts work on an issue, `execution_run_id` and
-`execution_locked_at` are set via `SELECT ... FOR UPDATE`. This prevents two
-agents from working on the same issue simultaneously. If a second agent
-tries to work on a locked issue, its wakeup is deferred with status
-`deferred_issue_execution` and promoted when the lock is released.
+When an agent begins work on an issue, `execution_run_id` and
+`execution_locked_at` are set to claim ownership. This is a work ownership
+marker, not a short-lived database lock — ownership persists across heartbeat
+cycles and may span hours or days. Only one agent works on a given issue at
+a time. If a second agent tries to work on an owned issue, its wakeup is
+deferred with status `deferred_issue_execution` and promoted when ownership
+is released (on completion, reassignment, or agent pause/termination).
 
 ### Wakeup queue
 

--- a/.dev/schema_migration.sql
+++ b/.dev/schema_migration.sql
@@ -87,6 +87,25 @@ CREATE TYPE invite_status AS ENUM ('pending', 'accepted', 'expired', 'revoked');
 CREATE TYPE project_doc_type AS ENUM ('tech_spec', 'implementation_plan', 'research', 'ui_design_decisions', 'marketing_plan', 'other');
 
 -------------------------------------------------------------------------------
+-- COMPANY TYPES (blueprints/recipes for creating companies)
+-------------------------------------------------------------------------------
+
+CREATE TABLE company_types (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name                TEXT NOT NULL UNIQUE,
+    description         TEXT NOT NULL DEFAULT '',
+    is_builtin          BOOLEAN NOT NULL DEFAULT false,  -- true for "Software Development"
+    -- Snapshot of default config for new companies created from this type
+    agents_config       JSONB NOT NULL DEFAULT '[]'::jsonb,
+    kb_docs_config      JSONB NOT NULL DEFAULT '[]'::jsonb,
+    preferences_config  JSONB NOT NULL DEFAULT '{}'::jsonb,
+    mcp_servers         JSONB NOT NULL DEFAULT '[]'::jsonb,
+    mpp_config          JSONB NOT NULL DEFAULT '{"enabled": false}'::jsonb,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-------------------------------------------------------------------------------
 -- COMPANIES
 -------------------------------------------------------------------------------
 
@@ -94,8 +113,12 @@ CREATE TABLE companies (
     id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     name                TEXT NOT NULL,
     mission             TEXT NOT NULL DEFAULT '',
+    -- The company type this company was created from
+    company_type_id     UUID REFERENCES company_types(id) ON DELETE SET NULL,
     -- Auto-derived from name, globally unique (e.g. "ACME", "NOTE")
     issue_prefix        TEXT NOT NULL UNIQUE,
+    -- Company email for outbound communication (invites, notifications)
+    email               TEXT,
     -- Company-level budget cap across all agents
     budget_monthly_cents INTEGER NOT NULL DEFAULT 50000,  -- $500 default
     budget_used_cents    INTEGER NOT NULL DEFAULT 0,
@@ -104,10 +127,6 @@ CREATE TABLE companies (
     mcp_servers         JSONB NOT NULL DEFAULT '[]'::jsonb,
     -- MPP wallet config
     mpp_config          JSONB NOT NULL DEFAULT '{"enabled": false}'::jsonb,
-    -- Shared Docker container for all agents in this company
-    docker_base_image   TEXT NOT NULL DEFAULT 'node:20-slim',
-    container_id        TEXT,          -- Docker container ID
-    container_status    container_status,
     created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at          TIMESTAMPTZ NOT NULL DEFAULT now()
 );
@@ -205,12 +224,18 @@ CREATE INDEX idx_agents_status ON agents(company_id, status);
 -------------------------------------------------------------------------------
 
 CREATE TABLE projects (
-    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    company_id  UUID NOT NULL REFERENCES companies(id) ON DELETE CASCADE,
-    name        TEXT NOT NULL,
-    goal        TEXT NOT NULL DEFAULT '',
-    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
-    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    company_id          UUID NOT NULL REFERENCES companies(id) ON DELETE CASCADE,
+    name                TEXT NOT NULL,
+    goal                TEXT NOT NULL DEFAULT '',
+    -- Docker container for this project (one container per project)
+    docker_base_image   TEXT NOT NULL DEFAULT 'node:20-slim',
+    container_id        TEXT,          -- Docker container ID
+    container_status    container_status,
+    -- Dev preview port forwarding: [{"container": 3000, "host": 13000}]
+    dev_ports           JSONB NOT NULL DEFAULT '[]'::jsonb,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
 CREATE INDEX idx_projects_company ON projects(company_id);
@@ -265,7 +290,7 @@ CREATE TABLE issues (
     priority            issue_priority NOT NULL DEFAULT 'medium',
     -- Simple labels as JSONB array: ["bug", "frontend"]
     labels              JSONB NOT NULL DEFAULT '[]'::jsonb,
-    -- Execution locking: prevents two agents working on same issue
+    -- Work ownership: only one agent works on an issue at a time (may span days)
     execution_run_id    UUID,
     execution_locked_at TIMESTAMPTZ,
     created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),

--- a/.dev/schema_migration.sql
+++ b/.dev/schema_migration.sql
@@ -1,8 +1,25 @@
 -- Migration 001: Initial schema
 -- Company orchestration platform
+--
+-- NOTE: This file will be renamed to migrations/001_initial_schema.sql
+-- in the implementation. All subsequent schema changes should be added
+-- as new numbered migration files (e.g. 002_add_feature.sql).
+-- See spec.md "Migration system" section for the full migration design.
 
 -- Enable UUID generation
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-------------------------------------------------------------------------------
+-- MIGRATION TRACKING (created automatically by the migration runner,
+-- included here for reference)
+-------------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS _migrations (
+    id          SERIAL PRIMARY KEY,
+    filename    TEXT NOT NULL UNIQUE,
+    applied_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    checksum    TEXT NOT NULL  -- SHA-256 of migration file contents
+);
 
 -------------------------------------------------------------------------------
 -- SYSTEM META (master key canary, config)

--- a/.dev/spec.md
+++ b/.dev/spec.md
@@ -35,19 +35,23 @@ Hezo ships as a single executable binary. No external database required. No clou
 
 | Component | Technology | Notes |
 |-----------|-----------|-------|
-| Base framework | QuickDapp | Single executable binary output |
-| Database | PGlite (in-memory Postgres) | Persisted to file on disk |
+| Server | Hono (TypeScript) | Lightweight HTTP framework |
+| Binary | `bun build --compile` | Single executable, cross-platform |
+| Database | PGlite with NodeFS | Filesystem-persisted embedded Postgres at `~/.hezo/pgdata` |
 | Persistence path | `~/.hezo/` by default | Overridable via `--data-dir` CLI arg |
-| Migrations | QuickDapp migration runner | Runs on every server startup |
+| Live queries | PGlite `live.query()` / `live.changes()` | Real-time UI updates without polling |
+| Migrations | Custom SQL runner | Numbered migration files, tracking table, runs on startup |
 | Encryption | AES-256-GCM | Master key held in memory only |
 | Company container | Docker Engine API | One shared container per company |
-| Frontend | React (bundled into binary) | Served by the same process |
-| Real-time | WebSocket | Board UI subscribes to company events |
+| Frontend | React (bundled into binary) | Served by the same Hono process, bundled via `bun build --compile` |
+| Real-time | PGlite live queries + WebSocket | Live queries for data reactivity, WebSocket for system events |
+| AI agent interface | MCP (Streamable HTTP) | `@modelcontextprotocol/sdk` at `/mcp` endpoint |
+| Skill file | Served at `GET /skill.md` | Teaches external AI agents how to interact with Hezo |
+| REST API | JSON over HTTP | Board + agent endpoints at `/api` |
 | OAuth gateway | Hezo Connect (self-hosted or connect.hezo.ai) | Handles OAuth flows for GitHub, Gmail, Stripe, etc. |
 | Auth | Better Auth | Email/password login, session cookies, multi-user |
 | Integrations | 9 platforms via OAuth | GitHub, Gmail, GitLab, Stripe, PostHog, Railway, Vercel, DigitalOcean, X |
 | Plugin runtime | Worker threads + dynamic import | TypeScript plugins with capability-gated APIs |
-| Plugin registry | plugins.hezo.ai | Centralized discovery, ratings, versioning |
 
 ### Master key lifecycle
 
@@ -64,7 +68,135 @@ hezo                          # Start server, prompt for master key if DB exists
 hezo --data-dir /path/to/dir  # Custom persistence directory
 hezo --master-key <key>       # Supply master key as argument
 hezo --port 3100              # Custom port (default 3100)
+hezo --connect-url <url>      # Hezo Connect OAuth gateway URL
+hezo --connect-api-key <key>  # API key for centrally hosted Connect
+hezo --no-connect             # Disable OAuth, manual credentials only
 ```
+
+### Database and persistence
+
+Hezo uses **PGlite** — an embedded Postgres that runs in-process — with filesystem persistence via **NodeFS**. No external database server is needed.
+
+```typescript
+import { PGlite } from "@electric-sql/pglite"
+import { live } from "@electric-sql/pglite/live"
+import { NodeFS } from "@electric-sql/pglite"
+
+const db = new PGlite({
+  fs: new NodeFS(dataDir),  // defaults to ~/.hezo/pgdata
+  extensions: { live },
+})
+```
+
+**Live queries** provide real-time reactivity for the frontend without polling:
+
+- `live.query(sql, params, callback)` — re-runs the query when dependent tables change, pushes only the diff from WASM to JS
+- `live.changes(sql, params, key, callback)` — emits granular insert/update/delete deltas keyed by a primary key column
+- `live.incrementalQuery()` — materializes full result sets from change streams, ideal for React integration via `useLiveIncrementalQuery()`
+
+The frontend uses PGlite React hooks (`useLiveQuery`, `useLiveIncrementalQuery`) for data-driven views (issue lists, agent status, cost dashboards). **WebSocket** is still used for non-database events: agent subprocess lifecycle, container status changes, live chat messages, and system notifications.
+
+**Future sync:** Electric-SQL sync (`@electric-sql/pglite-sync`) can enable multi-instance scenarios (e.g. read replicas, multi-device access). Not required for Phase 1.
+
+### Migration system
+
+Hezo uses a custom forward-only migration system with numbered SQL files. Migrations run automatically on every server startup, enabling safe upgrades without data loss.
+
+**Migration files** are stored as `migrations/NNN_description.sql`:
+```
+migrations/
+├── 001_initial_schema.sql     # The full initial schema
+├── 002_add_agent_model.sql    # Example: new column
+├── 003_add_mcp_tools.sql      # Example: new table
+└── ...
+```
+
+**Tracking table** (`_migrations`) records which migrations have been applied:
+```sql
+CREATE TABLE IF NOT EXISTS _migrations (
+    id          SERIAL PRIMARY KEY,
+    filename    TEXT NOT NULL UNIQUE,
+    applied_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    checksum    TEXT NOT NULL  -- SHA-256 of file contents
+);
+```
+
+**Startup behavior:**
+1. Ensure `_migrations` table exists (create if not)
+2. Read all `migrations/*.sql` files, sorted by filename
+3. Skip files already recorded in `_migrations`
+4. For each unapplied migration: run inside a transaction, record in `_migrations` with checksum
+5. Checksum verification: if a previously-applied migration file has changed, log a warning (indicates the migration was modified after being applied — this should not happen)
+
+**Design decisions:**
+- **Forward-only** — no rollback migrations. For an embedded database, the simplest recovery is restoring from a backup. Add new migrations to fix issues.
+- **Atomic per file** — each migration runs in its own transaction. If a migration fails, only that migration is rolled back, and startup halts with an error.
+- **Idempotent startup** — safe to restart at any time; already-applied migrations are skipped.
+
+### MCP endpoint
+
+Hezo exposes an **MCP (Model Context Protocol)** endpoint so external AI agents can discover and use Hezo's capabilities programmatically — without needing to know the REST API.
+
+**Transport:** Streamable HTTP at `POST /mcp` (single endpoint, bidirectional via optional SSE streaming). Uses `@modelcontextprotocol/sdk` with the `McpServer` class.
+
+**Architecture:**
+```
+┌─────────────────────────────────────────┐
+│       Hono Server (port 3100)           │
+├──────────────────┬──────────────────────┤
+│  REST API        │  MCP Endpoint        │
+│  /api/*          │  /mcp                │
+│  (Board + Agent) │  (Streamable HTTP)   │
+├──────────────────┴──────────────────────┤
+│         Shared Business Logic           │
+└─────────────────────────────────────────┘
+```
+
+MCP tools mirror the REST API surface. Both call the same underlying business logic layer. The MCP endpoint coexists with the REST API on the same Hono server and port.
+
+**Authentication:** Same as REST — local trusted (localhost), Better Auth session, or API key (`Authorization: Bearer hezo_<key>`).
+
+**Exposed MCP tools:**
+
+| Tool | Description |
+|------|-------------|
+| `list_companies` | List all companies the caller has access to |
+| `create_company` | Create a new company |
+| `list_issues` | List issues with filtering (project, status, assignee) |
+| `create_issue` | Create a new issue in a project |
+| `update_issue` | Update issue status, assignee, priority, etc. |
+| `list_agents` | List agents in a company |
+| `hire_agent` | Create a new agent from a role template or custom config |
+| `post_comment` | Post a comment on an issue |
+| `list_comments` | List comments on an issue |
+| `approve_request` | Approve a pending approval |
+| `deny_request` | Deny a pending approval |
+| `list_approvals` | List pending approvals |
+| `search_kb` | Search knowledge base documents |
+| `update_kb_doc` | Create or update a KB document |
+| `get_cost_summary` | Get cost breakdown by agent, project, or time period |
+| `list_projects` | List projects in a company |
+| `list_secrets` | List secret names (not values) in a company |
+
+Additional tools are registered dynamically when plugins are activated.
+
+### Skill file
+
+Hezo serves a **skill file** that teaches external AI agents (like Claude Code) how to interact with the system. This is the primary onboarding mechanism for AI-to-AI integration.
+
+**Served at:** `GET /skill.md` — returns a Markdown document describing Hezo's capabilities, available MCP tools, common workflows, and authentication instructions.
+
+**Also committed to the repo** at `.claude/skills/hezo/SKILL.md` so that Claude Code sessions working within a Hezo-managed repo automatically discover it.
+
+**Content includes:**
+- Overview of what Hezo is and how it works
+- Available MCP tools with parameter descriptions
+- Common workflows: create an issue, assign to an agent, monitor progress, approve requests
+- REST API endpoint summary (as a fallback for agents that don't support MCP)
+- Authentication instructions (API key setup)
+- Examples of typical interactions
+
+**Dynamically generated:** The skill file is generated at startup from the registered MCP tool definitions, ensuring it is always up-to-date with the current tool surface. Changes to MCP tools automatically update the skill file.
 
 ---
 
@@ -422,7 +554,7 @@ All Hezo data lives under `~/.hezo/` on the host machine. The structure mirrors 
 
 ```
 ~/.hezo/
-├── hezo.db                              # PGlite database file
+├── pgdata/                              # PGlite database (NodeFS persistence)
 ├── data/                                # Previews, temp files
 │   └── previews/{company_id}/{agent_id}/
 │
@@ -1758,7 +1890,9 @@ Three token types:
 |---------|-------------|
 | Board API | Full CRUD for companies, agents, projects, repos, issues, secrets, approvals, KB, connections, plugins, users, etc. |
 | Agent API | Heartbeat, context, comments, tool calls, delegation, secret requests, KB proposals, deploy requests. |
-| WebSocket | Real-time events for board UI. |
+| MCP Endpoint | Streamable HTTP at `/mcp`. Mirrors Board API as MCP tools for external AI agents. |
+| Skill File | `GET /skill.md`. Dynamically generated documentation for AI agent onboarding. |
+| WebSocket | Real-time system events for board UI (agent lifecycle, container status, live chat). |
 
 ---
 

--- a/.dev/spec.md
+++ b/.dev/spec.md
@@ -42,36 +42,63 @@ Hezo ships as a single executable binary. No external database required. No clou
 | Live queries | PGlite `live.query()` / `live.changes()` | Real-time UI updates without polling |
 | Migrations | Custom SQL runner | Numbered migration files, tracking table, runs on startup |
 | Encryption | AES-256-GCM | Master key held in memory only |
-| Company container | Docker Engine API | One shared container per company |
+| Project containers | Docker Engine API | One container per project (all repos checked out inside) |
 | Frontend | React (bundled into binary) | Served by the same Hono process, bundled via `bun build --compile` |
 | Real-time | PGlite live queries + WebSocket | Live queries for data reactivity, WebSocket for system events |
 | AI agent interface | MCP (Streamable HTTP) | `@modelcontextprotocol/sdk` at `/mcp` endpoint |
 | Skill file | Served at `GET /skill.md` | Teaches external AI agents how to interact with Hezo |
 | REST API | JSON over HTTP | Board + agent endpoints at `/api` |
 | OAuth gateway | Hezo Connect (self-hosted or connect.hezo.ai) | Handles OAuth flows for GitHub, Gmail, Stripe, etc. |
-| Auth | Better Auth | Email/password login, session cookies, multi-user |
+| Auth | Better Auth | Email/password + GitHub/GitLab OAuth, session cookies, multi-user |
 | Integrations | 9 platforms via OAuth | GitHub, Gmail, GitLab, Stripe, PostHog, Railway, Vercel, DigitalOcean, X |
 | Plugin runtime | Worker threads + dynamic import | TypeScript plugins with capability-gated APIs |
 
+### Monorepo structure
+
+Hezo is a monorepo using Bun workspaces and Turborepo for build orchestration:
+
+```
+packages/
+├── connect/       # Hezo Connect OAuth gateway (standalone Bun/Hono server)
+├── server/        # Main Hezo server (Hono + PGlite)
+├── web/           # React frontend
+└── shared/        # Shared types, utilities, validation schemas
+```
+
+- **`packages/connect`** — Hezo Connect OAuth gateway. Runs as a standalone process on port 4100. No dependency on the main server.
+- **`packages/server`** — Main Hezo app. Imports from `shared`. Embeds `web` at build time. Builds into a single self-contained binary via `bun build --compile` — the binary includes the server, the React frontend, PGlite, and all dependencies.
+- **`packages/web`** — React frontend. Bundled into the server binary via `bun build --compile`.
+- **`packages/shared`** — Shared TypeScript types, Zod validation schemas, constants, and utilities used by both `connect` and `server`. Reduces duplication between packages.
+
 ### Master key lifecycle
 
-1. **First startup** (empty DB): server generates a random 256-bit key, displays it in the terminal, asks the user to save it carefully.
+1. **First startup** (empty DB): server generates a random 256-bit key, displays it in the terminal, and stores the canary. No prompt needed — just generates and shows it.
 2. Server stores a canary value in `system_meta` table: `encrypt("CANARY", master_key)`.
 3. Key is held in memory only — never written to disk.
-4. **Subsequent startups** (DB has data): server prompts for the key via stdin or `--master-key <key>` CLI arg.
-5. Server attempts to decrypt the canary. Wrong key → server refuses to start.
+4. **Subsequent startups** (DB has data): if `--master-key <key>` is provided on the CLI, the server uses it directly. Otherwise, the server starts in a **locked state** and the web UI shows a master key entry screen on first load. The user enters the key in the browser. Once verified, the server unlocks and serves normally.
+5. Server attempts to decrypt the canary. Wrong key → server refuses to unlock.
 
-### CLI interface
+### CLI interface and default configuration
 
 ```
-hezo                          # Start server, prompt for master key if DB exists
-hezo --data-dir /path/to/dir  # Custom persistence directory
-hezo --master-key <key>       # Supply master key as argument
-hezo --port 3100              # Custom port (default 3100)
-hezo --connect-url <url>      # Hezo Connect OAuth gateway URL
+hezo                          # Start server with sensible defaults
+hezo --data-dir /path/to/dir  # Custom persistence directory (default: ~/.hezo/)
+hezo --master-key <key>       # Supply master key (skip web UI prompt)
+hezo --port 3100              # Custom port (default: 3100)
+hezo --connect-url <url>      # Hezo Connect URL (default: http://localhost:4100)
 hezo --connect-api-key <key>  # API key for centrally hosted Connect
-hezo --no-connect             # Disable OAuth, manual credentials only
 ```
+
+**Sensible defaults for zero-config local development:**
+
+| Setting | Default | Notes |
+|---------|---------|-------|
+| Server port | `3100` | Main Hezo app |
+| Connect URL | `http://localhost:4100` | Matches local Hezo Connect default port |
+| Data directory | `~/.hezo/` | PGlite database, company data, assets |
+| Master key | *(prompt via web UI)* | Auto-generated on first startup, web UI prompt on subsequent startups |
+
+Running `hezo` with zero arguments works for local development when Hezo Connect is running on its default port (4100). No configuration file needed for the common case.
 
 ### Database and persistence
 
@@ -220,11 +247,31 @@ API keys are company-scoped. A key grants full board-level access to that compan
 
 This means an OpenClaw instance or any AI agent with an API key can fully orchestrate a Hezo company: create issues, assign work, approve hires, review agent output, and steer strategy — all via REST.
 
+### Company types
+
+A **company type** (also called a template or recipe) defines the blueprint for a new company. Every company is created from a company type. A company type specifies:
+
+- **Name** — e.g., "Software Development", "Research Lab", "Marketing Agency"
+- **Description** — what this type of company does
+- **Default agents** — roles, titles, system prompts, org chart hierarchy, runtime types, heartbeat intervals, budget allocations
+- **Default KB documents** — starter knowledge base content (coding standards, guidelines, etc.)
+- **Default preferences** — initial company preferences
+- **Default MCP servers** — company-level MCP server configuration
+
+The current 9-agent team (CEO, Product Lead, Architect, Engineer, QA Engineer, UI Designer, DevOps Engineer, Marketing Lead, Researcher) is the built-in **"Software Development"** company type. It ships with Hezo and cannot be deleted (but can be customized per-company after creation).
+
+**Creating company types:**
+- Users can create new company types from scratch (define agents, KB docs, and preferences manually)
+- Users can save an existing company as a new company type (snapshots current agents, KB, and preferences)
+- Company types are stored locally in the Hezo instance
+
+**Future:** Company types will be distributable as recipes from the Hezo project website, enabling the community to share blueprints for different kinds of AI companies.
+
 ### Company onboarding flow
 
-When a new company is created, the system automatically:
+When a new company is created, the user selects a **company type** (see above). The system then clones from that type and automatically:
 
-1. **Creates a full agent team** using the built-in role templates (see `agents/` for full specs):
+1. **Creates the agent team** defined by the selected company type. For the built-in "Software Development" type, this includes (see `agents/` for full specs):
    - CEO (reports to board)
    - Product Lead (reports to CEO)
    - Architect (reports to CEO)
@@ -238,9 +285,10 @@ When a new company is created, the system automatically:
    - GitHub (required for repo access)
    - Gmail (recommended for agent email)
    - Others optional: Stripe, PostHog, Railway, Vercel, DigitalOcean, X, GitLab
-3. **Creates a "Setup" project** with an onboarding issue assigned to the CEO: *"Set up repository access — configure deploy keys for connected GitHub account."*
-4. **Provisions the company Docker container** (shared by all agents)
-5. **Creates the `.hezo/{company}/` folder structure** on the host machine
+3. **Sets up the company email address** — the owner provides an email address for the company (e.g., `team@acme.com`). Used for sending board member invitations and company-to-human communication. Can be changed later in company settings.
+4. **Creates a "Setup" project** with an onboarding issue assigned to the CEO: *"Set up repository access — configure deploy keys for connected GitHub account."*
+5. **Provisions the project's Docker container** when the first project is created
+6. **Creates the `.hezo/{company}/` folder structure** on the host machine
 
 All agent system prompts are pre-filled from templates and editable. The user can delete, modify, or add agents after creation. Connected platforms can be added or removed at any time in company settings.
 
@@ -266,17 +314,19 @@ Instead of manually managing API keys and OAuth tokens, Hezo uses a centralized 
 
 Each connected platform auto-registers as a **company-level MCP server** so agents can discover and use the tools immediately. Tokens are stored encrypted in the local secrets vault. Refresh is handled automatically by the Hezo app.
 
-### Company cloning
+### Company cloning and company types
 
-When creating a new company, the user can choose to **clone from an existing company**. Cloning copies:
+Every company is created from a **company type** (see "Company types" above). The company type determines the starting agents, knowledge base, and preferences. After creation, the company is fully independent of its source type — changes to the company do not affect the type, and vice versa.
 
-- **Knowledge base** — all documents (coding standards, guidelines, etc.)
-- **Company preferences** — board working style preferences (so the cloned company inherits established conventions)
+Users can also **save an existing company as a new company type**. This snapshots:
+
 - **Agent configurations** — titles, role descriptions, system prompts, org chart hierarchy, runtime types, heartbeat intervals, budget allocations
+- **Knowledge base** — all documents (coding standards, guidelines, etc.)
+- **Company preferences** — board working style preferences
 - **MCP server config** — company-level MCP servers
-- **MPP config** — wallet config structure (not the actual wallet keys — those must be set up fresh)
+- **MPP config** — wallet config structure (not actual wallet keys)
 
-Cloning does **not** copy: projects, repos, issues, secrets, connected platforms, cost history, audit log, or API keys. The cloned company starts with a clean operational slate but inherits all the institutional knowledge and team structure. Platform connections must be set up fresh for each company.
+Saving as a type does **not** include: projects, repos, issues, secrets, connected platforms, cost history, audit log, or API keys. The resulting type captures institutional knowledge and team structure only.
 
 ---
 
@@ -322,7 +372,9 @@ On agent creation, the UI provides a monospace editor with a toolbar for inserti
 
 ### Built-in role templates
 
-Hezo ships with 9 built-in role templates that form the default team. Full specifications for each role are in `agents/{slug}.md`. Users can customize every field. All roles are starting points, not fixed — agents can be added, removed, or reconfigured.
+Hezo ships with 9 built-in role templates that form the default team for the "Software Development" company type. Full specifications for each role are in `agents/{slug}.md`. Users can customize every field. All roles are starting points, not fixed — agents can be added, removed, or reconfigured.
+
+Users can also create **entirely new custom roles** with arbitrary titles, descriptions, system prompts, runtime types, and reporting lines. For example, a company could add a "Data Scientist", a second "Frontend Engineer", a "Security Auditor", or a "Legal Researcher" — any role the company needs. Custom roles are first-class citizens — they appear in the org chart, receive issues, participate in delegation, and have their own budgets just like built-in roles.
 
 ### Ticket workflow
 
@@ -611,26 +663,38 @@ Worktrees are created on demand when an agent starts work on an issue, and clean
 
 ### Docker container configuration
 
-Each company gets a single shared Docker container. All agents in the company run as **subprocesses** inside this container, making them easy to kill and restart independently. The repository source folder is the primary shared volume between host and container.
+Each project gets its own Docker container. All repositories linked to the project are checked out inside the container under `/workspace/`. Agents working on issues in that project run as **subprocesses** inside the project's container, making them easy to kill and restart independently.
+
+If a company has 3 projects, 3 containers run. If a project has multiple repos, they all live inside the single project container.
 
 | Aspect | Configuration |
 |--------|-------------|
-| Base image | Configurable per company (default: `node:20-slim`) |
-| Projects mount | Host `~/.hezo/companies/{company}/projects/` → Container `/workspace/` (rw) |
-| Worktrees mount | Host `~/.hezo/companies/{company}/worktrees/` → Container `/worktrees/` (rw) |
+| Base image | Configurable per project (default: `node:20-slim`) |
+| Project mount | Host `~/.hezo/companies/{company}/projects/{project}/` → Container `/workspace/` (rw) |
+| Worktrees mount | Host `~/.hezo/companies/{company}/projects/{project}/worktrees/` → Container `/worktrees/` (rw) |
 | SSH keys | Host `~/.ssh/` → Container `/root/.ssh/` (ro) |
 | Git config | Host `~/.gitconfig` → Container `/root/.gitconfig` (ro) |
 | SSH agent | Host `$SSH_AUTH_SOCK` → Container `/tmp/ssh-agent.sock` (if available) |
 | `.claude` | Inherited via symlinks in the repo folders |
 | Secrets | Injected as environment variables per subprocess (never container-wide, never written to disk) |
 | Connected platforms | OAuth tokens from connected platforms (GitHub, Gmail, etc.) injected per subprocess. Platform MCP servers available. |
-| Previews | Written to `/workspace/{project}/.previews/` — visible on host via the shared volume |
+| Previews | Written to `/workspace/.previews/{agent_id}/` — visible on host via the shared volume |
+| Dev ports | Forwarded from container to host for dev preview (e.g., container:3000 → host:13000). Auto-allocated from pool. |
 | Network | `host.docker.internal:3100` for Agent API access |
-| Isolation | All agents in the same company share the container. Different companies have separate containers. |
+| Isolation | All agents working on the same project share the container. Different projects have separate containers. |
+
+### Dev preview
+
+Project containers support **port forwarding** so users can interact with the running dev version of a project in a browser. When an agent runs a dev server inside the container (e.g., `npm run dev` on port 3000), the port is forwarded to the host.
+
+- Port mapping is stored per project as JSONB: `[{"container": 3000, "host": 13000}]`
+- Hezo auto-allocates host ports from a pool (10000–19999) to avoid conflicts between projects
+- The project detail UI shows a "Dev Preview" link when active ports are detected
+- Hezo proxies these ports through its own server (`GET /dev/{project_id}/`) for a consistent URL
 
 ### SSH and Git authentication
 
-The host machine's SSH configuration is mounted read-only into the company container:
+The host machine's SSH configuration is mounted read-only into each project container:
 
 1. `~/.ssh/` (keys, config, known_hosts) is available at `/root/.ssh/`
 2. If the host has an SSH agent running (`SSH_AUTH_SOCK`), the socket is forwarded into the container
@@ -642,24 +706,25 @@ The host machine's SSH configuration is mounted read-only into the company conta
 
 | Event | What happens |
 |-------|-------------|
-| Company created | Container provisioned from the company's configured base image. |
-| Agent heartbeat | Subprocess spawned inside the company container with the agent's environment. |
+| Project created | Container provisioned from the project's configured base image. All linked repos cloned inside. |
+| Agent heartbeat (for project issue) | Subprocess spawned inside the project's container with the agent's environment. |
 | Agent paused | Subprocess killed (if running). Container unaffected. |
 | Agent terminated | Subprocess killed. Container unaffected. Agent record kept for audit. |
 | Container rebuilt | All agent subprocesses killed, container destroyed, new one provisioned. |
-| Company deleted | Container destroyed. |
+| Project deleted | Container destroyed. All associated worktrees cleaned up. |
+| Company deleted | All project containers destroyed. |
 | Issue assigned | Worktree created for the repo + branch. Available inside container via `/worktrees/`. |
 | Issue closed | Worktree cleaned up (merged branch deleted, worktree pruned). |
 
 ### Agent subprocess model
 
-Each agent runs as a subprocess spawned inside the company container via `docker exec`. The Hezo orchestrator spawns each agent process with:
+Each agent runs as a subprocess spawned inside the project's container via `docker exec`. The Hezo orchestrator spawns each agent process with:
 
 - The agent's specific environment variables (secrets, OAuth tokens, JWT)
 - The correct working directory (the agent's assigned worktree or project folder)
 - The agent's runtime command (e.g., `claude-code`, `codex`, etc.)
 
-Agents can be killed and restarted independently without affecting the container or other agents. If the company container crashes, all running agent subprocesses for that company are lost — orphan detection handles this by marking all active heartbeat runs as failed and re-queuing them.
+Agents can be killed and restarted independently without affecting the container or other agents. If a project container crashes, all running agent subprocesses for that project are lost — orphan detection handles this by marking all active heartbeat runs as failed and re-queuing them.
 
 ### Subagents (built-in parallelism)
 
@@ -695,7 +760,7 @@ Agents can pay for third-party APIs autonomously using the Stripe/Tempo Machine 
 - Enabled/disabled toggle
 
 **How it works at runtime:**
-1. The company container has `mppx` CLI pre-installed
+1. The project container has `mppx` CLI pre-installed
 2. Wallet credentials are injected as environment variables (same mechanism as secrets)
 3. Agent calls a paid API → gets 402 → `mppx` handles payment flow automatically
 4. Payment amount is reported as a tool call cost and debited against the agent's budget
@@ -1069,7 +1134,7 @@ Agents can write temporary HTML files (mockups, prototypes, reports, visualizati
 
 Agents write previews to a well-known location inside the shared workspace volume:
 ```
-Container: /workspace/{project}/.previews/{agent_id}/
+Container: /workspace/.previews/{agent_id}/
 Host:      ~/.hezo/companies/{slug}/projects/{project}/.previews/{agent_id}/
 ```
 
@@ -1096,7 +1161,7 @@ The UI renders a clickable card. Clicking opens the preview in a sandboxed ifram
 - No access to web app cookies or auth from within the iframe
 - Max file size: 5MB per file, 50MB total per agent
 - Allowed types: `.html`, `.htm`, `.svg`, `.png`, `.jpg`, `.css`, `.js`
-- Preview directory is writable by the agent subprocess inside the company container
+- Preview directory is writable by the agent subprocess inside the project container
 - Filenames sanitized — no path traversal
 - Board access to company is validated before serving
 
@@ -1228,7 +1293,7 @@ Full action reference:
 | `plan_review.denied` | approval | Board or Product Lead |
 | `live_chat.started` | live_chat_session | Board |
 | `live_chat.ended` | live_chat_session | Board or agent |
-| `company.cloned` | company | Board |
+| `company.created_from_type` | company | Board creates company from company type |
 | `connection.created` | connected_platform | Board connects via OAuth |
 | `connection.refreshed` | connected_platform | System or board |
 | `connection.expired` | connected_platform | System |
@@ -1253,7 +1318,7 @@ Every agent has a heartbeat interval. Default is **60 minutes**. Configurable pe
 
 ### How heartbeats work
 
-1. On schedule, the system wakes the agent (ensures company container is running, spawns agent subprocess)
+1. On schedule, the system wakes the agent (ensures the project container is running, spawns agent subprocess)
 2. Agent calls `POST /agent-api/heartbeat` to report in and receive pending work
 3. Server returns: assigned issues, unread comments, notifications, budget remaining
 4. Agent works on its highest-priority issue
@@ -1277,27 +1342,30 @@ When multiple events fire for the same agent in quick succession (e.g. several @
 - Prevents redundant subprocess spawns and duplicate work
 - Maintains event ordering within the batch
 
-### Issue execution locking
+### Issue work ownership
 
-When an agent starts working on an issue, it acquires an execution lock. This prevents:
-- The same agent from processing the same issue in parallel (e.g. from overlapping heartbeats)
-- Race conditions when multiple events trigger wakeups for the same issue
-- Duplicate work on the same ticket
+An issue can only be actively worked on by **one agent at a time**. When an agent is assigned to an issue and begins work, that agent holds exclusive ownership of the issue. This prevents multiple agents from making conflicting changes to the same codebase or producing duplicate work.
 
-Locks are released when the agent completes its current work cycle or on timeout (configurable, default: 30 minutes).
+Work on an issue can span **hours or days** — this is not a short-lived database lock. The agent retains ownership until:
+- The issue is reassigned to a different agent
+- The issue status moves to `done`, `closed`, or `cancelled`
+- The agent is paused or terminated
+- The board manually releases the assignment
+
+There is no automatic timeout. If an agent appears stuck, the board can manually reassign the issue.
 
 ### Orphan detection and auto-retry
 
-The system monitors for orphaned work — agents that started processing an issue but never completed:
+The system monitors for orphaned work — agents that started working on an issue but whose subprocess died:
 
-- If an agent holds an execution lock past the timeout, the lock is released and the issue is flagged
-- If a subprocess crashes or the company container crashes mid-work, the system detects the failure and re-queues the issue for the agent's next heartbeat
+- If an agent's subprocess crashes while an issue is owned, the ownership is preserved but the issue is flagged for attention in the board inbox
+- If a subprocess crashes or the project container crashes mid-work, the system detects the failure and re-queues the issue for the agent's next heartbeat
 - Repeated failures (3+ consecutive) escalate to the board inbox as an agent error
 - The system tracks consecutive failure counts per agent per issue
 
 ### Persistent state
 
-Agents resume the same task context across heartbeats because the company container persists and session state is tracked per agent. No cold start, no re-cloning repos, no re-reading context.
+Agents resume the same task context across heartbeats because the project container persists and session state is tracked per agent. No cold start, no re-cloning repos, no re-reading context.
 
 ---
 
@@ -1572,7 +1640,12 @@ If a plugin worker thread crashes:
 
 ### Overview
 
-Hezo uses **Better Auth** for authentication. Board members sign up with email and password, and access is managed through session cookies.
+Hezo uses **Better Auth** for authentication. Board members can authenticate via:
+- **Email and password** — traditional signup and login
+- **GitHub OAuth** — sign in with an existing GitHub account (via Hezo Connect)
+- **GitLab OAuth** — sign in with an existing GitLab account (via Hezo Connect)
+
+All methods create the same Better Auth session. Access is managed through session cookies. Additional OAuth providers can be added in the future via Hezo Connect.
 
 ### Deployment modes
 
@@ -1602,10 +1675,13 @@ Board members are linked to companies through a `company_memberships` table. A m
 
 Board members can invite others to join a company:
 1. Existing board member creates an invite (email + company)
-2. System generates an invite link with a unique token
+2. System sends an invitation email **from the company email address** (see company onboarding, section 3) containing a unique invite link
 3. Invite is valid for **7 days**
-4. Recipient clicks the link, creates an account (or logs in if they already have one), and joins the company
-5. Expired invites must be re-created
+4. Recipient clicks the link and can create an account or log in using any supported auth method (email/password, GitHub OAuth, or GitLab OAuth)
+5. After authenticating, the recipient is automatically added to the company as a board member
+6. Expired invites must be re-created
+
+If the company has no email address configured, invites are still generated but must be shared manually (the invite link is displayed in the UI for copying).
 
 ### Instance admin
 
@@ -1731,11 +1807,11 @@ All of this happens within one ticket. The Comments tab shows the conversation f
 
 | # | Screen | Purpose |
 |---|--------|---------|
-| 1 | **Home — Company list** | Card grid of all companies. Stats + budget bar per card. "New" or "Clone" company. Board inbox badge. |
+| 1 | **Home — Company list** | Card grid of all companies. Stats + budget bar per card. "New company" (select company type). Board inbox badge. |
 | 2 | **Company workspace — Issues tab** | Default view. Filterable issue list. Every row shows identifier, project tag, assignee, status, priority. |
 | 3 | **Issue detail** | Primary work surface. Two tabs: Comments (threaded conversation, traces, goal chain sidebar, quick actions) and Live Chat (session list, inline transcripts). |
 | 4 | **Live chat panel** | Side panel or modal. Real-time back-and-forth with assigned agent. On close, session appears in Live Chat tab. |
-| 5 | **Company workspace — Agents tab** | Card grid of agents. Runtime, heartbeat, process status, budget bar per card. Company container status shown at the top. |
+| 5 | **Company workspace — Agents tab** | Card grid of agents. Runtime, heartbeat, process status, budget bar per card. |
 | 6 | **New agent / edit agent** | Form with system prompt editor (monospace, variable chips, role templates), reporting line, budget. |
 | 7 | **Board inbox** | Drawer accessible from any screen. Pending approvals, design reviews, escalations, budget alerts, agent errors, QA findings, OAuth requests. One-click actionable. Unread badge. |
 | 8 | **Company workspace — Org chart tab** | Read-only tree with status indicators. Click node to inspect agent. |
@@ -1747,7 +1823,7 @@ All of this happens within one ticket. The Comments tab shows the conversation f
 ### Navigation structure
 
 ```
-Home (company list — new or clone)
+Home (company list — new from company type)
   └── Company workspace
         ├── Issues (default tab)
         │     └── Issue detail
@@ -1791,7 +1867,8 @@ Account settings (accessible from user menu)
 |-------|---------|
 | `system_meta` | Key-value store for system config (master key canary) |
 | `users` | Board member accounts (email, password hash, admin flag) |
-| `companies` | Top-level tenant. Has `mcp_servers` (JSONB), `mpp_config` (JSONB), `budget_monthly_cents`, `budget_used_cents`. |
+| `company_types` | Company blueprints (recipes). Defines default agents, KB docs, preferences for new companies. |
+| `companies` | Top-level tenant. Has `email`, `company_type_id`, `mcp_servers` (JSONB), `mpp_config` (JSONB), `budget_monthly_cents`, `budget_used_cents`. |
 | `company_memberships` | Links board members to companies |
 | `invites` | Pending invitations to join a company (7-day expiry) |
 | `api_keys` | Company-scoped API keys for external orchestrators. Stored hashed. |
@@ -1821,14 +1898,14 @@ Account settings (accessible from user menu)
 | `plugin_state` | Key-value storage scoped to a plugin. |
 | `agent_sessions` | Per-task session tracking with token usage and compaction state. |
 | `wakeup_queue` | Pending agent wakeup events with coalescing. |
-| `execution_locks` | Issue execution locks for preventing duplicate work. |
+| `execution_locks` | Issue work ownership tracking — ensures only one agent works on an issue at a time. |
 
 ### Enums
 
 ```
 agent_runtime:        claude_code, codex, gemini, bash, http
 agent_status:         active, idle, paused, terminated
-container_status:     creating, running, stopped, error    (tracks company container, not per-agent)
+container_status:     creating, running, stopped, error    (tracks project container status)
 issue_status:         backlog, open, in_progress, review, blocked, done, closed, cancelled
 issue_priority:       urgent, high, medium, low
 comment_author_type:  board, agent, system
@@ -1901,7 +1978,7 @@ Three token types:
 | Feature | Notes |
 |---------|-------|
 | 1Password integration | Replace local encrypted secrets with 1Password Connect Server |
-| Portable company templates | Export/import full org structures, agent configs, skills |
+| Company type distribution | Community marketplace for sharing company types as downloadable recipes |
 | Config versioning with rollback | Revisioned config changes, safe rollback |
 | Visual drag-to-reorganize org chart | Interactive reordering of reporting lines |
 | Mobile-optimized UX | Responsive but not phone-first in MVP |


### PR DESCRIPTION
- Replace QuickDapp framework with Hono (TypeScript) + bun build --compile for single binary
- Add PGlite with NodeFS filesystem persistence and live queries (live.query, live.changes)
- Add custom forward-only migration system with numbered SQL files and _migrations tracking table
- Add MCP endpoint (Streamable HTTP at /mcp) for external AI agents via @modelcontextprotocol/sdk
- Add skill file (GET /skill.md) for AI agent onboarding, dynamically generated from MCP tools
- Update implementation phases to include MCP, skill file, and live queries in Phase 1
- Update API docs with MCP endpoint and skill file sections
- Update host filesystem layout (pgdata/ replaces hezo.db)

https://claude.ai/code/session_01W5Rpw6Jy8GGYsJWwA395qk