### PR TITLE
feat: render CEO chat entity references as links with per-channel renderer abstraction

### DIFF
--- a/.dev/api.md
+++ b/.dev/api.md
@@ -1453,6 +1453,41 @@ Return the models this provider offers for the stored credential. Calls the prov
 
 ---
 
+### Instance Settings
+
+Instance-wide settings live in the `system_meta` key-value table. The only setting today is the **instance base URL** — the public origin of this Hezo instance (e.g. `https://hezo.example.com`), used to build absolute entity links for external chat channels (Telegram). It is captured automatically from the request origin (`host` + first `x-forwarded-proto` entry) on the first successful `POST /auth/token` unlock and never overwritten after that; it stays editable on the global settings page.
+
+#### `GET /instance-settings`
+Returns `{ base_url: string | null }`. Any authenticated principal.
+
+#### `PATCH /instance-settings`
+Superuser only. Request: `{ "base_url": "https://hezo.example.com" }`. The value must be a bare http(s) origin — anything with a path, query, fragment, or credentials is rejected with `INVALID_REQUEST` — and is normalised to `URL.origin` (lowercased host, trailing slash dropped). Send `null` or `""` to clear. Echoes the stored value.
+
+---
+
+### Instance-wide mention resolution
+
+#### `POST /mentions/resolve`
+Resolution backing the global CEO chat's entity links (the project-scoped equivalents are `POST /projects/:projectId/tasks/resolve` and `POST /projects/:projectId/docs/resolve`). Gated on HQ-team access, exactly like the `/ceo/*` routes.
+
+Request — all fields optional string arrays, max 100 entries each (case-insensitive for tasks/agents, exact-case for filenames/assets):
+```json
+{
+  "tasks": ["to-1"],
+  "filenames": ["prd.md"],
+  "assets": ["mock.png"],
+  "agents": ["ceo"]
+}
+```
+
+Response: `{ tasks, kb_docs, project_docs, assets, agents }` mirroring the project-scoped resolve shapes (`assets` rows carry a `signed_url`; `agents` rows carry `{ slug, title, project_slug }` with HQ agents resolving to the `hq` project).
+
+**Uniqueness rule:** candidates are matched across every team, and a reference resolves only when it is unique instance-wide — task identifiers are unique per team but can collide across teams, and doc filenames / asset names / agent slugs collide commonly (every Startup team has a `captain`). Ambiguous or unknown references are omitted so the client renders them as plain text; a wrong link is worse than no link. Skills (KB docs) are instance-global and slug-unique, so they always resolve. Disabled agents are ignored.
+
+The per-channel rendering seam for stored CEO messages is `renderCeoMessageForChannel` (`packages/server/src/services/ceo-message-render.ts`): `web` returns content unchanged (the web client resolves and renders links itself), `telegram` rewrites unique references into absolute markdown links built from the instance base URL, `whatsapp` stays plain text. Stored `ceo_messages.content` is never mutated.
+
+---
+
 ### Execution Locks
 
 #### `GET /projects/:projectId/tasks/:taskId/lock`

--- a/agents/_instance/ceo.md
+++ b/agents/_instance/ceo.md
@@ -20,7 +20,7 @@ You live in **HQ**, the instance-level coordination project. You are the only ag
 
 Beyond coordination tickets, the operator talks to you directly — in a live chat box, or by opening a ticket in HQ addressed to you. Treat both the same: work out what they are trying to achieve and route it to the right level of work. Your job here is to figure out the best way to solve the operator's problem and make the call between answering in place, opening a trackable ticket, and standing up a project.
 
-In the live chat box you are talking to a human, so write for a human: refer to projects, tickets, and teams by their **slug, identifier, or name** (e.g. the project `todo6`, ticket `TO-1`, team `todo6`) — never paste raw UUIDs. UUIDs are for tool arguments only; the person reading the chat thinks in names.
+In the live chat box you are talking to a human, so write for a human: refer to projects, tickets, teams, docs, and teammates by their **bare slug, identifier, or name** (e.g. the project todo6, ticket TO-1, prd.md, @@captain) — never paste raw UUIDs. UUIDs are for tool arguments only; the person reading the chat thinks in names. The linking rules below apply in chat exactly as in comments: bare references render as clickable links, while backticked ones render as inert code and break navigation — never wrap an entity reference in backticks.
 
 - **General questions** — answer directly, in place. No ticket needed for a quick answer or explanation.
 - **Anything about an existing project** — work *through that project* and its Captain. Read and act across the project as needed; for anything substantial, open (or have the Captain open) a ticket in that project so the work is tracked, rather than doing it all inline.

--- a/packages/server/src/lib/request-origin.ts
+++ b/packages/server/src/lib/request-origin.ts
@@ -1,0 +1,13 @@
+import type { Context } from 'hono';
+import type { Env } from './types';
+
+/**
+ * The origin the client used to reach this instance, honoring reverse-proxy
+ * forwarding headers. `x-forwarded-proto` may be a comma-separated chain when
+ * multiple proxies are involved; the first entry is the client-facing scheme.
+ */
+export function requestOrigin(c: Context<Env>): string {
+	const proto = (c.req.header('x-forwarded-proto') ?? 'http').split(',')[0].trim() || 'http';
+	const host = c.req.header('host') ?? 'localhost';
+	return `${proto}://${host}`;
+}

--- a/packages/server/src/lib/system-meta.ts
+++ b/packages/server/src/lib/system-meta.ts
@@ -1,0 +1,57 @@
+import type { PGlite } from '@electric-sql/pglite';
+
+/**
+ * Instance-wide key-value settings stored in the `system_meta` table (the same
+ * store the master-key canary lives in).
+ */
+
+export const INSTANCE_BASE_URL_KEY = 'instance_base_url';
+
+export async function getSystemMeta(db: PGlite, key: string): Promise<string | null> {
+	const result = await db.query<{ value: string }>('SELECT value FROM system_meta WHERE key = $1', [
+		key,
+	]);
+	return result.rows[0]?.value ?? null;
+}
+
+export async function setSystemMeta(db: PGlite, key: string, value: string): Promise<void> {
+	await db.query(
+		`INSERT INTO system_meta (key, value) VALUES ($1, $2)
+		 ON CONFLICT (key) DO UPDATE SET value = $2`,
+		[key, value],
+	);
+}
+
+export async function deleteSystemMeta(db: PGlite, key: string): Promise<void> {
+	await db.query('DELETE FROM system_meta WHERE key = $1', [key]);
+}
+
+/**
+ * The public base URL of this instance (e.g. `https://hezo.example.com`),
+ * captured from the first authenticated request during setup and editable in
+ * global settings. Used to build absolute links for external channels
+ * (Telegram, …); null until captured or configured.
+ */
+export function getInstanceBaseUrl(db: PGlite): Promise<string | null> {
+	return getSystemMeta(db, INSTANCE_BASE_URL_KEY);
+}
+
+/**
+ * Validates and normalizes a base URL to a bare http(s) origin. Rejects
+ * anything with a path, query, fragment, or credentials — entity paths are
+ * appended verbatim, so a path prefix would silently break every link.
+ * Returns null when invalid.
+ */
+export function normalizeBaseUrl(raw: string): string | null {
+	let url: URL;
+	try {
+		url = new URL(raw);
+	} catch {
+		return null;
+	}
+	if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+	if (url.pathname !== '' && url.pathname !== '/') return null;
+	if (url.search !== '' || url.hash !== '') return null;
+	if (url.username !== '' || url.password !== '') return null;
+	return url.origin;
+}

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -1,8 +1,18 @@
 import { DEFAULT_TEAM_ID, MemberType } from '@hezo/shared';
 import { Hono } from 'hono';
+import { requestOrigin } from '../lib/request-origin';
 import { err, ok } from '../lib/response';
+import {
+	getSystemMeta,
+	INSTANCE_BASE_URL_KEY,
+	normalizeBaseUrl,
+	setSystemMeta,
+} from '../lib/system-meta';
 import type { Env } from '../lib/types';
+import { logger } from '../logger';
 import { signAdminJwt } from '../middleware/auth';
+
+const log = logger.child('routes');
 
 export const authRoutes = new Hono<Env>();
 
