### PR TITLE
Add pagination for sub-issues with configurable page size

### DIFF
--- a/packages/web/src/hooks/use-companies.ts
+++ b/packages/web/src/hooks/use-companies.ts
@@ -4,8 +4,11 @@ import { queryClient } from '../lib/query-client';
 
 export interface CompanySettings {
 	wake_mentioner_on_reply?: boolean;
+	subtask_page_size?: number;
 	[key: string]: unknown;
 }
+
+export const DEFAULT_SUBTASK_PAGE_SIZE = 10;
 
 export interface Company {
 	id: string;

--- a/packages/web/src/routes/companies/$companyId/projects/$projectId/issues/$issueId.tsx
+++ b/packages/web/src/routes/companies/$companyId/projects/$projectId/issues/$issueId.tsx
@@ -26,6 +26,7 @@ import {
 	useComments,
 	useCreateComment,
 } from '../../../../../../hooks/use-comments';
+import { DEFAULT_SUBTASK_PAGE_SIZE, useCompany } from '../../../../../../hooks/use-companies';
 import { type ExecutionLock, useExecutionLock } from '../../../../../../hooks/use-execution-locks';
 import {
 	useCreateSubIssue,
@@ -83,9 +84,14 @@ function IssueDetailPage() {
 	}, [issue?.identifier, issue?.project_slug, issueId, projectId, companyId, navigate]);
 	const { data: comments } = useComments(companyId, issueId);
 	const { data: deps } = useIssueDependencies(companyId, issueId);
+	const { data: company } = useCompany(companyId);
+	const subIssuePageSize = Math.max(
+		1,
+		company?.settings?.subtask_page_size ?? DEFAULT_SUBTASK_PAGE_SIZE,
+	);
 	const { data: subIssues } = useIssues(
 		companyId,
-		issue?.id ? { parent_issue_id: issue.id } : undefined,
+		issue?.id ? { parent_issue_id: issue.id, per_page: '200' } : undefined,
 		{ enabled: !!issue?.id },
 	);
 	const { data: agents } = useAgents(companyId);
@@ -102,7 +108,15 @@ function IssueDetailPage() {
 	const [wakeAssignee, setWakeAssignee] = useState(true);
 	const [subIssueTitle, setSubIssueTitle] = useState('');
 	const [showSubForm, setShowSubForm] = useState(false);
-	const [subIssuesOpen, setSubIssuesOpen] = useState(false);
+	const [subIssuesOpen, setSubIssuesOpen] = useState(true);
+	const [subIssuesShownState, setSubIssuesShownState] = useState<{
+		issueId: string;
+		count: number;
+	} | null>(null);
+	const subIssuesShown =
+		subIssuesShownState && subIssuesShownState.issueId === issue?.id
+			? subIssuesShownState.count
+			: subIssuePageSize;
 	const [editingSummary, setEditingSummary] = useState(false);
 	const [summaryText, setSummaryText] = useState('');
 	const [editingRules, setEditingRules] = useState(false);
@@ -396,7 +410,7 @@ function IssueDetailPage() {
 							{(subIssues?.data.length ?? 0) === 0 && !showSubForm && (
 								<span className="text-[13px] text-text-muted">No sub-issues.</span>
 							)}
-							{subIssues?.data.map((s) => (
+							{subIssues?.data.slice(0, subIssuesShown).map((s) => (
 								<Link
 									key={s.id}
 									to="/companies/$companyId/projects/$projectId/issues/$issueId"
@@ -415,6 +429,27 @@ function IssueDetailPage() {
 									<span className="truncate">{s.title}</span>
 								</Link>
 							))}
+							{subIssues && subIssues.data.length > subIssuesShown && (
+								<div className="flex justify-center pt-2 mt-0.5 border-t border-border-subtle">
+									<button
+										type="button"
+										onClick={() =>
+											setSubIssuesShownState({
+												issueId: issue?.id ?? '',
+												count: subIssuesShown + subIssuePageSize,
+											})
+										}
+										className="inline-flex items-center gap-1.5 text-[12px] text-text-subtle hover:text-text px-3 py-1 rounded-radius-md hover:bg-bg-subtle transition-colors cursor-pointer"
+										data-testid="sub-issues-show-more"
+									>
+										<ChevronDown className="w-3 h-3" />
+										Show more
+										<span className="text-text-subtle">
+											· {subIssues.data.length - subIssuesShown} hidden
+										</span>
+									</button>
+								</div>
+							)}
 						</div>
 					)}
 				</div>

--- a/packages/web/src/routes/companies/$companyId/settings/index.tsx
+++ b/packages/web/src/routes/companies/$companyId/settings/index.tsx
@@ -6,7 +6,11 @@ import { Badge } from '../../../../components/ui/badge';
 import { Button } from '../../../../components/ui/button';
 import { Input } from '../../../../components/ui/input';
 import { useApiKeys, useCreateApiKey, useDeleteApiKey } from '../../../../hooks/use-api-keys';
-import { useCompany, useUpdateCompany } from '../../../../hooks/use-companies';
+import {
+	DEFAULT_SUBTASK_PAGE_SIZE,
+	useCompany,
+	useUpdateCompany,
+} from '../../../../hooks/use-companies';
 import {
 	useConnections,
 	useDeleteConnection,
@@ -142,9 +146,27 @@ function AutomationsSection({ companyId }: { companyId: string }) {
 	const { data: company } = useCompany(companyId);
 	const updateCompany = useUpdateCompany(companyId);
 	const wakeOnReply = company?.settings?.wake_mentioner_on_reply ?? true;
+	const savedPageSize = company?.settings?.subtask_page_size ?? DEFAULT_SUBTASK_PAGE_SIZE;
+	const [pageSizeInput, setPageSizeInput] = useState<string>(String(savedPageSize));
+
+	useEffect(() => {
+		setPageSizeInput(String(savedPageSize));
+	}, [savedPageSize]);
 
 	async function toggleWakeOnReply(next: boolean) {
 		await updateCompany.mutateAsync({ settings: { wake_mentioner_on_reply: next } });
+	}
+
+	async function commitPageSize() {
+		const parsed = Math.floor(Number(pageSizeInput));
+		if (!Number.isFinite(parsed) || parsed < 1) {
+			setPageSizeInput(String(savedPageSize));
+			return;
+		}
+		const clamped = Math.min(500, parsed);
+		setPageSizeInput(String(clamped));
+		if (clamped === savedPageSize) return;
+		await updateCompany.mutateAsync({ settings: { subtask_page_size: clamped } });
 	}
 
 	return (
@@ -171,6 +193,30 @@ function AutomationsSection({ companyId }: { companyId: string }) {
 					</span>
 				</span>
 			</label>
+			<div className="mt-5 pt-5 border-t border-border-subtle max-w-xl">
+				<label htmlFor="subtask-page-size" className="block text-[13px] font-medium">
+					Sub-issue page size
+				</label>
+				<p className="text-text-muted text-[13px] mt-0.5 mb-1.5">
+					How many sub-issues to show on an issue page before a "Show more" link is offered.
+				</p>
+				<Input
+					id="subtask-page-size"
+					type="number"
+					min={1}
+					max={500}
+					step={1}
+					value={pageSizeInput}
+					onChange={(e) => setPageSizeInput(e.target.value)}
+					onBlur={commitPageSize}
+					onKeyDown={(e) => {
+						if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
+					}}
+					disabled={!company || updateCompany.isPending}
+					className="w-24"
+					data-testid="subtask-page-size-input"
+				/>
+			</div>
 		</section>
 	);
 }

--- a/tests/e2e/issue-sub-issues.spec.ts
+++ b/tests/e2e/issue-sub-issues.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { authenticate, createCompanyWithAgents, waitForPageLoad } from './helpers';
 
-test('sub-issues panel is collapsed by default and expands on click', async ({ page }) => {
+test('sub-issues panel is expanded by default and collapses on click', async ({ page }) => {
 	await page.goto('/');
 	await authenticate(page);
 
@@ -52,19 +52,86 @@ test('sub-issues panel is collapsed by default and expands on click', async ({ p
 	await expect(toggle).toBeVisible();
 	await expect(toggle).toContainText('Sub-issues');
 	await expect(toggle).toContainText('2');
-	await expect(toggle).toHaveAttribute('aria-expanded', 'false');
-	await expect(page.getByTestId('sub-issues-list')).toBeHidden();
-
-	await toggle.click();
-
 	await expect(toggle).toHaveAttribute('aria-expanded', 'true');
 	const list = page.getByTestId('sub-issues-list');
 	await expect(list).toBeVisible();
 	await expect(list.getByText('Child Issue Alpha')).toBeVisible();
 	await expect(list.getByText('Child Issue Beta')).toBeVisible();
 
+	// With only 2 sub-issues and a default page size of 10, no "Show more" should appear.
+	await expect(page.getByTestId('sub-issues-show-more')).toHaveCount(0);
+
+	await toggle.click();
+	await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+	await expect(list).toBeHidden();
+
 	// CEO agent variable retained to validate presence in the seeded company.
 	expect(ceo).toBeDefined();
+});
+
+test('sub-issues paginate to company page size with a Show more link', async ({ page }) => {
+	await page.goto('/');
+	await authenticate(page);
+
+	const { company, token } = await createCompanyWithAgents(page);
+	const headers = { Authorization: `Bearer ${token}` };
+
+	// Set the page size to 3 for this company so we don't have to seed dozens of sub-issues.
+	const patchRes = await page.request.patch(`/api/companies/${company.id}`, {
+		headers,
+		data: { settings: { subtask_page_size: 3 } },
+	});
+	expect(patchRes.ok()).toBeTruthy();
+
+	const agentsRes = await page.request.get(`/api/companies/${company.id}/agents`, { headers });
+	const agents = (await agentsRes.json()).data as { id: string; slug: string }[];
+	const engineer = agents.find((a) => a.slug === 'engineer') ?? agents[0];
+
+	const projectRes = await page.request.post(`/api/companies/${company.id}/projects`, {
+		headers,
+		data: { name: 'Pagination Project', description: 'Seeded for pagination test.' },
+	});
+	const project = (await projectRes.json()).data;
+
+	const parentRes = await page.request.post(`/api/companies/${company.id}/issues`, {
+		headers,
+		data: { project_id: project.id, title: 'Pagination Parent', assignee_id: engineer.id },
+	});
+	const parent = (await parentRes.json()).data;
+
+	const titles = ['Sub A', 'Sub B', 'Sub C', 'Sub D', 'Sub E', 'Sub F', 'Sub G'];
+	for (const title of titles) {
+		const res = await page.request.post(
+			`/api/companies/${company.id}/issues/${parent.id}/sub-issues`,
+			{ headers, data: { title, assignee_id: engineer.id } },
+		);
+		expect(res.ok()).toBeTruthy();
+	}
+
+	await page.goto(`/companies/${company.id}/issues/${parent.id}`);
+	await waitForPageLoad(page);
+	await expect(page.getByRole('heading', { name: 'Pagination Parent' })).toBeVisible({
+		timeout: 10000,
+	});
+
+	const list = page.getByTestId('sub-issues-list');
+	await expect(list).toBeVisible();
+
+	// First batch — 3 visible, 4 hidden.
+	await expect(list.getByTestId('sub-issue-item')).toHaveCount(3);
+	const showMore = page.getByTestId('sub-issues-show-more');
+	await expect(showMore).toBeVisible();
+	await expect(showMore).toContainText('4 hidden');
+
+	// Second batch — 6 visible, 1 hidden.
+	await showMore.click();
+	await expect(list.getByTestId('sub-issue-item')).toHaveCount(6);
+	await expect(showMore).toContainText('1 hidden');
+
+	// Final batch — all 7 visible, link gone.
+	await showMore.click();
+	await expect(list.getByTestId('sub-issue-item')).toHaveCount(7);
+	await expect(page.getByTestId('sub-issues-show-more')).toHaveCount(0);
 });
 
 test('sub-issues panel sits between description card and comments', async ({ page }) => {


### PR DESCRIPTION
## Summary
This PR implements pagination for sub-issues on issue detail pages, allowing users to load sub-issues incrementally via a "Show more" button. The page size is now configurable per company through the settings interface.

## Key Changes
- **Sub-issues panel now expanded by default** instead of collapsed, with the ability to collapse on click
- **Pagination UI**: Added a "Show more" button that appears when sub-issues exceed the configured page size, displaying the count of hidden items
- **Configurable page size**: Added a new "Sub-issue page size" setting in the company automations section (default: 10, max: 500)
- **State management**: Implemented `subIssuesShownState` to track how many sub-issues are displayed per issue, allowing independent pagination for different issues
- **API integration**: Updated sub-issues query to fetch all available sub-issues (per_page: 200) and slice them client-side based on the page size setting

## Implementation Details
- The default page size constant (`DEFAULT_SUBTASK_PAGE_SIZE = 10`) is exported from `use-companies.ts` and used across components
- Page size input includes validation (min: 1, max: 500) with automatic clamping and blur/Enter key handling
- Sub-issues are fetched in full but displayed incrementally, with each "Show more" click adding another page worth of items
- The pagination state is tied to the specific issue ID to support multiple issues on the same page
- Updated test suite includes a new test validating pagination behavior with a custom page size of 3

https://claude.ai/code/session_01DqBsptww7iKAxHfJYYsYNL