### PR TITLE
fix(runs): never let post-run teardown strand an agent in 'running'

### DIFF
--- a/packages/server/src/lib/net.ts
+++ b/packages/server/src/lib/net.ts
@@ -1,0 +1,43 @@
+import type { Server as HttpServer } from 'node:http';
+import type { Server as HttpsServer } from 'node:https';
+import type { Server as NetServer } from 'node:net';
+import { logger } from '../logger';
+
+const log = logger.child('net');
+
+const DEFAULT_CLOSE_DEADLINE_MS = 5_000;
+
+type CloseableServer = HttpServer | HttpsServer | NetServer;
+
+/**
+ * Close a server with a hard upper bound on how long the close can take.
+ * `server.close()`'s callback only fires once every accepted connection has
+ * ended, so a lingering (or mis-accounted) connection can park the returned
+ * promise forever and wedge whatever awaits it. Force-destroys remaining
+ * connections where the runtime supports it and resolves after the deadline
+ * regardless, so callers on a run-completion path can never hang on teardown.
+ */
+export function closeServerWithDeadline(
+	server: CloseableServer,
+	label: string,
+	deadlineMs: number = DEFAULT_CLOSE_DEADLINE_MS,
+): Promise<void> {
+	return new Promise<void>((resolve) => {
+		let settled = false;
+		const finish = (timedOut: boolean) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			if (timedOut) {
+				log.warn(`server close timed out after ${deadlineMs}ms; abandoning wait`, { label });
+			}
+			resolve();
+		};
+		const timer = setTimeout(() => finish(true), deadlineMs);
+		server.close(() => finish(false));
+		// http/https servers can sever remaining keep-alive and hijacked
+		// connections immediately; net servers expose no equivalent, so their
+		// callers destroy tracked sockets before closing.
+		(server as Partial<HttpServer>).closeAllConnections?.();
+	});
+}

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -28,6 +28,7 @@ import type { MasterKeyManager } from '../crypto/master-key';
 import type { DomainEventBus } from '../events/bus';
 import { broadcastRowChange } from '../lib/broadcast';
 import { withTransaction } from '../lib/sql';
