### PR TITLE
feat: comment attachments and agent run-failure handling

### DIFF
--- a/packages/server/migrations/001_initial_schema.sql
+++ b/packages/server/migrations/001_initial_schema.sql
@@ -767,8 +767,7 @@ CREATE UNIQUE INDEX ai_provider_configs_default_per_provider
 CREATE TABLE assets (
     id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     team_id               UUID NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
-    provider              TEXT NOT NULL DEFAULT 'local_disk',
-    object_key            TEXT NOT NULL,
+    project_id            UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
     content_type          TEXT NOT NULL,
     byte_size             BIGINT NOT NULL,
     sha256                TEXT NOT NULL,
@@ -777,7 +776,7 @@ CREATE TABLE assets (
     created_at            TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
-CREATE INDEX idx_assets_team ON assets(team_id);
+CREATE INDEX idx_assets_project ON assets(project_id);
 
 CREATE TABLE issue_attachments (
     id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -789,6 +788,17 @@ CREATE TABLE issue_attachments (
 );
 
 CREATE INDEX idx_issue_attachments_issue ON issue_attachments(issue_id);
+
+CREATE TABLE comment_attachments (
+    id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    comment_id UUID NOT NULL REFERENCES issue_comments(id) ON DELETE CASCADE,
+    asset_id   UUID NOT NULL REFERENCES assets(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    UNIQUE (comment_id, asset_id)
+);
+
+CREATE INDEX idx_comment_attachments_comment ON comment_attachments(comment_id);
 
 -------------------------------------------------------------------------------
 -- SKILLS

--- a/packages/server/src/lib/asset-urls.ts
+++ b/packages/server/src/lib/asset-urls.ts
@@ -1,0 +1,40 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { ATTACHMENT_SIGNED_URL_TTL_SECONDS } from '@hezo/shared';
+import { deriveKey } from '../crypto/encryption';
+import type { MasterKeyManager } from '../crypto/master-key';
+
+const KEY_PURPOSE = 'asset-url';
+
+async function getSigningKey(masterKeyManager: MasterKeyManager): Promise<Buffer> {
+	const masterKeyHex = masterKeyManager.getMasterKeyHex();
+	if (!masterKeyHex) throw new Error('Master key not available');
+	return deriveKey(masterKeyHex, KEY_PURPOSE);
+}
+
+export async function signAssetUrl(
+	assetId: string,
+	masterKeyManager: MasterKeyManager,
+	ttlSeconds: number = ATTACHMENT_SIGNED_URL_TTL_SECONDS,
+): Promise<string> {
+	const exp = Math.floor(Date.now() / 1000) + ttlSeconds;
+	const key = await getSigningKey(masterKeyManager);
+	const sig = createHmac('sha256', key).update(`${assetId}|${exp}`).digest('base64url');
+	return `/api/assets/${assetId}?exp=${exp}&sig=${sig}`;
+}
+
+export async function verifyAssetUrl(
+	assetId: string,
+	exp: number,
+	sig: string,
+	masterKeyManager: MasterKeyManager,
+): Promise<boolean> {
+	if (!Number.isFinite(exp) || Math.floor(Date.now() / 1000) > exp) return false;
+	const key = await getSigningKey(masterKeyManager);
+	const expected = createHmac('sha256', key).update(`${assetId}|${exp}`).digest('base64url');
+	if (sig.length !== expected.length) return false;
+	try {
+		return timingSafeEqual(Buffer.from(sig), Buffer.from(expected));
+	} catch {
+		return false;
+	}
+}

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -35,6 +35,7 @@ import { resolveActorMemberId, resolveIssueId } from '../lib/resolve';
 import type { AuthInfo } from '../lib/types';
 import { logger } from '../logger';
 import { resolveProjectIssuePrefix } from '../routes/projects';
+import { loadAgentAttachmentsForComments } from '../services/agent-runner';
 import {
 	AgentSystemPromptError,
 	fetchAgentSystemPromptForBatch,
@@ -1074,13 +1075,16 @@ export function registerTools(
 				args.issue_id as string,
 				viewerMemberId,
 			);
-			const withReactions: Record<string, unknown>[] = r.rows.map((row) => ({
+			const commentIds = r.rows.map((row) => row.id as string);
+			const attachmentsByComment = await loadAgentAttachmentsForComments(db, commentIds);
+			const enriched: Record<string, unknown>[] = r.rows.map((row) => ({
 				...row,
 				reactions: reactionsByComment.get(row.id as string) ?? [],
+				attachments: attachmentsByComment.get(row.id as string) ?? [],
 			}));
 			const max = args.excerpt_chars as number | undefined;
-			if (max == null) return withReactions;
-			return withReactions.map((row) => {
+			if (max == null) return enriched;
+			return enriched.map((row) => {
 				if (row.content_type !== CommentContentType.Text) return row;
 				const content = row.content as { text?: string } | null;
 				const text = content?.text;

--- a/packages/server/src/routes/assets.ts
+++ b/packages/server/src/routes/assets.ts
@@ -1,0 +1,175 @@
+import { randomUUID } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import {
+	ATTACHMENT_EXTENSIONS,
+	ATTACHMENT_MAX_BYTES,
+	isAllowedAttachmentExtension,
+	isAllowedAttachmentMime,
+} from '@hezo/shared';
+import { Hono } from 'hono';
+import { bodyLimit } from 'hono/body-limit';
+import { signAssetUrl, verifyAssetUrl } from '../lib/asset-urls';
+import { resolveActorMemberId, resolveIssueId } from '../lib/resolve';
+import { err, ok } from '../lib/response';
+import type { Env } from '../lib/types';
+import { logger } from '../logger';
+import { requireTeamAccess } from '../middleware/auth';
+import { AttachmentTooLargeError, writeAsset } from '../services/asset-storage';
+import { getAssetPath } from '../services/workspace';
+
+const log = logger.child('routes');
+
+export const assetsRoutes = new Hono<Env>();
+
+assetsRoutes.post(
+	'/teams/:teamId/issues/:issueId/assets',
+	bodyLimit({
+		maxSize: ATTACHMENT_MAX_BYTES,
+		onError: (c) => err(c, 'TOO_LARGE', 'Attachment exceeds 10 MB', 400),
+	}),
+	async (c) => {
+		const access = await requireTeamAccess(c);
+		if (access instanceof Response) return access;
+
+		const db = c.get('db');
+		const { teamId } = access;
+		const issueId = await resolveIssueId(db, teamId, c.req.param('issueId'));
+		if (!issueId) return err(c, 'NOT_FOUND', 'Issue not found', 404);
+
+		const issueLocator = await db.query<{
+			team_slug: string;
+			project_id: string;
+			project_slug: string;
+		}>(
+			`SELECT t.slug AS team_slug, p.id AS project_id, p.slug AS project_slug
+			 FROM issues i
+			 JOIN teams t ON t.id = i.team_id
+			 JOIN projects p ON p.id = i.project_id
+			 WHERE i.id = $1 AND i.team_id = $2`,
+			[issueId, teamId],
+		);
+		if (issueLocator.rows.length === 0) {
+			return err(c, 'NOT_FOUND', 'Issue not found', 404);
+		}
+		const {
+			team_slug: teamSlug,
+			project_id: projectId,
+			project_slug: projectSlug,
+		} = issueLocator.rows[0];
+
+		let form: Awaited<ReturnType<typeof c.req.parseBody>>;
+		try {
+			form = await c.req.parseBody({ all: false });
+		} catch (e) {
+			log.error('asset upload parseBody failed:', e);
+			return err(c, 'INVALID_REQUEST', 'Invalid multipart body', 400);
+		}
+		const file = form.file;
+		if (!(file instanceof Blob) || !('name' in file) || typeof file.name !== 'string') {
+			return err(c, 'INVALID_REQUEST', 'Missing file field', 400);
+		}
+		const filename = (file as File).name;
+
+		if (!isAllowedAttachmentExtension(filename)) {
+			return err(c, 'INVALID_ATTACHMENT', 'Unsupported file extension', 400);
+		}
+		const contentType = file.type || 'application/octet-stream';
+		if (!isAllowedAttachmentMime(contentType)) {
+			return err(c, 'INVALID_ATTACHMENT', `Unsupported content type: ${contentType}`, 400);
+		}
+		if (file.size > ATTACHMENT_MAX_BYTES) {
+			return err(c, 'TOO_LARGE', 'Attachment exceeds 10 MB', 400);
+		}
+
+		const assetId = randomUUID();
+		const dataDir = c.get('dataDir');
+		let byteSize: number;
+		let sha256: string;
+		try {
+			const result = await writeAsset(dataDir, teamSlug, projectSlug, assetId, file);
+			byteSize = result.byteSize;
+			sha256 = result.sha256;
+		} catch (e) {
+			if (e instanceof AttachmentTooLargeError) {
+				return err(c, 'TOO_LARGE', 'Attachment exceeds 10 MB', 400);
+			}
+			log.error('Failed to write asset to disk:', e);
+			return err(c, 'INTERNAL_ERROR', 'Failed to store attachment', 500);
+		}
+
+		const uploadedBy = await resolveActorMemberId(db, c.get('auth'), teamId);
+		const inserted = await db.query<{
+			id: string;
+			content_type: string;
+			byte_size: number;
+			original_filename: string;
+		}>(
+			`INSERT INTO assets (id, team_id, project_id, content_type, byte_size, sha256, original_filename, uploaded_by_member_id)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+			 RETURNING id, content_type, byte_size, original_filename`,
+			[assetId, teamId, projectId, contentType, byteSize, sha256, filename, uploadedBy],
+		);
+
+		const url = await signAssetUrl(assetId, c.get('masterKeyManager'));
+		return ok(c, { ...inserted.rows[0], url }, 201);
+	},
+);
+
+export const publicAssetsRoutes = new Hono<Env>();
+
+publicAssetsRoutes.get('/api/assets/:assetId', async (c) => {
+	const assetId = c.req.param('assetId');
+	const expRaw = c.req.query('exp');
+	const sig = c.req.query('sig');
+	if (!expRaw || !sig) {
+		return err(c, 'UNAUTHORIZED', 'Missing signature', 401);
+	}
+	const exp = Number.parseInt(expRaw, 10);
+	const masterKeyManager = c.get('masterKeyManager');
+	const valid = await verifyAssetUrl(assetId, exp, sig, masterKeyManager);
+	if (!valid) {
+		return err(c, 'UNAUTHORIZED', 'Invalid or expired signature', 401);
+	}
+
+	const row = await c.get('db').query<{
+		content_type: string;
+		original_filename: string;
+		byte_size: number;
+		team_slug: string;
+		project_slug: string;
+	}>(
+		`SELECT a.content_type, a.original_filename, a.byte_size,
+		        t.slug AS team_slug, p.slug AS project_slug
+		 FROM assets a
+		 JOIN teams t ON t.id = a.team_id
+		 JOIN projects p ON p.id = a.project_id
+		 WHERE a.id = $1`,
+		[assetId],
+	);
+	if (row.rows.length === 0) {
+		return err(c, 'NOT_FOUND', 'Asset not found', 404);
+	}
+	const { content_type, original_filename, team_slug, project_slug } = row.rows[0];
+
+	const diskPath = getAssetPath(c.get('dataDir'), team_slug, project_slug, assetId);
+	let buf: Buffer;
+	try {
+		buf = await readFile(diskPath);
+	} catch (e) {
+		log.error(`Failed to read asset ${assetId} from disk:`, e);
+		return err(c, 'NOT_FOUND', 'Asset file missing', 404);
+	}
+
+	const filenameSafe = original_filename.replace(/"/g, '');
+	const ab = new ArrayBuffer(buf.byteLength);
+	new Uint8Array(ab).set(buf);
+	return c.body(new Uint8Array(ab), 200, {
+		'Content-Type': content_type,
+		'Content-Length': String(buf.byteLength),
+		'Content-Disposition': `inline; filename="${filenameSafe}"`,
+		'Cache-Control': 'private, max-age=3600',
+	});
+});
+
+// Re-export the allowed extensions for tests
+export { ATTACHMENT_EXTENSIONS };

--- a/packages/server/src/routes/comments.ts
+++ b/packages/server/src/routes/comments.ts
@@ -1,6 +1,7 @@
 import { AuthType, CommentContentType, GrantScope, WakeupSource, wsRoom } from '@hezo/shared';
 import { Hono } from 'hono';
 import { encrypt } from '../crypto/encryption';
+import { signAssetUrl } from '../lib/asset-urls';
 import { broadcastChange } from '../lib/broadcast';
 import { validateCredentialValue } from '../lib/credential-validator';
 import { resolveActorMemberId, resolveIssueId } from '../lib/resolve';
@@ -50,6 +51,16 @@ commentsRoutes.get('/teams/:teamId/issues/:issueId/comments', async (c) => {
 	const reactionsByComment = await loadReactionsForIssue(db, issueId, viewerMemberId);
 	for (const comment of result.rows as Record<string, unknown>[]) {
 		comment.reactions = reactionsByComment.get(comment.id as string) ?? [];
+	}
+
+	const commentIds = (result.rows as Array<{ id: string }>).map((r) => r.id);
+	const attachmentsByComment = await loadAttachmentsForComments(
+		db,
+		commentIds,
+		c.get('masterKeyManager'),
+	);
+	for (const comment of result.rows as Record<string, unknown>[]) {
+		comment.attachments = attachmentsByComment.get(comment.id as string) ?? [];
 	}
 
 	if (includeToolCalls) {
@@ -168,10 +179,40 @@ commentsRoutes.post('/teams/:teamId/issues/:issueId/comments', async (c) => {
 		effort?: string;
 		wake_assignee?: boolean;
 		parent_comment_id?: string | null;
+		attachment_ids?: string[];
 	}>();
 
-	if (!body.content) {
+	const attachmentIds = Array.isArray(body.attachment_ids) ? body.attachment_ids : [];
+	const contentType = body.content_type ?? CommentContentType.Text;
+	const isText = contentType === CommentContentType.Text;
+	if (isText) {
+		const text =
+			typeof body.content === 'string'
+				? body.content
+				: typeof body.content === 'object' && body.content !== null
+					? ((body.content as Record<string, unknown>).text as string | undefined)
+					: undefined;
+		if ((typeof text !== 'string' || text.length === 0) && attachmentIds.length === 0) {
+			return err(c, 'INVALID_REQUEST', 'content or attachment_ids is required', 400);
+		}
+	} else if (!body.content) {
 		return err(c, 'INVALID_REQUEST', 'content is required', 400);
+	}
+	if (attachmentIds.length > 0) {
+		const matched = await db.query<{ id: string }>(
+			`SELECT id FROM assets
+			 WHERE id = ANY($1::uuid[])
+			   AND project_id = (SELECT project_id FROM issues WHERE id = $2)`,
+			[attachmentIds, issueId],
+		);
+		if (matched.rows.length !== attachmentIds.length) {
+			return err(
+				c,
+				'INVALID_REQUEST',
+				'One or more attachments do not belong to this project',
+				400,
+			);
+		}
 	}
 
 	// Optional per-comment effort override. Board users set this to dial up/down
@@ -202,18 +243,35 @@ commentsRoutes.post('/teams/:teamId/issues/:issueId/comments', async (c) => {
 	// regardless of the body field.
 	const wakeAssignee = auth.type === AuthType.Board && body.wake_assignee === true;
 
-	const result = await db.query<{ id: string }>(
-		`INSERT INTO issue_comments (issue_id, author_member_id, parent_comment_id, content_type, content)
+	await db.query('BEGIN');
+	let result: Awaited<ReturnType<typeof db.query<{ id: string }>>>;
+	try {
+		result = await db.query<{ id: string }>(
+			`INSERT INTO issue_comments (issue_id, author_member_id, parent_comment_id, content_type, content)
      VALUES ($1, $2, $3, $4::comment_content_type, $5::jsonb)
      RETURNING *`,
-		[
-			issueId,
-			authorMemberId,
-			parentCommentId,
-			body.content_type ?? CommentContentType.Text,
-			JSON.stringify(body.content),
-		],
-	);
+			[
+				issueId,
+				authorMemberId,
+				parentCommentId,
+				body.content_type ?? CommentContentType.Text,
+				JSON.stringify(body.content),
+			],
+		);
+
+		if (attachmentIds.length > 0) {
+			const newCommentId = result.rows[0].id;
+			await db.query(
+				`INSERT INTO comment_attachments (comment_id, asset_id)
+				 SELECT $1::uuid, asset FROM UNNEST($2::uuid[]) AS asset`,
+				[newCommentId, attachmentIds],
+			);
+		}
+		await db.query('COMMIT');
+	} catch (e) {
+		await db.query('ROLLBACK');
+		throw e;
+	}
 
 	await fireCommentWakeups({
 		db,
@@ -243,7 +301,20 @@ commentsRoutes.post('/teams/:teamId/issues/:issueId/comments', async (c) => {
 		'INSERT',
 		result.rows[0] as Record<string, unknown>,
 	);
-	return ok(c, result.rows[0], 201);
+	if (attachmentIds.length > 0) {
+		broadcastChange(c, wsRoom.team(teamId), 'comment_attachments', 'INSERT', {
+			comment_id: result.rows[0].id,
+			asset_ids: attachmentIds,
+		});
+	}
+
+	const masterKeyManager = c.get('masterKeyManager');
+	const attachments = await loadAttachmentsForComments(db, [result.rows[0].id], masterKeyManager);
+	const created = {
+		...(result.rows[0] as Record<string, unknown>),
+		attachments: attachments.get(result.rows[0].id) ?? [],
+	};
+	return ok(c, created, 201);
 });
 
 commentsRoutes.post('/teams/:teamId/issues/:issueId/comments/:commentId/choose', async (c) => {
@@ -474,6 +545,64 @@ commentsRoutes.post(
 		return ok(c, { secret_id: secretId, comment_id: commentId });
 	},
 );
+
+interface CommentAttachmentRow {
+	comment_id: string;
+	id: string;
+	content_type: string;
+	byte_size: number;
+	original_filename: string;
+}
+
+async function loadAttachmentsForComments(
+	db: import('@electric-sql/pglite').PGlite,
+	commentIds: string[],
+	masterKeyManager: import('../crypto/master-key').MasterKeyManager,
+): Promise<
+	Map<
+		string,
+		Array<{
+			id: string;
+			content_type: string;
+			byte_size: number;
+			original_filename: string;
+			url: string;
+		}>
+	>
+> {
+	if (commentIds.length === 0) return new Map();
+	const rows = await db.query<CommentAttachmentRow>(
+		`SELECT ca.comment_id, a.id, a.content_type, a.byte_size, a.original_filename
+		 FROM comment_attachments ca
+		 JOIN assets a ON a.id = ca.asset_id
+		 WHERE ca.comment_id = ANY($1::uuid[])
+		 ORDER BY ca.created_at ASC`,
+		[commentIds],
+	);
+	const out = new Map<
+		string,
+		Array<{
+			id: string;
+			content_type: string;
+			byte_size: number;
+			original_filename: string;
+			url: string;
+		}>
+	>();
+	for (const row of rows.rows) {
+		const url = await signAssetUrl(row.id, masterKeyManager);
+		const list = out.get(row.comment_id) ?? [];
+		list.push({
+			id: row.id,
+			content_type: row.content_type,
+			byte_size: row.byte_size,
+			original_filename: row.original_filename,
+			url,
+		});
+		out.set(row.comment_id, list);
+	}
+	return out;
+}
 
 function pickSecretCategory(kind: string): string {
 	switch (kind) {

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -987,6 +987,50 @@ export function formatReactionLine(groups: ReactionGroup[] | undefined): string 
 	return `Reactions: ${parts.join(' · ')}`;
 }
 
+export interface AgentAttachment {
+	id: string;
+	original_filename: string;
+	content_type: string;
+	byte_size: number;
+	path: string;
+}
+
+export const AGENT_ATTACHMENT_DIR = '/workspace/.hezo/assets';
+
+export async function loadAgentAttachmentsForComments(
+	db: PGlite,
+	commentIds: string[],
+): Promise<Map<string, AgentAttachment[]>> {
+	if (commentIds.length === 0) return new Map();
+	const rows = await db.query<{
+		comment_id: string;
+		id: string;
+		original_filename: string;
+		content_type: string;
+		byte_size: number;
+	}>(
+		`SELECT ca.comment_id, a.id, a.original_filename, a.content_type, a.byte_size
+		 FROM comment_attachments ca
+		 JOIN assets a ON a.id = ca.asset_id
+		 WHERE ca.comment_id = ANY($1::uuid[])
+		 ORDER BY ca.created_at ASC`,
+		[commentIds],
+	);
+	const out = new Map<string, AgentAttachment[]>();
+	for (const row of rows.rows) {
+		const list = out.get(row.comment_id) ?? [];
+		list.push({
+			id: row.id,
+			original_filename: row.original_filename,
+			content_type: row.content_type,
+			byte_size: row.byte_size,
+			path: `${AGENT_ATTACHMENT_DIR}/${row.id}`,
+		});
+		out.set(row.comment_id, list);
+	}
+	return out;
+}
+
 function extractCommentText(content: unknown): string {
 	if (!content || typeof content !== 'object') return '';
 	const obj = content as Record<string, unknown>;
@@ -1286,6 +1330,9 @@ export async function buildCoachReviewPrompt(
 		[teamId, issue.id],
 	);
 
+	const commentIds = comments.rows.map((c) => c.id);
+	const attachmentsByComment = await loadAgentAttachmentsForComments(db, commentIds);
+
 	const commentLog = comments.rows
 		.map((c) => {
 			const text =
@@ -1294,7 +1341,12 @@ export async function buildCoachReviewPrompt(
 					: JSON.stringify(c.content);
 			const base = `[${c.created_at}] ${c.author_name} (${c.content_type}): ${text}`;
 			const reactionLine = formatReactionLine(reactionsByComment.get(c.id));
-			return reactionLine ? `${base}\n${reactionLine}` : base;
+			const attachmentLines = (attachmentsByComment.get(c.id) ?? []).map(
+				(a) =>
+					`  attachment: ${a.original_filename} (${a.content_type}, ${a.byte_size} bytes) → ${a.path}`,
+			);
+			const extra = [reactionLine, ...attachmentLines].filter((l): l is string => l !== null);
+			return extra.length > 0 ? `${base}\n${extra.join('\n')}` : base;
 		})
 		.join('\n');
 

--- a/packages/server/src/services/asset-storage.ts
+++ b/packages/server/src/services/asset-storage.ts
@@ -1,0 +1,68 @@
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync } from 'node:fs';
+import { unlink, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { ATTACHMENT_MAX_BYTES } from '@hezo/shared';
+import { getAssetPath, getAssetsPath } from './workspace';
+
+export interface WriteAssetResult {
+	byteSize: number;
+	sha256: string;
+}
+
+export class AttachmentTooLargeError extends Error {
+	constructor() {
+		super(`Attachment exceeds ${ATTACHMENT_MAX_BYTES} bytes`);
+	}
+}
+
+export async function writeAsset(
+	dataDir: string,
+	teamSlug: string,
+	projectSlug: string,
+	assetId: string,
+	source: Blob,
+): Promise<WriteAssetResult> {
+	if (source.size > ATTACHMENT_MAX_BYTES) {
+		throw new AttachmentTooLargeError();
+	}
+
+	const buf = Buffer.from(await source.arrayBuffer());
+	if (buf.byteLength > ATTACHMENT_MAX_BYTES) {
+		throw new AttachmentTooLargeError();
+	}
+
+	const sha256 = createHash('sha256').update(buf).digest('hex');
+	const diskPath = getAssetPath(dataDir, teamSlug, projectSlug, assetId);
+	mkdirSync(dirname(diskPath), { recursive: true });
+
+	try {
+		await writeFile(diskPath, buf);
+	} catch (err) {
+		await unlink(diskPath).catch(() => {});
+		throw err;
+	}
+
+	return { byteSize: buf.byteLength, sha256 };
+}
+
+export async function deleteAsset(
+	dataDir: string,
+	teamSlug: string,
+	projectSlug: string,
+	assetId: string,
+): Promise<void> {
+	const diskPath = getAssetPath(dataDir, teamSlug, projectSlug, assetId);
+	await unlink(diskPath).catch(() => {});
+}
+
+export function assetExists(
+	dataDir: string,
+	teamSlug: string,
+	projectSlug: string,
+	assetId: string,
+): boolean {
+	return existsSync(getAssetPath(dataDir, teamSlug, projectSlug, assetId));
+}
+
+export { getAssetPath, getAssetsPath };

--- a/packages/server/src/services/containers.ts
+++ b/packages/server/src/services/containers.ts
@@ -153,11 +153,13 @@ export async function provisionContainer(
 		const workspacePath = join(projectDir, 'workspace');
 		const worktreesPath = join(projectDir, 'worktrees');
 		const previewsPath = join(projectDir, '.previews');
+		const assetsPath = join(projectDir, 'assets');
 
 		const binds = [
 			`${workspacePath}:/workspace:rw`,
 			`${worktreesPath}:/worktrees:rw`,
 			`${previewsPath}:/workspace/.previews:rw`,
+			`${assetsPath}:/workspace/.hezo/assets:ro`,
 		];
 		if (deps.egressCAPath) {
 			binds.push(`${deps.egressCAPath}:${CONTAINER_CA_PATH}:ro`);

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -5,6 +5,7 @@ import {
 	AgentRuntimeStatus,
 	type AiProvider,
 	COACH_AGENT_SLUG,
+	CommentContentType,
 	ContainerStatus,
 	HeartbeatRunStatus,
 	IssuePriority,
@@ -41,6 +42,13 @@ import { createWakeup } from './wakeup';
 import type { WebSocketManager } from './ws';
 
 const log = logger.child('job-manager');
+
+const MAX_CONSECUTIVE_FAILURE_PINGS = 3;
+const FAILURE_PING_ERROR_MAX_LEN = 500;
+const FAILURE_TERMINAL_STATUSES: HeartbeatRunStatus[] = [
+	HeartbeatRunStatus.Failed,
+	HeartbeatRunStatus.TimedOut,
+];
 
 const cronLog = {
 	trace: (msg: unknown) => log.debug(msg),
@@ -934,6 +942,10 @@ export class JobManager {
 			);
 		}
 
+		if (!result.success && result.heartbeatRunId) {
+			await this.postFailurePing(memberId, agentSlug, issueId, teamId, result.heartbeatRunId);
+		}
+
 		if (
 			agentSlug === COACH_AGENT_SLUG &&
 			result.success &&
@@ -971,6 +983,88 @@ export class JobManager {
 		}
 
 		await this.chainNextIssueWakeup(memberId, issueId, teamId);
+	}
+
+	private async postFailurePing(
+		memberId: string,
+		agentSlug: string,
+		issueId: string,
+		teamId: string,
+		runId: string,
+	): Promise<void> {
+		const { db } = this.deps;
+
+		const runRow = await db.query<{ status: HeartbeatRunStatus; error: string | null }>(
+			'SELECT status, error FROM heartbeat_runs WHERE id = $1',
+			[runId],
+		);
+		const run = runRow.rows[0];
+		if (!run || !FAILURE_TERMINAL_STATUSES.includes(run.status)) return;
+
+		const recent = await db.query<{ status: HeartbeatRunStatus }>(
+			`SELECT status FROM heartbeat_runs
+			 WHERE member_id = $1 AND issue_id = $2 AND status IN ($3::heartbeat_run_status, $4::heartbeat_run_status, $5::heartbeat_run_status)
+			 ORDER BY started_at DESC NULLS LAST
+			 LIMIT $6`,
+			[
+				memberId,
+				issueId,
+				HeartbeatRunStatus.Succeeded,
+				HeartbeatRunStatus.Failed,
+				HeartbeatRunStatus.TimedOut,
+				MAX_CONSECUTIVE_FAILURE_PINGS,
+			],
+		);
+		const streak = recent.rows.every((r) => FAILURE_TERMINAL_STATUSES.includes(r.status));
+		if (recent.rows.length >= MAX_CONSECUTIVE_FAILURE_PINGS && streak) {
+			log.warn(
+				`Suppressing failure ping for agent ${agentSlug} on issue ${issueId}: ${MAX_CONSECUTIVE_FAILURE_PINGS} consecutive failed runs`,
+			);
+			return;
+		}
+
+		const truncatedError = run.error
+			? run.error.length > FAILURE_PING_ERROR_MAX_LEN
+				? `${run.error.slice(0, FAILURE_PING_ERROR_MAX_LEN)}…`
+				: run.error
+			: null;
+
+		const inserted = await db.query<Record<string, unknown>>(
+			`INSERT INTO issue_comments (issue_id, author_member_id, content_type, content)
+			 VALUES ($1, NULL, $2::comment_content_type, $3::jsonb)
+			 RETURNING *`,
+			[
+				issueId,
+				CommentContentType.System,
+				JSON.stringify({
+					kind: 'run_failed',
+					run_id: runId,
+					status: run.status,
+					error: truncatedError,
+					member_id: memberId,
+					agent_slug: agentSlug,
+				}),
+			],
+		);
+		const commentRow = inserted.rows[0];
+		if (!commentRow) return;
+		const commentId = commentRow.id as string;
+
+		broadcastRowChange(
+			this.deps.wsManager,
+			wsRoom.team(teamId),
+			'issue_comments',
+			'INSERT',
+			commentRow,
+		);
+
+		await createWakeup(db, memberId, teamId, WakeupSource.Automation, {
+			source: WakeupSource.Automation,
+			issue_id: issueId,
+			comment_id: commentId,
+			run_id: runId,
+			reason: 'run_failed',
+		});
 	}
 
 	private async chainNextIssueWakeup(

--- a/packages/server/src/services/workspace.ts
+++ b/packages/server/src/services/workspace.ts
@@ -30,7 +30,7 @@ export function ensureProjectWorkspace(
 		throw new Error('dataDir, teamSlug, and projectSlug are required');
 	}
 	const projectDir = getProjectDir(dataDir, teamSlug, projectSlug);
-	for (const sub of ['workspace', 'worktrees', '.previews']) {
+	for (const sub of ['workspace', 'worktrees', '.previews', 'assets']) {
 		mkdirSync(join(projectDir, sub), { recursive: true });
 	}
 	return projectDir;
@@ -62,6 +62,19 @@ export function getProjectDir(dataDir: string, teamSlug: string, projectSlug: st
 
 export function getWorkspacePath(dataDir: string, teamSlug: string, projectSlug: string): string {
 	return join(getProjectDir(dataDir, teamSlug, projectSlug), 'workspace');
+}
+
+export function getAssetsPath(dataDir: string, teamSlug: string, projectSlug: string): string {
+	return join(getProjectDir(dataDir, teamSlug, projectSlug), 'assets');
+}
+
+export function getAssetPath(
+	dataDir: string,
+	teamSlug: string,
+	projectSlug: string,
+	assetId: string,
+): string {
+	return join(getAssetsPath(dataDir, teamSlug, projectSlug), assetId);
 }
 
 export function getWorktreesPath(dataDir: string, teamSlug: string, projectSlug: string): string {

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -20,6 +20,7 @@ import { agentsRoutes } from './routes/agents';
 import { aiProvidersRoutes } from './routes/ai-providers';
 import { apiKeysRoutes } from './routes/api-keys';
 import { approvalsRoutes } from './routes/approvals';
+import { assetsRoutes, publicAssetsRoutes } from './routes/assets';
 import { auditLogRoutes } from './routes/audit-log';
 import { authRoutes } from './routes/auth';
 import { commentsRoutes } from './routes/comments';
@@ -240,6 +241,10 @@ export function buildApp(
 	// Auth routes (token endpoint is public, handled before auth middleware)
 	app.route('/api', authRoutes);
 
+	// Public signed-URL asset read endpoint (sig query is the credential, so it
+	// must be reachable without a bearer token).
+	app.route('/', publicAssetsRoutes);
+
 	// Auth middleware for all /api/* and /agent-api/* routes
 	app.use('/api/*', authMiddleware);
 	app.use('/agent-api/*', authMiddleware);
@@ -256,6 +261,7 @@ export function buildApp(
 	app.route('/api', goalsRoutes);
 	app.route('/api', issuesRoutes);
 	app.route('/api', commentsRoutes);
+	app.route('/api', assetsRoutes);
 	app.route('/api', secretsRoutes);
 	app.route('/api', approvalsRoutes);
 	app.route('/api', costsRoutes);

--- a/packages/server/src/test/__tests__/coach.test.ts
+++ b/packages/server/src/test/__tests__/coach.test.ts
@@ -163,6 +163,41 @@ describe('Coach review prompt builder', () => {
 		expect(prompt).toMatch(/following the format defined in your system prompt/i);
 	});
 
+	it('includes attachment paths in the comment log so the agent can read them', async () => {
+		const issueRow = await db.query<IssueInfo>(
+			`SELECT id, identifier, title, description, status::text AS status,
+			        priority::text AS priority, project_id, rules,
+			        parent_issue_id, created_by_run_id
+			 FROM issues WHERE id = $1`,
+			[issueId],
+		);
+
+		const commentRes = await db.query<{ id: string }>(
+			`INSERT INTO issue_comments (issue_id, content_type, content)
+			 VALUES ($1, 'text'::comment_content_type, $2::jsonb)
+			 RETURNING id`,
+			[issueId, JSON.stringify({ text: 'logs attached' })],
+		);
+		const commentId = commentRes.rows[0].id;
+
+		const assetRes = await db.query<{ id: string }>(
+			`INSERT INTO assets (team_id, project_id, content_type, byte_size, sha256, original_filename)
+			 VALUES ($1, $2, 'text/plain', 42, 'abc', 'crash.log')
+			 RETURNING id`,
+			[teamId, projectId],
+		);
+		const assetId = assetRes.rows[0].id;
+
+		await db.query('INSERT INTO comment_attachments (comment_id, asset_id) VALUES ($1, $2)', [
+			commentId,
+			assetId,
+		]);
+
+		const prompt = await buildCoachReviewPrompt(db, 'SYS', issueRow.rows[0], teamId);
+		expect(prompt).toContain('attachment: crash.log');
+		expect(prompt).toContain(`/workspace/.hezo/assets/${assetId}`);
+	});
+
 	it('seeded coach system prompt contains the summary-comment rule from the partial', async () => {
 		const res = await db.query<{ system_prompt_template: string }>(
 			"SELECT system_prompt_template FROM agent_types WHERE slug = 'coach'",

--- a/packages/server/src/test/__tests__/comment-attachments.test.ts
+++ b/packages/server/src/test/__tests__/comment-attachments.test.ts
@@ -1,0 +1,287 @@
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { PGlite } from '@electric-sql/pglite';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { MasterKeyManager } from '../../crypto/master-key';
+import { signAssetUrl } from '../../lib/asset-urls';
+import type { Env } from '../../lib/types';
+import { safeClose } from '../helpers';
+import { authHeader, createTestApp } from '../helpers/app';
+
+let app: Hono<Env>;
+let db: PGlite;
+let token: string;
+let masterKeyManager: MasterKeyManager;
+let dataDir: string;
+let teamId: string;
+let teamSlug: string;
+let projectId: string;
+let projectSlug: string;
+let issueId: string;
+let otherProjectId: string;
+let otherIssueId: string;
+
+function buildPng(): Uint8Array {
+	const sig = Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+	const extra = new Uint8Array(64);
+	for (let i = 0; i < extra.length; i++) extra[i] = i;
+	const out = new Uint8Array(sig.length + extra.length);
+	out.set(sig, 0);
+	out.set(extra, sig.length);
+	return out;
+}
+
+async function uploadAsset(
+	filename: string,
+	mime: string,
+	bytes: Uint8Array,
+	targetIssueId: string = issueId,
+): Promise<Response> {
+	const fd = new FormData();
+	const copy = new Uint8Array(bytes.byteLength);
+	copy.set(bytes);
+	fd.set('file', new File([copy.buffer], filename, { type: mime }));
+	return app.request(`/api/teams/${teamId}/issues/${targetIssueId}/assets`, {
+		method: 'POST',
+		headers: { ...authHeader(token) },
+		body: fd,
+	});
+}
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+	masterKeyManager = ctx.masterKeyManager;
+	dataDir = ctx.dataDir;
+
+	const teamRes = await app.request('/api/teams', {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ name: 'Attach Co' }),
+	});
+	const teamData = (await teamRes.json()).data;
+	teamId = teamData.id;
+	teamSlug = teamData.slug;
+
+	const projectRes = await app.request(`/api/teams/${teamId}/projects`, {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ name: 'Main', description: 'Attachments project.' }),
+	});
+	const projectData = (await projectRes.json()).data;
+	projectId = projectData.id;
+	projectSlug = projectData.slug;
+
+	const agentRes = await app.request(`/api/teams/${teamId}/agents`, {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ title: 'Attach Bot' }),
+	});
+	const agentId = (await agentRes.json()).data.id;
+
+	const issueRes = await app.request(`/api/teams/${teamId}/issues`, {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			project_id: projectId,
+			title: 'Attachable Issue',
+			assignee_id: agentId,
+		}),
+	});
+	if (issueRes.status !== 201) {
+		throw new Error(`Issue create failed: ${issueRes.status} ${await issueRes.text()}`);
+	}
+	issueId = (await issueRes.json()).data.id;
+
+	const otherProjectRes = await app.request(`/api/teams/${teamId}/projects`, {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ name: 'Other', description: 'Isolation test.' }),
+	});
+	otherProjectId = (await otherProjectRes.json()).data.id;
+
+	const otherIssueRes = await app.request(`/api/teams/${teamId}/issues`, {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			project_id: otherProjectId,
+			title: 'Other Issue',
+			assignee_id: agentId,
+		}),
+	});
+	otherIssueId = (await otherIssueRes.json()).data.id;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+describe('asset upload', () => {
+	it('rejects unsupported extensions', async () => {
+		const res = await uploadAsset('virus.exe', 'application/octet-stream', new Uint8Array([0]));
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.error.code).toBe('INVALID_ATTACHMENT');
+	});
+
+	it('rejects disallowed MIMEs even with allowed extension', async () => {
+		const res = await uploadAsset('sneaky.png', 'application/x-msdownload', buildPng());
+		expect(res.status).toBe(400);
+	});
+
+	it('stores an uploaded PNG on disk with computed sha256', async () => {
+		const bytes = buildPng();
+		const expectedSha = createHash('sha256').update(bytes).digest('hex');
+		const res = await uploadAsset('shot.png', 'image/png', bytes);
+		expect(res.status).toBe(201);
+		const body = await res.json();
+		expect(body.data.id).toMatch(/^[0-9a-f-]{36}$/);
+		expect(body.data.content_type).toBe('image/png');
+		expect(body.data.original_filename).toBe('shot.png');
+		expect(body.data.byte_size).toBe(bytes.byteLength);
+		expect(body.data.url).toMatch(/^\/api\/assets\/[0-9a-f-]+\?exp=\d+&sig=/);
+
+		const onDisk = join(
+			dataDir,
+			'teams',
+			teamSlug,
+			'projects',
+			projectSlug,
+			'assets',
+			body.data.id,
+		);
+		expect(existsSync(onDisk)).toBe(true);
+		const written = readFileSync(onDisk);
+		expect(createHash('sha256').update(written).digest('hex')).toBe(expectedSha);
+	});
+
+	it('rejects uploads above 10 MB', async () => {
+		const huge = new Uint8Array(10 * 1024 * 1024 + 1);
+		const res = await uploadAsset('large.png', 'image/png', huge);
+		expect(res.status).toBe(400);
+	});
+});
+
+describe('signed URLs', () => {
+	let assetId: string;
+	let signedUrl: string;
+
+	beforeAll(async () => {
+		const res = await uploadAsset('signed.png', 'image/png', buildPng());
+		const body = await res.json();
+		assetId = body.data.id;
+		signedUrl = body.data.url;
+	});
+
+	it('returns the file when the signature is valid', async () => {
+		const res = await app.request(signedUrl);
+		expect(res.status).toBe(200);
+		expect(res.headers.get('content-type')).toBe('image/png');
+		expect(res.headers.get('content-disposition')).toContain('signed.png');
+		const buf = new Uint8Array(await res.arrayBuffer());
+		expect(buf.byteLength).toBeGreaterThan(0);
+	});
+
+	it('rejects requests with a tampered signature', async () => {
+		const tampered = signedUrl.replace(
+			/sig=[^&]+/,
+			'sig=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+		);
+		const res = await app.request(tampered);
+		expect(res.status).toBe(401);
+	});
+
+	it('rejects expired signatures', async () => {
+		const expired = await signAssetUrl(assetId, masterKeyManager, -10);
+		const res = await app.request(expired);
+		expect(res.status).toBe(401);
+	});
+
+	it('returns 404 for unknown asset ids with valid signature', async () => {
+		const fakeUrl = await signAssetUrl('00000000-0000-0000-0000-000000000000', masterKeyManager);
+		const res = await app.request(fakeUrl);
+		expect(res.status).toBe(404);
+	});
+
+	it('rejects URLs missing exp or sig', async () => {
+		const res = await app.request(`/api/assets/${assetId}`);
+		expect(res.status).toBe(401);
+	});
+});
+
+describe('comment + attachments', () => {
+	it('links uploaded assets to a comment and returns them on GET', async () => {
+		const upload = await uploadAsset('doc.pdf', 'application/pdf', new Uint8Array([1, 2, 3, 4]));
+		const assetId = (await upload.json()).data.id;
+
+		const createRes = await app.request(`/api/teams/${teamId}/issues/${issueId}/comments`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				content_type: 'text',
+				content: { text: 'See attached' },
+				attachment_ids: [assetId],
+			}),
+		});
+		expect(createRes.status).toBe(201);
+		const created = (await createRes.json()).data;
+		expect(created.attachments).toBeDefined();
+		expect(created.attachments).toHaveLength(1);
+		expect(created.attachments[0].id).toBe(assetId);
+		expect(created.attachments[0].original_filename).toBe('doc.pdf');
+		expect(created.attachments[0].url).toMatch(/^\/api\/assets\/[0-9a-f-]+\?exp=\d+&sig=/);
+
+		const listRes = await app.request(`/api/teams/${teamId}/issues/${issueId}/comments`, {
+			headers: authHeader(token),
+		});
+		const list = (await listRes.json()).data;
+		const fromList = list.find((c: { id: string }) => c.id === created.id);
+		expect(fromList.attachments).toHaveLength(1);
+		expect(fromList.attachments[0].id).toBe(assetId);
+	});
+
+	it('rejects attaching an asset from another project', async () => {
+		const upload = await uploadAsset('other.png', 'image/png', buildPng(), otherIssueId);
+		const otherAssetId = (await upload.json()).data.id;
+
+		const res = await app.request(`/api/teams/${teamId}/issues/${issueId}/comments`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				content_type: 'text',
+				content: { text: 'cross-project' },
+				attachment_ids: [otherAssetId],
+			}),
+		});
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.error.code).toBe('INVALID_REQUEST');
+	});
+
+	it('cascades comment_attachments rows when the comment is deleted', async () => {
+		const upload = await uploadAsset('todelete.txt', 'text/plain', new Uint8Array([42]));
+		const assetId = (await upload.json()).data.id;
+
+		const createRes = await app.request(`/api/teams/${teamId}/issues/${issueId}/comments`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				content_type: 'text',
+				content: { text: 'to delete' },
+				attachment_ids: [assetId],
+			}),
+		});
+		const commentId = (await createRes.json()).data.id;
+
+		await db.query('DELETE FROM issue_comments WHERE id = $1', [commentId]);
+		const remaining = await db.query<{ id: string }>(
+			'SELECT id FROM comment_attachments WHERE comment_id = $1',
+			[commentId],
+		);
+		expect(remaining.rows).toHaveLength(0);
+	});
+});

--- a/packages/server/src/test/__tests__/container-sync.test.ts
+++ b/packages/server/src/test/__tests__/container-sync.test.ts
@@ -362,6 +362,13 @@ describe('provisionContainer broadcasting', () => {
 		expect(event.action).toBe('UPDATE');
 		expect(event.row.container_status).toBe('running');
 		expect(event.row.container_id).toBe('test-container-123');
+
+		const binds = mockDocker.createContainer.mock.calls[0][1].HostConfig.Binds as string[];
+		const assetsBind = binds.find((b) => b.endsWith(':/workspace/.hezo/assets:ro'));
+		expect(assetsBind).toBeDefined();
+		expect(assetsBind).toContain(
+			`${dataDir}/teams/container-sync-co/projects/${project.slug}/assets`,
+		);
 	});
 
 	it('broadcasts row_change on provisioning error', async () => {

--- a/packages/server/src/test/__tests__/containers.test.ts
+++ b/packages/server/src/test/__tests__/containers.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { afterAll, describe, expect, it } from 'vitest';
 import {
 	ensureProjectWorkspace,
+	getAssetsPath,
 	getPreviewsPath,
 	getProjectDir,
 	getWorkspacePath,
@@ -25,6 +26,7 @@ describe('workspace filesystem', () => {
 		expect(existsSync(join(projectDir, 'workspace'))).toBe(true);
 		expect(existsSync(join(projectDir, 'worktrees'))).toBe(true);
 		expect(existsSync(join(projectDir, '.previews'))).toBe(true);
+		expect(existsSync(join(projectDir, 'assets'))).toBe(true);
 	});
 
 	it('is idempotent', () => {
@@ -62,6 +64,7 @@ describe('workspace filesystem', () => {
 
 		expect(getWorkspacePath(testDataDir, 'acme', 'api')).toBe(join(dir, 'workspace'));
 		expect(getWorktreesPath(testDataDir, 'acme', 'api')).toBe(join(dir, 'worktrees'));
+		expect(getAssetsPath(testDataDir, 'acme', 'api')).toBe(join(dir, 'assets'));
 
 		const wtPath = getWorktreePath(testDataDir, 'acme', 'api', 'frontend', 'feat-auth', 'abc12345');
 		expect(wtPath).toBe(join(dir, 'worktrees', 'frontend-feat-auth-agent-abc12345'));

--- a/packages/server/src/test/__tests__/job-manager-workflows.test.ts
+++ b/packages/server/src/test/__tests__/job-manager-workflows.test.ts
@@ -656,6 +656,258 @@ describe('JobManager workflow methods', () => {
 			manager.shutdown();
 		});
 
+		describe('failure pings', () => {
+			async function seedRun(
+				status: HeartbeatRunStatus,
+				error: string | null = null,
+				startedOffsetSeconds = 0,
+			): Promise<string> {
+				const r = await db.query<{ id: string }>(
+					`INSERT INTO heartbeat_runs (member_id, team_id, issue_id, status, error, started_at)
+					 VALUES ($1, $2, $3, $4::heartbeat_run_status, $5, now() - ($6 || ' seconds')::interval)
+					 RETURNING id`,
+					[agentId, teamId, issueId, status, error, String(startedOffsetSeconds)],
+				);
+				return r.rows[0].id;
+			}
+
+			async function clearRunsAndComments(): Promise<void> {
+				await db.query('DELETE FROM agent_wakeup_requests WHERE member_id = $1', [agentId]);
+				await db.query(
+					"DELETE FROM issue_comments WHERE issue_id = $1 AND content_type = 'system'",
+					[issueId],
+				);
+				await db.query('DELETE FROM heartbeat_runs WHERE issue_id = $1 AND member_id = $2', [
+					issueId,
+					agentId,
+				]);
+			}
+
+			async function readSystemComments(): Promise<
+				Array<{ content: Record<string, unknown>; author_member_id: string | null }>
+			> {
+				const r = await db.query<{
+					content: Record<string, unknown>;
+					author_member_id: string | null;
+				}>(
+					`SELECT content, author_member_id FROM issue_comments
+					 WHERE issue_id = $1 AND content_type = 'system'
+					 ORDER BY created_at ASC`,
+					[issueId],
+				);
+				return r.rows;
+			}
+
+			it('posts a system comment and automation wakeup on failed status', async () => {
+				await clearRunsAndComments();
+				const runId = await seedRun(HeartbeatRunStatus.Failed, 'The operation timed out.');
+
+				const manager = createJobManager();
+				await (manager as any).onAgentComplete(
+					agentId,
+					'researcher',
+					issueId,
+					teamId,
+					undefined,
+					undefined,
+					{
+						success: false,
+						exitCode: -1,
+						stdout: '',
+						stderr: 'The operation timed out.',
+						heartbeatRunId: runId,
+					},
+				);
+
+				const comments = await readSystemComments();
+				const failurePings = comments.filter((c) => c.content.kind === 'run_failed');
+				expect(failurePings.length).toBe(1);
+				expect(failurePings[0].author_member_id).toBeNull();
+				expect(failurePings[0].content.run_id).toBe(runId);
+				expect(failurePings[0].content.status).toBe(HeartbeatRunStatus.Failed);
+				expect(failurePings[0].content.error).toBe('The operation timed out.');
+				expect(failurePings[0].content.agent_slug).toBe('researcher');
+				expect(failurePings[0].content.member_id).toBe(agentId);
+
+				const wakeups = await db.query<{ source: string; payload: Record<string, unknown> }>(
+					`SELECT source::text AS source, payload FROM agent_wakeup_requests
+					 WHERE member_id = $1 AND source = 'automation'
+					 ORDER BY created_at DESC LIMIT 1`,
+					[agentId],
+				);
+				expect(wakeups.rows.length).toBe(1);
+				expect(wakeups.rows[0].payload).toMatchObject({
+					issue_id: issueId,
+					run_id: runId,
+					reason: 'run_failed',
+				});
+
+				manager.shutdown();
+				await clearRunsAndComments();
+			});
+
+			it('posts the ping on timed_out status', async () => {
+				await clearRunsAndComments();
+				const runId = await seedRun(HeartbeatRunStatus.TimedOut, 'Heartbeat lapsed');
+
+				const manager = createJobManager();
+				await (manager as any).onAgentComplete(
+					agentId,
+					'researcher',
+					issueId,
+					teamId,
+					undefined,
+					undefined,
+					{
+						success: false,
+						exitCode: -1,
+						stdout: '',
+						stderr: '',
+						heartbeatRunId: runId,
+					},
+				);
+
+				const comments = await readSystemComments();
+				const failurePings = comments.filter((c) => c.content.kind === 'run_failed');
+				expect(failurePings.length).toBe(1);
+				expect(failurePings[0].content.status).toBe(HeartbeatRunStatus.TimedOut);
+
+				manager.shutdown();
+				await clearRunsAndComments();
+			});
+
+			it('suppresses the ping after 3 consecutive failures', async () => {
+				await clearRunsAndComments();
+				await seedRun(HeartbeatRunStatus.Failed, 'first', 30);
+				await seedRun(HeartbeatRunStatus.Failed, 'second', 20);
+				const runId = await seedRun(HeartbeatRunStatus.Failed, 'third', 10);
+
+				const manager = createJobManager();
+				await (manager as any).onAgentComplete(
+					agentId,
+					'researcher',
+					issueId,
+					teamId,
+					undefined,
+					undefined,
+					{
+						success: false,
+						exitCode: -1,
+						stdout: '',
+						stderr: 'third',
+						heartbeatRunId: runId,
+					},
+				);
+
+				const comments = await readSystemComments();
+				const failurePings = comments.filter((c) => c.content.kind === 'run_failed');
+				expect(failurePings.length).toBe(0);
+
+				const wakeups = await db.query<{ id: string }>(
+					`SELECT id FROM agent_wakeup_requests WHERE member_id = $1 AND source = 'automation'`,
+					[agentId],
+				);
+				expect(wakeups.rows.length).toBe(0);
+
+				manager.shutdown();
+				await clearRunsAndComments();
+			});
+
+			it('resumes pinging after an intervening successful run', async () => {
+				await clearRunsAndComments();
+				await seedRun(HeartbeatRunStatus.Failed, 'first', 40);
+				await seedRun(HeartbeatRunStatus.Failed, 'second', 30);
+				await seedRun(HeartbeatRunStatus.Succeeded, null, 20);
+				const runId = await seedRun(HeartbeatRunStatus.Failed, 'after recovery', 10);
+
+				const manager = createJobManager();
+				await (manager as any).onAgentComplete(
+					agentId,
+					'researcher',
+					issueId,
+					teamId,
+					undefined,
+					undefined,
+					{
+						success: false,
+						exitCode: -1,
+						stdout: '',
+						stderr: 'after recovery',
+						heartbeatRunId: runId,
+					},
+				);
+
+				const comments = await readSystemComments();
+				const failurePings = comments.filter((c) => c.content.kind === 'run_failed');
+				expect(failurePings.length).toBe(1);
+
+				manager.shutdown();
+				await clearRunsAndComments();
+			});
+
+			it('does not ping on cancelled status', async () => {
+				await clearRunsAndComments();
+				const runId = await seedRun(HeartbeatRunStatus.Cancelled, null);
+
+				const manager = createJobManager();
+				await (manager as any).onAgentComplete(
+					agentId,
+					'researcher',
+					issueId,
+					teamId,
+					undefined,
+					undefined,
+					{
+						success: false,
+						exitCode: -1,
+						stdout: '',
+						stderr: 'cancelled',
+						heartbeatRunId: runId,
+					},
+				);
+
+				const comments = await readSystemComments();
+				expect(comments.filter((c) => c.content.kind === 'run_failed').length).toBe(0);
+
+				const wakeups = await db.query<{ id: string }>(
+					`SELECT id FROM agent_wakeup_requests WHERE member_id = $1 AND source = 'automation'`,
+					[agentId],
+				);
+				expect(wakeups.rows.length).toBe(0);
+
+				manager.shutdown();
+				await clearRunsAndComments();
+			});
+
+			it('does not ping on successful runs', async () => {
+				await clearRunsAndComments();
+				const runId = await seedRun(HeartbeatRunStatus.Succeeded, null);
+
+				const manager = createJobManager();
+				await (manager as any).onAgentComplete(
+					agentId,
+					'researcher',
+					issueId,
+					teamId,
+					undefined,
+					undefined,
+					{
+						success: true,
+						exitCode: 0,
+						stdout: '',
+						stderr: '',
+						heartbeatRunId: runId,
+					},
+				);
+
+				const comments = await readSystemComments();
+				expect(comments.filter((c) => c.content.kind === 'run_failed').length).toBe(0);
+
+				manager.shutdown();
+				await clearRunsAndComments();
+			});
+		});
+
 		it('chains a wakeup for the next assigned non-terminal issue', async () => {
 			const manager = createJobManager();
 

--- a/packages/server/src/test/helpers/context.ts
+++ b/packages/server/src/test/helpers/context.ts
@@ -1,3 +1,4 @@
+import { rmSync } from 'node:fs';
 import { createServer, type Server } from 'node:http';
 import type { PGlite } from '@electric-sql/pglite';
 import type { Hono } from 'hono';
@@ -15,10 +16,11 @@ export interface ServerTestContext {
 	token: string;
 	masterKeyHex: string;
 	masterKeyManager: MasterKeyManager;
+	dataDir: string;
 }
 
 export async function createTestContext(): Promise<ServerTestContext> {
-	const { app, db, token, masterKeyHex, masterKeyManager } = await createTestApp();
+	const { app, db, token, masterKeyHex, masterKeyManager, dataDir } = await createTestApp();
 
 	const server = createServer(async (req, res) => {
 		const url = `http://localhost${req.url}`;
@@ -49,10 +51,11 @@ export async function createTestContext(): Promise<ServerTestContext> {
 	const port = typeof addr === 'object' && addr ? addr.port : 0;
 	const baseUrl = `http://localhost:${port}`;
 
-	return { db, app, server, baseUrl, port, token, masterKeyHex, masterKeyManager };
+	return { db, app, server, baseUrl, port, token, masterKeyHex, masterKeyManager, dataDir };
 }
 
 export async function destroyTestContext(ctx: ServerTestContext): Promise<void> {
 	await new Promise<void>((resolve) => ctx.server.close(() => resolve()));
 	await safeClose(ctx.db);
+	rmSync(ctx.dataDir, { recursive: true, force: true });
 }

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -105,6 +105,53 @@ export const CommentContentType = {
 } as const;
 export type CommentContentType = (typeof CommentContentType)[keyof typeof CommentContentType];
 
+export const ATTACHMENT_MAX_BYTES = 10 * 1024 * 1024;
+export const ATTACHMENT_SIGNED_URL_TTL_SECONDS = 3600;
+
+export const ATTACHMENT_EXTENSIONS = {
+	txt: 'text/plain',
+	pdf: 'application/pdf',
+	png: 'image/png',
+	jpg: 'image/jpeg',
+	jpeg: 'image/jpeg',
+	gif: 'image/gif',
+	mp3: 'audio/mpeg',
+	opus: 'audio/opus',
+	aac: 'audio/aac',
+	wav: 'audio/wav',
+	mp4: 'video/mp4',
+	webm: 'video/webm',
+	mov: 'video/quicktime',
+} as const;
+export type AttachmentExtension = keyof typeof ATTACHMENT_EXTENSIONS;
+
+export const ATTACHMENT_MIME_ALLOWLIST: ReadonlySet<string> = new Set(
+	Object.values(ATTACHMENT_EXTENSIONS),
+);
+
+export function extensionOf(filename: string): string | null {
+	const dot = filename.lastIndexOf('.');
+	if (dot < 0 || dot === filename.length - 1) return null;
+	return filename.slice(dot + 1).toLowerCase();
+}
+
+export function isAllowedAttachmentExtension(filename: string): boolean {
+	const ext = extensionOf(filename);
+	return ext !== null && Object.hasOwn(ATTACHMENT_EXTENSIONS, ext);
+}
+
+export function isAllowedAttachmentMime(mime: string): boolean {
+	return ATTACHMENT_MIME_ALLOWLIST.has(mime);
+}
+
+export interface CommentAttachment {
+	id: string;
+	content_type: string;
+	byte_size: number;
+	original_filename: string;
+	url: string;
+}
+
 export const CredentialKind = {
 	ApiKey: 'api_key',
 	SshPrivateKey: 'ssh_private_key',

--- a/packages/web/src/components/comment-attachment-thumb.tsx
+++ b/packages/web/src/components/comment-attachment-thumb.tsx
@@ -1,0 +1,28 @@
+import { File, FileAudio, FileText, FileVideo, Image as ImageIcon } from 'lucide-react';
+import type { CommentAttachment } from '../hooks/use-comments';
+
+function iconFor(contentType: string) {
+	if (contentType.startsWith('image/')) return <ImageIcon className="h-4 w-4" />;
+	if (contentType.startsWith('audio/')) return <FileAudio className="h-4 w-4" />;
+	if (contentType.startsWith('video/')) return <FileVideo className="h-4 w-4" />;
+	if (contentType === 'application/pdf' || contentType === 'text/plain') {
+		return <FileText className="h-4 w-4" />;
+	}
+	return <File className="h-4 w-4" />;
+}
+
+export function CommentAttachmentThumb({ attachment }: { attachment: CommentAttachment }) {
+	return (
+		<a
+			href={attachment.url}
+			target="_blank"
+			rel="noopener noreferrer"
+			title={attachment.original_filename}
+			data-testid="comment-attachment-thumb"
+			data-filename={attachment.original_filename}
+			className="flex h-9 w-9 items-center justify-center rounded-radius-sm border border-border bg-bg-muted text-text-subtle hover:border-border-hover hover:text-text"
+		>
+			{iconFor(attachment.content_type)}
+		</a>
+	);
+}

--- a/packages/web/src/components/comment-attachments-drop.tsx
+++ b/packages/web/src/components/comment-attachments-drop.tsx
@@ -1,5 +1,6 @@
 import { ATTACHMENT_MAX_BYTES, isAllowedAttachmentExtension } from '@hezo/shared';
 import {
+	ExternalLink,
 	FileAudio,
 	File as FileIcon,
 	FileText,
@@ -13,6 +14,7 @@ import { type ReactNode, useCallback, useMemo, useRef, useState } from 'react';
 import type { CommentAttachment } from '../hooks/use-comments';
 import { useUploadAttachment } from '../hooks/use-upload-attachment';
 import type { ApiError } from '../lib/api';
+import { InfoTooltip } from './ui/info-tooltip';
 
 interface Props {
 	teamId: string;
@@ -148,6 +150,8 @@ export function CommentAttachmentsDrop({ teamId, issueId, value, onChange, child
 		[onChange, value],
 	);
 
+	const hasAnyChip = visibleAttachments.length > 0 || uploading.length > 0 || errors.length > 0;
+
 	return (
 		// biome-ignore lint/a11y/noStaticElementInteractions: drag-and-drop wrapper; the inner textarea owns keyboard interaction
 		<div
@@ -158,17 +162,55 @@ export function CommentAttachmentsDrop({ teamId, issueId, value, onChange, child
 			onDragOver={onDragOver}
 			onDrop={onDrop}
 		>
-			{(visibleAttachments.length > 0 || uploading.length > 0 || errors.length > 0) && (
+			{!hasAnyChip && (
+				<div
+					className="mb-2 flex items-center gap-1.5 text-xs text-text-subtle"
+					data-testid="comment-attachment-hint"
+				>
+					<span>Drag and drop files to attach</span>
+					<InfoTooltip
+						label="Supported attachment types"
+						data-testid="comment-attachment-hint-info"
+						content={
+							<div className="space-y-1">
+								<div>
+									<strong>Images:</strong> PNG, JPG, GIF
+								</div>
+								<div>
+									<strong>Documents:</strong> PDF, TXT
+								</div>
+								<div>
+									<strong>Audio:</strong> MP3, WAV, AAC, OPUS
+								</div>
+								<div>
+									<strong>Video:</strong> MP4, WEBM, MOV
+								</div>
+								<div className="pt-1 text-text-subtle">Max 10&nbsp;MB per file</div>
+							</div>
+						}
+					/>
+				</div>
+			)}
+			{hasAnyChip && (
 				<div className="mb-2 flex flex-wrap gap-1.5" data-testid="comment-attachment-pending-row">
 					{visibleAttachments.map((a) => (
 						<span
 							key={a.id}
 							className="flex items-center gap-1.5 rounded-radius-sm border border-border bg-bg-muted px-2 py-1 text-[12px] text-text"
-							title={a.original_filename}
 							data-testid="comment-attachment-chip"
 						>
 							{iconFor(a.content_type)}
-							<span className="max-w-[140px] truncate">{a.original_filename}</span>
+							<a
+								href={a.url}
+								target="_blank"
+								rel="noopener noreferrer"
+								title={a.original_filename}
+								className="flex items-center gap-1 text-text hover:underline"
+								data-testid="comment-attachment-preview"
+							>
+								<span className="max-w-[140px] truncate">{a.original_filename}</span>
+								<ExternalLink className="h-3 w-3 shrink-0" />
+							</a>
 							<button
 								type="button"
 								aria-label="Remove attachment"

--- a/packages/web/src/components/comment-attachments-drop.tsx
+++ b/packages/web/src/components/comment-attachments-drop.tsx
@@ -1,0 +1,216 @@
+import { ATTACHMENT_MAX_BYTES, isAllowedAttachmentExtension } from '@hezo/shared';
+import {
+	FileAudio,
+	File as FileIcon,
+	FileText,
+	FileVideo,
+	Image as ImageIcon,
+	Loader2,
+	Upload,
+	X,
+} from 'lucide-react';
+import { type ReactNode, useCallback, useMemo, useRef, useState } from 'react';
+import type { CommentAttachment } from '../hooks/use-comments';
+import { useUploadAttachment } from '../hooks/use-upload-attachment';
+import type { ApiError } from '../lib/api';
+
+interface Props {
+	teamId: string;
+	issueId: string;
+	value: string[];
+	onChange: (ids: string[]) => void;
+	children: ReactNode;
+}
+
+interface UploadingFile {
+	tempId: string;
+	filename: string;
+}
+
+interface ErrorChip {
+	id: string;
+	filename: string;
+	message: string;
+}
+
+function iconFor(contentType: string, className = 'h-3.5 w-3.5') {
+	if (contentType.startsWith('image/')) return <ImageIcon className={className} />;
+	if (contentType.startsWith('audio/')) return <FileAudio className={className} />;
+	if (contentType.startsWith('video/')) return <FileVideo className={className} />;
+	if (contentType === 'application/pdf' || contentType === 'text/plain') {
+		return <FileText className={className} />;
+	}
+	return <FileIcon className={className} />;
+}
+
+export function CommentAttachmentsDrop({ teamId, issueId, value, onChange, children }: Props) {
+	const [isDragActive, setIsDragActive] = useState(false);
+	const dragDepth = useRef(0);
+	const [metaById, setMetaById] = useState<Map<string, CommentAttachment>>(new Map());
+	const [uploading, setUploading] = useState<UploadingFile[]>([]);
+	const [errors, setErrors] = useState<ErrorChip[]>([]);
+	const upload = useUploadAttachment(teamId, issueId);
+
+	const visibleAttachments = useMemo(
+		() => value.map((id) => metaById.get(id)).filter((a): a is CommentAttachment => Boolean(a)),
+		[value, metaById],
+	);
+
+	const pushError = useCallback((filename: string, message: string) => {
+		const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+		setErrors((prev) => [...prev, { id, filename, message }]);
+		setTimeout(() => setErrors((prev) => prev.filter((e) => e.id !== id)), 5000);
+	}, []);
+
+	const handleFiles = useCallback(
+		async (files: File[]) => {
+			const accepted: File[] = [];
+			for (const file of files) {
+				if (!isAllowedAttachmentExtension(file.name)) {
+					pushError(file.name, 'Unsupported file type');
+					continue;
+				}
+				if (file.size > ATTACHMENT_MAX_BYTES) {
+					pushError(file.name, 'File exceeds 10 MB');
+					continue;
+				}
+				accepted.push(file);
+			}
+			if (accepted.length === 0) return;
+
+			const pending: UploadingFile[] = accepted.map((f) => ({
+				tempId: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+				filename: f.name,
+			}));
+			setUploading((prev) => [...prev, ...pending]);
+
+			const results = await Promise.allSettled(accepted.map((file) => upload.mutateAsync(file)));
+
+			const newOnes: CommentAttachment[] = [];
+			results.forEach((res, idx) => {
+				if (res.status === 'fulfilled') {
+					newOnes.push(res.value);
+				} else {
+					const reason = res.reason as ApiError;
+					pushError(accepted[idx].name, reason?.message ?? 'Upload failed');
+				}
+			});
+
+			setUploading((prev) => prev.filter((u) => !pending.some((p) => p.tempId === u.tempId)));
+
+			if (newOnes.length > 0) {
+				setMetaById((prev) => {
+					const next = new Map(prev);
+					for (const a of newOnes) next.set(a.id, a);
+					return next;
+				});
+				onChange([...value, ...newOnes.map((a) => a.id)]);
+			}
+		},
+		[onChange, pushError, upload, value],
+	);
+
+	const onDragEnter = useCallback((e: React.DragEvent) => {
+		if (!Array.from(e.dataTransfer.types).includes('Files')) return;
+		e.preventDefault();
+		dragDepth.current += 1;
+		setIsDragActive(true);
+	}, []);
+
+	const onDragLeave = useCallback((e: React.DragEvent) => {
+		if (!Array.from(e.dataTransfer.types).includes('Files')) return;
+		e.preventDefault();
+		dragDepth.current = Math.max(0, dragDepth.current - 1);
+		if (dragDepth.current === 0) setIsDragActive(false);
+	}, []);
+
+	const onDragOver = useCallback((e: React.DragEvent) => {
+		if (!Array.from(e.dataTransfer.types).includes('Files')) return;
+		e.preventDefault();
+	}, []);
+
+	const onDrop = useCallback(
+		(e: React.DragEvent) => {
+			if (!Array.from(e.dataTransfer.types).includes('Files')) return;
+			e.preventDefault();
+			dragDepth.current = 0;
+			setIsDragActive(false);
+			const files = Array.from(e.dataTransfer.files);
+			if (files.length > 0) handleFiles(files);
+		},
+		[handleFiles],
+	);
+
+	const removeAttachment = useCallback(
+		(id: string) => {
+			onChange(value.filter((v) => v !== id));
+		},
+		[onChange, value],
+	);
+
+	return (
+		// biome-ignore lint/a11y/noStaticElementInteractions: drag-and-drop wrapper; the inner textarea owns keyboard interaction
+		<div
+			className="relative"
+			data-testid="comment-attachments-drop"
+			onDragEnter={onDragEnter}
+			onDragLeave={onDragLeave}
+			onDragOver={onDragOver}
+			onDrop={onDrop}
+		>
+			{(visibleAttachments.length > 0 || uploading.length > 0 || errors.length > 0) && (
+				<div className="mb-2 flex flex-wrap gap-1.5" data-testid="comment-attachment-pending-row">
+					{visibleAttachments.map((a) => (
+						<span
+							key={a.id}
+							className="flex items-center gap-1.5 rounded-radius-sm border border-border bg-bg-muted px-2 py-1 text-[12px] text-text"
+							title={a.original_filename}
+							data-testid="comment-attachment-chip"
+						>
+							{iconFor(a.content_type)}
+							<span className="max-w-[140px] truncate">{a.original_filename}</span>
+							<button
+								type="button"
+								aria-label="Remove attachment"
+								className="text-text-subtle hover:text-text"
+								onClick={() => removeAttachment(a.id)}
+							>
+								<X className="h-3 w-3" />
+							</button>
+						</span>
+					))}
+					{uploading.map((u) => (
+						<span
+							key={u.tempId}
+							className="flex items-center gap-1.5 rounded-radius-sm border border-dashed border-border bg-bg-muted/50 px-2 py-1 text-[12px] text-text-subtle"
+						>
+							<Loader2 className="h-3 w-3 animate-spin" />
+							<span className="max-w-[140px] truncate">{u.filename}</span>
+						</span>
+					))}
+					{errors.map((e) => (
+						<span
+							key={e.id}
+							className="flex items-center gap-1.5 rounded-radius-sm border border-danger/40 bg-danger/10 px-2 py-1 text-[12px] text-danger"
+							data-testid="comment-attachment-error"
+						>
+							<span className="max-w-[200px] truncate">
+								{e.filename}: {e.message}
+							</span>
+						</span>
+					))}
+				</div>
+			)}
+			{children}
+			{isDragActive && (
+				<div
+					className="pointer-events-none absolute inset-0 z-10 flex flex-col items-center justify-center gap-2 rounded-radius-md border border-dashed border-border-hover bg-bg-elevated/95"
+					data-testid="comment-attachment-drop-overlay"
+				>
+					<Upload className="h-5 w-5 text-text-subtle" />
+					<p className="text-[13px] text-text-subtle">Drop to attach</p>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/packages/web/src/components/comment-renderers.tsx
+++ b/packages/web/src/components/comment-renderers.tsx
@@ -20,6 +20,7 @@ import {
 import type { ComponentType, SVGProps } from 'react';
 import { useState } from 'react';
 import {
+	type CommentAttachment,
 	type ReactionGroup,
 	useAddReaction,
 	useFulfillCredential,
@@ -32,6 +33,7 @@ import {
 	useHeartbeatRun,
 } from '../hooks/use-heartbeat-runs';
 import { useRunLogs } from '../hooks/use-run-logs';
+import { CommentAttachmentThumb } from './comment-attachment-thumb';
 import { LazyMount } from './lazy-mount';
 import { LogViewer } from './log-viewer';
 import { MarkdownProse } from './markdown-prose';
@@ -50,6 +52,7 @@ export interface CommentData {
 	created_at: string;
 	tool_calls?: ToolCall[];
 	reactions?: ReactionGroup[];
+	attachments?: CommentAttachment[];
 }
 
 const REACTION_GLYPH: Record<string, string> = { ack: '✓' };
@@ -400,9 +403,18 @@ function TextComment({
 			? comment.content.text || JSON.stringify(comment.content)
 			: String(comment.content);
 	return (
-		<MarkdownProse testId="text-comment-body" teamId={teamId} projectSlug={projectSlug}>
-			{content}
-		</MarkdownProse>
+		<>
+			<MarkdownProse testId="text-comment-body" teamId={teamId} projectSlug={projectSlug}>
+				{content}
+			</MarkdownProse>
+			{comment.attachments && comment.attachments.length > 0 ? (
+				<div className="mt-2 flex flex-wrap gap-1.5" data-testid="comment-attachments">
+					{comment.attachments.map((a) => (
+						<CommentAttachmentThumb key={a.id} attachment={a} />
+					))}
+				</div>
+			) : null}
+		</>
 	);
 }
 

--- a/packages/web/src/components/comment-renderers.tsx
+++ b/packages/web/src/components/comment-renderers.tsx
@@ -1,6 +1,7 @@
 import { formatIssueStatus } from '@hezo/shared';
 import { Link } from '@tanstack/react-router';
 import {
+	AlertTriangle,
 	ArrowRightLeft,
 	Check,
 	ChevronDown,
@@ -124,6 +125,8 @@ function systemEventIcon(kind: string | undefined): LucideIcon {
 			return UserRoundCog;
 		case 'issue_link':
 			return Link2;
+		case 'run_failed':
+			return AlertTriangle;
 		default:
 			return Dot;
 	}
@@ -429,6 +432,40 @@ function SystemComment({ comment, teamId }: { comment: CommentData; teamId?: str
 				<span className="text-xs text-text-muted">
 					{actorName} changed status from <em className="italic">{formatIssueStatus(from)}</em> to{' '}
 					<em className="italic">{formatIssueStatus(to)}</em>
+				</span>
+				{timestamp}
+			</div>
+		);
+	}
+
+	if (content?.kind === 'run_failed') {
+		const agentSlug = typeof content.agent_slug === 'string' ? content.agent_slug : '';
+		const status = typeof content.status === 'string' ? content.status : 'failed';
+		const error =
+			typeof content.error === 'string' && content.error.length > 0 ? content.error : null;
+		const statusLabel = status === 'timed_out' ? 'timed out' : 'failed';
+		const agentNode =
+			agentSlug && teamId ? (
+				<Link
+					to="/teams/$teamId/agents/$agentId"
+					params={{ teamId, agentId: agentSlug }}
+					className="text-xs text-accent-blue-text hover:underline"
+					data-testid="run-failed-agent"
+				>
+					@{agentSlug}
+				</Link>
+			) : (
+				<span className="text-xs text-text-muted">agent</span>
+			);
+		return (
+			<div
+				className="flex flex-col gap-0.5 sm:flex-row sm:items-baseline sm:gap-2 leading-[26px]"
+				data-testid="run-failed-comment"
+			>
+				<span className="text-xs text-text-muted">
+					Run for {agentNode} {statusLabel}
+					{error ? <span className="text-text-subtle">: {error}</span> : null}. Waking agent to
+					retry.
 				</span>
 				{timestamp}
 			</div>

--- a/packages/web/src/hooks/use-comments.ts
+++ b/packages/web/src/hooks/use-comments.ts
@@ -14,6 +14,14 @@ export interface ReactionGroup {
 	you_reacted: boolean;
 }
 
+export interface CommentAttachment {
+	id: string;
+	content_type: string;
+	byte_size: number;
+	original_filename: string;
+	url: string;
+}
+
 export interface Comment {
 	id: string;
 	issue_id: string;
@@ -27,6 +35,7 @@ export interface Comment {
 	parent_comment_id: string | null;
 	tool_calls?: unknown[];
 	reactions?: ReactionGroup[];
+	attachments?: CommentAttachment[];
 }
 
 export function useComments(teamId: string, issueId: string) {
@@ -47,6 +56,7 @@ export function useCreateComment(teamId: string, issueId: string) {
 			effort?: string;
 			wake_assignee?: boolean;
 			parent_comment_id?: string;
+			attachment_ids?: string[];
 		}) => api.post<Comment>(`/api/teams/${teamId}/issues/${issueId}/comments`, data),
 		onSuccess: () => {
 			queryClient.invalidateQueries({

--- a/packages/web/src/hooks/use-upload-attachment.ts
+++ b/packages/web/src/hooks/use-upload-attachment.ts
@@ -1,0 +1,40 @@
+import {
+	ATTACHMENT_MAX_BYTES,
+	isAllowedAttachmentExtension,
+	isAllowedAttachmentMime,
+} from '@hezo/shared';
+import { useMutation } from '@tanstack/react-query';
+import { type ApiError, api } from '../lib/api';
+import type { CommentAttachment } from './use-comments';
+
+export function useUploadAttachment(teamId: string, issueId: string) {
+	return useMutation<CommentAttachment, ApiError, File>({
+		mutationFn: async (file) => {
+			if (!isAllowedAttachmentExtension(file.name)) {
+				throw {
+					code: 'INVALID_TYPE',
+					message: `Unsupported file extension: ${file.name}`,
+					status: 400,
+				} as ApiError;
+			}
+			if (file.type && !isAllowedAttachmentMime(file.type)) {
+				throw {
+					code: 'INVALID_TYPE',
+					message: `Unsupported content type: ${file.type}`,
+					status: 400,
+				} as ApiError;
+			}
+			if (file.size > ATTACHMENT_MAX_BYTES) {
+				throw {
+					code: 'TOO_LARGE',
+					message: 'File exceeds 10 MB',
+					status: 400,
+				} as ApiError;
+			}
+
+			const fd = new FormData();
+			fd.set('file', file, file.name);
+			return api.postForm<CommentAttachment>(`/api/teams/${teamId}/issues/${issueId}/assets`, fd);
+		},
+	});
+}

--- a/packages/web/src/hooks/use-websocket.ts
+++ b/packages/web/src/hooks/use-websocket.ts
@@ -32,6 +32,7 @@ const TABLE_TO_QUERY_KEY: Record<
 	},
 	issue_comments: (cid) => [['teams', cid, 'issues']],
 	comment_reactions: (cid) => [['teams', cid, 'issues']],
+	comment_attachments: (cid) => [['teams', cid, 'issues']],
 	member_agents: (cid) => [['teams', cid, 'agents']],
 	projects: (cid) => [['teams', cid, 'projects']],
 	approvals: (cid) => [['teams', cid, 'approvals']],

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -23,6 +23,15 @@ class ApiClient {
 		localStorage.removeItem(TOKEN_KEY);
 	}
 
+	private async extractError(res: Response): Promise<ApiError> {
+		const json = await res.json().catch(() => null);
+		return {
+			code: json?.error?.code ?? 'UNKNOWN',
+			message: json?.error?.message ?? res.statusText,
+			status: res.status,
+		};
+	}
+
 	private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
 		const headers: Record<string, string> = { 'Content-Type': 'application/json' };
 		if (this.token) headers.Authorization = `Bearer ${this.token}`;
@@ -33,15 +42,7 @@ class ApiClient {
 			body: body !== undefined ? JSON.stringify(body) : undefined,
 		});
 
-		if (!res.ok) {
-			const json = await res.json().catch(() => null);
-			const err: ApiError = {
-				code: json?.error?.code ?? 'UNKNOWN',
-				message: json?.error?.message ?? res.statusText,
-				status: res.status,
-			};
-			throw err;
-		}
+		if (!res.ok) throw await this.extractError(res);
 
 		const json = await res.json();
 		return json.data !== undefined ? json.data : json;
@@ -73,6 +74,15 @@ class ApiClient {
 
 	delete<T>(path: string) {
 		return this.request<T>('DELETE', path);
+	}
+
+	async postForm<T>(path: string, formData: FormData): Promise<T> {
+		const headers: Record<string, string> = {};
+		if (this.token) headers.Authorization = `Bearer ${this.token}`;
+		const res = await fetch(path, { method: 'POST', headers, body: formData });
+		if (!res.ok) throw await this.extractError(res);
+		const json = await res.json();
+		return json.data !== undefined ? json.data : json;
 	}
 }
 

--- a/packages/web/src/routes/teams/$teamId/projects/$projectId/issues/$issueId.tsx
+++ b/packages/web/src/routes/teams/$teamId/projects/$projectId/issues/$issueId.tsx
@@ -22,6 +22,7 @@ import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso';
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 import { AgentStatusLabel } from '../../../../../../components/agent-status-label';
+import { CommentAttachmentsDrop } from '../../../../../../components/comment-attachments-drop';
 import {
 	type CommentData,
 	CommentReactions,
@@ -127,6 +128,7 @@ function IssueDetailPage() {
 	const [commentEffort, setCommentEffort] = useState<AgentEffort | null>(null);
 	const [wakeAssignee, setWakeAssignee] = useState(true);
 	const [replyTarget, setReplyTarget] = useState<Comment | null>(null);
+	const [pendingAttachmentIds, setPendingAttachmentIds] = useState<string[]>([]);
 	const commentFormRef = useRef<HTMLFormElement>(null);
 	const commentTextareaRef = useRef<HTMLTextAreaElement>(null);
 	const [subIssueTitle, setSubIssueTitle] = useState('');
@@ -304,17 +306,19 @@ function IssueDetailPage() {
 
 	async function handleComment(e: React.FormEvent) {
 		e.preventDefault();
-		if (!commentText.trim()) return;
+		if (!commentText.trim() && pendingAttachmentIds.length === 0) return;
 		await createComment.mutateAsync({
 			content: commentText,
 			...(commentEffort ? { effort: commentEffort } : {}),
 			...(issue?.assignee_id ? { wake_assignee: wakeAssignee } : {}),
 			...(replyTarget ? { parent_comment_id: replyTarget.id } : {}),
+			...(pendingAttachmentIds.length > 0 ? { attachment_ids: pendingAttachmentIds } : {}),
 		});
 		setCommentText('');
 		setCommentEffort(null);
 		setWakeAssignee(true);
 		setReplyTarget(null);
+		setPendingAttachmentIds([]);
 	}
 
 	function startReply(c: Comment) {
@@ -802,15 +806,22 @@ function IssueDetailPage() {
 					<form ref={commentFormRef} onSubmit={handleComment} className="flex gap-2.5 scroll-mt-20">
 						<div className="w-[26px] shrink-0" aria-hidden />
 						<div className="flex-1 min-w-0 flex flex-col gap-2">
-							<MentionTextarea
-								ref={commentTextareaRef}
+							<CommentAttachmentsDrop
 								teamId={teamId}
-								projectSlug={issueProjectSlug}
-								value={commentText}
-								onChange={(e) => setCommentText(e.target.value)}
-								placeholder="Add a comment..."
-								className="min-h-[60px]"
-							/>
+								issueId={issue.id}
+								value={pendingAttachmentIds}
+								onChange={setPendingAttachmentIds}
+							>
+								<MentionTextarea
+									ref={commentTextareaRef}
+									teamId={teamId}
+									projectSlug={issueProjectSlug}
+									value={commentText}
+									onChange={(e) => setCommentText(e.target.value)}
+									placeholder="Add a comment..."
+									className="min-h-[60px]"
+								/>
+							</CommentAttachmentsDrop>
 							{replyTarget && (
 								<div
 									className="flex items-center gap-2 text-[13px] text-text-muted"
@@ -854,7 +865,10 @@ function IssueDetailPage() {
 								<Button
 									type="submit"
 									size="sm"
-									disabled={!commentText.trim() || createComment.isPending}
+									disabled={
+										(!commentText.trim() && pendingAttachmentIds.length === 0) ||
+										createComment.isPending
+									}
 								>
 									{createComment.isPending && <Loader2 className="w-3 h-3 animate-spin" />}
 									Comment

--- a/test/e2e/issue-comment-attachments.spec.ts
+++ b/test/e2e/issue-comment-attachments.spec.ts
@@ -1,0 +1,141 @@
+import { expect, test } from '@playwright/test';
+import { authenticate, createTeamWithAgents, waitForPageLoad } from './helpers';
+
+const PNG_BYTES = Uint8Array.from([
+	0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+	0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+	0x89, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00,
+	0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae,
+	0x42, 0x60, 0x82,
+]);
+
+test.describe('Issue Comment Attachments', () => {
+	async function createIssue(page: import('@playwright/test').Page) {
+		const { team, token } = await createTeamWithAgents(page);
+		const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+
+		const projRes = await page.request.post(`/api/teams/${team.id}/projects`, {
+			headers,
+			data: { name: 'Attachments Project', description: 'Test project.' },
+		});
+		const project = ((await projRes.json()) as { data: { id: string } }).data;
+
+		const agentsRes = await page.request.get(`/api/teams/${team.id}/agents`, {
+			headers: { Authorization: `Bearer ${token}` },
+		});
+		const agents = ((await agentsRes.json()) as { data: Array<{ id: string }> }).data;
+
+		const issueRes = await page.request.post(`/api/teams/${team.id}/issues`, {
+			headers,
+			data: { project_id: project.id, title: 'Attach me', assignee_id: agents[0].id },
+		});
+		const issue = ((await issueRes.json()) as { data: { id: string } }).data;
+
+		return { team, token, issue, headers };
+	}
+
+	async function dropFile(
+		page: import('@playwright/test').Page,
+		selector: string,
+		filename: string,
+		mime: string,
+		bytes: number[],
+	) {
+		await page.evaluate(
+			async ({ selector, filename, mime, bytes }) => {
+				const el = document.querySelector(selector);
+				if (!el) throw new Error(`no element matching ${selector}`);
+				const data = new Uint8Array(bytes);
+				const file = new File([data], filename, { type: mime });
+				const dt = new DataTransfer();
+				dt.items.add(file);
+				for (const type of ['dragenter', 'dragover', 'drop']) {
+					el.dispatchEvent(
+						new DragEvent(type, { bubbles: true, cancelable: true, dataTransfer: dt }),
+					);
+				}
+			},
+			{ selector, filename, mime, bytes: Array.from(bytes) },
+		);
+	}
+
+	test('drag-drop adds a chip, sends, renders an icon thumb, opens in new tab', async ({
+		page,
+		context,
+	}) => {
+		await authenticate(page);
+		const { team, issue } = await createIssue(page);
+
+		await page.goto(`/teams/${team.slug}/issues/${issue.id}`);
+		await waitForPageLoad(page);
+		await expect(page.getByPlaceholder('Add a comment...')).toBeVisible({ timeout: 20000 });
+
+		await dropFile(
+			page,
+			'[data-testid="comment-attachments-drop"]',
+			'shot.png',
+			'image/png',
+			Array.from(PNG_BYTES),
+		);
+
+		const chip = page.locator('[data-testid="comment-attachment-chip"]', { hasText: 'shot.png' });
+		await expect(chip).toBeVisible({ timeout: 10000 });
+
+		const send = page.getByRole('button', { name: 'Comment', exact: true });
+		await expect(send).toBeEnabled();
+		await send.click();
+
+		const thumb = page
+			.locator('[data-testid="comment-attachment-thumb"][data-filename="shot.png"]')
+			.first();
+		await expect(thumb).toBeVisible({ timeout: 15000 });
+
+		const [popup] = await Promise.all([context.waitForEvent('page'), thumb.click()]);
+		await popup.waitForLoadState();
+		expect(popup.url()).toContain('/api/assets/');
+		await popup.close();
+	});
+
+	test('rejects an unsupported extension with an inline error chip', async ({ page }) => {
+		await authenticate(page);
+		const { team, issue } = await createIssue(page);
+
+		await page.goto(`/teams/${team.slug}/issues/${issue.id}`);
+		await waitForPageLoad(page);
+		await expect(page.getByPlaceholder('Add a comment...')).toBeVisible({ timeout: 20000 });
+
+		await dropFile(
+			page,
+			'[data-testid="comment-attachments-drop"]',
+			'virus.exe',
+			'application/octet-stream',
+			[0, 1, 2],
+		);
+
+		const errorChip = page.locator('[data-testid="comment-attachment-error"]');
+		await expect(errorChip).toBeVisible({ timeout: 5000 });
+		await expect(errorChip).toContainText('virus.exe');
+	});
+
+	test('mobile viewport — chips wrap and overlay still triggers', async ({ page }) => {
+		await page.setViewportSize({ width: 375, height: 812 });
+		await authenticate(page);
+		const { team, issue } = await createIssue(page);
+
+		await page.goto(`/teams/${team.slug}/issues/${issue.id}`);
+		await waitForPageLoad(page);
+		await expect(page.getByPlaceholder('Add a comment...')).toBeVisible({ timeout: 20000 });
+
+		await dropFile(
+			page,
+			'[data-testid="comment-attachments-drop"]',
+			'mobile.png',
+			'image/png',
+			Array.from(PNG_BYTES),
+		);
+
+		await expect(
+			page.locator('[data-testid="comment-attachment-chip"]', { hasText: 'mobile.png' }),
+		).toBeVisible({ timeout: 10000 });
+	});
+});

--- a/test/e2e/issue-comment-attachments.spec.ts
+++ b/test/e2e/issue-comment-attachments.spec.ts
@@ -96,6 +96,74 @@ test.describe('Issue Comment Attachments', () => {
 		await popup.close();
 	});
 
+	test('hint with tooltip shows when empty, hides once a chip appears, returns after removal', async ({
+		page,
+	}) => {
+		await authenticate(page);
+		const { team, issue } = await createIssue(page);
+
+		await page.goto(`/teams/${team.slug}/issues/${issue.id}`);
+		await waitForPageLoad(page);
+		await expect(page.getByPlaceholder('Add a comment...')).toBeVisible({ timeout: 20000 });
+
+		const hint = page.locator('[data-testid="comment-attachment-hint"]');
+		await expect(hint).toBeVisible();
+		await expect(hint).toContainText('Drag and drop files to attach');
+
+		const info = page.locator('[data-testid="comment-attachment-hint-info"]');
+		await info.hover();
+		const tooltip = page.getByRole('tooltip');
+		await expect(tooltip).toBeVisible({ timeout: 5000 });
+		await expect(tooltip).toContainText('PNG');
+		await expect(tooltip).toContainText('PDF');
+		await expect(tooltip).toContainText('MP3');
+		await expect(tooltip).toContainText('MP4');
+		await expect(tooltip).toContainText('10');
+
+		await dropFile(
+			page,
+			'[data-testid="comment-attachments-drop"]',
+			'shot.png',
+			'image/png',
+			Array.from(PNG_BYTES),
+		);
+
+		const chip = page.locator('[data-testid="comment-attachment-chip"]', { hasText: 'shot.png' });
+		await expect(chip).toBeVisible({ timeout: 10000 });
+		await expect(hint).toBeHidden();
+
+		await chip.getByRole('button', { name: 'Remove attachment' }).click();
+		await expect(chip).toBeHidden();
+		await expect(hint).toBeVisible();
+	});
+
+	test('pending chip exposes a preview link with the signed asset URL', async ({ page }) => {
+		await authenticate(page);
+		const { team, issue } = await createIssue(page);
+
+		await page.goto(`/teams/${team.slug}/issues/${issue.id}`);
+		await waitForPageLoad(page);
+		await expect(page.getByPlaceholder('Add a comment...')).toBeVisible({ timeout: 20000 });
+
+		await dropFile(
+			page,
+			'[data-testid="comment-attachments-drop"]',
+			'preview.png',
+			'image/png',
+			Array.from(PNG_BYTES),
+		);
+
+		const preview = page
+			.locator('[data-testid="comment-attachment-preview"]')
+			.filter({ hasText: 'preview.png' });
+		await expect(preview).toBeVisible({ timeout: 10000 });
+		await expect(preview).toHaveAttribute('target', '_blank');
+		await expect(preview).toHaveAttribute('rel', 'noopener noreferrer');
+		const href = await preview.getAttribute('href');
+		expect(href).toBeTruthy();
+		expect(href).toContain('/api/assets/');
+	});
+
 	test('rejects an unsupported extension with an inline error chip', async ({ page }) => {
 		await authenticate(page);
 		const { team, issue } = await createIssue(page);
@@ -117,7 +185,9 @@ test.describe('Issue Comment Attachments', () => {
 		await expect(errorChip).toContainText('virus.exe');
 	});
 
-	test('mobile viewport — chips wrap and overlay still triggers', async ({ page }) => {
+	test('mobile viewport — hint visible, chips wrap and overlay still triggers', async ({
+		page,
+	}) => {
 		await page.setViewportSize({ width: 375, height: 812 });
 		await authenticate(page);
 		const { team, issue } = await createIssue(page);
@@ -125,6 +195,10 @@ test.describe('Issue Comment Attachments', () => {
 		await page.goto(`/teams/${team.slug}/issues/${issue.id}`);
 		await waitForPageLoad(page);
 		await expect(page.getByPlaceholder('Add a comment...')).toBeVisible({ timeout: 20000 });
+
+		const hint = page.locator('[data-testid="comment-attachment-hint"]');
+		await expect(hint).toBeVisible();
+		await expect(hint).toContainText('Drag and drop files to attach');
 
 		await dropFile(
 			page,
@@ -134,8 +208,11 @@ test.describe('Issue Comment Attachments', () => {
 			Array.from(PNG_BYTES),
 		);
 
-		await expect(
-			page.locator('[data-testid="comment-attachment-chip"]', { hasText: 'mobile.png' }),
-		).toBeVisible({ timeout: 10000 });
+		const chip = page.locator('[data-testid="comment-attachment-chip"]', {
+			hasText: 'mobile.png',
+		});
+		await expect(chip).toBeVisible({ timeout: 10000 });
+		await expect(hint).toBeHidden();
+		await expect(chip.locator('[data-testid="comment-attachment-preview"]')).toBeVisible();
 	});
 });

--- a/test/e2e/run-failed-comment.spec.ts
+++ b/test/e2e/run-failed-comment.spec.ts
@@ -1,0 +1,109 @@
+import { expect, type Page, test } from '@playwright/test';
+import { authenticate, createTeamWithAgents } from './helpers';
+
+interface MockSetup {
+	teamId: string;
+	teamSlug: string;
+	agentId: string;
+	agentSlug: string;
+	issueId: string;
+}
+
+async function mockRunFailedComment(page: Page, setup: MockSetup): Promise<void> {
+	const failedComment = {
+		id: 'aaaa0000-0000-0000-0000-000000000001',
+		issue_id: setup.issueId,
+		content_type: 'system',
+		content: {
+			kind: 'run_failed',
+			run_id: 'bbbb0000-0000-0000-0000-000000000777',
+			status: 'timed_out',
+			error: 'The operation timed out.',
+			member_id: setup.agentId,
+			agent_slug: setup.agentSlug,
+		},
+		chosen_option: null,
+		created_at: '2026-05-20T11:30:40Z',
+		author_type: 'board',
+		author_name: 'Board',
+		author_member_id: null,
+	};
+
+	await page.route('**/api/teams/*/issues/*/comments**', async (route) => {
+		if (route.request().method() !== 'GET') return route.continue();
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({ data: [failedComment] }),
+		});
+	});
+}
+
+async function setupIssue(page: Page): Promise<MockSetup> {
+	const { team, token } = await createTeamWithAgents(page);
+	const headers = { Authorization: `Bearer ${token}` };
+
+	const agentsRes = await page.request.get(`/api/teams/${team.id}/agents`, { headers });
+	const agents = ((await agentsRes.json()) as { data: Array<{ id: string; slug: string }> }).data;
+	const agent = agents.find((a) => a.slug === 'ceo') ?? agents[0];
+
+	const projectRes = await page.request.post(`/api/teams/${team.id}/projects`, {
+		headers,
+		data: { name: 'Run Failed Project', description: 'Test project.' },
+	});
+	const project = ((await projectRes.json()) as { data: { id: string } }).data;
+
+	const issueRes = await page.request.post(`/api/teams/${team.id}/issues`, {
+		headers,
+		data: { project_id: project.id, title: 'Run Failed Issue', assignee_id: agent.id },
+	});
+	const issue = ((await issueRes.json()) as { data: { id: string } }).data;
+
+	return {
+		teamId: team.id,
+		teamSlug: team.slug,
+		agentId: agent.id,
+		agentSlug: agent.slug,
+		issueId: issue.id,
+	};
+}
+
+test('issue page renders run_failed system comment with agent link and error', async ({ page }) => {
+	await authenticate(page);
+	const setup = await setupIssue(page);
+	await mockRunFailedComment(page, setup);
+
+	await page.goto(`/teams/${setup.teamSlug}/issues/${setup.issueId}`);
+
+	const failureComment = page.getByTestId('run-failed-comment');
+	await expect(failureComment).toBeVisible({ timeout: 20_000 });
+	await expect(failureComment).toContainText('timed out');
+	await expect(failureComment).toContainText('The operation timed out.');
+	await expect(failureComment).toContainText('Waking agent to retry.');
+
+	const agentLink = failureComment.getByTestId('run-failed-agent');
+	await expect(agentLink).toBeVisible();
+	await expect(agentLink).toContainText(`@${setup.agentSlug}`);
+	await expect(agentLink).toHaveAttribute(
+		'href',
+		new RegExp(`/teams/${setup.teamSlug}/agents/${setup.agentSlug}$`),
+	);
+});
+
+test('run_failed comment renders correctly on mobile viewport', async ({ page }) => {
+	await page.setViewportSize({ width: 375, height: 800 });
+	await authenticate(page);
+	const setup = await setupIssue(page);
+	await mockRunFailedComment(page, setup);
+
+	await page.goto(`/teams/${setup.teamSlug}/issues/${setup.issueId}`);
+
+	const failureComment = page.getByTestId('run-failed-comment');
+	await expect(failureComment).toBeVisible({ timeout: 20_000 });
+	await expect(failureComment).toContainText('timed out');
+	await expect(failureComment).toContainText('The operation timed out.');
+
+	const agentLink = failureComment.getByTestId('run-failed-agent');
+	await expect(agentLink).toBeVisible();
+	await expect(agentLink).toContainText(`@${setup.agentSlug}`);
+});


### PR DESCRIPTION
- Drag-and-drop file uploads on issue comments (≤10 MB;
 `txt/pdf/png/jpg/jpeg/gif/mp3/opus/aac/wav/mp4/mov/webm`). Assets are project-scoped on disk under `dataDir`,
  bind-mounted read-only into the project agent container at `/workspace/.hezo/assets`, and served to the
 board via 1-hour HMAC-SHA256 signed URLs so bearer tokens never leak to `<img>`/new-tab loads. Coach-review
 prompts and the `list_comments` MCP tool surface attachments by in-container path so agents can read them
 through their filesystem tool.
 - New schema: `assets` (team/project-scoped, tracks `sha256`/`byte_size`/`original_filename`/`content_type`),
  `comment_attachments` join (cascades on comment delete), `issue_attachments` reserved for later. `project_id
  NOT NULL` on `assets` prevents cross-project reuse.
 - When a heartbeat run ends in `failed` or `timed_out`, post a `run_failed` system comment (agent @mention +
 truncated error) and queue an automation wakeup so the agent retries. Suppressed after three consecutive
 failures to avoid loops; resumes after a successful run.