### PR TITLE
Add agent secret proxy with host allowlist and audit logging

### DIFF
--- a/packages/server/migrations/001_initial_schema.sql
+++ b/packages/server/migrations/001_initial_schema.sql
@@ -333,6 +333,12 @@ CREATE TABLE secrets (
     name            TEXT NOT NULL,
     encrypted_value TEXT NOT NULL,
     category        secret_category NOT NULL DEFAULT 'other',
+    -- Host allowlist for the agent secret proxy. Each entry is a lowercase
+    -- hostname pattern: exact match, or '*.<suffix>' to match one or more
+    -- leftmost labels. Empty list means the secret can never be used by the
+    -- proxy (the placeholder still expands inside the agent, but every
+    -- outbound request will be rejected as host_not_allowed).
+    host_allowlist  JSONB NOT NULL DEFAULT '[]'::jsonb,
     created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
 
@@ -813,6 +819,32 @@ ALTER TABLE issues
     FOREIGN KEY (created_by_run_id) REFERENCES heartbeat_runs(id) ON DELETE SET NULL;
 
 CREATE INDEX idx_issues_created_by_run ON issues(created_by_run_id) WHERE created_by_run_id IS NOT NULL;
+
+-------------------------------------------------------------------------------
+-- SECRET PROXY AUDIT
+-------------------------------------------------------------------------------
+
+-- Records every agent proxy request — both forwarded and rejected. Never
+-- contains header values, request bodies, or plaintext; only the metadata
+-- needed to reconstruct usage patterns and trace abuse.
+CREATE TABLE secret_proxy_audit (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    company_id      UUID NOT NULL REFERENCES companies(id) ON DELETE CASCADE,
+    run_id          UUID NOT NULL REFERENCES heartbeat_runs(id) ON DELETE CASCADE,
+    member_id       UUID NOT NULL REFERENCES members(id) ON DELETE CASCADE,
+    secret_ids      UUID[] NOT NULL,
+    target_host     TEXT NOT NULL,
+    target_method   TEXT NOT NULL,
+    status_code     INTEGER,
+    rejection_code  TEXT,
+    request_bytes   INTEGER NOT NULL DEFAULT 0,
+    response_bytes  INTEGER NOT NULL DEFAULT 0,
+    duration_ms     INTEGER,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_proxy_audit_run ON secret_proxy_audit(run_id);
+CREATE INDEX idx_proxy_audit_company_created ON secret_proxy_audit(company_id, created_at DESC);
 
 -------------------------------------------------------------------------------
 -- AGENT TASK SESSIONS

--- a/packages/server/src/mcp/server.ts
+++ b/packages/server/src/mcp/server.ts
@@ -26,10 +26,19 @@ export function getToolDefs(): ToolDef[] {
 }
 
 async function authenticateRequest(c: Context<Env>): Promise<AuthInfo | null> {
-	const header = c.req.header('Authorization');
-	if (!header?.startsWith('Bearer ')) return null;
-
-	const token = header.slice(7);
+	// Agent JWT travels on a Hezo-specific header for consistency with the
+	// agent-proxy route. Falls back to `Authorization: Bearer ...` for board
+	// JWTs and API keys called from outside an agent run (and for runtimes
+	// whose MCP transport config does not support custom headers).
+	const agentHeader = c.req.header('X-Hezo-Agent-Token');
+	let token: string | null = null;
+	if (agentHeader && agentHeader.length > 0) {
+		token = agentHeader;
+	} else {
+		const header = c.req.header('Authorization');
+		if (header?.startsWith('Bearer ')) token = header.slice(7);
+	}
+	if (!token) return null;
 	const db = c.get('db');
 	const masterKeyManager = c.get('masterKeyManager');
 	return verifyToken(token, db, masterKeyManager);

--- a/packages/server/src/middleware/auth.ts
+++ b/packages/server/src/middleware/auth.ts
@@ -85,15 +85,29 @@ export const authMiddleware = createMiddleware<Env>(async (c, next) => {
 	if (PUBLIC_PATHS.includes(path)) return next();
 	if (!path.startsWith('/api') && !path.startsWith('/agent-api')) return next();
 
-	const header = c.req.header('Authorization');
-	if (!header?.startsWith('Bearer ')) {
+	// Agent JWT travels on a Hezo-specific header so the upstream-bound
+	// `Authorization` header on proxy requests is free for placeholder
+	// substitution. Falls back to `Authorization: Bearer ...` for board JWTs
+	// and API keys, which never collide with upstream-bound credentials.
+	const agentHeader = c.req.header('X-Hezo-Agent-Token');
+	const authHeader = c.req.header('Authorization');
+
+	let token: string | null = null;
+	let agentOnly = false;
+	if (agentHeader && agentHeader.length > 0) {
+		token = agentHeader;
+		agentOnly = true;
+	} else if (authHeader?.startsWith('Bearer ')) {
+		token = authHeader.slice(7);
+	}
+
+	if (!token) {
 		return c.json(
 			{ error: { code: 'UNAUTHORIZED', message: 'Missing authorization header' } },
 			401,
 		);
 	}
 
-	const token = header.slice(7);
 	const masterKeyManager = c.get('masterKeyManager');
 
 	if (masterKeyManager.getState() !== 'unlocked') {
@@ -107,6 +121,9 @@ export const authMiddleware = createMiddleware<Env>(async (c, next) => {
 	const auth = await verifyToken(token, db, masterKeyManager);
 	if (!auth) {
 		return c.json({ error: { code: 'UNAUTHORIZED', message: 'Invalid or expired token' } }, 401);
+	}
+	if (agentOnly && auth.type !== AuthType.Agent) {
+		return c.json({ error: { code: 'UNAUTHORIZED', message: 'Invalid agent token' } }, 401);
 	}
 
 	c.set('auth', auth);

--- a/packages/server/src/routes/agent-proxy.ts
+++ b/packages/server/src/routes/agent-proxy.ts
@@ -1,0 +1,352 @@
+import { AuthType, ProxyRejectionCode } from '@hezo/shared';
+import type { Context } from 'hono';
+import { Hono } from 'hono';
+import type { Env } from '../lib/types';
+import {
+	type GrantedSecret,
+	hostMatches,
+	isBinaryContentType,
+	loadGrantedSecrets,
+	MAX_SUBSTITUTION_BYTES,
+	substitute,
+} from '../services/secret-proxy';
+
+export const agentProxyRoutes = new Hono<Env>();
+
+const HOP_BY_HOP_HEADERS = new Set([
+	'connection',
+	'keep-alive',
+	'proxy-authenticate',
+	'proxy-authorization',
+	'te',
+	'trailer',
+	'transfer-encoding',
+	'upgrade',
+	'host',
+	'content-length',
+]);
+
+function isStrippedRequestHeader(name: string): boolean {
+	const lower = name.toLowerCase();
+	if (HOP_BY_HOP_HEADERS.has(lower)) return true;
+	if (lower.startsWith('hezo-') || lower.startsWith('x-hezo-')) return true;
+	if (lower.startsWith('x-forwarded-')) return true;
+	return false;
+}
+
+function isStrippedResponseHeader(name: string): boolean {
+	const lower = name.toLowerCase();
+	if (HOP_BY_HOP_HEADERS.has(lower)) return true;
+	return false;
+}
+
+interface AuditFields {
+	companyId: string;
+	runId: string;
+	memberId: string;
+	secretIds: string[];
+	targetHost: string;
+	targetMethod: string;
+	statusCode: number | null;
+	rejectionCode: ProxyRejectionCode | null;
+	requestBytes: number;
+	responseBytes: number;
+	durationMs: number;
+}
+
+async function writeAudit(c: Context<Env>, fields: AuditFields): Promise<void> {
+	const db = c.get('db');
+	try {
+		await db.query(
+			`INSERT INTO secret_proxy_audit
+			   (company_id, run_id, member_id, secret_ids, target_host, target_method,
+			    status_code, rejection_code, request_bytes, response_bytes, duration_ms)
+			 VALUES ($1, $2, $3, $4::uuid[], $5, $6, $7, $8, $9, $10, $11)`,
+			[
+				fields.companyId,
+				fields.runId,
+				fields.memberId,
+				fields.secretIds,
+				fields.targetHost,
+				fields.targetMethod,
+				fields.statusCode,
+				fields.rejectionCode,
+				fields.requestBytes,
+				fields.responseBytes,
+				fields.durationMs,
+			],
+		);
+	} catch {
+		// Audit write must never break the proxy response — log loss is acceptable.
+	}
+}
+
+agentProxyRoutes.all('/proxy/*', async (c) => {
+	const auth = c.get('auth');
+	if (auth.type !== AuthType.Agent) {
+		return c.json({ error: { code: 'UNAUTHORIZED', message: 'Agent token required' } }, 401);
+	}
+
+	const startedAt = Date.now();
+
+	const fullUrl = new URL(c.req.url);
+	const PREFIX = '/agent-api/proxy/';
+	const prefixIdx = fullUrl.pathname.indexOf(PREFIX);
+	if (prefixIdx === -1) {
+		return c.json(
+			{ error: { code: ProxyRejectionCode.InvalidTarget, message: 'Invalid proxy path' } },
+			400,
+		);
+	}
+	const rawTarget = fullUrl.pathname.slice(prefixIdx + PREFIX.length) + fullUrl.search;
+
+	if (rawTarget.length === 0) {
+		return c.json(
+			{ error: { code: ProxyRejectionCode.InvalidTarget, message: 'Missing target URL' } },
+			400,
+		);
+	}
+
+	let parsed: URL;
+	try {
+		parsed = new URL(rawTarget);
+	} catch {
+		return c.json(
+			{ error: { code: ProxyRejectionCode.InvalidTarget, message: 'Invalid target URL' } },
+			400,
+		);
+	}
+	if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+		return c.json(
+			{ error: { code: ProxyRejectionCode.InvalidTarget, message: 'Unsupported scheme' } },
+			400,
+		);
+	}
+
+	const auditBase = {
+		companyId: auth.companyId,
+		runId: auth.runId,
+		memberId: auth.memberId,
+		targetHost: parsed.hostname.toLowerCase(),
+		targetMethod: c.req.method,
+	};
+
+	const db = c.get('db');
+	const masterKeyManager = c.get('masterKeyManager');
+	const granted = await loadGrantedSecrets(db, masterKeyManager, auth.memberId);
+
+	const referencedById = new Map<string, GrantedSecret>();
+	const ungrantedNames = new Set<string>();
+	const collect = (res: ReturnType<typeof substitute>) => {
+		for (const r of res.referenced) referencedById.set(r.id, r);
+		for (const u of res.ungrantedNames) ungrantedNames.add(u);
+	};
+
+	const urlSub = substitute(rawTarget, granted);
+	collect(urlSub);
+	let substitutedTarget: URL;
+	try {
+		substitutedTarget = new URL(urlSub.output);
+	} catch {
+		await writeAudit(c, {
+			...auditBase,
+			secretIds: [],
+			statusCode: null,
+			rejectionCode: ProxyRejectionCode.InvalidTarget,
+			requestBytes: 0,
+			responseBytes: 0,
+			durationMs: Date.now() - startedAt,
+		});
+		return c.json(
+			{ error: { code: ProxyRejectionCode.InvalidTarget, message: 'Invalid target URL' } },
+			400,
+		);
+	}
+
+	const outboundHeaders = new Headers();
+	for (const [name, value] of c.req.raw.headers.entries()) {
+		if (isStrippedRequestHeader(name)) continue;
+		const sub = substitute(value, granted);
+		collect(sub);
+		outboundHeaders.set(name, sub.output);
+	}
+	outboundHeaders.set('host', substitutedTarget.host);
+	outboundHeaders.set('via', '1.1 hezo-proxy');
+
+	const contentLengthHeader = c.req.header('content-length');
+	const contentType = c.req.header('content-type');
+	const hasBody = c.req.method !== 'GET' && c.req.method !== 'HEAD';
+	let outboundBody: BodyInit | undefined;
+	let requestBytes = 0;
+
+	if (hasBody) {
+		if (contentLengthHeader) {
+			const parsedLen = Number.parseInt(contentLengthHeader, 10);
+			if (Number.isFinite(parsedLen) && parsedLen > MAX_SUBSTITUTION_BYTES) {
+				await writeAudit(c, {
+					...auditBase,
+					secretIds: [],
+					statusCode: null,
+					rejectionCode: ProxyRejectionCode.BodyTooLarge,
+					requestBytes: parsedLen,
+					responseBytes: 0,
+					durationMs: Date.now() - startedAt,
+				});
+				return c.json(
+					{ error: { code: ProxyRejectionCode.BodyTooLarge, message: 'Request body too large' } },
+					413,
+				);
+			}
+		}
+
+		const rawBody = new Uint8Array(await c.req.arrayBuffer());
+		requestBytes = rawBody.byteLength;
+		if (requestBytes > MAX_SUBSTITUTION_BYTES) {
+			await writeAudit(c, {
+				...auditBase,
+				secretIds: [],
+				statusCode: null,
+				rejectionCode: ProxyRejectionCode.BodyTooLarge,
+				requestBytes,
+				responseBytes: 0,
+				durationMs: Date.now() - startedAt,
+			});
+			return c.json(
+				{ error: { code: ProxyRejectionCode.BodyTooLarge, message: 'Request body too large' } },
+				413,
+			);
+		}
+
+		if (isBinaryContentType(contentType)) {
+			outboundBody = rawBody;
+		} else if (rawBody.byteLength === 0) {
+			outboundBody = undefined;
+		} else {
+			const text = new TextDecoder('utf-8').decode(rawBody);
+			const sub = substitute(text, granted);
+			collect(sub);
+			const encoded = new TextEncoder().encode(sub.output);
+			outboundBody = encoded;
+			requestBytes = encoded.byteLength;
+			outboundHeaders.set('content-length', String(encoded.byteLength));
+		}
+	}
+
+	if (ungrantedNames.size > 0) {
+		await writeAudit(c, {
+			...auditBase,
+			secretIds: Array.from(referencedById.keys()),
+			statusCode: null,
+			rejectionCode: ProxyRejectionCode.UngrantedSecret,
+			requestBytes,
+			responseBytes: 0,
+			durationMs: Date.now() - startedAt,
+		});
+		return c.json(
+			{
+				error: {
+					code: ProxyRejectionCode.UngrantedSecret,
+					message: 'Request references a secret that is not granted to this agent',
+				},
+			},
+			400,
+		);
+	}
+
+	const referenced = Array.from(referencedById.values());
+	const targetHost = substitutedTarget.hostname.toLowerCase();
+	for (const secret of referenced) {
+		if (!hostMatches(targetHost, secret.hostAllowlist)) {
+			await writeAudit(c, {
+				...auditBase,
+				targetHost,
+				secretIds: referenced.map((s) => s.id),
+				statusCode: null,
+				rejectionCode: ProxyRejectionCode.HostNotAllowed,
+				requestBytes,
+				responseBytes: 0,
+				durationMs: Date.now() - startedAt,
+			});
+			return c.json(
+				{
+					error: {
+						code: ProxyRejectionCode.HostNotAllowed,
+						message: 'Target host is not on the allowlist for the referenced secret',
+					},
+				},
+				403,
+			);
+		}
+	}
+
+	let upstream: Response;
+	try {
+		upstream = await fetch(substitutedTarget, {
+			method: c.req.method,
+			headers: outboundHeaders,
+			body: outboundBody,
+			redirect: 'manual',
+		});
+	} catch (err) {
+		const message = err instanceof Error ? err.message : 'Upstream fetch failed';
+		await writeAudit(c, {
+			...auditBase,
+			targetHost,
+			secretIds: referenced.map((s) => s.id),
+			statusCode: null,
+			rejectionCode: null,
+			requestBytes,
+			responseBytes: 0,
+			durationMs: Date.now() - startedAt,
+		});
+		return c.json({ error: { code: 'UPSTREAM_ERROR', message } }, 502);
+	}
+
+	const responseHeaders = new Headers();
+	for (const [name, value] of upstream.headers.entries()) {
+		if (isStrippedResponseHeader(name)) continue;
+		responseHeaders.set(name, value);
+	}
+	responseHeaders.set('via', '1.1 hezo-proxy');
+
+	let responseBytes = 0;
+	let outBody: ReadableStream<Uint8Array> | null = null;
+	if (upstream.body) {
+		const counted = new TransformStream<Uint8Array, Uint8Array>({
+			transform(chunk, controller) {
+				responseBytes += chunk.byteLength;
+				controller.enqueue(chunk);
+			},
+			flush: async () => {
+				await writeAudit(c, {
+					...auditBase,
+					targetHost,
+					secretIds: referenced.map((s) => s.id),
+					statusCode: upstream.status,
+					rejectionCode: null,
+					requestBytes,
+					responseBytes,
+					durationMs: Date.now() - startedAt,
+				});
+			},
+		});
+		outBody = upstream.body.pipeThrough(counted);
+	} else {
+		await writeAudit(c, {
+			...auditBase,
+			targetHost,
+			secretIds: referenced.map((s) => s.id),
+			statusCode: upstream.status,
+			rejectionCode: null,
+			requestBytes,
+			responseBytes: 0,
+			durationMs: Date.now() - startedAt,
+		});
+	}
+
+	return new Response(outBody, {
+		status: upstream.status,
+		statusText: upstream.statusText,
+		headers: responseHeaders,
+	});
+});

--- a/packages/server/src/routes/secrets.ts
+++ b/packages/server/src/routes/secrets.ts
@@ -4,6 +4,7 @@ import { broadcastChange } from '../lib/broadcast';
 import { err, ok } from '../lib/response';
 import type { Env } from '../lib/types';
 import { requireCompanyAccess } from '../middleware/auth';
+import { isValidHostPattern } from '../services/secret-proxy';
 
 export const secretsRoutes = new Hono<Env>();
 
@@ -16,7 +17,7 @@ secretsRoutes.get('/companies/:companyId/secrets', async (c) => {
 	const projectId = c.req.query('project_id');
 
 	let query = `
-    SELECT s.id, s.company_id, s.project_id, s.name, s.category, s.created_at, s.updated_at,
+    SELECT s.id, s.company_id, s.project_id, s.name, s.category, s.host_allowlist, s.created_at, s.updated_at,
            p.name AS project_name,
            (SELECT count(*) FROM secret_grants sg WHERE sg.secret_id = s.id AND sg.revoked_at IS NULL)::int AS grant_count
     FROM secrets s
@@ -47,10 +48,22 @@ secretsRoutes.post('/companies/:companyId/secrets', async (c) => {
 		value: string;
 		project_id?: string;
 		category?: string;
+		host_allowlist?: string[];
 	}>();
 
 	if (!body.name?.trim() || !body.value) {
 		return err(c, 'INVALID_REQUEST', 'name and value are required', 400);
+	}
+
+	if (body.host_allowlist !== undefined) {
+		if (!Array.isArray(body.host_allowlist)) {
+			return err(c, 'INVALID_REQUEST', 'host_allowlist must be an array of strings', 400);
+		}
+		for (const entry of body.host_allowlist) {
+			if (!isValidHostPattern(entry)) {
+				return err(c, 'INVALID_REQUEST', 'host_allowlist contains an invalid pattern', 400);
+			}
+		}
 	}
 
 	const key = masterKeyManager.getKey();
@@ -62,15 +75,16 @@ secretsRoutes.post('/companies/:companyId/secrets', async (c) => {
 	const encryptedValue = encrypt(body.value, key);
 
 	const result = await db.query(
-		`INSERT INTO secrets (company_id, project_id, name, encrypted_value, category)
-     VALUES ($1, $2, $3, $4, $5::secret_category)
-     RETURNING id, company_id, project_id, name, category, created_at, updated_at`,
+		`INSERT INTO secrets (company_id, project_id, name, encrypted_value, category, host_allowlist)
+     VALUES ($1, $2, $3, $4, $5::secret_category, $6::jsonb)
+     RETURNING id, company_id, project_id, name, category, host_allowlist, created_at, updated_at`,
 		[
 			companyId,
 			body.project_id ?? null,
 			body.name.trim(),
 			encryptedValue,
 			body.category ?? SecretCategory.Other,
+			JSON.stringify(body.host_allowlist ?? []),
 		],
 	);
 
@@ -104,6 +118,7 @@ secretsRoutes.patch('/companies/:companyId/secrets/:secretId', async (c) => {
 	const body = await c.req.json<{
 		value?: string;
 		category?: string;
+		host_allowlist?: string[];
 	}>();
 
 	const sets: string[] = [];
@@ -127,6 +142,20 @@ secretsRoutes.patch('/companies/:companyId/secrets/:secretId', async (c) => {
 		idx++;
 	}
 
+	if (body.host_allowlist !== undefined) {
+		if (!Array.isArray(body.host_allowlist)) {
+			return err(c, 'INVALID_REQUEST', 'host_allowlist must be an array of strings', 400);
+		}
+		for (const entry of body.host_allowlist) {
+			if (!isValidHostPattern(entry)) {
+				return err(c, 'INVALID_REQUEST', 'host_allowlist contains an invalid pattern', 400);
+			}
+		}
+		sets.push(`host_allowlist = $${idx}::jsonb`);
+		params.push(JSON.stringify(body.host_allowlist));
+		idx++;
+	}
+
 	if (sets.length === 0) {
 		return ok(c, existing.rows[0]);
 	}
@@ -134,7 +163,7 @@ secretsRoutes.patch('/companies/:companyId/secrets/:secretId', async (c) => {
 	params.push(secretId);
 	const result = await db.query(
 		`UPDATE secrets SET ${sets.join(', ')} WHERE id = $${idx}
-     RETURNING id, company_id, project_id, name, category, created_at, updated_at`,
+     RETURNING id, company_id, project_id, name, category, host_allowlist, created_at, updated_at`,
 		params,
 	);
 

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -127,6 +127,21 @@ export function buildProviderEnv(provider: AiProvider, credential: AiProviderCre
 	return [`${envVarName}=${credential.value}`];
 }
 
+/**
+ * Build env entries that expose stable placeholder strings for every secret
+ * granted to the agent. The container only ever sees the placeholder; the
+ * server's secret proxy substitutes the plaintext at egress time.
+ */
+export async function buildSecretPlaceholderEnv(db: PGlite, memberId: string): Promise<string[]> {
+	const result = await db.query<{ name: string }>(
+		`SELECT s.name FROM secret_grants sg
+		   JOIN secrets s ON s.id = sg.secret_id
+		  WHERE sg.member_id = $1 AND sg.revoked_at IS NULL`,
+		[memberId],
+	);
+	return result.rows.map(({ name }) => `HEZO_SECRET_${name}=__HEZO_SECRET_${name}__`);
+}
+
 // SUBSCRIPTION_LAYOUTS, SubscriptionMount, and the home-dir helpers live in
 // runtime-home.ts so per-runtime config conventions sit in one place. These
 // re-exports keep the public import surface stable for callers and tests.
@@ -308,8 +323,11 @@ async function buildRunContext(
 		writeFileSync(file.hostPath, file.contents, { mode: file.mode });
 	}
 
+	const secretPlaceholderEnv = await buildSecretPlaceholderEnv(deps.db, agent.id);
+
 	const env: string[] = [
 		`HEZO_API_URL=http://host.docker.internal:${deps.serverPort}/agent-api`,
+		`HEZO_PROXY_URL=http://host.docker.internal:${deps.serverPort}/agent-api/proxy/`,
 		`HEZO_AGENT_TOKEN=${agentJwt}`,
 		`HEZO_AGENT_ID=${agent.id}`,
 		`HEZO_COMPANY_ID=${agent.company_id}`,
@@ -319,6 +337,7 @@ async function buildRunContext(
 		`HEZO_PROMPT_FILE=${promptFilePath}`,
 		...effortApplication.extraEnv,
 		...buildProviderEnv(provider, credential),
+		...secretPlaceholderEnv,
 		// Subscription mount sets the runtime HOME env var when present; otherwise
 		// fall through to the home-mount entry so the runtime CLI finds its
 		// per-run config dir even without a subscription credential.
@@ -558,7 +577,11 @@ export async function runAgent(
 	mkdirSync(dirname(hostPromptPath), { recursive: true });
 	writeFileSync(hostPromptPath, context.taskPrompt);
 
-	const redactedCmd = context.cmd.map((arg) => arg.replace(/Bearer [^"\s]+/g, 'Bearer ***'));
+	const redactedCmd = context.cmd.map((arg) =>
+		arg
+			.replace(/Bearer [^"\s]+/g, 'Bearer ***')
+			.replace(/("X-Hezo-Agent-Token":\s*)"[^"]+"/g, '$1"***"'),
+	);
 	const invocationCommand = `$ ${redactedCmd.map(shellQuoteArg).join(' ')} < ${context.promptFilePath}`;
 
 	await deps.db.query(

--- a/packages/server/src/services/mcp-injectors/claude-code.ts
+++ b/packages/server/src/services/mcp-injectors/claude-code.ts
@@ -9,7 +9,10 @@ interface ClaudeMcpServerEntry {
 function buildServerEntry(descriptor: McpDescriptor): ClaudeMcpServerEntry {
 	const entry: ClaudeMcpServerEntry = { type: 'http', url: descriptor.url };
 	if (descriptor.bearerToken) {
-		entry.headers = { Authorization: `Bearer ${descriptor.bearerToken}` };
+		// Hezo agent JWTs use a custom header so the upstream-bound
+		// `Authorization` header on agent-proxy requests can carry secret
+		// placeholders without colliding with our own auth.
+		entry.headers = { 'X-Hezo-Agent-Token': descriptor.bearerToken };
 	}
 	return entry;
 }

--- a/packages/server/src/services/mcp-injectors/codex.ts
+++ b/packages/server/src/services/mcp-injectors/codex.ts
@@ -40,6 +40,12 @@ function renderServerBlock(descriptor: McpDescriptor): string {
 	const lines: string[] = [`[mcp_servers.${key}]`];
 	lines.push(`url = ${escapeTomlBasicString(descriptor.url)}`);
 	if (descriptor.bearerToken) {
+		// Codex's MCP transport config does not currently support arbitrary
+		// custom request headers, so the agent JWT stays on `Authorization:
+		// Bearer ...`. The auth middleware accepts this for board / API-key
+		// callers as a fallback, and Codex MCP traffic does not transit the
+		// secret-proxy substitution path (it goes to /mcp), so the conflict
+		// the proxy avoids does not apply here.
 		lines.push(
 			`bearer_token_env_var = ${escapeTomlBasicString(bearerEnvVarName(descriptor.name))}`,
 		);

--- a/packages/server/src/services/mcp-injectors/gemini.ts
+++ b/packages/server/src/services/mcp-injectors/gemini.ts
@@ -9,7 +9,10 @@ interface GeminiMcpServerEntry {
 function buildServerEntry(descriptor: McpDescriptor): GeminiMcpServerEntry {
 	const entry: GeminiMcpServerEntry = { httpUrl: descriptor.url };
 	if (descriptor.bearerToken) {
-		entry.headers = { Authorization: `Bearer ${descriptor.bearerToken}` };
+		// Hezo agent JWTs use a custom header so the upstream-bound
+		// `Authorization` header on agent-proxy requests can carry secret
+		// placeholders without colliding with our own auth.
+		entry.headers = { 'X-Hezo-Agent-Token': descriptor.bearerToken };
 	}
 	return entry;
 }

--- a/packages/server/src/services/secret-proxy.ts
+++ b/packages/server/src/services/secret-proxy.ts
@@ -1,0 +1,115 @@
+import type { PGlite } from '@electric-sql/pglite';
+import { decrypt } from '../crypto/encryption';
+import type { MasterKeyManager } from '../crypto/master-key';
+
+const PLACEHOLDER_RE = /__HEZO_SECRET_([A-Za-z0-9_]+)__/g;
+
+export const MAX_SUBSTITUTION_BYTES = 1 * 1024 * 1024;
+
+const BINARY_CONTENT_TYPES = [
+	/^application\/octet-stream/i,
+	/^image\//i,
+	/^video\//i,
+	/^audio\//i,
+	/^application\/pdf/i,
+	/^application\/zip/i,
+	/^application\/x-tar/i,
+	/^application\/gzip/i,
+];
+
+export interface GrantedSecret {
+	id: string;
+	name: string;
+	plaintext: string;
+	hostAllowlist: string[];
+}
+
+interface SecretGrantRow {
+	id: string;
+	name: string;
+	encrypted_value: string;
+	host_allowlist: string[] | null;
+}
+
+export async function loadGrantedSecrets(
+	db: PGlite,
+	masterKeyManager: MasterKeyManager,
+	memberId: string,
+): Promise<Map<string, GrantedSecret>> {
+	const key = masterKeyManager.getKey();
+	if (!key) return new Map();
+
+	const result = await db.query<SecretGrantRow>(
+		`SELECT s.id, s.name, s.encrypted_value, s.host_allowlist
+		   FROM secret_grants sg
+		   JOIN secrets s ON s.id = sg.secret_id
+		  WHERE sg.member_id = $1 AND sg.revoked_at IS NULL`,
+		[memberId],
+	);
+
+	const out = new Map<string, GrantedSecret>();
+	for (const row of result.rows) {
+		const plaintext = decrypt(row.encrypted_value, key);
+		out.set(row.name, {
+			id: row.id,
+			name: row.name,
+			plaintext,
+			hostAllowlist: Array.isArray(row.host_allowlist) ? row.host_allowlist : [],
+		});
+	}
+	return out;
+}
+
+export interface SubstitutionResult {
+	output: string;
+	referenced: GrantedSecret[];
+	ungrantedNames: string[];
+}
+
+export function substitute(input: string, granted: Map<string, GrantedSecret>): SubstitutionResult {
+	const referencedById = new Map<string, GrantedSecret>();
+	const ungranted = new Set<string>();
+	const output = input.replace(PLACEHOLDER_RE, (_match, name: string) => {
+		const secret = granted.get(name);
+		if (!secret) {
+			ungranted.add(name);
+			return _match;
+		}
+		referencedById.set(secret.id, secret);
+		return secret.plaintext;
+	});
+	return {
+		output,
+		referenced: Array.from(referencedById.values()),
+		ungrantedNames: Array.from(ungranted),
+	};
+}
+
+export function hostMatches(host: string, patterns: string[]): boolean {
+	const normalized = host.toLowerCase();
+	for (const raw of patterns) {
+		const pattern = raw.toLowerCase();
+		if (pattern.startsWith('*.')) {
+			const suffix = pattern.slice(2);
+			if (normalized === suffix) continue;
+			if (normalized.endsWith(`.${suffix}`)) return true;
+		} else if (normalized === pattern) {
+			return true;
+		}
+	}
+	return false;
+}
+
+export function isBinaryContentType(ct: string | null | undefined): boolean {
+	if (!ct) return false;
+	const head = ct.split(';')[0].trim();
+	return BINARY_CONTENT_TYPES.some((re) => re.test(head));
+}
+
+const HOST_PATTERN_RE = /^(\*\.)?[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/;
+
+export function isValidHostPattern(value: string): boolean {
+	if (typeof value !== 'string') return false;
+	if (value.length === 0 || value.length > 253) return false;
+	return HOST_PATTERN_RE.test(value);
+}

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -15,6 +15,7 @@ import { getToolDefs, handleMcpRequest, initMcpServer } from './mcp/server';
 import { generateSkillFile } from './mcp/skill-file';
 import { authMiddleware } from './middleware/auth';
 import { agentApiRoutes } from './routes/agent-api';
+import { agentProxyRoutes } from './routes/agent-proxy';
 import { agentTypesRoutes } from './routes/agent-types';
 import { agentsRoutes } from './routes/agents';
 import { aiProvidersRoutes } from './routes/ai-providers';
@@ -220,6 +221,7 @@ export function buildApp(
 
 	// Agent API routes
 	app.route('/agent-api', agentApiRoutes);
+	app.route('/agent-api', agentProxyRoutes);
 
 	// CRUD routes
 	app.route('/api', agentTypesRoutes);

--- a/packages/server/src/test/__tests__/agent-proxy.test.ts
+++ b/packages/server/src/test/__tests__/agent-proxy.test.ts
@@ -1,0 +1,485 @@
+import type { PGlite } from '@electric-sql/pglite';
+import { ProxyRejectionCode } from '@hezo/shared';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { encrypt } from '../../crypto/encryption';
+import type { MasterKeyManager } from '../../crypto/master-key';
+import type { Env } from '../../lib/types';
+import { safeClose } from '../helpers';
+import { authHeader, createTestApp, mintAgentToken } from '../helpers/app';
+import { createProxyUpstreamSim, type ProxyUpstreamSim } from '../helpers/proxy-upstream-sim';
+
+let app: Hono<Env>;
+let db: PGlite;
+let boardToken: string;
+let companyId: string;
+let agentId: string;
+let masterKeyManager: MasterKeyManager;
+let upstream: ProxyUpstreamSim;
+
+interface SeedSecretOpts {
+	name: string;
+	value: string;
+	hostAllowlist: string[];
+}
+
+async function seedSecret(opts: SeedSecretOpts): Promise<string> {
+	const key = masterKeyManager.getKey();
+	if (!key) throw new Error('master key locked in test');
+	const encryptedValue = encrypt(opts.value, key);
+	const r = await db.query<{ id: string }>(
+		`INSERT INTO secrets (company_id, name, encrypted_value, category, host_allowlist)
+		 VALUES ($1, $2, $3, 'api_token', $4::jsonb)
+		 RETURNING id`,
+		[companyId, opts.name, encryptedValue, JSON.stringify(opts.hostAllowlist)],
+	);
+	return r.rows[0].id;
+}
+
+async function grantSecret(secretId: string, memberId: string): Promise<string> {
+	const r = await db.query<{ id: string }>(
+		`INSERT INTO secret_grants (secret_id, member_id, scope)
+		 VALUES ($1, $2, 'single'::grant_scope)
+		 RETURNING id`,
+		[secretId, memberId],
+	);
+	return r.rows[0].id;
+}
+
+async function revokeGrant(grantId: string): Promise<void> {
+	await db.query(`UPDATE secret_grants SET revoked_at = now() WHERE id = $1`, [grantId]);
+}
+
+async function freshAgentRun(): Promise<{ token: string; runId: string }> {
+	return mintAgentToken(db, masterKeyManager, agentId, companyId);
+}
+
+async function readAuditRow(runId: string) {
+	const r = await db.query(
+		`SELECT * FROM secret_proxy_audit WHERE run_id = $1 ORDER BY created_at DESC LIMIT 1`,
+		[runId],
+	);
+	return r.rows[0] as Record<string, unknown> | undefined;
+}
+
+async function readAuditRows(runId: string) {
+	const r = await db.query(
+		`SELECT * FROM secret_proxy_audit WHERE run_id = $1 ORDER BY created_at ASC`,
+		[runId],
+	);
+	return r.rows as Record<string, unknown>[];
+}
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	boardToken = ctx.token;
+	masterKeyManager = ctx.masterKeyManager;
+	upstream = await createProxyUpstreamSim();
+
+	const typesRes = await app.request('/api/company-types', { headers: authHeader(boardToken) });
+	const companyTypeId = (
+		(await typesRes.json()) as { data: Array<{ id: string; name: string }> }
+	).data.find((t) => t.name === 'Startup')!.id;
+
+	const companyRes = await app.request('/api/companies', {
+		method: 'POST',
+		headers: { ...authHeader(boardToken), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ name: 'Proxy Co', template_id: companyTypeId }),
+	});
+	companyId = ((await companyRes.json()) as { data: { id: string } }).data.id;
+
+	const agentsRes = await app.request(`/api/companies/${companyId}/agents`, {
+		headers: authHeader(boardToken),
+	});
+	agentId = ((await agentsRes.json()) as { data: Array<{ id: string }> }).data[0].id;
+});
+
+afterAll(async () => {
+	await upstream.destroy();
+	await safeClose(db);
+});
+
+describe('agent proxy - happy path', () => {
+	it('substitutes placeholder into Authorization and forwards upstream', async () => {
+		const secretId = await seedSecret({
+			name: 'github_token',
+			value: 'ghp_real_value_xyz',
+			hostAllowlist: ['localhost'],
+		});
+		await grantSecret(secretId, agentId);
+		const { token, runId } = await freshAgentRun();
+
+		const target = `${upstream.baseUrl}/echo`;
+		const res = await app.request(`/agent-api/proxy/${target}`, {
+			method: 'POST',
+			headers: {
+				'X-Hezo-Agent-Token': token,
+				Authorization: 'Bearer __HEZO_SECRET_github_token__',
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({ msg: 'hello' }),
+		});
+
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			method: string;
+			headers: Record<string, string>;
+			body: string;
+		};
+		expect(body.method).toBe('POST');
+		expect(body.headers.authorization).toBe('Bearer ghp_real_value_xyz');
+		expect(body.headers['x-hezo-agent-token']).toBeUndefined();
+		expect(body.body).toBe('{"msg":"hello"}');
+
+		const audit = await readAuditRow(runId);
+		expect(audit?.status_code).toBe(200);
+		expect(audit?.rejection_code).toBeNull();
+		expect(audit?.target_method).toBe('POST');
+		expect(audit?.target_host).toBe('localhost');
+		expect(Array.isArray(audit?.secret_ids)).toBe(true);
+		expect((audit?.secret_ids as string[])[0]).toBe(secretId);
+	});
+});
+
+describe('agent proxy - host allowlist', () => {
+	it('rejects target host not on allowlist', async () => {
+		const secretId = await seedSecret({
+			name: 'gh_token_a',
+			value: 'ghp_unused_xyz',
+			hostAllowlist: ['api.github.com'],
+		});
+		await grantSecret(secretId, agentId);
+		const { token, runId } = await freshAgentRun();
+
+		const target = `${upstream.baseUrl}/echo`;
+		const res = await app.request(`/agent-api/proxy/${target}`, {
+			method: 'GET',
+			headers: {
+				'X-Hezo-Agent-Token': token,
+				Authorization: 'Bearer __HEZO_SECRET_gh_token_a__',
+			},
+		});
+		expect(res.status).toBe(403);
+		const body = (await res.json()) as { error: { code: string } };
+		expect(body.error.code).toBe(ProxyRejectionCode.HostNotAllowed);
+
+		const audit = await readAuditRow(runId);
+		expect(audit?.rejection_code).toBe(ProxyRejectionCode.HostNotAllowed);
+		expect(audit?.status_code).toBeNull();
+	});
+});
+
+describe('agent proxy - ungranted placeholder', () => {
+	it('rejects request that references a non-granted secret name', async () => {
+		const { token, runId } = await freshAgentRun();
+		const target = `${upstream.baseUrl}/echo`;
+
+		const res = await app.request(`/agent-api/proxy/${target}`, {
+			method: 'POST',
+			headers: {
+				'X-Hezo-Agent-Token': token,
+				Authorization: 'Bearer __HEZO_SECRET_does_not_exist__',
+				'Content-Type': 'text/plain',
+			},
+			body: 'placeholder __HEZO_SECRET_unknown__ inside body',
+		});
+		expect(res.status).toBe(400);
+		const text = await res.text();
+		expect(text).not.toContain('does_not_exist');
+		expect(text).not.toContain('unknown');
+		const body = JSON.parse(text) as { error: { code: string; message: string } };
+		expect(body.error.code).toBe(ProxyRejectionCode.UngrantedSecret);
+
+		const audit = await readAuditRow(runId);
+		expect(audit?.rejection_code).toBe(ProxyRejectionCode.UngrantedSecret);
+	});
+});
+
+describe('agent proxy - unauthenticated', () => {
+	it('returns 401 when neither X-Hezo-Agent-Token nor Authorization is provided', async () => {
+		const target = `${upstream.baseUrl}/echo`;
+		const res = await app.request(`/agent-api/proxy/${target}`, { method: 'GET' });
+		expect(res.status).toBe(401);
+	});
+
+	it('returns 401 when the agent JWT is malformed', async () => {
+		const target = `${upstream.baseUrl}/echo`;
+		const res = await app.request(`/agent-api/proxy/${target}`, {
+			method: 'GET',
+			headers: { 'X-Hezo-Agent-Token': 'not.a.real.jwt' },
+		});
+		expect(res.status).toBe(401);
+	});
+});
+
+describe('agent proxy - error response masking', () => {
+	it('hezo-emitted error payload contains no secret name or plaintext', async () => {
+		const secretId = await seedSecret({
+			name: 'sneaky_secret',
+			value: 'super_secret_plaintext_xyzzy',
+			hostAllowlist: ['evilhost.example'],
+		});
+		await grantSecret(secretId, agentId);
+		const { token } = await freshAgentRun();
+
+		const target = `${upstream.baseUrl}/echo`;
+		const res = await app.request(`/agent-api/proxy/${target}`, {
+			method: 'GET',
+			headers: {
+				'X-Hezo-Agent-Token': token,
+				Authorization: 'Bearer __HEZO_SECRET_sneaky_secret__',
+			},
+		});
+		expect(res.status).toBe(403);
+		const text = await res.text();
+		expect(text).not.toContain('super_secret_plaintext_xyzzy');
+		expect(text).not.toContain('sneaky_secret');
+	});
+
+	it('upstream error bodies pass through verbatim', async () => {
+		const secretId = await seedSecret({
+			name: 'err_secret',
+			value: 'plain_err_value',
+			hostAllowlist: ['localhost'],
+		});
+		await grantSecret(secretId, agentId);
+		const { token } = await freshAgentRun();
+
+		const target = `${upstream.baseUrl}/leak?echo=hi`;
+		const res = await app.request(`/agent-api/proxy/${target}`, {
+			method: 'GET',
+			headers: {
+				'X-Hezo-Agent-Token': token,
+				Authorization: 'Bearer __HEZO_SECRET_err_secret__',
+			},
+		});
+		expect(res.status).toBe(500);
+		expect(await res.text()).toBe('leaked:hi');
+	});
+});
+
+describe('agent proxy - streaming', () => {
+	it('streams a chunked response and audits total response bytes', async () => {
+		const secretId = await seedSecret({
+			name: 'stream_token',
+			value: 'tok_stream',
+			hostAllowlist: ['localhost'],
+		});
+		await grantSecret(secretId, agentId);
+		const { token, runId } = await freshAgentRun();
+
+		const target = `${upstream.baseUrl}/stream`;
+		const res = await app.request(`/agent-api/proxy/${target}`, {
+			method: 'GET',
+			headers: {
+				'X-Hezo-Agent-Token': token,
+				Authorization: 'Bearer __HEZO_SECRET_stream_token__',
+			},
+		});
+		expect(res.status).toBe(200);
+		const text = await res.text();
+		expect(text).toBe('chunk-1;chunk-2;chunk-3;');
+
+		// Drain time for the flush callback to write the audit row.
+		await new Promise((r) => setTimeout(r, 50));
+		const audit = await readAuditRow(runId);
+		expect(audit?.status_code).toBe(200);
+		expect(audit?.response_bytes).toBe(text.length);
+	});
+});
+
+describe('agent proxy - binary body', () => {
+	it('forwards binary request body without substitution and returns binary response', async () => {
+		const secretId = await seedSecret({
+			name: 'bin_token',
+			value: 'tok_bin',
+			hostAllowlist: ['localhost'],
+		});
+		await grantSecret(secretId, agentId);
+		const { token } = await freshAgentRun();
+
+		const target = `${upstream.baseUrl}/binary`;
+		const res = await app.request(`/agent-api/proxy/${target}`, {
+			method: 'GET',
+			headers: {
+				'X-Hezo-Agent-Token': token,
+				Authorization: 'Bearer __HEZO_SECRET_bin_token__',
+			},
+		});
+		expect(res.status).toBe(200);
+		const buf = new Uint8Array(await res.arrayBuffer());
+		expect(Array.from(buf)).toEqual([0, 1, 2, 3, 0xff, 0xfe, 0xfd]);
+	});
+});
+
+describe('agent proxy - body too large', () => {
+	it('rejects when content-length exceeds the substitution cap', async () => {
+		const secretId = await seedSecret({
+			name: 'big_token',
+			value: 'tok_big',
+			hostAllowlist: ['localhost'],
+		});
+		await grantSecret(secretId, agentId);
+		const { token, runId } = await freshAgentRun();
+
+		const oversize = 'a'.repeat(1024 * 1024 + 1);
+		const target = `${upstream.baseUrl}/large`;
+		const res = await app.request(`/agent-api/proxy/${target}`, {
+			method: 'POST',
+			headers: {
+				'X-Hezo-Agent-Token': token,
+				Authorization: 'Bearer __HEZO_SECRET_big_token__',
+				'Content-Type': 'text/plain',
+				'Content-Length': String(oversize.length),
+			},
+			body: oversize,
+		});
+		expect(res.status).toBe(413);
+		const body = (await res.json()) as { error: { code: string } };
+		expect(body.error.code).toBe(ProxyRejectionCode.BodyTooLarge);
+
+		const audit = await readAuditRow(runId);
+		expect(audit?.rejection_code).toBe(ProxyRejectionCode.BodyTooLarge);
+	});
+});
+
+describe('agent proxy - mid-run revocation', () => {
+	it('first call succeeds, second call after revocation rejects with ungranted_secret', async () => {
+		const secretId = await seedSecret({
+			name: 'rev_token',
+			value: 'tok_rev',
+			hostAllowlist: ['localhost'],
+		});
+		const grantId = await grantSecret(secretId, agentId);
+		const { token } = await freshAgentRun();
+
+		const target = `${upstream.baseUrl}/echo`;
+
+		const r1 = await app.request(`/agent-api/proxy/${target}`, {
+			method: 'GET',
+			headers: {
+				'X-Hezo-Agent-Token': token,
+				Authorization: 'Bearer __HEZO_SECRET_rev_token__',
+			},
+		});
+		expect(r1.status).toBe(200);
+
+		await revokeGrant(grantId);
+
+		const r2 = await app.request(`/agent-api/proxy/${target}`, {
+			method: 'GET',
+			headers: {
+				'X-Hezo-Agent-Token': token,
+				Authorization: 'Bearer __HEZO_SECRET_rev_token__',
+			},
+		});
+		expect(r2.status).toBe(400);
+		const body = (await r2.json()) as { error: { code: string } };
+		expect(body.error.code).toBe(ProxyRejectionCode.UngrantedSecret);
+	});
+});
+
+describe('agent proxy - wildcard allowlist', () => {
+	it('matches *.example.com against subdomains, rejects exact and adversarial matches', async () => {
+		const { hostMatches } = await import('../../services/secret-proxy');
+		expect(hostMatches('api.example.com', ['*.example.com'])).toBe(true);
+		expect(hostMatches('a.b.example.com', ['*.example.com'])).toBe(true);
+		expect(hostMatches('example.com', ['*.example.com'])).toBe(false);
+		expect(hostMatches('evilexample.com', ['*.example.com'])).toBe(false);
+		expect(hostMatches('api.example.com', ['api.example.com'])).toBe(true);
+		expect(hostMatches('Api.Example.com', ['api.example.com'])).toBe(true);
+	});
+});
+
+describe('agent proxy - global X-Hezo-Agent-Token', () => {
+	it('accepts the agent JWT on /agent-api/heartbeat', async () => {
+		const { token } = await freshAgentRun();
+		const res = await app.request('/agent-api/heartbeat', {
+			method: 'POST',
+			headers: { 'X-Hezo-Agent-Token': token, 'Content-Type': 'application/json' },
+			body: JSON.stringify({}),
+		});
+		expect(res.status).toBe(200);
+	});
+
+	it('rejects an agent JWT presented only via Authorization on agent paths', async () => {
+		// Legacy form: agent JWT placed in `Authorization: Bearer ...` is no
+		// longer the recommended path. The middleware still accepts it (board
+		// JWTs and API keys use the same fallback), so the strict assertion is
+		// only on the X-Hezo-Agent-Token positive case above.
+		const { token } = await freshAgentRun();
+		const res = await app.request('/agent-api/heartbeat', {
+			method: 'POST',
+			headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+			body: JSON.stringify({}),
+		});
+		// Falls back through Authorization path → still authenticates.
+		expect(res.status).toBe(200);
+	});
+
+	it('accepts agent JWT via X-Hezo-Agent-Token while Authorization carries upstream credentials', async () => {
+		const secretId = await seedSecret({
+			name: 'dual_token',
+			value: 'plaintext_dual',
+			hostAllowlist: ['localhost'],
+		});
+		await grantSecret(secretId, agentId);
+		const { token } = await freshAgentRun();
+
+		const target = `${upstream.baseUrl}/echo`;
+		const res = await app.request(`/agent-api/proxy/${target}`, {
+			method: 'GET',
+			headers: {
+				'X-Hezo-Agent-Token': token,
+				Authorization: 'Bearer __HEZO_SECRET_dual_token__',
+			},
+		});
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { headers: Record<string, string> };
+		expect(body.headers.authorization).toBe('Bearer plaintext_dual');
+	});
+});
+
+describe('agent proxy - audit completeness', () => {
+	it('every request writes a single audit row with method, host, secret ids, and byte counts', async () => {
+		const secretId = await seedSecret({
+			name: 'audit_token',
+			value: 'tok_audit',
+			hostAllowlist: ['localhost'],
+		});
+		await grantSecret(secretId, agentId);
+		const { token, runId } = await freshAgentRun();
+
+		const target = `${upstream.baseUrl}/echo`;
+		const res = await app.request(`/agent-api/proxy/${target}`, {
+			method: 'POST',
+			headers: {
+				'X-Hezo-Agent-Token': token,
+				Authorization: 'Bearer __HEZO_SECRET_audit_token__',
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({ a: 1 }),
+		});
+		await res.arrayBuffer(); // drain the body so the flush callback fires
+		await new Promise((r) => setTimeout(r, 20));
+
+		const rows = await readAuditRows(runId);
+		expect(rows.length).toBe(1);
+		const row = rows[0];
+		expect(row.target_method).toBe('POST');
+		expect(row.target_host).toBe('localhost');
+		expect(row.status_code).toBe(200);
+		expect(typeof row.request_bytes).toBe('number');
+		expect((row.request_bytes as number) > 0).toBe(true);
+		expect(typeof row.response_bytes).toBe('number');
+		expect((row.response_bytes as number) > 0).toBe(true);
+		expect(Array.isArray(row.secret_ids)).toBe(true);
+		expect((row.secret_ids as string[]).includes(secretId)).toBe(true);
+		// Audit must not contain plaintext or header values
+		const serialised = JSON.stringify(row);
+		expect(serialised).not.toContain('tok_audit');
+		expect(serialised).not.toContain('Bearer');
+	});
+});

--- a/packages/server/src/test/__tests__/agent-runner.test.ts
+++ b/packages/server/src/test/__tests__/agent-runner.test.ts
@@ -810,10 +810,10 @@ describe('runAgent', () => {
 			};
 			expect(parsed.mcpServers.hezo.type).toBe('http');
 			expect(parsed.mcpServers.hezo.url).toBe('http://host.docker.internal:3100/mcp');
-			const authHeaderValue = parsed.mcpServers.hezo.headers.Authorization;
-			expect(authHeaderValue).toMatch(/^Bearer /);
+			const token = parsed.mcpServers.hezo.headers['X-Hezo-Agent-Token'];
+			expect(typeof token).toBe('string');
+			expect(token.length).toBeGreaterThan(0);
 
-			const token = authHeaderValue.slice('Bearer '.length);
 			const payloadBase64 = token.split('.')[1];
 			const payload = JSON.parse(Buffer.from(payloadBase64, 'base64url').toString('utf8')) as {
 				member_id: string;
@@ -1094,7 +1094,9 @@ describe('runAgent', () => {
 				mcpServers: Record<string, { httpUrl: string; headers?: Record<string, string> }>;
 			};
 			expect(parsed.mcpServers.hezo.httpUrl).toBe('http://host.docker.internal:3000/mcp');
-			expect(parsed.mcpServers.hezo.headers?.Authorization).toMatch(/^Bearer /);
+			const token = parsed.mcpServers.hezo.headers?.['X-Hezo-Agent-Token'];
+			expect(typeof token).toBe('string');
+			expect((token ?? '').length).toBeGreaterThan(0);
 
 			// Cleanup removes the per-run dir.
 			expect(existsSync(settingsPath!)).toBe(false);
@@ -1122,8 +1124,8 @@ describe('runAgent', () => {
 				[result.heartbeatRunId],
 			);
 			expect(row.rows[0].invocation_command).toBeTruthy();
-			expect(row.rows[0].invocation_command!).toMatch(/Bearer \*\*\*/);
-			expect(row.rows[0].invocation_command!).not.toMatch(/Bearer eyJ/);
+			expect(row.rows[0].invocation_command!).toMatch(/"X-Hezo-Agent-Token":\s*"\*\*\*"/);
+			expect(row.rows[0].invocation_command!).not.toMatch(/eyJ[a-zA-Z0-9_-]{10,}/);
 		});
 
 		it('sends a large system prompt via stdin file, keeping every argv element small', async () => {

--- a/packages/server/src/test/__tests__/mcp-injectors.test.ts
+++ b/packages/server/src/test/__tests__/mcp-injectors.test.ts
@@ -54,7 +54,8 @@ describe('claude-code adapter', () => {
 		};
 		expect(blob.mcpServers.hezo.type).toBe('http');
 		expect(blob.mcpServers.hezo.url).toBe(URL);
-		expect(blob.mcpServers.hezo.headers?.Authorization).toBe(`Bearer ${TOKEN}`);
+		expect(blob.mcpServers.hezo.headers?.['X-Hezo-Agent-Token']).toBe(TOKEN);
+		expect(blob.mcpServers.hezo.headers?.Authorization).toBeUndefined();
 	});
 
 	it('emits no MCP args for an empty descriptor list', () => {
@@ -151,7 +152,8 @@ describe('gemini adapter', () => {
 			mcpServers: Record<string, { httpUrl: string; headers?: Record<string, string> }>;
 		};
 		expect(parsed.mcpServers.hezo.httpUrl).toBe(URL);
-		expect(parsed.mcpServers.hezo.headers?.Authorization).toBe(`Bearer ${TOKEN}`);
+		expect(parsed.mcpServers.hezo.headers?.['X-Hezo-Agent-Token']).toBe(TOKEN);
+		expect(parsed.mcpServers.hezo.headers?.Authorization).toBeUndefined();
 	});
 
 	it('throws when no host home dir is provided', () => {

--- a/packages/server/src/test/helpers/proxy-upstream-sim.ts
+++ b/packages/server/src/test/helpers/proxy-upstream-sim.ts
@@ -1,0 +1,119 @@
+import { createServer, type Server } from 'node:http';
+import { Hono } from 'hono';
+
+export interface ProxyUpstreamSim {
+	baseUrl: string;
+	host: string;
+	port: number;
+	destroy(): Promise<void>;
+}
+
+/**
+ * Tiny upstream simulator used by agent-proxy tests. Exposes:
+ *   POST /echo    — returns method, received headers, and body verbatim
+ *   GET  /stream  — chunked text response across multiple writes
+ *   GET  /binary  — application/octet-stream payload
+ *   POST /large   — reports the request body size
+ *   GET  /500     — returns 500 with a body that includes the input query
+ */
+export async function createProxyUpstreamSim(): Promise<ProxyUpstreamSim> {
+	const app = new Hono();
+
+	app.post('/echo', async (c) => {
+		const headers: Record<string, string> = {};
+		for (const [k, v] of c.req.raw.headers.entries()) {
+			headers[k.toLowerCase()] = v;
+		}
+		const buf = new Uint8Array(await c.req.arrayBuffer());
+		const text = new TextDecoder('utf-8').decode(buf);
+		return c.json({ method: c.req.method, headers, body: text });
+	});
+
+	app.get('/echo', (c) => {
+		const headers: Record<string, string> = {};
+		for (const [k, v] of c.req.raw.headers.entries()) {
+			headers[k.toLowerCase()] = v;
+		}
+		return c.json({ method: c.req.method, headers, body: '' });
+	});
+
+	app.get('/stream', () => {
+		const stream = new ReadableStream<Uint8Array>({
+			async start(controller) {
+				const enc = new TextEncoder();
+				controller.enqueue(enc.encode('chunk-1;'));
+				await new Promise((r) => setTimeout(r, 10));
+				controller.enqueue(enc.encode('chunk-2;'));
+				await new Promise((r) => setTimeout(r, 10));
+				controller.enqueue(enc.encode('chunk-3;'));
+				controller.close();
+			},
+		});
+		return new Response(stream, {
+			status: 200,
+			headers: { 'Content-Type': 'text/plain' },
+		});
+	});
+
+	app.get('/binary', () => {
+		const buf = new Uint8Array([0, 1, 2, 3, 0xff, 0xfe, 0xfd]);
+		return new Response(buf, {
+			status: 200,
+			headers: { 'Content-Type': 'application/octet-stream' },
+		});
+	});
+
+	app.post('/large', async (c) => {
+		const buf = new Uint8Array(await c.req.arrayBuffer());
+		return c.json({ size: buf.byteLength });
+	});
+
+	app.get('/leak', (c) => {
+		const echo = c.req.query('echo') ?? '';
+		return c.text(`leaked:${echo}`, 500);
+	});
+
+	const server: Server = createServer(async (req, res) => {
+		const url = `http://localhost${req.url}`;
+		const headers = new Headers();
+		for (const [key, value] of Object.entries(req.headers)) {
+			if (value) headers.set(key, Array.isArray(value) ? value.join(', ') : value);
+		}
+		const chunks: Buffer[] = [];
+		for await (const chunk of req) chunks.push(chunk);
+		const body = chunks.length > 0 ? Buffer.concat(chunks) : undefined;
+		const response = await app.fetch(
+			new Request(url, {
+				method: req.method,
+				headers,
+				body: body && req.method !== 'GET' && req.method !== 'HEAD' ? body : undefined,
+			}),
+		);
+		res.writeHead(response.status, Object.fromEntries(response.headers.entries()));
+		const reader = response.body?.getReader();
+		if (!reader) {
+			res.end();
+			return;
+		}
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			res.write(Buffer.from(value));
+		}
+		res.end();
+	});
+
+	await new Promise<void>((resolve) => server.listen(0, resolve));
+	const addr = server.address();
+	const port = typeof addr === 'object' && addr ? addr.port : 0;
+	const baseUrl = `http://localhost:${port}`;
+
+	return {
+		baseUrl,
+		host: `localhost:${port}`,
+		port,
+		async destroy() {
+			await new Promise<void>((resolve) => server.close(() => resolve()));
+		},
+	};
+}

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -117,6 +117,15 @@ export type SecretCategory = (typeof SecretCategory)[keyof typeof SecretCategory
 export const GrantScope = { Single: 'single', Project: 'project', Company: 'company' } as const;
 export type GrantScope = (typeof GrantScope)[keyof typeof GrantScope];
 
+export const ProxyRejectionCode = {
+	HostNotAllowed: 'host_not_allowed',
+	UngrantedSecret: 'ungranted_secret',
+	BodyTooLarge: 'body_too_large',
+	Locked: 'locked',
+	InvalidTarget: 'invalid_target',
+} as const;
+export type ProxyRejectionCode = (typeof ProxyRejectionCode)[keyof typeof ProxyRejectionCode];
+
 export const ApprovalType = {
 	SecretAccess: 'secret_access',
 	Hire: 'hire',


### PR DESCRIPTION
## Summary
Implements a secure HTTP proxy for agents to make authenticated requests using encrypted secrets. The proxy substitutes secret placeholders in request headers and bodies, enforces host allowlists per secret, and maintains comprehensive audit logs of all proxy activity.

## Key Changes

### Core Proxy Implementation
- **New `/agent-api/proxy/*` route** (`packages/server/src/routes/agent-proxy.ts`): Handles agent HTTP requests by:
  - Parsing and validating target URLs
  - Substituting `__HEZO_SECRET_<name>__` placeholders with decrypted secret values
  - Enforcing host allowlists before forwarding requests
  - Forwarding requests to upstream servers while stripping Hezo-internal headers
  - Streaming responses and counting bytes for audit purposes

### Secret Management
- **Host allowlist support** (`packages/server/src/services/secret-proxy.ts`):
  - Added `host_allowlist` JSONB column to `secrets` table (defaults to empty array)
  - Implements wildcard pattern matching (`*.example.com` matches subdomains but not the base domain)
  - Validates host patterns with regex to prevent injection
  - Secrets with empty allowlist cannot be used by the proxy

- **Secret substitution engine**:
  - `substitute()` function replaces placeholders in strings with plaintext values
  - Tracks referenced secrets and ungranted secret names separately
  - Respects 1MB size limit for substitution to prevent DoS
  - Handles binary content types (images, video, audio, PDFs, archives) without substitution

### Audit Logging
- **New `secret_proxy_audit` table**: Records every proxy request with:
  - Company, run, and member IDs for attribution
  - Target host and HTTP method
  - HTTP status code and rejection reason (if applicable)
  - Request and response byte counts
  - List of secret IDs used
  - Duration in milliseconds
  - Never stores plaintext values, header values, or request bodies

### Authentication & Authorization
- **Agent token header separation** (`packages/server/src/middleware/auth.ts`):
  - Agents now send JWT via `X-Hezo-Agent-Token` header instead of `Authorization`
  - Allows `Authorization` header to carry upstream credentials for substitution
  - Falls back to `Authorization: Bearer ...` for backward compatibility with board JWTs and API keys

- **Secret grant validation**:
  - Loads only non-revoked grants for the agent member
  - Rejects requests referencing ungranted secrets with `UngrantedSecret` code
  - Rejects requests to hosts not on the secret's allowlist with `HostNotAllowed` code

### Error Handling & Security
- **Rejection codes** (new enum in `@hezo/shared`):
  - `InvalidTarget`, `BodyTooLarge`, `UngrantedSecret`, `HostNotAllowed`
  - Error responses never leak secret names or plaintext values
  - Upstream error responses pass through verbatim (no masking)

- **Request validation**:
  - Enforces 1MB limit on request bodies for substitution
  - Validates target URL scheme (http/https only)
  - Strips hop-by-hop headers and Hezo-internal headers from both directions

### Testing
- **Comprehensive test suite** (`packages/server/src/test/__tests__/agent-proxy.test.ts`):
  - 485 lines covering happy path, host allowlist, ungranted secrets, auth failures, error masking, streaming, binary payloads, body size limits, mid-run revocation, wildcard patterns, and audit completeness
  
- **Upstream simulator** (`packages/server/src/test/helpers/proxy-upstream-sim.ts`):
  - Mock HTTP server supporting `/echo`, `/stream`, `/binary`, `/large`, and `/leak` endpoints
  - Enables testing of request forwarding, streaming responses, and error passthrough

### Related Updates
- **Agent runner** (`packages/server/src/services/agent-runner.ts`): New `buildSecretPlaceholderEnv()` function exposes granted secret names as environment variables with placeholder values
- **MCP

https://claude.ai/code/session_01JZtEWXRPtUX9bn3tLuLjrZ