### PR TITLE
feat: per-day budget breakdowns by agent and AI adapter; drop team cost tracking

### DIFF
--- a/.dev/api.md
+++ b/.dev/api.md
@@ -1272,14 +1272,16 @@ When approved, side effects depend on approval type:
 ### Cost & Budget
 
 #### `GET /projects/:projectId/costs`
-List cost entries with aggregation.
+List cost entries with aggregation. Scoped to the path project (`project_id`) — cost
+is never team-scoped.
 
 Query params:
 - `?agent_id=uuid`
-- `?project_id=uuid`
 - `?task_id=uuid`
 - `?from=2026-03-01&to=2026-03-31`
-- `?group_by=agent|project|day`
+- `?group_by=agent|day`
+- `?breakdown=agent|adapter` (with `group_by=day`) — per-day series split by agent or
+  by AI adapter config, for the stacked Budgets-page charts
 
 Response (when `group_by=agent`):
 ```json
@@ -1337,7 +1339,8 @@ page and the project warning banner.
 ```
 
 A limit of `0` means unlimited. `group_by=day` on `GET /costs` (with optional
-`agent_id`/`project_id`/`from`/`to`) returns the per-day series for the charts.
+`agent_id`/`from`/`to`, and optional `breakdown=agent|adapter`) returns the per-day
+series for the charts.
 
 ---
 
@@ -2813,7 +2816,7 @@ at `http://host.docker.internal:<serverPort>/mcp` and carries
 | `create_comment` | Add comment to task | `team_id`, `task_id`, `content`, `content_type?` |
 | `list_approvals` | List pending approvals | `team_id` |
 | `resolve_approval` | Resolve an approval | `team_id`, `approval_id`, `status` (`approved`/`denied`), `resolution_note?` |
-| `get_costs` | Get cost summary | `team_id`, `group_by?` (`agent`/`project`/`day`) |
+| `get_costs` | Get project cost summary | `project`, `group_by?` (`agent`/`day`) |
 | `get_agent_system_prompt` | Read agent's system prompt. Any agent or board user in the same team. | `team_id`, `agent_id` |
 | `update_agent_system_prompt` | Apply a system prompt change. **Coach-only.** Writes immediately and snapshots a revision for board rollback. | `team_id`, `agent_id`, `new_system_prompt`, `change_summary` |
 | `list_project_docs` | List project docs | `team_id`, `project_id` |

--- a/.dev/schema.md
+++ b/.dev/schema.md
@@ -27,7 +27,7 @@
 | `secrets` | Encrypted key/value. Scoped to team or team+project; `team_id NULL` = an instance-level credential shared with every team's egress (Admin-managed, unique by name). | belongs to team (or instance), optionally project |
 | `secret_grants` | Which agent has access to which secret. Revocable. | links secret ↔ member_agent |
 | `approvals` | Pending board decisions. Polymorphic payload. | belongs to team, requested by member_agent |
-| `cost_entries` | Immutable spend records per agent per task. | belongs to team + member_agent, optionally task/project |
+| `cost_entries` | Immutable spend records per agent per task, attributed to the AI adapter config (`ai_provider_config_id` + `provider` snapshot) that produced them. Cost is project/agent/adapter-scoped — there is **no** `team_id` (cost is never tracked per team). | belongs to member_agent, optionally task/project/ai_provider_config |
 | `audit_log` | Append-only activity trail. `team_id` is nullable (NULL = an instance-level admin action not bound to a team); `project_id` is nullable (set for project-scoped events). Read at three scopes: instance (`GET /api/audit-log`, superuser), team, and per-project. | optionally team, optionally project |
 | `documents` | Unified Markdown document store keyed by `type` (`project_doc` / `team_preferences` / `agent_system_prompt`). Project docs scope by `(project_id, slug)`; preferences by `(team_id)` (one per team); agent system prompts by `(member_agent_id)` (one per agent). Embeddings live on this table for project docs. The team-level reference store is the `skills` table, not this one. | belongs to team, optionally project or member_agent |
 | `document_revisions` | Snapshot of prior content created on every change. `change_summary` captures intent; `Restored to revision N` is set automatically by the rollback path. Shared by all document types — agent system prompt history lives here too. | belongs to document |
@@ -112,8 +112,15 @@ A run is blocked when the agent **or** its project is over **any** window. Enfor
 points: (1) a **pre-run gate** in `JobManager.activateAgent` skips the run (no
 `heartbeat_runs` row, no container/repo work), pauses the agent, and marks the wakeup
 skipped with `WakeupSkipReason.OverBudget`; (2) **run completion** (`agent-runner.ts`)
-records the run's cost as one `cost_entries` row and reactively pauses the agent if it
-is now over; (3) the manual `POST /costs` path does the same reactive pause. Run
+records the run's cost as one `cost_entries` row — attributed to the AI adapter config
+resolved for the run (stamped on `heartbeat_runs.ai_provider_config_id`/`provider` at
+start, read back when recording) — and reactively pauses the agent if it is now over;
+(3) the manual `POST /costs` path does the same reactive pause.
+
+Cost **reads** are project-scoped: `GET /projects/:projectId/costs` filters by
+`project_id`, and `group_by=day` (optionally `breakdown=agent|adapter`) powers the
+per-day Budgets-page charts (project total, stacked by agent, stacked by adapter
+config). There is no team-scoped cost query. Run
 completion is the single source of truth for run spend — the tool-call report path
 (`agent-api.ts`) records `tool_calls.cost_cents` for display only and does **not** debit
 (the run total already includes tool-call cost).

