### PR TITLE
fix(tasks): resolve parent_task_id by identifier, not just UUID

### DIFF
--- a/.dev/api.md
+++ b/.dev/api.md
@@ -845,6 +845,12 @@ Request:
 the agent receives an event trigger. If a board member, they are notified via
 inbox and configured messaging channels.
 
+`parent_task_id`, when set, accepts a task **identifier** (e.g. `IN-42`) or a UUID —
+it is resolved to the parent's UUID within the team before insert (an unknown
+reference is a `404`, not a `500`). Nesting is capped at `MAX_SUB_TASK_DEPTH` (2).
+The same field on the `create_tasks` MCP batch additionally accepts a `'#<index>'`
+token referencing an earlier item in the same call, mirroring `blocked_by_task_ids`.
+
 `runtime_type` is optional. It pins this task to a specific AI adapter
 (`claude_code | codex | gemini`). When unset, the server picks the
 instance default — the single active AI provider if only one is configured,

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -614,7 +614,7 @@ export function registerTools(
 				.string()
 				.optional()
 				.describe(
-					'Parent task ID (creates a sub-task). Sub-tasks can themselves have sub-tasks, but no deeper — depth is capped at 2.',
+					'Parent task to nest this under as a sub-task — a task identifier (e.g. "BE-2") or UUID. Sub-tasks can themselves have sub-tasks, but no deeper — depth is capped at 2.',
 				),
 			runtime_type: z
 				.string()
@@ -671,7 +671,7 @@ export function registerTools(
 							.string()
 							.optional()
 							.describe(
-								'Parent task ID (creates a sub-task). Sub-tasks can themselves have sub-tasks, but no deeper — depth is capped at 2.',
+								'Parent task to nest this under as a sub-task — a task identifier (e.g. "BE-2"), UUID, or a zero-based index token referencing an earlier item in this same call (e.g. "#0" = first item). Sub-tasks can themselves have sub-tasks, but no deeper — depth is capped at 2.',
 							),
 						runtime_type: z
 							.string()

--- a/packages/server/src/services/tasks.ts
+++ b/packages/server/src/services/tasks.ts
@@ -75,8 +75,17 @@ export async function createTask(
 		throw new CreateTaskError('INVALID_REQUEST', 'project_id and title are required');
 	}
 
+	// A parent may be referenced by identifier (e.g. "BE-2") or UUID, like every
+	// other task reference in the API. Resolve to a UUID before the depth check
+	// and INSERT — an unresolved identifier would otherwise reach the uuid column
+	// and surface as an opaque "invalid input syntax for type uuid" internal error.
+	let parentTaskId: string | null = null;
 	if (input.parent_task_id) {
-		const depthCheck = await assertChildDepthAllowed(db, teamId, input.parent_task_id);
+		parentTaskId = await resolveTaskId(db, teamId, input.parent_task_id);
+		if (!parentTaskId) {
+			throw new CreateTaskError('NOT_FOUND', `Parent task '${input.parent_task_id}' not found`);
+		}
+		const depthCheck = await assertChildDepthAllowed(db, teamId, parentTaskId);
 		if (!depthCheck.ok) {
 			throw new CreateTaskError('INVALID_REQUEST', depthCheck.message);
 		}
@@ -124,7 +133,7 @@ export async function createTask(
 				teamId,
 				input.project_id,
 				assigneeId,
-				input.parent_task_id ?? null,
+				parentTaskId,
 				caller.actorMemberId,
 				caller.runId ?? null,
 				taskNumber,
@@ -200,10 +209,10 @@ const BATCH_INDEX_TOKEN_RE = /^#(0|[1-9]\d*)$/;
 
 /**
  * Create a set of tasks in input order, continuing past per-item failures.
- * Within the batch, `blocked_by_task_ids` entries may reference an earlier
- * item by zero-based index token (`'#0'` = first item); the token is
- * substituted with that item's UUID before creation. Tokens that are
- * malformed, self/forward-referencing, or point at a failed item error
+ * Within the batch, `blocked_by_task_ids` entries and `parent_task_id` may
+ * reference an earlier item by zero-based index token (`'#0'` = first item);
+ * the token is substituted with that item's UUID before creation. Tokens that
+ * are malformed, self/forward-referencing, or point at a failed item error
  * that item without aborting the rest.
  */
 export async function createTaskBatch(
@@ -225,10 +234,11 @@ export async function createTaskBatch(
 				index,
 				createdIds,
 			);
+			const parent_task_id = resolveBatchParentRef(item.parent_task_id, index, createdIds);
 			const task = await createTask(
 				db,
 				teamId,
-				{ ...item, blocked_by_task_ids },
+				{ ...item, blocked_by_task_ids, parent_task_id },
 				caller,
 				wsManager,
 				events,
@@ -254,6 +264,38 @@ export async function createTaskBatch(
 	return results;
 }
 
+// Resolve a single '#<index>' batch token to the referenced item's UUID,
+// enforcing that it points at an earlier, successfully-created item. Shared by
+// the blocker-list and parent resolvers so both report identical errors.
+function resolveBatchIndexRef(
+	trimmed: string,
+	index: number,
+	createdIds: readonly (string | null)[],
+): string {
+	const match = BATCH_INDEX_TOKEN_RE.exec(trimmed);
+	if (!match) {
+		throw new CreateTaskError(
+			'INVALID_REQUEST',
+			`Invalid batch reference '${trimmed}' — use '#<zero-based index>' of an earlier item in this call`,
+		);
+	}
+	const ref = Number(match[1]);
+	if (ref >= index) {
+		throw new CreateTaskError(
+			'INVALID_REQUEST',
+			`'${trimmed}' must reference an earlier item in this batch (this is item ${index})`,
+		);
+	}
+	const refId = createdIds[ref];
+	if (!refId) {
+		throw new CreateTaskError(
+			'INVALID_REQUEST',
+			`'${trimmed}' references item ${ref}, which failed to create`,
+		);
+	}
+	return refId;
+}
+
 function resolveBatchBlockerRefs(
 	rawIds: readonly string[] | undefined,
 	index: number,
@@ -263,29 +305,23 @@ function resolveBatchBlockerRefs(
 	return rawIds.map((raw) => {
 		const trimmed = typeof raw === 'string' ? raw.trim() : '';
 		if (!trimmed.startsWith('#')) return raw;
-		const match = BATCH_INDEX_TOKEN_RE.exec(trimmed);
-		if (!match) {
-			throw new CreateTaskError(
-				'INVALID_REQUEST',
-				`Invalid batch reference '${trimmed}' — use '#<zero-based index>' of an earlier item in this call`,
-			);
-		}
-		const ref = Number(match[1]);
-		if (ref >= index) {
-			throw new CreateTaskError(
-				'INVALID_REQUEST',
-				`'${trimmed}' must reference an earlier item in this batch (this is item ${index})`,
-			);
-		}
-		const refId = createdIds[ref];
-		if (!refId) {
-			throw new CreateTaskError(
-				'INVALID_REQUEST',
-				`'${trimmed}' references item ${ref}, which failed to create`,
-			);
-		}
-		return refId;
+		return resolveBatchIndexRef(trimmed, index, createdIds);
 	});
+}
+
+// A batch item's parent may also use a '#<index>' token to nest under an earlier
+// item in the same call (e.g. file a parent then its sub-tasks in one batch).
+// Non-token values (identifier or UUID) pass through to createTask, which
+// resolves them.
+function resolveBatchParentRef(
+	raw: string | undefined,
+	index: number,
+	createdIds: readonly (string | null)[],
+): string | undefined {
+	if (typeof raw !== 'string') return raw;
+	const trimmed = raw.trim();
+	if (!trimmed.startsWith('#')) return raw;
+	return resolveBatchIndexRef(trimmed, index, createdIds);
 }
 
 async function attachBlockers(

--- a/packages/server/test/mcp-tools.test.ts
+++ b/packages/server/test/mcp-tools.test.ts
@@ -1165,6 +1165,36 @@ describe('MCP tool: create_task sub-task depth', () => {
 		})) as { error?: string };
 		expect(tooDeep.error).toMatch(/2 levels deep/);
 	});
+
+	it('create_task resolves a parent passed by identifier (the agent-facing form)', async () => {
+		const parent = (await callToolViaMcp('create_task', {
+			project: projectId,
+			title: 'Parent by identifier',
+			assignee_id: agentId,
+		})) as { id: string; identifier: string };
+
+		// Agents reference tasks by bare identifier (e.g. "BE-2") everywhere; passing
+		// that as parent_task_id must resolve to the parent UUID rather than reach the
+		// uuid column and crash with "invalid input syntax for type uuid".
+		const child = (await callToolViaMcp('create_task', {
+			project: projectId,
+			title: 'Child by identifier',
+			assignee_id: agentId,
+			parent_task_id: parent.identifier,
+		})) as { id: string; parent_task_id: string | null; error?: string };
+		expect(child.error).toBeUndefined();
+		expect(child.parent_task_id).toBe(parent.id);
+	});
+
+	it('create_task returns a clean not-found error for an unknown parent identifier', async () => {
+		const result = (await callToolViaMcp('create_task', {
+			project: projectId,
+			title: 'Orphan child',
+			assignee_id: agentId,
+			parent_task_id: 'ZZ-999999',
+		})) as { error?: string };
+		expect(result.error).toMatch(/parent task/i);
+	});
 });
 
 describe('MCP tool: result shape — no embeddings, opt-in excerpts, size guard', () => {

--- a/packages/server/test/tasks-batch.test.ts
+++ b/packages/server/test/tasks-batch.test.ts
@@ -357,6 +357,56 @@ describe('MCP tool: create_tasks (agent caller)', () => {
 		expect(result[2]).toMatchObject({ index: 2, ok: true });
 	});
 
+	it('nests a batch item under an existing parent referenced by identifier', async () => {
+		const parent = (await callMcpTool(token, 'create_task', {
+			project: projectId,
+			title: 'Existing parent for batch',
+			assignee_id: engineerId,
+		})) as { id: string; identifier: string };
+
+		const result = (await callMcpTool(token, 'create_tasks', {
+			project: projectId,
+			items: [
+				{
+					title: 'Child of existing parent',
+					assignee_id: engineerId,
+					parent_task_id: parent.identifier,
+				},
+			],
+		})) as Array<{ ok: boolean; code?: string; task?: { parent_task_id: string | null } }>;
+
+		expect(result[0].ok).toBe(true);
+		expect(result[0].task?.parent_task_id).toBe(parent.id);
+	});
+
+	it('nests a later batch item under an earlier one via a #index parent token', async () => {
+		const result = (await callMcpTool(token, 'create_tasks', {
+			project: projectId,
+			items: [
+				{ title: 'Batch parent', assignee_id: engineerId },
+				{ title: 'Batch child', assignee_id: engineerId, parent_task_id: '#0' },
+			],
+		})) as Array<{ ok: boolean; task?: { id: string; parent_task_id: string | null } }>;
+
+		expect(result[0].ok).toBe(true);
+		expect(result[1].ok).toBe(true);
+		expect(result[1].task?.parent_task_id).toBe(result[0].task?.id);
+	});
+
+	it('rejects a forward-referencing #index parent token without aborting the rest', async () => {
+		const result = (await callMcpTool(token, 'create_tasks', {
+			project: projectId,
+			items: [
+				{ title: 'Parent forward ref', assignee_id: engineerId, parent_task_id: '#1' },
+				{ title: 'Independent after bad parent', assignee_id: engineerId },
+			],
+		})) as Array<{ index: number; ok: boolean; code?: string; error?: string }>;
+
+		expect(result[0]).toMatchObject({ index: 0, ok: false, code: 'INVALID_REQUEST' });
+		expect(result[0].error).toMatch(/earlier item/i);
+		expect(result[1]).toMatchObject({ index: 1, ok: true });
+	});
+
 	it('rejects malformed and out-of-range index tokens', async () => {
 		const result = (await callMcpTool(token, 'create_tasks', {
 			project: projectId,

--- a/packages/server/test/tasks.test.ts
+++ b/packages/server/test/tasks.test.ts
@@ -813,6 +813,39 @@ describe('sub-task depth + ancestors', () => {
 		expect(tooDeep.body.error.message).toMatch(/2 levels deep/);
 	});
 
+	it('resolves a parent_task_id passed by identifier (not just UUID)', async () => {
+		const root = (await createTask()).body.data;
+		// Reference the parent by its bare identifier (lowercased), the way an
+		// agent or API caller would — must resolve to the parent UUID, not 500.
+		const childRes = await app.request(`/api/projects/${projectSlug}/tasks`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				project_id: projectId,
+				title: 'Child by identifier',
+				assignee_id: agentId,
+				parent_task_id: root.identifier.toLowerCase(),
+			}),
+		});
+		expect(childRes.status).toBe(201);
+		expect((await childRes.json()).data.parent_task_id).toBe(root.id);
+	});
+
+	it('returns 404 (not 500) when parent_task_id references an unknown task', async () => {
+		const res = await app.request(`/api/projects/${projectSlug}/tasks`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				project_id: projectId,
+				title: 'Orphan child',
+				assignee_id: agentId,
+				parent_task_id: 'MP-999999',
+			}),
+		});
+		expect(res.status).toBe(404);
+		expect((await res.json()).error.message).toMatch(/parent task/i);
+	});
+
 	it('rejects depth-3 creation via POST /tasks/:id/sub-tasks', async () => {
 		const root = (await createTask()).body.data;
 		const sub = (await createSub(root.id)).body.data;


### PR DESCRIPTION
## Problem

Batch task creation crashed with an opaque internal error when a sub-task referenced its parent by **identifier**:

```
[error] <tasks-service> Unexpected error in batch task creation: error: invalid input syntax for type uuid: "TO-2"
```

`createTask` passed `parent_task_id` straight into the uuid `tasks.parent_task_id` column (via the depth check in `assertChildDepthAllowed` and the INSERT). But agents reference tasks by their **bare identifier** (e.g. `TO-2`) everywhere else in the API — `blocked_by_task_ids`, `update_task`'s `task_id`, `get_task`, etc. all accept an identifier or UUID. `parent_task_id` was the odd one out: passing `"TO-2"` hit the uuid cast and surfaced as `INTERNAL_ERROR` (returned to the agent) plus a scary `Unexpected error` log line.

## Fix

- **Resolve `parent_task_id` (identifier or UUID) to a UUID up front** in `createTask`, via the existing `resolveTaskId` helper — mirroring how `blocked_by_task_ids` already resolve in `attachBlockers`. UUIDs pass through unchanged, so every existing caller (including `POST /tasks/:id/sub-tasks`, which already resolves the parent) is unaffected. An unknown reference now returns a clean **`NOT_FOUND` (404)** instead of a 500, consistent with the sibling blocker handling.
- **Extend the `create_tasks` batch** so `parent_task_id` also accepts a `'#<index>'` token referencing an earlier item in the same call — symmetric with `blocked_by_task_ids`. This lets an agent file a parent and its sub-tasks in a single batch. The shared `#index` token resolution (validation + earlier-item enforcement) is factored into `resolveBatchIndexRef`, used by both the blocker and parent resolvers so they report identical errors.
- **Docs:** updated the `create_task` / `create_tasks` tool descriptions and `.dev/api.md` to document the accepted forms.

## Tests (7 new, all green)

- `tasks.test.ts` — `POST /tasks` resolves a parent passed by (lowercased) identifier; unknown parent identifier returns 404, not 500.
- `mcp-tools.test.ts` — `create_task` resolves an identifier parent (the exact agent-facing form from the log); unknown identifier returns a clean error.
- `tasks-batch.test.ts` — batch item nests under an existing identifier parent; a later item nests under an earlier one via `#0`; a forward-referencing `#index` parent errors that item without aborting the rest.

`bun run typecheck` and `bun run build` pass (pre-commit hooks); the three affected vitest files are green (138 tests).

https://claude.ai/code/session_012Bg9LgmxLbUEeJTx3uQrcy

---
_Generated by [Claude Code](https://claude.ai/code/session_012Bg9LgmxLbUEeJTx3uQrcy)_