### PR TITLE
feat(web): drop Instance jargon, prune top nav, add page-title info tooltips

### DIFF
--- a/packages/web/src/components/app-header.tsx
+++ b/packages/web/src/components/app-header.tsx
@@ -1,5 +1,5 @@
 import { Link } from '@tanstack/react-router';
-import { BookOpen, FolderKanban, House, Inbox, KeyRound, Menu, Plug, Settings } from 'lucide-react';
+import { BookOpen, FolderKanban, House, Inbox, Menu, Settings } from 'lucide-react';
 import { useGlobalInboxUnreadCount } from '../hooks/use-inbox-count';
 import { useMe } from '../hooks/use-me';
 import { ThemeSwitcher } from './ui/theme-switcher';
@@ -9,10 +9,10 @@ const iconLinkClass =
 
 /**
  * The global top header: instance-wide navigation. Only Home sits at the
- * top-left; everything else (Inbox, All Tasks, the Admin-only instance
- * resources — Skills / Connectors / Credentials — Settings, and the theme
- * switcher) lives in the top-right group. On mobile a hamburger opens the
- * project drawer. Project creation lives on the project rail, not here.
+ * top-left; everything else (Inbox, All Tasks, the Admin-only Skills
+ * shortcut, Settings, and the theme switcher) lives in the top-right group.
+ * Connectors and Credentials are reached through the Settings sidebar.
+ * On mobile a hamburger opens the project drawer.
  */
 export function AppHeader({ onOpenDrawer }: { onOpenDrawer: () => void }) {
 	const { data: me } = useMe();
@@ -74,35 +74,15 @@ export function AppHeader({ onOpenDrawer }: { onOpenDrawer: () => void }) {
 					<FolderKanban className="w-4 h-4" />
 				</Link>
 				{me?.is_superuser && (
-					<>
-						<Link
-							to="/settings/skills"
-							aria-label="Skills"
-							title="Skills"
-							data-testid="app-header-skills"
-							className={iconLinkClass}
-						>
-							<BookOpen className="w-4 h-4" />
-						</Link>
-						<Link
-							to="/settings/connectors"
-							aria-label="Connectors"
-							title="Connectors"
-							data-testid="app-header-connectors"
-							className={iconLinkClass}
-						>
-							<Plug className="w-4 h-4" />
-						</Link>
-						<Link
-							to="/settings/credentials"
-							aria-label="Credentials"
-							title="Credentials"
-							data-testid="app-header-credentials"
-							className={iconLinkClass}
-						>
-							<KeyRound className="w-4 h-4" />
-						</Link>
-					</>
+					<Link
+						to="/settings/skills"
+						aria-label="Skills"
+						title="Skills"
+						data-testid="app-header-skills"
+						className={iconLinkClass}
+					>
+						<BookOpen className="w-4 h-4" />
+					</Link>
 				)}
 				<Link
 					to="/settings"

--- a/packages/web/src/components/inbox-view.tsx
+++ b/packages/web/src/components/inbox-view.tsx
@@ -7,6 +7,7 @@ import { ApprovalCard } from './approval-card';
 import { MentionCard } from './mention-card';
 import { EmptyState } from './ui/empty-state';
 import { FilterPills } from './ui/filter-pills';
+import { InfoTooltip } from './ui/info-tooltip';
 
 interface InboxViewProps {
 	teamIds: string[];
@@ -114,7 +115,18 @@ export function InboxView({ teamIds, scope }: InboxViewProps) {
 
 	return (
 		<div>
-			<h1 className="text-[22px] font-medium mb-5">Inbox</h1>
+			<div className="flex items-center gap-1.5 mb-5">
+				<h1 className="text-[22px] font-medium">{scope === 'global' ? 'Global inbox' : 'Inbox'}</h1>
+				<InfoTooltip
+					label="About the inbox"
+					content={
+						scope === 'global'
+							? 'Approvals and mentions waiting on you from every team you belong to.'
+							: 'Approvals and mentions waiting on you in this team.'
+					}
+					data-testid="inbox-info"
+				/>
+			</div>
 
 			<div className="flex flex-col gap-2 mb-4 sm:flex-row sm:items-center sm:justify-between">
 				<FilterPills options={READ_OPTIONS} value={readFilter} onChange={setReadFilter} />

--- a/packages/web/src/routes/home/tasks/index.tsx
+++ b/packages/web/src/routes/home/tasks/index.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { TaskStatusBadge } from '../../../components/task-status-badge';
+import { InfoTooltip } from '../../../components/ui/info-tooltip';
 import { useAllVisibleProjects } from '../../../hooks/use-projects';
 import { type GlobalTask, useAllTasks } from '../../../hooks/use-tasks';
 
@@ -35,7 +36,14 @@ function AllTasksPage() {
 			className="max-w-7xl mx-auto w-full px-4 py-4 md:px-6 md:py-5 lg:px-8 lg:py-6"
 			data-testid="all-tasks-page"
 		>
-			<h1 className="text-[22px] font-medium mb-5">All Tasks</h1>
+			<div className="flex items-center gap-1.5 mb-5">
+				<h1 className="text-[22px] font-medium">All Tasks</h1>
+				<InfoTooltip
+					label="About the All Tasks page"
+					content="Every task across every project and team you can see, in one list."
+					data-testid="all-tasks-info"
+				/>
+			</div>
 			{isLoading ? (
 				<div className="text-text-muted text-[13px]">Loading tasks…</div>
 			) : (tasks ?? []).length === 0 ? (

--- a/packages/web/src/routes/settings/audit-log.tsx
+++ b/packages/web/src/routes/settings/audit-log.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { AuditLogTable } from '../../components/audit-log-table';
+import { InfoTooltip } from '../../components/ui/info-tooltip';
 import { useInstanceAuditLog } from '../../hooks/use-audit-log';
 import { useMe } from '../../hooks/use-me';
 
@@ -15,7 +16,14 @@ function InstanceAuditLogPage() {
 		) : (
 			<>
 				<div className="mb-4">
-					<h1 className="text-[22px] font-medium">Instance activity</h1>
+					<div className="flex items-center gap-1.5">
+						<h1 className="text-[22px] font-medium">Activity</h1>
+						<InfoTooltip
+							label="About activity"
+							content="Audit log of every state-changing action across all teams, plus instance-level admin actions."
+							data-testid="activity-info"
+						/>
+					</div>
 					<p className="text-[13px] text-text-muted mt-1 max-w-[680px]">
 						Every state-changing action across all teams, plus instance-level admin actions
 						(credentials, connectors, skills) that aren't tied to a team. The combined view for

--- a/packages/web/src/routes/settings/connectors.tsx
+++ b/packages/web/src/routes/settings/connectors.tsx
@@ -3,6 +3,7 @@ import { Plus, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { Badge } from '../../components/ui/badge';
 import { Button } from '../../components/ui/button';
+import { InfoTooltip } from '../../components/ui/info-tooltip';
 import { Input } from '../../components/ui/input';
 import {
 	useCreateInstanceConnector,
@@ -55,7 +56,14 @@ function InstanceConnectorsPage() {
 			<>
 				<div className="flex items-start justify-between gap-3 mb-4">
 					<div>
-						<h1 className="text-[22px] font-medium">Instance connectors</h1>
+						<div className="flex items-center gap-1.5">
+							<h1 className="text-[22px] font-medium">Connectors</h1>
+							<InfoTooltip
+								label="About connectors"
+								content="Remote MCP servers shared with every team's agent runs. A team-scoped connector with the same name overrides this."
+								data-testid="connectors-info"
+							/>
+						</div>
 						<p className="text-[13px] text-text-muted mt-1 max-w-[680px]">
 							Remote (SaaS) MCP servers shared with every team's agent runs. A team-scoped connector
 							with the same name overrides the instance one for that team. Authenticate per-team

--- a/packages/web/src/routes/settings/credentials.tsx
+++ b/packages/web/src/routes/settings/credentials.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { Badge } from '../../components/ui/badge';
 import { Button } from '../../components/ui/button';
 import { type Column, DataTable } from '../../components/ui/data-table';
+import { InfoTooltip } from '../../components/ui/info-tooltip';
 import { Input } from '../../components/ui/input';
 import { Tooltip } from '../../components/ui/tooltip';
 import type { CredentialUsage } from '../../hooks/use-credentials';
@@ -198,7 +199,14 @@ function InstanceCredentialsPage() {
 			<>
 				<div className="flex items-start justify-between gap-3 mb-4">
 					<div>
-						<h1 className="text-[22px] font-medium">Instance credentials</h1>
+						<div className="flex items-center gap-1.5">
+							<h1 className="text-[22px] font-medium">Credentials</h1>
+							<InfoTooltip
+								label="About credentials"
+								content="Secrets shared with every team's egress. Agents reference them by placeholder; a team-scoped secret with the same name overrides this."
+								data-testid="credentials-info"
+							/>
+						</div>
 						<p className="text-[13px] text-text-muted mt-1 max-w-[680px]">
 							Secrets shared with every team's egress. Agents reference them by placeholder (
 							<span className="font-mono">__HEZO_SECRET_NAME__</span>); the egress proxy substitutes

--- a/packages/web/src/routes/settings/index.tsx
+++ b/packages/web/src/routes/settings/index.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { useState } from 'react';
 import { AiProvidersSection } from '../../components/ai-providers-section';
+import { InfoTooltip } from '../../components/ui/info-tooltip';
 import { useMe } from '../../hooks/use-me';
 
 const settingsNav = [{ id: 'ai-providers', label: 'AI providers' }];
@@ -24,7 +25,14 @@ function GlobalSettingsPage() {
 
 	return (
 		<div className="max-w-[1000px] w-full px-4 py-4 md:px-6 md:py-5 lg:px-8 lg:py-6">
-			<h1 className="text-[22px] font-medium mb-5">Settings</h1>
+			<div className="flex items-center gap-1.5 mb-5">
+				<h1 className="text-[22px] font-medium">Settings</h1>
+				<InfoTooltip
+					label="About settings"
+					content="AI providers, plus instance-wide resources shared across teams (admin only)."
+					data-testid="settings-info"
+				/>
+			</div>
 			<div className="flex flex-col gap-4 md:grid md:grid-cols-[160px_1fr] md:gap-6">
 				<nav className="flex flex-col gap-0.5 sticky top-0">
 					{settingsNav.map((item) => (
@@ -41,22 +49,18 @@ function GlobalSettingsPage() {
 							{item.label}
 						</button>
 					))}
-					{me?.is_superuser && (
-						<>
-							<div className="mt-3 mb-0.5 px-3 text-[11px] font-medium uppercase tracking-wide text-text-subtle">
-								Instance
-							</div>
-							{instanceNav.map((item) => (
-								<Link
-									key={item.to}
-									to={item.to}
-									className="text-left text-[13px] px-3 py-1.5 rounded-radius-md transition-colors text-text-muted hover:text-text hover:bg-bg-subtle"
-								>
-									{item.label}
-								</Link>
-							))}
-						</>
-					)}
+					{me?.is_superuser &&
+						instanceNav.map((item, idx) => (
+							<Link
+								key={item.to}
+								to={item.to}
+								className={`text-left text-[13px] px-3 py-1.5 rounded-radius-md transition-colors text-text-muted hover:text-text hover:bg-bg-subtle ${
+									idx === 0 ? 'mt-3' : ''
+								}`}
+							>
+								{item.label}
+							</Link>
+						))}
 				</nav>
 				<div className="space-y-8">
 					<div id="settings-ai-providers">

--- a/packages/web/src/routes/settings/skills.tsx
+++ b/packages/web/src/routes/settings/skills.tsx
@@ -3,6 +3,7 @@ import { Pencil, Plus, Trash2 } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { Badge } from '../../components/ui/badge';
 import { Button } from '../../components/ui/button';
+import { InfoTooltip } from '../../components/ui/info-tooltip';
 import { Input } from '../../components/ui/input';
 import {
 	useCreateInstanceSkill,
@@ -105,7 +106,14 @@ function InstanceSkillsPage() {
 			<>
 				<div className="flex items-start justify-between gap-3 mb-4">
 					<div>
-						<h1 className="text-[22px] font-medium">Instance skills</h1>
+						<div className="flex items-center gap-1.5">
+							<h1 className="text-[22px] font-medium">Skills</h1>
+							<InfoTooltip
+								label="About skills"
+								content="Reusable skill docs shared with every team's agents. A team-scoped skill with the same slug overrides this."
+								data-testid="skills-info"
+							/>
+						</div>
 						<p className="text-[13px] text-text-muted mt-1 max-w-[680px]">
 							Reusable skill docs shared with every team's agents. A team-scoped skill with the same
 							slug overrides the instance one for that team.

--- a/packages/web/test/app-header.test.tsx
+++ b/packages/web/test/app-header.test.tsx
@@ -32,8 +32,8 @@ test('header keeps Home top-left and the rest in the top-right group', async () 
 	expect(header.querySelector('[data-testid="app-header-new"]') ?? null).toBeNull();
 });
 
-test('header exposes instance-resource shortcuts that navigate to the settings pages', async () => {
-	const { findByTestId, getByTestId, user, router } = await renderApp({
+test('header exposes the Skills shortcut and routes connectors/credentials through Settings', async () => {
+	const { findByTestId, getByTestId, queryByTestId, user, router } = await renderApp({
 		initialPath: '/home',
 		seed: async () => {
 			await seedWorkspace();
@@ -41,9 +41,10 @@ test('header exposes instance-resource shortcuts that navigate to the settings p
 	});
 
 	await findByTestId('app-header-skills');
-	getByTestId('app-header-connectors');
-	getByTestId('app-header-credentials');
 	getByTestId('app-header-settings');
+
+	expect(queryByTestId('app-header-connectors')).toBeNull();
+	expect(queryByTestId('app-header-credentials')).toBeNull();
 
 	await user.click(getByTestId('app-header-skills'));
 	await waitFor(() => expect(router.state.location.pathname).toBe('/settings/skills'));

--- a/packages/web/test/inbox-global.test.tsx
+++ b/packages/web/test/inbox-global.test.tsx
@@ -13,5 +13,5 @@ test('global inbox route mounts across all of the user teams', async () => {
 	// The /home/inbox route mounts InboxView in global scope (aggregating every
 	// team the user belongs to). The page heading distinguishes it from the
 	// sidebar's per-team "Inbox" link.
-	await findByRole('heading', { name: 'Inbox' });
+	await findByRole('heading', { name: 'Global inbox' });
 });

--- a/packages/web/test/instance-connectors.test.tsx
+++ b/packages/web/test/instance-connectors.test.tsx
@@ -1,3 +1,4 @@
+import { waitFor } from '@testing-library/react';
 import { expect, test } from 'vitest';
 import { renderApp } from './helpers/render';
 
@@ -26,7 +27,7 @@ test('lists seeded instance connectors and creates a new one via the form', asyn
 		},
 	});
 
-	await findByText('Instance connectors');
+	await findByText('Connectors');
 	await findByText('Seeded Docs');
 
 	await user.click(getByRole('button', { name: 'Add' }));
@@ -37,15 +38,19 @@ test('lists seeded instance connectors and creates a new one via the form', asyn
 	await findByText('new-conn');
 });
 
-test('settings page Instance group links to connectors', async () => {
-	const { findByText, getAllByRole, user, router } = await renderApp({ initialPath: '/settings' });
+test('settings page sidebar links to connectors', async () => {
+	const { findByRole, getAllByRole, user, router } = await renderApp({ initialPath: '/settings' });
 
-	await findByText('Instance');
-	const links = getAllByRole('link', { name: 'Connectors' });
-	const instanceLink = links.find((l) => l.getAttribute('href') === '/settings/connectors');
-	expect(instanceLink).toBeTruthy();
-	await user.click(instanceLink as HTMLElement);
+	await findByRole('heading', { name: 'Settings' });
+	const sidebarLink = await waitFor(() => {
+		const link = getAllByRole('link', { name: 'Connectors' }).find(
+			(l) => l.getAttribute('href') === '/settings/connectors',
+		);
+		expect(link).toBeTruthy();
+		return link as HTMLElement;
+	});
+	await user.click(sidebarLink);
 
 	expect(router.state.location.pathname).toBe('/settings/connectors');
-	await findByText('Instance connectors');
+	await findByRole('heading', { name: 'Connectors' });
 });

--- a/packages/web/test/instance-credentials.test.tsx
+++ b/packages/web/test/instance-credentials.test.tsx
@@ -1,3 +1,4 @@
+import { waitFor } from '@testing-library/react';
 import { expect, test } from 'vitest';
 import { renderApp } from './helpers/render';
 
@@ -26,7 +27,7 @@ test('lists seeded instance credentials and creates a new one via the form', asy
 	});
 
 	// Heading + the seeded credential render.
-	await findByText('Instance credentials');
+	await findByText('Credentials');
 	await findByText('SEEDED_KEY');
 
 	// Open the create form and add a new credential.
@@ -66,16 +67,20 @@ test('edits an instance credential host policy via the row edit affordance', asy
 	await findByText('api.new.example');
 });
 
-test('settings page shows the superuser Instance > Credentials link and navigates to it', async () => {
-	const { findByText, getAllByRole, user, router } = await renderApp({ initialPath: '/settings' });
+test('settings page shows the superuser Credentials link and navigates to it', async () => {
+	const { findByRole, getAllByRole, user, router } = await renderApp({ initialPath: '/settings' });
 
-	await findByText('Instance');
-	// The team sidebar also renders a "Credentials" link; pick the instance one by href.
-	const links = getAllByRole('link', { name: 'Credentials' });
-	const instanceLink = links.find((l) => l.getAttribute('href') === '/settings/credentials');
-	expect(instanceLink).toBeTruthy();
-	await user.click(instanceLink as HTMLElement);
+	await findByRole('heading', { name: 'Settings' });
+	// The team sidebar also renders a "Credentials" link; pick the instance-scoped one by href.
+	const sidebarLink = await waitFor(() => {
+		const link = getAllByRole('link', { name: 'Credentials' }).find(
+			(l) => l.getAttribute('href') === '/settings/credentials',
+		);
+		expect(link).toBeTruthy();
+		return link as HTMLElement;
+	});
+	await user.click(sidebarLink);
 
 	expect(router.state.location.pathname).toBe('/settings/credentials');
-	await findByText('Instance credentials');
+	await findByRole('heading', { name: 'Credentials' });
 });

--- a/packages/web/test/instance-skills.test.tsx
+++ b/packages/web/test/instance-skills.test.tsx
@@ -1,3 +1,4 @@
+import { waitFor } from '@testing-library/react';
 import { expect, test } from 'vitest';
 import { renderApp } from './helpers/render';
 
@@ -21,7 +22,7 @@ test('lists seeded instance skills and creates a new one via the form', async ()
 		},
 	});
 
-	await findByText('Instance skills');
+	await findByText('Skills');
 	await findByText('Seeded Skill');
 
 	await user.click(getByRole('button', { name: 'Add' }));
@@ -56,15 +57,19 @@ test('edits an instance skill via the row edit affordance', async () => {
 	await findByText('new desc');
 });
 
-test('settings page Instance group links to skills', async () => {
-	const { findByText, getAllByRole, user, router } = await renderApp({ initialPath: '/settings' });
+test('settings page sidebar links to skills', async () => {
+	const { findByRole, getAllByRole, user, router } = await renderApp({ initialPath: '/settings' });
 
-	await findByText('Instance');
-	const links = getAllByRole('link', { name: 'Skills' });
-	const instanceLink = links.find((l) => l.getAttribute('href') === '/settings/skills');
-	expect(instanceLink).toBeTruthy();
-	await user.click(instanceLink as HTMLElement);
+	await findByRole('heading', { name: 'Settings' });
+	const sidebarLink = await waitFor(() => {
+		const link = getAllByRole('link', { name: 'Skills' }).find(
+			(l) => l.getAttribute('href') === '/settings/skills',
+		);
+		expect(link).toBeTruthy();
+		return link as HTMLElement;
+	});
+	await user.click(sidebarLink);
 
 	expect(router.state.location.pathname).toBe('/settings/skills');
-	await findByText('Instance skills');
+	await findByRole('heading', { name: 'Skills' });
 });


### PR DESCRIPTION
## Summary

Cleans up the global-page UI per user feedback:

- **Top nav**: removed the Connectors and Credentials shortcuts — both are already reachable via the Settings sidebar. Skills shortcut stays (superuser only).
- **Page titles**: dropped the \"Instance\" prefix from Connectors / Credentials / Skills / Activity — end users have no mental model for \"instance\".
- **Global inbox**: heading is now scope-aware — \"Global inbox\" on \`/home/inbox\`, plain \"Inbox\" inside a team.
- **Info tooltips**: every top-level page H1 (All Tasks, Inbox, Settings, Connectors, Credentials, Skills, Activity) gets a small \`<InfoTooltip>\` suffix explaining what the page is, reusing the existing \`components/ui/info-tooltip.tsx\`.
- **Settings sidebar**: removed the \"Instance\" uppercase section divider; the link group keeps its visual gap via \`mt-3\` on the first link.

## Test plan

- [x] \`bun run test --skip-browser --pattern instance\` — 8/8 passing
- [x] \`bun run test --skip-browser --pattern app-header\` — 2/2 passing
- [x] \`bun run test --skip-browser --pattern inbox\` — 12/12 passing
- [x] \`bun run test --skip-browser --package web\` — 243/243 passing
- [x] \`bun run typecheck\` — clean
- [ ] Manual: visit \`/home/inbox\`, \`/home/tasks\`, \`/settings\`, \`/settings/{connectors,credentials,skills,audit-log}\` and confirm titles, info-icons + hover tooltips, and the absence of Connectors/Credentials icons from the top header
- [ ] Manual: confirm the Settings sidebar's instance-link group has visual spacing without the \"Instance\" divider