### PR TITLE
feat(server): implement Phase 2 Core CRUD REST API

### DIFF
--- a/.dev/implementation-phases.md
+++ b/.dev/implementation-phases.md
@@ -12,6 +12,8 @@
 
 ## Phase 0: Hezo Connect (Self-Hosted, GitHub Only)
 
+**Status:** Done (2025-03)
+
 **Goal:** A standalone OAuth relay that can handle GitHub OAuth flows. First thing built, independently testable, no dependency on the main Hezo app. Lives in `packages/connect`.
 
 **What's included:**
@@ -37,6 +39,8 @@
 ---
 
 ## Phase 1: Foundation
+
+**Status:** Done (2025-03)
 
 **Goal:** A running Hono server with an embedded database, migration system, master key, and CLI argument parsing. No business logic yet. Lives in `packages/server` with shared types in `packages/shared`.
 

--- a/.dev/spec.md
+++ b/.dev/spec.md
@@ -463,6 +463,8 @@ The company-level `AGENTS.md` file lives in the project root and contains rules 
 
 AGENTS.md is the primary mechanism for enforcing engineering standards. It lives in the project root so that any coding agent (Claude Code, Codex, Gemini) automatically reads it — no runtime-specific configuration needed.
 
+To use AGENTS.md with Claude Code, project repos include a `CLAUDE.md` that points to it. The simplest approach is `@AGENTS.md` as the first line of `CLAUDE.md`, or a symlink (`ln -s AGENTS.md CLAUDE.md`). When hezo sets up a project repo, it creates both `AGENTS.md` and a `CLAUDE.md` pointing to it.
+
 Role-specific instructions are embedded directly in each agent's system prompt template — no separate skill files.
 
 ---

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+bunx commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-bunx biome check . && bun run typecheck
+bunx biome check . && bun run typecheck && bun run build

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+bunx biome check . && bun run typecheck

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-bunx biome check . && bun run typecheck && bun run build
+bunx biome check --diagnostic-level=error . && bun run typecheck && bun run build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,3 +8,7 @@ When updating docs:
 - Describe what the system **does**, not what changed
 - Don't reference what was removed, replaced, or decided against — only document what exists now
 - No backwards compatibility concerns until v1.0.0 — when things change, just change them cleanly
+
+## Implementation Phases
+
+When completing an implementation phase, update `.dev/implementation-phases.md` to mark the phase as done with a completion date. Keep the phase content intact — just add a status line at the top of the phase section.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,10 @@ When updating docs:
 - Don't reference what was removed, replaced, or decided against — only document what exists now
 - No backwards compatibility concerns until v1.0.0 — when things change, just change them cleanly
 
+## Testing
+
+Tests must actually test functionality — not just assert that code runs without throwing. If something is too difficult to mock for a unit test, write an integration test instead. Prefer integration tests over heavily-mocked unit tests.
+
 ## Implementation Phases
 
 When completing an implementation phase, update `.dev/implementation-phases.md` to mark the phase as done with a completion date. Keep the phase content intact — just add a status line at the top of the phase section.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/biome.json
+++ b/biome.json
@@ -29,6 +29,15 @@
 		}
 	},
 	"files": {
-		"includes": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.json", "!**/dist", "!.claude", "!.hezo"]
+		"includes": [
+			"**/*.ts",
+			"**/*.tsx",
+			"**/*.js",
+			"**/*.json",
+			"!**/dist",
+			"!.claude",
+			"!.hezo",
+			"!.turbo"
+		]
 	}
 }

--- a/biome.json
+++ b/biome.json
@@ -37,7 +37,8 @@
 			"!**/dist",
 			"!.claude",
 			"!.hezo",
-			"!.turbo"
+			"!.turbo",
+			"!**/migrations-bundle.json"
 		]
 	}
 }

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,9 @@
       "name": "hezo",
       "devDependencies": {
         "@biomejs/biome": "^2.4.10",
+        "@commitlint/cli": "^20.5.0",
+        "@commitlint/config-conventional": "^20.5.0",
+        "husky": "^9.1.7",
         "turbo": "^2",
         "typescript": "^5",
       },
@@ -49,6 +52,10 @@
     },
   },
   "packages": {
+    "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
     "@biomejs/biome": ["@biomejs/biome@2.4.10", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.10", "@biomejs/cli-darwin-x64": "2.4.10", "@biomejs/cli-linux-arm64": "2.4.10", "@biomejs/cli-linux-arm64-musl": "2.4.10", "@biomejs/cli-linux-x64": "2.4.10", "@biomejs/cli-linux-x64-musl": "2.4.10", "@biomejs/cli-win32-arm64": "2.4.10", "@biomejs/cli-win32-x64": "2.4.10" }, "bin": { "biome": "bin/biome" } }, "sha512-xxA3AphFQ1geij4JTHXv4EeSTda1IFn22ye9LdyVPoJU19fNVl0uzfEuhsfQ4Yue/0FaLs2/ccVi4UDiE7R30w=="],
 
     "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.10", "", { "os": "darwin", "cpu": "arm64" }, "sha512-vuzzI1cWqDVzOMIkYyHbKqp+AkQq4K7k+UCXWpkYcY/HDn1UxdsbsfgtVpa40shem8Kax4TLDLlx8kMAecgqiw=="],
@@ -66,6 +73,42 @@
     "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.10", "", { "os": "win32", "cpu": "arm64" }, "sha512-umwQU6qPzH+ISTf/eHyJ/QoQnJs3V9Vpjz2OjZXe9MVBZ7prgGafMy7yYeRGnlmDAn87AKTF3Q6weLoMGpeqdQ=="],
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.10", "", { "os": "win32", "cpu": "x64" }, "sha512-aW/JU5GuyH4uxMrNYpoC2kjaHlyJGLgIa3XkhPEZI0uKhZhJZU8BuEyJmvgzSPQNGozBwWjC972RaNdcJ9KyJg=="],
+
+    "@commitlint/cli": ["@commitlint/cli@20.5.0", "", { "dependencies": { "@commitlint/format": "^20.5.0", "@commitlint/lint": "^20.5.0", "@commitlint/load": "^20.5.0", "@commitlint/read": "^20.5.0", "@commitlint/types": "^20.5.0", "tinyexec": "^1.0.0", "yargs": "^17.0.0" }, "bin": { "commitlint": "./cli.js" } }, "sha512-yNkyN/tuKTJS3wdVfsZ2tXDM4G4Gi7z+jW54Cki8N8tZqwKBltbIvUUrSbT4hz1bhW/h0CdR+5sCSpXD+wMKaQ=="],
+
+    "@commitlint/config-conventional": ["@commitlint/config-conventional@20.5.0", "", { "dependencies": { "@commitlint/types": "^20.5.0", "conventional-changelog-conventionalcommits": "^9.2.0" } }, "sha512-t3Ni88rFw1XMa4nZHgOKJ8fIAT9M2j5TnKyTqJzsxea7FUetlNdYFus9dz+MhIRZmc16P0PPyEfh6X2d/qw8SA=="],
+
+    "@commitlint/config-validator": ["@commitlint/config-validator@20.5.0", "", { "dependencies": { "@commitlint/types": "^20.5.0", "ajv": "^8.11.0" } }, "sha512-T/Uh6iJUzyx7j35GmHWdIiGRQB+ouZDk0pwAaYq4SXgB54KZhFdJ0vYmxiW6AMYICTIWuyMxDBl1jK74oFp/Gw=="],
+
+    "@commitlint/ensure": ["@commitlint/ensure@20.5.0", "", { "dependencies": { "@commitlint/types": "^20.5.0", "lodash.camelcase": "^4.3.0", "lodash.kebabcase": "^4.1.1", "lodash.snakecase": "^4.1.1", "lodash.startcase": "^4.4.0", "lodash.upperfirst": "^4.3.1" } }, "sha512-IpHqAUesBeW1EDDdjzJeaOxU9tnogLAyXLRBn03SHlj1SGENn2JGZqSWGkFvBJkJzfXAuCNtsoYzax+ZPS+puw=="],
+
+    "@commitlint/execute-rule": ["@commitlint/execute-rule@20.0.0", "", {}, "sha512-xyCoOShoPuPL44gVa+5EdZsBVao/pNzpQhkzq3RdtlFdKZtjWcLlUFQHSWBuhk5utKYykeJPSz2i8ABHQA+ZZw=="],
+
+    "@commitlint/format": ["@commitlint/format@20.5.0", "", { "dependencies": { "@commitlint/types": "^20.5.0", "picocolors": "^1.1.1" } }, "sha512-TI9EwFU/qZWSK7a5qyXMpKPPv3qta7FO4tKW+Wt2al7sgMbLWTsAcDpX1cU8k16TRdsiiet9aOw0zpvRXNJu7Q=="],
+
+    "@commitlint/is-ignored": ["@commitlint/is-ignored@20.5.0", "", { "dependencies": { "@commitlint/types": "^20.5.0", "semver": "^7.6.0" } }, "sha512-JWLarAsurHJhPozbuAH6GbP4p/hdOCoqS9zJMfqwswne+/GPs5V0+rrsfOkP68Y8PSLphwtFXV0EzJ+GTXTTGg=="],
+
+    "@commitlint/lint": ["@commitlint/lint@20.5.0", "", { "dependencies": { "@commitlint/is-ignored": "^20.5.0", "@commitlint/parse": "^20.5.0", "@commitlint/rules": "^20.5.0", "@commitlint/types": "^20.5.0" } }, "sha512-jiM3hNUdu04jFBf1VgPdjtIPvbuVfDTBAc6L98AWcoLjF5sYqkulBHBzlVWll4rMF1T5zeQFB6r//a+s+BBKlA=="],
+
+    "@commitlint/load": ["@commitlint/load@20.5.0", "", { "dependencies": { "@commitlint/config-validator": "^20.5.0", "@commitlint/execute-rule": "^20.0.0", "@commitlint/resolve-extends": "^20.5.0", "@commitlint/types": "^20.5.0", "cosmiconfig": "^9.0.1", "cosmiconfig-typescript-loader": "^6.1.0", "is-plain-obj": "^4.1.0", "lodash.mergewith": "^4.6.2", "picocolors": "^1.1.1" } }, "sha512-sLhhYTL/KxeOTZjjabKDhwidGZan84XKK1+XFkwDYL/4883kIajcz/dZFAhBJmZPtL8+nBx6bnkzA95YxPeDPw=="],
+
+    "@commitlint/message": ["@commitlint/message@20.4.3", "", {}, "sha512-6akwCYrzcrFcTYz9GyUaWlhisY4lmQ3KvrnabmhoeAV8nRH4dXJAh4+EUQ3uArtxxKQkvxJS78hNX2EU3USgxQ=="],
+
+    "@commitlint/parse": ["@commitlint/parse@20.5.0", "", { "dependencies": { "@commitlint/types": "^20.5.0", "conventional-changelog-angular": "^8.2.0", "conventional-commits-parser": "^6.3.0" } }, "sha512-SeKWHBMk7YOTnnEWUhx+d1a9vHsjjuo6Uo1xRfPNfeY4bdYFasCH1dDpAv13Lyn+dDPOels+jP6D2GRZqzc5fA=="],
+
+    "@commitlint/read": ["@commitlint/read@20.5.0", "", { "dependencies": { "@commitlint/top-level": "^20.4.3", "@commitlint/types": "^20.5.0", "git-raw-commits": "^5.0.0", "minimist": "^1.2.8", "tinyexec": "^1.0.0" } }, "sha512-JDEIJ2+GnWpK8QqwfmW7O42h0aycJEWNqcdkJnyzLD11nf9dW2dWLTVEa8Wtlo4IZFGLPATjR5neA5QlOvIH1w=="],
+
+    "@commitlint/resolve-extends": ["@commitlint/resolve-extends@20.5.0", "", { "dependencies": { "@commitlint/config-validator": "^20.5.0", "@commitlint/types": "^20.5.0", "global-directory": "^4.0.1", "import-meta-resolve": "^4.0.0", "lodash.mergewith": "^4.6.2", "resolve-from": "^5.0.0" } }, "sha512-3SHPWUW2v0tyspCTcfSsYml0gses92l6TlogwzvM2cbxDgmhSRc+fldDjvGkCXJrjSM87BBaWYTPWwwyASZRrg=="],
+
+    "@commitlint/rules": ["@commitlint/rules@20.5.0", "", { "dependencies": { "@commitlint/ensure": "^20.5.0", "@commitlint/message": "^20.4.3", "@commitlint/to-lines": "^20.0.0", "@commitlint/types": "^20.5.0" } }, "sha512-5NdQXQEdnDPT5pK8O39ZA7HohzPRHEsDGU23cyVCNPQy4WegAbAwrQk3nIu7p2sl3dutPk8RZd91yKTrMTnRkQ=="],
+
+    "@commitlint/to-lines": ["@commitlint/to-lines@20.0.0", "", {}, "sha512-2l9gmwiCRqZNWgV+pX1X7z4yP0b3ex/86UmUFgoRt672Ez6cAM2lOQeHFRUTuE6sPpi8XBCGnd8Kh3bMoyHwJw=="],
+
+    "@commitlint/top-level": ["@commitlint/top-level@20.4.3", "", { "dependencies": { "escalade": "^3.2.0" } }, "sha512-qD9xfP6dFg5jQ3NMrOhG0/w5y3bBUsVGyJvXxdWEwBm8hyx4WOk3kKXw28T5czBYvyeCVJgJJ6aoJZUWDpaacQ=="],
+
+    "@commitlint/types": ["@commitlint/types@20.5.0", "", { "dependencies": { "conventional-commits-parser": "^6.3.0", "picocolors": "^1.1.1" } }, "sha512-ZJoS8oSq2CAZEpc/YI9SulLrdiIyXeHb/OGqGrkUP6Q7YV+0ouNAa7GjqRdXeQPncHQIDz/jbCTlHScvYvO/gA=="],
+
+    "@conventional-changelog/git-client": ["@conventional-changelog/git-client@2.6.0", "", { "dependencies": { "@simple-libs/child-process-utils": "^1.0.0", "@simple-libs/stream-utils": "^1.2.0", "semver": "^7.5.2" }, "peerDependencies": { "conventional-commits-filter": "^5.0.0", "conventional-commits-parser": "^6.3.0" }, "optionalPeers": ["conventional-commits-filter", "conventional-commits-parser"] }, "sha512-T+uPDciKf0/ioNNDpMGc8FDsehJClZP0yR3Q5MN6wE/Y/1QZ7F+80OgznnTCOlMEG4AV0LvH2UJi3C/nBnaBUg=="],
 
     "@electric-sql/pglite": ["@electric-sql/pglite@0.2.17", "", {}, "sha512-qEpKRT2oUaWDH6tjRxLHjdzMqRUGYDnGZlKrnL4dJ77JVMcP2Hpo3NYnOSPKdZdeec57B6QPprCUFg0picx5Pw=="],
 
@@ -185,6 +228,10 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.1", "", { "os": "win32", "cpu": "x64" }, "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ=="],
 
+    "@simple-libs/child-process-utils": ["@simple-libs/child-process-utils@1.0.2", "", { "dependencies": { "@simple-libs/stream-utils": "^1.2.0" } }, "sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw=="],
+
+    "@simple-libs/stream-utils": ["@simple-libs/stream-utils@1.2.0", "", {}, "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA=="],
+
     "@turbo/darwin-64": ["@turbo/darwin-64@2.9.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-d1zTcIf6VWT7cdfjhi0X36C2PRsUi2HdEwYzVgkLHmuuYtL+1Y1Zu3JdlouoB/NjG2vX3q4NnKLMNhDOEweoIg=="],
 
     "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.9.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-AwJ4mA++Kpem33Lcov093hS1LrgqbKxqq5FCReoqsA8ayEG6eAJAo8ItDd9qQTdBiXxZH8GHCspLAMIe1t3Xyw=="],
@@ -219,9 +266,15 @@
 
     "@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
 
-    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+    "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
-    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "array-ify": ["array-ify@1.0.0", "", {}, "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
@@ -231,11 +284,15 @@
 
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
 
+    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
+
     "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
+
+    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
@@ -243,27 +300,51 @@
 
     "commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 
+    "compare-func": ["compare-func@2.0.0", "", { "dependencies": { "array-ify": "^1.0.0", "dot-prop": "^5.1.0" } }, "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA=="],
+
+    "conventional-changelog-angular": ["conventional-changelog-angular@8.3.1", "", { "dependencies": { "compare-func": "^2.0.0" } }, "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg=="],
+
+    "conventional-changelog-conventionalcommits": ["conventional-changelog-conventionalcommits@9.3.1", "", { "dependencies": { "compare-func": "^2.0.0" } }, "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw=="],
+
+    "conventional-commits-parser": ["conventional-commits-parser@6.4.0", "", { "dependencies": { "@simple-libs/stream-utils": "^1.2.0", "meow": "^13.0.0" }, "bin": { "conventional-commits-parser": "dist/cli/index.js" } }, "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw=="],
+
+    "cosmiconfig": ["cosmiconfig@9.0.1", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ=="],
+
+    "cosmiconfig-typescript-loader": ["cosmiconfig-typescript-loader@6.2.0", "", { "dependencies": { "jiti": "^2.6.1" }, "peerDependencies": { "@types/node": "*", "cosmiconfig": ">=9", "typescript": ">=5" } }, "sha512-GEN39v7TgdxgIoNcdkRE3uiAzQt3UXLyHbRHD6YoL048XAeOomyxaP+Hh/+2C6C2wYjxJ2onhJcsQp+L4YEkVQ=="],
+
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
 
+    "dot-prop": ["dot-prop@5.3.0", "", { "dependencies": { "is-obj": "^2.0.0" } }, "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q=="],
+
     "dotenv": ["dotenv@17.3.1", "", {}, "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA=="],
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
-    "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
     "env-var": ["env-var@7.5.0", "", {}, "sha512-mKZOzLRN0ETzau2W2QXefbFjo5EF4yWq28OyKb9ICdeNhHJlOE/pHHnz4hdYJ9cNZXcJHo5xN4OT4pzuSHSNvA=="],
+
+    "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
 
     "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 
     "esbuild": ["esbuild@0.27.4", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.4", "@esbuild/android-arm": "0.27.4", "@esbuild/android-arm64": "0.27.4", "@esbuild/android-x64": "0.27.4", "@esbuild/darwin-arm64": "0.27.4", "@esbuild/darwin-x64": "0.27.4", "@esbuild/freebsd-arm64": "0.27.4", "@esbuild/freebsd-x64": "0.27.4", "@esbuild/linux-arm": "0.27.4", "@esbuild/linux-arm64": "0.27.4", "@esbuild/linux-ia32": "0.27.4", "@esbuild/linux-loong64": "0.27.4", "@esbuild/linux-mips64el": "0.27.4", "@esbuild/linux-ppc64": "0.27.4", "@esbuild/linux-riscv64": "0.27.4", "@esbuild/linux-s390x": "0.27.4", "@esbuild/linux-x64": "0.27.4", "@esbuild/netbsd-arm64": "0.27.4", "@esbuild/netbsd-x64": "0.27.4", "@esbuild/openbsd-arm64": "0.27.4", "@esbuild/openbsd-x64": "0.27.4", "@esbuild/openharmony-arm64": "0.27.4", "@esbuild/sunos-x64": "0.27.4", "@esbuild/win32-arm64": "0.27.4", "@esbuild/win32-ia32": "0.27.4", "@esbuild/win32-x64": "0.27.4" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ=="],
 
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
@@ -271,17 +352,59 @@
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "git-raw-commits": ["git-raw-commits@5.0.1", "", { "dependencies": { "@conventional-changelog/git-client": "^2.6.0", "meow": "^13.0.0" }, "bin": { "git-raw-commits": "src/cli.js" } }, "sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ=="],
+
     "glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
+
+    "global-directory": ["global-directory@4.0.1", "", { "dependencies": { "ini": "4.1.1" } }, "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q=="],
 
     "hono": ["hono@4.12.9", "", {}, "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA=="],
 
+    "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
+
+    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
+    "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
+
+    "ini": ["ini@4.1.1", "", {}, "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g=="],
+
+    "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
+
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-obj": ["is-obj@2.0.0", "", {}, "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="],
+
+    "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
 
+    "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
+
     "js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
+
+    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
+
+    "lodash.camelcase": ["lodash.camelcase@4.3.0", "", {}, "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="],
+
+    "lodash.kebabcase": ["lodash.kebabcase@4.1.1", "", {}, "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g=="],
+
+    "lodash.mergewith": ["lodash.mergewith@4.6.2", "", {}, "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="],
+
+    "lodash.snakecase": ["lodash.snakecase@4.1.1", "", {}, "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="],
+
+    "lodash.startcase": ["lodash.startcase@4.4.0", "", {}, "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg=="],
+
+    "lodash.upperfirst": ["lodash.upperfirst@4.3.1", "", {}, "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg=="],
 
     "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
 
@@ -289,7 +412,11 @@
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
+    "meow": ["meow@13.2.0", "", {}, "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA=="],
+
     "minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
@@ -298,6 +425,10 @@
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
+
+    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
+    "parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
@@ -313,7 +444,15 @@
 
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
 
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
+
     "rollup": ["rollup@4.60.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.1", "@rollup/rollup-android-arm64": "4.60.1", "@rollup/rollup-darwin-arm64": "4.60.1", "@rollup/rollup-darwin-x64": "4.60.1", "@rollup/rollup-freebsd-arm64": "4.60.1", "@rollup/rollup-freebsd-x64": "4.60.1", "@rollup/rollup-linux-arm-gnueabihf": "4.60.1", "@rollup/rollup-linux-arm-musleabihf": "4.60.1", "@rollup/rollup-linux-arm64-gnu": "4.60.1", "@rollup/rollup-linux-arm64-musl": "4.60.1", "@rollup/rollup-linux-loong64-gnu": "4.60.1", "@rollup/rollup-linux-loong64-musl": "4.60.1", "@rollup/rollup-linux-ppc64-gnu": "4.60.1", "@rollup/rollup-linux-ppc64-musl": "4.60.1", "@rollup/rollup-linux-riscv64-gnu": "4.60.1", "@rollup/rollup-linux-riscv64-musl": "4.60.1", "@rollup/rollup-linux-s390x-gnu": "4.60.1", "@rollup/rollup-linux-x64-gnu": "4.60.1", "@rollup/rollup-linux-x64-musl": "4.60.1", "@rollup/rollup-openbsd-x64": "4.60.1", "@rollup/rollup-openharmony-arm64": "4.60.1", "@rollup/rollup-win32-arm64-msvc": "4.60.1", "@rollup/rollup-win32-ia32-msvc": "4.60.1", "@rollup/rollup-win32-x64-gnu": "4.60.1", "@rollup/rollup-win32-x64-msvc": "4.60.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w=="],
+
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
@@ -329,11 +468,11 @@
 
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
-    "string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
-    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -341,7 +480,7 @@
 
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
-    "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+    "tinyexec": ["tinyexec@1.0.4", "", {}, "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw=="],
 
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
@@ -367,26 +506,32 @@
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
-    "wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
-    "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
-    "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+    "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
-    "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
-    "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+    "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+    "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
-    "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+    "@isaacs/cliui/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
-    "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
-    "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
-    "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "vitest/tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+
+    "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
   }
 }

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,0 +1,1 @@
+export default { extends: ['@commitlint/config-conventional'] };

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
 	],
 	"devDependencies": {
 		"@biomejs/biome": "^2.4.10",
+		"@commitlint/cli": "^20.5.0",
+		"@commitlint/config-conventional": "^20.5.0",
+		"husky": "^9.1.7",
 		"turbo": "^2",
 		"typescript": "^5"
 	},
@@ -16,6 +19,7 @@
 		"check:fix": "bunx biome check --write .",
 		"dev": "bun run scripts/dev.ts",
 		"test": "bun run scripts/test.ts",
-		"typecheck": "turbo typecheck"
+		"typecheck": "turbo typecheck",
+		"prepare": "husky"
 	}
 }

--- a/packages/connect/src/app.ts
+++ b/packages/connect/src/app.ts
@@ -1,11 +1,11 @@
 import { Hono } from 'hono';
 import type { ConnectConfig } from './config.js';
 import { NonceStore } from './crypto/state.js';
+import type { FetchFn } from './providers/github.js';
 import { healthRoutes } from './routes/health.js';
+import { oauthRoutes } from './routes/oauth.js';
 import { platformRoutes } from './routes/platforms.js';
 import { signingKeyRoutes } from './routes/signing-key.js';
-import { oauthRoutes } from './routes/oauth.js';
-import type { FetchFn } from './providers/github.js';
 
 export function createApp(config: ConnectConfig, fetchFn?: FetchFn): Hono {
 	const app = new Hono();

--- a/packages/connect/src/config.ts
+++ b/packages/connect/src/config.ts
@@ -1,44 +1,42 @@
-import { randomBytes } from "crypto";
-import { config as dotenvConfig } from "dotenv";
-import { get } from "env-var";
+import { randomBytes } from 'node:crypto';
+import { config as dotenvConfig } from 'dotenv';
+import { get } from 'env-var';
 
 export interface ConnectConfig {
-  port: number;
-  mode: "self_hosted";
-  stateSigningKey: string;
-  github?: {
-    clientId: string;
-    clientSecret: string;
-  };
+	port: number;
+	mode: 'self_hosted';
+	stateSigningKey: string;
+	github?: {
+		clientId: string;
+		clientSecret: string;
+	};
 }
 
 export interface LoadConfigOptions {
-  envPath?: string;
+	envPath?: string;
 }
 
 export function loadConfig(options?: LoadConfigOptions): ConnectConfig {
-  dotenvConfig({ path: options?.envPath });
+	dotenvConfig({ path: options?.envPath });
 
-  const port = get("HEZO_CONNECT_PORT").default("4100").asPortNumber();
+	const port = get('HEZO_CONNECT_PORT').default('4100').asPortNumber();
 
-  let stateSigningKey = get("STATE_SIGNING_KEY").default("").asString();
-  if (!stateSigningKey) {
-    stateSigningKey = randomBytes(32).toString("hex");
-    console.log(
-      "Auto-generated state signing key (set STATE_SIGNING_KEY env var to persist)"
-    );
-  }
+	let stateSigningKey = get('STATE_SIGNING_KEY').default('').asString();
+	if (!stateSigningKey) {
+		stateSigningKey = randomBytes(32).toString('hex');
+		console.log('Auto-generated state signing key (set STATE_SIGNING_KEY env var to persist)');
+	}
 
-  const githubClientId = get("GITHUB_CLIENT_ID").asString();
-  const githubClientSecret = get("GITHUB_CLIENT_SECRET").asString();
+	const githubClientId = get('GITHUB_CLIENT_ID').asString();
+	const githubClientSecret = get('GITHUB_CLIENT_SECRET').asString();
 
-  return {
-    port,
-    mode: "self_hosted",
-    stateSigningKey,
-    github:
-      githubClientId && githubClientSecret
-        ? { clientId: githubClientId, clientSecret: githubClientSecret }
-        : undefined,
-  };
+	return {
+		port,
+		mode: 'self_hosted',
+		stateSigningKey,
+		github:
+			githubClientId && githubClientSecret
+				? { clientId: githubClientId, clientSecret: githubClientSecret }
+				: undefined,
+	};
 }

--- a/packages/connect/src/crypto/state.ts
+++ b/packages/connect/src/crypto/state.ts
@@ -1,75 +1,65 @@
-import { createHmac, randomUUID, timingSafeEqual } from "crypto";
+import { createHmac, randomUUID, timingSafeEqual } from 'node:crypto';
 
 export interface StatePayload {
-  callback_url: string;
-  platform: string;
-  nonce: string;
-  timestamp: string;
-  original_state?: string;
+	callback_url: string;
+	platform: string;
+	nonce: string;
+	timestamp: string;
+	original_state?: string;
 }
 
 export function signState(payload: StatePayload, signingKey: string): string {
-  const json = JSON.stringify(payload);
-  const signature = createHmac("sha256", signingKey)
-    .update(json)
-    .digest("hex");
-  const encoded = Buffer.from(json).toString("base64url");
-  return `${encoded}.${signature}`;
+	const json = JSON.stringify(payload);
+	const signature = createHmac('sha256', signingKey).update(json).digest('hex');
+	const encoded = Buffer.from(json).toString('base64url');
+	return `${encoded}.${signature}`;
 }
 
-export function verifyState(
-  signedState: string,
-  signingKey: string
-): StatePayload | null {
-  const dotIndex = signedState.lastIndexOf(".");
-  if (dotIndex === -1) return null;
+export function verifyState(signedState: string, signingKey: string): StatePayload | null {
+	const dotIndex = signedState.lastIndexOf('.');
+	if (dotIndex === -1) return null;
 
-  const encoded = signedState.substring(0, dotIndex);
-  const signature = signedState.substring(dotIndex + 1);
+	const encoded = signedState.substring(0, dotIndex);
+	const signature = signedState.substring(dotIndex + 1);
 
-  const json = Buffer.from(encoded, "base64url").toString("utf8");
-  const expectedSignature = createHmac("sha256", signingKey)
-    .update(json)
-    .digest("hex");
+	const json = Buffer.from(encoded, 'base64url').toString('utf8');
+	const expectedSignature = createHmac('sha256', signingKey).update(json).digest('hex');
 
-  if (signature.length !== expectedSignature.length) return null;
-  if (
-    !timingSafeEqual(Buffer.from(signature), Buffer.from(expectedSignature))
-  )
-    return null;
+	if (signature.length !== expectedSignature.length) return null;
+	if (!timingSafeEqual(Buffer.from(signature), Buffer.from(expectedSignature))) return null;
 
-  try {
-    return JSON.parse(json) as StatePayload;
-  } catch {
-    return null;
-  }
+	try {
+		return JSON.parse(json) as StatePayload;
+	} catch {
+		return null;
+	}
 }
 
 export function createNonce(): string {
-  return randomUUID();
+	return randomUUID();
 }
 
 const NONCE_TTL_MS = 5 * 60 * 1000;
 
 export class NonceStore {
-  private nonces = new Map<string, number>();
+	private nonces = new Map<string, number>();
 
-  add(nonce: string): void {
-    this.cleanup();
-    this.nonces.set(nonce, Date.now() + NONCE_TTL_MS);
-  }
+	add(nonce: string): void {
+		this.cleanup();
+		this.nonces.set(nonce, Date.now() + NONCE_TTL_MS);
+	}
 
-  consume(nonce: string): boolean {
-    this.cleanup();
-    if (!this.nonces.has(nonce)) return false;
-    this.nonces.delete(nonce);
-    return true;
-  }
+	consume(nonce: string): boolean {
+		this.cleanup();
+		if (!this.nonces.has(nonce)) return false;
+		this.nonces.delete(nonce);
+		return true;
+	}
 
-  private cleanup(): void {
-    const now = Date.now();
-    for (const [nonce, expiry] of this.nonces) {
-      if (expiry < now) this.nonces.delete(nonce);
-    }
-  }
+	private cleanup(): void {
+		const now = Date.now();
+		for (const [nonce, expiry] of this.nonces) {
+			if (expiry < now) this.nonces.delete(nonce);
+		}
+	}
 }

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -1,5 +1,5 @@
-import { loadConfig } from './config.js';
 import { createApp } from './app.js';
+import { loadConfig } from './config.js';
 
 const config = loadConfig();
 const app = createApp(config);

--- a/packages/connect/src/providers/github.ts
+++ b/packages/connect/src/providers/github.ts
@@ -1,58 +1,55 @@
 export interface GitHubTokenResponse {
-  access_token: string;
-  token_type: string;
-  scope: string;
+	access_token: string;
+	token_type: string;
+	scope: string;
 }
 
 export interface GitHubUserInfo {
-  login: string;
-  avatar_url: string;
-  email: string | null;
+	login: string;
+	avatar_url: string;
+	email: string | null;
 }
 
 export type FetchFn = typeof globalThis.fetch;
 
 export async function exchangeCode(
-  code: string,
-  clientId: string,
-  clientSecret: string,
-  redirectUri: string,
-  fetchFn: FetchFn = globalThis.fetch
+	code: string,
+	clientId: string,
+	clientSecret: string,
+	redirectUri: string,
+	fetchFn: FetchFn = globalThis.fetch,
 ): Promise<GitHubTokenResponse> {
-  const res = await fetchFn("https://github.com/login/oauth/access_token", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-    },
-    body: JSON.stringify({
-      client_id: clientId,
-      client_secret: clientSecret,
-      code,
-      redirect_uri: redirectUri,
-    }),
-  });
+	const res = await fetchFn('https://github.com/login/oauth/access_token', {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			Accept: 'application/json',
+		},
+		body: JSON.stringify({
+			client_id: clientId,
+			client_secret: clientSecret,
+			code,
+			redirect_uri: redirectUri,
+		}),
+	});
 
-  if (!res.ok) throw new Error(`GitHub token exchange failed: ${res.status}`);
-  const data = (await res.json()) as Record<string, unknown>;
-  if (data.error)
-    throw new Error(
-      `GitHub OAuth error: ${data.error_description || data.error}`
-    );
-  return data as unknown as GitHubTokenResponse;
+	if (!res.ok) throw new Error(`GitHub token exchange failed: ${res.status}`);
+	const data = (await res.json()) as Record<string, unknown>;
+	if (data.error) throw new Error(`GitHub OAuth error: ${data.error_description || data.error}`);
+	return data as unknown as GitHubTokenResponse;
 }
 
 export async function fetchUserInfo(
-  accessToken: string,
-  fetchFn: FetchFn = globalThis.fetch
+	accessToken: string,
+	fetchFn: FetchFn = globalThis.fetch,
 ): Promise<GitHubUserInfo> {
-  const res = await fetchFn("https://api.github.com/user", {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      Accept: "application/vnd.github+json",
-    },
-  });
+	const res = await fetchFn('https://api.github.com/user', {
+		headers: {
+			Authorization: `Bearer ${accessToken}`,
+			Accept: 'application/vnd.github+json',
+		},
+	});
 
-  if (!res.ok) throw new Error(`GitHub user info fetch failed: ${res.status}`);
-  return (await res.json()) as GitHubUserInfo;
+	if (!res.ok) throw new Error(`GitHub user info fetch failed: ${res.status}`);
+	return (await res.json()) as GitHubUserInfo;
 }

--- a/packages/connect/src/routes/health.ts
+++ b/packages/connect/src/routes/health.ts
@@ -1,5 +1,5 @@
-import { Hono } from "hono";
+import { Hono } from 'hono';
 
 export const healthRoutes = new Hono();
 
-healthRoutes.get("/health", (c) => c.json({ ok: true }));
+healthRoutes.get('/health', (c) => c.json({ ok: true }));

--- a/packages/connect/src/routes/oauth.ts
+++ b/packages/connect/src/routes/oauth.ts
@@ -1,179 +1,173 @@
-import { Hono } from "hono";
-import type { ConnectConfig } from "../config.js";
+import { Hono } from 'hono';
+import type { ConnectConfig } from '../config.js';
 import {
-  signState,
-  verifyState,
-  createNonce,
-  NonceStore,
-  type StatePayload,
-} from "../crypto/state.js";
-import {
-  exchangeCode,
-  fetchUserInfo,
-  type FetchFn,
-} from "../providers/github.js";
+	createNonce,
+	type NonceStore,
+	type StatePayload,
+	signState,
+	verifyState,
+} from '../crypto/state.js';
+import { exchangeCode, type FetchFn, fetchUserInfo } from '../providers/github.js';
 
