### PR TITLE
fix: readable container logs, provisioning banner, wake agents after provision

### DIFF
--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -24,6 +24,7 @@ import {
 	rebuildContainer,
 	stopContainerGracefully,
 	teardownContainer,
+	wakeAgentsWithPendingWork,
 } from '../services/containers';
 import { enqueueTeamCoherenceReviewTask } from '../services/description-tasks';
 import { loadCoordinationContext } from '../services/internal-intake';
@@ -64,31 +65,6 @@ async function cancelRunningAgentTasks(
 	);
 	for (const row of running.rows) {
 		jobManager.cancelTask(wsRoom.agent(row.assignee_id));
-	}
-}
-
-async function wakeAgentsWithPendingWork(
-	db: PGlite,
-	projectId: string,
-	teamId: string,
-): Promise<void> {
-	const { placeholders, values } = terminalStatusParams(3);
-	const pending = await db.query<{ agent_id: string }>(
-		`SELECT DISTINCT i.assignee_id AS agent_id
-		 FROM tasks i
-		 JOIN member_agents ma ON ma.id = i.assignee_id
-		 WHERE i.project_id = $1 AND i.team_id = $2
-		   AND i.status NOT IN (${placeholders})
-		   AND ma.admin_status = 'enabled'`,
-		[projectId, teamId, ...values],
-	);
-	for (const row of pending.rows) {
-		trackBackground(
-			createWakeup(db, row.agent_id, teamId, WakeupSource.Automation, {
-				trigger: 'container_start',
-				project_id: projectId,
-			}).catch((e) => log.error('Failed to create wakeup on container start:', e)),
-		);
 	}
 }
 

--- a/packages/server/src/services/containers.ts
+++ b/packages/server/src/services/containers.ts
@@ -8,7 +8,9 @@ import {
 	wsRoom,
 } from '@hezo/shared';
 import type { MasterKeyManager } from '../crypto/master-key';
+import { trackBackground } from '../lib/background';
 import { broadcastProjectUpdate, broadcastRowChange } from '../lib/broadcast';
+import { terminalStatusParams } from '../lib/sql';
 import { logger } from '../logger';
 import { setAgentIdleIfNoActiveRuns } from './agent-runtime-status';
 import type { ContainerLogStreamer } from './container-logs';
