### PR TITLE
fix(dispatch): prevent leaked execution lock when an agent is already…

### DIFF
--- a/packages/server/migrations/001_initial_schema.sql
+++ b/packages/server/migrations/001_initial_schema.sql
@@ -638,6 +638,7 @@ CREATE TABLE approvals (
     payload                JSONB NOT NULL,
     resolved_at            TIMESTAMPTZ,
     resolution_note        TEXT,
+    archived_at            TIMESTAMPTZ,
     created_at             TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
@@ -1046,6 +1047,7 @@ CREATE TABLE board_mentions (
     user_id     UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
     read_at     TIMESTAMPTZ,
+    archived_at TIMESTAMPTZ,
     UNIQUE (comment_id, user_id)
 );
 
@@ -1055,6 +1057,12 @@ CREATE INDEX idx_board_mentions_user_unread
 CREATE INDEX idx_board_mentions_team_unread
     ON board_mentions (team_id, created_at DESC)
     WHERE read_at IS NULL;
+CREATE INDEX idx_board_mentions_user_active
+    ON board_mentions (user_id, team_id, created_at DESC)
+    WHERE archived_at IS NULL;
+CREATE INDEX idx_board_mentions_user_archived
+    ON board_mentions (user_id, team_id, created_at DESC)
+    WHERE archived_at IS NOT NULL;
 
 -------------------------------------------------------------------------------
 -- TRIGGERS: auto-update updated_at

--- a/packages/server/src/routes/approvals.ts
+++ b/packages/server/src/routes/approvals.ts
@@ -12,10 +12,17 @@ approvalsRoutes.get('/teams/:teamId/approvals', async (c) => {
 	const teamId = c.get('teamId') as string;
 	const db = c.get('db');
 	const statusFilter = c.req.query('status') || ApprovalStatus.Pending;
+	const archivedParam = c.req.query('archived');
+	const archivedClause =
+		archivedParam === 'true'
+			? ' AND a.archived_at IS NOT NULL'
+			: archivedParam === 'false'
+				? ' AND a.archived_at IS NULL'
+				: '';
 
 	const result = await db.query(
 		`SELECT a.id, a.team_id, a.type, a.status, a.payload, a.resolution_note,
-            a.resolved_at, a.created_at,
+            a.resolved_at, a.archived_at, a.created_at,
             co.name AS team_name,
             co.slug AS team_slug,
             COALESCE(ma.title, m.display_name) AS requested_by_name,
@@ -36,7 +43,7 @@ approvalsRoutes.get('/teams/:teamId/approvals', async (c) => {
      WHERE a.team_id = $1 AND a.status IN (${statusFilter
 				.split(',')
 				.map((_, i) => `$${i + 2}::approval_status`)
-				.join(', ')})
+				.join(', ')})${archivedClause}
      ORDER BY a.created_at DESC`,
 		[teamId, ...statusFilter.split(',').map((s) => s.trim())],
 	);

--- a/packages/server/src/routes/inbox.ts
+++ b/packages/server/src/routes/inbox.ts
@@ -1,4 +1,4 @@
-import { AuthType, wsRoom } from '@hezo/shared';
+import { ApprovalStatus, AuthType, wsRoom } from '@hezo/shared';
 import { Hono } from 'hono';
 import { broadcastChange } from '../lib/broadcast';
 import { err, ok } from '../lib/response';
@@ -40,7 +40,7 @@ inboxRoutes.get('/teams/:teamId/inbox/mentions', async (c) => {
 		return err(c, 'FORBIDDEN', 'Only board members have an inbox', 403);
 	}
 
-	const includeRead = c.req.query('include_read') === 'true';
+	const archived = c.req.query('archived') === 'true';
 	const db = c.get('db');
 
 	const result = await db.query<BoardMentionRow>(
@@ -58,10 +58,10 @@ inboxRoutes.get('/teams/:teamId/inbox/mentions', async (c) => {
 		 LEFT JOIN members m ON m.id = tc.author_member_id
 		 LEFT JOIN member_agents ma ON ma.id = tc.author_member_id
 		 WHERE bm.team_id = $1 AND bm.user_id = $2
-		   AND ($3::boolean OR bm.read_at IS NULL)
+		   AND (bm.archived_at IS NOT NULL) = $3::boolean
 		 ORDER BY bm.created_at DESC
 		 LIMIT 200`,
-		[teamId, auth.userId, includeRead],
+		[teamId, auth.userId, archived],
 	);
 
 	return ok(
@@ -82,6 +82,27 @@ inboxRoutes.get('/teams/:teamId/inbox/mentions', async (c) => {
 			read_at: r.read_at,
 		})),
 	);
+});
+
+inboxRoutes.get('/teams/:teamId/inbox/count', async (c) => {
+	const teamId = c.get('teamId') as string;
+	const auth = c.get('auth');
+	if (auth.type !== AuthType.Board) {
+		return err(c, 'FORBIDDEN', 'Only board members have an inbox', 403);
+	}
+
+	const db = c.get('db');
+	const result = await db.query<{ unread: number }>(
+		`SELECT (
+		          (SELECT count(*) FROM board_mentions
+		           WHERE team_id = $1 AND user_id = $2 AND read_at IS NULL)
+		        + (SELECT count(*) FROM approvals
+		           WHERE team_id = $1 AND status = $3::approval_status)
+		        )::int AS unread`,
+		[teamId, auth.userId, ApprovalStatus.Pending],
+	);
+
+	return ok(c, { unread: result.rows[0]?.unread ?? 0 });
 });
 
 inboxRoutes.post('/teams/:teamId/inbox/mentions/:mentionId/read', async (c) => {

--- a/packages/server/src/routes/queued-wakeups.ts
+++ b/packages/server/src/routes/queued-wakeups.ts
@@ -177,6 +177,7 @@ queuedWakeupsRoutes.post(
 			const messages: Record<string, string> = {
 				task_busy: 'This ticket already has a run in progress',
 				project_at_capacity: 'This project is at its concurrent-run limit',
+				agent_busy: 'This agent is already running in this project',
 				blocked: 'This ticket is blocked by an open dependency',
 				not_queued: 'Wakeup is no longer queued and cannot be run',
 			};

--- a/packages/server/src/services/inbox-archive.ts
+++ b/packages/server/src/services/inbox-archive.ts
@@ -1,0 +1,30 @@
+import type { PGlite } from '@electric-sql/pglite';
+
+/**
+ * Archive inbox items that have been seen and were seen more than the retention
+ * window ago. Mentions are seen when read; approvals are seen when resolved.
+ * Returns the number of rows archived across both kinds.
+ */
+export async function archiveOldInboxItems(db: PGlite, retentionDays: number): Promise<number> {
+	const days = String(retentionDays);
+
+	const mentions = await db.query<{ id: string }>(
+		`UPDATE board_mentions SET archived_at = now()
+		 WHERE archived_at IS NULL
+		   AND read_at IS NOT NULL
+		   AND read_at < now() - ($1 || ' days')::interval
+		 RETURNING id`,
+		[days],
+	);
+
+	const approvals = await db.query<{ id: string }>(
+		`UPDATE approvals SET archived_at = now()
+		 WHERE archived_at IS NULL
+		   AND status <> 'pending'::approval_status
+		   AND COALESCE(resolved_at, created_at) < now() - ($1 || ' days')::interval
+		 RETURNING id`,
+		[days],
+	);
+
+	return mentions.rows.length + approvals.rows.length;
+}

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -109,6 +109,8 @@ export interface JobManagerDeps {
 const COALESCING_WINDOW_MS = Number(process.env.HEZO_WAKEUP_COALESCING_MS ?? 2_000);
 const WAKEUP_CRON = process.env.HEZO_WAKEUP_CRON ?? '*/5 * * * * *';
 const HEARTBEAT_CRON = process.env.HEZO_HEARTBEAT_CRON ?? '*/5 * * * * *';
+const INBOX_ARCHIVE_CRON = process.env.HEZO_INBOX_ARCHIVE_CRON ?? '0 0 3 * * *';
+const INBOX_RETENTION_DAYS = Number(process.env.HEZO_INBOX_RETENTION_DAYS ?? 30);
 // Lower bound on how often a heartbeat can fire, regardless of an agent's
 // configured `heartbeat_interval_min`. Defends against misconfigured low/zero
 // intervals producing a tight 5-second-cron loop on the same agent.
@@ -344,6 +346,11 @@ export class JobManager {
 			cron: '*/30 * * * * *',
 			log: cronLog,
 			onTick: () => this.guarded('embeddings', () => this.processEmbeddingQueue()),
+		});
+		this.cron.createJob('inbox-archive', {
+			cron: INBOX_ARCHIVE_CRON,
+			log: cronLog,
+			onTick: () => this.guarded('inbox-archive', () => this.archiveInboxItems()),
 		});
 		log.info('Job manager started.');
 	}
@@ -1593,6 +1600,14 @@ export class JobManager {
 		const count = await processPendingEmbeddings(this.deps.db);
 		if (count > 0) {
 			log.debug(`Processed ${count} embedding(s)`);
+		}
+	}
+
+	private async archiveInboxItems(): Promise<void> {
+		const { archiveOldInboxItems } = await import('./inbox-archive');
+		const count = await archiveOldInboxItems(this.deps.db, INBOX_RETENTION_DAYS);
+		if (count > 0) {
+			log.debug(`Archived ${count} inbox item(s)`);
 		}
 	}
 }

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -83,7 +83,13 @@ export type DispatchNowResult =
 	| { dispatched: true }
 	| {
 			dispatched: false;
-			reason: 'task_busy' | 'project_at_capacity' | 'blocked' | 'not_queued' | 'not_found';
+			reason:
+				| 'task_busy'
+				| 'project_at_capacity'
+				| 'agent_busy'
+				| 'blocked'
+				| 'not_queued'
+				| 'not_found';
 	  };
 
 export interface JobManagerDeps {
@@ -223,6 +229,16 @@ export class JobManager {
 				);
 				return { dispatched: false, reason: 'project_at_capacity' };
 			}
+			if (projectId && (await this.isAgentBusyInProject(wakeup.member_id, projectId))) {
+				await this.markWakeupSkipped(
+					wakeup.id,
+					WakeupSkipReason.AgentRunning,
+					wakeupTaskId,
+					wakeup.team_id,
+					null,
+				);
+				return { dispatched: false, reason: 'agent_busy' };
+			}
 			if (await shouldDeferWakeupForBlockers(db, wakeup.source, wakeupTaskId)) {
 				await db.query(
 					`UPDATE agent_wakeup_requests
@@ -332,8 +348,12 @@ export class JobManager {
 		log.info('Job manager started.');
 	}
 
-	launchTask(key: string, fn: (signal: AbortSignal) => Promise<unknown>, timeoutMs: number): void {
-		if (this.runningTasks.has(key)) return;
+	launchTask(
+		key: string,
+		fn: (signal: AbortSignal) => Promise<unknown>,
+		timeoutMs: number,
+	): boolean {
+		if (this.runningTasks.has(key)) return false;
 		const ac = new AbortController();
 
 		const timeoutId = setTimeout(() => {
@@ -355,6 +375,7 @@ export class JobManager {
 			startedAt: Date.now(),
 			timeoutId,
 		});
+		return true;
 	}
 
 	cancelTask(key: string, reason?: unknown): boolean {
@@ -660,6 +681,36 @@ export class JobManager {
 		return r.rows[0]?.project_id ?? null;
 	}
 
+	/** Return a claimed wakeup to the queue so a later dispatch can retry it. */
+	private async requeueWakeup(wakeupId: string | undefined): Promise<void> {
+		if (!wakeupId) return;
+		await this.deps.db.query(
+			'UPDATE agent_wakeup_requests SET status = $1::wakeup_status, claimed_at = NULL WHERE id = $2',
+			[WakeupStatus.Queued, wakeupId],
+		);
+	}
+
+	/**
+	 * True when this agent already has an in-flight run in the project. Dispatch
+	 * serialises per agent+project (the launchTask key), so a second run for the
+	 * same pair would be dropped — callers re-queue instead. The in-memory guard
+	 * leads the DB during the window between launch and the run row landing; the
+	 * `heartbeat_runs` query is authoritative once the row exists.
+	 */
+	private async isAgentBusyInProject(memberId: string, projectId: string): Promise<boolean> {
+		if (this.isTaskRunning(`${memberId}:${projectId}`)) return true;
+		const active = await this.deps.db.query(
+			`SELECT 1 FROM heartbeat_runs hr
+			 JOIN tasks t ON t.id = hr.task_id
+			 WHERE hr.member_id = $1
+			   AND t.project_id = $2
+			   AND hr.status IN ($3::heartbeat_run_status, $4::heartbeat_run_status)
+			 LIMIT 1`,
+			[memberId, projectId, HeartbeatRunStatus.Queued, HeartbeatRunStatus.Running],
+		);
+		return active.rows.length > 0;
+	}
+
 	private async processWakeups(): Promise<void> {
 		const { db } = this.deps;
 		const coalescingCutoff = new Date(Date.now() - COALESCING_WINDOW_MS).toISOString();
@@ -705,6 +756,19 @@ export class JobManager {
 					await this.markWakeupSkipped(
 						wakeup.id,
 						WakeupSkipReason.ProjectAtCapacity,
+						wakeupTaskId,
+						wakeup.team_id,
+						null,
+					);
+					continue;
+				}
+				if (projectId && (await this.isAgentBusyInProject(wakeup.member_id, projectId))) {
+					log.debug(
+						`Skipping wakeup ${wakeup.id} — agent ${wakeup.member_id} already running in project ${projectId}`,
+					);
+					await this.markWakeupSkipped(
+						wakeup.id,
+						WakeupSkipReason.AgentRunning,
 						wakeupTaskId,
 						wakeup.team_id,
 						null,
@@ -967,24 +1031,25 @@ export class JobManager {
 			log.debug(
 				`Task ${ref(task.identifier, task.id)} already has an active run — re-queuing wakeup for ${ref(agent.rows[0].slug, memberId)}`,
 			);
-			if (wakeupId) {
-				await db.query(
-					'UPDATE agent_wakeup_requests SET status = $1::wakeup_status, claimed_at = NULL WHERE id = $2',
-					[WakeupStatus.Queued, wakeupId],
-				);
-			}
+			await this.requeueWakeup(wakeupId);
 			return;
 		}
 		if (await this.isProjectAtCapacity(task.project_id)) {
 			log.debug(
 				`Project ${task.project_id} is at run capacity — re-queuing wakeup for ${ref(agent.rows[0].slug, memberId)}`,
 			);
-			if (wakeupId) {
-				await db.query(
-					'UPDATE agent_wakeup_requests SET status = $1::wakeup_status, claimed_at = NULL WHERE id = $2',
-					[WakeupStatus.Queued, wakeupId],
-				);
-			}
+			await this.requeueWakeup(wakeupId);
+			return;
+		}
+		// A given agent runs at most one task at a time within a project: dispatch
+		// serialises on the agent+project pair and a second concurrent run would be
+		// dropped. Re-queue before any lock or status side-effects so the wakeup
+		// fires once the in-flight run frees the slot.
+		if (await this.isAgentBusyInProject(memberId, task.project_id)) {
+			log.debug(
+				`Agent ${ref(agent.rows[0].slug, memberId)} already running in project ${task.project_id} — re-queuing wakeup`,
+			);
+			await this.requeueWakeup(wakeupId);
 			return;
 		}
 
@@ -1148,29 +1213,7 @@ export class JobManager {
 		this.activeTaskRuns.add(lockedTaskId);
 		this.acquireProjectRun(projectId);
 
-		// A run reads the full task context at boot, so any wakeup already queued
-		// for this agent+task is served by this run. Retire those siblings so they
-		// don't fire a redundant back-to-back run once the task frees up. Wakeups
-		// created later (new comments/assignments during the run) stay queued and
-		// correctly drive a follow-up run.
-		const absorbed = await absorbQueuedTaskWakeups(db, memberId, lockedTaskId, wakeupId);
-		if (absorbed.length > 0) {
-			const refreshed = await db.query<Record<string, unknown>>(
-				'SELECT * FROM tasks WHERE id = $1',
-				[lockedTaskId],
-			);
-			if (refreshed.rows[0]) {
-				broadcastRowChange(
-					this.deps.wsManager,
-					wsRoom.team(teamId),
-					'tasks',
-					'UPDATE',
-					refreshed.rows[0],
-				);
-			}
-		}
-
-		this.launchTask(
+		const launched = this.launchTask(
 			taskKey,
 			async (signal) => {
 				let registeredRunId: string | undefined;
@@ -1234,6 +1277,43 @@ export class JobManager {
 			},
 			timeoutMs,
 		);
+
+		if (!launched) {
+			// A concurrent dispatch already holds this agent's per-project run slot,
+			// so the launch was dropped. Undo the lock and status side-effects so the
+			// task badge doesn't stick, and re-queue for a later slot.
+			this.activeTaskRuns.delete(lockedTaskId);
+			this.releaseProjectRun(projectId);
+			await db.query(
+				'UPDATE execution_locks SET released_at = now() WHERE task_id = $1 AND member_id = $2 AND released_at IS NULL',
+				[lockedTaskId, memberId],
+			);
+			await setAgentIdleIfNoActiveRuns(db, memberId, teamId, undefined, this.deps.wsManager);
+			await this.requeueWakeup(wakeupId);
+			return;
+		}
+
+		// A run reads the full task context at boot, so any wakeup already queued
+		// for this agent+task is served by this run. Retire those siblings so they
+		// don't fire a redundant back-to-back run once the task frees up. Wakeups
+		// created later (new comments/assignments during the run) stay queued and
+		// correctly drive a follow-up run.
+		const absorbed = await absorbQueuedTaskWakeups(db, memberId, lockedTaskId, wakeupId);
+		if (absorbed.length > 0) {
+			const refreshed = await db.query<Record<string, unknown>>(
+				'SELECT * FROM tasks WHERE id = $1',
+				[lockedTaskId],
+			);
+			if (refreshed.rows[0]) {
+				broadcastRowChange(
+					this.deps.wsManager,
+					wsRoom.team(teamId),
+					'tasks',
+					'UPDATE',
+					refreshed.rows[0],
+				);
+			}
+		}
 	}
 
 	private async onAgentComplete(

--- a/packages/server/test/board-mentions.test.ts
+++ b/packages/server/test/board-mentions.test.ts
@@ -278,7 +278,7 @@ describe('@board fan-out via MCP create_comment', () => {
 });
 
 describe('GET /teams/:teamId/inbox/mentions', () => {
-	it('returns the caller-scoped unread mentions only', async () => {
+	it('returns the caller-scoped active mentions', async () => {
 		const taskIdLocal = await insertTask(captainId, 'Inbox listing test');
 		const { token: agentToken } = await mintAgentToken(
 			db,
@@ -304,8 +304,8 @@ describe('GET /teams/:teamId/inbox/mentions', () => {
 		expect(data[0].read_at).toBeNull();
 	});
 
-	it('omits read mentions by default but includes them with include_read=true', async () => {
-		const taskIdLocal = await insertTask(captainId, 'Read filter test');
+	it('returns active (non-archived) mentions by default; archived=true returns only archived', async () => {
+		const taskIdLocal = await insertTask(captainId, 'Archive filter test');
 		const { token: agentToken } = await mintAgentToken(
 			db,
 			masterKeyManager,
@@ -313,24 +313,84 @@ describe('GET /teams/:teamId/inbox/mentions', () => {
 			teamId,
 			taskIdLocal,
 		);
-		const commentId = await mcpComment(agentToken, taskIdLocal, '@board check this.');
+		const readCommentId = await mcpComment(agentToken, taskIdLocal, '@board read but active.');
+		const archivedCommentId = await mcpComment(agentToken, taskIdLocal, '@board archived already.');
 
 		await db.query(
 			`UPDATE board_mentions SET read_at = now() WHERE comment_id = $1 AND user_id = $2`,
-			[commentId, testAdminUserId],
+			[readCommentId, testAdminUserId],
+		);
+		await db.query(
+			`UPDATE board_mentions SET read_at = now(), archived_at = now()
+			 WHERE comment_id = $1 AND user_id = $2`,
+			[archivedCommentId, testAdminUserId],
 		);
 
-		const unreadOnly = await app.request(`/api/teams/${teamId}/inbox/mentions`, {
+		const active = await app.request(`/api/teams/${teamId}/inbox/mentions`, {
 			headers: authHeader(token),
 		});
-		const unread = (await unreadOnly.json()).data as Array<{ comment_id: string }>;
-		expect(unread.some((m) => m.comment_id === commentId)).toBe(false);
+		const activeRows = (await active.json()).data as Array<{ comment_id: string }>;
+		// A read-but-not-archived mention stays in the default view; archived is hidden.
+		expect(activeRows.some((m) => m.comment_id === readCommentId)).toBe(true);
+		expect(activeRows.some((m) => m.comment_id === archivedCommentId)).toBe(false);
 
-		const withRead = await app.request(`/api/teams/${teamId}/inbox/mentions?include_read=true`, {
+		const archivedRes = await app.request(`/api/teams/${teamId}/inbox/mentions?archived=true`, {
 			headers: authHeader(token),
 		});
-		const all = (await withRead.json()).data as Array<{ comment_id: string }>;
-		expect(all.some((m) => m.comment_id === commentId)).toBe(true);
+		const archivedRows = (await archivedRes.json()).data as Array<{ comment_id: string }>;
+		expect(archivedRows.some((m) => m.comment_id === archivedCommentId)).toBe(true);
+		expect(archivedRows.some((m) => m.comment_id === readCommentId)).toBe(false);
+	});
+});
+
+describe('GET /teams/:teamId/inbox/count', () => {
+	it('counts the caller-unread mentions plus pending approvals', async () => {
+		await db.query('DELETE FROM approvals WHERE team_id = $1', [teamId]);
+
+		const taskIdLocal = await insertTask(captainId, 'Count test');
+		const { token: agentToken } = await mintAgentToken(
+			db,
+			masterKeyManager,
+			architectId,
+			teamId,
+			taskIdLocal,
+		);
+		await mcpComment(agentToken, taskIdLocal, '@board first decision.');
+		const readComment = await mcpComment(agentToken, taskIdLocal, '@board second decision.');
+		await db.query(
+			`UPDATE board_mentions SET read_at = now() WHERE comment_id = $1 AND user_id = $2`,
+			[readComment, testAdminUserId],
+		);
+
+		await db.query(
+			`INSERT INTO approvals (team_id, type, requested_by_member_id, payload, status)
+			 VALUES ($1, 'strategy'::approval_type, $2, '{}'::jsonb, 'pending'::approval_status),
+			        ($1, 'strategy'::approval_type, $2, '{}'::jsonb, 'approved'::approval_status)`,
+			[teamId, architectId],
+		);
+
+		const res = await app.request(`/api/teams/${teamId}/inbox/count`, {
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		const data = (await res.json()).data as { unread: number };
+		// One unread mention (the read one is excluded) plus one pending approval.
+		expect(data.unread).toBe(2);
+	});
+
+	it('rejects non-board auth', async () => {
+		const taskIdLocal = await insertTask(captainId, 'Count auth test');
+		const { token: agentToken } = await mintAgentToken(
+			db,
+			masterKeyManager,
+			architectId,
+			teamId,
+			taskIdLocal,
+		);
+		const res = await app.request(`/api/teams/${teamId}/inbox/count`, {
+			headers: authHeader(agentToken),
+		});
+		expect(res.status).toBe(403);
 	});
 });
 
@@ -412,5 +472,73 @@ describe('reserved agent slug "board"', () => {
 		expect(res.status).toBe(201);
 		const body = (await res.json()) as { data: { slug: string } };
 		expect(body.data.slug).toBe('board-member');
+	});
+});
+
+describe('archiveOldInboxItems sweep', () => {
+	async function seedMention(readAtSql: string): Promise<string> {
+		const taskIdLocal = await insertTask(captainId, `Sweep ${Math.random()}`);
+		const comment = await db.query<{ id: string }>(
+			`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
+			 VALUES ($1, $2, 'text'::comment_content_type, '{"text":"sweep"}'::jsonb)
+			 RETURNING id`,
+			[taskIdLocal, architectId],
+		);
+		const mention = await db.query<{ id: string }>(
+			`INSERT INTO board_mentions (team_id, task_id, comment_id, user_id, read_at)
+			 VALUES ($1, $2, $3, $4, ${readAtSql})
+			 RETURNING id`,
+			[teamId, taskIdLocal, comment.rows[0].id, testAdminUserId],
+		);
+		return mention.rows[0].id;
+	}
+
+	async function seedApproval(status: string, resolvedAtSql: string): Promise<string> {
+		const r = await db.query<{ id: string }>(
+			`INSERT INTO approvals (team_id, type, requested_by_member_id, payload, status, resolved_at)
+			 VALUES ($1, 'strategy'::approval_type, $2, '{}'::jsonb, $3::approval_status, ${resolvedAtSql})
+			 RETURNING id`,
+			[teamId, architectId, status],
+		);
+		return r.rows[0].id;
+	}
+
+	const mentionArchived = async (id: string) =>
+		(
+			await db.query<{ archived_at: string | null }>(
+				'SELECT archived_at FROM board_mentions WHERE id = $1',
+				[id],
+			)
+		).rows[0].archived_at;
+	const approvalArchived = async (id: string) =>
+		(
+			await db.query<{ archived_at: string | null }>(
+				'SELECT archived_at FROM approvals WHERE id = $1',
+				[id],
+			)
+		).rows[0].archived_at;
+
+	it('archives only seen items past the retention window, and is idempotent', async () => {
+		await db.query('DELETE FROM approvals WHERE team_id = $1', [teamId]);
+
+		const oldMention = await seedMention(`now() - interval '40 days'`);
+		const recentMention = await seedMention(`now() - interval '10 days'`);
+		const unreadMention = await seedMention('NULL');
+		const oldApproval = await seedApproval('approved', `now() - interval '40 days'`);
+		const recentApproval = await seedApproval('denied', `now() - interval '10 days'`);
+		const pendingApproval = await seedApproval('pending', 'NULL');
+
+		const { archiveOldInboxItems } = await import('../src/services/inbox-archive');
+		const archived = await archiveOldInboxItems(db, 30);
+		expect(archived).toBe(2);
+
+		expect(await mentionArchived(oldMention)).not.toBeNull();
+		expect(await mentionArchived(recentMention)).toBeNull();
+		expect(await mentionArchived(unreadMention)).toBeNull();
+		expect(await approvalArchived(oldApproval)).not.toBeNull();
+		expect(await approvalArchived(recentApproval)).toBeNull();
+		expect(await approvalArchived(pendingApproval)).toBeNull();
+
+		expect(await archiveOldInboxItems(db, 30)).toBe(0);
 	});
 });

--- a/packages/server/test/job-manager.test.ts
+++ b/packages/server/test/job-manager.test.ts
@@ -61,7 +61,7 @@ describe('JobManager', () => {
 				resolve = r;
 			});
 
-			manager.launchTask(
+			const first = manager.launchTask(
 				'test:dup',
 				async () => {
 					callCount++;
@@ -69,7 +69,7 @@ describe('JobManager', () => {
 				},
 				LONG_TIMEOUT,
 			);
-			manager.launchTask(
+			const second = manager.launchTask(
 				'test:dup',
 				async () => {
 					callCount++;
@@ -77,6 +77,8 @@ describe('JobManager', () => {
 				LONG_TIMEOUT,
 			);
 
+			expect(first).toBe(true);
+			expect(second).toBe(false);
 			expect(callCount).toBe(1);
 			resolve!();
 			await new Promise((r) => setTimeout(r, 10));

--- a/packages/server/test/queued-wakeups.test.ts
+++ b/packages/server/test/queued-wakeups.test.ts
@@ -319,6 +319,36 @@ describe('POST /teams/:teamId/tasks/:taskId/queued-wakeups/:wakeupId/run-now', (
 		await clearRuns();
 	});
 
+	it('returns 409 and leaks no lock when the agent already runs in the project', async () => {
+		await clearWakeups(taskId);
+		await clearRuns();
+		await db.query('UPDATE projects SET max_concurrent_runs = 3 WHERE id = $1', [projectId]);
+		// The same agent is already running on a sibling task in this project, so
+		// its per agent+project dispatch slot is taken even though capacity remains.
+		const sibling = await createTask('Agent-busy Sibling');
+		await insertRunningRun(agentA, sibling);
+		const wakeupId = await insertQueuedWakeup(agentA, taskId, { source: 'mention' });
+
+		const res = await runNow(taskId, wakeupId);
+		expect(res.status).toBe(409);
+
+		const row = await db.query<{ status: string; last_skipped_reason: string | null }>(
+			'SELECT status, last_skipped_reason FROM agent_wakeup_requests WHERE id = $1',
+			[wakeupId],
+		);
+		expect(row.rows[0].status).toBe('queued');
+		expect(row.rows[0].last_skipped_reason).toBe('agent_running');
+
+		// The target task must not be left with an unreleased execution lock — that
+		// stale lock is what drives a phantom "agent is running" badge.
+		const locks = await db.query(
+			'SELECT id FROM execution_locks WHERE task_id = $1 AND released_at IS NULL',
+			[taskId],
+		);
+		expect(locks.rows.length).toBe(0);
+		await clearRuns();
+	});
+
 	it('returns 409 when the task has an open dependency and the wakeup source is gated', async () => {
 		await clearWakeups(taskId);
 		await clearRuns();

--- a/packages/web/src/components/approval-card.tsx
+++ b/packages/web/src/components/approval-card.tsx
@@ -230,11 +230,32 @@ interface ApprovalCardProps {
 const baseCardClass = 'block p-4 border border-border rounded-radius-md';
 const linkCardClass = `${baseCardClass} hover:bg-bg-subtle transition-colors`;
 
-function CardBody({ approval, showTeam }: { approval: Approval; showTeam: boolean }) {
+function CardBody({
+	approval,
+	showTeam,
+	unread,
+}: {
+	approval: Approval;
+	showTeam: boolean;
+	unread: boolean;
+}) {
+	const resolved = approval.status !== ApprovalStatus.Pending;
 	return (
 		<>
 			<div className="flex items-center gap-2 mb-1.5 flex-wrap">
+				{unread && (
+					<span
+						role="img"
+						aria-label="Unread"
+						className="w-2 h-2 rounded-full bg-primary shrink-0"
+					/>
+				)}
 				<Badge color={typeColors[approval.type] as 'gray'}>{approval.type.replace('_', ' ')}</Badge>
+				{resolved && (
+					<Badge color={approval.status === ApprovalStatus.Approved ? 'green' : 'red'}>
+						{approval.status}
+					</Badge>
+				)}
 				{showTeam && approval.team_name && (
 					<span className="text-xs text-text-muted">{approval.team_name}</span>
 				)}
@@ -245,6 +266,9 @@ function CardBody({ approval, showTeam }: { approval: Approval; showTeam: boolea
 			<div className="text-sm text-text-subtle break-words">
 				<ApprovalMessage approval={approval} />
 			</div>
+			{resolved && approval.resolution_note && (
+				<p className="text-xs text-text-muted mt-2">Note: {approval.resolution_note}</p>
+			)}
 		</>
 	);
 }
@@ -268,6 +292,17 @@ function resolveOauthDestination(approval: Approval) {
 export function ApprovalCard({ approval, showTeam = false }: ApprovalCardProps) {
 	const resolveApproval = useResolveApproval();
 	const [modalOpen, setModalOpen] = useState(false);
+	const unread = approval.status === ApprovalStatus.Pending;
+	const highlight = unread ? ' border-l-2 border-l-primary bg-bg-subtle' : '';
+
+	// Resolved approvals are inbox history: read-only, no actions or navigation.
+	if (!unread) {
+		return (
+			<div className={baseCardClass} data-testid="approval-card" data-unread={false}>
+				<CardBody approval={approval} showTeam={showTeam} unread={false} />
+			</div>
+		);
+	}
 
 	if (approval.type === ApprovalType.DesignatedRepoRequest) {
 		const reason = approval.payload.reason as string | undefined;
@@ -277,11 +312,12 @@ export function ApprovalCard({ approval, showTeam = false }: ApprovalCardProps) 
 				<>
 					<button
 						type="button"
-						className={`${linkCardClass} w-full text-left`}
+						className={`${linkCardClass}${highlight} w-full text-left`}
 						data-testid="approval-card"
+						data-unread={true}
 						onClick={() => setModalOpen(true)}
 					>
-						<CardBody approval={approval} showTeam={showTeam} />
+						<CardBody approval={approval} showTeam={showTeam} unread />
 					</button>
 					<RepoSetupApprovalModal
 						approval={approval}
@@ -297,17 +333,18 @@ export function ApprovalCard({ approval, showTeam = false }: ApprovalCardProps) 
 			<Link
 				to={dest.to as never}
 				params={dest.params as never}
-				className={linkCardClass}
+				className={`${linkCardClass}${highlight}`}
 				data-testid="approval-card"
+				data-unread={true}
 			>
-				<CardBody approval={approval} showTeam={showTeam} />
+				<CardBody approval={approval} showTeam={showTeam} unread />
 			</Link>
 		);
 	}
 
 	return (
-		<div className={baseCardClass} data-testid="approval-card">
-			<CardBody approval={approval} showTeam={showTeam} />
+		<div className={`${baseCardClass}${highlight}`} data-testid="approval-card" data-unread={true}>
+			<CardBody approval={approval} showTeam={showTeam} unread />
 			<div className="flex gap-2 mt-3">
 				<Button
 					size="sm"

--- a/packages/web/src/components/inbox-view.tsx
+++ b/packages/web/src/components/inbox-view.tsx
@@ -1,40 +1,112 @@
-import type { BoardMentionItem } from '@hezo/shared';
-import { Inbox } from 'lucide-react';
-import { type Approval, useAllPendingApprovals } from '../hooks/use-approvals';
+import { ApprovalStatus, type BoardMentionItem } from '@hezo/shared';
+import { Inbox, Search } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { type Approval, useAllApprovals } from '../hooks/use-approvals';
 import { useAllBoardMentions } from '../hooks/use-board-mentions';
 import { ApprovalCard } from './approval-card';
 import { MentionCard } from './mention-card';
 import { EmptyState } from './ui/empty-state';
+import { FilterPills } from './ui/filter-pills';
 
 interface InboxViewProps {
 	teamIds: string[];
 	scope: 'team' | 'global';
 }
 
+type ReadFilter = 'all' | 'unread' | 'read' | 'archived';
+
 type InboxRow =
-	| { kind: 'approval'; created_at: string; key: string; approval: Approval }
-	| { kind: 'mention'; created_at: string; key: string; mention: BoardMentionItem };
+	| {
+			kind: 'approval';
+			created_at: string;
+			key: string;
+			read: boolean;
+			search: string;
+			approval: Approval;
+	  }
+	| {
+			kind: 'mention';
+			created_at: string;
+			key: string;
+			read: boolean;
+			search: string;
+			mention: BoardMentionItem;
+	  };
+
+const READ_OPTIONS: { value: ReadFilter; label: string }[] = [
+	{ value: 'all', label: 'All' },
+	{ value: 'unread', label: 'Unread' },
+	{ value: 'read', label: 'Read' },
+	{ value: 'archived', label: 'Archived' },
+];
+
+function mentionSearch(m: BoardMentionItem): string {
+	return [m.task_identifier, m.task_title, m.author_slug, m.author_display_name, m.snippet]
+		.filter(Boolean)
+		.join(' ')
+		.toLowerCase();
+}
+
+function approvalSearch(a: Approval): string {
+	return [
+		a.type.replace(/_/g, ' '),
+		a.requested_by_name,
+		a.payload_member_name,
+		a.payload_project_name,
+		a.payload_task_identifier,
+	]
+		.filter(Boolean)
+		.join(' ')
+		.toLowerCase();
+}
 
 export function InboxView({ teamIds, scope }: InboxViewProps) {
-	const { data: approvals, isLoading: approvalsLoading } = useAllPendingApprovals(teamIds);
-	const { data: mentions, isLoading: mentionsLoading } = useAllBoardMentions(teamIds);
+	const [readFilter, setReadFilter] = useState<ReadFilter>('all');
+	const archivedView = readFilter === 'archived';
+	const { data: approvals, isLoading: approvalsLoading } = useAllApprovals(teamIds, {
+		archived: archivedView,
+	});
+	const { data: mentions, isLoading: mentionsLoading } = useAllBoardMentions(teamIds, {
+		archived: archivedView,
+	});
+	const [search, setSearch] = useState('');
+	const [debouncedSearch, setDebouncedSearch] = useState('');
+
+	useEffect(() => {
+		const handle = setTimeout(() => setDebouncedSearch(search.trim().toLowerCase()), 250);
+		return () => clearTimeout(handle);
+	}, [search]);
 
 	const isLoading = approvalsLoading || mentionsLoading;
 
-	const rows: InboxRow[] = [
-		...(approvals ?? []).map<InboxRow>((a) => ({
+	const rows = useMemo<InboxRow[]>(() => {
+		const approvalRows = (approvals ?? []).map<InboxRow>((a) => ({
 			kind: 'approval',
 			created_at: a.created_at,
 			key: `approval:${a.id}`,
+			read: a.status !== ApprovalStatus.Pending,
+			search: approvalSearch(a),
 			approval: a,
-		})),
-		...(mentions ?? []).map<InboxRow>((m) => ({
+		}));
+		const mentionRows = (mentions ?? []).map<InboxRow>((m) => ({
 			kind: 'mention',
 			created_at: m.created_at,
 			key: `mention:${m.id}`,
+			read: !!m.read_at,
+			search: mentionSearch(m),
 			mention: m,
-		})),
-	].sort((a, b) => (a.created_at < b.created_at ? 1 : -1));
+		}));
+		return [...approvalRows, ...mentionRows].sort((a, b) => (a.created_at < b.created_at ? 1 : -1));
+	}, [approvals, mentions]);
+
+	const filtered = useMemo(() => {
+		return rows.filter((row) => {
+			if (readFilter === 'unread' && row.read) return false;
+			if (readFilter === 'read' && !row.read) return false;
+			if (debouncedSearch && !row.search.includes(debouncedSearch)) return false;
+			return true;
+		});
+	}, [rows, readFilter, debouncedSearch]);
 
 	if (isLoading) {
 		return <div className="text-text-muted">Loading...</div>;
@@ -44,15 +116,40 @@ export function InboxView({ teamIds, scope }: InboxViewProps) {
 		<div>
 			<h1 className="text-[22px] font-medium mb-5">Inbox</h1>
 
+			<div className="flex flex-col gap-2 mb-4 sm:flex-row sm:items-center sm:justify-between">
+				<FilterPills options={READ_OPTIONS} value={readFilter} onChange={setReadFilter} />
+				<div className="relative sm:w-64">
+					<Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-text-subtle" />
+					<input
+						type="text"
+						value={search}
+						onChange={(e) => setSearch(e.target.value)}
+						placeholder="Search inbox..."
+						aria-label="Search inbox"
+						className="w-full rounded-radius-md border border-border bg-bg pl-8 pr-2.5 py-1.5 text-xs text-text placeholder:text-text-subtle focus:outline-none focus:ring-1 focus:ring-primary"
+					/>
+				</div>
+			</div>
+
 			{rows.length === 0 ? (
 				<EmptyState
 					icon={<Inbox className="w-10 h-10" />}
-					title="All clear"
-					description="No pending approvals or mentions."
+					title={archivedView ? 'No archived items' : 'All clear'}
+					description={
+						archivedView
+							? 'Items are archived 30 days after they are read or resolved.'
+							: 'No approvals or mentions yet.'
+					}
+				/>
+			) : filtered.length === 0 ? (
+				<EmptyState
+					icon={<Inbox className="w-10 h-10" />}
+					title="Nothing matches"
+					description="No inbox items match your filters."
 				/>
 			) : (
 				<div className="flex flex-col gap-3">
-					{rows.map((row) =>
+					{filtered.map((row) =>
 						row.kind === 'approval' ? (
 							<ApprovalCard key={row.key} approval={row.approval} showTeam={scope === 'global'} />
 						) : (

--- a/packages/web/src/components/mention-card.tsx
+++ b/packages/web/src/components/mention-card.tsx
@@ -42,15 +42,24 @@ export function MentionCard({ mention, showTeam = false }: MentionCardProps) {
 	};
 
 	const author = mention.author_slug ? `@${mention.author_slug}` : mention.author_display_name;
+	const unread = !mention.read_at;
 
 	return (
 		<button
 			type="button"
 			onClick={handleClick}
-			className={linkCardClass}
+			className={`${linkCardClass}${unread ? ' border-l-2 border-l-primary bg-bg-subtle' : ''}`}
 			data-testid="mention-card"
+			data-unread={unread}
 		>
 			<div className="flex items-center gap-2 mb-1.5 flex-wrap">
+				{unread && (
+					<span
+						role="img"
+						aria-label="Unread"
+						className="w-2 h-2 rounded-full bg-primary shrink-0"
+					/>
+				)}
 				<Badge color="blue">
 					<MessageSquare className="w-3 h-3 mr-1 inline" />
 					mention

--- a/packages/web/src/components/team-sidebar.tsx
+++ b/packages/web/src/components/team-sidebar.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from '@tanstack/react-router';
 import { Settings } from 'lucide-react';
 import { useState } from 'react';
 import { useAgents } from '../hooks/use-agents';
+import { useInboxUnreadCount } from '../hooks/use-inbox-count';
 import { useProjects } from '../hooks/use-projects';
 import { useRouteTeamId } from '../hooks/use-route-team-id';
 import { useTeam } from '../hooks/use-teams';
@@ -19,6 +20,7 @@ export function TeamSidebar() {
 	const { data: agents } = useAgents(teamId);
 	const { data: projects } = useProjects(teamId);
 	const { data: team } = useTeam(teamId);
+	const { data: inboxCount } = useInboxUnreadCount(teamId);
 	const { data: uiState } = useUiState(teamId);
 	const updateUiState = useUpdateUiState(teamId);
 	const [createProjectOpen, setCreateProjectOpen] = useState(false);
@@ -38,7 +40,15 @@ export function TeamSidebar() {
 
 	const sections: SidebarNavSection[] = [
 		{
-			items: [{ to: '/teams/$teamId/inbox', params, label: 'Inbox' }],
+			items: [
+				{
+					to: '/teams/$teamId/inbox',
+					params,
+					label: 'Inbox',
+					count: inboxCount?.unread,
+					testId: 'sidebar-link-inbox',
+				},
+			],
 		},
 		{
 			title: 'Work',

--- a/packages/web/src/hooks/use-approvals.ts
+++ b/packages/web/src/hooks/use-approvals.ts
@@ -15,6 +15,7 @@ export interface Approval {
 	payload: Record<string, unknown>;
 	resolution_note: string | null;
 	resolved_at: string | null;
+	archived_at: string | null;
 	created_at: string;
 	team_name: string;
 	team_slug: string;
@@ -39,15 +40,22 @@ export function useApprovals(
 	});
 }
 
-export function useAllPendingApprovals(teamSlugs: string[]) {
+const ALL_APPROVAL_STATUSES = [
+	ApprovalStatus.Pending,
+	ApprovalStatus.Approved,
+	ApprovalStatus.Denied,
+].join(',');
+
+export function useAllApprovals(teamSlugs: string[], { archived = false } = {}) {
 	const teamKey = [...teamSlugs].sort().join(',');
 	return useQuery({
-		queryKey: ['approvals', 'pending', teamKey],
+		queryKey: ['approvals', 'all', teamKey, { archived }],
 		queryFn: async () => {
 			const results = await Promise.all(
 				teamSlugs.map((slug) =>
 					api.get<Approval[]>(`/api/teams/${slug}/approvals`, {
-						status: ApprovalStatus.Pending,
+						status: ALL_APPROVAL_STATUSES,
+						archived: String(archived),
 					}),
 				),
 			);
@@ -84,22 +92,25 @@ export function useResolveApproval() {
 			teamSlug?: string;
 		}) => api.post(`/api/approvals/${approvalId}/resolve`, { status, resolution_note }),
 		onSuccess: (_data, variables) => {
-			// Always invalidate the cross-team aggregated pending list — it has no team scope.
-			queryClient.invalidateQueries({ queryKey: ['approvals', 'pending'] });
+			// Always invalidate the cross-team aggregated lists — they have no team scope.
+			queryClient.invalidateQueries({ queryKey: ['approvals'] });
 			if (variables.teamSlug) {
 				queryClient.invalidateQueries({
 					queryKey: ['teams', variables.teamSlug, 'approvals'],
 				});
+				queryClient.invalidateQueries({
+					queryKey: ['teams', variables.teamSlug, 'inbox-count'],
+				});
 				invalidateTeamAgentCaches(queryClient, variables.teamSlug);
 			} else {
 				// No team scope provided — fall back to a predicate that matches any team's
-				// approvals list, keyed `['teams', <slug>, 'approvals', ...]`.
+				// approvals list and inbox count, keyed `['teams', <slug>, 'approvals' | 'inbox-count']`.
 				queryClient.invalidateQueries({
 					predicate: (query) =>
 						Array.isArray(query.queryKey) &&
 						query.queryKey[0] === 'teams' &&
 						typeof query.queryKey[1] === 'string' &&
-						query.queryKey[2] === 'approvals',
+						(query.queryKey[2] === 'approvals' || query.queryKey[2] === 'inbox-count'),
 				});
 				invalidateAllTeamAgentCaches(queryClient);
 			}

--- a/packages/web/src/hooks/use-board-mentions.ts
+++ b/packages/web/src/hooks/use-board-mentions.ts
@@ -13,13 +13,17 @@ export function useBoardMentions(teamSlug: string, enabled = true) {
 	});
 }
 
-export function useAllBoardMentions(teamSlugs: string[]) {
+export function useAllBoardMentions(teamSlugs: string[], { archived = false } = {}) {
 	const teamKey = [...teamSlugs].sort().join(',');
 	return useQuery({
-		queryKey: ['inbox-mentions', teamKey],
+		queryKey: ['inbox-mentions', teamKey, { archived }],
 		queryFn: async () => {
 			const results = await Promise.all(
-				teamSlugs.map((slug) => api.get<BoardMentionItem[]>(`/api/teams/${slug}/inbox/mentions`)),
+				teamSlugs.map((slug) =>
+					api.get<BoardMentionItem[]>(`/api/teams/${slug}/inbox/mentions`, {
+						archived: String(archived),
+					}),
+				),
 			);
 			return results.flat();
 		},
@@ -48,7 +52,7 @@ export function useMarkMentionRead() {
 			if (teamSnapshot) {
 				queryClient.setQueryData<BoardMentionItem[]>(
 					['teams', teamSlug, 'inbox-mentions'],
-					teamSnapshot.filter((m) => m.id !== mentionId),
+					teamSnapshot.map((m) => (m.id === mentionId ? { ...m, read_at: now } : m)),
 				);
 			}
 
@@ -78,6 +82,7 @@ export function useMarkMentionRead() {
 		onSettled: (_data, _err, { teamSlug }) => {
 			queryClient.invalidateQueries({ queryKey: ['teams', teamSlug, 'inbox-mentions'] });
 			queryClient.invalidateQueries({ queryKey: ['inbox-mentions'] });
+			queryClient.invalidateQueries({ queryKey: ['teams', teamSlug, 'inbox-count'] });
 		},
 	});
 }
@@ -89,6 +94,7 @@ export function useMarkAllMentionsRead() {
 		onSuccess: (_data, teamSlug) => {
 			queryClient.invalidateQueries({ queryKey: ['teams', teamSlug, 'inbox-mentions'] });
 			queryClient.invalidateQueries({ queryKey: ['inbox-mentions'] });
+			queryClient.invalidateQueries({ queryKey: ['teams', teamSlug, 'inbox-count'] });
 		},
 	});
 }

--- a/packages/web/src/hooks/use-inbox-count.ts
+++ b/packages/web/src/hooks/use-inbox-count.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '../lib/api';
+
+export function useInboxUnreadCount(teamSlug: string, enabled = true) {
+	return useQuery({
+		queryKey: ['teams', teamSlug, 'inbox-count'],
+		queryFn: () => api.get<{ unread: number }>(`/api/teams/${teamSlug}/inbox/count`),
+		enabled: enabled && !!teamSlug,
+	});
+}

--- a/packages/web/src/hooks/use-websocket.ts
+++ b/packages/web/src/hooks/use-websocket.ts
@@ -54,8 +54,12 @@ const TABLE_TO_QUERY_KEY: Record<
 		['teams', cid, 'projects'],
 		['teams', cid, 'onboarding'],
 	],
-	approvals: (cid) => [['teams', cid, 'approvals'], ['approvals'], ['approvals', 'pending']],
-	board_mentions: (cid) => [['teams', cid, 'inbox-mentions'], ['inbox-mentions']],
+	approvals: (cid) => [['teams', cid, 'approvals'], ['teams', cid, 'inbox-count'], ['approvals']],
+	board_mentions: (cid) => [
+		['teams', cid, 'inbox-mentions'],
+		['teams', cid, 'inbox-count'],
+		['inbox-mentions'],
+	],
 	documents: (cid, row) => {
 		switch (row.type) {
 			case 'project_doc':

--- a/packages/web/test/inbox-approvals.test.tsx
+++ b/packages/web/test/inbox-approvals.test.tsx
@@ -31,7 +31,7 @@ test('inbox shows empty state when no approvals', async () => {
 	});
 
 	await findByText('All clear', undefined, { timeout: 10_000 });
-	await findByText(/No pending approvals/);
+	await findByText(/No approvals or mentions/);
 });
 
 test('inbox shows pending approval with type badge', async () => {
@@ -86,7 +86,9 @@ test('can approve a pending approval', async () => {
 
 	await findByText('Proposing to hire', undefined, { timeout: 10_000 });
 	await user.click(await findByRole('button', { name: 'Approve' }));
-	await findByText('All clear', undefined, { timeout: 15_000 });
+	// Resolved approvals stay in the inbox as read history with a status badge.
+	await findByText('approved', undefined, { timeout: 15_000 });
+	await findByText('Proposing to hire');
 });
 
 test('can deny a pending approval', async () => {
@@ -110,7 +112,9 @@ test('can deny a pending approval', async () => {
 
 	await findByText(/Requesting access to secret/, undefined, { timeout: 10_000 });
 	await user.click(await findByRole('button', { name: 'Deny' }));
-	await findByText('All clear', undefined, { timeout: 15_000 });
+	// Resolved approvals stay in the inbox as read history with a status badge.
+	await findByText('denied', undefined, { timeout: 15_000 });
+	await findByText(/Requesting access to secret/);
 });
 
 test('sidebar has Inbox link', async () => {

--- a/packages/web/test/inbox-mentions.test.tsx
+++ b/packages/web/test/inbox-mentions.test.tsx
@@ -1,3 +1,4 @@
+import { waitFor } from '@testing-library/react';
 import { expect, test } from 'vitest';
 import { getTestContext, renderApp } from './helpers/render';
 import {
@@ -8,6 +9,19 @@ import {
 	seedTask,
 	seedWorkspace,
 } from './helpers/seed';
+
+async function markMentionRead(mentionId: string): Promise<void> {
+	const { db } = getTestContext();
+	await db.query('UPDATE board_mentions SET read_at = now() WHERE id = $1', [mentionId]);
+}
+
+async function markMentionArchived(mentionId: string): Promise<void> {
+	const { db } = getTestContext();
+	await db.query(
+		'UPDATE board_mentions SET read_at = COALESCE(read_at, now()), archived_at = now() WHERE id = $1',
+		[mentionId],
+	);
+}
 
 async function seedAgentBoardMention(
 	workspace: SeededWorkspace,
@@ -133,4 +147,142 @@ test('clicking a mention navigates to the task and marks it read', async () => {
 		updated = again.rows[0]?.read_at;
 	}
 	expect(updated).not.toBeNull();
+});
+
+test('inbox shows read mentions as history and highlights unread ones', async () => {
+	let ctx: { teamSlug: string };
+	const { findAllByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Demo' });
+			const unreadTask = await seedTask(ws, project, { title: 'Unread ticket' });
+			const readTask = await seedTask(ws, project, { title: 'Read ticket' });
+			await seedAgentBoardMention(ws, unreadTask, '@board fresh decision needed.');
+			const { mentionId } = await seedAgentBoardMention(ws, readTask, '@board already handled.');
+			await markMentionRead(mentionId);
+			ctx = { teamSlug: ws.team.slug };
+		},
+	});
+
+	await router.navigate({
+		to: '/teams/$teamId/inbox',
+		params: { teamId: ctx!.teamSlug },
+	});
+
+	await waitFor(async () => expect((await findAllByTestId('mention-card')).length).toBe(2), {
+		timeout: 10_000,
+	});
+	const cards = await findAllByTestId('mention-card');
+	const flags = cards.map((c) => c.getAttribute('data-unread')).sort();
+	expect(flags).toEqual(['false', 'true']);
+});
+
+test('read/unread filter and keyword search narrow the inbox', async () => {
+	let ctx: { teamSlug: string };
+	const { findAllByTestId, findByText, findByLabelText, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Demo' });
+			const unreadTask = await seedTask(ws, project, { title: 'Apple ticket' });
+			const readTask = await seedTask(ws, project, { title: 'Banana ticket' });
+			await seedAgentBoardMention(ws, unreadTask, '@board apple decision.');
+			const { mentionId } = await seedAgentBoardMention(ws, readTask, '@board banana decision.');
+			await markMentionRead(mentionId);
+			ctx = { teamSlug: ws.team.slug };
+		},
+	});
+
+	await router.navigate({
+		to: '/teams/$teamId/inbox',
+		params: { teamId: ctx!.teamSlug },
+	});
+
+	await waitFor(async () => expect((await findAllByTestId('mention-card')).length).toBe(2), {
+		timeout: 10_000,
+	});
+
+	// Unread filter keeps only the unread card.
+	await user.click(await findByText('Unread'));
+	await waitFor(async () => {
+		const cards = await findAllByTestId('mention-card');
+		expect(cards.length).toBe(1);
+		expect(cards[0].getAttribute('data-unread')).toBe('true');
+	});
+
+	// Read filter keeps only the read card.
+	await user.click(await findByText('Read'));
+	await waitFor(async () => {
+		const cards = await findAllByTestId('mention-card');
+		expect(cards.length).toBe(1);
+		expect(cards[0].getAttribute('data-unread')).toBe('false');
+	});
+
+	// Back to all, then keyword search narrows to the matching ticket.
+	await user.click(await findByText('All'));
+	await waitFor(async () => expect((await findAllByTestId('mention-card')).length).toBe(2));
+	const searchBox = await findByLabelText('Search inbox');
+	await user.type(searchBox, 'banana');
+	await waitFor(async () => {
+		const cards = await findAllByTestId('mention-card');
+		expect(cards.length).toBe(1);
+		expect(cards[0].getAttribute('data-unread')).toBe('false');
+	});
+});
+
+test('archived mentions are hidden by default and shown under the Archived filter', async () => {
+	let ctx: { teamSlug: string };
+	const { findAllByTestId, findByText, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Demo' });
+			const activeTask = await seedTask(ws, project, { title: 'Active ticket' });
+			const archivedTask = await seedTask(ws, project, { title: 'Archived ticket' });
+			const active = await seedAgentBoardMention(ws, activeTask, '@board active decision.');
+			await markMentionRead(active.mentionId);
+			const archived = await seedAgentBoardMention(ws, archivedTask, '@board old decision.');
+			await markMentionArchived(archived.mentionId);
+			ctx = { teamSlug: ws.team.slug };
+		},
+	});
+
+	await router.navigate({
+		to: '/teams/$teamId/inbox',
+		params: { teamId: ctx!.teamSlug },
+	});
+
+	// Default view shows only the active (non-archived) mention.
+	await findByText(/active decision/, undefined, { timeout: 10_000 });
+	await waitFor(async () => expect((await findAllByTestId('mention-card')).length).toBe(1));
+
+	// The Archived filter reveals the archived mention and hides the active one.
+	await user.click(await findByText('Archived'));
+	await findByText(/old decision/, undefined, { timeout: 10_000 });
+	await waitFor(async () => expect((await findAllByTestId('mention-card')).length).toBe(1));
+});
+
+test('sidebar inbox link shows the unread count badge', async () => {
+	let ctx: { teamSlug: string };
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Demo' });
+			const t1 = await seedTask(ws, project, { title: 'Decision one' });
+			const t2 = await seedTask(ws, project, { title: 'Decision two' });
+			await seedAgentBoardMention(ws, t1, '@board decision one.');
+			await seedAgentBoardMention(ws, t2, '@board decision two.');
+			ctx = { teamSlug: ws.team.slug };
+		},
+	});
+
+	await router.navigate({
+		to: '/teams/$teamId/projects',
+		params: { teamId: ctx!.teamSlug },
+	});
+
+	const link = await findByTestId('sidebar-link-inbox', undefined, { timeout: 10_000 });
+	await waitFor(() => expect(link.textContent).toContain('2'));
 });

--- a/packages/web/test/project-crud.test.tsx
+++ b/packages/web/test/project-crud.test.tsx
@@ -102,7 +102,7 @@ test('project list shows task and repo counts', async () => {
 	const card = within(main).getByRole('link', { name: new RegExp(name) });
 	expect(card.textContent).toMatch(/0 tasks/);
 	expect(card.textContent).toMatch(/0 repos/);
-});
+}, 60_000);
 
 test('project card links to project detail', async () => {
 	let ws!: SeededWorkspace;
@@ -130,7 +130,7 @@ test('project card links to project detail', async () => {
 	expect(router.state.location.pathname).toMatch(
 		new RegExp(`^/teams/${ws.team.slug}/projects/${projectSlug}(?:/tasks)?$`),
 	);
-});
+}, 60_000);
 
 test('initial PRD passed at creation is persisted as project doc', async () => {
 	let ws!: SeededWorkspace;
@@ -202,7 +202,7 @@ test('initial PRD passed at creation is persisted as project doc', async () => {
 	expect(docBody).toBeTruthy();
 	expect(docBody!.content).toBe(prdContent);
 	expect(docBody!.filename).toBe('initial-prd.md');
-});
+}, 60_000);
 
 test('Create button stays disabled until both name and description are filled', async () => {
 	let ws!: SeededWorkspace;

--- a/packages/web/test/repo-setup-approval.test.tsx
+++ b/packages/web/test/repo-setup-approval.test.tsx
@@ -85,9 +85,10 @@ test('inbox card opens popup listing every blocked ticket', async () => {
 		params: { teamId: seed.ws.team.slug },
 	});
 
+	// The inbox also surfaces the resolved project-creation approval from seeding as
+	// read history; the pending repo-setup request is newest, so it sorts first.
 	const cards = await findAllByTestId('approval-card', undefined, { timeout: 15_000 });
 	expect(cards.length).toBeGreaterThan(0);
-	expect(cards.length).toBe(1);
 
 	await user.click(cards[0]);
 


### PR DESCRIPTION
… running in a project

Dispatch serialises per agent+project, but activateAgent created the execution lock and set the agent active before launchTask, which silently dropped a second concurrent run for the same pair. The lock's only release path lived inside the dropped callback, so it leaked — surfacing as a phantom "agent is running" badge while the agent sat idle with no visible run.

Add an isAgentBusyInProject guard (in-memory dispatch slot plus an authoritative heartbeat_runs check, scoped to agent and project) across all three dispatch paths: processWakeups, dispatchWakeupNow (new agent_busy reason), and activateAgent. launchTask now reports when it drops a launch so activateAgent can roll back the lock, run refcounts, agent status, and re-queue the wakeup on the cross-path race. Extract requeueWakeup to de-duplicate the inline re-queues.