### PR TITLE
fix(server): give container names a random suffix so keep-old rebuild…

### DIFF
--- a/packages/server/src/services/containers.ts
+++ b/packages/server/src/services/containers.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'node:crypto';
 import { join } from 'node:path';
 import type { PGlite } from '@electric-sql/pglite';
 import {
@@ -94,11 +95,11 @@ const PORT_POOL_END = 19999;
 
 const LAST_LOGS_CAP_BYTES = 32 * 1024;
 
-// When true, every old-container removal is skipped (rebuild, teardown, and
-// the defensive same-name cleanup before create). Provisioning a fresh
-// container then fails with a name conflict until the operator removes the
-// old one by hand — the trade-off is keeping crashed containers around for
-// `docker logs` / `docker inspect`. Set centrally from parseConfig at startup.
+// When true, old containers are kept rather than removed on rebuild and
+// teardown, so crashed containers stay around for `docker logs` /
+// `docker inspect`. A fresh provision still succeeds because each container
+// name carries a random suffix, so a retained container never blocks the new
+// one. Set centrally from parseConfig at startup.
 let keepOldContainersFlag = false;
 
 export function setKeepOldContainers(value: boolean): void {
@@ -257,10 +258,11 @@ export async function provisionContainer(
 
 		// Bind mounts key on the immutable project id, so a rename never shifts
 		// paths or orphans data. The container name embeds the project slug for
-		// `docker ps` readability and an 8-char id prefix for uniqueness; on
-		// rename the next rebuild adopts the new slug, while the old container
-		// is torn down by stored `container_id` hash rather than by name.
-		const containerName = `hezo-${project.slug}-${project.id.slice(0, 8)}`;
+		// `docker ps` readability, an 8-char id prefix, and a random suffix so
+		// every provision yields a unique name. The old container is always torn
+		// down by stored `container_id`, never by name, so when it is retained
+		// (keep-old) the fresh name still avoids a create-time conflict.
+		const containerName = `hezo-${project.slug}-${project.id.slice(0, 8)}-${randomBytes(4).toString('hex')}`;
 		const containerLabels = { 'hezo.team': teamSlug, 'hezo.project': project.slug };
 		const extraHosts = ['host.docker.internal:host-gateway'];
 
@@ -275,13 +277,6 @@ export async function provisionContainer(
 		});
 
 		emit('stdout', `→ Creating container ${containerName}`);
-		if (!keepOldContainersFlag) {
-			try {
-				await docker.removeContainer(containerName, true);
-			} catch {
-				// Container doesn't exist — expected
-			}
-		}
 
 		const { Id } = await docker.createContainer(containerName, {
 			Image: project.docker_base_image,

--- a/packages/server/src/services/docker.ts
+++ b/packages/server/src/services/docker.ts
@@ -241,8 +241,29 @@ export class DockerClient {
 		return parseJsonOrThrow(res, 'inspectContainer');
 	}
 
-	async inspectContainerByName(name: string): Promise<ContainerInfo | null> {
-		return this.inspectContainer(name);
+	/**
+	 * Resolve a container by the deterministic name prefix a project provisions
+	 * under. The full name carries a random suffix that is not reconstructable
+	 * from project fields, so self-heal matches on the stable
+	 * `hezo-<slug>-<id8>` prefix and inspects the live match. Only a container
+	 * whose name segment after the prefix is the random suffix counts, so an
+	 * unrelated longer-slug project can't be matched by accident.
+	 */
+	async findContainerByNamePrefix(prefix: string): Promise<ContainerInfo | null> {
+		const filters = encodeURIComponent(JSON.stringify({ name: [prefix] }));
+		const res = await this.request('GET', `/containers/json?all=true&filters=${filters}`);
+		if (!res.ok) {
+			const text = await res.text();
+			throw new Error(`Docker listContainers failed (${res.status}): ${text}`);
+		}
+		const list = await parseJsonOrThrow<Array<{ Id: string; Names: string[] }>>(
+			res,
+			'listContainers',
+		);
+		const match = list.find((c) =>
+			c.Names.some((n) => n.replace(/^\//, '').startsWith(`${prefix}-`)),
+		);
+		return match ? this.inspectContainer(match.Id) : null;
 	}
 
 	/**

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -694,9 +694,9 @@ export class JobManager {
 
 		for (const project of candidates.rows) {
 			const name = `hezo-${project.slug}-${project.id.slice(0, 8)}`;
-			let info: Awaited<ReturnType<DockerClient['inspectContainerByName']>>;
+			let info: Awaited<ReturnType<DockerClient['findContainerByNamePrefix']>>;
 			try {
-				info = await docker.inspectContainerByName(name);
+				info = await docker.findContainerByNamePrefix(name);
 			} catch (err) {
 				log.warn(`Self-heal inspect failed for ${name}:`, err);
 				continue;

--- a/packages/server/test/container-sync.test.ts
+++ b/packages/server/test/container-sync.test.ts
@@ -843,9 +843,14 @@ describe('provisionContainer broadcasting', () => {
 		const nameAfter = dockerAfter.createContainer.mock.calls[0][0];
 		const bindsAfter = dockerAfter.createContainer.mock.calls[0][1].HostConfig.Binds as string[];
 
-		// Name embeds the slug for `docker ps` readability — rename changes it.
-		expect(nameBefore).toBe(`hezo-${before.slug}-${renameProjectId.slice(0, 8)}`);
-		expect(nameAfter).toBe(`hezo-renamed-project-slug-${renameProjectId.slice(0, 8)}`);
+		// Name embeds the slug for `docker ps` readability (rename changes it) plus
+		// a random suffix so a retained old container never blocks the new name.
+		expect(nameBefore).toMatch(
+			new RegExp(`^hezo-${before.slug}-${renameProjectId.slice(0, 8)}-[0-9a-f]+$`),
+		);
+		expect(nameAfter).toMatch(
+			new RegExp(`^hezo-renamed-project-slug-${renameProjectId.slice(0, 8)}-[0-9a-f]+$`),
+		);
 		expect(nameAfter).not.toBe(nameBefore);
 
 		// Bind mounts key on the immutable id, so paths stay stable across rename.

--- a/packages/server/test/helpers/app.ts
+++ b/packages/server/test/helpers/app.ts
@@ -34,6 +34,7 @@ const STUB_DOCKER_METHODS = {
 		State: { Status: 'running', Running: true, Pid: 1, ExitCode: 0 },
 		Config: { Image: 'stub' },
 	}),
+	findContainerByNamePrefix: async () => null,
 	containerStats: async () => null,
 	containerLogs: async () => ({ arrayBuffer: async () => new ArrayBuffer(0) }),
 	execCreate: async () => {

--- a/packages/server/test/job-manager-workflows.test.ts
+++ b/packages/server/test/job-manager-workflows.test.ts
@@ -2009,7 +2009,11 @@ describe('JobManager workflow methods', () => {
 
 				await manager.reconcileOnStartup();
 
-				expect(createCalls).toContain(`hezo-${projectSlug}-${projectId.slice(0, 8)}`);
+				expect(
+					createCalls.some((name) =>
+						name.startsWith(`hezo-${projectSlug}-${projectId.slice(0, 8)}-`),
+					),
+				).toBe(true);
 				const row = await db.query<{ container_id: string | null; container_status: string }>(
 					'SELECT container_id, container_status FROM projects WHERE id = $1',
 					[projectId],


### PR DESCRIPTION
…s don't 409

A stale-mount rebuild with keep-old-containers enabled left the old container in place, then tried to create the replacement under the same deterministic hezo-<slug>-<id8> name and failed with a Docker 409 name conflict — stranding the project with an unreachable /workspace mount.

Append a random suffix to the container name so every provision yields a unique name; old-container removal stays gated on keep-old-containers. Self-heal can no longer reconstruct the exact name, so add DockerClient.findContainerByNamePrefix and match on the stable prefix.