### PR TITLE
fix(egress): make upstream-failure logs diagnosable; widen teardown test

### DIFF
--- a/packages/server/src/services/egress/proxy.ts
+++ b/packages/server/src/services/egress/proxy.ts
@@ -283,7 +283,7 @@ class RunProxyInstance {
 		// connection list under Bun.
 		front.on('connection', (socket) => this.trackSocket(socket as Socket));
 		front.on('request', (req, res) => {
-			this.forward(false, null, req, res).catch((e: Error) => this.onForwardError(res, e));
+			this.forward(false, null, req, res).catch((e: Error) => this.onHandlerError(res, e));
 		});
 		front.on('connect', (req, socket, head) => this.onConnect(req, socket as Socket, head));
 		// A client that drops mid-handshake should not surface as an unhandled error.
@@ -403,7 +403,7 @@ class RunProxyInstance {
 		const ca = await this.cfg.getMintCa();
 		const leaf = await ca.generateCertificate(host);
 		const server = createHttpsServer({ key: leaf.key, cert: leaf.cert }, (req, res) => {
-			this.forward(true, host, req, res).catch((e: Error) => this.onForwardError(res, e));
+			this.forward(true, host, req, res).catch((e: Error) => this.onHandlerError(res, e));
 		});
 		server.on('connection', (socket) => this.trackSocket(socket as Socket));
 		server.on('clientError', (_err, socket) => socket.destroy());
@@ -548,15 +548,50 @@ class RunProxyInstance {
 			},
 		);
 		this.trackUpstream(upstream);
-		upstream.on('error', (err) => this.onForwardError(res, err));
+		upstream.on('error', (err) => this.onForwardError(res, err, { host, port, method, path }));
 		req.pipe(upstream);
 	}
 
