### PR TITLE
feat: cap sub-issue depth at 2 and surface parent chain in breadcrumbs

### DIFF
--- a/agents/_partials/common/subtask-preference.md
+++ b/agents/_partials/common/subtask-preference.md
@@ -1,0 +1,9 @@
+## Sub-issues for related work
+
+Default to sub-issues — not new top-level tickets — for work that surfaces while you are on a ticket and clearly belongs underneath it: cleanup spotted along the way, follow-ups that depend on the current change, parallelisable slices you want to delegate, or sub-tasks you want to track separately. Set `parent_issue_id` to the ticket you are currently working when you call `create_issue`. Top-level tickets are reserved for work that stands on its own.
+
+The hierarchy is capped at two levels deep. A top-level ticket can have sub-issues, and each sub-issue can have its own sub-issues, but no further. The server rejects creates beyond depth 2. If a sub-issue would need a third level to model the work cleanly, restructure: open the new ticket as a sibling under the same root (set `parent_issue_id` to the root, not to the intermediate sub-issue), or escalate to whoever owns the root and let them re-shape the hierarchy.
+
+When the new work is genuinely independent — a different domain, a different project, a lifecycle that does not depend on the current ticket — open a top-level or peer ticket instead. The `mention-handoff` guidance covers the @-mention triage decision; this guidance covers proactive work you generate yourself.
+
+The system records `created_by_run_id` automatically as provenance. `parent_issue_id` is the *semantic* parent and should be set deliberately when the relationship is real.

--- a/agents/blank/ceo.md
+++ b/agents/blank/ceo.md
@@ -64,6 +64,7 @@ Tickets in the Operations project labeled `description-update` are routine inter
 {{> partials/common/no-auto-timelines}}
 {{> partials/common/comment-formatting}}
 {{> partials/common/linking-syntax}}
+{{> partials/common/subtask-preference}}
 {{> partials/common/mention-handoff}}
 
 ---

--- a/agents/blank/coach.md
+++ b/agents/blank/coach.md
@@ -56,6 +56,7 @@ If a pattern suggests that a missing role or fundamental redesign is needed, fla
 {{> partials/common/coach-summary-comment}}
 {{> partials/common/comment-formatting}}
 {{> partials/common/linking-syntax}}
+{{> partials/common/subtask-preference}}
 {{> partials/common/mention-handoff}}
 
 ---

--- a/agents/software-development/architect.md
+++ b/agents/software-development/architect.md
@@ -52,6 +52,7 @@ The Architect uses a four-stage planning workflow, gated on a finalised PRD.
 {{> partials/common/no-auto-timelines}}
 {{> partials/common/comment-formatting}}
 {{> partials/common/linking-syntax}}
+{{> partials/common/subtask-preference}}
 {{> partials/common/mention-handoff}}
 
 ---

--- a/agents/software-development/ceo.md
+++ b/agents/software-development/ceo.md
@@ -69,6 +69,7 @@ Tickets in the Operations project labeled `description-update` are routine inter
 {{> partials/common/no-auto-timelines}}
 {{> partials/common/comment-formatting}}
 {{> partials/common/linking-syntax}}
+{{> partials/common/subtask-preference}}
 {{> partials/common/mention-handoff}}
 
 ---

--- a/agents/software-development/coach.md
+++ b/agents/software-development/coach.md
@@ -56,6 +56,7 @@ If a pattern suggests a fundamental role redesign is needed, flag it to the boar
 {{> partials/common/coach-summary-comment}}
 {{> partials/common/comment-formatting}}
 {{> partials/common/linking-syntax}}
+{{> partials/common/subtask-preference}}
 {{> partials/common/mention-handoff}}
 
 ---

--- a/agents/software-development/devops-engineer.md
+++ b/agents/software-development/devops-engineer.md
@@ -52,6 +52,7 @@ Escalation: infrastructure outages → @-mention the Architect and CEO immediate
 {{> partials/common/no-auto-timelines}}
 {{> partials/common/comment-formatting}}
 {{> partials/common/linking-syntax}}
+{{> partials/common/subtask-preference}}
 {{> partials/common/mention-handoff}}
 
 ---

--- a/agents/software-development/engineer.md
+++ b/agents/software-development/engineer.md
@@ -55,6 +55,7 @@ If the spec is unclear, ask the Architect — don't guess. If you disagree with 
 {{> partials/common/no-auto-timelines}}
 {{> partials/common/comment-formatting}}
 {{> partials/common/linking-syntax}}
+{{> partials/common/subtask-preference}}
 {{> partials/common/mention-handoff}}
 
 ---

