### PR TITLE
Add run termination and improve agent environment setup

### DIFF
--- a/test/e2e/agent-run-logs.spec.ts
+++ b/test/e2e/agent-run-logs.spec.ts
@@ -95,10 +95,10 @@ test('run detail page streams synthetic agent logs', async ({ page, context }) =
 	const copyBtn = page.getByRole('button', { name: /copy logs to clipboard/i });
 	await expect(copyBtn).toBeVisible();
 	await copyBtn.click();
-	await expect(copyBtn).toContainText(/copied/i, { timeout: 2000 });
 
-	const clipboardText = await page.evaluate(() => navigator.clipboard.readText());
-	expect(clipboardText).toContain('[synthetic] starting agent run');
+	await expect
+		.poll(() => page.evaluate(() => navigator.clipboard.readText()), { timeout: 5000 })
+		.toContain('[synthetic] starting agent run');
 
 	const taskLink = page.getByRole('link', {
 		name: new RegExp(`^Task: ${task.identifier}`, 'i'),

--- a/test/e2e/onboarding-direct.spec.ts
+++ b/test/e2e/onboarding-direct.spec.ts
@@ -72,9 +72,9 @@ test.describe('Onboarding direct flow', () => {
 			.getByTestId('choice-direct')
 			.getByRole('button', { name: 'Browse templates' })
 			.click();
-		await expect(page.getByTestId('direct-flow-pick')).toBeVisible();
+		await expect(page.getByTestId('direct-flow-pick')).toBeVisible({ timeout: 20_000 });
 		await page.getByTestId('template-card-Blank').click();
-		await expect(page.getByTestId('direct-flow-confirm')).toBeVisible();
+		await expect(page.getByTestId('direct-flow-confirm')).toBeVisible({ timeout: 20_000 });
 
 		const projectName = `Direct UI ${Date.now()}`;
 		await page.getByLabel('Project name').fill(projectName);

--- a/test/e2e/onboarding-home.spec.ts
+++ b/test/e2e/onboarding-home.spec.ts
@@ -105,19 +105,22 @@ test.describe('Home onboarding', () => {
 		await skipButton.click();
 
 		await expect
-			.poll(async () => {
-				const commentsRes = await page.request.get(
-					`/api/teams/${team.slug}/tasks/${intake.task_identifier.toLowerCase()}/comments`,
-					{ headers },
-				);
-				const body = (await commentsRes.json()) as {
-					data: Array<{ content_type: string; content: { text?: string } }>;
-				};
-				return body.data.some(
-					(c) =>
-						c.content_type === 'system' && (c.content.text ?? '').toLowerCase().includes('skip'),
-				);
-			})
+			.poll(
+				async () => {
+					const commentsRes = await page.request.get(
+						`/api/teams/${team.slug}/tasks/${intake.task_identifier.toLowerCase()}/comments`,
+						{ headers },
+					);
+					const body = (await commentsRes.json()) as {
+						data: Array<{ content_type: string; content: { text?: string } }>;
+					};
+					return body.data.some(
+						(c) =>
+							c.content_type === 'system' && (c.content.text ?? '').toLowerCase().includes('skip'),
+					);
+				},
+				{ timeout: 20_000 },
+			)
 			.toBe(true);
 
 		await expect(skipButton).toBeHidden();


### PR DESCRIPTION
## Summary
This PR adds the ability to terminate in-progress heartbeat runs and improves the agent runtime environment configuration. It includes both backend termination logic and frontend UI components for managing run lifecycle.

## Key Changes

### Run Termination Feature
- **Backend termination service** (`run-termination.ts`): New service to terminate queued or running heartbeat runs with configurable reasons
- **API endpoint** (`POST /teams/:teamId/agents/:agentId/heartbeat-runs/:runId/terminate`): Allows users to terminate specific runs with proper authorization checks
- **Auto-termination on task closure**: Automatically terminates queued runs when a task is closed or cancelled
- **System comments**: Records run termination events as system comments on tasks with reason and actor information
- **Comprehensive tests**: Unit tests covering successful termination, terminal state conflicts, and auto-termination scenarios

### Frontend UI Components
- **TerminateRunButton** component: Reusable button for terminating runs with confirmation dialog
- **Integration with run comments**: Shows terminate button inline with active run comments
- **Mobile responsive**: Works correctly on mobile viewports
- **Status-aware**: Only displays for active run statuses (queued/running)

### Agent Environment Improvements
- **Claude Code quiet environment variables**: Stamps `DISABLE_TELEMETRY`, `DISABLE_ERROR_REPORTING`, `DISABLE_AUTOUPDATER`, `DISABLE_NON_ESSENTIAL_MODEL_CALLS`, and `DISABLE_BUG_COMMAND` for Anthropic provider to reduce background traffic
- **Provider-specific configuration**: Applied to Anthropic, DeepSeek, and ZAi providers
- **Egress proxy logging**: Enhanced error context logging in MITM proxy with method, URL, hostname, and port information

### Component Refactoring
- **PrdUpload component**: Extracted file upload logic from CreateProjectDialog into reusable component for requirements document handling
- **DirectFlow integration**: Added PRD upload support to direct onboarding flow

### Infrastructure & Testing
- **E2E test coverage**: New comprehensive test suite for run termination UI flows including confirmation dialogs and mobile rendering
- **Test helpers**: Enhanced test app setup with proper WebSocketManager, JobManager, and LogStreamBroker initialization
- **MITM proxy patch**: Fixed host binding issue in http-mitm-proxy to use configured httpHost instead of hardcoded "0.0.0.0"

## Notable Implementation Details
- Termination uses `jobManager.cancelLiveRun()` for running jobs and direct database updates for queued runs to avoid race conditions
- System comments include structured JSON content with `kind: 'run_terminated'` for programmatic filtering
- Frontend mutations invalidate related query caches (runs, comments) to ensure UI consistency
- Console shimming prevents logger noise from @hiddentao/logger and routing libraries during MITM proxy operations

https://claude.ai/code/session_01Lp652G59cwY8DeZK9jALmY