-	private onForwardError(res: ServerResponse, err: Error): void {
-		log.warn('egress upstream request failed', {
+	/** A connection to the real upstream failed (refused, DNS, timeout, TLS).
+	 * Logs the target and the error's system-level fields so the cause is
+	 * diagnosable — `code` distinguishes ECONNREFUSED (upstream refused) from
+	 * ENOTFOUND (DNS) from ETIMEDOUT — then returns a 502 to the agent. */
+	private onForwardError(res: ServerResponse, err: Error, target?: UpstreamTarget): void {
+		log.warn('egress upstream request failed', this.failureMeta(err, target));
+		this.finishError(res, err);
+	}
+
+	/** An error thrown by the request handler itself (secret lookup, substitution,
+	 * target resolution) before any upstream connection — distinct from an
+	 * upstream connectivity failure so the two are not conflated in the logs. */
+	private onHandlerError(res: ServerResponse, err: Error): void {
+		log.warn('egress request handler failed', this.failureMeta(err));
+		this.finishError(res, err);
+	}
+
+	/** Structured failure context: the run, the upstream target (when known), and
+	 * the Node `SystemError` fields present on connection errors. Fields absent
+	 * under the runtime (Bun does not always populate `code`/`syscall`) are
+	 * omitted rather than logged as `undefined`. */
+	private failureMeta(err: Error, target?: UpstreamTarget): Record<string, unknown> {
+		const sysErr = err as NodeJS.ErrnoException;
+		const meta: Record<string, unknown> = {
 			run: ref(this.cfg.scope.label, this.cfg.runId),
 			error: err.message,
-		});
+		};
+		if (target) {
+			meta.host = target.host;
+			meta.port = target.port;
+			meta.method = target.method;
+			meta.path = target.path;
+		}
+		if (sysErr.code) meta.code = sysErr.code;
+		if (sysErr.syscall) meta.syscall = sysErr.syscall;
+		if (sysErr.errno !== undefined) meta.errno = sysErr.errno;
+		return meta;
+	}
+
+	private finishError(res: ServerResponse, err: Error): void {
 		if (!res.headersSent) {
 			respondEarly(res, 502, 'upstream_error', err.message);
 		} else {
@@ -592,6 +627,15 @@ class RunProxyInstance {
 interface TargetAddress {
 	host: string;
 	port: number;
+	path: string;
+}
+
+/** The upstream a forwarded request was aimed at, attached to failure logs so a
+ * connection error names the host it could not reach. */
+interface UpstreamTarget {
+	host: string;
+	port: number;
+	method: string;
 	path: string;
 }
 

--- a/packages/server/test/bun/egress-streaming.bun.test.ts
+++ b/packages/server/test/bun/egress-streaming.bun.test.ts
@@ -190,4 +190,92 @@ describe('EgressProxy streaming + teardown under Bun', () => {
 			await new Promise<void>((r) => upstream.close(() => r()));
 		}
 	}, 30_000);
+
+	// The single-stream case above is not the full shape a Streamable-HTTP MCP
+	// (api.githubcopilot.com) presents at teardown: it holds several connections
+	// to one host at once — concurrent long-lived SSE channels plus short
+	// JSON-RPC POSTs whose upstream sockets linger in the keep-alive pool. Every
+	// one of those must be severed when the run is released, or the per-host
+	// server's close parks on the 5s deadline (the production warning).
+	test('severs concurrent streams and idle keep-alive connections to one host on release', async () => {
+		const { cert, key } = await mintCertFromCA(ca, 'localhost');
+		let openUpstreamConns = 0;
+		let closedUpstreamConns = 0;
+		const timers = new Set<ReturnType<typeof setInterval>>();
+		const upstream: HttpsServer = createHttpsServer({ cert, key }, (req, res) => {
+			openUpstreamConns++;
+			req.on('close', () => {
+				closedUpstreamConns++;
+			});
+			if (req.url === '/sse') {
+				res.writeHead(200, { 'content-type': 'text/event-stream' });
+				res.write(': open\n\n');
+				const timer = setInterval(() => res.write(': ping\n\n'), 100);
+				timers.add(timer);
+				req.on('close', () => {
+					clearInterval(timer);
+					timers.delete(timer);
+				});
+			} else {
+				// Quick JSON-RPC-style reply; the connection stays alive afterward,
+				// so its upstream socket sits idle in the agent's keep-alive pool.
+				res.writeHead(200, { 'content-type': 'application/json' });
+				res.end('{"ok":true}');
+			}
+		});
+		await new Promise<void>((r) => upstream.listen(0, '127.0.0.1', () => r()));
+		const upstreamPort = (upstream.address() as { port: number }).port;
+		await insertSecret('STREAM_MULTI', 'tok', ['localhost']);
+		const runId = `stream-multi-${process.pid}`;
+		const allocated = await proxy.allocateRunProxy(runId, { teamId, agentId });
+
+		const tunnels: TLSSocket[] = [];
+		try {
+			// Two concurrent long-lived SSE streams over separate tunnels.
+			for (let i = 0; i < 2; i++) {
+				const tls = await tunnelTo(allocated.proxyPort, 'localhost', upstreamPort);
+				tunnels.push(tls);
+				await new Promise<void>((resolve, reject) => {
+					tls.once('data', () => resolve());
+					tls.once('error', reject);
+					tls.setTimeout(10_000, () => reject(new Error('no SSE data')));
+					tls.write(
+						`GET /sse HTTP/1.1\r\nHost: localhost:${upstreamPort}\r\nAccept: text/event-stream\r\n` +
+							`Authorization: Bearer __HEZO_SECRET_STREAM_MULTI__\r\n\r\n`,
+					);
+				});
+			}
+			// A completed request whose connection lingers (keep-alive pool).
+			const idle = await tunnelTo(allocated.proxyPort, 'localhost', upstreamPort);
+			tunnels.push(idle);
+			await new Promise<void>((resolve, reject) => {
+				let acc = '';
+				idle.on('data', (c: Buffer) => {
+					acc += c.toString();
+					if (acc.includes('ok')) resolve();
+				});
+				idle.once('error', reject);
+				idle.setTimeout(10_000, () => reject(new Error('no RPC response')));
+				idle.write(
+					`POST /rpc HTTP/1.1\r\nHost: localhost:${upstreamPort}\r\nContent-Type: application/json\r\n` +
+						`Authorization: Bearer __HEZO_SECRET_STREAM_MULTI__\r\nContent-Length: 2\r\n\r\n{}`,
+				);
+			});
+
+			const started = Date.now();
+			await proxy.releaseRunProxy(runId);
+			const elapsed = Date.now() - started;
+			// Well under the 5_000ms close deadline — every connection severed, not waited on.
+			expect(elapsed).toBeLessThan(2_000);
+
+			// No leaked upstream connection: every upstream request the proxy opened
+			// is torn down. Give the FIN/RST a moment to land.
+			await new Promise<void>((r) => setTimeout(r, 250));
+			expect(closedUpstreamConns).toBe(openUpstreamConns);
+		} finally {
+			for (const t of tunnels) t.destroy();
+			for (const timer of timers) clearInterval(timer);
+			await new Promise<void>((r) => upstream.close(() => r()));
+		}
+	}, 30_000);
 });


### PR DESCRIPTION
## Context

A running dev server was emitting two families of egress-proxy warnings. Both are now diagnosed at the source.

### 1. `egress upstream request failed` — opaque and unactionable
The proxy logged upstream connection failures with only `run` + `err.message`, so you couldn't tell *which host* failed or *why* (refused vs DNS vs timeout). The observed `ECONNREFUSED` / "Was there a typo in the url or port?" lines were upstream-side — an agent in a research spiral hammered `bundlephobia.com`'s API, which intermittently refused / 429'd / 502'd. The proxy behaved correctly (it returns a `502 {"error":"upstream_error"}` to the agent); only the log was useless.

### 2. `server close timed out after 5000ms` — already fixed by #248
Investigated and **could not reproduce on current code** — concurrent SSE streams, idle keep-alive, and high-churn refusals all tear down in ~2ms. The decisive experiment: temporarily disabling the socket-destruction in `RunProxyInstance.close()` makes the concurrent-SSE teardown time out at the 5s deadline — exactly the prod symptom. That destruction landed in **#248 (2026-06-14)**, five days before the logs. **Root cause: the running dev-server process predates #248** (`closeAllConnections()` reaches idle connections but not in-flight streamed responses). Fix is already in main — restart the server. No teardown code change in this PR.

## Changes

**`packages/server/src/services/egress/proxy.ts`**
- Split the old `onForwardError` into:
  - `onForwardError` (upstream connection errors) — now logs the **target** (`host`, `port`, `method`, `path`) and the Node `SystemError` fields (`code`, `syscall`, `errno`), included only when present so Bun's missing fields don't render as `undefined`.
  - `onHandlerError` (errors thrown inside `forward()` — secret lookup/substitution) — logged distinctly as `egress request handler failed` so a real handler bug isn't conflated with upstream connectivity.
- Kept at `warn` (visibility was the goal); the line is now self-explaining, e.g.
  `egress upstream request failed {"host":"localhost","port":51466,"method":"GET","path":"/","code":"ECONNREFUSED"}`.

**`packages/server/test/bun/egress-streaming.bun.test.ts`**
- Added a Bun-native regression test: concurrent long-lived SSE streams + an idle keep-alive connection to one host; asserts run release severs them within the close deadline (`< 2s`) and leaks no upstream connection. Verified it **fails pre-#248** and **passes** now — widening teardown coverage beyond the single-stream case.

## Verification
- `bun test test/bun/egress-streaming.bun.test.ts test/bun/close-deadline.bun.test.ts` → 7 pass
- `bun run test --pattern egress` → 34 pass
- `bun run typecheck` → clean; biome on changed files → clean