### PR TITLE
style(web): consolidate run detail metrics into Timing + Usage cards

### DIFF
--- a/packages/web/src/routes/projects/$projectId/agents/$agentId/executions/$runId.tsx
+++ b/packages/web/src/routes/projects/$projectId/agents/$agentId/executions/$runId.tsx
@@ -1,15 +1,37 @@
 import { INSTANCE_AGENT_SLUGS } from '@hezo/shared';
 import { createFileRoute, Link } from '@tanstack/react-router';
+import { format } from 'date-fns';
 import { ArrowLeft, ChevronDown, ChevronRight } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { LogViewer } from '../../../../../../components/log-viewer';
 import { TerminateRunButton } from '../../../../../../components/terminate-run-button';
 import { Badge } from '../../../../../../components/ui/badge';
+import { Tooltip } from '../../../../../../components/ui/tooltip';
 import { useAgent } from '../../../../../../hooks/use-agents';
 import { useElapsedDuration } from '../../../../../../hooks/use-elapsed-duration';
 import { getRunWaitingMessage, useHeartbeatRun } from '../../../../../../hooks/use-heartbeat-runs';
 import { useRunLogs } from '../../../../../../hooks/use-run-logs';
 import { formatTriggerReason } from '../../../../../../lib/run-trigger';
+
+function formatTimeRange(
+	startedAt: string | null,
+	finishedAt: string | null,
+): { compact: string; full: string } | null {
+	if (!startedAt) return null;
+	const start = new Date(startedAt);
+	const end = finishedAt ? new Date(finishedAt) : null;
+	const sameDay = end && start.toDateString() === end.toDateString();
+	const compactStart = format(start, 'MMM d, HH:mm:ss');
+	const compact = !end
+		? `Started ${compactStart}`
+		: sameDay
+			? `${compactStart} → ${format(end, 'HH:mm:ss')}`
+			: `${compactStart} → ${format(end, 'MMM d, HH:mm:ss')}`;
+	const full = !end
+		? `Started ${start.toLocaleString()}`
+		: `${start.toLocaleString()} → ${end.toLocaleString()}`;
+	return { compact, full };
+}
 
 function statusColor(status: string): string {
 	switch (status) {
@@ -114,47 +136,51 @@ function ExecutionDetailPage() {
 				);
 			})()}
 
