### PR TITLE
Add z.ai as a supported AI provider

### DIFF
--- a/packages/server/migrations/001_initial_schema.sql
+++ b/packages/server/migrations/001_initial_schema.sql
@@ -67,7 +67,7 @@ CREATE TYPE invite_status AS ENUM ('pending', 'accepted', 'expired', 'revoked');
 CREATE TYPE agent_type_source AS ENUM ('builtin', 'custom', 'remote');
 CREATE TYPE company_type_source AS ENUM ('builtin', 'custom', 'marketplace');
 CREATE TYPE goal_status AS ENUM ('active', 'achieved', 'archived');
-CREATE TYPE ai_provider AS ENUM ('anthropic', 'openai', 'google', 'deepseek');
+CREATE TYPE ai_provider AS ENUM ('anthropic', 'openai', 'google', 'deepseek', 'z_ai');
 CREATE TYPE ai_auth_method AS ENUM ('api_key', 'subscription');
 
 -------------------------------------------------------------------------------

--- a/packages/server/src/test/__tests__/ai-providers.test.ts
+++ b/packages/server/src/test/__tests__/ai-providers.test.ts
@@ -669,3 +669,47 @@ describe('AI providers DeepSeek', () => {
 		expect(body.data.providers).toContain('deepseek');
 	});
 });
+
+describe('AI providers z.ai', () => {
+	beforeAll(async () => {
+		await db.query('DELETE FROM ai_provider_configs');
+	});
+
+	it('accepts a z.ai API key (no key prefix constraint)', async () => {
+		const res = await app.request('/api/ai-providers', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				provider: 'z_ai',
+				api_key: 'zai-no-prefix-required',
+				label: 'zai-primary',
+			}),
+		});
+		expect(res.status).toBe(201);
+		const list = await app.request('/api/ai-providers', { headers: authHeader(token) });
+		const rows = (await list.json()).data as Array<{ provider: string }>;
+		expect(rows.some((r) => r.provider === 'z_ai')).toBe(true);
+	});
+
+	it('rejects subscription auth for z.ai (API key only)', async () => {
+		const res = await app.request('/api/ai-providers', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				provider: 'z_ai',
+				api_key: JSON.stringify({ tokens: { refresh_token: 'rt' } }),
+				auth_method: 'subscription',
+			}),
+		});
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.error.code).toBe('UNSUPPORTED_AUTH_METHOD');
+	});
+
+	it('reports z_ai under the configured providers status', async () => {
+		const res = await app.request('/api/ai-providers/status', { headers: authHeader(token) });
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data.providers).toContain('z_ai');
+	});
+});

--- a/packages/server/src/test/__tests__/runtime-resolver.test.ts
+++ b/packages/server/src/test/__tests__/runtime-resolver.test.ts
@@ -132,4 +132,21 @@ describe('resolveRuntimeForIssue', () => {
 			provider: AiProvider.DeepSeek,
 		});
 	});
+
+	it('resolves z.ai to the ClaudeCode runtime', async () => {
+		await storeAiProviderKey(
+			db,
+			masterKeyManager,
+			AiProvider.ZAi,
+			'zai-key',
+			AiAuthMethod.ApiKey,
+			'zai-primary',
+		);
+
+		expect(await resolveRuntimeForIssue(db, AgentRuntime.ClaudeCode)).toEqual({
+			runtime: AgentRuntime.ClaudeCode,
+			provider: AiProvider.ZAi,
+		});
+		expect(await resolveRuntimeForIssue(db, AgentRuntime.Codex)).toBeNull();
+	});
 });

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -359,6 +359,7 @@ export const AiProvider = {
 	OpenAI: 'openai',
 	Google: 'google',
 	DeepSeek: 'deepseek',
+	ZAi: 'z_ai',
 } as const;
 export type AiProvider = (typeof AiProvider)[keyof typeof AiProvider];
 
@@ -411,6 +412,17 @@ export const PROVIDER_RUNTIME_ADAPTERS: Record<AiProvider, ProviderRuntimeAdapte
 			ANTHROPIC_DEFAULT_SONNET_MODEL: 'deepseek-v4-pro',
 			ANTHROPIC_DEFAULT_HAIKU_MODEL: 'deepseek-v4-flash',
 			CLAUDE_CODE_SUBAGENT_MODEL: 'deepseek-v4-flash',
