### PR TITLE
feat(server): per-project container memory limit + raise default to 16 GiB

### DIFF
--- a/packages/server/migrations/001_initial_schema.sql
+++ b/packages/server/migrations/001_initial_schema.sql
@@ -294,6 +294,7 @@ CREATE TABLE projects (
     container_last_logs TEXT,
     designated_repo_id  UUID,
     max_concurrent_runs INTEGER NOT NULL DEFAULT 3 CHECK (max_concurrent_runs >= 1),
+    memory_limit_gib    INTEGER NOT NULL DEFAULT 16 CHECK (memory_limit_gib >= 1),
     dev_ports               JSONB NOT NULL DEFAULT '[]'::jsonb,
     execution_started_at    TIMESTAMPTZ,
     created_at              TIMESTAMPTZ NOT NULL DEFAULT now(),

--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -445,6 +445,7 @@ projectsRoutes.patch('/projects/:projectId', async (c) => {
 		name?: string;
 		description?: string;
 		max_concurrent_runs?: number;
+		memory_limit_gib?: number;
 	}>();
 
 	const sets: string[] = [];
@@ -477,6 +478,14 @@ projectsRoutes.patch('/projects/:projectId', async (c) => {
 		}
 		sets.push(`max_concurrent_runs = $${idx}`);
 		params.push(body.max_concurrent_runs);
+		idx++;
+	}
+	if (body.memory_limit_gib !== undefined) {
+		if (!Number.isInteger(body.memory_limit_gib) || body.memory_limit_gib < 1) {
+			return err(c, 'INVALID_REQUEST', 'memory_limit_gib must be an integer ≥ 1', 400);
+		}
+		sets.push(`memory_limit_gib = $${idx}`);
+		params.push(body.memory_limit_gib);
 		idx++;
 	}
 

--- a/packages/server/src/services/container-logs.ts
+++ b/packages/server/src/services/container-logs.ts
@@ -90,6 +90,7 @@ export class ContainerLogStreamer {
 			{ follow: true, tail: 200, stdout: true, stderr: true },
 			abortController.signal,
 		);
+		if (res === null) return;
 
 		const reader = res.body?.getReader();
 		if (!reader) return;

--- a/packages/server/src/services/containers.ts
+++ b/packages/server/src/services/containers.ts
@@ -93,11 +93,14 @@ const PORT_POOL_END = 19999;
 const LAST_LOGS_CAP_BYTES = 32 * 1024;
 
 /**
- * Threshold above which the sync loop stops a running container automatically.
- * Picked to leave headroom on a 16 GB laptop after Docker Desktop's own VM
- * overhead, the dev server (PGlite + embeddings model), and the host OS.
+ * Default per-container working-set ceiling, used when a project has not set
+ * its own `projects.memory_limit_gib`. The sync loop stops the container when
+ * working-set memory crosses this threshold and records an explanation in
+ * `container_error`. Override per project from the Settings page.
  */
-export const CONTAINER_MEMORY_KILL_BYTES = 12 * 1024 * 1024 * 1024;
+export const DEFAULT_MEMORY_LIMIT_GIB = 16;
+
+const memoryLimitBytes = (gib: number) => gib * 1024 ** 3;
 
 /**
  * Pull a one-shot tail of the container's stdout+stderr log buffer. Used to
@@ -115,6 +118,7 @@ export async function captureContainerLogs(
 			stdout: true,
 			stderr: true,
 		});
+		if (res === null) return null;
 		const raw = new Uint8Array(await res.arrayBuffer());
 		const decoder = new TextDecoder();
 		const chunks: string[] = [];
@@ -524,8 +528,9 @@ export async function syncContainerStatus(
 }
 
 /**
- * If the container's working-set memory crosses {@link CONTAINER_MEMORY_KILL_BYTES},
- * stop it and record an explanatory message in `container_error`. The banner and
+ * If the container's working-set memory crosses the per-project memory ceiling
+ * (`projects.memory_limit_gib`, default {@link DEFAULT_MEMORY_LIMIT_GIB}), stop
+ * it and record an explanatory message in `container_error`. The banner and
  * container page both surface that field. Returns the synthesised status when the
  * container was stopped, or null when it was within budget or stats were unavailable.
  *
@@ -537,6 +542,7 @@ async function enforceContainerMemoryLimit(
 	projectId: string,
 	teamId: string,
 	containerId: string,
+	memoryLimitGib: number,
 ): Promise<string | null> {
 	const { db, docker } = deps;
 
@@ -548,14 +554,14 @@ async function enforceContainerMemoryLimit(
 		return null;
 	}
 	if (!stats) return null;
-	if (stats.usedBytes <= CONTAINER_MEMORY_KILL_BYTES) return null;
+	const limitBytes = memoryLimitBytes(memoryLimitGib);
+	if (stats.usedBytes <= limitBytes) return null;
 
 	const usedGiB = (stats.usedBytes / 1024 ** 3).toFixed(2);
-	const limitGiB = (CONTAINER_MEMORY_KILL_BYTES / 1024 ** 3).toFixed(0);
 	const errorMessage =
-		`Container was using ${usedGiB} GiB of RAM, above the ${limitGiB} GiB safety limit, ` +
+		`Container was using ${usedGiB} GiB of RAM, above the ${memoryLimitGib} GiB safety limit, ` +
 		`and was stopped automatically to keep your machine responsive. Restart the container ` +
-		`to try again, or investigate what was using the memory before restarting.`;
+		`to try again, or raise the limit on the project settings page.`;
 
 	const lastLogs = await captureContainerLogs(docker, containerId);
 
@@ -578,7 +584,7 @@ async function enforceContainerMemoryLimit(
 	);
 
 	log.warn(
-		`Auto-stopped container ${containerId.slice(0, 12)} for project ${projectId}: used ${usedGiB} GiB (> ${limitGiB} GiB)`,
+		`Auto-stopped container ${containerId.slice(0, 12)} for project ${projectId}: used ${usedGiB} GiB (> ${memoryLimitGib} GiB)`,
 	);
 
 	await failProjectRuns(deps, projectId, teamId, 'container_error').catch((e) =>
@@ -598,8 +604,9 @@ export async function syncAllContainerStatuses(
 		team_id: string;
 		container_id: string;
 		container_status: string | null;
+		memory_limit_gib: number;
 	}>(
-		'SELECT id, team_id, container_id, container_status FROM projects WHERE container_id IS NOT NULL',
+		'SELECT id, team_id, container_id, container_status, memory_limit_gib FROM projects WHERE container_id IS NOT NULL',
 	);
 
 	const transitions: ContainerTransition[] = [];
@@ -619,6 +626,7 @@ export async function syncAllContainerStatuses(
 				project.id,
 				project.team_id,
 				project.container_id,
+				project.memory_limit_gib,
 			);
 			if (overrideStatus !== null) {
 				newStatus = overrideStatus;

--- a/packages/server/src/services/docker.ts
+++ b/packages/server/src/services/docker.ts
@@ -11,8 +11,6 @@ interface ContainerConfig {
 		Binds?: string[];
 		PortBindings?: Record<string, Array<{ HostPort: string }>>;
 		ExtraHosts?: string[];
-		Memory?: number;
-		MemorySwap?: number;
 	};
 	ExposedPorts?: Record<string, object>;
 }
@@ -260,7 +258,7 @@ export class DockerClient {
 		containerId: string,
 		opts: { follow?: boolean; tail?: number; stdout?: boolean; stderr?: boolean } = {},
 		signal?: AbortSignal,
-	): Promise<Response> {
+	): Promise<Response | null> {
 		const params = new URLSearchParams({
 			follow: String(opts.follow ?? true),
 			stdout: String(opts.stdout ?? true),
@@ -272,6 +270,10 @@ export class DockerClient {
 			unix: this.socketPath,
 			signal,
 		} as RequestInit & { unix: string });
+		if (res.status === 404) {
+			await res.text();
+			return null;
+		}
 		if (!res.ok) {
 			const text = await res.text();
 			throw new Error(`Docker containerLogs failed (${res.status}): ${text}`);

--- a/packages/server/test/container-sync.test.ts
+++ b/packages/server/test/container-sync.test.ts
@@ -307,7 +307,7 @@ describe('syncAllContainerStatuses', () => {
 		expect(mockWsManager.broadcast).not.toHaveBeenCalled();
 	});
 
-	it('auto-stops a running container that exceeds the memory limit', async () => {
+	it('auto-stops a running container that exceeds the default memory limit', async () => {
 		await db.query(
 			'UPDATE projects SET container_id = NULL, container_status = NULL, container_error = NULL WHERE team_id = $1',
 			[teamId],
@@ -325,7 +325,7 @@ describe('syncAllContainerStatuses', () => {
 			[projectId],
 		);
 
-		const overLimitBytes = 13 * 1024 ** 3;
+		const overLimitBytes = 17 * 1024 ** 3;
 		const stopContainer = vi.fn().mockResolvedValue(undefined);
 		const mockDocker = createStubDocker({
 			inspectContainer: vi.fn().mockResolvedValue({
@@ -349,11 +349,60 @@ describe('syncAllContainerStatuses', () => {
 			[projectId],
 		);
 		expect(result.rows[0].container_status).toBe('error');
-		expect(result.rows[0].container_error).toContain('13.00 GiB');
-		expect(result.rows[0].container_error).toContain('12 GiB');
+		expect(result.rows[0].container_error).toContain('17.00 GiB');
+		expect(result.rows[0].container_error).toContain('16 GiB');
 		expect(result.rows[0].container_error).toMatch(/restart/i);
 
 		expect(mockWsManager.broadcast).toHaveBeenCalled();
+	});
+
+	it('honors a per-project memory_limit_gib override and interpolates it into the error', async () => {
+		await db.query(
+			'UPDATE projects SET container_id = NULL, container_status = NULL, container_error = NULL WHERE team_id = $1',
+			[teamId],
+		);
+
+		const projectRes = await createTestProject(db, teamId, {
+			name: 'Tighter Limit Project',
+			description: 'Test project.',
+		});
+		const projectId = (await projectRes.json()).data.id;
+		await new Promise((r) => setTimeout(r, 100));
+
+		await db.query(
+			`UPDATE projects
+			 SET container_id = 'tight-container',
+			     container_status = 'running'::container_status,
+			     memory_limit_gib = 8
+			 WHERE id = $1`,
+			[projectId],
+		);
+
+		const usageBytes = 9 * 1024 ** 3;
+		const stopContainer = vi.fn().mockResolvedValue(undefined);
+		const mockDocker = createStubDocker({
+			inspectContainer: vi.fn().mockResolvedValue({
+				State: { Running: true, Status: 'running' },
+			}),
+			containerStats: vi.fn().mockResolvedValue({
+				usedBytes: usageBytes,
+				rawUsageBytes: usageBytes,
+			}),
+			stopContainer,
+			containerLogs: vi.fn().mockResolvedValue({ arrayBuffer: async () => new ArrayBuffer(0) }),
+		});
+
+		await syncAllContainerStatuses(deps(mockDocker));
+
+		expect(stopContainer).toHaveBeenCalledWith('tight-container');
+
+		const result = await db.query<{ container_status: string; container_error: string | null }>(
+			'SELECT container_status, container_error FROM projects WHERE id = $1',
+			[projectId],
+		);
+		expect(result.rows[0].container_status).toBe('error');
+		expect(result.rows[0].container_error).toContain('9.00 GiB');
+		expect(result.rows[0].container_error).toContain('8 GiB');
 	});
 
 	it('leaves a running container untouched when memory is within budget', async () => {
@@ -396,6 +445,47 @@ describe('syncAllContainerStatuses', () => {
 		);
 		expect(result.rows[0].container_status).toBe('running');
 		expect(result.rows[0].container_error).toBeNull();
+	});
+
+	it('records the running→stopped transition cleanly when the container is removed before log capture', async () => {
+		await db.query(
+			'UPDATE projects SET container_id = NULL, container_status = NULL, container_error = NULL WHERE team_id = $1',
+			[teamId],
+		);
+
+		const projectRes = await createTestProject(db, teamId, {
+			name: 'Log Race Project',
+			description: 'Test project.',
+		});
+		const projectId = (await projectRes.json()).data.id;
+		await new Promise((r) => setTimeout(r, 100));
+
+		await db.query(
+			"UPDATE projects SET container_id = 'race-1', container_status = 'running'::container_status, container_last_logs = NULL WHERE id = $1",
+			[projectId],
+		);
+
+		const mockDocker = createStubDocker({
+			inspectContainer: vi.fn().mockResolvedValue({
+				Id: 'race-1',
+				State: { Running: false, Status: 'exited', ExitCode: 137 },
+			}),
+			containerLogs: vi.fn().mockResolvedValue(null),
+		});
+
+		await expect(syncAllContainerStatuses(deps(mockDocker))).resolves.not.toThrow();
+
+		const result = await db.query<{
+			container_status: string;
+			container_error: string | null;
+			container_last_logs: string | null;
+		}>(
+			'SELECT container_status, container_error, container_last_logs FROM projects WHERE id = $1',
+			[projectId],
+		);
+		expect(result.rows[0].container_status).toBe('stopped');
+		expect(result.rows[0].container_error).toContain('exited with code 137');
+		expect(result.rows[0].container_last_logs).toBeNull();
 	});
 
 	it('does not poll stats for stopped containers', async () => {

--- a/packages/web/src/hooks/use-projects.ts
+++ b/packages/web/src/hooks/use-projects.ts
@@ -15,6 +15,7 @@ export interface Project {
 	description: string;
 	is_internal?: boolean;
 	max_concurrent_runs: number;
+	memory_limit_gib: number;
 	docker_base_image: string | null;
 	container_id: string | null;
 	container_status: 'creating' | 'running' | 'stopping' | 'stopped' | 'error' | null;
@@ -140,7 +141,12 @@ export function useCreateProjectWithTeam() {
 
 export function useUpdateProject(projectId: string) {
 	return useOptimisticMutation<
-		{ name?: string; description?: string; max_concurrent_runs?: number },
+		{
+			name?: string;
+			description?: string;
+			max_concurrent_runs?: number;
+			memory_limit_gib?: number;
+		},
 		Project,
 		Project
 	>({

--- a/packages/web/src/routes/projects/$projectId/settings/index.tsx
+++ b/packages/web/src/routes/projects/$projectId/settings/index.tsx
@@ -16,6 +16,7 @@ function ProjectSettingsPage() {
 	const [name, setName] = useState('');
 	const [description, setDescription] = useState('');
 	const [maxRuns, setMaxRuns] = useState('1');
+	const [memoryLimit, setMemoryLimit] = useState('16');
 	const [editing, setEditing] = useState(false);
 
 	if (!project) return null;
@@ -25,17 +26,23 @@ function ProjectSettingsPage() {
 		setName(project.name);
 		setDescription(project.description ?? '');
 		setMaxRuns(String(project.max_concurrent_runs));
+		setMemoryLimit(String(project.memory_limit_gib));
 		setEditing(true);
 	}
 
 	async function handleSave(e: React.FormEvent) {
 		e.preventDefault();
 		const parsedMaxRuns = Number(maxRuns);
+		const parsedMemoryLimit = Number(memoryLimit);
 		await updateProject.mutateAsync({
 			name: name.trim() || undefined,
 			description: description.trim(),
 			max_concurrent_runs:
 				Number.isInteger(parsedMaxRuns) && parsedMaxRuns >= 1 ? parsedMaxRuns : undefined,
+			memory_limit_gib:
+				Number.isInteger(parsedMemoryLimit) && parsedMemoryLimit >= 1
+					? parsedMemoryLimit
+					: undefined,
 		});
 		setEditing(false);
 	}
@@ -66,6 +73,19 @@ function ProjectSettingsPage() {
 							Agents that may run at once in this project. Different agents work different tickets
 							in parallel; one ticket still runs a single agent at a time.
 						</p>
+						<Input
+							label="Container memory limit (GiB)"
+							type="number"
+							min={1}
+							className="w-28"
+							value={memoryLimit}
+							onChange={(e) => setMemoryLimit(e.target.value)}
+							data-testid="memory-limit-gib-input"
+						/>
+						<p className="text-xs text-text-subtle -mt-1">
+							The container is auto-stopped when it exceeds this RSS budget. Raise it on
+							memory-heavy projects; lower it to fail fast on runaway workloads.
+						</p>
 						<div className="flex gap-2">
 							<Button type="submit" size="sm" disabled={updateProject.isPending}>
 								{updateProject.isPending ? <Loader2 className="w-3 h-3 animate-spin" /> : 'Save'}
@@ -88,6 +108,10 @@ function ProjectSettingsPage() {
 						<div data-testid="max-concurrent-runs-value">
 							<span className="text-text-muted">Max concurrent runs:</span>{' '}
 							{project.max_concurrent_runs}
+						</div>
+						<div data-testid="memory-limit-gib-value">
+							<span className="text-text-muted">Container memory limit:</span>{' '}
+							{project.memory_limit_gib} GiB
 						</div>
 						<Button variant="ghost" size="sm" onClick={startEditing} className="mt-2">
 							Edit

--- a/packages/web/test/project-settings.test.tsx
+++ b/packages/web/test/project-settings.test.tsx
@@ -155,6 +155,54 @@ test('edits the per-project concurrency cap and persists it', async () => {
 	);
 });
 
+test('edits the per-project memory limit and persists it', async () => {
+	const projectName = uniqueName('Memory Limit Project');
+	let ws!: SeededWorkspace;
+	let projectSlug = '';
+	let projectId = '';
+
+	const { findByRole, findByTestId, getByRole, ctx, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			ws = await seedWorkspace();
+			const project = await seedProject(ws, {
+				name: projectName,
+				description: 'Memory limit settings.',
+			});
+			projectSlug = project.slug;
+			projectId = project.id;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/settings',
+		params: { projectId: projectSlug },
+	});
+
+	// Read view shows the seeded default of 16 GiB.
+	const readValue = await findByTestId('memory-limit-gib-value', undefined, { timeout: 8_000 });
+	expect(readValue.textContent).toContain('16');
+
+	await user.click(await findByRole('button', { name: 'Edit' }));
+	const input = (await findByTestId('memory-limit-gib-input', undefined, {
+		timeout: 8_000,
+	})) as HTMLInputElement;
+	await user.clear(input);
+	await user.type(input, '24');
+	await user.click(getByRole('button', { name: 'Save' }));
+
+	await waitFor(
+		async () => {
+			const row = await ctx.db.query<{ memory_limit_gib: number }>(
+				'SELECT memory_limit_gib FROM projects WHERE id = $1',
+				[projectId],
+			);
+			expect(row.rows[0]?.memory_limit_gib).toBe(24);
+		},
+		{ timeout: 8_000 },
+	);
+});
+
 test('State A — no GitHub connection: shows Connect GitHub CTA', async () => {
 	const projectName = uniqueName('Settings Project');
 	let ws!: SeededWorkspace;


### PR DESCRIPTION
## Summary

- New `projects.memory_limit_gib` column (NOT NULL DEFAULT 16, CHECK ≥ 1) replaces the hardcoded 12 GiB ceiling from #174. The soft watchdog now reads each project's own value and interpolates it into the `container_error` message users see.
- Project Settings page gets a "Container memory limit (GiB)" input next to "Max concurrent runs"; PATCH `/projects` validates it with the same shape.
- `DockerClient.containerLogs` returns `Response | null` on 404 (mirrors `inspectContainer` / `containerStats`). `captureContainerLogs` treats null as a silent no-op; the live-stream path in `container-logs.ts` ends cleanly. Eliminates the `Failed to capture logs … 404` warn that fired on every clean container stop.
- Drops the now-unused `Memory?` / `MemorySwap?` fields from `ContainerConfig.HostConfig` — leftover from the hard cgroup cap reverted in #174.

## Why

The 12 GiB watchdog tripped on real agent workloads — Claude Code with a 1M-context model (`deepseek-v4-pro[1m]`) and 73 MCP tools comfortably crosses 12 GiB of RSS during context warmup, before the first Messages API round-trip. The original incident: TO-5 / TO-10 runs on the `todo` project showed exit-137 deaths with `input_tokens=0, output_tokens=0`. Raising the default to 16 GiB is a more honest ceiling for these workloads, and the per-project override gives an escape hatch for heavier projects without requiring a redeploy.

## Test plan

- [x] `bun run test --skip-browser` — 153 server + 69 web test files green (259 + ? tests)
- [x] `bun run typecheck` — clean
- [x] `bun run check` — no new lint warnings on changed files
- [x] New `container-sync.test.ts` cases:
  - Default 16 GiB watchdog auto-stops at 17 GiB usage, error message says "17.00 GiB / 16 GiB"
  - Per-project override (`memory_limit_gib = 8`) auto-stops at 9 GiB and says "9.00 GiB / 8 GiB"
  - Existing "Memory Frugal" path still leaves a 4 GiB container alone
  - 404 race: `inspectContainer` returns `{ Running: false, ExitCode: 137 }`, `containerLogs` returns null, sync resolves with `container_status='stopped'`, `container_error` containing 'exited with code 137', `container_last_logs IS NULL`, no warn
- [x] New `project-settings.test.tsx` case: editing the GiB input from 16 → 24 persists to the row