### PR TITLE
fix(web): global inbox uses project slugs so badge matches the list

### DIFF
--- a/packages/server/src/routes/inbox.ts
+++ b/packages/server/src/routes/inbox.ts
@@ -99,9 +99,11 @@ inboxRoutes.get('/projects/:projectId/inbox/count', async (c) => {
 	const result = await db.query<{ unread: number }>(
 		`SELECT (
 		          (SELECT count(*) FROM admin_mentions
-		           WHERE team_id = $1 AND user_id = $2 AND read_at IS NULL)
+		           WHERE team_id = $1 AND user_id = $2
+		             AND read_at IS NULL AND archived_at IS NULL)
 		        + (SELECT count(*) FROM approvals
-		           WHERE team_id = $1 AND status = $3::approval_status)
+		           WHERE team_id = $1 AND status = $3::approval_status
+		             AND archived_at IS NULL)
 		        )::int AS unread`,
 		[teamId, auth.userId, ApprovalStatus.Pending],
 	);

--- a/packages/server/test/admin-mentions.test.ts
+++ b/packages/server/test/admin-mentions.test.ts
@@ -406,6 +406,50 @@ describe('GET /teams/:teamId/inbox/count', () => {
 		});
 		expect(res.status).toBe(403);
 	});
+
+	it('excludes archived rows so the badge cannot exceed the default-tab list', async () => {
+		await db.query('DELETE FROM approvals WHERE team_id = $1', [teamId]);
+
+		const taskIdLocal = await insertTask(captainId, 'Archived-row count test');
+		const { token: agentToken } = await mintAgentToken(
+			db,
+			masterKeyManager,
+			architectId,
+			teamId,
+			taskIdLocal,
+		);
+		const liveCommentId = await mcpComment(agentToken, taskIdLocal, '@admin live ask.');
+		const archivedUnreadCommentId = await mcpComment(
+			agentToken,
+			taskIdLocal,
+			'@admin pre-archived ask.',
+		);
+
+		await db.query(
+			`UPDATE admin_mentions SET archived_at = now()
+			 WHERE comment_id = $1 AND user_id = $2`,
+			[archivedUnreadCommentId, testAdminUserId],
+		);
+
+		await db.query(
+			`INSERT INTO approvals (team_id, type, requested_by_member_id, payload, status, archived_at)
+			 VALUES ($1, 'strategy'::approval_type, $2, '{}'::jsonb, 'pending'::approval_status, NULL),
+			        ($1, 'strategy'::approval_type, $2, '{}'::jsonb, 'pending'::approval_status, now())`,
+			[teamId, architectId],
+		);
+
+		const res = await app.request(`/api/projects/${projectSlug}/inbox/count`, {
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		const { unread } = (await res.json()).data as { unread: number };
+		// One live unread mention + one live pending approval. The archived unread
+		// mention and the archived pending approval don't appear in the default-tab
+		// list, so they must not inflate the badge either.
+		expect(unread).toBe(2);
+		// Confirm: the live items truly exist for the caller (sanity check).
+		expect(liveCommentId).toBeTruthy();
+	});
 });
 
 describe('POST /teams/:teamId/inbox/mentions/:mentionId/read', () => {

--- a/packages/web/src/components/inbox-view.tsx
+++ b/packages/web/src/components/inbox-view.tsx
@@ -10,7 +10,7 @@ import { FilterPills } from './ui/filter-pills';
 import { InfoTooltip } from './ui/info-tooltip';
 
 interface InboxViewProps {
-	teamIds: string[];
+	projectSlugs: string[];
 	scope: 'team' | 'global';
 }
 
@@ -61,13 +61,13 @@ function approvalSearch(a: Approval): string {
 		.toLowerCase();
 }
 
-export function InboxView({ teamIds, scope }: InboxViewProps) {
+export function InboxView({ projectSlugs, scope }: InboxViewProps) {
 	const [readFilter, setReadFilter] = useState<ReadFilter>('all');
 	const archivedView = readFilter === 'archived';
-	const { data: approvals, isLoading: approvalsLoading } = useAllApprovals(teamIds, {
+	const { data: approvals, isLoading: approvalsLoading } = useAllApprovals(projectSlugs, {
 		archived: archivedView,
 	});
-	const { data: mentions, isLoading: mentionsLoading } = useAllAdminMentions(teamIds, {
+	const { data: mentions, isLoading: mentionsLoading } = useAllAdminMentions(projectSlugs, {
 		archived: archivedView,
 	});
 	const [search, setSearch] = useState('');

--- a/packages/web/src/routes/home/inbox/index.tsx
+++ b/packages/web/src/routes/home/inbox/index.tsx
@@ -1,13 +1,13 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { InboxView } from '../../../components/inbox-view';
-import { useTeams } from '../../../hooks/use-teams';
+import { useAllVisibleProjects } from '../../../hooks/use-projects';
 
 function GlobalInboxPage() {
-	const { data: teams } = useTeams();
-	const teamIds = (teams ?? []).map((t) => t.slug);
+	const { projects } = useAllVisibleProjects();
+	const projectSlugs = projects.map((p) => p.slug);
 	return (
 		<div className="px-4 py-4 md:px-6 md:py-5 lg:px-8 lg:py-6">
-			<InboxView teamIds={teamIds} scope="global" />
+			<InboxView projectSlugs={projectSlugs} scope="global" />
 		</div>
 	);
 }

--- a/packages/web/src/routes/projects/$projectId/inbox/index.tsx
+++ b/packages/web/src/routes/projects/$projectId/inbox/index.tsx
@@ -3,7 +3,7 @@ import { InboxView } from '../../../../components/inbox-view';
 
 function InboxPage() {
 	const { projectId } = Route.useParams();
-	return <InboxView teamIds={[projectId]} scope="team" />;
+	return <InboxView projectSlugs={[projectId]} scope="team" />;
 }
 
 export const Route = createFileRoute('/projects/$projectId/inbox/')({

--- a/packages/web/test/inbox-global.test.tsx
+++ b/packages/web/test/inbox-global.test.tsx
@@ -1,6 +1,50 @@
-import { test } from 'vitest';
-import { renderApp } from './helpers/render';
-import { seedWorkspace } from './helpers/seed';
+import { waitFor } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { getTestContext, renderApp } from './helpers/render';
+import {
+	type SeededTask,
+	type SeededWorkspace,
+	seedProject,
+	seedTask,
+	seedWorkspace,
+} from './helpers/seed';
+
+async function seedAgentAdminMention(
+	workspace: SeededWorkspace,
+	task: SeededTask,
+	text: string,
+): Promise<{ commentId: string; mentionId: string }> {
+	const { db } = getTestContext();
+	const architect = workspace.agents.find((a) => a.slug === 'architect');
+	if (!architect) throw new Error('seedAgentAdminMention: architect agent missing');
+
+	const userRow = await db.query<{ user_id: string }>(
+		`SELECT mu.user_id FROM member_users mu
+		 JOIN members m ON m.id = mu.id
+		 WHERE m.team_id = $1 AND mu.role = 'admin'
+		 LIMIT 1`,
+		[workspace.team.id],
+	);
+	const userId = userRow.rows[0]?.user_id;
+	if (!userId) throw new Error('seedAgentAdminMention: no admin on team');
+
+	const commentRow = await db.query<{ id: string }>(
+		`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
+		 VALUES ($1, $2, 'text'::comment_content_type, $3::jsonb)
+		 RETURNING id`,
+		[task.id, architect.id, JSON.stringify({ text })],
+	);
+	const commentId = commentRow.rows[0].id;
+
+	const mentionRow = await db.query<{ id: string }>(
+		`INSERT INTO admin_mentions (team_id, task_id, comment_id, user_id)
+		 VALUES ($1, $2, $3, $4)
+		 RETURNING id`,
+		[workspace.team.id, task.id, commentId, userId],
+	);
+
+	return { commentId, mentionId: mentionRow.rows[0].id };
+}
 
 test('global inbox route mounts across all of the user teams', async () => {
 	const { findByRole } = await renderApp({
@@ -14,4 +58,28 @@ test('global inbox route mounts across all of the user teams', async () => {
 	// team the user belongs to). The page heading distinguishes it from the
 	// sidebar's per-team "Inbox" link.
 	await findByRole('heading', { name: 'Global inbox' });
+});
+
+test('global inbox lists mentions from any team and matches the header badge', async () => {
+	const { findByTestId, findAllByTestId } = await renderApp({
+		initialPath: '/home/inbox',
+		seed: async () => {
+			// Team A: no mentions — its slug should not be confused with project slugs.
+			await seedWorkspace();
+			// Team B: one unread admin mention sitting on a real task.
+			const wsB = await seedWorkspace();
+			const project = await seedProject(wsB, { name: 'Demo' });
+			const task = await seedTask(wsB, project, { title: 'A admin-decision ticket' });
+			await seedAgentAdminMention(wsB, task, '@admin — please weigh in on shipping the new flow.');
+		},
+	});
+
+	// The list renders the mention card seeded into Team B.
+	await waitFor(async () => expect((await findAllByTestId('mention-card')).length).toBe(1), {
+		timeout: 10_000,
+	});
+
+	// The header badge agrees with the list — same unread count, same source.
+	const badge = await findByTestId('app-header-inbox-badge', undefined, { timeout: 10_000 });
+	await waitFor(() => expect(badge.textContent).toContain('1'));
 });


### PR DESCRIPTION
## Summary

The header inbox badge would show e.g. **"1"** while `/home/inbox` rendered the **"All clear"** empty state. The badge and the list read from different sources:

- **Badge** — `useGlobalInboxUnreadCount` iterates `useAllVisibleProjects()` and calls `/api/projects/:projectSlug/inbox/count` per project, which resolves correctly.
- **Global inbox view** — `routes/home/inbox/index.tsx` iterated `useTeams()` and passed **team slugs** as the `teamIds` prop to `InboxView`, which forwards them to `/api/projects/:projectSlug/inbox/...`. The middleware's `resolveProject` only matches `projects.slug`, so every list call 404'd silently → empty list.

Team and project slugs are generated independently from the same name, so the two coincide only for the seed/HQ team. Any other team's mentions and approvals were invisible in the global view while their unread count kept inflating the badge.

## Fix

- `routes/home/inbox/index.tsx` now iterates `useAllVisibleProjects()` — same source the badge uses, so they can never disagree. With `UNIQUE(projects.team_id)` enforcing one project per team, this is equivalent to iterating teams but without the routing hazard.
- `InboxView`'s misleading `teamIds` prop is renamed to `projectSlugs`. The naming is what produced the bug; leaving the wrong label would invite the same mistake again.
- Defensively add `AND archived_at IS NULL` to both subqueries in `/inbox/count` so the badge can never exceed the default-tab list even if a future code path sets `archived_at` on an unread or pending row.

## Files

- `packages/web/src/routes/home/inbox/index.tsx`
- `packages/web/src/components/inbox-view.tsx`
- `packages/web/src/routes/projects/$projectId/inbox/index.tsx`
- `packages/server/src/routes/inbox.ts`
- `packages/server/test/admin-mentions.test.ts` (new test)
- `packages/web/test/inbox-global.test.tsx` (new assertion)

## Test plan

- [x] `bun run typecheck` clean
- [x] `bunx vitest run packages/server/test/admin-mentions.test.ts` — 15/15 pass, including the new archived-row exclusion test
- [x] `bun run test --skip-browser --pattern inbox` — 14/14 web inbox tests pass, including the new global-inbox list+badge agreement test
- [x] Biome clean on touched files
- [ ] Manual: badge in the header and the rendered list at `/home/inbox` show the same item; mark it read and both clear together; mobile viewport (375×800) renders the same