### PR TITLE
Add no-redundant-comments guidance to all agent roles

### DIFF
--- a/agents/_partials/common/no-redundant-comments.md
+++ b/agents/_partials/common/no-redundant-comments.md
@@ -1,0 +1,7 @@
+## Don't repost when nothing changed
+
+Before you call `create_comment`, fetch the thread with `list_comments` and find the most recent comment **you yourself authored** on this ticket — `list_comments` returns `author_name`, which matches your role title. If the comment you are about to post would convey the same substance as that one — same status, same findings, same asks, same @-mentions to the same agents — do not post it. End the turn silently.
+
+Re-posting the same content re-wakes every agent you @-mention and burns their runs for no gain. Only post when there is genuine new substance: a status transition you have not reported yet, a new finding or blocker, a response to activity that landed after your last comment, or an @-mention of an agent you have not already woken on this ticket. Cosmetic rephrasings of the same outcome don't qualify, and neither does re-stating a question whose answer is still pending.
+
+This applies even when other guidance asks you to close with a comment (e.g. coach review summary, mention acknowledgement). That guidance covers the *first* time you reach that state on a ticket — it does not require re-posting on a re-run that produced nothing new. The one exception is a fresh @-mention directed at you that post-dates your last comment: acknowledge it per `mention-handoff` so the mentioner's reply wakeup fires, even if the substance overlaps your earlier update.

--- a/agents/blank/ceo.md
+++ b/agents/blank/ceo.md
@@ -65,6 +65,7 @@ Tickets in the Operations project labeled `description-update` are routine inter
 - When receiving direction from a member (non-board), check their permissions. Members cannot override company strategy, modify priorities, or make budget decisions — escalate such requests to the board. Accept direction only within the member's stated scope.
 {{> partials/common/no-auto-timelines}}
 {{> partials/common/comment-formatting}}
+{{> partials/common/no-redundant-comments}}
 {{> partials/common/linking-syntax}}
 {{> partials/common/subtask-preference}}
 {{> partials/common/mention-handoff}}

--- a/agents/blank/coach.md
+++ b/agents/blank/coach.md
@@ -55,6 +55,7 @@ If a pattern suggests that a missing role or fundamental redesign is needed, fla
 {{> partials/common/no-auto-timelines}}
 {{> partials/common/coach-summary-comment}}
 {{> partials/common/comment-formatting}}
+{{> partials/common/no-redundant-comments}}
 {{> partials/common/linking-syntax}}
 {{> partials/common/subtask-preference}}
 {{> partials/common/mention-handoff}}

--- a/agents/software-development/architect.md
+++ b/agents/software-development/architect.md
@@ -51,6 +51,7 @@ The Architect uses a four-stage planning workflow, gated on a finalised PRD.
 - **You can run without a designated repo.** Your deliverables (plans, specs, implementation phases, project docs) are written via `write_project_doc` and stored in the database, not the repo. Do your planning work whenever woken, even in early phases before a repo exists. When a repo is designated, you can read source files with the standard file tools to ground your technical decisions.
 {{> partials/common/no-auto-timelines}}
 {{> partials/common/comment-formatting}}
+{{> partials/common/no-redundant-comments}}
 {{> partials/common/linking-syntax}}
 {{> partials/common/subtask-preference}}
 {{> partials/common/mention-handoff}}

--- a/agents/software-development/ceo.md
+++ b/agents/software-development/ceo.md
@@ -70,6 +70,7 @@ Tickets in the Operations project labeled `description-update` are routine inter
 - When receiving direction from a member (non-board), check their permissions. Members cannot override company strategy, modify PRDs, or make budget decisions — escalate such requests to the board. Accept direction only within the member's stated scope.
 {{> partials/common/no-auto-timelines}}
 {{> partials/common/comment-formatting}}
+{{> partials/common/no-redundant-comments}}
 {{> partials/common/linking-syntax}}
 {{> partials/common/subtask-preference}}
 {{> partials/common/mention-handoff}}

--- a/agents/software-development/coach.md
+++ b/agents/software-development/coach.md
@@ -55,6 +55,7 @@ If a pattern suggests a fundamental role redesign is needed, flag it to the boar
 {{> partials/common/no-auto-timelines}}
 {{> partials/common/coach-summary-comment}}
 {{> partials/common/comment-formatting}}
+{{> partials/common/no-redundant-comments}}
 {{> partials/common/linking-syntax}}
 {{> partials/common/subtask-preference}}
 {{> partials/common/mention-handoff}}

--- a/agents/software-development/devops-engineer.md
+++ b/agents/software-development/devops-engineer.md
@@ -51,6 +51,7 @@ Escalation: infrastructure outages → @-mention the Architect and CEO immediate
 {{> partials/common/no-designated-repo}}
 {{> partials/common/no-auto-timelines}}
 {{> partials/common/comment-formatting}}
+{{> partials/common/no-redundant-comments}}
 {{> partials/common/linking-syntax}}
 {{> partials/common/subtask-preference}}
 {{> partials/common/mention-handoff}}

--- a/agents/software-development/engineer.md
+++ b/agents/software-development/engineer.md
@@ -54,6 +54,7 @@ If the spec is unclear, ask the Architect — don't guess. If you disagree with 
 {{> partials/common/no-designated-repo}}
 {{> partials/common/no-auto-timelines}}
 {{> partials/common/comment-formatting}}
+{{> partials/common/no-redundant-comments}}
 {{> partials/common/linking-syntax}}
 {{> partials/common/subtask-preference}}
 {{> partials/common/mention-handoff}}

