### PR TITLE
Enforce single-level delegation in assignment hierarchy

### DIFF
--- a/agents/_partials/common/assignment-hierarchy.md
+++ b/agents/_partials/common/assignment-hierarchy.md
@@ -8,3 +8,7 @@ To get work done by anyone outside your direct reports — peers, your manager, 
 2. If no existing ticket covers it and the work is genuinely theirs to own, comment on the most relevant adjacent ticket (e.g. the ticket you are on right now), describe the work, and `@<agent-slug>` the agent who should own it. They will triage the mention per `mention-handoff` and open their own ticket if appropriate.
 
 Cross-hierarchy ticket-creation works the same way for sub-tasks: a `parent_task_id` does not let you bypass the rule. If the sub-task's natural assignee is not your direct subordinate, file the sub-task assigned to yourself and `@`-mention the agent you want to pull in, or post a comment on the parent and let them open their own ticket.
+
+## Planning a multi-step chain across levels
+
+A plan you fan out with `blocked_by_task_ids` follows the same rule: every ticket you create is assigned to you or a direct report — never to someone two or more levels down. When a chain needs work that lives below your direct reports, do not pre-create the deep tickets assigned to the intermediate manager as placeholders. Hand the responsible direct report **one** breakdown ticket and let it land; when they pick it up, they create and fan out their own subtree's tickets, each with their own blockers. The chain extends one manager at a time, with each level owning the breakdown of the level below it. A "@@<role> — please reassign/delegate to <specialist>" note on a ticket you assigned to the wrong person is the anti-pattern this prevents.

--- a/agents/software-development/captain.md
+++ b/agents/software-development/captain.md
@@ -34,6 +34,8 @@ Concrete pattern for the research → PRD → spec chain:
 
 All three tickets exist immediately and are visible right away. Only the Researcher's run starts. The Product Lead wakes when research lands, the Architect wakes when the PRD lands.
 
+**Fan out only to your direct reports — delegate deeper breakdown to the responsible manager.** Every ticket in a chain you create must be assigned to you or one of your direct reports (Architect, Product Lead, Marketing Lead, Researcher). Work owned further down the org — implementation, QA, security, and UI design all sit under the Architect, not you — is not yours to pre-create. Hand the responsible direct report (here, the Architect) **one** breakdown/spec ticket; when it lands, they create and fan out their own subtree's tickets, with their own `blocked_by_task_ids`. The dependency chain extends one manager at a time. Do **not** pre-create implementation/QA/design/security tickets assigned to the Architect as placeholders with "please reassign to @ui-designer" notes — that lands work on the wrong owner, distorts the board, and misuses passive `@@` mentions where you actually want action. The server will reject any attempt to assign directly to a non-direct-report — that rejection is this rule, not a bug.
+
 If a peer agent later discovers a missed prerequisite, they will declare the blocker themselves via `add_task_blocker`. Don't chase the dependency manually.
 
 ## Dispute resolution

