### PR TITLE
feat: add board approvals banner to the task list

### DIFF
--- a/packages/web/src/components/board-approvals-banner.tsx
+++ b/packages/web/src/components/board-approvals-banner.tsx
@@ -1,0 +1,48 @@
+import { Link } from '@tanstack/react-router';
+import { ChevronRight, Inbox } from 'lucide-react';
+import { useApprovals } from '../hooks/use-approvals';
+import { useBoardMentions } from '../hooks/use-board-mentions';
+
+function pluralize(count: number, noun: string): string {
+	return `${count} ${noun}${count === 1 ? '' : 's'}`;
+}
+
+function buildMessage(approvalCount: number, mentionCount: number): string {
+	const parts: string[] = [];
+	if (approvalCount > 0) parts.push(pluralize(approvalCount, 'approval'));
+	if (mentionCount > 0) parts.push(pluralize(mentionCount, 'mention'));
+	return `${parts.join(' and ')} ${parts.length > 1 ? 'need' : approvalCount + mentionCount === 1 ? 'needs' : 'need'} your review`;
+}
+
+/**
+ * Persistent banner surfacing the board's outstanding inbox backlog (pending approvals + unread
+ * mentions) at the top of the task list. Clicking navigates to the Inbox where items are resolved.
+ * Renders nothing when the backlog is empty — which also hides it for non-board users, whose
+ * approval/mention queries 403 and leave the counts at zero.
+ */
+export function BoardApprovalsBanner({ teamId }: { teamId: string }) {
+	const { data: approvals } = useApprovals(teamId);
+	const { data: mentions } = useBoardMentions(teamId);
+
+	const approvalCount = approvals?.length ?? 0;
+	const mentionCount = mentions?.filter((m) => m.read_at === null).length ?? 0;
+	const total = approvalCount + mentionCount;
+
+	if (total === 0) return null;
+
+	return (
+		<Link
+			to="/teams/$teamId/inbox"
+			params={{ teamId }}
+			data-testid="board-approvals-banner"
+			className="mb-4 flex items-center gap-2 rounded-md bg-primary/10 px-4 py-2 text-[13px] font-medium text-primary hover:bg-primary/15 transition-colors"
+		>
+			<Inbox className="w-3.5 h-3.5 shrink-0" />
+			<span className="min-w-0 truncate">{buildMessage(approvalCount, mentionCount)}</span>
+			<span className="ml-auto flex items-center gap-1 shrink-0">
+				<span className="hidden sm:inline">View inbox</span>
+				<ChevronRight className="w-3.5 h-3.5" />
+			</span>
+		</Link>
+	);
+}

--- a/packages/web/src/components/task-list.tsx
+++ b/packages/web/src/components/task-list.tsx
@@ -4,6 +4,7 @@ import { ChevronDown, ListPlus, Plus, Search } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useAgents } from '../hooks/use-agents';
 import { type TaskFilters, useTasks } from '../hooks/use-tasks';
+import { BoardApprovalsBanner } from './board-approvals-banner';
 import { CreateTaskDialog } from './create-task-dialog';
 import { TaskStatusBadge } from './task-status-badge';
 import { Badge } from './ui/badge';
@@ -253,6 +254,7 @@ export function TaskList({ teamId, projectId }: TaskListProps) {
 
 	return (
 		<div>
+			<BoardApprovalsBanner teamId={teamId} />
 			<div className="mb-4 flex flex-col sm:flex-row items-stretch sm:items-start gap-2">
 				<div
 					data-testid="task-filter-bar"

--- a/packages/web/test/board-approvals-banner.test.tsx
+++ b/packages/web/test/board-approvals-banner.test.tsx
@@ -1,0 +1,72 @@
+import { waitFor } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { getTestContext, renderApp } from './helpers/render';
+import { type SeededWorkspace, seedProject, seedTask, seedWorkspace } from './helpers/seed';
+
+async function createApproval(
+	workspace: SeededWorkspace,
+	body: { type: string; payload: Record<string, unknown> },
+) {
+	const { apiBase } = getTestContext();
+	const res = await apiBase(`/api/teams/${workspace.team.id}/approvals`, {
+		method: 'POST',
+		headers: workspace.headers,
+		body: JSON.stringify(body),
+	});
+	if (!res.ok) throw new Error(`createApproval failed: ${res.status} ${await res.text()}`);
+	return ((await res.json()) as { data: { id: string } }).data;
+}
+
+test('banner surfaces pending approvals on the task list and links to the inbox', async () => {
+	const seeded = { teamSlug: '' };
+	const { findByTestId, router, user } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Demo' });
+			await seedTask(ws, project, { title: 'Demo Task' });
+			await createApproval(ws, { type: 'strategy', payload: { plan: 'Launch' } });
+			await createApproval(ws, { type: 'secret_access', payload: { secret_name: 'DB_PASSWORD' } });
+			seeded.teamSlug = ws.team.slug;
+		},
+	});
+
+	await router.navigate({
+		to: '/teams/$teamId/tasks',
+		params: { teamId: seeded.teamSlug },
+	});
+
+	const banner = await findByTestId('board-approvals-banner', undefined, { timeout: 10_000 });
+	expect(banner.textContent).toContain('2 approvals need your review');
+	expect(banner.getAttribute('href')).toContain(`/teams/${seeded.teamSlug}/inbox`);
+
+	await user.click(banner);
+
+	await waitFor(() => {
+		expect(router.state.location.pathname).toBe(`/teams/${seeded.teamSlug}/inbox`);
+	});
+});
+
+test('banner is hidden when there are no pending approvals or unread mentions', async () => {
+	const seeded = { teamSlug: '' };
+	const { findByTestId, queryByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Demo' });
+			await seedTask(ws, project, { title: 'Demo Task' });
+			seeded.teamSlug = ws.team.slug;
+		},
+	});
+
+	await router.navigate({
+		to: '/teams/$teamId/tasks',
+		params: { teamId: seeded.teamSlug },
+	});
+
+	// Wait for the list to render, then assert the banner never appears.
+	await findByTestId('task-filter-bar', undefined, { timeout: 10_000 });
+	await waitFor(() => {
+		expect(queryByTestId('board-approvals-banner')).toBeNull();
+	});
+});


### PR DESCRIPTION
Surface the board's outstanding inbox backlog (pending approvals + unread
@board mentions) in a persistent banner at the top of the task list. The
banner links to the Inbox where the items are resolved, and disappears once
the queue is cleared. Reuses the existing useApprovals / useBoardMentions
hooks so it stays in sync as the board works through the queue.

https://claude.ai/code/session_01AwSkGpfjmuB2GFMmRRft7X