### PR TITLE
fix(projects): key container and workspace identity on immutable ids

### DIFF
--- a/packages/server/src/db/seed.ts
+++ b/packages/server/src/db/seed.ts
@@ -222,29 +222,6 @@ export async function seedBuiltins(db: PGlite, roleDocs: Record<string, string>)
 
 	const skillsConfig = [
 		{
-			name: 'Team Overview',
-			slug: 'team-overview.md',
-			content: `# Team Overview
-
-<!-- TODO: customize this document for your team -->
-
-## Mission
-
-Describe your team's mission and what problem you're solving.
-
-## Product
-
-Describe your product, its target users, and key value propositions.
-
-## Decision Making
-
-- Strategic decisions escalate to the board
-- Technical architecture decisions go through the Architect
-- Product scope decisions go through the Product Lead
-- Day-to-day implementation decisions are made by the assigned agent
-`,
-		},
-		{
 			name: 'Development Workflow',
 			slug: 'development-workflow.md',
 			content: `# Development Workflow
@@ -273,36 +250,6 @@ Approval is conveyed via comment, not status. From **Review**, the ticket either
 - Every change requires a PR with a clear description
 - PRs must pass CI checks before merge
 - QA Engineer performs final review before approval
-`,
-		},
-		{
-			name: 'Architecture Guidelines',
-			slug: 'architecture-guidelines.md',
-			content: `# Architecture Guidelines
-
-<!-- TODO: customize for your tech stack -->
-
-## Tech Stack
-
-Describe your primary languages, frameworks, and infrastructure.
-
-## Project Structure
-
-Describe your repository layout and key directories.
-
-## Coding Conventions
-
-- Follow the language's standard style guide
-- Write self-documenting code with minimal comments
-- Prefer composition over inheritance
-- Keep functions focused and small
-
-## Architecture Decision Records
-
-Significant technical decisions should be documented with:
-- **Context** — what prompted the decision
-- **Decision** — what was chosen
-- **Consequences** — trade-offs and implications
 `,
 		},
 		{

--- a/packages/server/src/lib/log-ref.ts
+++ b/packages/server/src/lib/log-ref.ts
@@ -1,0 +1,4 @@
+// Formats an entity for logs as "label (uuid)", or just the uuid when no
+// friendly label is available.
+export const ref = (label: string | null | undefined, id: string): string =>
+	label ? `${label} (${id})` : id;

--- a/packages/server/src/routes/assets.ts
+++ b/packages/server/src/routes/assets.ts
@@ -33,25 +33,17 @@ assetsRoutes.post(
 		if (!taskId) return err(c, 'NOT_FOUND', 'Task not found', 404);
 
 		const taskLocator = await db.query<{
-			team_slug: string;
 			project_id: string;
-			project_slug: string;
 		}>(
-			`SELECT t.slug AS team_slug, p.id AS project_id, p.slug AS project_slug
+			`SELECT i.project_id
 			 FROM tasks i
-			 JOIN teams t ON t.id = i.team_id
-			 JOIN projects p ON p.id = i.project_id
 			 WHERE i.id = $1 AND i.team_id = $2`,
 			[taskId, teamId],
 		);
 		if (taskLocator.rows.length === 0) {
 			return err(c, 'NOT_FOUND', 'Task not found', 404);
 		}
-		const {
-			team_slug: teamSlug,
-			project_id: projectId,
-			project_slug: projectSlug,
-		} = taskLocator.rows[0];
+		const { project_id: projectId } = taskLocator.rows[0];
 
 		let form: Awaited<ReturnType<typeof c.req.parseBody>>;
 		try {
@@ -82,7 +74,7 @@ assetsRoutes.post(
 		let byteSize: number;
 		let sha256: string;
 		try {
-			const result = await writeAsset(dataDir, teamSlug, projectSlug, assetId, file);
+			const result = await writeAsset(dataDir, teamId, projectId, assetId, file);
 			byteSize = result.byteSize;
 			sha256 = result.sha256;
 		} catch (e) {
@@ -131,23 +123,20 @@ publicAssetsRoutes.get('/api/assets/:assetId', async (c) => {
 		content_type: string;
 		original_filename: string;
 		byte_size: number;
-		team_slug: string;
-		project_slug: string;
+		team_id: string;
+		project_id: string;
 	}>(
-		`SELECT a.content_type, a.original_filename, a.byte_size,
-		        t.slug AS team_slug, p.slug AS project_slug
-		 FROM assets a
-		 JOIN teams t ON t.id = a.team_id
-		 JOIN projects p ON p.id = a.project_id
-		 WHERE a.id = $1`,
+		`SELECT content_type, original_filename, byte_size, team_id, project_id
+		 FROM assets
+		 WHERE id = $1`,
 		[assetId],
 	);
 	if (row.rows.length === 0) {
 		return err(c, 'NOT_FOUND', 'Asset not found', 404);
 	}
-	const { content_type, original_filename, team_slug, project_slug } = row.rows[0];
+	const { content_type, original_filename, team_id, project_id } = row.rows[0];
 
-	const diskPath = getAssetPath(c.get('dataDir'), team_slug, project_slug, assetId);
+	const diskPath = getAssetPath(c.get('dataDir'), team_id, project_id, assetId);
 	let buf: Buffer;
 	try {
 		buf = await readFile(diskPath);

--- a/packages/server/src/routes/assets.ts
+++ b/packages/server/src/routes/assets.ts
@@ -9,6 +9,7 @@ import {
 import { Hono } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
 import { signAssetUrl, verifyAssetUrl } from '../lib/asset-urls';
+import { ref } from '../lib/log-ref';
 import { resolveActorMemberId, resolveTaskId } from '../lib/resolve';
 import { err, ok } from '../lib/response';
 import type { Env } from '../lib/types';
@@ -141,7 +142,7 @@ publicAssetsRoutes.get('/api/assets/:assetId', async (c) => {
 	try {
 		buf = await readFile(diskPath);
 	} catch (e) {
-		log.error(`Failed to read asset ${assetId} from disk:`, e);
+		log.error(`Failed to read asset ${ref(original_filename, assetId)} from disk:`, e);
 		return err(c, 'NOT_FOUND', 'Asset file missing', 404);
 	}
 

--- a/packages/server/src/routes/preview.ts
+++ b/packages/server/src/routes/preview.ts
@@ -35,20 +35,7 @@ previewRoutes.get('/teams/:teamId/projects/:projectId/preview/*', async (c) => {
 		return err(c, 'NOT_CONFIGURED', 'Data directory not configured', 500);
 	}
 
-	const project = await db.query<{ slug: string }>(
-		'SELECT slug FROM projects WHERE id = $1 AND team_id = $2',
-		[projectId, teamId],
-	);
-	if (project.rows.length === 0) {
-		return err(c, 'NOT_FOUND', 'Project not found', 404);
-	}
-
-	const team = await db.query<{ slug: string }>('SELECT slug FROM teams WHERE id = $1', [teamId]);
-	if (team.rows.length === 0) {
-		return err(c, 'NOT_FOUND', 'Team not found', 404);
-	}
-
-	const workspacePath = getWorkspacePath(dataDir, team.rows[0].slug, project.rows[0].slug);
+	const workspacePath = getWorkspacePath(dataDir, teamId, projectId);
 	const requestedPath = c.req.path.split('/preview/')[1] || 'index.html';
 	const resolvedPath = resolve(join(workspacePath, requestedPath));
 

--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -3,6 +3,7 @@ import { ContainerStatus, WakeupSource, wsRoom } from '@hezo/shared';
 import { type Context, Hono } from 'hono';
 import { trackBackground } from '../lib/background';
 import { broadcastChange } from '../lib/broadcast';
+import { ref } from '../lib/log-ref';
 import { resolveProjectId } from '../lib/resolve';
 import { err, ok } from '../lib/response';
 import { toProjectTaskPrefix, toSlug, uniqueSlug } from '../lib/slug';
@@ -479,7 +480,10 @@ projectsRoutes.post('/teams/:teamId/projects/:projectId/container/rebuild', asyn
 				await rebuildContainer(containerDeps, projectResult.rows[0] as ProjectRow, teamSlug);
 				wakeAgentsWithPendingWork(db, projectId, teamId);
 			} catch (error) {
-				log.error(`Container rebuild failed for project ${projectId}:`, error);
+				log.error(
+					`Container rebuild failed for project ${ref((projectResult.rows[0] as ProjectRow).slug, projectId)}:`,
+					error,
+				);
 			}
 		},
 		REBUILD_TIMEOUT_MS,

--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -328,20 +328,11 @@ projectsRoutes.delete('/teams/:teamId/projects/:projectId', async (c) => {
 		return err(c, 'CONFLICT', 'Cannot delete project with open tasks', 409);
 	}
 
-	const teamSlugResult = await db.query<{ slug: string }>('SELECT slug FROM teams WHERE id = $1', [
-		teamId,
-	]);
-	const teamSlug = teamSlugResult.rows[0]?.slug;
-
-	if (teamSlug) {
-		await trackBackground(
-			teardownContainer(buildContainerDeps(c), projectId, teamSlug, existing.rows[0].slug).catch(
-				(error) => {
-					log.error(`Failed to teardown container for project ${existing.rows[0].slug}:`, error);
-				},
-			),
-		);
-	}
+	await trackBackground(
+		teardownContainer(buildContainerDeps(c), projectId, teamId).catch((error) => {
+			log.error(`Failed to teardown container for project ${existing.rows[0].slug}:`, error);
+		}),
+	);
 
 	await db.query('DELETE FROM projects WHERE id = $1', [projectId]);
 	broadcastChange(c, wsRoom.team(teamId), 'projects', 'DELETE', { id: projectId });

--- a/packages/server/src/routes/repos.ts
+++ b/packages/server/src/routes/repos.ts
@@ -216,8 +216,6 @@ reposRoutes.post('/teams/:teamId/projects/:projectId/repos', async (c) => {
 				{
 					id: projectId,
 					team_id: teamId,
-					teamSlug: locator.teamSlug,
-					projectSlug: locator.slug,
 				},
 				dataDir,
 				c.get('sshAgentServer'),
@@ -309,7 +307,7 @@ reposRoutes.delete('/teams/:teamId/projects/:projectId/repos/:repoId', async (c)
 		const locator = await getProjectLocator(db, projectId);
 		if (locator) {
 			try {
-				removeRepoFromWorkspace(dataDir, locator.teamSlug, locator.slug, result.rows[0].short_name);
+				removeRepoFromWorkspace(dataDir, locator.teamId, locator.id, result.rows[0].short_name);
 			} catch (error) {
 				log.error(`Failed to clean up workspace for repo ${result.rows[0].short_name}:`, error);
 			}

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -651,7 +651,7 @@ tasksRoutes.patch('/teams/:teamId/tasks/:taskId', async (c) => {
 					const locator = await getProjectLocator(db, taskInfo.project_id);
 					if (locator) {
 						try {
-							removeTaskWorktrees(dataDir, locator.teamSlug, locator.slug, taskInfo.identifier);
+							removeTaskWorktrees(dataDir, locator.teamId, locator.id, taskInfo.identifier);
 						} catch (error) {
 							log.error(`Failed to clean up worktrees for task ${taskInfo.identifier}:`, error);
 						}

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -615,6 +615,10 @@ export async function runAgent(
 
 	await markHeartbeatRunRunning(deps.db, heartbeatRunId, runBroadcast);
 
+	// Human-friendly label for run-scoped logs (egress proxy, ssh-agent),
+	// since a run has no friendly identifier of its own.
+	const runLabel = `${agent.slug}/${task.identifier}`;
+
 	let sshSocketContainerPath: string | null = null;
 	let sshSocketHostPath: string | null = null;
 	let bridge: BridgeRunnerArgs | null = null;
@@ -622,7 +626,7 @@ export async function runAgent(
 		sshSocketHostPath = getRunSocketPath(deps.dataDir, heartbeatRunId);
 		const allocated = await deps.sshAgentServer.allocateRunSocket(
 			heartbeatRunId,
-			{ teamId: agent.team_id, agentId: agent.id },
+			{ teamId: agent.team_id, agentId: agent.id, label: runLabel },
 			sshSocketHostPath,
 		);
 		sshSocketContainerPath = `/run/hezo/${heartbeatRunId}.sock`;
@@ -645,6 +649,7 @@ export async function runAgent(
 			teamId: agent.team_id,
 			agentId: agent.id,
 			projectId: project.id,
+			label: runLabel,
 		});
 		egressAllocated = true;
 		egressEnv = {

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -212,12 +212,12 @@ export function getContainerPromptPath(heartbeatRunId: string): string {
 
 export function getHostPromptPath(
 	dataDir: string,
-	teamSlug: string,
-	projectSlug: string,
+	teamId: string,
+	projectId: string,
 	heartbeatRunId: string,
 ): string {
 	return join(
-		getWorkspacePath(dataDir, teamSlug, projectSlug),
+		getWorkspacePath(dataDir, teamId, projectId),
 		'.hezo',
 		'prompts',
 		`${heartbeatRunId}.txt`,
@@ -311,8 +311,8 @@ async function buildRunContext(
 
 	const subscriptionMount = buildSubscriptionMount(
 		deps.dataDir,
-		project.team_slug,
-		project.slug,
+		project.team_id,
+		project.id,
 		heartbeatRunId,
 		provider,
 		credential,
@@ -323,8 +323,8 @@ async function buildRunContext(
 		? ensureRuntimeHomeDir(
 				provider,
 				deps.dataDir,
-				project.team_slug,
-				project.slug,
+				project.team_id,
+				project.id,
 				heartbeatRunId,
 				subscriptionMount,
 			)
@@ -689,8 +689,8 @@ export async function runAgent(
 
 	const hostPromptPath = getHostPromptPath(
 		deps.dataDir,
-		project.team_slug,
-		project.slug,
+		project.team_id,
+		project.id,
 		heartbeatRunId,
 	);
 	mkdirSync(dirname(hostPromptPath), { recursive: true });
@@ -864,8 +864,6 @@ async function prepareWorktrees(
 		{
 			id: project.id,
 			team_id: project.team_id,
-			teamSlug: project.team_slug,
-			projectSlug: project.slug,
 		},
 		deps.dataDir,
 		deps.sshAgentServer,
@@ -877,8 +875,8 @@ async function prepareWorktrees(
 
 	if (signal?.aborted) return { workingDir: '/workspace', designatedRepo: null };
 
-	const workspaceRoot = getWorkspacePath(deps.dataDir, project.team_slug, project.slug);
-	const worktreesRoot = getWorktreesPath(deps.dataDir, project.team_slug, project.slug);
+	const workspaceRoot = getWorkspacePath(deps.dataDir, project.team_id, project.id);
+	const worktreesRoot = getWorktreesPath(deps.dataDir, project.team_id, project.id);
 	const taskWorktreeRoot = join(worktreesRoot, task.identifier);
 	mkdirSync(taskWorktreeRoot, { recursive: true });
 

--- a/packages/server/src/services/asset-storage.ts
+++ b/packages/server/src/services/asset-storage.ts
@@ -18,8 +18,8 @@ export class AttachmentTooLargeError extends Error {
 
 export async function writeAsset(
 	dataDir: string,
-	teamSlug: string,
-	projectSlug: string,
+	teamId: string,
+	projectId: string,
 	assetId: string,
 	source: Blob,
 ): Promise<WriteAssetResult> {
@@ -33,7 +33,7 @@ export async function writeAsset(
 	}
 
 	const sha256 = createHash('sha256').update(buf).digest('hex');
-	const diskPath = getAssetPath(dataDir, teamSlug, projectSlug, assetId);
+	const diskPath = getAssetPath(dataDir, teamId, projectId, assetId);
 	mkdirSync(dirname(diskPath), { recursive: true });
 
 	try {
@@ -48,21 +48,21 @@ export async function writeAsset(
 
 export async function deleteAsset(
 	dataDir: string,
-	teamSlug: string,
-	projectSlug: string,
+	teamId: string,
+	projectId: string,
 	assetId: string,
 ): Promise<void> {
-	const diskPath = getAssetPath(dataDir, teamSlug, projectSlug, assetId);
+	const diskPath = getAssetPath(dataDir, teamId, projectId, assetId);
 	await unlink(diskPath).catch(() => {});
 }
 
 export function assetExists(
 	dataDir: string,
-	teamSlug: string,
-	projectSlug: string,
+	teamId: string,
+	projectId: string,
 	assetId: string,
 ): boolean {
-	return existsSync(getAssetPath(dataDir, teamSlug, projectSlug, assetId));
+	return existsSync(getAssetPath(dataDir, teamId, projectId, assetId));
 }
 
 export { getAssetPath, getAssetsPath };

--- a/packages/server/src/services/containers.ts
+++ b/packages/server/src/services/containers.ts
@@ -151,7 +151,7 @@ export async function provisionContainer(
 
 	try {
 		emit('stdout', `→ Preparing workspace for ${teamSlug}/${project.slug}`);
-		const projectDir = ensureProjectWorkspace(dataDir, teamSlug, project.slug);
+		const projectDir = ensureProjectWorkspace(dataDir, project.team_id, project.id);
 		const workspacePath = join(projectDir, 'workspace');
 		const worktreesPath = join(projectDir, 'worktrees');
 		const previewsPath = join(projectDir, '.previews');
@@ -186,7 +186,11 @@ export async function provisionContainer(
 			]);
 		}
 
-		const containerName = `hezo-${teamSlug}-${project.slug}`;
+		// Container identity is keyed on the immutable project id so a team/project
+		// rename never orphans the container or shifts its bind mounts. The slugs ride
+		// along as labels purely for `docker ps` readability.
+		const containerName = `hezo-${project.id}`;
+		const containerLabels = { 'hezo.team': teamSlug, 'hezo.project': project.slug };
 		const extraHosts = ['host.docker.internal:host-gateway'];
 
 		const env = ['HEZO_API_URL=http://host.docker.internal:3100/agent-api'];
@@ -208,6 +212,7 @@ export async function provisionContainer(
 			Cmd: ['sleep', 'infinity'],
 			Env: env,
 			WorkingDir: '/workspace',
+			Labels: containerLabels,
 			HostConfig: {
 				Binds: binds,
 				PortBindings: portBindings,
@@ -251,8 +256,6 @@ export async function provisionContainer(
 				{
 					id: project.id,
 					team_id: teamId,
-					teamSlug,
-					projectSlug: project.slug,
 				},
 				dataDir,
 				deps.sshAgentServer ?? null,
@@ -311,8 +314,7 @@ export async function provisionContainer(
 export async function teardownContainer(
 	deps: ContainerDeps,
 	projectId: string,
-	teamSlug: string,
-	projectSlug: string,
+	teamId: string,
 ): Promise<void> {
 	const { db, docker, dataDir } = deps;
 
@@ -338,7 +340,7 @@ export async function teardownContainer(
 		projectId,
 	]);
 
-	removeProjectWorkspace(dataDir, teamSlug, projectSlug);
+	removeProjectWorkspace(dataDir, teamId, projectId);
 }
 
 export async function stopContainerGracefully(

--- a/packages/server/src/services/docker.ts
+++ b/packages/server/src/services/docker.ts
@@ -6,6 +6,7 @@ interface ContainerConfig {
 	Cmd?: string[];
 	Env?: string[];
 	WorkingDir?: string;
+	Labels?: Record<string, string>;
 	HostConfig: {
 		Binds?: string[];
 		PortBindings?: Record<string, Array<{ HostPort: string }>>;

--- a/packages/server/src/services/egress/proxy.ts
+++ b/packages/server/src/services/egress/proxy.ts
@@ -3,6 +3,7 @@ import type { PGlite } from '@electric-sql/pglite';
 import type { IContext, IProxy } from 'http-mitm-proxy';
 import { Proxy as MitmProxy } from 'http-mitm-proxy';
 import type { MasterKeyManager } from '../../crypto/master-key';
+import { ref } from '../../lib/log-ref';
 import { logger } from '../../logger';
 import { type EgressAuditEvent, recordEgressEvent } from './audit';
 import type { HezoCA } from './ca';
@@ -48,6 +49,8 @@ export interface RunProxyScope {
 	teamId: string;
 	agentId: string;
 	projectId?: string | null;
+	/** Human-friendly label (agentSlug/taskIdentifier) for run-scoped logs. */
+	label?: string | null;
 }
 
 export interface AllocatedRunProxy {
@@ -88,7 +91,7 @@ export class EgressProxy {
 		proxy.onError((ctx, err, errorKind) => {
 			if (!err) return;
 			log.warn('mitm proxy error', {
-				runId,
+				run: ref(scope.label, runId),
 				kind: errorKind,
 				error: err.message,
 				...describeErrorContext(proxy, ctx, err),
@@ -134,12 +137,12 @@ export class EgressProxy {
 		} catch (e) {
 			this.portAllocator.release(port);
 			const reason = (e as Error).message;
-			log.warn('egress proxy unavailable for run', { runId, reason });
+			log.warn('egress proxy unavailable for run', { run: ref(scope.label, runId), reason });
 			throw new EgressProxyUnavailableError(reason);
 		}
 
 		this.runs.set(runId, { proxy, port, scope });
-		log.debug('egress proxy allocated', { runId, port });
+		log.debug('egress proxy allocated', { run: ref(scope.label, runId), port });
 
 		return { proxyHost: this.proxyHost, proxyPort: port };
 	}
@@ -150,11 +153,14 @@ export class EgressProxy {
 		try {
 			record.proxy.close();
 		} catch (e) {
-			log.warn('egress proxy close failed', { runId, error: (e as Error).message });
+			log.warn('egress proxy close failed', {
+				run: ref(record.scope.label, runId),
+				error: (e as Error).message,
+			});
 		}
 		this.portAllocator.release(record.port);
 		this.runs.delete(runId);
-		log.debug('egress proxy released', { runId });
+		log.debug('egress proxy released', { run: ref(record.scope.label, runId) });
 	}
 
 	async releaseAll(): Promise<void> {

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -21,6 +21,7 @@ import type { MasterKeyManager } from '../crypto/master-key';
 import { trackBackground } from '../lib/background';
 import { broadcastRowChange } from '../lib/broadcast';
 import { shouldDeferWakeupForBlockers } from '../lib/dependencies';
+import { ref } from '../lib/log-ref';
 import { assertChildrenAllClosed } from '../lib/task-relationships';
 import { logger } from '../logger';
 import { type RunnerDeps, type RunResult, runAgent } from './agent-runner';
@@ -793,7 +794,9 @@ export class JobManager {
 				[payloadTaskId, teamId],
 			);
 			if (payloadTask.rows.length === 0) {
-				log.debug(`Payload task ${payloadTaskId} not found for agent ${memberId}`);
+				log.debug(
+					`Payload task ${payloadTaskId} not found for agent ${ref(agent.rows[0].slug, memberId)}`,
+				);
 				if (wakeupId) {
 					await db.query(
 						`UPDATE agent_wakeup_requests SET status = $1::wakeup_status, completed_at = now() WHERE id = $2`,
@@ -830,7 +833,7 @@ export class JobManager {
 				],
 			);
 			if (tasks.rows.length === 0) {
-				log.debug(`No actionable tasks for agent ${memberId}`);
+				log.debug(`No actionable tasks for agent ${ref(agent.rows[0].slug, memberId)}`);
 				if (wakeupId) {
 					await db.query(
 						`UPDATE agent_wakeup_requests SET status = $1::wakeup_status, completed_at = now() WHERE id = $2`,
@@ -851,7 +854,7 @@ export class JobManager {
 		// between the dispatcher check and now.
 		if (await this.isTaskBusy({ task_id: task.id })) {
 			log.debug(
-				`Task ${task.identifier} already has an active run — re-queuing wakeup for ${memberId}`,
+				`Task ${ref(task.identifier, task.id)} already has an active run — re-queuing wakeup for ${ref(agent.rows[0].slug, memberId)}`,
 			);
 			if (wakeupId) {
 				await db.query(
@@ -863,7 +866,7 @@ export class JobManager {
 		}
 		if (await this.isProjectBusy(task.project_id)) {
 			log.debug(
-				`Project ${task.project_id} already has an active run — re-queuing wakeup for ${memberId}`,
+				`Project ${task.project_id} already has an active run — re-queuing wakeup for ${ref(agent.rows[0].slug, memberId)}`,
 			);
 			if (wakeupId) {
 				await db.query(
@@ -935,7 +938,7 @@ export class JobManager {
 					);
 				}
 			} catch (e) {
-				log.error(`Failed to ensure repo setup action for agent ${agentSlug}:`, e);
+				log.error(`Failed to ensure repo setup action for agent ${ref(agentSlug, memberId)}:`, e);
 			}
 
 			if (wakeupId) {
@@ -956,13 +959,15 @@ export class JobManager {
 				);
 			}
 			log.debug(
-				`Agent ${agentSlug} deferred on task ${task.identifier} — project has no designated repo`,
+				`Agent ${ref(agentSlug, memberId)} deferred on task ${ref(task.identifier, task.id)} — project has no designated repo`,
 			);
 			return;
 		}
 
 		if (!projectRow.container_id) {
-			log.debug(`No container for project ${task.project_id} — wakeup failed`);
+			log.debug(
+				`No container for project ${ref(projectRow.slug, task.project_id)} — wakeup failed`,
+			);
 			if (wakeupId) {
 				await db.query(
 					'UPDATE agent_wakeup_requests SET status = $1::wakeup_status WHERE id = $2',
@@ -988,7 +993,7 @@ export class JobManager {
 
 		if (lockResult.rows.length === 0) {
 			log.debug(
-				`Agent ${agent.rows[0].slug} already holds a lock on task ${task.identifier} — deferring wakeup`,
+				`Agent ${ref(agent.rows[0].slug, memberId)} already holds a lock on task ${ref(task.identifier, task.id)} — deferring wakeup`,
 			);
 			if (wakeupId) {
 				await db.query(
@@ -1008,7 +1013,9 @@ export class JobManager {
 			runtime_status: AgentRuntimeStatus.Active,
 		});
 
-		log.debug(`Launching agent ${agent.rows[0].title} for task ${task.identifier}`);
+		log.debug(
+			`Launching agent ${ref(agentSlug, memberId)} for task ${ref(task.identifier, task.id)}`,
+		);
 
 		const deps: RunnerDeps = {
 			db,
@@ -1069,6 +1076,7 @@ export class JobManager {
 						memberId,
 						agent.rows[0].slug,
 						task.id,
+						task.identifier,
 						teamId,
 						wakeupId,
 						wakeupPayload,
@@ -1079,7 +1087,10 @@ export class JobManager {
 					// Background run errors must not become unhandled rejections — they
 					// most commonly fire when a test or shutdown closes the DB while a
 					// run is still cleaning up. Log and swallow.
-					log.error(`Background run for agent ${memberId} on task ${task.id} failed:`, err);
+					log.error(
+						`Background run for agent ${ref(agent.rows[0].slug, memberId)} on task ${ref(task.identifier, task.id)} failed:`,
+						err,
+					);
 					if (registeredRunId) this.unregisterLiveRun(registeredRunId);
 					return null;
 				} finally {
@@ -1096,6 +1107,7 @@ export class JobManager {
 		memberId: string,
 		agentSlug: string,
 		taskId: string,
+		taskIdentifier: string,
 		teamId: string,
 		wakeupId: string | undefined,
 		wakeupPayload: Record<string, unknown> | undefined,
@@ -1104,7 +1116,7 @@ export class JobManager {
 		const { db } = this.deps;
 
 		log.debug(
-			`Agent ${memberId} completed: success=${result.success}, exit=${result.exitCode}, duration=${result.durationMs}ms`,
+			`Agent ${ref(agentSlug, memberId)} completed: success=${result.success}, exit=${result.exitCode}, duration=${result.durationMs}ms`,
 		);
 
 		await db.query(
@@ -1128,7 +1140,14 @@ export class JobManager {
 		}
 
 		if (!result.success && result.heartbeatRunId) {
-			await this.postFailurePing(memberId, agentSlug, taskId, teamId, result.heartbeatRunId);
+			await this.postFailurePing(
+				memberId,
+				agentSlug,
+				taskId,
+				taskIdentifier,
+				teamId,
+				result.heartbeatRunId,
+			);
 		}
 
 		if (
@@ -1138,7 +1157,9 @@ export class JobManager {
 		) {
 			const childrenCheck = await assertChildrenAllClosed(db, teamId, taskId);
 			if (!childrenCheck.ok) {
-				log.warn(`Skipping coach auto-close for task ${taskId}: ${childrenCheck.message}`);
+				log.warn(
+					`Skipping coach auto-close for task ${ref(taskIdentifier, taskId)}: ${childrenCheck.message}`,
+				);
 			} else {
 				const closed = await db.query<Record<string, unknown>>(
 					`UPDATE tasks SET status = $1::task_status, updated_at = now()
@@ -1167,13 +1188,14 @@ export class JobManager {
 			}
 		}
 
-		await this.chainNextTaskWakeup(memberId, taskId, teamId);
+		await this.chainNextTaskWakeup(memberId, agentSlug, taskId, teamId);
 	}
 
 	private async postFailurePing(
 		memberId: string,
 		agentSlug: string,
 		taskId: string,
+		taskIdentifier: string,
 		teamId: string,
 		runId: string,
 	): Promise<void> {
@@ -1203,7 +1225,7 @@ export class JobManager {
 		const streak = recent.rows.every((r) => FAILURE_TERMINAL_STATUSES.includes(r.status));
 		if (recent.rows.length >= MAX_CONSECUTIVE_FAILURE_PINGS && streak) {
 			log.warn(
-				`Suppressing failure ping for agent ${agentSlug} on task ${taskId}: ${MAX_CONSECUTIVE_FAILURE_PINGS} consecutive failed runs`,
+				`Suppressing failure ping for agent ${ref(agentSlug, memberId)} on task ${ref(taskIdentifier, taskId)}: ${MAX_CONSECUTIVE_FAILURE_PINGS} consecutive failed runs`,
 			);
 			return;
 		}
@@ -1254,6 +1276,7 @@ export class JobManager {
 
 	private async chainNextTaskWakeup(
 		memberId: string,
+		agentSlug: string,
 		justCompletedTaskId: string,
 		teamId: string,
 	): Promise<void> {
@@ -1313,7 +1336,7 @@ export class JobManager {
 				reason: 'chain_after_completion',
 			});
 		} catch (e) {
-			log.error(`Failed to chain wakeup for agent ${memberId}:`, e);
+			log.error(`Failed to chain wakeup for agent ${ref(agentSlug, memberId)}:`, e);
 		}
 	}
 

--- a/packages/server/src/services/project-create.ts
+++ b/packages/server/src/services/project-create.ts
@@ -3,6 +3,44 @@ import { TaskPriority, TaskStatus } from '@hezo/shared';
 import { withTransaction } from '../lib/sql';
 import { allocateTaskIdentifier } from '../lib/task-identifier';
 
+/**
+ * Project documents seeded into every new project. These are starting-point
+ * templates the team fills in — project-specific knowledge that does not belong
+ * in the team-wide skills database.
+ */
+const DEFAULT_PROJECT_DOCS: ReadonlyArray<{ slug: string; title: string; content: string }> = [
+	{
+		slug: 'architecture-guidelines.md',
+		title: 'Architecture Guidelines',
+		content: `# Architecture Guidelines
+
+<!-- TODO: customize for your tech stack -->
+
+## Tech Stack
+
+Describe your primary languages, frameworks, and infrastructure.
+
+## Project Structure
+
+Describe your repository layout and key directories.
+
+## Coding Conventions
+
+- Follow the language's standard style guide
+- Write self-documenting code with minimal comments
+- Prefer composition over inheritance
+- Keep functions focused and small
+
+## Architecture Decision Records
+
+Significant technical decisions should be documented with:
+- **Context** — what prompted the decision
+- **Decision** — what was chosen
+- **Consequences** — trade-offs and implications
+`,
+	},
+];
+
 export interface CreateProjectWithPlanningInput {
 	teamId: string;
 	captainMemberId: string;
@@ -62,6 +100,14 @@ export async function createProjectWithPlanningTask(
 				`INSERT INTO documents (project_id, team_id, type, slug, content)
 				 VALUES ($1, $2, 'project_doc', 'initial-prd.md', $3)`,
 				[project.id, input.teamId, initialPrd],
+			);
+		}
+
+		for (const doc of DEFAULT_PROJECT_DOCS) {
+			await db.query(
+				`INSERT INTO documents (project_id, team_id, type, slug, title, content)
+				 VALUES ($1, $2, 'project_doc', $3, $4, $5)`,
+				[project.id, input.teamId, doc.slug, doc.title, doc.content],
 			);
 		}
 

--- a/packages/server/src/services/repo-sync.ts
+++ b/packages/server/src/services/repo-sync.ts
@@ -21,8 +21,6 @@ export interface RepoSyncResult {
 export interface ProjectIdentity {
 	id: string;
 	team_id: string;
-	teamSlug: string;
-	projectSlug: string;
 }
 
 export async function ensureProjectRepos(
@@ -43,7 +41,7 @@ export async function ensureProjectRepos(
 
 	if (repos.rows.length === 0) return result;
 
-	const workspacePath = getWorkspacePath(dataDir, project.teamSlug, project.projectSlug);
+	const workspacePath = getWorkspacePath(dataDir, project.team_id, project.id);
 	mkdirSync(workspacePath, { recursive: true });
 
 	const pending: RepoRow[] = [];
@@ -96,18 +94,18 @@ interface RepoRow {
 
 export function removeRepoFromWorkspace(
 	dataDir: string,
-	teamSlug: string,
-	projectSlug: string,
+	teamId: string,
+	projectId: string,
 	shortName: string,
 ): void {
 	if (!shortName || shortName.includes('/') || shortName === '..' || shortName === '.') return;
-	const workspacePath = getWorkspacePath(dataDir, teamSlug, projectSlug);
+	const workspacePath = getWorkspacePath(dataDir, teamId, projectId);
 	const repoDir = join(workspacePath, shortName);
 	if (existsSync(repoDir)) {
 		rmSync(repoDir, { recursive: true, force: true });
 	}
 
-	const worktreesRoot = getWorktreesPath(dataDir, teamSlug, projectSlug);
+	const worktreesRoot = getWorktreesPath(dataDir, teamId, projectId);
 	if (!existsSync(worktreesRoot)) return;
 
 	for (const entry of readdirSync(worktreesRoot, { withFileTypes: true })) {
@@ -121,8 +119,8 @@ export function removeRepoFromWorkspace(
 
 export function removeTaskWorktrees(
 	dataDir: string,
-	teamSlug: string,
-	projectSlug: string,
+	teamId: string,
+	projectId: string,
 	taskIdentifier: string,
 ): void {
 	if (
@@ -132,7 +130,7 @@ export function removeTaskWorktrees(
 		taskIdentifier === '.'
 	)
 		return;
-	const worktreesRoot = getWorktreesPath(dataDir, teamSlug, projectSlug);
+	const worktreesRoot = getWorktreesPath(dataDir, teamId, projectId);
 	const taskDir = join(worktreesRoot, taskIdentifier);
 	if (existsSync(taskDir)) {
 		rmSync(taskDir, { recursive: true, force: true });

--- a/packages/server/src/services/runtime-home.ts
+++ b/packages/server/src/services/runtime-home.ts
@@ -66,14 +66,14 @@ export function getContainerSubscriptionRoot(
 export function getHostSubscriptionRoot(
 	provider: AiProvider,
 	dataDir: string,
-	teamSlug: string,
-	projectSlug: string,
+	teamId: string,
+	projectId: string,
 	heartbeatRunId: string,
 ): string | null {
 	const layout = SUBSCRIPTION_LAYOUTS[provider];
 	if (!layout) return null;
 	return join(
-		getWorkspacePath(dataDir, teamSlug, projectSlug),
+		getWorkspacePath(dataDir, teamId, projectId),
 		'.hezo',
 		'subscription',
 		layout.dirName,
@@ -91,8 +91,8 @@ export interface SubscriptionMount {
 
 export function buildSubscriptionMount(
 	dataDir: string,
-	teamSlug: string,
-	projectSlug: string,
+	teamId: string,
+	projectId: string,
 	heartbeatRunId: string,
 	provider: AiProvider,
 	credential: AiProviderCredential,
@@ -105,8 +105,8 @@ export function buildSubscriptionMount(
 	const hostDir = getHostSubscriptionRoot(
 		provider,
 		dataDir,
-		teamSlug,
-		projectSlug,
+		teamId,
+		projectId,
 		heartbeatRunId,
 	) as string;
 	const containerDir = getContainerSubscriptionRoot(provider, heartbeatRunId) as string;
@@ -140,8 +140,8 @@ export interface RuntimeHomeMount {
 export function ensureRuntimeHomeDir(
 	provider: AiProvider,
 	dataDir: string,
-	teamSlug: string,
-	projectSlug: string,
+	teamId: string,
+	projectId: string,
 	heartbeatRunId: string,
 	existing: SubscriptionMount | null,
 ): RuntimeHomeMount | null {
@@ -159,8 +159,8 @@ export function ensureRuntimeHomeDir(
 	const hostDir = getHostSubscriptionRoot(
 		provider,
 		dataDir,
-		teamSlug,
-		projectSlug,
+		teamId,
+		projectId,
 		heartbeatRunId,
 	) as string;
 	const containerDir = getContainerSubscriptionRoot(provider, heartbeatRunId) as string;

--- a/packages/server/src/services/ssh-agent/host.ts
+++ b/packages/server/src/services/ssh-agent/host.ts
@@ -19,7 +19,7 @@ export async function withHostAgentSocket<T>(
 	const socketHostPath = getRunSocketPath(dataDir, runId);
 	const allocated = await sshAgentServer.allocateRunSocket(
 		runId,
-		{ teamId, agentId: 'host' },
+		{ teamId, agentId: 'host', label: 'host-git' },
 		socketHostPath,
 	);
 	try {

--- a/packages/server/src/services/ssh-agent/registry.ts
+++ b/packages/server/src/services/ssh-agent/registry.ts
@@ -10,6 +10,8 @@ export interface RunIdentity {
 	runId: string;
 	teamId: string;
 	agentId: string;
+	/** Human-friendly label (agentSlug/taskIdentifier) for run-scoped logs. */
+	label?: string | null;
 }
 
 export interface RegistryEntry {

--- a/packages/server/src/services/ssh-agent/server.ts
+++ b/packages/server/src/services/ssh-agent/server.ts
@@ -6,6 +6,7 @@ import { dirname } from 'node:path';
 import type { PGlite } from '@electric-sql/pglite';
 import { decrypt } from '../../crypto/encryption';
 import type { MasterKeyManager } from '../../crypto/master-key';
+import { ref } from '../../lib/log-ref';
 import { logger } from '../../logger';
 import {
 	type AgentIdentity,
@@ -48,7 +49,7 @@ export class SshAgentServer {
 
 	async allocateRunSocket(
 		runId: string,
-		identity: { teamId: string; agentId: string },
+		identity: { teamId: string; agentId: string; label?: string | null },
 		socketHostPath: string,
 	): Promise<AllocatedSocket> {
 		await mkdir(dirname(socketHostPath), { recursive: true, mode: 0o700 });
@@ -65,12 +66,18 @@ export class SshAgentServer {
 
 		const unixServer = createServer((socket) => {
 			this.handleAuthenticatedConnection(socket, runId).catch((e) => {
-				log.error('ssh-agent connection error', { runId, error: (e as Error).message });
+				log.error('ssh-agent connection error', {
+					run: ref(fullIdentity.label, runId),
+					error: (e as Error).message,
+				});
 				socket.destroy();
 			});
 		});
 		unixServer.on('error', (e) =>
-			log.error('ssh-agent listener error', { runId, error: e.message }),
+			log.error('ssh-agent listener error', {
+				run: ref(fullIdentity.label, runId),
+				error: e.message,
+			}),
 		);
 		await new Promise<void>((resolve, reject) => {
 			unixServer.once('error', reject);
@@ -84,14 +91,17 @@ export class SshAgentServer {
 		const tcpServer = createServer((socket) => {
 			this.handleTcpConnection(socket, runId).catch((e) => {
 				log.error('ssh-agent tcp connection error', {
-					runId,
+					run: ref(fullIdentity.label, runId),
 					error: (e as Error).message,
 				});
 				socket.destroy();
 			});
 		});
 		tcpServer.on('error', (e) =>
-			log.error('ssh-agent tcp listener error', { runId, error: e.message }),
+			log.error('ssh-agent tcp listener error', {
+				run: ref(fullIdentity.label, runId),
+				error: e.message,
+			}),
 		);
 		await new Promise<void>((resolve, reject) => {
 			tcpServer.once('error', reject);
@@ -105,7 +115,7 @@ export class SshAgentServer {
 		const tokenHex = tokenBytes.toString('hex');
 
 		log.debug('ssh-agent socket allocated', {
-			runId,
+			run: ref(fullIdentity.label, runId),
 			socketHostPath,
 			tcpHostPort,
 		});
@@ -129,7 +139,7 @@ export class SshAgentServer {
 			await rm(entry.socketHostPath, { force: true });
 			this.registry.delete(runId);
 		}
-		log.debug('ssh-agent socket released', { runId });
+		log.debug('ssh-agent socket released', { run: ref(entry?.identity.label, runId) });
 	}
 
 	async releaseAll(): Promise<void> {
@@ -180,7 +190,7 @@ export class SshAgentServer {
 			const candidate = all.subarray(0, TCP_TOKEN_BYTES);
 			const remainder = all.subarray(TCP_TOKEN_BYTES);
 			if (candidate.length !== expectedToken.length || !timingSafeEqual(candidate, expectedToken)) {
-				log.warn('ssh-agent tcp auth failed', { runId });
+				log.warn('ssh-agent tcp auth failed', { run: ref(entry.identity.label, runId) });
 				try {
 					socket.write(encodeFailure());
 				} catch {
@@ -226,7 +236,9 @@ export class SshAgentServer {
 						if (response) {
 							socket.write(encodeSignResponse(response));
 						} else {
-							log.warn('ssh-agent sign rejected: unknown key', { runId: identity.runId });
+							log.warn('ssh-agent sign rejected: unknown key', {
+								run: ref(identity.label, identity.runId),
+							});
 							socket.write(encodeFailure());
 						}
 						break;
@@ -236,7 +248,7 @@ export class SshAgentServer {
 				}
 			} catch (e) {
 				log.error('ssh-agent handler error', {
-					runId: identity.runId,
+					run: ref(identity.label, identity.runId),
 					error: (e as Error).message,
 				});
 				socket.write(encodeFailure());

--- a/packages/server/src/services/workspace.ts
+++ b/packages/server/src/services/workspace.ts
@@ -21,15 +21,11 @@ export function forceRmRecursive(path: string): void {
 	rmSync(path, { recursive: true, force: true });
 }
 
-export function ensureProjectWorkspace(
-	dataDir: string,
-	teamSlug: string,
-	projectSlug: string,
-): string {
-	if (!dataDir || !teamSlug || !projectSlug) {
-		throw new Error('dataDir, teamSlug, and projectSlug are required');
+export function ensureProjectWorkspace(dataDir: string, teamId: string, projectId: string): string {
+	if (!dataDir || !teamId || !projectId) {
+		throw new Error('dataDir, teamId, and projectId are required');
 	}
-	const projectDir = getProjectDir(dataDir, teamSlug, projectSlug);
+	const projectDir = getProjectDir(dataDir, teamId, projectId);
 	for (const sub of ['workspace', 'worktrees', '.previews', 'assets']) {
 		mkdirSync(join(projectDir, sub), { recursive: true });
 	}
@@ -46,62 +42,61 @@ export function getRunSocketPath(dataDir: string, runId: string): string {
 	return join(getRunSocketDir(dataDir), `${id}.sock`);
 }
 
-export function removeProjectWorkspace(
-	dataDir: string,
-	teamSlug: string,
-	projectSlug: string,
-): void {
-	if (!dataDir || !teamSlug || !projectSlug) return;
-	const projectDir = getProjectDir(dataDir, teamSlug, projectSlug);
+export function removeProjectWorkspace(dataDir: string, teamId: string, projectId: string): void {
+	if (!dataDir || !teamId || !projectId) return;
+	const projectDir = getProjectDir(dataDir, teamId, projectId);
 	forceRmRecursive(projectDir);
 }
 
-export function getProjectDir(dataDir: string, teamSlug: string, projectSlug: string): string {
-	return join(dataDir, 'teams', teamSlug, 'projects', projectSlug);
+// Project infrastructure (workspace, worktrees, previews, assets) is keyed on the
+// immutable team and project ids — never their slugs — so renaming a team or
+// project never changes where files live or which directory a container mounts.
+export function getProjectDir(dataDir: string, teamId: string, projectId: string): string {
+	return join(dataDir, 'teams', teamId, 'projects', projectId);
 }
 
-export function getWorkspacePath(dataDir: string, teamSlug: string, projectSlug: string): string {
-	return join(getProjectDir(dataDir, teamSlug, projectSlug), 'workspace');
+export function getWorkspacePath(dataDir: string, teamId: string, projectId: string): string {
+	return join(getProjectDir(dataDir, teamId, projectId), 'workspace');
 }
 
-export function getAssetsPath(dataDir: string, teamSlug: string, projectSlug: string): string {
-	return join(getProjectDir(dataDir, teamSlug, projectSlug), 'assets');
+export function getAssetsPath(dataDir: string, teamId: string, projectId: string): string {
+	return join(getProjectDir(dataDir, teamId, projectId), 'assets');
 }
 
 export function getAssetPath(
 	dataDir: string,
-	teamSlug: string,
-	projectSlug: string,
+	teamId: string,
+	projectId: string,
 	assetId: string,
 ): string {
-	return join(getAssetsPath(dataDir, teamSlug, projectSlug), assetId);
+	return join(getAssetsPath(dataDir, teamId, projectId), assetId);
 }
 
-export function getWorktreesPath(dataDir: string, teamSlug: string, projectSlug: string): string {
-	return join(getProjectDir(dataDir, teamSlug, projectSlug), 'worktrees');
+export function getWorktreesPath(dataDir: string, teamId: string, projectId: string): string {
+	return join(getProjectDir(dataDir, teamId, projectId), 'worktrees');
 }
 
 export function getWorktreePath(
 	dataDir: string,
-	teamSlug: string,
-	projectSlug: string,
+	teamId: string,
+	projectId: string,
 	repoShortName: string,
 	branchSlug: string,
 	agentIdShort: string,
 ): string {
 	return join(
-		getWorktreesPath(dataDir, teamSlug, projectSlug),
+		getWorktreesPath(dataDir, teamId, projectId),
 		`${repoShortName}-${branchSlug}-agent-${agentIdShort}`,
 	);
 }
 
 export function getPreviewsPath(
 	dataDir: string,
-	teamSlug: string,
-	projectSlug: string,
+	teamId: string,
+	projectId: string,
 	agentId: string,
 ): string {
-	return join(getProjectDir(dataDir, teamSlug, projectSlug), '.previews', agentId);
+	return join(getProjectDir(dataDir, teamId, projectId), '.previews', agentId);
 }
 
 export function clearAllProjectWorkspaces(dataDir: string): string[] {
@@ -110,12 +105,12 @@ export function clearAllProjectWorkspaces(dataDir: string): string[] {
 	if (!existsSync(teamsRoot)) return [];
 
 	const cleared: string[] = [];
-	for (const teamSlug of safeReaddir(teamsRoot)) {
-		const projectsRoot = join(teamsRoot, teamSlug, 'projects');
+	for (const teamDir of safeReaddir(teamsRoot)) {
+		const projectsRoot = join(teamsRoot, teamDir, 'projects');
 		if (!isDirectory(projectsRoot)) continue;
 
-		for (const projectSlug of safeReaddir(projectsRoot)) {
-			const workspaceDir = join(projectsRoot, projectSlug, 'workspace');
+		for (const projectDir of safeReaddir(projectsRoot)) {
+			const workspaceDir = join(projectsRoot, projectDir, 'workspace');
 			if (!isDirectory(workspaceDir)) continue;
 			forceRmRecursive(workspaceDir);
 			mkdirSync(workspaceDir, { recursive: true });

--- a/packages/server/test/agent-runner.test.ts
+++ b/packages/server/test/agent-runner.test.ts
@@ -29,7 +29,7 @@ import { authHeader, createTestApp, createTestProject } from './helpers/app';
 function readPromptFromExec(
 	opts: { Env: string[] },
 	dataDir: string,
-	project: { team_slug: string; slug: string },
+	project: { team_id: string; id: string },
 ): string {
 	const entry = opts.Env.find((e) => e.startsWith('HEZO_PROMPT_FILE='));
 	if (!entry) throw new Error('HEZO_PROMPT_FILE env var missing from exec');
@@ -38,7 +38,7 @@ function readPromptFromExec(
 		.split('/')
 		.pop()!
 		.replace(/\.txt$/, '');
-	return readFileSync(getHostPromptPath(dataDir, project.team_slug, project.slug, runId), 'utf8');
+	return readFileSync(getHostPromptPath(dataDir, project.team_id, project.id, runId), 'utf8');
 }
 
 let app: Hono<Env>;
@@ -881,8 +881,8 @@ describe('runAgent', () => {
 						stagedTomlPath = `${getHostSubscriptionRoot(
 							AiProvider.OpenAI,
 							'/tmp/test-data',
-							'runner-co',
-							'runner-project',
+							teamId,
+							projectId,
 							runId,
 						)}/config.toml`;
 						stagedTomlContents = readFileSync(stagedTomlPath, 'utf8');
@@ -966,8 +966,8 @@ describe('runAgent', () => {
 						const hostDir = getHostSubscriptionRoot(
 							AiProvider.OpenAI,
 							'/tmp/test-data',
-							'runner-co',
-							'runner-project',
+							teamId,
+							projectId,
 							runId,
 						);
 						observedAuthFile = `${hostDir}/auth.json`;
@@ -1054,8 +1054,8 @@ describe('runAgent', () => {
 						settingsPath = `${getHostSubscriptionRoot(
 							AiProvider.Google,
 							'/tmp/test-data',
-							'runner-co',
-							'runner-project',
+							teamId,
+							projectId,
 							runId,
 						)}/.gemini/settings.json`;
 						settingsContents = readFileSync(settingsPath, 'utf8');
@@ -1831,8 +1831,8 @@ describe('runAgent', () => {
 						stagedFile = `${getHostSubscriptionRoot(
 							AiProvider.OpenAI,
 							'/tmp/test-data',
-							'runner-co',
-							'runner-project',
+							teamId,
+							projectId,
 							runId,
 						)}/auth.json`;
 					}
@@ -1887,8 +1887,8 @@ describe('runAgent', () => {
 					const hostFile = `${getHostSubscriptionRoot(
 						AiProvider.OpenAI,
 						'/tmp/test-data',
-						'runner-co',
-						'runner-project',
+						teamId,
+						projectId,
 						runId,
 					)}/auth.json`;
 					// Simulate codex rotating the refresh token mid-run.

--- a/packages/server/test/comment-attachments.test.ts
+++ b/packages/server/test/comment-attachments.test.ts
@@ -16,9 +16,7 @@ let token: string;
 let masterKeyManager: MasterKeyManager;
 let dataDir: string;
 let teamId: string;
-let teamSlug: string;
 let projectId: string;
-let projectSlug: string;
 let taskId: string;
 let otherProjectId: string;
 let otherTaskId: string;
@@ -65,7 +63,6 @@ beforeAll(async () => {
 	});
 	const teamData = (await teamRes.json()).data;
 	teamId = teamData.id;
-	teamSlug = teamData.slug;
 
 	const projectRes = await createTestProject(db, teamId, {
 		name: 'Main',
@@ -73,7 +70,6 @@ beforeAll(async () => {
 	});
 	const projectData = (await projectRes.json()).data;
 	projectId = projectData.id;
-	projectSlug = projectData.slug;
 
 	const agentRes = await app.request(`/api/teams/${teamId}/agents`, {
 		method: 'POST',
@@ -143,15 +139,7 @@ describe('asset upload', () => {
 		expect(body.data.byte_size).toBe(bytes.byteLength);
 		expect(body.data.url).toMatch(/^\/api\/assets\/[0-9a-f-]+\?exp=\d+&sig=/);
 
-		const onDisk = join(
-			dataDir,
-			'teams',
-			teamSlug,
-			'projects',
-			projectSlug,
-			'assets',
-			body.data.id,
-		);
+		const onDisk = join(dataDir, 'teams', teamId, 'projects', projectId, 'assets', body.data.id);
 		expect(existsSync(onDisk)).toBe(true);
 		const written = readFileSync(onDisk);
 		expect(createHash('sha256').update(written).digest('hex')).toBe(expectedSha);

--- a/packages/server/test/container-sync.test.ts
+++ b/packages/server/test/container-sync.test.ts
@@ -355,8 +355,63 @@ describe('provisionContainer broadcasting', () => {
 		const assetsBind = binds.find((b) => b.endsWith(':/workspace/.hezo/assets:ro'));
 		expect(assetsBind).toBeDefined();
 		expect(assetsBind).toContain(
-			`${dataDir}/teams/container-sync-co/projects/${project.slug}/assets`,
+			`${dataDir}/teams/${project.team_id}/projects/${project.id}/assets`,
 		);
+	});
+
+	it('keeps container name and bind mounts stable when the project is renamed', async () => {
+		const dataDir = mkdtempSync(join(tmpdir(), 'hezo-test-'));
+		const makeMockDocker = () =>
+			createStubDocker({
+				imageExists: vi.fn().mockResolvedValue(false),
+				pullImage: vi.fn().mockResolvedValue(undefined),
+				createContainer: vi.fn().mockResolvedValue({ Id: 'renamed-container' }),
+				startContainer: vi.fn().mockResolvedValue(undefined),
+			});
+
+		const createRes = await createTestProject(db, teamId, {
+			name: 'Rename Target',
+			description: 'Rename invariance test.',
+		});
+		const renameProjectId = (await createRes.json()).data.id;
+		await db.query(
+			"UPDATE projects SET container_id = NULL, container_status = NULL, docker_base_image = 'test-unregistered:latest' WHERE id = $1",
+			[renameProjectId],
+		);
+
+		const before = (
+			await db.query<ProjectRow>('SELECT * FROM projects WHERE id = $1', [renameProjectId])
+		).rows[0];
+
+		const dockerBefore = makeMockDocker();
+		await provisionContainer({ db, docker: dockerBefore, dataDir }, before, 'container-sync-co');
+		const nameBefore = dockerBefore.createContainer.mock.calls[0][0];
+		const bindsBefore = dockerBefore.createContainer.mock.calls[0][1].HostConfig.Binds as string[];
+
+		// Rename the project — exactly what the PATCH handler does (new name + new slug).
+		await db.query(
+			'UPDATE projects SET name = $1, slug = $2, container_id = NULL, container_status = NULL WHERE id = $3',
+			['Renamed Project', 'renamed-project-slug', renameProjectId],
+		);
+
+		const after = (
+			await db.query<ProjectRow>('SELECT * FROM projects WHERE id = $1', [renameProjectId])
+		).rows[0];
+		expect(after.slug).toBe('renamed-project-slug');
+		expect(after.slug).not.toBe(before.slug);
+
+		const dockerAfter = makeMockDocker();
+		await provisionContainer({ db, docker: dockerAfter, dataDir }, after, 'container-sync-co');
+		const nameAfter = dockerAfter.createContainer.mock.calls[0][0];
+		const bindsAfter = dockerAfter.createContainer.mock.calls[0][1].HostConfig.Binds as string[];
+
+		// Identity and mounts are keyed on the immutable id, so the rename changes nothing.
+		expect(nameAfter).toBe(nameBefore);
+		expect(nameAfter).toBe(`hezo-${renameProjectId}`);
+		expect(bindsAfter).toEqual(bindsBefore);
+		expect(bindsAfter.join('\n')).toContain(`/projects/${renameProjectId}/`);
+		expect(bindsAfter.join('\n')).not.toContain(before.slug);
+		expect(bindsAfter.join('\n')).not.toContain('renamed-project-slug');
 	});
 
 	it('bind-mounts the egress CA when egressCAPath is provided', async () => {

--- a/packages/server/test/job-manager-workflows.test.ts
+++ b/packages/server/test/job-manager-workflows.test.ts
@@ -19,6 +19,7 @@ let masterKeyManager: MasterKeyManager;
 let teamId: string;
 let projectId: string;
 let taskId: string;
+let taskIdentifier: string;
 let agentId: string;
 
 function createMockDocker(): DockerClient {
@@ -94,7 +95,9 @@ beforeAll(async () => {
 			assignee_id: agentId,
 		}),
 	});
-	taskId = (await taskRes.json()).data.id;
+	const createdTask = (await taskRes.json()).data;
+	taskId = createdTask.id;
+	taskIdentifier = createdTask.identifier;
 
 	// These tests focus on wakeup/lock lifecycle, not the designated-repo gate.
 	// Seed a designated repo on the project so the gate short-circuit is bypassed.
@@ -638,6 +641,7 @@ describe('JobManager workflow methods', () => {
 				agentId,
 				'test-agent',
 				taskId,
+				taskIdentifier,
 				teamId,
 				wakeupId,
 				undefined,
@@ -691,6 +695,7 @@ describe('JobManager workflow methods', () => {
 				agentId,
 				'test-agent',
 				taskId,
+				taskIdentifier,
 				teamId,
 				wakeupId,
 				undefined,
@@ -730,6 +735,7 @@ describe('JobManager workflow methods', () => {
 				agentId,
 				'test-agent',
 				taskId,
+				taskIdentifier,
 				teamId,
 				undefined,
 				undefined,
@@ -801,6 +807,7 @@ describe('JobManager workflow methods', () => {
 					agentId,
 					'researcher',
 					taskId,
+					taskIdentifier,
 					teamId,
 					undefined,
 					undefined,
@@ -849,6 +856,7 @@ describe('JobManager workflow methods', () => {
 					agentId,
 					'researcher',
 					taskId,
+					taskIdentifier,
 					teamId,
 					undefined,
 					undefined,
@@ -881,6 +889,7 @@ describe('JobManager workflow methods', () => {
 					agentId,
 					'researcher',
 					taskId,
+					taskIdentifier,
 					teamId,
 					undefined,
 					undefined,
@@ -919,6 +928,7 @@ describe('JobManager workflow methods', () => {
 					agentId,
 					'researcher',
 					taskId,
+					taskIdentifier,
 					teamId,
 					undefined,
 					undefined,
@@ -948,6 +958,7 @@ describe('JobManager workflow methods', () => {
 					agentId,
 					'researcher',
 					taskId,
+					taskIdentifier,
 					teamId,
 					undefined,
 					undefined,
@@ -982,6 +993,7 @@ describe('JobManager workflow methods', () => {
 					agentId,
 					'researcher',
 					taskId,
+					taskIdentifier,
 					teamId,
 					undefined,
 					undefined,
@@ -1039,6 +1051,7 @@ describe('JobManager workflow methods', () => {
 				agentId,
 				'test-agent',
 				taskId,
+				taskIdentifier,
 				teamId,
 				undefined,
 				undefined,
@@ -1082,6 +1095,7 @@ describe('JobManager workflow methods', () => {
 				agentId,
 				'test-agent',
 				taskId,
+				taskIdentifier,
 				teamId,
 				undefined,
 				undefined,
@@ -1147,6 +1161,7 @@ describe('JobManager workflow methods', () => {
 				agentId,
 				'test-agent',
 				taskId,
+				taskIdentifier,
 				teamId,
 				undefined,
 				undefined,
@@ -1208,6 +1223,7 @@ describe('JobManager workflow methods', () => {
 				agentId,
 				'test-agent',
 				taskId,
+				taskIdentifier,
 				teamId,
 				undefined,
 				undefined,
@@ -1251,6 +1267,7 @@ describe('JobManager workflow methods', () => {
 				agentId,
 				'coach',
 				taskId,
+				taskIdentifier,
 				teamId,
 				undefined,
 				{ trigger: 'task_done', task_id: taskId },
@@ -1269,6 +1286,7 @@ describe('JobManager workflow methods', () => {
 				agentId,
 				'coach',
 				taskId,
+				taskIdentifier,
 				teamId,
 				undefined,
 				{ trigger: 'task_done', task_id: taskId },
@@ -1287,6 +1305,7 @@ describe('JobManager workflow methods', () => {
 				agentId,
 				'engineer',
 				taskId,
+				taskIdentifier,
 				teamId,
 				undefined,
 				{ trigger: 'task_done', task_id: taskId },
@@ -1308,6 +1327,7 @@ describe('JobManager workflow methods', () => {
 				agentId,
 				'coach',
 				taskId,
+				taskIdentifier,
 				teamId,
 				undefined,
 				{ trigger: 'task_done', task_id: taskId },
@@ -1326,6 +1346,7 @@ describe('JobManager workflow methods', () => {
 				agentId,
 				'coach',
 				taskId,
+				taskIdentifier,
 				teamId,
 				undefined,
 				{ trigger: 'mention', task_id: taskId },
@@ -1353,6 +1374,7 @@ describe('JobManager workflow methods', () => {
 				agentId,
 				'coach',
 				taskId,
+				taskIdentifier,
 				teamId,
 				undefined,
 				{ trigger: 'task_done', task_id: taskId },

--- a/packages/server/test/log-ref.test.ts
+++ b/packages/server/test/log-ref.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { ref } from '../src/lib/log-ref';
+
+describe('ref', () => {
+	const id = '3d8317ca-fd4b-4140-a42d-1fa97d187e34';
+
+	it('formats a friendly label alongside the uuid', () => {
+		expect(ref('OP-42', id)).toBe(`OP-42 (${id})`);
+		expect(ref('captain/OP-42', id)).toBe(`captain/OP-42 (${id})`);
+	});
+
+	it('falls back to the bare uuid when no label is available', () => {
+		expect(ref(undefined, id)).toBe(id);
+		expect(ref(null, id)).toBe(id);
+		expect(ref('', id)).toBe(id);
+	});
+});

--- a/packages/server/test/preview.test.ts
+++ b/packages/server/test/preview.test.ts
@@ -43,7 +43,6 @@ beforeAll(async () => {
 	});
 	const team = (await teamRes.json()).data;
 	teamId = team.id;
-	const teamSlug = team.slug;
 
 	const projectRes = await createTestProject(db, teamId, {
 		name: 'Preview Project',
@@ -51,10 +50,9 @@ beforeAll(async () => {
 	});
 	const project = (await projectRes.json()).data;
 	projectId = project.id;
-	const projectSlug = project.slug;
 
 	// Create workspace directory with test files matching getWorkspacePath layout
-	const workspacePath = join(dataDir, 'teams', teamSlug, 'projects', projectSlug, 'workspace');
+	const workspacePath = join(dataDir, 'teams', teamId, 'projects', projectId, 'workspace');
 	mkdirSync(workspacePath, { recursive: true });
 	writeFileSync(join(workspacePath, 'index.html'), '<html><body>Hello</body></html>');
 	writeFileSync(join(workspacePath, 'style.css'), 'body { color: red; }');

--- a/packages/server/test/project-docs.test.ts
+++ b/packages/server/test/project-docs.test.ts
@@ -56,13 +56,13 @@ afterAll(async () => {
 });
 
 describe('Project docs (DB-backed)', () => {
-	it('lists docs (empty initially)', async () => {
+	it('lists the default doc seeded at creation', async () => {
 		const res = await app.request(`/api/teams/${teamId}/projects/${projectId}/docs`, {
 			headers: authHeader(token),
 		});
 		expect(res.status).toBe(200);
 		const body = await res.json();
-		expect(body.data).toEqual([]);
+		expect(body.data.map((d: any) => d.filename)).toEqual(['architecture-guidelines.md']);
 	});
 
 	it('creates a doc via PUT', async () => {

--- a/packages/server/test/projects.test.ts
+++ b/packages/server/test/projects.test.ts
@@ -261,6 +261,43 @@ describe('initial PRD upload', () => {
 	});
 });
 
+describe('default project docs', () => {
+	it('seeds architecture-guidelines.md for every new project', async () => {
+		const res = await createTestProject(db, teamId, {
+			name: 'Defaults Project',
+			description: VALID_DESCRIPTION,
+		});
+		expect(res.status).toBe(201);
+		const project = (await res.json()).data;
+
+		const docResult = await db.query<{ title: string; content: string }>(
+			"SELECT title, content FROM documents WHERE type = 'project_doc' AND project_id = $1 AND slug = $2",
+			[project.id, 'architecture-guidelines.md'],
+		);
+		expect(docResult.rows.length).toBe(1);
+		expect(docResult.rows[0].title).toBe('Architecture Guidelines');
+		expect(docResult.rows[0].content.length).toBeGreaterThan(0);
+	});
+
+	it('seeds the architecture-guidelines.md default alongside an initial PRD', async () => {
+		const res = await createTestProject(db, teamId, {
+			name: 'Defaults With PRD Project',
+			description: VALID_DESCRIPTION,
+			initial_prd: '# PRD\n\nSome requirements.',
+		});
+		expect(res.status).toBe(201);
+		const project = (await res.json()).data;
+
+		const docResult = await db.query<{ slug: string }>(
+			"SELECT slug FROM documents WHERE type = 'project_doc' AND project_id = $1 ORDER BY slug",
+			[project.id],
+		);
+		const slugs = docResult.rows.map((d) => d.slug);
+		expect(slugs).toContain('architecture-guidelines.md');
+		expect(slugs).toContain('initial-prd.md');
+	});
+});
+
 describe('slug-based project access', () => {
 	it('gets a project by slug', async () => {
 		const listRes = await app.request(`/api/teams/${teamId}/projects`, {

--- a/packages/server/test/repo-sync.test.ts
+++ b/packages/server/test/repo-sync.test.ts
@@ -18,9 +18,7 @@ let db: PGlite;
 let token: string;
 let masterKeyManager: MasterKeyManager;
 let teamId: string;
-let teamSlug: string;
 let projectId: string;
-let projectSlug: string;
 let dataDir: string;
 
 beforeAll(async () => {
@@ -38,7 +36,6 @@ beforeAll(async () => {
 	});
 	const team = (await teamRes.json()).data;
 	teamId = team.id;
-	teamSlug = team.slug;
 
 	const projectRes = await createTestProject(db, teamId, {
 		name: 'Main',
@@ -46,7 +43,6 @@ beforeAll(async () => {
 	});
 	const project = (await projectRes.json()).data;
 	projectId = project.id;
-	projectSlug = project.slug;
 });
 
 afterAll(async () => {
@@ -58,7 +54,7 @@ describe('ensureProjectRepos', () => {
 		const result = await ensureProjectRepos(
 			db,
 			masterKeyManager,
-			{ id: projectId, team_id: teamId, teamSlug, projectSlug },
+			{ id: projectId, team_id: teamId },
 			dataDir,
 			null,
 		);
@@ -75,7 +71,7 @@ describe('ensureProjectRepos', () => {
 			[projectId],
 		);
 
-		const workspacePath = join(dataDir, 'teams', teamSlug, 'projects', projectSlug, 'workspace');
+		const workspacePath = join(dataDir, 'teams', teamId, 'projects', projectId, 'workspace');
 		const targetDir = join(workspacePath, 'preexisting');
 		mkdirSync(join(targetDir, '.git'), { recursive: true });
 		writeFileSync(join(targetDir, '.git', 'HEAD'), 'ref: refs/heads/main\n');
@@ -84,7 +80,7 @@ describe('ensureProjectRepos', () => {
 		const result = await ensureProjectRepos(
 			db,
 			masterKeyManager,
-			{ id: projectId, team_id: teamId, teamSlug, projectSlug },
+			{ id: projectId, team_id: teamId },
 			dataDir,
 			null,
 			(stream, text) => logs.push({ stream, text }),
@@ -96,8 +92,8 @@ describe('ensureProjectRepos', () => {
 
 describe('removeRepoFromWorkspace', () => {
 	it('removes the repo subdirectory and its per-task worktrees', async () => {
-		const workspacePath = join(dataDir, 'teams', teamSlug, 'projects', projectSlug, 'workspace');
-		const worktreesPath = join(dataDir, 'teams', teamSlug, 'projects', projectSlug, 'worktrees');
+		const workspacePath = join(dataDir, 'teams', teamId, 'projects', projectId, 'workspace');
+		const worktreesPath = join(dataDir, 'teams', teamId, 'projects', projectId, 'worktrees');
 
 		const repoDir = join(workspacePath, 'to-remove');
 		mkdirSync(join(repoDir, '.git'), { recursive: true });
@@ -107,7 +103,7 @@ describe('removeRepoFromWorkspace', () => {
 		mkdirSync(wtDir1, { recursive: true });
 		mkdirSync(wtDir2, { recursive: true });
 
-		removeRepoFromWorkspace(dataDir, teamSlug, projectSlug, 'to-remove');
+		removeRepoFromWorkspace(dataDir, teamId, projectId, 'to-remove');
 
 		expect(existsSync(repoDir)).toBe(false);
 		expect(existsSync(wtDir1)).toBe(false);
@@ -115,13 +111,13 @@ describe('removeRepoFromWorkspace', () => {
 	});
 
 	it('is a no-op for dangerous short_name values', () => {
-		const workspacePath = join(dataDir, 'teams', teamSlug, 'projects', projectSlug, 'workspace');
+		const workspacePath = join(dataDir, 'teams', teamId, 'projects', projectId, 'workspace');
 		const stayDir = join(workspacePath, 'stay');
 		mkdirSync(stayDir, { recursive: true });
 
-		removeRepoFromWorkspace(dataDir, teamSlug, projectSlug, '..');
-		removeRepoFromWorkspace(dataDir, teamSlug, projectSlug, 'has/slash');
-		removeRepoFromWorkspace(dataDir, teamSlug, projectSlug, '');
+		removeRepoFromWorkspace(dataDir, teamId, projectId, '..');
+		removeRepoFromWorkspace(dataDir, teamId, projectId, 'has/slash');
+		removeRepoFromWorkspace(dataDir, teamId, projectId, '');
 
 		expect(existsSync(stayDir)).toBe(true);
 	});
@@ -129,23 +125,23 @@ describe('removeRepoFromWorkspace', () => {
 
 describe('removeTaskWorktrees', () => {
 	it('removes the task directory under worktrees', () => {
-		const worktreesPath = join(dataDir, 'teams', teamSlug, 'projects', projectSlug, 'worktrees');
+		const worktreesPath = join(dataDir, 'teams', teamId, 'projects', projectId, 'worktrees');
 		const taskDir = join(worktreesPath, 'RS-9');
 		mkdirSync(join(taskDir, 'main'), { recursive: true });
 		mkdirSync(join(taskDir, 'secondary'), { recursive: true });
 
-		removeTaskWorktrees(dataDir, teamSlug, projectSlug, 'RS-9');
+		removeTaskWorktrees(dataDir, teamId, projectId, 'RS-9');
 
 		expect(existsSync(taskDir)).toBe(false);
 	});
 
 	it('is a no-op for dangerous identifier values', () => {
-		const worktreesPath = join(dataDir, 'teams', teamSlug, 'projects', projectSlug, 'worktrees');
+		const worktreesPath = join(dataDir, 'teams', teamId, 'projects', projectId, 'worktrees');
 		const stayDir = join(worktreesPath, 'RS-10');
 		mkdirSync(stayDir, { recursive: true });
 
-		removeTaskWorktrees(dataDir, teamSlug, projectSlug, '..');
-		removeTaskWorktrees(dataDir, teamSlug, projectSlug, '');
+		removeTaskWorktrees(dataDir, teamId, projectId, '..');
+		removeTaskWorktrees(dataDir, teamId, projectId, '');
 
 		expect(existsSync(stayDir)).toBe(true);
 	});

--- a/packages/server/test/teams.test.ts
+++ b/packages/server/test/teams.test.ts
@@ -55,14 +55,9 @@ describe('teams CRUD', () => {
 			headers: authHeader(token),
 		});
 		const skillsBody = await skillsRes.json();
-		expect(skillsBody.data.length).toBe(4);
+		expect(skillsBody.data.length).toBe(2);
 		const slugs = skillsBody.data.map((d: any) => d.slug).sort();
-		expect(slugs).toEqual([
-			'architecture-guidelines.md',
-			'code-review-standards.md',
-			'development-workflow.md',
-			'team-overview.md',
-		]);
+		expect(slugs).toEqual(['code-review-standards.md', 'development-workflow.md']);
 	});
 
 	it('creates a team without a type and includes built-in agents', async () => {

--- a/packages/server/test/template-resolver.test.ts
+++ b/packages/server/test/template-resolver.test.ts
@@ -85,10 +85,16 @@ describe('template resolver', () => {
 		expect(result).toContain('No preferences set');
 	});
 
-	it('resolves {{project_docs_context}} without designated repo', async () => {
+	it('resolves {{project_docs_context}} to empty-state when the project has no docs', async () => {
+		const bare = await db.query<{ id: string }>(
+			`INSERT INTO projects (team_id, name, slug, task_prefix, description, docker_base_image)
+			 VALUES ($1, 'Docless', 'docless', 'DL', 'No docs here', 'hezo/agent-base:latest')
+			 RETURNING id`,
+			[teamId],
+		);
 		const result = await resolveSystemPrompt(db, 'Docs: {{project_docs_context}}', {
 			teamId,
-			projectId,
+			projectId: bare.rows[0].id,
 		});
 		expect(result).toContain('No project documentation available');
 	});


### PR DESCRIPTION
Renaming a project (or team) regenerated its slug, but the workspace directory and Docker container were keyed on that mutable slug. The existing container kept bind-mounting the old slug's workspace while agent runs wrote per-run files (settings.json, prompt) to the new slug's directory — which the container does not mount — so every run after a rename failed with "Settings file not found".

Key all filesystem layout and container identity on the immutable team and project ids instead of slugs:
- workspace path helpers take (dataDir, teamId, projectId); layout is teams/{teamId}/projects/{projectId}/...
- container name is hezo-${project.id}; slugs become Docker labels for docker ps readability only
- runtime-home, agent-runner, repo-sync, asset-storage and the assets/ preview/projects/repos/tasks routes pass ids through

Renames now touch only the name/slug columns; the container and workspace are untouched and keep working. Also fixes the identical latent bug for team renames.