-const SUPPORTED_PLATFORMS = new Set(["github"]);
-const GITHUB_SCOPES = "repo,workflow,read:org";
+const SUPPORTED_PLATFORMS = new Set(['github']);
+const GITHUB_SCOPES = 'repo,workflow,read:org';
 
 function errorRedirect(
-  callbackUrl: string,
-  platform: string,
-  errorCode: string,
-  message?: string
+	callbackUrl: string,
+	platform: string,
+	errorCode: string,
+	message?: string,
 ): string {
-  const url = new URL(callbackUrl);
-  url.searchParams.set("error", errorCode);
-  url.searchParams.set("platform", platform);
-  if (message) url.searchParams.set("message", message);
-  return url.toString();
+	const url = new URL(callbackUrl);
+	url.searchParams.set('error', errorCode);
+	url.searchParams.set('platform', platform);
+	if (message) url.searchParams.set('message', message);
+	return url.toString();
 }
 
 export function oauthRoutes(
-  config: ConnectConfig,
-  nonceStore: NonceStore,
-  fetchFn: FetchFn = globalThis.fetch
+	config: ConnectConfig,
+	nonceStore: NonceStore,
+	fetchFn: FetchFn = globalThis.fetch,
 ): Hono {
-  const routes = new Hono();
+	const routes = new Hono();
 
-  routes.get("/auth/:platform/start", (c) => {
-    const platform = c.req.param("platform");
+	routes.get('/auth/:platform/start', (c) => {
+		const platform = c.req.param('platform');
 
-    if (!SUPPORTED_PLATFORMS.has(platform)) {
-      return c.json(
-        { error: "unsupported_platform", message: `Platform "${platform}" is not supported` },
-        400
-      );
-    }
+		if (!SUPPORTED_PLATFORMS.has(platform)) {
+			return c.json(
+				{ error: 'unsupported_platform', message: `Platform "${platform}" is not supported` },
+				400,
+			);
+		}
 
-    const callbackUrl = c.req.query("callback");
-    if (!callbackUrl) {
-      return c.json(
-        { error: "missing_callback", message: "callback query parameter is required" },
-        400
-      );
-    }
+		const callbackUrl = c.req.query('callback');
+		if (!callbackUrl) {
+			return c.json(
+				{ error: 'missing_callback', message: 'callback query parameter is required' },
+				400,
+			);
+		}
 
-    if (!config.github) {
-      return c.redirect(
-        errorRedirect(callbackUrl, platform, "missing_config", "GitHub OAuth is not configured")
-      );
-    }
+		if (!config.github) {
+			return c.redirect(
+				errorRedirect(callbackUrl, platform, 'missing_config', 'GitHub OAuth is not configured'),
+			);
+		}
 
-    const nonce = createNonce();
-    nonceStore.add(nonce);
+		const nonce = createNonce();
+		nonceStore.add(nonce);
 
-    const payload: StatePayload = {
-      callback_url: callbackUrl,
-      platform,
-      nonce,
-      timestamp: new Date().toISOString(),
-    };
+		const payload: StatePayload = {
+			callback_url: callbackUrl,
+			platform,
+			nonce,
+			timestamp: new Date().toISOString(),
+		};
 
-    const originalState = c.req.query("state");
-    if (originalState) payload.original_state = originalState;
+		const originalState = c.req.query('state');
+		if (originalState) payload.original_state = originalState;
 
-    const signedState = signState(payload, config.stateSigningKey);
+		const signedState = signState(payload, config.stateSigningKey);
 
-    const connectCallbackUrl = new URL(c.req.url);
-    connectCallbackUrl.pathname = `/auth/${platform}/callback`;
-    connectCallbackUrl.search = "";
+		const connectCallbackUrl = new URL(c.req.url);
+		connectCallbackUrl.pathname = `/auth/${platform}/callback`;
+		connectCallbackUrl.search = '';
 
-    const githubUrl = new URL("https://github.com/login/oauth/authorize");
-    githubUrl.searchParams.set("client_id", config.github.clientId);
-    githubUrl.searchParams.set("redirect_uri", connectCallbackUrl.toString());
-    githubUrl.searchParams.set("scope", GITHUB_SCOPES);
-    githubUrl.searchParams.set("state", signedState);
+		const githubUrl = new URL('https://github.com/login/oauth/authorize');
+		githubUrl.searchParams.set('client_id', config.github.clientId);
+		githubUrl.searchParams.set('redirect_uri', connectCallbackUrl.toString());
+		githubUrl.searchParams.set('scope', GITHUB_SCOPES);
+		githubUrl.searchParams.set('state', signedState);
 
-    return c.redirect(githubUrl.toString());
-  });
+		return c.redirect(githubUrl.toString());
+	});
 
-  routes.get("/auth/:platform/callback", async (c) => {
-    const platform = c.req.param("platform");
-    const code = c.req.query("code");
-    const stateParam = c.req.query("state");
+	routes.get('/auth/:platform/callback', async (c) => {
+		const platform = c.req.param('platform');
+		const code = c.req.query('code');
+		const stateParam = c.req.query('state');
 
-    if (!SUPPORTED_PLATFORMS.has(platform)) {
-      return c.json(
-        { error: "unsupported_platform", message: `Platform "${platform}" is not supported` },
-        400
-      );
-    }
+		if (!SUPPORTED_PLATFORMS.has(platform)) {
+			return c.json(
+				{ error: 'unsupported_platform', message: `Platform "${platform}" is not supported` },
+				400,
+			);
+		}
 
-    if (!stateParam) {
-      return c.json({ error: "invalid_state", message: "Missing state parameter" }, 400);
-    }
+		if (!stateParam) {
+			return c.json({ error: 'invalid_state', message: 'Missing state parameter' }, 400);
+		}
 
-    const payload = verifyState(stateParam, config.stateSigningKey);
-    if (!payload) {
-      return c.json({ error: "invalid_state", message: "Invalid state signature" }, 400);
-    }
+		const payload = verifyState(stateParam, config.stateSigningKey);
+		if (!payload) {
+			return c.json({ error: 'invalid_state', message: 'Invalid state signature' }, 400);
+		}
 
-    const callbackUrl = payload.callback_url;
+		const callbackUrl = payload.callback_url;
 
-    if (!nonceStore.consume(payload.nonce)) {
-      return c.redirect(
-        errorRedirect(callbackUrl, platform, "expired_nonce", "Nonce expired or already used")
-      );
-    }
+		if (!nonceStore.consume(payload.nonce)) {
+			return c.redirect(
+				errorRedirect(callbackUrl, platform, 'expired_nonce', 'Nonce expired or already used'),
+			);
+		}
 
-    if (c.req.query("error") === "access_denied") {
-      return c.redirect(
-        errorRedirect(callbackUrl, platform, "access_denied", "User denied authorization")
-      );
-    }
+		if (c.req.query('error') === 'access_denied') {
+			return c.redirect(
+				errorRedirect(callbackUrl, platform, 'access_denied', 'User denied authorization'),
+			);
+		}
 
-    if (!code) {
-      return c.redirect(
-        errorRedirect(callbackUrl, platform, "invalid_state", "Missing authorization code")
-      );
-    }
+		if (!code) {
+			return c.redirect(
+				errorRedirect(callbackUrl, platform, 'invalid_state', 'Missing authorization code'),
+			);
+		}
 
-    if (!config.github) {
-      return c.redirect(
-        errorRedirect(callbackUrl, platform, "missing_config", "GitHub OAuth is not configured")
-      );
-    }
+		if (!config.github) {
+			return c.redirect(
+				errorRedirect(callbackUrl, platform, 'missing_config', 'GitHub OAuth is not configured'),
+			);
+		}
 
-    const connectCallbackUrl = new URL(c.req.url);
-    connectCallbackUrl.search = "";
+		const connectCallbackUrl = new URL(c.req.url);
+		connectCallbackUrl.search = '';
 
-    try {
-      const tokenResponse = await exchangeCode(
-        code,
-        config.github.clientId,
-        config.github.clientSecret,
-        connectCallbackUrl.toString(),
-        fetchFn
-      );
+		try {
+			const tokenResponse = await exchangeCode(
+				code,
+				config.github.clientId,
+				config.github.clientSecret,
+				connectCallbackUrl.toString(),
+				fetchFn,
+			);
 
-      const userInfo = await fetchUserInfo(tokenResponse.access_token, fetchFn);
+			const userInfo = await fetchUserInfo(tokenResponse.access_token, fetchFn);
 
-      const metadata = Buffer.from(
-        JSON.stringify({
-          username: userInfo.login,
-          avatar_url: userInfo.avatar_url,
-          email: userInfo.email,
-        })
-      ).toString("base64url");
+			const metadata = Buffer.from(
+				JSON.stringify({
+					username: userInfo.login,
+					avatar_url: userInfo.avatar_url,
+					email: userInfo.email,
+				}),
+			).toString('base64url');
 
-      const redirectUrl = new URL(callbackUrl);
-      redirectUrl.searchParams.set("platform", platform);
-      redirectUrl.searchParams.set("access_token", tokenResponse.access_token);
-      redirectUrl.searchParams.set("scopes", tokenResponse.scope);
-      redirectUrl.searchParams.set("metadata", metadata);
-      if (payload.original_state) {
-        redirectUrl.searchParams.set("state", payload.original_state);
-      }
+			const redirectUrl = new URL(callbackUrl);
+			redirectUrl.searchParams.set('platform', platform);
+			redirectUrl.searchParams.set('access_token', tokenResponse.access_token);
+			redirectUrl.searchParams.set('scopes', tokenResponse.scope);
+			redirectUrl.searchParams.set('metadata', metadata);
+			if (payload.original_state) {
+				redirectUrl.searchParams.set('state', payload.original_state);
+			}
 
-      return c.redirect(redirectUrl.toString());
-    } catch (err) {
-      const message = err instanceof Error ? err.message : "Token exchange failed";
-      return c.redirect(
-        errorRedirect(callbackUrl, platform, "token_exchange_failed", message)
-      );
-    }
-  });
+			return c.redirect(redirectUrl.toString());
+		} catch (err) {
+			const message = err instanceof Error ? err.message : 'Token exchange failed';
+			return c.redirect(errorRedirect(callbackUrl, platform, 'token_exchange_failed', message));
+		}
+	});
 
-  return routes;
+	return routes;
 }

--- a/packages/connect/src/routes/platforms.ts
+++ b/packages/connect/src/routes/platforms.ts
@@ -1,13 +1,13 @@
-import { Hono } from "hono";
+import { Hono } from 'hono';
 
 const PLATFORMS = [
-  {
-    id: "github",
-    name: "GitHub",
-    scopes: ["repo", "workflow", "read:org"],
-  },
+	{
+		id: 'github',
+		name: 'GitHub',
+		scopes: ['repo', 'workflow', 'read:org'],
+	},
 ] as const;
 
 export const platformRoutes = new Hono();
 
-platformRoutes.get("/platforms", (c) => c.json({ platforms: PLATFORMS }));
+platformRoutes.get('/platforms', (c) => c.json({ platforms: PLATFORMS }));

--- a/packages/connect/src/routes/signing-key.ts
+++ b/packages/connect/src/routes/signing-key.ts
@@ -1,12 +1,10 @@
-import { Hono } from "hono";
-import type { ConnectConfig } from "../config.js";
+import { Hono } from 'hono';
+import type { ConnectConfig } from '../config.js';
 
 export function signingKeyRoutes(config: ConnectConfig): Hono {
-  const routes = new Hono();
+	const routes = new Hono();
 
-  routes.get("/signing-key", (c) =>
-    c.json({ key: config.stateSigningKey })
-  );
+	routes.get('/signing-key', (c) => c.json({ key: config.stateSigningKey }));
 
-  return routes;
+	return routes;
 }

--- a/packages/connect/src/test/__tests__/config.test.ts
+++ b/packages/connect/src/test/__tests__/config.test.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { writeFileSync, mkdirSync, rmSync } from "fs";
-import { join } from "path";
-import { tmpdir } from "os";
-import { randomUUID } from "crypto";
-import { loadConfig } from "../../config.js";
+import { randomUUID } from 'node:crypto';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { loadConfig } from '../../config.js';
 
 let tempDir: string;
