### PR TITLE
fix(web): only show run Retry button on the latest run

### DIFF
--- a/packages/web/src/components/comment-renderers/index.tsx
+++ b/packages/web/src/components/comment-renderers/index.tsx
@@ -21,6 +21,7 @@ interface RenderProps {
 	projectId?: string;
 	projectSlug?: string;
 	taskId?: string;
+	retryableRunId?: string | null;
 	inline?: boolean;
 }
 
@@ -36,6 +37,7 @@ type RendererComponent<K extends CommentContentType> = ComponentType<{
 	projectId?: string;
 	projectSlug?: string;
 	taskId?: string;
+	retryableRunId?: string | null;
 	inline?: boolean;
 }>;
 
@@ -50,8 +52,13 @@ const renderers: RendererRegistry = {
 	),
 	[CommentContentType.Preview]: ({ comment }) => <PreviewComment comment={comment} />,
 	[CommentContentType.Trace]: ({ comment }) => <TraceComment comment={comment} />,
-	[CommentContentType.System]: ({ comment, projectId, taskId }) => (
-		<SystemComment comment={comment} projectId={projectId} taskId={taskId} />
+	[CommentContentType.System]: ({ comment, projectId, taskId, retryableRunId }) => (
+		<SystemComment
+			comment={comment}
+			projectId={projectId}
+			taskId={taskId}
+			retryableRunId={retryableRunId}
+		/>
 	),
 	[CommentContentType.Run]: ({ comment, projectId, inline }) => (
 		<RunComment comment={comment} projectId={projectId} inline={inline} />

--- a/packages/web/src/components/comment-renderers/system-comment.tsx
+++ b/packages/web/src/components/comment-renderers/system-comment.tsx
@@ -17,6 +17,7 @@ interface Props {
 	comment: CommentDataOf<'system'>;
 	projectId?: string;
 	taskId?: string;
+	retryableRunId?: string | null;
 }
 
 function isTaskLink(c: SystemContent): c is SystemTaskLinkContent {
@@ -32,7 +33,7 @@ function isRepoDesignated(c: SystemContent): c is SystemRepoDesignatedContent {
 	return c.kind === 'repo_designated';
 }
 
-export function SystemComment({ comment, projectId, taskId }: Props) {
+export function SystemComment({ comment, projectId, taskId, retryableRunId }: Props) {
 	const content: SystemContent | null =
 		comment.content && typeof comment.content === 'object' ? comment.content : null;
 	const timestamp = (
@@ -67,6 +68,7 @@ export function SystemComment({ comment, projectId, taskId }: Props) {
 				content={content}
 				projectId={projectId}
 				taskId={taskId}
+				retryableRunId={retryableRunId}
 				timestamp={timestamp}
 			/>
 		);
@@ -149,11 +151,13 @@ function RunFailedBody({
 	content,
 	projectId,
 	taskId,
+	retryableRunId,
 	timestamp,
 }: {
 	content: SystemRunFailedContent;
 	projectId?: string;
 	taskId?: string;
+	retryableRunId?: string | null;
 	timestamp: React.ReactNode;
 }) {
 	const agentSlug = typeof content.agent_slug === 'string' ? content.agent_slug : '';
@@ -185,7 +189,7 @@ function RunFailedBody({
 					Run for {agentNode} {statusLabel}
 					{error ? <span className="text-text-subtle">: {error}</span> : null}.
 				</span>
-				{projectId && taskId && runId ? (
+				{projectId && taskId && runId && runId === retryableRunId ? (
 					<RetryRunButton projectId={projectId} taskId={taskId} runId={runId} />
 				) : null}
 			</span>

--- a/packages/web/src/components/task-detail/comments-section.tsx
+++ b/packages/web/src/components/task-detail/comments-section.tsx
@@ -87,6 +87,30 @@ export function CommentsSection({
 		return m;
 	}, [agents]);
 	const chooseOption = useChooseOption(projectId, taskId);
+	// The run_id whose run_failed comment may show a Retry button: the most
+	// recent run referenced in the thread, and only when no run is currently
+	// active. Run comments (any outcome) and run_failed comments both carry a
+	// run_id; comments arrive oldest-first, so the last match is the newest run.
+	// Older failed runs — superseded by a later run, or any run while one is
+	// active — resolve to a different id (or null) and hide their Retry button.
+	const retryableRunId = useMemo<string | null>(() => {
+		if (task.has_active_run) return null;
+		let latest: string | null = null;
+		for (const c of comments ?? []) {
+			const content =
+				c.content && typeof c.content === 'object'
+					? (c.content as { run_id?: string; kind?: string })
+					: null;
+			const runId = content?.run_id;
+			if (!runId) continue;
+			if (
+				c.content_type === 'run' ||
+				(c.content_type === 'system' && content?.kind === 'run_failed')
+			)
+				latest = runId;
+		}
+		return latest;
+	}, [comments, task.has_active_run]);
 	const virtuosoRef = useRef<VirtuosoHandle>(null);
 	const listContainerRef = useRef<HTMLDivElement>(null);
 	const [highlightedCommentId, setHighlightedCommentId] = useState<string | null>(null);
@@ -269,6 +293,7 @@ export function CommentsSection({
 											projectId={projectId}
 											projectSlug={taskProjectSlug}
 											taskId={taskId}
+											retryableRunId={retryableRunId}
 											inline
 										/>
 									</div>
@@ -353,6 +378,7 @@ export function CommentsSection({
 											projectId={projectId}
 											projectSlug={taskProjectSlug}
 											taskId={taskId}
+											retryableRunId={retryableRunId}
 										/>
 										<div className="flex items-end justify-between gap-2">
 											<div className="min-w-0 flex-1">

--- a/packages/web/test/run-failed-comment.test.tsx
+++ b/packages/web/test/run-failed-comment.test.tsx
@@ -3,18 +3,31 @@ import { renderApp } from './helpers/render';
 import { seedProject, seedTask, seedWorkspace } from './helpers/seed';
 
 const FAILED_RUN_ID = 'bbbb0000-0000-0000-0000-000000000777';
+const LATER_RUN_ID = 'bbbb0000-0000-0000-0000-000000000888';
 
-test('task page renders run_failed system comment with agent link, error, and retry button', async () => {
-	const seeded = {
-		teamId: '',
-		projectSlug: '',
-		taskId: '',
-		agentId: '',
-		agentSlug: '',
-	};
-	const retryCalls: string[] = [];
+type Seeded = {
+	teamId: string;
+	projectSlug: string;
+	taskId: string;
+	agentId: string;
+	agentSlug: string;
+};
 
-	const { findByTestId, router, user } = await renderApp({
+type Comment = Record<string, unknown>;
+
+/**
+ * Seed a team/project/task and stub the comments fetch with the given list.
+ * `taskOverride` patches the live task-detail response (e.g. has_active_run)
+ * by mutating the real seeded payload. `retryCalls` records run ids POSTed to
+ * the retry endpoint.
+ */
+async function setup(
+	seeded: Seeded,
+	retryCalls: string[],
+	buildComments: (ctx: { task: { id: string }; agent: { id: string; slug: string } }) => Comment[],
+	taskOverride?: Record<string, unknown>,
+) {
+	return renderApp({
 		initialPath: '/',
 		seed: async () => {
 			const ws = await seedWorkspace();
@@ -31,31 +44,27 @@ test('task page renders run_failed system comment with agent link, error, and re
 			seeded.agentId = captain.id;
 			seeded.agentSlug = captain.slug;
 
-			const failedComment = {
-				id: 'aaaa0000-0000-0000-0000-000000000001',
-				task_id: task.id,
-				content_type: 'system',
-				content: {
-					kind: 'run_failed',
-					run_id: FAILED_RUN_ID,
-					status: 'timed_out',
-					error: 'The operation timed out.',
-					member_id: captain.id,
-					agent_slug: captain.slug,
-				},
-				chosen_option: null,
-				created_at: '2026-05-20T11:30:40Z',
-				author_type: 'admin',
-				author_name: 'Admin',
-				author_member_id: null,
-			};
+			const comments = buildComments({ task, agent: captain });
 
 			const originalFetch = globalThis.fetch;
 			globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
 				const url = typeof input === 'string' ? input : (input as Request).url;
 				const method = init?.method ?? (input instanceof Request ? input.method : 'GET');
 				if (method === 'GET' && /\/api\/projects\/[^/]+\/tasks\/[^/]+\/comments/.test(url)) {
-					return new Response(JSON.stringify({ data: [failedComment] }), {
+					return new Response(JSON.stringify({ data: comments }), {
+						status: 200,
+						headers: { 'Content-Type': 'application/json' },
+					});
+				}
+				if (
+					taskOverride &&
+					method === 'GET' &&
+					/\/api\/projects\/[^/]+\/tasks\/[^/]+(\?|$)/.test(url) &&
+					!url.includes('/comments')
+				) {
+					const res = await originalFetch(input as RequestInfo, init);
+					const body = (await res.json()) as { data: Record<string, unknown> };
+					return new Response(JSON.stringify({ data: { ...body.data, ...taskOverride } }), {
 						status: 200,
 						headers: { 'Content-Type': 'application/json' },
 					});
@@ -74,18 +83,45 @@ test('task page renders run_failed system comment with agent link, error, and re
 			}) as typeof globalThis.fetch;
 		},
 	});
+}
+
+function runFailedComment(taskRowId: string, agentSlug: string, agentId: string): Comment {
+	return {
+		id: 'aaaa0000-0000-0000-0000-000000000001',
+		task_id: taskRowId,
+		content_type: 'system',
+		content: {
+			kind: 'run_failed',
+			run_id: FAILED_RUN_ID,
+			status: 'timed_out',
+			error: 'The operation timed out.',
+			member_id: agentId,
+			agent_slug: agentSlug,
+		},
+		chosen_option: null,
+		created_at: '2026-05-20T11:30:40Z',
+		author_type: 'admin',
+		author_name: 'Admin',
+		author_member_id: null,
+	};
+}
+
+test('run_failed comment shows retry when it is the latest run', async () => {
+	const seeded: Seeded = { teamId: '', projectSlug: '', taskId: '', agentId: '', agentSlug: '' };
+	const retryCalls: string[] = [];
+
+	const { findByTestId, router, user } = await setup(seeded, retryCalls, ({ task, agent }) => [
+		runFailedComment(task.id, agent.slug, agent.id),
+	]);
 
 	await router.navigate({
 		to: '/projects/$projectId/tasks/$taskId',
 		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
 	});
 
-	const failureComment = await findByTestId('run-failed-comment', undefined, {
-		timeout: 20_000,
-	});
+	const failureComment = await findByTestId('run-failed-comment', undefined, { timeout: 20_000 });
 	expect(failureComment.textContent ?? '').toContain('timed out');
 	expect(failureComment.textContent ?? '').toContain('The operation timed out.');
-	expect(failureComment.textContent ?? '').not.toContain('Waking agent to retry');
 
 	const agentLink = (await findByTestId('run-failed-agent')) as HTMLAnchorElement;
 	expect(agentLink.textContent ?? '').toContain(`@${seeded.agentSlug}`);
@@ -97,4 +133,61 @@ test('task page renders run_failed system comment with agent link, error, and re
 	expect(retryButton.textContent ?? '').toContain('Retry');
 	await user.click(retryButton);
 	expect(retryCalls).toEqual([FAILED_RUN_ID]);
+});
+
+test('run_failed comment hides retry when a later run exists', async () => {
+	const seeded: Seeded = { teamId: '', projectSlug: '', taskId: '', agentId: '', agentSlug: '' };
+	const retryCalls: string[] = [];
+
+	const { findByTestId, queryByTestId, router } = await setup(
+		seeded,
+		retryCalls,
+		({ task, agent }) => [
+			runFailedComment(task.id, agent.slug, agent.id),
+			{
+				id: 'aaaa0000-0000-0000-0000-000000000002',
+				task_id: task.id,
+				content_type: 'run',
+				content: {
+					run_id: LATER_RUN_ID,
+					agent_id: agent.id,
+					agent_slug: agent.slug,
+					agent_title: 'Captain',
+				},
+				chosen_option: null,
+				created_at: '2026-05-20T11:35:00Z',
+				author_type: 'agent',
+				author_name: 'Captain',
+				author_member_id: agent.id,
+			},
+		],
+	);
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
+	});
+
+	await findByTestId('run-failed-comment', undefined, { timeout: 20_000 });
+	expect(queryByTestId('retry-failed-run')).toBeNull();
+});
+
+test('run_failed comment hides retry while a run is active', async () => {
+	const seeded: Seeded = { teamId: '', projectSlug: '', taskId: '', agentId: '', agentSlug: '' };
+	const retryCalls: string[] = [];
+
+	const { findByTestId, queryByTestId, router } = await setup(
+		seeded,
+		retryCalls,
+		({ task, agent }) => [runFailedComment(task.id, agent.slug, agent.id)],
+		{ has_active_run: true },
+	);
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
+	});
+
+	await findByTestId('run-failed-comment', undefined, { timeout: 20_000 });
+	expect(queryByTestId('retry-failed-run')).toBeNull();
 });


### PR DESCRIPTION
## Problem

A failed run posts a \`run_failed\` system comment that rendered a **Retry** button unconditionally. Older, superseded runs kept offering Retry even after the agent had moved on to a later run (failed, succeeded, or still running) — so the thread showed Retry on a run the agent had already left behind.

## Fix

In the comments view, derive a single **retryable run id**: the newest run referenced anywhere in the thread (both \`run\` comments and \`run_failed\` comments carry \`run_id\`; comments are oldest-first, so the last match is the newest run), or \`null\` while a run is active (\`task.has_active_run\`). The Retry button now shows only on the \`run_failed\` comment whose \`run_id\` matches it.

Result: Retry appears only on the most recent run, and never while a run is queued/running.

## Changes

- \`comments-section.tsx\` — compute \`retryableRunId\`, pass to both \`CommentRenderer\` instances.
- \`comment-renderers/index.tsx\` — thread \`retryableRunId\` through the renderer registry to \`SystemComment\`.
- \`system-comment.tsx\` — gate the Retry button on \`runId === retryableRunId\`.

## Tests

\`test/run-failed-comment.test.tsx\` — 3 passing:
- shows Retry when the failed run is the latest run
- hides Retry when a later run comment exists
- hides Retry while a run is active