### PR TITLE
Add update notifications and self-contained binary support

### DIFF
--- a/.dev/spec.md
+++ b/.dev/spec.md
@@ -159,12 +159,12 @@ migrations/
 └── ...
 ```
 
-**Bundling into the binary:** Migration SQL files are compressed into a JSON archive at build time using `@hiddentao/zip-json` and embedded into the compiled binary. At startup, the server loads the compressed migrations from memory — no filesystem access needed for migration files. This ensures the binary is fully self-contained.
+**Bundling into the binary:** `scripts/bundle-migrations.ts` writes all `migrations/*.sql` files into a plain `{ filename: sql }` JSON map (`migrations-bundle.json`). `db/migrate.ts` pulls it in with a *literal* dynamic `import('./migrations-bundle.json')` — Bun embeds statically-analyzable imports into the compiled binary's virtual FS, so the SQL travels through the module graph and is run straight from memory (a runtime `readFile` of a sibling path is *not* embedded — it resolves to `/$bunfs/...` and ENOENTs). In dev the bundle doesn't exist; the import rejects and the runner falls back to reading the `migrations/` directory. See `.dev/upgrades.md` for the full binary-embedding story (frontend, agent roles, PGlite runtime, version).
 
 **Build process:**
-1. `zip()` compresses all `migrations/*.sql` files into a JSON object (base64-encoded gzip with metadata)
-2. The compressed archive is written to `migrations-bundle.json` and imported by the binary entry point
-3. At startup, `unzip()` extracts the SQL content in memory and the migration runner processes it
+1. `bundle-migrations.ts` writes `migrations-bundle.json` (`{ filename: sql }`)
+2. The compiled binary embeds it via the literal dynamic import in `db/migrate.ts`
+3. At startup the map is loaded from memory and the migration runner processes it
 
 **Tracking table** (`_migrations`) records which migrations have been applied:
 ```sql
@@ -178,10 +178,13 @@ CREATE TABLE IF NOT EXISTS _migrations (
 
 **Startup behavior:**
 1. Ensure `_migrations` table exists (create if not)
-2. Load migration SQL from the bundled archive (in memory)
-3. Skip files already recorded in `_migrations`
-4. For each unapplied migration: run inside a transaction, record in `_migrations` with checksum
-5. Checksum verification: if a previously-applied migration file has changed, log a warning (indicates the migration was modified after being applied — this should not happen)
+2. Load migration SQL from the bundled map (in memory)
+3. Compute the pending set (files not recorded in `_migrations`)
+4. **Pre-migration backup:** if there are pending migrations *and* the instance already has applied migrations (a real upgrade, not a fresh DB), snapshot `pgdata` with PGlite `dumpDataDir('gzip')` to `<dataDir>/backups/` (last 5 kept) before applying anything. If the backup fails, abort.
+5. For each unapplied migration: run inside a transaction, record in `_migrations` with checksum
+6. Checksum verification: if a previously-applied migration file has changed, log a warning (indicates the migration was modified after being applied — this should not happen)
+
+**Recovery from a bad migration (manual downgrade):** `hezo restore <backup.tar.gz>` wipes `pgdata` and reloads the pre-migration snapshot via PGlite `loadDataDir`; the operator then runs the previous Hezo version. Full lifecycle: `.dev/upgrades.md`.
 
 **`--reset` flag:** When provided, the server wipes the existing database directory and starts fresh before running migrations. This is useful during local development. The user is warned and must confirm (unless also providing `--master-key`, which implies non-interactive mode).
 

--- a/.dev/upgrades.md
+++ b/.dev/upgrades.md
@@ -1,0 +1,138 @@
+# Upgrades, release binaries, and migration safety
+
+How Hezo ships new versions, how the single binary stays self-contained, how
+the running instance learns about updates, and how the database is protected
+across migrations.
+
+## Release flow
+
+Releases run as a PR flow (see `.github/workflows/`):
+
+1. **`release.yml`** (manual dispatch) computes the next version from
+   Conventional Commits, bumps the per-package `package.json` versions, updates
+   `CHANGELOG.md`, and opens a `release/<version>` PR.
+2. Merging that PR fires **`release-publish.yml`**, which tags the merge commit
+   (plain semver, no `v` prefix), builds the cross-platform binaries
+   (`bun run build:release`), and publishes a GitHub Release with the
+   binaries + `SHA256SUMS` attached.
+
+## Building the binaries
+
+`bun run build:release` (→ `scripts/build.ts --release`) cross-compiles every
+supported platform from a single host (Bun cross-compiles all targets):
+
+| Asset | Target |
+|---|---|
+| `hezo-linux-x64` | `bun-linux-x64` |
+| `hezo-linux-arm64` | `bun-linux-arm64` |
+| `hezo-windows-x64.exe` | `bun-windows-x64` |
+| `hezo-darwin-x64` | `bun-darwin-x64` |
+| `hezo-darwin-arm64` | `bun-darwin-arm64` |
+
+Plus a `SHA256SUMS` manifest (`sha256sum -c` compatible). `bun run build:compile`
+builds just the current platform to `dist/hezo` for local testing.
+
+### Everything is embedded, served from memory
+
+`bun build --compile` only embeds what's reachable through the module graph —
+**not** files read at runtime via `new URL(..., import.meta.url)` or `readFile`
+(those resolve to `/$bunfs/...` and ENOENT). So each embeddable asset is pulled
+in through the graph and served from memory; the binary touches no sibling files:
+
+- **Migrations** — `scripts/bundle-migrations.ts` writes a plain
+  `{ filename: sql }` JSON map; `db/migrate.ts` pulls it in with a literal
+  dynamic `import('./migrations-bundle.json')` and runs it straight from memory.
+- **Agent roles** — same pattern in `db/agent-roles.ts` (`agents-bundle.json`).
+- **Frontend** — `scripts/bundle-static.ts` packs `packages/web/dist` into
+  `static-bundle.json` (path → base64); `startup.ts` serves it from an in-memory
+  map. No temp-dir extraction.
+- **PGlite runtime** — `scripts/bundle-pglite.ts` copies `postgres.wasm`,
+  `postgres.data`, and `vector.tar.gz` into `src/generated/pglite/`;
+  `db/pglite-assets.ts` embeds them (`import ... with { type: 'file' }`),
+  compiles the WASM, and feeds PGlite `wasmModule` + `fsBundle` from memory. The
+  one exception is the pgvector bundle: PGlite's extension loader reads its
+  `bundlePath` via `fs`, so that single ~330 KB tarball is extracted once to
+  `<dataDir>/.pglite/vector.tar.gz`.
+
+In dev (`bun run`) none of the generated bundles exist; every loader catches the
+missing import and falls back to the filesystem / `node_modules`, so dev is
+unchanged.
+
+### Version
+
+The version is injected at compile time via
+`bun build --define process.env.HEZO_VERSION="<v>"` (read from the server
+package.json). `src/version.ts` exposes `HEZO_VERSION`; in dev the define is
+absent and it reads the package.json off disk. It's surfaced at `/api/status`.
+
+### Known limitations
+
+- **Semantic search is unavailable in the standalone binary.** The embedding
+  model (`@huggingface/transformers` → `onnxruntime-node`) is a native addon
+  that can't be embedded and whose platform-specific `require` breaks
+  cross-compilation, so it's marked `--external`. Its loader fails soft (guarded
+  dynamic import), so the rest of the app is unaffected. Running from source
+  (`bun run`) still has full semantic search.
+- **macOS binaries are unsigned / un-notarized** (built on Linux). Gatekeeper
+  quarantines them on download; clear it with
+  `xattr -d com.apple.quarantine ./hezo-darwin-*`. Code signing is out of scope
+  pre-v1.
+
+## Update notifications
+
+The running instance learns about new releases and prompts the user:
+
+- **Server:** `GET /api/updates/latest` queries the GitHub Releases API for
+  `hezo-ai/hezo`, compares the latest tag against `HEZO_VERSION`, and returns
+  `{ current, latest, updateAvailable, url }`. The result is cached ~1h and
+  **fails soft** (no network / rate limit → `updateAvailable: false`).
+- **Web:** a dismissible "update available" banner (`components/update-banner.tsx`)
+  links to the GitHub Release to download. Dismissal is remembered per-version.
+
+### Replacing a running binary (operator's manual upgrade)
+
+The banner links to the download; swapping the binary is a manual step today.
+The platform mechanics, for reference / a future in-place updater:
+
+- **POSIX (Linux/macOS):** a running executable is held by inode, so you can
+  atomically `rename` a freshly downloaded binary over `process.execPath` while
+  the old process keeps running on the old inode. The new version takes effect
+  on the next launch. No need to stop first to replace the file — only to run
+  the new one.
+- **Windows:** a running `.exe` can't be overwritten or deleted, but it *can* be
+  renamed. The pattern is: rename the current `hezo.exe` → `hezo.old.exe`, move
+  the new binary into place, relaunch, then delete `hezo.old.exe` on next start.
+
+The data directory (`~/.hezo`) is independent of the binary, so data survives a
+swap.
+
+## Migration safety: pre-migration backup + restore
+
+The DB is **PGlite** (embedded Postgres) — the "database file" is the
+`~/.hezo/pgdata/` directory. Migrations are forward-only and run on every
+startup (tracked in `_migrations` by filename + SHA-256 checksum).
+
+**Before applying pending migrations to an already-initialized instance**
+(`startup.ts` → `runAvailableMigrations`):
+
+1. Compute the pending set (bundled filenames not in `_migrations`).
+2. If there are pending migrations **and** the instance already has applied
+   migrations (i.e. a real upgrade, not a fresh DB), snapshot the database with
+   PGlite's `dumpDataDir('gzip')` to
+   `<dataDir>/backups/pgdata-<ISO>-pre-<version>.tar.gz` (+ a sidecar `.json`
+   recording the version and pending list). The last 5 snapshots are kept.
+   `dumpDataDir` gives a consistent snapshot of the open DB — safer than copying
+   a live `pgdata` directory.
+3. If the backup fails, migrations are aborted (don't migrate without a safety
+   net). If a migration fails, the error names the backup directory and the
+   restore command.
+
+**Recovery (manual downgrade):**
+
+```
+hezo restore <dataDir>/backups/pgdata-<...>.tar.gz [--data-dir <dir>]
+```
+
+This wipes `pgdata` and reloads the snapshot (PGlite `loadDataDir`), then exits.
+Run the previous Hezo version against the restored data dir. The restored DB
+keeps its original master key.

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -36,6 +36,13 @@ jobs:
           bun-version: ${{ env.BUN_VERSION }}
       - run: bun install --frozen-lockfile
 
+      # Bun cross-compiles every platform from this one Linux runner. Each
+      # binary embeds the frontend, migrations, agent roles, and version, so
+      # the artifacts are fully self-contained. macOS binaries are unsigned —
+      # see CHANGELOG/docs for the Gatekeeper quarantine note.
+      - name: Build release binaries
+        run: bun run build:release
+
       - name: Tag and publish the GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -55,4 +62,5 @@ jobs:
           git push origin "refs/tags/${version}"
 
           bun run release --notes "$version" > /tmp/release-notes.md
-          gh release create "$version" --title "$version" --notes-file /tmp/release-notes.md
+          gh release create "$version" --title "$version" --notes-file /tmp/release-notes.md \
+            dist/binaries/*

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ dist/
 .turbo/
 migrations-bundle.json
 agents-bundle.json
+static-bundle.json
+packages/server/src/generated/
 packages/server/static/
 *.db
 .hezo/
@@ -21,5 +23,7 @@ packages/*/src/**/*.js
 packages/*/src/**/*.js.map
 packages/*/src/**/*.d.ts
 packages/*/src/**/*.d.ts.map
