### PR TITLE
fix: don't immediately retry a failed run

### DIFF
--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -1545,7 +1545,6 @@ export class JobManager {
 		);
 		const commentRow = inserted.rows[0];
 		if (!commentRow) return;
-		const commentId = commentRow.id as string;
 
 		broadcastRowChange(
 			this.deps.wsManager,
@@ -1554,14 +1553,6 @@ export class JobManager {
 			'INSERT',
 			commentRow,
 		);
-
-		await createWakeup(db, memberId, teamId, WakeupSource.Automation, {
-			source: WakeupSource.Automation,
-			task_id: taskId,
-			comment_id: commentId,
-			run_id: runId,
-			reason: 'run_failed',
-		});
 	}
 
 	private async chainNextTaskWakeup(

--- a/packages/server/test/job-manager-workflows.test.ts
+++ b/packages/server/test/job-manager-workflows.test.ts
@@ -846,7 +846,7 @@ describe('JobManager workflow methods', () => {
 				return r.rows;
 			}
 
-			it('posts a system comment and automation wakeup on failed status', async () => {
+			it('posts a system comment on failed status without queuing a retry wakeup', async () => {
 				await clearRunsAndComments();
 				const runId = await seedRun(HeartbeatRunStatus.Failed, 'The operation timed out.');
 
@@ -880,22 +880,16 @@ describe('JobManager workflow methods', () => {
 
 				const wakeups = await db.query<{ source: string; payload: Record<string, unknown> }>(
 					`SELECT source::text AS source, payload FROM agent_wakeup_requests
-					 WHERE member_id = $1 AND source = 'automation'
-					 ORDER BY created_at DESC LIMIT 1`,
+					 WHERE member_id = $1 AND source = 'automation' AND payload->>'reason' = 'run_failed'`,
 					[agentId],
 				);
-				expect(wakeups.rows.length).toBe(1);
-				expect(wakeups.rows[0].payload).toMatchObject({
-					task_id: taskId,
-					run_id: runId,
-					reason: 'run_failed',
-				});
+				expect(wakeups.rows.length).toBe(0);
 
 				manager.shutdown();
 				await clearRunsAndComments();
 			});
 
-			it('posts the ping on timed_out status', async () => {
+			it('posts the ping on timed_out status without queuing a retry wakeup', async () => {
 				await clearRunsAndComments();
 				const runId = await seedRun(HeartbeatRunStatus.TimedOut, 'Heartbeat lapsed');
 
@@ -921,6 +915,13 @@ describe('JobManager workflow methods', () => {
 				const failurePings = comments.filter((c) => c.content.kind === 'run_failed');
 				expect(failurePings.length).toBe(1);
 				expect(failurePings[0].content.status).toBe(HeartbeatRunStatus.TimedOut);
+
+				const wakeups = await db.query<{ id: string }>(
+					`SELECT id FROM agent_wakeup_requests
+					 WHERE member_id = $1 AND source = 'automation' AND payload->>'reason' = 'run_failed'`,
+					[agentId],
+				);
+				expect(wakeups.rows.length).toBe(0);
 
 				manager.shutdown();
 				await clearRunsAndComments();


### PR DESCRIPTION
## Summary

- `postFailurePing` was creating an `Automation` wakeup (`reason: 'run_failed'`) immediately after writing the `run_failed` system comment. The wakeups cron consumes that within ~5s, so the same agent re-runs the same task almost instantly — up to 3 strikes before the consecutive-failure guard kicks in.
- Drop the wakeup creation. The comment still posts for visibility; the natural heartbeat scheduler picks the agent up at its configured `heartbeat_interval_min` (with the existing 60s post-run cooldown) instead of an aggressive 5-second retry loop.
- `chainNextTaskWakeup` (which targets a *different* task) is intentionally untouched — this is about not retrying the *failed* task, not about pausing the whole agent.

## Test plan

- [x] `bun run test --pattern job-manager-workflows` — failure-ping suite updated (one renamed test, one widened assertion); 49/49 pass
- [x] `bun run typecheck`
- [ ] Manual: trigger a failing run, confirm exactly one `Failed` row in `heartbeat_runs`, no follow-up `automation` row in `agent_wakeup_requests` with `reason: 'run_failed'`, and the next run only fires after the heartbeat interval