### PR TITLE
fix(runs): require produced output for a run to count as success

### DIFF
--- a/.dev/egress.md
+++ b/.dev/egress.md
@@ -34,6 +34,8 @@ For a CONNECT, the proxy looks up (or builds) a **per-host `https.Server`** keye
 
 Per-host servers are keyed **by hostname → live server object**, not by a cached bare port. Before reuse the proxy checks the server still owns its recorded port (`server.listening && server.address().port === recordedPort`); a server that has died or lost its port is rebuilt on the next tunnel. This makes the historical failure mode — a hostname routed to an ephemeral port that has since died (ECONNREFUSED) or been recycled to another host's server (cross-host wrong-SAN cert) — structurally impossible: the hostname never routes through a port that isn't currently owned by that host's live server. Concurrent first-touches for the same host share one in-flight build so a run never spins up duplicate servers.
 
+The ownership check and the loopback dial must be **atomic**. The bridge (`bridgeConnect`) re-validates `serverOwnsPort` synchronously and rebuilds a stale record, then calls `net.connect` with **no further `await`** before the dial — so a per-host server that dies after lookup cannot have its freed ephemeral port recycled to another host's server between the check and the connect. Re-checking only at lookup time (with an `await` separating it from the dial) leaves a check→dial window that re-opens the cross-host wrong-SAN serving the per-host keying is meant to close.
+
 ## Container wiring
 
 At project provision the CA cert is bind-mounted into the container at `/usr/local/share/ca-certificates/hezo-egress.crt` and `update-ca-certificates` runs once so the system trust bundle (`/etc/ssl/certs/ca-certificates.crt`) includes it. That covers Python `ssl.create_default_context()`, Go's default cert pool, Ruby Net::HTTP, PHP cURL, etc.

--- a/packages/server/migrations/009_heartbeat_run_produced_output.sql
+++ b/packages/server/migrations/009_heartbeat_run_produced_output.sql
@@ -1,0 +1,13 @@
+-- 009_heartbeat_run_produced_output.sql
+-- Record whether an agent run produced any persisted output. A run only counts
+-- as a useful success if it wrote something — code changes in the task worktree,
+-- or a Hezo write (comment, task, document, blocker, reaction, credential
+-- request, …). Exit code 0 alone is not enough: a model that drifts into plan
+-- mode can exit cleanly having only described a plan, which previously read as a
+-- green "succeeded" while nothing actually happened.
+--
+-- The flag is set to true mid-run by the MCP tool layer (on any write tool) and
+-- by a post-run worktree diff. The run-completion path treats exit-0-but-false
+-- as a failure so the no-op surfaces instead of masquerading as success.
+
+ALTER TABLE heartbeat_runs ADD COLUMN produced_output BOOLEAN NOT NULL DEFAULT false;

