### PR TITLE
feat: queued agent runs display and cancel on task sidebar

### DIFF
--- a/packages/server/src/routes/queued-wakeups.ts
+++ b/packages/server/src/routes/queued-wakeups.ts
@@ -1,0 +1,103 @@
+import { WakeupStatus, wsRoom } from '@hezo/shared';
+import { Hono } from 'hono';
+import { broadcastChange } from '../lib/broadcast';
+import { resolveActorMemberId, resolveTaskId } from '../lib/resolve';
+import { err, ok } from '../lib/response';
+import type { Env } from '../lib/types';
+import { logger } from '../logger';
+import { recordWakeupCancelled } from '../services/task-events';
+
+const log = logger.child('routes');
+
+export const queuedWakeupsRoutes = new Hono<Env>();
+
+queuedWakeupsRoutes.get('/teams/:teamId/tasks/:taskId/queued-wakeups', async (c) => {
+	const teamId = c.get('teamId') as string;
+	const db = c.get('db');
+	const taskId = await resolveTaskId(db, teamId, c.req.param('taskId'));
+	if (!taskId) return err(c, 'NOT_FOUND', 'Task not found', 404);
+
+	const result = await db.query(
+		`SELECT w.id, w.member_id,
+		        COALESCE(ma.title, m.display_name) AS member_name,
+		        w.source, w.created_at, w.coalesced_count, w.last_skipped_reason
+		 FROM agent_wakeup_requests w
+		 JOIN members m ON m.id = w.member_id
+		 LEFT JOIN member_agents ma ON ma.id = w.member_id
+		 WHERE w.team_id = $1
+		   AND w.status = $2::wakeup_status
+		   AND w.payload->>'task_id' = $3::text
+		 ORDER BY w.created_at ASC`,
+		[teamId, WakeupStatus.Queued, taskId],
+	);
+
+	return ok(c, { wakeups: result.rows });
+});
+
+queuedWakeupsRoutes.post(
+	'/teams/:teamId/tasks/:taskId/queued-wakeups/:wakeupId/cancel',
+	async (c) => {
+		const teamId = c.get('teamId') as string;
+		const db = c.get('db');
+		const taskId = await resolveTaskId(db, teamId, c.req.param('taskId'));
+		if (!taskId) return err(c, 'NOT_FOUND', 'Task not found', 404);
+		const wakeupId = c.req.param('wakeupId');
+
+		const lookup = await db.query<{ status: string; member_id: string }>(
+			`SELECT status, member_id FROM agent_wakeup_requests
+			 WHERE id = $1 AND team_id = $2 AND payload->>'task_id' = $3::text`,
+			[wakeupId, teamId, taskId],
+		);
+		const row = lookup.rows[0];
+		// 404 (not 403) for unknown / wrong-team / wrong-task to avoid leaking existence.
+		if (!row) return err(c, 'NOT_FOUND', 'Queued wakeup not found', 404);
+		if (row.status !== WakeupStatus.Queued) {
+			return err(c, 'CONFLICT', `Wakeup is already ${row.status} and cannot be cancelled`, 409);
+		}
+
+		// Race-safe: the 5s dispatcher (processWakeups) may flip queued->claimed
+		// between the lookup and here. The conditional WHERE guards against it.
+		const updated = await db.query<{ id: string }>(
+			`UPDATE agent_wakeup_requests
+			    SET status = $1::wakeup_status, completed_at = now()
+			  WHERE id = $2 AND status = $3::wakeup_status
+			 RETURNING id`,
+			[WakeupStatus.Cancelled, wakeupId, WakeupStatus.Queued],
+		);
+		if (updated.rows.length === 0) {
+			return err(c, 'CONFLICT', 'Wakeup is no longer queued and cannot be cancelled', 409);
+		}
+
+		broadcastChange(c, wsRoom.team(teamId), 'agent_wakeup_requests', 'UPDATE', {
+			id: wakeupId,
+			team_id: teamId,
+			task_id: taskId,
+			member_id: row.member_id,
+			status: WakeupStatus.Cancelled,
+		});
+
+		const nameRes = await db.query<{ member_name: string }>(
+			`SELECT COALESCE(ma.title, m.display_name) AS member_name
+			 FROM members m LEFT JOIN member_agents ma ON ma.id = m.id
+			 WHERE m.id = $1`,
+			[row.member_id],
+		);
+		const agentName = nameRes.rows[0]?.member_name ?? 'an agent';
+		const actorMemberId = await resolveActorMemberId(db, c.get('auth'), teamId);
+		try {
+			await recordWakeupCancelled(
+				db,
+				teamId,
+				taskId,
+				wakeupId,
+				agentName,
+				actorMemberId,
+				c.get('wsManager'),
+			);
+		} catch (e) {
+			log.error('Failed to record wakeup cancellation comment:', e);
+		}
+
+		return ok(c, { cancelled: true });
+	},
+);

