### PR TITLE
feat: record status changes and first cross-issue links on the timeline

### DIFF
--- a/.dev/api.md
+++ b/.dev/api.md
@@ -978,6 +978,33 @@ Request:
 Sets `chosen_option` on the comment and posts a system comment recording the
 choice. Triggers the assigned agent.
 
+#### System events appended by the server
+
+The server automatically appends `system`-typed comments for two events:
+
+- **Status change** — fires whenever an issue's status changes, regardless of
+  the path that drove it (PATCH `/companies/:companyId/issues/:issueId`, MCP
+  `update_issue`, hire-approval auto-Done, agent-runner auto-flip
+  `backlog → in_progress`, Coach auto-close `done → closed`). A no-op PATCH
+  (status set to its current value) records nothing.
+  Body: `{ "kind": "status_change", "from": "<old>", "to": "<new>", "actor_id":
+  "<member_uuid|null>", "text": "<actor> changed status from <old> to <new>" }`.
+  `author_member_id` is the actor's member id (or `null` for unattributable
+  automations).
+- **Issue link** — fires on the **target** issue the first time a given source
+  issue mentions it. Sources are scanned in: descriptions on POST `/issues` and
+  PATCH `/issues/:issueId`, comments on POST `/issues/:issueId/comments`, and
+  the MCP equivalents (`create_issue`, `update_issue`, `create_comment`).
+  Subsequent mentions from the same source are silently deduped via the
+  `source_issue_id` JSONB key. Cross-company, self-, code-block, inline-code,
+  and unknown-identifier mentions are ignored.
+  Body: `{ "kind": "issue_link", "source_issue_id": "<uuid>",
+  "source_identifier": "<e.g. OP-42>", "actor_id": "<member_uuid|null>",
+  "text": "Linked from <source_identifier> by <actor>" }`.
+
+Both events broadcast over the company WebSocket as `RowChange` /
+`issue_comments` / `INSERT`, so live viewers see them without a refresh.
+
 ---
 
 ### Tool Calls

--- a/.dev/schema.md
+++ b/.dev/schema.md
@@ -92,7 +92,9 @@ The `content_type` enum discriminates the shape:
 - `options` → `{ "prompt": "...", "options": [{ "id", "label", "description" }] }`
 - `preview` → `{ "filename": "...", "label": "...", "description": "..." }`
 - `trace` → `{ "summary": "4 tool calls" }` (detail lives in `tool_calls` table)
-- `system` → `{ "text": "Agent disabled — budget limit reached" }`
+- `system` → `{ "text": "...", "kind"?: "status_change" | "issue_link" | <other>, ... }`. Auto-generated timeline entries. The renderer shows `text`; `kind` plus per-kind fields let the server dedup and tooling filter without re-parsing prose.
+  - `status_change`: `{ "kind": "status_change", "from": "<old>", "to": "<new>", "actor_id": "<member_uuid|null>", "text": "<actor> changed status from <old> to <new>" }` — written for every issue status transition.
+  - `issue_link`: `{ "kind": "issue_link", "source_issue_id": "<uuid>", "source_identifier": "<e.g. OP-42>", "actor_id": "<member_uuid|null>", "text": "Linked from <source_identifier> by <actor>" }` — written on the **target** issue the first time a given source issue mentions it; subsequent mentions from the same source are deduped via the `source_issue_id` JSONB key.
 - `execution` → `{ "heartbeat_run_id", "agent_id", "agent_title", "status", "exit_code", "duration_ms", "stdout_preview" }` (auto-created on agent run completion)
 - `action` → `{ "kind": "setup_repo", "approval_id": "..." }` — surfaces a board-required action inline on the ticket. Resolves by setting `chosen_option` to `{ status: 'complete', result: {...} }`. Currently only `setup_repo` is defined, used by the designated-repo gate.
 

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -33,6 +33,7 @@ import {
 	upsertDocument,
 } from '../services/documents';
 import { triggerStatusAutomations } from '../services/issue-automation';
+import { recordIssueLinks } from '../services/issue-events';
 import { createWakeup } from '../services/wakeup';
 import type { WebSocketManager } from '../services/ws';
 
@@ -357,6 +358,18 @@ export function registerTools(
 				}).catch((e) => log.error('Failed to wake agent:', e));
 			}
 
+			if (args.description) {
+				const actorMemberId = auth.type === AuthType.Agent ? auth.memberId : null;
+				recordIssueLinks(
+					db,
+					args.company_id as string,
+					r.rows[0].id,
+					args.description as string,
+					actorMemberId,
+					wsManager,
+				).catch((e) => log.error('Failed to record issue links from description:', e));
+			}
+
 			return r.rows[0];
 		},
 		db,
