### PR TITLE
feat(server): real tracked migrations — safe apply, version guard, code steps (HID-188)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,12 @@ Project-teams get a **Captain** + the chosen template's worker roles; templates 
 
 ## Database migrations
 
-Pre-v1: modify `packages/server/migrations/001_initial_schema.sql` in place and reset. Do not create new migration files.
+We ship **real, tracked, append-only migrations** that preserve user data across upgrades. `packages/server/migrations/001_initial_schema.sql` is the **frozen baseline** — never edit a migration that has shipped (each is checksummed and applied exactly once; editing it only logs a warning and is skipped on existing instances).
+
+- **Schema change** → add a new `NNN_description.sql` (next free number) under `packages/server/migrations/`. Never edit `001` (or any released file) in place.
+- **Data transform SQL can't express** (parse/re-encode/re-encrypt with app-side logic) → add a **code migration** TS module under `packages/server/src/db/migrations/code/` and register it in that dir's `index.ts`. SQL and code migrations share one ordered `NNN_` sequence and run in the same per-migration transaction.
+- **How they apply:** on startup the runner migrates a *copy* of the database (`<dataDir>/.migrate-tmp`) and atomically swaps it in on success. On failure the live `pgdata` is left untouched, so downgrading to the previous binary just works. A data dir carrying migrations the binary doesn't recognize (a downgrade) makes the server **exit** and ask the operator to upgrade.
+- Migration tests live in `packages/server/test/migrate-*.test.ts` — exercise real refactors (FK/layout changes, code transforms) against populated data and assert preservation. Don't just assert "the migration ran".
 
 ## Testing
 

--- a/packages/server/migrations/002_migration_smoke.sql
+++ b/packages/server/migrations/002_migration_smoke.sql
@@ -1,0 +1,18 @@
+-- First incremental migration after the frozen 001 baseline (HID-188).
+--
+-- This is an intentionally harmless, idempotent placeholder whose only job is to
+-- exercise the real upgrade path end-to-end: an instance created by an official
+-- release (which has only 001 applied) gains a pending migration when upgraded to
+-- a binary that ships this file, so the copy-migrate-swap runs and we can confirm
+-- existing data is preserved. Replace this with a real schema change when one lands.
+--
+-- Idempotent: re-running the SQL is a no-op (the runner already applies each
+-- migration exactly once, but additive/IF-NOT-EXISTS DDL keeps it safe regardless).
+
+CREATE TABLE IF NOT EXISTS migration_smoke (
+    id          INTEGER PRIMARY KEY DEFAULT 1,
+    applied_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT migration_smoke_singleton CHECK (id = 1)
+);
+
+INSERT INTO migration_smoke (id) VALUES (1) ON CONFLICT (id) DO NOTHING;

--- a/packages/server/src/db/migrate-errors.ts
+++ b/packages/server/src/db/migrate-errors.ts
@@ -1,0 +1,45 @@
+/**
+ * Fatal, operator-actionable migration conditions. Both carry a human-readable
+ * `.message` that the process entry point prints verbatim before exiting — same
+ * shape as `PgDataCorruptError` (see `src/db/client.ts`).
+ */
+
+/**
+ * The data directory was migrated by a newer Hezo version than the running
+ * binary (downgrade). The binary can't safely run against a schema it doesn't
+ * understand, so it must exit and ask the operator to upgrade.
+ */
+export class DbNewerThanAppError extends Error {
+	constructor(readonly unknownMigrations: string[]) {
+		super(
+			`This data directory was migrated by a newer version of Hezo. ` +
+				`It contains migration(s) this binary does not recognize: ` +
+				`${unknownMigrations.join(', ')}. ` +
+				`Upgrade Hezo to the latest version to use this database.`,
+		);
+		this.name = 'DbNewerThanAppError';
+	}
+}
+
+/**
+ * A pending migration failed while being applied to a *temporary copy* of the
+ * database. The live data directory was left completely untouched, so the
+ * operator can downgrade to the previous Hezo version and start again — it will
+ * pick up the existing database exactly as it was, no restore needed.
+ */
+export class MigrationFailedError extends Error {
+	constructor(
+		readonly pending: string[],
+		readonly dataDir: string,
+		readonly cause: unknown,
+	) {
+		const causeMsg = cause instanceof Error ? cause.message : String(cause);
+		super(
+			`Database migration failed while applying ${pending.join(', ')} to a temporary copy. ` +
+				`Your existing database at ${dataDir} was left untouched. ` +
+				`Downgrade to the previous Hezo version and start again — it will use your ` +
+				`existing database as-is. (cause: ${causeMsg})`,
+		);
+		this.name = 'MigrationFailedError';
+	}
+}

--- a/packages/server/src/db/migrate-runner.ts
+++ b/packages/server/src/db/migrate-runner.ts
@@ -1,0 +1,79 @@
+import type { PGlite } from '@electric-sql/pglite';
+import { logger } from '../logger';
+import { openPersistentDb } from './client';
+import {
+	findUnknownAppliedMigrations,
+	getPendingMigrations,
+	type Migration,
+	runMigrations,
+} from './migrate';
+import { DbNewerThanAppError, MigrationFailedError } from './migrate-errors';
+import { discardMigrationCopy, prepareMigrationCopy, promoteMigrationCopy } from './migrate-swap';
+import { BASE_SCHEMA } from './schema';
+
+const log = logger.child('migrate-runner');
+
+async function countApplied(db: PGlite): Promise<number> {
+	try {
+		const r = await db.query<{ c: number }>('SELECT COUNT(*)::int AS c FROM _migrations');
+		return r.rows[0]?.c ?? 0;
+	} catch {
+		return 0;
+	}
+}
+
+/**
+ * Apply any pending migrations safely, returning the live DB handle to keep
+ * using (which may be a NEW handle — see below). The data dir's `pgdata` is the
+ * source of truth.
+ *
+ * Behavior:
+ * - **Newer-than-binary DB** → throws `DbNewerThanAppError` (the data dir has
+ *   migrations this build doesn't know about). The DB is not touched.
+ * - **Nothing pending** → returns the same `db`.
+ * - **Fresh install** (nothing applied yet) → migrates in place; there's no user
+ *   data to protect, so no copy.
+ * - **Existing instance with pending** → copy-migrate-swap: the live DB is
+ *   closed, `pgdata` is copied aside, migrations run against the COPY, and only
+ *   on full success is the copy atomically swapped in (and a fresh handle
+ *   returned). On failure the original `pgdata` is left exactly as it was and
+ *   `MigrationFailedError` is thrown — a downgraded binary can run against it
+ *   unchanged.
+ */
+export async function applyPendingMigrations(
+	db: PGlite,
+	dataDir: string,
+	migrations: Record<string, Migration>,
+): Promise<PGlite> {
+	const unknown = await findUnknownAppliedMigrations(db, migrations);
+	if (unknown.length > 0) {
+		throw new DbNewerThanAppError(unknown);
+	}
+
+	const pending = await getPendingMigrations(db, migrations);
+	if (pending.length === 0) return db;
+
+	if ((await countApplied(db)) === 0) {
+		// Brand-new DB: nothing to lose, migrate in place.
+		await runMigrations(db, migrations);
+		return db;
+	}
+
+	// Existing instance: migrate a copy, swap on success, preserve original on failure.
+	log.info(`Applying ${pending.length} migration(s) to a temporary copy: ${pending.join(', ')}`);
+	await db.close();
+
+	const tmpDataDir = await prepareMigrationCopy(dataDir);
+	const tempDb = await openPersistentDb(tmpDataDir);
+	try {
+		await tempDb.exec(BASE_SCHEMA);
+		await runMigrations(tempDb, migrations);
+	} catch (err) {
+		await tempDb.close().catch(() => undefined);
+		await discardMigrationCopy(dataDir);
+		throw new MigrationFailedError(pending, dataDir, err);
+	}
+	await tempDb.close();
+	await promoteMigrationCopy(dataDir);
+	return openPersistentDb(dataDir);
+}

