### PR TITLE
feat(web): open doc/asset mention names in a new tab like the icon suffix

### DIFF
--- a/packages/web/src/components/markdown-prose.tsx
+++ b/packages/web/src/components/markdown-prose.tsx
@@ -1,6 +1,6 @@
 import { Link } from '@tanstack/react-router';
 import { ExternalLink } from 'lucide-react';
-import { useMemo } from 'react';
+import { type ReactNode, useMemo } from 'react';
 import Markdown, { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useAgents } from '../hooks/use-agents';
@@ -207,37 +207,21 @@ export function MarkdownProse({
 				const docFilename = attrs['data-mention-doc-filename'];
 				if (docProject && docFilename && mentionsEnabled) {
 					return (
-						<span className="inline-flex items-baseline gap-0.5">
-							<Tooltip
-								content={
-									<DocTooltipContent
-										title={docFilename}
-										size={Number(attrs['data-mention-size'] ?? 0)}
-										updatedAt={attrs['data-mention-updated-at'] ?? ''}
-									/>
-								}
-							>
-								<Link
-									to="/projects/$projectId/documents"
-									params={{ projectId: docProject }}
-									search={{ file: docFilename }}
-									className={MENTION_CLASSES}
-									data-testid="doc-mention-link"
-								>
-									{props.children}
-								</Link>
-							</Tooltip>
-							<a
-								href={docPreviewPath(docProject, docFilename)}
-								target="_blank"
-								rel="noopener noreferrer"
-								aria-label="Open preview in new tab"
-								data-testid="doc-mention-preview-link"
-								className="text-accent-blue-text hover:underline"
-							>
-								<ExternalLink className="w-3 h-3" />
-							</a>
-						</span>
+						<DedicatedViewMention
+							href={docPreviewPath(docProject, docFilename)}
+							nameTestId="doc-mention-link"
+							previewTestId="doc-mention-preview-link"
+							previewAriaLabel="Open preview in new tab"
+							tooltip={
+								<DocTooltipContent
+									title={docFilename}
+									size={Number(attrs['data-mention-size'] ?? 0)}
+									updatedAt={attrs['data-mention-updated-at'] ?? ''}
+								/>
+							}
+						>
+							{props.children}
+						</DedicatedViewMention>
 					);
 				}
 
@@ -245,30 +229,30 @@ export function MarkdownProse({
 				const assetFilename = attrs['data-mention-asset-filename'];
 				const assetUrl = attrs['data-mention-asset-url'];
 				if (assetProject && assetFilename && mentionsEnabled) {
-					return (
-						<span className="inline-flex items-baseline gap-0.5">
-							<Link
-								to="/projects/$projectId/assets"
-								params={{ projectId: assetProject }}
-								search={{ file: assetFilename }}
-								className={MENTION_CLASSES}
-								data-testid="asset-mention-link"
+					if (assetUrl) {
+						return (
+							<DedicatedViewMention
+								href={assetUrl}
+								nameTestId="asset-mention-link"
+								previewTestId="asset-mention-preview-link"
+								previewAriaLabel="Open asset in new tab"
 							>
 								{props.children}
-							</Link>
-							{assetUrl && (
-								<a
-									href={assetUrl}
-									target="_blank"
-									rel="noopener noreferrer"
-									aria-label="Open asset in new tab"
-									data-testid="asset-mention-preview-link"
-									className="text-accent-blue-text hover:underline"
-								>
-									<ExternalLink className="w-3 h-3" />
-								</a>
-							)}
-						</span>
+							</DedicatedViewMention>
+						);
+					}
+					// No signed URL → no dedicated view to open. Keep the same-tab
+					// library link with no icon (consistent with the general rule).
+					return (
+						<Link
+							to="/projects/$projectId/assets"
+							params={{ projectId: assetProject }}
+							search={{ file: assetFilename }}
+							className={MENTION_CLASSES}
+							data-testid="asset-mention-link"
+						>
+							{props.children}
+						</Link>
 					);
 				}
 
@@ -374,6 +358,55 @@ export function MarkdownProse({
 				{children}
 			</Markdown>
 		</div>
+	);
+}
+
+/**
+ * A mention whose name and trailing icon both open the same dedicated view in a
+ * new tab. The icon suffix is the visual marker for "this link opens a new tab",
+ * so it is rendered here and only here — same-tab in-app mentions never use this
+ * component and therefore never get the icon.
+ */
+function DedicatedViewMention({
+	href,
+	children,
+	nameTestId,
+	previewTestId,
+	previewAriaLabel,
+	tooltip,
+}: {
+	href: string;
+	children: ReactNode;
+	nameTestId: string;
+	previewTestId: string;
+	previewAriaLabel: string;
+	tooltip?: ReactNode;
+}) {
+	const name = (
+		<a
+			href={href}
+			target="_blank"
+			rel="noopener noreferrer"
+			className={MENTION_CLASSES}
+			data-testid={nameTestId}
+		>
+			{children}
+		</a>
+	);
+	return (
+		<span className="inline-flex items-baseline gap-0.5">
+			{tooltip ? <Tooltip content={tooltip}>{name}</Tooltip> : name}
+			<a
+				href={href}
+				target="_blank"
+				rel="noopener noreferrer"
+				aria-label={previewAriaLabel}
+				data-testid={previewTestId}
+				className="text-accent-blue-text hover:underline"
+			>
+				<ExternalLink className="w-3 h-3" />
+			</a>
+		</span>
 	);
 }
 

--- a/packages/web/test/ceo-chat-mentions.test.tsx
+++ b/packages/web/test/ceo-chat-mentions.test.tsx
@@ -80,8 +80,10 @@ test('CEO replies render unique refs as links; unknown and backticked refs stay 
 		`/projects/${refs.projectSlug}/tasks/${ident.toLowerCase()}#comment-${refs.commentId}`,
 	);
 
+	// The doc name now opens the standalone preview in a new tab (same as the suffix).
 	const docLink = getByTestId('doc-mention-link');
-	expect(docLink.getAttribute('href')).toBe(`/projects/${refs.projectSlug}/documents?file=prd.md`);
+	expect(docLink.getAttribute('href')).toBe(`/preview/${refs.projectSlug}/prd.md`);
+	expect(docLink.getAttribute('target')).toBe('_blank');
 
 	// Unknown identifiers stay plain text — no link wraps ZZ-99.
 	const body = getByTestId('ceo-chat-markdown');

--- a/packages/web/test/project-assets.test.tsx
+++ b/packages/web/test/project-assets.test.tsx
@@ -73,6 +73,9 @@ test('an assets/<name> reference in a comment links to the asset and opens it in
 	await findByTestId('text-comment-body', undefined, { timeout: 15_000 });
 	const link = await findByTestId('asset-mention-link', undefined, { timeout: 15_000 });
 	expect(link.textContent).toContain('assets/login.png');
+	// Clicking the name now does the same as the icon: open the asset in a new tab.
+	expect(link.getAttribute('href')).toMatch(/^\/api\/assets\/[0-9a-f-]+\?exp=\d+&sig=/);
+	expect(link.getAttribute('target')).toBe('_blank');
 	const preview = await findByTestId('asset-mention-preview-link', undefined, { timeout: 15_000 });
 	expect(preview.getAttribute('href')).toMatch(/^\/api\/assets\/[0-9a-f-]+\?exp=\d+&sig=/);
 	expect(preview.getAttribute('target')).toBe('_blank');

--- a/packages/web/test/project-doc-preview.test.tsx
+++ b/packages/web/test/project-doc-preview.test.tsx
@@ -130,4 +130,9 @@ test('a doc mention in a task comment gets a suffix link to the standalone previ
 	const preview = await findByTestId('doc-mention-preview-link', undefined, { timeout: 15_000 });
 	expect(preview.getAttribute('href')).toBe(`/preview/${ctx.projectSlug}/ui-mockups.md`);
 	expect(preview.getAttribute('target')).toBe('_blank');
+
+	// Clicking the name now does the same as the icon: open the preview in a new tab.
+	const name = await findByTestId('doc-mention-link');
+	expect(name.getAttribute('href')).toBe(`/preview/${ctx.projectSlug}/ui-mockups.md`);
+	expect(name.getAttribute('target')).toBe('_blank');
 });


### PR DESCRIPTION
## What & why

Document and asset mentions in markdown rendered a two-part affordance: clicking the **name** navigated in-app (same tab) to the library view, while only the trailing **external-link icon** opened the dedicated view in a new tab. This makes clicking the name do the **same thing as clicking the icon** — both now open the dedicated view in a new tab:

- **Doc mention** → the chrome-less standalone preview (`/preview/$slug/$filename`)
- **Asset mention** → the asset's signed URL

It also generalizes the icon suffix: instead of being hand-coded in the doc branch and again in the asset branch, the "name + new-tab icon suffix" pattern now lives in one `DedicatedViewMention` helper. The icon suffix is therefore governed by a single rule — *"this link opens a new tab to a dedicated view"* — rather than being keyed to a specific mention type.

Same-tab, in-app mentions (task, comment, agent, KB doc, admin inbox) don't use the helper, so they structurally keep **no** icon, exactly as before. Assets without a signed URL fall back to the same-tab library link with no icon, since there's no dedicated view to open.

## Changes

- `packages/web/src/components/markdown-prose.tsx`
  - Add `DedicatedViewMention` (name as a new-tab `<a>` + external-link icon suffix, both pointing at the same dedicated-view href; optional tooltip).
  - Doc branch and asset branch now render through it. Existing `data-testid`s, styling, and tooltip are preserved.
- Tests updated to assert the name now opens in a new tab:
  - `ceo-chat-mentions.test.tsx` — doc name href is now the preview path with `target="_blank"`.
  - `project-doc-preview.test.tsx` — doc name opens the preview in a new tab (in addition to the icon).
  - `project-assets.test.tsx` — asset name opens the signed URL in a new tab (in addition to the icon).

## Testing

- `bunx vitest run test/project-doc-preview.test.tsx test/project-assets.test.tsx test/ceo-chat-mentions.test.tsx` → 11 passed.
- `bunx turbo typecheck --filter=@hezo/web` and `biome check` on the changed files → clean.

Render-driven change (href/target attributes on an inline glyph), so component tests cover it — no real-layout/viewport/websocket behavior involved, hence no Playwright test.

https://claude.ai/code/session_014kXxfXwrG1mnJ1BBZXmKyk

---
_Generated by [Claude Code](https://claude.ai/code/session_014kXxfXwrG1mnJ1BBZXmKyk)_