### PR TITLE
test(browser): de-flake the attachment-hint tooltip assertion

### DIFF
--- a/test/browser/task-comment-attachments.spec.ts
+++ b/test/browser/task-comment-attachments.spec.ts
@@ -127,14 +127,22 @@ test.describe('Task Comment Attachments', () => {
 		await expect(hint).toContainText('Drag and drop files to attach');
 
 		const info = page.locator('[data-testid="comment-attachment-hint-info"]');
-		await info.hover();
 		const tooltip = page.getByRole('tooltip');
-		await expect(tooltip).toBeVisible({ timeout: 5000 });
-		await expect(tooltip).toContainText('PNG');
-		await expect(tooltip).toContainText('PDF');
-		await expect(tooltip).toContainText('MP3');
-		await expect(tooltip).toContainText('MP4');
-		await expect(tooltip).toContainText('10');
+		// The Radix hover tooltip is transient: a single open can be missed while the
+		// comment form is still settling, and it closes on any pointer drift or
+		// re-render. Re-trigger a fresh pointerenter on each poll and assert the whole
+		// content as one snapshot, so a missed open or mid-assertion close self-heals.
+		await expect(async () => {
+			await page.mouse.move(0, 0);
+			await info.hover();
+			await expect(tooltip).toBeVisible({ timeout: 1500 });
+			const text = (await tooltip.textContent()) ?? '';
+			expect(text).toContain('PNG');
+			expect(text).toContain('PDF');
+			expect(text).toContain('MP3');
+			expect(text).toContain('MP4');
+			expect(text).toContain('10');
+		}).toPass({ timeout: 15000 });
 
 		await dropFile(
 			page,


### PR DESCRIPTION
## What

De-flake the `task-comment-attachments.spec.ts` test **"hint with tooltip shows when empty…"**, which intermittently failed `test-browser` on `main` (and was flaky in earlier runs).

## Root cause

The supported-types hint uses a Radix **hover** tooltip. That open is transient:
- a single `hover()` can be missed while the comment form is still settling after page load (→ `expect(tooltip).toBeVisible()` times out — the dominant failure, ~3/10 locally), and
- it closes on any pointer drift or background re-render, so a later `toContainText('PDF')` could catch it mid-close.

Switching `hover()`→`focus()` alone didn't fix it — the open is still missed during the initial settle.

## Fix

Wrap the open in `expect(async () => …).toPass(...)`:
- reset the pointer (`mouse.move(0,0)`) and re-`hover()` each iteration to fire a fresh `pointerenter`, so a missed open self-heals;
- read the tooltip's text **once per iteration** and assert all supported-type tokens against that snapshot, so a mid-assertion close can't split the checks.

No production code changed — purely a test-robustness fix. The tooltip's behavior and content are unchanged.

## Verification

Locally **19/19 passed, 0 flaky** across 12 repeats (`--repeat-each=12`) of this test, vs. ~1-in-8 flaky before. `biome` clean.

## Context

This is a pre-existing suite flake (unrelated to the release tooling) that was blocking `main` from going green after the recent release-workflow merges.

https://claude.ai/code/session_01MbZz4aWhUjY3AZAK3WDX9f

---
_Generated by [Claude Code](https://claude.ai/code/session_01MbZz4aWhUjY3AZAK3WDX9f)_