### PR TITLE
fix(egress): heal cross-host route when one MITM server is registered under unrelated hosts

### DIFF
--- a/packages/server/src/services/egress/proxy.ts
+++ b/packages/server/src/services/egress/proxy.ts
@@ -385,9 +385,9 @@ function serverOwnsPort(entry: SslServerEntry): boolean {
  * After reconciliation a live cross-wildcard collision should be impossible.
  * If one is still observed, log it once per offending port with each entry's
  * server state, then heal: keep only the entries backed by the single verified
- * owner of the port (none, if ownership is ambiguous) so every other host
- * rebuilds a fresh server on its next tunnel instead of failing TLS for the
- * rest of the run.
+ * owner of the port — none if ownership is ambiguous, or if that one owner is
+ * itself registered across unrelated hosts — so every other host rebuilds a
+ * fresh server on its next tunnel instead of failing TLS for the rest of the run.
  */
 export function detectCrossHostCertRoute(
 	proxy: IProxy,
@@ -454,20 +454,30 @@ export function detectCrossHostCertRoute(
 			});
 		}
 
-		// Heal: the port has at most one true owner. Keep entries backed by
-		// that owner's server (plus its same-wildcard aliases); evict the
-		// rest. With no single unambiguous owner, evict everything on the
-		// port — each affected host re-mints a fresh server on its next
-		// tunnel, costing one extra TLS handshake instead of wrong-SAN
-		// failures for the rest of the run.
+		// Heal: keep only entries backed by the port's single verified owner
+		// (plus its same-wildcard aliases), and only while that owner serves one
+		// host family. Evict everything otherwise — ambiguous ownership, or one
+		// server registered across unrelated hosts. Each evicted host re-mints a
+		// fresh server on its next tunnel, costing one extra TLS handshake
+		// instead of wrong-SAN failures for the rest of the run.
 		const owningServers = new Set(
 			entries
 				.filter(({ entry }) => entry.server && serverOwnsPort(entry))
 				.map(({ entry }) => entry.server),
 		);
 		const keptServer = owningServers.size === 1 ? [...owningServers][0] : undefined;
-		const keptEntries =
+		const ownerEntries =
 			keptServer === undefined ? [] : entries.filter(({ entry }) => entry.server === keptServer);
