### PR TITLE
feat(web): surface last-run-failed on task list and task page

### DIFF
--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -177,6 +177,7 @@ tasksRoutes.get('/projects/:projectId/tasks', async (c) => {
               WHERE bm.task_id = i.id AND bm.user_id = $${idx}
                 AND bm.read_at IS NULL AND bm.archived_at IS NULL
             ) AS has_unread_admin_mention,
+            lr.status AS last_run_status,
             CASE WHEN qw.last_skipped_reason IS NOT NULL THEN json_build_object(
               'reason', qw.last_skipped_reason,
               'since', qw.last_skipped_at,
@@ -202,6 +203,14 @@ tasksRoutes.get('/projects/:projectId/tasks', async (c) => {
        ORDER BY w.last_skipped_at DESC
        LIMIT 1
      ) qw ON true
+     LEFT JOIN LATERAL (
+       SELECT hr.status
+       FROM heartbeat_runs hr
+       WHERE hr.task_id = i.id
+         AND hr.status NOT IN ('queued', 'running')
+       ORDER BY hr.finished_at DESC NULLS LAST, hr.started_at DESC
+       LIMIT 1
+     ) lr ON true
      WHERE ${where}
      ORDER BY EXISTS (
                 SELECT 1 FROM heartbeat_runs hr
@@ -306,6 +315,8 @@ tasksRoutes.get('/projects/:projectId/tasks/:taskId', async (c) => {
               SELECT 1 FROM heartbeat_runs hr
               WHERE hr.task_id = i.id AND hr.status IN ('running', 'queued')
             ) AS has_active_run,
+            lr.status AS last_run_status,
+            lr.comment_id AS last_run_comment_id,
             CASE WHEN qw.last_skipped_reason IS NOT NULL THEN json_build_object(
               'reason', qw.last_skipped_reason,
               'since', qw.last_skipped_at,
@@ -334,6 +345,18 @@ tasksRoutes.get('/projects/:projectId/tasks/:taskId', async (c) => {
        ORDER BY w.last_skipped_at DESC
        LIMIT 1
      ) qw ON true
+     LEFT JOIN LATERAL (
+       SELECT hr.status, hrc.id AS comment_id
+       FROM heartbeat_runs hr
+       LEFT JOIN task_comments hrc
+         ON hrc.task_id = hr.task_id
+         AND hrc.content_type = 'run'
+         AND hrc.content->>'run_id' = hr.id::text
+       WHERE hr.task_id = i.id
+         AND hr.status NOT IN ('queued', 'running')
+       ORDER BY hr.finished_at DESC NULLS LAST, hr.started_at DESC
+       LIMIT 1
+     ) lr ON true
      WHERE i.id = $1 AND i.team_id = $2`,
 		[taskId, teamId],
 	);

--- a/packages/server/test/tasks-last-run.test.ts
+++ b/packages/server/test/tasks-last-run.test.ts
@@ -1,0 +1,164 @@
+import type { PGlite } from '@electric-sql/pglite';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Env } from '../src/lib/types';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp, createTestProject } from './helpers/app';
+
+let app: Hono<Env>;
+let db: PGlite;
+let token: string;
+let teamId: string;
+let projectId: string;
+let projectSlug: string;
+let agentId: string;
+
+interface TaskRow {
+	id: string;
+	identifier: string;
+	last_run_status: string | null;
+	last_run_comment_id?: string | null;
+	has_active_run: boolean;
+}
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+
+	const teamRes = await app.request('/api/teams', {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ name: 'Last Run Co' }),
+	});
+	teamId = (await teamRes.json()).data.id;
+
+	const projectRes = await createTestProject(db, teamId, { name: 'Main' });
+	const projectData = (await projectRes.json()).data;
+	projectId = projectData.id;
+	projectSlug = projectData.slug;
+
+	const agentRes = await app.request(`/api/projects/${projectSlug}/agents`, {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ title: 'Runner' }),
+	});
+	agentId = (await agentRes.json()).data.id;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+async function createTask(title: string): Promise<string> {
+	const res = await app.request(`/api/projects/${projectSlug}/tasks`, {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ project_id: projectId, title, assignee_id: agentId }),
+	});
+	return (await res.json()).data.id as string;
+}
+
+async function insertRun(
+	taskId: string,
+	status: 'queued' | 'running' | 'succeeded' | 'failed' | 'cancelled' | 'timed_out',
+	finishedAt: Date | null,
+): Promise<string> {
+	const result = await db.query<{ id: string }>(
+		`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at, finished_at)
+		 VALUES ($1, $2, $3, $4::heartbeat_run_status, $5, $6)
+		 RETURNING id`,
+		[agentId, teamId, taskId, status, finishedAt ?? new Date(), finishedAt],
+	);
+	return result.rows[0].id;
+}
+
+async function insertRunComment(taskId: string, runId: string): Promise<string> {
+	const result = await db.query<{ id: string }>(
+		`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
+		 VALUES ($1, $2, 'run'::comment_content_type, $3::jsonb)
+		 RETURNING id`,
+		[taskId, agentId, JSON.stringify({ run_id: runId, agent_id: agentId })],
+	);
+	return result.rows[0].id;
+}
+
+async function fetchListRow(taskId: string): Promise<TaskRow> {
+	const res = await app.request(`/api/projects/${projectSlug}/tasks?per_page=200`, {
+		headers: authHeader(token),
+	});
+	const body = await res.json();
+	const row = (body.data as TaskRow[]).find((t) => t.id === taskId);
+	if (!row) throw new Error(`Task ${taskId} not in list response`);
+	return row;
+}
+
+async function fetchDetail(taskId: string): Promise<TaskRow> {
+	const res = await app.request(`/api/projects/${projectSlug}/tasks/${taskId}`, {
+		headers: authHeader(token),
+	});
+	return (await res.json()).data as TaskRow;
+}
+
+describe('task last-run fields', () => {
+	it('returns null when the task has no runs', async () => {
+		const taskId = await createTask('No runs');
+		const listRow = await fetchListRow(taskId);
+		const detail = await fetchDetail(taskId);
+		expect(listRow.last_run_status).toBeNull();
+		expect(detail.last_run_status).toBeNull();
+		expect(detail.last_run_comment_id).toBeNull();
+	});
+
+	it('returns null when the only run is still queued or running', async () => {
+		const taskId = await createTask('Only active');
+		await insertRun(taskId, 'running', null);
+		const listRow = await fetchListRow(taskId);
+		const detail = await fetchDetail(taskId);
+		expect(listRow.last_run_status).toBeNull();
+		expect(detail.last_run_status).toBeNull();
+		expect(detail.has_active_run).toBe(true);
+	});
+
+	it('exposes the run-start comment id for a failed run', async () => {
+		const taskId = await createTask('One failure');
+		const runId = await insertRun(taskId, 'failed', new Date());
+		const commentId = await insertRunComment(taskId, runId);
+		const listRow = await fetchListRow(taskId);
+		const detail = await fetchDetail(taskId);
+		expect(listRow.last_run_status).toBe('failed');
+		expect(detail.last_run_status).toBe('failed');
+		expect(detail.last_run_comment_id).toBe(commentId);
+	});
+
+	it('picks the most recent completed run when history exists', async () => {
+		const taskId = await createTask('History wins');
+		const earlier = await insertRun(taskId, 'succeeded', new Date(Date.now() - 60_000));
+		await insertRunComment(taskId, earlier);
+		const later = await insertRun(taskId, 'failed', new Date());
+		const laterCommentId = await insertRunComment(taskId, later);
+		const detail = await fetchDetail(taskId);
+		expect(detail.last_run_status).toBe('failed');
+		expect(detail.last_run_comment_id).toBe(laterCommentId);
+	});
+
+	it('still reports the previous failure when a retry is currently running', async () => {
+		const taskId = await createTask('Failure plus retry');
+		const failed = await insertRun(taskId, 'failed', new Date(Date.now() - 60_000));
+		const failedCommentId = await insertRunComment(taskId, failed);
+		await insertRun(taskId, 'running', null);
+		const detail = await fetchDetail(taskId);
+		expect(detail.last_run_status).toBe('failed');
+		expect(detail.last_run_comment_id).toBe(failedCommentId);
+		expect(detail.has_active_run).toBe(true);
+	});
+
+	it('returns timed_out distinctly from failed', async () => {
+		const taskId = await createTask('Timed out');
+		const runId = await insertRun(taskId, 'timed_out', new Date());
+		await insertRunComment(taskId, runId);
+		const detail = await fetchDetail(taskId);
+		expect(detail.last_run_status).toBe('timed_out');
+	});
+});

--- a/packages/web/src/components/task-detail/last-run-failed-banner.tsx
+++ b/packages/web/src/components/task-detail/last-run-failed-banner.tsx
@@ -1,0 +1,27 @@
+import { AlertTriangle, ChevronRight } from 'lucide-react';
+import type { Task } from '../../hooks/use-tasks';
+import { jumpToComment } from './comments-section';
+
+export function LastRunFailedBanner({ task }: { task: Task }) {
+	const failed = task.last_run_status === 'failed' || task.last_run_status === 'timed_out';
+	if (task.has_active_run || !failed || !task.last_run_comment_id) return null;
+
+	const commentId = task.last_run_comment_id;
+	return (
+		<a
+			href={`#comment-${commentId}`}
+			onClick={jumpToComment(commentId)}
+			data-testid="last-run-failed-banner"
+			className="mb-4 flex items-center gap-2 rounded-md bg-accent-red/10 px-4 py-2 text-[13px] font-medium text-red-400 hover:bg-accent-red/15 transition-colors"
+		>
+			<AlertTriangle className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
+			<span className="min-w-0 truncate">
+				{task.last_run_status === 'timed_out' ? 'Last run timed out' : 'Last run failed'} — view it
+			</span>
+			<span className="ml-auto flex items-center gap-1 shrink-0">
+				<span className="hidden sm:inline">Jump to run</span>
+				<ChevronRight className="w-3.5 h-3.5" />
+			</span>
+		</a>
+	);
+}

--- a/packages/web/src/components/task-list.tsx
+++ b/packages/web/src/components/task-list.tsx
@@ -1,6 +1,6 @@
 import { formatTaskStatus, TaskStatus, TERMINAL_TASK_STATUSES } from '@hezo/shared';
 import { useNavigate } from '@tanstack/react-router';
-import { AtSign, ChevronDown, ListPlus, Plus, Search } from 'lucide-react';
+import { AlertTriangle, AtSign, ChevronDown, ListPlus, Plus, Search } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useAgents } from '../hooks/use-agents';
 import { type TaskFilters, useTasks } from '../hooks/use-tasks';
@@ -58,6 +58,7 @@ interface TaskRow {
 	assignee_type: 'agent' | 'user' | null;
 	has_active_run: boolean;
 	has_unread_admin_mention: boolean;
+	last_run_status: 'succeeded' | 'failed' | 'cancelled' | 'timed_out' | null;
 	queued_wakeup: {
 		reason: 'task_busy' | 'project_at_capacity' | 'agent_running';
 		blocker_identifier: string | null;
@@ -171,51 +172,68 @@ export function TaskList({ projectId }: TaskListProps) {
 			header: 'ID',
 			width: '88px',
 			className: 'font-mono text-text-muted',
-			render: (row) => (
-				<span className="inline-flex items-center gap-1.5">
-					{row.has_active_run && (
-						<Tooltip content="Agent run in progress">
-							<span
-								role="img"
-								aria-label="Agent run in progress"
-								data-testid="task-running-dot"
-								className="inline-block w-2 h-2 rounded-full bg-accent-amber animate-pulse shrink-0"
-							/>
-						</Tooltip>
-					)}
-					{!row.has_active_run && row.queued_wakeup && (
-						<Tooltip
-							content={
-								row.queued_wakeup.reason === 'project_at_capacity'
-									? 'Run queued — project at capacity'
-									: 'Run queued — waiting'
-							}
-						>
-							<span
-								role="img"
-								aria-label={
+			render: (row) => {
+				const lastRunFailed =
+					!row.has_active_run &&
+					(row.last_run_status === 'failed' || row.last_run_status === 'timed_out');
+				return (
+					<span className="inline-flex items-center gap-1.5">
+						{row.has_active_run && (
+							<Tooltip content="Agent run in progress">
+								<span
+									role="img"
+									aria-label="Agent run in progress"
+									data-testid="task-running-dot"
+									className="inline-block w-2 h-2 rounded-full bg-accent-amber animate-pulse shrink-0"
+								/>
+							</Tooltip>
+						)}
+						{!row.has_active_run && row.queued_wakeup && (
+							<Tooltip
+								content={
 									row.queued_wakeup.reason === 'project_at_capacity'
 										? 'Run queued — project at capacity'
 										: 'Run queued — waiting'
 								}
-								data-testid="task-queued-dot"
-								className="inline-block w-2 h-2 rounded-full bg-accent-blue shrink-0"
-							/>
-						</Tooltip>
-					)}
-					{row.has_unread_admin_mention && (
-						<Tooltip content="Unread mention — needs your review">
-							<AtSign
-								role="img"
-								aria-label="Unread mention"
-								data-testid="task-mention-notice"
-								className="w-3 h-3 text-accent-blue shrink-0"
-							/>
-						</Tooltip>
-					)}
-					{row.identifier}
-				</span>
-			),
+							>
+								<span
+									role="img"
+									aria-label={
+										row.queued_wakeup.reason === 'project_at_capacity'
+											? 'Run queued — project at capacity'
+											: 'Run queued — waiting'
+									}
+									data-testid="task-queued-dot"
+									className="inline-block w-2 h-2 rounded-full bg-accent-blue shrink-0"
+								/>
+							</Tooltip>
+						)}
+						{lastRunFailed && (
+							<Tooltip content="Last run failed">
+								<span
+									role="img"
+									aria-label="Last run failed"
+									data-testid="task-failed-warning"
+									className="inline-flex shrink-0 text-red-400"
+								>
+									<AlertTriangle className="w-3 h-3" aria-hidden="true" />
+								</span>
+							</Tooltip>
+						)}
+						{row.has_unread_admin_mention && (
+							<Tooltip content="Unread mention — needs your review">
+								<AtSign
+									role="img"
+									aria-label="Unread mention"
+									data-testid="task-mention-notice"
+									className="w-3 h-3 text-accent-blue shrink-0"
+								/>
+							</Tooltip>
+						)}
+						{row.identifier}
+					</span>
+				);
+			},
 		},
 		{
 			key: 'title',

--- a/packages/web/src/hooks/use-tasks.ts
+++ b/packages/web/src/hooks/use-tasks.ts
@@ -27,6 +27,8 @@ export interface Task {
 	assignee_type: 'agent' | 'user' | null;
 	has_active_run: boolean;
 	has_unread_admin_mention: boolean;
+	last_run_status: 'succeeded' | 'failed' | 'cancelled' | 'timed_out' | null;
+	last_run_comment_id: string | null;
 	queued_wakeup: QueuedWakeup | null;
 	parent_task_id: string | null;
 	labels: string[];

--- a/packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx
@@ -8,6 +8,7 @@ import {
 	jumpToComment,
 } from '../../../../components/task-detail/comments-section';
 import { DependenciesSection } from '../../../../components/task-detail/dependencies-section';
+import { LastRunFailedBanner } from '../../../../components/task-detail/last-run-failed-banner';
 import { SubTasksSection } from '../../../../components/task-detail/sub-tasks-section';
 import { TaskHeader } from '../../../../components/task-detail/task-header';
 import { TaskSidebar } from '../../../../components/task-detail/task-sidebar';
@@ -89,6 +90,7 @@ function TaskDetailPage() {
 		<>
 			<div className="grid grid-cols-1 lg:grid-cols-[1fr_190px] gap-5">
 				<div className="min-w-0">
+					<LastRunFailedBanner task={task} />
 					<TaskHeader task={task} projectId={projectId} taskProjectSlug={taskProjectSlug} />
 
 					<TaskSummary

--- a/packages/web/test/task-detail-failed-banner.test.tsx
+++ b/packages/web/test/task-detail-failed-banner.test.tsx
@@ -1,0 +1,145 @@
+import { waitFor } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { getTestContext, renderApp } from './helpers/render';
+import {
+	type SeededTask,
+	type SeededWorkspace,
+	seedProject,
+	seedTask,
+	seedWorkspace,
+} from './helpers/seed';
+
+async function insertFailedRunWithComment(
+	workspace: SeededWorkspace,
+	task: SeededTask,
+	status: 'failed' | 'timed_out' = 'failed',
+): Promise<{ runId: string; commentId: string }> {
+	const { db } = getTestContext();
+	const agentId = workspace.agents[0].id;
+	const runRes = await db.query<{ id: string }>(
+		`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at, finished_at)
+		 VALUES ($1, $2, $3, $4::heartbeat_run_status, now() - interval '1 minute', now())
+		 RETURNING id`,
+		[agentId, workspace.team.id, task.id, status],
+	);
+	const runId = runRes.rows[0].id;
+	const commentRes = await db.query<{ id: string }>(
+		`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
+		 VALUES ($1, $2, 'run'::comment_content_type, $3::jsonb)
+		 RETURNING id`,
+		[task.id, agentId, JSON.stringify({ run_id: runId, agent_id: agentId })],
+	);
+	return { runId, commentId: commentRes.rows[0].id };
+}
+
+async function insertRunningRun(workspace: SeededWorkspace, task: SeededTask): Promise<void> {
+	const { db } = getTestContext();
+	await db.query(
+		`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at)
+		 VALUES ($1, $2, $3, 'running'::heartbeat_run_status, now())`,
+		[workspace.agents[0].id, workspace.team.id, task.id],
+	);
+}
+
+test('banner appears when last run failed and jumps to the run comment when clicked', async () => {
+	const seeded = { projectSlug: '', taskIdentifier: '', commentId: '' };
+	const { findByTestId, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Demo' });
+			const task = await seedTask(ws, project, { title: 'Failed Task' });
+			const { commentId } = await insertFailedRunWithComment(ws, task, 'failed');
+			seeded.projectSlug = project.slug;
+			seeded.taskIdentifier = task.identifier.toLowerCase();
+			seeded.commentId = commentId;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskIdentifier },
+	});
+
+	const banner = await findByTestId('last-run-failed-banner', undefined, { timeout: 10_000 });
+	expect(banner.textContent).toContain('Last run failed');
+
+	await user.click(banner);
+
+	await waitFor(() => {
+		expect(window.location.hash).toBe(`#comment-${seeded.commentId}`);
+	});
+});
+
+test('banner reports "timed out" copy when the last run timed out', async () => {
+	const seeded = { projectSlug: '', taskIdentifier: '' };
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Demo' });
+			const task = await seedTask(ws, project, { title: 'Timed Out Task' });
+			await insertFailedRunWithComment(ws, task, 'timed_out');
+			seeded.projectSlug = project.slug;
+			seeded.taskIdentifier = task.identifier.toLowerCase();
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskIdentifier },
+	});
+
+	const banner = await findByTestId('last-run-failed-banner', undefined, { timeout: 10_000 });
+	expect(banner.textContent).toContain('timed out');
+});
+
+test('banner is hidden when the task has no completed runs', async () => {
+	const seeded = { projectSlug: '', taskIdentifier: '' };
+	const { findByRole, queryByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Demo' });
+			const task = await seedTask(ws, project, { title: 'Fresh Task' });
+			seeded.projectSlug = project.slug;
+			seeded.taskIdentifier = task.identifier.toLowerCase();
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskIdentifier },
+	});
+
+	await findByRole('heading', { name: 'Fresh Task' });
+	await waitFor(() => {
+		expect(queryByTestId('last-run-failed-banner')).toBeNull();
+	});
+});
+
+test('banner is suppressed while a retry is currently running', async () => {
+	const seeded = { projectSlug: '', taskIdentifier: '' };
+	const { findByRole, queryByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Demo' });
+			const task = await seedTask(ws, project, { title: 'Retrying Task' });
+			await insertFailedRunWithComment(ws, task, 'failed');
+			await insertRunningRun(ws, task);
+			seeded.projectSlug = project.slug;
+			seeded.taskIdentifier = task.identifier.toLowerCase();
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskIdentifier },
+	});
+
+	await findByRole('heading', { name: 'Retrying Task' });
+	await waitFor(() => {
+		expect(queryByTestId('last-run-failed-banner')).toBeNull();
+	});
+});