@@ -20,6 +30,19 @@ authRoutes.post('/auth/token', async (c) => {
 
 	if (!unlocked) {
 		return err(c, 'UNAUTHORIZED', 'Invalid master key', 401);
+	}
+
+	// Capture the public base URL of this instance from the URL the operator
+	// used to reach it. Only when unset — a configured or previously captured
+	// value is never clobbered (it stays editable in global settings). Awaited
+	// so the settings page the operator lands on next reflects it.
+	try {
+		if (!(await getSystemMeta(db, INSTANCE_BASE_URL_KEY))) {
+			const origin = normalizeBaseUrl(requestOrigin(c));
+			if (origin) await setSystemMeta(db, INSTANCE_BASE_URL_KEY, origin);
+		}
+	} catch (e) {
+		log.error('Failed to capture instance base URL:', e);
 	}
 
 	const existing = await db.query<{ id: string }>(

--- a/packages/server/src/routes/instance-settings.ts
+++ b/packages/server/src/routes/instance-settings.ts
@@ -1,0 +1,52 @@
+import { Hono } from 'hono';
+import { err, ok } from '../lib/response';
+import {
+	deleteSystemMeta,
+	getInstanceBaseUrl,
+	INSTANCE_BASE_URL_KEY,
+	normalizeBaseUrl,
+	setSystemMeta,
+} from '../lib/system-meta';
+import type { Env } from '../lib/types';
+import { requireSuperuser } from '../middleware/auth';
+
+export const instanceSettingsRoutes = new Hono<Env>();
+
+// Instance-wide settings. Readable by any authenticated principal (the same
+// openness as GET /api/ai-providers); writes are superuser-only.
+instanceSettingsRoutes.get('/instance-settings', async (c) => {
+	const base_url = await getInstanceBaseUrl(c.get('db'));
+	return ok(c, { base_url });
+});
+
+instanceSettingsRoutes.patch('/instance-settings', async (c) => {
+	const denied = requireSuperuser(c);
+	if (denied) return denied;
+
+	const db = c.get('db');
+	const body = await c.req
+		.json<{ base_url?: unknown }>()
+		.catch(() => ({}) as { base_url?: unknown });
+
+	if (!('base_url' in body)) {
+		return err(c, 'INVALID_REQUEST', 'base_url is required', 400);
+	}
+	if (body.base_url === null || body.base_url === '') {
+		await deleteSystemMeta(db, INSTANCE_BASE_URL_KEY);
+		return ok(c, { base_url: null });
+	}
+	if (typeof body.base_url !== 'string') {
+		return err(c, 'INVALID_REQUEST', 'base_url must be a string or null', 400);
+	}
+	const normalized = normalizeBaseUrl(body.base_url.trim());
+	if (!normalized) {
+		return err(
+			c,
+			'INVALID_REQUEST',
+			'base_url must be an http(s) origin without path, query, or fragment',
+			400,
+		);
+	}
+	await setSystemMeta(db, INSTANCE_BASE_URL_KEY, normalized);
+	return ok(c, { base_url: normalized });
+});

--- a/packages/server/src/routes/mentions.ts
+++ b/packages/server/src/routes/mentions.ts
@@ -1,8 +1,10 @@
-import { ADMIN_MENTION_SLUG } from '@hezo/shared';
+import { ADMIN_MENTION_SLUG, DEFAULT_TEAM_ID, type MentionCandidates } from '@hezo/shared';
 import { Hono } from 'hono';
 import { signAssetUrl } from '../lib/asset-urls';
 import { err, ok } from '../lib/response';
 import type { Env } from '../lib/types';
+import { requireTeamAccessForResource } from '../middleware/auth';
+import { resolveInstanceMentions } from '../services/instance-mentions';
 
 export const mentionsRoutes = new Hono<Env>();
 
@@ -21,6 +23,63 @@ interface SearchResult {
 	label: string;
 	sublabel?: string;
 }
+
+// Instance-wide resolution for the global CEO chat. No `:projectId` in the
+// path, so the project-access middleware does not apply — access is gated on
+// the HQ team exactly like the /ceo/* routes. References resolve only when
+// unique across the whole instance (see resolveInstanceMentions).
+mentionsRoutes.post('/mentions/resolve', async (c) => {
+	const db = c.get('db');
+	const access = await requireTeamAccessForResource(db, c, DEFAULT_TEAM_ID);
+	if (access instanceof Response) return access;
+
+	const body = await c.req.json<{
+		tasks?: unknown;
+		filenames?: unknown;
+		assets?: unknown;
+		agents?: unknown;
+	}>();
+
+	const parseStrings = (raw: unknown, lowercase: boolean): string[] | null => {
+		if (raw === undefined) return [];
+		if (!Array.isArray(raw)) return null;
+		if (raw.length > 100) return null;
+		const out = new Set<string>();
+		for (const entry of raw) {
+			if (typeof entry !== 'string') continue;
+			const trimmed = entry.trim();
+			if (!trimmed) continue;
+			out.add(lowercase ? trimmed.toLowerCase() : trimmed);
+		}
+		return Array.from(out);
+	};
+
+	const tasks = parseStrings(body.tasks, true);
+	const filenames = parseStrings(body.filenames, false);
+	const assets = parseStrings(body.assets, false);
+	const agents = parseStrings(body.agents, true);
+	if (!tasks || !filenames || !assets || !agents) {
+		return err(
+			c,
+			'INVALID_REQUEST',
+			'tasks / filenames / assets / agents must be string arrays of at most 100 entries',
+			400,
+		);
+	}
+
+	const candidates: MentionCandidates = { tasks, filenames, assets, agents };
+	const resolution = await resolveInstanceMentions(db, candidates);
+
+	const masterKeyManager = c.get('masterKeyManager');
+	const signedAssets = await Promise.all(
+		resolution.assets.map(async (a) => ({
+			...a,
+			signed_url: await signAssetUrl(a.id, masterKeyManager),
+		})),
+	);
+
+	return ok(c, { ...resolution, assets: signedAssets });
+});
 
 mentionsRoutes.post('/projects/:projectId/docs/resolve', async (c) => {
 	const teamId = c.get('teamId') as string;

--- a/packages/server/src/routes/oauth.ts
+++ b/packages/server/src/routes/oauth.ts
@@ -8,6 +8,7 @@ import {
 import { Hono } from 'hono';
 import { trackBackground } from '../lib/background';
 import { broadcastChange } from '../lib/broadcast';
+import { requestOrigin } from '../lib/request-origin';
 import { err, ok } from '../lib/response';
 import type { Env } from '../lib/types';
 import { logger } from '../logger';
@@ -219,9 +220,7 @@ oauthRoutes.post('/projects/:projectId/oauth/auth-code/start', async (c) => {
 		scopes = body.scopes ?? (body.manual_config as ManualOAuthConfig).scopes;
 	}
 
-	const protocol = c.req.header('x-forwarded-proto') ?? 'http';
-	const host = c.req.header('host') ?? 'localhost';
-	const redirectUri = `${protocol}://${host}/api/oauth/callback`;
+	const redirectUri = `${requestOrigin(c)}/api/oauth/callback`;
 
 	const { state, codeChallenge } = await signState(masterKeyManager, {
 		teamId: teamId,
@@ -318,9 +317,7 @@ async function startConnectorAuthCode(
 			status: 400,
 		};
 
-	const protocol = c.req.header('x-forwarded-proto') ?? 'http';
-	const host = c.req.header('host') ?? 'localhost';
-	const redirectUri = `${protocol}://${host}/api/oauth/mcp-callback`;
+	const redirectUri = `${requestOrigin(c)}/api/oauth/mcp-callback`;
 
 	const capability = getConnectorCapability(connector.name);
 

--- a/packages/server/src/services/ceo-message-render.ts
+++ b/packages/server/src/services/ceo-message-render.ts
@@ -1,0 +1,96 @@
+import type { PGlite } from '@electric-sql/pglite';
+import {
+	ADMIN_MENTION_SLUG,
+	agentPath,
+	assetPath,
+	CeoChannel,
+	commentPath,
+	extractMentionCandidates,
+	GLOBAL_INBOX_PATH,
+	projectDocPath,
+	SKILLS_SETTINGS_PATH,
+	taskPath,
+	transformMentionsOutsideCode,
+} from '@hezo/shared';
+import { getInstanceBaseUrl } from '../lib/system-meta';
+import { resolveInstanceMentions } from './instance-mentions';
+
+/**
+ * Renders a stored CEO message (canonical bare-reference markdown, per
+ * agents/_partials/common/linking-syntax.md) for a delivery channel. Stored
+ * `ceo_messages.content` is NEVER rewritten — rendering happens at the
+ * consumption edge, so each channel decides how references appear:
+ *
+ * - `web`      → returned unchanged. The web client resolves references itself
+ *               and renders them as client-side router links.
+ * - `telegram` → instance-unique references become standard markdown links
+ *               `[ref](<base URL><entity path>)` using the instance base URL
+ *               from global settings. NOTE for the future bot transport:
+ *               Telegram parse modes are MarkdownV2/HTML and MarkdownV2
+ *               requires escaping `_*[]()~\`>#+-=|{}.!` outside entities —
+ *               this module emits plain CommonMark; conversion/escaping is the
+ *               transport layer's job.
+ * - `whatsapp` → returned unchanged (plain-text policy: no links injected).
+ *
+ * Fallbacks: base URL unset → unchanged; unknown or instance-ambiguous
+ * references stay bare text; references inside code fences and inline code are
+ * never touched.
+ */
+export async function renderCeoMessageForChannel(
+	db: PGlite,
+	content: string,
+	channel: CeoChannel,
+): Promise<string> {
+	if (channel !== CeoChannel.Telegram) return content;
+
+	const baseUrl = await getInstanceBaseUrl(db);
+	if (!baseUrl) return content;
+
+	const resolved = await resolveInstanceMentions(db, extractMentionCandidates(content));
+	const tasks = new Map(resolved.tasks.map((t) => [t.identifier.toLowerCase(), t]));
+	const docs = new Map(resolved.project_docs.map((d) => [d.filename, d]));
+	const kbDocs = new Map(resolved.kb_docs.map((k) => [k.slug.toLowerCase(), k]));
+	const assets = new Map(resolved.assets.map((a) => [a.filename, a]));
+	const agents = new Map(resolved.agents.map((a) => [a.slug.toLowerCase(), a]));
+
+	return transformMentionsOutsideCode(content, (token) => {
+		switch (token.kind) {
+			case 'task': {
+				const t = tasks.get(token.identifier);
+				return t ? `[${token.raw}](${baseUrl}${taskPath(t.project_slug, token.identifier)})` : null;
+			}
+			case 'comment': {
+				const t = tasks.get(token.taskIdentifier);
+				return t
+					? `[${token.raw}](${baseUrl}${commentPath(t.project_slug, token.taskIdentifier, token.commentId)})`
+					: null;
+			}
+			case 'filename': {
+				const d = docs.get(token.filename);
+				if (d) {
+					return `[${token.raw}](${baseUrl}${projectDocPath(d.project_slug, token.filename)})`;
+				}
+				const kb = kbDocs.get(token.filename.toLowerCase());
+				if (kb) {
+					const slugParam = `slug=${encodeURIComponent(kb.slug.toLowerCase())}`;
+					return `[${token.raw}](${baseUrl}${SKILLS_SETTINGS_PATH}?${slugParam})`;
+				}
+				return null;
+			}
+			case 'asset': {
+				const a = assets.get(token.filename);
+				return a ? `[${token.raw}](${baseUrl}${assetPath(a.project_slug, token.filename)})` : null;
+			}
+			case 'agent':
+			case 'passive_agent': {
+				// Passive `@@slug` displays as `@slug`, matching the web renderer.
+				const display = token.kind === 'passive_agent' ? token.raw.slice(1) : token.raw;
+				if (token.slug === ADMIN_MENTION_SLUG) {
+					return `[${display}](${baseUrl}${GLOBAL_INBOX_PATH})`;
+				}
+				const a = agents.get(token.slug);
+				return a ? `[${display}](${baseUrl}${agentPath(a.project_slug, token.slug)})` : null;
+			}
+		}
+	});
+}

--- a/packages/server/src/services/ceo-session-manager.ts
+++ b/packages/server/src/services/ceo-session-manager.ts
@@ -53,7 +53,7 @@ You are in a real-time chat with the operator — the human running this Hezo in
 
 Because you roam across every project here, there is **no per-project "Project State" block in your context** — its open-ticket count in the roster is a summary only. To report a project's live status (its actual tickets and their statuses, or its roster), call \`list_tasks\` / \`list_agents\` with that project's slug as the \`project\` argument. Never tell the operator a project is empty off the roster count alone — check with the tools first.
 
-Because this chat is human-facing, refer to projects, tickets, and teams by their slug, identifier, or name (e.g. the project \`todo6\`, ticket \`TO-1\`) — never paste raw UUIDs. Tools accept the same slugs and identifiers you use with the operator, so you never need a UUID. Keep replies focused and skip ceremony.`;
+Because this chat is human-facing, refer to projects, tickets, teams, docs, and teammates by their bare slug, identifier, or name (e.g. the project todo6, ticket TO-1, prd.md, @@captain) — never paste raw UUIDs. Tools accept the same slugs and identifiers you use with the operator, so you never need a UUID. Write entity references bare, never wrapped in backticks: bare references render as clickable links in the chat, while backticked ones render as inert code and break the link. Keep replies focused and skip ceremony.`;
 
 export interface CeoSessionDeps extends RunnerDeps {
 	wsManager: WebSocketManager;

--- a/packages/server/src/services/instance-mentions.ts
+++ b/packages/server/src/services/instance-mentions.ts
@@ -1,0 +1,143 @@
+import type { PGlite } from '@electric-sql/pglite';
+import type { MentionCandidates } from '@hezo/shared';
+
+/**
+ * Instance-wide mention resolution for the global CEO chat (and the per-channel
+ * message renderers). Unlike the project-scoped resolve endpoints, candidates
+ * are matched across every team, so a reference only resolves when it is
+ * UNIQUE instance-wide: task identifiers are unique per team but can collide
+ * across teams, and doc filenames / asset names / agent slugs collide commonly
+ * (every Startup-template team has a captain, most projects have a prd.md).
+ * Ambiguous references are omitted from the result and render as plain text —
+ * a wrong link is worse than no link. Skills (KB docs) are instance-global and
+ * slug-unique already, so they have no ambiguity clause.
+ */
+
+export interface InstanceResolvedTask {
+	identifier: string;
+	title: string;
+	project_slug: string;
+	status: string;
+}
+
+export interface InstanceResolvedKbDoc {
+	slug: string;
+	title: string;
+	size: number;
+	updated_at: string;
+}
+
+export interface InstanceResolvedProjectDoc {
+	project_slug: string;
+	filename: string;
+	size: number;
+	updated_at: string;
+}
+
+export interface InstanceResolvedAsset {
+	project_slug: string;
+	filename: string;
+	id: string;
+	content_type: string;
+}
+
+export interface InstanceResolvedAgent {
+	slug: string;
+	title: string;
+	project_slug: string;
+}
+
+export interface InstanceMentionResolution {
+	tasks: InstanceResolvedTask[];
+	kb_docs: InstanceResolvedKbDoc[];
+	project_docs: InstanceResolvedProjectDoc[];
+	assets: InstanceResolvedAsset[];
+	agents: InstanceResolvedAgent[];
+}
+
+export async function resolveInstanceMentions(
+	db: PGlite,
+	candidates: MentionCandidates,
+): Promise<InstanceMentionResolution> {
+	const out: InstanceMentionResolution = {
+		tasks: [],
+		kb_docs: [],
+		project_docs: [],
+		assets: [],
+		agents: [],
+	};
+
+	if (candidates.tasks.length > 0) {
+		const result = await db.query<InstanceResolvedTask>(
+			`WITH m AS (
+				SELECT i.identifier, i.title, i.status::text AS status, p.slug AS project_slug,
+				       COUNT(*) OVER (PARTITION BY LOWER(i.identifier)) AS n
+				FROM tasks i
+				JOIN projects p ON p.id = i.project_id
+				WHERE LOWER(i.identifier) = ANY($1::text[])
+			)
+			SELECT identifier, title, status, project_slug FROM m WHERE n = 1`,
+			[candidates.tasks],
+		);
+		out.tasks = result.rows;
+	}
+
+	if (candidates.filenames.length > 0) {
+		const docs = await db.query<InstanceResolvedProjectDoc>(
+			`WITH m AS (
+				SELECT p.slug AS project_slug, pd.slug AS filename,
+				       octet_length(pd.content)::int AS size, pd.updated_at,
+				       COUNT(*) OVER (PARTITION BY pd.slug) AS n
+				FROM documents pd
+				JOIN projects p ON p.id = pd.project_id
+				WHERE pd.type = 'project_doc' AND pd.slug = ANY($1::text[])
+			)
+			SELECT project_slug, filename, size, updated_at FROM m WHERE n = 1`,
+			[candidates.filenames],
+		);
+		out.project_docs = docs.rows;
+
+		const kb = await db.query<InstanceResolvedKbDoc>(
+			`SELECT slug, name AS title, octet_length(content)::int AS size, updated_at
+			 FROM skills
+			 WHERE LOWER(slug) = ANY($1::text[])`,
+			[candidates.filenames.map((f) => f.toLowerCase())],
+		);
+		out.kb_docs = kb.rows;
+	}
+
+	if (candidates.assets.length > 0) {
+		const result = await db.query<InstanceResolvedAsset>(
+			`WITH m AS (
+				SELECT p.slug AS project_slug, a.original_filename AS filename, a.id, a.content_type,
+				       COUNT(*) OVER (PARTITION BY a.original_filename) AS n
+				FROM assets a
+				JOIN projects p ON p.id = a.project_id
+				WHERE a.original_filename = ANY($1::text[])
+			)
+			SELECT project_slug, filename, id, content_type FROM m WHERE n = 1`,
+			[candidates.assets],
+		);
+		out.assets = result.rows;
+	}
+
+	if (candidates.agents.length > 0) {
+		// Teams and projects are 1:1 (UNIQUE(projects.team_id)), so the join is
+		// total; HQ agents (CEO/Coach) resolve to the HQ project's slug.
+		const result = await db.query<InstanceResolvedAgent>(
+			`WITH m AS (
+				SELECT ma.slug, ma.title, p.slug AS project_slug,
+				       COUNT(*) OVER (PARTITION BY LOWER(ma.slug)) AS n
+				FROM member_agents ma
+				JOIN members mem ON mem.id = ma.id
+				JOIN projects p ON p.team_id = mem.team_id
+				WHERE ma.admin_status = 'enabled' AND LOWER(ma.slug) = ANY($1::text[])
+			)
+			SELECT slug, title, project_slug FROM m WHERE n = 1`,
+			[candidates.agents],
+		);
+		out.agents = result.rows;
+	}
+
+	return out;
+}

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -31,6 +31,7 @@ import { costsRoutes } from './routes/costs';
 import { executionLocksRoutes } from './routes/execution-locks';
 import { healthRoutes } from './routes/health';
 import { inboxRoutes } from './routes/inbox';
+import { instanceSettingsRoutes } from './routes/instance-settings';
 import { mcpConnectionsRoutes } from './routes/mcp-connections';
 import { meRoutes } from './routes/me';
 import { mentionsRoutes } from './routes/mentions';
@@ -327,6 +328,7 @@ export function buildApp(
 	app.route('/api', projectDocsRoutes);
 	app.route('/api', mentionsRoutes);
 	app.route('/api', aiProvidersRoutes);
+	app.route('/api', instanceSettingsRoutes);
 	app.route('/api', reposRoutes);
 	app.route('/api', executionLocksRoutes);
 	app.route('/api', queuedWakeupsRoutes);

--- a/packages/server/test/ceo-message-render.test.ts
+++ b/packages/server/test/ceo-message-render.test.ts
@@ -1,0 +1,134 @@
+import type { PGlite } from '@electric-sql/pglite';
+import { CeoChannel, HQ_PROJECT_SLUG } from '@hezo/shared';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { INSTANCE_BASE_URL_KEY, setSystemMeta } from '../src/lib/system-meta';
+import type { Env } from '../src/lib/types';
+import { renderCeoMessageForChannel } from '../src/services/ceo-message-render';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp, createTestProject } from './helpers/app';
+
+let app: Hono<Env>;
+let db: PGlite;
+let token: string;
+
+let projectSlug: string;
+const BASE = 'https://hezo.example.com';
+const COMMENT_ID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+
+	const typesRes = await app.request('/api/team-templates', { headers: authHeader(token) });
+	const typeId = (await typesRes.json()).data.find(
+		(t: Record<string, unknown>) => t.name === 'Startup',
+	).id;
+	const teamRes = await app.request('/api/teams', {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ name: 'Render Co', template_id: typeId }),
+	});
+	const teamId = (await teamRes.json()).data.id;
+	const projectRes = await createTestProject(db, teamId, { name: 'Render Project' });
+	const project = (await projectRes.json()).data;
+	projectSlug = project.slug;
+
+	await db.query(
+		`INSERT INTO tasks (team_id, project_id, number, identifier, title)
+		 VALUES ($1, $2, 901, 'RD-901', 'Render ticket')`,
+		[teamId, project.id],
+	);
+	await db.query(
+		`INSERT INTO documents (team_id, project_id, type, slug, title, content)
+		 VALUES ($1, $2, 'project_doc'::document_type, 'spec.md', 'spec.md', 'spec body')`,
+		[teamId, project.id],
+	);
+	await db.query(
+		`INSERT INTO assets (team_id, project_id, content_type, byte_size, sha256, original_filename)
+		 VALUES ($1, $2, 'image/png', 4, 'deadbeef', 'mock.png')`,
+		[teamId, project.id],
+	);
+	await db.query(
+		`INSERT INTO skills (slug, name, content) VALUES ('playbook.md', 'Playbook', 'kb')`,
+	);
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+describe('renderCeoMessageForChannel', () => {
+	const message = 'Check RD-901 and spec.md before review.';
+
+	it('returns web content unchanged — the client renders links itself', async () => {
+		expect(await renderCeoMessageForChannel(db, message, CeoChannel.Web)).toBe(message);
+	});
+
+	it('returns whatsapp content unchanged — plain-text policy', async () => {
+		await setSystemMeta(db, INSTANCE_BASE_URL_KEY, BASE);
+		expect(await renderCeoMessageForChannel(db, message, CeoChannel.WhatsApp)).toBe(message);
+	});
+
+	it('returns telegram content unchanged while no base URL is configured', async () => {
+		await db.query('DELETE FROM system_meta WHERE key = $1', [INSTANCE_BASE_URL_KEY]);
+		expect(await renderCeoMessageForChannel(db, message, CeoChannel.Telegram)).toBe(message);
+	});
+
+	describe('telegram with a base URL', () => {
+		beforeAll(async () => {
+			await setSystemMeta(db, INSTANCE_BASE_URL_KEY, BASE);
+		});
+
+		it('links a unique task reference', async () => {
+			expect(await renderCeoMessageForChannel(db, 'See RD-901 now', CeoChannel.Telegram)).toBe(
+				`See [RD-901](${BASE}/projects/${projectSlug}/tasks/rd-901) now`,
+			);
+		});
+
+		it('links a comment reference via the task it belongs to', async () => {
+			expect(
+				await renderCeoMessageForChannel(
+					db,
+					`Answered in RD-901#comment-${COMMENT_ID} today`,
+					CeoChannel.Telegram,
+				),
+			).toBe(
+				`Answered in [RD-901#comment-${COMMENT_ID}](${BASE}/projects/${projectSlug}/tasks/rd-901#comment-${COMMENT_ID}) today`,
+			);
+		});
+
+		it('links project docs, KB docs, and assets', async () => {
+			expect(
+				await renderCeoMessageForChannel(
+					db,
+					'Read spec.md and playbook.md plus assets/mock.png today',
+					CeoChannel.Telegram,
+				),
+			).toBe(
+				`Read [spec.md](${BASE}/projects/${projectSlug}/documents?file=spec.md) ` +
+					`and [playbook.md](${BASE}/settings/skills?slug=playbook.md) ` +
+					`plus [assets/mock.png](${BASE}/projects/${projectSlug}/assets?file=mock.png) today`,
+			);
+		});
+
+		it('links agents to their home project and @admin to the global inbox', async () => {
+			expect(
+				await renderCeoMessageForChannel(db, 'Ask @@ceo or @admin first', CeoChannel.Telegram),
+			).toBe(
+				`Ask [@ceo](${BASE}/projects/${HQ_PROJECT_SLUG}/agents/ceo) ` +
+					`or [@admin](${BASE}${'/home/inbox'}) first`,
+			);
+		});
+
+		it('keeps unknown references and code spans bare in a mixed message', async () => {
+			const mixed = 'RD-901 is real but ZZ-99 is not, and `RD-901` stays code:\n```\nRD-901\n```';
+			expect(await renderCeoMessageForChannel(db, mixed, CeoChannel.Telegram)).toBe(
+				`[RD-901](${BASE}/projects/${projectSlug}/tasks/rd-901) is real but ZZ-99 is not, ` +
+					'and `RD-901` stays code:\n```\nRD-901\n```',
+			);
+		});
+	});
+});

--- a/packages/server/test/instance-mentions.test.ts
+++ b/packages/server/test/instance-mentions.test.ts
@@ -1,0 +1,271 @@
+import type { PGlite } from '@electric-sql/pglite';
+import { DEFAULT_TEAM_ID, HQ_PROJECT_SLUG } from '@hezo/shared';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { MasterKeyManager } from '../src/crypto/master-key';
+import type { Env } from '../src/lib/types';
+import { signAdminJwt } from '../src/middleware/auth';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp, mintAgentToken, projectSlugFor } from './helpers/app';
+
+let app: Hono<Env>;
+let db: PGlite;
+let token: string;
+let masterKeyManager: MasterKeyManager;
+
+let teamAId: string;
+let teamBId: string;
+let projectASlug: string;
+let projectBSlug: string;
+let projectAId: string;
+let projectBId: string;
+
+interface ResolveResponse {
+	tasks: Array<{ identifier: string; title: string; project_slug: string; status: string }>;
+	kb_docs: Array<{ slug: string; title: string; size: number; updated_at: string }>;
+	project_docs: Array<{ project_slug: string; filename: string; size: number; updated_at: string }>;
+	assets: Array<{
+		project_slug: string;
+		filename: string;
+		id: string;
+		content_type: string;
+		signed_url: string;
+	}>;
+	agents: Array<{ slug: string; title: string; project_slug: string }>;
+}
+
+async function resolve(
+	body: Record<string, unknown>,
+	authToken = token,
+): Promise<{ status: number; data: ResolveResponse }> {
+	const res = await app.request('/api/mentions/resolve', {
+		method: 'POST',
+		headers: { ...authHeader(authToken), 'Content-Type': 'application/json' },
+		body: JSON.stringify(body),
+	});
+	const json = res.status === 200 ? (await res.json()).data : undefined;
+	return { status: res.status, data: json };
+}
+
+async function insertTask(
+	teamId: string,
+	projectId: string,
+	identifier: string,
+	number: number,
+	title: string,
+): Promise<void> {
+	await db.query(
+		`INSERT INTO tasks (team_id, project_id, number, identifier, title)
+		 VALUES ($1, $2, $3, $4, $5)`,
+		[teamId, projectId, number, identifier, title],
+	);
+}
+
+async function insertProjectDoc(
+	teamId: string,
+	projectId: string,
+	filename: string,
+	content: string,
+): Promise<void> {
+	await db.query(
+		`INSERT INTO documents (team_id, project_id, type, slug, title, content)
+		 VALUES ($1, $2, 'project_doc'::document_type, $3, $3, $4)`,
+		[teamId, projectId, filename, content],
+	);
+}
+
+async function insertAsset(teamId: string, projectId: string, filename: string): Promise<void> {
+	await db.query(
+		`INSERT INTO assets (team_id, project_id, content_type, byte_size, sha256, original_filename)
+		 VALUES ($1, $2, 'image/png', 4, 'deadbeef', $3)`,
+		[teamId, projectId, filename],
+	);
+}
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+	masterKeyManager = ctx.masterKeyManager;
+
+	const typesRes = await app.request('/api/team-templates', { headers: authHeader(token) });
+	const typeId = (await typesRes.json()).data.find(
+		(t: Record<string, unknown>) => t.name === 'Startup',
+	).id;
+
+	for (const name of ['Mention Co Alpha', 'Mention Co Beta']) {
+		const teamRes = await app.request('/api/teams', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name, template_id: typeId }),
+		});
+		const teamData = (await teamRes.json()).data;
+		if (name.endsWith('Alpha')) teamAId = teamData.id;
+		else teamBId = teamData.id;
+	}
+
+	projectASlug = await projectSlugFor(db, teamAId);
+	projectBSlug = await projectSlugFor(db, teamBId);
+	const pA = await db.query<{ id: string }>('SELECT id FROM projects WHERE slug = $1', [
+		projectASlug,
+	]);
+	const pB = await db.query<{ id: string }>('SELECT id FROM projects WHERE slug = $1', [
+		projectBSlug,
+	]);
+	projectAId = pA.rows[0].id;
+	projectBId = pB.rows[0].id;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+describe('POST /api/mentions/resolve — tasks', () => {
+	it('resolves an instance-unique identifier with its project slug', async () => {
+		await insertTask(teamAId, projectAId, 'QQ-7', 907, 'Unique ticket');
+		const { status, data } = await resolve({ tasks: ['qq-7'] });
+		expect(status).toBe(200);
+		expect(data.tasks).toEqual([
+			expect.objectContaining({
+				identifier: 'QQ-7',
+				title: 'Unique ticket',
+				project_slug: projectASlug,
+			}),
+		]);
+	});
+
+	it('omits identifiers that collide across teams', async () => {
+		await insertTask(teamAId, projectAId, 'XX-1', 908, 'Alpha ticket');
+		await insertTask(teamBId, projectBId, 'XX-1', 908, 'Beta ticket');
+		const { data } = await resolve({ tasks: ['xx-1', 'qq-7'] });
+		expect(data.tasks.map((t) => t.identifier)).toEqual(['QQ-7']);
+	});
+
+	it('omits unknown identifiers', async () => {
+		const { data } = await resolve({ tasks: ['zz-99'] });
+		expect(data.tasks).toEqual([]);
+	});
+});
+
+describe('POST /api/mentions/resolve — docs and assets', () => {
+	it('resolves a filename present in exactly one project', async () => {
+		await insertProjectDoc(teamAId, projectAId, 'unique.md', 'hello');
+		const { data } = await resolve({ filenames: ['unique.md'] });
+		expect(data.project_docs).toEqual([
+			expect.objectContaining({ project_slug: projectASlug, filename: 'unique.md', size: 5 }),
+		]);
+	});
+
+	it('omits filenames that exist in multiple projects', async () => {
+		await insertProjectDoc(teamAId, projectAId, 'prd.md', 'a');
+		await insertProjectDoc(teamBId, projectBId, 'prd.md', 'b');
+		const { data } = await resolve({ filenames: ['prd.md', 'unique.md'] });
+		expect(data.project_docs.map((d) => d.filename)).toEqual(['unique.md']);
+	});
+
+	it('resolves skills (KB docs) by slug — instance-global, no ambiguity rule', async () => {
+		await db.query(
+			`INSERT INTO skills (slug, name, content) VALUES ('guide.md', 'Guide', 'kb content')`,
+		);
+		const { data } = await resolve({ filenames: ['guide.md'] });
+		expect(data.kb_docs).toEqual([expect.objectContaining({ slug: 'guide.md', title: 'Guide' })]);
+	});
+
+	it('resolves unique assets with a signed URL and omits colliding ones', async () => {
+		await insertAsset(teamAId, projectAId, 'mock.png');
+		await insertAsset(teamAId, projectAId, 'shared.png');
+		await insertAsset(teamBId, projectBId, 'shared.png');
+		const { data } = await resolve({ assets: ['mock.png', 'shared.png'] });
+		expect(data.assets).toHaveLength(1);
+		expect(data.assets[0]).toMatchObject({
+			project_slug: projectASlug,
+			filename: 'mock.png',
+			content_type: 'image/png',
+		});
+		expect(data.assets[0].signed_url).toBeTruthy();
+	});
+});
+
+describe('POST /api/mentions/resolve — agents', () => {
+	it('resolves HQ singletons to the HQ project and omits slugs present in multiple teams', async () => {
+		const { data } = await resolve({ agents: ['ceo', 'captain'] });
+		expect(data.agents).toEqual([
+			expect.objectContaining({ slug: 'ceo', project_slug: HQ_PROJECT_SLUG }),
+		]);
+	});
+
+	it('ignores disabled agents when counting uniqueness', async () => {
+		await db.query(
+			`UPDATE member_agents SET admin_status = 'disabled'
+			 WHERE slug = 'architect' AND id IN (SELECT id FROM members WHERE team_id = $1)`,
+			[teamBId],
+		);
+		const { data } = await resolve({ agents: ['architect'] });
+		expect(data.agents).toEqual([
+			expect.objectContaining({ slug: 'architect', project_slug: projectASlug }),
+		]);
+	});
+});
+
+describe('POST /api/mentions/resolve — validation', () => {
+	it('returns empty arrays for an empty body', async () => {
+		const { status, data } = await resolve({});
+		expect(status).toBe(200);
+		expect(data).toEqual({ tasks: [], kb_docs: [], project_docs: [], assets: [], agents: [] });
+	});
+
+	it('rejects non-array fields', async () => {
+		const { status } = await resolve({ tasks: 'to-1' });
+		expect(status).toBe(400);
+	});
+
+	it('rejects more than 100 entries', async () => {
+		const { status } = await resolve({
+			tasks: Array.from({ length: 101 }, (_, i) => `to-${i}`),
+		});
+		expect(status).toBe(400);
+	});
+});
+
+describe('POST /api/mentions/resolve — authorization', () => {
+	it('rejects a non-superuser with no HQ membership, then allows once added to HQ', async () => {
+		const user = await db.query<{ id: string }>(
+			"INSERT INTO users (display_name, is_superuser) VALUES ('Plain User', false) RETURNING id",
+		);
+		const userId = user.rows[0].id;
+		const userToken = await signAdminJwt(masterKeyManager, userId);
+
+		const denied = await resolve({ tasks: ['qq-7'] }, userToken);
+		expect(denied.status).toBe(403);
+
+		const member = await db.query<{ id: string }>(
+			`INSERT INTO members (team_id, member_type, display_name)
+			 VALUES ($1, 'user'::member_type, 'Plain User') RETURNING id`,
+			[DEFAULT_TEAM_ID],
+		);
+		await db.query(`INSERT INTO member_users (id, user_id, role) VALUES ($1, $2, 'admin')`, [
+			member.rows[0].id,
+			userId,
+		]);
+
+		const allowed = await resolve({ tasks: ['qq-7'] }, userToken);
+		expect(allowed.status).toBe(200);
+	});
+
+	it('rejects an agent token scoped to a non-HQ team', async () => {
+		const captain = await db.query<{ id: string }>(
+			`SELECT ma.id FROM member_agents ma JOIN members m ON m.id = ma.id
+			 WHERE m.team_id = $1 AND ma.slug = 'captain'`,
+			[teamAId],
+		);
+		const { token: agentToken } = await mintAgentToken(
+			db,
+			masterKeyManager,
+			captain.rows[0].id,
+			teamAId,
+		);
+		const { status } = await resolve({ tasks: ['qq-7'] }, agentToken);
+		expect(status).toBe(403);
+	});
+});

