### PR TITLE
feat(web): replace HQ coordination banner with sidebar info tooltip

### DIFF
--- a/packages/web/src/components/project-sidebar.tsx
+++ b/packages/web/src/components/project-sidebar.tsx
@@ -1,6 +1,6 @@
 import { AgentAdminStatus } from '@hezo/shared';
 import { Link, useNavigate } from '@tanstack/react-router';
-import { Globe } from 'lucide-react';
+import { Globe, Info } from 'lucide-react';
 import { useState } from 'react';
 import { useActiveProject } from '../hooks/use-active-project';
 import { useAgents } from '../hooks/use-agents';
@@ -9,6 +9,7 @@ import { useProjectMeta } from '../hooks/use-projects';
 import { agentPageParams } from './agent-link';
 import { AgentStatusLabel } from './agent-status-label';
 import { SidebarNav, type SidebarNavSection } from './sidebar-nav';
+import { Tooltip } from './ui/tooltip';
 
 const TEAM_COLLAPSED_KEY = 'hezo:sidebar:team-collapsed';
 
@@ -148,7 +149,7 @@ export function ProjectSidebar() {
 
 	return (
 		<div className="flex flex-col h-full">
-			<div className="px-2.5 pt-1.5 pb-1">
+			<div className="px-2.5 pt-1.5 pb-1 flex items-center gap-1 min-w-0">
 				<Link
 					to="/projects/$projectId"
 					params={projectParams}
@@ -165,6 +166,21 @@ export function ProjectSidebar() {
 						projectId
 					)}
 				</Link>
+				{isInternal && (
+					<Tooltip
+						content="Internal team coordination project, used for onboarding and team-level changes."
+						side="right"
+					>
+						<button
+							type="button"
+							aria-label="About this project"
+							data-testid="project-sidebar-info"
+							className="shrink-0 text-text-subtle hover:text-text transition-colors"
+						>
+							<Info className="w-3.5 h-3.5" aria-hidden="true" />
+						</button>
+					</Tooltip>
+				)}
 			</div>
 			<div className="flex-1">
 				<SidebarNav sections={sections} />

--- a/packages/web/src/routes/projects/$projectId/route.tsx
+++ b/packages/web/src/routes/projects/$projectId/route.tsx
@@ -1,29 +1,12 @@
-import { createFileRoute, Outlet, useLocation } from '@tanstack/react-router';
-import { Info } from 'lucide-react';
+import { createFileRoute, Outlet } from '@tanstack/react-router';
 import { ContainerStatusBanner } from '../../../components/container-status-banner';
-import { useProjectMeta } from '../../../hooks/use-projects';
 
 function ProjectLayout() {
 	const { projectId } = Route.useParams();
-	const project = useProjectMeta(projectId);
-	const { pathname } = useLocation();
-
-	const base = `/projects/${projectId}`;
-	const isInternal = project?.is_internal ?? false;
-	const showBanner =
-		isInternal && (pathname === `${base}/tasks` || pathname === `${base}/container`);
 
 	return (
 		<div>
 			<ContainerStatusBanner projectId={projectId} />
-			{showBanner && (
-				<div className="flex items-start gap-2 mb-4 px-3 py-2 rounded-radius-md bg-bg-subtle text-text-muted text-[13px]">
-					<Info className="w-4 h-4 mt-px shrink-0" aria-hidden="true" />
-					<span>
-						Internal team coordination project, used for onboarding and team-level changes.
-					</span>
-				</div>
-			)}
 			<Outlet />
 		</div>
 	);

--- a/packages/web/test/internal-project.test.tsx
+++ b/packages/web/test/internal-project.test.tsx
@@ -43,7 +43,7 @@ test('sidebar exposes only Tasks and Container for the HQ project', async () => 
 });
 
 test('coordination info tooltip sits beside the HQ name', async () => {
-	const { findByTestId, getByText, user, router } = await renderApp({
+	const { findByTestId, getAllByText, user, router } = await renderApp({
 		initialPath: '/',
 		seed: async () => {
 			await seedWorkspace();
@@ -60,8 +60,10 @@ test('coordination info tooltip sits beside the HQ name', async () => {
 
 	await waitFor(() =>
 		expect(
-			getByText('Internal team coordination project, used for onboarding and team-level changes.'),
-		).toBeTruthy(),
+			getAllByText(
+				'Internal team coordination project, used for onboarding and team-level changes.',
+			).length,
+		).toBeGreaterThan(0),
 	);
 });
 

--- a/packages/web/test/internal-project.test.tsx
+++ b/packages/web/test/internal-project.test.tsx
@@ -6,8 +6,8 @@ import { seedWorkspace } from './helpers/seed';
 
 // HQ is the only internal project: the instance-wide coordination project that
 // hosts the CEO and Coach. Its slug is HQ_PROJECT_SLUG and `is_internal` is
-// true, so it gets the restricted sidebar, the coordination banner, and the
-// documents/settings redirects.
+// true, so it gets the restricted sidebar, the coordination info tooltip beside
+// its name, and the documents/settings redirects.
 
 test('sidebar exposes only Tasks and Container for the HQ project', async () => {
 	const { findAllByRole, queryAllByRole, container, router } = await renderApp({
@@ -42,28 +42,27 @@ test('sidebar exposes only Tasks and Container for the HQ project', async () => 
 	expect(container.querySelector('nav')).toBeTruthy();
 });
 
-test('banner appears on HQ landing pages', async () => {
-	const { findByText, router } = await renderApp({
+test('coordination info tooltip sits beside the HQ name', async () => {
+	const { findByTestId, getByText, user, router } = await renderApp({
 		initialPath: '/',
 		seed: async () => {
 			await seedWorkspace();
 		},
 	});
 
-	const bannerCopy =
-		'Internal team coordination project, used for onboarding and team-level changes.';
-
 	await router.navigate({
 		to: '/projects/$projectId/tasks',
 		params: { projectId: HQ_PROJECT_SLUG },
 	});
-	await findByText(bannerCopy, undefined, { timeout: 10_000 });
 
-	await router.navigate({
-		to: '/projects/$projectId/container',
-		params: { projectId: HQ_PROJECT_SLUG },
-	});
-	await findByText(bannerCopy, undefined, { timeout: 10_000 });
+	const info = await findByTestId('project-sidebar-info', undefined, { timeout: 10_000 });
+	await user.hover(info);
+
+	await waitFor(() =>
+		expect(
+			getByText('Internal team coordination project, used for onboarding and team-level changes.'),
+		).toBeTruthy(),
+	);
 });
 
 test('direct navigation to /documents and /settings redirects to /tasks', async () => {


### PR DESCRIPTION
## Summary

Moves the HQ (internal-project) coordination copy out of the full-width banner that appeared on the Tasks/Container pages and into an info icon beside the project name in the project sidebar. Hovering the icon shows the tooltip _"Internal team coordination project, used for onboarding and team-level changes."_

## Changes

- **`project-sidebar.tsx`** — Added an `Info` icon button next to the project name, rendered only for internal projects (HQ). It uses the existing `Tooltip` component (positioned right). The name link + icon sit on one flex row.
- **`route.tsx`** (project layout) — Removed the full-width banner block and its now-unused imports/logic.
- **`internal-project.test.tsx`** — Replaced the banner-presence test with one that finds the info icon, hovers it, and asserts the tooltip copy appears.

## Behaviour note

The old banner only showed on Tasks/Container; the tooltip icon now lives in the sidebar, so it's reachable across all HQ pages.

## Testing

- `internal-project.test.tsx` passes (3/3)
- `tsc --noEmit` clean across packages