### PR TITLE
feat(repos): elegant handling of GitHub repo-name collision on create

### DIFF
--- a/packages/server/src/routes/repos.ts
+++ b/packages/server/src/routes/repos.ts
@@ -119,18 +119,22 @@ reposRoutes.post('/projects/:projectId/repos', async (c) => {
 			);
 		}
 	} else {
+		let created: Awaited<ReturnType<typeof createGitHubRepo>>;
 		try {
-			const created = await createGitHubRepo(
-				body.owner!,
-				body.name!,
-				body.private ?? true,
-				accessToken,
-			);
-			owner = created.owner;
-			repoName = created.name;
+			created = await createGitHubRepo(body.owner!, body.name!, body.private ?? true, accessToken);
 		} catch (e) {
 			return err(c, 'REPO_CREATE_FAILED', (e as Error).message, 500);
 		}
+		if (created.status === 'already_exists') {
+			return err(
+				c,
+				'GITHUB_REPO_EXISTS',
+				`A repository named "${created.owner}/${created.name}" already exists on GitHub.`,
+				409,
+			);
+		}
+		owner = created.owner;
+		repoName = created.name;
 	}
 	const repoIdentifier = `${owner}/${repoName}`;
 

--- a/packages/server/src/services/github.ts
+++ b/packages/server/src/services/github.ts
@@ -32,13 +32,16 @@ export interface GitHubRepoSummary {
 	ssh_url: string;
 }
 