--- a/packages/server/src/db/migrate-swap.ts
+++ b/packages/server/src/db/migrate-swap.ts
@@ -1,0 +1,66 @@
+import { cp, mkdir, readdir, rename, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { logger } from '../logger';
+
+const log = logger.child('migrate-swap');
+
+/** Temp data dir (sibling of `pgdata`) where migrations run against a copy. */
+const MIGRATE_TMP = '.migrate-tmp';
+/** Prefix for the previous `pgdata`, kept aside after a successful swap. */
+const SUPERSEDED_PREFIX = 'pgdata.superseded.';
+/** How many superseded `pgdata` directories to retain. */
+const KEEP_SUPERSEDED = 5;
+
+function pgDataPath(dataDir: string): string {
+	return join(dataDir, 'pgdata');
+}
+
+function tmpDataDir(dataDir: string): string {
+	return join(dataDir, MIGRATE_TMP);
+}
+
+/**
+ * Copy the live `pgdata` into a temporary sibling data dir so migrations run
+ * against the copy, never the original. The live DB MUST be closed first (so
+ * its files are flushed and consistent). Returns the temp *data dir* (the path
+ * to pass to `openPersistentDb`, which appends `pgdata` itself).
+ */
+export async function prepareMigrationCopy(dataDir: string): Promise<string> {
+	const tmp = tmpDataDir(dataDir);
+	await rm(tmp, { recursive: true, force: true });
+	await mkdir(tmp, { recursive: true });
+	await cp(pgDataPath(dataDir), join(tmp, 'pgdata'), { recursive: true });
+	return tmp;
+}
+
+/**
+ * Atomically swap the migrated copy into place: rename the original `pgdata`
+ * aside (kept for recovery / inspection, pruned to the last `KEEP_SUPERSEDED`),
+ * move the migrated copy into `pgdata`, and remove the temp dir. All renames are
+ * within `dataDir` (same filesystem) so each is atomic.
+ */
+export async function promoteMigrationCopy(dataDir: string): Promise<void> {
+	const tmp = tmpDataDir(dataDir);
+	const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+	const supersededPath = join(dataDir, `${SUPERSEDED_PREFIX}${stamp}`);
+
+	await rename(pgDataPath(dataDir), supersededPath);
+	await rename(join(tmp, 'pgdata'), pgDataPath(dataDir));
+	await rm(tmp, { recursive: true, force: true });
+
+	await pruneSuperseded(dataDir);
+	log.info(`Swapped in migrated database; previous pgdata kept at ${supersededPath}`);
+}
+
+/** Remove the temp copy after a failed migration. The original is untouched. */
+export async function discardMigrationCopy(dataDir: string): Promise<void> {
+	await rm(tmpDataDir(dataDir), { recursive: true, force: true });
+}
+
+async function pruneSuperseded(dataDir: string): Promise<void> {
+	const entries = (await readdir(dataDir)).filter((e) => e.startsWith(SUPERSEDED_PREFIX)).sort();
+	const excess = entries.slice(0, Math.max(0, entries.length - KEEP_SUPERSEDED));
+	for (const e of excess) {
+		await rm(join(dataDir, e), { recursive: true, force: true });
+	}
+}

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -4,7 +4,40 @@ import { logger } from '../logger';
 
 const log = logger.child('migrate');
 
-export async function runMigrations(db: PGlite, migrations: Record<string, string>): Promise<void> {
+/**
+ * A migration is either a SQL string (the common case) or a code step — a JS
+ * function that reshapes data in ways SQL can't express (parse/re-encode/
+ * re-encrypt with app-side logic). Both run inside the same per-migration
+ * transaction, so a throw rolls the whole step back. A code step must NOT
+ * issue its own BEGIN/COMMIT — the runner owns the transaction.
+ */
+export type CodeMigration = {
+	run: (db: PGlite) => Promise<void>;
+	/**
+	 * Stable identity for change-detection. Prefer setting this explicitly (a
+	 * minifier rewriting `run.toString()` would otherwise shift the checksum and
+	 * log a spurious "changed since applied" warning — never a re-apply).
+	 */
+	checksum?: string;
+};
+
+export type Migration = string | CodeMigration;
+
+function isCodeMigration(m: Migration): m is CodeMigration {
+	return typeof m !== 'string';
+}
+
+function checksumOf(m: Migration): string {
+	if (isCodeMigration(m)) {
+		return m.checksum ?? createHash('sha256').update(m.run.toString()).digest('hex');
+	}
+	return createHash('sha256').update(m).digest('hex');
+}
+
+export async function runMigrations(
+	db: PGlite,
+	migrations: Record<string, Migration>,
+): Promise<void> {
 	await db.exec(`
     CREATE TABLE IF NOT EXISTS _migrations (
       id          SERIAL PRIMARY KEY,
@@ -22,8 +55,8 @@ export async function runMigrations(db: PGlite, migrations: Record<string, strin
 	const filenames = Object.keys(migrations).sort();
 
 	for (const filename of filenames) {
-		const sql = migrations[filename];
-		const checksum = createHash('sha256').update(sql).digest('hex');
+		const migration = migrations[filename];
+		const checksum = checksumOf(migration);
 
 		if (appliedMap.has(filename)) {
 			if (appliedMap.get(filename) !== checksum) {
@@ -34,7 +67,11 @@ export async function runMigrations(db: PGlite, migrations: Record<string, strin
 
 		await db.exec('BEGIN');
 		try {
-			await db.exec(sql);
+			if (isCodeMigration(migration)) {
+				await migration.run(db);
+			} else {
+				await db.exec(migration);
+			}
 			await db.query('INSERT INTO _migrations (filename, checksum) VALUES ($1, $2)', [
 				filename,
 				checksum,
@@ -48,10 +85,35 @@ export async function runMigrations(db: PGlite, migrations: Record<string, strin
 	}
 }
 
+/**
+ * Applied migrations recorded in `_migrations` that the running binary does not
+ * know about — i.e. the data dir was migrated by a *newer* Hezo version. Relies
+ * on the append-only, stable-filename policy (released migrations are never
+ * renamed or removed), so an unknown applied filename can only mean "from the
+ * future". Returns `[]` when `_migrations` doesn't exist yet (brand-new DB).
+ */
+export async function findUnknownAppliedMigrations(
+	db: PGlite,
+	migrations: Record<string, Migration>,
+): Promise<string[]> {
+	let appliedRows: { filename: string }[];
+	try {
+		const res = await db.query<{ filename: string }>('SELECT filename FROM _migrations');
+		appliedRows = res.rows;
+	} catch {
+		return [];
+	}
+	const known = new Set(Object.keys(migrations));
+	return appliedRows
+		.map((r) => r.filename)
+		.filter((f) => !known.has(f))
+		.sort();
+}
+
 /** Bundled migration filenames (sorted) not yet recorded in `_migrations`. */
 export async function getPendingMigrations(
 	db: PGlite,
-	migrations: Record<string, string>,
+	migrations: Record<string, Migration>,
 ): Promise<string[]> {
 	let appliedSet = new Set<string>();
 	try {

--- a/packages/server/src/db/migrations/code/index.ts
+++ b/packages/server/src/db/migrations/code/index.ts
@@ -1,0 +1,25 @@
+import type { CodeMigration } from '../../migrate';
+
+/**
+ * Registry of **code migrations** — schema/data migrations whose data transform
+ * needs application-side logic that SQL can't express (e.g. re-encrypting
+ * master-key-encrypted secrets, parsing a bespoke encoding). Each is a real TS
+ * module, so `bun build --compile` embeds it into the binary via the static
+ * import below — the same module-graph mechanism the SQL bundle relies on, but
+ * with no serialization (a function can't travel through JSON).
+ *
+ * To add one:
+ *   1. Create `src/db/migrations/code/NNN_description.ts` exporting a
+ *      `CodeMigration` (`{ run, checksum }`). Pick the next free `NNN` across
+ *      BOTH `migrations/*.sql` and this directory — the numbers share one
+ *      ordered sequence.
+ *   2. Import it here and add it to `codeMigrations` keyed by its full name
+ *      (`'NNN_description'`, no extension) so it sorts correctly against the
+ *      SQL migrations.
+ *   3. Set an explicit `checksum` on the migration (a short stable string) so a
+ *      rebuild can't shift it.
+ *
+ * `loadMigrations()` in `startup.ts` merges this with the SQL migrations into a
+ * single ordered `Record<string, Migration>` the runner applies.
+ */
+export const codeMigrations: Record<string, CodeMigration> = {};

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -4,6 +4,7 @@ import { app } from './app';
 import { parseConfig, runRestore } from './cli';
 import type { MasterKeyManager } from './crypto/master-key';
 import { PgDataCorruptError } from './db/client';
+import { DbNewerThanAppError, MigrationFailedError } from './db/migrate-errors';
 import { logger, setLogLevel } from './logger';
 import { loadAdminAuth, verifyToken } from './middleware/auth';
 import type { ContainerLogStreamer } from './services/container-logs';
@@ -149,6 +150,13 @@ void (async () => {
 		}
 	} catch (err) {
 		if (thisStartupGeneration !== startupGeneration) return;
+		// Fatal, operator-actionable migration conditions: the DB is fine but the
+		// binary can't proceed. Print the guidance and exit rather than limping
+		// along in minimal mode.
+		if (err instanceof DbNewerThanAppError || err instanceof MigrationFailedError) {
+			log.error(`\n${err.message}\n`);
+			process.exit(1);
+		}
 		if (err instanceof PgDataCorruptError) {
 			log.error(`\n${err.message}\n`);
 		} else {

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -9,6 +9,7 @@ const log = logger.child('startup');
 
 import { MasterKeyManager } from './crypto/master-key';
 import { openPersistentDb } from './db/client';
+import type { Migration } from './db/migrate';
 import { BASE_SCHEMA } from './db/schema';
 import { registerAuditObserver } from './events/audit-observer';
 import { DomainEventBus } from './events/bus';
@@ -91,10 +92,12 @@ export interface StartupResult {
 export async function startup(config: HezoConfig): Promise<StartupResult> {
 	mkdirSync(config.dataDir, { recursive: true });
 
-	const db = await openPersistentDb(config.dataDir, { reset: config.reset });
+	// `db` may be replaced by a fresh handle if migrations run against a copy and
+	// swap it in, so it's a `let` — every consumer below uses the post-migration handle.
+	let db = await openPersistentDb(config.dataDir, { reset: config.reset });
 
 	await db.exec(BASE_SCHEMA);
-	await runAvailableMigrations(db, config.dataDir);
+	db = await runAvailableMigrations(db, config.dataDir);
 	await runSeed(db);
 
 	const masterKeyManager = new MasterKeyManager();
@@ -409,65 +412,44 @@ async function cleanupOrphanRunSockets(_db: PGlite, dataDir: string): Promise<vo
 	}
 }
 
-async function loadMigrations(): Promise<Record<string, string> | null> {
+async function loadMigrations(): Promise<Record<string, Migration> | null> {
 	const { loadBundledMigrations, loadFilesystemMigrations } = await import('./db/migrate.js');
+	const { codeMigrations } = await import('./db/migrations/code/index.js');
+
+	let sql: Record<string, string> | null = null;
 	try {
-		return await loadBundledMigrations();
+		sql = await loadBundledMigrations();
 	} catch {
 		// Dev (`bun run`): the bundle isn't generated — read from the source tree.
+		// `HEZO_MIGRATIONS_DIR` lets tests point startup at synthetic migrations.
+		try {
+			const migrationsDir =
+				process.env.HEZO_MIGRATIONS_DIR ??
+				join(new URL('.', import.meta.url).pathname, '..', 'migrations');
+			sql = await loadFilesystemMigrations(migrationsDir);
+		} catch {
+			sql = null;
+		}
 	}
-	try {
-		const migrationsDir = join(new URL('.', import.meta.url).pathname, '..', 'migrations');
-		return await loadFilesystemMigrations(migrationsDir);
-	} catch {
-		return null;
-	}
+	if (!sql) return null;
+
+	// SQL migrations + code migrations share one ordered sequence (the runner
+	// sorts by name). Code migrations travel through the TS module graph.
+	return { ...sql, ...codeMigrations };
 }
 
-async function runAvailableMigrations(db: PGlite, dataDir: string): Promise<void> {
+async function runAvailableMigrations(db: PGlite, dataDir: string): Promise<PGlite> {
 	const migrations = await loadMigrations();
 	if (!migrations) {
 		log.warn('No migrations found. Run build:migrations or add migration files.');
-		return;
+		return db;
 	}
 
-	const { getPendingMigrations, runMigrations } = await import('./db/migrate.js');
-	const pending = await getPendingMigrations(db, migrations);
-	if (pending.length === 0) return;
-
-	// Snapshot before mutating an *existing* instance. A brand-new DB (nothing
-	// applied yet) has no data worth saving, so skip the backup there.
-	const applied = await countAppliedMigrations(db);
-	if (applied > 0) {
-		try {
-			const { backupDataDir } = await import('./db/backup.js');
-			await backupDataDir(db, dataDir, { version: HEZO_VERSION, pending });
-		} catch (err) {
-			log.error('Pre-migration backup failed; aborting migrations to protect existing data', err);
-			throw err;
-		}
-	}
-
-	try {
-		await runMigrations(db, migrations);
-	} catch (err) {
-		log.error(
-			`Migration failed. To recover, downgrade to the previous Hezo version and restore the ` +
-				`pre-migration snapshot from ${join(dataDir, 'backups')} ` +
-				`(\`hezo restore <backup.tar.gz>\`).`,
-			err,
-		);
-		throw err;
-	}
-}
-
-async function countAppliedMigrations(db: PGlite): Promise<number> {
-	try {
-		const r = await db.query<{ c: number }>('SELECT COUNT(*)::int AS c FROM _migrations');
-		return r.rows[0]?.c ?? 0;
-	} catch {
-		return 0;
-	}
+	// Migrate a copy and swap on success; on failure the original is untouched
+	// (a downgraded binary can run against it as-is). Returns the live handle to
+	// use, which is a fresh one after a successful swap.
+	const { applyPendingMigrations } = await import('./db/migrate-runner.js');
+	return applyPendingMigrations(db, dataDir, migrations);
 }
 
 async function runSeed(db: PGlite): Promise<void> {

--- a/packages/server/test/migrate-backup.test.ts
+++ b/packages/server/test/migrate-backup.test.ts
@@ -8,14 +8,12 @@ import { openPersistentDb } from '../src/db/client';
 import { getPendingMigrations, runMigrations } from '../src/db/migrate';
 import { safeClose } from './helpers';
 
-// HID-188: the one production migration behavior that is *not* exercisable
-// in-memory — the pre-migration backup snapshot. Production opens a disk-backed
-// PGlite (`openPersistentDb`) and, before applying pending migrations to an
-// already-populated instance, dumps a gzipped tarball of pgdata
-// (`startup.ts` runAvailableMigrations -> backupDataDir). This test reproduces
-// that exact sequence against a real on-disk data dir with synthetic refactor
-// migrations, asserting the snapshot is written AND the data survives the
-// refactor.
+// HID-188: covers `backupDataDir` against a disk-backed PGlite — a gzipped
+// snapshot of pgdata that survives a destructive refactor. Startup's automatic
+// migration path no longer calls this (copy-migrate-swap leaves the original
+// pgdata untouched on failure and keeps the prior pgdata aside on success), but
+// `backupDataDir`/`restoreDataDir` remain the engine behind the manual
+// `hezo restore` snapshot/downgrade flow, so the round-trip stays under test.
 
 describe('migration backup-then-migrate (persistent, production path)', () => {
 	it('snapshots pgdata before applying pending refactor migrations and preserves data', async () => {

--- a/packages/server/test/migrate-backup.test.ts
+++ b/packages/server/test/migrate-backup.test.ts
@@ -1,0 +1,112 @@
+import { existsSync, mkdtempSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { PGlite } from '@electric-sql/pglite';
+import { describe, expect, it } from 'vitest';
+import { backupDataDir } from '../src/db/backup';
+import { openPersistentDb } from '../src/db/client';
+import { getPendingMigrations, runMigrations } from '../src/db/migrate';
+import { safeClose } from './helpers';
+
+// HID-188: the one production migration behavior that is *not* exercisable
+// in-memory — the pre-migration backup snapshot. Production opens a disk-backed
+// PGlite (`openPersistentDb`) and, before applying pending migrations to an
+// already-populated instance, dumps a gzipped tarball of pgdata
+// (`startup.ts` runAvailableMigrations -> backupDataDir). This test reproduces
+// that exact sequence against a real on-disk data dir with synthetic refactor
+// migrations, asserting the snapshot is written AND the data survives the
+// refactor.
+
+describe('migration backup-then-migrate (persistent, production path)', () => {
+	it('snapshots pgdata before applying pending refactor migrations and preserves data', async () => {
+		const dir = mkdtempSync(join(tmpdir(), 'hezo-mig-backup-'));
+		let db: PGlite | undefined;
+		try {
+			db = await openPersistentDb(dir);
+
+			const migrations: Record<string, string> = {
+				'001_posts.sql': `
+					CREATE TABLE posts (
+						id           SERIAL PRIMARY KEY,
+						title        TEXT NOT NULL,
+						author_name  TEXT NOT NULL,
+						author_email TEXT NOT NULL
+					);
+				`,
+				'002_extract_authors.sql': `
+					CREATE TABLE authors (id SERIAL PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL UNIQUE);
+					INSERT INTO authors (name, email) SELECT DISTINCT author_name, author_email FROM posts;
+					ALTER TABLE posts ADD COLUMN author_id INTEGER;
+					UPDATE posts p SET author_id = a.id FROM authors a WHERE a.email = p.author_email;
+					ALTER TABLE posts ALTER COLUMN author_id SET NOT NULL;
+					ALTER TABLE posts ADD CONSTRAINT posts_author_fk FOREIGN KEY (author_id) REFERENCES authors (id);
+					ALTER TABLE posts DROP COLUMN author_name;
+					ALTER TABLE posts DROP COLUMN author_email;
+				`,
+				'003_split_author_name.sql': `
+					ALTER TABLE authors ADD COLUMN first_name TEXT;
+					ALTER TABLE authors ADD COLUMN last_name  TEXT;
+					UPDATE authors SET first_name = split_part(name, ' ', 1), last_name = split_part(name, ' ', 2);
+					ALTER TABLE authors ALTER COLUMN first_name SET NOT NULL;
+					ALTER TABLE authors ALTER COLUMN last_name  SET NOT NULL;
+					ALTER TABLE authors DROP COLUMN name;
+				`,
+			};
+
+			// Simulate an existing instance: only v1 is installed, with live data.
+			await runMigrations(db, { '001_posts.sql': migrations['001_posts.sql'] });
+			const seed: Array<{ title: string; name: string; email: string }> = [
+				{ title: 'First', name: 'Ada Lovelace', email: 'ada@example.com' },
+				{ title: 'Second', name: 'Alan Turing', email: 'alan@example.com' },
+				{ title: 'Third', name: 'Ada Lovelace', email: 'ada@example.com' },
+			];
+			for (const row of seed) {
+				await db.query('INSERT INTO posts (title, author_name, author_email) VALUES ($1, $2, $3)', [
+					row.title,
+					row.name,
+					row.email,
+				]);
+			}
+
+			// Mirror runAvailableMigrations: an existing instance has applied rows,
+			// and there are pending refactors to run.
+			const appliedBefore = await db.query<{ c: number }>(
+				'SELECT COUNT(*)::int AS c FROM _migrations',
+			);
+			expect(appliedBefore.rows[0].c).toBeGreaterThan(0);
+			const pending = await getPendingMigrations(db, migrations);
+			expect(pending).toEqual(['002_extract_authors.sql', '003_split_author_name.sql']);
+
+			// Backup before mutating (same call shape as startup.ts:444).
+			const tarPath = await backupDataDir(db, dir, { version: 'test-1.0.0', pending });
+			expect(existsSync(tarPath)).toBe(true);
+			const backups = readdirSync(join(dir, 'backups')).filter((f) => f.endsWith('.tar.gz'));
+			expect(backups).toHaveLength(1);
+
+			// Now apply the pending refactors.
+			await runMigrations(db, migrations);
+
+			// Every post still maps to its original author, with the split name intact.
+			const joined = await db.query<{
+				title: string;
+				first_name: string;
+				last_name: string;
+				email: string;
+			}>(
+				`SELECT p.title, a.first_name, a.last_name, a.email
+				 FROM posts p JOIN authors a ON a.id = p.author_id
+				 ORDER BY p.id`,
+			);
+			expect(joined.rows).toEqual([
+				{ title: 'First', first_name: 'Ada', last_name: 'Lovelace', email: 'ada@example.com' },
+				{ title: 'Second', first_name: 'Alan', last_name: 'Turing', email: 'alan@example.com' },
+				{ title: 'Third', first_name: 'Ada', last_name: 'Lovelace', email: 'ada@example.com' },
+			]);
+			const authorCount = await db.query<{ c: number }>('SELECT COUNT(*)::int AS c FROM authors');
+			expect(authorCount.rows[0].c).toBe(2);
+		} finally {
+			if (db) await safeClose(db);
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/server/test/migrate-code-steps.test.ts
+++ b/packages/server/test/migrate-code-steps.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+import { createMemoryDb } from '../src/db/client';
+import { type Migration, runMigrations } from '../src/db/migrate';
+import { safeClose } from './helpers';
+
+// HID-188: code-step migrations. Some data transforms can't be expressed in SQL
+// and need application-side logic (parse/re-encode/re-encrypt). A migration can
+// therefore be a `{ run(db) }` code step instead of a SQL string. It runs inside
+// the same per-migration transaction the runner uses for SQL, so a throw rolls
+// the whole step back. These tests prove the transform preserves data, rolls back
+// cleanly on failure, and interleaves with SQL migrations in order.
+
+describe('code-step migrations', () => {
+	it('runs an application-side data transform and preserves every row', async () => {
+		const db = await createMemoryDb();
+		try {
+			await runMigrations(db, {
+				'001_contacts.sql': 'CREATE TABLE contacts (id INTEGER PRIMARY KEY, phone TEXT NOT NULL);',
+			});
+			// Messy phone formats SQL alone shouldn't be asked to normalize.
+			const seed: Array<{ id: number; phone: string }> = [
+				{ id: 1, phone: '(415) 555-0001' },
+				{ id: 2, phone: '+1 415.555.0002' },
+				{ id: 3, phone: '415-555-0003' },
+			];
+			for (const r of seed) {
+				await db.query('INSERT INTO contacts (id, phone) VALUES ($1, $2)', [r.id, r.phone]);
+			}
+
+			const normalizePhones: Migration = {
+				checksum: 'normalize-phones-v1',
+				run: async (mdb) => {
+					await mdb.exec('CREATE TABLE contacts_v2 (id INTEGER PRIMARY KEY, phone TEXT NOT NULL);');
+					const rows = await mdb.query<{ id: number; phone: string }>(
+						'SELECT id, phone FROM contacts ORDER BY id',
+					);
+					for (const r of rows.rows) {
+						// JS-side reformat: strip to digits, default a US country code
+						// when a bare 10-digit number is given, render E.164.
+						const digits = r.phone.replace(/\D/g, '');
+						const withCc = digits.length === 10 ? `1${digits}` : digits;
+						const e164 = `+${withCc}`;
+						await mdb.query('INSERT INTO contacts_v2 (id, phone) VALUES ($1, $2)', [r.id, e164]);
+					}
+					await mdb.exec('DROP TABLE contacts;');
+					await mdb.exec('ALTER TABLE contacts_v2 RENAME TO contacts;');
+				},
+			};
+			await runMigrations(db, { '002_normalize_phones': normalizePhones });
+
+			const result = await db.query<{ id: number; phone: string }>(
+				'SELECT id, phone FROM contacts ORDER BY id',
+			);
+			expect(result.rows).toEqual([
+				{ id: 1, phone: '+14155550001' },
+				{ id: 2, phone: '+14155550002' },
+				{ id: 3, phone: '+14155550003' },
+			]);
+			const recorded = await db.query<{ filename: string }>(
+				"SELECT filename FROM _migrations WHERE filename = '002_normalize_phones'",
+			);
+			expect(recorded.rows).toHaveLength(1);
+		} finally {
+			await safeClose(db);
+		}
+	});
+
+	it('rolls back a code step that throws mid-transform, preserving the original data', async () => {
+		const db = await createMemoryDb();
+		try {
+			await runMigrations(db, {
+				'001_accounts.sql':
+					'CREATE TABLE accounts (id INTEGER PRIMARY KEY, balance INTEGER NOT NULL);',
+			});
+			await db.query('INSERT INTO accounts (id, balance) VALUES (1, 100), (2, 250)');
+
+			const bad: Migration = {
+				checksum: 'bad-code-step',
+				run: async (mdb) => {
+					await mdb.query('UPDATE accounts SET balance = balance + 1000');
+					throw new Error('boom in code step');
+				},
+			};
+			await expect(runMigrations(db, { '002_bad_code': bad })).rejects.toThrow('002_bad_code');
+
+			// The in-transaction UPDATE was rolled back.
+			const rows = await db.query<{ id: number; balance: number }>(
+				'SELECT id, balance FROM accounts ORDER BY id',
+			);
+			expect(rows.rows).toEqual([
+				{ id: 1, balance: 100 },
+				{ id: 2, balance: 250 },
+			]);
+			const recorded = await db.query<{ c: number }>(
+				"SELECT COUNT(*)::int AS c FROM _migrations WHERE filename = '002_bad_code'",
+			);
+			expect(recorded.rows[0].c).toBe(0);
+		} finally {
+			await safeClose(db);
+		}
+	});
+
+	it('interleaves SQL and code migrations in name order and is idempotent', async () => {
+		const db = await createMemoryDb();
+		try {
+			let codeRuns = 0;
+			const migrations: Record<string, Migration> = {
+				'001_items.sql': 'CREATE TABLE items (id INTEGER PRIMARY KEY, label TEXT);',
+				'002_uppercase_labels': {
+					checksum: 'uppercase-v1',
+					run: async (mdb) => {
+						codeRuns += 1;
+						const rows = await mdb.query<{ id: number; label: string | null }>(
+							'SELECT id, label FROM items ORDER BY id',
+						);
+						for (const r of rows.rows) {
+							await mdb.query('UPDATE items SET label = $1 WHERE id = $2', [
+								r.label?.toUpperCase() ?? null,
+								r.id,
+							]);
+						}
+					},
+				},
+				'003_add_flag.sql': 'ALTER TABLE items ADD COLUMN flagged BOOLEAN NOT NULL DEFAULT false;',
+			};
+
+			// Apply 001 + seed, then the full set (002 code depends on 001's rows; 003 after 002).
+			await runMigrations(db, { '001_items.sql': migrations['001_items.sql'] });
+			await db.query("INSERT INTO items (id, label) VALUES (1, 'alpha'), (2, 'beta')");
+			await runMigrations(db, migrations);
+
+			const applied = await db.query<{ filename: string }>(
+				'SELECT filename FROM _migrations ORDER BY id',
+			);
+			expect(applied.rows.map((r) => r.filename)).toEqual([
+				'001_items.sql',
+				'002_uppercase_labels',
+				'003_add_flag.sql',
+			]);
+			const items = await db.query<{ id: number; label: string; flagged: boolean }>(
+				'SELECT id, label, flagged FROM items ORDER BY id',
+			);
+			expect(items.rows).toEqual([
+				{ id: 1, label: 'ALPHA', flagged: false },
+				{ id: 2, label: 'BETA', flagged: false },
+			]);
+
+			// Re-running is a no-op: the code step does not fire again.
+			await runMigrations(db, migrations);
+			expect(codeRuns).toBe(1);
+		} finally {
+			await safeClose(db);
+		}
+	});
+});

--- a/packages/server/test/migrate-data-preservation.test.ts
+++ b/packages/server/test/migrate-data-preservation.test.ts
@@ -1,0 +1,336 @@
+import { describe, expect, it } from 'vitest';
+import { createMemoryDb } from '../src/db/client';
+import { runMigrations } from '../src/db/migrate';
+import { safeClose } from './helpers';
+
+// HID-188: end-to-end coverage for the production migration runner
+// (`runMigrations`) applying *sequences* of migrations that refactor table
+// layouts and foreign-key relationships against a *populated* database, while
+// preserving every existing row. Migrations are synthetic, defined inline as
+// `Record<string, string>` (pre-v1 policy keeps a single real schema file), and
+// driven through the same `runMigrations` the server runs at startup — so these
+// exercise the real BEGIN/COMMIT/ROLLBACK, sorted ordering, and checksum
+// tracking, not a hand-rolled `db.exec` loop.
+
+describe('migration data preservation', () => {
+	it('A: extracts a normalized authors table + FK, preserving every author mapping', async () => {
+		const db = await createMemoryDb();
+		try {
+			await runMigrations(db, {
+				'001_posts.sql': `
+					CREATE TABLE posts (
+						id           SERIAL PRIMARY KEY,
+						title        TEXT NOT NULL,
+						author_name  TEXT NOT NULL,
+						author_email TEXT NOT NULL,
+						body         TEXT NOT NULL
+					);
+				`,
+			});
+
+			// v1 data: 3 distinct authors spread across 5 posts (deliberate repeats).
+			const seed: Array<{ title: string; name: string; email: string; body: string }> = [
+				{ title: 'First', name: 'Ada Lovelace', email: 'ada@example.com', body: 'b1' },
+				{ title: 'Second', name: 'Ada Lovelace', email: 'ada@example.com', body: 'b2' },
+				{ title: 'Third', name: 'Alan Turing', email: 'alan@example.com', body: 'b3' },
+				{ title: 'Fourth', name: 'Grace Hopper', email: 'grace@example.com', body: 'b4' },
+				{ title: 'Fifth', name: 'Alan Turing', email: 'alan@example.com', body: 'b5' },
+			];
+			for (const row of seed) {
+				await db.query(
+					'INSERT INTO posts (title, author_name, author_email, body) VALUES ($1, $2, $3, $4)',
+					[row.title, row.name, row.email, row.body],
+				);
+			}
+
+			// Refactor: pull authors into their own table, rewrite posts to an FK.
+			await runMigrations(db, {
+				'002_extract_authors.sql': `
+					CREATE TABLE authors (
+						id    SERIAL PRIMARY KEY,
+						name  TEXT NOT NULL,
+						email TEXT NOT NULL UNIQUE
+					);
+					INSERT INTO authors (name, email)
+						SELECT DISTINCT author_name, author_email FROM posts;
+					ALTER TABLE posts ADD COLUMN author_id INTEGER;
+					UPDATE posts p SET author_id = a.id
+						FROM authors a WHERE a.email = p.author_email;
+					ALTER TABLE posts ALTER COLUMN author_id SET NOT NULL;
+					ALTER TABLE posts ADD CONSTRAINT posts_author_fk
+						FOREIGN KEY (author_id) REFERENCES authors (id);
+					ALTER TABLE posts DROP COLUMN author_name;
+					ALTER TABLE posts DROP COLUMN author_email;
+				`,
+			});
+
+			// No data lost: 5 posts, 3 distinct authors, zero unmapped rows.
+			const postCount = await db.query<{ c: number }>('SELECT COUNT(*)::int AS c FROM posts');
+			expect(postCount.rows[0].c).toBe(5);
+			const authorCount = await db.query<{ c: number }>('SELECT COUNT(*)::int AS c FROM authors');
+			expect(authorCount.rows[0].c).toBe(3);
+			const nullCount = await db.query<{ c: number }>(
+				'SELECT COUNT(*)::int AS c FROM posts WHERE author_id IS NULL',
+			);
+			expect(nullCount.rows[0].c).toBe(0);
+
+			// Each post still resolves to its *original* author via the new FK.
+			const joined = await db.query<{ title: string; name: string; email: string }>(
+				`SELECT p.title, a.name, a.email
+				 FROM posts p JOIN authors a ON a.id = p.author_id
+				 ORDER BY p.id`,
+			);
+			expect(joined.rows).toEqual(
+				seed.map((r) => ({ title: r.title, name: r.name, email: r.email })),
+			);
+
+			// The new FK is enforced: a dangling author_id is rejected.
+			await expect(
+				db.query("INSERT INTO posts (title, body, author_id) VALUES ('x', 'y', 9999)"),
+			).rejects.toThrow();
+		} finally {
+			await safeClose(db);
+		}
+	});
+
+	it('B: migrates a one-to-many FK into a many-to-many join, preserving every assignment', async () => {
+		const db = await createMemoryDb();
+		try {
+			await runMigrations(db, {
+				'001_tasks.sql': `
+					CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT NOT NULL);
+					CREATE TABLE tasks (
+						id          SERIAL PRIMARY KEY,
+						title       TEXT NOT NULL,
+						assignee_id INTEGER REFERENCES users (id)
+					);
+				`,
+			});
+
+			await db.query("INSERT INTO users (name) VALUES ('Ada'), ('Alan'), ('Grace')");
+			// Tasks 1-3 assigned to users 1-3, task 4 deliberately unassigned (NULL).
+			await db.query(`
+				INSERT INTO tasks (title, assignee_id) VALUES
+					('T1', 1), ('T2', 2), ('T3', 3), ('T4', NULL)
+			`);
+
+			await runMigrations(db, {
+				'002_task_assignees.sql': `
+					CREATE TABLE task_assignees (
+						task_id INTEGER NOT NULL REFERENCES tasks (id),
+						user_id INTEGER NOT NULL REFERENCES users (id),
+						PRIMARY KEY (task_id, user_id)
+					);
+					INSERT INTO task_assignees (task_id, user_id)
+						SELECT id, assignee_id FROM tasks WHERE assignee_id IS NOT NULL;
+					ALTER TABLE tasks DROP COLUMN assignee_id;
+				`,
+			});
+
+			// The 3 original assignments became 3 join rows; the NULL task has none.
+			const pairs = await db.query<{ task_id: number; user_id: number }>(
+				'SELECT task_id, user_id FROM task_assignees ORDER BY task_id',
+			);
+			expect(pairs.rows).toEqual([
+				{ task_id: 1, user_id: 1 },
+				{ task_id: 2, user_id: 2 },
+				{ task_id: 3, user_id: 3 },
+			]);
+			const t4 = await db.query<{ c: number }>(
+				'SELECT COUNT(*)::int AS c FROM task_assignees WHERE task_id = 4',
+			);
+			expect(t4.rows[0].c).toBe(0);
+
+			// The new shape genuinely supports many-to-many: a second assignee lands.
+			await db.query('INSERT INTO task_assignees (task_id, user_id) VALUES (1, 2)');
+			const t1 = await db.query<{ c: number }>(
+				'SELECT COUNT(*)::int AS c FROM task_assignees WHERE task_id = 1',
+			);
+			expect(t1.rows[0].c).toBe(2);
+		} finally {
+			await safeClose(db);
+		}
+	});
+
+	it('C: splits a column into two with backfill + NOT NULL, preserving every value', async () => {
+		const db = await createMemoryDb();
+		try {
+			await runMigrations(db, {
+				'001_authors.sql': 'CREATE TABLE authors (id SERIAL PRIMARY KEY, name TEXT NOT NULL);',
+			});
+
+			const names = ['Ada Lovelace', 'Alan Turing', 'Grace Hopper'];
+			for (const name of names) {
+				await db.query('INSERT INTO authors (name) VALUES ($1)', [name]);
+			}
+
+			await runMigrations(db, {
+				'002_split_name.sql': `
+					ALTER TABLE authors ADD COLUMN first_name TEXT;
+					ALTER TABLE authors ADD COLUMN last_name  TEXT;
+					UPDATE authors SET
+						first_name = split_part(name, ' ', 1),
+						last_name  = split_part(name, ' ', 2);
+					ALTER TABLE authors ALTER COLUMN first_name SET NOT NULL;
+					ALTER TABLE authors ALTER COLUMN last_name  SET NOT NULL;
+					ALTER TABLE authors DROP COLUMN name;
+				`,
+			});
+
+			const rebuilt = await db.query<{ full: string }>(
+				"SELECT first_name || ' ' || last_name AS full FROM authors ORDER BY id",
+			);
+			expect(rebuilt.rows.map((r) => r.full)).toEqual(names);
+			const count = await db.query<{ c: number }>('SELECT COUNT(*)::int AS c FROM authors');
+			expect(count.rows[0].c).toBe(3);
+		} finally {
+			await safeClose(db);
+		}
+	});
+
+	it('D: applies a dependent multi-migration sequence in one call and is idempotent on re-run', async () => {
+		const db = await createMemoryDb();
+		try {
+			// A chain where each step depends on the previous one's output.
+			const schema = {
+				'001_posts.sql': `
+					CREATE TABLE posts (
+						id           SERIAL PRIMARY KEY,
+						title        TEXT NOT NULL,
+						author_name  TEXT NOT NULL,
+						author_email TEXT NOT NULL,
+						body         TEXT NOT NULL
+					);
+				`,
+			};
+			const refactors = {
+				'002_extract_authors.sql': `
+					CREATE TABLE authors (id SERIAL PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL UNIQUE);
+					INSERT INTO authors (name, email) SELECT DISTINCT author_name, author_email FROM posts;
+					ALTER TABLE posts ADD COLUMN author_id INTEGER;
+					UPDATE posts p SET author_id = a.id FROM authors a WHERE a.email = p.author_email;
+					ALTER TABLE posts ALTER COLUMN author_id SET NOT NULL;
+					ALTER TABLE posts ADD CONSTRAINT posts_author_fk FOREIGN KEY (author_id) REFERENCES authors (id);
+					ALTER TABLE posts DROP COLUMN author_name;
+					ALTER TABLE posts DROP COLUMN author_email;
+				`,
+				// 003 depends on the authors table that 002 created.
+				'003_split_author_name.sql': `
+					ALTER TABLE authors ADD COLUMN first_name TEXT;
+					ALTER TABLE authors ADD COLUMN last_name  TEXT;
+					UPDATE authors SET first_name = split_part(name, ' ', 1), last_name = split_part(name, ' ', 2);
+					ALTER TABLE authors ALTER COLUMN first_name SET NOT NULL;
+					ALTER TABLE authors ALTER COLUMN last_name  SET NOT NULL;
+					ALTER TABLE authors DROP COLUMN name;
+				`,
+				// 004 renames a posts column that has lived since 001.
+				'004_rename_body.sql': 'ALTER TABLE posts RENAME COLUMN body TO content;',
+			};
+			const all = { ...schema, ...refactors };
+
+			// Install v1 (schema only), seed, then apply the whole refactor chain at once.
+			await runMigrations(db, schema);
+			const seed: Array<{ title: string; name: string; email: string; body: string }> = [
+				{ title: 'First', name: 'Ada Lovelace', email: 'ada@example.com', body: 'b1' },
+				{ title: 'Second', name: 'Alan Turing', email: 'alan@example.com', body: 'b2' },
+				{ title: 'Third', name: 'Ada Lovelace', email: 'ada@example.com', body: 'b3' },
+			];
+			for (const row of seed) {
+				await db.query(
+					'INSERT INTO posts (title, author_name, author_email, body) VALUES ($1, $2, $3, $4)',
+					[row.title, row.name, row.email, row.body],
+				);
+			}
+
+			await runMigrations(db, all);
+
+			// All four recorded, applied in sorted order.
+			const applied = await db.query<{ filename: string }>(
+				'SELECT filename FROM _migrations ORDER BY id',
+			);
+			expect(applied.rows.map((r) => r.filename)).toEqual([
+				'001_posts.sql',
+				'002_extract_authors.sql',
+				'003_split_author_name.sql',
+				'004_rename_body.sql',
+			]);
+
+			// Snapshot the post-refactor world: renamed column + split names intact.
+			const snapshotSql = `
+				SELECT p.title, p.content, a.first_name, a.last_name
+				FROM posts p JOIN authors a ON a.id = p.author_id
+				ORDER BY p.id`;
+			const before = await db.query(snapshotSql);
+			expect(before.rows).toEqual([
+				{ title: 'First', content: 'b1', first_name: 'Ada', last_name: 'Lovelace' },
+				{ title: 'Second', content: 'b2', first_name: 'Alan', last_name: 'Turing' },
+				{ title: 'Third', content: 'b3', first_name: 'Ada', last_name: 'Lovelace' },
+			]);
+
+			// Re-running the identical set is a no-op: nothing re-applied, data untouched.
+			await runMigrations(db, all);
+			const appliedAgain = await db.query<{ c: number }>(
+				'SELECT COUNT(*)::int AS c FROM _migrations',
+			);
+			expect(appliedAgain.rows[0].c).toBe(4);
+			const after = await db.query(snapshotSql);
+			expect(after.rows).toEqual(before.rows);
+		} finally {
+			await safeClose(db);
+		}
+	});
+
+	it('E: rolls back a failure mid-refactor, leaving existing data exactly as before', async () => {
+		const db = await createMemoryDb();
+		try {
+			await runMigrations(db, {
+				'001_accounts.sql': `
+					CREATE TABLE accounts (
+						id      SERIAL PRIMARY KEY,
+						owner   TEXT NOT NULL,
+						balance INTEGER NOT NULL
+					);
+				`,
+			});
+			await db.query(`
+				INSERT INTO accounts (owner, balance) VALUES ('Ada', 100), ('Alan', 250), ('Grace', 400)
+			`);
+			const original = await db.query<{ id: number; owner: string; balance: number }>(
+				'SELECT id, owner, balance FROM accounts ORDER BY id',
+			);
+
+			// A migration that performs a real data mutation, then fails. The whole
+			// thing must roll back as one unit — no half-applied state.
+			await expect(
+				runMigrations(db, {
+					'002_bad_refactor.sql': `
+						UPDATE accounts SET balance = balance + 100;
+						ALTER TABLE accounts ADD COLUMN status TEXT;
+						THIS IS NOT VALID SQL;
+					`,
+				}),
+			).rejects.toThrow('002_bad_refactor.sql');
+
+			// The +100 update was undone — balances match the originals exactly.
+			const afterFail = await db.query<{ id: number; owner: string; balance: number }>(
+				'SELECT id, owner, balance FROM accounts ORDER BY id',
+			);
+			expect(afterFail.rows).toEqual(original.rows);
+
+			// The partial schema change was undone too.
+			const statusCol = await db.query<{ c: number }>(
+				`SELECT COUNT(*)::int AS c FROM information_schema.columns
+				 WHERE table_name = 'accounts' AND column_name = 'status'`,
+			);
+			expect(statusCol.rows[0].c).toBe(0);
+
+			// The failed migration was not recorded, so it stays pending.
+			const recorded = await db.query<{ c: number }>(
+				"SELECT COUNT(*)::int AS c FROM _migrations WHERE filename = '002_bad_refactor.sql'",
+			);
+			expect(recorded.rows[0].c).toBe(0);
+		} finally {
+			await safeClose(db);
+		}
+	});
+});

--- a/packages/server/test/migrate-runner.test.ts
+++ b/packages/server/test/migrate-runner.test.ts
@@ -1,0 +1,165 @@
+import { existsSync, mkdtempSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { openPersistentDb } from '../src/db/client';
+import { type Migration, runMigrations } from '../src/db/migrate';
+import { DbNewerThanAppError, MigrationFailedError } from '../src/db/migrate-errors';
+import { applyPendingMigrations } from '../src/db/migrate-runner';
+import { safeClose } from './helpers';
+
+// HID-188: end-to-end coverage for applyPendingMigrations — the startup
+// orchestrator that protects user data across upgrades. An existing instance is
+// migrated against a COPY of pgdata, swapped in only on success; on failure the
+// original is left untouched (so a downgraded binary just runs). It also refuses
+// to run against a data dir carrying migrations the binary doesn't recognize.
+
+const V1: Migration =
+	'CREATE TABLE posts (id INTEGER PRIMARY KEY, title TEXT NOT NULL, author TEXT NOT NULL);';
+
+// A real refactor: extract authors into their own table + FK, preserving data.
+const V2_EXTRACT_AUTHORS: Migration = `
+	CREATE TABLE authors (id SERIAL PRIMARY KEY, name TEXT NOT NULL UNIQUE);
+	INSERT INTO authors (name) SELECT DISTINCT author FROM posts;
+	ALTER TABLE posts ADD COLUMN author_id INTEGER;
+	UPDATE posts p SET author_id = a.id FROM authors a WHERE a.name = p.author;
+	ALTER TABLE posts ALTER COLUMN author_id SET NOT NULL;
+	ALTER TABLE posts ADD CONSTRAINT posts_author_fk FOREIGN KEY (author_id) REFERENCES authors (id);
+	ALTER TABLE posts DROP COLUMN author;
+`;
+
+describe('applyPendingMigrations', () => {
+	const dirs: string[] = [];
+	afterEach(() => {
+		for (const d of dirs) rmSync(d, { recursive: true, force: true });
+		dirs.length = 0;
+	});
+
+	function tempDir(): string {
+		const d = mkdtempSync(join(tmpdir(), 'hezo-mig-runner-'));
+		dirs.push(d);
+		return d;
+	}
+
+	async function seedExistingInstance(dir: string): Promise<void> {
+		const db = await openPersistentDb(dir);
+		await runMigrations(db, { '001_posts.sql': V1 });
+		await db.query(
+			"INSERT INTO posts (id, title, author) VALUES (1, 'A', 'Ada'), (2, 'B', 'Alan'), (3, 'C', 'Ada')",
+		);
+		await safeClose(db);
+	}
+
+	it('copy-migrate-swaps an existing instance and preserves data', async () => {
+		const dir = tempDir();
+		await seedExistingInstance(dir);
+
+		let db = await openPersistentDb(dir);
+		db = await applyPendingMigrations(db, dir, {
+			'001_posts.sql': V1,
+			'002_extract_authors.sql': V2_EXTRACT_AUTHORS,
+		});
+		try {
+			// Data survived the refactor through the swapped-in copy.
+			const joined = await db.query<{ title: string; name: string }>(
+				'SELECT p.title, a.name FROM posts p JOIN authors a ON a.id = p.author_id ORDER BY p.id',
+			);
+			expect(joined.rows).toEqual([
+				{ title: 'A', name: 'Ada' },
+				{ title: 'B', name: 'Alan' },
+				{ title: 'C', name: 'Ada' },
+			]);
+			// Temp copy cleaned up; previous pgdata kept aside.
+			expect(existsSync(join(dir, '.migrate-tmp'))).toBe(false);
+			expect(existsSync(join(dir, 'pgdata'))).toBe(true);
+			expect(readdirSync(dir).some((e) => e.startsWith('pgdata.superseded.'))).toBe(true);
+		} finally {
+			await safeClose(db);
+		}
+	});
+
+	it('leaves the original database untouched when a migration fails', async () => {
+		const dir = tempDir();
+		await seedExistingInstance(dir);
+
+		const db = await openPersistentDb(dir);
+		await expect(
+			applyPendingMigrations(db, dir, {
+				'001_posts.sql': V1,
+				'002_bad.sql': 'THIS IS NOT VALID SQL;',
+			}),
+		).rejects.toBeInstanceOf(MigrationFailedError);
+
+		// applyPendingMigrations closed the handle it was given; reopen the dir and
+		// confirm the original schema + data are exactly as before.
+		expect(existsSync(join(dir, '.migrate-tmp'))).toBe(false);
+		const reopened = await openPersistentDb(dir);
+		try {
+			const rows = await reopened.query<{ id: number; title: string; author: string }>(
+				'SELECT id, title, author FROM posts ORDER BY id',
+			);
+			expect(rows.rows).toEqual([
+				{ id: 1, title: 'A', author: 'Ada' },
+				{ id: 2, title: 'B', author: 'Alan' },
+				{ id: 3, title: 'C', author: 'Ada' },
+			]);
+			const applied = await reopened.query<{ filename: string }>(
+				'SELECT filename FROM _migrations ORDER BY id',
+			);
+			expect(applied.rows.map((r) => r.filename)).toEqual(['001_posts.sql']);
+		} finally {
+			await safeClose(reopened);
+		}
+	});
+
+	it('migrates a fresh install in place (no copy)', async () => {
+		const dir = tempDir();
+		const db = await openPersistentDb(dir);
+		try {
+			const returned = await applyPendingMigrations(db, dir, { '001_posts.sql': V1 });
+			expect(returned).toBe(db); // same handle — no swap
+			await returned.query("INSERT INTO posts (id, title, author) VALUES (1, 'A', 'Ada')");
+			expect(existsSync(join(dir, '.migrate-tmp'))).toBe(false);
+			expect(readdirSync(dir).some((e) => e.startsWith('pgdata.superseded.'))).toBe(false);
+		} finally {
+			await safeClose(db);
+		}
+	});
+
+	it('refuses to run against a DB newer than the binary', async () => {
+		const dir = tempDir();
+		// DB has 001 + 002 applied...
+		let db = await openPersistentDb(dir);
+		await runMigrations(db, {
+			'001_posts.sql': V1,
+			'002_extra.sql': 'CREATE TABLE extra (id INT);',
+		});
+		await safeClose(db);
+
+		// ...but this binary only knows 001.
+		db = await openPersistentDb(dir);
+		try {
+			await expect(applyPendingMigrations(db, dir, { '001_posts.sql': V1 })).rejects.toBeInstanceOf(
+				DbNewerThanAppError,
+			);
+			// Guard runs before any close/copy — the handle is still usable.
+			const ok = await db.query<{ one: number }>('SELECT 1 AS one');
+			expect(ok.rows[0].one).toBe(1);
+		} finally {
+			await safeClose(db);
+		}
+	});
+
+	it('is a no-op when nothing is pending', async () => {
+		const dir = tempDir();
+		await seedExistingInstance(dir);
+		const db = await openPersistentDb(dir);
+		try {
+			const returned = await applyPendingMigrations(db, dir, { '001_posts.sql': V1 });
+			expect(returned).toBe(db);
+			expect(existsSync(join(dir, '.migrate-tmp'))).toBe(false);
+		} finally {
+			await safeClose(db);
+		}
+	});
+});

--- a/packages/server/test/migrate.test.ts
+++ b/packages/server/test/migrate.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createMemoryDb } from '../src/db/client';
-import { getPendingMigrations, runMigrations } from '../src/db/migrate';
+import {
+	findUnknownAppliedMigrations,
+	getPendingMigrations,
+	runMigrations,
+} from '../src/db/migrate';
 import { safeClose } from './helpers';
 
 describe('migration runner', () => {
@@ -105,6 +109,48 @@ describe('migration runner', () => {
 				"SELECT tablename FROM pg_tables WHERE tablename = 'bad_table'",
 			);
 			expect(badTable.rows).toHaveLength(0);
+		} finally {
+			await safeClose(db);
+		}
+	});
+});
+
+describe('findUnknownAppliedMigrations', () => {
+	it('returns applied migrations the binary does not know about (newer DB)', async () => {
+		const db = await createMemoryDb();
+		try {
+			// Simulate a DB migrated by a newer binary: 001 + 002 applied...
+			await runMigrations(db, {
+				'001_a.sql': 'CREATE TABLE a (id SERIAL PRIMARY KEY);',
+				'002_b.sql': 'CREATE TABLE b (id SERIAL PRIMARY KEY);',
+			});
+			// ...but this binary only ships 001.
+			expect(
+				await findUnknownAppliedMigrations(db, { '001_a.sql': 'CREATE TABLE a (...);' }),
+			).toEqual(['002_b.sql']);
+		} finally {
+			await safeClose(db);
+		}
+	});
+
+	it('returns [] when every applied migration is known', async () => {
+		const db = await createMemoryDb();
+		try {
+			const migrations = {
+				'001_a.sql': 'CREATE TABLE a (id SERIAL PRIMARY KEY);',
+				'002_b.sql': 'CREATE TABLE b (id SERIAL PRIMARY KEY);',
+			};
+			await runMigrations(db, migrations);
+			expect(await findUnknownAppliedMigrations(db, migrations)).toEqual([]);
+		} finally {
+			await safeClose(db);
+		}
+	});
+
+	it('returns [] for a brand-new DB with no _migrations table', async () => {
+		const db = await createMemoryDb();
+		try {
+			expect(await findUnknownAppliedMigrations(db, { '001_a.sql': 'SELECT 1;' })).toEqual([]);
 		} finally {
 			await safeClose(db);
 		}


### PR DESCRIPTION
## HID-188 — Real tracked database migrations

Closes [HID-188](https://linear.app/hiddentao/issue/HID-188). Started as "thorough end-to-end migration testing" and grew into retiring the pre-v1 "edit `001` in place + reset" policy in favour of **real, tracked, append-only migrations** that preserve user data across upgrades.

### What changed

**1. Copy-migrate-swap (`src/db/migrate-runner.ts`, `src/db/migrate-swap.ts`)**
On startup an existing instance is migrated against a **copy** of `pgdata` and atomically swapped in only on full success. On failure the live `pgdata` is left untouched, so a downgraded binary just runs against it — no manual restore. Fresh installs migrate in place (nothing to protect). The prior `pgdata` is kept aside (`pgdata.superseded.*`, pruned to 5).

**2. Newer-DB guard (`findUnknownAppliedMigrations`)**
If the data dir carries migrations this binary doesn't recognize (a downgrade), the server **exits** and asks the operator to upgrade, instead of running half-broken.

**3. Code-step migrations (`src/db/migrate.ts`, `src/db/migrations/code/`)**
A migration can be a SQL string **or** a `{ run(db) }` JS step, run in the same per-migration transaction (atomic rollback), for data transforms SQL can't express (parse/re-encode/re-encrypt). A TS registry compiles code migrations into the binary so they ship in real releases.

**4. Startup wiring (`src/startup.ts`, `src/index.ts`)**
Migration runs return the (possibly reopened) DB handle, threaded to every consumer. The automatic pre-migration tarball backup is dropped (copy-swap supersedes it); `backupDataDir`/`restoreDataDir`/`hezo restore` stay for manual snapshots. `DbNewerThanAppError`/`MigrationFailedError` exit(1) with operator guidance.

**5. Policy + first migration**
`AGENTS.md` rewritten: `001` is the frozen baseline, schema changes are new `NNN_*.sql` files, code transforms go in the registry. `002_migration_smoke.sql` is an idempotent placeholder so the release→new-binary upgrade exercises a real delta.

### Tests
- `migrate-data-preservation.test.ts` — SQL refactors (table split + FK, 1:N→M:N, column split) preserve data; rollback safety.
- `migrate-code-steps.test.ts` — JS transform preserves data; throw mid-transform rolls back; SQL/code interleave in order + idempotent.
- `migrate-runner.test.ts` — copy-swap success/failure, fresh-install, newer-DB guard, no-op — against real on-disk databases.
- `migrate.test.ts` — `findUnknownAppliedMigrations`.

### Verification
`bunx vitest run test/migrate*.test.ts test/db-backup.test.ts test/startup.test.ts` → 27 passed, quiet log. `bun run typecheck` + Biome clean; `bun run build` embeds both migrations + the code registry. (Pre-existing `git.test.ts`/`ssh-agent-server.test.ts` failures are sandbox-env issues — no `git worktree`/`ssh-keygen` — untouched by this change.)

### Manual upgrade test (operator)
Deploy an official release, upgrade to this binary → `002` applies on first start via copy-swap, data preserved; running the old binary against the upgraded dir confirms the newer-DB guard exits with the upgrade message.

https://claude.ai/code/session_015X8ThizC89NWdBUR7JS3GK