### PR TITLE
test: harden flaky budget + comment-attachment specs

### DIFF
--- a/packages/server/test/budget.test.ts
+++ b/packages/server/test/budget.test.ts
@@ -84,28 +84,39 @@ async function insertCost(amountCents: number, ageInterval: string): Promise<voi
 	);
 }
 
+/**
+ * Insert a cost_entry anchored to the start of the current UTC day. Use this for
+ * "current/today" spend: the timestamp equals the daily window floor and sits at
+ * or after the weekly/monthly floors, so the entry counts in every window no
+ * matter what time of day the suite runs. A `now() - '1 hour'` entry, by
+ * contrast, lands in *yesterday* (and possibly last week/month) when the suite
+ * runs in the first hour after UTC midnight — the source of past flakes.
+ */
+async function insertCostToday(amountCents: number): Promise<void> {
+	await db.query(
+		`INSERT INTO cost_entries (member_id, project_id, amount_cents, created_at)
+		 VALUES ($1, $2, $3, date_trunc('day', now() AT TIME ZONE 'UTC'))`,
+		[agentId, projectId, amountCents],
+	);
+}
+
 describe('budget service - windowed spend', () => {
 	it('sums spend per UTC window and excludes older entries', async () => {
-		await insertCost(100, '1 hour'); // today
-		await insertCost(200, '2 days'); // this week (not today) — but only if same week
-		await insertCost(400, '40 days'); // older than a month
+		await insertCostToday(100); // in daily, weekly, and monthly
+		await insertCost(400, '40 days'); // older than any month → excluded from every window
 
 		const spend = await getAgentSpend(db, agentId);
-		// Daily includes only the 1-hour-old entry.
+		// Today's entry is the only one inside any window; the 40-day-old entry is
+		// excluded from all three (40 days predates every window floor year-round).
 		expect(spend.daily).toBe(100);
-		// Monthly excludes the 40-day-old entry (older than start-of-month for most of
-		// the month; at minimum it is excluded once we're >40 days into enforcement —
-		// assert the floor that today's entry is always counted and the 40d one is not
-		// counted in daily/weekly).
-		expect(spend.weekly).toBeGreaterThanOrEqual(100);
-		expect(spend.monthly).toBeGreaterThanOrEqual(spend.weekly);
-		expect(spend.monthly).toBeLessThan(700);
+		expect(spend.weekly).toBe(100);
+		expect(spend.monthly).toBe(100);
 	});
 });
 
 describe('budget service - status & limits', () => {
 	it('treats a 0 limit as unlimited', async () => {
-		await insertCost(10_000, '1 hour');
+		await insertCostToday(10_000);
 		const status = await getAgentBudgetStatus(db, agentId);
 		expect(status.daily.limitCents).toBe(0);
 		expect(status.daily.overBudget).toBe(false);
@@ -114,7 +125,7 @@ describe('budget service - status & limits', () => {
 
 	it('flags over budget when spend meets or exceeds a positive limit', async () => {
 		await db.query('UPDATE member_agents SET daily_budget_cents = 500 WHERE id = $1', [agentId]);
-		await insertCost(500, '1 hour');
+		await insertCostToday(500);
 		const status = await getAgentBudgetStatus(db, agentId);
 		expect(status.daily.overBudget).toBe(true);
 		expect(status.overBudget).toBe(true);
@@ -122,7 +133,7 @@ describe('budget service - status & limits', () => {
 
 	it('stays under budget below a positive limit', async () => {
 		await db.query('UPDATE member_agents SET monthly_budget_cents = 500 WHERE id = $1', [agentId]);
-		await insertCost(499, '1 hour');
+		await insertCostToday(499);
 		const status = await getAgentBudgetStatus(db, agentId);
 		expect(status.monthly.overBudget).toBe(false);
 	});
@@ -131,13 +142,13 @@ describe('budget service - status & limits', () => {
 describe('budget service - checkOverBudget gate', () => {
 	it('returns null when within budget', async () => {
 		await db.query('UPDATE member_agents SET daily_budget_cents = 1000 WHERE id = $1', [agentId]);
-		await insertCost(100, '1 hour');
+		await insertCostToday(100);
 		expect(await checkOverBudget(db, agentId, projectId)).toBeNull();
 	});
 
 	it('blocks on the agent window', async () => {
 		await db.query('UPDATE member_agents SET weekly_budget_cents = 100 WHERE id = $1', [agentId]);
-		await insertCost(150, '1 hour');
+		await insertCostToday(150);
 		const block = await checkOverBudget(db, agentId, projectId);
 		expect(block).toEqual({ scope: 'agent', period: 'weekly' });
 	});
@@ -145,14 +156,14 @@ describe('budget service - checkOverBudget gate', () => {
 	it('blocks all agents when the project is over budget', async () => {
 		// Agent itself is unlimited; the project cap is what trips.
 		await db.query('UPDATE projects SET monthly_budget_cents = 100 WHERE id = $1', [projectId]);
-		await insertCost(200, '1 hour');
+		await insertCostToday(200);
 		const block = await checkOverBudget(db, agentId, projectId);
 		expect(block).toEqual({ scope: 'project', period: 'monthly' });
 	});
 
 	it('checks only the agent when projectId is null', async () => {
 		await db.query('UPDATE projects SET monthly_budget_cents = 100 WHERE id = $1', [projectId]);
-		await insertCost(200, '1 hour');
+		await insertCostToday(200);
 		// Project is over, but a null project scope skips it.
 		expect(await checkOverBudget(db, agentId, null)).toBeNull();
 	});
@@ -213,7 +224,7 @@ describe('budget service - recordRunCost', () => {
 describe('budget-status API', () => {
 	it('returns project + per-agent window status with over-budget flags', async () => {
 		await db.query('UPDATE member_agents SET daily_budget_cents = 100 WHERE id = $1', [agentId]);
-		await insertCost(150, '1 hour');
+		await insertCostToday(150);
 
 		const res = await app.request(`/api/projects/${projectSlug}/budget-status`, {
 			headers: authHeader(token),

--- a/test/browser/task-comment-attachments.spec.ts
+++ b/test/browser/task-comment-attachments.spec.ts
@@ -72,6 +72,35 @@ test.describe('Task Comment Attachments', () => {
 		);
 	}
 
+	// Dispatch a drop and confirm it actually reached the handler by waiting for the
+	// upload POST to fire. A registered drop kicks off `upload.mutateAsync` (the
+	// POST) synchronously, so if no request appears within a few seconds the
+	// synthetic DragEvent was swallowed (handler not yet bound / lost under CI
+	// load) and we re-dispatch. We key off the *request*, never the response: a
+	// genuinely slow upload must not be mistaken for a lost drop, or the retry
+	// would fire a second upload and the composer (which does not dedupe) would
+	// render two chips.
+	async function dropFileAndAwaitUpload(
+		page: import('@playwright/test').Page,
+		taskId: string,
+		selector: string,
+		filename: string,
+		mime: string,
+		bytes: number[],
+	) {
+		for (let attempt = 0; attempt < 3; attempt++) {
+			const uploadStarted = page
+				.waitForRequest(
+					(r) => r.method() === 'POST' && r.url().includes(`/tasks/${taskId}/assets`),
+					{ timeout: 5000 },
+				)
+				.catch(() => null);
+			await dropFile(page, selector, filename, mime, bytes);
+			if (await uploadStarted) return;
+		}
+		throw new Error(`drop on ${selector} never triggered an upload for task ${taskId}`);
+	}
+
 	test('drag-drop adds a chip, sends, renders an icon thumb, opens in new tab', async ({
 		sharedPage: page,
 		context,
@@ -83,8 +112,9 @@ test.describe('Task Comment Attachments', () => {
 		await waitForPageLoad(page);
 		await expect(page.getByPlaceholder('Add a comment...')).toBeVisible({ timeout: 20000 });
 
-		await dropFile(
+		await dropFileAndAwaitUpload(
 			page,
+			task.id,
 			'[data-testid="comment-attachments-drop"]',
 			'shot.png',
 			'image/png',
@@ -144,8 +174,9 @@ test.describe('Task Comment Attachments', () => {
 			expect(text).toContain('10');
 		}).toPass({ timeout: 15000 });
 
-		await dropFile(
+		await dropFileAndAwaitUpload(
 			page,
+			task.id,
 			'[data-testid="comment-attachments-drop"]',
 			'shot.png',
 			'image/png',
@@ -171,8 +202,9 @@ test.describe('Task Comment Attachments', () => {
 		await waitForPageLoad(page);
 		await expect(page.getByPlaceholder('Add a comment...')).toBeVisible({ timeout: 20000 });
 
-		await dropFile(
+		await dropFileAndAwaitUpload(
 			page,
+			task.id,
 			'[data-testid="comment-attachments-drop"]',
 			'preview.png',
 			'image/png',
@@ -228,8 +260,9 @@ test.describe('Task Comment Attachments', () => {
 		await expect(hint).toBeVisible();
 		await expect(hint).toContainText('Drag and drop files to attach');
 
-		await dropFile(
+		await dropFileAndAwaitUpload(
 			page,
+			task.id,
 			'[data-testid="comment-attachments-drop"]',
 			'mobile.png',
 			'image/png',


### PR DESCRIPTION
## Why

Two pre-existing, environment-fragile tests that surfaced while watching CI on recent PRs. Both fail for reasons unrelated to product code — they're test-only robustness fixes.

## `budget.test.ts` — wall-clock fragility

Entries meant to represent "today" were inserted at `now() - '1 hour'`. When the suite runs in the **first hour after UTC midnight**, "1 hour ago" is *yesterday*, so it falls outside the daily window (`created_at >= date_trunc('day', now())`) → `daily` is 0 and the assertions fail (the exact failure seen at ~00:51 UTC). A `now() - '1 hour'` entry can also slip into last week/month near those boundaries.

- Add `insertCostToday()`, anchored to `date_trunc('day', now() AT TIME ZONE 'UTC')` — equal to the daily floor and at/after the weekly+monthly floors, so a "current" entry counts in every window regardless of run time. Use it for all "today" spend.
- Make the windowed-spend test deterministic: drop the boundary-fragile "2 days" middle entry, whose `monthly >= weekly` relation breaks when the start of the ISO week falls in the previous month. The test now asserts exact per-window sums from one today-entry + one 40-day-old entry (excluded from all windows year-round).

## `task-comment-attachments.spec.ts` — lost synthetic drop

The drag-drop → upload → chip path occasionally lost the synthetic `drop` event under CI load (parallel workers + 1 Hz agent cron + dev-mode Vite), so the upload never fired and the chip never appeared within the 20s wait. (Seen as 2 flaky + 1 failed in a recent run.)

- Add `dropFileAndAwaitUpload()`, which confirms the drop reached the handler by waiting for the upload `POST …/tasks/:id/assets` to fire, and re-dispatches the drop if it didn't.
- It keys off the **request**, never the response: a registered drop starts the POST near-instantly, so a genuinely slow upload is never mistaken for a lost drop. That distinction matters because the composer does **not** dedupe by filename — a spurious re-drop would upload twice and render two chips (strict-mode violation). The client-rejected `virus.exe` case keeps the plain `dropFile` (no upload fires).

## Verification
- `budget.test.ts` passes locally (12/12); the anchoring makes it time-of-day-independent by construction.
- Typecheck + build + lint green (pre-commit hook). No new lint warnings.
- The Playwright change can't run in this sandbox (no browser/network), but the retry is dedup-safe by construction; CI exercises it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tcy1Qir8VTcu8eAJcGdRup

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tcy1Qir8VTcu8eAJcGdRup)_