--- a/packages/web/test/task-list-failed-warning.test.tsx
+++ b/packages/web/test/task-list-failed-warning.test.tsx
@@ -1,0 +1,147 @@
+import { waitFor } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { getTestContext, renderApp } from './helpers/render';
+import {
+	type SeededTask,
+	type SeededWorkspace,
+	seedProject,
+	seedTask,
+	seedWorkspace,
+} from './helpers/seed';
+
+async function insertCompletedRun(
+	workspace: SeededWorkspace,
+	task: SeededTask,
+	status: 'succeeded' | 'failed' | 'cancelled' | 'timed_out',
+): Promise<void> {
+	const { db } = getTestContext();
+	await db.query(
+		`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at, finished_at)
+		 VALUES ($1, $2, $3, $4::heartbeat_run_status, now() - interval '1 minute', now())`,
+		[workspace.agents[0].id, workspace.team.id, task.id, status],
+	);
+}
+
+async function insertRunningRun(workspace: SeededWorkspace, task: SeededTask): Promise<void> {
+	const { db } = getTestContext();
+	await db.query(
+		`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at)
+		 VALUES ($1, $2, $3, 'running'::heartbeat_run_status, now())`,
+		[workspace.agents[0].id, workspace.team.id, task.id],
+	);
+}
+
+test('failed last run shows the warning icon in the task list', async () => {
+	const seeded = { projectSlug: '' };
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Demo' });
+			const task = await seedTask(ws, project, { title: 'Failed Task' });
+			await insertCompletedRun(ws, task, 'failed');
+			seeded.projectSlug = project.slug;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks',
+		params: { projectId: seeded.projectSlug },
+	});
+
+	await findByTestId('task-failed-warning', undefined, { timeout: 10_000 });
+});
+
+test('successful last run does not show the warning', async () => {
+	const seeded = { projectSlug: '' };
+	const { findByTestId, queryByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Demo' });
+			const task = await seedTask(ws, project, { title: 'Done Task' });
+			await insertCompletedRun(ws, task, 'succeeded');
+			seeded.projectSlug = project.slug;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks',
+		params: { projectId: seeded.projectSlug },
+	});
+
+	await findByTestId('task-filter-bar', undefined, { timeout: 10_000 });
+	await waitFor(() => {
+		expect(queryByTestId('task-failed-warning')).toBeNull();
+	});
+});
+
+test('cancelled last run does not show the warning', async () => {
+	const seeded = { projectSlug: '' };
+	const { findByTestId, queryByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Demo' });
+			const task = await seedTask(ws, project, { title: 'Cancelled Task' });
+			await insertCompletedRun(ws, task, 'cancelled');
+			seeded.projectSlug = project.slug;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks',
+		params: { projectId: seeded.projectSlug },
+	});
+
+	await findByTestId('task-filter-bar', undefined, { timeout: 10_000 });
+	await waitFor(() => {
+		expect(queryByTestId('task-failed-warning')).toBeNull();
+	});
+});
+
+test('active retry suppresses the failed-run warning', async () => {
+	const seeded = { projectSlug: '' };
+	const { findByTestId, queryByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Demo' });
+			const task = await seedTask(ws, project, { title: 'Retrying Task' });
+			await insertCompletedRun(ws, task, 'failed');
+			await insertRunningRun(ws, task);
+			seeded.projectSlug = project.slug;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks',
+		params: { projectId: seeded.projectSlug },
+	});
+
+	await findByTestId('task-running-dot', undefined, { timeout: 10_000 });
+	await waitFor(() => {
+		expect(queryByTestId('task-failed-warning')).toBeNull();
+	});
+});
+
+test('timed_out last run also shows the warning', async () => {
+	const seeded = { projectSlug: '' };
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Demo' });
+			const task = await seedTask(ws, project, { title: 'Timed Out Task' });
+			await insertCompletedRun(ws, task, 'timed_out');
+			seeded.projectSlug = project.slug;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks',
+		params: { projectId: seeded.projectSlug },
+	});
+
+	await findByTestId('task-failed-warning', undefined, { timeout: 10_000 });
+});


