### PR TITLE
refactor(web): fold "started queued run" system comment into the run card

### DIFF
--- a/packages/server/src/routes/queued-wakeups.ts
+++ b/packages/server/src/routes/queued-wakeups.ts
@@ -11,7 +11,7 @@ import {
 	isProjectAtCapacityInDb,
 	isTaskBusyInDb,
 } from '../services/run-concurrency';
-import { recordWakeupCancelled, recordWakeupStarted } from '../services/task-events';
+import { recordWakeupCancelled, resolveActorName } from '../services/task-events';
 import { createWakeup } from '../services/wakeup';
 
 const log = logger.child('routes');
@@ -179,6 +179,22 @@ queuedWakeupsRoutes.post(
 			return err(c, 'CONFLICT', `Wakeup is already ${row.status} and cannot be run`, 409);
 		}
 
+		// Stamp the triggering actor onto the wakeup payload so createHeartbeatRun
+		// can fold it into the run comment's content — the run card itself shows
+		// "started by Admin" instead of a separate system comment.
+		const actorMemberId = await resolveActorMemberId(db, c.get('auth'), teamId);
+		const actorName = await resolveActorName(db, actorMemberId);
+		await db.query(
+			`UPDATE agent_wakeup_requests
+			 SET payload = payload || $1::jsonb
+			 WHERE id = $2 AND status = $3::wakeup_status`,
+			[
+				JSON.stringify({ triggered_by: { member_id: actorMemberId, name: actorName } }),
+				wakeupId,
+				WakeupStatus.Queued,
+			],
+		);
+
 		// Dispatch through the JobManager so the in-memory run guards and the
 		// activateAgent launch path are reused (and the two run rules + blocker
 		// policy re-checked race-safely at dispatch time).
@@ -195,28 +211,6 @@ queuedWakeupsRoutes.post(
 				not_queued: 'Wakeup is no longer queued and cannot be run',
 			};
 			return err(c, 'CONFLICT', messages[result.reason] ?? 'Unable to start queued run', 409);
-		}
-
-		const nameRes = await db.query<{ member_name: string }>(
-			`SELECT COALESCE(ma.title, m.display_name) AS member_name
-			 FROM members m LEFT JOIN member_agents ma ON ma.id = m.id
-			 WHERE m.id = $1`,
-			[row.member_id],
-		);
-		const agentName = nameRes.rows[0]?.member_name ?? 'an agent';
-		const actorMemberId = await resolveActorMemberId(db, c.get('auth'), teamId);
-		try {
-			await recordWakeupStarted(
-				db,
-				teamId,
-				taskId,
-				wakeupId,
-				agentName,
-				actorMemberId,
-				c.get('wsManager'),
-			);
-		} catch (e) {
-			log.error('Failed to record wakeup-started comment:', e);
 		}
 
 		return ok(c, { dispatched: true });
@@ -246,10 +240,14 @@ queuedWakeupsRoutes.post('/projects/:projectId/tasks/:taskId/runs/:runId/retry',
 	// 404 (not 403) for unknown / wrong-team / wrong-task to avoid leaking existence.
 	if (!runRow) return err(c, 'NOT_FOUND', 'Run not found', 404);
 
+	const actorMemberId = await resolveActorMemberId(db, c.get('auth'), teamId);
+	const actorName = await resolveActorName(db, actorMemberId);
+
 	const wakeupId = await createWakeup(db, runRow.member_id, teamId, WakeupSource.OnDemand, {
 		task_id: taskId,
 		trigger: 'retry_failed_run',
 		source_run_id: runId,
+		triggered_by: { member_id: actorMemberId, name: actorName },
 	});
 
 	const result = await c.get('jobManager').dispatchWakeupNow(wakeupId);
@@ -265,28 +263,6 @@ queuedWakeupsRoutes.post('/projects/:projectId/tasks/:taskId/runs/:runId/retry',
 			not_queued: 'Wakeup is no longer queued and cannot be run',
 		};
 		return err(c, 'CONFLICT', messages[result.reason] ?? 'Unable to start retry run', 409);
-	}
-
-	const nameRes = await db.query<{ member_name: string }>(
-		`SELECT COALESCE(ma.title, m.display_name) AS member_name
-			 FROM members m LEFT JOIN member_agents ma ON ma.id = m.id
-			 WHERE m.id = $1`,
-		[runRow.member_id],
-	);
-	const agentName = nameRes.rows[0]?.member_name ?? 'an agent';
-	const actorMemberId = await resolveActorMemberId(db, c.get('auth'), teamId);
-	try {
-		await recordWakeupStarted(
-			db,
-			teamId,
-			taskId,
-			wakeupId,
-			agentName,
-			actorMemberId,
-			c.get('wsManager'),
-		);
-	} catch (e) {
-		log.error('Failed to record wakeup-started comment:', e);
 	}
 
 	return ok(c, { dispatched: true });

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -464,6 +464,16 @@ function exitReasonFromSignal(signal?: AbortSignal): ContainerExitAbortReason | 
 	return null;
 }
 
