### PR TITLE
fix(web): signal failed container in sidebar, soften copy, fix sticky overlap

### DIFF
--- a/packages/web/src/components/container-status-banner.tsx
+++ b/packages/web/src/components/container-status-banner.tsx
@@ -1,21 +1,33 @@
 import { ContainerStatus } from '@hezo/shared';
 import { Link } from '@tanstack/react-router';
 import { AlertTriangle, Loader2, RefreshCw } from 'lucide-react';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useProjectMeta } from '../hooks/use-projects';
 import { api } from '../lib/api';
 import { queryClient } from '../lib/query-client';
 import { Button } from './ui/button';
 
-const BANNER_BASE = 'sticky top-0 z-40 flex items-center gap-2 px-4 py-2 text-[13px] font-medium';
+const BANNER_OUTER = 'sticky top-0 z-40 bg-bg';
+const BANNER_INNER = 'flex items-center gap-2 px-4 py-2 text-[13px] font-medium';
 
 export function ContainerStatusBanner({ projectId }: { projectId: string }) {
 	const project = useProjectMeta(projectId);
 	const [isRebuilding, setIsRebuilding] = useState(false);
 
-	if (!project) return null;
+	const bannerRef = useCallback((node: HTMLDivElement | null) => {
+		if (!node) return;
+		const root = document.documentElement;
+		const observer = new ResizeObserver(([entry]) => {
+			root.style.setProperty('--container-banner-h', `${entry?.contentRect.height ?? 0}px`);
+		});
+		observer.observe(node);
+		return () => {
+			observer.disconnect();
+			root.style.setProperty('--container-banner-h', '0px');
+		};
+	}, []);
 
-	const status = project.container_status;
+	if (!project) return null;
 
 	// Provisioning / shutting down: a transient state that resolves on its own.
 	// Show a loading banner that links to the container page for live logs.
@@ -26,19 +38,21 @@ export function ContainerStatusBanner({ projectId }: { projectId: string }) {
 				? `Stopping ${project.name}'s container…`
 				: `Provisioning ${project.name}'s container…`;
 		return (
-			<Link
-				to="/projects/$projectId/container"
-				params={{ projectId }}
-				data-testid="container-status-banner-provisioning"
-				aria-label={`${message} View container logs`}
-				className={`${BANNER_BASE} bg-blue-500/10 text-blue-400 transition-colors hover:bg-blue-500/20`}
-			>
-				<Loader2 className="w-3.5 h-3.5 shrink-0 animate-spin" />
-				<span data-testid="container-status-banner-message" className="min-w-0 truncate">
-					{message}
-				</span>
-				<span className="ml-auto shrink-0 hidden sm:inline opacity-80">View logs</span>
-			</Link>
+			<div ref={bannerRef} className={BANNER_OUTER}>
+				<Link
+					to="/projects/$projectId/container"
+					params={{ projectId }}
+					data-testid="container-status-banner-provisioning"
+					aria-label={`${message} View container logs`}
+					className={`${BANNER_INNER} bg-blue-500/10 text-blue-400 transition-colors hover:bg-blue-500/20`}
+				>
+					<Loader2 className="w-3.5 h-3.5 shrink-0 animate-spin" />
+					<span data-testid="container-status-banner-message" className="min-w-0 truncate">
+						{message}
+					</span>
+					<span className="ml-auto shrink-0 hidden sm:inline opacity-80">View logs</span>
+				</Link>
+			</div>
 		);
 	}
 
@@ -46,7 +60,7 @@ export function ContainerStatusBanner({ projectId }: { projectId: string }) {
 	if (!unhealthy) return null;
 
 	const hasError = status === ContainerStatus.Error;
-	const message = `${project.name} container failed`;
+	const message = `${project.name} container is not running`;
 
 	const rebuild = async () => {
 		if (isRebuilding) return;
@@ -62,27 +76,28 @@ export function ContainerStatusBanner({ projectId }: { projectId: string }) {
 	const tone = hasError ? 'bg-red-500/10 text-red-400' : 'bg-amber-500/10 text-amber-400';
 
 	return (
-		<div data-testid="container-status-banner" className={`${BANNER_BASE} ${tone}`}>
-			<AlertTriangle className="w-3.5 h-3.5 shrink-0" />
-			<span data-testid="container-status-banner-message" className="min-w-0 truncate">
-				{message}
-			</span>
-			<Button
-				variant="ghost"
-				size="sm"
-				onClick={rebuild}
-				disabled={isRebuilding}
-				className="ml-auto shrink-0"
-				aria-label="Rebuild failed container"
-			>
-				{isRebuilding ? (
-					<Loader2 className="w-3 h-3 animate-spin" />
-				) : (
-					<RefreshCw className="w-3 h-3" />
-				)}
-				<span className="hidden sm:inline">Rebuild</span>
-				<span className="sm:hidden">Rebuild</span>
-			</Button>
+		<div ref={bannerRef} className={BANNER_OUTER}>
+			<div data-testid="container-status-banner" className={`${BANNER_INNER} ${tone}`}>
+				<AlertTriangle className="w-3.5 h-3.5 shrink-0" />
+				<span data-testid="container-status-banner-message" className="min-w-0 truncate">
+					{message}
+				</span>
+				<Button
+					variant="ghost"
+					size="sm"
+					onClick={rebuild}
+					disabled={isRebuilding}
+					className="ml-auto shrink-0"
+					aria-label="Restart failed container"
+				>
+					{isRebuilding ? (
+						<Loader2 className="w-3 h-3 animate-spin" />
+					) : (
+						<RefreshCw className="w-3 h-3" />
+					)}
+					<span>Restart</span>
+				</Button>
+			</div>
 		</div>
 	);
 }

--- a/packages/web/src/components/container-status-banner.tsx
+++ b/packages/web/src/components/container-status-banner.tsx
@@ -29,6 +29,8 @@ export function ContainerStatusBanner({ projectId }: { projectId: string }) {
 
 	if (!project) return null;
 
+	const status = project.container_status;
+
 	// Provisioning / shutting down: a transient state that resolves on its own.
 	// Show a loading banner that links to the container page for live logs.
 	const provisioning = status === ContainerStatus.Creating || status === ContainerStatus.Stopping;

--- a/packages/web/src/components/project-sidebar.tsx
+++ b/packages/web/src/components/project-sidebar.tsx
@@ -1,6 +1,6 @@
-import { AgentAdminStatus } from '@hezo/shared';
+import { AgentAdminStatus, ContainerStatus } from '@hezo/shared';
 import { Link, useNavigate } from '@tanstack/react-router';
-import { Globe, Info } from 'lucide-react';
+import { AlertTriangle, Globe, Info } from 'lucide-react';
 import { useState } from 'react';
 import { useActiveProject } from '../hooks/use-active-project';
 import { useAgents } from '../hooks/use-agents';
@@ -49,6 +49,9 @@ export function ProjectSidebar() {
 
 	const isInternal = project?.is_internal ?? false;
 	const projectParams = { projectId };
+	const containerFailed =
+		project?.container_status === ContainerStatus.Stopped ||
+		project?.container_status === ContainerStatus.Error;
 
 	const enabledAgents = (agents ?? []).filter((a) => a.admin_status !== AgentAdminStatus.Disabled);
 	const byCreatedAt = (a: { created_at: string }, b: { created_at: string }) =>
@@ -83,7 +86,23 @@ export function ProjectSidebar() {
 		{
 			to: '/projects/$projectId/container',
 			params: projectParams,
-			label: 'Container',
+			label: (
+				<span className="inline-flex items-center gap-1.5">
+					<span>Container</span>
+					{containerFailed && (
+						<Tooltip content="Container failed — click for details" side="right">
+							<span
+								role="img"
+								data-testid="project-sidebar-container-error"
+								aria-label="Container failed"
+								className="inline-flex shrink-0 text-red-400"
+							>
+								<AlertTriangle className="w-3 h-3" aria-hidden="true" />
+							</span>
+						</Tooltip>
+					)}
+				</span>
+			),
 		},
 		{
 			to: '/projects/$projectId/audit-log',

--- a/packages/web/src/components/task-detail/task-sidebar.tsx
+++ b/packages/web/src/components/task-detail/task-sidebar.tsx
@@ -86,7 +86,7 @@ export function TaskSidebar({
 		<>
 			<div
 				data-testid="task-sidebar"
-				className="flex flex-col gap-4 text-xs lg:sticky lg:top-0 lg:self-start"
+				className="flex flex-col gap-4 text-xs lg:sticky lg:top-[var(--container-banner-h,0px)] lg:self-start"
 			>
 				<AgentQueueSection
 					projectId={projectId}

--- a/packages/web/src/routes/projects/$projectId/container.tsx
+++ b/packages/web/src/routes/projects/$projectId/container.tsx
@@ -93,7 +93,7 @@ function ContainerPage() {
 							Stop
 						</Button>
 					</Tooltip>
-					<Tooltip content="Rebuild container from scratch">
+					<Tooltip content="Restart container">
 						<Button
 							variant="ghost"
 							size="sm"
@@ -105,7 +105,7 @@ function ContainerPage() {
 							) : (
 								<RefreshCw className="w-3 h-3" />
 							)}
-							Rebuild
+							Restart
 						</Button>
 					</Tooltip>
 				</div>
@@ -167,9 +167,9 @@ function ContainerPage() {
 			<ConfirmDialog
 				open={rebuildOpen}
 				onOpenChange={setRebuildOpen}
-				title="Rebuild container from scratch?"
+				title="Restart container?"
 				description="All unpushed work will be lost and running agent tasks will be cancelled."
-				confirmLabel="Rebuild"
+				confirmLabel="Restart"
 				variant="danger"
 				loading={rebuildContainer.isPending}
 				onConfirm={async () => {

--- a/packages/web/test/container-management.test.tsx
+++ b/packages/web/test/container-management.test.tsx
@@ -3,7 +3,7 @@ import { expect, test } from 'vitest';
 import { renderApp } from './helpers/render';
 import { type SeededWorkspace, seedProject, seedWorkspace } from './helpers/seed';
 
-test('container page renders rebuild button and Container nav crumb', async () => {
+test('container page renders restart button and Container nav crumb', async () => {
 	let ws!: SeededWorkspace;
 	let projectSlug = '';
 	const { findByRole, router } = await renderApp({
@@ -20,7 +20,7 @@ test('container page renders rebuild button and Container nav crumb', async () =
 		params: { projectId: projectSlug },
 	});
 
-	await findByRole('button', { name: /rebuild/i }, { timeout: 20_000 });
+	await findByRole('button', { name: /restart/i }, { timeout: 20_000 });
 });
 
 test('container page shows "Waiting for container output…" when status is running but no logs yet', async () => {
@@ -140,7 +140,7 @@ test('banner flags the active project as failed and rebuilds it', async () => {
 	expect(message.textContent ?? '').toContain('Failed Banner');
 
 	const rebuildBtn = banner.querySelector(
-		'button[aria-label="Rebuild failed container"]',
+		'button[aria-label="Restart failed container"]',
 	) as HTMLButtonElement;
 	expect(rebuildBtn).toBeTruthy();
 	fireEvent.click(rebuildBtn);


### PR DESCRIPTION
## Summary

When a project's container is unhealthy the only chrome cue was a sticky top banner reading `{project} container failed` with a `Rebuild` button. Two problems:
1. No persistent indicator in the sidebar — once the user scrolled or navigated, the only signal was gone.
2. The banner's translucent tint (`bg-red-500/10`) let page content bleed through, and on the task-detail page the sticky right sidebar (PRIORITY/ASSIGNEE) collided with the sticky banner at `top-0`.

This PR adds a persistent sidebar indicator, softens the wording, and fixes both stacking issues.

## Changes

- **Sidebar error icon** (`project-sidebar.tsx`): red `AlertTriangle` next to the **Container** nav item with a tooltip ("Container failed — click for details") when status is `stopped`/`error`. Clicking anywhere on the row navigates to the Container page.
- **Banner copy** (`container-status-banner.tsx`): "container failed" → "container is not running". `Rebuild` button → `Restart` (button text + aria-label). Banner and Container-page actions still call the existing rebuild endpoint; only wording changed.
- **Container page rename** (`routes/projects/$projectId/container.tsx`): page button, its tooltip, and the confirm dialog's title + confirmLabel all → `Restart`. Destructive warning copy kept since the underlying action is unchanged.
- **Opaque banner**: split sticky/z-index/`bg-bg` onto a wrapper div; the existing tinted element becomes the inner child. Page content scrolling under the banner is now hidden, not visible through the tint.
- **Sticky sidebar offset**: banner publishes its measured height as `--container-banner-h` on `<html>` via a React 19 callback ref + `ResizeObserver` (auto-cleanup on detach). `task-sidebar.tsx` uses `lg:top-[var(--container-banner-h,0px)]` so the right sidebar sticks *below* the banner. CSS var defaults to `0px` when no banner renders, so healthy projects are unaffected.

## Test plan

- [x] `bun run test --pattern container-management --skip-browser` — 4/4 pass (assertions updated to `/restart/i` and `aria-label="Restart failed container"`).
- [x] `bun run test --pattern sidebar --skip-browser` — 4/4 pass.
- [x] Typecheck clean.
- [ ] Manual: load a project, force its container into `error`, confirm:
  - Sidebar **Container** row shows red triangle; hover → "Container failed — click for details".
  - Top banner reads "{project} container is not running" with a **Restart** button; banner is opaque (no see-through).
  - On the task-detail page, the right sidebar (PRIORITY/ASSIGNEE/PROJECT) sticks below the banner — not behind it.
  - Container page **Restart** button + tooltip + confirm dialog all read "Restart".
  - Click Restart → status flips to `creating`, banner switches to provisioning style, sidebar icon disappears.