--- a/packages/server/src/lib/assignment-hierarchy.ts
+++ b/packages/server/src/lib/assignment-hierarchy.ts
@@ -3,7 +3,7 @@ import type { PGlite } from '@electric-sql/pglite';
 export type AssignmentHierarchyCheck = { ok: true } | { ok: false; message: string };
 
 export function assignmentHierarchyError(assigneeSlug: string): string {
-	return `Cannot assign to @${assigneeSlug}: agents can only assign work to their direct subordinates. To request work from someone outside your direct reports, use create_comment with @${assigneeSlug} on an existing ticket they own (or one they would naturally pick up).`;
+	return `Cannot assign to @${assigneeSlug}: agents can only assign work to a direct subordinate (or themselves). Do not route around this by assigning the ticket to @${assigneeSlug}'s manager as a stand-in with a "please reassign" note — that lands work on the wrong owner and distorts the board. Instead: post a create_comment with @${assigneeSlug} (on this ticket or the most relevant open one) describing the work, and let them open their own ticket. If you are planning a multi-step chain that runs below your direct reports, hand the responsible direct report a single breakdown ticket; when it lands, they create and fan out their subtree's tickets.`;
 }
 
 /**

--- a/packages/server/test/assignment-hierarchy.test.ts
+++ b/packages/server/test/assignment-hierarchy.test.ts
@@ -154,10 +154,14 @@ describe('assertSubordinateAssignee (unit)', () => {
 		expect(result.ok).toBe(true);
 	});
 
-	it('error message includes both target slug and create_comment guidance', () => {
-		expect(assignmentHierarchyError('engineer')).toContain('@engineer');
-		expect(assignmentHierarchyError('engineer')).toContain('create_comment');
-		expect(assignmentHierarchyError('engineer')).toContain('direct subordinate');
+	it('error message includes target slug, create_comment guidance, the stand-in warning, and the breakdown path', () => {
+		const msg = assignmentHierarchyError('engineer');
+		expect(msg).toContain('@engineer');
+		expect(msg).toContain('create_comment');
+		expect(msg).toContain('direct subordinate');
+		// new guidance: discourage manager-as-stand-in, point to the breakdown path
+		expect(msg).toContain('stand-in');
+		expect(msg).toContain('breakdown ticket');
 	});
 });
 

--- a/packages/server/test/resolve-partials.test.ts
+++ b/packages/server/test/resolve-partials.test.ts
@@ -71,6 +71,9 @@ describe('loadAgentRoles integrates resolvePartials', () => {
 		expect(sdCeo).toContain('Every run you take is at **max effort**');
 		expect(sdCeo).toContain('## Hire workflow');
 		expect(sdCeo).toContain('Ask before you write.');
+		// the assignment-hierarchy fix (captain.md body + shared partial) must reach the prompt
+		expect(sdCeo).toContain('Fan out only to your direct reports');
+		expect(sdCeo).toContain('## Planning a multi-step chain across levels');
 		expect(sdCeo).not.toContain('{{> partials/');
 
 		const blankCeo = docs['blank/captain.md'];
@@ -78,6 +81,8 @@ describe('loadAgentRoles integrates resolvePartials', () => {
 		expect(blankCeo).toContain('Every run you take is at **max effort**');
 		expect(blankCeo).toContain('## Hire workflow');
 		expect(blankCeo).toContain('Ask before you write.');
+		// blank captain includes the shared partial (but not the captain.md fan-out body edit)
+		expect(blankCeo).toContain('## Planning a multi-step chain across levels');
 		expect(blankCeo).not.toContain('{{> partials/');
 
 		for (const slug of [


### PR DESCRIPTION
## Summary
Strengthens the assignment hierarchy rule to prevent managers from being used as stand-ins for deeper subordinates. Updates error messaging, documentation, and tests to clarify that work must be delegated one level at a time through breakdown tickets rather than pre-created with reassignment notes.

## Key Changes

- **assignment-hierarchy.ts**: Enhanced error message to explicitly discourage the anti-pattern of assigning to a manager as a stand-in with "please reassign" notes, and directs users to the breakdown ticket pattern instead
- **captain.md**: Added guidance explaining the fan-out rule — agents can only create tickets for direct reports, and must hand deeper work to the responsible manager as a single breakdown ticket
- **assignment-hierarchy.md**: New section "Planning a multi-step chain across levels" documenting how multi-step chains should extend one manager at a time, with each level owning the breakdown of the level below
- **Tests**: Updated test expectations to verify the error message includes stand-in warning and breakdown ticket guidance; added assertions that the new guidance sections are properly included in resolved agent prompts

## Implementation Details

The change reinforces a key organizational principle: dependency chains extend one manager at a time, with each level responsible for breaking down and fanning out work to their own direct reports. This prevents work from landing on the wrong owner and keeps the task board accurate. The server-side validation now has clearer messaging that guides users toward the correct pattern.

https://claude.ai/code/session_01HpEj3pxjK87xye7EHdRHC1