### PR TITLE
refactor(web): remove Clear button from container logs view

### DIFF
--- a/packages/web/src/components/log-viewer.tsx
+++ b/packages/web/src/components/log-viewer.tsx
@@ -7,7 +7,6 @@ import {
 	Maximize2,
 	Minimize2,
 	MoveVertical,
-	Trash2,
 } from 'lucide-react';
 import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import { FormattedLogView } from './formatted-log-view';
@@ -22,7 +21,6 @@ export interface LogViewerLine {
 
 interface LogViewerProps {
 	lines: LogViewerLine[];
-	onClear?: () => void;
 	emptyState?: ReactNode;
 	liveLabel?: ReactNode;
 	heightClassName?: string;
@@ -41,7 +39,6 @@ interface LogViewerProps {
 
 export function LogViewer({
 	lines,
-	onClear,
 	emptyState,
 	liveLabel,
 	heightClassName = 'h-[400px]',
@@ -181,19 +178,6 @@ export function LogViewer({
 							<MoveVertical className="w-3 h-3" />
 						</Button>
 					</Tooltip>
-					{!compact && onClear && (
-						<Tooltip content="Clear logs">
-							<Button
-								variant="ghost"
-								size="sm"
-								onClick={onClear}
-								className="text-xs h-6 px-2"
-								aria-label="Clear logs"
-							>
-								<Trash2 className="w-3 h-3" /> Clear
-							</Button>
-						</Tooltip>
-					)}
 					{headerAction}
 					<Tooltip content={isExpanded ? 'Collapse' : 'Expand'}>
 						<Button

--- a/packages/web/src/components/log-viewer.tsx
+++ b/packages/web/src/components/log-viewer.tsx
@@ -1,13 +1,5 @@
 import * as Dialog from '@radix-ui/react-dialog';
-import {
-	AlignLeft,
-	Check,
-	Code,
-	Copy,
-	Maximize2,
-	Minimize2,
-	MoveVertical,
-} from 'lucide-react';
+import { AlignLeft, Check, Code, Copy, Maximize2, Minimize2, MoveVertical } from 'lucide-react';
 import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import { FormattedLogView } from './formatted-log-view';
 import { Button } from './ui/button';

--- a/packages/web/src/routes/projects/$projectId/container.tsx
+++ b/packages/web/src/routes/projects/$projectId/container.tsx
@@ -32,7 +32,7 @@ function ContainerPage() {
 	const isActive = isRunning || isCreating || isStopping;
 
 	const logPhase = isCreating ? 'creating' : isRunning ? 'running' : isError ? 'error' : null;
-	const { lines: liveLogs, clear } = useContainerLogs(
+	const { lines: liveLogs } = useContainerLogs(
 		project?.id ?? '',
 		project?.id ? logPhase : null,
 	);
@@ -179,7 +179,6 @@ function ContainerPage() {
 
 			<LogViewer
 				lines={logs}
-				onClear={showSnapshot ? undefined : clear}
 				liveLabel={
 					showSnapshot ? (
 						<Badge color="neutral">Last known logs</Badge>

--- a/packages/web/src/routes/projects/$projectId/container.tsx
+++ b/packages/web/src/routes/projects/$projectId/container.tsx
@@ -32,10 +32,7 @@ function ContainerPage() {
 	const isActive = isRunning || isCreating || isStopping;
 
 	const logPhase = isCreating ? 'creating' : isRunning ? 'running' : isError ? 'error' : null;
-	const { lines: liveLogs } = useContainerLogs(
-		project?.id ?? '',
-		project?.id ? logPhase : null,
-	);
+	const { lines: liveLogs } = useContainerLogs(project?.id ?? '', project?.id ? logPhase : null);
 
 	const snapshotLines = useMemo<LogViewerLine[]>(() => {
 		const raw = project?.container_last_logs;

--- a/packages/web/test/task-list.test.tsx
+++ b/packages/web/test/task-list.test.tsx
@@ -45,7 +45,6 @@ async function seedAdminMention(ws: SeededWorkspace, taskId: string, text: strin
 }
 
 test('default view shows non-terminal tasks with status badges and a collapsed filter bar with New Task button', async () => {
-	let teamSlug = '';
 	let projectSlug = '';
 
 	const { findByText, findByTestId, queryByTestId, queryByText, router } = await renderApp({
@@ -62,7 +61,6 @@ test('default view shows non-terminal tasks with status badges and a collapsed f
 			await patchStatus(ws, tasks[0].id, 'review');
 			await patchStatus(ws, tasks[1].id, 'in_progress');
 			await patchStatus(ws, tasks[2].id, 'done');
-			teamSlug = ws.team.slug;
 			projectSlug = project.slug;
 		},
 	});
@@ -83,7 +81,6 @@ test('default view shows non-terminal tasks with status badges and a collapsed f
 });
 
 test('multi-select status filter narrows results and reset restores defaults', async () => {
-	let teamSlug = '';
 	let projectSlug = '';
 
 	const { findByText, findByTestId, findByRole, queryByText, router, user } = await renderApp({
@@ -100,7 +97,6 @@ test('multi-select status filter narrows results and reset restores defaults', a
 			await patchStatus(ws, tasks[0].id, 'review');
 			await patchStatus(ws, tasks[1].id, 'in_progress');
 			await patchStatus(ws, tasks[2].id, 'done');
-			teamSlug = ws.team.slug;
 			projectSlug = project.slug;
 		},
 	});
@@ -164,7 +160,6 @@ test('multi-select status filter narrows results and reset restores defaults', a
 });
 
 test('filter bar collapses/expands and applies search + sort', async () => {
-	let teamSlug = '';
 	let projectSlug = '';
 
 	const { findByText, findByTestId, queryByTestId, queryByText, router, user } = await renderApp({
@@ -176,7 +171,6 @@ test('filter bar collapses/expands and applies search + sort', async () => {
 			for (const title of ['Authentication bug', 'Payment flow', 'Sign-up form']) {
 				await seedTask(ws, project, { title, assignee_id: agentId });
 			}
-			teamSlug = ws.team.slug;
 			projectSlug = project.slug;
 		},
 	});
@@ -229,7 +223,6 @@ test('filter bar collapses/expands and applies search + sort', async () => {
 });
 
 test('running dot is hidden by default and shown when a heartbeat run is active', async () => {
-	let teamSlug = '';
 	let projectSlug = '';
 
 	const { findByText, container, router } = await renderApp({
@@ -244,7 +237,6 @@ test('running dot is hidden by default and shown when a heartbeat run is active'
 				assignee_id: agentId,
 			});
 			await insertActiveRun(agentId, ws.team.id, busy.id);
-			teamSlug = ws.team.slug;
 			projectSlug = project.slug;
 		},
 	});
@@ -264,7 +256,6 @@ test('running dot is hidden by default and shown when a heartbeat run is active'
 });
 
 test('mention notice shows only on tasks with an unread admin mention for the viewer', async () => {
-	let teamSlug = '';
 	let projectSlug = '';
 
 	const { findByText, container, router } = await renderApp({
@@ -279,7 +270,6 @@ test('mention notice shows only on tasks with an unread admin mention for the vi
 				assignee_id: agentId,
 			});
 			await seedAdminMention(ws, mentioned.id, '@admin need your call here.');
-			teamSlug = ws.team.slug;
 			projectSlug = project.slug;
 		},
 	});
@@ -300,7 +290,6 @@ test('mention notice shows only on tasks with an unread admin mention for the vi
 });
 
 test('tasks with active runs pin to the top regardless of sort order', async () => {
-	let teamSlug = '';
 	let projectSlug = '';
 
 	const { findByText, container, router } = await renderApp({
@@ -320,7 +309,6 @@ test('tasks with active runs pin to the top regardless of sort order', async () 
 				assignee_id: agentId,
 			});
 			await insertActiveRun(agentId, ws.team.id, old.id);
-			teamSlug = ws.team.slug;
 			projectSlug = project.slug;
 		},
 	});


### PR DESCRIPTION
## Summary

- Drop the **Clear** button from the project container logs view — it served no real purpose since container logs stream live from the server.
- Remove the `onClear` prop from `LogViewer` (the container view was its only consumer) along with the now-unused `Trash2` import and the `clear` destructure from `useContainerLogs`.

## Test plan

- [ ] Open a project → Container tab and confirm the Clear button no longer appears in the log viewer header
- [ ] Confirm Copy, auto-scroll toggle, and expand/collapse still work
- [ ] Confirm agent run log viewers (which never used \`onClear\`) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)