--- a/packages/server/src/services/task-events.ts
+++ b/packages/server/src/services/task-events.ts
@@ -134,6 +134,39 @@ export async function recordRunTerminated(
 	}
 }
 
+export async function recordWakeupCancelled(
+	db: PGlite,
+	teamId: string,
+	taskId: string,
+	wakeupId: string,
+	agentName: string,
+	actorMemberId: string | null,
+	wsManager: WebSocketManager | undefined,
+): Promise<void> {
+	const actorName = await resolveActorName(db, actorMemberId);
+	const text = `${actorName} cancelled queued run for ${agentName}`;
+	const r = await db.query<Record<string, unknown>>(
+		`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
+		 VALUES ($1, $2, $3::comment_content_type, $4::jsonb) RETURNING *`,
+		[
+			taskId,
+			actorMemberId,
+			CommentContentType.System,
+			JSON.stringify({
+				kind: 'wakeup_cancelled',
+				wakeup_id: wakeupId,
+				actor_id: actorMemberId,
+				actor_name: actorName,
+				agent_name: agentName,
+				text,
+			}),
+		],
+	);
+	if (r.rows[0] && wsManager) {
+		broadcastRowChange(wsManager, wsRoom.team(teamId), 'task_comments', 'INSERT', r.rows[0]);
+	}
+}
+
 export async function recordTitleChange(
 	db: PGlite,
 	teamId: string,

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -37,6 +37,7 @@ import { preferencesRoutes } from './routes/preferences';
 import { previewRoutes } from './routes/preview';
 import { projectDocsRoutes } from './routes/project-docs';
 import { projectsRoutes } from './routes/projects';
+import { queuedWakeupsRoutes } from './routes/queued-wakeups';
 import { reposRoutes } from './routes/repos';
 import { searchRoutes } from './routes/search';
 import { secretsRoutes } from './routes/secrets';
@@ -292,6 +293,7 @@ export function buildApp(
 	app.route('/api', aiProvidersRoutes);
 	app.route('/api', reposRoutes);
 	app.route('/api', executionLocksRoutes);
+	app.route('/api', queuedWakeupsRoutes);
 	app.route('/api', auditLogRoutes);
 	app.route('/api', mcpConnectionsRoutes);
 	app.route('/api', oauthRoutes);

--- a/packages/server/test/queued-wakeups.test.ts
+++ b/packages/server/test/queued-wakeups.test.ts
@@ -1,0 +1,201 @@
+import type { PGlite } from '@electric-sql/pglite';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Env } from '../src/lib/types';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp, createTestProject } from './helpers/app';
+
+let app: Hono<Env>;
+let db: PGlite;
+let token: string;
+let teamId: string;
+let projectId: string;
+let taskId: string;
+let agentA: string;
+let agentB: string;
+
+const json = { 'Content-Type': 'application/json' };
+
+async function insertQueuedWakeup(
+	memberId: string,
+	forTaskId: string,
+	opts: { status?: string; coalesced?: number; source?: string } = {},
+): Promise<string> {
+	const { status = 'queued', coalesced = 0, source = 'mention' } = opts;
+	const r = await db.query<{ id: string }>(
+		`INSERT INTO agent_wakeup_requests (member_id, team_id, source, status, payload, coalesced_count)
+		 VALUES ($1, $2, $3::wakeup_source, $4::wakeup_status,
+		         jsonb_build_object('task_id', $5::text), $6)
+		 RETURNING id`,
+		[memberId, teamId, source, status, forTaskId, coalesced],
+	);
+	return r.rows[0].id;
+}
+
+async function createAgent(title: string): Promise<string> {
+	const res = await app.request(`/api/teams/${teamId}/agents`, {
+		method: 'POST',
+		headers: { ...authHeader(token), ...json },
+		body: JSON.stringify({ title }),
+	});
+	return (await res.json()).data.id;
+}
+
+async function createTask(title: string): Promise<string> {
+	const res = await app.request(`/api/teams/${teamId}/tasks`, {
+		method: 'POST',
+		headers: { ...authHeader(token), ...json },
+		// assignee is required; agentA owns the task. The auto 'assignment' wakeup
+		// it spawns is cleared per-test via clearWakeups so the list is controlled.
+		body: JSON.stringify({ project_id: projectId, title, assignee_id: agentA }),
+	});
+	return (await res.json()).data.id;
+}
+
+async function clearWakeups(forTaskId: string): Promise<void> {
+	await db.query("DELETE FROM agent_wakeup_requests WHERE payload->>'task_id' = $1::text", [
+		forTaskId,
+	]);
+}
+
+async function listQueued(forTaskId: string) {
+	const res = await app.request(`/api/teams/${teamId}/tasks/${forTaskId}/queued-wakeups`, {
+		headers: authHeader(token),
+	});
+	return { status: res.status, body: (await res.json()) as { data: { wakeups: WakeupRow[] } } };
+}
+
+interface WakeupRow {
+	id: string;
+	member_id: string;
+	member_name: string;
+	source: string;
+	created_at: string;
+	coalesced_count: number;
+	last_skipped_reason: string | null;
+}
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+
+	const teamRes = await app.request('/api/teams', {
+		method: 'POST',
+		headers: { ...authHeader(token), ...json },
+		body: JSON.stringify({ name: 'Queued Wakeups Co' }),
+	});
+	teamId = (await teamRes.json()).data.id;
+
+	const projectRes = await createTestProject(db, teamId, {
+		name: 'Main',
+		description: 'Test project.',
+	});
+	projectId = (await projectRes.json()).data.id;
+
+	agentA = await createAgent('Agent Alpha');
+	agentB = await createAgent('Agent Beta');
+	taskId = await createTask('Queued Task');
+	// Let the fire-and-forget assignment wakeup land, then start each test from a
+	// clean slate via clearWakeups.
+	await new Promise((r) => setTimeout(r, 50));
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+describe('GET /teams/:teamId/tasks/:taskId/queued-wakeups', () => {
+	it('lists queued wakeups with member name, excluding non-queued ones', async () => {
+		await clearWakeups(taskId);
+		const wA = await insertQueuedWakeup(agentA, taskId, { source: 'assignment' });
+		const wB = await insertQueuedWakeup(agentB, taskId, { coalesced: 2 });
+		// A claimed wakeup (the running agent) must be excluded.
+		await insertQueuedWakeup(agentA, taskId, { status: 'claimed' });
+
+		const { status, body } = await listQueued(taskId);
+		expect(status).toBe(200);
+		const { wakeups } = body.data;
+		const ids = wakeups.map((w) => w.id);
+		expect(ids).toContain(wA);
+		expect(ids).toContain(wB);
+		expect(wakeups.length).toBe(2);
+
+		const beta = wakeups.find((w) => w.id === wB);
+		expect(beta?.member_name).toBe('Agent Beta');
+		expect(beta?.source).toBe('mention');
+		expect(beta?.coalesced_count).toBe(2);
+
+		// Ordered by created_at ASC — A was inserted first.
+		expect(wakeups[0].id).toBe(wA);
+	});
+});
+
+describe('POST /teams/:teamId/tasks/:taskId/queued-wakeups/:wakeupId/cancel', () => {
+	it('cancels a queued wakeup and posts a system comment', async () => {
+		await clearWakeups(taskId);
+		const wakeupId = await insertQueuedWakeup(agentB, taskId);
+
+		const res = await app.request(
+			`/api/teams/${teamId}/tasks/${taskId}/queued-wakeups/${wakeupId}/cancel`,
+			{ method: 'POST', headers: { ...authHeader(token), ...json }, body: '{}' },
+		);
+		expect(res.status).toBe(200);
+		expect((await res.json()).data.cancelled).toBe(true);
+
+		const row = await db.query<{ status: string; completed_at: string | null }>(
+			'SELECT status, completed_at FROM agent_wakeup_requests WHERE id = $1',
+			[wakeupId],
+		);
+		expect(row.rows[0].status).toBe('cancelled');
+		expect(row.rows[0].completed_at).not.toBeNull();
+
+		const sys = await db.query<{ content: { kind?: string; wakeup_id?: string } }>(
+			"SELECT content FROM task_comments WHERE task_id = $1 AND content_type = 'system' ORDER BY created_at DESC",
+			[taskId],
+		);
+		const cancelComment = sys.rows.find(
+			(s) => s.content?.kind === 'wakeup_cancelled' && s.content?.wakeup_id === wakeupId,
+		);
+		expect(cancelComment).toBeTruthy();
+
+		// No longer listed.
+		const { body } = await listQueued(taskId);
+		expect(body.data.wakeups.map((w) => w.id)).not.toContain(wakeupId);
+	});
+
+	it('returns 409 when the wakeup is not queued', async () => {
+		const wakeupId = await insertQueuedWakeup(agentB, taskId, { status: 'claimed' });
+		const res = await app.request(
+			`/api/teams/${teamId}/tasks/${taskId}/queued-wakeups/${wakeupId}/cancel`,
+			{ method: 'POST', headers: { ...authHeader(token), ...json }, body: '{}' },
+		);
+		expect(res.status).toBe(409);
+	});
+
+	it('returns 404 for an unknown wakeup id', async () => {
+		const res = await app.request(
+			`/api/teams/${teamId}/tasks/${taskId}/queued-wakeups/00000000-0000-0000-0000-000000000000/cancel`,
+			{ method: 'POST', headers: { ...authHeader(token), ...json }, body: '{}' },
+		);
+		expect(res.status).toBe(404);
+	});
+
+	it('returns 404 when the wakeup belongs to a different task', async () => {
+		const otherTask = await createTask('Other Task');
+		const wakeupId = await insertQueuedWakeup(agentB, otherTask);
+		// Cancel via the original task's route — wrong task, must 404.
+		const res = await app.request(
+			`/api/teams/${teamId}/tasks/${taskId}/queued-wakeups/${wakeupId}/cancel`,
+			{ method: 'POST', headers: { ...authHeader(token), ...json }, body: '{}' },
+		);
+		expect(res.status).toBe(404);
+		// Still queued on its real task.
+		const row = await db.query<{ status: string }>(
+			'SELECT status FROM agent_wakeup_requests WHERE id = $1',
+			[wakeupId],
+		);
+		expect(row.rows[0].status).toBe('queued');
+	});
+});

