### PR TITLE
fix: persist agent git work, provider-aware completeness gate, planning-ticket closure

### DIFF
--- a/agents/software-development/captain.md
+++ b/agents/software-development/captain.md
@@ -38,6 +38,16 @@ All three tickets exist immediately and are visible right away. Only the Researc
 
 If a peer agent later discovers a missed prerequisite, they will declare the blocker themselves via `add_task_blocker`. Don't chase the dependency manually.
 
+## Drafting the execution plan (the planning ticket)
+
+When a project is created you are woken on its **planning ticket** (labelled `planning`, titled "Draft execution plan for …"). It is the **epic for the plan itself**, not a piece of execution work, so it has its own lifecycle:
+
+1. Draft the plan and fan out the chain — planning artefacts (research / PRD / spec / design) as **sub-tasks of this ticket**, execution work (implementation / security review / launch) as **top-level tickets** — per *Declaring dependencies between tickets* above.
+2. Leave the planning ticket `in_progress` while its sub-tasks run. The server rejects a `done`/`closed` transition while any sub-task is still open — that rejection is expected, not a bug.
+3. **Close it out — this is the final, required step.** Once every planning sub-task has reached `closed` (Coach-reviewed) and the top-level execution tickets exist, set the planning ticket to `done` with `update_task`; the Coach closes it after the post-mortem. Do not leave it parked in `in_progress` once it is eligible — the execution tickets ship independently and do not block it from closing.
+
+If a heartbeat returns you to the planning ticket and its sub-tasks are not all `closed` yet, there is nothing to do: leave it `in_progress` and end your turn. You will be woken again when the last sub-task lands.
+
 ## Dispute resolution
 
 When two agents disagree (e.g. Engineer thinks the Architect's plan is wrong):

--- a/agents/software-development/engineer.md
+++ b/agents/software-development/engineer.md
@@ -14,7 +14,7 @@ Your role is to implement features according to the Architect's technical specif
 - Apply the code quality principles (DRY, high cohesion / low coupling, reuse of established patterns, no dead code, maintainability, performance, testability, search-before-write) to every change — they are hard musts, not aspirations
 - Write automated tests for all code changes (mandatory, 90%+ coverage target)
 - Update documentation for every code change
-- Create git worktrees for feature branches
+- Create a git worktree for the feature branch; commit and push to the remote branch after every phase, and open a pull request when implementation is complete
 - Report progress via task comments with tool-call traces
 - Create sub-tasks for parallelisable work and delegate to peers (same level) or downward
 - Request clarification from the Architect or Product Lead when specs are ambiguous
@@ -27,10 +27,11 @@ Your role is to implement features according to the Architect's technical specif
 2. **Start work.** Set status to `in_progress` via `update_task`. Read the PRD, technical spec, and implementation phases.
 3. **Branch.** Create a git worktree for the feature branch. Record it via `update_task` with `branch_name`.
 4. **Implement each phase.** Use sub-agents to explore alternative implementations in parallel and reconcile the best approach. Write the code, write tests (mandatory — no exceptions), update documentation, and run the full test suite locally. Implement frontend alongside backend within each phase — both land together. Phase completion requires that new functionality is exercisable from the browser, not just via API or curl. When a phase adds user-facing functionality, add e2e tests covering the critical user flows.
-5. **Progress.** Update `progress_summary` via `update_task` at each milestone.
-6. **Review.** When complete, set status to `review` and @-mention `@qa-engineer`.
-7. **Address feedback.** If QA sets status back to `in_progress`, fix the tasks and re-request review (back to step 6).
-8. **Merge.** When QA posts an approval comment and @-mentions you, merge the feature branch to main, then set status to `done` (this triggers Coach review automatically).
+5. **Commit and push every phase.** As soon as a phase's tests pass, commit it in small focused commits and **push the branch** (`git push -u origin hezo/<TICKET>`). Never end a phase — or your turn — with work that exists only in the worktree: the per-run worktree is not guaranteed to survive to the next run, so anything unpushed is lost and the next run starts from scratch. Update `progress_summary` via `update_task` at each milestone.
+6. **Open a pull request.** When every phase is complete and the full suite passes, open a **draft** pull request with the `create_pull_request` tool from the `github` MCP server (base = the repo's default branch, head = `hezo/<TICKET>`, `draft: true`, a title summarising the change, and a body that summarises the work and links this ticket). Post the PR URL as a task comment. If the team has no GitHub connection (no `github` MCP server is available), skip the PR and just make sure the branch is pushed.
+7. **Review.** Set status to `review` and @-mention `@qa-engineer`, pointing them at the PR.
+8. **Address feedback.** If QA sets status back to `in_progress`, fix the issues, push the fixes, and re-request review (back to step 7).
+9. **Merge.** When QA posts an approval comment and @-mentions you, mark the PR ready and merge it to the default branch, then set status to `done` (this triggers Coach review automatically).
 
 If the spec is unclear, ask the Architect — don't guess. If you disagree with the Architect's approach, say so in the ticket; if they insist, do it their way. Escalate to the Captain only if you both feel strongly and can't resolve it. If you're blocked by an external dependency, @-mention the DevOps Engineer or the Architect.
 

--- a/docker/Dockerfile.agent-base
+++ b/docker/Dockerfile.agent-base
@@ -2,8 +2,30 @@ FROM node:24-slim
 
 # Install common development tools
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git curl jq openssh-client ca-certificates python3 socat sudo \
+    curl jq openssh-client ca-certificates python3 socat sudo \
     && rm -rf /var/lib/apt/lists/*
+
+# Build git from source. The host creates per-task worktrees with
+# `git worktree add --relative-paths`, which records `extensions.relativeworktrees`
+# in the repo config. Debian's packaged git (<2.48) refuses to read that
+# extension — "fatal: unknown repository extension found: relativeworktrees" —
+# which breaks every in-container git operation (status/commit/push), so agents
+# can never persist their work. Build a git new enough to understand it, then
+# drop the heavy build toolchain in the same layer (the small -dev packages stay
+# so git keeps its runtime shared libs). The final `git --version` fails the
+# build if anything is wrong.
+ENV GIT_VERSION=2.51.0
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      build-essential gettext libcurl4-openssl-dev libexpat1-dev zlib1g-dev libssl-dev \
+    && curl -fsSL "https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz" -o /tmp/git.tar.gz \
+    && tar -xzf /tmp/git.tar.gz -C /tmp \
+    && make -C "/tmp/git-${GIT_VERSION}" prefix=/usr/local NO_TCLTK=1 NO_GITWEB=1 NO_PERL=1 NO_PYTHON=1 -j"$(nproc)" all \
+    && make -C "/tmp/git-${GIT_VERSION}" prefix=/usr/local NO_TCLTK=1 NO_GITWEB=1 NO_PERL=1 NO_PYTHON=1 install \
+    && rm -rf /tmp/git.tar.gz "/tmp/git-${GIT_VERSION}" \
+    && apt-get purge -y build-essential \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/* \
+    && git --version
 
 # The container runs as the unprivileged `node` user (so bind-mounted worktree
 # files stay node-owned), but agents need to install system packages at runtime

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -362,6 +362,7 @@ async function buildRunContext(
 	const mcpInjection = adapter.build(mcpDescriptors, {
 		hostHomeDir: homeMount?.hostDir ?? null,
 		containerHomeDir: homeMount?.containerDir ?? null,
+		provider,
 		skillFiles,
 	});
 	validateInjection(adapter, mcpInjection);

--- a/packages/server/src/services/mcp-injectors/claude-code.ts
+++ b/packages/server/src/services/mcp-injectors/claude-code.ts
@@ -1,4 +1,5 @@
 import { join } from 'node:path';
+import { AiProvider } from '@hezo/shared';
 import { buildClaudeCodeSettings } from '../stop-hook-prompt';
 import type {
 	McpDescriptor,
@@ -56,7 +57,7 @@ export const claudeCodeAdapter: RuntimeMcpAdapter = {
 
 		const settingsHostPath = join(ctx.hostHomeDir, 'settings.json');
 		const settingsContainerPath = join(ctx.containerHomeDir, 'settings.json');
-		const settingsContents = `${JSON.stringify(buildClaudeCodeSettings(), null, 2)}\n`;
+		const settingsContents = `${JSON.stringify(buildClaudeCodeSettings(ctx.provider ?? AiProvider.Anthropic), null, 2)}\n`;
 
 		const cliArgs: string[] = ['--settings', settingsContainerPath];
 		if (descriptors.length > 0) {

--- a/packages/server/src/services/mcp-injectors/types.ts
+++ b/packages/server/src/services/mcp-injectors/types.ts
@@ -1,3 +1,5 @@
+import type { AiProvider } from '@hezo/shared';
+
 /**
  * Normalized MCP server descriptor passed by the agent runner. Per-runtime
  * adapters translate a list of these into the spawn artifacts (CLI args,
@@ -78,6 +80,14 @@ export interface McpAdapterContext {
 	hostHomeDir: string | null;
 	/** Same path as it appears inside the container. */
 	containerHomeDir: string | null;
+	/**
+	 * AI provider for this run. The Claude Code adapter uses it to pick the
+	 * Stop-hook judge model — the judge runs against the team's own upstream, so
+	 * the model must be one that provider serves (the Anthropic id on DeepSeek /
+	 * Z.ai would 404 and the hook would fail open). Optional for adapters/tests
+	 * that don't need it; the Claude Code adapter falls back to the Anthropic judge.
+	 */
+	provider?: AiProvider;
 	/** Team-scoped agent skill files (e.g. from `fetch_skill_file`). Adapters
 	 *  write these to their conventional skills directory; Claude Code reads
 	 *  `~/.claude/skills/<slug>.md`, others use whatever convention they have. */

--- a/packages/server/src/services/stop-hook-prompt.ts
+++ b/packages/server/src/services/stop-hook-prompt.ts
@@ -14,16 +14,37 @@
  *
  * The judge runs inside the container against the team's existing
  * provider credential. No server-side LLM client. The hook is always on;
- * teams do not opt in or out. If the configured judge model isn't
- * reachable through the team's upstream (e.g. DeepSeek for Claude Code,
- * an unreachable OpenAI/Google API) the script fails open — exits 0 with
- * no output, which Codex/Gemini treat as "allow" — and the agent stops
- * normally.
+ * teams do not opt in or out. The judge model is chosen per provider so the
+ * call resolves against the team's own upstream — see
+ * CLAUDE_CODE_JUDGE_MODEL_BY_PROVIDER for the Claude Code runtimes and the
+ * OpenAI/Google constants below. If a judge is genuinely unreachable
+ * (subscription auth with no API key, or an upstream outage) the script
+ * fails open — exits 0 with no output, which the runtimes treat as "allow"
+ * — and the agent stops normally.
  */
 
+import { AiProvider } from '@hezo/shared';
+
 export const STOP_HOOK_JUDGE_MODEL_ANTHROPIC = 'claude-sonnet-4-6';
+export const STOP_HOOK_JUDGE_MODEL_DEEPSEEK = 'deepseek-v4-pro';
+export const STOP_HOOK_JUDGE_MODEL_ZAI = 'GLM-4.7';
 export const STOP_HOOK_JUDGE_MODEL_OPENAI = 'gpt-4o-mini';
 export const STOP_HOOK_JUDGE_MODEL_GOOGLE = 'gemini-1.5-flash';
+
+/**
+ * Judge model for the Claude Code `type:"prompt"` Stop hook, keyed by provider.
+ * Claude Code makes the judge call itself against the session's own upstream,
+ * so the model MUST be one that provider's endpoint actually serves. Using the
+ * Anthropic id on DeepSeek/Z.ai 404s, so the hook fails open and never blocks —
+ * the bug this map fixes. Values mirror each provider's
+ * ANTHROPIC_DEFAULT_SONNET_MODEL in PROVIDER_RUNTIME_ADAPTERS; only Claude
+ * Code-runtime providers ever reach here.
+ */
+export const CLAUDE_CODE_JUDGE_MODEL_BY_PROVIDER: Partial<Record<AiProvider, string>> = {
+	[AiProvider.Anthropic]: STOP_HOOK_JUDGE_MODEL_ANTHROPIC,
+	[AiProvider.DeepSeek]: STOP_HOOK_JUDGE_MODEL_DEEPSEEK,
+	[AiProvider.ZAi]: STOP_HOOK_JUDGE_MODEL_ZAI,
+};
 
 /**
  * The rule body the judge LLM evaluates against. Claude Code's hook
@@ -68,7 +89,8 @@ export interface ClaudeCodeSettings {
 	};
 }
 
-export function buildClaudeCodeSettings(): ClaudeCodeSettings {
+export function buildClaudeCodeSettings(provider: AiProvider): ClaudeCodeSettings {
+	const model = CLAUDE_CODE_JUDGE_MODEL_BY_PROVIDER[provider] ?? STOP_HOOK_JUDGE_MODEL_ANTHROPIC;
 	return {
 		hooks: {
 			Stop: [
@@ -78,7 +100,7 @@ export function buildClaudeCodeSettings(): ClaudeCodeSettings {
 							type: 'prompt',
 							prompt: STOP_HOOK_PROMPT,
 							timeout: 30,
-							model: STOP_HOOK_JUDGE_MODEL_ANTHROPIC,
+							model,
 							statusMessage: 'Checking work completeness...',
 						},
 					],

--- a/packages/server/test/mcp-injectors.test.ts
+++ b/packages/server/test/mcp-injectors.test.ts
@@ -1,7 +1,12 @@
-import { AgentRuntime } from '@hezo/shared';
+import { AgentRuntime, AiProvider } from '@hezo/shared';
 import { describe, expect, it } from 'vitest';
 import { MCP_ADAPTERS, type McpDescriptor, validateInjection } from '../src/services/mcp-injectors';
-import { STOP_HOOK_RULES } from '../src/services/stop-hook-prompt';
+import {
+	STOP_HOOK_JUDGE_MODEL_ANTHROPIC,
+	STOP_HOOK_JUDGE_MODEL_DEEPSEEK,
+	STOP_HOOK_JUDGE_MODEL_ZAI,
+	STOP_HOOK_RULES,
+} from '../src/services/stop-hook-prompt';
 
 const HOME = '/workspace/.hezo/subscription/codex/run-1';
 const URL = 'http://host.docker.internal:3000/mcp';
@@ -122,6 +127,31 @@ describe('claude-code adapter', () => {
 		const settingsIndex = injection.cliArgs.indexOf('--settings');
 		expect(settingsIndex).toBeGreaterThanOrEqual(0);
 		expect(injection.cliArgs[settingsIndex + 1]).toBe(`${HOME}/settings.json`);
+	});
+
+	const judgeModelFor = (provider?: AiProvider): string => {
+		const injection = adapter.build([HEZO_DESCRIPTOR], {
+			hostHomeDir: HOME,
+			containerHomeDir: HOME,
+			provider,
+		});
+		const settings = JSON.parse(injection.files[0].contents) as {
+			hooks: { Stop: Array<{ hooks: Array<{ model: string }> }> };
+		};
+		return settings.hooks.Stop[0].hooks[0].model;
+	};
+
+	it('picks a Stop-hook judge model the provider upstream actually serves', () => {
+		// The judge call runs against the team's own upstream, so a non-Anthropic
+		// Claude Code provider must get its own model id — otherwise the call 404s
+		// and the hook fails open (the bug being fixed).
+		expect(judgeModelFor(AiProvider.Anthropic)).toBe(STOP_HOOK_JUDGE_MODEL_ANTHROPIC);
+		expect(judgeModelFor(AiProvider.DeepSeek)).toBe(STOP_HOOK_JUDGE_MODEL_DEEPSEEK);
+		expect(judgeModelFor(AiProvider.ZAi)).toBe(STOP_HOOK_JUDGE_MODEL_ZAI);
+	});
+
+	it('falls back to the Anthropic judge model when no provider is supplied', () => {
+		expect(judgeModelFor(undefined)).toBe(STOP_HOOK_JUDGE_MODEL_ANTHROPIC);
 	});
 });
 


### PR DESCRIPTION
## Why

Investigating three symptoms on the `todo` project:

1. **The Engineer (TO-7) "stopped building"** after 3 of 6 self-defined phases, ending its run cleanly and deferring the rest to "the next run".
2. Request: **the Engineer should commit + push between phases and open a PR when done.**
3. **The Captain's planning ticket (TO-2) was stuck `In Progress`** even though execution had started.

## Root causes found

- **In-container git was broken.** The host creates worktrees with `git worktree add --relative-paths` (`git.ts`), which writes `extensions.relativeworktrees=true` into the repo. The agent image (`node:24-slim`) shipped Debian git **< 2.48**, which refuses to read that extension — so *every* in-container `git` command failed (`fatal: unknown repository extension found: relativeworktrees`) and no agent work was ever committed. Each run restarted from a near-empty worktree, so "continue next run" lost everything.
- **The completeness Stop-hook failed open on DeepSeek/Z.ai.** `buildClaudeCodeSettings()` hardcoded the judge model `claude-sonnet-4-6`; on a DeepSeek session (`api.deepseek.com/anthropic`) that model 404s, the judge errored, and the hook failed open — so nothing blocked an early stop.
- **The planning epic had no reliable "close it" driver.** The instruction to move TO-2 to `done` lived only in the task *body* (`project-create.ts`), not the Captain's role doc; closure is also (correctly) gated until planning sub-tasks are Coach-`closed`. So once eligible, nothing brought the idle Captain back to close it.

## Changes

| # | Workstream | Files |
|---|---|---|
| 1 | Engineer role doc: commit + push after every phase; open a **draft PR** (`github` MCP `create_pull_request`) when implementation is complete | `agents/software-development/engineer.md` |
| 2 | Build **git 2.51 from source** in the agent base image so it can read `relativeworktrees` (prerequisite for #1) | `docker/Dockerfile.agent-base` |
| 3 | Make the Claude Code Stop-hook judge model **provider-aware** (Anthropic→`claude-sonnet-4-6`, DeepSeek→`deepseek-v4-pro`, Z.ai→`GLM-4.7`); thread `provider` through the MCP adapter context | `stop-hook-prompt.ts`, `mcp-injectors/types.ts`, `mcp-injectors/claude-code.ts`, `agent-runner.ts` |
| 4 | Document the planning-ticket lifecycle (close once sub-tasks are Coach-closed) in the Captain role doc | `agents/software-development/captain.md` |

## Verification

- `packages/server` typecheck ✅, `bun run build` ✅ (pre-commit gate)
- `mcp-injectors.test.ts` (27, incl. 2 new judge-model tests), `agent-runner.test.ts` (60), `oauth-mcp-injection.test.ts` (3), `resolve-partials.test.ts` (8) all green
- WS2 needs the agent image rebuilt to take effect; WS1/WS4 take effect on re-seed

## Notes

- Optional follow-up (not included): a `task-automation.ts` wake-nudge so the Captain returns to close the planning epic the moment its last sub-task closes, rather than on the next heartbeat.
- One pre-existing biome warning remains at `claude-code.ts:74` (`ctx.hostHomeDir!`), unrelated to this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqqtGoBDMPrEQgGgATrg8n)_