--- a/packages/server/test/instance-settings.test.ts
+++ b/packages/server/test/instance-settings.test.ts
@@ -1,0 +1,141 @@
+import type { PGlite } from '@electric-sql/pglite';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { getSystemMeta, INSTANCE_BASE_URL_KEY } from '../src/lib/system-meta';
+import type { Env } from '../src/lib/types';
+import { signAdminJwt } from '../src/middleware/auth';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp } from './helpers/app';
+
+let app: Hono<Env>;
+let db: PGlite;
+let token: string;
+let nonSuperuserToken: string;
+let masterKeyHex: string;
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+	masterKeyHex = ctx.masterKeyHex;
+
+	const nonAdmin = await db.query<{ id: string }>(
+		"INSERT INTO users (display_name, is_superuser) VALUES ('Regular Admin', false) RETURNING id",
+	);
+	nonSuperuserToken = await signAdminJwt(ctx.masterKeyManager, nonAdmin.rows[0].id);
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+function unlock(headers: Record<string, string> = {}) {
+	return app.request('/api/auth/token', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json', ...headers },
+		body: JSON.stringify({ master_key: masterKeyHex }),
+	});
+}
+
+function patchBaseUrl(value: unknown, authToken = token) {
+	return app.request('/api/instance-settings', {
+		method: 'PATCH',
+		headers: { ...authHeader(authToken), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ base_url: value }),
+	});
+}
+
+async function getBaseUrl(): Promise<string | null> {
+	const res = await app.request('/api/instance-settings', { headers: authHeader(token) });
+	expect(res.status).toBe(200);
+	return (await res.json()).data.base_url;
+}
+
+describe('GET /api/instance-settings', () => {
+	it('returns null base_url on a fresh instance', async () => {
+		expect(await getBaseUrl()).toBeNull();
+	});
+});
+
+describe('base URL capture on unlock', () => {
+	it('captures the forwarded origin on first unlock', async () => {
+		const res = await unlock({ host: 'hezo.example.com', 'x-forwarded-proto': 'https' });
+		expect(res.status).toBe(200);
+		expect(await getSystemMeta(db, INSTANCE_BASE_URL_KEY)).toBe('https://hezo.example.com');
+	});
+
+	it('does not overwrite an already-captured value on later unlocks', async () => {
+		const res = await unlock({ host: 'other.example.com', 'x-forwarded-proto': 'https' });
+		expect(res.status).toBe(200);
+		expect(await getSystemMeta(db, INSTANCE_BASE_URL_KEY)).toBe('https://hezo.example.com');
+	});
+
+	it('takes the first entry of a comma-separated x-forwarded-proto chain', async () => {
+		await db.query('DELETE FROM system_meta WHERE key = $1', [INSTANCE_BASE_URL_KEY]);
+		const res = await unlock({ host: 'chain.example.com', 'x-forwarded-proto': 'https, http' });
+		expect(res.status).toBe(200);
+		expect(await getSystemMeta(db, INSTANCE_BASE_URL_KEY)).toBe('https://chain.example.com');
+	});
+
+	it('defaults to http and the host header port when no proxy headers are set', async () => {
+		await db.query('DELETE FROM system_meta WHERE key = $1', [INSTANCE_BASE_URL_KEY]);
+		const res = await unlock({ host: 'localhost:3100' });
+		expect(res.status).toBe(200);
+		expect(await getSystemMeta(db, INSTANCE_BASE_URL_KEY)).toBe('http://localhost:3100');
+	});
+});
+
+describe('PATCH /api/instance-settings', () => {
+	it('rejects non-superusers', async () => {
+		const res = await patchBaseUrl('https://x.example.com', nonSuperuserToken);
+		expect(res.status).toBe(403);
+	});
+
+	it.each([
+		['non-URL text', 'not a url'],
+		['non-http scheme', 'ftp://x.example.com'],
+		['URL with a path', 'https://x.example.com/app'],
+		['URL with a query', 'https://x.example.com?q=1'],
+		['URL with a fragment', 'https://x.example.com#frag'],
+		['URL with credentials', 'https://user:pw@x.example.com'],
+	])('rejects %s', async (_name, value) => {
+		const res = await patchBaseUrl(value);
+		expect(res.status).toBe(400);
+		expect((await res.json()).error.code).toBe('INVALID_REQUEST');
+	});
+
+	it('rejects a non-string, non-null base_url', async () => {
+		const res = await patchBaseUrl(123);
+		expect(res.status).toBe(400);
+	});
+
+	it('rejects a body without base_url', async () => {
+		const res = await app.request('/api/instance-settings', {
+			method: 'PATCH',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({}),
+		});
+		expect(res.status).toBe(400);
+	});
+
+	it('normalizes to a bare origin and echoes it', async () => {
+		const res = await patchBaseUrl('https://Hezo.Example.com:8443/');
+		expect(res.status).toBe(200);
+		expect((await res.json()).data.base_url).toBe('https://hezo.example.com:8443');
+		expect(await getBaseUrl()).toBe('https://hezo.example.com:8443');
+	});
+
+	it('a manually-set value survives later unlocks', async () => {
+		const res = await unlock({ host: 'fresh.example.com', 'x-forwarded-proto': 'https' });
+		expect(res.status).toBe(200);
+		expect(await getBaseUrl()).toBe('https://hezo.example.com:8443');
+	});
+
+	it('clears the value with null', async () => {
+		const res = await patchBaseUrl(null);
+		expect(res.status).toBe(200);
+		expect((await res.json()).data.base_url).toBeNull();
+		expect(await getBaseUrl()).toBeNull();
+	});
+});