--- a/packages/web/src/components/task-detail/queued-agents-list.tsx
+++ b/packages/web/src/components/task-detail/queued-agents-list.tsx
@@ -1,0 +1,81 @@
+import { Trash2 } from 'lucide-react';
+import { useState } from 'react';
+import { useCancelQueuedWakeup } from '../../hooks/use-cancel-queued-wakeup';
+import type { QueuedWakeup } from '../../hooks/use-queued-wakeups';
+import { ConfirmDialog } from '../ui/confirm-dialog';
+import { Tooltip } from '../ui/tooltip';
+
+interface QueuedAgentsListProps {
+	teamId: string;
+	taskId: string;
+	wakeups: QueuedWakeup[];
+}
+
+export function QueuedAgentsList({ teamId, taskId, wakeups }: QueuedAgentsListProps) {
+	if (wakeups.length === 0) return null;
+
+	return (
+		<div data-testid="queued-agents-list">
+			<span className="text-text-subtle block mb-1 uppercase tracking-wider font-medium">
+				Queued to run
+			</span>
+			<div className="flex flex-col gap-1">
+				{wakeups.map((w) => (
+					<QueuedAgentRow key={w.id} teamId={teamId} taskId={taskId} wakeup={w} />
+				))}
+			</div>
+		</div>
+	);
+}
+
+function QueuedAgentRow({
+	teamId,
+	taskId,
+	wakeup,
+}: {
+	teamId: string;
+	taskId: string;
+	wakeup: QueuedWakeup;
+}) {
+	const [open, setOpen] = useState(false);
+	const mutation = useCancelQueuedWakeup({ teamId, taskId });
+
+	return (
+		<div
+			data-testid={`queued-agent-${wakeup.id}`}
+			className="flex items-center justify-between gap-2 text-[13px] text-text"
+		>
+			<span className="truncate min-w-0">
+				{wakeup.member_name}
+				{wakeup.coalesced_count > 0 && (
+					<span className="text-text-subtle"> ×{wakeup.coalesced_count + 1}</span>
+				)}
+			</span>
+			<Tooltip content="Cancel queued run">
+				<button
+					type="button"
+					onClick={() => setOpen(true)}
+					aria-label="Cancel queued agent"
+					data-testid={`cancel-queued-wakeup-${wakeup.id}`}
+					disabled={mutation.isPending}
+					className="inline-flex items-center justify-center h-6 w-6 shrink-0 text-accent-red hover:bg-accent-red/10 rounded-radius-md transition-colors"
+				>
+					<Trash2 className="w-3.5 h-3.5" />
+				</button>
+			</Tooltip>
+			<ConfirmDialog
+				open={open}
+				onOpenChange={setOpen}
+				title="Cancel queued agent?"
+				description={`${wakeup.member_name} will be removed from the queue and won't run on this task.`}
+				confirmLabel="Cancel run"
+				cancelLabel="Keep queued"
+				variant="danger"
+				loading={mutation.isPending}
+				onConfirm={async () => {
+					await mutation.mutateAsync(wakeup.id);
+				}}
+			/>
+		</div>
+	);
+}

