### PR TITLE
feat(budget): merge limit editing into the spend display and add budget editing to project settings

### DIFF
--- a/packages/web/src/components/budget/project-budget-panel.tsx
+++ b/packages/web/src/components/budget/project-budget-panel.tsx
@@ -1,0 +1,194 @@
+import { type BudgetWindowsCents, centsToDollars } from '@hezo/shared';
+import { Gauge, Loader2, Pencil } from 'lucide-react';
+import { useState } from 'react';
+import { useBudgetStatus, type WindowStatus } from '../../hooks/use-costs';
+import { useProject, useUpdateProject } from '../../hooks/use-projects';
+import { Badge } from '../ui/badge';
+import { BudgetBar } from '../ui/budget-bar';
+import { Button } from '../ui/button';
+import { SectionHeader } from '../ui/section-header';
+import { BudgetWindowsEditor } from './budget-windows-editor';
+
+function dollars(cents: number): string {
+	return `$${centsToDollars(cents)}`;
+}
+
+/** A prominent per-window KPI: big spend figure, limit, and a fill bar. */
+function WindowStatCard({ label, status }: { label: string; status: WindowStatus }) {
+	const unlimited = status.limitCents === 0;
+	const pct = unlimited
+		? 0
+		: Math.min(Math.round((status.spentCents / status.limitCents) * 100), 100);
+	return (
+		<div
+			className={`flex flex-col gap-3 rounded-radius-md border bg-bg p-4 ${
+				status.overBudget ? 'border-accent-red/40 bg-accent-red/5' : 'border-border'
+			}`}
+		>
+			<div className="flex items-center justify-between gap-2">
+				<span className="text-xs font-medium uppercase tracking-wider text-text-subtle">
+					{label}
+				</span>
+				{status.overBudget && <Badge color="red">Over budget</Badge>}
+			</div>
+			<div className="flex items-baseline gap-1.5">
+				<span
+					className={`font-mono text-2xl font-semibold tabular-nums ${
+						status.overBudget ? 'text-accent-red' : 'text-text'
+					}`}
+				>
+					{dollars(status.spentCents)}
+				</span>
+				<span className="text-[13px] text-text-subtle">
+					/ {unlimited ? '∞' : dollars(status.limitCents)}
+				</span>
+			</div>
+			{unlimited ? (
+				<span className="text-xs text-text-subtle">No limit set</span>
+			) : (
+				<div className="flex flex-col gap-1.5">
+					<BudgetBar used={status.spentCents} total={status.limitCents} />
+					<span className="text-xs text-text-subtle">{pct}% of limit used</span>
+				</div>
+			)}
+		</div>
+	);
+}
+
+/** A compact "label: value" limit cell for the settings (no-spend) variant. */
+function LimitCell({ label, cents }: { label: string; cents: number }) {
+	return (
+		<div className="flex flex-col gap-1">
+			<span className="text-xs font-medium uppercase tracking-wider text-text-subtle">{label}</span>
+			<span className="font-mono text-[15px] text-text">
+				{cents === 0 ? 'Unlimited' : dollars(cents)}
+			</span>
+		</div>
+	);
+}
+
+/**
+ * The project's budget windows in one place: the spend-vs-limit progress display
+ * and the limit editor are the same section, toggled by an Edit button.
+ *
+ * - `variant="spend"` (Budget page): live per-window KPI cards (spend, limit, fill
+ *   bar, % used, over-budget state). Editing swaps the cards for the window editor.
+ * - `variant="limits"` (Project settings): a compact read-only view of the limits,
+ *   with the same Edit → editor flow. No spend is fetched/shown.
+ *
+ * Both share one editor + save path so the cross-window rules live in a single place.
+ */
+export function ProjectBudgetPanel({
+	projectId,
+	variant = 'spend',
+}: {
+	projectId: string;
+	variant?: 'spend' | 'limits';
+}) {
+	const { data: project } = useProject(projectId);
+	const { data: status } = useBudgetStatus(projectId, { enabled: variant === 'spend' });
+	const updateProject = useUpdateProject(projectId);
+	const [editing, setEditing] = useState(false);
+	const [budget, setBudget] = useState<BudgetWindowsCents>({
+		daily_budget_cents: 0,
+		weekly_budget_cents: 0,
+		monthly_budget_cents: 0,
+	});
+
+	if (!project) return null;
+
+	function startEditing() {
+		if (!project) return;
+		setBudget({
+			daily_budget_cents: project.daily_budget_cents,
+			weekly_budget_cents: project.weekly_budget_cents,
+			monthly_budget_cents: project.monthly_budget_cents,
+		});
+		setEditing(true);
+	}
+
+	async function save() {
+		await updateProject.mutateAsync(budget);
+		setEditing(false);
+	}
+
+	const description =
+		variant === 'spend'
+			? 'Spend across all agents in this project. A run is blocked when any window is exceeded — edit to change the limits.'
+			: 'Spend across all agents in this project. A run is blocked when any window is exceeded. Disable a window to leave it unlimited.';
+
+	return (
+		<section>
+			<SectionHeader
+				icon={Gauge}
+				title="Project budget"
+				description={description}
+				action={
+					!editing && (
+						<Button
+							variant="ghost"
+							size="sm"
+							onClick={startEditing}
+							data-testid="edit-project-budget"
+						>
+							<Pencil className="h-3.5 w-3.5" aria-hidden />
+							Edit limits
+						</Button>
+					)
+				}
+			/>
+
+			{editing ? (
+				// Enter submits via the form; the buttons drive save/cancel explicitly so
+				// the flow doesn't hinge on implicit submit-button behaviour.
+				<form
+					onSubmit={(e) => {
+						e.preventDefault();
+						void save();
+					}}
+					className="flex flex-col gap-4"
+				>
+					<BudgetWindowsEditor value={budget} onChange={setBudget} />
+					<div className="flex gap-2">
+						<Button
+							type="button"
+							size="sm"
+							disabled={updateProject.isPending}
+							onClick={() => void save()}
+						>
+							{updateProject.isPending ? <Loader2 className="h-3 w-3 animate-spin" /> : 'Save'}
+						</Button>
+						<Button type="button" variant="ghost" size="sm" onClick={() => setEditing(false)}>
+							Cancel
+						</Button>
+					</div>
+				</form>
+			) : variant === 'spend' ? (
+				status ? (
+					<div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+						<WindowStatCard label="Daily" status={status.project.daily} />
+						<WindowStatCard label="Weekly" status={status.project.weekly} />
+						<WindowStatCard label="Monthly" status={status.project.monthly} />
+					</div>
+				) : (
+					<div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+						{['Daily', 'Weekly', 'Monthly'].map((label) => (
+							<div
+								key={label}
+								className="h-[104px] animate-pulse rounded-radius-md border border-border bg-bg-subtle"
+							/>
+						))}
+					</div>
+				)
+			) : (
+				<div className="rounded-radius-md border border-border bg-bg p-4">
+					<div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+						<LimitCell label="Daily" cents={project.daily_budget_cents} />
+						<LimitCell label="Weekly" cents={project.weekly_budget_cents} />
+						<LimitCell label="Monthly" cents={project.monthly_budget_cents} />
+					</div>
+				</div>
+			)}
+		</section>
+	);
+}

