### PR TITLE
feat: host UI mockups in assets library and link GitHub repos

### DIFF
--- a/agents/_partials/common/linking-syntax.md
+++ b/agents/_partials/common/linking-syntax.md
@@ -9,6 +9,7 @@ When your markdown (ticket descriptions, `progress_summary`, comments, project d
 - `@board` — **active** board reference. The board is the team's human project-owner group. Active `@board` lands a row in every board user's inbox, surfacing your question for human review. Use only when you genuinely cannot proceed without a human decision (product/strategy/sensitive trade-off) — then stop your turn and leave the task in a non-terminal status; the board's reply wakes you automatically. `@@board` is the passive form for narrative references and does not notify.
 - `<TASK-ID>` — ticket, using the project-scoped uppercase identifier. Example: `IN-42`, `BE-7`. Shape: `<project-prefix>-<number>`. No prefix — write the bare identifier.
 - `<project-doc-filename>` — project doc in the current project. Example: `prd.md`, `spec.md`. Available filenames are listed in the project-docs block injected into your context. No prefix — write the bare filename.
+- `assets/<filename>` — a file in the project assets library (mockups, wireframes, diagrams, exports). Example: `assets/ui-mockups.html`, `assets/login-wireframe.png`. Keep the `assets/` prefix and write it bare. Non-markdown deliverables belong in the assets library (author text-based ones with `write_project_asset`) — never commit them to the source repo.
 
 Skills in the team skills database are referenced by their slug (e.g. `deploy-runbook`) as shown in the injected skills manifest, not by filename. Only reference skills you know exist.
 
@@ -20,7 +21,7 @@ Skills in the team skills database are referenced by their slug (e.g. `deploy-ru
 - No other prefix is valid. Never write `#doc/<filename>` or `doc/<filename>` — those forms are not recognised. Just the bare filename or identifier.
 - Never wrap any of these in backticks or fence them in a code block — inline code suppresses the link. Write them as bare prose.
 - Only link entities that actually exist. Available targets come from: the project-docs block in your context, teammates (you can `list_agents`), and tickets you have read, created, or that the board has referenced. Do not guess identifiers.
-- Use backticks for things that are not Hezo entities — file paths inside a repo, package names, shell commands, code identifiers (e.g. `` `create_task` ``, `` `orzogc/grok3_api` ``, `` `src/app.ts` ``).
+- Use backticks for things that are not Hezo entities — file paths inside a repo, package names, shell commands, code identifiers (e.g. `` `create_task` ``, `` `orzogc/grok3_api` ``, `` `src/app.ts` ``). An `assets/<filename>` reference is a Hezo entity, not a repo path — write it bare, never in backticks.
 
 **Example rewrite:**
 

--- a/agents/software-development/ui-designer.md
+++ b/agents/software-development/ui-designer.md
@@ -24,7 +24,7 @@ You own the visual and interaction layer. You create HTML preview mockups for bo
 You are step 4 in the UI-work ticket flow (after Researcher, Product Lead, Architect; before Engineer), and review again at step 6 (after the Engineer implements).
 
 1. **Plan review.** When the Architect posts a technical spec and @-mentions you, review the PRD and spec.
-2. **Mockups.** Build the mockup as a self-contained, interactive HTML file that demonstrates the real interactions and renders at mobile, tablet, and desktop widths, and save it with `write_project_doc` (e.g. `ui-mockups.html`). Then post one `create_comment` that `@board`, linking the mockup file and `ui-design-decisions.md`, stating concretely what you need reviewed and listing any open design questions. The board is the sole reviewer and approver of mockups — do not route mockup approval to the Architect or any other teammate. After posting, stop your turn and leave the ticket in a non-terminal status; the board's reply wakes you.
+2. **Mockups.** Build the mockup as a self-contained, interactive HTML file that demonstrates the real interactions and renders at mobile, tablet, and desktop widths, and save it to the assets library with `write_project_asset` (e.g. `ui-mockups.html`) — never commit it to the source repo. Then post one `create_comment` that `@board`, linking the mockup as `assets/ui-mockups.html` and the decisions doc as `ui-design-decisions.md` (bare tokens, no backticks), stating concretely what you need reviewed and listing any open design questions. The board is the sole reviewer and approver of mockups — do not route mockup approval to the Architect or any other teammate. After posting, stop your turn and leave the ticket in a non-terminal status; the board's reply wakes you.
 3. **Iterate** on board feedback.
 4. **Component specs.** Once designs are approved, provide component specs for the Engineer covering:
    - Layout and spacing
@@ -37,12 +37,12 @@ When disagreeing with the Engineer on design, the Architect decides. Accessibili
 
 ## Rules
 
-- **Do not edit source code or tests.** Only the Engineer modifies the codebase. Provide component specs, HTML preview mockups (via `write_project_doc`), and review feedback — the Engineer applies the changes. HTML mockups written as project docs are not source code and are unaffected by this rule.
+- **Do not edit source code or tests.** Only the Engineer modifies the codebase. Provide component specs, HTML preview mockups (saved to the assets library via `write_project_asset`), and review feedback — the Engineer applies the changes. Mockups live in the assets library, never in the source repo.
 - Accessibility is encouraged. Aim for WCAG 2.1 AA where practical, but prioritise flexibility to build any kind of UI.
 - Every interactive element needs hover, focus, active, and disabled states.
 - Every data-loading state needs loading, error, and empty states.
 - Use design-system tokens — don't hardcode colours, spacing, or typography.
-- Preview mockups must be self-contained HTML files that demonstrate the actual interaction.
+- Preview mockups must be self-contained HTML files that demonstrate the actual interaction, saved via `write_project_asset` and referenced as `assets/<filename>`.
 - **Mobile-first, responsive layout is mandatory for every UI you design.** Design the mobile layout first (single column, stacked fields, drawer navigation, near full-screen dialogs), then specify how it adapts at tablet and desktop breakpoints. Never deliver a desktop-only or fixed-width design. Preview mockups must demonstrate the layout at mobile, tablet, and desktop widths. Component specs must explicitly cover responsive behaviour at each breakpoint.
 - Keep the UI minimal and clean — progressive disclosure over feature overload.
 - When making UI design decisions for a project, create and maintain a `ui-design-decisions.md` project doc via `write_project_doc`. Document the design rationale, component decisions, interaction patterns, and any board-approved directions. Keep it updated as designs evolve.

--- a/packages/server/src/lib/asset-name.ts
+++ b/packages/server/src/lib/asset-name.ts
@@ -102,3 +102,57 @@ export async function insertAssetWithUniqueName(
 	}
 	throw lastErr ?? new Error('Failed to insert asset with a unique name');
 }
+
+/**
+ * Insert an asset under an exact filename, or overwrite the row if one already
+ * exists for that `(project_id, original_filename)`. Used by agent-authored
+ * assets (e.g. an iterated HTML mockup) so the reference stays stable at
+ * `assets/<filename>` instead of accreting random suffixes on each re-save. The
+ * caller writes the new blob keyed by `assetId`; on overwrite the previous
+ * `assetId`'s blob is orphaned and should be cleaned up by the caller.
+ */
+export async function upsertProjectAsset(
+	db: PGlite,
+	input: InsertAssetInput,
+): Promise<InsertedAsset & { replacedAssetId: string | null }> {
+	const existing = await db.query<{ id: string }>(
+		'SELECT id FROM assets WHERE project_id = $1 AND original_filename = $2 LIMIT 1',
+		[input.projectId, input.desiredName],
+	);
+	const prior = existing.rows[0]?.id ?? null;
+	if (prior) {
+		const r = await db.query<InsertedAsset>(
+			`UPDATE assets
+			 SET id = $1, content_type = $2, byte_size = $3, sha256 = $4,
+			     uploaded_by_member_id = $5, created_at = now()
+			 WHERE project_id = $6 AND original_filename = $7
+			 RETURNING id, content_type, byte_size, original_filename`,
+			[
+				input.assetId,
+				input.contentType,
+				input.byteSize,
+				input.sha256,
+				input.uploadedByMemberId,
+				input.projectId,
+				input.desiredName,
+			],
+		);
+		return { ...r.rows[0], replacedAssetId: prior };
+	}
+	const r = await db.query<InsertedAsset>(
+		`INSERT INTO assets (id, team_id, project_id, content_type, byte_size, sha256, original_filename, uploaded_by_member_id)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		 RETURNING id, content_type, byte_size, original_filename`,
+		[
+			input.assetId,
+			input.teamId,
+			input.projectId,
+			input.contentType,
+			input.byteSize,
+			input.sha256,
+			input.desiredName,
+			input.uploadedByMemberId,
+		],
+	);
+	return { ...r.rows[0], replacedAssetId: null };
+}

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -4,6 +4,8 @@ import {
 	AgentAdminStatus,
 	ApprovalStatus,
 	ApprovalType,
+	ATTACHMENT_EXTENSIONS,
+	ATTACHMENT_MAX_BYTES,
 	AuditActorType,
 	AuthType,
 	CAPTAIN_AGENT_SLUG,
@@ -11,7 +13,10 @@ import {
 	CredentialInputType,
 	CredentialKind,
 	DocumentType,
+	extensionOf,
+	isAgentAuthorableAssetMime,
 	isMarkdownDocSlug,
+	normalizeAssetFilename,
 	ReactionKind,
 	TaskStatus,
 	WakeupSource,
@@ -22,6 +27,7 @@ import { z } from 'zod';
 import type { MasterKeyManager } from '../crypto/master-key';
 import { assertNoActiveRun } from '../lib/active-run';
 import { isCoach } from '../lib/agent-roles';
+import { upsertProjectAsset } from '../lib/asset-name';
 import { assertSubordinateAssignee } from '../lib/assignment-hierarchy';
 import { trackBackground } from '../lib/background';
 import { broadcastRowChange } from '../lib/broadcast';
@@ -47,6 +53,7 @@ import {
 } from '../services/agent-system-prompts';
 import { broadcastApprovalChange } from '../services/approval-broadcast';
 import { resolveApproval } from '../services/approval-resolve';
+import { deleteAsset, writeAsset } from '../services/asset-storage';
 import { fireCommentWakeups } from '../services/comment-wakeups';
 import { enqueueTeamCoherenceReviewTask } from '../services/description-tasks';
 import {
@@ -2432,7 +2439,7 @@ export function registerTools(
 	tool(
 		server,
 		'list_project_assets',
-		"List the project's assets — uploaded non-markdown files (UI mockups, wireframes, diagrams, PDFs). Reference one in a comment or doc as `assets/<filename>` (e.g. assets/login-mockup.png), no backticks. Assets are view-only and human-managed; you cannot upload or edit them.",
+		"List the project's assets — non-markdown files (UI mockups, wireframes, diagrams, PDFs). Reference one in a comment or doc as `assets/<filename>` (e.g. assets/login-mockup.png), no backticks. You can author text-based assets (.html, .svg, .txt) with write_project_asset; binary assets (images, PDFs) are human-uploaded.",
 		{
 			team_id: z.string().describe('Team ID'),
 			project_id: z.string().describe('Project ID'),
@@ -2460,6 +2467,68 @@ export function registerTools(
 					created_at: a.created_at,
 				})),
 			};
+		},
+		db,
+	);
+
+	tool(
+		server,
+		'write_project_asset',
+		'Save a text-based file to the project assets library so a human can open it (an interactive HTML mockup, an SVG diagram, a plain-text export). Allowed extensions: .html, .svg, .txt. Re-saving the same filename overwrites it, so the reference stays stable. Returns the reference string to drop into a comment as `assets/<filename>` (no backticks). HTML opens interactively in a new tab. Mockups and other deliverables belong here, never committed to the source repo.',
+		{
+			team_id: z.string().describe('Team ID'),
+			project_id: z.string().describe('Project ID'),
+			filename: z.string().describe('Filename to write (e.g. "ui-mockups.html")'),
+			content: z.string().describe('File content'),
+		},
+		async (args, db, auth) => {
+			const denied = await verifyTeamAccess(db, auth, args.team_id as string);
+			if (denied) return { error: denied };
+			const pDenied = assertProjectAccess(auth, args.project_id as string);
+			if (pDenied) return { error: pDenied };
+
+			const teamId = args.team_id as string;
+			const projectId = args.project_id as string;
+			const filename = normalizeAssetFilename(args.filename as string);
+			const ext = extensionOf(filename);
+			const contentType = ext
+				? ATTACHMENT_EXTENSIONS[ext as keyof typeof ATTACHMENT_EXTENSIONS]
+				: undefined;
+			if (!contentType || !isAgentAuthorableAssetMime(contentType)) {
+				return {
+					error:
+						'Asset must be a text-based file: .html, .svg, or .txt. Other types are human-uploaded.',
+				};
+			}
+
+			const blob = new Blob([args.content as string], { type: contentType });
+			if (blob.size > ATTACHMENT_MAX_BYTES) {
+				return { error: 'Asset exceeds 10 MB.' };
+			}
+
+			const assetId = crypto.randomUUID();
+			const { byteSize, sha256 } = await writeAsset(dataDir, teamId, projectId, assetId, blob);
+			const uploadedBy = auth.type === AuthType.Agent ? auth.memberId : null;
+			let result: Awaited<ReturnType<typeof upsertProjectAsset>>;
+			try {
+				result = await upsertProjectAsset(db, {
+					assetId,
+					teamId,
+					projectId,
+					contentType,
+					byteSize,
+					sha256,
+					desiredName: filename,
+					uploadedByMemberId: uploadedBy,
+				});
+			} catch (e) {
+				await deleteAsset(dataDir, teamId, projectId, assetId).catch(() => {});
+				throw e;
+			}
+			if (result.replacedAssetId) {
+				await deleteAsset(dataDir, teamId, projectId, result.replacedAssetId).catch(() => {});
+			}
+			return { written: true, id: result.id, reference: `assets/${result.original_filename}` };
 		},
 		db,
 	);

--- a/packages/server/src/routes/assets.ts
+++ b/packages/server/src/routes/assets.ts
@@ -5,6 +5,7 @@ import {
 	ATTACHMENT_MAX_BYTES,
 	AuthType,
 	assetContentDisposition,
+	assetServeCsp,
 	isAllowedAttachmentExtension,
 	isAllowedAttachmentMime,
 	normalizeAssetFilename,
@@ -245,14 +246,19 @@ publicAssetsRoutes.get('/api/assets/:assetId', async (c) => {
 	const filenameSafe = original_filename.replace(/"/g, '');
 	const ab = new ArrayBuffer(buf.byteLength);
 	new Uint8Array(ab).set(buf);
-	return c.body(new Uint8Array(ab), 200, {
+	const headers: Record<string, string> = {
 		'Content-Type': content_type,
 		'Content-Length': String(buf.byteLength),
 		// SVGs (and other active-content types) download instead of rendering as a
 		// top-level document on our origin — see `assetContentDisposition`.
 		'Content-Disposition': `${assetContentDisposition(content_type)}; filename="${filenameSafe}"`,
 		'Cache-Control': 'private, max-age=3600',
-	});
+	};
+	// HTML mockups render inline but are pinned to an opaque origin so their
+	// script can't reach the app's same-origin credentials.
+	const csp = assetServeCsp(content_type);
+	if (csp) headers['Content-Security-Policy'] = csp;
+	return c.body(new Uint8Array(ab), 200, headers);
 });
 
 // Re-export the allowed extensions for tests

--- a/packages/server/src/services/repo-setup.ts
+++ b/packages/server/src/services/repo-setup.ts
@@ -216,6 +216,9 @@ export async function finalizePendingRepoSetup(
 				row.task_id,
 				CommentContentType.System,
 				JSON.stringify({
+					kind: 'repo_designated',
+					repo_identifier: input.repoIdentifier,
+					host_type: 'github',
 					text: `Repository ${input.repoIdentifier} set as the designated repo.`,
 				}),
 			],

--- a/packages/server/test/project-assets.test.ts
+++ b/packages/server/test/project-assets.test.ts
@@ -31,6 +31,25 @@ function buildPng(seed = 0): Uint8Array {
 const SVG_BYTES = new TextEncoder().encode('<svg xmlns="http://www.w3.org/2000/svg"></svg>');
 const WEBP_BYTES = new TextEncoder().encode('RIFF....WEBPVP8 ');
 
+async function callToolViaMcp(
+	authToken: string,
+	toolName: string,
+	args: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+	const res = await app.request('/mcp', {
+		method: 'POST',
+		headers: { ...authHeader(authToken), 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			jsonrpc: '2.0',
+			method: 'tools/call',
+			params: { name: toolName, arguments: args },
+			id: 1,
+		}),
+	});
+	const body = (await res.json()) as { result: { content: Array<{ text: string }> } };
+	return JSON.parse(body.result.content[0].text);
+}
+
 async function uploadProjectAsset(
 	filename: string,
 	mime: string,
@@ -152,6 +171,107 @@ describe('asset serving disposition', () => {
 
 		const svgRes = await app.request(svg.data.url);
 		expect(svgRes.headers.get('content-disposition')).toContain('attachment');
+	});
+
+	it('serves html inline pinned to an opaque origin via a sandbox CSP', async () => {
+		const html = await (
+			await uploadProjectAsset('page.html', 'text/html', new TextEncoder().encode('<h1>hi</h1>'))
+		).json();
+		const res = await app.request(html.data.url);
+		expect(res.headers.get('content-disposition')).toContain('inline');
+		const csp = res.headers.get('content-security-policy');
+		expect(csp).toContain('sandbox');
+		expect(csp).toContain('allow-scripts');
+		expect(csp).not.toContain('allow-same-origin');
+	});
+});
+
+describe('agent-authored assets (write_project_asset)', () => {
+	it('writes an html mockup and returns its assets/<name> reference', async () => {
+		const { token: agentToken } = await mintAgentToken(
+			db,
+			masterKeyManager,
+			agentId,
+			teamId,
+			taskId,
+		);
+		const result = await callToolViaMcp(agentToken, 'write_project_asset', {
+			team_id: teamId,
+			project_id: projectId,
+			filename: 'ui-mockups.html',
+			content: '<!doctype html><title>Mock</title><h1>v1</h1>',
+		});
+		expect(result.written).toBe(true);
+		expect(result.reference).toBe('assets/ui-mockups.html');
+
+		const row = await db.query<{ id: string; content_type: string }>(
+			'SELECT id, content_type FROM assets WHERE project_id = $1 AND original_filename = $2',
+			[projectId, 'ui-mockups.html'],
+		);
+		expect(row.rows).toHaveLength(1);
+		expect(row.rows[0].content_type).toBe('text/html');
+		const onDisk = join(dataDir, 'teams', teamId, 'projects', projectId, 'assets', row.rows[0].id);
+		expect(existsSync(onDisk)).toBe(true);
+	});
+
+	it('overwrites the same filename on re-save, keeping a single stable reference', async () => {
+		const { token: agentToken } = await mintAgentToken(
+			db,
+			masterKeyManager,
+			agentId,
+			teamId,
+			taskId,
+		);
+		const first = await callToolViaMcp(agentToken, 'write_project_asset', {
+			team_id: teamId,
+			project_id: projectId,
+			filename: 'iterate.html',
+			content: '<h1>first</h1>',
+		});
+		const second = await callToolViaMcp(agentToken, 'write_project_asset', {
+			team_id: teamId,
+			project_id: projectId,
+			filename: 'iterate.html',
+			content: '<h1>second-and-longer</h1>',
+		});
+		expect(second.reference).toBe('assets/iterate.html');
+
+		const rows = await db.query<{ id: string; byte_size: number }>(
+			'SELECT id, byte_size FROM assets WHERE project_id = $1 AND original_filename = $2',
+			[projectId, 'iterate.html'],
+		);
+		expect(rows.rows).toHaveLength(1);
+		expect(rows.rows[0].id).toBe(second.id);
+		// The replaced asset's bytes are cleaned off disk.
+		expect(first.id).not.toBe(second.id);
+		const oldDisk = join(
+			dataDir,
+			'teams',
+			teamId,
+			'projects',
+			projectId,
+			'assets',
+			first.id as string,
+		);
+		expect(existsSync(oldDisk)).toBe(false);
+	});
+
+	it('rejects a binary asset type', async () => {
+		const { token: agentToken } = await mintAgentToken(
+			db,
+			masterKeyManager,
+			agentId,
+			teamId,
+			taskId,
+		);
+		const result = await callToolViaMcp(agentToken, 'write_project_asset', {
+			team_id: teamId,
+			project_id: projectId,
+			filename: 'diagram.png',
+			content: 'not really a png',
+		});
+		expect(result.written).toBeUndefined();
+		expect(String(result.error)).toMatch(/text-based|\.html|\.svg|\.txt/i);
 	});
 });
 

--- a/packages/server/test/repo-setup-finalize-multi.test.ts
+++ b/packages/server/test/repo-setup-finalize-multi.test.ts
@@ -157,11 +157,17 @@ describe('finalizePendingRepoSetup + enqueueRepoSetupResumeWakeups (multi-agent)
 			}
 
 			for (const taskId of [taskA, taskB, taskC]) {
-				const sys = await db.query<{ id: string }>(
-					`SELECT id FROM task_comments WHERE task_id = $1 AND content_type = 'system'::comment_content_type`,
+				const sys = await db.query<{
+					id: string;
+					content: { kind?: string; repo_identifier?: string; host_type?: string };
+				}>(
+					`SELECT id, content FROM task_comments WHERE task_id = $1 AND content_type = 'system'::comment_content_type`,
 					[taskId],
 				);
 				expect(sys.rows).toHaveLength(1);
+				expect(sys.rows[0].content.kind).toBe('repo_designated');
+				expect(sys.rows[0].content.repo_identifier).toBe('octo/multi');
+				expect(sys.rows[0].content.host_type).toBe('github');
 			}
 
 			await enqueueRepoSetupResumeWakeups(

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -111,6 +111,7 @@ export const ATTACHMENT_SIGNED_URL_TTL_SECONDS = 3600;
 
 export const ATTACHMENT_EXTENSIONS = {
 	txt: 'text/plain',
+	html: 'text/html',
 	pdf: 'application/pdf',
 	png: 'image/png',
 	jpg: 'image/jpeg',
@@ -141,6 +142,30 @@ export const ASSET_INLINE_UNSAFE_MIME: ReadonlySet<string> = new Set(['image/svg
 
 export function assetContentDisposition(contentType: string): 'inline' | 'attachment' {
 	return ASSET_INLINE_UNSAFE_MIME.has(contentType) ? 'attachment' : 'inline';
+}
+
+// Content types that may carry active script yet are meant to render inline (an
+// interactive HTML mockup a human opens in a new tab). Serving them on our own
+// origin would let agent-authored script read the app's credentials, so they are
+// pinned to an opaque origin via a `sandbox` Content-Security-Policy: scripts run,
+// but they cannot reach same-origin cookies/storage.
+const ASSET_SANDBOX_CSP = 'sandbox allow-scripts allow-forms allow-popups allow-modals';
+const ASSET_SANDBOX_SERVE_MIME: ReadonlySet<string> = new Set(['text/html']);
+
+export function assetServeCsp(contentType: string): string | null {
+	return ASSET_SANDBOX_SERVE_MIME.has(contentType) ? ASSET_SANDBOX_CSP : null;
+}
+
+// File types an agent may author directly into the assets library (text-based,
+// reviewable). Binary assets (images, PDF, media) stay human-uploaded.
+export const AGENT_AUTHORABLE_ASSET_MIME: ReadonlySet<string> = new Set([
+	'text/html',
+	'image/svg+xml',
+	'text/plain',
+]);
+
+export function isAgentAuthorableAssetMime(mime: string): boolean {
+	return AGENT_AUTHORABLE_ASSET_MIME.has(mime);
 }
 
 // Normalize an uploaded filename into a link-safe identity. This is the name an

--- a/packages/web/src/components/comment-content.ts
+++ b/packages/web/src/components/comment-content.ts
@@ -59,6 +59,13 @@ export interface SystemRunFailedContent {
 	text?: string;
 }
 
+export interface SystemRepoDesignatedContent {
+	kind: 'repo_designated';
+	repo_identifier?: string;
+	host_type?: string;
+	text?: string;
+}
+
 /**
  * Catch-all for system events that don't have a dedicated renderer branch
  * (`title_change`, `assignee_change`, `run_terminated`, future kinds). Renderers
@@ -75,6 +82,7 @@ export type SystemContent =
 	| SystemStatusChangeContent
 	| SystemTaskLinkContent
 	| SystemRunFailedContent
+	| SystemRepoDesignatedContent
 	| SystemGenericContent;
 
 export interface RunContent {

--- a/packages/web/src/components/comment-renderers/system-comment.tsx
+++ b/packages/web/src/components/comment-renderers/system-comment.tsx
@@ -1,7 +1,9 @@
 import { formatTaskStatus } from '@hezo/shared';
 import { Link } from '@tanstack/react-router';
+import { repoWebUrl } from '../../lib/github';
 import type {
 	SystemContent,
+	SystemRepoDesignatedContent,
 	SystemRunFailedContent,
 	SystemStatusChangeContent,
 	SystemTaskLinkContent,
@@ -21,6 +23,9 @@ function isStatusChange(c: SystemContent): c is SystemStatusChangeContent {
 }
 function isRunFailed(c: SystemContent): c is SystemRunFailedContent {
 	return c.kind === 'run_failed';
+}
+function isRepoDesignated(c: SystemContent): c is SystemRepoDesignatedContent {
+	return c.kind === 'repo_designated';
 }
 
 export function SystemComment({ comment, teamId }: Props) {
@@ -49,6 +54,10 @@ export function SystemComment({ comment, teamId }: Props) {
 
 	if (content && isRunFailed(content)) {
 		return <RunFailedBody content={content} teamId={teamId} timestamp={timestamp} />;
+	}
+
+	if (content && isRepoDesignated(content)) {
+		return <RepoDesignatedBody content={content} timestamp={timestamp} />;
 	}
 
 	const text = content
@@ -156,6 +165,39 @@ function RunFailedBody({
 			<span className="text-xs text-text-muted">
 				Run for {agentNode} {statusLabel}
 				{error ? <span className="text-text-subtle">: {error}</span> : null}. Waking agent to retry.
+			</span>
+			{timestamp}
+		</div>
+	);
+}
+
+function RepoDesignatedBody({
+	content,
+	timestamp,
+}: {
+	content: SystemRepoDesignatedContent;
+	timestamp: React.ReactNode;
+}) {
+	const identifier = typeof content.repo_identifier === 'string' ? content.repo_identifier : '';
+	const hostType = typeof content.host_type === 'string' ? content.host_type : '';
+	const url = identifier ? repoWebUrl(identifier, hostType) : null;
+	const repoNode = url ? (
+		<a
+			href={url}
+			target="_blank"
+			rel="noopener noreferrer"
+			className="text-xs text-accent-blue-text hover:underline"
+			data-testid="repo-designated-link"
+		>
+			{identifier}
+		</a>
+	) : (
+		<span className="text-xs text-text-muted">{identifier}</span>
+	);
+	return (
+		<div className="flex items-baseline gap-2 leading-[26px]" data-testid="repo-designated-comment">
+			<span className="text-xs text-text-muted">
+				Repository {repoNode} set as the designated repo.
 			</span>
 			{timestamp}
 		</div>

--- a/packages/web/src/components/github-section.tsx
+++ b/packages/web/src/components/github-section.tsx
@@ -8,6 +8,7 @@ import {
 	useOAuthConnections,
 } from '../hooks/use-oauth-connections';
 import { useDeleteRepo, useRepos } from '../hooks/use-repos';
+import { repoWebUrl } from '../lib/github';
 import { ConnectorDeviceFlowDialog } from './connector-device-flow-dialog';
 import { RepoPickerModal } from './repo-picker-modal';
 import { Badge } from './ui/badge';
@@ -176,7 +177,22 @@ export function GitHubSection({ teamId, projectId }: GitHubSectionProps) {
 								<div className="flex items-center gap-2">
 									<Badge color="gray">{r.host_type}</Badge>
 									<span className="font-medium">{r.short_name}</span>
-									<span className="text-text-muted">{r.repo_identifier}</span>
+									{(() => {
+										const url = repoWebUrl(r.repo_identifier, r.host_type);
+										return url ? (
+											<a
+												href={url}
+												target="_blank"
+												rel="noopener noreferrer"
+												className="text-accent-blue-text hover:underline"
+												data-testid={`repo-link-${r.short_name}`}
+											>
+												{r.repo_identifier}
+											</a>
+										) : (
+											<span className="text-text-muted">{r.repo_identifier}</span>
+										);
+									})()}
 									{r.is_designated && <Badge color="blue">Designated</Badge>}
 								</div>
 								{r.is_designated ? (

--- a/packages/web/src/lib/github.ts
+++ b/packages/web/src/lib/github.ts
@@ -1,0 +1,8 @@
+// Build the web URL for a repository from its `owner/repo` identifier. Returns
+// null for hosts we don't have a web-URL mapping for.
+export function repoWebUrl(identifier: string, hostType: string): string | null {
+	if (hostType !== 'github') return null;
+	const trimmed = identifier.trim();
+	if (!trimmed) return null;
+	return `https://github.com/${trimmed}`;
+}

--- a/packages/web/src/routes/teams/$teamId/projects/$projectId/assets.tsx
+++ b/packages/web/src/routes/teams/$teamId/projects/$projectId/assets.tsx
@@ -1,6 +1,7 @@
 import { INTERNAL_PROJECT_SLUG } from '@hezo/shared';
 import { createFileRoute, redirect } from '@tanstack/react-router';
 import {
+	Code,
 	ExternalLink,
 	FileAudio,
 	File as FileIcon,
@@ -37,6 +38,7 @@ function AssetIcon({ contentType }: { contentType: string }) {
 	const cls = 'h-8 w-8 text-text-subtle';
 	if (contentType.startsWith('audio/')) return <FileAudio className={cls} />;
 	if (contentType.startsWith('video/')) return <FileVideo className={cls} />;
+	if (contentType === 'text/html') return <Code className={cls} />;
 	if (contentType === 'application/pdf' || contentType === 'text/plain') {
 		return <FileText className={cls} />;
 	}
@@ -251,6 +253,7 @@ function AssetCard({
 	}, [highlighted]);
 
 	const isImage = asset.content_type.startsWith('image/');
+	const isHtml = asset.content_type === 'text/html';
 	return (
 		<li
 			ref={ref}
@@ -273,6 +276,13 @@ function AssetCard({
 						src={asset.url}
 						alt={asset.original_filename}
 						className="h-full w-full object-cover"
+					/>
+				) : isHtml ? (
+					<iframe
+						src={asset.url}
+						title={asset.original_filename}
+						sandbox=""
+						className="pointer-events-none h-full w-full bg-white"
 					/>
 				) : (
 					<AssetIcon contentType={asset.content_type} />

--- a/packages/web/test/github-url.test.ts
+++ b/packages/web/test/github-url.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from 'vitest';
+import { repoWebUrl } from '../src/lib/github';
+
+test('builds a github web url from an owner/repo identifier', () => {
+	expect(repoWebUrl('hiddentao-agent/todos', 'github')).toBe(
+		'https://github.com/hiddentao-agent/todos',
+	);
+});
+
+test('returns null for non-github hosts and empty identifiers', () => {
+	expect(repoWebUrl('owner/repo', 'gitlab')).toBeNull();
+	expect(repoWebUrl('   ', 'github')).toBeNull();
+});

--- a/packages/web/test/repo-designated-comment.test.tsx
+++ b/packages/web/test/repo-designated-comment.test.tsx
@@ -1,0 +1,62 @@
+import { expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+import { seedProject, seedTask, seedWorkspace } from './helpers/seed';
+
+test('task page renders repo_designated system comment with a GitHub link', async () => {
+	const seeded = { teamSlug: '', taskId: '' };
+
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Repo Link Project' });
+			const task = await seedTask(ws, project, { title: 'Repo Link Task' });
+
+			seeded.teamSlug = ws.team.slug;
+			seeded.taskId = task.id;
+
+			const designatedComment = {
+				id: 'cccc0000-0000-0000-0000-000000000001',
+				task_id: task.id,
+				content_type: 'system',
+				content: {
+					kind: 'repo_designated',
+					repo_identifier: 'hiddentao-agent/todos',
+					host_type: 'github',
+					text: 'Repository hiddentao-agent/todos set as the designated repo.',
+				},
+				chosen_option: null,
+				created_at: '2026-05-20T11:30:40Z',
+				author_type: 'board',
+				author_name: 'Board',
+				author_member_id: null,
+			};
+
+			const originalFetch = globalThis.fetch;
+			globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+				const url = typeof input === 'string' ? input : (input as Request).url;
+				const method = init?.method ?? (input instanceof Request ? input.method : 'GET');
+				if (method === 'GET' && /\/api\/teams\/[^/]+\/tasks\/[^/]+\/comments/.test(url)) {
+					return new Response(JSON.stringify({ data: [designatedComment] }), {
+						status: 200,
+						headers: { 'Content-Type': 'application/json' },
+					});
+				}
+				return originalFetch(input as RequestInfo, init);
+			}) as typeof globalThis.fetch;
+		},
+	});
+
+	await router.navigate({
+		to: '/teams/$teamId/tasks/$taskId',
+		params: { teamId: seeded.teamSlug, taskId: seeded.taskId },
+	});
+
+	const comment = await findByTestId('repo-designated-comment', undefined, { timeout: 20_000 });
+	expect(comment.textContent ?? '').toContain('set as the designated repo');
+
+	const link = (await findByTestId('repo-designated-link')) as HTMLAnchorElement;
+	expect(link.textContent ?? '').toContain('hiddentao-agent/todos');
+	expect(link.getAttribute('href')).toBe('https://github.com/hiddentao-agent/todos');
+	expect(link.getAttribute('target')).toBe('_blank');
+});


### PR DESCRIPTION
Interactive HTML mockups had no valid home — write_project_doc rejects non-markdown and the assets library rejected .html — so the UI Designer committed mockups to the source repo and linked them with inert backtick paths. Allow .html as an asset type, add a write_project_asset MCP tool (upserting by filename so re-saves keep a stable assets/<file> reference), and serve HTML inline pinned to an opaque origin via a sandbox CSP so the mockup stays interactive without reaching app credentials. Update the UI Designer role and the shared linking-syntax partial accordingly.

Also render repository identifiers as GitHub links: the "designated repo" system comment now carries structured content, and both the comment and the project settings page link owner/repo to github.com.