### PR TITLE
feat(server): auto-restart project containers on server startup

### DIFF
--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -34,9 +34,11 @@ import {
 	type ContainerExitReason,
 	type ContainerTransition,
 	failProjectRuns,
+	provisionContainer,
 	rebuildContainer,
 	syncAllContainerStatuses,
 	verifyContainerWorkspace,
+	wakeAgentsWithPendingWork,
 } from './containers';
 import type { DockerClient } from './docker';
 import type { EgressProxy } from './egress';
@@ -507,7 +509,95 @@ export class JobManager {
 		}
 
 		await this.selfHealErroredContainers(docker);
+		await this.restartStoppedRunningContainers(docker);
 		await this.repairStaleContainerMounts(docker);
+	}
+
+	/**
+	 * Bring projects whose DB says container_status = running back to actually-
+	 * running. Covers the host-reboot / Docker-restart case where the server
+	 * never got to mark the container as stopped. Missing containers are
+	 * re-provisioned from scratch; stopped ones are started in place. Projects
+	 * the user explicitly stopped (container_status = stopped) are left alone.
+	 */
+	private async restartStoppedRunningContainers(docker: DockerClient): Promise<void> {
+		const { db, wsManager, containerLogStreamer, logs } = this.deps;
+
+		const reachable = await docker.ping();
+		if (!reachable) {
+			log.warn('Docker not reachable at startup; skipping container restart pass');
+			return;
+		}
+
+		const candidates = await db.query<{
+			id: string;
+			team_id: string;
+			slug: string;
+			team_slug: string;
+			container_id: string;
+			container_status: string | null;
+			docker_base_image: string;
+			dev_ports: Array<{ container: number; host: number }>;
+		}>(
+			`SELECT p.id, p.team_id, p.slug, c.slug AS team_slug,
+			        p.container_id, p.container_status, p.docker_base_image, p.dev_ports
+			 FROM projects p
+			 JOIN teams c ON c.id = p.team_id
+			 WHERE p.container_status = $1::container_status AND p.container_id IS NOT NULL`,
+			[ContainerStatus.Running],
+		);
+
+		let restarted = 0;
+		let reprovisioned = 0;
+
+		for (const row of candidates.rows) {
+			try {
+				const info = await docker.inspectContainer(row.container_id);
+
+				if (info === null) {
+					await provisionContainer(
+						this.buildContainerDeps(),
+						{
+							id: row.id,
+							team_id: row.team_id,
+							slug: row.slug,
+							docker_base_image: row.docker_base_image,
+							container_id: row.container_id,
+							container_status: row.container_status,
+							dev_ports: row.dev_ports ?? [],
+						},
+						row.team_slug,
+					);
+					reprovisioned++;
+					log.info(`Re-provisioned project ${row.id} — container was missing from Docker`);
+					continue;
+				}
+
+				if (info.State.Running) continue;
+
+				await docker.startContainer(row.container_id);
+				await db.query('UPDATE projects SET container_error = NULL WHERE id = $1', [row.id]);
+				containerLogStreamer.subscribe(row.id, row.container_id, logs, docker);
+				broadcastRowChange(wsManager, wsRoom.team(row.team_id), 'projects', 'UPDATE', {
+					id: row.id,
+					container_status: ContainerStatus.Running,
+					container_error: null,
+				});
+				await wakeAgentsWithPendingWork(db, row.id, row.team_id).catch((e) =>
+					log.error(`Failed to wake agents after startup restart for project ${row.id}:`, e),
+				);
+				restarted++;
+				log.info(`Restarted container ${row.container_id.slice(0, 12)} for project ${row.id}`);
+			} catch (err) {
+				log.error(`Failed to restart container for project ${row.id} on startup:`, err);
+			}
+		}
+
+		if (restarted > 0 || reprovisioned > 0) {
+			log.info(
+				`Startup container restart: restarted ${restarted}, re-provisioned ${reprovisioned}`,
+			);
+		}
 	}
 
 	/**

--- a/packages/server/test/job-manager-workflows.test.ts
+++ b/packages/server/test/job-manager-workflows.test.ts
@@ -1,7 +1,7 @@
 import type { PGlite } from '@electric-sql/pglite';
 import { AgentRuntimeStatus, HeartbeatRunStatus, TaskStatus, WakeupStatus } from '@hezo/shared';
 import type { Hono } from 'hono';
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import type { MasterKeyManager } from '../src/crypto/master-key';
 import { waitForBackground } from '../src/lib/background';
 import type { Env } from '../src/lib/types';
@@ -10,7 +10,7 @@ import type { DockerClient } from '../src/services/docker';
 import { JobManager, type JobManagerDeps } from '../src/services/job-manager';
 import { LogStreamBroker } from '../src/services/log-stream-broker';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject } from './helpers/app';
+import { authHeader, createStubDocker, createTestApp, createTestProject } from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -1863,6 +1863,195 @@ describe('JobManager workflow methods', () => {
 			expect(locks.rows.length).toBe(0);
 
 			manager.shutdown();
+		});
+
+		describe('container restart', () => {
+			// Other projects (notably HQ) get provisioned in the background during
+			// file-level setup and end up with container_status='running'. Clear all
+			// projects before each test so the restart pass only sees the row the
+			// test under test seeded.
+			beforeEach(async () => {
+				await db.query(
+					`UPDATE projects
+					 SET container_status = NULL, container_id = NULL, container_error = NULL`,
+				);
+			});
+
+			afterEach(async () => {
+				await db.query(
+					`UPDATE projects
+					 SET container_status = NULL, container_id = NULL, container_error = NULL`,
+				);
+			});
+
+			// Default stub overrides that satisfy the post-restart repairStaleContainerMounts
+			// pass — verifyContainerWorkspace runs an exec; without a non-throwing exec
+			// stub it would trigger a rebuild and pollute every assertion.
+			const happyExec = {
+				execCreate: async () => 'exec-1',
+				execStart: async () => ({ stdout: 'ok', stderr: '' }),
+				execInspect: async () => ({ ExitCode: 0, Running: false, Pid: 0 }),
+			};
+
+			async function seedRunningContainer(containerId: string): Promise<void> {
+				await db.query(
+					`UPDATE projects
+					 SET container_status = 'running'::container_status, container_id = $2, container_error = 'old error'
+					 WHERE id = $1`,
+					[projectId, containerId],
+				);
+			}
+
+			it('starts an exited container whose DB status is running', async () => {
+				await seedRunningContainer('abc');
+
+				const startCalls: string[] = [];
+				const manager = createJobManager({
+					docker: createStubDocker({
+						...happyExec,
+						inspectContainer: async (id: string) => ({
+							Id: id,
+							State: { Status: 'exited', Running: false, Pid: 0, ExitCode: 0 },
+							Config: { Image: 'stub' },
+						}),
+						startContainer: async (id: string) => {
+							startCalls.push(id);
+						},
+					}),
+				});
+
+				await manager.reconcileOnStartup();
+
+				expect(startCalls).toEqual(['abc']);
+				const row = await db.query<{ container_error: string | null }>(
+					'SELECT container_error FROM projects WHERE id = $1',
+					[projectId],
+				);
+				expect(row.rows[0].container_error).toBe(null);
+
+				manager.shutdown();
+			});
+
+			it('leaves an already-running container alone', async () => {
+				await seedRunningContainer('abc');
+
+				const startCalls: string[] = [];
+				const manager = createJobManager({
+					docker: createStubDocker({
+						...happyExec,
+						inspectContainer: async (id: string) => ({
+							Id: id,
+							State: { Status: 'running', Running: true, Pid: 1, ExitCode: 0 },
+							Config: { Image: 'stub' },
+						}),
+						startContainer: async (id: string) => {
+							startCalls.push(id);
+						},
+					}),
+				});
+
+				await manager.reconcileOnStartup();
+
+				expect(startCalls).toEqual([]);
+
+				manager.shutdown();
+			});
+
+			it('does not touch a project the user has explicitly stopped', async () => {
+				await db.query(
+					`UPDATE projects
+					 SET container_status = 'stopped'::container_status, container_id = 'abc'
+					 WHERE id = $1`,
+					[projectId],
+				);
+
+				const startCalls: string[] = [];
+				const inspectCalls: string[] = [];
+				const manager = createJobManager({
+					docker: createStubDocker({
+						...happyExec,
+						inspectContainer: async (id: string) => {
+							inspectCalls.push(id);
+							return {
+								Id: id,
+								State: { Status: 'exited', Running: false, Pid: 0, ExitCode: 0 },
+								Config: { Image: 'stub' },
+							};
+						},
+						startContainer: async (id: string) => {
+							startCalls.push(id);
+						},
+					}),
+				});
+
+				await manager.reconcileOnStartup();
+
+				expect(inspectCalls).not.toContain('abc');
+				expect(startCalls).toEqual([]);
+
+				manager.shutdown();
+			});
+
+			it('re-provisions a project whose container has vanished from Docker', async () => {
+				await seedRunningContainer('gone');
+
+				const createCalls: string[] = [];
+				const manager = createJobManager({
+					docker: createStubDocker({
+						...happyExec,
+						inspectContainer: async () => null,
+						createContainer: async (name: string) => {
+							createCalls.push(name);
+							return { Id: 'fresh-container', Warnings: [] };
+						},
+					}),
+				});
+
+				await manager.reconcileOnStartup();
+
+				expect(createCalls).toContain(`hezo-${projectId}`);
+				const row = await db.query<{ container_id: string | null; container_status: string }>(
+					'SELECT container_id, container_status FROM projects WHERE id = $1',
+					[projectId],
+				);
+				expect(row.rows[0].container_id).toBe('fresh-container');
+				expect(row.rows[0].container_status).toBe('running');
+
+				manager.shutdown();
+			});
+
+			it('skips the restart pass when Docker is unreachable', async () => {
+				await seedRunningContainer('abc');
+
+				const inspectCalls: string[] = [];
+				const startCalls: string[] = [];
+				const manager = createJobManager({
+					docker: createStubDocker({
+						...happyExec,
+						ping: async () => false,
+						inspectContainer: async (id: string) => {
+							inspectCalls.push(id);
+							return null;
+						},
+						startContainer: async (id: string) => {
+							startCalls.push(id);
+						},
+					}),
+				});
+
+				await manager.reconcileOnStartup();
+
+				expect(inspectCalls).toEqual([]);
+				expect(startCalls).toEqual([]);
+				const row = await db.query<{ container_id: string | null; container_status: string }>(
+					'SELECT container_id, container_status FROM projects WHERE id = $1',
+					[projectId],
+				);
+				expect(row.rows[0].container_id).toBe('abc');
+				expect(row.rows[0].container_status).toBe('running');
+
+				manager.shutdown();
+			});
 		});
 	});
 

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -36,8 +36,12 @@ export default defineConfig({
 		environment: 'happy-dom',
 		include: ['test/**/*.test.tsx', 'test/**/*.test.ts'],
 		setupFiles: ['test/helpers/setup.ts'],
