### PR TITLE
fix(egress): PortAllocator race + cross-host cert detector; human-set credential hosts

### DIFF
--- a/packages/server/src/routes/comments.ts
+++ b/packages/server/src/routes/comments.ts
@@ -382,7 +382,11 @@ commentsRoutes.post(
 		if (!taskId) return err(c, 'NOT_FOUND', 'Task not found', 404);
 		const commentId = c.req.param('commentId');
 
-		const body = await c.req.json<{ value?: string; confirmed?: boolean }>();
+		const body = await c.req.json<{
+			value?: string;
+			confirmed?: boolean;
+			allowed_hosts?: string[];
+		}>();
 
 		const existing = await db.query<{
 			content_type: string;
@@ -411,9 +415,17 @@ commentsRoutes.post(
 			scope === 'project' && typeof requestContent.project_id === 'string'
 				? requestContent.project_id
 				: null;
-		const allowedHosts = Array.isArray(requestContent.allowed_hosts)
+		const requestHosts = Array.isArray(requestContent.allowed_hosts)
 			? (requestContent.allowed_hosts as string[])
 			: [];
+		// The human pasting the value can set or correct the host allowlist —
+		// the safety net when an agent requested an exempt kind (other/webhook)
+		// without scoping, leaving the secret undeliverable. A non-empty override
+		// wins; otherwise the agent's requested hosts stand.
+		const overrideHosts = Array.isArray(body.allowed_hosts)
+			? body.allowed_hosts.map((h) => String(h).trim().toLowerCase()).filter((h) => h.length > 0)
+			: [];
+		const allowedHosts = overrideHosts.length > 0 ? overrideHosts : requestHosts;
 		const requestingAgentId = row.author_member_id;
 
 		const isConfirmation = typeof requestContent.confirmation_text === 'string';

--- a/packages/server/src/services/egress/port-allocator.ts
+++ b/packages/server/src/services/egress/port-allocator.ts
@@ -20,22 +20,29 @@ export class PortAllocator {
 	) {}
 
 	async allocate(agentId?: string): Promise<number> {
+		// Reserve a candidate synchronously before the async availability probe.
+		// The probe yields to the event loop, so without claiming the port first
+		// two concurrent allocations would both see it free and return the same
+		// port — one run then fails to bind and aborts. Releasing the claim if
+		// the probe comes back negative keeps an externally-bound port skippable.
 		if (agentId) {
 			const previous = this.lastForAgent.get(agentId);
 			if (previous !== undefined && !this.inUse.has(previous)) {
+				this.inUse.add(previous);
 				if (await this.probeAvailability(previous)) {
-					this.inUse.add(previous);
 					return previous;
 				}
+				this.inUse.delete(previous);
 			}
 		}
 		for (let port = this.rangeStart; port <= this.rangeEnd; port++) {
 			if (this.inUse.has(port)) continue;
+			this.inUse.add(port);
 			if (await this.probeAvailability(port)) {
-				this.inUse.add(port);
 				if (agentId) this.lastForAgent.set(agentId, port);
 				return port;
 			}
+			this.inUse.delete(port);
 		}
 		throw new Error(`No free port in range [${this.rangeStart}, ${this.rangeEnd}]`);
 	}

--- a/packages/server/src/services/egress/proxy.ts
+++ b/packages/server/src/services/egress/proxy.ts
@@ -103,6 +103,19 @@ export class EgressProxy {
 				.catch((e: Error) => callback(e));
 		});
 
+		// The library terminates TLS with a per-host internal server, each
+		// presenting that host's leaf cert. A production report showed one host's
+		// cert served on another host's connection (a wrong-SAN TLS failure that
+		// the in-process MITM path never reproduces). This detector runs after the
+		// per-host server is (re)selected and fails loud if two unrelated upstream
+		// hosts resolved to the same internal port — the exact cross-host route —
+		// so the next occurrence is captured with the port and hosts involved.
+		const loggedCollisions = new Set<string>();
+		proxy.onConnect(((_req: unknown, _socket: unknown, _head: unknown, callback: () => void) => {
+			setImmediate(() => detectCrossHostCertRoute(proxy, scope, runId, loggedCollisions));
+			callback();
+		}) as Parameters<IProxy['onConnect']>[0]);
+
 		try {
 			await new Promise<void>((resolve, reject) => {
 				let settled = false;
@@ -329,6 +342,51 @@ function headersContainProbe(headers: Record<string, string>): boolean {
 		if (typeof v === 'string' && PLACEHOLDER_PROBE_REGEX.test(v)) return true;
 	}
 	return false;
+}
+
+/** Collapse the first DNS label to a wildcard so subdomains sharing one
+ * wildcard-covered internal server (a legitimate single cert) don't read as a
+ * collision. `api.githubcopilot.com` → `*.githubcopilot.com`. */
+function wildcardForm(host: string): string {
+	return host.replace(/^[^.]+\./, '*.');
+}
+
+/**
+ * Inspect the library's per-host server map for the egress invariant that no
+ * two unrelated upstream hosts share one internal MITM server port. A shared
+ * port means a tunnel for one host would be served the other host's leaf cert.
+ * Subdomains of the same wildcard legitimately share a server, so only ports
+ * spanning more than one wildcard group are flagged. Read-only; logs once per
+ * offending port.
+ */
+export function detectCrossHostCertRoute(
+	proxy: IProxy,
+	scope: RunProxyScope,
+	runId: string,
+	logged: Set<string>,
+): void {
+	const sslServers = (proxy as unknown as { sslServers?: Record<string, { port?: number }> })
+		.sslServers;
+	if (!sslServers) return;
+	const hostsByPort = new Map<number, string[]>();
+	for (const [host, entry] of Object.entries(sslServers)) {
+		const port = entry?.port;
+		if (typeof port !== 'number') continue;
+		const hosts = hostsByPort.get(port);
+		if (hosts) hosts.push(host);
+		else hostsByPort.set(port, [host]);
+	}
+	for (const [port, hosts] of hostsByPort) {
+		if (hosts.length < 2) continue;
+		if (new Set(hosts.map(wildcardForm)).size < 2) continue;
+		if (logged.has(`${port}`)) continue;
+		logged.add(`${port}`);
+		log.error('egress MITM server port serves unrelated hosts — cross-host cert risk', {
+			run: ref(scope.label, runId),
+			port,
+			hosts: [...new Set(hosts)],
+		});
+	}
 }
 
 interface ErrorContext {

--- a/packages/server/test/bun/egress-proxy.bun.test.ts
+++ b/packages/server/test/bun/egress-proxy.bun.test.ts
@@ -119,6 +119,35 @@ describe('EgressProxy under Bun', () => {
 			await new Promise<void>((resolve) => upstream.close(() => resolve()));
 		}
 	}, 30_000);
+
+	// A single run reaches multiple upstream hosts concurrently (e.g. a SaaS MCP
+	// host plus a package registry). Each host gets its own internally-minted
+	// leaf cert; a connection for one host must never be served the cert minted
+	// for another. The MITM library spins up a separate per-host HTTPS server,
+	// and concurrent first-time minting of two hosts must not cross the certs —
+	// otherwise the client sees ERR_TLS_CERT_ALTNAME_INVALID against the wrong
+	// SAN. Asserting on the served leaf cert is enough: the client↔proxy
+	// handshake completes before any upstream connection, so no upstream is
+	// needed and the hostnames need not resolve.
+	test('concurrent connections to different hosts are each served that host cert', async () => {
+		const hosts = Array.from({ length: 8 }, (_u, i) => `host-${i}.hezo-egress-test`);
+		// Fresh run proxies so every host is first-seen concurrently, forcing the
+		// per-host cert mint + listen to race within each proxy.
+		for (let attempt = 0; attempt < 8; attempt++) {
+			const runId = `bun-multihost-${process.pid}-${attempt}`;
+			const allocated = await proxy.allocateRunProxy(runId, { teamId, agentId });
+			try {
+				const certs = await Promise.all(
+					hosts.map((h) => servedCertThroughProxy(allocated.proxyPort, h, ca.cert)),
+				);
+				for (let i = 0; i < hosts.length; i++) {
+					expect(certs[i]).toContain(hosts[i]);
+				}
+			} finally {
+				await proxy.releaseRunProxy(runId);
+			}
+		}
+	}, 30_000);
 });
 
 const httpsHits: Array<Record<string, string | string[] | undefined>> = [];
@@ -210,5 +239,52 @@ async function fetchHttpsThroughProxy(
 		});
 		tls.on('error', reject);
 		tls.setTimeout(20_000, () => tls.destroy(new Error('https fetch timed out')));
+	});
+}
+
+// Open a CONNECT tunnel for `targetHost`, complete the client↔proxy TLS
+// handshake, and return a descriptor of the leaf cert the proxy served (CN +
+// subjectAltName). A wrong per-host cert makes the handshake reject with
+// ERR_TLS_CERT_ALTNAME_INVALID against `servername`, surfacing the cross-host
+// mix-up. No upstream is contacted, so the target host need not resolve.
+async function servedCertThroughProxy(
+	proxyPort: number,
+	targetHost: string,
+	caCert: string,
+): Promise<string> {
+	const tunnel = await new Promise<ReturnType<typeof netConnect>>((resolve, reject) => {
+		const sock = netConnect({ host: '127.0.0.1', port: proxyPort });
+		const onData = (chunk: Buffer) => {
+			const statusLine = chunk.toString().split('\r\n')[0] ?? '';
+			sock.removeListener('data', onData);
+			if (/^HTTP\/1\.[01] 200/.test(statusLine)) {
+				resolve(sock);
+			} else {
+				reject(new Error(`CONNECT failed: ${statusLine}`));
+			}
+		};
+		sock.on('connect', () => {
+			sock.write(`CONNECT ${targetHost}:443 HTTP/1.1\r\nHost: ${targetHost}:443\r\n\r\n`);
+		});
+		sock.on('data', onData);
+		sock.on('error', reject);
+		sock.setTimeout(20_000, () => sock.destroy(new Error('CONNECT timed out')));
+	});
+
+	return new Promise<string>((resolve, reject) => {
+		// rejectUnauthorized:false so a cross-host cert still completes the
+		// handshake — the caller asserts on which cert was served rather than
+		// the connection merely failing.
+		const tls = tlsConnect(
+			{ socket: tunnel, servername: targetHost, ca: [caCert], rejectUnauthorized: false },
+			() => {
+				const peer = tls.getPeerCertificate();
+				const descriptor = `${peer.subject?.CN ?? ''} ${peer.subjectaltname ?? ''}`;
+				tls.end();
+				resolve(descriptor);
+			},
+		);
+		tls.on('error', reject);
+		tls.setTimeout(20_000, () => tls.destroy(new Error('tls handshake timed out')));
 	});
 }

