### PR TITLE
fix(server): bound docker.request timeouts, bump cron-async to 1.2.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "@huggingface/transformers": "^4.0.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "commander": "^14.0.3",
-        "cron-async": "^1.2.0",
+        "cron-async": "^1.2.1",
         "hono": "^4",
         "http-mitm-proxy": "^1.1.0",
         "mockttp": "^4.3.1",
@@ -830,7 +830,7 @@
 
     "cosmiconfig-typescript-loader": ["cosmiconfig-typescript-loader@6.2.0", "", { "dependencies": { "jiti": "^2.6.1" }, "peerDependencies": { "@types/node": "*", "cosmiconfig": ">=9", "typescript": ">=5" } }, "sha512-GEN39v7TgdxgIoNcdkRE3uiAzQt3UXLyHbRHD6YoL048XAeOomyxaP+Hh/+2C6C2wYjxJ2onhJcsQp+L4YEkVQ=="],
 
-    "cron-async": ["cron-async@1.2.0", "", { "dependencies": { "cron-schedule": "^3.0.6" } }, "sha512-9CjhJ4iv3LHSmfacDl59XXwzQyBxViFpk1ULuuGsYPVs4cgHMno/YpUEQxQZhH74ENViHsc3yqmI9i6QpZK4yQ=="],
+    "cron-async": ["cron-async@1.2.1", "", { "dependencies": { "cron-schedule": "^3.0.6" } }, "sha512-drC42q2nzG1OBxJB21gemu+ilXZLnD9OGSCa6wZ4JfLIv6oUvdMqAfT5YpmV5Ymt8PPti/1jErmMUycOaV1KBw=="],
 
     "cron-schedule": ["cron-schedule@3.0.6", "", {}, "sha512-izfGgKyzzIyLaeb1EtZ3KbglkS6AKp9cv7LxmiyoOu+fXfol1tQDC0Cof0enVZGNtudTHW+3lfuW9ZkLQss4Wg=="],
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -19,7 +19,7 @@
 		"@huggingface/transformers": "^4.0.1",
 		"@modelcontextprotocol/sdk": "^1.29.0",
 		"commander": "^14.0.3",
-		"cron-async": "^1.2.0",
+		"cron-async": "^1.2.1",
 		"hono": "^4",
 		"http-mitm-proxy": "^1.1.0",
 		"mockttp": "^4.3.1",

--- a/packages/server/src/services/docker.ts
+++ b/packages/server/src/services/docker.ts
@@ -1,6 +1,19 @@
 const SOCKET_PATH = '/var/run/docker.sock';
 const API_VERSION = 'v1.44';
 
+/**
+ * Hard ceiling for docker daemon calls made by the cron-driven sync loop.
+ * A wedged Unix-socket fetch would otherwise stall the container-sync iteration
+ * indefinitely. Override via DOCKER_REQUEST_TIMEOUT_MS to widen for slow hosts.
+ */
+const DEFAULT_DOCKER_REQUEST_TIMEOUT_MS = 10_000;
+const DOCKER_REQUEST_TIMEOUT_MS = (() => {
+	const raw = process.env.DOCKER_REQUEST_TIMEOUT_MS;
+	if (!raw) return DEFAULT_DOCKER_REQUEST_TIMEOUT_MS;
+	const parsed = Number.parseInt(raw, 10);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_DOCKER_REQUEST_TIMEOUT_MS;
+})();
+
 interface ContainerConfig {
 	Image: string;
 	Cmd?: string[];
@@ -114,7 +127,12 @@ export class DockerClient {
 
 	async ping(): Promise<boolean> {
 		try {
-			const res = await this.request('GET', '/_ping');
+			const res = await this.request(
+				'GET',
+				'/_ping',
+				undefined,
+				AbortSignal.timeout(DOCKER_REQUEST_TIMEOUT_MS),
+			);
 			return res.ok;
 		} catch {
 			return false;
@@ -206,7 +224,12 @@ export class DockerClient {
 	}
 
 	async inspectContainer(containerId: string): Promise<ContainerInfo | null> {
-		const res = await this.request('GET', `/containers/${containerId}/json`);
+		const res = await this.request(
+			'GET',
+			`/containers/${containerId}/json`,
+			undefined,
+			AbortSignal.timeout(DOCKER_REQUEST_TIMEOUT_MS),
+		);
 		if (res.status === 404) {
 			await res.text();
 			return null;
@@ -231,7 +254,12 @@ export class DockerClient {
 	 * which avoids flagging containers that are merely reading/writing files.
 	 */
 	async containerStats(containerId: string): Promise<ContainerMemoryStats | null> {
-		const res = await this.request('GET', `/containers/${containerId}/stats?stream=false`);
+		const res = await this.request(
+			'GET',
+			`/containers/${containerId}/stats?stream=false`,
+			undefined,
+			AbortSignal.timeout(DOCKER_REQUEST_TIMEOUT_MS),
+		);
 		if (res.status === 404) {
 			await res.text();
 			return null;


### PR DESCRIPTION
## Summary

- Adds a `DOCKER_REQUEST_TIMEOUT_MS` env-var-configurable `AbortSignal.timeout` (default 10s) to the three sync-loop docker calls — `ping`, `inspectContainer`, `containerStats`. Streaming methods (`containerLogs` follow, `execStart`) keep their per-call signals.
- Bumps `cron-async` `^1.2.0` → `^1.2.1`, picking up the upstream fix for a `setInterval` bug where the scheduler was ticking every event-loop iteration instead of every 100ms.

## Why

After a dev-server restart the console was being flooded with thousands of lines per second of:

```
<job-manager> [container-sync] Job still executing previous iteration, skipping run
```

Two distinct bugs combined:

1. **`docker.request` had no timeout.** `syncAllContainerStatuses` calls `inspectContainer` and `containerStats` per project with each `fetch` to `/var/run/docker.sock` waiting indefinitely. macOS Docker Desktop can wedge those calls during a container restart/replace, and the cron iteration never returned.
2. **`cron-async@1.2.0` `_startCron` had `setInterval(fn)` with no delay** (the `100` was misplaced as a `forEach` thisArg). Node clamps the empty delay to 1ms, so the scheduler ticked ~1000×/sec. While the hung iteration held the `isExecutingAnIteration` flag, every tick logged the skip line.

The two together flooded the log AND blocked agent dispatch — `processWakeup` requires `container_status = Running`, but the sync that flips `Creating → Running` was the wedged loop.

(1) addresses the root cause: a wedged daemon call now errors after 10s, the next tick gets a clean iteration, and status transitions resume. (2) addresses defense-in-depth — even if something else hangs in future, the console stays readable.

## Test plan

- [x] `bun run test --skip-browser --package server` — all 153 vitest files / 1744 tests pass, Bun-native tier passes
- [x] `bunx turbo typecheck --filter=@hezo/server` — clean
- [ ] Restart dev server with a project that has a `running` container — verify `[container-sync] Running job` / `Finished running job` pair appears once per second, no flood
- [ ] Click Restart on an errored container — verify `container_status` reaches `Running` within ~5s and queued wakeups dispatch
- [ ] Optionally set `DOCKER_REQUEST_TIMEOUT_MS=30000` and confirm the override is picked up

🤖 Generated with [Claude Code](https://claude.com/claude-code)