### PR DESCRIPTION
## Summary

- Adds a red `AlertTriangle` warning icon to each task row in the task list when the last completed run on that task was a failure (`failed` or `timed_out`), styled to match the existing Container-failure icon in the project sidebar.
- Adds a banner at the top of the task detail page when the last run failed. Clicking it jumps to the failed run's position in the comments timeline via the existing `jumpToComment` / `#comment-<id>` hash-scroll path.
- Both indicators are **suppressed while a retry is currently queued or running**, so the existing amber active-run dot takes over; the failure indicator reappears only if the retry itself fails.

## How it works

Server (`packages/server/src/routes/tasks.ts`)
- The task list `GET` adds a `LATERAL` subquery over `heartbeat_runs` filtered to `status NOT IN ('queued','running')`, ordered by `finished_at DESC NULLS LAST, started_at DESC`, exposing `last_run_status`.
- The task detail `GET` adds the same subquery plus a `LEFT JOIN task_comments` on `content_type='run' AND content->>'run_id'`, exposing `last_run_comment_id` so the banner has a click target. Same join pattern already used in `agents.ts` for `run_comment_id`.

Frontend
- `Task` and `TaskRow` types gain `last_run_status` and `last_run_comment_id`.
- `task-list.tsx` renders the warning icon with `data-testid="task-failed-warning"`, gated on `!has_active_run && (last_run_status === 'failed' || 'timed_out')`.
- New `last-run-failed-banner.tsx` mounted above `TaskHeader`. Returns `null` unless the same gate plus a non-null `last_run_comment_id`. Click wiring reuses the existing `jumpToComment(commentId)` helper.
- No new WebSocket plumbing — `broadcastHeartbeatRunChange` already invalidates the task list and detail queries on run completion.

## Test plan

- [x] `bun run typecheck` clean across all packages
- [x] New server tests in `packages/server/test/tasks-last-run.test.ts` (6 cases — no runs, only active, single failure, multi-run history, failure + currently-running retry, timed_out)
- [x] New web tests in `packages/web/test/task-list-failed-warning.test.tsx` (5 cases) and `task-detail-failed-banner.test.tsx` (4 cases including click-and-hash assertion)
- [x] Existing `tasks.test.ts`, `tasks-extended.test.ts`, `heartbeat-runs.test.ts`, `list-tasks-assignee-filter.test.ts`, `task-list.test.tsx`, `task-crud.test.tsx` all still green