--- a/packages/web/src/components/ui/section-header.tsx
+++ b/packages/web/src/components/ui/section-header.tsx
@@ -1,0 +1,36 @@
+import type { LucideIcon } from 'lucide-react';
+import type { ReactNode } from 'react';
+
+/**
+ * Section heading with a leading icon, optional description, and an optional
+ * right-aligned action (e.g. an Edit button). Shared across the budget surfaces
+ * so headers line up the same way wherever budget UI is embedded.
+ */
+export function SectionHeader({
+	icon: Icon,
+	title,
+	description,
+	action,
+}: {
+	icon: LucideIcon;
+	title: string;
+	description?: string;
+	action?: ReactNode;
+}) {
+	return (
+		<div className="mb-3 flex items-start justify-between gap-3">
+			<div className="flex items-start gap-2">
+				<Icon className="mt-0.5 h-4 w-4 shrink-0 text-text-subtle" aria-hidden />
+				<div>
+					<h2 className="text-sm font-medium text-text">{title}</h2>
+					{description && (
+						<p className="mt-1 max-w-prose text-xs leading-relaxed text-text-subtle">
+							{description}
+						</p>
+					)}
+				</div>
+			</div>
+			{action && <div className="shrink-0">{action}</div>}
+		</div>
+	);
+}

