### PR TITLE
feat: expand audit log to instance, team, and per-project scopes

### DIFF
--- a/.dev/api.md
+++ b/.dev/api.md
@@ -1333,14 +1333,20 @@ Request:
 
 ### Audit Log
 
-#### `GET /teams/:teamId/audit-log`
-Paginated, read-only.
+Three read-only, paginated views over the single `audit_log` table — each is the
+same query with a different scope filter, populated by the domain-event audit
+observer (see "Activity / audit observer" below).
 
-Query params:
-- `?entity_type=agent&entity_id=uuid`
-- `?action=agent.created`
-- `?from=...&to=...`
-- `?page=1&per_page=50`
+- `GET /api/audit-log` — **instance view, superuser only.** Every team's rows
+  plus instance-level admin actions (`team_id` is NULL — managing instance
+  credentials / connectors / skills). Rows carry `team_name` for grouping.
+- `GET /teams/:teamId/audit-log` — **team view.** Accepts an optional
+  `?project_id=` to narrow to one project.
+- `GET /teams/:teamId/projects/:projectId/audit-log` — **per-project view**, a
+  filtered slice (`WHERE project_id = …`) of the instance log.
+
+Shared query params: `?entity_type=task`, `?action=created`, `?from=…&to=…`,
+`?page=1&per_page=50`.
 
 Response:
 ```json
@@ -1348,18 +1354,39 @@ Response:
   "data": [
     {
       "id": "uuid",
-      "actor_type": "board",
-      "actor_agent_id": null,
-      "action": "agent.created",
+      "team_id": "uuid",
+      "team_name": "Marketing Site",
+      "project_id": "uuid",
+      "actor_type": "admin",
+      "actor_member_id": "uuid",
+      "actor_name": "Frontend Engineer",
+      "action": "created",
       "entity_type": "agent",
       "entity_id": "uuid",
-      "details": { "title": "Frontend Engineer" },
+      "details": { "name": "Frontend Engineer" },
       "created_at": "..."
     }
   ],
   "meta": { "page": 1, "per_page": 50, "total": 234 }
 }
 ```
+
+`team_id` and `project_id` are nullable (instance-level rows have both NULL;
+team-level events have a NULL `project_id`). `actor_type` is one of
+`admin` / `agent` / `system`.
+
+#### Activity / audit observer
+
+Domain code never writes audit rows directly. Mutations emit a typed
+`DomainEvent` onto a per-app `DomainEventBus` (`events/bus.ts`); a single audit
+observer (`events/audit-observer.ts`) subscribes and persists each event as an
+`audit_log` row (best-effort, via `trackBackground`). Covered events: task
+create/update, project create, agent run started/completed, asset create,
+document create/update/delete (agent system-prompt edits are attributed to the
+agent entity), agent create/update/disable/enable, secret + MCP-connector +
+skill create/update/delete (at both team and instance scope), OAuth connection
+create/delete, and credential request/fulfill. Connector and credential events
+record `actor_type = agent` when an agent (via an MCP tool) triggered them.
 
 ---
 

--- a/.dev/schema.md
+++ b/.dev/schema.md
@@ -28,7 +28,7 @@
 | `secret_grants` | Which agent has access to which secret. Revocable. | links secret ↔ member_agent |
 | `approvals` | Pending board decisions. Polymorphic payload. | belongs to team, requested by member_agent |
 | `cost_entries` | Immutable spend records per agent per task. | belongs to team + member_agent, optionally task/project |
-| `audit_log` | Append-only. Never updated or deleted. | belongs to team |
+| `audit_log` | Append-only activity trail. `team_id` is nullable (NULL = an instance-level admin action not bound to a team); `project_id` is nullable (set for project-scoped events). Read at three scopes: instance (`GET /api/audit-log`, superuser), team, and per-project. | optionally team, optionally project |
 | `documents` | Unified Markdown document store keyed by `type` (`project_doc` / `team_preferences` / `agent_system_prompt`). Project docs scope by `(project_id, slug)`; preferences by `(team_id)` (one per team); agent system prompts by `(member_agent_id)` (one per agent). Embeddings live on this table for project docs. The team-level reference store is the `skills` table, not this one. | belongs to team, optionally project or member_agent |
 | `document_revisions` | Snapshot of prior content created on every change. `change_summary` captures intent; `Restored to revision N` is set automatically by the rollback path. Shared by all document types — agent system prompt history lives here too. | belongs to document |
 | `connected_platforms` | OAuth connections to external services. Tokens stored in secrets. | belongs to team |
@@ -219,14 +219,14 @@ token is used for API calls (repo validation, PRs, Actions).
 
 ### Audit log immutability
 
-The `audit_log` table has no `updated_at`. The app layer must never task
-UPDATE or DELETE on this table. A future migration can add a Postgres rule to
-hard-block these operations:
-
-```sql
-CREATE RULE no_update_audit AS ON UPDATE TO audit_log DO INSTEAD NOTHING;
-CREATE RULE no_delete_audit AS ON DELETE TO audit_log DO INSTEAD NOTHING;
-```
+The `audit_log` table has no `updated_at`. The app layer never issues UPDATE or
+DELETE on this table — rows are written once by the audit observer and only ever
+read. The two FK-driven exceptions are referential, not content edits: a deleted
+team cascade-deletes its rows (`team_id ... ON DELETE CASCADE`) and a deleted
+project nulls the back-reference (`project_id ... ON DELETE SET NULL`), so a
+blanket `DO INSTEAD NOTHING` rule on UPDATE/DELETE is intentionally **not**
+added (it would break those FK actions). Immutability is enforced at the app
+layer: the observer is the only writer, and nothing else touches the table.
 
 ### Budget resets
 

