### PR TITLE
fix(server): enrich read_project_doc description to steer agents off the filesystem

### DIFF
--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -2585,7 +2585,7 @@ export function registerTools(
 	tool(
 		server,
 		'read_project_doc',
-		'Read a project documentation file by filename',
+		'Read a markdown project doc by filename (e.g. "spec.md") — the high-level project context (PRDs, specs, architecture decisions, research) that list_project_docs returns; the full body comes back inline as `content`. These docs live in the project-doc store in the database, NOT on the filesystem: there is no /workspace/.hezo/project-docs path, so do not reach for the Read/cat file tools — always load a doc through this tool by its bare filename. For non-markdown assets (mockups, wireframes, diagrams) use read_project_asset instead.',
 		{
 			team_id: z.string().describe('Team ID'),
 			project_id: z.string().describe('Project ID'),

--- a/packages/server/src/services/template-resolver.ts
+++ b/packages/server/src/services/template-resolver.ts
@@ -202,7 +202,7 @@ export async function resolveSystemPrompt(
 					.join('\n');
 				docsText = [
 					'The project docs database holds high-level project context (PRDs, specs, architecture decisions, research). Entries are listed below by filename.',
-					"Call read_project_doc(filename) to load a doc's full contents when relevant to your task.",
+					"Call read_project_doc(filename) to load a doc's full contents when relevant to your task. These docs live in the database, not the filesystem — there is no /workspace/.hezo/project-docs path, so don't use the Read/cat file tools; load each one by its bare filename through read_project_doc.",
 					'',
 					lines,
 				].join('\n');

--- a/packages/server/test/template-resolver.test.ts
+++ b/packages/server/test/template-resolver.test.ts
@@ -129,6 +129,10 @@ describe('template resolver', () => {
 		expect(result).toContain('The project docs database holds high-level project context');
 		expect(result).toContain('read_project_doc(filename)');
 
+		// The manifest warns docs are not on disk, steering agents off filesystem probes.
+		expect(result).toContain('not the filesystem');
+		expect(result).toContain('/workspace/.hezo/project-docs');
+
 		// Titled doc (architecture-guidelines.md is seeded by createTestProject with a non-empty title).
 		expect(result).toMatch(
 			/- architecture-guidelines\.md — Architecture Guidelines \(updated \d{4}-\d{2}-\d{2}\)/,


### PR DESCRIPTION
## Why

When an agent (DeepSeek, here) was asked to read `spec.md`, it first probed the filesystem — `Read /workspace/.hezo/project-docs/spec.md` — which failed (`File does not exist`), then fell back to the `read_project_doc` MCP tool and succeeded.

The run prompt already does its job: the `{{project_docs_context}}` manifest lists the docs and says to call `read_project_doc(filename)` (`template-resolver.ts:188-211`), and `SHARED_INSTRUCTIONS` explicitly warns docs are "NOT filesystem paths" (`template-resolver.ts:47`). So this is model behavior, not a missing instruction — but a few things make the wrong move tempting:

- **Native `Read` is lower-friction** than an MCP tool that needs `team_id` + `project_id` + `filename`, so the agentic-coding prior ("file called spec.md → `Read`/`cat`") wins the first step.
- **The hallucinated path is a plausible confabulation.** There genuinely is a `.hezo/` tree on disk in the container (`assets/`, `prompts/`, `subscription/`, `mcp/`), and the prompt itself tells the agent assets are bind-mounted at `/workspace/.hezo/assets/` (`containers.ts:234`). The agent over-generalized "assets are at `.hezo/assets/`, so docs must be at `.hezo/project-docs/`." There is no such path.
- **The "not on disk" caveat lived far from tool-selection time** — buried in `SHARED_INSTRUCTIONS`, not in the two places the model actually reads when choosing how to load a doc: the tool description and the doc manifest.

## What

Two complementary changes that put the correction where the model decides:

1. **`read_project_doc` tool description** (`mcp/tools.ts`) — was a bare one-liner (`"Read a project documentation file by filename"`), while the sibling `read_project_asset` two tools up already has a full steering paragraph. Brought to parity: names what it reads (markdown PRDs/specs/architecture/research from `list_project_docs`), that the body returns inline as `content`, that docs live in the DB — **not** the filesystem, there is no `/workspace/.hezo/project-docs` path, don't reach for `Read`/`cat` — and cross-references `read_project_asset`.

2. **Project-docs manifest** (`template-resolver.ts`) — the injected `{{project_docs_context}}` block already lists docs and says to call `read_project_doc(filename)`; now it also echoes the "not the filesystem / no `.hezo/project-docs` path / load by bare filename" caveat right next to that instruction, instead of only in `SHARED_INSTRUCTIONS` far below. Locked in with an assertion in the existing manifest test.

## Testing

- `bun run typecheck` — 5/5 packages pass
- `bunx vitest run test/template-resolver.test.ts test/mcp-tools.test.ts` — 123/123 pass

No test asserted on the old tool-description string; the manifest test's existing `not.toContain` assertions target the old warning copy and doc bodies, neither of which the new wording reintroduces.

https://claude.ai/code/session_01LrsV6jP19uXCtsZXf4JNCq