### PR TITLE
refactor: consolidate transactions, fix cache-key bugs, shared onboarding types

### DIFF
--- a/packages/server/src/lib/sql.ts
+++ b/packages/server/src/lib/sql.ts
@@ -1,4 +1,25 @@
+import type { PGlite } from '@electric-sql/pglite';
 import { TERMINAL_TASK_STATUSES } from '@hezo/shared';
+
+/**
+ * Run `fn` inside a BEGIN/COMMIT block. ROLLBACK on any thrown error before
+ * rethrowing. Replaces hand-rolled `BEGIN`/try/COMMIT/catch/ROLLBACK scaffolding
+ * at call sites — forgetting ROLLBACK becomes impossible.
+ *
+ * PGlite has no nested transaction support, so do not call this from inside
+ * another `withTransaction`.
+ */
+export async function withTransaction<T>(db: PGlite, fn: () => Promise<T>): Promise<T> {
+	await db.query('BEGIN');
+	try {
+		const result = await fn();
+		await db.query('COMMIT');
+		return result;
+	} catch (e) {
+		await db.query('ROLLBACK');
+		throw e;
+	}
+}
 
 export interface TerminalStatusParams {
 	placeholders: string;
@@ -39,11 +60,20 @@ export function buildUpdateSet(fields: UpdateFieldSpec[], startIdx = 1): UpdateS
 }
 
 const PG_FK_VIOLATION = '23503';
+const PG_UNIQUE_VIOLATION = '23505';
 
 export function isFkViolation(err: unknown, constraintName?: string): boolean {
 	if (!err || typeof err !== 'object') return false;
 	const e = err as { code?: unknown; constraint?: unknown };
 	if (e.code !== PG_FK_VIOLATION) return false;
+	if (constraintName && e.constraint !== constraintName) return false;
+	return true;
+}
+
+export function isUniqueViolation(err: unknown, constraintName?: string): boolean {
+	if (!err || typeof err !== 'object') return false;
+	const e = err as { code?: unknown; constraint?: unknown };
+	if (e.code !== PG_UNIQUE_VIOLATION) return false;
 	if (constraintName && e.constraint !== constraintName) return false;
 	return true;
 }

--- a/packages/server/src/middleware/auth.ts
+++ b/packages/server/src/middleware/auth.ts
@@ -178,10 +178,39 @@ export function safeCompareHex(a: string, b: string): boolean {
 	return timingSafeEqual(bufA, bufB);
 }
 
-export async function requireTeamAccess(c: Context<Env>): Promise<{ teamId: string } | Response> {
-	const auth = c.get('auth');
-	const raw = c.req.param('teamId');
+/**
+ * Single source of truth for "does this auth principal have access to this team?".
+ * Returns `null` on success, or a 403 `Response` to short-circuit the handler.
+ */
+async function assertTeamAccess(
+	db: PGlite,
+	auth: AuthInfo,
+	c: Context<Env>,
+	teamId: string,
+): Promise<Response | null> {
+	if (auth.type === AuthType.ApiKey || auth.type === AuthType.Agent) {
+		if (auth.teamId !== teamId) {
+			return c.json({ error: { code: 'FORBIDDEN', message: 'Access denied' } }, 403);
+		}
+		return null;
+	}
 
+	if (auth.isSuperuser) {
+		return null;
+	}
+
+	const result = await db.query(
+		'SELECT m.id FROM members m JOIN member_users mu ON mu.id = m.id WHERE mu.user_id = $1 AND m.team_id = $2',
+		[auth.userId, teamId],
+	);
+	if (result.rows.length === 0) {
+		return c.json({ error: { code: 'FORBIDDEN', message: 'Access denied' } }, 403);
+	}
+	return null;
+}
+
+export async function requireTeamAccess(c: Context<Env>): Promise<{ teamId: string } | Response> {
+	const raw = c.req.param('teamId');
 	if (!raw) {
 		return c.json({ error: { code: 'BAD_REQUEST', message: 'Missing teamId' } }, 400);
 	}
@@ -192,24 +221,8 @@ export async function requireTeamAccess(c: Context<Env>): Promise<{ teamId: stri
 		return c.json({ error: { code: 'NOT_FOUND', message: 'Team not found' } }, 404);
 	}
 
-	if (auth.type === AuthType.ApiKey || auth.type === AuthType.Agent) {
-		if (auth.teamId !== teamId) {
-			return c.json({ error: { code: 'FORBIDDEN', message: 'Access denied' } }, 403);
-		}
-		return { teamId };
-	}
-
-	if (auth.isSuperuser) {
-		return { teamId };
-	}
-
-	const result = await db.query(
-		'SELECT m.id FROM members m JOIN member_users mu ON mu.id = m.id WHERE mu.user_id = $1 AND m.team_id = $2',
-		[auth.userId, teamId],
-	);
-	if (result.rows.length === 0) {
-		return c.json({ error: { code: 'FORBIDDEN', message: 'Access denied' } }, 403);
-	}
+	const denied = await assertTeamAccess(db, c.get('auth'), c, teamId);
+	if (denied) return denied;
 	return { teamId };
 }
 
@@ -218,28 +231,8 @@ export async function requireTeamAccessForResource(
 	c: Context<Env>,
 	resourceTeamId: string,
 ): Promise<{ teamId: string } | Response> {
-	const auth = c.get('auth');
-
-	if (auth.type === AuthType.ApiKey || auth.type === AuthType.Agent) {
-		if (auth.teamId !== resourceTeamId) {
-			return c.json({ error: { code: 'FORBIDDEN', message: 'Access denied' } }, 403);
-		}
-		return { teamId: resourceTeamId };
-	}
-
-	// Superusers can access any team
-	if (auth.isSuperuser) {
-		return { teamId: resourceTeamId };
-	}
-
-	// Board auth
-	const result = await db.query(
-		'SELECT m.id FROM members m JOIN member_users mu ON mu.id = m.id WHERE mu.user_id = $1 AND m.team_id = $2',
-		[auth.userId, resourceTeamId],
-	);
-	if (result.rows.length === 0) {
-		return c.json({ error: { code: 'FORBIDDEN', message: 'Access denied' } }, 403);
-	}
+	const denied = await assertTeamAccess(db, c.get('auth'), c, resourceTeamId);
+	if (denied) return denied;
 	return { teamId: resourceTeamId };
 }
 

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -22,7 +22,7 @@ import { broadcastChange } from '../lib/broadcast';
 import { resolveActorMemberId, resolveAgentId } from '../lib/resolve';
 import { err, ok } from '../lib/response';
 import { toSlug } from '../lib/slug';
-import { buildUpdateSet, isFkViolation, terminalStatusParams } from '../lib/sql';
+import { buildUpdateSet, isFkViolation, terminalStatusParams, withTransaction } from '../lib/sql';
 import { allocateTaskIdentifier } from '../lib/task-identifier';
 import type { Env } from '../lib/types';
 import { logger } from '../logger';
@@ -182,67 +182,67 @@ agentsRoutes.post('/teams/:teamId/agents', async (c) => {
 		return err(c, 'CONFLICT', `Agent with slug '${slug}' already exists in this team`, 409);
 	}
 
-	await db.query('BEGIN');
+	let memberId: string;
 	try {
-		const memberResult = await db.query<{ id: string }>(
-			`INSERT INTO members (team_id, member_type, display_name)
+		memberId = await withTransaction(db, async () => {
+			const memberResult = await db.query<{ id: string }>(
+				`INSERT INTO members (team_id, member_type, display_name)
        VALUES ($1, $2, $3)
        RETURNING id`,
-			[teamId, MemberType.Agent, body.title.trim()],
-		);
-		const memberId = memberResult.rows[0].id;
+				[teamId, MemberType.Agent, body.title.trim()],
+			);
+			const newMemberId = memberResult.rows[0].id;
 
-		await db.query(
-			`INSERT INTO member_agents (id, title, slug, role_description, reports_to, default_effort, heartbeat_interval_min, monthly_budget_cents, touches_code, mcp_servers)
+			await db.query(
+				`INSERT INTO member_agents (id, title, slug, role_description, reports_to, default_effort, heartbeat_interval_min, monthly_budget_cents, touches_code, mcp_servers)
        VALUES ($1, $2, $3, $4, $5, $6::agent_effort, $7, $8, $9, $10::jsonb)`,
-			[
-				memberId,
-				body.title.trim(),
-				slug,
-				body.role_description ?? '',
-				body.reports_to ?? null,
-				body.default_effort ?? DEFAULT_EFFORT,
-				body.heartbeat_interval_min ?? 60,
-				body.monthly_budget_cents ?? 3000,
-				body.touches_code ?? false,
-				JSON.stringify(body.mcp_servers ?? []),
-			],
-		);
+				[
+					newMemberId,
+					body.title.trim(),
+					slug,
+					body.role_description ?? '',
+					body.reports_to ?? null,
+					body.default_effort ?? DEFAULT_EFFORT,
+					body.heartbeat_interval_min ?? 60,
+					body.monthly_budget_cents ?? 3000,
+					body.touches_code ?? false,
+					JSON.stringify(body.mcp_servers ?? []),
+				],
+			);
 
-		await initAgentSystemPrompt(db, teamId, memberId, body.system_prompt ?? '', null);
-
-		await db.query('COMMIT');
-
-		const result = await db.query(
-			`SELECT ${AGENT_BASE_COLUMNS}
-			 FROM members m
-			 JOIN member_agents ma ON ma.id = m.id
-			 WHERE m.id = $1`,
-			[memberId],
-		);
-
-		broadcastChange(
-			c,
-			wsRoom.team(teamId),
-			'member_agents',
-			'INSERT',
-			result.rows[0] as Record<string, unknown>,
-		);
-
-		trackBackground(
-			enqueueTeamCoherenceReviewTask(db, teamId, 'agent_hired').catch((e) =>
-				log.error('Failed to enqueue team coherence review after agent create:', e),
-			),
-		);
-
-		return ok(c, result.rows[0], 201);
+			await initAgentSystemPrompt(db, teamId, newMemberId, body.system_prompt ?? '', null);
+			return newMemberId;
+		});
 	} catch (e) {
-		await db.query('ROLLBACK');
 		if (isFkViolation(e, 'member_agents_reports_to_fkey')) {
 			return err(c, 'INVALID_REQUEST', 'reports_to: agent does not exist', 400);
 		}
 		throw e;
 	}