@@ -196,8 +198,11 @@ export async function provisionContainer(
 		const env = ['HEZO_API_URL=http://host.docker.internal:3100/agent-api'];
 
 		emit('stdout', `→ Resolving image ${project.docker_base_image}`);
+		// Docker writes its build trace to stderr even on success; surface it as
+		// informational stdout so a clean build isn't a wall of red. A real build
+		// failure still throws (non-zero exit) and is reported by the catch below.
 		await ensureImage(docker, project.docker_base_image, {
-			onLine: (stream, text) => emit(stream, text),
+			onLine: (_stream, text) => emit('stdout', text),
 		});
 
 		emit('stdout', `→ Creating container ${containerName}`);
@@ -296,6 +301,14 @@ export async function provisionContainer(
 
 		await requeueContainerKilledRuns(deps, project.id, teamId).catch((e) =>
 			log.error('Failed to requeue container-killed runs after provision:', e),
+		);
+		// A wakeup that fired while the container was still provisioning could not
+		// run (container_status !== running). Now that it's up, nudge every agent
+		// holding pending work so freshly-created tasks (e.g. the CEO's coherence
+		// pass) start without waiting for the next scheduled heartbeat. Mirrors the
+		// container start/rebuild routes.
+		await wakeAgentsWithPendingWork(db, project.id, teamId).catch((e) =>
+			log.error('Failed to wake agents with pending work after provision:', e),
 		);
 
 		return Id;
@@ -657,6 +670,37 @@ export async function requeueContainerKilledRuns(
 	}
 
 	return killed.rows.length;
+}
+
+/**
+ * Queue a wakeup for every enabled agent that has a non-terminal task assigned
+ * in this project. Used after a container transitions to running (initial
+ * provision, start, rebuild) so pending work is picked up promptly instead of
+ * waiting for the next scheduled heartbeat.
+ */
+export async function wakeAgentsWithPendingWork(
+	db: PGlite,
+	projectId: string,
+	teamId: string,
+): Promise<void> {
+	const { placeholders, values } = terminalStatusParams(3);
+	const pending = await db.query<{ agent_id: string }>(
+		`SELECT DISTINCT i.assignee_id AS agent_id
+		 FROM tasks i
+		 JOIN member_agents ma ON ma.id = i.assignee_id
+		 WHERE i.project_id = $1 AND i.team_id = $2
+		   AND i.status NOT IN (${placeholders})
+		   AND ma.admin_status = 'enabled'`,
+		[projectId, teamId, ...values],
+	);
+	for (const row of pending.rows) {
+		trackBackground(
+			createWakeup(db, row.agent_id, teamId, WakeupSource.Automation, {
+				trigger: 'container_start',
+				project_id: projectId,
+			}).catch((e) => log.error('Failed to create wakeup on container start:', e)),
+		);
+	}
 }
 
 async function allocateHostPorts(

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -1169,6 +1169,18 @@ export class JobManager {
 		}
 
 		if (!projectRow.container_id) {
+			// container_id stays NULL until the container reaches running, so a
+			// 'creating' status here means provisioning is in flight (often minutes
+			// on a first image build). Re-queue and retry once it's up rather than
+			// burning the wakeup — otherwise a task assigned at project-creation time
+			// (e.g. the CEO's coherence pass) would never start.
+			if (projectRow.container_status === ContainerStatus.Creating) {
+				log.debug(
+					`Container for project ${ref(projectRow.slug, task.project_id)} still provisioning — re-queuing wakeup`,
+				);
+				await this.requeueWakeup(wakeupId);
+				return;
+			}
 			log.debug(
 				`No container for project ${ref(projectRow.slug, task.project_id)} — wakeup failed`,
 			);

--- a/packages/server/src/services/log-buffer.ts
+++ b/packages/server/src/services/log-buffer.ts
@@ -1,7 +1,9 @@
 /**
- * Append-only line buffer with a hard byte cap. Lines tagged as `stderr` are
- * stored with a `[stderr] ` prefix so the persisted log preserves stream
- * provenance when later replayed as plain text.
+ * Append-only line buffer with a hard byte cap. Each appended line is stored on
+ * its own line (newline-terminated). Lines tagged as `stderr` are stored with a
+ * `[stderr] ` prefix so the persisted log preserves stream provenance when later
+ * replayed as plain text — the prefix sits at the start of its own line so the
+ * reader can strip it back off cleanly.
  */
 export class CappedLogBuffer {
 	private bytes = 0;
@@ -12,7 +14,7 @@ export class CappedLogBuffer {
 
 	append(stream: 'stdout' | 'stderr', text: string): void {
 		if (this.truncatedAt !== null) return;
-		const marker = stream === 'stderr' ? `[stderr] ${text}` : text;
+		const marker = `${stream === 'stderr' ? `[stderr] ${text}` : text}\n`;
 		const remaining = this.capBytes - this.bytes;
 		if (remaining <= 0) {
 			this.truncatedAt = this.capBytes;

--- a/packages/server/src/services/log-format.ts
+++ b/packages/server/src/services/log-format.ts
@@ -1,0 +1,33 @@
+/**
+ * Normalize a raw log chunk into clean, display-ready lines.
+ *
+ * Container/build output is noisy in two ways that make the persisted snapshot
+ * unreadable:
+ *  - Carriage-return progress redraws (`apt`'s `Reading database ... 5%\r...10%`,
+ *    BuildKit spinners) pack many frames onto one physical line. Only the final
+ *    frame is meaningful once the line is done, so we collapse to it.
+ *  - `\r\n` line endings would otherwise leave a stray `\r` on every line.
+ *
+ * Splits on `\n`, collapses carriage-return redraws to the last non-empty frame,
+ * and drops empty lines. Returns one entry per logical line with no trailing
+ * newline (the caller re-terminates).
+ */
+export function splitLogLines(text: string): string[] {
+	const normalized = text.replace(/\r\n/g, '\n');
+	const out: string[] = [];
+	for (const physicalLine of normalized.split('\n')) {
+		const line = lastNonEmptyFrame(physicalLine);
+		if (line.length > 0) out.push(line);
+	}
+	return out;
+}
+
+/** Given a line that may contain `\r` redraw frames, return the last non-empty one. */
+function lastNonEmptyFrame(line: string): string {
+	if (!line.includes('\r')) return line;
+	const frames = line.split('\r');
+	for (let i = frames.length - 1; i >= 0; i--) {
+		if (frames[i].length > 0) return frames[i];
+	}
+	return '';
+}

--- a/packages/server/src/services/log-stream-broker.ts
+++ b/packages/server/src/services/log-stream-broker.ts
@@ -1,4 +1,5 @@
 import { CappedLogBuffer } from './log-buffer';
+import { splitLogLines } from './log-format';
 import type { WebSocketManager, WsEvent } from './ws';
 
 export type LogStream = 'stdout' | 'stderr';
@@ -66,17 +67,19 @@ export class LogStreamBroker {
 		const entry = this.streams.get(streamId);
 		if (!entry || entry.ended) return;
 
-		const newLines = text
-			.split('\n')
-			.filter((l) => l.length > 0)
-			.map((l) => ({ stream, text: l }));
-		if (newLines.length === 0) return;
+		// Collapse carriage-return progress redraws and split into discrete lines
+		// once, so the live broadcast and the persisted snapshot stay identical.
+		const lines = splitLogLines(text);
+		if (lines.length === 0) return;
 
-		const wasTruncated = entry.buffer.isTruncated;
-		entry.buffer.append(stream, text);
-		if (!wasTruncated && this.wsManager) {
-			for (const line of newLines) {
-				this.wsManager.broadcast(entry.config.room, entry.config.buildMessage(line));
+		for (const lineText of lines) {
+			const wasTruncated = entry.buffer.isTruncated;
+			entry.buffer.append(stream, lineText);
+			if (!wasTruncated && this.wsManager) {
+				this.wsManager.broadcast(
+					entry.config.room,
+					entry.config.buildMessage({ stream, text: lineText }),
+				);
 			}
 		}
 

--- a/packages/server/test/containers-recovery.test.ts
+++ b/packages/server/test/containers-recovery.test.ts
@@ -1,12 +1,14 @@
 import type { PGlite } from '@electric-sql/pglite';
-import { AgentRuntimeStatus, HeartbeatRunStatus, WakeupStatus } from '@hezo/shared';
+import { AgentRuntimeStatus, HeartbeatRunStatus, TaskStatus, WakeupStatus } from '@hezo/shared';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { waitForBackground } from '../src/lib/background';
 import type { Env } from '../src/lib/types';
 import {
 	type ContainerDeps,
 	failProjectRuns,
 	requeueContainerKilledRuns,
+	wakeAgentsWithPendingWork,
 } from '../src/services/containers';
 import { LogStreamBroker } from '../src/services/log-stream-broker';
 import { safeClose } from './helpers';
@@ -239,5 +241,50 @@ describe('requeueContainerKilledRuns', () => {
 
 		const count = await requeueContainerKilledRuns(buildDeps(), projectId, teamId);
 		expect(count).toBe(0);
+	});
+});
+
+describe('wakeAgentsWithPendingWork', () => {
+	it('queues a container_start wakeup for an enabled agent with a non-terminal assigned task', async () => {
+		await clearState();
+		await db.query(`UPDATE member_agents SET admin_status = 'enabled' WHERE id = $1`, [agentId]);
+
+		await wakeAgentsWithPendingWork(db, projectId, teamId);
+		await waitForBackground();
+
+		const wakeups = await db.query<{ payload: Record<string, unknown>; source: string }>(
+			`SELECT payload, source FROM agent_wakeup_requests
+			 WHERE member_id = $1 AND status = $2::wakeup_status
+			 ORDER BY created_at DESC LIMIT 1`,
+			[agentId, WakeupStatus.Queued],
+		);
+		expect(wakeups.rows.length).toBe(1);
+		expect(wakeups.rows[0].source).toBe('automation');
+		expect((wakeups.rows[0].payload as Record<string, unknown>).trigger).toBe('container_start');
+	});
+
+	it('does not wake an agent whose only task is in a terminal status', async () => {
+		await clearState();
+		const orig = await db.query<{ status: string }>('SELECT status FROM tasks WHERE id = $1', [
+			taskId,
+		]);
+		await db.query('UPDATE tasks SET status = $1::task_status WHERE id = $2', [
+			TaskStatus.Done,
+			taskId,
+		]);
+
+		await wakeAgentsWithPendingWork(db, projectId, teamId);
+		await waitForBackground();
+
+		const wakeups = await db.query<{ id: string }>(
+			`SELECT id FROM agent_wakeup_requests WHERE member_id = $1 AND status = $2::wakeup_status`,
+			[agentId, WakeupStatus.Queued],
+		);
+		expect(wakeups.rows.length).toBe(0);
+
+		await db.query('UPDATE tasks SET status = $1::task_status WHERE id = $2', [
+			orig.rows[0].status,
+			taskId,
+		]);
 	});
 });

--- a/packages/server/test/job-manager-workflows.test.ts
+++ b/packages/server/test/job-manager-workflows.test.ts
@@ -280,6 +280,49 @@ describe('JobManager workflow methods', () => {
 			await db.query('DELETE FROM agent_wakeup_requests WHERE id = $1', [wakeupId]);
 		});
 
+		it('re-queues a task wakeup while the project container is still provisioning', async () => {
+			const manager = createJobManager();
+			// Provisioning in flight: container_id stays NULL until the container
+			// reaches running, and status is 'creating'.
+			await db.query(
+				`UPDATE projects SET container_status = 'creating'::container_status, container_id = NULL WHERE id = $1`,
+				[projectId],
+			);
+
+			const wakeupRes = await db.query<{ id: string }>(
+				`INSERT INTO agent_wakeup_requests
+				   (member_id, team_id, source, status, payload, created_at)
+				 VALUES ($1, $2, 'assignment', 'queued', $3::jsonb, now() - interval '30 seconds')
+				 RETURNING id`,
+				[agentId, teamId, JSON.stringify({ task_id: taskId })],
+			);
+			const wakeupId = wakeupRes.rows[0].id;
+
+			await (manager as any).processWakeups();
+
+			// The wakeup is returned to the queue (not failed) so it retries once the
+			// container is running, and no run was started in the meantime.
+			const wakeup = await db.query<{ status: string; claimed_at: string | null }>(
+				'SELECT status, claimed_at FROM agent_wakeup_requests WHERE id = $1',
+				[wakeupId],
+			);
+			expect(wakeup.rows[0].status).toBe(WakeupStatus.Queued);
+			expect(wakeup.rows[0].claimed_at).toBeNull();
+
+			const runs = await db.query<{ count: string }>(
+				'SELECT count(*)::text AS count FROM heartbeat_runs WHERE task_id = $1',
+				[taskId],
+			);
+			expect(runs.rows[0].count).toBe('0');
+
+			manager.shutdown();
+			await db.query(
+				`UPDATE projects SET container_status = NULL, container_id = NULL WHERE id = $1`,
+				[projectId],
+			);
+			await db.query('DELETE FROM agent_wakeup_requests WHERE id = $1', [wakeupId]);
+		});
+
 		it('skips agents that already have a running task', async () => {
 			const manager = createJobManager();
 

--- a/packages/server/test/log-format.test.ts
+++ b/packages/server/test/log-format.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { splitLogLines } from '../src/services/log-format';
+
+describe('splitLogLines', () => {
+	it('splits on newlines and drops empty lines', () => {
+		expect(splitLogLines('a\nb\n\nc\n')).toEqual(['a', 'b', 'c']);
+	});
+
+	it('normalizes \\r\\n line endings', () => {
+		expect(splitLogLines('a\r\nb\r\n')).toEqual(['a', 'b']);
+	});
+
+	it('collapses carriage-return progress redraws to the final frame', () => {
+		expect(
+			splitLogLines('(Reading database 5%\r(Reading database 50%\r(Reading database 100%\n'),
+		).toEqual(['(Reading database 100%']);
+	});
+
+	it('keeps the last non-empty frame when a redraw ends with a bare CR', () => {
+		expect(splitLogLines('working...\rdone\r')).toEqual(['done']);
+	});
+
+	it('collapses redraws independently on each physical line', () => {
+		expect(splitLogLines('x 1%\rx 100%\ny 2%\ry 99%\n')).toEqual(['x 100%', 'y 99%']);
+	});
+
+	it('returns an empty array for input with no visible content', () => {
+		expect(splitLogLines('')).toEqual([]);
+		expect(splitLogLines('\n\n')).toEqual([]);
+	});
+});

--- a/packages/server/test/log-stream-broker.test.ts
+++ b/packages/server/test/log-stream-broker.test.ts
@@ -103,6 +103,24 @@ describe('LogStreamBroker', () => {
 		expect(texts).toEqual(expect.arrayContaining(['live line\n', '[stderr] prov line\n']));
 	});
 
+	it('persists each emit on its own line and collapses carriage-return redraws', () => {
+		broker.begin(makeContainerConfig('p1'));
+		// Provisioning emits discrete lines without trailing newlines...
+		broker.emit('container:p1', 'stdout', '→ Preparing workspace');
+		broker.emit('container:p1', 'stdout', '→ Resolving image');
+		// ...and image-build output arrives with carriage-return progress spam.
+		broker.emit('container:p1', 'stderr', '(Reading database 5%\r(Reading database 100%');
+
+		const replayed: Array<{ text?: string }> = [];
+		broker.replay('container-logs:p1', (p) => replayed.push(p as { text?: string }));
+		expect(replayed).toHaveLength(1);
+		// Each line is separated (no glued "→ …→ …"), the [stderr] tag sits at the
+		// start of its own line so it can be stripped, and the redraw collapsed.
+		expect(replayed[0].text).toBe(
+			'→ Preparing workspace\n→ Resolving image\n[stderr] (Reading database 100%\n',
+		);
+	});
+
 	it('does not bleed snapshots across streams in different rooms', () => {
 		broker.begin(makeRunConfig('r1', 'p1'));
 		broker.begin(makeRunConfig('r2', 'p2'));

--- a/packages/web/src/components/container-status-banner.tsx
+++ b/packages/web/src/components/container-status-banner.tsx
@@ -1,4 +1,5 @@
 import { ContainerStatus } from '@hezo/shared';
+import { Link } from '@tanstack/react-router';
 import { AlertTriangle, Loader2, RefreshCw } from 'lucide-react';
 import { useState } from 'react';
 import { useProjectMeta } from '../hooks/use-projects';
@@ -6,18 +7,45 @@ import { api } from '../lib/api';
 import { queryClient } from '../lib/query-client';
 import { Button } from './ui/button';
 
+const BANNER_BASE = 'sticky top-0 z-40 flex items-center gap-2 px-4 py-2 text-[13px] font-medium';
+
 export function ContainerStatusBanner({ projectId }: { projectId: string }) {
 	const project = useProjectMeta(projectId);
 	const [isRebuilding, setIsRebuilding] = useState(false);
 
-	const unhealthy =
-		project &&
-		(project.container_status === ContainerStatus.Stopped ||
-			project.container_status === ContainerStatus.Error);
+	if (!project) return null;
 
-	if (!unhealthy || !project) return null;
+	const status = project.container_status;
 
-	const hasError = project.container_status === ContainerStatus.Error;
+	// Provisioning / shutting down: a transient state that resolves on its own.
+	// Show a loading banner that links to the container page for live logs.
+	const provisioning = status === ContainerStatus.Creating || status === ContainerStatus.Stopping;
+	if (provisioning) {
+		const message =
+			status === ContainerStatus.Stopping
+				? `Stopping ${project.name}'s container…`
+				: `Provisioning ${project.name}'s container…`;
+		return (
+			<Link
+				to="/projects/$projectId/container"
+				params={{ projectId }}
+				data-testid="container-status-banner-provisioning"
+				aria-label={`${message} View container logs`}
+				className={`${BANNER_BASE} bg-blue-500/10 text-blue-400 transition-colors hover:bg-blue-500/20`}
+			>
+				<Loader2 className="w-3.5 h-3.5 shrink-0 animate-spin" />
+				<span data-testid="container-status-banner-message" className="min-w-0 truncate">
+					{message}
+				</span>
+				<span className="ml-auto shrink-0 hidden sm:inline opacity-80">View logs</span>
+			</Link>
+		);
+	}
+
+	const unhealthy = status === ContainerStatus.Stopped || status === ContainerStatus.Error;
+	if (!unhealthy) return null;
+
+	const hasError = status === ContainerStatus.Error;
 	const message = `${project.name} container failed`;
 
 	const rebuild = async () => {
@@ -34,10 +62,7 @@ export function ContainerStatusBanner({ projectId }: { projectId: string }) {
 	const tone = hasError ? 'bg-red-500/10 text-red-400' : 'bg-amber-500/10 text-amber-400';
 
 	return (
-		<div
-			data-testid="container-status-banner"
-			className={`sticky top-0 z-40 flex items-center gap-2 px-4 py-2 text-[13px] font-medium ${tone}`}
-		>
+		<div data-testid="container-status-banner" className={`${BANNER_BASE} ${tone}`}>
 			<AlertTriangle className="w-3.5 h-3.5 shrink-0" />
 			<span data-testid="container-status-banner-message" className="min-w-0 truncate">
 				{message}

--- a/packages/web/test/container-management.test.tsx
+++ b/packages/web/test/container-management.test.tsx
@@ -148,3 +148,61 @@ test('banner flags the active project as failed and rebuilds it', async () => {
 	await waitFor(() => expect(rebuildPosts.length).toBe(1), { timeout: 15_000 });
 	expect(rebuildPosts[0]).toContain(`/projects/${projectSlug}/container/rebuild`);
 });
+
+test('banner shows a provisioning state that links to the container page', async () => {
+	let ws!: SeededWorkspace;
+	const projectSlug = 'provisioning-banner';
+
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			ws = await seedWorkspace();
+
+			const provisioningProject = {
+				id: '33333333-3333-3333-3333-000000000001',
+				slug: projectSlug,
+				name: 'Provisioning Project',
+				team_id: ws.team.id,
+				team_slug: ws.team.slug,
+				team_name: 'Demo Team',
+				task_prefix: 'PB',
+				description: '',
+				docker_base_image: 'hezo/agent-base:latest',
+				container_id: null,
+				container_status: 'creating',
+				container_error: null,
+				container_last_logs: null,
+				dev_ports: [],
+				repo_count: 0,
+				open_task_count: 0,
+				is_internal: false,
+				created_at: new Date().toISOString(),
+			};
+
+			const originalFetch = globalThis.fetch;
+			globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+				const url = typeof input === 'string' ? input : (input as Request).url;
+				const method = init?.method ?? (input instanceof Request ? input.method : 'GET');
+				if (method === 'GET' && /\/api\/projects$/.test(url)) {
+					return new Response(JSON.stringify({ data: [provisioningProject] }), {
+						status: 200,
+						headers: { 'Content-Type': 'application/json' },
+					});
+				}
+				return originalFetch(input as RequestInfo, init);
+			}) as typeof globalThis.fetch;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/inbox',
+		params: { projectId: projectSlug },
+	});
+
+	const banner = await findByTestId('container-status-banner-provisioning', undefined, {
+		timeout: 20_000,
+	});
+	expect(banner.textContent ?? '').toContain('Provisioning Project');
+	// The whole banner is a link to the container/logs page.
+	expect(banner.getAttribute('href') ?? '').toContain(`/projects/${projectSlug}/container`);
+});


### PR DESCRIPTION
## Summary

Three container-experience fixes, all observed on a freshly-provisioned project.

### 1. Container/provisioning logs are now readable
Logs rendered as one glued-together blob with literal `[stderr]` markers mid-line, BuildKit progress, and carriage-return spam (`(Reading database ... 5%(Reading database ... 10% ...`).

**Root cause:** `LogStreamBroker.emit` broadcast each split line individually (live view was fine) but appended the **raw, non-newline-terminated** text to the `CappedLogBuffer`, whose `toString()` joins parts with `''`. So the persisted snapshot glued every emit together, and because the `[stderr] ` prefix landed mid-line, the frontend's `parseSeedLogText` (splits on `\n`, strips `[stderr] ` only at a line start) couldn't separate or de-tag them. Build output also arrived on stderr with embedded `\r` redraws that were never collapsed, so a *successful* build rendered entirely red.

**Fix:**
- New pure helper `splitLogLines` — normalizes `\r\n`, collapses carriage-return redraws to the final frame, splits on `\n`, drops empties.
- `CappedLogBuffer.append` newline-terminates each stored line (prefix sits at the line start, so it's strippable).
- `LogStreamBroker.emit` sanitizes once and uses the same lines for both the live broadcast and the snapshot.
- The docker image-build trace is surfaced as `stdout` so a clean build isn't a wall of red (a real build failure still throws and is reported by the catch).

### 2. Provisioning banner on every project page
Only an *error* banner existed. `ContainerStatusBanner` now also renders a loading banner (spinner + info tone) while the container is `creating`/`stopping`; the whole banner links to the container page for live logs. The existing stopped/error + Rebuild variant is unchanged.

### 3. Agents pick up tasks once the container is running
The CEO sat Idle on its coherence task even though the container was Running.

**Root cause:** the initial `provisionContainer` success path only called `requeueContainerKilledRuns` (which matches `error = 'container_error'` runs — none exist here). The `start`/`rebuild` routes additionally call `wakeAgentsWithPendingWork`; the initial provision path did not. Meanwhile a wakeup that fired during `creating` reached `activateAgent`'s gate (`container_id` is NULL until running) and was marked **Failed**, with nothing re-queuing it.

**Fix:**
- `wakeAgentsWithPendingWork` is extracted into `containers.ts` (shared by the routes) and called after the initial provision succeeds.
- `activateAgent` re-queues the wakeup (via the existing `requeueWakeup`) instead of failing it when the container is still `creating`, so the original wakeup retries as soon as the container is up — and no spurious failed run is recorded during the (often multi-minute) build.

## Testing
- `bun run typecheck` ✅, `bun run check` (changed files) ✅, production build ✅ (pre-commit hook).
- New/updated unit + integration tests, all green:
  - `splitLogLines` unit tests (`\r` collapse, `\r\n`, multi-line).
  - `LogStreamBroker` snapshot round-trips to clean, stream-tagged lines (no glued `→ …→ …`, no mid-line `[stderr]`).
  - `wakeAgentsWithPendingWork` queues a `container_start` wakeup for an enabled agent with a non-terminal assigned task (and skips terminal-only).
  - `activateAgent` re-queues (not fails) a wakeup while the project container is `creating`, with no run started.
  - Component test: provisioning banner renders with a spinner and links to `/projects/$projectId/container`.
- Full server vitest (1669 passing) and full web vitest (245 passing). The 6 failures in `git.test.ts`/`ssh-agent-server.test.ts` are pre-existing and environmental in this sandbox (missing `ssh-keygen`, no network for git clone/worktree) — confirmed identical with these changes stashed.

## Notes
No DB schema changes (`activateAgent`'s project query already selects `container_status`). Log sanitization drops only `\r` redraw frames, so build-failure debugging output is preserved.

https://claude.ai/code/session_01UELtgtAcNSm4ZckRR148Lr

---
_Generated by [Claude Code](https://claude.ai/code/session_01UELtgtAcNSm4ZckRR148Lr)_