### PR TITLE
fix(server): safer pgdata recovery + auto-stop runaway containers

### DIFF
--- a/packages/server/src/db/client.ts
+++ b/packages/server/src/db/client.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, renameSync } from 'node:fs';
 import { join } from 'node:path';
 import { PGlite } from '@electric-sql/pglite';
 import { vector } from '@electric-sql/pglite/vector';
@@ -8,14 +8,29 @@ const log = logger.child('db');
 
 /** WASM init failures that usually mean pgdata was left half-written or locked. */
 export function isRecoverablePgInitError(err: unknown): boolean {
+	if (err instanceof WebAssembly.RuntimeError) return true;
 	const msg = err instanceof Error ? err.message : String(err);
 	return (
 		msg.includes('Unreachable code should not be executed') ||
 		msg.includes('_pg_initdb') ||
 		msg.includes('initdb') ||
 		msg.includes('could not open file') ||
-		msg.includes('invalid record length')
+		msg.includes('invalid record length') ||
+		msg.includes('Aborted()') ||
+		msg.includes('Build with -sASSERTIONS')
 	);
+}
+
+export class PgDataCorruptError extends Error {
+	constructor(
+		message: string,
+		readonly pgDataPath: string,
+		readonly backupPathHint: string,
+		readonly cause: unknown,
+	) {
+		super(message);
+		this.name = 'PgDataCorruptError';
+	}
 }
 
 export interface OpenPersistentDbOptions {
@@ -24,9 +39,17 @@ export interface OpenPersistentDbOptions {
 
 /**
  * Open (or create) the on-disk PGlite database under `<dataDir>/pgdata`.
- * Retries once after wiping pgdata when init fails due to a corrupt/partial
- * data directory — common when `bun --watch` reloads before the prior
- * instance calls `db.close()`.
+ *
+ * Behaviour:
+ * - Normal open: returns a working PGlite handle.
+ * - `options.reset === true`: renames any existing pgdata aside as
+ *   `pgdata.corrupt.<timestamp>` (never silently deletes), then creates a
+ *   fresh DB. The renamed copy can be inspected later with a standalone
+ *   PGlite process.
+ * - Init fails with a recoverable WASM/initdb signature: throws
+ *   `PgDataCorruptError` with the path where a backup would be saved if
+ *   the user re-runs with `--reset`. Callers should surface this to the
+ *   user verbatim — recovery is opt-in, never automatic.
  */
 export async function openPersistentDb(
 	dataDir: string,
@@ -34,11 +57,16 @@ export async function openPersistentDb(
 ): Promise<PGlite> {
 	const pgDataPath = join(dataDir, 'pgdata');
 
-	if (options.reset) {
-		rmSync(pgDataPath, { recursive: true, force: true });
-	}
-
 	mkdirSync(dataDir, { recursive: true });
+
+	if (options.reset && existsSync(pgDataPath)) {
+		const corruptPath = `${pgDataPath}.corrupt.${Date.now()}`;
+		log.warn('Reset requested; renaming existing pgdata aside before creating fresh DB', {
+			pgDataPath,
+			corruptPath,
+		});
+		renameSync(pgDataPath, corruptPath);
+	}
 
 	const { NodeFS } = await import('@electric-sql/pglite/nodefs');
 	const { loadPgliteAssets } = await import('./pglite-assets');
@@ -47,32 +75,30 @@ export async function openPersistentDb(
 	// from memory; in dev this is null and PGlite resolves them from node_modules.
 	const assets = await loadPgliteAssets(dataDir);
 
-	for (let attempt = 0; attempt < 2; attempt++) {
-		try {
-			const db = assets
-				? new PGlite({
-						fs: new NodeFS(pgDataPath),
-						extensions: { vector: assets.vectorExtension },
-						wasmModule: assets.wasmModule,
-						fsBundle: assets.fsBundle,
-					})
-				: new PGlite({ fs: new NodeFS(pgDataPath), extensions: { vector } });
-			await db.query('SELECT 1');
-			return db;
-		} catch (err) {
-			if (attempt === 0 && isRecoverablePgInitError(err)) {
-				log.warn('PGlite init failed; wiping pgdata and retrying', {
-					pgDataPath,
-					error: err instanceof Error ? err.message : String(err),
-				});
-				rmSync(pgDataPath, { recursive: true, force: true });
-				continue;
-			}
-			throw err;
+	try {
+		const db = assets
+			? new PGlite({
+					fs: new NodeFS(pgDataPath),
+					extensions: { vector: assets.vectorExtension },
+					wasmModule: assets.wasmModule,
+					fsBundle: assets.fsBundle,
+				})
+			: new PGlite({ fs: new NodeFS(pgDataPath), extensions: { vector } });
+		await db.query('SELECT 1');
+		return db;
+	} catch (err) {
+		if (isRecoverablePgInitError(err)) {
+			const backupPathHint = `${pgDataPath}.corrupt.<timestamp>`;
+			const causeMsg = err instanceof Error ? err.message : String(err);
+			const message =
+				`Database at ${pgDataPath} appears corrupt (PGlite init failed: ${causeMsg}).\n` +
+				`To preserve a backup and start with a fresh database, restart the server ` +
+				`with --reset. The existing pgdata will be renamed to ${backupPathHint} before ` +
+				`a fresh database is created. No data is deleted.`;
+			throw new PgDataCorruptError(message, pgDataPath, backupPathHint, err);
 		}
+		throw err;
 	}
-
-	throw new Error('openPersistentDb: retry loop exhausted');
 }
 
 /** @deprecated Use {@link openPersistentDb} — kept for callers that only need a bare instance. */

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -4,6 +4,7 @@ import { AuthType, DEFAULT_WEB_PORT } from '@hezo/shared';
 import { app } from './app';
 import { parseArgs, runRestore } from './cli';
 import type { MasterKeyManager } from './crypto/master-key';
+import { PgDataCorruptError } from './db/client';
 import { logger } from './logger';
 import { loadAdminAuth, verifyToken } from './middleware/auth';
 import type { ContainerLogStreamer } from './services/container-logs';
@@ -145,7 +146,11 @@ void (async () => {
 		}
 	} catch (err) {
 		if (thisStartupGeneration !== startupGeneration) return;
-		log.error('Startup failed, serving minimal app:', err);
+		if (err instanceof PgDataCorruptError) {
+			log.error(`\n${err.message}\n`);
+		} else {
+			log.error('Startup failed, serving minimal app:', err);
+		}
 		log.info(`Hezo server (minimal) starting on port ${config.port}...`);
 	}
 })();

--- a/packages/server/src/services/containers.ts
+++ b/packages/server/src/services/containers.ts
@@ -92,11 +92,12 @@ const PORT_POOL_END = 19999;
 
 const LAST_LOGS_CAP_BYTES = 32 * 1024;
 
-// Cap each project container's memory so a runaway workload hits the cgroup OOM
-// killer (surfaces as a `docker events` oom event and a deterministic exit 137
-// on the offending container) rather than silently pressuring the whole Docker
-// Desktop VM and taking sibling containers down with it.
-const CONTAINER_MEMORY_LIMIT_BYTES = 6 * 1024 * 1024 * 1024;
+/**
+ * Threshold above which the sync loop stops a running container automatically.
+ * Picked to leave headroom on a 16 GB laptop after Docker Desktop's own VM
+ * overhead, the dev server (PGlite + embeddings model), and the host OS.
+ */
+export const CONTAINER_MEMORY_KILL_BYTES = 12 * 1024 * 1024 * 1024;
 
 /**
  * Pull a one-shot tail of the container's stdout+stderr log buffer. Used to
@@ -228,8 +229,6 @@ export async function provisionContainer(
 				Binds: binds,
 				PortBindings: portBindings,
 				ExtraHosts: extraHosts,
-				Memory: CONTAINER_MEMORY_LIMIT_BYTES,
-				MemorySwap: CONTAINER_MEMORY_LIMIT_BYTES,
 			},
 			ExposedPorts: exposedPorts,
 		});
@@ -524,11 +523,76 @@ export async function syncContainerStatus(
 	return status;
 }
 
+/**
+ * If the container's working-set memory crosses {@link CONTAINER_MEMORY_KILL_BYTES},
+ * stop it and record an explanatory message in `container_error`. The banner and
+ * container page both surface that field. Returns the synthesised status when the
+ * container was stopped, or null when it was within budget or stats were unavailable.
+ *
+ * Failure modes are non-fatal — a transport error on stats or stop must not stop
+ * the surrounding sync loop from servicing other projects.
+ */
+async function enforceContainerMemoryLimit(
+	deps: ContainerDeps,
+	projectId: string,
+	teamId: string,
+	containerId: string,
+): Promise<string | null> {
+	const { db, docker } = deps;
+
+	let stats: Awaited<ReturnType<DockerClient['containerStats']>>;
+	try {
+		stats = await docker.containerStats(containerId);
+	} catch (err) {
+		log.warn(`Container stats transport error for project ${projectId}; will retry`, err);
+		return null;
+	}
+	if (!stats) return null;
+	if (stats.usedBytes <= CONTAINER_MEMORY_KILL_BYTES) return null;
+
+	const usedGiB = (stats.usedBytes / 1024 ** 3).toFixed(2);
+	const limitGiB = (CONTAINER_MEMORY_KILL_BYTES / 1024 ** 3).toFixed(0);
+	const errorMessage =
+		`Container was using ${usedGiB} GiB of RAM, above the ${limitGiB} GiB safety limit, ` +
+		`and was stopped automatically to keep your machine responsive. Restart the container ` +
+		`to try again, or investigate what was using the memory before restarting.`;
+
+	const lastLogs = await captureContainerLogs(docker, containerId);
+
+	try {
+		await docker.stopContainer(containerId);
+	} catch (err) {
+		log.warn(
+			`docker.stopContainer failed during memory-limit enforcement for project ${projectId}; recording error anyway`,
+			err,
+		);
+	}
+
+	await db.query(
+		`UPDATE projects
+		 SET container_status = $1::container_status,
+		     container_last_logs = COALESCE($2, container_last_logs),
+		     container_error = $3
+		 WHERE id = $4`,
+		[ContainerStatus.Error, lastLogs, errorMessage, projectId],
+	);
+
+	log.warn(
+		`Auto-stopped container ${containerId.slice(0, 12)} for project ${projectId}: used ${usedGiB} GiB (> ${limitGiB} GiB)`,
+	);
+
+	await failProjectRuns(deps, projectId, teamId, 'container_error').catch((e) =>
+		log.error('Failed to fail project runs after memory-limit stop:', e),
+	);
+
+	return ContainerStatus.Error;
+}
+
 export async function syncAllContainerStatuses(
-	db: PGlite,
-	docker: DockerClient,
-	wsManager?: WebSocketManager,
+	deps: ContainerDeps,
 ): Promise<ContainerTransition[]> {
+	const { db, docker, wsManager } = deps;
+
 	const projects = await db.query<{
 		id: string;
 		team_id: string;
@@ -541,13 +605,25 @@ export async function syncAllContainerStatuses(
 	const transitions: ContainerTransition[] = [];
 	for (const project of projects.rows) {
 		const oldStatus = project.container_status;
-		const newStatus = await syncContainerStatus(
+		let newStatus = await syncContainerStatus(
 			db,
 			docker,
 			project.id,
 			project.container_id,
 			oldStatus,
 		);
+
+		if (newStatus === ContainerStatus.Running) {
+			const overrideStatus = await enforceContainerMemoryLimit(
+				deps,
+				project.id,
+				project.team_id,
+				project.container_id,
+			);
+			if (overrideStatus !== null) {
+				newStatus = overrideStatus;
+			}
+		}
 
 		if (newStatus !== null && newStatus !== oldStatus) {
 			transitions.push({

--- a/packages/server/src/services/docker.ts
+++ b/packages/server/src/services/docker.ts
@@ -49,6 +49,22 @@ interface ContainerInfo {
 	};
 }
 
+interface RawContainerStats {
+	memory_stats?: {
+		usage?: number;
+		stats?: {
+			inactive_file?: number;
+			total_inactive_file?: number;
+			cache?: number;
+		};
+	};
+}
+
+export interface ContainerMemoryStats {
+	usedBytes: number;
+	rawUsageBytes: number;
+}
+
 export interface ImageInfo {
 	Id: string;
 	Config: {
@@ -206,6 +222,38 @@ export class DockerClient {
 
 	async inspectContainerByName(name: string): Promise<ContainerInfo | null> {
 		return this.inspectContainer(name);
+	}
+
+	/**
+	 * Single-shot memory snapshot via /containers/:id/stats?stream=false.
+	 * Returns null when the container is gone or the stats payload is empty
+	 * (Docker can return empty bodies for containers that just exited).
+	 * `usedBytes` mirrors the `docker stats` CLI computation: raw usage minus
+	 * inactive file-backed pages (page cache the kernel can drop on demand),
+	 * which avoids flagging containers that are merely reading/writing files.
+	 */
+	async containerStats(containerId: string): Promise<ContainerMemoryStats | null> {
+		const res = await this.request('GET', `/containers/${containerId}/stats?stream=false`);
+		if (res.status === 404) {
+			await res.text();
+			return null;
+		}
+		if (!res.ok) {
+			const text = await res.text();
+			throw new Error(`Docker containerStats failed (${res.status}): ${text}`);
+		}
+		const text = await res.text();
+		if (text.trim() === '') return null;
+		const raw = JSON.parse(text) as RawContainerStats;
+		const usage = raw.memory_stats?.usage;
+		if (typeof usage !== 'number') return null;
+		const inactive =
+			raw.memory_stats?.stats?.inactive_file ??
+			raw.memory_stats?.stats?.total_inactive_file ??
+			raw.memory_stats?.stats?.cache ??
+			0;
+		const usedBytes = Math.max(0, usage - inactive);
+		return { usedBytes, rawUsageBytes: usage };
 	}
 
 	async containerLogs(

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -1663,11 +1663,7 @@ export class JobManager {
 			return;
 		}
 
-		const transitions = await syncAllContainerStatuses(
-			this.deps.db,
-			this.deps.docker,
-			this.deps.wsManager,
-		);
+		const transitions = await syncAllContainerStatuses(this.buildContainerDeps());
 
 		for (const transition of transitions) {
 			await this.handleContainerTransition(transition);

--- a/packages/server/test/container-sync.test.ts
+++ b/packages/server/test/container-sync.test.ts
@@ -7,14 +7,21 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import type { Env } from '../src/lib/types';
 import {
+	type ContainerDeps,
 	type ProjectRow,
 	provisionContainer,
 	stopContainerGracefully,
 	syncAllContainerStatuses,
 } from '../src/services/containers';
+import type { DockerClient } from '../src/services/docker';
 import { LogStreamBroker } from '../src/services/log-stream-broker';
+import type { WebSocketManager } from '../src/services/ws';
 import { safeClose } from './helpers';
 import { authHeader, createStubDocker, createTestApp, createTestProject } from './helpers/app';
+
+function deps(docker: DockerClient, wsManager?: WebSocketManager): ContainerDeps {
+	return { db, docker, dataDir: '/tmp/hezo-test-unused', wsManager };
+}
 
 let db: PGlite;
 let app: Hono<Env>;
@@ -50,7 +57,7 @@ describe('syncAllContainerStatuses', () => {
 	it('does nothing when no projects have containers', async () => {
 		await db.query('UPDATE projects SET container_id = NULL');
 		const mockDocker = createStubDocker({ inspectContainer: vi.fn() });
-		await syncAllContainerStatuses(db, mockDocker);
+		await syncAllContainerStatuses(deps(mockDocker));
 		expect(mockDocker.inspectContainer).not.toHaveBeenCalled();
 	});
 
@@ -70,7 +77,7 @@ describe('syncAllContainerStatuses', () => {
 			inspectContainer: vi.fn().mockResolvedValue(null),
 		});
 
-		await syncAllContainerStatuses(db, mockDocker);
+		await syncAllContainerStatuses(deps(mockDocker));
 
 		const result = await db.query<{ container_status: string; container_id: string | null }>(
 			'SELECT container_status, container_id FROM projects WHERE id = $1',
@@ -97,7 +104,7 @@ describe('syncAllContainerStatuses', () => {
 			inspectContainer: vi.fn().mockResolvedValue(null),
 		});
 
-		await syncAllContainerStatuses(db, mockDocker);
+		await syncAllContainerStatuses(deps(mockDocker));
 
 		const result = await db.query<{ container_error: string | null }>(
 			'SELECT container_error FROM projects WHERE id = $1',
@@ -140,7 +147,7 @@ describe('syncAllContainerStatuses', () => {
 			}),
 		});
 
-		await syncAllContainerStatuses(db, mockDocker);
+		await syncAllContainerStatuses(deps(mockDocker));
 
 		const result = await db.query<{
 			container_status: string;
@@ -174,7 +181,7 @@ describe('syncAllContainerStatuses', () => {
 			inspectContainer: vi.fn().mockRejectedValue(new Error('EPIPE')),
 		});
 
-		await syncAllContainerStatuses(db, mockDocker);
+		await syncAllContainerStatuses(deps(mockDocker));
 
 		const result = await db.query<{ container_status: string; container_id: string | null }>(
 			'SELECT container_status, container_id FROM projects WHERE id = $1',
@@ -202,7 +209,7 @@ describe('syncAllContainerStatuses', () => {
 			}),
 		});
 
-		await syncAllContainerStatuses(db, mockDocker);
+		await syncAllContainerStatuses(deps(mockDocker));
 
 		const result = await db.query<{ container_status: string }>(
 			'SELECT container_status FROM projects WHERE id = $1',
@@ -229,7 +236,7 @@ describe('syncAllContainerStatuses', () => {
 			}),
 		});
 
-		await syncAllContainerStatuses(db, mockDocker);
+		await syncAllContainerStatuses(deps(mockDocker));
 
 		const result = await db.query<{ container_status: string }>(
 			'SELECT container_status FROM projects WHERE id = $1',
@@ -255,7 +262,7 @@ describe('syncAllContainerStatuses', () => {
 		});
 		const mockWsManager = { broadcast: vi.fn() } as any;
 
-		await syncAllContainerStatuses(db, mockDocker, mockWsManager);
+		await syncAllContainerStatuses(deps(mockDocker, mockWsManager));
 
 		expect(mockWsManager.broadcast).toHaveBeenCalled();
 		const [room, event] = mockWsManager.broadcast.mock.calls.find(
@@ -295,9 +302,168 @@ describe('syncAllContainerStatuses', () => {
 		});
 		const mockWsManager = { broadcast: vi.fn() } as any;
 
-		await syncAllContainerStatuses(db, mockDocker, mockWsManager);
+		await syncAllContainerStatuses(deps(mockDocker, mockWsManager));
 
 		expect(mockWsManager.broadcast).not.toHaveBeenCalled();
+	});
+
+	it('auto-stops a running container that exceeds the memory limit', async () => {
+		await db.query(
+			'UPDATE projects SET container_id = NULL, container_status = NULL, container_error = NULL WHERE team_id = $1',
+			[teamId],
+		);
+
+		const projectRes = await createTestProject(db, teamId, {
+			name: 'Memory Hog Project',
+			description: 'Test project.',
+		});
+		const projectId = (await projectRes.json()).data.id;
+		await new Promise((r) => setTimeout(r, 100));
+
+		await db.query(
+			"UPDATE projects SET container_id = 'memory-hog-container', container_status = 'running'::container_status WHERE id = $1",
+			[projectId],
+		);
+
+		const overLimitBytes = 13 * 1024 ** 3;
+		const stopContainer = vi.fn().mockResolvedValue(undefined);
+		const mockDocker = createStubDocker({
+			inspectContainer: vi.fn().mockResolvedValue({
+				State: { Running: true, Status: 'running' },
+			}),
+			containerStats: vi.fn().mockResolvedValue({
+				usedBytes: overLimitBytes,
+				rawUsageBytes: overLimitBytes,
+			}),
+			stopContainer,
+			containerLogs: vi.fn().mockResolvedValue({ arrayBuffer: async () => new ArrayBuffer(0) }),
+		});
+		const mockWsManager = { broadcast: vi.fn() } as any;
+
+		await syncAllContainerStatuses(deps(mockDocker, mockWsManager));
+
+		expect(stopContainer).toHaveBeenCalledWith('memory-hog-container');
+
+		const result = await db.query<{ container_status: string; container_error: string | null }>(
+			'SELECT container_status, container_error FROM projects WHERE id = $1',
+			[projectId],
+		);
+		expect(result.rows[0].container_status).toBe('error');
+		expect(result.rows[0].container_error).toContain('13.00 GiB');
+		expect(result.rows[0].container_error).toContain('12 GiB');
+		expect(result.rows[0].container_error).toMatch(/restart/i);
+
+		expect(mockWsManager.broadcast).toHaveBeenCalled();
+	});
+
+	it('leaves a running container untouched when memory is within budget', async () => {
+		await db.query(
+			'UPDATE projects SET container_id = NULL, container_status = NULL, container_error = NULL WHERE team_id = $1',
+			[teamId],
+		);
+
+		const projectRes = await createTestProject(db, teamId, {
+			name: 'Memory Frugal Project',
+			description: 'Test project.',
+		});
+		const projectId = (await projectRes.json()).data.id;
+		await new Promise((r) => setTimeout(r, 100));
+
+		await db.query(
+			"UPDATE projects SET container_id = 'frugal-container', container_status = 'running'::container_status WHERE id = $1",
+			[projectId],
+		);
+
+		const stopContainer = vi.fn().mockResolvedValue(undefined);
+		const mockDocker = createStubDocker({
+			inspectContainer: vi.fn().mockResolvedValue({
+				State: { Running: true, Status: 'running' },
+			}),
+			containerStats: vi.fn().mockResolvedValue({
+				usedBytes: 4 * 1024 ** 3,
+				rawUsageBytes: 4 * 1024 ** 3,
+			}),
+			stopContainer,
+		});
+
+		await syncAllContainerStatuses(deps(mockDocker));
+
+		expect(stopContainer).not.toHaveBeenCalled();
+
+		const result = await db.query<{ container_status: string; container_error: string | null }>(
+			'SELECT container_status, container_error FROM projects WHERE id = $1',
+			[projectId],
+		);
+		expect(result.rows[0].container_status).toBe('running');
+		expect(result.rows[0].container_error).toBeNull();
+	});
+
+	it('does not poll stats for stopped containers', async () => {
+		await db.query(
+			'UPDATE projects SET container_id = NULL, container_status = NULL, container_error = NULL WHERE team_id = $1',
+			[teamId],
+		);
+
+		const projectRes = await createTestProject(db, teamId, {
+			name: 'Already Stopped Project',
+			description: 'Test project.',
+		});
+		const projectId = (await projectRes.json()).data.id;
+		await new Promise((r) => setTimeout(r, 100));
+
+		await db.query(
+			"UPDATE projects SET container_id = 'already-stopped', container_status = 'stopped'::container_status WHERE id = $1",
+			[projectId],
+		);
+
+		const containerStats = vi.fn();
+		const mockDocker = createStubDocker({
+			inspectContainer: vi.fn().mockResolvedValue({
+				State: { Running: false, Status: 'exited', ExitCode: 0 },
+			}),
+			containerStats,
+		});
+
+		await syncAllContainerStatuses(deps(mockDocker));
+
+		expect(containerStats).not.toHaveBeenCalled();
+	});
+
+	it('survives a stats transport error without stopping the container', async () => {
+		await db.query(
+			'UPDATE projects SET container_id = NULL, container_status = NULL, container_error = NULL WHERE team_id = $1',
+			[teamId],
+		);
+
+		const projectRes = await createTestProject(db, teamId, {
+			name: 'Stats Flake Project',
+			description: 'Test project.',
+		});
+		const projectId = (await projectRes.json()).data.id;
+		await new Promise((r) => setTimeout(r, 100));
+
+		await db.query(
+			"UPDATE projects SET container_id = 'flake-container', container_status = 'running'::container_status WHERE id = $1",
+			[projectId],
+		);
+
+		const stopContainer = vi.fn().mockResolvedValue(undefined);
+		const mockDocker = createStubDocker({
+			inspectContainer: vi.fn().mockResolvedValue({
+				State: { Running: true, Status: 'running' },
+			}),
+			containerStats: vi.fn().mockRejectedValue(new Error('EPIPE')),
+			stopContainer,
+		});
+
+		await syncAllContainerStatuses(deps(mockDocker));
+
+		expect(stopContainer).not.toHaveBeenCalled();
+		const result = await db.query<{ container_status: string }>(
+			'SELECT container_status FROM projects WHERE id = $1',
+			[projectId],
+		);
+		expect(result.rows[0].container_status).toBe('running');
 	});
 });
 
@@ -359,8 +525,8 @@ describe('provisionContainer broadcasting', () => {
 			`${dataDir}/teams/${project.team_id}/projects/${project.id}/assets`,
 		);
 
-		expect(hostConfig.Memory).toBeGreaterThan(0);
-		expect(hostConfig.MemorySwap).toBe(hostConfig.Memory);
+		expect(hostConfig.Memory).toBeUndefined();
+		expect(hostConfig.MemorySwap).toBeUndefined();
 	});
 
 	it('keeps container name and bind mounts stable when the project is renamed', async () => {
@@ -726,7 +892,7 @@ describe('syncAllContainerStatuses with stopping status', () => {
 		});
 		const mockWsManager = { broadcast: vi.fn() } as any;
 
-		await syncAllContainerStatuses(db, mockDocker, mockWsManager);
+		await syncAllContainerStatuses(deps(mockDocker, mockWsManager));
 
 		const result = await db.query<{ container_status: string }>(
 			'SELECT container_status FROM projects WHERE id = $1',

--- a/packages/server/test/db-client.test.ts
+++ b/packages/server/test/db-client.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from 'vitest';
-import { isRecoverablePgInitError } from '../src/db/client';
+import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { isRecoverablePgInitError, openPersistentDb, PgDataCorruptError } from '../src/db/client';
 
 describe('isRecoverablePgInitError', () => {
 	it('matches PGlite WASM init failures', () => {
@@ -10,7 +13,91 @@ describe('isRecoverablePgInitError', () => {
 		).toBe(true);
 	});
 
+	it('matches WASM Aborted() runtime errors', () => {
+		expect(
+			isRecoverablePgInitError(
+				new Error('RuntimeError: Aborted(). Build with -sASSERTIONS for more info.'),
+			),
+		).toBe(true);
+	});
+
+	it('matches bare Aborted() strings', () => {
+		expect(isRecoverablePgInitError(new Error('Aborted()'))).toBe(true);
+	});
+
+	it('matches any WebAssembly.RuntimeError regardless of message', () => {
+		expect(isRecoverablePgInitError(new WebAssembly.RuntimeError('unreachable'))).toBe(true);
+	});
+
 	it('ignores unrelated errors', () => {
 		expect(isRecoverablePgInitError(new Error('connection refused'))).toBe(false);
+	});
+});
+
+describe('openPersistentDb', () => {
+	let dataDir: string;
+
+	beforeEach(() => {
+		dataDir = mkdtempSync(join(tmpdir(), 'hezo-pgdata-test-'));
+	});
+
+	afterEach(() => {
+		rmSync(dataDir, { recursive: true, force: true });
+	});
+
+	it('throws PgDataCorruptError when pgdata is corrupt — never auto-resets', async () => {
+		const pgDataPath = join(dataDir, 'pgdata');
+		mkdirSync(pgDataPath, { recursive: true });
+		writeFileSync(join(pgDataPath, 'PG_VERSION'), 'garbage-not-a-real-pg-version');
+		writeFileSync(join(pgDataPath, 'postmaster.pid'), '99999\n/tmp/pglite\n');
+
+		await expect(openPersistentDb(dataDir)).rejects.toBeInstanceOf(PgDataCorruptError);
+
+		const entries = readdirSync(dataDir);
+		expect(entries).toContain('pgdata');
+		expect(entries.filter((name) => name.startsWith('pgdata.corrupt.')).length).toBe(0);
+
+		try {
+			await openPersistentDb(dataDir);
+			throw new Error('expected throw');
+		} catch (err) {
+			expect(err).toBeInstanceOf(PgDataCorruptError);
+			const corruptErr = err as PgDataCorruptError;
+			expect(corruptErr.message).toContain(pgDataPath);
+			expect(corruptErr.message).toContain('--reset');
+			expect(corruptErr.message).toContain('pgdata.corrupt.<timestamp>');
+			expect(corruptErr.pgDataPath).toBe(pgDataPath);
+		}
+	});
+
+	it('renames pgdata aside (never deletes) and starts fresh when reset is true', async () => {
+		const pgDataPath = join(dataDir, 'pgdata');
+		mkdirSync(pgDataPath, { recursive: true });
+		writeFileSync(join(pgDataPath, 'PG_VERSION'), 'garbage-not-a-real-pg-version');
+
+		const db = await openPersistentDb(dataDir, { reset: true });
+		try {
+			const result = await db.query<{ one: number }>('SELECT 1 AS one');
+			expect(result.rows[0]?.one).toBe(1);
+		} finally {
+			await db.close();
+		}
+
+		const corruptDirs = readdirSync(dataDir).filter((name) => name.startsWith('pgdata.corrupt.'));
+		expect(corruptDirs.length).toBe(1);
+		expect(readdirSync(join(dataDir, corruptDirs[0]!))).toContain('PG_VERSION');
+	});
+
+	it('is a no-op on reset when pgdata does not yet exist', async () => {
+		const db = await openPersistentDb(dataDir, { reset: true });
+		try {
+			const result = await db.query<{ one: number }>('SELECT 1 AS one');
+			expect(result.rows[0]?.one).toBe(1);
+		} finally {
+			await db.close();
+		}
+
+		const corruptDirs = readdirSync(dataDir).filter((name) => name.startsWith('pgdata.corrupt.'));
+		expect(corruptDirs.length).toBe(0);
 	});
 });

--- a/packages/server/test/helpers/app.ts
+++ b/packages/server/test/helpers/app.ts
@@ -33,6 +33,7 @@ const STUB_DOCKER_METHODS = {
 		State: { Status: 'running', Running: true, Pid: 1, ExitCode: 0 },
 		Config: { Image: 'stub' },
 	}),
+	containerStats: async () => null,
 	containerLogs: async () => ({ arrayBuffer: async () => new ArrayBuffer(0) }),
 	execCreate: async () => {
 		throw new Error('execCreate not mocked — pass a mock docker via RunnerDeps');


### PR DESCRIPTION
## Summary

Two related fixes for symptoms surfaced while the dev server was crashing:

- **Safer pgdata corruption recovery.** A SIGTERM (or any unclean exit) during a PGlite checkpoint can leave the on-disk pgdata half-written; the next boot then aborts at the WASM level (`RuntimeError: Aborted()`) and the dev server falls back to the minimal app. The previous behaviour either auto-wiped pgdata (matching a narrow set of error strings only — `Aborted()` was not in the set) or, after a recent change, auto-renamed it aside. Both were silent data resets from the user's perspective. Now `openPersistentDb` throws `PgDataCorruptError` with a clear message telling the user to restart with `--reset` and quoting the `pgdata.corrupt.<timestamp>` path that will be created; `--reset` itself renames the existing pgdata aside (never deletes). `isRecoverablePgInitError` also treats any `WebAssembly.RuntimeError` as recoverable, covering both `Aborted()` and `unreachable` traps.

- **Auto-stop project containers using >12 GiB RAM.** Replaces the per-container Docker `Memory` cap (which silently OOM-killed work without explanation) with active monitoring inside the existing 1 Hz sync loop. When `containerStats` reports working-set memory above 12 GiB, the container is stopped and `container_error` is populated with a user-facing explanation:

  > Container was using 13.42 GiB of RAM, above the 12 GiB safety limit, and was stopped automatically to keep your machine responsive. Restart the container to try again, or investigate what was using the memory before restarting.

  The existing `ContainerStatusBanner` on project pages and the container detail page (`/projects/$projectId/container`) already render `container_error`, so this lands with no new UI. In-flight runs are failed with reason `container_error` and a row_change broadcast nudges clients to refetch.

Memory accounting matches the `docker stats` CLI (`usage - inactive_file`) so containers merely reading/writing files don't trip the limit.

## Test plan

- [x] `bunx vitest run test/db-client.test.ts` — 8 tests (5 unit + 3 integration covering corrupt-throw, reset-renames-aside, no-op-on-fresh)
- [x] `bunx vitest run test/container-sync.test.ts` — 24 tests (20 existing + 4 new: auto-stop at >12 GiB, no-op under budget, no stats poll for stopped containers, survives transport errors)
- [x] `bunx vitest run test/startup.test.ts test/cli.test.ts` — adjacent suites green
- [x] `bun run typecheck` — green across all packages
- [ ] Manual: kill dev server mid-checkpoint, restart — confirm `PgDataCorruptError` message is printed and the dev server falls back to the minimal app until `--reset` is passed
- [ ] Manual: spin up a project container that allocates >12 GiB — confirm banner appears with the memory message and Restart works