### PR TITLE
fix(egress): sever streamed connections on teardown so MCP sessions don't leak

### DIFF
--- a/.dev/egress.md
+++ b/.dev/egress.md
@@ -95,7 +95,7 @@ The audit row is only written when there was a substitution attempt — pure pas
 
 - **HMAC-signed bodies** (e.g. AWS SigV4): substitution after signing is impossible. Use the local-MCP-with-proxy pattern — the MCP server itself does the signing using the substituted secret in its env.
 - **WebSocket / HTTP/2**: `Upgrade` requests are not proxied (no agent egress uses them today). An upgrade with no handler is closed cleanly rather than hung. Add an `upgrade`-event path if a real need appears.
-- **Streaming responses** (SSE etc.): the proxy does not buffer or modify response bodies — the upstream response is piped straight back to the client.
+- **Streaming responses** (SSE etc.): the proxy does not buffer or modify response bodies — the upstream response is piped straight back to the client. This is what carries a Streamable-HTTP MCP server's server→client channel (e.g. `api.githubcopilot.com/mcp/`). Because such a stream stays open for the whole run, the proxy **tracks every accepted/bridged socket and every in-flight upstream request** and severs them on `releaseRunProxy`. Without that, an open stream parks `server.close()` on the 5s deadline and **leaks the proxy→upstream socket** on every run — under Bun, `closeAllConnections()` reaches neither a hijacked CONNECT socket nor an in-flight streamed response, and aborting the `ClientRequest` alone does not drop its socket. Accumulated leaked sessions against a remote MCP host are a plausible cause of later "socket connection was closed unexpectedly" failures, so teardown must actually close them.
 - **Cert minting cost**: a few ms per host on first request. Per-host servers stay live for the lifetime of the per-run proxy, so a hot upstream mints once.
 - **Bypass for Hezo backend**: `NO_PROXY=host.docker.internal,localhost,127.0.0.1` excludes the agent → backend path. Verified for Node `undici`, Python `requests`, curl, git, Go.
 
@@ -124,3 +124,7 @@ Cert generation uses mockttp's CA (`@peculiar/x509`), the same path the tests tr
 - `egress-ca.test.ts` — CA generation + idempotent reload
 - `egress-proxy.test.ts` — in-process proxy with a Node HTTP upstream
 - `egress-proxy-docker.test.ts` — real container exercising substitution through curl with the CA bind-mounted into the trust store