+		},
+		credentialEnvByAuthMethod: { [AiAuthMethod.ApiKey]: 'ANTHROPIC_AUTH_TOKEN' },
+	},
+	[AiProvider.ZAi]: {
+		runtime: AgentRuntime.ClaudeCode,
+		staticEnv: {
+			ANTHROPIC_BASE_URL: 'https://api.z.ai/api/anthropic',
+			ANTHROPIC_DEFAULT_OPUS_MODEL: 'GLM-4.7',
+			ANTHROPIC_DEFAULT_SONNET_MODEL: 'GLM-4.7',
+			ANTHROPIC_DEFAULT_HAIKU_MODEL: 'GLM-4.5-Air',
+			CLAUDE_CODE_SUBAGENT_MODEL: 'GLM-4.5-Air',
 		},
 		credentialEnvByAuthMethod: { [AiAuthMethod.ApiKey]: 'ANTHROPIC_AUTH_TOKEN' },
 	},
@@ -544,6 +556,15 @@ export const AI_PROVIDER_INFO: Record<AiProvider, AiProviderInfo> = {
 		keyPlaceholder: 'sk-...',
 		verifyEndpoint: {
 			url: 'https://api.deepseek.com/models',
+			headers: (apiKey) => ({ Authorization: `Bearer ${apiKey}` }),
+		},
+	},
+	[AiProvider.ZAi]: {
+		name: 'z.ai',
+		runtimeLabel: 'Claude Code',
+		keyPlaceholder: 'z.ai api key',
+		verifyEndpoint: {
+			url: 'https://api.z.ai/api/paas/v4/models',
 			headers: (apiKey) => ({ Authorization: `Bearer ${apiKey}` }),
 		},
 	},

--- a/packages/web/src/components/ai-provider-setup-modal.tsx
+++ b/packages/web/src/components/ai-provider-setup-modal.tsx
@@ -10,6 +10,7 @@ import { Input } from './ui/input';
 
 const PROVIDERS = [
 	AiProvider.DeepSeek,
+	AiProvider.ZAi,
 	AiProvider.Anthropic,
 	AiProvider.OpenAI,
 	AiProvider.Google,

--- a/packages/web/src/components/ai-providers-section.tsx
+++ b/packages/web/src/components/ai-providers-section.tsx
@@ -18,6 +18,7 @@ import { Input } from './ui/input';
 
 const AI_PROVIDERS_ORDER: AiProvider[] = [
 	AiProvider.DeepSeek,
+	AiProvider.ZAi,
 	AiProvider.Anthropic,
 	AiProvider.OpenAI,
 	AiProvider.Google,


### PR DESCRIPTION
## Summary
This PR adds support for z.ai as a new AI provider in the system. z.ai is integrated as a Claude Code runtime provider that uses the Anthropic API with z.ai's custom endpoint and model mappings.

## Key Changes
- **Type definitions**: Added `z_ai` to the `AiProvider` enum in `packages/shared/src/types/common.ts`
- **Provider configuration**: Registered z.ai in `PROVIDER_RUNTIME_ADAPTERS` with:
  - Custom Anthropic API endpoint (`https://api.z.ai/api/anthropic`)
  - Model mappings (GLM-4.7 for Opus/Sonnet, GLM-4.5-Air for Haiku)
  - API key-based authentication
- **Provider metadata**: Added z.ai to `AI_PROVIDER_INFO` with verification endpoint and display information
- **Database schema**: Updated the `ai_provider` enum type to include `z_ai`
- **UI integration**: Added z.ai to provider selection lists in both setup modal and providers section
- **Tests**: Added comprehensive test coverage for z.ai including:
  - API key acceptance without prefix constraints
  - Rejection of subscription auth method (API key only)
  - Provider status reporting
  - Runtime resolution for ClaudeCode

## Implementation Details
- z.ai uses the ClaudeCode runtime, similar to Anthropic but with custom endpoint and model configurations
- Authentication is API key only; subscription-based auth is explicitly rejected
- The provider integrates seamlessly with the existing provider framework without requiring new authentication methods

https://claude.ai/code/session_01RpfHqc19fABo3XBSz9cou5