-export interface CreateRepoResult {
-	owner: string;
-	name: string;
-	full_name: string;
-	private: boolean;
-	default_branch: string;
-}
+export type CreateRepoResult =
+	| {
+			status: 'created';
+			owner: string;
+			name: string;
+			full_name: string;
+			private: boolean;
+			default_branch: string;
+	  }
+	| { status: 'already_exists'; owner: string; name: string };
 
 const authHeaders = (accessToken: string) => ({
 	Authorization: `Bearer ${accessToken}`,
@@ -147,6 +150,13 @@ export async function createGitHubRepo(
 
 	if (!res.ok) {
 		const body = await res.text();
+		if (res.status === 422 && isRepoNameAlreadyExists(body)) {
+			log.info('GitHub repo name already exists, surfacing as already_exists', {
+				owner,
+				name,
+			});
+			return { status: 'already_exists', owner, name };
+		}
 		throw new Error(`Failed to create GitHub repo (${res.status}): ${body}`);
 	}
 
@@ -158,6 +168,7 @@ export async function createGitHubRepo(
 		owner: { login: string };
 	};
 	return {
+		status: 'created',
 		owner: data.owner.login,
 		name: data.name,
 		full_name: data.full_name,
@@ -275,11 +286,35 @@ export async function registerAuthKey(
 	return { status: 'created', id: data.id, title: data.title };
 }
 
-function isKeyAlreadyInUse(body: string): boolean {
+interface GitHubFieldError {
+	resource?: string;
+	code?: string;
+	field?: string;
+	message?: string;
+}
+
+function matchesGitHubFieldError(
+	body: string,
+	predicate: (e: GitHubFieldError) => boolean,
+): boolean {
 	try {
-		const parsed = JSON.parse(body) as { errors?: Array<{ message?: string }> };
-		return (parsed.errors ?? []).some((e) => /key is already in use/i.test(e.message ?? ''));
+		const parsed = JSON.parse(body) as { errors?: GitHubFieldError[] };
+		return (parsed.errors ?? []).some(predicate);
 	} catch {
-		return /key is already in use/i.test(body);
+		return false;
 	}
+}
+
+function isKeyAlreadyInUse(body: string): boolean {
+	if (matchesGitHubFieldError(body, (e) => /key is already in use/i.test(e.message ?? ''))) {
+		return true;
+	}
+	return /key is already in use/i.test(body);
+}
+
+function isRepoNameAlreadyExists(body: string): boolean {
+	return matchesGitHubFieldError(
+		body,
+		(e) => e.field === 'name' && /already exists/i.test(e.message ?? ''),
+	);
 }

--- a/packages/server/test/helpers/app.ts
+++ b/packages/server/test/helpers/app.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { PGlite } from '@electric-sql/pglite';
 import { AgentAdminStatus, CAPTAIN_AGENT_SLUG } from '@hezo/shared';
+import { encrypt } from '../../src/crypto/encryption';
 import { generateMasterKey, MasterKeyManager } from '../../src/crypto/master-key';
 import { loadAgentRoles } from '../../src/db/agent-roles';
 import { seedBuiltins } from '../../src/db/seed';
@@ -47,6 +48,15 @@ export function createStubDocker<T extends Record<string, unknown>>(
 ): DockerClient & T {
 	return { ...STUB_DOCKER_METHODS, ...overrides } as unknown as DockerClient & T;
 }
+
+/**
+ * Re-exported from the server's crypto module so tests across packages can
+ * import it via the `@hezo/server/test/helpers/app` path the workspace
+ * symlink + vitest alias both resolve. Importing from `@hezo/server/crypto/*`
+ * directly would only work under the vitest alias, not under TS module
+ * resolution.
+ */
+export { encrypt };
 
 export async function createTestApp(opts: { webUrl?: string } = {}) {
 	const db = await createTestDbWithMigrations();

--- a/packages/server/test/helpers/github-sim.ts
+++ b/packages/server/test/helpers/github-sim.ts
@@ -160,9 +160,27 @@ export async function createGitHubSim(): Promise<GitHubSim> {
 		return c.json(found);
 	});
 
+	const repoNameAlreadyExistsResponse = () => ({
+		message: 'Repository creation failed.',
+		errors: [
+			{
+				resource: 'Repository',
+				code: 'custom',
+				field: 'name',
+				message: 'name already exists on this account',
+			},
+		],
+		documentation_url:
+			'https://docs.github.com/rest/repos/repos#create-a-repository-for-the-authenticated-user',
+		status: '422',
+	});
+
 	app.post('/user/repos', async (c) => {
 		if (!isAuthed(c.req.header('Authorization'))) return c.json({ message: 'Unauthorized' }, 401);
 		const body = await c.req.json<{ name: string; private?: boolean }>();
+		if (state.repos.some((r) => r.owner.login === state.user.login && r.name === body.name)) {
+			return c.json(repoNameAlreadyExistsResponse(), 422);
+		}
 		const repo = makeRepo(state.user.login, body.name, body.private ?? true);
 		state.repos.push(repo);
 		return c.json(repo, 201);
@@ -172,6 +190,9 @@ export async function createGitHubSim(): Promise<GitHubSim> {
 		if (!isAuthed(c.req.header('Authorization'))) return c.json({ message: 'Unauthorized' }, 401);
 		const owner = c.req.param('owner');
 		const body = await c.req.json<{ name: string; private?: boolean }>();
+		if (state.repos.some((r) => r.owner.login === owner && r.name === body.name)) {
+			return c.json(repoNameAlreadyExistsResponse(), 422);
+		}
 		const repo = makeRepo(owner, body.name, body.private ?? true);
 		state.repos.push(repo);
 		return c.json(repo, 201);

--- a/packages/server/test/repos-create-github.test.ts
+++ b/packages/server/test/repos-create-github.test.ts
@@ -1,0 +1,120 @@
+import type { PGlite } from '@electric-sql/pglite';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { MasterKeyManager } from '../src/crypto/master-key';
+import type { Env } from '../src/lib/types';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp, createTestProject } from './helpers/app';
+import { createGitHubSim, type GitHubSim } from './helpers/github-sim';
+
+let app: Hono<Env>;
+let db: PGlite;
+let masterKeyManager: MasterKeyManager;
+let token: string;
+let teamId: string;
+let projectId: string;
+let oauthConnectionId: string;
+let sim: GitHubSim;
+
+let prevApi: string | undefined;
+const accessToken = 'gho_repo_create_test_token';
+
+async function seedGitHubOAuthConnection(login: string): Promise<string> {
+	const { encrypt } = await import('../src/crypto/encryption');
+	const key = masterKeyManager.getKey();
+	if (!key) throw new Error('master key not available');
+	const encrypted = encrypt(accessToken, key);
+
+	const secretRes = await db.query<{ id: string }>(
+		`INSERT INTO secrets (team_id, name, encrypted_value, category, allowed_hosts)
+		 VALUES ($1, $2, $3, 'api_token', ARRAY['github.com'])
+		 RETURNING id`,
+		[teamId, `OAUTH_GITHUB_${Math.random().toString(16).slice(2, 10)}`, encrypted],
+	);
+	const connRes = await db.query<{ id: string }>(
+		`INSERT INTO oauth_connections (team_id, provider, provider_account_id, provider_account_label, access_token_secret_id, scopes)
+		 VALUES ($1, 'github', $2, $3, $4, ARRAY['repo','read:org'])
+		 RETURNING id`,
+		[teamId, '9001', login, secretRes.rows[0].id],
+	);
+	return connRes.rows[0].id;
+}
+
+beforeAll(async () => {
+	sim = await createGitHubSim();
+	prevApi = process.env.GITHUB_API_BASE_URL;
+	process.env.GITHUB_API_BASE_URL = sim.baseUrl;
+
+	sim.seed({
+		token: accessToken,
+		user: { id: 9001, login: 'octo-repo', avatar_url: '', email: 'octo@e2e' },
+		repos: [
+			{
+				id: 555,
+				name: 'already-taken',
+				full_name: 'octo-repo/already-taken',
+				owner: { login: 'octo-repo' },
+				private: true,
+				default_branch: 'main',
+				clone_url: 'https://github.com/octo-repo/already-taken.git',
+				ssh_url: 'git@github.com:octo-repo/already-taken.git',
+			},
+		],
+	});
+
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	masterKeyManager = ctx.masterKeyManager;
+	token = ctx.token;
+
+	const typesRes = await app.request('/api/team-templates', { headers: authHeader(token) });
+	const typeId = (await typesRes.json()).data.find(
+		(t: { name: string }) => t.name === 'Startup',
+	).id;
+	const teamRes = await app.request('/api/teams', {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ name: 'Repo Create Co', template_id: typeId }),
+	});
+	teamId = (await teamRes.json()).data.id;
+
+	const projectRes = await createTestProject(db, teamId, { name: 'Repo Create Project' });
+	projectId = (await projectRes.json()).data.id;
+
+	oauthConnectionId = await seedGitHubOAuthConnection('octo-repo');
+});
+
+afterAll(async () => {
+	process.env.GITHUB_API_BASE_URL = prevApi;
+	await sim.destroy();
+	await safeClose(db);
+});
+
+describe('POST /api/projects/:projectId/repos with mode=create', () => {
+	it('returns 409 GITHUB_REPO_EXISTS when the name is already taken on GitHub', async () => {
+		const res = await app.request(`/api/projects/${projectId}/repos`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				short_name: 'collision',
+				mode: 'create',
+				owner: 'octo-repo',
+				name: 'already-taken',
+				private: true,
+				oauth_connection_id: oauthConnectionId,
+			}),
+		});
+		expect(res.status).toBe(409);
+		const body = await res.json();
+		expect(body.error.code).toBe('GITHUB_REPO_EXISTS');
+		expect(body.error.message).toContain('octo-repo/already-taken');
+		expect(body.error.message).toContain('already exists');
+		expect(body.error.message).not.toMatch(/^Failed to create GitHub repo/);
+
+		const repoRows = await db.query<{ id: string }>('SELECT id FROM repos WHERE project_id = $1', [
+			projectId,
+		]);
+		expect(repoRows.rows).toHaveLength(0);
+	});
+});

--- a/packages/web/src/components/repo-picker-modal.tsx
+++ b/packages/web/src/components/repo-picker-modal.tsx
@@ -7,6 +7,7 @@ import {
 	useGitHubOrgs,
 	useGitHubReposForOwner,
 } from '../hooks/use-repos';
+import type { ApiError } from '../lib/api';
 import { Button } from './ui/button';
 import { dialogContentClassName, dialogOverlayClassName } from './ui/dialog';
 import { Input } from './ui/input';
@@ -19,6 +20,14 @@ interface RepoPickerModalProps {
 }
 
 type PickerMode = 'link' | 'create';
+
+type CreateError =
+	| { kind: 'generic'; message: string }
+	| { kind: 'repo_exists'; owner: string; name: string };
+
+function isApiError(e: unknown): e is ApiError {
+	return typeof e === 'object' && e !== null && 'code' in e && 'message' in e && 'status' in e;
+}
 
 function slugify(value: string): string {
 	return value
@@ -44,7 +53,7 @@ export function RepoPickerModal({
 	const [shortNameTouched, setShortNameTouched] = useState(false);
 	const [newRepoName, setNewRepoName] = useState('');
 	const [newRepoPrivate, setNewRepoPrivate] = useState(true);
-	const [error, setError] = useState<string | null>(null);
+	const [createError, setCreateError] = useState<CreateError | null>(null);
 
 	const createRepo = useCreateRepo(projectId);
 	const orgsQuery = useGitHubOrgs(projectId, open ? oauthConnectionId : null);
@@ -61,7 +70,7 @@ export function RepoPickerModal({
 			setShortNameTouched(false);
 			setNewRepoName('');
 			setNewRepoPrivate(true);
-			setError(null);
+			setCreateError(null);
 		}
 	}, [open]);
 
@@ -94,7 +103,7 @@ export function RepoPickerModal({
 	async function handleSubmit(e: React.FormEvent) {
 		e.preventDefault();
 		if (!owner) return;
-		setError(null);
+		setCreateError(null);
 		try {
 			if (mode === 'link') {
 				const sel = reposQuery.data?.find((r) => r.full_name === selectedRepoFullName);
@@ -117,8 +126,23 @@ export function RepoPickerModal({
 			}
 			onOpenChange(false);
 		} catch (e) {
-			setError((e as Error).message);
+			if (isApiError(e) && e.code === 'GITHUB_REPO_EXISTS' && mode === 'create') {
+				setCreateError({ kind: 'repo_exists', owner, name: newRepoName.trim() });
+			} else {
+				const message = isApiError(e) ? e.message : (e as Error).message;
+				setCreateError({ kind: 'generic', message });
+			}
 		}
+	}
+
+	function switchToLinkExisting(targetOwner: string, targetName: string) {
+		setMode('link');
+		setOwner(targetOwner);
+		setSearch(targetName);
+		setDebouncedSearch(targetName);
+		setSelectedRepoFullName(`${targetOwner}/${targetName}`);
+		setShortNameTouched(false);
+		setCreateError(null);
 	}
 
 	return (
@@ -264,9 +288,31 @@ export function RepoPickerModal({
 							required
 						/>
 
-						{error && (
+						{createError?.kind === 'generic' && (
 							<div className="rounded-radius-md border border-accent-red/40 bg-accent-red/10 px-3 py-2 text-sm text-accent-red">
-								{error}
+								{createError.message}
+							</div>
+						)}
+						{createError?.kind === 'repo_exists' && (
+							<div
+								className="flex flex-col gap-2 rounded-radius-md border border-accent-red/40 bg-accent-red/10 px-3 py-2 text-sm text-accent-red sm:flex-row sm:items-center sm:justify-between"
+								data-testid="repo-picker-exists-banner"
+							>
+								<span>
+									A repository named{' '}
+									<span className="font-mono">
+										{createError.owner}/{createError.name}
+									</span>{' '}
+									already exists on GitHub.
+								</span>
+								<Button
+									type="button"
+									variant="secondary"
+									onClick={() => switchToLinkExisting(createError.owner, createError.name)}
+									data-testid="repo-picker-link-existing"
+								>
+									Link existing instead
+								</Button>
 							</div>
 						)}
 

--- a/packages/web/test/helpers/render.tsx
+++ b/packages/web/test/helpers/render.tsx
@@ -42,6 +42,7 @@ interface TestAppContext {
 	// the version server-side seeders (createTestProject) expect — the web tree
 	// resolves a newer @electric-sql/pglite whose nominal type is incompatible.
 	db: Awaited<ReturnType<typeof createTestApp>>['db'];
+	masterKeyManager: Awaited<ReturnType<typeof createTestApp>>['masterKeyManager'];
 }
 
 let activeContext: TestAppContext | null = null;
@@ -64,6 +65,7 @@ beforeEach(async () => {
 		token: test.token,
 		apiBase,
 		db: test.db,
+		masterKeyManager: test.masterKeyManager,
 	} as unknown as TestAppContext;
 
 	// Auth: drop the token into localStorage AND push it into the api singleton

--- a/packages/web/test/repo-picker-exists.test.tsx
+++ b/packages/web/test/repo-picker-exists.test.tsx
@@ -1,0 +1,120 @@
+import { encrypt } from '@hezo/server/test/helpers/app';
+import { createGitHubSim, type GitHubSim } from '@hezo/server/test/helpers/github-sim';
+import { screen, waitFor } from '@testing-library/react';
+import { afterAll, beforeAll, expect, test } from 'vitest';
+import { getTestContext, renderApp } from './helpers/render';
+import { seedProject, seedWorkspace } from './helpers/seed';
+
+let sim: GitHubSim;
+let prevApi: string | undefined;
+const accessToken = 'gho_picker_test_token';
+const ghOwner = 'octo-picker';
+const collisionName = 'already-taken';
+
+beforeAll(async () => {
+	sim = await createGitHubSim();
+	prevApi = process.env.GITHUB_API_BASE_URL;
+	process.env.GITHUB_API_BASE_URL = sim.baseUrl;
+
+	sim.seed({
+		token: accessToken,
+		user: { id: 9001, login: ghOwner, avatar_url: '', email: 'octo@picker' },
+		repos: [
+			{
+				id: 7,
+				name: collisionName,
+				full_name: `${ghOwner}/${collisionName}`,
+				owner: { login: ghOwner },
+				private: true,
+				default_branch: 'main',
+				clone_url: `https://github.com/${ghOwner}/${collisionName}.git`,
+				ssh_url: `git@github.com:${ghOwner}/${collisionName}.git`,
+			},
+		],
+	});
+});
+
+afterAll(async () => {
+	process.env.GITHUB_API_BASE_URL = prevApi;
+	await sim.destroy();
+});
+
+async function seedGitHubOAuth(teamId: string): Promise<string> {
+	const { db, masterKeyManager } = getTestContext();
+	const key = masterKeyManager.getKey();
+	if (!key) throw new Error('master key not available');
+	const encrypted = encrypt(accessToken, key);
+
+	const secretRes = await db.query<{ id: string }>(
+		`INSERT INTO secrets (team_id, name, encrypted_value, category, allowed_hosts)
+		 VALUES ($1, $2, $3, 'api_token', ARRAY['github.com'])
+		 RETURNING id`,
+		[teamId, `OAUTH_GITHUB_${Math.random().toString(16).slice(2, 10)}`, encrypted],
+	);
+	const connRes = await db.query<{ id: string }>(
+		`INSERT INTO oauth_connections (team_id, provider, provider_account_id, provider_account_label, access_token_secret_id, scopes)
+		 VALUES ($1, 'github', $2, $3, $4, ARRAY['repo','read:org','write:public_key'])
+		 RETURNING id`,
+		[teamId, '9001', ghOwner, secretRes.rows[0].id],
+	);
+	return connRes.rows[0].id;
+}
+
+test('GITHUB_REPO_EXISTS surfaces a link-existing affordance that flips the modal', async () => {
+	let projectSlug = '';
+	const { user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Picker Project' });
+			projectSlug = project.slug;
+			await seedGitHubOAuth(ws.team.id);
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/settings',
+		params: { projectId: projectSlug },
+	});
+
+	const openModalButton = await screen.findByTestId('repo-setup-add', undefined, {
+		timeout: 15_000,
+	});
+	await user.click(openModalButton);
+
+	const modal = await screen.findByTestId('repo-picker-modal', undefined, { timeout: 5_000 });
+
+	await user.click(await screen.findByTestId('repo-picker-tab-create'));
+
+	const ownerSelect = await screen.findByTestId('repo-picker-owner');
+	await waitFor(() => {
+		expect((ownerSelect as HTMLSelectElement).value).toBe(ghOwner);
+	});
+
+	const nameInput = modal.querySelector('input[placeholder="my-new-service"]') as HTMLInputElement;
+	await user.type(nameInput, collisionName);
+
+	await user.click(await screen.findByTestId('repo-picker-submit'));
+
+	const banner = await screen.findByTestId('repo-picker-exists-banner', undefined, {
+		timeout: 10_000,
+	});
+	expect(banner.textContent).toContain(`${ghOwner}/${collisionName}`);
+	expect(banner.textContent).toContain('already exists');
+
+	await user.click(await screen.findByTestId('repo-picker-link-existing'));
+
+	await screen.findByTestId(`repo-picker-row-${ghOwner}/${collisionName}`, undefined, {
+		timeout: 10_000,
+	});
+
+	const searchInput = modal.querySelector(
+		'input[placeholder="Filter by name…"]',
+	) as HTMLInputElement;
+	expect(searchInput.value).toBe(collisionName);
+
+	const row = await screen.findByTestId(`repo-picker-row-${ghOwner}/${collisionName}`);
+	expect(row.className).toContain('bg-bg-subtle');
+
+	expect(screen.queryByTestId('repo-picker-exists-banner')).toBeNull();
+});


### PR DESCRIPTION
## Summary

When a user tries to create a GitHub repo whose name is already taken on the chosen account, today the server bubbles GitHub's raw 422 JSON up inside a 500 `REPO_CREATE_FAILED`, and the picker modal renders the blob verbatim — e.g.

> Failed to create GitHub repo (422): {"message":"Repository creation failed.","errors":[{"resource":"Repository","code":"custom","field":"name","message":"name already exists on this account"}],...}

This PR turns that into a clean 409 with a one-click recovery path.

- `createGitHubRepo` now returns a discriminated union (`{ status: 'created', ... } | { status: 'already_exists', owner, name }`), mirroring the pattern already used by `registerSigningKey` / `registerAuthKey` for 422 "key is already in use".
- The route maps `already_exists` to HTTP 409 with code `GITHUB_REPO_EXISTS` and a user-readable message. Other GitHub failures still throw and route through the catch-all 500 `REPO_CREATE_FAILED`.
- The picker modal swaps its string `error` state for a discriminated `CreateError`. On `GITHUB_REPO_EXISTS` it renders a banner with a **Link existing instead** button that switches the modal to link mode, prefills the owner + search, and pre-selects the colliding row — submit lands a link without re-entering anything.
- Small refactor: the JSON-error parsing in `isKeyAlreadyInUse` is generalised into a `matchesGitHubFieldError` helper shared with the new `isRepoNameAlreadyExists`.

## Tests

- `packages/server/test/repos-create-github.test.ts` — drives the route end-to-end through the existing GitHub simulator (now returning 422 on duplicate names) and asserts 409 + code + message shape, plus that no `repos` row is created on collision.
- `packages/web/test/repo-picker-exists.test.tsx` — full UI flow: open the modal, submit a colliding name, confirm the banner appears, click **Link existing instead**, confirm mode flips, search prefills, and the matching row is selected.
- Shared exposure: `encrypt` is re-exported from `@hezo/server/test/helpers/app` so cross-package tests can seed real OAuth secrets without depending on a path the TS resolver can't see.

## Test plan

- [x] `bun run test --pattern repos --skip-browser` — all repos server + web tests green
- [x] `bun run test --pattern repo- --skip-browser` — adjacent repo-* specs green
- [x] `bun run test --pattern oauth-github --skip-browser` — sim changes don't regress existing OAuth specs
- [x] `bun run typecheck` — clean across `@hezo/shared`, `@hezo/server`, `@hezo/web`
- [x] Full `bun run test --skip-browser` — 260/261 tests pass; one unrelated `project-sidebar` timeout on a full-load run, passes on its own