### PR TITLE
feat: stamp approved PRDs with a linkback to the approval task + comment

### DIFF
--- a/agents/software-development/product-lead.md
+++ b/agents/software-development/product-lead.md
@@ -27,16 +27,27 @@ You are the second step in the ticket workflow (after the Researcher).
 2. **Review the research** in the research.md project doc.
 3. **Identify ambiguity.** Read the request carefully and separate what's clear from what's ambiguous.
 4. **Clarify with the admin** via ticket comments — use structured-option cards when asking multiple-choice questions. Iterate until requirements are finalised and the admin approves.
-5. **Write the PRD** to the prd.md project doc via `write_project_doc`, and post a summary as a comment on the ticket. The PRD covers:
+5. **Write the PRD** to the prd.md project doc via `write_project_doc`, and post a summary as a comment on the ticket. Open the document with a metadata header — the title line, then four metadata lines, each on its own line:
+
+   ```
+   # Product Requirements Document: <Title>
+
+   Status: Draft — awaiting admin approval
+   Author: @@product-lead
+   Input: research.md by @@researcher
+   Date: <YYYY-MM-DD>
+   ```
+
+   Keep the attributions passive (`@@…`) and write `research.md` bare so it links — they are credits, not asks. Below the header, the PRD covers:
    - **What**: what to build, from the user's perspective
    - **Why**: how it connects to the team mission
    - **Acceptance criteria**: specific, testable conditions for "done"
    - **Out of scope**: what this ticket does NOT cover
 6. **Request admin approval of the PRD.** Post a comment on the ticket summarising the PRD and explicitly asking the admin to approve it before downstream work begins. End your turn. Do NOT @-mention `@architect` yet — the architect must not start until the admin has approved the PRD in a ticket comment.
-7. **On admin approval, mark this ticket done.** When the admin has posted an explicit approval comment on the PRD, call `update_task(status: 'done')` on the PRD ticket. Post a short wrap-up comment summarising what the PRD ships and naming the downstream tickets that will unblock — reference the architect **passively** (e.g. `Approved. prd.md is final. @@architect — BE-4 (technical spec) and BE-5 (UI/UX design) unblock now.`). The cascade unblock auto-wakes the architect on those tickets. An active `@architect` here would only wake them on this PRD ticket, which is no longer theirs to act on. If no downstream architect ticket exists yet (Captain didn't pre-file one with `blocked_by_task_ids: [<this-ticket>]`), keep the PRD open instead, post a comment with an active `@architect` ask, and let the architect triage the mention per the standard handoff flow. If the admin asks for changes, revise the PRD, summarise the changes in a comment, and request approval again.
+7. **On admin approval, stamp the PRD then mark this ticket done.** When the admin has posted an explicit approval comment on the PRD: first record the approval in the document — call `write_project_doc` for `prd.md`, change the header's `Status` line to `Status: Approved`, and add a line `Approved in <TASK-ID>#comment-<uuid>` where `<TASK-ID>` is this ticket's identifier and `<uuid>` is the admin's approval comment (the comment that triggered this run — its id is handed to you; never invent one). Write the link bare, no backticks, so it resolves to that comment. Then call `update_task(status: 'done')` on the PRD ticket. Post a short wrap-up comment summarising what the PRD ships and naming the downstream tickets that will unblock — reference the architect **passively** (e.g. `Approved. prd.md is final. @@architect — BE-4 (technical spec) and BE-5 (UI/UX design) unblock now.`). The cascade unblock auto-wakes the architect on those tickets. An active `@architect` here would only wake them on this PRD ticket, which is no longer theirs to act on. If no downstream architect ticket exists yet (Captain didn't pre-file one with `blocked_by_task_ids: [<this-ticket>]`), keep the PRD open instead, post a comment with an active `@architect` ask, and let the architect triage the mention per the standard handoff flow. If the admin asks for changes, revise the PRD, summarise the changes in a comment, and request approval again.
 8. **Post-implementation** — verify the result matches the PRD.
 
