### PR TITLE
feat: render markdown in CEO chat messages

### DIFF
--- a/packages/web/src/components/ceo-chat/ceo-chat-widget.tsx
+++ b/packages/web/src/components/ceo-chat/ceo-chat-widget.tsx
@@ -1,6 +1,7 @@
 import { Loader2, MessageSquare, Send, X } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { type CeoMessage, useCeoChat } from '../../hooks/use-ceo-chat';
+import { MarkdownProse } from '../markdown-prose';
 import { Tooltip } from '../ui/tooltip';
 
 function formatTime(iso: string): string {
@@ -146,10 +147,17 @@ function MessageBubble({ message }: { message: CeoMessage }) {
 				data-testid="ceo-chat-message"
 				data-role="ceo"
 			>
-				<div className="rounded-radius-md rounded-bl-sm border border-border bg-bg-subtle px-3 py-2 text-[13px] leading-relaxed text-text whitespace-pre-wrap">
-					{message.content || (failed ? 'Something went wrong.' : '')}
+				<div className="rounded-radius-md rounded-bl-sm border border-border bg-bg-subtle px-3 py-2 text-text">
+					{/* The CEO's replies are LLM-authored markdown. There's no single
+					    project scope on the global chat, so MarkdownProse renders pure
+					    GFM (mention resolution stays disabled without a projectId). */}
+					{message.content ? (
+						<MarkdownProse testId="ceo-chat-markdown">{message.content}</MarkdownProse>
+					) : failed ? (
+						<span className="text-[13px] leading-relaxed">Something went wrong.</span>
+					) : null}
 					{interrupted && (
-						<span className="ml-1 text-[11px] italic text-text-subtle">(interrupted)</span>
+						<div className="mt-1 text-[11px] italic text-text-subtle">(interrupted)</div>
 					)}
 					{/* Reply has begun but the CEO is still working → dots pinned to
 					    the bottom of the same bubble. */}
@@ -166,7 +174,7 @@ function MessageBubble({ message }: { message: CeoMessage }) {
 			data-testid="ceo-chat-message"
 			data-role="user"
 		>
-			<div className="rounded-radius-md rounded-br-sm border border-accent-blue-text/20 bg-accent-blue-bg px-3 py-2 text-[13px] leading-relaxed text-text whitespace-pre-wrap">
+			<div className="rounded-radius-md rounded-br-sm border border-accent-blue-text/20 bg-accent-blue-bg px-3 py-2 text-sm leading-relaxed text-text whitespace-pre-wrap">
 				{message.content}
 			</div>
 			<span className="text-[10px] text-text-subtle">{formatTime(message.created_at)}</span>

--- a/packages/web/test/ceo-chat.test.tsx
+++ b/packages/web/test/ceo-chat.test.tsx
@@ -133,3 +133,56 @@ test('a completed reply shows no typing dots', async () => {
 	expect(queryByTestId('ceo-chat-streaming-dots')).toBeNull();
 	expect(queryByTestId('ceo-chat-typing')).toBeNull();
 });
+
+test('a CEO reply renders its markdown as formatted HTML, not raw text', async () => {
+	const { findByTestId } = await renderApp({ initialPath: '/home' });
+	(await findByTestId('ceo-chat-launcher')).click();
+	await findByTestId('ceo-chat-panel');
+
+	seedConversation([
+		{
+			id: 'a1',
+			role: 'assistant',
+			channel: 'web',
+			status: 'complete',
+			content: ['**Two projects** are live:', '', '- `HQ` — internal', '- `todo6` — todo app'].join(
+				'\n',
+			),
+			created_at: now(),
+		},
+	]);
+
+	const body = await findByTestId('ceo-chat-markdown');
+	// Inline emphasis and code spans become real elements rather than literal
+	// `**`/backtick syntax.
+	expect(body.querySelector('strong')?.textContent).toBe('Two projects');
+	const codeText = Array.from(body.querySelectorAll('code')).map((el) => el.textContent);
+	expect(codeText).toContain('HQ');
+	expect(codeText).toContain('todo6');
+	// The dash bullets collapse into a real list.
+	expect(body.querySelectorAll('li').length).toBe(2);
+	// The raw markdown markers are gone from the visible text.
+	expect(body.textContent ?? '').not.toContain('**');
+});
+
+test('a user message is shown as typed, not parsed as markdown', async () => {
+	const { findByTestId, findByText } = await renderApp({ initialPath: '/home' });
+	(await findByTestId('ceo-chat-launcher')).click();
+	await findByTestId('ceo-chat-panel');
+
+	seedConversation([
+		{
+			id: 'u1',
+			role: 'user',
+			channel: 'web',
+			status: 'complete',
+			content: 'Does **HQ** use `client side storage`?',
+			created_at: now(),
+		},
+	]);
+
+	const bubble = await findByText(/Does \*\*HQ\*\* use `client side storage`\?/);
+	// The user's own input is echoed verbatim — no <strong>/<code> transformation.
+	expect(bubble.querySelector('strong')).toBeNull();
+	expect(bubble.querySelector('code')).toBeNull();
+});


### PR DESCRIPTION
## What

The CEO chat widget rendered messages as raw `whitespace-pre-wrap` text, so the CEO's LLM-authored markdown — `**bold**`, inline `` `code` ``, lists, headings — showed its literal syntax instead of being formatted (see the screenshot from the report).

This renders assistant (CEO) messages through the existing `MarkdownProse` component (`react-markdown` + `remark-gfm`), the single markdown-rendering source already used for task comments. It degrades to pure GFM when no project scope is passed — exactly right for the **global** CEO conversation, where mention resolution can't be wired up (the resolution hooks are all `enabled: !!projectId`, so they stay idle).

## Details

- **CEO bubbles** now render markdown (bold/italic, inline code + fenced code blocks, lists, headings, blockquotes, tables, links). Streaming renders markdown live, token by token; the typing indicator, in-bubble streaming dots, and `failed` fallback are unchanged. The `(interrupted)` marker moves to its own line below the rendered block.
- **User bubbles** stay verbatim — shown exactly as typed (matching the ChatGPT / Claude.ai convention); only their font size is aligned to the assistant bubble (`text-[13px]` → `text-sm`) for visual consistency.

## Testing

- Added two component tests to `packages/web/test/ceo-chat.test.tsx`:
  - a CEO reply with markdown renders real `<strong>` / `<code>` / `<li>` elements (no literal `**` left in the text)
  - a user message with markdown syntax is echoed verbatim (no `<strong>`/`<code>` transformation)
- Full web component tier green (78 files / 298 tests). `typecheck` and `biome check` clean on the changed files.

Per the testing decision tree this is render-driven (DOM only, no real layout / viewport / WebSocket), so it lives in the component tier rather than Playwright.

https://claude.ai/code/session_01TAA7fY29WmUMNvGjJjoZZf

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAA7fY29WmUMNvGjJjoZZf)_