### PR TITLE
fix: cool down chain-after-completion to stop ping-pong on parked tasks

### DIFF
--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -1573,14 +1573,27 @@ export class JobManager {
 		const { db } = this.deps;
 		// Pick the next non-terminal task for this agent that we aren't already
 		// covering: skip the just-completed task, anything the agent has an active
-		// run on (concurrent parallel runs), and anything that already has a
-		// queued/claimed wakeup for this agent. Without this dedupe, an agent with
-		// multiple concurrent runs creates a redundant chain wakeup for each
-		// sibling — those wakeups then cycle in the busy-skip queue and starve
-		// `Automation` wakeups (Coach) targeting the same project.
+		// run on (concurrent parallel runs), anything that already has a
+		// queued/claimed wakeup for this agent, and anything this agent already
+		// successfully ran within its effective heartbeat interval. The
+		// recent-success clause matches the cadence the heartbeat scheduler
+		// considers "due"; without it, an agent with multiple parked-on-input
+		// tasks (e.g. an Architect waiting on @admin approval on two specs)
+		// ping-pongs between them every few seconds since each completion
+		// re-selects the other parked task. Conversational triggers (mentions,
+		// replies, comments, dependency unblocks) ride their own wakeup sources,
+		// not this chain, so cooling the chain doesn't delay legitimate work.
 		// Instance agents (CEO/Coach) chain across every team; everyone else stays
 		// scoped to the just-completed task's team. Build params positionally so the
 		// team filter is only present when its placeholder is.
+		const agentRow = await db.query<{ heartbeat_interval_min: number }>(
+			'SELECT heartbeat_interval_min FROM member_agents WHERE id = $1',
+			[memberId],
+		);
+		const chainCooldownMin = Math.max(
+			agentRow.rows[0]?.heartbeat_interval_min ?? HEARTBEAT_INTERVAL_FLOOR_MIN,
+			HEARTBEAT_INTERVAL_FLOOR_MIN,
+		);
 		const isInstanceAgent = (INSTANCE_AGENT_SLUGS as readonly string[]).includes(agentSlug);
 		const params: unknown[] = [memberId];
 		let teamClause = '';
@@ -1599,6 +1612,10 @@ export class JobManager {
 		params.push(HeartbeatRunStatus.Queued, HeartbeatRunStatus.Running);
 		const wu = params.length + 1;
 		params.push(WakeupStatus.Queued, WakeupStatus.Claimed);
+		const succ = params.length + 1;
+		params.push(HeartbeatRunStatus.Succeeded);
+		const cd = params.length + 1;
+		params.push(chainCooldownMin);
 		const next = await db.query<{ id: string }>(
 			`SELECT i.id FROM tasks i
 			 WHERE i.assignee_id = $1${teamClause} AND i.id != $${selfIdx}
@@ -1619,6 +1636,13 @@ export class JobManager {
 			     WHERE w.member_id = $1
 			       AND w.status IN ($${wu}::wakeup_status, $${wu + 1}::wakeup_status)
 			       AND w.payload->>'task_id' = i.id::text
+			   )
+			   AND NOT EXISTS (
+			     SELECT 1 FROM heartbeat_runs hr
+			     WHERE hr.task_id = i.id AND hr.member_id = $1
+			       AND hr.status = $${succ}::heartbeat_run_status
+			       AND hr.finished_at IS NOT NULL
+			       AND hr.finished_at > now() - ($${cd}::int || ' minutes')::interval
 			   )
 			 ORDER BY
 			   CASE i.priority WHEN $${pr} THEN 0 WHEN $${pr + 1} THEN 1 WHEN $${pr + 2} THEN 2 WHEN $${pr + 3} THEN 3 END,

--- a/packages/server/test/job-manager-workflows.test.ts
+++ b/packages/server/test/job-manager-workflows.test.ts
@@ -1289,6 +1289,150 @@ describe('JobManager workflow methods', () => {
 			await db.query('DELETE FROM agent_wakeup_requests WHERE member_id = $1', [agentId]);
 			await db.query('DELETE FROM tasks WHERE id = $1', [siblingTaskId]);
 		});
+
+		it('does not chain back to a task the agent succeeded on within its heartbeat interval', async () => {
+			const manager = createJobManager();
+
+			await db.query('UPDATE tasks SET assignee_id = $1 WHERE id = $2', [agentId, taskId]);
+			await db.query(`UPDATE tasks SET status = $1::task_status WHERE id = $2`, [
+				TaskStatus.Backlog,
+				taskId,
+			]);
+
+			const meta = await db.query<{ task_prefix: string; number: number }>(
+				`SELECT p.task_prefix, next_project_task_number(p.id) AS number
+				 FROM projects p WHERE p.id = $1`,
+				[projectId],
+			);
+			const siblingInsert = await db.query<{ id: string }>(
+				`INSERT INTO tasks (team_id, project_id, assignee_id, number, identifier, title, description, status, priority, labels)
+				 VALUES ($1, $2, $3, $4, $5, $6, '', $7::task_status, 'medium'::task_priority, '[]'::jsonb)
+				 RETURNING id`,
+				[
+					teamId,
+					projectId,
+					agentId,
+					meta.rows[0].number,
+					`${meta.rows[0].task_prefix}-${meta.rows[0].number}`,
+					'Sibling already worked recently',
+					TaskStatus.Backlog,
+				],
+			);
+			const siblingTaskId = siblingInsert.rows[0].id;
+
+			// Use a generous heartbeat interval so the "recent success" window
+			// is unambiguous in test time.
+			await db.query('UPDATE member_agents SET heartbeat_interval_min = 60 WHERE id = $1', [
+				agentId,
+			]);
+
+			await db.query('DELETE FROM agent_wakeup_requests WHERE member_id = $1', [agentId]);
+			await db.query('DELETE FROM heartbeat_runs WHERE member_id = $1', [agentId]);
+
+			// A succeeded run by this agent on the sibling that finished a minute
+			// ago — well inside the 60-min heartbeat interval, so the sibling is
+			// not yet due to be re-picked.
+			await db.query(
+				`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at, finished_at)
+				 VALUES ($1, $2, $3, $4::heartbeat_run_status, now() - interval '90 seconds', now() - interval '60 seconds')`,
+				[agentId, teamId, siblingTaskId, HeartbeatRunStatus.Succeeded],
+			);
+
+			await (manager as any).onAgentComplete(
+				agentId,
+				'test-agent',
+				taskId,
+				taskIdentifier,
+				teamId,
+				undefined,
+				undefined,
+				{ success: true, exitCode: 0, stdout: '', stderr: '' },
+			);
+
+			const chain = await db.query<{ id: string }>(
+				`SELECT id FROM agent_wakeup_requests
+				 WHERE member_id = $1 AND source = 'timer'`,
+				[agentId],
+			);
+			expect(chain.rows.length).toBe(0);
+
+			manager.shutdown();
+			await db.query('DELETE FROM agent_wakeup_requests WHERE member_id = $1', [agentId]);
+			await db.query('DELETE FROM heartbeat_runs WHERE member_id = $1', [agentId]);
+			await db.query('DELETE FROM tasks WHERE id = $1', [siblingTaskId]);
+		});
+
+		it('does chain to a task whose last succeeded run is older than the heartbeat interval', async () => {
+			const manager = createJobManager();
+
+			await db.query('UPDATE tasks SET assignee_id = $1 WHERE id = $2', [agentId, taskId]);
+			await db.query(`UPDATE tasks SET status = $1::task_status WHERE id = $2`, [
+				TaskStatus.Backlog,
+				taskId,
+			]);
+
+			const meta = await db.query<{ task_prefix: string; number: number }>(
+				`SELECT p.task_prefix, next_project_task_number(p.id) AS number
+				 FROM projects p WHERE p.id = $1`,
+				[projectId],
+			);
+			const siblingInsert = await db.query<{ id: string }>(
+				`INSERT INTO tasks (team_id, project_id, assignee_id, number, identifier, title, description, status, priority, labels)
+				 VALUES ($1, $2, $3, $4, $5, $6, '', $7::task_status, 'medium'::task_priority, '[]'::jsonb)
+				 RETURNING id`,
+				[
+					teamId,
+					projectId,
+					agentId,
+					meta.rows[0].number,
+					`${meta.rows[0].task_prefix}-${meta.rows[0].number}`,
+					'Sibling last worked long ago',
+					TaskStatus.Backlog,
+				],
+			);
+			const siblingTaskId = siblingInsert.rows[0].id;
+
+			// Heartbeat interval of 5 min (matches the floor) — a run finished
+			// 10 min ago is comfortably outside the cooldown.
+			await db.query('UPDATE member_agents SET heartbeat_interval_min = 5 WHERE id = $1', [
+				agentId,
+			]);
+
+			await db.query('DELETE FROM agent_wakeup_requests WHERE member_id = $1', [agentId]);
+			await db.query('DELETE FROM heartbeat_runs WHERE member_id = $1', [agentId]);
+
+			await db.query(
+				`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at, finished_at)
+				 VALUES ($1, $2, $3, $4::heartbeat_run_status, now() - interval '11 minutes', now() - interval '10 minutes')`,
+				[agentId, teamId, siblingTaskId, HeartbeatRunStatus.Succeeded],
+			);
+
+			await (manager as any).onAgentComplete(
+				agentId,
+				'test-agent',
+				taskId,
+				taskIdentifier,
+				teamId,
+				undefined,
+				undefined,
+				{ success: true, exitCode: 0, stdout: '', stderr: '' },
+			);
+
+			const chain = await db.query<{ source: string; payload: Record<string, unknown> }>(
+				`SELECT source, payload FROM agent_wakeup_requests
+				 WHERE member_id = $1 AND status = $2::wakeup_status
+				 ORDER BY created_at DESC LIMIT 1`,
+				[agentId, WakeupStatus.Queued],
+			);
+			expect(chain.rows.length).toBe(1);
+			expect(chain.rows[0].payload.task_id).toBe(siblingTaskId);
+			expect(chain.rows[0].payload.reason).toBe('chain_after_completion');
+
+			manager.shutdown();
+			await db.query('DELETE FROM agent_wakeup_requests WHERE member_id = $1', [agentId]);
+			await db.query('DELETE FROM heartbeat_runs WHERE member_id = $1', [agentId]);
+			await db.query('DELETE FROM tasks WHERE id = $1', [siblingTaskId]);
+		});
 	});
 
 	describe('coach auto-close', () => {

--- a/packages/server/test/job-manager-workflows.test.ts
+++ b/packages/server/test/job-manager-workflows.test.ts
@@ -1392,8 +1392,9 @@ describe('JobManager workflow methods', () => {
 			);
 			const siblingTaskId = siblingInsert.rows[0].id;
 
-			// Heartbeat interval of 5 min (matches the floor) — a run finished
-			// 10 min ago is comfortably outside the cooldown.
+			// Heartbeat interval of 5 min (matches the floor). A run that finished
+			// a year ago is unambiguously outside the cooldown regardless of CI
+			// clock precision or test ordering.
 			await db.query('UPDATE member_agents SET heartbeat_interval_min = 5 WHERE id = $1', [
 				agentId,
 			]);
@@ -1403,7 +1404,7 @@ describe('JobManager workflow methods', () => {
 
 			await db.query(
 				`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at, finished_at)