-**Material PRD changes require fresh admin approval.** Material = scope, acceptance criteria, out-of-scope boundaries, or the "why". If anything material needs to change after the original approval (whether you propose it or the architect/engineer surfaces a need), update prd.md via `write_project_doc`, post a comment summarising what changed and why, and explicitly request admin re-approval. Downstream agents must wait for that re-approval before continuing. Typo fixes and clarifications that do not alter scope or acceptance criteria do not need re-approval — note them in a comment so the admin is aware. The PRD drives everything downstream.
+**Material PRD changes require fresh admin approval.** Material = scope, acceptance criteria, out-of-scope boundaries, or the "why". If anything material needs to change after the original approval (whether you propose it or the architect/engineer surfaces a need), update prd.md via `write_project_doc`, post a comment summarising what changed and why, and explicitly request admin re-approval. Downstream agents must wait for that re-approval before continuing. Typo fixes and clarifications that do not alter scope or acceptance criteria do not need re-approval — note them in a comment so the admin is aware. When you propose a material change, flip the header back to `Status: Draft — awaiting admin approval` and drop the `Approved in …` line; re-stamp it per step 7 once the admin re-approves. The PRD drives everything downstream.
 
 ## Rules
 

--- a/packages/server/test/template-resolver.test.ts
+++ b/packages/server/test/template-resolver.test.ts
@@ -491,6 +491,26 @@ Current date: {{current_date}}
 		);
 	});
 
