### PR TITLE
test(repos): close out Phase 13 with wizard-flow and designation lifecycle coverage

### DIFF
--- a/.dev/implementation-phases.md
+++ b/.dev/implementation-phases.md
@@ -730,7 +730,7 @@ Backend:
 
 ## Phase 13: Designated Repo Setup via OAuth
 
-**Status:** In progress
+**Status:** Done (2026-06-11)
 
 **Goal:** Drive the board through a Hezo Connect GitHub OAuth dance when a code-touching agent (`member_agents.touches_code = true`) starts work on a repo-less project. The flow either creates a new GitHub repo under a selected org or links an existing accessible one, and the first repo becomes the designated repo (immutable thereafter).
 
@@ -757,7 +757,7 @@ Frontend:
 Tests:
 - Local GitHub simulator in `packages/server/test/helpers/github-sim.ts` — Hono app on port 0 implementing the subset of GitHub API we call plus Connect's token-exchange endpoint
 - Integration: gate behavior (approval + comment + deferred wakeup, no execution lock); concurrent runs share one approval; immutability on delete; `mode=create` owner check; first-repo auto-designation race; `finalizePendingRepoSetup` idempotency; OAuth callback SSH-key idempotency; authorization on all new endpoints
-- E2E: full wizard flow end-to-end against the simulator, both `Create new` and `Select existing`, plus the disabled-delete path
+- Component tier (`packages/web/test/repo-picker-flows.test.tsx`): full wizard flow against the simulator, both `Create new` and `Select existing`, plus the designated-repo lock (no delete affordance) — component tests per the decision tree, since the wizard is pure form/dialog/mutation behavior; server tier (`repos-create-github.test.ts`) covers first-repo auto-designation and the `DESIGNATED_REPO_IMMUTABLE` 409 on delete
 
 Docs:
 - `.dev/spec.md`, `.dev/schema.md`, `.dev/api.md` updated to reflect the new flow and invariants

--- a/packages/server/test/repos-create-github.test.ts
+++ b/packages/server/test/repos-create-github.test.ts
@@ -1,3 +1,5 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import type { PGlite } from '@electric-sql/pglite';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
@@ -15,6 +17,7 @@ let teamId: string;
 let projectId: string;
 let oauthConnectionId: string;
 let sim: GitHubSim;
+let dataDir: string;
 
 let prevApi: string | undefined;
 const accessToken = 'gho_repo_create_test_token';
