### PR TITLE
feat: chatbox memory document + chatbox settings page (HID-194)

### DIFF
--- a/packages/server/src/lib/system-meta.ts
+++ b/packages/server/src/lib/system-meta.ts
@@ -1,4 +1,9 @@
 import type { PGlite } from '@electric-sql/pglite';
+import {
+	CHAT_HISTORY_LIMIT_MAX,
+	CHAT_HISTORY_LIMIT_MIN,
+	DEFAULT_CHAT_HISTORY_LIMIT,
+} from '@hezo/shared';
 
 /**
  * Instance-wide key-value settings stored in the `system_meta` table (the same
@@ -6,6 +11,7 @@ import type { PGlite } from '@electric-sql/pglite';
  */
 
 export const INSTANCE_BASE_URL_KEY = 'instance_base_url';
+export const CHAT_HISTORY_LIMIT_KEY = 'chat_history_limit';
 
 export async function getSystemMeta(db: PGlite, key: string): Promise<string | null> {
 	const result = await db.query<{ value: string }>('SELECT value FROM system_meta WHERE key = $1', [
@@ -24,6 +30,34 @@ export async function setSystemMeta(db: PGlite, key: string, value: string): Pro
 
 export async function deleteSystemMeta(db: PGlite, key: string): Promise<void> {
 	await db.query('DELETE FROM system_meta WHERE key = $1', [key]);
+}
+
+/**
+ * Clamp an arbitrary number to the allowed chat-history-window range. Exported
+ * so the settings route validates with the same bounds the reader enforces.
+ */
+export function clampChatHistoryLimit(value: number): number {
+	if (!Number.isFinite(value)) return DEFAULT_CHAT_HISTORY_LIMIT;
+	return Math.min(CHAT_HISTORY_LIMIT_MAX, Math.max(CHAT_HISTORY_LIMIT_MIN, Math.round(value)));
+}
+
+/**
+ * How many recent chatbox messages to replay into each turn's prompt. Falls
+ * back to the default when unset or malformed, and clamps stored values to the
+ * allowed range so a stale out-of-bounds row can never blow up a turn.
+ */
+export async function getChatHistoryLimit(db: PGlite): Promise<number> {
+	const raw = await getSystemMeta(db, CHAT_HISTORY_LIMIT_KEY);
+	if (raw === null) return DEFAULT_CHAT_HISTORY_LIMIT;
+	const parsed = Number.parseInt(raw, 10);
+	if (Number.isNaN(parsed)) return DEFAULT_CHAT_HISTORY_LIMIT;
+	return clampChatHistoryLimit(parsed);
+}
+
+export async function setChatHistoryLimit(db: PGlite, value: number): Promise<number> {
+	const clamped = clampChatHistoryLimit(value);
+	await setSystemMeta(db, CHAT_HISTORY_LIMIT_KEY, String(clamped));
+	return clamped;
 }
 
 /**

--- a/packages/server/src/routes/instance-settings.ts
+++ b/packages/server/src/routes/instance-settings.ts
@@ -1,10 +1,13 @@
+import { CHAT_HISTORY_LIMIT_MAX, CHAT_HISTORY_LIMIT_MIN } from '@hezo/shared';
 import { Hono } from 'hono';
 import { err, ok } from '../lib/response';
 import {
 	deleteSystemMeta,
+	getChatHistoryLimit,
 	getInstanceBaseUrl,
 	INSTANCE_BASE_URL_KEY,
 	normalizeBaseUrl,
+	setChatHistoryLimit,
 	setSystemMeta,
 } from '../lib/system-meta';
 import type { Env } from '../lib/types';
@@ -15,8 +18,10 @@ export const instanceSettingsRoutes = new Hono<Env>();
 // Instance-wide settings. Readable by any authenticated principal (the same
 // openness as GET /api/ai-providers); writes are superuser-only.
 instanceSettingsRoutes.get('/instance-settings', async (c) => {
-	const base_url = await getInstanceBaseUrl(c.get('db'));
-	return ok(c, { base_url });
+	const db = c.get('db');
+	const base_url = await getInstanceBaseUrl(db);
+	const chat_history_limit = await getChatHistoryLimit(db);
+	return ok(c, { base_url, chat_history_limit });
 });
 
 instanceSettingsRoutes.patch('/instance-settings', async (c) => {
@@ -25,28 +30,49 @@ instanceSettingsRoutes.patch('/instance-settings', async (c) => {
 
 	const db = c.get('db');
 	const body = await c.req
-		.json<{ base_url?: unknown }>()
-		.catch(() => ({}) as { base_url?: unknown });
+		.json<{ base_url?: unknown; chat_history_limit?: unknown }>()
+		.catch(() => ({}) as { base_url?: unknown; chat_history_limit?: unknown });
 
-	if (!('base_url' in body)) {
-		return err(c, 'INVALID_REQUEST', 'base_url is required', 400);
+	if (!('base_url' in body) && !('chat_history_limit' in body)) {
+		return err(c, 'INVALID_REQUEST', 'base_url or chat_history_limit is required', 400);
 	}
-	if (body.base_url === null || body.base_url === '') {
-		await deleteSystemMeta(db, INSTANCE_BASE_URL_KEY);
-		return ok(c, { base_url: null });
+
+	if ('chat_history_limit' in body) {
+		const value = body.chat_history_limit;
+		if (typeof value !== 'number' || !Number.isInteger(value)) {
+			return err(c, 'INVALID_REQUEST', 'chat_history_limit must be an integer', 400);
+		}
+		if (value < CHAT_HISTORY_LIMIT_MIN || value > CHAT_HISTORY_LIMIT_MAX) {
+			return err(
+				c,
+				'INVALID_REQUEST',
+				`chat_history_limit must be between ${CHAT_HISTORY_LIMIT_MIN} and ${CHAT_HISTORY_LIMIT_MAX}`,
+				400,
+			);
+		}
+		await setChatHistoryLimit(db, value);
 	}
-	if (typeof body.base_url !== 'string') {
-		return err(c, 'INVALID_REQUEST', 'base_url must be a string or null', 400);
+
+	if ('base_url' in body) {
+		if (body.base_url === null || body.base_url === '') {
+			await deleteSystemMeta(db, INSTANCE_BASE_URL_KEY);
+		} else if (typeof body.base_url !== 'string') {
+			return err(c, 'INVALID_REQUEST', 'base_url must be a string or null', 400);
+		} else {
+			const normalized = normalizeBaseUrl(body.base_url.trim());
+			if (!normalized) {
+				return err(
+					c,
+					'INVALID_REQUEST',
+					'base_url must be an http(s) origin without path, query, or fragment',
+					400,
+				);
+			}
+			await setSystemMeta(db, INSTANCE_BASE_URL_KEY, normalized);
+		}
 	}
-	const normalized = normalizeBaseUrl(body.base_url.trim());
-	if (!normalized) {
-		return err(
-			c,
-			'INVALID_REQUEST',
-			'base_url must be an http(s) origin without path, query, or fragment',
-			400,
-		);
-	}
-	await setSystemMeta(db, INSTANCE_BASE_URL_KEY, normalized);
-	return ok(c, { base_url: normalized });
+
+	const base_url = await getInstanceBaseUrl(db);
+	const chat_history_limit = await getChatHistoryLimit(db);
+	return ok(c, { base_url, chat_history_limit });
 });

--- a/packages/server/src/routes/project-docs.ts
+++ b/packages/server/src/routes/project-docs.ts
@@ -1,6 +1,8 @@
 import {
 	ApprovalType,
 	AuthType,
+	CHAT_MEMORY_SLUG,
+	DEFAULT_TEAM_ID,
 	DocumentType,
 	isMarkdownDocSlug,
 	repoNameFromIdentifier,
@@ -133,6 +135,12 @@ projectDocsRoutes.delete('/projects/:projectId/docs/:filename', async (c) => {
 	const filename = c.req.param('filename');
 	const projectId = await resolveProjectId(db, teamId, c.req.param('projectId'));
 	if (!projectId) return err(c, 'NOT_FOUND', 'Project not found', 404);
+
+	// The chatbox memory doc lives only in the HQ project (the default team) and
+	// is permanent — block deletion by any principal.
+	if (teamId === DEFAULT_TEAM_ID && filename === CHAT_MEMORY_SLUG) {
+		return err(c, 'FORBIDDEN', `'${filename}' is the chatbox memory and cannot be deleted`, 403);
+	}
 
 	const actorMemberId = await resolveActorMemberId(db, c.get('auth'), teamId);
 	const removed = await deleteDocument(

--- a/packages/server/src/services/ceo-session-manager.ts
+++ b/packages/server/src/services/ceo-session-manager.ts
@@ -9,12 +9,15 @@ import {
 	CeoMessageRole,
 	CeoMessageStatus,
 	CeoSessionStatus,
+	CHAT_MEMORY_SLUG,
 	DEFAULT_TEAM_ID,
+	DocumentType,
 	PROVIDER_RUNTIME_ADAPTERS,
 	WsMessageType,
 	wsRoom,
 } from '@hezo/shared';
 import { trackBackground } from '../lib/background';
+import { getChatHistoryLimit } from '../lib/system-meta';
 import { logger } from '../logger';
 import { signCeoSessionJwt } from '../middleware/auth';
 import {
@@ -30,7 +33,7 @@ import {
 	createAgentChatParser,
 } from './agent-stream-parser';
 import { getProviderCredentialAndModel } from './ai-provider-keys';
-import { getAgentSystemPrompt } from './documents';
+import { getAgentSystemPrompt, getDocument } from './documents';
 import { applyEffortToRuntime, type EffortRuntimeApplication } from './effort';
 import { resolveRuntimeForTask } from './runtime-resolver';
 import type { BridgeRunnerArgs } from './ssh-agent';
@@ -42,8 +45,6 @@ const log = logger.child('ceo-session');
 
 /** Container working directory for the (repo-free) chat session. */
 const CHAT_WORKING_DIR = '/workspace';
-/** How many recent messages to replay into each turn's prompt. */
-const HISTORY_LIMIT = 80;
 /** How often to verify the live session's container is still healthy. */
 const HEALTH_INTERVAL_MS = Number(process.env.HEZO_CEO_HEALTH_INTERVAL_MS ?? 10_000);
 
@@ -53,7 +54,29 @@ You are in a real-time chat with the operator — the human running this Hezo in
 
 Because you roam across every project here, there is **no per-project "Project State" block in your context** — its open-ticket count in the roster is a summary only. To report a project's live status (its actual tickets and their statuses, or its roster), call \`list_tasks\` / \`list_agents\` with that project's slug as the \`project\` argument. Never tell the operator a project is empty off the roster count alone — check with the tools first.
 
-Because this chat is human-facing, refer to projects, tickets, teams, docs, and teammates by their bare slug, identifier, or name (e.g. the project todo6, ticket TO-1, prd.md, @@captain) — never paste raw UUIDs. Tools accept the same slugs and identifiers you use with the operator, so you never need a UUID. Write entity references bare, never wrapped in backticks: bare references render as clickable links in the chat, while backticked ones render as inert code and break the link. Keep replies focused and skip ceremony.`;
+Because this chat is human-facing, refer to projects, tickets, teams, docs, and teammates by their bare slug, identifier, or name (e.g. the project todo6, ticket TO-1, prd.md, @@captain) — never paste raw UUIDs. Tools accept the same slugs and identifiers you use with the operator, so you never need a UUID. Write entity references bare, never wrapped in backticks: bare references render as clickable links in the chat, while backticked ones render as inert code and break the link. Keep replies focused and skip ceremony.
+
+## Chatbox memory
+
+Your context carries a **Chatbox memory** block (below the guide, above the conversation). It is the persisted contents of \`chat-memory.md\` in the hq project, injected in full on every turn, so anything recorded there survives once older messages scroll out of the conversation window.
+
+Use it for **durable, standing knowledge only**:
+
+- **Record:** operator preferences and guidelines (how they like things done, tone, defaults, recurring decisions), and **anything the operator explicitly asks you to remember** — record that regardless of what it is.
+- **Do NOT record:** live data you can already fetch each turn — project/ticket/comment contents or status, rosters, counts, or any metadata about them. That is rebuilt into your context from the live database every turn; copying it into memory only goes stale. The roster and the tools are the source of truth for state, not this memory.
+
+When something belongs in memory, update it by **rewriting the whole document via \`write_project_doc\` (project: hq, filename: chat-memory.md)** — read the current memory block, merge the new fact in, and write the full result back. Do not blindly append; keep it short, curated, and free of stale entries. There is no separate "remember" tool — \`write_project_doc\` is how you maintain it.`;
+
+/**
+ * Render the persistent chatbox-memory data block injected into every turn. The
+ * curation rules live in CHAT_GUIDE; this is just the current contents (or a
+ * placeholder when empty so the agent knows the facility exists).
+ */
+export function formatChatMemoryBlock(content: string): string {
+	const trimmed = content.trim();
+	const body = trimmed === '' ? '_(nothing recorded yet)_' : trimmed;
+	return `## Chatbox memory\n\nPersisted across the conversation (from ${CHAT_MEMORY_SLUG} in hq). Maintain it with write_project_doc — see the guidance above.\n\n${body}`;
+}
 
 export interface CeoSessionDeps extends RunnerDeps {
 	wsManager: WebSocketManager;
@@ -473,11 +496,19 @@ export class CeoSessionManager {
 			crossTeam: true,
 		});
 
+		const memoryDoc = await getDocument(this.deps.db, {
+			type: DocumentType.ProjectDoc,
+			teamId: DEFAULT_TEAM_ID,
+			projectId: session.projectId,
+			slug: CHAT_MEMORY_SLUG,
+		});
+
+		const historyLimit = await getChatHistoryLimit(this.deps.db);
 		const history = await this.deps.db.query<CeoMessageRow>(
 			`SELECT id, role, channel, status, content, created_at FROM ceo_messages
 			 WHERE conversation_id = $1 AND id != $2
 			 ORDER BY created_at DESC LIMIT $3`,
-			[session.conversationId, excludeMessageId, HISTORY_LIMIT],
+			[session.conversationId, excludeMessageId, historyLimit],
 		);
 		const transcript = history.rows
 			.reverse()
@@ -489,6 +520,7 @@ export class CeoSessionManager {
 			resolved,
 			session.promptDirective ?? '',
 			CHAT_GUIDE,
+			formatChatMemoryBlock(memoryDoc?.content ?? ''),
 			'## Conversation so far',
 			transcript,
 			'Reply to the latest operator message as the CEO.',

--- a/packages/server/src/services/teams.ts
+++ b/packages/server/src/services/teams.ts
@@ -1,5 +1,6 @@
 import type { PGlite } from '@electric-sql/pglite';
 import {
+	CHAT_MEMORY_SLUG,
 	DEFAULT_TEAM_ID,
 	DEFAULT_TEAM_NAME,
 	DEFAULT_TEAM_SLUG,
@@ -176,6 +177,11 @@ export async function seedDefaultTeam(deps: CreateTeamDeps): Promise<void> {
 		return projectResult.rows[0].id;
 	});
 
+	// The chatbox memory doc lives in the HQ project. Ensure it exists rather than
+	// assuming it — startup also calls this so instances created before this
+	// feature self-heal.
+	await ensureChatMemoryDoc(db);
+
 	await ensureInstanceCeo(db, DEFAULT_TEAM_ID);
 	await ensureInstanceCoach(db, DEFAULT_TEAM_ID);
 
@@ -206,4 +212,29 @@ export async function seedDefaultTeam(deps: CreateTeamDeps): Promise<void> {
 	}
 
 	log.info(`Seeded HQ team (${DEFAULT_TEAM_SLUG}) with CEO + Coach`);
+}
+
+/**
+ * Ensure the chatbox memory doc (chat-memory.md) exists in the HQ project. A
+ * single undeletable project_doc whose full body is injected into every chatbox
+ * turn, seeded empty. Idempotent and called on every startup so instances
+ * created before this feature — or any where it was removed — self-heal.
+ */
+export async function ensureChatMemoryDoc(db: PGlite): Promise<void> {
+	const proj = await db.query<{ id: string }>(
+		'SELECT id FROM projects WHERE team_id = $1 AND is_internal = true',
+		[DEFAULT_TEAM_ID],
+	);
+	const projectId = proj.rows[0]?.id;
+	if (!projectId) return;
+	const existing = await db.query(
+		"SELECT 1 FROM documents WHERE project_id = $1 AND slug = $2 AND type = 'project_doc'",
+		[projectId, CHAT_MEMORY_SLUG],
+	);
+	if (existing.rows.length > 0) return;
+	await db.query(
+		`INSERT INTO documents (project_id, team_id, type, slug, title, content)
+		 VALUES ($1, $2, 'project_doc', $3, 'Chatbox memory', '')`,
+		[projectId, DEFAULT_TEAM_ID, CHAT_MEMORY_SLUG],
+	);
 }

--- a/packages/server/src/services/template-resolver.ts
+++ b/packages/server/src/services/template-resolver.ts
@@ -1,4 +1,5 @@
 import type { PGlite } from '@electric-sql/pglite';
+import { CHAT_MEMORY_SLUG } from '@hezo/shared';
 import { terminalStatusParams } from '../lib/sql';
 
 interface ResolveContext {
@@ -195,9 +196,12 @@ export async function resolveSystemPrompt(
 	if (resolved.includes('{{project_docs_context}}')) {
 		let docsText = 'No project documentation available.';
 		if (ctx.projectId) {
+			// chat-memory.md (HQ) is injected in full into the chatbox prompt, so it
+			// is excluded from the manifest — listing it would tell the agent to
+			// read_project_doc something it already has verbatim.
 			const docs = await db.query<{ filename: string; title: string; updated_at: string }>(
-				"SELECT slug AS filename, title, updated_at FROM documents WHERE type = 'project_doc' AND project_id = $1 ORDER BY slug",
-				[ctx.projectId],
+				"SELECT slug AS filename, title, updated_at FROM documents WHERE type = 'project_doc' AND project_id = $1 AND slug != $2 ORDER BY slug",
+				[ctx.projectId, CHAT_MEMORY_SLUG],
 			);
 			if (docs.rows.length > 0) {
 				const lines = docs.rows

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -154,7 +154,7 @@ export async function startup(config: HezoConfig): Promise<StartupResult> {
 		egressCAPath: egressCA.certPath,
 	});
 
-	const { seedDefaultTeam } = await import('./services/teams.js');
+	const { seedDefaultTeam, ensureChatMemoryDoc } = await import('./services/teams.js');
 	try {
 		await seedDefaultTeam({
 			db,
@@ -166,6 +166,9 @@ export async function startup(config: HezoConfig): Promise<StartupResult> {
 			dataDir: config.dataDir,
 			egressCAPath: egressCA.certPath,
 		});
+		// Self-heal: instances created before the chatbox memory doc existed (or
+		// where it was removed) get it back. Idempotent.
+		await ensureChatMemoryDoc(db);
 	} catch (err) {
 		log.error('Failed to seed default team:', err);
 	}

--- a/packages/server/test/chat-memory.test.ts
+++ b/packages/server/test/chat-memory.test.ts
@@ -1,0 +1,234 @@
+import type { PGlite } from '@electric-sql/pglite';
+import {
+	CHAT_HISTORY_LIMIT_MAX,
+	CHAT_HISTORY_LIMIT_MIN,
+	CHAT_MEMORY_SLUG,
+	DEFAULT_CHAT_HISTORY_LIMIT,
+	DEFAULT_TEAM_ID,
+	HQ_PROJECT_SLUG,
+} from '@hezo/shared';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+	clampChatHistoryLimit,
+	getChatHistoryLimit,
+	setChatHistoryLimit,
+} from '../src/lib/system-meta';
+import type { Env } from '../src/lib/types';
+import { signAdminJwt } from '../src/middleware/auth';
+import { formatChatMemoryBlock } from '../src/services/ceo-session-manager';
+import { ensureChatMemoryDoc } from '../src/services/teams';
+import { resolveSystemPrompt } from '../src/services/template-resolver';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp } from './helpers/app';
+
+let app: Hono<Env>;
+let db: PGlite;
+let token: string;
+let nonSuperuserToken: string;
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+
+	const nonAdmin = await db.query<{ id: string }>(
+		"INSERT INTO users (display_name, is_superuser) VALUES ('Regular Admin', false) RETURNING id",
+	);
+	nonSuperuserToken = await signAdminJwt(ctx.masterKeyManager, nonAdmin.rows[0].id);
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+async function hqProjectId(): Promise<string> {
+	const r = await db.query<{ id: string }>(
+		'SELECT id FROM projects WHERE team_id = $1 AND is_internal = true',
+		[DEFAULT_TEAM_ID],
+	);
+	return r.rows[0].id;
+}
+
+describe('chat-memory seeding', () => {
+	it('seeds an empty chat-memory.md project_doc in the HQ project', async () => {
+		const r = await db.query<{ content: string; title: string; type: string }>(
+			'SELECT content, title, type FROM documents WHERE project_id = $1 AND slug = $2',
+			[await hqProjectId(), CHAT_MEMORY_SLUG],
+		);
+		expect(r.rows).toHaveLength(1);
+		expect(r.rows[0].type).toBe('project_doc');
+		expect(r.rows[0].content).toBe('');
+		expect(r.rows[0].title).toBe('Chatbox memory');
+	});
+});
+
+describe('ensureChatMemoryDoc', () => {
+	it('recreates the doc if it is missing and is idempotent', async () => {
+		const projectId = await hqProjectId();
+		// Simulate an instance that predates the feature.
+		await db.query('DELETE FROM documents WHERE project_id = $1 AND slug = $2', [
+			projectId,
+			CHAT_MEMORY_SLUG,
+		]);
+		await ensureChatMemoryDoc(db);
+		await ensureChatMemoryDoc(db);
+		const r = await db.query('SELECT 1 FROM documents WHERE project_id = $1 AND slug = $2', [
+			projectId,
+			CHAT_MEMORY_SLUG,
+		]);
+		expect(r.rows).toHaveLength(1);
+	});
+});
+
+describe('formatChatMemoryBlock', () => {
+	it('renders the content under a Chatbox memory heading', () => {
+		const block = formatChatMemoryBlock('- Operator prefers terse replies');
+		expect(block).toContain('## Chatbox memory');
+		expect(block).toContain('- Operator prefers terse replies');
+		expect(block).toContain(CHAT_MEMORY_SLUG);
+	});
+
+	it('shows a placeholder when empty so the agent knows the facility exists', () => {
+		const block = formatChatMemoryBlock('   ');
+		expect(block).toContain('## Chatbox memory');
+		expect(block).toContain('nothing recorded yet');
+	});
+});
+
+describe('chat-memory manifest exclusion', () => {
+	it('omits chat-memory.md from the HQ {{project_docs_context}} manifest', async () => {
+		const projectId = await hqProjectId();
+		// Seed a normal HQ doc so the manifest is non-empty and we can prove the
+		// reserved doc is the only thing excluded.
+		await db.query(
+			`INSERT INTO documents (project_id, team_id, type, slug, title, content)
+			 VALUES ($1, $2, 'project_doc', 'notes.md', 'Notes', '# Notes')`,
+			[projectId, DEFAULT_TEAM_ID],
+		);
+		const resolved = await resolveSystemPrompt(db, '{{project_docs_context}}', {
+			teamId: DEFAULT_TEAM_ID,
+			projectId,
+		});
+		expect(resolved).toContain('notes.md');
+		expect(resolved).not.toContain(CHAT_MEMORY_SLUG);
+	});
+});
+
+describe('chat-memory delete guard', () => {
+	it('rejects deleting chat-memory.md from the HQ project (403)', async () => {
+		const res = await app.request(`/api/projects/${HQ_PROJECT_SLUG}/docs/${CHAT_MEMORY_SLUG}`, {
+			method: 'DELETE',
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(403);
+		expect((await res.json()).error.code).toBe('FORBIDDEN');
+		// Still present afterwards.
+		const r = await db.query('SELECT 1 FROM documents WHERE project_id = $1 AND slug = $2', [
+			await hqProjectId(),
+			CHAT_MEMORY_SLUG,
+		]);
+		expect(r.rows).toHaveLength(1);
+	});
+
+	it('allows deleting a normal doc from the HQ project', async () => {
+		await app.request(`/api/projects/${HQ_PROJECT_SLUG}/docs/scratch.md`, {
+			method: 'PUT',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ content: '# scratch' }),
+		});
+		const res = await app.request(`/api/projects/${HQ_PROJECT_SLUG}/docs/scratch.md`, {
+			method: 'DELETE',
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+	});
+
+	it('does not guard a same-named doc in a non-HQ project', async () => {
+		const teamRes = await app.request('/api/teams', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name: 'Other Co' }),
+		});
+		const teamSlug = (await teamRes.json()).data.slug as string;
+		const projRes = await app.request('/api/projects', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ team: teamSlug, name: 'Side Project', description: 'x'.repeat(20) }),
+		});
+		const projectSlug = (await projRes.json()).data.slug as string;
+		await app.request(`/api/projects/${projectSlug}/docs/${CHAT_MEMORY_SLUG}`, {
+			method: 'PUT',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ content: '# not the reserved one' }),
+		});
+		const res = await app.request(`/api/projects/${projectSlug}/docs/${CHAT_MEMORY_SLUG}`, {
+			method: 'DELETE',
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+	});
+});
+
+describe('chat history limit setting', () => {
+	it('falls back to the default when unset', async () => {
+		expect(await getChatHistoryLimit(db)).toBe(DEFAULT_CHAT_HISTORY_LIMIT);
+	});
+
+	it('clamps stored values to the allowed range', () => {
+		expect(clampChatHistoryLimit(5)).toBe(CHAT_HISTORY_LIMIT_MIN);
+		expect(clampChatHistoryLimit(10_000)).toBe(CHAT_HISTORY_LIMIT_MAX);
+		expect(clampChatHistoryLimit(120)).toBe(120);
+	});
+
+	it('reads back a stored value', async () => {
+		await setChatHistoryLimit(db, 150);
+		expect(await getChatHistoryLimit(db)).toBe(150);
+	});
+
+	it('GET /api/instance-settings returns the chat_history_limit', async () => {
+		const res = await app.request('/api/instance-settings', { headers: authHeader(token) });
+		expect(res.status).toBe(200);
+		expect((await res.json()).data.chat_history_limit).toBe(150);
+	});
+
+	it('PATCH (superuser) updates the chat_history_limit and echoes it', async () => {
+		const res = await app.request('/api/instance-settings', {
+			method: 'PATCH',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ chat_history_limit: 42 }),
+		});
+		expect(res.status).toBe(200);
+		expect((await res.json()).data.chat_history_limit).toBe(42);
+		expect(await getChatHistoryLimit(db)).toBe(42);
+	});
+
+	it('rejects a non-superuser PATCH', async () => {
+		const res = await app.request('/api/instance-settings', {
+			method: 'PATCH',
+			headers: { ...authHeader(nonSuperuserToken), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ chat_history_limit: 99 }),
+		});
+		expect(res.status).toBe(403);
+	});
+
+	it('rejects an out-of-range chat_history_limit', async () => {
+		const res = await app.request('/api/instance-settings', {
+			method: 'PATCH',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ chat_history_limit: 9999 }),
+		});
+		expect(res.status).toBe(400);
+		expect((await res.json()).error.code).toBe('INVALID_REQUEST');
+	});
+
+	it('rejects a non-integer chat_history_limit', async () => {
+		const res = await app.request('/api/instance-settings', {
+			method: 'PATCH',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ chat_history_limit: 'lots' }),
+		});
+		expect(res.status).toBe(400);
+	});
+});

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -32,6 +32,23 @@ export const DEFAULT_TEAM_SLUG = 'default';
 export const DEFAULT_TEAM_NAME = 'Team';
 export const DEFAULT_TEAM_TEMPLATE_NAME = 'Blank';
 
