### PR TITLE
feat(web): breadcrumb to parent task in task header

### DIFF
--- a/packages/web/src/components/task-detail/task-header.tsx
+++ b/packages/web/src/components/task-detail/task-header.tsx
@@ -1,5 +1,6 @@
 import { Link } from '@tanstack/react-router';
-import type { Task } from '../../hooks/use-tasks';
+import { ChevronRight } from 'lucide-react';
+import { type Task, useTaskAncestors } from '../../hooks/use-tasks';
 import { MarkdownProse } from '../markdown-prose';
 import { TaskStatusBadge } from '../task-status-badge';
 import { Badge } from '../ui/badge';
@@ -14,18 +15,46 @@ const priorityColors: Record<string, string> = {
 interface TaskHeaderProps {
 	task: Task;
 	projectId: string;
+	taskId: string;
 	taskProjectSlug: string;
 }
 
 /**
- * Top-of-page header for a task: identifier, title, status / priority / project
- * badges, queued-wakeup chip, and the description card. Renders nothing
- * status-mutating — assignee / close / reopen live in the sidebar.
+ * Top-of-page header for a task: a breadcrumb of ancestor tasks ending in the
+ * current identifier, then title, status / priority / project badges,
+ * queued-wakeup chip, and the description card. Renders nothing status-mutating
+ * — assignee / close / reopen live in the sidebar.
  */
-export function TaskHeader({ task, projectId, taskProjectSlug }: TaskHeaderProps) {
+export function TaskHeader({ task, projectId, taskId, taskProjectSlug }: TaskHeaderProps) {
+	// Ancestors come back root-first, excluding the current task, so the
+	// breadcrumb reads `root → … → parent → current`. Sub-tasks are capped at two
+	// levels deep, so at most two links precede the current identifier. They share
+	// the current task's project (sub-tasks inherit the parent's project), so the
+	// current task's slug is the right link target.
+	const { data: ancestors } = useTaskAncestors(projectId, taskId);
 	return (
 		<>
-			<div className="mb-1 text-[13px] font-mono text-text-muted">{task.identifier}</div>
+			<nav
+				aria-label="Breadcrumb"
+				className="mb-1 flex flex-wrap items-center gap-x-1 text-[13px] font-mono text-text-muted"
+				data-testid="task-breadcrumb"
+			>
+				{ancestors?.map((ancestor) => (
+					<span key={ancestor.id} className="flex items-center gap-x-1">
+						<Link
+							to="/projects/$projectId/tasks/$taskId"
+							params={{ projectId: taskProjectSlug, taskId: ancestor.identifier.toLowerCase() }}
+							className="hover:text-text hover:underline transition-colors"
+							title={ancestor.title}
+							data-testid="task-breadcrumb-ancestor"
+						>
+							{ancestor.identifier}
+						</Link>
+						<ChevronRight className="w-3 h-3 shrink-0 text-text-subtle" />
+					</span>
+				))}
+				<span aria-current="page">{task.identifier}</span>
+			</nav>
 			<h1 className="text-xl font-medium mb-3">{task.title}</h1>
 
 			<div className="flex flex-wrap gap-1.5 mb-4">

--- a/packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx
@@ -91,7 +91,12 @@ function TaskDetailPage() {
 			<div className="grid grid-cols-1 lg:grid-cols-[1fr_190px] gap-5">
 				<div className="min-w-0">
 					<LastRunFailedBanner task={task} projectId={projectId} taskId={taskId} />
-					<TaskHeader task={task} projectId={projectId} taskProjectSlug={taskProjectSlug} />
+					<TaskHeader
+						task={task}
+						projectId={projectId}
+						taskId={taskId}
+						taskProjectSlug={taskProjectSlug}
+					/>
 
 					<TaskSummary
 						task={task}

--- a/packages/web/test/task-breadcrumb.test.tsx
+++ b/packages/web/test/task-breadcrumb.test.tsx
@@ -1,0 +1,81 @@
+import { waitFor } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+import { seedProject, seedTask, seedWorkspace } from './helpers/seed';
+
+test('sub-task header shows a breadcrumb link to its parent and navigates there', async () => {
+	const seeded = {
+		projectSlug: '',
+		childPath: '',
+		childIdentifier: '',
+		parentIdentifier: '',
+	};
+	const { findByTestId, router, user } = await renderApp({
+		initialPath: '/',
+		seed: async (ctx) => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Breadcrumb Project' });
+			const parent = await seedTask(ws, project, { title: 'Parent Task' });
+			// Sub-tasks aren't expressible through seedTask, so create one through the
+			// real /sub-tasks endpoint — it inherits the parent's project.
+			const subRes = await ctx.apiBase(
+				`/api/projects/${project.slug}/tasks/${parent.id}/sub-tasks`,
+				{
+					method: 'POST',
+					headers: ws.headers,
+					body: JSON.stringify({ title: 'Child Task', assignee_id: ws.agents[0].id }),
+				},
+			);
+			const child = ((await subRes.json()) as { data: { identifier: string } }).data;
+			seeded.projectSlug = project.slug;
+			seeded.parentIdentifier = parent.identifier;
+			seeded.childIdentifier = child.identifier;
+			seeded.childPath = child.identifier.toLowerCase();
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.childPath },
+	});
+
+	// The breadcrumb ends in the current task's identifier...
+	const breadcrumb = await findByTestId('task-breadcrumb');
+	expect(breadcrumb.textContent).toContain(seeded.childIdentifier);
+
+	// ...and is preceded by a link to the parent.
+	const parentLink = await findByTestId('task-breadcrumb-ancestor');
+	expect(parentLink.textContent).toBe(seeded.parentIdentifier);
+	expect(parentLink.getAttribute('href')).toContain(seeded.parentIdentifier.toLowerCase());
+
+	// Clicking it navigates to the parent task.
+	await user.click(parentLink);
+	await waitFor(() =>
+		expect(router.state.location.pathname).toContain(seeded.parentIdentifier.toLowerCase()),
+	);
+});
+
+test('top-level task header shows only its identifier with no ancestor links', async () => {
+	const seeded = { projectSlug: '', taskPath: '', identifier: '' };
+	const { findByTestId, queryByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Solo Project' });
+			const task = await seedTask(ws, project, { title: 'Solo Task' });
+			seeded.projectSlug = project.slug;
+			seeded.taskPath = task.identifier.toLowerCase();
+			seeded.identifier = task.identifier;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskPath },
+	});
+
+	const breadcrumb = await findByTestId('task-breadcrumb');
+	expect(breadcrumb.textContent).toContain(seeded.identifier);
+	// No parent → the breadcrumb is just the current identifier, no ancestor crumb.
+	expect(queryByTestId('task-breadcrumb-ancestor')).toBeNull();
+});


### PR DESCRIPTION
## What

The task detail header now renders the **ancestor chain as a breadcrumb** above the title. A sub-task shows `PARENT → CURRENT` (e.g. `TO-5 → TO-7`) where each ancestor links to its own task page, instead of just the bare current identifier.

Top-level tasks are visually unchanged — the breadcrumb is just their own identifier (no links).

[before/after: a sub-task header now reads "TO-5 → TO-7" with TO-5 linking to the parent]

## How

- Wires the already-present-but-unused `useTaskAncestors` hook into `TaskHeader`. The `/ancestors` endpoint and hook already existed; nothing consumed them.
- Ancestors come back **root-first, excluding the current task**, so the crumb reads `root → … → parent → current`. Sub-tasks are capped at two levels deep, so at most two links precede the current identifier.
- Sub-tasks inherit the parent's `project_id`, so the whole chain shares the current task's project — links target the current task's project slug. The existing canonical-URL redirect in the route is a safety net for any cross-project edge case.
- The current identifier carries `aria-current="page"`; the `<nav>` is labelled `Breadcrumb` for accessibility.

## Scope

Frontend only — no API or schema change.

- `task-header.tsx`: render the breadcrumb `<nav>` in place of the plain identifier `<div>`; accept a `taskId` prop.
- `$taskId.tsx`: pass the route `taskId` to `TaskHeader`.

## Tests

New component test `packages/web/test/task-breadcrumb.test.tsx`:
- A sub-task header shows a breadcrumb link to its parent (correct text + href) and clicking it navigates to the parent.
- A top-level task shows only its own identifier with no ancestor link.

`bun run test --package web --pattern task-breadcrumb`, `bun run typecheck`, and `biome check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmZKLBkcXzgvwyqg9deCtL)_