### PR TITLE
ci: shard test-backend and test-integration across runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}
+      - uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
       - run: bun install --frozen-lockfile
       - run: bun run check
 
@@ -27,6 +32,11 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}
+      - uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
       - run: bun install --frozen-lockfile
       - run: bun run build
 
@@ -67,11 +77,24 @@ jobs:
     permissions:
       contents: read
       packages: read
+    # Sharded across runners: each shard runs ~half the server files at the same
+    # per-runner fork concurrency, so the per-fork PGlite+Hono contention ceiling
+    # (the reason we can't just raise --concurrency) is unchanged. fail-fast off
+    # so one shard failing still lets the others report.
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
     steps:
       - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}
+      - uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -79,6 +102,8 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       # Pull the image built by build-agent-image and retag to the exact name the
       # container suites gate on (`docker image inspect hezo/agent-base:latest`).
+      # Every shard pulls it — vitest file-sharding is non-deterministic about
+      # which shard gets the *-docker.test.ts suites. Image is cached in GHCR.
       - name: Pull agent base image
         run: |
           docker pull ghcr.io/hezo-ai/agent-base:${{ github.sha }}
@@ -86,23 +111,34 @@ jobs:
       - run: bun install --frozen-lockfile
       # Runs the server vitest suite (Node runtime) — including the ssh-agent /
       # egress-proxy / mcp-connections container suites now that the image is
-      # present — followed by the Bun-native tier (test/bun/** under `bun test`),
-      # which exercises runtime-sensitive code (e.g. egress TLS) on the
-      # production Bun runtime.
-      - run: bun run test --package server
+      # present — followed by the Bun-native tier (test/bun/** under `bun test`,
+      # gated to shard 1 by scripts/test.ts), which exercises runtime-sensitive
+      # code (e.g. egress TLS) on the production Bun runtime.
+      - run: bun run test --package server --shard ${{ matrix.shard }}/2
 
   test-integration:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # Sharded across runners; each shard stays at --concurrency 4. The 4-core
+    # contention budget below is per-runner, so adding runners is safe.
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
     steps:
       - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}
+      - uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
       - run: bun install --frozen-lockfile
       # ubuntu-latest is 4 cores; 10 forks each owning a PGlite + Hono boot
       # produces enough contention that random `findBy*` queries time out.
-      - run: bun run test --package web --concurrency 4
+      - run: bun run test --package web --concurrency 4 --shard ${{ matrix.shard }}/3
 
   test-browser:
     runs-on: ubuntu-latest
@@ -112,6 +148,11 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}
+      - uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
       - run: bun install --frozen-lockfile
       - uses: actions/cache@v4
         id: playwright-cache
@@ -132,3 +173,21 @@ jobs:
             test-results/
           retention-days: 7
           if-no-files-found: ignore
+
+  # Stable aggregate check names for branch protection. The sharded jobs above
+  # fan out to `test-backend (1)`, `test-integration (2)`, … which a required
+  # status check can't pin to; these roll each matrix up to a single name that
+  # is green only when every shard passed. Point branch protection at these.
+  test-backend-complete:
+    if: always()
+    needs: test-backend
+    runs-on: ubuntu-latest
+    steps:
+      - run: '[ "${{ needs.test-backend.result }}" = "success" ]'
+
+  test-integration-complete:
+    if: always()
+    needs: test-integration
+    runs-on: ubuntu-latest
+    steps:
+      - run: '[ "${{ needs.test-integration.result }}" = "success" ]'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@
 - `bun run test --pattern <substring>` — filter by file-path substring (works across all tiers; combine with `--browser` to narrow browser tests)
 - `bun run test --package <server|web>` — restrict vitest run to one package
 - `bun run test --concurrency <n>` — override worker count (default 10)
+- `bun run test --shard <index>/<count>` — run one vitest shard (e.g. `1/3`); CI fans `test-backend` (2 shards) and `test-integration` (3 shards) across runners this way. The Bun-native tier runs only on shard 1. Composes with `--package`/`--concurrency`.
 - `bun run test --bail` — stop on first failure
 - `bun run build` / `check` / `check:fix` / `typecheck` / `dev`
 

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -17,6 +17,7 @@ const program = new Command()
 	.option('--package <name>', 'Run tests only in a specific package')
 	.option('--skip-browser', 'Skip Playwright browser tests')
 	.option('--browser', 'Run only Playwright browser tests')
+	.option('--shard <value>', 'Vitest shard, form <index>/<count> (e.g. 1/3)')
 	.parse();
 
 const opts = program.opts();
@@ -26,6 +27,8 @@ const pattern = opts.pattern as string | undefined;
 const packageFilter = opts.package as string | undefined;
 const skipBrowser = opts.skipBrowser as boolean;
 const browserFlag = opts.browser as boolean;
+const shard = opts.shard as string | undefined;
+const shardIndex = shard ? Number.parseInt(shard.split('/')[0], 10) : undefined;
 
 const TEST_PACKAGES = ['packages/server', 'packages/web'];
 
