### PR TITLE
feat: inject the full triggering comment into mention and reply handoffs

### DIFF
--- a/.dev/api.md
+++ b/.dev/api.md
@@ -2231,8 +2231,8 @@ explicitly `@`-mentioned themselves.
 
 **Handoff semantics.** A mention-triggered run opens on the triggering ticket
 for triage. The agent's task prompt includes a "Mention Handoff" section that
-names the mentioner, quotes an excerpt of the comment (≤ 500 chars, with code
-fences stripped), and lists the agent's own open tickets. The agent is expected
+names the mentioner, quotes the comment in full (untruncated, code blocks
+intact), and lists the agent's own open tickets. The agent is expected
 to route the work: update one of its own open tickets, or create a new one
 (sub-task of the triggering ticket, a sibling/peer, or top-level — the new
 ticket is first-class work owned by that agent; the system records the
@@ -2249,7 +2249,7 @@ wakeup for the original mentioner if both are agents and the team has
 carries `{ source: "reply", task_id, comment_id, triggering_comment_id,
 responder_member_id }`, idempotency key `reply:<triggering_comment_id>:<reply_comment_id>`.
 The mentioner's next run opens with a "Reply Received" prompt block that shows
-the responder's name, their reply excerpt, the original comment excerpt, and
+the responder's name, their full reply, the full original comment, and
 any tickets referenced in the reply. When one comment @-mentions several
 agents, each responder fires its own reply wakeup; nearby wakeups are coalesced
 by the standard 2-second window. Teams that prefer to batch replies can

--- a/.dev/spec.md
+++ b/.dev/spec.md
@@ -1237,7 +1237,7 @@ Every agent's resolved system prompt is auto-appended with a **Teammates** block
 
 Repo short names can also be @-mentioned: `@frontend`, `@api` — these reference the repo, not an agent.
 
-**Handoff contract.** When an agent is woken by a mention, its run opens on the triggering ticket for *triage only* — not as new assigned work. The agent's task prompt is prepended with a Mention Handoff block showing the mentioner, the comment excerpt, and the agent's own open tickets. The expected behaviour is:
+**Handoff contract.** When an agent is woken by a mention, its run opens on the triggering ticket for *triage only* — not as new assigned work. The agent's task prompt is prepended with a Mention Handoff block showing the mentioner, the full comment, and the agent's own open tickets. The expected behaviour is:
 
 - If one of the agent's open tickets already covers the topic of the mention, the agent updates that ticket's description, rules, or progress_summary to reflect what was communicated and references the triggering ticket so the handoff is traceable.
 - If no existing ticket covers it, the agent opens one via `create_task`. The new ticket is the mentioned agent's own first-class work and may be shaped as a sub-task of the triggering ticket, a sibling/peer, or a top-level ticket depending on context. The system records the triggering ticket as provenance automatically via `created_by_run_id`.

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -974,9 +974,6 @@ export interface MentionContext {
 	openTickets: MentionOpenTicket[];
 }
 
-const MENTION_EXCERPT_MAX = 500;
-const FENCED_CODE_STRIP_RE = /(?:^|\n)(?:```|~~~)[^\n]*\n[\s\S]*?(?:```|~~~)(?=\n|$)/g;
-
 export async function loadMentionContext(
 	db: PGlite,
 	agentMemberId: string,
@@ -1000,8 +997,9 @@ export async function loadMentionContext(
 	);
 	if (row.rows.length === 0) return null;
 
-	const commentText = extractCommentText(row.rows[0].content);
-	const excerpt = truncateExcerpt(commentText, MENTION_EXCERPT_MAX);
+	// The full comment body is injected verbatim into the handoff — no truncation,
+	// no code-fence stripping — so the agent sees exactly what was said.
+	const excerpt = extractCommentText(row.rows[0].content).trim();
 
 	const tickets = await db.query<MentionOpenTicket>(
 		`SELECT identifier, title, status::text AS status, priority::text AS priority
@@ -1092,12 +1090,6 @@ function extractCommentText(content: unknown): string {
 		.join('\n');
 }
 
-function truncateExcerpt(text: string, max: number): string {
-	const stripped = text.replace(FENCED_CODE_STRIP_RE, '[code omitted]').trim();
-	if (stripped.length <= max) return stripped;
-	return `${stripped.slice(0, max).trimEnd()}…`;
-}
-
 export interface BuildTaskPromptContext {
 	mentionContext?: MentionContext | null;
 	replyContext?: ReplyContext | null;
@@ -1173,7 +1165,7 @@ function renderMentionHandoff(task: TaskInfo, ctx: MentionContext): string[] {
 		: '> (empty)';
 	return [
 		'## Mention Handoff',
-		`You were mentioned by ${ctx.authorName} in ${task.identifier} — a comment excerpt:`,
+		`You were mentioned by ${ctx.authorName} in ${task.identifier} — their full comment:`,
 		'',
 		excerptBlock,
 		'',
@@ -1195,8 +1187,6 @@ export interface ReplyContext {
 	originalExcerpt: string;
 	referencedTasks: Array<{ identifier: string; title: string; status: string }>;
 }
-
-const REPLY_EXCERPT_MAX = 500;
 
 export async function loadReplyContext(
 	db: PGlite,
@@ -1253,8 +1243,8 @@ export async function loadReplyContext(
 	return {
 		responderName: reply.rows[0].author_name ?? 'Agent',
 		responderSlug: reply.rows[0].author_slug,
-		replyExcerpt: truncateExcerpt(replyText, REPLY_EXCERPT_MAX),
-		originalExcerpt: truncateExcerpt(originalText, REPLY_EXCERPT_MAX),
+		replyExcerpt: replyText.trim(),
+		originalExcerpt: originalText.trim(),
 		referencedTasks,
 	};
 }

--- a/packages/server/test/agent-autonomy.test.ts
+++ b/packages/server/test/agent-autonomy.test.ts
@@ -490,17 +490,13 @@ describe('agent-runner: mention handoff prompt', () => {
 });
 
 describe('agent-runner: mention context loader', () => {
-	it('truncateExcerpt behaviour via loadMentionContext return: strips fenced code', async () => {
-		// Unit-level excerpt shape test via buildTaskPrompt: long excerpt with code fence gets stripped.
+	it('renders the full mention comment, code blocks included', async () => {
 		const { buildTaskPrompt } = await import('../src/services/agent-runner');
 
-		const longCode = `Here is the plan\n\`\`\`\n${'x'.repeat(1200)}\n\`\`\`\nend`;
+		const fullComment = `Here is the plan\n\`\`\`\n${'x'.repeat(1200)}\n\`\`\`\nend`;
 		const ctx = {
 			authorName: 'Captain',
-			excerpt: longCode.replace(
-				/(?:^|\n)(?:```|~~~)[^\n]*\n[\s\S]*?(?:```|~~~)(?=\n|$)/g,
-				'[code omitted]',
-			),
+			excerpt: fullComment,
 			openTickets: [],
 		};
 
@@ -521,8 +517,10 @@ describe('agent-runner: mention context loader', () => {
 			{ mentionContext: ctx },
 		);
 
-		expect(prompt).toContain('[code omitted]');
-		expect(prompt).not.toContain('x'.repeat(600));
+		// The code block is rendered verbatim (no stripping, no truncation).
+		expect(prompt).toContain('x'.repeat(1200));
+		expect(prompt).not.toContain('[code omitted]');
+		expect(prompt).toContain('their full comment:');
 	});
 });
 

