### PR TITLE
fix(web): preserve line breaks for system status lines in formatted log view

### DIFF
--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -906,6 +906,9 @@ async function prepareWorktrees(
 	emit: (stream: 'stdout' | 'stderr', text: string) => void,
 	signal?: AbortSignal,
 ): Promise<{ workingDir: string; designatedRepo: RepoRow | null }> {
+	const emitSystem = (stream: 'stdout' | 'stderr', text: string) =>
+		emit(stream, `[system] ${text}\n`);
+
 	const repos = await deps.db.query<RepoRow>(
 		`SELECT id, short_name, repo_identifier FROM repos
 		 WHERE project_id = $1 ORDER BY created_at ASC`,
@@ -913,12 +916,12 @@ async function prepareWorktrees(
 	);
 
 	if (repos.rows.length === 0) {
-		emit('stdout', '(no repos linked to project — running in /workspace)\n');
+		emitSystem('stdout', '(no repos linked to project — running in /workspace)');
 		return { workingDir: '/workspace', designatedRepo: null };
 	}
 
 	return withProjectGitLock(project.id, async () => {
-		emit('stdout', '(syncing repos...)\n');
+		emitSystem('stdout', '(syncing repos...)');
 		const syncRes = await ensureProjectRepos(
 			deps.db,
 			deps.masterKeyManager,
@@ -928,10 +931,10 @@ async function prepareWorktrees(
 			},
 			deps.dataDir,
 			deps.sshAgentServer,
-			(stream, text) => emit(stream, `${text}\n`),
+			emitSystem,
 		);
 		if (syncRes.cloned.length > 0) {
-			emit('stdout', `(cloned ${syncRes.cloned.length} repo(s) on demand)\n`);
+			emitSystem('stdout', `(cloned ${syncRes.cloned.length} repo(s) on demand)`);
 		}
 
 		if (signal?.aborted) return { workingDir: '/workspace', designatedRepo: null };
@@ -957,12 +960,12 @@ async function prepareWorktrees(
 						if (signal?.aborted) break;
 						const repoDir = join(workspaceRoot, repo.short_name);
 
-						emit('stdout', `git fetch ${repo.short_name}...\n`);
+						emitSystem('stdout', `git fetch ${repo.short_name}...`);
 						const fetchRes = await fetchRepo(repoDir, sshAuthSock, knownHostsPath);
 						if (fetchRes.success) {
-							emit('stdout', `git fetch ${repo.short_name} done\n`);
+							emitSystem('stdout', `git fetch ${repo.short_name} done`);
 						} else {
-							emit('stderr', `git fetch ${repo.short_name} failed: ${fetchRes.error ?? '?'}\n`);
+							emitSystem('stderr', `git fetch ${repo.short_name} failed: ${fetchRes.error ?? '?'}`);
 						}
 					}
 				},
@@ -975,16 +978,19 @@ async function prepareWorktrees(
 			const worktreePath = join(taskWorktreeRoot, repo.short_name);
 
 			if (!existsSync(join(repoDir, '.git'))) {
-				emit('stderr', `(skipping worktree for ${repo.short_name} — not cloned)\n`);
+				emitSystem('stderr', `(skipping worktree for ${repo.short_name} — not cloned)`);
 				continue;
 			}
 
-			emit('stdout', `git worktree ${repo.short_name}...\n`);
+			emitSystem('stdout', `git worktree ${repo.short_name}...`);
 			const wt = await ensureTaskWorktree(repoDir, worktreePath, branchName);
 			if (!wt.success) {
-				emit('stderr', `git worktree for ${repo.short_name} failed: ${wt.error ?? 'unknown'}\n`);
+				emitSystem(
+					'stderr',
+					`git worktree for ${repo.short_name} failed: ${wt.error ?? 'unknown'}`,
+				);
 			} else if (wt.created) {
-				emit('stdout', `git worktree add ${repo.short_name} @ ${branchName}\n`);
+				emitSystem('stdout', `git worktree add ${repo.short_name} @ ${branchName}`);
 			}
 		}
 

--- a/packages/web/src/components/formatted-log-view.tsx
+++ b/packages/web/src/components/formatted-log-view.tsx
@@ -9,6 +9,7 @@ import {
 	parseAgentLog,
 	type ResultBlock,
 	type SessionBlock,
+	type SystemBlock,
 	type TextBlock,
 	type ThinkingBlock,
 	type ToolBlock,
@@ -65,7 +66,18 @@ function BlockView({
 			return <ResultView block={block} />;
 		case 'done':
 			return <DoneView block={block} />;
+		case 'system':
+			return <SystemView block={block} />;
 	}
+}
+
+function SystemView({ block }: { block: SystemBlock }) {
+	const color = block.stream === 'stderr' ? 'text-accent-red-text' : 'text-text-subtle';
+	return (
+		<pre className={`whitespace-pre-wrap break-words font-mono text-xs ${color}`}>
+			{block.lines.join('\n')}
+		</pre>
+	);
 }
 
 function SessionView({ block }: { block: SessionBlock }) {

--- a/packages/web/src/lib/parse-agent-log.ts
+++ b/packages/web/src/lib/parse-agent-log.ts
@@ -74,6 +74,14 @@ export interface DoneBlock {
 	costUsd: number | null;
 }
 
+/** Operational/lifecycle status lines from the run host (repo sync, worktree setup, …). */
+export interface SystemBlock {
+	type: 'system';
+	id: number;
+	lines: string[];
+	stream: 'stdout' | 'stderr';
+}
+
 export type LogBlock =
 	| SessionBlock
 	| TextBlock
@@ -81,7 +89,8 @@ export type LogBlock =
 	| CommandBlock
 	| ToolBlock
 	| ResultBlock
-	| DoneBlock;
+	| DoneBlock
+	| SystemBlock;
 
 /** Strip a `[prefix]` token and the single following space, if present. */
 function stripPrefix(text: string, prefix: string): string {
@@ -185,6 +194,17 @@ export function parseAgentLog(lines: AgentLogLine[]): LogBlock[] {
 		if (text.startsWith('[done]')) {
 			flushText();
 			blocks.push(parseDone(line.id, text));
+			continue;
+		}
+		if (text.startsWith('[system]')) {
+			flushText();
+			const body = stripPrefix(text, '[system]');
+			const tail = blocks[blocks.length - 1];
+			if (tail && tail.type === 'system' && tail.stream === line.stream) {
+				tail.lines.push(body);
+			} else {
+				blocks.push({ type: 'system', id: line.id, lines: [body], stream: line.stream });
+			}
 			continue;
 		}
 		if (text.startsWith('$ ')) {

--- a/packages/web/test/parse-agent-log.test.ts
+++ b/packages/web/test/parse-agent-log.test.ts
@@ -3,6 +3,7 @@ import {
 	type DoneBlock,
 	parseAgentLog,
 	type ResultBlock,
+	type SystemBlock,
 	type TextBlock,
 	type ToolBlock,
 } from '@hezo/web/lib/parse-agent-log';
@@ -138,4 +139,43 @@ test('leaves a tool pending when its result has not arrived', () => {
 	const tool = blocks[0] as ToolBlock;
 	expect(tool.status).toBe('pending');
 	expect(tool.result).toBeNull();
+});
+
+test('coalesces consecutive system status lines into one block', () => {
+	const blocks = parseAgentLog(
+		makeLines([
+			'[system] (syncing repos...)',
+			'[system] git fetch todo3...',
+			'[system] git fetch todo3 done',
+			'[system] git worktree todo3...',
+		]),
+	);
+	expect(blocks).toHaveLength(1);
+	const sys = blocks[0] as SystemBlock;
+	expect(sys.type).toBe('system');
+	expect(sys.stream).toBe('stdout');
+	expect(sys.lines).toEqual([
+		'(syncing repos...)',
+		'git fetch todo3...',
+		'git fetch todo3 done',
+		'git worktree todo3...',
+	]);
+});
+
+test('separates system stdout from system stderr into different blocks', () => {
+	const blocks = parseAgentLog(
+		makeLines([
+			['[system] git fetch foo...', 'stdout'],
+			['[system] git fetch foo failed: timeout', 'stderr'],
+			['[system] git worktree foo...', 'stdout'],
+		]),
+	);
+	const sys = blocks.filter((b): b is SystemBlock => b.type === 'system');
+	expect(sys).toHaveLength(3);
+	expect(sys.map((b) => b.stream)).toEqual(['stdout', 'stderr', 'stdout']);
+});
+
+test('flushes pending prose before opening a system block', () => {
+	const blocks = parseAgentLog(makeLines(['Setting up.', '[system] (syncing repos...)', 'Done.']));
+	expect(blocks.map((b) => b.type)).toEqual(['text', 'system', 'text']);
 });


### PR DESCRIPTION
## Summary

In the agent run **formatted log view**, the early lifecycle/system status lines (`(syncing repos...)`, `git fetch <repo>...`, `git worktree <repo>...`, etc.) were collapsing onto a single line:

```
(syncing repos...) git fetch todo3... git fetch todo3 done git worktree todo3...
```

…while the raw view rendered each on its own line.

## Root cause

These lines are emitted bare (no `[...]` prefix) by `prepareWorktrees` in `packages/server/src/services/agent-runner.ts`. On the client, `parseAgentLog` fell them into the bare-prose branch, coalesced them into a single `TextBlock`, joined with `\n`, and rendered the result via `MarkdownProse`. **Standard markdown treats a single `\n` within a paragraph as a soft break (i.e. a space)**, so all the lines collapsed onto one visual line.

The `$ claude ...` invocation that follows already has the `$ ` prefix and routed to its own `CommandView`, which is why the visible break appeared there but not within the git lines.

Switching the joiner to `\n\n` was rejected — that would break code fences and lists in real agent prose. Switching markdown to `breaks: true` was rejected — that would change soft-wrap behavior app-wide.

## Approach

Tag operational/lifecycle status messages with a `[system] ` prefix at the emission site, matching the existing `[session]` / `[tool]` / `[done]` pattern. Recognize the prefix client-side and render a dedicated block type with line breaks preserved (no markdown).

## Changes

- **`packages/server/src/services/agent-runner.ts`** — local `emitSystem(stream, text)` helper in `prepareWorktrees` prepends `[system] ` to the 11 lifecycle/status emit sites (the `ensureProjectRepos` progress callback is now `emitSystem` directly, so clone progress is tagged too).
- **`packages/web/src/lib/parse-agent-log.ts`** — added `SystemBlock` type plus a parser branch that coalesces consecutive same-stream `[system]` lines into one block. Flushes any pending prose first.
- **`packages/web/src/components/formatted-log-view.tsx`** — new `SystemView` renders the block as a compact `<pre className="whitespace-pre-wrap break-words font-mono text-xs">`. Stdout uses `text-text-subtle`; stderr keeps `text-accent-red-text` so failures remain visible.

## Test plan

- [x] Added 3 new unit tests in `packages/web/test/parse-agent-log.test.ts` covering: coalescing of consecutive same-stream system lines, separation of stdout vs stderr system blocks, and flushing pending prose before opening a system block.
- [x] `bunx vitest run packages/web/test/parse-agent-log.test.ts` — 13/13 pass (10 existing + 3 new).
- [x] `bunx vitest run packages/web/test/formatted-log-view.test.tsx packages/web/test/run-comment-formatted-log.test.tsx` — pass (no regressions).
- [x] `bun run typecheck` across `@hezo/server`, `@hezo/shared`, `@hezo/web` — clean.
- [x] `bunx biome check` — clean.
- [ ] Manual: start an agent task in dev, watch the formatted log view show the git/fetch/worktree lines on separate lines under a dimmed monospace block; confirm raw view text is unchanged.