### PR TITLE
fix(server): broadcast full project row on container lifecycle changes

### DIFF
--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -9,7 +9,7 @@ import {
 } from '@hezo/shared';
 import { type Context, Hono } from 'hono';
 import { trackBackground } from '../lib/background';
-import { broadcastChange } from '../lib/broadcast';
+import { broadcastChange, broadcastProjectUpdate } from '../lib/broadcast';
 import { ref } from '../lib/log-ref';
 import { err, ok } from '../lib/response';
 import { toProjectTaskPrefix, toSlug, uniqueSlug } from '../lib/slug';
@@ -569,11 +569,8 @@ projectsRoutes.post('/projects/:projectId/container/start', async (c) => {
 			projectId,
 		]);
 		c.get('containerLogStreamer').subscribe(projectId, containerId, c.get('logs'), docker);
-		broadcastChange(c, wsRoom.team(teamId), 'projects', 'UPDATE', {
-			id: projectId,
-			container_status: ContainerStatus.Running,
-		});
-		wakeAgentsWithPendingWork(db, projectId, teamId);
+		await broadcastProjectUpdate(db, c.get('wsManager'), teamId, projectId);
+		await wakeAgentsWithPendingWork(db, projectId, teamId);
 		log.info(`project ${projectId} container ${containerId.slice(0, 12)} started`);
 		return ok(c, { container_status: ContainerStatus.Running });
 	} catch (error) {
@@ -603,10 +600,7 @@ projectsRoutes.post('/projects/:projectId/container/stop', async (c) => {
 			ContainerStatus.Stopped,
 			projectId,
 		]);
-		broadcastChange(c, wsRoom.team(teamId), 'projects', 'UPDATE', {
-			id: projectId,
-			container_status: ContainerStatus.Stopped,
-		});
+		await broadcastProjectUpdate(db, c.get('wsManager'), teamId, projectId);
 		return ok(c, { container_status: ContainerStatus.Stopped });
 	}
 
@@ -614,10 +608,7 @@ projectsRoutes.post('/projects/:projectId/container/stop', async (c) => {
 		ContainerStatus.Stopping,
 		projectId,
 	]);
-	broadcastChange(c, wsRoom.team(teamId), 'projects', 'UPDATE', {
-		id: projectId,
-		container_status: ContainerStatus.Stopping,
-	});
+	await broadcastProjectUpdate(db, c.get('wsManager'), teamId, projectId);
 
 	const jobManager = c.get('jobManager');
 	const containerDeps = buildContainerDeps(c);
@@ -678,17 +669,14 @@ projectsRoutes.post('/projects/:projectId/container/rebuild', async (c) => {
 		projectId,
 	]);
 
