### PR TITLE
fix(agent-runtime): unblock in-container git, asset reads, and sudo

### DIFF
--- a/docker/Dockerfile.agent-base
+++ b/docker/Dockerfile.agent-base
@@ -2,8 +2,16 @@ FROM node:24-slim
 
 # Install common development tools
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git curl jq openssh-client ca-certificates python3 socat \
+    git curl jq openssh-client ca-certificates python3 socat sudo \
     && rm -rf /var/lib/apt/lists/*
+
+# The container runs as the unprivileged `node` user (so bind-mounted worktree
+# files stay node-owned), but agents need to install system packages at runtime
+# (e.g. `npx playwright install-deps`). Grant passwordless sudo: the container is
+# an ephemeral, egress-constrained sandbox in which the agent already executes
+# arbitrary code, so in-container root does not widen the trust boundary.
+RUN echo 'node ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/node \
+    && chmod 0440 /etc/sudoers.d/node
 
 ENV PATH="/root/.local/bin:${PATH}"
 

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -45,7 +45,7 @@ import { assertChildrenAllClosed, assertNoOutstandingActivity } from '../lib/tas
 import type { AuthInfo } from '../lib/types';
 import { logger } from '../logger';
 import { resolveProjectTaskPrefix } from '../routes/projects';
-import { loadAgentAttachmentsForComments } from '../services/agent-runner';
+import { AGENT_ATTACHMENT_DIR, loadAgentAttachmentsForComments } from '../services/agent-runner';
 import {
 	AgentSystemPromptError,
 	fetchAgentSystemPromptForBatch,
@@ -53,7 +53,7 @@ import {
 } from '../services/agent-system-prompts';
 import { broadcastApprovalChange } from '../services/approval-broadcast';
 import { resolveApproval } from '../services/approval-resolve';
-import { deleteAsset, writeAsset } from '../services/asset-storage';
+import { deleteAsset, readAsset, writeAsset } from '../services/asset-storage';
 import { fireCommentWakeups } from '../services/comment-wakeups';
 import { enqueueTeamCoherenceReviewTask } from '../services/description-tasks';
 import {
@@ -2529,6 +2529,62 @@ export function registerTools(
 				await deleteAsset(dataDir, teamId, projectId, result.replacedAssetId).catch(() => {});
 			}
 			return { written: true, id: result.id, reference: `assets/${result.original_filename}` };
+		},
+		db,
+	);
+
+	tool(
+		server,
+		'read_project_asset',
+		'Read a project asset\'s contents by filename (e.g. "ui-mockups.html") — the non-markdown files that list_project_assets returns (UI mockups, wireframes, SVG diagrams, text exports). Text-based assets (HTML, SVG, plain text) come back inline as `content`. Binary assets (images, PDFs, media) are not inlined; the response gives a read-only container path under /workspace/.hezo/assets/ to open directly. For markdown project docs use read_project_doc instead.',
+		{
+			team_id: z.string().describe('Team ID'),
+			project_id: z.string().describe('Project ID'),
+			filename: z.string().describe('Asset filename to read (e.g. "ui-mockups.html")'),
+		},
+		async (args, db, auth) => {
+			const denied = await verifyTeamAccess(db, auth, args.team_id as string);
+			if (denied) return { error: denied };
+			const pDenied = assertProjectAccess(auth, args.project_id as string);
+			if (pDenied) return { error: pDenied };
+
+			const teamId = args.team_id as string;
+			const projectId = args.project_id as string;
+			const filename = normalizeAssetFilename(args.filename as string);
+
+			const found = await db.query<{
+				id: string;
+				original_filename: string;
+				content_type: string;
+				byte_size: string;
+			}>(
+				`SELECT id, original_filename, content_type, byte_size
+				 FROM assets WHERE project_id = $1 AND original_filename = $2`,
+				[projectId, filename],
+			);
+			if (found.rows.length === 0) return { error: `Asset '${filename}' not found` };
+			const asset = found.rows[0];
+
+			// Text-based assets are returned inline; binary assets are left on the
+			// read-only bind mount for the agent to open directly.
+			const isText =
+				asset.content_type.startsWith('text/') || asset.content_type === 'image/svg+xml';
+			if (!isText) {
+				return {
+					filename: asset.original_filename,
+					content_type: asset.content_type,
+					byte_size: Number(asset.byte_size),
+					binary: true,
+					path: `${AGENT_ATTACHMENT_DIR}/${asset.id}`,
+				};
+			}
+
+			const buf = await readAsset(dataDir, teamId, projectId, asset.id);
+			return {
+				filename: asset.original_filename,
+				content_type: asset.content_type,
+				content: buf.toString('utf-8'),
+			};
 		},
 		db,
 	);

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -40,6 +40,7 @@ import { getAgentSystemPrompt } from './documents';
 import { applyEffortToRuntime, type EffortRuntimeApplication, resolveEffort } from './effort';
 import type { EgressProxy } from './egress';
 import { ensureGithubKnownHosts, ensureTaskWorktree, fetchRepo } from './git';
+import { buildGitIdentityEnv } from './git-identity';
 import type { LogStreamBroker } from './log-stream-broker';
 import { loadMcpConnectionDescriptors } from './mcp-connections';
 import { MCP_ADAPTERS, type McpDescriptor, validateInjection } from './mcp-injectors';
@@ -378,6 +379,10 @@ async function buildRunContext(
 	if (sshSocketContainerPath) {
 		env.push(`SSH_AUTH_SOCK=${sshSocketContainerPath}`);
 	}
+	// Configure git author/committer identity and SSH commit signing from the
+	// team's connected GitHub account + Ed25519 key, so in-container commits
+	// don't fail for lack of an author and land Verified via the agent socket.
+	env.push(...(await buildGitIdentityEnv(deps.db, deps.masterKeyManager, agent.team_id)));
 	if (egress) {
 		const proxyUrl = `http://${egress.host}:${egress.port}`;
 		const noProxyHosts = [

--- a/packages/server/src/services/asset-storage.ts
+++ b/packages/server/src/services/asset-storage.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync } from 'node:fs';
-import { unlink, writeFile } from 'node:fs/promises';
+import { readFile, unlink, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import { ATTACHMENT_MAX_BYTES } from '@hezo/shared';
 import { getAssetPath, getAssetsPath } from './workspace';
@@ -44,6 +44,15 @@ export async function writeAsset(
 	}
 
 	return { byteSize: buf.byteLength, sha256 };
+}
+
+export async function readAsset(
+	dataDir: string,
+	teamId: string,
+	projectId: string,
+	assetId: string,
+): Promise<Buffer> {
+	return readFile(getAssetPath(dataDir, teamId, projectId, assetId));
 }
 
 export async function deleteAsset(

--- a/packages/server/src/services/git-identity.ts
+++ b/packages/server/src/services/git-identity.ts
@@ -1,0 +1,96 @@
+import type { PGlite } from '@electric-sql/pglite';
+import type { MasterKeyManager } from '../crypto/master-key';
+import { listConnectionsForTeam } from './oauth/connection-store';
+
+/**
+ * Git author/committer identity plus an optional SSH commit-signing key,
+ * resolved from the team's connected GitHub account and Ed25519 key.
+ */
+export interface GitIdentity {
+	name: string;
+	email: string;
+	/** SSH public-key literal (`ssh-ed25519 AAAA... hezo`) for `user.signingkey`. */
+	signingKey: string | null;
+}
+
+const FALLBACK_IDENTITY = { name: 'Hezo Agent', email: 'agent@hezo.local' };
+
+/**
+ * Derive a Git author identity from a GitHub OAuth connection's stored metadata.
+ * The email uses GitHub's privacy-preserving noreply form so commits remain
+ * attributable and Verifiable regardless of the account's email privacy setting.
+ */
+export function deriveGitHubIdentity(
+	metadata: Record<string, unknown>,
+	fallbackLabel: string,
+): { name: string; email: string } | null {
+	const login = typeof metadata.login === 'string' ? metadata.login : fallbackLabel;
+	const userId = metadata.github_user_id;
+	if (!login || (typeof userId !== 'number' && typeof userId !== 'string')) return null;
+	return {
+		name: login,
+		email: `${userId}+${login}@users.noreply.github.com`,
+	};
+}
+
+/**
+ * Translate a resolved identity into `GIT_CONFIG_*` env entries. Git applies
+ * these to every invocation (git ≥ 2.31), so the container needs no `.gitconfig`
+ * file and no writable HOME. Signing config is emitted only when a key exists;
+ * the actual signature is produced by `ssh-keygen -Y sign` against the private
+ * key reachable through `SSH_AUTH_SOCK`.
+ */
+export function gitConfigEnv(identity: GitIdentity): string[] {
+	const entries: Array<[string, string]> = [
+		['user.name', identity.name],
+		['user.email', identity.email],
+	];
+	if (identity.signingKey) {
+		entries.push(
+			['gpg.format', 'ssh'],
+			['user.signingkey', identity.signingKey],
+			['commit.gpgsign', 'true'],
+		);
+	}
+	const env = [`GIT_CONFIG_COUNT=${entries.length}`];
+	entries.forEach(([key, value], i) => {
+		env.push(`GIT_CONFIG_KEY_${i}=${key}`, `GIT_CONFIG_VALUE_${i}=${value}`);
+	});
+	return env;
+}
+
+/**
+ * Resolve the team's Git identity from its GitHub connection (most recent wins)
+ * and Ed25519 public key, falling back to a generic identity so `git commit`
+ * never fails for lack of a configured author.
+ */
+export async function resolveGitIdentity(
+	db: PGlite,
+	masterKeyManager: MasterKeyManager,
+	teamId: string,
+): Promise<GitIdentity> {
+	const connections = await listConnectionsForTeam({ db, masterKeyManager }, teamId);
+	const github = connections.find((c) => c.provider === 'github');
+	const derived = github
+		? deriveGitHubIdentity(github.metadata, github.providerAccountLabel)
+		: null;
+
+	const keyRow = await db.query<{ public_key: string }>(
+		`SELECT public_key FROM team_ssh_keys WHERE team_id = $1`,
+		[teamId],
+	);
+
+	return {
+		...(derived ?? FALLBACK_IDENTITY),
+		signingKey: keyRow.rows[0]?.public_key ?? null,
+	};
+}
+
+/** Convenience: resolve the identity and return its `GIT_CONFIG_*` env entries. */
+export async function buildGitIdentityEnv(
+	db: PGlite,
+	masterKeyManager: MasterKeyManager,
+	teamId: string,
+): Promise<string[]> {
+	return gitConfigEnv(await resolveGitIdentity(db, masterKeyManager, teamId));
+}