@@ -66,9 +69,11 @@ async function runVitestForPackage(pkg: string): Promise<boolean> {
 		`--poolOptions.forks.minForks=${concurrency}`,
 	];
 	if (bail) args.push('--bail=1');
-	if (pattern) {
-		args.push('--passWithNoTests', pattern);
-	}
+	if (shard) args.push(`--shard=${shard}`);
+	// --passWithNoTests guards an empty selection (a pattern matching nothing, or
+	// a shard that lands zero files); add it once if either is in play.
+	if (pattern || shard) args.push('--passWithNoTests');
+	if (pattern) args.push(pattern);
 
 	console.log(`\n── Running ${pkg} tests (pool=forks, workers=${concurrency}) ──`);
 	const start = Date.now();
@@ -146,8 +151,11 @@ async function main() {
 		// The Bun-native tier runs under `bun test` (production runtime). Its
 		// files live in test/bun/ and contain "bun" in their path, so honour
 		// --pattern by running it only when no pattern is set or the pattern
-		// targets that tier.
-		const runBunNative = !pattern || pattern.includes('bun');
+		// targets that tier. It isn't shardable by vitest, so when sharding run
+		// it exactly once (on shard 1) — not duplicated across the matrix, not
+		// dropped. Without --shard, shardIndex is undefined → unchanged behavior.
+		const runBunNative =
+			(!pattern || pattern.includes('bun')) && (shardIndex === undefined || shardIndex === 1);
 
 		for (const pkg of packages) {
 			const passed = await runVitestForPackage(pkg);


### PR DESCRIPTION
## Why

`test-backend` (~5m) and `test-integration` (~6m) are the two slowest CI checks; target is **≤4 min each**, no coverage loss.

Both suites are **wall-clock-bound by core count**, not raw work: every test file boots its own PGlite + Hono and runs the full migration SQL + seed. That's why the web tier is already pinned to `--concurrency 4` — the `ci.yml` comment spells it out: *"ubuntu-latest is 4 cores; 10 forks each owning a PGlite + Hono boot produces enough contention that random `findBy*` queries time out."*

I checked the history first (the previous "parallel test runner" — an in-process queue with `test-run-order.json` duration scheduling — was deliberately removed in #51 for module-state bleed + maintenance churn, replaced by vitest's forks pool with `isolate: true`). The key realisation: that contention ceiling is **per-runner**. A CI matrix has never existed here; spreading files across *more runners* at the *same* safe per-runner concurrency sidesteps the exact failure modes that killed the earlier approaches instead of repeating them.

## What

- **`scripts/test.ts`** — add a `--shard <index>/<count>` passthrough to `vitest run` (vitest is `^3`, native support). The Bun-native tier (server-only, 2 files, not shardable by vitest) is gated to **shard 1** so it runs exactly once across the matrix. With no `--shard`, behavior is identical to today.
- **`.github/workflows/ci.yml`**
  - `test-backend` → **2 shards**, `test-integration` → **3 shards** (the "Balanced" sizing), `fail-fast: false`, each shard at the same per-runner concurrency. Every backend shard pulls the agent image (vitest file-sharding is non-deterministic about which shard gets the `*-docker.test.ts` suites).
  - `test-backend-complete` / `test-integration-complete` aggregate gate jobs — a single green-only-if-all-shards-passed status, so branch protection has a stable check name once the matrix fans the job names out.
  - Cache `~/.bun/install/cache` across all bun jobs (shaves the repeated `bun install`, more valuable now that sharding multiplies the job count).
- **`AGENTS.md`** — document the new `--shard` flag.

Projected wall-clock: backend ~3.1m, integration ~2.7m (fixed per-shard overhead ~1–1.5m + the shard's slice).

## Verification

- Partitioning is **disjoint and complete** — `vitest list` over a 13-file sample split 5 + 5 + 3, union = 13 = unsharded set. **No coverage loss, no duplication.**
- End-to-end through the runner: `bun run test --package web --pattern task-list --shard 1/2` ran exactly 1 of the 2 matching files, 6 tests passed, clean exit.
- `biome check`, `typecheck`, and `build` all green (pre-commit hook).
- Real proof is this PR's own CI run — confirm each `test-backend (1|2)` / `test-integration (1|2|3)` lands < 4 min, the `*-complete` gates go green, and rebalance the matrix only if a shard runs long (vitest splits by file, not by duration).

## ⚠️ Action needed before/at merge

Once these jobs become matrices, the check names change to `test-backend (1)`, `test-integration (2)`, … Any **branch-protection required status check** pinned to the old `test-backend` / `test-integration` names will block merges. **Update required checks to `test-backend-complete` and `test-integration-complete`** (the aggregate gates added here).

https://claude.ai/code/session_01UqTRYRRmATGXfxZu4VsWnP

---
_Generated by [Claude Code](https://claude.ai/code/session_01UqTRYRRmATGXfxZu4VsWnP)_