### PR TITLE
feat(connect): implement Hezo Connect OAuth gateway

### DIFF
--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -1,15 +1,91 @@
 # @hezo/connect
 
-Hezo Connect — OAuth gateway. Handles OAuth flows for GitHub.
+Hezo Connect — standalone OAuth gateway. Handles the OAuth authorization dance for GitHub and delivers tokens to the requesting Hezo instance via browser redirect. No database, no accounts — a transient relay.
 
-## Default Port
+## Setup
 
-`4100` (override with `HEZO_CONNECT_PORT` env var)
+```bash
+# From the monorepo root
+bun install
+```
 
 ## Environment Variables
 
-| Variable | Description |
-|----------|-------------|
-| `HEZO_CONNECT_PORT` | HTTP listen port |
-| `GITHUB_CLIENT_ID` | GitHub OAuth app client ID |
-| `GITHUB_CLIENT_SECRET` | GitHub OAuth app client secret |
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `HEZO_CONNECT_PORT` | No | `4100` | HTTP listen port |
+| `GITHUB_CLIENT_ID` | Yes | — | GitHub OAuth app client ID |
+| `GITHUB_CLIENT_SECRET` | Yes | — | GitHub OAuth app client secret |
+| `STATE_SIGNING_KEY` | No | auto-generated | HMAC-SHA256 key for state parameter signing. Auto-generated on startup if not set (not persisted — set this env var for consistent signing across restarts). |
+
+### GitHub OAuth App Setup
+
+1. Go to [GitHub Settings > Developer Settings > OAuth Apps > New](https://github.com/settings/applications/new)
+2. **Application name**: `Hezo Connect Dev`
+3. **Homepage URL**: `http://localhost:3100`
+4. **Authorization callback URL**: `http://localhost:4100/auth/github/callback`
+5. Copy Client ID and Client Secret into env vars
+
+## Dev Server
+
+```bash
+GITHUB_CLIENT_ID=your_id GITHUB_CLIENT_SECRET=your_secret bun run dev
+```
+
+Starts on port 4100 with hot reload.
+
+## OAuth Flow
+
+```
+1. Hezo app redirects browser to Connect:
+   GET /auth/github/start?callback=http://localhost:3100/oauth/callback
+
+2. Connect signs a state parameter (HMAC-SHA256) and stores a nonce (5-min TTL)
+
+3. Connect redirects browser to GitHub consent screen
+
+4. User authorizes on GitHub
+
+5. GitHub redirects to Connect:
+   GET /auth/github/callback?code=xxx&state=xxx
+
+6. Connect verifies state signature and nonce, exchanges code for token,
+   fetches user info, then redirects browser to the Hezo app callback:
+   http://localhost:3100/oauth/callback?platform=github&access_token=xxx&scopes=xxx&metadata=xxx
+
+7. Connect purges the token from memory immediately
+```
+
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/health` | Returns `{ "ok": true }` |
+| GET | `/platforms` | Lists supported platforms and their scopes |
+| GET | `/signing-key` | Returns the HMAC signing key (hex) for state verification |
+| GET | `/auth/:platform/start` | Initiates OAuth flow. Requires `?callback=<url>` query param |
+| GET | `/auth/:platform/callback` | Provider redirects here after consent |
+
+## Security
+
+- **State signing**: HMAC-SHA256 prevents CSRF and ensures callbacks reach the correct Hezo instance
+- **Nonce store**: In-memory, 5-minute TTL, single-use — prevents replay attacks
+- **Token handling**: Tokens exist in memory only during the exchange (seconds), purged immediately after redirect
+- **Timing-safe comparison**: State signature verification uses constant-time comparison
+
+## Testing
+
+```bash
+bun test
+```
+
+26 tests covering state signing, endpoint responses, and the full OAuth flow with mocked GitHub API (dependency-injected fetch).
+
+## Scripts
+
+| Command | Description |
+|---------|-------------|
+| `bun run dev` | Start with hot reload |
+| `bun run build` | Compile TypeScript |
+| `bun run test` | Run Vitest tests |
+| `bun run typecheck` | Type-check without emitting |

--- a/packages/connect/src/app.ts
+++ b/packages/connect/src/app.ts
@@ -1,5 +1,20 @@
 import { Hono } from 'hono';
+import type { ConnectConfig } from './config.js';
+import { NonceStore } from './crypto/state.js';
+import { healthRoutes } from './routes/health.js';
+import { platformRoutes } from './routes/platforms.js';
+import { signingKeyRoutes } from './routes/signing-key.js';
+import { oauthRoutes } from './routes/oauth.js';
+import type { FetchFn } from './providers/github.js';
 
-export const app = new Hono();
+export function createApp(config: ConnectConfig, fetchFn?: FetchFn): Hono {
+	const app = new Hono();
+	const nonceStore = new NonceStore();
 
-app.get('/health', (c) => c.json({ ok: true }));
+	app.route('/', healthRoutes);
+	app.route('/', platformRoutes);
+	app.route('/', signingKeyRoutes(config));
+	app.route('/', oauthRoutes(config, nonceStore, fetchFn));
+
+	return app;
+}

--- a/packages/connect/src/config.ts
+++ b/packages/connect/src/config.ts
@@ -1,0 +1,36 @@
+import { randomBytes } from "crypto";
+
+export interface ConnectConfig {
+  port: number;
+  mode: "self_hosted";
+  stateSigningKey: string;
+  github?: {
+    clientId: string;
+    clientSecret: string;
+  };
+}
+
+export function loadConfig(): ConnectConfig {
+  const port = parseInt(process.env.HEZO_CONNECT_PORT || "4100", 10);
+
+  let stateSigningKey = process.env.STATE_SIGNING_KEY || "";
+  if (!stateSigningKey) {
+    stateSigningKey = randomBytes(32).toString("hex");
+    console.log(
+      "Auto-generated state signing key (set STATE_SIGNING_KEY env var to persist)"
+    );
+  }
+
+  const githubClientId = process.env.GITHUB_CLIENT_ID;
+  const githubClientSecret = process.env.GITHUB_CLIENT_SECRET;
+
+  return {
+    port,
+    mode: "self_hosted",
+    stateSigningKey,
+    github:
+      githubClientId && githubClientSecret
+        ? { clientId: githubClientId, clientSecret: githubClientSecret }
+        : undefined,
+  };
+}

--- a/packages/connect/src/crypto/state.ts
+++ b/packages/connect/src/crypto/state.ts
@@ -1,0 +1,75 @@
+import { createHmac, randomUUID, timingSafeEqual } from "crypto";
+
+export interface StatePayload {
+  callback_url: string;
+  platform: string;
+  nonce: string;
+  timestamp: string;
+  original_state?: string;
+}
+
+export function signState(payload: StatePayload, signingKey: string): string {
+  const json = JSON.stringify(payload);
+  const signature = createHmac("sha256", signingKey)
+    .update(json)
+    .digest("hex");
+  const encoded = Buffer.from(json).toString("base64url");
+  return `${encoded}.${signature}`;
+}
+
+export function verifyState(
+  signedState: string,
+  signingKey: string
+): StatePayload | null {
+  const dotIndex = signedState.lastIndexOf(".");
+  if (dotIndex === -1) return null;
+
+  const encoded = signedState.substring(0, dotIndex);
+  const signature = signedState.substring(dotIndex + 1);
+
+  const json = Buffer.from(encoded, "base64url").toString("utf8");
+  const expectedSignature = createHmac("sha256", signingKey)
+    .update(json)
+    .digest("hex");
+
+  if (signature.length !== expectedSignature.length) return null;
+  if (
+    !timingSafeEqual(Buffer.from(signature), Buffer.from(expectedSignature))
+  )
+    return null;
+
+  try {
+    return JSON.parse(json) as StatePayload;
+  } catch {
+    return null;
+  }
+}
+
+export function createNonce(): string {
+  return randomUUID();
+}
+
+const NONCE_TTL_MS = 5 * 60 * 1000;
+
+export class NonceStore {
+  private nonces = new Map<string, number>();
+
+  add(nonce: string): void {
+    this.cleanup();
+    this.nonces.set(nonce, Date.now() + NONCE_TTL_MS);
+  }
+
+  consume(nonce: string): boolean {
+    this.cleanup();
+    if (!this.nonces.has(nonce)) return false;
+    this.nonces.delete(nonce);
+    return true;
+  }
+
+  private cleanup(): void {
+    const now = Date.now();
+    for (const [nonce, expiry] of this.nonces) {
+      if (expiry < now) this.nonces.delete(nonce);
+    }
+  }
+}

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -1,10 +1,17 @@
-import { app } from './app';
+import { loadConfig } from './config.js';
+import { createApp } from './app.js';
 
-const port = parseInt(process.env.HEZO_CONNECT_PORT || '4100', 10);
+const config = loadConfig();
+const app = createApp(config);
 
-console.log(`Hezo Connect starting on port ${port}...`);
+console.log(`Hezo Connect starting on port ${config.port}...`);
+if (config.github) {
+	console.log('GitHub OAuth: configured');
+} else {
+	console.log('GitHub OAuth: not configured (set GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET)');
+}
 
 export default {
-	port,
+	port: config.port,
 	fetch: app.fetch,
 };

--- a/packages/connect/src/providers/github.ts
+++ b/packages/connect/src/providers/github.ts
@@ -1,0 +1,58 @@
+export interface GitHubTokenResponse {
+  access_token: string;
+  token_type: string;
+  scope: string;
+}
+
+export interface GitHubUserInfo {
+  login: string;
+  avatar_url: string;
+  email: string | null;
+}
+
+export type FetchFn = typeof globalThis.fetch;
+
+export async function exchangeCode(
+  code: string,
+  clientId: string,
+  clientSecret: string,
+  redirectUri: string,
+  fetchFn: FetchFn = globalThis.fetch
+): Promise<GitHubTokenResponse> {
+  const res = await fetchFn("https://github.com/login/oauth/access_token", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({
+      client_id: clientId,
+      client_secret: clientSecret,
+      code,
+      redirect_uri: redirectUri,
+    }),
+  });
+
+  if (!res.ok) throw new Error(`GitHub token exchange failed: ${res.status}`);
+  const data = (await res.json()) as Record<string, unknown>;
+  if (data.error)
+    throw new Error(
+      `GitHub OAuth error: ${data.error_description || data.error}`
+    );
+  return data as unknown as GitHubTokenResponse;
+}
+
+export async function fetchUserInfo(
+  accessToken: string,
+  fetchFn: FetchFn = globalThis.fetch
+): Promise<GitHubUserInfo> {
+  const res = await fetchFn("https://api.github.com/user", {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: "application/vnd.github+json",
+    },
+  });
+
+  if (!res.ok) throw new Error(`GitHub user info fetch failed: ${res.status}`);
+  return (await res.json()) as GitHubUserInfo;
+}

--- a/packages/connect/src/routes/health.ts
+++ b/packages/connect/src/routes/health.ts
@@ -1,0 +1,5 @@
+import { Hono } from "hono";
+
+export const healthRoutes = new Hono();
+
+healthRoutes.get("/health", (c) => c.json({ ok: true }));

--- a/packages/connect/src/routes/oauth.ts
+++ b/packages/connect/src/routes/oauth.ts
@@ -1,0 +1,179 @@
+import { Hono } from "hono";
+import type { ConnectConfig } from "../config.js";
+import {
+  signState,
+  verifyState,
+  createNonce,
+  NonceStore,
+  type StatePayload,
+} from "../crypto/state.js";
+import {
+  exchangeCode,
+  fetchUserInfo,
+  type FetchFn,
+} from "../providers/github.js";
+
+const SUPPORTED_PLATFORMS = new Set(["github"]);
+const GITHUB_SCOPES = "repo,workflow,read:org";
+
+function errorRedirect(
+  callbackUrl: string,
+  platform: string,
+  errorCode: string,
+  message?: string
+): string {
+  const url = new URL(callbackUrl);
+  url.searchParams.set("error", errorCode);
+  url.searchParams.set("platform", platform);
+  if (message) url.searchParams.set("message", message);
+  return url.toString();
+}
+
+export function oauthRoutes(
+  config: ConnectConfig,
+  nonceStore: NonceStore,
+  fetchFn: FetchFn = globalThis.fetch
+): Hono {
+  const routes = new Hono();
+
+  routes.get("/auth/:platform/start", (c) => {
+    const platform = c.req.param("platform");
+
+    if (!SUPPORTED_PLATFORMS.has(platform)) {
+      return c.json(
+        { error: "unsupported_platform", message: `Platform "${platform}" is not supported` },
+        400
+      );
+    }
+
+    const callbackUrl = c.req.query("callback");
+    if (!callbackUrl) {
+      return c.json(
+        { error: "missing_callback", message: "callback query parameter is required" },
+        400
+      );
+    }
+
+    if (!config.github) {
+      return c.redirect(
+        errorRedirect(callbackUrl, platform, "missing_config", "GitHub OAuth is not configured")
+      );
+    }
+
+    const nonce = createNonce();
+    nonceStore.add(nonce);
+
+    const payload: StatePayload = {
+      callback_url: callbackUrl,
+      platform,
+      nonce,
+      timestamp: new Date().toISOString(),
+    };
+
+    const originalState = c.req.query("state");
+    if (originalState) payload.original_state = originalState;
+
+    const signedState = signState(payload, config.stateSigningKey);
+
+    const connectCallbackUrl = new URL(c.req.url);
+    connectCallbackUrl.pathname = `/auth/${platform}/callback`;
+    connectCallbackUrl.search = "";
+
+    const githubUrl = new URL("https://github.com/login/oauth/authorize");
+    githubUrl.searchParams.set("client_id", config.github.clientId);
+    githubUrl.searchParams.set("redirect_uri", connectCallbackUrl.toString());
+    githubUrl.searchParams.set("scope", GITHUB_SCOPES);
+    githubUrl.searchParams.set("state", signedState);
+
+    return c.redirect(githubUrl.toString());
+  });
+
+  routes.get("/auth/:platform/callback", async (c) => {
+    const platform = c.req.param("platform");
+    const code = c.req.query("code");
+    const stateParam = c.req.query("state");
+
+    if (!SUPPORTED_PLATFORMS.has(platform)) {
+      return c.json(
+        { error: "unsupported_platform", message: `Platform "${platform}" is not supported` },
+        400
+      );
+    }
+
+    if (!stateParam) {
+      return c.json({ error: "invalid_state", message: "Missing state parameter" }, 400);
+    }
+
+    const payload = verifyState(stateParam, config.stateSigningKey);
+    if (!payload) {
+      return c.json({ error: "invalid_state", message: "Invalid state signature" }, 400);
+    }
+
+    const callbackUrl = payload.callback_url;
+
+    if (!nonceStore.consume(payload.nonce)) {
+      return c.redirect(
+        errorRedirect(callbackUrl, platform, "expired_nonce", "Nonce expired or already used")
+      );
+    }
+
+    if (c.req.query("error") === "access_denied") {
+      return c.redirect(
+        errorRedirect(callbackUrl, platform, "access_denied", "User denied authorization")
+      );
+    }
+
+    if (!code) {
+      return c.redirect(
+        errorRedirect(callbackUrl, platform, "invalid_state", "Missing authorization code")
+      );
+    }
+
+    if (!config.github) {
+      return c.redirect(
+        errorRedirect(callbackUrl, platform, "missing_config", "GitHub OAuth is not configured")
+      );
+    }
+
+    const connectCallbackUrl = new URL(c.req.url);
+    connectCallbackUrl.search = "";
+
+    try {
+      const tokenResponse = await exchangeCode(
+        code,
+        config.github.clientId,
+        config.github.clientSecret,
+        connectCallbackUrl.toString(),
+        fetchFn
+      );
+
+      const userInfo = await fetchUserInfo(tokenResponse.access_token, fetchFn);
+
+      const metadata = Buffer.from(
+        JSON.stringify({
+          username: userInfo.login,
+          avatar_url: userInfo.avatar_url,
+          email: userInfo.email,
+        })
+      ).toString("base64url");
+
+      const redirectUrl = new URL(callbackUrl);
+      redirectUrl.searchParams.set("platform", platform);
+      redirectUrl.searchParams.set("access_token", tokenResponse.access_token);
+      redirectUrl.searchParams.set("scopes", tokenResponse.scope);
+      redirectUrl.searchParams.set("metadata", metadata);
+      if (payload.original_state) {
+        redirectUrl.searchParams.set("state", payload.original_state);
+      }
+
+      return c.redirect(redirectUrl.toString());
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Token exchange failed";
+      return c.redirect(
+        errorRedirect(callbackUrl, platform, "token_exchange_failed", message)
+      );
+    }
+  });
+
+  return routes;
+}

--- a/packages/connect/src/routes/platforms.ts
+++ b/packages/connect/src/routes/platforms.ts
@@ -1,0 +1,13 @@
+import { Hono } from "hono";
+
+const PLATFORMS = [
+  {
+    id: "github",
+    name: "GitHub",
+    scopes: ["repo", "workflow", "read:org"],
+  },
+] as const;
+
+export const platformRoutes = new Hono();
+
+platformRoutes.get("/platforms", (c) => c.json({ platforms: PLATFORMS }));

--- a/packages/connect/src/routes/signing-key.ts
+++ b/packages/connect/src/routes/signing-key.ts
@@ -1,0 +1,12 @@
+import { Hono } from "hono";
+import type { ConnectConfig } from "../config.js";
+
+export function signingKeyRoutes(config: ConnectConfig): Hono {
+  const routes = new Hono();
+
+  routes.get("/signing-key", (c) =>
+    c.json({ key: config.stateSigningKey })
+  );
+
+  return routes;
+}

--- a/packages/connect/src/test/__tests__/health.test.ts
+++ b/packages/connect/src/test/__tests__/health.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { createApp } from "../../app.js";
+import type { ConnectConfig } from "../../config.js";
+
+const config: ConnectConfig = {
+  port: 4100,
+  mode: "self_hosted",
+  stateSigningKey: "test-key",
+  github: { clientId: "test-id", clientSecret: "test-secret" },
+};
+
+const app = createApp(config);
+
+describe("GET /health", () => {
+  it("returns 200 with { ok: true }", async () => {
+    const res = await app.request("/health");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+});
+
+describe("GET /platforms", () => {
+  it("returns platform list with github", async () => {
+    const res = await app.request("/platforms");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.platforms).toHaveLength(1);
+    expect(body.platforms[0]).toEqual({
+      id: "github",
+      name: "GitHub",
+      scopes: ["repo", "workflow", "read:org"],
+    });
+  });
+});
+
+describe("GET /signing-key", () => {
+  it("returns the hex signing key", async () => {
+    const res = await app.request("/signing-key");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.key).toBe("test-key");
+  });
+});

--- a/packages/connect/src/test/__tests__/oauth.test.ts
+++ b/packages/connect/src/test/__tests__/oauth.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect } from "vitest";
+import { createApp } from "../../app.js";
+import { verifyState } from "../../crypto/state.js";
+import type { ConnectConfig } from "../../config.js";
+import type { FetchFn } from "../../providers/github.js";
+
+const SIGNING_KEY = "test-signing-key-for-oauth-tests";
+
+function makeConfig(github?: { clientId: string; clientSecret: string }): ConnectConfig {
+  return {
+    port: 4100,
+    mode: "self_hosted",
+    stateSigningKey: SIGNING_KEY,
+    github,
+  };
+}
+
+function mockFetchFn(
+  tokenResponse: Record<string, unknown>,
+  userInfo: Record<string, unknown>
+): FetchFn {
+  return async (input: string | URL | Request) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+
+    if (url.includes("github.com/login/oauth/access_token")) {
+      return new Response(JSON.stringify(tokenResponse), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (url.includes("api.github.com/user")) {
+      return new Response(JSON.stringify(userInfo), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    return new Response("Not found", { status: 404 });
+  };
+}
+
+describe("GET /auth/:platform/start", () => {
+  it("returns 400 without callback param", async () => {
+    const app = createApp(makeConfig({ clientId: "id", clientSecret: "secret" }));
+    const res = await app.request("/auth/github/start");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("missing_callback");
+  });
+
+  it("redirects to error when GitHub is not configured", async () => {
+    const app = createApp(makeConfig());
+    const res = await app.request(
+      "/auth/github/start?callback=http://localhost:3100/oauth/callback"
+    );
+    expect(res.status).toBe(302);
+    const location = res.headers.get("Location")!;
+    const url = new URL(location);
+    expect(url.searchParams.get("error")).toBe("missing_config");
+  });
+
+  it("returns 400 for unsupported platform", async () => {
+    const app = createApp(makeConfig({ clientId: "id", clientSecret: "secret" }));
+    const res = await app.request(
+      "/auth/unsupported/start?callback=http://localhost:3100/oauth/callback"
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("unsupported_platform");
+  });
+
+  it("redirects to GitHub OAuth with correct params", async () => {
+    const app = createApp(makeConfig({ clientId: "my-client-id", clientSecret: "secret" }));
+    const res = await app.request(
+      "/auth/github/start?callback=http://localhost:3100/oauth/callback"
+    );
+    expect(res.status).toBe(302);
+    const location = res.headers.get("Location")!;
+    const url = new URL(location);
+    expect(url.hostname).toBe("github.com");
+    expect(url.pathname).toBe("/login/oauth/authorize");
+    expect(url.searchParams.get("client_id")).toBe("my-client-id");
+    expect(url.searchParams.get("scope")).toBe("repo,workflow,read:org");
+    expect(url.searchParams.get("state")).toBeTruthy();
+  });
+});
+
+describe("GET /auth/:platform/callback", () => {
+  it("returns 400 with invalid state", async () => {
+    const app = createApp(makeConfig({ clientId: "id", clientSecret: "secret" }));
+    const res = await app.request(
+      "/auth/github/callback?code=test-code&state=invalid.state"
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_state");
+  });
+
+  it("returns 400 without state param", async () => {
+    const app = createApp(makeConfig({ clientId: "id", clientSecret: "secret" }));
+    const res = await app.request("/auth/github/callback?code=test-code");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_state");
+  });
+
+  it("returns 400 for unsupported platform in callback", async () => {
+    const app = createApp(makeConfig({ clientId: "id", clientSecret: "secret" }));
+    const res = await app.request("/auth/unsupported/callback?code=c&state=s.s");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("unsupported_platform");
+  });
+});
+
+describe("full OAuth flow with mocked GitHub API", () => {
+  it("completes start → callback → redirect with tokens", async () => {
+    const fetchFn = mockFetchFn(
+      { access_token: "gho_mock_token", token_type: "bearer", scope: "repo,workflow,read:org" },
+      { login: "testuser", avatar_url: "https://avatars.githubusercontent.com/u/1", email: "test@example.com" }
+    );
+    const config = makeConfig({ clientId: "cid", clientSecret: "csecret" });
+    const app = createApp(config, fetchFn);
+
+    // Step 1: Start the flow
+    const startRes = await app.request(
+      "http://localhost:4100/auth/github/start?callback=http://localhost:3100/oauth/callback&state=user-data"
+    );
+    expect(startRes.status).toBe(302);
+    const githubUrl = new URL(startRes.headers.get("Location")!);
+    const signedState = githubUrl.searchParams.get("state")!;
+
+    // Verify the state is valid
+    const payload = verifyState(signedState, SIGNING_KEY);
+    expect(payload).not.toBeNull();
+    expect(payload!.callback_url).toBe("http://localhost:3100/oauth/callback");
+    expect(payload!.platform).toBe("github");
+    expect(payload!.original_state).toBe("user-data");
+
+    // Step 2: Simulate GitHub callback
+    const callbackRes = await app.request(
+      `http://localhost:4100/auth/github/callback?code=mock-code&state=${encodeURIComponent(signedState)}`
+    );
+    expect(callbackRes.status).toBe(302);
+
+    // Step 3: Verify the final redirect
+    const finalUrl = new URL(callbackRes.headers.get("Location")!);
+    expect(finalUrl.origin + finalUrl.pathname).toBe(
+      "http://localhost:3100/oauth/callback"
+    );
+    expect(finalUrl.searchParams.get("platform")).toBe("github");
+    expect(finalUrl.searchParams.get("access_token")).toBe("gho_mock_token");
+    expect(finalUrl.searchParams.get("scopes")).toBe("repo,workflow,read:org");
+    expect(finalUrl.searchParams.get("state")).toBe("user-data");
+
+    // Verify metadata contains user info
+    const metadata = JSON.parse(
+      Buffer.from(finalUrl.searchParams.get("metadata")!, "base64url").toString("utf8")
+    );
+    expect(metadata.username).toBe("testuser");
+    expect(metadata.avatar_url).toBe("https://avatars.githubusercontent.com/u/1");
+    expect(metadata.email).toBe("test@example.com");
+  });
+
+  it("redirects with error when token exchange fails", async () => {
+    const fetchFn: FetchFn = async () =>
+      new Response(JSON.stringify({ error: "bad_verification_code" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+
+    const config = makeConfig({ clientId: "cid", clientSecret: "csecret" });
+    const app = createApp(config, fetchFn);
+
+    // Start the flow to get a valid state
+    const startRes = await app.request(
+      "http://localhost:4100/auth/github/start?callback=http://localhost:3100/oauth/callback"
+    );
+    const githubUrl = new URL(startRes.headers.get("Location")!);
+    const signedState = githubUrl.searchParams.get("state")!;
+
+    // Callback with the bad code
+    const callbackRes = await app.request(
+      `http://localhost:4100/auth/github/callback?code=bad-code&state=${encodeURIComponent(signedState)}`
+    );
+    expect(callbackRes.status).toBe(302);
+    const errorUrl = new URL(callbackRes.headers.get("Location")!);
+    expect(errorUrl.searchParams.get("error")).toBe("token_exchange_failed");
+    expect(errorUrl.searchParams.get("platform")).toBe("github");
+  });
+
+  it("nonce cannot be reused", async () => {
+    const fetchFn = mockFetchFn(
+      { access_token: "gho_token", token_type: "bearer", scope: "repo" },
+      { login: "user", avatar_url: "https://example.com/avatar", email: null }
+    );
+    const config = makeConfig({ clientId: "cid", clientSecret: "csecret" });
+    const app = createApp(config, fetchFn);
+
+    // Start the flow
+    const startRes = await app.request(
+      "http://localhost:4100/auth/github/start?callback=http://localhost:3100/oauth/callback"
+    );
+    const githubUrl = new URL(startRes.headers.get("Location")!);
+    const signedState = githubUrl.searchParams.get("state")!;
+
+    // First callback succeeds
+    const first = await app.request(
+      `http://localhost:4100/auth/github/callback?code=code&state=${encodeURIComponent(signedState)}`
+    );
+    expect(first.status).toBe(302);
+    const firstUrl = new URL(first.headers.get("Location")!);
+    expect(firstUrl.searchParams.get("access_token")).toBe("gho_token");
+
+    // Second callback with same state fails (nonce consumed)
+    const second = await app.request(
+      `http://localhost:4100/auth/github/callback?code=code&state=${encodeURIComponent(signedState)}`
+    );
+    expect(second.status).toBe(302);
+    const secondUrl = new URL(second.headers.get("Location")!);
+    expect(secondUrl.searchParams.get("error")).toBe("expired_nonce");
+  });
+});

--- a/packages/connect/src/test/__tests__/state.test.ts
+++ b/packages/connect/src/test/__tests__/state.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  signState,
+  verifyState,
+  createNonce,
+  NonceStore,
+  type StatePayload,
+} from "../../crypto/state.js";
+
+describe("signState + verifyState", () => {
+  const signingKey = "test-signing-key-256-bits-long-abc";
+  const payload: StatePayload = {
+    callback_url: "http://localhost:3100/oauth/callback",
+    platform: "github",
+    nonce: "test-nonce-123",
+    timestamp: "2026-03-30T12:00:00Z",
+  };
+
+  it("roundtrips successfully", () => {
+    const signed = signState(payload, signingKey);
+    const result = verifyState(signed, signingKey);
+    expect(result).toEqual(payload);
+  });
+
+  it("preserves original_state when present", () => {
+    const withState = { ...payload, original_state: "user-state-abc" };
+    const signed = signState(withState, signingKey);
+    const result = verifyState(signed, signingKey);
+    expect(result).toEqual(withState);
+  });
+
+  it("returns null for tampered payload", () => {
+    const signed = signState(payload, signingKey);
+    const [encoded, signature] = signed.split(".");
+    const tampered =
+      Buffer.from(
+        JSON.stringify({ ...payload, platform: "evil" })
+      ).toString("base64url") +
+      "." +
+      signature;
+    expect(verifyState(tampered, signingKey)).toBeNull();
+  });
+
+  it("returns null for tampered signature", () => {
+    const signed = signState(payload, signingKey);
+    const tampered = signed.slice(0, -4) + "xxxx";
+    expect(verifyState(tampered, signingKey)).toBeNull();
+  });
+
+  it("returns null with a different signing key", () => {
+    const signed = signState(payload, signingKey);
+    expect(verifyState(signed, "different-key")).toBeNull();
+  });
+
+  it("returns null for input without a dot separator", () => {
+    expect(verifyState("nodothere", signingKey)).toBeNull();
+  });
+});
+
+describe("createNonce", () => {
+  it("returns a UUID string", () => {
+    const nonce = createNonce();
+    expect(nonce).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    );
+  });
+
+  it("returns unique values", () => {
+    const a = createNonce();
+    const b = createNonce();
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("NonceStore", () => {
+  let store: NonceStore;
+
+  beforeEach(() => {
+    store = new NonceStore();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("add and consume succeeds", () => {
+    store.add("nonce-1");
+    expect(store.consume("nonce-1")).toBe(true);
+  });
+
+  it("consume same nonce twice fails", () => {
+    store.add("nonce-2");
+    expect(store.consume("nonce-2")).toBe(true);
+    expect(store.consume("nonce-2")).toBe(false);
+  });
+
+  it("consume unknown nonce fails", () => {
+    expect(store.consume("unknown")).toBe(false);
+  });
+
+  it("expired nonces are not consumable", () => {
+    store.add("nonce-3");
+    vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+    expect(store.consume("nonce-3")).toBe(false);
+  });
+
+  it("non-expired nonces remain consumable", () => {
+    store.add("nonce-4");
+    vi.advanceTimersByTime(4 * 60 * 1000);
+    expect(store.consume("nonce-4")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Implement Hezo Connect as self-hosted OAuth relay with GitHub platform
- 5 endpoints: /health, /platforms, /signing-key, /auth/:platform/start, /auth/:platform/callback
- HMAC-SHA256 state signing, in-memory nonce store with 5-min TTL
- Dependency-injected fetch for testability — 26 tests

## Test plan
- [x] `bun test` passes (26 tests)
- [x] Health, platforms, signing-key endpoints verified via curl

🤖 Generated with [Claude Code](https://claude.com/claude-code)