### PR TITLE
Add agent profile links to task detail page

### DIFF
--- a/packages/web/src/components/agent-link.tsx
+++ b/packages/web/src/components/agent-link.tsx
@@ -1,0 +1,40 @@
+import { Link } from '@tanstack/react-router';
+import type { ReactNode } from 'react';
+
+interface AgentLinkProps {
+	projectId: string;
+	/** Agent slug (preferred) or member id — the agent route resolves either. */
+	agentId: string;
+	className?: string;
+	title?: string;
+	testId?: string;
+	children: ReactNode;
+}
+
+/**
+ * Link to an agent's profile page within a project. Centralizes the
+ * `/projects/$projectId/agents/$agentId` target so assignee, comment authors,
+ * and the agent queue all navigate consistently. Callers gate on team
+ * membership before rendering this (cross-team instance agents like the CEO /
+ * Coach have no page in another team's project), so it stays a plain Link.
+ */
+export function AgentLink({
+	projectId,
+	agentId,
+	className,
+	title,
+	testId,
+	children,
+}: AgentLinkProps) {
+	return (
+		<Link
+			to="/projects/$projectId/agents/$agentId"
+			params={{ projectId, agentId }}
+			className={className}
+			title={title}
+			data-testid={testId}
+		>
+			{children}
+		</Link>
+	);
+}

--- a/packages/web/src/components/task-detail/agent-queue-section.tsx
+++ b/packages/web/src/components/task-detail/agent-queue-section.tsx
@@ -1,10 +1,12 @@
 import { Loader2, Play, Trash2 } from 'lucide-react';
 import { useState } from 'react';
+import type { Agent } from '../../hooks/use-agents';
 import { useCancelQueuedWakeup } from '../../hooks/use-cancel-queued-wakeup';
 import type { ExecutionLock } from '../../hooks/use-execution-locks';
 import type { QueuedDispatchState, QueuedWakeup } from '../../hooks/use-queued-wakeups';
 import { useRunQueuedWakeup } from '../../hooks/use-run-queued-wakeup';
 import { useTerminateRun } from '../../hooks/use-terminate-run';
+import { AgentLink } from '../agent-link';
 import { ConfirmDialog } from '../ui/confirm-dialog';
 import { Tooltip } from '../ui/tooltip';
 
