### PR TITLE
feat(server): add CLI argument parser

### DIFF
--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -1,0 +1,61 @@
+import { homedir } from "os";
+import { resolve } from "path";
+
+export interface HezoConfig {
+  port: number;
+  dataDir: string;
+  masterKey?: string;
+  connectUrl: string;
+  connectApiKey?: string;
+  reset: boolean;
+}
+
+const DEFAULT_PORT = 3100;
+const DEFAULT_DATA_DIR = "~/.hezo";
+const DEFAULT_CONNECT_URL = "http://localhost:4100";
+
+export function parseArgs(argv: string[] = process.argv): HezoConfig {
+  const args = argv.slice(2);
+
+  let port = DEFAULT_PORT;
+  let dataDir = DEFAULT_DATA_DIR;
+  let masterKey: string | undefined;
+  let connectUrl = DEFAULT_CONNECT_URL;
+  let connectApiKey: string | undefined;
+  let reset = false;
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case "--port":
+        port = parseInt(args[++i], 10);
+        if (isNaN(port) || port < 1 || port > 65535) {
+          throw new Error(`Invalid port: ${args[i]}. Must be 1-65535.`);
+        }
+        break;
+      case "--data-dir":
+        dataDir = args[++i];
+        break;
+      case "--master-key":
+        masterKey = args[++i];
+        break;
+      case "--connect-url":
+        connectUrl = args[++i];
+        break;
+      case "--connect-api-key":
+        connectApiKey = args[++i];
+        break;
+      case "--reset":
+        reset = true;
+        break;
+    }
+  }
+
+  // Resolve tilde to home directory
+  if (dataDir.startsWith("~")) {
+    dataDir = resolve(homedir(), dataDir.slice(2));
+  } else {
+    dataDir = resolve(dataDir);
+  }
+
+  return { port, dataDir, masterKey, connectUrl, connectApiKey, reset };
+}

--- a/packages/server/src/test/__tests__/cli.test.ts
+++ b/packages/server/src/test/__tests__/cli.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { homedir } from "os";
+import { resolve } from "path";
+import { parseArgs } from "../../cli";
+
+// Helper to build argv with the standard bun/node + script prefix
+const argv = (...flags: string[]) => ["bun", "src/index.ts", ...flags];
+
+describe("parseArgs", () => {
+  it("returns defaults when no args provided", () => {
+    const config = parseArgs(argv());
+    expect(config.port).toBe(3100);
+    expect(config.dataDir).toBe(resolve(homedir(), ".hezo"));
+    expect(config.connectUrl).toBe("http://localhost:4100");
+    expect(config.masterKey).toBeUndefined();
+    expect(config.connectApiKey).toBeUndefined();
+    expect(config.reset).toBe(false);
+  });
+
+  it("parses --port", () => {
+    const config = parseArgs(argv("--port", "8080"));
+    expect(config.port).toBe(8080);
+  });
+
+  it("throws on non-numeric port", () => {
+    expect(() => parseArgs(argv("--port", "abc"))).toThrow("Invalid port");
+  });
+
+  it("throws on port below valid range", () => {
+    expect(() => parseArgs(argv("--port", "0"))).toThrow("Invalid port");
+  });
+
+  it("throws on port above valid range", () => {
+    expect(() => parseArgs(argv("--port", "99999"))).toThrow("Invalid port");
+  });
+
+  it("parses --data-dir with absolute path", () => {
+    const config = parseArgs(argv("--data-dir", "/custom/path"));
+    expect(config.dataDir).toBe("/custom/path");
+  });
+
+  it("resolves tilde in --data-dir", () => {
+    const config = parseArgs(argv("--data-dir", "~/custom"));
+    expect(config.dataDir).toBe(resolve(homedir(), "custom"));
+  });
+
+  it("parses --master-key", () => {
+    const config = parseArgs(argv("--master-key", "mykey"));
+    expect(config.masterKey).toBe("mykey");
+  });
+
+  it("parses --connect-url", () => {
+    const config = parseArgs(argv("--connect-url", "https://custom.example.com"));
+    expect(config.connectUrl).toBe("https://custom.example.com");
+  });
+
+  it("parses --connect-api-key", () => {
+    const config = parseArgs(argv("--connect-api-key", "hc_abc123"));
+    expect(config.connectApiKey).toBe("hc_abc123");
+  });
+
+  it("parses --reset", () => {
+    const config = parseArgs(argv("--reset"));
+    expect(config.reset).toBe(true);
+  });
+
+  it("handles multiple flags combined", () => {
+    const config = parseArgs(
+      argv(
+        "--port", "9000",
+        "--data-dir", "/tmp/hezo",
+        "--master-key", "secret",
+        "--connect-url", "https://connect.hezo.dev",
+        "--connect-api-key", "hc_xyz",
+        "--reset",
+      ),
+    );
+    expect(config.port).toBe(9000);
+    expect(config.dataDir).toBe("/tmp/hezo");
+    expect(config.masterKey).toBe("secret");
+    expect(config.connectUrl).toBe("https://connect.hezo.dev");
+    expect(config.connectApiKey).toBe("hc_xyz");
+    expect(config.reset).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `parseArgs()` CLI parser for --port, --data-dir, --master-key, --connect-url, --connect-api-key, --reset
- Port validation and tilde expansion for data-dir
- 12 unit tests covering all flags and edge cases

## Test plan
- [x] `bun test` passes (12 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)