### PR TITLE
Add high-level docs/ folder for the marketing website

### DIFF
--- a/docs/cli-commands/usage.md
+++ b/docs/cli-commands/usage.md
@@ -1,0 +1,33 @@
+---
+title: CLI usage
+order: 5
+section: Reference
+---
+
+# CLI usage
+
+Hezo is one binary with a small, consistent set of commands. Run `hezo --help`
+at any time for the authoritative list.
+
+## Project commands
+
+| Command | Description |
+|---|---|
+| `hezo new` | Scaffold a new project with a chosen stack. |
+| `hezo deploy` | Build and ship the current project to production. |
+| `hezo status` | See health and traffic across all your projects. |
+| `hezo launch` | Run marketing and growth actions for a project. |
+
+## Common flags
+
+```sh
+hezo --version       # print the installed version
+hezo --help          # show all commands and flags
+```
+
+Every project responds to the same commands, so once you've learned the loop
+for one project it carries over to all the others.
+
+## Next
+
+- [Deployment](/docs/deployment) — production targets and self-hosting.

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -1,0 +1,39 @@
+---
+title: Core concepts
+order: 4
+section: Concepts
+---
+
+# Core concepts
+
+A short mental model for how Hezo is put together.
+
+## Projects
+
+A **project** is the primary unit you work with. Each project has its own stack,
+configuration, and deployment target, but every project speaks the same Hezo
+commands — so moving between them carries no context-switching cost.
+
+## A single binary
+
+Hezo is distributed as **one self-contained binary**. There's no runtime to
+install, no daemon to babysit, and nothing to keep up to date beyond the binary
+itself. Install it, put it on your `PATH`, and every command is available
+everywhere.
+
+## Your infrastructure
+
+Hezo **orchestrates**; you **own the accounts**. Deployments land on your own
+infrastructure and providers. Hezo coordinates the build, ship, and measurement
+steps without taking custody of your hosting, domains, or data.
+
+## The shipping loop
+
+Every project moves through the same loop — **build → deploy → measure →
+market** — and Hezo gives each stage a consistent command surface. You stay in
+flow instead of stitching services together.
+
+## Where to next
+
+- [CLI usage](/docs/cli-commands/usage) — every command and flag.
+- [Deployment](/docs/deployment) — shipping to production.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,35 @@
+---
+title: Deployment
+order: 6
+section: Guides
+---
+
+# Deployment
+
+Shipping a project to production is a single command:
+
+```sh
+hezo deploy
+```
+
+`hezo deploy` builds the current project and ships it to production. Because Hezo
+**orchestrates onto your own infrastructure**, the deploy runs against the
+accounts and providers you already own — you stay in control of hosting,
+domains, and data.
+
+## Checking a deployment
+
+```sh
+hezo status          # health and traffic across all your projects
+```
+
+## Self-hosting notes
+
+- Hezo keeps its state in a local data directory (default `~/.hezo/`).
+- Everything ships as a single binary — there is no separate runtime or daemon
+  to operate alongside it.
+
+## Related
+
+- [CLI usage](/docs/cli-commands/usage) — the full command reference.
+- [Core concepts](/docs/core-concepts) — the model behind projects and deploys.

