### PR TITLE
refactor(web): drop standalone Terminate button from run detail header

### DIFF
--- a/packages/web/src/components/terminate-run-button.tsx
+++ b/packages/web/src/components/terminate-run-button.tsx
@@ -11,7 +11,6 @@ interface TerminateRunButtonProps {
 	runId: string;
 	status: RunStatus;
 	taskId?: string | null;
-	variant?: 'compact' | 'standalone';
 }
 
 export function TerminateRunButton({
@@ -20,17 +19,11 @@ export function TerminateRunButton({
 	runId,
 	status,
 	taskId,
-	variant = 'compact',
 }: TerminateRunButtonProps) {
 	const [open, setOpen] = useState(false);
 	const mutation = useTerminateRun({ projectId, agentId, runId, taskId });
 
 	if (!isActiveRunStatus(status)) return null;
-
-	const triggerClass =
-		variant === 'compact'
-			? 'inline-flex items-center justify-center h-6 px-2 text-xs text-accent-red hover:bg-accent-red/10 rounded-radius-md transition-colors'
-			: 'inline-flex items-center justify-center gap-1.5 px-2.5 py-1 text-xs font-medium text-text-muted hover:text-accent-red border border-border hover:border-accent-red bg-bg-subtle hover:bg-bg-muted rounded-radius-md transition-colors';
 
 	return (
 		<>
@@ -41,10 +34,9 @@ export function TerminateRunButton({
 					aria-label="Terminate run"
 					data-testid="terminate-run-button"
 					disabled={mutation.isPending}
-					className={triggerClass}
+					className="inline-flex items-center justify-center h-6 px-2 text-xs text-accent-red hover:bg-accent-red/10 rounded-radius-md transition-colors"
 				>
 					<Square className="w-3 h-3" fill="currentColor" />
-					{variant === 'standalone' && <span>Terminate</span>}
 				</button>
 			</Tooltip>
 			<ConfirmDialog

--- a/packages/web/src/routes/projects/$projectId/agents/$agentId/executions/$runId.tsx
+++ b/packages/web/src/routes/projects/$projectId/agents/$agentId/executions/$runId.tsx
@@ -104,16 +104,6 @@ function ExecutionDetailPage() {
 			<div className="flex items-center gap-2 mb-4">
 				<h2 className="text-sm font-medium">Run {run.id.slice(0, 8)}</h2>
 				<Badge color={statusColor(run.status) as 'green'}>{run.status}</Badge>
-				<div className="ml-auto">
-					<TerminateRunButton
-						projectId={projectId}
-						agentId={agentId}
-						runId={runId}
-						status={run.status}
-						taskId={run.task_id}
-						variant="standalone"
-					/>
-				</div>
 			</div>
 
 			{(() => {


### PR DESCRIPTION
## Summary
- Removes the large standalone "Terminate" button next to the status badge on the run detail page — the compact terminate icon already lives in the LogViewer header, so it was a duplicate.
- Drops the now-unused `variant` prop and the `standalone` branch from `TerminateRunButton`, leaving just the single compact icon-only form.

## Test plan
- [ ] Open a running run's detail page and confirm only the compact terminate icon in the log viewer header remains (no big button beside the status badge).
- [ ] Open an inline run comment on a task page and confirm the compact terminate icon still appears and still opens the confirm dialog.
- [ ] `cd packages/web && bunx vitest run test/run-termination.test.tsx` passes.