+	it('Product Lead prompt codifies the PRD metadata header and the post-approval stamp', async () => {
+		const agentsRes = await app.request(
+			`/api/projects/${await projectSlugForTeamSlug(db, agentTeamSlug)}/agents`,
+			{ headers: authHeader(token) },
+		);
+		const agents = ((await agentsRes.json()) as any).data;
+		const productLead = agents.find((a: any) => a.slug === 'product-lead');
+		const prompt = await getAgentPrompt(productLead.id);
+
+		// Step 5 — the draft metadata header, so the Status line is parseable for re-stamping.
+		expect(prompt).toContain('Status: Draft — awaiting admin approval');
+		expect(prompt).toContain('Author: @@product-lead');
+
+		// Step 7 — on approval, flip the status and link back to the approval task + comment.
+		expect(prompt).toContain('Status: Approved');
+		expect(prompt).toContain('Approved in <TASK-ID>#comment-<uuid>');
+		// The linked comment is the triggering (admin approval) comment, never a fabricated id.
+		expect(prompt).toContain('the comment that triggered this run');
+	});
+
 	it('Captain system prompt does not use {{reports_to}}', async () => {
 		const agentsRes = await app.request(
 			`/api/projects/${await projectSlugForTeamSlug(db, agentTeamSlug)}/agents`,

--- a/packages/web/test/prd-approval-linkback.test.tsx
+++ b/packages/web/test/prd-approval-linkback.test.tsx
@@ -1,0 +1,59 @@
+import { expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+import { seedComment, seedProject, seedTask, seedWorkspace } from './helpers/seed';
+
+// Guards the codified PRD metadata format from product-lead.md: once the admin
+// approves, the Product Lead rewrites prd.md's header with
+// `Approved in <TASK-ID>#comment-<uuid>`. This asserts that header renders in the
+// documents viewer as a clickable deep link to the approval comment. Render-driven
+// (no real layout/WebSocket), so it belongs in the component tier.
+test('approved PRD metadata links back to the approval task + comment', async () => {
+	const seeded = { projectSlug: '', taskId: '', commentId: '' };
+
+	const { findByTestId, findByText, router } = await renderApp({
+		initialPath: '/',
+		seed: async ({ apiBase, token }) => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'PRD Linkback Project' });
+			const task = await seedTask(ws, project, { title: 'Draft the PRD' });
+			const approval = await seedComment(ws, task, 'Approved — ship it.');
+
+			// The approved header the Product Lead stamps at step 7.
+			const content = [
+				'# Product Requirements Document: Demo',
+				'',
+				'Status: Approved',
+				'Author: @@product-lead',
+				'Input: research.md by @@researcher',
+				'Date: 2026-06-11',
+				`Approved in ${task.identifier}#comment-${approval.id}`,
+			].join('\n');
+
+			const res = await apiBase(`/api/projects/${project.slug}/docs/prd.md`, {
+				method: 'PUT',
+				headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+				body: JSON.stringify({ content }),
+			});
+			if (!res.ok) throw new Error(`seed prd.md failed: ${res.status}`);
+
+			seeded.projectSlug = project.slug;
+			seeded.taskId = task.identifier.toLowerCase();
+			seeded.commentId = approval.id;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/documents',
+		params: { projectId: seeded.projectSlug },
+		search: { file: 'prd.md' } as never,
+	});
+
+	// Doc body rendered.
+	await findByText(/Product Requirements Document/, undefined, { timeout: 15_000 });
+
+	// findByTestId auto-waits for the useTaskMentions resolve to land and re-render.
+	const link = (await findByTestId('comment-mention-link')) as HTMLAnchorElement;
+	expect(link.getAttribute('href')).toBe(
+		`/projects/${seeded.projectSlug}/tasks/${seeded.taskId}#comment-${seeded.commentId}`,
+	);
+});


### PR DESCRIPTION
## What

Once an admin approves a PRD, the Product Lead now updates `prd.md`'s metadata header to record **where** it was approved:

- `Status: Draft — awaiting admin approval` → `Status: Approved`
- adds `Approved in <TASK-ID>#comment-<uuid>` — a bare link to the approval **task** and the admin's approval **comment**, which renders as a clickable deep link in the docs viewer.

## Why

A drafted PRD carries a metadata header (Status / Author / Input / Date). After approval the `Status` line went stale and nothing recorded the approval's provenance. The agent, when it confirms the admin's approval comment, already holds the task identifier (`HEZO_TASK_IDENTIFIER`) and the triggering comment's UUID (handed to it in its prompt), so it has everything needed to write the linkback.

## Approach

Approval stays **conversational and agent-driven**, exactly as it works today — the agent posts a comment asking for approval, the admin replies, and the agent acts on that reply. **No hard-coded write gate is added**; project docs remain writable at any time and handling "approval required" is the agent's responsibility. This is therefore a role-doc/agent-behavior change plus tests — no server gating code.

The linkback uses the existing `<TASK-ID>#comment-<uuid>` mention syntax, already rendered as a deep link by `remarkMentions` in `MarkdownProse` (which the documents viewer uses), so no frontend change was needed.

## Changes

- **`agents/software-development/product-lead.md`** — codify the PRD metadata header (step 5); on approval, flip `Status` to `Approved` and add the `Approved in …` linkback before marking the ticket done (step 7); re-stamp on a material change (step 39). Attributions use passive `@@` and the link is written bare so it resolves.
- **`packages/web/test/prd-approval-linkback.test.tsx`** — component test asserting the stamped header renders as a `comment-mention-link` pointing at the approval task + comment hash in the documents viewer.
- **`packages/server/test/template-resolver.test.ts`** — prompt-resolution test asserting the new guidance is wired into the resolved Product Lead system prompt.

## Testing

- `cd packages/web && bunx vitest run test/prd-approval-linkback.test.tsx` — passes.
- `cd packages/server && bunx vitest run test/template-resolver.test.ts` — passes (52 tests).
- Pre-commit `turbo typecheck` + full build pass.

One note on test output: the web component test emits a stray `<updates> update check failed` warning at teardown. This is the global `UpdateBanner` (in `__root.tsx`) firing its fail-soft GitHub release check; the in-process test backend calls real GitHub, and a single fast test tears down before that round-trip settles (longer multi-test files let it settle, so they're quiet). It's pre-existing shell/harness behavior surfaced by a fast test, not a defect in this change — happy to silence it if reviewers prefer.

## Out of scope

- An unrelated, agent-unreachable `prd.md` approval gate exists in the `/api` REST route (`project-docs.ts`); left untouched (agents write via MCP, which has no such gate).
- Extending the same stamp to `spec.md` (Architect) — identical pattern, deferred.

https://claude.ai/code/session_017G2o9Ksu4FuhFnasp8YQ2g

---
_Generated by [Claude Code](https://claude.ai/code/session_017G2o9Ksu4FuhFnasp8YQ2g)_