### PR TITLE
feat(run-summary): per-item linked rows for docs, skills, tickets

### DIFF
--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -100,10 +100,11 @@ const HEARTBEAT_RUN_COLUMNS = `hr.id, hr.member_id, hr.team_id, hr.wakeup_id, hr
 	-- wall-clock window (started_at .. finished_at). Mirrors created_tasks.
 	COALESCE(
 		(SELECT jsonb_agg(
-			jsonb_build_object('filename', d.slug)
+			jsonb_build_object('filename', d.slug, 'project_slug', p.slug)
 			ORDER BY d.updated_at ASC
 		)
 		FROM documents d
+		JOIN projects p ON p.id = d.project_id
 		WHERE d.type = 'project_doc'
 		  AND d.team_id = hr.team_id
 		  AND d.last_updated_by_member_id = hr.member_id
@@ -115,7 +116,7 @@ const HEARTBEAT_RUN_COLUMNS = `hr.id, hr.member_id, hr.team_id, hr.wakeup_id, hr
 	-- Skills the agent added/updated directly in the skills database this run.
 	COALESCE(
 		(SELECT jsonb_agg(
-			jsonb_build_object('name', s.name, 'slug', s.slug)
+			jsonb_build_object('name', s.name, 'slug', s.slug, 'created', (s.created_at >= hr.started_at))
 			ORDER BY s.updated_at ASC
 		)
 		FROM skills s

--- a/packages/server/test/heartbeat-runs.test.ts
+++ b/packages/server/test/heartbeat-runs.test.ts
@@ -18,6 +18,7 @@ let masterKeyManager: MasterKeyManager;
 let teamId: string;
 let agentId: string;
 let projectId: string;
+let projectSlug: string;
 let taskId: string;
 
 async function mintTestWakeup(memberId: string, cId: string): Promise<string> {
@@ -48,7 +49,9 @@ beforeAll(async () => {
 		name: 'Main',
 		description: 'Test project.',
 	});
-	projectId = (await projectRes.json()).data.id;
+	const projectData = (await projectRes.json()).data;
+	projectId = projectData.id;
+	projectSlug = projectData.slug;
 
 	const agentRes = await app.request(`/api/teams/${teamId}/agents`, {
 		method: 'POST',
@@ -567,15 +570,22 @@ describe('created_tasks tracking', () => {
 		expect(res.status).toBe(200);
 		const body = await res.json();
 
-		const docFilenames = (body.data.created_docs as Array<{ filename: string }>).map(
-			(d) => d.filename,
-		);
-		expect(docFilenames).toContain('spec.md');
+		const createdDocs = body.data.created_docs as Array<{
+			filename: string;
+			project_slug: string;
+		}>;
+		const specDoc = createdDocs.find((d) => d.filename === 'spec.md');
+		expect(specDoc).toBeDefined();
+		expect(specDoc?.project_slug).toBe(projectSlug);
 
-		const skillSlugs = (body.data.created_skills as Array<{ name: string; slug: string }>).map(
-			(s) => s.slug,
-		);
-		expect(skillSlugs).toContain('deploy-flow');
+		const createdSkills = body.data.created_skills as Array<{
+			name: string;
+			slug: string;
+			created: boolean;
+		}>;
+		const deploySkill = createdSkills.find((s) => s.slug === 'deploy-flow');
+		expect(deploySkill).toBeDefined();
+		expect(deploySkill?.created).toBe(true);
 
 		const proposedSlugs = (body.data.proposed_skills as Array<{ name: string; slug: string }>).map(
 			(s) => s.slug,

--- a/packages/web/src/components/comment-renderers/run-comment.tsx
+++ b/packages/web/src/components/comment-renderers/run-comment.tsx
@@ -181,7 +181,6 @@ function RunCommentBody({
 			)}
 			{createdTasks.length > 0 && (
 				<div className="flex flex-col gap-1 pt-1" data-testid="run-comment-created-tasks">
-					<span className="text-xs text-text-subtle">Created tickets</span>
 					{createdTasks.map((task) => (
 						<Link
 							key={task.id}
@@ -193,24 +192,28 @@ function RunCommentBody({
 							}}
 							className="text-xs text-accent-blue-text hover:underline self-start"
 						>
-							{task.identifier} — {task.title}
+							Created ticket {task.identifier} — {task.title}
 						</Link>
 					))}
 				</div>
 			)}
 			{createdDocs.length > 0 && (
 				<div className="flex flex-col gap-1 pt-1" data-testid="run-comment-created-docs">
-					<span className="text-xs text-text-subtle">Updated project docs</span>
 					{createdDocs.map((doc) => (
-						<span key={doc.filename} className="text-xs text-text-muted self-start">
-							{doc.filename}
-						</span>
+						<Link
+							key={doc.filename}
+							to="/teams/$teamId/projects/$projectId/documents"
+							params={{ teamId, projectId: doc.project_slug }}
+							search={{ file: doc.filename }}
+							className="text-xs text-accent-blue-text hover:underline self-start"
+						>
+							Updated {doc.filename}
+						</Link>
 					))}
 				</div>
 			)}
 			{createdSkills.length > 0 && (
 				<div className="flex flex-col gap-1 pt-1" data-testid="run-comment-created-skills">
-					<span className="text-xs text-text-subtle">Updated skills</span>
 					{createdSkills.map((skill) => (
 						<Link
 							key={skill.slug}
@@ -219,18 +222,22 @@ function RunCommentBody({
 							search={{ slug: skill.slug }}
 							className="text-xs text-accent-blue-text hover:underline self-start"
 						>
-							{skill.name}
+							{skill.created ? 'Added' : 'Updated'} skill {skill.name}
 						</Link>
 					))}
 				</div>
 			)}
 			{proposedSkills.length > 0 && (
 				<div className="flex flex-col gap-1 pt-1" data-testid="run-comment-proposed-skills">
-					<span className="text-xs text-text-subtle">Proposed skills (pending approval)</span>
 					{proposedSkills.map((skill) => (
-						<span key={skill.slug} className="text-xs text-text-muted self-start">
-							{skill.name}
-						</span>
+						<Link
+							key={skill.slug}
+							to="/teams/$teamId/inbox"
+							params={{ teamId }}
+							className="text-xs text-accent-blue-text hover:underline self-start"
+						>
+							Proposed skill {skill.name}
+						</Link>
 					))}
 				</div>
 			)}

--- a/packages/web/src/hooks/use-heartbeat-runs.ts
+++ b/packages/web/src/hooks/use-heartbeat-runs.ts
@@ -34,8 +34,8 @@ export interface HeartbeatRun {
 	trigger_comment_project_slug: string | null;
 	run_comment_id: string | null;
 	created_tasks: { id: string; identifier: string; title: string; project_slug: string }[];
-	created_docs: { filename: string }[];
-	created_skills: { name: string; slug: string }[];
+	created_docs: { filename: string; project_slug: string }[];
+	created_skills: { name: string; slug: string; created: boolean }[];
 	proposed_skills: { name: string; slug: string }[];
 }
 

--- a/packages/web/test/run-created-tasks.test.tsx
+++ b/packages/web/test/run-created-tasks.test.tsx
@@ -115,11 +115,10 @@ test('run comment shows created tickets as links to their pages', async () => {
 	const createdSection = await findByTestId('run-comment-created-tasks', undefined, {
 		timeout: 20_000,
 	});
-	expect(createdSection.textContent ?? '').toContain('Created tickets');
 
 	const links = Array.from(createdSection.querySelectorAll('a')) as HTMLAnchorElement[];
-	const linkA = links.find((a) => a.textContent === 'SPAWN-900 — Refactor auth');
-	const linkB = links.find((a) => a.textContent === 'SPAWN-901 — Add tests for X');
+	const linkA = links.find((a) => a.textContent === 'Created ticket SPAWN-900 — Refactor auth');
+	const linkB = links.find((a) => a.textContent === 'Created ticket SPAWN-901 — Add tests for X');
 	expect(linkA).toBeTruthy();
 	expect(linkB).toBeTruthy();
 	expect(linkA?.getAttribute('href')).toBe(
@@ -190,4 +189,91 @@ test('run comment omits created tickets section when list is empty', async () =>
 	// Wait for the heartbeat-run to load before asserting no created-tasks section.
 	await findByTestId('run-comment-summary', undefined, { timeout: 20_000 });
 	expect(queryByTestId('run-comment-created-tasks')).toBeNull();
+});
+
+test('run comment links updated docs, skills, and proposed skills', async () => {
+	const seeded = { teamSlug: '', taskId: '', projectSlug: '' };
+
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const captain = ws.agents.find((a) => a.slug === 'captain') ?? ws.agents[0];
+			const project = await seedProject(ws, { name: 'Docs And Skills Project' });
+			const task = await seedTask(ws, project, {
+				title: 'Outputs Parent',
+				assignee_id: captain.id,
+			});
+
+			seeded.teamSlug = ws.team.slug;
+			seeded.taskId = task.id;
+			seeded.projectSlug = project.slug;
+
+			const runId = '99999999-9999-9999-9999-000000000003';
+			const runComment = {
+				id: 'aaaa0000-0000-0000-0000-000000000003',
+				task_id: task.id,
+				content_type: 'run',
+				content: { run_id: runId, agent_id: captain.id, agent_title: 'Architect' },
+				chosen_option: null,
+				created_at: new Date().toISOString(),
+				author_type: 'agent',
+				author_name: 'Architect',
+				author_member_id: captain.id,
+			};
+
+			const runResponse = {
+				id: runId,
+				member_id: captain.id,
+				team_id: ws.team.id,
+				task_id: task.id,
+				status: 'succeeded',
+				started_at: new Date().toISOString(),
+				finished_at: new Date().toISOString(),
+				exit_code: 0,
+				error: null,
+				input_tokens: 0,
+				output_tokens: 0,
+				cost_cents: 0,
+				log_text: 'done',
+				created_tasks: [],
+				created_docs: [{ filename: 'spec.md', project_slug: project.slug }],
+				created_skills: [
+					{ name: 'Deploy Flow', slug: 'deploy-flow', created: true },
+					{ name: 'Triage', slug: 'triage', created: false },
+				],
+				proposed_skills: [{ name: 'Linear Triage', slug: 'linear-triage' }],
+			};
+
+			buildFetchMock({ runId, runComment, runResponse });
+		},
+	});
+
+	await router.navigate({
+		to: '/teams/$teamId/tasks/$taskId',
+		params: { teamId: seeded.teamSlug, taskId: seeded.taskId },
+	});
+
+	await findByTestId('run-comment', undefined, { timeout: 20_000 });
+
+	const docsSection = await findByTestId('run-comment-created-docs', undefined, {
+		timeout: 20_000,
+	});
+	const docLink = docsSection.querySelector('a') as HTMLAnchorElement | null;
+	expect(docLink?.textContent).toBe('Updated spec.md');
+	expect(docLink?.getAttribute('href')).toBe(
+		`/teams/${seeded.teamSlug}/projects/${seeded.projectSlug}/documents?file=spec.md`,
+	);
+
+	const skillsSection = await findByTestId('run-comment-created-skills');
+	const skillLinks = Array.from(skillsSection.querySelectorAll('a')) as HTMLAnchorElement[];
+	const added = skillLinks.find((a) => a.textContent === 'Added skill Deploy Flow');
+	const updated = skillLinks.find((a) => a.textContent === 'Updated skill Triage');
+	expect(added?.getAttribute('href')).toBe(`/teams/${seeded.teamSlug}/skills?slug=deploy-flow`);
+	expect(updated?.getAttribute('href')).toBe(`/teams/${seeded.teamSlug}/skills?slug=triage`);
+
+	const proposedSection = await findByTestId('run-comment-proposed-skills');
+	const proposedLink = proposedSection.querySelector('a') as HTMLAnchorElement | null;
+	expect(proposedLink?.textContent).toBe('Proposed skill Linear Triage');
+	expect(proposedLink?.getAttribute('href')).toBe(`/teams/${seeded.teamSlug}/inbox`);
 });


### PR DESCRIPTION
Replace the section headers in the agent run summary with self-describing, clickable rows. Docs now link to the project doc page, skills distinguish added vs updated and link to the skills database, proposed skills link to the team inbox, and tickets read as a full sentence.