### PR TITLE
feat(repos): drop short_name — the repository name is the label

### DIFF
--- a/.dev/api.md
+++ b/.dev/api.md
@@ -604,14 +604,17 @@ Response:
     {
       "id": "uuid",
       "project_id": "uuid",
-      "short_name": "frontend",
-      "url": "https://github.com/org/frontend",
+      "repo_identifier": "org/frontend",
       "host_type": "github",
       "created_at": "..."
     }
   ]
 }
 ```
+
+The repo's name — the segment after the owner in `repo_identifier` — is its
+display label and the name of its workspace/worktree directories. It is unique
+within a project (enforced by a DB index), even across owners.
 
 #### `POST /projects/:projectId/repos`
 Add a repo — either by linking an existing GitHub repository or creating a new
@@ -623,7 +626,6 @@ Requires: GitHub platform must be connected for this team.
 **Mode: link** (default) — link an existing repo:
 ```json
 {
-  "short_name": "frontend",
   "mode": "link",
   "url": "https://github.com/org/frontend"
 }
@@ -632,13 +634,15 @@ Requires: GitHub platform must be connected for this team.
 **Mode: create** — create a new repo on GitHub and link it:
 ```json
 {
-  "short_name": "app",
   "mode": "create",
   "owner": "acme-corp",
   "name": "my-app",
   "private": true
 }
 ```
+
+Returns 409 `REPO_NAME_TAKEN` if a repo with the same name (regardless of
+owner) is already linked to the project — its workspace directory would clash.
 The `owner` must appear in the user's accessible GitHub orgs (or match the
 authenticated user's personal namespace). Server re-checks this via
 `GET /user/orgs` before creating. Returns 403 `OWNER_NOT_ACCESSIBLE` otherwise.
@@ -684,8 +688,8 @@ The `REPO_ACCESS_FAILED` message includes the connected GitHub username (from
 access to the repository.
 
 **Synchronous clone:** on a successful insert the server clones the repo via
-SSH into `<dataDir>/teams/<team-slug>/projects/<project-slug>/workspace/<short_name>/`
-(bind-mounted as `/workspace/<short_name>/` inside the project container) and
+SSH into `<dataDir>/teams/<team-slug>/projects/<project-slug>/workspace/<repo-name>/`
+(bind-mounted as `/workspace/<repo-name>/` inside the project container) and
 returns the result in the response body as `clone_status` (`"cloned"`,
 `"skipped"`, or `"failed"`) and `clone_error` (string or `null`). Clone
 failures do not fail the request — the repo record is still created, and
@@ -695,7 +699,7 @@ provision.
 #### `DELETE /projects/:projectId/repos/:repoId`
 Remove a repo from a project. The server also removes the repo's on-disk
 workspace directory and every per-task worktree derived from it
-(`<workspace>/<short_name>/` and `<worktrees>/<task>/<short_name>/`).
+(`<workspace>/<repo-name>/` and `<worktrees>/<task>/<repo-name>/`).
 
 Returns 409 `DESIGNATED_REPO_IMMUTABLE` if `repoId` equals the project's
 `designated_repo_id`. The designated repo cannot be removed.
@@ -2137,7 +2141,7 @@ Response:
         "project_goal": "Ship collaboration features",
         "team_description": "Build the #1 AI note-taking app",
         "repos": [
-          { "short_name": "api", "url": "https://github.com/org/api" }
+          { "repo_identifier": "org/api", "url": "https://github.com/org/api" }
         ],
         "unread_comments": 1
       }
@@ -2202,7 +2206,7 @@ as GitHub. No side channels, no direct messaging. Everything is on the record.
 
 Text content can contain `@<agent-slug>` references. The slug is derived from
 the agent title (lowercased, spaces → hyphens, e.g. "Dev Engineer" → `dev-engineer`).
-Repo short names can also be referenced: `@frontend`, `@api`.
+Repo names can also be referenced: `@frontend`, `@api`.
 
 The resolved system prompt every agent receives ends with a **Teammates** block
 listing each enabled peer in the team in `@<slug> — Title` form. This block

--- a/.dev/implementation-phases.md
+++ b/.dev/implementation-phases.md
@@ -201,7 +201,7 @@ per-task worktrees on every linked repo, realtime run-log streaming, and the
 Backend:
 - Project Docker container lifecycle (provision, start, stop, rebuild via Docker Engine API)
   - One container per project (all project repos checked out at
-    `/workspace/<repo-short-name>/` inside; kept in sync by
+    `/workspace/<repo-name>/` inside; kept in sync by
     `ensureProjectRepos` on provision, on repo attach, and before every run)
   - Dev port forwarding for preview access
 - Agent subprocess management (`claude_code` adapter: subprocess in project container via `docker exec`)
@@ -212,7 +212,7 @@ Backend:
   each request against the run row's status, so the token is automatically
   rejected once the run finalizes.
 - Git worktrees per task on every linked repo
-  (`/worktrees/<task-identifier>/<repo-short-name>/` on branch
+  (`/worktrees/<task-identifier>/<repo-name>/` on branch
   `hezo/<task-identifier>`). The agent's working directory resolves to the
   designated repo's worktree; other repos sit alongside. Worktrees persist
   across runs on the same task and are removed when the task transitions to
@@ -765,7 +765,7 @@ Docs:
 
 **How to test:**
 - Create a team + project with no repo, assign an engineer to an task, see the action comment + inbox approval, drive the wizard with the GitHub simulator (integration) or a real local Connect + GitHub account (manual)
-- Verify the cloned repo appears at `/workspace/{short_name}/` inside the project container and a worktree is created on the engineer's resume
+- Verify the cloned repo appears at `/workspace/{repo-name}/` inside the project container and a worktree is created on the engineer's resume
 - Verify `DELETE` on the designated repo returns 409
 - `bun run test` and `bun run test --e2e` pass
 

--- a/.dev/schema.md
+++ b/.dev/schema.md
@@ -18,7 +18,7 @@
 | `invites` | Pending invitations. Carries role, title, permissions, project scope. | belongs to team |
 | `api_keys` | Team-scoped keys for external orchestrators. Stored bcrypt-hashed. | belongs to team |
 | `projects` | Group of related work under a team. Has `task_prefix` (2–4 uppercase chars used for task identifiers), Docker container config, dev ports, designated repo. `is_internal` flag marks auto-created projects (e.g. Internal) that cannot be deleted. | belongs to team |
-| `repos` | Git repo (GitHub only). Stores `org/repo` identifier. Short name for @-mentions. | belongs to project |
+| `repos` | Git repo (GitHub only). Stores `org/repo` identifier; the repo name (segment after the owner) is the display label, directory name, and @-mention handle. | belongs to project |
 | `tasks` | Ticket. Must have a project. Linear-style `identifier` (e.g. `IN-42`) built from the project's `task_prefix` + per-project number. Assignee references `members.id`. Has `rules` (approach instructions) and `progress_summary` (agent-maintained status). | belongs to team + project, assigned to member |
 | `task_dependencies` | Many-to-many blocking relationships between tasks. | links task ↔ task |
 | `task_comments` | Thread entries. Polymorphic via `content_type` + `content` JSONB. Includes execution-type comments auto-created when agent runs complete. | belongs to task |
@@ -163,8 +163,10 @@ The app layer performs a two-step validation before inserting:
    (403/404), the request fails with `REPO_ACCESS_FAILED` and includes the
    GitHub username so the board knows which account needs to be added.
 
-Short names are unique within a project and used for @-mentions in task
-comments (`@frontend`, `@api`).
+The repo's name — `split_part(repo_identifier, '/', 2)` — is its display label
+and the name of its workspace/worktree directories, so it is unique within a
+project (unique expression index), even across owners. It is also used for
+@-mentions in task comments (`@frontend`, `@api`).
 
 ### Designated repo immutability
 
@@ -270,7 +272,7 @@ ensure unambiguous @-mentions.
 
 All inter-agent communication happens via @-mentions in task comments — no
 side channels, no direct messaging. The server parses `@<slug>` from comment
-text and creates notifications for mentioned agents. Repo short names can also
+text and creates notifications for mentioned agents. Repo names can also
 be @-referenced (`@frontend`, `@api`).
 
 ### Subagents
@@ -653,7 +655,7 @@ Each row captures:
 - **Invocation**: `invocation_command` is the exact CLI that was passed to
   `docker exec` (with the agent JWT redacted to `Bearer ***`). `working_dir` is
   the container path the exec was rooted at (normally the designated repo's
-  per-task worktree, e.g. `/worktrees/<task-identifier>/<repo-short-name>`).
+  per-task worktree, e.g. `/worktrees/<task-identifier>/<repo-name>`).
 - **Logs**: `log_text` holds interleaved stdout and stderr captured from the
   streaming Docker exec, capped at 1 MB (with a `...[truncated — log capped at
   N bytes]` marker when exceeded). Stderr lines are prefixed `[stderr] ` so