@@ -398,14 +411,18 @@ export function registerTools(
 			const denied = await verifyCompanyAccess(db, auth, args.company_id as string);
 			if (denied) return { error: denied };
 
-			if (args.status !== undefined && auth.type === AuthType.Agent) {
-				const currentStatus = await db.query<{ status: string }>(
-					'SELECT status FROM issues WHERE id = $1 AND company_id = $2',
-					[args.issue_id, args.company_id],
-				);
-				if (currentStatus.rows[0]?.status === IssueStatus.Closed) {
-					return { error: 'Only board members can re-open a closed issue' };
-				}
+			const currentStatusResult = await db.query<{ status: string }>(
+				'SELECT status FROM issues WHERE id = $1 AND company_id = $2',
+				[args.issue_id, args.company_id],
+			);
+			const currentStatus = currentStatusResult.rows[0]?.status;
+
+			if (
+				args.status !== undefined &&
+				auth.type === AuthType.Agent &&
+				currentStatus === IssueStatus.Closed
+			) {
+				return { error: 'Only board members can re-open a closed issue' };
 			}
 
 			if (args.status === IssueStatus.Done || args.status === IssueStatus.Closed) {
@@ -488,13 +505,29 @@ export function registerTools(
 			);
 			if (!r.rows[0]) return null;
 
-			// Trigger status automations (e.g. Coach wakeup on Done)
-			if (args.status) {
+			const actorMemberId = auth.type === AuthType.Agent ? auth.memberId : null;
+
+			if (args.description !== undefined) {
+				recordIssueLinks(
+					db,
+					args.company_id as string,
+					args.issue_id as string,
+					args.description as string,
+					actorMemberId,
+					wsManager,
+				).catch((e) => log.error('Failed to record issue links from description:', e));
+			}
+
+			// Trigger status automations (e.g. Coach wakeup on Done) and record the change
+			if (args.status && currentStatus) {
 				triggerStatusAutomations(
 					db,
 					args.company_id as string,
 					args.issue_id as string,
+					currentStatus,
 					args.status as string,
+					actorMemberId,
+					wsManager,
 				).catch((e) => log.error('Failed to trigger status automations:', e));
 			}
 
@@ -741,6 +774,14 @@ export function registerTools(
 				authorMemberId,
 				authorRunId: auth.type === AuthType.Agent ? auth.runId : null,
 			});
+			recordIssueLinks(
+				db,
+				args.company_id as string,
+				args.issue_id as string,
+				args.content as string,
+				authorMemberId,
+				wsManager,
+			).catch((e) => log.error('Failed to record issue links from comment:', e));
 			return r.rows[0];
 		},
 		db,

--- a/packages/server/src/routes/approvals.ts
+++ b/packages/server/src/routes/approvals.ts
@@ -4,6 +4,7 @@ import {
 	AgentAdminStatus,
 	ApprovalStatus,
 	ApprovalType,
+	AuthType,
 	DocumentType,
 	IssueStatus,
 	MemberType,
@@ -17,6 +18,8 @@ import { logger } from '../logger';
 import { requireCompanyAccess, requireCompanyAccessForResource } from '../middleware/auth';
 import { enqueueAgentSummaryTask, enqueueTeamSummaryTask } from '../services/description-tasks';
 import { upsertDocument } from '../services/documents';
+import { recordStatusChange } from '../services/issue-events';
+import type { WebSocketManager } from '../services/ws';
 
 const log = logger.child('approvals');
 
@@ -30,6 +33,8 @@ async function applyApprovalSideEffect(
 	db: PGlite,
 	approval: Record<string, unknown>,
 	_dataDir: string,
+	actorMemberId: string | null,
+	wsManager: WebSocketManager | undefined,
 ): Promise<SideEffectBroadcast[]> {
 	const payload = approval.payload as Record<string, unknown>;
 	const broadcasts: SideEffectBroadcast[] = [];
@@ -94,13 +99,30 @@ async function applyApprovalSideEffect(
 			});
 
 			if (payload.issue_id) {
+				const issueId = payload.issue_id as string;
+				const prior = await db.query<{ status: string }>(
+					'SELECT status FROM issues WHERE id = $1',
+					[issueId],
+				);
+				const oldStatus = prior.rows[0]?.status;
 				const issueUpdate = await db.query<Record<string, unknown>>(
 					`UPDATE issues SET status = $1::issue_status, updated_at = now()
 					 WHERE id = $2 RETURNING *`,
-					[IssueStatus.Done, payload.issue_id as string],
+					[IssueStatus.Done, issueId],
 				);
 				if (issueUpdate.rows[0]) {
 					broadcasts.push({ table: 'issues', op: 'UPDATE', row: issueUpdate.rows[0] });
+					if (oldStatus) {
+						await recordStatusChange(
+							db,
+							companyId,
+							issueId,
+							oldStatus,
+							IssueStatus.Done,
+							actorMemberId,
+							wsManager,
+						);
+					}
 				}
 			}
 
@@ -330,7 +352,26 @@ approvalsRoutes.post('/approvals/:approvalId/resolve', async (c) => {
 
 	if (body.status === ApprovalStatus.Approved) {
 		const dataDir = c.get('dataDir');
-		sideEffects = await applyApprovalSideEffect(db, row, dataDir);
+		const auth = c.get('auth');
+		let actorMemberId: string | null = null;
+		if (auth.type === AuthType.Agent) {
+			actorMemberId = auth.memberId;
+		} else if (auth.type === AuthType.Board) {
+			const r = await db.query<{ id: string }>(
+				`SELECT m.id FROM members m
+				   JOIN member_users mu ON mu.id = m.id
+				  WHERE mu.user_id = $1 AND m.company_id = $2`,
+				[auth.userId, existing.rows[0].company_id],
+			);
+			actorMemberId = r.rows[0]?.id ?? null;
+		}
+		sideEffects = await applyApprovalSideEffect(
+			db,
+			row,
+			dataDir,
+			actorMemberId,
+			c.get('wsManager'),
+		);
 	}
 
 	if (row.company_id) {

--- a/packages/server/src/routes/comments.ts
+++ b/packages/server/src/routes/comments.ts
@@ -8,6 +8,7 @@ import { logger } from '../logger';
 import { requireCompanyAccess } from '../middleware/auth';
 import { fireCommentWakeups } from '../services/comment-wakeups';
 import { parseEffortFromCommentBody } from '../services/effort';
+import { recordIssueLinks } from '../services/issue-events';
 import { createWakeup } from '../services/wakeup';
 
 const log = logger.child('routes');
@@ -123,6 +124,13 @@ commentsRoutes.post('/companies/:companyId/issues/:issueId/comments', async (c) 
 		effort: commentEffort,
 		wakeAssignee,
 	});
+
+	const commentText = typeof body.content?.text === 'string' ? body.content.text : '';
+	if (commentText) {
+		recordIssueLinks(db, companyId, issueId, commentText, authorMemberId, c.get('wsManager')).catch(
+			(e) => log.error('Failed to record issue links from comment:', e),
+		);
+	}
 
 	broadcastChange(
 		c,

--- a/packages/server/src/routes/issues.ts
+++ b/packages/server/src/routes/issues.ts
@@ -10,7 +10,7 @@ import {
 	WakeupSource,
 	wsRoom,
 } from '@hezo/shared';
-import { Hono } from 'hono';
+import { type Context, Hono } from 'hono';
 import { assertNoActiveRun } from '../lib/active-run';
 import { auditLog } from '../lib/audit';
 import { broadcastChange } from '../lib/broadcast';
@@ -28,6 +28,7 @@ import type { Env } from '../lib/types';
 import { logger } from '../logger';
 import { requireCompanyAccess } from '../middleware/auth';
 import { triggerStatusAutomations } from '../services/issue-automation';
+import { recordIssueLinks } from '../services/issue-events';
 import { removeIssueWorktrees } from '../services/repo-sync';
 import { createWakeup } from '../services/wakeup';
 
@@ -46,6 +47,21 @@ async function wakeAgentIfAssigned(
 			issue_id: issueId,
 		}).catch((e) => log.error('Failed to create wakeup for assignment:', e));
 	}
+}
+
+async function resolveActorMemberId(c: Context<Env>, companyId: string): Promise<string | null> {
+	const auth = c.get('auth');
+	if (auth.type === AuthType.Agent) return auth.memberId;
+	if (auth.type === AuthType.Board) {
+		const r = await c.get('db').query<{ id: string }>(
+			`SELECT m.id FROM members m
+			   JOIN member_users mu ON mu.id = m.id
+			  WHERE mu.user_id = $1 AND m.company_id = $2`,
+			[auth.userId, companyId],
+		);
+		return r.rows[0]?.id ?? null;
+	}
+	return null;
 }
 
 export const issuesRoutes = new Hono<Env>();
@@ -248,6 +264,19 @@ issuesRoutes.post('/companies/:companyId/issues', async (c) => {
 		},
 	).catch(() => {});
 	wakeAgentIfAssigned(db, body.assignee_id, companyId, issue.id as string);
+
+	if (body.description) {
+		const actorMemberId = await resolveActorMemberId(c, companyId);
+		recordIssueLinks(
+			db,
+			companyId,
+			issue.id as string,
+			body.description,
+			actorMemberId,
+			c.get('wsManager'),
+		).catch((e) => log.error('Failed to record issue links from description:', e));
+	}
+
 	return ok(c, issue, 201);
 });
 
@@ -506,10 +535,29 @@ issuesRoutes.patch('/companies/:companyId/issues/:issueId', async (c) => {
 
 	wakeAgentIfAssigned(db, body.assignee_id, companyId, issueId);
 
+	const actorMemberId = await resolveActorMemberId(c, companyId);
+
+	if (body.description !== undefined) {
+		recordIssueLinks(
+			db,
+			companyId,
+			issueId,
+			body.description,
+			actorMemberId,
+			c.get('wsManager'),
+		).catch((e) => log.error('Failed to record issue links from description:', e));
+	}
+
 	if (body.status) {
-		triggerStatusAutomations(db, companyId, issueId, body.status, c.get('wsManager')).catch((e) =>
-			log.error('Failed to trigger status automations:', e),
-		);
+		triggerStatusAutomations(
+			db,
+			companyId,
+			issueId,
+			existing.rows[0].status,
+			body.status,
+			actorMemberId,
+			c.get('wsManager'),
+		).catch((e) => log.error('Failed to trigger status automations:', e));
 
 		if ((TERMINAL_ISSUE_STATUSES as readonly string[]).includes(body.status)) {
 			const dataDir = c.get('dataDir');

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -28,6 +28,7 @@ import type { DockerClient, ExecLogChunk } from './docker';
 import { getAgentSystemPrompt } from './documents';
 import { applyEffortToRuntime, type EffortRuntimeApplication, resolveEffort } from './effort';
 import { ensureIssueWorktree, fetchRepo } from './git';
+import { recordStatusChange } from './issue-events';
 import type { LogStreamBroker } from './log-stream-broker';
 import { ensureProjectRepos } from './repo-sync';
 import { resolveRuntimeForIssue } from './runtime-resolver';
@@ -1124,6 +1125,17 @@ export async function createHeartbeatRun(
 				},
 			);
 		}
+	}
+	if (statusFlippedToInProgress) {
+		await recordStatusChange(
+			db,
+			broadcast.companyId,
+			issue.id,
+			IssueStatus.Backlog,
+			IssueStatus.InProgress,
+			agent.id,
+			broadcast.wsManager,
+		);
 	}
 	return runId;
 }

--- a/packages/server/src/services/issue-automation.ts
+++ b/packages/server/src/services/issue-automation.ts
@@ -10,6 +10,7 @@ import {
 } from '@hezo/shared';
 import { broadcastRowChange } from '../lib/broadcast';
 import { logger } from '../logger';
+import { recordStatusChange } from './issue-events';
 import { OAUTH_VERIFICATION_LABEL } from './oauth-verification-tasks';
 import { createWakeup } from './wakeup';
 import type { WebSocketManager } from './ws';
@@ -107,9 +108,13 @@ export async function triggerStatusAutomations(
 	db: PGlite,
 	companyId: string,
 	issueId: string,
+	oldStatus: string,
 	newStatus: string,
+	actorMemberId: string | null,
 	wsManager?: WebSocketManager,
 ): Promise<void> {
+	await recordStatusChange(db, companyId, issueId, oldStatus, newStatus, actorMemberId, wsManager);
+
 	if (newStatus === IssueStatus.Done) {
 		const coach = await db.query<{ id: string }>(
 			`SELECT ma.id FROM member_agents ma

--- a/packages/server/src/services/issue-events.ts
+++ b/packages/server/src/services/issue-events.ts
@@ -1,0 +1,131 @@
+import type { PGlite } from '@electric-sql/pglite';
+import { CommentContentType, wsRoom } from '@hezo/shared';
+import { broadcastRowChange } from '../lib/broadcast';
+import type { WebSocketManager } from './ws';
+
+const ISSUE_IDENTIFIER_RE = /(?<![\w-])([A-Z][A-Z0-9]{1,3}-\d+)(?![\w-])/g;
+const FENCED_RE = /(?:^|\n)(?:```|~~~)[^\n]*\n[\s\S]*?(?:```|~~~)(?=\n|$)/g;
+const INLINE_RE = /`[^`]*`/g;
+
+export function extractIssueIdentifiers(text: string | null | undefined): string[] {
+	if (!text) return [];
+	const stripped = text.replace(FENCED_RE, ' ').replace(INLINE_RE, ' ');
+	const out = new Set<string>();
+	ISSUE_IDENTIFIER_RE.lastIndex = 0;
+	let m = ISSUE_IDENTIFIER_RE.exec(stripped);
+	while (m !== null) {
+		out.add(m[1]);
+		m = ISSUE_IDENTIFIER_RE.exec(stripped);
+	}
+	return Array.from(out);
+}
+
+async function resolveActorName(db: PGlite, actorMemberId: string | null): Promise<string> {
+	if (!actorMemberId) return 'Board';
+	const r = await db.query<{ name: string | null }>(
+		`SELECT COALESCE(ma.title, NULLIF(m.display_name, ''), 'Board') AS name
+		   FROM members m LEFT JOIN member_agents ma ON ma.id = m.id
+		  WHERE m.id = $1`,
+		[actorMemberId],
+	);
+	return r.rows[0]?.name ?? 'Board';
+}
+
+export async function recordStatusChange(
+	db: PGlite,
+	companyId: string,
+	issueId: string,
+	oldStatus: string,
+	newStatus: string,
+	actorMemberId: string | null,
+	wsManager: WebSocketManager | undefined,
+): Promise<void> {
+	if (oldStatus === newStatus) return;
+	const actorName = await resolveActorName(db, actorMemberId);
+	const text = `${actorName} changed status from ${oldStatus} to ${newStatus}`;
+	const r = await db.query<Record<string, unknown>>(
+		`INSERT INTO issue_comments (issue_id, author_member_id, content_type, content)
+		 VALUES ($1, $2, $3::comment_content_type, $4::jsonb) RETURNING *`,
+		[
+			issueId,
+			actorMemberId,
+			CommentContentType.System,
+			JSON.stringify({
+				kind: 'status_change',
+				from: oldStatus,
+				to: newStatus,
+				actor_id: actorMemberId,
+				text,
+			}),
+		],
+	);
+	if (r.rows[0] && wsManager) {
+		broadcastRowChange(wsManager, wsRoom.company(companyId), 'issue_comments', 'INSERT', r.rows[0]);
+	}
+}
+
+export async function recordIssueLinks(
+	db: PGlite,
+	companyId: string,
+	sourceIssueId: string,
+	text: string | null | undefined,
+	actorMemberId: string | null,
+	wsManager: WebSocketManager | undefined,
+): Promise<void> {
+	const ids = extractIssueIdentifiers(text);
+	if (ids.length === 0) return;
+
+	const targets = await db.query<{ id: string; identifier: string }>(
+		`SELECT id, identifier FROM issues
+		  WHERE company_id = $1 AND identifier = ANY($2::text[]) AND id <> $3`,
+		[companyId, ids, sourceIssueId],
+	);
+	if (targets.rows.length === 0) return;
+
+	const source = await db.query<{ identifier: string }>(
+		`SELECT identifier FROM issues WHERE id = $1`,
+		[sourceIssueId],
+	);
+	const sourceIdentifier = source.rows[0]?.identifier ?? '';
+	const actorName = await resolveActorName(db, actorMemberId);
+
+	for (const target of targets.rows) {
+		const exists = await db.query(
+			`SELECT 1 FROM issue_comments
+			  WHERE issue_id = $1
+			    AND content_type = 'system'
+			    AND content->>'kind' = 'issue_link'
+			    AND content->>'source_issue_id' = $2
+			  LIMIT 1`,
+			[target.id, sourceIssueId],
+		);
+		if (exists.rows.length > 0) continue;
+
+		const linkText = `Linked from ${sourceIdentifier} by ${actorName}`;
+		const r = await db.query<Record<string, unknown>>(
+			`INSERT INTO issue_comments (issue_id, author_member_id, content_type, content)
+			 VALUES ($1, $2, $3::comment_content_type, $4::jsonb) RETURNING *`,
+			[
+				target.id,
+				actorMemberId,
+				CommentContentType.System,
+				JSON.stringify({
+					kind: 'issue_link',
+					source_issue_id: sourceIssueId,
+					source_identifier: sourceIdentifier,
+					actor_id: actorMemberId,
+					text: linkText,
+				}),
+			],
+		);
+		if (r.rows[0] && wsManager) {
+			broadcastRowChange(
+				wsManager,
+				wsRoom.company(companyId),
+				'issue_comments',
+				'INSERT',
+				r.rows[0],
+			);
+		}
+	}
+}

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -28,6 +28,7 @@ import {
 	syncAllContainerStatuses,
 } from './containers';
 import type { DockerClient } from './docker';
+import { recordStatusChange } from './issue-events';
 import type { LogStreamBroker } from './log-stream-broker';
 import { detectOrphans } from './orphan-detector';
 import { ensureRepoSetupAction } from './repo-setup';
@@ -841,6 +842,15 @@ export class JobManager {
 						'issues',
 						'UPDATE',
 						closed.rows[0],
+					);
+					await recordStatusChange(
+						db,
+						companyId,
+						issueId,
+						IssueStatus.Done,
+						IssueStatus.Closed,
+						memberId,
+						this.deps.wsManager,
 					);
 				}
 			}

--- a/packages/server/src/test/__tests__/issue-events.test.ts
+++ b/packages/server/src/test/__tests__/issue-events.test.ts
@@ -1,0 +1,344 @@
+import type { PGlite } from '@electric-sql/pglite';
+import { CommentContentType, IssueStatus } from '@hezo/shared';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { MasterKeyManager } from '../../crypto/master-key';
+import type { Env } from '../../lib/types';
+import { extractIssueIdentifiers } from '../../services/issue-events';
+import { safeClose } from '../helpers';
+import { authHeader, createTestApp, mintAgentToken } from '../helpers/app';
+
+let app: Hono<Env>;
+let db: PGlite;
+let token: string;
+let masterKeyManager: MasterKeyManager;
+let companyId: string;
+let projectId: string;
+let agentId: string;
+
+interface CommentRow {
+	id: string;
+	issue_id: string;
+	content_type: string;
+	content: {
+		text?: string;
+		kind?: string;
+		from?: string;
+		to?: string;
+		actor_id?: string | null;
+		source_issue_id?: string;
+		source_identifier?: string;
+	};
+	author_member_id: string | null;
+	created_at: string;
+}
+
+async function createIssue(
+	title: string,
+	description = '',
+): Promise<{ id: string; identifier: string }> {
+	const res = await app.request(`/api/companies/${companyId}/issues`, {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ project_id: projectId, title, description, assignee_id: agentId }),
+	});
+	const body = await res.json();
+	return { id: body.data.id, identifier: body.data.identifier };
+}
+
+async function listComments(issueId: string): Promise<CommentRow[]> {
+	const res = await app.request(`/api/companies/${companyId}/issues/${issueId}/comments`, {
+		headers: authHeader(token),
+	});
+	return (await res.json()).data;
+}
+
+async function systemComments(issueId: string, kind: string): Promise<CommentRow[]> {
+	const all = await listComments(issueId);
+	return all.filter(
+		(c) => c.content_type === CommentContentType.System && c.content?.kind === kind,
+	);
+}
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+	masterKeyManager = ctx.masterKeyManager;
+
+	const companyRes = await app.request('/api/companies', {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ name: 'Events Co' }),
+	});
+	companyId = (await companyRes.json()).data.id;
+
+	const projectRes = await app.request(`/api/companies/${companyId}/projects`, {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ name: 'Widget', description: 'Widget project.' }),
+	});
+	projectId = (await projectRes.json()).data.id;
+
+	const agentRes = await app.request(`/api/companies/${companyId}/agents`, {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ title: 'Status Bot' }),
+	});
+	agentId = (await agentRes.json()).data.id;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+describe('extractIssueIdentifiers', () => {
+	it('returns identifiers from plain prose', () => {
+		expect(extractIssueIdentifiers('see OP-42 for the rest')).toEqual(['OP-42']);
+	});
+
+	it('finds multiple unique identifiers', () => {
+		expect(extractIssueIdentifiers('see OP-1 and OP-2 — also OP-1 again').sort()).toEqual([
+			'OP-1',
+			'OP-2',
+		]);
+	});
+
+	it('skips identifiers in fenced code blocks', () => {
+		expect(extractIssueIdentifiers('text\n```\nOP-9\n```\nmore')).toEqual([]);
+	});
+
+	it('skips identifiers in inline code', () => {
+		expect(extractIssueIdentifiers('inline `OP-9` here')).toEqual([]);
+	});
+
+	it('skips lowercase identifiers', () => {
+		expect(extractIssueIdentifiers('check op-9 sometime')).toEqual([]);
+	});
+
+	it('returns [] for null/undefined/empty', () => {
+		expect(extractIssueIdentifiers(null)).toEqual([]);
+		expect(extractIssueIdentifiers(undefined)).toEqual([]);
+		expect(extractIssueIdentifiers('')).toEqual([]);
+	});
+});
+
+describe('status change system events', () => {
+	it('records a board-authored PATCH status change with from/to and "Board" actor', async () => {
+		const issue = await createIssue('PATCH by board');
+		const before = (await systemComments(issue.id, 'status_change')).length;
+
+		const res = await app.request(`/api/companies/${companyId}/issues/${issue.id}`, {
+			method: 'PATCH',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ status: IssueStatus.InProgress }),
+		});
+		expect(res.status).toBe(200);
+
+		const after = await systemComments(issue.id, 'status_change');
+		expect(after.length).toBe(before + 1);
+		const ev = after[after.length - 1];
+		expect(ev.content.from).toBe(IssueStatus.Backlog);
+		expect(ev.content.to).toBe(IssueStatus.InProgress);
+		expect(ev.content.text).toContain('Test Admin');
+		expect(ev.content.text).toContain(IssueStatus.Backlog);
+		expect(ev.content.text).toContain(IssueStatus.InProgress);
+		expect(ev.author_member_id).not.toBeNull();
+	});
+
+	it('records an agent-authored PATCH status change attributed to the agent', async () => {
+		const issue = await createIssue('PATCH by agent');
+		const { token: agentToken } = await mintAgentToken(db, masterKeyManager, agentId, companyId);
+
+		const res = await app.request(`/api/companies/${companyId}/issues/${issue.id}`, {
+			method: 'PATCH',
+			headers: { ...authHeader(agentToken), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ status: IssueStatus.InProgress }),
+		});
+		expect(res.status).toBe(200);
+
+		const events = await systemComments(issue.id, 'status_change');
+		const ev = events[events.length - 1];
+		expect(ev.content.text).toContain('Status Bot');
+		expect(ev.content.actor_id).toBe(agentId);
+		expect(ev.author_member_id).toBe(agentId);
+	});
+
+	it('does not record an event when the status is unchanged', async () => {
+		const issue = await createIssue('Unchanged status');
+		const before = (await systemComments(issue.id, 'status_change')).length;
+
+		const res = await app.request(`/api/companies/${companyId}/issues/${issue.id}`, {
+			method: 'PATCH',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ status: IssueStatus.Backlog }),
+		});
+		expect(res.status).toBe(200);
+
+		const after = await systemComments(issue.id, 'status_change');
+		expect(after.length).toBe(before);
+	});
+});
+
+describe('issue link system events', () => {
+	it('creates a link comment on the target the first time another issue mentions it', async () => {
+		const target = await createIssue('Target ticket');
+		const source = await createIssue('Source ticket');
+
+		const res = await app.request(`/api/companies/${companyId}/issues/${source.id}/comments`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				content_type: 'text',
+				content: { text: `see ${target.identifier} for context` },
+			}),
+		});
+		expect(res.status).toBe(201);
+
+		const links = await systemComments(target.id, 'issue_link');
+		expect(links).toHaveLength(1);
+		expect(links[0].content.source_issue_id).toBe(source.id);
+		expect(links[0].content.source_identifier).toBe(source.identifier);
+		expect(links[0].content.text).toContain(`Linked from ${source.identifier}`);
+	});
+
+	it('does not create a second link comment for repeat mentions from the same source', async () => {
+		const target = await createIssue('Target repeat');
+		const source = await createIssue('Source repeat');
+
+		for (const text of [`first mention ${target.identifier}`, `another ${target.identifier}`]) {
+			await app.request(`/api/companies/${companyId}/issues/${source.id}/comments`, {
+				method: 'POST',
+				headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+				body: JSON.stringify({ content_type: 'text', content: { text } }),
+			});
+		}
+
+		const links = await systemComments(target.id, 'issue_link');
+		expect(links).toHaveLength(1);
+	});
+
+	it('records a link from issue creation when the description mentions another issue', async () => {
+		const target = await createIssue('Target via desc');
+		const source = await createIssue(
+			'Source via desc',
+			`pre-existing link to ${target.identifier}`,
+		);
+
+		const links = await systemComments(target.id, 'issue_link');
+		const fromSource = links.find((l) => l.content.source_issue_id === source.id);
+		expect(fromSource).toBeTruthy();
+	});
+
+	it('ignores self-references', async () => {
+		const issue = await createIssue('Self ref');
+		await app.request(`/api/companies/${companyId}/issues/${issue.id}/comments`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				content_type: 'text',
+				content: { text: `this is ${issue.identifier} talking about itself` },
+			}),
+		});
+		const links = await systemComments(issue.id, 'issue_link');
+		expect(links).toHaveLength(0);
+	});
+
+	it('ignores identifiers inside fenced code blocks', async () => {
+		const target = await createIssue('Target codeblock');
+		const source = await createIssue('Source codeblock');
+		await app.request(`/api/companies/${companyId}/issues/${source.id}/comments`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				content_type: 'text',
+				content: { text: `inert\n\`\`\`\n${target.identifier}\n\`\`\`\n` },
+			}),
+		});
+		const links = await systemComments(target.id, 'issue_link');
+		expect(links).toHaveLength(0);
+	});
+
+	it('ignores unknown identifiers', async () => {
+		const source = await createIssue('Source unknown');
+		const before = await db.query<{ count: string }>(
+			"SELECT count(*)::text AS count FROM issue_comments WHERE content_type = 'system' AND content->>'kind' = 'issue_link'",
+		);
+		await app.request(`/api/companies/${companyId}/issues/${source.id}/comments`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ content_type: 'text', content: { text: 'see XX-99 for nothing' } }),
+		});
+		const after = await db.query<{ count: string }>(
+			"SELECT count(*)::text AS count FROM issue_comments WHERE content_type = 'system' AND content->>'kind' = 'issue_link'",
+		);
+		expect(after.rows[0].count).toBe(before.rows[0].count);
+	});
+
+	it('does not cross company boundaries', async () => {
+		const targetA = await createIssue('Cross-company target');
+
+		const otherCompanyRes = await app.request('/api/companies', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name: 'Other Co' }),
+		});
+		const otherCompanyId = (await otherCompanyRes.json()).data.id;
+		const otherProjectRes = await app.request(`/api/companies/${otherCompanyId}/projects`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name: 'Foreign', description: 'Other.' }),
+		});
+		const otherProjectId = (await otherProjectRes.json()).data.id;
+		const otherAgentRes = await app.request(`/api/companies/${otherCompanyId}/agents`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ title: 'Other Bot' }),
+		});
+		const otherAgentId = (await otherAgentRes.json()).data.id;
+
+		const otherIssueRes = await app.request(`/api/companies/${otherCompanyId}/issues`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				project_id: otherProjectId,
+				title: 'Foreign source',
+				assignee_id: otherAgentId,
+			}),
+		});
+		const otherIssue = (await otherIssueRes.json()).data;
+
+		await app.request(`/api/companies/${otherCompanyId}/issues/${otherIssue.id}/comments`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				content_type: 'text',
+				content: { text: `mentions ${targetA.identifier} from another company` },
+			}),
+		});
+
+		const links = await systemComments(targetA.id, 'issue_link');
+		expect(links).toHaveLength(0);
+	});
+
+	it('records links for multiple targets in a single comment', async () => {
+		const target1 = await createIssue('Multi target 1');
+		const target2 = await createIssue('Multi target 2');
+		const source = await createIssue('Multi source');
+
+		await app.request(`/api/companies/${companyId}/issues/${source.id}/comments`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				content_type: 'text',
+				content: { text: `${target1.identifier} and ${target2.identifier}` },
+			}),
+		});
+
+		const links1 = await systemComments(target1.id, 'issue_link');
+		const links2 = await systemComments(target2.id, 'issue_link');
+		expect(links1.some((l) => l.content.source_issue_id === source.id)).toBe(true);
+		expect(links2.some((l) => l.content.source_issue_id === source.id)).toBe(true);
+	});
+});

