### PR TITLE
fix(containers): surface provisioning banner for rebuilds outside the rebuild route

### DIFF
--- a/packages/server/src/services/containers.ts
+++ b/packages/server/src/services/containers.ts
@@ -214,6 +214,9 @@ export async function provisionContainer(
 		ContainerStatus.Creating,
 		project.id,
 	]);
+	// Broadcast the creating transition so the web banner shows for provisions that
+	// don't go through the rebuild route (startup repair, self-heal, reprovision).
+	await broadcastProjectUpdate(db, wsManager, teamId, project.id);
 
 	beginProvisionStream(logs, project.id);
 	const streamId = provisionStreamId(project.id);

--- a/packages/server/test/container-sync.test.ts
+++ b/packages/server/test/container-sync.test.ts
@@ -756,14 +756,14 @@ describe('provisionContainer broadcasting', () => {
 		);
 	});
 
-	it('broadcasts row_change on successful provisioning', async () => {
+	it('broadcasts creating then running row_changes on successful provisioning', async () => {
 		const dataDir = mkdtempSync(join(tmpdir(), 'hezo-test-'));
-		const mockDocker = {
+		const mockDocker = createStubDocker({
 			imageExists: vi.fn().mockResolvedValue(false),
 			pullImage: vi.fn().mockResolvedValue(undefined),
 			createContainer: vi.fn().mockResolvedValue({ Id: 'test-container-123' }),
 			startContainer: vi.fn().mockResolvedValue(undefined),
-		} as any;
+		});
 		const mockWsManager = { broadcast: vi.fn() } as any;
 
 		const project = (
@@ -776,8 +776,18 @@ describe('provisionContainer broadcasting', () => {
 			'container-sync-co',
 		);
 
-		expect(mockWsManager.broadcast).toHaveBeenCalledTimes(1);
-		const [room, event] = mockWsManager.broadcast.mock.calls[0];
+		// The creating broadcast must precede the docker work — it is what shows
+		// the provisioning banner for rebuilds launched outside the rebuild route
+		// (startup stale-mount repair, self-heal, missing-container reprovision).
+		expect(mockWsManager.broadcast).toHaveBeenCalledTimes(2);
+		const [creatingRoom, creatingEvent] = mockWsManager.broadcast.mock.calls[0];
+		expect(creatingRoom).toBe(wsRoom.team(teamId));
+		expect(creatingEvent.type).toBe('row_change');
+		expect(creatingEvent.table).toBe('projects');
+		expect(creatingEvent.action).toBe('UPDATE');
+		expect(creatingEvent.row.container_status).toBe('creating');
+
+		const [room, event] = mockWsManager.broadcast.mock.calls[1];
 		expect(room).toBe(wsRoom.team(teamId));
 		expect(event.type).toBe('row_change');
 		expect(event.table).toBe('projects');
@@ -900,10 +910,10 @@ describe('provisionContainer broadcasting', () => {
 		);
 
 		const dataDir = mkdtempSync(join(tmpdir(), 'hezo-test-'));
-		const mockDocker = {
+		const mockDocker = createStubDocker({
 			imageExists: vi.fn().mockResolvedValue(false),
 			pullImage: vi.fn().mockRejectedValue(new Error('Image not found')),
-		} as any;
+		});
 		const mockWsManager = { broadcast: vi.fn() } as any;
 
 		const project = (
@@ -918,8 +928,9 @@ describe('provisionContainer broadcasting', () => {
 			),
 		).rejects.toThrow('Image not found');
 
-		expect(mockWsManager.broadcast).toHaveBeenCalledTimes(1);
-		const [room, event] = mockWsManager.broadcast.mock.calls[0];
+		expect(mockWsManager.broadcast).toHaveBeenCalledTimes(2);
+		expect(mockWsManager.broadcast.mock.calls[0][1].row.container_status).toBe('creating');
+		const [room, event] = mockWsManager.broadcast.mock.calls[1];
 		expect(room).toBe(wsRoom.team(teamId));
 		expect(event.type).toBe('row_change');
 		expect(event.table).toBe('projects');

--- a/packages/web/src/hooks/use-websocket.ts
+++ b/packages/web/src/hooks/use-websocket.ts
@@ -1,7 +1,7 @@
 import { WsMessageType, type WsRowChangeMessage, wsRoom } from '@hezo/shared';
 import type { QueryClient, QueryKey } from '@tanstack/react-query';
 import { useQueryClient } from '@tanstack/react-query';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useSocket } from '../contexts/socket-context';
 import { invalidateTeamAgentCaches } from '../lib/invalidate-team-caches';
 import { queryKeys } from '../lib/query-keys';
@@ -111,6 +111,26 @@ interface TeamRoom {
 }
 
 /**
+ * Refetch everything after a WebSocket drop heals. Row-change events emitted
+ * while the socket was down (e.g. a dev-server restart kicking off container
+ * rebuilds at boot) are lost — there is no replay — so the only way to catch
+ * up is a full invalidation once the connection is back. The initial connect
+ * is skipped: queries are freshly fetched on mount anyway.
+ */
+export function useInvalidateOnReconnect(connected: boolean): void {
+	const queryClient = useQueryClient();
+	const hadConnected = useRef(false);
+
+	useEffect(() => {
+		if (!connected) return;
+		if (hadConnected.current) {
+			queryClient.invalidateQueries();
+		}
+		hadConnected.current = true;
+	}, [connected, queryClient]);
+}
+
+/**
  * Subscribe to all team rooms so global UI (inbox badge, home) updates without a
  * full page refresh. Row-change events carry team/project UUIDs; we translate
  * them to the relevant project slug (the row's own project, or the team's
@@ -119,7 +139,9 @@ interface TeamRoom {
  */
 export function useShellWebSockets(teams: TeamRoom[] | undefined): void {
 	const queryClient = useQueryClient();
-	const { joinRoom, leaveRoom, subscribe } = useSocket();
+	const { connected, joinRoom, leaveRoom, subscribe } = useSocket();
+
+	useInvalidateOnReconnect(connected);
 
 	const teamsKey =
 		teams

--- a/packages/web/test/ws-reconnect-invalidate.test.tsx
+++ b/packages/web/test/ws-reconnect-invalidate.test.tsx
@@ -1,0 +1,41 @@
+// Covers the reconnect-invalidation hook: row-change events emitted while the
+// WebSocket was down are lost (no replay), so the shell must refetch everything
+// once the connection heals — and must NOT refetch on the initial connect.
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render } from '@testing-library/react';
+import { expect, test, vi } from 'vitest';
+import { useInvalidateOnReconnect } from '../src/hooks/use-websocket';
+
+function Probe({ connected }: { connected: boolean }) {
+	useInvalidateOnReconnect(connected);
+	return null;
+}
+
+test('invalidates all queries on reconnect but not on the initial connect', () => {
+	const queryClient = new QueryClient();
+	const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+
+	const ui = (connected: boolean) => (
+		<QueryClientProvider client={queryClient}>
+			<Probe connected={connected} />
+		</QueryClientProvider>
+	);
+
+	// Mounts disconnected — the socket dials asynchronously.
+	const { rerender } = render(ui(false));
+	expect(invalidate).not.toHaveBeenCalled();
+
+	// Initial connect: queries are freshly fetched on mount, so no invalidation.
+	rerender(ui(true));
+	expect(invalidate).not.toHaveBeenCalled();
+
+	// Server restart: the socket drops and heals — everything refetches.
+	rerender(ui(false));
+	rerender(ui(true));
+	expect(invalidate).toHaveBeenCalledTimes(1);
+
+	// Each subsequent drop/heal cycle refetches again.
+	rerender(ui(false));
+	rerender(ui(true));
+	expect(invalidate).toHaveBeenCalledTimes(2);
+});


### PR DESCRIPTION
## Problem

Restarting the dev server makes the job-manager reprovision containers (stale-mount repair, self-heal, missing-container reprovision), but the "Provisioning …'s container" banner never appears on the project page even though the container spends ~10s in `creating`.

Two independent gaps:

1. **`provisionContainer` never broadcast the `creating` transition.** It wrote `container_status = 'creating'` to the DB but only called `broadcastProjectUpdate` on the terminal states (`running` / `error`). The only `creating` broadcast in the system lived in the manual rebuild route (`POST /projects/:projectId/container/rebuild`), which is why the banner worked for the UI's Restart button but not for any job-manager-initiated provision. The browser's cached `['projects']` index kept saying `running` for the whole rebuild window; the eventual `running` broadcast refetched into `running` again — visually nothing.

2. **Nothing invalidated React Query caches on WebSocket reconnect.** A dev restart drops the socket at exactly the moment the first rebuild starts (the startup scan runs at boot). `WebSocketClient.onopen` only re-subscribed rooms, so row changes emitted before the client reconnected were lost with no replay, and the stale cache persisted until a window-refocus refetch.

Both fixes are needed: the broadcast alone misses the boot-instant rebuild (sent before the client reconnects); the reconnect invalidation alone misses rebuilds that start *after* reconnect (the DB still said `running` at reconnect time).

## Changes

- `packages/server/src/services/containers.ts` — broadcast the `creating` row change right after writing it, so every provision entry point (startup repair, self-heal, reprovision, project creation) shows the banner. The rebuild route's existing pre-broadcast becomes a harmless near-duplicate.
- `packages/web/src/hooks/use-websocket.ts` — new `useInvalidateOnReconnect` hook wired into `useShellWebSockets`: on a drop→heal transition, invalidate all queries (WS reconnect implies the API is reachable). The initial connect is skipped since mount fetches fresh.

## Tests

- Updated `packages/server/test/container-sync.test.ts` provisioning-broadcast tests to assert the new sequence: `creating` → `running` on success, `creating` → `error` on failure (and converted their inline docker mocks to `createStubDocker`).
- New `packages/web/test/ws-reconnect-invalidate.test.tsx` covering no-invalidate-on-initial-connect and invalidate-per-reconnect.

`bun run test --skip-browser`: server 1744 passed, web 285 passed, bun-native tier passed. The 7 failures in `git.test.ts` / `ssh-agent-server.test.ts` are pre-existing in this sandbox (fail identically on the base commit; git worktree + ssh-keygen operations).

https://claude.ai/code/session_01N1ExpWZJPN5aSCFuxZU23X

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1ExpWZJPN5aSCFuxZU23X)_