### PR TITLE
refactor(skills): split default skills into team skills and per-proje…

### DIFF
--- a/packages/server/src/db/seed.ts
+++ b/packages/server/src/db/seed.ts
@@ -222,29 +222,6 @@ export async function seedBuiltins(db: PGlite, roleDocs: Record<string, string>)
 
 	const skillsConfig = [
 		{
-			name: 'Team Overview',
-			slug: 'team-overview.md',
-			content: `# Team Overview
-
-<!-- TODO: customize this document for your team -->
-
-## Mission
-
-Describe your team's mission and what problem you're solving.
-
-## Product
-
-Describe your product, its target users, and key value propositions.
-
-## Decision Making
-
-- Strategic decisions escalate to the board
-- Technical architecture decisions go through the Architect
-- Product scope decisions go through the Product Lead
-- Day-to-day implementation decisions are made by the assigned agent
-`,
-		},
-		{
 			name: 'Development Workflow',
 			slug: 'development-workflow.md',
 			content: `# Development Workflow
@@ -273,36 +250,6 @@ Approval is conveyed via comment, not status. From **Review**, the ticket either
 - Every change requires a PR with a clear description
 - PRs must pass CI checks before merge
 - QA Engineer performs final review before approval
-`,
-		},
-		{
-			name: 'Architecture Guidelines',
-			slug: 'architecture-guidelines.md',
-			content: `# Architecture Guidelines
-
-<!-- TODO: customize for your tech stack -->
-
-## Tech Stack
-
-Describe your primary languages, frameworks, and infrastructure.
-
-## Project Structure
-
-Describe your repository layout and key directories.
-
-## Coding Conventions
-
-- Follow the language's standard style guide
-- Write self-documenting code with minimal comments
-- Prefer composition over inheritance
-- Keep functions focused and small
-
-## Architecture Decision Records
-
-Significant technical decisions should be documented with:
-- **Context** — what prompted the decision
-- **Decision** — what was chosen
-- **Consequences** — trade-offs and implications
 `,
 		},
 		{

--- a/packages/server/src/services/project-create.ts
+++ b/packages/server/src/services/project-create.ts
@@ -3,6 +3,44 @@ import { TaskPriority, TaskStatus } from '@hezo/shared';
 import { withTransaction } from '../lib/sql';
 import { allocateTaskIdentifier } from '../lib/task-identifier';
 
+/**
+ * Project documents seeded into every new project. These are starting-point
+ * templates the team fills in — project-specific knowledge that does not belong
+ * in the team-wide skills database.
+ */
+const DEFAULT_PROJECT_DOCS: ReadonlyArray<{ slug: string; title: string; content: string }> = [
+	{
+		slug: 'architecture-guidelines.md',
+		title: 'Architecture Guidelines',
+		content: `# Architecture Guidelines
+
+<!-- TODO: customize for your tech stack -->
+
+## Tech Stack
+
+Describe your primary languages, frameworks, and infrastructure.
+
+## Project Structure
+
+Describe your repository layout and key directories.
+
+## Coding Conventions
+
+- Follow the language's standard style guide
+- Write self-documenting code with minimal comments
+- Prefer composition over inheritance
+- Keep functions focused and small
+
+## Architecture Decision Records
+
+Significant technical decisions should be documented with:
+- **Context** — what prompted the decision
+- **Decision** — what was chosen
+- **Consequences** — trade-offs and implications
+`,
+	},
+];
+
 export interface CreateProjectWithPlanningInput {
 	teamId: string;
 	captainMemberId: string;
@@ -62,6 +100,14 @@ export async function createProjectWithPlanningTask(
 				`INSERT INTO documents (project_id, team_id, type, slug, content)
 				 VALUES ($1, $2, 'project_doc', 'initial-prd.md', $3)`,
 				[project.id, input.teamId, initialPrd],
+			);
+		}
+
+		for (const doc of DEFAULT_PROJECT_DOCS) {
+			await db.query(
+				`INSERT INTO documents (project_id, team_id, type, slug, title, content)
+				 VALUES ($1, $2, 'project_doc', $3, $4, $5)`,
+				[project.id, input.teamId, doc.slug, doc.title, doc.content],
 			);
 		}
 

--- a/packages/server/test/projects.test.ts
+++ b/packages/server/test/projects.test.ts
@@ -261,6 +261,43 @@ describe('initial PRD upload', () => {
 	});
 });
 
