### PR TITLE
feat(server): central config + slug-enriched logs + container debug toggle

### DIFF
--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -8,6 +8,8 @@ import {
 } from '@hezo/shared';
 import { Command } from 'commander';
 
+export type LogLevelName = 'debug' | 'info' | 'warn' | 'error';
+
 export interface HezoConfig {
 	port: number;
 	dataDir: string;
@@ -15,10 +17,38 @@ export interface HezoConfig {
 	webUrl: string;
 	reset: boolean;
 	open: boolean;
+	logLevel: LogLevelName;
+	keepOldContainers: boolean;
 }
 
 function resolveDataDir(raw: string): string {
 	return raw.startsWith('~') ? resolve(homedir(), raw.slice(2)) : resolve(raw);
+}
+
+function parsePort(raw: string): number {
+	const n = Number.parseInt(raw, 10);
+	if (Number.isNaN(n) || n < 1 || n > 65535) {
+		throw new Error(`Invalid port: ${raw}. Must be 1-65535.`);
+	}
+	return n;
+}
+
+function parseLogLevel(raw: string): LogLevelName {
+	const lower = raw.toLowerCase();
+	if (lower === 'debug' || lower === 'info' || lower === 'warn' || lower === 'error') {
+		return lower;
+	}
+	throw new Error(`Invalid log level: ${raw}. Must be debug | info | warn | error.`);
+}
+
+function parseBool(raw: string): boolean {
+	if (raw === '') return true;
+	const lower = raw.toLowerCase();
+	return lower !== '0' && lower !== 'false' && lower !== 'no' && lower !== 'off';
+}
+
+function parseMasterKey(raw: string): string {
+	return validateMnemonic(raw) ? mnemonicToMasterKey(raw) : raw;
 }
 
 /**
@@ -46,41 +76,64 @@ export async function runRestore(argv: string[] = process.argv): Promise<boolean
 	return true;
 }
 
-export function parseArgs(argv: string[] = process.argv): HezoConfig {
+/**
+ * Central configuration resolution. Each option can be set via either a CLI
+ * flag or an env var; the env var takes precedence when both are present. The
+ * defaults defined here are the final fallback. This is the only place where
+ * config values are resolved — subsystems (logger level, container removal
+ * gate, etc.) receive their slice and apply it locally at startup.
+ */
+export function parseConfig(
+	argv: string[] = process.argv,
+	env: NodeJS.ProcessEnv = process.env,
+): HezoConfig {
 	const program = new Command()
 		.name('hezo')
 		.description('Hezo server — self-hosted AI agent management platform')
-		.option('--port <port>', 'Server port', String(DEFAULT_PORT))
-		.option('--data-dir <path>', 'Data directory', DEFAULT_DATA_DIR)
-		.option('--master-key <key>', 'Master key for unlocking')
-		.option('--web-url <url>', 'Web UI base URL for redirects (leave empty to use same origin)', '')
-		.option('--reset', 'Reset database and start fresh')
-		.option('--open', 'Auto-open the browser')
+		.option('--port <port>', 'Server port (env: HEZO_PORT)', String(DEFAULT_PORT))
+		.option('--data-dir <path>', 'Data directory (env: HEZO_DATA_DIR)', DEFAULT_DATA_DIR)
+		.option('--master-key <key>', 'Master key for unlocking (env: HEZO_MASTER_KEY)')
+		.option('--web-url <url>', 'Web UI base URL for redirects (env: HEZO_WEB_URL)', '')
+		.option('--reset', 'Reset database and start fresh (env: HEZO_RESET)')
+		.option('--open', 'Auto-open the browser (env: HEZO_OPEN)')
+		.option(
+			'--log-level <level>',
+			'Log level: debug | info | warn | error (env: HEZO_LOG_LEVEL)',
+			'info',
+		)
+		.option(
+			'--keep-old-containers',
+			'Skip removal of old containers on rebuild/teardown/provision — useful for inspecting crashed containers via `docker logs` / `docker inspect`. Subsequent rebuilds will fail with a name conflict until the operator removes them manually. (env: HEZO_KEEP_OLD_CONTAINERS)',
+		)
 		.parse(argv);
 
-	const opts = program.opts();
+	const cli = program.opts();
 
-	const port = Number.parseInt(opts.port, 10);
-	if (Number.isNaN(port) || port < 1 || port > 65535) {
-		throw new Error(`Invalid port: ${opts.port}. Must be 1-65535.`);
-	}
+	// Env var > CLI value > default. For value-bearing options the CLI value
+	// is a string; for flags it's a boolean (commander sets `true` when the
+	// flag is present, `undefined` otherwise).
+	const pick = (envName: string, cliValue: unknown): string | undefined => {
+		const e = env[envName];
+		if (e !== undefined && e !== '') return e;
+		if (typeof cliValue === 'string' && cliValue.length > 0) return cliValue;
+		return undefined;
+	};
+	const pickBool = (envName: string, cliValue: unknown): boolean => {
+		const e = env[envName];
+		if (e !== undefined) return parseBool(e);
+		return cliValue === true;
+	};
 
-	const dataDir = resolveDataDir(opts.dataDir as string);
-
-	// The user-facing master key is a 12-word BIP39 phrase; convert it to the
-	// internal hex. Anything that isn't a valid phrase (raw hex, opaque e2e key)
-	// passes through unchanged.
-	let masterKey: string | undefined = opts.masterKey;
-	if (masterKey && validateMnemonic(masterKey)) {
-		masterKey = mnemonicToMasterKey(masterKey);
-	}
+	const masterKeyRaw = pick('HEZO_MASTER_KEY', cli.masterKey);
 
 	return {
-		port,
-		dataDir,
-		masterKey,
-		webUrl: opts.webUrl ?? '',
-		reset: opts.reset ?? false,
-		open: opts.open ?? false,
+		port: parsePort(pick('HEZO_PORT', cli.port) ?? String(DEFAULT_PORT)),
+		dataDir: resolveDataDir(pick('HEZO_DATA_DIR', cli.dataDir) ?? DEFAULT_DATA_DIR),
+		masterKey: masterKeyRaw ? parseMasterKey(masterKeyRaw) : undefined,
+		webUrl: pick('HEZO_WEB_URL', cli.webUrl) ?? '',
+		reset: pickBool('HEZO_RESET', cli.reset),
+		open: pickBool('HEZO_OPEN', cli.open),
+		logLevel: parseLogLevel(pick('HEZO_LOG_LEVEL', cli.logLevel) ?? 'info'),
+		keepOldContainers: pickBool('HEZO_KEEP_OLD_CONTAINERS', cli.keepOldContainers),
 	};
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -2,12 +2,13 @@ import './console-shim';
 import type { PGlite } from '@electric-sql/pglite';
 import { AuthType, DEFAULT_WEB_PORT } from '@hezo/shared';
 import { app } from './app';
-import { parseArgs, runRestore } from './cli';
+import { parseConfig, runRestore } from './cli';
 import type { MasterKeyManager } from './crypto/master-key';
 import { PgDataCorruptError } from './db/client';
-import { logger } from './logger';
+import { logger, setLogLevel } from './logger';
 import { loadAdminAuth, verifyToken } from './middleware/auth';
 import type { ContainerLogStreamer } from './services/container-logs';
+import { setKeepOldContainers } from './services/containers';
 import type { LogStreamBroker } from './services/log-stream-broker';
 import type { WebSocketManager, WsData, WsSocket } from './services/ws';
 import { handleWsSubscribe, handleWsUnsubscribe } from './services/ws-subscribe-handler';
@@ -68,7 +69,9 @@ if (await runRestore()) {
 	process.exit(0);
 }
 
-const config = parseArgs();
+const config = parseConfig();
+setLogLevel(config.logLevel);
+setKeepOldContainers(config.keepOldContainers);
 
 /** Bumped on each module load so stale async startup completions are ignored after HMR. */
 let startupGeneration = 0;

--- a/packages/server/src/lib/log-ref.ts
+++ b/packages/server/src/lib/log-ref.ts
@@ -1,4 +1,4 @@
-// Formats an entity for logs as "label (uuid)", or just the uuid when no
+// Formats an entity for logs as "label [uuid]", or just the uuid when no
 // friendly label is available.
 export const ref = (label: string | null | undefined, id: string): string =>
-	label ? `${label} (${id})` : id;
+	label ? `${label} [${id}]` : id;

--- a/packages/server/src/logger.ts
+++ b/packages/server/src/logger.ts
@@ -1,17 +1,47 @@
 import { Logger, LogLevel } from '@hiddentao/logger';
 import { ConsoleTransport } from '@hiddentao/logger/transports/console';
 
-const levelFromEnv = (process.env.LOG_LEVEL ?? '').toUpperCase();
-const minLevel: LogLevel =
-	levelFromEnv === 'DEBUG'
-		? LogLevel.DEBUG
-		: levelFromEnv === 'WARN'
-			? LogLevel.WARN
-			: levelFromEnv === 'ERROR'
-				? LogLevel.ERROR
-				: LogLevel.INFO;
+// @hiddentao/logger snapshots `minLevel` into each child logger's options at
+// construction time, so mutating the root's options after the fact wouldn't
+// affect children created at module load. Patch the prototype's level gate
+// to consult a single module-level variable instead — every logger instance,
+// past or future, picks up the current setting on every log call.
+const LEVEL_PRIORITY: Record<LogLevel, number> = {
+	[LogLevel.DEBUG]: 0,
+	[LogLevel.INFO]: 1,
+	[LogLevel.WARN]: 2,
+	[LogLevel.ERROR]: 3,
+};
+
+let currentMinLevel: LogLevel = LogLevel.INFO;
+
+(Logger.prototype as unknown as { shouldSkipLevel: (l: LogLevel) => boolean }).shouldSkipLevel =
+	function shouldSkipLevel(level: LogLevel): boolean {
+		return LEVEL_PRIORITY[level] < LEVEL_PRIORITY[currentMinLevel];
+	};
 
 export const logger = new Logger({
-	minLevel,
 	transports: [new ConsoleTransport({ showTimestamps: true })],
 });
+
+/**
+ * Update the min log level applied across every Logger instance — root and
+ * children alike. Called once at startup after the central config has been
+ * resolved (see `parseConfig` in cli.ts).
+ */
+export function setLogLevel(level: 'debug' | 'info' | 'warn' | 'error'): void {
+	switch (level) {
+		case 'debug':
+			currentMinLevel = LogLevel.DEBUG;
+			return;
+		case 'info':
+			currentMinLevel = LogLevel.INFO;
+			return;
+		case 'warn':
+			currentMinLevel = LogLevel.WARN;
+			return;
+		case 'error':
+			currentMinLevel = LogLevel.ERROR;
+			return;
+	}
+}

--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -537,9 +537,14 @@ projectsRoutes.delete('/projects/:projectId', async (c) => {
 	}
 
 	await trackBackground(
-		teardownContainer(buildContainerDeps(c), projectId, teamId).catch((error) => {
-			log.error(`Failed to teardown container for project ${existing.rows[0].slug}:`, error);
-		}),
+		teardownContainer(buildContainerDeps(c), projectId, existing.rows[0].slug, teamId).catch(
+			(error) => {
+				log.error(
+					`Failed to teardown container for project ${ref(existing.rows[0].slug, projectId)}:`,
+					error,
+				);
+			},
+		),
 	);
 
 	await db.query('DELETE FROM projects WHERE id = $1', [projectId]);
@@ -553,14 +558,15 @@ projectsRoutes.post('/projects/:projectId/container/start', async (c) => {
 	const projectId = c.get('projectId') as string;
 	if (!projectId) return err(c, 'NOT_FOUND', 'Project not found', 404);
 
-	const result = await db.query<{ container_id: string | null }>(
-		'SELECT container_id FROM projects WHERE id = $1 AND team_id = $2',
+	const result = await db.query<{ slug: string; container_id: string | null }>(
+		'SELECT slug, container_id FROM projects WHERE id = $1 AND team_id = $2',
 		[projectId, teamId],
 	);
 	if (result.rows.length === 0) return err(c, 'NOT_FOUND', 'Project not found', 404);
 	if (!result.rows[0].container_id) return err(c, 'NO_CONTAINER', 'No container provisioned', 400);
 
 	const docker = c.get('docker');
+	const projectSlug = result.rows[0].slug;
 	const containerId = result.rows[0].container_id;
 	try {
 		await docker.startContainer(containerId);
@@ -571,11 +577,15 @@ projectsRoutes.post('/projects/:projectId/container/start', async (c) => {
 		c.get('containerLogStreamer').subscribe(projectId, containerId, c.get('logs'), docker);
 		await broadcastProjectUpdate(db, c.get('wsManager'), teamId, projectId);
 		await wakeAgentsWithPendingWork(db, projectId, teamId);
-		log.info(`project ${projectId} container ${containerId.slice(0, 12)} started`);
+		log.info(
+			`project ${ref(projectSlug, projectId)} container ${ref(projectSlug, containerId.slice(0, 12))} started`,
+		);
 		return ok(c, { container_status: ContainerStatus.Running });
 	} catch (error) {
 		const message = (error as Error).message;
-		log.warn(`project ${projectId} container ${containerId.slice(0, 12)} start failed: ${message}`);
+		log.warn(
+			`project ${ref(projectSlug, projectId)} container ${ref(projectSlug, containerId.slice(0, 12))} start failed: ${message}`,
+		);
 		return err(c, 'DOCKER_ERROR', `Failed to start container: ${message}`, 500);
 	}
 });
@@ -586,10 +596,14 @@ projectsRoutes.post('/projects/:projectId/container/stop', async (c) => {
 	const projectId = c.get('projectId') as string;
 	if (!projectId) return err(c, 'NOT_FOUND', 'Project not found', 404);
 
-	const result = await db.query<{ container_id: string | null; container_status: string | null }>(
-		'SELECT container_id, container_status FROM projects WHERE id = $1 AND team_id = $2',
-		[projectId, teamId],
-	);
+	const result = await db.query<{
+		slug: string;
+		container_id: string | null;
+		container_status: string | null;
+	}>('SELECT slug, container_id, container_status FROM projects WHERE id = $1 AND team_id = $2', [
+		projectId,
+		teamId,
+	]);
 	if (result.rows.length === 0) return err(c, 'NOT_FOUND', 'Project not found', 404);
 
 	const row = result.rows[0];
@@ -618,11 +632,12 @@ projectsRoutes.post('/projects/:projectId/container/stop', async (c) => {
 	const containerId = row.container_id;
 	if (!containerId) return ok(c, { container_status: ContainerStatus.Stopping });
 
+	const projectSlug = row.slug;
 	const taskKey = `stop:${projectId}`;
 	jobManager.launchTask(
 		taskKey,
 		async () => {
-			await stopContainerGracefully(containerDeps, projectId, teamId, containerId);
+			await stopContainerGracefully(containerDeps, projectId, projectSlug, teamId, containerId);
 		},
 		60_000,
 	);

--- a/packages/server/src/services/containers.ts
+++ b/packages/server/src/services/containers.ts
@@ -10,6 +10,7 @@ import {
 import type { MasterKeyManager } from '../crypto/master-key';
 import { trackBackground } from '../lib/background';
 import { broadcastProjectUpdate, broadcastRowChange } from '../lib/broadcast';
+import { ref } from '../lib/log-ref';
 import { terminalStatusParams } from '../lib/sql';
 import { logger } from '../logger';
 import { setAgentIdleIfNoActiveRuns } from './agent-runtime-status';
@@ -27,6 +28,7 @@ export type ContainerExitReason = 'container_error' | 'container_stopped';
 
 export interface ContainerTransition {
 	projectId: string;
+	projectSlug: string;
 	teamId: string;
 	oldStatus: string | null;
 	newStatus: string | null;
@@ -92,6 +94,21 @@ const PORT_POOL_END = 19999;
 
 const LAST_LOGS_CAP_BYTES = 32 * 1024;
 
+// When true, every old-container removal is skipped (rebuild, teardown, and
+// the defensive same-name cleanup before create). Provisioning a fresh
+// container then fails with a name conflict until the operator removes the
+// old one by hand — the trade-off is keeping crashed containers around for
+// `docker logs` / `docker inspect`. Set centrally from parseConfig at startup.
+let keepOldContainersFlag = false;
+
+export function setKeepOldContainers(value: boolean): void {
+	keepOldContainersFlag = value;
+}
+
+export function shouldKeepOldContainers(): boolean {
+	return keepOldContainersFlag;
+}
+
 /**
  * Default per-container working-set ceiling, used when a project has not set
  * its own `projects.memory_limit_gib`. The sync loop stops the container when
@@ -145,6 +162,7 @@ function appendMemoryLine(existing: string | null, line: string | null): string 
 export async function captureContainerLogs(
 	docker: DockerClient,
 	containerId: string,
+	projectSlug?: string | null,
 ): Promise<string | null> {
 	try {
 		const res = await docker.containerLogs(containerId, {
@@ -175,7 +193,10 @@ export async function captureContainerLogs(
 		}
 		return combined || null;
 	} catch (err) {
-		log.warn(`Failed to capture logs for container ${containerId}:`, err);
+		log.warn(
+			`Failed to capture logs for container ${ref(projectSlug, containerId.slice(0, 12))}:`,
+			err,
+		);
 		return null;
 	}
 }
@@ -234,10 +255,12 @@ export async function provisionContainer(
 			]);
 		}
 
-		// Container identity is keyed on the immutable project id so a team/project
-		// rename never orphans the container or shifts its bind mounts. The slugs ride
-		// along as labels purely for `docker ps` readability.
-		const containerName = `hezo-${project.id}`;
+		// Bind mounts key on the immutable project id, so a rename never shifts
+		// paths or orphans data. The container name embeds the project slug for
+		// `docker ps` readability and an 8-char id prefix for uniqueness; on
+		// rename the next rebuild adopts the new slug, while the old container
+		// is torn down by stored `container_id` hash rather than by name.
+		const containerName = `hezo-${project.slug}-${project.id.slice(0, 8)}`;
 		const containerLabels = { 'hezo.team': teamSlug, 'hezo.project': project.slug };
 		const extraHosts = ['host.docker.internal:host-gateway'];
 
@@ -252,10 +275,12 @@ export async function provisionContainer(
 		});
 
 		emit('stdout', `→ Creating container ${containerName}`);
-		try {
-			await docker.removeContainer(containerName, true);
-		} catch {
-			// Container doesn't exist — expected
+		if (!keepOldContainersFlag) {
+			try {
+				await docker.removeContainer(containerName, true);
+			} catch {
+				// Container doesn't exist — expected
+			}
 		}
 
 		const { Id } = await docker.createContainer(containerName, {
@@ -274,7 +299,9 @@ export async function provisionContainer(
 
 		emit('stdout', '→ Starting container');
 		await docker.startContainer(Id);
-		log.info(`project ${project.id} container ${Id.slice(0, 12)} provisioned and started`);
+		log.info(
+			`project ${ref(project.slug, project.id)} container ${ref(project.slug, Id.slice(0, 12))} provisioned and started`,
+		);
 
 		await db.query(
 			'UPDATE projects SET container_id = $1, container_status = $2::container_status, container_error = NULL WHERE id = $3',
@@ -346,7 +373,7 @@ export async function provisionContainer(
 		emit('stdout', '✓ Container ready');
 		await broadcastProjectUpdate(db, wsManager, teamId, project.id);
 
-		await requeueContainerKilledRuns(deps, project.id, teamId).catch((e) =>
+		await requeueContainerKilledRuns(deps, project.id, project.slug, teamId).catch((e) =>
 			log.error('Failed to requeue container-killed runs after provision:', e),
 		);
 		// A wakeup that fired while the container was still provisioning could not
@@ -374,6 +401,7 @@ export async function provisionContainer(
 export async function teardownContainer(
 	deps: ContainerDeps,
 	projectId: string,
+	projectSlug: string,
 	teamId: string,
 ): Promise<void> {
 	const { db, docker, dataDir } = deps;
@@ -384,7 +412,7 @@ export async function teardownContainer(
 	);
 
 	const teardownContainerId = result.rows[0]?.container_id;
-	if (teardownContainerId) {
+	if (teardownContainerId && !keepOldContainersFlag) {
 		try {
 			await docker.stopContainer(teardownContainerId);
 		} catch {
@@ -405,21 +433,24 @@ export async function teardownContainer(
 	memoryUsageState.delete(projectId);
 
 	if (teardownContainerId) {
-		log.info(`project ${projectId} container ${teardownContainerId.slice(0, 12)} torn down`);
+		log.info(
+			`project ${ref(projectSlug, projectId)} container ${ref(projectSlug, teardownContainerId.slice(0, 12))} torn down`,
+		);
 	} else {
-		log.info(`project ${projectId} torn down (no container was provisioned)`);
+		log.info(`project ${ref(projectSlug, projectId)} torn down (no container was provisioned)`);
 	}
 }
 
 export async function stopContainerGracefully(
 	deps: ContainerDeps,
 	projectId: string,
+	projectSlug: string,
 	teamId: string,
 	containerId: string,
 ): Promise<void> {
 	const { db, docker, wsManager } = deps;
 
-	const lastLogs = await captureContainerLogs(docker, containerId);
+	const lastLogs = await captureContainerLogs(docker, containerId, projectSlug);
 	const annotatedLogs = appendMemoryLine(lastLogs, consumeFinalMemoryLine(projectId));
 
 	let exitReason: ContainerExitReason = 'container_stopped';
@@ -433,7 +464,9 @@ export async function stopContainerGracefully(
 			 WHERE id = $3`,
 			[ContainerStatus.Stopped, annotatedLogs, projectId],
 		);
-		log.info(`project ${projectId} container ${containerId.slice(0, 12)} stopped`);
+		log.info(
+			`project ${ref(projectSlug, projectId)} container ${ref(projectSlug, containerId.slice(0, 12))} stopped`,
+		);
 	} catch (err) {
 		const errorMessage = err instanceof Error ? err.message : String(err);
 		await db.query(
@@ -446,11 +479,11 @@ export async function stopContainerGracefully(
 		);
 		exitReason = 'container_error';
 		log.warn(
-			`project ${projectId} container ${containerId.slice(0, 12)} stop failed: ${errorMessage}`,
+			`project ${ref(projectSlug, projectId)} container ${ref(projectSlug, containerId.slice(0, 12))} stop failed: ${errorMessage}`,
 		);
 	}
 
-	await failProjectRuns(deps, projectId, teamId, exitReason).catch((e) =>
+	await failProjectRuns(deps, projectId, projectSlug, teamId, exitReason).catch((e) =>
 		log.error('Failed to fail project runs on stop:', e),
 	);
 
@@ -493,14 +526,14 @@ export async function rebuildContainer(
 
 	if (project.container_id) {
 		log.info(
-			`project ${project.id} container ${project.container_id.slice(0, 12)} rebuild started`,
+			`project ${ref(project.slug, project.id)} container ${ref(project.slug, project.container_id.slice(0, 12))} rebuild started`,
 		);
 		logs?.emit(
 			streamId,
 			'stdout',
 			`→ Removing previous container ${project.container_id.slice(0, 12)}`,
 		);
-		const lastLogs = await captureContainerLogs(docker, project.container_id);
+		const lastLogs = await captureContainerLogs(docker, project.container_id, project.slug);
 		const annotatedLogs = appendMemoryLine(lastLogs, consumeFinalMemoryLine(project.id));
 		if (annotatedLogs) {
 			await db.query('UPDATE projects SET container_last_logs = $1 WHERE id = $2', [
@@ -508,18 +541,20 @@ export async function rebuildContainer(
 				project.id,
 			]);
 		}
-		try {
-			await docker.stopContainer(project.container_id);
-		} catch {
-			// Already stopped
-		}
-		try {
-			await docker.removeContainer(project.container_id, true);
-		} catch {
-			// Already removed
+		if (!keepOldContainersFlag) {
+			try {
+				await docker.stopContainer(project.container_id);
+			} catch {
+				// Already stopped
+			}
+			try {
+				await docker.removeContainer(project.container_id, true);
+			} catch {
+				// Already removed
+			}
 		}
 	} else {
-		log.info(`project ${project.id} rebuild started (no previous container)`);
+		log.info(`project ${ref(project.slug, project.id)} rebuild started (no previous container)`);
 	}
 
 	return provisionContainer(deps, project, teamSlug);
@@ -529,6 +564,7 @@ export async function syncContainerStatus(
 	db: PGlite,
 	docker: DockerClient,
 	projectId: string,
+	projectSlug: string,
 	containerId: string,
 	previousStatus?: string | null,
 ): Promise<string | null> {
@@ -536,7 +572,10 @@ export async function syncContainerStatus(
 	try {
 		info = await docker.inspectContainer(containerId);
 	} catch (err) {
-		log.warn(`Container sync transport error for project ${projectId}; will retry`, err);
+		log.warn(
+			`Container sync transport error for project ${ref(projectSlug, projectId)}; will retry`,
+			err,
+		);
 		return null;
 	}
 
@@ -557,7 +596,7 @@ export async function syncContainerStatus(
 	const status = info.State.Running ? ContainerStatus.Running : ContainerStatus.Stopped;
 
 	if (previousStatus === ContainerStatus.Running && status !== ContainerStatus.Running) {
-		const lastLogs = await captureContainerLogs(docker, containerId);
+		const lastLogs = await captureContainerLogs(docker, containerId, projectSlug);
 		const finalMemoryLine = consumeFinalMemoryLine(projectId);
 		const annotatedLogs = appendMemoryLine(lastLogs, finalMemoryLine);
 		const exitCode = info.State.ExitCode;
@@ -568,7 +607,7 @@ export async function syncContainerStatus(
 				: `Container stopped (${exitStatus}).`;
 		if (finalMemoryLine) {
 			log.info(
-				`project ${projectId} container ${containerId.slice(0, 12)} exited; ${finalMemoryLine.replace(/^→ /, '')}`,
+				`project ${ref(projectSlug, projectId)} container ${ref(projectSlug, containerId.slice(0, 12))} exited; ${finalMemoryLine.replace(/^→ /, '')}`,
 			);
 		}
 		await db.query(
@@ -602,6 +641,7 @@ export async function syncContainerStatus(
 async function enforceContainerMemoryLimit(
 	deps: ContainerDeps,
 	projectId: string,
+	projectSlug: string,
 	teamId: string,
 	containerId: string,
 	memoryLimitGib: number,
@@ -612,7 +652,10 @@ async function enforceContainerMemoryLimit(
 	try {
 		stats = await docker.containerStats(containerId);
 	} catch (err) {
-		log.warn(`Container stats transport error for project ${projectId}; will retry`, err);
+		log.warn(
+			`Container stats transport error for project ${ref(projectSlug, projectId)}; will retry`,
+			err,
+		);
 		return null;
 	}
 	if (!stats) return null;
@@ -627,7 +670,7 @@ async function enforceContainerMemoryLimit(
 	if (now - entry.lastLogMs >= MEMORY_USAGE_LOG_INTERVAL_MS) {
 		entry.lastLogMs = now;
 		log.debug(
-			`project ${projectId} container ${containerId.slice(0, 12)} memory: ${formatMemoryLine(entry)}`,
+			`project ${ref(projectSlug, projectId)} container ${ref(projectSlug, containerId.slice(0, 12))} memory: ${formatMemoryLine(entry)}`,
 		);
 	}
 	memoryUsageState.set(projectId, entry);
@@ -641,13 +684,13 @@ async function enforceContainerMemoryLimit(
 		`and was stopped automatically to keep your machine responsive. Restart the container ` +
 		`to try again, or raise the limit on the project settings page.`;
 
-	const lastLogs = await captureContainerLogs(docker, containerId);
+	const lastLogs = await captureContainerLogs(docker, containerId, projectSlug);
 
 	try {
 		await docker.stopContainer(containerId);
 	} catch (err) {
 		log.warn(
-			`docker.stopContainer failed during memory-limit enforcement for project ${projectId}; recording error anyway`,
+			`docker.stopContainer failed during memory-limit enforcement for project ${ref(projectSlug, projectId)}; recording error anyway`,
 			err,
 		);
 	}
@@ -662,12 +705,12 @@ async function enforceContainerMemoryLimit(
 	);
 
 	log.warn(
-		`Auto-stopped container ${containerId.slice(0, 12)} for project ${projectId}: used ${usedGiB} GiB (> ${memoryLimitGib} GiB)`,
+		`Auto-stopped container ${ref(projectSlug, containerId.slice(0, 12))} for project ${ref(projectSlug, projectId)}: used ${usedGiB} GiB (> ${memoryLimitGib} GiB)`,
 	);
 
 	memoryUsageState.delete(projectId);
 
-	await failProjectRuns(deps, projectId, teamId, 'container_error').catch((e) =>
+	await failProjectRuns(deps, projectId, projectSlug, teamId, 'container_error').catch((e) =>
 		log.error('Failed to fail project runs after memory-limit stop:', e),
 	);
 
@@ -681,12 +724,13 @@ export async function syncAllContainerStatuses(
 
 	const projects = await db.query<{
 		id: string;
+		slug: string;
 		team_id: string;
 		container_id: string;
 		container_status: string | null;
 		memory_limit_gib: number;
 	}>(
-		'SELECT id, team_id, container_id, container_status, memory_limit_gib FROM projects WHERE container_id IS NOT NULL',
+		'SELECT id, slug, team_id, container_id, container_status, memory_limit_gib FROM projects WHERE container_id IS NOT NULL',
 	);
 
 	const transitions: ContainerTransition[] = [];
@@ -696,6 +740,7 @@ export async function syncAllContainerStatuses(
 			db,
 			docker,
 			project.id,
+			project.slug,
 			project.container_id,
 			oldStatus,
 		);
@@ -704,6 +749,7 @@ export async function syncAllContainerStatuses(
 			const overrideStatus = await enforceContainerMemoryLimit(
 				deps,
 				project.id,
+				project.slug,
 				project.team_id,
 				project.container_id,
 				project.memory_limit_gib,
@@ -716,6 +762,7 @@ export async function syncAllContainerStatuses(
 		if (newStatus !== null && newStatus !== oldStatus) {
 			transitions.push({
 				projectId: project.id,
+				projectSlug: project.slug,
 				teamId: project.team_id,
 				oldStatus,
 				newStatus,
@@ -736,6 +783,7 @@ export async function syncAllContainerStatuses(
 export async function failProjectRuns(
 	deps: ContainerDeps,
 	projectId: string,
+	projectSlug: string,
 	teamId: string,
 	reason: ContainerExitReason,
 ): Promise<void> {
@@ -787,7 +835,7 @@ export async function failProjectRuns(
 	}
 
 	log.info(
-		`Failed ${failedRuns.rows.length} run(s) in project ${projectId} due to ${reason}; ${idleCount}/${memberIds.length} agent(s) marked idle`,
+		`Failed ${failedRuns.rows.length} run(s) in project ${ref(projectSlug, projectId)} due to ${reason}; ${idleCount}/${memberIds.length} agent(s) marked idle`,
 	);
 }
 
@@ -802,6 +850,7 @@ const REQUEUE_LOOKBACK_HOURS = 24;
 export async function requeueContainerKilledRuns(
 	deps: ContainerDeps,
 	projectId: string,
+	projectSlug: string,
 	teamId: string,
 ): Promise<number> {
 	const { db } = deps;
@@ -837,7 +886,7 @@ export async function requeueContainerKilledRuns(
 
 	if (killed.rows.length > 0) {
 		log.info(
-			`Re-queued ${killed.rows.length} container-killed run(s) in project ${projectId} after container recovery`,
+			`Re-queued ${killed.rows.length} container-killed run(s) in project ${ref(projectSlug, projectId)} after container recovery`,
 		);
 	}
 

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -225,8 +225,8 @@ export class JobManager {
 				);
 				return { dispatched: false, reason: 'task_busy' };
 			}
-			const projectId = await this.resolveProjectForTask(wakeupTaskId);
-			if (projectId && (await this.isProjectAtCapacity(projectId))) {
+			const project = await this.resolveProjectForTask(wakeupTaskId);
+			if (project && (await this.isProjectAtCapacity(project.id))) {
 				await this.markWakeupSkipped(
 					wakeup.id,
 					WakeupSkipReason.ProjectAtCapacity,
@@ -236,7 +236,7 @@ export class JobManager {
 				);
 				return { dispatched: false, reason: 'project_at_capacity' };
 			}
-			if (projectId && (await this.isAgentBusyInProject(wakeup.member_id, projectId))) {
+			if (project && (await this.isAgentBusyInProject(wakeup.member_id, project.id))) {
 				await this.markWakeupSkipped(
 					wakeup.id,
 					WakeupSkipReason.AgentRunning,
@@ -569,7 +569,9 @@ export class JobManager {
 						row.team_slug,
 					);
 					reprovisioned++;
-					log.info(`Re-provisioned project ${row.id} — container was missing from Docker`);
+					log.info(
+						`Re-provisioned project ${ref(row.slug, row.id)} — container was missing from Docker`,
+					);
 					continue;
 				}
 
@@ -584,12 +586,20 @@ export class JobManager {
 					container_error: null,
 				});
 				await wakeAgentsWithPendingWork(db, row.id, row.team_id).catch((e) =>
-					log.error(`Failed to wake agents after startup restart for project ${row.id}:`, e),
+					log.error(
+						`Failed to wake agents after startup restart for project ${ref(row.slug, row.id)}:`,
+						e,
+					),
 				);
 				restarted++;
-				log.info(`Restarted container ${row.container_id.slice(0, 12)} for project ${row.id}`);
+				log.info(
+					`Restarted container ${ref(row.slug, row.container_id.slice(0, 12))} for project ${ref(row.slug, row.id)}`,
+				);
 			} catch (err) {
-				log.error(`Failed to restart container for project ${row.id} on startup:`, err);
+				log.error(
+					`Failed to restart container for project ${ref(row.slug, row.id)} on startup:`,
+					err,
+				);
 			}
 		}
 
@@ -634,7 +644,7 @@ export class JobManager {
 			if (ok) continue;
 
 			log.warn(
-				`Container ${row.container_id.slice(0, 12)} for project ${row.id} has unreachable /workspace mount — rebuilding`,
+				`Container ${ref(row.slug, row.container_id.slice(0, 12))} for project ${ref(row.slug, row.id)} has unreachable /workspace mount — rebuilding`,
 			);
 			try {
 				await rebuildContainer(
@@ -650,9 +660,11 @@ export class JobManager {
 					},
 					row.team_slug,
 				);
-				log.info(`Rebuilt container for project ${row.id} after stale-mount detection`);
+				log.info(
+					`Rebuilt container for project ${ref(row.slug, row.id)} after stale-mount detection`,
+				);
 			} catch (err) {
-				log.error(`Failed to rebuild stale container for project ${row.id}:`, err);
+				log.error(`Failed to rebuild stale container for project ${ref(row.slug, row.id)}:`, err);
 			}
 		}
 	}
@@ -681,7 +693,7 @@ export class JobManager {
 		);
 
 		for (const project of candidates.rows) {
-			const name = `hezo-${project.team_slug}-${project.slug}`;
+			const name = `hezo-${project.slug}-${project.id.slice(0, 8)}`;
 			let info: Awaited<ReturnType<DockerClient['inspectContainerByName']>>;
 			try {
 				info = await docker.inspectContainerByName(name);
@@ -701,7 +713,9 @@ export class JobManager {
 				container_id: info.Id,
 				container_status: ContainerStatus.Running,
 			});
-			log.info(`Self-healed project ${project.id} — re-attached to live container ${name}`);
+			log.info(
+				`Self-healed project ${ref(project.slug, project.id)} — re-attached to live container ${name}`,
+			);
 		}
 	}
 
@@ -773,12 +787,19 @@ export class JobManager {
 		}
 	}
 
-	private async resolveProjectForTask(taskId: string): Promise<string | null> {
+	private async resolveProjectForTask(
+		taskId: string,
+	): Promise<{ id: string; slug: string } | null> {
 		const { db } = this.deps;
-		const r = await db.query<{ project_id: string }>('SELECT project_id FROM tasks WHERE id = $1', [
-			taskId,
-		]);
-		return r.rows[0]?.project_id ?? null;
+		const r = await db.query<{ project_id: string; slug: string }>(
+			`SELECT t.project_id, p.slug
+			 FROM tasks t
+			 JOIN projects p ON p.id = t.project_id
+			 WHERE t.id = $1`,
+			[taskId],
+		);
+		const row = r.rows[0];
+		return row ? { id: row.project_id, slug: row.slug } : null;
 	}
 
 	/** Return a claimed wakeup to the queue so a later dispatch can retry it. */
@@ -851,9 +872,11 @@ export class JobManager {
 					);
 					continue;
 				}
-				const projectId = await this.resolveProjectForTask(wakeupTaskId);
-				if (projectId && (await this.isProjectAtCapacity(projectId))) {
-					log.debug(`Skipping wakeup ${wakeup.id} — project ${projectId} is at run capacity`);
+				const project = await this.resolveProjectForTask(wakeupTaskId);
+				if (project && (await this.isProjectAtCapacity(project.id))) {
+					log.debug(
+						`Skipping wakeup ${wakeup.id} — project ${ref(project.slug, project.id)} is at run capacity`,
+					);
 					await this.markWakeupSkipped(
 						wakeup.id,
 						WakeupSkipReason.ProjectAtCapacity,
@@ -863,9 +886,9 @@ export class JobManager {
 					);
 					continue;
 				}
-				if (projectId && (await this.isAgentBusyInProject(wakeup.member_id, projectId))) {
+				if (project && (await this.isAgentBusyInProject(wakeup.member_id, project.id))) {
 					log.debug(
-						`Skipping wakeup ${wakeup.id} — agent ${wakeup.member_id} already running in project ${projectId}`,
+						`Skipping wakeup ${wakeup.id} — agent ${wakeup.member_id} already running in project ${ref(project.slug, project.id)}`,
 					);
 					await this.markWakeupSkipped(
 						wakeup.id,
@@ -1761,7 +1784,7 @@ export class JobManager {
 	}
 
 	private async handleContainerTransition(transition: ContainerTransition): Promise<void> {
-		const { projectId, teamId, oldStatus, newStatus } = transition;
+		const { projectId, projectSlug, teamId, oldStatus, newStatus } = transition;
 
 		if (
 			oldStatus === ContainerStatus.Running &&
@@ -1770,7 +1793,7 @@ export class JobManager {
 			const reason: ContainerExitReason =
 				newStatus === ContainerStatus.Error ? 'container_error' : 'container_stopped';
 			this.cancelLiveRunsForProject(projectId, reason);
-			await failProjectRuns(this.buildContainerDeps(), projectId, teamId, reason);
+			await failProjectRuns(this.buildContainerDeps(), projectId, projectSlug, teamId, reason);
 		}
 	}
 

--- a/packages/server/test/cli.test.ts
+++ b/packages/server/test/cli.test.ts
@@ -1,65 +1,85 @@
 import { homedir } from 'node:os';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { parseArgs } from '../src/cli';
+import { parseConfig } from '../src/cli';
 
 // Helper to build argv with the standard bun/node + script prefix
 const argv = (...flags: string[]) => ['bun', 'src/index.ts', ...flags];
 
-describe('parseArgs', () => {
+// Always pass an empty env so the test outcomes do not depend on the host
+// process having or not having HEZO_* vars set.
+const EMPTY_ENV: NodeJS.ProcessEnv = {};
+
+describe('parseConfig', () => {
 	it('returns defaults when no args provided', () => {
-		const config = parseArgs(argv());
+		const config = parseConfig(argv(), EMPTY_ENV);
 		expect(config.port).toBe(3100);
 		expect(config.dataDir).toBe(resolve(homedir(), '.hezo'));
 		expect(config.masterKey).toBeUndefined();
 		expect(config.reset).toBe(false);
 		expect(config.open).toBe(false);
+		expect(config.logLevel).toBe('info');
+		expect(config.keepOldContainers).toBe(false);
 	});
 
 	it('parses --port', () => {
-		const config = parseArgs(argv('--port', '8080'));
+		const config = parseConfig(argv('--port', '8080'), EMPTY_ENV);
 		expect(config.port).toBe(8080);
 	});
 
 	it('throws on non-numeric port', () => {
-		expect(() => parseArgs(argv('--port', 'abc'))).toThrow('Invalid port');
+		expect(() => parseConfig(argv('--port', 'abc'), EMPTY_ENV)).toThrow('Invalid port');
 	});
 
 	it('throws on port below valid range', () => {
-		expect(() => parseArgs(argv('--port', '0'))).toThrow('Invalid port');
+		expect(() => parseConfig(argv('--port', '0'), EMPTY_ENV)).toThrow('Invalid port');
 	});
 
 	it('throws on port above valid range', () => {
-		expect(() => parseArgs(argv('--port', '99999'))).toThrow('Invalid port');
+		expect(() => parseConfig(argv('--port', '99999'), EMPTY_ENV)).toThrow('Invalid port');
 	});
 
 	it('parses --data-dir with absolute path', () => {
-		const config = parseArgs(argv('--data-dir', '/custom/path'));
+		const config = parseConfig(argv('--data-dir', '/custom/path'), EMPTY_ENV);
 		expect(config.dataDir).toBe('/custom/path');
 	});
 
 	it('resolves tilde in --data-dir', () => {
-		const config = parseArgs(argv('--data-dir', '~/custom'));
+		const config = parseConfig(argv('--data-dir', '~/custom'), EMPTY_ENV);
 		expect(config.dataDir).toBe(resolve(homedir(), 'custom'));
 	});
 
 	it('parses --master-key', () => {
-		const config = parseArgs(argv('--master-key', 'mykey'));
+		const config = parseConfig(argv('--master-key', 'mykey'), EMPTY_ENV);
 		expect(config.masterKey).toBe('mykey');
 	});
 
 	it('parses --reset', () => {
-		const config = parseArgs(argv('--reset'));
+		const config = parseConfig(argv('--reset'), EMPTY_ENV);
 		expect(config.reset).toBe(true);
 	});
 
 	it('parses --open', () => {
-		const config = parseArgs(argv('--open'));
+		const config = parseConfig(argv('--open'), EMPTY_ENV);
 		expect(config.open).toBe(true);
 	});
 
+	it('parses --log-level', () => {
+		const config = parseConfig(argv('--log-level', 'debug'), EMPTY_ENV);
+		expect(config.logLevel).toBe('debug');
+	});
+
+	it('throws on invalid --log-level', () => {
+		expect(() => parseConfig(argv('--log-level', 'trace'), EMPTY_ENV)).toThrow('Invalid log level');
+	});
+
+	it('parses --keep-old-containers', () => {
+		const config = parseConfig(argv('--keep-old-containers'), EMPTY_ENV);
+		expect(config.keepOldContainers).toBe(true);
+	});
+
 	it('handles multiple flags combined', () => {
-		const config = parseArgs(
+		const config = parseConfig(
 			argv(
 				'--port',
 				'9000',
@@ -70,11 +90,44 @@ describe('parseArgs', () => {
 				'--reset',
 				'--open',
 			),
+			EMPTY_ENV,
 		);
 		expect(config.port).toBe(9000);
 		expect(config.dataDir).toBe('/tmp/hezo');
 		expect(config.masterKey).toBe('secret');
 		expect(config.reset).toBe(true);
 		expect(config.open).toBe(true);
+	});
+
+	describe('env vars take precedence over CLI args', () => {
+		it('HEZO_PORT overrides --port', () => {
+			const config = parseConfig(argv('--port', '8080'), { HEZO_PORT: '9090' });
+			expect(config.port).toBe(9090);
+		});
+
+		it('HEZO_DATA_DIR overrides --data-dir', () => {
+			const config = parseConfig(argv('--data-dir', '/cli/path'), { HEZO_DATA_DIR: '/env/path' });
+			expect(config.dataDir).toBe('/env/path');
+		});
+
+		it('HEZO_LOG_LEVEL overrides --log-level', () => {
+			const config = parseConfig(argv('--log-level', 'debug'), { HEZO_LOG_LEVEL: 'warn' });
+			expect(config.logLevel).toBe('warn');
+		});
+
+		it('HEZO_KEEP_OLD_CONTAINERS overrides absence of CLI flag', () => {
+			const config = parseConfig(argv(), { HEZO_KEEP_OLD_CONTAINERS: '1' });
+			expect(config.keepOldContainers).toBe(true);
+		});
+
+		it('HEZO_RESET=false overrides --reset', () => {
+			const config = parseConfig(argv('--reset'), { HEZO_RESET: 'false' });
+			expect(config.reset).toBe(false);
+		});
+
+		it('empty env value falls through to CLI', () => {
+			const config = parseConfig(argv('--port', '8080'), { HEZO_PORT: '' });
+			expect(config.port).toBe(8080);
+		});
 	});
 });

--- a/packages/server/test/container-sync.test.ts
+++ b/packages/server/test/container-sync.test.ts
@@ -797,7 +797,7 @@ describe('provisionContainer broadcasting', () => {
 		expect(hostConfig.MemorySwap).toBeUndefined();
 	});
 
-	it('keeps container name and bind mounts stable when the project is renamed', async () => {
+	it('keeps bind mounts stable on rename; container name adopts the new slug', async () => {
 		const dataDir = mkdtempSync(join(tmpdir(), 'hezo-test-'));
 		const makeMockDocker = () =>
 			createStubDocker({
@@ -843,9 +843,12 @@ describe('provisionContainer broadcasting', () => {
 		const nameAfter = dockerAfter.createContainer.mock.calls[0][0];
 		const bindsAfter = dockerAfter.createContainer.mock.calls[0][1].HostConfig.Binds as string[];
 
-		// Identity and mounts are keyed on the immutable id, so the rename changes nothing.
-		expect(nameAfter).toBe(nameBefore);
-		expect(nameAfter).toBe(`hezo-${renameProjectId}`);
+		// Name embeds the slug for `docker ps` readability — rename changes it.
+		expect(nameBefore).toBe(`hezo-${before.slug}-${renameProjectId.slice(0, 8)}`);
+		expect(nameAfter).toBe(`hezo-renamed-project-slug-${renameProjectId.slice(0, 8)}`);
+		expect(nameAfter).not.toBe(nameBefore);
+
+		// Bind mounts key on the immutable id, so paths stay stable across rename.
 		expect(bindsAfter).toEqual(bindsBefore);
 		expect(bindsAfter.join('\n')).toContain(`/projects/${renameProjectId}/`);
 		expect(bindsAfter.join('\n')).not.toContain(before.slug);
@@ -1061,6 +1064,7 @@ describe('stopContainerGracefully', () => {
 		await stopContainerGracefully(
 			{ db, docker: mockDocker, dataDir: '', wsManager: mockWsManager },
 			projectId,
+			'stop-test-project',
 			teamId,
 			'stop-test-container',
 		);
@@ -1094,6 +1098,7 @@ describe('stopContainerGracefully', () => {
 		await stopContainerGracefully(
 			{ db, docker: mockDocker, dataDir: '', wsManager: mockWsManager },
 			projectId,
+			'stop-test-project',
 			teamId,
 			'fail-stop-container',
 		);
@@ -1122,6 +1127,7 @@ describe('stopContainerGracefully', () => {
 		await stopContainerGracefully(
 			{ db, docker: mockDocker, dataDir: '' },
 			projectId,
+			'stop-test-project',
 			teamId,
 			'no-ws-stop',
 		);
@@ -1167,6 +1173,7 @@ describe('stopContainerGracefully', () => {
 		await stopContainerGracefully(
 			{ db, docker: mockDocker, dataDir: '' },
 			stopProjectId,
+			'graceful-trail-project',
 			teamId,
 			'graceful-trail',
 		);

--- a/packages/server/test/containers-recovery.test.ts
+++ b/packages/server/test/containers-recovery.test.ts
@@ -115,7 +115,7 @@ describe('failProjectRuns', () => {
 			[AgentRuntimeStatus.Active, agentId],
 		);
 
-		await failProjectRuns(buildDeps(), projectId, teamId, 'container_error');
+		await failProjectRuns(buildDeps(), projectId, projectSlug, teamId, 'container_error');
 
 		const run = await db.query<{ status: string; error: string; exit_code: number }>(
 			'SELECT status, error, exit_code FROM heartbeat_runs WHERE id = $1',
@@ -139,6 +139,7 @@ describe('failProjectRuns', () => {
 		await failProjectRuns(
 			buildDeps(),
 			'00000000-0000-0000-0000-000000000000',
+			'unknown-project',
 			teamId,
 			'container_error',
 		);
@@ -158,7 +159,7 @@ describe('failProjectRuns', () => {
 			agentId,
 		]);
 
-		await failProjectRuns(buildDeps(), projectId, teamId, 'container_stopped');
+		await failProjectRuns(buildDeps(), projectId, projectSlug, teamId, 'container_stopped');
 
 		const lock = await db.query<{ released_at: string | null }>(
 			'SELECT released_at FROM execution_locks WHERE task_id = $1 AND member_id = $2',
@@ -184,7 +185,7 @@ describe('failProjectRuns', () => {
 			} as any,
 		};
 
-		await failProjectRuns(deps, projectId, teamId, 'container_error');
+		await failProjectRuns(deps, projectId, projectSlug, teamId, 'container_error');
 
 		expect(broadcasts.some((b) => b.table === 'heartbeat_runs')).toBe(true);
 		expect(broadcasts.some((b) => b.table === 'member_agents')).toBe(true);
@@ -200,7 +201,7 @@ describe('requeueContainerKilledRuns', () => {
 			[teamId, agentId, taskId, HeartbeatRunStatus.Failed],
 		);
 
-		const count = await requeueContainerKilledRuns(buildDeps(), projectId, teamId);
+		const count = await requeueContainerKilledRuns(buildDeps(), projectId, projectSlug, teamId);
 		expect(count).toBe(1);
 
 		const wakeups = await db.query<{ payload: Record<string, unknown> }>(
@@ -222,7 +223,7 @@ describe('requeueContainerKilledRuns', () => {
 			[teamId, agentId, taskId, HeartbeatRunStatus.Failed],
 		);
 
-		const count = await requeueContainerKilledRuns(buildDeps(), projectId, teamId);
+		const count = await requeueContainerKilledRuns(buildDeps(), projectId, projectSlug, teamId);
 		expect(count).toBe(0);
 	});
 
@@ -239,7 +240,7 @@ describe('requeueContainerKilledRuns', () => {
 			[teamId, agentId, taskId, HeartbeatRunStatus.Succeeded],
 		);
 
-		const count = await requeueContainerKilledRuns(buildDeps(), projectId, teamId);
+		const count = await requeueContainerKilledRuns(buildDeps(), projectId, projectSlug, teamId);
 		expect(count).toBe(0);
 	});
 });

--- a/packages/server/test/job-manager-workflows.test.ts
+++ b/packages/server/test/job-manager-workflows.test.ts
@@ -2009,7 +2009,7 @@ describe('JobManager workflow methods', () => {
 
 				await manager.reconcileOnStartup();
 
-				expect(createCalls).toContain(`hezo-${projectId}`);
+				expect(createCalls).toContain(`hezo-${projectSlug}-${projectId.slice(0, 8)}`);
 				const row = await db.query<{ container_id: string | null; container_status: string }>(
 					'SELECT container_id, container_status FROM projects WHERE id = $1',
 					[projectId],

--- a/packages/server/test/log-ref.test.ts
+++ b/packages/server/test/log-ref.test.ts
@@ -5,8 +5,8 @@ describe('ref', () => {
 	const id = '3d8317ca-fd4b-4140-a42d-1fa97d187e34';
 
 	it('formats a friendly label alongside the uuid', () => {
-		expect(ref('OP-42', id)).toBe(`OP-42 (${id})`);
-		expect(ref('captain/OP-42', id)).toBe(`captain/OP-42 (${id})`);
+		expect(ref('OP-42', id)).toBe(`OP-42 [${id}]`);
+		expect(ref('captain/OP-42', id)).toBe(`captain/OP-42 [${id}]`);
 	});
 
 	it('falls back to the bare uuid when no label is available', () => {


### PR DESCRIPTION
## Summary

- **Central config resolution.** `parseConfig` (renamed from `parseArgs`) in `packages/server/src/cli.ts` is now the single point that resolves every option from CLI args, env vars, and defaults. Env vars take precedence over CLI args; defaults are the final fallback. Both inputs are injectable for tests.
- **Two new options** (CLI + env, like the rest):
  - `--log-level <debug|info|warn|error>` / `HEZO_LOG_LEVEL` (replaces the old `LOG_LEVEL`).
  - `--keep-old-containers` / `HEZO_KEEP_OLD_CONTAINERS` — debug toggle that skips removal of old containers on rebuild / teardown / defensive same-name cleanup. Useful for inspecting crashed (OOM-killed) containers via `docker logs` / `docker inspect`. The trade-off is documented in the help string and the code: subsequent rebuilds will fail with a name conflict until the operator clears the old container by hand.
- **Dynamic log level.** `packages/server/src/logger.ts` exports `setLogLevel()`. Since `@hiddentao/logger` snapshots `minLevel` per child at construction time and many child loggers are created at module-load (before `parseConfig` runs), the gate is implemented as a prototype patch on `Logger.prototype.shouldSkipLevel` consulting a module-level variable — every existing and future child picks up the configured level on every log call.
- **Slug-enriched log lines.** Container / project / agent log messages now identify entities via the existing `ref()` helper (`slug [uuid]` form, switched from `(uuid)` to `[uuid]`). Function signatures in `containers.ts` widened to thread `projectSlug` through (`teardownContainer`, `stopContainerGracefully`, `syncContainerStatus`, `enforceContainerMemoryLimit`, `failProjectRuns`, `requeueContainerKilledRuns`, `captureContainerLogs`). Existing `ref()` users in `job-manager.ts`, `egress/proxy.ts`, `ssh-agent/server.ts` automatically inherit the new bracket format.
- **Readable docker container names.** `provisionContainer` now creates containers as `hezo-<project-slug>-<id8>` (e.g. `hezo-operations-530613e7`) so `docker ps` is grep-friendly. Bind mounts continue to key on the immutable project id, so rename-stability of paths is preserved (only the container name itself adopts the new slug on next rebuild). The self-heal lookup in `job-manager.ts:684` was updated to match.

### Centralised application

In `packages/server/src/index.ts`, immediately after the single `parseConfig()` call:

```ts
const config = parseConfig();
setLogLevel(config.logLevel);
setKeepOldContainers(config.keepOldContainers);
```

Subsystems receive their slice and apply it locally — there's no scattered `process.env.HEZO_*` reads for these knobs.

### Env ↔ CLI matrix

| CLI flag | Env var | Default |
|---|---|---|
| `--port <port>` | `HEZO_PORT` | `DEFAULT_PORT` (3100) |
| `--data-dir <path>` | `HEZO_DATA_DIR` | `DEFAULT_DATA_DIR` (`~/.hezo`) |
| `--master-key <key>` | `HEZO_MASTER_KEY` | unset |
| `--web-url <url>` | `HEZO_WEB_URL` | `''` |
| `--reset` | `HEZO_RESET` | `false` |
| `--open` | `HEZO_OPEN` | `false` |
| `--log-level <level>` | `HEZO_LOG_LEVEL` | `info` |
| `--keep-old-containers` | `HEZO_KEEP_OLD_CONTAINERS` | `false` |

## Test plan

- [x] `bun run typecheck` — passes
- [x] `bun run test --skip-browser --package server` — 1758 tests pass + Bun-native tier (TLS MITM) passes
- [x] `bun run test --skip-browser --package web` — 260 tests pass
- [x] New `cli.test.ts` coverage: `parseConfig` defaults, every CLI flag, invalid-port / invalid-log-level errors, env-precedence (`HEZO_PORT`, `HEZO_DATA_DIR`, `HEZO_LOG_LEVEL`, `HEZO_KEEP_OLD_CONTAINERS`, `HEZO_RESET=false`), and empty-env fall-through
- [ ] Manual: start dev server, trigger a container rebuild from the Settings page, observe `[info] <containers> project my-project [530613e7-…] container my-project [4a9a7ac4…] rebuild started`
- [ ] Manual: run with `--keep-old-containers`, force a container exit, confirm the container is still listed in `docker ps -a`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Sculptor <sculptor@imbue.com>