+# Hand-written ambient module declarations (not compiled output) — keep tracked.
+!packages/server/src/asset-modules.d.ts
 .http-mitm-proxy/
 .claude/plans/

--- a/bun.lock
+++ b/bun.lock
@@ -26,12 +26,11 @@
     },
     "packages/server": {
       "name": "@hezo/server",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "@electric-sql/pglite": "^0.2",
         "@hezo/shared": "workspace:*",
         "@hiddentao/logger": "^1.3.3",
-        "@hiddentao/zip-json": "^1",
         "@huggingface/transformers": "^4.0.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "commander": "^14.0.3",
@@ -52,7 +51,7 @@
     },
     "packages/shared": {
       "name": "@hezo/shared",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "@noble/hashes": "^1.8.0",
         "@scure/bip39": "^1.6.0",
@@ -63,7 +62,7 @@
     },
     "packages/web": {
       "name": "@hezo/web",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "@hezo/shared": "workspace:*",
         "@radix-ui/react-alert-dialog": "^1",
@@ -292,8 +291,6 @@
 
     "@hiddentao/logger": ["@hiddentao/logger@1.3.3", "", { "dependencies": { "picocolors": "^1.1.1" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-/DelaXZnOvfj6kmv4sJ6GuU0odz+5K7YoC8Ez8gvQzZlOa/1aFcF2iC/Y7K1ipkepjASoUXOuidQidFmB9XOgA=="],
 
-    "@hiddentao/zip-json": ["@hiddentao/zip-json@1.1.0", "", { "dependencies": { "chalk": "^5.3.0", "commander": "^12.0.0", "glob": "^10.3.10" }, "bin": { "zip-json": "bin/zip-json.js" } }, "sha512-rZ/d5LBzir6uCYM7aTTO4k9dRM7tcIhvMSlIf+6HZDn5/JdGBsslF3OaWELzDc+bzQlSFVg51+Jqza5X/rz3GA=="],
-
     "@hono/node-server": ["@hono/node-server@1.19.12", "", { "peerDependencies": { "hono": "^4" } }, "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw=="],
 
     "@httptoolkit/httpolyglot": ["@httptoolkit/httpolyglot@3.0.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-fU9psZBRc49PfdrxFZ8W19SwVQ4+rrc0EYVxmy7H41y6/elaIu5p68wly4uLVt1DPD0K92MdN65GqP3N1ofZKg=="],
@@ -360,8 +357,6 @@
 
     "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
-    "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
-
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
     "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
@@ -399,8 +394,6 @@
     "@peculiar/utils": ["@peculiar/utils@2.0.3", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ=="],
 
     "@peculiar/x509": ["@peculiar/x509@1.14.3", "", { "dependencies": { "@peculiar/asn1-cms": "^2.6.0", "@peculiar/asn1-csr": "^2.6.0", "@peculiar/asn1-ecc": "^2.6.0", "@peculiar/asn1-pkcs9": "^2.6.0", "@peculiar/asn1-rsa": "^2.6.0", "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.0", "pvtsutils": "^1.3.6", "reflect-metadata": "^0.2.2", "tslib": "^2.8.1", "tsyringe": "^4.10.0" } }, "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA=="],
-
-    "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
     "@playwright/test": ["@playwright/test@1.59.0", "", { "dependencies": { "playwright": "1.59.0" }, "bin": { "playwright": "cli.js" } }, "sha512-TOA5sTLd49rTDaZpYpvCQ9hGefHQq/OYOyCVnGqS2mjMfX+lGZv2iddIJd0I48cfxqSPttS9S3OuLKyylHcO1w=="],
 
@@ -744,8 +737,6 @@
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
-    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
-
     "base64-arraybuffer": ["base64-arraybuffer@1.0.2", "", {}, "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.13", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw=="],
@@ -757,8 +748,6 @@
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
     "boolean": ["boolean@3.2.0", "", {}, "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="],
-
-    "brace-expansion": ["brace-expansion@2.0.3", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
@@ -785,8 +774,6 @@
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
     "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
-
-    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
 
@@ -894,8 +881,6 @@
 
     "duplexify": ["duplexify@3.7.1", "", { "dependencies": { "end-of-stream": "^1.0.0", "inherits": "^2.0.1", "readable-stream": "^2.0.0", "stream-shift": "^1.0.0" } }, "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g=="],
 
-    "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
-
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.330", "", {}, "sha512-jFNydB5kFtYUobh4IkWUnXeyDbjf/r9gcUEXe1xcrcUxIGfTdzPXA+ld6zBRbwvgIGVzDll/LTIiDztEtckSnA=="],
@@ -974,8 +959,6 @@
 
     "flatbuffers": ["flatbuffers@25.9.23", "", {}, "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ=="],
 
-    "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
-
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
@@ -1001,8 +984,6 @@
     "get-uri": ["get-uri@6.0.5", "", { "dependencies": { "basic-ftp": "^5.0.2", "data-uri-to-buffer": "^6.0.2", "debug": "^4.3.4" } }, "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg=="],
 
     "git-raw-commits": ["git-raw-commits@5.0.1", "", { "dependencies": { "@conventional-changelog/git-client": "^2.6.0", "meow": "^13.0.0" }, "bin": { "git-raw-commits": "src/cli.js" } }, "sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ=="],
-
-    "glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
@@ -1107,8 +1088,6 @@
     "isomorphic-ws": ["isomorphic-ws@4.0.1", "", { "peerDependencies": { "ws": "*" } }, "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="],
 
     "iterall": ["iterall@1.3.0", "", {}, "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="],
-
-    "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
@@ -1288,11 +1267,7 @@
 
     "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
-    "minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
-
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
-
-    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
     "mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
 
@@ -1334,8 +1309,6 @@
 
     "pac-resolver": ["pac-resolver@7.0.1", "", { "dependencies": { "degenerator": "^5.0.0", "netmask": "^2.0.2" } }, "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg=="],
 
-    "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
-
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
@@ -1347,8 +1320,6 @@
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
-
-    "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
     "path-to-regexp": ["path-to-regexp@8.4.1", "", {}, "sha512-fvU78fIjZ+SBM9YwCknCvKOUKkLVqtWDVctl0s7xIqfmfb38t2TT4ZU2gHm+Z8xGwgW+QWEU3oQSAzIbo89Ggw=="],
 
@@ -1492,8 +1463,6 @@
 
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
 
-    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
-
     "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
 
     "socks": ["socks@2.8.8", "", { "dependencies": { "ip-address": "^10.1.1", "smart-buffer": "^4.2.0" } }, "sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog=="],
@@ -1518,15 +1487,11 @@
 
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
-    "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
     "string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-literal": ["strip-literal@3.1.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg=="],
 
@@ -1632,8 +1597,6 @@
 
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
-    "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
-
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
@@ -1665,14 +1628,6 @@
     "@hezo/server/@electric-sql/pglite": ["@electric-sql/pglite@0.2.17", "", {}, "sha512-qEpKRT2oUaWDH6tjRxLHjdzMqRUGYDnGZlKrnL4dJ77JVMcP2Hpo3NYnOSPKdZdeec57B6QPprCUFg0picx5Pw=="],
 
     "@hezo/web/@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
-
-    "@hiddentao/zip-json/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
-
-    "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
-
-    "@isaacs/cliui/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
-
-    "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
     "@modelcontextprotocol/sdk/hono": ["hono@4.12.9", "", {}, "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA=="],
 
@@ -1716,8 +1671,6 @@
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
-    "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
-
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
@@ -1744,15 +1697,7 @@
 
     "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
-    "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
     "@hezo/web/@vitejs/plugin-react/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
-
-    "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
-
-    "@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
-    "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "@radix-ui/react-label/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 	"scripts": {
 		"build": "bun run scripts/build.ts",
 		"build:compile": "bun run scripts/build.ts --compile",
+		"build:release": "bun run scripts/build.ts --release",
 		"check": "bunx biome check .",
 		"check:fix": "bunx biome check --write .",
 		"dev": "bun run scripts/dev.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -8,13 +8,14 @@
 		"test": "vitest run",
 		"typecheck": "tsc --noEmit",
 		"build:migrations": "bun run scripts/bundle-migrations.ts",
-		"build:agents": "bun run scripts/bundle-agents.ts"
+		"build:agents": "bun run scripts/bundle-agents.ts",
+		"build:static": "bun run scripts/bundle-static.ts",
+		"build:pglite": "bun run scripts/bundle-pglite.ts"
 	},
 	"dependencies": {
 		"@electric-sql/pglite": "^0.2",
 		"@hezo/shared": "workspace:*",
 		"@hiddentao/logger": "^1.3.3",
-		"@hiddentao/zip-json": "^1",
 		"@huggingface/transformers": "^4.0.1",
 		"@modelcontextprotocol/sdk": "^1.29.0",
 		"commander": "^14.0.3",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -4,9 +4,9 @@
 	"type": "module",
 	"scripts": {
 		"dev": "bun run --hot src/index.ts",
-		"build": "tsc",
+		"build": "bun run ../../scripts/ensure-bundles.ts && tsc",
 		"test": "vitest run",
-		"typecheck": "tsc --noEmit",
+		"typecheck": "bun run ../../scripts/ensure-bundles.ts && tsc --noEmit",
 		"build:migrations": "bun run scripts/bundle-migrations.ts",
 		"build:agents": "bun run scripts/bundle-agents.ts",
 		"build:static": "bun run scripts/bundle-static.ts",

--- a/packages/server/scripts/bundle-migrations.ts
+++ b/packages/server/scripts/bundle-migrations.ts
@@ -1,14 +1,20 @@
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
-import { zip } from '@hiddentao/zip-json';
 
+// Emit a plain `{ filename: sql }` JSON map that `src/db/migrate.ts` imports
+// statically, so `bun build --compile` embeds it into the binary's virtual FS.
+// A runtime `readFile` of a sibling path is NOT embedded by the compiler (it
+// resolves to `/$bunfs/root/...` and ENOENTs), so the SQL must travel through
+// the module graph. The migrations are small (~50KB), so no compression.
 const migrationsDir = join(import.meta.dir, '..', 'migrations');
 const outputPath = join(import.meta.dir, '..', 'src', 'db', 'migrations-bundle.json');
 
-const archive = await zip(['*.sql'], {
-	baseDir: migrationsDir,
-});
+const files = (await readdir(migrationsDir)).filter((f) => f.endsWith('.sql')).sort();
+const bundle: Record<string, string> = {};
+for (const file of files) {
+	bundle[file] = await readFile(join(migrationsDir, file), 'utf-8');
+}
 
 await mkdir(dirname(outputPath), { recursive: true });
-await writeFile(outputPath, JSON.stringify(archive));
-console.log(`Bundled migrations → ${outputPath}`);
+await writeFile(outputPath, JSON.stringify(bundle));
+console.log(`Bundled ${files.length} migration(s) → ${outputPath}`);

--- a/packages/server/scripts/bundle-pglite.ts
+++ b/packages/server/scripts/bundle-pglite.ts
@@ -1,0 +1,19 @@
+import { cp, mkdir } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
+// PGlite loads its runtime assets (the Postgres WASM, the initdb WASM, the
+// packed filesystem, and the pgvector bundle) via `new URL(..., import.meta.url)`,
+// which `bun build --compile` does NOT embed. Copy them into the source tree so
+// `db/pglite-assets.ts` can embed them with `import ... with { type: 'file' }`
+// and feed them to PGlite from memory in the compiled binary.
+const ASSETS = ['postgres.wasm', 'postgres.data', 'vector.tar.gz'];
+
+const pgliteEntry = Bun.resolveSync('@electric-sql/pglite', import.meta.dir);
+const distDir = dirname(pgliteEntry);
+const outDir = join(import.meta.dir, '..', 'src', 'generated', 'pglite');
+
+await mkdir(outDir, { recursive: true });
+for (const file of ASSETS) {
+	await cp(join(distDir, file), join(outDir, file));
+}
+console.log(`Bundled ${ASSETS.length} PGlite runtime asset(s) → ${outDir}`);

--- a/packages/server/scripts/bundle-static.ts
+++ b/packages/server/scripts/bundle-static.ts
@@ -1,0 +1,58 @@
+import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, extname, join, relative, sep } from 'node:path';
+
+// Bundle the built web frontend (`packages/web/dist`) into a single JSON map
+// that the server imports via a literal dynamic import, so `bun build --compile`
+// embeds it into the binary's virtual FS and the assets are served from memory
+// — no runtime extraction to a temp dir. Binary files are base64-encoded since
+// JSON can't carry raw bytes.
+const webDist = join(import.meta.dir, '..', '..', 'web', 'dist');
+const outputPath = join(import.meta.dir, '..', 'src', 'static-bundle.json');
+
+const MIME: Record<string, string> = {
+	'.html': 'text/html; charset=utf-8',
+	'.css': 'text/css; charset=utf-8',
+	'.js': 'application/javascript; charset=utf-8',
+	'.mjs': 'application/javascript; charset=utf-8',
+	'.json': 'application/json; charset=utf-8',
+	'.map': 'application/json; charset=utf-8',
+	'.txt': 'text/plain; charset=utf-8',
+	'.svg': 'image/svg+xml',
+	'.png': 'image/png',
+	'.jpg': 'image/jpeg',
+	'.jpeg': 'image/jpeg',
+	'.gif': 'image/gif',
+	'.webp': 'image/webp',
+	'.ico': 'image/x-icon',
+	'.woff': 'font/woff',
+	'.woff2': 'font/woff2',
+	'.ttf': 'font/ttf',
+	'.eot': 'application/vnd.ms-fontobject',
+	'.wasm': 'application/wasm',
+};
+
+async function walk(dir: string): Promise<string[]> {
+	const entries = await readdir(dir, { withFileTypes: true });
+	const out: string[] = [];
+	for (const entry of entries) {
+		const full = join(dir, entry.name);
+		if (entry.isDirectory()) out.push(...(await walk(full)));
+		else if (entry.isFile()) out.push(full);
+	}
+	return out;
+}
+
+const files = await walk(webDist);
+const bundle: Record<string, { type: string; b64: string }> = {};
+for (const full of files) {
+	const key = `/${relative(webDist, full).split(sep).join('/')}`;
+	const bytes = await readFile(full);
+	bundle[key] = {
+		type: MIME[extname(full).toLowerCase()] ?? 'application/octet-stream',
+		b64: bytes.toString('base64'),
+	};
+}
+
+await mkdir(dirname(outputPath), { recursive: true });
+await writeFile(outputPath, JSON.stringify(bundle));
+console.log(`Bundled ${files.length} static asset(s) → ${outputPath}`);

--- a/packages/server/src/asset-modules.d.ts
+++ b/packages/server/src/asset-modules.d.ts
@@ -1,0 +1,16 @@
+// `import x from './foo.wasm' with { type: 'file' }` resolves to the embedded
+// file's path string in a Bun-compiled binary. These ambient declarations let
+// tsc accept the imports without the generated asset files existing on disk
+// (they're produced by `scripts/bundle-pglite.ts` only for binary builds).
+declare module '*.wasm' {
+	const path: string;
+	export default path;
+}
+declare module '*.data' {
+	const path: string;
+	export default path;
+}
+declare module '*.tar.gz' {
+	const path: string;
+	export default path;
+}

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -17,6 +17,35 @@ export interface HezoConfig {
 	open: boolean;
 }
 
+function resolveDataDir(raw: string): string {
+	return raw.startsWith('~') ? resolve(homedir(), raw.slice(2)) : resolve(raw);
+}
+
+/**
+ * Handle the `hezo restore <backup>` subcommand: restore a pre-migration
+ * snapshot into the data dir's `pgdata`, then exit. Returns `true` when it
+ * handled the invocation so the caller skips normal server startup. The
+ * operator then runs the matching (older) Hezo binary against the restored DB.
+ */
+export async function runRestore(argv: string[] = process.argv): Promise<boolean> {
+	if (argv[2] !== 'restore') return false;
+
+	const program = new Command()
+		.name('hezo restore')
+		.description('Restore a pre-migration database snapshot (for manual downgrade)')
+		.argument('<backup>', 'path to a backup .tar.gz under <data-dir>/backups')
+		.option('--data-dir <path>', 'Data directory', DEFAULT_DATA_DIR)
+		// argv is [runtime, script, 'restore', <backup>, ...flags] in both dev and
+		// the compiled binary — parse only the tokens after the subcommand name.
+		.parse(argv.slice(3), { from: 'user' });
+
+	const backup = program.args[0];
+	const dataDir = resolveDataDir(program.opts().dataDir as string);
+	const { restoreDataDir } = await import('./db/backup.js');
+	await restoreDataDir(dataDir, resolve(backup));
+	return true;
+}
+
 export function parseArgs(argv: string[] = process.argv): HezoConfig {
 	const program = new Command()
 		.name('hezo')
@@ -36,12 +65,7 @@ export function parseArgs(argv: string[] = process.argv): HezoConfig {
 		throw new Error(`Invalid port: ${opts.port}. Must be 1-65535.`);
 	}
 
-	let dataDir: string = opts.dataDir;
-	if (dataDir.startsWith('~')) {
-		dataDir = resolve(homedir(), dataDir.slice(2));
-	} else {
-		dataDir = resolve(dataDir);
-	}
+	const dataDir = resolveDataDir(opts.dataDir as string);
 
 	// The user-facing master key is a 12-word BIP39 phrase; convert it to the
 	// internal hex. Anything that isn't a valid phrase (raw hex, opaque e2e key)

--- a/packages/server/src/db/agent-roles.ts
+++ b/packages/server/src/db/agent-roles.ts
@@ -11,6 +11,12 @@ export async function loadBundledAgentRoles(): Promise<Record<string, string>> {
 	} catch {
 		throw new Error("Failed to load agent roles bundle. Run 'bun run build:agents' first.");
 	}
+	// An empty stub (written by `scripts/ensure-bundles.ts` so tsc/vite can
+	// resolve the literal import) means the bundle was never generated — treat it
+	// as absent so `loadAgentRoles` falls back to the filesystem walk.
+	if (Object.keys(mod.default).length === 0) {
+		throw new Error('Agent roles bundle is empty. Run "bun run build:agents" first.');
+	}
 	return mod.default;
 }
 

--- a/packages/server/src/db/agent-roles.ts
+++ b/packages/server/src/db/agent-roles.ts
@@ -1,18 +1,17 @@
 import { resolvePartials } from './resolve-partials';
 
 export async function loadBundledAgentRoles(): Promise<Record<string, string>> {
-	const { readFile } = await import('node:fs/promises');
-	const { join } = await import('node:path');
-
-	const currentDir = new URL('.', import.meta.url).pathname;
-	const bundlePath = join(currentDir, 'agents-bundle.json');
-	let raw: string;
+	// Literal dynamic import so `bun build --compile` embeds the JSON into the
+	// binary's virtual FS (a runtime `readFile` of a sibling path is not embedded
+	// and ENOENTs at `/$bunfs/root/...`). In dev the file may be absent — the
+	// import rejects and `loadAgentRoles` falls back to the filesystem walk.
+	let mod: { default: Record<string, string> };
 	try {
-		raw = await readFile(bundlePath, 'utf-8');
+		mod = (await import('./agents-bundle.json')) as { default: Record<string, string> };
 	} catch {
 		throw new Error("Failed to load agent roles bundle. Run 'bun run build:agents' first.");
 	}
-	return JSON.parse(raw) as Record<string, string>;
+	return mod.default;
 }
 
 export async function loadFilesystemAgentRoles(agentsDir: string): Promise<Record<string, string>> {

--- a/packages/server/src/db/backup.ts
+++ b/packages/server/src/db/backup.ts
@@ -1,0 +1,99 @@
+import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { PGlite } from '@electric-sql/pglite';
+import { logger } from '../logger';
+
+const log = logger.child('backup');
+
+/** How many pre-migration snapshots to retain under `<dataDir>/backups`. */
+const KEEP_BACKUPS = 5;
+
+export interface BackupMeta {
+	version: string;
+	pending: string[];
+}
+
+/**
+ * Snapshot the live PGlite data directory to `<dataDir>/backups` before
+ * migrations mutate it. Uses PGlite's `dumpDataDir` (a consistent gzipped
+ * tarball of the open database) rather than copying the on-disk `pgdata`
+ * directory, which can be torn mid-write. Returns the tarball path so a failed
+ * migration can point the operator at it for a manual downgrade.
+ */
+export async function backupDataDir(
+	db: PGlite,
+	dataDir: string,
+	meta: BackupMeta,
+): Promise<string> {
+	const backupsDir = join(dataDir, 'backups');
+	await mkdir(backupsDir, { recursive: true });
+
+	const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+	const base = `pgdata-${stamp}-pre-${meta.version}`;
+	const tarPath = join(backupsDir, `${base}.tar.gz`);
+	const metaPath = join(backupsDir, `${base}.json`);
+
+	const dump = await db.dumpDataDir('gzip');
+	await writeFile(tarPath, Buffer.from(await dump.arrayBuffer()));
+	await writeFile(
+		metaPath,
+		JSON.stringify(
+			{
+				createdAt: new Date().toISOString(),
+				version: meta.version,
+				pending: meta.pending,
+				file: `${base}.tar.gz`,
+			},
+			null,
+			2,
+		),
+	);
+
+	log.info(`Backed up pgdata before migrations → ${tarPath}`);
+	await pruneBackups(backupsDir);
+	return tarPath;
+}
+
+async function pruneBackups(backupsDir: string): Promise<void> {
+	const tarballs = (await readdir(backupsDir)).filter((f) => f.endsWith('.tar.gz')).sort();
+	const excess = tarballs.slice(0, Math.max(0, tarballs.length - KEEP_BACKUPS));
+	for (const f of excess) {
+		const base = f.replace(/\.tar\.gz$/, '');
+		await rm(join(backupsDir, f), { force: true });
+		await rm(join(backupsDir, `${base}.json`), { force: true });
+	}
+}
+
+/**
+ * Restore a pre-migration snapshot into `<dataDir>/pgdata`, wiping the current
+ * data directory first. After this the operator runs the matching (older) Hezo
+ * binary. Used by the `hezo restore` CLI subcommand for manual downgrade.
+ */
+export async function restoreDataDir(dataDir: string, backupFile: string): Promise<void> {
+	const { PGlite } = await import('@electric-sql/pglite');
+	const { vector } = await import('@electric-sql/pglite/vector');
+	const { NodeFS } = await import('@electric-sql/pglite/nodefs');
+	const { loadPgliteAssets } = await import('./pglite-assets');
+
+	const pgDataPath = join(dataDir, 'pgdata');
+	const bytes = await readFile(backupFile);
+	const blob = new File([bytes as BlobPart], 'dump.tar.gz', { type: 'application/gzip' });
+
+	// In the compiled binary PGlite's WASM/data come from the embedded assets;
+	// in dev they resolve from node_modules.
+	const assets = await loadPgliteAssets(dataDir);
+
+	await rm(pgDataPath, { recursive: true, force: true });
+	const db = assets
+		? new PGlite({
+				fs: new NodeFS(pgDataPath),
+				extensions: { vector: assets.vectorExtension },
+				wasmModule: assets.wasmModule,
+				fsBundle: assets.fsBundle,
+				loadDataDir: blob,
+			})
+		: new PGlite({ fs: new NodeFS(pgDataPath), extensions: { vector }, loadDataDir: blob });
+	await db.query('SELECT 1');
+	await db.close();
+	log.info(`Restored pgdata from ${backupFile}`);
+}

--- a/packages/server/src/db/client.ts
+++ b/packages/server/src/db/client.ts
@@ -41,10 +41,22 @@ export async function openPersistentDb(
 	mkdirSync(dataDir, { recursive: true });
 
 	const { NodeFS } = await import('@electric-sql/pglite/nodefs');
+	const { loadPgliteAssets } = await import('./pglite-assets');
+
+	// In the compiled binary, PGlite's WASM/data assets are embedded and injected
+	// from memory; in dev this is null and PGlite resolves them from node_modules.
+	const assets = await loadPgliteAssets(dataDir);
 
 	for (let attempt = 0; attempt < 2; attempt++) {
 		try {
-			const db = new PGlite({ fs: new NodeFS(pgDataPath), extensions: { vector } });
+			const db = assets
+				? new PGlite({
+						fs: new NodeFS(pgDataPath),
+						extensions: { vector: assets.vectorExtension },
+						wasmModule: assets.wasmModule,
+						fsBundle: assets.fsBundle,
+					})
+				: new PGlite({ fs: new NodeFS(pgDataPath), extensions: { vector } });
 			await db.query('SELECT 1');
 			return db;
 		} catch (err) {

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -77,6 +77,12 @@ export async function loadBundledMigrations(): Promise<Record<string, string>> {
 	} catch {
 		throw new Error("Failed to load migration bundle. Run 'bun run build:migrations' first.");
 	}
+	// An empty stub (written by `scripts/ensure-bundles.ts` so tsc/vite can
+	// resolve the literal import) means the bundle was never generated — treat it
+	// as absent so the caller falls back to the filesystem.
+	if (Object.keys(mod.default).length === 0) {
+		throw new Error('Migration bundle is empty. Run "bun run build:migrations" first.');
+	}
 	return mod.default;
 }
 

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -48,38 +48,36 @@ export async function runMigrations(db: PGlite, migrations: Record<string, strin
 	}
 }
 
-export async function loadBundledMigrations(): Promise<Record<string, string>> {
-	const { unzip, list } = await import('@hiddentao/zip-json');
-	const { readFile, mkdir, rm } = await import('node:fs/promises');
-	const { join } = await import('node:path');
-	const { tmpdir } = await import('node:os');
-
-	const currentDir = new URL('.', import.meta.url).pathname;
-	const bundlePath = join(currentDir, 'migrations-bundle.json');
-	// biome-ignore lint/suspicious/noExplicitAny: JSON.parse returns unknown, zip-json expects its own type
-	let archive: any;
+/** Bundled migration filenames (sorted) not yet recorded in `_migrations`. */
+export async function getPendingMigrations(
+	db: PGlite,
+	migrations: Record<string, string>,
+): Promise<string[]> {
+	let appliedSet = new Set<string>();
 	try {
-		archive = JSON.parse(await readFile(bundlePath, 'utf-8'));
+		const applied = await db.query<{ filename: string }>('SELECT filename FROM _migrations');
+		appliedSet = new Set(applied.rows.map((r) => r.filename));
+	} catch {
+		// `_migrations` doesn't exist yet → a brand-new DB, everything is pending.
+	}
+	return Object.keys(migrations)
+		.sort()
+		.filter((f) => !appliedSet.has(f));
+}
+
+export async function loadBundledMigrations(): Promise<Record<string, string>> {
+	// A *literal* dynamic import is statically analyzable, so `bun build --compile`
+	// embeds the JSON into the binary's virtual FS. A runtime `readFile` of a
+	// sibling path is NOT embedded (it resolves to `/$bunfs/root/...` and ENOENTs).
+	// In dev (`bun run`) the file may be absent — the import rejects and the caller
+	// falls back to `loadFilesystemMigrations`.
+	let mod: { default: Record<string, string> };
+	try {
+		mod = (await import('./migrations-bundle.json')) as { default: Record<string, string> };
 	} catch {
 		throw new Error("Failed to load migration bundle. Run 'bun run build:migrations' first.");
 	}
-
-	const files = list(archive);
-	const tmpExtractDir = join(tmpdir(), `hezo-migrations-${Date.now()}`);
-	await mkdir(tmpExtractDir, { recursive: true });
-
-	try {
-		await unzip(archive, { outputDir: tmpExtractDir });
-		const migrations: Record<string, string> = {};
-		await Promise.all(
-			files.map(async (file: { path: string }) => {
-				migrations[file.path] = await readFile(join(tmpExtractDir, file.path), 'utf-8');
-			}),
-		);
-		return migrations;
-	} finally {
-		await rm(tmpExtractDir, { recursive: true, force: true });
-	}
+	return mod.default;
 }
 
 export async function loadFilesystemMigrations(

--- a/packages/server/src/db/pglite-assets.ts
+++ b/packages/server/src/db/pglite-assets.ts
@@ -1,0 +1,70 @@
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import type { vector } from '@electric-sql/pglite/vector';
+import { logger } from '../logger';
+
+const log = logger.child('pglite-assets');
+
+export interface PgliteAssetInjection {
+	wasmModule: WebAssembly.Module;
+	fsBundle: Blob;
+	vectorExtension: typeof vector;
+}
+
+/** Read an embedded asset's bytes. A literal `import ... with { type: 'file' }`
+ *  resolves to the file's path inside the binary's virtual FS (`/$bunfs/...`);
+ *  in dev the file is absent and the import rejects. */
+async function readEmbedded(load: () => Promise<{ default: string }>): Promise<Buffer> {
+	const { default: path } = await load();
+	return readFile(path);
+}
+
+/**
+ * Embedded PGlite runtime assets, fed to PGlite from memory so the compiled
+ * binary is self-contained. PGlite normally loads `postgres.wasm` /
+ * `postgres.data` / the pgvector bundle via `new URL(..., import.meta.url)`,
+ * which `bun build --compile` does not embed.
+ *
+ * Returns `null` in dev / tests (assets not generated) — callers then let
+ * PGlite resolve them from `node_modules` as usual.
+ */
+export async function loadPgliteAssets(dataDir: string): Promise<PgliteAssetInjection | null> {
+	let postgresWasm: Buffer;
+	let postgresData: Buffer;
+	let vectorTarball: Buffer;
+	try {
+		[postgresWasm, postgresData, vectorTarball] = await Promise.all([
+			readEmbedded(() => import('../generated/pglite/postgres.wasm', { with: { type: 'file' } })),
+			readEmbedded(() => import('../generated/pglite/postgres.data', { with: { type: 'file' } })),
+			readEmbedded(() => import('../generated/pglite/vector.tar.gz', { with: { type: 'file' } })),
+		]);
+	} catch {
+		return null;
+	}
+
+	// The vector extension loader reads its bundlePath via `fs`, so it must be a
+	// real file URL — extract the embedded tarball into the data dir once.
+	const vectorDir = join(dataDir, '.pglite');
+	const vectorPath = join(vectorDir, 'vector.tar.gz');
+	await mkdir(vectorDir, { recursive: true });
+	if (!existsSync(vectorPath)) {
+		await writeFile(vectorPath, vectorTarball);
+	}
+	const vectorUrl = pathToFileURL(vectorPath);
+	const vectorExtension = {
+		name: 'pgvector',
+		setup: async (_pg: unknown, emscriptenOpts: unknown) => ({
+			emscriptenOpts,
+			bundlePath: vectorUrl,
+		}),
+	} as unknown as typeof vector;
+
+	log.info('Using embedded PGlite runtime assets');
+	return {
+		wasmModule: await WebAssembly.compile(postgresWasm),
+		fsBundle: new Blob([postgresData as BlobPart]),
+		vectorExtension,
+	};
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -2,7 +2,7 @@ import './console-shim';
 import type { PGlite } from '@electric-sql/pglite';
 import { AuthType, DEFAULT_WEB_PORT } from '@hezo/shared';
 import { app } from './app';
-import { parseArgs } from './cli';
+import { parseArgs, runRestore } from './cli';
 import type { MasterKeyManager } from './crypto/master-key';
 import { logger } from './logger';
 import { loadAdminAuth, verifyToken } from './middleware/auth';
@@ -60,6 +60,11 @@ process.on('uncaughtException', (err) => {
 
 interface WsConnectionData extends WsData {
 	_token?: string;
+}
+
+// `hezo restore <backup>` runs and exits before any server startup.
+if (await runRestore()) {
+	process.exit(0);
 }
 
 const config = parseArgs();

--- a/packages/server/src/routes/updates.ts
+++ b/packages/server/src/routes/updates.ts
@@ -1,0 +1,73 @@
+import { Hono } from 'hono';
+import { logger } from '../logger';
+import { HEZO_VERSION } from '../version';
+
+const log = logger.child('updates');
+
+/** The repo whose GitHub Releases this build checks for updates. */
+const REPO = 'hezo-ai/hezo';
+/** Cache the upstream check for an hour — GitHub rate-limits anonymous calls. */
+const TTL_MS = 60 * 60 * 1000;
+
+export interface UpdateInfo {
+	current: string;
+	latest: string | null;
+	updateAvailable: boolean;
+	url: string | null;
+}
+
+let cache: { at: number; data: UpdateInfo } | null = null;
+
+/** Parse a plain `MAJOR.MINOR.PATCH` tag (no `v` prefix, matching our releases). */
+function parseSemver(v: string): [number, number, number] | null {
+	const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(v.trim());
+	return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
+}
+
+/** True when `latest` is strictly greater than `current`. */
+export function isNewer(latest: string, current: string): boolean {
+	const a = parseSemver(latest);
+	const b = parseSemver(current);
+	if (!a || !b) return false;
+	for (let i = 0; i < 3; i++) {
+		if (a[i] !== b[i]) return a[i] > b[i];
+	}
+	return false;
+}
+
+async function fetchLatest(): Promise<UpdateInfo> {
+	const base: UpdateInfo = {
+		current: HEZO_VERSION,
+		latest: null,
+		updateAvailable: false,
+		url: null,
+	};
+	try {
+		const res = await fetch(`https://api.github.com/repos/${REPO}/releases/latest`, {
+			headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'hezo' },
+			signal: AbortSignal.timeout(5000),
+		});
+		if (!res.ok) return base;
+		const body = (await res.json()) as { tag_name?: string; html_url?: string };
+		const latest = body.tag_name ?? null;
+		return {
+			...base,
+			latest,
+			url: body.html_url ?? null,
+			updateAvailable: latest ? isNewer(latest, HEZO_VERSION) : false,
+		};
+	} catch (err) {
+		// Fail soft: no network / egress / rate limit → report "no update".
+		log.warn('update check failed', err);
+		return base;
+	}
+}
+
+export const updatesRoutes = new Hono();
+
+updatesRoutes.get('/updates/latest', async (c) => {
+	if (!cache || Date.now() - cache.at >= TTL_MS) {
+		cache = { at: Date.now(), data: await fetchLatest() };
+	}
+	return c.json(cache.data);
+});

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -44,6 +44,7 @@ import { tasksRoutes } from './routes/tasks';
 import { teamTemplatesRoutes } from './routes/team-templates';
 import { teamsRoutes } from './routes/teams';
 import { uiStateRoutes } from './routes/ui-state';
+import { updatesRoutes } from './routes/updates';
 import { ContainerLogStreamer } from './services/container-logs';
 import { DockerClient } from './services/docker';
 import { EgressProxy, loadOrCreateCA } from './services/egress';
@@ -52,6 +53,8 @@ import { JobManager } from './services/job-manager';
 import { LogStreamBroker } from './services/log-stream-broker';
 import { SshAgentServer } from './services/ssh-agent';
 import { WebSocketManager } from './services/ws';
+import { loadStaticBundle } from './static-assets';
+import { HEZO_VERSION } from './version';
 
 export type { HezoConfig };
 
@@ -83,7 +86,7 @@ export async function startup(config: HezoConfig): Promise<StartupResult> {
 	const db = await openPersistentDb(config.dataDir, { reset: config.reset });
 
 	await db.exec(BASE_SCHEMA);
-	await runAvailableMigrations(db);
+	await runAvailableMigrations(db, config.dataDir);
 	await runSeed(db);
 
 	const masterKeyManager = new MasterKeyManager();
@@ -231,9 +234,10 @@ export function buildApp(
 	// Public routes
 	app.route('/', healthRoutes);
 
+	// `/api/status` carries master-key state + version. `/` is left to the SPA
+	// catch-all below (the compiled binary serves index.html there).
 	const statusHandler = (c: Context<Env>) =>
-		c.json({ masterKeyState: masterKeyManager.getState(), version: '0.1.0' });
-	app.get('/', statusHandler);
+		c.json({ masterKeyState: masterKeyManager.getState(), version: HEZO_VERSION });
 	app.get('/api/status', statusHandler);
 
 	// Skill file (public)
@@ -295,49 +299,59 @@ export function buildApp(
 	app.route('/api', oauthRoutes);
 	app.route('/api', previewRoutes);
 	app.route('/api', searchRoutes);
+	app.route('/api', updatesRoutes);
 
-	// Static file serving for compiled binary (frontend assets)
-	const staticDir = resolve(new URL('.', import.meta.url).pathname, '..', 'static');
-	if (existsSync(staticDir)) {
-		const STATIC_MIME: Record<string, string> = {
-			'.html': 'text/html',
-			'.css': 'text/css',
-			'.js': 'application/javascript',
-			'.json': 'application/json',
-			'.png': 'image/png',
-			'.jpg': 'image/jpeg',
-			'.svg': 'image/svg+xml',
-			'.ico': 'image/x-icon',
-			'.woff2': 'font/woff2',
-		};
+	// Frontend (SPA) serving. The compiled binary serves from the in-memory
+	// bundle embedded at build time (`loadStaticBundle`); in dev that bundle is
+	// absent, so we fall back to reading `packages/web/dist` off disk. Run the
+	// vite dev server for hot-reload during development.
+	const STATIC_MIME: Record<string, string> = {
+		'.html': 'text/html; charset=utf-8',
+		'.css': 'text/css; charset=utf-8',
+		'.js': 'application/javascript; charset=utf-8',
+		'.json': 'application/json; charset=utf-8',
+		'.png': 'image/png',
+		'.jpg': 'image/jpeg',
+		'.svg': 'image/svg+xml',
+		'.ico': 'image/x-icon',
+		'.woff2': 'font/woff2',
+	};
+	const webDistDir = resolve(new URL('.', import.meta.url).pathname, '..', '..', 'web', 'dist');
 
-		app.get('*', async (c) => {
-			const urlPath = new URL(c.req.url).pathname;
+	app.get('*', async (c) => {
+		const urlPath = new URL(c.req.url).pathname;
+		if (urlPath.startsWith('/api/') || urlPath.startsWith('/agent-api/')) {
+			return c.text('Not found', 404);
+		}
+		const filePath = urlPath === '/' ? '/index.html' : urlPath;
 
-			if (urlPath.startsWith('/api/') || urlPath.startsWith('/agent-api/')) {
-				return c.text('Not found', 404);
-			}
-			const filePath = urlPath === '/' ? '/index.html' : urlPath;
-			const fullPath = join(staticDir, filePath);
+		// In-memory bundle (compiled binary).
+		const bundle = await loadStaticBundle();
+		if (bundle) {
+			const asset = bundle.get(filePath) ?? bundle.get('/index.html');
+			if (!asset) return c.text('Not found', 404);
+			return new Response(asset.body, { headers: { 'Content-Type': asset.type } });
+		}
 
+		// Filesystem fallback (dev / `bun run`).
+		if (existsSync(webDistDir)) {
+			const fullPath = join(webDistDir, filePath);
 			if (existsSync(fullPath)) {
 				const ext = extname(fullPath).toLowerCase();
-				const content = readFileSync(fullPath);
-				return new Response(content, {
+				return new Response(readFileSync(fullPath), {
 					headers: { 'Content-Type': STATIC_MIME[ext] || 'application/octet-stream' },
 				});
 			}
-
-			// SPA fallback
-			const indexPath = join(staticDir, 'index.html');
+			const indexPath = join(webDistDir, 'index.html');
 			if (existsSync(indexPath)) {
-				const content = readFileSync(indexPath);
-				return new Response(content, { headers: { 'Content-Type': 'text/html' } });
+				return new Response(readFileSync(indexPath), {
+					headers: { 'Content-Type': 'text/html; charset=utf-8' },
+				});
 			}
+		}
 
-			return c.text('Not found', 404);
-		});
-	}
+		return c.text('Not found', 404);
+	});
 
 	return app;
 }
@@ -353,20 +367,64 @@ async function cleanupOrphanRunSockets(_db: PGlite, dataDir: string): Promise<vo
 	}
 }
 
-async function runAvailableMigrations(db: PGlite): Promise<void> {
+async function loadMigrations(): Promise<Record<string, string> | null> {
+	const { loadBundledMigrations, loadFilesystemMigrations } = await import('./db/migrate.js');
 	try {
-		const { runMigrations, loadBundledMigrations } = await import('./db/migrate.js');
-		const migrations = await loadBundledMigrations();
-		await runMigrations(db, migrations);
+		return await loadBundledMigrations();
 	} catch {
+		// Dev (`bun run`): the bundle isn't generated — read from the source tree.
+	}
+	try {
+		const migrationsDir = join(new URL('.', import.meta.url).pathname, '..', 'migrations');
+		return await loadFilesystemMigrations(migrationsDir);
+	} catch {
+		return null;
+	}
+}
+
+async function runAvailableMigrations(db: PGlite, dataDir: string): Promise<void> {
+	const migrations = await loadMigrations();
+	if (!migrations) {
+		log.warn('No migrations found. Run build:migrations or add migration files.');
+		return;
+	}
+
+	const { getPendingMigrations, runMigrations } = await import('./db/migrate.js');
+	const pending = await getPendingMigrations(db, migrations);
+	if (pending.length === 0) return;
+
+	// Snapshot before mutating an *existing* instance. A brand-new DB (nothing
+	// applied yet) has no data worth saving, so skip the backup there.
+	const applied = await countAppliedMigrations(db);
+	if (applied > 0) {
 		try {
-			const { runMigrations, loadFilesystemMigrations } = await import('./db/migrate.js');
-			const migrationsDir = join(new URL('.', import.meta.url).pathname, '..', 'migrations');
-			const migrations = await loadFilesystemMigrations(migrationsDir);
-			await runMigrations(db, migrations);
-		} catch {
-			log.warn('No migrations found. Run build:migrations or add migration files.');
+			const { backupDataDir } = await import('./db/backup.js');
+			await backupDataDir(db, dataDir, { version: HEZO_VERSION, pending });
+		} catch (err) {
+			log.error('Pre-migration backup failed; aborting migrations to protect existing data', err);
+			throw err;
 		}
+	}
+
+	try {
+		await runMigrations(db, migrations);
+	} catch (err) {
+		log.error(
+			`Migration failed. To recover, downgrade to the previous Hezo version and restore the ` +
+				`pre-migration snapshot from ${join(dataDir, 'backups')} ` +
+				`(\`hezo restore <backup.tar.gz>\`).`,
+			err,
+		);
+		throw err;
+	}
+}
+
+async function countAppliedMigrations(db: PGlite): Promise<number> {
+	try {
+		const r = await db.query<{ c: number }>('SELECT COUNT(*)::int AS c FROM _migrations');
+		return r.rows[0]?.c ?? 0;
+	} catch {
+		return 0;
 	}
 }
 

--- a/packages/server/src/static-assets.ts
+++ b/packages/server/src/static-assets.ts
@@ -26,6 +26,10 @@ export async function loadStaticBundle(): Promise<Map<string, StaticAsset> | nul
 	} catch {
 		return null;
 	}
+	// An empty stub (written by `scripts/ensure-bundles.ts` so tsc/vite can
+	// resolve the literal import) means the bundle was never generated — treat it
+	// as absent so the caller falls back to reading `packages/web/dist` off disk.
+	if (Object.keys(mod.default).length === 0) return null;
 	const map = new Map<string, StaticAsset>();
 	for (const [path, { type, b64 }] of Object.entries(mod.default)) {
 		map.set(path, { type, body: new Blob([Buffer.from(b64, 'base64')], { type }) });

--- a/packages/server/src/static-assets.ts
+++ b/packages/server/src/static-assets.ts
@@ -1,0 +1,35 @@
+/**
+ * In-memory frontend assets for the compiled binary.
+ *
+ * `scripts/bundle-static.ts` generates `static-bundle.json` (a `{ path: {type,
+ * b64} }` map of `packages/web/dist`). A *literal* dynamic import lets
+ * `bun build --compile` embed it into the binary's virtual FS, so the SPA is
+ * served straight from memory with no temp-dir extraction. In dev the file is
+ * absent — the import rejects and the server falls back to reading
+ * `packages/web/dist` off disk.
+ */
+
+export interface StaticAsset {
+	type: string;
+	body: Blob;
+}
+
+let cache: Map<string, StaticAsset> | null = null;
+
+export async function loadStaticBundle(): Promise<Map<string, StaticAsset> | null> {
+	if (cache) return cache;
+	let mod: { default: Record<string, { type: string; b64: string }> };
+	try {
+		mod = (await import('./static-bundle.json')) as {
+			default: Record<string, { type: string; b64: string }>;
+		};
+	} catch {
+		return null;
+	}
+	const map = new Map<string, StaticAsset>();
+	for (const [path, { type, b64 }] of Object.entries(mod.default)) {
+		map.set(path, { type, body: new Blob([Buffer.from(b64, 'base64')], { type }) });
+	}
+	cache = map;
+	return cache;
+}

--- a/packages/server/src/version.ts
+++ b/packages/server/src/version.ts
@@ -1,0 +1,24 @@
+/**
+ * The running build's version string.
+ *
+ * In the compiled binary it is injected at build time via
+ * `bun build --define process.env.HEZO_VERSION="<version>"` (see
+ * `scripts/build.ts`), so the constant folds to a literal and the dev fallback
+ * below is tree-shaken away.
+ *
+ * In dev (`bun run`) the define is absent, so we read the version off the
+ * server package.json on disk — `import.meta.url` points at the real file, so
+ * `../package.json` resolves. A static/dynamic *import* of package.json would
+ * violate the server tsconfig `rootDir`, so this stays a runtime read.
+ */
+function readDevVersion(): string {
+	try {
+		const { readFileSync } = require('node:fs');
+		const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf-8'));
+		return typeof pkg.version === 'string' ? pkg.version : '0.0.0-dev';
+	} catch {
+		return '0.0.0-dev';
+	}
+}
+
+export const HEZO_VERSION: string = process.env.HEZO_VERSION ?? readDevVersion();

--- a/packages/server/test/auth-middleware.test.ts
+++ b/packages/server/test/auth-middleware.test.ts
@@ -301,8 +301,12 @@ describe('authMiddleware (via HTTP)', () => {
 	});
 
 	it('skips non-API paths (no auth needed)', async () => {
+		// `/` is the SPA catch-all. With no frontend bundle/dist built in tests it
+		// 404s — but the point is the auth middleware lets it through (not 401/403)
+		// rather than gating it like an API route.
 		const res = await app.request('/');
-		expect(res.status).toBe(200);
+		expect(res.status).not.toBe(401);
+		expect(res.status).not.toBe(403);
 	});
 });
 

--- a/packages/server/test/db-backup.test.ts
+++ b/packages/server/test/db-backup.test.ts
@@ -1,0 +1,50 @@
+import { mkdtemp, readdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { backupDataDir, restoreDataDir } from '../src/db/backup';
+import { openPersistentDb } from '../src/db/client';
+import { safeClose } from './helpers';
+
+describe('pre-migration backup + restore', () => {
+	let dataDir: string;
+
+	afterEach(async () => {
+		if (dataDir) await rm(dataDir, { recursive: true, force: true });
+	});
+
+	it('snapshots the data dir and restores it after a wipe', async () => {
+		dataDir = await mkdtemp(join(tmpdir(), 'hezo-backup-'));
+
+		// Seed an instance with some data.
+		let db = await openPersistentDb(dataDir);
+		await db.exec('CREATE TABLE widgets (id SERIAL PRIMARY KEY, name TEXT NOT NULL)');
+		await db.exec("INSERT INTO widgets (name) VALUES ('alpha'), ('beta')");
+
+		const tarPath = await backupDataDir(db, dataDir, {
+			version: '0.1.0',
+			pending: ['002_next.sql'],
+		});
+		await safeClose(db);
+
+		// Backup tarball + sidecar metadata landed under backups/.
+		const backups = await readdir(join(dataDir, 'backups'));
+		expect(backups).toContain(tarPath.split('/').pop());
+		expect(backups.some((f) => f.endsWith('.json'))).toBe(true);
+
+		// Simulate a botched migration by dropping the table, then restore.
+		db = await openPersistentDb(dataDir);
+		await db.exec('DROP TABLE widgets');
+		await safeClose(db);
+
+		await restoreDataDir(dataDir, tarPath);
+
+		db = await openPersistentDb(dataDir);
+		try {
+			const rows = await db.query<{ name: string }>('SELECT name FROM widgets ORDER BY id');
+			expect(rows.rows.map((r) => r.name)).toEqual(['alpha', 'beta']);
+		} finally {
+			await safeClose(db);
+		}
+	});
+});

--- a/packages/server/test/migrate.test.ts
+++ b/packages/server/test/migrate.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createMemoryDb } from '../src/db/client';
-import { runMigrations } from '../src/db/migrate';
+import { getPendingMigrations, runMigrations } from '../src/db/migrate';
 import { safeClose } from './helpers';
 
 describe('migration runner', () => {
@@ -62,6 +62,27 @@ describe('migration runner', () => {
 			expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('001_test.sql'));
 		} finally {
 			logSpy.mockRestore();
+			await safeClose(db);
+		}
+	});
+
+	it('reports pending migrations before and after applying', async () => {
+		const db = await createMemoryDb();
+		try {
+			const migrations = {
+				'001_a.sql': 'CREATE TABLE a (id SERIAL PRIMARY KEY);',
+				'002_b.sql': 'CREATE TABLE b (id SERIAL PRIMARY KEY);',
+			};
+
+			// No `_migrations` table yet → everything pending, sorted.
+			expect(await getPendingMigrations(db, migrations)).toEqual(['001_a.sql', '002_b.sql']);
+
+			await runMigrations(db, { '001_a.sql': migrations['001_a.sql'] });
+			expect(await getPendingMigrations(db, migrations)).toEqual(['002_b.sql']);
+
+			await runMigrations(db, migrations);
+			expect(await getPendingMigrations(db, migrations)).toEqual([]);
+		} finally {
 			await safeClose(db);
 		}
 	});

--- a/packages/server/test/updates.test.ts
+++ b/packages/server/test/updates.test.ts
@@ -1,0 +1,65 @@
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import type { Env } from '../src/lib/types';
+import { isNewer } from '../src/routes/updates';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp } from './helpers/app';
+
+describe('isNewer (semver comparison)', () => {
+	it('detects a strictly greater version', () => {
+		expect(isNewer('0.2.0', '0.1.0')).toBe(true);
+		expect(isNewer('1.0.0', '0.9.9')).toBe(true);
+		expect(isNewer('0.1.1', '0.1.0')).toBe(true);
+	});
+
+	it('returns false for equal or older versions', () => {
+		expect(isNewer('0.1.0', '0.1.0')).toBe(false);
+		expect(isNewer('0.1.0', '0.2.0')).toBe(false);
+		expect(isNewer('1.0.0', '1.0.1')).toBe(false);
+	});
+
+	it('returns false for unparseable versions', () => {
+		expect(isNewer('v0.2.0', '0.1.0')).toBe(false);
+		expect(isNewer('garbage', '0.1.0')).toBe(false);
+	});
+});
+
+describe('GET /api/updates/latest', () => {
+	let app: Hono<Env>;
+	let db: Awaited<ReturnType<typeof createTestApp>>['db'];
+	let token: string;
+
+	beforeAll(async () => {
+		const ctx = await createTestApp();
+		app = ctx.app;
+		db = ctx.db;
+		token = ctx.token;
+	});
+
+	afterAll(async () => {
+		await safeClose(db);
+	});
+
+	it('reports an available update from the latest GitHub release', async () => {
+		const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					tag_name: '9.9.9',
+					html_url: 'https://github.com/hezo-ai/hezo/releases/9.9.9',
+				}),
+				{ status: 200, headers: { 'Content-Type': 'application/json' } },
+			),
+		);
+		try {
+			const res = await app.request('/api/updates/latest', { headers: authHeader(token) });
+			expect(res.status).toBe(200);
+			const body = await res.json();
+			expect(body.latest).toBe('9.9.9');
+			expect(body.updateAvailable).toBe(true);
+			expect(body.url).toContain('releases/9.9.9');
+			expect(typeof body.current).toBe('string');
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+});

--- a/packages/web/src/components/update-banner.tsx
+++ b/packages/web/src/components/update-banner.tsx
@@ -1,0 +1,66 @@
+import { X } from 'lucide-react';
+import { useState } from 'react';
+import { useUpdateCheck } from '../hooks/use-update-check';
+
+const DISMISS_KEY = 'hezo:update-dismissed';
+
+function readDismissed(): string | null {
+	try {
+		return localStorage.getItem(DISMISS_KEY);
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Dismissible "update available" banner. A newer release is detected by the
+ * server (`/api/updates/latest`); clicking through opens the GitHub Release to
+ * download. Dismissal is remembered per-version so it won't nag for the same one.
+ */
+export function UpdateBanner() {
+	const { data } = useUpdateCheck();
+	const [dismissed, setDismissed] = useState<string | null>(readDismissed);
+
+	if (!data?.updateAvailable || !data.latest || dismissed === data.latest) return null;
+
+	const dismiss = () => {
+		try {
+			localStorage.setItem(DISMISS_KEY, data.latest as string);
+		} catch {
+			// ignore storage failures — banner just reappears next load
+		}
+		setDismissed(data.latest);
+	};
+
+	return (
+		<div
+			data-testid="update-banner"
+			className="flex flex-col sm:flex-row sm:items-center gap-2 px-4 py-2 text-[13px] bg-bg-elevated border-b border-border text-text"
+		>
+			<span className="flex-1">
+				Hezo <span className="font-medium">{data.latest}</span> is available — you're on{' '}
+				{data.current}.
+			</span>
+			<div className="flex items-center gap-3">
+				{data.url && (
+					<a
+						href={data.url}
+						target="_blank"
+						rel="noreferrer"
+						className="font-medium text-primary hover:underline"
+					>
+						Download
+					</a>
+				)}
+				<button
+					type="button"
+					onClick={dismiss}
+					aria-label="Dismiss update notification"
+					className="text-text-muted hover:text-text"
+				>
+					<X className="w-4 h-4" />
+				</button>
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/hooks/use-update-check.ts
+++ b/packages/web/src/hooks/use-update-check.ts
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '../lib/api';
+
+export interface UpdateInfo {
+	current: string;
+	latest: string | null;
+	updateAvailable: boolean;
+	url: string | null;
+}
+
+/**
+ * Poll the server's GitHub-Releases check. The server caches upstream for an
+ * hour and fails soft, so this is cheap and never errors the shell.
+ */
+export function useUpdateCheck() {
+	return useQuery({
+		queryKey: ['update-check'],
+		queryFn: () => api.get<UpdateInfo>('/api/updates/latest'),
+		staleTime: 60 * 60 * 1000,
+		gcTime: 60 * 60 * 1000,
+		retry: false,
+	});
+}

--- a/packages/web/src/routes/__root.tsx
+++ b/packages/web/src/routes/__root.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react';
 import { MasterKeyGate } from '../components/master-key-gate';
 import { MasterKeyStep, SetupGate } from '../components/setup/setup-wizard';
 import { TeamSidebar } from '../components/team-sidebar';
+import { UpdateBanner } from '../components/update-banner';
 import { SocketProvider } from '../contexts/socket-context';
 import { useRouteTeamId } from '../hooks/use-route-team-id';
 import { useStatus } from '../hooks/use-status';
@@ -106,6 +107,7 @@ function ShellLayout() {
 				>
 					<Menu className="w-4 h-4" />
 				</button>
+				<UpdateBanner />
 				<Outlet />
 			</main>
 			{drawerOpen && (

--- a/packages/web/test/update-banner.test.tsx
+++ b/packages/web/test/update-banner.test.tsx
@@ -1,0 +1,57 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, expect, test } from 'vitest';
+import { UpdateBanner } from '../src/components/update-banner';
+import type { UpdateInfo } from '../src/hooks/use-update-check';
+
+function renderBanner(data: UpdateInfo) {
+	const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	// Seed the cache so the component renders without hitting the network.
+	qc.setQueryData(['update-check'], data);
+	return render(
+		<QueryClientProvider client={qc}>
+			<UpdateBanner />
+		</QueryClientProvider>,
+	);
+}
+
+afterEach(() => {
+	localStorage.clear();
+});
+
+test('shows when an update is available and links to the release', () => {
+	const { getByTestId, getByText } = renderBanner({
+		current: '0.1.0',
+		latest: '0.2.0',
+		updateAvailable: true,
+		url: 'https://github.com/hezo-ai/hezo/releases/0.2.0',
+	});
+	expect(getByTestId('update-banner')).toBeTruthy();
+	const link = getByText('Download') as HTMLAnchorElement;
+	expect(link.getAttribute('href')).toBe('https://github.com/hezo-ai/hezo/releases/0.2.0');
+});
+
+test('hidden when no update is available', () => {
+	const { queryByTestId } = renderBanner({
+		current: '0.1.0',
+		latest: '0.1.0',
+		updateAvailable: false,
+		url: null,
+	});
+	expect(queryByTestId('update-banner')).toBeNull();
+});
+
+test('dismiss hides the banner and remembers the version', async () => {
+	const user = userEvent.setup();
+	const { getByTestId, queryByTestId, getByLabelText } = renderBanner({
+		current: '0.1.0',
+		latest: '0.2.0',
+		updateAvailable: true,
+		url: 'https://github.com/hezo-ai/hezo/releases/0.2.0',
+	});
+	expect(getByTestId('update-banner')).toBeTruthy();
+	await user.click(getByLabelText('Dismiss update notification'));
+	expect(queryByTestId('update-banner')).toBeNull();
+	expect(localStorage.getItem('hezo:update-dismissed')).toBe('0.2.0');
+});

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,17 +1,31 @@
 #!/usr/bin/env bun
-import { cpSync, existsSync, mkdirSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { createHash } from 'node:crypto';
+import { mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
 import { Command } from 'commander';
 
 const ROOT = resolve(import.meta.dir, '..');
 
 const program = new Command()
 	.name('build')
-	.description('Build all Hezo packages (shared → server, connect, web in parallel)')
-	.option('--compile', 'Build a single compiled binary with embedded frontend')
+	.description('Build all Hezo packages (shared → server, web in parallel)')
+	.option('--compile', 'Build a single compiled binary for the current platform')
+	.option('--release', 'Cross-compile self-contained binaries for every supported platform')
 	.parse();
 
 const opts = program.opts();
+const wantBinary = Boolean(opts.compile || opts.release);
+
+// Bun cross-compiles every target from a single host, so a release build needs
+// only one runner. Each binary embeds the frontend, migrations, agent roles,
+// and version — fully self-contained, nothing read from disk at runtime.
+const TARGETS = [
+	{ target: 'bun-linux-x64', out: 'hezo-linux-x64' },
+	{ target: 'bun-linux-arm64', out: 'hezo-linux-arm64' },
+	{ target: 'bun-windows-x64', out: 'hezo-windows-x64.exe' },
+	{ target: 'bun-darwin-x64', out: 'hezo-darwin-x64' },
+	{ target: 'bun-darwin-arm64', out: 'hezo-darwin-arm64' },
+];
 
 async function run(pkg: string, cmd: string[]) {
 	const cwd = resolve(ROOT, pkg);
@@ -23,6 +37,30 @@ async function run(pkg: string, cmd: string[]) {
 		console.error(`Build failed: ${label}`);
 		process.exit(1);
 	}
+}
+
+function readVersion(): string {
+	// The release flow bumps the per-package versions (the root package.json has
+	// none), so read the server package — it's what the binary is built from.
+	const pkgPath = join(ROOT, 'packages', 'server', 'package.json');
+	const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as { version: string };
+	return pkg.version;
+}
+
+// Native addons can't be embedded in a Bun binary, and their platform-specific
+// `require`s break cross-compilation. The embedding model (@huggingface/
+// transformers → onnxruntime-node) is loaded via a guarded dynamic import that
+// fails soft, so we mark it external: the binary builds for every platform and
+// semantic search is simply unavailable in the standalone build.
+const EXTERNALS = ['@huggingface/transformers', 'onnxruntime-node'];
+
+async function compile(version: string, target: string | null, outfile: string) {
+	const cmd = ['bun', 'build', '--compile'];
+	if (target) cmd.push(`--target=${target}`);
+	cmd.push('--define', `process.env.HEZO_VERSION="${version}"`);
+	for (const ext of EXTERNALS) cmd.push('--external', ext);
+	cmd.push('packages/server/src/index.ts', '--outfile', outfile);
+	await run('.', cmd);
 }
 
 // shared must build first (dependency of server)
@@ -38,36 +76,41 @@ await Promise.all([
 	run('packages/web', ['bun', 'run', 'build']),
 ]);
 
+// Binary-only embedding steps: the static bundle (reads packages/web/dist) and
+// the PGlite runtime assets, both needed for a self-contained executable.
+if (wantBinary) {
+	await run('packages/server', ['bun', 'run', 'build:static']);
+	await run('packages/server', ['bun', 'run', 'build:pglite']);
+}
+
 console.log('Build complete.');
 
-if (opts.compile) {
-	console.log('\nCompiling single binary...');
+if (wantBinary) {
+	const version = readVersion();
 
-	// Copy web dist to server static
-	const webDist = resolve(ROOT, 'packages/web/dist');
-	const serverStatic = resolve(ROOT, 'packages/server/static');
-
-	if (!existsSync(webDist)) {
-		console.error('packages/web/dist not found. Run web build first.');
-		process.exit(1);
+	if (opts.release) {
+		console.log(`\nCross-compiling release binaries (v${version})...`);
+		const outDir = resolve(ROOT, 'dist', 'binaries');
+		mkdirSync(outDir, { recursive: true });
+		for (const { target, out } of TARGETS) {
+			await compile(version, target, join('dist', 'binaries', out));
+		}
+		// sha256sum -c compatible manifest for download verification.
+		const lines = readdirSync(outDir)
+			.filter((f) => f !== 'SHA256SUMS')
+			.sort()
+			.map(
+				(f) =>
+					`${createHash('sha256')
+						.update(readFileSync(join(outDir, f)))
+						.digest('hex')}  ${f}`,
+			);
+		writeFileSync(join(outDir, 'SHA256SUMS'), `${lines.join('\n')}\n`);
+		console.log(`\nRelease binaries + SHA256SUMS in ${outDir}`);
+	} else {
+		console.log(`\nCompiling single binary (v${version})...`);
+		mkdirSync(resolve(ROOT, 'dist'), { recursive: true });
+		await compile(version, null, 'dist/hezo');
+		console.log('\nCompiled binary at dist/hezo');
 	}
-
-	mkdirSync(serverStatic, { recursive: true });
-	cpSync(webDist, serverStatic, { recursive: true });
-	console.log('Copied web assets to packages/server/static/');
-
-	// Compile binary
-	const outDir = resolve(ROOT, 'dist');
-	mkdirSync(outDir, { recursive: true });
-
-	await run('.', [
-		'bun',
-		'build',
-		'--compile',
-		'packages/server/src/index.ts',
-		'--outfile',
-		'dist/hezo',
-	]);
-
-	console.log('\nCompiled binary at dist/hezo');
 }

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -3,6 +3,7 @@ import { createHash } from 'node:crypto';
 import { mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { Command } from 'commander';
+import { ensureBundles } from './ensure-bundles';
 
 const ROOT = resolve(import.meta.dir, '..');
 
@@ -65,6 +66,12 @@ async function compile(version: string, target: string | null, outfile: string) 
 
 // shared must build first (dependency of server)
 await run('packages/shared', ['bun', 'run', 'build']);
+
+// Stub any missing embed bundles before tsc (server) and vite (web, which
+// imports server's static-assets.ts) run in parallel — both statically resolve
+// the literal `import('./xxx-bundle.json')` and error if the file is absent.
+// The real content is written by the build:* steps below / the binary path.
+ensureBundles();
 
 // server and web build in parallel
 await Promise.all([

--- a/scripts/ensure-bundles.ts
+++ b/scripts/ensure-bundles.ts
@@ -1,0 +1,35 @@
+#!/usr/bin/env bun
+import { existsSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const ROOT = resolve(import.meta.dir, '..');
+
+// The embed bundles are generated artifacts (gitignored) that real builds fill
+// with content via `build:migrations` / `build:agents` / `build:static`. But the
+// consuming source files use a *literal* `import('./xxx-bundle.json')` so
+// `bun build --compile` can embed them — and a literal specifier is statically
+// resolved by tsc (the `build` job) and vite (the web/server vitest transform),
+// both of which error when the file is absent. Writing an empty stub satisfies
+// that static resolution; at runtime an empty bundle is treated as "not
+// generated" and the loaders fall back to the filesystem (see migrate.ts /
+// agent-roles.ts / static-assets.ts). Existing non-empty bundles are left
+// untouched, so this never clobbers real generated content.
+const BUNDLES = [
+	'packages/server/src/db/migrations-bundle.json',
+	'packages/server/src/db/agents-bundle.json',
+	'packages/server/src/static-bundle.json',
+];
+
+export function ensureBundles(): void {
+	for (const rel of BUNDLES) {
+		const path = resolve(ROOT, rel);
+		if (!existsSync(path)) {
+			writeFileSync(path, '{}\n');
+			console.log(`Wrote stub bundle: ${rel}`);
+		}
+	}
+}
+
+if (import.meta.main) {
+	ensureBundles();
+}

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -2,6 +2,7 @@
 import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { Command } from 'commander';
+import { ensureBundles } from './ensure-bundles';
 
 const ROOT = resolve(import.meta.dir, '..');
 
@@ -121,6 +122,12 @@ async function runBrowserTests(): Promise<boolean> {
 }
 
 async function main() {
+	// vitest transforms through vite, which statically resolves the literal
+	// `import('./xxx-bundle.json')` in the server's migrate/agent-roles/static
+	// loaders and errors if the file is absent. buildAgentBundle fills the agents
+	// bundle with real content; stub the rest so both the server and web suites
+	// resolve. An empty stub is treated as "absent" at runtime → filesystem fallback.
+	ensureBundles();
 	await Promise.all([buildShared(), buildAgentBundle()]);
 
 	const browserOnly = browserFlag;


### PR DESCRIPTION
## Summary

This PR adds update notifications to Hezo and refactors the build system to produce fully self-contained binaries that embed all runtime assets (frontend, migrations, agent roles, PGlite runtime, and version). The running instance can now check for new releases on GitHub and prompt users to upgrade.

## Key Changes

- **Update notifications**: Added `/api/updates/latest` endpoint that queries GitHub Releases API for the latest `hezo-ai/hezo` tag, caches results for 1 hour, and fails soft on network errors. Frontend displays a dismissible banner per-version linking to the release download.

- **Self-contained binaries**: Refactored asset loading to embed everything into the compiled binary:
  - Frontend assets bundled via `scripts/bundle-static.ts` → `static-bundle.json` (base64-encoded, served from memory)
  - Migrations bundled as plain JSON map (no compression) → `migrations-bundle.json`
  - PGlite runtime assets (WASM, data, pgvector tarball) copied to `src/generated/pglite/` and embedded via `import ... with { type: 'file' }`
  - Version injected at compile time via `bun build --define process.env.HEZO_VERSION="<v>"`

- **Cross-platform release builds**: `scripts/build.ts --release` now cross-compiles binaries for all supported platforms (Linux x64/arm64, Windows x64, macOS x64/arm64) from a single host, producing `SHA256SUMS` manifest.

- **Pre-migration backups**: Added `backupDataDir()` / `restoreDataDir()` to snapshot the database before migrations run (using PGlite's `dumpDataDir`), enabling safe manual downgrades. Backups are retained under `<dataDir>/backups/` with metadata.

- **Migration safety**: Refactored `runAvailableMigrations()` to accept `dataDir` parameter, compute pending migrations before running, and create pre-migration snapshots. Added `getPendingMigrations()` to report which migrations are queued.

- **CLI restore subcommand**: Added `hezo restore <backup>` to restore a pre-migration snapshot for manual downgrade (operator then runs the matching older binary).

- **Dev fallback**: In dev mode (`bun run`), all loaders gracefully fall back to reading from disk/node_modules when embedded bundles are absent, so development is unchanged.

## Implementation Details

- **Literal dynamic imports**: Asset bundles use literal `import('./file.json')` statements so Bun's compiler can statically analyze and embed them; runtime `readFile` calls are not embedded.
- **Semantic search limitation**: The embedding model (`@huggingface/transformers` → `onnxruntime-node`) is marked `--external` since native addons can't be embedded and break cross-compilation. It fails soft in the binary; full search is available in dev.
- **macOS binaries**: Currently unsigned/un-notarized (built on Linux); users must clear quarantine with `xattr -d com.apple.quarantine`.
- **Version exposure**: `HEZO_VERSION` is surfaced at `/api/status` and used by the update check; in dev it reads `packages/server/package.json` at runtime.

## Testing

- Added `updates.test.ts` for semver comparison and `/api/updates/latest` endpoint
- Added `update-banner.test.tsx` for UI dismissal and localStorage persistence
- Added `db-backup.test.ts` for backup/restore round-trip
- Extended `migrate.test.ts` to verify pending migration detection

https://claude.ai/code/session_01TVkJsYwFY9ysJifM5ih3zj