### PR TITLE
fix(budget): correct "Invalid Date" on spend charts and redesign the budget page

### DIFF
--- a/packages/server/src/routes/costs.ts
+++ b/packages/server/src/routes/costs.ts
@@ -67,9 +67,14 @@ costsRoutes.get('/projects/:projectId/costs', async (c) => {
 		return ok(c, { summary: result.rows, total_cents: totalCents });
 	}
 
+	// The per-day buckets cast to `::date::text` (not bare `::date`) on purpose: PGlite
+	// deserializes a Postgres `date` into a JS Date, which Hono's c.json() then renders
+	// as a full ISO timestamp ("2024-01-15T00:00:00.000Z"). The chart parses `day` as a
+	// date-only string, so the timestamp form breaks it ("Invalid Date"). `::text` keeps
+	// it a plain "YYYY-MM-DD". Keep the cast on all three group_by=day queries below.
 	if (groupBy === 'day' && breakdown === 'agent') {
 		const result = await db.query<{ total_cents: number }>(
-			`SELECT date_trunc('day', ce.created_at)::date AS day,
+			`SELECT date_trunc('day', ce.created_at)::date::text AS day,
               ce.member_id AS agent_id,
               COALESCE(ma.title, m.display_name) AS agent_title,
               sum(ce.amount_cents)::int AS total_cents
@@ -87,7 +92,7 @@ costsRoutes.get('/projects/:projectId/costs', async (c) => {
 
 	if (groupBy === 'day' && breakdown === 'adapter') {
 		const result = await db.query<{ total_cents: number }>(
-			`SELECT date_trunc('day', ce.created_at)::date AS day,
+			`SELECT date_trunc('day', ce.created_at)::date::text AS day,
               ce.ai_provider_config_id,
               ce.provider,
               apc.label AS adapter_label,
@@ -105,7 +110,7 @@ costsRoutes.get('/projects/:projectId/costs', async (c) => {
 
 	if (groupBy === 'day') {
 		const result = await db.query<{ total_cents: number }>(
-			`SELECT date_trunc('day', ce.created_at)::date AS day,
+			`SELECT date_trunc('day', ce.created_at)::date::text AS day,
               sum(ce.amount_cents)::int AS total_cents
        FROM cost_entries ce
        WHERE ${where}

--- a/packages/server/test/costs-extended.test.ts
+++ b/packages/server/test/costs-extended.test.ts
@@ -199,6 +199,12 @@ describe('costs – group_by=day', () => {
 		// Days are ordered ascending
 		const days = body.data.summary.map((r: any) => r.day);
 		expect(days).toEqual([...days].sort());
+		// Regression: `day` must be a date-only "YYYY-MM-DD" string, never a full ISO
+		// timestamp. A Postgres `date` deserializes to a JS Date that c.json() renders as
+		// "2024-01-15T00:00:00.000Z", which the chart can't parse (new Date(`${day}T00:00:00Z`)
+		// => Invalid Date). The route casts `::date::text` to keep it date-only.
+		for (const d of days) expect(d).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+		expect(days).toEqual(['2024-01-15', '2024-01-20', '2024-02-10', '2024-03-01']);
 		// Total across all days
 		expect(body.data.total_cents).toBe(275); // 50+75+120+30
 	});
@@ -227,6 +233,8 @@ describe('costs – group_by=day&breakdown=agent', () => {
 		// 4 (day, agent) cells; each row carries the agent's title.
 		expect(rows.length).toBe(4);
 		for (const r of rows) expect(typeof r.agent_title).toBe('string');
+		// `day` stays a date-only string in the breakdown too (chart parses it as such).
+		for (const r of rows) expect(r.day).toMatch(/^\d{4}-\d{2}-\d{2}$/);
 
 		const byAgent = (id: string) =>
 			rows.filter((r) => r.agent_id === id).reduce((s, r) => s + r.total_cents, 0);
@@ -245,6 +253,8 @@ describe('costs – group_by=day&breakdown=adapter', () => {
 		expect(res.status).toBe(200);
 		const body = await res.json();
 		const rows: any[] = body.data.summary;
+		// `day` stays a date-only string in the breakdown too (chart parses it as such).
+		for (const r of rows) expect(r.day).toMatch(/^\d{4}-\d{2}-\d{2}$/);
 
 		const byConfig = (id: string | null) =>
 			rows.filter((r) => r.ai_provider_config_id === id).reduce((s, r) => s + r.total_cents, 0);

--- a/packages/web/src/components/budget/budget-charts.tsx
+++ b/packages/web/src/components/budget/budget-charts.tsx
@@ -11,18 +11,9 @@ import {
 	YAxis,
 } from 'recharts';
 import { type DailyCostPoint, useDailyCostSeries } from '../../hooks/use-costs';
+import { dollars, formatDay } from './chart-format';
 
 type ChartKind = 'bar' | 'line';
-
-function formatDay(day: string): string {
-	// `day` is a date-only string (YYYY-MM-DD) from date_trunc; render month/day.
-	const d = new Date(`${day}T00:00:00Z`);
-	return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', timeZone: 'UTC' });
-}
-
-function dollars(cents: number): string {
-	return `$${(cents / 100).toFixed(2)}`;
-}
 
 interface ChartDatum {
 	day: string;

--- a/packages/web/src/components/budget/chart-format.ts
+++ b/packages/web/src/components/budget/chart-format.ts
@@ -1,0 +1,25 @@
+/**
+ * Formatting shared by the budget charts (project total + stacked breakdowns).
+ * Kept in one place so the x-axis label and tooltip render identically and the
+ * "Invalid Date" guard lives in a single, unit-tested function.
+ */
+
+/**
+ * Render a per-day bucket as a short "Mon DD" label.
+ *
+ * `day` is meant to be a date-only string (YYYY-MM-DD) from the costs API. We're
+ * defensive on two fronts so a label is never the literal string "Invalid Date":
+ *  - slice to the first 10 chars, so a full ISO timestamp ("2024-01-15T00:00:00.000Z",
+ *    the shape a Postgres `date` takes once JSON-serialized) still parses; and
+ *  - fall back to the raw input if the result isn't a real date.
+ */
+export function formatDay(day: string): string {
+	const datePart = (day ?? '').slice(0, 10);
+	const d = new Date(`${datePart}T00:00:00Z`);
+	if (Number.isNaN(d.getTime())) return day ?? '';
+	return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', timeZone: 'UTC' });
+}
+
+export function dollars(cents: number): string {
+	return `$${(cents / 100).toFixed(2)}`;
+}

--- a/packages/web/src/components/budget/stacked-spend-chart.tsx
+++ b/packages/web/src/components/budget/stacked-spend-chart.tsx
@@ -11,6 +11,7 @@ import {
 	XAxis,
 	YAxis,
 } from 'recharts';
+import { dollars, formatDay } from './chart-format';
 
 type ChartKind = 'bar' | 'line';
 
@@ -30,15 +31,6 @@ const SERIES_COLORS = [
 	'var(--color-accent-purple)',
 	'var(--color-accent-red)',
 ];
-
-function formatDay(day: string): string {
-	const d = new Date(`${day}T00:00:00Z`);
-	return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', timeZone: 'UTC' });
-}
-
-function dollars(cents: number): string {
-	return `$${(cents / 100).toFixed(2)}`;
-}
 
 interface PivotedRow {
 	day: string;

--- a/packages/web/src/routes/projects/$projectId/budget.tsx
+++ b/packages/web/src/routes/projects/$projectId/budget.tsx
@@ -1,10 +1,11 @@
 import { type BudgetWindowsCents, centsToDollars, HQ_PROJECT_SLUG } from '@hezo/shared';
 import { createFileRoute, redirect } from '@tanstack/react-router';
-import { Loader2 } from 'lucide-react';
-import { useState } from 'react';
+import { BarChart3, Gauge, Loader2, type LucideIcon, Pencil, Users, Wallet } from 'lucide-react';
+import { type ReactNode, useState } from 'react';
 import { BudgetCharts } from '../../../components/budget/budget-charts';
 import { BudgetWindowsEditor } from '../../../components/budget/budget-windows-editor';
 import { type SpendCell, StackedSpendChart } from '../../../components/budget/stacked-spend-chart';
+import { Badge } from '../../../components/ui/badge';
 import { BudgetBar } from '../../../components/ui/budget-bar';
 import { Button } from '../../../components/ui/button';
 import {
@@ -20,6 +21,78 @@ import { useProject, useUpdateProject } from '../../../hooks/use-projects';
 
 function dollars(cents: number): string {
 	return `$${centsToDollars(cents)}`;
+}
+
+/** Section heading with a leading icon and an optional right-aligned action. */
+function SectionHeader({
+	icon: Icon,
+	title,
+	description,
+	action,
+}: {
+	icon: LucideIcon;
+	title: string;
+	description?: string;
+	action?: ReactNode;
+}) {
+	return (
+		<div className="mb-3 flex items-start justify-between gap-3">
+			<div className="flex items-start gap-2">
+				<Icon className="mt-0.5 h-4 w-4 shrink-0 text-text-subtle" aria-hidden />
+				<div>
+					<h2 className="text-sm font-medium text-text">{title}</h2>
+					{description && (
+						<p className="mt-1 max-w-prose text-xs leading-relaxed text-text-subtle">
+							{description}
+						</p>
+					)}
+				</div>
+			</div>
+			{action && <div className="shrink-0">{action}</div>}
+		</div>
+	);
+}
+
+/** A prominent per-window KPI: big spend figure, limit, and a fill bar. */
+function WindowStatCard({ label, status }: { label: string; status: WindowStatus }) {
+	const unlimited = status.limitCents === 0;
+	const pct = unlimited
+		? 0
+		: Math.min(Math.round((status.spentCents / status.limitCents) * 100), 100);
+	return (
+		<div
+			className={`flex flex-col gap-3 rounded-radius-md border bg-bg p-4 ${
+				status.overBudget ? 'border-accent-red/40 bg-accent-red/5' : 'border-border'
+			}`}
+		>
+			<div className="flex items-center justify-between gap-2">
+				<span className="text-xs font-medium uppercase tracking-wider text-text-subtle">
+					{label}
+				</span>
+				{status.overBudget && <Badge color="red">Over budget</Badge>}
+			</div>
+			<div className="flex items-baseline gap-1.5">
+				<span
+					className={`font-mono text-2xl font-semibold tabular-nums ${
+						status.overBudget ? 'text-accent-red' : 'text-text'
+					}`}
+				>
+					{dollars(status.spentCents)}
+				</span>
+				<span className="text-[13px] text-text-subtle">
+					/ {unlimited ? '∞' : dollars(status.limitCents)}
+				</span>
+			</div>
+			{unlimited ? (
+				<span className="text-xs text-text-subtle">No limit set</span>
+			) : (
+				<div className="flex flex-col gap-1.5">
+					<BudgetBar used={status.spentCents} total={status.limitCents} />
+					<span className="text-xs text-text-subtle">{pct}% of limit used</span>
+				</div>
+			)}
+		</div>
+	);
 }
 
 /** A single window's spend vs. limit with a fill bar. 0 limit renders "unlimited". */
@@ -81,46 +154,55 @@ function ProjectBudgetForm({ projectId }: { projectId: string }) {
 		setEditing(false);
 	}
 
+	const limits: { label: string; cents: number }[] = [
+		{ label: 'Daily', cents: project.daily_budget_cents },
+		{ label: 'Weekly', cents: project.weekly_budget_cents },
+		{ label: 'Monthly', cents: project.monthly_budget_cents },
+	];
+
 	return (
 		<section>
-			<h2 className="mb-3 text-sm font-medium text-text-muted">Project budget limits</h2>
-			<p className="-mt-2 mb-3 text-xs text-text-subtle">
-				Spend across all agents in this project. A run is blocked when the project exceeds any
-				window. Disable a window to leave it unlimited.
-			</p>
-			{editing ? (
-				<form onSubmit={handleSave} className="flex flex-col gap-3 sm:max-w-xl">
-					<BudgetWindowsEditor value={budget} onChange={setBudget} />
-					<div className="flex gap-2">
-						<Button type="submit" size="sm" disabled={updateProject.isPending}>
-							{updateProject.isPending ? <Loader2 className="h-3 w-3 animate-spin" /> : 'Save'}
+			<SectionHeader
+				icon={Wallet}
+				title="Project budget limits"
+				description="Spend across all agents in this project. A run is blocked when the project exceeds any window. Disable a window to leave it unlimited."
+				action={
+					!editing && (
+						<Button variant="ghost" size="sm" onClick={startEditing}>
+							<Pencil className="h-3.5 w-3.5" aria-hidden />
+							Edit
 						</Button>
-						<Button type="button" variant="ghost" size="sm" onClick={() => setEditing(false)}>
-							Cancel
-						</Button>
+					)
+				}
+			/>
+			<div className="rounded-radius-md border border-border bg-bg p-4">
+				{editing ? (
+					<form onSubmit={handleSave} className="flex flex-col gap-4">
+						<BudgetWindowsEditor value={budget} onChange={setBudget} />
+						<div className="flex gap-2">
+							<Button type="submit" size="sm" disabled={updateProject.isPending}>
+								{updateProject.isPending ? <Loader2 className="h-3 w-3 animate-spin" /> : 'Save'}
+							</Button>
+							<Button type="button" variant="ghost" size="sm" onClick={() => setEditing(false)}>
+								Cancel
+							</Button>
+						</div>
+					</form>
+				) : (
+					<div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+						{limits.map((l) => (
+							<div key={l.label} className="flex flex-col gap-1">
+								<span className="text-xs font-medium uppercase tracking-wider text-text-subtle">
+									{l.label}
+								</span>
+								<span className="font-mono text-[15px] text-text">
+									{l.cents === 0 ? 'Unlimited' : dollars(l.cents)}
+								</span>
+							</div>
+						))}
 					</div>
-				</form>
-			) : (
-				<div className="space-y-1 text-[13px]">
-					<div>
-						<span className="text-text-muted">Daily:</span>{' '}
-						{project.daily_budget_cents === 0 ? 'Unlimited' : dollars(project.daily_budget_cents)}
-					</div>
-					<div>
-						<span className="text-text-muted">Weekly:</span>{' '}
-						{project.weekly_budget_cents === 0 ? 'Unlimited' : dollars(project.weekly_budget_cents)}
-					</div>
-					<div>
-						<span className="text-text-muted">Monthly:</span>{' '}
-						{project.monthly_budget_cents === 0
-							? 'Unlimited'
-							: dollars(project.monthly_budget_cents)}
-					</div>
-					<Button variant="ghost" size="sm" onClick={startEditing} className="mt-2">
-						Edit
-					</Button>
-				</div>
-			)}
+				)}
+			</div>
 		</section>
 	);
 }
@@ -154,55 +236,84 @@ function BudgetPage() {
 
 	return (
 		<div className="flex flex-col gap-8">
-			<ProjectBudgetForm projectId={projectId} />
+			<div>
+				<h1 className="text-base font-semibold text-text">Budget</h1>
+				<p className="mt-1 text-xs text-text-subtle">
+					Track spend and set limits for this project and its agents.
+				</p>
+			</div>
 
 			{status && (
 				<section>
-					<h2 className="mb-3 text-sm font-medium text-text-muted">Project spend</h2>
-					<div className="rounded-radius-md border border-border bg-bg p-4">
-						<WindowGrid status={status.project} />
+					<SectionHeader
+						icon={Gauge}
+						title="Project spend"
+						description="Current spend across all agents in each rolling window."
+					/>
+					<div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+						<WindowStatCard label="Daily" status={status.project.daily} />
+						<WindowStatCard label="Weekly" status={status.project.weekly} />
+						<WindowStatCard label="Monthly" status={status.project.monthly} />
 					</div>
 				</section>
 			)}
 
-			<section>
-				<h2 className="mb-3 text-sm font-medium text-text-muted">Project spend per day</h2>
-				<BudgetCharts projectId={projectId} />
-			</section>
+			<ProjectBudgetForm projectId={projectId} />
 
 			<section>
-				<h2 className="mb-3 text-sm font-medium text-text-muted">Spend per day by agent</h2>
-				<StackedSpendChart cells={toAgentCells(agentSeries?.summary)} isLoading={agentLoading} />
-			</section>
-
-			<section>
-				<h2 className="mb-3 text-sm font-medium text-text-muted">Spend per day by AI adapter</h2>
-				<StackedSpendChart
-					cells={toAdapterCells(adapterSeries?.summary)}
-					isLoading={adapterLoading}
+				<SectionHeader
+					icon={BarChart3}
+					title="Spend over time"
+					description="Daily project spend, and the same totals split by agent and by AI adapter."
 				/>
+				<div className="flex flex-col gap-4">
+					<BudgetCharts projectId={projectId} title="Project spend per day" />
+					<div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+						<StackedSpendChart
+							title="Spend per day by agent"
+							cells={toAgentCells(agentSeries?.summary)}
+							isLoading={agentLoading}
+						/>
+						<StackedSpendChart
+							title="Spend per day by AI adapter"
+							cells={toAdapterCells(adapterSeries?.summary)}
+							isLoading={adapterLoading}
+						/>
+					</div>
+				</div>
 			</section>
 
 			{status && (
 				<section>
-					<h2 className="mb-3 text-sm font-medium text-text-muted">Agent budgets</h2>
+					<SectionHeader
+						icon={Users}
+						title="Agent budgets"
+						description="Each agent's spend against its own per-window limits."
+					/>
 					{status.agents.length === 0 ? (
-						<p className="text-[13px] text-text-subtle">No agents yet.</p>
+						<div className="rounded-radius-md border border-border bg-bg p-4">
+							<p className="text-[13px] text-text-subtle">No agents yet.</p>
+						</div>
 					) : (
-						<div className="flex flex-col gap-2">
+						<div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
 							{status.agents.map((agent) => (
 								<div
 									key={agent.agent_id}
 									data-testid={`agent-budget-row-${agent.agent_slug}`}
-									className="flex flex-col gap-3 rounded-radius-md border border-border bg-bg p-4"
+									className={`flex flex-col gap-3 rounded-radius-md border bg-bg p-4 ${
+										agent.agent_over_budget ? 'border-accent-red/40' : 'border-border'
+									}`}
 								>
 									<div className="flex items-center justify-between gap-2">
-										<span className="text-[13px] font-medium text-text">{agent.agent_title}</span>
-										{agent.agent_over_budget && (
-											<span className="rounded-full bg-accent-red/10 px-2 py-0.5 text-[11px] font-medium text-accent-red">
-												Over budget
+										<div className="flex min-w-0 items-center gap-2">
+											<span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-bg-subtle text-[11px] font-medium text-text-muted">
+												{agent.agent_title.charAt(0).toUpperCase()}
 											</span>
-										)}
+											<span className="truncate text-[13px] font-medium text-text">
+												{agent.agent_title}
+											</span>
+										</div>
+										{agent.agent_over_budget && <Badge color="red">Over budget</Badge>}
 									</div>
 									<WindowGrid status={agent} />
 								</div>

--- a/packages/web/test/chart-format.test.ts
+++ b/packages/web/test/chart-format.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'vitest';
+import { dollars, formatDay } from '../src/components/budget/chart-format';
+
+describe('formatDay', () => {
+	test('formats a date-only YYYY-MM-DD string as a short label', () => {
+		expect(formatDay('2024-01-15')).toBe('Jan 15');
+	});
+
+	test('formats in UTC regardless of local time zone (no off-by-one)', () => {
+		// Midnight-UTC parsing + UTC formatting keeps the calendar day stable.
+		expect(formatDay('2024-12-31')).toBe('Dec 31');
+		expect(formatDay('2024-03-01')).toBe('Mar 1');
+	});
+
+	test('tolerates a full ISO timestamp by slicing to the date part', () => {
+		// Regression: a Postgres `date` once serialized as "...T00:00:00.000Z". The old
+		// formatter built `${day}T00:00:00Z` from that and produced "Invalid Date".
+		expect(formatDay('2024-01-15T00:00:00.000Z')).toBe('Jan 15');
+	});
+
+	test('never returns the literal "Invalid Date" for empty or junk input', () => {
+		expect(formatDay('')).toBe('');
+		expect(formatDay('not-a-date')).toBe('not-a-date');
+	});
+});
+
+describe('dollars', () => {
+	test('renders cents as a 2-decimal dollar string', () => {
+		expect(dollars(898)).toBe('$8.98');
+		expect(dollars(0)).toBe('$0.00');
+		expect(dollars(100000)).toBe('$1000.00');
+	});
+});


### PR DESCRIPTION
## Why

The budget page's per-day spend charts rendered **"Invalid Date"** on the x-axis (see the reported screenshot), and the page layout was fairly bare.

## Root cause of "Invalid Date"

The costs API selected the day bucket as `date_trunc('day', ce.created_at)::date`. PGlite deserializes a Postgres `date` into a **JS `Date` object**, which Hono's `c.json()` then serializes via `.toISOString()` to a full timestamp:

```
"2024-01-15T00:00:00.000Z"
```

The chart builds its label with ``new Date(`${day}T00:00:00Z`)``, so the value became ``"2024-01-15T00:00:00.000ZT00:00:00Z"`` → `Invalid Date`. Verified empirically against PGlite:

| SQL | serialized `day` | `new Date(\`${day}T00:00:00Z\`)` |
|---|---|---|
| `::date` | `"2024-01-15T00:00:00.000Z"` | **Invalid Date** |
| `::date::text` | `"2024-01-15"` | ✅ valid |

The existing test only checked `days === [...days].sort()`, which passes for both shapes — so the bug slipped through.

## Changes

**Fix (root cause)**
- Cast the bucket to `::date::text` in all three `group_by=day` queries so the API returns a plain `"YYYY-MM-DD"` string, with a comment explaining why the cast must stay.

**Frontend hardening + dedup**
- Extracted the duplicated `formatDay`/`dollars` helpers (copied across both chart components) into a shared `chart-format` module.
- Made `formatDay` defensive: it slices to the date part (so even a full ISO timestamp parses) and falls back to the raw input, so a label is **never** literally "Invalid Date" again.

**Beautify the budget page**
- Page header with a short description.
- Prominent per-window **KPI cards** for project spend — amount, limit, fill bar, % of limit used, and an over-budget state (red tint + badge).
- Icon-led section headers (`Wallet` / `Gauge` / `BarChart3` / `Users`).
- Editable limits in a clean card with the **Edit** action in the header.
- Chart titles moved into the chart headers (next to the Bar/Line toggle); the **by-agent** and **by-adapter** breakdowns sit 2-up on large screens.
- Per-agent budget cards with an avatar initial and an over-budget badge, 2-up on large screens.
- Mobile-first and responsive throughout (single column → `sm:`/`lg:` grids).

## Tests
- **Server regression** (`costs-extended.test.ts`): asserts `day` is a date-only `^\d{4}-\d{2}-\d{2}$` string for the plain, by-agent, and by-adapter day groupings (the precise guard the old sort-only check lacked).
- **Web unit** (`chart-format.test.ts`): `formatDay` handles date-only strings, full ISO timestamps, UTC stability, and empty/junk input without ever returning "Invalid Date".
- Existing `budget-page.test.tsx` (renders the redesigned page) and `budget-windows-editor.test.tsx` still pass.
- `typecheck`, `biome check`, and the production `build` all pass (run by the pre-commit hook).

https://claude.ai/code/session_01V74J2mEgb7TzNxdPQmRmPE

---
_Generated by [Claude Code](https://claude.ai/code/session_01V74J2mEgb7TzNxdPQmRmPE)_