+
+`packages/server/test/bun/` (run under `bun test` on the production runtime — Node/vitest can't see the Bun TLS/connection divergences):
+- `egress-proxy.bun.test.ts` — HTTPS MITM termination + per-host cert routing under Bun
+- `egress-streaming.bun.test.ts` — long-lived SSE responses pipe through incrementally, and an open stream is severed (not leaked) on run teardown without parking the close deadline

--- a/packages/server/src/services/egress/proxy.ts
+++ b/packages/server/src/services/egress/proxy.ts
@@ -1,4 +1,5 @@
 import {
+	type ClientRequest,
 	createServer as createHttpServer,
 	type Server as HttpServer,
 	request as httpRequest,
@@ -193,8 +194,46 @@ class RunProxyInstance {
 	private readonly hostServers = new Map<string, HostServer>();
 	private readonly pendingHostServers = new Map<string, Promise<HostServer>>();
 	private closed = false;
+	/** Every socket this run has accepted or bridged (front CONNECT sockets,
+	 * per-host loopback sockets, and the loopback client legs), tracked so close
+	 * can sever them directly. Bun's `closeAllConnections()` does not reach
+	 * hijacked CONNECT sockets or an in-flight streamed response, so a long-lived
+	 * stream (e.g. an MCP server→client SSE channel) would otherwise park
+	 * `server.close()` until the deadline on every teardown. */
+	private readonly liveSockets = new Set<Socket>();
+	/** Every in-flight upstream request. Destroying the client/bridge sockets
+	 * breaks the pipe but leaves the proxy→upstream socket open, so a streamed
+	 * upstream connection (the SSE channel to api.githubcopilot.com) leaks unless
+	 * the request itself is aborted on teardown. */
+	private readonly liveUpstreams = new Set<ClientRequest>();
 
 	constructor(private readonly cfg: RunProxyConfig) {}
+
+	/** Register a socket for forced teardown; auto-untracks when it closes. */
+	private trackSocket(sock: Socket): void {
+		if (this.closed || sock.destroyed) {
+			sock.destroy();
+			return;
+		}
+		this.liveSockets.add(sock);
+		sock.once('close', () => this.liveSockets.delete(sock));
+	}
+
+	/** Register an upstream request for forced abort; auto-untracks on settle.
+	 * Also tracks the underlying socket: under Bun `ClientRequest.destroy()` does
+	 * not reliably tear down the proxy→upstream socket of a streamed response, so
+	 * the socket itself must be severed to release the upstream connection. */
+	private trackUpstream(reqOut: ClientRequest): void {
+		if (this.closed) {
+			reqOut.destroy();
+			return;
+		}
+		this.liveUpstreams.add(reqOut);
+		const cleanup = () => this.liveUpstreams.delete(reqOut);
+		reqOut.once('close', cleanup);
+		reqOut.once('error', cleanup);
+		reqOut.on('socket', (sock) => this.trackSocket(sock));
+	}
 
 	get port(): number {
 		return this.cfg.port;
@@ -207,6 +246,10 @@ class RunProxyInstance {
 	listen(): Promise<void> {
 		const front = createHttpServer();
 		this.front = front;
+		// Track every accepted socket (plain-request and CONNECT alike) so close
+		// can sever it — a hijacked CONNECT socket leaves the server's own
+		// connection list under Bun.
+		front.on('connection', (socket) => this.trackSocket(socket as Socket));
 		front.on('request', (req, res) => {
 			this.forward(false, null, req, res).catch((e: Error) => this.onForwardError(res, e));
 		});
@@ -232,6 +275,15 @@ class RunProxyInstance {
 
 	async close(): Promise<void> {
 		this.closed = true;
+		// Sever every tracked connection first. Without this, a long-lived stream
+		// (an MCP server→client SSE channel) parks each server.close() until the
+		// 5s deadline and leaks the upstream connection — observed in production
+		// as repeated "server close timed out" warnings on api.githubcopilot.com.
+		for (const sock of this.liveSockets) sock.destroy();
+		this.liveSockets.clear();
+		for (const up of this.liveUpstreams) up.destroy();
+		this.liveUpstreams.clear();
+
 		const closables: Array<Promise<void>> = [];
 		for (const [host, { server }] of this.hostServers.entries()) {
 			closables.push(closeServer(server, `${this.cfg.scope.label}/${host}`));
@@ -260,6 +312,7 @@ class RunProxyInstance {
 					return;
 				}
 				const up = netConnect({ host: '127.0.0.1', port: rec.port }, () => {
+					this.trackSocket(up);
 					client.write('HTTP/1.1 200 Connection Established\r\n\r\n');
 					if (head?.length) up.write(head);
 					client.pipe(up);
@@ -310,6 +363,7 @@ class RunProxyInstance {
 		const server = createHttpsServer({ key: leaf.key, cert: leaf.cert }, (req, res) => {
 			this.forward(true, host, req, res).catch((e: Error) => this.onForwardError(res, e));
 		});
+		server.on('connection', (socket) => this.trackSocket(socket as Socket));
 		server.on('clientError', (_err, socket) => socket.destroy());
 		server.on('error', (err) => {
 			log.warn('egress per-host server error', {
@@ -451,6 +505,7 @@ class RunProxyInstance {
 				upstreamRes.pipe(res);
 			},
 		);
+		this.trackUpstream(upstream);
 		upstream.on('error', (err) => this.onForwardError(res, err));
 		req.pipe(upstream);
 	}

--- a/packages/server/test/bun/egress-streaming.bun.test.ts
+++ b/packages/server/test/bun/egress-streaming.bun.test.ts
@@ -1,0 +1,193 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { createServer as createHttpsServer, type Server as HttpsServer } from 'node:https';
+import { connect as netConnect, type Socket } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { type TLSSocket, connect as tlsConnect } from 'node:tls';
+import type { PGlite } from '@electric-sql/pglite';
+import { encrypt } from '../../src/crypto/encryption';
+import type { MasterKeyManager } from '../../src/crypto/master-key';
+import { type HezoCA, loadOrCreateCA } from '../../src/services/egress/ca';
+import { EgressProxy } from '../../src/services/egress/proxy';
+import { createTestApp, createTestProject } from '../helpers/app';
+import { mintCertFromCA } from '../helpers/self-signed-cert';
+
+// Runtime tier: runs under `bun test` on the production Bun runtime. It guards
+// the egress proxy's handling of long-lived Streamable-HTTP (SSE) responses —
+// the transport every remote MCP server (e.g. api.githubcopilot.com) uses.
+// Bun's https.Server `closeAllConnections()` does not reach a hijacked CONNECT
+// socket or an in-flight streamed response, so an open SSE channel parked
+// `server.close()` until the 5s deadline and leaked the upstream connection on
+// every run that touched the GitHub MCP. Node/vitest never sees this — the
+// failure is specific to Bun's connection accounting.
+
+let db: PGlite;
+let masterKeyManager: MasterKeyManager;
+let teamId: string;
+let agentId: string;
+let ca: HezoCA;
+let dataDir: string;
+let proxy: EgressProxy;
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	db = ctx.db;
+	masterKeyManager = ctx.masterKeyManager;
+	dataDir = mkdtempSync(join(tmpdir(), 'hezo-egress-stream-'));
+
+	const teamRes = await ctx.app.request('/api/teams', {
+		method: 'POST',
+		headers: { Authorization: `Bearer ${ctx.token}`, 'Content-Type': 'application/json' },
+		body: JSON.stringify({ name: 'Egress Stream Co' }),
+	});
+	teamId = (await teamRes.json()).data.id;
+	const projectSlug = (
+		await (await createTestProject(db, teamId, { name: 'Stream Project' })).json()
+	).data.slug;
+	const agentRes = await ctx.app.request(`/api/projects/${projectSlug}/agents`, {
+		method: 'POST',
+		headers: { Authorization: `Bearer ${ctx.token}`, 'Content-Type': 'application/json' },
+		body: JSON.stringify({ title: 'Egress Stream Agent' }),
+	});
+	agentId = (await agentRes.json()).data.id;
+
+	ca = await loadOrCreateCA(dataDir);
+	proxy = new EgressProxy({ db, masterKeyManager, ca, extraUpstreamTrustedCAs: ca.cert });
+}, 60_000);
+
+afterAll(async () => {
+	await proxy.releaseAll();
+	rmSync(dataDir, { recursive: true, force: true });
+	await db.close();
+});
+
+async function insertSecret(name: string, value: string, allowedHosts: string[]): Promise<void> {
+	const key = masterKeyManager.getKey();
+	if (!key) throw new Error('master key unavailable in test');
+	await db.query(
+		`INSERT INTO secrets (name, encrypted_value, category, allowed_hosts)
+		 VALUES ($1, $2, 'api_token'::secret_category, $3)
+		 ON CONFLICT (name) DO UPDATE
+		 SET encrypted_value = EXCLUDED.encrypted_value, allowed_hosts = EXCLUDED.allowed_hosts`,
+		[name, encrypt(value, key), allowedHosts],
+	);
+}
+
+/** Open a CONNECT tunnel through the proxy and complete the TLS handshake to the
+ * minted per-host cert, returning the decrypted TLS socket ready for a request. */
+async function tunnelTo(proxyPort: number, host: string, port: number): Promise<TLSSocket> {
+	const sock = await new Promise<Socket>((resolve, reject) => {
+		const s = netConnect({ host: '127.0.0.1', port: proxyPort });
+		const onData = (chunk: Buffer) => {
+			s.removeListener('data', onData);
+			if (/^HTTP\/1\.[01] 200/.test(chunk.toString().split('\r\n')[0] ?? '')) resolve(s);
+			else reject(new Error(`CONNECT failed: ${chunk.toString().split('\r\n')[0]}`));
+		};
+		s.on('connect', () =>
+			s.write(`CONNECT ${host}:${port} HTTP/1.1\r\nHost: ${host}:${port}\r\n\r\n`),
+		);
+		s.on('data', onData);
+		s.on('error', reject);
+		s.setTimeout(15_000, () => s.destroy(new Error('CONNECT timed out')));
+	});
+	return await new Promise<TLSSocket>((resolve, reject) => {
+		const tls = tlsConnect({ socket: sock, servername: host, ca: [ca.cert] }, () => resolve(tls));
+		tls.on('error', reject);
+	});
+}
+
+describe('EgressProxy streaming + teardown under Bun', () => {
+	// An SSE response must reach the client chunk-by-chunk as the upstream writes
+	// it — a Streamable-HTTP MCP transport breaks if the server→client channel is
+	// buffered until the response ends (which, for a long-lived stream, is never).
+	test('forwards an SSE response incrementally, not buffered until end', async () => {
+		const { cert, key } = await mintCertFromCA(ca, 'localhost');
+		const upstream: HttpsServer = createHttpsServer({ cert, key }, (_req, res) => {
+			res.writeHead(200, { 'content-type': 'text/event-stream' });
+			res.write('data: first\n\n');
+			// Second event lands well after the first; if the proxy buffered, the
+			// client would see nothing until both are written + the stream ends.
+			setTimeout(() => res.end('data: second\n\n'), 600);
+		});
+		await new Promise<void>((r) => upstream.listen(0, '127.0.0.1', () => r()));
+		const upstreamPort = (upstream.address() as { port: number }).port;
+		await insertSecret('STREAM_INCR', 'tok', ['localhost']);
+		const runId = `stream-incr-${process.pid}`;
+		const allocated = await proxy.allocateRunProxy(runId, { teamId, agentId });
+
+		try {
+			const tls = await tunnelTo(allocated.proxyPort, 'localhost', upstreamPort);
+			let acc = '';
+			const sawFirstAlone = new Promise<boolean>((resolve) => {
+				tls.on('data', (c: Buffer) => {
+					acc += c.toString();
+					if (acc.includes('first') && !acc.includes('second')) resolve(true);
+				});
+				tls.setTimeout(5_000, () => resolve(false));
+			});
+			tls.write(
+				`GET /sse HTTP/1.1\r\nHost: localhost:${upstreamPort}\r\nAccept: text/event-stream\r\n` +
+					`Authorization: Bearer __HEZO_SECRET_STREAM_INCR__\r\n\r\n`,
+			);
+
+			// There must be a moment where 'first' has arrived but 'second' has not
+			// — proof the bytes were flushed live rather than coalesced at end.
+			expect(await sawFirstAlone).toBe(true);
+			tls.destroy();
+		} finally {
+			await proxy.releaseRunProxy(runId);
+			await new Promise<void>((r) => upstream.close(() => r()));
+		}
+	}, 30_000);
+
+	// Releasing a run while a long-lived SSE stream is open must sever it promptly
+	// and free the upstream connection — not park teardown on the close deadline
+	// and leak the proxy→upstream socket (the production failure mode against
+	// api.githubcopilot.com: "server close timed out after 5000ms").
+	test('severs an open long-lived stream on release without hitting the close deadline', async () => {
+		const { cert, key } = await mintCertFromCA(ca, 'localhost');
+		let upstreamConnClosed = false;
+		const upstream: HttpsServer = createHttpsServer({ cert, key }, (req, res) => {
+			res.writeHead(200, { 'content-type': 'text/event-stream' });
+			res.write(': open\n\n');
+			const timer = setInterval(() => res.write(': ping\n\n'), 100);
+			req.on('close', () => {
+				clearInterval(timer);
+				upstreamConnClosed = true;
+			});
+		});
+		await new Promise<void>((r) => upstream.listen(0, '127.0.0.1', () => r()));
+		const upstreamPort = (upstream.address() as { port: number }).port;
+		await insertSecret('STREAM_LL', 'tok', ['localhost']);
+		const runId = `stream-ll-${process.pid}`;
+		const allocated = await proxy.allocateRunProxy(runId, { teamId, agentId });
+
+		const tls = await tunnelTo(allocated.proxyPort, 'localhost', upstreamPort);
+		await new Promise<void>((resolve, reject) => {
+			tls.once('data', () => resolve());
+			tls.once('error', reject);
+			tls.setTimeout(10_000, () => reject(new Error('no SSE data')));
+			tls.write(
+				`GET /sse HTTP/1.1\r\nHost: localhost:${upstreamPort}\r\nAccept: text/event-stream\r\n` +
+					`Authorization: Bearer __HEZO_SECRET_STREAM_LL__\r\n\r\n`,
+			);
+		});
+
+		try {
+			const started = Date.now();
+			await proxy.releaseRunProxy(runId);
+			const elapsed = Date.now() - started;
+			// Well under the 5_000ms close deadline — the stream is severed, not waited on.
+			expect(elapsed).toBeLessThan(2_000);
+
+			// The upstream connection is actually torn down (no leak). Give the
+			// FIN/RST a moment to land on the upstream server.
+			await new Promise<void>((r) => setTimeout(r, 250));
+			expect(upstreamConnClosed).toBe(true);
+		} finally {
+			tls.destroy();
+			await new Promise<void>((r) => upstream.close(() => r()));
+		}
+	}, 30_000);
+});


### PR DESCRIPTION
## Why the GitHub MCP couldn't create a PR

An agent (engineer/TO-12) repeatedly hit `The socket connection was closed unexpectedly` when calling `mcp__github__*` tools and never managed to open a PR. Tracing it through the egress path surfaced this in the backend logs — once per run that touched the GitHub MCP, across multiple agents:

```
[warn] <net> server close timed out after 5000ms; abandoning wait {"label":"egress:engineer/TO-7/api.githubcopilot.com"}
[warn] <net> server close timed out after 5000ms; abandoning wait {"label":"egress:coach/TO-11/api.githubcopilot.com"}
[warn] <net> server close timed out after 5000ms; abandoning wait {"label":"egress:engineer/TO-12/api.githubcopilot.com"}
```

## Root cause

The GitHub MCP (`api.githubcopilot.com/mcp/`) uses the **Streamable-HTTP transport**, which holds a long-lived `text/event-stream` server→client channel open for the entire run. On run teardown the egress proxy calls `server.close()` + `closeAllConnections()` — but **under Bun, `closeAllConnections()` reaches neither the hijacked CONNECT socket nor an in-flight streamed response** (the same connection-accounting divergence already documented in `close-deadline.bun.test.ts`). So every GitHub-MCP run:

1. **parked each per-host `server.close()` on the full 5s deadline** (the warnings above), and
2. **leaked the proxy→upstream socket to `api.githubcopilot.com`** — aborting the `ClientRequest` alone doesn't drop its socket under Bun.

Leaked MCP sessions pile up against the remote host run after run, which is a plausible driver of the later `socket connection was closed unexpectedly` failures (the error string itself is Bun's `fetch`, i.e. the in-container MCP client).

I reproduced the teardown bug against the **real `EgressProxy`** under Bun (`releaseRunProxy()` with an open SSE stream → **5002ms** + upstream socket never closed) and confirmed the streaming path itself is fine, so the fix is teardown-only.

## Fix

`RunProxyInstance` now tracks every accepted/bridged socket (front CONNECT sockets, per-host loopback legs, upstream sockets) and every in-flight upstream request, and severs them at the start of `close()`. The upstream socket is captured via the request's `socket` event and destroyed directly, since `ClientRequest.destroy()` doesn't drop it under Bun.

After the fix, the same reproduction tears down in **~5ms** and the upstream connection is actually closed (no leak).

## Tests

New Bun-native tier `test/bun/egress-streaming.bun.test.ts` (Node/vitest can't observe Bun's TLS/connection divergences):
- **forwards an SSE response incrementally** — guards the streaming path (there's a moment where `first` has arrived but `second` hasn't).
- **severs an open long-lived stream on release without hitting the close deadline** — release completes in `<2s` and the upstream connection is closed. This test **fails against the pre-fix proxy** (30s hang + the exact `server close timed out` warning); passes after.

All green: 26 Node egress vitest tests, 7 Bun-native egress tests, typecheck, biome.

https://claude.ai/code/session_01TcXJMrG658H5UBZaXiGce4

---
_Generated by [Claude Code](https://claude.ai/code/session_01TcXJMrG658H5UBZaXiGce4)_