@@ -673,13 +675,14 @@ is bind-mounted into the container:
 
 - `<dataDir>/teams/<team-slug>/projects/<project-slug>/workspace/` ↔
   `/workspace/` in the container. For every repo linked to the project,
-  `ensureProjectRepos` populates a subdirectory `<workspace>/<short-name>/`.
+  `ensureProjectRepos` populates a subdirectory `<workspace>/<repo-name>/`
+  (the repo name is the segment after the owner in `repo_identifier`).
   The repo-add route (`POST /repos`), container provision, and the agent
   runner all call this helper, so the set of on-disk clones stays in sync
   with the `repos` rows for the project.
 - `<dataDir>/.../worktrees/` ↔ `/worktrees/` in the container. For each task
   an agent works on, the runner creates `git worktree` directories under
-  `/worktrees/<task-identifier>/<repo-short-name>/` on the branch
+  `/worktrees/<task-identifier>/<repo-name>/` on the branch
   `hezo/<task-identifier>`. Worktrees persist across runs on the same task
   so iterative work survives between invocations, and are torn down when the
   task transitions to a terminal status (`done`, `cancelled`, etc.) or its

--- a/.dev/spec.md
+++ b/.dev/spec.md
@@ -787,13 +787,13 @@ All Hezo data lives under `~/.hezo/` on the host machine. The structure mirrors 
 
 ### Git worktrees for parallelism
 
-Repos are cloned once (via SSH) into the project's `workspace/<repo-short-name>/` directory. When an agent starts a run on an task, the runner lazily creates a **git worktree per (task × repo)** so iterative work across runs on the same task persists and concurrent tasks cannot collide.
+Repos are cloned once (via SSH) into the project's `workspace/<repo-name>/` directory (the repo name is the segment after the owner in the `org/repo` identifier). When an agent starts a run on an task, the runner lazily creates a **git worktree per (task × repo)** so iterative work across runs on the same task persists and concurrent tasks cannot collide.
 
 - Multiple agents working on different tasks use different worktrees — no conflicts.
 - Repeated runs on the same task reuse the existing worktree, pulling latest changes via `git fetch` + fast-forward merge.
 - The agent's working directory is the **designated repo's worktree**; other repos sit alongside and the agent can `cd` into them.
 
-Worktree layout: `~/.hezo/teams/{team}/projects/{project}/worktrees/{task-identifier}/{repo-short-name}/`
+Worktree layout: `~/.hezo/teams/{team}/projects/{project}/worktrees/{task-identifier}/{repo-name}/`
 Branch name: `hezo/{task-identifier}`
 
 Worktrees are created on first run of an task and removed when the task transitions to a terminal status (done/cancelled) or its repo is detached.
@@ -856,7 +856,7 @@ At runtime, the team's SSH private key is injected into agent subprocesses for g
 | Team deleted | All project containers destroyed. |
 | Server startup / every 5s | Container status sync — DB state reconciled with Docker. Stale "running" status corrected to "stopped" or "error". Changes broadcast via WebSocket. |
 | Task assigned | No-op until the first run. Worktrees are created lazily when an agent starts executing against the task. |
-| Task first run | Runner creates `/worktrees/{task-identifier}/{repo-short-name}/` on branch `hezo/{task-identifier}` for every linked repo, then runs the agent with the designated repo's worktree as its working directory. |
+| Task first run | Runner creates `/worktrees/{task-identifier}/{repo-name}/` on branch `hezo/{task-identifier}` for every linked repo, then runs the agent with the designated repo's worktree as its working directory. |
 | Task closed | Per-task worktree directory `/worktrees/{task-identifier}/` is removed (all per-repo worktrees under it). |
 
 ### Agent subprocess model
@@ -1042,10 +1042,9 @@ Hezo generates an SSH key pair per team, stores the private key encrypted in the
 ### Repos belong to projects
 
 - A project can reference multiple repos
-- Each repo within a project has a unique short name (e.g. `frontend`, `api`, `infra`)
-- Short names are user-defined at add time
-- Short names are used for @-mentioning in task comments: `@frontend`, `@api`
-- Uniqueness is enforced within a project (DB unique constraint)
+- Each repo is labelled by its own name — the segment after the owner in the `org/repo` identifier (e.g. `frontend`, `api`, `infra`)
+- Repo names are used for @-mentioning in task comments: `@frontend`, `@api`
+- Repo-name uniqueness is enforced within a project, even across owners (DB unique index on `split_part(repo_identifier, '/', 2)`), because the name is also the workspace directory
 
 ### What happens when a repo is linked
 
@@ -1058,8 +1057,8 @@ When a repo is added to a project via the API:
 2. **Repo access validation** — using the team's GitHub OAuth token, the system calls the GitHub API (`GET /repos/{owner}/{repo}`) to verify the authorized GitHub user has access. If access fails (403/404):
    - The request fails with `REPO_ACCESS_FAILED`
    - The error message includes the GitHub username from `connected_platforms.metadata` so the board knows which account needs access: *"Cannot access this repo — the GitHub user '{username}' needs to be added to {owner}/{repo}"*
