### PR TITLE
Move effort and wake assignee controls to sticky sidebar

### DIFF
--- a/packages/web/src/routes/companies/$companyId/projects/$projectId/issues/$issueId.tsx
+++ b/packages/web/src/routes/companies/$companyId/projects/$projectId/issues/$issueId.tsx
@@ -517,52 +517,25 @@ function IssueDetailPage() {
 							placeholder="Add a comment..."
 							className="min-h-[60px]"
 						/>
-						<div className="flex items-center justify-between gap-2">
-							<label className="flex items-center gap-2 text-[11px] text-text-muted">
-								<span>Effort</span>
-								<select
-									value={commentEffort ?? effectiveDefaultEffort}
-									onChange={(e) => setCommentEffort(e.target.value as AgentEffort)}
-									className="bg-background border border-border rounded-radius-md px-2 py-1 text-[11px]"
-									aria-label="Reasoning effort for the agent run triggered by this comment"
-								>
-									{EFFORT_LEVELS.map(({ value, label }) => (
-										<option key={value} value={value}>
-											{label}
-											{value === effectiveDefaultEffort ? ' (default)' : ''}
-										</option>
-									))}
-								</select>
-							</label>
-							<div className="flex items-center gap-3">
-								{issue.assignee_id && (
-									<label className="flex items-center gap-1.5 text-[11px] text-text-muted cursor-pointer select-none">
-										<input
-											type="checkbox"
-											checked={wakeAssignee}
-											onChange={(e) => setWakeAssignee(e.target.checked)}
-											className="rounded"
-											aria-label="Wake assignee on submit"
-										/>
-										Wake assignee
-									</label>
-								)}
-								<Button
-									type="submit"
-									size="sm"
-									disabled={!commentText.trim() || createComment.isPending}
-								>
-									{createComment.isPending && <Loader2 className="w-3 h-3 animate-spin" />}
-									Comment
-								</Button>
-							</div>
+						<div className="flex items-center justify-end gap-2">
+							<Button
+								type="submit"
+								size="sm"
+								disabled={!commentText.trim() || createComment.isPending}
+							>
+								{createComment.isPending && <Loader2 className="w-3 h-3 animate-spin" />}
+								Comment
+							</Button>
 						</div>
 					</form>
 				</div>
 			</div>
 
 			{/* Sidebar */}
-			<div className="flex flex-col gap-4 text-xs">
+			<div
+				data-testid="issue-sidebar"
+				className="flex flex-col gap-4 text-xs lg:sticky lg:top-0 lg:self-start"
+			>
 				<div>
 					<span className="text-text-subtle block mb-1 uppercase tracking-wider font-medium">
 						Priority
@@ -665,6 +638,38 @@ function IssueDetailPage() {
 						{new Date(issue.created_at).toLocaleDateString()}
 					</span>
 				</div>
+
+				<div>
+					<span className="text-text-subtle block mb-1 uppercase tracking-wider font-medium">
+						Effort
+					</span>
+					<select
+						value={commentEffort ?? effectiveDefaultEffort}
+						onChange={(e) => setCommentEffort(e.target.value as AgentEffort)}
+						className="w-full rounded-radius-md border border-border bg-bg px-2.5 py-1.5 text-xs text-text outline-none"
+						aria-label="Reasoning effort for the agent run triggered by this comment"
+					>
+						{EFFORT_LEVELS.map(({ value, label }) => (
+							<option key={value} value={value}>
+								{label}
+								{value === effectiveDefaultEffort ? ' (default)' : ''}
+							</option>
+						))}
+					</select>
+				</div>
+
+				{issue.assignee_id && (
+					<label className="flex items-center gap-2 text-[13px] text-text cursor-pointer select-none">
+						<input
+							type="checkbox"
+							checked={wakeAssignee}
+							onChange={(e) => setWakeAssignee(e.target.checked)}
+							className="rounded"
+							aria-label="Wake assignee on submit"
+						/>
+						<span>Wake assignee</span>
+					</label>
+				)}
 
 				<div className="mt-auto pt-4 border-t border-border">
 					{issue.status === IssueStatus.Closed ? (

--- a/tests/e2e/issue-sidebar-sticky.spec.ts
+++ b/tests/e2e/issue-sidebar-sticky.spec.ts
@@ -1,0 +1,96 @@
+import { expect, test } from '@playwright/test';
+import { authenticate, createCompanyWithAgents, waitForPageLoad } from './helpers';
+
+test.describe('Issue detail right sidebar', () => {
+	async function createProjectAndIssue(page: import('@playwright/test').Page) {
+		const { company, token } = await createCompanyWithAgents(page);
+		const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+
+		const projRes = await page.request.post(`/api/companies/${company.id}/projects`, {
+			headers,
+			data: { name: 'Sidebar Project', description: 'Sidebar test project.' },
+		});
+		const project = ((await projRes.json()) as any).data;
+
+		const agentsRes = await page.request.get(`/api/companies/${company.id}/agents`, {
+			headers: { Authorization: `Bearer ${token}` },
+		});
+		const agents = ((await agentsRes.json()) as any).data;
+		const agent = agents[0];
+
+		const issueRes = await page.request.post(`/api/companies/${company.id}/issues`, {
+			headers,
+			data: { project_id: project.id, title: 'Sidebar Test Issue', assignee_id: agent.id },
+		});
+		const issue = ((await issueRes.json()) as any).data;
+
+		return { company, headers, issue };
+	}
+
+	test('floats (sticky) as the page scrolls on desktop', async ({ page }) => {
+		await authenticate(page);
+		await page.setViewportSize({ width: 1280, height: 720 });
+		const { company, headers, issue } = await createProjectAndIssue(page);
+
+		// Seed enough comments to make the page scrollable past one viewport.
+		for (let i = 0; i < 25; i++) {
+			await page.request.post(`/api/companies/${company.id}/issues/${issue.id}/comments`, {
+				headers,
+				data: {
+					content_type: 'text',
+					content: { text: `Filler comment ${i}. ${'lorem ipsum '.repeat(30)}` },
+				},
+			});
+		}
+
+		await page.goto(`/companies/${company.slug}/issues/${issue.id}`);
+		await waitForPageLoad(page);
+
+		const sidebar = page.getByTestId('issue-sidebar');
+		await expect(sidebar).toBeVisible({ timeout: 10000 });
+
+		const position = await sidebar.evaluate((el) => getComputedStyle(el).position);
+		expect(position).toBe('sticky');
+
+		const main = page.locator('main').first();
+		const initialY = (await sidebar.boundingBox())?.y ?? 0;
+
+		await main.evaluate((el) => {
+			el.scrollBy(0, 800);
+		});
+		// Allow a paint to settle.
+		await page.waitForTimeout(100);
+
+		const scrolled = await sidebar.boundingBox();
+		expect(scrolled).not.toBeNull();
+		// Sticky pins the sidebar against the scroll container's top edge instead of
+		// letting it scroll out of view; its y must not drop below the initial value.
+		expect(scrolled!.y).toBeLessThanOrEqual(initialY);
+		// And it must still be on screen.
+		expect(scrolled!.y).toBeGreaterThanOrEqual(0);
+		expect(scrolled!.y + scrolled!.height).toBeLessThanOrEqual(720);
+	});
+
+	test('houses the Effort dropdown and Wake-assignee toggle (moved from the comment form)', async ({
+		page,
+	}) => {
+		await authenticate(page);
+		await page.setViewportSize({ width: 1280, height: 720 });
+		const { company, issue } = await createProjectAndIssue(page);
+
+		await page.goto(`/companies/${company.slug}/issues/${issue.id}`);
+		await waitForPageLoad(page);
+
+		const sidebar = page.getByTestId('issue-sidebar');
+		await expect(sidebar).toBeVisible({ timeout: 10000 });
+
+		const effort = sidebar.getByLabel(
+			'Reasoning effort for the agent run triggered by this comment',
+		);
+		await expect(effort).toBeVisible();
+
+		const wake = sidebar.getByRole('checkbox', { name: 'Wake assignee on submit' });
+		await expect(wake).toBeVisible();
+		await expect(wake).toBeChecked();
+	});
+});


### PR DESCRIPTION
## Summary
Refactored the issue detail page to move the "Effort" dropdown and "Wake assignee" toggle from the comment form into the right sidebar, which is now sticky on desktop viewports.

## Key Changes
- **Sticky sidebar**: Added `lg:sticky lg:top-0 lg:self-start` classes to the sidebar container to keep it pinned to the top while scrolling on desktop (1024px+)
- **Moved controls**: Relocated the Effort dropdown and Wake assignee checkbox from the comment form footer to dedicated sections in the sidebar
- **Simplified comment form**: Removed the effort/wake controls from the form footer, leaving only the submit button
- **Styling updates**: Updated the moved controls to match sidebar styling (full-width select, consistent text sizing)
- **Test coverage**: Added comprehensive e2e tests verifying:
  - Sidebar stickiness behavior during page scroll
  - Presence and visibility of the relocated controls in the sidebar

## Implementation Details
- The sidebar uses CSS `sticky` positioning with `top: 0` to maintain its position relative to the scroll container
- Controls are conditionally rendered (wake assignee only shows if issue has an assignee)
- Added `data-testid="issue-sidebar"` for test targeting
- Maintained all existing functionality and state management for the moved controls

https://claude.ai/code/session_016VZbLuj88kFkh56aEb63bR