### PR TITLE
refactor(projects): drop team name/slug from the roster agents echo

### DIFF
--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -1188,7 +1188,7 @@ export function registerTools(
 	tool(
 		server,
 		'list_projects',
-		'List projects. With CEO cross-team access (or as superuser) returns every project across the instance, each row carrying team_name/team_slug; a board user gets the projects on teams they belong to; an agent run gets its own project. Pass excerpt_chars (e.g. 300) to truncate description; omit for full content.',
+		'List projects. With CEO cross-team access (or as superuser) returns every project across the instance; a board user gets the projects on teams they belong to; an agent run gets its own project. Pass excerpt_chars (e.g. 300) to truncate description; omit for full content.',
 		{
 			excerpt_chars: z
 				.number()
@@ -1207,26 +1207,25 @@ export function registerTools(
 				(auth.type === AuthType.Admin && auth.isSuperuser);
 			if (instanceWide) {
 				const r = await db.query<Record<string, unknown>>(
-					`SELECT p.id, p.team_id, t.name AS team_name, t.slug AS team_slug,
+					`SELECT p.id, p.team_id,
 					        p.name, p.slug, p.task_prefix, p.description, p.is_internal,
 					        p.created_at, p.updated_at
-					 FROM projects p JOIN teams t ON t.id = p.team_id
-					 ORDER BY t.name, p.name`,
+					 FROM projects p
+					 ORDER BY p.name`,
 				);
 				return withExcerpt(r.rows);
 			}
 
 			if (auth.type === AuthType.Admin) {
 				const r = await db.query<Record<string, unknown>>(
-					`SELECT DISTINCT p.id, p.team_id, t.name AS team_name, t.slug AS team_slug,
+					`SELECT DISTINCT p.id, p.team_id,
 					        p.name, p.slug, p.task_prefix, p.description, p.is_internal,
 					        p.created_at, p.updated_at
 					 FROM projects p
-					 JOIN teams t ON t.id = p.team_id
 					 JOIN members m ON m.team_id = p.team_id
 					 JOIN member_users mu ON mu.id = m.id
 					 WHERE mu.user_id = $1
-					 ORDER BY t.name, p.name`,
+					 ORDER BY p.name`,
 					[auth.userId],
 				);
 				return withExcerpt(r.rows);

--- a/packages/server/src/services/template-resolver.ts
+++ b/packages/server/src/services/template-resolver.ts
@@ -404,34 +404,31 @@ async function buildProjectsContext(db: PGlite): Promise<string> {
 		name: string;
 		slug: string;
 		task_prefix: string;
-		team_name: string;
-		team_slug: string;
 		open_task_count: number;
 		created_at: string;
 	}>(
-		`SELECT p.name, p.slug, p.task_prefix, t.name AS team_name, t.slug AS team_slug,
+		`SELECT p.name, p.slug, p.task_prefix,
 		        (SELECT count(*) FROM tasks i
 		         WHERE i.project_id = p.id AND i.status NOT IN (${terminal.placeholders}))::int AS open_task_count,
 		        p.created_at
 		 FROM projects p
-		 JOIN teams t ON t.id = p.team_id
 		 WHERE p.is_internal = false
 		 ORDER BY p.created_at DESC`,
 		terminal.values,
 	);
 
 	const intro =
-		'Hezo is project-centric: one organisation containing many projects, each backed by its own dedicated team and Captain. As the instance CEO you have automatic cross-team reach over every one of them. The roster of project-teams below (HQ, your home, excluded) is regenerated every turn from the live database — trust it over memory, and never tell the operator a project does not exist without checking here first. When you name a project, ticket, or team in the chat box, use its slug, identifier, or name (e.g. the project `todo6`, ticket `TO-1`) — never a raw UUID. To read or act inside a project, pass its slug (shown on its line below) as the `project` argument to tools like `list_tasks` / `list_agents`; or call `list_projects` for this same live list.';
+		'Hezo is project-centric: one organisation containing many projects, each with its own Captain and roster of agents. As the instance CEO you have automatic cross-project reach over every one of them. The roster of projects below (HQ, your home, excluded) is regenerated every turn from the live database — trust it over memory, and never tell the operator a project does not exist without checking here first. When you name a project or ticket in the chat box, use its slug, identifier, or name (e.g. the project `todo6`, ticket `TO-1`) — never a raw UUID. To read or act inside a project, pass its slug (shown on its line below) as the `project` argument to tools like `list_tasks` / `list_agents`; or call `list_projects` for this same live list.';
 
 	if (projects.rows.length === 0) {
-		return `${intro}\n\n_No project-teams exist yet beyond HQ. When the operator wants to start one, take it through project intake._`;
+		return `${intro}\n\n_No projects exist yet beyond HQ. When the operator wants to start one, take it through project intake._`;
 	}
 
 	const lines = projects.rows
 		.map((p) => {
 			const date = new Date(p.created_at).toISOString().slice(0, 10);
 			const open = `${p.open_task_count} open ticket${p.open_task_count === 1 ? '' : 's'}`;
-			return `- ${p.name} (slug: ${p.slug}, prefix: ${p.task_prefix}) — team ${p.team_name} (slug: ${p.team_slug}), ${open}, created ${date}`;
+			return `- ${p.name} (slug: ${p.slug}, prefix: ${p.task_prefix}) — ${open}, created ${date}`;
 		})
 		.join('\n');
 

--- a/packages/server/test/mcp-project-scope.test.ts
+++ b/packages/server/test/mcp-project-scope.test.ts
@@ -229,11 +229,10 @@ describe('MCP cross-team CEO — instance-wide discovery', () => {
 		expect(ids).toContain(teamBId);
 	});
 
-	it('list_projects returns every project across all teams, tagged with its team', async () => {
+	it('list_projects returns every project across all teams, with team_id but no team name or slug', async () => {
 		const rows = (await callMcp(ceoToken, 'list_projects', {})) as Array<{
 			id: string;
 			team_id: string;
-			team_slug: string;
 			is_internal: boolean;
 		}>;
 		const ids = rows.map((r) => r.id);
@@ -241,10 +240,14 @@ describe('MCP cross-team CEO — instance-wide discovery', () => {
 		expect(ids).toContain(projectBId);
 		// HQ (the one internal project) is included so the CEO sees the whole picture.
 		expect(rows.some((r) => r.is_internal)).toBe(true);
-		// Every row carries its owning team so the CEO can drill in by project.
+		// Every row still carries its owning team_id so the CEO can drill in by
+		// project, but the human-readable team name/slug never leaks into output —
+		// projects are the unit the CEO names; teams are just a part of them.
 		const a = rows.find((r) => r.id === projectAId);
 		expect(a?.team_id).toBe(teamAId);
-		expect(a?.team_slug).toBeTruthy();
+		const aRecord = a as unknown as Record<string, unknown>;
+		expect(aRecord.team_name).toBeUndefined();
+		expect(aRecord.team_slug).toBeUndefined();
 	});
 
 	it('can list tasks in any project without being scoped to it', async () => {

--- a/packages/server/test/template-resolver.test.ts
+++ b/packages/server/test/template-resolver.test.ts
@@ -943,16 +943,23 @@ describe('project state block', () => {
 });
 
 describe('projects context block ({{projects_context}})', () => {
-	it('lists every non-internal project across teams by slug, never by UUID', async () => {
+	it('lists every non-internal project by name and slug, with no team in the line', async () => {
 		const result = await resolveSystemPrompt(db, 'Roster:\n{{projects_context}}', { teamId });
 		expect(result).toContain('Hezo is project-centric');
 
-		const proj = await db.query<{ slug: string }>('SELECT slug FROM projects WHERE id = $1', [
-			projectId,
-		]);
-		// The beforeAll project surfaces by slug, tagged with its owning team…
-		expect(result).toContain(`slug: ${proj.rows[0].slug}`);
-		expect(result).toContain('team Template Co');
+		const proj = await db.query<{ name: string; slug: string }>(
+			'SELECT name, slug FROM projects WHERE id = $1',
+			[projectId],
+		);
+		// The beforeAll project surfaces on its own roster line by name and slug…
+		const rosterLine = result
+			.split('\n')
+			.find((line) => line.includes(`slug: ${proj.rows[0].slug}`));
+		expect(rosterLine).toBeDefined();
+		expect(rosterLine).toContain(proj.rows[0].name);
+		// …with no team name or slug — projects are the unit; teams are just a part of them.
+		expect(rosterLine).not.toContain('team');
+		expect(rosterLine).not.toContain('Template Co');
 		// …and never by raw UUID, since this text is echoed to the human operator.
 		expect(result).not.toContain(projectId);
 
@@ -963,14 +970,14 @@ describe('projects context block ({{projects_context}})', () => {
 		expect(result).not.toContain(`slug: ${hq.rows[0].slug}`);
 	});
 
-	it('shows an empty-state line when no project-teams exist beyond HQ', async () => {
+	it('shows an empty-state line when no projects exist beyond HQ', async () => {
 		// A fresh instance has only HQ (internal), so the roster is empty.
 		const fresh = await createTestApp();
 		try {
 			const result = await resolveSystemPrompt(fresh.db, '{{projects_context}}', {
 				teamId: DEFAULT_TEAM_ID,
 			});
-			expect(result).toContain('No project-teams exist yet beyond HQ');
+			expect(result).toContain('No projects exist yet beyond HQ');
 		} finally {
 			await safeClose(fresh.db);
 		}


### PR DESCRIPTION
## What

When the CEO listed projects to the operator, it rendered a redundant **Team** column (e.g. project `HQ` → team `default`, project `todo9` → team `todo9`). Since a project owns exactly one team (1:1), the team name just duplicates the project. This makes the project roster project-centric — teams are treated as a part of a project, not a separately-named entity in chat output.

## Changes

Two agent-facing surfaces fed that roster, both updated to keep the machine `team_id` but drop the human-readable `team_name`/`team_slug`:

- **`buildProjectsContext` (`{{projects_context}}`)** — the CEO-only instance roster regenerated every turn and echoed to the operator. Each line dropped its `— team <name> (slug: <slug>)` segment, and the intro no longer tells the CEO to "name a project, ticket, or team" (now just projects and tickets) and is reworded to project-centric framing (`cross-project reach`, `roster of projects`).
- **`list_projects` MCP tool** — the instance-wide and admin queries no longer select `team_name`/`team_slug` (and drop the now-unused `teams` join); the single-project branch was already team-name-free. Tool description updated.

## Out of scope (deliberate)

- `list_teams` MCP tool — explicitly a team tool the CEO uses for team IDs; the roster intro now steers naming toward projects/tickets.
- `{{team_name}}` substitution in agent self-identity prompts ("You are the Captain of …") — that's the agent's own identity, and `team.name` ≠ `project.name` in general, so it's a larger semantic change beyond this directive.
- REST `/api/projects` and the admin audit-log/credentials views — board/admin UI surfaces, not agent chat output.

## Tests

Updated `template-resolver.test.ts` (roster line asserts project name/slug present, team name/slug absent; empty-state string) and `mcp-project-scope.test.ts` (`list_projects` row carries `team_id` but `team_name`/`team_slug` are `undefined`). `bun run typecheck`, lint, and the affected vitest files (148 tests) all pass.

https://claude.ai/code/session_01NXhWGb7AupRes1WD3FAdDN

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXhWGb7AupRes1WD3FAdDN)_