--- a/packages/server/migrations/001_initial_schema.sql
+++ b/packages/server/migrations/001_initial_schema.sql
@@ -667,7 +667,12 @@ CREATE INDEX idx_costs_created ON cost_entries(created_at);
 
 CREATE TABLE audit_log (
     id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    team_id         UUID NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+    -- team_id NULL = an instance-level action (e.g. an Admin managing an
+    -- instance secret / connector / skill that is not bound to any team).
+    team_id         UUID REFERENCES teams(id) ON DELETE CASCADE,
+    -- project_id scopes the event to a single project when applicable. NULL for
+    -- team-level (e.g. agent system prompt, team secrets) and instance-level events.
+    project_id      UUID REFERENCES projects(id) ON DELETE SET NULL,
     actor_type      audit_actor_type NOT NULL,
     actor_member_id UUID REFERENCES members(id) ON DELETE SET NULL,
     action          TEXT NOT NULL,
@@ -679,6 +684,8 @@ CREATE TABLE audit_log (
 
 CREATE INDEX idx_audit_team ON audit_log(team_id);
 CREATE INDEX idx_audit_created ON audit_log(team_id, created_at);
+CREATE INDEX idx_audit_project ON audit_log(project_id, created_at);
+CREATE INDEX idx_audit_created_global ON audit_log(created_at);
 CREATE INDEX idx_audit_entity ON audit_log(entity_type, entity_id);
 
 -------------------------------------------------------------------------------

--- a/packages/server/src/events/audit-observer.ts
+++ b/packages/server/src/events/audit-observer.ts
@@ -1,0 +1,186 @@
+import type { PGlite } from '@electric-sql/pglite';
+import { AuditAction, AuditActorType, AuditEntityType } from '@hezo/shared';
+import { type AuditLogInput, auditLog } from '../lib/audit';
+import { trackBackground } from '../lib/background';
+import { logger } from '../logger';
+import type { DomainEventBus } from './bus';
+import type { DomainEvent } from './types';
+
+const log = logger.child('audit-observer');
+
+/**
+ * Translate a domain event into the audit row it should produce, or `null` when
+ * the event is not auditable. This is the single place that knows the audit
+ * schema (entity_type / action / project_id / details mapping).
+ */
+export function mapEventToAudit(event: DomainEvent): AuditLogInput | null {
+	switch (event.type) {
+		case 'task.created':
+			return row(event, AuditAction.Created, AuditEntityType.Task, event.taskId, {
+				identifier: event.identifier,
+			});
+		case 'task.updated':
+			return row(event, AuditAction.Updated, AuditEntityType.Task, event.taskId, {
+				field: event.field,
+				from: event.from,
+				to: event.to,
+			});
+		case 'project.created':
+			return row(event, AuditAction.Created, AuditEntityType.Project, event.projectId, {
+				name: event.name,
+				slug: event.slug,
+			});
+		case 'agent_run.started':
+			return {
+				teamId: event.teamId,
+				projectId: event.projectId ?? null,
+				actorType: AuditActorType.Agent,
+				actorMemberId: event.agentMemberId,
+				action: AuditAction.RunStarted,
+				entityType: AuditEntityType.AgentRun,
+				entityId: event.runId,
+				details: {
+					task_id: event.taskId,
+					trigger_source: event.triggerSource,
+					triggered_by: event.triggeredBy ?? null,
+				},
+			};
+		case 'agent_run.completed':
+			return {
+				teamId: event.teamId,
+				projectId: event.projectId ?? null,
+				actorType: AuditActorType.Agent,
+				actorMemberId: event.agentMemberId,
+				action: AuditAction.RunCompleted,
+				entityType: AuditEntityType.AgentRun,
+				entityId: event.runId,
+				details: {
+					task_id: event.taskId,
+					status: event.status,
+					exit_code: event.exitCode,
+					error: event.error ?? null,
+				},
+			};
+		case 'asset.created':
+			return row(event, AuditAction.Created, AuditEntityType.Asset, event.assetId, {
+				filename: event.filename,
+				task_id: event.taskId ?? null,
+				run_id: event.runId ?? null,
+			});
+		case 'document.created':
+		case 'document.updated':
+		case 'document.deleted': {
+			// System-prompt edits are attributed to the agent entity; other docs to the document.
+			const entityType = event.agentMemberId ? AuditEntityType.Agent : AuditEntityType.Document;
+			const entityId = event.agentMemberId ?? event.documentId;
+			return row(event, actionFromSuffix(event.type), entityType, entityId, {
+				document_type: event.documentType,
+				slug: event.slug ?? null,
+				title: event.title ?? null,
+				...(event.agentMemberId ? { field: 'system_prompt' } : {}),
+			});
+		}
+		case 'agent.created':
+		case 'agent.updated':
+		case 'agent.disabled':
+		case 'agent.enabled': {
+			const sub = event.type.slice('agent.'.length);
+			const action = sub === 'created' ? AuditAction.Created : AuditAction.Updated;
+			return row(event, action, AuditEntityType.Agent, event.agentMemberId, {
+				...(sub === 'disabled' || sub === 'enabled' ? { change: sub } : {}),
+				...(event.changes ? { changes: event.changes } : {}),
+			});
+		}
+		case 'secret.created':
+		case 'secret.updated':
+		case 'secret.deleted':
+			return row(event, actionFromSuffix(event.type), AuditEntityType.Secret, event.secretId, {
+				name: event.name,
+			});
+		case 'credential.requested':
+			return row(event, AuditAction.Requested, AuditEntityType.Secret, null, {
+				name: event.name,
+				task_id: event.taskId,
+			});
+		case 'credential.fulfilled':
+			return row(event, AuditAction.Created, AuditEntityType.Secret, event.secretId, {
+				name: event.name,
+				via: 'credential_request',
+				requesting_agent_id: event.requestingAgentId ?? null,
+			});
+		case 'connection.created':
+		case 'connection.deleted':
+			return row(
+				event,
+				actionFromSuffix(event.type),
+				AuditEntityType.Connection,
+				event.connectionId,
+				{ provider: event.provider },
+			);
+		case 'mcp_connection.created':
+		case 'mcp_connection.updated':
+		case 'mcp_connection.deleted':
+			return row(
+				event,
+				actionFromSuffix(event.type),
+				AuditEntityType.McpConnection,
+				event.connectionId,
+				{ name: event.name, ...(event.changeKind ? { change_kind: event.changeKind } : {}) },
+			);
+		case 'skill.created':
+		case 'skill.updated':
+		case 'skill.deleted':
+			return row(event, actionFromSuffix(event.type), AuditEntityType.Skill, event.skillId, {
+				slug: event.slug,
+				name: event.name ?? null,
+			});
+		default:
+			return null;
+	}
+}
+
+/** Register the audit observer on a bus. The only consumer that persists audit rows. */
+export function registerAuditObserver(bus: DomainEventBus, db: PGlite): void {
+	bus.subscribe((event) => {
+		const input = mapEventToAudit(event);
+		if (!input) return;
+		trackBackground(
+			auditLog(db, input).catch((e) =>
+				log.error(`Failed to write audit row for ${event.type}:`, e),
+			),
+		);
+	});
+}
+
+type ScopedActor = {
+	teamId: string | null;
+	projectId?: string | null;
+	actorType: AuditActorType;
+	actorMemberId: string | null;
+};
+
+function row(
+	event: ScopedActor,
+	action: AuditAction,
+	entityType: AuditEntityType,
+	entityId: string | null,
+	details: Record<string, unknown>,
+): AuditLogInput {
+	return {
+		teamId: event.teamId,
+		projectId: event.projectId ?? null,
+		actorType: event.actorType,
+		actorMemberId: event.actorMemberId,
+		action,
+		entityType,
+		entityId,
+		details,
+	};
+}
+
+function actionFromSuffix(type: string): AuditAction {
+	const suffix = type.split('.')[1];
+	if (suffix === 'created') return AuditAction.Created;
+	if (suffix === 'updated') return AuditAction.Updated;
+	return AuditAction.Deleted;
+}

--- a/packages/server/src/events/bus.ts
+++ b/packages/server/src/events/bus.ts
@@ -1,0 +1,36 @@
+import { logger } from '../logger';
+import type { DomainEvent, DomainEventHandler } from './types';
+
+const log = logger.child('events');
+
+/**
+ * Minimal synchronous Subject for the Observer pattern. Business code emits
+ * domain events without knowing who consumes them; observers (e.g. the audit
+ * observer) subscribe once at startup.
+ *
+ * One instance lives per app (created in `startup.ts`, threaded like
+ * `wsManager`) — never a module-level singleton, so tests that boot a fresh app
+ * per `createTestContext` stay isolated.
+ *
+ * `emit` is fire-and-forget from the caller's perspective: each subscriber is
+ * invoked in its own try/catch so one failing observer never breaks the request
+ * path or another observer. Observers that do async work own their own
+ * background tracking.
+ */
+export class DomainEventBus {
+	private readonly handlers: DomainEventHandler[] = [];
+
+	subscribe(handler: DomainEventHandler): void {
+		this.handlers.push(handler);
+	}
+
+	emit(event: DomainEvent): void {
+		for (const handler of this.handlers) {
+			try {
+				handler(event);
+			} catch (err) {
+				log.error(`Observer threw handling ${event.type}:`, err);
+			}
+		}
+	}
+}

--- a/packages/server/src/events/types.ts
+++ b/packages/server/src/events/types.ts
@@ -1,0 +1,114 @@
+import type { AuditActorType, HeartbeatRunStatus } from '@hezo/shared';
+
+/**
+ * Domain events emitted by business logic and consumed by observers (today:
+ * the audit observer). Each event is self-contained — it carries every value an
+ * observer needs to persist a row, so observers never re-query the database.
+ *
+ * `teamId` is nullable for instance-level actions (e.g. an Admin managing an
+ * instance secret / connector / skill). `projectId` is set only for
+ * project-scoped events.
+ */
+
+interface Scope {
+	teamId: string | null;
+	projectId?: string | null;
+}
+
+interface Actor {
+	actorType: AuditActorType;
+	actorMemberId: string | null;
+}
+
+export type TaskUpdateField = 'title' | 'status' | 'assignee';
+
+export type DomainEvent =
+	| ({ type: 'task.created'; taskId: string; identifier: string } & Scope & Actor)
+	| ({
+			type: 'task.updated';
+			taskId: string;
+			field: TaskUpdateField;
+			from: string | null;
+			to: string | null;
+	  } & Scope &
+			Actor)
+	| ({ type: 'project.created'; projectId: string; name: string; slug: string } & Scope & Actor)
+	| ({
+			type: 'agent_run.started';
+			runId: string;
+			taskId: string | null;
+			agentMemberId: string;
+			triggerSource: string | null;
+			triggeredBy?: string | null;
+	  } & Scope)
+	| ({
+			type: 'agent_run.completed';
+			runId: string;
+			taskId: string | null;
+			agentMemberId: string;
+			status: HeartbeatRunStatus;
+			exitCode: number | null;
+			error?: string | null;
+	  } & Scope)
+	| ({
+			type: 'asset.created';
+			assetId: string;
+			filename: string;
+			taskId?: string | null;
+			runId?: string | null;
+	  } & Scope &
+			Actor)
+	| ({
+			type: 'document.created' | 'document.updated' | 'document.deleted';
+			documentId: string | null;
+			documentType: string;
+			slug?: string | null;
+			title?: string | null;
+			/** When set, the audit row is attributed to the agent entity (system prompt edits). */
+			agentMemberId?: string | null;
+	  } & Scope &
+			Actor)
+	| ({
+			type: 'agent.created' | 'agent.updated' | 'agent.disabled' | 'agent.enabled';
+			agentMemberId: string;
+			changes?: string[];
+	  } & Scope &
+			Actor)
+	| ({
+			type: 'secret.created' | 'secret.updated' | 'secret.deleted';
+			secretId: string;
+			name: string;
+	  } & Scope &
+			Actor)
+	| ({ type: 'credential.requested'; taskId: string | null; name: string } & Scope & Actor)
+	| ({
+			type: 'credential.fulfilled';
+			secretId: string;
+			name: string;
+			requestingAgentId?: string | null;
+	  } & Scope &
+			Actor)
+	| ({
+			type: 'connection.created' | 'connection.deleted';
+			connectionId: string;
+			provider: string;
+	  } & Scope &
+			Actor)
+	| ({
+			type: 'mcp_connection.created' | 'mcp_connection.updated' | 'mcp_connection.deleted';
+			connectionId: string;
+			name: string;
+			changeKind?: string;
+	  } & Scope &
+			Actor)
+	| ({
+			type: 'skill.created' | 'skill.updated' | 'skill.deleted';
+			skillId: string;
+			slug: string;
+			name?: string | null;
+	  } & Scope &
+			Actor);
+
+export type DomainEventType = DomainEvent['type'];
+
+export type DomainEventHandler = (event: DomainEvent) => void;

--- a/packages/server/src/lib/audit.ts
+++ b/packages/server/src/lib/audit.ts
@@ -1,19 +1,32 @@
 import type { PGlite } from '@electric-sql/pglite';
 import type { AuditAction, AuditActorType, AuditEntityType } from '@hezo/shared';
 
-export async function auditLog(
-	db: PGlite,
-	teamId: string,
-	actorType: AuditActorType,
-	actorMemberId: string | null,
-	action: AuditAction,
-	entityType: AuditEntityType,
-	entityId: string | null,
-	details?: Record<string, unknown>,
-): Promise<void> {
+export interface AuditLogInput {
+	/** NULL for instance-level actions not bound to any team. */
+	teamId: string | null;
+	/** NULL for team-level and instance-level events. */
+	projectId?: string | null;
+	actorType: AuditActorType;
+	actorMemberId: string | null;
+	action: AuditAction;
+	entityType: AuditEntityType;
+	entityId: string | null;
+	details?: Record<string, unknown>;
+}
+
+export async function auditLog(db: PGlite, input: AuditLogInput): Promise<void> {
 	await db.query(
-		`INSERT INTO audit_log (team_id, actor_type, actor_member_id, action, entity_type, entity_id, details)
-		 VALUES ($1, $2::audit_actor_type, $3, $4, $5, $6, $7::jsonb)`,
-		[teamId, actorType, actorMemberId, action, entityType, entityId, JSON.stringify(details ?? {})],
+		`INSERT INTO audit_log (team_id, project_id, actor_type, actor_member_id, action, entity_type, entity_id, details)
+		 VALUES ($1, $2, $3::audit_actor_type, $4, $5, $6, $7, $8::jsonb)`,
+		[
+			input.teamId,
+			input.projectId ?? null,
+			input.actorType,
+			input.actorMemberId,
+			input.action,
+			input.entityType,
+			input.entityId,
+			JSON.stringify(input.details ?? {}),
+		],
 	);
 }

--- a/packages/server/src/lib/resolve.ts
+++ b/packages/server/src/lib/resolve.ts
@@ -1,5 +1,5 @@
 import type { PGlite } from '@electric-sql/pglite';
-import { AuthType } from '@hezo/shared';
+import { type AuditActorType, AuthType } from '@hezo/shared';
 import type { AuthInfo } from './types';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -18,6 +18,26 @@ export async function resolveActorMemberId(
 		return result.rows[0]?.id ?? null;
 	}
 	return null;
+}
+
+/** Map an auth context to its audit actor type. Anything non-agent is an admin (board) actor. */
+export function actorTypeFromAuth(auth: AuthInfo): AuditActorType {
+	return auth.type === AuthType.Agent ? 'agent' : 'admin';
+}
+
+/**
+ * Resolve both the audit actor type and the acting member id for a request.
+ * `teamId` may be null for instance-level actions; the member id only resolves
+ * within a team, so it is null at instance scope (the actor is still `admin`).
+ */
+export async function resolveActor(
+	db: PGlite,
+	auth: AuthInfo,
+	teamId: string | null,
+): Promise<{ actorType: AuditActorType; actorMemberId: string | null }> {
+	const actorType = actorTypeFromAuth(auth);
+	const actorMemberId = teamId ? await resolveActorMemberId(db, auth, teamId) : null;
+	return { actorType, actorMemberId };
 }
 
 export async function resolveTeamId(db: PGlite, raw: string): Promise<string | null> {

--- a/packages/server/src/lib/types.ts
+++ b/packages/server/src/lib/types.ts
@@ -1,6 +1,7 @@
 import type { PGlite } from '@electric-sql/pglite';
 import type { AuthType } from '@hezo/shared';
 import type { MasterKeyManager } from '../crypto/master-key';
+import type { DomainEventBus } from '../events/bus';
 import type { ContainerLogStreamer } from '../services/container-logs';
 import type { DockerClient } from '../services/docker';
 import type { EgressProxy } from '../services/egress';
@@ -28,6 +29,7 @@ export type Env = {
 		masterKeyManager: MasterKeyManager;
 		docker: DockerClient;
 		wsManager: WebSocketManager;
+		events: DomainEventBus;
 		jobManager: JobManager;
 		logs: LogStreamBroker;
 		containerLogStreamer: ContainerLogStreamer;

--- a/packages/server/src/mcp/server.ts
+++ b/packages/server/src/mcp/server.ts
@@ -4,6 +4,7 @@ import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { Context } from 'hono';
 import type { MasterKeyManager } from '../crypto/master-key';
+import type { DomainEventBus } from '../events/bus';
 import type { AuthInfo, Env } from '../lib/types';
 import { verifyToken } from '../middleware/auth';
 import type { WebSocketManager } from '../services/ws';
@@ -17,9 +18,10 @@ export function initMcpServer(
 	dataDir: string,
 	masterKeyManager: MasterKeyManager,
 	wsManager?: WebSocketManager,
+	events?: DomainEventBus,
 ): ToolDef[] {
 	mcpServer = new McpServer({ name: 'hezo', version: '0.1.0' });
-	toolDefs = registerTools(mcpServer, db, dataDir, masterKeyManager, wsManager);
+	toolDefs = registerTools(mcpServer, db, dataDir, masterKeyManager, wsManager, events);
 	return toolDefs;
 }
 

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -25,6 +25,7 @@ import {
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { MasterKeyManager } from '../crypto/master-key';
+import type { DomainEventBus } from '../events/bus';
 import { assertNoActiveRun } from '../lib/active-run';
 import { isCoach } from '../lib/agent-roles';
 import { upsertProjectAsset } from '../lib/asset-name';
@@ -341,6 +342,7 @@ export function registerTools(
 	dataDir: string,
 	masterKeyManager: MasterKeyManager,
 	wsManager?: WebSocketManager,
+	events?: DomainEventBus,
 ): ToolDef[] {
 	registeredTools.length = 0;
 
@@ -584,7 +586,14 @@ export function registerTools(
 			const teamId = args.team_id as string;
 			const caller = await buildMcpCreateTaskCaller(db, auth, teamId);
 			try {
-				return await createTask(db, teamId, mcpArgsToCreateTaskInput(args), caller, wsManager);
+				return await createTask(
+					db,
+					teamId,
+					mcpArgsToCreateTaskInput(args),
+					caller,
+					wsManager,
+					events,
+				);
 			} catch (e) {
 				if (e instanceof CreateTaskError) return { error: e.message };
 				throw e;
@@ -656,6 +665,7 @@ export function registerTools(
 							mcpArgsToCreateTaskInput(item),
 							caller,
 							wsManager,
+							events,
 						);
 						return { index, ok: true as const, task };
 					} catch (e) {
@@ -1385,6 +1395,9 @@ export function registerTools(
 					slug,
 					taskPrefix: prefixResult.prefix,
 					description: (args.description as string | undefined) ?? '',
+					events,
+					actorType: auth.type === AuthType.Agent ? AuditActorType.Agent : AuditActorType.Admin,
+					actorMemberId: auth.type === AuthType.Agent ? auth.memberId : null,
 				});
 
 			broadcastRowChange(wsManager, wsRoom.team(teamId), 'projects', 'INSERT', project);
@@ -1774,6 +1787,16 @@ export function registerTools(
 				[taskId, authorMemberId, JSON.stringify(content)],
 			);
 
+			events?.emit({
+				type: 'credential.requested',
+				teamId,
+				projectId,
+				actorType: AuditActorType.Agent,
+				actorMemberId: authorMemberId,
+				taskId,
+				name,
+			});
+
 			return {
 				placeholder,
 				comment_id: inserted.rows[0].id,
@@ -1864,6 +1887,17 @@ export function registerTools(
 				createdByTaskId: taskId,
 				providerId,
 			});
+
+			if (!alreadyExisted) {
+				events?.emit({
+					type: 'mcp_connection.created',
+					teamId,
+					actorType: auth.type === AuthType.Agent ? AuditActorType.Agent : AuditActorType.Admin,
+					actorMemberId: auth.type === AuthType.Agent ? auth.memberId : null,
+					connectionId: row.id as string,
+					name: name as string,
+				});
+			}
 
 			const status = statusOf(row);
 
@@ -1995,6 +2029,10 @@ export function registerTools(
 				content: body,
 				authorMemberId,
 				changeSummary: `Fetched from ${url}`,
+				audit: {
+					events,
+					actorType: auth.type === AuthType.Agent ? AuditActorType.Agent : AuditActorType.Admin,
+				},
 			});
 
 			// Track source_url in a separate small table? For v1 we encode it in
@@ -2084,6 +2122,7 @@ export function registerTools(
 				dataDir,
 				actorMemberId,
 				wsManager,
+				events,
 			});
 			if (!resolved.ok) {
 				return { error: resolved.message };
@@ -2677,6 +2716,10 @@ export function registerTools(
 				},
 				content: args.content as string,
 				authorMemberId: callerMemberId,
+				audit: {
+					events,
+					actorType: auth.type === AuthType.Agent ? AuditActorType.Agent : AuditActorType.Admin,
+				},
 			});
 			return { written: true, id: doc.id, filename: doc.slug };
 		},

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -20,7 +20,12 @@ import {
 import { Hono } from 'hono';
 import { trackBackground } from '../lib/background';
 import { broadcastChange } from '../lib/broadcast';
-import { resolveActorMemberId, resolveAgentId } from '../lib/resolve';
+import {
+	actorTypeFromAuth,
+	resolveActor,
+	resolveActorMemberId,
+	resolveAgentId,
+} from '../lib/resolve';
 import { err, ok } from '../lib/response';
 import { toSlug } from '../lib/slug';
 import { buildUpdateSet, isFkViolation, terminalStatusParams, withTransaction } from '../lib/sql';
@@ -290,6 +295,15 @@ agentsRoutes.post('/teams/:teamId/agents', async (c) => {
 			log.error('Failed to enqueue team coherence review after agent create:', e),
 		),
 	);
+
+	const createActor = await resolveActor(db, c.get('auth'), teamId);
+	c.get('events').emit({
+		type: 'agent.created',
+		teamId,
+		actorType: createActor.actorType,
+		actorMemberId: createActor.actorMemberId,
+		agentMemberId: memberId,
+	});
 
 	return ok(c, result.rows[0], 201);
 });
@@ -683,6 +697,7 @@ agentsRoutes.post('/teams/:teamId/agents/:agentId/system-prompt/restore', async 
 		documentId: doc.id,
 		revisionNumber: body.revision_number,
 		restoredByMemberId: null,
+		audit: { events: c.get('events'), actorType: actorTypeFromAuth(auth) },
 	});
 	if (!restored) return err(c, 'NOT_FOUND', 'Revision not found', 404);
 
@@ -829,6 +844,7 @@ agentsRoutes.patch('/teams/:teamId/agents/:agentId', async (c) => {
 			content: body.system_prompt,
 			changeSummary: body.system_prompt_change_summary ?? 'Manual edit by the admin',
 			authorMemberId: null,
+			audit: { events: c.get('events'), actorType: actorTypeFromAuth(c.get('auth')) },
 		});
 	}
 
@@ -849,6 +865,23 @@ agentsRoutes.patch('/teams/:teamId/agents/:agentId', async (c) => {
 				log.error('Failed to enqueue team coherence review on reports_to change:', e),
 			),
 		);
+	}
+
+	// System-prompt-only edits are audited via the document event from upsertDocument;
+	// emit agent.updated for the other settings/profile changes.
+	if (sets.length > 0 || body.title?.trim()) {
+		const changes = Object.keys(body).filter(
+			(k) => k !== 'system_prompt' && k !== 'system_prompt_change_summary',
+		);
+		const updateActor = await resolveActor(db, c.get('auth'), teamId);
+		c.get('events').emit({
+			type: 'agent.updated',
+			teamId,
+			actorType: updateActor.actorType,
+			actorMemberId: updateActor.actorMemberId,
+			agentMemberId: agentId,
+			changes,
+		});
 	}
 
 	return ok(c, updatedRow);
@@ -890,6 +923,15 @@ agentsRoutes.post('/teams/:teamId/agents/:agentId/disable', async (c) => {
 		),
 	);
 
+	const disableActor = await resolveActor(db, c.get('auth'), teamId);
+	c.get('events').emit({
+		type: 'agent.disabled',
+		teamId,
+		actorType: disableActor.actorType,
+		actorMemberId: disableActor.actorMemberId,
+		agentMemberId: agentId,
+	});
+
 	return ok(c, { admin_status: AgentAdminStatus.Disabled });
 });
 
@@ -922,6 +964,15 @@ agentsRoutes.post('/teams/:teamId/agents/:agentId/enable', async (c) => {
 			log.error('Failed to enqueue team coherence review on enable:', e),
 		),
 	);
+
+	const enableActor = await resolveActor(db, c.get('auth'), teamId);
+	c.get('events').emit({
+		type: 'agent.enabled',
+		teamId,
+		actorType: enableActor.actorType,
+		actorMemberId: enableActor.actorMemberId,
+		agentMemberId: agentId,
+	});
 
 	return ok(c, { admin_status: AgentAdminStatus.Enabled });
 });

