### PR TITLE
feat: make every timestamped timeline item a self-permalink

### DIFF
--- a/packages/web/src/components/comment-renderers/comment-data.ts
+++ b/packages/web/src/components/comment-renderers/comment-data.ts
@@ -24,6 +24,7 @@ export interface ToolCall {
 export type CommentData = {
 	[K in CommentContentType]: {
 		id: string;
+		public_id: string;
 		content_type: K;
 		content: CommentContentByType[K];
 		chosen_option?: CommentChosenByType[K];

--- a/packages/web/src/components/comment-renderers/comment-timestamp-link.tsx
+++ b/packages/web/src/components/comment-renderers/comment-timestamp-link.tsx
@@ -1,0 +1,33 @@
+import { jumpToComment } from './helpers';
+
+/**
+ * A comment's timestamp rendered as a self-anchor (`#comment-<public_id>`), so
+ * every timeline row — text comments and inline events alike — exposes a
+ * copy-able permalink that scrolls to and highlights itself. `stopPropagation`
+ * keeps a click from reaching an enclosing control (the run row's expand
+ * button wraps its timestamp); it's a no-op for the other call sites.
+ */
+export function CommentTimestampLink({
+	publicId,
+	createdAt,
+	className,
+}: {
+	publicId: string;
+	createdAt: string;
+	className?: string;
+}) {
+	return (
+		<a
+			href={`#comment-${publicId}`}
+			onClick={(e) => {
+				e.stopPropagation();
+				jumpToComment(publicId)(e);
+			}}
+			className={`text-[11px] text-text-subtle hover:text-text hover:underline${className ? ` ${className}` : ''}`}
+			title="Link to this comment"
+			data-testid="comment-timestamp-link"
+		>
+			{new Date(createdAt).toLocaleString()}
+		</a>
+	);
+}

--- a/packages/web/src/components/comment-renderers/helpers.ts
+++ b/packages/web/src/components/comment-renderers/helpers.ts
@@ -7,11 +7,23 @@ import {
 	Terminal,
 	UserRoundCog,
 } from 'lucide-react';
-import type { ComponentType, SVGProps } from 'react';
+import type { ComponentType, MouseEvent, SVGProps } from 'react';
 import type { TextContent } from '../comment-content';
 import type { CommentData } from './comment-data';
 
 export type LucideIcon = ComponentType<SVGProps<SVGSVGElement>>;
+
+/** Drive the page's hashchange handler from any anchor — Virtuoso may not
+ * have the target row mounted yet, so the scroll has to flow through the
+ * `useEffect` in `comments-section.tsx`. */
+export function jumpToComment(commentId: string) {
+	return (e: MouseEvent) => {
+		e.preventDefault();
+		const target = `#comment-${commentId}`;
+		window.history.pushState(null, '', target);
+		window.dispatchEvent(new HashChangeEvent('hashchange'));
+	};
+}
 
 /**
  * Normalize a text comment's `content` to its body string. The composer sends a

--- a/packages/web/src/components/comment-renderers/index.tsx
+++ b/packages/web/src/components/comment-renderers/index.tsx
@@ -13,7 +13,8 @@ import { TraceComment } from './trace-comment';
 
 export type { CommentData } from './comment-data';
 export { CommentReactions } from './comment-reactions';
-export { commentText, inlineEventIcon, isInlineEventType } from './helpers';
+export { CommentTimestampLink } from './comment-timestamp-link';
+export { commentText, inlineEventIcon, isInlineEventType, jumpToComment } from './helpers';
 
 interface RenderProps {
 	comment: CommentData;

--- a/packages/web/src/components/comment-renderers/run-comment.tsx
+++ b/packages/web/src/components/comment-renderers/run-comment.tsx
@@ -14,6 +14,7 @@ import { LogViewer } from '../log-viewer';
 import { TerminateRunButton } from '../terminate-run-button';
 import { Tooltip } from '../ui/tooltip';
 import type { CommentDataOf } from './comment-data';
+import { CommentTimestampLink } from './comment-timestamp-link';
 import { runStatusDotClass, runStatusLabel } from './helpers';
 
 interface Props {
@@ -44,6 +45,7 @@ export function RunComment({ comment, projectId, inline }: Props) {
 					agentSlug={agentSlug}
 					actorName={actorName}
 					createdAt={comment.created_at}
+					publicId={comment.public_id}
 					inline={inline}
 				/>
 			</LazyMount>
@@ -68,6 +70,7 @@ function RunCommentBody({
 	agentSlug,
 	actorName,
 	createdAt,
+	publicId,
 	inline,
 }: {
 	projectId: string;
@@ -77,6 +80,7 @@ function RunCommentBody({
 	agentSlug: string;
 	actorName: string | null;
 	createdAt: string;
+	publicId: string;
 	inline?: boolean;
 }) {
 	const runQuery = useHeartbeatRun(projectId, agentId, runId);
@@ -152,9 +156,11 @@ function RunCommentBody({
 					)}
 				</span>
 			)}
-			<span className="text-[11px] text-text-subtle truncate min-w-0">
-				{new Date(createdAt).toLocaleString()}
-			</span>
+			<CommentTimestampLink
+				publicId={publicId}
+				createdAt={createdAt}
+				className="truncate min-w-0"
+			/>
 		</span>
 	);
 

--- a/packages/web/src/components/comment-renderers/system-comment.tsx
+++ b/packages/web/src/components/comment-renderers/system-comment.tsx
@@ -12,6 +12,7 @@ import type {
 } from '../comment-content';
 import { Tooltip } from '../ui/tooltip';
 import type { CommentDataOf } from './comment-data';
+import { CommentTimestampLink } from './comment-timestamp-link';
 
 interface Props {
 	comment: CommentDataOf<'system'>;
@@ -37,9 +38,7 @@ export function SystemComment({ comment, projectId, taskId, retryableRunId }: Pr
 	const content: SystemContent | null =
 		comment.content && typeof comment.content === 'object' ? comment.content : null;
 	const timestamp = (
-		<span className="text-[11px] text-text-subtle">
-			{new Date(comment.created_at).toLocaleString()}
-		</span>
+		<CommentTimestampLink publicId={comment.public_id} createdAt={comment.created_at} />
 	);
 
 	if (content && isTaskLink(content) && projectId) {

--- a/packages/web/src/components/task-detail/comments-section.tsx
+++ b/packages/web/src/components/task-detail/comments-section.tsx
@@ -11,23 +11,13 @@ import {
 	type CommentData,
 	CommentReactions,
 	CommentRenderer,
+	CommentTimestampLink,
 	commentText,
 	inlineEventIcon,
 	isInlineEventType,
+	jumpToComment,
 } from '../comment-renderers';
 import { Avatar, avatarColorFromString } from '../ui/avatar';
-
-/** Drive the page's hashchange handler from any anchor — Virtuoso may not
- * have the target row mounted yet, so the scroll has to flow through the
- * `useEffect` below. */
-export function jumpToComment(commentId: string) {
-	return (e: React.MouseEvent) => {
-		e.preventDefault();
-		const target = `#comment-${commentId}`;
-		window.history.pushState(null, '', target);
-		window.dispatchEvent(new HashChangeEvent('hashchange'));
-	};
-}
 
 /**
  * Copies a comment's markdown body to the clipboard, swapping its icon to a
@@ -438,15 +428,7 @@ export function CommentsSection({
 												{authorName}
 											</span>
 										)}
-										<a
-											href={`#comment-${c.public_id}`}
-											onClick={jumpToComment(c.public_id)}
-											className="text-[11px] text-text-subtle hover:text-text hover:underline"
-											title="Link to this comment"
-											data-testid="comment-timestamp-link"
-										>
-											{new Date(c.created_at).toLocaleString()}
-										</a>
+										<CommentTimestampLink publicId={c.public_id} createdAt={c.created_at} />
 										<div className="ml-auto flex items-center gap-2">
 											{c.parent_comment_id &&
 												(() => {

--- a/packages/web/src/components/task-detail/last-run-failed-banner.tsx
+++ b/packages/web/src/components/task-detail/last-run-failed-banner.tsx
@@ -1,7 +1,7 @@
 import { AlertTriangle, ChevronRight, Loader2, RotateCw } from 'lucide-react';
 import { useRetryFailedRun } from '../../hooks/use-retry-failed-run';
 import type { Task } from '../../hooks/use-tasks';
-import { jumpToComment } from './comments-section';
+import { jumpToComment } from '../comment-renderers';
 
 interface Props {
 	task: Task;

--- a/packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx
@@ -2,11 +2,9 @@ import type { AgentEffort } from '@hezo/shared';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { ArrowDown } from 'lucide-react';
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { jumpToComment } from '../../../../components/comment-renderers';
 import { CommentComposer } from '../../../../components/task-detail/comment-composer';
-import {
-	CommentsSection,
-	jumpToComment,
-} from '../../../../components/task-detail/comments-section';
+import { CommentsSection } from '../../../../components/task-detail/comments-section';
 import { DependenciesSection } from '../../../../components/task-detail/dependencies-section';
 import { LastRunFailedBanner } from '../../../../components/task-detail/last-run-failed-banner';
 import { SubTasksSection } from '../../../../components/task-detail/sub-tasks-section';

--- a/packages/web/test/comment-timestamp-permalink.test.tsx
+++ b/packages/web/test/comment-timestamp-permalink.test.tsx
@@ -2,9 +2,9 @@ import { expect, test } from 'vitest';
 import { renderApp } from './helpers/render';
 import { seedComment, seedProject, seedTask, seedWorkspace } from './helpers/seed';
 
-test("a comment's timestamp is a permalink to that comment", async () => {
+test("a text comment's timestamp is a permalink to that comment", async () => {
 	const seeded = { projectSlug: '', taskId: '', publicId: '' };
-	const { findByTestId, router } = await renderApp({
+	const { findAllByTestId, router } = await renderApp({
 		initialPath: '/',
 		seed: async () => {
 			const ws = await seedWorkspace();
@@ -23,9 +23,50 @@ test("a comment's timestamp is a permalink to that comment", async () => {
 
 	// The timestamp renders as an anchor whose href is the comment's `#comment-`
 	// hash, so a right-click → "Copy link" yields the comment's permalink.
-	const link = (await findByTestId('comment-timestamp-link', undefined, {
+	const links = (await findAllByTestId('comment-timestamp-link', undefined, {
 		timeout: 10_000,
-	})) as HTMLAnchorElement;
-	expect(link.tagName).toBe('A');
-	expect(link.getAttribute('href')).toBe(`#comment-${seeded.publicId}`);
+	})) as HTMLAnchorElement[];
+	const link = links.find((a) => a.getAttribute('href') === `#comment-${seeded.publicId}`);
+	expect(link).toBeDefined();
+	expect(link?.tagName).toBe('A');
+});
+
+test("an inline event row's timestamp is a permalink to that event", async () => {
+	const seeded = { projectSlug: '', taskId: '', publicId: '' };
+	const { findAllByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async (ctx) => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Event Permalink Project' });
+			const task = await seedTask(ws, project, { title: 'Event Permalink Task' });
+			// Inline system events (status changes, links, run summaries) render their
+			// timestamp inside the renderer, not the parent comment row. Insert one
+			// directly to assert it now carries the same self-permalink anchor as text
+			// comments — the run renderer shares the identical `CommentTimestampLink`.
+			const inserted = await ctx.db.query<{ public_id: string }>(
+				`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
+				 VALUES ($1, $2, 'system'::comment_content_type, $3::jsonb)
+				 RETURNING public_id`,
+				[
+					task.id,
+					ws.agents[0].id,
+					JSON.stringify({ kind: 'status_change', from: 'backlog', to: 'in_progress' }),
+				],
+			);
+			seeded.projectSlug = project.slug;
+			seeded.taskId = task.identifier.toLowerCase();
+			seeded.publicId = inserted.rows[0].public_id;
+		},
+	});
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
+	});
+
+	const links = (await findAllByTestId('comment-timestamp-link', undefined, {
+		timeout: 10_000,
+	})) as HTMLAnchorElement[];
+	const link = links.find((a) => a.getAttribute('href') === `#comment-${seeded.publicId}`);
+	expect(link).toBeDefined();
+	expect(link?.tagName).toBe('A');
 });


### PR DESCRIPTION
## What

In the task detail timeline, **text comments** rendered their timestamp as a clickable self-anchor (`<a href="#comment-<public_id>">`) — right-click → "Copy link" yields a permalink, and clicking scrolls to + highlights that row. But the **inline event rows** (system events like "Linked from TO-2", "Auto-unblocked — TO-3 closed", "changed status from Backlog to In Progress", and "… run succeeded · 19 lines · 44s · $0.13") rendered their timestamp as a plain `<span>`.

This makes **every** timeline item that shows a timestamp link to itself, consistent with text comments.

## Why it was small

The infrastructure already existed — every row wrapper already carries `id={`comment-${c.public_id}`}` (for both inline and regular items), and the hash-jump executor already resolves `#comment-<id>` for any loaded row. The only gap was rendering the inline timestamp as a link instead of a span.

## How

- Extract a shared **`CommentTimestampLink`** component, now used by the comment list, the system renderer, and the run renderer, so the permalink markup can't drift between item types. It `stopPropagation`s on click so the run row's enclosing expand `<button>` isn't toggled (mirrors the existing agent `<Link>` in that row).
- Move `jumpToComment` down into the `comment-renderers` layer so the inline renderers can use it without an import cycle (its 3 external importers are updated).
- Add `public_id` to the `CommentData` type — the row data already carries it at runtime (`comments-section` casts the full `Comment`), so this is type-only.

## Tests

`comment-timestamp-permalink.test.tsx` (component tier — DOM/href assertion only):
- Existing text-comment assertion made robust to multiple links on a page.
- New case: an inline **system** event row's timestamp is an `<a data-testid="comment-timestamp-link">` pointing at `#comment-<public_id>`. The run renderer shares the identical component.

## Verification

- `bunx vitest run test/comment-timestamp-permalink.test.tsx` — green (2/2).
- 12 comment/run/timeline web test files — green (45/45).
- `bun run typecheck` — green across all packages.
- `bunx biome check` on the changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014G9ACQWVJRFYNgnrtZoaiv

---
_Generated by [Claude Code](https://claude.ai/code/session_014G9ACQWVJRFYNgnrtZoaiv)_