### PR TITLE
perf(web): virtualize issue comment list and lazy-mount run logs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -82,6 +82,7 @@
         "react": "^19",
         "react-dom": "^19",
         "react-markdown": "^10",
+        "react-virtuoso": "^4.18.6",
         "reconnecting-websocket": "^4.4.0",
         "remark-gfm": "^4",
       },
@@ -1218,6 +1219,8 @@
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
+
+    "react-virtuoso": ["react-virtuoso@4.18.6", "", { "peerDependencies": { "react": ">=16 || >=17 || >= 18 || >= 19", "react-dom": ">=16 || >=17 || >= 18 || >=19" } }, "sha512-CrT3P6HyjJMHZVWSste2bG2q5aWGlHfW2QuySZjiFwB2Qok/xsvgy+k8Z2jeDP8PP5KsBip7zNrl/F0QoxeyKw=="],
 
     "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -29,6 +29,7 @@
 		"react": "^19",
 		"react-dom": "^19",
 		"react-markdown": "^10",
+		"react-virtuoso": "^4",
 		"reconnecting-websocket": "^4.4.0",
 		"remark-gfm": "^4"
 	},

--- a/packages/web/src/components/comment-renderers.tsx
+++ b/packages/web/src/components/comment-renderers.tsx
@@ -21,6 +21,7 @@ import {
 	useHeartbeatRun,
 } from '../hooks/use-heartbeat-runs';
 import { useRunLogs } from '../hooks/use-run-logs';
+import { LazyMount } from './lazy-mount';
 import { LogViewer } from './log-viewer';
 import { MarkdownProse } from './markdown-prose';
 import { RepoSetupWizard } from './repo-setup-wizard';
