### PR TITLE
test(browser): match run-comment deep-link test by task_id, not trigger_source

### DIFF
--- a/test/browser/run-trigger-reason.spec.ts
+++ b/test/browser/run-trigger-reason.spec.ts
@@ -42,6 +42,7 @@ async function createStartupProject(
 interface RunListItem {
 	id: string;
 	status: string;
+	task_id: string | null;
 	trigger_source: string | null;
 	trigger_actor_slug: string | null;
 	trigger_comment_id: string | null;
@@ -166,17 +167,21 @@ test('task link on run detail page scrolls to the run comment', async ({ page })
 	const task = ((await taskRes.json()) as { data: { id: string; identifier: string } }).data;
 
 	const taskIdLower = task.identifier.toLowerCase();
-	const assignmentRun = await waitForRunWithTrigger(
+	// Match by task_id instead of trigger_source: a frequent test-mode heartbeat
+	// cron (every 1s) can race the assignment wakeup — the first heartbeat fires
+	// before the assignment wakeup is claimed, picks up the only actionable task
+	// (this one), succeeds, and `assignmentWakeupAlreadyServed` then retires the
+	// assignment wakeup as redundant. The deep-link being tested works for any
+	// run on this task since every run posts a run_comment_id back to it.
+	const taskRun = await waitForRunWithTrigger(
 		page,
 		project.slug,
 		architect.id,
 		token,
-		(r) => r.trigger_source === 'assignment',
+		(r) => r.task_id === task.id,
 	);
 
-	await page.goto(
-		`/projects/${project.slug}/agents/${architect.id}/executions/${assignmentRun.id}`,
-	);
+	await page.goto(`/projects/${project.slug}/agents/${architect.id}/executions/${taskRun.id}`);
 
 	const taskLink = page.locator(`a[href*="/tasks/${taskIdLower}"]`).first();
 	await expect(taskLink).toBeVisible({ timeout: 15000 });


### PR DESCRIPTION
## Summary
- `run-trigger-reason.spec.ts` › *task link on run detail page scrolls to the run comment* polled forever for a run whose `trigger_source === 'assignment'`, so when the heartbeat cron won the race it silently lost the run it should have asserted on.
- Reason for the race: test-mode runs heartbeat every 1s (vs the 60-minute floor in prod). On a fresh agent, the heartbeat can fire, claim the only actionable task, and complete a run *before* the assignment wakeup gets its turn. `assignmentWakeupAlreadyServed` (added in #151) then correctly retires the now-redundant assignment wakeup, so no assignment-sourced run ever exists.
- The deep-link being verified works for any run on the task — every run posts a `run_comment_id` back. Match by `task_id` instead so the test is deterministic regardless of which trigger source wins.

## Test plan
- [x] `bun run test --browser --pattern run-trigger-reason` locally — 3 specs pass
- [x] Spec still asserts the original deep-link behaviour (`#comment-<uuid>` href, scroll lands on highlighted comment, `scrollTop > 100`)
- [ ] CI confirms the spec is no longer flaky

🤖 Generated with [Claude Code](https://claude.com/claude-code)