### PR TITLE
fix(egress): drop forceSNI (broken under Bun) and add a Bun-native te…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
         with:
           bun-version: ${{ env.BUN_VERSION }}
       - run: bun install --frozen-lockfile
+      # Runs the server vitest suite (Node runtime) followed by the Bun-native
+      # tier (test/bun/** under `bun test`), which exercises runtime-sensitive
+      # code — e.g. egress TLS — on the production Bun runtime.
       - run: bun run test --package server
 
   test-integration:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Commands
 
-- `bun run test` — server unit/integration (vitest) + web component tier (vitest) + browser (Playwright), in that order
+- `bun run test` — server unit/integration (vitest, Node) + server Bun-native tier (`bun test`) + web component tier (vitest) + browser (Playwright), in that order
 - `bun run test --skip-browser` — drop Playwright; runs server + web vitest only (~30s)
 - `bun run test --browser` — Playwright only
 - `bun run test --pattern <substring>` — filter by file-path substring (works across all tiers; combine with `--browser` to narrow browser tests)
@@ -18,6 +18,7 @@
 - One vitest file: `cd packages/<pkg> && bunx vitest run <path>` (e.g. `cd packages/web && bunx vitest run test/task-comments.test.tsx`). Same flags as `bun run test`.
 - Filter by test name: `bunx vitest run <path> -t '<substring>'`.
 - Watch mode while iterating: drop `run` (`bunx vitest <path>`).
+- One Bun-native file: `cd packages/server && bun test ./test/bun/<spec>.bun.test.ts` (must run under `bun test`, never vitest).
 - One Playwright spec: `bunx playwright test test/browser/<spec>.spec.ts` from the root.
 - Headed Playwright for debugging: `bunx playwright test --headed --debug test/browser/<spec>.spec.ts`.
 
@@ -39,13 +40,14 @@ Pre-v1: modify `packages/server/migrations/001_initial_schema.sql` in place and 
 
 ## Testing
 
