### PR TITLE
chore(server): demote routine mcp-connection descriptor logs to debug

### DIFF
--- a/packages/server/src/services/mcp-connections.ts
+++ b/packages/server/src/services/mcp-connections.ts
@@ -173,7 +173,7 @@ export async function loadMcpConnectionDescriptors(
 				if (entry && entry.accessToken) {
 					headers = stripExistingAuth(headers);
 					headers.Authorization = `Bearer ${entry.accessToken}`;
-					log.info('mcp descriptor built with materialized oauth token', {
+					log.debug('mcp descriptor built with materialized oauth token', {
 						name: row.name,
 						url: config.url,
 						host,
@@ -190,7 +190,7 @@ export async function loadMcpConnectionDescriptors(
 					continue;
 				}
 			} else {
-				log.info('mcp descriptor built without oauth (no oauth_connection_id)', {
+				log.debug('mcp descriptor built without oauth (no oauth_connection_id)', {
 					name: row.name,
 					url: config.url,
 					host,


### PR DESCRIPTION
## Summary

`loadMcpConnectionDescriptors` (in `packages/server/src/services/mcp-connections.ts`) emitted an `info`-level log for every materialized OAuth token (with token prefix + length) and another for every no-OAuth descriptor on each agent run startup. Because two concurrent agent runs routinely start within the same wakeup tick, the same team's GitHub connection was being materialized twice in quick succession and producing duplicate noisy lines like:

```
[info] <mcp-connections> mcp descriptor built with materialized oauth token {"name":"github","url":"https://api.githubcopilot.com/mcp/","host":"api.githubcopilot.com","secret_name":"OAUTH_GITHUB_...","token_prefix":"gho_...","token_length":40}
```

This change demotes both routine descriptor-build logs to `debug` so a default `LOG_LEVEL=INFO` run is quiet. Running with `LOG_LEVEL=DEBUG` still surfaces the diagnostics. The warn/error paths in the same file — missing OAuth secret, malformed URL, uninstalled local MCP — are unchanged.

- `log.info('mcp descriptor built with materialized oauth token', …)` → `log.debug(…)`
- `log.info('mcp descriptor built without oauth (no oauth_connection_id)', …)` → `log.debug(…)`

The two info logs were added in #86 (the connector-driven MCP integration with UI-mediated OAuth) as diagnostic output and never demoted.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bunx vitest run test/mcp-connections.test.ts test/oauth-mcp-injection.test.ts` — 12/12 pass; the demoted lines no longer appear in test stdout at the default level, while the kept `[warn]` paths still emit as expected
- [ ] CI green