### PR TITLE
ci(release): wait for in-flight CI in the release guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,21 +54,40 @@ jobs:
       # The workflow-runs API rolls all CI jobs into one conclusion, which is
       # exactly the "last build on main passed" semantic we want. Uses the
       # built-in token (the job has actions:read) so the app needs no Actions perm.
+      #
+      # We WAIT for an in-flight run rather than failing fast: triggering Release
+      # right after a merge (while that commit's CI is still running) is normal,
+      # so poll until the run for this SHA reaches a terminal state, then require
+      # success. Also tolerates the brief window where the run hasn't registered.
       - name: Verify CI passed for HEAD
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           sha="$(git rev-parse HEAD)"
-          echo "Checking CI conclusion for $sha"
-          conclusion="$(gh run list \
-            --workflow=ci.yml \
-            --branch=main \
-            --commit="$sha" \
-            --json conclusion,headSha \
-            --jq 'map(select(.headSha=="'"$sha"'")) | first | .conclusion')"
-          echo "CI conclusion: '${conclusion}'"
+          deadline=$(( $(date +%s) + 3600 )) # wait up to 60m (test-browser alone is ~40m)
+          status=""
+          conclusion=""
+          while :; do
+            info="$(gh run list \
+              --workflow=ci.yml \
+              --branch=main \
+              --commit="$sha" \
+              --json status,conclusion,headSha \
+              --jq 'map(select(.headSha=="'"$sha"'")) | first | "\(.status)|\(.conclusion)"' || true)"
+            status="${info%%|*}"
+            conclusion="${info##*|}"
+            echo "CI for $sha: status='${status}' conclusion='${conclusion}'"
+            if [ "$status" = "completed" ]; then
+              break
+            fi
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "::error::Timed out waiting for CI on $sha to complete (last status: '${status:-none}'). Aborting release."
+              exit 1
+            fi
+            sleep 30
+          done
           if [ "$conclusion" != "success" ]; then
-            echo "::error::CI for $sha did not conclude successfully (got: '${conclusion}'). Aborting release."
+            echo "::error::CI for $sha concluded '${conclusion}', not success. Aborting release."
             exit 1
           fi
 


### PR DESCRIPTION
## What

Make the **Release** workflow's "Verify CI passed for HEAD" guard **wait** for an in-flight CI run to finish, instead of failing the instant it sees one in progress.

## Why

Triggering Release right after merging to `main` is the normal flow — but at that moment the merge commit's `push` CI is usually still running, so `gh run list` returns an empty/`null` conclusion and the guard aborted. That forced you to time the dispatch precisely *after* CI went green (exactly what happened on the last manual run: CI started at 09:31:51, Release triggered 09:32:06 → blocked).

## How

Poll the workflow-runs API for the run matching the exact HEAD SHA until it reaches a **terminal** state (`status == completed`), then require `conclusion == success`:

- Waits up to **60 minutes** (the `test-browser` tier alone can take ~40m).
- Tolerates the brief window before the run registers (`status` empty → keep polling).
- A transient API error during a poll no longer aborts the job (`|| true` + retry on the next tick).
- Still aborts loudly on a real CI **failure** or on timeout.

Verified the status/conclusion parsing across all states (no-run, in-progress, success, failure) and the bash + YAML both parse clean.

## Context

The previous manual Release run failed only because of this fail-fast timing — not a real problem with the commit. With this change, dispatching Release while CI is still running just waits and then proceeds when it goes green.

## Notes

Workflow-only change; no application code touched. Guard still uses the built-in `GITHUB_TOKEN` (`actions: read`), so the App token's permissions are unchanged.

https://claude.ai/code/session_01MbZz4aWhUjY3AZAK3WDX9f

---
_Generated by [Claude Code](https://claude.ai/code/session_01MbZz4aWhUjY3AZAK3WDX9f)_