### PR TITLE
Make "Create new" the first/default tab in repo setup dialog

### DIFF
--- a/packages/web/src/components/repo-picker-modal.tsx
+++ b/packages/web/src/components/repo-picker-modal.tsx
@@ -35,7 +35,7 @@ export function RepoPickerModal({
 	projectId,
 	oauthConnectionId,
 }: RepoPickerModalProps) {
-	const [mode, setMode] = useState<PickerMode>('link');
+	const [mode, setMode] = useState<PickerMode>('create');
 	const [owner, setOwner] = useState<string | null>(null);
 	const [search, setSearch] = useState('');
 	const [debouncedSearch, setDebouncedSearch] = useState('');
@@ -50,7 +50,7 @@ export function RepoPickerModal({
 
 	useEffect(() => {
 		if (!open) {
-			setMode('link');
+			setMode('create');
 			setOwner(null);
 			setSearch('');
 			setDebouncedSearch('');
@@ -128,22 +128,10 @@ export function RepoPickerModal({
 						Set up GitHub repo
 					</Dialog.Title>
 					<Dialog.Description className="text-sm text-text-muted mb-4">
-						Pick an existing repository for this project, or create a new one in one of your orgs.
+						Create a new repository for this project in one of your orgs, or pick an existing one.
 					</Dialog.Description>
 
 					<div className="flex gap-1 border-b border-border mb-4">
-						<button
-							type="button"
-							className={`px-3 py-1.5 text-sm border-b-2 transition-colors ${
-								mode === 'link'
-									? 'text-text font-medium border-text'
-									: 'text-text-muted border-transparent hover:text-text'
-							}`}
-							onClick={() => setMode('link')}
-							data-testid="repo-picker-tab-link"
-						>
-							Link existing
-						</button>
 						<button
 							type="button"
 							className={`px-3 py-1.5 text-sm border-b-2 transition-colors ${
@@ -155,6 +143,18 @@ export function RepoPickerModal({
 							data-testid="repo-picker-tab-create"
 						>
 							Create new
+						</button>
+						<button
+							type="button"
+							className={`px-3 py-1.5 text-sm border-b-2 transition-colors ${
+								mode === 'link'
+									? 'text-text font-medium border-text'
+									: 'text-text-muted border-transparent hover:text-text'
+							}`}
+							onClick={() => setMode('link')}
+							data-testid="repo-picker-tab-link"
+						>
+							Link existing
 						</button>
 					</div>
 

--- a/packages/web/test/repo-picker-flows.test.tsx
+++ b/packages/web/test/repo-picker-flows.test.tsx
@@ -123,6 +123,8 @@ test('link-existing flow links the repo and auto-designates the first repo', asy
 
 	await openRepoPicker(user);
 
+	await user.click(screen.getByTestId('repo-picker-tab-link'));
+
 	await user.click(
 		await screen.findByTestId(`repo-picker-row-${ghOwner}/billing-service`, undefined, {
 			timeout: 10_000,
@@ -163,8 +165,7 @@ test('create-new flow creates the repo on GitHub and auto-designates it', async 
 
 	await openRepoPicker(user);
 
-	await user.click(screen.getByTestId('repo-picker-tab-create'));
-
+	// "Create new" is the default tab, so the name input is visible immediately.
 	const modal = screen.getByTestId('repo-picker-modal');
 	const nameInput = modal.querySelector('input[placeholder="my-new-service"]') as HTMLInputElement;
 	await user.type(nameInput, 'fresh-service');


### PR DESCRIPTION
## What

In the "Set up GitHub repo" dialog (`RepoPickerModal`), **Create new** is now the first tab and the one active on open; **Link existing** is now second.

## Changes

- Reordered the two tab buttons so `Create new` precedes `Link existing`.
- Default `mode` (and the on-close reset) is now `create`, so the first tab is the active one when the dialog opens — keeping the active-tab underline consistent with tab order.
- Updated the dialog description to lead with the create action: _"Create a new repository for this project in one of your orgs, or pick an existing one."_

## Tests

- Updated `repo-picker-flows.test.tsx`:
  - The link-existing flow now clicks the **Link existing** tab before selecting a repo row (it previously relied on link being the default).
  - The create-new flow no longer clicks the create tab — it relies on `create` being the default, locking in the new behavior as regression coverage.
- `repo-picker-exists.test.tsx` is unchanged and still passes (its explicit create-tab click is now a harmless no-op).

All 4 repo-picker tests pass; `tsc --noEmit` and `biome check` are clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y4dZmikDLnYaz9j51fkoC5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y4dZmikDLnYaz9j51fkoC5)_