### PR TITLE
refactor: remove the project task list planning-phase banner

### DIFF
--- a/.dev/api.md
+++ b/.dev/api.md
@@ -854,9 +854,8 @@ Response:
 ```
 
 - `planning_complete` — `true` once the planning epic is `closed`.
-- `project_status` — headline status for the current scope: `completed`, `working`, `error`, or `idle`. Precedence is Completed → Working → Error → Idle. `null` during onboarding (open team-coherence review) or before planning is complete when no planning-phase banner is shown.
-- `phase_banner` — `onboarding` while the team-coherence review ticket is open; `planning` while the planning epic is `in_progress` or `review`; otherwise `null`. When a banner is shown, the segmented progress bar is hidden.
-- `project_status` during the planning banner reflects planning-scope tasks only; after `planning_complete`, it reflects execution-scope tasks.
+- `project_status` — headline status across execution-scope tasks: `completed`, `working`, `error`, or `idle`. Precedence is Completed → Working → Error → Idle. `null` until `planning_complete` (during onboarding and the planning phase the per-task run dot is the working indicator).
+- `phase_banner` — `onboarding` while the team-coherence review ticket is open; otherwise `null`. When the onboarding banner is shown, the segmented progress bar is hidden.
 
 #### `POST /projects/:projectId/tasks`
 Create an task.

--- a/packages/server/test/project-status.test.ts
+++ b/packages/server/test/project-status.test.ts
@@ -29,7 +29,7 @@ describe('deriveProjectStatus', () => {
 
 	it('returns null when the execution scope is empty', () => {
 		expect(
-			deriveProjectStatus([row({ id: planningId, labels: ['planning'] })], planningId, 'execution'),
+			deriveProjectStatus([row({ id: planningId, labels: ['planning'] })], planningId),
 		).toBeNull();
 	});
 
@@ -39,12 +39,12 @@ describe('deriveProjectStatus', () => {
 			row({ id: 'a', status: TaskStatus.Done }),
 			row({ id: 'b', status: TaskStatus.Closed }),
 		];
-		expect(deriveProjectStatus(tasks, planningId, 'execution')).toBe(ProjectStatus.Completed);
+		expect(deriveProjectStatus(tasks, planningId)).toBe(ProjectStatus.Completed);
 	});
 
 	it('returns working when a scoped task has a queued run', () => {
 		const tasks = [row({ id: 'a', status: TaskStatus.Backlog, has_active_run: true })];
-		expect(deriveProjectStatus(tasks, null, 'execution')).toBe(ProjectStatus.Working);
+		expect(deriveProjectStatus(tasks, null)).toBe(ProjectStatus.Working);
 	});
 
 	it('prefers working over error', () => {
@@ -56,7 +56,7 @@ describe('deriveProjectStatus', () => {
 			}),
 			row({ id: 'b', status: TaskStatus.InProgress, has_active_run: true }),
 		];
-		expect(deriveProjectStatus(tasks, null, 'execution')).toBe(ProjectStatus.Working);
+		expect(deriveProjectStatus(tasks, null)).toBe(ProjectStatus.Working);
 	});
 
 	it('returns error only when every in_progress task has a failed last run', () => {
@@ -64,31 +64,23 @@ describe('deriveProjectStatus', () => {
 			row({ id: 'a', status: TaskStatus.InProgress, last_run_status: 'failed' }),
 			row({ id: 'b', status: TaskStatus.InProgress, last_run_status: 'timed_out' }),
 		];
-		expect(deriveProjectStatus(tasks, null, 'execution')).toBe(ProjectStatus.Error);
+		expect(deriveProjectStatus(tasks, null)).toBe(ProjectStatus.Error);
 
 		const mixed = [
 			row({ id: 'a', status: TaskStatus.InProgress, last_run_status: 'failed' }),
 			row({ id: 'b', status: TaskStatus.InProgress, last_run_status: 'succeeded' }),
 		];
-		expect(deriveProjectStatus(mixed, null, 'execution')).toBe(ProjectStatus.Idle);
+		expect(deriveProjectStatus(mixed, null)).toBe(ProjectStatus.Idle);
 	});
 
 	it('does not return error when there are no in_progress tasks', () => {
 		const tasks = [row({ id: 'a', status: TaskStatus.Backlog, last_run_status: 'failed' })];
-		expect(deriveProjectStatus(tasks, null, 'execution')).toBe(ProjectStatus.Idle);
+		expect(deriveProjectStatus(tasks, null)).toBe(ProjectStatus.Idle);
 	});
 
 	it('returns idle as the fallback', () => {
 		const tasks = [row({ id: 'a', status: TaskStatus.Backlog })];
-		expect(deriveProjectStatus(tasks, null, 'execution')).toBe(ProjectStatus.Idle);
-	});
-
-	it('derives status from the planning epic and its sub-tasks', () => {
-		const tasks = [
-			row({ id: planningId, labels: ['planning'], status: TaskStatus.InProgress }),
-			row({ id: 'prd', parent_task_id: planningId, status: TaskStatus.Backlog }),
-		];
-		expect(deriveProjectStatus(tasks, planningId, 'planning')).toBe(ProjectStatus.Idle);
+		expect(deriveProjectStatus(tasks, null)).toBe(ProjectStatus.Idle);
 	});
 });
 

--- a/packages/server/test/task-progress-summary.test.ts
+++ b/packages/server/test/task-progress-summary.test.ts
@@ -182,7 +182,7 @@ describe('GET /projects/:projectId/tasks/progress-summary phase_banner', () => {
 		expect(summary.phase_banner).toBe(ProjectTaskListPhaseBanner.Onboarding);
 	});
 
-	it('returns planning when coherence is done and the planning ticket is in progress', async () => {
+	it('shows no banner when coherence is done and the planning ticket is in progress', async () => {
 		await insertCoherenceTask(TaskStatus.Done);
 		await db.query('UPDATE tasks SET status = $1::task_status WHERE id = $2', [
 			TaskStatus.InProgress,
@@ -190,15 +190,11 @@ describe('GET /projects/:projectId/tasks/progress-summary phase_banner', () => {
 		]);
 
 		const summary = await getSummary();
-		expect(summary.phase_banner).toBe(ProjectTaskListPhaseBanner.Planning);
-		expect(summary.project_status).toBe('idle');
-		const nameRow = await db.query<{ name: string }>('SELECT name FROM projects WHERE id = $1', [
-			projectId,
-		]);
-		expect(summary.project_name).toBe(nameRow.rows[0].name);
+		expect(summary.phase_banner).toBeNull();
+		expect(summary.project_status).toBeNull();
 	});
 
-	it('prefers onboarding over planning when both tickets are active', async () => {
+	it('shows onboarding while coherence is open even if planning is in progress', async () => {
 		await insertCoherenceTask(TaskStatus.InProgress);
 		await db.query('UPDATE tasks SET status = $1::task_status WHERE id = $2', [
 			TaskStatus.InProgress,

--- a/packages/shared/src/task-progress.ts
+++ b/packages/shared/src/task-progress.ts
@@ -34,18 +34,6 @@ export function isExecutionScopeTask(
 	return !hasPlanningLabel(task.labels);
 }
 
-/** Planning-scope tasks are the planning epic and its direct sub-tasks. */
-export function isPlanningScopeTask(
-	task: TaskProgressScopeInput,
-	planningTaskId: string | null,
-): boolean {
-	if (!planningTaskId) return false;
-	if (task.id === planningTaskId) return true;
-	return task.parent_task_id === planningTaskId;
-}
-
-export type ProjectStatusScope = 'execution' | 'planning';
-
 /** Planning phase ends when the Captain's planning epic is Coach-closed. */
 export function isPlanningPhaseComplete(planningTaskStatus: string | null): boolean {
 	return planningTaskStatus === TaskStatus.Closed;
@@ -74,7 +62,6 @@ export const TEAM_COHERENCE_REVIEW_LABEL = 'team-coherence-review';
 
 export const ProjectTaskListPhaseBanner = {
 	Onboarding: 'onboarding',
-	Planning: 'planning',
 } as const;
 export type ProjectTaskListPhaseBanner =
 	(typeof ProjectTaskListPhaseBanner)[keyof typeof ProjectTaskListPhaseBanner];
@@ -83,20 +70,12 @@ function isOpenTaskStatus(status: string): boolean {
 	return !(TERMINAL_TASK_STATUSES as readonly string[]).includes(status);
 }
 
-function isActivePlanningStatus(status: string): boolean {
-	return status === TaskStatus.InProgress || status === TaskStatus.Review;
-}
-
 /** Banner shown above the project task list before execution tracking begins. */
 export function deriveProjectTaskListPhaseBanner(input: {
 	coherenceReviewStatus: string | null;
-	planningTaskStatus: string | null;
 }): ProjectTaskListPhaseBanner | null {
 	if (input.coherenceReviewStatus !== null && isOpenTaskStatus(input.coherenceReviewStatus)) {
 		return ProjectTaskListPhaseBanner.Onboarding;
-	}
-	if (input.planningTaskStatus !== null && isActivePlanningStatus(input.planningTaskStatus)) {
-		return ProjectTaskListPhaseBanner.Planning;
 	}
 	return null;
 }
@@ -110,7 +89,7 @@ export interface TaskProgressSummary {
 	not_done: number;
 	percent_complete: number;
 	by_status: Record<string, number>;
-	/** Null before planning is complete (execution) or during the planning-phase banner. */
+	/** Null until planning is complete; then the execution-scope headline status. */
 	project_status: ProjectStatus | null;
 	project_name: string;
 	phase_banner: ProjectTaskListPhaseBanner | null;
@@ -133,19 +112,14 @@ export function isLastRunFailed(hasActiveRun: boolean, lastRunStatus: string | n
 }
 
 /**
- * Derive the headline project status for a task scope.
+ * Derive the headline project status across execution-scope tasks.
  * Precedence: Completed → Working → Error → Idle.
  */
 export function deriveProjectStatus(
 	tasks: TaskProgressStatusRow[],
 	planningTaskId: string | null,
-	scope: ProjectStatusScope,
 ): ProjectStatus | null {
-	const scoped = tasks.filter((t) =>
-		scope === 'execution'
-			? isExecutionScopeTask(t, planningTaskId)
-			: isPlanningScopeTask(t, planningTaskId),
-	);
+	const scoped = tasks.filter((t) => isExecutionScopeTask(t, planningTaskId));
 	if (scoped.length === 0) return null;
 
 	const terminal = TERMINAL_TASK_STATUSES as readonly string[];
@@ -199,14 +173,11 @@ export function buildTaskProgressSummary(input: {
 
 	const phase_banner = deriveProjectTaskListPhaseBanner({
 		coherenceReviewStatus: input.coherenceReviewStatus,
-		planningTaskStatus: input.planningTaskStatus,
 	});
 
 	const project_status = planningComplete
-		? deriveProjectStatus(input.tasks, input.planningTaskId, 'execution')
-		: phase_banner === ProjectTaskListPhaseBanner.Planning
-			? deriveProjectStatus(input.tasks, input.planningTaskId, 'planning')
-			: null;
+		? deriveProjectStatus(input.tasks, input.planningTaskId)
+		: null;
 
 	return {
 		planning_complete: planningComplete,

--- a/packages/web/src/components/project-task-list-header.tsx
+++ b/packages/web/src/components/project-task-list-header.tsx
@@ -1,36 +1,18 @@
-import {
-	ProjectTaskListPhaseBanner as PhaseBannerKind,
-	type TaskProgressSummary,
-} from '@hezo/shared';
+import type { TaskProgressSummary } from '@hezo/shared';
 import { useTaskProgressSummary } from '../hooks/use-task-progress-summary';
 import { ProjectStatusBadge } from './project-status-badge';
 
 const bannerClass =
 	'mb-4 rounded-md border border-border bg-bg-elevated px-3 py-2.5 sm:px-4 text-sm text-text';
 
-function PhaseBanner({ summary }: { summary: TaskProgressSummary }) {
-	if (summary.phase_banner === PhaseBannerKind.Onboarding) {
-		return (
-			<div
-				data-testid="project-task-list-phase-banner-onboarding"
-				className={bannerClass}
-				role="status"
-			>
-				Please wait whilst the CEO onboards your new team members
-			</div>
-		);
-	}
-
+function OnboardingBanner() {
 	return (
 		<div
-			data-testid="project-task-list-phase-banner-planning"
+			data-testid="project-task-list-phase-banner-onboarding"
 			className={bannerClass}
 			role="status"
 		>
-			<div className="flex flex-wrap items-center gap-2 min-w-0">
-				{summary.project_status && <ProjectStatusBadge status={summary.project_status} />}
-				<span className="font-medium">{summary.project_name} - Planning phase</span>
-			</div>
+			Please wait whilst the CEO onboards your new team members
 		</div>
 	);
 }
@@ -115,7 +97,7 @@ export function ProjectTaskListHeader({ projectId }: { projectId: string }) {
 
 	return (
 		<>
-			{summary.phase_banner && <PhaseBanner summary={summary} />}
+			{summary.phase_banner && <OnboardingBanner />}
 			{showProgressBar && <ProgressBar summary={summary} />}
 		</>
 	);

--- a/packages/web/test/project-task-list-phase-banner.test.tsx
+++ b/packages/web/test/project-task-list-phase-banner.test.tsx
@@ -83,10 +83,10 @@ test('tasks page shows onboarding banner while coherence review is open', async 
 	expect(queryByTestId('project-task-list-phase-banner-planning')).toBeNull();
 });
 
-test('tasks page shows planning banner when the draft execution plan is in progress', async () => {
+test('tasks page shows no phase banner during planning', async () => {
 	let projectSlug = '';
 
-	const { findByTestId, findByText, queryByTestId, router } = await renderApp({
+	const { findByText, queryByTestId, router } = await renderApp({
 		initialPath: '/',
 		seed: async () => {
 			const ws = await seedWorkspace();
@@ -103,8 +103,10 @@ test('tasks page shows planning banner when the draft execution plan is in progr
 		params: { projectId: projectSlug },
 	});
 
-	await findByTestId('project-task-list-phase-banner-planning', undefined, { timeout: 10_000 });
-	await findByTestId('project-status-idle');
-	await findByText('Planning Phase Project - Planning phase');
+	// The planning epic renders in the list, but no phase banner is shown — the
+	// per-task run dot is the only "working" indicator during the planning phase.
+	await findByText(/Draft execution plan for/, undefined, { timeout: 10_000 });
+	expect(queryByTestId('project-task-list-phase-banner-planning')).toBeNull();
 	expect(queryByTestId('project-task-list-phase-banner-onboarding')).toBeNull();
+	expect(queryByTestId('task-progress-bar')).toBeNull();
 });

--- a/test/browser/task-list-progress.mobile.spec.ts
+++ b/test/browser/task-list-progress.mobile.spec.ts
@@ -2,40 +2,6 @@ import { expect, test } from './fixtures';
 import { createProjectAndClearPlanning, uniqueName, waitForPageLoad } from './helpers';
 
 test.describe('Project task list — progress header (mobile)', () => {
-	test('shows the planning phase banner while the draft execution plan is active', async ({
-		page,
-		sharedWorkspace,
-	}) => {
-		const { token } = sharedWorkspace;
-		const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
-
-		const projRes = await page.request.post('/api/projects', {
-			headers,
-			data: { name: uniqueName('Planning Phase'), description: 'E2E planning banner.' },
-		});
-		expect(projRes.ok()).toBeTruthy();
-		const project = (
-			(await projRes.json()) as {
-				data: { slug: string; name: string; planning_task_id: string };
-			}
-		).data;
-
-		const patchRes = await page.request.patch(
-			`/api/projects/${project.slug}/tasks/${project.planning_task_id}`,
-			{ headers, data: { status: 'in_progress' } },
-		);
-		expect(patchRes.ok()).toBeTruthy();
-
-		await page.goto(`/projects/${project.slug}/tasks`);
-		await waitForPageLoad(page);
-
-		const banner = page.getByTestId('project-task-list-phase-banner-planning');
-		await expect(banner).toBeVisible({ timeout: 20_000 });
-		await expect(banner).toContainText(`${project.name} - Planning phase`);
-		await expect(page.getByTestId('project-status-idle')).toBeVisible();
-		await expect(page.getByTestId('task-progress-bar')).toBeHidden();
-	});
-
 	test('shows the segmented progress bar after planning is closed', async ({
 		page,
 		sharedWorkspace,
@@ -102,6 +68,5 @@ test.describe('Project task list — progress header (mobile)', () => {
 				.getByTestId('task-progress-segment-in-progress')
 				.or(page.getByTestId('task-progress-segment-not-done')),
 		).toBeVisible({ timeout: 20_000 });
-		await expect(page.getByTestId('project-task-list-phase-banner-planning')).toBeHidden();
 	});
 });


### PR DESCRIPTION
## What & why

The project task list showed a **"Working — _<project>_ · Planning phase"** banner at the top during the planning phase. As flagged, this duplicates the per-task **run dot** (`TaskRunDot`) that already pulses beside the task an agent is actively working on — so the banner's "Working" status indicator was redundant. This removes that banner.

The separate **onboarding** banner ("Please wait whilst the CEO onboards your new team members") is kept — it's an instruction, not a redundant status — as is the post-planning segmented **progress bar**, which pairs status with completion %.

## Changes

- **`packages/shared/src/task-progress.ts`** — remove the `Planning` value from `ProjectTaskListPhaseBanner`, drop the planning-scope `project_status` derivation, and delete the now-unused `isPlanningScopeTask`, `ProjectStatusScope` and `isActivePlanningStatus` helpers. `deriveProjectStatus` is now execution-scope only; `project_status` is `null` until `planning_complete`.
- **`packages/web/src/components/project-task-list-header.tsx`** — `ProjectTaskListHeader` now renders only the onboarding banner and the progress bar (no `PhaseBanner`/planning branch).
- **Tests** — server (`task-progress-summary`, `project-status`) and web component (`project-task-list-phase-banner`) updated; a new component test guards that **no phase banner** renders during planning. The mobile Playwright planning-banner test is removed (the "no banner" case doesn't need a browser; it's covered by the component test).
- **`.dev/api.md`** — `phase_banner` / `project_status` docs updated.

## Verification

- `bun run typecheck` — passes (all 3 packages)
- Affected server tests (14) and web component tests (8) — pass, including the new "no phase banner during planning" guard
- `biome check` on changed files — clean (one pre-existing unused-param warning on a test helper, unrelated to this change)

https://claude.ai/code/session_01WQYpeSek7wEuAmbdzB9ysA

---
_Generated by [Claude Code](https://claude.ai/code/session_01WQYpeSek7wEuAmbdzB9ysA)_