--- a/packages/web/src/components/task-detail/task-sidebar.tsx
+++ b/packages/web/src/components/task-detail/task-sidebar.tsx
@@ -12,11 +12,13 @@ import { useEffect, useRef, useState } from 'react';
 import type { Agent } from '../../hooks/use-agents';
 import type { Comment } from '../../hooks/use-comments';
 import type { ExecutionLockState } from '../../hooks/use-execution-locks';
+import { useQueuedWakeups } from '../../hooks/use-queued-wakeups';
 import type { Task, useUpdateTask } from '../../hooks/use-tasks';
 import { AgentStatusLabel } from '../agent-status-label';
 import { Button } from '../ui/button';
 import { ConfirmDialog } from '../ui/confirm-dialog';
 import { InfoTooltip } from '../ui/info-tooltip';
+import { QueuedAgentsList } from './queued-agents-list';
 import { RunningAgentsLine } from './running-agents-line';
 
 const EFFORT_LEVELS: { value: AgentEffort; label: string }[] = [
@@ -68,6 +70,8 @@ export function TaskSidebar({
 		return () => document.removeEventListener('pointerdown', onPointerDown);
 	}, [assigneeOpen]);
 
+	const { data: queued } = useQueuedWakeups(teamId, task.id);
+
 	const assignedAgent = agents?.find((a) => a.id === task.assignee_id);
 	const effectiveDefaultEffort: AgentEffort =
 		assignedAgent?.slug === CAPTAIN_AGENT_SLUG
@@ -86,6 +90,10 @@ export function TaskSidebar({
 			>
 				{lock && lock.locks.length > 0 && (
 					<RunningAgentsLine locks={lock.locks} comments={comments ?? []} />
+				)}
+
+				{queued && queued.wakeups.length > 0 && (
+					<QueuedAgentsList teamId={teamId} taskId={task.id} wakeups={queued.wakeups} />
 				)}
 
 				<div>

--- a/packages/web/src/hooks/use-cancel-queued-wakeup.ts
+++ b/packages/web/src/hooks/use-cancel-queued-wakeup.ts
@@ -1,0 +1,33 @@
+import { useMutation } from '@tanstack/react-query';
+import { api } from '../lib/api';
+import { queryClient } from '../lib/query-client';
+import { toast } from './use-toast';
+
+interface CancelQueuedWakeupArgs {
+	teamId: string;
+	taskId: string;
+}
+
+export function useCancelQueuedWakeup({ teamId, taskId }: CancelQueuedWakeupArgs) {
+	return useMutation({
+		mutationFn: (wakeupId: string) =>
+			api.post<{ cancelled: boolean }>(
+				`/api/teams/${teamId}/tasks/${taskId}/queued-wakeups/${wakeupId}/cancel`,
+				{},
+			),
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: ['teams', teamId, 'tasks', taskId, 'queued-wakeups'],
+			});
+			// Surface the system comment recording the cancellation.
+			queryClient.invalidateQueries({
+				queryKey: ['teams', teamId, 'tasks', taskId, 'comments'],
+			});
+			// Refresh the single queued_wakeup badge / has_active_run on the task.
+			queryClient.invalidateQueries({ queryKey: ['teams', teamId, 'tasks', taskId] });
+		},
+		onError: (error: { message?: string }) => {
+			toast.error(error?.message ?? 'Failed to cancel queued agent');
+		},
+	});
+}

