### PR TITLE
fix: reconcile budgeting schema migration + unify agent-budget plumbing

### DIFF
--- a/.dev/schema.md
+++ b/.dev/schema.md
@@ -402,6 +402,10 @@ Agent types are linked to team types through the `team_template_agent_types`
 join table, which stores:
 - `reports_to_slug` — org chart hierarchy specific to this team type composition
 - Override columns — allow a team type to customize an agent type's defaults
+  (`heartbeat_interval_override`, and the per-window budget overrides
+  `monthly_budget_override` / `daily_budget_override` / `weekly_budget_override`,
+  nullable; an unset override falls back to the agent type / unlimited). Cloning a
+  team snapshots its agents' live daily/weekly/monthly budgets into these columns.
 - `sort_order` — ensures parents are created before children during agent provisioning
 
 When agents are created from a team type, `member_agents.agent_type_id`

--- a/packages/server/migrations/001_initial_schema.sql
+++ b/packages/server/migrations/001_initial_schema.sql
@@ -151,6 +151,9 @@ CREATE TABLE teams (
     slug                 TEXT NOT NULL UNIQUE,
     description          TEXT NOT NULL DEFAULT '',
     summary              TEXT NOT NULL DEFAULT '',
+    budget_monthly_cents INTEGER NOT NULL DEFAULT 50000,
+    budget_used_cents    INTEGER NOT NULL DEFAULT 0,
+    budget_reset_at      TIMESTAMPTZ NOT NULL DEFAULT date_trunc('month', now()),
     mcp_servers          JSONB NOT NULL DEFAULT '[]'::jsonb,
     mpp_config           JSONB NOT NULL DEFAULT '{"enabled": false}'::jsonb,
     settings             JSONB NOT NULL DEFAULT '{"wake_mentioner_on_reply": true}'::jsonb,
@@ -199,12 +202,10 @@ CREATE TABLE member_agents (
     default_effort          agent_effort NOT NULL DEFAULT 'medium',
     heartbeat_interval_min  INTEGER NOT NULL DEFAULT 60,
     run_timeout_min         INTEGER NOT NULL DEFAULT 60,
-    -- Spend limits per rolling UTC window; 0 = unlimited. Spend is derived from
-    -- cost_entries (no running counter), so there is no reset bookkeeping here.
-    daily_budget_cents      INTEGER NOT NULL DEFAULT 0,
-    weekly_budget_cents     INTEGER NOT NULL DEFAULT 0,
     monthly_budget_cents    INTEGER NOT NULL DEFAULT 3000,
     touches_code            BOOLEAN NOT NULL DEFAULT false,
+    budget_used_cents       INTEGER NOT NULL DEFAULT 0,
+    budget_reset_at         TIMESTAMPTZ NOT NULL DEFAULT date_trunc('month', now()),
     runtime_status          agent_runtime_status NOT NULL DEFAULT 'idle',
     admin_status            agent_admin_status NOT NULL DEFAULT 'enabled',
     mcp_servers             JSONB NOT NULL DEFAULT '[]'::jsonb,
@@ -297,10 +298,6 @@ CREATE TABLE projects (
     designated_repo_id  UUID,
     max_concurrent_runs INTEGER NOT NULL DEFAULT 3 CHECK (max_concurrent_runs >= 1),
     memory_limit_gib    INTEGER NOT NULL DEFAULT 16 CHECK (memory_limit_gib >= 1),
-    -- Spend limits per rolling UTC window; 0 = unlimited. Spend derived from cost_entries.
-    daily_budget_cents      INTEGER NOT NULL DEFAULT 0,
-    weekly_budget_cents     INTEGER NOT NULL DEFAULT 0,
-    monthly_budget_cents    INTEGER NOT NULL DEFAULT 0,
     dev_ports               JSONB NOT NULL DEFAULT '[]'::jsonb,
     execution_started_at    TIMESTAMPTZ,
     created_at              TIMESTAMPTZ NOT NULL DEFAULT now(),
@@ -643,9 +640,6 @@ CREATE INDEX idx_costs_member ON cost_entries(member_id);
 CREATE INDEX idx_costs_task ON cost_entries(task_id);
 CREATE INDEX idx_costs_project ON cost_entries(project_id);
 CREATE INDEX idx_costs_created ON cost_entries(created_at);
--- Windowed spend sums for budget enforcement scan by entity + created_at.
-CREATE INDEX idx_costs_member_created ON cost_entries(member_id, created_at);
-CREATE INDEX idx_costs_project_created ON cost_entries(project_id, created_at);
 
 -------------------------------------------------------------------------------
 -- AUDIT LOG
@@ -1193,6 +1187,46 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
--- Budget enforcement no longer uses a running-counter debit function. Spend is
--- computed on demand from cost_entries over UTC windows (see services/budget.ts),
--- and limits live on member_agents / projects (daily/weekly/monthly_budget_cents).
+CREATE OR REPLACE FUNCTION debit_agent_budget(
+    p_member_id UUID,
+    p_amount_cents INTEGER
+) RETURNS BOOLEAN AS $$
+DECLARE
+    v_agent_budget INTEGER;
+    v_agent_used INTEGER;
+    v_team_id UUID;
+    v_team_budget INTEGER;
+    v_team_used INTEGER;
+BEGIN
+    SELECT ma.monthly_budget_cents, ma.budget_used_cents, m.team_id
+    INTO v_agent_budget, v_agent_used, v_team_id
+    FROM member_agents ma
+    JOIN members m ON m.id = ma.id
+    WHERE ma.id = p_member_id
+    FOR UPDATE OF ma;
+
+    IF (v_agent_used + p_amount_cents) > v_agent_budget THEN
+        RETURN FALSE;
+    END IF;
+
+    SELECT budget_monthly_cents, budget_used_cents
+    INTO v_team_budget, v_team_used
+    FROM teams
+    WHERE id = v_team_id
+    FOR UPDATE;
+
+    IF (v_team_used + p_amount_cents) > v_team_budget THEN
+        RETURN FALSE;
+    END IF;
+
+    UPDATE member_agents
+    SET budget_used_cents = budget_used_cents + p_amount_cents
+    WHERE id = p_member_id;
+
+    UPDATE teams
+    SET budget_used_cents = budget_used_cents + p_amount_cents
+    WHERE id = v_team_id;
+
+    RETURN TRUE;
+END;
+$$ LANGUAGE plpgsql;

--- a/packages/server/migrations/003_budgeting.sql
+++ b/packages/server/migrations/003_budgeting.sql
@@ -1,0 +1,41 @@
+-- Budgeting overhaul (HID-195).
+--
+-- Spend is now computed on demand from cost_entries over rolling UTC windows
+-- (services/budget.ts) rather than tracked with running counters, and there is
+-- no team budget — Hezo is project-centric. Limits live per rolling window
+-- (daily/weekly/monthly; 0 = unlimited) on member_agents and projects.
+--
+-- This migration transforms the frozen 001 baseline into that shape, so existing
+-- instances reach the same schema fresh installs build from 001. Forward-only;
+-- additive columns default to 0 / NULL and the dropped running counters carried
+-- no value worth preserving (spend is re-derived from cost_entries).
+
+-- Teams: drop the old team-level budget + running counter (no team budget now).
+ALTER TABLE teams DROP COLUMN budget_monthly_cents;
+ALTER TABLE teams DROP COLUMN budget_used_cents;
+ALTER TABLE teams DROP COLUMN budget_reset_at;
+
+-- Agents: drop the running counter, add the daily/weekly windows alongside the
+-- existing monthly_budget_cents. 0 = unlimited.
+ALTER TABLE member_agents DROP COLUMN budget_used_cents;
+ALTER TABLE member_agents DROP COLUMN budget_reset_at;
+ALTER TABLE member_agents ADD COLUMN daily_budget_cents  INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE member_agents ADD COLUMN weekly_budget_cents INTEGER NOT NULL DEFAULT 0;
+
+-- Projects: gain their own per-window limits. 0 = unlimited.
+ALTER TABLE projects ADD COLUMN daily_budget_cents   INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE projects ADD COLUMN weekly_budget_cents  INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE projects ADD COLUMN monthly_budget_cents INTEGER NOT NULL DEFAULT 0;
+
+-- Team-type templates round-trip the daily/weekly windows too, so cloning a team
+-- (snapshotTeamAsTemplate -> provisionTeamTemplate) mirrors the source agents'
+-- per-window budgets instead of dropping them. Nullable, like monthly_budget_override.
+ALTER TABLE team_template_agent_types ADD COLUMN daily_budget_override  INTEGER;
+ALTER TABLE team_template_agent_types ADD COLUMN weekly_budget_override INTEGER;
+
+-- The running-counter debit function is gone; spend is derived from cost_entries.
+DROP FUNCTION IF EXISTS debit_agent_budget(UUID, INTEGER);
+
+-- Windowed spend sums for budget enforcement scan by entity + created_at.
+CREATE INDEX idx_costs_member_created  ON cost_entries(member_id, created_at);
+CREATE INDEX idx_costs_project_created ON cost_entries(project_id, created_at);

--- a/packages/server/src/services/agent-budget.ts
+++ b/packages/server/src/services/agent-budget.ts
@@ -1,0 +1,43 @@
+/**
+ * Per-agent spend limits and how they're resolved when provisioning an agent
+ * from a team type. Single source of truth shared by both provisioning paths —
+ * builtin agents (Captain/Coach) in `team-template-apply.ts` and worker agents
+ * in `team-template-provision.ts` — so a new budget window is added here once
+ * instead of being threaded through each path independently.
+ *
+ * Spend itself is derived on demand from `cost_entries` over rolling UTC windows
+ * (see `services/budget.ts`); these are only the limits. 0 = unlimited.
+ */
+
+/** Effective per-rolling-window limits written onto a `member_agents` row. */
+export interface AgentBudgets {
+	monthlyBudgetCents: number;
+	dailyBudgetCents: number;
+	weeklyBudgetCents: number;
+}
+
+/**
+ * The per-agent-type budget override columns a team type carries
+ * (`team_template_agent_types`). NULL means "inherit the agent-type default".
+ */
+export interface AgentBudgetOverrides {
+	monthly_budget_override: number | null;
+	daily_budget_override: number | null;
+	weekly_budget_override: number | null;
+}
+
+/**
+ * Resolve an agent's effective budgets: the team-type override when set, else
+ * the agent-type default. Agent types carry only a monthly default; daily and
+ * weekly have no agent-type default and fall back to unlimited (0).
+ */
+export function resolveAgentBudgets(
+	agentTypeMonthlyCents: number,
+	overrides: Partial<AgentBudgetOverrides> | null | undefined,
+): AgentBudgets {
+	return {
+		monthlyBudgetCents: overrides?.monthly_budget_override ?? agentTypeMonthlyCents,
+		dailyBudgetCents: overrides?.daily_budget_override ?? 0,
+		weeklyBudgetCents: overrides?.weekly_budget_override ?? 0,
+	};
+}

--- a/packages/server/src/services/team-template-apply.ts
+++ b/packages/server/src/services/team-template-apply.ts
@@ -8,6 +8,7 @@ import {
 	MemberType,
 } from '@hezo/shared';
 import { logger } from '../logger';
+import { resolveAgentBudgets } from './agent-budget';
 import { enqueueTeamCoherenceReviewTask } from './description-tasks';
 import { initAgentSystemPrompt, upsertDocument } from './documents';
 import { type ProvisionTeamTemplateResult, provisionTeamTemplate } from './team-template-provision';
@@ -37,6 +38,8 @@ interface BuiltinEffectiveConfig {
 	heartbeatIntervalMin: number;
 	runTimeoutMin: number;
 	monthlyBudgetCents: number;
+	dailyBudgetCents: number;
+	weeklyBudgetCents: number;
 	touchesCode: boolean;
 }
 
@@ -262,7 +265,8 @@ async function loadBuiltinDefaults(
 		defaultEffort: base.default_effort,
 		heartbeatIntervalMin: base.heartbeat_interval_min,
 		runTimeoutMin: base.run_timeout_min,
-		monthlyBudgetCents: base.monthly_budget_cents,
+		// No team-type override here — the agent-type monthly default, daily/weekly unlimited.
+		...resolveAgentBudgets(base.monthly_budget_cents, null),
 		touchesCode: base.touches_code ?? false,
 	};
 }
@@ -288,8 +292,11 @@ async function resolveBuiltinEffectiveConfig(
 	const joinResult = await db.query<{
 		heartbeat_interval_override: number | null;
 		monthly_budget_override: number | null;
+		daily_budget_override: number | null;
+		weekly_budget_override: number | null;
 	}>(
-		`SELECT ctat.heartbeat_interval_override, ctat.monthly_budget_override
+		`SELECT ctat.heartbeat_interval_override, ctat.monthly_budget_override,
+		        ctat.daily_budget_override, ctat.weekly_budget_override
 		 FROM team_template_agent_types ctat
 		 JOIN agent_types at ON at.id = ctat.agent_type_id
 		 WHERE ctat.team_template_id = $1 AND at.slug = $2`,
@@ -301,13 +308,17 @@ async function resolveBuiltinEffectiveConfig(
 	const teamContextOverride = tmpl?.builtin_agent_team_contexts?.[slug] || '';
 	const templateProvidesOverride = !!join || !!promptOverride || !!teamContextOverride;
 
+	const budgets = resolveAgentBudgets(base.monthlyBudgetCents, join);
+
 	return {
 		config: {
 			...base,
 			teamContext: teamContextOverride || base.teamContext,
 			systemPrompt: promptOverride || base.systemPrompt,
 			heartbeatIntervalMin: join?.heartbeat_interval_override ?? base.heartbeatIntervalMin,
-			monthlyBudgetCents: join?.monthly_budget_override ?? base.monthlyBudgetCents,
+			monthlyBudgetCents: budgets.monthlyBudgetCents,
+			dailyBudgetCents: budgets.dailyBudgetCents,
+			weeklyBudgetCents: budgets.weeklyBudgetCents,
 		},
 		templateProvidesOverride,
 	};
@@ -330,8 +341,9 @@ async function insertBuiltinAgent(
 		`INSERT INTO member_agents (id, agent_type_id, title, slug, role_description, summary,
 		                            team_context,
 		                            default_effort, heartbeat_interval_min, run_timeout_min,
-		                            monthly_budget_cents, touches_code)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8::agent_effort, $9, $10, $11, $12)`,
+		                            monthly_budget_cents, daily_budget_cents, weekly_budget_cents,
+		                            touches_code)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8::agent_effort, $9, $10, $11, $12, $13, $14)`,
 		[
 			memberId,
 			config.agentTypeId,
@@ -344,6 +356,8 @@ async function insertBuiltinAgent(
 			config.heartbeatIntervalMin,
 			config.runTimeoutMin,
 			config.monthlyBudgetCents,
+			config.dailyBudgetCents,
+			config.weeklyBudgetCents,
 			config.touchesCode,
 		],
 	);
@@ -368,10 +382,13 @@ async function updateBuiltinAgent(
 		heartbeat_interval_min: number;
 		run_timeout_min: number;
 		monthly_budget_cents: number;
+		daily_budget_cents: number;
+		weekly_budget_cents: number;
 		touches_code: boolean;
 	}>(
 		`SELECT title, role_description, summary, team_context, default_effort::text,
-		        heartbeat_interval_min, run_timeout_min, monthly_budget_cents, touches_code
+		        heartbeat_interval_min, run_timeout_min, monthly_budget_cents,
+		        daily_budget_cents, weekly_budget_cents, touches_code
 		 FROM member_agents WHERE id = $1`,
 		[memberId],
 	);
@@ -386,6 +403,8 @@ async function updateBuiltinAgent(
 		current.heartbeat_interval_min !== config.heartbeatIntervalMin ||
 		current.run_timeout_min !== config.runTimeoutMin ||
 		current.monthly_budget_cents !== config.monthlyBudgetCents ||
+		current.daily_budget_cents !== config.dailyBudgetCents ||
+		current.weekly_budget_cents !== config.weeklyBudgetCents ||
 		current.touches_code !== config.touchesCode;
 
 	if (metadataChanged) {
@@ -398,8 +417,10 @@ async function updateBuiltinAgent(
 			     heartbeat_interval_min = $5,
 			     run_timeout_min = $6,
 			     monthly_budget_cents = $7,
-			     touches_code = $8
-			 WHERE id = $9`,
+			     daily_budget_cents = $8,
+			     weekly_budget_cents = $9,
+			     touches_code = $10
+			 WHERE id = $11`,
 			[
 				config.title,
 				config.roleDescription,
@@ -408,6 +429,8 @@ async function updateBuiltinAgent(
 				config.heartbeatIntervalMin,
 				config.runTimeoutMin,
 				config.monthlyBudgetCents,
+				config.dailyBudgetCents,
+				config.weeklyBudgetCents,
 				config.touchesCode,
 				memberId,
 			],

--- a/packages/server/src/services/team-template-provision.ts
+++ b/packages/server/src/services/team-template-provision.ts
@@ -5,6 +5,7 @@ import { deriveSkillSummary } from '../lib/skill-summary';
 import { toSlug } from '../lib/slug';
 import { withTransaction } from '../lib/sql';
 import { logger } from '../logger';
+import { resolveAgentBudgets } from './agent-budget';
 import { initAgentSystemPrompt } from './documents';
 import { downloadSkillContent, SkillDownloadError } from './skill-downloader';
 
@@ -39,6 +40,8 @@ interface AgentTypeRow {
 	reports_to_slug: string | null;
 	heartbeat_interval_override: number | null;
 	monthly_budget_override: number | null;
+	daily_budget_override: number | null;
+	weekly_budget_override: number | null;
 }
 
 export interface ProvisionTeamTemplateResult {
@@ -55,7 +58,8 @@ async function loadTemplateAgentTypes(db: PGlite, templateIds: string[]): Promis
 			        at.default_effort, at.heartbeat_interval_min, at.monthly_budget_cents,
 			        at.touches_code,
 			        ctat.reports_to_slug,
-			        ctat.heartbeat_interval_override, ctat.monthly_budget_override
+			        ctat.heartbeat_interval_override, ctat.monthly_budget_override,
+				        ctat.daily_budget_override, ctat.weekly_budget_override
 			 FROM team_template_agent_types ctat
 			 JOIN agent_types at ON at.id = ctat.agent_type_id
 			 WHERE ctat.team_template_id = $1
@@ -190,7 +194,7 @@ export async function provisionTeamTemplate(
 			}
 
 			const heartbeat = row.heartbeat_interval_override ?? row.heartbeat_interval_min;
-			const budget = row.monthly_budget_override ?? row.monthly_budget_cents;
+			const budgets = resolveAgentBudgets(row.monthly_budget_cents, row);
 
 			const memberResult = await db.query<{ id: string }>(
 				`INSERT INTO members (team_id, member_type, display_name)
@@ -206,8 +210,9 @@ export async function provisionTeamTemplate(
 				`INSERT INTO member_agents (id, agent_type_id, title, slug, role_description, summary,
 			                            team_context,
 			                            default_effort, heartbeat_interval_min, monthly_budget_cents,
+			                            daily_budget_cents, weekly_budget_cents,
 			                            touches_code)
-			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8::agent_effort, $9, $10, $11)`,
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8::agent_effort, $9, $10, $11, $12, $13)`,
 				[
 					memberId,
 					row.id,
@@ -218,7 +223,9 @@ export async function provisionTeamTemplate(
 					row.default_team_context ?? '',
 					row.default_effort,
 					heartbeat,
-					budget,
+					budgets.monthlyBudgetCents,
+					budgets.dailyBudgetCents,
+					budgets.weeklyBudgetCents,
 					row.touches_code ?? false,
 				],
 			);

--- a/packages/server/src/services/team-template-snapshot.ts
+++ b/packages/server/src/services/team-template-snapshot.ts
@@ -21,6 +21,8 @@ interface RosterAgent {
 	reports_to: string | null;
 	heartbeat_interval_min: number;
 	monthly_budget_cents: number;
+	daily_budget_cents: number;
+	weekly_budget_cents: number;
 	team_context: string;
 }
 
@@ -46,7 +48,8 @@ export async function snapshotTeamAsTemplate(
 	return withTransaction(db, async () => {
 		const agentsRes = await db.query<RosterAgent>(
 			`SELECT ma.id, ma.slug, ma.agent_type_id, ma.reports_to,
-			        ma.heartbeat_interval_min, ma.monthly_budget_cents, ma.team_context
+			        ma.heartbeat_interval_min, ma.monthly_budget_cents,
+			        ma.daily_budget_cents, ma.weekly_budget_cents, ma.team_context
 			 FROM member_agents ma
 			 JOIN members m ON m.id = ma.id
 			 WHERE m.team_id = $1 AND m.member_type = $2
@@ -125,14 +128,16 @@ export async function snapshotTeamAsTemplate(
 			await db.query(
 				`INSERT INTO team_template_agent_types
 				   (team_template_id, agent_type_id, reports_to_slug, heartbeat_interval_override,
-				    monthly_budget_override, sort_order)
-				 VALUES ($1, $2, $3, $4, $5, $6)`,
+				    monthly_budget_override, daily_budget_override, weekly_budget_override, sort_order)
+				 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
 				[
 					newTemplateId,
 					a.agent_type_id,
 					reportsToSlug,
 					a.heartbeat_interval_min,
 					a.monthly_budget_cents,
+					a.daily_budget_cents,
+					a.weekly_budget_cents,
 					sortOrder,
 				],
 			);

--- a/packages/server/test/migrate-budgeting.test.ts
+++ b/packages/server/test/migrate-budgeting.test.ts
@@ -1,0 +1,171 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { PGlite } from '@electric-sql/pglite';
+import { vector } from '@electric-sql/pglite/vector';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { safeClose } from './helpers';
+
+// 003_budgeting.sql transforms the frozen 001 baseline into the derived-spend
+// budgeting schema: it drops the team budget + running counters and the
+// debit_agent_budget() function, adds the daily/weekly windows to agents, adds
+// per-window limits to projects, adds the daily/weekly overrides to the
+// team-type join table (so clones mirror agent budgets), and adds the windowed
+// cost indexes. This drives the REAL migration files through the same
+// apply-in-order path production uses (001 -> 002 -> 003) against populated
+// data, asserting both the schema delta and that existing rows survive.
+
+function migrationsDir(): string {
+	try {
+		return fileURLToPath(new URL('../migrations', import.meta.url));
+	} catch {
+		const override = process.env.HEZO_MIGRATIONS_DIR;
+		if (!override) throw new Error('HEZO_MIGRATIONS_DIR unset and import.meta.url not a file URL');
+		return override;
+	}
+}
+
+function loadMigration(file: string): string {
+	// PGlite loads pgcrypto built-in; strip only that, keep vector.
+	return readFileSync(join(migrationsDir(), file), 'utf-8').replace(
+		/CREATE EXTENSION IF NOT EXISTS "pgcrypto";/g,
+		'',
+	);
+}
+
+async function columnExists(db: PGlite, table: string, column: string): Promise<boolean> {
+	const r = await db.query(
+		`SELECT 1 FROM information_schema.columns WHERE table_name = $1 AND column_name = $2`,
+		[table, column],
+	);
+	return r.rows.length > 0;
+}
+
+describe('003_budgeting migration', () => {
+	let db: PGlite;
+	let agentId: string;
+	let costId: string;
+
+	beforeAll(async () => {
+		db = new PGlite({ extensions: { vector } });
+
+		// Apply the baseline + the smoke migration: the pre-budgeting schema.
+		await db.exec(loadMigration('001_initial_schema.sql'));
+		await db.exec(loadMigration('002_migration_smoke.sql'));
+
+		// Sanity: the pre-budgeting shape is what we expect to migrate FROM.
+		expect(await columnExists(db, 'teams', 'budget_monthly_cents')).toBe(true);
+		expect(await columnExists(db, 'member_agents', 'budget_used_cents')).toBe(true);
+		expect(await columnExists(db, 'projects', 'daily_budget_cents')).toBe(false);
+
+		// Populate: a team (with an old team budget), an agent (with an old running
+		// counter + a tuned monthly budget), a project, and a cost entry.
+		const team = await db.query<{ id: string }>(
+			`INSERT INTO teams (name, slug, budget_monthly_cents) VALUES ('Acme', 'acme', 12345) RETURNING id`,
+		);
+		const teamId = team.rows[0].id;
+		const member = await db.query<{ id: string }>(
+			`INSERT INTO members (team_id, member_type, display_name) VALUES ($1, 'agent', 'Bot') RETURNING id`,
+			[teamId],
+		);
+		agentId = member.rows[0].id;
+		await db.query(
+			`INSERT INTO member_agents (id, title, slug, monthly_budget_cents, budget_used_cents)
+			 VALUES ($1, 'Bot', 'bot', 4242, 99)`,
+			[agentId],
+		);
+		await db.query(
+			`INSERT INTO projects (team_id, name, slug, task_prefix) VALUES ($1, 'Ops', 'ops', 'OPS')`,
+			[teamId],
+		);
+		const cost = await db.query<{ id: string }>(
+			`INSERT INTO cost_entries (team_id, member_id, amount_cents, description)
+			 VALUES ($1, $2, 1234, 'a run') RETURNING id`,
+			[teamId, agentId],
+		);
+		costId = cost.rows[0].id;
+
+		// The actual upgrade step.
+		await db.exec(loadMigration('003_budgeting.sql'));
+	});
+
+	it('drops the team budget + running counters', async () => {
+		expect(await columnExists(db, 'teams', 'budget_monthly_cents')).toBe(false);
+		expect(await columnExists(db, 'teams', 'budget_used_cents')).toBe(false);
+		expect(await columnExists(db, 'teams', 'budget_reset_at')).toBe(false);
+		expect(await columnExists(db, 'member_agents', 'budget_used_cents')).toBe(false);
+		expect(await columnExists(db, 'member_agents', 'budget_reset_at')).toBe(false);
+	});
+
+	it('adds the daily/weekly agent windows and per-window project limits', async () => {
+		expect(await columnExists(db, 'member_agents', 'daily_budget_cents')).toBe(true);
+		expect(await columnExists(db, 'member_agents', 'weekly_budget_cents')).toBe(true);
+		expect(await columnExists(db, 'projects', 'daily_budget_cents')).toBe(true);
+		expect(await columnExists(db, 'projects', 'weekly_budget_cents')).toBe(true);
+		expect(await columnExists(db, 'projects', 'monthly_budget_cents')).toBe(true);
+	});
+
+	it('adds the daily/weekly overrides to the team-type join table', async () => {
+		expect(await columnExists(db, 'team_template_agent_types', 'daily_budget_override')).toBe(true);
+		expect(await columnExists(db, 'team_template_agent_types', 'weekly_budget_override')).toBe(
+			true,
+		);
+	});
+
+	it('drops the debit_agent_budget function', async () => {
+		const r = await db.query(`SELECT 1 FROM pg_proc WHERE proname = 'debit_agent_budget'`);
+		expect(r.rows.length).toBe(0);
+	});
+
+	it('adds the windowed cost indexes', async () => {
+		const r = await db.query<{ indexname: string }>(
+			`SELECT indexname FROM pg_indexes WHERE indexname IN ('idx_costs_member_created', 'idx_costs_project_created')`,
+		);
+		expect(r.rows.map((x) => x.indexname).sort()).toEqual([
+			'idx_costs_member_created',
+			'idx_costs_project_created',
+		]);
+	});
+
+	it('preserves existing rows through the refactor', async () => {
+		// The agent keeps its tuned monthly budget and gains zeroed (unlimited) windows.
+		const agent = await db.query<{
+			monthly_budget_cents: number;
+			daily_budget_cents: number;
+			weekly_budget_cents: number;
+		}>(
+			`SELECT monthly_budget_cents, daily_budget_cents, weekly_budget_cents
+			 FROM member_agents WHERE id = $1`,
+			[agentId],
+		);
+		expect(agent.rows[0]).toEqual({
+			monthly_budget_cents: 4242,
+			daily_budget_cents: 0,
+			weekly_budget_cents: 0,
+		});
+
+		// The cost entry survives — spend is re-derived from these.
+		const cost = await db.query<{ amount_cents: number }>(
+			`SELECT amount_cents FROM cost_entries WHERE id = $1`,
+			[costId],
+		);
+		expect(cost.rows[0]?.amount_cents).toBe(1234);
+	});
+
+	it('leaves projects defaulting to unlimited (0) per window', async () => {
+		const proj = await db.query<{
+			daily_budget_cents: number;
+			weekly_budget_cents: number;
+			monthly_budget_cents: number;
+		}>(`SELECT daily_budget_cents, weekly_budget_cents, monthly_budget_cents FROM projects`);
+		expect(proj.rows[0]).toEqual({
+			daily_budget_cents: 0,
+			weekly_budget_cents: 0,
+			monthly_budget_cents: 0,
+		});
+	});
+
+	it('cleans up', async () => {
+		await safeClose(db);
+	});
+});

--- a/packages/server/test/project-create-from-team.test.ts
+++ b/packages/server/test/project-create-from-team.test.ts
@@ -59,6 +59,31 @@ async function templateCount(): Promise<number> {
 	return res.rows[0].n;
 }
 
+async function agentBudgets(
+	teamId: string,
+	slug: string,
+): Promise<{ daily: number; weekly: number; monthly: number } | undefined> {
+	const res = await db.query<{
+		daily_budget_cents: number;
+		weekly_budget_cents: number;
+		monthly_budget_cents: number;
+	}>(
+		`SELECT ma.daily_budget_cents, ma.weekly_budget_cents, ma.monthly_budget_cents
+		 FROM member_agents ma
+		 JOIN members m ON m.id = ma.id
+		 WHERE m.team_id = $1 AND ma.slug = $2`,
+		[teamId, slug],
+	);
+	const row = res.rows[0];
+	return row
+		? {
+				daily: row.daily_budget_cents,
+				weekly: row.weekly_budget_cents,
+				monthly: row.monthly_budget_cents,
+			}
+		: undefined;
+}
+
 describe('POST /projects — clone an existing team (source_team_id)', () => {
 	it('provisions the new team from a fresh snapshot of the source team', async () => {
 		// A source team with a non-trivial roster.
@@ -107,6 +132,47 @@ describe('POST /projects — clone an existing team (source_team_id)', () => {
 			'Clone Source Co',
 		]);
 		expect(minted.rows).toHaveLength(1);
+	});
+
+	it("mirrors the source agents' per-window (daily/weekly/monthly) budgets", async () => {
+		const source = (
+			await (
+				await createProject({
+					name: 'Budget Source Co',
+					description: 'Source with tuned budgets.',
+					template_id: startupTemplateId,
+				})
+			).json()
+		).data as CreatedProjectTeam;
+
+		// Tune the captain's three budget windows on the source team.
+		await db.query(
+			`UPDATE member_agents ma SET daily_budget_cents = 111, weekly_budget_cents = 222, monthly_budget_cents = 333
+			 FROM members m WHERE m.id = ma.id AND m.team_id = $1 AND ma.slug = 'captain'`,
+			[source.team_id],
+		);
+
+		// Sanity: the source captain actually carries the tuned windows.
+		expect(await agentBudgets(source.team_id, 'captain')).toEqual({
+			daily: 111,
+			weekly: 222,
+			monthly: 333,
+		});
+
+		const cloneRes = await createProject({
+			name: 'Budget Clone Co',
+			description: 'Clones the tuned budgets.',
+			source_team_id: source.team_id,
+		});
+		expect(cloneRes.status).toBe(201);
+		const clone = (await cloneRes.json()).data as CreatedProjectTeam;
+
+		// The clone carries all three windows, not just monthly.
+		expect(await agentBudgets(clone.team_id, 'captain')).toEqual({
+			daily: 111,
+			weekly: 222,
+			monthly: 333,
+		});
 	});
 
 	it('mints a fresh, distinctly-named template each time the same team is cloned', async () => {


### PR DESCRIPTION
## Why

Reviewing today's seven merged PRs for cross-PR logic conflicts surfaced one that git merged textually clean but breaks at runtime, plus a smaller interaction gap:

1. **Budgeting (#227) edited the frozen `001_initial_schema.sql`** — *after* the migration system (#224, merged earlier the same day) declared `001` the checksummed, apply-once baseline. On an existing instance the runner detects the checksum mismatch, **warns and skips** the changed `001`, so the budget columns never get added and `services/budget.ts` + the costs/budget routes query columns that don't exist. Fresh installs were fine; **upgrades were broken** — exactly the failure `#224` exists to prevent.

2. **Cloning a team (#228) silently dropped the daily/weekly agent budgets (#227)** — the clone routes through the template snapshot + provisioning paths, which only carried `monthly_budget_override`.

Everything else across the seven PRs (`mcp/tools.ts`, `template-resolver.ts`, task parent-resolution vs run-state dot, `startup.ts` ordering, sidebar) was verified logically coherent with no leftover references to removed columns/functions.

## What

- **Restore `001` to its shipped bytes** and move the budgeting overhaul into a tracked **`003_budgeting.sql`**: drop the team budget + running counters and `debit_agent_budget()`, add the `daily`/`weekly` windows to `member_agents`, add per-window limits to `projects`, add the `daily`/`weekly` override columns to `team_template_agent_types`, and add the windowed cost indexes. Fresh installs run `001 → 002 → 003`; existing installs run `003` only — both converge to the same schema.

- **Plumb daily/weekly budgets through cloning** in the snapshot + both provisioning paths so a clone mirrors the source agents' per-window budgets.

- **Unify the resolution logic** in `services/agent-budget.ts` (`resolveAgentBudgets`). Both provisioning paths (builtin agents in `team-template-apply`, worker agents in `team-template-provision`) previously duplicated the `override ?? default` precedence — which is exactly why the daily/weekly gap slipped through one path. A new budget window is now added in one place.

## Tests

- `migrate-budgeting.test.ts` — applies the real `001 → 002 → 003` against populated data and asserts the schema delta **and** row preservation (agent keeps its tuned monthly budget + gains zeroed windows; cost entries survive).
- `project-create-from-team.test.ts` — new per-window budget round-trip: tune a source agent's daily/weekly/monthly, clone, assert all three carry over.
- Full server vitest + Bun-native tiers pass (the only failures are pre-existing, environment-only `git.test.ts` worktree / `ssh-agent-server.test.ts` signing tests that also fail on a clean tree in this sandbox). Typecheck + lint + production build (which bundles all 3 migrations) clean.

> Note: any **dev** database that ran today's transient broken `main` (the budget-baked `001`, never released) is in an inconsistent migration state and should be reset — `003` strictly transforms the canonical `001`, which is the only schema any released version shipped.

https://claude.ai/code/session_01N8gaynrcQZjcy4dg2MZLmH

---
_Generated by [Claude Code](https://claude.ai/code/session_01N8gaynrcQZjcy4dg2MZLmH)_