@@ -16,6 +18,9 @@ type RunCommentRef = { id: string; content_type: string; content: unknown };
 interface AgentQueueSectionProps {
 	projectId: string;
 	taskId: string;
+	/** Team roster, used to resolve a member id to its slug for the agent-page
+	 * link. Agents not in this list (cross-team CEO / Coach) render unlinked. */
+	agents?: Agent[];
 	locks: ExecutionLock[];
 	comments: RunCommentRef[];
 	wakeups: QueuedWakeup[];
@@ -31,12 +36,16 @@ interface AgentQueueSectionProps {
 export function AgentQueueSection({
 	projectId,
 	taskId,
+	agents,
 	locks,
 	comments,
 	wakeups,
 	dispatch,
 }: AgentQueueSectionProps) {
 	if (locks.length === 0 && wakeups.length === 0) return null;
+
+	const slugByMemberId = new Map<string, string>();
+	for (const a of agents ?? []) slugByMemberId.set(a.id, a.slug);
 
 	// Map each running agent to its current run via the run comment, which is the
 	// only place the heartbeat run id surfaces to the client. Iterate in order so
@@ -67,6 +76,7 @@ export function AgentQueueSection({
 						projectId={projectId}
 						taskId={taskId}
 						lock={lock}
+						agentSlug={slugByMemberId.get(lock.member_id)}
 						run={runByMemberId.get(lock.member_id)}
 					/>
 				))}
@@ -78,6 +88,7 @@ export function AgentQueueSection({
 								projectId={projectId}
 								taskId={taskId}
 								wakeup={w}
+								agentSlug={slugByMemberId.get(w.member_id)}
 								dispatch={dispatch}
 							/>
 						))}
@@ -92,11 +103,13 @@ function RunningAgentRow({
 	projectId,
 	taskId,
 	lock,
+	agentSlug,
 	run,
 }: {
 	projectId: string;
 	taskId: string;
 	lock: ExecutionLock;
+	agentSlug: string | undefined;
 	run: { runId: string; commentId: string } | undefined;
 }) {
 	const [open, setOpen] = useState(false);
@@ -115,34 +128,46 @@ function RunningAgentRow({
 			data-testid={`running-agent-${lock.member_id}`}
 			className="flex items-center justify-between gap-2 text-[13px] text-text"
 		>
-			{run ? (
-				<a
-					href={`#comment-${run.commentId}`}
-					onClick={(e) => {
-						// Drive scroll via the hash so the task page's hashchange handler can
-						// ask Virtuoso to mount and scroll to the row even when it isn't
-						// currently in the DOM (scrollIntoView alone fails for off-screen
-						// virtualized rows).
-						e.preventDefault();
-						const next = `#comment-${run.commentId}`;
-						if (window.location.hash === next) {
-							window.dispatchEvent(new HashChangeEvent('hashchange'));
-						} else {
-							window.history.pushState(null, '', next);
-							window.dispatchEvent(new HashChangeEvent('hashchange'));
-						}
-					}}
+			{agentSlug ? (
+				<AgentLink
+					projectId={projectId}
+					agentId={agentSlug}
 					className="text-accent-blue-text font-medium hover:underline truncate min-w-0"
+					testId={`running-agent-link-${lock.member_id}`}
 				>
 					{lock.member_name}
-				</a>
+				</AgentLink>
 			) : (
 				<span className="text-accent-blue-text font-medium truncate min-w-0">
 					{lock.member_name}
 				</span>
 			)}
 			<div className="flex items-center gap-1 shrink-0">
-				<Loader2 className="w-3.5 h-3.5 animate-spin text-accent-blue" aria-label="Running" />
+				{run ? (
+					<Tooltip content="Jump to run">
+						<a
+							href={`#comment-${run.commentId}`}
+							onClick={(e) => {
+								// Drive scroll via the hash so the task page's hashchange handler
+								// can ask Virtuoso to mount and scroll to the row even when it
+								// isn't currently in the DOM (scrollIntoView alone fails for
+								// off-screen virtualized rows).
+								e.preventDefault();
+								const next = `#comment-${run.commentId}`;
+								if (window.location.hash !== next) {
+									window.history.pushState(null, '', next);
+								}
+								window.dispatchEvent(new HashChangeEvent('hashchange'));
+							}}
+							aria-label="Jump to run"
+							className="inline-flex items-center justify-center h-6 w-6 rounded-radius-md hover:bg-bg-subtle transition-colors"
+						>
+							<Loader2 className="w-3.5 h-3.5 animate-spin text-accent-blue" />
+						</a>
+					</Tooltip>
+				) : (
+					<Loader2 className="w-3.5 h-3.5 animate-spin text-accent-blue" aria-label="Running" />
+				)}
 				{run && (
 					<Tooltip content="Terminate run">
 						<button
@@ -193,11 +218,13 @@ function QueuedAgentRow({
 	projectId,
 	taskId,
 	wakeup,
+	agentSlug,
 	dispatch,
 }: {
 	projectId: string;
 	taskId: string;
 	wakeup: QueuedWakeup;
+	agentSlug: string | undefined;
 	dispatch: QueuedDispatchState;
 }) {
 	const [open, setOpen] = useState(false);
@@ -210,7 +237,18 @@ function QueuedAgentRow({
 			data-testid={`queued-agent-${wakeup.id}`}
 			className="flex items-center justify-between gap-2 text-[13px] text-text"
 		>
-			<span className="truncate min-w-0">{wakeup.member_name}</span>
+			{agentSlug ? (
+				<AgentLink
+					projectId={projectId}
+					agentId={agentSlug}
+					className="truncate min-w-0 hover:text-accent-blue-text transition-colors"
+					testId={`queued-agent-link-${wakeup.id}`}
+				>
+					{wakeup.member_name}
+				</AgentLink>
+			) : (
+				<span className="truncate min-w-0">{wakeup.member_name}</span>
+			)}
 			<div className="flex items-center gap-1 shrink-0">
 				{blockReason ? (
 					// aria-disabled (not the native `disabled` attribute) keeps the button

--- a/packages/web/src/components/task-detail/comments-section.tsx
+++ b/packages/web/src/components/task-detail/comments-section.tsx
@@ -1,8 +1,10 @@
 import { CornerDownRight, Reply } from 'lucide-react';
-import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso';
+import { useAgents } from '../../hooks/use-agents';
 import { type Comment, useChooseOption, useComments } from '../../hooks/use-comments';
 import type { Task } from '../../hooks/use-tasks';
+import { AgentLink } from '../agent-link';
 import {
 	type CommentData,
 	CommentReactions,
@@ -49,6 +51,15 @@ export function CommentsSection({
 	onStartReply,
 }: CommentsSectionProps) {
 	const { data: comments } = useComments(projectId, taskId);
+	// Resolve agent comment authors to their slug so the avatar + name link to
+	// the agent's page. Reads the already-cached team roster; cross-team authors
+	// (CEO / Coach) aren't in it and stay unlinked.
+	const { data: agents } = useAgents(projectId);
+	const agentSlugById = useMemo(() => {
+		const m = new Map<string, string>();
+		for (const a of agents ?? []) m.set(a.id, a.slug);
+		return m;
+	}, [agents]);
 	const chooseOption = useChooseOption(projectId, taskId);
 	const virtuosoRef = useRef<VirtuosoHandle>(null);
 	const listContainerRef = useRef<HTMLDivElement>(null);
@@ -171,6 +182,8 @@ export function CommentsSection({
 						const commentData = c as unknown as CommentData;
 						const authorName = c.author_name ?? 'Admin';
 						const isAgent = c.author_type === 'agent';
+						const authorAgentSlug =
+							isAgent && c.author_member_id ? agentSlugById.get(c.author_member_id) : undefined;
 						const content = typeof c.content === 'object' ? (c.content as { kind?: string }) : null;
 						const isPendingSetupRepo =
 							c.content_type === 'action' && content?.kind === 'setup_repo' && !c.chosen_option;
@@ -215,19 +228,46 @@ export function CommentsSection({
 								data-comment-highlighted={isHighlighted ? 'true' : undefined}
 								{...(isPendingSetupRepo ? { 'data-setup-repo-anchor': '' } : {})}
 							>
-								<Avatar
-									initials={authorName.slice(0, 2)}
-									size="sm"
-									color={avatarColorFromString(authorName)}
-								/>
+								{authorAgentSlug ? (
+									<AgentLink
+										projectId={projectId}
+										agentId={authorAgentSlug}
+										title={`View ${authorName}`}
+										testId="comment-author-avatar-link"
+										className="shrink-0 rounded-full"
+									>
+										<Avatar
+											initials={authorName.slice(0, 2)}
+											size="sm"
+											color={avatarColorFromString(authorName)}
+										/>
+									</AgentLink>
+								) : (
+									<Avatar
+										initials={authorName.slice(0, 2)}
+										size="sm"
+										color={avatarColorFromString(authorName)}
+									/>
+								)}
 								<div className="flex-1 min-w-0 rounded-md border border-border bg-bg-elevated overflow-hidden">
 									<div className="flex items-center gap-2 px-3 py-2 border-b border-border bg-bg-muted">
-										<span
-											className={`text-xs font-medium ${isAgent ? 'text-text' : 'text-text-muted'}`}
-											data-testid="comment-author"
-										>
-											{authorName}
-										</span>
+										{authorAgentSlug ? (
+											<AgentLink
+												projectId={projectId}
+												agentId={authorAgentSlug}
+												className="text-xs font-medium text-text hover:text-accent-blue-text transition-colors"
+												testId="comment-author"
+											>
+												{authorName}
+											</AgentLink>
+										) : (
+											<span
+												className={`text-xs font-medium ${isAgent ? 'text-text' : 'text-text-muted'}`}
+												data-testid="comment-author"
+											>
+												{authorName}
+											</span>
+										)}
 										<span className="text-[11px] text-text-subtle">
 											{new Date(c.created_at).toLocaleString()}
 										</span>

--- a/packages/web/src/components/task-detail/task-sidebar.tsx
+++ b/packages/web/src/components/task-detail/task-sidebar.tsx
@@ -14,6 +14,7 @@ import type { Comment } from '../../hooks/use-comments';
 import type { ExecutionLockState } from '../../hooks/use-execution-locks';
 import { useQueuedWakeups } from '../../hooks/use-queued-wakeups';
 import type { Task, useUpdateTask } from '../../hooks/use-tasks';
+import { AgentLink } from '../agent-link';
 import { AgentStatusLabel } from '../agent-status-label';
 import { Button } from '../ui/button';
 import { ConfirmDialog } from '../ui/confirm-dialog';
@@ -90,6 +91,7 @@ export function TaskSidebar({
 				<AgentQueueSection
 					projectId={projectId}
 					taskId={task.id}
+					agents={agents}
 					locks={lock?.locks ?? []}
 					comments={comments ?? []}
 					wakeups={queued?.wakeups ?? []}
@@ -119,11 +121,26 @@ export function TaskSidebar({
 					</span>
 					{task.has_active_run ? (
 						<div className="flex items-center gap-1 w-full text-[13px] text-text px-1 py-0.5">
-							<AgentStatusLabel
-								name={assignedAgent?.title ?? '—'}
-								runtimeStatus={AgentRuntimeStatus.Active}
-								className="flex-1 min-w-0"
-							/>
+							{assignedAgent ? (
+								<AgentLink
+									projectId={projectId}
+									agentId={assignedAgent.slug}
+									className="flex flex-1 min-w-0 items-center hover:text-accent-blue-text transition-colors"
+									testId="task-assignee-link"
+								>
+									<AgentStatusLabel
+										name={assignedAgent.title}
+										runtimeStatus={AgentRuntimeStatus.Active}
+										className="min-w-0"
+									/>
+								</AgentLink>
+							) : (
+								<AgentStatusLabel
+									name="—"
+									runtimeStatus={AgentRuntimeStatus.Active}
+									className="flex-1 min-w-0"
+								/>
+							)}
 							<InfoTooltip
 								content="Cannot change assignee while an agent is running on this task"
 								label="Assignee locked: agent is running"
@@ -131,20 +148,40 @@ export function TaskSidebar({
 						</div>
 					) : (
 						<>
-							<button
-								type="button"
-								onClick={() => setAssigneeOpen((o) => !o)}
-								className="flex items-center gap-1 w-full text-left text-[13px] text-text rounded-radius-md hover:bg-bg-subtle px-1 py-0.5 transition-colors"
-							>
-								<AgentStatusLabel
-									name={assignedAgent?.title ?? '—'}
-									runtimeStatus={AgentRuntimeStatus.Idle}
-									className="flex-1 min-w-0"
-								/>
-								<ChevronDown
-									className={`w-3.5 h-3.5 text-text-subtle shrink-0 transition-transform ${assigneeOpen ? 'rotate-180' : ''}`}
-								/>
-							</button>
+							<div className="flex items-center gap-1 w-full text-[13px] text-text px-1 py-0.5">
+								{assignedAgent ? (
+									<AgentLink
+										projectId={projectId}
+										agentId={assignedAgent.slug}
+										className="flex flex-1 min-w-0 items-center hover:text-accent-blue-text transition-colors"
+										testId="task-assignee-link"
+									>
+										<AgentStatusLabel
+											name={assignedAgent.title}
+											runtimeStatus={AgentRuntimeStatus.Idle}
+											className="min-w-0"
+										/>
+									</AgentLink>
+								) : (
+									<span className="flex flex-1 min-w-0 items-center">
+										<AgentStatusLabel
+											name="—"
+											runtimeStatus={AgentRuntimeStatus.Idle}
+											className="min-w-0"
+										/>
+									</span>
+								)}
+								<button
+									type="button"
+									onClick={() => setAssigneeOpen((o) => !o)}
+									aria-label="Change assignee"
+									className="shrink-0 rounded-radius-md hover:bg-bg-subtle p-1 transition-colors"
+								>
+									<ChevronDown
+										className={`w-3.5 h-3.5 text-text-subtle transition-transform ${assigneeOpen ? 'rotate-180' : ''}`}
+									/>
+								</button>
+							</div>
 							{assigneeOpen && (
 								<div className="absolute left-0 right-0 top-full mt-1 z-20 rounded-radius-md border border-border bg-bg shadow-md max-h-48 overflow-y-auto">
 									{assigneeOptions?.map((a) => (

--- a/packages/web/test/agent-links.test.tsx
+++ b/packages/web/test/agent-links.test.tsx
@@ -1,0 +1,177 @@
+import { expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+import {
+	seedComment,
+	seedProject,
+	seedRunningAgent,
+	seedTask,
+	seedWorkspace,
+} from './helpers/seed';
+
+// These cover that agent references across the task detail page navigate to the
+// agent's profile page (`/projects/$projectId/agents/$agentId`): the assignee
+// chip, the comment author avatar + name, and the running / queued rows in the
+// Agent Queue. Pure render + href assertions, so a component test fits.
+
+test('assignee chip links to the agent page', async () => {
+	const seeded = { projectSlug: '', taskId: '', agentSlug: '' };
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Assignee Link Project' });
+			const agent = ws.agents[0];
+			const task = await seedTask(ws, project, {
+				title: 'Assignee Link Task',
+				assignee_id: agent.id,
+			});
+			seeded.projectSlug = project.slug;
+			seeded.taskId = task.identifier.toLowerCase();
+			seeded.agentSlug = agent.slug;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
+	});
+
+	const link = (await findByTestId('task-assignee-link', undefined, {
+		timeout: 15_000,
+	})) as HTMLAnchorElement;
+	expect(link.getAttribute('href')).toBe(
+		`/projects/${seeded.projectSlug}/agents/${seeded.agentSlug}`,
+	);
+});
+
+test('agent comment author avatar and name link to the agent page', async () => {
+	const seeded = { projectSlug: '', taskId: '', agentSlug: '' };
+	const { findByTestId, findByText, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Author Link Project' });
+			const task = await seedTask(ws, project, { title: 'Author Link Task' });
+			const agent = ws.agents[0];
+			await seedComment(ws, task, 'Authored by the agent', { authorMemberId: agent.id });
+			seeded.projectSlug = project.slug;
+			seeded.taskId = task.identifier.toLowerCase();
+			seeded.agentSlug = agent.slug;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
+	});
+
+	await findByText('Authored by the agent', undefined, { timeout: 15_000 });
+
+	const expectedHref = `/projects/${seeded.projectSlug}/agents/${seeded.agentSlug}`;
+	const avatarLink = (await findByTestId('comment-author-avatar-link')) as HTMLAnchorElement;
+	expect(avatarLink.getAttribute('href')).toBe(expectedHref);
+	const nameLink = (await findByTestId('comment-author')) as HTMLAnchorElement;
+	expect(nameLink.tagName).toBe('A');
+	expect(nameLink.getAttribute('href')).toBe(expectedHref);
+});
+
+test('human comment author stays an unlinked label', async () => {
+	const seeded = { projectSlug: '', taskId: '' };
+	const { findByTestId, findByText, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Human Author Project' });
+			const task = await seedTask(ws, project, { title: 'Human Author Task' });
+			// seedComment posts via the board token => author_type 'user'.
+			await seedComment(ws, task, 'Authored by a human');
+			seeded.projectSlug = project.slug;
+			seeded.taskId = task.identifier.toLowerCase();
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
+	});
+
+	await findByText('Authored by a human', undefined, { timeout: 15_000 });
+	const author = (await findByTestId('comment-author')) as HTMLElement;
+	expect(author.tagName).toBe('SPAN');
+});
+
+test('running agent in the Agent Queue links to the agent page', async () => {
+	const seeded = { projectSlug: '', taskId: '', agentId: '', agentSlug: '' };
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			// Assign Captain, run a different agent — mirrors agent-queue.test.tsx so
+			// the assignee's own wakeup can't add a second lock for our subject.
+			const captain = ws.agents.find((a) => a.slug === 'captain') ?? ws.agents[0];
+			const agent = ws.agents.find((a) => a.id !== captain.id) ?? ws.agents[0];
+			const project = await seedProject(ws, { name: 'Running Link Project' });
+			const task = await seedTask(ws, project, {
+				title: 'Running Link Task',
+				assignee_id: captain.id,
+			});
+			await seedRunningAgent(ws, task, agent.id);
+			seeded.projectSlug = project.slug;
+			seeded.taskId = task.identifier.toLowerCase();
+			seeded.agentId = agent.id;
+			seeded.agentSlug = agent.slug;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
+	});
+
+	const link = (await findByTestId(`running-agent-link-${seeded.agentId}`, undefined, {
+		timeout: 15_000,
+	})) as HTMLAnchorElement;
+	expect(link.getAttribute('href')).toBe(
+		`/projects/${seeded.projectSlug}/agents/${seeded.agentSlug}`,
+	);
+});
+
+test('queued agent in the Agent Queue links to the agent page', async () => {
+	const seeded = { projectSlug: '', taskId: '', wakeupId: '', agentSlug: '' };
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async (ctx) => {
+			const ws = await seedWorkspace();
+			const captain = ws.agents.find((a) => a.slug === 'captain') ?? ws.agents[0];
+			const queuedAgent = ws.agents.find((a) => a.id !== captain.id) ?? ws.agents[0];
+			const project = await seedProject(ws, { name: 'Queued Link Project' });
+			const task = await seedTask(ws, project, {
+				title: 'Queued Link Task',
+				assignee_id: captain.id,
+			});
+			const r = await ctx.db.query<{ id: string }>(
+				`INSERT INTO agent_wakeup_requests (member_id, team_id, source, status, payload)
+				 VALUES ($1, $2, 'mention'::wakeup_source, 'queued'::wakeup_status,
+				         jsonb_build_object('task_id', $3::text))
+				 RETURNING id`,
+				[queuedAgent.id, ws.team.id, task.id],
+			);
+			seeded.projectSlug = project.slug;
+			seeded.taskId = task.identifier.toLowerCase();
+			seeded.wakeupId = r.rows[0].id;
+			seeded.agentSlug = queuedAgent.slug;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
+	});
+
+	const link = (await findByTestId(`queued-agent-link-${seeded.wakeupId}`, undefined, {
+		timeout: 15_000,
+	})) as HTMLAnchorElement;
+	expect(link.getAttribute('href')).toBe(
+		`/projects/${seeded.projectSlug}/agents/${seeded.agentSlug}`,
+	);
+});

--- a/test/browser/task-crud.spec.ts
+++ b/test/browser/task-crud.spec.ts
@@ -7,7 +7,7 @@
 import { expect, test } from './fixtures';
 import { createProjectAndClearPlanning, uniqueName, waitForPageLoad } from './helpers';
 
-test('Agent Queue running row links the agent name to its run comment and scrolls into view', async ({
+test('Agent Queue running row links the name to the agent page and the run indicator scrolls to the run comment', async ({
 	sharedPage: page,
 	sharedWorkspace,
 }) => {
@@ -26,6 +26,7 @@ test('Agent Queue running row links the agent name to its run comment and scroll
 	).data;
 	const agent = (projectAgents.find((a) => a.slug === 'captain') ?? projectAgents[0]) as {
 		id: string;
+		slug: string;
 		title: string;
 	};
 
@@ -98,12 +99,17 @@ test('Agent Queue running row links the agent name to its run comment and scroll
 	const agentQueue = page.getByTestId('agent-queue-section');
 	await expect(agentQueue).toBeVisible({ timeout: 15000 });
 
-	const link = agentQueue.getByRole('link', { name: agent.title });
-	await expect(link).toHaveAttribute('href', `#comment-${commentId}`);
+	// The agent name navigates to the agent's profile page.
+	const nameLink = agentQueue.getByRole('link', { name: agent.title });
+	await expect(nameLink).toHaveAttribute('href', `/projects/${project.slug}/agents/${agent.slug}`);
+
+	// The running indicator jumps to — and scrolls in — the live run comment.
+	const runLink = agentQueue.getByRole('link', { name: 'Jump to run' });
+	await expect(runLink).toHaveAttribute('href', `#comment-${commentId}`);
 
 	const targetComment = page.locator(`#comment-${commentId}`);
 	await expect(targetComment).not.toBeInViewport();
 
-	await link.click();
+	await runLink.click();
 	await expect(targetComment).toBeInViewport({ timeout: 15000 });
 });


### PR DESCRIPTION
## Summary
Makes agent references across the task detail page navigable to the agent's profile page. This includes the assignee chip, comment author avatar and name, and running/queued agent rows in the Agent Queue.

## Changes
- **New `AgentLink` component** (`agent-link.tsx`): Centralizes navigation to `/projects/$projectId/agents/$agentId` for consistent agent profile linking across the app
- **Task sidebar assignee**: Wrapped assignee status label in `AgentLink` when an agent is assigned, allowing navigation to their profile
- **Comments section**: 
  - Agent comment author avatars now link to the agent's profile
  - Agent comment author names now render as links instead of plain text
  - Human comment authors remain unlinked (as `<span>`)
- **Agent Queue section**:
  - Running agent rows: Agent name now links to profile; separated the "jump to run" functionality into a distinct icon button with tooltip
  - Queued agent rows: Agent name now links to profile
  - Both sections conditionally render links only when the agent is in the team roster (cross-team agents like CEO/Coach remain unlinked)
- **Test coverage**: Added comprehensive test suite (`agent-links.test.tsx`) covering all agent link scenarios
- **E2E test update**: Updated existing browser test to reflect the new link behavior (name → agent page, run indicator → run comment)

## Implementation Details
- Agent slugs are resolved from the team roster (`useAgents` hook) and passed down through component props
- Links only render for agents in the current team; cross-team instance agents gracefully degrade to unlinked text
- Running agent rows now have a tooltip-wrapped button for the "jump to run" action, improving UX clarity
- All new links include appropriate `data-testid` attributes for testing

https://claude.ai/code/session_01WmNnjmWvFgGUWnPv932eQe