### PR TITLE
feat(release): add manual GitHub release workflow

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,58 @@
+name: Release Publish
+
+# Fires when a release PR (head branch release/<version>, opened by release.yml)
+# is merged into main. Tags the merge commit (no v-prefix) and publishes a
+# GitHub Release whose body is the just-merged CHANGELOG.md section.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write # create + push the tag, create the Release
+
+concurrency:
+  group: release-publish
+  cancel-in-progress: false
+
+env:
+  BUN_VERSION: "1.3.11"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/')
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: main # post-merge main, which includes the bump + changelog
+          fetch-depth: 0
+          fetch-tags: true
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+      - run: bun install --frozen-lockfile
+
+      - name: Tag and publish the GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          version="${HEAD_REF#release/}"
+          echo "Publishing release ${version}"
+
+          if git rev-parse "$version" >/dev/null 2>&1; then
+            echo "::error::Tag ${version} already exists. Aborting."
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$version" -m "Release ${version}"
+          git push origin "refs/tags/${version}"
+
+          bun run release --notes "$version" > /tmp/release-notes.md
+          gh release create "$version" --title "$version" --notes-file /tmp/release-notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,84 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release-type:
+        description: Version bump (auto = derive from conventional commits)
+        type: choice
+        options: [auto, major, minor, patch]
+        default: auto
+
+permissions:
+  contents: write # commit the version bump, push the tag, create the Release
+  actions: read # read the CI conclusion for the build-passed guard
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+env:
+  BUN_VERSION: "1.3.11"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # Releases are only ever cut from main.
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      # Guard: the latest CI run for this exact commit on main must have passed.
+      # The workflow-runs API rolls all CI jobs into one conclusion, which is
+      # exactly the "last build on main passed" semantic we want.
+      - name: Verify CI passed for HEAD
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          sha="$(git rev-parse HEAD)"
+          echo "Checking CI conclusion for $sha"
+          conclusion="$(gh run list \
+            --workflow=ci.yml \
+            --branch=main \
+            --commit="$sha" \
+            --json conclusion,headSha \
+            --jq 'map(select(.headSha=="'"$sha"'")) | first | .conclusion')"
+          echo "CI conclusion: '${conclusion}'"
+          if [ "$conclusion" != "success" ]; then
+            echo "::error::CI for $sha did not conclude successfully (got: '${conclusion}'). Aborting release."
+            exit 1
+          fi
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+      - run: bun install --frozen-lockfile
+
+      - name: Compute version, bump files, generate changelog
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bun run release --release-type "${{ inputs.release-type }}" --apply
+
+      - name: Commit, tag, and push
+        env:
+          TAG: ${{ steps.release.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "chore(release): ${TAG}"
+          git tag -a "${TAG}" -m "Release ${TAG}"
+          git push origin HEAD:main
+          git push origin "refs/tags/${TAG}"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.release.outputs.version }}
+          NOTES: ${{ steps.release.outputs.changelog }}
+        run: |
+          printf '%s' "$NOTES" | gh release create "$TAG" --title "$TAG" --notes-file -

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,6 @@ concurrency:
 
 env:
   BUN_VERSION: "1.3.11"
-  # A PAT / app token (RELEASE_TOKEN) is preferred so the opened PR triggers CI;
-  # PRs opened with the default GITHUB_TOKEN do not start new workflow runs.
-  GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
 jobs:
   prepare:
@@ -35,16 +32,31 @@ jobs:
     # Releases are only ever prepared from main.
     if: github.ref == 'refs/heads/main'
     steps:
+      # Mint a short-lived GitHub App installation token. The release PR must be
+      # opened with this token (not the default GITHUB_TOKEN) so it triggers CI —
+      # PRs opened by GITHUB_TOKEN do not start new workflow runs, so required
+      # checks would never run. The app needs Contents:write + PullRequests:write.
+      # Requires repo secrets RELEASE_APP_ID and RELEASE_APP_PRIVATE_KEY.
+      - name: Mint app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       # Guard: the latest CI run for this exact commit on main must have passed.
       # The workflow-runs API rolls all CI jobs into one conclusion, which is
-      # exactly the "last build on main passed" semantic we want.
+      # exactly the "last build on main passed" semantic we want. Uses the
+      # built-in token (the job has actions:read) so the app needs no Actions perm.
       - name: Verify CI passed for HEAD
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           sha="$(git rev-parse HEAD)"
           echo "Checking CI conclusion for $sha"
