### PR TITLE
Hide wake-assignee toggle when replying to agent comments

### DIFF
--- a/packages/web/src/components/task-detail/comment-composer.tsx
+++ b/packages/web/src/components/task-detail/comment-composer.tsx
@@ -1,6 +1,6 @@
 import type { AgentEffort } from '@hezo/shared';
 import { CornerDownRight, Loader2, Trash2 } from 'lucide-react';
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import type { Comment, useCreateComment } from '../../hooks/use-comments';
 import type { Task } from '../../hooks/use-tasks';
 import { CommentAttachmentsDrop } from '../comment-attachments-drop';
@@ -41,7 +41,8 @@ function previewCommentText(c: Comment): string {
 
 /**
  * The bottom-of-page comment-entry form: a MentionTextarea wrapped in a
- * drag-drop attachments target, a "wake assignee on submit" toggle, the
+ * drag-drop attachments target, a "wake assignee on submit" toggle (hidden when
+ * replying to an agent's comment, since the reply already wakes that agent), the
  * project-intake skip affordance, and the submit button. The "Effort" select
  * lives in the sidebar but writes into the same commentEffort state — owned
  * by the route component and passed in. `replyTarget` is similarly owned
@@ -66,13 +67,17 @@ export function CommentComposer({
 	const [wakeAssignee, setWakeAssignee] = useState(true);
 	const [pendingAttachmentIds, setPendingAttachmentIds] = useState<string[]>([]);
 
+	// Replying to an agent's comment already wakes that agent (WakeupSource.Reply),
+	// so the "wake assignee" toggle is redundant there — hide it and omit the flag.
+	const replyingToAgent = replyTarget?.author_type === 'agent';
+
 	async function handleComment(e: React.FormEvent) {
 		e.preventDefault();
 		if (!commentText.trim() && pendingAttachmentIds.length === 0) return;
 		await createComment.mutateAsync({
 			content: commentText,
 			...(commentEffort ? { effort: commentEffort } : {}),
-			...(task.assignee_id ? { wake_assignee: wakeAssignee } : {}),
+			...(task.assignee_id && !replyingToAgent ? { wake_assignee: wakeAssignee } : {}),
 			...(replyTarget ? { parent_comment_id: replyTarget.id } : {}),
 			...(pendingAttachmentIds.length > 0 ? { attachment_ids: pendingAttachmentIds } : {}),
 		});
@@ -136,7 +141,7 @@ export function CommentComposer({
 				)}
 				<div className="flex items-center justify-end gap-2">
 					<ProjectIntakeBanner task={task} teamId={teamId} taskId={taskId} comments={comments} />
-					{task.assignee_id && (
+					{task.assignee_id && !replyingToAgent && (
 						<label className="flex items-center gap-2 text-[13px] text-text-muted cursor-pointer select-none">
 							<input
 								type="checkbox"

--- a/packages/web/test/helpers/seed.ts
+++ b/packages/web/test/helpers/seed.ts
@@ -147,8 +147,20 @@ export async function seedComment(
 	workspace: SeededWorkspace,
 	task: SeededTask,
 	body: string,
+	opts?: { authorMemberId?: string },
 ): Promise<{ id: string }> {
-	const { apiBase } = getTestContext();
+	const { apiBase, db } = getTestContext();
+	// The API attributes authorship to the board token, so it can only produce
+	// author_type: 'user'. To seed an agent-authored comment, insert directly.
+	if (opts?.authorMemberId) {
+		const inserted = await db.query<{ id: string }>(
+			`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
+			 VALUES ($1, $2, 'text', $3::jsonb)
+			 RETURNING id`,
+			[task.id, opts.authorMemberId, JSON.stringify({ text: body })],
+		);
+		return { id: inserted.rows[0].id };
+	}
 	const res = await apiBase(`/api/teams/${workspace.team.id}/tasks/${task.id}/comments`, {
 		method: 'POST',
 		headers: workspace.headers,

--- a/packages/web/test/task-comments.test.tsx
+++ b/packages/web/test/task-comments.test.tsx
@@ -296,6 +296,137 @@ test('wake-assignee checkbox is default-checked and reflected in submit body', a
 	expect(posts[1].wake_assignee).toBe(false);
 });
 
+test('replying to an agent hides the wake-assignee toggle and omits the flag', async () => {
+	const seeded = { teamSlug: '', taskId: '' };
+	const { findByPlaceholderText, findByTestId, findByText, getByRole, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Agent Reply Project' });
+			const task = await seedTask(ws, project, { title: 'Agent Reply Task' });
+			// Author the parent as the assignee agent so author_type is 'agent'.
+			await seedComment(ws, task, 'Agent original comment', { authorMemberId: ws.agents[0].id });
+			seeded.teamSlug = ws.team.slug;
+			seeded.taskId = task.id;
+		},
+	});
+	await router.navigate({
+		to: '/teams/$teamId/tasks/$taskId',
+		params: { teamId: seeded.teamSlug, taskId: seeded.taskId },
+	});
+
+	await findByText('Agent original comment');
+
+	const userMod = await import('@testing-library/user-event');
+	const user = userMod.default.setup({ delay: null });
+
+	const replyButtons = document.querySelectorAll('[data-testid="comment-reply"]');
+	expect(replyButtons.length).toBeGreaterThan(0);
+	await user.click(replyButtons[0] as HTMLElement);
+
+	const indicator = await findByTestId('reply-indicator');
+	expect(indicator.textContent).toContain('Agent original comment');
+
+	const composer = (await findByPlaceholderText('Add a comment...')) as HTMLTextAreaElement;
+	const form = composer.closest('form');
+	expect(form).not.toBeNull();
+	// The toggle is gone when the parent is an agent.
+	const wakeCheckbox = form?.querySelector(
+		'input[type="checkbox"][aria-label="Wake assignee on submit"]',
+	);
+	expect(wakeCheckbox).toBeNull();
+
+	const original = globalThis.fetch;
+	const posts: Array<Record<string, unknown>> = [];
+	globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+		const url = typeof input === 'string' ? input : input.toString();
+		if (init?.method === 'POST' && /\/tasks\/[^/]+\/comments$/.test(url)) {
+			const body = init.body;
+			if (typeof body === 'string') {
+				try {
+					posts.push(JSON.parse(body) as Record<string, unknown>);
+				} catch {}
+			}
+		}
+		return original(input, init);
+	};
+	try {
+		await user.type(composer, 'My reply to the agent');
+		await user.click(getByRole('button', { name: 'Comment' }));
+		await findByText('My reply to the agent');
+	} finally {
+		globalThis.fetch = original;
+	}
+
+	expect(posts.length).toBe(1);
+	expect('wake_assignee' in posts[0]).toBe(false);
+	// Sanity: it really was sent as a reply to the agent's comment.
+	expect(posts[0].parent_comment_id).toBeTruthy();
+});
+
+test('replying to a human keeps the wake-assignee toggle and sends the flag', async () => {
+	const seeded = { teamSlug: '', taskId: '' };
+	const { findByPlaceholderText, findByTestId, findByText, getByRole, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Human Reply Project' });
+			const task = await seedTask(ws, project, { title: 'Human Reply Task' });
+			// seedComment posts via the board token => author_type 'user'.
+			await seedComment(ws, task, 'Human original comment');
+			seeded.teamSlug = ws.team.slug;
+			seeded.taskId = task.id;
+		},
+	});
+	await router.navigate({
+		to: '/teams/$teamId/tasks/$taskId',
+		params: { teamId: seeded.teamSlug, taskId: seeded.taskId },
+	});
+
+	await findByText('Human original comment');
+
+	const userMod = await import('@testing-library/user-event');
+	const user = userMod.default.setup({ delay: null });
+
+	const replyButtons = document.querySelectorAll('[data-testid="comment-reply"]');
+	expect(replyButtons.length).toBeGreaterThan(0);
+	await user.click(replyButtons[0] as HTMLElement);
+
+	const indicator = await findByTestId('reply-indicator');
+	expect(indicator.textContent).toContain('Human original comment');
+
+	const composer = (await findByPlaceholderText('Add a comment...')) as HTMLTextAreaElement;
+	// The toggle stays for a human-authored parent — nothing else wakes the assignee.
+	const checkbox = await findByRoleClosest(composer, 'checkbox', 'Wake assignee on submit');
+	expect(checkbox.checked).toBe(true);
+
+	const original = globalThis.fetch;
+	const posts: Array<Record<string, unknown>> = [];
+	globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+		const url = typeof input === 'string' ? input : input.toString();
+		if (init?.method === 'POST' && /\/tasks\/[^/]+\/comments$/.test(url)) {
+			const body = init.body;
+			if (typeof body === 'string') {
+				try {
+					posts.push(JSON.parse(body) as Record<string, unknown>);
+				} catch {}
+			}
+		}
+		return original(input, init);
+	};
+	try {
+		await user.type(composer, 'My reply to the human');
+		await user.click(getByRole('button', { name: 'Comment' }));
+		await findByText('My reply to the human');
+	} finally {
+		globalThis.fetch = original;
+	}
+
+	expect(posts.length).toBe(1);
+	expect(posts[0].wake_assignee).toBe(true);
+	expect(posts[0].parent_comment_id).toBeTruthy();
+});
+
 test('reply icon focuses composer, shows in-response-to, and persists parent link', async () => {
 	const seeded = { teamSlug: '', taskId: '', parentId: '' };
 	const { findByPlaceholderText, findByTestId, queryByTestId, findByText, getByRole, router } =


### PR DESCRIPTION
## Summary
When replying to an agent's comment, the "wake assignee" toggle is now hidden and the `wake_assignee` flag is omitted from the request body. This is because replying to an agent already wakes that agent through the reply mechanism, making the toggle redundant.

## Changes
- **comment-composer.tsx**: Added logic to detect when replying to an agent (`replyTarget?.author_type === 'agent'`) and conditionally hide the wake-assignee toggle and omit the flag from the submit payload
- **seed.ts**: Enhanced `seedComment()` to support seeding agent-authored comments by accepting an optional `authorMemberId` parameter that inserts comments directly into the database with the specified author
- **task-comments.test.tsx**: Added two comprehensive test cases:
  - "replying to an agent hides the wake-assignee toggle and omits the flag" — verifies the toggle is absent and `wake_assignee` is not sent
  - "replying to a human keeps the wake-assignee toggle and sends the flag" — verifies the toggle remains and `wake_assignee` is sent when replying to user comments

## Implementation Details
The solution checks the `author_type` of the parent comment to determine behavior. When `author_type === 'agent'`, the toggle is hidden via conditional rendering and the flag is excluded from the mutation payload using optional chaining. This ensures agent replies don't redundantly attempt to wake the assignee while preserving the existing behavior for human-authored comments.

https://claude.ai/code/session_013KLkhfpSgJygLaYsjT1Vhr