--- a/packages/server/src/services/git.ts
+++ b/packages/server/src/services/git.ts
@@ -114,7 +114,7 @@ export async function createWorktree(
 ): Promise<{ success: boolean; error?: string }> {
 	const { exitCode, stderr } = await spawn(
 		'git',
-		['worktree', 'add', '-b', branchName, worktreePath],
+		['worktree', 'add', '--relative-paths', '-b', branchName, worktreePath],
 		{ cwd: repoDir },
 	);
 
@@ -128,6 +128,13 @@ export async function ensureTaskWorktree(
 	branchName: string,
 ): Promise<{ success: boolean; created: boolean; error?: string }> {
 	if (existsSync(join(worktreePath, '.git'))) {
+		// Rewrite the worktree's gitdir links to relative form. Worktrees created
+		// before this used absolute host paths, which resolve on the host but not
+		// inside the container's bind mounts; relativizing makes them portable.
+		await spawn('git', ['worktree', 'repair', '--relative-paths', worktreePath], {
+			cwd: repoDir,
+			timeout: 30_000,
+		});
 		const ff = await spawn('git', ['merge', '--ff-only', `origin/${branchName}`], {
 			cwd: worktreePath,
 			timeout: 30_000,
@@ -147,14 +154,24 @@ export async function ensureTaskWorktree(
 	if (remoteCheck.exitCode === 0) {
 		result = await spawn(
 			'git',
-			['worktree', 'add', '--track', '-b', branchName, worktreePath, `origin/${branchName}`],
+			[
+				'worktree',
+				'add',
+				'--relative-paths',
+				'--track',
+				'-b',
+				branchName,
+				worktreePath,
+				`origin/${branchName}`,
+			],
 			{ cwd: repoDir, timeout: 30_000 },
 		);
 	} else {
-		result = await spawn('git', ['worktree', 'add', '-b', branchName, worktreePath], {
-			cwd: repoDir,
-			timeout: 30_000,
-		});
+		result = await spawn(
+			'git',
+			['worktree', 'add', '--relative-paths', '-b', branchName, worktreePath],
+			{ cwd: repoDir, timeout: 30_000 },
+		);
 	}
 
 	if (result.exitCode !== 0) {

--- a/packages/server/src/services/template-resolver.ts
+++ b/packages/server/src/services/template-resolver.ts
@@ -40,6 +40,7 @@ const SHARED_INSTRUCTIONS = `
 
 ### Knowledge Maintenance
 - **Project docs**: Use \`list_project_docs\`, \`read_project_doc\`, and \`write_project_doc\` for high-level project context — PRDs, architecture decisions, API designs, schemas, implementation plans. Docs live in the project-doc store and are addressed by bare filename (e.g. \`prd.md\`, \`spec.md\`, \`research.md\`) — they are NOT filesystem paths, so never prefix a folder. Keep them aligned with the actual codebase. Do NOT put agent-specific working knowledge here.
+- **Project assets**: Use \`list_project_assets\`, \`read_project_asset\`, and \`write_project_asset\` for non-markdown files — UI mockups, wireframes, SVG diagrams, PDFs. Like docs, they are addressed by bare filename (e.g. \`ui-mockups.html\`), not filesystem paths; \`read_project_asset\` returns text-based assets inline. They are also bind-mounted read-only into your container at \`/workspace/.hezo/assets/\` if you need to open one on disk.
 - **AGENTS.md**: For practical conventions, commands, and constraints that agents need when working on this project. Update via git in the repo.
 - **Skills database**: Use \`create_skill\` (or \`propose_skill\` when approval is required) to capture reusable, cross-project team know-how — MCP server usage, integration steps, conventions, how agents coordinate. A manifest of available skills is injected each run; call \`get_skill(slug)\` to read one in full.
 

--- a/packages/server/test/git-identity.test.ts
+++ b/packages/server/test/git-identity.test.ts
@@ -1,0 +1,124 @@
+import type { PGlite } from '@electric-sql/pglite';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { MasterKeyManager } from '../src/crypto/master-key';
+import {
+	buildGitIdentityEnv,
+	deriveGitHubIdentity,
+	gitConfigEnv,
+} from '../src/services/git-identity';
+import { createConnection } from '../src/services/oauth/connection-store';
+import { generateTeamSSHKey } from '../src/services/ssh-keys';
+import { safeClose } from './helpers';
+import { createTestApp } from './helpers/app';
+
+let db: PGlite;
+let masterKeyManager: MasterKeyManager;
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	db = ctx.db;
+	masterKeyManager = ctx.masterKeyManager;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+/** Parse the GIT_CONFIG_* env entries back into a { 'user.name': '…' } map. */
+function parseGitConfig(env: string[]): Record<string, string> {
+	const get = (k: string) => env.find((e) => e.startsWith(`${k}=`))?.slice(k.length + 1);
+	const count = Number(get('GIT_CONFIG_COUNT'));
+	const out: Record<string, string> = {};
+	for (let i = 0; i < count; i++) {
+		out[get(`GIT_CONFIG_KEY_${i}`) as string] = get(`GIT_CONFIG_VALUE_${i}`) as string;
+	}
+	return out;
+}
+
+async function makeTeam(slug: string): Promise<string> {
+	const team = await db.query<{ id: string }>(
+		`INSERT INTO teams (name, slug) VALUES ($1, $2) RETURNING id`,
+		[slug, slug],
+	);
+	return team.rows[0].id;
+}
+
+describe('deriveGitHubIdentity', () => {
+	it('builds name + privacy-form noreply email from metadata', () => {
+		expect(deriveGitHubIdentity({ login: 'octocat', github_user_id: 12345 }, 'octocat')).toEqual({
+			name: 'octocat',
+			email: '12345+octocat@users.noreply.github.com',
+		});
+	});
+
+	it('falls back to the connection label when metadata has no login', () => {
+		expect(deriveGitHubIdentity({ github_user_id: 7 }, 'fallback-login')).toEqual({
+			name: 'fallback-login',
+			email: '7+fallback-login@users.noreply.github.com',
+		});
+	});
+
+	it('returns null when the github user id is missing', () => {
+		expect(deriveGitHubIdentity({ login: 'octocat' }, 'octocat')).toBeNull();
+	});
+});
+
+describe('gitConfigEnv', () => {
+	it('emits only name + email when there is no signing key', () => {
+		const env = gitConfigEnv({ name: 'A', email: 'a@b.c', signingKey: null });
+		expect(parseGitConfig(env)).toEqual({ 'user.name': 'A', 'user.email': 'a@b.c' });
+	});
+
+	it('emits signing config when a key is present', () => {
+		const env = gitConfigEnv({ name: 'A', email: 'a@b.c', signingKey: 'ssh-ed25519 AAAA hezo' });
+		expect(parseGitConfig(env)).toEqual({
+			'user.name': 'A',
+			'user.email': 'a@b.c',
+			'gpg.format': 'ssh',
+			'user.signingkey': 'ssh-ed25519 AAAA hezo',
+			'commit.gpgsign': 'true',
+		});
+	});
+});
+
+describe('buildGitIdentityEnv', () => {
+	it('derives identity from the GitHub connection and signs with the team key', async () => {
+		const teamId = await makeTeam('gh-team');
+		const key = await generateTeamSSHKey(db, teamId, masterKeyManager);
+		await createConnection(
+			{ db, masterKeyManager },
+			{
+				teamId,
+				provider: 'github',
+				providerAccountId: '12345',
+				providerAccountLabel: 'octocat',
+				accessToken: 'gho_x',
+				scopes: ['repo'],
+				allowedHosts: ['github.com'],
+				metadata: { login: 'octocat', github_user_id: 12345, email: null },
+			},
+		);
+
+		const cfg = parseGitConfig(await buildGitIdentityEnv(db, masterKeyManager, teamId));
+		expect(cfg['user.name']).toBe('octocat');
+		expect(cfg['user.email']).toBe('12345+octocat@users.noreply.github.com');
+		expect(cfg['gpg.format']).toBe('ssh');
+		expect(cfg['user.signingkey']).toBe(key.publicKey);
+		expect(cfg['commit.gpgsign']).toBe('true');
+	});
+
+	it('falls back to a generic identity with no signing when nothing is connected', async () => {
+		const teamId = await makeTeam('bare-team');
+		const cfg = parseGitConfig(await buildGitIdentityEnv(db, masterKeyManager, teamId));
+		expect(cfg).toEqual({ 'user.name': 'Hezo Agent', 'user.email': 'agent@hezo.local' });
+	});
+
+	it('signs with the team key even when no GitHub account is connected', async () => {
+		const teamId = await makeTeam('key-only-team');
+		const key = await generateTeamSSHKey(db, teamId, masterKeyManager);
+		const cfg = parseGitConfig(await buildGitIdentityEnv(db, masterKeyManager, teamId));
+		expect(cfg['user.name']).toBe('Hezo Agent');
+		expect(cfg['user.signingkey']).toBe(key.publicKey);
+		expect(cfg['commit.gpgsign']).toBe('true');
+	});
+});

--- a/packages/server/test/git.test.ts
+++ b/packages/server/test/git.test.ts
@@ -1,9 +1,14 @@
 import { execSync } from 'node:child_process';
-import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { createWorktree, pruneWorktrees, removeWorktree } from '../src/services/git';
+import {
+	createWorktree,
+	ensureTaskWorktree,
+	pruneWorktrees,
+	removeWorktree,
+} from '../src/services/git';
 
 const testDir = join(tmpdir(), `hezo-test-git-${Date.now()}`);
 const bareRepoDir = join(testDir, 'bare.git');
@@ -65,5 +70,59 @@ describe('git worktrees', () => {
 		const r2 = await createWorktree(cloneDir, wt2, 'feat/dup');
 		expect(r2.success).toBe(false);
 		expect(r2.error).toBeTruthy();
+	});
+});
+
+// A worktree is created on the host but used inside the container, where the same
+// repo lives at a different absolute path under separate bind mounts. The gitdir
+// links must therefore be relative — an absolute host path resolves nowhere in the
+// container. Mirror the on-disk layout so the relative link is exercised exactly as
+// it would be at runtime: workspace/<repo> and worktrees/<task>/<repo> as siblings.
+describe('worktree gitdir links are container-portable (relative)', () => {
+	const projectDir = join(testDir, 'proj');
+	const repoDir = join(projectDir, 'workspace', 'todos');
+	const worktreePath = join(projectDir, 'worktrees', 'TO-1', 'todos');
+
+	function adminDirName(): string {
+		return readFileSync(join(worktreePath, '.git'), 'utf-8').trim().split('/').pop() as string;
+	}
+
+	beforeAll(() => {
+		mkdirSync(join(projectDir, 'workspace'), { recursive: true });
+		run(`git clone ${bareRepoDir} ${repoDir}`);
+		run('git config user.name Test', repoDir);
+		run('git config user.email test@test.com', repoDir);
+		run('git config commit.gpgsign false', repoDir);
+	});
+
+	it('writes relative gitdir pointers on create', async () => {
+		const res = await ensureTaskWorktree(repoDir, worktreePath, 'hezo/TO-1');
+		expect(res.success).toBe(true);
+		expect(res.created).toBe(true);
+
+		const dotGit = readFileSync(join(worktreePath, '.git'), 'utf-8').trim();
+		expect(dotGit.startsWith('gitdir: ../')).toBe(true);
+		expect(dotGit).not.toMatch(/gitdir: \//);
+
+		const backPtr = readFileSync(
+			join(repoDir, '.git', 'worktrees', adminDirName(), 'gitdir'),
+			'utf-8',
+		).trim();
+		expect(backPtr.startsWith('../')).toBe(true);
+		expect(backPtr.startsWith('/')).toBe(false);
+	});
+
+	it('self-heals an absolute gitdir back to relative on reuse', async () => {
+		const absoluteTarget = join(repoDir, '.git', 'worktrees', adminDirName());
+		writeFileSync(join(worktreePath, '.git'), `gitdir: ${absoluteTarget}\n`);
+		expect(readFileSync(join(worktreePath, '.git'), 'utf-8')).toMatch(/gitdir: \//);
+
+		const res = await ensureTaskWorktree(repoDir, worktreePath, 'hezo/TO-1');
+		expect(res.success).toBe(true);
+		expect(res.created).toBe(false);
+
+		const dotGit = readFileSync(join(worktreePath, '.git'), 'utf-8').trim();
+		expect(dotGit.startsWith('gitdir: ../')).toBe(true);
+		expect(dotGit).not.toMatch(/gitdir: \//);
 	});
 });

--- a/packages/server/test/mcp-tools.test.ts
+++ b/packages/server/test/mcp-tools.test.ts
@@ -1221,3 +1221,55 @@ describe('MCP tool: result shape — no embeddings, opt-in excerpts, size guard'
 		}
 	});
 });
+
+describe('read_project_asset', () => {
+	it('round-trips a text asset written via write_project_asset', async () => {
+		const html = '<html><body><h1>Login mockup</h1></body></html>';
+		const write = (await callToolViaMcp('write_project_asset', {
+			team_id: teamId,
+			project_id: projectId,
+			filename: 'ui-mockups.html',
+			content: html,
+		})) as { written?: boolean };
+		expect(write.written).toBe(true);
+
+		const read = (await callToolViaMcp('read_project_asset', {
+			team_id: teamId,
+			project_id: projectId,
+			filename: 'ui-mockups.html',
+		})) as { filename?: string; content_type?: string; content?: string };
+		expect(read.filename).toBe('ui-mockups.html');
+		expect(read.content_type).toBe('text/html');
+		expect(read.content).toBe(html);
+	});
+
+	it('returns an error for an unknown asset', async () => {
+		const res = (await callToolViaMcp('read_project_asset', {
+			team_id: teamId,
+			project_id: projectId,
+			filename: 'does-not-exist.html',
+		})) as { error?: string };
+		expect(res.error).toMatch(/not found/i);
+	});
+
+	it('denies a caller from another team', async () => {
+		const { token: bToken } = await mintAgentToken(db, masterKeyManager, agentBId, teamBId);
+		const res = await app.request('/mcp', {
+			method: 'POST',
+			headers: { ...authHeader(bToken), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				jsonrpc: '2.0',
+				method: 'tools/call',
+				params: {
+					name: 'read_project_asset',
+					arguments: { team_id: teamId, project_id: projectId, filename: 'ui-mockups.html' },
+				},
+				id: 1,
+			}),
+		});
+		const body = (await res.json()) as { result: { content: Array<{ text: string }> } };
+		const parsed = JSON.parse(body.result.content[0].text) as { error?: string; content?: string };
+		expect(parsed.error).toBeTruthy();
+		expect(parsed.content).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary

Four independent bugs, all surfaced by a single Engineer run on `TO-11`, made the agent container's git workflow unusable and blocked its tooling. Each is fixed here. **No workflow/orchestration code changed** — the existing mention-based engineer→QA→merge flow is what we want; these fixes are simply what make it run.

| Bug | Symptom | Fix |
|---|---|---|
| **1 — worktree git** | every git command → `fatal: not a git repository` | host-created worktrees wrote **absolute** gitdir links that resolve nowhere in the container's bind mounts. Use `git worktree add --relative-paths`; self-heal pre-existing worktrees with `git worktree repair --relative-paths`. |
| **3 — git identity/signing** | `git commit` → "Author identity unknown"; agent invented a bogus identity | inject `GIT_CONFIG_*` env (no file): `user.name`/`user.email` from the team GitHub connection (noreply form) + SSH signing with the team key. Signs via the existing `SSH_AUTH_SOCK` bridge → commits land Verified. |
| **2 — asset reads** | `list_project_assets` shows mockups but there's no way to read them | new `read_project_asset` MCP tool (text inline / container path for binary, same authz) + a `SHARED_INSTRUCTIONS` line. |
| **4 — no sudo** | `npx playwright install-deps` → `su: Authentication failure` | passwordless sudo for the `node` user in the agent base image. |

## Why relative worktree paths work
The container preserves the host's *relative* nesting across the two bind mounts (`workspace/<repo>` and `worktrees/<task>/<repo>` are siblings), so `../../../workspace/<repo>/.git/worktrees/<name>` resolves identically on host and in-container. Host git is 2.50.1; the container only ever *reads* the relative link.

## Tests
- `git.test.ts`: relative gitdir on create + back-pointer; absolute→relative self-heal on reuse.
- `git-identity.test.ts`: identity derivation, signing config, and the no-connection / key-only fallbacks.
- `mcp-tools.test.ts`: `read_project_asset` round-trip, unknown asset, cross-team denial.
- Full server suite: **144 files / 1633 tests pass** + Bun-native tier. Typecheck + biome clean.

## Deploy notes (manual)
1. **Rebuild the agent image** (Bug 4): restart the server so `pruneStaleBundledImages` rebuilds `hezo/agent-base:latest`, then recreate project containers — running containers keep the old image.
2. **Clean up the corrupted `TO-11` worktree**: the agent's `rm .git && git init` left it beyond `worktree repair`; remove + prune so it's recreated cleanly.