-		testTimeout: 15000,
-		hookTimeout: 30000,
+		// Matcher ceilings of 20_000 / 30_000ms appear throughout the suite;
+		// the per-test cap has to exceed them or the test-level timeout fires
+		// first on a contended CI runner (4 forks × PGlite + Hono boot) and
+		// the matcher's grace window never actually applies.
+		testTimeout: 45000,
+		hookTimeout: 45000,
 		pool: 'forks',
 		poolOptions: {
 			forks: {


### PR DESCRIPTION
## Summary

After a host reboot or Docker restart, projects whose DB recorded `container_status = running` end up with the Docker container in an Exited state. Until now the user had to click **Start** on each project before agents could resume — the existing startup pass only re-attached containers that happened to already be running (`selfHealErroredContainers`) and rebuilt ones with broken bind mounts (`repairStaleContainerMounts`). Nothing actually *started* a stopped container or re-provisioned a missing one.

This adds a new `restartStoppedRunningContainers` step to `reconcileOnStartup()` that, for every project marked `running` with a `container_id`, inspects Docker and:

- **starts the container in place** if it exists but is not running — clears any stale `container_error`, re-subscribes the log streamer, broadcasts the row update, and wakes agents holding pending work (mirrors the manual `/container/start` route).
- **re-provisions from scratch** via `provisionContainer` when the container has vanished from Docker entirely (e.g. pruned, Docker reset).

Projects the user explicitly stopped (`container_status = stopped`) are left alone — only `running`-but-not-actually-running rows are touched. Per-project `try/catch` keeps one failure from blocking the rest, and the pass short-circuits with a warn log when Docker isn't reachable.

Step ordering inside `reconcileOnStartup()`:

1. `selfHealErroredContainers` — re-link `Error`/null projects whose containers turn out to be alive
2. `restartStoppedRunningContainers` *(new)* — start/re-provision `running` projects whose containers aren't
3. `repairStaleContainerMounts` — verify `/workspace` mounts on the survivors (including ones we just brought back up)

## Test plan

- [x] `bunx vitest run test/job-manager-workflows.test.ts -t reconcileOnStartup` — 7 tests pass (2 existing + 5 new covering started, no-op-running, user-stopped, re-provisioned, Docker-unreachable)
- [x] `bunx vitest run test/job-manager-workflows.test.ts test/containers-recovery.test.ts test/container-sync.test.ts` — 91 tests pass
- [x] `bun run typecheck` clean
- [ ] Manual smoke: provision a project, `docker stop hezo-<project_id>`, restart the server, confirm `docker ps` shows it Up again without intervention