### PR TITLE
feat(web): add formatted view to the execution log viewer

### DIFF
--- a/packages/web/src/components/formatted-log-view.tsx
+++ b/packages/web/src/components/formatted-log-view.tsx
@@ -1,0 +1,250 @@
+import { Boxes, ChevronDown, ChevronRight, Cpu, Sparkles, Terminal, Wrench } from 'lucide-react';
+import { type ComponentType, useMemo, useState } from 'react';
+import {
+	type CommandBlock,
+	type DoneBlock,
+	type LogBlock,
+	parseAgentLog,
+	type ResultBlock,
+	type SessionBlock,
+	type TextBlock,
+	type ThinkingBlock,
+	type ToolBlock,
+} from '../lib/parse-agent-log';
+import { MarkdownProse } from './markdown-prose';
+import { Badge } from './ui/badge';
+
+interface FormattedLogViewProps {
+	lines: { id: number; stream: 'stdout' | 'stderr'; text: string }[];
+	teamId?: string;
+	projectSlug?: string;
+	testId?: string;
+}
+
+/**
+ * Document-style rendering of agent run logs: paragraph spacing between
+ * sections, prose/lists via markdown, and indented tool-use blocks whose result
+ * shows on expand. Parses the prefixed lines client-side (see parse-agent-log).
+ */
+export function FormattedLogView({ lines, teamId, projectSlug, testId }: FormattedLogViewProps) {
+	const blocks = useMemo(() => parseAgentLog(lines), [lines]);
+
+	return (
+		<div data-testid={testId} className="space-y-3 text-sm leading-relaxed text-text">
+			{blocks.map((block) => (
+				<BlockView key={block.id} block={block} teamId={teamId} projectSlug={projectSlug} />
+			))}
+		</div>
+	);
+}
+
+function BlockView({
+	block,
+	teamId,
+	projectSlug,
+}: {
+	block: LogBlock;
+	teamId?: string;
+	projectSlug?: string;
+}) {
+	switch (block.type) {
+		case 'session':
+			return <SessionView block={block} />;
+		case 'text':
+			return <TextView block={block} teamId={teamId} projectSlug={projectSlug} />;
+		case 'thinking':
+			return <ThinkingView block={block} />;
+		case 'command':
+			return <CommandView block={block} />;
+		case 'tool':
+			return <ToolView block={block} />;
+		case 'result':
+			return <ResultView block={block} />;
+		case 'done':
+			return <DoneView block={block} />;
+	}
+}
+
+function SessionView({ block }: { block: SessionBlock }) {
+	return (
+		<div className="flex items-center gap-1.5 text-xs text-text-subtle">
+			<Cpu className="w-3.5 h-3.5 shrink-0" />
+			<span className="font-medium text-text-muted">{block.model}</span>
+			{block.toolCount != null && <span>· {block.toolCount} tools</span>}
+		</div>
+	);
+}
+
+function TextView({
+	block,
+	teamId,
+	projectSlug,
+}: {
+	block: TextBlock;
+	teamId?: string;
+	projectSlug?: string;
+}) {
+	if (block.stream === 'stderr') {
+		return (
+			<pre className="whitespace-pre-wrap break-words font-mono text-xs text-accent-red-text">
+				{block.text}
+			</pre>
+		);
+	}
+	return (
+		<MarkdownProse teamId={teamId} projectSlug={projectSlug}>
+			{block.text}
+		</MarkdownProse>
+	);
+}
+
+function ThinkingView({ block }: { block: ThinkingBlock }) {
+	return (
+		<div className="border-l-2 border-border-subtle pl-3 text-text-subtle">
+			<div className="mb-0.5 flex items-center gap-1 text-[10px] uppercase tracking-wider">
+				<Sparkles className="w-3 h-3 shrink-0" />
+				Thinking
+			</div>
+			<p className="whitespace-pre-wrap text-xs italic leading-relaxed">{block.text}</p>
+		</div>
+	);
+}
+
+function CommandView({ block }: { block: CommandBlock }) {
+	const [open, setOpen] = useState(false);
+	const isLong = block.text.length > 100;
+	return (
+		<div className="rounded-radius-md border border-border-subtle bg-bg-muted">
+			<button
+				type="button"
+				onClick={() => isLong && setOpen((o) => !o)}
+				className={`flex w-full items-start gap-2 px-3 py-1.5 text-left font-mono text-xs text-text-muted ${
+					isLong ? 'cursor-pointer' : 'cursor-default'
+				}`}
+				aria-expanded={isLong ? open : undefined}
+			>
+				<span className="select-none text-text-subtle">$</span>
+				<span className={`min-w-0 flex-1 ${open ? 'whitespace-pre-wrap break-all' : 'truncate'}`}>
+					{block.text}
+				</span>
+				{isLong &&
+					(open ? (
+						<ChevronDown className="mt-0.5 w-3 h-3 shrink-0" />
+					) : (
+						<ChevronRight className="mt-0.5 w-3 h-3 shrink-0" />
+					))}
+			</button>
+		</div>
+	);
+}
+
+function toolDisplay(name: string): { label: string; Icon: ComponentType<{ className?: string }> } {
+	if (name.startsWith('mcp__')) {
+		const parts = name.split('__');
+		const server = parts[1] ?? '';
+		const tool = parts.slice(2).join('__');
+		return { label: tool ? `${server} / ${tool}` : name, Icon: Boxes };
+	}
+	if (name === 'Bash') return { label: name, Icon: Terminal };
+	return { label: name, Icon: Wrench };
+}
+
+const STATUS_DOT: Record<ToolBlock['status'], string> = {
+	pending: 'bg-text-subtle',
+	success: 'bg-accent-green',
+	error: 'bg-accent-red',
+};
+
+function ToolView({ block }: { block: ToolBlock }) {
+	const [open, setOpen] = useState(false);
+	const { label, Icon } = toolDisplay(block.name);
+	return (
+		<div className="border-l-2 border-border pl-3">
+			<button
+				type="button"
+				onClick={() => setOpen((o) => !o)}
+				aria-expanded={open}
+				className="flex w-full items-center gap-1.5 text-left text-xs text-text-muted hover:text-text"
+			>
+				{open ? (
+					<ChevronDown className="w-3 h-3 shrink-0" />
+				) : (
+					<ChevronRight className="w-3 h-3 shrink-0" />
+				)}
+				<Icon className="w-3 h-3 shrink-0" />
+				<span className="font-mono font-medium text-text">{label}</span>
+				<span className={`h-1.5 w-1.5 shrink-0 rounded-full ${STATUS_DOT[block.status]}`} />
+				{block.argsPreview && (
+					<span className="min-w-0 flex-1 truncate font-mono text-text-subtle">
+						{block.argsPreview}
+					</span>
+				)}
+			</button>
+			{open && (
+				<div className="mt-1.5 space-y-1.5">
+					{block.argsPreview && (
+						<pre className="overflow-x-auto whitespace-pre-wrap break-all rounded bg-bg-muted p-2 text-[11px] text-text-muted">
+							{block.argsPreview}
+						</pre>
+					)}
+					{block.result != null ? (
+						<pre
+							className={`overflow-x-auto whitespace-pre-wrap break-all rounded p-2 text-[11px] ${
+								block.status === 'error'
+									? 'bg-accent-red-bg text-accent-red-text'
+									: 'bg-bg-muted text-text-muted'
+							}`}
+						>
+							{block.result}
+						</pre>
+					) : (
+						<div className="text-[11px] italic text-text-subtle">No result captured.</div>
+					)}
+				</div>
+			)}
+		</div>
+	);
+}
+
+function ResultView({ block }: { block: ResultBlock }) {
+	return (
+		<pre
+			className={`overflow-x-auto whitespace-pre-wrap break-all rounded p-2 text-[11px] ${
+				block.isError ? 'bg-accent-red-bg text-accent-red-text' : 'bg-bg-muted text-text-muted'
+			}`}
+		>
+			{block.text}
+		</pre>
+	);
+}
+
+function formatDuration(ms: number): string {
+	if (ms < 1000) return `${ms}ms`;
+	const seconds = ms / 1000;
+	if (seconds < 60) return `${seconds.toFixed(1)}s`;
+	const minutes = Math.floor(seconds / 60);
+	const rest = Math.round(seconds % 60);
+	return `${minutes}m ${rest}s`;
+}
+
+function DoneView({ block }: { block: DoneBlock }) {
+	const isError = block.status === 'error' || block.status.startsWith('error');
+	return (
+		<div className="flex flex-wrap items-center gap-x-3 gap-y-1 rounded-radius-md border border-border-subtle bg-bg-subtle px-3 py-2 text-xs">
+			<Badge color={isError ? 'red' : 'green'}>{block.status}</Badge>
+			{block.turns != null && <span className="text-text-muted">{block.turns} turns</span>}
+			{block.durationMs != null && (
+				<span className="text-text-muted">{formatDuration(block.durationMs)}</span>
+			)}
+			{(block.inputTokens != null || block.outputTokens != null) && (
+				<span className="text-text-muted">
+					{(block.inputTokens ?? 0).toLocaleString()} in /{' '}
+					{(block.outputTokens ?? 0).toLocaleString()} out
+				</span>
+			)}
+			{block.costUsd != null && (
+				<span className="text-text-muted">${block.costUsd.toFixed(2)}</span>
+			)}
+		</div>
+	);
+}

