### PR TITLE
fix: keep manual retry available after repeated run failures

### DIFF
--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -299,6 +299,7 @@ tasksRoutes.get('/projects/:projectId/tasks/:taskId', async (c) => {
               WHERE hr.task_id = i.id AND hr.status IN ('running', 'queued')
             ) AS has_active_run,
             lr.status AS last_run_status,
+            lr.run_id AS last_run_id,
             lr.comment_id AS last_run_comment_id,
             lr.comment_public_id AS last_run_comment_public_id,
             CASE WHEN qw.last_skipped_reason IS NOT NULL THEN json_build_object(
@@ -330,7 +331,7 @@ tasksRoutes.get('/projects/:projectId/tasks/:taskId', async (c) => {
        LIMIT 1
      ) qw ON true
      LEFT JOIN LATERAL (
-       SELECT hr.status, hrc.id AS comment_id, hrc.public_id AS comment_public_id
+       SELECT hr.id AS run_id, hr.status, hrc.id AS comment_id, hrc.public_id AS comment_public_id
        FROM heartbeat_runs hr
        LEFT JOIN task_comments hrc
          ON hrc.task_id = hr.task_id

--- a/packages/server/test/tasks-last-run.test.ts
+++ b/packages/server/test/tasks-last-run.test.ts
@@ -17,6 +17,7 @@ interface TaskRow {
 	id: string;
 	identifier: string;
 	last_run_status: string | null;
+	last_run_id?: string | null;
 	last_run_comment_id?: string | null;
 	has_active_run: boolean;
 }
@@ -132,6 +133,15 @@ describe('task last-run fields', () => {
 		expect(detail.last_run_comment_id).toBe(commentId);
 	});
 
+	it('exposes the last run id as the retry target for a failed run', async () => {
+		const taskId = await createTask('Retryable failure');
+		const runId = await insertRun(taskId, 'failed', new Date());
+		await insertRunComment(taskId, runId);
+		const detail = await fetchDetail(taskId);
+		expect(detail.last_run_status).toBe('failed');
+		expect(detail.last_run_id).toBe(runId);
+	});
+
 	it('picks the most recent completed run when history exists', async () => {
 		const taskId = await createTask('History wins');
 		const earlier = await insertRun(taskId, 'succeeded', new Date(Date.now() - 60_000));
@@ -140,6 +150,7 @@ describe('task last-run fields', () => {
 		const laterCommentId = await insertRunComment(taskId, later);
 		const detail = await fetchDetail(taskId);
 		expect(detail.last_run_status).toBe('failed');
+		expect(detail.last_run_id).toBe(later);
 		expect(detail.last_run_comment_id).toBe(laterCommentId);
 	});
 

--- a/packages/web/src/components/task-detail/last-run-failed-banner.tsx
+++ b/packages/web/src/components/task-detail/last-run-failed-banner.tsx
@@ -1,27 +1,77 @@
-import { AlertTriangle, ChevronRight } from 'lucide-react';
+import { AlertTriangle, ChevronRight, Loader2, RotateCw } from 'lucide-react';
+import { useRetryFailedRun } from '../../hooks/use-retry-failed-run';
 import type { Task } from '../../hooks/use-tasks';
 import { jumpToComment } from './comments-section';
 
-export function LastRunFailedBanner({ task }: { task: Task }) {
+interface Props {
+	task: Task;
+	/** Route-param slug — required to wire the Retry action. */
+	projectId?: string;
+	/** Route-param slug — required to wire the Retry action. */
+	taskId?: string;
+}
+
+export function LastRunFailedBanner({ task, projectId, taskId }: Props) {
 	const failed = task.last_run_status === 'failed' || task.last_run_status === 'timed_out';
 	if (task.has_active_run || !failed || !task.last_run_comment_public_id) return null;
 
 	const commentId = task.last_run_comment_public_id;
 	return (
-		<a
-			href={`#comment-${commentId}`}
-			onClick={jumpToComment(commentId)}
-			data-testid="last-run-failed-banner"
-			className="mb-4 flex items-center gap-2 rounded-md bg-accent-red/10 px-4 py-2 text-[13px] font-medium text-red-400 hover:bg-accent-red/15 transition-colors"
+		<div className="mb-4 flex items-stretch gap-2">
+			<a
+				href={`#comment-${commentId}`}
+				onClick={jumpToComment(commentId)}
+				data-testid="last-run-failed-banner"
+				className="flex min-w-0 flex-1 items-center gap-2 rounded-md bg-accent-red/10 px-4 py-2 text-[13px] font-medium text-red-400 hover:bg-accent-red/15 transition-colors"
+			>
+				<AlertTriangle className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
+				<span className="min-w-0 truncate">
+					{task.last_run_status === 'timed_out' ? 'Last run timed out' : 'Last run failed'} — view
+					it
+				</span>
+				<span className="ml-auto flex items-center gap-1 shrink-0">
+					<span className="hidden sm:inline">Jump to run</span>
+					<ChevronRight className="w-3.5 h-3.5" />
+				</span>
+			</a>
+			{/*
+			 * The durable manual-retry path: the inline button on the `run_failed`
+			 * comment disappears once that ping is suppressed (3+ consecutive
+			 * failures), but this banner stays as long as the last run failed and
+			 * nothing is running — so retry must remain reachable here.
+			 */}
+			{projectId && taskId && task.last_run_id ? (
+				<RetryButton projectId={projectId} taskId={taskId} runId={task.last_run_id} />
+			) : null}
+		</div>
+	);
+}
+
+function RetryButton({
+	projectId,
+	taskId,
+	runId,
+}: {
+	projectId: string;
+	taskId: string;
+	runId: string;
+}) {
+	const retry = useRetryFailedRun({ projectId, taskId });
+	return (
+		<button
+			type="button"
+			onClick={() => retry.mutate(runId)}
+			disabled={retry.isPending}
+			aria-label="Retry failed run"
+			data-testid="retry-failed-run-banner"
+			className="inline-flex shrink-0 items-center gap-1 rounded-md bg-accent-red/10 px-3 text-[13px] font-medium text-red-400 hover:bg-accent-red/15 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
 		>
-			<AlertTriangle className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
-			<span className="min-w-0 truncate">
-				{task.last_run_status === 'timed_out' ? 'Last run timed out' : 'Last run failed'} — view it
-			</span>
-			<span className="ml-auto flex items-center gap-1 shrink-0">
-				<span className="hidden sm:inline">Jump to run</span>
-				<ChevronRight className="w-3.5 h-3.5" />
-			</span>
-		</a>
+			{retry.isPending ? (
+				<Loader2 className="w-3.5 h-3.5 animate-spin" />
+			) : (
+				<RotateCw className="w-3.5 h-3.5" />
+			)}
+			Retry
+		</button>
 	);
 }

--- a/packages/web/src/hooks/use-tasks.ts
+++ b/packages/web/src/hooks/use-tasks.ts
@@ -29,6 +29,8 @@ export interface Task {
 	has_active_run: boolean;
 	has_unread_admin_mention: boolean;
 	last_run_status: 'succeeded' | 'failed' | 'cancelled' | 'timed_out' | null;
+	/** Id of the last completed run — the target of a manual retry. */
+	last_run_id: string | null;
 	last_run_comment_id: string | null;
 	/** Deep-link slug for the last run's comment (`#comment-<public_id>`). */
 	last_run_comment_public_id: string | null;

--- a/packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx
@@ -90,7 +90,7 @@ function TaskDetailPage() {
 		<>
 			<div className="grid grid-cols-1 lg:grid-cols-[1fr_190px] gap-5">
 				<div className="min-w-0">
-					<LastRunFailedBanner task={task} />
+					<LastRunFailedBanner task={task} projectId={projectId} taskId={taskId} />
 					<TaskHeader task={task} projectId={projectId} taskProjectSlug={taskProjectSlug} />
 
 					<TaskSummary

--- a/packages/web/test/task-detail-failed-banner.test.tsx
+++ b/packages/web/test/task-detail-failed-banner.test.tsx
@@ -118,6 +118,62 @@ test('banner is hidden when the task has no completed runs', async () => {
 	});
 });
 
+test('banner Retry button retries the last failed run even when no run_failed comment exists', async () => {
+	// Reproduces the 3+ consecutive-failure case: the `run_failed` ping (which
+	// hosts the inline Retry button) is suppressed, so only the `run` comment
+	// remains. The banner must still expose a working manual-retry path.
+	const seeded = { projectSlug: '', taskIdentifier: '', runId: '' };
+	const retryCalls: string[] = [];
+
+	const { findByTestId, queryByTestId, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Demo' });
+			const task = await seedTask(ws, project, { title: 'Crash Loop Task' });
+			const { runId } = await insertFailedRunWithComment(ws, task, 'failed');
+			seeded.projectSlug = project.slug;
+			seeded.taskIdentifier = task.identifier.toLowerCase();
+			seeded.runId = runId;
+
+			// Intercept the retry POST so we assert on the call without driving a
+			// real container dispatch; everything else falls through to the
+			// in-process backend so the task GET returns a real `last_run_id`.
+			const passthrough = globalThis.fetch;
+			globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+				const url = typeof input === 'string' ? input : (input as Request).url;
+				const method = init?.method ?? (input instanceof Request ? input.method : 'GET');
+				const retryMatch = url.match(/\/api\/projects\/[^/]+\/tasks\/[^/]+\/runs\/([^/]+)\/retry/);
+				if (method === 'POST' && retryMatch) {
+					retryCalls.push(retryMatch[1]);
+					return new Response(JSON.stringify({ data: { dispatched: true } }), {
+						status: 200,
+						headers: { 'Content-Type': 'application/json' },
+					});
+				}
+				return passthrough(input as RequestInfo, init);
+			}) as typeof globalThis.fetch;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskIdentifier },
+	});
+
+	const retryButton = (await findByTestId('retry-failed-run-banner', undefined, {
+		timeout: 10_000,
+	})) as HTMLButtonElement;
+	// No inline run_failed retry in this scenario — the banner is the only path.
+	expect(queryByTestId('retry-failed-run')).toBeNull();
+
+	await user.click(retryButton);
+
+	await waitFor(() => {
+		expect(retryCalls).toEqual([seeded.runId]);
+	});
+});
+
 test('banner is suppressed while a retry is currently running', async () => {
 	const seeded = { projectSlug: '', taskIdentifier: '' };
 	const { findByRole, queryByTestId, router } = await renderApp({


### PR DESCRIPTION
## Problem

When an agent run fails repeatedly, you lose the ability to manually retry it.

The Retry button lived **only** on the `run_failed` system comment. But that "failure ping" is intentionally suppressed after **3 consecutive failed runs** (anti-spam in `postFailurePing`, `job-manager.ts` — `MAX_CONSECUTIVE_FAILURE_PINGS = 3`). So on the 3rd and later consecutive failures, no `run_failed` comment is posted — and with it goes the only retry affordance in the UI. A stuck task could no longer be retried by hand, which is exactly when you most want to.

## Fix

Decouple the manual-retry action from the suppressible ping by adding a **Retry button to the always-present `LastRunFailedBanner`**.

The banner is driven by the `run` comment (posted on *every* run via `createHeartbeatRun`), not the suppressible `run_failed` ping, and it already shows whenever the last completed run failed/timed out and nothing is currently running. That makes it the natural durable home for retry — available regardless of ping suppression.

The anti-spam suppression itself is **unchanged**: the thread still stops accumulating `run_failed` comments after 3 failures; only the human-facing retry path is restored.

## Changes

- **Backend** (`routes/tasks.ts`): the task-detail endpoint now returns `last_run_id` (the retry target) from the existing `lr` lateral.
- **Web** (`last-run-failed-banner.tsx`): renders a Retry button wired to the existing `POST .../runs/:runId/retry` endpoint via `useRetryFailedRun`. The banner is now a flex row holding the existing jump-to-run link plus the button (mobile-first: link truncates, button stays).
- **Type** (`use-tasks.ts`): adds `last_run_id` to `Task`.
- **Route**: passes `projectId`/`taskId` slugs to the banner.

## Tests

- **Server** (`tasks-last-run.test.ts`): asserts the detail endpoint returns `last_run_id` for the last completed run (and picks the most recent when history exists).
- **Web** (`task-detail-failed-banner.test.tsx`): with only a `run` comment seeded (no `run_failed` ping — i.e. the suppressed case), the banner exposes a Retry button that POSTs the correct run id, and the inline retry is confirmed absent.

All affected suites pass; `typecheck` and `biome check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HFmkYGynS2En4dMvBeNSHe

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFmkYGynS2En4dMvBeNSHe)_