### PR TITLE
fix(test): give the bun-native egress beforeAll 60s for slow CI

### DIFF
--- a/packages/server/test/bun/egress-proxy.bun.test.ts
+++ b/packages/server/test/bun/egress-proxy.bun.test.ts
@@ -27,6 +27,9 @@ let ca: HezoCA;
 let dataDir: string;
 let proxy: EgressProxy;
 
+// CA generation alone takes ~2s; on slow CI runners the full setup (PGlite +
+// Hono boot + three API calls + CA + proxy) can push past Bun's 5s default
+// hook timeout. Give the same headroom as the tests themselves.
 beforeAll(async () => {
 	const ctx = await createTestApp();
 	db = ctx.db;
@@ -52,7 +55,7 @@ beforeAll(async () => {
 
 	ca = await loadOrCreateCA(dataDir);
 	proxy = new EgressProxy({ db, masterKeyManager, ca, extraUpstreamTrustedCAs: ca.cert });
-});
+}, 60_000);
 
 afterAll(async () => {
 	await proxy.releaseAll();


### PR DESCRIPTION
## Summary

The PR #179 CI failed with `TypeError: undefined is not an object (evaluating 'proxy.releaseAll')` in the bun-native egress test. Root cause: `beforeAll` ran for 6.5s on a slow GHA runner — past Bun's 5s default hook timeout — so it bailed, `proxy` stayed undefined, and `afterAll` then crashed when it tried to release it.

The hook does PGlite + Hono boot, three API calls, a one-shot CA generation (~2s on its own), and constructs the proxy. The test functions themselves already carry 30s timeouts; this gives the setup the same headroom.

The failed run for PR #179 retried automatically and went green, so this didn't block the merge — but the underlying timing fragility remains and will bite again.

## Test plan

- [x] `bun test test/bun/egress-proxy.bun.test.ts` passes locally
- [x] `bun run test --package server --skip-browser` passes locally
- [x] `bun run typecheck` passes