### PR TITLE
fix: allow mentioning HQ instance agents (CEO/Coach) from any project

### DIFF
--- a/packages/server/src/routes/mentions.ts
+++ b/packages/server/src/routes/mentions.ts
@@ -247,16 +247,20 @@ mentionsRoutes.get('/projects/:projectId/mentions/search', async (c) => {
 		if (q === '' || ADMIN_MENTION_SLUG.startsWith(lq) || ADMIN_MENTION_SLUG.includes(lq)) {
 			results.push(BOARD_SUGGESTION);
 		}
+		// HQ instance agents (CEO/Coach) are virtual members of every project
+		// team — surface them alongside the team's own roster so they can be
+		// @-mentioned from any project (mirrors GET /projects/:projectId/agents).
+		// Own-team agents sort first; instance agents follow.
 		const r = await db.query<{ slug: string; title: string }>(
 			`SELECT ma.slug, ma.title
 			 FROM member_agents ma
 			 JOIN members m ON m.id = ma.id
-			 WHERE m.team_id = $1
+			 WHERE (m.team_id = $1 OR (m.team_id = $5 AND $1 <> $5))
 			   AND ma.admin_status = 'enabled'
 			   AND ($2 = '' OR ma.slug ILIKE $3 OR ma.title ILIKE $3)
-			 ORDER BY ma.title
+			 ORDER BY (m.team_id <> $1), ma.title
 			 LIMIT $4`,
-			[teamId, q, pattern, perKind],
+			[teamId, q, pattern, perKind, DEFAULT_TEAM_ID],
 		);
 		for (const row of r.rows) {
 			results.push({

--- a/packages/server/src/services/comment-wakeups.ts
+++ b/packages/server/src/services/comment-wakeups.ts
@@ -1,5 +1,11 @@
 import type { PGlite } from '@electric-sql/pglite';
-import { ADMIN_MENTION_SLUG, CommentContentType, WakeupSource, wsRoom } from '@hezo/shared';
+import {
+	ADMIN_MENTION_SLUG,
+	CommentContentType,
+	DEFAULT_TEAM_ID,
+	WakeupSource,
+	wsRoom,
+} from '@hezo/shared';
 import { broadcastRowChange } from '../lib/broadcast';
 import { extractMentionSlugs } from '../lib/mentions';
 import { logger } from '../logger';
@@ -58,11 +64,19 @@ export async function fireCommentWakeups(params: FireCommentWakeupsParams): Prom
 			}).catch((e) => log.error('Failed to fan out @admin mention:', e));
 			continue;
 		}
+		// Resolve against the task's team plus the HQ instance agents
+		// (CEO/Coach), which act inside every team's projects. A same-team
+		// agent wins over an HQ namesake. The wakeup carries the task's team,
+		// so an instance agent runs scoped to this project — the run-team
+		// split realigns it (see agent-runner).
 		const mentioned = await db.query<{ id: string }>(
 			`SELECT ma.id FROM member_agents ma
 			 JOIN members m ON m.id = ma.id
-			 WHERE ma.slug = $1 AND m.team_id = $2`,
-			[slug, teamId],
+			 WHERE ma.slug = $1
+			   AND (m.team_id = $2 OR (m.team_id = $3 AND $2 <> $3))
+			 ORDER BY (m.team_id <> $2)
+			 LIMIT 1`,
+			[slug, teamId, DEFAULT_TEAM_ID],
 		);
 		if (mentioned.rows.length === 0) continue;
 		const mentionedId = mentioned.rows[0].id;

--- a/packages/server/test/comment-wakeups.test.ts
+++ b/packages/server/test/comment-wakeups.test.ts
@@ -5,7 +5,13 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import type { MasterKeyManager } from '../src/crypto/master-key';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject, mintAgentToken } from './helpers/app';
+import {
+	authHeader,
+	createTestApp,
+	createTestProject,
+	instanceCeoId,
+	mintAgentToken,
+} from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -269,6 +275,31 @@ describe('MCP create_comment fires mention-only wakeups', () => {
 			.map((w) => w.member_id);
 		expect(mentionTargets).toEqual([architectId]);
 		expect(wakeups.some((w) => w.member_id === productLeadId)).toBe(false);
+	});
+
+	it('wakes the HQ CEO when @ceo is mentioned, scoped to the task team', async () => {
+		const ceoId = await instanceCeoId(db);
+		const { taskId, agentToken } = await setup(captainId, engineerId, 'Escalate to CEO');
+		const commentId = await postMcpComment(
+			agentToken,
+			taskId,
+			'@ceo can you weigh in on priorities here?',
+		);
+
+		const wakeups = await wakeupsForComment(commentId);
+		const ceoWake = wakeups.find((w) => w.member_id === ceoId);
+		expect(ceoWake).toBeDefined();
+		if (!ceoWake) throw new Error('expected a CEO mention wakeup');
+		expect(ceoWake.source).toBe(WakeupSource.Mention);
+		expect(ceoWake.payload.task_id).toBe(taskId);
+
+		// The CEO lives in HQ, but the wakeup carries the task's (non-HQ) team so
+		// the run executes scoped to this project (the run-team split).
+		const teamCheck = await db.query<{ team_id: string }>(
+			'SELECT team_id FROM agent_wakeup_requests WHERE id = $1',
+			[ceoWake.id],
+		);
+		expect(teamCheck.rows[0]?.team_id).toBe(teamId);
 	});
 });
 

--- a/packages/server/test/mentions.test.ts
+++ b/packages/server/test/mentions.test.ts
@@ -236,4 +236,39 @@ describe('GET /teams/:teamId/mentions/search', () => {
 		// Skills are instance-global, so the kb doc is searchable from every team.
 		expect(handles).toContain('onboarding-guide.md');
 	});
+
+	it('surfaces the HQ instance agents (CEO/Coach) from a non-HQ project', async () => {
+		const ceoRes = await app.request(
+			`/api/projects/${projectSlug}/mentions/search?q=ceo&kind=agent`,
+			{ headers: authHeader(token) },
+		);
+		expect(ceoRes.status).toBe(200);
+		const ceoHandles = ((await ceoRes.json()).data as Array<{ handle: string }>).map(
+			(row) => row.handle,
+		);
+		expect(ceoHandles).toContain('ceo');
+
+		const coachRes = await app.request(
+			`/api/projects/${projectSlug}/mentions/search?q=coach&kind=agent`,
+			{ headers: authHeader(token) },
+		);
+		expect(coachRes.status).toBe(200);
+		const coachHandles = ((await coachRes.json()).data as Array<{ handle: string }>).map(
+			(row) => row.handle,
+		);
+		expect(coachHandles).toContain('coach');
+	});
+
+	it('lists each HQ instance agent exactly once (no team/HQ duplication)', async () => {
+		const r = await app.request(
+			`/api/projects/${projectSlug}/mentions/search?q=&kind=agent&limit=50`,
+			{ headers: authHeader(token) },
+		);
+		expect(r.status).toBe(200);
+		const handles = ((await r.json()).data as Array<{ handle: string }>).map((row) => row.handle);
+		expect(handles.filter((h) => h === 'ceo')).toHaveLength(1);
+		expect(handles.filter((h) => h === 'coach')).toHaveLength(1);
+		// The team's own roster still appears alongside the instance agents.
+		expect(handles).toContain('picker-bot');
+	});
 });


### PR DESCRIPTION
## Problem

Typing `@ceo` in a task comment from any project outside HQ showed **"No matches for @ceo"** in the mention autocomplete, and even if the mention was typed out manually it never woke the CEO.

The CEO and Coach are instance-level singletons that live in the **HQ** team but act across every team's projects. Two mention paths still filtered agents to the *current* team, so those HQ-resident agents were invisible:

- `GET /projects/:projectId/mentions/search` (the autocomplete data source) — `WHERE m.team_id = $1`
- `fireCommentWakeups` (the active-mention → wakeup resolver) — `WHERE ma.slug = $1 AND m.team_id = $2`

Meanwhile the agent **roster** endpoint (`GET /projects/:projectId/agents`) *already* treats HQ instance agents as *"virtual members of every project team"*, which is why a manually-typed `@ceo` already rendered as a link — the search and wakeup paths were simply inconsistent with it.

## Fix

Mirror the roster's HQ-inclusion clause in both mention paths:

```sql
WHERE (m.team_id = $teamId OR (m.team_id = $hqId AND $teamId <> $hqId))
```

- **Autocomplete** now surfaces CEO/Coach from any project (own-team agents sort first, instance agents follow — matching the roster's ordering). The `$teamId <> $hqId` guard prevents double-listing when the project *is* HQ.
- **Wakeups** now resolve `@ceo`/`@coach` to the HQ singleton, preferring a same-team agent over an HQ namesake (`ORDER BY (m.team_id <> $teamId) … LIMIT 1`). The wakeup is created with the **task's** team, so the instance agent runs scoped to that project — this is the established cross-team pattern already used by CEO coherence review and Coach task-done review (the run-team split realigns the run; see `agent-runner`). No schema or dispatcher changes were needed.

Rendering already worked (via the roster endpoint), so no frontend changes were required.

## Tests

- `packages/server/test/mentions.test.ts`
  - CEO and Coach are surfaced by the search endpoint from a non-HQ project.
  - Each instance agent is listed exactly once (no team/HQ duplication), alongside the team's own roster.
- `packages/server/test/comment-wakeups.test.ts`
  - Mentioning `@ceo` creates a `Mention` wakeup for the HQ CEO **scoped to the task's (non-HQ) team**.

All 42 tests in the two files pass; `bun run check`, `typecheck`, and `build` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mWgdZvxDVrQ6SxVRFTRPs

---
_Generated by [Claude Code](https://claude.ai/code/session_012mWgdZvxDVrQ6SxVRFTRPs)_