-3. The repo is cloned (via SSH using the team's generated key) into `~/.hezo/teams/{team}/projects/{project}/{short_name}/`
-4. A symlink is created: `{short_name}/AGENTS.md → ../../../AGENTS.md` (pointing to team-level AGENTS.md)
+3. The repo is cloned (via SSH using the team's generated key) into `~/.hezo/teams/{team}/projects/{project}/{repo-name}/`
+4. A symlink is created: `{repo-name}/AGENTS.md → ../../../AGENTS.md` (pointing to team-level AGENTS.md)
 5. Git SSH command is configured to use the team's SSH key for all operations
 6. The repo is now available to any agent working on tasks in this project
 
@@ -1089,7 +1088,7 @@ Submitting the wizard calls `POST /repos` which, in one transaction:
 5. Sweeps every pending `action` setup-repo comment for this project, stamps each with `chosen_option = { status: 'complete', result: {...} }`, and appends a `system` confirmation comment per affected task.
 6. Resolves the pending approval.
 
-Post-commit the server clones the repo into the host workspace (`ensureProjectRepos`), then brings up the project container if it isn't already (`provisionContainer`) so `/workspace/{short_name}/` is live inside the container. Only then are the deferred wakeups re-enqueued as fresh `Automation` wakeups, so agents never wake up against an empty workspace.
+Post-commit the server clones the repo into the host workspace (`ensureProjectRepos`), then brings up the project container if it isn't already (`provisionContainer`) so `/workspace/{repo-name}/` is live inside the container. Only then are the deferred wakeups re-enqueued as fresh `Automation` wakeups, so agents never wake up against an empty workspace.
 
 ### Designated repo is immutable
 
@@ -1235,7 +1234,7 @@ An agent can `@architect` or `@engineer` in a comment. The mentioned agent wakes
 
 Every agent's resolved system prompt is auto-appended with a **Teammates** block listing each enabled peer in the team in `@<slug> — Title` form, sourced from `member_agents` filtered by `admin_status = 'enabled'` and excluding the running agent itself. This is the authoritative slug list at compose time — agents read it inline rather than calling `list_agents` on every reference. The block sits between the Project State block and the shared working guidelines.
 
-Repo short names can also be @-mentioned: `@frontend`, `@api` — these reference the repo, not an agent.
+Repo names can also be @-mentioned: `@frontend`, `@api` — these reference the repo, not an agent.
 
 **Handoff contract.** When an agent is woken by a mention, its run opens on the triggering ticket for *triage only* — not as new assigned work. The agent's task prompt is prepended with a Mention Handoff block showing the mentioner, the full comment, and the agent's own open tickets. The expected behaviour is:
 
@@ -2173,7 +2172,7 @@ See `schema.md` for the full table reference and design decisions. Key tables:
 | `api_keys` | Team-scoped API keys for external orchestrators. Stored hashed. |
 | `team_ssh_keys` | Generated SSH key pairs per team. Registered on GitHub via OAuth API. |
 | `projects` | Groups of work under a team. Each gets its own Docker container. |
-| `repos` | Git repos (GitHub only). Stores `org/repo` identifier. Short name for @-mentions. |
+| `repos` | Git repos (GitHub only). Stores `org/repo` identifier; the repo name (segment after the owner) is the label, directory name, and @-mention handle. |
 | `tasks` | Tickets. Must have a project. Assignee references `members.id`. |
 | `task_dependencies` | Many-to-many blocking relationships between tasks. |
 | `task_comments` | Thread entries. Polymorphic via `content_type` + `content` JSONB. |
@@ -2231,7 +2230,7 @@ auth_provider:        github, gitlab
 
 - `agents(team_id, slug)` UNIQUE: slugs unique within team (for unambiguous @-mentions)
 - `repos.url` CHECK: must match `github.com`
-- `repos(project_id, short_name)` UNIQUE: short names unique within project
+- `repos(project_id, split_part(repo_identifier, '/', 2))` UNIQUE: repo names unique within project (the name doubles as the workspace directory)
 - `tasks(team_id, number)` UNIQUE: task numbers unique within team
 - `tasks(team_id, identifier)` UNIQUE: identifiers unique within team
 - `tasks.project_id` NOT NULL: every task must belong to a project

--- a/packages/server/migrations/001_initial_schema.sql
+++ b/packages/server/migrations/001_initial_schema.sql
@@ -319,16 +319,17 @@ CREATE UNIQUE INDEX idx_projects_team_task_prefix ON projects(team_id, task_pref
 CREATE TABLE repos (
     id                   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     project_id           UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
-    short_name           TEXT NOT NULL,
     repo_identifier      TEXT NOT NULL,
     host_type            repo_host_type NOT NULL,
     oauth_connection_id  UUID,
-    created_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
-
-    UNIQUE (project_id, short_name)
+    created_at           TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
 CREATE INDEX idx_repos_project ON repos(project_id);
+-- Clones land in `<workspace>/<repo name>/` — the segment after the owner in
+-- repo_identifier — so the repo name must be unique within a project even
+-- across owners. Also rules out linking the exact same repo twice.
+CREATE UNIQUE INDEX idx_repos_project_repo_name ON repos(project_id, split_part(repo_identifier, '/', 2));
 CREATE INDEX idx_repos_oauth_connection ON repos(oauth_connection_id) WHERE oauth_connection_id IS NOT NULL;
 
 -- Deferred FK: projects.designated_repo_id → repos(id) (repos defined after projects)

--- a/packages/server/src/lib/docs.ts
+++ b/packages/server/src/lib/docs.ts
@@ -8,7 +8,7 @@ export function resolveAgentsMdPath(
 	dataDir: string,
 	teamSlug: string,
 	projectSlug: string,
-	repoShortName: string,
+	repoName: string,
 ): string {
-	return join(dataDir, 'teams', teamSlug, 'projects', projectSlug, repoShortName, 'AGENTS.md');
+	return join(dataDir, 'teams', teamSlug, 'projects', projectSlug, repoName, 'AGENTS.md');
 }

--- a/packages/server/src/routes/project-docs.ts
+++ b/packages/server/src/routes/project-docs.ts
@@ -1,4 +1,10 @@
-import { ApprovalType, AuthType, DocumentType, isMarkdownDocSlug } from '@hezo/shared';
+import {
+	ApprovalType,
+	AuthType,
+	DocumentType,
+	isMarkdownDocSlug,
+	repoNameFromIdentifier,
+} from '@hezo/shared';
 import { Hono } from 'hono';
 import { resolveAgentsMdPath } from '../lib/docs';
 import { actorTypeFromAuth, resolveActorMemberId, resolveProjectId } from '../lib/resolve';
@@ -217,12 +223,7 @@ projectDocsRoutes.get('/projects/:projectId/agents-md', async (c) => {
 	const info = await getDesignatedRepoInfo(db, teamId, projectId);
 	if (!info) return err(c, 'NOT_FOUND', 'Project has no designated repo', 404);
 
-	const agentsMdPath = resolveAgentsMdPath(
-		dataDir,
-		info.teamSlug,
-		info.projectSlug,
-		info.repoShortName,
-	);
+	const agentsMdPath = resolveAgentsMdPath(dataDir, info.teamSlug, info.projectSlug, info.repoName);
 	const { existsSync, readFileSync } = await import('node:fs');
 	if (!existsSync(agentsMdPath)) {
 		return err(c, 'NOT_FOUND', 'AGENTS.md not found', 404);
@@ -246,12 +247,7 @@ projectDocsRoutes.put('/projects/:projectId/agents-md', async (c) => {
 		return err(c, 'INVALID_REQUEST', 'content is required', 400);
 	}
 
-	const agentsMdPath = resolveAgentsMdPath(
-		dataDir,
-		info.teamSlug,
-		info.projectSlug,
-		info.repoShortName,
-	);
+	const agentsMdPath = resolveAgentsMdPath(dataDir, info.teamSlug, info.projectSlug, info.repoName);
 	const { mkdirSync, writeFileSync } = await import('node:fs');
 	const { dirname } = await import('node:path');
 	mkdirSync(dirname(agentsMdPath), { recursive: true });
@@ -264,13 +260,13 @@ async function getDesignatedRepoInfo(
 	db: import('@electric-sql/pglite').PGlite,
 	teamId: string,
 	projectId: string,
-): Promise<{ teamSlug: string; projectSlug: string; repoShortName: string } | null> {
+): Promise<{ teamSlug: string; projectSlug: string; repoName: string } | null> {
 	const result = await db.query<{
 		team_slug: string;
 		project_slug: string;
-		repo_short_name: string;
+		repo_identifier: string;
 	}>(
-		`SELECT co.slug AS team_slug, p.slug AS project_slug, r.short_name AS repo_short_name
+		`SELECT co.slug AS team_slug, p.slug AS project_slug, r.repo_identifier
 		 FROM projects p
 		 JOIN teams co ON co.id = p.team_id
 		 JOIN repos r ON r.id = p.designated_repo_id
@@ -282,6 +278,6 @@ async function getDesignatedRepoInfo(
 	return {
 		teamSlug: row.team_slug,
 		projectSlug: row.project_slug,
-		repoShortName: row.repo_short_name,
+		repoName: repoNameFromIdentifier(row.repo_identifier),
 	};
 }

--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -420,9 +420,10 @@ projectsRoutes.get('/projects/:projectId', async (c) => {
 		return err(c, 'NOT_FOUND', 'Project not found', 404);
 	}
 
-	const repos = await db.query('SELECT * FROM repos WHERE project_id = $1 ORDER BY short_name', [
-		projectId,
-	]);
+	const repos = await db.query(
+		`SELECT * FROM repos WHERE project_id = $1 ORDER BY split_part(repo_identifier, '/', 2)`,
+		[projectId],
+	);
 
 	return ok(c, { ...(result.rows[0] as Record<string, unknown>), repos: repos.rows });
 });

--- a/packages/server/src/routes/repos.ts
+++ b/packages/server/src/routes/repos.ts
@@ -1,4 +1,4 @@
-import { wsRoom } from '@hezo/shared';
+import { repoNameFromIdentifier, wsRoom } from '@hezo/shared';
 import { type Context, Hono } from 'hono';
 import { broadcastChange } from '../lib/broadcast';
 import { getProjectLocator, resolveProjectId } from '../lib/resolve';
@@ -23,7 +23,7 @@ reposRoutes.get('/projects/:projectId/repos', async (c) => {
 	if (!projectId) return err(c, 'NOT_FOUND', 'Project not found', 404);
 
 	const result = await db.query(
-		`SELECT r.id, r.project_id, r.short_name, r.repo_identifier, r.host_type,
+		`SELECT r.id, r.project_id, r.repo_identifier, r.host_type,
 		        r.oauth_connection_id, r.created_at,
 		        (p.designated_repo_id = r.id) AS is_designated,
 		        oc.provider_account_label AS oauth_account_label
@@ -53,7 +53,6 @@ reposRoutes.post('/projects/:projectId/repos', async (c) => {
 	if (!projectId) return err(c, 'NOT_FOUND', 'Project not found', 404);
 
 	const body = await c.req.json<{
-		short_name: string;
 		mode?: 'link' | 'create';
 		url?: string;
 		owner?: string;
@@ -61,10 +60,6 @@ reposRoutes.post('/projects/:projectId/repos', async (c) => {
 		private?: boolean;
 		oauth_connection_id: string;
 	}>();
-
-	if (!body.short_name?.trim()) {
-		return err(c, 'INVALID_REQUEST', 'short_name is required', 400);
-	}
 
 	const mode = body.mode ?? 'link';
 	let parsedOwner: string | null = null;
@@ -137,7 +132,6 @@ reposRoutes.post('/projects/:projectId/repos', async (c) => {
 	type InsertedRepo = {
 		id: string;
 		project_id: string;
-		short_name: string;
 		repo_identifier: string;
 		host_type: string;
 		oauth_connection_id: string | null;
@@ -166,10 +160,10 @@ reposRoutes.post('/projects/:projectId/repos', async (c) => {
 			const projectRow = lockRes.rows[0];
 
 			const insertRes = await db.query<InsertedRepo>(
-				`INSERT INTO repos (project_id, short_name, repo_identifier, host_type, oauth_connection_id)
-				 VALUES ($1, $2, $3, 'github'::repo_host_type, $4)
-				 RETURNING id, project_id, short_name, repo_identifier, host_type, oauth_connection_id, created_at`,
-				[projectId, body.short_name.trim(), repoIdentifier, conn.id],
+				`INSERT INTO repos (project_id, repo_identifier, host_type, oauth_connection_id)
+				 VALUES ($1, $2, 'github'::repo_host_type, $3)
+				 RETURNING id, project_id, repo_identifier, host_type, oauth_connection_id, created_at`,
+				[projectId, repoIdentifier, conn.id],
 			);
 			const inserted = insertRes.rows[0];
 
@@ -187,7 +181,6 @@ reposRoutes.post('/projects/:projectId/repos', async (c) => {
 					projectId,
 					repoId: inserted.id,
 					repoIdentifier,
-					shortName: inserted.short_name,
 				});
 			}
 			return { inserted, becameDesignated, finalize };
@@ -197,7 +190,12 @@ reposRoutes.post('/projects/:projectId/repos', async (c) => {
 		finalizeResult = txResult.finalize;
 	} catch (e) {
 		if (isUniqueViolation(e)) {
-			return err(c, 'SHORT_NAME_TAKEN', `short_name "${body.short_name}" already used`, 409);
+			return err(
+				c,
+				'REPO_NAME_TAKEN',
+				`a repository named "${repoName}" is already linked to this project`,
+				409,
+			);
 		}
 		const msg = e instanceof Error ? e.message : 'Failed to insert repo';
 		return err(c, 'REPO_INSERT_FAILED', msg, 500);
@@ -220,12 +218,12 @@ reposRoutes.post('/projects/:projectId/repos', async (c) => {
 				dataDir,
 				c.get('sshAgentServer'),
 			);
-			const failed = syncRes.failed.find((f) => f.short_name === insertedRepo.short_name);
+			const failed = syncRes.failed.find((f) => f.name === repoName);
 			if (failed) {
 				cloneStatus = 'failed';
 				cloneError = failed.error;
 				log.error(`Failed to clone ${repoIdentifier}:`, cloneError);
-			} else if (syncRes.cloned.includes(insertedRepo.short_name)) {
+			} else if (syncRes.cloned.includes(repoName)) {
 				cloneStatus = 'cloned';
 			}
 		}
@@ -293,8 +291,8 @@ reposRoutes.delete('/projects/:projectId/repos/:repoId', async (c) => {
 		return err(c, 'DESIGNATED_REPO_IMMUTABLE', 'The designated repository cannot be removed', 409);
 	}
 
-	const result = await db.query<{ id: string; short_name: string }>(
-		'DELETE FROM repos WHERE id = $1 AND project_id = $2 RETURNING id, short_name',
+	const result = await db.query<{ id: string; repo_identifier: string }>(
+		'DELETE FROM repos WHERE id = $1 AND project_id = $2 RETURNING id, repo_identifier',
 		[repoId, projectId],
 	);
 
@@ -306,10 +304,11 @@ reposRoutes.delete('/projects/:projectId/repos/:repoId', async (c) => {
 	if (dataDir) {
 		const locator = await getProjectLocator(db, projectId);
 		if (locator) {
+			const repoName = repoNameFromIdentifier(result.rows[0].repo_identifier);
 			try {
-				removeRepoFromWorkspace(dataDir, locator.teamId, locator.id, result.rows[0].short_name);
+				removeRepoFromWorkspace(dataDir, locator.teamId, locator.id, repoName);
 			} catch (error) {
-				log.error(`Failed to clean up workspace for repo ${result.rows[0].short_name}:`, error);
+				log.error(`Failed to clean up workspace for repo ${repoName}:`, error);
 			}
 		}
 	}

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -18,6 +18,7 @@ import {
 	RUNTIME_HEADLESS_PREFIX_ARGS,
 	RUNTIME_HEADLESS_SUFFIX_ARGS,
 	RUNTIME_STREAM_ARGS,
+	repoNameFromIdentifier,
 	TaskStatus,
 	TERMINAL_TASK_STATUSES,
 	WakeupSource,
@@ -126,7 +127,6 @@ export interface RunnerDeps {
 
 interface RepoRow {
 	id: string;
-	short_name: string;
 	repo_identifier: string;
 }
 
@@ -1010,7 +1010,7 @@ async function prepareWorktrees(
 		emit(stream, `[system] ${text}\n`);
 
 	const repos = await deps.db.query<RepoRow>(
-		`SELECT id, short_name, repo_identifier FROM repos
+		`SELECT id, repo_identifier FROM repos
 		 WHERE project_id = $1 ORDER BY created_at ASC`,
 		[project.id],
 	);
@@ -1047,7 +1047,9 @@ async function prepareWorktrees(
 		const branchName = `hezo/${task.identifier}`;
 		const knownHostsPath = await ensureGithubKnownHosts(deps.dataDir);
 		const reposNeedingWorktree = repos.rows.filter(
-			(r) => !signal?.aborted && existsSync(join(workspaceRoot, r.short_name, '.git')),
+			(r) =>
+				!signal?.aborted &&
+				existsSync(join(workspaceRoot, repoNameFromIdentifier(r.repo_identifier), '.git')),
 		);
 
 		if (reposNeedingWorktree.length > 0 && deps.sshAgentServer) {
@@ -1058,14 +1060,15 @@ async function prepareWorktrees(
 				async ({ sshAuthSock }) => {
 					for (const repo of reposNeedingWorktree) {
 						if (signal?.aborted) break;
-						const repoDir = join(workspaceRoot, repo.short_name);
+						const repoName = repoNameFromIdentifier(repo.repo_identifier);
+						const repoDir = join(workspaceRoot, repoName);
 
-						emitSystem('stdout', `git fetch ${repo.short_name}...`);
+						emitSystem('stdout', `git fetch ${repoName}...`);
 						const fetchRes = await fetchRepo(repoDir, sshAuthSock, knownHostsPath);
 						if (fetchRes.success) {
-							emitSystem('stdout', `git fetch ${repo.short_name} done`);
+							emitSystem('stdout', `git fetch ${repoName} done`);
 						} else {
-							emitSystem('stderr', `git fetch ${repo.short_name} failed: ${fetchRes.error ?? '?'}`);
+							emitSystem('stderr', `git fetch ${repoName} failed: ${fetchRes.error ?? '?'}`);
 						}
 					}
 				},
@@ -1075,25 +1078,23 @@ async function prepareWorktrees(
 		const worktreeErrors = new Map<string, string>();
 		for (const repo of repos.rows) {
 			if (signal?.aborted) break;
-			const repoDir = join(workspaceRoot, repo.short_name);
-			const worktreePath = join(taskWorktreeRoot, repo.short_name);
+			const repoName = repoNameFromIdentifier(repo.repo_identifier);
+			const repoDir = join(workspaceRoot, repoName);
+			const worktreePath = join(taskWorktreeRoot, repoName);
 
 			if (!existsSync(join(repoDir, '.git'))) {
 				worktreeErrors.set(repo.id, 'repo is not cloned');
-				emitSystem('stderr', `(skipping worktree for ${repo.short_name} — not cloned)`);
+				emitSystem('stderr', `(skipping worktree for ${repoName} — not cloned)`);
 				continue;
 			}
 
-			emitSystem('stdout', `git worktree ${repo.short_name}...`);
+			emitSystem('stdout', `git worktree ${repoName}...`);
 			const wt = await ensureTaskWorktree(repoDir, worktreePath, branchName);
 			if (!wt.success) {
 				worktreeErrors.set(repo.id, wt.error ?? 'unknown');
-				emitSystem(
-					'stderr',
-					`git worktree for ${repo.short_name} failed: ${wt.error ?? 'unknown'}`,
-				);
+				emitSystem('stderr', `git worktree for ${repoName} failed: ${wt.error ?? 'unknown'}`);
 			} else if (wt.created) {
-				emitSystem('stdout', `git worktree add ${repo.short_name} @ ${branchName}`);
+				emitSystem('stdout', `git worktree add ${repoName} @ ${branchName}`);
 			}
 		}
 
@@ -1103,15 +1104,16 @@ async function prepareWorktrees(
 			? repos.rows.find((r) => r.id === project.designated_repo_id)
 			: null;
 		const primary = designated ?? repos.rows[0];
+		const primaryName = repoNameFromIdentifier(primary.repo_identifier);
 
 		// The run executes with this worktree as its cwd; proceeding without it
 		// would only surface later as an opaque container chdir failure.
 		const primaryError = worktreeErrors.get(primary.id);
 		if (primaryError) {
-			throw new Error(`cannot prepare worktree for ${primary.short_name}: ${primaryError}`);
+			throw new Error(`cannot prepare worktree for ${primaryName}: ${primaryError}`);
 		}
 
-		const workingDir = `/worktrees/${task.identifier}/${primary.short_name}`;
+		const workingDir = `/worktrees/${task.identifier}/${primaryName}`;
 
 		return { workingDir, designatedRepo: primary ?? null };
 	});

--- a/packages/server/src/services/repo-setup.ts
+++ b/packages/server/src/services/repo-setup.ts
@@ -143,7 +143,6 @@ export interface FinalizeInput {
 	projectId: string;
 	repoId: string;
 	repoIdentifier: string;
-	shortName: string;
 }
 
 export interface FinalizeResult {
@@ -200,7 +199,6 @@ export async function finalizePendingRepoSetup(
 					result: {
 						repo_id: input.repoId,
 						repo_identifier: input.repoIdentifier,
-						short_name: input.shortName,
 					},
 				}),
 				row.id,

--- a/packages/server/src/services/repo-sync.ts
+++ b/packages/server/src/services/repo-sync.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import type { PGlite } from '@electric-sql/pglite';
+import { repoNameFromIdentifier } from '@hezo/shared';
 import type { MasterKeyManager } from '../crypto/master-key';
 import { logger } from '../logger';
 import { cloneRepo, ensureGithubKnownHosts } from './git';
@@ -12,10 +13,11 @@ const log = logger.child('repo-sync');
 
 export type LogEmitter = (stream: 'stdout' | 'stderr', text: string) => void;
 
+/** Repos keyed by name — the workspace directory each clone lives in. */
 export interface RepoSyncResult {
 	cloned: string[];
 	skipped: string[];
-	failed: Array<{ short_name: string; error: string }>;
+	failed: Array<{ name: string; error: string }>;
 }
 
 export interface ProjectIdentity {
@@ -34,7 +36,7 @@ export async function ensureProjectRepos(
 	const result: RepoSyncResult = { cloned: [], skipped: [], failed: [] };
 
 	const repos = await db.query<RepoRow>(
-		`SELECT short_name, repo_identifier FROM repos
+		`SELECT repo_identifier FROM repos
 		 WHERE project_id = $1 ORDER BY created_at ASC`,
 		[project.id],
 	);
@@ -46,9 +48,10 @@ export async function ensureProjectRepos(
 
 	const pending: RepoRow[] = [];
 	for (const r of repos.rows) {
-		const targetDir = join(workspacePath, r.short_name);
+		const name = repoNameFromIdentifier(r.repo_identifier);
+		const targetDir = join(workspacePath, name);
 		if (existsSync(join(targetDir, '.git'))) {
-			result.skipped.push(r.short_name);
+			result.skipped.push(name);
 		} else {
 			pending.push(r);
 		}
@@ -60,7 +63,7 @@ export async function ensureProjectRepos(
 		const msg = 'SshAgentServer not available — cannot clone over SSH';
 		for (const r of pending) {
 			logEmit?.('stderr', `✗ ${msg}`);
-			result.failed.push({ short_name: r.short_name, error: msg });
+			result.failed.push({ name: repoNameFromIdentifier(r.repo_identifier), error: msg });
 		}
 		return result;
 	}
@@ -69,16 +72,17 @@ export async function ensureProjectRepos(
 
 	await withHostAgentSocket(sshAgentServer, project.team_id, dataDir, async ({ sshAuthSock }) => {
 		for (const r of pending) {
-			const targetDir = join(workspacePath, r.short_name);
-			logEmit?.('stdout', `→ Cloning ${r.repo_identifier} into ${r.short_name}/`);
+			const name = repoNameFromIdentifier(r.repo_identifier);
+			const targetDir = join(workspacePath, name);
+			logEmit?.('stdout', `→ Cloning ${r.repo_identifier} into ${name}/`);
 			const clone = await cloneRepo(r.repo_identifier, targetDir, sshAuthSock, knownHostsPath);
 			if (clone.success) {
-				logEmit?.('stdout', `✓ Cloned ${r.short_name}`);
-				result.cloned.push(r.short_name);
+				logEmit?.('stdout', `✓ Cloned ${name}`);
+				result.cloned.push(name);
 			} else {
 				const errMsg = clone.error ?? 'unknown error';
-				logEmit?.('stderr', `✗ Clone failed for ${r.short_name}: ${errMsg}`);
-				result.failed.push({ short_name: r.short_name, error: errMsg });
+				logEmit?.('stderr', `✗ Clone failed for ${name}: ${errMsg}`);
+				result.failed.push({ name, error: errMsg });
 				log.error(`Failed to clone ${r.repo_identifier}`, errMsg);
 			}
 		}
@@ -88,7 +92,6 @@ export async function ensureProjectRepos(
 }
 
 interface RepoRow {
-	short_name: string;
 	repo_identifier: string;
 }
 
@@ -96,11 +99,11 @@ export function removeRepoFromWorkspace(
 	dataDir: string,
 	teamId: string,
 	projectId: string,
-	shortName: string,
+	repoName: string,
 ): void {
-	if (!shortName || shortName.includes('/') || shortName === '..' || shortName === '.') return;
+	if (!repoName || repoName.includes('/') || repoName === '..' || repoName === '.') return;
 	const workspacePath = getWorkspacePath(dataDir, teamId, projectId);
-	const repoDir = join(workspacePath, shortName);
+	const repoDir = join(workspacePath, repoName);
 	if (existsSync(repoDir)) {
 		rmSync(repoDir, { recursive: true, force: true });
 	}
@@ -110,7 +113,7 @@ export function removeRepoFromWorkspace(
 
 	for (const entry of readdirSync(worktreesRoot, { withFileTypes: true })) {
 		if (!entry.isDirectory()) continue;
-		const repoWorktree = join(worktreesRoot, entry.name, shortName);
+		const repoWorktree = join(worktreesRoot, entry.name, repoName);
 		if (existsSync(repoWorktree)) {
 			rmSync(repoWorktree, { recursive: true, force: true });
 		}

--- a/packages/server/src/services/workspace.ts
+++ b/packages/server/src/services/workspace.ts
@@ -80,13 +80,13 @@ export function getWorktreePath(
 	dataDir: string,
 	teamId: string,
 	projectId: string,
-	repoShortName: string,
+	repoName: string,
 	branchSlug: string,
 	agentIdShort: string,
 ): string {
 	return join(
 		getWorktreesPath(dataDir, teamId, projectId),
-		`${repoShortName}-${branchSlug}-agent-${agentIdShort}`,
+		`${repoName}-${branchSlug}-agent-${agentIdShort}`,
 	);
 }
 

--- a/packages/server/test/agent-runner.test.ts
+++ b/packages/server/test/agent-runner.test.ts
@@ -817,8 +817,8 @@ describe('runAgent', () => {
 
 		it('fails the run before exec when the primary repo worktree cannot be prepared', async () => {
 			const repoRes = await db.query<{ id: string }>(
-				`INSERT INTO repos (project_id, short_name, repo_identifier, host_type)
-				 VALUES ($1, 'todos', 'acme/todos', 'github') RETURNING id`,
+				`INSERT INTO repos (project_id, repo_identifier, host_type)
+				 VALUES ($1, 'acme/todos', 'github') RETURNING id`,
 				[projectId],
 			);
 			const repoId = repoRes.rows[0].id;

--- a/packages/server/test/dispatch-wakeup-now.test.ts
+++ b/packages/server/test/dispatch-wakeup-now.test.ts
@@ -105,8 +105,8 @@ beforeAll(async () => {
 	// Pass activateAgent's designated-repo gate and container check so a run can
 	// actually launch.
 	const repoRes = await db.query<{ id: string }>(
-		`INSERT INTO repos (project_id, short_name, repo_identifier, host_type)
-		 VALUES ($1, 'test', 'test-org/test-repo', 'github'::repo_host_type)
+		`INSERT INTO repos (project_id, repo_identifier, host_type)
+		 VALUES ($1, 'test-org/test-repo', 'github'::repo_host_type)
 		 RETURNING id`,
 		[projectId],
 	);

--- a/packages/server/test/job-manager-workflows.test.ts
+++ b/packages/server/test/job-manager-workflows.test.ts
@@ -106,8 +106,8 @@ beforeAll(async () => {
 	// These tests focus on wakeup/lock lifecycle, not the designated-repo gate.
 	// Seed a designated repo on the project so the gate short-circuit is bypassed.
 	const repoRes = await db.query<{ id: string }>(
-		`INSERT INTO repos (project_id, short_name, repo_identifier, host_type)
-		 VALUES ($1, 'test', 'test-org/test-repo', 'github'::repo_host_type)
+		`INSERT INTO repos (project_id, repo_identifier, host_type)
+		 VALUES ($1, 'test-org/test-repo', 'github'::repo_host_type)
 		 RETURNING id`,
 		[projectId],
 	);

--- a/packages/server/test/oauth-connection-store.test.ts
+++ b/packages/server/test/oauth-connection-store.test.ts
@@ -144,8 +144,8 @@ describe('oauth connection store', () => {
 		const projectId = proj.rows[0].id;
 
 		const repo = await db.query<{ id: string }>(
-			`INSERT INTO repos (project_id, short_name, repo_identifier, host_type, oauth_connection_id)
-			 VALUES ($1, 'r', 'octocat/x', 'github', $2) RETURNING id`,
+			`INSERT INTO repos (project_id, repo_identifier, host_type, oauth_connection_id)
+			 VALUES ($1, 'octocat/x', 'github', $2) RETURNING id`,
 			[projectId, connectionId],
 		);
 		const repoId = repo.rows[0].id;

--- a/packages/server/test/project-docs.test.ts
+++ b/packages/server/test/project-docs.test.ts
@@ -277,8 +277,8 @@ describe('AGENTS.md (filesystem-based)', () => {
 		repoProjectId = (await projRes.json()).data.id;
 
 		const repoResult = await db.query(
-			`INSERT INTO repos (project_id, short_name, repo_identifier, host_type)
-			 VALUES ($1, 'main-app', 'org/main-app', 'github') RETURNING id`,
+			`INSERT INTO repos (project_id, repo_identifier, host_type)
+			 VALUES ($1, 'org/main-app', 'github') RETURNING id`,
 			[repoProjectId],
 		);
 		const repoId = (repoResult.rows[0] as any).id;

--- a/packages/server/test/repo-setup-finalize-multi.test.ts
+++ b/packages/server/test/repo-setup-finalize-multi.test.ts
@@ -127,8 +127,8 @@ describe('finalizePendingRepoSetup + enqueueRepoSetupResumeWakeups (multi-agent)
 			await seedDeferredWakeup(db, teamId, carolId, projectId, taskC);
 
 			const repoInsert = await db.query<{ id: string }>(
-				`INSERT INTO repos (project_id, short_name, repo_identifier, host_type)
-				 VALUES ($1, 'main', 'octo/multi', 'github') RETURNING id`,
+				`INSERT INTO repos (project_id, repo_identifier, host_type)
+				 VALUES ($1, 'octo/multi', 'github') RETURNING id`,
 				[projectId],
 			);
 
@@ -137,7 +137,6 @@ describe('finalizePendingRepoSetup + enqueueRepoSetupResumeWakeups (multi-agent)
 				projectId,
 				repoId: repoInsert.rows[0].id,
 				repoIdentifier: 'octo/multi',
-				shortName: 'main',
 			});
 
 			expect(result.resolvedApprovalId).toBe(approvalId);
@@ -210,7 +209,6 @@ describe('finalizePendingRepoSetup + enqueueRepoSetupResumeWakeups (multi-agent)
 				projectId,
 				repoId: '00000000-0000-0000-0000-000000000000',
 				repoIdentifier: 'octo/none',
-				shortName: 'main',
 			});
 
 			expect(result.resolvedApprovalId).toBeNull();

--- a/packages/server/test/repo-sync.test.ts
+++ b/packages/server/test/repo-sync.test.ts
@@ -66,8 +66,8 @@ describe('ensureProjectRepos', () => {
 	it('skips repos whose target dir already contains .git', async () => {
 		// Insert a repo record directly; emulate an existing clone by creating .git.
 		await db.query(
-			`INSERT INTO repos (project_id, short_name, repo_identifier, host_type)
-			 VALUES ($1, 'preexisting', 'owner/preexisting', 'github'::repo_host_type)`,
+			`INSERT INTO repos (project_id, repo_identifier, host_type)
+			 VALUES ($1, 'owner/preexisting', 'github'::repo_host_type)`,
 			[projectId],
 		);
 
@@ -110,7 +110,7 @@ describe('removeRepoFromWorkspace', () => {
 		expect(existsSync(wtDir2)).toBe(false);
 	});
 
-	it('is a no-op for dangerous short_name values', () => {
+	it('is a no-op for dangerous repo name values', () => {
 		const workspacePath = join(dataDir, 'teams', teamId, 'projects', projectId, 'workspace');
 		const stayDir = join(workspacePath, 'stay');
 		mkdirSync(stayDir, { recursive: true });

--- a/packages/server/test/repos-create-github.test.ts
+++ b/packages/server/test/repos-create-github.test.ts
@@ -101,7 +101,6 @@ describe('POST /api/projects/:projectId/repos with mode=create', () => {
 			method: 'POST',
 			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
 			body: JSON.stringify({
-				short_name: 'collision',
 				mode: 'create',
 				owner: 'octo-repo',
 				name: 'already-taken',
@@ -126,7 +125,7 @@ describe('POST /api/projects/:projectId/repos with mode=create', () => {
 // POST /repos clones over SSH after the insert; the test app has no
 // SshAgentServer, so emulate an existing clone (repo-sync skips dirs that
 // already contain .git) to keep the success path quiet and deterministic.
-function fakeClonedRepoDir(shortName: string) {
+function fakeClonedRepoDir(repoName: string) {
 	const gitDir = join(
 		dataDir,
 		'teams',
@@ -134,7 +133,7 @@ function fakeClonedRepoDir(shortName: string) {
 		'projects',
 		projectId,
 		'workspace',
-		shortName,
+		repoName,
 		'.git',
 	);
 	mkdirSync(gitDir, { recursive: true });
@@ -151,13 +150,12 @@ describe('repo creation, first-repo designation, and designated immutability', (
 			`UPDATE projects SET container_id = 'test-container', container_status = 'running' WHERE id = $1`,
 			[projectId],
 		);
-		fakeClonedRepoDir('svc');
+		fakeClonedRepoDir('fresh-service');
 
 		const res = await app.request(`/api/projects/${projectId}/repos`, {
 			method: 'POST',
 			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
 			body: JSON.stringify({
-				short_name: 'svc',
 				mode: 'create',
 				owner: 'octo-repo',
 				name: 'fresh-service',
@@ -183,13 +181,12 @@ describe('repo creation, first-repo designation, and designated immutability', (
 	});
 
 	it('mode=link adds a second repo without re-designating', async () => {
-		fakeClonedRepoDir('second');
+		fakeClonedRepoDir('already-taken');
 
 		const res = await app.request(`/api/projects/${projectId}/repos`, {
 			method: 'POST',
 			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
 			body: JSON.stringify({
-				short_name: 'second',
 				mode: 'link',
 				url: 'https://github.com/octo-repo/already-taken',
 				oauth_connection_id: oauthConnectionId,

--- a/packages/server/test/repos.test.ts
+++ b/packages/server/test/repos.test.ts
@@ -59,7 +59,7 @@ describe('repos CRUD', () => {
 		const res = await app.request(`/api/projects/${projectId}/repos`, {
 			method: 'POST',
 			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({ short_name: 'bad', url: 'not-a-url' }),
+			body: JSON.stringify({ url: 'not-a-url' }),
 		});
 		expect(res.status).toBe(400);
 		const body = await res.json();
@@ -70,7 +70,7 @@ describe('repos CRUD', () => {
 		const res = await app.request(`/api/projects/${projectId}/repos`, {
 			method: 'POST',
 			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({ short_name: 'x' }),
+			body: JSON.stringify({}),
 		});
 		expect(res.status).toBe(400);
 	});
@@ -78,8 +78,8 @@ describe('repos CRUD', () => {
 	it('deletes a repo', async () => {
 		// Insert a repo directly for deletion test
 		const insertResult = await db.query<{ id: string }>(
-			`INSERT INTO repos (project_id, short_name, repo_identifier, host_type)
-			 VALUES ($1, 'to-delete', 'acme/to-delete', 'github') RETURNING id`,
+			`INSERT INTO repos (project_id, repo_identifier, host_type)
+			 VALUES ($1, 'acme/to-delete', 'github') RETURNING id`,
 			[projectId],
 		);
 		const repoId = insertResult.rows[0].id;
@@ -101,21 +101,22 @@ describe('repos CRUD', () => {
 		expect(res.status).toBe(404);
 	});
 
-	it('enforces unique short_name within project', async () => {
+	it('enforces unique repo name within project, even across owners', async () => {
 		await db.query(
-			`INSERT INTO repos (project_id, short_name, repo_identifier, host_type)
-			 VALUES ($1, 'unique-test', 'acme/unique-test', 'github')`,
+			`INSERT INTO repos (project_id, repo_identifier, host_type)
+			 VALUES ($1, 'acme/unique-test', 'github')`,
 			[projectId],
 		);
 
-		// Trying to insert the same short_name should fail at DB level
+		// A repo with the same name under a different owner would clash on the
+		// workspace directory, so the DB must reject it.
 		try {
 			await db.query(
-				`INSERT INTO repos (project_id, short_name, repo_identifier, host_type)
-				 VALUES ($1, 'unique-test', 'acme/other-repo', 'github')`,
+				`INSERT INTO repos (project_id, repo_identifier, host_type)
+				 VALUES ($1, 'other-org/unique-test', 'github')`,
 				[projectId],
 			);
-			expect.fail('Should have thrown on duplicate short_name');
+			expect.fail('Should have thrown on duplicate repo name');
 		} catch (e: any) {
 			expect(e.message).toContain('unique');
 		}

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -44,6 +44,18 @@ export const wsRoom = {
 } as const;
 
 /**
+ * The repository's own name — the segment after the owner in an `owner/name`
+ * identifier. Serves as the repo's display label and as its directory name
+ * under the project workspace and per-task worktrees. Must match the SQL
+ * expression `split_part(repo_identifier, '/', 2)` used by the per-project
+ * uniqueness index on repos.
+ */
+export function repoNameFromIdentifier(repoIdentifier: string): string {
+	const slash = repoIdentifier.indexOf('/');
+	return slash === -1 ? repoIdentifier : repoIdentifier.slice(slash + 1);
+}
+
+/**
  * Conventional-commit type → changelog heading, in render order. Single source
  * of truth shared by the release script and its tests. Commit types not listed
  * here (and non-conventional commits) fall into the "Other" section.

--- a/packages/web/src/components/comment-content.ts
+++ b/packages/web/src/components/comment-content.ts
@@ -154,7 +154,6 @@ export interface ActionChosen {
 	result?: {
 		repo_id?: string;
 		repo_identifier?: string;
-		short_name?: string;
 	};
 }
 

--- a/packages/web/src/components/github-section.tsx
+++ b/packages/web/src/components/github-section.tsx
@@ -1,3 +1,4 @@
+import { repoNameFromIdentifier } from '@hezo/shared';
 import { useQueryClient } from '@tanstack/react-query';
 import { AlertTriangle, GitBranch, Github, Loader2, Lock, Trash2 } from 'lucide-react';
 import { useState } from 'react';
@@ -170,56 +171,59 @@ export function GitHubSection({ projectId }: GitHubSectionProps) {
 			<div className="mt-4">
 				{hasRepos ? (
 					<div className="flex flex-col gap-2">
-						{repos?.map((r) => (
-							<div
-								key={r.id}
-								className="flex items-center justify-between rounded-md border border-border-subtle bg-bg px-3 py-2 text-sm"
-							>
-								<div className="flex items-center gap-2">
-									<Badge color="gray">{r.host_type}</Badge>
-									<span className="font-medium">{r.short_name}</span>
-									{(() => {
-										const url = repoWebUrl(r.repo_identifier, r.host_type);
-										return url ? (
-											<a
-												href={url}
-												target="_blank"
-												rel="noopener noreferrer"
-												className="text-accent-blue-text hover:underline"
-												data-testid={`repo-link-${r.short_name}`}
+						{repos?.map((r) => {
+							const repoName = repoNameFromIdentifier(r.repo_identifier);
+							return (
+								<div
+									key={r.id}
+									className="flex items-center justify-between rounded-md border border-border-subtle bg-bg px-3 py-2 text-sm"
+								>
+									<div className="flex items-center gap-2">
+										<Badge color="gray">{r.host_type}</Badge>
+										<span className="font-medium">{repoName}</span>
+										{(() => {
+											const url = repoWebUrl(r.repo_identifier, r.host_type);
+											return url ? (
+												<a
+													href={url}
+													target="_blank"
+													rel="noopener noreferrer"
+													className="text-accent-blue-text hover:underline"
+													data-testid={`repo-link-${repoName}`}
+												>
+													{r.repo_identifier}
+												</a>
+											) : (
+												<span className="text-text-muted">{r.repo_identifier}</span>
+											);
+										})()}
+										{r.is_designated && <Badge color="blue">Designated</Badge>}
+									</div>
+									{r.is_designated ? (
+										<Tooltip content="Designated repository cannot be removed">
+											<span
+												role="img"
+												aria-label="Designated repository cannot be removed"
+												className="text-text-subtle"
+												data-testid={`repo-locked-${repoName}`}
 											>
-												{r.repo_identifier}
-											</a>
-										) : (
-											<span className="text-text-muted">{r.repo_identifier}</span>
-										);
-									})()}
-									{r.is_designated && <Badge color="blue">Designated</Badge>}
-								</div>
-								{r.is_designated ? (
-									<Tooltip content="Designated repository cannot be removed">
-										<span
-											role="img"
-											aria-label="Designated repository cannot be removed"
-											className="text-text-subtle"
-											data-testid={`repo-locked-${r.short_name}`}
+												<Lock className="w-3.5 h-3.5" />
+											</span>
+										</Tooltip>
+									) : (
+										<button
+											type="button"
+											onClick={() => deleteRepo.mutate(r.id)}
+											className="text-text-subtle hover:text-accent-red"
+											aria-label={`Remove repo ${repoName}`}
+											data-testid={`repo-delete-${repoName}`}
 										>
-											<Lock className="w-3.5 h-3.5" />
-										</span>
-									</Tooltip>
-								) : (
-									<button
-										type="button"
-										onClick={() => deleteRepo.mutate(r.id)}
-										className="text-text-subtle hover:text-accent-red"
-										aria-label={`Remove repo ${r.short_name}`}
-										data-testid={`repo-delete-${r.short_name}`}
-									>
-										<Trash2 className="w-3.5 h-3.5" />
-									</button>
-								)}
-							</div>
-						))}
+											<Trash2 className="w-3.5 h-3.5" />
+										</button>
+									)}
+								</div>
+							);
+						})}
 					</div>
 				) : (
 					isReady && (

--- a/packages/web/src/components/repo-picker-modal.tsx
+++ b/packages/web/src/components/repo-picker-modal.tsx
@@ -1,6 +1,6 @@
 import * as Dialog from '@radix-ui/react-dialog';
 import { GitBranch, Loader2, Lock } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
 	type GitHubRepoSummary,
 	useCreateRepo,
@@ -29,15 +29,6 @@ function isApiError(e: unknown): e is ApiError {
 	return typeof e === 'object' && e !== null && 'code' in e && 'message' in e && 'status' in e;
 }
 
-function slugify(value: string): string {
-	return value
-		.toLowerCase()
-		.trim()
-		.replace(/[^a-z0-9]+/g, '-')
-		.replace(/^-+|-+$/g, '')
-		.slice(0, 40);
-}
-
 export function RepoPickerModal({
 	open,
 	onOpenChange,
@@ -49,8 +40,6 @@ export function RepoPickerModal({
 	const [search, setSearch] = useState('');
 	const [debouncedSearch, setDebouncedSearch] = useState('');
 	const [selectedRepoFullName, setSelectedRepoFullName] = useState<string | null>(null);
-	const [shortName, setShortName] = useState('');
-	const [shortNameTouched, setShortNameTouched] = useState(false);
 	const [newRepoName, setNewRepoName] = useState('');
 	const [newRepoPrivate, setNewRepoPrivate] = useState(true);
 	const [createError, setCreateError] = useState<CreateError | null>(null);
@@ -66,8 +55,6 @@ export function RepoPickerModal({
 			setSearch('');
 			setDebouncedSearch('');
 			setSelectedRepoFullName(null);
-			setShortName('');
-			setShortNameTouched(false);
 			setNewRepoName('');
 			setNewRepoPrivate(true);
 			setCreateError(null);
@@ -84,19 +71,8 @@ export function RepoPickerModal({
 		if (orgs && orgs.length > 0 && !owner) setOwner(orgs[0].login);
 	}, [orgsQuery.data, owner]);
 
-	const derivedShortName = useMemo(() => {
-		if (mode === 'link') {
-			const sel = reposQuery.data?.find((r) => r.full_name === selectedRepoFullName);
-			return sel ? slugify(sel.name) : '';
-		}
-		return slugify(newRepoName);
-	}, [mode, selectedRepoFullName, newRepoName, reposQuery.data]);
-
-	const effectiveShortName = shortNameTouched ? shortName : derivedShortName;
-
 	const canSubmit =
 		!createRepo.isPending &&
-		!!effectiveShortName.trim() &&
 		!!owner &&
 		(mode === 'link' ? !!selectedRepoFullName : !!newRepoName.trim());
 
@@ -109,14 +85,12 @@ export function RepoPickerModal({
 				const sel = reposQuery.data?.find((r) => r.full_name === selectedRepoFullName);
 				if (!sel) return;
 				await createRepo.mutateAsync({
-					short_name: effectiveShortName.trim(),
 					mode: 'link',
 					url: `https://github.com/${sel.full_name}`,
 					oauth_connection_id: oauthConnectionId,
 				});
 			} else {
 				await createRepo.mutateAsync({
-					short_name: effectiveShortName.trim(),
 					mode: 'create',
 					owner,
 					name: newRepoName.trim(),
@@ -141,7 +115,6 @@ export function RepoPickerModal({
 		setSearch(targetName);
 		setDebouncedSearch(targetName);
 		setSelectedRepoFullName(`${targetOwner}/${targetName}`);
-		setShortNameTouched(false);
 		setCreateError(null);
 	}
 
@@ -276,17 +249,6 @@ export function RepoPickerModal({
 								</label>
 							</>
 						)}
-
-						<Input
-							label="Short name"
-							placeholder={derivedShortName || 'api'}
-							value={effectiveShortName}
-							onChange={(e) => {
-								setShortNameTouched(true);
-								setShortName(e.target.value);
-							}}
-							required
-						/>
 
 						{createError?.kind === 'generic' && (
 							<div className="rounded-radius-md border border-accent-red/40 bg-accent-red/10 px-3 py-2 text-sm text-accent-red">

--- a/packages/web/src/hooks/use-projects.ts
+++ b/packages/web/src/hooks/use-projects.ts
@@ -34,7 +34,6 @@ export interface Project {
 export interface Repo {
 	id: string;
 	project_id: string;
-	short_name: string;
 	repo_identifier: string;
 	host_type: string;
 	created_at: string;

--- a/packages/web/src/hooks/use-repos.ts
+++ b/packages/web/src/hooks/use-repos.ts
@@ -5,7 +5,6 @@ import { queryKeys } from '../lib/query-keys';
 import type { Repo } from './use-projects';
 
 export interface CreateRepoPayload {
-	short_name: string;
 	mode?: 'link' | 'create';
 	url?: string;
 	owner?: string;

--- a/packages/web/test/helpers/render.tsx
+++ b/packages/web/test/helpers/render.tsx
@@ -44,7 +44,7 @@ interface TestAppContext {
 	db: Awaited<ReturnType<typeof createTestApp>>['db'];
 	masterKeyManager: Awaited<ReturnType<typeof createTestApp>>['masterKeyManager'];
 	// Per-test temp dir backing the server's workspace/worktree layout. Lets
-	// specs pre-create `workspace/<short_name>/.git` so repo-sync treats a repo
+	// specs pre-create `workspace/<repo name>/.git` so repo-sync treats a repo
 	// as already cloned instead of attempting a real SSH clone.
 	dataDir: string;
 }

--- a/packages/web/test/repo-picker-flows.test.tsx
+++ b/packages/web/test/repo-picker-flows.test.tsx
@@ -71,7 +71,7 @@ async function seedGitHubOAuth(): Promise<string> {
 // SshAgentServer, so emulate an existing clone (repo-sync skips dirs that
 // already contain .git) and mark the container running so the post-designation
 // container auto-start is a no-op. Keeps the success path quiet and green.
-async function neutralizeRepoSideEffects(teamId: string, projectId: string, shortName: string) {
+async function neutralizeRepoSideEffects(teamId: string, projectId: string, repoName: string) {
 	const { db, dataDir } = getTestContext();
 	const gitDir = join(
 		dataDir,
@@ -80,7 +80,7 @@ async function neutralizeRepoSideEffects(teamId: string, projectId: string, shor
 		'projects',
 		projectId,
 		'workspace',
-		shortName,
+		repoName,
 		'.git',
 	);
 	mkdirSync(gitDir, { recursive: true });
@@ -197,13 +197,13 @@ test('designated repo shows a lock with no delete affordance; extras stay deleta
 
 			const { db } = getTestContext();
 			const designated = await db.query<{ id: string }>(
-				`INSERT INTO repos (project_id, short_name, repo_identifier, host_type)
-				 VALUES ($1, 'main-repo', $2, 'github') RETURNING id`,
+				`INSERT INTO repos (project_id, repo_identifier, host_type)
+				 VALUES ($1, $2, 'github') RETURNING id`,
 				[project.id, `${ghOwner}/main-repo`],
 			);
 			await db.query(
-				`INSERT INTO repos (project_id, short_name, repo_identifier, host_type)
-				 VALUES ($1, 'extra-repo', $2, 'github')`,
+				`INSERT INTO repos (project_id, repo_identifier, host_type)
+				 VALUES ($1, $2, 'github')`,
 				[project.id, `${ghOwner}/extra-repo`],
 			);
 			await db.query('UPDATE projects SET designated_repo_id = $1 WHERE id = $2', [


### PR DESCRIPTION
Removes the user-supplied "Short name" from the git repository form and the `short_name` field end-to-end. The repository's own name — the segment after the owner in the `org/repo` identifier — now serves as the display label, the @-mention handle, and the workspace/worktree directory name, derived everywhere via the new shared `repoNameFromIdentifier()` helper.

## Changes

**Schema** (`001_initial_schema.sql`, modified in place per pre-v1 convention)
- Drop `repos.short_name`
- Replace `UNIQUE(project_id, short_name)` with a unique expression index on `(project_id, split_part(repo_identifier, '/', 2))` — directory names stay unique within a project even across owners, and the same repo can't be linked twice

**Server**
- `POST /projects/:projectId/repos` no longer accepts/requires `short_name`; a duplicate repo name returns `409 REPO_NAME_TAKEN`
- `repo-sync`, `agent-runner` worktree prep, repo deletion cleanup, and the AGENTS.md path resolution all derive the directory name from `repo_identifier`
- `finalizePendingRepoSetup` and the setup-repo action-comment result drop the `short_name` field

**Web**
- Repo picker modal: "Short name" input removed along with its derived-slug state; submit just sends the link/create payload
- Project settings repo list derives its label and testids from the repo identifier

**Docs**
- `.dev/spec.md`, `schema.md`, `api.md`, `implementation-phases.md` updated to describe the derived-name behavior

## Tests
- `repos.test.ts` uniqueness test now exercises the cross-owner name clash (`acme/unique-test` vs `other-org/unique-test`)
- All repo-related server suites and the `repo-picker-flows` component suite updated for the removed column and pass
- Full `--skip-browser` run green except `git.test.ts` / `ssh-agent-server.test.ts`, which fail identically on a clean checkout in this sandbox (environmental, unrelated)

https://claude.ai/code/session_01TADTaB3m5JtruRkRVinmqc

---
_Generated by [Claude Code](https://claude.ai/code/session_01TADTaB3m5JtruRkRVinmqc)_