### PR TITLE
ci(release): supersede a stale release PR on re-run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,12 +88,28 @@ jobs:
           NOTES: ${{ steps.release.outputs.changelog }}
         run: |
           branch="release/${VERSION}"
+
+          # Supersede any prior, still-open release PR. A release branch is
+          # generated and disposable: if you need more commits in a release you
+          # land them on main and re-run this workflow, which should replace the
+          # stale PR rather than collide with it. Close every open release/* PR
+          # (deleting its head branch), then make sure our target branch is gone
+          # remotely so the push + gh pr create below start clean — even when the
+          # recomputed version matches the stale one (same branch name).
+          stale="$(gh pr list --state open --json number,headRefName \
+            --jq '.[] | select(.headRefName | startswith("release/")) | .number')"
+          for pr in $stale; do
+            echo "Superseding stale release PR #${pr}"
+            gh pr close "$pr" --delete-branch || true
+          done
+          git push origin --delete "$branch" 2>/dev/null || true
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$branch"
           git add -A
           git commit -m "chore(release): ${VERSION}"
-          git push -u origin "$branch" --force-with-lease
+          git push -u origin "$branch"
 
           # Idempotent label so the PR is easy to filter / for publish gating.
           gh label create release --color 0e8a16 --description "Release PR" --force || true


### PR DESCRIPTION
## What

Make the **Release** workflow (`release.yml`) idempotent across re-runs by auto-superseding any stale release PR before opening a new one.

## Why

A `release/<version>` branch is generated and disposable. When you need more commits in a release, the intended flow is: land them on `main`, then re-run **Release** so it recomputes the version + changelog. But the previously-opened release PR (and its branch) would collide with the new one whenever the recomputed version string matched — `gh pr create` fails if an open PR already exists for that branch, and the branch push was fussy against the pre-existing remote ref.

## How

Right before pushing the release branch, the workflow now:

1. Lists every **open `release/*` PR** and closes it, deleting its head branch (`gh pr close --delete-branch`).
2. Deletes the target `release/<version>` branch from the remote as a belt-and-suspenders cleanup (covers an orphaned branch with no open PR).

Then it creates the branch fresh and does a plain `git push` — `--force-with-lease` is no longer needed since the branch is guaranteed new.

Matching is by the `release/` branch-name prefix (not the `release` label), so it works even if a PR lost its label.

## Result

Adding more commits to a pending release is now: land on `main` → re-run **Release**. The stale PR is closed and replaced automatically, with no manual branch/PR cleanup, even when the version string is unchanged.

## Notes

- Workflow-only change; no application code touched.
- Uses the existing GitHub App token (Contents + Pull Requests permissions) already wired into the step.

https://claude.ai/code/session_01MbZz4aWhUjY3AZAK3WDX9f

---
_Generated by [Claude Code](https://claude.ai/code/session_01MbZz4aWhUjY3AZAK3WDX9f)_