--- a/packages/server/migrations/010_heartbeat_run_produced_output.sql
+++ b/packages/server/migrations/010_heartbeat_run_produced_output.sql
@@ -1,4 +1,4 @@
--- 009_heartbeat_run_produced_output.sql
+-- 010_heartbeat_run_produced_output.sql
 -- Record whether an agent run produced any persisted output. A run only counts
 -- as a useful success if it wrote something — code changes in the task worktree,
 -- or a Hezo write (comment, task, document, blocker, reaction, credential

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -99,6 +99,51 @@ export interface ToolDef {
 
 const registeredTools: ToolDef[] = [];
 
+// Tools that persist data. When an agent run invokes one of these and it
+// succeeds, the run has produced output — recorded on the run row so the
+// completion path can distinguish a useful run from a no-op that merely exited
+// cleanly. Read-only tools (list_*/get_*/read_*/semantic_search/test_connector)
+// and run-local fetches (fetch_skill_file) are excluded.
+const MCP_WRITE_TOOLS: ReadonlySet<string> = new Set([
+	'create_team',
+	'create_task',
+	'create_tasks',
+	'update_task',
+	'add_task_blocker',
+	'remove_task_blocker',
+	'update_hire_proposal',
+	'update_project_creation_proposal',
+	'add_reaction',
+	'remove_reaction',
+	'create_comment',
+	'request_credential',
+	'register_connector',
+	'resolve_approval',
+	'update_agent_system_prompt',
+	'set_agent_summary',
+	'set_team_summary',
+	'set_agent_team_context',
+	'write_project_asset',
+	'write_project_doc',
+	'propose_skill',
+	'create_skill',
+	'add_mcp_connection',
+	'remove_mcp_connection',
+]);
+
+/** A handler result that signals failure rather than a persisted write. */
+function isErrorResult(result: unknown): boolean {
+	return typeof result === 'object' && result !== null && 'error' in result;
+}
+
+/** Flag an agent run as having produced output. Idempotent and self-contained. */
+async function markRunProducedOutput(db: PGlite, runId: string): Promise<void> {
+	await db.query(
+		'UPDATE heartbeat_runs SET produced_output = true WHERE id = $1 AND produced_output = false',
+		[runId],
+	);
+}
+
 // Qualified-column variant of services/tasks.ts TASK_COLUMNS_BARE — prefixes
 // every column with the `i.` alias for SELECT ... FROM tasks i JOIN ...
 // patterns.
@@ -206,6 +251,14 @@ function tool(
 			};
 		}
 		const result = await handler(args, db, auth);
+		if (
+			auth.type === AuthType.Agent &&
+			auth.runId &&
+			MCP_WRITE_TOOLS.has(name) &&
+			!isErrorResult(result)
+		) {
+			await markRunProducedOutput(db, auth.runId);
+		}
 		const text = JSON.stringify(result, null, 2);
 		const sizeBytes = Buffer.byteLength(text, 'utf8');
 		if (sizeBytes > MCP_RESULT_BYTE_LIMIT) {

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -45,7 +45,13 @@ import type { DockerClient, ExecLogChunk } from './docker';
 import { getAgentSystemPrompt } from './documents';
 import { applyEffortToRuntime, type EffortRuntimeApplication, resolveEffort } from './effort';
 import type { EgressProxy } from './egress';
-import { ensureGithubKnownHosts, ensureTaskWorktree, fetchRepo } from './git';
+import {
+	ensureGithubKnownHosts,
+	ensureTaskWorktree,
+	fetchRepo,
+	getWorktreeHead,
+	worktreeHasChanges,
+} from './git';
 import { buildGitIdentityEnv } from './git-identity';
 import type { LogStreamBroker } from './log-stream-broker';
 import { loadMcpConnectionDescriptors } from './mcp-connections';
@@ -968,7 +974,30 @@ export async function runAgent(
 			if (tail) emit('stdout', tail);
 			const execInfo = await deps.docker.execInspect(execId);
 			const durationMs = Date.now() - startTime;
-			const success = execInfo.ExitCode === 0;
+			const exitedClean = execInfo.ExitCode === 0;
+
+			// A clean exit is only a real success if the run produced persisted
+			// output: a Hezo write (comment/task/doc/blocker/…, flagged on the run
+			// row by the MCP tool layer) or a code change in a worktree. A run that
+			// exits 0 having written nothing — e.g. a model that drifts into plan
+			// mode and only describes a plan — is a no-op, not a success, and is
+			// marked failed so it surfaces and is retried rather than silently
+			// counting as servicing the task.
+			let producedOutput = false;
+			if (exitedClean) {
+				const flagged = await deps.db.query<{ produced_output: boolean }>(
+					'SELECT produced_output FROM heartbeat_runs WHERE id = $1',
+					[heartbeatRunId],
+				);
+				producedOutput =
+					(flagged.rows[0]?.produced_output ?? false) || (await anyWorktreeChanged(prep.worktrees));
+			}
+			const success = exitedClean && producedOutput;
+			const noOutputError =
+				exitedClean && !producedOutput
+					? 'run produced no output (no code changes, comments, tasks, documents, or other writes)'
+					: undefined;
+			if (noOutputError) emit('stderr', `\n[runner] ${noOutputError}\n`);
 
 			await deps.logs.end(streamId);
 			await updateHeartbeatRun(
@@ -978,6 +1007,7 @@ export async function runAgent(
 					status: success ? HeartbeatRunStatus.Succeeded : HeartbeatRunStatus.Failed,
 					exitCode: execInfo.ExitCode,
 					durationMs,
+					error: noOutputError,
 					usage: parser.getUsage(),
 				},
 				runBroadcast,
@@ -1057,13 +1087,26 @@ function withProjectGitLock<T>(projectId: string, fn: () => Promise<T>): Promise
 	return run;
 }
 
+interface WorktreeRef {
+	path: string;
+	headBefore: string | null;
+}
+
+/** Whether any of a run's worktrees has an uncommitted change or an advanced branch tip. */
+async function anyWorktreeChanged(worktrees: WorktreeRef[]): Promise<boolean> {
+	for (const wt of worktrees) {
+		if (await worktreeHasChanges(wt.path, wt.headBefore)) return true;
+	}
+	return false;
+}
+
 async function prepareWorktrees(
 	deps: RunnerDeps,
 	project: ProjectInfo,
 	task: TaskInfo,
 	emit: (stream: 'stdout' | 'stderr', text: string) => void,
 	signal?: AbortSignal,
-): Promise<{ workingDir: string; designatedRepo: RepoRow | null }> {
+): Promise<{ workingDir: string; designatedRepo: RepoRow | null; worktrees: WorktreeRef[] }> {
 	const emitSystem = (stream: 'stdout' | 'stderr', text: string) =>
 		emit(stream, `[system] ${text}\n`);
 
@@ -1075,7 +1118,7 @@ async function prepareWorktrees(
 
 	if (repos.rows.length === 0) {
 		emitSystem('stdout', '(no repos linked to project — running in /workspace)');
-		return { workingDir: '/workspace', designatedRepo: null };
+		return { workingDir: '/workspace', designatedRepo: null, worktrees: [] };
 	}
 
 	return withProjectGitLock(project.id, async () => {
@@ -1095,7 +1138,7 @@ async function prepareWorktrees(
 			emitSystem('stdout', `(cloned ${syncRes.cloned.length} repo(s) on demand)`);
 		}
 
-		if (signal?.aborted) return { workingDir: '/workspace', designatedRepo: null };
+		if (signal?.aborted) return { workingDir: '/workspace', designatedRepo: null, worktrees: [] };
 
 		const workspaceRoot = getWorkspacePath(deps.dataDir, project.team_id, project.id);
 		const worktreesRoot = getWorktreesPath(deps.dataDir, project.team_id, project.id);
@@ -1156,7 +1199,7 @@ async function prepareWorktrees(
 			}
 		}
 
-		if (signal?.aborted) return { workingDir: '/workspace', designatedRepo: null };
+		if (signal?.aborted) return { workingDir: '/workspace', designatedRepo: null, worktrees: [] };
 
 		const designated = project.designated_repo_id
 			? repos.rows.find((r) => r.id === project.designated_repo_id)
@@ -1173,7 +1216,17 @@ async function prepareWorktrees(
 
 		const workingDir = `/worktrees/${task.identifier}/${primaryName}`;
 
-		return { workingDir, designatedRepo: primary ?? null };
+		// Capture each prepared worktree's host path and pre-run commit so the
+		// completion path can detect whether the run produced any code change.
+		const worktrees: WorktreeRef[] = [];
+		for (const repo of repos.rows) {
+			if (worktreeErrors.has(repo.id)) continue;
+			const worktreePath = join(taskWorktreeRoot, repoNameFromIdentifier(repo.repo_identifier));
+			if (!existsSync(join(worktreePath, '.git'))) continue;
+			worktrees.push({ path: worktreePath, headBefore: await getWorktreeHead(worktreePath) });
+		}
+
+		return { workingDir, designatedRepo: primary ?? null, worktrees };
 	});
 }
 

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -381,6 +381,7 @@ export async function buildRuntimeInvocation(
 		`HEZO_API_URL=http://host.docker.internal:${deps.serverPort}/agent-api`,
 		`HEZO_AGENT_TOKEN=${agentJwt}`,
 		`HEZO_AGENT_ID=${agentId}`,
+		`HEZO_HEARTBEAT_RUN_ID=${resourceId}`,
 		`HEZO_TEAM_ID=${runTeamId}`,
 		`HEZO_AGENT_EFFORT=${effort}`,
 		`HEZO_PROMPT_FILE=${promptContainerPath}`,

--- a/packages/server/src/services/egress/proxy.ts
+++ b/packages/server/src/services/egress/proxy.ts
@@ -79,6 +79,9 @@ export interface AllocatedRunProxy {
 	proxyPort: number;
 }
 
+/** How many ports to try binding before giving up allocating a run's proxy. */
+const EGRESS_BIND_ATTEMPTS = 5;
+
 export class EgressProxy {
 	private readonly runs = new Map<string, RunProxyInstance>();
 	private readonly portAllocator: PortAllocator;
@@ -113,31 +116,60 @@ export class EgressProxy {
 		if (this.runs.has(runId)) {
 			throw new Error(`Egress proxy already allocated for run ${runId}`);
 		}
-		const port = await this.portAllocator.allocate(scope.agentId);
 
-		const instance = new RunProxyInstance({
-			runId,
-			scope,
-			port,
-			bindHost: this.proxyBindHost,
-			db: this.deps.db,
-			masterKeyManager: this.deps.masterKeyManager,
-			getMintCa: () => this.getMintCa(),
-			upstreamHttpsAgent: this.upstreamHttpsAgent,
-		});
-
+		// Allocate-and-bind with a few attempts. A candidate can pass the
+		// allocator's free-probe yet lose the race to bind — another run, a
+		// parallel test process, or an external listener grabs it in the window
+		// between probe and listen. Keep each failed port reserved so the next
+		// attempt lands on a different one, then release the losers once we've
+		// bound (or all of them if every attempt fails).
+		const reserved: number[] = [];
+		let lastReason = 'no bindable port in egress range';
 		try {
-			await instance.listen();
+			for (let attempt = 0; attempt < EGRESS_BIND_ATTEMPTS; attempt++) {
+				const port = await this.portAllocator.allocate(scope.agentId);
+				reserved.push(port);
+
+				const instance = new RunProxyInstance({
+					runId,
+					scope,
+					port,
+					bindHost: this.proxyBindHost,
+					db: this.deps.db,
+					masterKeyManager: this.deps.masterKeyManager,
+					getMintCa: () => this.getMintCa(),
+					upstreamHttpsAgent: this.upstreamHttpsAgent,
+				});
+
+				try {
+					await instance.listen();
+				} catch (e) {
+					lastReason = (e as Error).message;
+					log.warn('egress proxy bind lost a race; retrying on another port', {
+						run: ref(scope.label, runId),
+						port,
+						reason: lastReason,
+					});
+					continue;
+				}
+
+				this.runs.set(runId, instance);
+				for (const p of reserved) {
+					if (p !== port) this.portAllocator.release(p);
+				}
+				log.debug('egress proxy allocated', { run: ref(scope.label, runId), port });
+				return { proxyHost: this.proxyHost, proxyPort: port };
+			}
 		} catch (e) {
-			this.portAllocator.release(port);
-			const reason = (e as Error).message;
-			log.warn('egress proxy unavailable for run', { run: ref(scope.label, runId), reason });
-			throw new EgressProxyUnavailableError(reason);
+			lastReason = (e as Error).message;
 		}
 
-		this.runs.set(runId, instance);
-		log.debug('egress proxy allocated', { run: ref(scope.label, runId), port });
-		return { proxyHost: this.proxyHost, proxyPort: port };
+		for (const p of reserved) this.portAllocator.release(p);
+		log.warn('egress proxy unavailable for run', {
+			run: ref(scope.label, runId),
+			reason: lastReason,
+		});
+		throw new EgressProxyUnavailableError(lastReason);
 	}
 
 	async releaseRunProxy(runId: string): Promise<void> {

--- a/packages/server/src/services/egress/proxy.ts
+++ b/packages/server/src/services/egress/proxy.ts
@@ -305,32 +305,42 @@ class RunProxyInstance {
 		client.on('error', () => client.destroy());
 		client.pause();
 
-		this.ensureHostServer(host)
-			.then((rec) => {
-				if (this.closed) {
-					client.destroy();
-					return;
-				}
-				const up = netConnect({ host: '127.0.0.1', port: rec.port }, () => {
-					this.trackSocket(up);
-					client.write('HTTP/1.1 200 Connection Established\r\n\r\n');
-					if (head?.length) up.write(head);
-					client.pipe(up);
-					up.pipe(client);
-					client.resume();
-				});
-				up.on('error', () => client.destroy());
-				up.on('close', () => client.destroy());
-				client.on('close', () => up.destroy());
-			})
-			.catch((e: Error) => {
-				log.warn('egress CONNECT setup failed', {
-					run: ref(this.cfg.scope.label, this.cfg.runId),
-					host,
-					error: e.message,
-				});
-				client.destroy();
+		this.bridgeConnect(host, client, head).catch((e: Error) => {
+			log.warn('egress CONNECT setup failed', {
+				run: ref(this.cfg.scope.label, this.cfg.runId),
+				host,
+				error: e.message,
 			});
+			client.destroy();
+		});
+	}
+
+	/** Bridge a CONNECT tunnel into the host's per-host TLS server. The dial
+	 * re-validates port ownership synchronously and rebuilds a stale server,
+	 * then connects with no further `await` — only synchronous code separates the
+	 * ownership check from the `netConnect`, so a concurrently-built server can
+	 * never recycle the freed ephemeral port in between and route the tunnel to
+	 * another host's leaf cert. */
+	private async bridgeConnect(host: string, client: Socket, head: Buffer): Promise<void> {
+		let rec = await this.ensureHostServer(host);
+		while (!this.closed && !serverOwnsPort(rec)) {
+			rec = await this.buildHostServer(host);
+		}
+		if (this.closed) {
+			client.destroy();
+			return;
+		}
+		const up = netConnect({ host: '127.0.0.1', port: rec.port }, () => {
+			this.trackSocket(up);
+			client.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+			if (head?.length) up.write(head);
+			client.pipe(up);
+			up.pipe(client);
+			client.resume();
+		});
+		up.on('error', () => client.destroy());
+		up.on('close', () => client.destroy());
+		client.on('close', () => up.destroy());
 	}
 
 	/** Return a live per-host TLS server, rebuilding it if the cached one has

--- a/packages/server/src/services/fake-docker.ts
+++ b/packages/server/src/services/fake-docker.ts
@@ -1,3 +1,4 @@
+import type { PGlite } from '@electric-sql/pglite';
 import type { DockerClient, ExecLogChunk, ExecStartOpts } from './docker';
 
 const SYNTHETIC_EXEC_SCRIPT: Array<{
@@ -26,13 +27,22 @@ async function runSyntheticExec(opts: ExecStartOpts): Promise<{ stdout: string; 
 	return { stdout: stdoutAcc, stderr: stderrAcc };
 }
 
+const RUN_ID_ENV_PREFIX = 'HEZO_HEARTBEAT_RUN_ID=';
+
 /**
  * A happy-path Docker stub used by tests and any process started with
  * `HEZO_SKIP_DOCKER=1`. All operations succeed; agent execs emit a short
  * deterministic synthetic script so log streams behave like real runs.
+ *
+ * The synthetic exec stands in for an agent doing real work, so — like a real
+ * run that makes an MCP write — it marks its run as having produced output.
+ * Without this the completion path would treat every synthetic run as a no-op
+ * and fail it. Pass `db` to enable; omit it for pure docker-surface stubs.
  */
-export function createFakeDockerClient(): DockerClient {
+export function createFakeDockerClient(db?: PGlite): DockerClient {
 	const containers = new Map<string, { running: boolean }>();
+	const execRunIds = new Map<string, string | null>();
+	let execCounter = 0;
 
 	const stub = {
 		ping: async () => true,
@@ -70,13 +80,24 @@ export function createFakeDockerClient(): DockerClient {
 			};
 		},
 		containerLogs: async () => new Response(new Uint8Array()),
-		execCreate: async () => 'noop-exec',
+		execCreate: async (_id: string, config?: { Env?: string[] }) => {
+			const execId = `noop-exec-${++execCounter}`;
+			const runEntry = config?.Env?.find((e) => e.startsWith(RUN_ID_ENV_PREFIX));
+			execRunIds.set(execId, runEntry ? runEntry.slice(RUN_ID_ENV_PREFIX.length) : null);
+			return execId;
+		},
 		execStart: async (
-			_id: string,
+			execId: string,
 			opts?: ExecStartOpts,
 		): Promise<{ stdout: string; stderr: string }> => {
+			const runId = execRunIds.get(execId) ?? null;
+			execRunIds.delete(execId);
 			if (!opts?.onChunk) return { stdout: '', stderr: '' };
-			return runSyntheticExec(opts);
+			const result = await runSyntheticExec(opts);
+			if (db && runId) {
+				await db.query('UPDATE heartbeat_runs SET produced_output = true WHERE id = $1', [runId]);
+			}
+			return result;
 		},
 		execInspect: async () => ({ ExitCode: 0, Running: false, Pid: 0 }),
 	};

--- a/packages/server/src/services/git.ts
+++ b/packages/server/src/services/git.ts
@@ -297,3 +297,36 @@ export async function removeWorktree(
 export async function pruneWorktrees(repoDir: string): Promise<void> {
 	await spawn('git', ['worktree', 'prune', '--expire', 'now'], { cwd: repoDir });
 }
+
+/**
+ * Resolve the current commit a worktree points at, or null if the worktree is
+ * missing or has no commit (e.g. an unborn branch). Captured before a run so a
+ * post-run comparison can tell whether the agent advanced the branch.
+ */
+export async function getWorktreeHead(worktreePath: string): Promise<string | null> {
+	if (!existsSync(join(worktreePath, '.git'))) return null;
+	const { exitCode, stdout } = await spawn('git', ['rev-parse', 'HEAD'], {
+		cwd: worktreePath,
+		timeout: 10_000,
+	});
+	return exitCode === 0 ? stdout.trim() || null : null;
+}
+
+/**
+ * Whether a run changed code in this worktree: any uncommitted/untracked change
+ * (`git status --porcelain` non-empty), or the branch tip advanced past the
+ * commit captured before the run.
+ */
+export async function worktreeHasChanges(
+	worktreePath: string,
+	headBefore: string | null,
+): Promise<boolean> {
+	if (!existsSync(join(worktreePath, '.git'))) return false;
+	const status = await spawn('git', ['status', '--porcelain'], {
+		cwd: worktreePath,
+		timeout: 10_000,
+	});
+	if (status.exitCode === 0 && status.stdout.trim().length > 0) return true;
+	const headAfter = await getWorktreeHead(worktreePath);
+	return headAfter !== null && headBefore !== null && headAfter !== headBefore;
+}

--- a/packages/server/src/services/template-resolver.ts
+++ b/packages/server/src/services/template-resolver.ts
@@ -67,6 +67,9 @@ const SHARED_INSTRUCTIONS = `
 ### Sub-Task Delegation
 - Use \`create_task\` with \`parent_task_id\` and \`assignee_slug\` to create sub-tasks and delegate work to other agents. The Teammates block above lists every enabled peer's slug — use \`list_agents\` only when you need details (description / reports_to) on a specific teammate.
 
+### Shell Commands
+- Shell commands run from your run's working directory (a git worktree when the project has a repo) — you do not need to specify it. To run a command in a different directory, prefix it with \`cd <path> && …\`. Don't pass a separate directory / \`workdir\` / \`cwd\` argument to the shell tool; prefixing with \`cd\` works on every runtime, whereas a directory argument may be rejected.
+
 ### Fetching External URLs
 - To read a web page or hit an HTTP endpoint, use \`curl\` (or \`wget\`) from the shell. The container's proxy and CA trust are preconfigured, so HTTPS to any host works with no extra flags.
 - Use your native web-search tool for discovery, then fetch the resulting pages with \`curl\`/\`wget\`.

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -114,7 +114,7 @@ export async function startup(config: HezoConfig): Promise<StartupResult> {
 	let docker: DockerClient;
 	if (process.env.HEZO_SKIP_DOCKER) {
 		const { createFakeDockerClient } = await import('./services/fake-docker.js');
-		docker = createFakeDockerClient();
+		docker = createFakeDockerClient(db);
 	} else {
 		docker = new DockerClient();
 		try {

--- a/packages/server/test/agent-runner.test.ts
+++ b/packages/server/test/agent-runner.test.ts
@@ -119,7 +119,14 @@ afterAll(async () => {
 	await safeClose(db);
 });
 
+// A real agent run produces persisted output (an MCP write or a code change);
+// the runner only treats a clean exit as success when it did. Mirror that here
+// by flipping the run's produced_output flag during exec — the same thing the
+// MCP tool layer does mid-run — so exit-0 mocks read as genuine successes.
+// `producesOutput: false` simulates a no-op run (e.g. a plan-only termination).
 function createMockDocker(overrides: Record<string, any> = {}): DockerClient {
+	const { execStart: execStartOverride, producesOutput = true, ...rest } = overrides;
+	const innerExecStart = execStartOverride ?? (async () => ({ stdout: 'done', stderr: '' }));
 	return {
 		ping: async () => true,
 		imageExists: async () => true,
@@ -135,9 +142,17 @@ function createMockDocker(overrides: Record<string, any> = {}): DockerClient {
 		}),
 		containerLogs: async () => new ReadableStream(),
 		execCreate: async () => 'exec-123',
-		execStart: async () => ({ stdout: 'done', stderr: '' }),
 		execInspect: async () => ({ ExitCode: 0, Running: false, Pid: 0 }),
-		...overrides,
+		...rest,
+		execStart: async (...args: unknown[]) => {
+			if (producesOutput) {
+				await db.query(
+					`UPDATE heartbeat_runs SET produced_output = true WHERE task_id = $1 AND status = 'running'`,
+					[taskId],
+				);
+			}
+			return (innerExecStart as (...a: unknown[]) => unknown)(...args);
+		},
 	} as unknown as DockerClient;
 }
 
@@ -297,6 +312,57 @@ describe('runAgent', () => {
 		);
 		expect(run.rows[0].status).toBe(HeartbeatRunStatus.Succeeded);
 		expect(run.rows[0].exit_code).toBe(0);
+	});
+
+	it('marks produced_output on a successful run', async () => {
+		const deps: RunnerDeps = {
+			db,
+			docker: createMockDocker(),
+			masterKeyManager,
+			serverPort: 3000,
+			dataDir: '/tmp/test-data',
+			logs: new LogStreamBroker(),
+		};
+
+		const result = await runAgent(deps, makeAgent(), makeTask(), makeProject());
+
+		const run = await db.query<{ status: string; produced_output: boolean }>(
+			'SELECT status, produced_output FROM heartbeat_runs WHERE id = $1',
+			[result.heartbeatRunId],
+		);
+		expect(run.rows[0].status).toBe(HeartbeatRunStatus.Succeeded);
+		expect(run.rows[0].produced_output).toBe(true);
+	});
+
+	it('fails a clean exit that produced no output', async () => {
+		const deps: RunnerDeps = {
+			db,
+			docker: createMockDocker({
+				producesOutput: false,
+				execStart: async () => ({ stdout: 'here is my plan', stderr: '' }),
+				execInspect: async () => ({ ExitCode: 0, Running: false, Pid: 0 }),
+			}),
+			masterKeyManager,
+			serverPort: 3000,
+			dataDir: '/tmp/test-data',
+			logs: new LogStreamBroker(),
+		};
+
+		const result = await runAgent(deps, makeAgent(), makeTask(), makeProject());
+
+		expect(result.success).toBe(false);
+		expect(result.exitCode).toBe(0);
+
+		const run = await db.query<{
+			status: string;
+			produced_output: boolean;
+			error: string | null;
+		}>('SELECT status, produced_output, error FROM heartbeat_runs WHERE id = $1', [
+			result.heartbeatRunId,
+		]);
+		expect(run.rows[0].status).toBe(HeartbeatRunStatus.Failed);
+		expect(run.rows[0].produced_output).toBe(false);
+		expect(run.rows[0].error).toContain('produced no output');
 	});
 
 	it('records failure in heartbeat run on non-zero exit code', async () => {
@@ -1377,6 +1443,8 @@ describe('runAgent', () => {
 			expect(capturedCmd).toContain('--disallowedTools');
 			const idx = capturedCmd.indexOf('--disallowedTools');
 			expect(capturedCmd[idx + 1]).toBe('WebFetch');
+			// ExitPlanMode is disallowed so a model can't park in headless plan-mode approval.
+			expect(capturedCmd).toContain('ExitPlanMode');
 			expect(capturedCmd).not.toContain('WebSearch');
 		});
 

--- a/packages/server/test/bun/egress-proxy.bun.test.ts
+++ b/packages/server/test/bun/egress-proxy.bun.test.ts
@@ -126,22 +126,26 @@ describe('EgressProxy under Bun', () => {
 	// for another. The MITM library spins up a separate per-host HTTPS server,
 	// and concurrent first-time minting of two hosts must not cross the certs —
 	// otherwise the client sees ERR_TLS_CERT_ALTNAME_INVALID against the wrong
-	// SAN. Asserting on the served leaf cert is enough: the client↔proxy
-	// handshake completes before any upstream connection, so no upstream is
-	// needed and the hostnames need not resolve.
-	test('concurrent connections to different hosts are each served that host cert', async () => {
-		const hosts = Array.from({ length: 8 }, (_u, i) => `host-${i}.hezo-egress-test`);
+	// SAN. Full verification is on (`strictHandshakeThroughProxy`) so a crossed
+	// cert *rejects the handshake* exactly as curl does, rather than completing
+	// and being papered over by a CN that mockttp always sets to the host. The
+	// set mixes 3-label hosts with a 2-label apex (`bun.sh`, the production
+	// incident) so apex minting is covered too. The handshake completes before
+	// any upstream connection, so no upstream is needed and the hosts need not
+	// resolve.
+	test('concurrent connections to different hosts each pass strict verification', async () => {
+		const hosts = ['bun.sh', ...Array.from({ length: 7 }, (_u, i) => `host-${i}.hezo-egress-test`)];
 		// Fresh run proxies so every host is first-seen concurrently, forcing the
 		// per-host cert mint + listen to race within each proxy.
 		for (let attempt = 0; attempt < 8; attempt++) {
 			const runId = `bun-multihost-${process.pid}-${attempt}`;
 			const allocated = await proxy.allocateRunProxy(runId, { teamId, agentId });
 			try {
-				const certs = await Promise.all(
-					hosts.map((h) => servedCertThroughProxy(allocated.proxyPort, h, ca.cert)),
+				const sans = await Promise.all(
+					hosts.map((h) => strictHandshakeThroughProxy(allocated.proxyPort, h, ca.cert)),
 				);
 				for (let i = 0; i < hosts.length; i++) {
-					expect(certs[i]).toContain(hosts[i]);
+					expect(sans[i]).toContain(hosts[i]);
 				}
 			} finally {
 				await proxy.releaseRunProxy(runId);
@@ -159,7 +163,7 @@ describe('EgressProxy under Bun', () => {
 		const host = 'registry.npmjs.org';
 		const allocated = await proxy.allocateRunProxy(runId, { teamId, agentId });
 		try {
-			const first = await servedCertThroughProxy(allocated.proxyPort, host, ca.cert);
+			const first = await strictHandshakeThroughProxy(allocated.proxyPort, host, ca.cert);
 			expect(first).toContain(host);
 
 			const before = getHostServers(proxy, runId);
@@ -168,12 +172,14 @@ describe('EgressProxy under Bun', () => {
 			expect(rec.server.listening).toBe(true);
 			expect(rec.server.address()?.port).toBe(rec.port);
 
-			// The per-host server dies; its loopback port is now refused.
+			// The per-host server dies; its loopback port is now refused. A later
+			// CONNECT must rebuild and still pass strict verification — never dial
+			// a dead/recycled port and serve another host's cert.
 			await new Promise<void>((resolve) => rec.server.close(() => resolve()));
 			expect(rec.server.listening).toBe(false);
 
 			// The next tunnel must rebuild a fresh live server, not ECONNREFUSED.
-			const second = await servedCertThroughProxy(allocated.proxyPort, host, ca.cert);
+			const second = await strictHandshakeThroughProxy(allocated.proxyPort, host, ca.cert);
 			expect(second).toContain(host);
 
 			const after = getHostServers(proxy, runId);
@@ -193,7 +199,7 @@ describe('EgressProxy under Bun', () => {
 		const host = 'zombie.hezo-egress-test';
 		const allocated = await proxy.allocateRunProxy(runId, { teamId, agentId });
 		try {
-			await servedCertThroughProxy(allocated.proxyPort, host, ca.cert);
+			await servedSanThroughProxy(allocated.proxyPort, host, ca.cert);
 			const map = getHostServers(proxy, runId);
 			const rec = map.get(host);
 			if (!rec) throw new Error('per-host server missing');
@@ -210,7 +216,7 @@ describe('EgressProxy under Bun', () => {
 				} as unknown as HttpsServer,
 			});
 
-			const cert = await servedCertThroughProxy(allocated.proxyPort, host, ca.cert);
+			const cert = await servedSanThroughProxy(allocated.proxyPort, host, ca.cert);
 			expect(cert).toContain(host);
 			expect(map.get(host)?.server.listening).toBe(true);
 		} finally {
@@ -324,17 +330,64 @@ async function fetchHttpsThroughProxy(
 	});
 }
 
-// Open a CONNECT tunnel for `targetHost`, complete the client↔proxy TLS
-// handshake, and return a descriptor of the leaf cert the proxy served (CN +
-// subjectAltName). A wrong per-host cert makes the handshake reject with
-// ERR_TLS_CERT_ALTNAME_INVALID against `servername`, surfacing the cross-host
-// mix-up. No upstream is contacted, so the target host need not resolve.
-async function servedCertThroughProxy(
+// Open a CONNECT tunnel for `targetHost` and return the served leaf's
+// subjectAltName. The SAN — not the CN — is what real clients (curl, OpenSSL,
+// Node with verification on) check, and mockttp sets CN=host unconditionally,
+// so asserting on the CN would pass even when the proxy serves another host's
+// cert. `rejectUnauthorized:false` so a wrong cert still completes the
+// handshake and the caller can inspect which SAN was actually served. No
+// upstream is contacted, so the target host need not resolve.
+async function servedSanThroughProxy(
 	proxyPort: number,
 	targetHost: string,
 	caCert: string,
 ): Promise<string> {
-	const tunnel = await new Promise<ReturnType<typeof netConnect>>((resolve, reject) => {
+	const tunnel = await openConnectTunnel(proxyPort, targetHost);
+	return new Promise<string>((resolve, reject) => {
+		const tls = tlsConnect(
+			{ socket: tunnel, servername: targetHost, ca: [caCert], rejectUnauthorized: false },
+			() => {
+				const san = tls.getPeerCertificate().subjectaltname ?? '';
+				tls.end();
+				resolve(san);
+			},
+		);
+		tls.on('error', reject);
+		tls.setTimeout(20_000, () => tls.destroy(new Error('tls handshake timed out')));
+	});
+}
+
+// Complete a CONNECT + client↔proxy TLS handshake with full verification on
+// (`rejectUnauthorized:true`, `servername:targetHost`), exactly as curl does.
+// A leaf whose SAN doesn't cover `targetHost` rejects with
+// ERR_TLS_CERT_ALTNAME_INVALID — the production symptom (`curl: (60) SSL: no
+// alternative certificate subject name matches target host name`). Resolves
+// with the verified SAN.
+async function strictHandshakeThroughProxy(
+	proxyPort: number,
+	targetHost: string,
+	caCert: string,
+): Promise<string> {
+	const tunnel = await openConnectTunnel(proxyPort, targetHost);
+	return new Promise<string>((resolve, reject) => {
+		const tls = tlsConnect(
+			{ socket: tunnel, servername: targetHost, ca: [caCert], rejectUnauthorized: true },
+			() => {
+				const san = tls.getPeerCertificate().subjectaltname ?? '';
+				tls.end();
+				resolve(san);
+			},
+		);
+		tls.on('error', reject);
+		tls.setTimeout(20_000, () => tls.destroy(new Error('tls handshake timed out')));
+	});
+}
+
+async function openConnectTunnel(
+	proxyPort: number,
+	targetHost: string,
+): Promise<ReturnType<typeof netConnect>> {
+	return new Promise<ReturnType<typeof netConnect>>((resolve, reject) => {
 		const sock = netConnect({ host: '127.0.0.1', port: proxyPort });
 		const onData = (chunk: Buffer) => {
 			const statusLine = chunk.toString().split('\r\n')[0] ?? '';
@@ -351,22 +404,5 @@ async function servedCertThroughProxy(
 		sock.on('data', onData);
 		sock.on('error', reject);
 		sock.setTimeout(20_000, () => sock.destroy(new Error('CONNECT timed out')));
-	});
-
-	return new Promise<string>((resolve, reject) => {
-		// rejectUnauthorized:false so a cross-host cert still completes the
-		// handshake — the caller asserts on which cert was served rather than
-		// the connection merely failing.
-		const tls = tlsConnect(
-			{ socket: tunnel, servername: targetHost, ca: [caCert], rejectUnauthorized: false },
-			() => {
-				const peer = tls.getPeerCertificate();
-				const descriptor = `${peer.subject?.CN ?? ''} ${peer.subjectaltname ?? ''}`;
-				tls.end();
-				resolve(descriptor);
-			},
-		);
-		tls.on('error', reject);
-		tls.setTimeout(20_000, () => tls.destroy(new Error('tls handshake timed out')));
 	});
 }

--- a/packages/server/test/egress-proxy.test.ts
+++ b/packages/server/test/egress-proxy.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync } from 'node:fs';
 import { createServer, type IncomingMessage, type Server } from 'node:http';
 import type { Server as HttpsServer } from 'node:https';
-import type { Socket } from 'node:net';
+import { createServer as createNetServer, type Server as NetServer, type Socket } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { PGlite } from '@electric-sql/pglite';
@@ -9,6 +9,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { encrypt } from '../src/crypto/encryption';
 import type { MasterKeyManager } from '../src/crypto/master-key';
 import { type HezoCA, loadOrCreateCA } from '../src/services/egress/ca';
+import { PortAllocator } from '../src/services/egress/port-allocator';
 import { EgressProxy } from '../src/services/egress/proxy';
 import { safeClose } from './helpers';
 import { createTestApp, createTestProject } from './helpers/app';
@@ -507,4 +508,51 @@ describe('EgressProxy per-host cert routing', () => {
 			await httpsProxy.releaseRunProxy(runId);
 		}
 	}, 30_000);
+
+	// A candidate port can pass the allocator's free-probe yet lose the race to
+	// bind (a parallel process grabs it first). Allocation must try the next port
+	// rather than fail the whole run.
+	it('retries onto another port when a candidate loses the bind race', async () => {
+		const occupied = createNetServer();
+		const occupiedPort = await new Promise<number>((resolve, reject) => {
+			occupied.once('error', reject);
+			occupied.listen(0, '127.0.0.1', () => resolve((occupied.address() as { port: number }).port));
+		});
+		const freePort = await reserveFreePort();
+
+		class FixedAllocator extends PortAllocator {
+			private i = 0;
+			private readonly seq = [occupiedPort, freePort];
+			async allocate(): Promise<number> {
+				return this.seq[this.i++];
+			}
+			release(): void {}
+		}
+
+		const retryProxy = new EgressProxy({
+			db,
+			masterKeyManager,
+			ca,
+			portAllocator: new FixedAllocator(),
+		});
+		const runId = `run-${Date.now()}-bind-retry`;
+		try {
+			const allocated = await retryProxy.allocateRunProxy(runId, { teamId, agentId });
+			expect(allocated.proxyPort).toBe(freePort);
+		} finally {
+			await retryProxy.releaseRunProxy(runId);
+			await new Promise<void>((r) => occupied.close(() => r()));
+		}
+	});
 });
+
+function reserveFreePort(): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const s: NetServer = createNetServer();
+		s.once('error', reject);
+		s.listen(0, '127.0.0.1', () => {
+			const port = (s.address() as { port: number }).port;
+			s.close(() => resolve(port));
+		});
+	});
+}

--- a/packages/server/test/mcp-tools.test.ts
+++ b/packages/server/test/mcp-tools.test.ts
@@ -803,6 +803,69 @@ describe('MCP tool handlers: additional data queries via DB', () => {
 		expect(fetched.rows[0].author_member_id).toBe(agentId);
 	});
 
+	it('a write tool marks produced_output on the calling run', async () => {
+		const { token: agentToken, runId } = await mintAgentToken(
+			db,
+			masterKeyManager,
+			agentId,
+			teamId,
+		);
+
+		const before = await db.query<{ produced_output: boolean }>(
+			'SELECT produced_output FROM heartbeat_runs WHERE id = $1',
+			[runId],
+		);
+		expect(before.rows[0].produced_output).toBe(false);
+
+		const res = await app.request('/mcp', {
+			method: 'POST',
+			headers: { ...authHeader(agentToken), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				jsonrpc: '2.0',
+				method: 'tools/call',
+				params: {
+					name: 'create_comment',
+					arguments: { project: projectId, task_id: taskId, content: 'real output' },
+				},
+				id: 1,
+			}),
+		});
+		expect(res.status).toBe(200);
+
+		const after = await db.query<{ produced_output: boolean }>(
+			'SELECT produced_output FROM heartbeat_runs WHERE id = $1',
+			[runId],
+		);
+		expect(after.rows[0].produced_output).toBe(true);
+	});
+
+	it('a read tool does not mark produced_output', async () => {
+		const { token: agentToken, runId } = await mintAgentToken(
+			db,
+			masterKeyManager,
+			agentId,
+			teamId,
+		);
+
+		const res = await app.request('/mcp', {
+			method: 'POST',
+			headers: { ...authHeader(agentToken), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				jsonrpc: '2.0',
+				method: 'tools/call',
+				params: { name: 'list_comments', arguments: { project: projectId, task_id: taskId } },
+				id: 1,
+			}),
+		});
+		expect(res.status).toBe(200);
+
+		const after = await db.query<{ produced_output: boolean }>(
+			'SELECT produced_output FROM heartbeat_runs WHERE id = $1',
+			[runId],
+		);
+		expect(after.rows[0].produced_output).toBe(false);
+	});
+
 	it('list_comments query returns comments for task', async () => {
 		const r = await db.query(
 			'SELECT * FROM task_comments WHERE task_id = $1 ORDER BY created_at ASC',

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -880,7 +880,11 @@ export const RUNTIME_AUTO_APPROVE_ARGS: Record<AgentRuntime, readonly string[]> 
  * disallow nothing.
  */
 export const RUNTIME_DISALLOWED_TOOLS_ARGS: Record<AgentRuntime, readonly string[]> = {
-	[AgentRuntime.ClaudeCode]: ['--disallowedTools', 'WebFetch'],
+	// ExitPlanMode is disallowed: under headless `-p` its approval prompt can't be
+	// answered, so a model that drifts into plan mode parks there and exits 0 with
+	// only a plan written — a false success. Removing the tool forces the agent to
+	// act on the work directly.
+	[AgentRuntime.ClaudeCode]: ['--disallowedTools', 'WebFetch', 'ExitPlanMode'],
 	[AgentRuntime.Codex]: [],
 	[AgentRuntime.Gemini]: [],
 	[AgentRuntime.OpenCode]: [],

--- a/test/browser/agent-run-logs.spec.ts
+++ b/test/browser/agent-run-logs.spec.ts
@@ -33,6 +33,7 @@ async function waitForRunStatus(
 	timeoutMs = 180_000,
 ) {
 	const headers = { Authorization: `Bearer ${token}` };
+	const terminalFailures = new Set(['failed', 'cancelled', 'timed_out']);
 	const deadline = Date.now() + timeoutMs;
 	while (Date.now() < deadline) {
 		const res = await page.request.get(`/api/projects/${projectSlug}/tasks/${taskId}/latest-run`, {
@@ -44,6 +45,13 @@ async function waitForRunStatus(
 			(body.data.status === target || (target === 'running' && body.data.status === 'succeeded'))
 		) {
 			return body.data;
+		}
+		// When waiting for success, a terminal failure will never become success —
+		// surface it immediately instead of polling until the timeout.
+		if (body.data && target !== 'failed' && terminalFailures.has(body.data.status)) {
+			throw new Error(
+				`Latest run reached terminal status '${body.data.status}' while waiting for '${target}' (run ${body.data.id})`,
+			);
 		}
 		await new Promise((r) => setTimeout(r, 100));
 	}


### PR DESCRIPTION
## Context

An agent run was marked `Succeeded` on exit code `0` alone. A model that drifted into Claude Code **plan mode** would write an implementation plan, call `ExitPlanMode` (whose approval prompt can't be answered under headless `-p`), exit cleanly, and read as a **green success** — while having changed nothing. The agent then went Idle with the work unstarted (observed on the `todo` project's Engineer, task TO-7).

The real success signal isn't "did it edit a file" — research/coordination runs legitimately produce a *comment*, *task*, or *document* instead of code. **Every run must produce at least one persisted output.**

## Changes

- **Output gate** (`agent-runner.ts`): a clean exit only `Succeeded`s if the run produced output; otherwise `Failed` with `run produced no output (...)`. Detected two ways:
  - **Hezo writes** — `MCP_WRITE_TOOLS` flag `heartbeat_runs.produced_output` via the central `tool()` wrapper using the run's auth identity (`mcp/tools.ts`).
  - **Code changes** — post-run worktree diff (pre-run HEAD + `git status --porcelain`) across the task's worktrees (`getWorktreeHead`/`worktreeHasChanges` in `git.ts`).
- **Plan-mode trap** (`common.ts`): `ExitPlanMode` added to Claude Code's `--disallowedTools` so a model can't park in the headless approval prompt.
- **Schema**: migration `009_heartbeat_run_produced_output.sql` adds the boolean (default `false`).

No new retry-bound code: a no-output `Failed` run is already bounded by the existing `postFailurePing` streak suppression + 60-min heartbeat cadence, and `chainNextTaskWakeup` excludes the just-completed task.

Also bundles in-progress egress proxy refinements and a shell-commands note in the shared agent instructions.

## Tests

- `agent-runner.test.ts`: success sets `produced_output`; clean-exit-no-output → `Failed` with reason; `ExitPlanMode` in disallowed args. Mock-docker reworked so exit-0 mocks simulate a real mid-run write.
- `mcp-tools.test.ts`: write tool flips `produced_output`; read tool doesn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)