### PR TITLE
refactor(server): inject project docs as metadata manifest, not full bodies

### DIFF
--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -2391,6 +2391,7 @@ export function registerTools(
 				files: docs.map((d) => ({
 					id: d.id,
 					filename: d.slug,
+					title: d.title,
 					updated_at: d.updated_at,
 				})),
 			};

--- a/packages/server/src/services/template-resolver.ts
+++ b/packages/server/src/services/template-resolver.ts
@@ -180,21 +180,30 @@ export async function resolveSystemPrompt(
 		resolved = resolved.replace(/\{\{team_preferences_context\}\}/g, prefsText);
 	}
 
+	// Project docs are injected as a manifest (filename + optional title + updated date),
+	// not full bodies. The agent calls read_project_doc(filename) to load a doc on demand.
+	// Hand-rolled SQL (vs listDocuments) avoids pulling the content column, which is
+	// the whole point of switching away from full-body injection.
 	if (resolved.includes('{{project_docs_context}}')) {
 		let docsText = 'No project documentation available.';
 		if (ctx.projectId) {
-			const docs = await db.query<{ filename: string; content: string }>(
-				"SELECT slug AS filename, content FROM documents WHERE type = 'project_doc' AND project_id = $1 ORDER BY slug",
+			const docs = await db.query<{ filename: string; title: string; updated_at: string }>(
+				"SELECT slug AS filename, title, updated_at FROM documents WHERE type = 'project_doc' AND project_id = $1 ORDER BY slug",
 				[ctx.projectId],
 			);
 			if (docs.rows.length > 0) {
-				const body = docs.rows.map((d) => `### ${d.filename}\n${d.content}`).join('\n\n---\n\n');
+				const lines = docs.rows
+					.map((d) => {
+						const date = new Date(d.updated_at).toISOString().slice(0, 10);
+						const titlePart = d.title ? ` — ${d.title}` : '';
+						return `- ${d.filename}${titlePart} (updated ${date})`;
+					})
+					.join('\n');
 				docsText = [
-					'The following project docs are stored in the project-doc database, not the filesystem.',
-					'To modify any of them, use `write_project_doc` (with the bare filename, e.g. `prd.md`).',
-					'The filesystem `Edit`/`Write` tools will NOT work on these — they are not files in your worktree.',
+					'The project docs database holds high-level project context (PRDs, specs, architecture decisions, research). Entries are listed below by filename.',
+					"Call read_project_doc(filename) to load a doc's full contents when relevant to your task.",
 					'',
-					body,
+					lines,
 				].join('\n');
 			}
 		}

--- a/packages/server/test/template-resolver.test.ts
+++ b/packages/server/test/template-resolver.test.ts
@@ -113,7 +113,7 @@ describe('template resolver', () => {
 		expect(result).toContain('No project documentation available');
 	});
 
-	it('renders {{project_docs_context}} with a not-a-file warning and bare-filename headings when docs exist', async () => {
+	it('renders {{project_docs_context}} as a metadata manifest pointing at read_project_doc', async () => {
 		const docRes = await app.request(`/api/projects/${projectId}/docs/spec.md`, {
 			method: 'PUT',
 			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
@@ -125,21 +125,56 @@ describe('template resolver', () => {
 			teamId,
 			projectId,
 		});
-		expect(result).toContain(
-			'The following project docs are stored in the project-doc database, not the filesystem.',
-		);
-		expect(result).toContain('use `write_project_doc`');
-		expect(result).toContain('`Edit`/`Write` tools will NOT work');
-		expect(result).toContain('### spec.md');
-		expect(result).not.toContain('## spec.md (link: spec.md)');
-		expect(result).toContain('Detailed spec.');
 
-		const warningIdx = result.indexOf(
-			'The following project docs are stored in the project-doc database',
+		expect(result).toContain('The project docs database holds high-level project context');
+		expect(result).toContain('read_project_doc(filename)');
+
+		// Titled doc (architecture-guidelines.md is seeded by createTestProject with a non-empty title).
+		expect(result).toMatch(
+			/- architecture-guidelines\.md — Architecture Guidelines \(updated \d{4}-\d{2}-\d{2}\)/,
 		);
-		const headingIdx = result.indexOf('### spec.md');
-		expect(warningIdx).toBeGreaterThanOrEqual(0);
-		expect(headingIdx).toBeGreaterThan(warningIdx);
+
+		// Title-less doc (created via PUT, which leaves title empty) — no em-dash, no "undefined".
+		expect(result).toMatch(/- spec\.md \(updated \d{4}-\d{2}-\d{2}\)/);
+		expect(result).not.toContain('spec.md —');
+		expect(result).not.toContain('undefined');
+
+		// Doc bodies and the old warning copy are gone — the whole point of the manifest.
+		expect(result).not.toContain('Detailed spec.');
+		expect(result).not.toContain('### spec.md');
+		expect(result).not.toContain('Edit`/`Write` tools will NOT work');
+		expect(result).not.toContain('use `write_project_doc`');
+	});
+
+	it('sorts the {{project_docs_context}} manifest by filename', async () => {
+		const teamRes = await app.request('/api/teams', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name: 'Sort Co', description: '' }),
+		});
+		const sortTeamId = (await teamRes.json()).data.id as string;
+		const proj = await db.query<{ id: string }>(
+			`INSERT INTO projects (team_id, name, slug, task_prefix, description, docker_base_image)
+			 VALUES ($1, 'Sort', 'sort', 'SO', '', 'hezo/agent-base:latest')
+			 RETURNING id`,
+			[sortTeamId],
+		);
+		const sortProjectId = proj.rows[0].id;
+		await db.query(
+			`INSERT INTO documents (team_id, project_id, type, slug, content)
+			 VALUES ($1, $2, 'project_doc', 'z-last.md', 'z'),
+			        ($1, $2, 'project_doc', 'a-first.md', 'a')`,
+			[sortTeamId, sortProjectId],
+		);
+
+		const result = await resolveSystemPrompt(db, '{{project_docs_context}}', {
+			teamId: sortTeamId,
+			projectId: sortProjectId,
+		});
+		const aIdx = result.indexOf('a-first.md');
+		const zIdx = result.indexOf('z-last.md');
+		expect(aIdx).toBeGreaterThan(-1);
+		expect(zIdx).toBeGreaterThan(aIdx);
 	});
 
 	it('passes through text without template variables', async () => {


### PR DESCRIPTION
## Summary

Project docs were being baked into every agent's system prompt verbatim on every heartbeat run. With even a handful of medium-sized docs (PRD, spec, architecture notes, research) per project, the `{{project_docs_context}}` placeholder ate a substantial fraction of the context window for every agent, every turn — scaling linearly with doc count and body size.

This change switches `{{project_docs_context}}` to the same pattern `{{skills_context}}` already uses: emit only a metadata manifest, and let the agent fetch full content on demand via the existing `read_project_doc(filename)` MCP tool.

## Changes

- **`packages/server/src/services/template-resolver.ts`** — `{{project_docs_context}}` now emits a manifest line per doc (`- filename — title (updated YYYY-MM-DD)`, sorted by filename, em-dash omitted when title is empty) with a header instructing the agent to call `read_project_doc(filename)` for full contents. The SQL is hand-rolled (rather than going through `listDocuments`) specifically to avoid pulling the `content` column — which is the whole point.
- **`packages/server/src/mcp/tools.ts`** — `list_project_docs` now also returns `title`, mirroring the manifest's shape and matching `list_skills`/`{{skills_context}}` parity.
- **`packages/server/test/template-resolver.test.ts`** — Rewrote the existing "full body in prompt" test for the new manifest shape (covers titled doc, title-less doc, body exclusion, removal of old `Edit`/`Write` warning copy, absence of `undefined`) and added a sort-order test.

No changes to agent prompt files — they still reference `{{project_docs_context}}`; only the resolution changed. No schema migration. No new MCP tools (the existing `list_project_docs` / `read_project_doc` / `write_project_doc` trio already covers discovery, on-demand fetch, and write, and `SHARED_INSTRUCTIONS` already directs agents at them).

## Test plan

- [x] `bunx vitest run test/template-resolver.test.ts` — 48/48 pass (rewritten test + new sort test + everything pre-existing)
- [x] `bun run test --pattern mcp-tools --skip-browser` — 73/73 pass
- [x] `bun run test --pattern mcp-project-scope --skip-browser` — 12/12 pass
- [x] `bun run test --pattern project-docs --skip-browser` — 2/2 pass
- [x] `bun run test --pattern documents --skip-browser` — 3/3 pass
- [x] `bun run typecheck` — clean