+/**
+ * Reserved project-doc filename for the chatbox's persistent memory. A single
+ * undeletable doc seeded in the HQ project; its full contents are injected into
+ * every chatbox (CEO) turn so durable preferences survive the rolling message
+ * window. Maintained by the agent via `write_project_doc` and editable by the
+ * operator in the docs UI.
+ */
+export const CHAT_MEMORY_SLUG = 'chat-memory.md';
+
+/**
+ * How many recent chatbox messages are replayed into each turn's prompt.
+ * Operator-adjustable in global settings; clamped to [MIN, MAX].
+ */
+export const DEFAULT_CHAT_HISTORY_LIMIT = 80;
+export const CHAT_HISTORY_LIMIT_MIN = 10;
+export const CHAT_HISTORY_LIMIT_MAX = 500;
+
 export const PROJECT_INTAKE_LABEL = 'project-intake';
 export const PROJECT_INTAKE_SKIP_SIGNAL_TEXT =
 	'Admin chose to skip further questions — finalise the project proposal with what we have so far.';

--- a/packages/web/src/components/docs-library.tsx
+++ b/packages/web/src/components/docs-library.tsx
@@ -37,6 +37,8 @@ interface DocsLibraryProps {
 	getPopOutUrl?: (key: string) => string | null;
 
 	viewerExtras?: ReactNode;
+	/** Banner rendered above the selected doc (view and edit), e.g. for protected docs. */
+	viewerBanner?: ReactNode;
 
 	emptyTitle?: string;
 	emptyDescription?: string;
@@ -61,6 +63,7 @@ export function DocsLibrary({
 	newForm,
 	getPopOutUrl,
 	viewerExtras,
+	viewerBanner,
 	emptyTitle = 'No documents yet',
 	emptyDescription,
 	projectId,
@@ -182,6 +185,7 @@ export function DocsLibrary({
 					<div className="text-text-muted text-[13px] py-4">Loading...</div>
 				) : (
 					<div className="flex flex-col">
+						{viewerBanner}
 						<div className="flex items-center justify-between gap-2 mb-4 pb-3 border-b border-border-subtle">
 							<h2 className="text-base font-semibold text-text truncate">
 								{docTitle ?? selectedItem?.label ?? selectedKey}

--- a/packages/web/src/components/instance-settings-section.tsx
+++ b/packages/web/src/components/instance-settings-section.tsx
@@ -48,9 +48,9 @@ function BaseUrlForm({ settings }: { settings: InstanceSettings }) {
 	async function handleSave() {
 		setError(null);
 		try {
-			const result = await updateSettings.mutateAsync(
-				baseUrl.trim() === '' ? null : baseUrl.trim(),
-			);
+			const result = await updateSettings.mutateAsync({
+				base_url: baseUrl.trim() === '' ? null : baseUrl.trim(),
+			});
 			// Reflect the server-normalized origin (response-driven, never preempted).
 			setBaseUrl(result.base_url ?? '');
 		} catch (e) {

--- a/packages/web/src/components/project-sidebar.tsx
+++ b/packages/web/src/components/project-sidebar.tsx
@@ -69,14 +69,15 @@ export function ProjectSidebar() {
 			count: project?.open_task_count,
 			testId: 'project-sidebar-tasks',
 		},
+		// HQ (internal) exposes Documents for the chatbox memory doc, but not Assets.
+		{
+			to: '/projects/$projectId/documents',
+			params: projectParams,
+			label: 'Documents',
+		},
 		...(isInternal
 			? []
 			: [
-					{
-						to: '/projects/$projectId/documents',
-						params: projectParams,
-						label: 'Documents',
-					},
 					{
 						to: '/projects/$projectId/assets',
 						params: projectParams,

--- a/packages/web/src/hooks/use-instance-settings.ts
+++ b/packages/web/src/hooks/use-instance-settings.ts
@@ -5,7 +5,13 @@ import { queryKeys } from '../lib/query-keys';
 
 export interface InstanceSettings {
 	base_url: string | null;
+	chat_history_limit: number;
 }
+
+export type InstanceSettingsUpdate = Partial<{
+	base_url: string | null;
+	chat_history_limit: number;
+}>;
 
 export function useInstanceSettings() {
 	return useQuery({
@@ -15,13 +21,14 @@ export function useInstanceSettings() {
 }
 
 /**
- * Response-driven (not optimistic): the server validates and normalizes the
- * URL, so the cache is seeded from its echo rather than the typed value.
+ * Response-driven (not optimistic): the server validates and normalizes values,
+ * so the cache is seeded from its echo rather than the typed input. Accepts a
+ * partial patch — only the supplied fields change.
  */
 export function useUpdateInstanceSettings() {
 	return useMutation({
-		mutationFn: (base_url: string | null) =>
-			api.patch<InstanceSettings>('/api/instance-settings', { base_url }),
+		mutationFn: (update: InstanceSettingsUpdate) =>
+			api.patch<InstanceSettings>('/api/instance-settings', update),
 		onSuccess: (data) => {
 			queryClient.setQueryData(queryKeys.instanceSettings(), data);
 		},

--- a/packages/web/src/routeTree.gen.ts
+++ b/packages/web/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as HomeIndexRouteImport } from './routes/home/index'
 import { Route as SettingsSkillsRouteImport } from './routes/settings/skills'
 import { Route as SettingsCredentialsRouteImport } from './routes/settings/credentials'
 import { Route as SettingsConnectorsRouteImport } from './routes/settings/connectors'
+import { Route as SettingsChatboxRouteImport } from './routes/settings/chatbox'
 import { Route as SettingsAuditLogRouteImport } from './routes/settings/audit-log'
 import { Route as SettingsAiProvidersRouteImport } from './routes/settings/ai-providers'
 import { Route as ProjectsProjectIdRouteRouteImport } from './routes/projects/$projectId/route'
@@ -69,6 +70,11 @@ const SettingsCredentialsRoute = SettingsCredentialsRouteImport.update({
 const SettingsConnectorsRoute = SettingsConnectorsRouteImport.update({
   id: '/settings/connectors',
   path: '/settings/connectors',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SettingsChatboxRoute = SettingsChatboxRouteImport.update({
+  id: '/settings/chatbox',
+  path: '/settings/chatbox',
   getParentRoute: () => rootRouteImport,
 } as any)
 const SettingsAuditLogRoute = SettingsAuditLogRouteImport.update({
@@ -220,6 +226,7 @@ export interface FileRoutesByFullPath {
   '/projects/$projectId': typeof ProjectsProjectIdRouteRouteWithChildren
   '/settings/ai-providers': typeof SettingsAiProvidersRoute
   '/settings/audit-log': typeof SettingsAuditLogRoute
+  '/settings/chatbox': typeof SettingsChatboxRoute
   '/settings/connectors': typeof SettingsConnectorsRoute
   '/settings/credentials': typeof SettingsCredentialsRoute
   '/settings/skills': typeof SettingsSkillsRoute
@@ -252,6 +259,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/settings/ai-providers': typeof SettingsAiProvidersRoute
   '/settings/audit-log': typeof SettingsAuditLogRoute
+  '/settings/chatbox': typeof SettingsChatboxRoute
   '/settings/connectors': typeof SettingsConnectorsRoute
   '/settings/credentials': typeof SettingsCredentialsRoute
   '/settings/skills': typeof SettingsSkillsRoute
@@ -285,6 +293,7 @@ export interface FileRoutesById {
   '/projects/$projectId': typeof ProjectsProjectIdRouteRouteWithChildren
   '/settings/ai-providers': typeof SettingsAiProvidersRoute
   '/settings/audit-log': typeof SettingsAuditLogRoute
+  '/settings/chatbox': typeof SettingsChatboxRoute
   '/settings/connectors': typeof SettingsConnectorsRoute
   '/settings/credentials': typeof SettingsCredentialsRoute
   '/settings/skills': typeof SettingsSkillsRoute
@@ -320,6 +329,7 @@ export interface FileRouteTypes {
     | '/projects/$projectId'
     | '/settings/ai-providers'
     | '/settings/audit-log'
+    | '/settings/chatbox'
     | '/settings/connectors'
     | '/settings/credentials'
     | '/settings/skills'
@@ -352,6 +362,7 @@ export interface FileRouteTypes {
     | '/'
     | '/settings/ai-providers'
     | '/settings/audit-log'
+    | '/settings/chatbox'
     | '/settings/connectors'
     | '/settings/credentials'
     | '/settings/skills'
@@ -384,6 +395,7 @@ export interface FileRouteTypes {
     | '/projects/$projectId'
     | '/settings/ai-providers'
     | '/settings/audit-log'
+    | '/settings/chatbox'
     | '/settings/connectors'
     | '/settings/credentials'
     | '/settings/skills'
@@ -418,6 +430,7 @@ export interface RootRouteChildren {
   ProjectsProjectIdRouteRoute: typeof ProjectsProjectIdRouteRouteWithChildren
   SettingsAiProvidersRoute: typeof SettingsAiProvidersRoute
   SettingsAuditLogRoute: typeof SettingsAuditLogRoute
+  SettingsChatboxRoute: typeof SettingsChatboxRoute
   SettingsConnectorsRoute: typeof SettingsConnectorsRoute
   SettingsCredentialsRoute: typeof SettingsCredentialsRoute
   SettingsSkillsRoute: typeof SettingsSkillsRoute
@@ -470,6 +483,13 @@ declare module '@tanstack/react-router' {
       path: '/settings/connectors'
       fullPath: '/settings/connectors'
       preLoaderRoute: typeof SettingsConnectorsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/settings/chatbox': {
+      id: '/settings/chatbox'
+      path: '/settings/chatbox'
+      fullPath: '/settings/chatbox'
+      preLoaderRoute: typeof SettingsChatboxRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/settings/audit-log': {
@@ -724,6 +744,7 @@ const rootRouteChildren: RootRouteChildren = {
   ProjectsProjectIdRouteRoute: ProjectsProjectIdRouteRouteWithChildren,
   SettingsAiProvidersRoute: SettingsAiProvidersRoute,
   SettingsAuditLogRoute: SettingsAuditLogRoute,
+  SettingsChatboxRoute: SettingsChatboxRoute,
   SettingsConnectorsRoute: SettingsConnectorsRoute,
   SettingsCredentialsRoute: SettingsCredentialsRoute,
   SettingsSkillsRoute: SettingsSkillsRoute,

--- a/packages/web/src/routes/projects/$projectId/documents.tsx
+++ b/packages/web/src/routes/projects/$projectId/documents.tsx
@@ -1,6 +1,6 @@
-import { HQ_PROJECT_SLUG, isMarkdownDocSlug } from '@hezo/shared';
-import { createFileRoute, redirect } from '@tanstack/react-router';
-import { Loader2 } from 'lucide-react';
+import { CHAT_MEMORY_SLUG, HQ_PROJECT_SLUG, isMarkdownDocSlug } from '@hezo/shared';
+import { createFileRoute } from '@tanstack/react-router';
+import { Info, Loader2 } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { type DocItem, DocsLibrary } from '../../../components/docs-library';
 import { MentionTextarea } from '../../../components/mention-textarea';
@@ -39,6 +39,7 @@ function ProjectDocumentsPage() {
 
 	const [isCreating, setIsCreating] = useState(false);
 
+	const isHq = projectId === HQ_PROJECT_SLUG;
 	const isAgentsMd = file === AGENTS_MD_KEY;
 	const filenameForFetch = file && !isAgentsMd ? file : null;
 	const { data: doc, isLoading: isLoadingDoc } = useProjectDoc(projectId, filenameForFetch);
@@ -55,14 +56,19 @@ function ProjectDocumentsPage() {
 			});
 		}
 		for (const d of docs ?? []) {
+			// The chatbox memory doc is permanent — never offer to delete it.
+			const isChatMemory = isHq && d.filename === CHAT_MEMORY_SLUG;
 			list.push({
 				key: d.filename,
 				label: d.filename,
 				meta: `Updated ${new Date(d.updated_at).toLocaleDateString()}`,
+				canDelete: isChatMemory ? false : undefined,
 			});
 		}
 		return list;
-	}, [agentsMd, docs]);
+	}, [agentsMd, docs, isHq]);
+
+	const showChatMemoryBanner = isHq && file === CHAT_MEMORY_SLUG;
 
 	const docContent = isAgentsMd ? (agentsMd?.content ?? null) : (doc?.content ?? null);
 
@@ -130,6 +136,22 @@ function ProjectDocumentsPage() {
 			viewerExtras={
 				file && !isAgentsMd ? (
 					<ProjectDocRevisionsPanel projectId={projectId} filename={file} />
+				) : null
+			}
+			viewerBanner={
+				showChatMemoryBanner ? (
+					<div
+						data-testid="chat-memory-banner"
+						className="flex items-start gap-2 mb-4 rounded-radius-md border border-border bg-bg-subtle px-3 py-2.5 text-[13px] text-text-muted"
+					>
+						<Info className="w-4 h-4 mt-0.5 shrink-0 text-text-subtle" aria-hidden="true" />
+						<span>
+							This is the chatbox's persistent memory. Its full contents are injected into every
+							chat turn, so anything here is always in the assistant's context. The assistant keeps
+							durable operator preferences and standing guidelines here; edit it to correct what it
+							remembers. This document cannot be deleted.
+						</span>
+					</div>
 				) : null
 			}
 			emptyTitle="Select a document"
@@ -222,15 +244,8 @@ export const Route = createFileRoute('/projects/$projectId/documents')({
 	validateSearch: (search: Record<string, unknown>): DocumentsSearch => ({
 		file: typeof search.file === 'string' ? search.file : undefined,
 	}),
-	beforeLoad: ({ params }) => {
-		// Internal projects (slug `internal-<teamSlug>`) have no documents page.
-		if (params.projectId === HQ_PROJECT_SLUG) {
-			throw redirect({
-				to: '/projects/$projectId/tasks',
-				params,
-				replace: true,
-			});
-		}
-	},
+	// HQ renders its documents page so the operator can view/edit the chatbox
+	// memory (chat-memory.md). Other internal projects don't exist (HQ is the
+	// only one), so no redirect is needed.
 	component: ProjectDocumentsPage,
 });

--- a/packages/web/src/routes/settings/chatbox.tsx
+++ b/packages/web/src/routes/settings/chatbox.tsx
@@ -1,0 +1,152 @@
+import {
+	CHAT_HISTORY_LIMIT_MAX,
+	CHAT_HISTORY_LIMIT_MIN,
+	CHAT_MEMORY_SLUG,
+	DEFAULT_CHAT_HISTORY_LIMIT,
+	HQ_PROJECT_SLUG,
+} from '@hezo/shared';
+import { createFileRoute, Link } from '@tanstack/react-router';
+import { Loader2 } from 'lucide-react';
+import { useState } from 'react';
+import { Button } from '../../components/ui/button';
+import { InfoTooltip } from '../../components/ui/info-tooltip';
+import { Input } from '../../components/ui/input';
+import {
+	type InstanceSettings,
+	useInstanceSettings,
+	useUpdateInstanceSettings,
+} from '../../hooks/use-instance-settings';
+import { useMe } from '../../hooks/use-me';
+import type { ApiError } from '../../lib/api';
+
+function ChatboxSettingsPage() {
+	const { data: me } = useMe();
+	const { data: settings } = useInstanceSettings();
+
+	const content =
+		me && !me.is_superuser ? (
+			<p className="text-[13px] text-text-muted">
+				Chatbox settings are managed by the Admin. You don't have access to this page.
+			</p>
+		) : (
+			<>
+				<div className="mb-5">
+					<div className="flex items-center gap-1.5">
+						<h1 className="text-[22px] font-medium">Chatbox</h1>
+						<InfoTooltip
+							label="About the chatbox"
+							content="Settings for the assistant chatbox — how much conversation it keeps in context and how its persistent memory works."
+							data-testid="chatbox-info"
+						/>
+					</div>
+					<p className="text-[13px] text-text-muted mt-1 max-w-[680px]">
+						The chatbox is your direct line to the assistant. These settings control how much of the
+						conversation it keeps in working context each turn, and explain its persistent memory.
+					</p>
+				</div>
+
+				<section className="border border-border rounded-radius-md p-4 bg-bg mb-4">
+					<label className="block text-[13px] font-medium mb-1" htmlFor="chat-history-limit-input">
+						Conversation history window
+					</label>
+					<p className="text-[13px] text-text-muted mb-2.5 max-w-[680px]">
+						How many of the most recent chatbox messages are replayed into the assistant's context
+						on each turn. A larger window keeps more of the recent conversation in view but costs
+						more tokens per reply; older messages beyond the window scroll out of context (durable
+						facts belong in the chatbox memory below). Must be between {CHAT_HISTORY_LIMIT_MIN} and{' '}
+						{CHAT_HISTORY_LIMIT_MAX}; defaults to {DEFAULT_CHAT_HISTORY_LIMIT}.
+					</p>
+					{settings === undefined ? null : <HistoryLimitForm settings={settings} />}
+				</section>
+
+				<section className="border border-border rounded-radius-md p-4 bg-bg">
+					<h2 className="text-[13px] font-medium mb-1">Chatbox memory</h2>
+					<p className="text-[13px] text-text-muted max-w-[680px]">
+						The chatbox keeps a single persistent memory document,{' '}
+						<span className="font-mono">{CHAT_MEMORY_SLUG}</span>, whose full contents are injected
+						into every chat turn — so it survives even after older messages scroll out of the
+						history window above. The assistant records durable operator preferences, standing
+						guidelines, and anything you explicitly ask it to remember; it does not store live
+						project, ticket, or comment data there (that is always read fresh). You can review and
+						edit this document directly — it lives in the{' '}
+						<Link
+							to="/projects/$projectId/documents"
+							params={{ projectId: HQ_PROJECT_SLUG }}
+							className="text-accent hover:underline"
+						>
+							HQ project documents
+						</Link>{' '}
+						and cannot be deleted.
+					</p>
+				</section>
+			</>
+		);
+
+	return (
+		<div className="max-w-[900px] w-full px-4 py-4 md:px-6 md:py-5 lg:px-8 lg:py-6">{content}</div>
+	);
+}
+
+function HistoryLimitForm({ settings }: { settings: InstanceSettings }) {
+	const updateSettings = useUpdateInstanceSettings();
+	const [value, setValue] = useState(String(settings.chat_history_limit));
+	const [error, setError] = useState<string | null>(null);
+
+	async function handleSave() {
+		setError(null);
+		const parsed = Number.parseInt(value, 10);
+		if (
+			Number.isNaN(parsed) ||
+			parsed < CHAT_HISTORY_LIMIT_MIN ||
+			parsed > CHAT_HISTORY_LIMIT_MAX
+		) {
+			setError(
+				`Enter a whole number between ${CHAT_HISTORY_LIMIT_MIN} and ${CHAT_HISTORY_LIMIT_MAX}.`,
+			);
+			return;
+		}
+		try {
+			const result = await updateSettings.mutateAsync({ chat_history_limit: parsed });
+			setValue(String(result.chat_history_limit));
+		} catch (e) {
+			setError((e as ApiError).message);
+		}
+	}
+
+	const dirty = value.trim() !== String(settings.chat_history_limit);
+
+	return (
+		<>
+			<div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+				<Input
+					id="chat-history-limit-input"
+					data-testid="chat-history-limit-input"
+					type="number"
+					inputMode="numeric"
+					min={CHAT_HISTORY_LIMIT_MIN}
+					max={CHAT_HISTORY_LIMIT_MAX}
+					value={value}
+					onChange={(e) => setValue(e.target.value)}
+					className="sm:w-40"
+				/>
+				<Button
+					size="sm"
+					data-testid="chat-history-limit-save"
+					onClick={handleSave}
+					disabled={!dirty || updateSettings.isPending}
+				>
+					{updateSettings.isPending && <Loader2 className="w-3 h-3 animate-spin" />} Save
+				</Button>
+			</div>
+			{error && (
+				<p className="text-[13px] text-danger mt-1.5" data-testid="chat-history-limit-error">
+					{error}
+				</p>
+			)}
+		</>
+	);
+}
+
+export const Route = createFileRoute('/settings/chatbox')({
+	component: ChatboxSettingsPage,
+});

--- a/packages/web/src/routes/settings/index.tsx
+++ b/packages/web/src/routes/settings/index.tsx
@@ -12,6 +12,7 @@ const settingsNav = [
 
 // Instance-level resources shared across every team — Admin (superuser) only.
 const instanceNav = [
+	{ to: '/settings/chatbox', label: 'Chatbox' },
 	{ to: '/settings/skills', label: 'Skills' },
 	{ to: '/settings/connectors', label: 'Connectors' },
 	{ to: '/settings/credentials', label: 'Credentials' },

--- a/packages/web/test/chat-memory.test.tsx
+++ b/packages/web/test/chat-memory.test.tsx
@@ -1,0 +1,60 @@
+import { CHAT_MEMORY_SLUG, HQ_PROJECT_SLUG } from '@hezo/shared';
+import { waitFor } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { getTestContext, renderApp } from './helpers/render';
+
+async function putHqDoc(filename: string, content: string): Promise<void> {
+	const { apiBase, token } = getTestContext();
+	await apiBase(`/api/projects/${HQ_PROJECT_SLUG}/docs/${filename}`, {
+		method: 'PUT',
+		headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+		body: JSON.stringify({ content }),
+	});
+}
+
+test('chatbox settings page shows the history window and saves a new value', async () => {
+	const { findByTestId, findByRole, user } = await renderApp({ initialPath: '/settings/chatbox' });
+
+	await findByRole('heading', { name: 'Chatbox' });
+	const input = (await findByTestId('chat-history-limit-input')) as HTMLInputElement;
+	// Default when unset.
+	expect(input.value).toBe('80');
+
+	await user.clear(input);
+	await user.type(input, '120');
+	await user.click(await findByTestId('chat-history-limit-save'));
+
+	// Response-driven: the input reflects the server-echoed value.
+	await waitFor(() => expect(input.value).toBe('120'));
+
+	const { apiBase, token } = getTestContext();
+	const res = await apiBase('/api/instance-settings', {
+		headers: { Authorization: `Bearer ${token}` },
+	});
+	expect((await res.json()).data.chat_history_limit).toBe(120);
+});
+
+test('chat-memory.md in HQ shows the protected banner and no delete button', async () => {
+	const { findByTestId, queryByLabelText } = await renderApp({
+		initialPath: `/projects/${HQ_PROJECT_SLUG}/documents?file=${CHAT_MEMORY_SLUG}`,
+	});
+
+	// Banner explaining the protected doc renders.
+	await findByTestId('chat-memory-banner');
+	// Delete affordance is suppressed for this doc.
+	expect(queryByLabelText('Delete document')).toBeNull();
+});
+
+test('a normal HQ doc shows the delete button and no chat-memory banner', async () => {
+	const { findByLabelText, queryByTestId } = await renderApp({
+		initialPath: `/projects/${HQ_PROJECT_SLUG}/documents?file=notes.md`,
+		seed: async () => {
+			await putHqDoc('notes.md', '# Notes');
+		},
+	});
+
+	// Delete affordance is present for an ordinary doc.
+	await findByLabelText('Delete document');
+	// No protected-doc banner.
+	expect(queryByTestId('chat-memory-banner')).toBeNull();
+});

--- a/packages/web/test/internal-project.test.tsx
+++ b/packages/web/test/internal-project.test.tsx
@@ -6,10 +6,12 @@ import { seedWorkspace } from './helpers/seed';
 
 // HQ is the only internal project: the instance-wide coordination project that
 // hosts the CEO and Coach. Its slug is HQ_PROJECT_SLUG and `is_internal` is
-// true, so it gets the restricted sidebar, the coordination info tooltip beside
-// its name, and the documents/settings redirects.
+// true, so it gets the restricted sidebar (no Assets, no Settings) and the
+// coordination info tooltip beside its name. It DOES expose Documents — that's
+// where the chatbox memory (chat-memory.md) is viewed/edited — and the settings
+// route still redirects to tasks.
 
-test('sidebar exposes only Tasks and Container for the HQ project', async () => {
+test('sidebar exposes Tasks, Documents and Container for the HQ project (not Assets/Settings)', async () => {
 	const { findAllByRole, queryAllByRole, container, router } = await renderApp({
 		initialPath: '/',
 		seed: async () => {
@@ -30,8 +32,11 @@ test('sidebar exposes only Tasks and Container for the HQ project', async () => 
 	const tasksLinks = queryAllByRole('link', { name: 'Tasks' });
 	expect(tasksLinks.length).toBeGreaterThan(0);
 
-	// Documents/Assets are dropped once the index resolves the project as internal.
-	await waitFor(() => expect(queryAllByRole('link', { name: 'Documents' }).length).toBe(0));
+	// Documents is exposed for HQ (the chatbox memory lives here); Assets is not.
+	await waitFor(() =>
+		expect(queryAllByRole('link', { name: 'Documents' }).length).toBeGreaterThan(0),
+	);
+	expect(queryAllByRole('link', { name: 'Assets' }).length).toBe(0);
 
 	// No settings link pointing at the HQ project.
 	const settingsLinks = queryAllByRole('link', { name: 'Settings' });
@@ -67,7 +72,7 @@ test('coordination info tooltip sits beside the HQ name', async () => {
 	);
 });
 
-test('direct navigation to /documents and /settings redirects to /tasks', async () => {
+test('HQ /documents renders (chatbox memory) while /settings still redirects to /tasks', async () => {
 	const { router } = await renderApp({
 		initialPath: '/',
 		seed: async () => {
@@ -75,13 +80,15 @@ test('direct navigation to /documents and /settings redirects to /tasks', async 
 		},
 	});
 
+	// Documents is a real page for HQ now — no redirect.
 	await router.navigate({
 		to: '/projects/$projectId/documents',
 		params: { projectId: HQ_PROJECT_SLUG },
 	});
 	await new Promise((r) => setTimeout(r, 200));
-	expect(router.state.location.pathname).toBe(`/projects/${HQ_PROJECT_SLUG}/tasks`);
+	expect(router.state.location.pathname).toBe(`/projects/${HQ_PROJECT_SLUG}/documents`);
 
+	// Settings still redirects to tasks.
 	await router.navigate({
 		to: '/projects/$projectId/settings',
 		params: { projectId: HQ_PROJECT_SLUG },


### PR DESCRIPTION
## What & why

The chatbox (CEO) only remembered the last **80 messages**, so standing operator preferences and guidelines silently scrolled out of context. This adds a durable, always-in-context **chatbox memory** plus a **Chatbox settings page** to tune the history window.

Linear: **HID-194**

## Changes

**Chatbox memory (`chat-memory.md`)**
- A single, instance-wide project doc in the **HQ project**. Its **full contents are injected into every chatbox turn** (`composePrompt` in `ceo-session-manager.ts`) — unlike normal project docs, which are manifest-only — so anything recorded survives the rolling history window.
- **Chatbox-specific, not CEO-specific** in naming/framing.
- **Undeletable**: the REST delete handler returns 403 for this doc in HQ.
- **Self-healing existence**: seeded for fresh instances and re-ensured idempotently on every startup (`ensureChatMemoryDoc`), so pre-existing instances get it too. Never assumed to exist — created if missing.
- Maintained by the agent via the existing **`write_project_doc`** tool (no new tool).
- Excluded from the `{{project_docs_context}}` manifest to avoid double-prompting.

**Curation rules (in the chat-only runtime prompt, not the shared CEO system prompt)**
- Record durable operator preferences/guidelines and anything the operator explicitly asks to remember.
- Do **not** record live API data (projects/tickets/comments) or their metadata — that's rebuilt from live state each turn.

**Adjustable history window**
- Stored in `system_meta` (`chat_history_limit`, default 80, clamped 10–500), surfaced via `/api/instance-settings` (superuser PATCH).
- New **`/settings/chatbox`** page to adjust it, with an explanation of the window and of the chatbox memory.

**Docs UI**
- HQ now renders its documents page so the operator can view/edit the memory, with a protected-doc **banner** and no delete affordance.

## Tests
- Server integration (`packages/server/test/chat-memory.test.ts`): seeding, `ensureChatMemoryDoc` idempotency/recreation, full-inject block formatting, manifest exclusion, delete guard (403 in HQ; allowed elsewhere), history-limit get/set/clamp + route validation/authz.
- Web component (`packages/web/test/chat-memory.test.tsx`): chatbox settings save flow; HQ banner + delete-button suppression.

Typecheck and biome are clean. (Unrelated `test/git.test.ts` failures in CI sandbox are from the git commit-signing wrapper, not this change.)

https://claude.ai/code/session_01RRryezrPgfaypkW1pZg2h5

---
_Generated by [Claude Code](https://claude.ai/code/session_01RRryezrPgfaypkW1pZg2h5)_