-const NONEXISTENT_ENV = () => join(tempDir, ".env.nonexistent");
+const NONEXISTENT_ENV = () => join(tempDir, '.env.nonexistent');
 
 beforeEach(() => {
 	tempDir = join(tmpdir(), `hezo-config-test-${randomUUID()}`);
@@ -23,135 +23,133 @@ afterEach(() => {
 	rmSync(tempDir, { recursive: true, force: true });
 });
 
-describe("loadConfig defaults", () => {
-	it("uses default port 4100 when HEZO_CONNECT_PORT is unset", () => {
+describe('loadConfig defaults', () => {
+	it('uses default port 4100 when HEZO_CONNECT_PORT is unset', () => {
 		const config = loadConfig({ envPath: NONEXISTENT_ENV() });
 		expect(config.port).toBe(4100);
 	});
 
-	it("sets mode to self_hosted", () => {
+	it('sets mode to self_hosted', () => {
 		const config = loadConfig({ envPath: NONEXISTENT_ENV() });
-		expect(config.mode).toBe("self_hosted");
+		expect(config.mode).toBe('self_hosted');
 	});
 
-	it("auto-generates a 64-char hex signing key when STATE_SIGNING_KEY is unset", () => {
-		const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+	it('auto-generates a 64-char hex signing key when STATE_SIGNING_KEY is unset', () => {
+		const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
 		const config = loadConfig({ envPath: NONEXISTENT_ENV() });
 		expect(config.stateSigningKey).toMatch(/^[a-f0-9]{64}$/);
-		expect(spy).toHaveBeenCalledWith(
-			expect.stringContaining("Auto-generated state signing key"),
-		);
+		expect(spy).toHaveBeenCalledWith(expect.stringContaining('Auto-generated state signing key'));
 		spy.mockRestore();
 	});
 
-	it("returns undefined github when neither client ID nor secret is set", () => {
+	it('returns undefined github when neither client ID nor secret is set', () => {
 		const config = loadConfig({ envPath: NONEXISTENT_ENV() });
 		expect(config.github).toBeUndefined();
 	});
 });
 
-describe("loadConfig with env vars", () => {
-	it("reads custom port from HEZO_CONNECT_PORT", () => {
-		vi.stubEnv("HEZO_CONNECT_PORT", "8080");
+describe('loadConfig with env vars', () => {
+	it('reads custom port from HEZO_CONNECT_PORT', () => {
+		vi.stubEnv('HEZO_CONNECT_PORT', '8080');
 		const config = loadConfig({ envPath: NONEXISTENT_ENV() });
 		expect(config.port).toBe(8080);
 	});
 
-	it("reads STATE_SIGNING_KEY when provided", () => {
-		vi.stubEnv("STATE_SIGNING_KEY", "my-secret-key");
+	it('reads STATE_SIGNING_KEY when provided', () => {
+		vi.stubEnv('STATE_SIGNING_KEY', 'my-secret-key');
 		const config = loadConfig({ envPath: NONEXISTENT_ENV() });
-		expect(config.stateSigningKey).toBe("my-secret-key");
+		expect(config.stateSigningKey).toBe('my-secret-key');
 	});
 
-	it("returns github config when both client ID and secret are set", () => {
-		vi.stubEnv("GITHUB_CLIENT_ID", "id-123");
-		vi.stubEnv("GITHUB_CLIENT_SECRET", "secret-456");
+	it('returns github config when both client ID and secret are set', () => {
+		vi.stubEnv('GITHUB_CLIENT_ID', 'id-123');
+		vi.stubEnv('GITHUB_CLIENT_SECRET', 'secret-456');
 		const config = loadConfig({ envPath: NONEXISTENT_ENV() });
 		expect(config.github).toEqual({
-			clientId: "id-123",
-			clientSecret: "secret-456",
+			clientId: 'id-123',
+			clientSecret: 'secret-456',
 		});
 	});
 
-	it("returns undefined github when only client ID is set", () => {
-		vi.stubEnv("GITHUB_CLIENT_ID", "id-123");
+	it('returns undefined github when only client ID is set', () => {
+		vi.stubEnv('GITHUB_CLIENT_ID', 'id-123');
 		const config = loadConfig({ envPath: NONEXISTENT_ENV() });
 		expect(config.github).toBeUndefined();
 	});
 
-	it("returns undefined github when only client secret is set", () => {
-		vi.stubEnv("GITHUB_CLIENT_SECRET", "secret-456");
+	it('returns undefined github when only client secret is set', () => {
+		vi.stubEnv('GITHUB_CLIENT_SECRET', 'secret-456');
 		const config = loadConfig({ envPath: NONEXISTENT_ENV() });
 		expect(config.github).toBeUndefined();
 	});
 });
 
-describe("loadConfig port validation", () => {
-	it("throws on non-numeric port", () => {
-		vi.stubEnv("HEZO_CONNECT_PORT", "not-a-number");
+describe('loadConfig port validation', () => {
+	it('throws on non-numeric port', () => {
+		vi.stubEnv('HEZO_CONNECT_PORT', 'not-a-number');
 		expect(() => loadConfig({ envPath: NONEXISTENT_ENV() })).toThrow();
 	});
 
-	it("accepts port 0 (OS-assigned)", () => {
-		vi.stubEnv("HEZO_CONNECT_PORT", "0");
+	it('accepts port 0 (OS-assigned)', () => {
+		vi.stubEnv('HEZO_CONNECT_PORT', '0');
 		const config = loadConfig({ envPath: NONEXISTENT_ENV() });
 		expect(config.port).toBe(0);
 	});
 
-	it("throws on port above 65535", () => {
-		vi.stubEnv("HEZO_CONNECT_PORT", "70000");
+	it('throws on port above 65535', () => {
+		vi.stubEnv('HEZO_CONNECT_PORT', '70000');
 		expect(() => loadConfig({ envPath: NONEXISTENT_ENV() })).toThrow();
 	});
 
-	it("throws on negative port", () => {
-		vi.stubEnv("HEZO_CONNECT_PORT", "-1");
+	it('throws on negative port', () => {
+		vi.stubEnv('HEZO_CONNECT_PORT', '-1');
 		expect(() => loadConfig({ envPath: NONEXISTENT_ENV() })).toThrow();
 	});
 
-	it("accepts port 1", () => {
-		vi.stubEnv("HEZO_CONNECT_PORT", "1");
+	it('accepts port 1', () => {
+		vi.stubEnv('HEZO_CONNECT_PORT', '1');
 		const config = loadConfig({ envPath: NONEXISTENT_ENV() });
 		expect(config.port).toBe(1);
 	});
 
-	it("accepts port 65535", () => {
-		vi.stubEnv("HEZO_CONNECT_PORT", "65535");
+	it('accepts port 65535', () => {
+		vi.stubEnv('HEZO_CONNECT_PORT', '65535');
 		const config = loadConfig({ envPath: NONEXISTENT_ENV() });
 		expect(config.port).toBe(65535);
 	});
 });
 
-describe("loadConfig .env file loading", () => {
-	it("reads variables from a .env file", () => {
-		const envPath = join(tempDir, ".env");
+describe('loadConfig .env file loading', () => {
+	it('reads variables from a .env file', () => {
+		const envPath = join(tempDir, '.env');
 		writeFileSync(
 			envPath,
 			[
-				"HEZO_CONNECT_PORT=9090",
-				"STATE_SIGNING_KEY=from-dotenv",
-				"GITHUB_CLIENT_ID=env-id",
-				"GITHUB_CLIENT_SECRET=env-secret",
-			].join("\n"),
+				'HEZO_CONNECT_PORT=9090',
+				'STATE_SIGNING_KEY=from-dotenv',
+				'GITHUB_CLIENT_ID=env-id',
+				'GITHUB_CLIENT_SECRET=env-secret',
+			].join('\n'),
 		);
 		const config = loadConfig({ envPath });
 		expect(config.port).toBe(9090);
-		expect(config.stateSigningKey).toBe("from-dotenv");
+		expect(config.stateSigningKey).toBe('from-dotenv');
 		expect(config.github).toEqual({
-			clientId: "env-id",
-			clientSecret: "env-secret",
+			clientId: 'env-id',
+			clientSecret: 'env-secret',
 		});
 	});
 
-	it("process.env values take precedence over .env file", () => {
-		const envPath = join(tempDir, ".env");
-		writeFileSync(envPath, "HEZO_CONNECT_PORT=9090\n");
-		vi.stubEnv("HEZO_CONNECT_PORT", "7070");
+	it('process.env values take precedence over .env file', () => {
+		const envPath = join(tempDir, '.env');
+		writeFileSync(envPath, 'HEZO_CONNECT_PORT=9090\n');
+		vi.stubEnv('HEZO_CONNECT_PORT', '7070');
 		const config = loadConfig({ envPath });
 		expect(config.port).toBe(7070);
 	});
 
-	it("handles missing .env file gracefully", () => {
-		const config = loadConfig({ envPath: join(tempDir, ".env.does-not-exist") });
+	it('handles missing .env file gracefully', () => {
+		const config = loadConfig({ envPath: join(tempDir, '.env.does-not-exist') });
 		expect(config.port).toBe(4100);
 	});
 });

--- a/packages/connect/src/test/__tests__/health.test.ts
+++ b/packages/connect/src/test/__tests__/health.test.ts
@@ -1,43 +1,43 @@
-import { describe, it, expect } from "vitest";
-import { createApp } from "../../app.js";
-import type { ConnectConfig } from "../../config.js";
+import { describe, expect, it } from 'vitest';
+import { createApp } from '../../app.js';
+import type { ConnectConfig } from '../../config.js';
 
 const config: ConnectConfig = {
-  port: 4100,
-  mode: "self_hosted",
-  stateSigningKey: "test-key",
-  github: { clientId: "test-id", clientSecret: "test-secret" },
+	port: 4100,
+	mode: 'self_hosted',
+	stateSigningKey: 'test-key',
+	github: { clientId: 'test-id', clientSecret: 'test-secret' },
 };
 
 const app = createApp(config);
 
-describe("GET /health", () => {
-  it("returns 200 with { ok: true }", async () => {
-    const res = await app.request("/health");
-    expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ ok: true });
-  });
+describe('GET /health', () => {
+	it('returns 200 with { ok: true }', async () => {
+		const res = await app.request('/health');
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ ok: true });
+	});
 });
 
-describe("GET /platforms", () => {
-  it("returns platform list with github", async () => {
-    const res = await app.request("/platforms");
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.platforms).toHaveLength(1);
-    expect(body.platforms[0]).toEqual({
-      id: "github",
-      name: "GitHub",
-      scopes: ["repo", "workflow", "read:org"],
-    });
-  });
+describe('GET /platforms', () => {
+	it('returns platform list with github', async () => {
+		const res = await app.request('/platforms');
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.platforms).toHaveLength(1);
+		expect(body.platforms[0]).toEqual({
+			id: 'github',
+			name: 'GitHub',
+			scopes: ['repo', 'workflow', 'read:org'],
+		});
+	});
 });
 
-describe("GET /signing-key", () => {
-  it("returns the hex signing key", async () => {
-    const res = await app.request("/signing-key");
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.key).toBe("test-key");
-  });
+describe('GET /signing-key', () => {
+	it('returns the hex signing key', async () => {
+		const res = await app.request('/signing-key');
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.key).toBe('test-key');
+	});
 });

--- a/packages/connect/src/test/__tests__/oauth.test.ts
+++ b/packages/connect/src/test/__tests__/oauth.test.ts
@@ -1,224 +1,225 @@
-import { describe, it, expect } from "vitest";
-import { createApp } from "../../app.js";
-import { verifyState } from "../../crypto/state.js";
-import type { ConnectConfig } from "../../config.js";
-import type { FetchFn } from "../../providers/github.js";
+import { describe, expect, it } from 'vitest';
+import { createApp } from '../../app.js';
+import type { ConnectConfig } from '../../config.js';
+import { verifyState } from '../../crypto/state.js';
+import type { FetchFn } from '../../providers/github.js';
 
-const SIGNING_KEY = "test-signing-key-for-oauth-tests";
+const SIGNING_KEY = 'test-signing-key-for-oauth-tests';
 
 function makeConfig(github?: { clientId: string; clientSecret: string }): ConnectConfig {
-  return {
-    port: 4100,
-    mode: "self_hosted",
-    stateSigningKey: SIGNING_KEY,
-    github,
-  };
+	return {
+		port: 4100,
+		mode: 'self_hosted',
+		stateSigningKey: SIGNING_KEY,
+		github,
+	};
 }
 
 function mockFetchFn(
-  tokenResponse: Record<string, unknown>,
-  userInfo: Record<string, unknown>
+	tokenResponse: Record<string, unknown>,
+	userInfo: Record<string, unknown>,
 ): FetchFn {
-  return async (input: string | URL | Request) => {
-    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+	return async (input: string | URL | Request) => {
+		const url =
+			typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
 
-    if (url.includes("github.com/login/oauth/access_token")) {
-      return new Response(JSON.stringify(tokenResponse), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      });
-    }
+		if (url.includes('github.com/login/oauth/access_token')) {
+			return new Response(JSON.stringify(tokenResponse), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			});
+		}
 
-    if (url.includes("api.github.com/user")) {
-      return new Response(JSON.stringify(userInfo), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      });
-    }
+		if (url.includes('api.github.com/user')) {
+			return new Response(JSON.stringify(userInfo), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			});
+		}
 
-    return new Response("Not found", { status: 404 });
-  };
+		return new Response('Not found', { status: 404 });
+	};
 }
 
-describe("GET /auth/:platform/start", () => {
-  it("returns 400 without callback param", async () => {
-    const app = createApp(makeConfig({ clientId: "id", clientSecret: "secret" }));
-    const res = await app.request("/auth/github/start");
-    expect(res.status).toBe(400);
-    const body = await res.json();
-    expect(body.error).toBe("missing_callback");
-  });
+describe('GET /auth/:platform/start', () => {
+	it('returns 400 without callback param', async () => {
+		const app = createApp(makeConfig({ clientId: 'id', clientSecret: 'secret' }));
+		const res = await app.request('/auth/github/start');
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.error).toBe('missing_callback');
+	});
 
-  it("redirects to error when GitHub is not configured", async () => {
-    const app = createApp(makeConfig());
-    const res = await app.request(
-      "/auth/github/start?callback=http://localhost:3100/oauth/callback"
-    );
-    expect(res.status).toBe(302);
-    const location = res.headers.get("Location")!;
-    const url = new URL(location);
-    expect(url.searchParams.get("error")).toBe("missing_config");
-  });
+	it('redirects to error when GitHub is not configured', async () => {
+		const app = createApp(makeConfig());
+		const res = await app.request(
+			'/auth/github/start?callback=http://localhost:3100/oauth/callback',
+		);
+		expect(res.status).toBe(302);
+		const location = res.headers.get('Location')!;
+		const url = new URL(location);
+		expect(url.searchParams.get('error')).toBe('missing_config');
+	});
 
-  it("returns 400 for unsupported platform", async () => {
-    const app = createApp(makeConfig({ clientId: "id", clientSecret: "secret" }));
-    const res = await app.request(
-      "/auth/unsupported/start?callback=http://localhost:3100/oauth/callback"
-    );
-    expect(res.status).toBe(400);
-    const body = await res.json();
-    expect(body.error).toBe("unsupported_platform");
-  });
+	it('returns 400 for unsupported platform', async () => {
+		const app = createApp(makeConfig({ clientId: 'id', clientSecret: 'secret' }));
+		const res = await app.request(
+			'/auth/unsupported/start?callback=http://localhost:3100/oauth/callback',
+		);
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.error).toBe('unsupported_platform');
+	});
 
-  it("redirects to GitHub OAuth with correct params", async () => {
-    const app = createApp(makeConfig({ clientId: "my-client-id", clientSecret: "secret" }));
-    const res = await app.request(
-      "/auth/github/start?callback=http://localhost:3100/oauth/callback"
-    );
-    expect(res.status).toBe(302);
-    const location = res.headers.get("Location")!;
-    const url = new URL(location);
-    expect(url.hostname).toBe("github.com");
-    expect(url.pathname).toBe("/login/oauth/authorize");
-    expect(url.searchParams.get("client_id")).toBe("my-client-id");
-    expect(url.searchParams.get("scope")).toBe("repo,workflow,read:org");
-    expect(url.searchParams.get("state")).toBeTruthy();
-  });
+	it('redirects to GitHub OAuth with correct params', async () => {
+		const app = createApp(makeConfig({ clientId: 'my-client-id', clientSecret: 'secret' }));
+		const res = await app.request(
+			'/auth/github/start?callback=http://localhost:3100/oauth/callback',
+		);
+		expect(res.status).toBe(302);
+		const location = res.headers.get('Location')!;
+		const url = new URL(location);
+		expect(url.hostname).toBe('github.com');
+		expect(url.pathname).toBe('/login/oauth/authorize');
+		expect(url.searchParams.get('client_id')).toBe('my-client-id');
+		expect(url.searchParams.get('scope')).toBe('repo,workflow,read:org');
+		expect(url.searchParams.get('state')).toBeTruthy();
+	});
 });
 
-describe("GET /auth/:platform/callback", () => {
-  it("returns 400 with invalid state", async () => {
-    const app = createApp(makeConfig({ clientId: "id", clientSecret: "secret" }));
-    const res = await app.request(
-      "/auth/github/callback?code=test-code&state=invalid.state"
-    );
-    expect(res.status).toBe(400);
-    const body = await res.json();
-    expect(body.error).toBe("invalid_state");
-  });
+describe('GET /auth/:platform/callback', () => {
+	it('returns 400 with invalid state', async () => {
+		const app = createApp(makeConfig({ clientId: 'id', clientSecret: 'secret' }));
+		const res = await app.request('/auth/github/callback?code=test-code&state=invalid.state');
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.error).toBe('invalid_state');
+	});
 
-  it("returns 400 without state param", async () => {
-    const app = createApp(makeConfig({ clientId: "id", clientSecret: "secret" }));
-    const res = await app.request("/auth/github/callback?code=test-code");
-    expect(res.status).toBe(400);
-    const body = await res.json();
-    expect(body.error).toBe("invalid_state");
-  });
+	it('returns 400 without state param', async () => {
+		const app = createApp(makeConfig({ clientId: 'id', clientSecret: 'secret' }));
+		const res = await app.request('/auth/github/callback?code=test-code');
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.error).toBe('invalid_state');
+	});
 
-  it("returns 400 for unsupported platform in callback", async () => {
-    const app = createApp(makeConfig({ clientId: "id", clientSecret: "secret" }));
-    const res = await app.request("/auth/unsupported/callback?code=c&state=s.s");
-    expect(res.status).toBe(400);
-    const body = await res.json();
-    expect(body.error).toBe("unsupported_platform");
-  });
+	it('returns 400 for unsupported platform in callback', async () => {
+		const app = createApp(makeConfig({ clientId: 'id', clientSecret: 'secret' }));
+		const res = await app.request('/auth/unsupported/callback?code=c&state=s.s');
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.error).toBe('unsupported_platform');
+	});
 });
 
-describe("full OAuth flow with mocked GitHub API", () => {
-  it("completes start → callback → redirect with tokens", async () => {
-    const fetchFn = mockFetchFn(
-      { access_token: "gho_mock_token", token_type: "bearer", scope: "repo,workflow,read:org" },
-      { login: "testuser", avatar_url: "https://avatars.githubusercontent.com/u/1", email: "test@example.com" }
-    );
-    const config = makeConfig({ clientId: "cid", clientSecret: "csecret" });
-    const app = createApp(config, fetchFn);
+describe('full OAuth flow with mocked GitHub API', () => {
+	it('completes start → callback → redirect with tokens', async () => {
+		const fetchFn = mockFetchFn(
+			{ access_token: 'gho_mock_token', token_type: 'bearer', scope: 'repo,workflow,read:org' },
+			{
+				login: 'testuser',
+				avatar_url: 'https://avatars.githubusercontent.com/u/1',
+				email: 'test@example.com',
+			},
+		);
+		const config = makeConfig({ clientId: 'cid', clientSecret: 'csecret' });
+		const app = createApp(config, fetchFn);
 
-    // Step 1: Start the flow
-    const startRes = await app.request(
-      "http://localhost:4100/auth/github/start?callback=http://localhost:3100/oauth/callback&state=user-data"
-    );
-    expect(startRes.status).toBe(302);
-    const githubUrl = new URL(startRes.headers.get("Location")!);
-    const signedState = githubUrl.searchParams.get("state")!;
+		// Step 1: Start the flow
+		const startRes = await app.request(
+			'http://localhost:4100/auth/github/start?callback=http://localhost:3100/oauth/callback&state=user-data',
+		);
+		expect(startRes.status).toBe(302);
+		const githubUrl = new URL(startRes.headers.get('Location')!);
+		const signedState = githubUrl.searchParams.get('state')!;
 
-    // Verify the state is valid
-    const payload = verifyState(signedState, SIGNING_KEY);
-    expect(payload).not.toBeNull();
-    expect(payload!.callback_url).toBe("http://localhost:3100/oauth/callback");
-    expect(payload!.platform).toBe("github");
-    expect(payload!.original_state).toBe("user-data");
+		// Verify the state is valid
+		const payload = verifyState(signedState, SIGNING_KEY);
+		expect(payload).not.toBeNull();
+		expect(payload?.callback_url).toBe('http://localhost:3100/oauth/callback');
+		expect(payload?.platform).toBe('github');
+		expect(payload?.original_state).toBe('user-data');
 
-    // Step 2: Simulate GitHub callback
-    const callbackRes = await app.request(
-      `http://localhost:4100/auth/github/callback?code=mock-code&state=${encodeURIComponent(signedState)}`
-    );
-    expect(callbackRes.status).toBe(302);
+		// Step 2: Simulate GitHub callback
+		const callbackRes = await app.request(
+			`http://localhost:4100/auth/github/callback?code=mock-code&state=${encodeURIComponent(signedState)}`,
+		);
+		expect(callbackRes.status).toBe(302);
 
-    // Step 3: Verify the final redirect
-    const finalUrl = new URL(callbackRes.headers.get("Location")!);
-    expect(finalUrl.origin + finalUrl.pathname).toBe(
-      "http://localhost:3100/oauth/callback"
-    );
-    expect(finalUrl.searchParams.get("platform")).toBe("github");
-    expect(finalUrl.searchParams.get("access_token")).toBe("gho_mock_token");
-    expect(finalUrl.searchParams.get("scopes")).toBe("repo,workflow,read:org");
-    expect(finalUrl.searchParams.get("state")).toBe("user-data");
+		// Step 3: Verify the final redirect
+		const finalUrl = new URL(callbackRes.headers.get('Location')!);
+		expect(finalUrl.origin + finalUrl.pathname).toBe('http://localhost:3100/oauth/callback');
+		expect(finalUrl.searchParams.get('platform')).toBe('github');
+		expect(finalUrl.searchParams.get('access_token')).toBe('gho_mock_token');
+		expect(finalUrl.searchParams.get('scopes')).toBe('repo,workflow,read:org');
+		expect(finalUrl.searchParams.get('state')).toBe('user-data');
 
-    // Verify metadata contains user info
-    const metadata = JSON.parse(
-      Buffer.from(finalUrl.searchParams.get("metadata")!, "base64url").toString("utf8")
-    );
-    expect(metadata.username).toBe("testuser");
-    expect(metadata.avatar_url).toBe("https://avatars.githubusercontent.com/u/1");
-    expect(metadata.email).toBe("test@example.com");
-  });
+		// Verify metadata contains user info
+		const metadata = JSON.parse(
+			Buffer.from(finalUrl.searchParams.get('metadata')!, 'base64url').toString('utf8'),
+		);
+		expect(metadata.username).toBe('testuser');
+		expect(metadata.avatar_url).toBe('https://avatars.githubusercontent.com/u/1');
+		expect(metadata.email).toBe('test@example.com');
+	});
 
-  it("redirects with error when token exchange fails", async () => {
-    const fetchFn: FetchFn = async () =>
-      new Response(JSON.stringify({ error: "bad_verification_code" }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      });
+	it('redirects with error when token exchange fails', async () => {
+		const fetchFn: FetchFn = async () =>
+			new Response(JSON.stringify({ error: 'bad_verification_code' }), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			});
 
-    const config = makeConfig({ clientId: "cid", clientSecret: "csecret" });
-    const app = createApp(config, fetchFn);
+		const config = makeConfig({ clientId: 'cid', clientSecret: 'csecret' });
+		const app = createApp(config, fetchFn);
 
-    // Start the flow to get a valid state
-    const startRes = await app.request(
-      "http://localhost:4100/auth/github/start?callback=http://localhost:3100/oauth/callback"
-    );
-    const githubUrl = new URL(startRes.headers.get("Location")!);
-    const signedState = githubUrl.searchParams.get("state")!;
+		// Start the flow to get a valid state
+		const startRes = await app.request(
+			'http://localhost:4100/auth/github/start?callback=http://localhost:3100/oauth/callback',
+		);
+		const githubUrl = new URL(startRes.headers.get('Location')!);
+		const signedState = githubUrl.searchParams.get('state')!;
 
-    // Callback with the bad code
-    const callbackRes = await app.request(
-      `http://localhost:4100/auth/github/callback?code=bad-code&state=${encodeURIComponent(signedState)}`
-    );
-    expect(callbackRes.status).toBe(302);
-    const errorUrl = new URL(callbackRes.headers.get("Location")!);
-    expect(errorUrl.searchParams.get("error")).toBe("token_exchange_failed");
-    expect(errorUrl.searchParams.get("platform")).toBe("github");
-  });
+		// Callback with the bad code
+		const callbackRes = await app.request(
+			`http://localhost:4100/auth/github/callback?code=bad-code&state=${encodeURIComponent(signedState)}`,
+		);
+		expect(callbackRes.status).toBe(302);
+		const errorUrl = new URL(callbackRes.headers.get('Location')!);
+		expect(errorUrl.searchParams.get('error')).toBe('token_exchange_failed');
+		expect(errorUrl.searchParams.get('platform')).toBe('github');
+	});
 
-  it("nonce cannot be reused", async () => {
-    const fetchFn = mockFetchFn(
-      { access_token: "gho_token", token_type: "bearer", scope: "repo" },
-      { login: "user", avatar_url: "https://example.com/avatar", email: null }
-    );
-    const config = makeConfig({ clientId: "cid", clientSecret: "csecret" });
-    const app = createApp(config, fetchFn);
+	it('nonce cannot be reused', async () => {
+		const fetchFn = mockFetchFn(
+			{ access_token: 'gho_token', token_type: 'bearer', scope: 'repo' },
+			{ login: 'user', avatar_url: 'https://example.com/avatar', email: null },
+		);
+		const config = makeConfig({ clientId: 'cid', clientSecret: 'csecret' });
+		const app = createApp(config, fetchFn);
 
-    // Start the flow
-    const startRes = await app.request(
-      "http://localhost:4100/auth/github/start?callback=http://localhost:3100/oauth/callback"
-    );
-    const githubUrl = new URL(startRes.headers.get("Location")!);
-    const signedState = githubUrl.searchParams.get("state")!;
+		// Start the flow
+		const startRes = await app.request(
+			'http://localhost:4100/auth/github/start?callback=http://localhost:3100/oauth/callback',
+		);
+		const githubUrl = new URL(startRes.headers.get('Location')!);
+		const signedState = githubUrl.searchParams.get('state')!;
 
-    // First callback succeeds
-    const first = await app.request(
-      `http://localhost:4100/auth/github/callback?code=code&state=${encodeURIComponent(signedState)}`
-    );
-    expect(first.status).toBe(302);
-    const firstUrl = new URL(first.headers.get("Location")!);
-    expect(firstUrl.searchParams.get("access_token")).toBe("gho_token");
+		// First callback succeeds
+		const first = await app.request(
+			`http://localhost:4100/auth/github/callback?code=code&state=${encodeURIComponent(signedState)}`,
+		);
+		expect(first.status).toBe(302);
+		const firstUrl = new URL(first.headers.get('Location')!);
+		expect(firstUrl.searchParams.get('access_token')).toBe('gho_token');
 
-    // Second callback with same state fails (nonce consumed)
-    const second = await app.request(
-      `http://localhost:4100/auth/github/callback?code=code&state=${encodeURIComponent(signedState)}`
-    );
-    expect(second.status).toBe(302);
-    const secondUrl = new URL(second.headers.get("Location")!);
-    expect(secondUrl.searchParams.get("error")).toBe("expired_nonce");
-  });
+		// Second callback with same state fails (nonce consumed)
+		const second = await app.request(
+			`http://localhost:4100/auth/github/callback?code=code&state=${encodeURIComponent(signedState)}`,
+		);
+		expect(second.status).toBe(302);
+		const secondUrl = new URL(second.headers.get('Location')!);
+		expect(secondUrl.searchParams.get('error')).toBe('expired_nonce');
+	});
 });

--- a/packages/connect/src/test/__tests__/state.test.ts
+++ b/packages/connect/src/test/__tests__/state.test.ts
@@ -1,113 +1,109 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
-  signState,
-  verifyState,
-  createNonce,
-  NonceStore,
-  type StatePayload,
-} from "../../crypto/state.js";
+	createNonce,
+	NonceStore,
+	type StatePayload,
+	signState,
+	verifyState,
+} from '../../crypto/state.js';
 
-describe("signState + verifyState", () => {
-  const signingKey = "test-signing-key-256-bits-long-abc";
-  const payload: StatePayload = {
-    callback_url: "http://localhost:3100/oauth/callback",
-    platform: "github",
-    nonce: "test-nonce-123",
-    timestamp: "2026-03-30T12:00:00Z",
-  };
+describe('signState + verifyState', () => {
+	const signingKey = 'test-signing-key-256-bits-long-abc';
+	const payload: StatePayload = {
+		callback_url: 'http://localhost:3100/oauth/callback',
+		platform: 'github',
+		nonce: 'test-nonce-123',
+		timestamp: '2026-03-30T12:00:00Z',
+	};
 
-  it("roundtrips successfully", () => {
-    const signed = signState(payload, signingKey);
-    const result = verifyState(signed, signingKey);
-    expect(result).toEqual(payload);
-  });
+	it('roundtrips successfully', () => {
+		const signed = signState(payload, signingKey);
+		const result = verifyState(signed, signingKey);
+		expect(result).toEqual(payload);
+	});
 
-  it("preserves original_state when present", () => {
-    const withState = { ...payload, original_state: "user-state-abc" };
-    const signed = signState(withState, signingKey);
-    const result = verifyState(signed, signingKey);
-    expect(result).toEqual(withState);
-  });
+	it('preserves original_state when present', () => {
+		const withState = { ...payload, original_state: 'user-state-abc' };
+		const signed = signState(withState, signingKey);
+		const result = verifyState(signed, signingKey);
+		expect(result).toEqual(withState);
+	});
 
-  it("returns null for tampered payload", () => {
-    const signed = signState(payload, signingKey);
-    const [encoded, signature] = signed.split(".");
-    const tampered =
-      Buffer.from(
-        JSON.stringify({ ...payload, platform: "evil" })
-      ).toString("base64url") +
-      "." +
-      signature;
-    expect(verifyState(tampered, signingKey)).toBeNull();
-  });
+	it('returns null for tampered payload', () => {
+		const signed = signState(payload, signingKey);
+		const [_encoded, signature] = signed.split('.');
+		const tampered =
+			Buffer.from(JSON.stringify({ ...payload, platform: 'evil' })).toString('base64url') +
+			'.' +
+			signature;
+		expect(verifyState(tampered, signingKey)).toBeNull();
+	});
 
-  it("returns null for tampered signature", () => {
-    const signed = signState(payload, signingKey);
-    const tampered = signed.slice(0, -4) + "xxxx";
-    expect(verifyState(tampered, signingKey)).toBeNull();
-  });
+	it('returns null for tampered signature', () => {
+		const signed = signState(payload, signingKey);
+		const tampered = `${signed.slice(0, -4)}xxxx`;
+		expect(verifyState(tampered, signingKey)).toBeNull();
+	});
 
-  it("returns null with a different signing key", () => {
-    const signed = signState(payload, signingKey);
-    expect(verifyState(signed, "different-key")).toBeNull();
-  });
+	it('returns null with a different signing key', () => {
+		const signed = signState(payload, signingKey);
+		expect(verifyState(signed, 'different-key')).toBeNull();
+	});
 
-  it("returns null for input without a dot separator", () => {
-    expect(verifyState("nodothere", signingKey)).toBeNull();
-  });
+	it('returns null for input without a dot separator', () => {
+		expect(verifyState('nodothere', signingKey)).toBeNull();
+	});
 });
 
-describe("createNonce", () => {
-  it("returns a UUID string", () => {
-    const nonce = createNonce();
-    expect(nonce).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
-    );
-  });
+describe('createNonce', () => {
+	it('returns a UUID string', () => {
+		const nonce = createNonce();
+		expect(nonce).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+	});
 
-  it("returns unique values", () => {
-    const a = createNonce();
-    const b = createNonce();
-    expect(a).not.toBe(b);
-  });
+	it('returns unique values', () => {
+		const a = createNonce();
+		const b = createNonce();
+		expect(a).not.toBe(b);
+	});
 });
 
-describe("NonceStore", () => {
-  let store: NonceStore;
+describe('NonceStore', () => {
+	let store: NonceStore;
 
-  beforeEach(() => {
-    store = new NonceStore();
-    vi.useFakeTimers();
-  });
+	beforeEach(() => {
+		store = new NonceStore();
+		vi.useFakeTimers();
+	});
 
-  afterEach(() => {
-    vi.useRealTimers();
-  });
+	afterEach(() => {
+		vi.useRealTimers();
+	});
 
-  it("add and consume succeeds", () => {
-    store.add("nonce-1");
-    expect(store.consume("nonce-1")).toBe(true);
-  });
+	it('add and consume succeeds', () => {
+		store.add('nonce-1');
+		expect(store.consume('nonce-1')).toBe(true);
+	});
 
-  it("consume same nonce twice fails", () => {
-    store.add("nonce-2");
-    expect(store.consume("nonce-2")).toBe(true);
-    expect(store.consume("nonce-2")).toBe(false);
-  });
+	it('consume same nonce twice fails', () => {
+		store.add('nonce-2');
+		expect(store.consume('nonce-2')).toBe(true);
+		expect(store.consume('nonce-2')).toBe(false);
+	});
 
-  it("consume unknown nonce fails", () => {
-    expect(store.consume("unknown")).toBe(false);
-  });
+	it('consume unknown nonce fails', () => {
+		expect(store.consume('unknown')).toBe(false);
+	});
 
-  it("expired nonces are not consumable", () => {
-    store.add("nonce-3");
-    vi.advanceTimersByTime(5 * 60 * 1000 + 1);
-    expect(store.consume("nonce-3")).toBe(false);
-  });
+	it('expired nonces are not consumable', () => {
+		store.add('nonce-3');
+		vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+		expect(store.consume('nonce-3')).toBe(false);
+	});
 
-  it("non-expired nonces remain consumable", () => {
-    store.add("nonce-4");
-    vi.advanceTimersByTime(4 * 60 * 1000);
-    expect(store.consume("nonce-4")).toBe(true);
-  });
+	it('non-expired nonces remain consumable', () => {
+		store.add('nonce-4');
+		vi.advanceTimersByTime(4 * 60 * 1000);
+		expect(store.consume('nonce-4')).toBe(true);
+	});
 });

--- a/packages/server/scripts/bundle-migrations.ts
+++ b/packages/server/scripts/bundle-migrations.ts
@@ -1,18 +1,12 @@
-import { join, dirname } from "path";
-import { writeFile, mkdir } from "fs/promises";
-import { zip } from "@hiddentao/zip-json";
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { zip } from '@hiddentao/zip-json';
 
-const migrationsDir = join(import.meta.dir, "..", "migrations");
-const outputPath = join(
-  import.meta.dir,
-  "..",
-  "src",
-  "db",
-  "migrations-bundle.json",
-);
+const migrationsDir = join(import.meta.dir, '..', 'migrations');
+const outputPath = join(import.meta.dir, '..', 'src', 'db', 'migrations-bundle.json');
 
-const archive = await zip(["*.sql"], {
-  baseDir: migrationsDir,
+const archive = await zip(['*.sql'], {
+	baseDir: migrationsDir,
 });
 
 await mkdir(dirname(outputPath), { recursive: true });

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -1,66 +1,66 @@
-import { homedir } from "os";
-import { resolve } from "path";
+import { homedir } from 'node:os';
+import { resolve } from 'node:path';
 
 export interface HezoConfig {
-  port: number;
-  dataDir: string;
-  masterKey?: string;
-  connectUrl: string;
-  connectApiKey?: string;
-  reset: boolean;
-  noOpen: boolean;
+	port: number;
+	dataDir: string;
+	masterKey?: string;
+	connectUrl: string;
+	connectApiKey?: string;
+	reset: boolean;
+	noOpen: boolean;
 }
 
 const DEFAULT_PORT = 3100;
-const DEFAULT_DATA_DIR = "~/.hezo";
-const DEFAULT_CONNECT_URL = "http://localhost:4100";
+const DEFAULT_DATA_DIR = '~/.hezo';
+const DEFAULT_CONNECT_URL = 'http://localhost:4100';
 
 export function parseArgs(argv: string[] = process.argv): HezoConfig {
-  const args = argv.slice(2);
+	const args = argv.slice(2);
 
-  let port = DEFAULT_PORT;
-  let dataDir = DEFAULT_DATA_DIR;
-  let masterKey: string | undefined;
-  let connectUrl = DEFAULT_CONNECT_URL;
-  let connectApiKey: string | undefined;
-  let reset = false;
-  let noOpen = false;
+	let port = DEFAULT_PORT;
+	let dataDir = DEFAULT_DATA_DIR;
+	let masterKey: string | undefined;
+	let connectUrl = DEFAULT_CONNECT_URL;
+	let connectApiKey: string | undefined;
+	let reset = false;
+	let noOpen = false;
 
-  for (let i = 0; i < args.length; i++) {
-    switch (args[i]) {
-      case "--port":
-        port = parseInt(args[++i], 10);
-        if (isNaN(port) || port < 1 || port > 65535) {
-          throw new Error(`Invalid port: ${args[i]}. Must be 1-65535.`);
-        }
-        break;
-      case "--data-dir":
-        dataDir = args[++i];
-        break;
-      case "--master-key":
-        masterKey = args[++i];
-        break;
-      case "--connect-url":
-        connectUrl = args[++i];
-        break;
-      case "--connect-api-key":
-        connectApiKey = args[++i];
-        break;
-      case "--reset":
-        reset = true;
-        break;
-      case "--no-open":
-        noOpen = true;
-        break;
-    }
-  }
+	for (let i = 0; i < args.length; i++) {
+		switch (args[i]) {
+			case '--port':
+				port = parseInt(args[++i], 10);
+				if (Number.isNaN(port) || port < 1 || port > 65535) {
+					throw new Error(`Invalid port: ${args[i]}. Must be 1-65535.`);
+				}
+				break;
+			case '--data-dir':
+				dataDir = args[++i];
+				break;
+			case '--master-key':
+				masterKey = args[++i];
+				break;
+			case '--connect-url':
+				connectUrl = args[++i];
+				break;
+			case '--connect-api-key':
+				connectApiKey = args[++i];
+				break;
+			case '--reset':
+				reset = true;
+				break;
+			case '--no-open':
+				noOpen = true;
+				break;
+		}
+	}
 
-  // Resolve tilde to home directory
-  if (dataDir.startsWith("~")) {
-    dataDir = resolve(homedir(), dataDir.slice(2));
-  } else {
-    dataDir = resolve(dataDir);
-  }
+	// Resolve tilde to home directory
+	if (dataDir.startsWith('~')) {
+		dataDir = resolve(homedir(), dataDir.slice(2));
+	} else {
+		dataDir = resolve(dataDir);
+	}
 
-  return { port, dataDir, masterKey, connectUrl, connectApiKey, reset, noOpen };
+	return { port, dataDir, masterKey, connectUrl, connectApiKey, reset, noOpen };
 }

--- a/packages/server/src/crypto/encryption.ts
+++ b/packages/server/src/crypto/encryption.ts
@@ -1,54 +1,41 @@
-import { createCipheriv, createDecipheriv, randomBytes, hkdf } from "crypto";
+import { createCipheriv, createDecipheriv, hkdf, randomBytes } from 'node:crypto';
 
-const ALGORITHM = "aes-256-gcm";
+const ALGORITHM = 'aes-256-gcm';
 const IV_LENGTH = 12;
 const AUTH_TAG_LENGTH = 16;
 
 export function encrypt(plaintext: string, key: Buffer): string {
-  const iv = randomBytes(IV_LENGTH);
-  const cipher = createCipheriv(ALGORITHM, key, iv, {
-    authTagLength: AUTH_TAG_LENGTH,
-  });
-  const encrypted = Buffer.concat([
-    cipher.update(plaintext, "utf8"),
-    cipher.final(),
-  ]);
-  const authTag = cipher.getAuthTag();
-  return Buffer.concat([iv, encrypted, authTag]).toString("base64");
+	const iv = randomBytes(IV_LENGTH);
+	const cipher = createCipheriv(ALGORITHM, key, iv, {
+		authTagLength: AUTH_TAG_LENGTH,
+	});
+	const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+	const authTag = cipher.getAuthTag();
+	return Buffer.concat([iv, encrypted, authTag]).toString('base64');
 }
 
 export function decrypt(ciphertext: string, key: Buffer): string {
-  const data = Buffer.from(ciphertext, "base64");
-  const iv = data.subarray(0, IV_LENGTH);
-  const authTag = data.subarray(data.length - AUTH_TAG_LENGTH);
-  const encrypted = data.subarray(IV_LENGTH, data.length - AUTH_TAG_LENGTH);
-  const decipher = createDecipheriv(ALGORITHM, key, iv, {
-    authTagLength: AUTH_TAG_LENGTH,
-  });
-  decipher.setAuthTag(authTag);
-  return decipher.update(encrypted) + decipher.final("utf8");
+	const data = Buffer.from(ciphertext, 'base64');
+	const iv = data.subarray(0, IV_LENGTH);
+	const authTag = data.subarray(data.length - AUTH_TAG_LENGTH);
+	const encrypted = data.subarray(IV_LENGTH, data.length - AUTH_TAG_LENGTH);
+	const decipher = createDecipheriv(ALGORITHM, key, iv, {
+		authTagLength: AUTH_TAG_LENGTH,
+	});
+	decipher.setAuthTag(authTag);
+	return decipher.update(encrypted) + decipher.final('utf8');
 }
 
-export function deriveKey(
-  masterKey: string,
-  purpose: string,
-): Promise<Buffer> {
-  return new Promise((resolve, reject) => {
-    const salt = Buffer.from(purpose, "utf8");
-    hkdf(
-      "sha256",
-      masterKey,
-      salt,
-      Buffer.from("hezo", "utf8"),
-      32,
-      (err, derivedKey) => {
-        if (err) reject(err);
-        else resolve(Buffer.from(derivedKey));
-      },
-    );
-  });
+export function deriveKey(masterKey: string, purpose: string): Promise<Buffer> {
+	return new Promise((resolve, reject) => {
+		const salt = Buffer.from(purpose, 'utf8');
+		hkdf('sha256', masterKey, salt, Buffer.from('hezo', 'utf8'), 32, (err, derivedKey) => {
+			if (err) reject(err);
+			else resolve(Buffer.from(derivedKey));
+		});
+	});
 }
 
 export function generateMasterKey(): string {
-  return randomBytes(32).toString("hex");
+	return randomBytes(32).toString('hex');
 }

--- a/packages/server/src/crypto/master-key.ts
+++ b/packages/server/src/crypto/master-key.ts
@@ -1,101 +1,102 @@
-import { encrypt, decrypt, deriveKey } from "./encryption";
+import { decrypt, deriveKey, encrypt } from './encryption';
 
-const CANARY_PLAINTEXT = "CANARY";
-const CANARY_PURPOSE = "master-key-canary";
+const CANARY_PLAINTEXT = 'CANARY';
+const CANARY_PURPOSE = 'master-key-canary';
 
-export type MasterKeyState = "unset" | "locked" | "unlocked";
+export type MasterKeyState = 'unset' | 'locked' | 'unlocked';
 
 interface DbClient {
-  query<T = any>(sql: string, params?: any[]): Promise<{ rows: T[] }>;
+	query<T = any>(sql: string, params?: any[]): Promise<{ rows: T[] }>;
 }
 
 export class MasterKeyManager {
-  private key: Buffer | null = null;
-  private state: MasterKeyState = "unset";
+	private key: Buffer | null = null;
+	private jwtKey: Buffer | null = null;
+	private masterKeyHex: string | null = null;
+	private state: MasterKeyState = 'unset';
 
-  getState(): MasterKeyState {
-    return this.state;
-  }
+	getState(): MasterKeyState {
+		return this.state;
+	}
 
-  getKey(): Buffer | null {
-    return this.key;
-  }
+	getKey(): Buffer | null {
+		return this.key;
+	}
 
-  async initialize(
-    db: DbClient,
-    masterKeyHex?: string,
-  ): Promise<MasterKeyState> {
-    const canary = await this.loadCanary(db);
+	async initialize(db: DbClient, masterKeyHex?: string): Promise<MasterKeyState> {
+		const canary = await this.loadCanary(db);
 
-    if (canary) {
-      if (masterKeyHex && (await this.checkCanary(canary, masterKeyHex))) {
-        await this.setUnlocked(masterKeyHex);
-      } else {
-        this.state = "locked";
-      }
-    } else {
-      if (masterKeyHex) {
-        await this.storeCanary(db, masterKeyHex);
-        await this.setUnlocked(masterKeyHex);
-      } else {
-        this.state = "unset";
-      }
-    }
+		if (canary) {
+			if (masterKeyHex && (await this.checkCanary(canary, masterKeyHex))) {
+				await this.setUnlocked(masterKeyHex);
+			} else {
+				this.state = 'locked';
+			}
+		} else {
+			if (masterKeyHex) {
+				await this.storeCanary(db, masterKeyHex);
+				await this.setUnlocked(masterKeyHex);
+			} else {
+				this.state = 'unset';
+			}
+		}
 
-    return this.state;
-  }
+		return this.state;
+	}
 
-  async unlock(db: DbClient, masterKeyHex: string): Promise<boolean> {
-    if (this.state === "unset") {
-      await this.storeCanary(db, masterKeyHex);
-      await this.setUnlocked(masterKeyHex);
-      return true;
-    }
+	async unlock(db: DbClient, masterKeyHex: string): Promise<boolean> {
+		if (this.state === 'unset') {
+			await this.storeCanary(db, masterKeyHex);
+			await this.setUnlocked(masterKeyHex);
+			return true;
+		}
 
-    const canary = await this.loadCanary(db);
-    if (canary && (await this.checkCanary(canary, masterKeyHex))) {
-      await this.setUnlocked(masterKeyHex);
-      return true;
-    }
-    return false;
-  }
+		const canary = await this.loadCanary(db);
+		if (canary && (await this.checkCanary(canary, masterKeyHex))) {
+			await this.setUnlocked(masterKeyHex);
+			return true;
+		}
+		return false;
+	}
 
-  private async setUnlocked(masterKeyHex: string): Promise<void> {
-    this.key = await deriveKey(masterKeyHex, "encryption");
-    this.state = "unlocked";
-  }
+	async getJwtKey(): Promise<Buffer> {
+		if (this.jwtKey) return this.jwtKey;
+		if (!this.masterKeyHex) throw new Error('Master key not available');
+		this.jwtKey = await deriveKey(this.masterKeyHex, 'jwt');
+		return this.jwtKey;
+	}
 
-  private async loadCanary(db: DbClient): Promise<string | null> {
-    const result = await db.query<{ value: string }>(
-      "SELECT value FROM system_meta WHERE key = 'master_key_canary'",
-    );
-    return result.rows[0]?.value ?? null;
-  }
+	private async setUnlocked(masterKeyHex: string): Promise<void> {
+		this.masterKeyHex = masterKeyHex;
+		this.key = await deriveKey(masterKeyHex, 'encryption');
+		this.state = 'unlocked';
+	}
 
-  private async storeCanary(
-    db: DbClient,
-    masterKeyHex: string,
-  ): Promise<void> {
-    const derivedKey = await deriveKey(masterKeyHex, CANARY_PURPOSE);
-    const encrypted = encrypt(CANARY_PLAINTEXT, derivedKey);
-    await db.query(
-      `INSERT INTO system_meta (key, value) VALUES ('master_key_canary', $1)
+	private async loadCanary(db: DbClient): Promise<string | null> {
+		const result = await db.query<{ value: string }>(
+			"SELECT value FROM system_meta WHERE key = 'master_key_canary'",
+		);
+		return result.rows[0]?.value ?? null;
+	}
+
+	private async storeCanary(db: DbClient, masterKeyHex: string): Promise<void> {
+		const derivedKey = await deriveKey(masterKeyHex, CANARY_PURPOSE);
+		const encrypted = encrypt(CANARY_PLAINTEXT, derivedKey);
+		await db.query(
+			`INSERT INTO system_meta (key, value) VALUES ('master_key_canary', $1)
        ON CONFLICT (key) DO UPDATE SET value = $1`,
-      [encrypted],
-    );
-  }
+			[encrypted],
+		);
+	}
 
-  private async checkCanary(
-    encryptedCanary: string,
-    masterKeyHex: string,
-  ): Promise<boolean> {
-    try {
-      const derivedKey = await deriveKey(masterKeyHex, CANARY_PURPOSE);
-      return decrypt(encryptedCanary, derivedKey) === CANARY_PLAINTEXT;
-    } catch {
-      return false;
-    }
-  }
+	private async checkCanary(encryptedCanary: string, masterKeyHex: string): Promise<boolean> {
+		try {
+			const derivedKey = await deriveKey(masterKeyHex, CANARY_PURPOSE);
+			return decrypt(encryptedCanary, derivedKey) === CANARY_PLAINTEXT;
+		} catch {
+			return false;
+		}
+	}
 }
 
-export { generateMasterKey } from "./encryption";
+export { generateMasterKey } from './encryption';

--- a/packages/server/src/db/client.ts
+++ b/packages/server/src/db/client.ts
@@ -1,12 +1,12 @@
-import { PGlite } from "@electric-sql/pglite";
+import { PGlite } from '@electric-sql/pglite';
 
 export async function createDb(dataDir: string): Promise<PGlite> {
-  const { NodeFS } = await import("@electric-sql/pglite/nodefs");
-  const { join } = await import("path");
-  const pgDataPath = join(dataDir, "pgdata");
-  return new PGlite({ fs: new NodeFS(pgDataPath) });
+	const { NodeFS } = await import('@electric-sql/pglite/nodefs');
+	const { join } = await import('node:path');
+	const pgDataPath = join(dataDir, 'pgdata');
+	return new PGlite({ fs: new NodeFS(pgDataPath) });
 }
 
 export async function createMemoryDb(): Promise<PGlite> {
-  return new PGlite();
+	return new PGlite();
 }

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -1,11 +1,8 @@
-import { createHash } from "crypto";
-import type { PGlite } from "@electric-sql/pglite";
+import { createHash } from 'node:crypto';
+import type { PGlite } from '@electric-sql/pglite';
 
-export async function runMigrations(
-  db: PGlite,
-  migrations: Record<string, string>,
-): Promise<void> {
-  await db.exec(`
+export async function runMigrations(db: PGlite, migrations: Record<string, string>): Promise<void> {
+	await db.exec(`
     CREATE TABLE IF NOT EXISTS _migrations (
       id          SERIAL PRIMARY KEY,
       filename    TEXT NOT NULL UNIQUE,
@@ -14,96 +11,85 @@ export async function runMigrations(
     );
   `);
 
-  const applied = await db.query<{ filename: string; checksum: string }>(
-    "SELECT filename, checksum FROM _migrations ORDER BY id",
-  );
-  const appliedMap = new Map(
-    applied.rows.map((r) => [r.filename, r.checksum]),
-  );
+	const applied = await db.query<{ filename: string; checksum: string }>(
+		'SELECT filename, checksum FROM _migrations ORDER BY id',
+	);
+	const appliedMap = new Map(applied.rows.map((r) => [r.filename, r.checksum]));
 
-  const filenames = Object.keys(migrations).sort();
+	const filenames = Object.keys(migrations).sort();
 
-  for (const filename of filenames) {
-    const sql = migrations[filename];
-    const checksum = createHash("sha256").update(sql).digest("hex");
+	for (const filename of filenames) {
+		const sql = migrations[filename];
+		const checksum = createHash('sha256').update(sql).digest('hex');
 
-    if (appliedMap.has(filename)) {
-      if (appliedMap.get(filename) !== checksum) {
-        console.warn(
-          `Warning: migration ${filename} has changed since it was applied`,
-        );
-      }
-      continue;
-    }
+		if (appliedMap.has(filename)) {
+			if (appliedMap.get(filename) !== checksum) {
+				console.warn(`Warning: migration ${filename} has changed since it was applied`);
+			}
+			continue;
+		}
 
-    await db.exec("BEGIN");
-    try {
-      await db.exec(sql);
-      await db.query(
-        "INSERT INTO _migrations (filename, checksum) VALUES ($1, $2)",
-        [filename, checksum],
-      );
-      await db.exec("COMMIT");
-      console.log(`Applied migration: ${filename}`);
-    } catch (err) {
-      await db.exec("ROLLBACK");
-      throw new Error(`Migration ${filename} failed: ${err}`);
-    }
-  }
+		await db.exec('BEGIN');
+		try {
+			await db.exec(sql);
+			await db.query('INSERT INTO _migrations (filename, checksum) VALUES ($1, $2)', [
+				filename,
+				checksum,
+			]);
+			await db.exec('COMMIT');
+			console.log(`Applied migration: ${filename}`);
+		} catch (err) {
+			await db.exec('ROLLBACK');
+			throw new Error(`Migration ${filename} failed: ${err}`);
+		}
+	}
 }
 
-export async function loadBundledMigrations(): Promise<
-  Record<string, string>
-> {
-  const { unzip, list } = await import("@hiddentao/zip-json");
-  const { readFile, mkdir, rm } = await import("fs/promises");
-  const { join } = await import("path");
-  const { tmpdir } = await import("os");
+export async function loadBundledMigrations(): Promise<Record<string, string>> {
+	const { unzip, list } = await import('@hiddentao/zip-json');
+	const { readFile, mkdir, rm } = await import('node:fs/promises');
+	const { join } = await import('node:path');
+	const { tmpdir } = await import('node:os');
 
-  const bundlePath = join(import.meta.dir, "migrations-bundle.json");
-  let archive: unknown;
-  try {
-    archive = JSON.parse(await readFile(bundlePath, "utf-8"));
-  } catch {
-    throw new Error(
-      "Failed to load migration bundle. Run 'bun run build:migrations' first.",
-    );
-  }
+	const currentDir = new URL('.', import.meta.url).pathname;
+	const bundlePath = join(currentDir, 'migrations-bundle.json');
+	// biome-ignore lint/suspicious/noExplicitAny: JSON.parse returns unknown, zip-json expects its own type
+	let archive: any;
+	try {
+		archive = JSON.parse(await readFile(bundlePath, 'utf-8'));
+	} catch {
+		throw new Error("Failed to load migration bundle. Run 'bun run build:migrations' first.");
+	}
 
-  const files = list(archive);
-  const tmpExtractDir = join(tmpdir(), `hezo-migrations-${Date.now()}`);
-  await mkdir(tmpExtractDir, { recursive: true });
+	const files = list(archive);
+	const tmpExtractDir = join(tmpdir(), `hezo-migrations-${Date.now()}`);
+	await mkdir(tmpExtractDir, { recursive: true });
 
-  try {
-    await unzip(archive, { outputDir: tmpExtractDir });
-    const migrations: Record<string, string> = {};
-    await Promise.all(
-      files.map(async (file: { path: string }) => {
-        migrations[file.path] = await readFile(
-          join(tmpExtractDir, file.path),
-          "utf-8",
-        );
-      }),
-    );
-    return migrations;
-  } finally {
-    await rm(tmpExtractDir, { recursive: true, force: true });
-  }
+	try {
+		await unzip(archive, { outputDir: tmpExtractDir });
+		const migrations: Record<string, string> = {};
+		await Promise.all(
+			files.map(async (file: { path: string }) => {
+				migrations[file.path] = await readFile(join(tmpExtractDir, file.path), 'utf-8');
+			}),
+		);
+		return migrations;
+	} finally {
+		await rm(tmpExtractDir, { recursive: true, force: true });
+	}
 }
 
 export async function loadFilesystemMigrations(
-  migrationsDir: string,
+	migrationsDir: string,
 ): Promise<Record<string, string>> {
-  const { readdir, readFile } = await import("fs/promises");
-  const { join } = await import("path");
-  const files = (await readdir(migrationsDir))
-    .filter((f) => f.endsWith(".sql"))
-    .sort();
-  const migrations: Record<string, string> = {};
-  await Promise.all(
-    files.map(async (file) => {
-      migrations[file] = await readFile(join(migrationsDir, file), "utf-8");
-    }),
-  );
-  return migrations;
+	const { readdir, readFile } = await import('node:fs/promises');
+	const { join } = await import('node:path');
+	const files = (await readdir(migrationsDir)).filter((f) => f.endsWith('.sql')).sort();
+	const migrations: Record<string, string> = {};
+	await Promise.all(
+		files.map(async (file) => {
+			migrations[file] = await readFile(join(migrationsDir, file), 'utf-8');
+		}),
+	);
+	return migrations;
 }

--- a/packages/server/src/db/seed.ts
+++ b/packages/server/src/db/seed.ts
@@ -1,0 +1,120 @@
+import type { PGlite } from '@electric-sql/pglite';
+
+const SOFTWARE_DEV_AGENTS = [
+	{
+		title: 'CEO',
+		slug: 'ceo',
+		reports_to_slug: null,
+		runtime_type: 'claude_code',
+		heartbeat_interval_min: 120,
+		monthly_budget_cents: 2000,
+		role_description:
+			'Translates company mission into actionable strategy, delegates work across leadership, and resolves disputes between agents.',
+		status: 'active',
+	},
+	{
+		title: 'Architect',
+		slug: 'architect',
+		reports_to_slug: 'ceo',
+		runtime_type: 'claude_code',
+		heartbeat_interval_min: 60,
+		monthly_budget_cents: 4000,
+		role_description:
+			'Owns technical vision, translates product requirements into technical specifications, and makes architecture decisions.',
+		status: 'active',
+	},
+	{
+		title: 'Product Lead',
+		slug: 'product-lead',
+		reports_to_slug: 'ceo',
+		runtime_type: 'claude_code',
+		heartbeat_interval_min: 60,
+		monthly_budget_cents: 3000,
+		role_description:
+			'Owns product requirements, writes PRDs, manages scope, and ensures development aligns with company mission.',
+		status: 'active',
+	},
+	{
+		title: 'Engineer',
+		slug: 'engineer',
+		reports_to_slug: 'architect',
+		runtime_type: 'claude_code',
+		heartbeat_interval_min: 30,
+		monthly_budget_cents: 5000,
+		role_description:
+			"Primary implementer who writes code, tests, and documentation based on the Architect's technical specification.",
+		status: 'active',
+	},
+	{
+		title: 'QA Engineer',
+		slug: 'qa-engineer',
+		reports_to_slug: 'architect',
+		runtime_type: 'claude_code',
+		heartbeat_interval_min: 60,
+		monthly_budget_cents: 4000,
+		role_description:
+			'Final approval gate for every ticket, responsible for test coverage, security audits, and code quality.',
+		status: 'active',
+	},
+	{
+		title: 'UI Designer',
+		slug: 'ui-designer',
+		reports_to_slug: 'architect',
+		runtime_type: 'claude_code',
+		heartbeat_interval_min: 60,
+		monthly_budget_cents: 3000,
+		role_description:
+			'Owns visual and interaction layer, defines component architecture, and creates HTML preview mockups.',
+		status: 'active',
+	},
+	{
+		title: 'DevOps Engineer',
+		slug: 'devops-engineer',
+		reports_to_slug: 'architect',
+		runtime_type: 'claude_code',
+		heartbeat_interval_min: 60,
+		monthly_budget_cents: 3000,
+		role_description:
+			'Owns infrastructure and deployment pipeline, manages staging and production environments, and configures CI/CD.',
+		status: 'idle',
+	},
+	{
+		title: 'Marketing Lead',
+		slug: 'marketing-lead',
+		reports_to_slug: 'ceo',
+		runtime_type: 'claude_code',
+		heartbeat_interval_min: 120,
+		monthly_budget_cents: 2000,
+		role_description:
+			'Owns marketing strategy and content creation including blog posts, social media, and public-facing documentation.',
+		status: 'active',
+	},
+	{
+		title: 'Researcher',
+		slug: 'researcher',
+		reports_to_slug: 'ceo',
+		runtime_type: 'claude_code',
+		heartbeat_interval_min: 120,
+		monthly_budget_cents: 3000,
+		role_description:
+			'Conducts competitive analysis, technical research, and feasibility studies to inform strategic decisions.',
+		status: 'active',
+	},
+];
+
+export async function seedBuiltins(db: PGlite): Promise<void> {
+	const agentsConfig = JSON.stringify(SOFTWARE_DEV_AGENTS);
+
+	await db.query(
+		`INSERT INTO company_types (name, description, is_builtin, agents_config)
+     VALUES ($1, $2, true, $3::jsonb)
+     ON CONFLICT (name) DO NOTHING`,
+		[
+			'Software Development',
+			'Full-stack software development team with 9 specialized agents',
+			agentsConfig,
+		],
+	);
+}
+
+export { SOFTWARE_DEV_AGENTS };

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,9 +1,12 @@
+declare const Bun: { spawn: (args: string[]) => unknown };
+
 import { app } from './app';
 import { parseArgs } from './cli';
 import { startup } from './startup';
 
 const config = parseArgs();
-let serveFetch = app.fetch;
+// biome-ignore lint/suspicious/noExplicitAny: fetch signatures differ between Hono<Env> and Hono
+let serveFetch: any = app.fetch;
 
 startup(config)
 	.then((result) => {
@@ -11,7 +14,7 @@ startup(config)
 		const url = `http://localhost:${result.port}`;
 		console.log(`Hezo server running at ${url} [${result.masterKeyState}]`);
 		if (!config.noOpen) {
-			Bun.spawn(["open", url]);
+			Bun.spawn(['open', url]);
 		}
 	})
 	.catch((err) => {

--- a/packages/server/src/lib/pagination.ts
+++ b/packages/server/src/lib/pagination.ts
@@ -1,0 +1,18 @@
+import type { Context } from 'hono';
+
+const DEFAULT_PER_PAGE = 50;
+const MAX_PER_PAGE = 200;
+
+export function parsePagination(c: Context) {
+	const page = Math.max(1, Number(c.req.query('page')) || 1);
+	const perPage = Math.min(
+		MAX_PER_PAGE,
+		Math.max(1, Number(c.req.query('per_page')) || DEFAULT_PER_PAGE),
+	);
+	const offset = (page - 1) * perPage;
+	return { page, perPage, offset };
+}
+
+export function buildMeta(page: number, perPage: number, total: number) {
+	return { page, per_page: perPage, total };
+}

--- a/packages/server/src/lib/response.ts
+++ b/packages/server/src/lib/response.ts
@@ -1,0 +1,14 @@
+import type { Context } from 'hono';
+
+export function ok(c: Context, data: unknown, status: 200 | 201 = 200) {
+	return c.json({ data }, status);
+}
+
+export function err(
+	c: Context,
+	code: string,
+	message: string,
+	status: 400 | 401 | 403 | 404 | 409 | 422 | 402 | 500,
+) {
+	return c.json({ error: { code, message } }, status);
+}

--- a/packages/server/src/lib/slug.ts
+++ b/packages/server/src/lib/slug.ts
@@ -1,0 +1,19 @@
+export function toSlug(title: string): string {
+	return title
+		.toLowerCase()
+		.replace(/[^a-z0-9\s-]/g, '')
+		.replace(/\s+/g, '-')
+		.replace(/-+/g, '-')
+		.replace(/^-|-$/g, '');
+}
+
+export function toIssuePrefix(companyName: string): string {
+	const words = companyName.trim().split(/\s+/);
+	if (words.length === 1) {
+		return words[0].substring(0, 4).toUpperCase();
+	}
+	return words
+		.map((w) => w[0])
+		.join('')
+		.toUpperCase();
+}

--- a/packages/server/src/lib/types.ts
+++ b/packages/server/src/lib/types.ts
@@ -1,0 +1,15 @@
+import type { PGlite } from '@electric-sql/pglite';
+import type { MasterKeyManager } from '../crypto/master-key';
+
+export type AuthInfo =
+	| { type: 'board'; userId: string }
+	| { type: 'api_key'; companyId: string }
+	| { type: 'agent'; memberId: string; companyId: string };
+
+export type Env = {
+	Variables: {
+		db: PGlite;
+		masterKeyManager: MasterKeyManager;
+		auth: AuthInfo;
+	};
+};

--- a/packages/server/src/middleware/auth.ts
+++ b/packages/server/src/middleware/auth.ts
@@ -1,0 +1,104 @@
+import { createHash } from 'crypto';
+import { createMiddleware } from 'hono/factory';
+import { sign, verify } from 'hono/jwt';
+import type { Env } from '../lib/types';
+
+const PUBLIC_PATHS = ['/health', '/api/status', '/api/auth/token', '/'];
+
+export const authMiddleware = createMiddleware<Env>(async (c, next) => {
+	const path = new URL(c.req.url).pathname;
+	if (PUBLIC_PATHS.includes(path)) return next();
+	if (!path.startsWith('/api')) return next();
+
+	const header = c.req.header('Authorization');
+	if (!header?.startsWith('Bearer ')) {
+		return c.json(
+			{ error: { code: 'UNAUTHORIZED', message: 'Missing authorization header' } },
+			401,
+		);
+	}
+
+	const token = header.slice(7);
+	const masterKeyManager = c.get('masterKeyManager');
+
+	if (masterKeyManager.getState() !== 'unlocked') {
+		return c.json(
+			{ error: { code: 'LOCKED', message: 'Server is locked. Provide master key to unlock.' } },
+			401,
+		);
+	}
+
+	// API key auth
+	if (token.startsWith('hezo_')) {
+		const db = c.get('db');
+		const prefix = token.slice(5, 13);
+		const result = await db.query<{ id: string; company_id: string; key_hash: string }>(
+			'SELECT id, company_id, key_hash FROM api_keys WHERE prefix = $1',
+			[prefix],
+		);
+
+		if (result.rows.length === 0) {
+			return c.json({ error: { code: 'UNAUTHORIZED', message: 'Invalid API key' } }, 401);
+		}
+
+		const tokenHash = createHash('sha256').update(token).digest('hex');
+		const matched = tokenHash === result.rows[0].key_hash;
+		if (!matched) {
+			return c.json({ error: { code: 'UNAUTHORIZED', message: 'Invalid API key' } }, 401);
+		}
+
+		// Update last_used_at
+		await db.query('UPDATE api_keys SET last_used_at = now() WHERE id = $1', [result.rows[0].id]);
+
+		c.set('auth', { type: 'api_key', companyId: result.rows[0].company_id });
+		return next();
+	}
+
+	// JWT auth
+	try {
+		const jwtKey = await masterKeyManager.getJwtKey();
+		const secret = jwtKey.toString('base64');
+		const payload = await verify(token, secret, 'HS256');
+
+		if (payload.member_id && payload.company_id) {
+			c.set('auth', {
+				type: 'agent',
+				memberId: payload.member_id as string,
+				companyId: payload.company_id as string,
+			});
+		} else if (payload.user_id) {
+			c.set('auth', { type: 'board', userId: payload.user_id as string });
+		} else {
+			return c.json({ error: { code: 'UNAUTHORIZED', message: 'Invalid token payload' } }, 401);
+		}
+
+		return next();
+	} catch {
+		return c.json({ error: { code: 'UNAUTHORIZED', message: 'Invalid or expired token' } }, 401);
+	}
+});
+
+export async function signBoardJwt(
+	masterKeyManager: { getJwtKey: () => Promise<Buffer> },
+	userId: string,
+): Promise<string> {
+	const jwtKey = await masterKeyManager.getJwtKey();
+	const secret = jwtKey.toString('base64');
+	const now = Math.floor(Date.now() / 1000);
+	return sign({ user_id: userId, iat: now, exp: now + 86400 * 7 }, secret, 'HS256');
+}
+
+export async function signAgentJwt(
+	masterKeyManager: { getJwtKey: () => Promise<Buffer> },
+	memberId: string,
+	companyId: string,
+): Promise<string> {
+	const jwtKey = await masterKeyManager.getJwtKey();
+	const secret = jwtKey.toString('base64');
+	const now = Math.floor(Date.now() / 1000);
+	return sign(
+		{ member_id: memberId, company_id: companyId, iat: now, exp: now + 86400 * 30 },
+		secret,
+		'HS256',
+	);
+}

--- a/packages/server/src/middleware/auth.ts
+++ b/packages/server/src/middleware/auth.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto';
+import { createHash } from 'node:crypto';
 import { createMiddleware } from 'hono/factory';
 import { sign, verify } from 'hono/jwt';
 import type { Env } from '../lib/types';

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -1,0 +1,311 @@
+import { Hono } from 'hono';
+import { err, ok } from '../lib/response';
+import { toSlug } from '../lib/slug';
+import type { Env } from '../lib/types';
+
+export const agentsRoutes = new Hono<Env>();
+
+agentsRoutes.get('/companies/:companyId/agents', async (c) => {
+	const db = c.get('db');
+	const companyId = c.req.param('companyId');
+	const statusFilter = c.req.query('status');
+
+	let query = `
+    SELECT m.id, m.company_id, m.display_name, m.created_at,
+           ma.title, ma.slug, ma.role_description, ma.runtime_type,
+           ma.heartbeat_interval_min, ma.monthly_budget_cents, ma.budget_used_cents,
+           ma.budget_reset_at, ma.status, ma.last_heartbeat_at, ma.updated_at,
+           ma.reports_to,
+           (SELECT ma2.title FROM member_agents ma2 WHERE ma2.id = ma.reports_to) AS reports_to_title,
+           (SELECT count(*) FROM issues i WHERE i.assignee_id = m.id AND i.status NOT IN ('done', 'closed', 'cancelled'))::int AS assigned_issue_count
+    FROM members m
+    JOIN member_agents ma ON ma.id = m.id
+    WHERE m.company_id = $1`;
+	const params: unknown[] = [companyId];
+
+	if (statusFilter) {
+		const statuses = statusFilter.split(',').map((s) => s.trim());
+		const placeholders = statuses
+			.map((_, i) => `$${params.length + 1 + i}::agent_status`)
+			.join(', ');
+		query += ` AND ma.status IN (${placeholders})`;
+		params.push(...statuses);
+	}
+
+	query += ' ORDER BY ma.title ASC';
+
+	const result = await db.query(query, params);
+	return ok(c, result.rows);
+});
+
+agentsRoutes.post('/companies/:companyId/agents', async (c) => {
+	const db = c.get('db');
+	const companyId = c.req.param('companyId');
+
+	// Verify company exists
+	const companyCheck = await db.query('SELECT id FROM companies WHERE id = $1', [companyId]);
+	if (companyCheck.rows.length === 0) {
+		return err(c, 'NOT_FOUND', 'Company not found', 404);
+	}
+
+	const body = await c.req.json<{
+		title: string;
+		role_description?: string;
+		system_prompt?: string;
+		reports_to?: string;
+		runtime_type?: string;
+		heartbeat_interval_min?: number;
+		monthly_budget_cents?: number;
+		mcp_servers?: unknown[];
+	}>();
+
+	if (!body.title?.trim()) {
+		return err(c, 'INVALID_REQUEST', 'title is required', 400);
+	}
+
+	const slug = toSlug(body.title);
+
+	// Check slug uniqueness within company
+	const slugCheck = await db.query(
+		`SELECT ma.id FROM member_agents ma
+     JOIN members m ON m.id = ma.id
+     WHERE m.company_id = $1 AND ma.slug = $2`,
+		[companyId, slug],
+	);
+	if (slugCheck.rows.length > 0) {
+		return err(c, 'CONFLICT', `Agent with slug '${slug}' already exists in this company`, 409);
+	}
+
+	const memberResult = await db.query(
+		`INSERT INTO members (company_id, member_type, display_name)
+     VALUES ($1, 'agent', $2)
+     RETURNING id`,
+		[companyId, body.title.trim()],
+	);
+	const memberId = memberResult.rows[0].id;
+
+	await db.query(
+		`INSERT INTO member_agents (id, title, slug, role_description, system_prompt, reports_to, runtime_type, heartbeat_interval_min, monthly_budget_cents, mcp_servers)
+     VALUES ($1, $2, $3, $4, $5, $6, $7::agent_runtime, $8, $9, $10::jsonb)`,
+		[
+			memberId,
+			body.title.trim(),
+			slug,
+			body.role_description ?? '',
+			body.system_prompt ?? '',
+			body.reports_to ?? null,
+			body.runtime_type ?? 'claude_code',
+			body.heartbeat_interval_min ?? 60,
+			body.monthly_budget_cents ?? 3000,
+			JSON.stringify(body.mcp_servers ?? []),
+		],
+	);
+
+	// Fetch the created agent
+	const result = await db.query(
+		`SELECT m.id, m.company_id, m.display_name, m.created_at,
+            ma.title, ma.slug, ma.role_description, ma.system_prompt, ma.runtime_type,
+            ma.heartbeat_interval_min, ma.monthly_budget_cents, ma.budget_used_cents,
+            ma.status, ma.reports_to, ma.mcp_servers, ma.updated_at
+     FROM members m
+     JOIN member_agents ma ON ma.id = m.id
+     WHERE m.id = $1`,
+		[memberId],
+	);
+
+	return ok(c, result.rows[0], 201);
+});
+
+agentsRoutes.get('/companies/:companyId/agents/:agentId', async (c) => {
+	const db = c.get('db');
+	const result = await db.query(
+		`SELECT m.id, m.company_id, m.display_name, m.created_at,
+            ma.title, ma.slug, ma.role_description, ma.system_prompt, ma.runtime_type,
+            ma.heartbeat_interval_min, ma.monthly_budget_cents, ma.budget_used_cents,
+            ma.budget_reset_at, ma.status, ma.last_heartbeat_at, ma.reports_to,
+            ma.mcp_servers, ma.updated_at,
+            (SELECT ma2.title FROM member_agents ma2 WHERE ma2.id = ma.reports_to) AS reports_to_title,
+            (SELECT count(*) FROM issues i WHERE i.assignee_id = m.id AND i.status NOT IN ('done', 'closed', 'cancelled'))::int AS assigned_issue_count
+     FROM members m
+     JOIN member_agents ma ON ma.id = m.id
+     WHERE m.id = $1 AND m.company_id = $2`,
+		[c.req.param('agentId'), c.req.param('companyId')],
+	);
+
+	if (result.rows.length === 0) {
+		return err(c, 'NOT_FOUND', 'Agent not found', 404);
+	}
+
+	return ok(c, result.rows[0]);
+});
+
+agentsRoutes.patch('/companies/:companyId/agents/:agentId', async (c) => {
+	const db = c.get('db');
+	const agentId = c.req.param('agentId');
+	const companyId = c.req.param('companyId');
+
+	const existing = await db.query(
+		'SELECT m.id FROM members m JOIN member_agents ma ON ma.id = m.id WHERE m.id = $1 AND m.company_id = $2',
+		[agentId, companyId],
+	);
+	if (existing.rows.length === 0) {
+		return err(c, 'NOT_FOUND', 'Agent not found', 404);
+	}
+
+	const body = await c.req.json<{
+		title?: string;
+		role_description?: string;
+		system_prompt?: string;
+		reports_to?: string | null;
+		heartbeat_interval_min?: number;
+		monthly_budget_cents?: number;
+		mcp_servers?: unknown[];
+	}>();
+
+	const sets: string[] = [];
+	const params: unknown[] = [];
+	let idx = 1;
+
+	const addField = (field: string, value: unknown, jsonb = false) => {
+		if (value !== undefined) {
+			sets.push(`${field} = $${idx}${jsonb ? '::jsonb' : ''}`);
+			params.push(jsonb ? JSON.stringify(value) : value);
+			idx++;
+		}
+	};
+
+	addField('title', body.title?.trim());
+	addField('role_description', body.role_description);
+	addField('system_prompt', body.system_prompt);
+	addField('reports_to', body.reports_to);
+	addField('heartbeat_interval_min', body.heartbeat_interval_min);
+	addField('monthly_budget_cents', body.monthly_budget_cents);
+	addField('mcp_servers', body.mcp_servers, true);
+
+	if (sets.length === 0) {
+		const result = await db.query(
+			`SELECT m.*, ma.* FROM members m JOIN member_agents ma ON ma.id = m.id WHERE m.id = $1`,
+			[agentId],
+		);
+		return ok(c, result.rows[0]);
+	}
+
+	// Update display_name if title changed
+	if (body.title?.trim()) {
+		await db.query('UPDATE members SET display_name = $1 WHERE id = $2', [
+			body.title.trim(),
+			agentId,
+		]);
+	}
+
+	params.push(agentId);
+	const result = await db.query(
+		`UPDATE member_agents SET ${sets.join(', ')} WHERE id = $${idx} RETURNING *`,
+		params,
+	);
+
+	return ok(c, result.rows[0]);
+});
+
+// Lifecycle endpoints
+agentsRoutes.post('/companies/:companyId/agents/:agentId/pause', async (c) => {
+	return changeAgentStatus(c, 'paused', ['active']);
+});
+
+agentsRoutes.post('/companies/:companyId/agents/:agentId/resume', async (c) => {
+	return changeAgentStatus(c, 'idle', ['paused']);
+});
+
+agentsRoutes.post('/companies/:companyId/agents/:agentId/terminate', async (c) => {
+	const db = c.get('db');
+	const agentId = c.req.param('agentId');
+	const companyId = c.req.param('companyId');
+
+	const existing = await db.query<{ status: string }>(
+		'SELECT ma.status FROM members m JOIN member_agents ma ON ma.id = m.id WHERE m.id = $1 AND m.company_id = $2',
+		[agentId, companyId],
+	);
+	if (existing.rows.length === 0) {
+		return err(c, 'NOT_FOUND', 'Agent not found', 404);
+	}
+	if (existing.rows[0].status === 'terminated') {
+		return err(c, 'INVALID_STATE', 'Agent is already terminated', 409);
+	}
+
+	await db.query("UPDATE member_agents SET status = 'terminated'::agent_status WHERE id = $1", [
+		agentId,
+	]);
+
+	// Unassign all open issues
+	await db.query(
+		"UPDATE issues SET assignee_id = NULL WHERE assignee_id = $1 AND status NOT IN ('done', 'closed', 'cancelled')",
+		[agentId],
+	);
+
+	return ok(c, { status: 'terminated' });
+});
+
+// Org chart
+agentsRoutes.get('/companies/:companyId/org-chart', async (c) => {
+	const db = c.get('db');
+	const companyId = c.req.param('companyId');
+
+	const result = await db.query(
+		`SELECT m.id, ma.title, ma.slug, ma.status, ma.reports_to
+     FROM members m
+     JOIN member_agents ma ON ma.id = m.id
+     WHERE m.company_id = $1`,
+		[companyId],
+	);
+
+	const agents = result.rows as {
+		id: string;
+		title: string;
+		slug: string;
+		status: string;
+		reports_to: string | null;
+	}[];
+	const byId = new Map(agents.map((a) => [a.id, { ...a, children: [] as any[] }]));
+
+	const roots: any[] = [];
+	for (const agent of byId.values()) {
+		if (agent.reports_to && byId.has(agent.reports_to)) {
+			byId.get(agent.reports_to)!.children.push(agent);
+		} else {
+			roots.push(agent);
+		}
+	}
+
+	return ok(c, { board: { children: roots } });
+});
+
+async function changeAgentStatus(c: any, newStatus: string, validFrom: string[]) {
+	const db = c.get('db');
+	const agentId = c.req.param('agentId');
+	const companyId = c.req.param('companyId');
+
+	const existing = await db.query<{ status: string }>(
+		'SELECT ma.status FROM members m JOIN member_agents ma ON ma.id = m.id WHERE m.id = $1 AND m.company_id = $2',
+		[agentId, companyId],
+	);
+
+	if (existing.rows.length === 0) {
+		return err(c, 'NOT_FOUND', 'Agent not found', 404);
+	}
+
+	if (!validFrom.includes(existing.rows[0].status)) {
+		return err(
+			c,
+			'INVALID_STATE',
+			`Cannot transition from '${existing.rows[0].status}' to '${newStatus}'`,
+			409,
+		);
+	}
+
+	await db.query(`UPDATE member_agents SET status = $1::agent_status WHERE id = $2`, [
+		newStatus,
+		agentId,
+	]);
+
+	return ok(c, { status: newStatus });
+}

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -76,7 +76,7 @@ agentsRoutes.post('/companies/:companyId/agents', async (c) => {
 		return err(c, 'CONFLICT', `Agent with slug '${slug}' already exists in this company`, 409);
 	}
 
-	const memberResult = await db.query(
+	const memberResult = await db.query<{ id: string }>(
 		`INSERT INTO members (company_id, member_type, display_name)
      VALUES ($1, 'agent', $2)
      RETURNING id`,
@@ -270,7 +270,7 @@ agentsRoutes.get('/companies/:companyId/org-chart', async (c) => {
 	const roots: any[] = [];
 	for (const agent of byId.values()) {
 		if (agent.reports_to && byId.has(agent.reports_to)) {
-			byId.get(agent.reports_to)!.children.push(agent);
+			byId.get(agent.reports_to)?.children.push(agent);
 		} else {
 			roots.push(agent);
 		}
@@ -279,7 +279,11 @@ agentsRoutes.get('/companies/:companyId/org-chart', async (c) => {
 	return ok(c, { board: { children: roots } });
 });
 
-async function changeAgentStatus(c: any, newStatus: string, validFrom: string[]) {
+async function changeAgentStatus(
+	c: import('hono').Context<Env>,
+	newStatus: string,
+	validFrom: string[],
+) {
 	const db = c.get('db');
 	const agentId = c.req.param('agentId');
 	const companyId = c.req.param('companyId');

--- a/packages/server/src/routes/api-keys.ts
+++ b/packages/server/src/routes/api-keys.ts
@@ -1,0 +1,64 @@
+import { createHash, randomBytes } from 'crypto';
+import { Hono } from 'hono';
+import { err, ok } from '../lib/response';
+import type { Env } from '../lib/types';
+
+export const apiKeysRoutes = new Hono<Env>();
+
+function hashKey(key: string): string {
+	return createHash('sha256').update(key).digest('hex');
+}
+
+apiKeysRoutes.get('/companies/:companyId/api-keys', async (c) => {
+	const db = c.get('db');
+	const result = await db.query(
+		`SELECT id, company_id, name, prefix, last_used_at, created_at
+     FROM api_keys
+     WHERE company_id = $1
+     ORDER BY created_at DESC`,
+		[c.req.param('companyId')],
+	);
+	return ok(c, result.rows);
+});
+
+apiKeysRoutes.post('/companies/:companyId/api-keys', async (c) => {
+	const db = c.get('db');
+	const companyId = c.req.param('companyId');
+
+	const body = await c.req.json<{ name: string }>();
+	if (!body.name?.trim()) {
+		return err(c, 'INVALID_REQUEST', 'name is required', 400);
+	}
+
+	// Generate key: hezo_ + 32 random hex chars
+	const rawKey = `hezo_${randomBytes(16).toString('hex')}`;
+	const prefix = rawKey.slice(5, 13); // 8 chars after hezo_
+	const keyHash = hashKey(rawKey);
+
+	const result = await db.query(
+		`INSERT INTO api_keys (company_id, name, prefix, key_hash)
+     VALUES ($1, $2, $3, $4)
+     RETURNING id, company_id, name, prefix, created_at`,
+		[companyId, body.name.trim(), prefix, keyHash],
+	);
+
+	// Return the raw key once
+	return ok(c, { ...result.rows[0], key: rawKey }, 201);
+});
+
+apiKeysRoutes.delete('/companies/:companyId/api-keys/:apiKeyId', async (c) => {
+	const db = c.get('db');
+	const apiKeyId = c.req.param('apiKeyId');
+	const companyId = c.req.param('companyId');
+
+	const existing = await db.query('SELECT id FROM api_keys WHERE id = $1 AND company_id = $2', [
+		apiKeyId,
+		companyId,
+	]);
+	if (existing.rows.length === 0) {
+		return err(c, 'NOT_FOUND', 'API key not found', 404);
+	}
+
+	await db.query('DELETE FROM api_keys WHERE id = $1', [apiKeyId]);
+	return c.json({ data: null }, 200);
+});

--- a/packages/server/src/routes/api-keys.ts
+++ b/packages/server/src/routes/api-keys.ts
@@ -1,4 +1,4 @@
-import { createHash, randomBytes } from 'crypto';
+import { createHash, randomBytes } from 'node:crypto';
 import { Hono } from 'hono';
 import { err, ok } from '../lib/response';
 import type { Env } from '../lib/types';
@@ -35,7 +35,13 @@ apiKeysRoutes.post('/companies/:companyId/api-keys', async (c) => {
 	const prefix = rawKey.slice(5, 13); // 8 chars after hezo_
 	const keyHash = hashKey(rawKey);
 
-	const result = await db.query(
+	const result = await db.query<{
+		id: string;
+		company_id: string;
+		name: string;
+		prefix: string;
+		created_at: string;
+	}>(
 		`INSERT INTO api_keys (company_id, name, prefix, key_hash)
      VALUES ($1, $2, $3, $4)
      RETURNING id, company_id, name, prefix, created_at`,

--- a/packages/server/src/routes/approvals.ts
+++ b/packages/server/src/routes/approvals.ts
@@ -1,0 +1,88 @@
+import { Hono } from 'hono';
+import { err, ok } from '../lib/response';
+import type { Env } from '../lib/types';
+
+export const approvalsRoutes = new Hono<Env>();
+
+approvalsRoutes.get('/companies/:companyId/approvals', async (c) => {
+	const db = c.get('db');
+	const companyId = c.req.param('companyId');
+	const statusFilter = c.req.query('status') || 'pending';
+
+	const result = await db.query(
+		`SELECT a.id, a.company_id, a.type, a.status, a.payload, a.resolution_note,
+            a.resolved_at, a.created_at,
+            co.name AS company_name,
+            COALESCE(ma.title, m.display_name) AS requested_by_name,
+            a.requested_by_member_id
+     FROM approvals a
+     JOIN companies co ON co.id = a.company_id
+     LEFT JOIN members m ON m.id = a.requested_by_member_id
+     LEFT JOIN member_agents ma ON ma.id = a.requested_by_member_id
+     WHERE a.company_id = $1 AND a.status IN (${statusFilter
+				.split(',')
+				.map((_, i) => `$${i + 2}::approval_status`)
+				.join(', ')})
+     ORDER BY a.created_at DESC`,
+		[companyId, ...statusFilter.split(',').map((s) => s.trim())],
+	);
+
+	return ok(c, result.rows);
+});
+
+approvalsRoutes.post('/companies/:companyId/approvals', async (c) => {
+	const db = c.get('db');
+	const companyId = c.req.param('companyId');
+
+	const body = await c.req.json<{
+		type: string;
+		requested_by_member_id: string;
+		payload: Record<string, unknown>;
+	}>();
+
+	if (!body.type || !body.requested_by_member_id || !body.payload) {
+		return err(c, 'INVALID_REQUEST', 'type, requested_by_member_id, and payload are required', 400);
+	}
+
+	const result = await db.query(
+		`INSERT INTO approvals (company_id, type, requested_by_member_id, payload)
+     VALUES ($1, $2::approval_type, $3, $4::jsonb)
+     RETURNING *`,
+		[companyId, body.type, body.requested_by_member_id, JSON.stringify(body.payload)],
+	);
+
+	return ok(c, result.rows[0], 201);
+});
+
+approvalsRoutes.post('/approvals/:approvalId/resolve', async (c) => {
+	const db = c.get('db');
+	const approvalId = c.req.param('approvalId');
+
+	const existing = await db.query<{ status: string }>(
+		'SELECT status FROM approvals WHERE id = $1',
+		[approvalId],
+	);
+	if (existing.rows.length === 0) {
+		return err(c, 'NOT_FOUND', 'Approval not found', 404);
+	}
+	if (existing.rows[0].status !== 'pending') {
+		return err(c, 'INVALID_STATE', 'Approval is already resolved', 409);
+	}
+
+	const body = await c.req.json<{
+		status: 'approved' | 'denied';
+		resolution_note?: string;
+	}>();
+
+	if (!['approved', 'denied'].includes(body.status)) {
+		return err(c, 'INVALID_REQUEST', "status must be 'approved' or 'denied'", 400);
+	}
+
+	const result = await db.query(
+		`UPDATE approvals SET status = $1::approval_status, resolution_note = $2, resolved_at = now()
+     WHERE id = $3 RETURNING *`,
+		[body.status, body.resolution_note ?? null, approvalId],
+	);
+
+	return ok(c, result.rows[0]);
+});

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -1,0 +1,26 @@
+import { Hono } from 'hono';
+import { err, ok } from '../lib/response';
+import type { Env } from '../lib/types';
+import { signBoardJwt } from '../middleware/auth';
+
+export const authRoutes = new Hono<Env>();
+
+// Bootstrap endpoint: exchange master key for a board JWT (Phase 2 dev convenience)
+authRoutes.post('/auth/token', async (c) => {
+	const body = await c.req.json<{ master_key?: string }>();
+
+	if (!body.master_key) {
+		return err(c, 'INVALID_REQUEST', 'master_key is required', 400);
+	}
+
+	const masterKeyManager = c.get('masterKeyManager');
+	const db = c.get('db');
+	const unlocked = await masterKeyManager.unlock(db, body.master_key);
+
+	if (!unlocked) {
+		return err(c, 'UNAUTHORIZED', 'Invalid master key', 401);
+	}
+
+	const token = await signBoardJwt(masterKeyManager, 'board-bootstrap');
+	return ok(c, { token }, 200);
+});

--- a/packages/server/src/routes/comments.ts
+++ b/packages/server/src/routes/comments.ts
@@ -1,0 +1,115 @@
+import { Hono } from 'hono';
+import { err, ok } from '../lib/response';
+import type { Env } from '../lib/types';
+
+export const commentsRoutes = new Hono<Env>();
+
+commentsRoutes.get('/companies/:companyId/issues/:issueId/comments', async (c) => {
+	const db = c.get('db');
+	const issueId = c.req.param('issueId');
+	const includeToolCalls = c.req.query('include_tool_calls') === 'true';
+
+	const result = await db.query(
+		`SELECT ic.id, ic.issue_id, ic.content_type, ic.content, ic.chosen_option, ic.created_at,
+            m.member_type AS author_type,
+            COALESCE(ma.title, m.display_name) AS author_name,
+            ic.author_member_id
+     FROM issue_comments ic
+     LEFT JOIN members m ON m.id = ic.author_member_id
+     LEFT JOIN member_agents ma ON ma.id = ic.author_member_id
+     WHERE ic.issue_id = $1
+     ORDER BY ic.created_at ASC`,
+		[issueId],
+	);
+
+	if (includeToolCalls) {
+		for (const comment of result.rows as any[]) {
+			if (comment.content_type === 'trace') {
+				const toolCalls = await db.query(
+					'SELECT * FROM tool_calls WHERE comment_id = $1 ORDER BY created_at ASC',
+					[comment.id],
+				);
+				comment.tool_calls = toolCalls.rows;
+			} else {
+				comment.tool_calls = [];
+			}
+		}
+	}
+
+	return ok(c, result.rows);
+});
+
+commentsRoutes.post('/companies/:companyId/issues/:issueId/comments', async (c) => {
+	const db = c.get('db');
+	const issueId = c.req.param('issueId');
+	const auth = c.get('auth');
+
+	const body = await c.req.json<{
+		content_type?: string;
+		content: Record<string, unknown>;
+	}>();
+
+	if (!body.content) {
+		return err(c, 'INVALID_REQUEST', 'content is required', 400);
+	}
+
+	// Find the board member for this company (if board auth)
+	let authorMemberId: string | null = null;
+	if (auth.type === 'board') {
+		// For board users, author_member_id is null (board post)
+		authorMemberId = null;
+	} else if (auth.type === 'agent') {
+		authorMemberId = auth.memberId;
+	}
+
+	const result = await db.query(
+		`INSERT INTO issue_comments (issue_id, author_member_id, content_type, content)
+     VALUES ($1, $2, $3::comment_content_type, $4::jsonb)
+     RETURNING *`,
+		[issueId, authorMemberId, body.content_type ?? 'text', JSON.stringify(body.content)],
+	);
+
+	return ok(c, result.rows[0], 201);
+});
+
+commentsRoutes.post(
+	'/companies/:companyId/issues/:issueId/comments/:commentId/choose',
+	async (c) => {
+		const db = c.get('db');
+		const commentId = c.req.param('commentId');
+
+		const body = await c.req.json<{ chosen_id: string }>();
+		if (!body.chosen_id) {
+			return err(c, 'INVALID_REQUEST', 'chosen_id is required', 400);
+		}
+
+		// Verify it's an options-type comment
+		const existing = await db.query<{ content_type: string; issue_id: string }>(
+			'SELECT content_type, issue_id FROM issue_comments WHERE id = $1',
+			[commentId],
+		);
+		if (existing.rows.length === 0) {
+			return err(c, 'NOT_FOUND', 'Comment not found', 404);
+		}
+		if (existing.rows[0].content_type !== 'options') {
+			return err(c, 'INVALID_REQUEST', 'Can only choose on options-type comments', 400);
+		}
+
+		const result = await db.query(
+			'UPDATE issue_comments SET chosen_option = $1::jsonb WHERE id = $2 RETURNING *',
+			[JSON.stringify({ chosen_id: body.chosen_id }), commentId],
+		);
+
+		// Post a system comment recording the choice
+		await db.query(
+			`INSERT INTO issue_comments (issue_id, content_type, content)
+       VALUES ($1, 'system'::comment_content_type, $2::jsonb)`,
+			[
+				existing.rows[0].issue_id,
+				JSON.stringify({ text: `Board selected option: ${body.chosen_id}` }),
+			],
+		);
+
+		return ok(c, result.rows[0]);
+	},
+);

--- a/packages/server/src/routes/companies.ts
+++ b/packages/server/src/routes/companies.ts
@@ -1,0 +1,231 @@
+import { Hono } from 'hono';
+import { err, ok } from '../lib/response';
+import { toIssuePrefix } from '../lib/slug';
+import type { Env } from '../lib/types';
+
+export const companiesRoutes = new Hono<Env>();
+
+companiesRoutes.get('/companies', async (c) => {
+	const db = c.get('db');
+	const result = await db.query(
+		`SELECT c.*,
+       (SELECT count(*) FROM members m WHERE m.company_id = c.id AND m.member_type = 'agent')::int AS agent_count,
+       (SELECT count(*) FROM issues i WHERE i.company_id = c.id AND i.status NOT IN ('done', 'closed', 'cancelled'))::int AS open_issue_count
+     FROM companies c
+     ORDER BY c.created_at DESC`,
+	);
+	return ok(c, result.rows);
+});
+
+companiesRoutes.post('/companies', async (c) => {
+	const body = await c.req.json<{
+		name: string;
+		mission?: string;
+		company_type_id?: string;
+		issue_prefix?: string;
+		email?: string;
+	}>();
+
+	if (!body.name?.trim()) {
+		return err(c, 'INVALID_REQUEST', 'name is required', 400);
+	}
+
+	const db = c.get('db');
+	const issuePrefix = body.issue_prefix?.trim() || toIssuePrefix(body.name);
+
+	// Check prefix uniqueness
+	const prefixCheck = await db.query('SELECT id FROM companies WHERE issue_prefix = $1', [
+		issuePrefix,
+	]);
+	if (prefixCheck.rows.length > 0) {
+		return err(c, 'CONFLICT', `Issue prefix '${issuePrefix}' is already in use`, 409);
+	}
+
+	const companyResult = await db.query(
+		`INSERT INTO companies (name, mission, company_type_id, issue_prefix, email)
+     VALUES ($1, $2, $3, $4, $5)
+     RETURNING *`,
+		[
+			body.name.trim(),
+			body.mission ?? '',
+			body.company_type_id ?? null,
+			issuePrefix,
+			body.email ?? null,
+		],
+	);
+	const company = companyResult.rows[0] as any;
+
+	// Initialize issue counter
+	await db.query('INSERT INTO company_issue_counters (company_id, next_number) VALUES ($1, 1)', [
+		company.id,
+	]);
+
+	// Auto-create agents from company type
+	if (body.company_type_id) {
+		const typeResult = await db.query<{ agents_config: any }>(
+			'SELECT agents_config FROM company_types WHERE id = $1',
+			[body.company_type_id],
+		);
+
+		if (typeResult.rows.length > 0) {
+			const agentsConfig = typeResult.rows[0].agents_config;
+			if (Array.isArray(agentsConfig) && agentsConfig.length > 0) {
+				await createAgentsFromConfig(db, company.id, agentsConfig);
+			}
+		}
+	}
+
+	// Re-fetch with counts
+	const result = await db.query(
+		`SELECT c.*,
+       (SELECT count(*) FROM members m WHERE m.company_id = c.id AND m.member_type = 'agent')::int AS agent_count,
+       0 AS open_issue_count
+     FROM companies c WHERE c.id = $1`,
+		[company.id],
+	);
+
+	return ok(c, result.rows[0], 201);
+});
+
+companiesRoutes.get('/companies/:companyId', async (c) => {
+	const db = c.get('db');
+	const result = await db.query(
+		`SELECT c.*,
+       (SELECT count(*) FROM members m WHERE m.company_id = c.id AND m.member_type = 'agent')::int AS agent_count,
+       (SELECT count(*) FROM issues i WHERE i.company_id = c.id AND i.status NOT IN ('done', 'closed', 'cancelled'))::int AS open_issue_count
+     FROM companies c WHERE c.id = $1`,
+		[c.req.param('companyId')],
+	);
+
+	if (result.rows.length === 0) {
+		return err(c, 'NOT_FOUND', 'Company not found', 404);
+	}
+
+	return ok(c, result.rows[0]);
+});
+
+companiesRoutes.patch('/companies/:companyId', async (c) => {
+	const db = c.get('db');
+	const id = c.req.param('companyId');
+
+	const existing = await db.query('SELECT id FROM companies WHERE id = $1', [id]);
+	if (existing.rows.length === 0) {
+		return err(c, 'NOT_FOUND', 'Company not found', 404);
+	}
+
+	const body = await c.req.json<{
+		name?: string;
+		mission?: string;
+		email?: string;
+		mcp_servers?: unknown[];
+		mpp_config?: Record<string, unknown>;
+	}>();
+
+	const sets: string[] = [];
+	const params: unknown[] = [];
+	let idx = 1;
+
+	const addField = (field: string, value: unknown, jsonb = false) => {
+		if (value !== undefined) {
+			sets.push(`${field} = $${idx}${jsonb ? '::jsonb' : ''}`);
+			params.push(jsonb ? JSON.stringify(value) : value);
+			idx++;
+		}
+	};
+
+	addField('name', body.name?.trim());
+	addField('mission', body.mission);
+	addField('email', body.email);
+	addField('mcp_servers', body.mcp_servers, true);
+	addField('mpp_config', body.mpp_config, true);
+
+	if (sets.length === 0) {
+		const result = await db.query('SELECT * FROM companies WHERE id = $1', [id]);
+		return ok(c, result.rows[0]);
+	}
+
+	params.push(id);
+	const result = await db.query(
+		`UPDATE companies SET ${sets.join(', ')} WHERE id = $${idx} RETURNING *`,
+		params,
+	);
+
+	return ok(c, result.rows[0]);
+});
+
+companiesRoutes.delete('/companies/:companyId', async (c) => {
+	const db = c.get('db');
+	const id = c.req.param('companyId');
+
+	const existing = await db.query('SELECT id FROM companies WHERE id = $1', [id]);
+	if (existing.rows.length === 0) {
+		return err(c, 'NOT_FOUND', 'Company not found', 404);
+	}
+
+	await db.query('DELETE FROM companies WHERE id = $1', [id]);
+	return c.json({ data: null }, 200);
+});
+
+interface AgentConfig {
+	title: string;
+	slug: string;
+	reports_to_slug: string | null;
+	runtime_type: string;
+	heartbeat_interval_min: number;
+	monthly_budget_cents: number;
+	role_description: string;
+	status: string;
+	system_prompt?: string;
+}
+
+async function createAgentsFromConfig(
+	db: any,
+	companyId: string,
+	agentsConfig: AgentConfig[],
+): Promise<void> {
+	// Pass 1: Create all members and agents with reports_to = NULL
+	const slugToMemberId = new Map<string, string>();
+
+	for (const agent of agentsConfig) {
+		const memberResult = await db.query(
+			`INSERT INTO members (company_id, member_type, display_name)
+       VALUES ($1, 'agent', $2)
+       RETURNING id`,
+			[companyId, agent.title],
+		);
+		const memberId = memberResult.rows[0].id;
+		slugToMemberId.set(agent.slug, memberId);
+
+		await db.query(
+			`INSERT INTO member_agents (id, title, slug, role_description, system_prompt, runtime_type, heartbeat_interval_min, monthly_budget_cents, status)
+       VALUES ($1, $2, $3, $4, $5, $6::agent_runtime, $7, $8, $9::agent_status)`,
+			[
+				memberId,
+				agent.title,
+				agent.slug,
+				agent.role_description ?? '',
+				agent.system_prompt ?? '',
+				agent.runtime_type ?? 'claude_code',
+				agent.heartbeat_interval_min ?? 60,
+				agent.monthly_budget_cents ?? 3000,
+				agent.status ?? 'active',
+			],
+		);
+	}
+
+	// Pass 2: Update reports_to references
+	for (const agent of agentsConfig) {
+		if (agent.reports_to_slug && agent.reports_to_slug !== 'board') {
+			const reportsToId = slugToMemberId.get(agent.reports_to_slug);
+			if (reportsToId) {
+				const memberId = slugToMemberId.get(agent.slug);
+				await db.query('UPDATE member_agents SET reports_to = $1 WHERE id = $2', [
+					reportsToId,
+					memberId,
+				]);
+			}
+		}
+	}
+}
+
+export { createAgentsFromConfig };

--- a/packages/server/src/routes/company-types.ts
+++ b/packages/server/src/routes/company-types.ts
@@ -1,0 +1,129 @@
+import { Hono } from 'hono';
+import { err, ok } from '../lib/response';
+import type { Env } from '../lib/types';
+
+export const companyTypesRoutes = new Hono<Env>();
+
+companyTypesRoutes.get('/company-types', async (c) => {
+	const db = c.get('db');
+	const result = await db.query('SELECT * FROM company_types ORDER BY is_builtin DESC, name ASC');
+	return ok(c, result.rows);
+});
+
+companyTypesRoutes.post('/company-types', async (c) => {
+	const body = await c.req.json<{
+		name: string;
+		description?: string;
+		agents_config?: unknown[];
+		kb_docs_config?: unknown[];
+		preferences_config?: Record<string, unknown>;
+		mcp_servers?: unknown[];
+		mpp_config?: Record<string, unknown>;
+	}>();
+
+	if (!body.name?.trim()) {
+		return err(c, 'INVALID_REQUEST', 'name is required', 400);
+	}
+
+	const db = c.get('db');
+	const result = await db.query(
+		`INSERT INTO company_types (name, description, agents_config, kb_docs_config, preferences_config, mcp_servers, mpp_config)
+     VALUES ($1, $2, $3::jsonb, $4::jsonb, $5::jsonb, $6::jsonb, $7::jsonb)
+     RETURNING *`,
+		[
+			body.name.trim(),
+			body.description ?? '',
+			JSON.stringify(body.agents_config ?? []),
+			JSON.stringify(body.kb_docs_config ?? []),
+			JSON.stringify(body.preferences_config ?? {}),
+			JSON.stringify(body.mcp_servers ?? []),
+			JSON.stringify(body.mpp_config ?? { enabled: false }),
+		],
+	);
+
+	return ok(c, result.rows[0], 201);
+});
+
+companyTypesRoutes.get('/company-types/:id', async (c) => {
+	const db = c.get('db');
+	const result = await db.query('SELECT * FROM company_types WHERE id = $1', [c.req.param('id')]);
+
+	if (result.rows.length === 0) {
+		return err(c, 'NOT_FOUND', 'Company type not found', 404);
+	}
+
+	return ok(c, result.rows[0]);
+});
+
+companyTypesRoutes.patch('/company-types/:id', async (c) => {
+	const db = c.get('db');
+	const id = c.req.param('id');
+
+	const existing = await db.query('SELECT * FROM company_types WHERE id = $1', [id]);
+	if (existing.rows.length === 0) {
+		return err(c, 'NOT_FOUND', 'Company type not found', 404);
+	}
+
+	const body = await c.req.json<{
+		name?: string;
+		description?: string;
+		agents_config?: unknown[];
+		kb_docs_config?: unknown[];
+		preferences_config?: Record<string, unknown>;
+		mcp_servers?: unknown[];
+		mpp_config?: Record<string, unknown>;
+	}>();
+
+	const sets: string[] = [];
+	const params: unknown[] = [];
+	let idx = 1;
+
+	const addField = (field: string, value: unknown, jsonb = false) => {
+		if (value !== undefined) {
+			sets.push(`${field} = $${idx}${jsonb ? '::jsonb' : ''}`);
+			params.push(jsonb ? JSON.stringify(value) : value);
+			idx++;
+		}
+	};
+
+	addField('name', body.name?.trim());
+	addField('description', body.description);
+	addField('agents_config', body.agents_config, true);
+	addField('kb_docs_config', body.kb_docs_config, true);
+	addField('preferences_config', body.preferences_config, true);
+	addField('mcp_servers', body.mcp_servers, true);
+	addField('mpp_config', body.mpp_config, true);
+
+	if (sets.length === 0) {
+		return ok(c, existing.rows[0]);
+	}
+
+	params.push(id);
+	const result = await db.query(
+		`UPDATE company_types SET ${sets.join(', ')}, updated_at = now() WHERE id = $${idx} RETURNING *`,
+		params,
+	);
+
+	return ok(c, result.rows[0]);
+});
+
+companyTypesRoutes.delete('/company-types/:id', async (c) => {
+	const db = c.get('db');
+	const id = c.req.param('id');
+
+	const existing = await db.query<{ is_builtin: boolean }>(
+		'SELECT is_builtin FROM company_types WHERE id = $1',
+		[id],
+	);
+
+	if (existing.rows.length === 0) {
+		return err(c, 'NOT_FOUND', 'Company type not found', 404);
+	}
+
+	if (existing.rows[0].is_builtin) {
+		return err(c, 'FORBIDDEN', 'Cannot delete built-in company types', 403);
+	}
+
+	await db.query('DELETE FROM company_types WHERE id = $1', [id]);
+	return c.json({ data: null }, 200);
+});

--- a/packages/server/src/routes/costs.ts
+++ b/packages/server/src/routes/costs.ts
@@ -1,0 +1,142 @@
+import { Hono } from 'hono';
+import { err, ok } from '../lib/response';
+import type { Env } from '../lib/types';
+
+export const costsRoutes = new Hono<Env>();
+
+costsRoutes.get('/companies/:companyId/costs', async (c) => {
+	const db = c.get('db');
+	const companyId = c.req.param('companyId');
+	const agentId = c.req.query('agent_id');
+	const projectId = c.req.query('project_id');
+	const issueId = c.req.query('issue_id');
+	const from = c.req.query('from');
+	const to = c.req.query('to');
+	const groupBy = c.req.query('group_by');
+
+	const conditions: string[] = ['ce.company_id = $1'];
+	const params: unknown[] = [companyId];
+	let idx = 2;
+
+	if (agentId) {
+		conditions.push(`ce.member_id = $${idx}`);
+		params.push(agentId);
+		idx++;
+	}
+	if (projectId) {
+		conditions.push(`ce.project_id = $${idx}`);
+		params.push(projectId);
+		idx++;
+	}
+	if (issueId) {
+		conditions.push(`ce.issue_id = $${idx}`);
+		params.push(issueId);
+		idx++;
+	}
+	if (from) {
+		conditions.push(`ce.created_at >= $${idx}`);
+		params.push(from);
+		idx++;
+	}
+	if (to) {
+		conditions.push(`ce.created_at <= $${idx}`);
+		params.push(to);
+		idx++;
+	}
+
+	const where = conditions.join(' AND ');
+
+	if (groupBy === 'agent') {
+		const result = await db.query(
+			`SELECT ce.member_id AS agent_id,
+              COALESCE(ma.title, m.display_name) AS agent_title,
+              sum(ce.amount_cents)::int AS total_cents
+       FROM cost_entries ce
+       LEFT JOIN members m ON m.id = ce.member_id
+       LEFT JOIN member_agents ma ON ma.id = ce.member_id
+       WHERE ${where}
+       GROUP BY ce.member_id, ma.title, m.display_name`,
+			params,
+		);
+		const totalCents = result.rows.reduce((sum: number, r: any) => sum + r.total_cents, 0);
+		return ok(c, { summary: result.rows, total_cents: totalCents });
+	}
+
+	if (groupBy === 'project') {
+		const result = await db.query(
+			`SELECT ce.project_id, p.name AS project_name,
+              sum(ce.amount_cents)::int AS total_cents
+       FROM cost_entries ce
+       LEFT JOIN projects p ON p.id = ce.project_id
+       WHERE ${where}
+       GROUP BY ce.project_id, p.name`,
+			params,
+		);
+		const totalCents = result.rows.reduce((sum: number, r: any) => sum + r.total_cents, 0);
+		return ok(c, { summary: result.rows, total_cents: totalCents });
+	}
+
+	if (groupBy === 'day') {
+		const result = await db.query(
+			`SELECT date_trunc('day', ce.created_at)::date AS day,
+              sum(ce.amount_cents)::int AS total_cents
+       FROM cost_entries ce
+       WHERE ${where}
+       GROUP BY day ORDER BY day`,
+			params,
+		);
+		const totalCents = result.rows.reduce((sum: number, r: any) => sum + r.total_cents, 0);
+		return ok(c, { summary: result.rows, total_cents: totalCents });
+	}
+
+	// Default: list entries
+	const result = await db.query(
+		`SELECT ce.* FROM cost_entries ce WHERE ${where} ORDER BY ce.created_at DESC`,
+		params,
+	);
+	const totalCents = result.rows.reduce((sum: number, r: any) => sum + r.amount_cents, 0);
+	return ok(c, { entries: result.rows, total_cents: totalCents });
+});
+
+costsRoutes.post('/companies/:companyId/costs', async (c) => {
+	const db = c.get('db');
+	const companyId = c.req.param('companyId');
+
+	const body = await c.req.json<{
+		member_id: string;
+		amount_cents: number;
+		issue_id?: string;
+		project_id?: string;
+		description?: string;
+	}>();
+
+	if (!body.member_id || body.amount_cents == null || body.amount_cents <= 0) {
+		return err(c, 'INVALID_REQUEST', 'member_id and positive amount_cents are required', 400);
+	}
+
+	// Attempt budget debit
+	const debitResult = await db.query<{ debit_agent_budget: boolean }>(
+		'SELECT debit_agent_budget($1, $2)',
+		[body.member_id, body.amount_cents],
+	);
+
+	if (!debitResult.rows[0].debit_agent_budget) {
+		return err(c, 'BUDGET_EXCEEDED', 'Agent or company budget exceeded', 402);
+	}
+
+	const result = await db.query(
+		`INSERT INTO cost_entries (company_id, member_id, issue_id, project_id, amount_cents, description)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     RETURNING *`,
+		[
+			companyId,
+			body.member_id,
+			body.issue_id ?? null,
+			body.project_id ?? null,
+			body.amount_cents,
+			body.description ?? '',
+		],
+	);
+
+	return ok(c, result.rows[0], 201);
+});

--- a/packages/server/src/routes/health.ts
+++ b/packages/server/src/routes/health.ts
@@ -1,5 +1,5 @@
-import { Hono } from "hono";
+import { Hono } from 'hono';
 
 export const healthRoutes = new Hono();
 
-healthRoutes.get("/health", (c) => c.json({ ok: true }));
+healthRoutes.get('/health', (c) => c.json({ ok: true }));

--- a/packages/server/src/routes/issues.ts
+++ b/packages/server/src/routes/issues.ts
@@ -1,0 +1,381 @@
+import { Hono } from 'hono';
+import { buildMeta, parsePagination } from '../lib/pagination';
+import { err, ok } from '../lib/response';
+import type { Env } from '../lib/types';
+
+export const issuesRoutes = new Hono<Env>();
+
+issuesRoutes.get('/companies/:companyId/issues', async (c) => {
+	const db = c.get('db');
+	const companyId = c.req.param('companyId');
+	const { page, perPage, offset } = parsePagination(c);
+
+	const conditions: string[] = ['i.company_id = $1'];
+	const params: unknown[] = [companyId];
+	let idx = 2;
+
+	const projectId = c.req.query('project_id');
+	if (projectId) {
+		conditions.push(`i.project_id = $${idx}`);
+		params.push(projectId);
+		idx++;
+	}
+
+	const assigneeId = c.req.query('assignee_id');
+	if (assigneeId) {
+		conditions.push(`i.assignee_id = $${idx}`);
+		params.push(assigneeId);
+		idx++;
+	}
+
+	const statusFilter = c.req.query('status');
+	if (statusFilter) {
+		const statuses = statusFilter.split(',').map((s) => s.trim());
+		const placeholders = statuses.map((_, i) => `$${idx + i}::issue_status`).join(', ');
+		conditions.push(`i.status IN (${placeholders})`);
+		params.push(...statuses);
+		idx += statuses.length;
+	}
+
+	const priorityFilter = c.req.query('priority');
+	if (priorityFilter) {
+		const priorities = priorityFilter.split(',').map((s) => s.trim());
+		const placeholders = priorities.map((_, i) => `$${idx + i}::issue_priority`).join(', ');
+		conditions.push(`i.priority IN (${placeholders})`);
+		params.push(...priorities);
+		idx += priorities.length;
+	}
+
+	const search = c.req.query('search');
+	if (search) {
+		conditions.push(`(i.title ILIKE $${idx} OR i.description ILIKE $${idx})`);
+		params.push(`%${search}%`);
+		idx++;
+	}
+
+	const where = conditions.join(' AND ');
+
+	// Sort
+	const sortParam = c.req.query('sort') || 'created_at:desc';
+	const [sortField, sortDir] = sortParam.split(':');
+	const allowedSorts = ['created_at', 'updated_at', 'priority', 'number'];
+	const sortColumn = allowedSorts.includes(sortField) ? sortField : 'created_at';
+	const sortDirection = sortDir === 'asc' ? 'ASC' : 'DESC';
+
+	// Count
+	const countResult = await db.query<{ count: number }>(
+		`SELECT count(*)::int AS count FROM issues i WHERE ${where}`,
+		params,
+	);
+	const total = countResult.rows[0].count;
+
+	// Fetch
+	const dataParams = [...params, perPage, offset];
+	const result = await db.query(
+		`SELECT i.id, i.company_id, i.project_id, i.assignee_id, i.parent_issue_id,
+            i.number, i.identifier, i.title, i.description, i.status, i.priority,
+            i.labels, i.created_at, i.updated_at,
+            p.name AS project_name,
+            COALESCE(ma.title, m.display_name) AS assignee_name
+     FROM issues i
+     JOIN projects p ON p.id = i.project_id
+     LEFT JOIN members m ON m.id = i.assignee_id
+     LEFT JOIN member_agents ma ON ma.id = i.assignee_id
+     WHERE ${where}
+     ORDER BY i.${sortColumn} ${sortDirection}
+     LIMIT $${idx} OFFSET $${idx + 1}`,
+		dataParams,
+	);
+
+	return c.json({ data: result.rows, meta: buildMeta(page, perPage, total) });
+});
+
+issuesRoutes.post('/companies/:companyId/issues', async (c) => {
+	const db = c.get('db');
+	const companyId = c.req.param('companyId');
+
+	const body = await c.req.json<{
+		project_id: string;
+		title: string;
+		description?: string;
+		assignee_id?: string;
+		parent_issue_id?: string;
+		priority?: string;
+		labels?: string[];
+	}>();
+
+	if (!body.project_id || !body.title?.trim()) {
+		return err(c, 'INVALID_REQUEST', 'project_id and title are required', 400);
+	}
+
+	// Get issue prefix
+	const companyResult = await db.query<{ issue_prefix: string }>(
+		'SELECT issue_prefix FROM companies WHERE id = $1',
+		[companyId],
+	);
+	if (companyResult.rows.length === 0) {
+		return err(c, 'NOT_FOUND', 'Company not found', 404);
+	}
+
+	// Get next number atomically
+	const numberResult = await db.query<{ number: number }>(
+		'SELECT next_issue_number($1) AS number',
+		[companyId],
+	);
+	const issueNumber = numberResult.rows[0].number;
+	const identifier = `${companyResult.rows[0].issue_prefix}-${issueNumber}`;
+
+	const result = await db.query(
+		`INSERT INTO issues (company_id, project_id, assignee_id, parent_issue_id,
+                         number, identifier, title, description, status, priority, labels)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'backlog', $9::issue_priority, $10::jsonb)
+     RETURNING *`,
+		[
+			companyId,
+			body.project_id,
+			body.assignee_id ?? null,
+			body.parent_issue_id ?? null,
+			issueNumber,
+			identifier,
+			body.title.trim(),
+			body.description ?? '',
+			body.priority ?? 'medium',
+			JSON.stringify(body.labels ?? []),
+		],
+	);
+
+	return ok(c, result.rows[0], 201);
+});
+
+issuesRoutes.get('/companies/:companyId/issues/:issueId', async (c) => {
+	const db = c.get('db');
+	const result = await db.query(
+		`SELECT i.*,
+            p.name AS project_name, p.goal AS project_goal,
+            co.mission AS company_mission,
+            COALESCE(ma.title, m.display_name) AS assignee_name,
+            (SELECT count(*)::int FROM issue_comments ic WHERE ic.issue_id = i.id) AS comment_count,
+            (SELECT COALESCE(sum(ce.amount_cents), 0)::int FROM cost_entries ce WHERE ce.issue_id = i.id) AS cost_cents
+     FROM issues i
+     JOIN projects p ON p.id = i.project_id
+     JOIN companies co ON co.id = i.company_id
+     LEFT JOIN members m ON m.id = i.assignee_id
+     LEFT JOIN member_agents ma ON ma.id = i.assignee_id
+     WHERE i.id = $1 AND i.company_id = $2`,
+		[c.req.param('issueId'), c.req.param('companyId')],
+	);
+
+	if (result.rows.length === 0) {
+		return err(c, 'NOT_FOUND', 'Issue not found', 404);
+	}
+
+	return ok(c, result.rows[0]);
+});
+
+issuesRoutes.patch('/companies/:companyId/issues/:issueId', async (c) => {
+	const db = c.get('db');
+	const issueId = c.req.param('issueId');
+	const companyId = c.req.param('companyId');
+
+	const existing = await db.query(
+		'SELECT id, status FROM issues WHERE id = $1 AND company_id = $2',
+		[issueId, companyId],
+	);
+	if (existing.rows.length === 0) {
+		return err(c, 'NOT_FOUND', 'Issue not found', 404);
+	}
+
+	const body = await c.req.json<{
+		title?: string;
+		description?: string;
+		status?: string;
+		priority?: string;
+		assignee_id?: string | null;
+		labels?: string[];
+	}>();
+
+	const sets: string[] = [];
+	const params: unknown[] = [];
+	let idx = 1;
+
+	if (body.title?.trim() !== undefined) {
+		sets.push(`title = $${idx}`);
+		params.push(body.title.trim());
+		idx++;
+	}
+	if (body.description !== undefined) {
+		sets.push(`description = $${idx}`);
+		params.push(body.description);
+		idx++;
+	}
+	if (body.status !== undefined) {
+		sets.push(`status = $${idx}::issue_status`);
+		params.push(body.status);
+		idx++;
+	}
+	if (body.priority !== undefined) {
+		sets.push(`priority = $${idx}::issue_priority`);
+		params.push(body.priority);
+		idx++;
+	}
+	if (body.assignee_id !== undefined) {
+		sets.push(`assignee_id = $${idx}`);
+		params.push(body.assignee_id);
+		idx++;
+	}
+	if (body.labels !== undefined) {
+		sets.push(`labels = $${idx}::jsonb`);
+		params.push(JSON.stringify(body.labels));
+		idx++;
+	}
+
+	if (sets.length === 0) {
+		return ok(c, (existing as any).rows[0]);
+	}
+
+	params.push(issueId);
+	const result = await db.query(
+		`UPDATE issues SET ${sets.join(', ')} WHERE id = $${idx} RETURNING *`,
+		params,
+	);
+
+	return ok(c, result.rows[0]);
+});
+
+issuesRoutes.delete('/companies/:companyId/issues/:issueId', async (c) => {
+	const db = c.get('db');
+	const issueId = c.req.param('issueId');
+	const companyId = c.req.param('companyId');
+
+	const existing = await db.query<{ status: string }>(
+		'SELECT status FROM issues WHERE id = $1 AND company_id = $2',
+		[issueId, companyId],
+	);
+	if (existing.rows.length === 0) {
+		return err(c, 'NOT_FOUND', 'Issue not found', 404);
+	}
+
+	if (!['backlog', 'open'].includes(existing.rows[0].status)) {
+		return err(c, 'FORBIDDEN', 'Can only delete issues with status backlog or open', 403);
+	}
+
+	// Check for comments
+	const comments = await db.query<{ count: number }>(
+		'SELECT count(*)::int AS count FROM issue_comments WHERE issue_id = $1',
+		[issueId],
+	);
+	if (comments.rows[0].count > 0) {
+		return err(c, 'CONFLICT', 'Cannot delete issue with comments', 409);
+	}
+
+	await db.query('DELETE FROM issues WHERE id = $1', [issueId]);
+	return c.json({ data: null }, 200);
+});
+
+// Sub-issues
+issuesRoutes.post('/companies/:companyId/issues/:issueId/sub-issues', async (c) => {
+	const db = c.get('db');
+	const companyId = c.req.param('companyId');
+	const parentIssueId = c.req.param('issueId');
+
+	// Verify parent exists
+	const parent = await db.query<{ project_id: string }>(
+		'SELECT project_id FROM issues WHERE id = $1 AND company_id = $2',
+		[parentIssueId, companyId],
+	);
+	if (parent.rows.length === 0) {
+		return err(c, 'NOT_FOUND', 'Parent issue not found', 404);
+	}
+
+	const body = await c.req.json<{
+		title: string;
+		description?: string;
+		assignee_id?: string;
+		priority?: string;
+		labels?: string[];
+	}>();
+
+	if (!body.title?.trim()) {
+		return err(c, 'INVALID_REQUEST', 'title is required', 400);
+	}
+
+	const companyResult = await db.query<{ issue_prefix: string }>(
+		'SELECT issue_prefix FROM companies WHERE id = $1',
+		[companyId],
+	);
+	const numberResult = await db.query<{ number: number }>(
+		'SELECT next_issue_number($1) AS number',
+		[companyId],
+	);
+	const issueNumber = numberResult.rows[0].number;
+	const identifier = `${companyResult.rows[0].issue_prefix}-${issueNumber}`;
+
+	const result = await db.query(
+		`INSERT INTO issues (company_id, project_id, assignee_id, parent_issue_id,
+                         number, identifier, title, description, status, priority, labels)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'backlog', $9::issue_priority, $10::jsonb)
+     RETURNING *`,
+		[
+			companyId,
+			parent.rows[0].project_id,
+			body.assignee_id ?? null,
+			parentIssueId,
+			issueNumber,
+			identifier,
+			body.title.trim(),
+			body.description ?? '',
+			body.priority ?? 'medium',
+			JSON.stringify(body.labels ?? []),
+		],
+	);
+
+	return ok(c, result.rows[0], 201);
+});
+
+// Dependencies
+issuesRoutes.get('/companies/:companyId/issues/:issueId/dependencies', async (c) => {
+	const db = c.get('db');
+	const result = await db.query(
+		`SELECT d.id, d.issue_id, d.blocked_by_issue_id, d.created_at,
+            i.identifier AS blocked_by_identifier, i.title AS blocked_by_title, i.status AS blocked_by_status
+     FROM issue_dependencies d
+     JOIN issues i ON i.id = d.blocked_by_issue_id
+     WHERE d.issue_id = $1`,
+		[c.req.param('issueId')],
+	);
+	return ok(c, result.rows);
+});
+
+issuesRoutes.post('/companies/:companyId/issues/:issueId/dependencies', async (c) => {
+	const db = c.get('db');
+	const issueId = c.req.param('issueId');
+	const body = await c.req.json<{ blocked_by_issue_id: string }>();
+
+	if (!body.blocked_by_issue_id) {
+		return err(c, 'INVALID_REQUEST', 'blocked_by_issue_id is required', 400);
+	}
+
+	if (body.blocked_by_issue_id === issueId) {
+		return err(c, 'INVALID_REQUEST', 'An issue cannot block itself', 400);
+	}
+
+	const result = await db.query(
+		`INSERT INTO issue_dependencies (issue_id, blocked_by_issue_id)
+     VALUES ($1, $2)
+     ON CONFLICT DO NOTHING
+     RETURNING *`,
+		[issueId, body.blocked_by_issue_id],
+	);
+
+	if (result.rows.length === 0) {
+		return err(c, 'CONFLICT', 'Dependency already exists', 409);
+	}
+
+	return ok(c, result.rows[0], 201);
+});
+
+issuesRoutes.delete('/companies/:companyId/issues/:issueId/dependencies/:depId', async (c) => {
+	const db = c.get('db');
+	await db.query('DELETE FROM issue_dependencies WHERE id = $1', [c.req.param('depId')]);
+	return c.json({ data: null }, 200);
+});

--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -67,7 +67,7 @@ projectsRoutes.get('/companies/:companyId/projects/:projectId', async (c) => {
 		c.req.param('projectId'),
 	]);
 
-	return ok(c, { ...result.rows[0], repos: repos.rows });
+	return ok(c, { ...(result.rows[0] as Record<string, unknown>), repos: repos.rows });
 });
 
 projectsRoutes.patch('/companies/:companyId/projects/:projectId', async (c) => {

--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -1,0 +1,144 @@
+import { Hono } from 'hono';
+import { err, ok } from '../lib/response';
+import type { Env } from '../lib/types';
+
+export const projectsRoutes = new Hono<Env>();
+
+projectsRoutes.get('/companies/:companyId/projects', async (c) => {
+	const db = c.get('db');
+	const result = await db.query(
+		`SELECT p.*,
+       (SELECT count(*) FROM repos r WHERE r.project_id = p.id)::int AS repo_count,
+       (SELECT count(*) FROM issues i WHERE i.project_id = p.id AND i.status NOT IN ('done', 'closed', 'cancelled'))::int AS open_issue_count
+     FROM projects p
+     WHERE p.company_id = $1
+     ORDER BY p.created_at DESC`,
+		[c.req.param('companyId')],
+	);
+	return ok(c, result.rows);
+});
+
+projectsRoutes.post('/companies/:companyId/projects', async (c) => {
+	const db = c.get('db');
+	const companyId = c.req.param('companyId');
+
+	const companyCheck = await db.query('SELECT id FROM companies WHERE id = $1', [companyId]);
+	if (companyCheck.rows.length === 0) {
+		return err(c, 'NOT_FOUND', 'Company not found', 404);
+	}
+
+	const body = await c.req.json<{
+		name: string;
+		goal?: string;
+		docker_base_image?: string;
+	}>();
+
+	if (!body.name?.trim()) {
+		return err(c, 'INVALID_REQUEST', 'name is required', 400);
+	}
+
+	const result = await db.query(
+		`INSERT INTO projects (company_id, name, goal, docker_base_image)
+     VALUES ($1, $2, $3, $4)
+     RETURNING *`,
+		[companyId, body.name.trim(), body.goal ?? '', body.docker_base_image ?? 'node:20-slim'],
+	);
+
+	return ok(c, result.rows[0], 201);
+});
+
+projectsRoutes.get('/companies/:companyId/projects/:projectId', async (c) => {
+	const db = c.get('db');
+	const result = await db.query(
+		`SELECT p.*,
+       (SELECT count(*) FROM repos r WHERE r.project_id = p.id)::int AS repo_count,
+       (SELECT count(*) FROM issues i WHERE i.project_id = p.id AND i.status NOT IN ('done', 'closed', 'cancelled'))::int AS open_issue_count
+     FROM projects p
+     WHERE p.id = $1 AND p.company_id = $2`,
+		[c.req.param('projectId'), c.req.param('companyId')],
+	);
+
+	if (result.rows.length === 0) {
+		return err(c, 'NOT_FOUND', 'Project not found', 404);
+	}
+
+	// Also fetch repos
+	const repos = await db.query('SELECT * FROM repos WHERE project_id = $1 ORDER BY short_name', [
+		c.req.param('projectId'),
+	]);
+
+	return ok(c, { ...result.rows[0], repos: repos.rows });
+});
+
+projectsRoutes.patch('/companies/:companyId/projects/:projectId', async (c) => {
+	const db = c.get('db');
+	const projectId = c.req.param('projectId');
+	const companyId = c.req.param('companyId');
+
+	const existing = await db.query('SELECT id FROM projects WHERE id = $1 AND company_id = $2', [
+		projectId,
+		companyId,
+	]);
+	if (existing.rows.length === 0) {
+		return err(c, 'NOT_FOUND', 'Project not found', 404);
+	}
+
+	const body = await c.req.json<{
+		name?: string;
+		goal?: string;
+	}>();
+
+	const sets: string[] = [];
+	const params: unknown[] = [];
+	let idx = 1;
+
+	if (body.name?.trim() !== undefined) {
+		sets.push(`name = $${idx}`);
+		params.push(body.name.trim());
+		idx++;
+	}
+	if (body.goal !== undefined) {
+		sets.push(`goal = $${idx}`);
+		params.push(body.goal);
+		idx++;
+	}
+
+	if (sets.length === 0) {
+		const result = await db.query('SELECT * FROM projects WHERE id = $1', [projectId]);
+		return ok(c, result.rows[0]);
+	}
+
+	params.push(projectId);
+	const result = await db.query(
+		`UPDATE projects SET ${sets.join(', ')} WHERE id = $${idx} RETURNING *`,
+		params,
+	);
+
+	return ok(c, result.rows[0]);
+});
+
+projectsRoutes.delete('/companies/:companyId/projects/:projectId', async (c) => {
+	const db = c.get('db');
+	const projectId = c.req.param('projectId');
+	const companyId = c.req.param('companyId');
+
+	const existing = await db.query('SELECT id FROM projects WHERE id = $1 AND company_id = $2', [
+		projectId,
+		companyId,
+	]);
+	if (existing.rows.length === 0) {
+		return err(c, 'NOT_FOUND', 'Project not found', 404);
+	}
+
+	// Check for open issues
+	const openIssues = await db.query<{ count: number }>(
+		"SELECT count(*)::int AS count FROM issues WHERE project_id = $1 AND status NOT IN ('done', 'closed', 'cancelled')",
+		[projectId],
+	);
+	if (openIssues.rows[0].count > 0) {
+		return err(c, 'CONFLICT', 'Cannot delete project with open issues', 409);
+	}
+
+	await db.query('DELETE FROM projects WHERE id = $1', [projectId]);
+	return c.json({ data: null }, 200);
+});

--- a/packages/server/src/routes/secrets.ts
+++ b/packages/server/src/routes/secrets.ts
@@ -1,0 +1,193 @@
+import { Hono } from 'hono';
+import { err, ok } from '../lib/response';
+import type { Env } from '../lib/types';
+
+export const secretsRoutes = new Hono<Env>();
+
+secretsRoutes.get('/companies/:companyId/secrets', async (c) => {
+	const db = c.get('db');
+	const companyId = c.req.param('companyId');
+	const projectId = c.req.query('project_id');
+
+	let query = `
+    SELECT s.id, s.company_id, s.project_id, s.name, s.category, s.created_at, s.updated_at,
+           p.name AS project_name,
+           (SELECT count(*) FROM secret_grants sg WHERE sg.secret_id = s.id AND sg.revoked_at IS NULL)::int AS grant_count
+    FROM secrets s
+    LEFT JOIN projects p ON p.id = s.project_id
+    WHERE s.company_id = $1`;
+	const params: unknown[] = [companyId];
+
+	if (projectId) {
+		query += ` AND s.project_id = $2`;
+		params.push(projectId);
+	}
+
+	query += ' ORDER BY s.name ASC';
+	const result = await db.query(query, params);
+	return ok(c, result.rows);
+});
+
+secretsRoutes.post('/companies/:companyId/secrets', async (c) => {
+	const db = c.get('db');
+	const companyId = c.req.param('companyId');
+	const masterKeyManager = c.get('masterKeyManager');
+
+	const body = await c.req.json<{
+		name: string;
+		value: string;
+		project_id?: string;
+		category?: string;
+	}>();
+
+	if (!body.name?.trim() || !body.value) {
+		return err(c, 'INVALID_REQUEST', 'name and value are required', 400);
+	}
+
+	const key = masterKeyManager.getKey();
+	if (!key) {
+		return err(c, 'LOCKED', 'Server must be unlocked to manage secrets', 401);
+	}
+
+	const { encrypt } = await import('../crypto/encryption');
+	const encryptedValue = encrypt(body.value, key);
+
+	const result = await db.query(
+		`INSERT INTO secrets (company_id, project_id, name, encrypted_value, category)
+     VALUES ($1, $2, $3, $4, $5::secret_category)
+     RETURNING id, company_id, project_id, name, category, created_at, updated_at`,
+		[
+			companyId,
+			body.project_id ?? null,
+			body.name.trim(),
+			encryptedValue,
+			body.category ?? 'other',
+		],
+	);
+
+	return ok(c, result.rows[0], 201);
+});
+
+secretsRoutes.patch('/companies/:companyId/secrets/:secretId', async (c) => {
+	const db = c.get('db');
+	const secretId = c.req.param('secretId');
+	const companyId = c.req.param('companyId');
+	const masterKeyManager = c.get('masterKeyManager');
+
+	const existing = await db.query('SELECT id FROM secrets WHERE id = $1 AND company_id = $2', [
+		secretId,
+		companyId,
+	]);
+	if (existing.rows.length === 0) {
+		return err(c, 'NOT_FOUND', 'Secret not found', 404);
+	}
+
+	const body = await c.req.json<{
+		value?: string;
+		category?: string;
+	}>();
+
+	const sets: string[] = [];
+	const params: unknown[] = [];
+	let idx = 1;
+
+	if (body.value !== undefined) {
+		const key = masterKeyManager.getKey();
+		if (!key) {
+			return err(c, 'LOCKED', 'Server must be unlocked to manage secrets', 401);
+		}
+		const { encrypt } = await import('../crypto/encryption');
+		sets.push(`encrypted_value = $${idx}`);
+		params.push(encrypt(body.value, key));
+		idx++;
+	}
+
+	if (body.category !== undefined) {
+		sets.push(`category = $${idx}::secret_category`);
+		params.push(body.category);
+		idx++;
+	}
+
+	if (sets.length === 0) {
+		return ok(c, existing.rows[0]);
+	}
+
+	params.push(secretId);
+	const result = await db.query(
+		`UPDATE secrets SET ${sets.join(', ')} WHERE id = $${idx}
+     RETURNING id, company_id, project_id, name, category, created_at, updated_at`,
+		params,
+	);
+
+	return ok(c, result.rows[0]);
+});
+
+secretsRoutes.delete('/companies/:companyId/secrets/:secretId', async (c) => {
+	const db = c.get('db');
+	const secretId = c.req.param('secretId');
+	const companyId = c.req.param('companyId');
+
+	const existing = await db.query('SELECT id FROM secrets WHERE id = $1 AND company_id = $2', [
+		secretId,
+		companyId,
+	]);
+	if (existing.rows.length === 0) {
+		return err(c, 'NOT_FOUND', 'Secret not found', 404);
+	}
+
+	await db.query('DELETE FROM secrets WHERE id = $1', [secretId]);
+	return c.json({ data: null }, 200);
+});
+
+// Secret Grants
+secretsRoutes.get('/companies/:companyId/secrets/:secretId/grants', async (c) => {
+	const db = c.get('db');
+	const result = await db.query(
+		`SELECT sg.id, sg.secret_id, sg.member_id AS agent_id, sg.scope, sg.granted_at, sg.revoked_at,
+            ma.title AS agent_title
+     FROM secret_grants sg
+     LEFT JOIN member_agents ma ON ma.id = sg.member_id
+     WHERE sg.secret_id = $1
+     ORDER BY sg.granted_at DESC`,
+		[c.req.param('secretId')],
+	);
+	return ok(c, result.rows);
+});
+
+secretsRoutes.post('/companies/:companyId/secrets/:secretId/grants', async (c) => {
+	const db = c.get('db');
+	const secretId = c.req.param('secretId');
+
+	const body = await c.req.json<{
+		agent_id: string;
+		scope?: string;
+	}>();
+
+	if (!body.agent_id) {
+		return err(c, 'INVALID_REQUEST', 'agent_id is required', 400);
+	}
+
+	const result = await db.query(
+		`INSERT INTO secret_grants (secret_id, member_id, scope)
+     VALUES ($1, $2, $3::grant_scope)
+     ON CONFLICT (secret_id, member_id) DO UPDATE SET revoked_at = NULL
+     RETURNING *`,
+		[secretId, body.agent_id, body.scope ?? 'single'],
+	);
+
+	return ok(c, result.rows[0], 201);
+});
+
+secretsRoutes.delete('/companies/:companyId/secret-grants/:grantId', async (c) => {
+	const db = c.get('db');
+	const result = await db.query(
+		'UPDATE secret_grants SET revoked_at = now() WHERE id = $1 RETURNING *',
+		[c.req.param('grantId')],
+	);
+
+	if (result.rows.length === 0) {
+		return err(c, 'NOT_FOUND', 'Grant not found', 404);
+	}
+
+	return ok(c, result.rows[0]);
+});

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -1,7 +1,7 @@
+import { mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
 import type { PGlite } from '@electric-sql/pglite';
-import { mkdirSync, rmSync } from 'fs';
 import { Hono } from 'hono';
-import { join } from 'path';
 import type { HezoConfig } from './cli';
 import { MasterKeyManager } from './crypto/master-key';
 import { BASE_SCHEMA } from './db/schema';
@@ -25,7 +25,7 @@ export type { HezoConfig };
 export type MasterKeyState = 'unset' | 'locked' | 'unlocked';
 
 export interface StartupResult {
-	app: Hono;
+	app: Hono<Env>;
 	port: number;
 	masterKeyState: MasterKeyState;
 }
@@ -60,7 +60,7 @@ export async function startup(config: HezoConfig): Promise<StartupResult> {
 	return { app, port: config.port, masterKeyState };
 }
 
-export function buildApp(db: PGlite, masterKeyManager: MasterKeyManager): Hono {
+export function buildApp(db: PGlite, masterKeyManager: MasterKeyManager): Hono<Env> {
 	const app = new Hono<Env>();
 
 	// Inject db and masterKeyManager into every request

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -1,107 +1,151 @@
-import { Hono } from "hono";
-import { mkdirSync, rmSync } from "fs";
-import { join } from "path";
-import { healthRoutes } from "./routes/health";
-import { BASE_SCHEMA } from "./db/schema";
-import type { HezoConfig } from "./cli";
+import type { PGlite } from '@electric-sql/pglite';
+import { mkdirSync, rmSync } from 'fs';
+import { Hono } from 'hono';
+import { join } from 'path';
+import type { HezoConfig } from './cli';
+import { MasterKeyManager } from './crypto/master-key';
+import { BASE_SCHEMA } from './db/schema';
+import type { Env } from './lib/types';
+import { authMiddleware } from './middleware/auth';
+import { agentsRoutes } from './routes/agents';
+import { apiKeysRoutes } from './routes/api-keys';
+import { approvalsRoutes } from './routes/approvals';
+import { authRoutes } from './routes/auth';
+import { commentsRoutes } from './routes/comments';
+import { companiesRoutes } from './routes/companies';
+import { companyTypesRoutes } from './routes/company-types';
+import { costsRoutes } from './routes/costs';
+import { healthRoutes } from './routes/health';
+import { issuesRoutes } from './routes/issues';
+import { projectsRoutes } from './routes/projects';
+import { secretsRoutes } from './routes/secrets';
+
 export type { HezoConfig };
 
-export type MasterKeyState = "unset" | "locked" | "unlocked";
+export type MasterKeyState = 'unset' | 'locked' | 'unlocked';
 
 export interface StartupResult {
-  app: Hono;
-  port: number;
-  masterKeyState: MasterKeyState;
+	app: Hono;
+	port: number;
+	masterKeyState: MasterKeyState;
 }
 
 export async function startup(config: HezoConfig): Promise<StartupResult> {
-  const pgDataPath = join(config.dataDir, "pgdata");
+	const pgDataPath = join(config.dataDir, 'pgdata');
 
-  if (config.reset) {
-    rmSync(pgDataPath, { recursive: true, force: true });
-  }
+	if (config.reset) {
+		rmSync(pgDataPath, { recursive: true, force: true });
+	}
 
-  mkdirSync(config.dataDir, { recursive: true });
+	mkdirSync(config.dataDir, { recursive: true });
 
-  const { PGlite } = await import("@electric-sql/pglite");
-  let db: InstanceType<typeof PGlite>;
+	const { PGlite } = await import('@electric-sql/pglite');
+	let db: InstanceType<typeof PGlite>;
 
-  try {
-    const { NodeFS } = await import("@electric-sql/pglite/nodefs");
-    db = new PGlite({ fs: new NodeFS(pgDataPath) });
-  } catch {
-    db = new PGlite();
-  }
+	try {
+		const { NodeFS } = await import('@electric-sql/pglite/nodefs');
+		db = new PGlite({ fs: new NodeFS(pgDataPath) });
+	} catch {
+		db = new PGlite();
+	}
 
-  await db.exec(BASE_SCHEMA);
-  await runAvailableMigrations(db);
+	await db.exec(BASE_SCHEMA);
+	await runAvailableMigrations(db);
+	await runSeed(db);
 
-  const masterKeyState = await resolveMasterKeyState(db, config.masterKey);
-  const app = buildApp(masterKeyState);
+	const masterKeyManager = new MasterKeyManager();
+	const masterKeyState = await resolveMasterKeyState(db, masterKeyManager, config.masterKey);
+	const app = buildApp(db, masterKeyManager);
 
-  return { app, port: config.port, masterKeyState };
+	return { app, port: config.port, masterKeyState };
 }
 
-async function runAvailableMigrations(db: any): Promise<void> {
-  try {
-    const { runMigrations, loadBundledMigrations } = await import(
-      "./db/migrate.js"
-    );
-    const migrations = await loadBundledMigrations();
-    await runMigrations(db, migrations);
-  } catch {
-    try {
-      const { runMigrations, loadFilesystemMigrations } = await import(
-        "./db/migrate.js"
-      );
-      const migrationsDir = join(
-        new URL(".", import.meta.url).pathname,
-        "..",
-        "migrations",
-      );
-      const migrations = await loadFilesystemMigrations(migrationsDir);
-      await runMigrations(db, migrations);
-    } catch {
-      console.warn(
-        "No migrations found. Run build:migrations or add migration files.",
-      );
-    }
-  }
+export function buildApp(db: PGlite, masterKeyManager: MasterKeyManager): Hono {
+	const app = new Hono<Env>();
+
+	// Inject db and masterKeyManager into every request
+	app.use('*', async (c, next) => {
+		c.set('db', db);
+		c.set('masterKeyManager', masterKeyManager);
+		return next();
+	});
+
+	// Public routes
+	app.route('/', healthRoutes);
+
+	const statusPayload = {
+		masterKeyState: masterKeyManager.getState(),
+		version: '0.1.0',
+	};
+	app.get('/', (c) => c.json(statusPayload));
+	app.get('/api/status', (c) => c.json(statusPayload));
+
+	// Auth routes (token endpoint is public, handled before auth middleware)
+	app.route('/api', authRoutes);
+
+	// Auth middleware for all /api/* routes
+	app.use('/api/*', authMiddleware);
+
+	// CRUD routes
+	app.route('/api', companyTypesRoutes);
+	app.route('/api', companiesRoutes);
+	app.route('/api', agentsRoutes);
+	app.route('/api', projectsRoutes);
+	app.route('/api', issuesRoutes);
+	app.route('/api', commentsRoutes);
+	app.route('/api', secretsRoutes);
+	app.route('/api', approvalsRoutes);
+	app.route('/api', costsRoutes);
+	app.route('/api', apiKeysRoutes);
+
+	return app;
+}
+
+async function runAvailableMigrations(db: PGlite): Promise<void> {
+	try {
+		const { runMigrations, loadBundledMigrations } = await import('./db/migrate.js');
+		const migrations = await loadBundledMigrations();
+		await runMigrations(db, migrations);
+	} catch {
+		try {
+			const { runMigrations, loadFilesystemMigrations } = await import('./db/migrate.js');
+			const migrationsDir = join(new URL('.', import.meta.url).pathname, '..', 'migrations');
+			const migrations = await loadFilesystemMigrations(migrationsDir);
+			await runMigrations(db, migrations);
+		} catch {
+			console.warn('No migrations found. Run build:migrations or add migration files.');
+		}
+	}
+}
+
+async function runSeed(db: PGlite): Promise<void> {
+	try {
+		const { seedBuiltins } = await import('./db/seed.js');
+		await seedBuiltins(db);
+	} catch {
+		// Seed module may not be available in minimal builds
+	}
 }
 
 async function resolveMasterKeyState(
-  db: any,
-  masterKey?: string,
+	db: PGlite,
+	masterKeyManager: MasterKeyManager,
+	masterKey?: string,
 ): Promise<MasterKeyState> {
-  try {
-    const { MasterKeyManager } = await import("./crypto/master-key.js");
-    const manager = new MasterKeyManager();
-    const state = await manager.initialize(db, masterKey);
+	try {
+		const state = await masterKeyManager.initialize(db, masterKey);
 
-    const messages: Record<string, string> = {
-      unlocked: "Master key verified. Server unlocked.",
-      unset: "No master key set. Set via web UI on first login.",
-      locked: masterKey
-        ? "Invalid master key provided. Server starting in locked state."
-        : "Server starting in locked state. Provide master key to unlock.",
-    };
-    console.log(messages[state]);
-    return state;
-  } catch {
-    console.warn("Master key module not available. Skipping key verification.");
-    return "unset";
-  }
-}
-
-function buildApp(masterKeyState: MasterKeyState): Hono {
-  const app = new Hono();
-
-  app.route("/", healthRoutes);
-
-  const statusPayload = { masterKeyState, version: "0.1.0" };
-
-  app.get("/", (c) => c.json(statusPayload));
-  app.get("/api/status", (c) => c.json(statusPayload));
-
-  return app;
+		const messages: Record<string, string> = {
+			unlocked: 'Master key verified. Server unlocked.',
+			unset: 'No master key set. Set via web UI on first login.',
+			locked: masterKey
+				? 'Invalid master key provided. Server starting in locked state.'
+				: 'Server starting in locked state. Provide master key to unlock.',
+		};
+		console.log(messages[state]);
+		return state;
+	} catch {
+		console.warn('Master key module not available. Skipping key verification.');
+		return 'unset';
+	}
 }

--- a/packages/server/src/test/__tests__/agents.test.ts
+++ b/packages/server/src/test/__tests__/agents.test.ts
@@ -1,0 +1,180 @@
+import type { PGlite } from '@electric-sql/pglite';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { safeClose } from '../helpers';
+import { authHeader, createTestApp } from '../helpers/app';
+
+let app: Hono;
+let db: PGlite;
+let token: string;
+let companyId: string;
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+
+	// Create a company with agents
+	const typesRes = await app.request('/api/company-types', {
+		headers: authHeader(token),
+	});
+	const typeId = (await typesRes.json()).data.find((t: any) => t.is_builtin).id;
+
+	const companyRes = await app.request('/api/companies', {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			name: 'Agent Test Co',
+			company_type_id: typeId,
+		}),
+	});
+	companyId = (await companyRes.json()).data.id;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+describe('agents CRUD', () => {
+	it('lists all 9 auto-created agents', async () => {
+		const res = await app.request(`/api/companies/${companyId}/agents`, {
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data).toHaveLength(9);
+	});
+
+	it('filters agents by status', async () => {
+		const res = await app.request(`/api/companies/${companyId}/agents?status=idle`, {
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		// DevOps Engineer starts idle
+		expect(body.data.length).toBeGreaterThanOrEqual(1);
+		expect(body.data.every((a: any) => a.status === 'idle')).toBe(true);
+	});
+
+	it('gets an agent by id with full detail', async () => {
+		const listRes = await app.request(`/api/companies/${companyId}/agents`, {
+			headers: authHeader(token),
+		});
+		const agents = (await listRes.json()).data;
+		const ceo = agents.find((a: any) => a.slug === 'ceo');
+
+		const res = await app.request(`/api/companies/${companyId}/agents/${ceo.id}`, {
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data.title).toBe('CEO');
+		expect(body.data).toHaveProperty('system_prompt');
+		expect(body.data).toHaveProperty('mcp_servers');
+	});
+
+	it('creates (hires) a custom agent', async () => {
+		const res = await app.request(`/api/companies/${companyId}/agents`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				title: 'Data Scientist',
+				role_description: 'Analyzes data and builds ML models',
+				monthly_budget_cents: 4000,
+			}),
+		});
+		expect(res.status).toBe(201);
+		const body = await res.json();
+		expect(body.data.title).toBe('Data Scientist');
+		expect(body.data.slug).toBe('data-scientist');
+	});
+
+	it('updates an agent', async () => {
+		const listRes = await app.request(`/api/companies/${companyId}/agents`, {
+			headers: authHeader(token),
+		});
+		const agents = (await listRes.json()).data;
+		const engineer = agents.find((a: any) => a.slug === 'engineer');
+
+		const res = await app.request(`/api/companies/${companyId}/agents/${engineer.id}`, {
+			method: 'PATCH',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ monthly_budget_cents: 8000 }),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data.monthly_budget_cents).toBe(8000);
+	});
+
+	it('pauses an active agent', async () => {
+		const listRes = await app.request(`/api/companies/${companyId}/agents`, {
+			headers: authHeader(token),
+		});
+		const agents = (await listRes.json()).data;
+		const researcher = agents.find((a: any) => a.slug === 'researcher');
+
+		const res = await app.request(`/api/companies/${companyId}/agents/${researcher.id}/pause`, {
+			method: 'POST',
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data.status).toBe('paused');
+	});
+
+	it('resumes a paused agent', async () => {
+		const listRes = await app.request(`/api/companies/${companyId}/agents`, {
+			headers: authHeader(token),
+		});
+		const agents = (await listRes.json()).data;
+		const researcher = agents.find((a: any) => a.slug === 'researcher');
+
+		const res = await app.request(`/api/companies/${companyId}/agents/${researcher.id}/resume`, {
+			method: 'POST',
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data.status).toBe('idle');
+	});
+
+	it('terminates an agent', async () => {
+		const listRes = await app.request(`/api/companies/${companyId}/agents`, {
+			headers: authHeader(token),
+		});
+		const agents = (await listRes.json()).data;
+		const marketingLead = agents.find((a: any) => a.slug === 'marketing-lead');
+
+		const res = await app.request(
+			`/api/companies/${companyId}/agents/${marketingLead.id}/terminate`,
+			{ method: 'POST', headers: authHeader(token) },
+		);
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data.status).toBe('terminated');
+	});
+
+	it('returns org chart', async () => {
+		const res = await app.request(`/api/companies/${companyId}/org-chart`, {
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data.board).toBeDefined();
+		expect(body.data.board.children.length).toBeGreaterThan(0);
+		// CEO should be at top level with children
+		const ceo = body.data.board.children.find((c: any) => c.title === 'CEO');
+		expect(ceo).toBeDefined();
+		expect(ceo.children.length).toBeGreaterThan(0);
+	});
+
+	it('rejects duplicate agent slug', async () => {
+		const res = await app.request(`/api/companies/${companyId}/agents`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ title: 'CEO' }),
+		});
+		expect(res.status).toBe(409);
+	});
+});

--- a/packages/server/src/test/__tests__/agents.test.ts
+++ b/packages/server/src/test/__tests__/agents.test.ts
@@ -1,10 +1,11 @@
 import type { PGlite } from '@electric-sql/pglite';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Env } from '../../lib/types';
 import { safeClose } from '../helpers';
 import { authHeader, createTestApp } from '../helpers/app';
 
-let app: Hono;
+let app: Hono<Env>;
 let db: PGlite;
 let token: string;
 let companyId: string;

--- a/packages/server/src/test/__tests__/api-keys.test.ts
+++ b/packages/server/src/test/__tests__/api-keys.test.ts
@@ -1,0 +1,93 @@
+import type { PGlite } from '@electric-sql/pglite';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { safeClose } from '../helpers';
+import { authHeader, createTestApp } from '../helpers/app';
+
+let app: Hono;
+let db: PGlite;
+let token: string;
+let companyId: string;
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+
+	const companyRes = await app.request('/api/companies', {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ name: 'API Key Co', issue_prefix: 'AKC' }),
+	});
+	companyId = (await companyRes.json()).data.id;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+describe('API keys CRUD', () => {
+	it('creates an API key and returns raw key once', async () => {
+		const res = await app.request(`/api/companies/${companyId}/api-keys`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name: 'Test Key' }),
+		});
+		expect(res.status).toBe(201);
+		const body = await res.json();
+		expect(body.data.key).toMatch(/^hezo_/);
+		expect(body.data.name).toBe('Test Key');
+		expect(body.data.prefix).toHaveLength(8);
+	});
+
+	it('lists API keys (without raw key)', async () => {
+		const res = await app.request(`/api/companies/${companyId}/api-keys`, {
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data.length).toBeGreaterThanOrEqual(1);
+		// Raw key should NOT be in list
+		expect(body.data[0]).not.toHaveProperty('key');
+		expect(body.data[0]).not.toHaveProperty('key_hash');
+	});
+
+	it('authenticates with an API key', async () => {
+		// Create a key
+		const createRes = await app.request(`/api/companies/${companyId}/api-keys`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name: 'Auth Test Key' }),
+		});
+		const rawKey = (await createRes.json()).data.key;
+
+		// Use the key to access an API
+		const res = await app.request(`/api/companies/${companyId}/api-keys`, {
+			headers: { Authorization: `Bearer ${rawKey}` },
+		});
+		expect(res.status).toBe(200);
+	});
+
+	it('revokes an API key', async () => {
+		const createRes = await app.request(`/api/companies/${companyId}/api-keys`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name: 'To Revoke' }),
+		});
+		const apiKey = (await createRes.json()).data;
+		const rawKey = apiKey.key;
+
+		const res = await app.request(`/api/companies/${companyId}/api-keys/${apiKey.id}`, {
+			method: 'DELETE',
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+
+		// Verify key no longer works
+		const authRes = await app.request(`/api/companies/${companyId}/api-keys`, {
+			headers: { Authorization: `Bearer ${rawKey}` },
+		});
+		expect(authRes.status).toBe(401);
+	});
+});

--- a/packages/server/src/test/__tests__/api-keys.test.ts
+++ b/packages/server/src/test/__tests__/api-keys.test.ts
@@ -1,10 +1,11 @@
 import type { PGlite } from '@electric-sql/pglite';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Env } from '../../lib/types';
 import { safeClose } from '../helpers';
 import { authHeader, createTestApp } from '../helpers/app';
 
-let app: Hono;
+let app: Hono<Env>;
 let db: PGlite;
 let token: string;
 let companyId: string;

--- a/packages/server/src/test/__tests__/approvals.test.ts
+++ b/packages/server/src/test/__tests__/approvals.test.ts
@@ -1,0 +1,110 @@
+import type { PGlite } from '@electric-sql/pglite';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { safeClose } from '../helpers';
+import { authHeader, createTestApp } from '../helpers/app';
+
+let app: Hono;
+let db: PGlite;
+let token: string;
+let companyId: string;
+let agentId: string;
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+
+	const typesRes = await app.request('/api/company-types', {
+		headers: authHeader(token),
+	});
+	const typeId = (await typesRes.json()).data.find((t: any) => t.is_builtin).id;
+
+	const companyRes = await app.request('/api/companies', {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			name: 'Approval Co',
+			company_type_id: typeId,
+			issue_prefix: 'AC',
+		}),
+	});
+	companyId = (await companyRes.json()).data.id;
+
+	const agentsRes = await app.request(`/api/companies/${companyId}/agents`, {
+		headers: authHeader(token),
+	});
+	agentId = (await agentsRes.json()).data[0].id;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+describe('approvals CRUD', () => {
+	it('creates and resolves an approval', async () => {
+		// Create
+		const createRes = await app.request(`/api/companies/${companyId}/approvals`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				type: 'secret_access',
+				requested_by_member_id: agentId,
+				payload: { secret_name: 'DB_PASSWORD', reason: 'Need for migration' },
+			}),
+		});
+		expect(createRes.status).toBe(201);
+		const approval = (await createRes.json()).data;
+		expect(approval.status).toBe('pending');
+
+		// List pending
+		const listRes = await app.request(`/api/companies/${companyId}/approvals`, {
+			headers: authHeader(token),
+		});
+		expect(listRes.status).toBe(200);
+		expect((await listRes.json()).data.length).toBeGreaterThanOrEqual(1);
+
+		// Approve
+		const resolveRes = await app.request(`/api/approvals/${approval.id}/resolve`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				status: 'approved',
+				resolution_note: 'Granted for project scope',
+			}),
+		});
+		expect(resolveRes.status).toBe(200);
+		const resolved = (await resolveRes.json()).data;
+		expect(resolved.status).toBe('approved');
+		expect(resolved.resolved_at).not.toBeNull();
+	});
+
+	it('rejects resolving an already-resolved approval', async () => {
+		// Create and resolve
+		const createRes = await app.request(`/api/companies/${companyId}/approvals`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				type: 'hire',
+				requested_by_member_id: agentId,
+				payload: { title: 'New Agent' },
+			}),
+		});
+		const approval = (await createRes.json()).data;
+
+		await app.request(`/api/approvals/${approval.id}/resolve`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ status: 'denied' }),
+		});
+
+		// Try again
+		const res = await app.request(`/api/approvals/${approval.id}/resolve`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ status: 'approved' }),
+		});
+		expect(res.status).toBe(409);
+	});
+});

--- a/packages/server/src/test/__tests__/approvals.test.ts
+++ b/packages/server/src/test/__tests__/approvals.test.ts
@@ -1,10 +1,11 @@
 import type { PGlite } from '@electric-sql/pglite';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Env } from '../../lib/types';
 import { safeClose } from '../helpers';
 import { authHeader, createTestApp } from '../helpers/app';
 
-let app: Hono;
+let app: Hono<Env>;
 let db: PGlite;
 let token: string;
 let companyId: string;

--- a/packages/server/src/test/__tests__/cli.test.ts
+++ b/packages/server/src/test/__tests__/cli.test.ts
@@ -1,93 +1,98 @@
-import { describe, it, expect } from "vitest";
-import { homedir } from "os";
-import { resolve } from "path";
-import { parseArgs } from "../../cli";
+import { homedir } from 'node:os';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { parseArgs } from '../../cli';
 
 // Helper to build argv with the standard bun/node + script prefix
-const argv = (...flags: string[]) => ["bun", "src/index.ts", ...flags];
+const argv = (...flags: string[]) => ['bun', 'src/index.ts', ...flags];
 
-describe("parseArgs", () => {
-  it("returns defaults when no args provided", () => {
-    const config = parseArgs(argv());
-    expect(config.port).toBe(3100);
-    expect(config.dataDir).toBe(resolve(homedir(), ".hezo"));
-    expect(config.connectUrl).toBe("http://localhost:4100");
-    expect(config.masterKey).toBeUndefined();
-    expect(config.connectApiKey).toBeUndefined();
-    expect(config.reset).toBe(false);
-    expect(config.noOpen).toBe(false);
-  });
+describe('parseArgs', () => {
+	it('returns defaults when no args provided', () => {
+		const config = parseArgs(argv());
+		expect(config.port).toBe(3100);
+		expect(config.dataDir).toBe(resolve(homedir(), '.hezo'));
+		expect(config.connectUrl).toBe('http://localhost:4100');
+		expect(config.masterKey).toBeUndefined();
+		expect(config.connectApiKey).toBeUndefined();
+		expect(config.reset).toBe(false);
+		expect(config.noOpen).toBe(false);
+	});
 
-  it("parses --port", () => {
-    const config = parseArgs(argv("--port", "8080"));
-    expect(config.port).toBe(8080);
-  });
+	it('parses --port', () => {
+		const config = parseArgs(argv('--port', '8080'));
+		expect(config.port).toBe(8080);
+	});
 
-  it("throws on non-numeric port", () => {
-    expect(() => parseArgs(argv("--port", "abc"))).toThrow("Invalid port");
-  });
+	it('throws on non-numeric port', () => {
+		expect(() => parseArgs(argv('--port', 'abc'))).toThrow('Invalid port');
+	});
 
-  it("throws on port below valid range", () => {
-    expect(() => parseArgs(argv("--port", "0"))).toThrow("Invalid port");
-  });
+	it('throws on port below valid range', () => {
+		expect(() => parseArgs(argv('--port', '0'))).toThrow('Invalid port');
+	});
 
-  it("throws on port above valid range", () => {
-    expect(() => parseArgs(argv("--port", "99999"))).toThrow("Invalid port");
-  });
+	it('throws on port above valid range', () => {
+		expect(() => parseArgs(argv('--port', '99999'))).toThrow('Invalid port');
+	});
 
-  it("parses --data-dir with absolute path", () => {
-    const config = parseArgs(argv("--data-dir", "/custom/path"));
-    expect(config.dataDir).toBe("/custom/path");
-  });
+	it('parses --data-dir with absolute path', () => {
+		const config = parseArgs(argv('--data-dir', '/custom/path'));
+		expect(config.dataDir).toBe('/custom/path');
+	});
 
-  it("resolves tilde in --data-dir", () => {
-    const config = parseArgs(argv("--data-dir", "~/custom"));
-    expect(config.dataDir).toBe(resolve(homedir(), "custom"));
-  });
+	it('resolves tilde in --data-dir', () => {
+		const config = parseArgs(argv('--data-dir', '~/custom'));
+		expect(config.dataDir).toBe(resolve(homedir(), 'custom'));
+	});
 
-  it("parses --master-key", () => {
-    const config = parseArgs(argv("--master-key", "mykey"));
-    expect(config.masterKey).toBe("mykey");
-  });
+	it('parses --master-key', () => {
+		const config = parseArgs(argv('--master-key', 'mykey'));
+		expect(config.masterKey).toBe('mykey');
+	});
 
-  it("parses --connect-url", () => {
-    const config = parseArgs(argv("--connect-url", "https://custom.example.com"));
-    expect(config.connectUrl).toBe("https://custom.example.com");
-  });
+	it('parses --connect-url', () => {
+		const config = parseArgs(argv('--connect-url', 'https://custom.example.com'));
+		expect(config.connectUrl).toBe('https://custom.example.com');
+	});
 
-  it("parses --connect-api-key", () => {
-    const config = parseArgs(argv("--connect-api-key", "hc_abc123"));
-    expect(config.connectApiKey).toBe("hc_abc123");
-  });
+	it('parses --connect-api-key', () => {
+		const config = parseArgs(argv('--connect-api-key', 'hc_abc123'));
+		expect(config.connectApiKey).toBe('hc_abc123');
+	});
 
-  it("parses --reset", () => {
-    const config = parseArgs(argv("--reset"));
-    expect(config.reset).toBe(true);
-  });
+	it('parses --reset', () => {
+		const config = parseArgs(argv('--reset'));
+		expect(config.reset).toBe(true);
+	});
 
-  it("parses --no-open", () => {
-    const config = parseArgs(argv("--no-open"));
-    expect(config.noOpen).toBe(true);
-  });
+	it('parses --no-open', () => {
+		const config = parseArgs(argv('--no-open'));
+		expect(config.noOpen).toBe(true);
+	});
 
-  it("handles multiple flags combined", () => {
-    const config = parseArgs(
-      argv(
-        "--port", "9000",
-        "--data-dir", "/tmp/hezo",
-        "--master-key", "secret",
-        "--connect-url", "https://connect.hezo.dev",
-        "--connect-api-key", "hc_xyz",
-        "--reset",
-        "--no-open",
-      ),
-    );
-    expect(config.port).toBe(9000);
-    expect(config.dataDir).toBe("/tmp/hezo");
-    expect(config.masterKey).toBe("secret");
-    expect(config.connectUrl).toBe("https://connect.hezo.dev");
-    expect(config.connectApiKey).toBe("hc_xyz");
-    expect(config.reset).toBe(true);
-    expect(config.noOpen).toBe(true);
-  });
+	it('handles multiple flags combined', () => {
+		const config = parseArgs(
+			argv(
+				'--port',
+				'9000',
+				'--data-dir',
+				'/tmp/hezo',
+				'--master-key',
+				'secret',
+				'--connect-url',
+				'https://connect.hezo.dev',
+				'--connect-api-key',
+				'hc_xyz',
+				'--reset',
+				'--no-open',
+			),
+		);
+		expect(config.port).toBe(9000);
+		expect(config.dataDir).toBe('/tmp/hezo');
+		expect(config.masterKey).toBe('secret');
+		expect(config.connectUrl).toBe('https://connect.hezo.dev');
+		expect(config.connectApiKey).toBe('hc_xyz');
+		expect(config.reset).toBe(true);
+		expect(config.noOpen).toBe(true);
+	});
 });

--- a/packages/server/src/test/__tests__/comments.test.ts
+++ b/packages/server/src/test/__tests__/comments.test.ts
@@ -1,0 +1,112 @@
+import type { PGlite } from '@electric-sql/pglite';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { safeClose } from '../helpers';
+import { authHeader, createTestApp } from '../helpers/app';
+
+let app: Hono;
+let db: PGlite;
+let token: string;
+let companyId: string;
+let issueId: string;
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+
+	const companyRes = await app.request('/api/companies', {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ name: 'Comment Co', issue_prefix: 'CC' }),
+	});
+	companyId = (await companyRes.json()).data.id;
+
+	const projectRes = await app.request(`/api/companies/${companyId}/projects`, {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ name: 'Main' }),
+	});
+	const projectId = (await projectRes.json()).data.id;
+
+	const issueRes = await app.request(`/api/companies/${companyId}/issues`, {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ project_id: projectId, title: 'Test Issue' }),
+	});
+	issueId = (await issueRes.json()).data.id;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+describe('comments CRUD', () => {
+	it('creates a text comment', async () => {
+		const res = await app.request(`/api/companies/${companyId}/issues/${issueId}/comments`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				content_type: 'text',
+				content: { text: 'Hello world' },
+			}),
+		});
+		expect(res.status).toBe(201);
+		const body = await res.json();
+		expect(body.data.content_type).toBe('text');
+		expect(body.data.content.text).toBe('Hello world');
+	});
+
+	it('lists comments in order', async () => {
+		// Add another comment
+		await app.request(`/api/companies/${companyId}/issues/${issueId}/comments`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				content_type: 'text',
+				content: { text: 'Second comment' },
+			}),
+		});
+
+		const res = await app.request(`/api/companies/${companyId}/issues/${issueId}/comments`, {
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data.length).toBeGreaterThanOrEqual(2);
+		// Ordered by created_at ASC
+		expect(body.data[0].content.text).toBe('Hello world');
+	});
+
+	it('creates an options comment and chooses an option', async () => {
+		const createRes = await app.request(`/api/companies/${companyId}/issues/${issueId}/comments`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				content_type: 'options',
+				content: {
+					prompt: 'Which approach?',
+					options: [
+						{ id: 'a', label: 'Option A' },
+						{ id: 'b', label: 'Option B' },
+					],
+				},
+			}),
+		});
+		expect(createRes.status).toBe(201);
+		const comment = (await createRes.json()).data;
+
+		const chooseRes = await app.request(
+			`/api/companies/${companyId}/issues/${issueId}/comments/${comment.id}/choose`,
+			{
+				method: 'POST',
+				headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+				body: JSON.stringify({ chosen_id: 'a' }),
+			},
+		);
+		expect(chooseRes.status).toBe(200);
+		const chosenBody = await chooseRes.json();
+		expect(chosenBody.data.chosen_option.chosen_id).toBe('a');
+	});
+});

--- a/packages/server/src/test/__tests__/comments.test.ts
+++ b/packages/server/src/test/__tests__/comments.test.ts
@@ -1,10 +1,11 @@
 import type { PGlite } from '@electric-sql/pglite';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Env } from '../../lib/types';
 import { safeClose } from '../helpers';
 import { authHeader, createTestApp } from '../helpers/app';
 
-let app: Hono;
+let app: Hono<Env>;
 let db: PGlite;
 let token: string;
 let companyId: string;

--- a/packages/server/src/test/__tests__/companies.test.ts
+++ b/packages/server/src/test/__tests__/companies.test.ts
@@ -1,10 +1,11 @@
 import type { PGlite } from '@electric-sql/pglite';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Env } from '../../lib/types';
 import { safeClose } from '../helpers';
 import { authHeader, createTestApp } from '../helpers/app';
 
-let app: Hono;
+let app: Hono<Env>;
 let db: PGlite;
 let token: string;
 let builtinTypeId: string;

--- a/packages/server/src/test/__tests__/companies.test.ts
+++ b/packages/server/src/test/__tests__/companies.test.ts
@@ -1,0 +1,148 @@
+import type { PGlite } from '@electric-sql/pglite';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { safeClose } from '../helpers';
+import { authHeader, createTestApp } from '../helpers/app';
+
+let app: Hono;
+let db: PGlite;
+let token: string;
+let builtinTypeId: string;
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+
+	// Get the built-in type ID for company creation
+	const res = await app.request('/api/company-types', {
+		headers: authHeader(token),
+	});
+	const types = (await res.json()).data;
+	builtinTypeId = types.find((t: any) => t.is_builtin).id;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+describe('companies CRUD', () => {
+	it('creates a company from built-in type with auto-created agents', async () => {
+		const res = await app.request('/api/companies', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				name: 'NoteGenius AI',
+				mission: 'Build the #1 AI note-taking app',
+				company_type_id: builtinTypeId,
+			}),
+		});
+		expect(res.status).toBe(201);
+		const body = await res.json();
+		expect(body.data.name).toBe('NoteGenius AI');
+		expect(body.data.issue_prefix).toBe('NA');
+		expect(body.data.agent_count).toBe(9);
+	});
+
+	it('creates a company without a type', async () => {
+		const res = await app.request('/api/companies', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				name: 'Solo Project',
+				issue_prefix: 'SOLO',
+			}),
+		});
+		expect(res.status).toBe(201);
+		const body = await res.json();
+		expect(body.data.issue_prefix).toBe('SOLO');
+		expect(body.data.agent_count).toBe(0);
+	});
+
+	it('rejects duplicate issue prefix', async () => {
+		const res = await app.request('/api/companies', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				name: 'Another Company',
+				issue_prefix: 'SOLO',
+			}),
+		});
+		expect(res.status).toBe(409);
+	});
+
+	it('lists companies with counts', async () => {
+		const res = await app.request('/api/companies', {
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data.length).toBeGreaterThanOrEqual(2);
+		expect(body.data[0]).toHaveProperty('agent_count');
+		expect(body.data[0]).toHaveProperty('open_issue_count');
+	});
+
+	it('gets a company by id', async () => {
+		const listRes = await app.request('/api/companies', {
+			headers: authHeader(token),
+		});
+		const companies = (await listRes.json()).data;
+		const id = companies[0].id;
+
+		const res = await app.request(`/api/companies/${id}`, {
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data.id).toBe(id);
+	});
+
+	it('updates a company', async () => {
+		const listRes = await app.request('/api/companies', {
+			headers: authHeader(token),
+		});
+		const company = (await listRes.json()).data[0];
+
+		const res = await app.request(`/api/companies/${company.id}`, {
+			method: 'PATCH',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ mission: 'Updated mission' }),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data.mission).toBe('Updated mission');
+	});
+
+	it('deletes a company', async () => {
+		// Create a throwaway company
+		const createRes = await app.request('/api/companies', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name: 'To Delete', issue_prefix: 'DEL' }),
+		});
+		const created = (await createRes.json()).data;
+
+		const res = await app.request(`/api/companies/${created.id}`, {
+			method: 'DELETE',
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+
+		const getRes = await app.request(`/api/companies/${created.id}`, {
+			headers: authHeader(token),
+		});
+		expect(getRes.status).toBe(404);
+	});
+
+	it('auto-derives issue prefix from company name', async () => {
+		const res = await app.request('/api/companies', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name: 'Acme Corp Industries' }),
+		});
+		expect(res.status).toBe(201);
+		const body = await res.json();
+		expect(body.data.issue_prefix).toBe('ACI');
+	});
+});

--- a/packages/server/src/test/__tests__/company-types.test.ts
+++ b/packages/server/src/test/__tests__/company-types.test.ts
@@ -1,0 +1,132 @@
+import type { PGlite } from '@electric-sql/pglite';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { safeClose } from '../helpers';
+import { authHeader, createTestApp } from '../helpers/app';
+
+let app: Hono;
+let db: PGlite;
+let token: string;
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+describe('company types CRUD', () => {
+	it('lists company types including the built-in one', async () => {
+		const res = await app.request('/api/company-types', {
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data.length).toBeGreaterThanOrEqual(1);
+		const builtin = body.data.find((t: any) => t.name === 'Software Development');
+		expect(builtin).toBeDefined();
+		expect(builtin.is_builtin).toBe(true);
+	});
+
+	it('creates a custom company type', async () => {
+		const res = await app.request('/api/company-types', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				name: 'Marketing Agency',
+				description: 'A marketing-focused company',
+			}),
+		});
+		expect(res.status).toBe(201);
+		const body = await res.json();
+		expect(body.data.name).toBe('Marketing Agency');
+		expect(body.data.is_builtin).toBe(false);
+	});
+
+	it('gets a company type by id', async () => {
+		// First list to get an ID
+		const listRes = await app.request('/api/company-types', {
+			headers: authHeader(token),
+		});
+		const types = (await listRes.json()).data;
+		const id = types[0].id;
+
+		const res = await app.request(`/api/company-types/${id}`, {
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data.id).toBe(id);
+	});
+
+	it('updates a custom company type', async () => {
+		// Create one
+		const createRes = await app.request('/api/company-types', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name: 'Updatable Type' }),
+		});
+		const created = (await createRes.json()).data;
+
+		const res = await app.request(`/api/company-types/${created.id}`, {
+			method: 'PATCH',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ description: 'Updated description' }),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data.description).toBe('Updated description');
+	});
+
+	it('deletes a custom company type', async () => {
+		const createRes = await app.request('/api/company-types', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name: 'Deletable Type' }),
+		});
+		const created = (await createRes.json()).data;
+
+		const res = await app.request(`/api/company-types/${created.id}`, {
+			method: 'DELETE',
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+
+		// Verify it's gone
+		const getRes = await app.request(`/api/company-types/${created.id}`, {
+			headers: authHeader(token),
+		});
+		expect(getRes.status).toBe(404);
+	});
+
+	it('prevents deleting built-in company types', async () => {
+		const listRes = await app.request('/api/company-types', {
+			headers: authHeader(token),
+		});
+		const builtin = (await listRes.json()).data.find((t: any) => t.is_builtin);
+
+		const res = await app.request(`/api/company-types/${builtin.id}`, {
+			method: 'DELETE',
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(403);
+	});
+
+	it('returns 401 without auth', async () => {
+		const res = await app.request('/api/company-types');
+		expect(res.status).toBe(401);
+	});
+
+	it('returns 400 for missing name', async () => {
+		const res = await app.request('/api/company-types', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ description: 'No name' }),
+		});
+		expect(res.status).toBe(400);
+	});
+});

--- a/packages/server/src/test/__tests__/company-types.test.ts
+++ b/packages/server/src/test/__tests__/company-types.test.ts
@@ -1,10 +1,11 @@
 import type { PGlite } from '@electric-sql/pglite';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Env } from '../../lib/types';
 import { safeClose } from '../helpers';
 import { authHeader, createTestApp } from '../helpers/app';
 
-let app: Hono;
+let app: Hono<Env>;
 let db: PGlite;
 let token: string;
 

--- a/packages/server/src/test/__tests__/costs.test.ts
+++ b/packages/server/src/test/__tests__/costs.test.ts
@@ -1,0 +1,97 @@
+import type { PGlite } from '@electric-sql/pglite';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { safeClose } from '../helpers';
+import { authHeader, createTestApp } from '../helpers/app';
+
+let app: Hono;
+let db: PGlite;
+let token: string;
+let companyId: string;
+let agentId: string;
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+
+	const typesRes = await app.request('/api/company-types', {
+		headers: authHeader(token),
+	});
+	const typeId = (await typesRes.json()).data.find((t: any) => t.is_builtin).id;
+
+	const companyRes = await app.request('/api/companies', {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			name: 'Cost Co',
+			company_type_id: typeId,
+			issue_prefix: 'COST',
+		}),
+	});
+	companyId = (await companyRes.json()).data.id;
+
+	const agentsRes = await app.request(`/api/companies/${companyId}/agents`, {
+		headers: authHeader(token),
+	});
+	// Use the engineer (has 5000 budget)
+	agentId = (await agentsRes.json()).data.find((a: any) => a.slug === 'engineer').id;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+describe('costs CRUD', () => {
+	it('creates a cost entry with budget debit', async () => {
+		const res = await app.request(`/api/companies/${companyId}/costs`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				member_id: agentId,
+				amount_cents: 100,
+				description: 'Tool call cost',
+			}),
+		});
+		expect(res.status).toBe(201);
+		const body = await res.json();
+		expect(body.data.amount_cents).toBe(100);
+	});
+
+	it('lists cost entries', async () => {
+		const res = await app.request(`/api/companies/${companyId}/costs`, {
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data.entries.length).toBeGreaterThanOrEqual(1);
+		expect(body.data.total_cents).toBeGreaterThan(0);
+	});
+
+	it('groups costs by agent', async () => {
+		const res = await app.request(`/api/companies/${companyId}/costs?group_by=agent`, {
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data.summary.length).toBeGreaterThanOrEqual(1);
+		expect(body.data.total_cents).toBeGreaterThan(0);
+	});
+
+	it('rejects budget-exceeding cost', async () => {
+		// Engineer budget is 5000 cents
+		const res = await app.request(`/api/companies/${companyId}/costs`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				member_id: agentId,
+				amount_cents: 99999,
+				description: 'Way too expensive',
+			}),
+		});
+		expect(res.status).toBe(402);
+		const body = await res.json();
+		expect(body.error.code).toBe('BUDGET_EXCEEDED');
+	});
+});

