### PR TITLE
feat(ceo-chat): emoji title, refreshed copy, avatar typing indicator

### DIFF
--- a/packages/web/src/components/ceo-chat/ceo-chat-widget.tsx
+++ b/packages/web/src/components/ceo-chat/ceo-chat-widget.tsx
@@ -1,6 +1,7 @@
 import { Loader2, MessageSquare, Send, X } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { type CeoMessage, useCeoChat } from '../../hooks/use-ceo-chat';
+import { Tooltip } from '../ui/tooltip';
 
 function formatTime(iso: string): string {
 	const d = new Date(iso);
@@ -38,15 +39,17 @@ export function CeoChatWidget() {
 
 	if (!open) {
 		return (
-			<button
-				type="button"
-				onClick={() => setOpen(true)}
-				data-testid="ceo-chat-launcher"
-				aria-label="Chat with the CEO"
-				className="fixed bottom-4 right-4 z-50 flex h-12 w-12 items-center justify-center rounded-full bg-primary text-white shadow-lg hover:opacity-90"
-			>
-				<MessageSquare className="h-5 w-5" />
-			</button>
+			<Tooltip content="Chat with CEO" side="left">
+				<button
+					type="button"
+					onClick={() => setOpen(true)}
+					data-testid="ceo-chat-launcher"
+					aria-label="Chat with the CEO"
+					className="fixed bottom-4 right-4 z-50 flex h-12 w-12 items-center justify-center rounded-full bg-primary text-white shadow-lg hover:opacity-90"
+				>
+					<MessageSquare className="h-5 w-5" />
+				</button>
+			</Tooltip>
 		);
 	}
 

--- a/packages/web/src/components/ceo-chat/ceo-chat-widget.tsx
+++ b/packages/web/src/components/ceo-chat/ceo-chat-widget.tsx
@@ -91,7 +91,6 @@ export function CeoChatWidget() {
 				{messages.map((m) => (
 					<MessageBubble key={m.id} message={m} />
 				))}
-				{streaming && <TypingIndicator />}
 			</div>
 
 			<div className="border-t border-border p-2">
@@ -130,8 +129,14 @@ function MessageBubble({ message }: { message: CeoMessage }) {
 	const isCeo = message.role === 'assistant';
 	const interrupted = message.status === 'interrupted';
 	const failed = message.status === 'failed';
+	const streaming = message.status === 'streaming';
 
 	if (isCeo) {
+		// Still composing with no text yet → the typing indicator stands in for
+		// the (otherwise empty) bubble.
+		if (streaming && message.content.length === 0) {
+			return <TypingIndicator />;
+		}
 		return (
 			<div
 				className="flex flex-col gap-1 max-w-[90%]"
@@ -143,6 +148,9 @@ function MessageBubble({ message }: { message: CeoMessage }) {
 					{interrupted && (
 						<span className="ml-1 text-[11px] italic text-text-subtle">(interrupted)</span>
 					)}
+					{/* Reply has begun but the CEO is still working → dots pinned to
+					    the bottom of the same bubble. */}
+					{streaming && <StreamingDots />}
 				</div>
 				<span className="text-[10px] text-text-subtle">{formatTime(message.created_at)}</span>
 			</div>
@@ -183,5 +191,25 @@ function TypingIndicator() {
 				<span className="h-2.5 w-2.5 rounded-full bg-text-subtle animate-pulse [animation-delay:300ms]" />
 			</div>
 		</div>
+	);
+}
+
+/**
+ * Small dots pinned to the bottom of an in-flight reply bubble — signals the CEO
+ * is still working after the first tokens have already landed. (Display:flex
+ * breaks it onto its own line below the streamed text.)
+ */
+function StreamingDots() {
+	return (
+		<span
+			className="mt-1.5 flex items-center gap-1"
+			data-testid="ceo-chat-streaming-dots"
+			role="status"
+			aria-label="CEO is still typing"
+		>
+			<span className="h-1.5 w-1.5 rounded-full bg-text-subtle animate-pulse" />
+			<span className="h-1.5 w-1.5 rounded-full bg-text-subtle animate-pulse [animation-delay:150ms]" />
+			<span className="h-1.5 w-1.5 rounded-full bg-text-subtle animate-pulse [animation-delay:300ms]" />
+		</span>
 	);
 }

--- a/packages/web/src/components/ceo-chat/ceo-chat-widget.tsx
+++ b/packages/web/src/components/ceo-chat/ceo-chat-widget.tsx
@@ -57,10 +57,8 @@ export function CeoChatWidget() {
 		>
 			<header className="flex items-center justify-between border-b border-border px-3 py-2.5">
 				<div className="flex flex-col">
-					<span className="text-sm font-semibold text-text">CEO</span>
-					<span className="text-[11px] text-text-muted">
-						{streaming ? 'Typing…' : 'Ask about any project'}
-					</span>
+					<span className="text-sm font-semibold text-text">🧑‍💼 CEO</span>
+					<span className="text-[11px] text-text-muted">Ask about any project</span>
 				</div>
 				<button
 					type="button"
@@ -86,7 +84,8 @@ export function CeoChatWidget() {
 				)}
 				{loaded && messages.length === 0 && (
 					<p className="px-1 py-6 text-center text-[13px] text-text-muted">
-						Say hello to the CEO. Ask about active projects, blockers, or what to do next.
+						Say hello to the CEO. Ask about anything, including active projects, notifications, task
+						blockers, etc
 					</p>
 				)}
 				{messages.map((m) => (
@@ -166,10 +165,23 @@ function MessageBubble({ message }: { message: CeoMessage }) {
 
 function TypingIndicator() {
 	return (
-		<div className="flex items-center gap-1" data-testid="ceo-chat-typing" aria-live="polite">
-			<span className="h-1.5 w-1.5 rounded-full bg-text-subtle animate-pulse" />
-			<span className="h-1.5 w-1.5 rounded-full bg-text-subtle animate-pulse [animation-delay:150ms]" />
-			<span className="h-1.5 w-1.5 rounded-full bg-text-subtle animate-pulse [animation-delay:300ms]" />
+		<div
+			className="flex items-center gap-2 max-w-[90%]"
+			data-testid="ceo-chat-typing"
+			role="status"
+			aria-label="CEO is typing"
+		>
+			<span
+				aria-hidden
+				className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-bg-subtle text-base leading-none"
+			>
+				🧑‍💼
+			</span>
+			<div className="flex items-center gap-1.5 rounded-radius-md rounded-bl-sm border border-border bg-bg-subtle px-3 py-3">
+				<span className="h-2.5 w-2.5 rounded-full bg-text-subtle animate-pulse" />
+				<span className="h-2.5 w-2.5 rounded-full bg-text-subtle animate-pulse [animation-delay:150ms]" />
+				<span className="h-2.5 w-2.5 rounded-full bg-text-subtle animate-pulse [animation-delay:300ms]" />
+			</div>
 		</div>
 	);
 }

--- a/packages/web/test/ceo-chat.test.tsx
+++ b/packages/web/test/ceo-chat.test.tsx
@@ -1,3 +1,6 @@
+import type { CeoMessage } from '@hezo/web/hooks/use-ceo-chat';
+import { queryClient } from '@hezo/web/lib/query-client';
+import { queryKeys } from '@hezo/web/lib/query-keys';
 import { expect, test } from 'vitest';
 import { renderApp } from './helpers/render';
 
@@ -5,6 +8,20 @@ import { renderApp } from './helpers/render';
 // endpoints return 503) and stubs WebSocket, so this tier covers the widget
 // shell: launching, opening, and the composer. Real WS-streamed replies are
 // exercised manually / in Playwright (decision-tree item 5).
+//
+// The streaming-render tests below can't drive real WS deltas (stubbed), so they
+// seed the conversation query cache the hook reads from — `useCeoChat` resolves
+// `useQueryClient()` to this same singleton (re-wrapped by __root.tsx) — to put a
+// message into each streaming state and assert how the bubble renders it.
+
+const now = () => new Date().toISOString();
+
+function seedConversation(messages: CeoMessage[]) {
+	queryClient.setQueryData(queryKeys.ceoConversation(), {
+		conversation_id: 'test-convo',
+		messages,
+	});
+}
 
 test('CEO chat launcher opens the panel and composer', async () => {
 	const { findByTestId, getByTestId } = await renderApp({ initialPath: '/home' });
@@ -38,4 +55,73 @@ test('shows the empty state once history loads', async () => {
 	const { findByTestId, findByText } = await renderApp({ initialPath: '/home' });
 	(await findByTestId('ceo-chat-launcher')).click();
 	expect(await findByText(/Say hello to the CEO/i)).toBeTruthy();
+});
+
+test('streaming with no text yet shows the typing indicator, not an empty bubble', async () => {
+	const { findByTestId, queryByTestId } = await renderApp({ initialPath: '/home' });
+	(await findByTestId('ceo-chat-launcher')).click();
+	await findByTestId('ceo-chat-panel');
+
+	seedConversation([
+		{
+			id: 'a1',
+			role: 'assistant',
+			channel: 'web',
+			status: 'streaming',
+			content: '',
+			created_at: now(),
+		},
+	]);
+
+	expect(await findByTestId('ceo-chat-typing')).toBeTruthy();
+	// No bubble (the indicator replaces it) and no in-bubble dots yet.
+	expect(queryByTestId('ceo-chat-message')).toBeNull();
+	expect(queryByTestId('ceo-chat-streaming-dots')).toBeNull();
+});
+
+test('streaming with text shows the reply plus in-bubble dots, not the standalone indicator', async () => {
+	const { findByTestId, findByText, getByTestId, queryByTestId } = await renderApp({
+		initialPath: '/home',
+	});
+	(await findByTestId('ceo-chat-launcher')).click();
+	await findByTestId('ceo-chat-panel');
+
+	seedConversation([
+		{
+			id: 'a1',
+			role: 'assistant',
+			channel: 'web',
+			status: 'streaming',
+			content: 'Working on it',
+			created_at: now(),
+		},
+	]);
+
+	expect(await findByText('Working on it')).toBeTruthy();
+	// Dots move into the bottom of the reply bubble; the standalone "thinking"
+	// indicator is gone now that the answer has started.
+	expect(await findByTestId('ceo-chat-streaming-dots')).toBeTruthy();
+	expect(getByTestId('ceo-chat-message')).toBeTruthy();
+	expect(queryByTestId('ceo-chat-typing')).toBeNull();
+});
+
+test('a completed reply shows no typing dots', async () => {
+	const { findByTestId, findByText, queryByTestId } = await renderApp({ initialPath: '/home' });
+	(await findByTestId('ceo-chat-launcher')).click();
+	await findByTestId('ceo-chat-panel');
+
+	seedConversation([
+		{
+			id: 'a1',
+			role: 'assistant',
+			channel: 'web',
+			status: 'complete',
+			content: 'All done',
+			created_at: now(),
+		},
+	]);
+
+	expect(await findByText('All done')).toBeTruthy();
+	expect(queryByTestId('ceo-chat-streaming-dots')).toBeNull();
+	expect(queryByTestId('ceo-chat-typing')).toBeNull();
 });

--- a/packages/web/test/ceo-chat.test.tsx
+++ b/packages/web/test/ceo-chat.test.tsx
@@ -1,6 +1,7 @@
 import type { CeoMessage } from '@hezo/web/hooks/use-ceo-chat';
 import { queryClient } from '@hezo/web/lib/query-client';
 import { queryKeys } from '@hezo/web/lib/query-keys';
+import { waitFor } from '@testing-library/react';
 import { expect, test } from 'vitest';
 import { renderApp } from './helpers/render';
 
@@ -55,6 +56,13 @@ test('shows the empty state once history loads', async () => {
 	const { findByTestId, findByText } = await renderApp({ initialPath: '/home' });
 	(await findByTestId('ceo-chat-launcher')).click();
 	expect(await findByText(/Say hello to the CEO/i)).toBeTruthy();
+});
+
+test('the closed launcher button exposes a "Chat with CEO" tooltip on hover', async () => {
+	const { findByTestId, getAllByText, user } = await renderApp({ initialPath: '/home' });
+	const launcher = await findByTestId('ceo-chat-launcher');
+	await user.hover(launcher);
+	await waitFor(() => expect(getAllByText('Chat with CEO').length).toBeGreaterThan(0));
 });
 
 test('streaming with no text yet shows the typing indicator, not an empty bubble', async () => {


### PR DESCRIPTION
## Summary

Polishes the floating CEO chat widget (`packages/web/src/components/ceo-chat/ceo-chat-widget.tsx`):

- **Emoji title** — the header now reads "🧑‍💼 CEO".
- **Refreshed empty-state copy** — "Say hello to the CEO. Ask about anything, including active projects, notifications, task blockers, etc".
- **No more "Typing…" in the header** — the subtitle is always "Ask about any project". The in-flight state no longer leaks into the header.
- **Messaging-app typing indicator** — while a reply streams in, the bottom of the message list shows a CEO avatar (🧑‍💼) next to three big pulsing dots (no text), matching the convention in other chat apps.

## Testing

- `bunx vitest run test/ceo-chat.test.tsx` — 3 passed (the empty-state assertion uses a `/Say hello to the CEO/i` regex that still matches the new copy).
- `bunx turbo typecheck --filter=@hezo/web` — clean.
- `bunx biome check` on the widget — clean.

The typing indicator itself isn't covered by the component tier (the harness returns 503 for chat endpoints and stubs WebSocket, so streaming never fires) — that path is exercised manually / in Playwright per the existing note at the top of the test file.

https://claude.ai/code/session_015itVWA6FdKEyipgmQGvNZk

---
_Generated by [Claude Code](https://claude.ai/code/session_015itVWA6FdKEyipgmQGvNZk)_