### PR TITLE
fix: suppress redundant downstream wakeup on terminal→terminal status flips

### DIFF
--- a/packages/server/src/lib/dependencies.ts
+++ b/packages/server/src/lib/dependencies.ts
@@ -1,5 +1,6 @@
 import type { PGlite } from '@electric-sql/pglite';
 import {
+	HeartbeatRunStatus,
 	TaskStatus,
 	TERMINAL_TASK_STATUSES,
 	WakeupSource,
@@ -252,6 +253,18 @@ export async function wakeIfReady(db: PGlite, taskId: string): Promise<void> {
 	);
 
 	if (flipped.rows.length > 0) return;
+
+	// If the assignee is already mid-run on this task, the running agent reads
+	// the latest task state and serves the unblock — a fresh wakeup would just
+	// queue a redundant follow-up behind the in-flight run.
+	const activeRun = await db.query(
+		`SELECT 1 FROM heartbeat_runs
+		 WHERE member_id = $1 AND task_id = $2
+		   AND status IN ($3::heartbeat_run_status, $4::heartbeat_run_status)
+		 LIMIT 1`,
+		[row.assignee_id, taskId, HeartbeatRunStatus.Queued, HeartbeatRunStatus.Running],
+	);
+	if (activeRun.rows.length > 0) return;
 
 	try {
 		await createWakeup(

--- a/packages/server/src/services/task-automation.ts
+++ b/packages/server/src/services/task-automation.ts
@@ -164,10 +164,20 @@ export async function triggerStatusAutomations(
 ): Promise<void> {
 	await recordStatusChange(db, teamId, taskId, oldStatus, newStatus, actorMemberId, wsManager);
 
-	try {
-		await recomputeDownstreamReadiness(db, teamId, taskId, actorMemberId, wsManager);
-	} catch (e) {
-		log.error('Failed to recompute downstream readiness:', e);
+	// Downstream blocker state only flips when this task crosses the
+	// terminal boundary. Same-bucket transitions (e.g. done → closed
+	// during Coach's review, or backlog → in_progress at run start)
+	// leave every downstream's blocker count unchanged, so skip the
+	// recompute — otherwise it fires a redundant `wakeIfReady` that
+	// queues a duplicate assignment wakeup behind the current run.
+	const oldTerminal = (TERMINAL_TASK_STATUSES as readonly string[]).includes(oldStatus);
+	const newTerminal = (TERMINAL_TASK_STATUSES as readonly string[]).includes(newStatus);
+	if (oldTerminal !== newTerminal) {
+		try {
+			await recomputeDownstreamReadiness(db, teamId, taskId, actorMemberId, wsManager);
+		} catch (e) {
+			log.error('Failed to recompute downstream readiness:', e);
+		}
 	}
 
 	if ((TERMINAL_TASK_STATUSES as readonly string[]).includes(newStatus)) {

--- a/packages/server/test/task-dependencies-gate.test.ts
+++ b/packages/server/test/task-dependencies-gate.test.ts
@@ -1,5 +1,5 @@
 import type { PGlite } from '@electric-sql/pglite';
-import { TaskStatus, WakeupSource, WakeupStatus } from '@hezo/shared';
+import { HeartbeatRunStatus, TaskStatus, WakeupSource, WakeupStatus } from '@hezo/shared';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import {
@@ -360,6 +360,68 @@ describe('dependency gate — wakeup deferral and reverse trigger', () => {
 		await new Promise((res) => setTimeout(res, 100));
 
 		await wakeIfReady(db, p.id);
+		const after = await getWakeupForTask(productLeadId, p.id);
+		expect(after).toBeNull();
+	});
+
+	it("blocker's done → closed transition does not requeue the downstream's assignee while it is mid-run", async () => {
+		const r = await createTask('term-r', researcherId);
+		const p = await createTask('term-p', productLeadId, [r.identifier]);
+
+		await setStatus(r.id, TaskStatus.Done);
+		await new Promise((res) => setTimeout(res, 100));
+
+		await db.query('DELETE FROM agent_wakeup_requests WHERE member_id = $1', [productLeadId]);
+
+		// Stand in for an in-flight run on p — wakeIfReady should treat the running agent as already serving the unblock.
+		await db.query(
+			`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at)
+			 VALUES ($1, $2, $3, $4::heartbeat_run_status, now())`,
+			[productLeadId, teamId, p.id, HeartbeatRunStatus.Running],
+		);
+
+		await setStatus(r.id, TaskStatus.Closed);
+		await new Promise((res) => setTimeout(res, 100));
+
+		const after = await getWakeupForTask(productLeadId, p.id);
+		expect(after).toBeNull();
+	});
+
+	it("blocker's done → closed creates no downstream wakeup even when downstream has no in-flight run", async () => {
+		const r = await createTask('term2-r', researcherId);
+		const p = await createTask('term2-p', productLeadId, [r.identifier]);
+
+		await setStatus(r.id, TaskStatus.Done);
+		await new Promise((res) => setTimeout(res, 100));
+
+		await db.query('DELETE FROM agent_wakeup_requests WHERE member_id = $1', [productLeadId]);
+
+		await setStatus(r.id, TaskStatus.Closed);
+		await new Promise((res) => setTimeout(res, 100));
+
+		const after = await getWakeupForTask(productLeadId, p.id);
+		expect(after).toBeNull();
+	});
+
+	it('wakeIfReady skips creating a wakeup when the assignee already has an in-flight run on the task', async () => {
+		const r = await createTask('inflight-r', researcherId);
+		const p = await createTask('inflight-p', productLeadId, [r.identifier]);
+
+		await new Promise((res) => setTimeout(res, 50));
+		await db.query('UPDATE tasks SET status = $1::task_status WHERE id = $2', [
+			TaskStatus.Done,
+			r.id,
+		]);
+		await db.query('DELETE FROM agent_wakeup_requests WHERE member_id = $1', [productLeadId]);
+
+		await db.query(
+			`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at)
+			 VALUES ($1, $2, $3, $4::heartbeat_run_status, now())`,
+			[productLeadId, teamId, p.id, HeartbeatRunStatus.Running],
+		);
+
+		await wakeIfReady(db, p.id);
+
 		const after = await getWakeupForTask(productLeadId, p.id);
 		expect(after).toBeNull();
 	});


### PR DESCRIPTION
## Summary

PR #155 routed Coach's `done → closed` close through `triggerStatusAutomations`, which calls `recomputeDownstreamReadiness` and ends up invoking `wakeIfReady` on every downstream. For tasks whose only blocker had already been satisfied at `done` (so the downstream is already mid-run), this queues a second `reason: 'unblocked'` assignment wakeup behind the in-flight run. `assignmentWakeupAlreadyServed` (PR #151) can't retire it — `started_at < wakeup.created_at` — so once the run completes, a redundant follow-up run fires.

Repro observed on the local dev server (task `TO-7`): Architect closed TO-6 in_progress → done at 19:09:00 (unblocked TO-7, Engineer started at 19:09:05), Coach then closed TO-6 done → closed at 19:10:36 — that second close created a `reason: 'unblocked'` wakeup for Engineer on TO-7 that's been parked on `task_busy` ever since.

## Fix

Two changes:

1. **Root cause** — `triggerStatusAutomations` only calls `recomputeDownstreamReadiness` when `oldTerminal !== newTerminal`. Downstream blocker count can only change when the upstream crosses the terminal boundary; same-bucket transitions (`done → closed`, `backlog → in_progress`) can't shift any downstream's blocker state.
2. **Defense in depth** — `wakeIfReady` short-circuits when the assignee already has a `queued`/`running` `heartbeat_runs` row on the task. The in-flight run reads the latest task state and serves the unblock without needing a follow-up wakeup. This catches any other path that ends up at `wakeIfReady` during a run (e.g. dependency removal via REST/MCP while the agent is working).

`wakeParentIfChildrenClosed` is unchanged — `done → closed` legitimately matters for that gate (children-all-closed only counts `closed`, not `done`).

## Test plan

- [x] `bunx vitest run test/task-dependencies-gate.test.ts` — 28/28 pass, including 3 new regression tests
- [x] `bunx vitest run test/parent-cascade.test.ts` — 8/8 pass (the `done → closed` parent-wake path is still intact)
- [x] `bunx vitest run test/tasks.test.ts test/run-trigger-reason.test.ts test/oauth-verification-automation.test.ts` — 51/51 pass
- [x] `bun run typecheck` — clean