### PR TITLE
ci: notify website to rebuild after CI passes on main

### DIFF
--- a/.github/workflows/notify-website.yml
+++ b/.github/workflows/notify-website.yml
@@ -1,0 +1,42 @@
+name: Notify website
+
+# When CI passes on main, tell the marketing website (hezo-ai/website) to bump its
+# vendor/hezo submodule to the new main commit. The website's docs are sourced from
+# this repo's docs/ folder via that submodule, and Cloudflare Pages redeploys the
+# site on the resulting push. Gated on CI success so the website never picks up a
+# commit that failed tests.
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    # Only fire when the CI run actually succeeded (skip failed / cancelled runs).
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      # Mint a short-lived token for the website repo via the existing
+      # hezo-release-bot app (App ID 3938851). Requires repo secrets
+      # RELEASE_APP_ID and RELEASE_APP_PRIVATE_KEY, and the app installed on
+      # hezo-ai/website with Contents:write.
+      - name: Mint app token (website)
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: hezo-ai
+          repositories: website
+
+      - name: Dispatch submodule-update event to website
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh api repos/hezo-ai/website/dispatches \
+            -f event_type=hezo-main-updated \
+            -F "client_payload[sha]=${{ github.event.workflow_run.head_sha }}"


### PR DESCRIPTION
## What

When CI passes on this repo's `main`, notify `hezo-ai/website` to bump its
`vendor/hezo` submodule (the website renders this repo's `docs/` via that
submodule) so Cloudflare Pages redeploys with the new docs.

## How

`.github/workflows/notify-website.yml`:
- Triggers on `workflow_run` for the **CI** workflow completing on `main`.
- Gated on `github.event.workflow_run.conclusion == 'success'` — a failed or
  cancelled CI run dispatches nothing, so the website never picks up a commit that
  failed tests.
- Mints a token via the existing **hezo-release-bot** app
  (`RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY`) scoped to the website repo and
  sends a `hezo-main-updated` `repository_dispatch`.

## Setup required

`hezo-release-bot` must be installed on `hezo-ai/website` with Contents: write,
and that repo needs the `RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY` secrets. The
companion workflow lives in `hezo-ai/website` (branch `claude/auto-update-hezo-submodule`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AEPHGLhap7UdcPzamqCocV

---
_Generated by [Claude Code](https://claude.ai/code/session_01AEPHGLhap7UdcPzamqCocV)_