--- a/packages/server/src/routes/approvals.ts
+++ b/packages/server/src/routes/approvals.ts
@@ -208,6 +208,7 @@ approvalsRoutes.post('/approvals/:approvalId/resolve', async (c) => {
 		dataDir: c.get('dataDir'),
 		actorMemberId,
 		wsManager: c.get('wsManager'),
+		events: c.get('events'),
 		containerDeps: {
 			db,
 			docker: c.get('docker'),

--- a/packages/server/src/routes/assets.ts
+++ b/packages/server/src/routes/assets.ts
@@ -32,7 +32,13 @@ export const assetsRoutes = new Hono<Env>();
  * task-comment upload and the project Assets upload. Returns a `201` response
  * with the stored asset + a freshly-signed read URL, or an error response.
  */
-async function storeUploadedAsset(c: Context<Env>, teamId: string, projectId: string, file: File) {
+async function storeUploadedAsset(
+	c: Context<Env>,
+	teamId: string,
+	projectId: string,
+	file: File,
+	taskId?: string | null,
+) {
 	if (!isAllowedAttachmentExtension(file.name)) {
 		return err(c, 'INVALID_ATTACHMENT', 'Unsupported file extension', 400);
 	}
@@ -60,7 +66,8 @@ async function storeUploadedAsset(c: Context<Env>, teamId: string, projectId: st
 		return err(c, 'INTERNAL_ERROR', 'Failed to store attachment', 500);
 	}
 
-	const uploadedBy = await resolveActorMemberId(db, c.get('auth'), teamId);
+	const auth = c.get('auth');
+	const uploadedBy = await resolveActorMemberId(db, auth, teamId);
 	const asset = await insertAssetWithUniqueName(db, {
 		assetId,
 		teamId,
@@ -70,6 +77,19 @@ async function storeUploadedAsset(c: Context<Env>, teamId: string, projectId: st
 		sha256,
 		desiredName: normalizeAssetFilename(file.name),
 		uploadedByMemberId: uploadedBy,
+	});
+
+	const isAgent = auth.type === AuthType.Agent;
+	c.get('events').emit({
+		type: 'asset.created',
+		teamId,
+		projectId,
+		actorType: isAgent ? 'agent' : 'admin',
+		actorMemberId: uploadedBy,
+		assetId: asset.id,
+		filename: asset.original_filename,
+		taskId: taskId ?? (isAgent ? auth.taskId : null),
+		runId: isAgent ? auth.runId : null,
 	});
 
 	const url = await signAssetUrl(assetId, c.get('masterKeyManager'));
@@ -119,7 +139,7 @@ assetsRoutes.post(
 		const file = await readUploadFile(c);
 		if (!file) return err(c, 'INVALID_REQUEST', 'Missing file field', 400);
 
-		return storeUploadedAsset(c, teamId, projectId, file);
+		return storeUploadedAsset(c, teamId, projectId, file, taskId);
 	},
 );
 

--- a/packages/server/src/routes/audit-log.ts
+++ b/packages/server/src/routes/audit-log.ts
@@ -1,67 +1,113 @@
+import type { PGlite } from '@electric-sql/pglite';
+import type { Context } from 'hono';
 import { Hono } from 'hono';
 import { buildMeta, parsePagination } from '../lib/pagination';
+import { resolveProjectId } from '../lib/resolve';
+import { err } from '../lib/response';
 import type { Env } from '../lib/types';
+import { requireSuperuser } from '../middleware/auth';
 
 export const auditLogRoutes = new Hono<Env>();
 
-auditLogRoutes.get('/teams/:teamId/audit-log', async (c) => {
-	const teamId = c.get('teamId') as string;
-	const db = c.get('db');
+/**
+ * Shared reader for the audit log. `scope` pins the base WHERE clause:
+ * - team:     `team_id = :id` (with optional ?project_id= filter)
+ * - project:  `project_id = :id`
+ * - instance: no scope filter (every team + instance-level rows)
+ * All three accept the same entity_type / action / from / to filters.
+ */
+async function queryAuditLog(
+	c: Context<Env>,
+	db: PGlite,
+	scope:
+		| { kind: 'team'; teamId: string }
+		| { kind: 'project'; projectId: string }
+		| { kind: 'instance' },
+): Promise<Response> {
 	const { page, perPage, offset } = parsePagination(c);
+	const conditions: string[] = [];
+	const params: unknown[] = [];
+	let idx = 1;
 
-	const conditions: string[] = ['al.team_id = $1'];
-	const params: unknown[] = [teamId];
-	let idx = 2;
+	if (scope.kind === 'team') {
+		conditions.push(`al.team_id = $${idx++}`);
+		params.push(scope.teamId);
+		const projectId = c.req.query('project_id');
+		if (projectId) {
+			conditions.push(`al.project_id = $${idx++}`);
+			params.push(projectId);
+		}
+	} else if (scope.kind === 'project') {
+		conditions.push(`al.project_id = $${idx++}`);
+		params.push(scope.projectId);
+	}
 
 	const entityType = c.req.query('entity_type');
 	if (entityType) {
-		conditions.push(`al.entity_type = $${idx}`);
+		conditions.push(`al.entity_type = $${idx++}`);
 		params.push(entityType);
-		idx++;
 	}
-
 	const action = c.req.query('action');
 	if (action) {
-		conditions.push(`al.action = $${idx}`);
+		conditions.push(`al.action = $${idx++}`);
 		params.push(action);
-		idx++;
 	}
-
 	const from = c.req.query('from');
 	if (from) {
-		conditions.push(`al.created_at >= $${idx}`);
+		conditions.push(`al.created_at >= $${idx++}`);
 		params.push(from);
-		idx++;
 	}
-
 	const to = c.req.query('to');
 	if (to) {
-		conditions.push(`al.created_at <= $${idx}`);
+		conditions.push(`al.created_at <= $${idx++}`);
 		params.push(to);
-		idx++;
 	}
 
-	const where = conditions.join(' AND ');
+	const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
 
 	const countResult = await db.query<{ count: number }>(
-		`SELECT count(*)::int AS count FROM audit_log al WHERE ${where}`,
+		`SELECT count(*)::int AS count FROM audit_log al ${where}`,
 		params,
 	);
 	const total = countResult.rows[0].count;
 
 	const dataParams = [...params, perPage, offset];
 	const result = await db.query(
-		`SELECT al.id, al.team_id, al.actor_type, al.actor_member_id,
+		`SELECT al.id, al.team_id, al.project_id, al.actor_type, al.actor_member_id,
 		        al.action, al.entity_type, al.entity_id, al.details, al.created_at,
-		        COALESCE(ma.title, m.display_name) AS actor_name
+		        COALESCE(ma.title, m.display_name) AS actor_name,
+		        t.name AS team_name
 		 FROM audit_log al
 		 LEFT JOIN members m ON m.id = al.actor_member_id
 		 LEFT JOIN member_agents ma ON ma.id = al.actor_member_id
-		 WHERE ${where}
+		 LEFT JOIN teams t ON t.id = al.team_id
+		 ${where}
 		 ORDER BY al.created_at DESC
 		 LIMIT $${idx} OFFSET $${idx + 1}`,
 		dataParams,
 	);
 
 	return c.json({ data: result.rows, meta: buildMeta(page, perPage, total) });
+}
+
+// Team-scoped view (board members of the team). Optional ?project_id= narrows it.
+auditLogRoutes.get('/teams/:teamId/audit-log', async (c) => {
+	const teamId = c.get('teamId') as string;
+	return queryAuditLog(c, c.get('db'), { kind: 'team', teamId });
+});
+
+// Per-project view — a filtered slice of the instance log.
+auditLogRoutes.get('/teams/:teamId/projects/:projectId/audit-log', async (c) => {
+	const teamId = c.get('teamId') as string;
+	const db = c.get('db');
+	const projectId = await resolveProjectId(db, teamId, c.req.param('projectId'));
+	if (!projectId) return err(c, 'NOT_FOUND', 'Project not found', 404);
+	return queryAuditLog(c, db, { kind: 'project', projectId });
+});
+
+// Instance-level view — every team + instance-scoped rows. Superuser only.
+auditLogRoutes.get('/audit-log', async (c) => {
+	const denied = requireSuperuser(c);
+	if (denied) return denied;
+	return queryAuditLog(c, c.get('db'), { kind: 'instance' });
 });

--- a/packages/server/src/routes/comments.ts
+++ b/packages/server/src/routes/comments.ts
@@ -5,7 +5,7 @@ import { signAssetUrl } from '../lib/asset-urls';
 import { trackBackground } from '../lib/background';
 import { broadcastChange } from '../lib/broadcast';
 import { validateCredentialValue } from '../lib/credential-validator';
-import { resolveActorMemberId, resolveTaskId } from '../lib/resolve';
+import { resolveActor, resolveActorMemberId, resolveTaskId } from '../lib/resolve';
 import { err, ok } from '../lib/response';
 import { withTransaction } from '../lib/sql';
 import type { Env } from '../lib/types';
@@ -515,6 +515,17 @@ commentsRoutes.post(
 		}
 
 		broadcastChange(c, wsRoom.team(teamId), 'task_comments', 'UPDATE', updatedComment);
+		const actor = await resolveActor(db, c.get('auth'), teamId);
+		c.get('events').emit({
+			type: 'credential.fulfilled',
+			teamId,
+			projectId,
+			actorType: actor.actorType,
+			actorMemberId: actor.actorMemberId,
+			secretId,
+			name,
+			requestingAgentId,
+		});
 		return ok(c, { secret_id: secretId, comment_id: commentId });
 	},
 );

--- a/packages/server/src/routes/mcp-connections.ts
+++ b/packages/server/src/routes/mcp-connections.ts
@@ -2,6 +2,7 @@ import { getConnectorCapability, McpConnectionKind, wsRoom } from '@hezo/shared'
 import { Hono } from 'hono';
 import { trackBackground } from '../lib/background';
 import { broadcastChange } from '../lib/broadcast';
+import { resolveActor } from '../lib/resolve';
 import { err, ok } from '../lib/response';
 import type { Env } from '../lib/types';
 import { logger } from '../logger';
@@ -102,6 +103,15 @@ mcpConnectionsRoutes.post('/mcp-connections', async (c) => {
 		[body.name.trim(), body.display_name?.trim() ?? null, body.kind, JSON.stringify(body.config)],
 	);
 
+	const createdRow = result.rows[0] as { id: string; name: string };
+	c.get('events').emit({
+		type: 'mcp_connection.created',
+		teamId: null,
+		actorType: 'admin',
+		actorMemberId: null,
+		connectionId: createdRow.id,
+		name: createdRow.name,
+	});
 	return ok(c, result.rows[0], 201);
 });
 
@@ -110,13 +120,21 @@ mcpConnectionsRoutes.delete('/mcp-connections/:id', async (c) => {
 	if (denied) return denied;
 	const db = c.get('db');
 	const id = c.req.param('id');
-	const result = await db.query<{ id: string }>(
-		'DELETE FROM mcp_connections WHERE id = $1 AND team_id IS NULL RETURNING id',
+	const result = await db.query<{ id: string; name: string }>(
+		'DELETE FROM mcp_connections WHERE id = $1 AND team_id IS NULL RETURNING id, name',
 		[id],
 	);
 	if (result.rows.length === 0) {
 		return err(c, 'NOT_FOUND', 'instance connector not found', 404);
 	}
+	c.get('events').emit({
+		type: 'mcp_connection.deleted',
+		teamId: null,
+		actorType: 'admin',
+		actorMemberId: null,
+		connectionId: result.rows[0].id,
+		name: result.rows[0].name,
+	});
 	return c.json({ data: null }, 200);
 });
 
@@ -142,10 +160,11 @@ mcpConnectionsRoutes.post('/teams/:teamId/mcp-connections/:id/revoke', async (c)
 	const db = c.get('db');
 	const id = c.req.param('id');
 	const { markRevoked } = await import('../services/connectors/lifecycle');
-	const existing = await db.query<{ team_id: string; oauth_connection_id: string | null }>(
-		`SELECT team_id, oauth_connection_id FROM mcp_connections WHERE id = $1`,
-		[id],
-	);
+	const existing = await db.query<{
+		team_id: string;
+		name: string;
+		oauth_connection_id: string | null;
+	}>(`SELECT team_id, name, oauth_connection_id FROM mcp_connections WHERE id = $1`, [id]);
 	if (existing.rows.length === 0) return err(c, 'NOT_FOUND', 'connector not found', 404);
 	if (existing.rows[0].team_id !== teamId)
 		return err(c, 'FORBIDDEN', 'connector does not belong to this team', 403);
@@ -153,15 +172,39 @@ mcpConnectionsRoutes.post('/teams/:teamId/mcp-connections/:id/revoke', async (c)
 	if (existing.rows[0].oauth_connection_id) {
 		const { deleteConnection } = await import('../services/oauth/connection-store');
 		const masterKeyManager = c.get('masterKeyManager');
-		await deleteConnection({ db, masterKeyManager }, existing.rows[0].oauth_connection_id).catch(
-			(e) =>
+		const oauthConnectionId = existing.rows[0].oauth_connection_id;
+		await deleteConnection({ db, masterKeyManager }, oauthConnectionId)
+			.then(() => {
+				const a = resolveActor(db, c.get('auth'), teamId);
+				return a.then((actor) =>
+					c.get('events').emit({
+						type: 'connection.deleted',
+						teamId,
+						actorType: actor.actorType,
+						actorMemberId: actor.actorMemberId,
+						connectionId: oauthConnectionId,
+						provider: existing.rows[0].name,
+					}),
+				);
+			})
+			.catch((e) =>
 				log.warn('failed to delete oauth_connection on revoke', { error: (e as Error).message }),
-		);
+			);
 	}
 	broadcastChange(c, wsRoom.team(teamId), 'mcp_connections', 'UPDATE', {
 		id,
 		team_id: teamId,
 		status: 'revoked',
+	});
+	const revokeActor = await resolveActor(db, c.get('auth'), teamId);
+	c.get('events').emit({
+		type: 'mcp_connection.updated',
+		teamId,
+		actorType: revokeActor.actorType,
+		actorMemberId: revokeActor.actorMemberId,
+		connectionId: id,
+		name: existing.rows[0].name,
+		changeKind: 'revoked',
 	});
 	return ok(c, row);
 });
@@ -230,6 +273,17 @@ mcpConnectionsRoutes.post('/teams/:teamId/mcp-connections', async (c) => {
 
 	const inserted = result.rows[0] as Record<string, unknown>;
 	broadcastChange(c, wsRoom.team(teamId), 'mcp_connections', 'INSERT', inserted);
+
+	const createActor = await resolveActor(db, c.get('auth'), teamId);
+	c.get('events').emit({
+		type: 'mcp_connection.created',
+		teamId,
+		projectId: body.project_id ?? null,
+		actorType: createActor.actorType,
+		actorMemberId: createActor.actorMemberId,
+		connectionId: inserted.id as string,
+		name: inserted.name as string,
+	});
 
 	// Kick off install for local MCPs against any running project containers.
 	// We don't block the response — the route returns immediately and the
@@ -313,6 +367,15 @@ mcpConnectionsRoutes.post('/teams/:teamId/connectors/ensure', async (c) => {
 	});
 	if (!alreadyExisted) {
 		broadcastChange(c, wsRoom.team(teamId), 'mcp_connections', 'INSERT', { id: row.id });
+		const ensureActor = await resolveActor(db, c.get('auth'), teamId);
+		c.get('events').emit({
+			type: 'mcp_connection.created',
+			teamId,
+			actorType: ensureActor.actorType,
+			actorMemberId: ensureActor.actorMemberId,
+			connectionId: row.id as string,
+			name: row.name as string,
+		});
 	}
 	return ok(c, row);
 });
@@ -322,13 +385,22 @@ mcpConnectionsRoutes.delete('/teams/:teamId/mcp-connections/:id', async (c) => {
 	const db = c.get('db');
 	const id = c.req.param('id');
 
-	const result = await db.query<{ id: string }>(
-		'DELETE FROM mcp_connections WHERE id = $1 AND team_id = $2 RETURNING id',
+	const result = await db.query<{ id: string; name: string }>(
+		'DELETE FROM mcp_connections WHERE id = $1 AND team_id = $2 RETURNING id, name',
 		[id, teamId],
 	);
 	if (result.rows.length === 0) {
 		return err(c, 'NOT_FOUND', 'MCP connection not found', 404);
 	}
 	broadcastChange(c, wsRoom.team(teamId), 'mcp_connections', 'DELETE', { id });
+	const deleteActor = await resolveActor(db, c.get('auth'), teamId);
+	c.get('events').emit({
+		type: 'mcp_connection.deleted',
+		teamId,
+		actorType: deleteActor.actorType,
+		actorMemberId: deleteActor.actorMemberId,
+		connectionId: result.rows[0].id,
+		name: result.rows[0].name,
+	});
 	return c.json({ data: null }, 200);
 });

--- a/packages/server/src/routes/oauth.ts
+++ b/packages/server/src/routes/oauth.ts
@@ -146,6 +146,17 @@ oauthRoutes.get('/oauth/callback', async (c) => {
 		provider_account_label: conn.providerAccountLabel,
 	});
 
+	// The callback is an unauthenticated browser redirect (state is signed), so
+	// the acting member can't be resolved here — attribute to the admin actor.
+	c.get('events').emit({
+		type: 'connection.created',
+		teamId: payload.teamId,
+		actorType: 'admin',
+		actorMemberId: null,
+		connectionId: conn.id,
+		provider: conn.provider,
+	});
+
 	return c.html(buildCallbackPage('success', undefined, payload.returnTo), 200);
 });
 

--- a/packages/server/src/routes/project-docs.ts
+++ b/packages/server/src/routes/project-docs.ts
@@ -1,7 +1,7 @@
 import { ApprovalType, AuthType, DocumentType, isMarkdownDocSlug } from '@hezo/shared';
 import { Hono } from 'hono';
 import { resolveAgentsMdPath } from '../lib/docs';
-import { resolveActorMemberId, resolveProjectId } from '../lib/resolve';
+import { actorTypeFromAuth, resolveActorMemberId, resolveProjectId } from '../lib/resolve';
 import { err, ok } from '../lib/response';
 import type { Env } from '../lib/types';
 import { broadcastApprovalChange } from '../services/approval-broadcast';
@@ -110,6 +110,7 @@ projectDocsRoutes.put('/teams/:teamId/projects/:projectId/docs/:filename', async
 		content: body.content,
 		changeSummary: body.change_summary,
 		authorMemberId: memberId,
+		audit: { events: c.get('events'), actorType: actorTypeFromAuth(auth) },
 	});
 
 	return ok(c, {
@@ -127,12 +128,18 @@ projectDocsRoutes.delete('/teams/:teamId/projects/:projectId/docs/:filename', as
 	const projectId = await resolveProjectId(db, teamId, c.req.param('projectId'));
 	if (!projectId) return err(c, 'NOT_FOUND', 'Project not found', 404);
 
-	const removed = await deleteDocument(db, c.get('wsManager'), {
-		type: DocumentType.ProjectDoc,
-		teamId: teamId,
-		projectId,
-		slug: filename,
-	});
+	const actorMemberId = await resolveActorMemberId(db, c.get('auth'), teamId);
+	const removed = await deleteDocument(
+		db,
+		c.get('wsManager'),
+		{
+			type: DocumentType.ProjectDoc,
+			teamId: teamId,
+			projectId,
+			slug: filename,
+		},
+		{ events: c.get('events'), actorType: actorTypeFromAuth(c.get('auth')), actorMemberId },
+	);
 	if (!removed) return err(c, 'NOT_FOUND', `Document '${filename}' not found`, 404);
 
 	return c.json({ data: null }, 200);
@@ -188,6 +195,7 @@ projectDocsRoutes.post('/teams/:teamId/projects/:projectId/docs/:filename/restor
 		documentId: doc.id,
 		revisionNumber: body.revision_number,
 		restoredByMemberId,
+		audit: { events: c.get('events'), actorType: actorTypeFromAuth(auth) },
 	});
 	if (!restored) return err(c, 'NOT_FOUND', 'Revision not found', 404);
 

--- a/packages/server/src/routes/secrets.ts
+++ b/packages/server/src/routes/secrets.ts
@@ -1,6 +1,7 @@
 import { SecretCategory, wsRoom } from '@hezo/shared';
 import { Hono } from 'hono';
 import { broadcastChange } from '../lib/broadcast';
+import { resolveActor } from '../lib/resolve';
 import { err, ok } from '../lib/response';
 import type { Env } from '../lib/types';
 import { requireSuperuser } from '../middleware/auth';
@@ -94,6 +95,15 @@ secretsRoutes.post('/secrets', async (c) => {
 			allowAllHosts,
 		],
 	);
+	const created = result.rows[0] as { id: string; name: string };
+	c.get('events').emit({
+		type: 'secret.created',
+		teamId: null,
+		actorType: 'admin',
+		actorMemberId: null,
+		secretId: created.id,
+		name: created.name,
+	});
 	return ok(c, result.rows[0], 201);
 });
 
@@ -161,6 +171,15 @@ secretsRoutes.patch('/secrets/:secretId', async (c) => {
 		 RETURNING id, team_id, project_id, name, category, allowed_hosts, allow_all_hosts, created_at, updated_at`,
 		params,
 	);
+	const updated = result.rows[0] as { id: string; name: string };
+	c.get('events').emit({
+		type: 'secret.updated',
+		teamId: null,
+		actorType: 'admin',
+		actorMemberId: null,
+		secretId: updated.id,
+		name: updated.name,
+	});
 	return ok(c, result.rows[0]);
 });
 
@@ -170,13 +189,21 @@ secretsRoutes.delete('/secrets/:secretId', async (c) => {
 	const db = c.get('db');
 	const secretId = c.req.param('secretId');
 
-	const result = await db.query(
-		'DELETE FROM secrets WHERE id = $1 AND team_id IS NULL RETURNING id',
+	const result = await db.query<{ id: string; name: string }>(
+		'DELETE FROM secrets WHERE id = $1 AND team_id IS NULL RETURNING id, name',
 		[secretId],
 	);
 	if (result.rows.length === 0) {
 		return err(c, 'NOT_FOUND', 'Secret not found', 404);
 	}
+	c.get('events').emit({
+		type: 'secret.deleted',
+		teamId: null,
+		actorType: 'admin',
+		actorMemberId: null,
+		secretId: result.rows[0].id,
+		name: result.rows[0].name,
+	});
 	return c.json({ data: null }, 200);
 });
 
@@ -296,6 +323,17 @@ secretsRoutes.post('/teams/:teamId/secrets', async (c) => {
 		'INSERT',
 		result.rows[0] as Record<string, unknown>,
 	);
+	const createdRow = result.rows[0] as { id: string; name: string };
+	const actor = await resolveActor(db, c.get('auth'), teamId);
+	c.get('events').emit({
+		type: 'secret.created',
+		teamId,
+		projectId: body.project_id ?? null,
+		actorType: actor.actorType,
+		actorMemberId: actor.actorMemberId,
+		secretId: createdRow.id,
+		name: createdRow.name,
+	});
 	return ok(c, result.rows[0], 201);
 });
 
@@ -367,6 +405,17 @@ secretsRoutes.patch('/teams/:teamId/secrets/:secretId', async (c) => {
 		params,
 	);
 
+	const updatedRow = result.rows[0] as { id: string; name: string; project_id: string | null };
+	const actor = await resolveActor(db, c.get('auth'), teamId);
+	c.get('events').emit({
+		type: 'secret.updated',
+		teamId,
+		projectId: updatedRow.project_id,
+		actorType: actor.actorType,
+		actorMemberId: actor.actorMemberId,
+		secretId: updatedRow.id,
+		name: updatedRow.name,
+	});
 	return ok(c, result.rows[0]);
 });
 
@@ -375,16 +424,26 @@ secretsRoutes.delete('/teams/:teamId/secrets/:secretId', async (c) => {
 	const db = c.get('db');
 	const secretId = c.req.param('secretId');
 
-	const existing = await db.query('SELECT id FROM secrets WHERE id = $1 AND team_id = $2', [
-		secretId,
-		teamId,
-	]);
+	const existing = await db.query<{ id: string; name: string; project_id: string | null }>(
+		'SELECT id, name, project_id FROM secrets WHERE id = $1 AND team_id = $2',
+		[secretId, teamId],
+	);
 	if (existing.rows.length === 0) {
 		return err(c, 'NOT_FOUND', 'Secret not found', 404);
 	}
 
 	await db.query('DELETE FROM secrets WHERE id = $1', [secretId]);
 	broadcastChange(c, wsRoom.team(teamId), 'secrets', 'DELETE', { id: secretId });
+	const actor = await resolveActor(db, c.get('auth'), teamId);
+	c.get('events').emit({
+		type: 'secret.deleted',
+		teamId,
+		projectId: existing.rows[0].project_id,
+		actorType: actor.actorType,
+		actorMemberId: actor.actorMemberId,
+		secretId: existing.rows[0].id,
+		name: existing.rows[0].name,
+	});
 	return c.json({ data: null }, 200);
 });
 

--- a/packages/server/src/routes/skills.ts
+++ b/packages/server/src/routes/skills.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 import type { SkillRecord } from '@hezo/shared';
-import { Hono } from 'hono';
+import { type Context, Hono } from 'hono';
+import { resolveActor } from '../lib/resolve';
 import { err, ok } from '../lib/response';
 import { deriveSkillSummary } from '../lib/skill-summary';
 import { toSlug } from '../lib/slug';
@@ -9,6 +10,24 @@ import { requireSuperuser } from '../middleware/auth';
 import { downloadSkillContent, SkillDownloadError } from '../services/skill-downloader';
 
 export const skillsRoutes = new Hono<Env>();
+
+async function emitSkill(
+	c: Context<Env>,
+	teamId: string,
+	type: 'skill.created' | 'skill.updated' | 'skill.deleted',
+	skill: { id: string; slug: string; name: string },
+): Promise<void> {
+	const actor = await resolveActor(c.get('db'), c.get('auth'), teamId);
+	c.get('events').emit({
+		type,
+		teamId,
+		actorType: actor.actorType,
+		actorMemberId: actor.actorMemberId,
+		skillId: skill.id,
+		slug: skill.slug,
+		name: skill.name,
+	});
+}
 
 function downloadErrorStatus(reason: SkillDownloadError['reason']): 400 | 404 | 422 | 503 {
 	switch (reason) {
@@ -74,7 +93,17 @@ skillsRoutes.post('/skills', async (c) => {
 		 RETURNING *`,
 		[body.name.trim(), slug, description, content, hash, JSON.stringify(body.tags ?? [])],
 	);
-	return ok(c, result.rows[0], 201);
+	const skill = result.rows[0];
+	c.get('events').emit({
+		type: 'skill.created',
+		teamId: null,
+		actorType: 'admin',
+		actorMemberId: null,
+		skillId: skill.id,
+		slug: skill.slug,
+		name: skill.name,
+	});
+	return ok(c, skill, 201);
 });
 
 skillsRoutes.get('/skills/:slug', async (c) => {
@@ -161,6 +190,15 @@ skillsRoutes.patch('/skills/:slug', async (c) => {
 			[skill.id, nextRev, body.content, skill.content_hash],
 		);
 	}
+	c.get('events').emit({
+		type: 'skill.updated',
+		teamId: null,
+		actorType: 'admin',
+		actorMemberId: null,
+		skillId: skill.id,
+		slug: skill.slug,
+		name: skill.name,
+	});
 	return ok(c, skill);
 });
 
@@ -169,13 +207,22 @@ skillsRoutes.delete('/skills/:slug', async (c) => {
 	if (denied) return denied;
 	const db = c.get('db');
 	const slug = c.req.param('slug');
-	const result = await db.query(
-		'DELETE FROM skills WHERE team_id IS NULL AND slug = $1 RETURNING id',
+	const result = await db.query<{ id: string; name: string }>(
+		'DELETE FROM skills WHERE team_id IS NULL AND slug = $1 RETURNING id, name',
 		[slug],
 	);
 	if (result.rows.length === 0) {
 		return err(c, 'NOT_FOUND', 'Skill not found', 404);
 	}
+	c.get('events').emit({
+		type: 'skill.deleted',
+		teamId: null,
+		actorType: 'admin',
+		actorMemberId: null,
+		skillId: result.rows[0].id,
+		slug,
+		name: result.rows[0].name,
+	});
 	return c.json({ data: null }, 200);
 });
 
@@ -270,6 +317,7 @@ skillsRoutes.post('/teams/:teamId/skills', async (c) => {
 			[skill.id, content, hash],
 		);
 
+		await emitSkill(c, teamId, 'skill.created', skill);
 		return ok(c, skill, 201);
 	}
 
@@ -310,6 +358,7 @@ skillsRoutes.post('/teams/:teamId/skills', async (c) => {
 			[skill.id, content, hash],
 		);
 
+		await emitSkill(c, teamId, 'skill.created', skill);
 		return ok(c, skill, 201);
 	} catch (e) {
 		if (e instanceof SkillDownloadError) {
@@ -397,6 +446,7 @@ skillsRoutes.patch('/teams/:teamId/skills/:slug', async (c) => {
 		);
 	}
 
+	await emitSkill(c, teamId, 'skill.updated', skill);
 	return ok(c, skill);
 });
 
@@ -456,8 +506,8 @@ skillsRoutes.delete('/teams/:teamId/skills/:slug', async (c) => {
 	const db = c.get('db');
 	const slug = c.req.param('slug');
 
-	const result = await db.query(
-		'DELETE FROM skills WHERE team_id = $1 AND slug = $2 RETURNING id',
+	const result = await db.query<{ id: string; name: string }>(
+		'DELETE FROM skills WHERE team_id = $1 AND slug = $2 RETURNING id, name',
 		[teamId, slug],
 	);
 
@@ -465,5 +515,10 @@ skillsRoutes.delete('/teams/:teamId/skills/:slug', async (c) => {
 		return err(c, 'NOT_FOUND', 'Skill not found', 404);
 	}
 
+	await emitSkill(c, teamId, 'skill.deleted', {
+		id: result.rows[0].id,
+		slug,
+		name: result.rows[0].name,
+	});
 	return c.json({ data: null }, 200);
 });

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -21,6 +21,7 @@ import {
 import { assertInternalAssignee } from '../lib/internal-assignee';
 import { buildMeta, parsePagination } from '../lib/pagination';
 import {
+	actorTypeFromAuth,
 	getProjectLocator,
 	resolveActorMemberId as resolveAuthActorMemberId,
 	resolveProjectId,
@@ -46,10 +47,6 @@ import { createWakeup } from '../services/wakeup';
 const log = logger.child('routes');
 
 const MAX_BATCH_TASKS = 50;
-
-function actorTypeFromAuth(auth: AuthInfo): AuditActorType {
-	return auth.type === AuthType.Agent ? AuditActorType.Agent : AuditActorType.Admin;
-}
 
 async function buildCreateTaskCaller(c: Context<Env>, teamId: string): Promise<CreateTaskCaller> {
 	const auth = c.get('auth');
@@ -236,7 +233,7 @@ tasksRoutes.post('/teams/:teamId/tasks', async (c) => {
 	const caller = await buildCreateTaskCaller(c, teamId);
 
 	try {
-		const task = await createTask(db, teamId, body, caller, c.get('wsManager'));
+		const task = await createTask(db, teamId, body, caller, c.get('wsManager'), c.get('events'));
 		return ok(c, task, 201);
 	} catch (e) {
 		if (e instanceof CreateTaskError) {
@@ -265,11 +262,19 @@ tasksRoutes.post('/teams/:teamId/tasks/batch', async (c) => {
 
 	const caller = await buildCreateTaskCaller(c, teamId);
 	const wsManager = c.get('wsManager');
+	const events = c.get('events');
 
 	const results = await Promise.all(
 		raw.map(async (item, index) => {
 			try {
-				const task = await createTask(db, teamId, item as CreateTaskInput, caller, wsManager);
+				const task = await createTask(
+					db,
+					teamId,
+					item as CreateTaskInput,
+					caller,
+					wsManager,
+					events,
+				);
 				return { index, ok: true as const, task };
 			} catch (e) {
 				if (e instanceof CreateTaskError) {
@@ -578,6 +583,9 @@ tasksRoutes.patch('/teams/:teamId/tasks/:taskId', async (c) => {
 	}
 
 	const actorMemberId = await resolveActorMemberId(c, teamId);
+	const events = c.get('events');
+	const actorType = actorTypeFromAuth(c.get('auth'));
+	const projectId = existing.rows[0].project_id;
 
 	if (body.description !== undefined) {
 		trackBackground(
@@ -603,6 +611,17 @@ tasksRoutes.patch('/teams/:teamId/tasks/:taskId', async (c) => {
 				actorMemberId,
 				c.get('wsManager'),
 			);
+			events?.emit({
+				type: 'task.updated',
+				teamId,
+				projectId,
+				actorType,
+				actorMemberId,
+				taskId,
+				field: 'title',
+				from: existing.rows[0].title,
+				to: body.title.trim(),
+			});
 		} catch (e) {
 			log.error('Failed to record title change:', e);
 		}
@@ -619,6 +638,17 @@ tasksRoutes.patch('/teams/:teamId/tasks/:taskId', async (c) => {
 				actorMemberId,
 				c.get('wsManager'),
 			);
+			events?.emit({
+				type: 'task.updated',
+				teamId,
+				projectId,
+				actorType,
+				actorMemberId,
+				taskId,
+				field: 'assignee',
+				from: existing.rows[0].assignee_id,
+				to: body.assignee_id,
+			});
 		} catch (e) {
 			log.error('Failed to record assignee change:', e);
 		}
@@ -637,6 +667,23 @@ tasksRoutes.patch('/teams/:teamId/tasks/:taskId', async (c) => {
 			);
 		} catch (e) {
 			log.error('Failed to trigger status automations:', e);
+		}
+
+		{
+			const newStatus = (result.rows[0] as Record<string, unknown>).status as string;
+			if (newStatus !== existing.rows[0].status) {
+				events?.emit({
+					type: 'task.updated',
+					teamId,
+					projectId,
+					actorType,
+					actorMemberId,
+					taskId,
+					field: 'status',
+					from: existing.rows[0].status,
+					to: newStatus,
+				});
+			}
 		}
 
 		if (body.status === TaskStatus.Closed || body.status === TaskStatus.Cancelled) {
@@ -715,6 +762,7 @@ tasksRoutes.post('/teams/:teamId/tasks/:taskId/sub-tasks', async (c) => {
 			},
 			caller,
 			c.get('wsManager'),
+			c.get('events'),
 		);
 		return ok(c, subTask, 201);
 	} catch (e) {

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -25,6 +25,7 @@ import {
 	wsRoom,
 } from '@hezo/shared';
 import type { MasterKeyManager } from '../crypto/master-key';
+import type { DomainEventBus } from '../events/bus';
 import { broadcastRowChange } from '../lib/broadcast';
 import { withTransaction } from '../lib/sql';
 import { signAgentJwt } from '../middleware/auth';
@@ -116,6 +117,7 @@ export interface RunnerDeps {
 	serverPort: number;
 	dataDir: string;
 	wsManager?: WebSocketManager;
+	events?: DomainEventBus;
 	logs: LogStreamBroker;
 	sshAgentServer?: SshAgentServer;
 	egressProxy?: EgressProxy | null;
@@ -482,7 +484,9 @@ export async function runAgent(
 
 	const runBroadcast: HeartbeatRunBroadcast = {
 		wsManager: deps.wsManager,
+		events: deps.events,
 		teamId: agent.team_id,
+		projectId: project.id,
 		taskId: task.id,
 		memberId: agent.id,
 	};
@@ -496,6 +500,7 @@ export async function runAgent(
 		effectiveWakeupId,
 	);
 	onRunRegistered?.(heartbeatRunId);
+	await emitRunStarted(deps, heartbeatRunId, agent, task, project, effectiveWakeupId);
 	const streamId = `run:${heartbeatRunId}`;
 
 	deps.logs.begin({
@@ -1448,7 +1453,9 @@ export async function buildCoachReviewPrompt(
 
 export interface HeartbeatRunBroadcast {
 	wsManager?: WebSocketManager;
+	events?: DomainEventBus;
 	teamId: string;
+	projectId?: string;
 	taskId: string;
 	memberId: string;
 }
@@ -1598,4 +1605,54 @@ async function updateHeartbeatRun(
 		],
 	);
 	broadcastHeartbeatRunChange(broadcast, runId, update.status, 'UPDATE');
+	broadcast.events?.emit({
+		type: 'agent_run.completed',
+		teamId: broadcast.teamId,
+		projectId: broadcast.projectId ?? null,
+		runId,
+		taskId: broadcast.taskId,
+		agentMemberId: broadcast.memberId,
+		status: update.status as HeartbeatRunStatus,
+		exitCode: update.exitCode,
+		error: update.error ?? null,
+	});
+}
+
+/**
+ * Emit `agent_run.started` once the run row exists. Looks up the wakeup's source
+ * and a light triggered-by hint for the audit trail.
+ */
+async function emitRunStarted(
+	deps: RunnerDeps,
+	runId: string,
+	agent: AgentInfo,
+	task: TaskInfo,
+	project: ProjectInfo,
+	wakeupId: string,
+): Promise<void> {
+	if (!deps.events) return;
+	let triggerSource: string | null = null;
+	let triggeredBy: string | null = null;
+	try {
+		const r = await deps.db.query<{ source: string; payload: Record<string, unknown> | null }>(
+			'SELECT source, payload FROM agent_wakeup_requests WHERE id = $1',
+			[wakeupId],
+		);
+		triggerSource = r.rows[0]?.source ?? null;
+		const payload = r.rows[0]?.payload;
+		const by = payload?.author_member_id ?? payload?.reason;
+		triggeredBy = typeof by === 'string' ? by : null;
+	} catch {
+		// Best-effort enrichment; the started event still fires without it.
+	}
+	deps.events.emit({
+		type: 'agent_run.started',
+		teamId: agent.team_id,
+		projectId: project.id,
+		runId,
+		taskId: task.id,
+		agentMemberId: agent.id,
+		triggerSource,
+		triggeredBy,
+	});
 }

--- a/packages/server/src/services/approval-resolve.ts
+++ b/packages/server/src/services/approval-resolve.ts
@@ -1,5 +1,6 @@
 import type { PGlite } from '@electric-sql/pglite';
 import { ApprovalStatus, ApprovalType } from '@hezo/shared';
+import type { DomainEventBus } from '../events/bus';
 import {
 	applyApprovalDeniedSideEffect,
 	applyApprovalSideEffect,
@@ -19,6 +20,7 @@ export interface ResolveApprovalInput {
 	actorMemberId: string | null;
 	wsManager?: WebSocketManager;
 	containerDeps?: ContainerDeps;
+	events?: DomainEventBus;
 }
 
 export type ResolveApprovalResult =
@@ -57,6 +59,7 @@ export async function resolveApproval(
 			input.actorMemberId,
 			input.wsManager,
 			input.containerDeps,
+			input.events,
 		);
 	} else if (
 		existing.rows[0].type === ApprovalType.TeamTemplate ||

--- a/packages/server/src/services/approval-side-effects.ts
+++ b/packages/server/src/services/approval-side-effects.ts
@@ -10,6 +10,7 @@ import {
 	WakeupSource,
 	wsRoom,
 } from '@hezo/shared';
+import type { DomainEventBus } from '../events/bus';
 import { trackBackground } from '../lib/background';
 import { broadcastRowChange } from '../lib/broadcast';
 import { toSlug, uniqueSlug } from '../lib/slug';
@@ -81,6 +82,7 @@ export async function applyApprovalSideEffect(
 	actorMemberId: string | null,
 	wsManager?: WebSocketManager,
 	containerDeps?: ContainerDeps,
+	events?: DomainEventBus,
 ): Promise<SideEffectBroadcast[]> {
 	const payload = approval.payload as Record<string, unknown>;
 	const broadcasts: SideEffectBroadcast[] = [];
@@ -307,6 +309,9 @@ export async function applyApprovalSideEffect(
 						slug: projectSlug,
 						taskPrefix: prefixResult.prefix,
 						description: projectDescription,
+						events,
+						actorType: 'admin',
+						actorMemberId,
 					});
 
 				broadcastRowChange(wsManager, wsRoom.team(teamId), 'projects', 'INSERT', project);
@@ -391,6 +396,9 @@ export async function applyApprovalSideEffect(
 				taskPrefix: prefixResult.prefix,
 				description: projectDescription,
 				initialPrd,
+				events,
+				actorType: 'admin',
+				actorMemberId,
 			});
 
 			if (wsManager) {

--- a/packages/server/src/services/documents.ts
+++ b/packages/server/src/services/documents.ts
@@ -1,8 +1,36 @@
 import type { PGlite } from '@electric-sql/pglite';
-import { DocumentType, wsRoom } from '@hezo/shared';
+import { type AuditActorType, DocumentType, wsRoom } from '@hezo/shared';
+import type { DomainEventBus } from '../events/bus';
 import { broadcastRowChange } from '../lib/broadcast';
 import { withTransaction } from '../lib/sql';
 import type { WebSocketManager } from './ws';
+
+/** Audit context shared by document mutations. */
+export interface DocumentAuditContext {
+	events?: DomainEventBus;
+	actorType?: AuditActorType;
+}
+
+function emitDocumentEvent(
+	ctx: DocumentAuditContext | undefined,
+	type: 'document.created' | 'document.updated' | 'document.deleted',
+	row: DocumentRow,
+	actorMemberId: string | null,
+): void {
+	if (!ctx?.events) return;
+	ctx.events.emit({
+		type,
+		teamId: row.team_id,
+		projectId: row.project_id,
+		actorType: ctx.actorType ?? 'admin',
+		actorMemberId,
+		documentId: row.id,
+		documentType: row.type,
+		slug: row.slug,
+		title: row.title,
+		agentMemberId: row.type === DocumentType.AgentSystemPrompt ? row.member_agent_id : null,
+	});
+}
 
 export interface DocumentRow {
 	id: string;
@@ -146,6 +174,8 @@ export interface UpsertDocumentInput {
 	content: string;
 	changeSummary?: string;
 	authorMemberId: string | null;
+	/** Optional audit context — when present, a document event is emitted. */
+	audit?: DocumentAuditContext;
 }
 
 export async function upsertDocument(
@@ -193,6 +223,12 @@ export async function upsertDocument(
 		'documents',
 		action,
 		row as unknown as Record<string, unknown>,
+	);
+	emitDocumentEvent(
+		input.audit,
+		action === 'INSERT' ? 'document.created' : 'document.updated',
+		row,
+		input.authorMemberId,
 	);
 	return row;
 }
@@ -250,6 +286,7 @@ export async function deleteDocument(
 	db: PGlite,
 	wsManager: WebSocketManager | undefined,
 	scope: DocumentScope,
+	audit?: DocumentAuditContext & { actorMemberId?: string | null },
 ): Promise<{ id: string; type: DocumentType } | null> {
 	const where = scopeWhere(scope, '');
 	const result = await db.query<DocumentRow>(
@@ -265,6 +302,7 @@ export async function deleteDocument(
 		'DELETE',
 		row as unknown as Record<string, unknown>,
 	);
+	emitDocumentEvent(audit, 'document.deleted', row, audit?.actorMemberId ?? null);
 	return { id: row.id, type: row.type };
 }
 
@@ -288,6 +326,7 @@ export interface RestoreRevisionInput {
 	documentId: string;
 	revisionNumber: number;
 	restoredByMemberId: string | null;
+	audit?: DocumentAuditContext;
 }
 
 export async function restoreRevision(
@@ -332,6 +371,7 @@ export async function restoreRevision(
 		'UPDATE',
 		row as unknown as Record<string, unknown>,
 	);
+	emitDocumentEvent(input.audit, 'document.updated', row, input.restoredByMemberId);
 	return row;
 }
 

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -18,6 +18,7 @@ import {
 } from '@hezo/shared';
 import { Cron } from 'cron-async';
 import type { MasterKeyManager } from '../crypto/master-key';
+import type { DomainEventBus } from '../events/bus';
 import { trackBackground } from '../lib/background';
 import { broadcastRowChange } from '../lib/broadcast';
 import { shouldDeferWakeupForBlockers } from '../lib/dependencies';
@@ -99,6 +100,7 @@ export interface JobManagerDeps {
 	serverPort: number;
 	dataDir: string;
 	wsManager: WebSocketManager;
+	events?: DomainEventBus;
 	logs: LogStreamBroker;
 	containerLogStreamer: ContainerLogStreamer;
 	sshAgentServer?: SshAgentServer;
@@ -1208,6 +1210,7 @@ export class JobManager {
 			serverPort,
 			dataDir: this.deps.dataDir,
 			wsManager: this.deps.wsManager,
+			events: this.deps.events,
 			logs: this.deps.logs,
 			sshAgentServer: this.deps.sshAgentServer,
 			egressProxy: this.deps.egressProxy ?? null,

--- a/packages/server/src/services/project-create.ts
+++ b/packages/server/src/services/project-create.ts
@@ -1,5 +1,6 @@
 import type { PGlite } from '@electric-sql/pglite';
-import { TaskPriority, TaskStatus } from '@hezo/shared';
+import { type AuditActorType, TaskPriority, TaskStatus } from '@hezo/shared';
+import type { DomainEventBus } from '../events/bus';
 import { withTransaction } from '../lib/sql';
 import { allocateTaskIdentifier } from '../lib/task-identifier';
 
@@ -50,6 +51,10 @@ export interface CreateProjectWithPlanningInput {
 	description: string;
 	dockerBaseImage?: string;
 	initialPrd?: string | null;
+	/** Optional audit context: who created the project and the bus to emit on. */
+	events?: DomainEventBus;
+	actorType?: AuditActorType;
+	actorMemberId?: string | null;
 }
 
 export interface CreateProjectWithPlanningResult {
@@ -67,7 +72,7 @@ export async function createProjectWithPlanningTask(
 	const projectDescription = input.description.trim();
 	const initialPrd = input.initialPrd?.trim() || null;
 
-	return withTransaction(db, async () => {
+	const result = await withTransaction(db, async () => {
 		await db.query('SELECT id FROM teams WHERE id = $1 FOR UPDATE', [input.teamId]);
 		const countResult = await db.query<{ count: string }>(
 			`SELECT count(*)::text AS count FROM projects
@@ -165,4 +170,16 @@ Container provisioning for this project is in progress. Focus on planning while 
 
 		return { project, planningTask, deferCaptainPlanningWake };
 	});
+
+	input.events?.emit({
+		type: 'project.created',
+		teamId: input.teamId,
+		projectId: result.project.id as string,
+		actorType: input.actorType ?? 'admin',
+		actorMemberId: input.actorMemberId ?? null,
+		name: result.project.name as string,
+		slug: result.project.slug as string,
+	});
+
+	return result;
 }

--- a/packages/server/src/services/tasks.ts
+++ b/packages/server/src/services/tasks.ts
@@ -1,15 +1,7 @@
 import type { PGlite } from '@electric-sql/pglite';
-import {
-	AuditAction,
-	type AuditActorType,
-	AuditEntityType,
-	TaskPriority,
-	TaskStatus,
-	WakeupSource,
-	wsRoom,
-} from '@hezo/shared';
+import { type AuditActorType, TaskPriority, TaskStatus, WakeupSource, wsRoom } from '@hezo/shared';
+import type { DomainEventBus } from '../events/bus';
 import { assertSubordinateAssignee } from '../lib/assignment-hierarchy';
-import { auditLog } from '../lib/audit';
 import { trackBackground } from '../lib/background';
 import { broadcastRowChange } from '../lib/broadcast';
 import { hasOpenBlockers, wouldCreateCycle } from '../lib/dependencies';
@@ -76,6 +68,7 @@ export async function createTask(
 	input: CreateTaskInput,
 	caller: CreateTaskCaller,
 	wsManager: WebSocketManager | undefined,
+	events?: DomainEventBus,
 ): Promise<TaskRow> {
 	const title = input.title?.trim();
 	if (!input.project_id || !title) {
@@ -169,18 +162,15 @@ export async function createTask(
 
 	broadcastRowChange(wsManager, wsRoom.team(teamId), 'tasks', 'INSERT', task);
 
-	trackBackground(
-		auditLog(
-			db,
-			teamId,
-			caller.actorType,
-			caller.actorMemberId,
-			AuditAction.Created,
-			AuditEntityType.Task,
-			task.id,
-			{ identifier },
-		).catch((e) => log.error('Failed to write audit log for task creation:', e)),
-	);
+	events?.emit({
+		type: 'task.created',
+		teamId,
+		projectId: input.project_id,
+		actorType: caller.actorType,
+		actorMemberId: caller.actorMemberId,
+		taskId: task.id,
+		identifier,
+	});
 
 	if (input.description) {
 		trackBackground(

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -10,6 +10,8 @@ const log = logger.child('startup');
 import { MasterKeyManager } from './crypto/master-key';
 import { openPersistentDb } from './db/client';
 import { BASE_SCHEMA } from './db/schema';
+import { registerAuditObserver } from './events/audit-observer';
+import { DomainEventBus } from './events/bus';
 import type { Env } from './lib/types';
 import { getToolDefs, handleMcpRequest, initMcpServer } from './mcp/server';
 import { generateSkillFile } from './mcp/skill-file';
@@ -118,6 +120,7 @@ export async function startup(config: HezoConfig): Promise<StartupResult> {
 	await cleanupOrphanRunSockets(db, config.dataDir);
 	const egressCA = await loadOrCreateCA(config.dataDir);
 	const egressProxy = new EgressProxy({ db, masterKeyManager, ca: egressCA });
+	const events = new DomainEventBus();
 	const jobManager = new JobManager({
 		db,
 		docker,
@@ -125,6 +128,7 @@ export async function startup(config: HezoConfig): Promise<StartupResult> {
 		serverPort: config.port,
 		dataDir: config.dataDir,
 		wsManager,
+		events,
 		logs,
 		containerLogStreamer,
 		sshAgentServer,
@@ -176,6 +180,7 @@ export async function startup(config: HezoConfig): Promise<StartupResult> {
 		sshAgentServer,
 		egressProxy,
 		containerLogStreamer,
+		events,
 	);
 
 	return {
@@ -205,9 +210,11 @@ export function buildApp(
 	sshAgentServer: SshAgentServer | null = null,
 	egressProxy: EgressProxy | null = null,
 	containerLogStreamer: ContainerLogStreamer = new ContainerLogStreamer(),
+	events: DomainEventBus = new DomainEventBus(),
 ): Hono<Env> {
 	const app = new Hono<Env>();
 	logs.setWsManager(wsManager);
+	registerAuditObserver(events, db);
 
 	app.onError((err, c) => {
 		log.error(`Route error on ${c.req.method} ${c.req.path}:`, err);
@@ -219,6 +226,7 @@ export function buildApp(
 		c.set('masterKeyManager', masterKeyManager);
 		c.set('docker', docker);
 		c.set('wsManager', wsManager);
+		c.set('events', events);
 		if (jobManager) c.set('jobManager', jobManager);
 		c.set('logs', logs);
 		c.set('containerLogStreamer', containerLogStreamer);
@@ -230,7 +238,7 @@ export function buildApp(
 	});
 
 	// Initialize MCP server
-	initMcpServer(db, config.dataDir, masterKeyManager, wsManager);
+	initMcpServer(db, config.dataDir, masterKeyManager, wsManager, events);
 
 	// Public routes
 	app.route('/', healthRoutes);

--- a/packages/server/test/audit-events.test.ts
+++ b/packages/server/test/audit-events.test.ts
@@ -1,0 +1,97 @@
+import type { PGlite } from '@electric-sql/pglite';
+import { CAPTAIN_AGENT_SLUG } from '@hezo/shared';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { waitForBackground } from '../src/lib/background';
+import type { Env } from '../src/lib/types';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp, createTestProject } from './helpers/app';
+
+let app: Hono<Env>;
+let db: PGlite;
+let token: string;
+let teamId: string;
+let projectId: string;
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+
+	const teamRes = await app.request('/api/teams', {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ name: 'Events Co' }),
+	});
+	teamId = (await teamRes.json()).data.id;
+
+	const project = await createTestProject(db, teamId, { name: 'Events Project' });
+	projectId = (await project.json()).data.id;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+/** The observer writes via trackBackground; drain it before asserting. */
+async function auditRows(filter: { entityType?: string; action?: string } = {}) {
+	await waitForBackground();
+	const params = new URLSearchParams();
+	if (filter.entityType) params.set('entity_type', filter.entityType);
+	if (filter.action) params.set('action', filter.action);
+	const res = await app.request(`/api/audit-log?${params.toString()}`, {
+		headers: authHeader(token),
+	});
+	expect(res.status).toBe(200);
+	return (await res.json()).data as Array<Record<string, unknown>>;
+}
+
+describe('audit observer (end-to-end)', () => {
+	it('records task creation with project scope', async () => {
+		const res = await app.request(`/api/teams/${teamId}/tasks`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				project_id: projectId,
+				title: 'Audited task',
+				assignee_slug: CAPTAIN_AGENT_SLUG,
+			}),
+		});
+		expect(res.status).toBe(201);
+		const taskId = (await res.json()).data.id;
+
+		const rows = await auditRows({ entityType: 'task', action: 'created' });
+		const entry = rows.find((e) => e.entity_id === taskId);
+		expect(entry).toBeDefined();
+		expect(entry?.project_id).toBe(projectId);
+		expect(entry?.actor_type).toBe('admin');
+	});
+
+	it('records an instance secret creation with a null team', async () => {
+		const res = await app.request('/api/secrets', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name: 'OBSERVED_KEY', value: 'shhh' }),
+		});
+		expect(res.status).toBe(201);
+
+		const rows = await auditRows({ entityType: 'secret', action: 'created' });
+		const entry = rows.find((e) => (e.details as Record<string, unknown>)?.name === 'OBSERVED_KEY');
+		expect(entry).toBeDefined();
+		expect(entry?.team_id).toBeNull();
+		expect(entry?.actor_type).toBe('admin');
+	});
+
+	it('records an instance skill creation', async () => {
+		const res = await app.request('/api/skills', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name: 'Observed Skill', content: '# hi' }),
+		});
+		expect(res.status).toBe(201);
+
+		const rows = await auditRows({ entityType: 'skill', action: 'created' });
+		expect(rows.length).toBeGreaterThanOrEqual(1);
+	});
+});

--- a/packages/server/test/audit-log.test.ts
+++ b/packages/server/test/audit-log.test.ts
@@ -1,21 +1,26 @@
 import type { PGlite } from '@electric-sql/pglite';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { MasterKeyManager } from '../src/crypto/master-key';
 import { auditLog } from '../src/lib/audit';
 import type { Env } from '../src/lib/types';
+import { signAdminJwt } from '../src/middleware/auth';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp } from './helpers/app';
+import { authHeader, createTestApp, createTestProject } from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
 let token: string;
+let masterKeyManager: MasterKeyManager;
 let teamId: string;
+let projectId: string;
 
 beforeAll(async () => {
 	const ctx = await createTestApp();
 	app = ctx.app;
 	db = ctx.db;
 	token = ctx.token;
+	masterKeyManager = ctx.masterKeyManager;
 
 	const teamRes = await app.request('/api/teams', {
 		method: 'POST',
@@ -23,6 +28,9 @@ beforeAll(async () => {
 		body: JSON.stringify({ name: 'Audit Co' }),
 	});
 	teamId = (await teamRes.json()).data.id;
+
+	const project = await createTestProject(db, teamId, { name: 'Audit Project' });
+	projectId = (await project.json()).data.id;
 });
 
 afterAll(async () => {
@@ -31,8 +39,14 @@ afterAll(async () => {
 
 describe('audit log', () => {
 	it('inserts an audit entry via helper', async () => {
-		await auditLog(db, teamId, 'admin', null, 'created', 'task', null, {
-			title: 'Test',
+		await auditLog(db, {
+			teamId,
+			actorType: 'admin',
+			actorMemberId: null,
+			action: 'created',
+			entityType: 'task',
+			entityId: null,
+			details: { title: 'Test' },
 		});
 
 		const res = await app.request(`/api/teams/${teamId}/audit-log`, {
@@ -49,7 +63,14 @@ describe('audit log', () => {
 	});
 
 	it('filters by entity_type', async () => {
-		await auditLog(db, teamId, 'system', null, 'updated', 'agent', null);
+		await auditLog(db, {
+			teamId,
+			actorType: 'system',
+			actorMemberId: null,
+			action: 'updated',
+			entityType: 'agent',
+			entityId: null,
+		});
 
 		const res = await app.request(`/api/teams/${teamId}/audit-log?entity_type=agent`, {
 			headers: authHeader(token),
@@ -60,7 +81,14 @@ describe('audit log', () => {
 	});
 
 	it('filters by action', async () => {
-		await auditLog(db, teamId, 'admin', null, 'deleted', 'project', null);
+		await auditLog(db, {
+			teamId,
+			actorType: 'admin',
+			actorMemberId: null,
+			action: 'deleted',
+			entityType: 'project',
+			entityId: null,
+		});
 
 		const res = await app.request(`/api/teams/${teamId}/audit-log?action=deleted`, {
 			headers: authHeader(token),
@@ -82,9 +110,16 @@ describe('audit log', () => {
 	});
 
 	it('supports pagination', async () => {
-		// Insert several entries
 		for (let i = 0; i < 5; i++) {
-			await auditLog(db, teamId, 'system', null, 'created', 'task', null, { i });
+			await auditLog(db, {
+				teamId,
+				actorType: 'system',
+				actorMemberId: null,
+				action: 'created',
+				entityType: 'task',
+				entityId: null,
+				details: { i },
+			});
 		}
 
 		const res = await app.request(`/api/teams/${teamId}/audit-log?page=1&per_page=2`, {
@@ -97,5 +132,66 @@ describe('audit log', () => {
 		expect(body.meta.page).toBe(1);
 		expect(body.meta.per_page).toBe(2);
 		expect(body.meta.total).toBeGreaterThanOrEqual(5);
+	});
+
+	it('scopes the per-project view to its project, and ?project_id filters the team view', async () => {
+		await auditLog(db, {
+			teamId,
+			projectId,
+			actorType: 'admin',
+			actorMemberId: null,
+			action: 'created',
+			entityType: 'document',
+			entityId: null,
+			details: { slug: 'scoped.md' },
+		});
+
+		const projectRes = await app.request(`/api/teams/${teamId}/projects/${projectId}/audit-log`, {
+			headers: authHeader(token),
+		});
+		expect(projectRes.status).toBe(200);
+		const projectBody = await projectRes.json();
+		expect(projectBody.data.length).toBeGreaterThanOrEqual(1);
+		expect(projectBody.data.every((e: Record<string, unknown>) => e.project_id === projectId)).toBe(
+			true,
+		);
+
+		const filteredRes = await app.request(
+			`/api/teams/${teamId}/audit-log?project_id=${projectId}`,
+			{ headers: authHeader(token) },
+		);
+		const filteredBody = await filteredRes.json();
+		expect(
+			filteredBody.data.every((e: Record<string, unknown>) => e.project_id === projectId),
+		).toBe(true);
+	});
+
+	it('exposes the instance view to superusers with cross-team rows', async () => {
+		await auditLog(db, {
+			teamId: null,
+			actorType: 'admin',
+			actorMemberId: null,
+			action: 'created',
+			entityType: 'secret',
+			entityId: null,
+			details: { name: 'INSTANCE_KEY' },
+		});
+
+		const res = await app.request('/api/audit-log', { headers: authHeader(token) });
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		// Includes the instance-scoped (team_id NULL) row plus team-scoped rows.
+		expect(body.data.some((e: Record<string, unknown>) => e.team_id === null)).toBe(true);
+		expect(body.data.some((e: Record<string, unknown>) => e.team_id === teamId)).toBe(true);
+	});
+
+	it('denies the instance view to non-superusers', async () => {
+		const userRes = await db.query<{ id: string }>(
+			"INSERT INTO users (display_name, is_superuser) VALUES ('Regular User', false) RETURNING id",
+		);
+		const nonSuperToken = await signAdminJwt(masterKeyManager, userRes.rows[0].id);
+
+		const res = await app.request('/api/audit-log', { headers: authHeader(nonSuperToken) });
+		expect(res.status).toBe(403);
 	});
 });

--- a/packages/server/test/events-bus.test.ts
+++ b/packages/server/test/events-bus.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import { mapEventToAudit } from '../src/events/audit-observer';
+import { DomainEventBus } from '../src/events/bus';
+import type { DomainEvent } from '../src/events/types';
+
+describe('DomainEventBus', () => {
+	it('fans out an event to every subscriber', () => {
+		const bus = new DomainEventBus();
+		const seen: string[] = [];
+		bus.subscribe((e) => seen.push(`a:${e.type}`));
+		bus.subscribe((e) => seen.push(`b:${e.type}`));
+
+		const event: DomainEvent = {
+			type: 'project.created',
+			teamId: 't1',
+			projectId: 'p1',
+			actorType: 'admin',
+			actorMemberId: null,
+			name: 'Demo',
+			slug: 'demo',
+		};
+		bus.emit(event);
+
+		expect(seen).toEqual(['a:project.created', 'b:project.created']);
+	});
+
+	it('a throwing subscriber does not break other subscribers', () => {
+		const bus = new DomainEventBus();
+		const seen: string[] = [];
+		bus.subscribe(() => {
+			throw new Error('observer boom');
+		});
+		bus.subscribe((e) => seen.push(e.type));
+
+		expect(() =>
+			bus.emit({
+				type: 'task.created',
+				teamId: 't1',
+				projectId: 'p1',
+				actorType: 'admin',
+				actorMemberId: null,
+				taskId: 'task1',
+				identifier: 'ENG-1',
+			}),
+		).not.toThrow();
+		expect(seen).toEqual(['task.created']);
+	});
+});
+
+describe('mapEventToAudit', () => {
+	it('maps an agent run completion to an agent_run / run_completed row with typed status', () => {
+		const input = mapEventToAudit({
+			type: 'agent_run.completed',
+			teamId: 't1',
+			projectId: 'p1',
+			runId: 'run1',
+			taskId: 'task1',
+			agentMemberId: 'agent1',
+			status: 'succeeded',
+			exitCode: 0,
+			error: null,
+		});
+		expect(input).not.toBeNull();
+		expect(input?.entityType).toBe('agent_run');
+		expect(input?.action).toBe('run_completed');
+		expect(input?.actorType).toBe('agent');
+		expect(input?.actorMemberId).toBe('agent1');
+		expect(input?.entityId).toBe('run1');
+		expect(input?.details?.status).toBe('succeeded');
+	});
+
+	it('attributes a system-prompt document edit to the agent entity', () => {
+		const input = mapEventToAudit({
+			type: 'document.updated',
+			teamId: 't1',
+			projectId: null,
+			actorType: 'admin',
+			actorMemberId: null,
+			documentId: 'doc1',
+			documentType: 'agent_system_prompt',
+			slug: 'system-prompt',
+			title: '',
+			agentMemberId: 'agent1',
+		});
+		expect(input?.entityType).toBe('agent');
+		expect(input?.entityId).toBe('agent1');
+		expect(input?.details?.field).toBe('system_prompt');
+	});
+
+	it('maps a credential request to a requested action with no entity id', () => {
+		const input = mapEventToAudit({
+			type: 'credential.requested',
+			teamId: 't1',
+			projectId: null,
+			actorType: 'agent',
+			actorMemberId: 'agent1',
+			taskId: 'task1',
+			name: 'GITHUB_TOKEN',
+		});
+		expect(input?.entityType).toBe('secret');
+		expect(input?.action).toBe('requested');
+		expect(input?.entityId).toBeNull();
+	});
+});

--- a/packages/server/test/helpers/app.ts
+++ b/packages/server/test/helpers/app.ts
@@ -6,6 +6,7 @@ import { AgentAdminStatus, CAPTAIN_AGENT_SLUG, INTERNAL_PROJECT_SLUG } from '@he
 import { generateMasterKey, MasterKeyManager } from '../../src/crypto/master-key';
 import { loadAgentRoles } from '../../src/db/agent-roles';
 import { seedBuiltins } from '../../src/db/seed';
+import { DomainEventBus } from '../../src/events/bus';
 import { toSlug, uniqueSlug } from '../../src/lib/slug';
 import { signAdminJwt, signAgentJwt } from '../../src/middleware/auth';
 import { resolveProjectTaskPrefix } from '../../src/routes/projects';
@@ -58,6 +59,7 @@ export async function createTestApp(opts: { webUrl?: string } = {}) {
 	const logs = new LogStreamBroker();
 	logs.setWsManager(wsManager);
 	const containerLogStreamer = new ContainerLogStreamer();
+	const events = new DomainEventBus();
 	const jobManager = new JobManager({
 		db,
 		docker,
@@ -65,6 +67,7 @@ export async function createTestApp(opts: { webUrl?: string } = {}) {
 		serverPort: 0,
 		dataDir,
 		wsManager,
+		events,
 		logs,
 		containerLogStreamer,
 	});
@@ -82,6 +85,7 @@ export async function createTestApp(opts: { webUrl?: string } = {}) {
 		null,
 		null,
 		containerLogStreamer,
+		events,
 	);
 	const userResult = await db.query<{ id: string }>(
 		"INSERT INTO users (display_name, is_superuser) VALUES ('Test Admin', true) RETURNING id",

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -448,9 +448,14 @@ export const AuditEntityType = {
 	Task: 'task',
 	Project: 'project',
 	Agent: 'agent',
+	AgentRun: 'agent_run',
 	Team: 'team',
 	Secret: 'secret',
 	Document: 'document',
+	Asset: 'asset',
+	Connection: 'connection',
+	McpConnection: 'mcp_connection',
+	Skill: 'skill',
 	EgressRequest: 'egress_request',
 } as const;
 export type AuditEntityType = (typeof AuditEntityType)[keyof typeof AuditEntityType];
@@ -505,6 +510,9 @@ export const AuditAction = {
 	Created: 'created',
 	Updated: 'updated',
 	Deleted: 'deleted',
+	RunStarted: 'run_started',
+	RunCompleted: 'run_completed',
+	Requested: 'requested',
 } as const;
 export type AuditAction = (typeof AuditAction)[keyof typeof AuditAction];
 

--- a/packages/web/src/components/audit-log-table.tsx
+++ b/packages/web/src/components/audit-log-table.tsx
@@ -1,0 +1,76 @@
+import type { AuditEntry } from '../hooks/use-audit-log';
+import { Badge } from './ui/badge';
+import { type Column, DataTable } from './ui/data-table';
+
+/**
+ * Shared renderer for the activity (audit) log, used by the team, per-project,
+ * and instance views. Pass `showTeam` to surface the originating team — only
+ * useful in the cross-team instance view.
+ */
+export function AuditLogTable({
+	entries,
+	showTeam = false,
+	emptyText = 'No activity yet.',
+}: {
+	entries: AuditEntry[] | undefined;
+	showTeam?: boolean;
+	emptyText?: string;
+}) {
+	if (!entries?.length) {
+		return <p className="text-[13px] text-text-muted">{emptyText}</p>;
+	}
+	return <DataTable columns={buildColumns(showTeam)} data={entries} rowKey={(row) => row.id} />;
+}
+
+function buildColumns(showTeam: boolean): Column<AuditEntry>[] {
+	const columns: Column<AuditEntry>[] = [
+		{
+			key: 'time',
+			header: 'Time',
+			hideOnMobile: true,
+			render: (e) => (
+				<span className="text-xs text-text-subtle">{new Date(e.created_at).toLocaleString()}</span>
+			),
+		},
+		{
+			key: 'actor',
+			header: 'Actor',
+			render: (e) => (
+				<span className="text-xs">
+					{e.actor_name || e.actor_type}
+					{e.actor_name ? <span className="text-text-subtle"> · {e.actor_type}</span> : null}
+				</span>
+			),
+		},
+		{
+			key: 'action',
+			header: 'Action',
+			render: (e) => <Badge color="neutral">{e.action}</Badge>,
+		},
+		{
+			key: 'entity',
+			header: 'Entity',
+			render: (e) => {
+				const name = (e.details as { name?: string; slug?: string; identifier?: string }).name;
+				const label = name ?? (e.details as { identifier?: string }).identifier ?? null;
+				return (
+					<span className="text-xs text-text-muted">
+						{e.entity_type}
+						{label ? <span className="text-text"> · {label}</span> : null}
+					</span>
+				);
+			},
+		},
+	];
+	if (showTeam) {
+		columns.push({
+			key: 'team',
+			header: 'Team',
+			hideOnMobile: true,
+			render: (e) => (
+				<span className="text-xs text-text-muted">{e.team_name ?? <em>instance</em>}</span>
+			),
+		});
+	}
+	return columns;
+}

--- a/packages/web/src/components/project-sidebar.tsx
+++ b/packages/web/src/components/project-sidebar.tsx
@@ -64,6 +64,11 @@ export function ProjectSidebar() {
 						testId: 'project-sidebar-settings',
 					},
 				]),
+		{
+			to: '/teams/$teamId/projects/$projectId/audit-log',
+			params: projectParams,
+			label: 'Activity',
+		},
 	];
 
 	const sections: SidebarNavSection[] = [

--- a/packages/web/src/hooks/use-audit-log.ts
+++ b/packages/web/src/hooks/use-audit-log.ts
@@ -3,10 +3,12 @@ import { api } from '../lib/api';
 
 export interface AuditEntry {
 	id: string;
-	team_id: string;
+	team_id: string | null;
+	project_id: string | null;
 	actor_type: string;
 	actor_member_id: string | null;
 	actor_name: string | null;
+	team_name: string | null;
 	action: string;
 	entity_type: string;
 	entity_id: string | null;
@@ -14,7 +16,9 @@ export interface AuditEntry {
 	created_at: string;
 }
 
-export function useAuditLog(teamId: string, filters?: { entity_type?: string; action?: string }) {
+type AuditFilters = { entity_type?: string; action?: string };
+
+export function useAuditLog(teamId: string, filters?: AuditFilters) {
 	return useQuery({
 		queryKey: ['teams', teamId, 'audit-log', filters],
 		queryFn: () =>
@@ -22,6 +26,33 @@ export function useAuditLog(teamId: string, filters?: { entity_type?: string; ac
 				entity_type: filters?.entity_type,
 				action: filters?.action,
 				per_page: '50',
+			}),
+	});
+}
+
+// Per-project view — a filtered slice of the instance log scoped to one project.
+export function useProjectAuditLog(teamId: string, projectId: string, filters?: AuditFilters) {
+	return useQuery({
+		queryKey: ['teams', teamId, 'projects', projectId, 'audit-log', filters],
+		queryFn: () =>
+			api.get<AuditEntry[]>(`/api/teams/${teamId}/projects/${projectId}/audit-log`, {
+				entity_type: filters?.entity_type,
+				action: filters?.action,
+				per_page: '50',
+			}),
+	});
+}
+
+// Instance-level view — every team plus instance-scoped (team_id NULL) rows.
+// Superuser only; the un-prefixed /api/audit-log route enforces it.
+export function useInstanceAuditLog(filters?: AuditFilters) {
+	return useQuery({
+		queryKey: ['instance', 'audit-log', filters],
+		queryFn: () =>
+			api.get<AuditEntry[]>('/api/audit-log', {
+				entity_type: filters?.entity_type,
+				action: filters?.action,
+				per_page: '100',
 			}),
 	});
 }

--- a/packages/web/src/routeTree.gen.ts
+++ b/packages/web/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as HomeIndexRouteImport } from './routes/home/index'
 import { Route as SettingsSkillsRouteImport } from './routes/settings/skills'
 import { Route as SettingsCredentialsRouteImport } from './routes/settings/credentials'
 import { Route as SettingsConnectorsRouteImport } from './routes/settings/connectors'
+import { Route as SettingsAuditLogRouteImport } from './routes/settings/audit-log'
 import { Route as SettingsAiProvidersRouteImport } from './routes/settings/ai-providers'
 import { Route as TeamsTeamIdRouteRouteImport } from './routes/teams/$teamId/route'
 import { Route as TeamsTeamIdIndexRouteImport } from './routes/teams/$teamId/index'
@@ -39,6 +40,7 @@ import { Route as TeamsTeamIdProjectsProjectIdIndexRouteImport } from './routes/
 import { Route as TeamsTeamIdAgentsAgentIdIndexRouteImport } from './routes/teams/$teamId/agents/$agentId/index'
 import { Route as TeamsTeamIdProjectsProjectIdDocumentsRouteImport } from './routes/teams/$teamId/projects/$projectId/documents'
 import { Route as TeamsTeamIdProjectsProjectIdContainerRouteImport } from './routes/teams/$teamId/projects/$projectId/container'
+import { Route as TeamsTeamIdProjectsProjectIdAuditLogRouteImport } from './routes/teams/$teamId/projects/$projectId/audit-log'
 import { Route as TeamsTeamIdProjectsProjectIdAssetsRouteImport } from './routes/teams/$teamId/projects/$projectId/assets'
 import { Route as TeamsTeamIdAgentsAgentIdSettingsRouteImport } from './routes/teams/$teamId/agents/$agentId/settings'
 import { Route as TeamsTeamIdProjectsProjectIdTasksIndexRouteImport } from './routes/teams/$teamId/projects/$projectId/tasks/index'
@@ -80,6 +82,11 @@ const SettingsCredentialsRoute = SettingsCredentialsRouteImport.update({
 const SettingsConnectorsRoute = SettingsConnectorsRouteImport.update({
   id: '/settings/connectors',
   path: '/settings/connectors',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SettingsAuditLogRoute = SettingsAuditLogRouteImport.update({
+  id: '/settings/audit-log',
+  path: '/settings/audit-log',
   getParentRoute: () => rootRouteImport,
 } as any)
 const SettingsAiProvidersRoute = SettingsAiProvidersRouteImport.update({
@@ -208,6 +215,12 @@ const TeamsTeamIdProjectsProjectIdContainerRoute =
     path: '/container',
     getParentRoute: () => TeamsTeamIdProjectsProjectIdRouteRoute,
   } as any)
+const TeamsTeamIdProjectsProjectIdAuditLogRoute =
+  TeamsTeamIdProjectsProjectIdAuditLogRouteImport.update({
+    id: '/audit-log',
+    path: '/audit-log',
+    getParentRoute: () => TeamsTeamIdProjectsProjectIdRouteRoute,
+  } as any)
 const TeamsTeamIdProjectsProjectIdAssetsRoute =
   TeamsTeamIdProjectsProjectIdAssetsRouteImport.update({
     id: '/assets',
@@ -255,6 +268,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/teams/$teamId': typeof TeamsTeamIdRouteRouteWithChildren
   '/settings/ai-providers': typeof SettingsAiProvidersRoute
+  '/settings/audit-log': typeof SettingsAuditLogRoute
   '/settings/connectors': typeof SettingsConnectorsRoute
   '/settings/credentials': typeof SettingsCredentialsRoute
   '/settings/skills': typeof SettingsSkillsRoute
@@ -280,6 +294,7 @@ export interface FileRoutesByFullPath {
   '/teams/$teamId/tasks/': typeof TeamsTeamIdTasksIndexRoute
   '/teams/$teamId/agents/$agentId/settings': typeof TeamsTeamIdAgentsAgentIdSettingsRoute
   '/teams/$teamId/projects/$projectId/assets': typeof TeamsTeamIdProjectsProjectIdAssetsRoute
+  '/teams/$teamId/projects/$projectId/audit-log': typeof TeamsTeamIdProjectsProjectIdAuditLogRoute
   '/teams/$teamId/projects/$projectId/container': typeof TeamsTeamIdProjectsProjectIdContainerRoute
   '/teams/$teamId/projects/$projectId/documents': typeof TeamsTeamIdProjectsProjectIdDocumentsRoute
   '/teams/$teamId/agents/$agentId/': typeof TeamsTeamIdAgentsAgentIdIndexRoute
@@ -293,6 +308,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/settings/ai-providers': typeof SettingsAiProvidersRoute
+  '/settings/audit-log': typeof SettingsAuditLogRoute
   '/settings/connectors': typeof SettingsConnectorsRoute
   '/settings/credentials': typeof SettingsCredentialsRoute
   '/settings/skills': typeof SettingsSkillsRoute
@@ -316,6 +332,7 @@ export interface FileRoutesByTo {
   '/teams/$teamId/tasks': typeof TeamsTeamIdTasksIndexRoute
   '/teams/$teamId/agents/$agentId/settings': typeof TeamsTeamIdAgentsAgentIdSettingsRoute
   '/teams/$teamId/projects/$projectId/assets': typeof TeamsTeamIdProjectsProjectIdAssetsRoute
+  '/teams/$teamId/projects/$projectId/audit-log': typeof TeamsTeamIdProjectsProjectIdAuditLogRoute
   '/teams/$teamId/projects/$projectId/container': typeof TeamsTeamIdProjectsProjectIdContainerRoute
   '/teams/$teamId/projects/$projectId/documents': typeof TeamsTeamIdProjectsProjectIdDocumentsRoute
   '/teams/$teamId/agents/$agentId': typeof TeamsTeamIdAgentsAgentIdIndexRoute
@@ -331,6 +348,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/teams/$teamId': typeof TeamsTeamIdRouteRouteWithChildren
   '/settings/ai-providers': typeof SettingsAiProvidersRoute
+  '/settings/audit-log': typeof SettingsAuditLogRoute
   '/settings/connectors': typeof SettingsConnectorsRoute
   '/settings/credentials': typeof SettingsCredentialsRoute
   '/settings/skills': typeof SettingsSkillsRoute
@@ -356,6 +374,7 @@ export interface FileRoutesById {
   '/teams/$teamId/tasks/': typeof TeamsTeamIdTasksIndexRoute
   '/teams/$teamId/agents/$agentId/settings': typeof TeamsTeamIdAgentsAgentIdSettingsRoute
   '/teams/$teamId/projects/$projectId/assets': typeof TeamsTeamIdProjectsProjectIdAssetsRoute
+  '/teams/$teamId/projects/$projectId/audit-log': typeof TeamsTeamIdProjectsProjectIdAuditLogRoute
   '/teams/$teamId/projects/$projectId/container': typeof TeamsTeamIdProjectsProjectIdContainerRoute
   '/teams/$teamId/projects/$projectId/documents': typeof TeamsTeamIdProjectsProjectIdDocumentsRoute
   '/teams/$teamId/agents/$agentId/': typeof TeamsTeamIdAgentsAgentIdIndexRoute
@@ -372,6 +391,7 @@ export interface FileRouteTypes {
     | '/'
     | '/teams/$teamId'
     | '/settings/ai-providers'
+    | '/settings/audit-log'
     | '/settings/connectors'
     | '/settings/credentials'
     | '/settings/skills'
@@ -397,6 +417,7 @@ export interface FileRouteTypes {
     | '/teams/$teamId/tasks/'
     | '/teams/$teamId/agents/$agentId/settings'
     | '/teams/$teamId/projects/$projectId/assets'
+    | '/teams/$teamId/projects/$projectId/audit-log'
     | '/teams/$teamId/projects/$projectId/container'
     | '/teams/$teamId/projects/$projectId/documents'
     | '/teams/$teamId/agents/$agentId/'
@@ -410,6 +431,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/settings/ai-providers'
+    | '/settings/audit-log'
     | '/settings/connectors'
     | '/settings/credentials'
     | '/settings/skills'
@@ -433,6 +455,7 @@ export interface FileRouteTypes {
     | '/teams/$teamId/tasks'
     | '/teams/$teamId/agents/$agentId/settings'
     | '/teams/$teamId/projects/$projectId/assets'
+    | '/teams/$teamId/projects/$projectId/audit-log'
     | '/teams/$teamId/projects/$projectId/container'
     | '/teams/$teamId/projects/$projectId/documents'
     | '/teams/$teamId/agents/$agentId'
@@ -447,6 +470,7 @@ export interface FileRouteTypes {
     | '/'
     | '/teams/$teamId'
     | '/settings/ai-providers'
+    | '/settings/audit-log'
     | '/settings/connectors'
     | '/settings/credentials'
     | '/settings/skills'
@@ -472,6 +496,7 @@ export interface FileRouteTypes {
     | '/teams/$teamId/tasks/'
     | '/teams/$teamId/agents/$agentId/settings'
     | '/teams/$teamId/projects/$projectId/assets'
+    | '/teams/$teamId/projects/$projectId/audit-log'
     | '/teams/$teamId/projects/$projectId/container'
     | '/teams/$teamId/projects/$projectId/documents'
     | '/teams/$teamId/agents/$agentId/'
@@ -487,6 +512,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   TeamsTeamIdRouteRoute: typeof TeamsTeamIdRouteRouteWithChildren
   SettingsAiProvidersRoute: typeof SettingsAiProvidersRoute
+  SettingsAuditLogRoute: typeof SettingsAuditLogRoute
   SettingsConnectorsRoute: typeof SettingsConnectorsRoute
   SettingsCredentialsRoute: typeof SettingsCredentialsRoute
   SettingsSkillsRoute: typeof SettingsSkillsRoute
@@ -547,6 +573,13 @@ declare module '@tanstack/react-router' {
       path: '/settings/connectors'
       fullPath: '/settings/connectors'
       preLoaderRoute: typeof SettingsConnectorsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/settings/audit-log': {
+      id: '/settings/audit-log'
+      path: '/settings/audit-log'
+      fullPath: '/settings/audit-log'
+      preLoaderRoute: typeof SettingsAuditLogRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/settings/ai-providers': {
@@ -710,6 +743,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof TeamsTeamIdProjectsProjectIdContainerRouteImport
       parentRoute: typeof TeamsTeamIdProjectsProjectIdRouteRoute
     }
+    '/teams/$teamId/projects/$projectId/audit-log': {
+      id: '/teams/$teamId/projects/$projectId/audit-log'
+      path: '/audit-log'
+      fullPath: '/teams/$teamId/projects/$projectId/audit-log'
+      preLoaderRoute: typeof TeamsTeamIdProjectsProjectIdAuditLogRouteImport
+      parentRoute: typeof TeamsTeamIdProjectsProjectIdRouteRoute
+    }
     '/teams/$teamId/projects/$projectId/assets': {
       id: '/teams/$teamId/projects/$projectId/assets'
       path: '/assets'
@@ -787,6 +827,7 @@ const TeamsTeamIdAgentsAgentIdRouteRouteWithChildren =
 
 interface TeamsTeamIdProjectsProjectIdRouteRouteChildren {
   TeamsTeamIdProjectsProjectIdAssetsRoute: typeof TeamsTeamIdProjectsProjectIdAssetsRoute
+  TeamsTeamIdProjectsProjectIdAuditLogRoute: typeof TeamsTeamIdProjectsProjectIdAuditLogRoute
   TeamsTeamIdProjectsProjectIdContainerRoute: typeof TeamsTeamIdProjectsProjectIdContainerRoute
   TeamsTeamIdProjectsProjectIdDocumentsRoute: typeof TeamsTeamIdProjectsProjectIdDocumentsRoute
   TeamsTeamIdProjectsProjectIdIndexRoute: typeof TeamsTeamIdProjectsProjectIdIndexRoute
@@ -799,6 +840,8 @@ const TeamsTeamIdProjectsProjectIdRouteRouteChildren: TeamsTeamIdProjectsProject
   {
     TeamsTeamIdProjectsProjectIdAssetsRoute:
       TeamsTeamIdProjectsProjectIdAssetsRoute,
+    TeamsTeamIdProjectsProjectIdAuditLogRoute:
+      TeamsTeamIdProjectsProjectIdAuditLogRoute,
     TeamsTeamIdProjectsProjectIdContainerRoute:
       TeamsTeamIdProjectsProjectIdContainerRoute,
     TeamsTeamIdProjectsProjectIdDocumentsRoute:
@@ -861,6 +904,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   TeamsTeamIdRouteRoute: TeamsTeamIdRouteRouteWithChildren,
   SettingsAiProvidersRoute: SettingsAiProvidersRoute,
+  SettingsAuditLogRoute: SettingsAuditLogRoute,
   SettingsConnectorsRoute: SettingsConnectorsRoute,
   SettingsCredentialsRoute: SettingsCredentialsRoute,
   SettingsSkillsRoute: SettingsSkillsRoute,

--- a/packages/web/src/routes/settings/audit-log.tsx
+++ b/packages/web/src/routes/settings/audit-log.tsx
@@ -1,0 +1,47 @@
+import { createFileRoute, Link } from '@tanstack/react-router';
+import { ArrowLeft } from 'lucide-react';
+import { AuditLogTable } from '../../components/audit-log-table';
+import { useInstanceAuditLog } from '../../hooks/use-audit-log';
+import { useMe } from '../../hooks/use-me';
+
+function InstanceAuditLogPage() {
+	const { data: me } = useMe();
+	const { data: entries } = useInstanceAuditLog();
+
+	const body =
+		me && !me.is_superuser ? (
+			<p className="text-[13px] text-text-muted">
+				The instance activity log is managed by the Admin. You don't have access to this page.
+			</p>
+		) : (
+			<>
+				<div className="mb-4">
+					<h1 className="text-[22px] font-medium">Instance activity</h1>
+					<p className="text-[13px] text-text-muted mt-1 max-w-[680px]">
+						Every state-changing action across all teams, plus instance-level admin actions
+						(credentials, connectors, skills) that aren't tied to a team. The combined view for
+						reconstructing what happened.
+					</p>
+				</div>
+				<AuditLogTable entries={entries} showTeam emptyText="No activity recorded yet." />
+			</>
+		);
+
+	return (
+		<div className="max-w-[1000px] mx-auto w-full px-4 py-4 md:px-6 md:py-5 lg:px-8 lg:py-6">
+			<div className="flex items-center gap-3 mb-6">
+				<Link
+					to="/settings"
+					className="text-text-muted hover:text-text inline-flex items-center gap-1 text-[13px]"
+				>
+					<ArrowLeft className="w-3.5 h-3.5" /> Settings
+				</Link>
+			</div>
+			{body}
+		</div>
+	);
+}
+
+export const Route = createFileRoute('/settings/audit-log')({
+	component: InstanceAuditLogPage,
+});

--- a/packages/web/src/routes/settings/index.tsx
+++ b/packages/web/src/routes/settings/index.tsx
@@ -10,6 +10,7 @@ const instanceNav = [
 	{ to: '/settings/skills', label: 'Skills' },
 	{ to: '/settings/connectors', label: 'Connectors' },
 	{ to: '/settings/credentials', label: 'Credentials' },
+	{ to: '/settings/audit-log', label: 'Activity' },
 ] as const;
 
 function GlobalSettingsPage() {

--- a/packages/web/src/routes/teams/$teamId/projects/$projectId/audit-log.tsx
+++ b/packages/web/src/routes/teams/$teamId/projects/$projectId/audit-log.tsx
@@ -1,0 +1,25 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { AuditLogTable } from '../../../../../components/audit-log-table';
+import { useProjectAuditLog } from '../../../../../hooks/use-audit-log';
+
+function ProjectAuditLogPage() {
+	const { teamId, projectId } = Route.useParams();
+	const { data: entries } = useProjectAuditLog(teamId, projectId);
+
+	return (
+		<div className="px-4 py-4 md:px-6 md:py-5 lg:px-8 lg:py-6">
+			<div className="mb-4">
+				<h2 className="text-base font-medium">Activity</h2>
+				<p className="text-[13px] text-text-muted mt-1">
+					Everything that happened on this project — tasks, agent runs, documents, assets, and
+					connector changes — newest first.
+				</p>
+			</div>
+			<AuditLogTable entries={entries} emptyText="No activity on this project yet." />
+		</div>
+	);
+}
+
+export const Route = createFileRoute('/teams/$teamId/projects/$projectId/audit-log')({
+	component: ProjectAuditLogPage,
+});

--- a/packages/web/src/routes/teams/$teamId/settings/audit-log.tsx
+++ b/packages/web/src/routes/teams/$teamId/settings/audit-log.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { useState } from 'react';
+import { AuditLogTable } from '../../../../components/audit-log-table';
 import { Badge } from '../../../../components/ui/badge';
 import { type Column, DataTable } from '../../../../components/ui/data-table';
 import { type AuditEntry, useAuditLog } from '../../../../hooks/use-audit-log';
@@ -13,33 +14,6 @@ const tabs: Array<{ key: TabKey; label: string; description: string }> = [
 		label: 'Outbound traffic',
 		description:
 			'Every outbound HTTPS request from an agent container that the egress proxy substituted a placeholder for, or denied. Values are never recorded — only the secret name.',
-	},
-];
-
-const baseColumns: Column<AuditEntry>[] = [
-	{
-		key: 'time',
-		header: 'Time',
-		hideOnMobile: true,
-		render: (e) => (
-			<span className="text-xs text-text-subtle">{new Date(e.created_at).toLocaleString()}</span>
-		),
-	},
-	{
-		key: 'actor',
-		header: 'Actor',
-		render: (e) => <span className="text-xs">{e.actor_name || e.actor_type}</span>,
-	},
-	{
-		key: 'action',
-		header: 'Action',
-		render: (e) => <Badge color="neutral">{e.action}</Badge>,
-	},
-	{
-		key: 'entity',
-		header: 'Entity',
-		hideOnMobile: true,
-		render: (e) => <span className="text-xs text-text-muted">{e.entity_type}</span>,
 	},
 ];
 
@@ -118,7 +92,6 @@ function AuditLogPage() {
 	const filter = tab === 'egress' ? { entity_type: 'egress_request' } : undefined;
 	const { data: entries } = useAuditLog(teamId, filter);
 	const activeTab = tabs.find((t) => t.key === tab) ?? tabs[0];
-	const columns = tab === 'egress' ? egressColumns : baseColumns;
 
 	return (
 		<div>
@@ -142,12 +115,14 @@ function AuditLogPage() {
 					</button>
 				))}
 			</div>
-			{!entries?.length ? (
-				<p className="text-[13px] text-text-muted">
-					{tab === 'egress' ? 'No egress events yet.' : 'No audit entries yet.'}
-				</p>
+			{tab === 'egress' ? (
+				!entries?.length ? (
+					<p className="text-[13px] text-text-muted">No egress events yet.</p>
+				) : (
+					<DataTable columns={egressColumns} data={entries} rowKey={(row) => row.id} />
+				)
 			) : (
-				<DataTable columns={columns} data={entries} rowKey={(row) => row.id} />
+				<AuditLogTable entries={entries} emptyText="No audit entries yet." />
 			)}
 		</div>
 	);

--- a/packages/web/test/project-audit-log.test.tsx
+++ b/packages/web/test/project-audit-log.test.tsx
@@ -1,0 +1,32 @@
+import { expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+import { seedProject, seedTask, seedWorkspace } from './helpers/seed';
+
+test('project Activity page lists the project audit trail', async () => {
+	const seeded = { teamSlug: '', projectSlug: '', identifier: '' };
+	const helpers = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Activity Project' });
+			const task = await seedTask(ws, project, { title: 'Audited Task' });
+			seeded.teamSlug = ws.team.slug;
+			seeded.projectSlug = project.slug;
+			seeded.identifier = task.identifier;
+			return { ws, project, task };
+		},
+	});
+
+	await helpers.router.navigate({
+		to: '/teams/$teamId/projects/$projectId/audit-log',
+		params: { teamId: seeded.teamSlug, projectId: seeded.projectSlug },
+	});
+
+	// The page mounts (unique description) and the task-created event renders
+	// as a row carrying the task identifier.
+	await helpers.findByText(/Everything that happened on this project/, undefined, {
+		timeout: 20_000,
+	});
+	await helpers.findByText(new RegExp(seeded.identifier), undefined, { timeout: 20_000 });
+	expect(seeded.identifier).toBeTruthy();
+}, 30_000);


### PR DESCRIPTION
Record the full set of state-changing actions across the system at three
scopes that are all views over one audit_log table:

- Instance (GET /api/audit-log, superuser): the cross-team superset,
  including instance-level admin actions (team_id NULL).
- Team (existing GET /teams/:teamId/audit-log): kept, + ?project_id filter.
- Per-project (GET /teams/:teamId/projects/:projectId/audit-log): a
  filtered slice of the instance log.

Wiring uses the Observer pattern: domain code emits typed DomainEvents onto
a per-app DomainEventBus and knows nothing about auditing; a single audit
observer subscribes and persists rows (best-effort via trackBackground).

Schema: audit_log.team_id is now nullable (instance actions), plus a new
nullable project_id (ON DELETE SET NULL) with supporting indexes.

Events covered: task create/update, project create, agent run
started/completed, asset create, document create/update/delete (system
prompt edits attributed to the agent), agent create/update/disable/enable,
secret + MCP connector + skill create/update/delete (team and instance),
OAuth connection create/delete, credential request/fulfill. Agent-initiated
connector/credential actions record actor_type=agent.

UI: instance Activity page under Settings, per-project Activity page, shared
audit table component; team page reuses it.

Tests: bus fan-out + observer mapping units, scope-filter + superuser-gating
API tests, end-to-end observer tests, and a per-project web component test.