### PR TITLE
Fix vertical alignment of run comment inline icon

### DIFF
--- a/packages/web/src/components/comment-renderers/run-comment.tsx
+++ b/packages/web/src/components/comment-renderers/run-comment.tsx
@@ -123,7 +123,7 @@ function RunCommentBody({
 						aria-expanded={expanded}
 						aria-controls={logRegionId}
 						data-testid="run-comment-header"
-						className="flex items-center gap-2 min-w-0 text-left -mx-1 px-1 rounded-radius-md hover:bg-bg-muted cursor-pointer"
+						className="flex items-center gap-2 min-h-[26px] min-w-0 text-left -mx-1 px-1 rounded-radius-md hover:bg-bg-muted cursor-pointer"
 					>
 						{summaryRow}
 						<svg
@@ -136,7 +136,7 @@ function RunCommentBody({
 						</svg>
 					</button>
 				) : (
-					<div className="flex items-center min-w-0" data-testid="run-comment-header">
+					<div className="flex items-center min-h-[26px] min-w-0" data-testid="run-comment-header">
 						{summaryRow}
 					</div>
 				))}

--- a/packages/web/src/components/task-detail/comments-section.tsx
+++ b/packages/web/src/components/task-detail/comments-section.tsx
@@ -185,7 +185,10 @@ export function CommentsSection({
 									data-testid="comment-item"
 									data-comment-highlighted={isHighlighted ? 'true' : undefined}
 								>
-									<div className="w-[26px] h-[26px] flex items-center justify-center shrink-0 text-text-subtle">
+									<div
+										data-testid="inline-event-icon"
+										className="w-[26px] h-[26px] flex items-center justify-center shrink-0 text-text-subtle"
+									>
 										<Icon className="w-3.5 h-3.5" />
 									</div>
 									<div className="flex-1 min-w-0">

--- a/test/browser/agent-run-logs.spec.ts
+++ b/test/browser/agent-run-logs.spec.ts
@@ -395,6 +395,47 @@ test('completed run header stays on one line when the log expands (mobile)', asy
 	expect(expandedDelta).toBeLessThan(8);
 });
 
+// #1 (real CSS layout): the leading inline-event icon must share a vertical
+// centre-line with the run summary's "<agent> run" label. The icon sits in a
+// 26px slot while the label is a 16px text-xs line, so their centres only line
+// up if the header row is also 26px tall — a layout fact happy-dom can't compute
+// (boundingBox returns 0). Guards the regression where the icon sat ~5px low.
+test('completed run inline icon is vertically centred on the summary label', async ({ page }) => {
+	await authenticate(page);
+	const { team, token } = await createTeamWithAgents(page);
+	const headers = { Authorization: `Bearer ${token}` };
+
+	const agentsRes = await page.request.get(`/api/teams/${team.id}/agents`, { headers });
+	const agents = ((await agentsRes.json()) as { data: Array<{ id: string; slug: string }> }).data;
+	const captain = agents.find((a) => a.slug === 'captain') ?? agents[0];
+
+	const { task } = await mockCompletedRun(page, team.id, captain.id, token);
+
+	await page.goto(`/teams/${team.slug}/tasks/${task.id}`);
+
+	const runCommentEl = page.getByTestId('run-comment').first();
+	await expect(runCommentEl).toBeVisible({ timeout: 20_000 });
+	await expect(runCommentEl.getByTestId('run-comment-summary')).toBeVisible({ timeout: 20_000 });
+
+	const commentItem = page
+		.getByTestId('comment-item')
+		.filter({ has: page.getByTestId('run-comment') })
+		.first();
+	const icon = commentItem.getByTestId('inline-event-icon');
+	const label = runCommentEl.getByText('Product Lead run', { exact: true });
+
+	const centerY = async (loc: Locator): Promise<number> => {
+		const box = await loc.boundingBox();
+		if (!box) throw new Error('element has no bounding box');
+		return box.y + box.height / 2;
+	};
+
+	// Buggy layout left the icon centre ~5px below the label centre; aligned
+	// centres sit within a sub-pixel. 2px cleanly separates the two states.
+	const delta = Math.abs((await centerY(icon)) - (await centerY(label)));
+	expect(delta).toBeLessThan(2);
+});
+
 // #1 (real CSS layout): asserts the formatted log body keeps the dark terminal
 // surface (#0d1117) even with the app forced into light mode — a computed-style
 // check happy-dom can't make. Runs on mobile to satisfy the mobile-layout rule.


### PR DESCRIPTION
## Summary
Fixes a layout regression where the inline event icon in run comments was positioned approximately 5px lower than the run summary label, breaking vertical center alignment.

## Changes
- Added `min-h-[26px]` to the run comment header container (both button and div variants) to ensure the header row matches the 26px height of the icon slot, allowing their vertical centers to align properly
- Added `data-testid="inline-event-icon"` to the icon container div for test targeting
- Added a new test case that verifies the icon and label centers are aligned within 2px tolerance, catching this regression

## Implementation Details
The issue occurred because the header row height was not explicitly constrained. The icon sits in a 26px slot while the label is a 16px text-xs line. Without an explicit minimum height on the header, the centers only align when the row is 26px tall. The fix ensures the header respects this constraint via `min-h-[26px]`, which is a CSS layout requirement that happy-dom cannot compute (boundingBox returns 0), hence the need for a real browser test.

https://claude.ai/code/session_01LbALaWqJbBnHwDAiFdJar9