### PR TITLE
fix(server): reject non-UUID comment_id in MCP reaction tools

### DIFF
--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -1401,7 +1401,12 @@ export function registerTools(
 		{
 			team_id: z.string().describe('Team ID'),
 			task_id: z.string().describe('Task ID the comment belongs to'),
-			comment_id: z.string().describe('Comment ID to react to'),
+			comment_id: z
+				.string()
+				.uuid()
+				.describe(
+					'UUID of the comment to react to, as returned by list_comments. Sentinels like "last" / "latest" are not supported — you must pass an explicit UUID.',
+				),
 			kind: reactionKindSchema.describe(
 				`Reaction kind. v1 supports: ${Object.values(ReactionKind).join(', ')}`,
 			),
@@ -1445,7 +1450,12 @@ export function registerTools(
 		{
 			team_id: z.string().describe('Team ID'),
 			task_id: z.string().describe('Task ID the comment belongs to'),
-			comment_id: z.string().describe('Comment ID to remove the reaction from'),
+			comment_id: z
+				.string()
+				.uuid()
+				.describe(
+					'UUID of the comment to remove the reaction from, as returned by list_comments. Sentinels like "last" / "latest" are not supported — you must pass an explicit UUID.',
+				),
 			kind: reactionKindSchema.describe(
 				`Reaction kind. v1 supports: ${Object.values(ReactionKind).join(', ')}`,
 			),

--- a/packages/server/test/reactions.test.ts
+++ b/packages/server/test/reactions.test.ts
@@ -431,6 +431,42 @@ describe('MCP add_reaction / remove_reaction tools', () => {
 		expect(c.reactions[0].kind).toBe(ReactionKind.Ack);
 	});
 
+	it('add_reaction rejects a non-UUID comment_id at the schema layer', async () => {
+		const taskId = await insertTask(captainId, 'MCP reject non-uuid');
+		const { token: agentToken } = await mintAgentToken(
+			db,
+			masterKeyManager,
+			captainId,
+			teamId,
+			taskId,
+		);
+
+		const res = await app.request('/mcp', {
+			method: 'POST',
+			headers: { ...authHeader(agentToken), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				jsonrpc: '2.0',
+				method: 'tools/call',
+				params: {
+					name: 'add_reaction',
+					arguments: {
+						team_id: teamId,
+						task_id: taskId,
+						comment_id: 'last',
+						kind: ReactionKind.Ack,
+					},
+				},
+				id: 1,
+			}),
+		});
+		const body = await res.text();
+		expect(body).not.toContain('invalid input syntax for type uuid');
+		const reactionCount = await db.query<{ c: number }>(
+			'SELECT COUNT(*)::int AS c FROM comment_reactions',
+		);
+		expect(reactionCount.rows[0].c).toBe(0);
+	});
+
 	it('add_reaction does not fire any wakeups', async () => {
 		const taskId = await insertTask(architectId, 'MCP no wakeups');
 		const commentId = await insertComment(taskId, captainId);


### PR DESCRIPTION
## Summary

- `add_reaction` and `remove_reaction` accepted any string for `comment_id`. When an agent passed a sentinel like `"last"`, it flowed past Zod into the SQL layer, and PGlite's raw `invalid input syntax for type uuid: "last"` was returned to the agent verbatim instead of a clean validation error.
- Tighten the schemas in `packages/server/src/mcp/tools.ts` to `z.string().uuid()` and rewrite the parameter descriptions to explicitly state that sentinels like `"last"` / `"latest"` are not supported.
- Add a regression test that POSTs `add_reaction` with `comment_id: 'last'` and asserts the Postgres error string no longer leaks back to the MCP caller. Verified the test fails on the pre-fix code (reproducing the exact response from the live trace) and passes with the fix.

## Why not a broader sweep

While reviewing the change I noticed the `tool()` wrapper at `tools.ts:203–226` does identifier→UUID resolution for `task_id` (agents can pass either `TO-5` or a UUID), and `agent_id` sometimes accepts a slug. Blindly adding `.uuid()` to every `_id` schema would break those. The safely-tightenable params (`team_id`, `project_id`, `approval_id`) are a worthwhile follow-up but not strictly required to close this bug.

## Test plan

- [x] `bunx vitest run test/reactions.test.ts` — all 12 tests pass
- [x] New `add_reaction rejects a non-UUID comment_id at the schema layer` test fails without the fix, passes with it
- [x] `bun run typecheck` clean