--- a/docs/getting-started/first-project.md
+++ b/docs/getting-started/first-project.md
@@ -1,0 +1,37 @@
+---
+title: Your first project
+order: 3
+section: Getting started
+---
+
+# Your first project
+
+With the [`hezo` binary installed](/docs/getting-started/installation), you can
+take a project from an empty directory to a live deployment in two commands.
+
+## Scaffold and deploy
+
+```sh
+hezo new my-app      # scaffold a project with a chosen stack
+cd my-app
+hezo deploy          # build and ship to production
+```
+
+`hezo new` lays down a project using sensible defaults and conventions. `hezo
+deploy` builds the project and ships it to production on your own
+infrastructure — Hezo orchestrates the steps, you own the accounts.
+
+## Check on it
+
+```sh
+hezo status          # health and traffic across all your projects
+```
+
+## Keep shipping
+
+From here, the same commands work for every project you create — that's the
+point. Spinning up the next idea costs minutes, not a whole evening of setup.
+
+- [Core concepts](/docs/core-concepts) — how Hezo thinks about projects.
+- [CLI usage](/docs/cli-commands/usage) — the full command reference.
+- [Deployment](/docs/deployment) — targets and self-hosting notes.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,38 @@
+---
+title: Installation
+order: 2
+section: Getting started
+---
+
+# Installation
+
+Hezo ships as a single self-contained binary. The install command detects your
+OS and CPU architecture and downloads the matching build.
+
+## macOS & Linux
+
+```sh
+curl -fsSL https://hezo.ai/install.sh | sh
+```
+
+## Windows (PowerShell)
+
+```powershell
+irm https://hezo.ai/install.ps1 | iex
+```
+
+## Manual download
+
+Prefer to grab the binary yourself? Every build is published on
+[GitHub Releases](https://github.com/hezo-ai/hezo/releases). Download the asset
+for your platform (for example `hezo_darwin_arm64` or
+`hezo_windows_amd64.exe`), make it executable, and put it on your `PATH`.
+
+## Verify the install
+
+```sh
+hezo --version
+```
+
+Once that prints a version number you're ready to
+[create your first project](/docs/getting-started/first-project).

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,0 +1,41 @@
+---
+title: Introduction
+order: 1
+section: Overview
+---
+
+# Introduction
+
+**Hezo is the full-stack CLI for indie hackers** — one command line to take any
+side project from first commit to real users. Instead of stitching together a
+dozen separate tools, Hezo covers the whole shipping loop: **build, deploy,
+measure, and market**.
+
+## Why Hezo
+
+Indie founders rarely run a single app. You've got the main bet, two
+experiments, and that weekend idea that's quietly growing. Context-switching
+between dashboards, deploy configs, and analytics for each one is where momentum
+goes to die.
+
+Hezo gives every project the same muscle memory:
+
+- **One workflow** across all your repos and stacks.
+- **Zero config to start** — sensible defaults, escape hatches when you need them.
+- **A single binary** with no runtime to install or manage.
+- **Your infrastructure** — Hezo orchestrates, you own the accounts.
+
+## The shipping loop
+
+| Stage | What Hezo does |
+|---|---|
+| **Build** | Scaffold a project with a chosen stack and sensible conventions. |
+| **Deploy** | Build and ship the current project to production in one command. |
+| **Measure** | See health and traffic across all of your projects at a glance. |
+| **Market** | Run growth and launch actions without leaving the terminal. |
+
+## Where to next
+
+- [Installation](/docs/getting-started/installation) — get the `hezo` binary on your machine.
+- [Your first project](/docs/getting-started/first-project) — zero to deployed.
+- [Core concepts](/docs/core-concepts) — the mental model behind Hezo.


### PR DESCRIPTION
## What

Adds a top-level `docs/` folder of high-level, user-facing Hezo documentation in
markdown. These are consumed by the `hezo-ai/website` marketing site, which
mounts this repo as a git submodule and renders `docs/*.md` at `/docs`.

## Files

| File | Section / order |
|---|---|
| `docs/introduction.md` | Overview · 1 |
| `docs/getting-started/installation.md` | Getting started · 2 |
| `docs/getting-started/first-project.md` | Getting started · 3 |
| `docs/core-concepts.md` | Concepts · 4 |
| `docs/cli-commands/usage.md` | Reference · 5 |
| `docs/deployment.md` | Guides · 6 |

Each file carries `title` / `order` / `section` frontmatter that the website's
sidebar uses for grouping and ordering. Content is intentionally high-level and
marketing-facing (build → deploy → measure → market) — the internal `.dev/*`
specs are not exposed.

## Companion PR

The website integration (theme + `/docs` rendering + the submodule pointer) is
in `hezo-ai/website` on the same branch name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AEPHGLhap7UdcPzamqCocV

---
_Generated by [Claude Code](https://claude.ai/code/session_01AEPHGLhap7UdcPzamqCocV)_