### PR TITLE
style(web): restore page padding around project content

### DIFF
--- a/packages/web/src/components/inbox-view.tsx
+++ b/packages/web/src/components/inbox-view.tsx
@@ -109,13 +109,11 @@ export function InboxView({ teamIds, scope }: InboxViewProps) {
 	}, [rows, readFilter, debouncedSearch]);
 
 	if (isLoading) {
-		return (
-			<div className="px-4 py-4 md:px-6 md:py-5 lg:px-8 lg:py-6 text-text-muted">Loading...</div>
-		);
+		return <div className="text-text-muted">Loading...</div>;
 	}
 
 	return (
-		<div className="px-4 py-4 md:px-6 md:py-5 lg:px-8 lg:py-6">
+		<div>
 			<h1 className="text-[22px] font-medium mb-5">Inbox</h1>
 
 			<div className="flex flex-col gap-2 mb-4 sm:flex-row sm:items-center sm:justify-between">

--- a/packages/web/src/routes/home/inbox/index.tsx
+++ b/packages/web/src/routes/home/inbox/index.tsx
@@ -5,7 +5,11 @@ import { useTeams } from '../../../hooks/use-teams';
 function GlobalInboxPage() {
 	const { data: teams } = useTeams();
 	const teamIds = (teams ?? []).map((t) => t.slug);
-	return <InboxView teamIds={teamIds} scope="global" />;
+	return (
+		<div className="px-4 py-4 md:px-6 md:py-5 lg:px-8 lg:py-6">
+			<InboxView teamIds={teamIds} scope="global" />
+		</div>
+	);
 }
 
 export const Route = createFileRoute('/home/inbox/')({

--- a/packages/web/src/routes/projects/$projectId/audit-log.tsx
+++ b/packages/web/src/routes/projects/$projectId/audit-log.tsx
@@ -7,7 +7,7 @@ function ProjectAuditLogPage() {
 	const { data: entries } = useProjectAuditLog(projectId);
 
 	return (
-		<div className="px-4 py-4 md:px-6 md:py-5 lg:px-8 lg:py-6">
+		<div>
 			<div className="mb-4">
 				<h2 className="text-base font-medium">Activity</h2>
 				<p className="text-[13px] text-text-muted mt-1">

--- a/packages/web/src/routes/projects/$projectId/connectors.tsx
+++ b/packages/web/src/routes/projects/$projectId/connectors.tsx
@@ -47,7 +47,7 @@ function ConnectorsPage() {
 	const isEmpty = connectors.length === 0 && oauthConnections.length === 0;
 
 	return (
-		<div className="space-y-6 p-4 sm:p-6 max-w-4xl">
+		<div className="space-y-6 max-w-4xl">
 			<header>
 				<h1 className="text-xl font-semibold flex items-center gap-2">
 					<Plug className="size-5" />

--- a/packages/web/src/routes/projects/$projectId/route.tsx
+++ b/packages/web/src/routes/projects/$projectId/route.tsx
@@ -7,7 +7,9 @@ function ProjectLayout() {
 	return (
 		<div>
 			<ContainerStatusBanner projectId={projectId} />
-			<Outlet />
+			<div className="px-4 py-4 md:px-6 md:py-5 lg:px-8 lg:py-6">
+				<Outlet />
+			</div>
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary

- Wraps the project layout's inner content (info banner + `<Outlet />`) in the standard `px-4 py-4 md:px-6 md:py-5 lg:px-8 lg:py-6` so every project subroute (tasks list, task detail, container, documents, agents, settings, etc.) has breathing room from the project sidebar and viewport edge again.
- Keeps `ContainerStatusBanner` outside the wrapper — it is `sticky top-0` and meant to be edge-to-edge.
- Dedupes the three project pages that already padded themselves: project audit-log, project connectors, and `InboxView` (whose padding moves up to the standalone `/home/inbox` route so the global inbox is unchanged).

## Why

The project-centric refactor (#135) dropped the page-padding wrapper the old `teams/$teamId/route.tsx` had around its `<Outlet />`. PR #138 added padding to standalone pages but not to the project layout, so every project page — including the HQ tasks list shown in the regression screenshot — was rendering its filters and action buttons flush against the right edge with no top gap below sticky banners.

## Test plan

- [x] `bunx vitest run` (web component tier) — 67 files / 243 tests pass
- [ ] Manual check at mobile / tablet / desktop widths: `/projects/hq/tasks`, `/projects/hq/inbox`, `/projects/hq/audit-log`, `/projects/hq/connectors`, `/home/inbox`, `/home/tasks`
- [ ] Playwright `content-width.spec.ts` (1280px well cap) — unaffected because the padding sits inside the well