### PR TITLE
fix(agent-runtime): extract reply excerpt from bare-string comment bodies

### DIFF
--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -1087,11 +1087,14 @@ export async function loadAgentAttachmentsForComments(
 }
 
 function extractCommentText(content: unknown): string {
-	if (!content || typeof content !== 'object') return '';
+	if (content == null) return '';
+	if (typeof content === 'string') return content;
+	if (typeof content !== 'object') return String(content);
 	const obj = content as Record<string, unknown>;
 	if (typeof obj.text === 'string') return obj.text;
 	return Object.values(obj)
-		.filter((v): v is string => typeof v === 'string')
+		.map(extractCommentText)
+		.filter((v) => v.length > 0)
 		.join('\n');
 }
 
@@ -1390,9 +1393,7 @@ export async function buildCoachReviewPrompt(
 	const commentLog = comments.rows
 		.map((c) => {
 			const text =
-				c.content_type === 'text'
-					? (c.content as Record<string, unknown>).text
-					: JSON.stringify(c.content);
+				c.content_type === 'text' ? extractCommentText(c.content) : JSON.stringify(c.content);
 			const base = `[${c.created_at}] ${c.author_name} (${c.content_type}): ${text}`;
 			const reactionLine = formatReactionLine(reactionsByComment.get(c.id));
 			const attachmentLines = (attachmentsByComment.get(c.id) ?? []).map(

--- a/packages/server/test/mention-handoff-prompt.test.ts
+++ b/packages/server/test/mention-handoff-prompt.test.ts
@@ -397,6 +397,28 @@ describe('reply handoff prompt (integration)', () => {
 		});
 		expect(ctx).toBeNull();
 	});
+
+	it('extracts the reply excerpt when the body is a bare string (web-composer shape)', async () => {
+		const { triggeringTaskId, commentId: triggeringCommentId } =
+			await createTriggeringTaskWithComment('Please review and approve the PRD.');
+
+		const replyInsert = await db.query<{ id: string }>(
+			`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
+			 VALUES ($1, NULL, $2::comment_content_type, $3::jsonb)
+			 RETURNING id`,
+			[triggeringTaskId, CommentContentType.Text, JSON.stringify('APPROVED')],
+		);
+
+		const ctx = await loadReplyContext(db, {
+			source: WakeupSource.Reply,
+			task_id: triggeringTaskId,
+			comment_id: replyInsert.rows[0].id,
+			triggering_comment_id: triggeringCommentId,
+		});
+
+		expect(ctx?.replyExcerpt).toBe('APPROVED');
+		expect(ctx?.originalExcerpt).toContain('approve the PRD');
+	});
 });
 
 describe('spawned-from prompt line', () => {


### PR DESCRIPTION
## Problem

In the dev server, the board replied **"APPROVED"** to the Product Lead's PRD-approval request, but when the agent woke up its injected reply context said the reply was **"(empty)"** — so it couldn't act on the approval.

## Root cause

Comment bodies live in `task_comments.content` (JSONB) in two shapes:

- **bare string** — what the web composer posts (`content: "APPROVED"`), stored verbatim
- **`{ text: "..." }` object** — what the seed and some API paths post

`extractCommentText` (in `agent-runner.ts`) only handled the object form — `typeof content !== 'object'` returned `''`. So a bare-string reply collapsed to an empty excerpt, and `renderReplyHandoff` printed the `> (empty)` fallback.

Mention *detection* still fired (a separate flatten-all helper in `mentions.ts` handles strings), which is why the agent woke up at all but with no reply text. A second symptom from the same cause: the full-thread comment log read `.text` directly, rendering string-shaped bodies as literal `undefined`.

## Fix

- `extractCommentText` now handles a top-level string and recurses object values, keeping the `text`-field preference for clean excerpts.
- The comment-log formatter routes `text`-type bodies through the same extractor.

`mentions.ts`'s `flattenTextFields` is left separate on purpose — it intentionally flattens *all* fields to catch `@mentions` in nested structures (option lists, etc.), whereas the excerpt path wants only the readable `text`.

## Test

Added a regression case in `mention-handoff-prompt.test.ts` that inserts a board reply as a bare JSON string (the real web-composer shape) and asserts `replyExcerpt === 'APPROVED'`. Fails without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)