### PR TITLE
feat: cross-window budget validation + per-window disable

### DIFF
--- a/packages/server/src/lib/budget-validation.ts
+++ b/packages/server/src/lib/budget-validation.ts
@@ -1,0 +1,23 @@
+import { type BudgetWindowsCents, validateBudgetWindows } from '@hezo/shared';
+
+/**
+ * Validate a budget trio destined for a `member_agents`/`projects` row. Enforces
+ * non-negative integer cents per window plus the cross-window consistency rules
+ * (the rules themselves live in `@hezo/shared`, shared with the web forms).
+ * Returns the first problem's message, or null when the trio is coherent —
+ * callers map a non-null result to a 400.
+ */
+export function budgetWindowsError(w: BudgetWindowsCents): string | null {
+	for (const field of [
+		'daily_budget_cents',
+		'weekly_budget_cents',
+		'monthly_budget_cents',
+	] as const) {
+		const value = w[field];
+		if (!Number.isInteger(value) || value < 0) {
+			return `${field} must be an integer ≥ 0`;
+		}
+	}
+	const violations = validateBudgetWindows(w);
+	return violations.length > 0 ? violations[0].message : null;
+}

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -20,6 +20,7 @@ import {
 import { Hono } from 'hono';
 import { trackBackground } from '../lib/background';
 import { broadcastChange } from '../lib/broadcast';
+import { budgetWindowsError } from '../lib/budget-validation';
 import {
 	actorTypeFromAuth,
 	resolveActor,
@@ -213,6 +214,8 @@ agentsRoutes.post('/projects/:projectId/agents', async (c) => {
 		reports_to?: string;
 		default_effort?: string;
 		heartbeat_interval_min?: number;
+		daily_budget_cents?: number;
+		weekly_budget_cents?: number;
 		monthly_budget_cents?: number;
 		touches_code?: boolean;
 		mcp_servers?: unknown[];
@@ -224,6 +227,15 @@ agentsRoutes.post('/projects/:projectId/agents', async (c) => {
 
 	if (body.default_effort !== undefined && !isAgentEffort(body.default_effort)) {
 		return err(c, 'INVALID_REQUEST', `Invalid default_effort: ${body.default_effort}`, 400);
+	}
+
+	const budgetError = budgetWindowsError({
+		daily_budget_cents: body.daily_budget_cents ?? 0,
+		weekly_budget_cents: body.weekly_budget_cents ?? 0,
+		monthly_budget_cents: body.monthly_budget_cents ?? 3000,
+	});
+	if (budgetError) {
+		return err(c, 'INVALID_REQUEST', budgetError, 400);
 	}
 
 	const slug = toSlug(body.title);
@@ -254,8 +266,8 @@ agentsRoutes.post('/projects/:projectId/agents', async (c) => {
 			const newMemberId = memberResult.rows[0].id;
 
 			await db.query(
-				`INSERT INTO member_agents (id, title, slug, role_description, reports_to, default_effort, heartbeat_interval_min, monthly_budget_cents, touches_code, mcp_servers)
-       VALUES ($1, $2, $3, $4, $5, $6::agent_effort, $7, $8, $9, $10::jsonb)`,
+				`INSERT INTO member_agents (id, title, slug, role_description, reports_to, default_effort, heartbeat_interval_min, daily_budget_cents, weekly_budget_cents, monthly_budget_cents, touches_code, mcp_servers)
+       VALUES ($1, $2, $3, $4, $5, $6::agent_effort, $7, $8, $9, $10, $11, $12::jsonb)`,
 				[
 					newMemberId,
 					body.title.trim(),
@@ -264,6 +276,8 @@ agentsRoutes.post('/projects/:projectId/agents', async (c) => {
 					body.reports_to ?? null,
 					body.default_effort ?? DEFAULT_EFFORT,
 					body.heartbeat_interval_min ?? 60,
+					body.daily_budget_cents ?? 0,
+					body.weekly_budget_cents ?? 0,
 					body.monthly_budget_cents ?? 3000,
 					body.touches_code ?? false,
 					JSON.stringify(body.mcp_servers ?? []),
@@ -324,6 +338,8 @@ agentsRoutes.post('/projects/:projectId/agents/onboard', async (c) => {
 		system_prompt?: string;
 		default_effort?: string;
 		heartbeat_interval_min?: number;
+		daily_budget_cents?: number;
+		weekly_budget_cents?: number;
 		monthly_budget_cents?: number;
 		touches_code?: boolean;
 	}>();
@@ -334,6 +350,15 @@ agentsRoutes.post('/projects/:projectId/agents/onboard', async (c) => {
 
 	if (body.default_effort !== undefined && !isAgentEffort(body.default_effort)) {
 		return err(c, 'INVALID_REQUEST', `Invalid default_effort: ${body.default_effort}`, 400);
+	}
+
+	const budgetError = budgetWindowsError({
+		daily_budget_cents: body.daily_budget_cents ?? 0,
+		weekly_budget_cents: body.weekly_budget_cents ?? 0,
+		monthly_budget_cents: body.monthly_budget_cents ?? 3000,
+	});
+	if (budgetError) {
+		return err(c, 'INVALID_REQUEST', budgetError, 400);
 	}
 
 	const slug = toSlug(body.title);
@@ -373,6 +398,8 @@ agentsRoutes.post('/projects/:projectId/agents/onboard', async (c) => {
 		system_prompt: body.system_prompt ?? '',
 		default_effort: body.default_effort ?? DEFAULT_EFFORT,
 		heartbeat_interval_min: body.heartbeat_interval_min ?? 60,
+		daily_budget_cents: body.daily_budget_cents ?? 0,
+		weekly_budget_cents: body.weekly_budget_cents ?? 0,
 		monthly_budget_cents: body.monthly_budget_cents ?? 3000,
 		touches_code: body.touches_code ?? false,
 	};
@@ -389,9 +416,10 @@ agentsRoutes.post('/projects/:projectId/agents/onboard', async (c) => {
 
 			await db.query(
 				`INSERT INTO member_agents (id, title, slug, role_description,
-				                            default_effort, heartbeat_interval_min, monthly_budget_cents,
+				                            default_effort, heartbeat_interval_min,
+				                            daily_budget_cents, weekly_budget_cents, monthly_budget_cents,
 				                            touches_code, admin_status)
-				 VALUES ($1, $2, $3, $4, $5::agent_effort, $6, $7, $8, $9::agent_admin_status)`,
+				 VALUES ($1, $2, $3, $4, $5::agent_effort, $6, $7, $8, $9, $10, $11::agent_admin_status)`,
 				[
 					memberId,
 					proposal.title,
@@ -399,6 +427,8 @@ agentsRoutes.post('/projects/:projectId/agents/onboard', async (c) => {
 					proposal.role_description,
 					proposal.default_effort,
 					proposal.heartbeat_interval_min,
+					proposal.daily_budget_cents,
+					proposal.weekly_budget_cents,
 					proposal.monthly_budget_cents,
 					proposal.touches_code,
 					AgentAdminStatus.Enabled,
@@ -772,6 +802,34 @@ agentsRoutes.patch('/projects/:projectId/agents/:agentId', async (c) => {
 				'model_override_model requires model_override_provider',
 				400,
 			);
+		}
+	}
+
+	// Budget limits: 0 = unlimited. Validate the *merged* trio (incoming ?? stored)
+	// since a PATCH may touch only one window — per-field integer ≥ 0 plus the
+	// cross-window consistency rules (shared with the web forms).
+	if (
+		body.daily_budget_cents !== undefined ||
+		body.weekly_budget_cents !== undefined ||
+		body.monthly_budget_cents !== undefined
+	) {
+		const current = await db.query<{
+			daily_budget_cents: number;
+			weekly_budget_cents: number;
+			monthly_budget_cents: number;
+		}>(
+			`SELECT daily_budget_cents, weekly_budget_cents, monthly_budget_cents
+			 FROM member_agents WHERE id = $1`,
+			[agentId],
+		);
+		const stored = current.rows[0];
+		const budgetError = budgetWindowsError({
+			daily_budget_cents: body.daily_budget_cents ?? stored.daily_budget_cents,
+			weekly_budget_cents: body.weekly_budget_cents ?? stored.weekly_budget_cents,
+			monthly_budget_cents: body.monthly_budget_cents ?? stored.monthly_budget_cents,
+		});
+		if (budgetError) {
+			return err(c, 'INVALID_REQUEST', budgetError, 400);
 		}
 	}
 

--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -10,6 +10,7 @@ import {
 import { type Context, Hono } from 'hono';
 import { trackBackground } from '../lib/background';
 import { broadcastChange, broadcastProjectUpdate } from '../lib/broadcast';
+import { budgetWindowsError } from '../lib/budget-validation';
 import { ref } from '../lib/log-ref';
 import { err, ok } from '../lib/response';
 import { toProjectTaskPrefix, toSlug, uniqueSlug } from '../lib/slug';
@@ -516,10 +517,15 @@ projectsRoutes.patch('/projects/:projectId', async (c) => {
 	const projectId = c.get('projectId') as string;
 	if (!projectId) return err(c, 'NOT_FOUND', 'Project not found', 404);
 
-	const existing = await db.query('SELECT id FROM projects WHERE id = $1 AND team_id = $2', [
-		projectId,
-		teamId,
-	]);
+	const existing = await db.query<{
+		daily_budget_cents: number;
+		weekly_budget_cents: number;
+		monthly_budget_cents: number;
+	}>(
+		`SELECT daily_budget_cents, weekly_budget_cents, monthly_budget_cents
+		 FROM projects WHERE id = $1 AND team_id = $2`,
+		[projectId, teamId],
+	);
 	if (existing.rows.length === 0) {
 		return err(c, 'NOT_FOUND', 'Project not found', 404);
 	}
@@ -574,20 +580,31 @@ projectsRoutes.patch('/projects/:projectId', async (c) => {
 		params.push(body.memory_limit_gib);
 		idx++;
 	}
-	// Budget limits: 0 = unlimited. Reject negatives/non-integers.
-	for (const column of [
+	// Budget limits: 0 = unlimited. Validate the *merged* trio (incoming ?? stored)
+	// since a PATCH may touch only one window — enforces both per-field integer ≥ 0
+	// and the cross-window consistency rules (shared with the web forms).
+	const budgetColumns = [
 		'daily_budget_cents',
 		'weekly_budget_cents',
 		'monthly_budget_cents',
-	] as const) {
-		const value = body[column];
-		if (value === undefined) continue;
-		if (!Number.isInteger(value) || value < 0) {
-			return err(c, 'INVALID_REQUEST', `${column} must be an integer ≥ 0`, 400);
+	] as const;
+	if (budgetColumns.some((column) => body[column] !== undefined)) {
+		const current = existing.rows[0];
+		const merged = {
+			daily_budget_cents: body.daily_budget_cents ?? current.daily_budget_cents,
+			weekly_budget_cents: body.weekly_budget_cents ?? current.weekly_budget_cents,
+			monthly_budget_cents: body.monthly_budget_cents ?? current.monthly_budget_cents,
+		};
+		const budgetError = budgetWindowsError(merged);
+		if (budgetError) {
+			return err(c, 'INVALID_REQUEST', budgetError, 400);
 		}
-		sets.push(`${column} = $${idx}`);
-		params.push(value);
-		idx++;
+		for (const column of budgetColumns) {
+			if (body[column] === undefined) continue;
+			sets.push(`${column} = $${idx}`);
+			params.push(body[column]);
+			idx++;
+		}
 	}
 
 	if (sets.length === 0) {

--- a/packages/server/src/services/approval-handlers/hire.ts
+++ b/packages/server/src/services/approval-handlers/hire.ts
@@ -41,8 +41,9 @@ export const hireHandler: ApprovalHandler = {
 		await db.query(
 			`INSERT INTO member_agents (id, title, slug, role_description,
 			                            default_effort, heartbeat_interval_min,
-			                            monthly_budget_cents, touches_code, admin_status)
-			 VALUES ($1, $2, $3, $4, $5::agent_effort, $6, $7, $8, $9::agent_admin_status)`,
+			                            daily_budget_cents, weekly_budget_cents, monthly_budget_cents,
+			                            touches_code, admin_status)
+			 VALUES ($1, $2, $3, $4, $5::agent_effort, $6, $7, $8, $9, $10, $11::agent_admin_status)`,
 			[
 				memberId,
 				title,
@@ -50,6 +51,8 @@ export const hireHandler: ApprovalHandler = {
 				(payload.role_description as string) ?? '',
 				(payload.default_effort as string) ?? 'medium',
 				(payload.heartbeat_interval_min as number) ?? 60,
+				(payload.daily_budget_cents as number) ?? 0,
+				(payload.weekly_budget_cents as number) ?? 0,
 				(payload.monthly_budget_cents as number) ?? 3000,
 				(payload.touches_code as boolean) ?? false,
 				AgentAdminStatus.Enabled,

--- a/packages/server/test/budget-validation.test.ts
+++ b/packages/server/test/budget-validation.test.ts
@@ -1,0 +1,154 @@
+import {
+	centsToDollars,
+	dollarsToCents,
+	minMonthlyCents,
+	minWeeklyCents,
+	normalizeBudgetWindowsUp,
+	validateBudgetWindows,
+} from '@hezo/shared';
+import { describe, expect, it } from 'vitest';
+
+// daily $20/day → weekly floor $140, monthly floor ceil(2000*365/12)=60834 cents.
+const DAILY = 2000;
+const WEEKLY_FLOOR = 14000; // 2000 * 7
+const MONTHLY_FLOOR_FROM_DAILY = 60834; // ceil(2000 * 365 / 12)
+const WEEKLY = 14000;
+const MONTHLY_FLOOR_FROM_WEEKLY = 60667; // ceil(14000 * 52 / 12)
+
+describe('minWeeklyCents', () => {
+	it('is daily × 7 when daily is enabled', () => {
+		expect(minWeeklyCents(DAILY)).toBe(WEEKLY_FLOOR);
+	});
+	it('is 0 (no constraint) when daily is disabled', () => {
+		expect(minWeeklyCents(0)).toBe(0);
+	});
+});
+
+describe('minMonthlyCents', () => {
+	it('takes the daily-implied floor (ceil of /12)', () => {
+		expect(minMonthlyCents(DAILY, 0)).toBe(MONTHLY_FLOOR_FROM_DAILY);
+	});
+	it('takes the weekly-implied floor when no daily', () => {
+		expect(minMonthlyCents(0, WEEKLY)).toBe(MONTHLY_FLOOR_FROM_WEEKLY);
+	});
+	it('takes the larger of the two when both enabled', () => {
+		expect(minMonthlyCents(DAILY, WEEKLY)).toBe(
+			Math.max(MONTHLY_FLOOR_FROM_DAILY, MONTHLY_FLOOR_FROM_WEEKLY),
+		);
+	});
+	it('is 0 when both shorter windows are disabled', () => {
+		expect(minMonthlyCents(0, 0)).toBe(0);
+	});
+});
+
+describe('validateBudgetWindows', () => {
+	it('accepts a coherent trio exactly at the floors', () => {
+		expect(
+			validateBudgetWindows({
+				daily_budget_cents: DAILY,
+				weekly_budget_cents: WEEKLY_FLOOR,
+				monthly_budget_cents: MONTHLY_FLOOR_FROM_DAILY,
+			}),
+		).toEqual([]);
+	});
+
+	it('rejects weekly one cent under the daily-implied floor', () => {
+		const v = validateBudgetWindows({
+			daily_budget_cents: DAILY,
+			weekly_budget_cents: WEEKLY_FLOOR - 1,
+			monthly_budget_cents: 0,
+		});
+		expect(v).toHaveLength(1);
+		expect(v[0].field).toBe('weekly_budget_cents');
+		expect(v[0].minCents).toBe(WEEKLY_FLOOR);
+	});
+
+	it('rejects monthly one cent under the floor', () => {
+		const v = validateBudgetWindows({
+			daily_budget_cents: DAILY,
+			weekly_budget_cents: 0,
+			monthly_budget_cents: MONTHLY_FLOOR_FROM_DAILY - 1,
+		});
+		expect(v).toHaveLength(1);
+		expect(v[0].field).toBe('monthly_budget_cents');
+		expect(v[0].minCents).toBe(MONTHLY_FLOOR_FROM_DAILY);
+	});
+
+	it('skips disabled (0) windows', () => {
+		// weekly disabled → no weekly constraint; monthly meets the daily floor → valid.
+		expect(
+			validateBudgetWindows({
+				daily_budget_cents: DAILY,
+				weekly_budget_cents: 0,
+				monthly_budget_cents: MONTHLY_FLOOR_FROM_DAILY,
+			}),
+		).toEqual([]);
+	});
+
+	it('treats an all-disabled trio as valid', () => {
+		expect(
+			validateBudgetWindows({
+				daily_budget_cents: 0,
+				weekly_budget_cents: 0,
+				monthly_budget_cents: 0,
+			}),
+		).toEqual([]);
+	});
+});
+
+describe('normalizeBudgetWindowsUp', () => {
+	it('raises dependent longer windows up to their floors', () => {
+		expect(
+			normalizeBudgetWindowsUp({
+				daily_budget_cents: DAILY,
+				weekly_budget_cents: 100,
+				monthly_budget_cents: 100,
+			}),
+		).toEqual({
+			daily_budget_cents: DAILY,
+			weekly_budget_cents: WEEKLY_FLOOR,
+			monthly_budget_cents: MONTHLY_FLOOR_FROM_DAILY,
+		});
+	});
+
+	it('never lowers a window already above its floor', () => {
+		expect(
+			normalizeBudgetWindowsUp({
+				daily_budget_cents: DAILY,
+				weekly_budget_cents: 20000,
+				monthly_budget_cents: 100000,
+			}),
+		).toEqual({
+			daily_budget_cents: DAILY,
+			weekly_budget_cents: 20000,
+			monthly_budget_cents: 100000,
+		});
+	});
+
+	it('leaves a disabled longer window at 0 (unlimited)', () => {
+		expect(
+			normalizeBudgetWindowsUp({
+				daily_budget_cents: DAILY,
+				weekly_budget_cents: 0,
+				monthly_budget_cents: 100,
+			}),
+		).toEqual({
+			daily_budget_cents: DAILY,
+			weekly_budget_cents: 0,
+			monthly_budget_cents: MONTHLY_FLOOR_FROM_DAILY,
+		});
+	});
+});
+
+describe('dollar/cents conversion', () => {
+	it('centsToDollars formats with two decimals', () => {
+		expect(centsToDollars(2000)).toBe('20.00');
+		expect(centsToDollars(0)).toBe('0.00');
+	});
+	it('dollarsToCents parses, rounds, and clamps to >= 0', () => {
+		expect(dollarsToCents('20')).toBe(2000);
+		expect(dollarsToCents('')).toBe(0);
+		expect(dollarsToCents('20.005')).toBe(2001);
+		expect(dollarsToCents('-5')).toBe(0);
+	});
+});

--- a/packages/server/test/budget-windows-routes.test.ts
+++ b/packages/server/test/budget-windows-routes.test.ts
@@ -1,0 +1,217 @@
+import type { PGlite } from '@electric-sql/pglite';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import type { Env } from '../src/lib/types';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp, createTestProject } from './helpers/app';
+
+let app: Hono<Env>;
+let db: PGlite;
+let token: string;
+let teamId: string;
+let projectId: string;
+let projectSlug: string;
+let agentId: string;
+let agentSlug: string;
+
+const jsonHeaders = () => ({ ...authHeader(token), 'Content-Type': 'application/json' });
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+
+	const typesRes = await app.request('/api/team-templates', { headers: authHeader(token) });
+	const templates = (await typesRes.json()) as { data: Array<{ id: string; name: string }> };
+	const typeId = templates.data.find((t) => t.name === 'Startup')?.id;
+
+	const teamRes = await app.request('/api/teams', {
+		method: 'POST',
+		headers: jsonHeaders(),
+		body: JSON.stringify({ name: 'Budget Rules Co', template_id: typeId }),
+	});
+	const teamSlug = (await teamRes.json()).data.slug;
+	teamId = (await db.query<{ id: string }>('SELECT id FROM teams WHERE slug = $1', [teamSlug]))
+		.rows[0].id;
+
+	const projectRes = await createTestProject(db, teamId, { name: 'Rules Project' });
+	const project = (await projectRes.json()).data;
+	projectId = project.id;
+	projectSlug = project.slug;
+
+	const agentsRes = await app.request(`/api/projects/${projectSlug}/agents`, {
+		headers: authHeader(token),
+	});
+	const agents = (await agentsRes.json()) as { data: Array<{ id: string; slug: string }> };
+	const engineer = agents.data.find((a) => a.slug === 'engineer');
+	if (!engineer) throw new Error('engineer agent not seeded');
+	agentId = engineer.id;
+	agentSlug = engineer.slug;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+beforeEach(async () => {
+	await db.query(
+		'UPDATE member_agents SET daily_budget_cents = 0, weekly_budget_cents = 0, monthly_budget_cents = 0 WHERE id = $1',
+		[agentId],
+	);
+	await db.query(
+		'UPDATE projects SET daily_budget_cents = 0, weekly_budget_cents = 0, monthly_budget_cents = 0 WHERE id = $1',
+		[projectId],
+	);
+});
+
+function patchProject(body: Record<string, number>) {
+	return app.request(`/api/projects/${projectSlug}`, {
+		method: 'PATCH',
+		headers: jsonHeaders(),
+		body: JSON.stringify(body),
+	});
+}
+
+function patchAgent(body: Record<string, number>) {
+	return app.request(`/api/projects/${projectSlug}/agents/${agentSlug}`, {
+		method: 'PATCH',
+		headers: jsonHeaders(),
+		body: JSON.stringify(body),
+	});
+}
+
+describe('project budget PATCH cross-window validation', () => {
+	it('rejects a weekly budget below daily × 7', async () => {
+		const res = await patchProject({
+			daily_budget_cents: 2000,
+			weekly_budget_cents: 5000, // < 14000
+			monthly_budget_cents: 0,
+		});
+		expect(res.status).toBe(400);
+		expect((await res.json()).error.message).toMatch(/weekly budget must be at least/i);
+	});
+
+	it('accepts the trio when the offending window is disabled (0)', async () => {
+		const res = await patchProject({
+			daily_budget_cents: 2000,
+			weekly_budget_cents: 0, // unlimited → no constraint
+			monthly_budget_cents: 70000,
+		});
+		expect(res.status).toBe(200);
+	});
+
+	it('validates against the stored value when a single window is patched', async () => {
+		// Store a daily budget first.
+		expect((await patchProject({ daily_budget_cents: 2000 })).status).toBe(200);
+		// Now patch only weekly to an incoherent value — must merge with stored daily.
+		const bad = await patchProject({ weekly_budget_cents: 5000 });
+		expect(bad.status).toBe(400);
+		// A coherent weekly against the stored daily passes.
+		const good = await patchProject({ weekly_budget_cents: 20000 });
+		expect(good.status).toBe(200);
+	});
+});
+
+describe('agent budget PATCH cross-window validation', () => {
+	it('rejects an incoherent monthly budget', async () => {
+		const res = await patchAgent({
+			daily_budget_cents: 2000,
+			weekly_budget_cents: 0,
+			monthly_budget_cents: 5000, // < ceil(2000*365/12)=60834
+		});
+		expect(res.status).toBe(400);
+		expect((await res.json()).error.message).toMatch(/monthly budget must be at least/i);
+	});
+
+	it('persists a coherent trio', async () => {
+		const res = await patchAgent({
+			daily_budget_cents: 2000,
+			weekly_budget_cents: 20000,
+			monthly_budget_cents: 90000,
+		});
+		expect(res.status).toBe(200);
+		const row = await db.query<{ daily_budget_cents: number; weekly_budget_cents: number }>(
+			'SELECT daily_budget_cents, weekly_budget_cents FROM member_agents WHERE id = $1',
+			[agentId],
+		);
+		expect(row.rows[0]).toEqual({ daily_budget_cents: 2000, weekly_budget_cents: 20000 });
+	});
+});
+
+describe('agent create persists + validates all three windows', () => {
+	it('rejects an incoherent trio at create time', async () => {
+		const res = await app.request(`/api/projects/${projectSlug}/agents`, {
+			method: 'POST',
+			headers: jsonHeaders(),
+			body: JSON.stringify({
+				title: 'Bad Budget Hire',
+				daily_budget_cents: 2000,
+				weekly_budget_cents: 5000,
+			}),
+		});
+		expect(res.status).toBe(400);
+	});
+
+	it('stores the daily/weekly windows passed at create time', async () => {
+		const res = await app.request(`/api/projects/${projectSlug}/agents`, {
+			method: 'POST',
+			headers: jsonHeaders(),
+			body: JSON.stringify({
+				title: 'Good Budget Hire',
+				daily_budget_cents: 1000,
+				weekly_budget_cents: 20000,
+				monthly_budget_cents: 90000,
+			}),
+		});
+		expect(res.status).toBe(201);
+		const created = (await res.json()).data;
+		expect(created.daily_budget_cents).toBe(1000);
+		expect(created.weekly_budget_cents).toBe(20000);
+		expect(created.monthly_budget_cents).toBe(90000);
+	});
+});
+
+describe('agent onboard threads all three windows', () => {
+	it('rejects an incoherent trio before proposing the hire', async () => {
+		const res = await app.request(`/api/projects/${projectSlug}/agents/onboard`, {
+			method: 'POST',
+			headers: jsonHeaders(),
+			body: JSON.stringify({
+				title: 'Onboard Bad',
+				daily_budget_cents: 2000,
+				weekly_budget_cents: 5000,
+			}),
+		});
+		expect(res.status).toBe(400);
+	});
+
+	it('carries daily/weekly through the hire (approval payload or bootstrap insert)', async () => {
+		const res = await app.request(`/api/projects/${projectSlug}/agents/onboard`, {
+			method: 'POST',
+			headers: jsonHeaders(),
+			body: JSON.stringify({
+				title: 'Onboard Good',
+				daily_budget_cents: 1000,
+				weekly_budget_cents: 20000,
+				monthly_budget_cents: 90000,
+			}),
+		});
+		expect(res.status).toBe(201);
+		const result = (await res.json()).data;
+		if (result.bootstrap) {
+			// No coordination: the agent was created directly.
+			expect(result.agent.daily_budget_cents).toBe(1000);
+			expect(result.agent.weekly_budget_cents).toBe(20000);
+		} else {
+			// Coordinated: the windows ride in the pending hire approval payload, to be
+			// materialised by approval-handlers/hire.ts on approval.
+			const payload = await db.query<{ payload: Record<string, number> }>(
+				`SELECT payload FROM approvals WHERE team_id = $1 AND payload->>'slug' = 'onboard-good'`,
+				[teamId],
+			);
+			expect(payload.rows[0].payload.daily_budget_cents).toBe(1000);
+			expect(payload.rows[0].payload.weekly_budget_cents).toBe(20000);
+		}
+	});
+});

--- a/packages/shared/src/budget.ts
+++ b/packages/shared/src/budget.ts
@@ -1,0 +1,121 @@
+/**
+ * Budget window math — the single source of truth for the daily/weekly/monthly
+ * rolling spend caps on agents and projects. Imported by the web forms, every
+ * backend write path, and the tests so the rules live in exactly one place.
+ *
+ * 0 = unlimited/disabled for a window and is skipped by every check. Longer
+ * windows must be consistent with shorter ones: a longer window can't be set
+ * below what the shorter window's rate implies over the same span.
+ *   - weekly  >= daily  * 7
+ *   - monthly >= daily  * 365/12
+ *   - monthly >= weekly * 52/12
+ */
+
+export interface BudgetWindowsCents {
+	daily_budget_cents: number;
+	weekly_budget_cents: number;
+	monthly_budget_cents: number;
+}
+
+const DAYS_PER_WEEK = 7;
+const DAYS_PER_MONTH = 365 / 12; // average calendar month
+const WEEKS_PER_MONTH = 52 / 12;
+
+/** A window with a 0 limit is unlimited/disabled and never constrains anything. */
+function isEnabled(cents: number): boolean {
+	return cents > 0;
+}
+
+/** Cents → fixed-2 dollar string, e.g. 2000 → "20.00". */
+export function centsToDollars(cents: number): string {
+	return (cents / 100).toFixed(2);
+}
+
+/** Parse a dollar input string → non-negative integer cents. Empty/NaN → 0. */
+export function dollarsToCents(input: string): number {
+	const parsed = Number.parseFloat(input || '0');
+	if (!Number.isFinite(parsed)) return 0;
+	return Math.max(0, Math.round(parsed * 100));
+}
+
+/** Minimum weekly cents implied by the daily cap (daily × 7). 0 when daily is unlimited. */
+export function minWeeklyCents(dailyCents: number): number {
+	return isEnabled(dailyCents) ? dailyCents * DAYS_PER_WEEK : 0;
+}
+
+/**
+ * Minimum monthly cents implied by the daily and/or weekly caps — the larger of
+ * daily × 365/12 and weekly × 52/12, over whichever are enabled. 0 when neither
+ * is. `ceil` so the integer-cent floor still satisfies `monthly*12 >= daily*365`.
+ */
+export function minMonthlyCents(dailyCents: number, weeklyCents: number): number {
+	let min = 0;
+	if (isEnabled(dailyCents)) min = Math.max(min, Math.ceil(dailyCents * DAYS_PER_MONTH));
+	if (isEnabled(weeklyCents)) min = Math.max(min, Math.ceil(weeklyCents * WEEKS_PER_MONTH));
+	return min;
+}
+
+export interface BudgetViolation {
+	field: 'weekly_budget_cents' | 'monthly_budget_cents';
+	minCents: number;
+	message: string;
+}
+
+/**
+ * All cross-window violations for a trio. Empty array means coherent. Disabled
+ * (0) windows are skipped. Comparisons use the same ceil-based floors as
+ * `minWeeklyCents`/`minMonthlyCents`, so client and server agree to the cent.
+ */
+export function validateBudgetWindows(w: BudgetWindowsCents): BudgetViolation[] {
+	const violations: BudgetViolation[] = [];
+
+	const weeklyFloor = minWeeklyCents(w.daily_budget_cents);
+	if (isEnabled(w.weekly_budget_cents) && w.weekly_budget_cents < weeklyFloor) {
+		violations.push({
+			field: 'weekly_budget_cents',
+			minCents: weeklyFloor,
+			message: `Weekly budget must be at least $${centsToDollars(weeklyFloor)} to cover the daily budget (daily × 7).`,
+		});
+	}
+
+	const monthlyFloor = minMonthlyCents(w.daily_budget_cents, w.weekly_budget_cents);
+	if (isEnabled(w.monthly_budget_cents) && w.monthly_budget_cents < monthlyFloor) {
+		// Name the window that binds, for an actionable message.
+		const dailyImplied = isEnabled(w.daily_budget_cents)
+			? Math.ceil(w.daily_budget_cents * DAYS_PER_MONTH)
+			: 0;
+		const weeklyImplied = isEnabled(w.weekly_budget_cents)
+			? Math.ceil(w.weekly_budget_cents * WEEKS_PER_MONTH)
+			: 0;
+		const basis =
+			dailyImplied >= weeklyImplied
+				? 'daily budget (daily × 365/12)'
+				: 'weekly budget (weekly × 52/12)';
+		violations.push({
+			field: 'monthly_budget_cents',
+			minCents: monthlyFloor,
+			message: `Monthly budget must be at least $${centsToDollars(monthlyFloor)} to cover the ${basis}.`,
+		});
+	}
+
+	return violations;
+}
+
+/**
+ * Raise (never lower) each enabled longer window up to its floor so the trio is
+ * coherent. Processes daily → weekly → monthly so the raised weekly feeds the
+ * monthly floor. Used by the web editor for live auto-raise as the user types.
+ */
+export function normalizeBudgetWindowsUp(w: BudgetWindowsCents): BudgetWindowsCents {
+	const weekly = isEnabled(w.weekly_budget_cents)
+		? Math.max(w.weekly_budget_cents, minWeeklyCents(w.daily_budget_cents))
+		: w.weekly_budget_cents;
+	const monthly = isEnabled(w.monthly_budget_cents)
+		? Math.max(w.monthly_budget_cents, minMonthlyCents(w.daily_budget_cents, weekly))
+		: w.monthly_budget_cents;
+	return {
+		daily_budget_cents: w.daily_budget_cents,
+		weekly_budget_cents: weekly,
+		monthly_budget_cents: monthly,
+	};
+}

--- a/packages/shared/src/budget.ts
+++ b/packages/shared/src/budget.ts
@@ -5,10 +5,10 @@
  *
  * 0 = unlimited/disabled for a window and is skipped by every check. Longer
  * windows must be consistent with shorter ones: a longer window can't be set
- * below what the shorter window's rate implies over the same span.
- *   - weekly  >= daily  * 7
- *   - monthly >= daily  * 365/12
- *   - monthly >= weekly * 52/12
+ * below what the shorter window's rate implies over the same span —
+ *   weekly  >= daily  * 7
+ *   monthly >= daily  * 365/12
+ *   monthly >= weekly * 52/12
  */
 
 export interface BudgetWindowsCents {
@@ -45,8 +45,7 @@ export function minWeeklyCents(dailyCents: number): number {
 
 /**
  * Minimum monthly cents implied by the daily and/or weekly caps — the larger of
- * daily × 365/12 and weekly × 52/12, over whichever are enabled. 0 when neither
- * is. `ceil` so the integer-cent floor still satisfies `monthly*12 >= daily*365`.
+ * daily × 365/12 and weekly × 52/12, over whichever are enabled. 0 when neither is.
  */
 export function minMonthlyCents(dailyCents: number, weeklyCents: number): number {
 	let min = 0;
@@ -80,7 +79,7 @@ export function validateBudgetWindows(w: BudgetWindowsCents): BudgetViolation[] 
 
 	const monthlyFloor = minMonthlyCents(w.daily_budget_cents, w.weekly_budget_cents);
 	if (isEnabled(w.monthly_budget_cents) && w.monthly_budget_cents < monthlyFloor) {
-		// Name the window that binds, for an actionable message.
+		// Name whichever shorter window binds the floor, for a clearer message.
 		const dailyImplied = isEnabled(w.daily_budget_cents)
 			? Math.ceil(w.daily_budget_cents * DAYS_PER_MONTH)
 			: 0;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,4 @@
+export * from './budget.js';
 export * from './constants.js';
 export * from './crypto/auth.js';
 export * from './crypto/mnemonic.js';

--- a/packages/web/src/components/budget/budget-windows-editor.tsx
+++ b/packages/web/src/components/budget/budget-windows-editor.tsx
@@ -1,0 +1,226 @@
+import {
+	type BudgetWindowsCents,
+	centsToDollars,
+	dollarsToCents,
+	minMonthlyCents,
+	minWeeklyCents,
+	normalizeBudgetWindowsUp,
+} from '@hezo/shared';
+import { useEffect, useRef, useState } from 'react';
+import { Input } from '../ui/input';
+
+type WindowKey = 'daily' | 'weekly' | 'monthly';
+
+interface FieldState {
+	daily: string;
+	weekly: string;
+	monthly: string;
+	dailyEnabled: boolean;
+	weeklyEnabled: boolean;
+	monthlyEnabled: boolean;
+}
+
+function seed(value: BudgetWindowsCents): FieldState {
+	return {
+		daily: centsToDollars(value.daily_budget_cents),
+		weekly: centsToDollars(value.weekly_budget_cents),
+		monthly: centsToDollars(value.monthly_budget_cents),
+		dailyEnabled: value.daily_budget_cents > 0,
+		weeklyEnabled: value.weekly_budget_cents > 0,
+		monthlyEnabled: value.monthly_budget_cents > 0,
+	};
+}
+
+function toCents(f: FieldState): BudgetWindowsCents {
+	return {
+		daily_budget_cents: f.dailyEnabled ? dollarsToCents(f.daily) : 0,
+		weekly_budget_cents: f.weeklyEnabled ? dollarsToCents(f.weekly) : 0,
+		monthly_budget_cents: f.monthlyEnabled ? dollarsToCents(f.monthly) : 0,
+	};
+}
+
+/**
+ * The single place the daily/weekly/monthly budget-editing UX lives — a per-window
+ * enable toggle, a `$` input, a live "minimum" hint, and the cross-window auto-raise.
+ * Editing a shorter window silently raises the dependent longer windows to their
+ * floor; a longer window typed below its floor is clamped up on blur. Because the
+ * editor only ever emits a coherent trio (via `normalizeBudgetWindowsUp`), parents
+ * just store `value` and submit it. 0 = unlimited/disabled.
+ *
+ * Used by the project budget form, the agent settings form, and the hire form so the
+ * rules (in `@hezo/shared`) are never re-implemented per form.
+ */
+export function BudgetWindowsEditor({
+	value,
+	onChange,
+	className = '',
+}: {
+	value: BudgetWindowsCents;
+	onChange: (next: BudgetWindowsCents) => void;
+	className?: string;
+}) {
+	const [fields, setFields] = useState<FieldState>(() => seed(value));
+	// Last value we emitted, so an echoed-back `value` prop doesn't clobber edits.
+	const lastEmitted = useRef<BudgetWindowsCents>(value);
+	// Last non-zero dollar string per window, to restore on re-enable.
+	const lastNonZero = useRef<Record<WindowKey, string>>({
+		daily: value.daily_budget_cents > 0 ? centsToDollars(value.daily_budget_cents) : '',
+		weekly: value.weekly_budget_cents > 0 ? centsToDollars(value.weekly_budget_cents) : '',
+		monthly: value.monthly_budget_cents > 0 ? centsToDollars(value.monthly_budget_cents) : '',
+	});
+
+	// Re-seed when the parent pushes a value we didn't emit (e.g. the entity loaded
+	// after first render). An echo of our own last emit is ignored.
+	useEffect(() => {
+		const e = lastEmitted.current;
+		if (
+			e.daily_budget_cents === value.daily_budget_cents &&
+			e.weekly_budget_cents === value.weekly_budget_cents &&
+			e.monthly_budget_cents === value.monthly_budget_cents
+		) {
+			return;
+		}
+		lastEmitted.current = value;
+		setFields(seed(value));
+	}, [value]);
+
+	function commit(next: FieldState, norm: BudgetWindowsCents) {
+		// Reflect any auto-raised window back into its dollar string.
+		const reflected: FieldState = {
+			...next,
+			weekly:
+				next.weeklyEnabled && norm.weekly_budget_cents !== toCents(next).weekly_budget_cents
+					? centsToDollars(norm.weekly_budget_cents)
+					: next.weekly,
+			monthly:
+				next.monthlyEnabled && norm.monthly_budget_cents !== toCents(next).monthly_budget_cents
+					? centsToDollars(norm.monthly_budget_cents)
+					: next.monthly,
+		};
+		for (const key of ['daily', 'weekly', 'monthly'] as const) {
+			if (reflected[`${key}Enabled`] && dollarsToCents(reflected[key]) > 0) {
+				lastNonZero.current[key] = reflected[key];
+			}
+		}
+		setFields(reflected);
+		lastEmitted.current = norm;
+		onChange(norm);
+	}
+
+	// On change of `edited`, raise only windows *strictly longer* than it — never the
+	// field being typed into (clamping that mid-keystroke would fight the user).
+	function handleChange(edited: WindowKey, str: string) {
+		const next = { ...fields, [edited]: str };
+		const cents = toCents(next);
+		let weekly = cents.weekly_budget_cents;
+		if (edited === 'daily' && next.weeklyEnabled) {
+			weekly = Math.max(weekly, minWeeklyCents(cents.daily_budget_cents));
+		}
+		let monthly = cents.monthly_budget_cents;
+		if (edited !== 'monthly' && next.monthlyEnabled) {
+			monthly = Math.max(monthly, minMonthlyCents(cents.daily_budget_cents, weekly));
+		}
+		commit(next, {
+			daily_budget_cents: cents.daily_budget_cents,
+			weekly_budget_cents: weekly,
+			monthly_budget_cents: monthly,
+		});
+	}
+
+	// On blur, clamp everything up — including a longer window the user just typed
+	// below its floor.
+	function handleBlur() {
+		commit(fields, normalizeBudgetWindowsUp(toCents(fields)));
+	}
+
+	function handleToggle(key: WindowKey, enabled: boolean) {
+		const next: FieldState = { ...fields, [`${key}Enabled`]: enabled };
+		if (enabled) {
+			const restored = lastNonZero.current[key];
+			next[key] = restored && dollarsToCents(restored) > 0 ? restored : centsToDollars(0);
+		}
+		// Toggling isn't typing, so a full clamp is fine here.
+		commit(next, normalizeBudgetWindowsUp(toCents(next)));
+	}
+
+	const cents = toCents(fields);
+	const weeklyFloor = minWeeklyCents(cents.daily_budget_cents);
+	const monthlyFloor = minMonthlyCents(cents.daily_budget_cents, cents.weekly_budget_cents);
+
+	const rows: {
+		key: WindowKey;
+		label: string;
+		enabled: boolean;
+		dollarVal: string;
+		floor: number;
+		testid: string;
+	}[] = [
+		{
+			key: 'daily',
+			label: 'Daily',
+			enabled: fields.dailyEnabled,
+			dollarVal: fields.daily,
+			floor: 0,
+			testid: 'budget-daily',
+		},
+		{
+			key: 'weekly',
+			label: 'Weekly',
+			enabled: fields.weeklyEnabled,
+			dollarVal: fields.weekly,
+			floor: weeklyFloor,
+			testid: 'budget-weekly',
+		},
+		{
+			key: 'monthly',
+			label: 'Monthly',
+			enabled: fields.monthlyEnabled,
+			dollarVal: fields.monthly,
+			floor: monthlyFloor,
+			testid: 'budget-monthly',
+		},
+	];
+
+	return (
+		<div className={`grid grid-cols-1 gap-4 sm:grid-cols-3 ${className}`}>
+			{rows.map((row) => (
+				<div key={row.key} className="flex flex-col gap-1.5">
+					<label className="flex items-center gap-2 cursor-pointer">
+						<input
+							type="checkbox"
+							checked={row.enabled}
+							onChange={(e) => handleToggle(row.key, e.target.checked)}
+							data-testid={`${row.testid}-toggle`}
+							aria-label={`Enable ${row.label.toLowerCase()} budget`}
+						/>
+						<span className="text-xs font-medium uppercase tracking-wider text-text-muted">
+							{row.label} ($)
+						</span>
+					</label>
+					{row.enabled ? (
+						<>
+							<Input
+								type="number"
+								step="0.01"
+								min={row.floor > 0 ? centsToDollars(row.floor) : '0'}
+								value={row.dollarVal}
+								onChange={(e) => handleChange(row.key, e.target.value)}
+								onBlur={handleBlur}
+								data-testid={row.testid}
+								aria-label={`${row.label} budget`}
+							/>
+							{row.floor > 0 && (
+								<span className="text-xs text-text-subtle" data-testid={`${row.testid}-hint`}>
+									Minimum ${centsToDollars(row.floor)} based on the{' '}
+									{row.key === 'weekly' ? 'daily' : 'shorter'} budget
+								</span>
+							)}
+						</>
+					) : (
+						<span className="text-[13px] text-text-subtle py-2">Unlimited</span>
+					)}
+				</div>
+			))}
+		</div>
+	);
+}

--- a/packages/web/src/hooks/use-agents.ts
+++ b/packages/web/src/hooks/use-agents.ts
@@ -180,6 +180,8 @@ export function useOnboardAgent(projectId: string) {
 			title: string;
 			role_description?: string;
 			system_prompt?: string;
+			daily_budget_cents?: number;
+			weekly_budget_cents?: number;
 			monthly_budget_cents?: number;
 			heartbeat_interval_min?: number;
 			touches_code?: boolean;

--- a/packages/web/src/routes/projects/$projectId/agents/$agentId/settings.tsx
+++ b/packages/web/src/routes/projects/$projectId/agents/$agentId/settings.tsx
@@ -1,7 +1,13 @@
-import { AgentAdminStatus, AI_PROVIDER_INFO, type AiProvider } from '@hezo/shared';
+import {
+	AgentAdminStatus,
+	AI_PROVIDER_INFO,
+	type AiProvider,
+	type BudgetWindowsCents,
+} from '@hezo/shared';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { Loader2, Power, PowerOff } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { BudgetWindowsEditor } from '../../../../../components/budget/budget-windows-editor';
 import { MarkdownProse } from '../../../../../components/markdown-prose';
 import { RevisionsPanel } from '../../../../../components/revisions-panel';
 import { Button } from '../../../../../components/ui/button';
@@ -44,9 +50,11 @@ function AgentSettingsPage() {
 		promptMode === 'preview',
 	);
 	const [reportsTo, setReportsTo] = useState('');
-	const [dailyBudget, setDailyBudget] = useState('');
-	const [weeklyBudget, setWeeklyBudget] = useState('');
-	const [budget, setBudget] = useState('');
+	const [budget, setBudget] = useState<BudgetWindowsCents>({
+		daily_budget_cents: 0,
+		weekly_budget_cents: 0,
+		monthly_budget_cents: 0,
+	});
 	const [heartbeat, setHeartbeat] = useState('');
 	const [runTimeout, setRunTimeout] = useState('');
 	const [touchesCode, setTouchesCode] = useState(false);
@@ -60,9 +68,11 @@ function AgentSettingsPage() {
 		setTitle(agent.title);
 		setRoleDesc(agent.role_description ?? '');
 		setReportsTo(agent.reports_to ?? '');
-		setDailyBudget(String(agent.daily_budget_cents / 100));
-		setWeeklyBudget(String(agent.weekly_budget_cents / 100));
-		setBudget(String(agent.monthly_budget_cents / 100));
+		setBudget({
+			daily_budget_cents: agent.daily_budget_cents,
+			weekly_budget_cents: agent.weekly_budget_cents,
+			monthly_budget_cents: agent.monthly_budget_cents,
+		});
 		setHeartbeat(String(agent.heartbeat_interval_min));
 		setRunTimeout(String(agent.run_timeout_min));
 		setTouchesCode(agent.touches_code);
@@ -91,9 +101,9 @@ function AgentSettingsPage() {
 			role_description: roleDesc || undefined,
 			system_prompt: promptChanged ? systemPrompt : undefined,
 			reports_to: reportsTo || null,
-			daily_budget_cents: Math.max(0, Math.round(Number.parseFloat(dailyBudget || '0') * 100)),
-			weekly_budget_cents: Math.max(0, Math.round(Number.parseFloat(weeklyBudget || '0') * 100)),
-			monthly_budget_cents: Math.max(0, Math.round(Number.parseFloat(budget || '0') * 100)),
+			daily_budget_cents: budget.daily_budget_cents,
+			weekly_budget_cents: budget.weekly_budget_cents,
+			monthly_budget_cents: budget.monthly_budget_cents,
 			heartbeat_interval_min: Number.parseInt(heartbeat, 10),
 			run_timeout_min: Number.parseInt(runTimeout, 10),
 			touches_code: touchesCode,
@@ -256,31 +266,12 @@ function AgentSettingsPage() {
 					</p>
 				</div>
 
+				<div className="flex flex-col gap-1.5">
+					<span className="text-sm text-text-muted">Budget limits</span>
+					<BudgetWindowsEditor value={budget} onChange={setBudget} />
+				</div>
+
 				<div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
-					<Input
-						label="Daily Budget ($)"
-						type="number"
-						step="0.01"
-						min="0"
-						value={dailyBudget}
-						onChange={(e) => setDailyBudget(e.target.value)}
-					/>
-					<Input
-						label="Weekly Budget ($)"
-						type="number"
-						step="0.01"
-						min="0"
-						value={weeklyBudget}
-						onChange={(e) => setWeeklyBudget(e.target.value)}
-					/>
-					<Input
-						label="Monthly Budget ($)"
-						type="number"
-						step="0.01"
-						min="0"
-						value={budget}
-						onChange={(e) => setBudget(e.target.value)}
-					/>
 					<Input
 						label="Heartbeat (min)"
 						type="number"

--- a/packages/web/src/routes/projects/$projectId/agents/hire.tsx
+++ b/packages/web/src/routes/projects/$projectId/agents/hire.tsx
@@ -1,6 +1,8 @@
+import type { BudgetWindowsCents } from '@hezo/shared';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import { Loader2 } from 'lucide-react';
 import { useState } from 'react';
+import { BudgetWindowsEditor } from '../../../../components/budget/budget-windows-editor';
 import { Button } from '../../../../components/ui/button';
 import { Input } from '../../../../components/ui/input';
 import { useOnboardAgent } from '../../../../hooks/use-agents';
@@ -24,7 +26,11 @@ function HireAgentPage() {
 	const [title, setTitle] = useState('');
 	const [roleDesc, setRoleDesc] = useState('');
 	const [systemPrompt, setSystemPrompt] = useState('');
-	const [budget, setBudget] = useState('20');
+	const [budget, setBudget] = useState<BudgetWindowsCents>({
+		daily_budget_cents: 0,
+		weekly_budget_cents: 0,
+		monthly_budget_cents: 2000,
+	});
 	const [heartbeat, setHeartbeat] = useState('60');
 	const [touchesCode, setTouchesCode] = useState(false);
 
@@ -34,7 +40,9 @@ function HireAgentPage() {
 			title,
 			role_description: roleDesc || undefined,
 			system_prompt: systemPrompt || undefined,
-			monthly_budget_cents: Math.round(Number.parseFloat(budget) * 100),
+			daily_budget_cents: budget.daily_budget_cents,
+			weekly_budget_cents: budget.weekly_budget_cents,
+			monthly_budget_cents: budget.monthly_budget_cents,
 			heartbeat_interval_min: Number.parseInt(heartbeat, 10),
 			touches_code: touchesCode,
 		});
@@ -97,15 +105,12 @@ function HireAgentPage() {
 					</select>
 				</div>
 
-				<Input
-					label="Monthly budget"
-					type="number"
-					step="0.01"
-					min="0"
-					value={budget}
-					onChange={(e) => setBudget(e.target.value)}
-					className="max-w-[140px]"
-				/>
+				<div className="flex flex-col gap-1.5 max-w-[500px]">
+					<span className="text-xs font-medium uppercase tracking-wider text-text-muted">
+						Budget limits
+					</span>
+					<BudgetWindowsEditor value={budget} onChange={setBudget} />
+				</div>
 
 				<label className="flex items-start gap-2 cursor-pointer max-w-[500px]">
 					<input

--- a/packages/web/src/routes/projects/$projectId/budget.tsx
+++ b/packages/web/src/routes/projects/$projectId/budget.tsx
@@ -1,11 +1,11 @@
-import { HQ_PROJECT_SLUG } from '@hezo/shared';
+import { type BudgetWindowsCents, centsToDollars, HQ_PROJECT_SLUG } from '@hezo/shared';
 import { createFileRoute, redirect } from '@tanstack/react-router';
 import { Loader2 } from 'lucide-react';
 import { useState } from 'react';
 import { BudgetCharts } from '../../../components/budget/budget-charts';
+import { BudgetWindowsEditor } from '../../../components/budget/budget-windows-editor';
 import { BudgetBar } from '../../../components/ui/budget-bar';
 import { Button } from '../../../components/ui/button';
-import { Input } from '../../../components/ui/input';
 import {
 	type EntityBudgetStatus,
 	useBudgetStatus,
@@ -14,7 +14,7 @@ import {
 import { useProject, useUpdateProject } from '../../../hooks/use-projects';
 
 function dollars(cents: number): string {
-	return `$${(cents / 100).toFixed(2)}`;
+	return `$${centsToDollars(cents)}`;
 }
 
 /** A single window's spend vs. limit with a fill bar. 0 limit renders "unlimited". */
@@ -52,32 +52,27 @@ function ProjectBudgetForm({ projectId }: { projectId: string }) {
 	const { data: project } = useProject(projectId);
 	const updateProject = useUpdateProject(projectId);
 	const [editing, setEditing] = useState(false);
-	const [daily, setDaily] = useState('0');
-	const [weekly, setWeekly] = useState('0');
-	const [monthly, setMonthly] = useState('0');
+	const [budget, setBudget] = useState<BudgetWindowsCents>({
+		daily_budget_cents: 0,
+		weekly_budget_cents: 0,
+		monthly_budget_cents: 0,
+	});
 
 	if (!project) return null;
 
-	function toDollars(cents: number): string {
-		return (cents / 100).toFixed(2);
-	}
-
 	function startEditing() {
 		if (!project) return;
-		setDaily(toDollars(project.daily_budget_cents));
-		setWeekly(toDollars(project.weekly_budget_cents));
-		setMonthly(toDollars(project.monthly_budget_cents));
+		setBudget({
+			daily_budget_cents: project.daily_budget_cents,
+			weekly_budget_cents: project.weekly_budget_cents,
+			monthly_budget_cents: project.monthly_budget_cents,
+		});
 		setEditing(true);
 	}
 
 	async function handleSave(e: React.FormEvent) {
 		e.preventDefault();
-		const toCents = (v: string) => Math.max(0, Math.round(Number.parseFloat(v || '0') * 100));
-		await updateProject.mutateAsync({
-			daily_budget_cents: toCents(daily),
-			weekly_budget_cents: toCents(weekly),
-			monthly_budget_cents: toCents(monthly),
-		});
+		await updateProject.mutateAsync(budget);
 		setEditing(false);
 	}
 
@@ -86,37 +81,11 @@ function ProjectBudgetForm({ projectId }: { projectId: string }) {
 			<h2 className="mb-3 text-sm font-medium text-text-muted">Project budget limits</h2>
 			<p className="-mt-2 mb-3 text-xs text-text-subtle">
 				Spend across all agents in this project. A run is blocked when the project exceeds any
-				window. 0 means unlimited.
+				window. Disable a window to leave it unlimited.
 			</p>
 			{editing ? (
-				<form onSubmit={handleSave} className="flex flex-col gap-3 sm:max-w-md">
-					<Input
-						label="Daily ($)"
-						type="number"
-						min={0}
-						step="0.01"
-						value={daily}
-						onChange={(e) => setDaily(e.target.value)}
-						data-testid="project-daily-budget"
-					/>
-					<Input
-						label="Weekly ($)"
-						type="number"
-						min={0}
-						step="0.01"
-						value={weekly}
-						onChange={(e) => setWeekly(e.target.value)}
-						data-testid="project-weekly-budget"
-					/>
-					<Input
-						label="Monthly ($)"
-						type="number"
-						min={0}
-						step="0.01"
-						value={monthly}
-						onChange={(e) => setMonthly(e.target.value)}
-						data-testid="project-monthly-budget"
-					/>
+				<form onSubmit={handleSave} className="flex flex-col gap-3 sm:max-w-xl">
+					<BudgetWindowsEditor value={budget} onChange={setBudget} />
 					<div className="flex gap-2">
 						<Button type="submit" size="sm" disabled={updateProject.isPending}>
 							{updateProject.isPending ? <Loader2 className="h-3 w-3 animate-spin" /> : 'Save'}

--- a/packages/web/test/agent-hire.test.tsx
+++ b/packages/web/test/agent-hire.test.tsx
@@ -108,7 +108,12 @@ test('can hire agent with full fields', async () => {
 	await user.clear(budgetInput);
 	await user.type(budgetInput, '50');
 
-	const touchesCode = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+	// The budget editor renders its own enable toggles first, so the touches-code
+	// checkbox is the last one in the form.
+	const checkboxes = container.querySelectorAll(
+		'input[type="checkbox"]',
+	) as NodeListOf<HTMLInputElement>;
+	const touchesCode = checkboxes[checkboxes.length - 1];
 	await user.click(touchesCode);
 
 	const textarea = container.querySelector('textarea') as HTMLTextAreaElement;

--- a/packages/web/test/agent-team-context.test.tsx
+++ b/packages/web/test/agent-team-context.test.tsx
@@ -72,7 +72,7 @@ test('section appears between Reports To and Monthly Budget controls in DOM orde
 
 	const section = await findByTestId('agent-team-context', undefined, { timeout: 20_000 });
 	const reportsToLabel = await findByText('Reports To');
-	const budgetLabel = await findByText(/Monthly Budget/);
+	const budgetLabel = await findByText('Budget limits');
 
 	// Assert DOM order via compareDocumentPosition since happy-dom lacks layout.
 	const all = Array.from(container.querySelectorAll('*')) as HTMLElement[];

--- a/packages/web/test/budget-windows-editor.test.tsx
+++ b/packages/web/test/budget-windows-editor.test.tsx
@@ -1,0 +1,86 @@
+import type { BudgetWindowsCents } from '@hezo/shared';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { expect, test, vi } from 'vitest';
+import { BudgetWindowsEditor } from '../src/components/budget/budget-windows-editor';
+
+/** Controlled wrapper mirroring how the real forms drive the editor. */
+function Harness({
+	initial,
+	onChange,
+}: {
+	initial: BudgetWindowsCents;
+	onChange: (next: BudgetWindowsCents) => void;
+}) {
+	const [value, setValue] = useState(initial);
+	return (
+		<BudgetWindowsEditor
+			value={value}
+			onChange={(next) => {
+				setValue(next);
+				onChange(next);
+			}}
+		/>
+	);
+}
+
+test('auto-raises the longer windows when the daily budget is edited', async () => {
+	const user = userEvent.setup();
+	const onChange = vi.fn();
+	// All three windows enabled (non-zero) so the longer ones can be auto-raised.
+	const { getByTestId } = render(
+		<Harness
+			initial={{ daily_budget_cents: 100, weekly_budget_cents: 100, monthly_budget_cents: 100 }}
+			onChange={onChange}
+		/>,
+	);
+
+	const daily = getByTestId('budget-daily') as HTMLInputElement;
+	await user.clear(daily);
+	await user.type(daily, '20'); // $20/day
+
+	// daily × 7 = $140 weekly floor; ceil(2000 × 365/12) = 60834¢ monthly floor.
+	const last = onChange.mock.calls.at(-1)?.[0] as BudgetWindowsCents;
+	expect(last).toEqual({
+		daily_budget_cents: 2000,
+		weekly_budget_cents: 14000,
+		monthly_budget_cents: 60834,
+	});
+	// The raised values are reflected back into the inputs.
+	expect((getByTestId('budget-weekly') as HTMLInputElement).value).toBe('140.00');
+	expect((getByTestId('budget-monthly') as HTMLInputElement).value).toBe('608.34');
+});
+
+test('disabling a window emits 0 (unlimited) and drops its constraint', async () => {
+	const user = userEvent.setup();
+	const onChange = vi.fn();
+	const { getByTestId, queryByTestId } = render(
+		<Harness
+			initial={{
+				daily_budget_cents: 2000,
+				weekly_budget_cents: 14000,
+				monthly_budget_cents: 60834,
+			}}
+			onChange={onChange}
+		/>,
+	);
+
+	await user.click(getByTestId('budget-weekly-toggle'));
+
+	const last = onChange.mock.calls.at(-1)?.[0] as BudgetWindowsCents;
+	expect(last.weekly_budget_cents).toBe(0);
+	// The weekly input disappears (replaced by an "Unlimited" placeholder).
+	expect(queryByTestId('budget-weekly')).toBeNull();
+});
+
+test('renders a live minimum hint for a constrained window', async () => {
+	const onChange = vi.fn();
+	const { getByTestId } = render(
+		<Harness
+			initial={{ daily_budget_cents: 2000, weekly_budget_cents: 14000, monthly_budget_cents: 0 }}
+			onChange={onChange}
+		/>,
+	);
+	expect(getByTestId('budget-weekly-hint').textContent).toContain('Minimum $140.00');
+});


### PR DESCRIPTION
## Why

Agents and projects each carry three independent rolling spend caps — `daily_budget_cents`, `weekly_budget_cents`, `monthly_budget_cents` (0 = unlimited). Nothing stopped an operator from setting an **incoherent** set, e.g. a $20/day cap with a $50/week cap, even though the daily rate alone implies $140/week. This makes longer windows consistent with shorter ones, validated on **both** client and server, and lets any individual window be disabled.

## Rules (only among *enabled* windows; 0 = disabled/unlimited and is skipped)

- `weekly  >= daily  × 7`
- `monthly >= daily  × 365/12`  (integer-exact via `ceil`)
- `monthly >= weekly × 52/12`

## What changed

**Layer 1 — `@hezo/shared/budget.ts` (single source of truth).** All budget math lives here and is imported by every consumer: `minWeeklyCents`/`minMonthlyCents` floors, `validateBudgetWindows`, `normalizeBudgetWindowsUp` (raise-only), plus `centsToDollars`/`dollarsToCents` (replacing the conversion copies that were inlined across the web package).

**Layer 2 — backend (authoritative reject).** One `budgetWindowsError` helper is called by every write path:
- Project + agent `PATCH` validate the **merged** incoming-vs-stored trio (a PATCH may touch only one window).
- Agent **create**, **onboard**, and the **hire approval fulfillment** (`approval-handlers/hire.ts`) now accept, validate, and persist all three windows — so per-agent daily/weekly/monthly can be set at hire time, not just monthly.
- Invalid input → `400`.

**Layer 3 — frontend.** One self-contained `BudgetWindowsEditor` (per-window enable toggle, live auto-raise of dependent longer windows as you type, "minimum $X" hints, dollar↔cents conversion) replaces the bespoke budget inputs in the **project budget**, **agent settings**, and **hire** forms. Disabling a window stores 0 (unlimited). The editor only ever emits a coherent trio, so the backstop rarely fires.

## Tests

- `budget-validation.test.ts` — shared logic (floors, validation boundaries, ceil rounding, raise-only normalization, conversion).
- `budget-windows-routes.test.ts` — PATCH/create/onboard validation + persistence, including the merge-with-stored-value path and the hire approval payload.
- `budget-windows-editor.test.tsx` — auto-raise, disable, and live min-hint.

All packages typecheck; 59 server + 16 web tests pass.

## Notes

- Reuses the existing `0 = unlimited` semantics — **no schema change** (the daily/weekly/monthly columns landed in `003_budgeting.sql` / #230).
- UX decisions confirmed with the requester: longer windows auto-raise as shorter ones are edited; disabling a window = unlimited.

https://claude.ai/code/session_0185u1PvtaWhabjJEu9FbyhJ

---
_Generated by [Claude Code](https://claude.ai/code/session_0185u1PvtaWhabjJEu9FbyhJ)_