--- a/packages/server/src/test/__tests__/costs.test.ts
+++ b/packages/server/src/test/__tests__/costs.test.ts
@@ -1,10 +1,11 @@
 import type { PGlite } from '@electric-sql/pglite';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Env } from '../../lib/types';
 import { safeClose } from '../helpers';
 import { authHeader, createTestApp } from '../helpers/app';
 
-let app: Hono;
+let app: Hono<Env>;
 let db: PGlite;
 let token: string;
 let companyId: string;

--- a/packages/server/src/test/__tests__/db.test.ts
+++ b/packages/server/src/test/__tests__/db.test.ts
@@ -1,46 +1,40 @@
-import { describe, it, expect } from "vitest";
-import { createMemoryDb, createDb } from "../../db/client";
-import { safeClose } from "../helpers";
-import { mkdtemp, rm } from "fs/promises";
-import { join } from "path";
-import { tmpdir } from "os";
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { createDb, createMemoryDb } from '../../db/client';
+import { safeClose } from '../helpers';
 
-describe("PGlite client", () => {
-  it("creates an in-memory database and executes queries", async () => {
-    const db = await createMemoryDb();
-    try {
-      const result = await db.query<{ val: number }>("SELECT 1 + 1 AS val");
-      expect(result.rows[0].val).toBe(2);
-    } finally {
-      await safeClose(db);
-    }
-  });
+describe('PGlite client', () => {
+	it('creates an in-memory database and executes queries', async () => {
+		const db = await createMemoryDb();
+		try {
+			const result = await db.query<{ val: number }>('SELECT 1 + 1 AS val');
+			expect(result.rows[0].val).toBe(2);
+		} finally {
+			await safeClose(db);
+		}
+	});
 
-  it("persists data across restarts with filesystem storage", async () => {
-    const tempDir = await mkdtemp(join(tmpdir(), "hezo-db-test-"));
+	it('persists data across restarts with filesystem storage', async () => {
+		const tempDir = await mkdtemp(join(tmpdir(), 'hezo-db-test-'));
 
-    try {
-      const db1 = await createDb(tempDir);
-      await db1.exec(
-        "CREATE TABLE test_persist (id SERIAL PRIMARY KEY, name TEXT NOT NULL)",
-      );
-      await db1.query("INSERT INTO test_persist (name) VALUES ($1)", [
-        "hello",
-      ]);
-      await safeClose(db1);
+		try {
+			const db1 = await createDb(tempDir);
+			await db1.exec('CREATE TABLE test_persist (id SERIAL PRIMARY KEY, name TEXT NOT NULL)');
+			await db1.query('INSERT INTO test_persist (name) VALUES ($1)', ['hello']);
+			await safeClose(db1);
 
-      const db2 = await createDb(tempDir);
-      try {
-        const result = await db2.query<{ name: string }>(
-          "SELECT name FROM test_persist",
-        );
-        expect(result.rows).toHaveLength(1);
-        expect(result.rows[0].name).toBe("hello");
-      } finally {
-        await safeClose(db2);
-      }
-    } finally {
-      await rm(tempDir, { recursive: true, force: true });
-    }
-  });
+			const db2 = await createDb(tempDir);
+			try {
+				const result = await db2.query<{ name: string }>('SELECT name FROM test_persist');
+				expect(result.rows).toHaveLength(1);
+				expect(result.rows[0].name).toBe('hello');
+			} finally {
+				await safeClose(db2);
+			}
+		} finally {
+			await rm(tempDir, { recursive: true, force: true });
+		}
+	});
 });

--- a/packages/server/src/test/__tests__/health.test.ts
+++ b/packages/server/src/test/__tests__/health.test.ts
@@ -1,11 +1,11 @@
-import { describe, it, expect } from "vitest";
-import { app } from "../../app";
+import { describe, expect, it } from 'vitest';
+import { app } from '../../app';
 
-describe("GET /health", () => {
-  it("returns ok: true", async () => {
-    const res = await app.request("/health");
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body).toEqual({ ok: true });
-  });
+describe('GET /health', () => {
+	it('returns ok: true', async () => {
+		const res = await app.request('/health');
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body).toEqual({ ok: true });
+	});
 });

--- a/packages/server/src/test/__tests__/issues.test.ts
+++ b/packages/server/src/test/__tests__/issues.test.ts
@@ -1,10 +1,11 @@
 import type { PGlite } from '@electric-sql/pglite';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Env } from '../../lib/types';
 import { safeClose } from '../helpers';
 import { authHeader, createTestApp } from '../helpers/app';
 
-let app: Hono;
+let app: Hono<Env>;
 let db: PGlite;
 let token: string;
 let companyId: string;

--- a/packages/server/src/test/__tests__/issues.test.ts
+++ b/packages/server/src/test/__tests__/issues.test.ts
@@ -1,0 +1,207 @@
+import type { PGlite } from '@electric-sql/pglite';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { safeClose } from '../helpers';
+import { authHeader, createTestApp } from '../helpers/app';
+
+let app: Hono;
+let db: PGlite;
+let token: string;
+let companyId: string;
+let projectId: string;
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+
+	const companyRes = await app.request('/api/companies', {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ name: 'Issue Test Co', issue_prefix: 'ITC' }),
+	});
+	companyId = (await companyRes.json()).data.id;
+
+	const projectRes = await app.request(`/api/companies/${companyId}/projects`, {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ name: 'Main Project' }),
+	});
+	projectId = (await projectRes.json()).data.id;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+describe('issues CRUD', () => {
+	it('creates an issue with auto-generated identifier', async () => {
+		const res = await app.request(`/api/companies/${companyId}/issues`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				project_id: projectId,
+				title: 'First issue',
+				priority: 'high',
+			}),
+		});
+		expect(res.status).toBe(201);
+		const body = await res.json();
+		expect(body.data.identifier).toBe('ITC-1');
+		expect(body.data.number).toBe(1);
+		expect(body.data.status).toBe('backlog');
+		expect(body.data.priority).toBe('high');
+	});
+
+	it('creates sequential issue numbers', async () => {
+		const res = await app.request(`/api/companies/${companyId}/issues`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				project_id: projectId,
+				title: 'Second issue',
+			}),
+		});
+		expect(res.status).toBe(201);
+		expect((await res.json()).data.identifier).toBe('ITC-2');
+	});
+
+	it('lists issues with pagination', async () => {
+		const res = await app.request(`/api/companies/${companyId}/issues?per_page=1`, {
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data).toHaveLength(1);
+		expect(body.meta.total).toBeGreaterThanOrEqual(2);
+		expect(body.meta.per_page).toBe(1);
+	});
+
+	it('filters issues by status', async () => {
+		const res = await app.request(`/api/companies/${companyId}/issues?status=backlog`, {
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data.every((i: any) => i.status === 'backlog')).toBe(true);
+	});
+
+	it('gets an issue by id with computed fields', async () => {
+		const listRes = await app.request(`/api/companies/${companyId}/issues`, {
+			headers: authHeader(token),
+		});
+		const issue = (await listRes.json()).data[0];
+
+		const res = await app.request(`/api/companies/${companyId}/issues/${issue.id}`, {
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data).toHaveProperty('project_name');
+		expect(body.data).toHaveProperty('comment_count');
+		expect(body.data).toHaveProperty('cost_cents');
+	});
+
+	it('updates an issue status', async () => {
+		const listRes = await app.request(`/api/companies/${companyId}/issues`, {
+			headers: authHeader(token),
+		});
+		const issue = (await listRes.json()).data[0];
+
+		const res = await app.request(`/api/companies/${companyId}/issues/${issue.id}`, {
+			method: 'PATCH',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ status: 'in_progress' }),
+		});
+		expect(res.status).toBe(200);
+		expect((await res.json()).data.status).toBe('in_progress');
+	});
+
+	it('creates a sub-issue', async () => {
+		const listRes = await app.request(`/api/companies/${companyId}/issues`, {
+			headers: authHeader(token),
+		});
+		const parentIssue = (await listRes.json()).data[0];
+
+		const res = await app.request(
+			`/api/companies/${companyId}/issues/${parentIssue.id}/sub-issues`,
+			{
+				method: 'POST',
+				headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+				body: JSON.stringify({ title: 'Sub-task' }),
+			},
+		);
+		expect(res.status).toBe(201);
+		const body = await res.json();
+		expect(body.data.parent_issue_id).toBe(parentIssue.id);
+		expect(body.data.identifier).toBe('ITC-3');
+	});
+
+	it('manages issue dependencies', async () => {
+		const listRes = await app.request(`/api/companies/${companyId}/issues`, {
+			headers: authHeader(token),
+		});
+		const issues = (await listRes.json()).data;
+
+		// Add dependency
+		const addRes = await app.request(
+			`/api/companies/${companyId}/issues/${issues[0].id}/dependencies`,
+			{
+				method: 'POST',
+				headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+				body: JSON.stringify({ blocked_by_issue_id: issues[1].id }),
+			},
+		);
+		expect(addRes.status).toBe(201);
+
+		// List dependencies
+		const listDepsRes = await app.request(
+			`/api/companies/${companyId}/issues/${issues[0].id}/dependencies`,
+			{ headers: authHeader(token) },
+		);
+		expect(listDepsRes.status).toBe(200);
+		const deps = (await listDepsRes.json()).data;
+		expect(deps).toHaveLength(1);
+
+		// Remove dependency
+		const removeRes = await app.request(
+			`/api/companies/${companyId}/issues/${issues[0].id}/dependencies/${deps[0].id}`,
+			{ method: 'DELETE', headers: authHeader(token) },
+		);
+		expect(removeRes.status).toBe(200);
+	});
+
+	it('deletes a backlog issue with no comments', async () => {
+		const createRes = await app.request(`/api/companies/${companyId}/issues`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				project_id: projectId,
+				title: 'To delete',
+			}),
+		});
+		const issue = (await createRes.json()).data;
+
+		const res = await app.request(`/api/companies/${companyId}/issues/${issue.id}`, {
+			method: 'DELETE',
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+	});
+
+	it('prevents deleting an in-progress issue', async () => {
+		const listRes = await app.request(`/api/companies/${companyId}/issues`, {
+			headers: authHeader(token),
+		});
+		const inProgress = (await listRes.json()).data.find((i: any) => i.status === 'in_progress');
+
+		if (inProgress) {
+			const res = await app.request(`/api/companies/${companyId}/issues/${inProgress.id}`, {
+				method: 'DELETE',
+				headers: authHeader(token),
+			});
+			expect(res.status).toBe(403);
+		}
+	});
+});

