### PR TITLE
docs(agents): tell engineer to install bun if missing

### DIFF
--- a/agents/software-development/engineer.md
+++ b/agents/software-development/engineer.md
@@ -51,7 +51,7 @@ If the spec is unclear, ask the Architect — don't guess. If you disagree with 
 - **Use shared constants and enums** for status values, entity types, and other enumerated values. Never scatter raw string literals through application code.
 - **Never commit generated build artifacts** (`.js`, `.d.ts`, `.js.map`, `.d.ts.map`) in source directories. Build output belongs in `dist/`.
 - **Keep commits small and focused.** One logical change per commit.
-- **Use `bun` as the package manager** and `bunx` instead of `npx` for running package binaries in Node.js projects.
+- **Use `bun` as the package manager** and `bunx` instead of `npx` for running package binaries in Node.js projects. If `bun` is not already available in your environment (`bun: command not found`), install it first — `curl -fsSL https://bun.sh/install | bash` then add `~/.bun/bin` to your `PATH` — before running any `bun`/`bunx` commands.
 - Use sub-agents aggressively — parallelise research, testing, and independent file changes.
 - Before starting work on a project, read its AGENTS.md for codebase conventions, commands, and constraints. When you discover an operational task or convention that would prevent future mistakes, update the project's AGENTS.md.
 - Review team preferences to align implementation style with the admin's preferences. When you observe a new preference in admin feedback, update the team preferences document.


### PR DESCRIPTION
## What

Adds a one-line instruction to the Engineer role doc (`agents/software-development/engineer.md`) telling the agent to install `bun` if it isn't already available in its environment, before running any `bun`/`bunx` commands.

## Why

The Engineer role already mandates using `bun`/`bunx` as the package manager, but it assumed `bun` was always present. A fresh agent container may not have bun installed, so the first `bun`/`bunx` call fails with `bun: command not found`. The doc now points the engineer at the official installer and reminds it to add `~/.bun/bin` to `PATH`.

## Change

```diff
- - **Use `bun` as the package manager** and `bunx` instead of `npx` for running package binaries in Node.js projects.
+ - **Use `bun` as the package manager** and `bunx` instead of `npx` for running package binaries in Node.js projects. If `bun` is not already available in your environment (`bun: command not found`), install it first — `curl -fsSL https://bun.sh/install | bash` then add `~/.bun/bin` to your `PATH` — before running any `bun`/`bunx` commands.
```

Per `AGENTS.md`, `agents/<template>/*.md` is the single source of truth for agent system prompts (read by `packages/server/src/db/seed.ts` at startup), so editing the role doc directly is the intended mechanism. Docs-only change; pre-commit hooks (biome / typecheck / build) passed locally.

https://claude.ai/code/session_019qqi6gHMwUydatz6rdCNNT

---
_Generated by [Claude Code](https://claude.ai/code/session_019qqi6gHMwUydatz6rdCNNT)_