### PR TITLE
fix(ceo): give the CEO cross-team visibility over every project

### DIFF
--- a/agents/_instance/ceo.md
+++ b/agents/_instance/ceo.md
@@ -2,7 +2,9 @@
 
 You are the CEO of this Hezo instance — the single executive overseeing every project-team.
 
-You report to the human admin (the operators). The instance is organised as **one team per project**: each project has its own dedicated team led by its own Captain, and every Captain reports to you. You set cross-project direction, coordinate priorities across projects, and act as the escalation point above the Captains. You do not implement features or take over any team's day-to-day delivery — you lead through the Captains.
+You report to the human admin (the operators). Hezo is **project-centric**: this is a single organisation containing **many projects**, and each project is backed by its **own dedicated team** led by its own Captain, with every Captain reporting to you. You set cross-project direction, coordinate priorities across projects, and act as the escalation point above the Captains. You do not implement features or take over any team's day-to-day delivery — you lead through the Captains.
+
+You have **automatic cross-team reach**. Your tools and context already span every project and team in the org: `list_teams` returns the whole roster (not just HQ), `list_projects` with no `team_id` returns every project across the org, and the live project roster below is rebuilt into your context each turn. You can read and act inside any project without being granted per-team access. Never tell the operator a project or team doesn't exist from stale memory — check the roster below (or call the tools) first.
 
 You live in **HQ**, the instance-level coordination project. You are the only agent who works across projects: most of your tickets live either in HQ (instance-wide and pre-project work) or inside a specific project-team's project (its setup and roster work), and you action each one wherever it lives.
 
@@ -17,6 +19,8 @@ You live in **HQ**, the instance-level coordination project. You are the only ag
 ## Helping the operator directly
 
 Beyond coordination tickets, the operator talks to you directly — in a live chat box, or by opening a ticket in HQ addressed to you. Treat both the same: work out what they are trying to achieve and route it to the right level of work. Your job here is to figure out the best way to solve the operator's problem and make the call between answering in place, opening a trackable ticket, and standing up a project.
+
+In the live chat box you are talking to a human, so write for a human: refer to projects, tickets, and teams by their **slug, identifier, or name** (e.g. the project `todo6`, ticket `TO-1`, team `todo6`) — never paste raw UUIDs. UUIDs are for tool arguments only; the person reading the chat thinks in names.
 
 - **General questions** — answer directly, in place. No ticket needed for a quick answer or explanation.
 - **Anything about an existing project** — work *through that project* and its Captain. Read and act across the project as needed; for anything substantial, open (or have the Captain open) a ticket in that project so the work is tracked, rather than doing it all inline.
@@ -64,5 +68,7 @@ Current date: {{current_date}}
 {{team_preferences_context}}
 
 {{project_docs_context}}
