### PR TITLE
fix: capture token usage for Codex and Gemini agent runs

### DIFF
--- a/packages/server/src/services/agent-stream-parser.ts
+++ b/packages/server/src/services/agent-stream-parser.ts
@@ -2,16 +2,20 @@
  * Converts per-runtime machine-readable stdout event streams into friendly,
  * human-readable log lines suitable for the run log viewer.
  *
- * Today only Claude Code's `--output-format stream-json --verbose` is
- * structured; other runtimes stream plain text and pass through unchanged.
+ * Every supported runtime is driven in a newline-delimited JSON (JSONL)
+ * streaming mode (see `RUNTIME_STREAM_ARGS`): Claude Code's
+ * `--output-format stream-json`, Codex's `exec --json`, and Gemini's
+ * `--output-format stream-json`. Each parser is stateful per run: `onStdout`
+ * buffers partial bytes, splits on newlines, attempts `JSON.parse`, and emits
+ * rendered lines. Anything that fails to parse falls through verbatim; valid
+ * events of an unknown type are dropped so raw JSON never reaches the log.
  *
- * The parser is stateful per run: `onChunk` buffers partial stdout bytes,
- * splits on newlines, attempts `JSON.parse`, and emits rendered lines.
- * Anything that fails to parse falls through verbatim.
- *
- * The parser also observes the terminal `result` event and exposes the
- * captured token usage and cost via `getUsage()` so the runner can persist
- * it on the heartbeat_run row.
+ * Each parser also observes its runtime's terminal event (Claude/Gemini
+ * `result`, Codex `turn.completed`) and exposes the captured token usage via
+ * `getUsage()` so the runner can persist it on the heartbeat_run row. The
+ * emitted `[done] … tokens=<in>/<out>` line matches the contract the web
+ * client parses in `parse-agent-log.ts`, so the log viewer's Done block shows
+ * tokens uniformly across runtimes.
  */
 import { AgentRuntime } from '@hezo/shared';
 
@@ -32,6 +36,10 @@ export function createAgentStreamParser(runtime: AgentRuntime): AgentStreamParse
 	switch (runtime) {
 		case AgentRuntime.ClaudeCode:
 			return createClaudeCodeParser();
+		case AgentRuntime.Codex:
+			return createCodexParser();
+		case AgentRuntime.Gemini:
+			return createGeminiParser();
 		default:
 			return createPassthroughParser();
 	}
@@ -45,6 +53,59 @@ function createPassthroughParser(): AgentStreamParser {
 		getUsage: () => null,
 	};
 }
