### PR TITLE
fix: suppress redundant assignment-driven agent re-runs

### DIFF
--- a/.dev/spec.md
+++ b/.dev/spec.md
@@ -1558,6 +1558,7 @@ When multiple events fire for the same agent in quick succession (e.g. several @
 - Delivers all pending events in a single heartbeat response
 - Prevents redundant subprocess spawns and duplicate work
 - Maintains event ordering within the batch
+- Retires a stale `assignment` wakeup instead of running it when a completed (succeeded) run for that agent+task already started after the wakeup was created — the run already served the assignment. This complements the run-start absorb, covering wakeups that only become claimable after a run begins (blocker-deferred releases, busy-skip survivors). Genuine re-assignments (created after the last run) and other sources still fire.
 
 ### Reasoning effort
 

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -46,7 +46,7 @@ import { ensureRepoSetupAction } from './repo-setup';
 import { getProjectConcurrency, isTaskBusyInDb } from './run-concurrency';
 import type { SshAgentServer } from './ssh-agent';
 import { recordStatusChange } from './task-events';
-import { absorbQueuedTaskWakeups, createWakeup } from './wakeup';
+import { absorbQueuedTaskWakeups, assignmentWakeupAlreadyServed, createWakeup } from './wakeup';
 import type { WebSocketManager } from './ws';
 
 const log = logger.child('job-manager');
@@ -731,8 +731,9 @@ export class JobManager {
 			team_id: string;
 			source: string;
 			payload: Record<string, unknown>;
+			created_at: string;
 		}>(
-			`SELECT id, member_id, team_id, source, payload
+			`SELECT id, member_id, team_id, source, payload, created_at
 			 FROM agent_wakeup_requests
 			 WHERE status = $2::wakeup_status
 			   AND created_at < $1
@@ -797,6 +798,41 @@ export class JobManager {
 					wakeup.team_id,
 					null,
 				);
+				continue;
+			}
+
+			// A still-queued `assignment` wakeup whose task was already worked by a
+			// completed run is stale: that run read the task at boot and served the
+			// assignment. `absorbQueuedTaskWakeups` only retires such siblings that
+			// were queued at run *start*; this catches the ones that become claimable
+			// later (blocker-deferred flips, busy-skip survivors) so they don't fire a
+			// redundant back-to-back run. Genuine re-assignments and triggers created
+			// after the run keep firing — their created_at is newer than its started_at.
+			if (
+				wakeupTaskId &&
+				wakeup.source === WakeupSource.Assignment &&
+				(await assignmentWakeupAlreadyServed(db, wakeup.member_id, wakeupTaskId, wakeup.created_at))
+			) {
+				await db.query(
+					'UPDATE agent_wakeup_requests SET status = $1::wakeup_status WHERE id = $2',
+					[WakeupStatus.Coalesced, wakeup.id],
+				);
+				log.debug(
+					`Retiring stale assignment wakeup ${wakeup.id} — task ${wakeupTaskId} already served by a completed run`,
+				);
+				const refreshed = await db.query<Record<string, unknown>>(
+					'SELECT * FROM tasks WHERE id = $1',
+					[wakeupTaskId],
+				);
+				if (refreshed.rows[0]) {
+					broadcastRowChange(
+						this.deps.wsManager,
+						wsRoom.team(wakeup.team_id),
+						'tasks',
+						'UPDATE',
+						refreshed.rows[0],
+					);
+				}
 				continue;
 			}
 

--- a/packages/server/src/services/wakeup.ts
+++ b/packages/server/src/services/wakeup.ts
@@ -1,5 +1,5 @@
 import type { PGlite } from '@electric-sql/pglite';
-import { type WakeupSource, WakeupStatus } from '@hezo/shared';
+import { HeartbeatRunStatus, type WakeupSource, WakeupStatus } from '@hezo/shared';
 
 export async function createWakeup(
 	db: PGlite,
@@ -92,6 +92,35 @@ export async function absorbQueuedTaskWakeups(
 		[WakeupStatus.Coalesced, memberId, WakeupStatus.Queued, taskId, exceptWakeupId],
 	);
 	return absorbed.rows.map((r) => r.id);
+}
+
+/**
+ * True when a successful run for this agent+task already started at or after the
+ * wakeup was created — the run read the task at boot and served the assignment,
+ * so starting another would be a no-op repeat. Closes the gap that
+ * `absorbQueuedTaskWakeups` leaves at run *start*: a blocker-deferred or
+ * busy-skipped `assignment` wakeup that only becomes claimable after the run has
+ * already worked the task. Scoped to `succeeded` runs so a failed/timed-out run
+ * still allows a legitimate retry, and an assignment created *after* the last run
+ * (`created_at > started_at`) is never suppressed.
+ */
+export async function assignmentWakeupAlreadyServed(
+	db: PGlite,
+	memberId: string,
+	taskId: string,
+	wakeupCreatedAt: string,
+): Promise<boolean> {
+	const served = await db.query<{ id: string }>(
+		`SELECT id FROM heartbeat_runs
+		 WHERE member_id = $1
+		   AND task_id = $2
+		   AND status = $3::heartbeat_run_status
+		   AND started_at IS NOT NULL
+		   AND started_at >= $4
+		 LIMIT 1`,
+		[memberId, taskId, HeartbeatRunStatus.Succeeded, wakeupCreatedAt],
+	);
+	return served.rows.length > 0;
 }
 
 function mergePayloads(

--- a/packages/server/test/wakeup.test.ts
+++ b/packages/server/test/wakeup.test.ts
@@ -1,8 +1,13 @@
+import { randomUUID } from 'node:crypto';
 import type { PGlite } from '@electric-sql/pglite';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Env } from '../src/lib/types';
-import { absorbQueuedTaskWakeups, createWakeup } from '../src/services/wakeup';
+import {
+	absorbQueuedTaskWakeups,
+	assignmentWakeupAlreadyServed,
+	createWakeup,
+} from '../src/services/wakeup';
 import { safeClose } from './helpers';
 import { authHeader, createTestApp, createTestProject } from './helpers/app';
 
@@ -373,5 +378,66 @@ describe('absorbQueuedTaskWakeups', () => {
 		expect(absorbed).toEqual([]);
 		expect(await status(otherAgent)).toBe('queued');
 		expect(await status(otherTask)).toBe('queued');
+	});
+});
+
+describe('assignmentWakeupAlreadyServed', () => {
+	let servedTaskId: string;
+
+	beforeAll(async () => {
+		const project = (await (await createTestProject(db, teamId, { name: 'Served Project' })).json())
+			.data;
+		const taskRes = await app.request(`/api/projects/${project.slug}/tasks`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ project_id: project.id, title: 'Served task', assignee_id: agentId }),
+		});
+		servedTaskId = (await taskRes.json()).data.id;
+	});
+
+	const ago = (ms: number) => new Date(Date.now() - ms).toISOString();
+
+	async function insertRun(opts: { status?: string; startedAt: string }): Promise<void> {
+		await db.query(
+			`INSERT INTO heartbeat_runs (team_id, member_id, task_id, status, started_at, finished_at)
+			 VALUES ($1, $2, $3, $4::heartbeat_run_status, $5, $5)`,
+			[teamId, agentId, servedTaskId, opts.status ?? 'succeeded', opts.startedAt],
+		);
+	}
+
+	it('returns true when a succeeded run started at/after the wakeup was created', async () => {
+		await db.query('DELETE FROM heartbeat_runs WHERE task_id = $1', [servedTaskId]);
+		await insertRun({ startedAt: ago(30_000) });
+		expect(await assignmentWakeupAlreadyServed(db, agentId, servedTaskId, ago(60_000))).toBe(true);
+	});
+
+	it('returns false when the only run started before the wakeup (genuine re-assignment)', async () => {
+		await db.query('DELETE FROM heartbeat_runs WHERE task_id = $1', [servedTaskId]);
+		await insertRun({ startedAt: ago(60_000) });
+		expect(await assignmentWakeupAlreadyServed(db, agentId, servedTaskId, ago(30_000))).toBe(false);
+	});
+
+	it('returns false when no run exists for the task (first assignment)', async () => {
+		await db.query('DELETE FROM heartbeat_runs WHERE task_id = $1', [servedTaskId]);
+		expect(await assignmentWakeupAlreadyServed(db, agentId, servedTaskId, ago(1_000))).toBe(false);
+	});
+
+	it('ignores non-succeeded runs so failed/cancelled/timed-out runs still allow a retry', async () => {
+		await db.query('DELETE FROM heartbeat_runs WHERE task_id = $1', [servedTaskId]);
+		await insertRun({ status: 'failed', startedAt: ago(30_000) });
+		await insertRun({ status: 'cancelled', startedAt: ago(20_000) });
+		await insertRun({ status: 'timed_out', startedAt: ago(10_000) });
+		expect(await assignmentWakeupAlreadyServed(db, agentId, servedTaskId, ago(60_000))).toBe(false);
+	});
+
+	it('is scoped to the same agent and task', async () => {
+		await db.query('DELETE FROM heartbeat_runs WHERE task_id = $1', [servedTaskId]);
+		await insertRun({ startedAt: ago(30_000) });
+		// A succeeded run for a different agent must not satisfy this agent's wakeup.
+		expect(await assignmentWakeupAlreadyServed(db, randomUUID(), servedTaskId, ago(60_000))).toBe(
+			false,
+		);
+		// ...nor a different task.
+		expect(await assignmentWakeupAlreadyServed(db, agentId, randomUUID(), ago(60_000))).toBe(false);
 	});
 });


