### PR TITLE
Add formatted/raw log switcher to task-page run comments

### DIFF
--- a/packages/web/src/components/comment-renderers/run-comment.tsx
+++ b/packages/web/src/components/comment-renderers/run-comment.tsx
@@ -78,17 +78,21 @@ function RunCommentBody({
 	const [expanded, setExpanded] = useState(false);
 	const logRegionId = `run-comment-log-${runId}`;
 
+	// Single non-wrapping row: the agent title and status block keep their width,
+	// the timestamp truncates first under pressure, and the status block clips
+	// last — so the header (and its expand chevron) stay on one horizontal line at
+	// any width, including once the log opens and a scrollbar narrows the row.
 	const summaryRow = (
-		<>
-			<span className="text-xs text-text-muted">{agentTitle} run</span>
+		<span className="flex flex-1 items-center gap-x-2 min-w-0 overflow-hidden">
+			<span className="text-xs text-text-muted shrink-0 whitespace-nowrap">{agentTitle} run</span>
 			{completed && (
 				<span
-					className="inline-flex items-baseline gap-1.5 text-xs text-text-subtle"
+					className="inline-flex items-center gap-1.5 text-xs text-text-subtle shrink-0 whitespace-nowrap"
 					data-testid="run-comment-summary"
 				>
 					<span
 						aria-hidden="true"
-						className={`inline-block w-2 h-2 rounded-full self-center ${runStatusDotClass(status)}`}
+						className={`inline-block w-2 h-2 rounded-full ${runStatusDotClass(status)}`}
 					/>
 					<span>{runStatusLabel(status)}</span>
 					<span aria-hidden="true">·</span>
@@ -103,8 +107,10 @@ function RunCommentBody({
 					)}
 				</span>
 			)}
-			<span className="text-[11px] text-text-subtle">{new Date(createdAt).toLocaleString()}</span>
-		</>
+			<span className="text-[11px] text-text-subtle truncate min-w-0">
+				{new Date(createdAt).toLocaleString()}
+			</span>
+		</span>
 	);
 
 	return (
@@ -117,12 +123,12 @@ function RunCommentBody({
 						aria-expanded={expanded}
 						aria-controls={logRegionId}
 						data-testid="run-comment-header"
-						className="flex flex-wrap items-baseline gap-x-2 gap-y-1 text-left -mx-1 px-1 rounded-radius-md hover:bg-bg-muted cursor-pointer"
+						className="flex items-center gap-2 min-w-0 text-left -mx-1 px-1 rounded-radius-md hover:bg-bg-muted cursor-pointer"
 					>
 						{summaryRow}
 						<svg
 							aria-hidden="true"
-							className={`w-3 h-3 self-center shrink-0 ml-auto text-text-subtle transition-transform ${expanded ? 'rotate-90' : ''}`}
+							className={`w-3 h-3 shrink-0 text-text-subtle transition-transform ${expanded ? 'rotate-90' : ''}`}
 							viewBox="0 0 16 16"
 							fill="currentColor"
 						>
@@ -130,10 +136,7 @@ function RunCommentBody({
 						</svg>
 					</button>
 				) : (
-					<div
-						className="flex flex-wrap items-baseline gap-x-2 gap-y-1"
-						data-testid="run-comment-header"
-					>
+					<div className="flex items-center min-w-0" data-testid="run-comment-header">
 						{summaryRow}
 					</div>
 				))}

--- a/packages/web/src/components/comment-renderers/run-comment.tsx
+++ b/packages/web/src/components/comment-renderers/run-comment.tsx
@@ -145,6 +145,9 @@ function RunCommentBody({
 					<LogViewer
 						lines={lines}
 						compact
+						formattable
+						teamId={teamId}
+						projectSlug={run?.project_slug ?? undefined}
 						heightClassName="h-[180px]"
 						testId="run-comment-log"
 						liveLabel={

--- a/packages/web/src/components/log-viewer.tsx
+++ b/packages/web/src/components/log-viewer.tsx
@@ -116,7 +116,7 @@ export function LogViewer({
 	const isFormatted = formattable && viewMode === 'formatted';
 	const sizing = isExpanded ? 'flex-1 min-h-0' : heightClassName;
 	const bodyClassName = isFormatted
-		? `bg-bg text-text ${sizing} overflow-y-auto p-3 text-sm leading-relaxed`
+		? `bg-[#0d1117] log-surface-dark text-text ${sizing} overflow-y-auto p-3 text-sm leading-relaxed`
 		: `bg-[#0d1117] ${sizing} overflow-y-auto p-3 font-mono text-xs leading-relaxed`;
 
 	const content = (

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -45,7 +45,11 @@
 	--radius-lg: 12px;
 }
 
-html.dark {
+/* `.log-surface-dark` opts a subtree into the dark palette regardless of the
+   active theme — used by the log viewer's formatted view so it keeps the same
+   terminal-dark surface as the raw view even in light mode. */
+html.dark,
+.log-surface-dark {
 	--color-bg: #1a1a1a;
 	--color-bg-subtle: #2c2c2a;
 	--color-bg-muted: #3d3d3a;

--- a/packages/web/test/run-comment-formatted-log.test.tsx
+++ b/packages/web/test/run-comment-formatted-log.test.tsx
@@ -1,0 +1,112 @@
+import { expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+import { seedProject, seedTask, seedWorkspace } from './helpers/seed';
+
+const LOG_TEXT = [
+	'[session] model=claude-opus-4 tools=42',
+	'[thinking] Considering the next step.',
+	'Proceeding with the change.',
+	'[tool] Bash(command=ls -la, description=list files)',
+	'[tool-result] total 0',
+	'[done] success turns=2 duration=900ms tokens=10/20 cost=$0.0001',
+].join('\n');
+
+test('task-page run comment exposes the formatted/raw log switcher and defaults to formatted', async () => {
+	const seeded = { teamSlug: '', taskId: '' };
+
+	const { findByTestId, findByText, getByLabelText, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const captain = ws.agents.find((a) => a.slug === 'captain') ?? ws.agents[0];
+			const project = await seedProject(ws, { name: 'Formatted Log Project' });
+			const task = await seedTask(ws, project, {
+				title: 'Formatted Log Task',
+				assignee_id: captain.id,
+			});
+
+			seeded.teamSlug = ws.team.slug;
+			seeded.taskId = task.id;
+
+			const runId = '99999999-9999-9999-9999-00000000abcd';
+			const runComment = {
+				id: 'aaaa0000-0000-0000-0000-0000000000fa',
+				task_id: task.id,
+				content_type: 'run',
+				content: { run_id: runId, agent_id: captain.id, agent_title: 'Captain' },
+				chosen_option: null,
+				created_at: new Date().toISOString(),
+				author_type: 'agent',
+				author_name: 'Captain',
+				author_member_id: captain.id,
+			};
+			const runResponse = {
+				id: runId,
+				member_id: captain.id,
+				team_id: ws.team.id,
+				task_id: task.id,
+				project_id: project.id,
+				project_slug: project.slug,
+				status: 'succeeded',
+				started_at: new Date().toISOString(),
+				finished_at: new Date().toISOString(),
+				exit_code: 0,
+				error: null,
+				input_tokens: 10,
+				output_tokens: 20,
+				cost_cents: 0,
+				invocation_command: null,
+				log_text: LOG_TEXT,
+				working_dir: null,
+				created_tasks: [],
+			};
+
+			const originalFetch = globalThis.fetch;
+			globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+				const url = typeof input === 'string' ? input : (input as Request).url;
+				const method = init?.method ?? (input instanceof Request ? input.method : 'GET');
+				if (method === 'GET' && /\/api\/teams\/[^/]+\/tasks\/[^/]+\/comments/.test(url)) {
+					return new Response(JSON.stringify({ data: [runComment] }), {
+						status: 200,
+						headers: { 'Content-Type': 'application/json' },
+					});
+				}
+				if (
+					method === 'GET' &&
+					new RegExp(`/api/teams/[^/]+/agents/[^/]+/heartbeat-runs/${runId}$`).test(url)
+				) {
+					return new Response(JSON.stringify({ data: runResponse }), {
+						status: 200,
+						headers: { 'Content-Type': 'application/json' },
+					});
+				}
+				return originalFetch(input as RequestInfo, init);
+			}) as typeof globalThis.fetch;
+		},
+	});
+
+	await router.navigate({
+		to: '/teams/$teamId/tasks/$taskId',
+		params: { teamId: seeded.teamSlug, taskId: seeded.taskId },
+	});
+
+	// Wait for the run to load as completed (the summary only renders then) so the
+	// header is the collapsed expand button, then click it to reveal the log viewer.
+	await findByTestId('run-comment-summary', undefined, { timeout: 10_000 });
+	await user.click(await findByTestId('run-comment-header'));
+
+	// Formatted is the default view: the tool renders without its raw `[tool]`
+	// prefix and the markdown body renders as prose.
+	await findByText('Bash', undefined, { timeout: 10_000 });
+	expect((await findByTestId('run-comment-log')).textContent).not.toContain('[tool]');
+
+	// The switcher is present; Raw shows the literal prefixed line, Formatted hides it.
+	await user.click(getByLabelText('Raw logs'));
+	expect((await findByTestId('run-comment-log')).textContent).toContain(
+		'[tool] Bash(command=ls -la, description=list files)',
+	);
+
+	await user.click(getByLabelText('Formatted view'));
+	await findByText('Bash');
+	expect((await findByTestId('run-comment-log')).textContent).not.toContain('[tool]');
+});

--- a/test/browser/agent-run-logs.spec.ts
+++ b/test/browser/agent-run-logs.spec.ts
@@ -1,4 +1,4 @@
-import { expect, type Page, test } from '@playwright/test';
+import { expect, type Locator, type Page, test } from '@playwright/test';
 import {
 	authenticate,
 	createProjectAndClearPlanning,
@@ -345,4 +345,52 @@ test('completed run expansion works on mobile viewport', async ({ page }) => {
 	const log = runCommentEl.getByTestId('run-comment-log');
 	await expect(log).toBeVisible();
 	await expect(log).toContainText('[synthetic] line 1');
+});
+
+// #1 (real CSS layout): asserts the summary row and its expand chevron share a
+// single horizontal line via boundingBox y-centres — happy-dom can't lay out
+// the flex row, so this can only be verified in a real browser. Mobile width is
+// the forcing function: the full header (title · status · lines · duration ·
+// timestamp · chevron) is wider than a 375px row, so a wrapping container would
+// drop the chevron to a second line.
+test('completed run header stays on one line when the log expands (mobile)', async ({ page }) => {
+	await page.setViewportSize({ width: 375, height: 800 });
+	await authenticate(page);
+	const { team, token } = await createTeamWithAgents(page);
+	const headers = { Authorization: `Bearer ${token}` };
+
+	const agentsRes = await page.request.get(`/api/teams/${team.id}/agents`, { headers });
+	const agents = ((await agentsRes.json()) as { data: Array<{ id: string; slug: string }> }).data;
+	const captain = agents.find((a) => a.slug === 'captain') ?? agents[0];
+
+	const { task } = await mockCompletedRun(page, team.id, captain.id, token);
+
+	await page.goto(`/teams/${team.slug}/tasks/${task.id}`);
+
+	const runCommentEl = page.getByTestId('run-comment').first();
+	await expect(runCommentEl).toBeVisible({ timeout: 20_000 });
+
+	const header = runCommentEl.getByTestId('run-comment-header');
+	const summary = header.getByTestId('run-comment-summary');
+	await expect(summary).toBeVisible({ timeout: 20_000 });
+	// The chevron is the only <svg> in the header (the status dot is a <span>).
+	const chevron = header.locator('svg');
+
+	const centerY = async (loc: Locator): Promise<number> => {
+		const box = await loc.boundingBox();
+		if (!box) throw new Error('element has no bounding box');
+		return box.y + box.height / 2;
+	};
+
+	// Line height is ~16px (text-xs); a wrapped chevron would sit a full line
+	// below the summary, so an 8px tolerance cleanly separates one line from two.
+	const collapsedDelta = Math.abs((await centerY(chevron)) - (await centerY(summary)));
+	expect(collapsedDelta).toBeLessThan(8);
+
+	// Opening the inline log grows the comment and can introduce a scrollbar that
+	// narrows the row — the header must not reflow onto a second line.
+	await header.click();
+	await expect(runCommentEl.getByTestId('run-comment-log')).toBeVisible();
+	const expandedDelta = Math.abs((await centerY(chevron)) - (await centerY(summary)));
+	expect(expandedDelta).toBeLessThan(8);
 });

--- a/test/browser/agent-run-logs.spec.ts
+++ b/test/browser/agent-run-logs.spec.ts
@@ -394,3 +394,52 @@ test('completed run header stays on one line when the log expands (mobile)', asy
 	const expandedDelta = Math.abs((await centerY(chevron)) - (await centerY(summary)));
 	expect(expandedDelta).toBeLessThan(8);
 });
+
+// #1 (real CSS layout): asserts the formatted log body keeps the dark terminal
+// surface (#0d1117) even with the app forced into light mode — a computed-style
+// check happy-dom can't make. Runs on mobile to satisfy the mobile-layout rule.
+test('task-page run log offers the formatted/raw switcher on a dark surface in light mode (mobile)', async ({
+	page,
+}) => {
+	await page.emulateMedia({ colorScheme: 'light' });
+	await page.addInitScript(() => localStorage.setItem('theme', 'light'));
+	await page.setViewportSize({ width: 375, height: 800 });
+	await authenticate(page);
+	const { team, token } = await createTeamWithAgents(page);
+	const headers = { Authorization: `Bearer ${token}` };
+
+	const agentsRes = await page.request.get(`/api/teams/${team.id}/agents`, { headers });
+	const agents = ((await agentsRes.json()) as { data: Array<{ id: string; slug: string }> }).data;
+	const captain = agents.find((a) => a.slug === 'captain') ?? agents[0];
+
+	const { task } = await mockCompletedRun(page, team.id, captain.id, token);
+
+	await page.goto(`/teams/${team.slug}/tasks/${task.id}`);
+
+	const runCommentEl = page.getByTestId('run-comment').first();
+	await expect(runCommentEl).toBeVisible({ timeout: 20_000 });
+	await runCommentEl.getByTestId('run-comment-header').click();
+
+	const log = runCommentEl.getByTestId('run-comment-log');
+	await expect(log).toBeVisible();
+
+	// The formatted/raw switcher is available on task-page run logs, defaulting to
+	// formatted.
+	const formattedBtn = runCommentEl.getByRole('button', { name: 'Formatted view' });
+	const rawBtn = runCommentEl.getByRole('button', { name: 'Raw logs' });
+	await expect(formattedBtn).toBeVisible();
+	await expect(rawBtn).toBeVisible();
+	await expect(formattedBtn).toHaveAttribute('aria-pressed', 'true');
+
+	// In light mode the formatted body still uses the dark terminal surface.
+	const formattedBg = await log.evaluate((el) => getComputedStyle(el).backgroundColor);
+	expect(formattedBg).toBe('rgb(13, 17, 23)');
+
+	// Raw stays on the same dark surface.
+	await rawBtn.click();
+	await expect(rawBtn).toHaveAttribute('aria-pressed', 'true');
+	const rawBg = await runCommentEl
+		.getByTestId('run-comment-log')
+		.evaluate((el) => getComputedStyle(el).backgroundColor);
+	expect(rawBg).toBe('rgb(13, 17, 23)');
+});


### PR DESCRIPTION
## Summary
Adds a formatted/raw log view switcher to run comments displayed on the task page, allowing users to toggle between a human-readable formatted view and the raw log with prefixed markers. The formatted view maintains a dark terminal surface even when the app is in light mode.

## Key Changes
- **Run comment UI improvements**: Refactored the run comment header to use a single non-wrapping flex row that stays on one line even when the log expands and introduces a scrollbar. The timestamp now truncates under pressure rather than wrapping.
- **Log viewer formatting**: Enhanced `LogViewer` component with a `formattable` prop that enables the formatted/raw switcher. The formatted view now uses a dark terminal background (`#0d1117`) via a new `.log-surface-dark` CSS class that applies dark theme colors regardless of the active theme.
- **CSS theming**: Added `.log-surface-dark` class to `index.css` that applies the dark color palette to any subtree, ensuring the log viewer's formatted view maintains visual consistency with the raw view in light mode.
- **Test coverage**: Added comprehensive unit test (`run-comment-formatted-log.test.tsx`) verifying the switcher defaults to formatted view, renders correctly, and toggles between modes. Added two Playwright integration tests validating mobile layout stability and dark surface rendering in light mode.

## Implementation Details
- The run comment header uses `flex items-center gap-2 min-w-0` with child elements having `shrink-0 whitespace-nowrap` to prevent wrapping while allowing the timestamp to truncate via `truncate min-w-0`.
- The formatted log body is wrapped with the `.log-surface-dark` class to inherit dark theme variables, creating a consistent terminal-like appearance across all theme modes.
- The switcher is passed `teamId` and `projectSlug` props to the `LogViewer` for potential future use in formatting logic.

https://claude.ai/code/session_01YbvrUuiEKYzjAtBNqrF4rN