@@ -71,6 +83,7 @@ jobs:
 
       - name: Push release branch and open PR
         env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           VERSION: ${{ steps.release.outputs.version }}
           NOTES: ${{ steps.release.outputs.changelog }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,10 @@
 name: Release
 
+# Manually-triggered "prepare release": opens a PR that bumps the version and
+# updates CHANGELOG.md. Merging that PR triggers release-publish.yml, which
+# creates the tag and GitHub Release. This keeps releases off direct pushes to
+# main and lets the PR's own CI gate the merge.
+
 on:
   workflow_dispatch:
     inputs:
@@ -10,7 +15,8 @@ on:
         default: auto
 
 permissions:
-  contents: write # commit the version bump, push the tag, create the Release
+  contents: write # push the release branch
+  pull-requests: write # open the release PR
   actions: read # read the CI conclusion for the build-passed guard
 
 concurrency:
@@ -19,24 +25,26 @@ concurrency:
 
 env:
   BUN_VERSION: "1.3.11"
+  # A PAT / app token (RELEASE_TOKEN) is preferred so the opened PR triggers CI;
+  # PRs opened with the default GITHUB_TOKEN do not start new workflow runs.
+  GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
 jobs:
-  release:
+  prepare:
     runs-on: ubuntu-latest
-    # Releases are only ever cut from main.
+    # Releases are only ever prepared from main.
     if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
+          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
       # Guard: the latest CI run for this exact commit on main must have passed.
       # The workflow-runs API rolls all CI jobs into one conclusion, which is
       # exactly the "last build on main passed" semantic we want.
       - name: Verify CI passed for HEAD
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           sha="$(git rev-parse HEAD)"
           echo "Checking CI conclusion for $sha"
@@ -59,26 +67,28 @@ jobs:
 
       - name: Compute version, bump files, generate changelog
         id: release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bun run release --release-type "${{ inputs.release-type }}" --apply
 
-      - name: Commit, tag, and push
+      - name: Push release branch and open PR
         env:
-          TAG: ${{ steps.release.outputs.version }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git commit -m "chore(release): ${TAG}"
-          git tag -a "${TAG}" -m "Release ${TAG}"
-          git push origin HEAD:main
-          git push origin "refs/tags/${TAG}"
-
-      - name: Create GitHub Release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ steps.release.outputs.version }}
+          VERSION: ${{ steps.release.outputs.version }}
           NOTES: ${{ steps.release.outputs.changelog }}
         run: |
-          printf '%s' "$NOTES" | gh release create "$TAG" --title "$TAG" --notes-file -
+          branch="release/${VERSION}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          git add -A
+          git commit -m "chore(release): ${VERSION}"
+          git push -u origin "$branch" --force-with-lease
+
+          # Idempotent label so the PR is easy to filter / for publish gating.
+          gh label create release --color 0e8a16 --description "Release PR" --force || true
+
+          body="$(printf 'Automated release for **%s**.\n\nMerging this PR tags the release and publishes the GitHub Release.\n\n---\n\n%s' "$VERSION" "$NOTES")"
+          gh pr create \
+            --base main \
+            --head "$branch" \
+            --title "chore(release): ${VERSION}" \
+            --label release \
+            --body "$body"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 		"check": "bunx biome check .",
 		"check:fix": "bunx biome check --write .",
 		"dev": "bun run scripts/dev.ts",
+		"release": "bun run scripts/release.ts",
 		"test": "bun run scripts/test.ts",
 		"typecheck": "turbo typecheck",
 		"prepare": "husky"

--- a/packages/server/src/release/changelog.ts
+++ b/packages/server/src/release/changelog.ts
@@ -73,3 +73,23 @@ export function renderChangelog(opts: RenderChangelogOptions): string {
 
 	return `${blocks.join('\n').trimEnd()}\n`;
 }
+
+/**
+ * Extract a single version's notes from a rendered `CHANGELOG.md` — everything
+ * below the `## <version> - <date>` heading up to the next `## ` heading (or end
+ * of file). The version heading itself is omitted (the GitHub Release title
+ * already carries the version). Returns null when the version is not present.
+ */
+export function extractReleaseNotes(changelog: string, version: string): string | null {
+	const lines = changelog.split('\n');
+	const start = lines.findIndex(
+		(l) => l.startsWith(`## ${version} `) || l.trim() === `## ${version}`,
+	);
+	if (start === -1) {
+		return null;
+	}
+	const rest = lines.slice(start + 1);
+	const end = rest.findIndex((l) => l.startsWith('## '));
+	const section = end === -1 ? rest : rest.slice(0, end);
+	return section.join('\n').trim();
+}

--- a/packages/server/src/release/changelog.ts
+++ b/packages/server/src/release/changelog.ts
@@ -1,0 +1,75 @@
+/**
+ * Render a categorized Markdown changelog from parsed Conventional Commits.
+ * Pure: the date and repo URL are injected so output is deterministic.
+ */
+import {
+	CHANGELOG_BREAKING_HEADING,
+	CHANGELOG_OTHER_HEADING,
+	CHANGELOG_SECTIONS,
+} from '@hezo/shared';
+import type { ParsedCommit } from './conventional.js';
+
+export interface RenderChangelogOptions {
+	version: string;
+	/** ISO date (YYYY-MM-DD) for the release heading. */
+	date: string;
+	commits: ParsedCommit[];
+	/** Previous release tag, or null for the first release. */
+	previousTag: string | null;
+	/** Repo URL (e.g. https://github.com/owner/repo) for PR/compare links. */
+	repoUrl?: string;
+}
+
+const KNOWN_TYPES = new Set<string>(CHANGELOG_SECTIONS.map(([type]) => type));
+
+function renderLine(c: ParsedCommit, repoUrl?: string): string {
+	const scope = c.scope ? `**${c.scope}:** ` : '';
+	let line = `- ${scope}${c.description}`;
+	if (c.pr !== null) {
+		line += repoUrl ? ` ([#${c.pr}](${repoUrl}/pull/${c.pr}))` : ` (#${c.pr})`;
+	}
+	return line;
+}
+
+function renderSection(heading: string, commits: ParsedCommit[], repoUrl?: string): string {
+	if (commits.length === 0) {
+		return '';
+	}
+	const lines = commits.map((c) => renderLine(c, repoUrl));
+	return `### ${heading}\n\n${lines.join('\n')}\n`;
+}
+
+/** Render the changelog body for a release (used as the GitHub Release body). */
+export function renderChangelog(opts: RenderChangelogOptions): string {
+	const { version, date, commits, previousTag, repoUrl } = opts;
+	const blocks: string[] = [`## ${version} - ${date}\n`];
+
+	const breaking = commits.filter((c) => c.breaking);
+	const breakingBlock = renderSection(CHANGELOG_BREAKING_HEADING, breaking, repoUrl);
+	if (breakingBlock) {
+		blocks.push(breakingBlock);
+	}
+
+	for (const [type, heading] of CHANGELOG_SECTIONS) {
+		const section = commits.filter((c) => c.type === type);
+		const block = renderSection(heading, section, repoUrl);
+		if (block) {
+			blocks.push(block);
+		}
+	}
+
+	const other = commits.filter((c) => c.type === '' || !KNOWN_TYPES.has(c.type));
+	const otherBlock = renderSection(CHANGELOG_OTHER_HEADING, other, repoUrl);
+	if (otherBlock) {
+		blocks.push(otherBlock);
+	}
+
+	if (repoUrl) {
+		const link = previousTag
+			? `${repoUrl}/compare/${previousTag}...${version}`
+			: `${repoUrl}/commits/${version}`;
+		blocks.push(`**Full Changelog**: ${link}`);
+	}
+
+	return `${blocks.join('\n').trimEnd()}\n`;
+}