+
+const MAX_LINE_LEN = 500;
+
+/**
+ * Shared JSONL line processor. Buffers partial stdout bytes, splits on
+ * newlines, and runs each complete line through `renderEvent`. Lines that
+ * fail `JSON.parse` fall through verbatim; `renderEvent` returns `[]` to drop
+ * an event. `getUsage` is supplied by the caller, which captures usage in a
+ * closure as it renders the terminal event.
+ */
+function createJsonlParser(
+	renderEvent: (event: unknown) => string[],
+	getUsage: () => AgentRunUsage | null,
+): AgentStreamParser {
+	let buffer = '';
+
+	const consumeLine = (line: string): string => {
+		const trimmed = line.trimEnd();
+		if (trimmed === '') return '';
+		let event: unknown;
+		try {
+			event = JSON.parse(trimmed);
+		} catch {
+			return `${trimmed}\n`;
+		}
+		const rendered = renderEvent(event);
+		if (rendered.length === 0) return '';
+		return `${rendered.join('\n')}\n`;
+	};
+
+	return {
+		onStdout(chunk: string): string {
+			buffer += chunk;
+			const parts = buffer.split('\n');
+			buffer = parts.pop() ?? '';
+			let out = '';
+			for (const line of parts) out += consumeLine(line);
+			return out;
+		},
+		onStderr: (chunk) => chunk,
+		flush(): string {
+			if (buffer === '') return '';
+			const remainder = buffer;
+			buffer = '';
+			return consumeLine(remainder);
+		},
+		getUsage,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Claude Code (`--output-format stream-json --verbose`)
+// ---------------------------------------------------------------------------
 
 interface ClaudeContentBlock {
 	type: string;
@@ -84,13 +145,11 @@ interface ClaudeStreamEvent {
 	usage?: ClaudeUsage;
 }
 
-const MAX_LINE_LEN = 500;
-
 function createClaudeCodeParser(): AgentStreamParser {
-	let buffer = '';
 	let usage: AgentRunUsage | null = null;
 
-	const renderEvent = (event: ClaudeStreamEvent): string[] => {
+	const renderEvent = (raw: unknown): string[] => {
+		const event = raw as ClaudeStreamEvent;
 		const out: string[] = [];
 
 		if (event.type === 'system' && event.subtype === 'init') {
@@ -150,39 +209,220 @@ function createClaudeCodeParser(): AgentStreamParser {
 		return out;
 	};
 
-	const consumeLine = (line: string): string => {
-		const trimmed = line.trimEnd();
-		if (trimmed === '') return '';
-		let event: ClaudeStreamEvent;
-		try {
-			event = JSON.parse(trimmed) as ClaudeStreamEvent;
-		} catch {
-			return `${trimmed}\n`;
+	return createJsonlParser(renderEvent, () => usage);
+}
+
+// ---------------------------------------------------------------------------
+// Codex (`codex exec --json`)
+// ---------------------------------------------------------------------------
+
+interface CodexUsage {
+	input_tokens?: number;
+	cached_input_tokens?: number;
+	output_tokens?: number;
+	reasoning_output_tokens?: number;
+}
+
+interface CodexItem {
+	type?: string;
+	item_type?: string;
+	text?: string;
+	message?: string;
+	command?: string;
+	aggregated_output?: string;
+	output?: string;
+	exit_code?: number;
+	name?: string;
+	arguments?: unknown;
+	args?: unknown;
+}
+
+interface CodexEvent {
+	type?: string;
+	model?: string;
+	message?: string;
+	item?: CodexItem;
+	usage?: CodexUsage;
+	error?: { message?: string } | string;
+}
+
+function createCodexParser(): AgentStreamParser {
+	let usage: AgentRunUsage | null = null;
+	let turns = 0;
+
+	const renderEvent = (raw: unknown): string[] => {
+		const event = raw as CodexEvent;
+		const type = event.type ?? '';
+
+		if (type === 'thread.started') {
+			return [`[session] model=${event.model ?? 'codex'} tools=0`];
 		}
-		const rendered = renderEvent(event);
-		if (rendered.length === 0) return '';
-		return `${rendered.join('\n')}\n`;
+
+		// A turn wraps one user→assistant exchange (tool calls included), so a
+		// single `codex exec` emits one terminal turn event. Codex reports the
+		// turn's totals on `turn.completed`; the last one seen wins.
+		if (type === 'turn.completed' || type === 'turn.failed') {
+			turns += 1;
+			const u = event.usage ?? {};
+			const input = u.input_tokens ?? 0;
+			const output = (u.output_tokens ?? 0) + (u.reasoning_output_tokens ?? 0);
+			usage = { inputTokens: input, outputTokens: output, costCents: 0 };
+			const status = type === 'turn.failed' ? 'error' : 'success';
+			return [`[done] ${status} turns=${turns} tokens=${input}/${output}`];
+		}
+
+		if (type === 'item.completed' && event.item) {
+			return renderCodexItem(event.item);
+		}
+
+		if (type === 'error') {
+			const msg = extractErrorMessage(event.error, event.message);
+			return msg ? [`[tool-error] ${truncate(msg.replace(/\s+/g, ' ').trim(), MAX_LINE_LEN)}`] : [];
+		}
+
+		return [];
 	};
 
-	return {
-		onStdout(chunk: string): string {
-			buffer += chunk;
-			const parts = buffer.split('\n');
-			buffer = parts.pop() ?? '';
-			let out = '';
-			for (const line of parts) out += consumeLine(line);
-			return out;
-		},
-		onStderr: (chunk) => chunk,
-		flush(): string {
-			if (buffer === '') return '';
-			const remainder = buffer;
-			buffer = '';
-			return consumeLine(remainder);
-		},
-		getUsage: () => usage,
-	};
+	return createJsonlParser(renderEvent, () => usage);
 }
+
+function renderCodexItem(item: CodexItem): string[] {
+	const kind = item.type ?? item.item_type ?? '';
+
+	if (kind === 'reasoning') {
+		const text = (item.text ?? '').trim();
+		return text ? [formatThinking(text)] : [];
+	}
+
+	if (kind === 'agent_message' || kind === 'assistant_message') {
+		const text = (item.text ?? item.message ?? '').trim();
+		return text ? [text] : [];
+	}
+
+	if (kind === 'command_execution') {
+		const out: string[] = [];
+		const cmd = (item.command ?? '').replace(/\s+/g, ' ').trim();
+		if (cmd) out.push(`[tool] shell(${truncate(cmd, MAX_LINE_LEN)})`);
+		const output = (item.aggregated_output ?? item.output ?? '').replace(/\s+/g, ' ').trim();
+		if (output) {
+			const isError = typeof item.exit_code === 'number' && item.exit_code !== 0;
+			out.push(`${isError ? '[tool-error]' : '[tool-result]'} ${truncate(output, MAX_LINE_LEN)}`);
+		}
+		return out;
+	}
+
+	if (kind === 'mcp_tool_call' || kind === 'tool_call') {
+		return [formatToolUse(item.name ?? 'tool', item.arguments ?? item.args)];
+	}
+
+	return [];
+}
+
+// ---------------------------------------------------------------------------
+// Gemini (`--output-format stream-json`)
+// ---------------------------------------------------------------------------
+
+interface GeminiTokens {
+	prompt?: number;
+	candidates?: number;
+	thoughts?: number;
+	total?: number;
+	cached?: number;
+	tool?: number;
+}
+
+interface GeminiModelStats {
+	tokens?: GeminiTokens;
+}
+
+interface GeminiStats {
+	models?: Record<string, GeminiModelStats>;
+}
+
+interface GeminiEvent {
+	type?: string;
+	model?: string;
+	role?: string;
+	content?: string;
+	text?: string;
+	name?: string;
+	input?: unknown;
+	args?: unknown;
+	output?: unknown;
+	result?: unknown;
+	is_error?: boolean;
+	stats?: GeminiStats;
+	message?: string;
+	error?: { message?: string } | string;
+}
+
+function createGeminiParser(): AgentStreamParser {
+	let usage: AgentRunUsage | null = null;
+
+	const renderEvent = (raw: unknown): string[] => {
+		const event = raw as GeminiEvent;
+		const type = event.type ?? '';
+
+		if (type === 'init') {
+			return [`[session] model=${event.model ?? 'gemini'} tools=0`];
+		}
+
+		if (type === 'message') {
+			if (event.role === 'user') return [];
+			const text = (event.content ?? event.text ?? '').trim();
+			return text ? [text] : [];
+		}
+
+		if (type === 'tool_use') {
+			return [formatToolUse(event.name ?? 'tool', event.input ?? event.args)];
+		}
+
+		if (type === 'tool_result') {
+			const body = extractToolResultText(event.output ?? event.result)
+				.replace(/\s+/g, ' ')
+				.trim();
+			const label = event.is_error ? '[tool-error]' : '[tool-result]';
+			return [body ? `${label} ${truncate(body, MAX_LINE_LEN)}` : label];
+		}
+
+		if (type === 'result') {
+			const { input, output } = sumGeminiTokens(event.stats);
+			usage = { inputTokens: input, outputTokens: output, costCents: 0 };
+			const status = event.error ? 'error' : 'success';
+			return [`[done] ${status} tokens=${input}/${output}`];
+		}
+
+		if (type === 'error') {
+			const msg = extractErrorMessage(event.error, event.message);
+			return msg ? [msg.replace(/\s+/g, ' ').trim()] : [];
+		}
+
+		return [];
+	};
+
+	return createJsonlParser(renderEvent, () => usage);
+}
+
+/**
+ * Sum token usage across every model Gemini reports. `prompt` is the full
+ * input (the `cached` count is a subset of it, not additive); billed output is
+ * the generated `candidates` plus reasoning `thoughts` tokens.
+ */
+function sumGeminiTokens(stats: GeminiStats | undefined): { input: number; output: number } {
+	let input = 0;
+	let output = 0;
+	for (const model of Object.values(stats?.models ?? {})) {
+		const t = model.tokens;
+		if (!t) continue;
+		input += t.prompt ?? 0;
+		output += (t.candidates ?? 0) + (t.thoughts ?? 0);
+	}
+	return { input, output };
+}
+
+// ---------------------------------------------------------------------------
+// Shared rendering helpers
+// ---------------------------------------------------------------------------
 
 function normalizeContent(content: ClaudeMessage['content']): ClaudeContentBlock[] {
 	if (typeof content === 'string') return [{ type: 'text', text: content }];
@@ -243,6 +483,15 @@ function extractToolResultText(content: unknown): string {
 			.join(' ');
 	}
 	return '';
+}
+
+function extractErrorMessage(
+	error: { message?: string } | string | undefined,
+	fallback?: string,
+): string {
+	if (typeof error === 'string' && error) return error;
+	if (error && typeof error === 'object' && typeof error.message === 'string') return error.message;
+	return typeof fallback === 'string' ? fallback : '';
 }
 
 function truncate(s: string, max: number): string {

--- a/packages/server/test/agent-runner.test.ts
+++ b/packages/server/test/agent-runner.test.ts
@@ -1424,7 +1424,7 @@ describe('runAgent', () => {
 			expect(capturedCmd).not.toContain('exec');
 		});
 
-		it('does not pass --output-format for non-claude runtimes', async () => {
+		it('passes exec --json (not claude stream flags) for the codex runtime', async () => {
 			let capturedCmd: string[] = [];
 			const docker = createMockDocker({
 				execCreate: async (_id: string, opts: any) => {
@@ -1443,6 +1443,21 @@ describe('runAgent', () => {
 				logs: new LogStreamBroker(),
 			};
 
+			// Configure an OpenAI provider so the Codex runtime resolves a credential
+			// and actually reaches execCreate. Mock fetch so verifyProviderKey doesn't
+			// make a real network call.
+			globalThis.fetch = vi.fn().mockResolvedValue({ ok: true }) as unknown as typeof fetch;
+			await app.request('/api/ai-providers', {
+				method: 'POST',
+				headers: { ...authHeader(adminToken), 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					provider: 'openai',
+					api_key: 'sk-test-codex-stream',
+					label: 'openai-codex-stream',
+				}),
+			});
+			globalThis.fetch = originalFetch;
+
 			await runAgent(
 				deps,
 				makeAgent(),
@@ -1450,6 +1465,12 @@ describe('runAgent', () => {
 				makeProject(),
 			);
 
+			// Codex streams newline-delimited JSON via `--json`, so token usage is
+			// parsed from its turn.completed events — but it must not pick up
+			// Claude's stream flags.
+			expect(capturedCmd).toContain('exec');
+			expect(capturedCmd).toContain('--json');
+			expect(capturedCmd[capturedCmd.length - 1]).toBe('-');
 			expect(capturedCmd).not.toContain('--output-format');
 			expect(capturedCmd).not.toContain('stream-json');
 			expect(capturedCmd).not.toContain('-p');
@@ -1495,6 +1516,11 @@ describe('runAgent', () => {
 
 			expect(capturedCmd).toContain('gemini');
 			expect(capturedCmd).toContain('--yolo');
+			// Gemini streams newline-delimited JSON via stream-json (live logs
+			// preserved) and reports per-model token usage in its result event.
+			expect(capturedCmd).toContain('--output-format');
+			const fmtIdx = capturedCmd.indexOf('--output-format');
+			expect(capturedCmd[fmtIdx + 1]).toBe('stream-json');
 			expect(capturedCmd).not.toContain('-p');
 			expect(capturedCmd).not.toContain('exec');
 			const geminiIdx = capturedCmd.indexOf('gemini');

--- a/packages/server/test/agent-stream-parser.test.ts
+++ b/packages/server/test/agent-stream-parser.test.ts
@@ -3,14 +3,6 @@ import { describe, expect, it } from 'vitest';
 import { createAgentStreamParser } from '../src/services/agent-stream-parser';
 
 describe('agent-stream-parser', () => {
-	it('passes non-claude runtimes through unchanged', () => {
-		const parser = createAgentStreamParser(AgentRuntime.Codex);
-		expect(parser.onStdout('some raw text\n')).toBe('some raw text\n');
-		expect(parser.onStderr('error line\n')).toBe('error line\n');
-		expect(parser.flush()).toBe('');
-		expect(parser.getUsage()).toBeNull();
-	});
-
 	it('buffers partial lines and parses when a newline arrives', () => {
 		const parser = createAgentStreamParser(AgentRuntime.ClaudeCode);
 		const event = { type: 'system', subtype: 'init', model: 'claude-x', tools: [] };
@@ -101,5 +93,135 @@ describe('agent-stream-parser', () => {
 		const parser = createAgentStreamParser(AgentRuntime.ClaudeCode);
 		expect(parser.onStdout('tail without newline')).toBe('');
 		expect(parser.flush()).toBe('tail without newline\n');
+	});
+
+	describe('codex', () => {
+		it('captures usage from the turn.completed event', () => {
+			const parser = createAgentStreamParser(AgentRuntime.Codex);
+			const event = {
+				type: 'turn.completed',
+				usage: {
+					input_tokens: 24763,
+					cached_input_tokens: 24448,
+					output_tokens: 122,
+					reasoning_output_tokens: 8,
+				},
+			};
+			const out = parser.onStdout(`${JSON.stringify(event)}\n`);
+			// cached_input_tokens is a subset of input_tokens; reasoning is billed output.
+			expect(out).toContain('[done] success turns=1 tokens=24763/130');
+
+			const usage = parser.getUsage();
+			expect(usage?.inputTokens).toBe(24763);
+			expect(usage?.outputTokens).toBe(130);
+			expect(usage?.costCents).toBe(0);
+		});
+
+		it('marks a failed turn as error', () => {
+			const parser = createAgentStreamParser(AgentRuntime.Codex);
+			const event = { type: 'turn.failed', usage: { input_tokens: 10, output_tokens: 2 } };
+			const out = parser.onStdout(`${JSON.stringify(event)}\n`);
+			expect(out).toContain('[done] error turns=1 tokens=10/2');
+			expect(parser.getUsage()?.outputTokens).toBe(2);
+		});
+
+		it('renders an agent message item as plain text', () => {
+			const parser = createAgentStreamParser(AgentRuntime.Codex);
+			const event = {
+				type: 'item.completed',
+				item: { type: 'agent_message', text: 'Hello world' },
+			};
+			expect(parser.onStdout(`${JSON.stringify(event)}\n`)).toBe('Hello world\n');
+		});
+
+		it('renders a command execution as a tool call and result', () => {
+			const parser = createAgentStreamParser(AgentRuntime.Codex);
+			const event = {
+				type: 'item.completed',
+				item: {
+					type: 'command_execution',
+					command: 'ls -la',
+					aggregated_output: 'file1\nfile2',
+					exit_code: 0,
+				},
+			};
+			const out = parser.onStdout(`${JSON.stringify(event)}\n`);
+			expect(out).toContain('[tool] shell(ls -la)');
+			expect(out).toContain('[tool-result] file1 file2');
+		});
+
+		it('buffers a turn.completed split across chunks', () => {
+			const parser = createAgentStreamParser(AgentRuntime.Codex);
+			const serialized = JSON.stringify({
+				type: 'turn.completed',
+				usage: { input_tokens: 5, output_tokens: 7 },
+			});
+			const half = Math.floor(serialized.length / 2);
+			expect(parser.onStdout(serialized.slice(0, half))).toBe('');
+			parser.onStdout(`${serialized.slice(half)}\n`);
+			expect(parser.getUsage()).toEqual({ inputTokens: 5, outputTokens: 7, costCents: 0 });
+		});
+
+		it('drops unknown events instead of emitting raw JSON', () => {
+			const parser = createAgentStreamParser(AgentRuntime.Codex);
+			expect(parser.onStdout(`${JSON.stringify({ type: 'turn.started' })}\n`)).toBe('');
+		});
+	});
+
+	describe('gemini', () => {
+		it('captures usage from the result event', () => {
+			const parser = createAgentStreamParser(AgentRuntime.Gemini);
+			const event = {
+				type: 'result',
+				stats: {
+					models: {
+						'gemini-2.5-pro': {
+							tokens: { prompt: 24939, candidates: 20, thoughts: 154, total: 25113, cached: 21263 },
+						},
+					},
+				},
+			};
+			const out = parser.onStdout(`${JSON.stringify(event)}\n`);
+			// input = prompt; output = candidates + thoughts (cached is a subset of prompt).
+			expect(out).toContain('[done] success tokens=24939/174');
+
+			const usage = parser.getUsage();
+			expect(usage?.inputTokens).toBe(24939);
+			expect(usage?.outputTokens).toBe(174);
+			expect(usage?.costCents).toBe(0);
+		});
+
+		it('sums usage across multiple models', () => {
+			const parser = createAgentStreamParser(AgentRuntime.Gemini);
+			const event = {
+				type: 'result',
+				stats: {
+					models: {
+						'gemini-2.5-pro': { tokens: { prompt: 1000, candidates: 100, thoughts: 0 } },
+						'gemini-2.5-flash': { tokens: { prompt: 200, candidates: 50, thoughts: 10 } },
+					},
+				},
+			};
+			parser.onStdout(`${JSON.stringify(event)}\n`);
+			expect(parser.getUsage()).toEqual({ inputTokens: 1200, outputTokens: 160, costCents: 0 });
+		});
+
+		it('renders an assistant message and skips the user echo', () => {
+			const parser = createAgentStreamParser(AgentRuntime.Gemini);
+			expect(
+				parser.onStdout(`${JSON.stringify({ type: 'message', role: 'user', content: 'hi' })}\n`),
+			).toBe('');
+			expect(
+				parser.onStdout(
+					`${JSON.stringify({ type: 'message', role: 'assistant', content: 'Done.' })}\n`,
+				),
+			).toBe('Done.\n');
+		});
+
+		it('renders the init event as a session line', () => {
+			const parser = createAgentStreamParser(AgentRuntime.Gemini);
+			const out = parser.onStdout(`${JSON.stringify({ type: 'init', model: 'gemini-2.5-pro' })}\n`);
+			expect(out).toBe('[session] model=gemini-2.5-pro tools=0\n');
+		});
 	});
 });

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -707,13 +707,15 @@ export const RUNTIME_DISALLOWED_TOOLS_ARGS: Record<AgentRuntime, readonly string
  * Flags that make each CLI emit structured per-turn events to stdout while
  * the run is in flight, so the run log shows tool calls, thinking, and
  * partial assistant text live instead of silence until the final result.
- * Runtimes without a documented stream mode default to [] and stream their
- * native text output.
+ * Every supported runtime exposes a newline-delimited JSON (JSONL) stream
+ * whose terminal event carries token usage; `agent-stream-parser.ts` renders
+ * those events and captures the usage. Codex accepts `--experimental-json` as
+ * an alias for `--json`; Gemini's `stream-json` shipped in CLI v0.11.0.
  */
 export const RUNTIME_STREAM_ARGS: Record<AgentRuntime, readonly string[]> = {
 	[AgentRuntime.ClaudeCode]: ['--output-format', 'stream-json', '--verbose'],
-	[AgentRuntime.Codex]: [],
-	[AgentRuntime.Gemini]: [],
+	[AgentRuntime.Codex]: ['--json'],
+	[AgentRuntime.Gemini]: ['--output-format', 'stream-json'],
 };
 
 /**


### PR DESCRIPTION
## Problem

Agent run pages show a **TOKENS** card reading `0 in / 0 out` for runs that use the **Codex (OpenAI)** or **Gemini (Google)** runtimes.

## Root cause

The display, persistence, and API are all correct and already work for **Claude Code** — the gap is upstream of them:

- Token usage is produced by the per-runtime stream parser (`agent-stream-parser.ts`). Only `createClaudeCodeParser()` parsed usage (from the `result` event). **Codex and Gemini fell through to a passthrough parser whose `getUsage()` always returned `null`**, so `COALESCE($, input_tokens)` kept the DB default of `0`.
- On top of that, Codex and Gemini were launched in **plain-text mode** (`RUNTIME_STREAM_ARGS = []`), so there was no structured usage in their streams to parse even if a parser existed.

## Fix

Drive both runtimes in **streaming JSONL** mode and parse usage from each runtime's terminal event. Both flags preserve live log streaming (no buffering trade-off):

| Runtime | Flag | Usage source |
|---|---|---|
| Codex | `exec --json` | `turn.completed.usage` → input = `input_tokens`; output = `output_tokens + reasoning_output_tokens` |
| Gemini | `--output-format stream-json` | `result` event → per-model `stats.models[].tokens`, summed: input = Σ`prompt`; output = Σ(`candidates + thoughts`) |

The three parsers now share a common JSONL line processor (`createJsonlParser`), and each emits the same `[done] … tokens=<in>/<out>` line the web client already parses (`parse-agent-log.ts`), so the run page **and** the log viewer's Done block render tokens uniformly across all runtimes. Unknown JSON events are dropped (never dumped as raw JSON); non-JSON lines still fall through verbatim.

No frontend, API, or schema changes were needed — they already read/return `input_tokens` / `output_tokens`.

## Files

- `packages/shared/src/types/common.ts` — `RUNTIME_STREAM_ARGS` for Codex/Gemini
- `packages/server/src/services/agent-stream-parser.ts` — `createCodexParser()` + `createGeminiParser()`, shared JSONL helper, refactored Claude onto it
- `packages/server/test/agent-stream-parser.test.ts` — Codex/Gemini usage + rendering tests
- `packages/server/test/agent-runner.test.ts` — assert the new invocation flags (also fixed a pre-existing **vacuous** Codex test that never resolved a provider, so `runAgent` bailed before `execCreate`)

## Testing

- `agent-stream-parser.test.ts` (16) and `agent-runner.test.ts` (60) pass; full typecheck + build + biome clean.
- Remaining suite failures are pre-existing and environmental (`spawn ssh-keygen ENOENT` — no `ssh-keygen` in this container; unrelated to this change).
- **Manual end-to-end** (recommended before merge): configure an OpenAI (Codex) and a Google (Gemini) provider, run a task on each, open the run page, and confirm the TOKENS card + Done block show non-zero in/out and that Gemini logs still stream live.

## Follow-ups (out of scope)

- **Cost**: Codex/Gemini CLIs emit no cost figure, so `cost_cents` stays `0` for them; deriving it needs a per-model pricing table.
- **Version pinning**: parsers are format-coupled but `Dockerfile.agent-base` installs the CLIs unpinned — consider pinning `@openai/codex` / `@google/gemini-cli`.
- Confirm Codex `item.*` field names and Gemini's `result` nesting against a captured real run (parsers read these defensively).

https://claude.ai/code/session_01XJVKtAnQ6FuTxdbGYm8mKv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XJVKtAnQ6FuTxdbGYm8mKv)_