### PR TITLE
fix(repos): adopt pre-populated workspace dir instead of failing the clone

### DIFF
--- a/packages/server/src/routes/repos.ts
+++ b/packages/server/src/routes/repos.ts
@@ -9,7 +9,11 @@ import { logger } from '../logger';
 import { provisionContainer } from '../services/containers';
 import { createGitHubRepo, parseGitHubUrl, validateRepoAccess } from '../services/github';
 import { getConnection } from '../services/oauth/connection-store';
-import { enqueueRepoSetupResumeWakeups, finalizePendingRepoSetup } from '../services/repo-setup';
+import {
+	enqueueRepoSetupResumeWakeups,
+	finalizePendingRepoSetup,
+	markRepoSetupFailed,
+} from '../services/repo-setup';
 import { ensureProjectRepos, removeRepoFromWorkspace } from '../services/repo-sync';
 
 const log = logger.child('routes');
@@ -149,6 +153,10 @@ reposRoutes.post('/projects/:projectId/repos', async (c) => {
 	let insertedRepo: InsertedRepo;
 	let becameDesignated = false;
 	let finalizeResult = emptyFinalize;
+	// Whether this repo would become the project's designated repo once its
+	// checkout is in place. Designation is deferred until the clone/init
+	// succeeds so a setup failure never leaves the gate half-open.
+	let wouldDesignate = false;
 
 	try {
 		const txResult = await withTransaction(db, async () => {
@@ -165,29 +173,10 @@ reposRoutes.post('/projects/:projectId/repos', async (c) => {
 				 RETURNING id, project_id, repo_identifier, host_type, oauth_connection_id, created_at`,
 				[projectId, repoIdentifier, conn.id],
 			);
-			const inserted = insertRes.rows[0];
-
-			let becameDesignated = false;
-			let finalize = emptyFinalize;
-			if (!projectRow.designated_repo_id) {
-				await db.query('UPDATE projects SET designated_repo_id = $1 WHERE id = $2', [
-					inserted.id,
-					projectId,
-				]);
-				becameDesignated = true;
-
-				finalize = await finalizePendingRepoSetup(db, {
-					teamId,
-					projectId,
-					repoId: inserted.id,
-					repoIdentifier,
-				});
-			}
-			return { inserted, becameDesignated, finalize };
+			return { inserted: insertRes.rows[0], wouldDesignate: !projectRow.designated_repo_id };
 		});
 		insertedRepo = txResult.inserted;
-		becameDesignated = txResult.becameDesignated;
-		finalizeResult = txResult.finalize;
+		wouldDesignate = txResult.wouldDesignate;
 	} catch (e) {
 		if (isUniqueViolation(e)) {
 			return err(
@@ -229,7 +218,43 @@ reposRoutes.post('/projects/:projectId/repos', async (c) => {
 		}
 	}
 
-	if (becameDesignated && cloneStatus !== 'failed') {
+	if (wouldDesignate) {
+		if (cloneStatus === 'failed') {
+			// Setup never produced a usable checkout. Don't designate or persist the
+			// repo; tell the operator on the gated task(s) and leave the approval
+			// pending so a fixed retry resolves it. Agents stay correctly parked.
+			const failure = await markRepoSetupFailed(db, {
+				teamId,
+				projectId,
+				repoIdentifier,
+				error: cloneError ?? 'unknown error',
+			});
+			await db.query('DELETE FROM repos WHERE id = $1', [insertedRepo.id]);
+			for (const row of failure.systemCommentRows) {
+				broadcastChange(c, wsRoom.team(teamId), 'task_comments', 'INSERT', row);
+			}
+			return err(
+				c,
+				'REPO_SETUP_FAILED',
+				`Failed to set up ${repoIdentifier}: ${cloneError ?? 'unknown error'}`,
+				500,
+			);
+		}
+
+		finalizeResult = await withTransaction(db, async () => {
+			await db.query('UPDATE projects SET designated_repo_id = $1 WHERE id = $2', [
+				insertedRepo.id,
+				projectId,
+			]);
+			return finalizePendingRepoSetup(db, {
+				teamId,
+				projectId,
+				repoId: insertedRepo.id,
+				repoIdentifier,
+			});
+		});
+		becameDesignated = true;
+
 		await ensureProjectContainerUp(c, projectId);
 		if (finalizeResult.resolvedApprovalId) {
 			await enqueueRepoSetupResumeWakeups(

--- a/packages/server/src/services/git.ts
+++ b/packages/server/src/services/git.ts
@@ -93,6 +93,95 @@ export async function cloneRepo(
 	return { success: true };
 }
 
+/**
+ * Connects an existing, already-populated directory to a remote — the path
+ * `cloneRepo` can't take because `git clone` refuses a non-empty destination.
+ * Used when an agent populated the workspace directory reserved for a repo
+ * before that repo was connected. When the remote already has commits its
+ * content is checked out (existing untracked files that would be overwritten
+ * abort rather than clobber either side); when the remote is empty the existing
+ * files are kept as the working tree to become the repo's initial content on the
+ * first commit/push. A `.git` created here is removed on failure so the
+ * directory stays eligible for a clean retry.
+ */
+export async function initRepoInPlace(
+	repoIdentifier: string,
+	targetDir: string,
+	sshAuthSock: string,
+	knownHostsPath: string,
+	hostType: RepoHostType = RepoHostType.GitHub,
+): Promise<{ success: boolean; error?: string }> {
+	return connectExistingRepo(
+		buildGitSshUrl(hostType, repoIdentifier),
+		targetDir,
+		sshEnv(sshAuthSock, knownHostsPath),
+	);
+}
+
+/**
+ * Transport-agnostic core of {@link initRepoInPlace}: connects `targetDir` to the
+ * repo at `url` (already protocol-qualified) using `env` for any network op.
+ * Exposed for tests that point at a local `file://` bare repo.
+ */
+export async function connectExistingRepo(
+	url: string,
+	targetDir: string,
+	env: Record<string, string>,
+): Promise<{ success: boolean; error?: string }> {
+	const hadGit = existsSync(join(targetDir, '.git'));
+	const fail = (error: string): { success: false; error: string } => {
+		if (!hadGit) rmSync(join(targetDir, '.git'), { recursive: true, force: true });
+		return { success: false, error };
+	};
+
+	const init = await spawn('git', ['init', '-b', 'main'], { cwd: targetDir, timeout: 30_000 });
+	if (init.exitCode !== 0) return fail(formatGitError(init.stderr));
+
+	const remote = await spawn('git', ['remote', 'add', 'origin', url], {
+		cwd: targetDir,
+		timeout: 30_000,
+	});
+	if (remote.exitCode !== 0) return fail(formatGitError(remote.stderr));
+
+	// A remote with no refs has no commits yet — keep the existing files as the
+	// initial working tree. `ls-remote --symref HEAD` can print a symref line even
+	// for an unborn HEAD, so emptiness is judged by the full ref listing.
+	const refs = await spawn('git', ['ls-remote', 'origin'], {
+		cwd: targetDir,
+		env,
+		timeout: 60_000,
+	});
+	if (refs.exitCode !== 0) return fail(formatGitError(refs.stderr));
+
+	if (refs.stdout.trim().length > 0) {
+		const head = await spawn('git', ['ls-remote', '--symref', 'origin', 'HEAD'], {
+			cwd: targetDir,
+			env,
+			timeout: 60_000,
+		});
+		if (head.exitCode !== 0) return fail(formatGitError(head.stderr));
+		const branch = head.stdout.match(/^ref:\s+refs\/heads\/(\S+)\s+HEAD/m)?.[1];
+		if (!branch) return fail('could not determine the remote default branch');
+
+		const fetch = await spawn('git', ['fetch', 'origin', branch], {
+			cwd: targetDir,
+			env,
+			timeout: 120_000,
+		});
+		if (fetch.exitCode !== 0) return fail(formatGitError(fetch.stderr));
+
+		// No `-f`: an existing untracked file that the checkout would overwrite
+		// aborts the operation rather than clobbering the agent's work.
+		const checkout = await spawn('git', ['checkout', '-B', branch, '--track', `origin/${branch}`], {
+			cwd: targetDir,
+			timeout: 60_000,
+		});
+		if (checkout.exitCode !== 0) return fail(formatGitError(checkout.stderr));
+	}
+
+	return { success: true };
+}
+
 export async function fetchRepo(
 	repoDir: string,
 	sshAuthSock: string,

--- a/packages/server/src/services/repo-setup.ts
+++ b/packages/server/src/services/repo-setup.ts
@@ -265,6 +265,67 @@ export async function finalizePendingRepoSetup(
 	};
 }
 
+export interface MarkFailedInput {
+	teamId: string;
+	projectId: string;
+	repoIdentifier: string;
+	error: string;
+}
+
+export interface MarkFailedResult {
+	approvalId: string | null;
+	systemCommentRows: Record<string, unknown>[];
+}
+
+/**
+ * Records a failed designated-repo setup on every task currently gated on it,
+ * without resolving the pending approval — so the operator can fix the cause and
+ * retry, and the agents stay correctly parked rather than running against a
+ * broken checkout. Posts one system comment per affected task and returns the
+ * inserted rows for broadcast.
+ */
+export async function markRepoSetupFailed(
+	db: PGlite,
+	input: MarkFailedInput,
+): Promise<MarkFailedResult> {
+	const approvalId = await findPendingApproval(db, input.teamId, input.projectId);
+	if (!approvalId) return { approvalId: null, systemCommentRows: [] };
+
+	const pendingTasks = await db.query<{ task_id: string }>(
+		`SELECT DISTINCT ic.task_id FROM task_comments ic
+		 JOIN tasks i ON i.id = ic.task_id
+		 WHERE ic.content_type = $1::comment_content_type
+		   AND ic.content->>'kind' = $2
+		   AND ic.content->>'approval_id' = $3
+		   AND ic.chosen_option IS NULL
+		   AND i.project_id = $4`,
+		[CommentContentType.Action, ActionCommentKind.SetupRepo, approvalId, input.projectId],
+	);
+
+	const systemCommentRows: Record<string, unknown>[] = [];
+	for (const row of pendingTasks.rows) {
+		const sys = await db.query<Record<string, unknown>>(
+			`INSERT INTO task_comments (task_id, content_type, content)
+			 VALUES ($1, $2::comment_content_type, $3::jsonb)
+			 RETURNING *`,
+			[
+				row.task_id,
+				CommentContentType.System,
+				JSON.stringify({
+					kind: 'repo_setup_failed',
+					repo_identifier: input.repoIdentifier,
+					host_type: 'github',
+					error: input.error,
+					text: `Could not set up repository ${input.repoIdentifier}: ${input.error}`,
+				}),
+			],
+		);
+		if (sys.rows[0]) systemCommentRows.push(sys.rows[0]);
+	}
+
+	return { approvalId, systemCommentRows };
+}
+
 /**
  * Re-enqueues each deferred wakeup as a fresh Automation wakeup pointing at the
  * previously-blocked task. The old Deferred rows are left for audit — they are

--- a/packages/server/src/services/repo-sync.ts
+++ b/packages/server/src/services/repo-sync.ts
@@ -4,7 +4,7 @@ import type { PGlite } from '@electric-sql/pglite';
 import { repoNameFromIdentifier } from '@hezo/shared';
 import type { MasterKeyManager } from '../crypto/master-key';
 import { logger } from '../logger';
-import { cloneRepo, ensureGithubKnownHosts } from './git';
+import { cloneRepo, ensureGithubKnownHosts, initRepoInPlace } from './git';
 import { withHostAgentSocket } from './ssh-agent/host';
 import type { SshAgentServer } from './ssh-agent/server';
 import { getWorkspacePath, getWorktreesPath } from './workspace';
@@ -46,14 +46,18 @@ export async function ensureProjectRepos(
 	const workspacePath = getWorkspacePath(dataDir, project.team_id, project.id);
 	mkdirSync(workspacePath, { recursive: true });
 
-	const pending: RepoRow[] = [];
+	const pending: Array<{ repo: RepoRow; mode: 'clone' | 'init' }> = [];
 	for (const r of repos.rows) {
 		const name = repoNameFromIdentifier(r.repo_identifier);
 		const targetDir = join(workspacePath, name);
 		if (existsSync(join(targetDir, '.git'))) {
 			result.skipped.push(name);
+		} else if (existsSync(targetDir) && readdirSync(targetDir).length > 0) {
+			// An agent populated this directory before the repo was connected — a
+			// plain clone would refuse the non-empty target, so adopt it in place.
+			pending.push({ repo: r, mode: 'init' });
 		} else {
-			pending.push(r);
+			pending.push({ repo: r, mode: 'clone' });
 		}
 	}
 
@@ -61,7 +65,7 @@ export async function ensureProjectRepos(
 
 	if (!sshAgentServer) {
 		const msg = 'SshAgentServer not available — cannot clone over SSH';
-		for (const r of pending) {
+		for (const { repo: r } of pending) {
 			logEmit?.('stderr', `✗ ${msg}`);
 			result.failed.push({ name: repoNameFromIdentifier(r.repo_identifier), error: msg });
 		}
@@ -71,19 +75,23 @@ export async function ensureProjectRepos(
 	const knownHostsPath = await ensureGithubKnownHosts(dataDir);
 
 	await withHostAgentSocket(sshAgentServer, project.team_id, dataDir, async ({ sshAuthSock }) => {
-		for (const r of pending) {
+		for (const { repo: r, mode } of pending) {
 			const name = repoNameFromIdentifier(r.repo_identifier);
 			const targetDir = join(workspacePath, name);
-			logEmit?.('stdout', `→ Cloning ${r.repo_identifier} into ${name}/`);
-			const clone = await cloneRepo(r.repo_identifier, targetDir, sshAuthSock, knownHostsPath);
-			if (clone.success) {
-				logEmit?.('stdout', `✓ Cloned ${name}`);
+			const verb = mode === 'init' ? 'Initializing' : 'Cloning';
+			logEmit?.('stdout', `→ ${verb} ${r.repo_identifier} → ${name}/`);
+			const res =
+				mode === 'init'
+					? await initRepoInPlace(r.repo_identifier, targetDir, sshAuthSock, knownHostsPath)
+					: await cloneRepo(r.repo_identifier, targetDir, sshAuthSock, knownHostsPath);
+			if (res.success) {
+				logEmit?.('stdout', `✓ ${mode === 'init' ? 'Initialized' : 'Cloned'} ${name}`);
 				result.cloned.push(name);
 			} else {
-				const errMsg = clone.error ?? 'unknown error';
-				logEmit?.('stderr', `✗ Clone failed for ${name}: ${errMsg}`);
+				const errMsg = res.error ?? 'unknown error';
+				logEmit?.('stderr', `✗ ${verb} failed for ${name}: ${errMsg}`);
 				result.failed.push({ name, error: errMsg });
-				log.error(`Failed to clone ${r.repo_identifier}`, errMsg);
+				log.error(`Failed to set up ${r.repo_identifier}`, errMsg);
 			}
 		}
 	});

--- a/packages/server/test/git-init-in-place.test.ts
+++ b/packages/server/test/git-init-in-place.test.ts
@@ -1,0 +1,94 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { connectExistingRepo } from '../src/services/git';
+
+let root: string;
+
+function git(cwd: string, ...args: string[]): void {
+	execFileSync('git', args, {
+		cwd,
+		env: {
+			...process.env,
+			GIT_AUTHOR_NAME: 'Test',
+			GIT_AUTHOR_EMAIL: 'test@example.com',
+			GIT_COMMITTER_NAME: 'Test',
+			GIT_COMMITTER_EMAIL: 'test@example.com',
+		},
+	});
+}
+
+/** A bare repo with one commit containing the given files, default branch `main`. */
+function makeRemoteWithCommit(files: Record<string, string>): string {
+	const seed = join(root, 'seed');
+	mkdirSync(seed, { recursive: true });
+	git(seed, 'init', '-b', 'main');
+	for (const [name, content] of Object.entries(files)) {
+		writeFileSync(join(seed, name), content);
+	}
+	git(seed, 'add', '-A');
+	git(seed, 'commit', '-m', 'initial');
+	const bare = join(root, 'remote.git');
+	git(root, 'clone', '--bare', seed, bare);
+	return bare;
+}
+
+function makeEmptyRemote(): string {
+	const bare = join(root, 'empty.git');
+	git(root, 'init', '--bare', '-b', 'main', bare);
+	return bare;
+}
+
+beforeEach(() => {
+	root = mkdtempSync(join(tmpdir(), 'init-in-place-'));
+});
+
+afterEach(() => {
+	rmSync(root, { recursive: true, force: true });
+});
+
+describe('connectExistingRepo', () => {
+	it('keeps existing files as the initial tree when the remote is empty', async () => {
+		const remote = makeEmptyRemote();
+		const target = join(root, 'work');
+		mkdirSync(target, { recursive: true });
+		writeFileSync(join(target, 'index.html'), '<html></html>');
+
+		const res = await connectExistingRepo(`file://${remote}`, target, {});
+
+		expect(res.success).toBe(true);
+		expect(existsSync(join(target, '.git'))).toBe(true);
+		expect(readFileSync(join(target, 'index.html'), 'utf8')).toBe('<html></html>');
+	});
+
+	it('checks out remote content while preserving non-conflicting local files', async () => {
+		const remote = makeRemoteWithCommit({ 'README.md': 'from remote\n' });
+		const target = join(root, 'work');
+		mkdirSync(target, { recursive: true });
+		writeFileSync(join(target, 'local-only.txt'), 'scaffold\n');
+
+		const res = await connectExistingRepo(`file://${remote}`, target, {});
+
+		expect(res.success).toBe(true);
+		expect(readFileSync(join(target, 'README.md'), 'utf8')).toBe('from remote\n');
+		expect(readFileSync(join(target, 'local-only.txt'), 'utf8')).toBe('scaffold\n');
+	});
+
+	it('fails and rolls back its .git when a local file conflicts with the remote', async () => {
+		const remote = makeRemoteWithCommit({ 'README.md': 'from remote\n' });
+		const target = join(root, 'work');
+		mkdirSync(target, { recursive: true });
+		writeFileSync(join(target, 'README.md'), 'local version\n');
+
+		const res = await connectExistingRepo(`file://${remote}`, target, {});
+
+		expect(res.success).toBe(false);
+		expect(res.error).toBeTruthy();
+		// Rolled back so the directory stays clone-eligible on retry, and the
+		// agent's file is untouched.
+		expect(existsSync(join(target, '.git'))).toBe(false);
+		expect(readFileSync(join(target, 'README.md'), 'utf8')).toBe('local version\n');
+	});
+});

--- a/packages/server/test/repo-setup-finalize-multi.test.ts
+++ b/packages/server/test/repo-setup-finalize-multi.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
 	enqueueRepoSetupResumeWakeups,
 	finalizePendingRepoSetup,
+	markRepoSetupFailed,
 } from '../src/services/repo-setup';
 import { safeClose } from './helpers';
 import { createTestDbWithMigrations } from './helpers/db';
@@ -216,6 +217,97 @@ describe('finalizePendingRepoSetup + enqueueRepoSetupResumeWakeups (multi-agent)
 			expect(result.deferredWakeups).toEqual([]);
 			expect(result.approvalRow).toBeNull();
 			expect(result.updatedCommentRows).toEqual([]);
+			expect(result.systemCommentRows).toEqual([]);
+		} finally {
+			await safeClose(db);
+		}
+	});
+});
+
+describe('markRepoSetupFailed', () => {
+	it('posts a failure comment per gated task, leaves the approval pending and the action unresolved, and does not resume the deferred wakeup', async () => {
+		const db = await createTestDbWithMigrations();
+		try {
+			const { teamId, projectId } = await seedTeamProject(db);
+			const aliceId = await seedAgent(db, teamId, 'Alice');
+			const bobId = await seedAgent(db, teamId, 'Bob');
+			const taskA = await seedTask(db, teamId, projectId, 1, 'Alice work', aliceId);
+			const taskB = await seedTask(db, teamId, projectId, 2, 'Bob work', bobId);
+			const { approvalId, commentIds } = await seedApprovalAndComments(db, teamId, projectId, [
+				taskA,
+				taskB,
+			]);
+			await seedDeferredWakeup(db, teamId, aliceId, projectId, taskA);
+			await seedDeferredWakeup(db, teamId, bobId, projectId, taskB);
+
+			const result = await markRepoSetupFailed(db, {
+				teamId,
+				projectId,
+				repoIdentifier: 'octo/multi',
+				error: 'destination path already exists',
+			});
+
+			expect(result.approvalId).toBe(approvalId);
+			expect(result.systemCommentRows).toHaveLength(2);
+
+			// Approval stays pending so a fixed retry can resolve it.
+			const approval = await db.query<{ status: string }>(
+				`SELECT status FROM approvals WHERE id = $1`,
+				[approvalId],
+			);
+			expect(approval.rows[0].status).toBe('pending');
+
+			// The setup-repo action stays actionable.
+			for (const cId of commentIds) {
+				const c = await db.query<{ chosen_option: unknown }>(
+					`SELECT chosen_option FROM task_comments WHERE id = $1`,
+					[cId],
+				);
+				expect(c.rows[0].chosen_option).toBeNull();
+			}
+
+			// A visible failure comment lands on each gated task.
+			for (const taskId of [taskA, taskB]) {
+				const sys = await db.query<{ content: { kind?: string; error?: string } }>(
+					`SELECT content FROM task_comments
+					 WHERE task_id = $1 AND content_type = 'system'::comment_content_type`,
+					[taskId],
+				);
+				expect(sys.rows).toHaveLength(1);
+				expect(sys.rows[0].content.kind).toBe('repo_setup_failed');
+				expect(sys.rows[0].content.error).toBe('destination path already exists');
+			}
+
+			// Agents stay parked — no resume wakeup was created.
+			const resumed = await db.query<{ count: number }>(
+				`SELECT COUNT(*)::int AS count FROM agent_wakeup_requests
+				 WHERE team_id = $1 AND payload->>'reason' = 'repo_setup_complete'`,
+				[teamId],
+			);
+			expect(resumed.rows[0].count).toBe(0);
+
+			const stillDeferred = await db.query<{ count: number }>(
+				`SELECT COUNT(*)::int AS count FROM agent_wakeup_requests
+				 WHERE team_id = $1 AND status = 'deferred'::wakeup_status`,
+				[teamId],
+			);
+			expect(stillDeferred.rows[0].count).toBe(2);
+		} finally {
+			await safeClose(db);
+		}
+	});
+
+	it('is a no-op when no pending approval exists', async () => {
+		const db = await createTestDbWithMigrations();
+		try {
+			const { teamId, projectId } = await seedTeamProject(db);
+			const result = await markRepoSetupFailed(db, {
+				teamId,
+				projectId,
+				repoIdentifier: 'octo/none',
+				error: 'boom',
+			});
+			expect(result.approvalId).toBeNull();
 			expect(result.systemCommentRows).toEqual([]);
 		} finally {
 			await safeClose(db);


### PR DESCRIPTION
## Problem

When an agent scaffolds files into `workspace/<repoName>` **before** the project's repo is connected, the later `git clone` refuses the non-empty destination (`destination path … already exists and is not an empty directory`) and reports the clone as **failed**. That failure short-circuits the resume step in the repo route (`if (becameDesignated && cloneStatus !== 'failed')`), so every agent parked waiting on repo setup stays permanently `deferred` — while the UI already shows the repo as set, because the approval + "Repository set" comment were committed earlier in the transaction.

Observed on a live dev instance: a `UI Designer` assigned to a task sat **Idle** forever after the repo was connected. Its only wakeup row was `assignment` / `deferred` / `reason: awaiting_repo_setup`, never resumed, with `repo-sync` logging the clone collision at the same moment the repo was designated.

## Fix

**Primary — adopt the existing directory instead of failing**
- `git.ts`: add `initRepoInPlace` (+ a transport-agnostic `connectExistingRepo` core). When the workspace dir exists without `.git`, it `git init`s in place, wires the remote, and either checks out remote content or — for an **empty** remote (a freshly-created GitHub repo, the common case) — keeps the agent's files as the repo's initial working tree. Checkout runs **without `-f`**, so a genuine conflict aborts rather than clobbering either side; a `.git` created on a failed attempt is removed so retries stay clean.
- `repo-sync.ts`: route a non-empty, `.git`-less target to init-in-place instead of a doomed clone.

**Secondary — stop silently stranding agents on genuine failure**
- `repos.ts` + `repo-setup.ts` (`markRepoSetupFailed`): defer designation, approval resolution, and wakeup resume until a working checkout exists. On genuine failure, roll back the repo row, leave the `designated_repo_request` approval **pending**, and post a visible `repo_setup_failed` comment on each gated task — so agents stay correctly parked and the operator can retry, instead of a half-commit.

## Tests

- `git-init-in-place.test.ts`: empty remote keeps files; non-conflicting checkout preserves local files; conflict → fail + `.git` rollback (against local `file://` bare repos).
- `repo-setup-finalize-multi.test.ts`: `markRepoSetupFailed` posts a failure comment per gated task, leaves the approval pending + action unresolved, and does **not** resume the deferred wakeup.

Existing `repo-sync` / `repos` / `repos-create-github` suites still pass; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)