### PR TITLE
Render thinking-stream enumerations as markdown lists

### DIFF
--- a/packages/web/src/components/formatted-log-view.tsx
+++ b/packages/web/src/components/formatted-log-view.tsx
@@ -1,5 +1,7 @@
 import { Boxes, ChevronDown, ChevronRight, Cpu, Sparkles, Terminal, Wrench } from 'lucide-react';
 import { type ComponentType, useMemo, useState } from 'react';
+import Markdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import {
 	type CommandBlock,
 	type DoneBlock,
@@ -11,6 +13,7 @@ import {
 	type ThinkingBlock,
 	type ToolBlock,
 } from '../lib/parse-agent-log';
+import { reflowEnumerations } from '../lib/reflow-thinking-lists';
 import { MarkdownProse } from './markdown-prose';
 import { Badge } from './ui/badge';
 
@@ -98,14 +101,24 @@ function TextView({
 	);
 }
 
+// Markers (`1.`/`2.`/`•`) the server flattened onto a single line are reflowed into
+// markdown so they render as lists; the de-emphasized thinking look (small, italic,
+// subtle) is preserved with explicit list styling rather than the full `prose` plugin,
+// which would impose its own font size and colours.
+const THINKING_PROSE =
+	'text-xs italic leading-relaxed [&_ol]:list-decimal [&_ul]:list-disc [&_ol]:pl-5 [&_ul]:pl-5 [&_li]:my-0.5 [&_p]:my-1 [&_p:first-child]:mt-0 [&_p:last-child]:mb-0 [&_li]:marker:text-text-subtle';
+
 function ThinkingView({ block }: { block: ThinkingBlock }) {
+	const reflowed = useMemo(() => reflowEnumerations(block.text), [block.text]);
 	return (
 		<div className="border-l-2 border-border-subtle pl-3 text-text-subtle">
 			<div className="mb-0.5 flex items-center gap-1 text-[10px] uppercase tracking-wider">
 				<Sparkles className="w-3 h-3 shrink-0" />
 				Thinking
 			</div>
-			<p className="whitespace-pre-wrap text-xs italic leading-relaxed">{block.text}</p>
+			<div className={THINKING_PROSE}>
+				<Markdown remarkPlugins={[remarkGfm]}>{reflowed}</Markdown>
+			</div>
 		</div>
 	);
 }

--- a/packages/web/src/lib/reflow-thinking-lists.ts
+++ b/packages/web/src/lib/reflow-thinking-lists.ts
@@ -1,0 +1,123 @@
+/**
+ * Reconstructs list structure in agent "thinking" streams.
+ *
+ * The server flattens thinking text before persisting it: `formatThinking` in
+ * `packages/server/src/services/agent-stream-parser.ts` collapses all whitespace
+ * (including the newlines the model emitted) into single spaces, so an enumeration
+ * the model wrote as a list arrives at the client as one run-on line. This re-inserts
+ * newlines before genuine enumeration markers so remark-gfm renders them as
+ * `<ol>`/`<ul>` in the formatted log view.
+ *
+ * High precision by design — when in doubt, leave the text alone:
+ *   - Numbered: only a run that is sequential from 1 with >= 2 items is converted.
+ *     The marker must be an integer at a non-word boundary followed by `.`/`)` and a
+ *     space, so decimals (`3.14`), versions (`v1.2`), hyphenated identifiers (`TO-2`,
+ *     `PROJ-123`), `etc.`, and filenames (`research.md`) are never matched.
+ *   - Bullets: only unicode glyphs (`•`, `‣`) are recognised. Raw `-`/`*`/`+` are left
+ *     untouched because they collide with ranges (`5-10`), emphasis (`*x*`), and `C++`.
+ *
+ * When nothing qualifies the input is returned unchanged, so plain prose never regresses.
+ * Idempotent: re-running, or running on already-newline-delimited markdown, is a no-op
+ * (each insertion is skipped when the marker already sits at the start of a line).
+ *
+ * Inline code spans are not parsed (rare in collapsed thinking); the non-word-boundary
+ * guard already neutralises most code-ish numerics.
+ */
+
+/** Integer marker at a non-word boundary, e.g. `1.` / `2)`, followed by whitespace. */
+const NUMBERED_MARKER = /(?:^|[^\w.)-])(\d{1,3})[.)](?=\s)/g;
+/** Unicode list bullets, preceded by start/whitespace and followed by whitespace. */
+const BULLET_MARKER = /(?:^|\s)[•‣](?=\s)/g;
+
+interface NumberedMarker {
+	/** Index of the first digit (where the newline is spliced in). */
+	numStart: number;
+	value: number;
+}
+
+export function reflowEnumerations(text: string): string {
+	return applyBullets(applyNumbered(text));
+}
+
+function applyNumbered(text: string): string {
+	const markers: NumberedMarker[] = [];
+	for (const m of text.matchAll(NUMBERED_MARKER)) {
+		if (m.index === undefined) continue;
+		// m[0] = optional leading separator + digits + one `.`/`)` delimiter.
+		const numStart = m.index + (m[0].length - m[1].length - 1);
+		markers.push({ numStart, value: Number(m[1]) });
+	}
+	const run = firstSequentialRun(markers);
+	if (!run) return text;
+	return splice(
+		text,
+		run.map((mk) => mk.numStart),
+		(chunk) => chunk,
+	);
+}
+
+function applyBullets(text: string): string {
+	const positions: number[] = [];
+	for (const m of text.matchAll(BULLET_MARKER)) {
+		if (m.index === undefined) continue;
+		// The glyph is the last char of the match (after an optional separator).
+		positions.push(m.index + m[0].length - 1);
+	}
+	if (positions.length < 2) return text;
+	// Drop the 1-char glyph and emit a GFM `-` bullet in its place (the space the glyph
+	// was followed by becomes the marker's separator). Because the glyph is rewritten, a
+	// second pass finds nothing — that is what makes this idempotent.
+	return splice(text, positions, (chunk) => chunk, { stripChars: 1, marker: '-' });
+}
+
+/**
+ * Splice a newline before each marker position so the markers become line-leading
+ * (and therefore valid GFM list items). The first marker gets a blank line `\n\n`
+ * (terminating the preceding paragraph); subsequent markers get a single `\n` (a tight
+ * list). Insertion is skipped when the marker already starts a line, so re-runs no-op.
+ */
+function splice(
+	text: string,
+	positions: number[],
+	transform: (chunk: string) => string,
+	opts?: { stripChars?: number; marker?: string },
+): string {
+	const stripChars = opts?.stripChars ?? 0;
+	const marker = opts?.marker ?? '';
+	let out = '';
+	let cursor = 0;
+	positions.forEach((pos, i) => {
+		const chunk = text.slice(cursor, pos);
+		if (/(?:^|\n)[ \t]*$/.test(chunk)) {
+			// Already at the start of a line — leave it untouched (idempotency).
+			out += transform(chunk) + marker;
+		} else {
+			const trimmed = chunk.replace(/[ \t]+$/, '');
+			out += transform(trimmed) + (i === 0 ? '\n\n' : '\n') + marker;
+		}
+		cursor = pos + stripChars;
+	});
+	out += text.slice(cursor);
+	return out;
+}
+
+/** First run of markers whose values are exactly 1, 2, 3, … (length >= 2), else null. */
+function firstSequentialRun(markers: NumberedMarker[]): NumberedMarker[] | null {
+	let run: NumberedMarker[] = [];
+	let expected = 1;
+	for (const mk of markers) {
+		if (mk.value === expected) {
+			run.push(mk);
+			expected++;
+		} else if (mk.value === 1) {
+			if (run.length >= 2) return run;
+			run = [mk];
+			expected = 2;
+		} else {
+			if (run.length >= 2) return run;
+			run = [];
+			expected = 1;
+		}
+	}
+	return run.length >= 2 ? run : null;
+}