--- a/packages/server/src/test/__tests__/master-key.test.ts
+++ b/packages/server/src/test/__tests__/master-key.test.ts
@@ -1,144 +1,139 @@
-import { describe, it, expect, beforeEach } from "vitest";
-import { PGlite } from "@electric-sql/pglite";
-import {
-  encrypt,
-  decrypt,
-  deriveKey,
-  generateMasterKey,
-} from "../../crypto/encryption";
-import { MasterKeyManager } from "../../crypto/master-key";
+import { PGlite } from '@electric-sql/pglite';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { decrypt, deriveKey, encrypt, generateMasterKey } from '../../crypto/encryption';
+import { MasterKeyManager } from '../../crypto/master-key';
 
-describe("encryption", () => {
-  it("encrypts and decrypts to original plaintext", async () => {
-    const key = await deriveKey("test-key", "test");
-    const plaintext = "hello world";
-    const encrypted = encrypt(plaintext, key);
-    expect(decrypt(encrypted, key)).toBe(plaintext);
-  });
+describe('encryption', () => {
+	it('encrypts and decrypts to original plaintext', async () => {
+		const key = await deriveKey('test-key', 'test');
+		const plaintext = 'hello world';
+		const encrypted = encrypt(plaintext, key);
+		expect(decrypt(encrypted, key)).toBe(plaintext);
+	});
 
-  it("fails to decrypt with wrong key", async () => {
-    const key1 = await deriveKey("key-one", "test");
-    const key2 = await deriveKey("key-two", "test");
-    const encrypted = encrypt("secret", key1);
-    expect(() => decrypt(encrypted, key2)).toThrow();
-  });
+	it('fails to decrypt with wrong key', async () => {
+		const key1 = await deriveKey('key-one', 'test');
+		const key2 = await deriveKey('key-two', 'test');
+		const encrypted = encrypt('secret', key1);
+		expect(() => decrypt(encrypted, key2)).toThrow();
+	});
 
-  it("generates a 64-char hex master key", () => {
-    const key = generateMasterKey();
-    expect(key).toMatch(/^[0-9a-f]{64}$/);
-  });
+	it('generates a 64-char hex master key', () => {
+		const key = generateMasterKey();
+		expect(key).toMatch(/^[0-9a-f]{64}$/);
+	});
 
-  it("derives consistent keys for same inputs", async () => {
-    const a = await deriveKey("master", "purpose");
-    const b = await deriveKey("master", "purpose");
-    expect(a.equals(b)).toBe(true);
-  });
+	it('derives consistent keys for same inputs', async () => {
+		const a = await deriveKey('master', 'purpose');
+		const b = await deriveKey('master', 'purpose');
+		expect(a.equals(b)).toBe(true);
+	});
 
-  it("derives different keys for different purposes", async () => {
-    const a = await deriveKey("master", "purpose-a");
-    const b = await deriveKey("master", "purpose-b");
-    expect(a.equals(b)).toBe(false);
-  });
+	it('derives different keys for different purposes', async () => {
+		const a = await deriveKey('master', 'purpose-a');
+		const b = await deriveKey('master', 'purpose-b');
+		expect(a.equals(b)).toBe(false);
+	});
 });
 
-describe("MasterKeyManager", () => {
-  let db: PGlite;
+describe('MasterKeyManager', () => {
+	let db: PGlite;
 
-  beforeEach(async () => {
-    db = new PGlite();
-    await db.query(
-      "CREATE TABLE IF NOT EXISTS system_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)",
-    );
-  });
+	beforeEach(async () => {
+		db = new PGlite();
+		await db.query(
+			'CREATE TABLE IF NOT EXISTS system_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)',
+		);
+	});
 
-  it("returns 'unset' on first run with no key", async () => {
-    const mgr = new MasterKeyManager();
-    const state = await mgr.initialize(db);
-    expect(state).toBe("unset");
-    expect(mgr.getKey()).toBeNull();
-  });
+	it("returns 'unset' on first run with no key", async () => {
+		const mgr = new MasterKeyManager();
+		const state = await mgr.initialize(db);
+		expect(state).toBe('unset');
+		expect(mgr.getKey()).toBeNull();
+	});
 
-  it("returns 'unlocked' on first run with key provided", async () => {
-    const mgr = new MasterKeyManager();
-    const key = generateMasterKey();
-    const state = await mgr.initialize(db, key);
-    expect(state).toBe("unlocked");
-    expect(mgr.getKey()).not.toBeNull();
-  });
+	it("returns 'unlocked' on first run with key provided", async () => {
+		const mgr = new MasterKeyManager();
+		const key = generateMasterKey();
+		const state = await mgr.initialize(db, key);
+		expect(state).toBe('unlocked');
+		expect(mgr.getKey()).not.toBeNull();
+	});
 
-  it("returns 'unlocked' on subsequent run with correct key", async () => {
-    const key = generateMasterKey();
-    const mgr1 = new MasterKeyManager();
-    await mgr1.initialize(db, key);
+	it("returns 'unlocked' on subsequent run with correct key", async () => {
+		const key = generateMasterKey();
+		const mgr1 = new MasterKeyManager();
+		await mgr1.initialize(db, key);
 
-    const mgr2 = new MasterKeyManager();
-    const state = await mgr2.initialize(db, key);
-    expect(state).toBe("unlocked");
-  });
+		const mgr2 = new MasterKeyManager();
+		const state = await mgr2.initialize(db, key);
+		expect(state).toBe('unlocked');
+	});
 
-  it("returns 'locked' on subsequent run with wrong key", async () => {
-    const correctKey = generateMasterKey();
-    const wrongKey = generateMasterKey();
-    const mgr1 = new MasterKeyManager();
-    await mgr1.initialize(db, correctKey);
+	it("returns 'locked' on subsequent run with wrong key", async () => {
+		const correctKey = generateMasterKey();
+		const wrongKey = generateMasterKey();
+		const mgr1 = new MasterKeyManager();
+		await mgr1.initialize(db, correctKey);
 
-    const mgr2 = new MasterKeyManager();
-    const state = await mgr2.initialize(db, wrongKey);
-    expect(state).toBe("locked");
-    expect(mgr2.getKey()).toBeNull();
-  });
+		const mgr2 = new MasterKeyManager();
+		const state = await mgr2.initialize(db, wrongKey);
+		expect(state).toBe('locked');
+		expect(mgr2.getKey()).toBeNull();
+	});
 
-  it("returns 'locked' on subsequent run with no key", async () => {
-    const key = generateMasterKey();
-    const mgr1 = new MasterKeyManager();
-    await mgr1.initialize(db, key);
+	it("returns 'locked' on subsequent run with no key", async () => {
+		const key = generateMasterKey();
+		const mgr1 = new MasterKeyManager();
+		await mgr1.initialize(db, key);
 
-    const mgr2 = new MasterKeyManager();
-    const state = await mgr2.initialize(db);
-    expect(state).toBe("locked");
-  });
+		const mgr2 = new MasterKeyManager();
+		const state = await mgr2.initialize(db);
+		expect(state).toBe('locked');
+	});
 
-  it("unlocks from 'locked' with correct key", async () => {
-    const key = generateMasterKey();
-    const mgr1 = new MasterKeyManager();
-    await mgr1.initialize(db, key);
+	it("unlocks from 'locked' with correct key", async () => {
+		const key = generateMasterKey();
+		const mgr1 = new MasterKeyManager();
+		await mgr1.initialize(db, key);
 
-    const mgr2 = new MasterKeyManager();
-    await mgr2.initialize(db);
-    expect(mgr2.getState()).toBe("locked");
+		const mgr2 = new MasterKeyManager();
+		await mgr2.initialize(db);
+		expect(mgr2.getState()).toBe('locked');
 
-    const result = await mgr2.unlock(db, key);
-    expect(result).toBe(true);
-    expect(mgr2.getState()).toBe("unlocked");
-    expect(mgr2.getKey()).not.toBeNull();
-  });
+		const result = await mgr2.unlock(db, key);
+		expect(result).toBe(true);
+		expect(mgr2.getState()).toBe('unlocked');
+		expect(mgr2.getKey()).not.toBeNull();
+	});
 
-  it("stays 'locked' when unlocking with wrong key", async () => {
-    const key = generateMasterKey();
-    const mgr1 = new MasterKeyManager();
-    await mgr1.initialize(db, key);
+	it("stays 'locked' when unlocking with wrong key", async () => {
+		const key = generateMasterKey();
+		const mgr1 = new MasterKeyManager();
+		await mgr1.initialize(db, key);
 
-    const mgr2 = new MasterKeyManager();
-    await mgr2.initialize(db);
+		const mgr2 = new MasterKeyManager();
+		await mgr2.initialize(db);
 
-    const result = await mgr2.unlock(db, generateMasterKey());
-    expect(result).toBe(false);
-    expect(mgr2.getState()).toBe("locked");
-  });
+		const result = await mgr2.unlock(db, generateMasterKey());
+		expect(result).toBe(false);
+		expect(mgr2.getState()).toBe('locked');
+	});
 
-  it("unlocks from 'unset' by storing canary", async () => {
-    const mgr = new MasterKeyManager();
-    await mgr.initialize(db);
-    expect(mgr.getState()).toBe("unset");
+	it("unlocks from 'unset' by storing canary", async () => {
+		const mgr = new MasterKeyManager();
+		await mgr.initialize(db);
+		expect(mgr.getState()).toBe('unset');
 
-    const key = generateMasterKey();
-    const result = await mgr.unlock(db, key);
-    expect(result).toBe(true);
-    expect(mgr.getState()).toBe("unlocked");
+		const key = generateMasterKey();
+		const result = await mgr.unlock(db, key);
+		expect(result).toBe(true);
+		expect(mgr.getState()).toBe('unlocked');
 
-    // Verify canary was stored by initializing a new manager
-    const mgr2 = new MasterKeyManager();
-    const state = await mgr2.initialize(db, key);
-    expect(state).toBe("unlocked");
-  });
+		// Verify canary was stored by initializing a new manager
+		const mgr2 = new MasterKeyManager();
+		const state = await mgr2.initialize(db, key);
+		expect(state).toBe('unlocked');
+	});
 });

--- a/packages/server/src/test/__tests__/migrate.test.ts
+++ b/packages/server/src/test/__tests__/migrate.test.ts
@@ -1,104 +1,91 @@
-import { describe, it, expect, vi } from "vitest";
-import { createMemoryDb } from "../../db/client";
-import { runMigrations } from "../../db/migrate";
-import { safeClose } from "../helpers";
+import { describe, expect, it, vi } from 'vitest';
+import { createMemoryDb } from '../../db/client';
+import { runMigrations } from '../../db/migrate';
+import { safeClose } from '../helpers';
 
-describe("migration runner", () => {
-  it("creates _migrations table and applies migrations", async () => {
-    const db = await createMemoryDb();
-    try {
-      const migrations = {
-        "001_test.sql":
-          "CREATE TABLE test_table (id SERIAL PRIMARY KEY, name TEXT NOT NULL);",
-      };
+describe('migration runner', () => {
+	it('creates _migrations table and applies migrations', async () => {
+		const db = await createMemoryDb();
+		try {
+			const migrations = {
+				'001_test.sql': 'CREATE TABLE test_table (id SERIAL PRIMARY KEY, name TEXT NOT NULL);',
+			};
 
-      await runMigrations(db, migrations);
+			await runMigrations(db, migrations);
 
-      const tables = await db.query<{ tablename: string }>(
-        "SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND tablename = '_migrations'",
-      );
-      expect(tables.rows).toHaveLength(1);
+			const tables = await db.query<{ tablename: string }>(
+				"SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND tablename = '_migrations'",
+			);
+			expect(tables.rows).toHaveLength(1);
 
-      const applied = await db.query<{ filename: string }>(
-        "SELECT filename FROM _migrations",
-      );
-      expect(applied.rows).toHaveLength(1);
-      expect(applied.rows[0].filename).toBe("001_test.sql");
+			const applied = await db.query<{ filename: string }>('SELECT filename FROM _migrations');
+			expect(applied.rows).toHaveLength(1);
+			expect(applied.rows[0].filename).toBe('001_test.sql');
 
-      const testRows = await db.query("SELECT * FROM test_table");
-      expect(testRows.rows).toHaveLength(0);
-    } finally {
-      await safeClose(db);
-    }
-  });
+			const testRows = await db.query('SELECT * FROM test_table');
+			expect(testRows.rows).toHaveLength(0);
+		} finally {
+			await safeClose(db);
+		}
+	});
 
-  it("skips already-applied migrations on second run", async () => {
-    const db = await createMemoryDb();
-    try {
-      const migrations = {
-        "001_test.sql":
-          "CREATE TABLE test_table (id SERIAL PRIMARY KEY, name TEXT NOT NULL);",
-      };
+	it('skips already-applied migrations on second run', async () => {
+		const db = await createMemoryDb();
+		try {
+			const migrations = {
+				'001_test.sql': 'CREATE TABLE test_table (id SERIAL PRIMARY KEY, name TEXT NOT NULL);',
+			};
 
-      await runMigrations(db, migrations);
-      await runMigrations(db, migrations);
+			await runMigrations(db, migrations);
+			await runMigrations(db, migrations);
 
-      const applied = await db.query<{ filename: string }>(
-        "SELECT filename FROM _migrations",
-      );
-      expect(applied.rows).toHaveLength(1);
-    } finally {
-      await safeClose(db);
-    }
-  });
+			const applied = await db.query<{ filename: string }>('SELECT filename FROM _migrations');
+			expect(applied.rows).toHaveLength(1);
+		} finally {
+			await safeClose(db);
+		}
+	});
 
-  it("warns when a migration checksum has changed", async () => {
-    const db = await createMemoryDb();
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+	it('warns when a migration checksum has changed', async () => {
+		const db = await createMemoryDb();
+		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-    try {
-      await runMigrations(db, {
-        "001_test.sql": "CREATE TABLE test_table (id SERIAL PRIMARY KEY);",
-      });
+		try {
+			await runMigrations(db, {
+				'001_test.sql': 'CREATE TABLE test_table (id SERIAL PRIMARY KEY);',
+			});
 
-      await runMigrations(db, {
-        "001_test.sql":
-          "CREATE TABLE test_table (id SERIAL PRIMARY KEY, name TEXT);",
-      });
+			await runMigrations(db, {
+				'001_test.sql': 'CREATE TABLE test_table (id SERIAL PRIMARY KEY, name TEXT);',
+			});
 
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining("001_test.sql"),
-      );
-    } finally {
-      warnSpy.mockRestore();
-      await safeClose(db);
-    }
-  });
+			expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('001_test.sql'));
+		} finally {
+			warnSpy.mockRestore();
+			await safeClose(db);
+		}
+	});
 
-  it("rolls back a failed migration", async () => {
-    const db = await createMemoryDb();
-    try {
-      const migrations = {
-        "001_good.sql": "CREATE TABLE good_table (id SERIAL PRIMARY KEY);",
-        "002_bad.sql": "THIS IS NOT VALID SQL;",
-      };
+	it('rolls back a failed migration', async () => {
+		const db = await createMemoryDb();
+		try {
+			const migrations = {
+				'001_good.sql': 'CREATE TABLE good_table (id SERIAL PRIMARY KEY);',
+				'002_bad.sql': 'THIS IS NOT VALID SQL;',
+			};
 
-      await expect(runMigrations(db, migrations)).rejects.toThrow(
-        "002_bad.sql",
-      );
+			await expect(runMigrations(db, migrations)).rejects.toThrow('002_bad.sql');
 
-      const applied = await db.query<{ filename: string }>(
-        "SELECT filename FROM _migrations",
-      );
-      expect(applied.rows).toHaveLength(1);
-      expect(applied.rows[0].filename).toBe("001_good.sql");
+			const applied = await db.query<{ filename: string }>('SELECT filename FROM _migrations');
+			expect(applied.rows).toHaveLength(1);
+			expect(applied.rows[0].filename).toBe('001_good.sql');
 
-      const badTable = await db.query<{ tablename: string }>(
-        "SELECT tablename FROM pg_tables WHERE tablename = 'bad_table'",
-      );
-      expect(badTable.rows).toHaveLength(0);
-    } finally {
-      await safeClose(db);
-    }
-  });
+			const badTable = await db.query<{ tablename: string }>(
+				"SELECT tablename FROM pg_tables WHERE tablename = 'bad_table'",
+			);
+			expect(badTable.rows).toHaveLength(0);
+		} finally {
+			await safeClose(db);
+		}
+	});
 });

--- a/packages/server/src/test/__tests__/projects.test.ts
+++ b/packages/server/src/test/__tests__/projects.test.ts
@@ -1,0 +1,97 @@
+import type { PGlite } from '@electric-sql/pglite';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { safeClose } from '../helpers';
+import { authHeader, createTestApp } from '../helpers/app';
+
+let app: Hono;
+let db: PGlite;
+let token: string;
+let companyId: string;
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+
+	const companyRes = await app.request('/api/companies', {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ name: 'Project Test Co', issue_prefix: 'PTC' }),
+	});
+	companyId = (await companyRes.json()).data.id;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+describe('projects CRUD', () => {
+	it('creates a project', async () => {
+		const res = await app.request(`/api/companies/${companyId}/projects`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name: 'Backend API', goal: 'Ship fast' }),
+		});
+		expect(res.status).toBe(201);
+		const body = await res.json();
+		expect(body.data.name).toBe('Backend API');
+		expect(body.data.company_id).toBe(companyId);
+	});
+
+	it('lists projects with counts', async () => {
+		const res = await app.request(`/api/companies/${companyId}/projects`, {
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data.length).toBeGreaterThanOrEqual(1);
+		expect(body.data[0]).toHaveProperty('repo_count');
+		expect(body.data[0]).toHaveProperty('open_issue_count');
+	});
+
+	it('gets a project by id with repos', async () => {
+		const listRes = await app.request(`/api/companies/${companyId}/projects`, {
+			headers: authHeader(token),
+		});
+		const project = (await listRes.json()).data[0];
+
+		const res = await app.request(`/api/companies/${companyId}/projects/${project.id}`, {
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data).toHaveProperty('repos');
+	});
+
+	it('updates a project', async () => {
+		const listRes = await app.request(`/api/companies/${companyId}/projects`, {
+			headers: authHeader(token),
+		});
+		const project = (await listRes.json()).data[0];
+
+		const res = await app.request(`/api/companies/${companyId}/projects/${project.id}`, {
+			method: 'PATCH',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ goal: 'Updated goal' }),
+		});
+		expect(res.status).toBe(200);
+		expect((await res.json()).data.goal).toBe('Updated goal');
+	});
+
+	it('deletes a project with no open issues', async () => {
+		const createRes = await app.request(`/api/companies/${companyId}/projects`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name: 'Temp Project' }),
+		});
+		const project = (await createRes.json()).data;
+
+		const res = await app.request(`/api/companies/${companyId}/projects/${project.id}`, {
+			method: 'DELETE',
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+	});
+});