+
+{{projects_context}}
 
 {{requester_context}}

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -352,9 +352,15 @@ export function registerTools(
 	tool(
 		server,
 		'list_teams',
-		'List teams accessible to the caller',
+		'List teams accessible to the caller. The instance CEO (cross-team session) gets every team in the instance; other agents get only their own team.',
 		{},
 		async (_args, db, auth) => {
+			// The instance CEO chat session acts across every team (cross-team gated
+			// at mint time), so it discovers the whole roster — not just HQ.
+			if (auth.type === AuthType.Agent && auth.crossTeam) {
+				const r = await db.query('SELECT * FROM teams ORDER BY name');
+				return r.rows;
+			}
 			if (auth.type === AuthType.ApiKey || auth.type === AuthType.Agent) {
 				const r = await db.query('SELECT * FROM teams WHERE id = $1', [auth.teamId]);
 				return r.rows;
@@ -1208,9 +1214,14 @@ export function registerTools(
 	tool(
 		server,
 		'list_projects',
-		'List projects for a team. Pass excerpt_chars (e.g. 300) to truncate description; omit for full content.',
+		'List projects. Omit team_id to list every project across all teams in the instance (CEO cross-team access only) — each row carries team_name/team_slug. Pass team_id to scope to one team. Pass excerpt_chars (e.g. 300) to truncate description; omit for full content.',
 		{
-			team_id: z.string().describe('Team ID'),
+			team_id: z
+				.string()
+				.optional()
+				.describe(
+					'Team ID. Omit to list every project across all teams (CEO cross-team access only).',
+				),
 			excerpt_chars: z
 				.number()
 				.int()
@@ -1219,20 +1230,41 @@ export function registerTools(
 				.describe('When set, truncates description and adds description_truncated/_length'),
 		},
 		async (args, db, auth) => {
-			const denied = await verifyTeamAccess(db, auth, args.team_id as string);
-			if (denied) return { error: denied };
-			const scoped = auth.type === AuthType.Agent && !auth.crossProject;
-			const r = await db.query<Record<string, unknown>>(
-				scoped
-					? `SELECT id, team_id, name, slug, task_prefix, description, created_at, updated_at
-					 FROM projects WHERE team_id = $1 AND id = $2`
-					: `SELECT id, team_id, name, slug, task_prefix, description, created_at, updated_at
-					 FROM projects WHERE team_id = $1 ORDER BY name`,
-				scoped ? [args.team_id, auth.projectId] : [args.team_id],
-			);
 			const max = args.excerpt_chars as number | undefined;
-			if (max == null) return r.rows;
-			return r.rows.map((row) => applyExcerpt(row, 'description', max));
+			const withExcerpt = (rows: Record<string, unknown>[]) =>
+				max == null ? rows : rows.map((row) => applyExcerpt(row, 'description', max));
+			const teamId = args.team_id as string | undefined;
+
+			if (teamId) {
+				const denied = await verifyTeamAccess(db, auth, teamId);
+				if (denied) return { error: denied };
+				const scoped = auth.type === AuthType.Agent && !auth.crossProject;
+				const r = await db.query<Record<string, unknown>>(
+					scoped
+						? `SELECT id, team_id, name, slug, task_prefix, description, is_internal, created_at, updated_at
+						 FROM projects WHERE team_id = $1 AND id = $2`
+						: `SELECT id, team_id, name, slug, task_prefix, description, is_internal, created_at, updated_at
+						 FROM projects WHERE team_id = $1 ORDER BY name`,
+					scoped ? [teamId, auth.projectId] : [teamId],
+				);
+				return withExcerpt(r.rows);
+			}
+
+			// No team_id → instance-wide listing across every team. Restricted to
+			// principals with cross-team reach (the CEO session) or a superuser admin;
+			// a project-scoped agent must name its team.
+			const instanceWide =
+				(auth.type === AuthType.Agent && auth.crossTeam) ||
+				(auth.type === AuthType.Admin && auth.isSuperuser);
+			if (!instanceWide) return { error: 'team_id is required' };
+			const r = await db.query<Record<string, unknown>>(
+				`SELECT p.id, p.team_id, t.name AS team_name, t.slug AS team_slug,
+				        p.name, p.slug, p.task_prefix, p.description, p.is_internal,
+				        p.created_at, p.updated_at
+				 FROM projects p JOIN teams t ON t.id = p.team_id
+				 ORDER BY t.name, p.name`,
+			);
+			return withExcerpt(r.rows);
 		},
 		db,
 	);

--- a/packages/server/src/services/ceo-session-manager.ts
+++ b/packages/server/src/services/ceo-session-manager.ts
@@ -49,7 +49,9 @@ const HEALTH_INTERVAL_MS = Number(process.env.HEZO_CEO_HEALTH_INTERVAL_MS ?? 10_
 
 const CHAT_GUIDE = `# Live Chat
 
-You are in a real-time chat with the operator — the human running this Hezo instance — through the web app. This is a conversation, not a task run: reply directly and conversationally as the CEO. You have your MCP tools available and may read from and act across every project (you hold cross-team privileges here). Use them whenever the operator asks about state or wants something changed, then summarize what you did. Keep replies focused and skip ceremony.`;
+You are in a real-time chat with the operator — the human running this Hezo instance — through the web app. This is a conversation, not a task run: reply directly and conversationally as the CEO. You hold cross-team privileges here, so you can read from and act across every project and team in the org: \`list_teams\` returns every team (not just HQ), \`list_projects\` with no \`team_id\` returns every project across the org, and the project roster already in your context is rebuilt each turn. Lean on the roster first; reach for the tools when the operator asks about state or wants something changed, then summarize what you did.
+
+Because this chat is human-facing, refer to projects, tickets, and teams by their slug, identifier, or name (e.g. the project \`todo6\`, ticket \`TO-1\`) — never paste raw UUIDs, which are for tool arguments only. Keep replies focused and skip ceremony.`;
 
 export interface CeoSessionDeps extends RunnerDeps {
 	wsManager: WebSocketManager;

--- a/packages/server/src/services/template-resolver.ts
+++ b/packages/server/src/services/template-resolver.ts
@@ -211,6 +211,14 @@ export async function resolveSystemPrompt(
 		resolved = resolved.replace(/\{\{project_docs_context\}\}/g, docsText);
 	}
 
+	// Instance-wide project roster. Only the CEO's prompt carries this placeholder
+	// (it is the one agent with cross-team reach), so a worker prompt never leaks
+	// other teams' projects. Regenerated every turn, so the CEO answers "what
+	// projects do we have?" from live state instead of memory.
+	if (resolved.includes('{{projects_context}}')) {
+		resolved = resolved.replace(/\{\{projects_context\}\}/g, await buildProjectsContext(db));
+	}
+
 	resolved = resolved.replace(/\{\{requester_context\}\}/g, '');
 
 	if (ctx.mode === 'placeholders') {
@@ -371,6 +379,52 @@ function formatCreatedTicket(t: {
 }): string {
 	const assignee = t.assignee_name ?? 'unassigned';
 	return `- ${t.identifier} — ${t.title} (${t.status}, assigned to ${assignee})`;
+}
+
+/**
+ * Instance-wide roster of every project-team (HQ excluded). Resolved inline for
+ * the `{{projects_context}}` placeholder, which only the CEO's prompt carries.
+ * Uses slugs/names — never UUIDs — because this text is also what the CEO echoes
+ * back to the operator in the chat box.
+ */
+async function buildProjectsContext(db: PGlite): Promise<string> {
+	const terminal = terminalStatusParams(1, true);
+	const projects = await db.query<{
+		name: string;
+		slug: string;
+		task_prefix: string;
+		team_name: string;
+		team_slug: string;
+		open_task_count: number;
+		created_at: string;
+	}>(
+		`SELECT p.name, p.slug, p.task_prefix, t.name AS team_name, t.slug AS team_slug,
+		        (SELECT count(*) FROM tasks i
+		         WHERE i.project_id = p.id AND i.status NOT IN (${terminal.placeholders}))::int AS open_task_count,
+		        p.created_at
+		 FROM projects p
+		 JOIN teams t ON t.id = p.team_id
+		 WHERE p.is_internal = false
+		 ORDER BY p.created_at DESC`,
+		terminal.values,
+	);
+
+	const intro =
+		'Hezo is project-centric: one organisation containing many projects, each backed by its own dedicated team and Captain. As the instance CEO you have automatic cross-team reach over every one of them. The roster of project-teams below (HQ, your home, excluded) is regenerated every turn from the live database — trust it over memory, and never tell the operator a project does not exist without checking here first. When you name a project, ticket, or team in the chat box, use its slug, identifier, or name (e.g. the project `todo6`, ticket `TO-1`) — never a raw UUID. To act inside a project, pass its team to `list_tasks` / `list_agents`, or call `list_projects` with no `team_id` for this same live list.';
+
+	if (projects.rows.length === 0) {
+		return `${intro}\n\n_No project-teams exist yet beyond HQ. When the operator wants to start one, take it through project intake._`;
+	}
+
+	const lines = projects.rows
+		.map((p) => {
+			const date = new Date(p.created_at).toISOString().slice(0, 10);
+			const open = `${p.open_task_count} open ticket${p.open_task_count === 1 ? '' : 's'}`;
+			return `- ${p.name} (slug: ${p.slug}, prefix: ${p.task_prefix}) — team ${p.team_name} (slug: ${p.team_slug}), ${open}, created ${date}`;
+		})
+		.join('\n');
+
+	return `${intro}\n\n${lines}`;
 }
 
 function buildRunContextBlock(ctx: ResolveContext): string {

--- a/packages/server/test/mcp-project-scope.test.ts
+++ b/packages/server/test/mcp-project-scope.test.ts
@@ -1,8 +1,10 @@
 import type { PGlite } from '@electric-sql/pglite';
+import { DEFAULT_TEAM_ID } from '@hezo/shared';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { MasterKeyManager } from '../src/crypto/master-key';
 import type { Env } from '../src/lib/types';
+import { signCeoSessionJwt } from '../src/middleware/auth';
 import { safeClose } from './helpers';
 import { authHeader, createTestApp, createTestProject, mintAgentToken } from './helpers/app';
 
@@ -206,6 +208,81 @@ describe('MCP project scope — agent run scoped to its team`s project', () => {
 			task_id: taskInBId,
 		})) as { error: string };
 		expect(result.error).toMatch(/Access denied/);
+	});
+
+	it('list_projects without team_id is rejected for a project-scoped agent', async () => {
+		const result = (await callMcp(scopedToken, 'list_projects', {})) as { error: string };
+		expect(result.error).toMatch(/team_id is required/);
+	});
+});
+
+describe('MCP cross-team CEO — instance-wide discovery', () => {
+	let ceoToken: string;
+
+	beforeAll(async () => {
+		// Mint a persistent CEO chat-session principal (cross_team + cross_project),
+		// the same token the live chat box runs under.
+		const ceo = await db.query<{ id: string }>(
+			`SELECT m.id FROM members m JOIN member_agents ma ON ma.id = m.id
+			 WHERE ma.slug = 'ceo' AND m.team_id = $1`,
+			[DEFAULT_TEAM_ID],
+		);
+		const hqProject = await db.query<{ id: string }>(
+			`SELECT id FROM projects WHERE team_id = $1 AND is_internal = true`,
+			[DEFAULT_TEAM_ID],
+		);
+		const session = await db.query<{ id: string }>(
+			`INSERT INTO ceo_sessions (member_id, team_id, project_id, runtime_type, status)
+			 VALUES ($1, $2, $3, 'claude_code', 'running') RETURNING id`,
+			[ceo.rows[0].id, DEFAULT_TEAM_ID, hqProject.rows[0].id],
+		);
+		ceoToken = await signCeoSessionJwt(
+			masterKeyManager,
+			ceo.rows[0].id,
+			DEFAULT_TEAM_ID,
+			session.rows[0].id,
+			hqProject.rows[0].id,
+		);
+	});
+
+	it('list_teams returns every team in the instance, not just HQ', async () => {
+		const rows = (await callMcp(ceoToken, 'list_teams', {})) as Array<{ id: string }>;
+		const ids = rows.map((r) => r.id);
+		expect(ids).toContain(DEFAULT_TEAM_ID);
+		expect(ids).toContain(teamAId);
+		expect(ids).toContain(teamBId);
+	});
+
+	it('list_projects with no team_id returns every project across all teams, tagged with its team', async () => {
+		const rows = (await callMcp(ceoToken, 'list_projects', {})) as Array<{
+			id: string;
+			team_id: string;
+			team_slug: string;
+			is_internal: boolean;
+		}>;
+		const ids = rows.map((r) => r.id);
+		expect(ids).toContain(projectAId);
+		expect(ids).toContain(projectBId);
+		// HQ (the one internal project) is included so the CEO sees the whole picture.
+		expect(rows.some((r) => r.is_internal)).toBe(true);
+		// Every row carries its owning team so the CEO can drill in by team.
+		const a = rows.find((r) => r.id === projectAId);
+		expect(a?.team_id).toBe(teamAId);
+		expect(a?.team_slug).toBeTruthy();
+	});
+
+	it('list_projects still scopes to one team when team_id is given', async () => {
+		const rows = (await callMcp(ceoToken, 'list_projects', { team_id: teamBId })) as Array<{
+			id: string;
+		}>;
+		expect(rows.map((r) => r.id)).toEqual([projectBId]);
+	});
+
+	it('can list tasks in any team without being scoped to it', async () => {
+		const rows = (await callMcp(ceoToken, 'list_tasks', { team_id: teamBId })) as Array<{
+			id: string;
+		}>;
+		expect(rows.some((r) => r.id === taskInBId)).toBe(true);
 	});
 });
 

--- a/packages/server/test/template-resolver.test.ts
+++ b/packages/server/test/template-resolver.test.ts
@@ -1,4 +1,5 @@
 import type { PGlite } from '@electric-sql/pglite';
+import { DEFAULT_TEAM_ID } from '@hezo/shared';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Env } from '../src/lib/types';
@@ -913,5 +914,45 @@ describe('project state block', () => {
 			projectId: psProjectId,
 		});
 		expect(result).not.toContain('Tickets you created on prior runs');
+	});
+});
+
+describe('projects context block ({{projects_context}})', () => {
+	it('lists every non-internal project across teams by slug, never by UUID', async () => {
+		const result = await resolveSystemPrompt(db, 'Roster:\n{{projects_context}}', { teamId });
+		expect(result).toContain('Hezo is project-centric');
+
+		const proj = await db.query<{ slug: string }>('SELECT slug FROM projects WHERE id = $1', [
+			projectId,
+		]);
+		// The beforeAll project surfaces by slug, tagged with its owning team…
+		expect(result).toContain(`slug: ${proj.rows[0].slug}`);
+		expect(result).toContain('team Template Co');
+		// …and never by raw UUID, since this text is echoed to the human operator.
+		expect(result).not.toContain(projectId);
+
+		// HQ is the one internal project and must never appear as a roster row.
+		const hq = await db.query<{ slug: string }>(
+			'SELECT slug FROM projects WHERE is_internal = true LIMIT 1',
+		);
+		expect(result).not.toContain(`slug: ${hq.rows[0].slug}`);
+	});
+
+	it('shows an empty-state line when no project-teams exist beyond HQ', async () => {
+		// A fresh instance has only HQ (internal), so the roster is empty.
+		const fresh = await createTestApp();
+		try {
+			const result = await resolveSystemPrompt(fresh.db, '{{projects_context}}', {
+				teamId: DEFAULT_TEAM_ID,
+			});
+			expect(result).toContain('No project-teams exist yet beyond HQ');
+		} finally {
+			await safeClose(fresh.db);
+		}
+	});
+
+	it('does not inject the roster into prompts that omit the placeholder', async () => {
+		const result = await resolveSystemPrompt(db, 'No placeholder here', { teamId });
+		expect(result).not.toContain('Hezo is project-centric');
 	});
 });


