### PR TITLE
feat: flag tasks with unseen board mentions in the task list

### DIFF
--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -93,6 +93,12 @@ tasksRoutes.get('/teams/:teamId/tasks', async (c) => {
 	const db = c.get('db');
 	const { page, perPage, offset } = parsePagination(c);
 
+	// Only board users have an inbox, so the per-task unread-mention notice is
+	// scoped to the authenticated board user; other callers (agents, API keys)
+	// get `false` because `bm.user_id = NULL` never matches.
+	const auth = c.get('auth');
+	const boardUserId = auth.type === AuthType.Board ? auth.userId : null;
+
 	const conditions: string[] = ['i.team_id = $1'];
 	const params: unknown[] = [teamId];
 	let idx = 2;
@@ -167,7 +173,7 @@ tasksRoutes.get('/teams/:teamId/tasks', async (c) => {
 	);
 	const total = countResult.rows[0].count;
 
-	const dataParams = [...params, perPage, offset];
+	const dataParams = [...params, boardUserId, perPage, offset];
 	const result = await db.query(
 		`SELECT i.id, i.team_id, i.project_id, i.assignee_id, i.parent_task_id,
             i.number, i.identifier, i.title, i.description, i.status, i.priority,
@@ -179,6 +185,11 @@ tasksRoutes.get('/teams/:teamId/tasks', async (c) => {
               SELECT 1 FROM heartbeat_runs hr
               WHERE hr.task_id = i.id AND hr.status IN ('running', 'queued')
             ) AS has_active_run,
+            EXISTS (
+              SELECT 1 FROM board_mentions bm
+              WHERE bm.task_id = i.id AND bm.user_id = $${idx}
+                AND bm.read_at IS NULL AND bm.archived_at IS NULL
+            ) AS has_unread_board_mention,
             CASE WHEN qw.last_skipped_reason IS NOT NULL THEN json_build_object(
               'reason', qw.last_skipped_reason,
               'since', qw.last_skipped_at,
@@ -210,7 +221,7 @@ tasksRoutes.get('/teams/:teamId/tasks', async (c) => {
                 WHERE hr.task_id = i.id AND hr.status IN ('running', 'queued')
               ) DESC,
               i.${sortColumn} ${sortDirection}
-     LIMIT $${idx} OFFSET $${idx + 1}`,
+     LIMIT $${idx + 1} OFFSET $${idx + 2}`,
 		dataParams,
 	);
 

--- a/packages/server/test/tasks-extended.test.ts
+++ b/packages/server/test/tasks-extended.test.ts
@@ -540,6 +540,79 @@ describe('tasks list — assignee_type and has_active_run', () => {
 	});
 });
 
+describe('tasks list — has_unread_board_mention', () => {
+	const findTask = (data: any[], id: string) => data.find((i: any) => i.id === id);
+
+	async function boardUserId(): Promise<string> {
+		const row = await db.query<{ user_id: string }>(
+			`SELECT mu.user_id FROM member_users mu
+			 JOIN members m ON m.id = mu.id
+			 WHERE m.team_id = $1 AND mu.role = 'board' LIMIT 1`,
+			[teamId],
+		);
+		const id = row.rows[0]?.user_id;
+		if (!id) throw new Error('no board user on team');
+		return id;
+	}
+
+	async function seedMention(taskId: string): Promise<{ commentId: string; mentionId: string }> {
+		const userId = await boardUserId();
+		const comment = await db.query<{ id: string }>(
+			`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
+			 VALUES ($1, $2, 'text'::comment_content_type, $3::jsonb) RETURNING id`,
+			[taskId, memberId, JSON.stringify({ text: '@board your call?' })],
+		);
+		const mention = await db.query<{ id: string }>(
+			`INSERT INTO board_mentions (team_id, task_id, comment_id, user_id)
+			 VALUES ($1, $2, $3, $4) RETURNING id`,
+			[teamId, taskId, comment.rows[0].id, userId],
+		);
+		return { commentId: comment.rows[0].id, mentionId: mention.rows[0].id };
+	}
+
+	it('flags only the task with an unread board mention, and clears once read', async () => {
+		const { commentId, mentionId } = await seedMention(taskBacklogHigh);
+		try {
+			let res = await app.request(`/api/teams/${teamId}/tasks?per_page=50`, {
+				headers: authHeader(token),
+			});
+			let body = await res.json();
+			expect(findTask(body.data, taskBacklogHigh).has_unread_board_mention).toBe(true);
+			// A task without a mention stays false.
+			expect(findTask(body.data, taskInProgressUrgent).has_unread_board_mention).toBe(false);
+
+			// Reading the mention clears the per-task flag.
+			await db.query(`UPDATE board_mentions SET read_at = now() WHERE id = $1`, [mentionId]);
+			res = await app.request(`/api/teams/${teamId}/tasks?per_page=50`, {
+				headers: authHeader(token),
+			});
+			body = await res.json();
+			expect(findTask(body.data, taskBacklogHigh).has_unread_board_mention).toBe(false);
+		} finally {
+			await db.query(`DELETE FROM board_mentions WHERE id = $1`, [mentionId]);
+			await db.query(`DELETE FROM task_comments WHERE id = $1`, [commentId]);
+		}
+	});
+
+	it('does not flag an archived mention', async () => {
+		const { commentId, mentionId } = await seedMention(taskBacklogHigh);
+		try {
+			await db.query(
+				`UPDATE board_mentions SET read_at = now(), archived_at = now() WHERE id = $1`,
+				[mentionId],
+			);
+			const res = await app.request(`/api/teams/${teamId}/tasks?per_page=50`, {
+				headers: authHeader(token),
+			});
+			const body = await res.json();
+			expect(findTask(body.data, taskBacklogHigh).has_unread_board_mention).toBe(false);
+		} finally {
+			await db.query(`DELETE FROM board_mentions WHERE id = $1`, [mentionId]);
+			await db.query(`DELETE FROM task_comments WHERE id = $1`, [commentId]);
+		}
+	});
+});
+
 describe('tasks PATCH — block assignee change while agent is running', () => {
 	let otherMemberId: string;
 

--- a/packages/web/src/components/task-list.tsx
+++ b/packages/web/src/components/task-list.tsx
@@ -1,6 +1,6 @@
 import { formatTaskStatus, TaskStatus, TERMINAL_TASK_STATUSES } from '@hezo/shared';
 import { useNavigate } from '@tanstack/react-router';
-import { ChevronDown, ListPlus, Plus, Search } from 'lucide-react';
+import { AtSign, ChevronDown, ListPlus, Plus, Search } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useAgents } from '../hooks/use-agents';
 import { type TaskFilters, useTasks } from '../hooks/use-tasks';
@@ -57,6 +57,7 @@ interface TaskRow {
 	assignee_name: string | null;
 	assignee_type: 'agent' | 'user' | null;
 	has_active_run: boolean;
+	has_unread_board_mention: boolean;
 	queued_wakeup: {
 		reason: 'task_busy' | 'project_at_capacity' | 'agent_running';
 		blocker_identifier: string | null;
@@ -200,6 +201,16 @@ export function TaskList({ teamId, projectId }: TaskListProps) {
 								}
 								data-testid="task-queued-dot"
 								className="inline-block w-2 h-2 rounded-full bg-accent-blue shrink-0"
+							/>
+						</Tooltip>
+					)}
+					{row.has_unread_board_mention && (
+						<Tooltip content="Unread mention — needs your review">
+							<AtSign
+								role="img"
+								aria-label="Unread mention"
+								data-testid="task-mention-notice"
+								className="w-3 h-3 text-accent-blue shrink-0"
 							/>
 						</Tooltip>
 					)}

--- a/packages/web/src/hooks/use-tasks.ts
+++ b/packages/web/src/hooks/use-tasks.ts
@@ -26,6 +26,7 @@ export interface Task {
 	assignee_name: string | null;
 	assignee_type: 'agent' | 'user' | null;
 	has_active_run: boolean;
+	has_unread_board_mention: boolean;
 	queued_wakeup: QueuedWakeup | null;
 	parent_task_id: string | null;
 	labels: string[];

--- a/packages/web/src/hooks/use-websocket.ts
+++ b/packages/web/src/hooks/use-websocket.ts
@@ -56,6 +56,7 @@ const TABLE_TO_QUERY_KEY: Record<
 	],
 	approvals: (cid) => [['teams', cid, 'approvals'], ['teams', cid, 'inbox-count'], ['approvals']],
 	board_mentions: (cid) => [
+		['teams', cid, 'tasks'],
 		['teams', cid, 'inbox-mentions'],
 		['teams', cid, 'inbox-count'],
 		['inbox-mentions'],

--- a/packages/web/test/task-list.test.tsx
+++ b/packages/web/test/task-list.test.tsx
@@ -22,6 +22,28 @@ async function insertActiveRun(memberId: string, teamId: string, taskId: string)
 	);
 }
 
+async function seedBoardMention(ws: SeededWorkspace, taskId: string, text: string) {
+	const { db } = getTestContext();
+	const userRow = await db.query<{ user_id: string }>(
+		`SELECT mu.user_id FROM member_users mu
+		 JOIN members m ON m.id = mu.id
+		 WHERE m.team_id = $1 AND mu.role = 'board' LIMIT 1`,
+		[ws.team.id],
+	);
+	const userId = userRow.rows[0]?.user_id;
+	if (!userId) throw new Error('seedBoardMention: no board user on team');
+	const comment = await db.query<{ id: string }>(
+		`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
+		 VALUES ($1, $2, 'text'::comment_content_type, $3::jsonb) RETURNING id`,
+		[taskId, ws.agents[0].id, JSON.stringify({ text })],
+	);
+	await db.query(
+		`INSERT INTO board_mentions (team_id, task_id, comment_id, user_id)
+		 VALUES ($1, $2, $3, $4)`,
+		[ws.team.id, taskId, comment.rows[0].id, userId],
+	);
+}
+
 test('default view shows non-terminal tasks with status badges and a collapsed filter bar with New Task button', async () => {
 	let teamSlug = '';
 	let projectSlug = '';
@@ -238,6 +260,42 @@ test('running dot is hidden by default and shown when a heartbeat run is active'
 	await waitFor(() => {
 		const dots = container.querySelectorAll('[data-testid="task-running-dot"]');
 		expect(dots.length).toBe(1);
+	});
+});
+
+test('mention notice shows only on tasks with an unread board mention for the viewer', async () => {
+	let teamSlug = '';
+	let projectSlug = '';
+
+	const { findByText, container, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Mention Project' });
+			const agentId = ws.agents[0].id;
+			await seedTask(ws, project, { title: 'No mention task', assignee_id: agentId });
+			const mentioned = await seedTask(ws, project, {
+				title: 'Mentioned task',
+				assignee_id: agentId,
+			});
+			await seedBoardMention(ws, mentioned.id, '@board need your call here.');
+			teamSlug = ws.team.slug;
+			projectSlug = project.slug;
+		},
+	});
+
+	await router.navigate({
+		to: '/teams/$teamId/projects/$projectId/tasks',
+		params: { teamId: teamSlug, projectId: projectSlug },
+	});
+
+	await findByText('Mentioned task', undefined, { timeout: 10_000 });
+	await findByText('No mention task');
+
+	// Exactly one row carries the unread-mention notice — the mentioned task.
+	await waitFor(() => {
+		const notices = container.querySelectorAll('[data-testid="task-mention-notice"]');
+		expect(notices.length).toBe(1);
 	});
 });
 


### PR DESCRIPTION
Surface a per-task notice next to the existing run/queued dot when the
signed-in board user has an unread (read_at IS NULL, archived_at IS NULL)
mention on that task, so reviewers can spot which specific tasks need
their attention from the list.

- GET /teams/:teamId/tasks now returns has_unread_board_mention, scoped to
  the authenticated board user (agents/API keys get false).
- Task list renders an @ notice icon, independent of the run/queued dot.
- board_mentions realtime changes now invalidate the tasks query so the
  notice appears/clears without a manual reload.