--- a/packages/server/test/credential-requests.test.ts
+++ b/packages/server/test/credential-requests.test.ts
@@ -334,6 +334,39 @@ describe('fulfill-credential endpoint', () => {
 		expect(body.error.message).toContain('already fulfilled');
 	});
 
+	it('lets the human set allowed_hosts at fulfillment for an unscoped request', async () => {
+		// Exempt kind (other) can be requested with no hosts, leaving it
+		// undeliverable. The human scopes it when pasting the value.
+		const created = (await callRequestCredential({
+			team_id: teamId,
+			task_id: taskId,
+			name: 'FULFILL_HOST_OVERRIDE',
+			kind: 'other',
+			instructions: 'paste and scope me',
+		})) as { comment_id: string };
+
+		const res = await app.request(
+			`/api/projects/${projectSlug}/tasks/${taskId}/comments/${created.comment_id}/fulfill-credential`,
+			{
+				method: 'POST',
+				headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					value: 'tok-123',
+					allowed_hosts: ['API.NETLIFY.COM', ' app.netlify.com '],
+				}),
+			},
+		);
+		expect(res.status).toBe(200);
+		const secretId = (await res.json()).data.secret_id;
+
+		const secretRow = await db.query<{ allowed_hosts: string[] }>(
+			'SELECT allowed_hosts FROM secrets WHERE id = $1',
+			[secretId],
+		);
+		// Normalized (trimmed + lowercased) and applied over the empty request.
+		expect(secretRow.rows[0].allowed_hosts).toEqual(['api.netlify.com', 'app.netlify.com']);
+	});
+
 	it('rejects fulfill on a non-credential-request comment', async () => {
 		const textRes = await app.request(`/api/projects/${projectSlug}/tasks/${taskId}/comments`, {
 			method: 'POST',

--- a/packages/server/test/egress-port-allocator.test.ts
+++ b/packages/server/test/egress-port-allocator.test.ts
@@ -32,6 +32,17 @@ describe('PortAllocator', () => {
 		expect(second).not.toBe(first);
 	});
 
+	it('hands out distinct ports for concurrent allocations', async () => {
+		// The availability probe yields to the event loop; concurrent allocations
+		// must not all settle on the same candidate port during that window.
+		const allocator = new PortAllocator(20100, 20107, async () => {
+			await new Promise((resolve) => setTimeout(resolve, 1));
+			return true;
+		});
+		const ports = await Promise.all(Array.from({ length: 8 }, () => allocator.allocate('agent-A')));
+		expect(new Set(ports).size).toBe(ports.length);
+	});
+
 	it('throws when the entire range is exhausted', async () => {
 		const allocator = new PortAllocator(20100, 20100, async () => true);
 		await allocator.allocate();

--- a/packages/server/test/egress-proxy.test.ts
+++ b/packages/server/test/egress-proxy.test.ts
@@ -5,11 +5,12 @@ import type { Socket } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { PGlite } from '@electric-sql/pglite';
+import type { IProxy } from 'http-mitm-proxy';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { encrypt } from '../src/crypto/encryption';
 import type { MasterKeyManager } from '../src/crypto/master-key';
 import { type HezoCA, loadOrCreateCA } from '../src/services/egress/ca';
-import { EgressProxy } from '../src/services/egress/proxy';
+import { detectCrossHostCertRoute, EgressProxy } from '../src/services/egress/proxy';
 import { safeClose } from './helpers';
 import { createTestApp, createTestProject } from './helpers/app';
 
@@ -397,3 +398,52 @@ async function fetchHttpsThroughProxy(
 		tls.setTimeout(20_000, () => tls.destroy(new Error('https fetch timed out')));
 	});
 }
+
+describe('detectCrossHostCertRoute', () => {
+	const scope = { teamId: 't', agentId: 'a', label: 'run' };
+	const fakeProxy = (sslServers: Record<string, { port: number }>) =>
+		({ sslServers }) as unknown as IProxy;
+
+	it('flags two unrelated hosts sharing one internal server port', () => {
+		const logged = new Set<string>();
+		detectCrossHostCertRoute(
+			fakeProxy({
+				'api.githubcopilot.com': { port: 5001 },
+				'registry.npmjs.org': { port: 5001 },
+			}),
+			scope,
+			'run-1',
+			logged,
+		);
+		expect(logged.has('5001')).toBe(true);
+	});
+
+	it('does not flag distinct hosts on distinct ports', () => {
+		const logged = new Set<string>();
+		detectCrossHostCertRoute(
+			fakeProxy({
+				'api.githubcopilot.com': { port: 5001 },
+				'registry.npmjs.org': { port: 5002 },
+			}),
+			scope,
+			'run-1',
+			logged,
+		);
+		expect(logged.size).toBe(0);
+	});
+
+	it('does not flag subdomains legitimately sharing a wildcard server', () => {
+		const logged = new Set<string>();
+		detectCrossHostCertRoute(
+			fakeProxy({
+				'api.example.com': { port: 5003 },
+				'cdn.example.com': { port: 5003 },
+				'*.example.com': { port: 5003 },
+			}),
+			scope,
+			'run-1',
+			logged,
+		);
+		expect(logged.size).toBe(0);
+	});
+});

--- a/packages/web/src/components/comment-renderers/credential-request-comment.tsx
+++ b/packages/web/src/components/comment-renderers/credential-request-comment.tsx
@@ -24,8 +24,15 @@ export function CredentialRequestComment({ comment, projectId, taskId }: Props) 
 	const fulfilled = typeof comment.chosen_option?.secret_id === 'string';
 
 	const [value, setValue] = useState('');
+	const [hostsInput, setHostsInput] = useState(allowedHosts.join(', '));
 	const [error, setError] = useState<string | null>(null);
 	const fulfill = useFulfillCredential(projectId ?? '', taskId ?? '');
+
+	const parseHosts = (raw: string): string[] =>
+		raw
+			.split(/[\s,]+/)
+			.map((h) => h.trim().toLowerCase())
+			.filter((h) => h.length > 0);
 
 	if (!projectId || !taskId) {
 		return (
@@ -58,7 +65,7 @@ export function CredentialRequestComment({ comment, projectId, taskId }: Props) 
 		setError(null);
 		const args = confirmationText
 			? { commentId: comment.id, confirmed: true }
-			: { commentId: comment.id, value };
+			: { commentId: comment.id, value, allowedHosts: parseHosts(hostsInput) };
 		fulfill.mutate(args, {
 			onError: (e: unknown) => {
 				const msg = e instanceof Error ? e.message : 'Failed to submit';
@@ -150,6 +157,22 @@ export function CredentialRequestComment({ comment, projectId, taskId }: Props) 
 							data-testid="credential-input"
 						/>
 					)}
+					<div className="flex flex-col gap-1">
+						<label htmlFor={`hosts-${comment.id}`} className="text-xs text-text-muted">
+							Allowed hosts — the API host(s) this value may be sent to (comma-separated). The
+							egress proxy substitutes it only for these hosts.
+						</label>
+						<input
+							id={`hosts-${comment.id}`}
+							type="text"
+							value={hostsInput}
+							onChange={(e) => setHostsInput(e.target.value)}
+							placeholder="e.g. api.netlify.com, *.netlify.com"
+							autoComplete="off"
+							className="w-full text-sm p-2 rounded border border-border bg-bg focus:outline-none focus:border-accent-blue"
+							data-testid="credential-hosts-input"
+						/>
+					</div>
 					{error && <p className="text-xs text-accent-red-text">{error}</p>}
 					<div>
 						<Button

--- a/packages/web/src/hooks/use-comments.ts
+++ b/packages/web/src/hooks/use-comments.ts
@@ -197,16 +197,19 @@ export function useFulfillCredential(projectId: string, taskId: string) {
 			commentId,
 			value,
 			confirmed,
+			allowedHosts,
 		}: {
 			commentId: string;
 			value?: string;
 			confirmed?: boolean;
+			allowedHosts?: string[];
 		}) =>
 			api.post(
 				`/api/projects/${projectId}/tasks/${taskId}/comments/${commentId}/fulfill-credential`,
 				{
 					value,
 					confirmed,
+					allowed_hosts: allowedHosts,
 				},
 			),
 		onSuccess: () =>

--- a/packages/web/test/credential-request-comment.test.tsx
+++ b/packages/web/test/credential-request-comment.test.tsx
@@ -66,6 +66,24 @@ test('credential request without allowed_hosts shows a not-scoped warning', asyn
 	expect(warning.textContent).toContain('Not scoped to any host');
 });
 
+test('human can set allowed_hosts when fulfilling an unscoped request', async () => {
+	const { findByTestId, user } = await renderTaskWithCredentialRequest([]);
+	await findByTestId('credential-request', undefined, { timeout: 15_000 });
+
+	await user.type(await findByTestId('credential-input'), 'tok-123');
+	await user.type(await findByTestId('credential-hosts-input'), 'api.netlify.com, *.netlify.com');
+	await user.click(await findByTestId('credential-submit'));
+
+	// Fulfillment swaps the form for the confirmation block.
+	await findByTestId('credential-fulfilled', undefined, { timeout: 15_000 });
+
+	const { db } = getTestContext();
+	const secret = await db.query<{ allowed_hosts: string[] }>(
+		"SELECT allowed_hosts FROM secrets WHERE name = 'NETLIFY_AUTH_TOKEN'",
+	);
+	expect(secret.rows[0]?.allowed_hosts).toEqual(['api.netlify.com', '*.netlify.com']);
+});
+
 test('credential request with allowed_hosts shows the scoped-hosts line', async () => {
 	const { findByTestId, findByText, queryByTestId } = await renderTaskWithCredentialRequest([
 		'api.netlify.com',


### PR DESCRIPTION
Investigates two egress failures observed during a live agent run (TO-10): an `npm install` TLS error where `registry.npmjs.org` was served the MITM leaf cert minted for `api.githubcopilot.com`, and a Netlify credential created with empty `allowed_hosts` that the egress proxy then refused to substitute.

## Workstream A — egress proxy

**PortAllocator TOCTOU race (real, reproduced, fixed).** `allocate()` `await`ed the availability probe *between* the `inUse` check and the claim, so two concurrent allocations both saw a port free and returned the same one — the loser then fails to bind and the run aborts. Now reserves the candidate synchronously before probing (releasing on a negative probe). Regression test added.

**Cross-host cert mixing (not reproducible in-process → detector instead of a blind fix).** The exact symptom could not be reproduced across five concurrency models (simple concurrent, 8×8, held-open, cross-run, and 1200+ aggressive allocate/connect/release churn — 0 mismatches), and a full trace shows `http-mitm-proxy`'s per-host cert routing is deterministic and per-host-keyed. Shipping a speculative change to a security-critical TLS path with no reproducing failure would be irresponsible. Instead this adds `detectCrossHostCertRoute` — a read-only, wildcard-aware detector wired via `onConnect` that fails loud (logging the port + hosts) if two *unrelated* upstream hosts ever resolve to the same internal MITM server port, capturing the next live occurrence with the data needed to root-cause.

Also adds the first multi-host cert-invariant Bun-native test (each concurrent host must get its own leaf) and detector unit tests.

## Workstream B — credentials

An agent can request a credential under an egress-exempt kind (`other`, `webhook_secret`) with no `allowed_hosts`, yielding a secret the proxy won't substitute for any host — undeliverable with no recovery path. Adds a **fulfillment-time human override**: the paste form carries an editable allowed-hosts field (pre-filled from the request), and the fulfill endpoint accepts/normalizes `allowed_hosts` with a non-empty override winning. Stays response-driven (never optimistically fulfilled). Server + web tests added.

## Tests
Server vitest 44 ✓ (egress + credentials), Bun-native egress 3 ✓, web component 3 ✓, typecheck server+web clean, biome clean.