### PR TITLE
Link comment references in agent runs; make comment timestamps permalinks

### DIFF
--- a/packages/web/src/components/comment-ref-link.tsx
+++ b/packages/web/src/components/comment-ref-link.tsx
@@ -1,0 +1,41 @@
+import { Link } from '@tanstack/react-router';
+import type { ReactNode } from 'react';
+import { Tooltip } from './ui/tooltip';
+
+/** Shared styling for every entity mention/reference link. */
+export const MENTION_CLASSES = 'font-semibold text-[1.05em] text-accent-blue-text hover:underline';
+
+/**
+ * In-app link to a specific comment in a task, scrolling straight to it via the
+ * `#comment-<public_id>` hash. Shared by the markdown @mention renderer and the
+ * agent-run formatted log view (bare/inline-code public_id references).
+ */
+export function CommentRefLink({
+	taskIdentifier,
+	commentId,
+	projectSlug,
+	taskTitle,
+	children,
+}: {
+	taskIdentifier: string;
+	commentId: string;
+	projectSlug: string;
+	taskTitle?: string;
+	children: ReactNode;
+}) {
+	return (
+		<Tooltip
+			content={`Comment in ${taskIdentifier.toUpperCase()}${taskTitle ? ` — ${taskTitle}` : ''}`}
+		>
+			<Link
+				to="/projects/$projectId/tasks/$taskId"
+				params={{ projectId: projectSlug, taskId: taskIdentifier.toLowerCase() }}
+				hash={`comment-${commentId}`}
+				className={MENTION_CLASSES}
+				data-testid="comment-mention-link"
+			>
+				{children}
+			</Link>
+		</Tooltip>
+	);
+}

