### PR TITLE
fix(pricing): resolve unknown models via nearest segment-prefix match

### DIFF
--- a/packages/server/src/services/pricing/pricing-service.ts
+++ b/packages/server/src/services/pricing/pricing-service.ts
@@ -19,23 +19,54 @@ const log = logger.child('pricing');
 
 /**
  * Normalize a model id for fuzzy lookup. The CLI may emit a provider-prefixed,
- * dated, or 1M-context-tagged id (`openai/gpt-5`, `claude-opus-4-8-20260205`,
- * `deepseek-v4-pro[1m]`) while the feed keys the bare base id — strip those so
- * they resolve to the same rate.
+ * dated, or context-tagged id (`openai/gpt-5`, `claude-opus-4-8-20260205`,
+ * `deepseek-v4-pro[1m]`, `glm-4.7[200k]`) while the feed keys the bare base id —
+ * strip those so they resolve to the same rate. The context tag is any bracketed
+ * window size (`[1m]`, `[2m]`, `[200k]`, …), not only `[1m]`.
  */
 export function normalizeModelId(id: string): string {
 	let s = id.toLowerCase().trim();
 	const slash = s.lastIndexOf('/');
 	if (slash >= 0) s = s.slice(slash + 1);
-	s = s.replace(/\[1m\]/g, '');
+	s = s.replace(/\[[^\]]*\]/g, '');
 	s = s.replace(/-\d{8}$/, '').replace(/-\d{4}-\d{2}-\d{2}$/, '');
 	return s;