--- a/packages/server/src/release/conventional.ts
+++ b/packages/server/src/release/conventional.ts
@@ -1,0 +1,56 @@
+/**
+ * Parsing of Conventional-Commit messages into structured data. Pure functions
+ * only — no git/IO — so the release script and its tests share one parser.
+ */
+
+export interface ParsedCommit {
+	/** Lowercased commit type (e.g. `feat`, `fix`); empty string if the header is non-conventional. */
+	type: string;
+	/** Scope from `feat(scope):`, or null. */
+	scope: string | null;
+	/** True when the commit declares a breaking change (`!` in header or `BREAKING CHANGE:` footer). */
+	breaking: boolean;
+	/** Description text after the `type(scope):` prefix (trailing PR ref stripped). */
+	description: string;
+	/** Short commit hash. */
+	hash: string;
+	/** Trailing PR number from a `(#123)` suffix, or null. */
+	pr: number | null;
+}
+
+export interface RawCommit {
+	subject: string;
+	body: string;
+	hash: string;
+}
+
+const HEADER_RE = /^(\w+)(?:\(([^)]+)\))?(!)?: (.+)$/;
+const PR_SUFFIX_RE = /\s*\(#(\d+)\)\s*$/;
+const BREAKING_FOOTER_RE = /^BREAKING[ -]CHANGE:/m;
+
+export function parseCommit({ subject, body, hash }: RawCommit): ParsedCommit {
+	const trimmed = subject.trim();
+	const match = HEADER_RE.exec(trimmed);
+
+	let pr: number | null = null;
+	const prMatch = PR_SUFFIX_RE.exec(trimmed);
+	if (prMatch) {
+		pr = Number.parseInt(prMatch[1], 10);
+	}
+
+	const breaking = Boolean(match?.[3]) || BREAKING_FOOTER_RE.test(body);
+
+	if (!match) {
+		return { type: '', scope: null, breaking, description: trimmed, hash, pr };
+	}
+
+	const description = match[4].replace(PR_SUFFIX_RE, '').trim();
+	return {
+		type: match[1].toLowerCase(),
+		scope: match[2] ?? null,
+		breaking,
+		description,
+		hash,
+		pr,
+	};
+}

--- a/packages/server/src/release/index.ts
+++ b/packages/server/src/release/index.ts
@@ -1,0 +1,3 @@
+export * from './changelog.js';
+export * from './conventional.js';
+export * from './version.js';

--- a/packages/server/src/release/version.ts
+++ b/packages/server/src/release/version.ts
@@ -1,0 +1,69 @@
+/**
+ * Semantic-version computation from Conventional-Commit metadata. Pure
+ * arithmetic over `MAJOR.MINOR.PATCH` strings — no `v` prefix, no pre-release
+ * tags. Avoids a `semver` dependency for the simple scheme we use.
+ */
+import type { ParsedCommit } from './conventional.js';
+
+export type Bump = 'major' | 'minor' | 'patch' | 'none';
+export type ReleaseType = 'auto' | 'major' | 'minor' | 'patch';
+
+/** Version used as the base when there is no previous release tag. */
+export const INITIAL_BASE_VERSION = '0.0.0';
+/** Default first-release version when bumping from {@link INITIAL_BASE_VERSION}. */
+export const FIRST_RELEASE_VERSION = '0.1.0';
+
+/** Derive the bump implied by a set of commits, ignoring any explicit override. */
+export function computeBump(commits: ParsedCommit[]): Bump {
+	let bump: Bump = 'none';
+	for (const c of commits) {
+		if (c.breaking) {
+			return 'major';
+		}
+		if (c.type === 'feat') {
+			bump = 'minor';
+		} else if (bump === 'none' && c.type !== '') {
+			bump = 'patch';
+		}
+	}
+	return bump;
+}
+
+/** Apply an explicit release-type override; `auto` keeps the computed bump. */
+export function applyOverride(auto: Bump, override: ReleaseType): Bump {
+	return override === 'auto' ? auto : override;
+}
+
+function parse(version: string): [number, number, number] {
+	const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(version.trim());
+	if (!m) {
+		throw new Error(`Not a plain semver version: ${version}`);
+	}
+	return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+/**
+ * Compute the next version string from a previous version and a bump. When the
+ * previous version is the initial base (no prior release), a non-major bump
+ * yields {@link FIRST_RELEASE_VERSION} so the first release lands at 0.1.0.
+ */
+export function nextVersion(prev: string, bump: Bump): string {
+	if (bump === 'none') {
+		throw new Error('Cannot compute next version for a "none" bump');
+	}
+
+	const isInitial = prev.trim() === INITIAL_BASE_VERSION;
+	if (isInitial && bump !== 'major') {
+		return FIRST_RELEASE_VERSION;
+	}
+
+	const [major, minor, patch] = parse(prev);
+	switch (bump) {
+		case 'major':
+			return `${major + 1}.0.0`;
+		case 'minor':
+			return `${major}.${minor + 1}.0`;
+		case 'patch':
+			return `${major}.${minor}.${patch + 1}`;
+	}
+}

--- a/packages/server/test/release/changelog.test.ts
+++ b/packages/server/test/release/changelog.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { renderChangelog } from '../../src/release/changelog';
+import { extractReleaseNotes, renderChangelog } from '../../src/release/changelog';
 import type { ParsedCommit } from '../../src/release/conventional';
 
 function commit(overrides: Partial<ParsedCommit>): ParsedCommit {
@@ -130,5 +130,52 @@ describe('renderChangelog', () => {
 		expect(out).toContain('### Other');
 		expect(out).toContain('- random commit');
 		expect(out).toContain('- unknown type');
+	});
+});
+
+const SAMPLE_CHANGELOG = `# Changelog
+
+## 1.1.0 - 2026-06-10
+
+### Features
+
+- a new thing (#10)
+
+**Full Changelog**: https://github.com/hezo-ai/hezo/compare/1.0.0...1.1.0
+
+## 1.0.0 - 2026-06-01
+
+### Bug Fixes
+
+- an old fix (#1)
+`;
+
+describe('extractReleaseNotes', () => {
+	it('extracts the latest version section without the heading', () => {
+		const notes = extractReleaseNotes(SAMPLE_CHANGELOG, '1.1.0');
+		expect(notes).toContain('### Features');
+		expect(notes).toContain('- a new thing (#10)');
+		expect(notes).toContain('**Full Changelog**');
+		// Stops before the previous version and drops its own heading. (The
+		// compare link legitimately mentions 1.0.0, so assert on section content.)
+		expect(notes).not.toContain('## 1.1.0');
+		expect(notes).not.toContain('## 1.0.0');
+		expect(notes).not.toContain('### Bug Fixes');
+		expect(notes).not.toContain('an old fix');
+	});
+
+	it('extracts a trailing (oldest) version section through end of file', () => {
+		const notes = extractReleaseNotes(SAMPLE_CHANGELOG, '1.0.0');
+		expect(notes).toContain('### Bug Fixes');
+		expect(notes).toContain('- an old fix (#1)');
+	});
+
+	it('returns null when the version is absent', () => {
+		expect(extractReleaseNotes(SAMPLE_CHANGELOG, '9.9.9')).toBeNull();
+	});
+
+	it('does not prefix-match a longer version', () => {
+		const cl = '# Changelog\n\n## 1.2.10 - 2026-06-10\n\n### Features\n\n- ten\n';
+		expect(extractReleaseNotes(cl, '1.2.1')).toBeNull();
 	});
 });

--- a/packages/server/test/release/changelog.test.ts
+++ b/packages/server/test/release/changelog.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import { renderChangelog } from '../../src/release/changelog';
+import type { ParsedCommit } from '../../src/release/conventional';
+
+function commit(overrides: Partial<ParsedCommit>): ParsedCommit {
+	return {
+		type: 'feat',
+		scope: null,
+		breaking: false,
+		description: 'something',
+		hash: 'h',
+		pr: null,
+		...overrides,
+	};
+}
+
+const REPO = 'https://github.com/hezo-ai/hezo';
+
+describe('renderChangelog', () => {
+	it('renders a heading with the version and date', () => {
+		const out = renderChangelog({
+			version: '0.1.0',
+			date: '2026-06-02',
+			commits: [commit({ type: 'feat', description: 'a feature' })],
+			previousTag: null,
+		});
+		expect(out).toContain('## 0.1.0 - 2026-06-02');
+	});
+
+	it('groups commits under their section headings in order', () => {
+		const out = renderChangelog({
+			version: '1.0.0',
+			date: '2026-06-02',
+			commits: [
+				commit({ type: 'fix', description: 'a bug' }),
+				commit({ type: 'feat', description: 'a feature' }),
+			],
+			previousTag: '0.9.0',
+		});
+		expect(out).toContain('### Features');
+		expect(out).toContain('### Bug Fixes');
+		expect(out).toContain('- a feature');
+		expect(out).toContain('- a bug');
+		// Features section comes before Bug Fixes
+		expect(out.indexOf('### Features')).toBeLessThan(out.indexOf('### Bug Fixes'));
+	});
+
+	it('omits empty sections', () => {
+		const out = renderChangelog({
+			version: '1.0.1',
+			date: '2026-06-02',
+			commits: [commit({ type: 'fix', description: 'a bug' })],
+			previousTag: '1.0.0',
+		});
+		expect(out).not.toContain('### Features');
+		expect(out).toContain('### Bug Fixes');
+	});
+
+	it('places a Breaking Changes section above the rest', () => {
+		const out = renderChangelog({
+			version: '2.0.0',
+			date: '2026-06-02',
+			commits: [
+				commit({ type: 'feat', description: 'normal feature' }),
+				commit({ type: 'feat', breaking: true, description: 'removed thing' }),
+			],
+			previousTag: '1.5.0',
+		});
+		expect(out).toContain('### Breaking Changes');
+		expect(out.indexOf('### Breaking Changes')).toBeLessThan(out.indexOf('### Features'));
+		// The breaking commit also appears in its type section.
+		expect(out).toContain('- normal feature');
+	});
+
+	it('formats scope and PR with a link when a repo url is given', () => {
+		const out = renderChangelog({
+			version: '1.1.0',
+			date: '2026-06-02',
+			commits: [commit({ type: 'feat', scope: 'projects', description: 'add assets', pr: 105 })],
+			previousTag: '1.0.0',
+			repoUrl: REPO,
+		});
+		expect(out).toContain(
+			'- **projects:** add assets ([#105](https://github.com/hezo-ai/hezo/pull/105))',
+		);
+	});
+
+	it('formats PR without a link when no repo url is given', () => {
+		const out = renderChangelog({
+			version: '1.1.0',
+			date: '2026-06-02',
+			commits: [commit({ type: 'feat', description: 'add assets', pr: 105 })],
+			previousTag: '1.0.0',
+		});
+		expect(out).toContain('- add assets (#105)');
+	});
+
+	it('uses a compare link when there is a previous tag', () => {
+		const out = renderChangelog({
+			version: '1.1.0',
+			date: '2026-06-02',
+			commits: [commit({})],
+			previousTag: '1.0.0',
+			repoUrl: REPO,
+		});
+		expect(out).toContain(`**Full Changelog**: ${REPO}/compare/1.0.0...1.1.0`);
+	});
+
+	it('uses a commits link for the first release', () => {
+		const out = renderChangelog({
+			version: '0.1.0',
+			date: '2026-06-02',
+			commits: [commit({})],
+			previousTag: null,
+			repoUrl: REPO,
+		});
+		expect(out).toContain(`**Full Changelog**: ${REPO}/commits/0.1.0`);
+	});
+
+	it('buckets non-conventional/unknown types under Other', () => {
+		const out = renderChangelog({
+			version: '1.0.1',
+			date: '2026-06-02',
+			commits: [
+				commit({ type: '', description: 'random commit' }),
+				commit({ type: 'wip', description: 'unknown type' }),
+			],
+			previousTag: '1.0.0',
+		});
+		expect(out).toContain('### Other');
+		expect(out).toContain('- random commit');
+		expect(out).toContain('- unknown type');
+	});
+});

--- a/packages/server/test/release/conventional.test.ts
+++ b/packages/server/test/release/conventional.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { parseCommit } from '../../src/release/conventional';
+
+describe('parseCommit', () => {
+	it('parses type, scope, and description', () => {
+		const c = parseCommit({
+			subject: 'feat(projects): add Assets library',
+			body: '',
+			hash: 'abc123',
+		});
+		expect(c.type).toBe('feat');
+		expect(c.scope).toBe('projects');
+		expect(c.description).toBe('add Assets library');
+		expect(c.breaking).toBe(false);
+		expect(c.pr).toBeNull();
+		expect(c.hash).toBe('abc123');
+	});
+
+	it('parses a type without a scope', () => {
+		const c = parseCommit({ subject: 'fix: correct a typo', body: '', hash: 'h' });
+		expect(c.type).toBe('fix');
+		expect(c.scope).toBeNull();
+		expect(c.description).toBe('correct a typo');
+	});
+
+	it('extracts a trailing PR number and strips it from the description', () => {
+		const c = parseCommit({
+			subject: 'feat(projects): add Assets library (#105)',
+			body: '',
+			hash: 'h',
+		});
+		expect(c.pr).toBe(105);
+		expect(c.description).toBe('add Assets library');
+	});
+
+	it('detects a breaking change from the `!` marker', () => {
+		const c = parseCommit({ subject: 'feat(api)!: drop legacy endpoint', body: '', hash: 'h' });
+		expect(c.breaking).toBe(true);
+		expect(c.type).toBe('feat');
+		expect(c.description).toBe('drop legacy endpoint');
+	});
+
+	it('detects a breaking change from a BREAKING CHANGE footer', () => {
+		const c = parseCommit({
+			subject: 'refactor(db): reshape schema',
+			body: 'Body text.\n\nBREAKING CHANGE: the column was removed.',
+			hash: 'h',
+		});
+		expect(c.breaking).toBe(true);
+		expect(c.type).toBe('refactor');
+	});
+
+	it('also accepts the hyphenated BREAKING-CHANGE footer form', () => {
+		const c = parseCommit({
+			subject: 'chore: bump',
+			body: 'BREAKING-CHANGE: removed config flag',
+			hash: 'h',
+		});
+		expect(c.breaking).toBe(true);
+	});
+
+	it('lowercases the type', () => {
+		const c = parseCommit({ subject: 'FEAT: shout', body: '', hash: 'h' });
+		expect(c.type).toBe('feat');
+	});
+
+	it('returns an empty type for a non-conventional subject', () => {
+		const c = parseCommit({ subject: 'just some words', body: '', hash: 'h' });
+		expect(c.type).toBe('');
+		expect(c.scope).toBeNull();
+		expect(c.description).toBe('just some words');
+		expect(c.breaking).toBe(false);
+	});
+
+	it('still extracts a PR number from a non-conventional subject', () => {
+		const c = parseCommit({ subject: 'Merge pull request stuff (#42)', body: '', hash: 'h' });
+		expect(c.type).toBe('');
+		expect(c.pr).toBe(42);
+	});
+});

--- a/packages/server/test/release/version.test.ts
+++ b/packages/server/test/release/version.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import type { ParsedCommit } from '../../src/release/conventional';
+import { applyOverride, computeBump, nextVersion } from '../../src/release/version';
+
+function commit(overrides: Partial<ParsedCommit>): ParsedCommit {
+	return {
+		type: 'fix',
+		scope: null,
+		breaking: false,
+		description: 'x',
+		hash: 'h',
+		pr: null,
+		...overrides,
+	};
+}
+
+describe('computeBump', () => {
+	it('returns none for an empty commit list', () => {
+		expect(computeBump([])).toBe('none');
+	});
+
+	it('returns major when any commit is breaking', () => {
+		expect(computeBump([commit({ type: 'fix' }), commit({ type: 'feat', breaking: true })])).toBe(
+			'major',
+		);
+	});
+
+	it('returns minor when a feat is present without breaking changes', () => {
+		expect(computeBump([commit({ type: 'fix' }), commit({ type: 'feat' })])).toBe('minor');
+	});
+
+	it('returns patch for fixes/other types only', () => {
+		expect(computeBump([commit({ type: 'fix' }), commit({ type: 'refactor' })])).toBe('patch');
+	});
+
+	it('ignores non-conventional commits when deciding patch', () => {
+		expect(computeBump([commit({ type: '' })])).toBe('none');
+	});
+});
+
+describe('applyOverride', () => {
+	it('keeps the computed bump for auto', () => {
+		expect(applyOverride('minor', 'auto')).toBe('minor');
+	});
+
+	it('honors an explicit override over the computed bump', () => {
+		expect(applyOverride('patch', 'major')).toBe('major');
+		expect(applyOverride('none', 'patch')).toBe('patch');
+	});
+});
+
+describe('nextVersion', () => {
+	it('bumps major', () => {
+		expect(nextVersion('1.2.3', 'major')).toBe('2.0.0');
+	});
+
+	it('bumps minor', () => {
+		expect(nextVersion('1.2.3', 'minor')).toBe('1.3.0');
+	});
+
+	it('bumps patch', () => {
+		expect(nextVersion('1.2.3', 'patch')).toBe('1.2.4');
+	});
+
+	it('yields 0.1.0 for the first non-major release from the initial base', () => {
+		expect(nextVersion('0.0.0', 'minor')).toBe('0.1.0');
+		expect(nextVersion('0.0.0', 'patch')).toBe('0.1.0');
+	});
+
+	it('yields 1.0.0 for a major first release', () => {
+		expect(nextVersion('0.0.0', 'major')).toBe('1.0.0');
+	});
+
+	it('throws on a none bump', () => {
+		expect(() => nextVersion('1.0.0', 'none')).toThrow();
+	});
+
+	it('throws on a non-plain-semver previous version', () => {
+		expect(() => nextVersion('v1.0.0', 'patch')).toThrow();
+	});
+});

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -30,3 +30,22 @@ export const wsRoom = {
 	team: (id: string) => `team:${id}`,
 	agent: (id: string) => `agent:${id}`,
 } as const;
+
+/**
+ * Conventional-commit type → changelog heading, in render order. Single source
+ * of truth shared by the release script and its tests. Commit types not listed
+ * here (and non-conventional commits) fall into the "Other" section.
+ */
+export const CHANGELOG_SECTIONS = [
+	['feat', 'Features'],
+	['fix', 'Bug Fixes'],
+	['perf', 'Performance'],
+	['refactor', 'Refactors'],
+	['docs', 'Documentation'],
+	['build', 'Build System'],
+	['test', 'Tests'],
+	['chore', 'Chores'],
+] as const;
+
+export const CHANGELOG_OTHER_HEADING = 'Other';
+export const CHANGELOG_BREAKING_HEADING = 'Breaking Changes';

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,0 +1,171 @@
+#!/usr/bin/env bun
+/**
+ * Compute the next release version + changelog from the Conventional-Commit
+ * history since the previous tag. The git/IO shell around the pure release
+ * logic in `@hezo/server`'s release module.
+ *
+ * Modes:
+ *   --dry-run   print the computed version and changelog body; mutate nothing.
+ *   --apply     write package.json versions + prepend CHANGELOG.md, and (when
+ *               run in CI) emit `version`/`changelog` to $GITHUB_OUTPUT.
+ *
+ * Tag creation, commit, push, and GitHub Release publishing happen in
+ * .github/workflows/release.yml — this script stays locally runnable.
+ */
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { Command } from 'commander';
+import {
+	applyOverride,
+	computeBump,
+	nextVersion,
+	type ParsedCommit,
+	parseCommit,
+	type ReleaseType,
+	renderChangelog,
+} from '../packages/server/src/release/index.js';
+
+const ROOT = resolve(import.meta.dir, '..');
+const PACKAGE_PATHS = ['packages/shared', 'packages/server', 'packages/web'].map((p) =>
+	resolve(ROOT, p, 'package.json'),
+);
+const CHANGELOG_PATH = resolve(ROOT, 'CHANGELOG.md');
+const SEMVER_TAG_RE = /^\d+\.\d+\.\d+$/;
+// NUL field separator and RS record separator — robust against multiline bodies.
+// Git expands the `%x00`/`%x1e` placeholders to the raw bytes in its output; the
+// literal bytes can't be passed in spawn args, so the format string uses the
+// placeholders while we split the output on the actual control characters.
+const FIELD = '\x00';
+const RECORD = '\x1e';
+const LOG_FORMAT = '--format=%h%x00%s%x00%b%x1e';
+
+function sh(cmd: string[]): string {
+	const proc = Bun.spawnSync(cmd, { cwd: ROOT, stdout: 'pipe', stderr: 'pipe' });
+	if (proc.exitCode !== 0) {
+		const stderr = proc.stderr.toString().trim();
+		throw new Error(`Command failed (${cmd.join(' ')}): ${stderr}`);
+	}
+	return proc.stdout.toString();
+}
+
+/** Latest plain-semver tag (no `v` prefix, no pre-release), or null. */
+function previousTag(): string | null {
+	const out = sh(['git', 'tag', '--list', '--sort=-v:refname']);
+	for (const line of out.split('\n')) {
+		const tag = line.trim();
+		if (SEMVER_TAG_RE.test(tag)) {
+			return tag;
+		}
+	}
+	return null;
+}
+
+function collectCommits(prev: string | null): ParsedCommit[] {
+	const range = prev ? `${prev}..HEAD` : 'HEAD';
+	const out = sh(['git', 'log', range, '--no-merges', LOG_FORMAT]);
+	return out
+		.split(RECORD)
+		.map((r) => r.replace(/^\n/, ''))
+		.filter((r) => r.trim().length > 0)
+		.map((record) => {
+			const [hash, subject, body = ''] = record.split(FIELD);
+			return parseCommit({ hash: hash.trim(), subject, body });
+		})
+		.filter((c) => !(c.type === 'chore' && c.scope === 'release'));
+}
+
+function repoUrl(): string | undefined {
+	const { GITHUB_SERVER_URL, GITHUB_REPOSITORY } = process.env;
+	if (GITHUB_SERVER_URL && GITHUB_REPOSITORY) {
+		return `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}`;
+	}
+	try {
+		const remote = sh(['git', 'remote', 'get-url', 'origin']).trim();
+		const m = /github\.com[:/](.+?)(?:\.git)?$/.exec(remote);
+		return m ? `https://github.com/${m[1]}` : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function bumpPackageVersions(version: string): void {
+	for (const path of PACKAGE_PATHS) {
+		const text = readFileSync(path, 'utf8');
+		const updated = text.replace(/("version":\s*)"[^"]*"/, `$1"${version}"`);
+		writeFileSync(path, updated);
+	}
+}
+
+function prependChangelog(body: string): void {
+	const header = '# Changelog\n';
+	const existing = existsSync(CHANGELOG_PATH) ? readFileSync(CHANGELOG_PATH, 'utf8') : '';
+	const previousEntries = existing.replace(/^# Changelog\n+/, '');
+	const next = `${header}\n${body.trim()}\n${previousEntries ? `\n${previousEntries.trimStart()}` : ''}`;
+	writeFileSync(CHANGELOG_PATH, next.endsWith('\n') ? next : `${next}\n`);
+}
+
+function emitGithubOutput(version: string, changelog: string): void {
+	const out = process.env.GITHUB_OUTPUT;
+	if (!out) {
+		return;
+	}
+	const block = `version=${version}\nchangelog<<HEZO_EOF\n${changelog}\nHEZO_EOF\n`;
+	writeFileSync(out, block, { flag: 'a' });
+}
+
+const program = new Command()
+	.name('release')
+	.description('Compute the next release version and changelog from conventional commits')
+	.option('--release-type <type>', 'version bump: auto | major | minor | patch', 'auto')
+	.option('--dry-run', 'print the version and changelog without writing anything')
+	.option('--apply', 'write package.json versions, prepend CHANGELOG.md, emit $GITHUB_OUTPUT')
+	.parse();
+
+const opts = program.opts<{ releaseType: string; dryRun?: boolean; apply?: boolean }>();
+const overrideRaw = opts.releaseType;
+if (!['auto', 'major', 'minor', 'patch'].includes(overrideRaw)) {
+	console.error(`Invalid --release-type: ${overrideRaw} (expected auto|major|minor|patch)`);
+	process.exit(1);
+}
+const override = overrideRaw as ReleaseType;
+
+try {
+	sh(['git', 'fetch', '--tags', '--force']);
+} catch (e) {
+	console.warn(`Warning: could not fetch tags: ${(e as Error).message}`);
+}
+
+const prev = previousTag();
+const commits = collectCommits(prev);
+const auto = computeBump(commits);
+const bump = applyOverride(auto, override);
+
+if (bump === 'none') {
+	console.error(
+		`No releasable commits since ${prev ?? 'the start of history'}. ` +
+			'Use --release-type to force a release.',
+	);
+	process.exit(1);
+}
+
+const base = prev ?? '0.0.0';
+const version = nextVersion(base, bump);
+const date = new Date().toISOString().slice(0, 10);
+const changelog = renderChangelog({
+	version,
+	date,
+	commits,
+	previousTag: prev,
+	repoUrl: repoUrl(),
+});
+
+if (opts.apply) {
+	bumpPackageVersions(version);
+	prependChangelog(changelog);
+	emitGithubOutput(version, changelog);
+	console.log(`Prepared release ${version} (bump: ${bump}, previous: ${prev ?? 'none'}).`);
+} else {
+	// Default + --dry-run: print only.
+	console.log(`version: ${version} (bump: ${bump}, previous: ${prev ?? 'none'})\n`);
+	console.log(changelog);
+}

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -5,12 +5,14 @@
  * logic in `@hezo/server`'s release module.
  *
  * Modes:
- *   --dry-run   print the computed version and changelog body; mutate nothing.
- *   --apply     write package.json versions + prepend CHANGELOG.md, and (when
- *               run in CI) emit `version`/`changelog` to $GITHUB_OUTPUT.
+ *   --dry-run         print the computed version and changelog body; mutate nothing.
+ *   --apply           write package.json versions + prepend CHANGELOG.md, and
+ *                     (when run in CI) emit `version`/`changelog` to $GITHUB_OUTPUT.
+ *   --notes <version> print an already-written CHANGELOG.md section and exit.
  *
- * Tag creation, commit, push, and GitHub Release publishing happen in
- * .github/workflows/release.yml — this script stays locally runnable.
+ * The release runs as a PR flow: release.yml prepares the bump on a release
+ * branch and opens a PR; release-publish.yml tags + publishes the GitHub Release
+ * when that PR merges. This script stays side-effect-light and locally runnable.
  */
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
@@ -18,6 +20,7 @@ import { Command } from 'commander';
 import {
 	applyOverride,
 	computeBump,
+	extractReleaseNotes,
 	nextVersion,
 	type ParsedCommit,
 	parseCommit,
@@ -119,9 +122,32 @@ const program = new Command()
 	.option('--release-type <type>', 'version bump: auto | major | minor | patch', 'auto')
 	.option('--dry-run', 'print the version and changelog without writing anything')
 	.option('--apply', 'write package.json versions, prepend CHANGELOG.md, emit $GITHUB_OUTPUT')
+	.option('--notes <version>', 'print the CHANGELOG.md section for a version and exit')
 	.parse();
 
-const opts = program.opts<{ releaseType: string; dryRun?: boolean; apply?: boolean }>();
+const opts = program.opts<{
+	releaseType: string;
+	dryRun?: boolean;
+	apply?: boolean;
+	notes?: string;
+}>();
+
+// --notes is a standalone read of an already-written CHANGELOG.md (used by the
+// publish workflow to build the GitHub Release body); it ignores git history.
+if (opts.notes) {
+	if (!existsSync(CHANGELOG_PATH)) {
+		console.error('CHANGELOG.md not found');
+		process.exit(1);
+	}
+	const notes = extractReleaseNotes(readFileSync(CHANGELOG_PATH, 'utf8'), opts.notes);
+	if (notes === null) {
+		console.error(`No CHANGELOG.md section found for version ${opts.notes}`);
+		process.exit(1);
+	}
+	console.log(notes);
+	process.exit(0);
+}
+
 const overrideRaw = opts.releaseType;
 if (!['auto', 'major', 'minor', 'patch'].includes(overrideRaw)) {
 	console.error(`Invalid --release-type: ${overrideRaw} (expected auto|major|minor|patch)`);

--- a/test/browser/task-crud.spec.ts
+++ b/test/browser/task-crud.spec.ts
@@ -26,12 +26,6 @@ test('running-agents line links each name to its run comment and scrolls into vi
 	});
 	const task = (await taskRes.json()).data;
 
-	const lockRes = await page.request.post(`/api/teams/${team.id}/tasks/${task.id}/lock`, {
-		headers,
-		data: { member_id: agent.id },
-	});
-	expect(lockRes.ok()).toBeTruthy();
-
 	const commentId = 'bbbb0000-0000-0000-0000-000000000001';
 	const runId = 'cccc0000-0000-0000-0000-000000000001';
 	const runComment = {
@@ -44,6 +38,19 @@ test('running-agents line links each name to its run comment and scrolls into vi
 		author_type: 'agent',
 		author_name: agent.title,
 		author_member_id: agent.id,
+	};
+
+	// Drive RunningAgentsLine from a mocked lock rather than a real POST /lock:
+	// creating an agent-assigned task posts a background wakeup whose cron can
+	// acquire (and then roll back) the execution lock first, racing the test.
+	// The line only reads the locks + comments queries, so mocking both keeps
+	// this scroll-into-view assertion hermetic.
+	const lock = {
+		id: 'aaaa0000-0000-0000-0000-000000000001',
+		task_id: task.id,
+		member_id: agent.id,
+		member_name: agent.title,
+		locked_at: new Date().toISOString(),
 	};
 
 	const filler = Array.from({ length: 20 }, (_, i) => ({
@@ -64,6 +71,15 @@ test('running-agents line links each name to its run comment and scrolls into vi
 			status: 200,
 			contentType: 'application/json',
 			body: JSON.stringify({ data: [...filler, runComment] }),
+		});
+	});
+
+	await page.route(`**/api/teams/*/tasks/*/lock`, async (route) => {
+		if (route.request().method() !== 'GET') return route.continue();
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({ data: { locks: [lock] } }),
 		});
 	});
 


### PR DESCRIPTION
Add a manually-triggered (workflow_dispatch) release process that cuts a
release from main: it diffs against the previous tag, generates a changelog
categorized from the conventional-commit history, computes the next semver
version, bumps all package.json files, maintains CHANGELOG.md, tags the
commit (no v-prefix), and publishes a GitHub Release.

The release is gated on the latest CI run for the HEAD commit on main having
concluded successfully. Version bump is auto-derived from commit types
(breaking->major, feat->minor, otherwise patch) with an optional dispatch
override. First release lands at 0.1.0.

Pure changelog/versioning logic lives in packages/server/src/release with
unit tests in the server tier; scripts/release.ts is the git/IO shell.

https://claude.ai/code/session_01MbZz4aWhUjY3AZAK3WDX9f