### PR TITLE
build(web): declare @hezo/shared path mapping explicitly in web tsconfig

### DIFF
--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -9,7 +9,12 @@
 		"forceConsistentCasingInFileNames": true,
 		"resolveJsonModule": true,
 		"jsx": "react-jsx",
-		"noEmit": true
+		"noEmit": true,
+		"baseUrl": ".",
+		"paths": {
+			"@hezo/shared": ["../shared/src/index.ts"],
+			"@hezo/shared/*": ["../shared/src/*"]
+		}
 	},
 	"include": ["src", "vite-env.d.ts"]
 }


### PR DESCRIPTION
Web imports `@hezo/shared` but its tsconfig had no paths declaration.
Module resolution worked only because Bun's workspace resolver found
the package transitively — IDE intellisense, non-Bun typecheck runs,
and any future tooling that doesn't read workspaces silently depended
on that.

Adds `baseUrl + paths` to packages/web/tsconfig.json. Web is noEmit, so
the mapping can't trigger the rootDir violation that would hit if
declared in tsconfig.base.json (server emits to dist).