### PR TITLE
feat(web): add "Reply" label to comment reply button

### DIFF
--- a/packages/web/src/components/task-detail/comments-section.tsx
+++ b/packages/web/src/components/task-detail/comments-section.tsx
@@ -438,11 +438,12 @@ export function CommentsSection({
 											<button
 												type="button"
 												onClick={() => onStartReply(c)}
-												className="mt-2 text-text-subtle hover:text-text shrink-0 p-1 -m-1"
+												className="mt-2 flex items-center gap-1 text-[11px] text-text-subtle hover:text-text shrink-0 p-1 -m-1"
 												aria-label="Reply to comment"
 												data-testid="comment-reply"
 											>
 												<Reply className="w-3.5 h-3.5" />
+												Reply
 											</button>
 										</div>
 									</div>

--- a/packages/web/test/task-comments.test.tsx
+++ b/packages/web/test/task-comments.test.tsx
@@ -323,6 +323,8 @@ test('replying to an agent hides the wake-assignee toggle and omits the flag', a
 
 	const replyButtons = document.querySelectorAll('[data-testid="comment-reply"]');
 	expect(replyButtons.length).toBeGreaterThan(0);
+	// The button surfaces a visible "Reply" label alongside the icon.
+	expect(replyButtons[0].textContent).toContain('Reply');
 	await user.click(replyButtons[0] as HTMLElement);
 
 	const indicator = await findByTestId('reply-indicator');


### PR DESCRIPTION
## What

The reply button in the bottom-right corner of each comment previously showed only an icon. This adds a visible **"Reply"** text prefix alongside the icon so the affordance reads clearly.

## Details

- `comments-section.tsx`: the reply button now lays out the `Reply` icon + a "Reply" label with `flex items-center gap-1`, sized at `text-[11px]` to match the nearby "replying to" link. The `aria-label`, `data-testid="comment-reply"`, and click behavior are unchanged.
- `task-comments.test.tsx`: added an assertion that the reply button surfaces the visible "Reply" label.

## Before / After

| | |
|---|---|
| **Before** | ↩ (icon only) |
| **After** | ↩ Reply |

## Testing

- `bunx vitest run test/task-comments.test.tsx` — all 14 tests pass, including the updated label assertion.
- Biome clean on the component file.

https://claude.ai/code/session_019dMNJ7H4AjJHUiSR9qXwgT

---
_Generated by [Claude Code](https://claude.ai/code/session_019dMNJ7H4AjJHUiSR9qXwgT)_