--- a/packages/server/src/test/__tests__/projects.test.ts
+++ b/packages/server/src/test/__tests__/projects.test.ts
@@ -1,10 +1,11 @@
 import type { PGlite } from '@electric-sql/pglite';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Env } from '../../lib/types';
 import { safeClose } from '../helpers';
 import { authHeader, createTestApp } from '../helpers/app';
 
-let app: Hono;
+let app: Hono<Env>;
 let db: PGlite;
 let token: string;
 let companyId: string;

--- a/packages/server/src/test/__tests__/secrets.test.ts
+++ b/packages/server/src/test/__tests__/secrets.test.ts
@@ -1,0 +1,115 @@
+import type { PGlite } from '@electric-sql/pglite';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { safeClose } from '../helpers';
+import { authHeader, createTestApp } from '../helpers/app';
+
+let app: Hono;
+let db: PGlite;
+let token: string;
+let companyId: string;
+let agentId: string;
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+
+	// Create a company with agents
+	const typesRes = await app.request('/api/company-types', {
+		headers: authHeader(token),
+	});
+	const typeId = (await typesRes.json()).data.find((t: any) => t.is_builtin).id;
+
+	const companyRes = await app.request('/api/companies', {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			name: 'Secret Co',
+			company_type_id: typeId,
+			issue_prefix: 'SC',
+		}),
+	});
+	companyId = (await companyRes.json()).data.id;
+
+	// Get an agent ID
+	const agentsRes = await app.request(`/api/companies/${companyId}/agents`, {
+		headers: authHeader(token),
+	});
+	agentId = (await agentsRes.json()).data[0].id;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+describe('secrets CRUD', () => {
+	let secretId: string;
+
+	it('creates a secret (value encrypted)', async () => {
+		const res = await app.request(`/api/companies/${companyId}/secrets`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				name: 'GITHUB_TOKEN',
+				value: 'ghp_abc123',
+				category: 'api_token',
+			}),
+		});
+		expect(res.status).toBe(201);
+		const body = await res.json();
+		expect(body.data.name).toBe('GITHUB_TOKEN');
+		expect(body.data.category).toBe('api_token');
+		// Value should NOT be returned
+		expect(body.data).not.toHaveProperty('encrypted_value');
+		expect(body.data).not.toHaveProperty('value');
+		secretId = body.data.id;
+	});
+
+	it('lists secrets (no values)', async () => {
+		const res = await app.request(`/api/companies/${companyId}/secrets`, {
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data.length).toBeGreaterThanOrEqual(1);
+		expect(body.data[0]).toHaveProperty('grant_count');
+		expect(body.data[0]).not.toHaveProperty('encrypted_value');
+	});
+
+	it('creates and revokes a secret grant', async () => {
+		// Create grant
+		const grantRes = await app.request(`/api/companies/${companyId}/secrets/${secretId}/grants`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ agent_id: agentId, scope: 'single' }),
+		});
+		expect(grantRes.status).toBe(201);
+		const grant = (await grantRes.json()).data;
+		expect(grant.scope).toBe('single');
+
+		// List grants
+		const listRes = await app.request(`/api/companies/${companyId}/secrets/${secretId}/grants`, {
+			headers: authHeader(token),
+		});
+		expect((await listRes.json()).data).toHaveLength(1);
+
+		// Revoke
+		const revokeRes = await app.request(`/api/companies/${companyId}/secret-grants/${grant.id}`, {
+			method: 'DELETE',
+			headers: authHeader(token),
+		});
+		expect(revokeRes.status).toBe(200);
+		const revoked = (await revokeRes.json()).data;
+		expect(revoked.revoked_at).not.toBeNull();
+	});
+
+	it('deletes a secret', async () => {
+		const res = await app.request(`/api/companies/${companyId}/secrets/${secretId}`, {
+			method: 'DELETE',
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+	});
+});

