### PR TITLE
feat(concurrency): cap concurrent agent runs per project

### DIFF
--- a/packages/server/migrations/001_initial_schema.sql
+++ b/packages/server/migrations/001_initial_schema.sql
@@ -294,6 +294,7 @@ CREATE TABLE projects (
     container_error     TEXT,
     container_last_logs TEXT,
     designated_repo_id  UUID,
+    max_concurrent_runs INTEGER NOT NULL DEFAULT 3 CHECK (max_concurrent_runs >= 1),
     dev_ports               JSONB NOT NULL DEFAULT '[]'::jsonb,
     execution_started_at    TIMESTAMPTZ,
     created_at              TIMESTAMPTZ NOT NULL DEFAULT now(),

--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -255,6 +255,7 @@ projectsRoutes.patch('/teams/:teamId/projects/:projectId', async (c) => {
 	const body = await c.req.json<{
 		name?: string;
 		description?: string;
+		max_concurrent_runs?: number;
 	}>();
 
 	const sets: string[] = [];
@@ -279,6 +280,14 @@ projectsRoutes.patch('/teams/:teamId/projects/:projectId', async (c) => {
 	if (body.description !== undefined) {
 		sets.push(`description = $${idx}`);
 		params.push(body.description);
+		idx++;
+	}
+	if (body.max_concurrent_runs !== undefined) {
+		if (!Number.isInteger(body.max_concurrent_runs) || body.max_concurrent_runs < 1) {
+			return err(c, 'INVALID_REQUEST', 'max_concurrent_runs must be an integer ≥ 1', 400);
+		}
+		sets.push(`max_concurrent_runs = $${idx}`);
+		params.push(body.max_concurrent_runs);
 		idx++;
 	}
 

--- a/packages/server/src/routes/queued-wakeups.ts
+++ b/packages/server/src/routes/queued-wakeups.ts
@@ -6,11 +6,7 @@ import { resolveActorMemberId, resolveTaskId } from '../lib/resolve';
 import { err, ok } from '../lib/response';
 import type { Env } from '../lib/types';
 import { logger } from '../logger';
-import {
-	findBusyTaskOnProject,
-	isProjectBusyInDb,
-	isTaskBusyInDb,
-} from '../services/run-concurrency';
+import { isProjectAtCapacityInDb, isTaskBusyInDb } from '../services/run-concurrency';
 import { recordWakeupCancelled, recordWakeupStarted } from '../services/task-events';
 
 const log = logger.child('routes');
@@ -45,9 +41,10 @@ queuedWakeupsRoutes.get('/teams/:teamId/tasks/:taskId/queued-wakeups', async (c)
 		[teamId, WakeupStatus.Queued, taskId],
 	);
 
-	// Live run-now gating. Task/project busy state is shared by every wakeup on
-	// this task, so compute it once; dependency-blocker state is per-wakeup
-	// because shouldDeferWakeupForBlockers only gates certain wakeup sources.
+	// Live run-now gating. Task busy state and project capacity are shared by
+	// every wakeup on this task, so compute them once; dependency-blocker state
+	// is per-wakeup because shouldDeferWakeupForBlockers only gates certain
+	// wakeup sources.
 	const projRow = await db.query<{ project_id: string }>(
 		'SELECT project_id FROM tasks WHERE id = $1',
 		[taskId],
@@ -55,20 +52,11 @@ queuedWakeupsRoutes.get('/teams/:teamId/tasks/:taskId/queued-wakeups', async (c)
 	const projectId = projRow.rows[0]?.project_id ?? null;
 
 	let taskBusy = false;
-	let projectBusy = false;
-	let blockerTaskIdentifier: string | null = null;
+	let projectAtCapacity = false;
 	if (await isTaskBusyInDb(db, taskId)) {
 		taskBusy = true;
-	} else if (projectId && (await isProjectBusyInDb(db, projectId))) {
-		projectBusy = true;
-		const busyTaskId = await findBusyTaskOnProject(db, projectId);
-		if (busyTaskId) {
-			const idRow = await db.query<{ identifier: string }>(
-				'SELECT identifier FROM tasks WHERE id = $1',
-				[busyTaskId],
-			);
-			blockerTaskIdentifier = idRow.rows[0]?.identifier ?? null;
-		}
+	} else if (projectId && (await isProjectAtCapacityInDb(db, projectId))) {
+		projectAtCapacity = true;
 	}
 
 	const wakeups = await Promise.all(
@@ -84,8 +72,7 @@ queuedWakeupsRoutes.get('/teams/:teamId/tasks/:taskId/queued-wakeups', async (c)
 		wakeups,
 		dispatch: {
 			task_busy: taskBusy,
-			project_busy: projectBusy,
-			blocker_task_identifier: blockerTaskIdentifier,
+			project_at_capacity: projectAtCapacity,
 		},
 	});
 });
@@ -189,7 +176,7 @@ queuedWakeupsRoutes.post(
 			}
 			const messages: Record<string, string> = {
 				task_busy: 'This ticket already has a run in progress',
-				project_busy: 'Another ticket in this project is already running',
+				project_at_capacity: 'This project is at its concurrent-run limit',
 				blocked: 'This ticket is blocked by an open dependency',
 				not_queued: 'Wakeup is no longer queued and cannot be run',
 			};

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -844,6 +844,23 @@ export function shellQuoteArg(arg: string): string {
 	return `'${arg.replace(/'/g, `'\\''`)}'`;
 }
 
+// Serializes git operations that mutate a repo's shared .git store (clone,
+// fetch, worktree add) per project. Concurrent runs on the same project work in
+// separate per-task worktrees but share one .git per repo, so these brief setup
+// steps must not overlap or they race on git's index/ref locks. Keyed by
+// project id, so different projects never block one another.
+const projectGitLocks = new Map<string, Promise<unknown>>();
+function withProjectGitLock<T>(projectId: string, fn: () => Promise<T>): Promise<T> {
+	const prev = projectGitLocks.get(projectId) ?? Promise.resolve();
+	const run = prev.then(() => fn());
+	const tail = run.catch(() => {});
+	projectGitLocks.set(projectId, tail);
+	void tail.then(() => {
+		if (projectGitLocks.get(projectId) === tail) projectGitLocks.delete(projectId);
+	});
+	return run;
+}
+
 async function prepareWorktrees(
 	deps: RunnerDeps,
 	project: ProjectInfo,
@@ -862,83 +879,85 @@ async function prepareWorktrees(
 		return { workingDir: '/workspace', designatedRepo: null };
 	}
 
-	emit('stdout', '(syncing repos...)\n');
-	const syncRes = await ensureProjectRepos(
-		deps.db,
-		deps.masterKeyManager,
-		{
-			id: project.id,
-			team_id: project.team_id,
-		},
-		deps.dataDir,
-		deps.sshAgentServer,
-		(stream, text) => emit(stream, `${text}\n`),
-	);
-	if (syncRes.cloned.length > 0) {
-		emit('stdout', `(cloned ${syncRes.cloned.length} repo(s) on demand)\n`);
-	}
-
-	if (signal?.aborted) return { workingDir: '/workspace', designatedRepo: null };
-
-	const workspaceRoot = getWorkspacePath(deps.dataDir, project.team_id, project.id);
-	const worktreesRoot = getWorktreesPath(deps.dataDir, project.team_id, project.id);
-	const taskWorktreeRoot = join(worktreesRoot, task.identifier);
-	mkdirSync(taskWorktreeRoot, { recursive: true });
-
-	const branchName = `hezo/${task.identifier}`;
-	const knownHostsPath = await ensureGithubKnownHosts(deps.dataDir);
-	const reposNeedingWorktree = repos.rows.filter(
-		(r) => !signal?.aborted && existsSync(join(workspaceRoot, r.short_name, '.git')),
-	);
-
-	if (reposNeedingWorktree.length > 0 && deps.sshAgentServer) {
-		await withHostAgentSocket(
-			deps.sshAgentServer,
-			project.team_id,
-			deps.dataDir,
-			async ({ sshAuthSock }) => {
-				for (const repo of reposNeedingWorktree) {
-					if (signal?.aborted) break;
-					const repoDir = join(workspaceRoot, repo.short_name);
-
-					emit('stdout', `git fetch ${repo.short_name}...\n`);
-					const fetchRes = await fetchRepo(repoDir, sshAuthSock, knownHostsPath);
-					if (fetchRes.success) {
-						emit('stdout', `git fetch ${repo.short_name} done\n`);
-					} else {
-						emit('stderr', `git fetch ${repo.short_name} failed: ${fetchRes.error ?? '?'}\n`);
-					}
-				}
+	return withProjectGitLock(project.id, async () => {
+		emit('stdout', '(syncing repos...)\n');
+		const syncRes = await ensureProjectRepos(
+			deps.db,
+			deps.masterKeyManager,
+			{
+				id: project.id,
+				team_id: project.team_id,
 			},
+			deps.dataDir,
+			deps.sshAgentServer,
+			(stream, text) => emit(stream, `${text}\n`),
 		);
-	}
-
-	for (const repo of repos.rows) {
-		if (signal?.aborted) break;
-		const repoDir = join(workspaceRoot, repo.short_name);
-		const worktreePath = join(taskWorktreeRoot, repo.short_name);
-
-		if (!existsSync(join(repoDir, '.git'))) {
-			emit('stderr', `(skipping worktree for ${repo.short_name} — not cloned)\n`);
-			continue;
+		if (syncRes.cloned.length > 0) {
+			emit('stdout', `(cloned ${syncRes.cloned.length} repo(s) on demand)\n`);
 		}
 
-		emit('stdout', `git worktree ${repo.short_name}...\n`);
-		const wt = await ensureTaskWorktree(repoDir, worktreePath, branchName);
-		if (!wt.success) {
-			emit('stderr', `git worktree for ${repo.short_name} failed: ${wt.error ?? 'unknown'}\n`);
-		} else if (wt.created) {
-			emit('stdout', `git worktree add ${repo.short_name} @ ${branchName}\n`);
+		if (signal?.aborted) return { workingDir: '/workspace', designatedRepo: null };
+
+		const workspaceRoot = getWorkspacePath(deps.dataDir, project.team_id, project.id);
+		const worktreesRoot = getWorktreesPath(deps.dataDir, project.team_id, project.id);
+		const taskWorktreeRoot = join(worktreesRoot, task.identifier);
+		mkdirSync(taskWorktreeRoot, { recursive: true });
+
+		const branchName = `hezo/${task.identifier}`;
+		const knownHostsPath = await ensureGithubKnownHosts(deps.dataDir);
+		const reposNeedingWorktree = repos.rows.filter(
+			(r) => !signal?.aborted && existsSync(join(workspaceRoot, r.short_name, '.git')),
+		);
+
+		if (reposNeedingWorktree.length > 0 && deps.sshAgentServer) {
+			await withHostAgentSocket(
+				deps.sshAgentServer,
+				project.team_id,
+				deps.dataDir,
+				async ({ sshAuthSock }) => {
+					for (const repo of reposNeedingWorktree) {
+						if (signal?.aborted) break;
+						const repoDir = join(workspaceRoot, repo.short_name);
+
+						emit('stdout', `git fetch ${repo.short_name}...\n`);
+						const fetchRes = await fetchRepo(repoDir, sshAuthSock, knownHostsPath);
+						if (fetchRes.success) {
+							emit('stdout', `git fetch ${repo.short_name} done\n`);
+						} else {
+							emit('stderr', `git fetch ${repo.short_name} failed: ${fetchRes.error ?? '?'}\n`);
+						}
+					}
+				},
+			);
 		}
-	}
 
-	const designated = project.designated_repo_id
-		? repos.rows.find((r) => r.id === project.designated_repo_id)
-		: null;
-	const primary = designated ?? repos.rows[0];
-	const workingDir = `/worktrees/${task.identifier}/${primary.short_name}`;
+		for (const repo of repos.rows) {
+			if (signal?.aborted) break;
+			const repoDir = join(workspaceRoot, repo.short_name);
+			const worktreePath = join(taskWorktreeRoot, repo.short_name);
 
-	return { workingDir, designatedRepo: primary ?? null };
+			if (!existsSync(join(repoDir, '.git'))) {
+				emit('stderr', `(skipping worktree for ${repo.short_name} — not cloned)\n`);
+				continue;
+			}
+
+			emit('stdout', `git worktree ${repo.short_name}...\n`);
+			const wt = await ensureTaskWorktree(repoDir, worktreePath, branchName);
+			if (!wt.success) {
+				emit('stderr', `git worktree for ${repo.short_name} failed: ${wt.error ?? 'unknown'}\n`);
+			} else if (wt.created) {
+				emit('stdout', `git worktree add ${repo.short_name} @ ${branchName}\n`);
+			}
+		}
+
+		const designated = project.designated_repo_id
+			? repos.rows.find((r) => r.id === project.designated_repo_id)
+			: null;
+		const primary = designated ?? repos.rows[0];
+		const workingDir = `/worktrees/${task.identifier}/${primary.short_name}`;
+
+		return { workingDir, designatedRepo: primary ?? null };
+	});
 }
 
 export interface MentionOpenTicket {

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -41,11 +41,7 @@ import type { EgressProxy } from './egress';
 import type { LogStreamBroker } from './log-stream-broker';
 import { detectOrphans } from './orphan-detector';
 import { ensureRepoSetupAction } from './repo-setup';
-import {
-	findBusyTaskOnProject as findBusyTaskOnProjectInDb,
-	isProjectBusyInDb,
-	isTaskBusyInDb,
-} from './run-concurrency';
+import { getProjectConcurrency, isTaskBusyInDb } from './run-concurrency';
 import type { SshAgentServer } from './ssh-agent';
 import { recordStatusChange } from './task-events';
 import { absorbQueuedTaskWakeups, createWakeup } from './wakeup';
@@ -87,7 +83,7 @@ export type DispatchNowResult =
 	| { dispatched: true }
 	| {
 			dispatched: false;
-			reason: 'task_busy' | 'project_busy' | 'blocked' | 'not_queued' | 'not_found';
+			reason: 'task_busy' | 'project_at_capacity' | 'blocked' | 'not_queued' | 'not_found';
 	  };
 
 export interface JobManagerDeps {
@@ -125,11 +121,14 @@ export class JobManager {
 	// before launchTask, cleared in the launchTask finally. Closes the race window between
 	// dispatch and createHeartbeatRun where the DB-backed check is not yet authoritative.
 	private activeTaskRuns = new Set<string>();
-	// Projects whose container/workspace is currently held by a dispatched run.
-	// Same in-memory guard as activeTaskRuns, scoped at the project level so a
-	// second run cannot enter the project's shared workspace until the first
-	// releases. Tracked in parallel with activeTaskRuns in activateAgent.
-	private activeProjectRuns = new Set<string>();
+	// Refcount of dispatched runs per project, scoped at the project level so the
+	// number of concurrent runs entering a project's shared container never
+	// exceeds its configured ceiling. Incremented synchronously in activateAgent
+	// before launchTask and decremented in the launchTask finally — this closes
+	// the race window where the DB-backed count is not yet authoritative. A Set
+	// would be wrong here: with several runs in flight, the first to finish would
+	// free the guard for the rest.
+	private activeProjectRuns = new Map<string, number>();
 	private deps: JobManagerDeps;
 	private started = false;
 
@@ -174,10 +173,10 @@ export class JobManager {
 	/**
 	 * Dispatch a single queued wakeup immediately, bypassing the cron's
 	 * coalescing window. Applies the exact per-wakeup gating `processWakeups`
-	 * does — task busy, project busy, and source-gated dependency blockers — so
-	 * the two run rules and the scheduler's blocker policy stay respected. The
+	 * does — task busy, project at capacity, and source-gated dependency blockers
+	 * — so the run rules and the scheduler's blocker policy stay respected. The
 	 * in-memory `activeTaskRuns`/`activeProjectRuns` guards (checked inside
-	 * `isTaskBusy`/`isProjectBusy` and set synchronously by `activateAgent`)
+	 * `isTaskBusy`/`isProjectAtCapacity` and set synchronously by `activateAgent`)
 	 * make back-to-back calls race-safe. Returns a discriminated result the
 	 * route maps to 200 / 409 / 404.
 	 */
@@ -214,16 +213,15 @@ export class JobManager {
 				return { dispatched: false, reason: 'task_busy' };
 			}
 			const projectId = await this.resolveProjectForTask(wakeupTaskId);
-			if (projectId && (await this.isProjectBusy(projectId))) {
-				const busyTaskId = await this.findBusyTaskOnProject(projectId);
+			if (projectId && (await this.isProjectAtCapacity(projectId))) {
 				await this.markWakeupSkipped(
 					wakeup.id,
-					WakeupSkipReason.ProjectBusy,
+					WakeupSkipReason.ProjectAtCapacity,
 					wakeupTaskId,
 					wakeup.team_id,
-					busyTaskId,
+					null,
 				);
-				return { dispatched: false, reason: 'project_busy' };
+				return { dispatched: false, reason: 'project_at_capacity' };
 			}
 			if (await shouldDeferWakeupForBlockers(db, wakeup.source, wakeupTaskId)) {
 				await db.query(
@@ -607,13 +605,24 @@ export class JobManager {
 		return isTaskBusyInDb(this.deps.db, taskId);
 	}
 
-	private async isProjectBusy(projectId: string): Promise<boolean> {
-		if (this.activeProjectRuns.has(projectId)) return true;
-		return isProjectBusyInDb(this.deps.db, projectId);
+	private async isProjectAtCapacity(projectId: string): Promise<boolean> {
+		const { limit, active } = await getProjectConcurrency(this.deps.db, projectId);
+		// The in-memory refcount leads the DB during the dispatch window; once a
+		// run's row lands both refer to the same run, so `max` dedupes rather than
+		// double-counting. Using the larger of the two never under-counts, so the
+		// ceiling is never exceeded.
+		const inFlight = Math.max(this.activeProjectRuns.get(projectId) ?? 0, active);
+		return inFlight >= limit;
 	}
 
-	private findBusyTaskOnProject(projectId: string): Promise<string | null> {
-		return findBusyTaskOnProjectInDb(this.deps.db, projectId);
+	private acquireProjectRun(projectId: string): void {
+		this.activeProjectRuns.set(projectId, (this.activeProjectRuns.get(projectId) ?? 0) + 1);
+	}
+
+	private releaseProjectRun(projectId: string): void {
+		const next = (this.activeProjectRuns.get(projectId) ?? 0) - 1;
+		if (next > 0) this.activeProjectRuns.set(projectId, next);
+		else this.activeProjectRuns.delete(projectId);
 	}
 
 	private async markWakeupSkipped(
@@ -691,17 +700,14 @@ export class JobManager {
 					continue;
 				}
 				const projectId = await this.resolveProjectForTask(wakeupTaskId);
-				if (projectId && (await this.isProjectBusy(projectId))) {
-					log.debug(
-						`Skipping wakeup ${wakeup.id} — project ${projectId} already has an active run`,
-					);
-					const busyTaskId = await this.findBusyTaskOnProject(projectId);
+				if (projectId && (await this.isProjectAtCapacity(projectId))) {
+					log.debug(`Skipping wakeup ${wakeup.id} — project ${projectId} is at run capacity`);
 					await this.markWakeupSkipped(
 						wakeup.id,
-						WakeupSkipReason.ProjectBusy,
+						WakeupSkipReason.ProjectAtCapacity,
 						wakeupTaskId,
 						wakeup.team_id,
-						busyTaskId,
+						null,
 					);
 					continue;
 				}
@@ -950,13 +956,13 @@ export class JobManager {
 			task = tasks.rows[0];
 		}
 
-		// Per-task and per-project serialisation: only one agent runs on a given
-		// task at a time, and only one run is allowed per project at a time (the
-		// container/workspace is shared at the project level). Most blocked
-		// wakeups are filtered earlier by processWakeups; this guard catches
+		// Per-task serialisation plus the per-project concurrency ceiling: only one
+		// agent runs on a given task at a time, and no more than the project's
+		// configured limit of agents run concurrently in its shared container. Most
+		// blocked wakeups are filtered earlier by processWakeups; this guard catches
 		// heartbeat-style wakeups (no payload.task_id) where the chosen task is
-		// determined here, plus any race where the task or project became busy
-		// between the dispatcher check and now.
+		// determined here, plus any race where the task became busy or the project
+		// reached capacity between the dispatcher check and now.
 		if (await this.isTaskBusy({ task_id: task.id })) {
 			log.debug(
 				`Task ${ref(task.identifier, task.id)} already has an active run — re-queuing wakeup for ${ref(agent.rows[0].slug, memberId)}`,
@@ -969,9 +975,9 @@ export class JobManager {
 			}
 			return;
 		}
-		if (await this.isProjectBusy(task.project_id)) {
+		if (await this.isProjectAtCapacity(task.project_id)) {
 			log.debug(
-				`Project ${task.project_id} already has an active run — re-queuing wakeup for ${ref(agent.rows[0].slug, memberId)}`,
+				`Project ${task.project_id} is at run capacity — re-queuing wakeup for ${ref(agent.rows[0].slug, memberId)}`,
 			);
 			if (wakeupId) {
 				await db.query(
@@ -1140,7 +1146,7 @@ export class JobManager {
 		const taskKey = `${memberId}:${projectId}`;
 		const lockedTaskId = task.id;
 		this.activeTaskRuns.add(lockedTaskId);
-		this.activeProjectRuns.add(projectId);
+		this.acquireProjectRun(projectId);
 
 		// A run reads the full task context at boot, so any wakeup already queued
 		// for this agent+task is served by this run. Retire those siblings so they
@@ -1222,7 +1228,7 @@ export class JobManager {
 					return null;
 				} finally {
 					this.activeTaskRuns.delete(lockedTaskId);
-					this.activeProjectRuns.delete(projectId);
+					this.releaseProjectRun(projectId);
 					void trackBackground(this.guarded('wakeups', () => this.processWakeups()));
 				}
 			},

--- a/packages/server/src/services/run-concurrency.ts
+++ b/packages/server/src/services/run-concurrency.ts
@@ -4,8 +4,9 @@ import { HeartbeatRunStatus } from '@hezo/shared';
 /**
  * DB-backed concurrency checks — the single source of truth for the two run
  * rules: at most one active (queued/running) agent run per task, and at most
- * one per project. Shared by the scheduler (`JobManager`, which layers its
- * in-memory dispatch guards on top) and the stateless run-now route.
+ * `projects.max_concurrent_runs` per project. Shared by the scheduler
+ * (`JobManager`, which layers its in-memory dispatch guards on top) and the
+ * stateless run-now route.
  *
  * `lib/active-run.ts` and the `has_active_run` flag in `routes/tasks.ts` run
  * similar task-scoped checks for assignee-lock / badge purposes; they have
@@ -23,27 +24,37 @@ export async function isTaskBusyInDb(db: PGlite, taskId: string): Promise<boolea
 	return active.rows.length > 0;
 }
 
-export async function isProjectBusyInDb(db: PGlite, projectId: string): Promise<boolean> {
-	const active = await db.query(
-		`SELECT 1 FROM heartbeat_runs r
-		 JOIN tasks t ON t.id = r.task_id
-		 WHERE t.project_id = $1
-		   AND r.status IN ($2::heartbeat_run_status, $3::heartbeat_run_status)
-		 LIMIT 1`,
-		[projectId, HeartbeatRunStatus.Queued, HeartbeatRunStatus.Running],
-	);
-	return active.rows.length > 0;
+export interface ProjectConcurrency {
+	/** Configured ceiling on simultaneous agent runs for the project. */
+	limit: number;
+	/** Active (queued/running) runs currently counted against that ceiling. */
+	active: number;
 }
 
-export async function findBusyTaskOnProject(db: PGlite, projectId: string): Promise<string | null> {
-	const active = await db.query<{ task_id: string }>(
-		`SELECT r.task_id FROM heartbeat_runs r
-		 JOIN tasks t ON t.id = r.task_id
-		 WHERE t.project_id = $1
-		   AND r.status IN ($2::heartbeat_run_status, $3::heartbeat_run_status)
-		 ORDER BY r.created_at ASC
-		 LIMIT 1`,
+/**
+ * Read a project's concurrency ceiling alongside its current active-run count
+ * in a single query. The scheduler reconciles `active` against its in-memory
+ * dispatch refcount (taking the larger of the two) before comparing to `limit`.
+ */
+export async function getProjectConcurrency(
+	db: PGlite,
+	projectId: string,
+): Promise<ProjectConcurrency> {
+	const row = await db.query<{ limit: number; active: number }>(
+		`SELECT p.max_concurrent_runs AS limit,
+		        (SELECT count(*)::int FROM heartbeat_runs r
+		           JOIN tasks t ON t.id = r.task_id
+		          WHERE t.project_id = p.id
+		            AND r.status IN ($2::heartbeat_run_status, $3::heartbeat_run_status)) AS active
+		 FROM projects p
+		 WHERE p.id = $1`,
 		[projectId, HeartbeatRunStatus.Queued, HeartbeatRunStatus.Running],
 	);
-	return active.rows[0]?.task_id ?? null;
+	const r = row.rows[0];
+	return { limit: r?.limit ?? 1, active: r?.active ?? 0 };
+}
+
+export async function isProjectAtCapacityInDb(db: PGlite, projectId: string): Promise<boolean> {
+	const { limit, active } = await getProjectConcurrency(db, projectId);
+	return active >= limit;
 }

--- a/packages/server/test/job-manager-workflows.test.ts
+++ b/packages/server/test/job-manager-workflows.test.ts
@@ -186,8 +186,9 @@ describe('JobManager workflow methods', () => {
 			await db.query('DELETE FROM agent_wakeup_requests WHERE id = $1', [wakeupId]);
 		});
 
-		it('records project_busy on a task wakeup when another task in the project is running', async () => {
+		it('records project_at_capacity on a task wakeup when the project is at its run limit', async () => {
 			const manager = createJobManager();
+			await db.query('UPDATE projects SET max_concurrent_runs = 1 WHERE id = $1', [projectId]);
 
 			const otherTaskRes = await app.request(`/api/teams/${teamId}/tasks`, {
 				method: 'POST',
@@ -227,8 +228,8 @@ describe('JobManager workflow methods', () => {
 				[wakeupId],
 			);
 			expect(wakeup.rows[0].status).toBe(WakeupStatus.Queued);
-			expect(wakeup.rows[0].last_skipped_reason).toBe('project_busy');
-			expect(wakeup.rows[0].last_skipped_blocker_task_id).toBe(otherTask.id);
+			expect(wakeup.rows[0].last_skipped_reason).toBe('project_at_capacity');
+			expect(wakeup.rows[0].last_skipped_blocker_task_id).toBeNull();
 
 			const taskRes = await app.request(`/api/teams/${teamId}/tasks/${taskId}`, {
 				headers: authHeader(token),
@@ -240,10 +241,10 @@ describe('JobManager workflow methods', () => {
 				} | null;
 			};
 			expect(task.queued_wakeup).not.toBeNull();
-			expect(task.queued_wakeup?.reason).toBe('project_busy');
-			expect(task.queued_wakeup?.blocker_identifier).toBe(otherTask.identifier);
+			expect(task.queued_wakeup?.reason).toBe('project_at_capacity');
 
 			manager.shutdown();
+			await db.query('UPDATE projects SET max_concurrent_runs = 3 WHERE id = $1', [projectId]);
 			await db.query('DELETE FROM agent_wakeup_requests WHERE id = $1', [wakeupId]);
 			await db.query('DELETE FROM heartbeat_runs WHERE task_id = $1', [otherTask.id]);
 		});
@@ -256,7 +257,7 @@ describe('JobManager workflow methods', () => {
 				   (member_id, team_id, source, status, payload, last_skipped_at,
 				    last_skipped_reason, created_at)
 				 VALUES ($1, $2, 'assignment', 'queued', $3::jsonb, now(),
-				         'project_busy', now() - interval '30 seconds')
+				         'project_at_capacity', now() - interval '30 seconds')
 				 RETURNING id`,
 				[agentId, teamId, JSON.stringify({ task_id: taskId, reason: 'unblocked' })],
 			);
@@ -1772,8 +1773,9 @@ describe('JobManager workflow methods', () => {
 	});
 
 	describe('per-project serialisation and cross-project parallelism', () => {
-		it('isProjectBusy returns true while another task in the same project is running', async () => {
+		it('isProjectAtCapacity returns true once running runs reach the limit', async () => {
 			const manager = createJobManager();
+			await db.query('UPDATE projects SET max_concurrent_runs = 1 WHERE id = $1', [projectId]);
 
 			const otherTaskRes = await app.request(`/api/teams/${teamId}/tasks`, {
 				method: 'POST',
@@ -1792,26 +1794,55 @@ describe('JobManager workflow methods', () => {
 				[agentId, teamId, otherTaskId, HeartbeatRunStatus.Running],
 			);
 
-			const busy = await (manager as any).isProjectBusy(projectId);
+			const busy = await (manager as any).isProjectAtCapacity(projectId);
 			expect(busy).toBe(true);
 
 			await db.query(
 				"UPDATE heartbeat_runs SET status = 'succeeded', finished_at = now() WHERE task_id = $1",
 				[otherTaskId],
 			);
-			const busyAfter = await (manager as any).isProjectBusy(projectId);
+			const busyAfter = await (manager as any).isProjectAtCapacity(projectId);
 			expect(busyAfter).toBe(false);
 
 			manager.shutdown();
+			await db.query('UPDATE projects SET max_concurrent_runs = 3 WHERE id = $1', [projectId]);
 			await db.query('DELETE FROM heartbeat_runs WHERE task_id = $1', [otherTaskId]);
 			await db.query('DELETE FROM tasks WHERE id = $1', [otherTaskId]);
 		});
 
-		it('re-queues a wakeup when its project already has a different active run', async () => {
+		it('isProjectAtCapacity stays false while running runs are below the limit', async () => {
 			const manager = createJobManager();
+			await db.query('UPDATE projects SET max_concurrent_runs = 3 WHERE id = $1', [projectId]);
 
-			// Stand up a sibling project + task for this team so an unrelated active
-			// run in project A blocks a wakeup targeting another task in project A.
+			const taskRes = await app.request(`/api/teams/${teamId}/tasks`, {
+				method: 'POST',
+				headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					project_id: projectId,
+					title: 'One of three slots',
+					assignee_id: agentId,
+				}),
+			});
+			const oneOfThree = (await taskRes.json()).data.id;
+			await db.query(
+				`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at)
+				 VALUES ($1, $2, $3, $4::heartbeat_run_status, now())`,
+				[agentId, teamId, oneOfThree, HeartbeatRunStatus.Running],
+			);
+
+			expect(await (manager as any).isProjectAtCapacity(projectId)).toBe(false);
+
+			manager.shutdown();
+			await db.query('DELETE FROM heartbeat_runs WHERE task_id = $1', [oneOfThree]);
+			await db.query('DELETE FROM tasks WHERE id = $1', [oneOfThree]);
+		});
+
+		it('re-queues a wakeup when its project is already at its run limit', async () => {
+			const manager = createJobManager();
+			await db.query('UPDATE projects SET max_concurrent_runs = 1 WHERE id = $1', [projectId]);
+
+			// An active run in project A at the limit blocks a wakeup targeting
+			// another task in project A.
 			const sibTaskRes = await app.request(`/api/teams/${teamId}/tasks`, {
 				method: 'POST',
 				headers: { ...authHeader(token), 'Content-Type': 'application/json' },
@@ -1846,6 +1877,7 @@ describe('JobManager workflow methods', () => {
 			expect(status.rows[0].status).toBe(WakeupStatus.Queued);
 
 			manager.shutdown();
+			await db.query('UPDATE projects SET max_concurrent_runs = 3 WHERE id = $1', [projectId]);
 			await db.query('DELETE FROM agent_wakeup_requests WHERE id = $1', [wakeupId]);
 			await db.query('DELETE FROM heartbeat_runs WHERE task_id = $1', [taskId]);
 			await db.query('DELETE FROM tasks WHERE id = $1', [sibTaskId]);
@@ -1853,6 +1885,7 @@ describe('JobManager workflow methods', () => {
 
 		it('the per-agent lock is gone: agent busy in project A does not block a wakeup for project B', async () => {
 			const manager = createJobManager();
+			await db.query('UPDATE projects SET max_concurrent_runs = 1 WHERE id = $1', [projectId]);
 
 			// Project B (sibling) with a task assigned to the same agent. We never
 			// dispatch on this one — we just need the row to exist so resolveProjectForTask
@@ -1874,10 +1907,10 @@ describe('JobManager workflow methods', () => {
 			const taskBId = (await taskBRes.json()).data.id;
 
 			// Pretend the agent is mid-run in project A by pre-populating the
-			// in-memory project lock. This is what activateAgent does synchronously
-			// before launchTask; using it directly here avoids spinning up a real
-			// runAgent that would then race with cleanup.
-			(manager as any).activeProjectRuns.add(projectId);
+			// in-memory project refcount. This is what activateAgent does
+			// synchronously before launchTask; using it directly here avoids spinning
+			// up a real runAgent that would then race with cleanup.
+			(manager as any).acquireProjectRun(projectId);
 			(manager as any).runningTasks.set(`${agentId}:${projectId}`, {
 				key: `${agentId}:${projectId}`,
 				abortController: new AbortController(),
@@ -1887,12 +1920,13 @@ describe('JobManager workflow methods', () => {
 			});
 
 			// The legacy per-agent check would have skipped this wakeup. The
-			// per-project check should not: project B has no active run.
+			// per-project capacity check should not: project B has no active run.
 			expect(manager.isMemberRunning(agentId)).toBe(true);
-			expect(await (manager as any).isProjectBusy(projectId)).toBe(true);
-			expect(await (manager as any).isProjectBusy(projectBId)).toBe(false);
+			expect(await (manager as any).isProjectAtCapacity(projectId)).toBe(true);
+			expect(await (manager as any).isProjectAtCapacity(projectBId)).toBe(false);
 
 			manager.shutdown();
+			await db.query('UPDATE projects SET max_concurrent_runs = 3 WHERE id = $1', [projectId]);
 			await db.query('DELETE FROM tasks WHERE id = $1', [taskBId]);
 			await db.query('DELETE FROM projects WHERE id = $1', [projectBId]);
 		});

--- a/packages/server/test/queued-wakeups.test.ts
+++ b/packages/server/test/queued-wakeups.test.ts
@@ -88,13 +88,6 @@ async function clearBlockers(forTaskId: string): Promise<void> {
 	await db.query('DELETE FROM task_dependencies WHERE task_id = $1', [forTaskId]);
 }
 
-async function taskIdentifier(forTaskId: string): Promise<string> {
-	const r = await db.query<{ identifier: string }>('SELECT identifier FROM tasks WHERE id = $1', [
-		forTaskId,
-	]);
-	return r.rows[0].identifier;
-}
-
 function runNow(forTaskId: string, wakeupId: string) {
 	return app.request(`/api/teams/${teamId}/tasks/${forTaskId}/queued-wakeups/${wakeupId}/run-now`, {
 		method: 'POST',
@@ -126,8 +119,7 @@ interface WakeupRow {
 
 interface DispatchState {
 	task_busy: boolean;
-	project_busy: boolean;
-	blocker_task_identifier: string | null;
+	project_at_capacity: boolean;
 }
 
 beforeAll(async () => {
@@ -194,8 +186,7 @@ describe('GET /teams/:teamId/tasks/:taskId/queued-wakeups', () => {
 
 		const { body } = await listQueued(taskId);
 		expect(body.data.dispatch.task_busy).toBe(false);
-		expect(body.data.dispatch.project_busy).toBe(false);
-		expect(body.data.dispatch.blocker_task_identifier).toBeNull();
+		expect(body.data.dispatch.project_at_capacity).toBe(false);
 		expect(body.data.wakeups[0].run_now_blocked).toBeNull();
 	});
 
@@ -210,17 +201,31 @@ describe('GET /teams/:teamId/tasks/:taskId/queued-wakeups', () => {
 		await clearRuns();
 	});
 
-	it('reports project_busy with the busy task identifier', async () => {
+	it('reports project_at_capacity when the project is at its run limit', async () => {
 		await clearWakeups(taskId);
 		await clearRuns();
+		await db.query('UPDATE projects SET max_concurrent_runs = 1 WHERE id = $1', [projectId]);
 		const sibling = await createTask('Busy Sibling');
 		await insertRunningRun(agentA, sibling);
 		await insertQueuedWakeup(agentB, taskId);
 
 		const { body } = await listQueued(taskId);
 		expect(body.data.dispatch.task_busy).toBe(false);
-		expect(body.data.dispatch.project_busy).toBe(true);
-		expect(body.data.dispatch.blocker_task_identifier).toBe(await taskIdentifier(sibling));
+		expect(body.data.dispatch.project_at_capacity).toBe(true);
+		await db.query('UPDATE projects SET max_concurrent_runs = 3 WHERE id = $1', [projectId]);
+		await clearRuns();
+	});
+
+	it('still has capacity while running runs stay below the limit', async () => {
+		await clearWakeups(taskId);
+		await clearRuns();
+		await db.query('UPDATE projects SET max_concurrent_runs = 3 WHERE id = $1', [projectId]);
+		const sibling = await createTask('One Of Three');
+		await insertRunningRun(agentA, sibling);
+		await insertQueuedWakeup(agentB, taskId);
+
+		const { body } = await listQueued(taskId);
+		expect(body.data.dispatch.project_at_capacity).toBe(false);
 		await clearRuns();
 	});
 
@@ -293,9 +298,10 @@ describe('POST /teams/:teamId/tasks/:taskId/queued-wakeups/:wakeupId/run-now', (
 		await clearRuns();
 	});
 
-	it('returns 409 and records project_busy when a sibling task in the project is running', async () => {
+	it('returns 409 and records project_at_capacity when the project is at its run limit', async () => {
 		await clearWakeups(taskId);
 		await clearRuns();
+		await db.query('UPDATE projects SET max_concurrent_runs = 1 WHERE id = $1', [projectId]);
 		const sibling = await createTask('Run-now Busy Sibling');
 		await insertRunningRun(agentA, sibling);
 		const wakeupId = await insertQueuedWakeup(agentB, taskId);
@@ -308,7 +314,8 @@ describe('POST /teams/:teamId/tasks/:taskId/queued-wakeups/:wakeupId/run-now', (
 			[wakeupId],
 		);
 		expect(row.rows[0].status).toBe('queued');
-		expect(row.rows[0].last_skipped_reason).toBe('project_busy');
+		expect(row.rows[0].last_skipped_reason).toBe('project_at_capacity');
+		await db.query('UPDATE projects SET max_concurrent_runs = 3 WHERE id = $1', [projectId]);
 		await clearRuns();
 	});
 

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -321,7 +321,7 @@ export type WakeupStatus = (typeof WakeupStatus)[keyof typeof WakeupStatus];
 
 export const WakeupSkipReason = {
 	TaskBusy: 'task_busy',
-	ProjectBusy: 'project_busy',
+	ProjectAtCapacity: 'project_at_capacity',
 	AgentRunning: 'agent_running',
 } as const;
 export type WakeupSkipReason = (typeof WakeupSkipReason)[keyof typeof WakeupSkipReason];

--- a/packages/web/src/components/task-detail/queued-agents-list.tsx
+++ b/packages/web/src/components/task-detail/queued-agents-list.tsx
@@ -19,9 +19,7 @@ interface QueuedAgentsListProps {
  */
 function runNowBlockReason(wakeup: QueuedWakeup, dispatch: QueuedDispatchState): string | null {
 	if (dispatch.task_busy) return 'This ticket already has a run in progress';
-	if (dispatch.project_busy) {
-		return `Project is busy — ${dispatch.blocker_task_identifier ?? 'another ticket'} is running`;
-	}
+	if (dispatch.project_at_capacity) return 'Project is at its concurrent-run limit';
 	if (wakeup.run_now_blocked === 'blocked_by_dependency') return 'Blocked by an open dependency';
 	return null;
 }

--- a/packages/web/src/components/task-detail/task-header.tsx
+++ b/packages/web/src/components/task-detail/task-header.tsx
@@ -43,24 +43,9 @@ export function TaskHeader({ task, teamId, taskProjectSlug }: TaskHeaderProps) {
 				{!task.has_active_run && task.queued_wakeup && (
 					<Badge color="blue" className="gap-1" data-testid="task-queued-badge">
 						<span className="inline-block w-1.5 h-1.5 rounded-full bg-accent-blue-text" />
-						{task.queued_wakeup.blocker_identifier && task.queued_wakeup.blocker_project_slug ? (
-							<>
-								Queued behind{' '}
-								<Link
-									to="/teams/$teamId/projects/$projectId/tasks/$taskId"
-									params={{
-										teamId,
-										projectId: task.queued_wakeup.blocker_project_slug,
-										taskId: task.queued_wakeup.blocker_identifier.toLowerCase(),
-									}}
-									className="underline"
-								>
-									{task.queued_wakeup.blocker_identifier}
-								</Link>
-							</>
-						) : (
-							'Run queued'
-						)}
+						{task.queued_wakeup.reason === 'project_at_capacity'
+							? 'Queued — project at capacity'
+							: 'Run queued'}
 					</Badge>
 				)}
 			</div>

--- a/packages/web/src/components/task-list.tsx
+++ b/packages/web/src/components/task-list.tsx
@@ -57,7 +57,7 @@ interface TaskRow {
 	assignee_type: 'agent' | 'user' | null;
 	has_active_run: boolean;
 	queued_wakeup: {
-		reason: 'task_busy' | 'project_busy' | 'agent_running';
+		reason: 'task_busy' | 'project_at_capacity' | 'agent_running';
 		blocker_identifier: string | null;
 	} | null;
 }
@@ -185,16 +185,16 @@ export function TaskList({ teamId, projectId }: TaskListProps) {
 					{!row.has_active_run && row.queued_wakeup && (
 						<Tooltip
 							content={
-								row.queued_wakeup.blocker_identifier
-									? `Run queued — waiting on ${row.queued_wakeup.blocker_identifier}`
+								row.queued_wakeup.reason === 'project_at_capacity'
+									? 'Run queued — project at capacity'
 									: 'Run queued — waiting'
 							}
 						>
 							<span
 								role="img"
 								aria-label={
-									row.queued_wakeup.blocker_identifier
-										? `Run queued — waiting on ${row.queued_wakeup.blocker_identifier}`
+									row.queued_wakeup.reason === 'project_at_capacity'
+										? 'Run queued — project at capacity'
 										: 'Run queued — waiting'
 								}
 								data-testid="task-queued-dot"

--- a/packages/web/src/hooks/use-projects.ts
+++ b/packages/web/src/hooks/use-projects.ts
@@ -12,6 +12,7 @@ export interface Project {
 	task_prefix: string;
 	description: string;
 	is_internal?: boolean;
+	max_concurrent_runs: number;
 	docker_base_image: string | null;
 	container_id: string | null;
 	container_status: 'creating' | 'running' | 'stopping' | 'stopped' | 'error' | null;
@@ -106,7 +107,11 @@ export function useCreateProject(teamId: string) {
 }
 
 export function useUpdateProject(teamId: string, projectId: string) {
-	return useOptimisticMutation<{ name?: string; description?: string }, Project, Project>({
+	return useOptimisticMutation<
+		{ name?: string; description?: string; max_concurrent_runs?: number },
+		Project,
+		Project
+	>({
 		mutationFn: (data) => api.patch<Project>(`/api/teams/${teamId}/projects/${projectId}`, data),
 		queryKey: ['teams', teamId, 'projects', projectId],
 		applyOptimistic: (current, vars) => (current ? { ...current, ...vars } : current),

--- a/packages/web/src/hooks/use-queued-wakeups.ts
+++ b/packages/web/src/hooks/use-queued-wakeups.ts
@@ -16,8 +16,7 @@ export interface QueuedWakeup {
 /** Live "can this task accept a run now" state, shared by every queued wakeup on the task. */
 export interface QueuedDispatchState {
 	task_busy: boolean;
-	project_busy: boolean;
-	blocker_task_identifier: string | null;
+	project_at_capacity: boolean;
 }
 
 export interface QueuedWakeupsState {

--- a/packages/web/src/hooks/use-tasks.ts
+++ b/packages/web/src/hooks/use-tasks.ts
@@ -5,7 +5,7 @@ import { queryClient } from '../lib/query-client';
 import { useOptimisticMutation } from './use-optimistic-mutation';
 
 export interface QueuedWakeup {
-	reason: 'task_busy' | 'project_busy' | 'agent_running';
+	reason: 'task_busy' | 'project_at_capacity' | 'agent_running';
 	since: string;
 	blocker_task_id: string | null;
 	blocker_identifier: string | null;

--- a/packages/web/src/routes/teams/$teamId/projects/$projectId/settings/index.tsx
+++ b/packages/web/src/routes/teams/$teamId/projects/$projectId/settings/index.tsx
@@ -15,6 +15,7 @@ function ProjectSettingsPage() {
 
 	const [name, setName] = useState('');
 	const [description, setDescription] = useState('');
+	const [maxRuns, setMaxRuns] = useState('1');
 	const [editing, setEditing] = useState(false);
 
 	if (!project) return null;
@@ -23,14 +24,18 @@ function ProjectSettingsPage() {
 		if (!project) return;
 		setName(project.name);
 		setDescription(project.description ?? '');
+		setMaxRuns(String(project.max_concurrent_runs));
 		setEditing(true);
 	}
 
 	async function handleSave(e: React.FormEvent) {
 		e.preventDefault();
+		const parsedMaxRuns = Number(maxRuns);
 		await updateProject.mutateAsync({
 			name: name.trim() || undefined,
 			description: description.trim(),
+			max_concurrent_runs:
+				Number.isInteger(parsedMaxRuns) && parsedMaxRuns >= 1 ? parsedMaxRuns : undefined,
 		});
 		setEditing(false);
 	}
@@ -48,6 +53,19 @@ function ProjectSettingsPage() {
 							onChange={(e) => setDescription(e.target.value)}
 							rows={4}
 						/>
+						<Input
+							label="Max concurrent runs"
+							type="number"
+							min={1}
+							className="w-28"
+							value={maxRuns}
+							onChange={(e) => setMaxRuns(e.target.value)}
+							data-testid="max-concurrent-runs-input"
+						/>
+						<p className="text-xs text-text-subtle -mt-1">
+							Agents that may run at once in this project. Different agents work different tickets
+							in parallel; one ticket still runs a single agent at a time.
+						</p>
 						<div className="flex gap-2">
 							<Button type="submit" size="sm" disabled={updateProject.isPending}>
 								{updateProject.isPending ? <Loader2 className="w-3 h-3 animate-spin" /> : 'Save'}
@@ -67,6 +85,10 @@ function ProjectSettingsPage() {
 								<span className="text-text-muted">Description:</span> {project.description}
 							</div>
 						)}
+						<div data-testid="max-concurrent-runs-value">
+							<span className="text-text-muted">Max concurrent runs:</span>{' '}
+							{project.max_concurrent_runs}
+						</div>
 						<Button variant="ghost" size="sm" onClick={startEditing} className="mt-2">
 							Edit
 						</Button>

--- a/packages/web/test/project-settings.test.tsx
+++ b/packages/web/test/project-settings.test.tsx
@@ -108,6 +108,55 @@ test('cancel button discards edits', async () => {
 	expect(queryByText('Should Not Save')).toBeNull();
 });
 
+test('edits the per-project concurrency cap and persists it', async () => {
+	const projectName = uniqueName('Concurrency Project');
+	let ws!: SeededWorkspace;
+	let projectSlug = '';
+	let projectId = '';
+
+	const { findByRole, findByTestId, getByRole, ctx, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			ws = await seedWorkspace();
+			const project = await seedProject(ws, {
+				name: projectName,
+				description: 'Concurrency settings.',
+			});
+			projectSlug = project.slug;
+			projectId = project.id;
+		},
+	});
+
+	await router.navigate({
+		to: '/teams/$teamId/projects/$projectId/settings',
+		params: { teamId: ws.team.slug, projectId: projectSlug },
+	});
+
+	// Read view shows the seeded default of 3.
+	const readValue = await findByTestId('max-concurrent-runs-value', undefined, { timeout: 8_000 });
+	expect(readValue.textContent).toContain('3');
+
+	await user.click(await findByRole('button', { name: 'Edit' }));
+	const input = (await findByTestId('max-concurrent-runs-input', undefined, {
+		timeout: 8_000,
+	})) as HTMLInputElement;
+	await user.clear(input);
+	await user.type(input, '5');
+	await user.click(getByRole('button', { name: 'Save' }));
+
+	// The optimistic mutation hits the real backend; the project row reflects it.
+	await waitFor(
+		async () => {
+			const row = await ctx.db.query<{ max_concurrent_runs: number }>(
+				'SELECT max_concurrent_runs FROM projects WHERE id = $1',
+				[projectId],
+			);
+			expect(row.rows[0]?.max_concurrent_runs).toBe(5);
+		},
+		{ timeout: 8_000 },
+	);
+});
+
 test('State A — no GitHub connection: shows Connect GitHub CTA', async () => {
 	const projectName = uniqueName('Settings Project');
 	let ws!: SeededWorkspace;

--- a/packages/web/test/queued-agents.test.tsx
+++ b/packages/web/test/queued-agents.test.tsx
@@ -111,6 +111,56 @@ test('runs a queued agent immediately via the play button', async () => {
 	);
 });
 
+test('disables run-now with a capacity reason when the project is at its run limit', async () => {
+	const seeded = { teamSlug: '', taskId: '', wakeupId: '' };
+
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async (ctx) => {
+			const ws = await seedWorkspace();
+			const captain = ws.agents.find((a) => a.slug === 'captain') ?? ws.agents[0];
+			const queuedAgent = ws.agents.find((a) => a.id !== captain.id) ?? ws.agents[0];
+			const project = await seedProject(ws, { name: 'At Capacity Demo' });
+			// Cap the project at a single concurrent run.
+			await ctx.db.query('UPDATE projects SET max_concurrent_runs = 1 WHERE id = $1', [project.id]);
+
+			// A sibling ticket is already running, so the project's one slot is taken.
+			const sibling = await seedTask(ws, project, { title: 'Occupying Slot' });
+			await ctx.db.query(
+				`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at)
+				 VALUES ($1, $2, $3, 'running'::heartbeat_run_status, now())`,
+				[captain.id, ws.team.id, sibling.id],
+			);
+
+			const task = await seedTask(ws, project, { title: 'Waiting Task', assignee_id: captain.id });
+			const r = await ctx.db.query<{ id: string }>(
+				`INSERT INTO agent_wakeup_requests (member_id, team_id, source, status, payload)
+				 VALUES ($1, $2, 'mention'::wakeup_source, 'queued'::wakeup_status,
+				         jsonb_build_object('task_id', $3::text))
+				 RETURNING id`,
+				[queuedAgent.id, ws.team.id, task.id],
+			);
+
+			seeded.teamSlug = ws.team.slug;
+			seeded.taskId = task.id;
+			seeded.wakeupId = r.rows[0].id;
+		},
+	});
+
+	await router.navigate({
+		to: '/teams/$teamId/tasks/$taskId',
+		params: { teamId: seeded.teamSlug, taskId: seeded.taskId },
+	});
+
+	const playBtn = (await findByTestId(`run-queued-wakeup-${seeded.wakeupId}`, undefined, {
+		timeout: 15_000,
+	})) as HTMLButtonElement;
+	await waitFor(() => {
+		expect(playBtn.getAttribute('aria-disabled')).toBe('true');
+	});
+	expect(playBtn.getAttribute('aria-label')).toMatch(/concurrent-run limit/i);
+});
+
 test('disables the play button with a reason when the ticket already has a run', async () => {
 	const seeded = { teamSlug: '', taskId: '', wakeupId: '' };
 


### PR DESCRIPTION
Replace the per-project run lock with a configurable per-project concurrency ceiling. Different agents now run concurrently on the same project, each in its own per-task worktree, bounded by the project's max_concurrent_runs (default 3). One run per task is still enforced.

- run-concurrency: getProjectConcurrency / isProjectAtCapacityInDb replace the binary isProjectBusyInDb; drop dead findBusyTaskOnProject
- job-manager: activeProjectRuns becomes a refcount map; isProjectBusy becomes isProjectAtCapacity using max(in-memory, db) >= limit
- agent-runner: per-project mutex around the shared-.git fetch/worktree setup so concurrent runs don't race on git's index/ref locks
- schema: projects.max_concurrent_runs (default 3, >= 1)
- WakeupSkipReason.ProjectBusy -> ProjectAtCapacity; routes, dispatch state, settings UI, task header/list, and types updated accordingly

Container rebuild already aborts all in-flight runs and reprovisions, so it stays correct for any number of concurrent runs.