### PR TITLE
feat: HTML project doc previews + per-agent busy flag on queued wakeups

### DIFF
--- a/agents/software-development/ui-designer.md
+++ b/agents/software-development/ui-designer.md
@@ -24,7 +24,7 @@ You own the visual and interaction layer. You create HTML preview mockups for bo
 You are step 4 in the UI-work ticket flow (after Researcher, Product Lead, Architect; before Engineer), and review again at step 6 (after the Engineer implements).
 
 1. **Plan review.** When the Architect posts a technical spec and @-mentions you, review the PRD and spec.
-2. **Mockups.** Create HTML preview mockups and post them as `preview` comments on the ticket. Previews appear in the board inbox for approval; the board can approve directly or delegate approval to the Product Lead.
+2. **Mockups.** Build the mockup as a self-contained, interactive HTML file that demonstrates the real interactions and renders at mobile, tablet, and desktop widths, and save it with `write_project_doc` (e.g. `ui-mockups.html`). Then post one `create_comment` that `@board`, linking the mockup file and `ui-design-decisions.md`, stating concretely what you need reviewed and listing any open design questions. The board is the sole reviewer and approver of mockups — do not route mockup approval to the Architect or any other teammate. After posting, stop your turn and leave the ticket in a non-terminal status; the board's reply wakes you.
 3. **Iterate** on board feedback.
 4. **Component specs.** Once designs are approved, provide component specs for the Engineer covering:
    - Layout and spacing

--- a/packages/server/src/routes/queued-wakeups.ts
+++ b/packages/server/src/routes/queued-wakeups.ts
@@ -6,7 +6,11 @@ import { resolveActorMemberId, resolveTaskId } from '../lib/resolve';
 import { err, ok } from '../lib/response';
 import type { Env } from '../lib/types';
 import { logger } from '../logger';
-import { isProjectAtCapacityInDb, isTaskBusyInDb } from '../services/run-concurrency';
+import {
+	getBusyAgentIdsInProject,
+	isProjectAtCapacityInDb,
+	isTaskBusyInDb,
+} from '../services/run-concurrency';
 import { recordWakeupCancelled, recordWakeupStarted } from '../services/task-events';
 
 const log = logger.child('routes');
@@ -59,9 +63,17 @@ queuedWakeupsRoutes.get('/teams/:teamId/tasks/:taskId/queued-wakeups', async (c)
 		projectAtCapacity = true;
 	}
 