+		// A single owning server registered under more than one wildcard form is itself the
+		// cross-host route (one leaf cert can't validly serve unrelated hosts). The library can
+		// register one sslServer object under unrelated hostnames, collapsing owningServers to
+		// size 1 — so the ambiguous-owner branch never fires. Keep nothing on the port; every
+		// host re-mints a correct single-host server on its next tunnel.
+		const ownerSpansUnrelatedHosts =
+			new Set(ownerEntries.map(({ host }) => wildcardForm(host))).size > 1;
+		const keptEntries = ownerSpansUnrelatedHosts ? [] : ownerEntries;
+		// keptWildcards must derive from the post-span-check keptEntries (not ownerEntries) so an
+		// alias on a poisoned port is evicted too — do not reorder these two lines.
 		const keptWildcards = new Set(keptEntries.map(({ host }) => wildcardForm(host)));
 		for (const { host, entry } of entries) {
 			const kept = entry.server

--- a/packages/server/test/egress-proxy.test.ts
+++ b/packages/server/test/egress-proxy.test.ts
@@ -435,6 +435,38 @@ describe('detectCrossHostCertRoute', () => {
 		expect(Object.keys(sslServers)).toEqual([]);
 	});
 
+	it('evicts both hosts when one shared server object is registered under unrelated hostnames', () => {
+		const logged = new Set<string>();
+		// The library's `hosts.forEach(h => sslServers[h] = sslServer)` can register ONE server
+		// object under unrelated hostnames. Both keys are the same object, so `owningServers`
+		// collapses to size 1 — the ambiguous-owner path can't fire. A single server spanning
+		// unrelated wildcards is itself the cross-host route. (Production: registry.npmjs.org and
+		// github.com both reported listening:true, addressPort:64283 — only possible if they share
+		// one live socket.)
+		const shared = live(64283);
+		const sslServers: Record<string, Entry> = {
+			'registry.npmjs.org': shared,
+			'github.com': shared,
+		};
+		detectCrossHostCertRoute(fakeProxy(sslServers), scope, 'run-1', logged);
+		expect(logged.has('64283')).toBe(true);
+		expect(Object.keys(sslServers)).toEqual([]);
+	});
+
+	it('evicts a legit wildcard pair only when an unrelated live server also claims the port', () => {
+		const logged = new Set<string>();
+		const wildcardOwner = live(5009); // serves *.example.com
+		const sslServers: Record<string, Entry> = {
+			'api.example.com': wildcardOwner,
+			'cdn.example.com': wildcardOwner, // same object, same wildcard (legit)
+			'registry.npmjs.org': live(5009), // unrelated live server on same port
+		};
+		detectCrossHostCertRoute(fakeProxy(sslServers), scope, 'run-1', logged);
+		expect(logged.has('5009')).toBe(true);
+		// Two distinct owners → ambiguous → evict all; each re-mints next tunnel.
+		expect(Object.keys(sslServers)).toEqual([]);
+	});
+
 	it('does not flag distinct hosts on distinct ports', () => {
 		const logged = new Set<string>();
 		detectCrossHostCertRoute(


### PR DESCRIPTION
## Problem

A live run logged the cross-host cert tripwire again:

```
[error] <egress-proxy> egress MITM server port serves unrelated hosts — cross-host cert risk
{"run":"researcher/TO-5 [...]","port":64283,
 "hosts":["registry.npmjs.org","github.com"],
 "entries":[{"host":"registry.npmjs.org","listening":true,"addressPort":64283},
            {"host":"github.com","listening":true,"addressPort":64283}]}
```

Prior fixes (#201, #202, `a343580`) added the `detectCrossHostCertRoute` reconciler, but this signature slips through it — the route is never repaired, so one host is served the other's leaf cert (a wrong-SAN TLS failure) for the **rest of the run**.

## Root cause

What's distinctive here: **both** entries report `listening: true` **and** `addressPort: 64283`.

- Port `64283` is outside the egress range `[20000, 29999]`, so it's the library's internal per-host TLS server port.
- Two *distinct* live sockets can't share one port, and the Bun-native test proves a cleanly-closed server reads `address() === null` / `listening === false`. So neither entry is a closed/recycled zombie.
- The only consistent explanation: **both host keys point at the same live server object.** `http-mitm-proxy`'s `hosts.forEach(h => self.sslServers[h] = sslServer)` can register one `sslServer` under unrelated hostnames (a nondeterministic concurrency artifact in its cert-mint path).

That collapses `owningServers` to **size 1**, so the healer treats it as a legitimate single owner and **keeps both entries** instead of evicting them. The existing unit test only covered two *distinct* server objects (`live(5001)` twice → `owningServers.size === 2`), which the code already evicts — the shared-object case was untested and unhandled.

## Fix

In the heal block of `detectCrossHostCertRoute`: when the single owning server's own entries span **more than one wildcard form**, that server *is itself* the cross-host route (one leaf cert can't validly serve unrelated hosts) — so keep nothing on the port and let every host re-mint a correct single-host server on its next tunnel.

Behavior preserved:
- **Legit wildcard share** (`api`/`cdn`/`*.example.com`) never reaches the heal block (the `Set(wildcardForm).size < 2` guard skips it).
- **Distinct-objects collision** (`owningServers.size === 2`) still evicts both.
- **Legit wildcard server + unrelated stale entry on one port** keeps the wildcard, evicts only the stale one.

This is the reconciler's established self-heal seam (#202): it converts a whole-run breakage into a transient one — the first colliding request may still fail, then the route is purged and rebuilt correctly.

## Tests

- New unit test: one shared server object registered under two unrelated hosts → both evicted, logged once.
- New regression guard: a legit wildcard pair is evicted only when an unrelated live server *also* claims the port.
- All 9 existing `detectCrossHostCertRoute` tests unchanged; full regression trace done.
- `bunx vitest run test/egress-proxy.test.ts` → 17 passed.
- `bun test test/bun/egress-proxy.bun.test.ts` (real patched library on Bun) → 5 passed.
- `bun run typecheck` + biome check → clean.

https://claude.ai/code/session_017YKSChtYLgu1aAvw7RkR7c

---
_Generated by [Claude Code](https://claude.ai/code/session_017YKSChtYLgu1aAvw7RkR7c)_