### PR TITLE
Show a status dot instead of idle/running text in the team sidebar

### DIFF
--- a/packages/web/src/components/agent-status-label.tsx
+++ b/packages/web/src/components/agent-status-label.tsx
@@ -1,6 +1,7 @@
 import { AgentRuntimeStatus, BUDGET_PAUSE_STATUSES } from '@hezo/shared';
 import { agentRuntimeStatusMeta } from '../lib/status-meta';
 import { Badge } from './ui/badge';
+import { StatusDot } from './ui/status-dot';
 
 interface AgentStatusLabelProps {
 	name: string;
@@ -8,8 +9,9 @@ interface AgentStatusLabelProps {
 	/**
 	 * `badge` (default) renders the quiet-tint pill used on the task rail, the
 	 * agent roster and assignee menus. `sidebar` renders the design system's
-	 * team-list row: the name on the left, the status right-aligned in lowercase
-	 * mono, with a running agent shown in the cyan `live` tone and a bold name.
+	 * team-list row: the name on the left and a right-aligned status dot — a
+	 * pulsing cyan `live` dot (plus a bold name) while the agent is running, an
+	 * amber dot when budget-paused, and nothing at all when idle.
 	 */
 	variant?: 'badge' | 'sidebar';
 	className?: string;
@@ -24,15 +26,16 @@ export function AgentStatusLabel({
 	if (variant === 'sidebar') {
 		const running = runtimeStatus === AgentRuntimeStatus.Active;
 		const paused = (BUDGET_PAUSE_STATUSES as readonly string[]).includes(runtimeStatus);
-		const statusColor = running ? 'text-live' : paused ? 'text-danger' : 'text-text-3';
 		return (
 			<span className={`flex min-w-0 flex-1 items-center justify-between gap-2 ${className}`}>
 				<span className={`min-w-0 truncate ${running ? 'font-semibold text-text-1' : ''}`}>
 					{name}
 				</span>
-				<span className={`shrink-0 font-mono text-[11px] ${statusColor}`}>
-					{running ? 'running' : paused ? 'paused' : 'idle'}
-				</span>
+				{running ? (
+					<StatusDot status="active" pulse label="Running" />
+				) : paused ? (
+					<StatusDot status="paused" label="Over budget" />
+				) : null}
 			</span>
 		);
 	}

--- a/packages/web/src/components/ui/status-dot.tsx
+++ b/packages/web/src/components/ui/status-dot.tsx
@@ -17,12 +17,22 @@ const glowMap = {
 interface StatusDotProps {
 	status: keyof typeof statusMap;
 	pulse?: boolean;
+	/**
+	 * When set, the dot is exposed to assistive tech (and tests) as `role="img"`
+	 * with this accessible name, and gets a native `title` tooltip. Omit to keep
+	 * the dot purely decorative (e.g. when an adjacent label already names it).
+	 */
+	label?: string;
 	className?: string;
 }
 
-export function StatusDot({ status, pulse, className = '' }: StatusDotProps) {
+export function StatusDot({ status, pulse, label, className = '' }: StatusDotProps) {
+	// `role` + `aria-label` are set together — a generic <span> (no role) doesn't
+	// support `aria-label`, so the named case opts into the `img` role.
+	const a11y = label ? { role: 'img' as const, 'aria-label': label, title: label } : {};
 	return (
 		<span
+			{...a11y}
 			className={`inline-block h-[7px] w-[7px] shrink-0 rounded-full ${statusMap[status]} ${
 				pulse ? `animate-pulse ring-[3px] ${glowMap[status]}` : ''
 			} ${className}`}

--- a/packages/web/test/project-sidebar.test.tsx
+++ b/packages/web/test/project-sidebar.test.tsx
@@ -103,7 +103,7 @@ test('HQ agents appear in the Team section as global members linking to the HQ p
 	expect(link.getAttribute('href')).toBe('/projects/hq/agents/ceo');
 });
 
-test('Team agents use the spec status treatment — lowercase mono status, running in cyan + bold', async () => {
+test('Team agents use a pulsing live dot for running and no dot when idle', async () => {
 	let ws!: SeededWorkspace;
 	let projectSlug = '';
 	let runningTitle = '';
@@ -130,16 +130,23 @@ test('Team agents use the spec status treatment — lowercase mono status, runni
 	await findByTestId('project-sidebar-name', undefined, { timeout: 15_000 });
 	const nav = getNav(container);
 
-	// Status renders as lowercase mono text, never the capitalized quiet-tint pill.
-	await waitFor(() => expect(within(nav).getAllByText('idle').length).toBeGreaterThan(0), {
+	// The "idle"/"running" text suffixes are gone — status is a dot now.
+	await waitFor(() => expect(within(nav).getByRole('link', { name: /Captain/ })).toBeTruthy(), {
 		timeout: 20_000,
 	});
-	expect(within(nav).queryByText('Idle')).toBeNull();
-	expect(within(nav).queryByText('Running')).toBeNull();
+	expect(within(nav).queryByText('idle')).toBeNull();
+	expect(within(nav).queryByText('running')).toBeNull();
 
-	// The running agent shows the cyan "live" status and a bold name.
-	await waitFor(() => expect(within(nav).getByText('running')).toBeTruthy(), { timeout: 20_000 });
-	expect(within(nav).getByText('running').className).toContain('text-live');
+	// The running agent shows a pulsing cyan "live" dot; idle agents show none.
+	await waitFor(() => expect(within(nav).getByRole('img', { name: 'Running' })).toBeTruthy(), {
+		timeout: 20_000,
+	});
+	const runningDot = within(nav).getByRole('img', { name: 'Running' });
+	expect(runningDot.className).toContain('bg-live');
+	expect(runningDot.className).toContain('animate-pulse');
+	expect(within(nav).queryByRole('img', { name: 'Idle' })).toBeNull();
+
+	// The running agent keeps the bold-name emphasis.
 	const runningLink = within(nav).getByRole('link', { name: new RegExp(runningTitle) });
 	expect(within(runningLink).getByText(runningTitle).className).toContain('font-semibold');
 });

--- a/packages/web/test/task-crud.test.tsx
+++ b/packages/web/test/task-crud.test.tsx
@@ -269,8 +269,8 @@ test('task detail shows assignee with status badge', async () => {
 	expect(sidebar.textContent).toContain(seeded.agentTitle);
 
 	// Status badge should be one of Idle / Running / Paused. Scope the query to
-	// the assignee chip — the sidebar agent rail also surfaces status text (now
-	// lowercase "idle") for every agent in the team and would otherwise match.
+	// the assignee chip (the badge variant) — other agent labels on the page use
+	// their own treatment (e.g. the sidebar rail's status dot) and shouldn't match.
 	const assignee = await findByTestId('task-assignee');
 	expect(assignee.textContent ?? '').toMatch(/Idle|Running|Paused/);
 });
@@ -438,14 +438,13 @@ test('project badge and metadata label both link to the project page', async () 
 	}
 });
 
-test('project menu Team section shows agent status badges', async () => {
+test('project menu Team section lists the team agents', async () => {
 	const seeded = { projectSlug: '' };
 	const { router, container } = await renderApp({
 		initialPath: '/',
 		seed: async () => {
 			const ws = await seedWorkspace();
 			const project = await seedProject(ws, { name: 'Demo' });
-			seeded.projectSlug = project.slug;
 			seeded.projectSlug = project.slug;
 		},
 	});
@@ -455,15 +454,14 @@ test('project menu Team section shows agent status badges', async () => {
 		params: { projectId: seeded.projectSlug },
 	});
 
-	// The project menu's Team section lists each agent with its runtime status once
-	// it finishes loading. Per the Wire spec the sidebar renders the status as
-	// right-aligned lowercase mono ("idle"), not a capitalized pill — wait for at
-	// least one to appear in the sidebar nav.
+	// The project menu's Team section lists each agent once it finishes loading.
+	// Runtime status now shows as a dot indicator (pulsing for running, none for
+	// idle) rather than a text suffix, so wait on an agent name to confirm load.
 	await waitFor(
 		() => {
 			const nav = container.querySelector('nav[aria-label="Sidebar"]');
-			expect(nav?.textContent ?? '').toContain('idle');
+			expect(nav?.textContent ?? '').toContain('Captain');
 		},
-		{ timeout: 5000 },
+		{ timeout: 15_000 },
 	);
 });


### PR DESCRIPTION
## Summary

The project sidebar's **Team** list showed each agent's runtime status as a right-aligned lowercase word suffix (`idle` / `running` / `paused`). This swaps that text for the design-system **`StatusDot`** indicator:

- **Running** → pulsing cyan "live" dot (and the name stays bold)
- **Budget-paused** → static amber dot
- **Idle** → no dot at all

The result reads as a clean right gutter you can scan for who's actively working, instead of a column of repeated "idle" text.

| Before | After |
|---|---|
| `Captain ················ idle` | `Captain` |
| `UI Designer ······· running` | `UI Designer •` (pulsing, bold) |

## Changes

- **`agent-status-label.tsx`** — the `sidebar` variant now renders a `StatusDot` (pulsing for running, amber for budget-paused, nothing for idle) instead of the mono status word. The bold-name emphasis for running agents is preserved. The `badge` variant (assignee chip, agent roster) is untouched.
- **`status-dot.tsx`** — added an optional `label` prop. When set, the dot is exposed as `role="img"` with that accessible name plus a native `title` tooltip, so the status stays discoverable to assistive tech and tests now that the text is gone. The dot is decorative by default, so all existing `StatusDot` usages are unchanged.

## Testing

- Rewrote the `project-sidebar.test.tsx` status-treatment test to assert on the pulsing live dot (`role="img"` name `Running`, `bg-live` + `animate-pulse`), that idle agents render no dot, and that the running name stays bold.
- Updated `task-crud.test.tsx` to wait on an agent name (status text is gone) and refreshed a now-stale comment.
- `bun run typecheck` ✅ · Biome ✅ · affected web suites (`project-sidebar`, `task-crud`, plus `StatusDot` consumers: `agent-detail`, `agent-links`, `onboarding-*`, `status-meta`, `task-assignee-status`) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4pVT4vLNdep9Vau9EaTDj

---
_Generated by [Claude Code](https://claude.ai/code/session_01J4pVT4vLNdep9Vau9EaTDj)_