### PR TITLE
feat(server): container memory observability + lifecycle event logs

### DIFF
--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -574,9 +574,12 @@ projectsRoutes.post('/projects/:projectId/container/start', async (c) => {
 			container_status: ContainerStatus.Running,
 		});
 		wakeAgentsWithPendingWork(db, projectId, teamId);
+		log.info(`project ${projectId} container ${containerId.slice(0, 12)} started`);
 		return ok(c, { container_status: ContainerStatus.Running });
 	} catch (error) {
-		return err(c, 'DOCKER_ERROR', `Failed to start container: ${(error as Error).message}`, 500);
+		const message = (error as Error).message;
+		log.warn(`project ${projectId} container ${containerId.slice(0, 12)} start failed: ${message}`);
+		return err(c, 'DOCKER_ERROR', `Failed to start container: ${message}`, 500);
 	}
 });
 

--- a/packages/server/src/services/containers.ts
+++ b/packages/server/src/services/containers.ts
@@ -102,6 +102,41 @@ export const DEFAULT_MEMORY_LIMIT_GIB = 16;
 
 const memoryLimitBytes = (gib: number) => gib * 1024 ** 3;
 
+const MEMORY_USAGE_LOG_INTERVAL_MS = 30_000;
+
+interface MemoryUsageEntry {
+	lastLogMs: number;
+	lastUsedBytes: number;
+	limitGib: number;
+}
+
+const memoryUsageState = new Map<string, MemoryUsageEntry>();
+
+function formatMemoryLine(entry: MemoryUsageEntry): string {
+	const usedGiB = (entry.lastUsedBytes / 1024 ** 3).toFixed(2);
+	return `${usedGiB} / ${entry.limitGib} GiB`;
+}
+
+/**
+ * Pull-and-clear the most recent stats reading for a project, formatted as a
+ * single line suitable for appending to `container_last_logs`. Returns null
+ * when no reading was ever recorded for this project (e.g. the container died
+ * before the first sync tick observed it). Clears the entry as a side effect
+ * so subsequent transition handlers do not double-emit.
+ */
+export function consumeFinalMemoryLine(projectId: string): string | null {
+	const entry = memoryUsageState.get(projectId);
+	if (!entry) return null;
+	memoryUsageState.delete(projectId);
+	return `→ Final container memory: ${formatMemoryLine(entry)}`;
+}
+
+function appendMemoryLine(existing: string | null, line: string | null): string | null {
+	if (!line) return existing;
+	if (!existing) return `${line}\n`;
+	return existing.endsWith('\n') ? `${existing}${line}\n` : `${existing}\n${line}\n`;
+}
+
 /**
  * Pull a one-shot tail of the container's stdout+stderr log buffer. Used to
  * snapshot the last-known console output when a container exits or errors so
@@ -239,6 +274,7 @@ export async function provisionContainer(
 
 		emit('stdout', '→ Starting container');
 		await docker.startContainer(Id);
+		log.info(`project ${project.id} container ${Id.slice(0, 12)} provisioned and started`);
 
 		await db.query(
 			'UPDATE projects SET container_id = $1, container_status = $2::container_status, container_error = NULL WHERE id = $3',
@@ -347,14 +383,15 @@ export async function teardownContainer(
 		[projectId],
 	);
 
-	if (result.rows[0]?.container_id) {
+	const teardownContainerId = result.rows[0]?.container_id;
+	if (teardownContainerId) {
 		try {
-			await docker.stopContainer(result.rows[0].container_id);
+			await docker.stopContainer(teardownContainerId);
 		} catch {
 			// Container may already be stopped
 		}
 		try {
-			await docker.removeContainer(result.rows[0].container_id, true);
+			await docker.removeContainer(teardownContainerId, true);
 		} catch {
 			// Container may already be removed
 		}
@@ -365,6 +402,13 @@ export async function teardownContainer(
 	]);
 
 	removeProjectWorkspace(dataDir, teamId, projectId);
+	memoryUsageState.delete(projectId);
+
+	if (teardownContainerId) {
+		log.info(`project ${projectId} container ${teardownContainerId.slice(0, 12)} torn down`);
+	} else {
+		log.info(`project ${projectId} torn down (no container was provisioned)`);
+	}
 }
 
 export async function stopContainerGracefully(
@@ -376,6 +420,7 @@ export async function stopContainerGracefully(
 	const { db, docker, wsManager } = deps;
 
 	const lastLogs = await captureContainerLogs(docker, containerId);
+	const annotatedLogs = appendMemoryLine(lastLogs, consumeFinalMemoryLine(projectId));
 
 	let exitReason: ContainerExitReason = 'container_stopped';
 	try {
@@ -386,8 +431,9 @@ export async function stopContainerGracefully(
 			     container_last_logs = COALESCE($2, container_last_logs),
 			     container_error = NULL
 			 WHERE id = $3`,
-			[ContainerStatus.Stopped, lastLogs, projectId],
+			[ContainerStatus.Stopped, annotatedLogs, projectId],
 		);
+		log.info(`project ${projectId} container ${containerId.slice(0, 12)} stopped`);
 	} catch (err) {
 		const errorMessage = err instanceof Error ? err.message : String(err);
 		await db.query(
@@ -396,9 +442,12 @@ export async function stopContainerGracefully(
 			     container_last_logs = COALESCE($2, container_last_logs),
 			     container_error = $3
 			 WHERE id = $4`,
-			[ContainerStatus.Error, lastLogs, errorMessage, projectId],
+			[ContainerStatus.Error, annotatedLogs, errorMessage, projectId],
 		);
 		exitReason = 'container_error';
+		log.warn(
+			`project ${projectId} container ${containerId.slice(0, 12)} stop failed: ${errorMessage}`,
+		);
 	}
 
 	await failProjectRuns(deps, projectId, teamId, exitReason).catch((e) =>
@@ -443,15 +492,19 @@ export async function rebuildContainer(
 	const streamId = provisionStreamId(project.id);
 
 	if (project.container_id) {
+		log.info(
+			`project ${project.id} container ${project.container_id.slice(0, 12)} rebuild started`,
+		);
 		logs?.emit(
 			streamId,
 			'stdout',
 			`→ Removing previous container ${project.container_id.slice(0, 12)}`,
 		);
 		const lastLogs = await captureContainerLogs(docker, project.container_id);
-		if (lastLogs) {
+		const annotatedLogs = appendMemoryLine(lastLogs, consumeFinalMemoryLine(project.id));
+		if (annotatedLogs) {
 			await db.query('UPDATE projects SET container_last_logs = $1 WHERE id = $2', [
-				lastLogs,
+				annotatedLogs,
 				project.id,
 			]);
 		}
@@ -465,6 +518,8 @@ export async function rebuildContainer(
 		} catch {
 			// Already removed
 		}
+	} else {
+		log.info(`project ${project.id} rebuild started (no previous container)`);
 	}
 
 	return provisionContainer(deps, project, teamSlug);
@@ -503,19 +558,26 @@ export async function syncContainerStatus(
 
 	if (previousStatus === ContainerStatus.Running && status !== ContainerStatus.Running) {
 		const lastLogs = await captureContainerLogs(docker, containerId);
+		const finalMemoryLine = consumeFinalMemoryLine(projectId);
+		const annotatedLogs = appendMemoryLine(lastLogs, finalMemoryLine);
 		const exitCode = info.State.ExitCode;
 		const exitStatus = info.State.Status;
 		const errorMessage =
 			exitCode && exitCode !== 0
 				? `Container exited with code ${exitCode} (${exitStatus}).`
 				: `Container stopped (${exitStatus}).`;
+		if (finalMemoryLine) {
+			log.info(
+				`project ${projectId} container ${containerId.slice(0, 12)} exited; ${finalMemoryLine.replace(/^→ /, '')}`,
+			);
+		}
 		await db.query(
 			`UPDATE projects
 			 SET container_status = $1::container_status,
 			     container_last_logs = COALESCE($2, container_last_logs),
 			     container_error = $3
 			 WHERE id = $4`,
-			[status, lastLogs, errorMessage, projectId],
+			[status, annotatedLogs, errorMessage, projectId],
 		);
 	} else {
 		await db.query('UPDATE projects SET container_status = $1::container_status WHERE id = $2', [
@@ -554,6 +616,22 @@ async function enforceContainerMemoryLimit(
 		return null;
 	}
 	if (!stats) return null;
+
+	const now = Date.now();
+	const prevEntry = memoryUsageState.get(projectId);
+	const entry: MemoryUsageEntry = {
+		lastLogMs: prevEntry?.lastLogMs ?? 0,
+		lastUsedBytes: stats.usedBytes,
+		limitGib: memoryLimitGib,
+	};
+	if (now - entry.lastLogMs >= MEMORY_USAGE_LOG_INTERVAL_MS) {
+		entry.lastLogMs = now;
+		log.debug(
+			`project ${projectId} container ${containerId.slice(0, 12)} memory: ${formatMemoryLine(entry)}`,
+		);
+	}
+	memoryUsageState.set(projectId, entry);
+
 	const limitBytes = memoryLimitBytes(memoryLimitGib);
 	if (stats.usedBytes <= limitBytes) return null;
 
@@ -586,6 +664,8 @@ async function enforceContainerMemoryLimit(
 	log.warn(
 		`Auto-stopped container ${containerId.slice(0, 12)} for project ${projectId}: used ${usedGiB} GiB (> ${memoryLimitGib} GiB)`,
 	);
+
+	memoryUsageState.delete(projectId);
 
 	await failProjectRuns(deps, projectId, teamId, 'container_error').catch((e) =>
 		log.error('Failed to fail project runs after memory-limit stop:', e),

--- a/packages/server/test/container-sync.test.ts
+++ b/packages/server/test/container-sync.test.ts
@@ -8,6 +8,7 @@ import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import type { Env } from '../src/lib/types';
 import {
 	type ContainerDeps,
+	consumeFinalMemoryLine,
 	type ProjectRow,
 	provisionContainer,
 	stopContainerGracefully,
@@ -464,6 +465,7 @@ describe('syncAllContainerStatuses', () => {
 			"UPDATE projects SET container_id = 'race-1', container_status = 'running'::container_status, container_last_logs = NULL WHERE id = $1",
 			[projectId],
 		);
+		consumeFinalMemoryLine(projectId);
 
 		const mockDocker = createStubDocker({
 			inspectContainer: vi.fn().mockResolvedValue({
@@ -517,6 +519,182 @@ describe('syncAllContainerStatuses', () => {
 		await syncAllContainerStatuses(deps(mockDocker));
 
 		expect(containerStats).not.toHaveBeenCalled();
+	});
+
+	it('records the last memory reading and appends it to container_last_logs on exit', async () => {
+		await db.query(
+			'UPDATE projects SET container_id = NULL, container_status = NULL, container_error = NULL WHERE team_id = $1',
+			[teamId],
+		);
+
+		const projectRes = await createTestProject(db, teamId, {
+			name: 'Memory Trail Project',
+			description: 'Test project.',
+		});
+		const projectId = (await projectRes.json()).data.id;
+		await new Promise((r) => setTimeout(r, 100));
+
+		await db.query(
+			`UPDATE projects
+			 SET container_id = 'memory-trail',
+			     container_status = 'running'::container_status,
+			     container_last_logs = NULL,
+			     memory_limit_gib = 16
+			 WHERE id = $1`,
+			[projectId],
+		);
+		consumeFinalMemoryLine(projectId);
+
+		const inspectContainer = vi
+			.fn()
+			.mockResolvedValueOnce({ State: { Running: true, Status: 'running' } })
+			.mockResolvedValueOnce({
+				Id: 'memory-trail',
+				State: { Running: false, Status: 'exited', ExitCode: 137 },
+			});
+		const usedBytes = 4 * 1024 ** 3;
+		const mockDocker = createStubDocker({
+			inspectContainer,
+			containerStats: vi.fn().mockResolvedValue({ usedBytes, rawUsageBytes: usedBytes }),
+			containerLogs: vi.fn().mockResolvedValue(null),
+		});
+
+		await syncAllContainerStatuses(deps(mockDocker));
+		await syncAllContainerStatuses(deps(mockDocker));
+
+		const result = await db.query<{
+			container_status: string;
+			container_error: string | null;
+			container_last_logs: string | null;
+		}>(
+			'SELECT container_status, container_error, container_last_logs FROM projects WHERE id = $1',
+			[projectId],
+		);
+		expect(result.rows[0].container_status).toBe('stopped');
+		expect(result.rows[0].container_error).toContain('exited with code 137');
+		expect(result.rows[0].container_last_logs).toContain('→ Final container memory: 4.00 / 16 GiB');
+		expect(consumeFinalMemoryLine(projectId)).toBeNull();
+	});
+
+	it('honors the per-project memory limit when formatting the final-memory line', async () => {
+		await db.query(
+			'UPDATE projects SET container_id = NULL, container_status = NULL, container_error = NULL WHERE team_id = $1',
+			[teamId],
+		);
+
+		const projectRes = await createTestProject(db, teamId, {
+			name: 'Tighter Trail Project',
+			description: 'Test project.',
+		});
+		const projectId = (await projectRes.json()).data.id;
+		await new Promise((r) => setTimeout(r, 100));
+
+		await db.query(
+			`UPDATE projects
+			 SET container_id = 'tight-trail',
+			     container_status = 'running'::container_status,
+			     memory_limit_gib = 8,
+			     container_last_logs = NULL
+			 WHERE id = $1`,
+			[projectId],
+		);
+		consumeFinalMemoryLine(projectId);
+
+		const inspectContainer = vi
+			.fn()
+			.mockResolvedValueOnce({ State: { Running: true, Status: 'running' } })
+			.mockResolvedValueOnce({
+				Id: 'tight-trail',
+				State: { Running: false, Status: 'exited', ExitCode: 0 },
+			});
+		const usedBytes = 2.5 * 1024 ** 3;
+		const mockDocker = createStubDocker({
+			inspectContainer,
+			containerStats: vi.fn().mockResolvedValue({ usedBytes, rawUsageBytes: usedBytes }),
+			containerLogs: vi.fn().mockResolvedValue(null),
+		});
+
+		await syncAllContainerStatuses(deps(mockDocker));
+		await syncAllContainerStatuses(deps(mockDocker));
+
+		const result = await db.query<{ container_last_logs: string | null }>(
+			'SELECT container_last_logs FROM projects WHERE id = $1',
+			[projectId],
+		);
+		expect(result.rows[0].container_last_logs).toContain('→ Final container memory: 2.50 / 8 GiB');
+	});
+
+	it('skips the final-memory line on exit when stats were never observed', async () => {
+		await db.query(
+			'UPDATE projects SET container_id = NULL, container_status = NULL, container_error = NULL WHERE team_id = $1',
+			[teamId],
+		);
+
+		const projectRes = await createTestProject(db, teamId, {
+			name: 'No Stats Project',
+			description: 'Test project.',
+		});
+		const projectId = (await projectRes.json()).data.id;
+		await new Promise((r) => setTimeout(r, 100));
+
+		await db.query(
+			"UPDATE projects SET container_id = 'no-stats', container_status = 'running'::container_status, container_last_logs = NULL WHERE id = $1",
+			[projectId],
+		);
+		consumeFinalMemoryLine(projectId);
+
+		const mockDocker = createStubDocker({
+			inspectContainer: vi.fn().mockResolvedValue({
+				Id: 'no-stats',
+				State: { Running: false, Status: 'exited', ExitCode: 1 },
+			}),
+			containerLogs: vi.fn().mockResolvedValue(null),
+		});
+
+		await syncAllContainerStatuses(deps(mockDocker));
+
+		const result = await db.query<{ container_last_logs: string | null }>(
+			'SELECT container_last_logs FROM projects WHERE id = $1',
+			[projectId],
+		);
+		expect(result.rows[0].container_last_logs).toBeNull();
+	});
+
+	it('clears the memory readout after a memory-limit auto-stop so the next exit does not double-emit', async () => {
+		await db.query(
+			'UPDATE projects SET container_id = NULL, container_status = NULL, container_error = NULL WHERE team_id = $1',
+			[teamId],
+		);
+
+		const projectRes = await createTestProject(db, teamId, {
+			name: 'Auto Stop Trail Project',
+			description: 'Test project.',
+		});
+		const projectId = (await projectRes.json()).data.id;
+		await new Promise((r) => setTimeout(r, 100));
+
+		await db.query(
+			"UPDATE projects SET container_id = 'auto-stop-trail', container_status = 'running'::container_status WHERE id = $1",
+			[projectId],
+		);
+		consumeFinalMemoryLine(projectId);
+
+		const overLimitBytes = 17 * 1024 ** 3;
+		const mockDocker = createStubDocker({
+			inspectContainer: vi.fn().mockResolvedValue({
+				State: { Running: true, Status: 'running' },
+			}),
+			containerStats: vi.fn().mockResolvedValue({
+				usedBytes: overLimitBytes,
+				rawUsageBytes: overLimitBytes,
+			}),
+			stopContainer: vi.fn().mockResolvedValue(undefined),
+			containerLogs: vi.fn().mockResolvedValue(null),
+		});
+
+		await syncAllContainerStatuses(deps(mockDocker));
+
+		expect(consumeFinalMemoryLine(projectId)).toBeNull();
 	});
 
 	it('survives a stats transport error without stopping the container', async () => {
@@ -953,6 +1131,51 @@ describe('stopContainerGracefully', () => {
 			[projectId],
 		);
 		expect(result.rows[0].container_status).toBe('stopped');
+	});
+
+	it('appends the final-memory line when the sync loop has observed stats', async () => {
+		const projectRes = await createTestProject(db, teamId, {
+			name: 'Graceful Stop Trail Project',
+			description: 'Test project.',
+		});
+		const stopProjectId = (await projectRes.json()).data.id;
+		await new Promise((r) => setTimeout(r, 100));
+
+		await db.query(
+			`UPDATE projects
+			 SET container_id = 'graceful-trail',
+			     container_status = 'running'::container_status,
+			     container_last_logs = NULL,
+			     memory_limit_gib = 16
+			 WHERE id = $1`,
+			[stopProjectId],
+		);
+		consumeFinalMemoryLine(stopProjectId);
+
+		const usedBytes = 6 * 1024 ** 3;
+		const mockDocker = createStubDocker({
+			inspectContainer: vi.fn().mockResolvedValue({
+				State: { Running: true, Status: 'running' },
+			}),
+			containerStats: vi.fn().mockResolvedValue({ usedBytes, rawUsageBytes: usedBytes }),
+			stopContainer: vi.fn().mockResolvedValue(undefined),
+			containerLogs: vi.fn().mockResolvedValue(null),
+		});
+
+		await syncAllContainerStatuses(deps(mockDocker));
+
+		await stopContainerGracefully(
+			{ db, docker: mockDocker, dataDir: '' },
+			stopProjectId,
+			teamId,
+			'graceful-trail',
+		);
+
+		const result = await db.query<{ container_last_logs: string | null }>(
+			'SELECT container_last_logs FROM projects WHERE id = $1',
+			[stopProjectId],
+		);
+		expect(result.rows[0].container_last_logs).toContain('→ Final container memory: 6.00 / 16 GiB');
 	});
 });
 


### PR DESCRIPTION
## Summary

When a project's dev container exits unexpectedly (e.g. exit 137 / SIGKILL from the Docker Desktop VM kernel), neither the captured in-container stdout nor the dev-server log shows the memory pressure that preceded the kill. The UI logs panel just ends at `✓ Container ready` and gives the user no context on why the container died. This PR adds three layers of meta-level visibility that close that gap.

### Periodic memory debug log

`enforceContainerMemoryLimit` already calls `docker.containerStats(containerId)` once per second from the sync loop. It now also writes each reading into a module-level Map and, every 30 s per project, emits

```
[debug] <containers> project <id> container <short-id> memory: X.XX / N GiB
```

Reuses the existing Docker API call — no extra traffic — and stays under `LOG_LEVEL=debug` so it doesn't add noise at default level.

### Final memory readout on every exit

The most recent reading is consumed and appended to `container_last_logs` whenever the container leaves the `Running` state, via four code paths:

- `syncContainerStatus` (auto-detected Running → non-Running)
- `stopContainerGracefully` (user-initiated stop)
- `rebuildContainer` (before tearing down the old container)
- `enforceContainerMemoryLimit` auto-stop (already records the same info in `container_error`; just clears the Map entry to avoid double-emit)

So the UI logs panel that previously ended at `✓ Container ready` now ends with:

```
✓ Container ready
→ Final container memory: 4.27 / 16 GiB
```

The same line is also emitted to the dev-server log at `info` level so the trail is in two places.

### Info-level lifecycle log lines

Every container state transition now leaves an info (or warn on failure) entry in the dev-server log:

| Event | Level |
|---|---|
| Provisioned + started | info |
| Started (existing container, `/container/start`) | info |
| Start failed | warn |
| Stopped (graceful) | info |
| Stop failed | warn |
| Rebuild started | info |
| Torn down | info |
| Exited (auto-detected by sync loop) | info (with memory readout) |
| Auto-stopped by OOM watchdog | warn (already existed) |

Format: `project <id> container <short-id> <verb>` so they grep cleanly.

`teardownContainer` also clears the project's `memoryUsageState` entry so a stale reading doesn't survive its container.

## Test plan

- [x] `bunx vitest run test/container-sync.test.ts` — 31 pass (5 new tests covering the final-memory append, custom limit formatting, no-stats no-op, auto-stop cleanup, and the `stopContainerGracefully` path)
- [x] `bun run test --package server --skip-browser` — 1739 tests, 153 files pass
- [x] `bun run typecheck` — clean
- [x] `biome check` on changed files — clean

## Files

- `packages/server/src/services/containers.ts` — Map, helpers, throttled debug, final-line append in 4 transition paths, lifecycle info logs
- `packages/server/src/routes/projects.ts` — info/warn around the inline `docker.startContainer` call in `/container/start`
- `packages/server/test/container-sync.test.ts` — 5 new behavioural tests

Co-authored-by: Sculptor <sculptor@imbue.com>