--- a/packages/web/src/components/log-viewer.tsx
+++ b/packages/web/src/components/log-viewer.tsx
@@ -1,6 +1,16 @@
 import * as Dialog from '@radix-ui/react-dialog';
-import { Check, Copy, Maximize2, Minimize2, MoveVertical, Trash2 } from 'lucide-react';
+import {
+	AlignLeft,
+	Check,
+	Code,
+	Copy,
+	Maximize2,
+	Minimize2,
+	MoveVertical,
+	Trash2,
+} from 'lucide-react';
 import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import { FormattedLogView } from './formatted-log-view';
 import { Button } from './ui/button';
 import { Tooltip } from './ui/tooltip';
 
@@ -20,6 +30,13 @@ interface LogViewerProps {
 	compact?: boolean;
 	headerAction?: ReactNode;
 	headerActionLeading?: ReactNode;
+	/** Enables the Formatted/Raw switcher and defaults to the formatted view.
+	 *  Only meaningful for agent-run logs (prefixed lines); container logs leave
+	 *  it off and stay raw. */
+	formattable?: boolean;
+	/** Threaded to the formatted view's markdown renderer for @mention links. */
+	teamId?: string;
+	projectSlug?: string;
 }
 
 export function LogViewer({
@@ -32,10 +49,14 @@ export function LogViewer({
 	compact = false,
 	headerAction,
 	headerActionLeading,
+	formattable = false,
+	teamId,
+	projectSlug,
 }: LogViewerProps) {
 	const [autoScroll, setAutoScroll] = useState(true);
 	const [copied, setCopied] = useState(false);
 	const [isExpanded, setIsExpanded] = useState(false);
+	const [viewMode, setViewMode] = useState<'formatted' | 'raw'>(formattable ? 'formatted' : 'raw');
 	const scrollRef = useRef<HTMLDivElement | null>(null);
 	const lastCountRef = useRef(0);
 	const pendingBottomOffsetRef = useRef<number | null>(null);
@@ -92,9 +113,11 @@ export function LogViewer({
 		}
 	};
 
-	const bodyClassName = isExpanded
-		? 'bg-[#0d1117] flex-1 min-h-0 overflow-y-auto p-3 font-mono text-xs leading-relaxed'
-		: `bg-[#0d1117] ${heightClassName} overflow-y-auto p-3 font-mono text-xs leading-relaxed`;
+	const isFormatted = formattable && viewMode === 'formatted';
+	const sizing = isExpanded ? 'flex-1 min-h-0' : heightClassName;
+	const bodyClassName = isFormatted
+		? `bg-bg text-text ${sizing} overflow-y-auto p-3 text-sm leading-relaxed`
+		: `bg-[#0d1117] ${sizing} overflow-y-auto p-3 font-mono text-xs leading-relaxed`;
 
 	const content = (
 		<>
@@ -103,6 +126,34 @@ export function LogViewer({
 					<span>Logs</span>
 					{liveLabel}
 					<span className="text-text-subtle font-normal">{lines.length} lines</span>
+					{formattable && (
+						<div className="flex items-center gap-0.5">
+							<Tooltip content="Formatted view">
+								<Button
+									variant="ghost"
+									size="sm"
+									onClick={() => setViewMode('formatted')}
+									aria-pressed={viewMode === 'formatted'}
+									aria-label="Formatted view"
+									className={`h-6 px-1.5 ${viewMode === 'formatted' ? 'bg-bg-muted text-text border border-border shadow-inner' : ''}`}
+								>
+									<AlignLeft className="w-3 h-3" />
+								</Button>
+							</Tooltip>
+							<Tooltip content="Raw logs">
+								<Button
+									variant="ghost"
+									size="sm"
+									onClick={() => setViewMode('raw')}
+									aria-pressed={viewMode === 'raw'}
+									aria-label="Raw logs"
+									className={`h-6 px-1.5 ${viewMode === 'raw' ? 'bg-bg-muted text-text border border-border shadow-inner' : ''}`}
+								>
+									<Code className="w-3 h-3" />
+								</Button>
+							</Tooltip>
+						</div>
+					)}
 				</div>
 				<div className="flex items-center gap-2">
 					{headerActionLeading}
@@ -160,6 +211,8 @@ export function LogViewer({
 			<div ref={attachScrollRef} data-testid={testId} className={bodyClassName}>
 				{lines.length === 0 ? (
 					<span className="text-text-subtle">{emptyState ?? 'No output.'}</span>
+				) : isFormatted ? (
+					<FormattedLogView lines={lines} teamId={teamId} projectSlug={projectSlug} />
 				) : (
 					lines.map((line) => (
 						<div

--- a/packages/web/src/lib/parse-agent-log.ts
+++ b/packages/web/src/lib/parse-agent-log.ts
@@ -1,0 +1,205 @@
+/**
+ * Client-side parser that turns the flattened, prefixed agent-run log lines
+ * (produced server-side by `agent-stream-parser.ts`) into structured blocks the
+ * Formatted log view can render.
+ *
+ * The server discards the original stream-json and persists only single-line,
+ * prefixed text (`[session]`, `[thinking]`, `[tool] Name(args)`, `[tool-result]`,
+ * `[tool-error]`, `[done]`, plus bare prose and `$ command` lines). There is no
+ * correlation id between a tool call and its result — Claude emits N parallel
+ * `[tool]` lines and then N `[tool-result]`/`[tool-error]` lines in the same
+ * order, so we pair them FIFO via a queue of pending tool blocks.
+ */
+
+/** Minimal shape of a log line; structurally compatible with `LogViewerLine`. */
+export interface AgentLogLine {
+	id: number;
+	stream: 'stdout' | 'stderr';
+	text: string;
+}
+
+export type ToolStatus = 'pending' | 'success' | 'error';
+
+export interface SessionBlock {
+	type: 'session';
+	id: number;
+	model: string;
+	toolCount: number | null;
+}
+
+export interface TextBlock {
+	type: 'text';
+	id: number;
+	text: string;
+	stream: 'stdout' | 'stderr';
+}
+
+export interface ThinkingBlock {
+	type: 'thinking';
+	id: number;
+	text: string;
+}
+
+export interface CommandBlock {
+	type: 'command';
+	id: number;
+	text: string;
+}
+
+export interface ToolBlock {
+	type: 'tool';
+	id: number;
+	name: string;
+	argsPreview: string;
+	result: string | null;
+	status: ToolStatus;
+}
+
+/** A `[tool-result]`/`[tool-error]` that arrived with no pending tool to pair with. */
+export interface ResultBlock {
+	type: 'result';
+	id: number;
+	text: string;
+	isError: boolean;
+}
+
+export interface DoneBlock {
+	type: 'done';
+	id: number;
+	status: string;
+	turns: number | null;
+	durationMs: number | null;
+	inputTokens: number | null;
+	outputTokens: number | null;
+	costUsd: number | null;
+}
+
+export type LogBlock =
+	| SessionBlock
+	| TextBlock
+	| ThinkingBlock
+	| CommandBlock
+	| ToolBlock
+	| ResultBlock
+	| DoneBlock;
+
+/** Strip a `[prefix]` token and the single following space, if present. */
+function stripPrefix(text: string, prefix: string): string {
+	const rest = text.slice(prefix.length);
+	return rest.startsWith(' ') ? rest.slice(1) : rest;
+}
+
+function parseSession(id: number, text: string): SessionBlock {
+	const model = /\bmodel=(\S+)/.exec(text)?.[1] ?? 'unknown';
+	const toolMatch = /\btools=(\d+)/.exec(text)?.[1];
+	return { type: 'session', id, model, toolCount: toolMatch ? Number(toolMatch) : null };
+}
+
+function parseTool(id: number, text: string): ToolBlock {
+	const body = stripPrefix(text, '[tool]');
+	const open = body.indexOf('(');
+	let name = body;
+	let argsPreview = '';
+	if (open !== -1) {
+		name = body.slice(0, open);
+		argsPreview = body.slice(open + 1);
+		if (argsPreview.endsWith(')')) argsPreview = argsPreview.slice(0, -1);
+	}
+	return {
+		type: 'tool',
+		id,
+		name: name.trim(),
+		argsPreview: argsPreview.trim(),
+		result: null,
+		status: 'pending',
+	};
+}
+
+function parseDone(id: number, text: string): DoneBlock {
+	const status = /^\[done\]\s+(\S+)/.exec(text)?.[1] ?? 'done';
+	const turns = /\bturns=(\d+)/.exec(text)?.[1];
+	const duration = /\bduration=(\d+)ms/.exec(text)?.[1];
+	const tokens = /\btokens=(\d+)\/(\d+)/.exec(text);
+	const cost = /\bcost=\$([\d.]+)/.exec(text)?.[1];
+	return {
+		type: 'done',
+		id,
+		status,
+		turns: turns ? Number(turns) : null,
+		durationMs: duration ? Number(duration) : null,
+		inputTokens: tokens ? Number(tokens[1]) : null,
+		outputTokens: tokens ? Number(tokens[2]) : null,
+		costUsd: cost ? Number(cost) : null,
+	};
+}
+
+export function parseAgentLog(lines: AgentLogLine[]): LogBlock[] {
+	const blocks: LogBlock[] = [];
+	const pendingTools: ToolBlock[] = [];
+	let textBuf: { id: number; parts: string[]; stream: 'stdout' | 'stderr' } | null = null;
+
+	const flushText = () => {
+		if (!textBuf) return;
+		blocks.push({
+			type: 'text',
+			id: textBuf.id,
+			text: textBuf.parts.join('\n'),
+			stream: textBuf.stream,
+		});
+		textBuf = null;
+	};
+
+	for (const line of lines) {
+		const text = line.text;
+
+		if (text.startsWith('[session]')) {
+			flushText();
+			blocks.push(parseSession(line.id, text));
+			continue;
+		}
+		if (text.startsWith('[thinking]')) {
+			flushText();
+			blocks.push({ type: 'thinking', id: line.id, text: stripPrefix(text, '[thinking]') });
+			continue;
+		}
+		if (text.startsWith('[tool] ')) {
+			flushText();
+			const tool = parseTool(line.id, text);
+			blocks.push(tool);
+			pendingTools.push(tool);
+			continue;
+		}
+		if (text.startsWith('[tool-result]') || text.startsWith('[tool-error]')) {
+			flushText();
+			const isError = text.startsWith('[tool-error]');
+			const body = stripPrefix(text, isError ? '[tool-error]' : '[tool-result]');
+			const target = pendingTools.shift();
+			if (target) {
+				target.result = body;
+				target.status = isError ? 'error' : 'success';
+			} else {
+				blocks.push({ type: 'result', id: line.id, text: body, isError });
+			}
+			continue;
+		}
+		if (text.startsWith('[done]')) {
+			flushText();
+			blocks.push(parseDone(line.id, text));
+			continue;
+		}
+		if (text.startsWith('$ ')) {
+			flushText();
+			blocks.push({ type: 'command', id: line.id, text: text.slice(2) });
+			continue;
+		}
+
+		// Bare prose / preamble — coalesce consecutive same-stream lines into one
+		// block so multi-line markdown (lists, etc.) renders as a single document.
+		if (textBuf && textBuf.stream !== line.stream) flushText();
+		if (!textBuf) textBuf = { id: line.id, parts: [], stream: line.stream };
+		textBuf.parts.push(text);
+	}
+
+	flushText();
+	return blocks;
+}

--- a/packages/web/src/routes/teams/$teamId/agents/$agentId/executions/$runId.tsx
+++ b/packages/web/src/routes/teams/$teamId/agents/$agentId/executions/$runId.tsx
@@ -211,6 +211,9 @@ function ExecutionDetailPage() {
 			<div className="mb-4">
 				<LogViewer
 					lines={lines}
+					formattable
+					teamId={teamId}
+					projectSlug={run.project_slug ?? undefined}
 					emptyState={isActive ? getRunWaitingMessage(run.status) : 'No output captured.'}
 					liveLabel={isActive ? <span className="text-accent-amber">(live)</span> : null}
 					heightClassName="max-h-[60vh]"

--- a/packages/web/test/formatted-log-view.test.tsx
+++ b/packages/web/test/formatted-log-view.test.tsx
@@ -1,0 +1,70 @@
+import { expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+import { seedWorkspace } from './helpers/seed';
+
+const LOG_TEXT = [
+	'[session] model=deepseek-v4-pro tools=115',
+	'[thinking] Planning the approach now.',
+	'Here is the plan to follow:',
+	'- first item',
+	'- second item',
+	'[tool] Bash(command=ls -la /tmp, description=list files)',
+	'[tool-result] total 8 drwxr-xr-x 4 node node',
+	'All done with the work.',
+	'[done] success turns=3 duration=1200ms tokens=100/200 cost=$0.0100',
+].join('\n');
+
+test('run log defaults to the formatted view and toggles to raw via the icon buttons', async () => {
+	const seeded = { teamSlug: '', agentSlug: '', runId: '' };
+
+	const { findByText, findByTestId, queryByText, getByLabelText, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async (ctx) => {
+			const ws = await seedWorkspace();
+			const agent = ws.agents.find((a) => a.slug === 'captain') ?? ws.agents[0];
+			const run = await ctx.db.query<{ id: string }>(
+				`INSERT INTO heartbeat_runs (member_id, team_id, status, started_at, finished_at, log_text, input_tokens, output_tokens, cost_cents)
+				 VALUES ($1, $2, 'succeeded'::heartbeat_run_status, now(), now(), $3, 100, 200, 1)
+				 RETURNING id`,
+				[agent.id, ws.team.id, LOG_TEXT],
+			);
+			seeded.teamSlug = ws.team.slug;
+			seeded.agentSlug = agent.slug;
+			seeded.runId = run.rows[0].id;
+		},
+	});
+
+	await router.navigate({
+		to: '/teams/$teamId/agents/$agentId/executions/$runId',
+		params: { teamId: seeded.teamSlug, agentId: seeded.agentSlug, runId: seeded.runId },
+	});
+
+	// Formatted is the default: the tool name renders without its `[tool]` prefix,
+	// and the markdown list renders as real <li> elements.
+	const toolLabel = await findByText('Bash', undefined, { timeout: 15_000 });
+	const listItem = await findByText('first item');
+	expect(listItem.closest('li')).not.toBeNull();
+
+	const body = await findByTestId('run-log');
+	expect(body.textContent).not.toContain('[tool]');
+	expect(body.textContent).not.toContain('[thinking]');
+	expect(body.textContent).not.toContain('[session]');
+
+	// The tool result is hidden until the tool block is expanded.
+	expect(queryByText(/total 8/)).toBeNull();
+	const toolButton = toolLabel.closest('button');
+	expect(toolButton).not.toBeNull();
+	await user.click(toolButton as HTMLButtonElement);
+	await findByText(/total 8/);
+
+	// Switching to Raw shows the literal prefixed line.
+	await user.click(getByLabelText('Raw logs'));
+	expect((await findByTestId('run-log')).textContent).toContain(
+		'[tool] Bash(command=ls -la /tmp, description=list files)',
+	);
+
+	// Switching back to Formatted hides the prefixes again.
+	await user.click(getByLabelText('Formatted view'));
+	await findByText('Bash');
+	expect((await findByTestId('run-log')).textContent).not.toContain('[tool]');
+});

--- a/packages/web/test/parse-agent-log.test.ts
+++ b/packages/web/test/parse-agent-log.test.ts
@@ -1,0 +1,141 @@
+import {
+	type AgentLogLine,
+	type DoneBlock,
+	parseAgentLog,
+	type ResultBlock,
+	type TextBlock,
+	type ToolBlock,
+} from '@hezo/web/lib/parse-agent-log';
+import { expect, test } from 'vitest';
+
+let counter = 0;
+function makeLines(
+	items: ReadonlyArray<string | readonly [string, 'stdout' | 'stderr']>,
+): AgentLogLine[] {
+	return items.map((it) =>
+		typeof it === 'string'
+			? { id: counter++, stream: 'stdout', text: it }
+			: { id: counter++, stream: it[1], text: it[0] },
+	);
+}
+
+test('parses the session header', () => {
+	const blocks = parseAgentLog(makeLines(['[session] model=deepseek-v4-pro tools=115']));
+	expect(blocks).toEqual([
+		{ type: 'session', id: expect.any(Number), model: 'deepseek-v4-pro', toolCount: 115 },
+	]);
+});
+
+test('pairs parallel tool calls with their results FIFO', () => {
+	const blocks = parseAgentLog(
+		makeLines([
+			'[tool] Bash(command=ls -la, description=list)',
+			'[tool] mcp__hezo__list_comments(team_id=abc)',
+			'[tool] mcp__hezo__get_task(task_id=def)',
+			'[tool-result] total 8',
+			'[tool-result] [ { "id": "c1" } ]',
+			'[tool-result] { "id": "t1" }',
+		]),
+	);
+	const tools = blocks.filter((b): b is ToolBlock => b.type === 'tool');
+	expect(tools).toHaveLength(3);
+	expect(tools[0]).toMatchObject({
+		name: 'Bash',
+		argsPreview: 'command=ls -la, description=list',
+		status: 'success',
+		result: 'total 8',
+	});
+	expect(tools[1]).toMatchObject({
+		name: 'mcp__hezo__list_comments',
+		result: '[ { "id": "c1" } ]',
+	});
+	expect(tools[2]).toMatchObject({ name: 'mcp__hezo__get_task', result: '{ "id": "t1" }' });
+	// Every result paired — no orphan result blocks.
+	expect(blocks.some((b) => b.type === 'result')).toBe(false);
+});
+
+test('marks a tool-error result with error status and pairs in order', () => {
+	const blocks = parseAgentLog(
+		makeLines([
+			'[tool] Bash(command=git log)',
+			'[tool] mcp__hezo__list_assets(team_id=abc)',
+			'[tool-error] Exit code 128 fatal: not a git repository',
+			'[tool-result] { "files": [] }',
+		]),
+	);
+	const tools = blocks.filter((b): b is ToolBlock => b.type === 'tool');
+	expect(tools[0]).toMatchObject({
+		name: 'Bash',
+		status: 'error',
+		result: expect.stringContaining('Exit code 128'),
+	});
+	expect(tools[1]).toMatchObject({ status: 'success', result: '{ "files": [] }' });
+});
+
+test('coalesces consecutive prose lines and preserves a markdown list', () => {
+	const blocks = parseAgentLog(
+		makeLines(['Here is the plan to follow:', '- first item', '- second item']),
+	);
+	const texts = blocks.filter((b): b is TextBlock => b.type === 'text');
+	expect(texts).toHaveLength(1);
+	expect(texts[0].text).toBe('Here is the plan to follow:\n- first item\n- second item');
+});
+
+test('splits prose into separate blocks across an interrupting event', () => {
+	const blocks = parseAgentLog(
+		makeLines([
+			'Let me check the mockup.',
+			'[thinking] considering options',
+			'Now starting phase 1.',
+		]),
+	);
+	expect(blocks.map((b) => b.type)).toEqual(['text', 'thinking', 'text']);
+});
+
+test('keeps stdout and stderr prose in separate blocks', () => {
+	const blocks = parseAgentLog(
+		makeLines([
+			['building...', 'stdout'],
+			['warning: deprecated', 'stderr'],
+		]),
+	);
+	const texts = blocks.filter((b): b is TextBlock => b.type === 'text');
+	expect(texts).toHaveLength(2);
+	expect(texts[1]).toMatchObject({ stream: 'stderr', text: 'warning: deprecated' });
+});
+
+test('treats a $ line as a command block', () => {
+	const blocks = parseAgentLog(makeLines(['$ claude --settings /x -p < /y.txt']));
+	expect(blocks[0]).toMatchObject({ type: 'command', text: 'claude --settings /x -p < /y.txt' });
+});
+
+test('parses the done summary', () => {
+	const blocks = parseAgentLog(
+		makeLines(['[done] success turns=12 duration=34000ms tokens=1000/2000 cost=$0.1234']),
+	);
+	expect(blocks[0]).toMatchObject<Partial<DoneBlock>>({
+		type: 'done',
+		status: 'success',
+		turns: 12,
+		durationMs: 34000,
+		inputTokens: 1000,
+		outputTokens: 2000,
+		costUsd: 0.1234,
+	});
+});
+
+test('emits a standalone result block when no tool is pending', () => {
+	const blocks = parseAgentLog(makeLines(['[tool-result] orphaned output']));
+	expect(blocks[0]).toMatchObject<Partial<ResultBlock>>({
+		type: 'result',
+		isError: false,
+		text: 'orphaned output',
+	});
+});
+
+test('leaves a tool pending when its result has not arrived', () => {
+	const blocks = parseAgentLog(makeLines(['[tool] Bash(command=sleep 1)']));
+	const tool = blocks[0] as ToolBlock;
+	expect(tool.status).toBe('pending');
+	expect(tool.result).toBeNull();
+});


### PR DESCRIPTION
## What

The run log viewer rendered agent output as a flat wall of prefixed monospace lines (`[thinking]`, `[tool] …`, `[tool-result]`, …). This adds a document-style **Formatted** view — now the default — alongside the existing **Raw** view.

The two modes are switchable via two compact icon buttons in the header, immediately after the line count, with tooltips explaining each (no text labels, to save space). Available in both the inline and expanded full-page views.

## How

The formatted view parses the existing prefixed lines **client-side** (the structured stream-json is discarded server-side, so there are **no server/DB changes**) into semantic blocks:

- **Assistant prose** → rendered as markdown via the existing `MarkdownProse`, so lists and paragraphs read nicely.
- **Thinking** → de-emphasized, italic, with a subtle label.
- **Tool calls** → indented, collapsible blocks. Args + result are revealed on expand (error results styled red). Parallel calls pair with their results **FIFO by stream order**, since the flattened lines carry no correlation id.
- **Command / session / done** lines get their own styling (command block, model chip, summary card).

The formatted mode is **opt-in** via a new `formattable` prop — only agent-run logs enable it; container build/run logs stay raw and unchanged.

## Files

- `packages/web/src/lib/parse-agent-log.ts` — pure parser (prefixed lines → blocks)
- `packages/web/src/components/formatted-log-view.tsx` — block renderer
- `packages/web/src/components/log-viewer.tsx` — opt-in toggle + formatted body
- `packages/web/src/routes/.../executions/$runId.tsx` — enables it on the run page

## Testing

- `packages/web/test/parse-agent-log.test.ts` — pure parser (session/done parsing, FIFO tool↔result pairing, error pairing, prose coalescing + markdown list, command, orphan result, pending tool).
- `packages/web/test/formatted-log-view.test.tsx` — component test through the run-detail route: asserts Formatted is the default, the markdown list renders as `<li>`, tool result is hidden until expanded, and the icon toggle switches to Raw (literal prefixed line) and back.

Local: new tests pass, `agent-detail.test.tsx` (other `LogViewer` consumer) passes, `typecheck` and `biome` clean, production build succeeds.

https://claude.ai/code/session_01SP4A1aTeB6EEFXSYFJTo4p

---
_Generated by [Claude Code](https://claude.ai/code/session_01SP4A1aTeB6EEFXSYFJTo4p)_