+
+	const result = await db.query(
+		`SELECT ${AGENT_BASE_COLUMNS}
+		 FROM members m
+		 JOIN member_agents ma ON ma.id = m.id
+		 WHERE m.id = $1`,
+		[memberId],
+	);
+
+	broadcastChange(
+		c,
+		wsRoom.team(teamId),
+		'member_agents',
+		'INSERT',
+		result.rows[0] as Record<string, unknown>,
+	);
+
+	trackBackground(
+		enqueueTeamCoherenceReviewTask(db, teamId, 'agent_hired').catch((e) =>
+			log.error('Failed to enqueue team coherence review after agent create:', e),
+		),
+	);
+
+	return ok(c, result.rows[0], 201);
 });
 
 agentsRoutes.post('/teams/:teamId/agents/onboard', async (c) => {
@@ -318,8 +318,7 @@ agentsRoutes.post('/teams/:teamId/agents/onboard', async (c) => {
 	};
 
 	if (!hasCaptain || !hasOpsProject) {
-		await db.query('BEGIN');
-		try {
+		await withTransaction(db, async () => {
 			const memberResult = await db.query<{ id: string }>(
 				`INSERT INTO members (team_id, member_type, display_name)
 				 VALUES ($1, $2, $3)
@@ -347,12 +346,7 @@ agentsRoutes.post('/teams/:teamId/agents/onboard', async (c) => {
 			);
 
 			await initAgentSystemPrompt(db, teamId, memberId, proposal.system_prompt, null);
-
-			await db.query('COMMIT');
-		} catch (e) {
-			await db.query('ROLLBACK');
-			throw e;
-		}
+		});
 
 		const agentResult = await db.query(
 			`SELECT ${AGENT_BASE_COLUMNS}
@@ -387,8 +381,7 @@ agentsRoutes.post('/teams/:teamId/agents/onboard', async (c) => {
 		requestedByMemberId = me.rows[0]?.id ?? null;
 	}
 
-	await db.query('BEGIN');
-	try {
+	const { task, finalApproval } = await withTransaction(db, async () => {
 		const approvalResult = await db.query<Record<string, unknown>>(
 			`INSERT INTO approvals (team_id, type, requested_by_member_id, payload, status)
 			 VALUES ($1, $2::approval_type, $3, $4::jsonb, $5::approval_status)
@@ -457,27 +450,24 @@ ${teamRoster}`;
 			`UPDATE approvals SET payload = payload || jsonb_build_object('task_id', $1::text) WHERE id = $2`,
 			[task.id, approvalId],
 		);
-		const finalApproval = await db.query<Record<string, unknown>>(
+		const finalApprovalResult = await db.query<Record<string, unknown>>(
 			'SELECT * FROM approvals WHERE id = $1',
 			[approvalId],
 		);
 
-		await db.query('COMMIT');
+		return { task, finalApproval: finalApprovalResult.rows[0] };
+	});
 
-		broadcastChange(c, wsRoom.team(teamId), 'approvals', 'INSERT', finalApproval.rows[0]);
-		broadcastChange(c, wsRoom.team(teamId), 'tasks', 'INSERT', task);
+	broadcastChange(c, wsRoom.team(teamId), 'approvals', 'INSERT', finalApproval);
+	broadcastChange(c, wsRoom.team(teamId), 'tasks', 'INSERT', task);
 
-		trackBackground(
-			createWakeup(db, captainId, teamId, WakeupSource.Assignment, {
-				task_id: task.id,
-			}).catch((e) => log.error('Failed to wake Captain for hire request:', e)),
-		);
+	trackBackground(
+		createWakeup(db, captainId, teamId, WakeupSource.Assignment, {
+			task_id: task.id as string,
+		}).catch((e) => log.error('Failed to wake Captain for hire request:', e)),
+	);
 
-		return ok(c, { agent: null, task, approval: finalApproval.rows[0], bootstrap: false }, 201);
-	} catch (e) {
-		await db.query('ROLLBACK');
-		throw e;
-	}
+	return ok(c, { agent: null, task, approval: finalApproval, bootstrap: false }, 201);
 });
 
 agentsRoutes.get('/teams/:teamId/agents/:agentId', async (c) => {

--- a/packages/server/src/routes/comments.ts
+++ b/packages/server/src/routes/comments.ts
@@ -7,6 +7,7 @@ import { broadcastChange } from '../lib/broadcast';
 import { validateCredentialValue } from '../lib/credential-validator';
 import { resolveActorMemberId, resolveTaskId } from '../lib/resolve';
 import { err, ok } from '../lib/response';
+import { withTransaction } from '../lib/sql';
 import type { Env } from '../lib/types';
 import { logger } from '../logger';
 import { requireTeamAccess } from '../middleware/auth';
@@ -244,10 +245,8 @@ commentsRoutes.post('/teams/:teamId/tasks/:taskId/comments', async (c) => {
 	// regardless of the body field.
 	const wakeAssignee = auth.type === AuthType.Board && body.wake_assignee === true;
 
-	await db.query('BEGIN');
-	let result: Awaited<ReturnType<typeof db.query<{ id: string }>>>;
-	try {
-		result = await db.query<{ id: string }>(
+	const result = await withTransaction(db, async () => {
+		const inserted = await db.query<{ id: string }>(
 			`INSERT INTO task_comments (task_id, author_member_id, parent_comment_id, content_type, content)
      VALUES ($1, $2, $3, $4::comment_content_type, $5::jsonb)
      RETURNING *`,
@@ -261,18 +260,15 @@ commentsRoutes.post('/teams/:teamId/tasks/:taskId/comments', async (c) => {
 		);
 
 		if (attachmentIds.length > 0) {
-			const newCommentId = result.rows[0].id;
+			const newCommentId = inserted.rows[0].id;
 			await db.query(
 				`INSERT INTO comment_attachments (comment_id, asset_id)
 				 SELECT $1::uuid, asset FROM UNNEST($2::uuid[]) AS asset`,
 				[newCommentId, attachmentIds],
 			);
 		}
-		await db.query('COMMIT');
-	} catch (e) {
-		await db.query('ROLLBACK');
-		throw e;
-	}
+		return inserted;
+	});
 
 	await fireCommentWakeups({
 		db,
@@ -345,10 +341,8 @@ commentsRoutes.post('/teams/:teamId/tasks/:taskId/comments/:commentId/choose', a
 		return err(c, 'INVALID_REQUEST', 'Can only choose on options-type comments', 400);
 	}
 
-	await db.query('BEGIN');
-	let result: Awaited<ReturnType<typeof db.query>>;
-	try {
-		result = await db.query(
+	const result = await withTransaction(db, async () => {
+		const updated = await db.query(
 			'UPDATE task_comments SET chosen_option = $1::jsonb WHERE id = $2 RETURNING *',
 			[JSON.stringify({ chosen_id: body.chosen_id }), commentId],
 		);
@@ -362,11 +356,8 @@ commentsRoutes.post('/teams/:teamId/tasks/:taskId/comments/:commentId/choose', a
 				JSON.stringify({ text: `Board selected option: ${body.chosen_id}` }),
 			],
 		);
-		await db.query('COMMIT');
-	} catch (e) {
-		await db.query('ROLLBACK');
-		throw e;
-	}
+		return updated;
+	});
 
 	const task = await db.query<{ assignee_id: string | null }>(
 		'SELECT assignee_id FROM tasks WHERE id = $1',
@@ -467,10 +458,7 @@ commentsRoutes.post(
 			return err(c, 'LOCKED', 'Master key not available', 503);
 		}
 
-		await db.query('BEGIN');
-		let secretId: string;
-		let updatedComment: Record<string, unknown>;
-		try {
+		const { secretId, updatedComment } = await withTransaction(db, async () => {
 			const encryptedValue = isConfirmation ? '' : encrypt(storedValue as string, encryptionKey);
 			const category = pickSecretCategory(kind);
 
@@ -485,7 +473,7 @@ commentsRoutes.post(
 				 RETURNING id`,
 				[teamId, projectId, name, encryptedValue, category, allowedHosts],
 			);
-			secretId = upsert.rows[0].id;
+			const secretId = upsert.rows[0].id;
 
 			if (requestingAgentId) {
 				await db.query(
@@ -506,7 +494,6 @@ commentsRoutes.post(
 					commentId,
 				],
 			);
-			updatedComment = updated.rows[0] as Record<string, unknown>;
 
 			await db.query(
 				`INSERT INTO task_comments (task_id, content_type, content)
@@ -520,11 +507,11 @@ commentsRoutes.post(
 					}),
 				],
 			);
-			await db.query('COMMIT');
-		} catch (e) {
-			await db.query('ROLLBACK');
-			throw e;
-		}
+			return {
+				secretId,
+				updatedComment: updated.rows[0] as Record<string, unknown>,
+			};
+		});
 
 		if (requestingAgentId) {
 			const isAgent = await db.query('SELECT id FROM member_agents WHERE id = $1', [

--- a/packages/server/src/routes/repos.ts
+++ b/packages/server/src/routes/repos.ts
@@ -3,6 +3,7 @@ import { type Context, Hono } from 'hono';
 import { broadcastChange } from '../lib/broadcast';
 import { getProjectLocator, resolveProjectId } from '../lib/resolve';
 import { err, ok } from '../lib/response';
+import { isUniqueViolation, withTransaction } from '../lib/sql';
 import type { Env } from '../lib/types';
 import { logger } from '../logger';
 import { requireTeamAccess } from '../middleware/auth';
@@ -140,7 +141,7 @@ reposRoutes.post('/teams/:teamId/projects/:projectId/repos', async (c) => {
 	}
 	const repoIdentifier = `${owner}/${repoName}`;
 
-	let insertedRepo: {
+	type InsertedRepo = {
 		id: string;
 		project_id: string;
 		short_name: string;
@@ -149,8 +150,7 @@ reposRoutes.post('/teams/:teamId/projects/:projectId/repos', async (c) => {
 		oauth_connection_id: string | null;
 		created_at: string;
 	};
-	let becameDesignated = false;
-	let finalizeResult: Awaited<ReturnType<typeof finalizePendingRepoSetup>> = {
+	const emptyFinalize: Awaited<ReturnType<typeof finalizePendingRepoSetup>> = {
 		resolvedApprovalId: null,
 		affectedTaskIds: [],
 		deferredWakeups: [],
@@ -159,46 +159,54 @@ reposRoutes.post('/teams/:teamId/projects/:projectId/repos', async (c) => {
 		systemCommentRows: [],
 	};
 
-	await db.query('BEGIN');
+	let insertedRepo: InsertedRepo;
+	let becameDesignated = false;
+	let finalizeResult = emptyFinalize;
+
 	try {
-		const lockRes = await db.query<{ id: string; designated_repo_id: string | null }>(
-			'SELECT id, designated_repo_id FROM projects WHERE id = $1 FOR UPDATE',
-			[projectId],
-		);
-		if (lockRes.rows.length === 0) throw new Error('project disappeared during insert');
-		const projectRow = lockRes.rows[0];
+		const txResult = await withTransaction(db, async () => {
+			const lockRes = await db.query<{ id: string; designated_repo_id: string | null }>(
+				'SELECT id, designated_repo_id FROM projects WHERE id = $1 FOR UPDATE',
+				[projectId],
+			);
+			if (lockRes.rows.length === 0) throw new Error('project disappeared during insert');
+			const projectRow = lockRes.rows[0];
 
-		const insertRes = await db.query<typeof insertedRepo>(
-			`INSERT INTO repos (project_id, short_name, repo_identifier, host_type, oauth_connection_id)
-			 VALUES ($1, $2, $3, 'github'::repo_host_type, $4)
-			 RETURNING id, project_id, short_name, repo_identifier, host_type, oauth_connection_id, created_at`,
-			[projectId, body.short_name.trim(), repoIdentifier, conn.id],
-		);
-		insertedRepo = insertRes.rows[0];
+			const insertRes = await db.query<InsertedRepo>(
+				`INSERT INTO repos (project_id, short_name, repo_identifier, host_type, oauth_connection_id)
+				 VALUES ($1, $2, $3, 'github'::repo_host_type, $4)
+				 RETURNING id, project_id, short_name, repo_identifier, host_type, oauth_connection_id, created_at`,
+				[projectId, body.short_name.trim(), repoIdentifier, conn.id],
+			);
+			const inserted = insertRes.rows[0];
 
-		if (!projectRow.designated_repo_id) {
-			await db.query('UPDATE projects SET designated_repo_id = $1 WHERE id = $2', [
-				insertedRepo.id,
-				projectId,
-			]);
-			becameDesignated = true;
+			let becameDesignated = false;
+			let finalize = emptyFinalize;
+			if (!projectRow.designated_repo_id) {
+				await db.query('UPDATE projects SET designated_repo_id = $1 WHERE id = $2', [
+					inserted.id,
+					projectId,
+				]);
+				becameDesignated = true;
 
-			finalizeResult = await finalizePendingRepoSetup(db, {
-				teamId,
-				projectId,
-				repoId: insertedRepo.id,
-				repoIdentifier,
-				shortName: insertedRepo.short_name,
-			});
-		}
-
-		await db.query('COMMIT');
+				finalize = await finalizePendingRepoSetup(db, {
+					teamId,
+					projectId,
+					repoId: inserted.id,
+					repoIdentifier,
+					shortName: inserted.short_name,
+				});
+			}
+			return { inserted, becameDesignated, finalize };
+		});
+		insertedRepo = txResult.inserted;
+		becameDesignated = txResult.becameDesignated;
+		finalizeResult = txResult.finalize;
 	} catch (e) {
-		await db.query('ROLLBACK');
-		const msg = e instanceof Error ? e.message : 'Failed to insert repo';
-		if (msg.includes('unique') || msg.includes('duplicate')) {
+		if (isUniqueViolation(e)) {
 			return err(c, 'SHORT_NAME_TAKEN', `short_name "${body.short_name}" already used`, 409);
 		}
+		const msg = e instanceof Error ? e.message : 'Failed to insert repo';
 		return err(c, 'REPO_INSERT_FAILED', msg, 500);
 	}
 

--- a/packages/server/src/routes/team-templates.ts
+++ b/packages/server/src/routes/team-templates.ts
@@ -1,6 +1,7 @@
 import type { PGlite } from '@electric-sql/pglite';
 import { Hono } from 'hono';
 import { err, ok } from '../lib/response';
+import { withTransaction } from '../lib/sql';
 import type { Env } from '../lib/types';
 
 export const teamTemplatesRoutes = new Hono<Env>();
@@ -53,36 +54,36 @@ teamTemplatesRoutes.post('/team-templates', async (c) => {
 
 	const db = c.get('db');
 
-	await db.query('BEGIN');
+	const teamTemplate = await withTransaction(db, async () => {
+		const ctResult = await db.query(
+			`INSERT INTO team_templates (name, description, kb_docs_config, skills_config, preferences_config, mcp_servers, mpp_config)
+			 VALUES ($1, $2, $3::jsonb, $4::jsonb, $5::jsonb, $6::jsonb, $7::jsonb)
+			 RETURNING *`,
+			[
+				body.name.trim(),
+				body.description ?? '',
+				JSON.stringify(body.kb_docs_config ?? []),
+				JSON.stringify(body.skills_config ?? []),
+				JSON.stringify(body.preferences_config ?? {}),
+				JSON.stringify(body.mcp_servers ?? []),
+				JSON.stringify(body.mpp_config ?? { enabled: false }),
+			],
+		);
 
-	const ctResult = await db.query(
-		`INSERT INTO team_templates (name, description, kb_docs_config, skills_config, preferences_config, mcp_servers, mpp_config)
-		 VALUES ($1, $2, $3::jsonb, $4::jsonb, $5::jsonb, $6::jsonb, $7::jsonb)
-		 RETURNING *`,
-		[
-			body.name.trim(),
-			body.description ?? '',
-			JSON.stringify(body.kb_docs_config ?? []),
-			JSON.stringify(body.skills_config ?? []),
-			JSON.stringify(body.preferences_config ?? {}),
-			JSON.stringify(body.mcp_servers ?? []),
-			JSON.stringify(body.mpp_config ?? { enabled: false }),
-		],
-	);
+		const row = ctResult.rows[0] as Record<string, unknown>;
 
-	const teamTemplate = ctResult.rows[0] as Record<string, unknown>;
-
-	if (body.agent_types?.length) {
-		for (const at of body.agent_types) {
-			await db.query(
-				`INSERT INTO team_template_agent_types (team_template_id, agent_type_id, reports_to_slug, sort_order)
-				 VALUES ($1, $2, $3, $4)`,
-				[teamTemplate.id, at.agent_type_id, at.reports_to_slug ?? null, at.sort_order ?? 0],
-			);
+		if (body.agent_types?.length) {
+			for (const at of body.agent_types) {
+				await db.query(
+					`INSERT INTO team_template_agent_types (team_template_id, agent_type_id, reports_to_slug, sort_order)
+					 VALUES ($1, $2, $3, $4)`,
+					[row.id, at.agent_type_id, at.reports_to_slug ?? null, at.sort_order ?? 0],
+				);
+			}
 		}
-	}
 
-	await db.query('COMMIT');
+		return row;
+	});
 
 	const full = await getTeamTemplateWithAgentTypes(db, teamTemplate.id as string);
 	return ok(c, full, 201);
@@ -119,45 +120,43 @@ teamTemplatesRoutes.patch('/team-templates/:id', async (c) => {
 		mpp_config?: Record<string, unknown>;
 	}>();
 
-	await db.query('BEGIN');
+	await withTransaction(db, async () => {
+		const sets: string[] = [];
+		const params: unknown[] = [];
+		let idx = 1;
 
-	const sets: string[] = [];
-	const params: unknown[] = [];
-	let idx = 1;
+		const addField = (field: string, value: unknown, jsonb = false) => {
+			if (value !== undefined) {
+				sets.push(`${field} = $${idx}${jsonb ? '::jsonb' : ''}`);
+				params.push(jsonb ? JSON.stringify(value) : value);
+				idx++;
+			}
+		};
 
-	const addField = (field: string, value: unknown, jsonb = false) => {
-		if (value !== undefined) {
-			sets.push(`${field} = $${idx}${jsonb ? '::jsonb' : ''}`);
-			params.push(jsonb ? JSON.stringify(value) : value);
-			idx++;
+		addField('name', body.name?.trim());
+		addField('description', body.description);
+		addField('kb_docs_config', body.kb_docs_config, true);
+		addField('skills_config', body.skills_config, true);
+		addField('preferences_config', body.preferences_config, true);
+		addField('mcp_servers', body.mcp_servers, true);
+		addField('mpp_config', body.mpp_config, true);
+
+		if (sets.length > 0) {
+			params.push(id);
+			await db.query(`UPDATE team_templates SET ${sets.join(', ')} WHERE id = $${idx}`, params);
 		}
-	};
 
-	addField('name', body.name?.trim());
-	addField('description', body.description);
-	addField('kb_docs_config', body.kb_docs_config, true);
-	addField('skills_config', body.skills_config, true);
-	addField('preferences_config', body.preferences_config, true);
-	addField('mcp_servers', body.mcp_servers, true);
-	addField('mpp_config', body.mpp_config, true);
-
-	if (sets.length > 0) {
-		params.push(id);
-		await db.query(`UPDATE team_templates SET ${sets.join(', ')} WHERE id = $${idx}`, params);
-	}
-
-	if (body.agent_types !== undefined) {
-		await db.query('DELETE FROM team_template_agent_types WHERE team_template_id = $1', [id]);
-		for (const at of body.agent_types) {
-			await db.query(
-				`INSERT INTO team_template_agent_types (team_template_id, agent_type_id, reports_to_slug, sort_order)
-				 VALUES ($1, $2, $3, $4)`,
-				[id, at.agent_type_id, at.reports_to_slug ?? null, at.sort_order ?? 0],
-			);
+		if (body.agent_types !== undefined) {
+			await db.query('DELETE FROM team_template_agent_types WHERE team_template_id = $1', [id]);
+			for (const at of body.agent_types) {
+				await db.query(
+					`INSERT INTO team_template_agent_types (team_template_id, agent_type_id, reports_to_slug, sort_order)
+					 VALUES ($1, $2, $3, $4)`,
+					[id, at.agent_type_id, at.reports_to_slug ?? null, at.sort_order ?? 0],
+				);
+			}
 		}
-	}
-
-	await db.query('COMMIT');
+	});
 
 	const full = await getTeamTemplateWithAgentTypes(db, id);
 	return ok(c, full);

--- a/packages/server/src/routes/teams.ts
+++ b/packages/server/src/routes/teams.ts
@@ -1,5 +1,6 @@
 import { AuthType, MemberType } from '@hezo/shared';
 import { Hono } from 'hono';
+import { resolveTaskId } from '../lib/resolve';
 import { err, ok } from '../lib/response';
 import { toSlug, uniqueSlug } from '../lib/slug';
 import { terminalStatusParams } from '../lib/sql';
@@ -122,8 +123,12 @@ teamsRoutes.post('/teams/:teamId/project-intake/:taskId/skip-questions', async (
 	const access = await requireTeamAccess(c);
 	if (access instanceof Response) return access;
 
-	const taskId = c.req.param('taskId');
-	const comment = await postSkipQuestionsSignalForProjectIntake(c.get('db'), access.teamId, taskId);
+	const db = c.get('db');
+	const taskId = await resolveTaskId(db, access.teamId, c.req.param('taskId'));
+	if (!taskId) {
+		return err(c, 'NOT_FOUND', 'Task not found', 404);
+	}
+	const comment = await postSkipQuestionsSignalForProjectIntake(db, access.teamId, taskId);
 	if (!comment) {
 		return err(c, 'NOT_FOUND', 'No open project intake found for this task', 404);
 	}

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -25,6 +25,7 @@ import {
 } from '@hezo/shared';
 import type { MasterKeyManager } from '../crypto/master-key';
 import { broadcastRowChange } from '../lib/broadcast';
+import { withTransaction } from '../lib/sql';
 import { signAgentJwt } from '../middleware/auth';
 import { type AgentRunUsage, createAgentStreamParser } from './agent-stream-parser';
 import {
@@ -1437,17 +1438,14 @@ export async function createHeartbeatRun(
 	broadcast: HeartbeatRunBroadcast,
 	wakeupId: string,
 ): Promise<string> {
-	await db.query('BEGIN');
-	let runId: string;
-	let statusFlippedToInProgress = false;
-	try {
+	const { runId, statusFlippedToInProgress } = await withTransaction(db, async () => {
 		const runResult = await db.query<{ id: string }>(
 			`INSERT INTO heartbeat_runs (member_id, team_id, task_id, wakeup_id, status)
 			 VALUES ($1, $2, $3, $4, $5::heartbeat_run_status)
 			 RETURNING id`,
 			[agent.id, agent.team_id, task.id, wakeupId, HeartbeatRunStatus.Queued],
 		);
-		runId = runResult.rows[0].id;
+		const runId = runResult.rows[0].id;
 
 		await db.query(
 			`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
@@ -1460,6 +1458,7 @@ export async function createHeartbeatRun(
 			],
 		);
 
+		let statusFlippedToInProgress = false;
 		if (task.assignee_id === agent.id && task.status === TaskStatus.Backlog) {
 			const updated = await db.query<{ id: string }>(
 				`UPDATE tasks
@@ -1474,11 +1473,8 @@ export async function createHeartbeatRun(
 			}
 		}
 
-		await db.query('COMMIT');
-	} catch (e) {
-		await db.query('ROLLBACK');
-		throw e;
-	}
+		return { runId, statusFlippedToInProgress };
+	});
 
 	broadcastHeartbeatRunChange(broadcast, runId, HeartbeatRunStatus.Queued, 'INSERT');
 	if (broadcast.wsManager) {

--- a/packages/server/src/services/ai-provider-keys.ts
+++ b/packages/server/src/services/ai-provider-keys.ts
@@ -2,6 +2,7 @@ import type { PGlite } from '@electric-sql/pglite';
 import { type AiAuthMethod, type AiProvider, AiProviderStatus } from '@hezo/shared';
 import { decrypt, encrypt } from '../crypto/encryption';
 import type { MasterKeyManager } from '../crypto/master-key';
+import { withTransaction } from '../lib/sql';
 
 export interface AiProviderCredential {
 	value: string;
@@ -170,8 +171,7 @@ export async function setDefaultAiProvider(db: PGlite, configId: string): Promis
 
 	const provider = config.rows[0].provider;
 
-	await db.query('BEGIN');
-	try {
+	await withTransaction(db, async () => {
 		await db.query(
 			`UPDATE ai_provider_configs SET is_default = false WHERE provider = $1::ai_provider AND id <> $2`,
 			[provider, configId],
@@ -180,11 +180,7 @@ export async function setDefaultAiProvider(db: PGlite, configId: string): Promis
 			`UPDATE ai_provider_configs SET is_default = true, updated_at = now() WHERE id = $1`,
 			[configId],
 		);
-		await db.query('COMMIT');
-	} catch (e) {
-		await db.query('ROLLBACK');
-		throw e;
-	}
+	});
 
 	return true;
 }

--- a/packages/server/src/services/documents.ts
+++ b/packages/server/src/services/documents.ts
@@ -1,6 +1,7 @@
 import type { PGlite } from '@electric-sql/pglite';
 import { DocumentType, wsRoom } from '@hezo/shared';
 import { broadcastRowChange } from '../lib/broadcast';
+import { withTransaction } from '../lib/sql';
 import type { WebSocketManager } from './ws';
 
 export interface DocumentRow {
@@ -159,40 +160,32 @@ export async function upsertDocument(
 	);
 
 	const action: 'INSERT' | 'UPDATE' = existing.rows.length === 0 ? 'INSERT' : 'UPDATE';
-	let row: DocumentRow;
 
-	await db.query('BEGIN');
-	try {
+	const row = await withTransaction(db, async () => {
 		if (existing.rows.length === 0) {
-			const insert = await insertDocument(db, input);
-			row = insert;
-		} else {
-			const prior = existing.rows[0];
-			if (prior.content !== input.content) {
-				await recordRevision(
-					db,
-					prior.id,
-					prior.content,
-					input.changeSummary ?? '',
-					input.authorMemberId,
-				);
-			}
-			const updateResult = await db.query<DocumentRow>(
-				`UPDATE documents
-				 SET content = $1,
-				     title = COALESCE($2, title),
-				     last_updated_by_member_id = $3
-				 WHERE id = $4
-				 RETURNING *`,
-				[input.content, input.title ?? null, input.authorMemberId, prior.id],
-			);
-			row = updateResult.rows[0];
+			return await insertDocument(db, input);
 		}
-		await db.query('COMMIT');
-	} catch (e) {
-		await db.query('ROLLBACK');
-		throw e;
-	}
+		const prior = existing.rows[0];
+		if (prior.content !== input.content) {
+			await recordRevision(
+				db,
+				prior.id,
+				prior.content,
+				input.changeSummary ?? '',
+				input.authorMemberId,
+			);
+		}
+		const updateResult = await db.query<DocumentRow>(
+			`UPDATE documents
+			 SET content = $1,
+			     title = COALESCE($2, title),
+			     last_updated_by_member_id = $3
+			 WHERE id = $4
+			 RETURNING *`,
+			[input.content, input.title ?? null, input.authorMemberId, prior.id],
+		);
+		return updateResult.rows[0];
+	});
 
 	broadcastRowChange(
 		wsManager,
@@ -313,9 +306,7 @@ export async function restoreRevision(
 	);
 	if (target.rows.length === 0) return null;
 
-	let row: DocumentRow;
-	await db.query('BEGIN');
-	try {
+	const row = await withTransaction(db, async () => {
 		await recordRevision(
 			db,
 			input.documentId,
@@ -331,12 +322,8 @@ export async function restoreRevision(
 			 RETURNING *`,
 			[target.rows[0].content, input.restoredByMemberId, input.documentId],
 		);
-		row = updated.rows[0];
-		await db.query('COMMIT');
-	} catch (e) {
-		await db.query('ROLLBACK');
-		throw e;
-	}
+		return updated.rows[0];
+	});
 
 	broadcastRowChange(
 		wsManager,

--- a/packages/server/src/services/oauth/connection-store.ts
+++ b/packages/server/src/services/oauth/connection-store.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import type { PGlite } from '@electric-sql/pglite';
 import { encrypt } from '../../crypto/encryption';
 import type { MasterKeyManager } from '../../crypto/master-key';
+import { withTransaction } from '../../lib/sql';
 import { logger } from '../../logger';
 
 const log = logger.child('oauth-connections');
@@ -77,8 +78,7 @@ export async function createConnection(
 		: null;
 	const allowedHosts = input.allowedHosts.length > 0 ? input.allowedHosts : [];
 
-	await deps.db.query('BEGIN');
-	try {
+	const row = await withTransaction(deps.db, async () => {
 		const accessSecret = await deps.db.query<{ id: string }>(
 			`INSERT INTO secrets (team_id, project_id, name, encrypted_value, category, allowed_hosts, allow_all_hosts)
 			 VALUES ($1, NULL, $2, $3, 'api_token', $4, false)
@@ -139,18 +139,15 @@ export async function createConnection(
 			],
 		);
 
-		await deps.db.query('COMMIT');
-		const row = { ...conn.rows[0], access_token_secret_name: accessName };
-		log.info('oauth connection created', {
-			id: row.id,
-			provider: row.provider,
-			account: row.provider_account_label,
-		});
-		return mapRow(row, accessName);
-	} catch (e) {
-		await deps.db.query('ROLLBACK');
-		throw e;
-	}
+		return { ...conn.rows[0], access_token_secret_name: accessName };
+	});
+
+	log.info('oauth connection created', {
+		id: row.id,
+		provider: row.provider,
+		account: row.provider_account_label,
+	});
+	return mapRow(row, accessName);
 }
 
 export async function getConnection(
@@ -220,8 +217,7 @@ export async function deleteConnection(
 	deps: ConnectionStoreDeps,
 	connectionId: string,
 ): Promise<boolean> {
-	await deps.db.query('BEGIN');
-	try {
+	const deleted = await withTransaction(deps.db, async () => {
 		const conn = await deps.db.query<{
 			access_token_secret_id: string;
 			refresh_token_secret_id: string | null;
@@ -230,10 +226,7 @@ export async function deleteConnection(
 			 FROM oauth_connections WHERE id = $1`,
 			[connectionId],
 		);
-		if (conn.rows.length === 0) {
-			await deps.db.query('ROLLBACK');
-			return false;
-		}
+		if (conn.rows.length === 0) return false;
 		const { access_token_secret_id, refresh_token_secret_id } = conn.rows[0];
 
 		await deps.db.query(
@@ -251,13 +244,11 @@ export async function deleteConnection(
 			await deps.db.query(`DELETE FROM secrets WHERE id = $1`, [refresh_token_secret_id]);
 		}
 
-		await deps.db.query('COMMIT');
-		log.info('oauth connection deleted', { id: connectionId });
 		return true;
-	} catch (e) {
-		await deps.db.query('ROLLBACK');
-		throw e;
-	}
+	});
+
+	if (deleted) log.info('oauth connection deleted', { id: connectionId });
+	return deleted;
 }
 
 export async function updateTokens(
@@ -270,8 +261,7 @@ export async function updateTokens(
 	const conn = await getConnection(deps, input.connectionId);
 	if (!conn) throw new Error(`oauth_connection ${input.connectionId} not found`);
 
-	await deps.db.query('BEGIN');
-	try {
+	await withTransaction(deps.db, async () => {
 		await deps.db.query(`UPDATE secrets SET encrypted_value = $1 WHERE id = $2`, [
 			encrypt(input.accessToken, key),
 			conn.accessTokenSecretId,
@@ -301,12 +291,7 @@ export async function updateTokens(
 			input.expiresAt ?? null,
 			conn.id,
 		]);
-
-		await deps.db.query('COMMIT');
-	} catch (e) {
-		await deps.db.query('ROLLBACK');
-		throw e;
-	}
+	});
 }
 
 interface RawConnRow {

--- a/packages/server/src/services/onboarding.ts
+++ b/packages/server/src/services/onboarding.ts
@@ -1,10 +1,9 @@
 import type { PGlite } from '@electric-sql/pglite';
-import { GoalStatus } from '@hezo/shared';
+import { GoalStatus, type OnboardingStageKey, type OnboardingStageStatus } from '@hezo/shared';
 import { terminalStatusParams } from '../lib/sql';
 import { ONBOARDING_INTAKE_LABEL } from './onboarding-intake';
 
-export type OnboardingStageKey = 'intake' | 'done';
-export type OnboardingStageStatus = 'complete' | 'current' | 'pending';
+export type { OnboardingStageKey, OnboardingStageStatus };
 
 export interface OnboardingGoalSummary {
 	id: string;

--- a/packages/server/src/services/project-create.ts
+++ b/packages/server/src/services/project-create.ts
@@ -1,5 +1,6 @@
 import type { PGlite } from '@electric-sql/pglite';
 import { TaskPriority, TaskStatus } from '@hezo/shared';
+import { withTransaction } from '../lib/sql';
 import { allocateTaskIdentifier } from '../lib/task-identifier';
 
 export interface CreateProjectWithPlanningInput {
@@ -28,8 +29,7 @@ export async function createProjectWithPlanningTask(
 	const projectDescription = input.description.trim();
 	const initialPrd = input.initialPrd?.trim() || null;
 
-	await db.query('BEGIN');
-	try {
+	return withTransaction(db, async () => {
 		await db.query('SELECT id FROM teams WHERE id = $1 FOR UPDATE', [input.teamId]);
 		const countResult = await db.query<{ count: string }>(
 			`SELECT count(*)::text AS count FROM projects
@@ -117,10 +117,6 @@ Container provisioning for this project is in progress. Focus on planning while 
 		);
 		const planningTask = taskResult.rows[0] as Record<string, unknown>;
 
-		await db.query('COMMIT');
 		return { project, planningTask, deferCaptainPlanningWake };
-	} catch (e) {
-		await db.query('ROLLBACK');
-		throw e;
-	}
+	});
 }

--- a/packages/server/src/services/project-intake.ts
+++ b/packages/server/src/services/project-intake.ts
@@ -12,7 +12,7 @@ import {
 } from '@hezo/shared';
 import { broadcastRowChange } from '../lib/broadcast';
 import { recomputeDownstreamReadiness } from '../lib/dependencies';
-import { terminalStatusParams } from '../lib/sql';
+import { terminalStatusParams, withTransaction } from '../lib/sql';
 import { allocateTaskIdentifier } from '../lib/task-identifier';
 import { logger } from '../logger';
 import { loadCaptainInternalContext } from './internal-intake';
@@ -121,27 +121,24 @@ export async function createProjectIntake(
 		initial_prd: input.initialPrd,
 	};
 
-	await db.query('BEGIN');
-	let intakeTaskId: string;
-	let intakeTaskIdentifier: string;
-	let approvalId: string;
-	let projectSlug: string;
-	try {
-		const approvalResult = await db.query<{ id: string }>(
-			`INSERT INTO approvals (team_id, type, status, payload)
+	const { intakeTaskId, intakeTaskIdentifier, approvalId, projectSlug } = await withTransaction(
+		db,
+		async () => {
+			const approvalResult = await db.query<{ id: string }>(
+				`INSERT INTO approvals (team_id, type, status, payload)
 			 VALUES ($1, $2::approval_type, $3::approval_status, $4::jsonb)
 			 RETURNING id`,
-			[teamId, ApprovalType.ProjectCreation, ApprovalStatus.Pending, JSON.stringify(payload)],
-		);
-		approvalId = approvalResult.rows[0].id;
+				[teamId, ApprovalType.ProjectCreation, ApprovalStatus.Pending, JSON.stringify(payload)],
+			);
+			const approvalId = approvalResult.rows[0].id;
 
-		const { number: taskNumber, identifier } = await allocateTaskIdentifier(
-			db,
-			ctx.internalProjectId,
-		);
+			const { number: taskNumber, identifier } = await allocateTaskIdentifier(
+				db,
+				ctx.internalProjectId,
+			);
 
-		const taskResult = await db.query<{ id: string; identifier: string; project_slug: string }>(
-			`WITH inserted AS (
+			const taskResult = await db.query<{ id: string; identifier: string; project_slug: string }>(
+				`WITH inserted AS (
 			   INSERT INTO tasks (team_id, project_id, assignee_id, number, identifier,
 			                      title, description, status, priority, labels)
 			   VALUES ($1, $2, $3, $4, $5, $6, $7, $8::task_status, $9::task_priority, $10::jsonb)
@@ -149,61 +146,59 @@ export async function createProjectIntake(
 			 )
 			 SELECT inserted.id, inserted.identifier, p.slug AS project_slug
 			 FROM inserted JOIN projects p ON p.id = inserted.project_id`,
-			[
-				teamId,
-				ctx.internalProjectId,
-				ctx.captainMemberId,
-				taskNumber,
-				identifier,
-				`Open new project: ${input.name}`,
-				buildTaskDescription(input, approvalId),
-				TaskStatus.InProgress,
-				TaskPriority.High,
-				JSON.stringify([PROJECT_INTAKE_LABEL]),
-			],
-		);
-		intakeTaskId = taskResult.rows[0].id;
-		intakeTaskIdentifier = taskResult.rows[0].identifier;
-		projectSlug = taskResult.rows[0].project_slug;
+				[
+					teamId,
+					ctx.internalProjectId,
+					ctx.captainMemberId,
+					taskNumber,
+					identifier,
+					`Open new project: ${input.name}`,
+					buildTaskDescription(input, approvalId),
+					TaskStatus.InProgress,
+					TaskPriority.High,
+					JSON.stringify([PROJECT_INTAKE_LABEL]),
+				],
+			);
+			const intakeTaskId = taskResult.rows[0].id;
+			const intakeTaskIdentifier = taskResult.rows[0].identifier;
+			const projectSlug = taskResult.rows[0].project_slug;
 
-		await db.query(
-			`UPDATE approvals
+			await db.query(
+				`UPDATE approvals
 			 SET payload = payload || $1::jsonb
 			 WHERE id = $2`,
-			[JSON.stringify({ intake_task_id: intakeTaskId }), approvalId],
-		);
+				[JSON.stringify({ intake_task_id: intakeTaskId }), approvalId],
+			);
 
-		await db.query(
-			`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
-			 VALUES ($1, $2, $3::comment_content_type, $4::jsonb)`,
-			[
-				intakeTaskId,
-				ctx.captainMemberId,
-				CommentContentType.Text,
-				JSON.stringify({ text: buildGreetingText(input) }),
-			],
-		);
-
-		if (input.initialPrd) {
 			await db.query(
 				`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
-				 VALUES ($1, $2, $3::comment_content_type, $4::jsonb)`,
+			 VALUES ($1, $2, $3::comment_content_type, $4::jsonb)`,
 				[
 					intakeTaskId,
 					ctx.captainMemberId,
 					CommentContentType.Text,
-					JSON.stringify({
-						text: `**Requirements document attached to this intake:**\n\n${input.initialPrd}`,
-					}),
+					JSON.stringify({ text: buildGreetingText(input) }),
 				],
 			);
-		}
 
-		await db.query('COMMIT');
-	} catch (e) {
-		await db.query('ROLLBACK');
-		throw e;
-	}
+			if (input.initialPrd) {
+				await db.query(
+					`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
+				 VALUES ($1, $2, $3::comment_content_type, $4::jsonb)`,
+					[
+						intakeTaskId,
+						ctx.captainMemberId,
+						CommentContentType.Text,
+						JSON.stringify({
+							text: `**Requirements document attached to this intake:**\n\n${input.initialPrd}`,
+						}),
+					],
+				);
+			}
+
+			return { intakeTaskId, intakeTaskIdentifier, approvalId, projectSlug };
+		},
+	);
 
 	if (wsManager) {
 		const taskRow = await db.query<Record<string, unknown>>('SELECT * FROM tasks WHERE id = $1', [

--- a/packages/server/src/services/repo-setup.ts
+++ b/packages/server/src/services/repo-setup.ts
@@ -9,6 +9,7 @@ import {
 	WakeupSource,
 	WakeupStatus,
 } from '@hezo/shared';
+import { withTransaction } from '../lib/sql';
 import { logger } from '../logger';
 import { createWakeup } from './wakeup';
 
@@ -33,89 +34,87 @@ export async function ensureRepoSetupAction(
 	db: PGlite,
 	ctx: RepoSetupGateCtx,
 ): Promise<EnsureResult> {
-	await db.query('BEGIN');
-	try {
-		const existingApproval = await findPendingApproval(db, ctx.teamId, ctx.projectId);
-		let approvalId = existingApproval;
-		let approvalCreated = false;
-		if (!approvalId) {
-			try {
+	const { approvalId, commentId, approvalCreated, commentCreated } = await withTransaction(
+		db,
+		async () => {
+			const existingApproval = await findPendingApproval(db, ctx.teamId, ctx.projectId);
+			let approvalId = existingApproval;
+			let approvalCreated = false;
+			if (!approvalId) {
+				try {
+					const ins = await db.query<{ id: string }>(
+						`INSERT INTO approvals (team_id, type, status, payload)
+						 VALUES ($1, $2::approval_type, $3::approval_status, $4::jsonb)
+						 RETURNING id`,
+						[
+							ctx.teamId,
+							ApprovalType.DesignatedRepoRequest,
+							ApprovalStatus.Pending,
+							JSON.stringify({
+								platform: PlatformType.GitHub,
+								reason: OAuthRequestReason.DesignatedRepo,
+								project_id: ctx.projectId,
+								task_id: ctx.taskId,
+							}),
+						],
+					);
+					approvalId = ins.rows[0].id;
+					approvalCreated = true;
+				} catch (e) {
+					const retry = await findPendingApproval(db, ctx.teamId, ctx.projectId);
+					if (!retry) throw e;
+					approvalId = retry;
+				}
+			}
+
+			const existingComment = await db.query<{ id: string }>(
+				`SELECT id FROM task_comments
+				 WHERE task_id = $1
+				   AND content_type = $2::comment_content_type
+				   AND content->>'kind' = $3
+				   AND content->>'approval_id' = $4
+				   AND chosen_option IS NULL
+				 LIMIT 1`,
+				[ctx.taskId, CommentContentType.Action, ActionCommentKind.SetupRepo, approvalId],
+			);
+
+			let commentId: string;
+			let commentCreated = false;
+			if (existingComment.rows.length > 0) {
+				commentId = existingComment.rows[0].id;
+			} else {
 				const ins = await db.query<{ id: string }>(
-					`INSERT INTO approvals (team_id, type, status, payload)
-					 VALUES ($1, $2::approval_type, $3::approval_status, $4::jsonb)
+					`INSERT INTO task_comments (task_id, content_type, content)
+					 VALUES ($1, $2::comment_content_type, $3::jsonb)
 					 RETURNING id`,
 					[
-						ctx.teamId,
-						ApprovalType.DesignatedRepoRequest,
-						ApprovalStatus.Pending,
-						JSON.stringify({
-							platform: PlatformType.GitHub,
-							reason: OAuthRequestReason.DesignatedRepo,
-							project_id: ctx.projectId,
-							task_id: ctx.taskId,
-						}),
+						ctx.taskId,
+						CommentContentType.Action,
+						JSON.stringify({ kind: ActionCommentKind.SetupRepo, approval_id: approvalId }),
 					],
 				);
-				approvalId = ins.rows[0].id;
-				approvalCreated = true;
-			} catch (e) {
-				const retry = await findPendingApproval(db, ctx.teamId, ctx.projectId);
-				if (!retry) throw e;
-				approvalId = retry;
+				commentId = ins.rows[0].id;
+				commentCreated = true;
 			}
-		}
 
-		const existingComment = await db.query<{ id: string }>(
-			`SELECT id FROM task_comments
-			 WHERE task_id = $1
-			   AND content_type = $2::comment_content_type
-			   AND content->>'kind' = $3
-			   AND content->>'approval_id' = $4
-			   AND chosen_option IS NULL
-			 LIMIT 1`,
-			[ctx.taskId, CommentContentType.Action, ActionCommentKind.SetupRepo, approvalId],
-		);
+			return { approvalId, commentId, approvalCreated, commentCreated };
+		},
+	);
 
-		let commentId: string;
-		let commentCreated = false;
-		if (existingComment.rows.length > 0) {
-			commentId = existingComment.rows[0].id;
-		} else {
-			const ins = await db.query<{ id: string }>(
-				`INSERT INTO task_comments (task_id, content_type, content)
-				 VALUES ($1, $2::comment_content_type, $3::jsonb)
-				 RETURNING id`,
-				[
-					ctx.taskId,
-					CommentContentType.Action,
-					JSON.stringify({ kind: ActionCommentKind.SetupRepo, approval_id: approvalId }),
-				],
-			);
-			commentId = ins.rows[0].id;
-			commentCreated = true;
-		}
-
-		await db.query('COMMIT');
-
-		const result: EnsureResult = { approvalId, commentId, approvalCreated, commentCreated };
-		if (approvalCreated) {
-			const r = await db.query<Record<string, unknown>>('SELECT * FROM approvals WHERE id = $1', [
-				approvalId,
-			]);
-			if (r.rows[0]) result.approvalRow = r.rows[0];
-		}
-		if (commentCreated) {
-			const r = await db.query<Record<string, unknown>>(
-				'SELECT * FROM task_comments WHERE id = $1',
-				[commentId],
-			);
-			if (r.rows[0]) result.commentRow = r.rows[0];
-		}
-		return result;
-	} catch (e) {
-		await db.query('ROLLBACK');
-		throw e;
+	const result: EnsureResult = { approvalId, commentId, approvalCreated, commentCreated };
+	if (approvalCreated) {
+		const r = await db.query<Record<string, unknown>>('SELECT * FROM approvals WHERE id = $1', [
+			approvalId,
+		]);
+		if (r.rows[0]) result.approvalRow = r.rows[0];
 	}
+	if (commentCreated) {
+		const r = await db.query<Record<string, unknown>>('SELECT * FROM task_comments WHERE id = $1', [
+			commentId,
+		]);
+		if (r.rows[0]) result.commentRow = r.rows[0];
+	}
+	return result;
 }
 
 async function findPendingApproval(

--- a/packages/server/src/services/stop-hook-prompt.ts
+++ b/packages/server/src/services/stop-hook-prompt.ts
@@ -89,17 +89,36 @@ export function buildClaudeCodeSettings(): ClaudeCodeSettings {
 }
 
 /**
- * Node script that runs inside the Codex container as the `Stop` hook
- * command. Reads Codex's StopCommandInput JSON from stdin, asks the
- * OpenAI Chat Completions API to judge completeness, writes a
- * `{"decision":"block","reason":"..."}` payload to stdout to block the
- * stop, or exits silently to allow it. Fails open on every error path.
+ * Per-runtime parameters for the judge script that runs inside the agent
+ * container. The script body is identical across Codex and Gemini — stdin
+ * read, JSON parse, fetch, verdict extraction, fail-open — only the input
+ * field, API call, and response extraction differ.
  */
-export function buildCodexJudgeScript(): string {
+interface JudgeRuntimeSpec {
+	/** API key env var(s), checked in order; first non-empty wins. */
+	apiKeyEnvVars: string[];
+	/** Field on the parsed stdin JSON that carries the agent's final message. */
+	inputField: string;
+	/** Judge model identifier passed to the upstream API. */
+	model: string;
+	/**
+	 * JS expression (as a string) evaluating to the fetch request. Receives
+	 * `apiKey`, `JUDGE_MODEL`, `SYSTEM_PROMPT`, and `message` in scope.
+	 */
+	fetchExpr: string;
+	/**
+	 * JS expression (as a string) extracting the verdict JSON text from the
+	 * parsed response `data`.
+	 */
+	extractTextExpr: string;
+}
+
+function buildJudgeScript(spec: JudgeRuntimeSpec): string {
+	const apiKeyExpr = spec.apiKeyEnvVars.map((v) => `process.env.${v}`).join(' || ');
 	return `#!/usr/bin/env node
 const SYSTEM_PROMPT = ${JSON.stringify(STOP_HOOK_RULES)};
-const JUDGE_MODEL = ${JSON.stringify(STOP_HOOK_JUDGE_MODEL_OPENAI)};
-const apiKey = process.env.OPENAI_API_KEY;
+const JUDGE_MODEL = ${JSON.stringify(spec.model)};
+const apiKey = ${apiKeyExpr};
 
 async function readStdin() {
 	let buf = '';
@@ -108,35 +127,20 @@ async function readStdin() {
 }
 
 async function main() {
-	if (!apiKey) return; // subscription auth — fail open
+	if (!apiKey) return; // no api key — fail open
 	const raw = await readStdin();
 	if (!raw.trim()) return;
 	let input;
 	try { input = JSON.parse(raw); } catch { return; }
-	const message = input.last_assistant_message;
+	const message = input[${JSON.stringify(spec.inputField)}];
 	if (!message) return;
-
-	const body = {
-		model: JUDGE_MODEL,
-		messages: [
-			{ role: 'system', content: SYSTEM_PROMPT },
-			{ role: 'user', content: 'Agent\\'s final response:\\n' + message },
-		],
-		response_format: { type: 'json_object' },
-		temperature: 0,
-	};
 
 	let verdict;
 	try {
-		const res = await fetch('https://api.openai.com/v1/chat/completions', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + apiKey },
-			body: JSON.stringify(body),
-			signal: AbortSignal.timeout(25_000),
-		});
+		const res = await ${spec.fetchExpr};
 		if (!res.ok) return;
 		const data = await res.json();
-		const text = data && data.choices && data.choices[0] && data.choices[0].message && data.choices[0].message.content;
+		const text = ${spec.extractTextExpr};
 		if (!text) return;
 		verdict = JSON.parse(text);
 	} catch { return; }
@@ -151,64 +155,53 @@ main().catch(() => {});
 }
 
 /**
- * Node script that runs inside the Gemini container as the
- * `AfterAgent` hook command. Reads the AfterAgent input JSON from
- * stdin, asks the Google Generative AI API to judge completeness on
- * the agent's `prompt_response`, writes a
- * `{"decision":"block","reason":"..."}` payload to stdout to block the
- * stop, or exits silently to allow. Fails open on every error path.
+ * Node script that runs inside the Codex container as the `Stop` hook
+ * command. Reads Codex's StopCommandInput JSON from stdin and asks the
+ * OpenAI Chat Completions API to judge completeness.
+ */
+export function buildCodexJudgeScript(): string {
+	return buildJudgeScript({
+		apiKeyEnvVars: ['OPENAI_API_KEY'],
+		inputField: 'last_assistant_message',
+		model: STOP_HOOK_JUDGE_MODEL_OPENAI,
+		fetchExpr: `fetch('https://api.openai.com/v1/chat/completions', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + apiKey },
+			body: JSON.stringify({
+				model: JUDGE_MODEL,
+				messages: [
+					{ role: 'system', content: SYSTEM_PROMPT },
+					{ role: 'user', content: "Agent's final response:\\n" + message },
+				],
+				response_format: { type: 'json_object' },
+				temperature: 0,
+			}),
+			signal: AbortSignal.timeout(25_000),
+		})`,
+		extractTextExpr: `data && data.choices && data.choices[0] && data.choices[0].message && data.choices[0].message.content`,
+	});
+}
+
+/**
+ * Node script that runs inside the Gemini container as the `AfterAgent`
+ * hook command. Reads the AfterAgent input JSON from stdin and asks the
+ * Google Generative AI API to judge completeness on `prompt_response`.
  */
 export function buildGeminiJudgeScript(): string {
-	return `#!/usr/bin/env node
-const SYSTEM_PROMPT = ${JSON.stringify(STOP_HOOK_RULES)};
-const JUDGE_MODEL = ${JSON.stringify(STOP_HOOK_JUDGE_MODEL_GOOGLE)};
-const apiKey = process.env.GOOGLE_API_KEY || process.env.GEMINI_API_KEY;
-
-async function readStdin() {
-	let buf = '';
-	for await (const chunk of process.stdin) buf += chunk;
-	return buf;
-}
-
-async function main() {
-	if (!apiKey) return; // no api-key auth — fail open
-	const raw = await readStdin();
-	if (!raw.trim()) return;
-	let input;
-	try { input = JSON.parse(raw); } catch { return; }
-	const message = input.prompt_response;
-	if (!message) return;
-
-	const body = {
-		systemInstruction: { parts: [{ text: SYSTEM_PROMPT }] },
-		contents: [{ role: 'user', parts: [{ text: 'Agent\\'s final response:\\n' + message }] }],
-		generationConfig: {
-			responseMimeType: 'application/json',
-			temperature: 0,
-		},
-	};
-
-	let verdict;
-	try {
-		const url = 'https://generativelanguage.googleapis.com/v1beta/models/' + encodeURIComponent(JUDGE_MODEL) + ':generateContent?key=' + encodeURIComponent(apiKey);
-		const res = await fetch(url, {
+	return buildJudgeScript({
+		apiKeyEnvVars: ['GOOGLE_API_KEY', 'GEMINI_API_KEY'],
+		inputField: 'prompt_response',
+		model: STOP_HOOK_JUDGE_MODEL_GOOGLE,
+		fetchExpr: `fetch('https://generativelanguage.googleapis.com/v1beta/models/' + encodeURIComponent(JUDGE_MODEL) + ':generateContent?key=' + encodeURIComponent(apiKey), {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify(body),
+			body: JSON.stringify({
+				systemInstruction: { parts: [{ text: SYSTEM_PROMPT }] },
+				contents: [{ role: 'user', parts: [{ text: "Agent's final response:\\n" + message }] }],
+				generationConfig: { responseMimeType: 'application/json', temperature: 0 },
+			}),
 			signal: AbortSignal.timeout(25_000),
-		});
-		if (!res.ok) return;
-		const data = await res.json();
-		const text = data && data.candidates && data.candidates[0] && data.candidates[0].content && data.candidates[0].content.parts && data.candidates[0].content.parts[0] && data.candidates[0].content.parts[0].text;
-		if (!text) return;
-		verdict = JSON.parse(text);
-	} catch { return; }
-
-	if (verdict && verdict.decision === 'block' && typeof verdict.reason === 'string' && verdict.reason.length > 0) {
-		process.stdout.write(JSON.stringify({ decision: 'block', reason: verdict.reason }));
-	}
-}
-
-main().catch(() => {});
-`;
+		})`,
+		extractTextExpr: `data && data.candidates && data.candidates[0] && data.candidates[0].content && data.candidates[0].content.parts && data.candidates[0].content.parts[0] && data.candidates[0].content.parts[0].text`,
+	});
 }

--- a/packages/server/src/services/team-template-provision.ts
+++ b/packages/server/src/services/team-template-provision.ts
@@ -1,6 +1,7 @@
 import type { PGlite } from '@electric-sql/pglite';
 import { MemberType } from '@hezo/shared';
 import { toSlug } from '../lib/slug';
+import { withTransaction } from '../lib/sql';
 import { logger } from '../logger';
 import { initAgentSystemPrompt } from './documents';
 import { downloadSkillContent, SkillDownloadError } from './skill-downloader';
@@ -137,8 +138,7 @@ export async function provisionTeamTemplate(
 	const skippedSlugs: string[] = [];
 	const slugToMemberId = new Map<string, string>();
 
-	await db.query('BEGIN');
-	try {
+	await withTransaction(db, async () => {
 		for (const row of dedupedRows) {
 			if (skipExistingSlugs && existingSlugs.has(row.slug)) {
 				skippedSlugs.push(row.slug);
@@ -210,12 +210,7 @@ export async function provisionTeamTemplate(
 		);
 
 		await createKbDocsFromTemplate(db, teamId, templateId);
-
-		await db.query('COMMIT');
-	} catch (e) {
-		await db.query('ROLLBACK');
-		throw e;
-	}
+	});
 
 	if (options?.dataDir) {
 		await createSkillsFromTemplate(db, teamId, templateId);

--- a/packages/server/src/services/teams.ts
+++ b/packages/server/src/services/teams.ts
@@ -11,6 +11,7 @@ import {
 import type { MasterKeyManager } from '../crypto/master-key';
 import { trackBackground } from '../lib/background';
 import { toSlug, uniqueSlug } from '../lib/slug';
+import { withTransaction } from '../lib/sql';
 import { logger } from '../logger';
 import type { ContainerLogStreamer } from './container-logs';
 import { type ProjectRow, provisionContainer } from './containers';
@@ -69,9 +70,7 @@ export async function createTeam(
 			return r.rows.length > 0;
 		}));
 
-	let teamId: string;
-	await db.query('BEGIN');
-	try {
+	const teamId = await withTransaction(db, async () => {
 		const teamSummaryResult = input.templateId
 			? await db.query<{ default_summary: string }>(
 					'SELECT default_summary FROM team_templates WHERE id = $1',
@@ -93,7 +92,7 @@ export async function createTeam(
 					 RETURNING id`,
 					[name, slug, input.description ?? '', teamSummary],
 				);
-		teamId = teamResult.rows[0].id;
+		const teamId = teamResult.rows[0].id;
 
 		if (input.creatorUserId) {
 			const memberResult = await db.query<{ id: string }>(
@@ -127,11 +126,8 @@ export async function createTeam(
 			);
 		}
 
-		await db.query('COMMIT');
-	} catch (e) {
-		await db.query('ROLLBACK');
-		throw e;
-	}
+		return teamId;
+	});
 
 	if (input.templateId) {
 		await applyTemplateToTeam(db, teamId, input.templateId, { dataDir, wsManager });

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -320,6 +320,20 @@ export const HeartbeatRunStatus = {
 } as const;
 export type HeartbeatRunStatus = (typeof HeartbeatRunStatus)[keyof typeof HeartbeatRunStatus];
 
+export const OnboardingStageKey = {
+	Intake: 'intake',
+	Done: 'done',
+} as const;
+export type OnboardingStageKey = (typeof OnboardingStageKey)[keyof typeof OnboardingStageKey];
+
+export const OnboardingStageStatus = {
+	Complete: 'complete',
+	Current: 'current',
+	Pending: 'pending',
+} as const;
+export type OnboardingStageStatus =
+	(typeof OnboardingStageStatus)[keyof typeof OnboardingStageStatus];
+
 export const PluginStatus = {
 	Installed: 'installed',
 	Enabled: 'enabled',

--- a/packages/web/src/components/comment-renderers.tsx
+++ b/packages/web/src/components/comment-renderers.tsx
@@ -45,9 +45,9 @@ import { Tooltip } from './ui/tooltip';
 export interface CommentData {
 	id: string;
 	content_type: string;
-	// biome-ignore lint/suspicious/noExplicitAny: content varies by type
+	// biome-ignore lint/suspicious/noExplicitAny: content varies by content_type; renderers narrow per case
 	content: any;
-	// biome-ignore lint/suspicious/noExplicitAny: varies
+	// biome-ignore lint/suspicious/noExplicitAny: shape depends on the originating options comment
 	chosen_option?: any;
 	author_name?: string;
 	author_type?: string;
@@ -64,9 +64,9 @@ const AVAILABLE_REACTION_KINDS = ['ack'] as const;
 interface ToolCall {
 	id: string;
 	tool_name: string;
-	// biome-ignore lint/suspicious/noExplicitAny: varies
+	// biome-ignore lint/suspicious/noExplicitAny: per-tool shape; renderer narrows per tool_name
 	input: any;
-	// biome-ignore lint/suspicious/noExplicitAny: varies
+	// biome-ignore lint/suspicious/noExplicitAny: per-tool shape; renderer narrows per tool_name
 	output: any;
 	status: string;
 	duration_ms: number | null;

--- a/packages/web/src/hooks/use-approvals.ts
+++ b/packages/web/src/hooks/use-approvals.ts
@@ -84,10 +84,23 @@ export function useResolveApproval() {
 			teamSlug?: string;
 		}) => api.post(`/api/approvals/${approvalId}/resolve`, { status, resolution_note }),
 		onSuccess: (_data, variables) => {
-			queryClient.invalidateQueries({ queryKey: ['approvals'] });
+			// Always invalidate the cross-team aggregated pending list — it has no team scope.
+			queryClient.invalidateQueries({ queryKey: ['approvals', 'pending'] });
 			if (variables.teamSlug) {
+				queryClient.invalidateQueries({
+					queryKey: ['teams', variables.teamSlug, 'approvals'],
+				});
 				invalidateTeamAgentCaches(queryClient, variables.teamSlug);
 			} else {
+				// No team scope provided — fall back to a predicate that matches any team's
+				// approvals list, keyed `['teams', <slug>, 'approvals', ...]`.
+				queryClient.invalidateQueries({
+					predicate: (query) =>
+						Array.isArray(query.queryKey) &&
+						query.queryKey[0] === 'teams' &&
+						typeof query.queryKey[1] === 'string' &&
+						query.queryKey[2] === 'approvals',
+				});
 				invalidateAllTeamAgentCaches(queryClient);
 			}
 		},

--- a/packages/web/src/hooks/use-onboarding.ts
+++ b/packages/web/src/hooks/use-onboarding.ts
@@ -1,8 +1,8 @@
+import type { OnboardingStageKey, OnboardingStageStatus } from '@hezo/shared';
 import { useQuery } from '@tanstack/react-query';
 import { api } from '../lib/api';
 
-export type OnboardingStageKey = 'intake' | 'done';
-export type OnboardingStageStatus = 'complete' | 'current' | 'pending';
+export type { OnboardingStageKey, OnboardingStageStatus };
 
 export interface OnboardingGoalSummary {
 	id: string;

--- a/packages/web/src/hooks/use-project-intake.ts
+++ b/packages/web/src/hooks/use-project-intake.ts
@@ -2,15 +2,18 @@ import { useMutation } from '@tanstack/react-query';
 import { api } from '../lib/api';
 import { queryClient } from '../lib/query-client';
 
+// `intakeTaskId` is the route-param slug — it must match the key used by
+// `useComments(teamId, taskId)` so the optimistic invalidation actually refetches.
+// The server route accepts both slugs and UUIDs (resolveTaskId).
 export function useSkipProjectIntakeQuestions(teamId: string, intakeTaskId: string) {
 	return useMutation({
 		mutationFn: () =>
 			api.post<{ task_id: string; comment_id: string }>(
 				`/api/teams/${teamId}/project-intake/${intakeTaskId}/skip-questions`,
 			),
-		onSuccess: (data) => {
+		onSuccess: () => {
 			queryClient.invalidateQueries({
-				queryKey: ['teams', teamId, 'tasks', data.task_id, 'comments'],
+				queryKey: ['teams', teamId, 'tasks', intakeTaskId, 'comments'],
 			});
 		},
 	});

--- a/packages/web/src/routes/teams/$teamId/projects/$projectId/tasks/$taskId.tsx
+++ b/packages/web/src/routes/teams/$teamId/projects/$projectId/tasks/$taskId.tsx
@@ -127,7 +127,7 @@ function TaskDetailPage() {
 	const chooseOption = useChooseOption(teamId, taskId);
 	const createSubTask = useCreateSubTask(teamId, taskId);
 	const removeDep = useRemoveDependency(teamId, taskId);
-	const skipProjectIntake = useSkipProjectIntakeQuestions(teamId, task?.id ?? '');
+	const skipProjectIntake = useSkipProjectIntakeQuestions(teamId, taskId);
 	const isProjectIntake = useMemo(
 		() => (task?.labels ?? []).includes(PROJECT_INTAKE_LABEL),
 		[task?.labels],


### PR DESCRIPTION
P0 correctness fixes:
- use-project-intake skip-questions invalidated comments cache with the
  UUID from the response, but the comments query keys with the route-param
  slug (per AGENTS.md). The invalidation was a silent no-op. Hook now takes
  the slug; server route resolves either via resolveTaskId.
- useResolveApproval scopes invalidation to the resolving team's approvals
  list + the cross-team aggregated pending list, instead of blowing away
  every team's approval cache.
- OnboardingStageKey/OnboardingStageStatus moved into @hezo/shared so the
  server and web declarations can't drift.

Server consolidation:
- New withTransaction helper in lib/sql.ts replaces 16 hand-rolled
  BEGIN/try/COMMIT/catch/ROLLBACK blocks across agents/comments/repos/
  team-templates routes and project-intake/documents/teams/oauth/agent-runner
  services. Forgetting ROLLBACK is no longer possible.
- New isUniqueViolation helper alongside isFkViolation, applied to the
  repos insert path (was string-matching error messages).
- assertTeamAccess extracted; requireTeamAccess and
  requireTeamAccessForResource now share the team-membership check body
  instead of duplicating it.
- Stop-hook judge scripts: extracted buildJudgeScript factory; Codex and
  Gemini variants now declare only their per-runtime differences (input
  field, API call, response extractor).