### PR TITLE
fix(web): offset sticky doc-list sidebar so it doesn't slam into the header on scroll

### DIFF
--- a/packages/web/src/components/docs-library.tsx
+++ b/packages/web/src/components/docs-library.tsx
@@ -108,9 +108,12 @@ export function DocsLibrary({
 				}`}
 			>
 				{/* Sticky on desktop so the doc list stays visible while a long
-				    document scrolls. 2.5rem = the h-10 app header; the list scrolls
-				    internally if it outgrows the viewport. */}
-				<div className="md:sticky md:top-0 md:max-h-[calc(100vh-2.5rem)] md:overflow-y-auto">
+				    document scrolls. The top offset mirrors the project layout's
+				    vertical padding (md:py-5 lg:py-6) so the pinned position
+				    preserves the breathing room visible when unscrolled. max-h
+				    subtracts the h-10 app header (2.5rem) plus the top offset so
+				    the list never overflows the bottom of <main>. */}
+				<div className="md:sticky md:top-5 lg:top-6 md:max-h-[calc(100vh-3.75rem)] lg:max-h-[calc(100vh-4rem)] md:overflow-y-auto">
 					{onNewDoc && (
 						<Button
 							variant="outline"

--- a/test/browser/docs-sidebar-sticky.spec.ts
+++ b/test/browser/docs-sidebar-sticky.spec.ts
@@ -52,6 +52,11 @@ test('documents sidebar stays pinned while the page scrolls on desktop', async (
 		expect(after.y).toBeGreaterThanOrEqual(0);
 		// Pinned: it did not drift down from its starting position.
 		expect(after.y).toBeLessThanOrEqual(before.y + 1);
+		// And it did not drift up either. The sticky offset mirrors the project
+		// layout's vertical padding so the breathing room above the button when
+		// unscrolled is preserved when the sidebar sticks; without it the button
+		// would slide flush against the app header.
+		expect(after.y).toBeGreaterThanOrEqual(before.y - 1);
 		// And it sits within the app header + a small offset of the top.
 		expect(after.y).toBeLessThan(120);
 	}


### PR DESCRIPTION
## Summary

The project documents sidebar (`/projects/:projectId/documents`) is `position: sticky` with `top: 0` relative to the `<main>` scroll container. Because `<main>` starts flush below the app header, on scroll the "+ New document" button slid up against the header — losing the breathing room that the project layout's `md:py-5 lg:py-6` padding provides when unscrolled. The visual effect: the side menu "drifts up" as you scroll a long doc, until the button is touching the top.

Fix: match the surrounding padding with `md:top-5 lg:top-6` on the sticky element so the pinned position equals the natural position. Adjust `max-h` to subtract the new offset alongside the header (`100vh − 2.5rem − 1.25rem` at md, `− 1.5rem` at lg) so the list still can't overflow the bottom of `<main>`.

## Files changed

- `packages/web/src/components/docs-library.tsx` — sticky offset + max-h fix.
- `test/browser/docs-sidebar-sticky.spec.ts` — the existing spec only asserted the button doesn't drift **down** (`after.y <= before.y + 1`), so the drift-**up** bug slipped through. Added a symmetric `after.y >= before.y - 1` lower bound. Reverting just the source change makes the assertion fail at the exact line, confirming it locks in the regression.

## Test plan

- [x] `bunx playwright test test/browser/docs-sidebar-sticky.spec.ts` — passes with the fix; reverting the source change makes the new assertion fail (verified locally before pushing).
- [ ] Manual desktop check (≥1024px): open Documents on a project with a long doc, scroll — "+ New document" button keeps its breathing room from the app header at all scroll positions.
- [ ] Manual md check (768–1023px): same behavior, offset is `top-5` instead of `top-6`.
- [ ] Mobile (<768px): sticky is disabled at this breakpoint; behavior unchanged.