--- a/packages/web/src/hooks/use-queued-wakeups.ts
+++ b/packages/web/src/hooks/use-queued-wakeups.ts
@@ -1,0 +1,25 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '../lib/api';
+
+export interface QueuedWakeup {
+	id: string;
+	member_id: string;
+	member_name: string;
+	source: string;
+	created_at: string;
+	coalesced_count: number;
+	last_skipped_reason: string | null;
+}
+
+export interface QueuedWakeupsState {
+	wakeups: QueuedWakeup[];
+}
+
+export function useQueuedWakeups(teamId: string, taskId: string) {
+	return useQuery({
+		queryKey: ['teams', teamId, 'tasks', taskId, 'queued-wakeups'],
+		queryFn: () =>
+			api.get<QueuedWakeupsState>(`/api/teams/${teamId}/tasks/${taskId}/queued-wakeups`),
+		refetchInterval: 5_000,
+	});
+}

--- a/packages/web/test/queued-agents.test.tsx
+++ b/packages/web/test/queued-agents.test.tsx
@@ -1,0 +1,62 @@
+import { waitFor } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+import { seedProject, seedTask, seedWorkspace } from './helpers/seed';
+
+test('task sidebar lists a queued agent and cancels it via the confirm dialog', async () => {
+	const seeded = { teamSlug: '', taskId: '', wakeupId: '', queuedAgentTitle: '' };
+
+	const { findByTestId, findByText, getByTestId, queryByTestId, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async (ctx) => {
+			const ws = await seedWorkspace();
+			const captain = ws.agents.find((a) => a.slug === 'captain') ?? ws.agents[0];
+			// Queue a *different* agent than the assignee so the inserted wakeup is
+			// unambiguous regardless of any auto 'assignment' wakeup.
+			const queuedAgent = ws.agents.find((a) => a.id !== captain.id) ?? ws.agents[0];
+			const project = await seedProject(ws, { name: 'Queued Demo' });
+			const task = await seedTask(ws, project, { title: 'Queued Task', assignee_id: captain.id });
+
+			const r = await ctx.db.query<{ id: string }>(
+				`INSERT INTO agent_wakeup_requests (member_id, team_id, source, status, payload)
+				 VALUES ($1, $2, 'mention'::wakeup_source, 'queued'::wakeup_status,
+				         jsonb_build_object('task_id', $3::text))
+				 RETURNING id`,
+				[queuedAgent.id, ws.team.id, task.id],
+			);
+
+			seeded.teamSlug = ws.team.slug;
+			seeded.taskId = task.id;
+			seeded.wakeupId = r.rows[0].id;
+			seeded.queuedAgentTitle = queuedAgent.title;
+		},
+	});
+
+	await router.navigate({
+		to: '/teams/$teamId/tasks/$taskId',
+		params: { teamId: seeded.teamSlug, taskId: seeded.taskId },
+	});
+
+	// The queued-agents list renders in the sidebar with the queued agent's name.
+	const list = await findByTestId('queued-agents-list', undefined, { timeout: 15_000 });
+	expect(list.textContent).toContain(seeded.queuedAgentTitle);
+
+	// Open the confirm dialog and cancel.
+	const cancelBtn = await findByTestId(`cancel-queued-wakeup-${seeded.wakeupId}`);
+	await user.click(cancelBtn);
+
+	const dialog = await findByText('Cancel queued agent?');
+	expect(dialog).toBeTruthy();
+
+	const confirm = getByTestId('confirm-dialog-confirm');
+	await user.click(confirm);
+
+	// The real backend cancels the wakeup; the mutation's invalidation forces an
+	// immediate refetch, so the row disappears.
+	await waitFor(
+		() => {
+			expect(queryByTestId(`queued-agent-${seeded.wakeupId}`)).toBeNull();
+		},
+		{ timeout: 15_000 },
+	);
+});


### PR DESCRIPTION
When agents are @mentioned on a busy task, their wakeups queue up
(agent_wakeup_requests with status='queued'). Surface that queue in the
task sidebar and let users cancel a queued run before it dispatches.

Backend:
- New routes GET/POST /teams/:teamId/tasks/:taskId/queued-wakeups[/:id/cancel].
  List returns queued wakeups (agent name, source, coalesced_count). Cancel is
  race-safe against the 5s dispatcher (conditional UPDATE ... WHERE status=
  'queued', 409 on lost race), authorizes by team + task, and records a
  'wakeup_cancelled' system comment.
- recordWakeupCancelled in task-events, rendered via the system-comment text
  fallback (no new renderer needed).

Frontend:
- useQueuedWakeups (5s poll) + useCancelQueuedWakeup hooks.
- QueuedAgentsList in the task sidebar: per-agent row with a trash button that
  opens a confirm dialog. Mobile-first.

Tests: server integration (list/cancel/auth/409/404) and a web component test
driving the click -> confirm -> removal flow against the real backend.

https://claude.ai/code/session_01STnHWG9HKBhNJj5Yo4atke