+describe('default project docs', () => {
+	it('seeds architecture-guidelines.md for every new project', async () => {
+		const res = await createTestProject(db, teamId, {
+			name: 'Defaults Project',
+			description: VALID_DESCRIPTION,
+		});
+		expect(res.status).toBe(201);
+		const project = (await res.json()).data;
+
+		const docResult = await db.query<{ title: string; content: string }>(
+			"SELECT title, content FROM documents WHERE type = 'project_doc' AND project_id = $1 AND slug = $2",
+			[project.id, 'architecture-guidelines.md'],
+		);
+		expect(docResult.rows.length).toBe(1);
+		expect(docResult.rows[0].title).toBe('Architecture Guidelines');
+		expect(docResult.rows[0].content.length).toBeGreaterThan(0);
+	});
+
+	it('seeds the architecture-guidelines.md default alongside an initial PRD', async () => {
+		const res = await createTestProject(db, teamId, {
+			name: 'Defaults With PRD Project',
+			description: VALID_DESCRIPTION,
+			initial_prd: '# PRD\n\nSome requirements.',
+		});
+		expect(res.status).toBe(201);
+		const project = (await res.json()).data;
+
+		const docResult = await db.query<{ slug: string }>(
+			"SELECT slug FROM documents WHERE type = 'project_doc' AND project_id = $1 ORDER BY slug",
+			[project.id],
+		);
+		const slugs = docResult.rows.map((d) => d.slug);
+		expect(slugs).toContain('architecture-guidelines.md');
+		expect(slugs).toContain('initial-prd.md');
+	});
+});
+
 describe('slug-based project access', () => {
 	it('gets a project by slug', async () => {
 		const listRes = await app.request(`/api/teams/${teamId}/projects`, {

--- a/packages/server/test/teams.test.ts
+++ b/packages/server/test/teams.test.ts
@@ -55,14 +55,9 @@ describe('teams CRUD', () => {
 			headers: authHeader(token),
 		});
 		const skillsBody = await skillsRes.json();
-		expect(skillsBody.data.length).toBe(4);
+		expect(skillsBody.data.length).toBe(2);
 		const slugs = skillsBody.data.map((d: any) => d.slug).sort();
-		expect(slugs).toEqual([
-			'architecture-guidelines.md',
-			'code-review-standards.md',
-			'development-workflow.md',
-			'team-overview.md',
-		]);
+		expect(slugs).toEqual(['code-review-standards.md', 'development-workflow.md']);
 	});
 
 	it('creates a team without a type and includes built-in agents', async () => {

--- a/packages/server/test/template-resolver.test.ts
+++ b/packages/server/test/template-resolver.test.ts
@@ -85,10 +85,16 @@ describe('template resolver', () => {
 		expect(result).toContain('No preferences set');
 	});
 
-	it('resolves {{project_docs_context}} without designated repo', async () => {
+	it('resolves {{project_docs_context}} to empty-state when the project has no docs', async () => {
+		const bare = await db.query<{ id: string }>(
+			`INSERT INTO projects (team_id, name, slug, task_prefix, description, docker_base_image)
+			 VALUES ($1, 'Docless', 'docless', 'DL', 'No docs here', 'hezo/agent-base:latest')
+			 RETURNING id`,
+			[teamId],
+		);
 		const result = await resolveSystemPrompt(db, 'Docs: {{project_docs_context}}', {
 			teamId,
-			projectId,
+			projectId: bare.rows[0].id,
 		});
 		expect(result).toContain('No project documentation available');
 	});


### PR DESCRIPTION
…ct docs

The team skills database is for reusable, team-wide know-how, but two of the four seeded defaults were project-specific. Rebalance the defaults:

- Remove the Team Overview skill entirely.
- Move Architecture Guidelines out of the team skills and seed it as a default project document (architecture-guidelines.md) created for every new project, via a DEFAULT_PROJECT_DOCS constant in the project-creation service so all creation paths get it.
- Keep Development Workflow and Code Review Standards as team-level skills.

Update tests for the new default set and point the empty-docs template-resolver test at a bare project so it still exercises the no-docs branch.