--- a/agents/software-development/marketing-lead.md
+++ b/agents/software-development/marketing-lead.md
@@ -45,6 +45,7 @@ Escalation: brand or messaging disagreements → CEO decides. Need technical inf
 {{> partials/common/no-auto-timelines}}
 {{> partials/common/comment-formatting}}
 {{> partials/common/linking-syntax}}
+{{> partials/common/subtask-preference}}
 {{> partials/common/mention-handoff}}
 
 ---

--- a/agents/software-development/product-lead.md
+++ b/agents/software-development/product-lead.md
@@ -49,6 +49,7 @@ You are the second step in the ticket workflow (after the Researcher).
 {{> partials/common/no-auto-timelines}}
 {{> partials/common/comment-formatting}}
 {{> partials/common/linking-syntax}}
+{{> partials/common/subtask-preference}}
 {{> partials/common/mention-handoff}}
 
 ---

--- a/agents/software-development/qa-engineer.md
+++ b/agents/software-development/qa-engineer.md
@@ -79,6 +79,7 @@ On heartbeats, audit the entire codebase across these areas:
 {{> partials/common/no-auto-timelines}}
 {{> partials/common/comment-formatting}}
 {{> partials/common/linking-syntax}}
+{{> partials/common/subtask-preference}}
 {{> partials/common/mention-handoff}}
 
 ---

--- a/agents/software-development/researcher.md
+++ b/agents/software-development/researcher.md
@@ -60,6 +60,7 @@ Keep the research document updated as new findings emerge or earlier conclusions
 {{> partials/common/no-auto-timelines}}
 {{> partials/common/comment-formatting}}
 {{> partials/common/linking-syntax}}
+{{> partials/common/subtask-preference}}
 {{> partials/common/mention-handoff}}
 
 ---

--- a/agents/software-development/security-engineer.md
+++ b/agents/software-development/security-engineer.md
@@ -72,6 +72,7 @@ On heartbeats, audit the codebase across these areas:
 {{> partials/common/no-auto-timelines}}
 {{> partials/common/comment-formatting}}
 {{> partials/common/linking-syntax}}
+{{> partials/common/subtask-preference}}
 {{> partials/common/mention-handoff}}
 
 ---

--- a/agents/software-development/ui-designer.md
+++ b/agents/software-development/ui-designer.md
@@ -52,6 +52,7 @@ When disagreeing with the Engineer on design, the Architect decides. Accessibili
 {{> partials/common/no-auto-timelines}}
 {{> partials/common/comment-formatting}}
 {{> partials/common/linking-syntax}}
+{{> partials/common/subtask-preference}}
 {{> partials/common/mention-handoff}}
 
 ---

