### PR TITLE
fix(server): cap project container memory to surface OOM kills

### DIFF
--- a/packages/server/src/services/containers.ts
+++ b/packages/server/src/services/containers.ts
@@ -92,6 +92,12 @@ const PORT_POOL_END = 19999;
 
 const LAST_LOGS_CAP_BYTES = 32 * 1024;
 
+// Cap each project container's memory so a runaway workload hits the cgroup OOM
+// killer (surfaces as a `docker events` oom event and a deterministic exit 137
+// on the offending container) rather than silently pressuring the whole Docker
+// Desktop VM and taking sibling containers down with it.
+const CONTAINER_MEMORY_LIMIT_BYTES = 6 * 1024 * 1024 * 1024;
+
 /**
  * Pull a one-shot tail of the container's stdout+stderr log buffer. Used to
  * snapshot the last-known console output when a container exits or errors so
@@ -222,6 +228,8 @@ export async function provisionContainer(
 				Binds: binds,
 				PortBindings: portBindings,
 				ExtraHosts: extraHosts,
+				Memory: CONTAINER_MEMORY_LIMIT_BYTES,
+				MemorySwap: CONTAINER_MEMORY_LIMIT_BYTES,
 			},
 			ExposedPorts: exposedPorts,
 		});

--- a/packages/server/src/services/docker.ts
+++ b/packages/server/src/services/docker.ts
@@ -11,6 +11,8 @@ interface ContainerConfig {
 		Binds?: string[];
 		PortBindings?: Record<string, Array<{ HostPort: string }>>;
 		ExtraHosts?: string[];
+		Memory?: number;
+		MemorySwap?: number;
 	};
 	ExposedPorts?: Record<string, object>;
 }

--- a/packages/server/test/container-sync.test.ts
+++ b/packages/server/test/container-sync.test.ts
@@ -351,12 +351,16 @@ describe('provisionContainer broadcasting', () => {
 		expect(event.row.container_status).toBe('running');
 		expect(event.row.container_id).toBe('test-container-123');
 
-		const binds = mockDocker.createContainer.mock.calls[0][1].HostConfig.Binds as string[];
+		const hostConfig = mockDocker.createContainer.mock.calls[0][1].HostConfig;
+		const binds = hostConfig.Binds as string[];
 		const assetsBind = binds.find((b) => b.endsWith(':/workspace/.hezo/assets:ro'));
 		expect(assetsBind).toBeDefined();
 		expect(assetsBind).toContain(
 			`${dataDir}/teams/${project.team_id}/projects/${project.id}/assets`,
 		);
+
+		expect(hostConfig.Memory).toBeGreaterThan(0);
+		expect(hostConfig.MemorySwap).toBe(hostConfig.Memory);
 	});
 
 	it('keeps container name and bind mounts stable when the project is renamed', async () => {


### PR DESCRIPTION
## Summary

Project containers were spun up with no Docker memory limit. When the Docker Desktop VM ran low on memory, its in-kernel OOM killer would SIGKILL one or more `hezo-*` containers — observed today as **six different project containers dying simultaneously at the same second** with `exitCode=137`, no `docker events oom` signal, and no `container_last_logs` capture. The job-manager then suppressed failure pings on three consecutive run failures (`packages/server/src/services/job-manager.ts:1518`), masking the underlying cause.

This sets `Memory` + `MemorySwap` to **6 GiB per container** so a runaway workload trips the **cgroup** OOM killer on its own container instead of pressuring the whole VM and taking siblings down with it. The OOM then surfaces as a `docker events` oom event and a deterministic exit 137 traceable to the offending project.

## Changes

- `packages/server/src/services/containers.ts`: add `CONTAINER_MEMORY_LIMIT_BYTES`, pass it as `Memory` + `MemorySwap` in `provisionContainer`'s `createContainer` call.
- `packages/server/src/services/docker.ts`: extend `HostConfig` type with optional `Memory` / `MemorySwap`.
- `packages/server/test/container-sync.test.ts`: assert `Memory > 0` and `MemorySwap == Memory` in the existing `provisionContainer broadcasting` test.

## Notes

- Existing containers keep the old un-capped config until rebuilt; only new provisions get the cap.
- 6 GiB matches the observed peak working set (active runs sit at ~150 MiB; the cap mostly bounds the pathological case). Tunable as a single constant if 6 GiB proves too tight or too loose.
- Setting `MemorySwap == Memory` disables swap so the OOM fires deterministically rather than swap-thrashing first.

## Test plan

- [x] `bun run typecheck` clean across `@hezo/shared`, `@hezo/server`, `@hezo/web`.
- [x] `bunx vitest run test/container-sync.test.ts` — 20/20 pass (including the new HostConfig assertions).
- [ ] After merge, rebuild one project container locally and verify `docker inspect | grep -i memory` shows the 6 GiB limit.