### PR TITLE
feat(auth): challenge-response master-key auth — the mnemonic never leaves the client

### DIFF
--- a/.dev/api.md
+++ b/.dev/api.md
@@ -16,23 +16,46 @@ Timestamps are ISO 8601. IDs are UUIDs. Money is in cents.
 
 Three auth methods:
 
-### Bootstrap — Master Key Exchange
+### Bootstrap — Challenge-Response Master Key Auth
 
-`POST /auth/token` exchanges the master key for a board JWT. This is the bootstrap endpoint for initial access.
+The master key is a 12-word BIP39 phrase that **never leaves the client**. From its seed the client derives two independent keys (HKDF-SHA256, distinct salts):
+
+- an **Ed25519 auth keypair** — the private key signs server challenges; the public key is enrolled at setup and stored in `system_meta` (`auth_public_key`);
+- a 32-byte **unlock key** — the input to the server's at-rest key derivations (canary, secrets encryption, JWT signing). It transits only at setup and at unlock-after-restart, always inside an Ed25519-signed payload.
+
+Signed payloads use versioned, domain-separated messages: `hezo-auth-v1:setup:<pub>:<unlock>`, `hezo-auth-v1:login:<nonce>`, `hezo-auth-v1:unlock:<nonce>:<unlock>`. All key/nonce fields are lowercase hex (keys 64 chars, signatures 128, nonces 64).
+
+#### `POST /auth/setup`
+
+First-boot enrollment (master-key state `unset` only). Self-certifying: the signature (over the setup message) proves possession of the private key matching the submitted public key. Verified before anything is persisted; the public key and canary are stored in one transaction.
 
 Request:
 ```json
-{ "master_key": "..." }
+{ "public_key": "<64 hex>", "unlock_key": "<64 hex>", "signature": "<128 hex>" }
 ```
 
-Response:
+Response: `{ "data": { "token": "<user_jwt>" } }` — 400 `INVALID_REQUEST` (shape), 401 `INVALID_SIGNATURE`, 409 `ALREADY_SET`.
+
+#### `POST /auth/challenge`
+
+Issues a single-use nonce (in-memory, ~2 min TTL) for the client to sign.
+
+Response: `{ "data": { "challenge_id": "<uuid>", "nonce": "<64 hex>", "expires_in": 120 } }` — 409 `SETUP_REQUIRED` while `unset`.
+
+#### `POST /auth/verify`
+
+Completes login (and unlock, when the server is locked after a restart). The nonce is never echoed back — the server reconstructs the signed message from its stored copy, so the signature is the sole authenticator. The challenge is consumed before verification: a failed attempt burns it.
+
+Request (login while unlocked / unlock while locked):
 ```json
-{ "data": { "token": "<user_jwt>" } }
+{ "challenge_id": "<uuid>", "signature": "<128 hex>", "unlock_key": "<64 hex, only when unlocking>" }
 ```
+
+Response: `{ "data": { "token": "<user_jwt>" } }` — 400 `INVALID_REQUEST`, 401 `INVALID_CHALLENGE` (unknown/expired/used), 401 `INVALID_SIGNATURE`, 401 `UNLOCK_KEY_REQUIRED` (locked, no key supplied — client retries the dance with the key), 401 `INVALID_UNLOCK_KEY` (canary mismatch), 409 `SETUP_REQUIRED`. Supplying `unlock_key` while already unlocked succeeds (stale-locked-client tolerance).
 
 ### Board — User JWT
 
-All subsequent requests use a stateless JWT signed with the master key. No session cookies.
+All subsequent requests use a stateless JWT (HS256, secret derived from the unlock key). No session cookies.
 
 ```
 Authorization: Bearer <user_jwt>
@@ -1459,7 +1482,7 @@ Return the models this provider offers for the stored credential. Calls the prov
 
 ### Instance Settings
 
-Instance-wide settings live in the `system_meta` key-value table. The only setting today is the **instance base URL** — the public origin of this Hezo instance (e.g. `https://hezo.example.com`), used to build absolute entity links for external chat channels (Telegram). It is captured automatically from the request origin (`host` + first `x-forwarded-proto` entry) on the first successful `POST /auth/token` unlock and never overwritten after that; it stays editable on the global settings page.
+Instance-wide settings live in the `system_meta` key-value table. The only setting today is the **instance base URL** — the public origin of this Hezo instance (e.g. `https://hezo.example.com`), used to build absolute entity links for external chat channels (Telegram). It is captured automatically from the request origin (`host` + first `x-forwarded-proto` entry) on the first successful auth (`POST /auth/setup` or `POST /auth/verify`) and never overwritten after that; it stays editable on the global settings page.
 
 #### `GET /instance-settings`
 Returns `{ base_url: string | null }`. Any authenticated principal.
@@ -1889,7 +1912,7 @@ List installed plugins for a team.
 
 ### Auth & Team
 
-Current auth uses `POST /auth/token` to exchange the master key for a board JWT (see Authentication section above). OAuth login (GitHub/GitLab) is planned for Phase 6.5.
+Current auth is the challenge-response flow over `POST /auth/setup` / `/auth/challenge` / `/auth/verify` (see Authentication section above). OAuth login (GitHub/GitLab) is planned for Phase 6.5.
 
 **OAuth login endpoints — not yet implemented — planned for Phase 6.5.**
 

--- a/.dev/spec.md
+++ b/.dev/spec.md
@@ -73,37 +73,37 @@ packages/
 
 ### Master key lifecycle
 
-The master key is held in memory only — never written to disk. It encrypts all secrets, agent JWTs, and the canary value stored in `system_meta`.
+The master key is a **12-word BIP39 phrase held by the operator**. It never reaches the server. From its seed the client (browser, or the CLI boot path) derives two independent keys via HKDF-SHA256 with distinct salts:
 
-**First startup** (no canary in `system_meta`):
-1. If `--master-key <key>` provided on CLI → use that key, store canary (`encrypt("CANARY", master_key)`), proceed.
-2. If no CLI key → server starts but master key is "unset". The web UI shows a **master key gate modal** on the first authenticated user's first visit:
-   - **Option A: Generate a new key.** Server generates a random 256-bit key, displays it once in the UI, and warns the user to save it — it will not be shown again.
-   - **Option B: Enter an existing key.** User provides a key they already have (e.g., restoring from backup).
-3. Store canary and proceed.
+- **Ed25519 auth keypair** (`hezo-auth-key-v1`) — the private key exists only client-side, re-derived from the typed phrase at each login, never persisted. The public key is enrolled at setup, stored plaintext in `system_meta.auth_public_key`, and verifies every login/unlock signature.
+- **Unlock key** (`hezo-unlock-key-v1`, 32 bytes) — the input to all server-side key derivations: the canary, the at-rest secrets-encryption key, and the JWT signing key. The server holds it in memory only — never on disk. It transits exactly twice in a server's life-per-boot: at setup and at unlock-after-restart, always inside an Ed25519-signed payload (the server must hold symmetric key material at runtime because it decrypts secrets with no client in the loop — egress substitution, ssh-agent signing, provider keys).
 
-**Subsequent startup** (canary exists in `system_meta`):
-1. If `--master-key <key>` provided on CLI → attempt to decrypt canary.
-   - **Success** → unlock, proceed normally.
-   - **Failure** → server starts but in locked state. Web UI shows "incorrect master key" with option to re-enter.
-2. If no CLI key → server starts in locked state. Web UI prompts user to enter master key.
-   - **Success** → unlock, proceed normally.
-   - **Failure** → prompt again or offer recovery.
+Routine logins transmit **zero key material**: the client signs a single-use server nonce (`POST /auth/challenge` → `POST /auth/verify`) and gets a JWT.
 
-**Key principle:** CLI `--master-key` is for **unlocking** (verifying the canary) on startup. The web UI is for **setting/managing** the key. The CLI never sets a new key interactively.
+**First startup** (no canary in `system_meta`, state `unset`):
+1. If `--master-key <phrase>` / `HEZO_MASTER_KEY` is provided → the CLI derives both keys, enrolls the public key + canary (equivalent to web setup), and unlocks.
+2. Otherwise the web UI shows the **setup wizard's master-key step**: it generates a 12-word phrase client-side, the operator saves it, and submit runs `POST /auth/setup` (public key + unlock key + self-certifying signature, persisted in one transaction).
+
+**Subsequent startup** (canary exists):
+1. With `--master-key <phrase>` → derived unlock key decrypts the canary → unlocked (the enrolled public key is backfilled if missing; the phrase is the root of trust). A wrong phrase leaves the server **locked**.
+2. Without it → server starts **locked**. The web UI gate prompts for the phrase; the client signs the challenge *and* includes the unlock key (`POST /auth/verify` with `unlock_key`).
+
+**Key principles:** the phrase/seed never transits; enrollment is explicit (`unlock()` never implicitly trusts-on-first-use — only `setup`/the CLI boot path enroll); `--master-key` accepts only a valid mnemonic (a raw derived key could never enroll the public key, which would leave an unlocked server nobody can log into — boot fails fast instead).
 
 **On unlock:** `MasterKeyManager` fires registered `onUnlock` callbacks when the state transitions to `unlocked`. The server registers a callback at startup that starts the `JobManager` (agent wakeups, heartbeats, container sync, orphan detection). This means background processing begins as soon as the server is unlocked, regardless of whether the key was provided via CLI or web UI.
 
-**Recovery options** (after failed canary decryption, via web UI):
-- **Re-enter a different master key.** Try again with the correct key.
-- **Generate a new master key and start fresh.** Warn that all existing instance data (secrets, teams, agents) will be lost. If confirmed, wipe the database, store a new canary, and proceed with a clean instance.
+**Recovery options** (locked, phrase rejected):
+- **Re-enter the correct phrase.** Try again.
+- **Reset and start fresh.** Wipe the database (`--reset`), run setup with a new phrase. All existing instance data (secrets, teams, agents) is lost.
+
+**Threat notes:** a captured setup/unlock request could be replayed against a *different, freshly-reset* instance to enroll the same key there — the same exposure class as any first-boot credential; TLS is the transit defense. Login signatures are bound to single-use nonces (consumed before verification, so a failed attempt burns the challenge) and to domain-separated message tags, so they cannot be replayed or cross-purposed.
 
 ### CLI interface and default configuration
 
 ```
 hezo                          # Start server with sensible defaults
 hezo --data-dir /path/to/dir  # Custom persistence directory (default: ~/.hezo/)
-hezo --master-key <key>       # Supply master key (skip terminal prompt)
+hezo --master-key <phrase>    # The 12-word master key phrase (setup/unlock)
 hezo --port 3100              # Custom port (default: 3100)
 hezo --connect-url <url>      # Hezo Connect URL (default: http://localhost:4100)
 hezo --connect-api-key <key>  # API key for centrally hosted Connect

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The server creates its database at `~/.hezo/pgdata` on first run.
 hezo                              # Start with defaults
 hezo --port 3100                  # Custom port (default: 3100)
 hezo --data-dir /path/to/dir     # Custom data directory (default: ~/.hezo/)
-hezo --master-key <key>          # Provide master key for unlock
+hezo --master-key <phrase>       # 12-word master key phrase (setup/unlock)
 hezo --web-url <url>             # Web UI base URL for redirects (default: same origin)
 hezo --reset                      # Wipe database and start fresh
 ```

--- a/bun.lock
+++ b/bun.lock
@@ -52,6 +52,7 @@
       "name": "@hezo/shared",
       "version": "0.2.0",
       "dependencies": {
+        "@noble/curves": "^1.9.1",
         "@noble/hashes": "^1.8.0",
         "@scure/bip39": "^1.6.0",
       },
@@ -365,6 +366,8 @@
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
+    "@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
 
     "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -3,7 +3,8 @@ import { resolve } from 'node:path';
 import {
 	DEFAULT_DATA_DIR,
 	DEFAULT_PORT,
-	mnemonicToMasterKey,
+	deriveAuthKeyPair,
+	deriveUnlockKey,
 	validateMnemonic,
 } from '@hezo/shared';
 import { Command } from 'commander';