--- a/packages/server/src/lib/issue-depth.ts
+++ b/packages/server/src/lib/issue-depth.ts
@@ -1,0 +1,28 @@
+import type { PGlite } from '@electric-sql/pglite';
+
+export const MAX_SUB_ISSUE_DEPTH = 2;
+
+export const SUB_ISSUE_DEPTH_ERROR = `Sub-issues cannot be nested more than ${MAX_SUB_ISSUE_DEPTH} levels deep`;
+
+export type DepthCheck = { ok: true } | { ok: false; message: string };
+
+export async function assertChildDepthAllowed(
+	db: PGlite,
+	companyId: string,
+	parentIssueId: string,
+): Promise<DepthCheck> {
+	const r = await db.query<{ id: string; grand_parent_id: string | null }>(
+		`SELECT p.id, gp.parent_issue_id AS grand_parent_id
+		 FROM issues p
+		 LEFT JOIN issues gp ON gp.id = p.parent_issue_id
+		 WHERE p.id = $1 AND p.company_id = $2`,
+		[parentIssueId, companyId],
+	);
+	if (r.rows.length === 0) {
+		return { ok: false, message: 'Parent issue not found' };
+	}
+	if (r.rows[0].grand_parent_id !== null) {
+		return { ok: false, message: SUB_ISSUE_DEPTH_ERROR };
+	}
+	return { ok: true };
+}

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -15,6 +15,7 @@ import {
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { assertNoActiveRun } from '../lib/active-run';
+import { assertChildDepthAllowed } from '../lib/issue-depth';
 import { allocateIssueIdentifier } from '../lib/issue-identifier';
 import { assertOperationsAssignee } from '../lib/operations-assignee';
 import type { AuthInfo } from '../lib/types';
@@ -254,7 +255,7 @@ export function registerTools(
 	tool(
 		server,
 		'create_issue',
-		'Create a new issue. Use parent_issue_id for sub-issues. Use assignee_slug as alternative to assignee_id. In title/description, reference other Hezo entities with @-mentions: @<agent-slug>, @<ISSUE-ID> (e.g. @op-42), @kb/<slug>, @doc/<filename>. Do not wrap these in backticks — that makes them inert.',
+		'Create a new issue. Use parent_issue_id for sub-issues — prefer this over a top-level ticket whenever the new work is part of the ticket you are on. Sub-issues themselves can have sub-issues, but no deeper (depth is capped at 2). Use assignee_slug as alternative to assignee_id. In title/description, reference other Hezo entities with @-mentions: @<agent-slug>, @<ISSUE-ID> (e.g. @op-42), @kb/<slug>, @doc/<filename>. Do not wrap these in backticks — that makes them inert.',
 		{
 			company_id: z.string().describe('Company ID'),
 			project_id: z.string().describe('Project ID'),
@@ -266,7 +267,12 @@ export function registerTools(
 				.string()
 				.optional()
 				.describe('Assignee agent slug (alternative to assignee_id)'),
-			parent_issue_id: z.string().optional().describe('Parent issue ID (creates a sub-issue)'),
+			parent_issue_id: z
+				.string()
+				.optional()
+				.describe(
+					'Parent issue ID (creates a sub-issue). Sub-issues can themselves have sub-issues, but no deeper — depth is capped at 2.',
+				),
 			runtime_type: z
 				.string()
 				.optional()
@@ -300,6 +306,15 @@ export function registerTools(
 				assigneeId,
 			);
 			if (!opsCheck.ok) return { error: opsCheck.message };
+
+			if (args.parent_issue_id) {
+				const depthCheck = await assertChildDepthAllowed(
+					db,
+					args.company_id as string,
+					args.parent_issue_id as string,
+				);
+				if (!depthCheck.ok) return { error: depthCheck.message };
+			}
 
 			const { number: num, identifier } = await allocateIssueIdentifier(
 				db,

--- a/packages/server/src/routes/issues.ts
+++ b/packages/server/src/routes/issues.ts
@@ -14,6 +14,7 @@ import { Hono } from 'hono';
 import { assertNoActiveRun } from '../lib/active-run';
 import { auditLog } from '../lib/audit';
 import { broadcastChange } from '../lib/broadcast';
+import { assertChildDepthAllowed } from '../lib/issue-depth';
 import { allocateIssueIdentifier } from '../lib/issue-identifier';
 import { assertOperationsAssignee } from '../lib/operations-assignee';
 import { buildMeta, parsePagination } from '../lib/pagination';
@@ -184,6 +185,13 @@ issuesRoutes.post('/companies/:companyId/issues', async (c) => {
 	const opsCheck = await assertOperationsAssignee(db, companyId, body.project_id, body.assignee_id);
 	if (!opsCheck.ok) {
 		return err(c, 'INVALID_REQUEST', opsCheck.message, 400);
+	}
+
+	if (body.parent_issue_id) {
+		const depthCheck = await assertChildDepthAllowed(db, companyId, body.parent_issue_id);
+		if (!depthCheck.ok) {
+			return err(c, 'INVALID_REQUEST', depthCheck.message, 400);
+		}
 	}
 
 	const { number: issueNumber, identifier } = await allocateIssueIdentifier(db, body.project_id);
@@ -539,6 +547,11 @@ issuesRoutes.post('/companies/:companyId/issues/:issueId/sub-issues', async (c) 
 		return err(c, 'NOT_FOUND', 'Parent issue not found', 404);
 	}
 
+	const depthCheck = await assertChildDepthAllowed(db, companyId, parentIssueId);
+	if (!depthCheck.ok) {
+		return err(c, 'INVALID_REQUEST', depthCheck.message, 400);
+	}
+
 	const body = await c.req.json<{
 		title: string;
 		description?: string;
@@ -595,6 +608,42 @@ issuesRoutes.post('/companies/:companyId/issues/:issueId/sub-issues', async (c) 
 	broadcastChange(c, wsRoom.company(companyId), 'issues', 'INSERT', subIssue);
 	wakeAgentIfAssigned(db, body.assignee_id, companyId, subIssue.id as string);
 	return ok(c, subIssue, 201);
+});
+
+issuesRoutes.get('/companies/:companyId/issues/:issueId/ancestors', async (c) => {
+	const access = await requireCompanyAccess(c);
+	if (access instanceof Response) return access;
+
+	const db = c.get('db');
+	const { companyId } = access;
+	const issueId = await resolveIssueId(db, companyId, c.req.param('issueId'));
+	if (!issueId) return err(c, 'NOT_FOUND', 'Issue not found', 404);
+
+	const result = await db.query<{
+		id: string;
+		identifier: string;
+		title: string;
+		depth: number;
+	}>(
+		`WITH RECURSIVE chain AS (
+			SELECT id, parent_issue_id, identifier, title, 0 AS depth
+			FROM issues WHERE id = $1 AND company_id = $2
+			UNION ALL
+			SELECT i.id, i.parent_issue_id, i.identifier, i.title, c.depth + 1
+			FROM issues i
+			JOIN chain c ON c.parent_issue_id = i.id
+			WHERE i.company_id = $2 AND c.depth < 3
+		)
+		SELECT id, identifier, title, depth FROM chain ORDER BY depth DESC`,
+		[issueId, companyId],
+	);
+	if (result.rows.length === 0) return err(c, 'NOT_FOUND', 'Issue not found', 404);
+	return ok(
+		c,
+		result.rows
+			.filter((r) => r.depth > 0)
+			.map(({ id, identifier, title }) => ({ id, identifier, title })),
+	);
 });
 
 issuesRoutes.get('/companies/:companyId/issues/:issueId/dependencies', async (c) => {

--- a/packages/server/src/test/__tests__/issues.test.ts
+++ b/packages/server/src/test/__tests__/issues.test.ts
@@ -595,6 +595,116 @@ describe('issues CRUD', () => {
 	});
 });
 
+describe('sub-issue depth + ancestors', () => {
+	async function createIssue(parent_issue_id?: string) {
+		const res = await app.request(`/api/companies/${companyId}/issues`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				project_id: projectId,
+				title: parent_issue_id ? 'Child' : 'Root',
+				assignee_id: agentId,
+				...(parent_issue_id ? { parent_issue_id } : {}),
+			}),
+		});
+		return { res, body: await res.json() };
+	}
+
+	async function createSub(parentId: string) {
+		const res = await app.request(`/api/companies/${companyId}/issues/${parentId}/sub-issues`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ title: 'Sub', assignee_id: agentId }),
+		});
+		return { res, body: await res.json() };
+	}
+
+	it('allows creating a depth-2 sub-issue (sub-issue of a sub-issue)', async () => {
+		const root = (await createIssue()).body.data;
+		const sub = (await createSub(root.id)).body.data;
+		const subSubViaRest = await createIssue(sub.id);
+		expect(subSubViaRest.res.status).toBe(201);
+		expect(subSubViaRest.body.data.parent_issue_id).toBe(sub.id);
+
+		const sub2 = (await createSub(root.id)).body.data;
+		const subSubViaSubRoute = await createSub(sub2.id);
+		expect(subSubViaSubRoute.res.status).toBe(201);
+		expect(subSubViaSubRoute.body.data.parent_issue_id).toBe(sub2.id);
+	});
+
+	it('rejects depth-3 creation via POST /issues with parent_issue_id', async () => {
+		const root = (await createIssue()).body.data;
+		const sub = (await createSub(root.id)).body.data;
+		const subSub = (await createSub(sub.id)).body.data;
+
+		const tooDeep = await createIssue(subSub.id);
+		expect(tooDeep.res.status).toBe(400);
+		expect(tooDeep.body.error.message).toMatch(/2 levels deep/);
+	});
+
+	it('rejects depth-3 creation via POST /issues/:id/sub-issues', async () => {
+		const root = (await createIssue()).body.data;
+		const sub = (await createSub(root.id)).body.data;
+		const subSub = (await createSub(sub.id)).body.data;
+
+		const tooDeep = await createSub(subSub.id);
+		expect(tooDeep.res.status).toBe(400);
+		expect(tooDeep.body.error.message).toMatch(/2 levels deep/);
+	});
+
+	it('returns ancestors in root-first order, excluding the current issue', async () => {
+		const root = (await createIssue()).body.data;
+		const sub = (await createSub(root.id)).body.data;
+		const subSub = (await createSub(sub.id)).body.data;
+
+		const rootRes = await app.request(`/api/companies/${companyId}/issues/${root.id}/ancestors`, {
+			headers: authHeader(token),
+		});
+		expect(rootRes.status).toBe(200);
+		expect((await rootRes.json()).data).toEqual([]);
+
+		const subRes = await app.request(`/api/companies/${companyId}/issues/${sub.id}/ancestors`, {
+			headers: authHeader(token),
+		});
+		expect(subRes.status).toBe(200);
+		const subAncestors = (await subRes.json()).data;
+		expect(subAncestors).toHaveLength(1);
+		expect(subAncestors[0].id).toBe(root.id);
+
+		const subSubRes = await app.request(
+			`/api/companies/${companyId}/issues/${subSub.id}/ancestors`,
+			{ headers: authHeader(token) },
+		);
+		expect(subSubRes.status).toBe(200);
+		const subSubAncestors = (await subSubRes.json()).data;
+		expect(subSubAncestors).toHaveLength(2);
+		expect(subSubAncestors[0].id).toBe(root.id);
+		expect(subSubAncestors[1].id).toBe(sub.id);
+	});
+
+	it('resolves identifier-based path for ancestors', async () => {
+		const root = (await createIssue()).body.data;
+		const sub = (await createSub(root.id)).body.data;
+
+		const res = await app.request(
+			`/api/companies/${companyId}/issues/${sub.identifier.toLowerCase()}/ancestors`,
+			{ headers: authHeader(token) },
+		);
+		expect(res.status).toBe(200);
+		const ancestors = (await res.json()).data;
+		expect(ancestors).toHaveLength(1);
+		expect(ancestors[0].identifier).toBe(root.identifier);
+	});
+
+	it('returns 404 on ancestors for an unknown issue', async () => {
+		const res = await app.request(
+			`/api/companies/${companyId}/issues/00000000-0000-0000-0000-000000000000/ancestors`,
+			{ headers: authHeader(token) },
+		);
+		expect(res.status).toBe(404);
+	});
+});
+
 describe('operations project assignee restriction', () => {
 	let operationsProjectId: string;
 	let ceoAgentId: string;

--- a/packages/server/src/test/__tests__/mcp-tools.test.ts
+++ b/packages/server/src/test/__tests__/mcp-tools.test.ts
@@ -754,6 +754,43 @@ describe('MCP tool: operations project assignee restriction', () => {
 		expect(result.project_id).toBe(ops.rows[0].id);
 	});
 
+	it('create_issue caps sub-issue depth at 2', async () => {
+		const root = (await callToolViaMcp('create_issue', {
+			company_id: companyId,
+			project_id: projectId,
+			title: 'Depth root',
+			assignee_id: agentId,
+		})) as { id: string; error?: string };
+		expect(root.error).toBeUndefined();
+
+		const sub = (await callToolViaMcp('create_issue', {
+			company_id: companyId,
+			project_id: projectId,
+			title: 'Depth sub',
+			assignee_id: agentId,
+			parent_issue_id: root.id,
+		})) as { id: string; error?: string };
+		expect(sub.error).toBeUndefined();
+
+		const subSub = (await callToolViaMcp('create_issue', {
+			company_id: companyId,
+			project_id: projectId,
+			title: 'Depth sub-sub',
+			assignee_id: agentId,
+			parent_issue_id: sub.id,
+		})) as { id: string; error?: string };
+		expect(subSub.error).toBeUndefined();
+
+		const tooDeep = (await callToolViaMcp('create_issue', {
+			company_id: companyId,
+			project_id: projectId,
+			title: 'Depth too deep',
+			assignee_id: agentId,
+			parent_issue_id: subSub.id,
+		})) as { error?: string };
+		expect(tooDeep.error).toMatch(/2 levels deep/);
+	});
+
 	it('update_issue rejects reassigning Operations issue to non-CEO', async () => {
 		const ops = await db.query<{ id: string }>(
 			`SELECT id FROM projects WHERE company_id = $1 AND slug = 'operations'`,

--- a/packages/server/src/test/__tests__/resolve-partials.test.ts
+++ b/packages/server/src/test/__tests__/resolve-partials.test.ts
@@ -121,6 +121,16 @@ describe('loadAgentRoles integrates resolvePartials', () => {
 			expect(docs[key], `${key} should include an @kb/ example`).toContain('@kb/');
 		}
 
+		// Every role doc picks up the subtask-preference guidance.
+		for (const key of allRoleKeys) {
+			expect(docs[key], `${key} should include the sub-issue heading`).toContain(
+				'## Sub-issues for related work',
+			);
+			expect(docs[key], `${key} should mention the depth-2 cap`).toContain(
+				'capped at two levels deep',
+			);
+		}
+
 		// Partial files themselves are stripped from the returned map
 		expect(Object.keys(docs).some((k) => k.startsWith('_partials/'))).toBe(false);
 	});

--- a/packages/web/src/hooks/use-issues.ts
+++ b/packages/web/src/hooks/use-issues.ts
@@ -131,6 +131,21 @@ export function useUpdateIssue(companyId: string, issueId: string) {
 	});
 }
 
+export interface IssueAncestor {
+	id: string;
+	identifier: string;
+	title: string;
+}
+
+export function useIssueAncestors(companyId: string, issueId: string | undefined) {
+	return useQuery({
+		queryKey: ['companies', companyId, 'issues', issueId, 'ancestors'],
+		queryFn: () =>
+			api.get<IssueAncestor[]>(`/api/companies/${companyId}/issues/${issueId}/ancestors`),
+		enabled: !!companyId && !!issueId,
+	});
+}
+
 export function useCreateSubIssue(companyId: string, parentIssueId: string) {
 	return useMutation({
 		mutationFn: (data: {

--- a/packages/web/src/routes/companies/$companyId/projects/$projectId/issues/$issueId.tsx
+++ b/packages/web/src/routes/companies/$companyId/projects/$projectId/issues/$issueId.tsx
@@ -162,9 +162,13 @@ function IssueDetailPage() {
 	async function handleSubIssue(e: React.FormEvent) {
 		e.preventDefault();
 		if (!subIssueTitle.trim()) return;
-		await createSubIssue.mutateAsync({ title: subIssueTitle });
-		setSubIssueTitle('');
-		setShowSubForm(false);
+		try {
+			await createSubIssue.mutateAsync({ title: subIssueTitle });
+			setSubIssueTitle('');
+			setShowSubForm(false);
+		} catch {
+			// error rendered below the form via createSubIssue.error
+		}
 	}
 
 	const issueProjectSlug = issue.project_slug ?? projectId;
@@ -368,18 +372,26 @@ function IssueDetailPage() {
 							data-testid="sub-issues-list"
 						>
 							{showSubForm && (
-								<form onSubmit={handleSubIssue} className="flex gap-2 mb-1">
-									<input
-										value={subIssueTitle}
-										onChange={(e) => setSubIssueTitle(e.target.value)}
-										placeholder="Sub-issue title"
-										className="flex-1 rounded-radius-md border border-border bg-bg px-3 py-1.5 text-[13px] text-text outline-none focus:border-border-hover"
-										data-testid="sub-issue-title-input"
-									/>
-									<Button type="submit" size="sm" disabled={!subIssueTitle.trim()}>
-										Create
-									</Button>
-								</form>
+								<>
+									<form onSubmit={handleSubIssue} className="flex gap-2 mb-1">
+										<input
+											value={subIssueTitle}
+											onChange={(e) => setSubIssueTitle(e.target.value)}
+											placeholder="Sub-issue title"
+											className="flex-1 rounded-radius-md border border-border bg-bg px-3 py-1.5 text-[13px] text-text outline-none focus:border-border-hover"
+											data-testid="sub-issue-title-input"
+										/>
+										<Button type="submit" size="sm" disabled={!subIssueTitle.trim()}>
+											Create
+										</Button>
+									</form>
+									{createSubIssue.error && (
+										<div className="text-[12px] text-red-500 mb-1" data-testid="sub-issue-error">
+											{(createSubIssue.error as { message?: string }).message ??
+												'Failed to create sub-issue'}
+										</div>
+									)}
+								</>
 							)}
 							{(subIssues?.data.length ?? 0) === 0 && !showSubForm && (
 								<span className="text-[13px] text-text-muted">No sub-issues.</span>

--- a/packages/web/src/routes/companies/$companyId/projects/$projectId/route.tsx
+++ b/packages/web/src/routes/companies/$companyId/projects/$projectId/route.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Outlet, useLocation, useParams, useSearch } from '@tanstack/react-router';
 import { Breadcrumb } from '../../../../../components/ui/breadcrumb';
+import { useIssueAncestors } from '../../../../../hooks/use-issues';
 import { useProject } from '../../../../../hooks/use-projects';
 
 const AGENTS_MD_KEY = '__agents_md__';
@@ -12,12 +13,18 @@ function ProjectLayout() {
 	const { pathname } = useLocation();
 
 	const base = `/companies/${companyId}/projects/${projectId}`;
+	const onIssueDetail = pathname.startsWith(`${base}/issues`) && Boolean(allParams.issueId);
+	const { data: ancestors } = useIssueAncestors(
+		companyId,
+		onIssueDetail ? allParams.issueId : undefined,
+	);
 	const projectParams = { companyId, projectId };
 
 	const items: Array<{
 		label: string;
 		to?: string;
 		params?: Record<string, string>;
+		key?: string;
 	}> = [
 		{ label: 'Projects', to: '/companies/$companyId/projects', params: { companyId } },
 		{
@@ -34,6 +41,14 @@ function ProjectLayout() {
 			params: projectParams,
 		});
 		if (allParams.issueId) {
+			for (const ancestor of ancestors ?? []) {
+				items.push({
+					key: `ancestor-${ancestor.id}`,
+					label: ancestor.identifier.toUpperCase(),
+					to: '/companies/$companyId/projects/$projectId/issues/$issueId',
+					params: { ...projectParams, issueId: ancestor.identifier },
+				});
+			}
 			items.push({ label: allParams.issueId.toUpperCase() });
 		}
 	} else if (pathname.startsWith(`${base}/documents`)) {

--- a/tests/e2e/issue-breadcrumbs.spec.ts
+++ b/tests/e2e/issue-breadcrumbs.spec.ts
@@ -1,0 +1,155 @@
+import { expect, test } from '@playwright/test';
+import { authenticate, createCompanyWithAgents, waitForPageLoad } from './helpers';
+
+test('breadcrumb walks the parent chain on a sub-sub-issue', async ({ page }) => {
+	await page.goto('/');
+	await authenticate(page);
+
+	const { company, token } = await createCompanyWithAgents(page);
+	const headers = { Authorization: `Bearer ${token}` };
+
+	const agentsRes = await page.request.get(`/api/companies/${company.id}/agents`, { headers });
+	const agents = (await agentsRes.json()).data as { id: string; slug: string }[];
+	const engineer = agents.find((a) => a.slug === 'engineer') ?? agents[0];
+
+	const projectRes = await page.request.post(`/api/companies/${company.id}/projects`, {
+		headers,
+		data: { name: 'Breadcrumb Project', description: 'Seeded for breadcrumb test.' },
+	});
+	const project = (await projectRes.json()).data;
+
+	const rootRes = await page.request.post(`/api/companies/${company.id}/issues`, {
+		headers,
+		data: { project_id: project.id, title: 'Root Issue', assignee_id: engineer.id },
+	});
+	const root = (await rootRes.json()).data;
+
+	const subRes = await page.request.post(
+		`/api/companies/${company.id}/issues/${root.id}/sub-issues`,
+		{ headers, data: { title: 'Sub Issue', assignee_id: engineer.id } },
+	);
+	const sub = (await subRes.json()).data;
+
+	const subSubRes = await page.request.post(
+		`/api/companies/${company.id}/issues/${sub.id}/sub-issues`,
+		{ headers, data: { title: 'Sub-Sub Issue', assignee_id: engineer.id } },
+	);
+	const subSub = (await subSubRes.json()).data;
+
+	await page.goto(
+		`/companies/${company.id}/projects/${project.slug}/issues/${subSub.identifier.toLowerCase()}`,
+	);
+	await waitForPageLoad(page);
+	await expect(page.getByRole('heading', { name: 'Sub-Sub Issue' })).toBeVisible({
+		timeout: 10000,
+	});
+
+	const breadcrumb = page.getByTestId('breadcrumb');
+	await expect(breadcrumb).toContainText(root.identifier);
+	await expect(breadcrumb).toContainText(sub.identifier);
+	await expect(breadcrumb).toContainText(subSub.identifier);
+
+	const rootLink = breadcrumb.getByRole('link', { name: root.identifier });
+	const subLink = breadcrumb.getByRole('link', { name: sub.identifier });
+	await expect(rootLink).toBeVisible();
+	await expect(subLink).toBeVisible();
+
+	await rootLink.click();
+	await expect(page.getByRole('heading', { name: 'Root Issue' })).toBeVisible({ timeout: 10000 });
+});
+
+test('breadcrumb on a top-level issue shows no ancestors', async ({ page }) => {
+	await page.goto('/');
+	await authenticate(page);
+
+	const { company, token } = await createCompanyWithAgents(page);
+	const headers = { Authorization: `Bearer ${token}` };
+
+	const agentsRes = await page.request.get(`/api/companies/${company.id}/agents`, { headers });
+	const agents = (await agentsRes.json()).data as { id: string; slug: string }[];
+	const engineer = agents.find((a) => a.slug === 'engineer') ?? agents[0];
+
+	const projectRes = await page.request.post(`/api/companies/${company.id}/projects`, {
+		headers,
+		data: { name: 'Top Project', description: 'Top-level breadcrumb check.' },
+	});
+	const project = (await projectRes.json()).data;
+
+	const issueRes = await page.request.post(`/api/companies/${company.id}/issues`, {
+		headers,
+		data: { project_id: project.id, title: 'Top-Level Issue', assignee_id: engineer.id },
+	});
+	const issue = (await issueRes.json()).data;
+
+	await page.goto(
+		`/companies/${company.id}/projects/${project.slug}/issues/${issue.identifier.toLowerCase()}`,
+	);
+	await waitForPageLoad(page);
+	await expect(page.getByRole('heading', { name: 'Top-Level Issue' })).toBeVisible({
+		timeout: 10000,
+	});
+
+	const breadcrumb = page.getByTestId('breadcrumb');
+	await expect(breadcrumb).toContainText('Issues');
+	await expect(breadcrumb).toContainText(issue.identifier);
+	await expect(breadcrumb.getByRole('link')).toHaveCount(3); // Projects, project name, Issues
+});
+
+test('UI surfaces the depth-cap error when creating a sub-issue under a depth-2 ticket', async ({
+	page,
+}) => {
+	await page.goto('/');
+	await authenticate(page);
+
+	const { company, token } = await createCompanyWithAgents(page);
+	const headers = { Authorization: `Bearer ${token}` };
+
+	const agentsRes = await page.request.get(`/api/companies/${company.id}/agents`, { headers });
+	const agents = (await agentsRes.json()).data as { id: string; slug: string }[];
+	const engineer = agents.find((a) => a.slug === 'engineer') ?? agents[0];
+
+	const projectRes = await page.request.post(`/api/companies/${company.id}/projects`, {
+		headers,
+		data: { name: 'Depth Project', description: 'Depth-cap UI check.' },
+	});
+	const project = (await projectRes.json()).data;
+
+	const root = (
+		await (
+			await page.request.post(`/api/companies/${company.id}/issues`, {
+				headers,
+				data: { project_id: project.id, title: 'Depth Root', assignee_id: engineer.id },
+			})
+		).json()
+	).data;
+	const sub = (
+		await (
+			await page.request.post(`/api/companies/${company.id}/issues/${root.id}/sub-issues`, {
+				headers,
+				data: { title: 'Depth Sub', assignee_id: engineer.id },
+			})
+		).json()
+	).data;
+	const subSub = (
+		await (
+			await page.request.post(`/api/companies/${company.id}/issues/${sub.id}/sub-issues`, {
+				headers,
+				data: { title: 'Depth Sub-Sub', assignee_id: engineer.id },
+			})
+		).json()
+	).data;
+
+	await page.goto(
+		`/companies/${company.id}/projects/${project.slug}/issues/${subSub.identifier.toLowerCase()}`,
+	);
+	await waitForPageLoad(page);
+	await expect(page.getByRole('heading', { name: 'Depth Sub-Sub' })).toBeVisible({
+		timeout: 10000,
+	});
+
+	await page.getByTestId('sub-issues-add').click();
+	await page.getByTestId('sub-issue-title-input').fill('Should be rejected');
+	await page.getByRole('button', { name: 'Create' }).click();
+
+	await expect(page.getByTestId('sub-issue-error')).toContainText(/2 levels deep/);
+});


### PR DESCRIPTION
Sub-issues already exist but had no nesting limit and no UI affordance for
walking the parent chain. This change adds a hard cap of two levels of
descendants below a top-level issue (root → sub → sub-sub; depth 3 rejected),
extends the project-route breadcrumb to show every ancestor as a clickable
crumb, and instructs every agent role to prefer sub-issues over fresh
top-level tickets when the new work belongs underneath the current one.

- Server: assertChildDepthAllowed enforces the cap in POST /issues,
  POST /issues/:id/sub-issues, and the create_issue MCP tool, with a shared
  error message and an updated tool description.
- Server: new GET /issues/:id/ancestors returns root → parent via a recursive
  CTE (max 3 hops) and 404s on unknown issues.
- Agents: new shared partial agents/_partials/common/subtask-preference.md
  is included from every role doc, covering when to use sub-issues, the
  depth-2 cap, and how to restructure when a third level would be needed.
- Web: useIssueAncestors hook + project-route breadcrumb walks the chain so
  a sub-sub-issue page reads Projects > <Project> > Issues > <root> > <sub>
  > <sub-sub>; the sub-issue create form now surfaces the depth error.
- Tests: REST + MCP depth enforcement, ancestors endpoint, and
  partial-resolution coverage for the new include. Added an e2e spec for
  the breadcrumb chain and depth-3 UI rejection (Playwright browsers
  unavailable in this sandbox, so the spec was not executed locally).

https://claude.ai/code/session_01Tm4B2ghiqkE71h9auxEU71