### PR TITLE
refactor(server): change --no-open to --open flag

### DIFF
--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -10,7 +10,7 @@ export interface HezoConfig {
 	connectUrl: string;
 	connectApiKey?: string;
 	reset: boolean;
-	noOpen: boolean;
+	open: boolean;
 }
 
 export function parseArgs(argv: string[] = process.argv): HezoConfig {
@@ -23,7 +23,7 @@ export function parseArgs(argv: string[] = process.argv): HezoConfig {
 		.option('--connect-url <url>', 'Hezo Connect URL', DEFAULT_CONNECT_URL)
 		.option('--connect-api-key <key>', 'Hezo Connect API key')
 		.option('--reset', 'Reset database and start fresh')
-		.option('--no-open', 'Do not auto-open the browser')
+		.option('--open', 'Auto-open the browser')
 		.parse(argv);
 
 	const opts = program.opts();
@@ -47,6 +47,6 @@ export function parseArgs(argv: string[] = process.argv): HezoConfig {
 		connectUrl: opts.connectUrl,
 		connectApiKey: opts.connectApiKey,
 		reset: opts.reset ?? false,
-		noOpen: opts.open === false,
+		open: opts.open ?? false,
 	};
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -60,7 +60,7 @@ startup(config)
 		logsRef = result.logs;
 		const url = `http://localhost:${result.port}`;
 		log.info(`Hezo server running at ${url} [${result.masterKeyState}]`);
-		if (!config.noOpen) {
+		if (config.open) {
 			Bun.spawn(['open', `http://localhost:${DEFAULT_WEB_PORT}`]);
 		}
 	})

--- a/packages/server/src/test/__tests__/cli.test.ts
+++ b/packages/server/src/test/__tests__/cli.test.ts
@@ -15,7 +15,7 @@ describe('parseArgs', () => {
 		expect(config.masterKey).toBeUndefined();
 		expect(config.connectApiKey).toBeUndefined();
 		expect(config.reset).toBe(false);
-		expect(config.noOpen).toBe(false);
+		expect(config.open).toBe(false);
 	});
 
 	it('parses --port', () => {
@@ -65,9 +65,9 @@ describe('parseArgs', () => {
 		expect(config.reset).toBe(true);
 	});
 
-	it('parses --no-open', () => {
-		const config = parseArgs(argv('--no-open'));
-		expect(config.noOpen).toBe(true);
+	it('parses --open', () => {
+		const config = parseArgs(argv('--open'));
+		expect(config.open).toBe(true);
 	});
 
 	it('handles multiple flags combined', () => {
@@ -84,7 +84,7 @@ describe('parseArgs', () => {
 				'--connect-api-key',
 				'hc_xyz',
 				'--reset',
-				'--no-open',
+				'--open',
 			),
 		);
 		expect(config.port).toBe(9000);
@@ -93,6 +93,6 @@ describe('parseArgs', () => {
 		expect(config.connectUrl).toBe('https://connect.hezo.dev');
 		expect(config.connectApiKey).toBe('hc_xyz');
 		expect(config.reset).toBe(true);
-		expect(config.noOpen).toBe(true);
+		expect(config.open).toBe(true);
 	});
 });

--- a/packages/server/src/test/__tests__/startup.test.ts
+++ b/packages/server/src/test/__tests__/startup.test.ts
@@ -14,7 +14,7 @@ function baseConfig(overrides: Partial<HezoConfig> = {}): HezoConfig {
 		dataDir: overrides.dataDir ?? makeTempDir(),
 		connectUrl: 'https://connect.test',
 		reset: false,
-		noOpen: false,
+		open: false,
 		...overrides,
 	};
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
 	},
 	webServer: [
 		{
-			command: `bun run --watch src/index.ts -- --port ${SERVER_PORT} --data-dir ${TEST_DATA_DIR} --connect-url http://localhost:${CONNECT_PORT} --master-key e2e-test-master-key-0123456789abcdef0123456789abcdef --reset --no-open`,
+			command: `bun run --watch src/index.ts -- --port ${SERVER_PORT} --data-dir ${TEST_DATA_DIR} --connect-url http://localhost:${CONNECT_PORT} --master-key e2e-test-master-key-0123456789abcdef0123456789abcdef --reset`,
 			cwd: './packages/server',
 			port: SERVER_PORT,
 			reuseExistingServer: true,

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -10,7 +10,7 @@ const program = new Command()
 	.name('dev')
 	.description('Start all Hezo services in development mode')
 	.option('--reset', 'Reset the server database')
-	.option('--no-open', 'Do not auto-open the browser')
+	.option('--open', 'Auto-open the browser')
 	.option('--port <port>', 'Server port')
 	.option('--master-key <key>', 'Master key for unlocking')
 	.option('--data-dir <path>', 'Data directory')
@@ -28,7 +28,7 @@ if (opts.reset) {
 }
 
 const serverArgs: string[] = [];
-if (opts.open === false) serverArgs.push('--no-open');
+if (opts.open) serverArgs.push('--open');
 if (opts.port) serverArgs.push('--port', opts.port);
 if (opts.masterKey) serverArgs.push('--master-key', opts.masterKey);
 if (opts.dataDir) serverArgs.push('--data-dir', opts.dataDir);


### PR DESCRIPTION
## Summary

- Flip the browser auto-open default: the server and dev script no longer open the browser on startup
- Replace `--no-open` flag with `--open` — pass `--open` to explicitly open the browser
- Rename `HezoConfig.noOpen` to `HezoConfig.open` with matching positive semantics
- Remove now-unnecessary `--no-open` from Playwright config (not opening is the default)

## Files changed

- `packages/server/src/cli.ts` — `--open` flag and `open` config field
- `packages/server/src/index.ts` — use `config.open` instead of `!config.noOpen`
- `scripts/dev.ts` — forward `--open` to the server
- `playwright.config.ts` — drop redundant `--no-open`
- `packages/server/src/test/__tests__/cli.test.ts` — updated test expectations
- `packages/server/src/test/__tests__/startup.test.ts` — updated mock config

## Test plan

- [x] All 87 unit/integration tests pass (`bun run test --skip-e2e`)
- [ ] `bun run dev` starts without opening browser
- [ ] `bun run dev --open` opens the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)