### PR TITLE
fix(mcp): resolve human-readable task identifiers in tool args

### DIFF
--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -199,6 +199,30 @@ function tool(
 				],
 			};
 		}
+		// Agents reference tickets by their project-scoped identifier (e.g. "TO-8")
+		// as readily as by UUID. Normalize the canonical task argument to a UUID
+		// once here so every task-scoped tool handler can query tasks.id directly.
+		// resolveTaskId returns a UUID input unchanged (no DB round-trip), so this
+		// is a no-op for callers that already pass UUIDs.
+		if (
+			typeof args.task_id === 'string' &&
+			args.task_id.length > 0 &&
+			typeof args.team_id === 'string' &&
+			args.team_id.length > 0
+		) {
+			const resolved = await resolveTaskId(db, args.team_id, args.task_id);
+			if (!resolved) {
+				return {
+					content: [
+						{
+							type: 'text' as const,
+							text: JSON.stringify({ error: `Task not found: ${args.task_id}` }),
+						},
+					],
+				};
+			}
+			args.task_id = resolved;
+		}
 		const result = await handler(args, db, auth);
 		const text = JSON.stringify(result, null, 2);
 		const sizeBytes = Buffer.byteLength(text, 'utf8');
@@ -878,8 +902,7 @@ export function registerTools(
 			const denied = await verifyTeamAccess(db, auth, args.team_id as string);
 			if (denied) return { error: denied };
 			const teamId = args.team_id as string;
-			const taskId = await resolveTaskId(db, teamId, args.task_id as string);
-			if (!taskId) return { error: 'Task not found' };
+			const taskId = args.task_id as string;
 			const taskScope = await assertProjectAccessForTask(db, auth, taskId);
 			if (taskScope) return { error: taskScope };
 			const blockerId = await resolveTaskId(db, teamId, args.blocked_by_task_id as string);
@@ -917,8 +940,7 @@ export function registerTools(
 			const denied = await verifyTeamAccess(db, auth, args.team_id as string);
 			if (denied) return { error: denied };
 			const teamId = args.team_id as string;
-			const taskId = await resolveTaskId(db, teamId, args.task_id as string);
-			if (!taskId) return { error: 'Task not found' };
+			const taskId = args.task_id as string;
 			const taskScope = await assertProjectAccessForTask(db, auth, taskId);
 			if (taskScope) return { error: taskScope };
 			const blockerId = await resolveTaskId(db, teamId, args.blocked_by_task_id as string);

--- a/packages/server/test/mcp-tools.test.ts
+++ b/packages/server/test/mcp-tools.test.ts
@@ -1033,6 +1033,45 @@ describe('MCP tool: result shape — no embeddings, opt-in excerpts, size guard'
 		expect(task).toHaveProperty('description');
 	});
 
+	it('get_task resolves a human-readable task identifier to its UUID', async () => {
+		const created = (await callToolViaMcp('create_task', {
+			team_id: teamId,
+			project_id: projectId,
+			title: 'Identifier resolution target',
+			assignee_id: agentId,
+		})) as { id: string; identifier: string };
+
+		const byIdentifier = (await callToolViaMcp('get_task', {
+			team_id: teamId,
+			task_id: created.identifier,
+		})) as Record<string, unknown>;
+		expect(byIdentifier.id).toBe(created.id);
+		expect(byIdentifier.identifier).toBe(created.identifier);
+	});
+
+	it('get_task returns a clean error for an unknown identifier instead of crashing', async () => {
+		const result = (await callToolViaMcp('get_task', {
+			team_id: teamId,
+			task_id: 'ZZ-999',
+		})) as { error?: string };
+		expect(result.error).toContain('ZZ-999');
+	});
+
+	it('list_comments accepts a task identifier (centralized resolution)', async () => {
+		const created = (await callToolViaMcp('create_task', {
+			team_id: teamId,
+			project_id: projectId,
+			title: 'Identifier resolution for comments',
+			assignee_id: agentId,
+		})) as { id: string; identifier: string };
+
+		const comments = await callToolViaMcp('list_comments', {
+			team_id: teamId,
+			task_id: created.identifier,
+		});
+		expect(Array.isArray(comments)).toBe(true);
+	});
+
 	it('get_task returns blockers and dependents symmetrically', async () => {
 		const upstream = (await callToolViaMcp('create_task', {
 			team_id: teamId,


### PR DESCRIPTION
## Problem

On the dev server, the UI Designer agent called the `get_task` MCP tool with `task_id=TO-8` — a project-scoped human-readable identifier — and the run crashed with:

```
invalid input syntax for type uuid: "TO-8"
```

Agents reference tickets by their identifier (`TO-8`, `OP-42`) as readily as by UUID — the agent prompts and several tool descriptions tell them to. But the MCP tool handlers passed `task_id` straight into queries against the `UUID` `tasks.id` column. The REST API resolves identifiers via `resolveTaskId` before querying; the MCP tools mostly did not.

## Fix

Normalize the canonical `task_id` argument to a UUID **once** in the shared `tool()` registration wrapper, using the existing `resolveTaskId` helper (`packages/server/src/lib/resolve.ts`). This fixes every task-scoped tool in one place — `get_task`, `update_task`, `list_comments`, `create_comment`, `add_reaction`, `remove_reaction`, `request_credential` — and any future one.

- UUID inputs short-circuit with **no DB round-trip** (regex check), so zero cost on the common path.
- Identifier inputs resolve via the indexed `(team_id, identifier)` lookup.
- An unresolvable identifier returns a clean `{ error: "Task not found: ..." }` instead of a uuid-syntax crash.
- `team_id` is reliably a UUID by the time any handler runs (`verifyTeamAccess` enforces strict UUID equality), so it's a safe scoping key.

Also drops the now-redundant per-handler `resolveTaskId` calls in `add_task_blocker` / `remove_task_blocker` (their `blocked_by_task_id` resolution stays — different arg key).

## Tests

Added to `mcp-tools.test.ts`:
- `get_task` resolves a human-readable identifier to its UUID (the exact repro).
- An unknown identifier yields a clean error, not a crash.
- `list_comments` accepts an identifier too — proving the fix is genuinely centralized, not `get_task`-specific.

70/70 in `mcp-tools.test.ts` pass; related MCP/scope/hierarchy suites and full typecheck/build are green.