-All changes ship with tests that exercise functionality (not "code runs without throwing"). Prefer integration over heavily-mocked unit tests. Three tiers:
+All changes ship with tests that exercise functionality (not "code runs without throwing"). Prefer integration over heavily-mocked unit tests. Four tiers:
 
 | Tier | Where | Run cost | What it tests | When to use |
 |---|---|---|---|---|
 | Server unit/integration | `packages/server/test/**/*.test.ts` | ~ms each | API handlers, DB queries, services, MCP tools, agent run plumbing. Each test boots a fresh PGlite + Hono app via `createTestContext()`. | Everything backend. |
 | Web component | `packages/web/test/**/*.test.tsx` | ~100-700ms each | React tree rendered in happy-dom against an **in-process** Hono + PGlite backend via `renderApp()` in `packages/web/test/helpers/render.tsx`. Asserts on DOM, forms, React Query refetches, navigation, mention rendering. Stubs WebSocket (`reconnecting-websocket`'s constructor checks) and `IntersectionObserver`. | Anything render-driven that doesn't depend on a real browser layout engine or WebSocket stream. ~80% of what would otherwise be a browser test. |
 | Playwright browser | `test/browser/**/*.spec.ts` | ~10-30s each | Real Chromium. Mobile viewport (responsive checks at 375px), drag-drop file events, `boundingBox()` / sticky positioning, Virtuoso virtualization windows + scroll, scroll-to-bottom buttons, real `clientHeight`/`scrollHeight` comparisons, real WebSocket-streamed logs, the master-key gate flow before any token is set. | The thin slice that genuinely needs the browser. Default: write a component test instead. |
+| Bun-native runtime | `packages/server/test/bun/**/*.bun.test.ts` | ~ms each | Code whose behaviour diverges between Node and Bun, exercised on the **production Bun runtime** via `bun test` (not vitest, which runs under Node). Today: the egress proxy's TLS MITM path. Imports `bun:test`; reuses the server helpers (`createTestApp`, etc.). | Anything that relies on runtime-specific `node:` API behaviour (TLS, `net`, `crypto`, `child_process`) where a Node-only test would give false confidence. |
 
 ### Server unit/integration rules
 
@@ -55,6 +57,15 @@ All changes ship with tests that exercise functionality (not "code runs without 
 - Always `destroyTestContext()` in `afterAll` (resource leak otherwise).
 - Pure logic tests (crypto, parsing) can call functions directly.
 - GitHub OAuth/repo/SSH-key tests use the local simulator at `packages/server/test/helpers/github-sim.ts` — set `GITHUB_API_BASE_URL` and `GITHUB_OAUTH_BASE_URL` before the test context boots.
+
+### Bun-native runtime rules
+
+The server runs on **Bun** in dev/prod, but vitest runs on **Node** (`bunx vitest` resolves vitest's `#!/usr/bin/env node` shebang, and the forks pool spawns Node workers). So a green vitest run says nothing about runtime-specific `node:` API behaviour under Bun — Bun's `https.Server` has no `addContext` and ignores `SNICallback`, and its TLS verifies the upstream cert against the `Host` header. Vitest can't be flipped to Bun (`bunx --bun vitest` breaks module interop — `import { z } from 'zod'` resolves to `undefined`). So runtime-sensitive code gets a Bun-native tier instead.
+
+- Files are `packages/server/test/bun/**/*.bun.test.ts`, import from `bun:test`, and run via `bun test test/bun/`. `bun run test --package server` runs them automatically after the vitest suite; `--pattern bun` narrows to this tier.
+- They are **excluded from vitest** (`vitest.config.ts` `exclude: ['test/bun/**']`) — vitest's `test/**/*.test.ts` glob would otherwise import `bun:test` and fail.
+- Reuse the existing server helpers — `createTestApp`, `loadOrCreateCA`, `mintCertFromCA`, `encrypt` all import cleanly under Bun (no vitest coupling). `bun:test`'s `expect` is close to vitest's but not identical; keep assertions simple.
+- Default to a normal vitest test. Reach here only when the assertion depends on `node:` runtime behaviour that differs between Node and Bun (TLS, `net`, `crypto`, `child_process`) and a Node-only test would pass while production breaks.
 
 ### Web component rules
 

--- a/packages/server/src/services/egress/proxy.ts
+++ b/packages/server/src/services/egress/proxy.ts
@@ -112,37 +112,34 @@ export class EgressProxy {
 						reject(err ?? new Error('HTTPS_SERVER_ERROR'));
 					}
 				});
-				// forceSNI collapses the library's per-host internal MITM TLS
-				// servers into a single SNI-multiplexed server created once at
-				// listen() and torn down only at close(). Without it the library
-				// spins up and tears down a separate loopback HTTPS server per
-				// host, and the loopback connect from the CONNECT handler can race
-				// that lifecycle and be refused — leaving the client tunnel hung.
-				// Every TLS client we proxy (Claude Code / undici / curl) sends SNI.
-				withConsoleInfoSuppressed(() => {
-					proxy.listen(
-						{
-							port,
-							host: '127.0.0.1',
-							sslCaDir: this.deps.ca.rootDir,
-							forceSNI: true,
-							...(upstreamHttpsAgent ? { httpsAgent: upstreamHttpsAgent } : {}),
-						},
-						((err?: Error | null) => {
-							if (err) {
-								if (!settled) {
-									settled = true;
-									reject(err);
-								}
-								return;
-							}
+				// The library terminates TLS with a separate internal HTTPS
+				// server per host, each presenting a statically-minted leaf cert.
+				// (forceSNI — a single SNI-multiplexed server via addContext — is
+				// unusable here: the runtime's https.Server has no addContext and
+				// ignores SNICallback, so dynamic SNI never fires. The patched
+				// loopback connect retries then fails fast instead of hanging when
+				// a per-host server is mid-listen or closing under run churn.)
+				proxy.listen(
+					{
+						port,
+						host: '127.0.0.1',
+						sslCaDir: this.deps.ca.rootDir,
+						...(upstreamHttpsAgent ? { httpsAgent: upstreamHttpsAgent } : {}),
+					},
+					((err?: Error | null) => {
+						if (err) {
 							if (!settled) {
 								settled = true;
-								resolve();
+								reject(err);
 							}
-						}) as () => void,
-					);
-				});
+							return;
+						}
+						if (!settled) {
+							settled = true;
+							resolve();
+						}
+					}) as () => void,
+				);
 			});
 		} catch (e) {
 			this.portAllocator.release(port);
@@ -188,6 +185,18 @@ export class EgressProxy {
 		const headers = opts.headers ?? {};
 		const protocol = ctx.isSSL ? 'https' : 'http';
 		const url = `${protocol}://${host}${urlPath}`;
+
+		if (ctx.isSSL) {
+			// Drop the client-forwarded Host header so the runtime regenerates it
+			// from the connection target. Some runtimes verify the upstream cert
+			// against the Host header verbatim — which carries the port for
+			// non-default ports and so fails hostname validation against a cert
+			// whose SAN is the bare host. With no Host header, verification uses
+			// the connection host and the regenerated header still carries the
+			// correct host:port to the upstream.
+			delete headers.host;
+			delete headers.Host;
+		}
 
 		const probeInUrlOrHeaders =
 			PLACEHOLDER_PROBE_REGEX.test(urlPath) || headersContainProbe(headers);
@@ -313,21 +322,6 @@ function respondEarly(ctx: IContext, statusCode: number, code: string, message: 
 		'content-length': Buffer.byteLength(body).toString(),
 	});
 	res.end(body);
-}
-
-/**
- * Run a synchronous block with `console.info` silenced. The MITM library emits
- * a single "SNI enabled" info line at listen() time under forceSNI; suppressing
- * it keeps run/test output free of per-proxy noise without touching other logs.
- */
-function withConsoleInfoSuppressed(fn: () => void): void {
-	const original = console.info;
-	console.info = () => {};
-	try {
-		fn();
-	} finally {
-		console.info = original;
-	}
 }
 
 function headersContainProbe(headers: Record<string, string>): boolean {

--- a/packages/server/test/bun/egress-proxy.bun.test.ts
+++ b/packages/server/test/bun/egress-proxy.bun.test.ts
@@ -1,0 +1,207 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { createServer as createHttpsServer, type Server as HttpsServer } from 'node:https';
+import { connect as netConnect } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { connect as tlsConnect } from 'node:tls';
+import type { PGlite } from '@electric-sql/pglite';
+import { encrypt } from '../../src/crypto/encryption';
+import type { MasterKeyManager } from '../../src/crypto/master-key';
+import { type HezoCA, loadOrCreateCA } from '../../src/services/egress/ca';
+import { EgressProxy } from '../../src/services/egress/proxy';
+import { createTestApp } from '../helpers/app';
+import { mintCertFromCA } from '../helpers/self-signed-cert';
+
+// Runtime tier: this spec runs under `bun test`, exercising the egress proxy on
+// the production Bun runtime rather than the Node runtime that vitest uses. It
+// guards the HTTPS MITM path — Bun's https.Server lacks addContext and ignores
+// SNICallback, so any single-server SNI scheme (e.g. forceSNI) silently breaks
+// here even though it passes under Node/vitest.
+
+let db: PGlite;
+let masterKeyManager: MasterKeyManager;
+let teamId: string;
+let agentId: string;
+let ca: HezoCA;
+let dataDir: string;
+let proxy: EgressProxy;
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	db = ctx.db;
+	masterKeyManager = ctx.masterKeyManager;
+	dataDir = mkdtempSync(join(tmpdir(), 'hezo-egress-bun-'));
+
+	const teamRes = await ctx.app.request('/api/teams', {
+		method: 'POST',
+		headers: { Authorization: `Bearer ${ctx.token}`, 'Content-Type': 'application/json' },
+		body: JSON.stringify({ name: 'Egress Bun Co' }),
+	});
+	teamId = (await teamRes.json()).data.id;
+	const agentRes = await ctx.app.request(`/api/teams/${teamId}/agents`, {
+		method: 'POST',
+		headers: { Authorization: `Bearer ${ctx.token}`, 'Content-Type': 'application/json' },
+		body: JSON.stringify({ title: 'Egress Bun Agent' }),
+	});
+	agentId = (await agentRes.json()).data.id;
+
+	ca = await loadOrCreateCA(dataDir);
+	proxy = new EgressProxy({ db, masterKeyManager, ca, extraUpstreamTrustedCAs: ca.cert });
+});
+
+afterAll(async () => {
+	await proxy.releaseAll();
+	rmSync(dataDir, { recursive: true, force: true });
+	await db.close();
+});
+
+describe('EgressProxy under Bun', () => {
+	test('terminates HTTPS through the MITM path and substitutes a header placeholder', async () => {
+		const upstream = await startHttpsUpstream(ca);
+		const upstreamPort = (upstream.address() as { port: number }).port;
+		const runId = `bun-run-${process.pid}-https`;
+		await insertSecret('BUN_HTTPS_HEADER', 'real-bun-value', ['localhost']);
+		const allocated = await proxy.allocateRunProxy(runId, { teamId, agentId });
+		try {
+			const res = await fetchHttpsThroughProxy({
+				proxyHost: '127.0.0.1',
+				proxyPort: allocated.proxyPort,
+				targetHost: 'localhost',
+				targetPort: upstreamPort,
+				path: '/echo',
+				headers: { authorization: 'Bearer __HEZO_SECRET_BUN_HTTPS_HEADER__' },
+				caCert: ca.cert,
+			});
+			expect(res.status).toBe(200);
+			expect(httpsHits.at(-1)?.authorization).toBe('Bearer real-bun-value');
+		} finally {
+			await proxy.releaseRunProxy(runId);
+			await new Promise<void>((resolve) => upstream.close(() => resolve()));
+		}
+	}, 30_000);
+
+	test('handles concurrent run allocate/connect/release churn without hanging', async () => {
+		const upstream = await startHttpsUpstream(ca);
+		const upstreamPort = (upstream.address() as { port: number }).port;
+		await insertSecret('BUN_CHURN_HEADER', 'churn-value', ['localhost']);
+		try {
+			const runs = await Promise.all(
+				Array.from({ length: 6 }, async (_unused, i) => {
+					const runId = `bun-churn-${process.pid}-${i}`;
+					const allocated = await proxy.allocateRunProxy(runId, { teamId, agentId });
+					return { runId, port: allocated.proxyPort };
+				}),
+			);
+			const statuses = await Promise.all(
+				runs.map((r) =>
+					fetchHttpsThroughProxy({
+						proxyHost: '127.0.0.1',
+						proxyPort: r.port,
+						targetHost: 'localhost',
+						targetPort: upstreamPort,
+						path: '/echo',
+						headers: { authorization: 'Bearer __HEZO_SECRET_BUN_CHURN_HEADER__' },
+						caCert: ca.cert,
+					}).then((res) => res.status),
+				),
+			);
+			expect(statuses).toEqual(runs.map(() => 200));
+			await Promise.all(runs.map((r) => proxy.releaseRunProxy(r.runId)));
+		} finally {
+			await new Promise<void>((resolve) => upstream.close(() => resolve()));
+		}
+	}, 30_000);
+});
+
+const httpsHits: Array<Record<string, string | string[] | undefined>> = [];
+
+async function insertSecret(name: string, value: string, allowedHosts: string[]): Promise<void> {
+	const key = masterKeyManager.getKey();
+	if (!key) throw new Error('master key unavailable in test');
+	const enc = encrypt(value, key);
+	await db.query(
+		`INSERT INTO secrets (team_id, project_id, name, encrypted_value, category, allowed_hosts)
+		 VALUES ($1, NULL, $2, $3, 'api_token'::secret_category, $4)
+		 ON CONFLICT (team_id, project_id, name) DO UPDATE
+		 SET encrypted_value = EXCLUDED.encrypted_value,
+		     allowed_hosts = EXCLUDED.allowed_hosts`,
+		[teamId, name, enc, allowedHosts],
+	);
+}
+
+async function startHttpsUpstream(rootCa: { cert: string; key: string }): Promise<HttpsServer> {
+	const { cert, key } = await mintCertFromCA(rootCa, 'localhost');
+	const server = createHttpsServer({ cert, key }, (req, res) => {
+		httpsHits.push(req.headers as Record<string, string | string[] | undefined>);
+		res.writeHead(200, { 'content-type': 'application/json' });
+		res.end(JSON.stringify({ ok: true }));
+	});
+	await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+	return server;
+}
+
+interface HttpsProxyFetchOpts {
+	proxyHost: string;
+	proxyPort: number;
+	targetHost: string;
+	targetPort: number;
+	path: string;
+	method?: string;
+	headers?: Record<string, string>;
+	caCert: string;
+}
+
+async function fetchHttpsThroughProxy(
+	opts: HttpsProxyFetchOpts,
+): Promise<{ status: number; body: string }> {
+	const tunnel = await new Promise<ReturnType<typeof netConnect>>((resolve, reject) => {
+		const sock = netConnect({ host: opts.proxyHost, port: opts.proxyPort });
+		const onData = (chunk: Buffer) => {
+			const statusLine = chunk.toString().split('\r\n')[0] ?? '';
+			sock.removeListener('data', onData);
+			if (/^HTTP\/1\.[01] 200/.test(statusLine)) {
+				resolve(sock);
+			} else {
+				reject(new Error(`CONNECT failed: ${statusLine}`));
+			}
+		};
+		sock.on('connect', () => {
+			sock.write(
+				`CONNECT ${opts.targetHost}:${opts.targetPort} HTTP/1.1\r\n` +
+					`Host: ${opts.targetHost}:${opts.targetPort}\r\n\r\n`,
+			);
+		});
+		sock.on('data', onData);
+		sock.on('error', reject);
+		sock.setTimeout(20_000, () => sock.destroy(new Error('CONNECT timed out')));
+	});
+
+	return new Promise((resolve, reject) => {
+		const tls = tlsConnect(
+			{ socket: tunnel, servername: opts.targetHost, ca: [opts.caCert] },
+			() => {
+				const headerLines = [
+					`${opts.method ?? 'GET'} ${opts.path} HTTP/1.1`,
+					`Host: ${opts.targetHost}:${opts.targetPort}`,
+					'Connection: close',
+					...Object.entries(opts.headers ?? {}).map(([k, v]) => `${k}: ${v}`),
+				];
+				tls.write(`${headerLines.join('\r\n')}\r\n\r\n`);
+			},
+		);
+		const chunks: Buffer[] = [];
+		tls.on('data', (chunk: Buffer) => chunks.push(chunk));
+		tls.on('end', () => {
+			const all = Buffer.concat(chunks).toString();
+			const sep = all.indexOf('\r\n\r\n');
+			const headPart = sep === -1 ? all : all.slice(0, sep);
+			const body = sep === -1 ? '' : all.slice(sep + 4);
+			const statusLine = headPart.split('\r\n')[0] ?? '';
+			const status = Number(statusLine.split(' ')[1] ?? '0');
+			resolve({ status, body });
+		});
+		tls.on('error', reject);
+		tls.setTimeout(20_000, () => tls.destroy(new Error('https fetch timed out')));
+	});
+}