### PR DESCRIPTION
## Problem

When the operator asked the CEO chat "what projects do I have?", the CEO insisted only **HQ** existed — even with a freshly created project (`todo6`) sitting in the UI. Two variants were observed: the CEO answering confidently from memory, and the CEO actually calling its tools and *still* seeing only HQ.

## Root cause

The CEO chat session principal carries `cross_team: true`, and `verifyTeamAccess` honors it — so the CEO **can** read any team it names. But its two **discovery** tools never let it find other teams:

- **`list_teams`** returned only `WHERE id = auth.teamId` (HQ) for Agent auth — it ignored `crossTeam` entirely.
- **`list_projects`** required a `team_id` and only listed within it; there was no instance-wide path. Even with cross-team access, the CEO couldn't enumerate without first knowing every team — which `list_teams` wouldn't give it.

So `list_teams → only HQ`, `list_projects → only HQ project`, and `todo6` was never discovered. On top of that, the CEO's prompt had **no instance-wide project roster**, so it had no proactive awareness either.

## Fix

- **`list_teams`** now honors `auth.crossTeam`: the CEO gets every team in the instance, not just HQ.
- **`list_projects`** — `team_id` is now optional. With no `team_id`, a cross-team CEO (or superuser admin) gets **every project across the org**, each row tagged with `team_name`/`team_slug`; a project-scoped agent must still name its team (returns `team_id is required` otherwise). Rows now also carry `is_internal` so HQ is distinguishable.
- **`{{projects_context}}` prompt roster** — a new placeholder, carried only by the CEO's prompt, injects the live list of every project-team (HQ excluded) into the system prompt. It's rebuilt **every turn** from the DB, so the CEO answers from current state instead of memory and never claims a project doesn't exist. Mirrors the existing "Project State" pattern, lifted to instance scope.
- **`ceo.md`** now emphasizes the **project-centric, one-org-many-projects** model and the CEO's **automatic cross-team reach**.
- **Human-facing chat** — the `CHAT_GUIDE`, `ceo.md`, and the roster block all instruct the CEO to refer to projects/tickets/teams by **slug / identifier / name** (e.g. the project `todo6`, ticket `TO-1`), never raw UUIDs (those are for tool arguments only).

## Tests

- `mcp-project-scope.test.ts`: a cross-team CEO session principal sees **every** team via `list_teams` and **every** project via `list_projects` (no `team_id`, each tagged with its team), can list tasks in any team, and still scopes correctly when a `team_id` is given. A project-scoped agent without a `team_id` is rejected.
- `template-resolver.test.ts`: `{{projects_context}}` lists projects across teams by slug (never UUID), excludes HQ, shows an empty-state line on a fresh instance, and is absent from prompts that omit the placeholder.

All affected server suites pass; `typecheck` and `check` are green.

> Pre-v1 note: existing instances pick up the `ceo.md`/placeholder changes on the next seed/reset (the agents bundle is rebuilt at commit time).


---
_Generated by [Claude Code](https://claude.ai/code/session_0193o8oDM8GCS8dfuDsBHKV8)_