-				 VALUES ($1, $2, $3, $4::heartbeat_run_status, now() - interval '11 minutes', now() - interval '10 minutes')`,
+				 VALUES ($1, $2, $3, $4::heartbeat_run_status, now() - interval '1 year' - interval '1 hour', now() - interval '1 year')`,
 				[agentId, teamId, siblingTaskId, HeartbeatRunStatus.Succeeded],
 			);
 
@@ -1418,15 +1419,18 @@ describe('JobManager workflow methods', () => {
 				{ success: true, exitCode: 0, stdout: '', stderr: '' },
 			);
 
-			const chain = await db.query<{ source: string; payload: Record<string, unknown> }>(
-				`SELECT source, payload FROM agent_wakeup_requests
-				 WHERE member_id = $1 AND status = $2::wakeup_status
-				 ORDER BY created_at DESC LIMIT 1`,
-				[agentId, WakeupStatus.Queued],
+			// Specifically query for the chain wakeup targeting the sibling, so
+			// the assertion is unaffected by any other wakeup that might exist for
+			// the agent (e.g. from prior tests or side effects of onAgentComplete).
+			const chain = await db.query<{ payload: Record<string, unknown> }>(
+				`SELECT payload FROM agent_wakeup_requests
+				 WHERE member_id = $1
+				   AND source = 'timer'::wakeup_source
+				   AND payload->>'task_id' = $2
+				   AND payload->>'reason' = 'chain_after_completion'`,
+				[agentId, siblingTaskId],
 			);
 			expect(chain.rows.length).toBe(1);
-			expect(chain.rows[0].payload.task_id).toBe(siblingTaskId);
-			expect(chain.rows[0].payload.reason).toBe('chain_after_completion');
 
 			manager.shutdown();
 			await db.query('DELETE FROM agent_wakeup_requests WHERE member_id = $1', [agentId]);


### PR DESCRIPTION
## Summary

Fixes a self-perpetuating wakeup loop where an agent owning two or more non-blocked tickets that are all parked waiting on the same external input (e.g. an Architect with two specs both parked on `@admin` approval) ping-pongs between them every ~15 seconds, racking up hundreds of no-op runs.

Observed in dogfooding: **1308 chain runs over 16 hours** for a single Architect, ~15s avg duration, only 5 substantive comments produced across the lot. All 1308 were `WakeupSource.Timer` with payload `{reason: 'chain_after_completion'}`, alternating between two tickets the agent owned.

## Root cause

`JobManager.chainNextTaskWakeup` (`packages/server/src/services/job-manager.ts`) queues a Timer wakeup for the agent's next assigned non-terminal task after every completion, so an agent doesn't have to wait a full heartbeat interval between tickets. The dedupe correctly excluded:

- the just-completed task
- tasks with active `heartbeat_runs`
- tasks with already-queued/claimed wakeups
- tasks with open blockers

…but had no notion of "this agent just successfully ran this task a moment ago." With two parked tickets, each completion re-selected the other parked ticket and queued a fresh chain wakeup, looping indefinitely.

## Fix

Adds a fifth `NOT EXISTS` clause that excludes tasks this agent successfully ran within `GREATEST(heartbeat_interval_min, HEARTBEAT_INTERVAL_FLOOR_MIN)` minutes — the same cadence the heartbeat scheduler considers "due" (`processScheduledHeartbeats`). If the heartbeat wouldn't pick the task up yet, the chain shouldn't either.

Conversational triggers (mentions, replies, comments, dependency unblocks) ride their own non-Timer wakeup sources and bypass the chain entirely, so legitimate new work still fires immediately — the cooldown only suppresses the redundant self-loop.

## Test plan

- [x] `bunx vitest run packages/server/test/job-manager-workflows.test.ts -t chain` — 6/6 passing (4 existing + 2 new)
- [x] Full server suite — `1714/1714` passing
- [x] Web suite — `249/249` passing
- [x] `bun run typecheck` — clean
- [x] New tests cover both sides of the cooldown:
  - `does not chain back to a task the agent succeeded on within its heartbeat interval`
  - `does chain to a task whose last succeeded run is older than the heartbeat interval`