--- a/packages/web/src/hooks/use-costs.ts
+++ b/packages/web/src/hooks/use-costs.ts
@@ -60,11 +60,11 @@ export interface BudgetStatus {
 }
 
 /** Project + per-agent budget status; powers the Budgets page and warning banner. */
-export function useBudgetStatus(projectId: string) {
+export function useBudgetStatus(projectId: string, options?: { enabled?: boolean }) {
 	return useQuery({
 		queryKey: queryKeys.projects.budgetStatus(projectId),
 		queryFn: () => api.get<BudgetStatus>(`/api/projects/${projectId}/budget-status`),
-		enabled: !!projectId,
+		enabled: !!projectId && (options?.enabled ?? true),
 	});
 }
 

--- a/packages/web/src/hooks/use-projects.ts
+++ b/packages/web/src/hooks/use-projects.ts
@@ -160,7 +160,13 @@ export function useUpdateProject(projectId: string) {
 	return useSimpleOptimisticUpdate<Project, UpdateProjectVars>(
 		`/api/projects/${projectId}`,
 		queryKeys.projects.detail(projectId),
-		{ invalidateOnSettled: [queryKeys.projects.all()], errorMessage: 'Failed to update project' },
+		{
+			// budgetStatus carries the per-window limits the Budget page KPI cards read,
+			// so a budget-limit edit must refetch it (the optimistic update only touches
+			// the project detail cache).
+			invalidateOnSettled: [queryKeys.projects.all(), queryKeys.projects.budgetStatus(projectId)],
+			errorMessage: 'Failed to update project',
+		},
 	);
 }
 

--- a/packages/web/src/routes/projects/$projectId/budget.tsx
+++ b/packages/web/src/routes/projects/$projectId/budget.tsx
@@ -1,13 +1,12 @@
-import { type BudgetWindowsCents, centsToDollars, HQ_PROJECT_SLUG } from '@hezo/shared';
+import { centsToDollars, HQ_PROJECT_SLUG } from '@hezo/shared';
 import { createFileRoute, redirect } from '@tanstack/react-router';
-import { BarChart3, Gauge, Loader2, type LucideIcon, Pencil, Users, Wallet } from 'lucide-react';
-import { type ReactNode, useState } from 'react';
+import { BarChart3, Users } from 'lucide-react';
 import { BudgetCharts } from '../../../components/budget/budget-charts';
-import { BudgetWindowsEditor } from '../../../components/budget/budget-windows-editor';
+import { ProjectBudgetPanel } from '../../../components/budget/project-budget-panel';
 import { type SpendCell, StackedSpendChart } from '../../../components/budget/stacked-spend-chart';
 import { Badge } from '../../../components/ui/badge';
 import { BudgetBar } from '../../../components/ui/budget-bar';
-import { Button } from '../../../components/ui/button';
+import { SectionHeader } from '../../../components/ui/section-header';
 import {
 	type AdapterDailyCostPoint,
 	type AgentDailyCostPoint,
@@ -17,82 +16,9 @@ import {
 	useBudgetStatus,
 	type WindowStatus,
 } from '../../../hooks/use-costs';
-import { useProject, useUpdateProject } from '../../../hooks/use-projects';
 
 function dollars(cents: number): string {
 	return `$${centsToDollars(cents)}`;
-}
-
-/** Section heading with a leading icon and an optional right-aligned action. */
-function SectionHeader({
-	icon: Icon,
-	title,
-	description,
-	action,
-}: {
-	icon: LucideIcon;
-	title: string;
-	description?: string;
-	action?: ReactNode;
-}) {
-	return (
-		<div className="mb-3 flex items-start justify-between gap-3">
-			<div className="flex items-start gap-2">
-				<Icon className="mt-0.5 h-4 w-4 shrink-0 text-text-subtle" aria-hidden />
-				<div>
-					<h2 className="text-sm font-medium text-text">{title}</h2>
-					{description && (
-						<p className="mt-1 max-w-prose text-xs leading-relaxed text-text-subtle">
-							{description}
-						</p>
-					)}
-				</div>
-			</div>
-			{action && <div className="shrink-0">{action}</div>}
-		</div>
-	);
-}
-
-/** A prominent per-window KPI: big spend figure, limit, and a fill bar. */
-function WindowStatCard({ label, status }: { label: string; status: WindowStatus }) {
-	const unlimited = status.limitCents === 0;
-	const pct = unlimited
-		? 0
-		: Math.min(Math.round((status.spentCents / status.limitCents) * 100), 100);
-	return (
-		<div
-			className={`flex flex-col gap-3 rounded-radius-md border bg-bg p-4 ${
-				status.overBudget ? 'border-accent-red/40 bg-accent-red/5' : 'border-border'
-			}`}
-		>
-			<div className="flex items-center justify-between gap-2">
-				<span className="text-xs font-medium uppercase tracking-wider text-text-subtle">
-					{label}
-				</span>
-				{status.overBudget && <Badge color="red">Over budget</Badge>}
-			</div>
-			<div className="flex items-baseline gap-1.5">
-				<span
-					className={`font-mono text-2xl font-semibold tabular-nums ${
-						status.overBudget ? 'text-accent-red' : 'text-text'
-					}`}
-				>
-					{dollars(status.spentCents)}
-				</span>
-				<span className="text-[13px] text-text-subtle">
-					/ {unlimited ? '∞' : dollars(status.limitCents)}
-				</span>
-			</div>
-			{unlimited ? (
-				<span className="text-xs text-text-subtle">No limit set</span>
-			) : (
-				<div className="flex flex-col gap-1.5">
-					<BudgetBar used={status.spentCents} total={status.limitCents} />
-					<span className="text-xs text-text-subtle">{pct}% of limit used</span>
-				</div>
-			)}
-		</div>
-	);
 }
 
 /** A single window's spend vs. limit with a fill bar. 0 limit renders "unlimited". */
@@ -123,87 +49,6 @@ function WindowGrid({ status }: { status: EntityBudgetStatus }) {
 			<WindowRow label="Weekly" status={status.weekly} />
 			<WindowRow label="Monthly" status={status.monthly} />
 		</div>
-	);
-}
-
-function ProjectBudgetForm({ projectId }: { projectId: string }) {
-	const { data: project } = useProject(projectId);
-	const updateProject = useUpdateProject(projectId);
-	const [editing, setEditing] = useState(false);
-	const [budget, setBudget] = useState<BudgetWindowsCents>({
-		daily_budget_cents: 0,
-		weekly_budget_cents: 0,
-		monthly_budget_cents: 0,
-	});
-
-	if (!project) return null;
-
-	function startEditing() {
-		if (!project) return;
-		setBudget({
-			daily_budget_cents: project.daily_budget_cents,
-			weekly_budget_cents: project.weekly_budget_cents,
-			monthly_budget_cents: project.monthly_budget_cents,
-		});
-		setEditing(true);
-	}
-
-	async function handleSave(e: React.FormEvent) {
-		e.preventDefault();
-		await updateProject.mutateAsync(budget);
-		setEditing(false);
-	}
-
-	const limits: { label: string; cents: number }[] = [
-		{ label: 'Daily', cents: project.daily_budget_cents },
-		{ label: 'Weekly', cents: project.weekly_budget_cents },
-		{ label: 'Monthly', cents: project.monthly_budget_cents },
-	];
-
-	return (
-		<section>
-			<SectionHeader
-				icon={Wallet}
-				title="Project budget limits"
-				description="Spend across all agents in this project. A run is blocked when the project exceeds any window. Disable a window to leave it unlimited."
-				action={
-					!editing && (
-						<Button variant="ghost" size="sm" onClick={startEditing}>
-							<Pencil className="h-3.5 w-3.5" aria-hidden />
-							Edit
-						</Button>
-					)
-				}
-			/>
-			<div className="rounded-radius-md border border-border bg-bg p-4">
-				{editing ? (
-					<form onSubmit={handleSave} className="flex flex-col gap-4">
-						<BudgetWindowsEditor value={budget} onChange={setBudget} />
-						<div className="flex gap-2">
-							<Button type="submit" size="sm" disabled={updateProject.isPending}>
-								{updateProject.isPending ? <Loader2 className="h-3 w-3 animate-spin" /> : 'Save'}
-							</Button>
-							<Button type="button" variant="ghost" size="sm" onClick={() => setEditing(false)}>
-								Cancel
-							</Button>
-						</div>
-					</form>
-				) : (
-					<div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-						{limits.map((l) => (
-							<div key={l.label} className="flex flex-col gap-1">
-								<span className="text-xs font-medium uppercase tracking-wider text-text-subtle">
-									{l.label}
-								</span>
-								<span className="font-mono text-[15px] text-text">
-									{l.cents === 0 ? 'Unlimited' : dollars(l.cents)}
-								</span>
-							</div>
-						))}
-					</div>
-				)}
-			</div>
-		</section>
 	);
 }
 
@@ -243,22 +88,9 @@ function BudgetPage() {
 				</p>
 			</div>
 
-			{status && (
-				<section>
-					<SectionHeader
-						icon={Gauge}
-						title="Project spend"
-						description="Current spend across all agents in each rolling window."
-					/>
-					<div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-						<WindowStatCard label="Daily" status={status.project.daily} />
-						<WindowStatCard label="Weekly" status={status.project.weekly} />
-						<WindowStatCard label="Monthly" status={status.project.monthly} />
-					</div>
-				</section>
-			)}
-
-			<ProjectBudgetForm projectId={projectId} />
+			{/* Spend progress + limit editing are one section: the KPI cards show spend vs.
+			    limit; Edit swaps them for the window editor. */}
+			<ProjectBudgetPanel projectId={projectId} variant="spend" />
 
 			<section>
 				<SectionHeader

--- a/packages/web/src/routes/projects/$projectId/settings/index.tsx
+++ b/packages/web/src/routes/projects/$projectId/settings/index.tsx
@@ -2,6 +2,7 @@ import { HQ_PROJECT_SLUG } from '@hezo/shared';
 import { createFileRoute, redirect } from '@tanstack/react-router';
 import { ExternalLink, Loader2 } from 'lucide-react';
 import { useState } from 'react';
+import { ProjectBudgetPanel } from '../../../../components/budget/project-budget-panel';
 import { GitHubSection } from '../../../../components/github-section';
 import { Button } from '../../../../components/ui/button';
 import { Input } from '../../../../components/ui/input';
@@ -119,6 +120,8 @@ function ProjectSettingsPage() {
 					</div>
 				)}
 			</section>
+
+			<ProjectBudgetPanel projectId={projectId} variant="limits" />
 
 			{project.container_status === 'running' && project.dev_ports?.length > 0 && (
 				<section>

--- a/packages/web/test/budget-page.test.tsx
+++ b/packages/web/test/budget-page.test.tsx
@@ -1,7 +1,7 @@
 import { waitFor } from '@testing-library/react';
 import { expect, test } from 'vitest';
 import { getTestContext, renderApp } from './helpers/render';
-import { seedWorkspace } from './helpers/seed';
+import { seedProject, seedWorkspace } from './helpers/seed';
 
 test('Budgets page shows per-agent windows and flags an over-budget agent', async () => {
 	let teamSlug = '';
@@ -87,5 +87,41 @@ test('Budgets page renders per-day breakdown panels by agent and adapter', async
 	// rather than letting findAllByTestId return after just the first.
 	await waitFor(() => {
 		expect(document.querySelectorAll('[data-testid="stacked-spend-chart"]').length).toBe(2);
+	});
+});
+
+test('Budget page: editing limits inline updates the spend progress cards', async () => {
+	let teamSlug = '';
+	let projectId = '';
+
+	const { findByText, findByTestId, findByRole, user, ctx, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Budget Inline' });
+			teamSlug = ws.internalSlug;
+			projectId = project.id;
+		},
+	});
+
+	await router.navigate({ to: '/projects/$projectId/budget', params: { projectId: teamSlug } });
+
+	// The progress display and the editor are one section: edit limits in place.
+	await user.click(await findByTestId('edit-project-budget'));
+	await user.click(await findByTestId('budget-daily-toggle'));
+	const daily = (await findByTestId('budget-daily')) as HTMLInputElement;
+	await user.clear(daily);
+	await user.type(daily, '20');
+	await user.click(await findByRole('button', { name: 'Save' }));
+
+	// The KPI card (driven by budget-status) reflects the new $20 daily limit — i.e.
+	// editing the limit refreshes the same progress display it lives in.
+	await findByText('0% of limit used', undefined, { timeout: 15_000 });
+	await waitFor(async () => {
+		const row = await ctx.db.query<{ daily_budget_cents: number }>(
+			'SELECT daily_budget_cents FROM projects WHERE id = $1',
+			[projectId],
+		);
+		expect(row.rows[0]?.daily_budget_cents).toBe(2000);
 	});
 });

--- a/packages/web/test/project-settings.test.tsx
+++ b/packages/web/test/project-settings.test.tsx
@@ -203,6 +203,54 @@ test('edits the per-project memory limit and persists it', async () => {
 	);
 });
 
+test('edits the project budget limits from settings and persists them', async () => {
+	const projectName = uniqueName('Budget Settings Project');
+	let ws!: SeededWorkspace;
+	let projectSlug = '';
+	let projectId = '';
+
+	const { findByTestId, findByRole, getByRole, ctx, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			ws = await seedWorkspace();
+			const project = await seedProject(ws, {
+				name: projectName,
+				description: 'Budget settings.',
+			});
+			projectSlug = project.slug;
+			projectId = project.id;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/settings',
+		params: { projectId: projectSlug },
+	});
+
+	// The budget editor lives in its own "Edit limits" affordance, distinct from the
+	// General section's "Edit".
+	await user.click(await findByTestId('edit-project-budget'));
+	await user.click(await findByTestId('budget-daily-toggle'));
+	const daily = (await findByTestId('budget-daily')) as HTMLInputElement;
+	await user.clear(daily);
+	await user.type(daily, '15');
+	await user.click(getByRole('button', { name: 'Save' }));
+
+	await waitFor(
+		async () => {
+			const row = await ctx.db.query<{ daily_budget_cents: number }>(
+				'SELECT daily_budget_cents FROM projects WHERE id = $1',
+				[projectId],
+			);
+			expect(row.rows[0]?.daily_budget_cents).toBe(1500);
+		},
+		{ timeout: 8_000 },
+	);
+
+	// Returns to the read-only view (the "Edit limits" button reappears).
+	await findByRole('button', { name: 'Edit limits' });
+});
+
 test('State A — no GitHub connection: shows Connect GitHub CTA', async () => {
 	const projectName = uniqueName('Settings Project');
 	let ws!: SeededWorkspace;


### PR DESCRIPTION
## What

Two related budget-UI changes:

1. **Merge the limit-editing UI into the spend "progress display."** The Budget page had two separate sections — the per-window KPI cards (spend vs. limit) *and* a standalone "Project budget limits" editor. They're now **one section**: the KPI cards are the display, and an **"Edit limits"** toggle swaps them for the window editor in place. Saving refetches budget-status so the same cards immediately reflect the new limits.

2. **Add budget editing to Project settings.** The settings page (`/projects/:id/settings`) now has a **Project budget** section using the *same* component (`variant="limits"`: a compact limit view with the same Edit → editor flow, no spend fetched).

One component, one save path, so the cross-window rules (weekly ≥ 7×daily, etc.) stay in a single place.

## How

- **New `ProjectBudgetPanel`** (`components/budget/project-budget-panel.tsx`) with `variant: 'spend' | 'limits'`. Extracted the shared icon `SectionHeader` to `components/ui/section-header.tsx` so the panel and the Budget page reuse it (avoids a circular import).
- **`useUpdateProject` now invalidates `budgetStatus` on settle** — the KPI cards read limits from the budget-status query, which the optimistic project-detail update doesn't touch, so without this the cards wouldn't reflect a freshly-saved limit.
- **`useBudgetStatus` takes an `enabled` option** so the settings variant skips the spend fetch it doesn't render.
- Save/Cancel are explicit `onClick` (`type="button"`) with the form's `onSubmit` kept for Enter — saving no longer depends on implicit submit-button behaviour.

## Tests

- **Budget page:** edit a limit inline → the progress card updates (`% of limit used`) and the value persists to the DB.
- **Settings:** edit the project budget from settings → persists; returns to the read-only view. (The budget "Edit limits" button is deliberately named distinctly from the General section's "Edit".)
- Full web component suite green (**326 tests**); typecheck, Biome, and the production build all pass (pre-commit hook).

https://claude.ai/code/session_01V74J2mEgb7TzNxdPQmRmPE

---
_Generated by [Claude Code](https://claude.ai/code/session_01V74J2mEgb7TzNxdPQmRmPE)_