### PR TITLE
feat(projects): select an existing team as a template for a new team

### DIFF
--- a/.dev/per-project-teams.md
+++ b/.dev/per-project-teams.md
@@ -83,6 +83,12 @@ team from a team-type template (default **Blank** = Captain only).
    (Captain, blocked on coherence), and closes the intake. `GET /api/project-intakes`
    returns the open intake for the home/welcome view.
 
+Both flows also accept a `source_team_id` (mutually exclusive with `template_id`):
+the chosen existing team is snapshotted into a fresh, permanent, uniquely-named
+team-type template (via `snapshotTeamAsTemplate`) and the new team is provisioned
+from it — so cloning a team also seeds a reusable type. The internal HQ team is
+rejected as a source (its CEO/Coach must not land in a project roster).
+
 Both the first-run welcome and the ongoing "new project with the CEO" use flow 2's
 intake in HQ. The old per-team onboarding/onboarding-intake machinery is gone.
 

--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -31,6 +31,7 @@ import { loadCoordinationContext } from '../services/internal-intake';
 import type { JobManager } from '../services/job-manager';
 import { createPlanningTask, createProject } from '../services/project-create';
 import { createProjectIntake, getOpenProjectIntakeForHome } from '../services/project-intake';
+import { snapshotTeamAsTemplate } from '../services/team-template-snapshot';
 import { createTeam } from '../services/teams';
 import { createWakeup } from '../services/wakeup';
 
