### PR TITLE
feat(web): surface task project on CEO/Coach execution pages

### DIFF
--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -75,7 +75,7 @@ const HEARTBEAT_RUN_COLUMNS = `hr.id, hr.member_id, hr.team_id, hr.wakeup_id, hr
 	hr.invocation_command, hr.log_text, hr.working_dir,
 	hr.process_pid, hr.retry_of_run_id, hr.process_loss_retry_count,
 	i.identifier AS task_identifier, i.title AS task_title,
-	i.project_id AS project_id, p.slug AS project_slug,
+	i.project_id AS project_id, p.slug AS project_slug, p.name AS project_name,
 	aw.source AS trigger_source,
 	aw.payload AS trigger_payload,
 	tic.id AS trigger_comment_id,

--- a/packages/server/test/heartbeat-runs.test.ts
+++ b/packages/server/test/heartbeat-runs.test.ts
@@ -123,6 +123,9 @@ describe('heartbeat-runs API', () => {
 		expect(run.task_id).toBe(taskId);
 		expect(run.task_identifier).toBeTruthy();
 		expect(run.task_title).toBe('Test Task');
+		// The task's project is surfaced on the run so CEO/Coach pages can show it.
+		expect(run.project_slug).toBe(projectSlug);
+		expect(run.project_name).toBe('Main');
 	});
 
 	it('gets a single run by id with task info', async () => {
@@ -134,6 +137,8 @@ describe('heartbeat-runs API', () => {
 		const body = await res.json();
 		expect(body.data.id).toBe(runId);
 		expect(body.data.task_title).toBe('Test Task');
+		expect(body.data.project_slug).toBe(projectSlug);
+		expect(body.data.project_name).toBe('Main');
 		expect(body.data.status).toBe('succeeded');
 		expect(body.data.log_text).toBe('test output');
 		expect(body.data.invocation_command).toContain('$ claude --mcp-config');

--- a/packages/web/src/hooks/use-heartbeat-runs.ts
+++ b/packages/web/src/hooks/use-heartbeat-runs.ts
@@ -12,6 +12,7 @@ export interface HeartbeatRun {
 	task_title: string | null;
 	project_id: string | null;
 	project_slug: string | null;
+	project_name: string | null;
 	status: 'queued' | 'running' | 'succeeded' | 'failed' | 'cancelled' | 'timed_out';
 	queued_reason: string | null;
 	started_at: string | null;

--- a/packages/web/src/routes/projects/$projectId/agents/$agentId/executions/$runId.tsx
+++ b/packages/web/src/routes/projects/$projectId/agents/$agentId/executions/$runId.tsx
@@ -1,9 +1,11 @@
+import { INSTANCE_AGENT_SLUGS } from '@hezo/shared';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { ArrowLeft, ChevronDown, ChevronRight } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { LogViewer } from '../../../../../../components/log-viewer';
 import { TerminateRunButton } from '../../../../../../components/terminate-run-button';
 import { Badge } from '../../../../../../components/ui/badge';
+import { useAgent } from '../../../../../../hooks/use-agents';
 import { useElapsedDuration } from '../../../../../../hooks/use-elapsed-duration';
 import { getRunWaitingMessage, useHeartbeatRun } from '../../../../../../hooks/use-heartbeat-runs';
 import { useRunLogs } from '../../../../../../hooks/use-run-logs';
@@ -29,6 +31,13 @@ function statusColor(status: string): string {
 function ExecutionDetailPage() {
 	const { projectId, agentId, runId } = Route.useParams();
 	const { data: run, isLoading } = useHeartbeatRun(projectId, agentId, runId);
+	const { data: agent } = useAgent(projectId, agentId);
+
+	// CEO/Coach run across every project, so their pages surface which project a
+	// task lives in. Gate on the agent slug (not the context-dependent
+	// `is_instance` flag, which is false when they're viewed under HQ's own roster).
+	const isInstanceAgent =
+		!!agent && (INSTANCE_AGENT_SLUGS as readonly string[]).includes(agent.slug);
 
 	const isActive = run?.status === 'running' || run?.status === 'queued';
 	const { lines } = useRunLogs(run?.project_id ?? null, run?.id ?? null, run?.log_text, isActive);
@@ -45,6 +54,20 @@ function ExecutionDetailPage() {
 
 	if (isLoading) return <div className="text-text-muted text-sm">Loading...</div>;
 	if (!run) return <div className="text-text-muted text-sm">Run not found.</div>;
+
+	const projectLabel = run.project_name ?? run.project_slug;
+	const taskLineInner = (
+		<>
+			<span>Task:</span>
+			<span className="font-mono text-text">{run.task_identifier}</span>
+			{run.task_title && <span>{run.task_title}</span>}
+			{isInstanceAgent && projectLabel && (
+				<span data-testid="run-task-project" className="text-text-subtle">
+					· {projectLabel}
+				</span>
+			)}
+		</>
+	);
 
 	return (
 		<div>
@@ -133,36 +156,20 @@ function ExecutionDetailPage() {
 
 			{run.task_identifier &&
 				(run.task_id ? (
-					run.project_slug ? (
-						<Link
-							to="/projects/$projectId/tasks/$taskId"
-							params={{
-								projectId: run.project_slug,
-								taskId: run.task_identifier.toLowerCase(),
-							}}
-							{...(run.run_comment_id ? { hash: `comment-${run.run_comment_id}` } : {})}
-							className="mb-4 inline-flex items-baseline gap-1 text-xs text-text-muted hover:text-text"
-						>
-							<span>Task:</span>
-							<span className="font-mono text-text">{run.task_identifier}</span>
-							{run.task_title && <span>{run.task_title}</span>}
-						</Link>
-					) : (
-						<Link
-							to="/projects/$projectId/tasks/$taskId"
-							params={{ projectId, taskId: run.task_identifier.toLowerCase() }}
-							{...(run.run_comment_id ? { hash: `comment-${run.run_comment_id}` } : {})}
-							className="mb-4 inline-flex items-baseline gap-1 text-xs text-text-muted hover:text-text"
-						>
-							<span>Task:</span>
-							<span className="font-mono text-text">{run.task_identifier}</span>
-							{run.task_title && <span>{run.task_title}</span>}
-						</Link>
-					)
+					<Link
+						to="/projects/$projectId/tasks/$taskId"
+						params={{
+							projectId: run.project_slug ?? projectId,
+							taskId: run.task_identifier.toLowerCase(),
+						}}
+						{...(run.run_comment_id ? { hash: `comment-${run.run_comment_id}` } : {})}
+						className="mb-4 inline-flex items-baseline gap-1 text-xs text-text-muted hover:text-text"
+					>
+						{taskLineInner}
+					</Link>
 				) : (
-					<div className="mb-4 text-xs text-text-muted">
-						Task: <span className="font-mono text-text">{run.task_identifier}</span>
-						{run.task_title && <span className="ml-1">{run.task_title}</span>}
+					<div className="mb-4 inline-flex items-baseline gap-1 text-xs text-text-muted">
+						{taskLineInner}
 					</div>
 				))}
 

--- a/packages/web/src/routes/projects/$projectId/agents/$agentId/executions/index.tsx
+++ b/packages/web/src/routes/projects/$projectId/agents/$agentId/executions/index.tsx
@@ -1,6 +1,8 @@
+import { INSTANCE_AGENT_SLUGS } from '@hezo/shared';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { Badge } from '../../../../../../components/ui/badge';
 import { Tooltip } from '../../../../../../components/ui/tooltip';
+import { useAgent } from '../../../../../../hooks/use-agents';
 import { useElapsedDuration } from '../../../../../../hooks/use-elapsed-duration';
 import { type HeartbeatRun, useHeartbeatRuns } from '../../../../../../hooks/use-heartbeat-runs';
 import { formatTriggerReason } from '../../../../../../lib/run-trigger';
@@ -26,13 +28,16 @@ function ExecutionRow({
 	run,
 	projectId,
 	agentId,
+	isInstanceAgent,
 }: {
 	run: HeartbeatRun;
 	projectId: string;
 	agentId: string;
+	isInstanceAgent: boolean;
 }) {
 	const elapsed = useElapsedDuration(run.started_at ?? '', run.finished_at);
 	const trigger = formatTriggerReason(run, projectId);
+	const projectLabel = run.project_name ?? run.project_slug;
 
 	return (
 		<Link
@@ -51,6 +56,11 @@ function ExecutionRow({
 				<span className="text-text-muted font-mono">
 					{run.task_identifier}
 					{run.task_title && <span className="font-sans ml-1.5 text-text">{run.task_title}</span>}
+					{isInstanceAgent && projectLabel && (
+						<span data-testid="run-row-project" className="font-sans ml-1.5 text-text-subtle">
+							· {projectLabel}
+						</span>
+					)}
 				</span>
 			)}
 
@@ -80,6 +90,12 @@ function ExecutionRow({
 function ExecutionListPage() {
 	const { projectId, agentId } = Route.useParams();
 	const { data: runs, isLoading } = useHeartbeatRuns(projectId, agentId);
+	const { data: agent } = useAgent(projectId, agentId);
+
+	// CEO/Coach runs span many projects (the list is member-scoped), so show each
+	// row's project. Gate on the agent slug — see the run-detail page for why.
+	const isInstanceAgent =
+		!!agent && (INSTANCE_AGENT_SLUGS as readonly string[]).includes(agent.slug);
 
 	if (isLoading) return <div className="text-text-muted text-sm">Loading executions...</div>;
 
@@ -90,7 +106,13 @@ function ExecutionListPage() {
 	return (
 		<div className="flex flex-col gap-1">
 			{runs.map((run) => (
-				<ExecutionRow key={run.id} run={run} projectId={projectId} agentId={agentId} />
+				<ExecutionRow
+					key={run.id}
+					run={run}
+					projectId={projectId}
+					agentId={agentId}
+					isInstanceAgent={isInstanceAgent}
+				/>
 			))}
 		</div>
 	);

--- a/packages/web/test/agent-executions-project.test.tsx
+++ b/packages/web/test/agent-executions-project.test.tsx
@@ -1,0 +1,189 @@
+// CEO/Coach are instance agents that run tasks across every project, so their
+// execution pages surface which project each task lives in. Render-driven (no
+// real layout/viewport/WebSocket), so this lives in the component tier. The run
+// + agent responses are fetch-mocked (same pattern as run-created-tasks /
+// run-termination) because constructing a realistic cross-project run against
+// the real backend is impractical; the server returns project_name is covered
+// by packages/server/test/heartbeat-runs.test.ts.
+
+import { afterEach, expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+import { seedProject, seedTask, seedWorkspace } from './helpers/seed';
+
+const RUN_ID = 'dddd0000-0000-0000-0000-0000000000a1';
+
+let restoreFetch: (() => void) | null = null;
+afterEach(() => {
+	restoreFetch?.();
+	restoreFetch = null;
+});
+
+function installMocks(opts: {
+	agentId: string;
+	agentSlug: string;
+	teamId: string;
+	taskId: string;
+}) {
+	const agent = {
+		id: opts.agentId,
+		team_id: opts.teamId,
+		display_name: opts.agentSlug,
+		title: opts.agentSlug === 'ceo' ? 'CEO' : 'Captain',
+		slug: opts.agentSlug,
+		summary: 'Agent summary.',
+		role_description: '',
+		team_context: '',
+		default_effort: 'medium',
+		heartbeat_interval_min: 60,
+		run_timeout_min: 60,
+		monthly_budget_cents: 3000,
+		budget_used_cents: 0,
+		touches_code: false,
+		budget_reset_at: null,
+		runtime_status: 'active',
+		admin_status: 'enabled',
+		is_instance: opts.agentSlug === 'ceo',
+		reports_to: null,
+		reports_to_title: null,
+		assigned_task_count: 0,
+		model_override_provider: null,
+		model_override_model: null,
+		created_at: new Date().toISOString(),
+	};
+
+	// The run's task lives in a *different* project than the page's route, the way
+	// a real CEO/Coach cross-team run does.
+	const run = {
+		id: RUN_ID,
+		member_id: opts.agentId,
+		team_id: opts.teamId,
+		wakeup_id: null,
+		task_id: opts.taskId,
+		task_identifier: 'ACME-12',
+		task_title: 'Review team coherence after roster change',
+		project_id: '99999999-9999-9999-9999-999999999999',
+		project_slug: 'acme-robotics',
+		project_name: 'Acme Robotics',
+		status: 'succeeded',
+		queued_reason: null,
+		started_at: '2026-06-07T20:58:30Z',
+		finished_at: '2026-06-07T20:59:50Z',
+		exit_code: 0,
+		error: null,
+		input_tokens: 0,
+		output_tokens: 0,
+		cost_cents: 0,
+		invocation_command: null,
+		log_text: 'done',
+		working_dir: null,
+		trigger_source: 'assignment',
+		trigger_payload: null,
+		trigger_comment_id: null,
+		trigger_actor_member_id: null,
+		trigger_actor_slug: null,
+		trigger_actor_title: null,
+		trigger_comment_task_id: null,
+		trigger_comment_task_identifier: null,
+		trigger_comment_project_slug: null,
+		run_comment_id: null,
+		created_tasks: [],
+		created_docs: [],
+		created_skills: [],
+		proposed_skills: [],
+	};
+
+	const original = globalThis.fetch;
+	restoreFetch = () => {
+		globalThis.fetch = original;
+	};
+	globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+		const url = typeof input === 'string' ? input : (input as Request).url;
+		const method = init?.method ?? (input instanceof Request ? input.method : 'GET');
+
+		// Short-circuit the app shell's update check so the in-process server never
+		// reaches out to GitHub (keeps the run network-free and the log quiet).
+		if (method === 'GET' && /\/api\/updates\/latest$/.test(url)) {
+			return new Response(
+				JSON.stringify({
+					data: { current: '0.0.0', latest: null, updateAvailable: false, url: null },
+				}),
+				{ status: 200, headers: { 'Content-Type': 'application/json' } },
+			);
+		}
+
+		if (
+			method === 'GET' &&
+			new RegExp(`/api/projects/[^/]+/agents/[^/]+/heartbeat-runs/${RUN_ID}$`).test(url)
+		) {
+			return new Response(JSON.stringify({ data: run }), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			});
+		}
+		if (
+			method === 'GET' &&
+			new RegExp(`/api/projects/[^/]+/agents/${opts.agentId}(\\?.*)?$`).test(url)
+		) {
+			return new Response(JSON.stringify({ data: agent }), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			});
+		}
+		return original(input as RequestInfo, init);
+	}) as typeof globalThis.fetch;
+}
+
+test('CEO run-detail page shows the task project as a suffix on the task link', async () => {
+	const seeded = { projectSlug: '', agentId: '' };
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const captain = ws.agents.find((a) => a.slug === 'captain') ?? ws.agents[0];
+			const project = await seedProject(ws, { name: 'Home Project' });
+			const task = await seedTask(ws, project, { title: 'Anchor', assignee_id: captain.id });
+			seeded.projectSlug = project.slug;
+			seeded.agentId = captain.id;
+			installMocks({ agentId: captain.id, agentSlug: 'ceo', teamId: ws.team.id, taskId: task.id });
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/agents/$agentId/executions/$runId',
+		params: { projectId: seeded.projectSlug, agentId: seeded.agentId, runId: RUN_ID },
+	});
+
+	const suffix = await findByTestId('run-task-project', undefined, { timeout: 20_000 });
+	expect(suffix.textContent).toContain('Acme Robotics');
+});
+
+test('non-instance agent run-detail page omits the task project suffix', async () => {
+	const seeded = { projectSlug: '', agentId: '' };
+	const { findByTestId, queryByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const captain = ws.agents.find((a) => a.slug === 'captain') ?? ws.agents[0];
+			const project = await seedProject(ws, { name: 'Plain Project' });
+			const task = await seedTask(ws, project, { title: 'Anchor', assignee_id: captain.id });
+			seeded.projectSlug = project.slug;
+			seeded.agentId = captain.id;
+			installMocks({
+				agentId: captain.id,
+				agentSlug: 'captain',
+				teamId: ws.team.id,
+				taskId: task.id,
+			});
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/agents/$agentId/executions/$runId',
+		params: { projectId: seeded.projectSlug, agentId: seeded.agentId, runId: RUN_ID },
+	});
+
+	// The triggered-by line renders as soon as the run loads, so once it's present
+	// the task line has rendered too — and must carry no project suffix.
+	await findByTestId('run-trigger-reason', undefined, { timeout: 20_000 });
+	expect(queryByTestId('run-task-project')).toBeNull();
+});


### PR DESCRIPTION
CEO and Coach are instance agents that run tasks across every project, so
their executions list and run-detail pages now show which project each task
belongs to, as a "· <project>" suffix on the task title. Gated on the agent
slug (ceo/coach) — normal team agents, whose tasks are always in their own
1:1 project, are unaffected.

- agents.ts: return the task's project name on heartbeat runs (project_name)
- run-detail + executions list: render the project suffix for instance agents
- collapse the duplicated run-detail task-link branches into one

Tests: extend heartbeat-runs API test for project_name/project_slug; add a
web component test asserting the suffix shows for CEO and not for a captain.

https://claude.ai/code/session_016vBUDxgoTrNJqYbKVQxMtM