-	broadcastChange(c, wsRoom.team(teamId), 'projects', 'UPDATE', {
-		id: projectId,
-		container_status: ContainerStatus.Creating,
-	});
+	await broadcastProjectUpdate(db, c.get('wsManager'), teamId, projectId);
 
 	jobManager.launchTask(
 		taskKey,
 		async () => {
 			try {
 				await rebuildContainer(containerDeps, projectResult.rows[0] as ProjectRow, teamSlug);
-				wakeAgentsWithPendingWork(db, projectId, teamId);
+				await wakeAgentsWithPendingWork(db, projectId, teamId);
 			} catch (error) {
 				log.error(
 					`Container rebuild failed for project ${ref((projectResult.rows[0] as ProjectRow).slug, projectId)}:`,

--- a/packages/server/test/container-rebuild-broadcast.test.ts
+++ b/packages/server/test/container-rebuild-broadcast.test.ts
@@ -1,0 +1,137 @@
+import { ContainerStatus, WsMessageType, wsRoom } from '@hezo/shared';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import type { Env } from '../src/lib/types';
+import { WebSocketManager, type WsEvent } from '../src/services/ws';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp, createTestProject } from './helpers/app';
+
+interface CapturedBroadcast {
+	room: string;
+	event: WsEvent;
+}
+
+describe('container lifecycle broadcasts carry team_id', () => {
+	let ctx: Awaited<ReturnType<typeof createTestApp>>;
+	let teamId: string;
+	let projectId: string;
+	let projectSlug: string;
+	let captured: CapturedBroadcast[];
+	let broadcastSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeAll(async () => {
+		ctx = await createTestApp();
+
+		const typesRes = await ctx.app.request('/api/team-templates', {
+			headers: authHeader(ctx.token),
+		});
+		const typeId = (await typesRes.json()).data.find(
+			(t: { name: string }) => t.name === 'Blank',
+		).id;
+
+		const teamRes = await ctx.app.request('/api/teams', {
+			method: 'POST',
+			headers: { ...authHeader(ctx.token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name: 'Container Broadcast Co', template_id: typeId }),
+		});
+		teamId = (await teamRes.json()).data.id;
+
+		const projectRes = await createTestProject(ctx.db, teamId, {
+			name: 'Container Broadcast Project',
+		});
+		const project = (await projectRes.json()).data;
+		projectId = project.id;
+		projectSlug = project.slug;
+
+		captured = [];
+		broadcastSpy = vi.spyOn(WebSocketManager.prototype, 'broadcast').mockImplementation(function (
+			this: WebSocketManager,
+			room: string,
+			event: WsEvent,
+		) {
+			captured.push({ room, event });
+		});
+	});
+
+	afterAll(async () => {
+		broadcastSpy.mockRestore();
+		await safeClose(ctx.db);
+	});
+
+	function lastProjectUpdate(): CapturedBroadcast | undefined {
+		// Find the latest projects-UPDATE broadcast on this team's room.
+		const teamRoom = wsRoom.team(teamId);
+		for (let i = captured.length - 1; i >= 0; i--) {
+			const entry = captured[i];
+			if (entry.room !== teamRoom) continue;
+			if (entry.event.type !== WsMessageType.RowChange) continue;
+			if (entry.event.table !== 'projects') continue;
+			if (entry.event.action !== 'UPDATE') continue;
+			return entry;
+		}
+		return undefined;
+	}
+
+	it('rebuild broadcasts a full project row with team_id', async () => {
+		captured.length = 0;
+
+		const res = await ctx.app.request(`/api/projects/${projectSlug}/container/rebuild`, {
+			method: 'POST',
+			headers: authHeader(ctx.token),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data.container_status).toBe(ContainerStatus.Creating);
+
+		const update = lastProjectUpdate();
+		expect(update).toBeDefined();
+		const row = update?.event.row as Record<string, unknown>;
+		expect(row.id).toBe(projectId);
+		expect(row.team_id).toBe(teamId);
+		expect(row.container_status).toBe(ContainerStatus.Creating);
+	});
+
+	it('stop broadcasts a full project row with team_id', async () => {
+		// Give the project a container_id so the stop route takes the "in progress" branch.
+		await ctx.db.query(
+			"UPDATE projects SET container_id = 'stub-running', container_status = 'running'::container_status WHERE id = $1",
+			[projectId],
+		);
+
+		captured.length = 0;
+
+		const res = await ctx.app.request(`/api/projects/${projectSlug}/container/stop`, {
+			method: 'POST',
+			headers: authHeader(ctx.token),
+		});
+		expect(res.status).toBe(200);
+
+		const update = lastProjectUpdate();
+		expect(update).toBeDefined();
+		const row = update?.event.row as Record<string, unknown>;
+		expect(row.id).toBe(projectId);
+		expect(row.team_id).toBe(teamId);
+		expect(row.container_status).toBe(ContainerStatus.Stopping);
+	});
+
+	it('start broadcasts a full project row with team_id', async () => {
+		await ctx.db.query(
+			"UPDATE projects SET container_id = 'stub-stopped', container_status = 'stopped'::container_status WHERE id = $1",
+			[projectId],
+		);
+
+		captured.length = 0;
+
+		const res = await ctx.app.request(`/api/projects/${projectSlug}/container/start`, {
+			method: 'POST',
+			headers: authHeader(ctx.token),
+		});
+		expect(res.status).toBe(200);
+
+		const update = lastProjectUpdate();
+		expect(update).toBeDefined();
+		const row = update?.event.row as Record<string, unknown>;
+		expect(row.id).toBe(projectId);
+		expect(row.team_id).toBe(teamId);
+		expect(row.container_status).toBe(ContainerStatus.Running);
+	});
+});


### PR DESCRIPTION
## Summary

The container `start`/`stop`/`rebuild` HTTP routes (`packages/server/src/routes/projects.ts`) were broadcasting `RowChange` events with a partial row payload — `{ id, container_status }` — and no `team_id`. The web client's `useShellWebSockets` resolver needs `row.team_id` or `row.project_id` to map the change to a project slug for `invalidateQueries`. With neither in the payload, `['projects']` never refetched, and the existing `ContainerStatusBanner` stayed stale during the rebuild window.

User-visible symptom: clicking **Rebuild** showed no banner during the ~10s rebuild, then the banner briefly flashed Creating → Running only when the rebuild's *final* `broadcastProjectUpdate` (which sends the full row) landed.

## Fix

- Replace the four partial-payload `broadcastChange` calls with `broadcastProjectUpdate`, which `SELECT *` the row and matches the convention used everywhere else (`containers.ts`, the project `INSERT`/`PATCH` routes). Now `team_id` is in every payload, and the existing realtime → invalidate → refetch → re-render chain fires immediately.
- Drive-by: `await` the two orphan `wakeAgentsWithPendingWork(...)` calls so the outer `SELECT` joins the trackable chain. Without this, the new test surfaces a `PGlite is closing` log on teardown — symptomatic of the broader pattern AGENTS.md flags ("fire-and-forget background work must be tracked").

Banner placement (project-route only) and styling are unchanged — this is purely a wire-protocol fix.

## Test plan

- [x] New `packages/server/test/container-rebuild-broadcast.test.ts` asserts `row.team_id` is present in the `start`, `stop`, and `rebuild` broadcasts
- [x] `bun run test --pattern container --skip-browser` — green (4 web + 3 new server)
- [x] `bun run typecheck` — green
- [ ] Manual: trigger a rebuild from `/projects/<slug>/container`, confirm the blue "Provisioning…" banner appears within ~1s and disappears when the container reaches Running

🤖 Generated with [Claude Code](https://claude.com/claude-code)