--- a/packages/server/src/test/__tests__/secrets.test.ts
+++ b/packages/server/src/test/__tests__/secrets.test.ts
@@ -1,10 +1,11 @@
 import type { PGlite } from '@electric-sql/pglite';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Env } from '../../lib/types';
 import { safeClose } from '../helpers';
 import { authHeader, createTestApp } from '../helpers/app';
 
-let app: Hono;
+let app: Hono<Env>;
 let db: PGlite;
 let token: string;
 let companyId: string;

--- a/packages/server/src/test/__tests__/startup.test.ts
+++ b/packages/server/src/test/__tests__/startup.test.ts
@@ -1,80 +1,80 @@
-import { describe, it, expect, afterEach } from "vitest";
-import { mkdtempSync, rmSync, existsSync } from "fs";
-import { join } from "path";
-import { tmpdir } from "os";
-import { startup, type HezoConfig } from "../../startup";
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { type HezoConfig, startup } from '../../startup';
 
 function makeTempDir(): string {
-  return mkdtempSync(join(tmpdir(), "hezo-test-"));
+	return mkdtempSync(join(tmpdir(), 'hezo-test-'));
 }
 
 function baseConfig(overrides: Partial<HezoConfig> = {}): HezoConfig {
-  return {
-    port: 0,
-    dataDir: overrides.dataDir ?? makeTempDir(),
-    connectUrl: "https://connect.test",
-    reset: false,
-    noOpen: false,
-    ...overrides,
-  };
+	return {
+		port: 0,
+		dataDir: overrides.dataDir ?? makeTempDir(),
+		connectUrl: 'https://connect.test',
+		reset: false,
+		noOpen: false,
+		...overrides,
+	};
 }
 