--- a/packages/server/test/mention-tokens.test.ts
+++ b/packages/server/test/mention-tokens.test.ts
@@ -1,0 +1,109 @@
+import {
+	agentPath,
+	assetPath,
+	buildMentionRegex,
+	commentPath,
+	extractMentionCandidates,
+	type MentionToken,
+	parseMentionMatch,
+	projectDocPath,
+	projectInboxPath,
+	taskPath,
+	transformMentionsOutsideCode,
+} from '@hezo/shared';
+import { describe, expect, it } from 'vitest';
+
+const UUID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+
+function tokensOf(value: string): MentionToken[] {
+	const re = buildMentionRegex();
+	const out: MentionToken[] = [];
+	let m = re.exec(value);
+	while (m !== null) {
+		out.push(parseMentionMatch(m));
+		m = re.exec(value);
+	}
+	return out;
+}
+
+describe('parseMentionMatch', () => {
+	it('maps each alternation branch to its token kind', () => {
+		const tokens = tokensOf(
+			`@@product-lead and @captain should read TO-1, IN-42#comment-${UUID}, prd.md and assets/mock.png`,
+		);
+		expect(tokens).toEqual([
+			{ kind: 'passive_agent', raw: '@@product-lead', slug: 'product-lead' },
+			{ kind: 'agent', raw: '@captain', slug: 'captain' },
+			{ kind: 'task', raw: 'TO-1', identifier: 'to-1' },
+			{ kind: 'comment', raw: `IN-42#comment-${UUID}`, taskIdentifier: 'in-42', commentId: UUID },
+			{ kind: 'filename', raw: 'prd.md', filename: 'prd.md' },
+			{ kind: 'asset', raw: 'assets/mock.png', filename: 'mock.png' },
+		]);
+	});
+
+	it('keeps raw text exact-case while lowercasing slugs and identifiers', () => {
+		const [token] = tokensOf('see TO-7');
+		expect(token).toEqual({ kind: 'task', raw: 'TO-7', identifier: 'to-7' });
+	});
+
+	it('does not treat a non-UUID comment suffix as a comment link', () => {
+		const tokens = tokensOf('IN-42#comment-foo');
+		expect(tokens[0]).toEqual({ kind: 'task', raw: 'IN-42', identifier: 'in-42' });
+	});
+});
+
+describe('extractMentionCandidates', () => {
+	it('collects deduped candidates per kind', () => {
+		const c = extractMentionCandidates(
+			`TO-1 again TO-1 and to boot IN-42#comment-${UUID}; ask @captain or @@captain about prd.md and assets/a.png`,
+		);
+		expect(c.tasks.sort()).toEqual(['in-42', 'to-1']);
+		expect(c.filenames).toEqual(['prd.md']);
+		expect(c.assets).toEqual(['a.png']);
+		expect(c.agents).toEqual(['captain']);
+	});
+
+	it('excludes @admin and ignores references inside code', () => {
+		const c = extractMentionCandidates(
+			'ping @admin about `TO-9` and\n```\nIN-3 spec.md @captain\n```\nplus TO-2',
+		);
+		expect(c.agents).toEqual([]);
+		expect(c.tasks).toEqual(['to-2']);
+		expect(c.filenames).toEqual([]);
+	});
+});
+
+describe('transformMentionsOutsideCode', () => {
+	const linkTasks = (token: MentionToken) =>
+		token.kind === 'task' ? `[${token.raw}](https://x.test/t/${token.identifier})` : null;
+
+	it('replaces tokens outside code and preserves everything else byte-for-byte', () => {
+		const input = 'Look at TO-1 (and TO-2), please.';
+		expect(transformMentionsOutsideCode(input, linkTasks)).toBe(
+			'Look at [TO-1](https://x.test/t/to-1) (and [TO-2](https://x.test/t/to-2)), please.',
+		);
+	});
+
+	it('leaves inline code and fences untouched', () => {
+		const input = 'TO-1 then `TO-2` and\n```\nTO-3\n```\n~~~\nTO-5\n~~~\nthen TO-4';
+		expect(transformMentionsOutsideCode(input, linkTasks)).toBe(
+			'[TO-1](https://x.test/t/to-1) then `TO-2` and\n```\nTO-3\n```\n~~~\nTO-5\n~~~\nthen [TO-4](https://x.test/t/to-4)',
+		);
+	});
+
+	it('keeps the original text when the replacer returns null', () => {
+		const input = 'TO-1 and prd.md stay put';
+		expect(transformMentionsOutsideCode(input, () => null)).toBe(input);
+	});
+});
+
+describe('entity paths', () => {
+	it('builds web-route-shaped paths', () => {
+		expect(taskPath('todo6', 'TO-1')).toBe('/projects/todo6/tasks/to-1');
+		expect(commentPath('todo6', 'TO-1', UUID)).toBe(`/projects/todo6/tasks/to-1#comment-${UUID}`);
+		expect(projectDocPath('todo6', 'prd.md')).toBe('/projects/todo6/documents?file=prd.md');
+		expect(assetPath('todo6', 'a b.png')).toBe('/projects/todo6/assets?file=a%20b.png');
+		expect(agentPath('hq', 'ceo')).toBe('/projects/hq/agents/ceo');
+		expect(projectInboxPath('todo6')).toBe('/projects/todo6/inbox');
+	});
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,4 @@
 export * from './constants.js';
 export * from './crypto/mnemonic.js';
+export * from './mentions/index.js';
 export * from './types/index.js';

--- a/packages/shared/src/mentions/index.ts
+++ b/packages/shared/src/mentions/index.ts
@@ -1,0 +1,2 @@
+export * from './paths.js';
+export * from './tokens.js';

--- a/packages/shared/src/mentions/paths.ts
+++ b/packages/shared/src/mentions/paths.ts
@@ -1,0 +1,36 @@
+/**
+ * Relative URL paths for entity references, matching the web app's routes.
+ * The web remark plugin emits these as-is (client-side navigation); server-side
+ * channel renderers prefix the instance base URL to produce absolute links.
+ * Callers pass project slugs (browser URLs use slugs, never UUIDs).
+ */
+
+export function taskPath(projectSlug: string, identifier: string): string {
+	return `/projects/${projectSlug}/tasks/${identifier.toLowerCase()}`;
+}
+
+export function commentPath(projectSlug: string, identifier: string, commentId: string): string {
+	return `${taskPath(projectSlug, identifier)}#comment-${commentId}`;
+}
+
+export function projectDocPath(projectSlug: string, filename: string): string {
+	return `/projects/${projectSlug}/documents?file=${encodeURIComponent(filename)}`;
+}
+
+export function assetPath(projectSlug: string, filename: string): string {
+	return `/projects/${projectSlug}/assets?file=${encodeURIComponent(filename)}`;
+}
+
+export function agentPath(projectSlug: string, agentSlug: string): string {
+	return `/projects/${projectSlug}/agents/${agentSlug}`;
+}
+
+export function projectInboxPath(projectSlug: string): string {
+	return `/projects/${projectSlug}/inbox`;
+}
+
+/** Instance-wide admin inbox (used when no project context exists). */
+export const GLOBAL_INBOX_PATH = '/home/inbox';
+
+/** Skills (KB docs) live in instance settings, not under a project. */
+export const SKILLS_SETTINGS_PATH = '/settings/skills';

--- a/packages/shared/src/mentions/tokens.ts
+++ b/packages/shared/src/mentions/tokens.ts
@@ -1,0 +1,227 @@
+import { ADMIN_MENTION_SLUG } from '../constants.js';
+
+/**
+ * Canonical mention/reference syntax shared by every surface that parses or
+ * renders entity references (the web remark plugin, the server-side channel
+ * renderer, candidate extraction for resolve endpoints). The syntax itself is
+ * documented for agents in agents/_partials/common/linking-syntax.md — bare
+ * identifiers, never wrapped in backticks.
+ */
+
+export const PASSIVE_AGENT_RE_SRC = String.raw`(?<![\w@])@@([a-z][\w-]*)(?![\w/])`;
+export const AGENT_RE_SRC = String.raw`(?<![\w@])@([a-z][\w-]*)(?![\w/])`;
+export const TASK_RE_SRC = String.raw`(?<![\w-])([A-Z][A-Z0-9]{1,3}-\d+)(?![\w-])`;
+// Comment links embed a task identifier plus the comment's UUID
+// (`IN-42#comment-<uuid>`), reusing the `#comment-<uuid>` URL hash. The UUID is
+// shape-matched so `IN-42#comment-foo` prose stays plain text. This MUST come
+// before TASK_RE_SRC in the alternation: regex alternation prefers the leftmost
+// matching branch at a position, so otherwise TASK_RE_SRC consumes the bare
+// `IN-42` prefix and the `#comment-...` suffix is left dangling.
+export const COMMENT_LINK_RE_SRC = String.raw`(?<![\w-])([A-Z][A-Z0-9]{1,3}-\d+)#comment-([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})(?![\w-])`;
+export const FILENAME_RE_SRC = String.raw`(?<![\w/.-])([a-z0-9][\w-]*\.[a-z0-9]+)(?![\w/.-])`;
+// Asset references are path-prefixed (`assets/<name>.<ext>`) and may contain
+// uppercase (e.g. a task identifier embedded in the name). The leading `assets/`
+// keeps them from colliding with the bare project-doc filenames above.
+export const ASSET_RE_SRC = String.raw`(?<![\w/.-])assets/([A-Za-z0-9][\w.-]*\.[A-Za-z0-9]+)(?![\w/.-])`;
+
+/**
+ * Combined mention regex. Capture-group layout (consumed by
+ * `parseMentionMatch`): 1 = passive agent slug, 2 = agent slug, 3+4 = comment
+ * link (task identifier, comment UUID), 5 = task identifier, 6 = bare
+ * filename, 7 = asset filename.
+ *
+ * Returns a fresh `g`-flagged instance per call — `g` regexes carry
+ * `lastIndex` state, so a shared module-level instance would corrupt
+ * concurrent or re-entrant scans.
+ */
+export function buildMentionRegex(): RegExp {
+	return new RegExp(
+		`${PASSIVE_AGENT_RE_SRC}|${AGENT_RE_SRC}|${COMMENT_LINK_RE_SRC}|${TASK_RE_SRC}|${FILENAME_RE_SRC}|${ASSET_RE_SRC}`,
+		'g',
+	);
+}
+
+export type MentionToken = { raw: string } & (
+	| { kind: 'passive_agent'; slug: string }
+	| { kind: 'agent'; slug: string }
+	| { kind: 'comment'; taskIdentifier: string; commentId: string }
+	| { kind: 'task'; identifier: string }
+	| { kind: 'filename'; filename: string }
+	| { kind: 'asset'; filename: string }
+);
+
+/**
+ * Maps a `buildMentionRegex()` match to a typed token. Slugs and task
+ * identifiers are lowercased (resolution is case-insensitive); filenames keep
+ * their exact case (project docs and assets match exact-case); `raw` always
+ * preserves the matched text for display.
+ */
+export function parseMentionMatch(m: RegExpExecArray): MentionToken {
+	const raw = m[0];
+	if (m[1]) return { kind: 'passive_agent', raw, slug: m[1].toLowerCase() };
+	if (m[2]) return { kind: 'agent', raw, slug: m[2].toLowerCase() };
+	if (m[3] && m[4]) {
+		return { kind: 'comment', raw, taskIdentifier: m[3].toLowerCase(), commentId: m[4] };
+	}
+	if (m[5]) return { kind: 'task', raw, identifier: m[5].toLowerCase() };
+	if (m[6]) return { kind: 'filename', raw, filename: m[6] };
+	return { kind: 'asset', raw, filename: m[7] };
+}
+
+export interface MentionCandidates {
+	/** Lowercased task identifiers (includes the task part of comment links). */
+	tasks: string[];
+	/** Exact-case bare filenames (project docs / KB slugs). */
+	filenames: string[];
+	/** Exact-case asset filenames (without the `assets/` prefix). */
+	assets: string[];
+	/** Lowercased agent slugs from @/@@ mentions; `@admin` is excluded. */
+	agents: string[];
+}
+
+/**
+ * Extracts every resolvable reference from `value` (code blocks and inline
+ * code stripped first), deduped. Used to build resolve-endpoint requests.
+ */
+export function extractMentionCandidates(value: string): MentionCandidates {
+	const stripped = stripCode(value);
+	const tasks = new Set<string>();
+	const filenames = new Set<string>();
+	const assets = new Set<string>();
+	const agents = new Set<string>();
+	const re = buildMentionRegex();
+	let m = re.exec(stripped);
+	while (m !== null) {
+		const token = parseMentionMatch(m);
+		switch (token.kind) {
+			case 'task':
+				tasks.add(token.identifier);
+				break;
+			case 'comment':
+				tasks.add(token.taskIdentifier);
+				break;
+			case 'filename':
+				filenames.add(token.filename);
+				break;
+			case 'asset':
+				assets.add(token.filename);
+				break;
+			case 'agent':
+			case 'passive_agent':
+				if (token.slug !== ADMIN_MENTION_SLUG) agents.add(token.slug);
+				break;
+		}
+		m = re.exec(stripped);
+	}
+	return {
+		tasks: Array.from(tasks),
+		filenames: Array.from(filenames),
+		assets: Array.from(assets),
+		agents: Array.from(agents),
+	};
+}
+
+export function extractTaskCandidates(value: string): string[] {
+	const stripped = stripCode(value);
+	const re = new RegExp(TASK_RE_SRC, 'g');
+	const out = new Set<string>();
+	let m = re.exec(stripped);
+	while (m !== null) {
+		out.add(m[1].toLowerCase());
+		m = re.exec(stripped);
+	}
+	return Array.from(out);
+}
+
+export interface DocCandidates {
+	kbSlugs: string[];
+	projectDocs: Array<{ project_slug: string; filename: string }>;
+	assets: Array<{ project_slug: string; filename: string }>;
+}
+
+export function extractDocCandidates(value: string, projectSlug?: string): DocCandidates {
+	const stripped = stripCode(value);
+	const filenameSet = new Set<string>();
+
+	const re = new RegExp(FILENAME_RE_SRC, 'g');
+	let m = re.exec(stripped);
+	while (m !== null) {
+		filenameSet.add(m[1]);
+		m = re.exec(stripped);
+	}
+
+	const assetSet = new Set<string>();
+	const assetRe = new RegExp(ASSET_RE_SRC, 'g');
+	let am = assetRe.exec(stripped);
+	while (am !== null) {
+		assetSet.add(am[1]);
+		am = assetRe.exec(stripped);
+	}
+
+	const kbSlugs = Array.from(filenameSet, (f) => f.toLowerCase());
+	const projectDocs: Array<{ project_slug: string; filename: string }> = [];
+	const assets: Array<{ project_slug: string; filename: string }> = [];
+	if (projectSlug) {
+		const slug = projectSlug.toLowerCase();
+		for (const filename of filenameSet) {
+			projectDocs.push({ project_slug: slug, filename });
+		}
+		for (const filename of assetSet) {
+			assets.push({ project_slug: slug, filename });
+		}
+	}
+
+	return { kbSlugs, projectDocs, assets };
+}
+
+export function stripCode(value: string): string {
+	return value.replace(/```[\s\S]*?```|~~~[\s\S]*?~~~/g, ' ').replace(/`[^`]*`/g, ' ');
+}
+
+// Same shapes stripCode blanks out, but as a splitter so code segments can be
+// preserved verbatim rather than erased.
+const CODE_SEGMENT_RE_SRC = '```[\\s\\S]*?```|~~~[\\s\\S]*?~~~|`[^`]*`';
+
+/**
+ * Rewrites mention tokens in `value` via `replace`, leaving code fences and
+ * inline code untouched — the string-level equivalent of the remark plugin
+ * skipping `code`/`inlineCode` mdast nodes. `replace` returns the replacement
+ * text for a token, or null to keep the original text.
+ */
+export function transformMentionsOutsideCode(
+	value: string,
+	replace: (token: MentionToken) => string | null,
+): string {
+	const codeRe = new RegExp(CODE_SEGMENT_RE_SRC, 'g');
+	let out = '';
+	let last = 0;
+	let m = codeRe.exec(value);
+	while (m !== null) {
+		out += transformSegment(value.slice(last, m.index), replace);
+		out += m[0];
+		last = m.index + m[0].length;
+		m = codeRe.exec(value);
+	}
+	out += transformSegment(value.slice(last), replace);
+	return out;
+}
+
+function transformSegment(
+	segment: string,
+	replace: (token: MentionToken) => string | null,
+): string {
+	if (segment === '') return segment;
+	const re = buildMentionRegex();
+	let out = '';
+	let last = 0;
+	let m = re.exec(segment);
+	while (m !== null) {
+		const replacement = replace(parseMentionMatch(m));
+		if (replacement !== null) {
+			out += segment.slice(last, m.index) + replacement;
+			last = m.index + m[0].length;
+		}
+		m = re.exec(segment);
+	}
+	return out + segment.slice(last);
+}

--- a/packages/web/src/components/ceo-chat/ceo-chat-widget.tsx
+++ b/packages/web/src/components/ceo-chat/ceo-chat-widget.tsx
@@ -148,11 +148,15 @@ function MessageBubble({ message }: { message: CeoMessage }) {
 				data-role="ceo"
 			>
 				<div className="rounded-radius-md rounded-bl-sm border border-border bg-bg-subtle px-3 py-2 text-text">
-					{/* The CEO's replies are LLM-authored markdown. There's no single
-					    project scope on the global chat, so MarkdownProse renders pure
-					    GFM (mention resolution stays disabled without a projectId). */}
+					{/* The CEO's replies are LLM-authored markdown. The global chat has
+					    no single project scope, so mentions resolve instance-wide:
+					    references that are unique across all projects (TO-1, prd.md,
+					    @agent, …) render as client-side links; ambiguous ones stay
+					    plain text. */}
 					{message.content ? (
-						<MarkdownProse testId="ceo-chat-markdown">{message.content}</MarkdownProse>
+						<MarkdownProse testId="ceo-chat-markdown" instance>
+							{message.content}
+						</MarkdownProse>
 					) : failed ? (
 						<span className="text-[13px] leading-relaxed">Something went wrong.</span>
 					) : null}

--- a/packages/web/src/components/instance-settings-section.tsx
+++ b/packages/web/src/components/instance-settings-section.tsx
@@ -1,0 +1,92 @@
+import { Loader2 } from 'lucide-react';
+import { useState } from 'react';
+import {
+	type InstanceSettings,
+	useInstanceSettings,
+	useUpdateInstanceSettings,
+} from '../hooks/use-instance-settings';
+import { useMe } from '../hooks/use-me';
+import type { ApiError } from '../lib/api';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+
+export function InstanceSettingsSection() {
+	const { data: me } = useMe();
+	const { data: settings } = useInstanceSettings();
+
+	return (
+		<section>
+			<div className="mb-4">
+				<h2 className="text-base font-medium">Instance</h2>
+				<p className="text-[13px] text-text-muted mt-1">
+					Public base URL of this Hezo instance, used to build absolute links to tasks and documents
+					in external channels (e.g. Telegram). Captured automatically the first time the instance
+					is unlocked.
+				</p>
+			</div>
+			<div className="border border-border rounded-radius-md p-3 bg-bg">
+				<label className="block text-[13px] font-medium mb-1.5" htmlFor="instance-base-url-input">
+					Base URL
+				</label>
+				{settings === undefined ? null : me?.is_superuser ? (
+					<BaseUrlForm settings={settings} />
+				) : (
+					<p className="text-[13px] text-text-muted" data-testid="instance-base-url-readonly">
+						{settings.base_url ?? 'Not configured'}
+					</p>
+				)}
+			</div>
+		</section>
+	);
+}
+
+function BaseUrlForm({ settings }: { settings: InstanceSettings }) {
+	const updateSettings = useUpdateInstanceSettings();
+	const [baseUrl, setBaseUrl] = useState(settings.base_url ?? '');
+	const [error, setError] = useState<string | null>(null);
+
+	async function handleSave() {
+		setError(null);
+		try {
+			const result = await updateSettings.mutateAsync(
+				baseUrl.trim() === '' ? null : baseUrl.trim(),
+			);
+			// Reflect the server-normalized origin (response-driven, never preempted).
+			setBaseUrl(result.base_url ?? '');
+		} catch (e) {
+			setError((e as ApiError).message);
+		}
+	}
+
+	const dirty = baseUrl.trim() !== (settings.base_url ?? '');
+
+	return (
+		<>
+			<div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+				<Input
+					id="instance-base-url-input"
+					data-testid="instance-base-url-input"
+					type="url"
+					inputMode="url"
+					placeholder="https://hezo.example.com"
+					value={baseUrl}
+					onChange={(e) => setBaseUrl(e.target.value)}
+					className="sm:w-96"
+				/>
+				<Button
+					size="sm"
+					data-testid="instance-base-url-save"
+					onClick={handleSave}
+					disabled={!dirty || updateSettings.isPending}
+				>
+					{updateSettings.isPending && <Loader2 className="w-3 h-3 animate-spin" />} Save
+				</Button>
+			</div>
+			{error && (
+				<p className="text-[13px] text-danger mt-1.5" data-testid="instance-base-url-error">
+					{error}
+				</p>
+			)}
+		</>
+	);
+}

--- a/packages/web/src/components/markdown-prose.tsx
+++ b/packages/web/src/components/markdown-prose.tsx
@@ -4,7 +4,7 @@ import { useMemo } from 'react';
 import Markdown, { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useAgents } from '../hooks/use-agents';
-import { useDocMentions } from '../hooks/use-mentions';
+import { useDocMentions, useInstanceMentions } from '../hooks/use-mentions';
 import { useTaskMentions } from '../hooks/use-tasks';
 import { docPreviewPath } from '../lib/doc-preview';
 import {
@@ -33,6 +33,13 @@ interface MarkdownProseProps {
 	className?: string;
 	projectId?: string;
 	projectSlug?: string;
+	/**
+	 * Instance scope (the global CEO chat): mentions resolve across every
+	 * project via /api/mentions/resolve instead of the project-scoped
+	 * endpoints; only instance-unique references become links. Mutually
+	 * exclusive with `projectId`.
+	 */
+	instance?: boolean;
 }
 
 export function MarkdownProse({
@@ -41,6 +48,7 @@ export function MarkdownProse({
 	className,
 	projectId,
 	projectSlug,
+	instance,
 }: MarkdownProseProps) {
 	const { data: agents } = useAgents(projectId ?? '');
 	const taskCandidates = useMemo(() => extractTaskCandidates(children), [children]);
@@ -50,36 +58,46 @@ export function MarkdownProse({
 		[children, projectSlug],
 	);
 	const { data: resolvedDocs } = useDocMentions(projectId ?? '', docCandidates);
+	const { data: instanceResolved } = useInstanceMentions(children, instance === true && !projectId);
 
 	const agentsMap = useMemo<Map<string, AgentMentionData>>(() => {
 		const m = new Map<string, AgentMentionData>();
+		if (instanceResolved) {
+			for (const a of instanceResolved.agents) {
+				m.set(a.slug.toLowerCase(), { title: a.title, projectSlug: a.project_slug });
+			}
+			return m;
+		}
 		if (!agents) return m;
 		for (const a of agents) m.set(a.slug.toLowerCase(), { title: a.title });
 		return m;
-	}, [agents]);
+	}, [agents, instanceResolved]);
 
 	const tasksMap = useMemo<Map<string, TaskMentionData>>(() => {
 		const m = new Map<string, TaskMentionData>();
-		if (!resolvedTasks) return m;
-		for (const i of resolvedTasks) {
+		const source = instanceResolved?.tasks ?? resolvedTasks;
+		if (!source) return m;
+		for (const i of source) {
 			m.set(i.identifier.toLowerCase(), { title: i.title, projectSlug: i.project_slug });
 		}
 		return m;
-	}, [resolvedTasks]);
+	}, [resolvedTasks, instanceResolved]);
 
 	const kbDocsMap = useMemo<Map<string, KbDocMentionData>>(() => {
 		const m = new Map<string, KbDocMentionData>();
-		if (!resolvedDocs) return m;
-		for (const d of resolvedDocs.kb_docs) {
+		const source = instanceResolved?.kb_docs ?? resolvedDocs?.kb_docs;
+		if (!source) return m;
+		for (const d of source) {
 			m.set(d.slug.toLowerCase(), { title: d.title, size: d.size, updatedAt: d.updated_at });
 		}
 		return m;
-	}, [resolvedDocs]);
+	}, [resolvedDocs, instanceResolved]);
 
 	const projectDocsMap = useMemo<ProjectDocsMap>(() => {
 		const m: ProjectDocsMap = new Map();
-		if (!resolvedDocs) return m;
-		for (const d of resolvedDocs.project_docs) {
+		const source = instanceResolved?.project_docs ?? resolvedDocs?.project_docs;
+		if (!source) return m;
+		for (const d of source) {
 			const slug = d.project_slug.toLowerCase();
 			let perProject = m.get(slug);
 			if (!perProject) {
@@ -89,21 +107,27 @@ export function MarkdownProse({
 			perProject.set(d.filename, { size: d.size, updatedAt: d.updated_at });
 		}
 		return m;
-	}, [resolvedDocs]);
+	}, [resolvedDocs, instanceResolved]);
 
 	const assetsMap = useMemo<Map<string, AssetMentionData>>(() => {
 		const m = new Map<string, AssetMentionData>();
-		if (!resolvedDocs) return m;
-		for (const a of resolvedDocs.assets) {
-			m.set(a.filename, { id: a.id, contentType: a.content_type, signedUrl: a.signed_url });
+		const source = instanceResolved?.assets ?? resolvedDocs?.assets;
+		if (!source) return m;
+		for (const a of source) {
+			m.set(a.filename, {
+				id: a.id,
+				contentType: a.content_type,
+				signedUrl: a.signed_url,
+				projectSlug: a.project_slug,
+			});
 		}
 		return m;
-	}, [resolvedDocs]);
+	}, [resolvedDocs, instanceResolved]);
 
 	const remarkPlugins = useMemo<RemarkPlugin>(() => {
 		const plugins: NonNullable<RemarkPlugin> = [remarkGfm];
 		if (
-			projectId &&
+			(projectId || instance) &&
 			(agentsMap.size > 0 ||
 				tasksMap.size > 0 ||
 				kbDocsMap.size > 0 ||
@@ -115,6 +139,7 @@ export function MarkdownProse({
 				{
 					projectId,
 					projectSlug,
+					instance,
 					agents: agentsMap,
 					tasks: tasksMap,
 					kbDocs: kbDocsMap,
@@ -124,14 +149,20 @@ export function MarkdownProse({
 			]);
 		}
 		return plugins;
-	}, [projectId, projectSlug, agentsMap, tasksMap, kbDocsMap, projectDocsMap, assetsMap]);
+	}, [projectId, projectSlug, instance, agentsMap, tasksMap, kbDocsMap, projectDocsMap, assetsMap]);
 
-	const components = useMemo<Components>(
-		() => ({
+	const components = useMemo<Components>(() => {
+		// Mention links render whenever a scope is active: project scope carries
+		// the route's projectId; instance scope (CEO chat) derives each link's
+		// project from the per-entity data attributes instead.
+		const mentionsEnabled = Boolean(projectId) || instance === true;
+		return {
 			a: (props) => {
 				const attrs = props as {
+					'data-mention-admin'?: string;
 					'data-mention-agent-slug'?: string;
 					'data-mention-agent-title'?: string;
+					'data-mention-agent-project-slug'?: string;
 					'data-mention-passive'?: string;
 					'data-mention-task-identifier'?: string;
 					'data-mention-task-title'?: string;
@@ -154,7 +185,7 @@ export function MarkdownProse({
 
 				const kbSlug = attrs['data-mention-kb-slug'];
 				const kbTitle = attrs['data-mention-kb-title'];
-				if (kbSlug && kbTitle && projectId) {
+				if (kbSlug && kbTitle && mentionsEnabled) {
 					return (
 						<Tooltip
 							content={
@@ -174,7 +205,7 @@ export function MarkdownProse({
 
 				const docProject = attrs['data-mention-doc-project-slug'];
 				const docFilename = attrs['data-mention-doc-filename'];
-				if (docProject && docFilename && projectId) {
+				if (docProject && docFilename && mentionsEnabled) {
 					return (
 						<span className="inline-flex items-baseline gap-0.5">
 							<Tooltip
@@ -213,7 +244,7 @@ export function MarkdownProse({
 				const assetProject = attrs['data-mention-asset-project-slug'];
 				const assetFilename = attrs['data-mention-asset-filename'];
 				const assetUrl = attrs['data-mention-asset-url'];
-				if (assetProject && assetFilename && projectId) {
+				if (assetProject && assetFilename && mentionsEnabled) {
 					return (
 						<span className="inline-flex items-baseline gap-0.5">
 							<Link
@@ -245,7 +276,7 @@ export function MarkdownProse({
 				const commentId = attrs['data-mention-comment-id'];
 				const commentProjectSlug = attrs['data-mention-comment-project-slug'];
 				const commentTaskTitle = attrs['data-mention-comment-task-title'];
-				if (commentTaskIdentifier && commentId && commentProjectSlug && projectId) {
+				if (commentTaskIdentifier && commentId && commentProjectSlug && mentionsEnabled) {
 					return (
 						<Tooltip
 							content={`Comment in ${commentTaskIdentifier.toUpperCase()}${commentTaskTitle ? ` — ${commentTaskTitle}` : ''}`}
@@ -269,7 +300,7 @@ export function MarkdownProse({
 				const taskIdentifier = attrs['data-mention-task-identifier'];
 				const taskTitle = attrs['data-mention-task-title'];
 				const taskProjectSlug = attrs['data-mention-project-slug'];
-				if (taskIdentifier && taskTitle && taskProjectSlug && projectId) {
+				if (taskIdentifier && taskTitle && taskProjectSlug && mentionsEnabled) {
 					return (
 						<Tooltip content={taskTitle}>
 							<Link
@@ -290,12 +321,13 @@ export function MarkdownProse({
 				const agentSlug = attrs['data-mention-agent-slug'];
 				const agentTitle = attrs['data-mention-agent-title'];
 				const agentPassive = attrs['data-mention-passive'] === 'true';
-				if (agentSlug && projectId) {
+				const agentProjectSlug = attrs['data-mention-agent-project-slug'] ?? projectId;
+				if (agentSlug && agentProjectSlug && mentionsEnabled) {
 					return (
 						<Tooltip content={agentTitle ?? `@${agentSlug}`}>
 							<Link
 								to="/projects/$projectId/agents/$agentId"
-								params={{ projectId, agentId: agentSlug }}
+								params={{ projectId: agentProjectSlug, agentId: agentSlug }}
 								className={MENTION_CLASSES}
 								data-testid="agent-mention-link"
 								data-mention-passive={agentPassive ? 'true' : undefined}
@@ -305,15 +337,33 @@ export function MarkdownProse({
 						</Tooltip>
 					);
 				}
+
+				if (attrs['data-mention-admin'] === 'true' && mentionsEnabled) {
+					const adminLink = projectId ? (
+						<Link
+							to="/projects/$projectId/inbox"
+							params={{ projectId }}
+							className={MENTION_CLASSES}
+							data-testid="admin-mention-link"
+						>
+							{props.children}
+						</Link>
+					) : (
+						<Link to="/home/inbox" className={MENTION_CLASSES} data-testid="admin-mention-link">
+							{props.children}
+						</Link>
+					);
+					return <Tooltip content="Admin inbox">{adminLink}</Tooltip>;
+				}
+
 				return (
 					<a href={props.href} target="_blank" rel="noopener noreferrer">
 						{props.children}
 					</a>
 				);
 			},
-		}),
-		[projectId],
-	);
+		};
+	}, [projectId, instance]);
 
 	return (
 		<div

--- a/packages/web/src/hooks/use-instance-settings.ts
+++ b/packages/web/src/hooks/use-instance-settings.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { api } from '../lib/api';
+import { queryClient } from '../lib/query-client';
+import { queryKeys } from '../lib/query-keys';
+
+export interface InstanceSettings {
+	base_url: string | null;
+}
+
+export function useInstanceSettings() {
+	return useQuery({
+		queryKey: queryKeys.instanceSettings(),
+		queryFn: () => api.get<InstanceSettings>('/api/instance-settings'),
+	});
+}
+
+/**
+ * Response-driven (not optimistic): the server validates and normalizes the
+ * URL, so the cache is seeded from its echo rather than the typed value.
+ */
+export function useUpdateInstanceSettings() {
+	return useMutation({
+		mutationFn: (base_url: string | null) =>
+			api.patch<InstanceSettings>('/api/instance-settings', { base_url }),
+		onSuccess: (data) => {
+			queryClient.setQueryData(queryKeys.instanceSettings(), data);
+		},
+	});
+}

--- a/packages/web/src/hooks/use-mentions.ts
+++ b/packages/web/src/hooks/use-mentions.ts
@@ -1,3 +1,4 @@
+import { extractMentionCandidates } from '@hezo/shared';
 import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { api } from '../lib/api';
@@ -72,6 +73,56 @@ export function useDocMentions(projectId: string, candidates: DocMentionsRequest
 		enabled:
 			!!projectId &&
 			(key.kbSlugs.length > 0 || key.projectDocs.length > 0 || key.assets.length > 0),
+		staleTime: 60_000,
+	});
+}
+
+export interface InstanceResolvedTask {
+	identifier: string;
+	title: string;
+	project_slug: string;
+	status: string;
+}
+
+export interface InstanceResolvedAgent {
+	slug: string;
+	title: string;
+	project_slug: string;
+}
+
+export interface InstanceMentionsResponse {
+	tasks: InstanceResolvedTask[];
+	kb_docs: ResolvedKbDoc[];
+	project_docs: ResolvedProjectDoc[];
+	assets: ResolvedAsset[];
+	agents: InstanceResolvedAgent[];
+}
+
+/**
+ * Instance-wide mention resolution for the global CEO chat. Candidates are
+ * extracted from the message content client-side; the server resolves only
+ * references that are unique across the whole instance (ambiguous ones stay
+ * plain text). The sorted-array key dedupes identical candidate sets across
+ * messages and bounds refetches while a reply streams.
+ */
+export function useInstanceMentions(content: string, enabled: boolean) {
+	const key = useMemo(() => {
+		const c = extractMentionCandidates(content);
+		return {
+			tasks: [...c.tasks].sort(),
+			filenames: [...c.filenames].sort(),
+			assets: [...c.assets].sort(),
+			agents: [...c.agents].sort(),
+		};
+	}, [content]);
+
+	const hasCandidates =
+		key.tasks.length + key.filenames.length + key.assets.length + key.agents.length > 0;
+
+	return useQuery({
+		queryKey: queryKeys.instanceMentionsResolve(key),
+		queryFn: () => api.post<InstanceMentionsResponse>('/api/mentions/resolve', key),
+		enabled: enabled && hasCandidates,
 		staleTime: 60_000,
 	});
 }

--- a/packages/web/src/lib/query-keys.ts
+++ b/packages/web/src/lib/query-keys.ts
@@ -25,6 +25,8 @@ export const queryKeys = {
 	aiProviderModels: (configId: string) => ['ai-providers', configId, 'models'],
 	instanceAuditLog: (filters: KeyParam) => ['instance', 'audit-log', filters],
 	instanceSettings: () => ['instance', 'settings'],
+	/** Instance-wide mention resolution (global CEO chat), keyed by sorted candidates. */
+	instanceMentionsResolve: (key: KeyParam) => ['instance', 'mentions', 'resolve', key],
 	/** The single global CEO chat conversation (history + streamed messages). */
 	ceoConversation: () => ['ceo', 'conversation'],
 

--- a/packages/web/src/lib/query-keys.ts
+++ b/packages/web/src/lib/query-keys.ts
@@ -24,6 +24,7 @@ export const queryKeys = {
 	teamTemplates: () => ['team-templates'],
 	aiProviderModels: (configId: string) => ['ai-providers', configId, 'models'],
 	instanceAuditLog: (filters: KeyParam) => ['instance', 'audit-log', filters],
+	instanceSettings: () => ['instance', 'settings'],
 	/** The single global CEO chat conversation (history + streamed messages). */
 	ceoConversation: () => ['ceo', 'conversation'],
 

--- a/packages/web/src/lib/remark-mentions.ts
+++ b/packages/web/src/lib/remark-mentions.ts
@@ -1,4 +1,19 @@
-import { ADMIN_MENTION_SLUG } from '@hezo/shared';
+import {
+	ADMIN_MENTION_SLUG,
+	agentPath,
+	assetPath,
+	buildMentionRegex,
+	commentPath,
+	type MentionToken,
+	parseMentionMatch,
+	projectDocPath,
+	projectInboxPath,
+	taskPath,
+} from '@hezo/shared';
+
+// Candidate extraction lives in @hezo/shared (the server-side renderer uses it
+// too); re-exported here so web consumers keep a single import path.
+export { type DocCandidates, extractDocCandidates, extractTaskCandidates } from '@hezo/shared';
 
 interface TextNode {
 	type: 'text';
@@ -59,26 +74,7 @@ interface Options {
 	assets: Map<string, AssetMentionData>;
 }
 
-const PASSIVE_AGENT_RE_SRC = String.raw`(?<![\w@])@@([a-z][\w-]*)(?![\w/])`;
-const AGENT_RE_SRC = String.raw`(?<![\w@])@([a-z][\w-]*)(?![\w/])`;
-const TASK_RE_SRC = String.raw`(?<![\w-])([A-Z][A-Z0-9]{1,3}-\d+)(?![\w-])`;
-// Comment links embed a task identifier plus the comment's UUID
-// (`IN-42#comment-<uuid>`), reusing the `#comment-<uuid>` URL hash. The UUID is
-// shape-matched so `IN-42#comment-foo` prose stays plain text. This MUST come
-// before TASK_RE_SRC in the alternation: regex alternation prefers the leftmost
-// matching branch at a position, so otherwise TASK_RE_SRC consumes the bare
-// `IN-42` prefix and the `#comment-...` suffix is left dangling.
-const COMMENT_LINK_RE_SRC = String.raw`(?<![\w-])([A-Z][A-Z0-9]{1,3}-\d+)#comment-([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})(?![\w-])`;
-const FILENAME_RE_SRC = String.raw`(?<![\w/.-])([a-z0-9][\w-]*\.[a-z0-9]+)(?![\w/.-])`;
-// Asset references are path-prefixed (`assets/<name>.<ext>`) and may contain
-// uppercase (e.g. a task identifier embedded in the name). The leading `assets/`
-// keeps them from colliding with the bare project-doc filenames above.
-const ASSET_RE_SRC = String.raw`(?<![\w/.-])assets/([A-Za-z0-9][\w.-]*\.[A-Za-z0-9]+)(?![\w/.-])`;
-
-const MENTION_RE = new RegExp(
-	`${PASSIVE_AGENT_RE_SRC}|${AGENT_RE_SRC}|${COMMENT_LINK_RE_SRC}|${TASK_RE_SRC}|${FILENAME_RE_SRC}|${ASSET_RE_SRC}`,
-	'g',
-);
+const MENTION_RE = buildMentionRegex();
 
 const SKIP_TYPES = new Set(['code', 'inlineCode', 'link']);
 
@@ -116,7 +112,7 @@ function splitTextNode(node: TextNode, opts: Options): MdNode[] {
 	MENTION_RE.lastIndex = 0;
 	let match = MENTION_RE.exec(value);
 	while (match !== null) {
-		const link = buildLink(match, opts);
+		const link = buildLink(parseMentionMatch(match), opts);
 		if (!link) {
 			match = MENTION_RE.exec(value);
 			continue;
@@ -137,30 +133,23 @@ function splitTextNode(node: TextNode, opts: Options): MdNode[] {
 	return parts;
 }
 
-function buildLink(match: RegExpExecArray, opts: Options): LinkNode | null {
+function buildLink(token: MentionToken, opts: Options): LinkNode | null {
 	const { projectId, projectSlug, agents, tasks, kbDocs, projectDocs, assets } = opts;
-	const display = match[0];
-	const passiveAgentToken = match[1];
-	const agentToken = match[2];
-	const commentLinkTaskToken = match[3];
-	const commentLinkUuid = match[4];
-	const taskToken = match[5];
-	const filenameToken = match[6];
-	const assetToken = match[7];
+	const display = token.raw;
 
-	if (assetToken) {
+	if (token.kind === 'asset') {
 		if (!projectSlug) return null;
 		const slug = projectSlug.toLowerCase();
-		const data = assets.get(assetToken);
+		const data = assets.get(token.filename);
 		if (!data) return null;
 		return {
 			type: 'link',
-			url: `/projects/${slug}/assets?file=${encodeURIComponent(assetToken)}`,
+			url: assetPath(slug, token.filename),
 			children: [{ type: 'text', value: display }],
 			data: {
 				hProperties: {
 					'data-mention-asset-project-slug': slug,
-					'data-mention-asset-filename': assetToken,
+					'data-mention-asset-filename': token.filename,
 					'data-mention-asset-content-type': data.contentType,
 					'data-mention-asset-url': data.signedUrl,
 				},
@@ -168,13 +157,14 @@ function buildLink(match: RegExpExecArray, opts: Options): LinkNode | null {
 		};
 	}
 
-	if (passiveAgentToken) {
-		const slug = passiveAgentToken.toLowerCase();
-		if (slug === ADMIN_MENTION_SLUG) {
+	if (token.kind === 'passive_agent') {
+		// `@@slug` renders as `@slug` — passive mentions display like active ones.
+		const passiveDisplay = display.slice(1);
+		if (token.slug === ADMIN_MENTION_SLUG) {
 			return {
 				type: 'link',
-				url: `/projects/${projectId}/inbox`,
-				children: [{ type: 'text', value: `@${passiveAgentToken}` }],
+				url: projectInboxPath(projectId),
+				children: [{ type: 'text', value: passiveDisplay }],
 				data: {
 					hProperties: {
 						'data-mention-admin': 'true',
@@ -183,15 +173,15 @@ function buildLink(match: RegExpExecArray, opts: Options): LinkNode | null {
 				},
 			};
 		}
-		const data = agents.get(slug);
+		const data = agents.get(token.slug);
 		if (!data) return null;
 		return {
 			type: 'link',
-			url: `/projects/${projectId}/agents/${slug}`,
-			children: [{ type: 'text', value: `@${passiveAgentToken}` }],
+			url: agentPath(projectId, token.slug),
+			children: [{ type: 'text', value: passiveDisplay }],
 			data: {
 				hProperties: {
-					'data-mention-agent-slug': slug,
+					'data-mention-agent-slug': token.slug,
 					'data-mention-agent-title': data.title,
 					'data-mention-passive': 'true',
 				},
@@ -199,12 +189,11 @@ function buildLink(match: RegExpExecArray, opts: Options): LinkNode | null {
 		};
 	}
 
-	if (agentToken) {
-		const slug = agentToken.toLowerCase();
-		if (slug === ADMIN_MENTION_SLUG) {
+	if (token.kind === 'agent') {
+		if (token.slug === ADMIN_MENTION_SLUG) {
 			return {
 				type: 'link',
-				url: `/projects/${projectId}/inbox`,
+				url: projectInboxPath(projectId),
 				children: [{ type: 'text', value: display }],
 				data: {
 					hProperties: {
@@ -213,33 +202,32 @@ function buildLink(match: RegExpExecArray, opts: Options): LinkNode | null {
 				},
 			};
 		}
-		const data = agents.get(slug);
+		const data = agents.get(token.slug);
 		if (!data) return null;
 		return {
 			type: 'link',
-			url: `/projects/${projectId}/agents/${slug}`,
+			url: agentPath(projectId, token.slug),
 			children: [{ type: 'text', value: display }],
 			data: {
 				hProperties: {
-					'data-mention-agent-slug': slug,
+					'data-mention-agent-slug': token.slug,
 					'data-mention-agent-title': data.title,
 				},
 			},
 		};
 	}
 
-	if (commentLinkTaskToken && commentLinkUuid) {
-		const key = commentLinkTaskToken.toLowerCase();
-		const data = tasks.get(key);
+	if (token.kind === 'comment') {
+		const data = tasks.get(token.taskIdentifier);
 		if (!data) return null;
 		return {
 			type: 'link',
-			url: `/projects/${data.projectSlug}/tasks/${key}#comment-${commentLinkUuid}`,
+			url: commentPath(data.projectSlug, token.taskIdentifier, token.commentId),
 			children: [{ type: 'text', value: display }],
 			data: {
 				hProperties: {
-					'data-mention-comment-task-identifier': key,
-					'data-mention-comment-id': commentLinkUuid,
+					'data-mention-comment-task-identifier': token.taskIdentifier,
+					'data-mention-comment-id': token.commentId,
 					'data-mention-comment-project-slug': data.projectSlug,
 					'data-mention-comment-task-title': data.title,
 				},
@@ -247,17 +235,16 @@ function buildLink(match: RegExpExecArray, opts: Options): LinkNode | null {
 		};
 	}
 
-	if (taskToken) {
-		const key = taskToken.toLowerCase();
-		const data = tasks.get(key);
+	if (token.kind === 'task') {
+		const data = tasks.get(token.identifier);
 		if (!data) return null;
 		return {
 			type: 'link',
-			url: `/projects/${data.projectSlug}/tasks/${key}`,
+			url: taskPath(data.projectSlug, token.identifier),
 			children: [{ type: 'text', value: display }],
 			data: {
 				hProperties: {
-					'data-mention-task-identifier': key,
+					'data-mention-task-identifier': token.identifier,
 					'data-mention-task-title': data.title,
 					'data-mention-project-slug': data.projectSlug,
 				},
@@ -265,20 +252,20 @@ function buildLink(match: RegExpExecArray, opts: Options): LinkNode | null {
 		};
 	}
 
-	if (filenameToken) {
+	if (token.kind === 'filename') {
 		if (projectSlug) {
 			const slug = projectSlug.toLowerCase();
 			const perProject = projectDocs.get(slug);
-			const data = perProject?.get(filenameToken);
+			const data = perProject?.get(token.filename);
 			if (data) {
 				return {
 					type: 'link',
-					url: `/projects/${slug}/documents?file=${encodeURIComponent(filenameToken)}`,
+					url: projectDocPath(slug, token.filename),
 					children: [{ type: 'text', value: display }],
 					data: {
 						hProperties: {
 							'data-mention-doc-project-slug': slug,
-							'data-mention-doc-filename': filenameToken,
+							'data-mention-doc-filename': token.filename,
 							'data-mention-size': String(data.size),
 							'data-mention-updated-at': data.updatedAt,
 						},
@@ -287,7 +274,7 @@ function buildLink(match: RegExpExecArray, opts: Options): LinkNode | null {
 			}
 		}
 
-		const kbKey = filenameToken.toLowerCase();
+		const kbKey = token.filename.toLowerCase();
 		const kbData = kbDocs.get(kbKey);
 		if (kbData) {
 			return {
@@ -307,61 +294,4 @@ function buildLink(match: RegExpExecArray, opts: Options): LinkNode | null {
 	}
 
 	return null;
-}
-
-export function extractTaskCandidates(value: string): string[] {
-	const stripped = stripCode(value);
-	const re = new RegExp(TASK_RE_SRC, 'g');
-	const out = new Set<string>();
-	let m = re.exec(stripped);
-	while (m !== null) {
-		out.add(m[1].toLowerCase());
-		m = re.exec(stripped);
-	}
-	return Array.from(out);
-}
-
-export interface DocCandidates {
-	kbSlugs: string[];
-	projectDocs: Array<{ project_slug: string; filename: string }>;
-	assets: Array<{ project_slug: string; filename: string }>;
-}
-
-export function extractDocCandidates(value: string, projectSlug?: string): DocCandidates {
-	const stripped = stripCode(value);
-	const filenameSet = new Set<string>();
-
-	const re = new RegExp(FILENAME_RE_SRC, 'g');
-	let m = re.exec(stripped);
-	while (m !== null) {
-		filenameSet.add(m[1]);
-		m = re.exec(stripped);
-	}
-
-	const assetSet = new Set<string>();
-	const assetRe = new RegExp(ASSET_RE_SRC, 'g');
-	let am = assetRe.exec(stripped);
-	while (am !== null) {
-		assetSet.add(am[1]);
-		am = assetRe.exec(stripped);
-	}
-
-	const kbSlugs = Array.from(filenameSet, (f) => f.toLowerCase());
-	const projectDocs: Array<{ project_slug: string; filename: string }> = [];
-	const assets: Array<{ project_slug: string; filename: string }> = [];
-	if (projectSlug) {
-		const slug = projectSlug.toLowerCase();
-		for (const filename of filenameSet) {
-			projectDocs.push({ project_slug: slug, filename });
-		}
-		for (const filename of assetSet) {
-			assets.push({ project_slug: slug, filename });
-		}
-	}
-
-	return { kbSlugs, projectDocs, assets };
-}
-
-function stripCode(value: string): string {
-	return value.replace(/```[\s\S]*?```|~~~[\s\S]*?~~~/g, ' ').replace(/`[^`]*`/g, ' ');
 }

--- a/packages/web/src/lib/remark-mentions.ts
+++ b/packages/web/src/lib/remark-mentions.ts
@@ -4,10 +4,12 @@ import {
 	assetPath,
 	buildMentionRegex,
 	commentPath,
+	GLOBAL_INBOX_PATH,
 	type MentionToken,
 	parseMentionMatch,
 	projectDocPath,
 	projectInboxPath,
+	SKILLS_SETTINGS_PATH,
 	taskPath,
 } from '@hezo/shared';
 
@@ -38,6 +40,8 @@ type MdNode = ParentNode | TextNode | LinkNode;
 
 export interface AgentMentionData {
 	title: string;
+	/** Set in instance scope: the agent's home project (HQ agents → `hq`). */
+	projectSlug?: string;
 }
 
 export interface TaskMentionData {
@@ -62,11 +66,19 @@ export interface AssetMentionData {
 	id: string;
 	contentType: string;
 	signedUrl: string;
+	/** Set in instance scope: the project the asset belongs to. */
+	projectSlug?: string;
 }
 
 interface Options {
-	projectId: string;
+	/**
+	 * Project scope: links resolve against this project (agents, admin inbox,
+	 * KB). Instance scope (the global CEO chat) omits it and sets `instance` —
+	 * every link then derives its project from the per-entity resolution data.
+	 */
+	projectId?: string;
 	projectSlug?: string;
+	instance?: boolean;
 	agents: Map<string, AgentMentionData>;
 	tasks: Map<string, TaskMentionData>;
 	kbDocs: Map<string, KbDocMentionData>;
@@ -138,10 +150,10 @@ function buildLink(token: MentionToken, opts: Options): LinkNode | null {
 	const display = token.raw;
 
 	if (token.kind === 'asset') {
-		if (!projectSlug) return null;
-		const slug = projectSlug.toLowerCase();
 		const data = assets.get(token.filename);
 		if (!data) return null;
+		const slug = (data.projectSlug ?? projectSlug)?.toLowerCase();
+		if (!slug) return null;
 		return {
 			type: 'link',
 			url: assetPath(slug, token.filename),
@@ -163,7 +175,7 @@ function buildLink(token: MentionToken, opts: Options): LinkNode | null {
 		if (token.slug === ADMIN_MENTION_SLUG) {
 			return {
 				type: 'link',
-				url: projectInboxPath(projectId),
+				url: projectId ? projectInboxPath(projectId) : GLOBAL_INBOX_PATH,
 				children: [{ type: 'text', value: passiveDisplay }],
 				data: {
 					hProperties: {
@@ -175,14 +187,17 @@ function buildLink(token: MentionToken, opts: Options): LinkNode | null {
 		}
 		const data = agents.get(token.slug);
 		if (!data) return null;
+		const agentProject = data.projectSlug ?? projectId;
+		if (!agentProject) return null;
 		return {
 			type: 'link',
-			url: agentPath(projectId, token.slug),
+			url: agentPath(agentProject, token.slug),
 			children: [{ type: 'text', value: passiveDisplay }],
 			data: {
 				hProperties: {
 					'data-mention-agent-slug': token.slug,
 					'data-mention-agent-title': data.title,
+					'data-mention-agent-project-slug': agentProject,
 					'data-mention-passive': 'true',
 				},
 			},
@@ -193,7 +208,7 @@ function buildLink(token: MentionToken, opts: Options): LinkNode | null {
 		if (token.slug === ADMIN_MENTION_SLUG) {
 			return {
 				type: 'link',
-				url: projectInboxPath(projectId),
+				url: projectId ? projectInboxPath(projectId) : GLOBAL_INBOX_PATH,
 				children: [{ type: 'text', value: display }],
 				data: {
 					hProperties: {
@@ -204,14 +219,17 @@ function buildLink(token: MentionToken, opts: Options): LinkNode | null {
 		}
 		const data = agents.get(token.slug);
 		if (!data) return null;
+		const agentProject = data.projectSlug ?? projectId;
+		if (!agentProject) return null;
 		return {
 			type: 'link',
-			url: agentPath(projectId, token.slug),
+			url: agentPath(agentProject, token.slug),
 			children: [{ type: 'text', value: display }],
 			data: {
 				hProperties: {
 					'data-mention-agent-slug': token.slug,
 					'data-mention-agent-title': data.title,
+					'data-mention-agent-project-slug': agentProject,
 				},
 			},
 		};
@@ -253,33 +271,32 @@ function buildLink(token: MentionToken, opts: Options): LinkNode | null {
 	}
 
 	if (token.kind === 'filename') {
-		if (projectSlug) {
-			const slug = projectSlug.toLowerCase();
-			const perProject = projectDocs.get(slug);
-			const data = perProject?.get(token.filename);
-			if (data) {
-				return {
-					type: 'link',
-					url: projectDocPath(slug, token.filename),
-					children: [{ type: 'text', value: display }],
-					data: {
-						hProperties: {
-							'data-mention-doc-project-slug': slug,
-							'data-mention-doc-filename': token.filename,
-							'data-mention-size': String(data.size),
-							'data-mention-updated-at': data.updatedAt,
-						},
+		const docHit = findProjectDoc(token.filename, opts);
+		if (docHit) {
+			return {
+				type: 'link',
+				url: projectDocPath(docHit.projectSlug, token.filename),
+				children: [{ type: 'text', value: display }],
+				data: {
+					hProperties: {
+						'data-mention-doc-project-slug': docHit.projectSlug,
+						'data-mention-doc-filename': token.filename,
+						'data-mention-size': String(docHit.data.size),
+						'data-mention-updated-at': docHit.data.updatedAt,
 					},
-				};
-			}
+				},
+			};
 		}
 
 		const kbKey = token.filename.toLowerCase();
 		const kbData = kbDocs.get(kbKey);
 		if (kbData) {
+			const slugParam = `slug=${encodeURIComponent(kbKey)}`;
 			return {
 				type: 'link',
-				url: `/projects/${projectId}/skills?slug=${encodeURIComponent(kbKey)}`,
+				url: projectId
+					? `/projects/${projectId}/skills?${slugParam}`
+					: `${SKILLS_SETTINGS_PATH}?${slugParam}`,
 				children: [{ type: 'text', value: display }],
 				data: {
 					hProperties: {
@@ -293,5 +310,25 @@ function buildLink(token: MentionToken, opts: Options): LinkNode | null {
 		}
 	}
 
+	return null;
+}
+
+function findProjectDoc(
+	filename: string,
+	opts: Options,
+): { projectSlug: string; data: ProjectDocMentionData } | null {
+	if (opts.projectSlug) {
+		const slug = opts.projectSlug.toLowerCase();
+		const data = opts.projectDocs.get(slug)?.get(filename);
+		return data ? { projectSlug: slug, data } : null;
+	}
+	if (opts.instance) {
+		// Instance scope: the resolver returns a filename only when exactly one
+		// project has it, so the first per-project hit is the only one.
+		for (const [slug, perProject] of opts.projectDocs) {
+			const data = perProject.get(filename);
+			if (data) return { projectSlug: slug, data };
+		}
+	}
 	return null;
 }

--- a/packages/web/src/routes/settings/index.tsx
+++ b/packages/web/src/routes/settings/index.tsx
@@ -1,10 +1,14 @@
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { useState } from 'react';
 import { AiProvidersSection } from '../../components/ai-providers-section';
+import { InstanceSettingsSection } from '../../components/instance-settings-section';
 import { InfoTooltip } from '../../components/ui/info-tooltip';
 import { useMe } from '../../hooks/use-me';
 
-const settingsNav = [{ id: 'ai-providers', label: 'AI providers' }];
+const settingsNav = [
+	{ id: 'ai-providers', label: 'AI providers' },
+	{ id: 'instance', label: 'Instance' },
+];
 
 // Instance-level resources shared across every team — Admin (superuser) only.
 const instanceNav = [
@@ -65,6 +69,9 @@ function GlobalSettingsPage() {
 				<div className="space-y-8">
 					<div id="settings-ai-providers">
 						<AiProvidersSection />
+					</div>
+					<div id="settings-instance">
+						<InstanceSettingsSection />
 					</div>
 				</div>
 			</div>

--- a/packages/web/test/ceo-chat-mentions.test.tsx
+++ b/packages/web/test/ceo-chat-mentions.test.tsx
@@ -1,0 +1,142 @@
+import type { CeoMessage } from '@hezo/web/hooks/use-ceo-chat';
+import { queryClient } from '@hezo/web/lib/query-client';
+import { queryKeys } from '@hezo/web/lib/query-keys';
+import { waitFor } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { getTestContext, renderApp } from './helpers/render';
+import { seedComment, seedProject, seedTask, seedWorkspace } from './helpers/seed';
+
+// The CEO chat renders replies in instance scope: entity references resolve
+// through the real in-process backend (POST /api/mentions/resolve) and unique
+// ones become client-side <Link>s. The harness has no CeoSessionManager, so
+// replies are seeded straight into the conversation query cache the widget
+// reads (same pattern as ceo-chat.test.tsx).
+
+const now = () => new Date().toISOString();
+
+function seedCeoReply(content: string) {
+	queryClient.setQueryData(queryKeys.ceoConversation(), {
+		conversation_id: 'test-convo',
+		messages: [
+			{
+				id: 'a1',
+				role: 'assistant',
+				channel: 'web',
+				status: 'complete',
+				content,
+				created_at: now(),
+			} as CeoMessage,
+		],
+	});
+}
+
+interface SeededRefs {
+	projectSlug: string;
+	taskIdentifier: string;
+	commentId: string;
+}
+
+async function seedEntities(): Promise<SeededRefs> {
+	const ws = await seedWorkspace();
+	const project = await seedProject(ws, { name: 'Demo' });
+	const task = await seedTask(ws, project, { title: 'Demo Task' });
+	const comment = await seedComment(ws, task, 'first comment');
+	const { apiBase } = getTestContext();
+	await apiBase(`/api/projects/${project.slug}/docs/prd.md`, {
+		method: 'PUT',
+		headers: ws.headers,
+		body: JSON.stringify({ content: '# PRD' }),
+	});
+	return { projectSlug: project.slug, taskIdentifier: task.identifier, commentId: comment.id };
+}
+
+test('CEO replies render unique refs as links; unknown and backticked refs stay plain', async () => {
+	let refs!: SeededRefs;
+	const { findByTestId, getByTestId } = await renderApp({
+		initialPath: '/home',
+		seed: async () => {
+			refs = await seedEntities();
+		},
+	});
+
+	(await findByTestId('ceo-chat-launcher')).click();
+	await findByTestId('ceo-chat-panel');
+
+	const ident = refs.taskIdentifier;
+	seedCeoReply(
+		[
+			`Progress lives in ${ident} — see ${ident}#comment-${refs.commentId} and prd.md for context.`,
+			`The spec for ZZ-99 is pending. Mention syntax: \`${ident}\`.`,
+		].join('\n\n'),
+	);
+
+	const taskLink = await findByTestId('task-mention-link');
+	expect(taskLink.getAttribute('href')).toBe(
+		`/projects/${refs.projectSlug}/tasks/${ident.toLowerCase()}`,
+	);
+
+	const commentLink = getByTestId('comment-mention-link');
+	expect(commentLink.getAttribute('href')).toBe(
+		`/projects/${refs.projectSlug}/tasks/${ident.toLowerCase()}#comment-${refs.commentId}`,
+	);
+
+	const docLink = getByTestId('doc-mention-link');
+	expect(docLink.getAttribute('href')).toBe(`/projects/${refs.projectSlug}/documents?file=prd.md`);
+
+	// Unknown identifiers stay plain text — no link wraps ZZ-99.
+	const body = getByTestId('ceo-chat-markdown');
+	const linkTexts = Array.from(body.querySelectorAll('a')).map((a) => a.textContent);
+	expect(linkTexts).not.toContain('ZZ-99');
+	expect(body.textContent).toContain('ZZ-99');
+
+	// Backticked references render as inert code, never links.
+	const codeTexts = Array.from(body.querySelectorAll('code')).map((el) => el.textContent);
+	expect(codeTexts).toContain(ident);
+});
+
+test('clicking a chat comment link navigates client-side with the chat still open', async () => {
+	let refs!: SeededRefs;
+	const { findByTestId, getByTestId, router, user } = await renderApp({
+		initialPath: '/home',
+		seed: async () => {
+			refs = await seedEntities();
+		},
+	});
+
+	(await findByTestId('ceo-chat-launcher')).click();
+	await findByTestId('ceo-chat-panel');
+
+	seedCeoReply(`Answered in ${refs.taskIdentifier}#comment-${refs.commentId}.`);
+
+	await user.click(await findByTestId('comment-mention-link'));
+
+	await waitFor(() =>
+		expect(router.state.location.pathname).toBe(
+			`/projects/${refs.projectSlug}/tasks/${refs.taskIdentifier.toLowerCase()}`,
+		),
+	);
+	expect(router.state.location.hash).toBe(`comment-${refs.commentId}`);
+
+	// The widget lives in the root layout, outside the route outlet — the panel
+	// (and the rendered reply) survive the navigation.
+	expect(getByTestId('ceo-chat-panel')).toBeTruthy();
+	expect(getByTestId('ceo-chat-markdown')).toBeTruthy();
+});
+
+test('agent mentions link to the agent home project; HQ singletons resolve to hq', async () => {
+	const { findByTestId } = await renderApp({
+		initialPath: '/home',
+		seed: async () => {
+			await seedWorkspace();
+		},
+	});
+
+	(await findByTestId('ceo-chat-launcher')).click();
+	await findByTestId('ceo-chat-panel');
+
+	seedCeoReply('Ask @@ceo to review.');
+
+	const agentLink = await findByTestId('agent-mention-link');
+	expect(agentLink.getAttribute('href')).toBe('/projects/hq/agents/ceo');
+	expect(agentLink.textContent).toBe('@ceo');
+});

--- a/packages/web/test/instance-settings.test.tsx
+++ b/packages/web/test/instance-settings.test.tsx
@@ -1,0 +1,41 @@
+import { waitFor } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { getTestContext, renderApp } from './helpers/render';
+
+async function fetchBaseUrl(): Promise<string | null> {
+	const { apiBase, token } = getTestContext();
+	const res = await apiBase('/api/instance-settings', {
+		headers: { Authorization: `Bearer ${token}` },
+	});
+	const body = (await res.json()) as { data: { base_url: string | null } };
+	return body.data.base_url;
+}
+
+test('instance base URL saves from /settings and echoes the normalized origin', async () => {
+	const { findByTestId, findByRole, user } = await renderApp({ initialPath: '/settings' });
+
+	await findByRole('heading', { name: 'Instance' });
+	const input = (await findByTestId('instance-base-url-input')) as HTMLInputElement;
+	expect(input.value).toBe('');
+
+	await user.type(input, 'https://Hezo.Example.com:8443/');
+	await user.click(await findByTestId('instance-base-url-save'));
+
+	// Response-driven: the input reflects the server-normalized origin.
+	await waitFor(() => expect(input.value).toBe('https://hezo.example.com:8443'));
+	expect(await fetchBaseUrl()).toBe('https://hezo.example.com:8443');
+});
+
+test('an invalid base URL shows an inline error and saves nothing', async () => {
+	const { findByTestId, user } = await renderApp({ initialPath: '/settings' });
+
+	const input = (await findByTestId('instance-base-url-input')) as HTMLInputElement;
+	await user.type(input, 'https://x.example.com/some/path');
+	await user.click(await findByTestId('instance-base-url-save'));
+
+	const error = await findByTestId('instance-base-url-error');
+	expect(error.textContent).toMatch(/http\(s\) origin/);
+	// The typed value stays in place for correction; nothing was persisted.
+	expect(input.value).toBe('https://x.example.com/some/path');
+	expect(await fetchBaseUrl()).toBeNull();
+});


### PR DESCRIPTION
## Summary

The CEO chatbox showed references to tasks, comments, docs, assets, and agents as inert inline code. This PR makes them render as **links to the live Hezo instance**, with a per-channel renderer abstraction so each delivery surface decides how references appear, plus the **instance base URL** plumbing the non-web channels need.

### Web chatbox (live now)
- `MarkdownProse` gains an **instance scope**: CEO replies extract reference candidates client-side and resolve them through a new `POST /api/mentions/resolve` (HQ-gated, like `/ceo/*`). Unique refs render as relative TanStack `Link`s — **clicking a comment/task link navigates client-side (no reload) and the chatbox stays open** (it lives in the root layout).
- References resolve only when **unique instance-wide** (task identifiers can collide across teams; filenames/agent slugs collide commonly). Ambiguous/unknown refs stay plain text — a wrong link is worse than no link. HQ singletons (`@ceo`, `@coach`) resolve to `/projects/hq/...`; admin mentions now render as inbox links instead of dead external anchors.

### Renderer abstraction (channels)
- Mention regexes, candidate extraction, a code-fence-aware transformer, and entity path builders moved to `@hezo/shared/mentions` — one tokenizer for the web remark plugin and the server renderer.
- `renderCeoMessageForChannel` (`packages/server/src/services/ceo-message-render.ts`) is the seam future delivery bots call: **web** → unchanged (client renders), **telegram** → unique refs become `[ref](```&lt;base URL&gt;```<path>)` absolute markdown links, **whatsapp** → plain text. Stored `ceo_messages.content` is never mutated.

### Instance base URL
- Captured automatically from the request origin (`host` + `x-forwarded-proto`) on the **first successful master-key unlock**; never overwritten afterwards. Stored in `system_meta` (no schema change).
- `GET/PATCH /api/instance-settings` (superuser writes, origin-normalized validation) + an editable **Instance** section on `/settings`.
- `oauth.ts` origin derivation extracted into a shared `requestOrigin` helper.

### Prompt fixes
- `agents/_instance/ceo.md` and the runtime `CHAT_GUIDE` block both instructed backtick-wrapped examples (`` `TO-1` ``), which is what produced code-styled refs (the mention pipeline deliberately never linkifies code spans). Both now require bare references per `linking-syntax.md`.

## Tests
- Server: `instance-settings` (capture-on-unlock, validation, superuser gating), `instance-mentions` (cross-team uniqueness, disabled agents, HQ gating incl. agent-token rejection), `ceo-message-render` (per-channel semantics, code spans untouched, unset base URL), `mention-tokens` (tokenizer/paths pure logic).
- Web component: CEO chat renders task/comment/doc links with exact hrefs, unknown + backticked refs stay plain, **click → client-side route change with the chat panel still mounted**, `@ceo → /projects/hq/agents/ceo`; instance settings save/normalize/error flows.
- All existing mention/markdown/settings suites pass unchanged (the shared-module extraction is byte-identical for project scope).

https://claude.ai/code/session_01BNKCJRQFsCEGDPD2ubt6kJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNKCJRQFsCEGDPD2ubt6kJ)_