### PR TITLE
Skills refactor: skills.sh discovery, manifest-only surfacing, admin search-and-add

### DIFF
--- a/.dev/credentials.md
+++ b/.dev/credentials.md
@@ -68,7 +68,7 @@ Subsequent agent runs (any project in the team) get the MCP injected into their 
 
 Pending and revoked connectors are excluded from the agent runtime by `loadMcpConnectionsForRun` so an agent never sees an MCP it can't authenticate against.
 
-Agent skill files (`AGENTS.md`-style markdown a provider ships alongside its MCP server) are fetched via `fetch_skill_file`, stored as `documents` of `type='mcp_skill'`, and written into the adapter's skills directory at each run start (Claude Code: `~/.claude/skills/<slug>.md`).
+Agent skill files (`AGENTS.md`-style markdown a provider ships alongside its MCP server) are fetched via `fetch_skill_file` and upserted into the instance-global `skills` catalog. Skills are surfaced to every run through the `{{skills_context}}` prompt manifest (name + slug + description, with `get_skill(slug)` to load a body on demand) — not written as files into the adapter's skills directory. The built-in `find-skills` skill is the one exception: its full body is inlined into the prompt. Agents discover new skills from the open ecosystem with the `npx skills` CLI and persist the chosen one back into the catalog via `create_skill` / `fetch_skill_file`.
 
 The egress proxy's `loadAllSecrets` calls `refreshExpiringTokens` on every outbound request — tokens within 60s of expiry refresh through their provider's registered refresh function before the substitution fires.
 

--- a/agents/_instance/skills/find-skills.md
+++ b/agents/_instance/skills/find-skills.md
@@ -1,0 +1,26 @@
+---
+name: find-skills
+description: Discover and install agent skills from the open ecosystem when no existing skill covers the task — search skills.sh with `npx skills`, then persist the chosen skill into Hezo's shared catalog so it sticks for every future run.
+---
+
+# Finding and adding skills
+
+You have a shared **skills catalog** (the manifest above) plus this discovery skill. Skills are reusable, *project-independent* know-how (e.g. "how to build with React", "how to use the Stripe API"). Project-specific knowledge belongs in a **project document** (`write_project_doc`), never here.
+
+When a task needs a capability you don't already have:
+
+1. **Check what you already have first.** Re-read the skills manifest above. If a listed skill fits, load it with `get_skill(slug)` and use it — don't go searching when you already have a match.
+
+2. **Search the open ecosystem.** If nothing fits, search skills.sh from inside the container:
+   - `npx skills find "<query>"` — search by capability (e.g. `npx skills find "react native"`).
+   - Browse https://skills.sh for the leaderboard to compare options.
+   Prefer well-adopted skills (higher install counts, reputable sources).
+
+3. **Add it to the shared catalog via the Hezo API — this is the step that makes it stick.** A local `npx skills add … -g` install lives only in *this* container and is discarded when the run ends. To make a skill permanent and available to every agent on every future run, persist it into Hezo's catalog:
+   - If you have the skill's raw `SKILL.md` URL (e.g. a GitHub raw link), call `fetch_skill_file({ url })`.
+   - Otherwise install it locally to read it (`npx skills add <owner/repo@skill> -g -y`), open the installed `SKILL.md`, and call `create_skill({ name, slug, content, tags })` with its body.
+   Re-adding the same slug updates it (idempotent).
+
+4. **That's the record.** Skills you add this way are reported automatically in this run's summary — the same place created tickets and updated docs appear — so you don't need to announce them separately. They appear in the manifest for every future run.
+
+If no suitable skill exists anywhere, do the work directly; if what you learned is reusable team know-how, capture it with `create_skill` so the next agent has it.

--- a/packages/server/migrations/009_skills_builtin.sql
+++ b/packages/server/migrations/009_skills_builtin.sql
@@ -1,0 +1,9 @@
+-- Built-in skills.
+--
+-- Some skills are shipped by Hezo itself (e.g. the seeded `find-skills`
+-- discovery skill, whose body is inlined into every run's system prompt). They
+-- are upserted by the startup reconcile (`seedBuiltins`) and marked here so the
+-- admin UI can label them and block deletion, and so the reconcile can re-own a
+-- row that was edited or removed. Agent- and admin-authored skills keep the
+-- default `false`.
+ALTER TABLE skills ADD COLUMN is_builtin BOOLEAN NOT NULL DEFAULT false;

--- a/packages/server/src/db/seed.ts
+++ b/packages/server/src/db/seed.ts
@@ -1,5 +1,9 @@
+import { createHash } from 'node:crypto';
 import type { PGlite } from '@electric-sql/pglite';
 import { AgentEffort, CEO_AGENT_SLUG, INSTANCE_AGENT_SLUGS } from '@hezo/shared';
+import { parseFrontmatter } from '../lib/frontmatter';
+import { deriveSkillSummary } from '../lib/skill-summary';
+import { toSlug } from '../lib/slug';
 import agentSummaries from './agent-summaries.json' with { type: 'json' };
 
 const summaries: {
@@ -387,4 +391,42 @@ Approval is conveyed via comment, not status. From **Review**, the ticket either
 			JSON.stringify(blankBuiltinTeamContexts),
 		],
 	);
+
+	await ensureBuiltinSkills(db, roleDocs);
+}
+
+// Skill docs shipped by Hezo, bundled under `agents/_instance/skills/` and loaded
+// by `loadAgentRoles()` keyed by their path. Upserted into the global skills
+// catalog on every boot (so existing instances pick them up and edits propagate),
+// marked `is_builtin` so the admin UI labels them and blocks deletion.
+const BUILTIN_SKILL_DOCS = ['_instance/skills/find-skills.md'];
+
+export async function ensureBuiltinSkills(
+	db: PGlite,
+	roleDocs: Record<string, string>,
+): Promise<void> {
+	for (const key of BUILTIN_SKILL_DOCS) {
+		const raw = roleDocs[key];
+		if (!raw) continue;
+		const { data, body } = parseFrontmatter(raw);
+		const fallback = key.split('/').pop()?.replace(/\.md$/, '') ?? key;
+		const slug = toSlug(data.slug || data.name || fallback);
+		const name = data.name?.trim() || slug;
+		const content = body.trim();
+		const description = data.description?.trim() || deriveSkillSummary(content);
+		const hash = createHash('sha256').update(content).digest('hex');
+		await db.query(
+			`INSERT INTO skills (name, slug, description, content, source_url, content_hash, tags, is_builtin, is_active)
+			 VALUES ($1, $2, $3, $4, NULL, $5, '["builtin"]'::jsonb, true, true)
+			 ON CONFLICT (slug) DO UPDATE SET
+			     name = EXCLUDED.name,
+			     description = EXCLUDED.description,
+			     content = EXCLUDED.content,
+			     content_hash = EXCLUDED.content_hash,
+			     is_builtin = true,
+			     is_active = true,
+			     updated_at = now()`,
+			[name, slug, description, content, hash],
+		);
+	}
 }

--- a/packages/server/src/lib/frontmatter.ts
+++ b/packages/server/src/lib/frontmatter.ts
@@ -1,0 +1,33 @@
+/**
+ * Minimal YAML-frontmatter parser for SKILL.md / skill docs.
+ *
+ * Skill frontmatter is a leading `---` fenced block of top-level `key: value`
+ * scalar pairs (`name`, `description`, occasionally `slug`/`metadata`). That is
+ * the only shape we need, so this avoids pulling a YAML dependency: it extracts
+ * top-level scalar keys and returns the remainder as `body`. Nested/structured
+ * YAML (indented children) is ignored rather than mis-parsed.
+ */
+export function parseFrontmatter(input: string): {
+	data: Record<string, string>;
+	body: string;
+} {
+	const match = /^﻿?---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*\r?\n?/.exec(input);
+	if (!match) return { data: {}, body: input };
+
+	const data: Record<string, string> = {};
+	for (const line of match[1].split(/\r?\n/)) {
+		// Only top-level `key: value` lines (no leading indent → not a nested child).
+		const m = /^([A-Za-z][\w-]*):[ \t]*(.*)$/.exec(line);
+		if (!m) continue;
+		let value = m[2].trim();
+		if (
+			value.length >= 2 &&
+			((value.startsWith('"') && value.endsWith('"')) ||
+				(value.startsWith("'") && value.endsWith("'")))
+		) {
+			value = value.slice(1, -1);
+		}
+		data[m[1]] = value;
+	}
+	return { data, body: input.slice(match[0].length) };
+}

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -126,7 +126,7 @@ const HEARTBEAT_RUN_COLUMNS = `hr.id, hr.member_id, hr.team_id, hr.wakeup_id, hr
 	-- Skills the agent added/updated directly in the skills database this run.
 	COALESCE(
 		(SELECT jsonb_agg(
-			jsonb_build_object('name', s.name, 'slug', s.slug, 'created', (s.created_at >= hr.started_at))
+			jsonb_build_object('name', s.name, 'slug', s.slug, 'source_url', s.source_url, 'created', (s.created_at >= hr.started_at))
 			ORDER BY s.updated_at ASC
 		)
 		FROM skills s

--- a/packages/server/src/routes/skills.ts
+++ b/packages/server/src/routes/skills.ts
@@ -6,6 +6,14 @@ import { deriveSkillSummary } from '../lib/skill-summary';
 import { toSlug } from '../lib/slug';
 import type { Env } from '../lib/types';
 import { requireSuperuser } from '../middleware/auth';
+import {
+	getRegistryToken,
+	hasRegistryToken,
+	installRegistrySkill,
+	SkillsRegistryError,
+	searchRegistry,
+	setRegistryToken,
+} from '../services/skills-registry';
 
 export const skillsRoutes = new Hono<Env>();
 
@@ -18,7 +26,7 @@ skillsRoutes.get('/skills', async (c) => {
 	const db = c.get('db');
 	const result = await db.query<Omit<SkillRecord, 'content'>>(
 		`SELECT id, name, slug, description, source_url, content_hash,
