### PR TITLE
Reorder project rail pinned controls: create button above HQ

### DIFF
--- a/packages/web/src/components/project-rail.tsx
+++ b/packages/web/src/components/project-rail.tsx
@@ -13,7 +13,8 @@ import { Tooltip } from './ui/tooltip';
  * axis: every visible project across every team appears here. Selecting one
  * opens its menu in the panel to the right. There is no team-level grouping —
  * each project is presented as a standalone entity. The create-project action
- * is pinned to the bottom so it stays in place as the avatar list scrolls.
+ * and the HQ entry are pinned below the scrolling avatar list (create-project
+ * above HQ) so they stay in place as the avatar list scrolls.
  */
 export function ProjectRail() {
 	const { data: me } = useMe();
@@ -50,6 +51,21 @@ export function ProjectRail() {
 						);
 					})}
 				</div>
+				{me?.is_superuser && (
+					<div className="shrink-0 pt-2 mt-2 w-full flex justify-center border-t border-border">
+						<Tooltip content="New project" side="right">
+							<button
+								type="button"
+								onClick={() => setCreateOpen(true)}
+								aria-label="New project"
+								data-testid="project-rail-new"
+								className="w-9 h-9 rounded-radius-md flex items-center justify-center text-text-muted hover:text-text hover:bg-bg-elevated border border-dashed border-border transition-colors"
+							>
+								<Plus className="w-4 h-4" />
+							</button>
+						</Tooltip>
+					</div>
+				)}
 				{hq && (
 					<div className="shrink-0 pt-2 mt-2 w-full flex justify-center border-t border-border">
 						<Tooltip content={hq.name} side="right">
@@ -64,21 +80,6 @@ export function ProjectRail() {
 							>
 								<Building2 className="w-4 h-4" />
 							</Link>
-						</Tooltip>
-					</div>
-				)}
-				{me?.is_superuser && (
-					<div className="shrink-0 pt-2 mt-2 w-full flex justify-center border-t border-border">
-						<Tooltip content="New project" side="right">
-							<button
-								type="button"
-								onClick={() => setCreateOpen(true)}
-								aria-label="New project"
-								data-testid="project-rail-new"
-								className="w-9 h-9 rounded-radius-md flex items-center justify-center text-text-muted hover:text-text hover:bg-bg-elevated border border-dashed border-border transition-colors"
-							>
-								<Plus className="w-4 h-4" />
-							</button>
 						</Tooltip>
 					</div>
 				)}

--- a/packages/web/test/project-rail.test.tsx
+++ b/packages/web/test/project-rail.test.tsx
@@ -37,6 +37,27 @@ test('the HQ project is pinned at the bottom of the rail and opens on click', as
 	await waitFor(() => expect(router.state.location.pathname).toMatch(/^\/projects\/hq(\/|$)/));
 });
 
+test('the create-project button is pinned above the HQ button', async () => {
+	const { findByTestId } = await renderApp({
+		initialPath: '/home',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			await seedProject(ws, { name: 'Alpha' });
+		},
+	});
+
+	// Wait for both pinned controls to render before asserting their order.
+	await findByTestId('project-rail-new', undefined, { timeout: 15_000 });
+	await findByTestId('project-rail-hq', undefined, { timeout: 15_000 });
+
+	const rail = await findByTestId('project-rail');
+	// querySelectorAll yields document order, so create-project must come first.
+	const pinned = Array.from(
+		rail.querySelectorAll('[data-testid="project-rail-new"], [data-testid="project-rail-hq"]'),
+	).map((el) => el.getAttribute('data-testid'));
+	expect(pinned).toEqual(['project-rail-new', 'project-rail-hq']);
+});
+
 test('clicking a project avatar opens that project menu', async () => {
 	let ws!: SeededWorkspace;
 	let slug = '';


### PR DESCRIPTION
## Summary
Reordered the pinned controls at the bottom of the project rail so the "create project" button appears above the HQ entry, rather than below it.

## Changes
- Moved the create-project button markup to render before the HQ entry in `ProjectRail` component
- Updated the component documentation to reflect the new ordering
- Added a test to verify the create-project button is pinned above the HQ button in document order

## Implementation Details
The visual and functional behavior remains unchanged—both controls stay pinned below the scrolling project list. Only their relative order has been swapped, with the create-project button now appearing first (above) when both are present.

https://claude.ai/code/session_01KV4WaA89A4EP6SdVspZFgr