### PR TITLE
feat(tasks): show run-state dot in Blocked By and sub-task lists

### DIFF
--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -806,10 +806,35 @@ tasksRoutes.get('/projects/:projectId/tasks/:taskId/dependencies', async (c) => 
 	const result = await db.query(
 		`SELECT d.id, d.task_id, d.blocked_by_task_id, d.created_at,
             i.identifier AS blocked_by_identifier, i.title AS blocked_by_title, i.status AS blocked_by_status,
-            p.slug AS blocked_by_project_slug
+            p.slug AS blocked_by_project_slug,
+            EXISTS (
+              SELECT 1 FROM heartbeat_runs hr
+              WHERE hr.task_id = i.id AND hr.status IN ('running', 'queued')
+            ) AS blocked_by_has_active_run,
+            CASE WHEN qw.last_skipped_reason IS NOT NULL THEN json_build_object(
+              'reason', qw.last_skipped_reason,
+              'since', qw.last_skipped_at,
+              'blocker_task_id', qw.last_skipped_blocker_task_id,
+              'blocker_identifier', qw.blocker_identifier,
+              'blocker_project_slug', qw.blocker_project_slug
+            ) ELSE NULL END AS blocked_by_queued_wakeup
      FROM task_dependencies d
      JOIN tasks i ON i.id = d.blocked_by_task_id
      JOIN projects p ON p.id = i.project_id
+     LEFT JOIN LATERAL (
+       SELECT w.last_skipped_reason, w.last_skipped_at, w.last_skipped_blocker_task_id,
+              b.identifier AS blocker_identifier,
+              bp.slug AS blocker_project_slug
+       FROM agent_wakeup_requests w
+       LEFT JOIN tasks b ON b.id = w.last_skipped_blocker_task_id
+       LEFT JOIN projects bp ON bp.id = b.project_id
+       WHERE w.member_id = i.assignee_id
+         AND w.payload->>'task_id' = i.id::text
+         AND w.status = 'queued'
+         AND w.last_skipped_at IS NOT NULL
+       ORDER BY w.last_skipped_at DESC
+       LIMIT 1
+     ) qw ON true
      WHERE d.task_id = $1`,
 		[taskId],
 	);

--- a/packages/server/test/tasks.test.ts
+++ b/packages/server/test/tasks.test.ts
@@ -307,6 +307,47 @@ describe('tasks CRUD', () => {
 		expect(removeRes.status).toBe(200);
 	});
 
+	it('reports the blocker run state in the dependencies list', async () => {
+		const blocker = await insertTaskDirect(agentId, 'Upstream blocker');
+		const blocked = await insertTaskDirect(agentId, 'Downstream blocked');
+
+		const addRes = await app.request(
+			`/api/projects/${projectSlug}/tasks/${blocked.id}/dependencies`,
+			{
+				method: 'POST',
+				headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+				body: JSON.stringify({ blocked_by_task_id: blocker.id }),
+			},
+		);
+		expect(addRes.status).toBe(201);
+
+		const listDeps = async () =>
+			(
+				await (
+					await app.request(`/api/projects/${projectSlug}/tasks/${blocked.id}/dependencies`, {
+						headers: authHeader(token),
+					})
+				).json()
+			).data;
+
+		// No run yet — the blocker is idle.
+		let deps = await listDeps();
+		expect(deps).toHaveLength(1);
+		expect(deps[0].blocked_by_has_active_run).toBe(false);
+		expect(deps[0].blocked_by_queued_wakeup).toBeNull();
+
+		// A run lands on the blocker — the downstream's dependency row reflects it.
+		await db.query(
+			`INSERT INTO heartbeat_runs (team_id, member_id, task_id, status)
+			 VALUES ($1, $2, $3, 'running')`,
+			[teamId, agentId, blocker.id],
+		);
+		deps = await listDeps();
+		expect(deps[0].blocked_by_has_active_run).toBe(true);
+
+		await db.query(`DELETE FROM heartbeat_runs WHERE task_id = $1`, [blocker.id]);
+	});
+
 	it('updates and retrieves progress_summary', async () => {
 		const listRes = await app.request(`/api/projects/${projectSlug}/tasks`, {
 			headers: authHeader(token),

--- a/packages/web/src/components/task-detail/dependencies-section.tsx
+++ b/packages/web/src/components/task-detail/dependencies-section.tsx
@@ -5,6 +5,7 @@ import {
 	useRemoveDependency,
 	useTaskDependencies,
 } from '../../hooks/use-tasks';
+import { TaskRunDot } from '../task-run-dot';
 import { TaskStatusBadge } from '../task-status-badge';
 
 interface DependenciesSectionProps {
@@ -41,6 +42,10 @@ export function DependenciesSection({ projectId, taskId }: DependenciesSectionPr
 							data-testid="blocked-by-item"
 						>
 							<TaskStatusBadge status={d.blocked_by_status} />
+							<TaskRunDot
+								hasActiveRun={d.blocked_by_has_active_run}
+								queuedWakeup={d.blocked_by_queued_wakeup}
+							/>
 							<span className="font-mono text-xs text-text-muted">{d.blocked_by_identifier}</span>
 							<span className="truncate">{d.blocked_by_title}</span>
 						</Link>

--- a/packages/web/src/components/task-detail/sub-tasks-section.tsx
+++ b/packages/web/src/components/task-detail/sub-tasks-section.tsx
@@ -3,6 +3,7 @@ import { ChevronDown, Plus } from 'lucide-react';
 import { useState } from 'react';
 import { useCreateSubTask, useTasks } from '../../hooks/use-tasks';
 import { DEFAULT_SUBTASK_PAGE_SIZE, useTeam } from '../../hooks/use-teams';
+import { TaskRunDot } from '../task-run-dot';
 import { TaskStatusBadge } from '../task-status-badge';
 import { Button } from '../ui/button';
 
@@ -138,6 +139,7 @@ export function SubTasksSection({
 							data-testid="sub-task-item"
 						>
 							<TaskStatusBadge status={s.status} className="shrink-0" />
+							<TaskRunDot hasActiveRun={s.has_active_run} queuedWakeup={s.queued_wakeup} />
 							<span className="font-mono text-xs text-text-muted shrink-0 whitespace-nowrap">
 								{s.identifier}
 							</span>

--- a/packages/web/src/components/task-list.tsx
+++ b/packages/web/src/components/task-list.tsx
@@ -6,6 +6,7 @@ import { useAgents } from '../hooks/use-agents';
 import { type TaskFilters, useTasks } from '../hooks/use-tasks';
 import { AdminApprovalsBanner } from './admin-approvals-banner';
 import { CreateTaskDialog } from './create-task-dialog';
+import { TaskRunDot } from './task-run-dot';
 import { TaskStatusBadge } from './task-status-badge';
 import { Badge } from './ui/badge';
 import { Button } from './ui/button';
@@ -178,36 +179,7 @@ export function TaskList({ projectId }: TaskListProps) {
 					(row.last_run_status === 'failed' || row.last_run_status === 'timed_out');
 				return (
 					<span className="inline-flex items-center gap-1.5">
-						{row.has_active_run && (
-							<Tooltip content="Agent run in progress">
-								<span
-									role="img"
-									aria-label="Agent run in progress"
-									data-testid="task-running-dot"
-									className="inline-block w-2 h-2 rounded-full bg-accent-amber animate-pulse shrink-0"
-								/>
-							</Tooltip>
-						)}
-						{!row.has_active_run && row.queued_wakeup && (
-							<Tooltip
-								content={
-									row.queued_wakeup.reason === 'project_at_capacity'
-										? 'Run queued — project at capacity'
-										: 'Run queued — waiting'
-								}
-							>
-								<span
-									role="img"
-									aria-label={
-										row.queued_wakeup.reason === 'project_at_capacity'
-											? 'Run queued — project at capacity'
-											: 'Run queued — waiting'
-									}
-									data-testid="task-queued-dot"
-									className="inline-block w-2 h-2 rounded-full bg-accent-blue shrink-0"
-								/>
-							</Tooltip>
-						)}
+						<TaskRunDot hasActiveRun={row.has_active_run} queuedWakeup={row.queued_wakeup} />
 						{lastRunFailed && (
 							<Tooltip content="Last run failed">
 								<span

--- a/packages/web/src/components/task-run-dot.tsx
+++ b/packages/web/src/components/task-run-dot.tsx
@@ -1,0 +1,48 @@
+import type { QueuedWakeup } from '../hooks/use-tasks';
+import { Tooltip } from './ui/tooltip';
+
+interface TaskRunDotProps {
+	/** True when an agent run is currently queued or executing for the task. */
+	hasActiveRun: boolean;
+	/** The task's parked wakeup, if a run is waiting rather than in flight. */
+	queuedWakeup: Pick<QueuedWakeup, 'reason'> | null;
+}
+
+/**
+ * Run-state dot shown beside a task reference: an amber pulsing dot while an
+ * agent run is in flight, a blue dot when a run is queued and waiting, and
+ * nothing when the task is idle. Shared by the task list, the sub-tasks list,
+ * and the "Blocked By" dependency list so the indicator stays identical
+ * everywhere a task is referenced.
+ */
+export function TaskRunDot({ hasActiveRun, queuedWakeup }: TaskRunDotProps) {
+	if (hasActiveRun) {
+		return (
+			<Tooltip content="Agent run in progress">
+				<span
+					role="img"
+					aria-label="Agent run in progress"
+					data-testid="task-running-dot"
+					className="inline-block w-2 h-2 rounded-full bg-accent-amber animate-pulse shrink-0"
+				/>
+			</Tooltip>
+		);
+	}
+	if (queuedWakeup) {
+		const label =
+			queuedWakeup.reason === 'project_at_capacity'
+				? 'Run queued — project at capacity'
+				: 'Run queued — waiting';
+		return (
+			<Tooltip content={label}>
+				<span
+					role="img"
+					aria-label={label}
+					data-testid="task-queued-dot"
+					className="inline-block w-2 h-2 rounded-full bg-accent-blue shrink-0"
+				/>
+			</Tooltip>
+		);
+	}
+	return null;
+}

--- a/packages/web/src/hooks/use-tasks.ts
+++ b/packages/web/src/hooks/use-tasks.ts
@@ -213,6 +213,8 @@ export interface TaskDependency {
 	blocked_by_title: string;
 	blocked_by_status: string;
 	blocked_by_project_slug: string;
+	blocked_by_has_active_run: boolean;
+	blocked_by_queued_wakeup: QueuedWakeup | null;
 }
 
 export function useTaskDependencies(projectId: string, taskId: string) {

--- a/packages/web/test/task-blocked-by.test.tsx
+++ b/packages/web/test/task-blocked-by.test.tsx
@@ -1,3 +1,4 @@
+import { waitFor } from '@testing-library/react';
 import { expect, test } from 'vitest';
 import { getTestContext, renderApp } from './helpers/render';
 import { seedProject, seedTask, seedWorkspace } from './helpers/seed';
@@ -59,4 +60,57 @@ test('Blocked By row links to the blocking task', async () => {
 	expect(router.state.location.pathname).toBe(
 		`/projects/${ctx!.projectSlug}/tasks/${ctx!.blockerIdentifier.toLowerCase()}`,
 	);
+});
+
+test('Blocked By row shows the running dot when the blocker has an active run', async () => {
+	let ctx: { projectSlug: string; blockedIdentifier: string };
+	const { findByRole, findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async ({ apiBase }) => {
+			const ws = await seedWorkspace();
+			const engineer = ws.agents.find((a) => a.slug === 'engineer') ?? ws.agents[0];
+			const project = await seedProject(ws, { name: 'Blocking Project' });
+			const blocker = await seedTask(ws, project, {
+				title: 'Upstream blocker',
+				assignee_id: engineer.id,
+			});
+			const blocked = await seedTask(ws, project, {
+				title: 'Downstream blocked',
+				assignee_id: engineer.id,
+			});
+			const dep = await apiBase(
+				`/api/projects/${ws.internalSlug}/tasks/${blocked.id}/dependencies`,
+				{
+					method: 'POST',
+					headers: ws.headers,
+					body: JSON.stringify({ blocked_by_task_id: blocker.id }),
+				},
+			);
+			if (!dep.ok) throw new Error(`dependency seed failed: ${dep.status}`);
+
+			// Put an in-flight run on the blocker so its dependency row lights up.
+			await getTestContext().db.query(
+				`INSERT INTO heartbeat_runs (team_id, member_id, task_id, status)
+				 VALUES ($1, $2, $3, 'running')`,
+				[ws.team.id, engineer.id, blocker.id],
+			);
+
+			ctx = { projectSlug: project.slug, blockedIdentifier: blocked.identifier };
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: {
+			projectId: ctx!.projectSlug,
+			taskId: ctx!.blockedIdentifier.toLowerCase(),
+		},
+	});
+
+	await findByRole('heading', { name: 'Downstream blocked' });
+
+	const row = await findByTestId('blocked-by-item');
+	await waitFor(() => {
+		expect(row.querySelector('[data-testid="task-running-dot"]')).not.toBeNull();
+	});
 });

--- a/packages/web/test/task-sub-tasks.test.tsx
+++ b/packages/web/test/task-sub-tasks.test.tsx
@@ -1,6 +1,6 @@
 import { waitFor } from '@testing-library/react';
 import { expect, test } from 'vitest';
-import { renderApp } from './helpers/render';
+import { getTestContext, renderApp } from './helpers/render';
 import { seedProject, seedTask, seedWorkspace } from './helpers/seed';
 
 test('sub-tasks panel is expanded by default and collapses on click', async () => {
@@ -135,6 +135,53 @@ test('sub-tasks paginate to team page size with a Show more link', async () => {
 	await waitFor(() => {
 		expect(countItems()).toBe(7);
 		expect(queryByTestId('sub-tasks-show-more')).toBeNull();
+	});
+});
+
+test('sub-task row shows the running dot when the child has an active run', async () => {
+	let teamSlug = '';
+	let parentIdentifier = '';
+
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async ({ apiBase }) => {
+			const ws = await seedWorkspace();
+			const engineer = ws.agents.find((a) => a.slug === 'engineer') ?? ws.agents[0];
+			const project = await seedProject(ws, { name: 'Running Sub-Task Project' });
+			teamSlug = project.slug;
+			const parent = await seedTask(ws, project, {
+				title: 'Parent Task',
+				assignee_id: engineer.id,
+			});
+			parentIdentifier = parent.identifier;
+
+			const res = await apiBase(`/api/projects/${ws.internalSlug}/tasks/${parent.id}/sub-tasks`, {
+				method: 'POST',
+				headers: ws.headers,
+				body: JSON.stringify({ title: 'Running child', assignee_id: engineer.id }),
+			});
+			if (!res.ok) throw new Error(`sub-task create failed: ${res.status}`);
+			const child = ((await res.json()) as { data: { id: string } }).data;
+
+			// Put an in-flight run on the child so its row lights up.
+			await getTestContext().db.query(
+				`INSERT INTO heartbeat_runs (team_id, member_id, task_id, status)
+				 VALUES ($1, $2, $3, 'running')`,
+				[ws.team.id, engineer.id, child.id],
+			);
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: teamSlug, taskId: parentIdentifier.toLowerCase() },
+	});
+
+	const list = await findByTestId('sub-tasks-list');
+	await waitFor(() => {
+		const item = list.querySelector('[data-testid="sub-task-item"]');
+		expect(item).not.toBeNull();
+		expect(item?.querySelector('[data-testid="task-running-dot"]')).not.toBeNull();
 	});
 });
 


### PR DESCRIPTION
## What

The queued/running run-state dot indicator previously only appeared in the main task list. This surfaces it everywhere a task is referenced, so an in-flight or queued agent run is visible without opening each task:

- **"Blocked By" dependency section** — shows the dot for the blocking task (the case in the original request).
- **Sub-tasks list** — shows the dot for each child task.

The dot is amber + pulsing while an agent run is in flight, and blue when a run is queued/waiting (with a tooltip explaining why). It renders nothing when the task is idle, so idle rows are unchanged.

## How

- Extracted a shared `TaskRunDot` component (`packages/web/src/components/task-run-dot.tsx`) from the inline markup in `task-list.tsx`, and reused it in all three places (task list, dependencies section, sub-tasks section). The task list's failed-run warning and unread-mention indicators stay inline — only the run/queued dots moved.
- The sub-tasks list already receives `has_active_run` / `queued_wakeup` on each task (it uses the standard tasks query), so no server change was needed there.
- The dependencies endpoint (`GET /api/projects/:projectId/tasks/:taskId/dependencies`) did **not** carry run state, so added `blocked_by_has_active_run` and `blocked_by_queued_wakeup` to its response (same EXISTS + LATERAL pattern used by the task list/detail queries), and to the `TaskDependency` client interface.

## Tests

- **Server** (`packages/server/test/tasks.test.ts`): new case asserting the dependencies list reports `blocked_by_has_active_run` (false when idle → true once a `running` heartbeat run lands on the blocker) and a null `blocked_by_queued_wakeup` by default.
- **Web component** (`task-blocked-by.test.tsx`, `task-sub-tasks.test.tsx`): each navigates to a task detail page with a blocker / child that has an active run and asserts the `task-running-dot` renders within the row.
- Existing task-list dot tests still pass after the refactor; full `tasks.test.ts` (44) green; typecheck clean across all packages.

https://claude.ai/code/session_015Zv8FwR8Bi93XMWnSxnZHv

---
_Generated by [Claude Code](https://claude.ai/code/session_015Zv8FwR8Bi93XMWnSxnZHv)_