### PR TITLE
fix(web): reliably scroll to source comment on inbox deep-link

### DIFF
--- a/packages/web/src/components/task-detail/comments-section.tsx
+++ b/packages/web/src/components/task-detail/comments-section.tsx
@@ -1,3 +1,4 @@
+import { useLocation } from '@tanstack/react-router';
 import { CornerDownRight, Reply } from 'lucide-react';
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso';
@@ -24,6 +25,31 @@ export function jumpToComment(commentId: string) {
 		window.history.pushState(null, '', target);
 		window.dispatchEvent(new HashChangeEvent('hashchange'));
 	};
+}
+
+type HashScrollTarget = { idx: number; highlightId: string | null };
+
+/**
+ * Resolve a '#'-prefixed hash to a row in the loaded comments list.
+ * `#comment-<id>` targets that comment (and highlights it); `#setup-repo`
+ * targets the unresolved setup-repo action card. `idx` is -1 when the hash
+ * points at nothing here — no jump hash, or the row hasn't loaded yet.
+ */
+function resolveHashTarget(hash: string, comments: Comment[]): HashScrollTarget {
+	if (hash.startsWith('#comment-')) {
+		const targetId = hash.slice('#comment-'.length);
+		const idx = comments.findIndex((c) => c.id === targetId);
+		return { idx, highlightId: idx >= 0 ? targetId : null };
+	}
+	if (hash === '#setup-repo') {
+		const idx = comments.findIndex((c) => {
+			if (c.content_type !== 'action') return false;
+			const content = typeof c.content === 'object' ? (c.content as { kind?: string }) : null;
+			return content?.kind === 'setup_repo' && !c.chosen_option;
+		});
+		return { idx, highlightId: null };
+	}
+	return { idx: -1, highlightId: null };
 }
 
 interface CommentsSectionProps {
@@ -63,9 +89,18 @@ export function CommentsSection({
 	const chooseOption = useChooseOption(projectId, taskId);
 	const virtuosoRef = useRef<VirtuosoHandle>(null);
 	const listContainerRef = useRef<HTMLDivElement>(null);
-	const didScrollToHashRef = useRef(false);
 	const [highlightedCommentId, setHighlightedCommentId] = useState<string | null>(null);
 	const lastResetTaskIdRef = useRef<string | null>(null);
+	// Deep-link scroll. `hashTarget` is the '#'-prefixed hash we want to scroll
+	// to, written from two sources (router navigations + raw window hash changes)
+	// so it stays correct under both browser and memory history. It drives the
+	// executor effect; `lastScrolledHashRef` records what we last scrolled to so a
+	// WebSocket comments refetch can't yank the viewport back.
+	const routerHash = useLocation({ select: (l) => l.hash });
+	const [hashTarget, setHashTarget] = useState<string>(() =>
+		typeof window !== 'undefined' ? window.location.hash : '',
+	);
+	const lastScrolledHashRef = useRef<string | null>(null);
 
 	useLayoutEffect(() => {
 		if (!scrollParent) return;
@@ -76,97 +111,118 @@ export function CommentsSection({
 		lastResetTaskIdRef.current = taskId;
 	}, [taskId, scrollParent]);
 
+	// Router navigations carry the deep-link hash here — `navigate({ hash })` from
+	// the mention card, approval modal, and run-detail link. Reading it off the
+	// router (rather than `window.location`) makes it reactive in both browser and
+	// memory history, so it fires on a fresh cross-page mount and on same-task
+	// re-navigation alike. `location.hash` has no leading '#'.
 	useEffect(() => {
-		if (!comments || comments.length === 0) return;
+		if (routerHash) setHashTarget(`#${routerHash}`);
+	}, [routerHash]);
+
+	// The in-page `jumpToComment` helper changes the hash with a raw `pushState`
+	// plus a dispatched `hashchange` (bypassing the router); browser back/forward
+	// fires `popstate`. Catch both so those jumps still drive the executor.
+	useEffect(() => {
 		if (typeof window === 'undefined') return;
-
-		// Resolve the current hash (a specific comment via `#comment-<id>`, or
-		// the unresolved setup-repo action card via `#setup-repo`) to its
-		// index in the loaded comments list and tell Virtuoso to scroll there.
-		// `scrollToIndex` is computed off estimated row heights, so iterate a
-		// few times: each pass mounts more rows, grows the measured document,
-		// and the next call lands closer to the target.
-		const scrollToHash = () => {
-			const hash = window.location.hash;
-			let idx = -1;
-			let highlightId: string | null = null;
-			if (hash.startsWith('#comment-')) {
-				const targetId = hash.slice('#comment-'.length);
-				idx = comments.findIndex((c) => c.id === targetId);
-				if (idx >= 0) highlightId = targetId;
-			} else if (hash === '#setup-repo') {
-				idx = comments.findIndex((c) => {
-					if (c.content_type !== 'action') return false;
-					const content = typeof c.content === 'object' ? (c.content as { kind?: string }) : null;
-					return content?.kind === 'setup_repo' && !c.chosen_option;
-				});
-			}
-			if (idx < 0) return [] as ReturnType<typeof setTimeout>[];
-			const out: ReturnType<typeof setTimeout>[] = [];
-			// Virtuoso with `customScrollParent` only mounts items once its
-			// container intersects the parent's viewport. On a fresh task page
-			// load, the comments list starts far below the fold (header,
-			// description, sidebar, etc.) and Virtuoso's IntersectionObserver
-			// never fires — so itemContent is never called, no row exists in
-			// the DOM, and `scrollToIndex` has no measured rows to land on.
-			// Force the parent to scroll the list container into view first;
-			// that wakes the IntersectionObserver and Virtuoso starts mounting.
-			if (listContainerRef.current && scrollParent) {
-				const listTop = listContainerRef.current.getBoundingClientRect().top;
-				const parentTop = scrollParent.getBoundingClientRect().top;
-				const offset = scrollParent.scrollTop + listTop - parentTop;
-				scrollParent.scrollTo({ top: Math.max(0, offset - 80), behavior: 'auto' });
-			}
-			// Each tick: first ask Virtuoso to mount the target row, then read
-			// the rendered element's real position and scroll precisely to it.
-			// Virtuoso's scrollToIndex alone underscrolls when the row's height
-			// grows after mount (LazyMount in run comments, async log body),
-			// because the offset is computed from stale estimates. The extra
-			// 3000ms tick absorbs the post-fetch height jump.
-			const scrollDelays = [16, 200, 600, 1500, 3000];
-			for (const delay of scrollDelays) {
-				out.push(
-					setTimeout(() => {
-						virtuosoRef.current?.scrollToIndex({ index: idx, align: 'center' });
-						if (highlightId) {
-							const el = document.getElementById(`comment-${highlightId}`);
-							el?.scrollIntoView({ block: 'center', behavior: 'auto' });
-						}
-					}, delay),
-				);
-			}
-			if (highlightId) {
-				setHighlightedCommentId(highlightId);
-				// Clear the highlight 2s AFTER the last scroll attempt — under load,
-				// Virtuoso may not mount the target row until that final attempt, so
-				// the highlight must outlive row mount or it flashes invisibly.
-				const lastScrollDelay = scrollDelays[scrollDelays.length - 1];
-				out.push(
-					setTimeout(() => {
-						setHighlightedCommentId(null);
-					}, lastScrollDelay + 2000),
-				);
-				window.history.replaceState(null, '', window.location.pathname + window.location.search);
-			}
-			if (hash === '#setup-repo') {
-				window.history.replaceState(null, '', window.location.pathname + window.location.search);
-			}
-			return out;
-		};
-
-		const initialTimers = didScrollToHashRef.current ? [] : scrollToHash();
-		didScrollToHashRef.current = true;
-
-		const allTimers: ReturnType<typeof setTimeout>[] = [...initialTimers];
-		const onHashChange = () => {
-			allTimers.push(...scrollToHash());
-		};
+		const onHashChange = () => setHashTarget(window.location.hash);
 		window.addEventListener('hashchange', onHashChange);
+		window.addEventListener('popstate', onHashChange);
 		return () => {
 			window.removeEventListener('hashchange', onHashChange);
-			for (const t of allTimers) clearTimeout(t);
+			window.removeEventListener('popstate', onHashChange);
 		};
-	}, [comments, scrollParent]);
+	}, []);
+
+	// Execute the deep-link scroll once we have a hash target AND comments are
+	// loaded AND Virtuoso has its scroll parent. Re-runs as rows stream in
+	// (`comments`) and when the hash changes (`hashTarget`). Decoupling the
+	// intent (hashTarget) from execution is what makes this survive a fresh
+	// cross-page mount, StrictMode's double-invoke, comment caching, and refetch.
+	useEffect(() => {
+		if (!comments || comments.length === 0) return;
+		if (!scrollParent) return;
+		if (typeof window === 'undefined') return;
+
+		const { idx, highlightId } = resolveHashTarget(hashTarget, comments);
+		// Nothing to jump to, or we already handled this exact hash. The dedupe
+		// guard stops a WebSocket comments refetch (fresh array reference, same
+		// consumed hash) from re-yanking the viewport while the user reads.
+		if (idx < 0 || lastScrolledHashRef.current === hashTarget) return;
+
+		const consumedHash = hashTarget;
+		const timers: ReturnType<typeof setTimeout>[] = [];
+
+		// Virtuoso with `customScrollParent` only mounts items once its container
+		// intersects the parent's viewport. On a fresh task page the comments list
+		// starts far below the fold, so its IntersectionObserver never fires, no
+		// row exists in the DOM, and `scrollToIndex` has nothing to land on. Scroll
+		// the list container into view first to wake it and start mounting rows.
+		if (listContainerRef.current) {
+			const listTop = listContainerRef.current.getBoundingClientRect().top;
+			const parentTop = scrollParent.getBoundingClientRect().top;
+			const offset = scrollParent.scrollTop + listTop - parentTop;
+			scrollParent.scrollTo({ top: Math.max(0, offset - 80), behavior: 'auto' });
+		}
+
+		// Retry ladder: each tick asks Virtuoso to mount the target row, then reads
+		// the rendered element's real position and scrolls precisely to it. The
+		// later ticks absorb post-mount height growth (LazyMount run comments,
+		// async log bodies) that would otherwise leave scrollToIndex short.
+		//
+		// Mark the hash consumed inside the FIRST tick, not now: React StrictMode
+		// runs setup -> cleanup -> setup synchronously and the cleanup clears these
+		// timers before the 16ms tick fires. Setting the ref now would make the
+		// second setup's `=== hashTarget` guard skip the re-arm and nothing would
+		// scroll; deferring it lets the surviving setup re-arm and land the scroll.
+		const scrollDelays = [16, 200, 600, 1500, 3000];
+		scrollDelays.forEach((delay, i) => {
+			timers.push(
+				setTimeout(() => {
+					if (i === 0) lastScrolledHashRef.current = consumedHash;
+					virtuosoRef.current?.scrollToIndex({ index: idx, align: 'center' });
+					if (highlightId) {
+						document
+							.getElementById(`comment-${highlightId}`)
+							?.scrollIntoView({ block: 'center', behavior: 'auto' });
+					}
+				}, delay),
+			);
+		});
+
+		if (highlightId) setHighlightedCommentId(highlightId);
+
+		// Strip the hash once the scroll settles so a reload doesn't re-jump — but
+		// only if it still points at what we consumed, so a fresh click during the
+		// scroll isn't swallowed.
+		timers.push(
+			setTimeout(
+				() => {
+					if (window.location.hash === consumedHash) {
+						window.history.replaceState(
+							null,
+							'',
+							window.location.pathname + window.location.search,
+						);
+					}
+				},
+				scrollDelays[scrollDelays.length - 1] + 50,
+			),
+		);
+
+		return () => {
+			for (const t of timers) clearTimeout(t);
+		};
+	}, [comments, scrollParent, hashTarget]);
+
+	// Fade the deep-link highlight a couple seconds after it lands. Keyed on the
+	// highlighted id (not the scroll timers) so a comments refetch mid-scroll
+	// can't cancel the fade and strand the ring on screen.
+	useEffect(() => {
+		if (!highlightedCommentId) return;
+		const t = setTimeout(() => setHighlightedCommentId(null), 5000);
+		return () => clearTimeout(t);
+	}, [highlightedCommentId]);
 
 	return (
 		<div ref={listContainerRef} className="mb-4" data-testid="comments-list">

--- a/packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx
@@ -38,6 +38,9 @@ function TaskDetailPage() {
 			navigate({
 				to: '/projects/$projectId/tasks/$taskId',
 				params: { projectId: canonicalProject, taskId: friendlyId },
+				// Preserve a deep-link hash (`#comment-<id>`) across the canonical
+				// redirect so it can't be stripped before the scroll fires.
+				hash: window.location.hash ? window.location.hash.replace(/^#/, '') : undefined,
 				replace: true,
 			});
 		}

--- a/packages/web/test/helpers/render.tsx
+++ b/packages/web/test/helpers/render.tsx
@@ -19,6 +19,7 @@ import {
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { Hono } from 'hono';
+import { StrictMode } from 'react';
 import { afterEach, beforeEach } from 'vitest';
 
 interface RenderOptions {
@@ -26,6 +27,11 @@ interface RenderOptions {
 	// Caller can seed the test DB before the app mounts — runs after the test
 	// app boots and gets the auth token, so seeders can hit the API or DB.
 	seed?: (ctx: TestAppContext) => Promise<unknown> | unknown;
+	// Wrap the tree in <StrictMode> to exercise React's mount→cleanup→mount
+	// double-invoke (the real app runs under StrictMode via main.tsx). Off by
+	// default to keep existing specs unchanged; opt in where effect resilience
+	// across remount matters (e.g. the deep-link scroll).
+	strictMode?: boolean;
 }
 
 interface TestAppContext {
@@ -164,13 +170,14 @@ export async function renderApp(options: RenderOptions) {
 		defaultNotFoundComponent: () => <Navigate to="/home" replace />,
 	});
 
-	const utils = render(
+	const tree = (
 		<QueryClientProvider client={activeQueryClient}>
 			<ThemeProvider>
 				<RouterProvider router={router} />
 			</ThemeProvider>
-		</QueryClientProvider>,
+		</QueryClientProvider>
 	);
+	const utils = render(options.strictMode ? <StrictMode>{tree}</StrictMode> : tree);
 
 	return {
 		...utils,

--- a/packages/web/test/inbox-mentions.test.tsx
+++ b/packages/web/test/inbox-mentions.test.tsx
@@ -5,6 +5,7 @@ import {
 	type SeededProject,
 	type SeededTask,
 	type SeededWorkspace,
+	seedComment,
 	seedProject,
 	seedTask,
 	seedWorkspace,
@@ -145,6 +146,56 @@ test('clicking a mention navigates to the task and marks it read', async () => {
 		updated = again.rows[0]?.read_at;
 	}
 	expect(updated).not.toBeNull();
+});
+
+test('clicking a mention deep-links to and highlights the source comment', async () => {
+	let ctx: { projectSlug: string; commentId: string };
+	const { findByTestId, user, router } = await renderApp({
+		initialPath: '/',
+		// Run under StrictMode so the mount→cleanup→mount double-invoke that used
+		// to wipe the one-shot scroll is exercised — the highlight must survive it.
+		strictMode: true,
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Deep Link' });
+			const task = await seedTask(ws, project, { title: 'Deep-link target ticket' });
+			// Seed the mention's comment first (comments sort created_at ASC) so it
+			// sits at the top and Virtuoso mounts it under happy-dom; the trailing
+			// comments make it a real multi-row thread rather than a single row.
+			const { commentId } = await seedAgentAdminMention(
+				ws,
+				task,
+				'@admin please review the source comment.',
+			);
+			for (let i = 0; i < 4; i++) await seedComment(ws, task, `follow-up comment ${i}`);
+			ctx = { projectSlug: project.slug, commentId };
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/inbox',
+		params: { projectId: ctx!.projectSlug },
+	});
+
+	const card = await findByTestId('mention-card', undefined, { timeout: 10_000 });
+	await user.click(card);
+
+	// The click runs navigate({ hash: 'comment-<id>' }). The redesigned
+	// CommentsSection reads that hash off the router (reactive under the memory
+	// history the harness uses) and flags the resolved row via
+	// data-comment-highlighted — the signal the deep-link landed on the right
+	// comment instead of dumping the user at the top of the page.
+	const highlighted = await waitFor(
+		() => {
+			const el = document.querySelector(
+				`#comment-${ctx!.commentId}[data-comment-highlighted="true"]`,
+			);
+			if (!el) throw new Error('source comment not highlighted yet');
+			return el as HTMLElement;
+		},
+		{ timeout: 10_000 },
+	);
+	expect(highlighted.textContent).toContain('please review the source comment');
 });
 
 test('inbox shows read mentions as history and highlights unread ones', async () => {


### PR DESCRIPTION
## Problem

Clicking an item in the inbox (e.g. a mention, *"@product-lead asked you on TO-4"*) navigated to the task page but **landed at the top**, forcing the user to scroll down to find the source comment.

The deep-link machinery already existed — `mention-card.tsx` navigates with `hash: comment-<id>` and `CommentsSection` has scroll-to-comment logic — but it only fired reliably on a **raw full-page load** (the one path the existing tests covered). On the real in-app inbox→task SPA navigation it silently failed.

## Root cause

`CommentsSection`'s scroll-to-comment was a single effect that read the hash, scheduled a ladder of retry `setTimeout`s, **and returned those timers as its cleanup**, gated by a one-shot `didScrollToHashRef`:

- **StrictMode double-invoke** (dev): on `mount → cleanup → mount`, the cleanup immediately cleared the retry timers and the ref-guard blocked the second invoke. When comments were already cached at mount (revisiting a task from the inbox), nothing scrolled. A raw `page.goto` dodged this because comments load *after* mount, so the scroll ran on a normal re-render whose timers survived — which is why the existing test passed while the inbox path was broken.
- **`navigate({hash})` emits no `hashchange`** (TanStack uses the History API), so the `hashchange` listener never helped the cross-page case, and the effect only read `window.location.hash`.

## Fix

Decouple **intent** from **execution** in `CommentsSection`:

- Read the target hash reactively off the **router** (`useLocation`) — reactive in both browser and memory history — plus a `hashchange`/`popstate` listener for the in-page `jumpToComment` path.
- An idempotent, **hash-keyed** executor performs the scroll once comments + Virtuoso are ready, and a `lastScrolledHashRef` guard stops a WebSocket comments refetch from yanking the viewport back while the user reads.
- The dedupe ref is set **inside the first retry tick**, not at arm-time, so StrictMode's synchronous cleanup can't defeat it — the surviving setup re-arms and lands the scroll.
- Preserve the deep-link hash across the task-page canonical redirect (`$taskId.tsx`).

No caller changes were needed (`mention-card`, `repo-setup-approval-modal`, the run-detail link). The existing `#setup-repo` and `jumpToComment` paths are preserved.

## Testing

- **New component test** (`inbox-mentions.test.tsx`) runs under StrictMode, clicks a real inbox mention card, and asserts the source comment is highlighted (`data-comment-highlighted="true"`). It fails against the old `window.location.hash`-only code (memory-history `navigate` never sets `window.location.hash`), so it genuinely guards the fix. Added an opt-in `strictMode` flag to the render harness.
- Full web suite green: **245 tests passing**. Existing Playwright deep-link specs (`task-comments.spec.ts` raw-load, `run-trigger-reason.spec.ts` in-app `<Link hash>` → scroll + `data-comment-highlighted` + `scrollTop > 100`) exercise the same executor through the other entry points and remain compatible.

> Note: an inbox-specific Playwright test would need a real `admin_mention`, which requires an agent-authored `@admin` comment (heavy/flaky to seed from the browser context). The component test covers the inbox click→highlight path, and the existing run-detail Playwright spec covers real-layout scroll-via-`navigate({hash})` through the shared `CommentsSection` executor.

https://claude.ai/code/session_016Lgqrv7CekeQKm7adjLwDE

---
_Generated by [Claude Code](https://claude.ai/code/session_016Lgqrv7CekeQKm7adjLwDE)_