--- a/packages/server/src/test/__tests__/oauth-verification-automation.test.ts
+++ b/packages/server/src/test/__tests__/oauth-verification-automation.test.ts
@@ -84,7 +84,15 @@ describe('triggerStatusAutomations: OAuth verification done', () => {
 			IssueStatus.Done,
 			verif!.issueId,
 		]);
-		await triggerStatusAutomations(db, companyId, verif!.issueId, IssueStatus.Done);
+		await triggerStatusAutomations(
+			db,
+			companyId,
+			verif!.issueId,
+			IssueStatus.Backlog,
+			IssueStatus.Done,
+			null,
+			undefined,
+		);
 
 		const comments = await db.query<{
 			content: { text?: string };
@@ -112,7 +120,15 @@ describe('triggerStatusAutomations: OAuth verification done', () => {
 			IssueStatus.Done,
 			verif!.issueId,
 		]);
-		await triggerStatusAutomations(db, companyId, verif!.issueId, IssueStatus.Done);
+		await triggerStatusAutomations(
+			db,
+			companyId,
+			verif!.issueId,
+			IssueStatus.Backlog,
+			IssueStatus.Done,
+			null,
+			undefined,
+		);
 
 		const commentsAfter = await db.query<{ count: string }>(
 			`SELECT count(*)::text AS count FROM issue_comments
@@ -133,12 +149,30 @@ describe('triggerStatusAutomations: OAuth verification done', () => {
 			IssueStatus.Done,
 			parentId,
 		]);
-		await triggerStatusAutomations(db, companyId, parentId, IssueStatus.Done);
+		await triggerStatusAutomations(
+			db,
+			companyId,
+			parentId,
+			IssueStatus.Backlog,
+			IssueStatus.Done,
+			null,
+			undefined,
+		);
 
 		const after = await db.query<{ count: string }>(
 			'SELECT count(*)::text AS count FROM issue_comments WHERE issue_id = $1',
 			[parentId],
 		);
-		expect(after.rows[0].count).toBe(before.rows[0].count);
+		expect(Number.parseInt(after.rows[0].count, 10)).toBe(
+			Number.parseInt(before.rows[0].count, 10) + 1,
+		);
+		const sysComment = await db.query<{ content: { kind?: string; from?: string; to?: string } }>(
+			`SELECT content FROM issue_comments
+			 WHERE issue_id = $1 AND content_type = 'system'
+			 ORDER BY created_at DESC LIMIT 1`,
+			[parentId],
+		);
+		expect(sysComment.rows[0]?.content.kind).toBe('status_change');
+		expect(sysComment.rows[0]?.content.to).toBe(IssueStatus.Done);
 	});
 });

--- a/tests/e2e/issue-history-timeline.spec.ts
+++ b/tests/e2e/issue-history-timeline.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test } from '@playwright/test';
+import { authenticate, createCompanyWithAgents, waitForPageLoad } from './helpers';
+
+test('status changes and cross-issue mentions appear as system entries on the timeline', async ({
+	page,
+}) => {
+	await authenticate(page);
+	const { company, token } = await createCompanyWithAgents(page);
+	const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+
+	const agentsRes = await page.request.get(`/api/companies/${company.id}/agents`, {
+		headers: { Authorization: `Bearer ${token}` },
+	});
+	const agent = ((await agentsRes.json()) as { data: Array<{ id: string }> }).data[0];
+
+	const projectRes = await page.request.post(`/api/companies/${company.id}/projects`, {
+		headers,
+		data: { name: 'History Project', description: 'Project for history events.' },
+	});
+	const project = ((await projectRes.json()) as { data: { id: string; slug: string } }).data;
+
+	const targetRes = await page.request.post(`/api/companies/${company.id}/issues`, {
+		headers,
+		data: { project_id: project.id, title: 'Target ticket', assignee_id: agent.id },
+	});
+	const target = ((await targetRes.json()) as { data: { id: string; identifier: string } }).data;
+
+	const sourceRes = await page.request.post(`/api/companies/${company.id}/issues`, {
+		headers,
+		data: { project_id: project.id, title: 'Source ticket', assignee_id: agent.id },
+	});
+	const source = ((await sourceRes.json()) as { data: { id: string; identifier: string } }).data;
+
+	const targetUrl = `/companies/${company.slug}/projects/${project.slug}/issues/${target.identifier.toLowerCase()}`;
+	await page.goto(targetUrl);
+	await waitForPageLoad(page);
+
+	const closeButton = page.getByTestId('issue-close-button');
+	await expect(closeButton).toBeVisible({ timeout: 20000 });
+	await closeButton.click();
+	await page.getByTestId('confirm-dialog-confirm').click();
+
+	await expect(page.getByTestId('issue-reopen-button')).toBeVisible({ timeout: 20000 });
+
+	await expect(
+		page.locator('[data-testid="comment-item"]').filter({ hasText: /changed status/i }),
+	).toBeVisible({ timeout: 15000 });
+
+	await page.request.post(`/api/companies/${company.id}/issues/${source.id}/comments`, {
+		headers,
+		data: { content_type: 'text', content: { text: `context: ${target.identifier}` } },
+	});
+
+	await page.goto(targetUrl);
+	await waitForPageLoad(page);
+
+	const linkEntry = page
+		.locator('[data-testid="comment-item"]')
+		.filter({ hasText: new RegExp(`Linked from ${source.identifier}`) });
+	await expect(linkEntry).toBeVisible({ timeout: 15000 });
+
+	await page.request.post(`/api/companies/${company.id}/issues/${source.id}/comments`, {
+		headers,
+		data: { content_type: 'text', content: { text: `still on ${target.identifier}` } },
+	});
+
+	await page.goto(targetUrl);
+	await waitForPageLoad(page);
+
+	const allLinkEntries = page
+		.locator('[data-testid="comment-item"]')
+		.filter({ hasText: new RegExp(`Linked from ${source.identifier}`) });
+	await expect(allLinkEntries).toHaveCount(1);
+});


### PR DESCRIPTION
Adds two system entries to the issue comment timeline so history is visible where users actually read it:

- status_change — fires on every transition, attributed to the actor (agent title, board user display name, or "Board" fallback). Wired through the REST PATCH, MCP update_issue, hire-approval auto-Done, agent-runner backlog→in_progress auto-flip, and Coach auto-close.
- issue_link — fires on the target issue the first time a given source mentions it, scanning descriptions and comments across REST and MCP. Repeat mentions from the same source are deduped via the source_issue_id JSONB key. Code blocks, self-mentions, and cross-company identifiers are ignored.

No schema or UI changes — both use the existing 'system' content_type and SystemComment renderer.