--- a/packages/server/test/egress-proxy.test.ts
+++ b/packages/server/test/egress-proxy.test.ts
@@ -174,11 +174,11 @@ describe('EgressProxy', () => {
 		}
 	}, 30_000);
 
-	it('terminates HTTPS via the shared SNI MITM server and substitutes a header placeholder', async () => {
-		// Exercises the CONNECT → internal MITM TLS server path that forceSNI
-		// reshapes. The agent's TLS terminates on a proxy-minted leaf (signed by
-		// the Hezo CA), the placeholder is substituted, then the request is
-		// re-encrypted to the upstream — all without a container.
+	it('terminates HTTPS via the internal MITM server and substitutes a header placeholder', async () => {
+		// Exercises the CONNECT → internal MITM TLS server path. The agent's TLS
+		// terminates on a proxy-minted leaf (signed by the Hezo CA), the
+		// placeholder is substituted, then the request is re-encrypted to the
+		// upstream — all without a container.
 		const httpsProxy = new EgressProxy({
 			db,
 			masterKeyManager,

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -1,9 +1,12 @@
-import { defineConfig } from 'vitest/config';
+import { configDefaults, defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
 		globals: true,
 		include: ['test/**/*.test.ts'],
+		// test/bun/** runs under Bun's native runner (`bun test`), not vitest —
+		// it imports `bun:test` and exercises the production Bun runtime.
+		exclude: [...configDefaults.exclude, 'test/bun/**'],
 		setupFiles: ['test/setup.ts'],
 		testTimeout: 60000,
 		hookTimeout: 60000,

--- a/packages/web/test/project-crud.test.tsx
+++ b/packages/web/test/project-crud.test.tsx
@@ -1,4 +1,4 @@
-import { within } from '@testing-library/react';
+import { waitFor, within } from '@testing-library/react';
 import { expect, test } from 'vitest';
 import { getTestContext, renderApp } from './helpers/render';
 import {
@@ -82,7 +82,7 @@ test('project list shows the default (Internal) project', async () => {
 test('project list shows task and repo counts', async () => {
 	let ws!: SeededWorkspace;
 	const name = uniqueName('Count Test');
-	const { findByText, router } = await renderApp({
+	const { router } = await renderApp({
 		initialPath: '/',
 		seed: async () => {
 			ws = await seedWorkspace();
@@ -96,10 +96,17 @@ test('project list shows task and repo counts', async () => {
 		params: { teamId: ws.team.slug },
 	});
 
-	// Scope to <main> — the same project name appears in the sidebar nav.
-	await findByText(name, undefined, { timeout: 15_000 });
-	const main = document.querySelector('main') as HTMLElement;
-	const card = within(main).getByRole('link', { name: new RegExp(name) });
+	// Scope to <main> — the same project name appears in the sidebar nav, so an
+	// unscoped query races the two renders and can match both. Wait for <main>
+	// to mount and contain the card link before asserting.
+	const card = await waitFor(
+		() => {
+			const main = document.querySelector('main');
+			if (!main) throw new Error('main not mounted yet');
+			return within(main).getByRole('link', { name: new RegExp(name) });
+		},
+		{ timeout: 15_000 },
+	);
 	expect(card.textContent).toMatch(/0 tasks/);
 	expect(card.textContent).toMatch(/0 repos/);
 }, 60_000);

--- a/patches/http-mitm-proxy@1.1.0.patch
+++ b/patches/http-mitm-proxy@1.1.0.patch
@@ -1,13 +1,46 @@
 diff --git a/dist/lib/proxy.js b/dist/lib/proxy.js
-index e89659568c500de1dcd1c3611e353353d7158714..48409cf036918dc41352e6319fa089b2ce5ecec5 100644
+index e89659568c500de1dcd1c3611e353353d7158714..e3992edf667e2fc89aa078e1ca4af41ffddffbf2 100644
 --- a/dist/lib/proxy.js
 +++ b/dist/lib/proxy.js
-@@ -361,7 +361,7 @@ class Proxy {
-         function makeConnection(port) {
+@@ -358,12 +358,14 @@ class Proxy {
+     _onHttpServerConnectData(req, socket, head) {
+         const self = this;
+         socket.pause();
+-        function makeConnection(port) {
++        function makeConnection(port, attemptsLeft = 5) {
++            let connected = false;
              const conn = net_1.default.connect({
                  port,
 -                host: "0.0.0.0",
 +                host: self.httpHost,
                  allowHalfOpen: true,
              }, () => {
++                connected = true;
                  const connectKey = `${conn.localPort}:${conn.remotePort}`;
+                 self.connectRequests[connectKey] = req;
+                 const cleanupFunction = () => {
+@@ -390,7 +392,23 @@ class Proxy {
+                 socket.emit("data", head);
+                 return socket.resume();
+             });
+-            conn.on("error", self._onSocketError.bind(self, "PROXY_TO_PROXY_SOCKET"));
++            conn.on("error", (err) => {
++                // The per-host internal MITM server may be mid-listen or closing
++                // under run churn, refusing the loopback connect. Retry a few
++                // times, then fail the client tunnel fast — leaving the paused
++                // CONNECT socket undestroyed would hang the agent until timeout.
++                if (!connected &&
++                    err &&
++                    (err.code === "ECONNREFUSED" || err.code === "ECONNRESET") &&
++                    attemptsLeft > 0) {
++                    setTimeout(() => makeConnection(port, attemptsLeft - 1), 25);
++                    return;
++                }
++                self._onSocketError("PROXY_TO_PROXY_SOCKET", err);
++                if (!socket.destroyed) {
++                    socket.destroy(err);
++                }
++            });
+         }
+         function getHttpsServer(hostname, callback) {
+             self.onCertificateRequired(hostname, (err, files) => {

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { Command } from 'commander';
 
@@ -83,6 +84,27 @@ async function runVitestForPackage(pkg: string): Promise<boolean> {
 	return passed;
 }
 
+async function runBunNativeForPackage(pkg: string): Promise<boolean> {
+	const bunDir = resolve(ROOT, pkg, 'test/bun');
+	if (!existsSync(bunDir)) return true;
+
+	console.log(`\n── Running ${pkg} Bun-native tier (bun test test/bun/) ──`);
+	const start = Date.now();
+	const proc = Bun.spawn(['bun', 'test', 'test/bun/'], {
+		cwd: resolve(ROOT, pkg),
+		stdout: 'inherit',
+		stderr: 'inherit',
+		env: { ...process.env, NODE_ENV: 'test' },
+	});
+	const exitCode = await proc.exited;
+	const duration = Date.now() - start;
+	const passed = exitCode === 0;
+	console.log(
+		`\n${pkg} (Bun-native): ${passed ? 'passed' : 'FAILED'} (${(duration / 1000).toFixed(1)}s)`,
+	);
+	return passed;
+}
+
 async function runBrowserTests(): Promise<boolean> {
 	console.log('\n── Browser Tests ──');
 	const playwrightArgs = ['playwright', 'test'];
@@ -114,11 +136,24 @@ async function main() {
 			process.exit(1);
 		}
 
+		// The Bun-native tier runs under `bun test` (production runtime). Its
+		// files live in test/bun/ and contain "bun" in their path, so honour
+		// --pattern by running it only when no pattern is set or the pattern
+		// targets that tier.
+		const runBunNative = !pattern || pattern.includes('bun');
+
 		for (const pkg of packages) {
 			const passed = await runVitestForPackage(pkg);
 			if (!passed) {
 				integrationPassed = false;
 				if (bail) break;
+			}
+			if (runBunNative) {
+				const bunPassed = await runBunNativeForPackage(pkg);
+				if (!bunPassed) {
+					integrationPassed = false;
+					if (bail) break;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
…st tier

forceSNI (added in #101) is structurally impossible under Bun: its https.Server has no addContext and ignores SNICallback, so the library's single-server SNI scheme throws `addContext is not a function` on every HTTPS CONNECT — breaking all HTTPS egress in dev/prod. It passed CI only because vitest runs under Node (its `env node` shebang), where https.Server extends tls.Server and addContext exists.

Changes:
- Revert forceSNI; restore the per-host MITM path (static per-host certs, which Bun honours).
- Extend the http-mitm-proxy patch: retry the loopback connect under run churn, then destroy the paused client CONNECT socket on terminal failure so a refused/closing per-host server fails fast instead of hanging — the runtime-agnostic fix for the race #101 targeted.
- Drop the client-forwarded Host header for HTTPS upstream requests so the runtime regenerates it from the connection target. Bun verifies the upstream cert against the Host header verbatim (including the port), which broke non-443 HTTPS egress; regeneration keeps the correct host:port while verifying against the bare host.
- Add a Bun-native test tier (packages/server/test/bun/**, run via `bun test`) that exercises the egress TLS path on the production Bun runtime — re-adding forceSNI now fails it. Excluded from vitest; wired into `bun run test --package server` and the test-backend CI job. Document the tier in AGENTS.md.