-			<div className="grid grid-cols-2 sm:grid-cols-3 gap-3 mb-6">
-				<div className="rounded-lg border border-border-subtle bg-bg p-3">
-					<div className="text-[11px] text-text-subtle uppercase tracking-wider mb-1">Duration</div>
-					<div className="text-sm font-medium">{elapsedDisplay}</div>
-				</div>
-
-				<div className="rounded-lg border border-border-subtle bg-bg p-3">
-					<div className="text-[11px] text-text-subtle uppercase tracking-wider mb-1">When</div>
-					<div className="text-sm">
-						{run.started_at ? (
-							<>
-								{new Date(run.started_at).toLocaleString()}
-								{run.finished_at && (
-									<>
-										<span className="text-text-subtle"> → </span>
-										{new Date(run.finished_at).toLocaleString()}
-									</>
+			{(() => {
+				const range = formatTimeRange(run.started_at, run.finished_at);
+				return (
+					<div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-6">
+						<div className="rounded-lg border border-border-subtle bg-bg p-3">
+							<div className="text-[11px] text-text-subtle uppercase tracking-wider mb-1">
+								Timing
+							</div>
+							<div className="flex items-baseline gap-2 flex-wrap">
+								<span data-testid="run-duration" className="text-sm font-medium tabular-nums">
+									{elapsedDisplay}
+								</span>
+								{range ? (
+									<Tooltip content={range.full}>
+										<span className="text-xs text-text-subtle whitespace-nowrap tabular-nums">
+											{range.compact}
+										</span>
+									</Tooltip>
+								) : (
+									<span className="text-xs text-text-subtle">Waiting to start…</span>
 								)}
-							</>
-						) : (
-							<span className="text-text-subtle">Waiting to start…</span>
+							</div>
+						</div>
+
+						{!isActive && (
+							<div className="rounded-lg border border-border-subtle bg-bg p-3">
+								<div className="text-[11px] text-text-subtle uppercase tracking-wider mb-1">
+									Usage
+								</div>
+								<div className="flex items-baseline gap-2 flex-wrap">
+									{run.cost_cents != null && run.cost_cents > 0 && (
+										<span className="text-sm font-medium tabular-nums">
+											${(run.cost_cents / 100).toFixed(2)}
+										</span>
+									)}
+									<span className="text-xs text-text-subtle whitespace-nowrap tabular-nums">
+										{run.input_tokens.toLocaleString()} in · {run.output_tokens.toLocaleString()}{' '}
+										out tokens
+									</span>
+								</div>
+							</div>
 						)}
 					</div>
-				</div>
-
-				{!isActive && (
-					<div className="rounded-lg border border-border-subtle bg-bg p-3">
-						<div className="text-[11px] text-text-subtle uppercase tracking-wider mb-1">Tokens</div>
-						<div className="text-sm">
-							{run.input_tokens.toLocaleString()} in / {run.output_tokens.toLocaleString()} out
-						</div>
-					</div>
-				)}
-
-				{!isActive && run.cost_cents != null && run.cost_cents > 0 && (
-					<div className="rounded-lg border border-border-subtle bg-bg p-3">
-						<div className="text-[11px] text-text-subtle uppercase tracking-wider mb-1">Cost</div>
-						<div className="text-sm font-medium">${(run.cost_cents / 100).toFixed(2)}</div>
-					</div>
-				)}
-			</div>
+				);
+			})()}
 
 			{run.task_identifier &&
 				(run.task_id ? (

--- a/packages/web/test/task-history-timeline.test.tsx
+++ b/packages/web/test/task-history-timeline.test.tsx
@@ -44,7 +44,7 @@ test('status changes and cross-task mentions appear as system entries on the tim
 	let sourceTaskId = '';
 	let workspace: SeededWorkspace;
 
-	const { findByText, findAllByTestId, container, router } = await renderApp({
+	const { findByText, findAllByTestId, router } = await renderApp({
 		initialPath: '/',
 		seed: async () => {
 			workspace = await seedWorkspace();

--- a/test/browser/agent-run-logs.spec.ts
+++ b/test/browser/agent-run-logs.spec.ts
@@ -101,9 +101,7 @@ test('run detail page streams synthetic agent logs', async ({ page, context }) =
 	await expect(logPane).toContainText('[synthetic] starting agent run', { timeout: 20_000 });
 	await expect(logPane).toContainText('[synthetic] task complete', { timeout: 15000 });
 
-	const durationValue = page
-		.getByText('Duration', { exact: true })
-		.locator('xpath=following-sibling::*[1]');
+	const durationValue = page.getByTestId('run-duration');
 	await expect(durationValue).toHaveText(/^\d+(d\d+h\d+m|h\d+m|m)?\d*s$/);
 
 	const copyBtn = page.getByRole('button', { name: /copy logs to clipboard/i });


### PR DESCRIPTION
## Summary

The run-detail page (`/projects/$projectId/agents/$agentId/executions/$runId`) was rendering four separate cards — Duration, When, Tokens, Cost — in a `grid-cols-2 sm:grid-cols-3` layout. The **When** card held a long timestamp range like `08/06/2026, 17:51:14 → 08/06/2026, 17:52:06` which wrapped to two lines and made the layout feel cramped. The four metrics also split related concepts (duration / timestamps, cost / tokens) across separate tiles.

This PR consolidates them into **two grouped cards**:

| Card | Primary | Secondary |
| --- | --- | --- |
| **Timing** | elapsed duration (`51s`) | compact range `Aug 6, 17:51:14 → 17:52:06`, with full localized timestamps in a hover tooltip |
| **Usage** | cost (`\$0.59`, hidden when null/0) | `318,326 in · 1,625 out tokens` |

### Details

- Grid switched to `grid-cols-1 sm:grid-cols-2 gap-3 mb-6` — stacks on mobile, side-by-side from tablet up.
- New file-local `formatTimeRange()` helper uses `date-fns` `format()` (already a dep via `use-elapsed-duration.ts`). Same-day ranges drop the duplicated date; running runs render `Started Aug 6, 17:51:14`; cross-midnight ranges show both dates.
- Full `toLocaleString()` strings are preserved in the `Tooltip` (same `components/ui/tooltip.tsx` used by the executions list view) so precision isn't lost — just moved to hover.
- `tabular-nums` keeps the numeric columns from shifting; `whitespace-nowrap` on the secondary line keeps the breakdown on one row at desktop while `flex-wrap` lets it fall gracefully on narrow viewports.
- Token separator changed from `/` to `·` and the unit (`tokens`) is appended once for clarity.
- The Usage card now always renders (the old layout dropped the entire Cost card when cost was null/0); tokens are always tracked, so the card always has content.

## Test plan

- [ ] `bun run dev` → open a finished run; expect two cards side-by-side at desktop width, each on one line
- [ ] Resize to mobile (375px); expect cards stack to one column, no horizontal scroll
- [ ] Hover the compact time range; expect a tooltip with full `MM/DD/YYYY, HH:MM:SS AM/PM` for both endpoints
- [ ] Open a **running** run; expect live-updating duration plus `Started …` (no `→`)
- [ ] Open a run that spans midnight; expect both dates in the compact range
- [ ] Open a run with `cost_cents = 0` or `null`; expect the Usage card to render with the token breakdown only (no `$` line)
- [ ] `bun run test --pattern executions` stays green (existing tests touch the seed fields only, no assertions on the visual layout)