### PR TITLE
feat(web): retry button on the run-failed system comment

### DIFF
--- a/packages/server/src/routes/queued-wakeups.ts
+++ b/packages/server/src/routes/queued-wakeups.ts
@@ -1,4 +1,4 @@
-import { WakeupStatus, wsRoom } from '@hezo/shared';
+import { WakeupSource, WakeupStatus, wsRoom } from '@hezo/shared';
 import { Hono } from 'hono';
 import { broadcastChange } from '../lib/broadcast';
 import { shouldDeferWakeupForBlockers } from '../lib/dependencies';
@@ -12,6 +12,7 @@ import {
 	isTaskBusyInDb,
 } from '../services/run-concurrency';
 import { recordWakeupCancelled, recordWakeupStarted } from '../services/task-events';
+import { createWakeup } from '../services/wakeup';
 
 const log = logger.child('routes');
 
@@ -221,3 +222,72 @@ queuedWakeupsRoutes.post(
 		return ok(c, { dispatched: true });
 	},
 );
+
+// Retry the agent that owned a previously-failed run on this task. Used by the
+// Retry button on the `run_failed` system comment, where the user wants
+// explicit control over re-running *this* task with *this* agent — the
+// chained wakeup from the failure path doesn't guarantee either. Creates a
+// fresh queued wakeup (or coalesces onto a pending one for the same
+// agent+task) and dispatches it immediately through the same JobManager path
+// as /run-now, so the run rules and dependency policy re-check race-safely.
+queuedWakeupsRoutes.post('/projects/:projectId/tasks/:taskId/runs/:runId/retry', async (c) => {
+	const teamId = c.get('teamId') as string;
+	const db = c.get('db');
+	const taskId = await resolveTaskId(db, teamId, c.req.param('taskId'));
+	if (!taskId) return err(c, 'NOT_FOUND', 'Task not found', 404);
+	const runId = c.req.param('runId');
+
+	const runLookup = await db.query<{ member_id: string }>(
+		`SELECT member_id FROM heartbeat_runs
+			 WHERE id = $1 AND team_id = $2 AND task_id = $3`,
+		[runId, teamId, taskId],
+	);
+	const runRow = runLookup.rows[0];
+	// 404 (not 403) for unknown / wrong-team / wrong-task to avoid leaking existence.
+	if (!runRow) return err(c, 'NOT_FOUND', 'Run not found', 404);
+
+	const wakeupId = await createWakeup(db, runRow.member_id, teamId, WakeupSource.OnDemand, {
+		task_id: taskId,
+		trigger: 'retry_failed_run',
+		source_run_id: runId,
+	});
+
+	const result = await c.get('jobManager').dispatchWakeupNow(wakeupId);
+	if (!result.dispatched) {
+		if (result.reason === 'not_found') {
+			return err(c, 'NOT_FOUND', 'Queued wakeup not found', 404);
+		}
+		const messages: Record<string, string> = {
+			task_busy: 'This ticket already has a run in progress',
+			project_at_capacity: 'This project is at its concurrent-run limit',
+			agent_busy: 'This agent is currently running on another task in this project',
+			blocked: 'This ticket is blocked by an open dependency',
+			not_queued: 'Wakeup is no longer queued and cannot be run',
+		};
+		return err(c, 'CONFLICT', messages[result.reason] ?? 'Unable to start retry run', 409);
+	}
+
+	const nameRes = await db.query<{ member_name: string }>(
+		`SELECT COALESCE(ma.title, m.display_name) AS member_name
+			 FROM members m LEFT JOIN member_agents ma ON ma.id = m.id
+			 WHERE m.id = $1`,
+		[runRow.member_id],
+	);
+	const agentName = nameRes.rows[0]?.member_name ?? 'an agent';
+	const actorMemberId = await resolveActorMemberId(db, c.get('auth'), teamId);
+	try {
+		await recordWakeupStarted(
+			db,
+			teamId,
+			taskId,
+			wakeupId,
+			agentName,
+			actorMemberId,
+			c.get('wsManager'),
+		);
+	} catch (e) {
+		log.error('Failed to record wakeup-started comment:', e);
+	}
+
+	return ok(c, { dispatched: true });
+});