@@ -218,17 +219,9 @@ function RunComment({
 	const agentId: string = content.agent_id ?? '';
 	const agentTitle: string = content.agent_title ?? 'Agent';
 
-	const runQuery = useHeartbeatRun(companyId ?? '', agentId, runId);
-	const run = runQuery.data;
-	const status = run?.status ?? 'queued';
-	const isActive = isActiveRunStatus(status);
-	const { lines } = useRunLogs(run?.project_id, runId, run?.log_text, isActive);
-
 	if (!companyId || !runId || !agentId) {
 		return <p className="text-xs text-text-subtle italic">Run reference missing.</p>;
 	}
-
-	const createdIssues = run?.created_issues ?? [];
 
 	return (
 		<div className="flex flex-col gap-1.5" data-testid="run-comment">
@@ -240,6 +233,38 @@ function RunComment({
 					</span>
 				</div>
 			)}
+			<LazyMount minHeight={210} testId="run-comment-lazy">
+				<RunCommentBody
+					companyId={companyId}
+					runId={runId}
+					agentId={agentId}
+					agentTitle={agentTitle}
+				/>
+			</LazyMount>
+		</div>
+	);
+}
+
+function RunCommentBody({
+	companyId,
+	runId,
+	agentId,
+	agentTitle,
+}: {
+	companyId: string;
+	runId: string;
+	agentId: string;
+	agentTitle: string;
+}) {
+	const runQuery = useHeartbeatRun(companyId, agentId, runId);
+	const run = runQuery.data;
+	const status = run?.status ?? 'queued';
+	const isActive = isActiveRunStatus(status);
+	const { lines } = useRunLogs(run?.project_id, runId, run?.log_text, isActive);
+	const createdIssues = run?.created_issues ?? [];
+
+	return (
+		<>
 			<LogViewer
 				lines={lines}
 				compact
@@ -281,7 +306,7 @@ function RunComment({
 			>
 				View full run <ArrowRight className="w-3 h-3" />
 			</Link>
-		</div>
+		</>
 	);
 }
 

--- a/packages/web/src/components/lazy-mount.tsx
+++ b/packages/web/src/components/lazy-mount.tsx
@@ -1,0 +1,48 @@
+import { type ReactNode, useEffect, useRef, useState } from 'react';
+
+interface LazyMountProps {
+	minHeight: number;
+	rootMargin?: string;
+	testId?: string;
+	children: ReactNode;
+}
+
+export function LazyMount({
+	minHeight,
+	rootMargin = '400px 0px',
+	testId,
+	children,
+}: LazyMountProps) {
+	const ref = useRef<HTMLDivElement | null>(null);
+	const [mounted, setMounted] = useState(
+		() => typeof window === 'undefined' || typeof IntersectionObserver === 'undefined',
+	);
+
+	useEffect(() => {
+		if (mounted) return;
+		const node = ref.current;
+		if (!node) return;
+		const io = new IntersectionObserver(
+			(entries) => {
+				if (entries.some((e) => e.isIntersecting)) {
+					setMounted(true);
+					io.disconnect();
+				}
+			},
+			{ rootMargin },
+		);
+		io.observe(node);
+		return () => io.disconnect();
+	}, [mounted, rootMargin]);
+
+	return (
+		<div
+			ref={ref}
+			data-testid={testId}
+			data-lazy-mounted={mounted ? 'true' : 'false'}
+			style={mounted ? undefined : { minHeight }}
+		>
+			{mounted ? children : null}
+		</div>
+	);
+}

--- a/packages/web/src/routes/companies/$companyId/projects/$projectId/issues/$issueId.tsx
+++ b/packages/web/src/routes/companies/$companyId/projects/$projectId/issues/$issueId.tsx
@@ -7,7 +7,8 @@ import {
 } from '@hezo/shared';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import { ChevronDown, Info, Loader2, Plus, Trash2 } from 'lucide-react';
-import { Fragment, useEffect, useRef, useState } from 'react';
+import { Fragment, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -130,6 +131,18 @@ function IssueDetailPage() {
 	const [closeOpen, setCloseOpen] = useState(false);
 	const [reopenOpen, setReopenOpen] = useState(false);
 	const assigneeRef = useRef<HTMLDivElement>(null);
+	const virtuosoRef = useRef<VirtuosoHandle>(null);
+	const didScrollToHashRef = useRef(false);
+	// The app shell wraps the route in `<main className="flex-1 overflow-auto">`
+	// (see __root.tsx). The window never scrolls — that <main> does — so
+	// Virtuoso needs `customScrollParent` pointing at it for measurement and
+	// scroll restoration to work. Resolve before paint so Virtuoso's first
+	// mount is wired to the right scroll container.
+	const [scrollParent, setScrollParent] = useState<HTMLElement | null>(null);
+	useLayoutEffect(() => {
+		if (typeof document === 'undefined') return;
+		setScrollParent(document.querySelector('main'));
+	}, []);
 
 	useEffect(() => {
 		if (!assigneeOpen) return;
@@ -145,11 +158,53 @@ function IssueDetailPage() {
 	useEffect(() => {
 		if (!comments || comments.length === 0) return;
 		if (typeof window === 'undefined') return;
-		if (window.location.hash !== '#setup-repo') return;
-		const target = document.querySelector('[data-setup-repo-anchor]');
-		if (!target) return;
-		target.scrollIntoView({ behavior: 'smooth', block: 'center' });
-		window.history.replaceState(null, '', window.location.pathname + window.location.search);
+
+		// Resolve the current hash (a specific comment via `#comment-<id>`, or
+		// the unresolved setup-repo action card via `#setup-repo`) to its
+		// index in the loaded comments list and tell Virtuoso to scroll there.
+		// `scrollToIndex` is computed off estimated row heights, so iterate a
+		// few times: each pass mounts more rows, grows the measured document,
+		// and the next call lands closer to the target.
+		const scrollToHash = () => {
+			const hash = window.location.hash;
+			let idx = -1;
+			if (hash.startsWith('#comment-')) {
+				const targetId = hash.slice('#comment-'.length);
+				idx = comments.findIndex((c) => c.id === targetId);
+			} else if (hash === '#setup-repo') {
+				idx = comments.findIndex((c) => {
+					if (c.content_type !== 'action') return false;
+					const content = typeof c.content === 'object' ? (c.content as { kind?: string }) : null;
+					return content?.kind === 'setup_repo' && !c.chosen_option;
+				});
+			}
+			if (idx < 0) return [] as ReturnType<typeof setTimeout>[];
+			const out: ReturnType<typeof setTimeout>[] = [];
+			for (const delay of [16, 200, 600, 1500]) {
+				out.push(
+					setTimeout(() => {
+						virtuosoRef.current?.scrollToIndex({ index: idx, align: 'center' });
+					}, delay),
+				);
+			}
+			if (hash === '#setup-repo') {
+				window.history.replaceState(null, '', window.location.pathname + window.location.search);
+			}
+			return out;
+		};
+
+		const initialTimers = didScrollToHashRef.current ? [] : scrollToHash();
+		didScrollToHashRef.current = true;
+
+		const allTimers: ReturnType<typeof setTimeout>[] = [...initialTimers];
+		const onHashChange = () => {
+			allTimers.push(...scrollToHash());
+		};
+		window.addEventListener('hashchange', onHashChange);
+		return () => {
+			window.removeEventListener('hashchange', onHashChange);
+			for (const t of allTimers) clearTimeout(t);
+		};
 	}, [comments]);
 
 	const assignedAgent = agents?.find((a) => a.id === issue?.assignee_id);
@@ -493,86 +548,97 @@ function IssueDetailPage() {
 						</span>
 					</div>
 
-					<div className="flex flex-col gap-4 mb-4">
-						{comments?.map((c) => {
-							const commentData = c as unknown as CommentData;
-							const authorName = c.author_name ?? 'Board';
-							const isAgent = c.author_type === 'agent';
-							const content =
-								typeof c.content === 'object' ? (c.content as { kind?: string }) : null;
-							const isPendingSetupRepo =
-								c.content_type === 'action' && content?.kind === 'setup_repo' && !c.chosen_option;
+					<div className="mb-4" data-testid="comments-list">
+						{scrollParent && (
+							<Virtuoso
+								ref={virtuosoRef}
+								customScrollParent={scrollParent}
+								data={comments ?? []}
+								computeItemKey={(_, c) => c.id}
+								followOutput="auto"
+								defaultItemHeight={120}
+								increaseViewportBy={{ top: 600, bottom: 600 }}
+								itemContent={(_, c) => {
+									const commentData = c as unknown as CommentData;
+									const authorName = c.author_name ?? 'Board';
+									const isAgent = c.author_type === 'agent';
+									const content =
+										typeof c.content === 'object' ? (c.content as { kind?: string }) : null;
+									const isPendingSetupRepo =
+										c.content_type === 'action' &&
+										content?.kind === 'setup_repo' &&
+										!c.chosen_option;
 
-							if (isInlineEventType(c.content_type)) {
-								const Icon = inlineEventIcon(commentData);
-								return (
-									<div
-										key={c.id}
-										id={`comment-${c.id}`}
-										className="flex items-start gap-2.5 scroll-mt-20"
-										data-testid="comment-item"
-									>
-										<div className="w-[26px] h-[26px] flex items-center justify-center shrink-0 text-text-subtle">
-											<Icon className="w-3.5 h-3.5" />
-										</div>
-										<div className="flex-1 min-w-0">
-											<CommentRenderer
-												comment={commentData}
-												onChooseOption={(commentId, chosenId) =>
-													chooseOption.mutate({ commentId, chosen_id: chosenId })
-												}
-												companyId={companyId}
-												projectId={issue?.project_id ?? undefined}
-												projectSlug={issueProjectSlug}
-												issueId={issue?.id ?? undefined}
-												inline
-											/>
-										</div>
-									</div>
-								);
-							}
-
-							return (
-								<div
-									key={c.id}
-									id={`comment-${c.id}`}
-									className="flex gap-2.5 scroll-mt-20"
-									data-testid="comment-item"
-									{...(isPendingSetupRepo ? { 'data-setup-repo-anchor': '' } : {})}
-								>
-									<Avatar
-										initials={authorName.slice(0, 2)}
-										size="sm"
-										color={avatarColorFromString(authorName)}
-									/>
-									<div className="flex-1 min-w-0 rounded-md border border-border bg-bg-elevated overflow-hidden">
-										<div className="flex items-center gap-2 px-3 py-2 border-b border-border bg-bg-muted">
-											<span
-												className={`text-xs font-medium ${isAgent ? 'text-text' : 'text-text-muted'}`}
-												data-testid="comment-author"
+									if (isInlineEventType(c.content_type)) {
+										const Icon = inlineEventIcon(commentData);
+										return (
+											<div
+												id={`comment-${c.id}`}
+												className="flex items-start gap-2.5 scroll-mt-20 pb-4"
+												data-testid="comment-item"
 											>
-												{authorName}
-											</span>
-											<span className="text-[11px] text-text-subtle">
-												{new Date(c.created_at).toLocaleString()}
-											</span>
-										</div>
-										<div className="px-3 py-2.5">
-											<CommentRenderer
-												comment={commentData}
-												onChooseOption={(commentId, chosenId) =>
-													chooseOption.mutate({ commentId, chosen_id: chosenId })
-												}
-												companyId={companyId}
-												projectId={issue?.project_id ?? undefined}
-												projectSlug={issueProjectSlug}
-												issueId={issue?.id ?? undefined}
+												<div className="w-[26px] h-[26px] flex items-center justify-center shrink-0 text-text-subtle">
+													<Icon className="w-3.5 h-3.5" />
+												</div>
+												<div className="flex-1 min-w-0">
+													<CommentRenderer
+														comment={commentData}
+														onChooseOption={(commentId, chosenId) =>
+															chooseOption.mutate({ commentId, chosen_id: chosenId })
+														}
+														companyId={companyId}
+														projectId={issue?.project_id ?? undefined}
+														projectSlug={issueProjectSlug}
+														issueId={issue?.id ?? undefined}
+														inline
+													/>
+												</div>
+											</div>
+										);
+									}
+
+									return (
+										<div
+											id={`comment-${c.id}`}
+											className="flex gap-2.5 scroll-mt-20 pb-4"
+											data-testid="comment-item"
+											{...(isPendingSetupRepo ? { 'data-setup-repo-anchor': '' } : {})}
+										>
+											<Avatar
+												initials={authorName.slice(0, 2)}
+												size="sm"
+												color={avatarColorFromString(authorName)}
 											/>
+											<div className="flex-1 min-w-0 rounded-md border border-border bg-bg-elevated overflow-hidden">
+												<div className="flex items-center gap-2 px-3 py-2 border-b border-border bg-bg-muted">
+													<span
+														className={`text-xs font-medium ${isAgent ? 'text-text' : 'text-text-muted'}`}
+														data-testid="comment-author"
+													>
+														{authorName}
+													</span>
+													<span className="text-[11px] text-text-subtle">
+														{new Date(c.created_at).toLocaleString()}
+													</span>
+												</div>
+												<div className="px-3 py-2.5">
+													<CommentRenderer
+														comment={commentData}
+														onChooseOption={(commentId, chosenId) =>
+															chooseOption.mutate({ commentId, chosen_id: chosenId })
+														}
+														companyId={companyId}
+														projectId={issue?.project_id ?? undefined}
+														projectSlug={issueProjectSlug}
+														issueId={issue?.id ?? undefined}
+													/>
+												</div>
+											</div>
 										</div>
-									</div>
-								</div>
-							);
-						})}
+									);
+								}}
+							/>
+						)}
 					</div>
 
 					<form onSubmit={handleComment} className="flex flex-col gap-2">
@@ -832,9 +898,18 @@ function RunningAgentsLine({
 				key={l.id}
 				href={`#${targetId}`}
 				onClick={(e) => {
+					// Drive scroll via the hash so the issue page's hashchange handler
+					// can ask Virtuoso to mount and scroll to the row even when it
+					// isn't currently in the DOM. Falling back to scrollIntoView
+					// alone silently fails for off-screen virtualized rows.
 					e.preventDefault();
-					document.getElementById(targetId)?.scrollIntoView({ block: 'center' });
-					window.history.replaceState(null, '', `#${targetId}`);
+					const next = `#${targetId}`;
+					if (window.location.hash === next) {
+						window.dispatchEvent(new HashChangeEvent('hashchange'));
+					} else {
+						window.history.pushState(null, '', next);
+						window.dispatchEvent(new HashChangeEvent('hashchange'));
+					}
 				}}
 				className="text-accent-blue-text font-medium hover:underline"
 			>

--- a/tests/e2e/issue-comments.spec.ts
+++ b/tests/e2e/issue-comments.spec.ts
@@ -280,4 +280,57 @@ test.describe('Issue Comments', () => {
 		await expect(header).toHaveClass(/bg-bg-muted/);
 		await expect(header.getByTestId('comment-author')).toBeVisible();
 	});
+
+	test('virtualizes a large comment thread and scrolls to deep-link target', async ({ page }) => {
+		test.setTimeout(60_000);
+		await authenticate(page);
+		const { company, issue, headers } = await createProjectAndIssue(page);
+
+		const TOTAL = 120;
+		const created: { id: string; index: number }[] = [];
+		// Seed comments in parallel batches to keep the setup fast.
+		const BATCH = 12;
+		for (let start = 0; start < TOTAL; start += BATCH) {
+			const batch = Array.from({ length: Math.min(BATCH, TOTAL - start) }, (_, i) => start + i);
+			const results = await Promise.all(
+				batch.map((i) =>
+					page.request.post(`/api/companies/${company.id}/issues/${issue.id}/comments`, {
+						headers,
+						data: { content_type: 'text', content: { text: `seeded-comment-${i}` } },
+					}),
+				),
+			);
+			for (const [k, res] of results.entries()) {
+				const json = (await res.json()) as { data: { id: string } };
+				created.push({ id: json.data.id, index: batch[k] });
+			}
+		}
+
+		await page.goto(`/companies/${company.slug}/issues/${issue.id}`);
+		await waitForPageLoad(page);
+
+		// Wait for at least the first comment to render so we know the query resolved.
+		const items = page.getByTestId('comment-item');
+		await expect(items.first()).toBeVisible({ timeout: 20_000 });
+		await expect(page.getByText('seeded-comment-0')).toBeVisible({ timeout: 20_000 });
+
+		// Virtualization: only a window of rows is mounted at first paint —
+		// the total in-DOM count is well below TOTAL, and a late-thread row
+		// is not yet rendered.
+		const initialCount = await items.count();
+		expect(initialCount).toBeGreaterThan(0);
+		expect(initialCount).toBeLessThan(TOTAL);
+		await expect(page.getByText(`seeded-comment-${TOTAL - 1}`)).toHaveCount(0);
+
+		// Hash deep-link to a comment that is past the initial viewport:
+		// Virtuoso must mount and scroll to it. We pick an index near the
+		// middle of the thread which lies outside the initial render window
+		// but is reliably reachable in a single scrollToIndex pass.
+		const target = created[Math.floor(TOTAL / 2)];
+		await page.goto(`/companies/${company.slug}/issues/${issue.id}#comment-${target.id}`);
+		await waitForPageLoad(page);
+		const anchored = page.locator(`#comment-${target.id}`);
+		await expect(anchored).toBeVisible({ timeout: 20_000 });
+		await expect(anchored).toContainText(`seeded-comment-${target.index}`);
+	});
 });


### PR DESCRIPTION
The issue detail page renders every comment, every markdown tree with its
mention queries, and every run-comment LogViewer up front, which makes pages
with many comments slow to load and freezes navigation. Wrap the list with
react-virtuoso (anchored to the actual <main> scroll container, not the
window) so off-screen rows stay unmounted, and gate the run-comment body
behind an IntersectionObserver-based LazyMount so its heartbeat-run and
log-tail queries only fire when the row is near the viewport.

Hash deep-links (`#comment-<id>`, `#setup-repo`) and the running-agents
inline-link both route through a shared scrollToIndex effect, which iterates
a few times to converge once Virtuoso has measured rows.

https://claude.ai/code/session_01P8kc3Hx7sE1NDu4sj6NRJb