### PR DESCRIPTION
## Problem

An agent could start a **second run on a task it had just fully worked**, with the run's trigger shown as `assignment` ("Assigned to TO‑5") and **no new comment/reply/mention** behind it — a no‑op repeat that burns a container + LLM call.

## Root cause

The system already guards against redundant back‑to‑back runs via `absorbQueuedTaskWakeups`, but only **at run start**, and it deliberately spares:
- `deferred` (blocker‑parked) wakeups, and
- wakeups created after the run starts.

So a blocker‑deferred or busy‑skipped `assignment` wakeup survives behind the task‑busy gate (`processWakeups` → `markWakeupSkipped(TaskBusy)`), and fires the instant the run ends (`onAgentComplete`'s `finally` re‑invokes `processWakeups`). `createWakeup` coalescing also only matches `queued` rows, so it doesn't absorb a deferred sibling either.

The invariant `absorb` encodes — *"a run serves every assignment trigger that predates it"* — was only enforced at run start. This closes the gap at the wakeup **claim** chokepoint.

## Fix

Add an **"already‑served" guard** in `processWakeups`: before claiming an `assignment`‑source wakeup carrying a `task_id`, retire it (`status = coalesced`) if a **succeeded** run for the same agent+task already started **at/after the wakeup's `created_at`**.

New helper `assignmentWakeupAlreadyServed(db, memberId, taskId, wakeupCreatedAt)` in `wakeup.ts`; wired into the dispatcher in `job-manager.ts`.

### Why it can't break legitimate behavior
- **First assignment** (no prior run) → fires. ✓
- **Genuine re‑assignment after a run** → new `created_at` > prior `started_at` → fires. ✓
- **New info mid‑run** (created after start) → fires as the intended follow‑up (unchanged absorb semantics). ✓
- **Failed / timed‑out / cancelled run** → not `succeeded` → retry preserved. ✓
- **Non‑assignment sources** (mention/comment/reply/on_demand/automation) and **chain/heartbeat** → untouched. ✓

## Tests

5 new pure‑DB unit tests in `packages/server/test/wakeup.test.ts` (mirroring the existing `absorbQueuedTaskWakeups` tests): suppression when served, fires on genuine re‑assignment, fires on first assignment, ignores non‑succeeded runs, and agent/task scoping.

- `packages/server/test/wakeup.test.ts` — **19 passed**
- `job-manager`, `job-manager-workflows`, `task-dependencies-gate`, `tasks`, `mcp-tools`, `wakeup` — **220 passed**
- Typecheck + build green (husky pre‑commit). (`git.test.ts` / `ssh-agent-server.test.ts` fail only because this container has no `ssh-keygen` — unrelated.)

`.dev/spec.md` "Wakeup queue and coalescing" updated to document the guard.

https://claude.ai/code/session_01TN8mYdN6FiJ7TcDrBkpo7Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01TN8mYdN6FiJ7TcDrBkpo7Z)_