-		        created_by_member_id, tags, is_active, auto_load, created_at, updated_at
+		        created_by_member_id, tags, is_active, auto_load, is_builtin, created_at, updated_at
 		 FROM skills
 		 WHERE is_active = true
 		 ORDER BY name`,
@@ -70,6 +78,79 @@ skillsRoutes.post('/skills', async (c) => {
 		name: skill.name,
 	});
 	return ok(c, skill, 201);
+});
+
+// --- skills.sh registry: admin "search and add" (token-gated; agents bypass this
+// and use the `npx skills` CLI directly). Registered before /skills/:slug; the
+// two-segment paths don't collide with the single-segment slug route. ---
+
+skillsRoutes.get('/skills/registry/token', async (c) => {
+	const denied = requireSuperuser(c);
+	if (denied) return denied;
+	return ok(c, { configured: await hasRegistryToken(c.get('db')) });
+});
+
+skillsRoutes.put('/skills/registry/token', async (c) => {
+	const denied = requireSuperuser(c);
+	if (denied) return denied;
+	const key = c.get('masterKeyManager').getKey();
+	if (!key) return err(c, 'LOCKED', 'Server must be unlocked to manage the token', 401);
+	const body = await c.req.json<{ token?: string }>();
+	await setRegistryToken(c.get('db'), key, body.token ?? '');
+	return ok(c, { configured: (body.token ?? '').trim().length > 0 });
+});
+
+skillsRoutes.get('/skills/registry/search', async (c) => {
+	const denied = requireSuperuser(c);
+	if (denied) return denied;
+	const key = c.get('masterKeyManager').getKey();
+	if (!key) return err(c, 'LOCKED', 'Server must be unlocked', 401);
+	const token = await getRegistryToken(c.get('db'), key);
+	if (!token) {
+		return err(
+			c,
+			'REGISTRY_TOKEN_REQUIRED',
+			'Configure a skills.sh token to search the registry',
+			400,
+		);
+	}
+	const limit = Number.parseInt(c.req.query('limit') ?? '20', 10);
+	try {
+		return ok(c, await searchRegistry(token, c.req.query('q') ?? '', limit));
+	} catch (e) {
+		if (e instanceof SkillsRegistryError) {
+			return err(c, 'REGISTRY_ERROR', e.message, e.status >= 500 ? 503 : 400);
+		}
+		throw e;
+	}
+});
+
+skillsRoutes.post('/skills/registry/install', async (c) => {
+	const denied = requireSuperuser(c);
+	if (denied) return denied;
+	const key = c.get('masterKeyManager').getKey();
+	if (!key) return err(c, 'LOCKED', 'Server must be unlocked', 401);
+	const body = await c.req.json<{ id?: string }>();
+	if (!body.id?.trim()) return err(c, 'INVALID_REQUEST', 'id is required', 400);
+	const token = await getRegistryToken(c.get('db'), key);
+	try {
+		const skill = await installRegistrySkill(c.get('db'), body.id.trim(), token, null);
+		c.get('events').emit({
+			type: 'skill.created',
+			teamId: null,
+			actorType: 'admin',
+			actorMemberId: null,
+			skillId: skill.id,
+			slug: skill.slug,
+			name: skill.name,
+		});
+		return ok(c, skill, skill.reused ? 200 : 201);
+	} catch (e) {
+		if (e instanceof SkillsRegistryError) {
+			return err(c, 'REGISTRY_ERROR', e.message, e.status >= 500 ? 503 : 400);
+		}
+		throw e;
+	}
 });
 
 skillsRoutes.get('/skills/:slug', async (c) => {
@@ -170,21 +251,27 @@ skillsRoutes.delete('/skills/:slug', async (c) => {
 	if (denied) return denied;
 	const db = c.get('db');
 	const slug = c.req.param('slug');
-	const result = await db.query<{ id: string; name: string }>(
-		'DELETE FROM skills WHERE slug = $1 RETURNING id, name',
+	const existing = await db.query<{ id: string; name: string; is_builtin: boolean }>(
+		'SELECT id, name, is_builtin FROM skills WHERE slug = $1',
 		[slug],
 	);
-	if (result.rows.length === 0) {
+	if (existing.rows.length === 0) {
 		return err(c, 'NOT_FOUND', 'Skill not found', 404);
 	}
+	if (existing.rows[0].is_builtin) {
+		// Built-ins are re-seeded by the startup reconcile, so deletion would just
+		// reappear on next boot — block it outright instead.
+		return err(c, 'FORBIDDEN', 'Built-in skills cannot be deleted', 403);
+	}
+	await db.query('DELETE FROM skills WHERE slug = $1', [slug]);
 	c.get('events').emit({
 		type: 'skill.deleted',
 		teamId: null,
 		actorType: 'admin',
 		actorMemberId: null,
-		skillId: result.rows[0].id,
+		skillId: existing.rows[0].id,
 		slug,
-		name: result.rows[0].name,
+		name: existing.rows[0].name,
 	});
 	return c.json({ data: null }, 200);
 });

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -41,7 +41,6 @@ import {
 	updateAiProviderCredential,
 } from './ai-provider-keys';
 import { checkOverBudget, recordRunCost } from './budget';
-import { loadConnectorSkillFiles } from './connectors/lifecycle';
 import type { DockerClient, ExecLogChunk } from './docker';
 import { getAgentSystemPrompt } from './documents';
 import { applyEffortToRuntime, type EffortRuntimeApplication, resolveEffort } from './effort';
@@ -355,13 +354,11 @@ export async function buildRuntimeInvocation(
 		...(await loadMcpConnectionDescriptors(deps.db, deps.masterKeyManager)),
 	];
 
-	const skillFiles = await loadConnectorSkillFiles(deps.db);
 	const mcpInjection = adapter.build(mcpDescriptors, {
 		hostHomeDir: homeMount?.hostDir ?? null,
 		containerHomeDir: homeMount?.containerDir ?? null,
 		provider,
 		authMethod: credential.authMethod,
-		skillFiles,
 		// Kimi takes its provider credential and model from config.toml rather than
 		// env, so the adapter needs them directly (api-key auth only).
 		providerApiKey: credential.authMethod === AiAuthMethod.ApiKey ? credential.value : undefined,

--- a/packages/server/src/services/connectors/lifecycle.ts
+++ b/packages/server/src/services/connectors/lifecycle.ts
@@ -176,23 +176,6 @@ export async function getConnector(db: PGlite, connectorId: string): Promise<Con
 	return result.rows[0] ?? null;
 }
 
-/**
- * Load the global skills flagged `auto_load` (e.g. provider usage docs fetched
- * via fetch_skill_file) so the agent runner can write them into the adapter's
- * skills directory (~/.claude/skills/<slug>.md). Returns `{slug, content}`
- * pairs suitable for `McpAdapterContext.skillFiles`.
- */
-export async function loadConnectorSkillFiles(
-	db: PGlite,
-): Promise<Array<{ slug: string; content: string }>> {
-	const result = await db.query<{ slug: string; content: string }>(
-		`SELECT slug, content FROM skills
-		 WHERE auto_load = true AND is_active = true
-		 ORDER BY slug ASC`,
-	);
-	return result.rows;
-}
-
 export async function listConnectors(db: PGlite): Promise<ConnectorRow[]> {
 	const result = await db.query<ConnectorRow>(
 		`SELECT ${CONNECTOR_COLS} FROM mcp_connections ORDER BY created_at ASC`,

--- a/packages/server/src/services/mcp-injectors/claude-code.ts
+++ b/packages/server/src/services/mcp-injectors/claude-code.ts
@@ -64,23 +64,16 @@ export const claudeCodeAdapter: RuntimeMcpAdapter = {
 			cliArgs.push('--mcp-config', JSON.stringify({ mcpServers }), '--strict-mcp-config');
 		}
 
-		const files = [
-			{
-				hostPath: settingsHostPath,
-				mode: 0o600,
-				contents: settingsContents,
-			},
-			...(ctx.skillFiles ?? []).map((skill) => ({
-				hostPath: join(ctx.hostHomeDir!, 'skills', `${skill.slug}.md`),
-				mode: 0o600,
-				contents: skill.content,
-			})),
-		];
-
 		return {
 			cliArgs,
 			envEntries: [],
-			files,
+			files: [
+				{
+					hostPath: settingsHostPath,
+					mode: 0o600,
+					contents: settingsContents,
+				},
+			],
 		};
 	},
 };

--- a/packages/server/src/services/mcp-injectors/types.ts
+++ b/packages/server/src/services/mcp-injectors/types.ts
@@ -68,13 +68,6 @@ export interface McpAdapterCapabilities {
 	requiresHomeDir: boolean;
 }
 
-export interface McpSkillFile {
-	/** Filename-safe slug; renderers write `<slug>.md`. */
-	slug: string;
-	/** Skill file body (markdown). */
-	content: string;
-}
-
 export interface McpAdapterContext {
 	/** Per-run host config directory. Required when capabilities.requiresHomeDir is true. */
 	hostHomeDir: string | null;
@@ -95,10 +88,6 @@ export interface McpAdapterContext {
 	 * Defaults to api-key semantics when absent.
 	 */
 	authMethod?: AiAuthMethod;
-	/** Team-scoped agent skill files (e.g. from `fetch_skill_file`). Adapters
-	 *  write these to their conventional skills directory; Claude Code reads
-	 *  `~/.claude/skills/<slug>.md`, others use whatever convention they have. */
-	skillFiles?: readonly McpSkillFile[];
 	/**
 	 * Resolved provider API key (api-key auth only). Most runtimes receive the
 	 * credential via container env (`buildProviderEnv`); the Kimi adapter needs it

--- a/packages/server/src/services/skills-registry.ts
+++ b/packages/server/src/services/skills-registry.ts
@@ -1,0 +1,216 @@
+import { createHash } from 'node:crypto';
+import type { PGlite } from '@electric-sql/pglite';
+import { decrypt, encrypt } from '../crypto/encryption';
+import { parseFrontmatter } from '../lib/frontmatter';
+import { deriveSkillSummary } from '../lib/skill-summary';
+import { toSlug } from '../lib/slug';
+import { deleteSystemMeta, getSystemMeta, setSystemMeta } from '../lib/system-meta';
+import { downloadSkillContent, SkillDownloadError } from './skill-downloader';
+
+// The skills.sh registry (https://skills.sh) is a public, GitHub-backed catalog
+// of agent skills. Its REST API requires a bearer token, so the admin-facing
+// "search and add" UI uses a stored token; agents bypass all of this and use the
+// `npx skills` CLI directly inside the container.
+
+const REGISTRY_TOKEN_KEY = 'skills_registry_token';
+const DEFAULT_BASE_URL = 'https://skills.sh';
+const FETCH_TIMEOUT_MS = 10_000;
+const SKILL_ID_RE = /^[\w.-]+\/[\w.-]+\/[\w.-]+$/;
+
+function baseUrl(): string {
+	return (process.env.SKILLS_REGISTRY_BASE_URL || DEFAULT_BASE_URL).replace(/\/+$/, '');
+}
+
+export interface RegistrySearchHit {
+	id: string;
+	name: string;
+	source: string;
+	slug: string;
+	installs: number;
+	url: string;
+}
+
+export class SkillsRegistryError extends Error {
+	constructor(
+		message: string,
+		public readonly status: number,
+	) {
+		super(message);
+		this.name = 'SkillsRegistryError';
+	}
+}
+
+// --- token storage (encrypted in system_meta) ---
+
+export async function setRegistryToken(db: PGlite, key: Buffer, token: string): Promise<void> {
+	const trimmed = token.trim();
+	if (!trimmed) {
+		await deleteSystemMeta(db, REGISTRY_TOKEN_KEY);
+		return;
+	}
+	await setSystemMeta(db, REGISTRY_TOKEN_KEY, encrypt(trimmed, key));
+}
+
+export async function getRegistryToken(db: PGlite, key: Buffer): Promise<string | null> {
+	const stored = await getSystemMeta(db, REGISTRY_TOKEN_KEY);
+	if (!stored) return null;
+	try {
+		return decrypt(stored, key);
+	} catch {
+		return null;
+	}
+}
+
+export async function hasRegistryToken(db: PGlite): Promise<boolean> {
+	return (await getSystemMeta(db, REGISTRY_TOKEN_KEY)) !== null;
+}
+
+// --- registry HTTP ---
+
+async function registryGet(path: string, token: string | null): Promise<Response> {
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+	try {
+		return await fetch(`${baseUrl()}${path}`, {
+			headers: token ? { Authorization: `Bearer ${token}` } : {},
+			signal: controller.signal,
+		});
+	} catch (e) {
+		if ((e as Error).name === 'AbortError') {
+			throw new SkillsRegistryError('skills.sh request timed out', 504);
+		}
+		throw new SkillsRegistryError(`skills.sh request failed: ${(e as Error).message}`, 502);
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+export async function searchRegistry(
+	token: string | null,
+	query: string,
+	limit = 20,
+): Promise<RegistrySearchHit[]> {
+	const q = query.trim();
+	if (q.length < 2) {
+		throw new SkillsRegistryError('Search query must be at least 2 characters', 400);
+	}
+	const clamped = Math.min(50, Math.max(1, Math.floor(limit) || 20));
+	const res = await registryGet(
+		`/api/v1/skills/search?q=${encodeURIComponent(q)}&limit=${clamped}`,
+		token,
+	);
+	if (res.status === 401 || res.status === 403) {
+		throw new SkillsRegistryError(
+			'skills.sh rejected the request — check the configured token',
+			401,
+		);
+	}
+	if (!res.ok) {
+		throw new SkillsRegistryError(`skills.sh search failed (HTTP ${res.status})`, 502);
+	}
+	const body = (await res.json()) as { data?: Array<Record<string, unknown>> };
+	const rows = Array.isArray(body.data) ? body.data : [];
+	return rows
+		.map((d) => ({
+			id: String(d.id ?? ''),
+			name: String(d.name ?? d.slug ?? d.id ?? ''),
+			source: String(d.source ?? ''),
+			slug: String(d.slug ?? ''),
+			installs: Number(d.installs ?? 0) || 0,
+			url: String(d.url ?? ''),
+		}))
+		.filter((d) => d.id);
+}
+
+/**
+ * Fetch one skill's raw SKILL.md. Prefers the skills.sh API (needs a token), and
+ * falls back to an anonymous GitHub raw fetch when no token is configured.
+ */
+async function fetchRegistrySkillMarkdown(
+	token: string | null,
+	id: string,
+): Promise<{ markdown: string; defaultSlug: string; sourceUrl: string }> {
+	const cleanId = id.trim().replace(/^\/+|\/+$/g, '');
+	if (!SKILL_ID_RE.test(cleanId)) {
+		throw new SkillsRegistryError('Invalid skill id (expected owner/repo/skill)', 400);
+	}
+	const [owner, repo, skill] = cleanId.split('/');
+
+	if (token) {
+		const res = await registryGet(`/api/v1/skills/${cleanId}`, token);
+		if (res.status === 401 || res.status === 403) {
+			throw new SkillsRegistryError(
+				'skills.sh rejected the request — check the configured token',
+				401,
+			);
+		}
+		if (res.ok) {
+			const body = (await res.json()) as { files?: Array<{ path: string; contents: string }> };
+			const file = (body.files ?? []).find((f) => /(^|\/)SKILL\.md$/i.test(f.path));
+			if (file?.contents) {
+				return {
+					markdown: file.contents,
+					defaultSlug: skill,
+					sourceUrl: `${baseUrl()}/${cleanId}`,
+				};
+			}
+		}
+	}
+
+	// Anonymous GitHub raw fallback. The standard layout is skills/<name>/SKILL.md;
+	// the default branch is usually main, occasionally master.
+	for (const branch of ['main', 'master']) {
+		const rawUrl = `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/skills/${skill}/SKILL.md`;
+		try {
+			const { content } = await downloadSkillContent(rawUrl);
+			return { markdown: content, defaultSlug: skill, sourceUrl: rawUrl };
+		} catch (e) {
+			if (e instanceof SkillDownloadError && e.reason === 'not_found') continue;
+			throw new SkillsRegistryError(`Failed to fetch skill: ${(e as Error).message}`, 502);
+		}
+	}
+	throw new SkillsRegistryError(
+		token
+			? 'Skill not found on skills.sh or GitHub'
+			: 'Skill not found on GitHub (configure a skills.sh token for full registry access)',
+		404,
+	);
+}
+
+/**
+ * Fetch a registry skill and upsert it into the global skills catalog. Mirrors
+ * the `fetch_skill_file` MCP tool insert so a registry-installed skill surfaces
+ * in the manifest (and, when an agent triggers it, in run output via
+ * `created_by_member_id`). Idempotent on the derived slug.
+ */
+export async function installRegistrySkill(
+	db: PGlite,
+	id: string,
+	token: string | null,
+	actorMemberId: string | null,
+): Promise<{ id: string; slug: string; name: string; reused: boolean }> {
+	const { markdown, defaultSlug, sourceUrl } = await fetchRegistrySkillMarkdown(token, id);
+	const { data, body } = parseFrontmatter(markdown);
+	const content = body.trim() || markdown.trim();
+	const slug = toSlug(data.slug || defaultSlug || data.name || 'skill');
+	if (!slug) throw new SkillsRegistryError('Could not derive a slug for the skill', 400);
+	const name = data.name?.trim() || slug;
+	const description = data.description?.trim() || deriveSkillSummary(content);
+	const hash = createHash('sha256').update(content).digest('hex');
+
+	const existing = await db.query<{ id: string }>('SELECT id FROM skills WHERE slug = $1', [slug]);
+	const upserted = await db.query<{ id: string; slug: string; name: string }>(
+		`INSERT INTO skills (name, slug, description, content, source_url, content_hash, created_by_member_id, tags)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, '[]'::jsonb)
+		 ON CONFLICT (slug) DO UPDATE SET
+		     name = EXCLUDED.name,
+		     description = EXCLUDED.description,
+		     content = EXCLUDED.content,
+		     source_url = EXCLUDED.source_url,
+		     content_hash = EXCLUDED.content_hash,
+		     updated_at = now()
+		 RETURNING id, slug, name`,
+		[name, slug, description, content, sourceUrl, hash, actorMemberId],
+	);
+	return { ...upserted.rows[0], reused: existing.rows.length > 0 };
+}

--- a/packages/server/src/services/template-resolver.ts
+++ b/packages/server/src/services/template-resolver.ts
@@ -157,25 +157,37 @@ export async function resolveSystemPrompt(
 		resolved = resolved.replace(/\{\{kb_context\}\}\n?/g, '');
 	}
 
-	// Skills are injected as a manifest (name + slug + summary), not full bodies.
-	// The agent calls get_skill(slug) to load a skill's content on demand.
+	// Skills are injected as a manifest (name + slug + summary), not full bodies —
+	// the agent calls get_skill(slug) to load one on demand. The built-in
+	// `find-skills` skill is the exception: its full body is inlined below so every
+	// run carries the discovery workflow without a tool call.
 	if (resolved.includes('{{skills_context}}')) {
 		const dbSkills = await db.query<{ name: string; slug: string; description: string }>(
-			'SELECT name, slug, description FROM skills WHERE is_active = true ORDER BY name',
+			'SELECT name, slug, description FROM skills WHERE is_active = true AND is_builtin = false ORDER BY name',
 		);
-		let skillsText = 'No skills in the team skills database yet.';
+		const builtin = await db.query<{ content: string }>(
+			"SELECT content FROM skills WHERE slug = 'find-skills' AND is_active = true LIMIT 1",
+		);
+		const sections: string[] = [];
 		if (dbSkills.rows.length > 0) {
 			const lines = dbSkills.rows
 				.map((s) => `- ${s.name} (slug: ${s.slug})${s.description ? `: ${s.description}` : ''}`)
 				.join('\n');
-			skillsText = [
-				'The team skills database holds reusable know-how. Entries are listed below by name and slug.',
-				"Call get_skill(slug) to load a skill's full instructions when it is relevant to your task.",
-				'',
-				lines,
-			].join('\n');
+			sections.push(
+				[
+					'The team skills database holds reusable know-how. Entries are listed below by name and slug.',
+					"Call get_skill(slug) to load a skill's full instructions when it is relevant to your task.",
+					'',
+					lines,
+				].join('\n'),
+			);
+		} else {
+			sections.push('No skills in the team skills database yet.');
 		}
-		resolved = resolved.replace(/\{\{skills_context\}\}/g, skillsText);
+		if (builtin.rows[0]?.content?.trim()) {
+			sections.push(builtin.rows[0].content.trim());
+		}
+		resolved = resolved.replace(/\{\{skills_context\}\}/g, sections.join('\n\n'));
 	}
 
 	if (resolved.includes('{{team_preferences_context}}')) {

--- a/packages/server/test/resolve-partials.test.ts
+++ b/packages/server/test/resolve-partials.test.ts
@@ -106,9 +106,11 @@ describe('loadAgentRoles integrates resolvePartials', () => {
 		expect(architectDoc).not.toContain('No designated repo means no run.');
 		expect(architectDoc).toContain('You can run without a designated repo.');
 
-		// Every role doc picks up the no-auto-timelines guidance.
+		// Every role doc picks up the no-auto-timelines guidance. Skill docs (e.g.
+		// `_instance/skills/find-skills.md`) are not agent prompts and don't carry
+		// these behavioral partials, so exclude them.
 		const allRoleKeys = Object.keys(docs).filter(
-			(k) => !k.startsWith('_partials/') && k.endsWith('.md'),
+			(k) => !k.startsWith('_partials/') && !k.includes('/skills/') && k.endsWith('.md'),
 		);
 		expect(allRoleKeys.length).toBeGreaterThan(0);
 		for (const key of allRoleKeys) {

--- a/packages/server/test/skills-registry.test.ts
+++ b/packages/server/test/skills-registry.test.ts
@@ -1,0 +1,238 @@
+import { mkdirSync, rmSync } from 'node:fs';
+import { createServer, type Server } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { PGlite } from '@electric-sql/pglite';
+import { Hono } from 'hono';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { generateUnlockKey, MasterKeyManager } from '../src/crypto/master-key';
+import type { Env } from '../src/lib/types';
+import { signAdminJwt } from '../src/middleware/auth';
+import {
+	getRegistryToken,
+	hasRegistryToken,
+	installRegistrySkill,
+	SkillsRegistryError,
+	searchRegistry,
+	setRegistryToken,
+} from '../src/services/skills-registry';
+import { buildApp } from '../src/startup';
+import { safeClose } from './helpers';
+import { authHeader, createStubDocker } from './helpers/app';
+import { createTestDbWithMigrations } from './helpers/db';
+
+// A minimal stand-in for the skills.sh REST API. Auth-gated like the real one,
+// so the "no token" paths are exercised against a 401 rather than the internet.
+const TOKEN = 'sim-token-123';
+const SKILL_MD =
+	'---\nname: React Hooks\ndescription: Use hooks well\n---\n# React Hooks\nAlways follow the rules of hooks.';
+
+async function createSkillsSim(): Promise<{ baseUrl: string; destroy: () => Promise<void> }> {
+	const app = new Hono();
+	const authed = (h: string | undefined) => h === `Bearer ${TOKEN}`;
+
+	app.get('/api/v1/skills/search', (c) => {
+		if (!authed(c.req.header('authorization'))) return c.json({ error: 'unauthorized' }, 401);
+		return c.json({
+			data: [
+				{
+					id: 'acme/skills/react-hooks',
+					slug: 'react-hooks',
+					name: 'React Hooks',
+					source: 'acme/skills',
+					installs: 1234,
+					sourceType: 'github',
+					url: 'https://skills.sh/acme/skills/react-hooks',
+				},
+			],
+			query: c.req.query('q') ?? '',
+		});
+	});
+
+	app.get('/api/v1/skills/:owner/:repo/:skill', (c) => {
+		if (!authed(c.req.header('authorization'))) return c.json({ error: 'unauthorized' }, 401);
+		return c.json({
+			id: 'acme/skills/react-hooks',
+			source: 'acme/skills',
+			slug: 'react-hooks',
+			files: [{ path: 'SKILL.md', contents: SKILL_MD }],
+		});
+	});
+
+	const server: Server = createServer(async (req, res) => {
+		const headers = new Headers();
+		for (const [k, v] of Object.entries(req.headers)) {
+			if (v) headers.set(k, Array.isArray(v) ? v.join(', ') : v);
+		}
+		const response = await app.fetch(
+			new Request(`http://localhost${req.url}`, { method: req.method, headers }),
+		);
+		res.writeHead(response.status, Object.fromEntries(response.headers.entries()));
+		res.end(Buffer.from(await response.arrayBuffer()));
+	});
+	await new Promise<void>((resolve) => server.listen(0, resolve));
+	const addr = server.address();
+	const port = typeof addr === 'object' && addr ? addr.port : 0;
+	return {
+		baseUrl: `http://localhost:${port}`,
+		destroy: () => new Promise<void>((resolve) => server.close(() => resolve())),
+	};
+}
+
+let db: PGlite;
+let key: Buffer;
+let app: Hono<Env>;
+let adminToken: string;
+let tempDataDir: string;
+let sim: { baseUrl: string; destroy: () => Promise<void> };
+const prevBaseUrl = process.env.SKILLS_REGISTRY_BASE_URL;
+
+beforeAll(async () => {
+	tempDataDir = join(
+		tmpdir(),
+		`hezo-test-registry-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+	);
+	mkdirSync(tempDataDir, { recursive: true });
+
+	db = await createTestDbWithMigrations();
+	const mkm = new MasterKeyManager();
+	await mkm.initialize(db, generateUnlockKey());
+	const k = mkm.getKey();
+	if (!k) throw new Error('master key not available');
+	key = k;
+
+	app = buildApp(db, mkm, { dataDir: tempDataDir, webUrl: '' }, createStubDocker());
+	const userResult = await db.query<{ id: string }>(
+		"INSERT INTO users (display_name, is_superuser) VALUES ('Registry Admin', true) RETURNING id",
+	);
+	adminToken = await signAdminJwt(mkm, userResult.rows[0].id);
+
+	sim = await createSkillsSim();
+	process.env.SKILLS_REGISTRY_BASE_URL = sim.baseUrl;
+});
+
+afterAll(async () => {
+	if (prevBaseUrl === undefined) delete process.env.SKILLS_REGISTRY_BASE_URL;
+	else process.env.SKILLS_REGISTRY_BASE_URL = prevBaseUrl;
+	await sim.destroy();
+	await safeClose(db);
+	rmSync(tempDataDir, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+	await db.query('DELETE FROM skills');
+});
+
+describe('registry token storage', () => {
+	it('stores, reads, and clears the token (encrypted at rest)', async () => {
+		expect(await hasRegistryToken(db)).toBe(false);
+		await setRegistryToken(db, key, TOKEN);
+		expect(await hasRegistryToken(db)).toBe(true);
+		expect(await getRegistryToken(db, key)).toBe(TOKEN);
+
+		const raw = await db.query<{ value: string }>(
+			"SELECT value FROM system_meta WHERE key = 'skills_registry_token'",
+		);
+		expect(raw.rows[0].value).not.toContain(TOKEN);
+
+		await setRegistryToken(db, key, '   ');
+		expect(await hasRegistryToken(db)).toBe(false);
+	});
+});
+
+describe('searchRegistry', () => {
+	it('returns mapped hits with a valid token', async () => {
+		const hits = await searchRegistry(TOKEN, 'react', 5);
+		expect(hits).toHaveLength(1);
+		expect(hits[0]).toMatchObject({
+			id: 'acme/skills/react-hooks',
+			name: 'React Hooks',
+			source: 'acme/skills',
+			installs: 1234,
+		});
+	});
+
+	it('throws 401 when the token is missing', async () => {
+		await expect(searchRegistry(null, 'react')).rejects.toMatchObject({ status: 401 });
+	});
+
+	it('rejects too-short queries before calling out', async () => {
+		await expect(searchRegistry(TOKEN, 'a')).rejects.toBeInstanceOf(SkillsRegistryError);
+	});
+});
+
+describe('installRegistrySkill', () => {
+	it('fetches, strips frontmatter, and upserts a global skill (idempotent)', async () => {
+		const res = await installRegistrySkill(db, 'acme/skills/react-hooks', TOKEN, null);
+		expect(res.reused).toBe(false);
+		expect(res.slug).toBe('react-hooks');
+
+		const row = await db.query<{
+			name: string;
+			content: string;
+			description: string;
+			source_url: string;
+		}>('SELECT name, content, description, source_url FROM skills WHERE slug = $1', [res.slug]);
+		expect(row.rows[0].name).toBe('React Hooks');
+		expect(row.rows[0].description).toBe('Use hooks well');
+		expect(row.rows[0].content).toContain('Always follow the rules of hooks.');
+		expect(row.rows[0].content).not.toContain('name: React Hooks'); // frontmatter stripped
+		expect(row.rows[0].source_url).toContain('acme/skills/react-hooks');
+
+		const again = await installRegistrySkill(db, 'acme/skills/react-hooks', TOKEN, null);
+		expect(again.reused).toBe(true);
+	});
+
+	it('rejects a malformed skill id', async () => {
+		await expect(installRegistrySkill(db, 'not-an-id', TOKEN, null)).rejects.toBeInstanceOf(
+			SkillsRegistryError,
+		);
+	});
+});
+
+describe('registry routes (HTTP)', () => {
+	function req(path: string, init?: RequestInit) {
+		return app.request(`/api/skills${path}`, {
+			...init,
+			headers: {
+				...authHeader(adminToken),
+				'Content-Type': 'application/json',
+				...(init?.headers ?? {}),
+			},
+		});
+	}
+
+	it('gates search on a configured token', async () => {
+		await setRegistryToken(db, key, '');
+		const status = await req('/registry/token');
+		expect((await status.json()).data.configured).toBe(false);
+
+		const search = await req('/registry/search?q=react');
+		expect(search.status).toBe(400);
+		expect((await search.json()).error.code).toBe('REGISTRY_TOKEN_REQUIRED');
+	});
+
+	it('sets the token, then searches and installs straight from a result', async () => {
+		const put = await req('/registry/token', {
+			method: 'PUT',
+			body: JSON.stringify({ token: TOKEN }),
+		});
+		expect(put.status).toBe(200);
+		expect((await put.json()).data.configured).toBe(true);
+
+		const search = await req('/registry/search?q=react');
+		expect(search.status).toBe(200);
+		const hits = (await search.json()).data as Array<{ id: string }>;
+		expect(hits[0].id).toBe('acme/skills/react-hooks');
+
+		const install = await req('/registry/install', {
+			method: 'POST',
+			body: JSON.stringify({ id: hits[0].id }),
+		});
+		expect(install.status).toBe(201);
+
+		const list = await req('');
+		const slugs = ((await list.json()).data as Array<{ slug: string }>).map((s) => s.slug);
+		expect(slugs).toContain('react-hooks');
+	});
+});

--- a/packages/server/test/skills.test.ts
+++ b/packages/server/test/skills.test.ts
@@ -6,10 +6,9 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { generateUnlockKey, MasterKeyManager } from '../src/crypto/master-key';
 import { loadAgentRoles } from '../src/db/agent-roles';
-import { seedBuiltins } from '../src/db/seed';
+import { ensureBuiltinSkills, seedBuiltins } from '../src/db/seed';
 import type { Env } from '../src/lib/types';
 import { signAdminJwt } from '../src/middleware/auth';
-import { loadConnectorSkillFiles } from '../src/services/connectors/lifecycle';
 import { parseGitHubRawUrl, SkillDownloadError } from '../src/services/skill-downloader';
 import { resolveSystemPrompt } from '../src/services/template-resolver';
 import { buildApp } from '../src/startup';
@@ -150,18 +149,61 @@ describe('template resolver {{skills_context}} (global)', () => {
 		});
 		expect(resolved).toContain('No skills');
 	});
+
+	it('inlines the built-in find-skills body and keeps it out of the manifest list', async () => {
+		await db.query(
+			`INSERT INTO skills (name, slug, content, content_hash, is_active, is_builtin)
+			 VALUES ('find-skills', 'find-skills', '# Finding skills\nRun npx skills find.', 'h', true, true),
+			        ('React', 'react', '# React', 'h', true, false)`,
+		);
+		const resolved = await resolveSystemPrompt(db, '{{skills_context}}', {
+			teamId,
+			dataDir: tempDataDir,
+		});
+		// Built-in body is inlined in full…
+		expect(resolved).toContain('Run npx skills find.');
+		// …and not shown as a one-line manifest entry.
+		expect(resolved).not.toContain('(slug: find-skills)');
+		// Other active skills still appear in the manifest.
+		expect(resolved).toContain('- React (slug: react)');
+	});
 });
 
-describe('loadConnectorSkillFiles', () => {
-	it('returns only auto_load + active skills for run-start injection', async () => {
-		await db.query(
-			`INSERT INTO skills (name, slug, content, content_hash, auto_load, is_active)
-			 VALUES ('Provider Doc', 'provider-doc', 'usage', 'h', true, true),
-			        ('Manual Skill', 'manual-skill', 'body', 'h', false, true),
-			        ('Inactive', 'inactive', 'x', 'h', true, false)`,
+describe('ensureBuiltinSkills', () => {
+	const roleDocs = {
+		'_instance/skills/find-skills.md':
+			'---\nname: find-skills\ndescription: Discover skills\n---\n# Finding skills\nUse npx skills find.',
+	};
+
+	it('upserts the built-in skill (is_builtin, frontmatter stripped) idempotently', async () => {
+		await ensureBuiltinSkills(db, roleDocs);
+		const r1 = await db.query<{
+			name: string;
+			description: string;
+			content: string;
+			is_builtin: boolean;
+		}>("SELECT name, description, content, is_builtin FROM skills WHERE slug = 'find-skills'");
+		expect(r1.rows).toHaveLength(1);
+		expect(r1.rows[0].is_builtin).toBe(true);
+		expect(r1.rows[0].name).toBe('find-skills');
+		expect(r1.rows[0].description).toBe('Discover skills');
+		expect(r1.rows[0].content).toContain('Use npx skills find.');
+		expect(r1.rows[0].content).not.toContain('description: Discover skills');
+
+		// Re-running reconciles in place (no duplicate row).
+		await ensureBuiltinSkills(db, roleDocs);
+		const count = await db.query<{ n: number }>(
+			"SELECT COUNT(*)::int AS n FROM skills WHERE slug = 'find-skills'",
 		);
-		const files = await loadConnectorSkillFiles(db);
-		expect(files.map((f) => f.slug)).toEqual(['provider-doc']);
-		expect(files[0].content).toBe('usage');
+		expect(count.rows[0].n).toBe(1);
+	});
+
+	it('blocks deletion of a built-in skill via the API', async () => {
+		await ensureBuiltinSkills(db, roleDocs);
+		const res = await app.request('/api/skills/find-skills', {
+			method: 'DELETE',
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(403);
 	});
 });

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -575,8 +575,22 @@ export interface SkillRecord {
 	tags: string[];
 	is_active: boolean;
 	auto_load: boolean;
+	is_builtin: boolean;
 	created_at: string;
 	updated_at: string;
+}
+
+/** A search hit from the skills.sh registry (the UI "search and add" panel). */
+export interface RegistrySkillSearchResult {
+	/** Registry id, "owner/repo/skill". */
+	id: string;
+	name: string;
+	/** "owner/repo" source. */
+	source: string;
+	slug: string;
+	installs: number;
+	/** Human-facing skills.sh page URL. */
+	url: string;
 }
 
 export const AuditAction = {

--- a/packages/web/src/components/comment-renderers/run-comment.tsx
+++ b/packages/web/src/components/comment-renderers/run-comment.tsx
@@ -51,6 +51,15 @@ export function RunComment({ comment, projectId, inline }: Props) {
 	);
 }
 
+/** Short provenance hint for a created skill, e.g. "skills.sh" or "github.com". */
+function skillSourceLabel(url: string): string {
+	try {
+		return new URL(url).hostname.replace(/^www\./, '');
+	} catch {
+		return 'source';
+	}
+}
+
 function RunCommentBody({
 	projectId,
 	runId,
@@ -265,13 +274,17 @@ function RunCommentBody({
 			{createdSkills.length > 0 && (
 				<div className="flex flex-col gap-1 pt-1" data-testid="run-comment-created-skills">
 					{createdSkills.map((skill) => (
-						<Link
-							key={skill.slug}
-							to="/settings/skills"
-							className="text-xs text-accent-blue-text hover:underline self-start"
-						>
-							{skill.created ? 'Added' : 'Updated'} skill {skill.name}
-						</Link>
+						<span key={skill.slug} className="text-xs self-start">
+							<Link to="/settings/skills" className="text-accent-blue-text hover:underline">
+								{skill.created ? 'Added' : 'Updated'} skill {skill.name}
+							</Link>
+							{skill.source_url && (
+								<span className="text-text-subtle">
+									{' '}
+									· from {skillSourceLabel(skill.source_url)}
+								</span>
+							)}
+						</span>
 					))}
 				</div>
 			)}

--- a/packages/web/src/hooks/use-heartbeat-runs.ts
+++ b/packages/web/src/hooks/use-heartbeat-runs.ts
@@ -42,7 +42,7 @@ export interface HeartbeatRun {
 	run_comment_public_id: string | null;
 	created_tasks: { id: string; identifier: string; title: string; project_slug: string }[];
 	created_docs: { filename: string; project_slug: string }[];
-	created_skills: { name: string; slug: string; created: boolean }[];
+	created_skills: { name: string; slug: string; created: boolean; source_url: string | null }[];
 	proposed_skills: { name: string; slug: string }[];
 }
 

--- a/packages/web/src/hooks/use-instance-skills.ts
+++ b/packages/web/src/hooks/use-instance-skills.ts
@@ -1,4 +1,4 @@
-import type { SkillRecord } from '@hezo/shared';
+import type { RegistrySkillSearchResult, SkillRecord } from '@hezo/shared';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { api } from '../lib/api';
 import { queryClient } from '../lib/query-client';
@@ -62,6 +62,51 @@ export function useUpdateInstanceSkill() {
 export function useDeleteInstanceSkill() {
 	return useMutation({
 		mutationFn: (slug: string) => api.delete(`/api/skills/${slug}`),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: INSTANCE_SKILLS_KEY });
+		},
+	});
+}
+
+// --- skills.sh registry (admin "search and add"). Token-gated; agents bypass
+// this entirely and discover skills with the `npx skills` CLI in the container.
+
+const REGISTRY_TOKEN_KEY = [...INSTANCE_SKILLS_KEY, 'registry', 'token'] as const;
+
+export function useRegistryTokenStatus() {
+	return useQuery({
+		queryKey: REGISTRY_TOKEN_KEY,
+		queryFn: () => api.get<{ configured: boolean }>('/api/skills/registry/token'),
+	});
+}
+
+export function useSetRegistryToken() {
+	return useMutation({
+		mutationFn: (token: string) =>
+			api.put<{ configured: boolean }>('/api/skills/registry/token', { token }),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: REGISTRY_TOKEN_KEY });
+		},
+	});
+}
+
+export function useSearchRegistrySkills(query: string) {
+	const trimmed = query.trim();
+	return useQuery({
+		queryKey: [...INSTANCE_SKILLS_KEY, 'registry', 'search', trimmed],
+		queryFn: () =>
+			api.get<RegistrySkillSearchResult[]>(
+				`/api/skills/registry/search?q=${encodeURIComponent(trimmed)}`,
+			),
+		enabled: trimmed.length >= 2,
+		retry: false,
+	});
+}
+
+export function useInstallRegistrySkill() {
+	return useMutation({
+		mutationFn: (id: string) =>
+			api.post<{ slug: string; name: string }>('/api/skills/registry/install', { id }),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: INSTANCE_SKILLS_KEY });
 		},

--- a/packages/web/src/routes/settings/skills.tsx
+++ b/packages/web/src/routes/settings/skills.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { Pencil, Plus, Trash2 } from 'lucide-react';
+import { ExternalLink, Loader2, Pencil, Plus, Search, Trash2 } from 'lucide-react';
 import { useEffect, useState } from 'react';
+import { MarkdownProse } from '../../components/markdown-prose';
 import { Badge } from '../../components/ui/badge';
 import { Button } from '../../components/ui/button';
 import { InfoTooltip } from '../../components/ui/info-tooltip';
@@ -8,8 +9,12 @@ import { Input } from '../../components/ui/input';
 import {
 	useCreateInstanceSkill,
 	useDeleteInstanceSkill,
+	useInstallRegistrySkill,
 	useInstanceSkill,
 	useInstanceSkills,
+	useRegistryTokenStatus,
+	useSearchRegistrySkills,
+	useSetRegistryToken,
 	useUpdateInstanceSkill,
 } from '../../hooks/use-instance-skills';
 import { useMe } from '../../hooks/use-me';
@@ -22,11 +27,13 @@ function InstanceSkillsPage() {
 	const deleteSkill = useDeleteInstanceSkill();
 
 	const [showForm, setShowForm] = useState(false);
+	const [showSearch, setShowSearch] = useState(false);
 	// `editingSlug` null = the form (when open) creates; otherwise it edits.
 	const [editingSlug, setEditingSlug] = useState<string | null>(null);
 	const [name, setName] = useState('');
 	const [description, setDescription] = useState('');
 	const [content, setContent] = useState('');
+	const [contentMode, setContentMode] = useState<'edit' | 'preview'>('edit');
 	const [tags, setTags] = useState('');
 	const [error, setError] = useState<string | null>(null);
 
@@ -48,6 +55,7 @@ function InstanceSkillsPage() {
 		setName('');
 		setDescription('');
 		setContent('');
+		setContentMode('edit');
 		setTags('');
 		setError(null);
 	}
@@ -110,23 +118,35 @@ function InstanceSkillsPage() {
 							<h1 className="text-[22px] font-medium">Skills</h1>
 							<InfoTooltip
 								label="About skills"
-								content="Reusable skill docs shared with every team's agents (admin-authored or agent-fetched)."
+								content="Reusable, project-independent skill docs shared with every team's agents. Agents also discover new skills from skills.sh and add them here."
 								data-testid="skills-info"
 							/>
 						</div>
 						<p className="text-[13px] text-text-muted mt-1 max-w-[680px]">
-							Reusable skill docs shared with every team's agents — whether you author them here or
-							an agent fetches them via a connector.
+							Reusable skill docs shared with every team's agents — author them here, search and add
+							them from skills.sh, or let an agent fetch one while it works.
 						</p>
 					</div>
-					<Button
-						variant="secondary"
-						size="sm"
-						onClick={() => (showForm ? resetForm() : openCreate())}
-					>
-						<Plus className="w-3 h-3" /> Add
-					</Button>
+					<div className="flex items-center gap-2 shrink-0">
+						<Button
+							variant="secondary"
+							size="sm"
+							onClick={() => setShowSearch((s) => !s)}
+							data-testid="toggle-search"
+						>
+							<Search className="w-3 h-3" /> Search skills.sh
+						</Button>
+						<Button
+							variant="secondary"
+							size="sm"
+							onClick={() => (showForm ? resetForm() : openCreate())}
+						>
+							<Plus className="w-3 h-3" /> Add
+						</Button>
+					</div>
 				</div>
+
+				{showSearch && <RegistrySearch />}
 
 				{showForm && (
 					<form onSubmit={handleSubmit} className="flex flex-col gap-2 mb-4">
@@ -150,14 +170,59 @@ function InstanceSkillsPage() {
 							value={description}
 							onChange={(e) => setDescription(e.target.value)}
 						/>
-						<textarea
-							placeholder="Skill content (markdown)"
-							value={content}
-							onChange={(e) => setContent(e.target.value)}
-							required
-							rows={8}
-							className="w-full rounded-radius-md border border-border bg-bg px-3 py-2 text-[13px] font-mono focus:outline-none focus:ring-1 focus:ring-accent"
-						/>
+						<div className="flex items-center justify-between">
+							<span className="text-[13px] text-text-muted">Content (markdown)</span>
+							<div
+								role="tablist"
+								aria-label="Content view mode"
+								className="inline-flex rounded-md border border-border-subtle bg-bg-subtle p-0.5 text-xs"
+							>
+								<button
+									type="button"
+									role="tab"
+									aria-selected={contentMode === 'edit'}
+									onClick={() => setContentMode('edit')}
+									className={`px-2.5 py-1 rounded ${
+										contentMode === 'edit'
+											? 'bg-bg text-text shadow-sm'
+											: 'text-text-muted hover:text-text'
+									}`}
+								>
+									Edit
+								</button>
+								<button
+									type="button"
+									role="tab"
+									aria-selected={contentMode === 'preview'}
+									onClick={() => setContentMode('preview')}
+									className={`px-2.5 py-1 rounded ${
+										contentMode === 'preview'
+											? 'bg-bg text-text shadow-sm'
+											: 'text-text-muted hover:text-text'
+									}`}
+								>
+									Preview
+								</button>
+							</div>
+						</div>
+						{contentMode === 'edit' ? (
+							<textarea
+								aria-label="Skill content"
+								placeholder="Skill content (markdown)"
+								value={content}
+								onChange={(e) => setContent(e.target.value)}
+								required
+								rows={10}
+								className="w-full rounded-radius-md border border-border bg-bg px-3 py-2 text-[13px] font-mono focus:outline-none focus:ring-1 focus:ring-accent"
+							/>
+						) : (
+							<div
+								data-testid="skill-content-preview"
+								className="min-h-[200px] rounded-radius-md border border-border bg-bg-subtle px-3 py-2 text-sm"
+							>
+								<MarkdownProse>{content || '_(nothing to preview)_'}</MarkdownProse>
+							</div>
+						)}
 						{error && <p className="text-[13px] text-accent-red">{error}</p>}
 						<div className="flex gap-2">
 							<Button
@@ -187,6 +252,7 @@ function InstanceSkillsPage() {
 							>
 								<div className="flex items-center gap-2 min-w-0 flex-1">
 									<span className="font-medium">{s.name}</span>
+									{s.is_builtin && <Badge color="blue">built-in</Badge>}
 									{s.tags?.map((t) => (
 										<Badge key={t} color="neutral">
 											{t}
@@ -205,18 +271,20 @@ function InstanceSkillsPage() {
 									>
 										<Pencil className="w-3.5 h-3.5" />
 									</button>
-									<button
-										type="button"
-										onClick={() => {
-											if (confirm(`Delete instance skill "${s.name}"?`)) {
-												deleteSkill.mutate(s.slug);
-											}
-										}}
-										aria-label={`Delete ${s.name}`}
-										className="text-text-subtle hover:text-accent-red"
-									>
-										<Trash2 className="w-3.5 h-3.5" />
-									</button>
+									{!s.is_builtin && (
+										<button
+											type="button"
+											onClick={() => {
+												if (confirm(`Delete instance skill "${s.name}"?`)) {
+													deleteSkill.mutate(s.slug);
+												}
+											}}
+											aria-label={`Delete ${s.name}`}
+											className="text-text-subtle hover:text-accent-red"
+										>
+											<Trash2 className="w-3.5 h-3.5" />
+										</button>
+									)}
 								</span>
 							</div>
 						))}
@@ -227,6 +295,154 @@ function InstanceSkillsPage() {
 
 	return (
 		<div className="max-w-[900px] w-full px-4 py-4 md:px-6 md:py-5 lg:px-8 lg:py-6">{content_}</div>
+	);
+}
+
+/**
+ * Search skills.sh and add a result straight into the instance catalog. The
+ * registry API needs a bearer token, so this panel is gated on a configured
+ * token (agents don't need it — they use the `npx skills` CLI in the container).
+ */
+function RegistrySearch() {
+	const { data: tokenStatus } = useRegistryTokenStatus();
+	const setToken = useSetRegistryToken();
+	const installSkill = useInstallRegistrySkill();
+
+	const [tokenInput, setTokenInput] = useState('');
+	const [queryInput, setQueryInput] = useState('');
+	const [submitted, setSubmitted] = useState('');
+	const [installingId, setInstallingId] = useState<string | null>(null);
+
+	const search = useSearchRegistrySkills(submitted);
+	const configured = tokenStatus?.configured ?? false;
+
+	async function handleInstall(id: string) {
+		setInstallingId(id);
+		try {
+			await installSkill.mutateAsync(id);
+		} finally {
+			setInstallingId(null);
+		}
+	}
+
+	return (
+		<div className="mb-4 rounded-radius-md border border-border bg-bg-subtle p-3">
+			{!configured ? (
+				<div className="flex flex-col gap-2">
+					<p className="text-[13px] text-text-muted">
+						Searching skills.sh needs a skills.sh API token. Paste one to enable search and add.
+						Agents discover skills without it (via the <code>npx skills</code> CLI).
+					</p>
+					<div className="flex flex-col sm:flex-row gap-2">
+						<Input
+							type="password"
+							placeholder="skills.sh API token"
+							value={tokenInput}
+							onChange={(e) => setTokenInput(e.target.value)}
+							className="flex-1"
+							aria-label="skills.sh API token"
+						/>
+						<Button
+							size="sm"
+							disabled={!tokenInput.trim() || setToken.isPending}
+							onClick={() =>
+								setToken.mutate(tokenInput.trim(), { onSuccess: () => setTokenInput('') })
+							}
+						>
+							Save token
+						</Button>
+					</div>
+				</div>
+			) : (
+				<div className="flex flex-col gap-2">
+					<form
+						className="flex gap-2"
+						onSubmit={(e) => {
+							e.preventDefault();
+							setSubmitted(queryInput.trim());
+						}}
+					>
+						<Input
+							placeholder="Search skills.sh (e.g. react, stripe, playwright)"
+							value={queryInput}
+							onChange={(e) => setQueryInput(e.target.value)}
+							className="flex-1"
+							aria-label="Search skills.sh"
+						/>
+						<Button type="submit" size="sm" disabled={queryInput.trim().length < 2}>
+							<Search className="w-3 h-3" /> Search
+						</Button>
+						<Button
+							type="button"
+							variant="ghost"
+							size="sm"
+							onClick={() => setToken.mutate('')}
+							title="Clear the stored token"
+						>
+							Clear token
+						</Button>
+					</form>
+
+					{search.isFetching && (
+						<div className="flex items-center gap-1.5 text-[13px] text-text-muted">
+							<Loader2 className="w-3.5 h-3.5 animate-spin" /> Searching…
+						</div>
+					)}
+					{search.error && (
+						<p className="text-[13px] text-accent-red">
+							{(search.error as { message?: string }).message ?? 'Search failed'}
+						</p>
+					)}
+					{search.data?.length === 0 && !search.isFetching && submitted && (
+						<p className="text-[13px] text-text-muted">No results for “{submitted}”.</p>
+					)}
+					{search.data && search.data.length > 0 && (
+						<div className="flex flex-col gap-1">
+							{search.data.map((r) => (
+								<div
+									key={r.id}
+									className="flex items-center justify-between gap-2 rounded-radius-md border border-border bg-bg px-3 py-2 text-[13px]"
+								>
+									<div className="min-w-0 flex-1">
+										<div className="flex items-center gap-2">
+											<span className="font-medium truncate">{r.name}</span>
+											{r.url && (
+												<a
+													href={r.url}
+													target="_blank"
+													rel="noopener noreferrer"
+													className="text-text-subtle hover:text-text"
+													aria-label={`Open ${r.name} on skills.sh`}
+												>
+													<ExternalLink className="w-3 h-3" />
+												</a>
+											)}
+										</div>
+										<div className="text-xs text-text-subtle truncate">
+											{r.source}
+											{r.installs > 0 && ` · ${r.installs.toLocaleString()} installs`}
+										</div>
+									</div>
+									<Button
+										size="sm"
+										variant="secondary"
+										disabled={installSkill.isPending && installingId === r.id}
+										onClick={() => handleInstall(r.id)}
+									>
+										{installSkill.isPending && installingId === r.id ? (
+											<Loader2 className="w-3 h-3 animate-spin" />
+										) : (
+											<Plus className="w-3 h-3" />
+										)}
+										Add
+									</Button>
+								</div>
+							))}
+						</div>
+					)}
+				</div>
+			)}
+		</div>
 	);
 }
 

--- a/packages/web/test/settings-skills.test.tsx
+++ b/packages/web/test/settings-skills.test.tsx
@@ -1,0 +1,33 @@
+import { expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+
+test('built-in skills show a badge and cannot be deleted (but can be edited)', async () => {
+	const r = await renderApp({ initialPath: '/settings/skills' });
+
+	// The seeded find-skills built-in appears in the list…
+	await r.findByText('find-skills');
+	expect(await r.findByText('built-in')).toBeTruthy();
+	// …with no delete affordance, but an edit one.
+	expect(r.queryByLabelText('Delete find-skills')).toBeNull();
+	expect(r.queryByLabelText('Edit find-skills')).not.toBeNull();
+});
+
+test('the skill content editor previews markdown', async () => {
+	const r = await renderApp({ initialPath: '/settings/skills' });
+
+	await r.user.click(await r.findByRole('button', { name: 'Add' }));
+	const content = await r.findByLabelText('Skill content');
+	await r.user.type(content, '# Hello heading');
+
+	await r.user.click(await r.findByRole('tab', { name: 'Preview' }));
+	const preview = await r.findByTestId('skill-content-preview');
+	expect(preview.querySelector('h1')?.textContent).toContain('Hello heading');
+});
+
+test('the skills.sh search panel is gated on a configured token', async () => {
+	const r = await renderApp({ initialPath: '/settings/skills' });
+
+	await r.user.click(await r.findByTestId('toggle-search'));
+	// No token configured for a fresh instance → prompts for one instead of searching.
+	expect(await r.findByLabelText('skills.sh API token')).toBeTruthy();
+});


### PR DESCRIPTION
## What & why

Refactors the instance-global skills system around three goals: a clear split between **project-specific knowledge** (project documents) and **general, reusable skills** (the global catalog), an **agent discovery loop**, and a **better admin UI**. Builds on the existing `skills` table, `/api/skills` CRUD, and the MCP tools rather than recreating them.

## Decisions (confirmed with the requester)

- **Surfacing = manifest only.** Skills reach every runtime uniformly via the existing `{{skills_context}}` prompt manifest + `get_skill(slug)`. The previous Claude-only flat-file install (`~/.claude/skills/<slug>.md`) was the wrong native format and is removed, along with the `auto_load`-gated `loadConnectorSkillFiles` path. The built-in `find-skills` skill is the one exception — its **full body is inlined** into every run prompt.
- **Discovery via `npx skills`.** A built-in, reconciled `find-skills` skill instructs agents to search the open ecosystem with the `npx skills` CLI (anonymous, GitHub-backed) and then **persist** the chosen skill into Hezo's catalog via `create_skill` / `fetch_skill_file` — so it appears in run output and is available to every future run (a bare `npx skills add -g` dies with the ephemeral container).
- **Project-specific skills reuse project documents** — no new table.
- **skills.sh token is UI-only.** The registry REST API needs a bearer token; agents never do. It's optional and stored encrypted in `system_meta`.

## Changes

**Server**
- Remove the file-install path: `loadConnectorSkillFiles`, `McpSkillFile`/`skillFiles`, the claude-code adapter skill write, and the `agent-runner` wiring.
- `template-resolver`: exclude `find-skills` from the manifest list and inline its full body.
- New `services/skills-registry.ts` (search + install with a GitHub-raw fallback) and superuser routes under `/api/skills/registry` (`search`, `install`, `token` get/set), gated on the optional token.
- Built-in `find-skills` skill: source at `agents/_instance/skills/find-skills.md`, reconciled idempotently every boot via `ensureBuiltinSkills` (marked `is_builtin`); deletion blocked in the API.
- `created_skills` run output now carries `source_url` for provenance.
- New `lib/frontmatter.ts` (minimal YAML-frontmatter parser; no new dependency).
- Migration `009_skills_builtin.sql` adds `skills.is_builtin`.

**Web**
- `/settings/skills`: markdown **edit/preview** editor, a **built-in** badge with delete disabled, and a **"Search skills.sh"** panel that adds straight from results (with a token-config prompt when unset).
- Run-comment renderer shows the skill source (e.g. "from skills.sh").

## Tests
- Server: registry service + HTTP routes against a simulated skills.sh, built-in seeding/idempotency + delete-block, inlined-manifest behavior.
- Web: editor markdown preview, built-in handling, token-gated search panel.
- Migration `009` exercised by the migrate suite.

Full non-browser suite is green except pre-existing **environmental** failures in `git.test.ts` / `ssh-agent-server.test.ts` (this sandbox's commit-signer rejects commits and `ssh-keygen` isn't installed) — unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019hxCWYcdi2tTHsjyfeDyiN

---
_Generated by [Claude Code](https://claude.ai/code/session_019hxCWYcdi2tTHsjyfeDyiN)_