--- a/packages/server/test/queued-wakeups.test.ts
+++ b/packages/server/test/queued-wakeups.test.ts
@@ -486,3 +486,82 @@ describe('POST /teams/:teamId/tasks/:taskId/queued-wakeups/:wakeupId/cancel', ()
 		expect(row.rows[0].status).toBe('queued');
 	});
 });
+
+describe('POST /teams/:teamId/tasks/:taskId/runs/:runId/retry', () => {
+	async function insertFailedRun(memberId: string, forTaskId: string): Promise<string> {
+		const r = await db.query<{ id: string }>(
+			`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at, finished_at, error)
+			 VALUES ($1, $2, $3, 'failed'::heartbeat_run_status, now(), now(), 'API Error: socket closed')
+			 RETURNING id`,
+			[memberId, teamId, forTaskId],
+		);
+		return r.rows[0].id;
+	}
+
+	function retry(forTaskId: string, runId: string) {
+		return app.request(`/api/projects/${projectId}/tasks/${forTaskId}/runs/${runId}/retry`, {
+			method: 'POST',
+			headers: { ...authHeader(token), ...json },
+			body: '{}',
+		});
+	}
+
+	it("creates an on_demand wakeup for the failed run's agent and dispatches it", async () => {
+		await clearWakeups(taskId);
+		await clearRuns();
+		await clearBlockers(taskId);
+		const runId = await insertFailedRun(agentB, taskId);
+
+		const res = await retry(taskId, runId);
+		expect(res.status).toBe(200);
+		expect((await res.json()).data.dispatched).toBe(true);
+
+		// A wakeup was created for the failed run's agent and was claimed by dispatch.
+		const wakeup = await db.query<{
+			id: string;
+			member_id: string;
+			source: string;
+			status: string;
+			payload: { task_id?: string; source_run_id?: string };
+		}>(
+			"SELECT id, member_id, source, status, payload FROM agent_wakeup_requests WHERE payload->>'task_id' = $1",
+			[taskId],
+		);
+		expect(wakeup.rows.length).toBe(1);
+		expect(wakeup.rows[0].member_id).toBe(agentB);
+		expect(wakeup.rows[0].source).toBe('on_demand');
+		expect(wakeup.rows[0].status).not.toBe('queued');
+		expect(wakeup.rows[0].payload?.source_run_id).toBe(runId);
+
+		const sys = await db.query<{ content: { kind?: string } }>(
+			"SELECT content FROM task_comments WHERE task_id = $1 AND content_type = 'system' ORDER BY created_at DESC",
+			[taskId],
+		);
+		expect(sys.rows.some((s) => s.content?.kind === 'wakeup_started')).toBe(true);
+	});
+
+	it('returns 404 when the run id is unknown', async () => {
+		const res = await retry(taskId, '00000000-0000-0000-0000-000000000000');
+		expect(res.status).toBe(404);
+	});
+
+	it('returns 404 when the run belongs to a different task', async () => {
+		const otherTask = await createTask('Retry Other Task');
+		const runId = await insertFailedRun(agentB, otherTask);
+
+		const res = await retry(taskId, runId);
+		expect(res.status).toBe(404);
+		await clearRuns();
+	});
+
+	it('returns 409 when the task already has a run in progress', async () => {
+		await clearWakeups(taskId);
+		await clearRuns();
+		await insertRunningRun(agentA, taskId);
+		const failedRunId = await insertFailedRun(agentB, taskId);
+
+		const res = await retry(taskId, failedRunId);
+		expect(res.status).toBe(409);
+		await clearRuns();
+	});
+});

--- a/packages/web/src/components/comment-content.ts
+++ b/packages/web/src/components/comment-content.ts
@@ -56,6 +56,7 @@ export interface SystemRunFailedContent {
 	agent_slug?: string;
 	status?: string;
 	error?: string;
+	run_id?: string;
 	text?: string;
 }
 