@@ -13,7 +14,7 @@ export type LogLevelName = 'debug' | 'info' | 'warn' | 'error';
 export interface HezoConfig {
 	port: number;
 	dataDir: string;
-	masterKey?: string;
+	masterKey?: { unlockKeyHex: string; publicKeyHex: string };
 	webUrl: string;
 	reset: boolean;
 	open: boolean;
@@ -47,8 +48,19 @@ function parseBool(raw: string): boolean {
 	return lower !== '0' && lower !== 'false' && lower !== 'no' && lower !== 'off';
 }
 
-function parseMasterKey(raw: string): string {
-	return validateMnemonic(raw) ? mnemonicToMasterKey(raw) : raw;
+/**
+ * The master key is always the 12-word mnemonic — a raw derived key is
+ * rejected because it could never enroll the auth public key, leaving an
+ * unlocked server nobody can log into.
+ */
+function parseMasterKey(raw: string): { unlockKeyHex: string; publicKeyHex: string } {
+	if (!validateMnemonic(raw)) {
+		throw new Error('Invalid master key: must be the 12-word master key phrase.');
+	}
+	return {
+		unlockKeyHex: deriveUnlockKey(raw),
+		publicKeyHex: deriveAuthKeyPair(raw).publicKeyHex,
+	};
 }
 
 /**
@@ -92,7 +104,10 @@ export function parseConfig(
 		.description('Hezo server — self-hosted AI agent management platform')
 		.option('--port <port>', 'Server port (env: HEZO_PORT)', String(DEFAULT_PORT))
 		.option('--data-dir <path>', 'Data directory (env: HEZO_DATA_DIR)', DEFAULT_DATA_DIR)
-		.option('--master-key <key>', 'Master key for unlocking (env: HEZO_MASTER_KEY)')
+		.option(
+			'--master-key <phrase>',
+			'The 12-word master key phrase for setup/unlock (env: HEZO_MASTER_KEY)',
+		)
 		.option('--web-url <url>', 'Web UI base URL for redirects (env: HEZO_WEB_URL)', '')
 		.option('--reset', 'Reset database and start fresh (env: HEZO_RESET)')
 		.option('--open', 'Auto-open the browser (env: HEZO_OPEN)')

--- a/packages/server/src/crypto/encryption.ts
+++ b/packages/server/src/crypto/encryption.ts
@@ -36,6 +36,6 @@ export function deriveKey(masterKey: string, purpose: string): Promise<Buffer> {
 	});
 }
 
-export function generateMasterKey(): string {
+export function generateUnlockKey(): string {
 	return randomBytes(32).toString('hex');
 }

--- a/packages/server/src/crypto/master-key.ts
+++ b/packages/server/src/crypto/master-key.ts
@@ -1,7 +1,12 @@
+import { verifyAuthSignature } from '@hezo/shared';
+import { logger } from '../logger';
 import { decrypt, deriveKey, encrypt } from './encryption';
 
 const CANARY_PLAINTEXT = 'CANARY';
 const CANARY_PURPOSE = 'master-key-canary';
+const AUTH_PUBLIC_KEY_META = 'auth_public_key';
+
+const log = logger.child('master-key');
 
 export type MasterKeyState = 'unset' | 'locked' | 'unlocked';
 
@@ -9,10 +14,19 @@ interface DbClient {
 	query<T = Record<string, unknown>>(sql: string, params?: unknown[]): Promise<{ rows: T[] }>;
 }
 
+/**
+ * Holds the server's symmetric key material, derived from the **unlock key** —
+ * a 32-byte key the client derives from the master-key mnemonic. The mnemonic
+ * itself (and the Ed25519 auth private key derived alongside the unlock key)
+ * never reaches the server; the unlock key transits only at setup and at
+ * unlock-after-restart. The enrolled auth public key (stored in `system_meta`)
+ * verifies challenge signatures for login/unlock.
+ */
 export class MasterKeyManager {
 	private key: Buffer | null = null;
 	private jwtKey: Buffer | null = null;
-	private masterKeyHex: string | null = null;
+	private unlockKeyHex: string | null = null;
+	private authPublicKeyHex: string | null = null;
 	private state: MasterKeyState = 'unset';
 	private unlockCallbacks: Array<() => void> = [];
 
@@ -24,41 +38,84 @@ export class MasterKeyManager {
 		return this.key;
 	}
 
-	getMasterKeyHex(): string | null {
-		return this.masterKeyHex;
+	getUnlockKeyHex(): string | null {
+		return this.unlockKeyHex;
 	}
 
-	async initialize(db: DbClient, masterKeyHex?: string): Promise<MasterKeyState> {
+	/**
+	 * Boot path. `publicKeyHex` is present only when booting from a CLI/env
+	 * mnemonic — in that case a fresh database gets fully enrolled (equivalent
+	 * to web setup), and an existing one gets its stored public key backfilled.
+	 * An unlock key without a public key is the test-helper path: the canary is
+	 * stored and the server unlocks, but the auth endpoints are unusable.
+	 */
+	async initialize(
+		db: DbClient,
+		unlockKeyHex?: string,
+		publicKeyHex?: string,
+	): Promise<MasterKeyState> {
 		const canary = await this.loadCanary(db);
 
 		if (canary) {
-			if (masterKeyHex && (await this.checkCanary(canary, masterKeyHex))) {
-				await this.setUnlocked(masterKeyHex);
+			if (unlockKeyHex && (await this.checkCanary(canary, unlockKeyHex))) {
+				if (publicKeyHex) await this.ensureAuthPublicKey(db, publicKeyHex);
+				await this.setUnlocked(unlockKeyHex);
 			} else {
 				this.state = 'locked';
 			}
+		} else if (unlockKeyHex && publicKeyHex) {
+			await this.setup(db, unlockKeyHex, publicKeyHex);
+		} else if (unlockKeyHex) {
+			await this.storeCanary(db, unlockKeyHex);
+			await this.setUnlocked(unlockKeyHex);
 		} else {
-			if (masterKeyHex) {
-				await this.storeCanary(db, masterKeyHex);
-				await this.setUnlocked(masterKeyHex);
-			} else {
-				this.state = 'unset';
-			}
+			this.state = 'unset';
 		}
 
 		return this.state;
 	}
 
-	async unlock(db: DbClient, masterKeyHex: string): Promise<boolean> {
-		if (this.state === 'unset') {
-			await this.storeCanary(db, masterKeyHex);
-			await this.setUnlocked(masterKeyHex);
-			return true;
+	/**
+	 * Explicit enrollment, only from 'unset': store the auth public key and the
+	 * canary atomically, then unlock. Once a canary exists, unlock() is the only
+	 * way in — there is no implicit re-enrollment.
+	 */
+	async setup(db: DbClient, unlockKeyHex: string, publicKeyHex: string): Promise<boolean> {
+		if (this.state !== 'unset') return false;
+
+		const derivedKey = await deriveKey(unlockKeyHex, CANARY_PURPOSE);
+		const encryptedCanary = encrypt(CANARY_PLAINTEXT, derivedKey);
+		await db.query('BEGIN');
+		try {
+			await db.query(
+				`INSERT INTO system_meta (key, value) VALUES ($1, $2)
+				 ON CONFLICT (key) DO UPDATE SET value = $2`,
+				[AUTH_PUBLIC_KEY_META, publicKeyHex],
+			);
+			await db.query(
+				`INSERT INTO system_meta (key, value) VALUES ('master_key_canary', $1)
+				 ON CONFLICT (key) DO UPDATE SET value = $1`,
+				[encryptedCanary],
+			);
+			await db.query('COMMIT');
+		} catch (e) {
+			await db.query('ROLLBACK');
+			throw e;
 		}
 
+		this.authPublicKeyHex = publicKeyHex;
+		await this.setUnlocked(unlockKeyHex);
+		return true;
+	}
+
+	/**
+	 * Canary check against an existing enrollment. Returns false when no canary
+	 * exists yet (state 'unset') — enrollment goes through setup() explicitly.
+	 */
+	async unlock(db: DbClient, unlockKeyHex: string): Promise<boolean> {
 		const canary = await this.loadCanary(db);
-		if (canary && (await this.checkCanary(canary, masterKeyHex))) {
-			await this.setUnlocked(masterKeyHex);
+		if (canary && (await this.checkCanary(canary, unlockKeyHex))) {
+			await this.setUnlocked(unlockKeyHex);
 			return true;
 		}
 		return false;
@@ -71,14 +128,51 @@ export class MasterKeyManager {
 
 	async getJwtKey(): Promise<Buffer> {
 		if (this.jwtKey) return this.jwtKey;
-		if (!this.masterKeyHex) throw new Error('Master key not available');
-		this.jwtKey = await deriveKey(this.masterKeyHex, 'jwt');
+		if (!this.unlockKeyHex) throw new Error('Master key not available');
+		this.jwtKey = await deriveKey(this.unlockKeyHex, 'jwt');
 		return this.jwtKey;
 	}
 
-	private async setUnlocked(masterKeyHex: string): Promise<void> {
-		this.masterKeyHex = masterKeyHex;
-		this.key = await deriveKey(masterKeyHex, 'encryption');
+	/** The enrolled Ed25519 auth public key (hex), memoized after first read. */
+	async getAuthPublicKeyHex(db: DbClient): Promise<string | null> {
+		if (this.authPublicKeyHex) return this.authPublicKeyHex;
+		const result = await db.query<{ value: string }>(
+			'SELECT value FROM system_meta WHERE key = $1',
+			[AUTH_PUBLIC_KEY_META],
+		);
+		this.authPublicKeyHex = result.rows[0]?.value ?? null;
+		return this.authPublicKeyHex;
+	}
+
+	/** Verify an Ed25519 signature against the enrolled auth public key. */
+	async verifySignature(db: DbClient, message: string, signatureHex: string): Promise<boolean> {
+		const publicKeyHex = await this.getAuthPublicKeyHex(db);
+		if (!publicKeyHex) return false;
+		return verifyAuthSignature(publicKeyHex, message, signatureHex);
+	}
+
+	/**
+	 * Boot-time backfill: ensure the stored public key matches the one derived
+	 * from the boot mnemonic. The mnemonic is the root of trust, so a mismatch
+	 * is overwritten (with a warning) rather than rejected.
+	 */
+	private async ensureAuthPublicKey(db: DbClient, publicKeyHex: string): Promise<void> {
+		const stored = await this.getAuthPublicKeyHex(db);
+		if (stored === publicKeyHex) return;
+		if (stored) {
+			log.warn('Stored auth public key differs from boot mnemonic; overwriting.');
+		}
+		await db.query(
+			`INSERT INTO system_meta (key, value) VALUES ($1, $2)
+			 ON CONFLICT (key) DO UPDATE SET value = $2`,
+			[AUTH_PUBLIC_KEY_META, publicKeyHex],
+		);
+		this.authPublicKeyHex = publicKeyHex;
+	}
+
+	private async setUnlocked(unlockKeyHex: string): Promise<void> {
+		this.unlockKeyHex = unlockKeyHex;
+		this.key = await deriveKey(unlockKeyHex, 'encryption');
 		const wasLocked = this.state !== 'unlocked';
 		this.state = 'unlocked';
 		if (wasLocked) {
@@ -93,8 +187,8 @@ export class MasterKeyManager {
 		return result.rows[0]?.value ?? null;
 	}
 
-	private async storeCanary(db: DbClient, masterKeyHex: string): Promise<void> {
-		const derivedKey = await deriveKey(masterKeyHex, CANARY_PURPOSE);
+	private async storeCanary(db: DbClient, unlockKeyHex: string): Promise<void> {
+		const derivedKey = await deriveKey(unlockKeyHex, CANARY_PURPOSE);
 		const encrypted = encrypt(CANARY_PLAINTEXT, derivedKey);
 		await db.query(
 			`INSERT INTO system_meta (key, value) VALUES ('master_key_canary', $1)
@@ -103,9 +197,9 @@ export class MasterKeyManager {
 		);
 	}
 
-	private async checkCanary(encryptedCanary: string, masterKeyHex: string): Promise<boolean> {
+	private async checkCanary(encryptedCanary: string, unlockKeyHex: string): Promise<boolean> {
 		try {
-			const derivedKey = await deriveKey(masterKeyHex, CANARY_PURPOSE);
+			const derivedKey = await deriveKey(unlockKeyHex, CANARY_PURPOSE);
 			return decrypt(encryptedCanary, derivedKey) === CANARY_PLAINTEXT;
 		} catch {
 			return false;
@@ -113,4 +207,4 @@ export class MasterKeyManager {
 	}
 }
 
-export { generateMasterKey } from './encryption';
+export { generateUnlockKey } from './encryption';

--- a/packages/server/src/crypto/state.ts
+++ b/packages/server/src/crypto/state.ts
@@ -44,9 +44,9 @@ export async function signOAuthState(
 	payload: OAuthStatePayload,
 	masterKeyManager: MasterKeyManager,
 ): Promise<string> {
-	const masterKeyHex = masterKeyManager.getMasterKeyHex();
-	if (!masterKeyHex) throw new Error('Master key not available');
-	const key = await deriveKey(masterKeyHex, 'oauth-state');
+	const unlockKeyHex = masterKeyManager.getUnlockKeyHex();
+	if (!unlockKeyHex) throw new Error('Master key not available');
+	const key = await deriveKey(unlockKeyHex, 'oauth-state');
 	const json = JSON.stringify(payload);
 	const encoded = Buffer.from(json).toString('base64url');
 	const signature = createHmac('sha256', key).update(encoded).digest('base64url');
@@ -67,9 +67,9 @@ export async function verifyOAuthState(
 	const signature = signedState.substring(dotIndex + 1);
 
 	try {
-		const masterKeyHex = masterKeyManager.getMasterKeyHex();
-		if (!masterKeyHex) return null;
-		const key = await deriveKey(masterKeyHex, 'oauth-state');
+		const unlockKeyHex = masterKeyManager.getUnlockKeyHex();
+		if (!unlockKeyHex) return null;
+		const key = await deriveKey(unlockKeyHex, 'oauth-state');
 		const expected = createHmac('sha256', key).update(encoded).digest('base64url');
 
 		if (signature.length !== expected.length) return null;

--- a/packages/server/src/lib/asset-urls.ts
+++ b/packages/server/src/lib/asset-urls.ts
@@ -6,9 +6,9 @@ import type { MasterKeyManager } from '../crypto/master-key';
 const KEY_PURPOSE = 'asset-url';
 
 async function getSigningKey(masterKeyManager: MasterKeyManager): Promise<Buffer> {
-	const masterKeyHex = masterKeyManager.getMasterKeyHex();
-	if (!masterKeyHex) throw new Error('Master key not available');
-	return deriveKey(masterKeyHex, KEY_PURPOSE);
+	const unlockKeyHex = masterKeyManager.getUnlockKeyHex();
+	if (!unlockKeyHex) throw new Error('Master key not available');
+	return deriveKey(unlockKeyHex, KEY_PURPOSE);
 }
 
 export async function signAssetUrl(

--- a/packages/server/src/lib/types.ts
+++ b/packages/server/src/lib/types.ts
@@ -2,6 +2,7 @@ import type { PGlite } from '@electric-sql/pglite';
 import type { AuthType } from '@hezo/shared';
 import type { MasterKeyManager } from '../crypto/master-key';
 import type { DomainEventBus } from '../events/bus';
+import type { AuthChallengeStore } from '../services/auth-challenges';
 import type { CeoSessionManager } from '../services/ceo-session-manager';
 import type { ContainerLogStreamer } from '../services/container-logs';
 import type { DockerClient } from '../services/docker';
@@ -33,6 +34,7 @@ export type Env = {
 	Variables: {
 		db: PGlite;
 		masterKeyManager: MasterKeyManager;
+		authChallenges: AuthChallengeStore;
 		docker: DockerClient;
 		wsManager: WebSocketManager;
 		events: DomainEventBus;

--- a/packages/server/src/middleware/auth.ts
+++ b/packages/server/src/middleware/auth.ts
@@ -13,7 +13,15 @@ const AGENT_JWT_TTL_SECONDS = 60 * 60 * 4;
 // the ceo_sessions row status, so a long TTL is safe.
 const CEO_SESSION_JWT_TTL_SECONDS = 60 * 60 * 24 * 30;
 
-const PUBLIC_PATHS = ['/health', '/api/status', '/api/auth/token', '/', '/api/oauth/callback'];
+const PUBLIC_PATHS = [
+	'/health',
+	'/api/status',
+	'/api/auth/setup',
+	'/api/auth/challenge',
+	'/api/auth/verify',
+	'/',
+	'/api/oauth/callback',
+];
 
 /**
  * Shared token verification used by HTTP middleware, MCP, and WebSocket auth.

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -1,4 +1,12 @@
-import { DEFAULT_TEAM_ID, MemberType } from '@hezo/shared';
+import {
+	buildLoginMessage,
+	buildSetupMessage,
+	buildUnlockMessage,
+	DEFAULT_TEAM_ID,
+	MemberType,
+	verifyAuthSignature,
+} from '@hezo/shared';
+import type { Context } from 'hono';
 import { Hono } from 'hono';
 import { requestOrigin } from '../lib/request-origin';
 import { err, ok } from '../lib/response';
@@ -14,23 +22,132 @@ import { signAdminJwt } from '../middleware/auth';
 
 const log = logger.child('routes');
 
+const KEY_HEX = /^[0-9a-f]{64}$/;
+const SIGNATURE_HEX = /^[0-9a-f]{128}$/;
+
 export const authRoutes = new Hono<Env>();
 
-// Bootstrap endpoint: exchange master key for a admin JWT (Phase 2 dev convenience)
-authRoutes.post('/auth/token', async (c) => {
-	const body = await c.req.json<{ master_key?: string }>();
+// Challenge-response auth. The master-key mnemonic never reaches the server:
+// the client derives an Ed25519 keypair (enrolled at setup, signs challenges
+// thereafter) and an unlock key (transits only at setup and unlock — inside a
+// signed payload — to root the server's at-rest encryption).
 
-	if (!body.master_key) {
-		return err(c, 'INVALID_REQUEST', 'master_key is required', 400);
+// Enrollment, first boot only: bind the auth public key and store the canary.
+authRoutes.post('/auth/setup', async (c) => {
+	let body: { public_key?: string; unlock_key?: string; signature?: string };
+	try {
+		body = await c.req.json();
+	} catch {
+		return err(c, 'INVALID_REQUEST', 'JSON body required', 400);
+	}
+	const { public_key, unlock_key, signature } = body;
+	if (
+		typeof public_key !== 'string' ||
+		!KEY_HEX.test(public_key) ||
+		typeof unlock_key !== 'string' ||
+		!KEY_HEX.test(unlock_key) ||
+		typeof signature !== 'string' ||
+		!SIGNATURE_HEX.test(signature)
+	) {
+		return err(c, 'INVALID_REQUEST', 'public_key, unlock_key, and signature are required', 400);
+	}
+
+	const masterKeyManager = c.get('masterKeyManager');
+	if (masterKeyManager.getState() !== 'unset') {
+		return err(c, 'ALREADY_SET', 'Master key is already set', 409);
+	}
+
+	// Self-certifying enrollment (TOFU, the same trust level as any first-boot
+	// credential): the signature proves possession of the private key matching
+	// the submitted public key. Verified before anything is persisted.
+	if (!verifyAuthSignature(public_key, buildSetupMessage(public_key, unlock_key), signature)) {
+		return err(c, 'INVALID_SIGNATURE', 'Signature verification failed', 401);
+	}
+
+	const enrolled = await masterKeyManager.setup(c.get('db'), unlock_key, public_key);
+	if (!enrolled) {
+		return err(c, 'ALREADY_SET', 'Master key is already set', 409);
+	}
+
+	return issueAdminSession(c);
+});
+
+// Step 1 of login/unlock: a single-use nonce for the client to sign.
+authRoutes.post('/auth/challenge', (c) => {
+	if (c.get('masterKeyManager').getState() === 'unset') {
+		return err(c, 'SETUP_REQUIRED', 'No master key set. Run setup first.', 409);
+	}
+	const { challengeId, nonce, expiresInSeconds } = c.get('authChallenges').issue();
+	return ok(c, { challenge_id: challengeId, nonce, expires_in: expiresInSeconds });
+});
+
+// Step 2: verify the Ed25519 signature over the stored nonce and issue a JWT.
+// The client signs buildUnlockMessage(nonce, unlock_key) when it includes the
+// unlock key (server locked), buildLoginMessage(nonce) otherwise. The nonce is
+// never echoed back — the message is reconstructed from the stored copy, so
+// the signature is the sole authenticator.
+authRoutes.post('/auth/verify', async (c) => {
+	let body: { challenge_id?: string; signature?: string; unlock_key?: string };
+	try {
+		body = await c.req.json();
+	} catch {
+		return err(c, 'INVALID_REQUEST', 'JSON body required', 400);
+	}
+	const { challenge_id, signature, unlock_key } = body;
+	// Shape-validate before consuming, so malformed junk can't burn a challenge.
+	if (
+		typeof challenge_id !== 'string' ||
+		challenge_id.length === 0 ||
+		typeof signature !== 'string' ||
+		!SIGNATURE_HEX.test(signature) ||
+		(unlock_key !== undefined && (typeof unlock_key !== 'string' || !KEY_HEX.test(unlock_key)))
+	) {
+		return err(c, 'INVALID_REQUEST', 'challenge_id and signature are required', 400);
 	}
 
 	const masterKeyManager = c.get('masterKeyManager');
 	const db = c.get('db');
-	const unlocked = await masterKeyManager.unlock(db, body.master_key);
-
-	if (!unlocked) {
-		return err(c, 'UNAUTHORIZED', 'Invalid master key', 401);
+	if (masterKeyManager.getState() === 'unset') {
+		return err(c, 'SETUP_REQUIRED', 'No master key set. Run setup first.', 409);
 	}
+
+	// Consume before verifying: a failed attempt burns the nonce, so one
+	// challenge never absorbs more than a single signature guess.
+	const challenge = c.get('authChallenges').consume(challenge_id);
+	if (!challenge) {
+		return err(c, 'INVALID_CHALLENGE', 'Unknown, expired, or already used challenge', 401);
+	}
+
+	const message =
+		unlock_key !== undefined
+			? buildUnlockMessage(challenge.nonce, unlock_key)
+			: buildLoginMessage(challenge.nonce);
+	if (!(await masterKeyManager.verifySignature(db, message, signature))) {
+		return err(c, 'INVALID_SIGNATURE', 'Signature verification failed', 401);
+	}
+
+	if (masterKeyManager.getState() === 'locked' && unlock_key === undefined) {
+		// Distinct from the middleware's LOCKED so the client can retry the
+		// challenge dance with the unlock key included.
+		return err(c, 'UNLOCK_KEY_REQUIRED', 'Server is locked; include unlock_key', 401);
+	}
+
+	// Runs even when already unlocked, so a client that believed the server was
+	// locked (stale status) still succeeds — the canary check makes it a no-op.
+	if (unlock_key !== undefined) {
+		const unlocked = await masterKeyManager.unlock(db, unlock_key);
+		if (!unlocked) {
+			return err(c, 'INVALID_UNLOCK_KEY', 'Invalid unlock key', 401);
+		}
+	}
+
+	return issueAdminSession(c);
+});
+
+/** Shared tail of setup/verify: capture base URL, ensure superuser, mint JWT. */
+async function issueAdminSession(c: Context<Env>) {
+	const db = c.get('db');
+	const masterKeyManager = c.get('masterKeyManager');
 
 	// Capture the public base URL of this instance from the URL the operator
 	// used to reach it. Only when unset — a configured or previously captured
@@ -61,7 +178,7 @@ authRoutes.post('/auth/token', async (c) => {
 
 	const token = await signAdminJwt(masterKeyManager, userId);
 	return ok(c, { token }, 200);
-});
+}
 
 async function addUserToDefaultTeam(
 	db: import('@electric-sql/pglite').PGlite,

--- a/packages/server/src/services/auth-challenges.ts
+++ b/packages/server/src/services/auth-challenges.ts
@@ -1,0 +1,63 @@
+import { randomBytes, randomUUID } from 'node:crypto';
+
+const DEFAULT_TTL_MS = 2 * 60 * 1000;
+const DEFAULT_MAX_OUTSTANDING = 1000;
+
+interface ChallengeEntry {
+	nonce: string;
+	expiresAt: number;
+}
+
+/**
+ * Single-use login/unlock challenges, in memory. The server is a single
+ * process, and a restart locks it anyway — losing outstanding challenges on
+ * restart is semantically correct (the client just requests a new one). The
+ * nonce is never echoed back by the client: /auth/verify reconstructs the
+ * signed message from the stored copy, so the Ed25519 signature is the sole
+ * authenticator and no timing-sensitive comparison exists here.
+ */
+export class AuthChallengeStore {
+	private readonly ttlMs: number;
+	private readonly maxOutstanding: number;
+	private readonly entries = new Map<string, ChallengeEntry>();
+
+	constructor(opts?: { ttlMs?: number; maxOutstanding?: number }) {
+		this.ttlMs = opts?.ttlMs ?? DEFAULT_TTL_MS;
+		this.maxOutstanding = opts?.maxOutstanding ?? DEFAULT_MAX_OUTSTANDING;
+	}
+
+	issue(): { challengeId: string; nonce: string; expiresInSeconds: number } {
+		this.sweep();
+		// Bound memory against unauthenticated spam: evict oldest-first (Map
+		// preserves insertion order) once the cap is reached.
+		while (this.entries.size >= this.maxOutstanding) {
+			const oldest = this.entries.keys().next().value;
+			if (oldest === undefined) break;
+			this.entries.delete(oldest);
+		}
+		const challengeId = randomUUID();
+		const nonce = randomBytes(32).toString('hex');
+		this.entries.set(challengeId, { nonce, expiresAt: Date.now() + this.ttlMs });
+		return { challengeId, nonce, expiresInSeconds: Math.floor(this.ttlMs / 1000) };
+	}
+
+	/**
+	 * Single-use: the entry is deleted on lookup regardless of what the caller
+	 * does next, so a failed verification burns the challenge. Returns null for
+	 * unknown, already-consumed, or expired ids.
+	 */
+	consume(challengeId: string): { nonce: string } | null {
+		const entry = this.entries.get(challengeId);
+		if (!entry) return null;
+		this.entries.delete(challengeId);
+		if (entry.expiresAt < Date.now()) return null;
+		return { nonce: entry.nonce };
+	}
+
+	private sweep(): void {
+		const now = Date.now();
+		for (const [id, entry] of this.entries) {
+			if (entry.expiresAt < now) this.entries.delete(id);
+		}
+	}
+}

--- a/packages/server/src/services/oauth/state.ts
+++ b/packages/server/src/services/oauth/state.ts
@@ -42,7 +42,7 @@ export async function signState(
 	masterKeyManager: MasterKeyManager,
 	input: NewStateInput,
 ): Promise<{ state: string; codeVerifier: string; codeChallenge: string }> {
-	const masterHex = masterKeyManager.getMasterKeyHex();
+	const masterHex = masterKeyManager.getUnlockKeyHex();
 	if (!masterHex) throw new Error('master key not unlocked');
 
 	const codeVerifier = base64url(randomBytes(32));
@@ -73,7 +73,7 @@ export async function verifyState(
 	masterKeyManager: MasterKeyManager,
 	state: string,
 ): Promise<StatePayload | null> {
-	const masterHex = masterKeyManager.getMasterKeyHex();
+	const masterHex = masterKeyManager.getUnlockKeyHex();
 	if (!masterHex) return null;
 
 	const [payloadB64, sigB64] = state.split('.');

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -50,6 +50,7 @@ import { teamTemplatesRoutes } from './routes/team-templates';
 import { teamsRoutes } from './routes/teams';
 import { uiStateRoutes } from './routes/ui-state';
 import { updatesRoutes } from './routes/updates';
+import { AuthChallengeStore } from './services/auth-challenges';
 import { CeoSessionManager } from './services/ceo-session-manager';
 import { ContainerLogStreamer } from './services/container-logs';
 import { DockerClient } from './services/docker';
@@ -237,6 +238,7 @@ export function buildApp(
 	ceoSessionManager?: CeoSessionManager,
 ): Hono<Env> {
 	const app = new Hono<Env>();
+	const authChallenges = new AuthChallengeStore();
 	logs.setWsManager(wsManager);
 	registerAuditObserver(events, db);
 
@@ -248,6 +250,7 @@ export function buildApp(
 	app.use('*', async (c, next) => {
 		c.set('db', db);
 		c.set('masterKeyManager', masterKeyManager);
+		c.set('authChallenges', authChallenges);
 		c.set('docker', docker);
 		c.set('wsManager', wsManager);
 		c.set('events', events);
@@ -487,10 +490,14 @@ async function runSeed(db: PGlite): Promise<void> {
 async function resolveMasterKeyState(
 	db: PGlite,
 	masterKeyManager: MasterKeyManager,
-	masterKey?: string,
+	masterKey?: { unlockKeyHex: string; publicKeyHex: string },
 ): Promise<MasterKeyState> {
 	try {
-		const state = await masterKeyManager.initialize(db, masterKey);
+		const state = await masterKeyManager.initialize(
+			db,
+			masterKey?.unlockKeyHex,
+			masterKey?.publicKeyHex,
+		);
 
 		const messages: Record<string, string> = {
 			unlocked: 'Master key verified. Server unlocked.',

--- a/packages/server/test/auth-challenges.test.ts
+++ b/packages/server/test/auth-challenges.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { AuthChallengeStore } from '../src/services/auth-challenges';
+
+describe('AuthChallengeStore', () => {
+	it('issues 64-hex nonces with unique ids', () => {
+		const store = new AuthChallengeStore();
+		const a = store.issue();
+		const b = store.issue();
+		expect(a.nonce).toMatch(/^[0-9a-f]{64}$/);
+		expect(a.challengeId).not.toBe(b.challengeId);
+		expect(a.nonce).not.toBe(b.nonce);
+		expect(a.expiresInSeconds).toBeGreaterThan(0);
+	});
+
+	it('consume is single-use', () => {
+		const store = new AuthChallengeStore();
+		const { challengeId, nonce } = store.issue();
+		expect(store.consume(challengeId)?.nonce).toBe(nonce);
+		expect(store.consume(challengeId)).toBeNull();
+	});
+
+	it('returns null for unknown ids', () => {
+		const store = new AuthChallengeStore();
+		expect(store.consume('00000000-0000-4000-8000-000000000000')).toBeNull();
+	});
+
+	it('honors expiry', async () => {
+		const store = new AuthChallengeStore({ ttlMs: 1 });
+		const { challengeId } = store.issue();
+		await new Promise((r) => setTimeout(r, 10));
+		expect(store.consume(challengeId)).toBeNull();
+	});
+
+	it('evicts oldest entries beyond the cap', () => {
+		const store = new AuthChallengeStore({ maxOutstanding: 3 });
+		const first = store.issue();
+		const rest = [store.issue(), store.issue(), store.issue()];
+		expect(store.consume(first.challengeId)).toBeNull();
+		for (const c of rest) {
+			expect(store.consume(c.challengeId)?.nonce).toBe(c.nonce);
+		}
+	});
+});

--- a/packages/server/test/auth-crypto.test.ts
+++ b/packages/server/test/auth-crypto.test.ts
@@ -1,0 +1,100 @@
+import {
+	buildLoginMessage,
+	buildSetupMessage,
+	buildUnlockMessage,
+	deriveAuthKeyPair,
+	deriveUnlockKey,
+	signAuthMessage,
+	verifyAuthSignature,
+} from '@hezo/shared';
+import { describe, expect, it } from 'vitest';
+
+// Canonical BIP39 test vector (the all-"abandon" phrase). The pinned outputs
+// catch any drift in the HKDF salts, the BIP39 seed derivation, or the noble
+// libraries — a silent change here would strand every existing instance.
+const VECTOR =
+	'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+const VECTOR_UNLOCK_KEY = '1b9b632446707426957408aed76cd1a45d3494e8609584eb74189b7742e10dad';
+const VECTOR_PUBLIC_KEY = 'dbb05bb48f810ee380f91dcda76e3b1f3a343297ac691f2899e7f7d6afea43cc';
+
+describe('deriveUnlockKey', () => {
+	it('derives the pinned unlock key for the canonical vector', () => {
+		const hex = deriveUnlockKey(VECTOR);
+		expect(hex).toBe(VECTOR_UNLOCK_KEY);
+		expect(hex).toMatch(/^[0-9a-f]{64}$/);
+	});
+
+	it('is deterministic and normalizes whitespace/case', () => {
+		const messy = `  ABANDON   abandon\tabandon abandon abandon abandon
+			abandon abandon abandon abandon abandon ABOUT  `;
+		expect(deriveUnlockKey(messy)).toBe(VECTOR_UNLOCK_KEY);
+	});
+});
+
+describe('deriveAuthKeyPair', () => {
+	it('derives the pinned public key for the canonical vector', () => {
+		const keys = deriveAuthKeyPair(VECTOR);
+		expect(keys.publicKeyHex).toBe(VECTOR_PUBLIC_KEY);
+		expect(keys.privateKey).toHaveLength(32);
+	});
+
+	it('is salt-separated from the unlock key', () => {
+		const keys = deriveAuthKeyPair(VECTOR);
+		expect(Buffer.from(keys.privateKey).toString('hex')).not.toBe(VECTOR_UNLOCK_KEY);
+	});
+
+	it('different phrases produce different keypairs', () => {
+		const other = deriveAuthKeyPair(
+			'legal winner thank year wave sausage worth useful legal winner thank yellow',
+		);
+		expect(other.publicKeyHex).not.toBe(VECTOR_PUBLIC_KEY);
+	});
+});
+
+describe('signAuthMessage / verifyAuthSignature', () => {
+	const keys = deriveAuthKeyPair(VECTOR);
+
+	it('roundtrips', () => {
+		const sig = signAuthMessage(keys.privateKey, 'hello');
+		expect(sig).toMatch(/^[0-9a-f]{128}$/);
+		expect(verifyAuthSignature(keys.publicKeyHex, 'hello', sig)).toBe(true);
+	});
+
+	it('rejects a tampered message', () => {
+		const sig = signAuthMessage(keys.privateKey, 'hello');
+		expect(verifyAuthSignature(keys.publicKeyHex, 'hellO', sig)).toBe(false);
+	});
+
+	it('rejects a signature from a different keypair', () => {
+		const other = deriveAuthKeyPair(
+			'legal winner thank year wave sausage worth useful legal winner thank yellow',
+		);
+		const sig = signAuthMessage(other.privateKey, 'hello');
+		expect(verifyAuthSignature(keys.publicKeyHex, 'hello', sig)).toBe(false);
+	});
+
+	it('returns false (never throws) on malformed inputs', () => {
+		const sig = signAuthMessage(keys.privateKey, 'hello');
+		expect(verifyAuthSignature('not-hex', 'hello', sig)).toBe(false);
+		expect(verifyAuthSignature(keys.publicKeyHex, 'hello', 'zz')).toBe(false);
+		expect(verifyAuthSignature('', 'hello', '')).toBe(false);
+		expect(verifyAuthSignature('ab', 'hello', sig)).toBe(false);
+	});
+});
+
+describe('canonical messages', () => {
+	it('pin the exact wire formats', () => {
+		expect(buildSetupMessage('aa', 'bb')).toBe('hezo-auth-v1:setup:aa:bb');
+		expect(buildLoginMessage('cc')).toBe('hezo-auth-v1:login:cc');
+		expect(buildUnlockMessage('cc', 'bb')).toBe('hezo-auth-v1:unlock:cc:bb');
+	});
+
+	it('a login signature does not verify as an unlock signature', () => {
+		const keys = deriveAuthKeyPair(VECTOR);
+		const nonce = 'cc'.repeat(32);
+		const sig = signAuthMessage(keys.privateKey, buildLoginMessage(nonce));
+		expect(
+			verifyAuthSignature(keys.publicKeyHex, buildUnlockMessage(nonce, VECTOR_UNLOCK_KEY), sig),
+		).toBe(false);
+	});
+});

--- a/packages/server/test/auth-middleware.test.ts
+++ b/packages/server/test/auth-middleware.test.ts
@@ -307,14 +307,25 @@ describe('authMiddleware (via HTTP)', () => {
 		expect(res.status).toBe(200);
 	});
 
-	it('allows /api/auth/token without auth', async () => {
-		// Should get 400 (missing body), not 401
-		const res = await app.request('/api/auth/token', {
+	it('allows the /api/auth/* endpoints without auth', async () => {
+		// Malformed bodies should get 400/409 from the handlers, not the
+		// middleware's 401 — proving the paths are public.
+		const setup = await app.request('/api/auth/setup', {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify({}),
 		});
-		expect(res.status).not.toBe(401);
+		expect(setup.status).not.toBe(401);
+
+		const challenge = await app.request('/api/auth/challenge', { method: 'POST' });
+		expect(challenge.status).not.toBe(401);
+
+		const verify = await app.request('/api/auth/verify', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({}),
+		});
+		expect(verify.status).not.toBe(401);
 	});
 
 	it('allows API requests without auth header (anonymous admin while unlocked)', async () => {

--- a/packages/server/test/auth-routes.test.ts
+++ b/packages/server/test/auth-routes.test.ts
@@ -1,105 +1,318 @@
 import type { PGlite } from '@electric-sql/pglite';
+import {
+	buildLoginMessage,
+	buildSetupMessage,
+	buildUnlockMessage,
+	deriveAuthKeyPair,
+	deriveUnlockKey,
+	generateMnemonic,
+	signAuthMessage,
+} from '@hezo/shared';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { MasterKeyManager } from '../src/crypto/master-key';
 import type { Env } from '../src/lib/types';
 import { verifyToken } from '../src/middleware/auth';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp } from './helpers/app';
+import {
+	authHeader,
+	createTestApp,
+	createUnsetTestApp,
+	loginViaAuthApi,
+	restartTestApp,
+} from './helpers/app';
 
-let app: Hono<Env>;
-let db: PGlite;
-let masterKeyHex: string;
-let masterKeyManager: MasterKeyManager;
+const JSON_HEADERS = { 'Content-Type': 'application/json' };
 
-beforeAll(async () => {
-	const ctx = await createTestApp();
-	app = ctx.app;
-	db = ctx.db;
-	masterKeyHex = ctx.masterKeyHex;
-	masterKeyManager = ctx.masterKeyManager;
-});
+function postJson(app: Hono<Env>, path: string, body: unknown) {
+	return app.request(path, {
+		method: 'POST',
+		headers: JSON_HEADERS,
+		body: JSON.stringify(body),
+	});
+}
 
-afterAll(async () => {
-	await safeClose(db);
-});
+async function getChallenge(app: Hono<Env>): Promise<{ challenge_id: string; nonce: string }> {
+	const res = await app.request('/api/auth/challenge', { method: 'POST' });
+	expect(res.status).toBe(200);
+	return (await res.json()).data;
+}
 
-describe('POST /api/auth/token', () => {
-	it('returns 400 when master_key is missing', async () => {
-		const res = await app.request('/api/auth/token', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({}),
-		});
-		expect(res.status).toBe(400);
-		const body = await res.json();
-		expect(body.error.code).toBe('INVALID_REQUEST');
+async function errorCode(res: Response): Promise<string> {
+	return (await res.json()).error.code;
+}
+
+describe('setup, unlock, and restart flows', () => {
+	let app: Hono<Env>;
+	let db: PGlite;
+	let masterKeyManager: MasterKeyManager;
+	let dataDir: string;
+	const mnemonic = generateMnemonic();
+	const keys = deriveAuthKeyPair(mnemonic);
+	const unlockKey = deriveUnlockKey(mnemonic);
+
+	beforeAll(async () => {
+		({ app, db, masterKeyManager, dataDir } = await createUnsetTestApp());
 	});
 
-	it('returns 401 for invalid master key', async () => {
-		const res = await app.request('/api/auth/token', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ master_key: 'wrong_key_value' }),
-		});
-		expect(res.status).toBe(401);
-		const body = await res.json();
-		expect(body.error.code).toBe('UNAUTHORIZED');
+	afterAll(async () => {
+		await safeClose(db);
 	});
 
-	it('returns a valid JWT for correct master key', async () => {
-		const res = await app.request('/api/auth/token', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ master_key: masterKeyHex }),
-		});
-		expect(res.status).toBe(200);
-		const body = await res.json();
-		expect(body.data).toHaveProperty('token');
-		expect(typeof body.data.token).toBe('string');
+	function setupBody(overrides: Record<string, string> = {}) {
+		return {
+			public_key: keys.publicKeyHex,
+			unlock_key: unlockKey,
+			signature: signAuthMessage(keys.privateKey, buildSetupMessage(keys.publicKeyHex, unlockKey)),
+			...overrides,
+		};
+	}
 
-		// Verify the returned token is valid
-		const auth = await verifyToken(body.data.token, db, masterKeyManager);
-		expect(auth).not.toBeNull();
-		expect(auth!.type).toBe('admin');
-	});
-
-	it('reuses existing superuser on subsequent calls', async () => {
-		const res1 = await app.request('/api/auth/token', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ master_key: masterKeyHex }),
-		});
-		const token1 = (await res1.json()).data.token;
-		const auth1 = await verifyToken(token1, db, masterKeyManager);
-
-		const res2 = await app.request('/api/auth/token', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ master_key: masterKeyHex }),
-		});
-		const token2 = (await res2.json()).data.token;
-		const auth2 = await verifyToken(token2, db, masterKeyManager);
-
-		// Both tokens should reference the same user
-		expect(auth1).not.toBeNull();
-		expect(auth2).not.toBeNull();
-		if (auth1!.type === 'admin' && auth2!.type === 'admin') {
-			expect(auth1!.userId).toBe(auth2!.userId);
+	it('rejects malformed setup payloads with 400', async () => {
+		for (const body of [
+			{},
+			setupBody({ public_key: 'short' }),
+			setupBody({ unlock_key: 'Z'.repeat(64) }),
+			setupBody({ signature: 'ab' }),
+		]) {
+			const res = await postJson(app, '/api/auth/setup', body);
+			expect(res.status).toBe(400);
+			expect(await errorCode(res)).toBe('INVALID_REQUEST');
 		}
 	});
 
-	it('returned token grants access to protected endpoints', async () => {
-		const res = await app.request('/api/auth/token', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ master_key: masterKeyHex }),
+	it('refuses challenges before setup', async () => {
+		const res = await app.request('/api/auth/challenge', { method: 'POST' });
+		expect(res.status).toBe(409);
+		expect(await errorCode(res)).toBe('SETUP_REQUIRED');
+	});
+
+	it('refuses verify before setup', async () => {
+		const res = await postJson(app, '/api/auth/verify', {
+			challenge_id: '00000000-0000-4000-8000-000000000000',
+			signature: 'ab'.repeat(64),
 		});
+		expect(res.status).toBe(409);
+		expect(await errorCode(res)).toBe('SETUP_REQUIRED');
+	});
+
+	it('rejects a bad setup signature and persists nothing', async () => {
+		// Signed over a different unlock key than the one submitted.
+		const res = await postJson(
+			app,
+			'/api/auth/setup',
+			setupBody({
+				signature: signAuthMessage(
+					keys.privateKey,
+					buildSetupMessage(keys.publicKeyHex, 'ff'.repeat(32)),
+				),
+			}),
+		);
+		expect(res.status).toBe(401);
+		expect(await errorCode(res)).toBe('INVALID_SIGNATURE');
+		expect(masterKeyManager.getState()).toBe('unset');
+		const rows = await db.query(
+			"SELECT key FROM system_meta WHERE key IN ('auth_public_key', 'master_key_canary')",
+		);
+		expect(rows.rows).toHaveLength(0);
+	});
+
+	it('enrolls, unlocks, and returns a working token', async () => {
+		const res = await postJson(app, '/api/auth/setup', setupBody());
+		expect(res.status).toBe(200);
 		const { token } = (await res.json()).data;
 
-		const teamsRes = await app.request('/api/teams', {
-			headers: authHeader(token),
+		const auth = await verifyToken(token, db, masterKeyManager);
+		expect(auth).not.toBeNull();
+		expect(auth?.type).toBe('admin');
+
+		const status = await app.request('/api/status');
+		expect((await status.json()).masterKeyState).toBe('unlocked');
+
+		const superuser = await db.query('SELECT id FROM users WHERE is_superuser = true');
+		expect(superuser.rows).toHaveLength(1);
+
+		const meta = await db.query<{ key: string; value: string }>(
+			"SELECT key, value FROM system_meta WHERE key IN ('auth_public_key', 'master_key_canary') ORDER BY key",
+		);
+		expect(meta.rows.map((r) => r.key)).toEqual(['auth_public_key', 'master_key_canary']);
+		expect(meta.rows[0].value).toBe(keys.publicKeyHex);
+	});
+
+	it('rejects a second setup with 409', async () => {
+		const res = await postJson(app, '/api/auth/setup', setupBody());
+		expect(res.status).toBe(409);
+		expect(await errorCode(res)).toBe('ALREADY_SET');
+	});
+
+	it('requires the unlock key after a restart, then unlocks with it', async () => {
+		const restarted = await restartTestApp(db, dataDir);
+		expect(restarted.masterKeyManager.getState()).toBe('locked');
+
+		// Valid login signature, but no unlock key while locked.
+		const withoutKey = await loginViaAuthApi(restarted.app, mnemonic);
+		expect(withoutKey.status).toBe(401);
+		expect(await errorCode(withoutKey)).toBe('UNLOCK_KEY_REQUIRED');
+		expect(restarted.masterKeyManager.getState()).toBe('locked');
+
+		const withKey = await loginViaAuthApi(restarted.app, mnemonic, { includeUnlockKey: true });
+		expect(withKey.status).toBe(200);
+		expect((await withKey.json()).data.token).toBeTypeOf('string');
+		expect(restarted.masterKeyManager.getState()).toBe('unlocked');
+	});
+
+	it('rejects a wrong unlock key even with a valid signature', async () => {
+		const restarted = await restartTestApp(db, dataDir);
+		expect(restarted.masterKeyManager.getState()).toBe('locked');
+
+		const wrongKey = 'ff'.repeat(32);
+		const { challenge_id, nonce } = await getChallenge(restarted.app);
+		const res = await postJson(restarted.app, '/api/auth/verify', {
+			challenge_id,
+			unlock_key: wrongKey,
+			signature: signAuthMessage(keys.privateKey, buildUnlockMessage(nonce, wrongKey)),
 		});
+		expect(res.status).toBe(401);
+		expect(await errorCode(res)).toBe('INVALID_UNLOCK_KEY');
+		expect(restarted.masterKeyManager.getState()).toBe('locked');
+	});
+});
+
+describe('login flow on an enrolled, unlocked server', () => {
+	let app: Hono<Env>;
+	let db: PGlite;
+	let mnemonic: string;
+	let masterKeyManager: MasterKeyManager;
+
+	beforeAll(async () => {
+		const ctx = await createTestApp();
+		app = ctx.app;
+		db = ctx.db;
+		mnemonic = ctx.mnemonic;
+		masterKeyManager = ctx.masterKeyManager;
+	});
+
+	afterAll(async () => {
+		await safeClose(db);
+	});
+
+	it('rejects malformed verify payloads with 400', async () => {
+		for (const body of [
+			{},
+			{ challenge_id: '', signature: 'ab'.repeat(64) },
+			{ challenge_id: 'x', signature: 'not-hex' },
+			{ challenge_id: 'x', signature: 'ab'.repeat(64), unlock_key: 'bad' },
+		]) {
+			const res = await postJson(app, '/api/auth/verify', body);
+			expect(res.status).toBe(400);
+			expect(await errorCode(res)).toBe('INVALID_REQUEST');
+		}
+	});
+
+	it('rejects non-JSON bodies with 400', async () => {
+		const res = await app.request('/api/auth/verify', {
+			method: 'POST',
+			headers: JSON_HEADERS,
+			body: 'not json',
+		});
+		expect(res.status).toBe(400);
+	});
+
+	it('rejects setup once enrolled', async () => {
+		const keys = deriveAuthKeyPair(mnemonic);
+		const unlockKey = deriveUnlockKey(mnemonic);
+		const res = await postJson(app, '/api/auth/setup', {
+			public_key: keys.publicKeyHex,
+			unlock_key: unlockKey,
+			signature: signAuthMessage(keys.privateKey, buildSetupMessage(keys.publicKeyHex, unlockKey)),
+		});
+		expect(res.status).toBe(409);
+		expect(await errorCode(res)).toBe('ALREADY_SET');
+	});
+
+	it('logs in via challenge + signature, twice, as the same user', async () => {
+		const res1 = await loginViaAuthApi(app, mnemonic);
+		expect(res1.status).toBe(200);
+		const token1 = (await res1.json()).data.token;
+
+		const res2 = await loginViaAuthApi(app, mnemonic);
+		expect(res2.status).toBe(200);
+		const token2 = (await res2.json()).data.token;
+
+		const auth1 = await verifyToken(token1, db, masterKeyManager);
+		const auth2 = await verifyToken(token2, db, masterKeyManager);
+		expect(auth1?.type).toBe('admin');
+		expect(auth2?.type).toBe('admin');
+		if (auth1?.type === 'admin' && auth2?.type === 'admin') {
+			expect(auth1.userId).toBe(auth2.userId);
+		}
+	});
+
+	it('the token grants access to protected endpoints', async () => {
+		const res = await loginViaAuthApi(app, mnemonic);
+		const { token } = (await res.json()).data;
+		const teamsRes = await app.request('/api/teams', { headers: authHeader(token) });
 		expect(teamsRes.status).toBe(200);
+	});
+
+	it('rejects a replayed challenge', async () => {
+		const keys = deriveAuthKeyPair(mnemonic);
+		const { challenge_id, nonce } = await getChallenge(app);
+		const body = {
+			challenge_id,
+			signature: signAuthMessage(keys.privateKey, buildLoginMessage(nonce)),
+		};
+		expect((await postJson(app, '/api/auth/verify', body)).status).toBe(200);
+
+		const replay = await postJson(app, '/api/auth/verify', body);
+		expect(replay.status).toBe(401);
+		expect(await errorCode(replay)).toBe('INVALID_CHALLENGE');
+	});
+
+	it('rejects an unknown challenge id', async () => {
+		const res = await postJson(app, '/api/auth/verify', {
+			challenge_id: '00000000-0000-4000-8000-000000000000',
+			signature: 'ab'.repeat(64),
+		});
+		expect(res.status).toBe(401);
+		expect(await errorCode(res)).toBe('INVALID_CHALLENGE');
+	});
+
+	it("rejects a signature over a different challenge's nonce, and burns the challenge", async () => {
+		const keys = deriveAuthKeyPair(mnemonic);
+		const a = await getChallenge(app);
+		const b = await getChallenge(app);
+
+		const res = await postJson(app, '/api/auth/verify', {
+			challenge_id: b.challenge_id,
+			signature: signAuthMessage(keys.privateKey, buildLoginMessage(a.nonce)),
+		});
+		expect(res.status).toBe(401);
+		expect(await errorCode(res)).toBe('INVALID_SIGNATURE');
+
+		// The failed attempt consumed challenge B — a correct signature now fails.
+		const retry = await postJson(app, '/api/auth/verify', {
+			challenge_id: b.challenge_id,
+			signature: signAuthMessage(keys.privateKey, buildLoginMessage(b.nonce)),
+		});
+		expect(retry.status).toBe(401);
+		expect(await errorCode(retry)).toBe('INVALID_CHALLENGE');
+	});
+
+	it('rejects a signature from the wrong keypair', async () => {
+		const wrongKeys = deriveAuthKeyPair(generateMnemonic());
+		const { challenge_id, nonce } = await getChallenge(app);
+		const res = await postJson(app, '/api/auth/verify', {
+			challenge_id,
+			signature: signAuthMessage(wrongKeys.privateKey, buildLoginMessage(nonce)),
+		});
+		expect(res.status).toBe(401);
+		expect(await errorCode(res)).toBe('INVALID_SIGNATURE');
+	});
+
+	it('accepts the unlock flow while already unlocked (stale-locked client)', async () => {
+		const res = await loginViaAuthApi(app, mnemonic, { includeUnlockKey: true });
+		expect(res.status).toBe(200);
+		expect((await res.json()).data.token).toBeTypeOf('string');
 	});
 });

--- a/packages/server/test/cli.test.ts
+++ b/packages/server/test/cli.test.ts
@@ -1,7 +1,12 @@
 import { homedir } from 'node:os';
 import { resolve } from 'node:path';
+import { deriveAuthKeyPair, deriveUnlockKey } from '@hezo/shared';
 import { describe, expect, it } from 'vitest';
 import { parseConfig } from '../src/cli';
+
+// Canonical BIP39 vector — parseMasterKey only accepts a valid mnemonic.
+const PHRASE =
+	'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
 
 // Helper to build argv with the standard bun/node + script prefix
 const argv = (...flags: string[]) => ['bun', 'src/index.ts', ...flags];
@@ -49,9 +54,23 @@ describe('parseConfig', () => {
 		expect(config.dataDir).toBe(resolve(homedir(), 'custom'));
 	});
 
-	it('parses --master-key', () => {
-		const config = parseConfig(argv('--master-key', 'mykey'), EMPTY_ENV);
-		expect(config.masterKey).toBe('mykey');
+	it('derives unlock key + auth public key from a --master-key phrase', () => {
+		const config = parseConfig(argv('--master-key', PHRASE), EMPTY_ENV);
+		expect(config.masterKey).toEqual({
+			unlockKeyHex: deriveUnlockKey(PHRASE),
+			publicKeyHex: deriveAuthKeyPair(PHRASE).publicKeyHex,
+		});
+	});
+
+	it('rejects a --master-key that is not a valid mnemonic', () => {
+		expect(() => parseConfig(argv('--master-key', 'not-a-phrase'), EMPTY_ENV)).toThrow(
+			'Invalid master key',
+		);
+		// A raw derived hex key is no longer accepted either — it could never
+		// enroll the auth public key.
+		expect(() => parseConfig(argv('--master-key', 'ab'.repeat(32)), EMPTY_ENV)).toThrow(
+			'Invalid master key',
+		);
 	});
 
 	it('parses --reset', () => {
@@ -86,7 +105,7 @@ describe('parseConfig', () => {
 				'--data-dir',
 				'/tmp/hezo',
 				'--master-key',
-				'secret',
+				PHRASE,
 				'--reset',
 				'--open',
 			),
@@ -94,7 +113,7 @@ describe('parseConfig', () => {
 		);
 		expect(config.port).toBe(9000);
 		expect(config.dataDir).toBe('/tmp/hezo');
-		expect(config.masterKey).toBe('secret');
+		expect(config.masterKey?.unlockKeyHex).toBe(deriveUnlockKey(PHRASE));
 		expect(config.reset).toBe(true);
 		expect(config.open).toBe(true);
 	});

--- a/packages/server/test/helpers/app.ts
+++ b/packages/server/test/helpers/app.ts
@@ -2,13 +2,24 @@ import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { PGlite } from '@electric-sql/pglite';
-import { AgentAdminStatus, CAPTAIN_AGENT_SLUG } from '@hezo/shared';
+import {
+	AgentAdminStatus,
+	buildLoginMessage,
+	buildUnlockMessage,
+	CAPTAIN_AGENT_SLUG,
+	deriveAuthKeyPair,
+	deriveUnlockKey,
+	generateMnemonic,
+	signAuthMessage,
+} from '@hezo/shared';
+import type { Hono } from 'hono';
 import { encrypt } from '../../src/crypto/encryption';
-import { generateMasterKey, MasterKeyManager } from '../../src/crypto/master-key';
+import { MasterKeyManager } from '../../src/crypto/master-key';
 import { loadAgentRoles } from '../../src/db/agent-roles';
 import { seedBuiltins } from '../../src/db/seed';
 import { DomainEventBus } from '../../src/events/bus';
 import { toSlug, uniqueSlug } from '../../src/lib/slug';
+import type { Env } from '../../src/lib/types';
 import { signAdminJwt, signAgentJwt } from '../../src/middleware/auth';
 import { resolveProjectTaskPrefix } from '../../src/routes/projects';
 import { ContainerLogStreamer } from '../../src/services/container-logs';
@@ -62,8 +73,10 @@ export { encrypt };
 export async function createTestApp(opts: { webUrl?: string } = {}) {
 	const db = await createTestDbWithMigrations();
 	const masterKeyManager = new MasterKeyManager();
-	const masterKeyHex = generateMasterKey();
-	await masterKeyManager.initialize(db, masterKeyHex);
+	const mnemonic = generateMnemonic();
+	const unlockKeyHex = deriveUnlockKey(mnemonic);
+	const authKeys = deriveAuthKeyPair(mnemonic);
+	await masterKeyManager.initialize(db, unlockKeyHex, authKeys.publicKeyHex);
 	const roleDocs = await loadAgentRoles();
 	await seedBuiltins(db, roleDocs);
 	const dataDir = mkdtempSync(join(tmpdir(), 'hezo-test-'));
@@ -117,7 +130,96 @@ export async function createTestApp(opts: { webUrl?: string } = {}) {
 		containerLogStreamer,
 	});
 
-	return { app, db, token, masterKeyHex, masterKeyManager, dataDir };
+	return { app, db, token, mnemonic, unlockKeyHex, authKeys, masterKeyManager, dataDir };
+}
+
+/**
+ * A test app whose master key was never set (state 'unset'): no canary, no
+ * enrolled public key, no superuser, no token. Mirrors a fresh production
+ * boot, which also seeds the default team before any key exists. For suites
+ * exercising /api/auth/setup.
+ */
+export async function createUnsetTestApp() {
+	const db = await createTestDbWithMigrations();
+	const masterKeyManager = new MasterKeyManager();
+	await masterKeyManager.initialize(db);
+	const roleDocs = await loadAgentRoles();
+	await seedBuiltins(db, roleDocs);
+	const dataDir = mkdtempSync(join(tmpdir(), 'hezo-test-'));
+	const docker = createStubDocker();
+	const wsManager = new WebSocketManager();
+	const logs = new LogStreamBroker();
+	logs.setWsManager(wsManager);
+	const containerLogStreamer = new ContainerLogStreamer();
+	const events = new DomainEventBus();
+	const app = buildApp(
+		db,
+		masterKeyManager,
+		{ dataDir, webUrl: '' },
+		docker,
+		wsManager,
+		undefined,
+		logs,
+		null,
+		null,
+		containerLogStreamer,
+		events,
+	);
+	await seedDefaultTeam({
+		db,
+		docker,
+		dataDir,
+		wsManager,
+		masterKeyManager,
+		logs,
+		containerLogStreamer,
+	});
+	return { app, db, masterKeyManager, dataDir };
+}
+
+/**
+ * Drives the full challenge-response login over the app's HTTP surface and
+ * returns the /api/auth/verify response. `includeUnlockKey` mirrors the
+ * locked-server flow (signature covers nonce + unlock key). Extra `headers`
+ * land on the verify request — the one that captures the instance base URL.
+ */
+export async function loginViaAuthApi(
+	app: Hono<Env>,
+	mnemonic: string,
+	opts: { headers?: Record<string, string>; includeUnlockKey?: boolean } = {},
+): Promise<Response> {
+	const headers = { 'Content-Type': 'application/json', ...(opts.headers ?? {}) };
+	const challengeRes = await app.request('/api/auth/challenge', { method: 'POST', headers });
+	if (challengeRes.status !== 200) return challengeRes;
+	const challenge = (await challengeRes.json()) as {
+		data: { challenge_id: string; nonce: string };
+	};
+	const { challenge_id, nonce } = challenge.data;
+	const keys = deriveAuthKeyPair(mnemonic);
+	const body: Record<string, string> = { challenge_id };
+	if (opts.includeUnlockKey) {
+		const unlockKeyHex = deriveUnlockKey(mnemonic);
+		body.unlock_key = unlockKeyHex;
+		body.signature = signAuthMessage(keys.privateKey, buildUnlockMessage(nonce, unlockKeyHex));
+	} else {
+		body.signature = signAuthMessage(keys.privateKey, buildLoginMessage(nonce));
+	}
+	return app.request('/api/auth/verify', {
+		method: 'POST',
+		headers,
+		body: JSON.stringify(body),
+	});
+}
+
+/**
+ * Simulates a server restart over the same database: a fresh manager holds no
+ * key material, so the canary leaves it 'locked' until an unlock-flow login.
+ */
+export async function restartTestApp(db: PGlite, dataDir: string) {
+	const masterKeyManager = new MasterKeyManager();
+	await masterKeyManager.initialize(db);
+	const app = buildApp(db, masterKeyManager, { dataDir, webUrl: '' }, createStubDocker());
+	return { app, masterKeyManager };
 }
 
 export function authHeader(token: string) {

--- a/packages/server/test/helpers/context.ts
+++ b/packages/server/test/helpers/context.ts
@@ -14,13 +14,15 @@ export interface ServerTestContext {
 	baseUrl: string;
 	port: number;
 	token: string;
-	masterKeyHex: string;
+	mnemonic: string;
+	unlockKeyHex: string;
 	masterKeyManager: MasterKeyManager;
 	dataDir: string;
 }
 
 export async function createTestContext(): Promise<ServerTestContext> {
-	const { app, db, token, masterKeyHex, masterKeyManager, dataDir } = await createTestApp();
+	const { app, db, token, mnemonic, unlockKeyHex, masterKeyManager, dataDir } =
+		await createTestApp();
 
 	const server = createServer(async (req, res) => {
 		const url = `http://localhost${req.url}`;
@@ -51,7 +53,18 @@ export async function createTestContext(): Promise<ServerTestContext> {
 	const port = typeof addr === 'object' && addr ? addr.port : 0;
 	const baseUrl = `http://localhost:${port}`;
 
-	return { db, app, server, baseUrl, port, token, masterKeyHex, masterKeyManager, dataDir };
+	return {
+		db,
+		app,
+		server,
+		baseUrl,
+		port,
+		token,
+		mnemonic,
+		unlockKeyHex,
+		masterKeyManager,
+		dataDir,
+	};
 }
 
 export async function destroyTestContext(ctx: ServerTestContext): Promise<void> {

--- a/packages/server/test/instance-settings.test.ts
+++ b/packages/server/test/instance-settings.test.ts
@@ -5,20 +5,20 @@ import { getSystemMeta, INSTANCE_BASE_URL_KEY } from '../src/lib/system-meta';
 import type { Env } from '../src/lib/types';
 import { signAdminJwt } from '../src/middleware/auth';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp } from './helpers/app';
+import { authHeader, createTestApp, loginViaAuthApi } from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
 let token: string;
 let nonSuperuserToken: string;
-let masterKeyHex: string;
+let mnemonic: string;
 
 beforeAll(async () => {
 	const ctx = await createTestApp();
 	app = ctx.app;
 	db = ctx.db;
 	token = ctx.token;
-	masterKeyHex = ctx.masterKeyHex;
+	mnemonic = ctx.mnemonic;
 
 	const nonAdmin = await db.query<{ id: string }>(
 		"INSERT INTO users (display_name, is_superuser) VALUES ('Regular Admin', false) RETURNING id",
@@ -31,11 +31,9 @@ afterAll(async () => {
 });
 
 function unlock(headers: Record<string, string> = {}) {
-	return app.request('/api/auth/token', {
-		method: 'POST',
-		headers: { 'Content-Type': 'application/json', ...headers },
-		body: JSON.stringify({ master_key: masterKeyHex }),
-	});
+	// Base-URL capture fires from the /api/auth/verify request that completes
+	// the challenge dance, so the headers land there.
+	return loginViaAuthApi(app, mnemonic, { headers });
 }
 
 function patchBaseUrl(value: unknown, authToken = token) {

--- a/packages/server/test/master-key.test.ts
+++ b/packages/server/test/master-key.test.ts
@@ -1,6 +1,6 @@
 import { PGlite } from '@electric-sql/pglite';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { decrypt, deriveKey, encrypt, generateMasterKey } from '../src/crypto/encryption';
+import { decrypt, deriveKey, encrypt, generateUnlockKey } from '../src/crypto/encryption';
 import { MasterKeyManager } from '../src/crypto/master-key';
 
 describe('encryption', () => {
@@ -18,8 +18,8 @@ describe('encryption', () => {
 		expect(() => decrypt(encrypted, key2)).toThrow();
 	});
 
-	it('generates a 64-char hex master key', () => {
-		const key = generateMasterKey();
+	it('generates a 64-char hex unlock key', () => {
+		const key = generateUnlockKey();
 		expect(key).toMatch(/^[0-9a-f]{64}$/);
 	});
 
@@ -55,14 +55,14 @@ describe('MasterKeyManager', () => {
 
 	it("returns 'unlocked' on first run with key provided", async () => {
 		const mgr = new MasterKeyManager();
-		const key = generateMasterKey();
+		const key = generateUnlockKey();
 		const state = await mgr.initialize(db, key);
 		expect(state).toBe('unlocked');
 		expect(mgr.getKey()).not.toBeNull();
 	});
 
 	it("returns 'unlocked' on subsequent run with correct key", async () => {
-		const key = generateMasterKey();
+		const key = generateUnlockKey();
 		const mgr1 = new MasterKeyManager();
 		await mgr1.initialize(db, key);
 
@@ -72,8 +72,8 @@ describe('MasterKeyManager', () => {
 	});
 
 	it("returns 'locked' on subsequent run with wrong key", async () => {
-		const correctKey = generateMasterKey();
-		const wrongKey = generateMasterKey();
+		const correctKey = generateUnlockKey();
+		const wrongKey = generateUnlockKey();
 		const mgr1 = new MasterKeyManager();
 		await mgr1.initialize(db, correctKey);
 
@@ -84,7 +84,7 @@ describe('MasterKeyManager', () => {
 	});
 
 	it("returns 'locked' on subsequent run with no key", async () => {
-		const key = generateMasterKey();
+		const key = generateUnlockKey();
 		const mgr1 = new MasterKeyManager();
 		await mgr1.initialize(db, key);
 
@@ -94,7 +94,7 @@ describe('MasterKeyManager', () => {
 	});
 
 	it("unlocks from 'locked' with correct key", async () => {
-		const key = generateMasterKey();
+		const key = generateUnlockKey();
 		const mgr1 = new MasterKeyManager();
 		await mgr1.initialize(db, key);
 
@@ -109,36 +109,82 @@ describe('MasterKeyManager', () => {
 	});
 
 	it("stays 'locked' when unlocking with wrong key", async () => {
-		const key = generateMasterKey();
+		const key = generateUnlockKey();
 		const mgr1 = new MasterKeyManager();
 		await mgr1.initialize(db, key);
 
 		const mgr2 = new MasterKeyManager();
 		await mgr2.initialize(db);
 
-		const result = await mgr2.unlock(db, generateMasterKey());
+		const result = await mgr2.unlock(db, generateUnlockKey());
 		expect(result).toBe(false);
 		expect(mgr2.getState()).toBe('locked');
 	});
 
-	it("unlocks from 'unset' by storing canary", async () => {
+	it("refuses unlock() from 'unset' — enrollment is explicit via setup()", async () => {
 		const mgr = new MasterKeyManager();
 		await mgr.initialize(db);
 		expect(mgr.getState()).toBe('unset');
 
-		const key = generateMasterKey();
-		const result = await mgr.unlock(db, key);
+		const result = await mgr.unlock(db, generateUnlockKey());
+		expect(result).toBe(false);
+		expect(mgr.getState()).toBe('unset');
+	});
+
+	it("setup() from 'unset' stores public key + canary atomically and unlocks", async () => {
+		const mgr = new MasterKeyManager();
+		await mgr.initialize(db);
+		const key = generateUnlockKey();
+		const publicKey = 'ab'.repeat(32);
+
+		const result = await mgr.setup(db, key, publicKey);
 		expect(result).toBe(true);
 		expect(mgr.getState()).toBe('unlocked');
+		expect(await mgr.getAuthPublicKeyHex(db)).toBe(publicKey);
 
-		// Verify canary was stored by initializing a new manager
+		// A fresh manager unlocks against the stored canary and reads the key.
 		const mgr2 = new MasterKeyManager();
-		const state = await mgr2.initialize(db, key);
+		expect(await mgr2.initialize(db, key)).toBe('unlocked');
+		expect(await mgr2.getAuthPublicKeyHex(db)).toBe(publicKey);
+	});
+
+	it('setup() refuses to run twice', async () => {
+		const mgr = new MasterKeyManager();
+		await mgr.initialize(db);
+		const key = generateUnlockKey();
+		expect(await mgr.setup(db, key, 'ab'.repeat(32))).toBe(true);
+		expect(await mgr.setup(db, generateUnlockKey(), 'cd'.repeat(32))).toBe(false);
+		expect(await mgr.getAuthPublicKeyHex(db)).toBe('ab'.repeat(32));
+	});
+
+	it('initialize() with both params enrolls a fresh database (CLI/env boot)', async () => {
+		const mgr = new MasterKeyManager();
+		const key = generateUnlockKey();
+		const state = await mgr.initialize(db, key, 'ab'.repeat(32));
 		expect(state).toBe('unlocked');
+		expect(await mgr.getAuthPublicKeyHex(db)).toBe('ab'.repeat(32));
+	});
+
+	it('initialize() backfills a missing public key on an already-enrolled database', async () => {
+		const key = generateUnlockKey();
+		const mgr1 = new MasterKeyManager();
+		// Canary without a public key (the bare test-helper path).
+		await mgr1.initialize(db, key);
+
+		const mgr2 = new MasterKeyManager();
+		await mgr2.initialize(db, key, 'ef'.repeat(32));
+		expect(mgr2.getState()).toBe('unlocked');
+		expect(await mgr2.getAuthPublicKeyHex(db)).toBe('ef'.repeat(32));
+	});
+
+	it('getAuthPublicKeyHex returns null when nothing is enrolled', async () => {
+		const mgr = new MasterKeyManager();
+		await mgr.initialize(db);
+		expect(await mgr.getAuthPublicKeyHex(db)).toBeNull();
 	});
 
 	it('fires onUnlock callback when transitioning to unlocked', async () => {
-		const key = generateMasterKey();
+		const key = generateUnlockKey();
 		const mgr = new MasterKeyManager();
 		await mgr.initialize(db);
 		expect(mgr.getState()).toBe('unset');
@@ -146,7 +192,7 @@ describe('MasterKeyManager', () => {
 		let callCount = 0;
 		mgr.onUnlock(() => callCount++);
 
-		await mgr.unlock(db, key);
+		await mgr.setup(db, key, 'ab'.repeat(32));
 		expect(callCount).toBe(1);
 
 		// Subsequent unlock with same key should NOT fire again
@@ -155,7 +201,7 @@ describe('MasterKeyManager', () => {
 	});
 
 	it('fires onUnlock immediately if already unlocked when registered', async () => {
-		const key = generateMasterKey();
+		const key = generateUnlockKey();
 		const mgr = new MasterKeyManager();
 		await mgr.initialize(db, key);
 		expect(mgr.getState()).toBe('unlocked');
@@ -168,7 +214,7 @@ describe('MasterKeyManager', () => {
 	});
 
 	it('fires onUnlock callback on initialize with key', async () => {
-		const key = generateMasterKey();
+		const key = generateUnlockKey();
 		const mgr = new MasterKeyManager();
 
 		let callCount = 0;

--- a/packages/server/test/mnemonic.test.ts
+++ b/packages/server/test/mnemonic.test.ts
@@ -1,17 +1,10 @@
-import {
-	generateMnemonic,
-	mnemonicToMasterKey,
-	normalizeMnemonic,
-	validateMnemonic,
-} from '@hezo/shared';
+import { generateMnemonic, normalizeMnemonic, validateMnemonic } from '@hezo/shared';
 import { describe, expect, it } from 'vitest';
 
-// Canonical BIP39 test vector (the all-"abandon" phrase). Its seed is the
-// well-known 5eb00bbd... value; the first 32 bytes pin our derivation so a
-// library/algorithm change is caught.
+// Canonical BIP39 test vector (the all-"abandon" phrase). The derived-key
+// pins for this vector live in auth-crypto.test.ts.
 const VECTOR =
 	'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
-const VECTOR_HEX = '5eb00bbddcf069084889a8ab9155568165f5c453ccb85e70811aaed6f6da5fc1';
 
 describe('mnemonic', () => {
 	it('generates a valid 12-word phrase', () => {
@@ -24,23 +17,11 @@ describe('mnemonic', () => {
 		expect(generateMnemonic()).not.toBe(generateMnemonic());
 	});
 
-	it('derives the pinned hex for the canonical vector', () => {
-		expect(validateMnemonic(VECTOR)).toBe(true);
-		const hex = mnemonicToMasterKey(VECTOR);
-		expect(hex).toBe(VECTOR_HEX);
-		expect(hex).toMatch(/^[0-9a-f]{64}$/);
-	});
-
-	it('is deterministic', () => {
-		expect(mnemonicToMasterKey(VECTOR)).toBe(mnemonicToMasterKey(VECTOR));
-	});
-
-	it('normalizes whitespace, newlines and case before deriving', () => {
+	it('normalizes whitespace, newlines and case', () => {
 		const messy = `  ABANDON   abandon\tabandon abandon abandon abandon
 			abandon abandon abandon abandon abandon ABOUT  `;
 		expect(normalizeMnemonic(messy)).toBe(VECTOR);
 		expect(validateMnemonic(messy)).toBe(true);
-		expect(mnemonicToMasterKey(messy)).toBe(VECTOR_HEX);
 	});
 
 	it('rejects invalid phrases without throwing', () => {

--- a/packages/server/test/preview.test.ts
+++ b/packages/server/test/preview.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import type { PGlite } from '@electric-sql/pglite';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { generateMasterKey, MasterKeyManager } from '../src/crypto/master-key';
+import { generateUnlockKey, MasterKeyManager } from '../src/crypto/master-key';
 import { loadAgentRoles } from '../src/db/agent-roles';
 import { seedBuiltins } from '../src/db/seed';
 import type { Env } from '../src/lib/types';
@@ -27,7 +27,7 @@ beforeAll(async () => {
 
 	db = await createTestDbWithMigrations();
 	const masterKeyManager = new MasterKeyManager();
-	const masterKeyHex = generateMasterKey();
+	const masterKeyHex = generateUnlockKey();
 	await masterKeyManager.initialize(db, masterKeyHex);
 	await seedBuiltins(db, await loadAgentRoles());
 	app = buildApp(db, masterKeyManager, { dataDir, webUrl: '' }, createStubDocker());

--- a/packages/server/test/project-docs.test.ts
+++ b/packages/server/test/project-docs.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import type { PGlite } from '@electric-sql/pglite';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { generateMasterKey, MasterKeyManager } from '../src/crypto/master-key';
+import { generateUnlockKey, MasterKeyManager } from '../src/crypto/master-key';
 import { loadAgentRoles } from '../src/db/agent-roles';
 import { seedBuiltins } from '../src/db/seed';
 import type { Env } from '../src/lib/types';
@@ -27,7 +27,7 @@ beforeAll(async () => {
 
 	db = await createTestDbWithMigrations();
 	const masterKeyManager = new MasterKeyManager();
-	const masterKeyHex = generateMasterKey();
+	const masterKeyHex = generateUnlockKey();
 	await masterKeyManager.initialize(db, masterKeyHex);
 	await seedBuiltins(db, await loadAgentRoles());
 	app = buildApp(db, masterKeyManager, { dataDir: tempDataDir, webUrl: '' }, createStubDocker());

--- a/packages/server/test/skills.test.ts
+++ b/packages/server/test/skills.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import type { PGlite } from '@electric-sql/pglite';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
-import { generateMasterKey, MasterKeyManager } from '../src/crypto/master-key';
+import { generateUnlockKey, MasterKeyManager } from '../src/crypto/master-key';
 import { loadAgentRoles } from '../src/db/agent-roles';
 import { seedBuiltins } from '../src/db/seed';
 import type { Env } from '../src/lib/types';
@@ -32,7 +32,7 @@ beforeAll(async () => {
 
 	db = await createTestDbWithMigrations();
 	const masterKeyManager = new MasterKeyManager();
-	await masterKeyManager.initialize(db, generateMasterKey());
+	await masterKeyManager.initialize(db, generateUnlockKey());
 	await seedBuiltins(db, await loadAgentRoles());
 	app = buildApp(db, masterKeyManager, { dataDir: tempDataDir, webUrl: '' }, createStubDocker());
 	const userResult = await db.query<{ id: string }>(

--- a/packages/server/test/ssh-keys.test.ts
+++ b/packages/server/test/ssh-keys.test.ts
@@ -1,6 +1,6 @@
 import type { PGlite } from '@electric-sql/pglite';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { generateMasterKey, MasterKeyManager } from '../src/crypto/master-key';
+import { generateUnlockKey, MasterKeyManager } from '../src/crypto/master-key';
 import { loadAgentRoles } from '../src/db/agent-roles';
 import { seedBuiltins } from '../src/db/seed';
 import { generateTeamSSHKey, getTeamSSHKey } from '../src/services/ssh-keys';
@@ -13,7 +13,7 @@ let teamId: string;
 beforeAll(async () => {
 	db = await createTestDbWithMigrations();
 	masterKeyManager = new MasterKeyManager();
-	await masterKeyManager.initialize(db, generateMasterKey());
+	await masterKeyManager.initialize(db, generateUnlockKey());
 	await seedBuiltins(db, await loadAgentRoles());
 
 	// Create a team

--- a/packages/server/test/state.test.ts
+++ b/packages/server/test/state.test.ts
@@ -1,6 +1,6 @@
 import { generateKeyPairSync } from 'node:crypto';
 import { describe, expect, it } from 'vitest';
-import { generateMasterKey, MasterKeyManager } from '../src/crypto/master-key';
+import { generateUnlockKey, MasterKeyManager } from '../src/crypto/master-key';
 import { signOAuthState, verifyConnectState, verifyOAuthState } from '../src/crypto/state';
 import { createTestDbWithMigrations } from './helpers/db';
 
@@ -73,7 +73,7 @@ describe('signOAuthState + verifyOAuthState', () => {
 	it('roundtrips team_id', async () => {
 		const db = await createTestDbWithMigrations();
 		const mkm = new MasterKeyManager();
-		await mkm.initialize(db, generateMasterKey());
+		await mkm.initialize(db, generateUnlockKey());
 
 		const signed = await signOAuthState({ team_id: 'abc-123' }, mkm);
 		const result = await verifyOAuthState(signed, mkm);
@@ -84,7 +84,7 @@ describe('signOAuthState + verifyOAuthState', () => {
 	it('returns null for tampered state', async () => {
 		const db = await createTestDbWithMigrations();
 		const mkm = new MasterKeyManager();
-		await mkm.initialize(db, generateMasterKey());
+		await mkm.initialize(db, generateUnlockKey());
 
 		const signed = await signOAuthState({ team_id: 'abc-123' }, mkm);
 		const tampered = `${signed.slice(0, -4)}xxxx`;
@@ -96,11 +96,11 @@ describe('signOAuthState + verifyOAuthState', () => {
 	it('returns null with different master key', async () => {
 		const db1 = await createTestDbWithMigrations();
 		const mkm1 = new MasterKeyManager();
-		await mkm1.initialize(db1, generateMasterKey());
+		await mkm1.initialize(db1, generateUnlockKey());
 
 		const db2 = await createTestDbWithMigrations();
 		const mkm2 = new MasterKeyManager();
-		await mkm2.initialize(db2, generateMasterKey());
+		await mkm2.initialize(db2, generateUnlockKey());
 
 		const signed = await signOAuthState({ team_id: 'abc' }, mkm1);
 		const result = await verifyOAuthState(signed, mkm2);
@@ -113,7 +113,7 @@ describe('signOAuthState + verifyOAuthState', () => {
 	it('returns null for no dot separator', async () => {
 		const db = await createTestDbWithMigrations();
 		const mkm = new MasterKeyManager();
-		await mkm.initialize(db, generateMasterKey());
+		await mkm.initialize(db, generateUnlockKey());
 
 		const result = await verifyOAuthState('nodot', mkm);
 		expect(result).toBeNull();
@@ -123,7 +123,7 @@ describe('signOAuthState + verifyOAuthState', () => {
 	it('roundtrips a payload that includes an task_id alongside team_id', async () => {
 		const db = await createTestDbWithMigrations();
 		const mkm = new MasterKeyManager();
-		await mkm.initialize(db, generateMasterKey());
+		await mkm.initialize(db, generateUnlockKey());
 
 		const signed = await signOAuthState({ team_id: 'co-1', task_id: 'iss-9' }, mkm);
 		const result = await verifyOAuthState(signed, mkm);

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -14,7 +14,6 @@ import { DEFAULT_PORT, AgentRuntime, type HezoConfig } from "@hezo/shared";
 
 ### Types
 
-- `HezoConfig` — server configuration (port, dataDir, masterKey, etc.)
 - `ConnectConfig` — OAuth gateway configuration
 - `MasterKeyState` — `"unset" | "locked" | "unlocked"`
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -11,6 +11,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
+		"@noble/curves": "^1.9.1",
 		"@noble/hashes": "^1.8.0",
 		"@scure/bip39": "^1.6.0"
 	},

--- a/packages/shared/src/crypto/auth.ts
+++ b/packages/shared/src/crypto/auth.ts
@@ -1,0 +1,75 @@
+import { ed25519 } from '@noble/curves/ed25519';
+import { hkdf } from '@noble/hashes/hkdf';
+import { sha256 } from '@noble/hashes/sha2';
+import { bytesToHex, hexToBytes, utf8ToBytes } from '@noble/hashes/utils';
+import { mnemonicToSeedSync } from '@scure/bip39';
+import { normalizeMnemonic } from './mnemonic.js';
+
+const HKDF_INFO = utf8ToBytes('hezo');
+const UNLOCK_KEY_SALT = utf8ToBytes('hezo-unlock-key-v1');
+const AUTH_KEY_SALT = utf8ToBytes('hezo-auth-key-v1');
+
+export interface AuthKeyPair {
+	/** 32-byte Ed25519 public key, lowercase hex (64 chars). Safe to share. */
+	publicKeyHex: string;
+	/** 32-byte Ed25519 private seed. Never serialized, never transmitted. */
+	privateKey: Uint8Array;
+}
+
+/**
+ * Deterministic words -> 32-byte unlock key, lowercase hex (64 chars). The only
+ * key material the server ever receives: it feeds the server's canary /
+ * encryption / JWT derivations and transits solely at setup and at
+ * unlock-after-restart, inside an Ed25519-signed payload. Salt-separated from
+ * the auth keypair so neither derived key reveals the other. Identical output
+ * in the browser (esbuild) and Node/Bun (pure JS, no node:crypto).
+ */
+export function deriveUnlockKey(phrase: string): string {
+	const seed = mnemonicToSeedSync(normalizeMnemonic(phrase)); // 64 bytes
+	return bytesToHex(hkdf(sha256, seed, UNLOCK_KEY_SALT, HKDF_INFO, 32));
+}
+
+/**
+ * Deterministic words -> Ed25519 keypair for challenge-response auth. The
+ * private seed never leaves the client; the public key is enrolled on the
+ * server at setup and verifies login/unlock signatures thereafter.
+ */
+export function deriveAuthKeyPair(phrase: string): AuthKeyPair {
+	const seed = mnemonicToSeedSync(normalizeMnemonic(phrase));
+	const privateKey = hkdf(sha256, seed, AUTH_KEY_SALT, HKDF_INFO, 32);
+	return { publicKeyHex: bytesToHex(ed25519.getPublicKey(privateKey)), privateKey };
+}
+
+/** Ed25519 signature over the UTF-8 message, lowercase hex (128 chars). */
+export function signAuthMessage(privateKey: Uint8Array, message: string): string {
+	return bytesToHex(ed25519.sign(utf8ToBytes(message), privateKey));
+}
+
+/** Verify an Ed25519 signature. Never throws — malformed input returns false. */
+export function verifyAuthSignature(
+	publicKeyHex: string,
+	message: string,
+	signatureHex: string,
+): boolean {
+	try {
+		return ed25519.verify(hexToBytes(signatureHex), utf8ToBytes(message), hexToBytes(publicKeyHex));
+	} catch {
+		return false;
+	}
+}
+
+// Canonical signed payloads. Versioned domain tags + fixed-length hex fields
+// (colon-delimited) keep a signature from one flow from being replayed in
+// another.
+
+export function buildSetupMessage(publicKeyHex: string, unlockKeyHex: string): string {
+	return `hezo-auth-v1:setup:${publicKeyHex}:${unlockKeyHex}`;
+}
+
+export function buildLoginMessage(nonceHex: string): string {
+	return `hezo-auth-v1:login:${nonceHex}`;
+}
+
+export function buildUnlockMessage(nonceHex: string, unlockKeyHex: string): string {
+	return `hezo-auth-v1:unlock:${nonceHex}:${unlockKeyHex}`;
+}

--- a/packages/shared/src/crypto/mnemonic.ts
+++ b/packages/shared/src/crypto/mnemonic.ts
@@ -1,9 +1,4 @@
-import { bytesToHex } from '@noble/hashes/utils';
-import {
-	mnemonicToSeedSync,
-	generateMnemonic as scureGenerate,
-	validateMnemonic as scureValidate,
-} from '@scure/bip39';
+import { generateMnemonic as scureGenerate, validateMnemonic as scureValidate } from '@scure/bip39';
 import { wordlist } from '@scure/bip39/wordlists/english';
 
 /** 12-word BIP39 phrase (128-bit entropy). The user-facing master key. */
@@ -19,15 +14,4 @@ export function normalizeMnemonic(phrase: string): string {
 /** True iff `phrase` (after normalization) is a valid BIP39 phrase. Never throws. */
 export function validateMnemonic(phrase: string): boolean {
 	return scureValidate(normalizeMnemonic(phrase), wordlist);
-}
-
-/**
- * Deterministic words -> 64-hex-char internal master key. Takes the first 32
- * bytes of the BIP39 seed so the string handed to the server keeps the
- * historical [0-9a-f]{64} shape. Identical output in the browser (esbuild) and
- * Node/Bun (pure JS, no node:crypto).
- */
-export function mnemonicToMasterKey(phrase: string): string {
-	const seed = mnemonicToSeedSync(normalizeMnemonic(phrase)); // 64 bytes
-	return bytesToHex(seed.slice(0, 32)); // 32 bytes -> 64 hex chars
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,5 @@
 export * from './constants.js';
+export * from './crypto/auth.js';
 export * from './crypto/mnemonic.js';
 export * from './mentions/index.js';
 export * from './types/index.js';

--- a/packages/shared/src/types/config.ts
+++ b/packages/shared/src/types/config.ts
@@ -1,12 +1,3 @@
-export interface HezoConfig {
-	port: number;
-	dataDir: string;
-	masterKey?: string;
-	connectUrl: string;
-	connectApiKey?: string;
-	reset: boolean;
-}
-
 export interface ConnectConfig {
 	port: number;
 	mode: 'self_hosted' | 'centrally_hosted';

--- a/packages/web/src/components/master-key-gate.tsx
+++ b/packages/web/src/components/master-key-gate.tsx
@@ -1,14 +1,13 @@
 import {
 	generateMnemonic,
 	type MasterKeyState,
-	mnemonicToMasterKey,
 	normalizeMnemonic,
 	validateMnemonic,
 } from '@hezo/shared';
 import * as Dialog from '@radix-ui/react-dialog';
 import { KeyRound, Loader2, ShieldCheck } from 'lucide-react';
 import { useState } from 'react';
-import { authenticate } from '../lib/auth';
+import { authenticateWithMnemonic } from '../lib/auth';
 import { queryClient } from '../lib/query-client';
 import { queryKeys } from '../lib/query-keys';
 import { Button } from './ui/button';
@@ -44,7 +43,7 @@ export function MasterKeyForm({ state, embedded }: MasterKeyFormProps) {
 		}
 		setLoading(true);
 		try {
-			await authenticate(mnemonicToMasterKey(phrase));
+			await authenticateWithMnemonic(phrase, state);
 			queryClient.invalidateQueries({ queryKey: queryKeys.status() });
 		} catch (err: unknown) {
 			const apiErr = err as { message?: string };

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -1,5 +1,14 @@
-import type { MasterKeyState } from '@hezo/shared';
-import { api } from './api';
+import {
+	type AuthKeyPair,
+	buildLoginMessage,
+	buildSetupMessage,
+	buildUnlockMessage,
+	deriveAuthKeyPair,
+	deriveUnlockKey,
+	type MasterKeyState,
+	signAuthMessage,
+} from '@hezo/shared';
+import { type ApiError, api } from './api';
 
 interface StatusResponse {
 	masterKeyState: MasterKeyState;
@@ -21,8 +30,55 @@ export async function checkStatus(): Promise<StatusResponse> {
 	return body;
 }
 
-export async function authenticate(masterKey: string): Promise<string> {
-	const data = await api.post<{ token: string }>('/api/auth/token', { master_key: masterKey });
+/**
+ * Authenticate with the 12-word master key phrase. The phrase never leaves
+ * the browser: it derives an Ed25519 keypair (whose signature over a server
+ * challenge is the login credential) and an unlock key (transmitted only at
+ * setup and unlock-after-restart, inside the signed payload, to root the
+ * server's at-rest encryption).
+ */
+export async function authenticateWithMnemonic(
+	phrase: string,
+	state: MasterKeyState,
+): Promise<string> {
+	const keys = deriveAuthKeyPair(phrase);
+	const unlockKey = deriveUnlockKey(phrase);
+
+	if (state === 'unset') {
+		const data = await api.post<{ token: string }>('/api/auth/setup', {
+			public_key: keys.publicKeyHex,
+			unlock_key: unlockKey,
+			signature: signAuthMessage(keys.privateKey, buildSetupMessage(keys.publicKeyHex, unlockKey)),
+		});
+		api.setToken(data.token);
+		return data.token;
+	}
+
+	try {
+		return await challengeLogin(keys, state === 'locked' ? unlockKey : null);
+	} catch (err) {
+		// The server restarted (and locked) between the status fetch and this
+		// attempt — retry once with the unlock key included.
+		if ((err as ApiError).code === 'UNLOCK_KEY_REQUIRED') {
+			return await challengeLogin(keys, unlockKey);
+		}
+		throw err;
+	}
+}
+
+async function challengeLogin(keys: AuthKeyPair, unlockKey: string | null): Promise<string> {
+	const challenge = await api.post<{ challenge_id: string; nonce: string }>('/api/auth/challenge');
+	const body: Record<string, string> = { challenge_id: challenge.challenge_id };
+	if (unlockKey !== null) {
+		body.unlock_key = unlockKey;
+		body.signature = signAuthMessage(
+			keys.privateKey,
+			buildUnlockMessage(challenge.nonce, unlockKey),
+		);
+	} else {
+		body.signature = signAuthMessage(keys.privateKey, buildLoginMessage(challenge.nonce));
+	}
+	const data = await api.post<{ token: string }>('/api/auth/verify', body);
 	api.setToken(data.token);
 	return data.token;
 }

--- a/packages/web/test/helpers/render.tsx
+++ b/packages/web/test/helpers/render.tsx
@@ -37,6 +37,8 @@ interface RenderOptions {
 interface TestAppContext {
 	app: Hono;
 	token: string;
+	/** The 12-word master key phrase the test app was enrolled with. */
+	mnemonic: string;
 	apiBase: (path: string, init?: RequestInit) => Promise<Response>;
 	// Source the PGlite type from the server helper so it stays in lockstep with
 	// the version server-side seeders (createTestProject) expect — the web tree
@@ -67,6 +69,7 @@ beforeEach(async () => {
 	activeContext = {
 		app: test.app,
 		token: test.token,
+		mnemonic: test.mnemonic,
 		apiBase,
 		db: test.db,
 		masterKeyManager: test.masterKeyManager,

--- a/packages/web/test/master-key-unlock.test.tsx
+++ b/packages/web/test/master-key-unlock.test.tsx
@@ -1,0 +1,40 @@
+import { generateMnemonic } from '@hezo/shared';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, expect, test } from 'vitest';
+import { MasterKeyForm } from '../src/components/master-key-gate';
+import { api } from '../src/lib/api';
+// Importing the harness registers its beforeEach: an in-process Hono + PGlite
+// backend (enrolled and unlocked) with fetch rerouted to it. The form is
+// rendered with state="locked", so the client runs the unlock flow — derive
+// keys in the browser, sign the challenge, send the unlock key — which the
+// server accepts even while already unlocked (stale-locked-client tolerance).
+import { getTestContext } from './helpers/render';
+
+afterEach(cleanup);
+
+test('unlock derives keys client-side and completes the challenge dance', async () => {
+	const ctx = getTestContext();
+	api.clearToken();
+
+	render(<MasterKeyForm state="locked" embedded />);
+	fireEvent.change(screen.getByLabelText(/master key/i), {
+		target: { value: ctx.mnemonic },
+	});
+	fireEvent.click(screen.getByRole('button', { name: /unlock/i }));
+
+	await waitFor(() => {
+		expect(api.getToken()).toBeTruthy();
+	});
+	expect(screen.queryByText(/failed|invalid/i)).toBeNull();
+});
+
+test('a wrong-but-valid phrase shows the server rejection inline', async () => {
+	render(<MasterKeyForm state="locked" embedded />);
+	fireEvent.change(screen.getByLabelText(/master key/i), {
+		target: { value: generateMnemonic() },
+	});
+	fireEvent.click(screen.getByRole('button', { name: /unlock/i }));
+
+	// The signature comes from the wrong keypair, so the server rejects it.
+	await screen.findByText(/signature verification failed/i);
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,10 +1,17 @@
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { defineConfig } from '@playwright/test';
+import { TEST_MNEMONIC } from './test/browser/constants';
 
 const SERVER_PORT = 3101;
 const WEB_PORT = 5174;
 const TEST_DATA_DIR = join(tmpdir(), 'hezo-e2e-test');
+
+// The master-key-gate spec owns its own backend lifecycle (boot, kill,
+// restart on :3102), so it gets a dedicated vite instance proxying there —
+// the shared server on :3101 must stay up for every other project.
+const GATE_SERVER_PORT = 3102;
+const GATE_WEB_PORT = 5175;
 
 export default defineConfig({
 	tsconfig: './tsconfig.json',
@@ -44,7 +51,8 @@ export default defineConfig({
 		},
 		{
 			name: 'parallel',
-			testIgnore: /(?:ai-providers|\.mobile|agent-run-logs|run-trigger-reason)\.spec\.ts$/,
+			testIgnore:
+				/(?:ai-providers|\.mobile|agent-run-logs|run-trigger-reason|master-key-gate)\.spec\.ts$/,
 			// Run after agent-runs-serial so the shared e2e job queue is not flooded first.
 			dependencies: ['ai-provider-serial', 'agent-runs-serial'],
 		},
@@ -54,21 +62,36 @@ export default defineConfig({
 			use: { viewport: { width: 390, height: 844 } },
 			dependencies: ['ai-provider-serial'],
 		},
+		{
+			// Self-contained: drives the pre-token setup wizard + locked gate
+			// against its own server on :3102 (spawned by the spec itself).
+			name: 'auth-gate',
+			testMatch: /master-key-gate\.spec\.ts$/,
+			fullyParallel: false,
+			workers: 1,
+			use: {
+				baseURL: `http://localhost:${GATE_WEB_PORT}`,
+				viewport: { width: 390, height: 844 },
+			},
+		},
 	],
 	webServer: [
 		{
-			command: `bun run src/index.ts -- --port ${SERVER_PORT} --data-dir ${TEST_DATA_DIR} --master-key e2e-test-master-key-0123456789abcdef0123456789abcdef --reset`,
+			command: `bun run src/index.ts -- --port ${SERVER_PORT} --data-dir ${TEST_DATA_DIR} --reset`,
 			cwd: './packages/server',
 			// `Bun.serve` opens the port before `startup()` finishes registering
 			// routes, so a port-only check races against route mounting and the
-			// first /api/auth/token call sees Hono's default "404 Not Found".
-			// /api/status is only mounted inside startup, so polling it waits
-			// for full readiness.
+			// first auth call sees Hono's default "404 Not Found". /api/status is
+			// only mounted inside startup, so polling it waits for full readiness.
 			url: `http://localhost:${SERVER_PORT}/api/status`,
 			reuseExistingServer: false,
 			env: {
 				SKIP_AI_KEY_VALIDATION: '1',
 				HEZO_SKIP_DOCKER: '1',
+				// Boot-enrolls the master key (canary + auth public key) so tests
+				// log in via the challenge dance instead of running setup. Env var
+				// rather than a flag: a 12-word phrase is hostile to shell quoting.
+				HEZO_MASTER_KEY: TEST_MNEMONIC,
 				HEZO_WAKEUP_COALESCING_MS: '100',
 				HEZO_WAKEUP_CRON: '* * * * * *',
 				HEZO_HEARTBEAT_CRON: '* * * * * *',
@@ -87,6 +110,16 @@ export default defineConfig({
 			env: {
 				HEZO_WEB_PORT: String(WEB_PORT),
 				HEZO_SERVER_PORT: String(SERVER_PORT),
+			},
+		},
+		{
+			command: 'bun run dev',
+			cwd: './packages/web',
+			port: GATE_WEB_PORT,
+			reuseExistingServer: false,
+			env: {
+				HEZO_WEB_PORT: String(GATE_WEB_PORT),
+				HEZO_SERVER_PORT: String(GATE_SERVER_PORT),
 			},
 		},
 	],

--- a/test/browser/constants.ts
+++ b/test/browser/constants.ts
@@ -1,0 +1,8 @@
+/**
+ * The e2e master key phrase (the canonical all-"abandon" BIP39 vector).
+ * Shared by playwright.config.ts (boot-enrolls the shared server via
+ * HEZO_MASTER_KEY) and helpers.ts (derives the keypair + unlock key for the
+ * challenge-response login dance).
+ */
+export const TEST_MNEMONIC =
+	'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';

--- a/test/browser/helpers.ts
+++ b/test/browser/helpers.ts
@@ -1,6 +1,18 @@
+import {
+	buildLoginMessage,
+	buildSetupMessage,
+	buildUnlockMessage,
+	deriveAuthKeyPair,
+	deriveUnlockKey,
+	signAuthMessage,
+} from '@hezo/shared';
 import { expect, type Locator, type Page, type Response } from '@playwright/test';
+import { TEST_MNEMONIC } from './constants';
 
-const TEST_MASTER_KEY = 'e2e-test-master-key-0123456789abcdef0123456789abcdef';
+// The phrase never goes over the wire: the Node test process derives the same
+// keys the browser would and runs the challenge-response dance over HTTP.
+const TEST_AUTH_KEYS = deriveAuthKeyPair(TEST_MNEMONIC);
+const TEST_UNLOCK_KEY = deriveUnlockKey(TEST_MNEMONIC);
 
 // Bun's webserver starts listening before Hono routes are mounted, so the very
 // first request during cold start can hit the default 404 ("404 Not Found"
@@ -10,21 +22,65 @@ async function requestToken(page: Page): Promise<string> {
 	let lastError: unknown = null;
 	while (Date.now() < deadline) {
 		try {
-			const res = await page.request.post('/api/auth/token', {
-				data: { master_key: TEST_MASTER_KEY },
-			});
-			if (res.ok()) {
-				const json = (await res.json()) as { data?: { token: string }; token?: string };
-				const token = json.data?.token ?? json.token;
+			const statusRes = await page.request.get('/api/status');
+			if (statusRes.ok()) {
+				const { masterKeyState } = (await statusRes.json()) as { masterKeyState: string };
+				// The shared e2e server boots enrolled via HEZO_MASTER_KEY, so the
+				// setup branch only fires against a fresh/unset server (and a 409
+				// race between workers just loops into the login branch).
+				const token =
+					masterKeyState === 'unset'
+						? await setupViaApi(page)
+						: await loginViaApi(page, masterKeyState === 'locked');
 				if (token) return token;
 			}
-			lastError = new Error(`Unexpected ${res.status()} from /api/auth/token`);
+			lastError = new Error(`Unexpected ${statusRes.status()} from /api/status`);
 		} catch (err) {
 			lastError = err;
 		}
 		await new Promise((resolve) => setTimeout(resolve, 250));
 	}
-	throw lastError ?? new Error('Timed out waiting for /api/auth/token');
+	throw lastError ?? new Error('Timed out authenticating via /api/auth');
+}
+
+async function setupViaApi(page: Page): Promise<string | null> {
+	const res = await page.request.post('/api/auth/setup', {
+		data: {
+			public_key: TEST_AUTH_KEYS.publicKeyHex,
+			unlock_key: TEST_UNLOCK_KEY,
+			signature: signAuthMessage(
+				TEST_AUTH_KEYS.privateKey,
+				buildSetupMessage(TEST_AUTH_KEYS.publicKeyHex, TEST_UNLOCK_KEY),
+			),
+		},
+	});
+	if (!res.ok()) throw new Error(`Unexpected ${res.status()} from /api/auth/setup`);
+	const json = (await res.json()) as { data?: { token: string } };
+	return json.data?.token ?? null;
+}
+
+async function loginViaApi(page: Page, includeUnlockKey: boolean): Promise<string | null> {
+	const challengeRes = await page.request.post('/api/auth/challenge');
+	if (!challengeRes.ok()) {
+		throw new Error(`Unexpected ${challengeRes.status()} from /api/auth/challenge`);
+	}
+	const challenge = (
+		(await challengeRes.json()) as { data: { challenge_id: string; nonce: string } }
+	).data;
+	const body: Record<string, string> = { challenge_id: challenge.challenge_id };
+	if (includeUnlockKey) {
+		body.unlock_key = TEST_UNLOCK_KEY;
+		body.signature = signAuthMessage(
+			TEST_AUTH_KEYS.privateKey,
+			buildUnlockMessage(challenge.nonce, TEST_UNLOCK_KEY),
+		);
+	} else {
+		body.signature = signAuthMessage(TEST_AUTH_KEYS.privateKey, buildLoginMessage(challenge.nonce));
+	}
+	const res = await page.request.post('/api/auth/verify', { data: body });
+	if (!res.ok()) throw new Error(`Unexpected ${res.status()} from /api/auth/verify`);
+	const json = (await res.json()) as { data?: { token: string } };
+	return json.data?.token ?? null;
 }
 
 export async function authenticate(page: Page) {
@@ -540,5 +596,3 @@ export async function clickAndWaitForResponse(
 	]);
 	return response;
 }
-
-export { TEST_MASTER_KEY };

--- a/test/browser/master-key-gate.spec.ts
+++ b/test/browser/master-key-gate.spec.ts
@@ -1,0 +1,120 @@
+// Playwright-tier per AGENTS.md decision-tree item 6: this drives the
+// master-key gate / instance setup flow before any token exists — the
+// component harness always seeds an enrolled, unlocked server, so the unset
+// wizard and the locked modal can only be exercised here. Runs in the
+// dedicated `auth-gate` project against its own backend on :3102 (vite :5175).
+import { type ChildProcess, spawn } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { expect, test } from '@playwright/test';
+
+const GATE_SERVER_PORT = 3102;
+
+test.describe.configure({ mode: 'serial' });
+
+let server: ChildProcess | null = null;
+let dataDir: string;
+
+async function startGateServer(opts: { reset: boolean }): Promise<void> {
+	const args = [
+		'run',
+		'src/index.ts',
+		'--',
+		'--port',
+		String(GATE_SERVER_PORT),
+		'--data-dir',
+		dataDir,
+	];
+	if (opts.reset) args.push('--reset');
+	server = spawn('bun', args, {
+		// Playwright is invoked from the repo root (AGENTS.md).
+		cwd: resolve(process.cwd(), 'packages/server'),
+		env: {
+			...process.env,
+			HEZO_SKIP_DOCKER: '1',
+			SKIP_AI_KEY_VALIDATION: '1',
+			// No boot key — the whole point is exercising the in-browser setup.
+			// (Empty string reads as unset in the CLI's env resolution.)
+			HEZO_MASTER_KEY: '',
+		},
+		stdio: 'ignore',
+	});
+	const deadline = Date.now() + 60_000;
+	while (Date.now() < deadline) {
+		try {
+			const res = await fetch(`http://localhost:${GATE_SERVER_PORT}/api/status`);
+			if (res.ok) return;
+		} catch {
+			// Not listening yet.
+		}
+		await new Promise((r) => setTimeout(r, 250));
+	}
+	throw new Error('master-key-gate server did not become ready on :3102');
+}
+
+async function stopGateServer(): Promise<void> {
+	const proc = server;
+	server = null;
+	if (!proc || proc.exitCode !== null) return;
+	await new Promise<void>((done) => {
+		const killTimer = setTimeout(() => proc.kill('SIGKILL'), 5_000);
+		proc.once('exit', () => {
+			clearTimeout(killTimer);
+			done();
+		});
+		proc.kill('SIGTERM');
+	});
+}
+
+test.beforeAll(() => {
+	dataDir = mkdtempSync(join(tmpdir(), 'hezo-gate-e2e-'));
+});
+
+test.afterAll(async () => {
+	await stopGateServer();
+	rmSync(dataDir, { recursive: true, force: true });
+});
+
+test('first-boot setup wizard, then the locked gate after a restart', async ({ page }) => {
+	await startGateServer({ reset: true });
+	await page.goto('/');
+
+	// Phase A — unset: the setup wizard's master-key step at mobile viewport.
+	await expect(page.getByTestId('setup-step-master-key')).toBeVisible();
+	await page.getByRole('button', { name: /generate key/i }).click();
+	const words = page.getByTestId('mnemonic-word');
+	await expect(words).toHaveCount(12);
+	// Each item renders "<n> <word>" — strip the leading position number.
+	const phrase = (await words.allTextContents())
+		.map((t) => t.replace(/^\s*\d+\s*/, '').trim())
+		.join(' ');
+	await page.getByRole('button', { name: /set key & continue/i }).click();
+
+	// Setup enrolled + unlocked the server; the wizard advances to the
+	// AI-provider step (none configured on this fresh instance).
+	await expect(page.getByTestId('setup-step-ai-provider')).toBeVisible();
+	const status = await page.request.get(`http://localhost:${GATE_SERVER_PORT}/api/status`);
+	expect(((await status.json()) as { masterKeyState: string }).masterKeyState).toBe('unlocked');
+
+	// Phase B — restart on the same data dir without a boot key: locked gate.
+	await stopGateServer();
+	await startGateServer({ reset: false });
+	await page.reload();
+
+	const entry = page.getByLabel(/master key/i);
+	await expect(entry).toBeVisible();
+
+	// A valid-but-wrong phrase signs with the wrong keypair — server rejects.
+	await entry.fill('legal winner thank year wave sausage worth useful legal winner thank yellow');
+	await page.getByRole('button', { name: /unlock/i }).click();
+	await expect(page.getByText(/signature verification failed/i)).toBeVisible();
+
+	// The phrase captured during setup unlocks; with no AI provider configured
+	// the wizard resumes at the provider step — the post-gate surface.
+	await entry.fill(phrase);
+	await page.getByRole('button', { name: /unlock/i }).click();
+	await expect(page.getByTestId('setup-step-ai-provider')).toBeVisible();
+	const after = await page.request.get(`http://localhost:${GATE_SERVER_PORT}/api/status`);
+	expect(((await after.json()) as { masterKeyState: string }).masterKeyState).toBe('unlocked');
+});


### PR DESCRIPTION
## What

The 12-word master key phrase no longer transits to the server — previously the derived 64-hex master key was POSTed to `/api/auth/token` on **every** login, where it doubled as both the auth credential and the at-rest encryption root.

The client now derives two independent keys from the BIP39 seed (HKDF-SHA256, distinct salts, `@noble/curves` + `@noble/hashes` — pure JS, identical in browser/Node/Bun):

- **Ed25519 auth keypair** — the private key never leaves the browser (re-derived from the typed phrase at each login, never persisted). The public key is enrolled at setup in `system_meta.auth_public_key`. Login = sign a single-use server nonce: `POST /auth/challenge` → `POST /auth/verify`. **Routine logins transmit zero key material.**
- **Unlock key** (32 bytes) — feeds the server's existing canary / secrets-encryption / JWT derivations unchanged. It transits only at setup and at unlock-after-restart, always inside an Ed25519-signed payload. (The server must hold symmetric key material at runtime: egress credential substitution, ssh-agent signing, AI provider keys all decrypt with no client in the loop, so a fully key-blind server isn't possible.)

## Endpoints

`POST /auth/token` is replaced by:

| Endpoint | Purpose |
|---|---|
| `POST /auth/setup` | First-boot enrollment (state `unset` only): public key + unlock key + self-certifying signature, persisted in one transaction |
| `POST /auth/challenge` | Issues a single-use nonce (in-memory, 2 min TTL, capped store) |
| `POST /auth/verify` | Verifies the signature over the stored nonce (never echoed back), unlocks when `unlock_key` is included, returns the JWT |

Protocol hardening: challenges are consumed **before** signature verification (a failed attempt burns the nonce); signed messages carry versioned domain-separation tags (`hezo-auth-v1:setup|login|unlock:`) so a signature from one flow can't be replayed in another; `UNLOCK_KEY_REQUIRED` is a distinct error code so a client with a stale status can retry the dance with the key included, and supplying the key while already unlocked succeeds (stale-locked tolerance in the other direction).

## Behavior changes

- `MasterKeyManager.unlock()` loses its implicit trust-on-first-use branch — enrollment is explicit via `setup()`.
- `--master-key` / `HEZO_MASTER_KEY` now requires the 12-word phrase (a raw derived key could never enroll the public key, leaving an unlocked server nobody can log into). An invalid value fails boot loudly. A CLI/env boot on a fresh database performs full enrollment, equivalent to web setup.
- All previously issued JWTs become invalid (the signing-key input changed) — acceptable pre-v1; the UI recovers via the existing 401 → status → gate path.
- No DB schema change: the public key is one new `system_meta` row.
- No UI changes: the wizard/gate DOM is untouched; only the wiring beneath the submit handler changed.

## Tests

- **`auth-crypto.test.ts`** — pinned derivation vectors for the canonical all-abandon phrase (catches HKDF-salt/library drift), salt separation, sign/verify roundtrip + tamper + malformed-never-throws, message-format pins, cross-flow signature rejection.
- **`auth-challenges.test.ts`** — nonce uniqueness, single-use, TTL expiry, oldest-first eviction cap.
- **`auth-routes.test.ts`** (rewritten) — full matrix: setup happy path / replay / bad-signature-persists-nothing / malformed shapes; login twice as the same user; replayed + unknown + burned challenges; wrong keypair; signature over the wrong challenge's nonce; locked-restart flows (`UNLOCK_KEY_REQUIRED`, wrong unlock key with a valid signature, unlock success); verify-with-key-while-unlocked.
- **`master-key.test.ts`** — explicit-enrollment semantics, CLI-boot enrollment, public-key backfill.
- **Web component** — new `master-key-unlock.test.tsx` drives real client-side HKDF + Ed25519 signing in happy-dom against the in-process backend; existing setup specs pass unchanged.
- **Playwright** — new `auth-gate` project (`master-key-gate.spec.ts`, mobile viewport) owns its own server on :3102: first-boot wizard → generate phrase → setup → kill + restart → locked gate → wrong-phrase rejection → unlock with the captured phrase. The shared e2e server boot-enrolls via `HEZO_MASTER_KEY` and every existing spec logs in through the challenge dance in `helpers.ts`.

## Verification

- `bun run typecheck` ✅ · `bun run check` ✅
- Server suite: all auth/crypto/cli/middleware/instance-settings tests green; full run has 10 pre-existing failures (`git.test.ts` ×9, `ssh-agent-server.test.ts` ×1) that reproduce identically on the base commit in this sandbox (host git/ssh-keygen environment, unrelated to this change).
- Web component suite: 81 files / 305 tests ✅
- Playwright: new gate spec ✅, shared-server login dance smoke ✅ (full-suite confirmation run in flight)

https://claude.ai/code/session_01WrhomZGGr72T6SFYPT5dGT

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrhomZGGr72T6SFYPT5dGT)_