### PR TITLE
fix(web): correct inbox deep-link scroll (alignment, bounce, jump-to-top)

### DIFF
--- a/packages/web/src/components/task-detail/comments-section.tsx
+++ b/packages/web/src/components/task-detail/comments-section.tsx
@@ -222,6 +222,56 @@ export function CommentsSection({
 
 		const consumedHash = hashTarget;
 		const timers: ReturnType<typeof setTimeout>[] = [];
+		// Headroom left above the landed comment: matches the rows' `scroll-mt-20`
+		// (scroll-margin-top: 80px) that `scrollIntoView({ block: 'start' })`
+		// honours, and the wake-the-list pre-scroll below.
+		const HEADROOM = 80;
+		let settled = false;
+
+		// The live DOM node we're aiming at: the highlighted comment, or the
+		// unresolved setup-repo card for `#setup-repo` (which has no highlight).
+		const targetEl = (): HTMLElement | null =>
+			highlightId
+				? document.getElementById(`comment-${highlightId}`)
+				: (listContainerRef.current?.querySelector<HTMLElement>('[data-setup-repo-anchor]') ??
+					null);
+
+		// Stop re-anchoring and consume the hash. Runs once — on natural settle or
+		// the moment the user takes over scrolling. Aborting the signal removes the
+		// input listeners; stripping the hash keeps a reload from re-jumping. The
+		// `__root` shell no longer resets scroll on a hash-only change, so this
+		// replaceState can't bounce the viewport to the top.
+		const inputAbort = new AbortController();
+		const finish = () => {
+			if (settled) return;
+			settled = true;
+			for (const t of timers) clearTimeout(t);
+			inputAbort.abort();
+			if (window.location.hash === consumedHash) {
+				window.history.replaceState(null, '', window.location.pathname + window.location.search);
+			}
+		};
+
+		// Never fight the user: the first real scroll *intent* aborts the
+		// re-anchor loop. Listen for input events (wheel / touch / scroll keys),
+		// NOT `scroll` — our own programmatic scrolls and Virtuoso's height
+		// adjustments fire `scroll` too and must not self-abort.
+		const SCROLL_KEYS = new Set(['PageUp', 'PageDown', 'ArrowUp', 'ArrowDown', 'Home', 'End', ' ']);
+		const isEditable = (t: EventTarget | null): boolean =>
+			t instanceof HTMLElement &&
+			(t.isContentEditable || t.tagName === 'INPUT' || t.tagName === 'TEXTAREA');
+		scrollParent.addEventListener('wheel', finish, { passive: true, signal: inputAbort.signal });
+		scrollParent.addEventListener('touchmove', finish, {
+			passive: true,
+			signal: inputAbort.signal,
+		});
+		window.addEventListener(
+			'keydown',
+			(e) => {
+				if (!isEditable(e.target) && SCROLL_KEYS.has(e.key)) finish();
+			},
+			{ signal: inputAbort.signal },
+		);
 
 		// Virtuoso with `customScrollParent` only mounts items once its container
 		// intersects the parent's viewport. On a fresh task page the comments list
@@ -232,55 +282,48 @@ export function CommentsSection({
 			const listTop = listContainerRef.current.getBoundingClientRect().top;
 			const parentTop = scrollParent.getBoundingClientRect().top;
 			const offset = scrollParent.scrollTop + listTop - parentTop;
-			scrollParent.scrollTo({ top: Math.max(0, offset - 80), behavior: 'auto' });
+			scrollParent.scrollTo({ top: Math.max(0, offset - HEADROOM), behavior: 'auto' });
 		}
 
-		// Retry ladder: each tick asks Virtuoso to mount the target row, then reads
-		// the rendered element's real position and scrolls precisely to it. The
-		// later ticks absorb post-mount height growth (LazyMount run comments,
-		// async log bodies) that would otherwise leave scrollToIndex short.
+		// Re-anchor the target to the TOP of the viewport (not centred), absorbing
+		// post-mount height growth (LazyMount run comments, async log bodies) that
+		// would otherwise leave a single scroll short. Each tick mounts the row via
+		// Virtuoso (`align: 'start'`), then fine-tunes against its real rendered
+		// position; `scroll-mt-20` provides the 80px headroom. The loop self-
+		// terminates once the row has held its spot for two consecutive ticks, or
+		// when the budget runs out — so it doesn't keep yanking the viewport.
 		//
 		// Mark the hash consumed inside the FIRST tick, not now: React StrictMode
-		// runs setup -> cleanup -> setup synchronously and the cleanup clears these
-		// timers before the 16ms tick fires. Setting the ref now would make the
+		// runs setup -> cleanup -> setup synchronously and the cleanup aborts this
+		// run before the first tick fires. Setting the ref now would make the
 		// second setup's `=== hashTarget` guard skip the re-arm and nothing would
 		// scroll; deferring it lets the surviving setup re-arm and land the scroll.
-		const scrollDelays = [16, 200, 600, 1500, 3000];
-		scrollDelays.forEach((delay, i) => {
-			timers.push(
-				setTimeout(() => {
-					if (i === 0) lastScrolledHashRef.current = consumedHash;
-					virtuosoRef.current?.scrollToIndex({ index: idx, align: 'center' });
-					if (highlightId) {
-						document
-							.getElementById(`comment-${highlightId}`)
-							?.scrollIntoView({ block: 'center', behavior: 'auto' });
-					}
-				}, delay),
-			);
-		});
+		const scrollDelays = [16, 150, 400, 800, 1500];
+		let landedStreak = 0;
+		const step = (attempt: number) => {
+			if (settled) return;
+			if (attempt === 0) lastScrolledHashRef.current = consumedHash;
+			virtuosoRef.current?.scrollToIndex({ index: idx, align: 'start' });
+			const el = targetEl();
+			el?.scrollIntoView({ block: 'start', behavior: 'auto' });
+
+			const top = el
+				? el.getBoundingClientRect().top - scrollParent.getBoundingClientRect().top
+				: null;
+			landedStreak = top !== null && Math.abs(top - HEADROOM) <= 8 ? landedStreak + 1 : 0;
+
+			if (landedStreak >= 2 || attempt >= scrollDelays.length - 1) {
+				finish();
+				return;
+			}
+			timers.push(setTimeout(() => step(attempt + 1), scrollDelays[attempt + 1]));
+		};
+		timers.push(setTimeout(() => step(0), scrollDelays[0]));
 
 		if (highlightId) setHighlightedCommentId(highlightId);
 
-		// Strip the hash once the scroll settles so a reload doesn't re-jump — but
-		// only if it still points at what we consumed, so a fresh click during the
-		// scroll isn't swallowed.
-		timers.push(
-			setTimeout(
-				() => {
-					if (window.location.hash === consumedHash) {
-						window.history.replaceState(
-							null,
-							'',
-							window.location.pathname + window.location.search,
-						);
-					}
-				},
-				scrollDelays[scrollDelays.length - 1] + 50,
-			),
-		);
-
 		return () => {
+			inputAbort.abort();
 			for (const t of timers) clearTimeout(t);
 		};
 	}, [comments, scrollParent, hashTarget]);

--- a/packages/web/src/routes/__root.tsx
+++ b/packages/web/src/routes/__root.tsx
@@ -113,16 +113,24 @@ function ShellChrome() {
 	const mainRef = useRef<HTMLElement>(null);
 	const pathname = useLocation({ select: (l) => l.pathname });
 	const hash = useLocation({ select: (l) => l.hash });
+	const lastPathnameRef = useRef(pathname);
 
 	// Reset the main scroll container to the top on every page change. <main> is the
 	// only scroller here and it never unmounts across navigations (just the <Outlet>
 	// content swaps), so its scrollTop otherwise persists and a freshly-opened page
-	// shows scrolled down to wherever the previous page left off. Skip when the URL
-	// carries a hash: that navigation targets an in-page anchor (e.g. #comment-…)
-	// whose own scroll logic should win. `behavior: 'instant'` overrides the global
-	// `html { scroll-behavior: smooth }` so the reset is immediate, not animated.
-	// biome-ignore lint/correctness/useExhaustiveDependencies: pathname is the navigation trigger — its value isn't read, its change is what should reset the scroll
+	// shows scrolled down to wherever the previous page left off. `behavior: 'instant'`
+	// overrides the global `html { scroll-behavior: smooth }` so the reset is
+	// immediate, not animated. Two guards keep this from stealing the viewport:
+	//   - Only reset when the PATHNAME actually changed. A hash-only change is an
+	//     in-page jump, not a page change — notably the deep-link executor strips
+	//     `#comment-…` once it settles (TanStack patches replaceState, so `hash`
+	//     here flips to ''); resetting on that would yank the reader to the top.
+	//   - Skip when the new URL carries a hash: that navigation targets an in-page
+	//     anchor whose own scroll logic should win.
 	useEffect(() => {
+		const pathnameChanged = lastPathnameRef.current !== pathname;
+		lastPathnameRef.current = pathname;
+		if (!pathnameChanged) return;
 		if (hash) return;
 		mainRef.current?.scrollTo({ top: 0, left: 0, behavior: 'instant' });
 	}, [pathname, hash]);

--- a/test/browser/task-deep-link-scroll.spec.ts
+++ b/test/browser/task-deep-link-scroll.spec.ts
@@ -1,0 +1,150 @@
+// Deep-link scroll behaviour needs a real browser (testing decision tree points
+// 1 & 3): it asserts on <main>'s real `scrollTop` and a comment's `boundingBox`
+// after the hash-driven scroll, and fires a real wheel event to prove the
+// auto-scroll yields to the user. happy-dom returns 0 for layout and can't
+// synthesise a native wheel, so this can't be a component test.
+//
+// Regression coverage for the inbox deep-link bugs: the executor used to centre
+// the comment (not land it at the top), re-yank the viewport for ~3s via a blind
+// retry ladder (fighting the user's scroll), then strip the `#comment-…` hash —
+// which made the shell scroll-reset bounce the reader to the very top.
+
+import { expect, test } from './fixtures';
+import { createProjectAndClearPlanning, uniqueName, waitForPageLoad } from './helpers';
+
+type Page = import('@playwright/test').Page;
+
+async function seedTaskWithComments(page: Page, token: string, count: number) {
+	const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+	const projRes = await createProjectAndClearPlanning(page, '', token, {
+		name: uniqueName('Deep Link Scroll'),
+		description: 'Deep-link scroll test.',
+	});
+	const project = (
+		(await projRes.json()) as { data: { id: string; slug: string; team_slug: string } }
+	).data;
+
+	const agentsRes = await page.request.get(`/api/projects/${project.slug}/agents`, { headers });
+	const agents = ((await agentsRes.json()) as { data: Array<{ id: string; slug: string }> }).data;
+	const assigneeId = (agents.find((a) => a.slug === 'captain') ?? agents[0]).id;
+
+	const taskRes = await page.request.post(`/api/projects/${project.slug}/tasks`, {
+		headers,
+		data: { project_id: project.id, title: 'Deep-link scroll task', assignee_id: assigneeId },
+	});
+	const task = ((await taskRes.json()) as { data: { id: string; identifier: string } }).data;
+
+	// Seed enough text comments that the thread overflows <main> and the target
+	// sits well below the fold. Authored by the admin token (no agent wakeup);
+	// any later agent comments append at the bottom and don't shift the target.
+	const created: { public_id: string; index: number }[] = [];
+	const BATCH = 10;
+	for (let start = 0; start < count; start += BATCH) {
+		const batch = Array.from({ length: Math.min(BATCH, count - start) }, (_, i) => start + i);
+		const results = await Promise.all(
+			batch.map((i) =>
+				page.request.post(`/api/projects/${project.slug}/tasks/${task.id}/comments`, {
+					headers,
+					data: {
+						content_type: 'text',
+						content: { text: `seeded comment ${i}. ${'lorem ipsum '.repeat(8)}` },
+					},
+				}),
+			),
+		);
+		for (const [k, res] of results.entries()) {
+			const json = (await res.json()) as { data: { public_id: string } };
+			created.push({ public_id: json.data.public_id, index: batch[k] });
+		}
+	}
+
+	return { project, task, created };
+}
+
+/** Vertical offset of the target comment's top from <main>'s top, in px. */
+async function targetTopWithinMain(page: Page, publicId: string): Promise<number | null> {
+	return page.evaluate((id) => {
+		const el = document.getElementById(`comment-${id}`);
+		const main = document.querySelector('main');
+		if (!el || !main) return null;
+		return Math.round(el.getBoundingClientRect().top - main.getBoundingClientRect().top);
+	}, publicId);
+}
+
+const mainScrollTop = (page: Page) =>
+	page
+		.locator('main')
+		.first()
+		.evaluate((el) => el.scrollTop);
+
+test.describe('Inbox deep-link scroll', () => {
+	test('lands the target comment at the top and never jumps back to the top of the task', async ({
+		sharedPage: page,
+		sharedWorkspace,
+	}) => {
+		test.setTimeout(60_000);
+		// A tall viewport so "near the top" (≈80px) is unambiguously distinct from
+		// the old centred landing (~clientHeight/2).
+		await page.setViewportSize({ width: 1280, height: 900 });
+		const { project, task, created } = await seedTaskWithComments(page, sharedWorkspace.token, 30);
+		const target = created[15];
+
+		await page.goto(
+			`/projects/${project.slug}/tasks/${task.identifier.toLowerCase()}#comment-${target.public_id}`,
+		);
+		await waitForPageLoad(page);
+
+		const anchored = page.locator(`#comment-${target.public_id}`);
+		await expect(anchored).toBeVisible({ timeout: 20_000 });
+
+		// The executor strips the hash once the scroll settles. Wait for that so we
+		// read the final resting position, not a mid-scroll frame.
+		await expect
+			.poll(() => page.evaluate(() => window.location.hash), { timeout: 15_000 })
+			.toBe('');
+
+		// (symptom 3) Stripping the hash must NOT bounce <main> to the top. The
+		// target is deep in the thread, so a correct landing keeps a large scrollTop.
+		expect(await mainScrollTop(page)).toBeGreaterThan(200);
+
+		// (symptom 1) The comment sits near the TOP of the viewport (≈80px headroom
+		// from `scroll-mt-20`), not centred.
+		const top = await targetTopWithinMain(page, target.public_id);
+		expect(top).not.toBeNull();
+		expect(top as number).toBeGreaterThanOrEqual(0);
+		expect(top as number).toBeLessThan(200);
+	});
+
+	test('a user scroll during the deep-link is honoured, not fought', async ({
+		sharedPage: page,
+		sharedWorkspace,
+	}) => {
+		test.setTimeout(60_000);
+		await page.setViewportSize({ width: 1280, height: 900 });
+		const { project, task, created } = await seedTaskWithComments(page, sharedWorkspace.token, 30);
+		const target = created[15];
+
+		await page.goto(
+			`/projects/${project.slug}/tasks/${task.identifier.toLowerCase()}#comment-${target.public_id}`,
+		);
+		await waitForPageLoad(page);
+		await expect(page.locator(`#comment-${target.public_id}`)).toBeVisible({ timeout: 20_000 });
+
+		// The user takes over scrolling right after the landing. Hover <main> so the
+		// wheel targets the scroll container, then scroll away from the comment.
+		const main = page.locator('main').first();
+		await main.hover();
+		await page.mouse.wheel(0, 300);
+		await page.waitForTimeout(150);
+		const afterUser = await mainScrollTop(page);
+
+		// Wait past the old retry-ladder + hash-strip window (~3.05s). On the buggy
+		// build this is where the viewport snapped back to the comment and/or was
+		// reset to the top; the fix backs off the moment the wheel fires and stays
+		// where the user left it. (The wait is intrinsic to the time-based bug, not
+		// masking a race.)
+		await page.waitForTimeout(3500);
+		const settled = await mainScrollTop(page);
+		expect(Math.abs(settled - afterUser)).toBeLessThan(80);
+	});
+});


### PR DESCRIPTION
## Problem

Clicking an inbox notification deep-links to a comment via `#comment-<id>` and the task page scrolls that comment into view. This had three bugs:

1. **Lands on the middle of the comment**, not its start.
2. **Bounces the user back** to the comment for ~3s every time they try to scroll away.
3. **Then jumps to the very top of the task** once the bouncing stops.

## Root cause

All three live in the deep-link executor in `packages/web/src/components/task-detail/comments-section.tsx` and its interaction with the shell scroll-reset in `routes/__root.tsx`:

- **(1)** The executor scrolled with `align: 'center'` / `scrollIntoView({ block: 'center' })` — both center the target.
- **(2)** A blind retry ladder fired the scroll five times over ~3s (`[16, 200, 600, 1500, 3000]`), re-forcing it regardless of user input. (The ladder existed for a real reason: Virtuoso with `customScrollParent` mounts rows lazily and comment heights grow post-mount, so one `scrollToIndex` lands short.)
- **(3)** On settle the executor strips the hash via `replaceState`. TanStack Router patches `replaceState`, so `useLocation().hash` in the shell flips to `''`, which fired the shell scroll-reset effect (`if (hash) return; main.scrollTo({ top: 0 })`) → jump to top.

## Fix

- **Land at the top, not center**: `scrollToIndex({ align: 'start' })` + `scrollIntoView({ block: 'start' })`. Rows already carry `scroll-mt-20` (80px headroom), matching the existing "wake the list" pre-scroll.
- **Stop fighting the user**: a self-terminating re-anchor loop that stops once the row holds its spot for two consecutive ticks (still absorbing post-mount height growth within a bounded budget), and **aborts immediately** on the first user scroll intent (`wheel` / `touchmove` / scroll keys) via an `AbortController`.
- **No jump-to-top**: the shell scroll-reset now resets only on an actual **pathname** change, not a hash-only change — so stripping `#comment-<id>` on the same page no longer bounces `<main>` to the top.

All the hard-won guards are preserved (dedupe ref set in the first tick for StrictMode safety, highlight, wake-the-list pre-scroll, refetch dedupe).

## Testing

- New Playwright spec `test/browser/task-deep-link-scroll.spec.ts` (real `scrollTop`/`boundingBox` + a native wheel event):
  - lands the target near the top and **does not** jump to the top after the hash is stripped;
  - a user scroll during the deep-link is honored, not fought.
  - Both **fail on the pre-fix code** (e.g. the viewport moved 2561px from where the user left it) and **pass after** the fix.
- Existing `test/browser/scroll-reset-on-navigate.spec.ts` still passes (page-change reset preserved).
- `packages/web/test/inbox-mentions.test.tsx` (StrictMode deep-link/highlight), `comment-timestamp-permalink.test.tsx`, and the broader comment-related component suite all pass.
- `typecheck` + `biome` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JbYcWqPMKoEEjwLEALbFci

---
_Generated by [Claude Code](https://claude.ai/code/session_01JbYcWqPMKoEEjwLEALbFci)_