--- a/packages/web/src/components/comment-renderers/index.tsx
+++ b/packages/web/src/components/comment-renderers/index.tsx
@@ -50,8 +50,8 @@ const renderers: RendererRegistry = {
 	),
 	[CommentContentType.Preview]: ({ comment }) => <PreviewComment comment={comment} />,
 	[CommentContentType.Trace]: ({ comment }) => <TraceComment comment={comment} />,
-	[CommentContentType.System]: ({ comment, projectId }) => (
-		<SystemComment comment={comment} projectId={projectId} />
+	[CommentContentType.System]: ({ comment, projectId, taskId }) => (
+		<SystemComment comment={comment} projectId={projectId} taskId={taskId} />
 	),
 	[CommentContentType.Run]: ({ comment, projectId, inline }) => (
 		<RunComment comment={comment} projectId={projectId} inline={inline} />

--- a/packages/web/src/components/comment-renderers/system-comment.tsx
+++ b/packages/web/src/components/comment-renderers/system-comment.tsx
@@ -1,5 +1,7 @@
 import { formatTaskStatus } from '@hezo/shared';
 import { Link } from '@tanstack/react-router';
+import { Loader2, RotateCw } from 'lucide-react';
+import { useRetryFailedRun } from '../../hooks/use-retry-failed-run';
 import { repoWebUrl } from '../../lib/github';
 import type {
 	SystemContent,
@@ -8,11 +10,13 @@ import type {
 	SystemStatusChangeContent,
 	SystemTaskLinkContent,
 } from '../comment-content';
+import { Tooltip } from '../ui/tooltip';
 import type { CommentDataOf } from './comment-data';
 
 interface Props {
 	comment: CommentDataOf<'system'>;
 	projectId?: string;
+	taskId?: string;
 }
 
 function isTaskLink(c: SystemContent): c is SystemTaskLinkContent {
@@ -28,7 +32,7 @@ function isRepoDesignated(c: SystemContent): c is SystemRepoDesignatedContent {
 	return c.kind === 'repo_designated';
 }
 
-export function SystemComment({ comment, projectId }: Props) {
+export function SystemComment({ comment, projectId, taskId }: Props) {
 	const content: SystemContent | null =
 		comment.content && typeof comment.content === 'object' ? comment.content : null;
 	const timestamp = (
@@ -58,7 +62,14 @@ export function SystemComment({ comment, projectId }: Props) {
 	}
 
 	if (content && isRunFailed(content)) {
-		return <RunFailedBody content={content} projectId={projectId} timestamp={timestamp} />;
+		return (
+			<RunFailedBody
+				content={content}
+				projectId={projectId}
+				taskId={taskId}
+				timestamp={timestamp}
+			/>
+		);
 	}
 
 	if (content && isRepoDesignated(content)) {
@@ -137,16 +148,19 @@ function StatusChangeBody({
 function RunFailedBody({
 	content,
 	projectId,
+	taskId,
 	timestamp,
 }: {
 	content: SystemRunFailedContent;
 	projectId?: string;
+	taskId?: string;
 	timestamp: React.ReactNode;
 }) {
 	const agentSlug = typeof content.agent_slug === 'string' ? content.agent_slug : '';
 	const status = typeof content.status === 'string' ? content.status : 'failed';
 	const error =
 		typeof content.error === 'string' && content.error.length > 0 ? content.error : null;
+	const runId = typeof content.run_id === 'string' ? content.run_id : null;
 	const statusLabel = status === 'timed_out' ? 'timed out' : 'failed';
 	const agentNode =
 		agentSlug && projectId ? (
@@ -166,12 +180,48 @@ function RunFailedBody({
 			className="flex flex-col gap-0.5 sm:flex-row sm:items-baseline sm:gap-2 leading-[26px]"
 			data-testid="run-failed-comment"
 		>
-			<span className="text-xs text-text-muted">
-				Run for {agentNode} {statusLabel}
-				{error ? <span className="text-text-subtle">: {error}</span> : null}. Waking agent to retry.
+			<span className="text-xs text-text-muted inline-flex items-baseline gap-1.5 flex-wrap">
+				<span>
+					Run for {agentNode} {statusLabel}
+					{error ? <span className="text-text-subtle">: {error}</span> : null}.
+				</span>
+				{projectId && taskId && runId ? (
+					<RetryRunButton projectId={projectId} taskId={taskId} runId={runId} />
+				) : null}
 			</span>
 			{timestamp}
 		</div>
+	);
+}
+
+function RetryRunButton({
+	projectId,
+	taskId,
+	runId,
+}: {
+	projectId: string;
+	taskId: string;
+	runId: string;
+}) {
+	const retry = useRetryFailedRun({ projectId, taskId });
+	return (
+		<Tooltip content="Retry this run">
+			<button
+				type="button"
+				onClick={() => retry.mutate(runId)}
+				disabled={retry.isPending}
+				aria-label="Retry failed run"
+				data-testid="retry-failed-run"
+				className="inline-flex items-center gap-1 self-baseline rounded-radius-md border border-border-default px-1.5 py-0.5 text-[11px] font-medium text-text-muted hover:bg-bg-subtle hover:text-text disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+			>
+				{retry.isPending ? (
+					<Loader2 className="w-3 h-3 animate-spin" />
+				) : (
+					<RotateCw className="w-3 h-3" />
+				)}
+				Retry
+			</button>
+		</Tooltip>
 	);
 }
 

--- a/packages/web/src/hooks/use-retry-failed-run.ts
+++ b/packages/web/src/hooks/use-retry-failed-run.ts
@@ -1,0 +1,31 @@
+import { useMutation } from '@tanstack/react-query';
+import { api } from '../lib/api';
+import { queryClient } from '../lib/query-client';
+import { toast } from './use-toast';
+
+interface RetryFailedRunArgs {
+	projectId: string;
+	taskId: string;
+}
+
+export function useRetryFailedRun({ projectId, taskId }: RetryFailedRunArgs) {
+	return useMutation({
+		mutationFn: (runId: string) =>
+			api.post<{ dispatched: boolean }>(
+				`/api/projects/${projectId}/tasks/${taskId}/runs/${runId}/retry`,
+				{},
+			),
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: ['projects', projectId, 'tasks', taskId, 'queued-wakeups'],
+			});
+			queryClient.invalidateQueries({
+				queryKey: ['projects', projectId, 'tasks', taskId, 'comments'],
+			});
+			queryClient.invalidateQueries({ queryKey: ['projects', projectId, 'tasks', taskId] });
+		},
+		onError: (error: { message?: string }) => {
+			toast.error(error?.message ?? 'Failed to retry run');
+		},
+	});
+}

--- a/packages/web/test/run-failed-comment.test.tsx
+++ b/packages/web/test/run-failed-comment.test.tsx
@@ -2,7 +2,9 @@ import { expect, test } from 'vitest';
 import { renderApp } from './helpers/render';
 import { seedProject, seedTask, seedWorkspace } from './helpers/seed';
 
-test('task page renders run_failed system comment with agent link and error', async () => {
+const FAILED_RUN_ID = 'bbbb0000-0000-0000-0000-000000000777';
+
+test('task page renders run_failed system comment with agent link, error, and retry button', async () => {
 	const seeded = {
 		teamId: '',
 		projectSlug: '',
@@ -10,8 +12,9 @@ test('task page renders run_failed system comment with agent link and error', as
 		agentId: '',
 		agentSlug: '',
 	};
+	const retryCalls: string[] = [];
 
-	const { findByTestId, router } = await renderApp({
+	const { findByTestId, router, user } = await renderApp({
 		initialPath: '/',
 		seed: async () => {
 			const ws = await seedWorkspace();
@@ -34,7 +37,7 @@ test('task page renders run_failed system comment with agent link and error', as
 				content_type: 'system',
 				content: {
 					kind: 'run_failed',
-					run_id: 'bbbb0000-0000-0000-0000-000000000777',
+					run_id: FAILED_RUN_ID,
 					status: 'timed_out',
 					error: 'The operation timed out.',
 					member_id: captain.id,
@@ -57,6 +60,16 @@ test('task page renders run_failed system comment with agent link and error', as
 						headers: { 'Content-Type': 'application/json' },
 					});
 				}
+				const retryMatch = url.match(
+					/\/api\/projects\/([^/]+)\/tasks\/([^/]+)\/runs\/([^/]+)\/retry/,
+				);
+				if (method === 'POST' && retryMatch) {
+					retryCalls.push(retryMatch[3]);
+					return new Response(JSON.stringify({ data: { dispatched: true } }), {
+						status: 200,
+						headers: { 'Content-Type': 'application/json' },
+					});
+				}
 				return originalFetch(input as RequestInfo, init);
 			}) as typeof globalThis.fetch;
 		},
@@ -72,11 +85,16 @@ test('task page renders run_failed system comment with agent link and error', as
 	});
 	expect(failureComment.textContent ?? '').toContain('timed out');
 	expect(failureComment.textContent ?? '').toContain('The operation timed out.');
-	expect(failureComment.textContent ?? '').toContain('Waking agent to retry.');
+	expect(failureComment.textContent ?? '').not.toContain('Waking agent to retry');
 
 	const agentLink = (await findByTestId('run-failed-agent')) as HTMLAnchorElement;
 	expect(agentLink.textContent ?? '').toContain(`@${seeded.agentSlug}`);
 	expect(agentLink.getAttribute('href')).toMatch(
 		new RegExp(`/projects/${seeded.projectSlug}/agents/${seeded.agentSlug}$`),
 	);
+
+	const retryButton = (await findByTestId('retry-failed-run')) as HTMLButtonElement;
+	expect(retryButton.textContent ?? '').toContain('Retry');
+	await user.click(retryButton);
+	expect(retryCalls).toEqual([FAILED_RUN_ID]);
 });


### PR DESCRIPTION
## Summary

- Replaces the trailing "Waking agent to retry." text in the `run_failed` system comment with an explicit **Retry** button. The chained wakeup that fires on failure (`chainNextTaskWakeup` in `job-manager.ts`) picks the *next non-terminal task for the agent* — often a different task — so the old text was actively wrong and the user had no way to retry *this* task from the failed-comment itself.
- New endpoint `POST /api/projects/:projectId/tasks/:taskId/runs/:runId/retry` creates an `on_demand` wakeup for the failed run's agent and dispatches it through the same `JobManager.dispatchWakeupNow` path as `/run-now`, so the task-busy / project-capacity / agent-busy / blocker gates are re-checked race-safely.
- Web side: small inline button (RotateCw icon, accent border, Loader2 while pending), wired through a new `useRetryFailedRun` hook that mirrors `useRunQueuedWakeup`. `taskId` is plumbed through `CommentRenderer` → `SystemComment` → `RunFailedBody`; `SystemRunFailedContent` gets `run_id?: string` on the client (server already writes it).

## Context on the API error in the prompting screenshot

The screenshot showed `API Error: The socket connection was closed unexpectedly` mid-`[thinking]` on a `deepseek-v4-pro[1m]` run (250K input tokens / 6.4K output, 10 turns, 3m49s). DeepSeek's hostname is in `NO_PROXY` (`.dev/egress.md:38`), so traffic goes direct from the container — no Hezo proxy involvement. The upstream simply terminated the long-running generation. No request-path fix is in scope; the user-facing mitigation is this retry button.

## Test plan

- [x] `bunx vitest run packages/web/test/run-failed-comment.test.tsx` — asserts the Retry button renders, the old text is gone, and clicking POSTs to the new endpoint
- [x] `bunx vitest run packages/server/test/queued-wakeups.test.ts` — adds 4 retry-endpoint tests (happy path with `wakeup_started` comment, 404 for unknown run, 404 for cross-task run, 409 when task is busy); all 23 tests in the file pass
- [x] `bun run typecheck`
- [ ] Manual: force a failing agent run on the dev server, confirm the Retry button appears on the run-failed comment, click it, observe a new run starts