### PR TITLE
Rename task list "To do" section header to "Backlog"

### DIFF
--- a/packages/web/src/components/task-list.tsx
+++ b/packages/web/src/components/task-list.tsx
@@ -487,7 +487,7 @@ export function TaskList({ projectId }: TaskListProps) {
 
 			<section data-testid="task-list-main" className="mb-6 last:mb-0">
 				<h2 className="text-[11px] font-medium uppercase tracking-wider text-text-subtle mb-2 px-0.5">
-					To do
+					Backlog
 				</h2>
 
 				{mainLoading ? (


### PR DESCRIPTION
## Summary

Renames the task list section header from **"To do"** to **"Backlog"** in `packages/web/src/components/task-list.tsx`.

The header is styled with an `uppercase` CSS class, so it renders as **BACKLOG** alongside the other section headers (IN PROGRESS, etc.). "Backlog" matches the established task-status terminology already used throughout the codebase (`TaskStatus.Backlog` → label `"Backlog"` in `@hezo/shared`).

## Testing

No automated tests reference the visible header text — every task-list test targets the section via the stable `task-list-main` testId — so this purely cosmetic label change does not affect any test assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSv969oDAdm3bGqXowie7y

---
_Generated by [Claude Code](https://claude.ai/code/session_01DSv969oDAdm3bGqXowie7y)_