### PR TITLE
test(mentions): fix ceo-chat passive @@ assertion dropped from #252

### DIFF
--- a/packages/web/test/ceo-chat-mentions.test.tsx
+++ b/packages/web/test/ceo-chat-mentions.test.tsx
@@ -146,5 +146,5 @@ test('agent mentions link to the agent home project; HQ singletons resolve to hq
 
 	const agentLink = await findByTestId('agent-mention-link');
 	expect(agentLink.getAttribute('href')).toBe('/projects/hq/agents/ceo');
-	expect(agentLink.textContent).toBe('@ceo');
+	expect(agentLink.textContent).toBe('ceo');
 });


### PR DESCRIPTION
## Why

PR #252 (passive `@@` renders without the `@` prefix) was squash-merged from a **stale branch head** — GitHub's API was lagging at merge time and the squash captured only the first commit, dropping the follow-up that updated `ceo-chat-mentions.test.tsx`.

As a result main is currently red: the renderer emits the bare slug (`ceo`) but the test still asserts `@ceo`.

## Fix

One-line test update to expect the bare slug, matching the shipped renderer behaviour. Verified locally (`ceo-chat-mentions.test.tsx` 3/3 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)