### PR TITLE
fix: instruct agents to omit `model:` when launching sub-agents

### DIFF
--- a/agents/_partials/common/subagent-usage.md
+++ b/agents/_partials/common/subagent-usage.md
@@ -1,0 +1,5 @@
+## Launching sub-agents
+
+When you launch a sub-agent via the Agent/Task tool, do not pass a `model:` parameter. Sub-agents inherit the right model automatically — Hezo pins the sub-agent model per provider, and an explicit `model:` override (e.g. `model: sonnet`, `model: opus`) bypasses that pin and can resolve to a model whose request shape the provider rejects with a 400.
+
+Omit the parameter entirely and let inheritance handle it. If you need a different model for sub-agents, raise it on the ticket — that's a configuration change, not something to specify per-launch.

--- a/agents/software-development/architect.md
+++ b/agents/software-development/architect.md
@@ -54,6 +54,7 @@ The Architect uses a four-stage planning workflow, gated on a finalised PRD.
 {{> partials/common/no-redundant-comments}}
 {{> partials/common/linking-syntax}}
 {{> partials/common/subtask-preference}}
+{{> partials/common/subagent-usage}}
 {{> partials/common/check-before-create}}
 {{> partials/common/assignment-hierarchy}}
 {{> partials/common/mention-handoff}}

--- a/agents/software-development/engineer.md
+++ b/agents/software-development/engineer.md
@@ -61,6 +61,7 @@ If the spec is unclear, ask the Architect — don't guess. If you disagree with 
 {{> partials/common/no-redundant-comments}}
 {{> partials/common/linking-syntax}}
 {{> partials/common/subtask-preference}}
+{{> partials/common/subagent-usage}}
 {{> partials/common/check-before-create}}
 {{> partials/common/assignment-hierarchy}}
 {{> partials/common/mention-handoff}}


### PR DESCRIPTION
## Summary

The Engineer and Architect role docs tell agents to use sub-agents aggressively to parallelise work, but a recent engineer run on a DeepSeek-backed Claude Code runtime had every parallel sub-agent launch fail with:

> API Error: 400 thinking options type cannot be disabled when reasoning_effort is set

The agent then bailed on parallelism and ran the work serially.

## Root cause

Hezo's DeepSeek runtime config in `packages/shared/src/types/common.ts:588-598` sets:

- `CLAUDE_CODE_SUBAGENT_MODEL=deepseek-v4-flash` — pins sub-agents to the cheap, non-thinking model. Request shape is fine.
- `ANTHROPIC_DEFAULT_SONNET_MODEL=deepseek-v4-pro` — resolves \`model: sonnet\` to DeepSeek's thinking-capable 1M-context model.

When the engineer's sub-agent calls explicitly passed \`model: sonnet\`, Claude Code resolved it to \`deepseek-v4-pro\` and built a request that combined \`thinking: { type: "disabled" }\` (its sub-agent default) with \`reasoning_effort\` (carried by the thinking-capable model). The provider correctly 400s on that combination. The \`CLAUDE_CODE_SUBAGENT_MODEL\` pin Hezo already sets is the right shape — the engineer's explicit override bypassed it.

The deeper bug (Claude Code shouldn't send those two fields together) is upstream; this PR is an in-tree mitigation.

## Change

- New shared partial \`agents/_partials/common/subagent-usage.md\` telling agents to omit the \`model:\` parameter on sub-agent launches and let inheritance handle it (Hezo pins the right sub-agent model per provider).
- Reference the new partial from \`agents/software-development/engineer.md\` and \`agents/software-development/architect.md\`, the two roles whose docs already encourage aggressive sub-agent use.

## Test plan

- [ ] Dev server starts cleanly — \`resolvePartials\` in \`packages/server/src/db/resolve-partials.ts\` would throw at startup if the partial reference were broken.
- [ ] Engineer agent_types row's stored \`system_prompt_template\` includes the new "Launching sub-agents" section after restart (seed's \`ON CONFLICT DO UPDATE\` in \`packages/server/src/db/seed.ts\` refreshes it).
- [ ] Next engineer run on a DeepSeek team that needs parallel sub-agents: sub-agent calls omit \`model:\` and the parallel work completes without the 400.