### PR TITLE
feat: auto-include description, progress summary, and rules in every run prompt

### DIFF
--- a/.dev/api.md
+++ b/.dev/api.md
@@ -2265,6 +2265,14 @@ line to the task block, regardless of whether the new ticket is a sub-task
 task and its structural parent is the same as the spawning ticket, the prompt
 collapses to a single **Parent ticket:** line.
 
+**Run context (every run).** Independent of the wakeup source, the task block
+opens with the ticket's full `description` (labeled `### Description`), its
+`rules` (approach constraints), and its latest `progress_summary` (the
+agent-maintained running checkpoint) — all untruncated. This lets a run resume
+exactly where the last one left off without a `get_task` round-trip; agents keep
+`progress_summary` current via `update_task`. The Coach's post-completion review
+prompt carries the same three fields alongside the full comment history.
+
 Agents can use this to: ask questions, request reviews, escalate blockers, hand
 off context, or coordinate work across teams — all visible in the task thread,
 all traceable in the audit log.

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -81,6 +81,7 @@ export interface TaskInfo {
 	priority: string;
 	project_id: string;
 	rules: string | null;
+	progress_summary: string | null;
 	assignee_id?: string | null;
 	runtime_type?: AgentRuntime | null;
 	parent_task_id?: string | null;
@@ -1131,7 +1132,14 @@ export function buildTaskPrompt(
 		parts.push('');
 	}
 
+	parts.push('### Description');
 	parts.push(task.description || 'No description provided.');
+
+	if (task.progress_summary) {
+		parts.push('');
+		parts.push('### Progress Summary');
+		parts.push(task.progress_summary);
+	}
 
 	if (wakeupPayload?.previous_failure) {
 		const pf = wakeupPayload.previous_failure as Record<string, unknown>;
@@ -1417,6 +1425,8 @@ export async function buildCoachReviewPrompt(
 		'### Description',
 		task.description || 'No description provided.',
 		'',
+		...(task.rules ? ['### Rules', task.rules, ''] : []),
+		...(task.progress_summary ? ['### Progress Summary', task.progress_summary, ''] : []),
 		'### Agents Involved',
 		agentList || 'No agents identified.',
 		'',

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -958,6 +958,7 @@ export class JobManager {
 			priority: string;
 			project_id: string;
 			rules: string | null;
+			progress_summary: string | null;
 			assignee_id: string | null;
 			runtime_type: AgentRuntime | null;
 			parent_task_id: string | null;
@@ -972,7 +973,7 @@ export class JobManager {
 			typeof wakeupPayload?.task_id === 'string' ? wakeupPayload.task_id : undefined;
 		if (payloadTaskId) {
 			const payloadTask = await db.query<TaskRow>(
-				'SELECT id, identifier, title, description, status, priority, project_id, rules, assignee_id, runtime_type, parent_task_id, created_by_run_id FROM tasks WHERE id = $1 AND team_id = $2',
+				'SELECT id, identifier, title, description, status, priority, project_id, rules, progress_summary, assignee_id, runtime_type, parent_task_id, created_by_run_id FROM tasks WHERE id = $1 AND team_id = $2',
 				[payloadTaskId, teamId],
 			);
 			if (payloadTask.rows.length === 0) {
@@ -990,7 +991,7 @@ export class JobManager {
 			task = payloadTask.rows[0];
 		} else {
 			const tasks = await db.query<TaskRow>(
-				`SELECT i.id, i.identifier, i.title, i.description, i.status, i.priority, i.project_id, i.rules, i.assignee_id, i.runtime_type, i.parent_task_id, i.created_by_run_id
+				`SELECT i.id, i.identifier, i.title, i.description, i.status, i.priority, i.project_id, i.rules, i.progress_summary, i.assignee_id, i.runtime_type, i.parent_task_id, i.created_by_run_id
 				 FROM tasks i
 				 WHERE i.assignee_id = $1 AND i.team_id = $2
 				   AND i.status NOT IN ($3, $4, $5)

--- a/packages/server/src/services/template-resolver.ts
+++ b/packages/server/src/services/template-resolver.ts
@@ -17,7 +17,7 @@ const SHARED_INSTRUCTIONS = `
 ## Working Guidelines
 
 ### Ticket Maintenance
-- **Progress**: Update the current ticket's progress_summary via \`update_task\` at natural milestones to reflect what you've accomplished and what remains.
+- **Progress**: Update the current ticket's progress_summary via \`update_task\` at natural milestones to reflect what you've accomplished and what remains. The latest progress_summary is surfaced (in full, alongside the description and rules) at the top of every run, so each run picks up where the last one left off — keep it current.
 - **Rules**: The ticket \`rules\` field captures *how this ticket should be worked on* — approach constraints, guardrails, or required workflows that shape execution (e.g. "run the full suite before pushing", "consult the architect before touching auth", "do not edit migrations"). Add these via \`update_task\` as you discover them. Do NOT use \`rules\` to pass project domain knowledge to a future agent — domain and scope context belongs in the ticket \`description\`; work-in-flight status belongs in \`progress_summary\`; project- or team-wide knowledge belongs in project docs (\`write_project_doc\`) or the team skills database (\`create_skill\`).
 - **Status**: Update the ticket status as you progress:
   - \`in_progress\` — when you begin active work

--- a/packages/server/test/agent-autonomy.test.ts
+++ b/packages/server/test/agent-autonomy.test.ts
@@ -279,6 +279,7 @@ describe('agent-runner: retry context in task prompt', () => {
 			priority: 'high',
 			project_id: 'test-project',
 			rules: null,
+			progress_summary: null,
 		};
 
 		const wakeupPayload = {
@@ -314,6 +315,7 @@ describe('agent-runner: retry context in task prompt', () => {
 			priority: 'medium',
 			project_id: 'test-project',
 			rules: null,
+			progress_summary: null,
 		};
 
 		const prompt = buildTaskPrompt('System prompt', task);
@@ -322,6 +324,8 @@ describe('agent-runner: retry context in task prompt', () => {
 		expect(prompt).not.toContain('previous attempt FAILED');
 		expect(prompt).toContain('AUT-2');
 		expect(prompt).toContain('Add feature');
+		// Progress Summary section is omitted when the field is empty.
+		expect(prompt).not.toContain('### Progress Summary');
 	});
 
 	it('buildTaskPrompt includes rules when present', async () => {
@@ -336,6 +340,7 @@ describe('agent-runner: retry context in task prompt', () => {
 			priority: 'high',
 			project_id: 'test-project',
 			rules: 'Must use PostgreSQL transactions\nNo raw SQL in route handlers',
+			progress_summary: null,
 		};
 
 		const prompt = buildTaskPrompt('System prompt', task);
@@ -343,6 +348,29 @@ describe('agent-runner: retry context in task prompt', () => {
 		expect(prompt).toContain('### Rules for this task');
 		expect(prompt).toContain('Must use PostgreSQL transactions');
 		expect(prompt).toContain('No raw SQL in route handlers');
+	});
+
+	it('buildTaskPrompt includes a labeled Description and the full progress summary', async () => {
+		const { buildTaskPrompt } = await import('../src/services/agent-runner');
+
+		const task = {
+			id: 'test-id',
+			identifier: 'AUT-4',
+			title: 'Resumable task',
+			description: 'Implement the CSV exporter end to end',
+			status: 'in_progress',
+			priority: 'high',
+			project_id: 'test-project',
+			rules: null,
+			progress_summary: 'Exporter scaffolded; header row done, body rows pending',
+		};
+
+		const prompt = buildTaskPrompt('System prompt', task);
+
+		expect(prompt).toContain('### Description');
+		expect(prompt).toContain('Implement the CSV exporter end to end');
+		expect(prompt).toContain('### Progress Summary');
+		expect(prompt).toContain('Exporter scaffolded; header row done, body rows pending');
 	});
 });
 
@@ -356,6 +384,7 @@ describe('agent-runner: mention handoff prompt', () => {
 		priority: 'high',
 		project_id: 'proj-uuid',
 		rules: null,
+		progress_summary: null,
 	};
 
 	const mentionPayload = {
@@ -486,6 +515,7 @@ describe('agent-runner: mention context loader', () => {
 				priority: 'low',
 				project_id: 'p',
 				rules: null,
+				progress_summary: null,
 			},
 			{ source: 'mention', comment_id: 'c', task_id: 'i' },
 			{ mentionContext: ctx },

--- a/packages/server/test/agent-runner.test.ts
+++ b/packages/server/test/agent-runner.test.ts
@@ -164,6 +164,7 @@ function makeTask() {
 		priority: 'medium',
 		project_id: projectId,
 		rules: null,
+		progress_summary: null,
 	};
 }
 
@@ -376,6 +377,36 @@ describe('runAgent', () => {
 
 		const taskWithRules = { ...makeTask(), rules: 'Always write tests' };
 		const result = await runAgent(deps, makeAgent(), taskWithRules, project);
+		expect(result.success).toBe(true);
+	});
+
+	it('includes task progress summary in task prompt when present', async () => {
+		const project = makeProject();
+		const docker = createMockDocker({
+			execCreate: async (_containerId: string, opts: any) => {
+				const prompt = readPromptFromExec(opts, '/tmp/test-data', project);
+				expect(prompt).toContain('### Progress Summary');
+				expect(prompt).toContain('Parser landed; tests still failing');
+				return 'exec-progress';
+			},
+			execStart: async () => ({ stdout: 'ok', stderr: '' }),
+			execInspect: async () => ({ ExitCode: 0, Running: false, Pid: 0 }),
+		});
+
+		const deps: RunnerDeps = {
+			db,
+			docker,
+			masterKeyManager,
+			serverPort: 3000,
+			dataDir: '/tmp/test-data',
+			logs: new LogStreamBroker(),
+		};
+
+		const taskWithSummary = {
+			...makeTask(),
+			progress_summary: 'Parser landed; tests still failing',
+		};
+		const result = await runAgent(deps, makeAgent(), taskWithSummary, project);
 		expect(result.success).toBe(true);
 	});
 

--- a/packages/server/test/coach.test.ts
+++ b/packages/server/test/coach.test.ts
@@ -152,7 +152,7 @@ describe('Coach review prompt builder', () => {
 	it('prepends the system prompt and points the coach back to it for the final summary comment', async () => {
 		const taskRow = await db.query<TaskInfo>(
 			`SELECT id, identifier, title, description, status::text AS status,
-			        priority::text AS priority, project_id, rules,
+			        priority::text AS priority, project_id, rules, progress_summary,
 			        parent_task_id, created_by_run_id
 			 FROM tasks WHERE id = $1`,
 			[taskId],
@@ -168,10 +168,33 @@ describe('Coach review prompt builder', () => {
 		expect(prompt).toMatch(/following the format defined in your system prompt/i);
 	});
 
+	it('includes the task rules and progress summary when present', async () => {
+		await db.query(`UPDATE tasks SET rules = $2, progress_summary = $3 WHERE id = $1`, [
+			taskId,
+			'Run the full suite before pushing',
+			'Schema migration done; API wiring pending',
+		]);
+
+		const taskRow = await db.query<TaskInfo>(
+			`SELECT id, identifier, title, description, status::text AS status,
+			        priority::text AS priority, project_id, rules, progress_summary,
+			        parent_task_id, created_by_run_id
+			 FROM tasks WHERE id = $1`,
+			[taskId],
+		);
+
+		const prompt = await buildCoachReviewPrompt(db, 'SYS', taskRow.rows[0], teamId);
+
+		expect(prompt).toContain('### Rules');
+		expect(prompt).toContain('Run the full suite before pushing');
+		expect(prompt).toContain('### Progress Summary');
+		expect(prompt).toContain('Schema migration done; API wiring pending');
+	});
+
 	it('includes attachment paths in the comment log so the agent can read them', async () => {
 		const taskRow = await db.query<TaskInfo>(
 			`SELECT id, identifier, title, description, status::text AS status,
-			        priority::text AS priority, project_id, rules,
+			        priority::text AS priority, project_id, rules, progress_summary,
 			        parent_task_id, created_by_run_id
 			 FROM tasks WHERE id = $1`,
 			[taskId],

--- a/packages/server/test/mention-handoff-prompt.test.ts
+++ b/packages/server/test/mention-handoff-prompt.test.ts
@@ -31,6 +31,7 @@ const TRIGGERING_TASK: Parameters<typeof buildTaskPrompt>[1] = {
 	priority: 'high',
 	project_id: 'filled-below',
 	rules: null,
+	progress_summary: null,
 };
 
 beforeAll(async () => {
@@ -238,6 +239,7 @@ describe('mention handoff prompt (integration)', () => {
 				priority: 'medium',
 				project_id: soloProjectId,
 				rules: null,
+				progress_summary: null,
 			},
 			payload,
 			{ mentionContext: ctx },

--- a/packages/web/src/components/task-detail/task-summary.tsx
+++ b/packages/web/src/components/task-detail/task-summary.tsx
@@ -39,7 +39,7 @@ export function TaskSummary({ task, teamId, taskProjectSlug, updateTask }: TaskS
 						<InfoTooltip
 							label="About Progress Summary"
 							data-testid="progress-summary-info"
-							content="A running checkpoint of what's been done and what's left on this task. Agents update it at natural milestones via the update_task tool. Not auto-included in the agent's prompt — agents fetch it on demand to stay continuous across runs."
+							content="A running checkpoint of what's been done and what's left on this task. Automatically included in every agent run's prompt — alongside the description and rules — so work stays continuous across runs. Agents update it at natural milestones via the update_task tool."
 						/>
 					</div>
 					{!editingSummary && (


### PR DESCRIPTION
## What & why

Every agent run should open with the full picture of the ticket so a run resumes exactly where the last one left off — without a `get_task` round-trip. Today the two run-prompt builders are inconsistent:

| Field | `buildTaskPrompt` (before) | `buildCoachReviewPrompt` (before) |
|---|---|---|
| description | ✅ full, but **unlabeled** | ✅ `### Description` |
| rules | ✅ `### Rules for this task` | ❌ missing |
| progress_summary | ❌ missing (not even loaded into `TaskInfo`) | ❌ missing |

`progress_summary` (the agent-maintained "what's done / what's left" checkpoint) was documented as *fetch-on-demand* and never injected. This PR makes the **full description, rules, and progress_summary** auto-included in **every** run — the normal task prompt and the Coach's post-completion review prompt — all untruncated.

## Changes

- **`buildTaskPrompt`**: label the description as `### Description`; append a `### Progress Summary` block when present.
- **`buildCoachReviewPrompt`**: add `### Rules` + `### Progress Summary` alongside the existing description and full comment history.
- **Load `progress_summary` into the run `TaskInfo`**: both `job-manager` run-task `SELECT`s, the local `TaskRow` type, and the `TaskInfo` interface (required field, mirroring `rules`).
- **Docs/UX**: refresh the Progress Summary tooltip (was *"Not auto-included… fetch on demand"*) and the agent shared-instructions to reflect the new behavior; add a run-prompt composition note in `.dev/api.md`.

## Testing

- `bunx vitest run test/agent-runner.test.ts test/agent-autonomy.test.ts test/mention-handoff-prompt.test.ts test/coach.test.ts` → **103 passed**. New assertions cover the labeled description, the Progress Summary block (present + omitted-when-empty), and the Coach prompt carrying rules + progress_summary.
- `bun run typecheck` and `bun run check` clean.

## Note (no behavior change here)

A mention-triggered run still injects only an **excerpt** of the triggering comment (≤ 500 chars, code fences stripped) in the Mention Handoff block — not the whole comment. Out of scope for this PR; happy to follow up if we want the full comment too.

https://claude.ai/code/session_011hw1NB2htdg71m2RBduYJZ

---
_Generated by [Claude Code](https://claude.ai/code/session_011hw1NB2htdg71m2RBduYJZ)_