+import { logger } from '../logger';
 import { signAgentJwt } from '../middleware/auth';
 import { type AgentRunUsage, createAgentStreamParser } from './agent-stream-parser';
 import {
@@ -63,6 +64,8 @@ import { recordStatusChange } from './task-events';
 import { resolveSystemPrompt } from './template-resolver';
 import { getRunSocketPath, getWorkspacePath, getWorktreesPath } from './workspace';
 import type { WebSocketManager } from './ws';
+
+const log = logger.child('agent-runner');
 
 export interface AgentInfo {
 	id: string;
@@ -809,20 +812,6 @@ export async function runAgent(
 			egressEnv,
 		);
 
-		if (signal?.aborted) {
-			const dirToRemove = context.subscriptionMount?.hostDir ?? context.homeMount?.hostDir;
-			if (dirToRemove) {
-				rmSync(dirToRemove, { recursive: true, force: true });
-			}
-			if (deps.sshAgentServer) {
-				await deps.sshAgentServer.releaseRunSocket(heartbeatRunId);
-			}
-			if (deps.egressProxy && egressAllocated) {
-				await deps.egressProxy.releaseRunProxy(heartbeatRunId);
-			}
-			return finalizeAbort();
-		}
-
 		const hostPromptPath = getHostPromptPath(
 			deps.dataDir,
 			project.team_id,
@@ -855,20 +844,42 @@ export async function runAgent(
 			}
 		};
 
+		// Best-effort teardown of run-scoped artifacts. Each step is isolated so a
+		// failed or slow release can never block the run result from reaching the
+		// completion bookkeeping (lock release, idle flip, wakeup completion) —
+		// a wedge here previously left agents stuck "running" forever.
 		const cleanupRunArtifacts = async () => {
-			await persistRotatedAuth();
-			rmSync(hostPromptPath, { force: true });
-			const dirToRemove = context.subscriptionMount?.hostDir ?? context.homeMount?.hostDir;
-			if (dirToRemove) {
-				rmSync(dirToRemove, { recursive: true, force: true });
-			}
-			if (deps.sshAgentServer) {
-				await deps.sshAgentServer.releaseRunSocket(heartbeatRunId);
-			}
-			if (deps.egressProxy && egressAllocated) {
-				await deps.egressProxy.releaseRunProxy(heartbeatRunId);
-			}
+			const step = async (label: string, fn: () => void | Promise<void>) => {
+				try {
+					await fn();
+				} catch (e) {
+					log.error(`Run ${heartbeatRunId} artifact cleanup step '${label}' failed:`, e);
+				}
+			};
+			await step('persist-rotated-auth', persistRotatedAuth);
+			await step('remove-prompt', () => rmSync(hostPromptPath, { force: true }));
+			await step('remove-home-mount', () => {
+				const dirToRemove = context.subscriptionMount?.hostDir ?? context.homeMount?.hostDir;
+				if (dirToRemove) {
+					rmSync(dirToRemove, { recursive: true, force: true });
+				}
+			});
+			await step('release-ssh-socket', async () => {
+				if (deps.sshAgentServer) {
+					await deps.sshAgentServer.releaseRunSocket(heartbeatRunId);
+				}
+			});
+			await step('release-egress-proxy', async () => {
+				if (deps.egressProxy && egressAllocated) {
+					await deps.egressProxy.releaseRunProxy(heartbeatRunId);
+				}
+			});
 		};
+
+		if (signal?.aborted) {
+			await cleanupRunArtifacts();
+			return finalizeAbort();
+		}
 
 		try {
 			if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');

--- a/packages/server/src/services/egress/proxy.ts
+++ b/packages/server/src/services/egress/proxy.ts
@@ -17,6 +17,7 @@ import type { CA } from 'mockttp/dist/util/certificates';
 import { getCA } from 'mockttp/dist/util/certificates';
 import type { MasterKeyManager } from '../../crypto/master-key';
 import { ref } from '../../lib/log-ref';
+import { closeServerWithDeadline } from '../../lib/net';
 import { logger } from '../../logger';
 import { type EgressAuditEvent, recordEgressEvent } from './audit';
 import type { HezoCA } from './ca';
@@ -232,13 +233,13 @@ class RunProxyInstance {
 	async close(): Promise<void> {
 		this.closed = true;
 		const closables: Array<Promise<void>> = [];
-		for (const { server } of this.hostServers.values()) {
-			closables.push(closeServer(server));
+		for (const [host, { server }] of this.hostServers.entries()) {
+			closables.push(closeServer(server, `${this.cfg.scope.label}/${host}`));
 		}
 		this.hostServers.clear();
 		this.pendingHostServers.clear();
 		if (this.front) {
-			closables.push(closeServer(this.front));
+			closables.push(closeServer(this.front, `${this.cfg.scope.label}/front`));
 			this.front = null;
 		}
 		await Promise.all(closables);
@@ -301,7 +302,7 @@ class RunProxyInstance {
 		const stale = this.hostServers.get(host);
 		if (stale) {
 			this.hostServers.delete(host);
-			void closeServer(stale.server);
+			void closeServer(stale.server, `${this.cfg.scope.label}/${host}`);
 		}
 
 		const ca = await this.cfg.getMintCa();
@@ -328,7 +329,7 @@ class RunProxyInstance {
 		});
 
 		if (this.closed) {
-			await closeServer(server);
+			await closeServer(server, `${this.cfg.scope.label}/${host}`);
 			throw new Error('proxy closed');
 		}
 
@@ -540,10 +541,8 @@ function serverOwnsPort(rec: HostServer): boolean {
 	return typeof addr === 'object' && addr !== null && addr.port === rec.port;
 }
 
-function closeServer(server: HttpServer | HttpsServer): Promise<void> {
-	return new Promise<void>((resolve) => {
-		server.close(() => resolve());
-	});
+function closeServer(server: HttpServer | HttpsServer, label: string): Promise<void> {
+	return closeServerWithDeadline(server, `egress:${label}`);
 }
 
 interface FailureDescription {

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -43,7 +43,7 @@ import {
 import type { DockerClient } from './docker';
 import type { EgressProxy } from './egress';
 import type { LogStreamBroker } from './log-stream-broker';
-import { detectOrphans } from './orphan-detector';
+import { detectOrphans, healStaleRunState, STALE_STATE_GRACE_SECONDS } from './orphan-detector';
 import { ensureRepoSetupAction } from './repo-setup';
 import { getProjectConcurrency, isTaskBusyInDb } from './run-concurrency';
 import type { SshAgentServer } from './ssh-agent';
@@ -66,12 +66,25 @@ const cronLog = {
 	error: (msg: unknown) => log.error(msg),
 };
 
+/** Identifies the agent-run dispatch a launchTask entry belongs to, so the
+ * stale-state sweep can correlate the in-memory entry with its run rows and
+ * release the dispatch guards if the completion path never lands. */
+interface RunDispatchContext {
+	memberId: string;
+	taskId: string;
+	projectId: string;
+}
+
 interface RunningTask {
 	key: string;
 	abortController: AbortController;
 	promise: Promise<unknown>;
 	startedAt: number;
 	timeoutId: ReturnType<typeof setTimeout>;
+	runContext?: RunDispatchContext;
+	/** Set when the stale-state sweep already released this entry's dispatch
+	 * guards, so the task's own settle handler doesn't double-release. */
+	reaped: boolean;
 }
 
 export interface LiveRun {
@@ -364,6 +377,7 @@ export class JobManager {
 		key: string,
 		fn: (signal: AbortSignal) => Promise<unknown>,
 		timeoutMs: number,
+		runContext?: RunDispatchContext,
 	): boolean {
 		if (this.runningTasks.has(key)) return false;
 		const ac = new AbortController();
@@ -373,21 +387,32 @@ export class JobManager {
 			ac.abort();
 		}, timeoutMs);
 
-		const promise = trackBackground(
+		const entry: RunningTask = {
+			key,
+			abortController: ac,
+			promise: Promise.resolve(),
+			startedAt: Date.now(),
+			timeoutId,
+			runContext,
+			reaped: false,
+		};
+		entry.promise = trackBackground(
 			fn(ac.signal).finally(() => {
 				clearTimeout(timeoutId);
-				this.runningTasks.delete(key);
+				// The sweep may have reaped this entry and a fresh launch may
+				// occupy the key, so only release what still belongs to us.
+				if (this.runningTasks.get(key) === entry) this.runningTasks.delete(key);
+				if (runContext && !entry.reaped) this.releaseRunDispatch(runContext);
 			}),
 		);
 
-		this.runningTasks.set(key, {
-			key,
-			abortController: ac,
-			promise,
-			startedAt: Date.now(),
-			timeoutId,
-		});
+		this.runningTasks.set(key, entry);
 		return true;
+	}
+
+	private releaseRunDispatch(ctx: RunDispatchContext): void {
+		this.activeTaskRuns.delete(ctx.taskId);
+		this.releaseProjectRun(ctx.projectId);
 	}
 
 	cancelTask(key: string, reason?: unknown): boolean {
@@ -1458,14 +1483,43 @@ export class JobManager {
 						err,
 					);
 					if (registeredRunId) this.unregisterLiveRun(registeredRunId);
+					// The completion bookkeeping (lock release, idle flip, wakeup
+					// resolution) must still run or the agent stays stuck busy with
+					// no recovery path. Synthesize a failed result; the failure-ping
+					// path reads the run row's real status so this never misreports.
+					try {
+						await this.onAgentComplete(
+							memberId,
+							agent.rows[0].slug,
+							task.id,
+							task.identifier,
+							teamId,
+							wakeupId,
+							wakeupPayload,
+							{
+								success: false,
+								exitCode: -1,
+								stdout: '',
+								stderr: err instanceof Error ? err.message : String(err),
+								durationMs: 0,
+								heartbeatRunId: registeredRunId,
+							},
+						);
+					} catch (completeErr) {
+						log.error(
+							`Completion bookkeeping after failed run for agent ${ref(agent.rows[0].slug, memberId)} failed:`,
+							completeErr,
+						);
+					}
 					return null;
 				} finally {
-					this.activeTaskRuns.delete(lockedTaskId);
-					this.releaseProjectRun(projectId);
+					// Dispatch guards (activeTaskRuns / activeProjectRuns) are
+					// released by launchTask's settle handler via runContext.
 					void trackBackground(this.guarded('wakeups', () => this.processWakeups()));
 				}
 			},
 			timeoutMs,
+			{ memberId, taskId: lockedTaskId, projectId },
 		);
 
 		if (!launched) {
@@ -1768,6 +1822,50 @@ export class JobManager {
 
 	private async detectOrphanedRuns(): Promise<void> {
 		await detectOrphans(this.deps.db, this.getLiveRunIds(), this.deps.wsManager);
+		await this.sweepStaleDispatches();
+		await healStaleRunState(this.deps.db, this.deps.wsManager);
+	}
+
+	/**
+	 * Release in-memory dispatch state for runs whose row went terminal but
+	 * whose completion path never settled (e.g. a wedged teardown). Without
+	 * this, the launchTask key, activeTaskRuns entry, and activeProjectRuns
+	 * refcount leak forever and the agent can never be dispatched again. The
+	 * DB-side counterpart is `healStaleRunState`.
+	 */
+	private async sweepStaleDispatches(): Promise<void> {
+		const { db } = this.deps;
+		const now = Date.now();
+		for (const [key, entry] of [...this.runningTasks]) {
+			const ctx = entry.runContext;
+			if (!ctx || entry.reaped) continue;
+			if (now - entry.startedAt < STALE_STATE_GRACE_SECONDS * 1000) continue;
+			const active = await db.query(
+				`SELECT 1 FROM heartbeat_runs
+				 WHERE member_id = $1 AND task_id = $2
+				   AND (status IN ($3::heartbeat_run_status, $4::heartbeat_run_status)
+				        OR finished_at > now() - ($5 || ' seconds')::interval)
+				 LIMIT 1`,
+				[
+					ctx.memberId,
+					ctx.taskId,
+					HeartbeatRunStatus.Queued,
+					HeartbeatRunStatus.Running,
+					String(STALE_STATE_GRACE_SECONDS),
+				],
+			);
+			if (active.rows.length > 0) continue;
+
+			log.warn(`Reaping stale dispatch ${key}: its run is terminal but completion never settled`);
+			entry.reaped = true;
+			clearTimeout(entry.timeoutId);
+			entry.abortController.abort();
+			if (this.runningTasks.get(key) === entry) this.runningTasks.delete(key);
+			this.releaseRunDispatch(ctx);
+			for (const [runId, liveRun] of this.liveRuns) {
+				if (liveRun.taskKey === key) this.liveRuns.delete(runId);
+			}
+		}
 	}
 
 	private async syncContainerStatuses(): Promise<void> {

--- a/packages/server/src/services/orphan-detector.ts
+++ b/packages/server/src/services/orphan-detector.ts
@@ -1,12 +1,26 @@
 import type { PGlite } from '@electric-sql/pglite';
-import { ApprovalType, HeartbeatRunStatus, WakeupSource, wsRoom } from '@hezo/shared';
+import {
+	AgentRuntimeStatus,
+	ApprovalType,
+	HeartbeatRunStatus,
+	WakeupSource,
+	WakeupStatus,
+	wsRoom,
+} from '@hezo/shared';
 import { broadcastRowChange } from '../lib/broadcast';
+import { logger } from '../logger';
 import { setAgentIdleIfNoActiveRuns } from './agent-runtime-status';
 import { createWakeup } from './wakeup';
 import type { WebSocketManager } from './ws';
 
+const log = logger.child('orphan-detector');
+
 const MAX_RETRIES = 3;
 const SAFETY_WINDOW_SECONDS = 30;
+/** How long DB state may disagree with the absence of any active run before
+ * the heal pass repairs it. Long enough to cover the dispatch window (status
+ * flips active before the run row lands) and normal completion bookkeeping. */
+export const STALE_STATE_GRACE_SECONDS = 120;
 
 export async function detectOrphans(
 	db: PGlite,
@@ -94,4 +108,102 @@ export async function detectOrphans(
 	}
 
 	return orphanCount;
+}
+
+/**
+ * Repair DB state stranded when a run's completion bookkeeping never landed
+ * (process wedge, swallowed error, crash between the run going terminal and
+ * `onAgentComplete`). The orphan detector above only covers runs still marked
+ * `running`; this pass covers the inverse — the run row is already terminal
+ * but the surrounding state (execution lock, agent runtime status, claimed
+ * wakeup) still says the agent is busy, which silently blocks every future
+ * dispatch for that agent. Each step is independent and idempotent.
+ */
+export async function healStaleRunState(db: PGlite, wsManager?: WebSocketManager): Promise<void> {
+	const grace = String(STALE_STATE_GRACE_SECONDS);
+
+	// Locks whose holder has no queued/running run anymore.
+	const locks = await db.query<{ id: string; member_id: string; task_id: string }>(
+		`UPDATE execution_locks el
+		 SET released_at = now()
+		 WHERE el.released_at IS NULL
+		   AND el.locked_at < now() - ($1 || ' seconds')::interval
+		   AND NOT EXISTS (
+		     SELECT 1 FROM heartbeat_runs hr
+		     WHERE hr.member_id = el.member_id AND hr.task_id = el.task_id
+		       AND hr.status IN ($2::heartbeat_run_status, $3::heartbeat_run_status)
+		   )
+		 RETURNING el.id, el.member_id, el.task_id`,
+		[grace, HeartbeatRunStatus.Queued, HeartbeatRunStatus.Running],
+	);
+	for (const lock of locks.rows) {
+		log.warn(
+			`Released stale execution lock ${lock.id} (member ${lock.member_id}, task ${lock.task_id}): no active run holds it`,
+		);
+	}
+
+	// Agents stuck `active` with no queued/running run. setAgentIdleIfNoActiveRuns
+	// re-checks, advances last_heartbeat_at, and broadcasts.
+	const stuckAgents = await db.query<{ id: string; team_id: string }>(
+		`SELECT ma.id, m.team_id
+		 FROM member_agents ma
+		 JOIN members m ON m.id = ma.id
+		 WHERE ma.runtime_status = $4::agent_runtime_status
+		   AND ma.updated_at < now() - ($1 || ' seconds')::interval
+		   AND NOT EXISTS (
+		     SELECT 1 FROM heartbeat_runs hr
+		     WHERE hr.member_id = ma.id
+		       AND hr.status IN ($2::heartbeat_run_status, $3::heartbeat_run_status)
+		   )`,
+		[grace, HeartbeatRunStatus.Queued, HeartbeatRunStatus.Running, AgentRuntimeStatus.Active],
+	);
+	for (const agent of stuckAgents.rows) {
+		const reset = await setAgentIdleIfNoActiveRuns(
+			db,
+			agent.id,
+			agent.team_id,
+			undefined,
+			wsManager,
+		);
+		if (reset) {
+			log.warn(`Reset stuck-active agent ${agent.id} to idle: no active run exists`);
+		}
+	}
+
+	// Claimed wakeups whose dispatch never resolved them. If the run they
+	// dispatched reached a terminal state, mirror onAgentComplete; if no run
+	// row ever landed, return them to the queue for a retry.
+	const stuckWakeups = await db.query<{ id: string }>(
+		`SELECT w.id FROM agent_wakeup_requests w
+		 WHERE w.status = $1::wakeup_status
+		   AND w.claimed_at < now() - ($2 || ' seconds')::interval
+		   AND NOT EXISTS (
+		     SELECT 1 FROM heartbeat_runs hr
+		     WHERE hr.wakeup_id = w.id
+		       AND hr.status IN ($3::heartbeat_run_status, $4::heartbeat_run_status)
+		   )`,
+		[WakeupStatus.Claimed, grace, HeartbeatRunStatus.Queued, HeartbeatRunStatus.Running],
+	);
+	for (const wakeup of stuckWakeups.rows) {
+		const run = await db.query<{ status: HeartbeatRunStatus }>(
+			`SELECT status FROM heartbeat_runs WHERE wakeup_id = $1 ORDER BY created_at DESC LIMIT 1`,
+			[wakeup.id],
+		);
+		const runStatus = run.rows[0]?.status;
+		if (runStatus) {
+			const resolved =
+				runStatus === HeartbeatRunStatus.Succeeded ? WakeupStatus.Completed : WakeupStatus.Failed;
+			await db.query(
+				`UPDATE agent_wakeup_requests SET status = $1::wakeup_status, completed_at = now() WHERE id = $2`,
+				[resolved, wakeup.id],
+			);
+			log.warn(`Resolved stale claimed wakeup ${wakeup.id} as ${resolved} (run ${runStatus})`);
+		} else {
+			await db.query(
+				`UPDATE agent_wakeup_requests SET status = $1::wakeup_status, claimed_at = NULL WHERE id = $2`,
+				[WakeupStatus.Queued, wakeup.id],
+			);
+			log.warn(`Requeued stale claimed wakeup ${wakeup.id}: its run never materialized`);
+		}
+	}
 }

--- a/packages/server/src/services/ssh-agent/server.ts
+++ b/packages/server/src/services/ssh-agent/server.ts
@@ -7,6 +7,7 @@ import type { PGlite } from '@electric-sql/pglite';
 import { decrypt } from '../../crypto/encryption';
 import type { MasterKeyManager } from '../../crypto/master-key';
 import { ref } from '../../lib/log-ref';
+import { closeServerWithDeadline } from '../../lib/net';
 import { logger } from '../../logger';
 import {
 	type AgentIdentity,
@@ -50,8 +51,27 @@ export class SshAgentServer {
 	private readonly listeners = new Map<string, Server>();
 	private readonly tcpListeners = new Map<string, Server>();
 	private readonly tokens = new Map<string, Buffer>();
+	// Accepted connections per run. `net.Server.close()` only completes once
+	// every accepted socket has ended, so release must be able to destroy any
+	// stragglers rather than wait on them.
+	private readonly connections = new Map<string, Set<Socket>>();
 
 	constructor(private readonly deps: SshAgentServerDeps) {}
+
+	private trackConnection(runId: string, socket: Socket): void {
+		let set = this.connections.get(runId);
+		if (!set) {
+			set = new Set();
+			this.connections.set(runId, set);
+		}
+		set.add(socket);
+		socket.on('close', () => {
+			const live = this.connections.get(runId);
+			if (!live) return;
+			live.delete(socket);
+			if (live.size === 0) this.connections.delete(runId);
+		});
+	}
 
 	async allocateRunSocket(
 		runId: string,
@@ -71,6 +91,7 @@ export class SshAgentServer {
 		});
 
 		const unixServer = createServer((socket) => {
+			this.trackConnection(runId, socket);
 			this.handleAuthenticatedConnection(socket, runId).catch((e) => {
 				log.error('ssh-agent connection error', {
 					run: ref(fullIdentity.label, runId),
@@ -95,6 +116,7 @@ export class SshAgentServer {
 		this.listeners.set(runId, unixServer);
 
 		const tcpServer = createServer((socket) => {
+			this.trackConnection(runId, socket);
 			this.handleTcpConnection(socket, runId).catch((e) => {
 				log.error('ssh-agent tcp connection error', {
 					run: ref(fullIdentity.label, runId),
@@ -129,14 +151,18 @@ export class SshAgentServer {
 	}
 
 	async releaseRunSocket(runId: string): Promise<void> {
+		for (const socket of this.connections.get(runId) ?? []) {
+			socket.destroy();
+		}
+		this.connections.delete(runId);
 		const server = this.listeners.get(runId);
 		if (server) {
-			await new Promise<void>((resolve) => server.close(() => resolve()));
+			await closeServerWithDeadline(server, `ssh-agent:${runId}`);
 			this.listeners.delete(runId);
 		}
 		const tcpServer = this.tcpListeners.get(runId);
 		if (tcpServer) {
-			await new Promise<void>((resolve) => tcpServer.close(() => resolve()));
+			await closeServerWithDeadline(tcpServer, `ssh-agent-tcp:${runId}`);
 			this.tcpListeners.delete(runId);
 		}
 		this.tokens.delete(runId);

--- a/packages/server/test/bun/close-deadline.bun.test.ts
+++ b/packages/server/test/bun/close-deadline.bun.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from 'bun:test';
+import { createServer as createHttpServer } from 'node:http';
+import { type AddressInfo, createServer as createNetServer, connect as netConnect } from 'node:net';
+import { closeServerWithDeadline } from '../../src/lib/net';
+
+// Runtime tier: this spec runs under `bun test`, exercising server close
+// semantics on the production Bun runtime. `server.close()`'s callback only
+// fires once every accepted connection ends, and Bun's connection accounting
+// for hijacked CONNECT sockets has diverged from Node's — a close that never
+// completes wedged the agent-run completion path in production (agents stuck
+// "running" forever). These tests pin the contract: closeServerWithDeadline
+// always resolves, bounded by its deadline, connections or not.
+
+describe('closeServerWithDeadline', () => {
+	test('resolves promptly for a server with no connections', async () => {
+		const server = createHttpServer();
+		await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+
+		const started = Date.now();
+		await closeServerWithDeadline(server, 'test:idle', 5_000);
+		expect(Date.now() - started).toBeLessThan(1_000);
+	});
+
+	test('resolves while an http keep-alive connection is still open', async () => {
+		const server = createHttpServer((_req, res) => res.end('ok'));
+		await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+		const port = (server.address() as AddressInfo).port;
+
+		// A raw socket holding a keep-alive connection open across the close.
+		const client = netConnect({ host: '127.0.0.1', port });
+		await new Promise<void>((resolve) => client.on('connect', () => resolve()));
+		client.write('GET / HTTP/1.1\r\nHost: x\r\nConnection: keep-alive\r\n\r\n');
+		await new Promise((resolve) => setTimeout(resolve, 100));
+
+		const started = Date.now();
+		await closeServerWithDeadline(server, 'test:keep-alive', 2_000);
+		expect(Date.now() - started).toBeLessThanOrEqual(2_500);
+		client.destroy();
+	});
+
+	test('resolves while a hijacked CONNECT tunnel is still open', async () => {
+		const server = createHttpServer();
+		server.on('connect', (_req, socket) => {
+			socket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+		});
+		await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+		const port = (server.address() as AddressInfo).port;
+
+		const client = netConnect({ host: '127.0.0.1', port });
+		await new Promise<void>((resolve) => client.on('connect', () => resolve()));
+		client.write('CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n');
+		await new Promise((resolve) => setTimeout(resolve, 100));
+
+		const started = Date.now();
+		await closeServerWithDeadline(server, 'test:connect-tunnel', 2_000);
+		expect(Date.now() - started).toBeLessThanOrEqual(2_500);
+		client.destroy();
+	});
+
+	test('resolves within the deadline for a net server with an undrained connection', async () => {
+		// Under Node an open accepted socket blocks net.Server.close() until it
+		// ends; under Bun close completes immediately. Either way the helper
+		// must come back no later than its deadline.
+		const server = createNetServer(() => {});
+		await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+		const port = (server.address() as AddressInfo).port;
+
+		const client = netConnect({ host: '127.0.0.1', port });
+		await new Promise<void>((resolve) => client.on('connect', () => resolve()));
+
+		const started = Date.now();
+		await closeServerWithDeadline(server, 'test:net-undrained', 500);
+		expect(Date.now() - started).toBeLessThan(2_000);
+		client.destroy();
+	});
+});

--- a/packages/server/test/job-manager-workflows.test.ts
+++ b/packages/server/test/job-manager-workflows.test.ts
@@ -2352,4 +2352,158 @@ describe('JobManager workflow methods', () => {
 			void taskBId;
 		});
 	});
+
+	describe('sweepStaleDispatches', () => {
+		it('reaps a dispatch whose run is terminal but whose completion never settled', async () => {
+			await db.query('DELETE FROM heartbeat_runs WHERE team_id = $1', [teamId]);
+			const manager = createJobManager();
+			const key = `${agentId}:${projectId}`;
+
+			// Simulate the wedge: the dispatched closure never settles on its own
+			// (it resolves only when the sweep aborts it), while its run row has
+			// long since gone terminal.
+			(manager as any).activeTaskRuns.add(taskId);
+			(manager as any).acquireProjectRun(projectId);
+			const launched = manager.launchTask(
+				key,
+				(signal) =>
+					new Promise((resolve) => {
+						signal.addEventListener('abort', () => resolve(null));
+					}),
+				60 * 60 * 1000,
+				{ memberId: agentId, taskId, projectId },
+			);
+			expect(launched).toBe(true);
+			await db.query(
+				`INSERT INTO heartbeat_runs (team_id, member_id, task_id, status, started_at, finished_at, exit_code)
+				 VALUES ($1, $2, $3, $4::heartbeat_run_status, now() - interval '10 minutes', now() - interval '8 minutes', 0)`,
+				[teamId, agentId, taskId, HeartbeatRunStatus.Succeeded],
+			);
+			(manager as any).runningTasks.get(key).startedAt = Date.now() - 10 * 60 * 1000;
+
+			await (manager as any).sweepStaleDispatches();
+
+			expect(manager.isTaskRunning(key)).toBe(false);
+			expect((manager as any).activeTaskRuns.has(taskId)).toBe(false);
+			expect((manager as any).activeProjectRuns.has(projectId)).toBe(false);
+
+			// The wedged closure settling afterwards must not double-release the
+			// project refcount a fresh dispatch now holds.
+			await waitForBackground();
+			(manager as any).activeTaskRuns.add(taskId);
+			(manager as any).acquireProjectRun(projectId);
+			expect(
+				manager.launchTask(key, async () => null, 1000, {
+					memberId: agentId,
+					taskId,
+					projectId,
+				}),
+			).toBe(true);
+			expect((manager as any).activeProjectRuns.get(projectId)).toBe(1);
+			await waitForBackground();
+
+			manager.shutdown();
+			await db.query('DELETE FROM heartbeat_runs WHERE team_id = $1', [teamId]);
+		});
+
+		it('leaves a dispatch with a live run untouched', async () => {
+			await db.query('DELETE FROM heartbeat_runs WHERE team_id = $1', [teamId]);
+			const manager = createJobManager();
+			const key = `${agentId}:${projectId}`;
+
+			(manager as any).activeTaskRuns.add(taskId);
+			(manager as any).acquireProjectRun(projectId);
+			let settle: (() => void) | undefined;
+			manager.launchTask(
+				key,
+				() =>
+					new Promise<void>((resolve) => {
+						settle = resolve;
+					}),
+				60 * 60 * 1000,
+				{ memberId: agentId, taskId, projectId },
+			);
+			await db.query(
+				`INSERT INTO heartbeat_runs (team_id, member_id, task_id, status, started_at)
+				 VALUES ($1, $2, $3, $4::heartbeat_run_status, now() - interval '10 minutes')`,
+				[teamId, agentId, taskId, HeartbeatRunStatus.Running],
+			);
+			(manager as any).runningTasks.get(key).startedAt = Date.now() - 10 * 60 * 1000;
+
+			await (manager as any).sweepStaleDispatches();
+
+			expect(manager.isTaskRunning(key)).toBe(true);
+			expect((manager as any).activeTaskRuns.has(taskId)).toBe(true);
+
+			settle?.();
+			await waitForBackground();
+			manager.shutdown();
+			await db.query('DELETE FROM heartbeat_runs WHERE team_id = $1', [teamId]);
+		});
+	});
+
+	describe('completion bookkeeping when runAgent throws', () => {
+		it('releases the lock, idles the agent, and fails the wakeup', async () => {
+			await db.query('DELETE FROM heartbeat_runs WHERE team_id = $1', [teamId]);
+			await db.query('DELETE FROM agent_wakeup_requests WHERE member_id = $1', [agentId]);
+			await db.query(
+				'UPDATE execution_locks SET released_at = now() WHERE member_id = $1 AND released_at IS NULL',
+				[agentId],
+			);
+
+			// A log broker whose begin() throws makes runAgent throw outside its
+			// own try/catch — the exact shape of a completion path that never
+			// reaches onAgentComplete on its own.
+			// The dispatch path requires a running container on the project; the
+			// stub docker reports any container id as running.
+			await db.query(
+				`UPDATE projects SET container_id = 'stub-contain', container_status = 'running' WHERE id = $1`,
+				[projectId],
+			);
+			let threw = false;
+			const throwingLogs = new LogStreamBroker();
+			throwingLogs.begin = () => {
+				threw = true;
+				throw new Error('synthetic stream failure');
+			};
+			const manager = createJobManager({ logs: throwingLogs });
+
+			const wakeupRes = await db.query<{ id: string }>(
+				`INSERT INTO agent_wakeup_requests (member_id, team_id, source, status, payload, created_at)
+				 VALUES ($1, $2, 'assignment', 'queued', $3::jsonb, now() - interval '30 seconds')
+				 RETURNING id`,
+				[agentId, teamId, JSON.stringify({ task_id: taskId, reason: 'unblocked' })],
+			);
+			const wakeupId = wakeupRes.rows[0].id;
+
+			await (manager as any).processWakeups();
+			await waitForBackground();
+
+			expect(threw).toBe(true);
+			const wakeup = await db.query<{ status: string }>(
+				'SELECT status FROM agent_wakeup_requests WHERE id = $1',
+				[wakeupId],
+			);
+			expect(wakeup.rows[0].status).toBe(WakeupStatus.Failed);
+
+			const locks = await db.query<{ id: string }>(
+				'SELECT id FROM execution_locks WHERE member_id = $1 AND released_at IS NULL',
+				[agentId],
+			);
+			expect(locks.rows).toHaveLength(0);
+
+			const agent = await db.query<{ runtime_status: string }>(
+				'SELECT runtime_status FROM member_agents WHERE id = $1',
+				[agentId],
+			);
+			expect(agent.rows[0].runtime_status).toBe(AgentRuntimeStatus.Idle);
+
+			expect(manager.isTaskRunning(`${agentId}:${projectId}`)).toBe(false);
+			expect((manager as any).activeTaskRuns.has(taskId)).toBe(false);
+
+			manager.shutdown();
+			await db.query('DELETE FROM agent_wakeup_requests WHERE id = $1', [wakeupId]);
+			await db.query('DELETE FROM heartbeat_runs WHERE team_id = $1', [teamId]);
+		});
+	});
 });

--- a/packages/server/test/orphan-detector.test.ts
+++ b/packages/server/test/orphan-detector.test.ts
@@ -1,9 +1,15 @@
 import type { PGlite } from '@electric-sql/pglite';
-import { AgentRuntimeStatus, ApprovalType, HeartbeatRunStatus, WakeupSource } from '@hezo/shared';
+import {
+	AgentRuntimeStatus,
+	ApprovalType,
+	HeartbeatRunStatus,
+	WakeupSource,
+	WakeupStatus,
+} from '@hezo/shared';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Env } from '../src/lib/types';
-import { detectOrphans } from '../src/services/orphan-detector';
+import { detectOrphans, healStaleRunState } from '../src/services/orphan-detector';
 import { safeClose } from './helpers';
 import { authHeader, createTestApp, createTestProject, projectSlugFor } from './helpers/app';
 
@@ -219,5 +225,190 @@ describe('detectOrphans', () => {
 
 		const count = await detectOrphans(db, new Set());
 		expect(count).toBe(3);
+	});
+});
+
+/** Set an agent active with an updated_at older than the heal grace window.
+ * The updated_at trigger overwrites explicit values, so it is suspended for
+ * the backdating write. */
+async function setAgentActiveStale(memberId: string): Promise<void> {
+	await db.query('ALTER TABLE member_agents DISABLE TRIGGER trg_member_agents_updated');
+	await db.query(
+		`UPDATE member_agents
+		 SET runtime_status = $1::agent_runtime_status, updated_at = now() - interval '10 minutes'
+		 WHERE id = $2`,
+		[AgentRuntimeStatus.Active, memberId],
+	);
+	await db.query('ALTER TABLE member_agents ENABLE TRIGGER trg_member_agents_updated');
+}
+
+describe('healStaleRunState', () => {
+	it('repairs lock, agent status, and claimed wakeup stranded by a lost completion path', async () => {
+		await db.query(`DELETE FROM heartbeat_runs WHERE team_id = $1`, [teamId]);
+		await db.query('DELETE FROM agent_wakeup_requests WHERE member_id = $1', [agentId]);
+
+		// The exact stuck shape: wakeup claimed, run succeeded, lock never
+		// released, agent never flipped back to idle.
+		const taskId = await createTask(teamId);
+		const wakeupRes = await db.query<{ id: string }>(
+			`INSERT INTO agent_wakeup_requests (member_id, team_id, source, status, claimed_at, created_at)
+			 VALUES ($1, $2, 'assignment', $3::wakeup_status, now() - interval '10 minutes', now() - interval '10 minutes')
+			 RETURNING id`,
+			[agentId, teamId, WakeupStatus.Claimed],
+		);
+		const wakeupId = wakeupRes.rows[0].id;
+		await db.query(
+			`INSERT INTO heartbeat_runs (team_id, member_id, task_id, wakeup_id, status, started_at, finished_at, exit_code)
+			 VALUES ($1, $2, $3, $4, $5::heartbeat_run_status, now() - interval '10 minutes', now() - interval '8 minutes', 0)`,
+			[teamId, agentId, taskId, wakeupId, HeartbeatRunStatus.Succeeded],
+		);
+		const lockRes = await db.query<{ id: string }>(
+			`INSERT INTO execution_locks (task_id, member_id, locked_at) VALUES ($1, $2, now() - interval '10 minutes') RETURNING id`,
+			[taskId, agentId],
+		);
+		await setAgentActiveStale(agentId);
+
+		await healStaleRunState(db);
+
+		const lock = await db.query<{ released_at: string | null }>(
+			'SELECT released_at FROM execution_locks WHERE id = $1',
+			[lockRes.rows[0].id],
+		);
+		expect(lock.rows[0].released_at).not.toBeNull();
+
+		const agent = await db.query<{ runtime_status: string; last_heartbeat_at: string | null }>(
+			'SELECT runtime_status, last_heartbeat_at FROM member_agents WHERE id = $1',
+			[agentId],
+		);
+		expect(agent.rows[0].runtime_status).toBe(AgentRuntimeStatus.Idle);
+		expect(agent.rows[0].last_heartbeat_at).not.toBeNull();
+
+		const wakeup = await db.query<{ status: string; completed_at: string | null }>(
+			'SELECT status, completed_at FROM agent_wakeup_requests WHERE id = $1',
+			[wakeupId],
+		);
+		expect(wakeup.rows[0].status).toBe(WakeupStatus.Completed);
+		expect(wakeup.rows[0].completed_at).not.toBeNull();
+	});
+
+	it('marks a stale claimed wakeup failed when its run failed', async () => {
+		await db.query(`DELETE FROM heartbeat_runs WHERE team_id = $1`, [teamId]);
+		const wakeupRes = await db.query<{ id: string }>(
+			`INSERT INTO agent_wakeup_requests (member_id, team_id, source, status, claimed_at, created_at)
+			 VALUES ($1, $2, 'assignment', $3::wakeup_status, now() - interval '10 minutes', now() - interval '10 minutes')
+			 RETURNING id`,
+			[agentId, teamId, WakeupStatus.Claimed],
+		);
+		const wakeupId = wakeupRes.rows[0].id;
+		await db.query(
+			`INSERT INTO heartbeat_runs (team_id, member_id, wakeup_id, status, started_at, finished_at, exit_code)
+			 VALUES ($1, $2, $3, $4::heartbeat_run_status, now() - interval '10 minutes', now() - interval '8 minutes', 1)`,
+			[teamId, agentId, wakeupId, HeartbeatRunStatus.Failed],
+		);
+
+		await healStaleRunState(db);
+
+		const wakeup = await db.query<{ status: string }>(
+			'SELECT status FROM agent_wakeup_requests WHERE id = $1',
+			[wakeupId],
+		);
+		expect(wakeup.rows[0].status).toBe(WakeupStatus.Failed);
+	});
+
+	it('requeues a stale claimed wakeup whose run never materialized', async () => {
+		await db.query(`DELETE FROM heartbeat_runs WHERE team_id = $1`, [teamId]);
+		const wakeupRes = await db.query<{ id: string }>(
+			`INSERT INTO agent_wakeup_requests (member_id, team_id, source, status, claimed_at, created_at)
+			 VALUES ($1, $2, 'assignment', $3::wakeup_status, now() - interval '10 minutes', now() - interval '10 minutes')
+			 RETURNING id`,
+			[agentId, teamId, WakeupStatus.Claimed],
+		);
+		const wakeupId = wakeupRes.rows[0].id;
+
+		await healStaleRunState(db);
+
+		const wakeup = await db.query<{ status: string; claimed_at: string | null }>(
+			'SELECT status, claimed_at FROM agent_wakeup_requests WHERE id = $1',
+			[wakeupId],
+		);
+		expect(wakeup.rows[0].status).toBe(WakeupStatus.Queued);
+		expect(wakeup.rows[0].claimed_at).toBeNull();
+	});
+
+	it('leaves fresh dispatch state and live runs untouched', async () => {
+		await db.query(`DELETE FROM heartbeat_runs WHERE team_id = $1`, [teamId]);
+		await db.query('DELETE FROM agent_wakeup_requests WHERE member_id = $1', [agentId]);
+
+		// Fresh dispatch: everything just happened — inside the grace window.
+		const taskId = await createTask(teamId);
+		const wakeupRes = await db.query<{ id: string }>(
+			`INSERT INTO agent_wakeup_requests (member_id, team_id, source, status, claimed_at, created_at)
+			 VALUES ($1, $2, 'assignment', $3::wakeup_status, now(), now())
+			 RETURNING id`,
+			[agentId, teamId, WakeupStatus.Claimed],
+		);
+		const lockRes = await db.query<{ id: string }>(
+			`INSERT INTO execution_locks (task_id, member_id) VALUES ($1, $2) RETURNING id`,
+			[taskId, agentId],
+		);
+		await setAgentActive(agentId);
+
+		await healStaleRunState(db);
+
+		const lock = await db.query<{ released_at: string | null }>(
+			'SELECT released_at FROM execution_locks WHERE id = $1',
+			[lockRes.rows[0].id],
+		);
+		expect(lock.rows[0].released_at).toBeNull();
+		const agent = await db.query<{ runtime_status: string }>(
+			'SELECT runtime_status FROM member_agents WHERE id = $1',
+			[agentId],
+		);
+		expect(agent.rows[0].runtime_status).toBe(AgentRuntimeStatus.Active);
+		const wakeup = await db.query<{ status: string }>(
+			'SELECT status FROM agent_wakeup_requests WHERE id = $1',
+			[wakeupRes.rows[0].id],
+		);
+		expect(wakeup.rows[0].status).toBe(WakeupStatus.Claimed);
+
+		// Old state backed by a live (running) run also stays untouched.
+		await db.query(
+			`UPDATE agent_wakeup_requests SET claimed_at = now() - interval '10 minutes' WHERE id = $1`,
+			[wakeupRes.rows[0].id],
+		);
+		await db.query(
+			`UPDATE execution_locks SET locked_at = now() - interval '10 minutes' WHERE id = $1`,
+			[lockRes.rows[0].id],
+		);
+		await setAgentActiveStale(agentId);
+		await db.query(
+			`INSERT INTO heartbeat_runs (team_id, member_id, task_id, wakeup_id, status, started_at)
+			 VALUES ($1, $2, $3, $4, $5::heartbeat_run_status, now() - interval '10 minutes')`,
+			[teamId, agentId, taskId, wakeupRes.rows[0].id, HeartbeatRunStatus.Running],
+		);
+
+		await healStaleRunState(db);
+
+		const lock2 = await db.query<{ released_at: string | null }>(
+			'SELECT released_at FROM execution_locks WHERE id = $1',
+			[lockRes.rows[0].id],
+		);
+		expect(lock2.rows[0].released_at).toBeNull();
+		const agent2 = await db.query<{ runtime_status: string }>(
+			'SELECT runtime_status FROM member_agents WHERE id = $1',
+			[agentId],
+		);
+		expect(agent2.rows[0].runtime_status).toBe(AgentRuntimeStatus.Active);
+		const wakeup2 = await db.query<{ status: string }>(
+			'SELECT status FROM agent_wakeup_requests WHERE id = $1',
+			[wakeupRes.rows[0].id],
+		);
+		expect(wakeup2.rows[0].status).toBe(WakeupStatus.Claimed);
+
+		await db.query(`DELETE FROM heartbeat_runs WHERE team_id = $1`, [teamId]);
+		await db.query(
+			'UPDATE member_agents SET runtime_status = $1::agent_runtime_status WHERE id = $2',
+			[AgentRuntimeStatus.Idle, agentId],
+		);
 	});
 });


### PR DESCRIPTION
## Problem

On the dev server the UI Designer agent showed **Running** indefinitely after its run had already succeeded. Forensics on the stuck instance:

- The run row was `succeeded` (exit 0), but `member_agents.runtime_status` stayed `active`, the execution lock was never released, and the dispatching wakeup stayed `claimed`.
- A queued `repo_setup_complete` wakeup was skipped every tick with `task_busy` (coalesced 71×) — the agent could never run again.
- The server still held the run's egress-proxy and ssh-bridge listeners with **zero** established connections.

**Root cause:** `runAgent` awaited `cleanupRunArtifacts()` before returning, and that teardown awaits `releaseRunSocket()` / `releaseRunProxy()`, which resolved via bare `server.close(cb)`. Under Bun a close callback can fail to fire even after connections are gone. When it wedges, `onAgentComplete` (lock release → idle flip → wakeup completion) never runs, the `launchTask` finally never fires, and the in-memory dispatch guards (`runningTasks`, `activeTaskRuns`, `activeProjectRuns`) leak forever. No exception is thrown, so nothing is logged, and no recovery path existed: the orphan detector only covers `status='running'` rows and `reconcileOnStartup` only runs at boot.

## Fix (three layers)

1. **Bounded, force-closing releases** — new `closeServerWithDeadline()` (`lib/net.ts`) calls `closeAllConnections()` where available and resolves at a 5s deadline regardless; used by the egress proxy and the ssh-agent bridge (which now tracks accepted sockets per run and destroys them on release).
2. **Unconditional completion bookkeeping** — each artifact-cleanup step in `runAgent` is isolated (log-and-continue), and the `launchTask` closure now runs `onAgentComplete` with a synthesized failed result when `runAgent` throws, so lock/status/wakeup state is always resolved.
3. **Self-heal sweep (defense in depth)** — on the existing 30s orphan-detection tick: reap in-memory dispatch entries whose run is terminal beyond a 2-minute grace, release stale execution locks, idle stuck-`active` agents, and resolve (or requeue) stale `claimed` wakeups.

## Tests

- `orphan-detector.test.ts`: heals the exact observed stuck state (lock released, agent idled + heartbeat advanced, claimed wakeup resolved by its run's terminal status, requeue when no run landed, fresh/live state untouched).
- `job-manager-workflows.test.ts`: stale-dispatch reap (incl. no double-release of project refcounts) and the runAgent-throws path (lock released, agent idled, wakeup failed).
- `test/bun/close-deadline.bun.test.ts` (Bun-native tier): `closeServerWithDeadline` resolves promptly/bounded with idle, keep-alive, hijacked-CONNECT, and undrained-net-socket connections — runtime-sensitive close semantics where Node-only tests give false confidence.

Full suite green locally: server 1799 tests + Bun tier + web 298 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)