### PR TITLE
fix: wake parent task agent when sub-tasks all reach Closed

### DIFF
--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -45,7 +45,7 @@ import { detectOrphans } from './orphan-detector';
 import { ensureRepoSetupAction } from './repo-setup';
 import { getProjectConcurrency, isTaskBusyInDb } from './run-concurrency';
 import type { SshAgentServer } from './ssh-agent';
-import { recordStatusChange } from './task-events';
+import { triggerStatusAutomations } from './task-automation';
 import { absorbQueuedTaskWakeups, assignmentWakeupAlreadyServed, createWakeup } from './wakeup';
 import type { WebSocketManager } from './ws';
 
@@ -1465,7 +1465,7 @@ export class JobManager {
 						'UPDATE',
 						closed.rows[0],
 					);
-					await recordStatusChange(
+					await triggerStatusAutomations(
 						db,
 						teamId,
 						taskId,

--- a/packages/server/src/services/task-automation.ts
+++ b/packages/server/src/services/task-automation.ts
@@ -5,12 +5,14 @@ import {
 	COACH_AGENT_SLUG,
 	CommentContentType,
 	TaskStatus,
+	TERMINAL_TASK_STATUSES,
 	WakeupSource,
 	wsRoom,
 } from '@hezo/shared';
 import { trackBackground } from '../lib/background';
 import { broadcastRowChange } from '../lib/broadcast';
 import { recomputeDownstreamReadiness } from '../lib/dependencies';
+import { assertChildrenAllClosed } from '../lib/task-relationships';
 import { logger } from '../logger';
 import { OAUTH_VERIFICATION_LABEL } from './oauth-verification-tasks';
 import { recordStatusChange } from './task-events';
@@ -103,6 +105,51 @@ async function notifyParentOfOAuthVerification(
 }
 
 /**
+ * Wake the parent task's assigned agent when the transitioning sub-task
+ * pushes the parent past its child-closure gate. Mirrors the blocked-by
+ * cascade in `recomputeDownstreamReadiness` but walks the parent edge.
+ * The idempotency key collapses sibling closes that land near-simultaneously
+ * into a single queued wakeup; the dispatch-time `assignmentWakeupAlreadyServed`
+ * guard suppresses runs that already covered this state.
+ */
+async function wakeParentIfChildrenClosed(
+	db: PGlite,
+	teamId: string,
+	taskId: string,
+): Promise<void> {
+	const parentRow = await db.query<{ parent_task_id: string | null }>(
+		'SELECT parent_task_id FROM tasks WHERE id = $1 AND team_id = $2',
+		[taskId, teamId],
+	);
+	const parentTaskId = parentRow.rows[0]?.parent_task_id;
+	if (!parentTaskId) return;
+
+	const childrenCheck = await assertChildrenAllClosed(db, teamId, parentTaskId);
+	if (!childrenCheck.ok) return;
+
+	const parent = await db.query<{ assignee_id: string | null; team_id: string }>(
+		'SELECT assignee_id, team_id FROM tasks WHERE id = $1',
+		[parentTaskId],
+	);
+	const parentInfo = parent.rows[0];
+	if (!parentInfo?.assignee_id) return;
+
+	const isAgent = await db.query('SELECT id FROM member_agents WHERE id = $1', [
+		parentInfo.assignee_id,
+	]);
+	if (isAgent.rows.length === 0) return;
+
+	await createWakeup(
+		db,
+		parentInfo.assignee_id,
+		parentInfo.team_id,
+		WakeupSource.Assignment,
+		{ task_id: parentTaskId, reason: 'children_closed' },
+		`children-closed:${parentTaskId}`,
+	);
+}
+
+/**
  * Trigger automations when an task's status changes.
  * Called from both the REST handler and MCP tool to ensure consistent behavior.
  */
@@ -121,6 +168,14 @@ export async function triggerStatusAutomations(
 		await recomputeDownstreamReadiness(db, teamId, taskId, actorMemberId, wsManager);
 	} catch (e) {
 		log.error('Failed to recompute downstream readiness:', e);
+	}
+
+	if ((TERMINAL_TASK_STATUSES as readonly string[]).includes(newStatus)) {
+		try {
+			await wakeParentIfChildrenClosed(db, teamId, taskId);
+		} catch (e) {
+			log.error('Failed to wake parent on child closure:', e);
+		}
 	}
 
 	if (newStatus === TaskStatus.Done) {

--- a/packages/server/test/parent-cascade.test.ts
+++ b/packages/server/test/parent-cascade.test.ts
@@ -1,0 +1,312 @@
+import type { PGlite } from '@electric-sql/pglite';
+import { TaskStatus, WakeupStatus } from '@hezo/shared';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Env } from '../src/lib/types';
+import { triggerStatusAutomations } from '../src/services/task-automation';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp, createTestProject, projectSlugFor } from './helpers/app';
+
+let db: PGlite;
+let app: Hono<Env>;
+let token: string;
+let teamId: string;
+let projectId: string;
+let projectSlug: string;
+let architectId: string;
+let uiDesignerId: string;
+let engineerId: string;
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	db = ctx.db;
+	app = ctx.app;
+	token = ctx.token;
+
+	const typesRes = await app.request('/api/team-templates', { headers: authHeader(token) });
+	const teamTemplateId = (await typesRes.json()).data.find(
+		(t: { name: string }) => t.name === 'Startup',
+	).id;
+
+	const teamRes = await app.request('/api/teams', {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ name: 'Parent Cascade Co', template_id: teamTemplateId }),
+	});
+	const teamData = (await teamRes.json()).data;
+	teamId = teamData.id;
+	const internalProjectSlug = await projectSlugFor(db, teamData.id);
+
+	const projectRes = await createTestProject(db, teamId, {
+		name: 'Cascade Project',
+		description: 'Test project.',
+	});
+	const projectData = (await projectRes.json()).data;
+	projectId = projectData.id;
+	projectSlug = projectData.slug;
+
+	const agentsRes = await app.request(`/api/projects/${internalProjectSlug}/agents`, {
+		headers: authHeader(token),
+	});
+	const agents = (await agentsRes.json()).data as Array<{ id: string; slug: string }>;
+	architectId = agents.find((a) => a.slug === 'architect')!.id;
+	uiDesignerId = agents.find((a) => a.slug === 'ui-designer')!.id;
+	engineerId = agents.find((a) => a.slug === 'engineer')!.id;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+async function createTask(
+	title: string,
+	assigneeId: string,
+	parentTaskId?: string,
+): Promise<{ id: string; identifier: string }> {
+	const res = await app.request(`/api/projects/${projectSlug}/tasks`, {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			project_id: projectId,
+			title,
+			assignee_id: assigneeId,
+			...(parentTaskId ? { parent_task_id: parentTaskId } : {}),
+		}),
+	});
+	expect(res.status).toBe(201);
+	return (await res.json()).data;
+}
+
+async function clearWakeups(memberId: string): Promise<void> {
+	await db.query('DELETE FROM agent_wakeup_requests WHERE member_id = $1', [memberId]);
+}
+
+async function setStatusDirect(taskId: string, status: string): Promise<void> {
+	await db.query('UPDATE tasks SET status = $1::task_status WHERE id = $2', [status, taskId]);
+}
+
+async function listWakeups(
+	memberId: string,
+	taskId: string,
+): Promise<
+	Array<{
+		status: string;
+		source: string;
+		payload: Record<string, unknown>;
+		idempotency_key: string | null;
+	}>
+> {
+	const r = await db.query<{
+		status: string;
+		source: string;
+		payload: Record<string, unknown>;
+		idempotency_key: string | null;
+	}>(
+		`SELECT status::text AS status, source::text AS source, payload, idempotency_key
+		 FROM agent_wakeup_requests
+		 WHERE member_id = $1 AND payload->>'task_id' = $2
+		 ORDER BY created_at ASC`,
+		[memberId, taskId],
+	);
+	return r.rows;
+}
+
+describe('parent cascade — sub-task closure wakes parent agent', () => {
+	it('wakes parent assignee when the only sub-task transitions to Closed', async () => {
+		const parent = await createTask('parent solo', architectId);
+		const child = await createTask('child solo', uiDesignerId, parent.id);
+		await clearWakeups(architectId);
+
+		await setStatusDirect(child.id, TaskStatus.Closed);
+		await triggerStatusAutomations(
+			db,
+			teamId,
+			child.id,
+			TaskStatus.Done,
+			TaskStatus.Closed,
+			null,
+			undefined,
+		);
+
+		const wakeups = await listWakeups(architectId, parent.id);
+		const childrenClosed = wakeups.find((w) => w.payload.reason === 'children_closed');
+		expect(childrenClosed).toBeDefined();
+		expect(childrenClosed?.source).toBe('assignment');
+		expect(childrenClosed?.status).toBe(WakeupStatus.Queued);
+		expect(childrenClosed?.idempotency_key).toBe(`children-closed:${parent.id}`);
+	});
+
+	it('does not wake parent while a sibling sub-task is still open', async () => {
+		const parent = await createTask('parent siblings', architectId);
+		const childA = await createTask('child A', uiDesignerId, parent.id);
+		await createTask('child B still open', engineerId, parent.id);
+		await clearWakeups(architectId);
+
+		await setStatusDirect(childA.id, TaskStatus.Closed);
+		await triggerStatusAutomations(
+			db,
+			teamId,
+			childA.id,
+			TaskStatus.Done,
+			TaskStatus.Closed,
+			null,
+			undefined,
+		);
+
+		const wakeups = await listWakeups(architectId, parent.id);
+		const childrenClosed = wakeups.find((w) => w.payload.reason === 'children_closed');
+		expect(childrenClosed).toBeUndefined();
+	});
+
+	it('fires once the final sibling sub-task reaches Closed', async () => {
+		const parent = await createTask('parent two siblings', architectId);
+		const childA = await createTask('first child', uiDesignerId, parent.id);
+		const childB = await createTask('second child', engineerId, parent.id);
+		await clearWakeups(architectId);
+
+		await setStatusDirect(childA.id, TaskStatus.Closed);
+		await triggerStatusAutomations(
+			db,
+			teamId,
+			childA.id,
+			TaskStatus.Done,
+			TaskStatus.Closed,
+			null,
+			undefined,
+		);
+		expect(
+			(await listWakeups(architectId, parent.id)).find(
+				(w) => w.payload.reason === 'children_closed',
+			),
+		).toBeUndefined();
+
+		await setStatusDirect(childB.id, TaskStatus.Closed);
+		await triggerStatusAutomations(
+			db,
+			teamId,
+			childB.id,
+			TaskStatus.Done,
+			TaskStatus.Closed,
+			null,
+			undefined,
+		);
+		const after = (await listWakeups(architectId, parent.id)).find(
+			(w) => w.payload.reason === 'children_closed',
+		);
+		expect(after).toBeDefined();
+	});
+
+	it('cancelled sub-task does not wake parent — parent stays gated on Closed', async () => {
+		const parent = await createTask('parent cancel', architectId);
+		const child = await createTask('to be cancelled', uiDesignerId, parent.id);
+		await clearWakeups(architectId);
+
+		await setStatusDirect(child.id, TaskStatus.Cancelled);
+		await triggerStatusAutomations(
+			db,
+			teamId,
+			child.id,
+			TaskStatus.Backlog,
+			TaskStatus.Cancelled,
+			null,
+			undefined,
+		);
+
+		const wakeups = await listWakeups(architectId, parent.id);
+		expect(wakeups.find((w) => w.payload.reason === 'children_closed')).toBeUndefined();
+	});
+
+	it('does not fire on Done — Done leaves parent still gated', async () => {
+		const parent = await createTask('parent done child', architectId);
+		const child = await createTask('child going done', uiDesignerId, parent.id);
+		await clearWakeups(architectId);
+
+		await setStatusDirect(child.id, TaskStatus.Done);
+		await triggerStatusAutomations(
+			db,
+			teamId,
+			child.id,
+			TaskStatus.InProgress,
+			TaskStatus.Done,
+			null,
+			undefined,
+		);
+
+		const wakeups = await listWakeups(architectId, parent.id);
+		expect(wakeups.find((w) => w.payload.reason === 'children_closed')).toBeUndefined();
+	});
+
+	it('idempotency key collapses concurrent sibling-close cascades into one queued wakeup', async () => {
+		const parent = await createTask('parent idempotent', architectId);
+		const childA = await createTask('idem child A', uiDesignerId, parent.id);
+		const childB = await createTask('idem child B', engineerId, parent.id);
+		await clearWakeups(architectId);
+
+		await setStatusDirect(childA.id, TaskStatus.Closed);
+		await setStatusDirect(childB.id, TaskStatus.Closed);
+
+		await triggerStatusAutomations(
+			db,
+			teamId,
+			childA.id,
+			TaskStatus.Done,
+			TaskStatus.Closed,
+			null,
+			undefined,
+		);
+		await triggerStatusAutomations(
+			db,
+			teamId,
+			childB.id,
+			TaskStatus.Done,
+			TaskStatus.Closed,
+			null,
+			undefined,
+		);
+
+		const matching = (await listWakeups(architectId, parent.id)).filter(
+			(w) => w.payload.reason === 'children_closed',
+		);
+		expect(matching.length).toBe(1);
+	});
+
+	it('skips when parent has no assignee', async () => {
+		const parent = await createTask('parent no assignee', architectId);
+		await db.query('UPDATE tasks SET assignee_id = NULL WHERE id = $1', [parent.id]);
+		const child = await createTask('orphan child', uiDesignerId, parent.id);
+		await clearWakeups(architectId);
+
+		await setStatusDirect(child.id, TaskStatus.Closed);
+		await triggerStatusAutomations(
+			db,
+			teamId,
+			child.id,
+			TaskStatus.Done,
+			TaskStatus.Closed,
+			null,
+			undefined,
+		);
+
+		const wakeups = await listWakeups(architectId, parent.id);
+		expect(wakeups.find((w) => w.payload.reason === 'children_closed')).toBeUndefined();
+	});
+
+	it('skips when child has no parent (top-level task close)', async () => {
+		const top = await createTask('top-level standalone', architectId);
+		await clearWakeups(architectId);
+
+		await setStatusDirect(top.id, TaskStatus.Closed);
+		await triggerStatusAutomations(
+			db,
+			teamId,
+			top.id,
+			TaskStatus.Done,
+			TaskStatus.Closed,
+			null,
+			undefined,
+		);
+
+		const wakeups = await listWakeups(architectId, top.id);
+		expect(wakeups.find((w) => w.payload.reason === 'children_closed')).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary

The parent task's assigned agent had no auto-trigger to re-run when its last sub-task reached a terminal status. Hezo's existing cascade walked `task_dependencies` (blocked-by edges) via `recomputeDownstreamReadiness`, but had no analogue for `parent_task_id`. So an Architect that delegated work via a sub-task would post its wrap-up, end its turn, and never wake again to mark the parent Done once Coach closed the children.

Compounding it, the Coach auto-close path in `job-manager.ts` (`Done` → `Closed` after a successful `task_done` review) called `recordStatusChange` directly instead of `triggerStatusAutomations`, so even the existing blocked-by cascade was skipped on Coach-driven closes.

Real-world repro: TO-6 (UI/UX design) with Architect assigned, sub-task TO-11 Closed, blocker TO-4 Closed — Architect sat idle because the only path that could have re-woken it (TO-4's `Done` transition) had already fired, and TO-11's `Closed` transition produced no cascade at all.

## Changes

- **`packages/server/src/services/task-automation.ts`** — `triggerStatusAutomations` now runs a parent-cascade after the existing downstream-readiness step. When `newStatus` is in `TERMINAL_TASK_STATUSES`, it looks up the transitioning task's parent, reuses `assertChildrenAllClosed` (`lib/task-relationships.ts`) as the gate, and fires an `Assignment`-source wakeup on the parent's agent assignee with payload `{ task_id, reason: 'children_closed' }` and idempotency key `children-closed:{parentId}`. The existing `assignmentWakeupAlreadyServed` guard suppresses redundant runs at dispatch time.
- **`packages/server/src/services/job-manager.ts`** — Coach auto-close at the `Done → Closed` step now routes through `triggerStatusAutomations` instead of calling `recordStatusChange` directly. Same automation chain as PATCH-driven status changes.
- **`packages/server/test/parent-cascade.test.ts`** — 8 vitest cases covering: single sub-task close fires, partial closure doesn't fire, last sibling fires, `Cancelled` stays gated (matches existing `assertChildrenAllClosed` semantics — `OPEN_CHILD_STATUSES` includes `Cancelled`), `Done` alone doesn't fire (parent still gated on `Closed`), idempotency collapses concurrent sibling closes, missing-assignee skip, top-level (no parent) skip.

## Pre-existing quirk worth a follow-up

`assertChildrenAllClosed` treats `Cancelled` children as "still open" — so a parent with a cancelled child can never satisfy the gate (Coach won't review a Cancelled child, so it stays Cancelled forever). Orthogonal to this fix but flagging for a separate ticket.

## Test plan

- [x] `bunx vitest run test/parent-cascade.test.ts` — 8/8 pass
- [x] `bunx vitest run test/task-dependencies-gate.test.ts test/coach.test.ts test/oauth-verification-automation.test.ts test/agent-triggering.test.ts test/job-manager-workflows.test.ts test/tasks.test.ts` — 146/146 pass (includes existing Coach auto-close suite, which validates the routing change)
- [x] `bun run typecheck` — clean
- [x] `bunx biome check` on changed files — clean
- [ ] CI green