### PR TITLE
feat: surface DeepSeek as the first AI provider option

### DIFF
--- a/packages/web/src/components/ai-provider-setup-modal.tsx
+++ b/packages/web/src/components/ai-provider-setup-modal.tsx
@@ -8,10 +8,10 @@ import { Button } from './ui/button';
 import { Input } from './ui/input';
 
 const PROVIDERS = [
+	AiProvider.DeepSeek,
 	AiProvider.Anthropic,
 	AiProvider.OpenAI,
 	AiProvider.Google,
-	AiProvider.DeepSeek,
 ] as const;
 
 export function AiProviderSetupModal() {

--- a/packages/web/src/components/ai-providers-section.tsx
+++ b/packages/web/src/components/ai-providers-section.tsx
@@ -17,10 +17,10 @@ import { Button } from './ui/button';
 import { Input } from './ui/input';
 
 const AI_PROVIDERS_ORDER: AiProvider[] = [
+	AiProvider.DeepSeek,
 	AiProvider.Anthropic,
 	AiProvider.OpenAI,
 	AiProvider.Google,
-	AiProvider.DeepSeek,
 ];
 
 export function AiProvidersSection() {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -34,7 +34,12 @@ export default defineConfig({
 		{
 			command: `bun run src/index.ts -- --port ${SERVER_PORT} --data-dir ${TEST_DATA_DIR} --connect-url http://localhost:${CONNECT_PORT} --master-key e2e-test-master-key-0123456789abcdef0123456789abcdef --reset`,
 			cwd: './packages/server',
-			port: SERVER_PORT,
+			// `Bun.serve` opens the port before `startup()` finishes registering
+			// routes, so a port-only check races against route mounting and the
+			// first /api/auth/token call sees Hono's default "404 Not Found".
+			// /api/status is only mounted inside startup, so polling it waits
+			// for full readiness.
+			url: `http://localhost:${SERVER_PORT}/api/status`,
 			reuseExistingServer: true,
 			env: {
 				SKIP_AI_KEY_VALIDATION: '1',

--- a/tests/e2e/ai-providers.spec.ts
+++ b/tests/e2e/ai-providers.spec.ts
@@ -220,9 +220,12 @@ test.describe('AI provider gate (post-master-key, pre-company)', () => {
 
 		await expect(page.getByRole('heading', { name: 'Welcome to Hezo' })).toBeHidden();
 
-		await page.getByRole('button', { name: 'Enter API key' }).first().click();
-		await page.locator('input[type="password"]').first().fill('sk-ant-gate-test-12345');
-		await page.getByRole('button', { name: 'Save' }).first().click();
+		const anthropicCard = page
+			.locator('div.border.border-border.rounded-radius-md.p-4', { hasText: 'Anthropic' })
+			.first();
+		await anthropicCard.getByRole('button', { name: 'Enter API key' }).click();
+		await anthropicCard.locator('input[type="password"]').fill('sk-ant-gate-test-12345');
+		await anthropicCard.getByRole('button', { name: 'Save' }).click();
 
 		await expect(page.getByRole('heading', { name: 'Set up an AI provider' })).toBeHidden({
 			timeout: 20000,


### PR DESCRIPTION
Move DeepSeek to the top of the provider lists rendered by the gate
modal and the settings section so it's the first card shown. Scope the
gate-modal e2e test's "first" lookups to the Anthropic card so it
remains correct regardless of array order.