--- a/packages/web/test/formatted-log-view.test.tsx
+++ b/packages/web/test/formatted-log-view.test.tsx
@@ -5,6 +5,7 @@ import { seedWorkspace } from './helpers/seed';
 const LOG_TEXT = [
 	'[session] model=deepseek-v4-pro tools=115',
 	'[thinking] Planning the approach now.',
+	'[thinking] My plan: 1. Investigate storage 2. Survey implementations 3. Write the report',
 	'Here is the plan to follow:',
 	'- first item',
 	'- second item',
@@ -44,6 +45,11 @@ test('run log defaults to the formatted view and toggles to raw via the icon but
 	const toolLabel = await findByText('Bash', undefined, { timeout: 15_000 });
 	const listItem = await findByText('first item');
 	expect(listItem.closest('li')).not.toBeNull();
+
+	// A collapsed thinking enumeration (`1. … 2. … 3. …` on one line) is reflowed into a
+	// real list inside the thinking block, not shown as a run-on paragraph.
+	const thinkingItem = await findByText('Investigate storage');
+	expect(thinkingItem.closest('li')).not.toBeNull();
 
 	const body = await findByTestId('run-log');
 	expect(body.textContent).not.toContain('[tool]');

--- a/packages/web/test/reflow-thinking-lists.test.ts
+++ b/packages/web/test/reflow-thinking-lists.test.ts
@@ -1,0 +1,104 @@
+import { reflowEnumerations } from '@hezo/web/lib/reflow-thinking-lists';
+import { expect, test } from 'vitest';
+
+// The real-world run-on thinking line the feature targets.
+const EXAMPLE =
+	'The user wants me to work on TO-2, which is a research task about client-side todo app ' +
+	'approaches. I need to: 1. Investigate client-side storage options (localStorage, IndexedDB, ' +
+	'etc.) 2. Survey existing open-source client-side todo implementations 3. Investigate ' +
+	'offline-capable patterns (Service Workers, PWA) 4. Research UX patterns for anonymous-first, ' +
+	'no-auth web apps 5. Produce a research.md report with findings and recommendations Let me ' +
+	'start by doing web research and then compile finding…';
+
+test('reflows the run-on example into a sequential markdown list', () => {
+	const out = reflowEnumerations(EXAMPLE);
+	// A blank line terminates the lead-in paragraph, then each item is line-leading.
+	expect(out).toContain('I need to:\n\n1. Investigate client-side storage options');
+	expect(out).toContain('\n2. Survey existing open-source');
+	expect(out).toContain('\n3. Investigate offline-capable patterns');
+	expect(out).toContain('\n4. Research UX patterns');
+	expect(out).toContain('\n5. Produce a research.md report');
+	// Trailing prose stays glued to the last item (no end-of-list delimiter exists).
+	expect(out).toContain('recommendations Let me start by doing web research');
+	// Exactly the 6 inserted newlines: `\n\n` before item 1 + one `\n` before items 2-5.
+	expect((out.match(/\n/g) ?? []).length).toBe(6);
+});
+
+test('leaves hyphenated identifiers, filenames, decimals, and the lead-in text intact', () => {
+	const out = reflowEnumerations(EXAMPLE);
+	expect(out).toContain('TO-2');
+	expect(out).toContain('research.md report');
+	expect(out.startsWith('The user wants me to work on TO-2, which is a research task')).toBe(true);
+});
+
+test('reflows a simple numbered run', () => {
+	expect(reflowEnumerations('Steps: 1. a 2. b 3. c')).toBe('Steps:\n\n1. a\n2. b\n3. c');
+});
+
+test('reflows markers using the `)` delimiter', () => {
+	expect(reflowEnumerations('Order: 1) first 2) second')).toBe('Order:\n\n1) first\n2) second');
+});
+
+test('reflows repeated unicode bullets into a `-` list', () => {
+	expect(reflowEnumerations('Options: • foo • bar')).toBe('Options:\n\n- foo\n- bar');
+	expect(reflowEnumerations('Try ‣ one ‣ two ‣ three')).toBe('Try\n\n- one\n- two\n- three');
+});
+
+test('does not touch decimals', () => {
+	const t = 'Pi is 3.14 and e is 2.71 in this note.';
+	expect(reflowEnumerations(t)).toBe(t);
+});
+
+test('does not touch version numbers', () => {
+	const t = 'Upgrade to v1.2 then maybe v1.3 later.';
+	expect(reflowEnumerations(t)).toBe(t);
+});
+
+test('does not touch money amounts', () => {
+	const t = 'It costs $1.50 today and $2.50 tomorrow.';
+	expect(reflowEnumerations(t)).toBe(t);
+});
+
+test('does not touch hyphenated identifiers', () => {
+	const t = 'Work on TO-2 and then PROJ-123 next.';
+	expect(reflowEnumerations(t)).toBe(t);
+});
+
+test('does not treat `etc.` or filenames as markers', () => {
+	const t = 'See research.md and notes.txt etc. for the details.';
+	expect(reflowEnumerations(t)).toBe(t);
+});
+
+test('does not reflow a run that does not start at 1', () => {
+	const t = 'Pick 2. apples then 3. pears from the bin.';
+	expect(reflowEnumerations(t)).toBe(t);
+});
+
+test('does not reflow a lone marker', () => {
+	const t = 'Step 1. do the only thing and stop.';
+	expect(reflowEnumerations(t)).toBe(t);
+});
+
+test('does not reflow a single bullet', () => {
+	const t = 'A note • with one inline glyph only.';
+	expect(reflowEnumerations(t)).toBe(t);
+});
+
+test('is a no-op on plain prose', () => {
+	const t = 'Just a normal sentence with no enumeration whatsoever.';
+	expect(reflowEnumerations(t)).toBe(t);
+});
+
+test('is idempotent', () => {
+	const once = reflowEnumerations(EXAMPLE);
+	expect(reflowEnumerations(once)).toBe(once);
+	// Already-newline-delimited markdown is left unchanged.
+	const md = 'Steps:\n\n1. a\n2. b\n3. c';
+	expect(reflowEnumerations(md)).toBe(md);
+});
+
+test('keeps `etc.` mid-item without splitting the item', () => {
+	expect(reflowEnumerations('Need: 1. localStorage (etc.) 2. IndexedDB')).toBe(
+		'Need:\n\n1. localStorage (etc.)\n2. IndexedDB',
+	);
+});


### PR DESCRIPTION
## What

In the formatted agent-run log view, **thinking** streams rendered as a single run-on paragraph, even when the model laid out a numbered or bulleted list. For example, this thinking line:

> The user wants me to work on TO-2... I need to: 1. Investigate client-side storage options (localStorage, IndexedDB, etc.) 2. Survey existing implementations 3. Investigate offline-capable patterns ...

now renders as a real ordered list inside the Thinking block.

## Why

`formatThinking()` in `packages/server/src/services/agent-stream-parser.ts` collapses **all** whitespace — including the newlines the model emitted — into single spaces before persisting, so any list structure is flattened onto one line. `ThinkingView` then printed that line as plain text. (Text blocks are only `.trim()`ed, so they keep their newlines and already render markdown lists — the run-on problem was thinking-specific.)

The fix is a presentation-layer change only; the server format, persisted log, and client parser are untouched.

## How

- **New pure util** `packages/web/src/lib/reflow-thinking-lists.ts` — `reflowEnumerations(text)` reconstructs list structure from the flattened line by inserting newlines before genuine enumeration markers, which `remark-gfm` then renders as `<ol>`/`<ul>`. High precision by design:
  - **Numbered:** only a run that is **sequential from 1 with ≥2 items** is converted.
  - **Bullets:** only unicode glyphs (`•`, `‣`); raw `-`/`*`/`+` are left alone (they collide with ranges like `5-10`, emphasis, `C++`).
  - Rejects decimals (`3.14`), versions (`v1.2`), money (`$1.50`), hyphenated identifiers (`TO-2`, `PROJ-123`), `etc.`, and filenames (`research.md`).
  - **Idempotent**, and a **no-op on plain prose** — when nothing qualifies the text is returned unchanged, so there's no regression.
- **`ThinkingView`** (`formatted-log-view.tsx`) now reflows the text and renders it through `react-markdown` + `remark-gfm` **without** a `teamId`, so there are zero network calls and mentions stay plain text as before. The de-emphasized thinking aesthetic (small, italic, subtle) is preserved with explicit list-styling classes rather than the full `prose` plugin.

## Testing

- 16 unit tests for the heuristic: the real-world example, numbered / `)` / unicode-bullet conversion, every false-positive case, idempotency, and the plain-prose no-op.
- Extended `formatted-log-view.test.tsx` to assert a collapsed thinking enumeration renders as `<li>`.
- Full web vitest tier green (52 files, 213 tests); `tsc --noEmit` clean; biome clean.

https://claude.ai/code/session_01MySwbZnFgRqcoPgTZ36hw9

---
_Generated by [Claude Code](https://claude.ai/code/session_01MySwbZnFgRqcoPgTZ36hw9)_