### PR TITLE
feat: remove "general help" escape hatch from onboarding choice

### DIFF
--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -1345,13 +1345,9 @@ export function registerTools(
 					slug,
 					taskPrefix: prefixResult.prefix,
 					description: (args.description as string | undefined) ?? '',
-					createPlanningTask: true,
 				});
 
 			broadcastRowChange(wsManager, wsRoom.team(teamId), 'projects', 'INSERT', project);
-			if (!planningTask) {
-				throw new Error('Expected planning task for MCP project creation');
-			}
 			broadcastRowChange(wsManager, wsRoom.team(teamId), 'tasks', 'INSERT', planningTask);
 
 			if (!deferCaptainPlanningWake) {

--- a/packages/server/src/routes/teams.ts
+++ b/packages/server/src/routes/teams.ts
@@ -146,7 +146,6 @@ teamsRoutes.post('/teams/:teamId/onboarding/direct', async (c) => {
 		template_id?: string;
 		project_name?: string;
 		project_description?: string;
-		skip_planning_task?: boolean;
 	}>();
 	if (!body.template_id?.trim()) {
 		return err(c, 'INVALID_REQUEST', 'template_id is required', 400);
@@ -168,7 +167,6 @@ teamsRoutes.post('/teams/:teamId/onboarding/direct', async (c) => {
 		containerLogStreamer: c.get('containerLogStreamer'),
 		sshAgentServer: c.get('sshAgentServer'),
 		egressCAPath: c.get('egressProxy')?.caCertPath ?? null,
-		skipPlanningTask: body.skip_planning_task === true,
 	});
 
 	if (!result.ok) {

--- a/packages/server/src/services/approval-side-effects.ts
+++ b/packages/server/src/services/approval-side-effects.ts
@@ -365,13 +365,9 @@ export async function applyApprovalSideEffect(
 						slug: projectSlug,
 						taskPrefix: prefixResult.prefix,
 						description: projectDescription,
-						createPlanningTask: true,
 					});
 
 				broadcastRowChange(wsManager, wsRoom.team(teamId), 'projects', 'INSERT', project);
-				if (!planningTask) {
-					throw new Error('Expected planning task for approval-driven project creation');
-				}
 				broadcastRowChange(wsManager, wsRoom.team(teamId), 'tasks', 'INSERT', planningTask);
 
 				if (!deferCaptainPlanningWake) {
@@ -453,16 +449,10 @@ export async function applyApprovalSideEffect(
 				taskPrefix: prefixResult.prefix,
 				description: projectDescription,
 				initialPrd,
-				createPlanningTask: true,
 			});
 
 			if (wsManager) {
 				broadcastRowChange(wsManager, wsRoom.team(teamId), 'projects', 'INSERT', project);
-			}
-			if (!planningTask) {
-				throw new Error('Expected planning task for project_creation approval');
-			}
-			if (wsManager) {
 				broadcastRowChange(wsManager, wsRoom.team(teamId), 'tasks', 'INSERT', planningTask);
 			}
 

--- a/packages/server/src/services/onboarding-direct.ts
+++ b/packages/server/src/services/onboarding-direct.ts
@@ -31,8 +31,6 @@ export interface OnboardingDirectInput {
 	sshAgentServer?: SshAgentServer | null;
 	/** Host path to the egress CA PEM; bind-mounted into the project container. */
 	egressCAPath?: string | null;
-	/** When true, the project is created without a planning task (e.g. the "general help" exploratory project). */
-	skipPlanningTask?: boolean;
 }
 
 export type OnboardingDirectResult =
@@ -40,8 +38,8 @@ export type OnboardingDirectResult =
 			ok: true;
 			project_id: string;
 			project_slug: string;
-			planning_task_id: string | null;
-			planning_task_identifier: string | null;
+			planning_task_id: string;
+			planning_task_identifier: string;
 			created_agent_slugs: string[];
 	  }
 	| { ok: false; code: 'INVALID_REQUEST' | 'CONFLICT' | 'NOT_FOUND' | 'INTERNAL'; message: string };
@@ -130,19 +128,16 @@ export async function runOnboardingDirect(
 		slug: projectSlug,
 		taskPrefix: prefixResult.prefix,
 		description: input.projectDescription?.trim() ?? '',
-		createPlanningTask: !input.skipPlanningTask,
 	});
 
 	broadcastRowChange(input.wsManager, wsRoom.team(input.teamId), 'projects', 'INSERT', project);
-	if (planningTask) {
-		broadcastRowChange(input.wsManager, wsRoom.team(input.teamId), 'tasks', 'INSERT', planningTask);
-		try {
-			await createWakeup(db, captainMemberId, input.teamId, WakeupSource.Assignment, {
-				task_id: planningTask.id as string,
-			});
-		} catch (e) {
-			log.error('Failed to wake Captain on planning task after direct onboarding:', e);
-		}
+	broadcastRowChange(input.wsManager, wsRoom.team(input.teamId), 'tasks', 'INSERT', planningTask);
+	try {
+		await createWakeup(db, captainMemberId, input.teamId, WakeupSource.Assignment, {
+			task_id: planningTask.id as string,
+		});
+	} catch (e) {
+		log.error('Failed to wake Captain on planning task after direct onboarding:', e);
 	}
 
 	const teamSlugRow = await db.query<{ slug: string }>('SELECT slug FROM teams WHERE id = $1', [
@@ -177,8 +172,8 @@ export async function runOnboardingDirect(
 		ok: true,
 		project_id: project.id as string,
 		project_slug: project.slug as string,
-		planning_task_id: (planningTask?.id as string | undefined) ?? null,
-		planning_task_identifier: (planningTask?.identifier as string | undefined) ?? null,
+		planning_task_id: planningTask.id as string,
+		planning_task_identifier: planningTask.identifier as string,
 		created_agent_slugs: apply.created_slugs,
 	};
 }

--- a/packages/server/src/services/project-create.ts
+++ b/packages/server/src/services/project-create.ts
@@ -11,13 +11,11 @@ export interface CreateProjectWithPlanningInput {
 	description: string;
 	dockerBaseImage?: string;
 	initialPrd?: string | null;
-	/** When false, the project is created without a planning task. Caller must pass this explicitly. */
-	createPlanningTask: boolean;
 }
 
 export interface CreateProjectWithPlanningResult {
 	project: Record<string, unknown>;
-	planningTask: Record<string, unknown> | null;
+	planningTask: Record<string, unknown>;
 	/** True when this was the first user-facing project at insert time (defer Captain planning wakeup). */
 	deferCaptainPlanningWake: boolean;
 }
@@ -65,11 +63,6 @@ export async function createProjectWithPlanningTask(
 				 VALUES ($1, $2, 'project_doc', 'initial-prd.md', $3)`,
 				[project.id, input.teamId, initialPrd],
 			);
-		}
-
-		if (!input.createPlanningTask) {
-			await db.query('COMMIT');
-			return { project, planningTask: null, deferCaptainPlanningWake };
 		}
 
 		const { number: taskNumber, identifier } = await allocateTaskIdentifier(

--- a/packages/server/src/test/helpers/app.ts
+++ b/packages/server/src/test/helpers/app.ts
@@ -173,7 +173,6 @@ export async function createTestProject(
 		task_prefix?: string;
 		initial_prd?: string | null;
 		docker_base_image?: string;
-		createPlanningTask?: boolean;
 	},
 ): Promise<{
 	status: 201;
@@ -213,7 +212,6 @@ export async function createTestProject(
 		description: input.description ?? '',
 		dockerBaseImage: input.docker_base_image,
 		initialPrd: input.initial_prd ?? null,
-		createPlanningTask: input.createPlanningTask ?? true,
 	});
 
 	const data: CreatedTestProject = {
@@ -227,8 +225,8 @@ export async function createTestProject(
 		docker_base_image: (project.docker_base_image as string) ?? 'hezo/agent-base:latest',
 		container_id: (project.container_id as string | null) ?? null,
 		container_status: (project.container_status as string | null) ?? null,
-		planning_task_id: (planningTask?.id as string) ?? null,
-		planning_task_identifier: (planningTask?.identifier as string) ?? null,
+		planning_task_id: planningTask.id as string,
+		planning_task_identifier: planningTask.identifier as string,
 	};
 
 	return {

--- a/packages/web/src/components/setup/onboarding-choice.tsx
+++ b/packages/web/src/components/setup/onboarding-choice.tsx
@@ -1,9 +1,6 @@
-import { useNavigate } from '@tanstack/react-router';
 import { MessagesSquare, Sparkles } from 'lucide-react';
 import { useState } from 'react';
-import { useOnboardingDirect } from '../../hooks/use-onboarding-direct';
 import { useStartOnboardingIntake } from '../../hooks/use-onboarding-intake';
-import { useTeamTemplates } from '../../hooks/use-team-templates';
 import { Button } from '../ui/button';
 import { Card } from '../ui/card';
 import { DirectFlow } from './direct-flow';
@@ -19,30 +16,10 @@ interface OnboardingChoiceProps {
 export function OnboardingChoice({ teamId, onChosen }: OnboardingChoiceProps) {
 	const [mode, setMode] = useState<Mode>('choose');
 	const startIntake = useStartOnboardingIntake(teamId);
-	const directOnboarding = useOnboardingDirect(teamId);
-	const { data: templates } = useTeamTemplates();
-	const navigate = useNavigate();
-
-	const blankTemplate = templates?.find((t) => t.name === 'Blank');
 
 	async function handleStartChat() {
 		await startIntake.mutateAsync();
 		onChosen();
-	}
-
-	async function handleGeneralHelp() {
-		if (!blankTemplate) return;
-		const result = await directOnboarding.mutateAsync({
-			template_id: blankTemplate.id,
-			project_name: 'General',
-			project_description: 'Catch-all for ad-hoc help and one-off tasks.',
-			skip_planning_task: true,
-		});
-		onChosen();
-		navigate({
-			to: '/teams/$teamId/projects/$projectId/tasks',
-			params: { teamId, projectId: result.project_slug },
-		});
 	}
 
 	if (mode === 'direct') {
@@ -87,25 +64,6 @@ export function OnboardingChoice({ teamId, onChosen }: OnboardingChoiceProps) {
 						Browse templates
 					</Button>
 				</Card>
-			</div>
-
-			<div className="text-center">
-				<button
-					type="button"
-					onClick={handleGeneralHelp}
-					disabled={!blankTemplate || directOnboarding.isPending}
-					data-testid="choice-general"
-					className="text-[13px] text-text-muted hover:text-text underline disabled:opacity-50"
-				>
-					{directOnboarding.isPending
-						? 'Setting up your General project…'
-						: 'Just exploring? Set me up with general help →'}
-				</button>
-				{directOnboarding.error && (
-					<p className="mt-2 text-[12px] text-accent-red">
-						{(directOnboarding.error as { message?: string }).message || 'Something went wrong'}
-					</p>
-				)}
 			</div>
 		</div>
 	);

--- a/packages/web/src/hooks/use-onboarding-direct.ts
+++ b/packages/web/src/hooks/use-onboarding-direct.ts
@@ -6,14 +6,13 @@ export interface OnboardingDirectInput {
 	template_id: string;
 	project_name: string;
 	project_description?: string;
-	skip_planning_task?: boolean;
 }
 
 export interface OnboardingDirectResult {
 	project_id: string;
 	project_slug: string;
-	planning_task_id: string | null;
-	planning_task_identifier: string | null;
+	planning_task_id: string;
+	planning_task_identifier: string;
 	created_agent_slugs: string[];
 }
 

--- a/test/e2e/onboarding-direct.spec.ts
+++ b/test/e2e/onboarding-direct.spec.ts
@@ -51,127 +51,24 @@ test.describe('Onboarding direct flow', () => {
 		expect(created?.name).toBe('My First App');
 	});
 
-	test('clicking "general help" on the home choice navigates to the General project tasks page', async ({
+	test('the first-time choice screen no longer exposes a "general help" escape hatch', async ({
 		page,
 	}) => {
 		await authenticate(page);
-		const token = await getToken(page);
-		const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
 
-		// The home page is pinned to the seeded default team, so the OnboardingChoice
-		// only renders when that team has no intake and no project. Other parallel
-		// tests may have already onboarded it; in that case skip the UI navigation
-		// check since the button cannot appear.
 		await page.goto('/home');
 		await waitForPageLoad(page);
 		await page.reload();
 		await waitForPageLoad(page);
 
-		const generalButton = page.getByTestId('choice-general');
-		if (!(await generalButton.isVisible().catch(() => false))) {
+		const choiceRoot = page.getByTestId('onboarding-choice');
+		if (!(await choiceRoot.isVisible().catch(() => false))) {
 			test.skip(true, 'default team already onboarded by a parallel test');
 			return;
 		}
 
-		await generalButton.click();
-		await page.waitForURL(/\/teams\/default\/projects\/general\/tasks/, { timeout: 15_000 });
-		expect(page.url()).toMatch(/\/teams\/default\/projects\/general\/tasks/);
-
-		const projectsRes = await page.request.get('/api/teams/default/projects', { headers });
-		const projects = (await projectsRes.json()) as { data: Array<{ slug: string; name: string }> };
-		expect(projects.data.some((p) => p.slug === 'general' && p.name === 'General')).toBe(true);
-	});
-
-	test('"general help" creates a Blank-template General project with no planning task', async ({
-		page,
-	}) => {
-		await authenticate(page);
-		const token = await getToken(page);
-		const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
-
-		const typesRes = await page.request.get('/api/team-templates', { headers });
-		const types = (await typesRes.json()) as { data: Array<{ id: string; name: string }> };
-		const blank = types.data.find((t) => t.name === 'Blank');
-
-		const uid = `${Date.now()}${Math.random().toString(36).slice(2, 6)}`;
-		const teamRes = await page.request.post('/api/teams', {
-			headers,
-			data: { name: `Onboard General E2E ${uid}`, template_id: blank?.id },
-		});
-		const team = ((await teamRes.json()) as { data: { slug: string } }).data;
-
-		const generalRes = await page.request.post(`/api/teams/${team.slug}/onboarding/direct`, {
-			headers,
-			data: {
-				template_id: blank?.id,
-				project_name: 'General',
-				project_description: 'Catch-all for ad-hoc help and one-off tasks.',
-				skip_planning_task: true,
-			},
-		});
-		expect(generalRes.status()).toBe(201);
-		const general = (
-			(await generalRes.json()) as {
-				data: { project_id: string; planning_task_id: string | null };
-			}
-		).data;
-		expect(general.planning_task_id).toBeNull();
-
-		const projectsRes = await page.request.get(`/api/teams/${team.slug}/projects`, { headers });
-		const projects = (await projectsRes.json()) as { data: Array<{ slug: string; name: string }> };
-		expect(projects.data.some((p) => p.slug === 'general' && p.name === 'General')).toBe(true);
-
-		const tasksRes = await page.request.get(
-			`/api/teams/${team.slug}/tasks?project_id=${general.project_id}`,
-			{ headers },
-		);
-		const tasks = (await tasksRes.json()) as { data: unknown[] };
-		expect(tasks.data).toHaveLength(0);
-	});
-
-	test('"general help" provisions a container for the General project so agent wakeups can run', async ({
-		page,
-	}) => {
-		await authenticate(page);
-		const token = await getToken(page);
-		const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
-
-		const typesRes = await page.request.get('/api/team-templates', { headers });
-		const types = (await typesRes.json()) as { data: Array<{ id: string; name: string }> };
-		const blank = types.data.find((t) => t.name === 'Blank');
-
-		const uid = `${Date.now()}${Math.random().toString(36).slice(2, 6)}`;
-		const teamRes = await page.request.post('/api/teams', {
-			headers,
-			data: { name: `Onboard General Container E2E ${uid}`, template_id: blank?.id },
-		});
-		const team = ((await teamRes.json()) as { data: { slug: string } }).data;
-
-		const generalRes = await page.request.post(`/api/teams/${team.slug}/onboarding/direct`, {
-			headers,
-			data: {
-				template_id: blank?.id,
-				project_name: 'General',
-				project_description: 'Catch-all for ad-hoc help and one-off tasks.',
-				skip_planning_task: true,
-			},
-		});
-		expect(generalRes.status()).toBe(201);
-
-		// provisionContainer is fire-and-forget; poll until the General project's
-		// container_status flips out of null. Without this, agent wakeups for tasks
-		// in the project would be silently marked Failed by activateAgent.
-		await expect
-			.poll(
-				async () => {
-					const res = await page.request.get(`/api/teams/${team.slug}/projects`, { headers });
-					const json = (await res.json()) as {
-						data: Array<{ slug: string; container_status: string | null }>;
-					};
-					return json.data.find((p) => p.slug === 'general')?.container_status ?? null;
-				},
-				{ timeout: 30_000, intervals: [500, 1000, 2000] },
-			)
-			.not.toBeNull();
+		await expect(page.getByTestId('choice-general')).toHaveCount(0);
+		await expect(page.getByTestId('choice-chat')).toBeVisible();
+		await expect(page.getByTestId('choice-direct')).toBeVisible();
 	});
 });


### PR DESCRIPTION
Drop the tertiary "Just exploring? Set me up with general help" link from the first-time onboarding choice. It silently picked the Blank template, named the project "General", and skipped the planning task — a dead-end path at odds with the product's audience. The Blank template stays reachable via "Pick a template", so nothing is lost.

While we're at it, unwind the `skip_planning_task` / `skipPlanningTask` / `createPlanningTask` plumbing across:

- `POST /api/teams/:teamId/onboarding/direct` request body
- `runOnboardingDirect` (`onboarding-direct.ts`)
- `createProjectWithPlanningTask` (`project-create.ts`) — planning task is now always created
- `project_creation` and `team_template` approval side-effect handlers
- MCP `create_project` tool
- `createTestProject` test helper

Drop the three e2e tests that targeted the escape hatch; add a regression test that the choice screen no longer renders the `choice-general` button.

Note: rebased onto current main, which independently shipped per-project Captain intake via a different paradigm (form-driven + `project_creation` approval). My earlier chat-driven per-project intake work has been discarded in favor of main's implementation; only the escape-hatch cleanup remains in this PR.

https://claude.ai/code/session_01UncG9p69KrbEPwEMz1mBSs