+function extractTriggeredBy(payload: Record<string, unknown> | undefined): TriggeredBy | null {
+	const raw = payload?.triggered_by;
+	if (!raw || typeof raw !== 'object') return null;
+	const obj = raw as Record<string, unknown>;
+	const name = typeof obj.name === 'string' ? obj.name : null;
+	if (!name) return null;
+	const memberId = typeof obj.member_id === 'string' ? obj.member_id : null;
+	return { member_id: memberId, name };
+}
+
 async function createSyntheticOnDemandWakeup(
 	db: PGlite,
 	memberId: string,
@@ -512,6 +522,7 @@ export async function runAgent(
 		task,
 		runBroadcast,
 		effectiveWakeupId,
+		extractTriggeredBy(wakeupPayload),
 	);
 	onRunRegistered?.(heartbeatRunId);
 	await emitRunStarted(deps, heartbeatRunId, agent, task, project, effectiveWakeupId);
@@ -1509,6 +1520,11 @@ function broadcastHeartbeatRunChange(
 	});
 }
 
+export interface TriggeredBy {
+	member_id: string | null;
+	name: string;
+}
+
 export async function createHeartbeatRun(
 	db: PGlite,
 	agent: AgentInfo,
@@ -1516,6 +1532,7 @@ export async function createHeartbeatRun(
 	task: TaskInfo,
 	broadcast: HeartbeatRunBroadcast,
 	wakeupId: string,
+	triggeredBy: TriggeredBy | null = null,
 ): Promise<string> {
 	const { runId, statusFlippedToInProgress } = await withTransaction(db, async () => {
 		const runResult = await db.query<{ id: string }>(
@@ -1538,6 +1555,7 @@ export async function createHeartbeatRun(
 					agent_id: agent.id,
 					agent_title: agent.title,
 					agent_slug: agent.slug,
+					...(triggeredBy ? { actor_id: triggeredBy.member_id, actor_name: triggeredBy.name } : {}),
 				}),
 			],
 		);

--- a/packages/server/src/services/task-events.ts
+++ b/packages/server/src/services/task-events.ts
@@ -20,7 +20,7 @@ export function extractTaskIdentifiers(text: string | null | undefined): string[
 	return Array.from(out);
 }
 
-async function resolveActorName(db: PGlite, actorMemberId: string | null): Promise<string> {
+export async function resolveActorName(db: PGlite, actorMemberId: string | null): Promise<string> {
 	if (!actorMemberId) return 'Admin';
 	const r = await db.query<{ name: string | null }>(
 		`SELECT COALESCE(ma.title, NULLIF(m.display_name, ''), 'Admin') AS name
@@ -154,39 +154,6 @@ export async function recordWakeupCancelled(
 			CommentContentType.System,
 			JSON.stringify({
 				kind: 'wakeup_cancelled',
-				wakeup_id: wakeupId,
-				actor_id: actorMemberId,
-				actor_name: actorName,
-				agent_name: agentName,
-				text,
-			}),
-		],
-	);
-	if (r.rows[0] && wsManager) {
-		broadcastRowChange(wsManager, wsRoom.team(teamId), 'task_comments', 'INSERT', r.rows[0]);
-	}
-}
-
-export async function recordWakeupStarted(
-	db: PGlite,
-	teamId: string,
-	taskId: string,
-	wakeupId: string,
-	agentName: string,
-	actorMemberId: string | null,
-	wsManager: WebSocketManager | undefined,
-): Promise<void> {
-	const actorName = await resolveActorName(db, actorMemberId);
-	const text = `${actorName} started queued run for ${agentName}`;
-	const r = await db.query<Record<string, unknown>>(
-		`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
-		 VALUES ($1, $2, $3::comment_content_type, $4::jsonb) RETURNING *`,
-		[
-			taskId,
-			actorMemberId,
-			CommentContentType.System,
-			JSON.stringify({
-				kind: 'wakeup_started',
 				wakeup_id: wakeupId,
 				actor_id: actorMemberId,
 				actor_name: actorName,

--- a/packages/server/test/heartbeat-runs.test.ts
+++ b/packages/server/test/heartbeat-runs.test.ts
@@ -227,6 +227,44 @@ describe('run comments', () => {
 		expect(comments.rows[0].content.run_id).toBe(runId);
 		expect(comments.rows[0].content.agent_id).toBe(agentId);
 		expect(comments.rows[0].content.agent_title).toBe('Test Runner');
+		expect(comments.rows[0].content.actor_name).toBeUndefined();
+	});
+
+	it('embeds triggeredBy actor into the run comment content', async () => {
+		const agent: AgentInfo = {
+			id: agentId,
+			title: 'Test Runner',
+			team_id: teamId,
+		};
+		const task = {
+			id: taskId,
+			identifier: 'RT-1',
+			title: 'Test Task',
+			description: '',
+			status: 'backlog',
+			priority: 'medium',
+			project_id: projectId,
+			rules: null,
+		};
+
+		const runId = await createHeartbeatRun(
+			db,
+			agent,
+			teamId,
+			task,
+			{ teamId, taskId, memberId: agentId },
+			await mintTestWakeup(agentId, teamId),
+			{ member_id: null, name: 'Admin' },
+		);
+
+		const comments = await db.query<{ content: Record<string, unknown> }>(
+			`SELECT content FROM task_comments
+			 WHERE task_id = $1 AND content_type = 'run'::comment_content_type
+			   AND content->>'run_id' = $2`,
+			[taskId, runId],
+		);
+		expect(comments.rows[0].content.actor_name).toBe('Admin');
+		expect(comments.rows[0].content.actor_id).toBeNull();
 	});
 
 	it('does not insert a second comment when the run finishes', async () => {

--- a/packages/server/test/queued-wakeups.test.ts
+++ b/packages/server/test/queued-wakeups.test.ts
@@ -273,7 +273,7 @@ describe('GET /teams/:teamId/tasks/:taskId/queued-wakeups', () => {
 });
 
 describe('POST /teams/:teamId/tasks/:taskId/queued-wakeups/:wakeupId/run-now', () => {
-	it('dispatches a runnable queued wakeup and records a wakeup_started comment', async () => {
+	it('stamps the actor on the wakeup payload and dispatches without a wakeup_started comment', async () => {
 		await clearWakeups(taskId);
 		await clearRuns();
 		await clearBlockers(taskId);
@@ -283,25 +283,21 @@ describe('POST /teams/:teamId/tasks/:taskId/queued-wakeups/:wakeupId/run-now', (
 		expect(res.status).toBe(200);
 		expect((await res.json()).data.dispatched).toBe(true);
 
-		// The wakeup is claimed out of the queue. The seeded project has no
-		// designated repo / container, so activateAgent no-ops before launching a
-		// container (keeping the stub-docker run from firing) — but the route's
-		// claim + dispatch + system-comment path is fully exercised.
-		const row = await db.query<{ status: string }>(
-			'SELECT status FROM agent_wakeup_requests WHERE id = $1',
-			[wakeupId],
-		);
+		// The wakeup is claimed out of the queue and carries the triggering actor
+		// in its payload — createHeartbeatRun reads it from there and folds it
+		// into the run comment's content (no separate system comment is written).
+		const row = await db.query<{
+			status: string;
+			payload: { triggered_by?: { member_id: string | null; name: string } };
+		}>('SELECT status, payload FROM agent_wakeup_requests WHERE id = $1', [wakeupId]);
 		expect(row.rows[0].status).not.toBe('queued');
+		expect(row.rows[0].payload.triggered_by?.name).toBe('Test Admin');
 
-		const sys = await db.query<{ content: { kind?: string; wakeup_id?: string } }>(
-			"SELECT content FROM task_comments WHERE task_id = $1 AND content_type = 'system' ORDER BY created_at DESC",
+		const sys = await db.query<{ content: { kind?: string } }>(
+			"SELECT content FROM task_comments WHERE task_id = $1 AND content_type = 'system'",
 			[taskId],
 		);
-		expect(
-			sys.rows.some(
-				(s) => s.content?.kind === 'wakeup_started' && s.content?.wakeup_id === wakeupId,
-			),
-		).toBe(true);
+		expect(sys.rows.some((s) => s.content?.kind === 'wakeup_started')).toBe(false);
 
 		const { body } = await listQueued(taskId);
 		expect(body.data.wakeups.map((w) => w.id)).not.toContain(wakeupId);
@@ -516,13 +512,19 @@ describe('POST /teams/:teamId/tasks/:taskId/runs/:runId/retry', () => {
 		expect(res.status).toBe(200);
 		expect((await res.json()).data.dispatched).toBe(true);
 
-		// A wakeup was created for the failed run's agent and was claimed by dispatch.
+		// A wakeup was created for the failed run's agent, carries the actor on
+		// its payload (so the run comment surfaces "started by …"), and was
+		// claimed by dispatch — no separate wakeup_started system comment.
 		const wakeup = await db.query<{
 			id: string;
 			member_id: string;
 			source: string;
 			status: string;
-			payload: { task_id?: string; source_run_id?: string };
+			payload: {
+				task_id?: string;
+				source_run_id?: string;
+				triggered_by?: { member_id: string | null; name: string };
+			};
 		}>(
 			"SELECT id, member_id, source, status, payload FROM agent_wakeup_requests WHERE payload->>'task_id' = $1",
 			[taskId],
@@ -532,12 +534,13 @@ describe('POST /teams/:teamId/tasks/:taskId/runs/:runId/retry', () => {
 		expect(wakeup.rows[0].source).toBe('on_demand');
 		expect(wakeup.rows[0].status).not.toBe('queued');
 		expect(wakeup.rows[0].payload?.source_run_id).toBe(runId);
+		expect(wakeup.rows[0].payload.triggered_by?.name).toBe('Test Admin');
 
 		const sys = await db.query<{ content: { kind?: string } }>(
-			"SELECT content FROM task_comments WHERE task_id = $1 AND content_type = 'system' ORDER BY created_at DESC",
+			"SELECT content FROM task_comments WHERE task_id = $1 AND content_type = 'system'",
 			[taskId],
 		);
-		expect(sys.rows.some((s) => s.content?.kind === 'wakeup_started')).toBe(true);
+		expect(sys.rows.some((s) => s.content?.kind === 'wakeup_started')).toBe(false);
 	});
 
 	it('returns 404 when the run id is unknown', async () => {

--- a/packages/web/src/components/comment-content.ts
+++ b/packages/web/src/components/comment-content.ts
@@ -91,6 +91,8 @@ export interface RunContent {
 	agent_id?: string;
 	agent_title?: string;
 	agent_slug?: string;
+	actor_id?: string | null;
+	actor_name?: string;
 }
 
 export interface ActionContent {

--- a/packages/web/src/components/comment-renderers/run-comment.tsx
+++ b/packages/web/src/components/comment-renderers/run-comment.tsx
@@ -27,6 +27,7 @@ export function RunComment({ comment, projectId, inline }: Props) {
 	const agentId = comment.content?.agent_id ?? '';
 	const agentTitle = comment.content?.agent_title ?? 'Agent';
 	const agentSlug = comment.content?.agent_slug ?? '';
+	const actorName = comment.content?.actor_name ?? null;
 
 	if (!projectId || !runId || !agentId) {
 		return <p className="text-xs text-text-subtle italic">Run reference missing.</p>;
@@ -41,6 +42,7 @@ export function RunComment({ comment, projectId, inline }: Props) {
 					agentId={agentId}
 					agentTitle={agentTitle}
 					agentSlug={agentSlug}
+					actorName={actorName}
 					createdAt={comment.created_at}
 					inline={inline}
 				/>
@@ -55,6 +57,7 @@ function RunCommentBody({
 	agentId,
 	agentTitle,
 	agentSlug,
+	actorName,
 	createdAt,
 	inline,
 }: {
@@ -63,6 +66,7 @@ function RunCommentBody({
 	agentId: string;
 	agentTitle: string;
 	agentSlug: string;
+	actorName: string | null;
 	createdAt: string;
 	inline?: boolean;
 }) {
@@ -102,6 +106,15 @@ function RunCommentBody({
 			>
 				{agentTitle} run
 			</Link>
+			{actorName && (
+				<span
+					className="inline-flex items-center text-xs text-text-subtle shrink-0 whitespace-nowrap"
+					data-testid="run-comment-actor"
+				>
+					<span aria-hidden="true">·</span>
+					<span className="ml-1.5">started by {actorName}</span>
+				</span>
+			)}
 			{completed && (
 				<span
 					className="inline-flex items-center gap-1.5 text-xs text-text-subtle shrink-0 whitespace-nowrap"

--- a/packages/web/test/run-created-tasks.test.tsx
+++ b/packages/web/test/run-created-tasks.test.tsx
@@ -186,6 +186,75 @@ test('run comment omits created tickets section when list is empty', async () =>
 	expect(queryByTestId('run-comment-created-tasks')).toBeNull();
 });
 
+test('run comment header shows "started by …" chip when actor_name is set', async () => {
+	const seeded = { projectSlug: '', taskId: '' };
+
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const captain = ws.agents.find((a) => a.slug === 'captain') ?? ws.agents[0];
+			const project = await seedProject(ws, { name: 'Actor Chip Project' });
+			const task = await seedTask(ws, project, {
+				title: 'Triggered Task',
+				assignee_id: captain.id,
+			});
+
+			seeded.projectSlug = project.slug;
+			seeded.taskId = task.identifier.toLowerCase();
+
+			const runId = '99999999-9999-9999-9999-0000000000aa';
+			const runComment = {
+				id: 'aaaa0000-0000-0000-0000-0000000000aa',
+				task_id: task.id,
+				content_type: 'run',
+				content: {
+					run_id: runId,
+					agent_id: captain.id,
+					agent_title: 'Architect',
+					actor_id: null,
+					actor_name: 'Admin',
+				},
+				chosen_option: null,
+				created_at: new Date().toISOString(),
+				author_type: 'agent',
+				author_name: 'Architect',
+				author_member_id: captain.id,
+			};
+			const runResponse = {
+				id: runId,
+				member_id: captain.id,
+				team_id: ws.team.id,
+				task_id: task.id,
+				project_id: project.id,
+				project_slug: project.slug,
+				status: 'succeeded',
+				started_at: new Date().toISOString(),
+				finished_at: new Date().toISOString(),
+				exit_code: 0,
+				error: null,
+				input_tokens: 0,
+				output_tokens: 0,
+				cost_cents: 0,
+				log_text: 'done',
+				created_tasks: [],
+			};
+
+			buildFetchMock({ runId, runComment, runResponse });
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
+	});
+
+	await findByTestId('run-comment', undefined, { timeout: 20_000 });
+
+	const actorChip = await findByTestId('run-comment-actor', undefined, { timeout: 20_000 });
+	expect(actorChip.textContent).toContain('started by Admin');
+});
+
 test('run comment links updated docs, skills, and proposed skills', async () => {
 	const seeded = { projectSlug: '', taskId: '' };
 


### PR DESCRIPTION
## Summary

The "Admin started queued run for {agent}" system comment was being written as a separate row ~3ms after the run-card comment with the same timestamp, so it rendered as a duplicate grey line beneath the run card. This change folds that metadata into the run card itself.

- Stamp `triggered_by: {member_id, name}` onto the wakeup payload in the `/run-now` and `/retry-failed-run` routes
- Read `triggered_by` from the wakeup payload in `createHeartbeatRun` and embed `actor_id` / `actor_name` into the run comment's content JSONB
- Render a `· started by {actor_name}` chip in the run-card header next to the agent title
- Delete `recordWakeupStarted` and the `wakeup_started` system row entirely
- Scheduler-triggered runs stay clean (no chip)

### Before

> Architect run — running 41 lines
> *(separate row)* Admin started queued run for Architect &nbsp;&nbsp; 09/06/2026, 15:10:47

### After

> Architect run · started by Admin · 41 lines · …

## Test plan

- [x] `bun run typecheck`
- [x] `bun run test --skip-browser` (server: 1739 passed / web: 261 passed)
- [x] New web component test asserts the chip renders when `actor_name` is set
- [x] New server unit test asserts `createHeartbeatRun` embeds `triggeredBy` into the run comment content
- [x] Updated server route tests assert actor info lands on the wakeup payload and no `wakeup_started` system row is created
- [ ] Manual: click **Run now** on a queued wakeup and **Retry** on a failed run — verify the chip appears in the run card header and no separate grey line is rendered below it