@@ -177,6 +178,7 @@ projectsRoutes.post('/projects', async (c) => {
 		name: string;
 		description?: string;
 		template_id?: string;
+		source_team_id?: string;
 		task_prefix?: string;
 		initial_prd?: string;
 		docker_base_image?: string;
@@ -185,15 +187,17 @@ projectsRoutes.post('/projects', async (c) => {
 	if (!body.name?.trim()) return err(c, 'INVALID_REQUEST', 'name is required', 400);
 	if (!body.description?.trim()) return err(c, 'INVALID_REQUEST', 'description is required', 400);
 
-	// A project is always created from a team-type template — the Blank template
-	// (Captain only) when the caller doesn't choose one.
-	let templateId = body.template_id;
-	if (!templateId) {
-		const blank = await db.query<{ id: string }>('SELECT id FROM team_templates WHERE name = $1', [
-			'Blank',
-		]);
-		templateId = blank.rows[0]?.id;
-	}
+	// A project is always created from a team-type template: an existing one, a
+	// fresh snapshot of an existing team (source_team_id), or the Blank template
+	// (Captain only) when the caller chooses neither.
+	const templateResult = await resolveCreationTemplate(db, {
+		templateId: body.template_id,
+		sourceTeamId: body.source_team_id,
+		description: body.description,
+	});
+	if (!templateResult.ok)
+		return err(c, templateResult.code, templateResult.message, templateResult.status);
+	const templateId = templateResult.templateId;
 
 	// 1. Create the project's dedicated team (its roster), named after the project.
 	const auth = c.get('auth');
@@ -308,12 +312,82 @@ projectsRoutes.post('/projects', async (c) => {
 	);
 });
 
-async function resolveTemplateId(db: PGlite, requested?: string): Promise<string | undefined> {
-	if (requested) return requested;
+type ResolveTemplateResult =
+	| { ok: true; templateId: string | undefined }
+	| { ok: false; code: 'INVALID_REQUEST' | 'NOT_FOUND'; message: string; status: 400 | 404 };
+
+/**
+ * Generates a `team_templates.name` that doesn't clash with an existing one by
+ * appending " (2)", " (3)", … to the base. Mirrors `uniqueSlug` — each
+ * snapshot of a source team mints a fresh, distinctly-named template.
+ */
+async function uniqueTemplateName(db: PGlite, base: string): Promise<string> {
+	let candidate = base;
+	let n = 2;
+	while (
+		(await db.query('SELECT 1 FROM team_templates WHERE name = $1', [candidate])).rows.length
+	) {
+		candidate = `${base} (${n})`;
+		n++;
+	}
+	return candidate;
+}
+
+/**
+ * Resolves the team-type template a new project's team is provisioned from.
+ * A caller picks either an existing template (`templateId`) or an existing team
+ * to clone (`sourceTeamId`); cloning snapshots that team into a fresh permanent
+ * template (reusable from then on). With neither, defaults to the Blank template.
+ */
+async function resolveCreationTemplate(
+	db: PGlite,
+	opts: { templateId?: string; sourceTeamId?: string; description?: string },
+): Promise<ResolveTemplateResult> {
+	const templateId = opts.templateId?.trim() || undefined;
+	const sourceTeamId = opts.sourceTeamId?.trim() || undefined;
+
+	if (templateId && sourceTeamId) {
+		return {
+			ok: false,
+			code: 'INVALID_REQUEST',
+			message: 'Provide either template_id or source_team_id, not both',
+			status: 400,
+		};
+	}
+
+	if (templateId) return { ok: true, templateId };
+
+	if (sourceTeamId) {
+		const team = await db.query<{ name: string; is_internal: boolean }>(
+			`SELECT t.name,
+			        EXISTS (SELECT 1 FROM projects p WHERE p.team_id = t.id AND p.is_internal = true) AS is_internal
+			 FROM teams t WHERE t.id = $1`,
+			[sourceTeamId],
+		);
+		const row = team.rows[0];
+		if (!row) {
+			return { ok: false, code: 'NOT_FOUND', message: 'Source team not found', status: 404 };
+		}
+		if (row.is_internal) {
+			return {
+				ok: false,
+				code: 'INVALID_REQUEST',
+				message: 'The HQ team cannot be used as a source team',
+				status: 400,
+			};
+		}
+		const name = await uniqueTemplateName(db, row.name);
+		const snapshot = await snapshotTeamAsTemplate(db, sourceTeamId, {
+			name,
+			description: opts.description?.trim() || `Snapshot of the "${row.name}" team`,
+		});
+		return { ok: true, templateId: snapshot.template_id };
+	}
+
 	const blank = await db.query<{ id: string }>('SELECT id FROM team_templates WHERE name = $1', [
 		'Blank',
 	]);
-	return blank.rows[0]?.id;
+	return { ok: true, templateId: blank.rows[0]?.id };
 }
 
 // CEO-assisted project creation: stand up the project's team up front, then open
@@ -329,6 +403,7 @@ projectsRoutes.post('/project-intakes', async (c) => {
 		name: string;
 		description?: string;
 		template_id?: string;
+		source_team_id?: string;
 		task_prefix?: string;
 		initial_prd?: string;
 	}>();
@@ -342,7 +417,14 @@ projectsRoutes.post('/project-intakes', async (c) => {
 		return err(c, 'INTERNAL', 'HQ coordination project is not available', 500);
 	}
 
-	const templateId = await resolveTemplateId(db, body.template_id);
+	const templateResult = await resolveCreationTemplate(db, {
+		templateId: body.template_id,
+		sourceTeamId: body.source_team_id,
+		description: body.description,
+	});
+	if (!templateResult.ok)
+		return err(c, templateResult.code, templateResult.message, templateResult.status);
+	const templateId = templateResult.templateId;
 	const auth = c.get('auth');
 	const team = await createTeam(
 		{

--- a/packages/server/src/routes/teams.ts
+++ b/packages/server/src/routes/teams.ts
@@ -30,14 +30,16 @@ teamsRoutes.get('/teams', async (c) => {
 		query = `SELECT c.*,
        (SELECT count(*) FROM members m WHERE m.team_id = c.id AND m.member_type = $1)::int AS agent_count,
        (SELECT count(*) FROM tasks i WHERE i.team_id = c.id AND i.status NOT IN (${ts.placeholders}))::int AS open_task_count,
-       (SELECT tt.name FROM team_template_assignments tta JOIN team_templates tt ON tt.id = tta.team_template_id WHERE tta.team_id = c.id ORDER BY tt.is_builtin DESC LIMIT 1) AS primary_template_name
+       (SELECT tt.name FROM team_template_assignments tta JOIN team_templates tt ON tt.id = tta.team_template_id WHERE tta.team_id = c.id ORDER BY tt.is_builtin DESC LIMIT 1) AS primary_template_name,
+       EXISTS (SELECT 1 FROM projects p WHERE p.team_id = c.id AND p.is_internal = true) AS is_internal
      FROM teams c
      ORDER BY c.created_at DESC`;
 	} else {
 		query = `SELECT c.*,
        (SELECT count(*) FROM members m WHERE m.team_id = c.id AND m.member_type = $1)::int AS agent_count,
        (SELECT count(*) FROM tasks i WHERE i.team_id = c.id AND i.status NOT IN (${ts.placeholders}))::int AS open_task_count,
-       (SELECT tt.name FROM team_template_assignments tta JOIN team_templates tt ON tt.id = tta.team_template_id WHERE tta.team_id = c.id ORDER BY tt.is_builtin DESC LIMIT 1) AS primary_template_name
+       (SELECT tt.name FROM team_template_assignments tta JOIN team_templates tt ON tt.id = tta.team_template_id WHERE tta.team_id = c.id ORDER BY tt.is_builtin DESC LIMIT 1) AS primary_template_name,
+       EXISTS (SELECT 1 FROM projects p WHERE p.team_id = c.id AND p.is_internal = true) AS is_internal
      FROM teams c
      JOIN members m2 ON m2.team_id = c.id
      JOIN member_users mu ON mu.id = m2.id

--- a/packages/server/test/project-create-from-team.test.ts
+++ b/packages/server/test/project-create-from-team.test.ts
@@ -1,0 +1,206 @@
+import type { PGlite } from '@electric-sql/pglite';
+import { DEFAULT_TEAM_ID, MemberType } from '@hezo/shared';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Env } from '../src/lib/types';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp } from './helpers/app';
+
+let app: Hono<Env>;
+let db: PGlite;
+let token: string;
+let startupTemplateId: string;
+
+interface CreatedProjectTeam {
+	id: string;
+	team_id: string;
+	team_slug: string;
+	slug: string;
+	planning_task_id: string;
+}
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+	const res = await app.request('/api/team-templates', { headers: authHeader(token) });
+	const startup = (await res.json()).data.find((t: { name: string }) => t.name === 'Startup');
+	startupTemplateId = startup.id;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+async function createProject(body: Record<string, unknown>) {
+	return app.request('/api/projects', {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify(body),
+	});
+}
+
+// All agent slugs on a team (member_agents), sorted — project teams carry no
+// CEO/Coach members, so this is the full roster.
+async function rosterSlugs(teamId: string): Promise<string[]> {
+	const res = await db.query<{ slug: string }>(
+		`SELECT ma.slug FROM member_agents ma
+		 JOIN members m ON m.id = ma.id
+		 WHERE m.team_id = $1 AND m.member_type = $2
+		 ORDER BY ma.slug`,
+		[teamId, MemberType.Agent],
+	);
+	return res.rows.map((r) => r.slug);
+}
+
+async function templateCount(): Promise<number> {
+	const res = await db.query<{ n: number }>('SELECT count(*)::int AS n FROM team_templates');
+	return res.rows[0].n;
+}
+
+describe('POST /projects — clone an existing team (source_team_id)', () => {
+	it('provisions the new team from a fresh snapshot of the source team', async () => {
+		// A source team with a non-trivial roster.
+		const source = (
+			await (
+				await createProject({
+					name: 'Clone Source Co',
+					description: 'Source team to clone.',
+					template_id: startupTemplateId,
+				})
+			).json()
+		).data as CreatedProjectTeam;
+		const sourceRoster = await rosterSlugs(source.team_id);
+		expect(sourceRoster).toContain('captain');
+		expect(sourceRoster).toContain('architect');
+		expect(sourceRoster.length).toBeGreaterThan(1);
+
+		const before = await templateCount();
+
+		// Create a new project cloning that team.
+		const cloneRes = await createProject({
+			name: 'Cloned Co',
+			description: 'Clones the source.',
+			source_team_id: source.team_id,
+		});
+		expect(cloneRes.status).toBe(201);
+		const clone = (await cloneRes.json()).data as CreatedProjectTeam;
+
+		// The new team's roster mirrors the source.
+		expect(await rosterSlugs(clone.team_id)).toEqual(sourceRoster);
+
+		// Reporting structure round-trips: architect reports to the captain.
+		const architect = await db.query<{ reports_to_slug: string | null }>(
+			`SELECT mgr.slug AS reports_to_slug
+			 FROM member_agents ma
+			 JOIN members m ON m.id = ma.id
+			 LEFT JOIN member_agents mgr ON mgr.id = ma.reports_to
+			 WHERE m.team_id = $1 AND ma.slug = 'architect'`,
+			[clone.team_id],
+		);
+		expect(architect.rows[0]?.reports_to_slug).toBe('captain');
+
+		// A new permanent template was minted, named after the source team.
+		expect(await templateCount()).toBe(before + 1);
+		const minted = await db.query<{ id: string }>('SELECT id FROM team_templates WHERE name = $1', [
+			'Clone Source Co',
+		]);
+		expect(minted.rows).toHaveLength(1);
+	});
+
+	it('mints a fresh, distinctly-named template each time the same team is cloned', async () => {
+		const source = (
+			await (
+				await createProject({
+					name: 'Repeat Source Co',
+					description: 'Cloned twice.',
+					template_id: startupTemplateId,
+				})
+			).json()
+		).data as CreatedProjectTeam;
+
+		const first = await createProject({
+			name: 'Repeat Clone One',
+			description: 'First clone.',
+			source_team_id: source.team_id,
+		});
+		expect(first.status).toBe(201);
+		const second = await createProject({
+			name: 'Repeat Clone Two',
+			description: 'Second clone.',
+			source_team_id: source.team_id,
+		});
+		expect(second.status).toBe(201);
+
+		const names = await db.query<{ name: string }>(
+			"SELECT name FROM team_templates WHERE name LIKE 'Repeat Source Co%' ORDER BY name",
+		);
+		expect(names.rows.map((r) => r.name)).toEqual(['Repeat Source Co', 'Repeat Source Co (2)']);
+	});
+
+	it('rejects cloning the internal HQ team', async () => {
+		const res = await createProject({
+			name: 'No HQ Clone',
+			description: 'Should fail.',
+			source_team_id: DEFAULT_TEAM_ID,
+		});
+		expect(res.status).toBe(400);
+	});
+
+	it('rejects an unknown source team', async () => {
+		const res = await createProject({
+			name: 'Unknown Source',
+			description: 'Should 404.',
+			source_team_id: '00000000-0000-0000-0000-000000000000',
+		});
+		expect(res.status).toBe(404);
+	});
+
+	it('rejects passing both template_id and source_team_id', async () => {
+		const source = (
+			await (
+				await createProject({
+					name: 'Both Fields Co',
+					description: 'Source.',
+					template_id: startupTemplateId,
+				})
+			).json()
+		).data as CreatedProjectTeam;
+		const res = await createProject({
+			name: 'Both Fields Clone',
+			description: 'Should 400.',
+			template_id: startupTemplateId,
+			source_team_id: source.team_id,
+		});
+		expect(res.status).toBe(400);
+	});
+});
+
+describe('POST /project-intakes — clone an existing team', () => {
+	it('stands up the intake team from a snapshot of the source team', async () => {
+		const source = (
+			await (
+				await createProject({
+					name: 'Intake Source Co',
+					description: 'Source for intake clone.',
+					template_id: startupTemplateId,
+				})
+			).json()
+		).data as CreatedProjectTeam;
+		const sourceRoster = await rosterSlugs(source.team_id);
+
+		const res = await app.request('/api/project-intakes', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				name: 'Intake Clone Co',
+				description: 'Cloned via intake.',
+				source_team_id: source.team_id,
+			}),
+		});
+		expect(res.status).toBe(201);
+		const intake = (await res.json()).data as { team_id: string };
+		expect(await rosterSlugs(intake.team_id)).toEqual(sourceRoster);
+	});
+});

--- a/packages/web/src/components/create-project-with-team-dialog.tsx
+++ b/packages/web/src/components/create-project-with-team-dialog.tsx
@@ -6,6 +6,7 @@ import { setActiveTeamSlug } from '../hooks/use-active-team-slug';
 import { useStartProjectIntake } from '../hooks/use-project-intake';
 import { useCreateProjectWithTeam } from '../hooks/use-projects';
 import { useTeamTemplates } from '../hooks/use-team-templates';
+import { useTeams } from '../hooks/use-teams';
 import { Button } from './ui/button';
 import { Card } from './ui/card';
 import { dialogContentClassName, dialogOverlayClassName } from './ui/dialog';
@@ -18,6 +19,12 @@ interface CreateProjectWithTeamDialogProps {
 }
 
 /**
+ * Exactly one source backs the new team: either a catalog template or an
+ * existing team to clone (snapshotted into a fresh template server-side).
+ */
+type Selection = { kind: 'template'; id: string } | { kind: 'team'; id: string } | null;
+
+/**
  * Projects-primary "New project": each project owns its own team. Pick a team
  * type, name the project, describe it, then either create it straight away or
  * hand the brief to the CEO, who scopes it with you in HQ before it opens.
@@ -27,30 +34,43 @@ export function CreateProjectWithTeamDialog({
 	onOpenChange,
 }: CreateProjectWithTeamDialogProps) {
 	const { data: templates, isLoading } = useTeamTemplates();
+	const { data: teams } = useTeams();
 	const [name, setName] = useState('');
 	const [description, setDescription] = useState('');
-	const [templateId, setTemplateId] = useState<string | null>(null);
+	const [selection, setSelection] = useState<Selection>(null);
 	const createProject = useCreateProjectWithTeam();
 	const startIntake = useStartProjectIntake();
 	const navigate = useNavigate();
 
+	// Existing teams the new project's team can be cloned from. HQ (the internal
+	// team) is excluded — snapshotting it would carry the CEO/Coach into the roster.
+	const sourceTeams = (teams ?? []).filter((t) => !t.is_internal);
+
 	const pending = createProject.isPending || startIntake.isPending;
 	const canSubmit =
-		name.trim().length > 0 && description.trim().length > 0 && !!templateId && !pending;
+		name.trim().length > 0 && description.trim().length > 0 && !!selection && !pending;
 	const error = createProject.error || startIntake.error;
+
+	// The chosen source as request fields: a template id or a source-team id.
+	const sourceFields =
+		selection?.kind === 'template'
+			? { template_id: selection.id }
+			: selection?.kind === 'team'
+				? { source_team_id: selection.id }
+				: null;
 
 	function reset() {
 		setName('');
 		setDescription('');
-		setTemplateId(null);
+		setSelection(null);
 	}
 
 	async function handleCreateNow() {
-		if (!templateId) return;
+		if (!sourceFields) return;
 		const res = await createProject.mutateAsync({
 			name: name.trim(),
 			description: description.trim(),
-			template_id: templateId,
+			...sourceFields,
 		});
 		setActiveTeamSlug(res.team_slug);
 		onOpenChange(false);
@@ -66,11 +86,11 @@ export function CreateProjectWithTeamDialog({
 	}
 
 	async function handlePlanWithCeo() {
-		if (!templateId) return;
+		if (!sourceFields) return;
 		const res = await startIntake.mutateAsync({
 			name: name.trim(),
 			description: description.trim(),
-			template_id: templateId,
+			...sourceFields,
 		});
 		setActiveTeamSlug(res.team_slug);
 		onOpenChange(false);
@@ -126,12 +146,12 @@ export function CreateProjectWithTeamDialog({
 							) : (
 								<div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-2">
 									{(templates ?? []).map((tpl) => {
-										const selected = templateId === tpl.id;
+										const selected = selection?.kind === 'template' && selection.id === tpl.id;
 										return (
 											<button
 												key={tpl.id}
 												type="button"
-												onClick={() => setTemplateId(tpl.id)}
+												onClick={() => setSelection({ kind: 'template', id: tpl.id })}
 												className="text-left"
 												data-testid={`team-type-card-${tpl.name}`}
 												aria-pressed={selected}
@@ -161,6 +181,43 @@ export function CreateProjectWithTeamDialog({
 								</div>
 							)}
 						</div>
+						{sourceTeams.length > 0 && (
+							<div>
+								<span className="text-[13px] font-medium text-text">Copy an existing team</span>
+								<p className="text-[12px] text-text-muted">
+									Start from another team's roster. A reusable team type is saved from its current
+									setup.
+								</p>
+								<div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-2">
+									{sourceTeams.map((team) => {
+										const selected = selection?.kind === 'team' && selection.id === team.id;
+										return (
+											<button
+												key={team.id}
+												type="button"
+												onClick={() => setSelection({ kind: 'team', id: team.id })}
+												className="text-left"
+												data-testid={`source-team-card-${team.slug}`}
+												aria-pressed={selected}
+											>
+												<Card
+													className={`p-3 h-full transition-colors ${
+														selected ? 'border-primary' : 'hover:border-border-hover'
+													}`}
+												>
+													<h3 className="text-[14px] font-medium mb-1">{team.name}</h3>
+													<p className="text-[11px] text-text-muted">
+														{team.agent_count === 0
+															? 'No agents yet'
+															: `${team.agent_count} agent${team.agent_count === 1 ? '' : 's'}`}
+													</p>
+												</Card>
+											</button>
+										);
+									})}
+								</div>
+							</div>
+						)}
 						{error && (
 							<p className="text-[13px] text-accent-red">
 								{(error as { message?: string }).message || 'Failed to create project'}

--- a/packages/web/src/hooks/use-project-intake.ts
+++ b/packages/web/src/hooks/use-project-intake.ts
@@ -18,6 +18,7 @@ export interface StartProjectIntakeInput {
 	name: string;
 	description: string;
 	template_id?: string;
+	source_team_id?: string;
 	task_prefix?: string;
 	initial_prd?: string;
 }
@@ -50,6 +51,8 @@ export function useStartProjectIntake() {
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: queryKeys.projectIntakes() });
 			queryClient.invalidateQueries({ queryKey: queryKeys.teams.all() });
+			// Cloning a team mints a new reusable template — refresh the catalog.
+			queryClient.invalidateQueries({ queryKey: queryKeys.teamTemplates() });
 		},
 	});
 }

--- a/packages/web/src/hooks/use-projects.ts
+++ b/packages/web/src/hooks/use-projects.ts
@@ -120,8 +120,9 @@ export interface ProjectWithTeamResponse {
 /**
  * Projects-primary creation: a project owns its own team (1:1). Calls
  * POST /api/projects, which provisions a fresh team from the chosen team-type
- * template (default Blank) and directly creates the project + planning task.
- * See .dev/per-project-teams.md.
+ * template (default Blank) — or, when `source_team_id` is given, from a fresh
+ * snapshot of an existing team — and directly creates the project + planning
+ * task. See .dev/per-project-teams.md.
  */
 export function useCreateProjectWithTeam() {
 	return useMutation({
@@ -129,12 +130,15 @@ export function useCreateProjectWithTeam() {
 			name: string;
 			description: string;
 			template_id?: string;
+			source_team_id?: string;
 			initial_prd?: string;
 			task_prefix?: string;
 		}) => api.post<ProjectWithTeamResponse>('/api/projects', data),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: queryKeys.projects.all() });
 			queryClient.invalidateQueries({ queryKey: queryKeys.teams.all() });
+			// Cloning a team mints a new reusable template — refresh the catalog.
+			queryClient.invalidateQueries({ queryKey: queryKeys.teamTemplates() });
 		},
 	});
 }

--- a/packages/web/src/hooks/use-teams.ts
+++ b/packages/web/src/hooks/use-teams.ts
@@ -19,6 +19,8 @@ export interface Team {
 	summary: string | null;
 	/** Name of the team template this team was created from ("its type"), or null. */
 	primary_template_name: string | null;
+	/** True for the instance-level HQ team (owns the one is_internal project). */
+	is_internal: boolean;
 	mcp_servers: unknown[];
 	settings: TeamSettings;
 	agent_count: number;

--- a/packages/web/test/create-project-from-team.test.tsx
+++ b/packages/web/test/create-project-from-team.test.tsx
@@ -1,0 +1,57 @@
+import { DEFAULT_TEAM_SLUG } from '@hezo/shared';
+import { screen, waitFor, within } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { getTestContext, renderApp } from './helpers/render';
+import { type SeededWorkspace, seedProject, seedWorkspace } from './helpers/seed';
+
+async function openNewProjectDialog() {
+	let ws!: SeededWorkspace;
+	const utils = await renderApp({
+		initialPath: '/home',
+		seed: async () => {
+			ws = await seedWorkspace();
+			await seedProject(ws, { name: 'Existing Project' });
+			sessionStorage.setItem('hezo:activeTeamSlug', ws.team.slug);
+		},
+	});
+	const section = await utils.findByTestId('home-projects-list', undefined, { timeout: 15_000 });
+	await utils.user.click(within(section).getByRole('button', { name: 'New project' }));
+	await screen.findByTestId('create-project-submit');
+	return { ...utils, ws };
+}
+
+test('lists existing teams (not HQ) as cloneable sources and submits source_team_id', async () => {
+	const { user, ws } = await openNewProjectDialog();
+
+	// The seeded project-team is offered as a source; the internal HQ team is not.
+	const sourceCard = await screen.findByTestId(`source-team-card-${ws.team.slug}`);
+	expect(screen.queryByTestId(`source-team-card-${DEFAULT_TEAM_SLUG}`)).toBeNull();
+
+	const submit = screen.getByTestId('create-project-submit') as HTMLButtonElement;
+	// Disabled until name + description + a source selection are all present.
+	expect(submit.disabled).toBe(true);
+
+	await user.type(screen.getByPlaceholderText('e.g. Marketing Site'), 'Cloned From Team');
+	await user.type(
+		screen.getByPlaceholderText(
+			'What is this project? Domain, users, and the core problem it solves.',
+		),
+		'A project cloned from an existing team.',
+	);
+	// Still disabled with no source picked.
+	expect(submit.disabled).toBe(true);
+
+	await user.click(sourceCard);
+	expect(submit.disabled).toBe(false);
+
+	await user.click(submit);
+
+	// The source-team path mints a fresh template named after the source team —
+	// a signal the request carried source_team_id (the template path mints none).
+	const { db } = getTestContext();
+	await waitFor(async () => {
+		// seedWorkspace names the source team "Demo Team".
+		const minted = await db.query('SELECT 1 FROM team_templates WHERE name = $1', ['Demo Team']);
+		expect(minted.rows.length).toBe(1);
+	});
+});


### PR DESCRIPTION
## What & why

Implements **HID-193** — lets the operator pick an **existing team** directly in the New-project dialog as the basis for a new project's team, instead of only choosing a team-type template.

Previously this was a clumsy two-step manual flow ("Save current team as template", then create a project from that saved template). Now selecting a team **snapshots it** (roster, reporting structure, Captain/Coach prompts, skills, preferences, MCP/MPP config) into a fresh, permanent, uniquely-named team-type template via the existing `snapshotTeamAsTemplate`, then provisions the new team from it. The clone therefore also seeds a reusable type for future projects.

## Model

- Picking a team mints a **permanent, reusable** template (no transient/temporary rows). Re-selecting the same team mints a **fresh** template each time, with names auto-uniquified (`Demo Team`, `Demo Team (2)`, …) since `team_templates.name` is `UNIQUE`.
- The dialog selector lists **both** existing templates and existing teams, as a single mutually-exclusive selection. Applies to both the "Create now" and "Plan with the CEO" paths.
- The internal **HQ team is excluded** as a source (snapshotting it would drag CEO/Coach into a project roster) — filtered in the UI and rejected server-side.

## Changes

**Backend**
- `POST /api/projects` and `POST /api/project-intakes` accept an optional `source_team_id` (mutually exclusive with `template_id`). A shared `resolveCreationTemplate` resolves `template_id` | `source_team_id` (snapshot) | Blank, with a `uniqueTemplateName` helper.
- `GET /api/teams` now returns `is_internal` so the UI can hide HQ.

**Frontend**
- New-project dialog renders a "Copy an existing team" card section alongside the team types, sharing one selection model.
- `useCreateProjectWithTeam` / `useStartProjectIntake` pass `source_team_id`; cloning invalidates the team-templates query so the new type appears next time.

## Tests
- **Server** (`project-create-from-team.test.ts`): clone happy-path; roster + reporting structure mirror the source; unique naming across repeat clones; HQ-source and both-fields rejection; the intake path.
- **Web** (`create-project-from-team.test.tsx`): existing-team card shown (HQ hidden), submit gated on name + description + selection, and `source_team_id` wiring verified via the minted template.

All four test tiers' relevant suites pass; pre-commit `typecheck` + `build` green; changed files are biome-clean.

https://claude.ai/code/session_01RzsAAJkT6zTFJ429kaKhVp

---
_Generated by [Claude Code](https://claude.ai/code/session_01RzsAAJkT6zTFJ429kaKhVp)_