+	// agent_busy is per-agent (each wakeup has its own member), so it lives on
+	// the wakeup rather than the shared dispatch state. One query for the whole
+	// project; per-wakeup is a set membership check.
+	const busyAgentIds = projectId
+		? await getBusyAgentIdsInProject(db, projectId)
+		: new Set<string>();
+
 	const wakeups = await Promise.all(
 		result.rows.map(async (w) => ({
 			...w,
+			agent_busy: busyAgentIds.has(w.member_id),
 			run_now_blocked: (await shouldDeferWakeupForBlockers(db, w.source, taskId))
 				? ('blocked_by_dependency' as const)
 				: null,
@@ -177,7 +189,7 @@ queuedWakeupsRoutes.post(
 			const messages: Record<string, string> = {
 				task_busy: 'This ticket already has a run in progress',
 				project_at_capacity: 'This project is at its concurrent-run limit',
-				agent_busy: 'This agent is already running in this project',
+				agent_busy: 'This agent is currently running on another task in this project',
 				blocked: 'This ticket is blocked by an open dependency',
 				not_queued: 'Wakeup is no longer queued and cannot be run',
 			};

--- a/packages/server/src/services/run-concurrency.ts
+++ b/packages/server/src/services/run-concurrency.ts
@@ -58,3 +58,22 @@ export async function isProjectAtCapacityInDb(db: PGlite, projectId: string): Pr
 	const { limit, active } = await getProjectConcurrency(db, projectId);
 	return active >= limit;
 }
+
+/**
+ * Member ids with an active (queued/running) run anywhere in the project — the
+ * set whose per-agent dispatch slot is taken. The stateless run-now route uses
+ * this to mirror `JobManager.isAgentBusyInProject` minus its in-memory guard.
+ */
+export async function getBusyAgentIdsInProject(
+	db: PGlite,
+	projectId: string,
+): Promise<Set<string>> {
+	const res = await db.query<{ member_id: string }>(
+		`SELECT DISTINCT hr.member_id FROM heartbeat_runs hr
+		 JOIN tasks t ON t.id = hr.task_id
+		 WHERE t.project_id = $1
+		   AND hr.status IN ($2::heartbeat_run_status, $3::heartbeat_run_status)`,
+		[projectId, HeartbeatRunStatus.Queued, HeartbeatRunStatus.Running],
+	);
+	return new Set(res.rows.map((r) => r.member_id));
+}

--- a/packages/server/test/queued-wakeups.test.ts
+++ b/packages/server/test/queued-wakeups.test.ts
@@ -114,6 +114,7 @@ interface WakeupRow {
 	created_at: string;
 	coalesced_count: number;
 	last_skipped_reason: string | null;
+	agent_busy: boolean;
 	run_now_blocked: 'blocked_by_dependency' | null;
 }
 
@@ -242,6 +243,26 @@ describe('GET /teams/:teamId/tasks/:taskId/queued-wakeups', () => {
 		expect(byId[gated].run_now_blocked).toBe('blocked_by_dependency');
 		expect(byId[ungated].run_now_blocked).toBeNull();
 		await clearBlockers(taskId);
+	});
+
+	it('flags agent_busy per agent when that agent runs on another task in the project', async () => {
+		await clearWakeups(taskId);
+		await clearRuns();
+		await db.query('UPDATE projects SET max_concurrent_runs = 3 WHERE id = $1', [projectId]);
+		// Agent Alpha is running on a sibling task, so its dispatch slot is taken
+		// even though the project still has capacity. Agent Beta is free.
+		const sibling = await createTask('Agent-busy GET Sibling');
+		await insertRunningRun(agentA, sibling);
+		const busy = await insertQueuedWakeup(agentA, taskId, { source: 'mention' });
+		const free = await insertQueuedWakeup(agentB, taskId, { source: 'mention' });
+
+		const { body } = await listQueued(taskId);
+		const byId = Object.fromEntries(body.data.wakeups.map((w) => [w.id, w]));
+		expect(byId[busy].agent_busy).toBe(true);
+		expect(byId[free].agent_busy).toBe(false);
+		expect(body.data.dispatch.task_busy).toBe(false);
+		expect(body.data.dispatch.project_at_capacity).toBe(false);
+		await clearRuns();
 	});
 });
 

--- a/packages/web/src/components/docs-library.tsx
+++ b/packages/web/src/components/docs-library.tsx
@@ -1,5 +1,6 @@
 import { ArrowLeft, FileText, Loader2, Plus, Trash2 } from 'lucide-react';
 import { type ReactNode, useEffect, useRef, useState } from 'react';
+import { HtmlPreview } from './html-preview';
 import { MarkdownProse } from './markdown-prose';
 import { MentionTextarea } from './mention-textarea';
 import { Button } from './ui/button';
@@ -24,6 +25,8 @@ interface DocsLibraryProps {
 	isLoadingDoc?: boolean;
 	/** Heading shown for the loaded doc; falls back to the items entry or selectedKey. */
 	docTitle?: ReactNode;
+	/** Controls how the doc body renders in view mode. Defaults to markdown. */
+	docFormat?: 'markdown' | 'html';
 
 	onSave: (content: string) => Promise<void> | void;
 	isSaving?: boolean;
@@ -50,6 +53,7 @@ export function DocsLibrary({
 	docContent,
 	isLoadingDoc,
 	docTitle,
+	docFormat = 'markdown',
 	onSave,
 	isSaving,
 	onDelete,
@@ -63,6 +67,7 @@ export function DocsLibrary({
 	projectSlug,
 }: DocsLibraryProps) {
 	const [mode, setMode] = useState<'view' | 'edit'>('view');
+	const [viewFormat, setViewFormat] = useState<'preview' | 'source'>('preview');
 	const [modeKey, setModeKey] = useState<string | null>(selectedKey);
 	const [draft, setDraft] = useState('');
 	const [deleteOpen, setDeleteOpen] = useState(false);
@@ -71,6 +76,7 @@ export function DocsLibrary({
 	if (modeKey !== selectedKey) {
 		setModeKey(selectedKey);
 		setMode('view');
+		setViewFormat('preview');
 	}
 
 	useEffect(() => {
@@ -176,6 +182,24 @@ export function DocsLibrary({
 							<div className="flex items-center gap-2 shrink-0">
 								{mode === 'view' ? (
 									<>
+										{docFormat === 'html' && (
+											<div className="flex items-center rounded-radius-md border border-border p-0.5">
+												{(['preview', 'source'] as const).map((fmt) => (
+													<button
+														key={fmt}
+														type="button"
+														onClick={() => setViewFormat(fmt)}
+														className={`px-2 py-0.5 text-[12px] rounded-radius-sm capitalize transition-colors ${
+															viewFormat === fmt
+																? 'bg-bg-subtle text-text'
+																: 'text-text-muted hover:text-text'
+														}`}
+													>
+														{fmt}
+													</button>
+												))}
+											</div>
+										)}
 										<Button variant="ghost" size="sm" onClick={() => setMode('edit')}>
 											Edit
 										</Button>
@@ -206,9 +230,22 @@ export function DocsLibrary({
 						</div>
 
 						{mode === 'view' ? (
-							<MarkdownProse teamId={teamId} projectSlug={projectSlug}>
-								{docContent || '_(empty)_'}
-							</MarkdownProse>
+							docFormat === 'html' ? (
+								viewFormat === 'preview' ? (
+									<HtmlPreview
+										html={docContent || ''}
+										title={String(docTitle ?? 'Document preview')}
+									/>
+								) : (
+									<pre className="overflow-auto rounded-radius-md border border-border bg-bg-muted p-3 text-xs font-mono text-text whitespace-pre-wrap break-words">
+										{docContent || ''}
+									</pre>
+								)
+							) : (
+								<MarkdownProse teamId={teamId} projectSlug={projectSlug}>
+									{docContent || '_(empty)_'}
+								</MarkdownProse>
+							)
 						) : (
 							<MentionTextarea
 								teamId={teamId}

--- a/packages/web/src/components/html-preview.tsx
+++ b/packages/web/src/components/html-preview.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useRef, useState } from 'react';
+
+const MIN_HEIGHT = 300;
+
+// Posts the document height to the parent on load and whenever the content
+// resizes, so the parent can size the iframe to fit without an inner scrollbar.
+const HEIGHT_REPORTER = `<script>
+(function () {
+  function report() {
+    var h = Math.max(
+      document.documentElement.scrollHeight,
+      document.body ? document.body.scrollHeight : 0
+    );
+    parent.postMessage({ __hezoHtmlPreviewHeight: h }, '*');
+  }
+  window.addEventListener('load', report);
+  if (window.ResizeObserver) {
+    new ResizeObserver(report).observe(document.documentElement);
+  }
+  report();
+})();
+</script>`;
+
+interface HtmlPreviewProps {
+	html: string;
+	title?: string;
+}
+
+export function HtmlPreview({ html, title = 'Document preview' }: HtmlPreviewProps) {
+	const iframeRef = useRef<HTMLIFrameElement>(null);
+	const [height, setHeight] = useState(MIN_HEIGHT);
+
+	useEffect(() => {
+		function onMessage(e: MessageEvent) {
+			if (e.source !== iframeRef.current?.contentWindow) return;
+			const reported = (e.data as { __hezoHtmlPreviewHeight?: number })?.__hezoHtmlPreviewHeight;
+			if (typeof reported === 'number' && Number.isFinite(reported)) {
+				setHeight(Math.max(MIN_HEIGHT, Math.ceil(reported)));
+			}
+		}
+		window.addEventListener('message', onMessage);
+		return () => window.removeEventListener('message', onMessage);
+	}, []);
+
+	return (
+		<iframe
+			ref={iframeRef}
+			title={title}
+			// Scripts run, but the opaque origin (no allow-same-origin) keeps the
+			// frame from reaching the parent DOM, cookies, or storage.
+			sandbox="allow-scripts"
+			srcDoc={`${html}${HEIGHT_REPORTER}`}
+			className="w-full bg-white rounded-radius-md border border-border"
+			style={{ height, maxHeight: '80vh' }}
+		/>
+	);
+}

--- a/packages/web/src/components/task-detail/queued-agents-list.tsx
+++ b/packages/web/src/components/task-detail/queued-agents-list.tsx
@@ -20,6 +20,7 @@ interface QueuedAgentsListProps {
 function runNowBlockReason(wakeup: QueuedWakeup, dispatch: QueuedDispatchState): string | null {
 	if (dispatch.task_busy) return 'This ticket already has a run in progress';
 	if (dispatch.project_at_capacity) return 'Project is at its concurrent-run limit';
+	if (wakeup.agent_busy) return 'This agent is currently running on another task in this project';
 	if (wakeup.run_now_blocked === 'blocked_by_dependency') return 'Blocked by an open dependency';
 	return null;
 }

--- a/packages/web/src/hooks/use-queued-wakeups.ts
+++ b/packages/web/src/hooks/use-queued-wakeups.ts
@@ -9,6 +9,8 @@ export interface QueuedWakeup {
 	created_at: string;
 	coalesced_count: number;
 	last_skipped_reason: string | null;
+	/** This agent already has an active run on another task in the same project. */
+	agent_busy: boolean;
 	/** Set when the wakeup's source is gated and the task has open dependency blockers. */
 	run_now_blocked: 'blocked_by_dependency' | null;
 }

--- a/packages/web/src/routes/teams/$teamId/projects/$projectId/documents.tsx
+++ b/packages/web/src/routes/teams/$teamId/projects/$projectId/documents.tsx
@@ -64,6 +64,7 @@ function ProjectDocumentsPage() {
 	}, [agentsMd, docs]);
 
 	const docContent = isAgentsMd ? (agentsMd?.content ?? null) : (doc?.content ?? null);
+	const docFormat = file && !isAgentsMd && /\.html?$/i.test(file) ? 'html' : 'markdown';
 
 	function selectFile(key: string | null) {
 		navigate({
@@ -98,6 +99,7 @@ function ProjectDocumentsPage() {
 			docContent={docContent}
 			isLoadingDoc={isLoadingDoc}
 			docTitle={isAgentsMd ? 'AGENTS.md' : (file ?? undefined)}
+			docFormat={docFormat}
 			onSave={handleSave}
 			isSaving={updateDoc.isPending || updateAgentsMd.isPending}
 			onDelete={handleDelete}
@@ -173,12 +175,14 @@ function NewProjectDocForm({
 	const [content, setContent] = useState('');
 	const [error, setError] = useState<string | null>(null);
 
+	const isHtml = /\.html?$/i.test(filename.trim());
+
 	async function handleSubmit(e: React.FormEvent) {
 		e.preventDefault();
 		const name = filename.trim();
-		if (!/^[a-z0-9][a-z0-9._-]*\.md$/i.test(name)) {
+		if (!/^[a-z0-9][a-z0-9._-]*\.(md|html?)$/i.test(name)) {
 			setError(
-				'Filename must end with .md and contain only letters, digits, dot, dash, underscore',
+				'Filename must end with .md or .html and contain only letters, digits, dot, dash, underscore',
 			);
 			return;
 		}
@@ -191,7 +195,7 @@ function NewProjectDocForm({
 			<h2 className="text-base font-semibold">New document</h2>
 			<Input
 				label="Filename"
-				placeholder="notes.md"
+				placeholder="notes.md or mockup.html"
 				value={filename}
 				onChange={(e) => setFilename(e.target.value)}
 				required
@@ -199,7 +203,7 @@ function NewProjectDocForm({
 			<MentionTextarea
 				teamId={teamId}
 				projectSlug={projectSlug}
-				label="Content (Markdown)"
+				label={isHtml ? 'Content (HTML)' : 'Content (Markdown)'}
 				value={content}
 				onChange={(e) => setContent(e.target.value)}
 				className="min-h-[300px] font-mono text-xs"

--- a/packages/web/test/project-docs-html.test.tsx
+++ b/packages/web/test/project-docs-html.test.tsx
@@ -1,0 +1,86 @@
+import { expect, test } from 'vitest';
+import { getTestContext, renderApp } from './helpers/render';
+import {
+	type SeededProject,
+	type SeededWorkspace,
+	seedProject,
+	seedWorkspace,
+} from './helpers/seed';
+
+async function seedDoc(
+	ws: SeededWorkspace,
+	project: SeededProject,
+	filename: string,
+	content: string,
+): Promise<void> {
+	const { apiBase } = getTestContext();
+	await apiBase(`/api/teams/${ws.team.id}/projects/${project.slug}/docs/${filename}`, {
+		method: 'PUT',
+		headers: ws.headers,
+		body: JSON.stringify({ content }),
+	});
+}
+
+const HTML_BODY =
+	'<!DOCTYPE html><html><head><style>h1{color:red}</style></head><body><h1>Mockup heading</h1></body></html>';
+
+test('renders an .html project doc in a sandboxed preview iframe with a source toggle', async () => {
+	let ctx!: { teamSlug: string; projectSlug: string };
+	const { container, findByText, getByText, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Docs Demo' });
+			await seedDoc(ws, project, 'ui-mockups.html', HTML_BODY);
+			ctx = { teamSlug: ws.team.slug, projectSlug: project.slug };
+		},
+	});
+
+	await router.navigate({
+		to: '/teams/$teamId/projects/$projectId/documents',
+		params: { teamId: ctx.teamSlug, projectId: ctx.projectSlug },
+		search: { file: 'ui-mockups.html' },
+	});
+
+	// Preview is the default: a sandboxed iframe carrying the doc in srcDoc.
+	await findByText('ui-mockups.html');
+	const iframe = await waitForIframe(container);
+	expect(iframe.getAttribute('sandbox')).toBe('allow-scripts');
+	expect(iframe.getAttribute('srcdoc')).toContain('Mockup heading');
+
+	// Flipping to Source swaps the iframe for the raw HTML text.
+	await user.click(getByText('source'));
+	await findByText(HTML_BODY, { exact: false });
+	expect(container.querySelector('iframe')).toBeNull();
+});
+
+test('renders an .md project doc as markdown, not an iframe', async () => {
+	let ctx!: { teamSlug: string; projectSlug: string };
+	const { container, findByText, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Docs Demo MD' });
+			await seedDoc(ws, project, 'notes.md', '# Hello markdown');
+			ctx = { teamSlug: ws.team.slug, projectSlug: project.slug };
+		},
+	});
+
+	await router.navigate({
+		to: '/teams/$teamId/projects/$projectId/documents',
+		params: { teamId: ctx.teamSlug, projectId: ctx.projectSlug },
+		search: { file: 'notes.md' },
+	});
+
+	await findByText('Hello markdown');
+	expect(container.querySelector('iframe')).toBeNull();
+});
+
+async function waitForIframe(container: HTMLElement): Promise<HTMLIFrameElement> {
+	for (let i = 0; i < 50; i++) {
+		const el = container.querySelector('iframe');
+		if (el) return el as HTMLIFrameElement;
+		await new Promise((r) => setTimeout(r, 20));
+	}
+	throw new Error('iframe never appeared');
+}

--- a/packages/web/test/queued-agents.test.tsx
+++ b/packages/web/test/queued-agents.test.tsx
@@ -161,6 +161,56 @@ test('disables run-now with a capacity reason when the project is at its run lim
 	expect(playBtn.getAttribute('aria-label')).toMatch(/concurrent-run limit/i);
 });
 
+test('disables run-now when the queued agent is already running on another task in the project', async () => {
+	const seeded = { teamSlug: '', taskId: '', wakeupId: '' };
+
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async (ctx) => {
+			const ws = await seedWorkspace();
+			const captain = ws.agents.find((a) => a.slug === 'captain') ?? ws.agents[0];
+			const queuedAgent = ws.agents.find((a) => a.id !== captain.id) ?? ws.agents[0];
+			const project = await seedProject(ws, { name: 'Agent Busy Demo' });
+			// Plenty of capacity, so the only blocker is the agent's own slot.
+			await ctx.db.query('UPDATE projects SET max_concurrent_runs = 3 WHERE id = $1', [project.id]);
+
+			// The queued agent is already running on a sibling task in this project.
+			const sibling = await seedTask(ws, project, { title: 'Occupying Agent Slot' });
+			await ctx.db.query(
+				`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at)
+				 VALUES ($1, $2, $3, 'running'::heartbeat_run_status, now())`,
+				[queuedAgent.id, ws.team.id, sibling.id],
+			);
+
+			const task = await seedTask(ws, project, { title: 'Waiting Task', assignee_id: captain.id });
+			const r = await ctx.db.query<{ id: string }>(
+				`INSERT INTO agent_wakeup_requests (member_id, team_id, source, status, payload)
+				 VALUES ($1, $2, 'mention'::wakeup_source, 'queued'::wakeup_status,
+				         jsonb_build_object('task_id', $3::text))
+				 RETURNING id`,
+				[queuedAgent.id, ws.team.id, task.id],
+			);
+
+			seeded.teamSlug = ws.team.slug;
+			seeded.taskId = task.id;
+			seeded.wakeupId = r.rows[0].id;
+		},
+	});
+
+	await router.navigate({
+		to: '/teams/$teamId/tasks/$taskId',
+		params: { teamId: seeded.teamSlug, taskId: seeded.taskId },
+	});
+
+	const playBtn = (await findByTestId(`run-queued-wakeup-${seeded.wakeupId}`, undefined, {
+		timeout: 15_000,
+	})) as HTMLButtonElement;
+	await waitFor(() => {
+		expect(playBtn.getAttribute('aria-disabled')).toBe('true');
+	});
+	expect(playBtn.getAttribute('aria-label')).toMatch(/another task in this project/i);
+});
+
 test('disables the play button with a reason when the ticket already has a run', async () => {
 	const seeded = { teamSlug: '', taskId: '', wakeupId: '' };
 

--- a/packages/web/test/sidebar.test.tsx
+++ b/packages/web/test/sidebar.test.tsx
@@ -256,7 +256,12 @@ test('creating a project from the sidebar surfaces it in the sidebar after intak
 		});
 
 	await router.navigate({ to: '/teams/$teamId/projects', params: { teamId: ws.team.slug } });
-	await findByText('(Internal)', undefined, { timeout: 20_000 });
+	// On the projects list route the Internal project renders in both the sidebar
+	// nav and the main content, so a plain findByText trips on duplicates — wait
+	// for it to appear inside the nav specifically.
+	await waitFor(() => expect(within(getNav(container)).getByText('(Internal)')).toBeTruthy(), {
+		timeout: 20_000,
+	});
 
 	const navEl = getNav(container);
 	// The sidebar's Projects section has an "add" button with the addLabel tooltip.


### PR DESCRIPTION
## Summary

- **HTML project document previews** — project docs that are HTML render in an inline preview pane (`html-preview.tsx`) from the docs library and the documents route, instead of showing raw source.
- **Per-agent busy flag on queued wakeups** — the run-now route now returns an `agent_busy` flag per wakeup, set when that agent already has an active run on another task in the same project (even when the project still has concurrency headroom). The board UI disables run-now and shows an explanatory reason.
- **UI designer agent prompt** — mockups are now built as self-contained interactive HTML saved via `write_project_doc`, with the board as sole reviewer/approver.

## Test plan

- Server: `queued-wakeups.test.ts` asserts `agent_busy` is true for an agent running on a sibling task and false for a free agent, with project capacity available.
- Web: `queued-agents.test.tsx` verifies run-now is disabled with the agent-busy reason; `project-docs-html.test.tsx` covers HTML doc preview rendering.
- `bun run check`, `typecheck`, and `build` pass (pre-commit hooks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)