--- a/packages/server/test/mention-handoff-prompt.test.ts
+++ b/packages/server/test/mention-handoff-prompt.test.ts
@@ -278,7 +278,7 @@ describe('mention handoff prompt (integration)', () => {
 		expect(prompt).toContain('check-before-create');
 	});
 
-	it('truncates long comment excerpts and strips fenced code', async () => {
+	it('injects the full comment verbatim — no truncation, no code stripping', async () => {
 		const longBody = `Here is a proposal:\n\`\`\`\n${'payload'.repeat(100)}\n\`\`\`\nand ${'x'.repeat(700)} tail`;
 		const { triggeringTaskId, commentId } = await createTriggeringTaskWithComment(longBody);
 
@@ -288,11 +288,14 @@ describe('mention handoff prompt (integration)', () => {
 			comment_id: commentId,
 		});
 		expect(ctx).not.toBeNull();
-		const excerpt = ctx?.excerpt ?? '';
-		expect(excerpt.length).toBeLessThanOrEqual(501);
-		expect(excerpt).toContain('[code omitted]');
-		expect(excerpt).not.toContain('payload'.repeat(10));
-		expect(excerpt.endsWith('…')).toBe(true);
+		const comment = ctx?.excerpt ?? '';
+		// The whole comment is present: the fenced code block survives and the long
+		// tail is not cut off at 500 chars.
+		expect(comment).toContain('payload'.repeat(100));
+		expect(comment).toContain('x'.repeat(700));
+		expect(comment).toContain('```');
+		expect(comment).not.toContain('[code omitted]');
+		expect(comment.endsWith('…')).toBe(false);
 	});
 });
 


### PR DESCRIPTION
## What & why

When an agent is woken by an **@-mention** (or a **reply** to its comment), the handoff block previously injected only a **500-character excerpt** of the triggering comment, with fenced code blocks stripped to `[code omitted]`. That meant the agent often acted on a partial view of what was actually said.

This makes the handoff carry the **full comment, verbatim** — no truncation, no code stripping — consistent with the "inject the full context" direction from #119 (full description / progress summary / rules).

## Changes

- **`loadMentionContext`**: injects the entire comment body (trimmed) instead of `truncateExcerpt(…, 500)`.
- **`loadReplyContext`**: injects the full reply **and** the full original comment.
- Removed the now-dead `truncateExcerpt` helper, `FENCED_CODE_STRIP_RE`, and the two `*_EXCERPT_MAX = 500` caps.
- Mention handoff wording: *"a comment excerpt:"* → *"their full comment:"* so the agent knows it's the whole thing.
- Rewrote the truncation/stripping tests to assert full-comment injection (code blocks preserved, no 500-char cap); updated the `.dev/api.md` and `.dev/spec.md` handoff docs.

## Testing

- `bunx vitest run test/mention-handoff-prompt.test.ts test/agent-autonomy.test.ts` → **28 passed**.
- `bun run typecheck` + `bun run check` clean.

## Note

Comments can be long, so a mention/reply now adds the full body to the prompt. That's the intent here; there's no per-team cap. If we later want a safety ceiling for pathologically large comments, that'd be a follow-up.

https://claude.ai/code/session_011hw1NB2htdg71m2RBduYJZ

---
_Generated by [Claude Code](https://claude.ai/code/session_011hw1NB2htdg71m2RBduYJZ)_