@@ -67,6 +70,7 @@ beforeAll(async () => {
 	db = ctx.db;
 	masterKeyManager = ctx.masterKeyManager;
 	token = ctx.token;
+	dataDir = ctx.dataDir;
 
 	const typesRes = await app.request('/api/team-templates', { headers: authHeader(token) });
 	const typeId = (await typesRes.json()).data.find(
@@ -116,5 +120,113 @@ describe('POST /api/projects/:projectId/repos with mode=create', () => {
 			projectId,
 		]);
 		expect(repoRows.rows).toHaveLength(0);
+	});
+});
+
+// POST /repos clones over SSH after the insert; the test app has no
+// SshAgentServer, so emulate an existing clone (repo-sync skips dirs that
+// already contain .git) to keep the success path quiet and deterministic.
+function fakeClonedRepoDir(shortName: string) {
+	const gitDir = join(
+		dataDir,
+		'teams',
+		teamId,
+		'projects',
+		projectId,
+		'workspace',
+		shortName,
+		'.git',
+	);
+	mkdirSync(gitDir, { recursive: true });
+	writeFileSync(join(gitDir, 'HEAD'), 'ref: refs/heads/main\n');
+}
+
+describe('repo creation, first-repo designation, and designated immutability', () => {
+	let designatedRepoId: string;
+	let secondRepoId: string;
+
+	it('mode=create creates the repo on GitHub and auto-designates the first repo', async () => {
+		// Container already "running" so the post-designation auto-start is a no-op.
+		await db.query(
+			`UPDATE projects SET container_id = 'test-container', container_status = 'running' WHERE id = $1`,
+			[projectId],
+		);
+		fakeClonedRepoDir('svc');
+
+		const res = await app.request(`/api/projects/${projectId}/repos`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				short_name: 'svc',
+				mode: 'create',
+				owner: 'octo-repo',
+				name: 'fresh-service',
+				private: true,
+				oauth_connection_id: oauthConnectionId,
+			}),
+		});
+		expect(res.status).toBe(201);
+		const body = await res.json();
+		expect(body.data.repo_identifier).toBe('octo-repo/fresh-service');
+		expect(body.data.is_designated).toBe(true);
+		expect(body.data.clone_status).toBe('skipped');
+		designatedRepoId = body.data.id;
+
+		// Created upstream, not just recorded locally.
+		expect(sim.state.repos.some((r) => r.full_name === 'octo-repo/fresh-service')).toBe(true);
+
+		const project = await db.query<{ designated_repo_id: string | null }>(
+			'SELECT designated_repo_id FROM projects WHERE id = $1',
+			[projectId],
+		);
+		expect(project.rows[0].designated_repo_id).toBe(designatedRepoId);
+	});
+
+	it('mode=link adds a second repo without re-designating', async () => {
+		fakeClonedRepoDir('second');
+
+		const res = await app.request(`/api/projects/${projectId}/repos`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				short_name: 'second',
+				mode: 'link',
+				url: 'https://github.com/octo-repo/already-taken',
+				oauth_connection_id: oauthConnectionId,
+			}),
+		});
+		expect(res.status).toBe(201);
+		const body = await res.json();
+		expect(body.data.is_designated).toBe(false);
+		secondRepoId = body.data.id;
+
+		const project = await db.query<{ designated_repo_id: string | null }>(
+			'SELECT designated_repo_id FROM projects WHERE id = $1',
+			[projectId],
+		);
+		expect(project.rows[0].designated_repo_id).toBe(designatedRepoId);
+	});
+
+	it('DELETE on the designated repo returns 409 DESIGNATED_REPO_IMMUTABLE', async () => {
+		const res = await app.request(`/api/projects/${projectId}/repos/${designatedRepoId}`, {
+			method: 'DELETE',
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(409);
+		const body = await res.json();
+		expect(body.error.code).toBe('DESIGNATED_REPO_IMMUTABLE');
+
+		const still = await db.query('SELECT id FROM repos WHERE id = $1', [designatedRepoId]);
+		expect(still.rows).toHaveLength(1);
+	});
+
+	it('DELETE on a non-designated repo still works', async () => {
+		const res = await app.request(`/api/projects/${projectId}/repos/${secondRepoId}`, {
+			method: 'DELETE',
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data.deleted).toBe(true);
 	});
 });

--- a/packages/web/src/components/github-section.tsx
+++ b/packages/web/src/components/github-section.tsx
@@ -212,6 +212,8 @@ export function GitHubSection({ projectId }: GitHubSectionProps) {
 										type="button"
 										onClick={() => deleteRepo.mutate(r.id)}
 										className="text-text-subtle hover:text-accent-red"
+										aria-label={`Remove repo ${r.short_name}`}
+										data-testid={`repo-delete-${r.short_name}`}
 									>
 										<Trash2 className="w-3.5 h-3.5" />
 									</button>

--- a/packages/web/test/helpers/render.tsx
+++ b/packages/web/test/helpers/render.tsx
@@ -43,6 +43,10 @@ interface TestAppContext {
 	// resolves a newer @electric-sql/pglite whose nominal type is incompatible.
 	db: Awaited<ReturnType<typeof createTestApp>>['db'];
 	masterKeyManager: Awaited<ReturnType<typeof createTestApp>>['masterKeyManager'];
+	// Per-test temp dir backing the server's workspace/worktree layout. Lets
+	// specs pre-create `workspace/<short_name>/.git` so repo-sync treats a repo
+	// as already cloned instead of attempting a real SSH clone.
+	dataDir: string;
 }
 
 let activeContext: TestAppContext | null = null;
@@ -66,6 +70,7 @@ beforeEach(async () => {
 		apiBase,
 		db: test.db,
 		masterKeyManager: test.masterKeyManager,
+		dataDir: test.dataDir,
 	} as unknown as TestAppContext;
 
 	// Auth: drop the token into localStorage AND push it into the api singleton
@@ -93,6 +98,11 @@ beforeEach(async () => {
 	// entirely; matches the way the dev Vite proxy forwards /api, /oauth, /mcp,
 	// /health, and /skill.md to the server.
 	realFetch = globalThis.fetch;
+	// Close over the captured fetch rather than reading `realFetch` at call
+	// time: a debounced/in-flight request can land after afterEach nulls the
+	// module variable, and the late call would then throw inside the server
+	// route ("realFetch is not a function") instead of completing quietly.
+	const passthroughFetch = realFetch;
 	globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
 		let req: Request;
 		if (input instanceof Request) {
@@ -112,9 +122,9 @@ beforeEach(async () => {
 		) {
 			return test.app.fetch(req);
 		}
-		// Unknown path — fall back to realFetch (which will likely fail in
+		// Unknown path — fall back to the real fetch (which will likely fail in
 		// happy-dom, which is what we want: it should surface as a test bug).
-		return realFetch!(req);
+		return passthroughFetch(req);
 	}) as typeof globalThis.fetch;
 });
 

--- a/packages/web/test/helpers/setup.ts
+++ b/packages/web/test/helpers/setup.ts
@@ -30,6 +30,33 @@ console.error = (...args: unknown[]) => {
 	originalConsoleError(...args);
 };
 
+// Node ≥22 ships an experimental `localStorage` global that is undefined unless
+// the process runs with --localstorage-file. Vitest's happy-dom environment
+// won't overwrite an existing global, so on those Node versions every module
+// that touches localStorage at import time (the api singleton) explodes with
+// "Cannot read properties of undefined". Backfill a plain in-memory Storage.
+if (globalThis.localStorage === undefined) {
+	const store = new Map<string, string>();
+	const memoryStorage: Storage = {
+		get length() {
+			return store.size;
+		},
+		clear: () => store.clear(),
+		getItem: (key: string) => store.get(key) ?? null,
+		key: (index: number) => [...store.keys()][index] ?? null,
+		removeItem: (key: string) => {
+			store.delete(key);
+		},
+		setItem: (key: string, value: string) => {
+			store.set(key, String(value));
+		},
+	};
+	Object.defineProperty(globalThis, 'localStorage', {
+		value: memoryStorage,
+		configurable: true,
+	});
+}
+
 // happy-dom has no layout, so react-virtuoso measures zero viewport and refuses
 // to mount any items. Component-tier tests don't care about virtualization;
 // stub Virtuoso to a plain mapped list so comments / sub-tasks / KB lists

--- a/packages/web/test/repo-picker-flows.test.tsx
+++ b/packages/web/test/repo-picker-flows.test.tsx
@@ -1,0 +1,233 @@
+// Wizard-flow coverage for the Phase 13 repo-setup picker: the successful
+// "Link existing" and "Create new" paths against the GitHub simulator, plus
+// the designated-repo lock (no delete affordance) on the project settings
+// page. Component tier per the decision tree — pure form/dialog/mutation
+// behavior, no real layout, viewport, or WebSocket dependency.
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { encrypt } from '@hezo/server/test/helpers/app';
+import { createGitHubSim, type GitHubSim } from '@hezo/server/test/helpers/github-sim';
+import { screen, waitFor } from '@testing-library/react';
+import { afterAll, beforeAll, expect, test } from 'vitest';
+import { getTestContext, renderApp } from './helpers/render';
+import { seedProject, seedWorkspace } from './helpers/seed';
+
+let sim: GitHubSim;
+let prevApi: string | undefined;
+const accessToken = 'gho_picker_flows_token';
+const ghOwner = 'octo-flows';
+
+beforeAll(async () => {
+	sim = await createGitHubSim();
+	prevApi = process.env.GITHUB_API_BASE_URL;
+	process.env.GITHUB_API_BASE_URL = sim.baseUrl;
+
+	sim.seed({
+		token: accessToken,
+		user: { id: 9100, login: ghOwner, avatar_url: '', email: 'octo@flows' },
+		repos: [
+			{
+				id: 11,
+				name: 'billing-service',
+				full_name: `${ghOwner}/billing-service`,
+				owner: { login: ghOwner },
+				private: true,
+				default_branch: 'main',
+				clone_url: `https://github.com/${ghOwner}/billing-service.git`,
+				ssh_url: `git@github.com:${ghOwner}/billing-service.git`,
+			},
+		],
+	});
+});
+
+afterAll(async () => {
+	process.env.GITHUB_API_BASE_URL = prevApi;
+	await sim.destroy();
+});
+
+async function seedGitHubOAuth(): Promise<string> {
+	const { db, masterKeyManager } = getTestContext();
+	const key = masterKeyManager.getKey();
+	if (!key) throw new Error('master key not available');
+	const encrypted = encrypt(accessToken, key);
+
+	const secretRes = await db.query<{ id: string }>(
+		`INSERT INTO secrets (name, encrypted_value, category, allowed_hosts)
+		 VALUES ($1, $2, 'api_token', ARRAY['github.com'])
+		 RETURNING id`,
+		[`OAUTH_GITHUB_${Math.random().toString(16).slice(2, 10)}`, encrypted],
+	);
+	const connRes = await db.query<{ id: string }>(
+		`INSERT INTO oauth_connections (provider, provider_account_id, provider_account_label, access_token_secret_id, scopes)
+		 VALUES ('github', $1, $2, $3, ARRAY['repo','read:org','write:public_key'])
+		 RETURNING id`,
+		['9100', ghOwner, secretRes.rows[0].id],
+	);
+	return connRes.rows[0].id;
+}
+
+// POST /repos clones over SSH after the insert; the test app has no
+// SshAgentServer, so emulate an existing clone (repo-sync skips dirs that
+// already contain .git) and mark the container running so the post-designation
+// container auto-start is a no-op. Keeps the success path quiet and green.
+async function neutralizeRepoSideEffects(teamId: string, projectId: string, shortName: string) {
+	const { db, dataDir } = getTestContext();
+	const gitDir = join(
+		dataDir,
+		'teams',
+		teamId,
+		'projects',
+		projectId,
+		'workspace',
+		shortName,
+		'.git',
+	);
+	mkdirSync(gitDir, { recursive: true });
+	writeFileSync(join(gitDir, 'HEAD'), 'ref: refs/heads/main\n');
+	await db.query(
+		`UPDATE projects SET container_id = 'test-container', container_status = 'running' WHERE id = $1`,
+		[projectId],
+	);
+}
+
+async function openRepoPicker(user: Awaited<ReturnType<typeof renderApp>>['user']) {
+	const openModalButton = await screen.findByTestId('repo-setup-add', undefined, {
+		timeout: 15_000,
+	});
+	await user.click(openModalButton);
+	await screen.findByTestId('repo-picker-modal', undefined, { timeout: 5_000 });
+	const ownerSelect = await screen.findByTestId('repo-picker-owner');
+	await waitFor(() => {
+		expect((ownerSelect as HTMLSelectElement).value).toBe(ghOwner);
+	});
+}
+
+test('link-existing flow links the repo and auto-designates the first repo', async () => {
+	let projectSlug = '';
+	const { user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Flows Link Project' });
+			projectSlug = project.slug;
+			await seedGitHubOAuth();
+			await neutralizeRepoSideEffects(ws.team.id, project.id, 'billing-service');
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/settings',
+		params: { projectId: projectSlug },
+	});
+
+	await openRepoPicker(user);
+
+	await user.click(
+		await screen.findByTestId(`repo-picker-row-${ghOwner}/billing-service`, undefined, {
+			timeout: 10_000,
+		}),
+	);
+	await user.click(screen.getByTestId('repo-picker-submit'));
+
+	await waitFor(() => expect(screen.queryByTestId('repo-picker-modal')).toBeNull(), {
+		timeout: 10_000,
+	});
+
+	const link = await screen.findByTestId('repo-link-billing-service', undefined, {
+		timeout: 10_000,
+	});
+	expect(link.textContent).toBe(`${ghOwner}/billing-service`);
+	await screen.findByText('Designated');
+	await screen.findByTestId('repo-locked-billing-service');
+	expect(screen.queryByTestId('repo-delete-billing-service')).toBeNull();
+});
+
+test('create-new flow creates the repo on GitHub and auto-designates it', async () => {
+	let projectSlug = '';
+	const { user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Flows Create Project' });
+			projectSlug = project.slug;
+			await seedGitHubOAuth();
+			await neutralizeRepoSideEffects(ws.team.id, project.id, 'fresh-service');
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/settings',
+		params: { projectId: projectSlug },
+	});
+
+	await openRepoPicker(user);
+
+	await user.click(screen.getByTestId('repo-picker-tab-create'));
+
+	const modal = screen.getByTestId('repo-picker-modal');
+	const nameInput = modal.querySelector('input[placeholder="my-new-service"]') as HTMLInputElement;
+	await user.type(nameInput, 'fresh-service');
+	await user.click(screen.getByTestId('repo-picker-submit'));
+
+	await waitFor(() => expect(screen.queryByTestId('repo-picker-modal')).toBeNull(), {
+		timeout: 10_000,
+	});
+
+	const link = await screen.findByTestId('repo-link-fresh-service', undefined, {
+		timeout: 10_000,
+	});
+	expect(link.textContent).toBe(`${ghOwner}/fresh-service`);
+	await screen.findByText('Designated');
+	await screen.findByTestId('repo-locked-fresh-service');
+
+	// The repo really got created upstream, not just recorded locally.
+	expect(sim.state.repos.some((r) => r.full_name === `${ghOwner}/fresh-service`)).toBe(true);
+});
+
+test('designated repo shows a lock with no delete affordance; extras stay deletable', async () => {
+	let projectSlug = '';
+	const { user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Flows Lock Project' });
+			projectSlug = project.slug;
+			await seedGitHubOAuth();
+
+			const { db } = getTestContext();
+			const designated = await db.query<{ id: string }>(
+				`INSERT INTO repos (project_id, short_name, repo_identifier, host_type)
+				 VALUES ($1, 'main-repo', $2, 'github') RETURNING id`,
+				[project.id, `${ghOwner}/main-repo`],
+			);
+			await db.query(
+				`INSERT INTO repos (project_id, short_name, repo_identifier, host_type)
+				 VALUES ($1, 'extra-repo', $2, 'github')`,
+				[project.id, `${ghOwner}/extra-repo`],
+			);
+			await db.query('UPDATE projects SET designated_repo_id = $1 WHERE id = $2', [
+				designated.rows[0].id,
+				project.id,
+			]);
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/settings',
+		params: { projectId: projectSlug },
+	});
+
+	await screen.findByTestId('repo-locked-main-repo', undefined, { timeout: 15_000 });
+	await screen.findByText('Designated');
+	expect(screen.queryByTestId('repo-delete-main-repo')).toBeNull();
+
+	await user.click(await screen.findByTestId('repo-delete-extra-repo'));
+	await waitFor(() => expect(screen.queryByText(`${ghOwner}/extra-repo`)).toBeNull(), {
+		timeout: 10_000,
+	});
+
+	// The designated repo survives, still locked.
+	screen.getByTestId('repo-locked-main-repo');
+	expect(screen.queryByTestId('repo-delete-main-repo')).toBeNull();
+});