--- a/packages/server/migrations/004_cost_provider_tracking.sql
+++ b/packages/server/migrations/004_cost_provider_tracking.sql
@@ -1,0 +1,31 @@
+-- Cost provider tracking + drop team cost dimension.
+--
+-- Cost is project/agent/adapter-scoped now — never team-scoped. Budget
+-- enforcement (services/budget.ts) already keys off member_id and project_id;
+-- cost_entries.team_id was load-bearing only for cost *reads*, which we re-scope
+-- to project_id. So drop the team dimension from cost entirely.
+--
+-- We also start attributing each cost to the AI adapter configuration that
+-- produced it (ai_provider_configs row + provider snapshot), captured at run
+-- completion. The run carries the resolved config through heartbeat_runs.
+--
+-- Forward-only. Existing cost rows keep project_id; the new provider columns are
+-- NULL for historical rows (surfaced as "Unattributed"). Rows with a NULL
+-- project_id (task-less runs) become unattributable to any project page —
+-- acceptable, since cost is project-centric.
+
+-- cost_entries: drop the team dimension.
+DROP INDEX IF EXISTS idx_costs_team;
+ALTER TABLE cost_entries DROP COLUMN team_id;
+
+-- cost_entries: attribute spend to the AI adapter configuration that produced it.
+-- ai_provider_config_id keeps the FK (ON DELETE SET NULL so deleting a config
+-- doesn't erase history); provider is a snapshot that survives config deletion.
+ALTER TABLE cost_entries ADD COLUMN ai_provider_config_id UUID REFERENCES ai_provider_configs(id) ON DELETE SET NULL;
+ALTER TABLE cost_entries ADD COLUMN provider ai_provider;
+CREATE INDEX idx_costs_provider_config ON cost_entries(ai_provider_config_id);
+
+-- heartbeat_runs: carry the resolved config from run start to the cost-recording
+-- step (recordRunCostAndEnforce reads it back by run id).
+ALTER TABLE heartbeat_runs ADD COLUMN ai_provider_config_id UUID REFERENCES ai_provider_configs(id) ON DELETE SET NULL;
+ALTER TABLE heartbeat_runs ADD COLUMN provider ai_provider;

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -1952,7 +1952,7 @@ export function registerTools(
 		'Get the cost summary for a project',
 		{
 			project: projectArg(),
-			group_by: z.enum(['agent', 'project', 'day']).optional().describe('Group costs by'),
+			group_by: z.enum(['agent', 'day']).optional().describe('Group costs by'),
 		},
 		async (args, db, auth) => {
 			const scope = await resolveScope(db, auth, args);
@@ -1961,14 +1961,22 @@ export function registerTools(
 				const r = await db.query(
 					`SELECT ce.member_id, COALESCE(ma.title, m.display_name) AS agent_title, sum(ce.amount_cents)::int AS total_cents
 				 FROM cost_entries ce LEFT JOIN members m ON m.id = ce.member_id LEFT JOIN member_agents ma ON ma.id = ce.member_id
-				 WHERE ce.team_id = $1 GROUP BY ce.member_id, ma.title, m.display_name`,
-					[scope.teamId],
+				 WHERE ce.project_id = $1 GROUP BY ce.member_id, ma.title, m.display_name`,
+					[scope.projectId],
+				);
+				return r.rows;
+			}
+			if (args.group_by === 'day') {
+				const r = await db.query(
+					`SELECT date_trunc('day', ce.created_at)::date AS day, sum(ce.amount_cents)::int AS total_cents
+				 FROM cost_entries ce WHERE ce.project_id = $1 GROUP BY day ORDER BY day`,
+					[scope.projectId],
 				);
 				return r.rows;
 			}
 			const r = await db.query(
-				`SELECT sum(amount_cents)::int AS total_cents, count(*)::int AS entry_count FROM cost_entries WHERE team_id = $1`,
-				[scope.teamId],
+				`SELECT sum(amount_cents)::int AS total_cents, count(*)::int AS entry_count FROM cost_entries WHERE project_id = $1`,
+				[scope.projectId],
 			);
 			return r.rows[0];
 		},

--- a/packages/server/src/routes/costs.ts
+++ b/packages/server/src/routes/costs.ts
@@ -7,28 +7,29 @@ import { checkOverBudget, getProjectBudgetStatus, toEntityBudgetStatus } from '.
 
 export const costsRoutes = new Hono<Env>();
 
+/**
+ * Cost reads are scoped to a single project (`ce.project_id`) — cost is
+ * project/agent/adapter-scoped, never team-scoped. `group_by=day` powers the
+ * project total chart; `breakdown=agent` / `breakdown=adapter` add a per-day
+ * series split for the stacked charts on the Budgets page.
+ */
 costsRoutes.get('/projects/:projectId/costs', async (c) => {
-	const teamId = c.get('teamId') as string;
+	const projectId = c.get('projectId') as string;
 	const db = c.get('db');
 	const agentId = c.req.query('agent_id');
-	const projectId = c.req.query('project_id');
 	const taskId = c.req.query('task_id');
 	const from = c.req.query('from');
 	const to = c.req.query('to');
 	const groupBy = c.req.query('group_by');
+	const breakdown = c.req.query('breakdown');
 
-	const conditions: string[] = ['ce.team_id = $1'];
-	const params: unknown[] = [teamId];
+	const conditions: string[] = ['ce.project_id = $1'];
+	const params: unknown[] = [projectId];
 	let idx = 2;
 
 	if (agentId) {
 		conditions.push(`ce.member_id = $${idx}`);
 		params.push(agentId);
-		idx++;
-	}
-	if (projectId) {
-		conditions.push(`ce.project_id = $${idx}`);
-		params.push(projectId);
 		idx++;
 	}
 	if (taskId) {
@@ -65,14 +66,36 @@ costsRoutes.get('/projects/:projectId/costs', async (c) => {
 		return ok(c, { summary: result.rows, total_cents: totalCents });
 	}
 
-	if (groupBy === 'project') {
+	if (groupBy === 'day' && breakdown === 'agent') {
 		const result = await db.query<{ total_cents: number }>(
-			`SELECT ce.project_id, p.name AS project_name,
+			`SELECT date_trunc('day', ce.created_at)::date AS day,
+              ce.member_id AS agent_id,
+              COALESCE(ma.title, m.display_name) AS agent_title,
               sum(ce.amount_cents)::int AS total_cents
        FROM cost_entries ce
-       LEFT JOIN projects p ON p.id = ce.project_id
+       LEFT JOIN members m ON m.id = ce.member_id
+       LEFT JOIN member_agents ma ON ma.id = ce.member_id
        WHERE ${where}
-       GROUP BY ce.project_id, p.name`,
+       GROUP BY day, ce.member_id, ma.title, m.display_name
+       ORDER BY day`,
+			params,
+		);
+		const totalCents = result.rows.reduce((sum, r) => sum + r.total_cents, 0);
+		return ok(c, { summary: result.rows, total_cents: totalCents });
+	}
+
+	if (groupBy === 'day' && breakdown === 'adapter') {
+		const result = await db.query<{ total_cents: number }>(
+			`SELECT date_trunc('day', ce.created_at)::date AS day,
+              ce.ai_provider_config_id,
+              ce.provider,
+              apc.label AS adapter_label,
+              sum(ce.amount_cents)::int AS total_cents
+       FROM cost_entries ce
+       LEFT JOIN ai_provider_configs apc ON apc.id = ce.ai_provider_config_id
+       WHERE ${where}
+       GROUP BY day, ce.ai_provider_config_id, ce.provider, apc.label
+       ORDER BY day`,
 			params,
 		);
 		const totalCents = result.rows.reduce((sum, r) => sum + r.total_cents, 0);
@@ -102,6 +125,7 @@ costsRoutes.get('/projects/:projectId/costs', async (c) => {
 
 costsRoutes.post('/projects/:projectId/costs', async (c) => {
 	const teamId = c.get('teamId') as string;
+	const projectId = c.get('projectId') as string;
 	const db = c.get('db');
 
 	const body = await c.req.json<{
@@ -117,17 +141,18 @@ costsRoutes.post('/projects/:projectId/costs', async (c) => {
 	}
 
 	// Spend is always recorded; budgets are enforced by windowed sums (services/budget.ts),
-	// not a debit counter. After recording, reactively pause the agent if this pushed it
-	// or its project over any window — mirroring the run-completion enforcement path.
+	// not a debit counter. Cost is project-scoped, so attribute it to the path project
+	// unless the body names a specific one. After recording, reactively pause the agent if
+	// this pushed it or its project over any window — mirroring the run-completion path.
+	const costProjectId = body.project_id ?? projectId;
 	const result = await db.query(
-		`INSERT INTO cost_entries (team_id, member_id, task_id, project_id, amount_cents, description)
-     VALUES ($1, $2, $3, $4, $5, $6)
+		`INSERT INTO cost_entries (member_id, task_id, project_id, amount_cents, description)
+     VALUES ($1, $2, $3, $4, $5)
      RETURNING *`,
 		[
-			teamId,
 			body.member_id,
 			body.task_id ?? null,
-			body.project_id ?? null,
+			costProjectId,
 			body.amount_cents,
 			body.description ?? '',
 		],
@@ -141,7 +166,7 @@ costsRoutes.post('/projects/:projectId/costs', async (c) => {
 		result.rows[0] as Record<string, unknown>,
 	);
 
-	const block = await checkOverBudget(db, body.member_id, body.project_id ?? null);
+	const block = await checkOverBudget(db, body.member_id, costProjectId);
 	if (block) {
 		await db.query(
 			'UPDATE member_agents SET runtime_status = $1::agent_runtime_status WHERE id = $2',

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -752,7 +752,10 @@ export async function runAgent(
 	// run on this credential forever. Release is idempotent, so the explicit cleanup
 	// paths below don't double-free.
 	try {
-		await markHeartbeatRunRunning(deps.db, heartbeatRunId, runBroadcast);
+		await markHeartbeatRunRunning(deps.db, heartbeatRunId, runBroadcast, {
+			aiProviderConfigId: credential.configId,
+			provider,
+		});
 
 		// Human-friendly label for run-scoped logs (egress proxy, ssh-agent),
 		// since a run has no friendly identifier of its own.
@@ -1735,13 +1738,23 @@ async function markHeartbeatRunRunning(
 	db: PGlite,
 	runId: string,
 	broadcast: HeartbeatRunBroadcast,
+	adapter: { aiProviderConfigId: string | null; provider: AiProvider | null },
 ): Promise<void> {
+	// Stamp the resolved AI adapter config on the run so recordRunCostAndEnforce
+	// can attribute the run's cost to it without re-resolving.
 	const result = await db.query<{ id: string }>(
 		`UPDATE heartbeat_runs
-		    SET status = $1::heartbeat_run_status, started_at = now()
+		    SET status = $1::heartbeat_run_status, started_at = now(),
+		        ai_provider_config_id = $4, provider = $5::ai_provider
 		  WHERE id = $2 AND status = $3::heartbeat_run_status
 		  RETURNING id`,
-		[HeartbeatRunStatus.Running, runId, HeartbeatRunStatus.Queued],
+		[
+			HeartbeatRunStatus.Running,
+			runId,
+			HeartbeatRunStatus.Queued,
+			adapter.aiProviderConfigId,
+			adapter.provider,
+		],
 	);
 	if (result.rows.length > 0) {
 		broadcastHeartbeatRunChange(broadcast, runId, HeartbeatRunStatus.Running, 'UPDATE');
@@ -1814,13 +1827,22 @@ async function recordRunCostAndEnforce(
 ): Promise<void> {
 	if (!usage || usage.costCents <= 0) return;
 	try {
+		// The resolved AI adapter config was stamped on the run at start
+		// (markHeartbeatRunRunning); read it back to attribute this cost to it.
+		const runRow = await db.query<{
+			ai_provider_config_id: string | null;
+			provider: AiProvider | null;
+		}>(`SELECT ai_provider_config_id, provider FROM heartbeat_runs WHERE id = $1`, [runId]);
+		const adapter = runRow.rows[0] ?? { ai_provider_config_id: null, provider: null };
+
 		const entry = await recordRunCost(db, {
-			teamId: broadcast.teamId,
 			memberId: broadcast.memberId,
 			taskId: broadcast.taskId ?? null,
 			projectId: broadcast.projectId ?? null,
 			amountCents: usage.costCents,
 			description: `Agent run ${runId}`,
+			aiProviderConfigId: adapter.ai_provider_config_id,
+			provider: adapter.provider,
 		});
 		if (entry && broadcast.wsManager) {
 			broadcastRowChange(

--- a/packages/server/src/services/budget.ts
+++ b/packages/server/src/services/budget.ts
@@ -1,5 +1,5 @@
 import type { PGlite } from '@electric-sql/pglite';
-import { BudgetPeriod } from '@hezo/shared';
+import { type AiProvider, BudgetPeriod } from '@hezo/shared';
 
 /**
  * Budget enforcement — the single source of truth for agent/project spend.
@@ -185,26 +185,28 @@ export async function checkOverBudget(
 export async function recordRunCost(
 	db: PGlite,
 	entry: {
-		teamId: string;
 		memberId: string;
 		taskId: string | null;
 		projectId: string | null;
 		amountCents: number;
 		description: string;
+		aiProviderConfigId: string | null;
+		provider: AiProvider | null;
 	},
 ): Promise<Record<string, unknown> | null> {
 	if (entry.amountCents <= 0) return null;
 	const res = await db.query<Record<string, unknown>>(
-		`INSERT INTO cost_entries (team_id, member_id, task_id, project_id, amount_cents, description)
-		 VALUES ($1, $2, $3, $4, $5, $6)
+		`INSERT INTO cost_entries (member_id, task_id, project_id, amount_cents, description, ai_provider_config_id, provider)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7::ai_provider)
 		 RETURNING *`,
 		[
-			entry.teamId,
 			entry.memberId,
 			entry.taskId,
 			entry.projectId,
 			entry.amountCents,
 			entry.description,
+			entry.aiProviderConfigId,
+			entry.provider,
 		],
 	);
 	return res.rows[0] ?? null;

--- a/packages/server/test/budget.test.ts
+++ b/packages/server/test/budget.test.ts
@@ -78,9 +78,9 @@ beforeEach(async () => {
 /** Insert a cost_entry at an explicit age (negative offset from now). */
 async function insertCost(amountCents: number, ageInterval: string): Promise<void> {
 	await db.query(
-		`INSERT INTO cost_entries (team_id, member_id, project_id, amount_cents, created_at)
-		 VALUES ($1, $2, $3, $4, now() AT TIME ZONE 'UTC' - $5::interval)`,
-		[teamId, agentId, projectId, amountCents, ageInterval],
+		`INSERT INTO cost_entries (member_id, project_id, amount_cents, created_at)
+		 VALUES ($1, $2, $3, now() AT TIME ZONE 'UTC' - $4::interval)`,
+		[agentId, projectId, amountCents, ageInterval],
 	);
 }
 
@@ -161,26 +161,48 @@ describe('budget service - checkOverBudget gate', () => {
 describe('budget service - recordRunCost', () => {
 	it('inserts exactly one cost_entry for a positive amount', async () => {
 		const entry = await recordRunCost(db, {
-			teamId,
 			memberId: agentId,
 			taskId: null,
 			projectId,
 			amountCents: 250,
 			description: 'Agent run abc',
+			aiProviderConfigId: null,
+			provider: null,
 		});
 		expect(entry).not.toBeNull();
 		const spend = await getAgentSpend(db, agentId);
 		expect(spend.daily).toBe(250);
 	});
 
+	it('attributes the cost to the AI adapter config that produced it', async () => {
+		const cfg = await db.query<{ id: string }>(
+			`INSERT INTO ai_provider_configs (provider, auth_method, label, encrypted_credential)
+			 VALUES ('anthropic', 'api_key', 'Attribution Test Key', 'x') RETURNING id`,
+		);
+		const configId = cfg.rows[0].id;
+		const entry = await recordRunCost(db, {
+			memberId: agentId,
+			taskId: null,
+			projectId,
+			amountCents: 99,
+			description: 'Agent run xyz',
+			aiProviderConfigId: configId,
+			provider: 'anthropic',
+		});
+		expect(entry).not.toBeNull();
+		expect((entry as Record<string, unknown>).ai_provider_config_id).toBe(configId);
+		expect((entry as Record<string, unknown>).provider).toBe('anthropic');
+	});
+
 	it('is a no-op for non-positive amounts', async () => {
 		const entry = await recordRunCost(db, {
-			teamId,
 			memberId: agentId,
 			taskId: null,
 			projectId,
 			amountCents: 0,
 			description: 'free run',
+			aiProviderConfigId: null,
+			provider: null,
 		});
 		expect(entry).toBeNull();
 		const spend = await getAgentSpend(db, agentId);

--- a/packages/server/test/costs-extended.test.ts
+++ b/packages/server/test/costs-extended.test.ts
@@ -9,13 +9,13 @@ let app: Hono<Env>;
 let db: PGlite;
 let token: string;
 let teamId: string;
-let teamSlug: string;
 let projectSlug: string;
 let agentId: string;
 let agent2Id: string;
 let projectId: string;
-let project2Id: string;
 let taskId: string;
+let anthropicConfigId: string;
+let openaiConfigId: string;
 
 beforeAll(async () => {
 	const ctx = await createTestApp();
@@ -39,7 +39,6 @@ beforeAll(async () => {
 	});
 	const team = (await teamRes.json()).data;
 	teamId = team.id;
-	teamSlug = team.slug;
 
 	// Get two agents to work with
 	const agentsRes = await app.request(`/api/projects/${await projectSlugFor(db, teamId)}/agents`, {
@@ -49,7 +48,7 @@ beforeAll(async () => {
 	agentId = agents.find((a: Record<string, unknown>) => a.slug === 'engineer').id;
 	agent2Id = agents.find((a: Record<string, unknown>) => a.slug === 'ui-designer').id;
 
-	// Create two projects
+	// All cost reads are project-scoped now; everything below belongs to this project.
 	const proj1Res = await createTestProject(db, teamId, {
 		name: 'Project Alpha',
 		description: 'Test project.',
@@ -58,22 +57,7 @@ beforeAll(async () => {
 	projectId = proj1.id;
 	projectSlug = proj1.slug;
 
-	// With 1:1 teams↔projects a second project needs its own team. The cost_entries
-	// below stay scoped to this team (team_id = teamId); project2Id is only a
-	// project reference used by the project_id/group-by filters.
-	const team2Res = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Extended Cost Co Beta', template_id: typeId }),
-	});
-	const team2Id = (await team2Res.json()).data.id;
-	const proj2Res = await createTestProject(db, team2Id, {
-		name: 'Project Beta',
-		description: 'Test project.',
-	});
-	project2Id = (await proj2Res.json()).data.id;
-
-	// Create an task under project 1
+	// Create an task under the project
 	const taskRes = await app.request(`/api/projects/${projectSlug}/tasks`, {
 		method: 'POST',
 		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
@@ -85,17 +69,27 @@ beforeAll(async () => {
 	});
 	taskId = (await taskRes.json()).data.id;
 
-	// Insert cost entries with varied dates, agents, and projects directly via DB
-	// so we can control timestamps precisely for date-range tests.
-	// All amounts are small to stay within budget limits.
+	// Two AI adapter configs to exercise the per-adapter breakdown.
+	const cfg = await db.query<{ id: string }>(
+		`INSERT INTO ai_provider_configs (provider, auth_method, label, encrypted_credential)
+		 VALUES ('anthropic', 'api_key', 'Anthropic Prod', 'x'),
+		        ('openai', 'api_key', 'OpenAI Prod', 'y')
+		 RETURNING id, provider`,
+	);
+	anthropicConfigId = (cfg.rows as any[]).find((r) => r.provider === 'anthropic').id;
+	openaiConfigId = (cfg.rows as any[]).find((r) => r.provider === 'openai').id;
+
+	// Insert cost entries with varied dates, agents, and adapters directly via DB
+	// so we can control timestamps precisely for date-range tests. All belong to the
+	// project above. Amounts stay small to stay within budget limits.
 	await db.query(
-		`INSERT INTO cost_entries (team_id, member_id, project_id, task_id, amount_cents, description, created_at)
+		`INSERT INTO cost_entries (member_id, project_id, task_id, amount_cents, description, ai_provider_config_id, provider, created_at)
      VALUES
-       ($1, $2, $3, $4, 50,  'past entry',          '2024-01-15 10:00:00+00'),
-       ($1, $2, $3, NULL, 75,  'past no-task',      '2024-01-20 12:00:00+00'),
-       ($1, $5, $6, NULL, 120, 'agent2 project2',    '2024-02-10 08:00:00+00'),
-       ($1, $2, NULL, NULL, 30, 'agent1 no project',  '2024-03-01 09:00:00+00')`,
-		[teamId, agentId, projectId, taskId, agent2Id, project2Id],
+       ($2, $1, $3, 50,  'past entry',         $4, 'anthropic', '2024-01-15 10:00:00+00'),
+       ($2, $1, NULL, 75, 'past no-task',       $4, 'anthropic', '2024-01-20 12:00:00+00'),
+       ($5, $1, NULL, 120,'agent2 openai',      $6, 'openai',    '2024-02-10 08:00:00+00'),
+       ($2, $1, NULL, 30, 'agent1 unattributed', NULL, NULL,     '2024-03-01 09:00:00+00')`,
+		[projectId, agentId, taskId, anthropicConfigId, agent2Id, openaiConfigId],
 	);
 });
 
@@ -105,26 +99,20 @@ afterAll(async () => {
 
 describe('costs – date range filtering', () => {
 	it('filters by from date (inclusive)', async () => {
-		const res = await app.request(
-			`/api/projects/${await projectSlugFor(db, teamId)}/costs?from=2024-02-01`,
-			{
-				headers: authHeader(token),
-			},
-		);
+		const res = await app.request(`/api/projects/${projectSlug}/costs?from=2024-02-01`, {
+			headers: authHeader(token),
+		});
 		expect(res.status).toBe(200);
 		const body = await res.json();
-		// Only entries on/after 2024-02-01: agent2 (120) + agent1 no-project (30)
+		// Only entries on/after 2024-02-01: agent2 (120) + agent1 unattributed (30)
 		expect(body.data.entries.length).toBe(2);
 		expect(body.data.total_cents).toBe(150);
 	});
 
 	it('filters by to date (inclusive)', async () => {
-		const res = await app.request(
-			`/api/projects/${await projectSlugFor(db, teamId)}/costs?to=2024-01-31`,
-			{
-				headers: authHeader(token),
-			},
-		);
+		const res = await app.request(`/api/projects/${projectSlug}/costs?to=2024-01-31`, {
+			headers: authHeader(token),
+		});
 		expect(res.status).toBe(200);
 		const body = await res.json();
 		// Only entries on/before 2024-01-31: past entry (50) + past no-task (75)
@@ -134,58 +122,61 @@ describe('costs – date range filtering', () => {
 
 	it('filters by from and to range together', async () => {
 		const res = await app.request(
-			`/api/projects/${await projectSlugFor(db, teamId)}/costs?from=2024-01-18&to=2024-02-28`,
+			`/api/projects/${projectSlug}/costs?from=2024-01-18&to=2024-02-28`,
 			{
 				headers: authHeader(token),
 			},
 		);
 		expect(res.status).toBe(200);
 		const body = await res.json();
-		// Entries in range: past no-task (75, Jan 20) + agent2 project2 (120, Feb 10)
+		// Entries in range: past no-task (75, Jan 20) + agent2 openai (120, Feb 10)
 		expect(body.data.entries.length).toBe(2);
 		expect(body.data.total_cents).toBe(195);
 	});
 });
 
-describe('costs – project_id filter', () => {
-	it('returns only entries for the specified project', async () => {
-		const res = await app.request(
-			`/api/projects/${await projectSlugFor(db, teamId)}/costs?project_id=${projectId}`,
-			{
-				headers: authHeader(token),
-			},
-		);
+describe('costs – project scoping', () => {
+	it('returns only entries for the path project', async () => {
+		const res = await app.request(`/api/projects/${projectSlug}/costs`, {
+			headers: authHeader(token),
+		});
 		expect(res.status).toBe(200);
 		const body = await res.json();
-		// past entry (50) + past no-task (75) both belong to project 1
-		expect(body.data.entries.length).toBe(2);
+		expect(body.data.entries.length).toBe(4);
 		for (const entry of body.data.entries) {
 			expect(entry.project_id).toBe(projectId);
 		}
+		expect(body.data.total_cents).toBe(275);
 	});
 
-	it('returns only entries for project2', async () => {
-		const res = await app.request(
-			`/api/projects/${await projectSlugFor(db, teamId)}/costs?project_id=${project2Id}`,
-			{
-				headers: authHeader(token),
-			},
-		);
+	it('returns no entries for a different project', async () => {
+		// A team owns exactly one project (1:1), so a second project needs its own
+		// team. None of our cost entries belong to it, so it should read empty.
+		const typesRes = await app.request('/api/team-templates', { headers: authHeader(token) });
+		const typeId = (await typesRes.json()).data.find((t: any) => t.name === 'Startup').id;
+		const team2Res = await app.request('/api/teams', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name: 'Other Cost Co', template_id: typeId }),
+		});
+		const team2Id = (await team2Res.json()).data.id;
+		const other = await createTestProject(db, team2Id, { name: 'Project Beta' });
+		const otherSlug = (await other.json()).data.slug;
+		const res = await app.request(`/api/projects/${otherSlug}/costs`, {
+			headers: authHeader(token),
+		});
 		expect(res.status).toBe(200);
 		const body = await res.json();
-		expect(body.data.entries.length).toBe(1);
-		expect(body.data.total_cents).toBe(120);
+		expect(body.data.entries.length).toBe(0);
+		expect(body.data.total_cents).toBe(0);
 	});
 });
 
 describe('costs – task_id filter', () => {
 	it('returns only entries linked to the specified task', async () => {
-		const res = await app.request(
-			`/api/projects/${await projectSlugFor(db, teamId)}/costs?task_id=${taskId}`,
-			{
-				headers: authHeader(token),
-			},
-		);
+		const res = await app.request(`/api/projects/${projectSlug}/costs?task_id=${taskId}`, {
+			headers: authHeader(token),
+		});
 		expect(res.status).toBe(200);
 		const body = await res.json();
 		// Only "past entry" (50) has task_id set
@@ -197,12 +188,9 @@ describe('costs – task_id filter', () => {
 
 describe('costs – group_by=day', () => {
 	it('groups cost entries by day with correct totals', async () => {
-		const res = await app.request(
-			`/api/projects/${await projectSlugFor(db, teamId)}/costs?group_by=day`,
-			{
-				headers: authHeader(token),
-			},
-		);
+		const res = await app.request(`/api/projects/${projectSlug}/costs?group_by=day`, {
+			headers: authHeader(token),
+		});
 		expect(res.status).toBe(200);
 		const body = await res.json();
 		expect(body.data.summary).toBeDefined();
@@ -217,7 +205,7 @@ describe('costs – group_by=day', () => {
 
 	it('group_by=day with date range returns subset', async () => {
 		const res = await app.request(
-			`/api/projects/${await projectSlugFor(db, teamId)}/costs?group_by=day&from=2024-02-01&to=2024-03-31`,
+			`/api/projects/${projectSlug}/costs?group_by=day&from=2024-02-01&to=2024-03-31`,
 			{ headers: authHeader(token) },
 		);
 		expect(res.status).toBe(200);
@@ -227,37 +215,53 @@ describe('costs – group_by=day', () => {
 	});
 });
 
-describe('costs – group_by=project', () => {
-	it('groups cost entries by project', async () => {
+describe('costs – group_by=day&breakdown=agent', () => {
+	it('returns per-day spend split by agent', async () => {
 		const res = await app.request(
-			`/api/projects/${await projectSlugFor(db, teamId)}/costs?group_by=project`,
-			{
-				headers: authHeader(token),
-			},
+			`/api/projects/${projectSlug}/costs?group_by=day&breakdown=agent`,
+			{ headers: authHeader(token) },
 		);
 		expect(res.status).toBe(200);
 		const body = await res.json();
-		expect(body.data.summary).toBeDefined();
+		const rows: any[] = body.data.summary;
+		// 4 (day, agent) cells; each row carries the agent's title.
+		expect(rows.length).toBe(4);
+		for (const r of rows) expect(typeof r.agent_title).toBe('string');
 
-		const proj1Row = body.data.summary.find((r: any) => r.project_id === projectId);
-		const proj2Row = body.data.summary.find((r: any) => r.project_id === project2Id);
-		const nullRow = body.data.summary.find((r: any) => r.project_id === null);
+		const byAgent = (id: string) =>
+			rows.filter((r) => r.agent_id === id).reduce((s, r) => s + r.total_cents, 0);
+		expect(byAgent(agentId)).toBe(155); // 50 + 75 + 30
+		expect(byAgent(agent2Id)).toBe(120);
+		expect(body.data.total_cents).toBe(275);
+	});
+});
 
-		expect(proj1Row).toBeDefined();
-		expect(proj1Row.total_cents).toBe(125); // 50+75
-		expect(proj2Row).toBeDefined();
-		expect(proj2Row.total_cents).toBe(120);
-		// The entry with no project lands in the null bucket
-		expect(nullRow).toBeDefined();
-		expect(nullRow.total_cents).toBe(30);
+describe('costs – group_by=day&breakdown=adapter', () => {
+	it('returns per-day spend split by AI adapter config', async () => {
+		const res = await app.request(
+			`/api/projects/${projectSlug}/costs?group_by=day&breakdown=adapter`,
+			{ headers: authHeader(token) },
+		);
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		const rows: any[] = body.data.summary;
 
+		const byConfig = (id: string | null) =>
+			rows.filter((r) => r.ai_provider_config_id === id).reduce((s, r) => s + r.total_cents, 0);
+		expect(byConfig(anthropicConfigId)).toBe(125); // 50 + 75
+		expect(byConfig(openaiConfigId)).toBe(120);
+		expect(byConfig(null)).toBe(30); // unattributed
+
+		const anthropicRow = rows.find((r) => r.ai_provider_config_id === anthropicConfigId);
+		expect(anthropicRow.adapter_label).toBe('Anthropic Prod');
+		expect(anthropicRow.provider).toBe('anthropic');
 		expect(body.data.total_cents).toBe(275);
 	});
 });
 
 describe('costs – POST validation', () => {
 	it('returns 400 when member_id is missing', async () => {
-		const res = await app.request(`/api/projects/${await projectSlugFor(db, teamId)}/costs`, {
+		const res = await app.request(`/api/projects/${projectSlug}/costs`, {
 			method: 'POST',
 			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
 			body: JSON.stringify({ amount_cents: 100 }),
@@ -268,7 +272,7 @@ describe('costs – POST validation', () => {
 	});
 
 	it('returns 400 when amount_cents is zero', async () => {
-		const res = await app.request(`/api/projects/${await projectSlugFor(db, teamId)}/costs`, {
+		const res = await app.request(`/api/projects/${projectSlug}/costs`, {
 			method: 'POST',
 			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
 			body: JSON.stringify({ member_id: agentId, amount_cents: 0 }),
@@ -279,7 +283,7 @@ describe('costs – POST validation', () => {
 	});
 
 	it('returns 400 when amount_cents is negative', async () => {
-		const res = await app.request(`/api/projects/${await projectSlugFor(db, teamId)}/costs`, {
+		const res = await app.request(`/api/projects/${projectSlug}/costs`, {
 			method: 'POST',
 			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
 			body: JSON.stringify({ member_id: agentId, amount_cents: -50 }),
@@ -290,7 +294,7 @@ describe('costs – POST validation', () => {
 	});
 
 	it('returns 400 when amount_cents is missing', async () => {
-		const res = await app.request(`/api/projects/${await projectSlugFor(db, teamId)}/costs`, {
+		const res = await app.request(`/api/projects/${projectSlug}/costs`, {
 			method: 'POST',
 			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
 			body: JSON.stringify({ member_id: agentId }),

--- a/packages/server/test/mcp-tools.test.ts
+++ b/packages/server/test/mcp-tools.test.ts
@@ -848,8 +848,8 @@ describe('MCP tool handlers: additional data queries via DB', () => {
 
 	it('get_costs query returns cost summary', async () => {
 		const r = await db.query<{ total_cents: number }>(
-			'SELECT COALESCE(SUM(amount_cents), 0)::int AS total_cents FROM cost_entries WHERE team_id = $1',
-			[teamId],
+			'SELECT COALESCE(SUM(amount_cents), 0)::int AS total_cents FROM cost_entries WHERE project_id = $1',
+			[projectId],
 		);
 		expect(r.rows[0].total_cents).toBeDefined();
 	});

--- a/packages/server/test/migrate-cost-provider.test.ts
+++ b/packages/server/test/migrate-cost-provider.test.ts
@@ -1,0 +1,127 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { PGlite } from '@electric-sql/pglite';
+import { vector } from '@electric-sql/pglite/vector';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { safeClose } from './helpers';
+
+// 004_cost_provider_tracking.sql drops the team dimension from cost_entries
+// (cost is project/agent/adapter-scoped now) and adds AI-adapter attribution
+// (ai_provider_config_id + provider snapshot) to cost_entries and heartbeat_runs.
+// This drives the REAL migration files through the apply-in-order path
+// (001 -> 002 -> 003 -> 004) against populated data, asserting both the schema
+// delta and that existing cost rows survive with their project attribution.
+
+function migrationsDir(): string {
+	try {
+		return fileURLToPath(new URL('../migrations', import.meta.url));
+	} catch {
+		const override = process.env.HEZO_MIGRATIONS_DIR;
+		if (!override) throw new Error('HEZO_MIGRATIONS_DIR unset and import.meta.url not a file URL');
+		return override;
+	}
+}
+
+function loadMigration(file: string): string {
+	return readFileSync(join(migrationsDir(), file), 'utf-8').replace(
+		/CREATE EXTENSION IF NOT EXISTS "pgcrypto";/g,
+		'',
+	);
+}
+
+async function columnExists(db: PGlite, table: string, column: string): Promise<boolean> {
+	const r = await db.query(
+		`SELECT 1 FROM information_schema.columns WHERE table_name = $1 AND column_name = $2`,
+		[table, column],
+	);
+	return r.rows.length > 0;
+}
+
+describe('004_cost_provider_tracking migration', () => {
+	let db: PGlite;
+	let costId: string;
+	let projectId: string;
+
+	beforeAll(async () => {
+		db = new PGlite({ extensions: { vector } });
+
+		// Apply the schema up to (but not including) 004 — the pre-004 shape still
+		// has cost_entries.team_id, so we can populate with it.
+		await db.exec(loadMigration('001_initial_schema.sql'));
+		await db.exec(loadMigration('002_migration_smoke.sql'));
+		await db.exec(loadMigration('003_budgeting.sql'));
+
+		expect(await columnExists(db, 'cost_entries', 'team_id')).toBe(true);
+		expect(await columnExists(db, 'cost_entries', 'ai_provider_config_id')).toBe(false);
+
+		const team = await db.query<{ id: string }>(
+			`INSERT INTO teams (name, slug) VALUES ('Acme', 'acme') RETURNING id`,
+		);
+		const teamId = team.rows[0].id;
+		const member = await db.query<{ id: string }>(
+			`INSERT INTO members (team_id, member_type, display_name) VALUES ($1, 'agent', 'Bot') RETURNING id`,
+			[teamId],
+		);
+		const agentId = member.rows[0].id;
+		await db.query(`INSERT INTO member_agents (id, title, slug) VALUES ($1, 'Bot', 'bot')`, [
+			agentId,
+		]);
+		const project = await db.query<{ id: string }>(
+			`INSERT INTO projects (team_id, name, slug, task_prefix) VALUES ($1, 'Ops', 'ops', 'OPS') RETURNING id`,
+			[teamId],
+		);
+		projectId = project.rows[0].id;
+		const cost = await db.query<{ id: string }>(
+			`INSERT INTO cost_entries (team_id, member_id, project_id, amount_cents, description)
+			 VALUES ($1, $2, $3, 1234, 'a run') RETURNING id`,
+			[teamId, agentId, projectId],
+		);
+		costId = cost.rows[0].id;
+
+		// The actual upgrade step.
+		await db.exec(loadMigration('004_cost_provider_tracking.sql'));
+	});
+
+	it('drops the team dimension from cost_entries', async () => {
+		expect(await columnExists(db, 'cost_entries', 'team_id')).toBe(false);
+		const r = await db.query<{ indexname: string }>(
+			`SELECT indexname FROM pg_indexes WHERE indexname = 'idx_costs_team'`,
+		);
+		expect(r.rows.length).toBe(0);
+	});
+
+	it('adds adapter attribution to cost_entries and heartbeat_runs', async () => {
+		expect(await columnExists(db, 'cost_entries', 'ai_provider_config_id')).toBe(true);
+		expect(await columnExists(db, 'cost_entries', 'provider')).toBe(true);
+		expect(await columnExists(db, 'heartbeat_runs', 'ai_provider_config_id')).toBe(true);
+		expect(await columnExists(db, 'heartbeat_runs', 'provider')).toBe(true);
+		const idx = await db.query<{ indexname: string }>(
+			`SELECT indexname FROM pg_indexes WHERE indexname = 'idx_costs_provider_config'`,
+		);
+		expect(idx.rows.length).toBe(1);
+	});
+
+	it('preserves existing cost rows with NULL adapter attribution', async () => {
+		const cost = await db.query<{
+			amount_cents: number;
+			project_id: string;
+			ai_provider_config_id: string | null;
+			provider: string | null;
+		}>(
+			`SELECT amount_cents, project_id, ai_provider_config_id, provider
+			 FROM cost_entries WHERE id = $1`,
+			[costId],
+		);
+		expect(cost.rows[0]).toEqual({
+			amount_cents: 1234,
+			project_id: projectId,
+			ai_provider_config_id: null,
+			provider: null,
+		});
+	});
+
+	it('cleans up', async () => {
+		await safeClose(db);
+	});
+});

--- a/packages/web/src/components/budget/budget-charts.tsx
+++ b/packages/web/src/components/budget/budget-charts.tsx
@@ -61,8 +61,8 @@ export function BudgetCharts({
 
 	return (
 		<div className="rounded-radius-md border border-border bg-bg p-4">
-			<div className="mb-3 flex items-center justify-between gap-2">
-				<span className="text-[13px] font-medium text-text">{title ?? 'Spend per day'}</span>
+			<div className={`mb-3 flex items-center gap-2 ${title ? 'justify-between' : 'justify-end'}`}>
+				{title && <span className="text-[13px] font-medium text-text">{title}</span>}
 				<div
 					role="tablist"
 					aria-label="Chart type"

--- a/packages/web/src/components/budget/stacked-spend-chart.tsx
+++ b/packages/web/src/components/budget/stacked-spend-chart.tsx
@@ -1,0 +1,189 @@
+import { useMemo, useState } from 'react';
+import {
+	Bar,
+	BarChart,
+	CartesianGrid,
+	Legend,
+	Line,
+	LineChart,
+	ResponsiveContainer,
+	Tooltip,
+	XAxis,
+	YAxis,
+} from 'recharts';
+
+type ChartKind = 'bar' | 'line';
+
+/** A single (day, series) spend cell. `seriesKey` is the stable id; `seriesLabel` is shown. */
+export interface SpendCell {
+	day: string;
+	seriesKey: string;
+	seriesLabel: string;
+	total_cents: number;
+}
+
+// Ordered palette for stacked series; cycles if there are more series than colors.
+const SERIES_COLORS = [
+	'var(--color-accent-blue)',
+	'var(--color-accent-green)',
+	'var(--color-accent-amber)',
+	'var(--color-accent-purple)',
+	'var(--color-accent-red)',
+];
+
+function formatDay(day: string): string {
+	const d = new Date(`${day}T00:00:00Z`);
+	return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', timeZone: 'UTC' });
+}
+
+function dollars(cents: number): string {
+	return `$${(cents / 100).toFixed(2)}`;
+}
+
+interface PivotedRow {
+	day: string;
+	label: string;
+	[seriesKey: string]: string | number;
+}
+
+interface Series {
+	key: string;
+	label: string;
+	color: string;
+}
+
+/**
+ * Pivot flat (day, series) cells into one row per day with a numeric (dollars)
+ * field per series, plus the ordered series list for the legend / stacks.
+ * Series are ordered by total spend desc so the largest sits at the bottom.
+ */
+function pivot(cells: SpendCell[]): { rows: PivotedRow[]; series: Series[] } {
+	const totalByKey = new Map<string, { label: string; total: number }>();
+	for (const c of cells) {
+		const prev = totalByKey.get(c.seriesKey);
+		totalByKey.set(c.seriesKey, {
+			label: c.seriesLabel,
+			total: (prev?.total ?? 0) + c.total_cents,
+		});
+	}
+	const series: Series[] = [...totalByKey.entries()]
+		.sort((a, b) => b[1].total - a[1].total)
+		.map(([key, v], i) => ({
+			key,
+			label: v.label,
+			color: SERIES_COLORS[i % SERIES_COLORS.length],
+		}));
+
+	const byDay = new Map<string, PivotedRow>();
+	for (const c of cells) {
+		let row = byDay.get(c.day);
+		if (!row) {
+			row = { day: c.day, label: formatDay(c.day) };
+			for (const s of series) row[s.key] = 0;
+			byDay.set(c.day, row);
+		}
+		row[c.seriesKey] = Number(
+			((Number(row[c.seriesKey] ?? 0) as number) + c.total_cents / 100).toFixed(2),
+		);
+	}
+	const rows = [...byDay.values()].sort((a, b) => a.day.localeCompare(b.day));
+	return { rows, series };
+}
+
+/**
+ * Per-day stacked spend chart with a bar/line toggle. Each series (agent or AI
+ * adapter config) is a stacked segment. Responsive: full-width, stacks on mobile,
+ * legend wraps.
+ */
+export function StackedSpendChart({
+	title,
+	cells,
+	isLoading,
+}: {
+	title?: string;
+	cells: SpendCell[] | undefined;
+	isLoading: boolean;
+}) {
+	const [kind, setKind] = useState<ChartKind>('bar');
+	const { rows, series } = useMemo(() => pivot(cells ?? []), [cells]);
+
+	return (
+		<div className="rounded-radius-md border border-border bg-bg p-4">
+			<div className={`mb-3 flex items-center gap-2 ${title ? 'justify-between' : 'justify-end'}`}>
+				{title && <span className="text-[13px] font-medium text-text">{title}</span>}
+				<div
+					role="tablist"
+					aria-label="Chart type"
+					className="inline-flex rounded-md border border-border-subtle bg-bg-subtle p-0.5 text-xs"
+				>
+					{(['bar', 'line'] as const).map((k) => (
+						<button
+							key={k}
+							type="button"
+							role="tab"
+							aria-selected={kind === k}
+							onClick={() => setKind(k)}
+							className={`px-2.5 py-1 rounded capitalize ${
+								kind === k ? 'bg-bg text-text shadow-sm' : 'text-text-muted hover:text-text'
+							}`}
+						>
+							{k}
+						</button>
+					))}
+				</div>
+			</div>
+
+			{isLoading ? (
+				<div className="h-[200px] flex items-center justify-center text-[13px] text-text-subtle">
+					Loading…
+				</div>
+			) : rows.length === 0 ? (
+				<div className="h-[200px] flex items-center justify-center text-[13px] text-text-subtle">
+					No spend recorded.
+				</div>
+			) : (
+				<div className="h-[260px] w-full" data-testid="stacked-spend-chart">
+					<ResponsiveContainer width="100%" height="100%">
+						{kind === 'bar' ? (
+							<BarChart data={rows} margin={{ top: 8, right: 8, bottom: 0, left: -16 }}>
+								<CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
+								<XAxis dataKey="label" tick={{ fontSize: 11 }} stroke="var(--color-text-subtle)" />
+								<YAxis tick={{ fontSize: 11 }} stroke="var(--color-text-subtle)" />
+								<Tooltip
+									formatter={(value) => dollars(Math.round(Number(value) * 100))}
+									contentStyle={{ fontSize: 12 }}
+								/>
+								<Legend wrapperStyle={{ fontSize: 12 }} />
+								{series.map((s) => (
+									<Bar key={s.key} dataKey={s.key} name={s.label} stackId="spend" fill={s.color} />
+								))}
+							</BarChart>
+						) : (
+							<LineChart data={rows} margin={{ top: 8, right: 8, bottom: 0, left: -16 }}>
+								<CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
+								<XAxis dataKey="label" tick={{ fontSize: 11 }} stroke="var(--color-text-subtle)" />
+								<YAxis tick={{ fontSize: 11 }} stroke="var(--color-text-subtle)" />
+								<Tooltip
+									formatter={(value) => dollars(Math.round(Number(value) * 100))}
+									contentStyle={{ fontSize: 12 }}
+								/>
+								<Legend wrapperStyle={{ fontSize: 12 }} />
+								{series.map((s) => (
+									<Line
+										key={s.key}
+										type="monotone"
+										dataKey={s.key}
+										name={s.label}
+										stroke={s.color}
+										strokeWidth={2}
+										dot={false}
+									/>
+								))}
+							</LineChart>
+						)}
+					</ResponsiveContainer>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/packages/web/src/hooks/use-costs.ts
+++ b/packages/web/src/hooks/use-costs.ts
@@ -73,7 +73,7 @@ export interface DailyCostPoint {
 	total_cents: number;
 }
 
-/** Per-day spend series for the project (or a single agent), for the charts. */
+/** Per-day project spend total — powers the project "spend per day" chart. */
 export function useDailyCostSeries(
 	projectId: string,
 	params?: { agent_id?: string; from?: string; to?: string },
@@ -85,6 +85,50 @@ export function useDailyCostSeries(
 			api.get<{ summary: DailyCostPoint[]; total_cents: number }>(
 				`/api/projects/${projectId}/costs`,
 				query as Record<string, string>,
+			),
+		enabled: !!projectId,
+	});
+}
+
+/** One day's spend for a single series (agent or adapter) in a breakdown. */
+export interface AgentDailyCostPoint {
+	day: string;
+	agent_id: string;
+	agent_title: string;
+	total_cents: number;
+}
+
+export interface AdapterDailyCostPoint {
+	day: string;
+	ai_provider_config_id: string | null;
+	provider: string | null;
+	adapter_label: string | null;
+	total_cents: number;
+}
+
+/** Per-day spend split by agent — powers the stacked "by agent" chart. */
+export function useAgentDailyCostSeries(projectId: string) {
+	const query = { group_by: 'day', breakdown: 'agent' };
+	return useQuery({
+		queryKey: queryKeys.projects.costs(projectId, query),
+		queryFn: () =>
+			api.get<{ summary: AgentDailyCostPoint[]; total_cents: number }>(
+				`/api/projects/${projectId}/costs`,
+				query,
+			),
+		enabled: !!projectId,
+	});
+}
+
+/** Per-day spend split by AI adapter configuration — powers the stacked "by adapter" chart. */
+export function useAdapterDailyCostSeries(projectId: string) {
+	const query = { group_by: 'day', breakdown: 'adapter' };
+	return useQuery({
+		queryKey: queryKeys.projects.costs(projectId, query),
+		queryFn: () =>
+			api.get<{ summary: AdapterDailyCostPoint[]; total_cents: number }>(
+				`/api/projects/${projectId}/costs`,
+				query,
 			),
 		enabled: !!projectId,
 	});

--- a/packages/web/src/routes/projects/$projectId/budget.tsx
+++ b/packages/web/src/routes/projects/$projectId/budget.tsx
@@ -4,10 +4,15 @@ import { Loader2 } from 'lucide-react';
 import { useState } from 'react';
 import { BudgetCharts } from '../../../components/budget/budget-charts';
 import { BudgetWindowsEditor } from '../../../components/budget/budget-windows-editor';
+import { type SpendCell, StackedSpendChart } from '../../../components/budget/stacked-spend-chart';
 import { BudgetBar } from '../../../components/ui/budget-bar';
 import { Button } from '../../../components/ui/button';
 import {
+	type AdapterDailyCostPoint,
+	type AgentDailyCostPoint,
 	type EntityBudgetStatus,
+	useAdapterDailyCostSeries,
+	useAgentDailyCostSeries,
 	useBudgetStatus,
 	type WindowStatus,
 } from '../../../hooks/use-costs';
@@ -120,11 +125,32 @@ function ProjectBudgetForm({ projectId }: { projectId: string }) {
 	);
 }
 
+/** A NULL adapter config (manual entries, historical rows) groups under one label. */
+const UNATTRIBUTED_KEY = 'unattributed';
+
+function toAgentCells(points: AgentDailyCostPoint[] | undefined): SpendCell[] {
+	return (points ?? []).map((p) => ({
+		day: p.day,
+		seriesKey: p.agent_id,
+		seriesLabel: p.agent_title,
+		total_cents: p.total_cents,
+	}));
+}
+
+function toAdapterCells(points: AdapterDailyCostPoint[] | undefined): SpendCell[] {
+	return (points ?? []).map((p) => ({
+		day: p.day,
+		seriesKey: p.ai_provider_config_id ?? UNATTRIBUTED_KEY,
+		seriesLabel: p.adapter_label ?? p.provider ?? 'Unattributed',
+		total_cents: p.total_cents,
+	}));
+}
+
 function BudgetPage() {
 	const { projectId } = Route.useParams();
 	const { data: status } = useBudgetStatus(projectId);
-	// `null` scopes the chart to the whole project; an agent id scopes it to that agent.
-	const [chartAgentId, setChartAgentId] = useState<string | null>(null);
+	const { data: agentSeries, isLoading: agentLoading } = useAgentDailyCostSeries(projectId);
+	const { data: adapterSeries, isLoading: adapterLoading } = useAdapterDailyCostSeries(projectId);
 
 	return (
 		<div className="flex flex-col gap-8">
@@ -140,23 +166,21 @@ function BudgetPage() {
 			)}
 
 			<section>
-				<div className="mb-3 flex items-center justify-between gap-2">
-					<h2 className="text-sm font-medium text-text-muted">
-						Spend over time
-						{chartAgentId &&
-							status &&
-							(() => {
-								const a = status.agents.find((x) => x.agent_id === chartAgentId);
-								return a ? ` — ${a.agent_title}` : '';
-							})()}
-					</h2>
-					{chartAgentId && (
-						<Button variant="ghost" size="sm" onClick={() => setChartAgentId(null)}>
-							Show project
-						</Button>
-					)}
-				</div>
-				<BudgetCharts projectId={projectId} agentId={chartAgentId ?? undefined} />
+				<h2 className="mb-3 text-sm font-medium text-text-muted">Project spend per day</h2>
+				<BudgetCharts projectId={projectId} />
+			</section>
+
+			<section>
+				<h2 className="mb-3 text-sm font-medium text-text-muted">Spend per day by agent</h2>
+				<StackedSpendChart cells={toAgentCells(agentSeries?.summary)} isLoading={agentLoading} />
+			</section>
+
+			<section>
+				<h2 className="mb-3 text-sm font-medium text-text-muted">Spend per day by AI adapter</h2>
+				<StackedSpendChart
+					cells={toAdapterCells(adapterSeries?.summary)}
+					isLoading={adapterLoading}
+				/>
 			</section>
 
 			{status && (
@@ -167,14 +191,10 @@ function BudgetPage() {
 					) : (
 						<div className="flex flex-col gap-2">
 							{status.agents.map((agent) => (
-								<button
-									type="button"
+								<div
 									key={agent.agent_id}
-									onClick={() => setChartAgentId(agent.agent_id)}
 									data-testid={`agent-budget-row-${agent.agent_slug}`}
-									className={`flex flex-col gap-3 rounded-radius-md border bg-bg p-4 text-left transition-colors hover:border-border-hover ${
-										chartAgentId === agent.agent_id ? 'border-accent-blue' : 'border-border'
-									}`}
+									className="flex flex-col gap-3 rounded-radius-md border border-border bg-bg p-4"
 								>
 									<div className="flex items-center justify-between gap-2">
 										<span className="text-[13px] font-medium text-text">{agent.agent_title}</span>
@@ -185,7 +205,7 @@ function BudgetPage() {
 										)}
 									</div>
 									<WindowGrid status={agent} />
-								</button>
+								</div>
 							))}
 						</div>
 					)}

--- a/packages/web/test/budget-page.test.tsx
+++ b/packages/web/test/budget-page.test.tsx
@@ -46,3 +46,42 @@ test('Budgets page shows per-agent windows and flags an over-budget agent', asyn
 	const banner = await findByTestId('budget-banner');
 	expect(banner).toBeTruthy();
 });
+
+test('Budgets page renders per-day breakdown panels by agent and adapter', async () => {
+	let teamSlug = '';
+
+	const { findByText, findAllByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const { apiBase } = getTestContext();
+			const agent = ws.agents.find((a) => a.slug === 'engineer') ?? ws.agents[0];
+			teamSlug = ws.internalSlug;
+
+			const projects = (await (await apiBase('/api/projects', { headers: ws.headers })).json()) as {
+				data: Array<{ id: string; slug: string }>;
+			};
+			const projectId = projects.data.find((p) => p.slug === ws.internalSlug)?.id;
+			await apiBase(`/api/projects/${ws.internalSlug}/costs`, {
+				method: 'POST',
+				headers: ws.headers,
+				body: JSON.stringify({
+					member_id: agent.id,
+					amount_cents: 120,
+					project_id: projectId,
+					description: 'a run',
+				}),
+			});
+		},
+	});
+
+	await router.navigate({ to: '/projects/$projectId/budget', params: { projectId: teamSlug } });
+
+	// Both stacked panels are present...
+	await findByText('Spend per day by agent');
+	await findByText('Spend per day by AI adapter');
+	// ...and each renders its chart once the seeded cost flows through the breakdown
+	// endpoints (project chart uses its own test id, so exactly two stacked charts).
+	const charts = await findAllByTestId('stacked-spend-chart');
+	expect(charts.length).toBe(2);
+});

--- a/packages/web/test/budget-page.test.tsx
+++ b/packages/web/test/budget-page.test.tsx
@@ -1,3 +1,4 @@
+import { waitFor } from '@testing-library/react';
 import { expect, test } from 'vitest';
 import { getTestContext, renderApp } from './helpers/render';
 import { seedWorkspace } from './helpers/seed';
@@ -50,7 +51,7 @@ test('Budgets page shows per-agent windows and flags an over-budget agent', asyn
 test('Budgets page renders per-day breakdown panels by agent and adapter', async () => {
 	let teamSlug = '';
 
-	const { findByText, findAllByTestId, router } = await renderApp({
+	const { findByText, router } = await renderApp({
 		initialPath: '/',
 		seed: async () => {
 			const ws = await seedWorkspace();
@@ -82,6 +83,9 @@ test('Budgets page renders per-day breakdown panels by agent and adapter', async
 	await findByText('Spend per day by AI adapter');
 	// ...and each renders its chart once the seeded cost flows through the breakdown
 	// endpoints (project chart uses its own test id, so exactly two stacked charts).
-	const charts = await findAllByTestId('stacked-spend-chart');
-	expect(charts.length).toBe(2);
+	// The two breakdown queries resolve independently, so wait for both charts to mount
+	// rather than letting findAllByTestId return after just the first.
+	await waitFor(() => {
+		expect(document.querySelectorAll('[data-testid="stacked-spend-chart"]').length).toBe(2);
+	});
 });


### PR DESCRIPTION
## What

The project Budget page (`/projects/$projectId/budget`) previously showed a single, ambiguous "Spend over time" chart (which actually filtered only by `team_id`, not by project). This replaces it with **three per-day breakdown panels** and removes team-level cost tracking entirely.

### Budget page now shows
1. **Project spend per day** — daily total, scoped to *this project*.
2. **Spend per day by agent** — one stacked chart across all agents.
3. **Spend per day by AI adapter** — daily spend stacked by the `ai_provider_configs` row that produced it.

### AI adapter attribution (new)
Cost was never attributed to a provider config. Now each run's cost records the resolved adapter:
- The resolved provider + `ai_provider_config_id` are stamped on `heartbeat_runs` at run start (`markHeartbeatRunRunning`) and read back when recording the cost (`recordRunCostAndEnforce`).
- `cost_entries` gains `ai_provider_config_id` (FK, `ON DELETE SET NULL`) and a `provider` enum snapshot (survives config deletion). Historical rows are `NULL` → surfaced as **Unattributed**.

### Team cost tracking removed (per request)
Cost is project/agent/adapter-scoped now — never team-scoped. Budget *enforcement* was already member/project-based (`services/budget.ts`), so `team_id` on `cost_entries` was load-bearing only for cost *reads*:
- `cost_entries.team_id` dropped (migration 004).
- `GET /projects/:projectId/costs` and the `get_costs` MCP tool scope by `project_id`.
- The manual `POST /costs` path defaults a cost to its path project.

## How

- **Migration `004_cost_provider_tracking.sql`**: drops `cost_entries.team_id` + `idx_costs_team`; adds `ai_provider_config_id` + `provider` to `cost_entries` and `heartbeat_runs`; adds `idx_costs_provider_config`.
- **Route**: `group_by=day` + optional `breakdown=agent|adapter` returns the per-day series split for the stacked charts. Dropped the redundant `group_by=project` branch and `project_id` query param.
- **Frontend**: new reusable `StackedSpendChart` (pivots flat `(day, series)` cells into stacked recharts bars/lines with a legend); new `useAgentDailyCostSeries` / `useAdapterDailyCostSeries` hooks; budget page wired to the three panels. Mobile-first, panels stack single-column.

## Tests

- `migrate-cost-provider.test.ts` (new): drops `team_id`, adds the new columns, preserves existing cost rows with NULL attribution.
- `costs-extended.test.ts`: rewritten for project scoping + `breakdown=agent`/`breakdown=adapter`.
- `budget.test.ts`: `recordRunCost` carries config id + provider.
- `costs.test.ts`, `mcp-tools.test.ts`: project-scoped reads.
- `budget-page.test.tsx` (web): asserts both stacked panels render once seeded costs flow through the breakdown endpoints.

All affected suites pass. The only failing tests in the full run (`git.test.ts`, `ssh-agent-server.test.ts`) are pre-existing environmental failures — this container has no `ssh-keygen` — and are untouched by this change.

## Docs

`.dev/schema.md` and `.dev/api.md` updated to describe cost as project/agent/adapter-scoped with the new per-day breakdowns.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VysiUiGGNVMLvTGfgfezQv)_