### PR TITLE
fix(web): hide token and cost cards while agent run is active

### DIFF
--- a/packages/web/src/routes/projects/$projectId/agents/$agentId/executions/$runId.tsx
+++ b/packages/web/src/routes/projects/$projectId/agents/$agentId/executions/$runId.tsx
@@ -139,14 +139,16 @@ function ExecutionDetailPage() {
 					</div>
 				</div>
 
-				<div className="rounded-lg border border-border-subtle bg-bg p-3">
-					<div className="text-[11px] text-text-subtle uppercase tracking-wider mb-1">Tokens</div>
-					<div className="text-sm">
-						{run.input_tokens.toLocaleString()} in / {run.output_tokens.toLocaleString()} out
+				{!isActive && (
+					<div className="rounded-lg border border-border-subtle bg-bg p-3">
+						<div className="text-[11px] text-text-subtle uppercase tracking-wider mb-1">Tokens</div>
+						<div className="text-sm">
+							{run.input_tokens.toLocaleString()} in / {run.output_tokens.toLocaleString()} out
+						</div>
 					</div>
-				</div>
+				)}
 
-				{run.cost_cents != null && run.cost_cents > 0 && (
+				{!isActive && run.cost_cents != null && run.cost_cents > 0 && (
 					<div className="rounded-lg border border-border-subtle bg-bg p-3">
 						<div className="text-[11px] text-text-subtle uppercase tracking-wider mb-1">Cost</div>
 						<div className="text-sm font-medium">${(run.cost_cents / 100).toFixed(2)}</div>


### PR DESCRIPTION
## Summary
- `input_tokens`, `output_tokens`, and `cost_cents` on a heartbeat run are only written in `updateHeartbeatRun` when the run reaches a terminal state, so during `running` / `queued` they always read 0.
- The execution detail page was rendering a "Tokens — 0 in / 0 out" card mid-run, which looked like a bug. Suppress both the Tokens card and the Cost card while `isActive` is true.
- Once the run finishes, both cards behave as before (cost still gated on `> 0`).

## Test plan
- [x] `bunx vitest run test/run-termination.test.tsx test/run-created-tasks.test.tsx test/agent-executions-project.test.tsx` (7/7 pass)
- [ ] Manual: open an in-flight run → metrics grid shows only Duration + When; once the run completes the Tokens card reappears.