-describe("startup", () => {
-  const tempDirs: string[] = [];
+describe('startup', () => {
+	const tempDirs: string[] = [];
 
-  afterEach(() => {
-    for (const dir of tempDirs) {
-      rmSync(dir, { recursive: true, force: true });
-    }
-    tempDirs.length = 0;
-  });
+	afterEach(() => {
+		for (const dir of tempDirs) {
+			rmSync(dir, { recursive: true, force: true });
+		}
+		tempDirs.length = 0;
+	});
 
-  it("starts successfully and returns an app with health endpoint", async () => {
-    const config = baseConfig();
-    tempDirs.push(config.dataDir);
+	it('starts successfully and returns an app with health endpoint', async () => {
+		const config = baseConfig();
+		tempDirs.push(config.dataDir);
 
-    const result = await startup(config);
+		const result = await startup(config);
 
-    expect(result.app).toBeDefined();
-    expect(result.port).toBe(0);
-    expect(["unset", "locked", "unlocked"]).toContain(result.masterKeyState);
+		expect(result.app).toBeDefined();
+		expect(result.port).toBe(0);
+		expect(['unset', 'locked', 'unlocked']).toContain(result.masterKeyState);
 
-    const res = await result.app.request("/health");
-    expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ ok: true });
-  });
+		const res = await result.app.request('/health');
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ ok: true });
+	});
 
-  it("returns status endpoint with masterKeyState and version", async () => {
-    const config = baseConfig();
-    tempDirs.push(config.dataDir);
+	it('returns status endpoint with masterKeyState and version', async () => {
+		const config = baseConfig();
+		tempDirs.push(config.dataDir);
 
-    const result = await startup(config);
+		const result = await startup(config);
 
-    const res = await result.app.request("/api/status");
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body).toHaveProperty("masterKeyState");
-    expect(body).toHaveProperty("version", "0.1.0");
-  });
+		const res = await result.app.request('/api/status');
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body).toHaveProperty('masterKeyState');
+		expect(body).toHaveProperty('version', '0.1.0');
+	});
 
-  it("handles --reset flag with a fresh data directory", async () => {
-    const config = baseConfig({ reset: true });
-    tempDirs.push(config.dataDir);
+	it('handles --reset flag with a fresh data directory', async () => {
+		const config = baseConfig({ reset: true });
+		tempDirs.push(config.dataDir);
 
-    const result = await startup(config);
+		const result = await startup(config);
 
-    expect(result.app).toBeDefined();
-    const res = await result.app.request("/health");
-    expect(res.status).toBe(200);
-  });
+		expect(result.app).toBeDefined();
+		const res = await result.app.request('/health');
+		expect(res.status).toBe(200);
+	});
 
-  it("creates the data directory if it does not exist", async () => {
-    const dataDir = join(tmpdir(), `hezo-test-${Date.now()}-nonexistent`);
-    tempDirs.push(dataDir);
-    const config = baseConfig({ dataDir });
+	it('creates the data directory if it does not exist', async () => {
+		const dataDir = join(tmpdir(), `hezo-test-${Date.now()}-nonexistent`);
+		tempDirs.push(dataDir);
+		const config = baseConfig({ dataDir });
 
-    expect(existsSync(dataDir)).toBe(false);
-    await startup(config);
-    expect(existsSync(dataDir)).toBe(true);
-  });
+		expect(existsSync(dataDir)).toBe(false);
+		await startup(config);
+		expect(existsSync(dataDir)).toBe(true);
+	});
 });

--- a/packages/server/src/test/helpers.ts
+++ b/packages/server/src/test/helpers.ts
@@ -1,7 +1,7 @@
 export async function safeClose(db: { close: () => Promise<void> }) {
-  try {
-    await db.close();
-  } catch {
-    // PGlite 0.2 can throw on close in some environments
-  }
+	try {
+		await db.close();
+	} catch {
+		// PGlite 0.2 can throw on close in some environments
+	}
 }

--- a/packages/server/src/test/helpers/app.ts
+++ b/packages/server/src/test/helpers/app.ts
@@ -1,0 +1,22 @@
+import type { PGlite } from '@electric-sql/pglite';
+import { generateMasterKey, MasterKeyManager } from '../../crypto/master-key';
+import { seedBuiltins } from '../../db/seed';
+import { signBoardJwt } from '../../middleware/auth';
+import { buildApp } from '../../startup';
+import { createTestDbWithMigrations } from './db';
+
+export async function createTestApp() {
+	const db = await createTestDbWithMigrations();
+	const masterKeyManager = new MasterKeyManager();
+	const masterKeyHex = generateMasterKey();
+	await masterKeyManager.initialize(db, masterKeyHex);
+	await seedBuiltins(db);
+	const app = buildApp(db, masterKeyManager);
+	const token = await signBoardJwt(masterKeyManager, 'test-user');
+
+	return { app, db, token, masterKeyHex, masterKeyManager };
+}
+
+export function authHeader(token: string) {
+	return { Authorization: `Bearer ${token}` };
+}

--- a/packages/server/src/test/helpers/app.ts
+++ b/packages/server/src/test/helpers/app.ts
@@ -1,4 +1,3 @@
-import type { PGlite } from '@electric-sql/pglite';
 import { generateMasterKey, MasterKeyManager } from '../../crypto/master-key';
 import { seedBuiltins } from '../../db/seed';
 import { signBoardJwt } from '../../middleware/auth';

--- a/packages/server/src/test/helpers/db.ts
+++ b/packages/server/src/test/helpers/db.ts
@@ -1,6 +1,6 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { PGlite } from '@electric-sql/pglite';
-import { readdirSync, readFileSync } from 'fs';
-import { join } from 'path';
 import { BASE_SCHEMA } from '../../db/schema';
 
 /** Creates a fresh in-memory PGlite instance with base tables for testing. */

--- a/packages/server/src/test/helpers/db.ts
+++ b/packages/server/src/test/helpers/db.ts
@@ -1,32 +1,53 @@
-import { PGlite } from "@electric-sql/pglite";
-import { BASE_SCHEMA } from "../../db/schema";
+import { PGlite } from '@electric-sql/pglite';
+import { readdirSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { BASE_SCHEMA } from '../../db/schema';
 
 /** Creates a fresh in-memory PGlite instance with base tables for testing. */
 export async function createTestDb(): Promise<PGlite> {
-  const db = new PGlite();
-  await db.exec(BASE_SCHEMA);
-  return db;
+	const db = new PGlite();
+	await db.exec(BASE_SCHEMA);
+	return db;
 }
 
-/** Creates a test DB with full migrations applied (falls back to base schema). */
+/** Creates a test DB with full migrations applied. */
 export async function createTestDbWithMigrations(): Promise<PGlite> {
-  const db = new PGlite();
-  try {
-    const { runMigrations, loadFilesystemMigrations } = await import(
-      "../../db/migrate.js"
+	const db = new PGlite();
+
+	// Ensure _migrations table exists (uses IF NOT EXISTS, safe to run before migration)
+	await db.exec(`
+    CREATE TABLE IF NOT EXISTS _migrations (
+      id          SERIAL PRIMARY KEY,
+      filename    TEXT NOT NULL UNIQUE,
+      applied_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+      checksum    TEXT NOT NULL
     );
-    const { join } = await import("path");
-    const migrationsDir = join(
-      new URL(".", import.meta.url).pathname,
-      "..",
-      "..",
-      "..",
-      "migrations",
-    );
-    const migrations = await loadFilesystemMigrations(migrationsDir);
-    await runMigrations(db, migrations);
-  } catch {
-    await db.exec(BASE_SCHEMA);
-  }
-  return db;
+  `);
+
+	// Load migration SQL directly from filesystem
+	const currentDir = new URL('.', import.meta.url).pathname;
+	const migrationsDir = join(currentDir, '..', '..', '..', 'migrations');
+
+	try {
+		const files = readdirSync(migrationsDir)
+			.filter((f: string) => f.endsWith('.sql'))
+			.sort();
+
+		for (const file of files) {
+			let sql = readFileSync(join(migrationsDir, file), 'utf-8');
+			// PGlite doesn't support CREATE EXTENSION; gen_random_uuid() is built-in
+			sql = sql.replace(/CREATE EXTENSION IF NOT EXISTS [^;]+;/g, '');
+			try {
+				await db.exec(sql);
+			} catch (e) {
+				console.error(`Migration ${file} failed:`, e);
+				throw e;
+			}
+		}
+	} catch (e) {
+		console.error('Migration loading failed:', e);
+		throw e;
+	}
+
+	return db;
 }

--- a/packages/server/src/test/helpers/port.ts
+++ b/packages/server/src/test/helpers/port.ts
@@ -1,17 +1,17 @@
-import { createServer } from "net";
+import { createServer } from 'node:net';
 
 export function getAvailablePort(): Promise<number> {
-  return new Promise((resolve, reject) => {
-    const server = createServer();
-    server.listen(0, () => {
-      const address = server.address();
-      if (address && typeof address === "object") {
-        const port = address.port;
-        server.close(() => resolve(port));
-      } else {
-        server.close(() => reject(new Error("Failed to get port")));
-      }
-    });
-    server.on("error", reject);
-  });
+	return new Promise((resolve, reject) => {
+		const server = createServer();
+		server.listen(0, () => {
+			const address = server.address();
+			if (address && typeof address === 'object') {
+				const port = address.port;
+				server.close(() => resolve(port));
+			} else {
+				server.close(() => reject(new Error('Failed to get port')));
+			}
+		});
+		server.on('error', reject);
+	});
 }

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -1,5 +1,5 @@
 export const DEFAULT_PORT = 3100;
 export const DEFAULT_CONNECT_PORT = 4100;
-export const DEFAULT_DATA_DIR = "~/.hezo";
-export const DEFAULT_CONNECT_URL = "http://localhost:4100";
-export const CANARY_PLAINTEXT = "CANARY";
+export const DEFAULT_DATA_DIR = '~/.hezo';
+export const DEFAULT_CONNECT_URL = 'http://localhost:4100';
+export const CANARY_PLAINTEXT = 'CANARY';

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,2 +1,2 @@
-export * from "./types/index.js";
-export * from "./constants.js";
+export * from './constants.js';
+export * from './types/index.js';

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -1,68 +1,172 @@
-export const MemberType = { Agent: "agent", User: "user" } as const;
+export const MemberType = { Agent: 'agent', User: 'user' } as const;
 export type MemberType = (typeof MemberType)[keyof typeof MemberType];
 
-export const AgentRuntime = { ClaudeCode: "claude_code", Codex: "codex", Gemini: "gemini" } as const;
+export const AgentRuntime = {
+	ClaudeCode: 'claude_code',
+	Codex: 'codex',
+	Gemini: 'gemini',
+} as const;
 export type AgentRuntime = (typeof AgentRuntime)[keyof typeof AgentRuntime];
 
-export const AgentStatus = { Active: "active", Idle: "idle", Paused: "paused", Terminated: "terminated" } as const;
+export const AgentStatus = {
+	Active: 'active',
+	Idle: 'idle',
+	Paused: 'paused',
+	Terminated: 'terminated',
+} as const;
 export type AgentStatus = (typeof AgentStatus)[keyof typeof AgentStatus];
 
-export const ContainerStatus = { Creating: "creating", Running: "running", Stopped: "stopped", Error: "error" } as const;
+export const ContainerStatus = {
+	Creating: 'creating',
+	Running: 'running',
+	Stopped: 'stopped',
+	Error: 'error',
+} as const;
 export type ContainerStatus = (typeof ContainerStatus)[keyof typeof ContainerStatus];
 
-export const IssueStatus = { Backlog: "backlog", Open: "open", InProgress: "in_progress", Review: "review", Blocked: "blocked", Done: "done", Closed: "closed", Cancelled: "cancelled" } as const;
+export const IssueStatus = {
+	Backlog: 'backlog',
+	Open: 'open',
+	InProgress: 'in_progress',
+	Review: 'review',
+	Blocked: 'blocked',
+	Done: 'done',
+	Closed: 'closed',
+	Cancelled: 'cancelled',
+} as const;
 export type IssueStatus = (typeof IssueStatus)[keyof typeof IssueStatus];
 
-export const IssuePriority = { Urgent: "urgent", High: "high", Medium: "medium", Low: "low" } as const;
+export const IssuePriority = {
+	Urgent: 'urgent',
+	High: 'high',
+	Medium: 'medium',
+	Low: 'low',
+} as const;
 export type IssuePriority = (typeof IssuePriority)[keyof typeof IssuePriority];
 
-export const CommentContentType = { Text: "text", Options: "options", Preview: "preview", Trace: "trace", System: "system" } as const;
+export const CommentContentType = {
+	Text: 'text',
+	Options: 'options',
+	Preview: 'preview',
+	Trace: 'trace',
+	System: 'system',
+} as const;
 export type CommentContentType = (typeof CommentContentType)[keyof typeof CommentContentType];
 
-export const ToolCallStatus = { Running: "running", Success: "success", Error: "error" } as const;
+export const ToolCallStatus = { Running: 'running', Success: 'success', Error: 'error' } as const;
 export type ToolCallStatus = (typeof ToolCallStatus)[keyof typeof ToolCallStatus];
 
-export const SecretCategory = { SshKey: "ssh_key", Credential: "credential", ApiToken: "api_token", Certificate: "certificate", Other: "other" } as const;
+export const SecretCategory = {
+	SshKey: 'ssh_key',
+	Credential: 'credential',
+	ApiToken: 'api_token',
+	Certificate: 'certificate',
+	Other: 'other',
+} as const;
 export type SecretCategory = (typeof SecretCategory)[keyof typeof SecretCategory];
 
-export const GrantScope = { Single: "single", Project: "project", Company: "company" } as const;
+export const GrantScope = { Single: 'single', Project: 'project', Company: 'company' } as const;
 export type GrantScope = (typeof GrantScope)[keyof typeof GrantScope];
 
-export const ApprovalType = { SecretAccess: "secret_access", Hire: "hire", Strategy: "strategy", KbUpdate: "kb_update", PlanReview: "plan_review", DeployProduction: "deploy_production" } as const;
+export const ApprovalType = {
+	SecretAccess: 'secret_access',
+	Hire: 'hire',
+	Strategy: 'strategy',
+	KbUpdate: 'kb_update',
+	PlanReview: 'plan_review',
+	DeployProduction: 'deploy_production',
+} as const;
 export type ApprovalType = (typeof ApprovalType)[keyof typeof ApprovalType];
 
-export const ApprovalStatus = { Pending: "pending", Approved: "approved", Denied: "denied" } as const;
+export const ApprovalStatus = {
+	Pending: 'pending',
+	Approved: 'approved',
+	Denied: 'denied',
+} as const;
 export type ApprovalStatus = (typeof ApprovalStatus)[keyof typeof ApprovalStatus];
 
-export const MembershipRole = { Board: "board", Member: "member" } as const;
+export const MembershipRole = { Board: 'board', Member: 'member' } as const;
 export type MembershipRole = (typeof MembershipRole)[keyof typeof MembershipRole];
 
-export const InviteStatus = { Pending: "pending", Accepted: "accepted", Expired: "expired", Revoked: "revoked" } as const;
+export const InviteStatus = {
+	Pending: 'pending',
+	Accepted: 'accepted',
+	Expired: 'expired',
+	Revoked: 'revoked',
+} as const;
 export type InviteStatus = (typeof InviteStatus)[keyof typeof InviteStatus];
 
-export const PlatformType = { GitHub: "github", Gmail: "gmail", GitLab: "gitlab", Stripe: "stripe", PostHog: "posthog", Railway: "railway", Vercel: "vercel", DigitalOcean: "digitalocean", X: "x" } as const;
+export const PlatformType = {
+	GitHub: 'github',
+	Gmail: 'gmail',
+	GitLab: 'gitlab',
+	Stripe: 'stripe',
+	PostHog: 'posthog',
+	Railway: 'railway',
+	Vercel: 'vercel',
+	DigitalOcean: 'digitalocean',
+	X: 'x',
+} as const;
 export type PlatformType = (typeof PlatformType)[keyof typeof PlatformType];
 
-export const ConnectionStatus = { Active: "active", Expired: "expired", Disconnected: "disconnected" } as const;
+export const ConnectionStatus = {
+	Active: 'active',
+	Expired: 'expired',
+	Disconnected: 'disconnected',
+} as const;
 export type ConnectionStatus = (typeof ConnectionStatus)[keyof typeof ConnectionStatus];
 
-export const WakeupSource = { Timer: "timer", Assignment: "assignment", OnDemand: "on_demand", Mention: "mention", Automation: "automation" } as const;
+export const WakeupSource = {
+	Timer: 'timer',
+	Assignment: 'assignment',
+	OnDemand: 'on_demand',
+	Mention: 'mention',
+	Automation: 'automation',
+} as const;
 export type WakeupSource = (typeof WakeupSource)[keyof typeof WakeupSource];
 
-export const WakeupStatus = { Queued: "queued", Claimed: "claimed", Completed: "completed", Failed: "failed", Skipped: "skipped", Coalesced: "coalesced", Deferred: "deferred", Cancelled: "cancelled" } as const;
+export const WakeupStatus = {
+	Queued: 'queued',
+	Claimed: 'claimed',
+	Completed: 'completed',
+	Failed: 'failed',
+	Skipped: 'skipped',
+	Coalesced: 'coalesced',
+	Deferred: 'deferred',
+	Cancelled: 'cancelled',
+} as const;
 export type WakeupStatus = (typeof WakeupStatus)[keyof typeof WakeupStatus];
 
-export const HeartbeatRunStatus = { Queued: "queued", Running: "running", Succeeded: "succeeded", Failed: "failed", Cancelled: "cancelled", TimedOut: "timed_out" } as const;
+export const HeartbeatRunStatus = {
+	Queued: 'queued',
+	Running: 'running',
+	Succeeded: 'succeeded',
+	Failed: 'failed',
+	Cancelled: 'cancelled',
+	TimedOut: 'timed_out',
+} as const;
 export type HeartbeatRunStatus = (typeof HeartbeatRunStatus)[keyof typeof HeartbeatRunStatus];
 
-export const PluginStatus = { Installed: "installed", Enabled: "enabled", Disabled: "disabled", Error: "error" } as const;
+export const PluginStatus = {
+	Installed: 'installed',
+	Enabled: 'enabled',
+	Disabled: 'disabled',
+	Error: 'error',
+} as const;
 export type PluginStatus = (typeof PluginStatus)[keyof typeof PluginStatus];
 
-export const ProjectDocType = { TechSpec: "tech_spec", ImplementationPlan: "implementation_plan", Research: "research", UiDesignDecisions: "ui_design_decisions", MarketingPlan: "marketing_plan", Other: "other" } as const;
+export const ProjectDocType = {
+	TechSpec: 'tech_spec',
+	ImplementationPlan: 'implementation_plan',
+	Research: 'research',
+	UiDesignDecisions: 'ui_design_decisions',
+	MarketingPlan: 'marketing_plan',
+	Other: 'other',
+} as const;
 export type ProjectDocType = (typeof ProjectDocType)[keyof typeof ProjectDocType];
 
-export const AuditActorType = { Board: "board", Agent: "agent", System: "system" } as const;
+export const AuditActorType = { Board: 'board', Agent: 'agent', System: 'system' } as const;
 export type AuditActorType = (typeof AuditActorType)[keyof typeof AuditActorType];
 
-export const RepoHostType = { GitHub: "github" } as const;
+export const RepoHostType = { GitHub: 'github' } as const;
 export type RepoHostType = (typeof RepoHostType)[keyof typeof RepoHostType];

--- a/packages/shared/src/types/config.ts
+++ b/packages/shared/src/types/config.ts
@@ -1,20 +1,20 @@
 export interface HezoConfig {
-  port: number;
-  dataDir: string;
-  masterKey?: string;
-  connectUrl: string;
-  connectApiKey?: string;
-  reset: boolean;
+	port: number;
+	dataDir: string;
+	masterKey?: string;
+	connectUrl: string;
+	connectApiKey?: string;
+	reset: boolean;
 }
 
 export interface ConnectConfig {
-  port: number;
-  mode: "self_hosted" | "centrally_hosted";
-  stateSigningKey: string;
-  github?: {
-    clientId: string;
-    clientSecret: string;
-  };
+	port: number;
+	mode: 'self_hosted' | 'centrally_hosted';
+	stateSigningKey: string;
+	github?: {
+		clientId: string;
+		clientSecret: string;
+	};
 }
 
-export type MasterKeyState = "unset" | "locked" | "unlocked";
+export type MasterKeyState = 'unset' | 'locked' | 'unlocked';

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1,2 +1,2 @@
-export * from "./config.js";
-export * from "./common.js";
+export * from './common.js';
+export * from './config.js';


### PR DESCRIPTION
Full REST API for all core entities with JWT auth, comprehensive test
coverage (95 tests), and built-in "Software Development" company type
seeding.

New endpoints:
- Company Types: CRUD with built-in type protection
- Companies: CRUD with auto-creation of 9 agents from company type
- Agents: CRUD + pause/resume/terminate lifecycle + org chart
- Projects: CRUD with open-issue deletion guard
- Issues: CRUD + atomic numbering (ACME-42) + pagination/filtering +
  sub-issues + dependencies
- Comments: CRUD with polymorphic content types + option choosing
- Secrets: encrypted vault with grants (create/revoke)
- Approvals: create + approve/deny workflow
- Cost entries: create/list with debit_agent_budget() + group_by
- API keys: create/list/revoke with SHA-256 hashing

Infrastructure:
- JWT auth middleware (board JWT, API key, agent JWT)
- Bootstrap POST /api/auth/token endpoint
- Hono context injection for db and masterKeyManager
- Response envelope helpers (ok/err)
- Pagination, slug, and issue prefix utilities
- createTestApp() helper for integration tests

Also:
- Create CLAUDE.md pointing to AGENTS.md
- Update AGENTS.md with implementation phase tracking instruction
- Update spec.md with CLAUDE.md convention for project repos
- Mark Phases 0-1 as complete in implementation-phases.md

https://claude.ai/code/session_011CwfMC6cxsNRGKjbYXJMD5