+}
+
+/** Model-id segment separators — ids break on dashes and version dots. */
+const SEGMENT_SEPARATOR = /[-.]/;
+
+/**
+ * Length of the longest common prefix of two normalized model ids that ends on a
+ * segment boundary in both — i.e. one id is a whole-segment prefix of the other.
+ * `gpt-5` ↔ `gpt-5-codex` and `deepseek-v4-pro` ↔ `deepseek-v4-pro-0606` match
+ * (returning the shorter length); siblings like `gpt-5.1` ↔ `gpt-5.2` and partial
+ * tokens like `gpt-5` ↔ `gpt-50` return 0. A shared *vendor-only* prefix
+ * (`deepseek-v4-pro` ↔ `deepseek-chat`) never matches, because the whole shorter
+ * id — boundary included — has to prefix the longer one.
+ */
+function segmentPrefixLen(a: string, b: string): number {
+	if (a === b) return a.length;
+	const [short, long] = a.length <= b.length ? [a, b] : [b, a];
+	if (short.length === 0 || !long.startsWith(short)) return 0;
+	return SEGMENT_SEPARATOR.test(long[short.length]) ? short.length : 0;
+}
+
+/**
+ * Tie-break equal-length prefix matches deterministically: prefer the key closest
+ * in length to the query (fewest extra segments), then the lexically smaller one
+ * so the choice never depends on map iteration order.
+ */
+function isCloserKey(candidate: string, current: string): boolean {
+	if (candidate.length !== current.length) return candidate.length < current.length;
+	return candidate < current;
 }
 
 export class PricingService {
 	private byId = new Map<string, ModelRate>();
 	private byNorm = new Map<string, ModelRate>();
 	private warned = new Set<string>();
+	private fuzzyMatched = new Set<string>();
 
 	constructor(private readonly db: PGlite) {}
 
@@ -98,6 +129,38 @@ export class PricingService {
 
 	private resolve(model: string | undefined): ModelRate | undefined {
 		if (!model) return undefined;
-		return this.byId.get(model.toLowerCase()) ?? this.byNorm.get(normalizeModelId(model));
+		const norm = normalizeModelId(model);
+		const exact = this.byId.get(model.toLowerCase()) ?? this.byNorm.get(norm);
+		return exact ?? this.resolveByPrefix(model, norm);
+	}
+
+	/**
+	 * Last-resort match for a model the feed doesn't list exactly: the entry whose
+	 * normalized id shares the longest segment-aligned prefix with `norm` (so
+	 * `deepseek-v4-pro[1m]` prices off a `deepseek-v4-pro-0606` feed row when only
+	 * the dated variant is listed). Best-effort — an approximate rate beats
+	 * recording the run at $0 — so it logs once per model instead of warning.
+	 */
+	private resolveByPrefix(model: string, norm: string): ModelRate | undefined {
+		if (!norm) return undefined;
+		let bestKey: string | undefined;
+		let bestLen = 0;
+		for (const key of this.byNorm.keys()) {
+			const len = segmentPrefixLen(norm, key);
+			if (len === 0) continue;
+			if (
+				len > bestLen ||
+				(len === bestLen && bestKey !== undefined && isCloserKey(key, bestKey))
+			) {
+				bestKey = key;
+				bestLen = len;
+			}
+		}
+		if (bestKey === undefined) return undefined;
+		if (!this.fuzzyMatched.has(model)) {
+			this.fuzzyMatched.add(model);
+			log.info(`No exact pricing for model "${model}"; using nearest match "${bestKey}"`);
+		}
+		return this.byNorm.get(bestKey);
 	}
 }

--- a/packages/server/test/pricing-service.test.ts
+++ b/packages/server/test/pricing-service.test.ts
@@ -34,6 +34,12 @@ describe('normalizeModelId', () => {
 		expect(normalizeModelId('deepseek-v4-pro[1m]')).toBe('deepseek-v4-pro');
 		expect(normalizeModelId('zai/glm-4.7')).toBe('glm-4.7');
 	});
+
+	it('strips any bracketed context-window tag, not just [1m]', () => {
+		expect(normalizeModelId('deepseek-v4-pro[2m]')).toBe('deepseek-v4-pro');
+		expect(normalizeModelId('glm-4.7[200k]')).toBe('glm-4.7');
+		expect(normalizeModelId('anthropic/claude-opus-4-8[1m]')).toBe('claude-opus-4-8');
+	});
 });
 
 describe('PricingService', () => {
@@ -63,6 +69,47 @@ describe('PricingService', () => {
 		await svc.init();
 		expect(svc.costCents('no-such-model-xyz', { inputTokens: M, outputTokens: M })).toBe(0);
 		expect(svc.costCents(undefined, { inputTokens: M, outputTokens: M })).toBe(0);
+	});
+
+	it('prices a context-tagged model off its nearest feed sibling', async () => {
+		const svc = new PricingService(db);
+		await svc.init();
+		// The feed lists only a dated variant of the model the CLI reports.
+		await svc.refresh(
+			stubFetch({
+				'deepseek-v4-pro-0606': {
+					input_cost_per_token: 0.000001,
+					output_cost_per_token: 0.000002,
+				},
+			}),
+		);
+		// Exact dated id prices directly: 1M input @ $1/M → 100c.
+		const exact = svc.costCents('deepseek-v4-pro-0606', { inputTokens: M, outputTokens: 0 });
+		expect(exact).toBe(100);
+		// The logged miss now resolves: strip `[1m]`, then match the segment-prefix
+		// sibling instead of recording $0.
+		expect(svc.costCents('deepseek-v4-pro[1m]', { inputTokens: M, outputTokens: 0 })).toBe(exact);
+	});
+
+	it('prices a more-specific variant off its base model', async () => {
+		const svc = new PricingService(db);
+		await svc.init();
+		// `gpt-5-pro` isn't in the feed but `gpt-5` is; the variant borrows the base
+		// rate rather than falling through to $0.
+		const base = svc.costCents('gpt-5', { inputTokens: M, outputTokens: 0 });
+		expect(base).toBeGreaterThan(0);
+		expect(svc.costCents('gpt-5-pro[1m]', { inputTokens: M, outputTokens: 0 })).toBe(base);
+	});
+
+	it('does not cross-match a model sharing only a vendor prefix', async () => {
+		const svc = new PricingService(db);
+		await svc.init();
+		// `deepseek-v4-pro` shares only the `deepseek` vendor token with the seeded
+		// `deepseek-chat` / `deepseek-reasoner` rows — not a whole-segment prefix —
+		// so it must stay unpriced rather than borrow an unrelated rate.
+		expect(svc.costCents('deepseek-v4-pro[1m]', { inputTokens: M, outputTokens: 0 })).toBe(0);
+		// A sibling version is likewise not a match for a different sibling.
+		expect(svc.costCents('claude-sonnet-9', { inputTokens: M, outputTokens: 0 })).toBe(0);
 	});
 
 	it('lets a manual override win over the feed row', async () => {


### PR DESCRIPTION
## Problem

Runs were being recorded at **$0** for models the pricing feed doesn't list under an exact id:

```
[warn] <pricing> No pricing for model "deepseek-v4-pro[1m]"; recording run cost as $0
```

`normalizeModelId` already strips a provider prefix, release date, and the literal `[1m]` tag — but two gaps remained:

1. Only the literal `[1m]` context tag was stripped, not other window sizes (`[2m]`, `[200k]`, …).
2. After normalization, lookup was **exact-only**. If the feed keys a model under a slightly different id (a dated variant, or only a more-specific sibling), the run fell through to $0.

## Change

When exact + normalized lookups both miss, fall back to the feed entry whose normalized id shares the **longest segment-aligned prefix** with the query, instead of recording $0.

- `deepseek-v4-pro[1m]` → strips the tag to `deepseek-v4-pro`, then prices off a `deepseek-v4-pro-0606` feed row.
- `gpt-5-pro` → prices off its `gpt-5` base.

The match is deliberately conservative — it fires **only when one normalized id is a whole-segment prefix of the other** (boundary on `-`/`.`). So:

- A shared **vendor-only** prefix never matches: `deepseek-v4-pro` does *not* borrow `deepseek-chat`'s rate.
- **Sibling versions** never cross-match: `gpt-5.1` ≠ `gpt-5.2`, `gpt-5` ≠ `gpt-50`.

Ties are broken deterministically (closest length, then lexical) so the result never depends on map iteration order. A fuzzy match logs **once per model at info level** ("using nearest match …") rather than warning — a genuinely-unknown model still warns and records $0 as before.

Also generalized the context-tag strip in `normalizeModelId` from the literal `[1m]` to any bracketed window size.

## Tests

`packages/server/test/pricing-service.test.ts` (all 11 pass):

- `normalizeModelId` strips any bracketed context tag (`[2m]`, `[200k]`, prefixed `[1m]`).
- Context-tagged miss resolves to its nearest feed sibling and matches the exact rate (the logged `deepseek-v4-pro[1m]` scenario).
- A more-specific variant prices off its base model.
- A vendor-only prefix and a sibling version both stay unpriced ($0) — no over-eager matching.

`bun run check`, `typecheck`, and `build` all pass via the pre-commit hook.

https://claude.ai/code/session_017UJbUPpFk4DAQmA9tSHXaA

---
_Generated by [Claude Code](https://claude.ai/code/session_017UJbUPpFk4DAQmA9tSHXaA)_