### PR TITLE
feat(shared): add shared types and constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,88 @@
 # Hezo
 
-Self-hosted company orchestration platform for AI agents.
+Self-hosted company orchestration platform for AI agents. Orchestrate teams of AI agents (CEO, Architect, Engineer, QA, etc.) to run autonomous companies under human board oversight.
 
 ## Prerequisites
 
 - [Bun](https://bun.sh/) v1.1+
 
-## Quick Start
+## Setup
 
 ```bash
 bun install
+```
+
+## Dev Server
+
+```bash
 bun run dev
 ```
 
-## Monorepo Structure
+This starts:
 
-| Package | Description | Default Port |
-|---------|-------------|--------------|
-| `packages/server` | Main application server (Hono + PGlite) | 3100 |
-| `packages/connect` | OAuth gateway for GitHub | 4100 |
-| `packages/shared` | Shared types, constants, and utilities | — |
+1. **Hezo Server** (port 3100) — main application with embedded PGlite database
+2. **Hezo Connect** (port 4100) — OAuth gateway for GitHub
+
+The server creates its database at `~/.hezo/pgdata` on first run.
+
+### Server CLI Flags
+
+```bash
+hezo                              # Start with defaults
+hezo --port 3100                  # Custom port (default: 3100)
+hezo --data-dir /path/to/dir     # Custom data directory (default: ~/.hezo/)
+hezo --master-key <key>          # Provide master key for unlock
+hezo --connect-url <url>         # Hezo Connect URL (default: http://localhost:4100)
+hezo --connect-api-key <key>     # API key for centrally hosted Connect
+hezo --reset                      # Wipe database and start fresh
+```
+
+## Testing
+
+```bash
+bun run test
+```
+
+Tests use Vitest with in-memory PGlite instances — no external database needed.
+
+## Project Structure
+
+```
+packages/
+  server/    — Main application server (Hono + PGlite)
+  connect/   — OAuth gateway for GitHub
+  shared/    — Shared TypeScript types and constants
+```
+
+## Key URLs
+
+| URL | Description |
+|-----|-------------|
+| http://localhost:3100 | Hezo Server |
+| http://localhost:3100/health | Server health check |
+| http://localhost:3100/api/status | Server status (master key state) |
+| http://localhost:4100 | Hezo Connect |
+| http://localhost:4100/health | Connect health check |
+| http://localhost:4100/platforms | Supported OAuth platforms |
 
 ## Scripts
 
 | Command | Description |
 |---------|-------------|
-| `bun run dev` | Start all packages in development mode |
+| `bun run dev` | Start all packages in dev mode |
 | `bun run build` | Build all packages |
 | `bun run test` | Run all tests |
 | `bun run typecheck` | Type-check all packages |
+| `bun run check` | Lint with Biome |
+| `bun run check:fix` | Lint and auto-fix |
+
+## Tech Stack
+
+| Component | Technology |
+|-----------|-----------|
+| Server | [Hono](https://hono.dev/) (TypeScript) |
+| Database | [PGlite](https://electric-sql.com/docs/api/pglite) (embedded Postgres) |
+| Encryption | AES-256-GCM (master key in memory only) |
+| OAuth | Hezo Connect gateway (self-hosted) |
+| Monorepo | Bun workspaces + Turborepo |
+| Tests | Vitest |

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -1,3 +1,42 @@
 # @hezo/shared
 
-Shared types, constants, and utilities used across Hezo packages.
+Shared TypeScript types and constants used across Hezo packages.
+
+## Usage
+
+Import from `@hezo/shared` in any workspace package:
+
+```typescript
+import { DEFAULT_PORT, AgentRuntime, type HezoConfig } from "@hezo/shared";
+```
+
+## Exports
+
+### Types
+
+- `HezoConfig` — server configuration (port, dataDir, masterKey, etc.)
+- `ConnectConfig` — OAuth gateway configuration
+- `MasterKeyState` — `"unset" | "locked" | "unlocked"`
+
+### Enums
+
+All enums use the `as const` object pattern (not TypeScript `enum`):
+
+`MemberType`, `AgentRuntime`, `AgentStatus`, `IssueStatus`, `IssuePriority`, `CommentContentType`, `ApprovalType`, `ApprovalStatus`, `MembershipRole`, `PlatformType`, `ConnectionStatus`, and more.
+
+### Constants
+
+| Constant | Value |
+|----------|-------|
+| `DEFAULT_PORT` | `3100` |
+| `DEFAULT_CONNECT_PORT` | `4100` |
+| `DEFAULT_DATA_DIR` | `~/.hezo` |
+| `DEFAULT_CONNECT_URL` | `http://localhost:4100` |
+| `CANARY_PLAINTEXT` | `CANARY` |
+
+## Scripts
+
+| Command | Description |
+|---------|-------------|
+| `bun run build` | Compile TypeScript |
+| `bun run typecheck` | Type-check without emitting |

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -1,0 +1,5 @@
+export const DEFAULT_PORT = 3100;
+export const DEFAULT_CONNECT_PORT = 4100;
+export const DEFAULT_DATA_DIR = "~/.hezo";
+export const DEFAULT_CONNECT_URL = "http://localhost:4100";
+export const CANARY_PLAINTEXT = "CANARY";

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,1 +1,2 @@
-export {};
+export * from "./types/index.js";
+export * from "./constants.js";

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -1,0 +1,68 @@
+export const MemberType = { Agent: "agent", User: "user" } as const;
+export type MemberType = (typeof MemberType)[keyof typeof MemberType];
+
+export const AgentRuntime = { ClaudeCode: "claude_code", Codex: "codex", Gemini: "gemini" } as const;
+export type AgentRuntime = (typeof AgentRuntime)[keyof typeof AgentRuntime];
+
+export const AgentStatus = { Active: "active", Idle: "idle", Paused: "paused", Terminated: "terminated" } as const;
+export type AgentStatus = (typeof AgentStatus)[keyof typeof AgentStatus];
+
+export const ContainerStatus = { Creating: "creating", Running: "running", Stopped: "stopped", Error: "error" } as const;
+export type ContainerStatus = (typeof ContainerStatus)[keyof typeof ContainerStatus];
+
+export const IssueStatus = { Backlog: "backlog", Open: "open", InProgress: "in_progress", Review: "review", Blocked: "blocked", Done: "done", Closed: "closed", Cancelled: "cancelled" } as const;
+export type IssueStatus = (typeof IssueStatus)[keyof typeof IssueStatus];
+
+export const IssuePriority = { Urgent: "urgent", High: "high", Medium: "medium", Low: "low" } as const;
+export type IssuePriority = (typeof IssuePriority)[keyof typeof IssuePriority];
+
+export const CommentContentType = { Text: "text", Options: "options", Preview: "preview", Trace: "trace", System: "system" } as const;
+export type CommentContentType = (typeof CommentContentType)[keyof typeof CommentContentType];
+
+export const ToolCallStatus = { Running: "running", Success: "success", Error: "error" } as const;
+export type ToolCallStatus = (typeof ToolCallStatus)[keyof typeof ToolCallStatus];
+
+export const SecretCategory = { SshKey: "ssh_key", Credential: "credential", ApiToken: "api_token", Certificate: "certificate", Other: "other" } as const;
+export type SecretCategory = (typeof SecretCategory)[keyof typeof SecretCategory];
+
+export const GrantScope = { Single: "single", Project: "project", Company: "company" } as const;
+export type GrantScope = (typeof GrantScope)[keyof typeof GrantScope];
+
+export const ApprovalType = { SecretAccess: "secret_access", Hire: "hire", Strategy: "strategy", KbUpdate: "kb_update", PlanReview: "plan_review", DeployProduction: "deploy_production" } as const;
+export type ApprovalType = (typeof ApprovalType)[keyof typeof ApprovalType];
+
+export const ApprovalStatus = { Pending: "pending", Approved: "approved", Denied: "denied" } as const;
+export type ApprovalStatus = (typeof ApprovalStatus)[keyof typeof ApprovalStatus];
+
+export const MembershipRole = { Board: "board", Member: "member" } as const;
+export type MembershipRole = (typeof MembershipRole)[keyof typeof MembershipRole];
+
+export const InviteStatus = { Pending: "pending", Accepted: "accepted", Expired: "expired", Revoked: "revoked" } as const;
+export type InviteStatus = (typeof InviteStatus)[keyof typeof InviteStatus];
+
+export const PlatformType = { GitHub: "github", Gmail: "gmail", GitLab: "gitlab", Stripe: "stripe", PostHog: "posthog", Railway: "railway", Vercel: "vercel", DigitalOcean: "digitalocean", X: "x" } as const;
+export type PlatformType = (typeof PlatformType)[keyof typeof PlatformType];
+
+export const ConnectionStatus = { Active: "active", Expired: "expired", Disconnected: "disconnected" } as const;
+export type ConnectionStatus = (typeof ConnectionStatus)[keyof typeof ConnectionStatus];
+
+export const WakeupSource = { Timer: "timer", Assignment: "assignment", OnDemand: "on_demand", Mention: "mention", Automation: "automation" } as const;
+export type WakeupSource = (typeof WakeupSource)[keyof typeof WakeupSource];
+
+export const WakeupStatus = { Queued: "queued", Claimed: "claimed", Completed: "completed", Failed: "failed", Skipped: "skipped", Coalesced: "coalesced", Deferred: "deferred", Cancelled: "cancelled" } as const;
+export type WakeupStatus = (typeof WakeupStatus)[keyof typeof WakeupStatus];
+
+export const HeartbeatRunStatus = { Queued: "queued", Running: "running", Succeeded: "succeeded", Failed: "failed", Cancelled: "cancelled", TimedOut: "timed_out" } as const;
+export type HeartbeatRunStatus = (typeof HeartbeatRunStatus)[keyof typeof HeartbeatRunStatus];
+
+export const PluginStatus = { Installed: "installed", Enabled: "enabled", Disabled: "disabled", Error: "error" } as const;
+export type PluginStatus = (typeof PluginStatus)[keyof typeof PluginStatus];
+
+export const ProjectDocType = { TechSpec: "tech_spec", ImplementationPlan: "implementation_plan", Research: "research", UiDesignDecisions: "ui_design_decisions", MarketingPlan: "marketing_plan", Other: "other" } as const;
+export type ProjectDocType = (typeof ProjectDocType)[keyof typeof ProjectDocType];
+
+export const AuditActorType = { Board: "board", Agent: "agent", System: "system" } as const;
+export type AuditActorType = (typeof AuditActorType)[keyof typeof AuditActorType];
+
+export const RepoHostType = { GitHub: "github" } as const;
+export type RepoHostType = (typeof RepoHostType)[keyof typeof RepoHostType];

--- a/packages/shared/src/types/config.ts
+++ b/packages/shared/src/types/config.ts
@@ -1,0 +1,20 @@
+export interface HezoConfig {
+  port: number;
+  dataDir: string;
+  masterKey?: string;
+  connectUrl: string;
+  connectApiKey?: string;
+  reset: boolean;
+}
+
+export interface ConnectConfig {
+  port: number;
+  mode: "self_hosted" | "centrally_hosted";
+  stateSigningKey: string;
+  github?: {
+    clientId: string;
+    clientSecret: string;
+  };
+}
+
+export type MasterKeyState = "unset" | "locked" | "unlocked";

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1,0 +1,2 @@
+export * from "./config.js";
+export * from "./common.js";


### PR DESCRIPTION
## Summary
- Add shared TypeScript types matching the database schema (members model)
- Add configuration types (HezoConfig, ConnectConfig)
- Add constants (default port, data dir, connect URL)

## Test plan
- [x] `bun run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)