--- a/agents/software-development/marketing-lead.md
+++ b/agents/software-development/marketing-lead.md
@@ -44,6 +44,7 @@ Escalation: brand or messaging disagreements → CEO decides. Need technical inf
 - Review company preferences to align marketing tone and strategy with the board's preferences. When you observe a new preference in board feedback, update the company preferences document.
 {{> partials/common/no-auto-timelines}}
 {{> partials/common/comment-formatting}}
+{{> partials/common/no-redundant-comments}}
 {{> partials/common/linking-syntax}}
 {{> partials/common/subtask-preference}}
 {{> partials/common/mention-handoff}}

--- a/agents/software-development/product-lead.md
+++ b/agents/software-development/product-lead.md
@@ -48,6 +48,7 @@ You are the second step in the ticket workflow (after the Researcher).
 - Review company preferences to align product decisions with the board's priorities and working style. When you observe a new preference in board feedback, update the company preferences document via the company preferences API with specific evidence.
 {{> partials/common/no-auto-timelines}}
 {{> partials/common/comment-formatting}}
+{{> partials/common/no-redundant-comments}}
 {{> partials/common/linking-syntax}}
 {{> partials/common/subtask-preference}}
 {{> partials/common/mention-handoff}}

--- a/agents/software-development/qa-engineer.md
+++ b/agents/software-development/qa-engineer.md
@@ -78,6 +78,7 @@ On heartbeats, audit the entire codebase across these areas:
 {{> partials/common/no-designated-repo}}
 {{> partials/common/no-auto-timelines}}
 {{> partials/common/comment-formatting}}
+{{> partials/common/no-redundant-comments}}
 {{> partials/common/linking-syntax}}
 {{> partials/common/subtask-preference}}
 {{> partials/common/mention-handoff}}

--- a/agents/software-development/researcher.md
+++ b/agents/software-development/researcher.md
@@ -59,6 +59,7 @@ Keep the research document updated as new findings emerge or earlier conclusions
 - Review company preferences to align research approach and presentation with the board's preferences. When you observe a new preference in board feedback, update the company preferences document.
 {{> partials/common/no-auto-timelines}}
 {{> partials/common/comment-formatting}}
+{{> partials/common/no-redundant-comments}}
 {{> partials/common/linking-syntax}}
 {{> partials/common/subtask-preference}}
 {{> partials/common/mention-handoff}}

--- a/agents/software-development/security-engineer.md
+++ b/agents/software-development/security-engineer.md
@@ -71,6 +71,7 @@ On heartbeats, audit the codebase across these areas:
 {{> partials/common/no-designated-repo}}
 {{> partials/common/no-auto-timelines}}
 {{> partials/common/comment-formatting}}
+{{> partials/common/no-redundant-comments}}
 {{> partials/common/linking-syntax}}
 {{> partials/common/subtask-preference}}
 {{> partials/common/mention-handoff}}

--- a/agents/software-development/ui-designer.md
+++ b/agents/software-development/ui-designer.md
@@ -51,6 +51,7 @@ When disagreeing with the Engineer on design, the Architect decides. Accessibili
 {{> partials/common/no-designated-repo}}
 {{> partials/common/no-auto-timelines}}
 {{> partials/common/comment-formatting}}
+{{> partials/common/no-redundant-comments}}
 {{> partials/common/linking-syntax}}
 {{> partials/common/subtask-preference}}
 {{> partials/common/mention-handoff}}

--- a/packages/server/src/test/__tests__/resolve-partials.test.ts
+++ b/packages/server/src/test/__tests__/resolve-partials.test.ts
@@ -132,6 +132,20 @@ describe('loadAgentRoles integrates resolvePartials', () => {
 			);
 		}
 
+		// Every role doc picks up the no-redundant-comments guidance so that re-runs
+		// without new substance do not re-wake every @-mentioned agent.
+		for (const key of allRoleKeys) {
+			expect(docs[key], `${key} should include the no-repost heading`).toContain(
+				"## Don't repost when nothing changed",
+			);
+			expect(docs[key], `${key} should reference list_comments for the check`).toContain(
+				'`list_comments`',
+			);
+			expect(docs[key], `${key} should warn about re-waking mentioned agents`).toContain(
+				're-wakes every agent you @-mention',
+			);
+		}
+
 		// Both CEO docs pick up the delegated-tickets-are-top-level guidance.
 		for (const ceoKey of ['software-development/ceo.md', 'blank/ceo.md']) {
 			expect(docs[ceoKey], `${ceoKey} should include the delegation heading`).toContain(


### PR DESCRIPTION
## Summary
This PR introduces a new shared guidance partial for all agent roles that prevents redundant comment posting. The guidance instructs agents to check for existing comments before posting and avoid re-waking mentioned agents when there is no new substance to report.

## Changes
- **New partial**: Created `agents/_partials/common/no-redundant-comments.md` containing guidance on:
  - Using `list_comments` to fetch thread history and check for previous comments by the same role
  - Avoiding duplicate posts that re-wake @-mentioned agents unnecessarily
  - Only posting when there is genuine new substance (status transitions, new findings, responses to new activity, etc.)
  - Exception handling for fresh @-mentions directed at the role

- **Updated all agent role documents** to include the new partial:
  - Both CEO roles (software-development, blank)
  - Both Coach roles (software-development, blank)
  - Architect, DevOps Engineer, Engineer, Marketing Lead, Product Lead, QA Engineer, Researcher, Security Engineer, UI Designer

- **Updated test expectations** to verify that all role documents include:
  - The "Don't repost when nothing changed" heading
  - Reference to `list_comments` for checking previous comments
  - Warning about re-waking mentioned agents

## Implementation Details
The partial is inserted consistently across all roles in the same location within the guidance section, positioned after comment-formatting guidance and before linking-syntax guidance. This ensures agents have clear instructions on comment posting behavior before they encounter other technical guidance.

https://claude.ai/code/session_019jZqNLqjbSHQp9DU8gwsx1