--- a/packages/web/src/components/comment-renderers/run-comment.tsx
+++ b/packages/web/src/components/comment-renderers/run-comment.tsx
@@ -184,6 +184,15 @@ function RunCommentBody({
 						formattable
 						projectId={projectId}
 						projectSlug={run?.project_slug ?? undefined}
+						commentRefTask={
+							run?.task_identifier
+								? {
+										identifier: run.task_identifier,
+										title: run.task_title ?? '',
+										projectSlug: run.project_slug ?? projectId,
+									}
+								: undefined
+						}
 						heightClassName="h-[180px]"
 						testId="run-comment-log"
 						liveLabel={

--- a/packages/web/src/components/formatted-log-view.tsx
+++ b/packages/web/src/components/formatted-log-view.tsx
@@ -1,6 +1,6 @@
 import { Boxes, ChevronDown, ChevronRight, Cpu, Sparkles, Terminal, Wrench } from 'lucide-react';
 import { type ComponentType, useMemo, useState } from 'react';
-import Markdown from 'react-markdown';
+import Markdown, { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import {
 	type CommandBlock,
@@ -15,6 +15,8 @@ import {
 	type ToolBlock,
 } from '../lib/parse-agent-log';
 import { reflowEnumerations } from '../lib/reflow-thinking-lists';
+import { type CommentRefTask, remarkCommentRefs } from '../lib/remark-comment-refs';
+import { CommentRefLink } from './comment-ref-link';
 import { MarkdownProse } from './markdown-prose';
 import { Badge } from './ui/badge';
 
@@ -22,6 +24,8 @@ interface FormattedLogViewProps {
 	lines: { id: number; stream: 'stdout' | 'stderr'; text: string }[];
 	projectId?: string;
 	projectSlug?: string;
+	/** Run's task — links bare comment public_ids in the prose to its thread. */
+	commentRefTask?: CommentRefTask;
 	testId?: string;
 }
 
@@ -30,13 +34,25 @@ interface FormattedLogViewProps {
  * sections, prose/lists via markdown, and indented tool-use blocks whose result
  * shows on expand. Parses the prefixed lines client-side (see parse-agent-log).
  */
-export function FormattedLogView({ lines, projectId, projectSlug, testId }: FormattedLogViewProps) {
+export function FormattedLogView({
+	lines,
+	projectId,
+	projectSlug,
+	commentRefTask,
+	testId,
+}: FormattedLogViewProps) {
 	const blocks = useMemo(() => parseAgentLog(lines), [lines]);
 
 	return (
 		<div data-testid={testId} className="space-y-3 text-sm leading-relaxed text-text">
 			{blocks.map((block) => (
-				<BlockView key={block.id} block={block} projectId={projectId} projectSlug={projectSlug} />
+				<BlockView
+					key={block.id}
+					block={block}
+					projectId={projectId}
+					projectSlug={projectSlug}
+					commentRefTask={commentRefTask}
+				/>
 			))}
 		</div>
 	);
@@ -46,18 +62,27 @@ function BlockView({
 	block,
 	projectId,
 	projectSlug,
+	commentRefTask,
 }: {
 	block: LogBlock;
 	projectId?: string;
 	projectSlug?: string;
+	commentRefTask?: CommentRefTask;
 }) {
 	switch (block.type) {
 		case 'session':
 			return <SessionView block={block} />;
 		case 'text':
-			return <TextView block={block} projectId={projectId} projectSlug={projectSlug} />;
+			return (
+				<TextView
+					block={block}
+					projectId={projectId}
+					projectSlug={projectSlug}
+					commentRefTask={commentRefTask}
+				/>
+			);
 		case 'thinking':
-			return <ThinkingView block={block} />;
+			return <ThinkingView block={block} commentRefTask={commentRefTask} />;
 		case 'command':
 			return <CommandView block={block} />;
 		case 'tool':
@@ -94,10 +119,12 @@ function TextView({
 	block,
 	projectId,
 	projectSlug,
+	commentRefTask,
 }: {
 	block: TextBlock;
 	projectId?: string;
 	projectSlug?: string;
+	commentRefTask?: CommentRefTask;
 }) {
 	if (block.stream === 'stderr') {
 		return (
@@ -107,11 +134,46 @@ function TextView({
 		);
 	}
 	return (
-		<MarkdownProse projectId={projectId} projectSlug={projectSlug}>
+		<MarkdownProse projectId={projectId} projectSlug={projectSlug} commentRefTask={commentRefTask}>
 			{block.text}
 		</MarkdownProse>
 	);
 }
+
+// `a`-component for the thinking block's bare markdown renderer: turns the
+// comment-ref link nodes emitted by remarkCommentRefs into in-app scroll-to
+// links, and leaves any other anchor as a plain external link.
+const THINKING_COMPONENTS: Components = {
+	a: (props) => {
+		const attrs = props as {
+			'data-mention-comment-task-identifier'?: string;
+			'data-mention-comment-id'?: string;
+			'data-mention-comment-project-slug'?: string;
+			'data-mention-comment-task-title'?: string;
+			href?: string;
+		};
+		const taskIdentifier = attrs['data-mention-comment-task-identifier'];
+		const commentId = attrs['data-mention-comment-id'];
+		const projectSlug = attrs['data-mention-comment-project-slug'];
+		if (taskIdentifier && commentId && projectSlug) {
+			return (
+				<CommentRefLink
+					taskIdentifier={taskIdentifier}
+					commentId={commentId}
+					projectSlug={projectSlug}
+					taskTitle={attrs['data-mention-comment-task-title']}
+				>
+					{props.children}
+				</CommentRefLink>
+			);
+		}
+		return (
+			<a href={attrs.href} target="_blank" rel="noopener noreferrer">
+				{props.children}
+			</a>
+		);
+	},
+};
 
 // Markers (`1.`/`2.`/`•`) the server flattened onto a single line are reflowed into
 // markdown so they render as lists; the de-emphasized thinking look (small, italic,
@@ -120,8 +182,18 @@ function TextView({
 const THINKING_PROSE =
 	'text-xs italic leading-relaxed [&_ol]:list-decimal [&_ul]:list-disc [&_ol]:pl-5 [&_ul]:pl-5 [&_li]:my-0.5 [&_p]:my-1 [&_p:first-child]:mt-0 [&_p:last-child]:mb-0 [&_li]:marker:text-text-subtle';
 
-function ThinkingView({ block }: { block: ThinkingBlock }) {
+function ThinkingView({
+	block,
+	commentRefTask,
+}: {
+	block: ThinkingBlock;
+	commentRefTask?: CommentRefTask;
+}) {
 	const reflowed = useMemo(() => reflowEnumerations(block.text), [block.text]);
+	const remarkPlugins = useMemo<Parameters<typeof Markdown>[0]['remarkPlugins']>(
+		() => (commentRefTask ? [remarkGfm, [remarkCommentRefs, commentRefTask]] : [remarkGfm]),
+		[commentRefTask],
+	);
 	return (
 		<div className="border-l-2 border-border-subtle pl-3 text-text-subtle">
 			<div className="mb-0.5 flex items-center gap-1 text-[10px] uppercase tracking-wider">
@@ -129,7 +201,12 @@ function ThinkingView({ block }: { block: ThinkingBlock }) {
 				Thinking
 			</div>
 			<div className={THINKING_PROSE}>
-				<Markdown remarkPlugins={[remarkGfm]}>{reflowed}</Markdown>
+				<Markdown
+					remarkPlugins={remarkPlugins}
+					components={commentRefTask ? THINKING_COMPONENTS : undefined}
+				>
+					{reflowed}
+				</Markdown>
 			</div>
 		</div>
 	);

--- a/packages/web/src/components/log-viewer.tsx
+++ b/packages/web/src/components/log-viewer.tsx
@@ -1,6 +1,7 @@
 import * as Dialog from '@radix-ui/react-dialog';
 import { AlignLeft, Check, Code, Copy, Maximize2, Minimize2, MoveVertical } from 'lucide-react';
 import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import type { CommentRefTask } from '../lib/remark-comment-refs';
 import { FormattedLogView } from './formatted-log-view';
 import { Button } from './ui/button';
 import { Tooltip } from './ui/tooltip';
@@ -27,6 +28,11 @@ interface LogViewerProps {
 	/** Threaded to the formatted view's markdown renderer for @mention links. */
 	projectId?: string;
 	projectSlug?: string;
+	/**
+	 * Run's task. When set, bare/inline-code comment public_ids in the formatted
+	 * view link to that comment in the task thread.
+	 */
+	commentRefTask?: CommentRefTask;
 }
 
 export function LogViewer({
@@ -41,6 +47,7 @@ export function LogViewer({
 	formattable = false,
 	projectId,
 	projectSlug,
+	commentRefTask,
 }: LogViewerProps) {
 	const [autoScroll, setAutoScroll] = useState(true);
 	const [copied, setCopied] = useState(false);
@@ -188,7 +195,12 @@ export function LogViewer({
 				{lines.length === 0 ? (
 					<span className="text-text-subtle">{emptyState ?? 'No output.'}</span>
 				) : isFormatted ? (
-					<FormattedLogView lines={lines} projectId={projectId} projectSlug={projectSlug} />
+					<FormattedLogView
+						lines={lines}
+						projectId={projectId}
+						projectSlug={projectSlug}
+						commentRefTask={commentRefTask}
+					/>
 				) : (
 					lines.map((line) => (
 						<div

--- a/packages/web/src/components/markdown-prose.tsx
+++ b/packages/web/src/components/markdown-prose.tsx
@@ -7,6 +7,7 @@ import { useAgents } from '../hooks/use-agents';
 import { useDocMentions, useInstanceMentions } from '../hooks/use-mentions';
 import { useTaskMentions } from '../hooks/use-tasks';
 import { docPreviewPath } from '../lib/doc-preview';
+import { type CommentRefTask, remarkCommentRefs } from '../lib/remark-comment-refs';
 import {
 	type AgentMentionData,
 	type AssetMentionData,
@@ -18,14 +19,13 @@ import {
 	remarkMentions,
 	type TaskMentionData,
 } from '../lib/remark-mentions';
+import { CommentRefLink, MENTION_CLASSES } from './comment-ref-link';
 import { Tooltip } from './ui/tooltip';
 
 type RemarkPlugin = Parameters<typeof Markdown>[0]['remarkPlugins'];
 
 const PROSE_CLASSES =
 	'prose prose-sm max-w-none text-sm text-text [&_a]:text-accent-blue-text [&_h1]:text-text [&_h2]:text-text [&_h3]:text-text [&_h4]:text-text [&_strong]:text-text [&_code]:text-accent-blue-text [&_code]:bg-bg-muted [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded [&_pre]:bg-bg-muted [&_pre]:border [&_pre]:border-border [&_blockquote]:text-text [&_blockquote]:border-l-border-hover [&_blockquote_p]:text-text [&_p:last-child]:mb-0 [&_p:first-child]:mt-0 [&_hr]:my-6';
-
-const MENTION_CLASSES = 'font-semibold text-[1.05em] text-accent-blue-text hover:underline';
 
 interface MarkdownProseProps {
 	children: string;
@@ -40,6 +40,12 @@ interface MarkdownProseProps {
 	 * exclusive with `projectId`.
 	 */
 	instance?: boolean;
+	/**
+	 * Agent-run context: links bare/inline-code comment public_ids in the text to
+	 * the run's task comment (see remarkCommentRefs). Only set by the formatted
+	 * log view.
+	 */
+	commentRefTask?: CommentRefTask;
 }
 
 export function MarkdownProse({
@@ -49,6 +55,7 @@ export function MarkdownProse({
 	projectId,
 	projectSlug,
 	instance,
+	commentRefTask,
 }: MarkdownProseProps) {
 	const { data: agents } = useAgents(projectId ?? '');
 	const taskCandidates = useMemo(() => extractTaskCandidates(children), [children]);
@@ -148,8 +155,21 @@ export function MarkdownProse({
 				},
 			]);
 		}
+		// Comment-ref linking runs regardless of resolved @mentions — it only needs
+		// the run's task context, which the formatted log view supplies directly.
+		if (commentRefTask) plugins.push([remarkCommentRefs, commentRefTask]);
 		return plugins;
-	}, [projectId, projectSlug, instance, agentsMap, tasksMap, kbDocsMap, projectDocsMap, assetsMap]);
+	}, [
+		projectId,
+		projectSlug,
+		instance,
+		agentsMap,
+		tasksMap,
+		kbDocsMap,
+		projectDocsMap,
+		assetsMap,
+		commentRefTask,
+	]);
 
 	const components = useMemo<Components>(() => {
 		// Mention links render whenever a scope is active: project scope carries
@@ -262,22 +282,14 @@ export function MarkdownProse({
 				const commentTaskTitle = attrs['data-mention-comment-task-title'];
 				if (commentTaskIdentifier && commentId && commentProjectSlug && mentionsEnabled) {
 					return (
-						<Tooltip
-							content={`Comment in ${commentTaskIdentifier.toUpperCase()}${commentTaskTitle ? ` — ${commentTaskTitle}` : ''}`}
+						<CommentRefLink
+							taskIdentifier={commentTaskIdentifier}
+							commentId={commentId}
+							projectSlug={commentProjectSlug}
+							taskTitle={commentTaskTitle}
 						>
-							<Link
-								to="/projects/$projectId/tasks/$taskId"
-								params={{
-									projectId: commentProjectSlug,
-									taskId: commentTaskIdentifier.toLowerCase(),
-								}}
-								hash={`comment-${commentId}`}
-								className={MENTION_CLASSES}
-								data-testid="comment-mention-link"
-							>
-								{props.children}
-							</Link>
-						</Tooltip>
+							{props.children}
+						</CommentRefLink>
 					);
 				}
 

--- a/packages/web/src/components/task-detail/comments-section.tsx
+++ b/packages/web/src/components/task-detail/comments-section.tsx
@@ -395,9 +395,15 @@ export function CommentsSection({
 												{authorName}
 											</span>
 										)}
-										<span className="text-[11px] text-text-subtle">
+										<a
+											href={`#comment-${c.public_id}`}
+											onClick={jumpToComment(c.public_id)}
+											className="text-[11px] text-text-subtle hover:text-text hover:underline"
+											title="Link to this comment"
+											data-testid="comment-timestamp-link"
+										>
 											{new Date(c.created_at).toLocaleString()}
-										</span>
+										</a>
 										<div className="ml-auto flex items-center gap-2">
 											{c.parent_comment_id &&
 												(() => {

--- a/packages/web/src/lib/remark-comment-refs.ts
+++ b/packages/web/src/lib/remark-comment-refs.ts
@@ -1,0 +1,167 @@
+import { commentPath } from '@hezo/shared';
+
+/**
+ * The task an agent run is working on. A run's prose references comments on this
+ * task by their bare `public_id` (the creation-timestamp slug), so the formatted
+ * log view links those references back to the comment in this task's thread.
+ */
+export interface CommentRefTask {
+	/** Project-scoped task identifier (e.g. `TO-7`); lowercased when linked. */
+	identifier: string;
+	title: string;
+	projectSlug: string;
+}
+
+interface TextNode {
+	type: 'text';
+	value: string;
+}
+
+interface InlineCodeNode {
+	type: 'inlineCode';
+	value: string;
+}
+
+interface LinkNode {
+	type: 'link';
+	url: string;
+	title?: string | null;
+	children: TextNode[];
+	data?: { hProperties?: Record<string, string> };
+}
+
+interface ParentNode {
+	type: string;
+	children?: MdNode[];
+	value?: string;
+}
+
+type MdNode = ParentNode | TextNode | InlineCodeNode | LinkNode;
+
+// A comment's public_id is its creation timestamp `YYYYMMDDHHMMSS` (UTC) with an
+// optional `-N` suffix for same-second collisions on a task. Bare in prose, the
+// lookbehind/lookaround keep it from matching inside a longer number or a
+// hyphenated token (mirrors the shared mention regexes).
+const PUBLIC_ID_RE = /(?<![\w-])(\d{14}(?:-\d+)?)(?![\w-])/g;
+
+/**
+ * True when `value` is shape-valid as a comment public_id: 14 digits that parse
+ * as a plausible UTC timestamp, plus an optional `-N` disambiguation suffix.
+ * The timestamp sanity check is what keeps an arbitrary 14-digit number (an
+ * order id, a hash) from being mistaken for a comment reference.
+ */
+export function isCommentPublicId(value: string): boolean {
+	const m = /^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(?:-\d+)?$/.exec(value);
+	if (!m) return false;
+	const year = Number(m[1]);
+	const month = Number(m[2]);
+	const day = Number(m[3]);
+	const hour = Number(m[4]);
+	const minute = Number(m[5]);
+	const second = Number(m[6]);
+	if (year < 2000 || year > 2099) return false;
+	if (month < 1 || month > 12) return false;
+	if (day < 1 || day > 31) return false;
+	if (hour > 23 || minute > 59 || second > 59) return false;
+	return true;
+}
+
+function commentLink(publicId: string, task: CommentRefTask): LinkNode {
+	const identifier = task.identifier.toLowerCase();
+	return {
+		type: 'link',
+		url: commentPath(task.projectSlug, identifier, publicId),
+		children: [{ type: 'text', value: publicId }],
+		// Same data attributes the @mention comment link emits, so the markdown
+		// renderer's existing `a` override turns it into an in-app, scroll-to-comment
+		// link (see CommentRefLink).
+		data: {
+			hProperties: {
+				'data-mention-comment-task-identifier': identifier,
+				'data-mention-comment-id': publicId,
+				'data-mention-comment-project-slug': task.projectSlug,
+				'data-mention-comment-task-title': task.title,
+			},
+		},
+	};
+}
+
+/** Split a text node on every valid public_id, linking each occurrence. */
+function splitText(value: string, task: CommentRefTask): MdNode[] {
+	const parts: MdNode[] = [];
+	let lastIndex = 0;
+	const re = new RegExp(PUBLIC_ID_RE.source, 'g');
+	let match = re.exec(value);
+	while (match !== null) {
+		const candidate = match[1];
+		if (isCommentPublicId(candidate)) {
+			if (match.index > lastIndex) {
+				parts.push({ type: 'text', value: value.slice(lastIndex, match.index) });
+			}
+			parts.push(commentLink(candidate, task));
+			lastIndex = match.index + match[0].length;
+		}
+		match = re.exec(value);
+	}
+	if (parts.length === 0) return [{ type: 'text', value }];
+	if (lastIndex < value.length) parts.push({ type: 'text', value: value.slice(lastIndex) });
+	return parts;
+}
+
+/**
+ * When an inline-code span is *exactly* a public_id (optionally wrapped in
+ * quotes, as agents habitually write `"<public_id>"`), link it. Anything else
+ * inside backticks stays literal code — only a whole-span id is rewritten, so
+ * real code like `npm install` is never touched.
+ */
+function inlineCodeLink(value: string, task: CommentRefTask): LinkNode | null {
+	let inner = value.trim();
+	if (
+		(inner.startsWith('"') && inner.endsWith('"')) ||
+		(inner.startsWith("'") && inner.endsWith("'"))
+	) {
+		inner = inner.slice(1, -1).trim();
+	}
+	return isCommentPublicId(inner) ? commentLink(inner, task) : null;
+}
+
+// Fenced code blocks and existing links are left untouched.
+const SKIP_TYPES = new Set(['code', 'link']);
+
+function walk(parent: ParentNode, task: CommentRefTask) {
+	const children = parent.children;
+	if (!children) return;
+	const next: MdNode[] = [];
+	for (const child of children) {
+		if (child.type === 'text' && typeof (child as TextNode).value === 'string') {
+			next.push(...splitText((child as TextNode).value, task));
+			continue;
+		}
+		if (child.type === 'inlineCode' && typeof (child as InlineCodeNode).value === 'string') {
+			const link = inlineCodeLink((child as InlineCodeNode).value, task);
+			next.push(link ?? child);
+			continue;
+		}
+		if (SKIP_TYPES.has(child.type)) {
+			next.push(child);
+			continue;
+		}
+		if ((child as ParentNode).children) walk(child as ParentNode, task);
+		next.push(child);
+	}
+	parent.children = next;
+}
+
+/**
+ * Remark plugin (scoped to the agent-run formatted log view) that turns bare
+ * and inline-code comment public_ids in the run's prose into links to that
+ * comment in the run's task. Unlike the @mention pipeline — which deliberately
+ * leaves inline code literal — this view is a read-only render of an agent's
+ * reasoning, where a timestamp-shaped id is overwhelmingly a comment reference,
+ * so we link it even when the agent wrapped it in backticks.
+ */
+export function remarkCommentRefs(task: CommentRefTask) {
+	return (tree: ParentNode) => {
+		walk(tree, task);
+	};
+}

--- a/packages/web/src/routes/projects/$projectId/agents/$agentId/executions/$runId.tsx
+++ b/packages/web/src/routes/projects/$projectId/agents/$agentId/executions/$runId.tsx
@@ -238,6 +238,15 @@ function ExecutionDetailPage() {
 					formattable
 					projectId={projectId}
 					projectSlug={run.project_slug ?? undefined}
+					commentRefTask={
+						run.task_identifier
+							? {
+									identifier: run.task_identifier,
+									title: run.task_title ?? '',
+									projectSlug: run.project_slug ?? projectId,
+								}
+							: undefined
+					}
 					emptyState={
 						isActive ? getRunWaitingMessage(run.status, run.queued_reason) : 'No output captured.'
 					}

--- a/packages/web/test/comment-timestamp-permalink.test.tsx
+++ b/packages/web/test/comment-timestamp-permalink.test.tsx
@@ -1,0 +1,31 @@
+import { expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+import { seedComment, seedProject, seedTask, seedWorkspace } from './helpers/seed';
+
+test("a comment's timestamp is a permalink to that comment", async () => {
+	const seeded = { projectSlug: '', taskId: '', publicId: '' };
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Permalink Project' });
+			const task = await seedTask(ws, project, { title: 'Permalink Task' });
+			const comment = await seedComment(ws, task, 'A comment to link to');
+			seeded.projectSlug = project.slug;
+			seeded.taskId = task.identifier.toLowerCase();
+			seeded.publicId = comment.public_id;
+		},
+	});
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
+	});
+
+	// The timestamp renders as an anchor whose href is the comment's `#comment-`
+	// hash, so a right-click → "Copy link" yields the comment's permalink.
+	const link = (await findByTestId('comment-timestamp-link', undefined, {
+		timeout: 10_000,
+	})) as HTMLAnchorElement;
+	expect(link.tagName).toBe('A');
+	expect(link.getAttribute('href')).toBe(`#comment-${seeded.publicId}`);
+});

--- a/packages/web/test/remark-comment-refs.test.tsx
+++ b/packages/web/test/remark-comment-refs.test.tsx
@@ -1,0 +1,78 @@
+import { render } from '@testing-library/react';
+import Markdown from 'react-markdown';
+import { expect, test } from 'vitest';
+import { isCommentPublicId, remarkCommentRefs } from '../src/lib/remark-comment-refs';
+
+// A comment's public_id is its creation-timestamp slug (YYYYMMDDHHMMSS, UTC),
+// with an optional `-N` suffix for same-second collisions on a task.
+const PUBLIC_ID = '20260618030521';
+const TASK = { identifier: 'TO-7', title: 'Approve the spec', projectSlug: 'demo' };
+
+function renderMd(text: string) {
+	return render(<Markdown remarkPlugins={[[remarkCommentRefs, TASK]]}>{text}</Markdown>);
+}
+
+test('a bare public_id in prose links to the comment in the run task', () => {
+	const { container } = renderMd(`The admin approved at ${PUBLIC_ID} just now.`);
+	const link = container.querySelector('a[data-mention-comment-id]');
+	expect(link).not.toBeNull();
+	expect(link?.getAttribute('data-mention-comment-id')).toBe(PUBLIC_ID);
+	expect(link?.getAttribute('data-mention-comment-task-identifier')).toBe('to-7');
+	expect(link?.getAttribute('data-mention-comment-project-slug')).toBe('demo');
+	expect(link?.getAttribute('href')).toBe(`/projects/demo/tasks/to-7#comment-${PUBLIC_ID}`);
+	expect(link?.textContent).toBe(PUBLIC_ID);
+});
+
+test('a backticked public_id links — agents habitually wrap ids in inline code', () => {
+	const { container } = renderMd(`Comment \`${PUBLIC_ID}\` says approved.`);
+	const link = container.querySelector('a[data-mention-comment-id]');
+	expect(link?.getAttribute('data-mention-comment-id')).toBe(PUBLIC_ID);
+	expect(link?.getAttribute('href')).toBe(`/projects/demo/tasks/to-7#comment-${PUBLIC_ID}`);
+});
+
+test('a quoted, backticked public_id links (the `"<id>"` form)', () => {
+	const { container } = renderMd(`posted at \`"${PUBLIC_ID}"\` per the log.`);
+	expect(
+		container.querySelector('a[data-mention-comment-id]')?.getAttribute('data-mention-comment-id'),
+	).toBe(PUBLIC_ID);
+});
+
+test('a public_id with a -N disambiguation suffix still links', () => {
+	const { container } = renderMd(`see ${PUBLIC_ID}-2 here`);
+	expect(
+		container.querySelector('a[data-mention-comment-id]')?.getAttribute('data-mention-comment-id'),
+	).toBe(`${PUBLIC_ID}-2`);
+});
+
+test('a 14-digit number that is not a plausible timestamp is left untouched', () => {
+	// month 99 / day 99 — fails the timestamp sanity check.
+	const { container } = renderMd('order 20269999030521 shipped');
+	expect(container.querySelector('a[data-mention-comment-id]')).toBeNull();
+	expect(container.textContent).toContain('20269999030521');
+});
+
+test('real inline code is preserved as code, never linked', () => {
+	const { container } = renderMd('run `npm install` and `git status 20260618030521`');
+	expect(container.querySelector('a[data-mention-comment-id]')).toBeNull();
+	const codes = Array.from(container.querySelectorAll('code')).map((c) => c.textContent);
+	expect(codes).toContain('npm install');
+	// A public_id embedded inside a larger code span stays literal — only a
+	// whole-span id is rewritten.
+	expect(codes).toContain('git status 20260618030521');
+});
+
+test('a fenced code block is never rewritten', () => {
+	const { container } = renderMd(['```', PUBLIC_ID, '```'].join('\n'));
+	expect(container.querySelector('a[data-mention-comment-id]')).toBeNull();
+	expect(container.querySelector('pre')?.textContent).toContain(PUBLIC_ID);
+});
+
+test('isCommentPublicId validates the timestamp shape', () => {
+	expect(isCommentPublicId(PUBLIC_ID)).toBe(true);
+	expect(isCommentPublicId(`${PUBLIC_ID}-3`)).toBe(true);
+	expect(isCommentPublicId('20261309030521')).toBe(false); // month 13
+	expect(isCommentPublicId('20260618306021')).toBe(false); // minute 60
+	expect(isCommentPublicId('19990618030521')).toBe(false); // year < 2000
+	expect(isCommentPublicId('1234')).toBe(false);
+	expect(isCommentPublicId('not-a-number')).toBe(false);
+});

--- a/packages/web/test/run-log-comment-ref.test.tsx
+++ b/packages/web/test/run-log-comment-ref.test.tsx
@@ -1,0 +1,54 @@
+import { expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+import { seedProject, seedTask, seedWorkspace } from './helpers/seed';
+
+// A comment public_id the agent's reasoning refers to (creation-timestamp slug).
+const PUBLIC_ID = '20260618030521';
+
+const LOG_TEXT = [
+	'[session] model=claude-opus-4 tools=42',
+	`The admin approved at ${PUBLIC_ID} — proceeding to the next stage.`,
+	'[done] success turns=1 duration=500ms tokens=10/20 cost=$0.0001',
+].join('\n');
+
+test('agent-run formatted view links a comment public_id in the prose to the run task', async () => {
+	const seeded = { projectSlug: '', agentSlug: '', runId: '', taskId: '' };
+
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async (ctx) => {
+			const ws = await seedWorkspace();
+			const captain = ws.agents.find((a) => a.slug === 'captain') ?? ws.agents[0];
+			const project = await seedProject(ws, { name: 'Run Link Project' });
+			const task = await seedTask(ws, project, {
+				title: 'Approve the spec',
+				assignee_id: captain.id,
+			});
+			// A run scoped to the task: its detail response carries task_identifier /
+			// task_title / project_slug, which the page passes as the comment-ref task.
+			const run = await ctx.db.query<{ id: string }>(
+				`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at, finished_at, log_text, input_tokens, output_tokens, cost_cents)
+				 VALUES ($1, $2, $3, 'succeeded'::heartbeat_run_status, now(), now(), $4, 10, 20, 1)
+				 RETURNING id`,
+				[captain.id, ws.team.id, task.id, LOG_TEXT],
+			);
+			seeded.projectSlug = project.slug;
+			seeded.agentSlug = captain.slug;
+			seeded.runId = run.rows[0].id;
+			seeded.taskId = task.identifier.toLowerCase();
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/agents/$agentId/executions/$runId',
+		params: { projectId: seeded.projectSlug, agentId: seeded.agentSlug, runId: seeded.runId },
+	});
+
+	const link = (await findByTestId('comment-mention-link', undefined, {
+		timeout: 15_000,
+	})) as HTMLAnchorElement;
+	expect(link.getAttribute('href')).toBe(
+		`/projects/${seeded.projectSlug}/tasks/${seeded.taskId}#comment-${PUBLIC_ID}`,
+	);
+	expect(link.textContent).toBe(PUBLIC_ID);
+});


### PR DESCRIPTION
## What & why

Two related improvements to comment navigation, from the request: *"when mentioning comment in agent run the formatted view should link it to comment in task list. also, the timestamp of a comment in the comment rendered view should itself be a link to the comment so that user can right-click and copy the link."*

### 1. Agent-run formatted log view links comment references

When an agent reasons about a comment it read back from `list_comments`, it refers to the comment by its bare `public_id` (a creation-timestamp slug like `20260618030521`), often wrapped in backticks. Those references were inert text.

A run already knows the task it's working on (`task_identifier` / `project_slug`), so a timestamp-shaped id in the run's prose is now resolved against that task and rendered as an in-app, **scroll-to-comment** link — in both the main agent text and the thinking blocks.

- New `remarkCommentRefs` remark plugin (`packages/web/src/lib/remark-comment-refs.ts`) emits the **same** `data-mention-comment-*` attributes the existing `@mention` comment link uses, so it renders through the existing renderer with tooltip + hash navigation.
- **Scoped to the formatted log view only** — the shared `@mention` pipeline (server-side rendering, task comments, CEO chat) is untouched.
- **False-positive guards:** a plausible-UTC-timestamp check keeps arbitrary 14-digit numbers (order ids, hashes) from being linked; only a *whole* inline-code span that is exactly a public_id is rewritten, so real code (`` `git status` ``) stays literal; fenced code blocks are never touched.

### 2. Comment timestamps are permalinks

A comment's timestamp in the thread is now an anchor to its `#comment-<public_id>` hash. Right-click → **Copy link** yields the comment's permalink; left-click still scrolls to it (same `jumpToComment` behavior as the existing "replying to" link).

### Refactor

Extracted the comment-link rendering into a shared `CommentRefLink` component used by both the markdown renderer and the thinking-block renderer (no behavior change — the existing comment-mention test still passes).

## Tests

- `remark-comment-refs.test.tsx` — bare / backticked / quoted / `-N`-suffixed ids link; non-timestamp 14-digit numbers, real inline code, and fenced code are left alone; `isCommentPublicId` shape validation.
- `run-log-comment-ref.test.tsx` — a public_id in a run's prose renders a `comment-mention-link` with the correct `…/tasks/<id>#comment-<public_id>` href.
- `comment-timestamp-permalink.test.tsx` — the timestamp renders as an `<a>` whose href is the comment's `#comment-` hash.

All new tests pass; existing log/comment/mention suites (formatted-log-view, run-comment-formatted-log, remark-mentions-comment-link, task-comments, inbox/ceo mentions, prd-approval-linkback, and the comment-renderer suites) remain green. `turbo typecheck` and the production build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WXCQSbMKKme6NLGqySyWf2

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXCQSbMKKme6NLGqySyWf2)_