### PR TITLE
feat: captain can update agent prompts; web log toolbar + tooltip polish

### DIFF
--- a/agents/software-development/coach.md
+++ b/agents/software-development/coach.md
@@ -22,7 +22,7 @@ You do not implement features or review code. Your sole purpose is organisationa
 
 ## Triggering
 
-You are not assigned tasks in the traditional sense. When any task is marked `done`, you are woken automatically and receive the completed task's full context (comments, tool-call traces, feedback exchanges). You also run on heartbeat to catch any completed tasks that may have been missed. You are the only agent allowed to call `update_agent_system_prompt`; changes apply immediately and a revision snapshot is recorded so the board can roll back from the agent settings page if needed.
+You are not assigned tasks in the traditional sense. When any task is marked `done`, you are woken automatically and receive the completed task's full context (comments, tool-call traces, feedback exchanges). You also run on heartbeat to catch any completed tasks that may have been missed. You call `update_agent_system_prompt` to append retrospective learned-rules updates; the Captain uses the same tool during team-coherence reviews for broader rewrites. Changes apply immediately and a revision snapshot is recorded so the board can roll back from the agent settings page if needed.
 
 ## Review workflow
 

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -2019,7 +2019,7 @@ export function registerTools(
 	tool(
 		server,
 		'update_agent_system_prompt',
-		'Apply a system prompt change for an agent. Only the Coach agent can call this. The change is applied immediately and a revision snapshot is stored so the board can restore previous versions.',
+		'Apply a system prompt change for an agent. Callable by the Coach agent (for after-task learned-rules updates) or by the Captain of the same team (during team-coherence reviews). The change is applied immediately and a revision snapshot is stored so the board can restore previous versions.',
 		{
 			team_id: z.string().describe('Team ID'),
 			agent_id: z.string().describe('Target agent member ID'),
@@ -2030,8 +2030,12 @@ export function registerTools(
 			const denied = await verifyTeamAccess(db, auth, args.team_id as string);
 			if (denied) return { error: denied };
 
-			if (!(await isCoach(db, auth))) {
-				return { error: 'Access denied: only the Coach agent can update system prompts' };
+			const allowed =
+				(await isCoach(db, auth)) || (await isCaptainOfTeam(db, auth, args.team_id as string));
+			if (!allowed) {
+				return {
+					error: 'Access denied: only the Coach or the Captain can update system prompts',
+				};
 			}
 
 			const agentCheck = await db.query<{ id: string }>(
@@ -2053,6 +2057,13 @@ export function registerTools(
 				changeSummary: args.change_summary as string,
 				authorMemberId: callerMemberId,
 			});
+
+			trackBackground(
+				enqueueTeamCoherenceReviewTask(db, args.team_id as string, 'prompt_updated').catch((e) =>
+					log.error('Failed to enqueue team coherence review after prompt update:', e),
+				),
+			);
+
 			return { applied: true, document_id: doc.id };
 		},
 		db,

--- a/packages/server/test/coach.test.ts
+++ b/packages/server/test/coach.test.ts
@@ -17,6 +17,8 @@ let coachId: string;
 let engineerId: string;
 let engineerToken: string;
 let architectId: string;
+let captainId: string;
+let captainToken: string;
 let masterKeyManager: MasterKeyManager;
 
 beforeAll(async () => {
@@ -53,16 +55,20 @@ beforeAll(async () => {
 	const coach = agents.find((a: any) => a.slug === 'coach');
 	const engineer = agents.find((a: any) => a.slug === 'engineer');
 	const architect = agents.find((a: any) => a.slug === 'architect');
+	const captain = agents.find((a: any) => a.slug === 'captain');
 
 	expect(coach).toBeTruthy();
 	expect(engineer).toBeTruthy();
 	expect(architect).toBeTruthy();
+	expect(captain).toBeTruthy();
 
 	coachId = coach.id;
 	engineerId = engineer.id;
 	architectId = architect.id;
+	captainId = captain.id;
 
 	({ token: engineerToken } = await mintAgentToken(db, masterKeyManager, engineerId, teamId));
+	({ token: captainToken } = await mintAgentToken(db, masterKeyManager, captainId, teamId));
 
 	const taskRes = await app.request(`/api/teams/${teamId}/tasks`, {
 		method: 'POST',
@@ -231,7 +237,7 @@ describe('Agent system-prompt access', () => {
 		expect(res.status).toBe(404);
 	});
 
-	it('non-coach agents cannot call update_agent_system_prompt via MCP', async () => {
+	it('agents other than Coach and Captain cannot call update_agent_system_prompt via MCP', async () => {
 		const res = await app.request('/mcp', {
 			method: 'POST',
 			headers: { ...authHeader(engineerToken), 'Content-Type': 'application/json' },
@@ -254,6 +260,40 @@ describe('Agent system-prompt access', () => {
 		const body = await res.json();
 		const content = body.result.content?.[0]?.text ?? '';
 		expect(content).toMatch(/Access denied/);
+	});
+
+	it('Captain can call update_agent_system_prompt via MCP', async () => {
+		const res = await app.request('/mcp', {
+			method: 'POST',
+			headers: { ...authHeader(captainToken), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				jsonrpc: '2.0',
+				method: 'tools/call',
+				id: 1,
+				params: {
+					name: 'update_agent_system_prompt',
+					arguments: {
+						team_id: teamId,
+						agent_id: architectId,
+						new_system_prompt: 'Captain coherence rewrite',
+						change_summary: 'team coherence review',
+					},
+				},
+			}),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		const text = body.result.content?.[0]?.text ?? '';
+		const payload = JSON.parse(text);
+		expect(payload.applied).toBe(true);
+		expect(payload.document_id).toBeTruthy();
+
+		const promptRes = await app.request(
+			`/api/teams/${teamId}/agents/${architectId}/system-prompt`,
+			{ headers: authHeader(boardToken) },
+		);
+		const promptDoc = (await promptRes.json()).data;
+		expect(promptDoc.content).toBe('Captain coherence rewrite');
 	});
 });
 

--- a/packages/web/src/components/comment-attachment-thumb.tsx
+++ b/packages/web/src/components/comment-attachment-thumb.tsx
@@ -1,5 +1,6 @@
 import { File, FileAudio, FileText, FileVideo, Image as ImageIcon } from 'lucide-react';
 import type { CommentAttachment } from '../hooks/use-comments';
+import { Tooltip } from './ui/tooltip';
 
 function iconFor(contentType: string) {
 	if (contentType.startsWith('image/')) return <ImageIcon className="h-4 w-4" />;
@@ -13,16 +14,18 @@ function iconFor(contentType: string) {
 
 export function CommentAttachmentThumb({ attachment }: { attachment: CommentAttachment }) {
 	return (
-		<a
-			href={attachment.url}
-			target="_blank"
-			rel="noopener noreferrer"
-			title={attachment.original_filename}
-			data-testid="comment-attachment-thumb"
-			data-filename={attachment.original_filename}
-			className="flex h-9 w-9 items-center justify-center rounded-radius-sm border border-border bg-bg-muted text-text-subtle hover:border-border-hover hover:text-text"
-		>
-			{iconFor(attachment.content_type)}
-		</a>
+		<Tooltip content={attachment.original_filename}>
+			<a
+				href={attachment.url}
+				target="_blank"
+				rel="noopener noreferrer"
+				aria-label={attachment.original_filename}
+				data-testid="comment-attachment-thumb"
+				data-filename={attachment.original_filename}
+				className="flex h-9 w-9 items-center justify-center rounded-radius-sm border border-border bg-bg-muted text-text-subtle hover:border-border-hover hover:text-text"
+			>
+				{iconFor(attachment.content_type)}
+			</a>
+		</Tooltip>
 	);
 }

--- a/packages/web/src/components/comment-attachments-drop.tsx
+++ b/packages/web/src/components/comment-attachments-drop.tsx
@@ -15,6 +15,7 @@ import type { CommentAttachment } from '../hooks/use-comments';
 import { useUploadAttachment } from '../hooks/use-upload-attachment';
 import type { ApiError } from '../lib/api';
 import { InfoTooltip } from './ui/info-tooltip';
+import { Tooltip } from './ui/tooltip';
 
 interface Props {
 	teamId: string;
@@ -200,17 +201,18 @@ export function CommentAttachmentsDrop({ teamId, taskId, value, onChange, childr
 							data-testid="comment-attachment-chip"
 						>
 							{iconFor(a.content_type)}
-							<a
-								href={a.url}
-								target="_blank"
-								rel="noopener noreferrer"
-								title={a.original_filename}
-								className="flex items-center gap-1 text-text hover:underline"
-								data-testid="comment-attachment-preview"
-							>
-								<span className="max-w-[140px] truncate">{a.original_filename}</span>
-								<ExternalLink className="h-3 w-3 shrink-0" />
-							</a>
+							<Tooltip content={a.original_filename}>
+								<a
+									href={a.url}
+									target="_blank"
+									rel="noopener noreferrer"
+									className="flex items-center gap-1 text-text hover:underline"
+									data-testid="comment-attachment-preview"
+								>
+									<span className="max-w-[140px] truncate">{a.original_filename}</span>
+									<ExternalLink className="h-3 w-3 shrink-0" />
+								</a>
+							</Tooltip>
 							<button
 								type="button"
 								aria-label="Remove attachment"

--- a/packages/web/src/components/comment-renderers.tsx
+++ b/packages/web/src/components/comment-renderers.tsx
@@ -40,6 +40,7 @@ import { MarkdownProse } from './markdown-prose';
 import { TerminateRunButton } from './terminate-run-button';
 import { Badge } from './ui/badge';
 import { Button } from './ui/button';
+import { Tooltip } from './ui/tooltip';
 
 export interface CommentData {
 	id: string;
@@ -363,15 +364,16 @@ function RunCommentBody({
 							/>
 						}
 						headerAction={
-							<Link
-								to="/teams/$teamId/agents/$agentId/executions/$runId"
-								params={{ teamId, agentId, runId }}
-								title="View full run"
-								aria-label="View full run"
-								className="inline-flex items-center justify-center h-6 px-2 text-xs text-text-muted hover:text-text hover:bg-bg-muted rounded-radius-md transition-colors"
-							>
-								<DoorOpen className="w-3 h-3" />
-							</Link>
+							<Tooltip content="View full run">
+								<Link
+									to="/teams/$teamId/agents/$agentId/executions/$runId"
+									params={{ teamId, agentId, runId }}
+									aria-label="View full run"
+									className="inline-flex items-center justify-center h-6 px-2 text-xs text-text-muted hover:text-text hover:bg-bg-muted rounded-radius-md transition-colors"
+								>
+									<DoorOpen className="w-3 h-3" />
+								</Link>
+							</Tooltip>
 						}
 					/>
 				</div>
@@ -918,24 +920,24 @@ export function CommentReactions({
 	return (
 		<div className="flex flex-wrap items-center gap-1.5 mt-2" data-testid="comment-reactions">
 			{groups.map((g) => (
-				<button
-					key={g.kind}
-					type="button"
-					onClick={() => toggle(g.kind, g.you_reacted)}
-					disabled={busy}
-					title={reactorsTooltip(g)}
-					aria-pressed={g.you_reacted}
-					data-reaction-kind={g.kind}
-					data-you-reacted={g.you_reacted ? 'true' : 'false'}
-					className={`inline-flex items-center gap-1 min-h-[28px] px-2 rounded-full border text-xs leading-none transition-colors ${
-						g.you_reacted
-							? 'border-accent-blue bg-accent-blue-bg text-accent-blue-text'
-							: 'border-border bg-bg-subtle text-text-muted hover:border-border-hover'
-					} disabled:opacity-60`}
-				>
-					<span aria-hidden="true">{REACTION_GLYPH[g.kind] ?? g.kind}</span>
-					<span className="tabular-nums">{g.members.length}</span>
-				</button>
+				<Tooltip key={g.kind} content={reactorsTooltip(g)}>
+					<button
+						type="button"
+						onClick={() => toggle(g.kind, g.you_reacted)}
+						disabled={busy}
+						aria-pressed={g.you_reacted}
+						data-reaction-kind={g.kind}
+						data-you-reacted={g.you_reacted ? 'true' : 'false'}
+						className={`inline-flex items-center gap-1 min-h-[28px] px-2 rounded-full border text-xs leading-none transition-colors ${
+							g.you_reacted
+								? 'border-accent-blue bg-accent-blue-bg text-accent-blue-text'
+								: 'border-border bg-bg-subtle text-text-muted hover:border-border-hover'
+						} disabled:opacity-60`}
+					>
+						<span aria-hidden="true">{REACTION_GLYPH[g.kind] ?? g.kind}</span>
+						<span className="tabular-nums">{g.members.length}</span>
+					</button>
+				</Tooltip>
 			))}
 			{availableToAdd.length > 0 && (
 				<div className="relative">
@@ -956,19 +958,20 @@ export function CommentReactions({
 							data-testid="reaction-picker"
 						>
 							{availableToAdd.map((kind) => (
-								<button
-									key={kind}
-									type="button"
-									onClick={() => {
-										setPickerOpen(false);
-										toggle(kind, false);
-									}}
-									title={REACTION_LABEL[kind] ?? kind}
-									className="inline-flex items-center justify-center min-w-[32px] min-h-[32px] px-2 rounded text-sm hover:bg-bg-subtle"
-									data-reaction-kind={kind}
-								>
-									{REACTION_GLYPH[kind] ?? kind}
-								</button>
+								<Tooltip key={kind} content={REACTION_LABEL[kind] ?? kind}>
+									<button
+										type="button"
+										onClick={() => {
+											setPickerOpen(false);
+											toggle(kind, false);
+										}}
+										aria-label={REACTION_LABEL[kind] ?? kind}
+										className="inline-flex items-center justify-center min-w-[32px] min-h-[32px] px-2 rounded text-sm hover:bg-bg-subtle"
+										data-reaction-kind={kind}
+									>
+										{REACTION_GLYPH[kind] ?? kind}
+									</button>
+								</Tooltip>
 							))}
 						</div>
 					)}

--- a/packages/web/src/components/log-viewer.tsx
+++ b/packages/web/src/components/log-viewer.tsx
@@ -1,7 +1,8 @@
 import * as Dialog from '@radix-ui/react-dialog';
-import { Check, Copy, Maximize2, Minimize2, Trash2 } from 'lucide-react';
+import { Check, Copy, Maximize2, Minimize2, MoveVertical, Trash2 } from 'lucide-react';
 import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import { Button } from './ui/button';
+import { Tooltip } from './ui/tooltip';
 
 export interface LogViewerLine {
 	id: number;
@@ -105,44 +106,55 @@ export function LogViewer({
 				</div>
 				<div className="flex items-center gap-2">
 					{headerActionLeading}
-					<Button
-						variant="ghost"
-						size="sm"
-						onClick={handleCopy}
-						disabled={lines.length === 0}
-						className="text-xs h-6 px-2"
-						aria-label="Copy logs to clipboard"
-					>
-						{copied ? <Check className="w-3 h-3" /> : <Copy className="w-3 h-3" />}
-					</Button>
-					{!compact && (
-						<>
-							<label className="flex items-center gap-1.5 text-xs text-text-muted cursor-pointer">
-								<input
-									type="checkbox"
-									checked={autoScroll}
-									onChange={(e) => setAutoScroll(e.target.checked)}
-									className="rounded"
-								/>
-								Auto-scroll
-							</label>
-							{onClear && (
-								<Button variant="ghost" size="sm" onClick={onClear} className="text-xs h-6 px-2">
-									<Trash2 className="w-3 h-3" /> Clear
-								</Button>
-							)}
-						</>
+					<Tooltip content="Copy logs">
+						<Button
+							variant="ghost"
+							size="sm"
+							onClick={handleCopy}
+							disabled={lines.length === 0}
+							className="text-xs h-6 px-2"
+							aria-label="Copy logs to clipboard"
+						>
+							{copied ? <Check className="w-3 h-3" /> : <Copy className="w-3 h-3" />}
+						</Button>
+					</Tooltip>
+					<Tooltip content={autoScroll ? 'Auto-scroll on' : 'Auto-scroll off'}>
+						<Button
+							variant="ghost"
+							size="sm"
+							onClick={() => setAutoScroll((v) => !v)}
+							aria-pressed={autoScroll}
+							aria-label="Toggle auto-scroll"
+							className={`text-xs h-6 px-2 ${autoScroll ? 'bg-bg-muted text-text' : ''}`}
+						>
+							<MoveVertical className="w-3 h-3" />
+						</Button>
+					</Tooltip>
+					{!compact && onClear && (
+						<Tooltip content="Clear logs">
+							<Button
+								variant="ghost"
+								size="sm"
+								onClick={onClear}
+								className="text-xs h-6 px-2"
+								aria-label="Clear logs"
+							>
+								<Trash2 className="w-3 h-3" /> Clear
+							</Button>
+						</Tooltip>
 					)}
 					{headerAction}
-					<Button
-						variant="ghost"
-						size="sm"
-						onClick={toggleExpanded}
-						className="text-xs h-6 px-2"
-						aria-label={isExpanded ? 'Collapse log viewer' : 'Expand log viewer'}
-					>
-						{isExpanded ? <Minimize2 className="w-3 h-3" /> : <Maximize2 className="w-3 h-3" />}
-					</Button>
+					<Tooltip content={isExpanded ? 'Collapse' : 'Expand'}>
+						<Button
+							variant="ghost"
+							size="sm"
+							onClick={toggleExpanded}
+							className="text-xs h-6 px-2"
+							aria-label={isExpanded ? 'Collapse log viewer' : 'Expand log viewer'}
+						>
+							{isExpanded ? <Minimize2 className="w-3 h-3" /> : <Maximize2 className="w-3 h-3" />}
+						</Button>
+					</Tooltip>
 				</div>
 			</div>
 			<div ref={attachScrollRef} data-testid={testId} className={bodyClassName}>

--- a/packages/web/src/components/repo-setup-section.tsx
+++ b/packages/web/src/components/repo-setup-section.tsx
@@ -6,6 +6,7 @@ import { GitHubDeviceFlowDialog } from './github-device-flow-dialog';
 import { RepoPickerModal } from './repo-picker-modal';
 import { Badge } from './ui/badge';
 import { Button } from './ui/button';
+import { Tooltip } from './ui/tooltip';
 
 interface RepoSetupSectionProps {
 	teamId: string;
@@ -171,13 +172,16 @@ export function RepoSetupSection({ teamId, projectId }: RepoSetupSectionProps) {
 									{r.is_designated && <Badge color="blue">Designated</Badge>}
 								</div>
 								{r.is_designated ? (
-									<span
-										className="text-text-subtle"
-										title="Designated repository cannot be removed"
-										data-testid={`repo-locked-${r.short_name}`}
-									>
-										<Lock className="w-3.5 h-3.5" />
-									</span>
+									<Tooltip content="Designated repository cannot be removed">
+										<span
+											role="img"
+											aria-label="Designated repository cannot be removed"
+											className="text-text-subtle"
+											data-testid={`repo-locked-${r.short_name}`}
+										>
+											<Lock className="w-3.5 h-3.5" />
+										</span>
+									</Tooltip>
 								) : (
 									<button
 										type="button"

--- a/packages/web/src/components/task-list.tsx
+++ b/packages/web/src/components/task-list.tsx
@@ -11,6 +11,7 @@ import { Button } from './ui/button';
 import { type Column, DataTable } from './ui/data-table';
 import { EmptyState } from './ui/empty-state';
 import { MultiSelect, type MultiSelectOption } from './ui/multi-select';
+import { Tooltip } from './ui/tooltip';
 
 const priorityColors: Record<string, string> = {
 	urgent: 'danger',
@@ -172,22 +173,34 @@ export function TaskList({ teamId, projectId }: TaskListProps) {
 			render: (row) => (
 				<span className="inline-flex items-center gap-1.5">
 					{row.has_active_run && (
-						<span
-							data-testid="task-running-dot"
-							title="Agent run in progress"
-							className="inline-block w-2 h-2 rounded-full bg-accent-amber animate-pulse shrink-0"
-						/>
+						<Tooltip content="Agent run in progress">
+							<span
+								role="img"
+								aria-label="Agent run in progress"
+								data-testid="task-running-dot"
+								className="inline-block w-2 h-2 rounded-full bg-accent-amber animate-pulse shrink-0"
+							/>
+						</Tooltip>
 					)}
 					{!row.has_active_run && row.queued_wakeup && (
-						<span
-							data-testid="task-queued-dot"
-							title={
+						<Tooltip
+							content={
 								row.queued_wakeup.blocker_identifier
 									? `Run queued — waiting on ${row.queued_wakeup.blocker_identifier}`
 									: 'Run queued — waiting'
 							}
-							className="inline-block w-2 h-2 rounded-full bg-accent-blue shrink-0"
-						/>
+						>
+							<span
+								role="img"
+								aria-label={
+									row.queued_wakeup.blocker_identifier
+										? `Run queued — waiting on ${row.queued_wakeup.blocker_identifier}`
+										: 'Run queued — waiting'
+								}
+								data-testid="task-queued-dot"
+								className="inline-block w-2 h-2 rounded-full bg-accent-blue shrink-0"
+							/>
+						</Tooltip>
 					)}
 					{row.identifier}
 				</span>

--- a/packages/web/src/components/team-sidebar.tsx
+++ b/packages/web/src/components/team-sidebar.tsx
@@ -146,7 +146,6 @@ export function TeamSidebar() {
 					<Link
 						to="/settings"
 						className="inline-flex items-center gap-2 px-2 py-1 rounded-radius-md text-[13px] text-text-muted hover:text-text hover:bg-bg-subtle transition-colors"
-						title="Settings"
 					>
 						<Settings className="w-4 h-4" />
 						<span>Settings</span>

--- a/packages/web/src/components/terminate-run-button.tsx
+++ b/packages/web/src/components/terminate-run-button.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { isActiveRunStatus, type RunStatus } from '../hooks/use-heartbeat-runs';
 import { useTerminateRun } from '../hooks/use-terminate-run';
 import { ConfirmDialog } from './ui/confirm-dialog';
+import { Tooltip } from './ui/tooltip';
 
 interface TerminateRunButtonProps {
 	teamId: string;
@@ -33,18 +34,19 @@ export function TerminateRunButton({
 
 	return (
 		<>
-			<button
-				type="button"
-				onClick={() => setOpen(true)}
-				title="Terminate run"
-				aria-label="Terminate run"
-				data-testid="terminate-run-button"
-				disabled={mutation.isPending}
-				className={triggerClass}
-			>
-				<Square className="w-3 h-3" fill="currentColor" />
-				{variant === 'standalone' && <span>Terminate</span>}
-			</button>
+			<Tooltip content="Terminate run">
+				<button
+					type="button"
+					onClick={() => setOpen(true)}
+					aria-label="Terminate run"
+					data-testid="terminate-run-button"
+					disabled={mutation.isPending}
+					className={triggerClass}
+				>
+					<Square className="w-3 h-3" fill="currentColor" />
+					{variant === 'standalone' && <span>Terminate</span>}
+				</button>
+			</Tooltip>
 			<ConfirmDialog
 				open={open}
 				onOpenChange={setOpen}

--- a/packages/web/src/routes/home/index.tsx
+++ b/packages/web/src/routes/home/index.tsx
@@ -8,6 +8,7 @@ import { OnboardingChoice } from '../../components/setup/onboarding-choice';
 import { Avatar, avatarColorFromString } from '../../components/ui/avatar';
 import { Button } from '../../components/ui/button';
 import { Card } from '../../components/ui/card';
+import { Tooltip } from '../../components/ui/tooltip';
 import { useActiveTeamSlug } from '../../hooks/use-active-team-slug';
 import { type OnboardingStatus, useOnboarding } from '../../hooks/use-onboarding';
 import { useOnboardingIntake } from '../../hooks/use-onboarding-intake';
@@ -93,12 +94,13 @@ function HomeProjectsSection({
 									<div className="flex items-center justify-between gap-2">
 										<h3 className="text-[15px] font-medium text-text truncate">{p.name}</h3>
 										{p.container_status && p.container_status !== 'running' && (
-											<span
-												role="img"
-												title={`Container ${p.container_status}`}
-												aria-label={`Container ${p.container_status}`}
-												className="w-2 h-2 rounded-full bg-accent-red shrink-0"
-											/>
+											<Tooltip content={`Container ${p.container_status}`}>
+												<span
+													role="img"
+													aria-label={`Container ${p.container_status}`}
+													className="w-2 h-2 rounded-full bg-accent-red shrink-0"
+												/>
+											</Tooltip>
 										)}
 									</div>
 									{showTeamName && <p className="text-xs text-text-muted truncate">{p.teamName}</p>}

--- a/packages/web/src/routes/teams/$teamId/agents/$agentId/executions/$runId.tsx
+++ b/packages/web/src/routes/teams/$teamId/agents/$agentId/executions/$runId.tsx
@@ -215,6 +215,15 @@ function ExecutionDetailPage() {
 					liveLabel={isActive ? <span className="text-accent-amber">(live)</span> : null}
 					heightClassName="max-h-[60vh]"
 					testId="run-log"
+					headerActionLeading={
+						<TerminateRunButton
+							teamId={teamId}
+							agentId={agentId}
+							runId={runId}
+							status={run.status}
+							taskId={run.task_id}
+						/>
+					}
 				/>
 			</div>
 		</div>

--- a/packages/web/src/routes/teams/$teamId/agents/$agentId/executions/index.tsx
+++ b/packages/web/src/routes/teams/$teamId/agents/$agentId/executions/index.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { Badge } from '../../../../../../components/ui/badge';
+import { Tooltip } from '../../../../../../components/ui/tooltip';
 import { useElapsedDuration } from '../../../../../../hooks/use-elapsed-duration';
 import { type HeartbeatRun, useHeartbeatRuns } from '../../../../../../hooks/use-heartbeat-runs';
 import { formatTriggerReason } from '../../../../../../lib/run-trigger';
@@ -53,9 +54,9 @@ function ExecutionRow({
 				</span>
 			)}
 
-			<span className="text-text-subtle truncate" title={trigger.text}>
-				{trigger.text}
-			</span>
+			<Tooltip content={trigger.text}>
+				<span className="text-text-subtle truncate">{trigger.text}</span>
+			</Tooltip>
 
 			<span className="text-text-muted ml-auto whitespace-nowrap">
 				{run.started_at ? new Date(run.started_at).toLocaleString() : 'queued'}

--- a/packages/web/src/routes/teams/$teamId/projects/$projectId/container.tsx
+++ b/packages/web/src/routes/teams/$teamId/projects/$projectId/container.tsx
@@ -5,6 +5,7 @@ import { LogViewer, type LogViewerLine } from '../../../../../components/log-vie
 import { Badge } from '../../../../../components/ui/badge';
 import { Button } from '../../../../../components/ui/button';
 import { ConfirmDialog } from '../../../../../components/ui/confirm-dialog';
+import { Tooltip } from '../../../../../components/ui/tooltip';
 import {
 	useRebuildContainer,
 	useStartContainer,
@@ -62,48 +63,51 @@ function ContainerPage() {
 					</span>
 				)}
 				<div className="ml-auto flex items-center gap-2">
-					<Button
-						variant="ghost"
-						size="sm"
-						onClick={() => startContainer.mutate()}
-						disabled={anyPending || isActive || !hasContainer}
-						title="Start container"
-					>
-						{startContainer.isPending ? (
-							<Loader2 className="w-3 h-3 animate-spin" />
-						) : (
-							<Play className="w-3 h-3" />
-						)}
-						Start
-					</Button>
-					<Button
-						variant="ghost"
-						size="sm"
-						onClick={() => setStopOpen(true)}
-						disabled={anyPending || isStopping || (!isRunning && !isCreating)}
-						title="Stop container"
-					>
-						{stopContainer.isPending || isStopping ? (
-							<Loader2 className="w-3 h-3 animate-spin" />
-						) : (
-							<Square className="w-3 h-3" />
-						)}
-						Stop
-					</Button>
-					<Button
-						variant="ghost"
-						size="sm"
-						onClick={() => setRebuildOpen(true)}
-						disabled={anyPending || isCreating || isStopping}
-						title="Rebuild container from scratch"
-					>
-						{rebuildContainer.isPending ? (
-							<Loader2 className="w-3 h-3 animate-spin" />
-						) : (
-							<RefreshCw className="w-3 h-3" />
-						)}
-						Rebuild
-					</Button>
+					<Tooltip content="Start container">
+						<Button
+							variant="ghost"
+							size="sm"
+							onClick={() => startContainer.mutate()}
+							disabled={anyPending || isActive || !hasContainer}
+						>
+							{startContainer.isPending ? (
+								<Loader2 className="w-3 h-3 animate-spin" />
+							) : (
+								<Play className="w-3 h-3" />
+							)}
+							Start
+						</Button>
+					</Tooltip>
+					<Tooltip content="Stop container">
+						<Button
+							variant="ghost"
+							size="sm"
+							onClick={() => setStopOpen(true)}
+							disabled={anyPending || isStopping || (!isRunning && !isCreating)}
+						>
+							{stopContainer.isPending || isStopping ? (
+								<Loader2 className="w-3 h-3 animate-spin" />
+							) : (
+								<Square className="w-3 h-3" />
+							)}
+							Stop
+						</Button>
+					</Tooltip>
+					<Tooltip content="Rebuild container from scratch">
+						<Button
+							variant="ghost"
+							size="sm"
+							onClick={() => setRebuildOpen(true)}
+							disabled={anyPending || isCreating || isStopping}
+						>
+							{rebuildContainer.isPending ? (
+								<Loader2 className="w-3 h-3 animate-spin" />
+							) : (
+								<RefreshCw className="w-3 h-3" />
+							)}
+							Rebuild
+						</Button>
+					</Tooltip>
 				</div>
 			</div>
 

--- a/packages/web/src/routes/teams/$teamId/projects/index.tsx
+++ b/packages/web/src/routes/teams/$teamId/projects/index.tsx
@@ -7,6 +7,7 @@ import { Avatar, avatarColorFromString } from '../../../../components/ui/avatar'
 import { Button } from '../../../../components/ui/button';
 import { Card } from '../../../../components/ui/card';
 import { EmptyState } from '../../../../components/ui/empty-state';
+import { Tooltip } from '../../../../components/ui/tooltip';
 import { useProjects } from '../../../../hooks/use-projects';
 
 type ProjectListSearch = { create?: boolean };
@@ -84,12 +85,13 @@ function ProjectListPage() {
 												{p.name}
 											</h2>
 											{p.container_status && p.container_status !== 'running' && (
-												<span
-													role="img"
-													title={`Container ${p.container_status}`}
-													aria-label={`Container ${p.container_status}`}
-													className="w-2 h-2 rounded-full bg-accent-red shrink-0"
-												/>
+												<Tooltip content={`Container ${p.container_status}`}>
+													<span
+														role="img"
+														aria-label={`Container ${p.container_status}`}
+														className="w-2 h-2 rounded-full bg-accent-red shrink-0"
+													/>
+												</Tooltip>
 											)}
 										</div>
 										{p.description && (

--- a/packages/web/src/routes/teams/$teamId/settings/credentials.tsx
+++ b/packages/web/src/routes/teams/$teamId/settings/credentials.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from '@tanstack/react-router';
 import { Trash2 } from 'lucide-react';
 import { Badge } from '../../../../components/ui/badge';
 import { type Column, DataTable } from '../../../../components/ui/data-table';
+import { Tooltip } from '../../../../components/ui/tooltip';
 import { type CredentialUsage, useCredentials } from '../../../../hooks/use-credentials';
 import { useDeleteSecret } from '../../../../hooks/use-secrets';
 
@@ -53,7 +54,13 @@ function CredentialsPage() {
 			header: 'Last used',
 			render: (r) => (
 				<span className="text-xs">
-					<span title={r.last_used_at ?? ''}>{formatRelative(r.last_used_at)}</span>
+					{r.last_used_at ? (
+						<Tooltip content={r.last_used_at}>
+							<span>{formatRelative(r.last_used_at)}</span>
+						</Tooltip>
+					) : (
+						<span>{formatRelative(r.last_used_at)}</span>
+					)}
 					{r.last_host && <span className="text-text-subtle ml-2 font-mono">{r.last_host}</span>}
 				</span>
 			),
@@ -68,22 +75,24 @@ function CredentialsPage() {
 			key: 'actions',
 			header: '',
 			render: (r) => (
-				<button
-					type="button"
-					onClick={() => {
-						if (
-							confirm(
-								`Revoke secret "${r.name}"? Any in-flight runs that try to use it will get a 400 unknown_secret response.`,
-							)
-						) {
-							deleteSecret.mutate(r.id);
-						}
-					}}
-					className="text-text-subtle hover:text-accent-red"
-					title="Revoke"
-				>
-					<Trash2 className="w-3.5 h-3.5" />
-				</button>
+				<Tooltip content="Revoke">
+					<button
+						type="button"
+						onClick={() => {
+							if (
+								confirm(
+									`Revoke secret "${r.name}"? Any in-flight runs that try to use it will get a 400 unknown_secret response.`,
+								)
+							) {
+								deleteSecret.mutate(r.id);
+							}
+						}}
+						aria-label="Revoke"
+						className="text-text-subtle hover:text-accent-red"
+					>
+						<Trash2 className="w-3.5 h-3.5" />
+					</button>
+				</Tooltip>
 			),
 		},
 	];

--- a/packages/web/src/routes/teams/$teamId/settings/general.tsx
+++ b/packages/web/src/routes/teams/$teamId/settings/general.tsx
@@ -5,6 +5,7 @@ import { RevisionsPanel } from '../../../../components/revisions-panel';
 import { Badge } from '../../../../components/ui/badge';
 import { Button } from '../../../../components/ui/button';
 import { Input } from '../../../../components/ui/input';
+import { Tooltip } from '../../../../components/ui/tooltip';
 import { useApiKeys, useCreateApiKey, useDeleteApiKey } from '../../../../hooks/use-api-keys';
 import { useCosts } from '../../../../hooks/use-costs';
 import {
@@ -777,24 +778,28 @@ function SkillsSection({ teamId }: { teamId: string }) {
 							</div>
 							<div className="flex items-center gap-1">
 								{s.source_url && (
+									<Tooltip content="Re-download">
+										<button
+											type="button"
+											onClick={() => syncSkill.mutate(s.slug)}
+											disabled={syncSkill.isPending}
+											aria-label="Re-download"
+											className="text-text-subtle hover:text-text p-1"
+										>
+											<RefreshCw className="w-3.5 h-3.5" />
+										</button>
+									</Tooltip>
+								)}
+								<Tooltip content="Delete">
 									<button
 										type="button"
-										onClick={() => syncSkill.mutate(s.slug)}
-										disabled={syncSkill.isPending}
-										className="text-text-subtle hover:text-text p-1"
-										title="Re-download"
+										onClick={() => deleteSkill.mutate(s.slug)}
+										aria-label="Delete"
+										className="text-text-subtle hover:text-accent-red p-1"
 									>
-										<RefreshCw className="w-3.5 h-3.5" />
+										<Trash2 className="w-3.5 h-3.5" />
 									</button>
-								)}
-								<button
-									type="button"
-									onClick={() => deleteSkill.mutate(s.slug)}
-									className="text-text-subtle hover:text-accent-red p-1"
-									title="Delete"
-								>
-									<Trash2 className="w-3.5 h-3.5" />
-								</button>
+								</Tooltip>
 							</div>
 						</div>
 					))}

--- a/test/browser/log-viewer-fullscreen.spec.ts
+++ b/test/browser/log-viewer-fullscreen.spec.ts
@@ -79,7 +79,10 @@ test('log viewer preserves bottom-pinned scroll across expand/collapse cycles', 
 	const inlineScrollable = await inlineLog.evaluate((el) => el.scrollHeight > el.clientHeight);
 	expect(inlineScrollable).toBe(true);
 
-	await page.getByLabel('Auto-scroll').uncheck();
+	const autoScrollBtn = page.getByRole('button', { name: /toggle auto-scroll/i }).first();
+	await expect(autoScrollBtn).toHaveAttribute('aria-pressed', 'true');
+	await autoScrollBtn.click();
+	await expect(autoScrollBtn).toHaveAttribute('aria-pressed', 'false');
 	const scrolledUpOffset = 200;
 	await setBottomOffset(inlineLog, scrolledUpOffset);
 	const actualScrolledOffset = await readBottomOffset(inlineLog);
@@ -90,7 +93,7 @@ test('log viewer preserves bottom-pinned scroll across expand/collapse cycles', 
 	const expanded = await readBottomOffset(fullscreenLog);
 	expect(Math.abs(expanded - actualScrolledOffset)).toBeLessThan(20);
 
-	await page.keyboard.press('Escape');
+	await page.getByRole('button', { name: /collapse log viewer/i }).click();
 	await expect(fullscreen).toBeHidden();
 	const restoredInline = await readBottomOffset(page.getByTestId('run-log'));
 	expect(Math.abs(restoredInline - actualScrolledOffset)).toBeLessThan(20);


### PR DESCRIPTION
Two changes on this branch. **Captain prompt edits**: Captain's role docs already direct it to call `update_agent_system_prompt` during team-coherence-review tickets, but the MCP tool rejected anyone who wasn't the Coach — allow the Captain of the same team too, drop the now-false exclusivity claim from the Coach prompt, and enqueue a `prompt_updated` coherence review from the MCP path so it matches the board REST edit path (existing dedupe prevents looping when Captain edits during its own review). **Web log/run toolbar polish**: auto-scroll becomes a `MoveVertical` icon toggle (depressed when on, visible in compact mode), the execution-detail page wires `TerminateRunButton` into the `LogViewer` header so its toolbar matches the task-comment one, and native `title=` tooltips are migrated to the project `Tooltip` component across run, reaction, attachment, repo, container, credentials, skill, project-card, and execution-list sites.