### PR DESCRIPTION
## Summary

Phase 13 (Designated Repo Setup via OAuth) was feature-complete but missing the wizard-flow test coverage its spec called for. This PR adds that coverage, fixes the harness issues it surfaced, and flips the phase to **Done (2026-06-11)**.

### New coverage

- **`packages/web/test/repo-picker-flows.test.tsx`** — component-tier wizard flows against the GitHub simulator:
  - **Link existing**: picks a repo from the owner's list, links it, first repo auto-designates (Designated badge + lock, no delete affordance)
  - **Create new**: creates the repo upstream (asserted on the simulator's state, not just the local DB) and auto-designates it
  - **Designated lock**: designated repo shows lock with no delete button; a second repo stays deletable through the UI
- **`packages/server/test/repos-create-github.test.ts`** — success-path lifecycle: `mode=create` → 201 + auto-designation + repo created on the sim; `mode=link` adds a second repo without re-designating; `DELETE` on the designated repo → **409 `DESIGNATED_REPO_IMMUTABLE`** (previously untested anywhere); `DELETE` on a non-designated repo still works.

Component tier per the decision tree — the wizard is pure form/dialog/mutation behavior, no real layout/viewport/WebSocket dependency.

### Source / harness changes

- `github-section.tsx`: `aria-label` + `data-testid` on the repo delete button (was an unlabeled icon button)
- `render.tsx`: expose `dataDir` so specs can emulate an existing clone (`workspace/<short_name>/.git`), letting repo-sync skip the real SSH clone and keeping the success path quiet; fetch wrapper now closes over the captured fetch so late in-flight requests don't throw `realFetch is not a function` after teardown
- `setup.ts`: backfill `localStorage` on Node ≥ 22, where Node's experimental global (undefined without `--localstorage-file`) shadows happy-dom's and broke every web component test at import time
- `.dev/implementation-phases.md`: Phase 13 → Done; test bullet updated to describe the shipped coverage

## Test plan

- [x] `bun run test --skip-browser` — server 1761 passed, Bun-native passed, web 290 passed (exit 0)
- [x] New specs run with a quiet log (no spurious `[error]`/`[warn]`)
- [x] `bun run typecheck` / `bun run check` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)