### PR TITLE
feat(web): Wire task detail (mono header + preview panel) + Mission-control home

### DIFF
--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -143,7 +143,15 @@ projectsRoutes.get('/projects', async (c) => {
 	const params: unknown[] = [...ts.values];
 	const base = `SELECT p.*, t.slug AS team_slug, t.name AS team_name,
        (SELECT count(*) FROM repos r WHERE r.project_id = p.id)::int AS repo_count,
-       (SELECT count(*) FROM tasks i WHERE i.project_id = p.id AND i.status NOT IN (${ts.placeholders}))::int AS open_task_count
+       (SELECT count(*) FROM tasks i WHERE i.project_id = p.id AND i.status NOT IN (${ts.placeholders}))::int AS open_task_count,
+       (SELECT count(*) FROM member_agents ma JOIN members mm ON mm.id = ma.id
+          WHERE mm.team_id = p.team_id AND ma.runtime_status = 'active'::agent_runtime_status)::int
+          AS running_agents_count,
+       (SELECT COALESCE(sum(ce.amount_cents), 0) FROM cost_entries ce
+          WHERE ce.project_id = p.id AND ce.created_at >= date_trunc('day', now()))::int
+          AS today_spend_cents,
+       COALESCE((SELECT max(i3.updated_at) FROM tasks i3 WHERE i3.project_id = p.id), p.created_at)
+          AS last_activity_at
      FROM projects p
      JOIN teams t ON t.id = p.team_id`;
 

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -291,9 +291,11 @@ tasksRoutes.get('/projects/:projectId/tasks/:taskId', async (c) => {
             p.name AS project_name, p.slug AS project_slug, p.description AS project_description,
             co.description AS team_description,
             COALESCE(ma.title, m.display_name) AS assignee_name,
+            ma.slug AS assignee_slug,
             m.member_type AS assignee_type,
             COALESCE(ma_ps.title, m_ps.display_name) AS progress_summary_updated_by_name,
             (SELECT count(*)::int FROM task_comments ic WHERE ic.task_id = i.id) AS comment_count,
+            ra.run_count, ra.total_duration_seconds, ca.total_cost_cents,
             EXISTS (
               SELECT 1 FROM heartbeat_runs hr
               WHERE hr.task_id = i.id AND hr.status IN ('running', 'queued')
@@ -342,6 +344,20 @@ tasksRoutes.get('/projects/:projectId/tasks/:taskId', async (c) => {
        ORDER BY hr.finished_at DESC NULLS LAST, hr.started_at DESC
        LIMIT 1
      ) lr ON true
+     LEFT JOIN LATERAL (
+       SELECT count(*) FILTER (WHERE hr.started_at IS NOT NULL)::int AS run_count,
+              COALESCE(sum(
+                EXTRACT(EPOCH FROM (hr.finished_at - hr.started_at))
+              ) FILTER (WHERE hr.started_at IS NOT NULL AND hr.finished_at IS NOT NULL), 0)::int
+                AS total_duration_seconds
+       FROM heartbeat_runs hr
+       WHERE hr.task_id = i.id
+     ) ra ON true
+     LEFT JOIN LATERAL (
+       SELECT COALESCE(sum(ce.amount_cents), 0)::int AS total_cost_cents
+       FROM cost_entries ce
+       WHERE ce.task_id = i.id
+     ) ca ON true
      WHERE i.id = $1 AND i.team_id = $2`,
 		[taskId, teamId],
 	);

--- a/packages/server/test/projects-dashboard-stats.test.ts
+++ b/packages/server/test/projects-dashboard-stats.test.ts
@@ -1,0 +1,100 @@
+import type { PGlite } from '@electric-sql/pglite';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, expect, it } from 'vitest';
+import type { Env } from '../src/lib/types';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp, createTestProject } from './helpers/app';
+
+let app: Hono<Env>;
+let db: PGlite;
+let token: string;
+let teamId: string;
+let projectId: string;
+let agentId: string;
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+
+	const teamRes = await app.request('/api/teams', {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ name: 'Dashboard Co' }),
+	});
+	teamId = (await teamRes.json()).data.id;
+
+	const projectRes = await createTestProject(db, teamId, { name: 'Main' });
+	const projectData = (await projectRes.json()).data;
+	projectId = projectData.id;
+
+	const agentRes = await app.request(`/api/projects/${projectData.slug}/agents`, {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ title: 'Runner' }),
+	});
+	agentId = (await agentRes.json()).data.id;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+it('projects index carries running-agent count, today spend, and last activity', async () => {
+	// One running agent on the team.
+	await db.query(
+		`UPDATE member_agents SET runtime_status = 'active'::agent_runtime_status WHERE id = $1`,
+		[agentId],
+	);
+	// $2.50 spent today, plus $9.99 two days ago that must not count toward today.
+	await db.query(
+		`INSERT INTO cost_entries (member_id, project_id, amount_cents) VALUES ($1, $2, 250)`,
+		[agentId, projectId],
+	);
+	await db.query(
+		`INSERT INTO cost_entries (member_id, project_id, amount_cents, created_at)
+		 VALUES ($1, $2, 999, now() - interval '2 days')`,
+		[agentId, projectId],
+	);
+
+	const res = await app.request('/api/projects', { headers: authHeader(token) });
+	expect(res.status).toBe(200);
+	const projects = (await res.json()).data as Array<{
+		id: string;
+		running_agents_count: number;
+		today_spend_cents: number;
+		last_activity_at: string | null;
+	}>;
+	const p = projects.find((x) => x.id === projectId);
+	if (!p) throw new Error('project missing from index');
+	expect(p.running_agents_count).toBe(1);
+	expect(p.today_spend_cents).toBe(250);
+	expect(p.last_activity_at).toBeTruthy();
+});
+
+it('a project with no active agents and no spend reports zeros', async () => {
+	await db.query(
+		`UPDATE member_agents SET runtime_status = 'idle'::agent_runtime_status WHERE id = $1`,
+		[agentId],
+	);
+	const teamRes = await app.request('/api/teams', {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ name: 'Quiet Co' }),
+	});
+	const quietTeamId = (await teamRes.json()).data.id;
+	const quietRes = await createTestProject(db, quietTeamId, { name: 'Quiet' });
+	const quietId = (await quietRes.json()).data.id;
+
+	const res = await app.request('/api/projects', { headers: authHeader(token) });
+	const projects = (await res.json()).data as Array<{
+		id: string;
+		running_agents_count: number;
+		today_spend_cents: number;
+	}>;
+	const quiet = projects.find((x) => x.id === quietId);
+	if (!quiet) throw new Error('quiet project missing');
+	expect(quiet.running_agents_count).toBe(0);
+	expect(quiet.today_spend_cents).toBe(0);
+});

--- a/packages/server/test/task-detail-aggregates.test.ts
+++ b/packages/server/test/task-detail-aggregates.test.ts
@@ -1,0 +1,99 @@
+import type { PGlite } from '@electric-sql/pglite';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, expect, it } from 'vitest';
+import type { Env } from '../src/lib/types';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp, createTestProject } from './helpers/app';
+
+let app: Hono<Env>;
+let db: PGlite;
+let token: string;
+let teamId: string;
+let projectId: string;
+let projectSlug: string;
+let agentId: string;
+let agentSlug: string;
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+
+	const teamRes = await app.request('/api/teams', {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ name: 'Aggregates Co' }),
+	});
+	teamId = (await teamRes.json()).data.id;
+
+	const projectRes = await createTestProject(db, teamId, { name: 'Main' });
+	const projectData = (await projectRes.json()).data;
+	projectId = projectData.id;
+	projectSlug = projectData.slug;
+
+	const agentRes = await app.request(`/api/projects/${projectSlug}/agents`, {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ title: 'Runner' }),
+	});
+	const agent = (await agentRes.json()).data;
+	agentId = agent.id;
+	agentSlug = agent.slug;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+async function createTask(title: string, assignee?: string): Promise<string> {
+	const res = await app.request(`/api/projects/${projectSlug}/tasks`, {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ project_id: projectId, title, assignee_id: assignee }),
+	});
+	return (await res.json()).data.id as string;
+}
+
+async function getTask(taskId: string) {
+	const res = await app.request(`/api/projects/${projectSlug}/tasks/${taskId}`, {
+		headers: authHeader(token),
+	});
+	expect(res.status).toBe(200);
+	return (await res.json()).data;
+}
+
+it('aggregates run count, finished-run duration and cost onto the task detail', async () => {
+	const taskId = await createTask('Aggregate me', agentId);
+
+	// Two finished runs (120s + 41s of wall-clock) plus a queued run that never
+	// started — the queued one must not count toward run_count or duration.
+	await db.query(
+		`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at, finished_at)
+		 VALUES ($1,$2,$3,'succeeded'::heartbeat_run_status,'2026-01-01T00:00:00Z','2026-01-01T00:02:00Z'),
+		        ($1,$2,$3,'failed'::heartbeat_run_status,'2026-01-01T00:00:00Z','2026-01-01T00:00:41Z'),
+		        ($1,$2,$3,'queued'::heartbeat_run_status,NULL,NULL)`,
+		[agentId, teamId, taskId],
+	);
+	// Two cost entries totalling $2.97 (cost_entries lost its team dimension in 004).
+	await db.query(
+		`INSERT INTO cost_entries (member_id, task_id, project_id, amount_cents)
+		 VALUES ($1,$2,$3,186),($1,$2,$3,111)`,
+		[agentId, taskId, projectId],
+	);
+
+	const task = await getTask(taskId);
+	expect(task.run_count).toBe(2);
+	expect(task.total_duration_seconds).toBe(161);
+	expect(task.total_cost_cents).toBe(297);
+	expect(task.assignee_slug).toBe(agentSlug);
+});
+
+it('returns zeroed aggregates for a task with no runs or costs', async () => {
+	const taskId = await createTask('Fresh task', agentId);
+	const task = await getTask(taskId);
+	expect(task.run_count).toBe(0);
+	expect(task.total_duration_seconds).toBe(0);
+	expect(task.total_cost_cents).toBe(0);
+	expect(task.assignee_slug).toBe(agentSlug);
+});

--- a/packages/web/src/components/markdown-prose.tsx
+++ b/packages/web/src/components/markdown-prose.tsx
@@ -20,6 +20,7 @@ import {
 	type TaskMentionData,
 } from '../lib/remark-mentions';
 import { CommentRefLink, MENTION_CLASSES } from './comment-ref-link';
+import { useOpenPreview } from './task-detail/preview-context';
 import { Tooltip } from './ui/tooltip';
 
 type RemarkPlugin = Parameters<typeof Markdown>[0]['remarkPlugins'];
@@ -66,6 +67,9 @@ export function MarkdownProse({
 	);
 	const { data: resolvedDocs } = useDocMentions(projectId ?? '', docCandidates);
 	const { data: instanceResolved } = useInstanceMentions(children, instance === true && !projectId);
+	// When the surface hosts a preview panel (task detail), doc/asset mentions open
+	// in it; otherwise they keep their new-tab links.
+	const openPreview = useOpenPreview();
 
 	const agentsMap = useMemo<Map<string, AgentMentionData>>(() => {
 		const m = new Map<string, AgentMentionData>();
@@ -226,19 +230,42 @@ export function MarkdownProse({
 				const docProject = attrs['data-mention-doc-project-slug'];
 				const docFilename = attrs['data-mention-doc-filename'];
 				if (docProject && docFilename && mentionsEnabled) {
+					const docTooltip = (
+						<DocTooltipContent
+							title={docFilename}
+							size={Number(attrs['data-mention-size'] ?? 0)}
+							updatedAt={attrs['data-mention-updated-at'] ?? ''}
+						/>
+					);
+					// In a comment thread (preview panel present) the mention opens the
+					// doc in the panel — no separate new-tab icon.
+					if (openPreview) {
+						return (
+							<PreviewMentionButton
+								tooltip={docTooltip}
+								testId="doc-mention-link"
+								onClick={() =>
+									openPreview({
+										kind: 'doc',
+										projectId: docProject,
+										projectSlug: docProject,
+										filename: docFilename,
+										size: Number(attrs['data-mention-size'] ?? 0) || undefined,
+										updatedAt: attrs['data-mention-updated-at'] || undefined,
+									})
+								}
+							>
+								{props.children}
+							</PreviewMentionButton>
+						);
+					}
 					return (
 						<DedicatedViewMention
 							href={docPreviewPath(docProject, docFilename)}
 							nameTestId="doc-mention-link"
 							previewTestId="doc-mention-preview-link"
 							previewAriaLabel="Open preview in new tab"
-							tooltip={
-								<DocTooltipContent
-									title={docFilename}
-									size={Number(attrs['data-mention-size'] ?? 0)}
-									updatedAt={attrs['data-mention-updated-at'] ?? ''}
-								/>
-							}
+							tooltip={docTooltip}
 						>
 							{props.children}
 						</DedicatedViewMention>
@@ -249,6 +276,27 @@ export function MarkdownProse({
 				const assetFilename = attrs['data-mention-asset-filename'];
 				const assetUrl = attrs['data-mention-asset-url'];
 				if (assetProject && assetFilename && mentionsEnabled) {
+					if (openPreview) {
+						return (
+							<PreviewMentionButton
+								testId="asset-mention-link"
+								onClick={() =>
+									openPreview({
+										kind: 'asset',
+										projectId: assetProject,
+										projectSlug: assetProject,
+										filename: assetFilename,
+										contentType: attrs['data-mention-asset-content-type'],
+										url: assetUrl,
+										size: Number(attrs['data-mention-size'] ?? 0) || undefined,
+										updatedAt: attrs['data-mention-updated-at'] || undefined,
+									})
+								}
+							>
+								{props.children}
+							</PreviewMentionButton>
+						);
+					}
 					if (assetUrl) {
 						return (
 							<DedicatedViewMention
@@ -359,7 +407,7 @@ export function MarkdownProse({
 				);
 			},
 		};
-	}, [projectId, instance]);
+	}, [projectId, instance, openPreview]);
 
 	return (
 		<div
@@ -420,6 +468,30 @@ function DedicatedViewMention({
 			</a>
 		</span>
 	);
+}
+
+/**
+ * A doc/asset mention that opens in the in-page preview panel rather than a new
+ * tab. No trailing external-link icon — the new-tab affordance lives on the panel
+ * itself. Used only when a surface provides the preview context.
+ */
+function PreviewMentionButton({
+	onClick,
+	tooltip,
+	testId,
+	children,
+}: {
+	onClick: () => void;
+	tooltip?: ReactNode;
+	testId: string;
+	children: ReactNode;
+}) {
+	const button = (
+		<button type="button" onClick={onClick} className={MENTION_CLASSES} data-testid={testId}>
+			{children}
+		</button>
+	);
+	return tooltip ? <Tooltip content={tooltip}>{button}</Tooltip> : button;
 }
 
 function DocTooltipContent({

--- a/packages/web/src/components/task-detail/preview-context.tsx
+++ b/packages/web/src/components/task-detail/preview-context.tsx
@@ -1,0 +1,34 @@
+import { createContext, useContext } from 'react';
+
+/** A document or asset that can be shown in the task-detail preview panel. */
+export interface PreviewItem {
+	kind: 'doc' | 'asset';
+	/** Project slug (route-param form) — used for both the API path and preview URL. */
+	projectId: string;
+	projectSlug: string;
+	filename: string;
+	/** Asset only — MIME type, drives how the asset is rendered. */
+	contentType?: string;
+	/** Asset only — signed URL to fetch/display the asset and open it in a new tab. */
+	url?: string;
+	size?: number;
+	updatedAt?: string;
+}
+
+type OpenPreview = (item: PreviewItem) => void;
+
+/**
+ * Surfaces that host a preview panel (today: the task-detail page) provide an
+ * opener through this context. When present, in-comment doc/asset mentions open
+ * in the panel instead of a new tab; when absent (docs/assets pages, CEO chat)
+ * the mentions keep their new-tab links. Defaulting to `null` is what lets the
+ * same MarkdownProse render behave differently per surface without a prop drill.
+ */
+const PreviewContext = createContext<OpenPreview | null>(null);
+
+export const PreviewProvider = PreviewContext.Provider;
+
+/** The open-preview handler for the current surface, or null when none hosts a panel. */
+export function useOpenPreview(): OpenPreview | null {
+	return useContext(PreviewContext);
+}

--- a/packages/web/src/components/task-detail/preview-panel.tsx
+++ b/packages/web/src/components/task-detail/preview-panel.tsx
@@ -1,0 +1,127 @@
+import { ExternalLink, X } from 'lucide-react';
+import { useProjectDoc } from '../../hooks/use-project-docs';
+import { docPreviewPath } from '../../lib/doc-preview';
+import { MarkdownProse } from '../markdown-prose';
+import type { PreviewItem } from './preview-context';
+
+function formatBytes(bytes?: number): string {
+	if (!bytes || bytes < 0) return '';
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+	return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+interface PreviewPanelProps {
+	item: PreviewItem;
+	onClose: () => void;
+}
+
+/**
+ * Right-rail preview of a document or asset, opened by clicking its mention in a
+ * task comment. Documents render their markdown inline; assets render by MIME
+ * type (image / embeddable iframe), with a fallback for everything else. The
+ * header carries an "open in new tab" affordance — the new-tab link that used to
+ * sit on the mention itself moves here.
+ */
+export function PreviewPanel({ item, onClose }: PreviewPanelProps) {
+	const isDoc = item.kind === 'doc';
+	const docQuery = useProjectDoc(item.projectId, isDoc ? item.filename : null);
+	const openUrl = isDoc ? docPreviewPath(item.projectSlug, item.filename) : (item.url ?? '');
+	const meta = formatBytes(item.size);
+
+	return (
+		<aside
+			data-testid="preview-panel"
+			className="flex min-h-0 flex-col overflow-hidden rounded-lg border border-border bg-surface lg:sticky lg:top-4 lg:max-h-[calc(100vh-2rem)]"
+		>
+			<div className="flex items-center gap-2 border-b border-border bg-surface-2 px-3 py-2">
+				<span
+					className="min-w-0 flex-1 truncate font-mono text-[13px] text-text-1"
+					title={item.filename}
+					data-testid="preview-panel-filename"
+				>
+					{item.filename}
+				</span>
+				{openUrl && (
+					<a
+						href={openUrl}
+						target="_blank"
+						rel="noopener noreferrer"
+						className="inline-flex shrink-0 items-center gap-1 text-[11px] text-info-soft-fg hover:underline"
+						data-testid="preview-open-tab"
+					>
+						open in new tab
+						<ExternalLink className="h-3 w-3" />
+					</a>
+				)}
+				<button
+					type="button"
+					onClick={onClose}
+					aria-label="Close preview"
+					data-testid="preview-close"
+					className="shrink-0 rounded-md p-1 text-text-3 transition-colors hover:bg-surface-3 hover:text-text-1"
+				>
+					<X className="h-4 w-4" />
+				</button>
+			</div>
+			{meta && (
+				<div className="border-b border-border px-3 py-1.5 text-[11px] text-text-3">{meta}</div>
+			)}
+			<div className="min-h-0 flex-1 overflow-auto">
+				<PreviewBody
+					item={item}
+					docContent={docQuery.data?.content}
+					docLoading={isDoc && docQuery.isLoading}
+				/>
+			</div>
+		</aside>
+	);
+}
+
+function PreviewBody({
+	item,
+	docContent,
+	docLoading,
+}: {
+	item: PreviewItem;
+	docContent?: string;
+	docLoading: boolean;
+}) {
+	if (item.kind === 'doc') {
+		if (docLoading) return <div className="p-3 text-[13px] text-text-3">Loading…</div>;
+		if (!docContent)
+			return <div className="p-3 text-[13px] text-text-3">No content to preview.</div>;
+		return (
+			<div className="p-3" data-testid="preview-doc-body">
+				<MarkdownProse projectId={item.projectId} projectSlug={item.projectSlug}>
+					{docContent}
+				</MarkdownProse>
+			</div>
+		);
+	}
+
+	const contentType = item.contentType ?? '';
+	if (!item.url) return <div className="p-3 text-[13px] text-text-3">No preview available.</div>;
+	if (contentType.startsWith('image/')) {
+		// biome-ignore lint/a11y/useAltText: filename is the best available description
+		return (
+			<img src={item.url} alt={item.filename} className="w-full" data-testid="preview-image" />
+		);
+	}
+	if (contentType === 'text/html' || contentType === 'application/pdf') {
+		return (
+			<iframe
+				src={item.url}
+				title={item.filename}
+				sandbox=""
+				className="h-[60vh] w-full bg-surface"
+				data-testid="preview-iframe"
+			/>
+		);
+	}
+	return (
+		<div className="p-3 text-[13px] text-text-3">
+			No inline preview for this file type — use “open in new tab”.
+		</div>
+	);
+}

--- a/packages/web/src/components/task-detail/task-header.tsx
+++ b/packages/web/src/components/task-detail/task-header.tsx
@@ -2,15 +2,18 @@ import { Link } from '@tanstack/react-router';
 import { ChevronRight } from 'lucide-react';
 import { type Task, useTaskAncestors } from '../../hooks/use-tasks';
 import { MarkdownProse } from '../markdown-prose';
-import { TaskStatusBadge } from '../task-status-badge';
 import { Badge } from '../ui/badge';
 
-const priorityColors: Record<string, string> = {
-	urgent: 'danger',
-	high: 'warning',
-	medium: 'info',
-	low: 'neutral',
-};
+/** Compact wall-clock duration ("35s", "7m 41s", "1h 4m") from a seconds total. */
+function formatDuration(totalSeconds: number): string {
+	if (totalSeconds < 60) return `${totalSeconds}s`;
+	const minutes = Math.floor(totalSeconds / 60);
+	const seconds = totalSeconds % 60;
+	if (minutes < 60) return seconds ? `${minutes}m ${seconds}s` : `${minutes}m`;
+	const hours = Math.floor(minutes / 60);
+	const mins = minutes % 60;
+	return mins ? `${hours}h ${mins}m` : `${hours}h`;
+}
 
 interface TaskHeaderProps {
 	task: Task;
@@ -21,9 +24,10 @@ interface TaskHeaderProps {
 
 /**
  * Top-of-page header for a task: a breadcrumb of ancestor tasks ending in the
- * current identifier, then title, status / priority / project badges,
- * queued-wakeup chip, and the description card. Renders nothing status-mutating
- * — assignee / close / reopen live in the sidebar.
+ * current identifier, then title, an inline mono metadata row (status · priority ·
+ * assignee) with a runs · duration · cost summary, the queued-wakeup chip, and the
+ * description card. Renders nothing status-mutating — assignee / close / reopen
+ * live in the sidebar.
  */
 export function TaskHeader({ task, projectId, taskId, taskProjectSlug }: TaskHeaderProps) {
 	// Ancestors come back root-first, excluding the current task, so the
@@ -57,17 +61,20 @@ export function TaskHeader({ task, projectId, taskId, taskProjectSlug }: TaskHea
 			</nav>
 			<h1 className="text-xl font-medium mb-3">{task.title}</h1>
 
-			<div className="flex flex-wrap gap-1.5 mb-4">
-				<TaskStatusBadge status={task.status} />
-				<Badge color={priorityColors[task.priority] as 'neutral'}>{task.priority}</Badge>
-				{task.project_name && task.project_slug && (
-					<Link
-						to="/projects/$projectId"
-						params={{ projectId: task.project_slug }}
-						className="hover:opacity-80 transition-opacity"
-					>
-						<Badge color="info">{task.project_name}</Badge>
-					</Link>
+			{/* Wire spec — task header reads as inline mono metadata (status · priority ·
+			    assignee) with a runs / duration / cost summary pushed right; the
+			    quiet-tint pills move out of the header. */}
+			<div className="mb-4 flex flex-wrap items-center gap-x-3 gap-y-1.5 font-mono text-[13px]">
+				<span className="text-text-2" data-testid="task-status-inline">
+					{task.status}
+				</span>
+				<span className="text-text-2" data-testid="task-priority-inline">
+					{task.priority}
+				</span>
+				{task.assignee_id && (
+					<span className="min-w-0 truncate text-text-2" data-testid="task-assignee-inline">
+						{task.assignee_slug ?? task.assignee_name}
+					</span>
 				)}
 				{!task.has_active_run && task.queued_wakeup && (
 					<Badge color="blue" className="gap-1" data-testid="task-queued-badge">
@@ -76,6 +83,13 @@ export function TaskHeader({ task, projectId, taskId, taskProjectSlug }: TaskHea
 							? 'Queued — project at capacity'
 							: 'Run queued'}
 					</Badge>
+				)}
+				{task.run_count > 0 && (
+					<span className="text-text-3 sm:ml-auto" data-testid="task-run-summary">
+						{task.run_count} {task.run_count === 1 ? 'run' : 'runs'}
+						{task.total_duration_seconds > 0 && ` · ${formatDuration(task.total_duration_seconds)}`}
+						{task.total_cost_cents > 0 && ` · $${(task.total_cost_cents / 100).toFixed(2)}`}
+					</span>
 				)}
 			</div>
 

--- a/packages/web/src/hooks/use-projects.ts
+++ b/packages/web/src/hooks/use-projects.ts
@@ -28,6 +28,12 @@ export interface Project {
 	dev_ports: Array<{ container: number; host: number }>;
 	repo_count: number;
 	open_task_count: number;
+	/** Agents currently running on this project's team (runtime_status = active). */
+	running_agents_count: number;
+	/** Spend on this project so far today (UTC), in cents. */
+	today_spend_cents: number;
+	/** Most recent task update, falling back to the project's creation time. */
+	last_activity_at: string;
 	created_at: string;
 	repos?: Repo[];
 	planning_task_id?: string;

--- a/packages/web/src/hooks/use-tasks.ts
+++ b/packages/web/src/hooks/use-tasks.ts
@@ -25,8 +25,16 @@ export interface Task {
 	priority: string;
 	assignee_id: string | null;
 	assignee_name: string | null;
+	/** Agent slug for an agent assignee (null for human assignees / unassigned). */
+	assignee_slug: string | null;
 	assignee_type: 'agent' | 'user' | null;
 	has_active_run: boolean;
+	/** Number of agent runs that have started on this task (excludes queued). */
+	run_count: number;
+	/** Summed wall-clock duration of finished runs, in seconds. */
+	total_duration_seconds: number;
+	/** Summed cost across the task's runs, in cents. */
+	total_cost_cents: number;
 	has_unread_admin_mention: boolean;
 	last_run_status: 'succeeded' | 'failed' | 'cancelled' | 'timed_out' | null;
 	/** Id of the last completed run — the target of a manual retry. */

--- a/packages/web/src/routes/home/index.tsx
+++ b/packages/web/src/routes/home/index.tsx
@@ -285,6 +285,8 @@ function ActiveProjectCard({
 
 function OtherProjectRow({ project }: { project: ProjectWithTeam }) {
 	const paused = project.container_status === 'stopped' || project.container_status === 'error';
+	const rel = relativeTime(project.last_activity_at);
+	const activity = rel === 'now' ? 'just now' : `last ${rel} ago`;
 	return (
 		<Link
 			to="/projects/$projectId"
@@ -302,7 +304,7 @@ function OtherProjectRow({ project }: { project: ProjectWithTeam }) {
 					{paused ? 'paused' : 'idle'}
 				</span>
 				<span className="shrink-0 font-mono text-[11px] text-text-3">
-					{project.open_task_count} tasks · {relativeTime(project.last_activity_at)} ago
+					{project.open_task_count} tasks · {activity}
 				</span>
 			</div>
 		</Link>

--- a/packages/web/src/routes/home/index.tsx
+++ b/packages/web/src/routes/home/index.tsx
@@ -1,15 +1,215 @@
+import { type AdminMentionItem, ApprovalStatus, ApprovalType } from '@hezo/shared';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { Building2, Plus } from 'lucide-react';
-import { useState } from 'react';
+import { type ReactNode, useState } from 'react';
 import { CreateProjectWithTeamDialog } from '../../components/create-project-with-team-dialog';
 import { ProjectIntakeHomePanel } from '../../components/project-intake-home-panel';
 import { Avatar, avatarColorFromString, getInitials } from '../../components/ui/avatar';
+import { Badge } from '../../components/ui/badge';
 import { Button } from '../../components/ui/button';
 import { Card } from '../../components/ui/card';
-import { Tooltip } from '../../components/ui/tooltip';
+import { useAllAdminMentions } from '../../hooks/use-admin-mentions';
+import { type Approval, useAllApprovals } from '../../hooks/use-approvals';
 import { useProjectIntake } from '../../hooks/use-project-intake';
-import { useAllVisibleProjects } from '../../hooks/use-projects';
+import { type ProjectWithTeam, useAllVisibleProjects } from '../../hooks/use-projects';
 import { useTeams } from '../../hooks/use-teams';
+
+const RELATIVE_UNITS: Array<[Intl.RelativeTimeFormatUnit, number]> = [
+	['day', 86400],
+	['hour', 3600],
+	['minute', 60],
+];
+
+/** Compact "2h ago" / "3d ago" / "just now" from an ISO timestamp. */
+function relativeTime(iso: string): string {
+	const then = new Date(iso).getTime();
+	if (!Number.isFinite(then)) return '';
+	const deltaSec = Math.round((Date.now() - then) / 1000);
+	for (const [unit, per] of RELATIVE_UNITS) {
+		if (deltaSec >= per) {
+			const n = Math.floor(deltaSec / per);
+			return `${n}${unit[0]}`; // 2d / 3h / 5m
+		}
+	}
+	return 'now';
+}
+
+function formatMoney(cents: number): string {
+	return `$${(cents / 100).toFixed(2)}`;
+}
+
+/** A short, human phrase for an approval that needs the admin. */
+function approvalText(a: Approval): string {
+	const who = a.requested_by_name ?? 'An agent';
+	switch (a.type) {
+		case ApprovalType.DesignatedRepoRequest:
+			return `${who} needs GitHub access to set up the repo`;
+		case ApprovalType.SecretAccess:
+			return `${who} requests a credential`;
+		case ApprovalType.PlanReview:
+			return `${who} drafted a plan to review`;
+		case ApprovalType.Hire:
+			return `${who} wants to hire an agent`;
+		case ApprovalType.DeployProduction:
+			return `${who} wants to deploy to production`;
+		case ApprovalType.SkillProposal:
+			return `${who} proposed a reusable skill`;
+		case ApprovalType.Strategy:
+			return `${who} needs a strategy decision`;
+		case ApprovalType.ProjectCreation:
+			return `${who} proposed a new project`;
+		default:
+			return `${who} needs your approval`;
+	}
+}
+
+function approvalActionLabel(type: string): string {
+	if (type === ApprovalType.DesignatedRepoRequest) return 'Set up';
+	if (type === ApprovalType.PlanReview) return 'Open plan';
+	if (type === ApprovalType.SecretAccess || type === ApprovalType.SkillProposal) return 'Review';
+	return 'Open';
+}
+
+type NeedsYouRow =
+	| { kind: 'action'; id: string; createdAt: string; approval: Approval }
+	| { kind: 'mention'; id: string; createdAt: string; mention: AdminMentionItem };
+
+const NEEDS_YOU_PREVIEW = 5;
+
+function NeedsYouSection({ projectSlugs }: { projectSlugs: string[] }) {
+	const { data: approvals } = useAllApprovals(projectSlugs);
+	const { data: mentions } = useAllAdminMentions(projectSlugs);
+
+	const pending = (approvals ?? []).filter((a) => a.status === ApprovalStatus.Pending);
+	const unread = (mentions ?? []).filter((m) => !m.read_at);
+
+	const rows: NeedsYouRow[] = [
+		...pending.map((a) => ({
+			kind: 'action' as const,
+			id: a.id,
+			createdAt: a.created_at,
+			approval: a,
+		})),
+		...unread.map((m) => ({
+			kind: 'mention' as const,
+			id: m.id,
+			createdAt: m.created_at,
+			mention: m,
+		})),
+	].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+
+	if (rows.length === 0) return null;
+	const shown = rows.slice(0, NEEDS_YOU_PREVIEW);
+	const more = rows.length - shown.length;
+
+	return (
+		<section className="mb-6" data-testid="home-needs-you">
+			<h2 className="text-eyebrow mb-2">Needs you · {rows.length}</h2>
+			<Card className="divide-y divide-border p-0">
+				{shown.map((row) =>
+					row.kind === 'action' ? (
+						<NeedsYouAction key={`a-${row.id}`} approval={row.approval} />
+					) : (
+						<NeedsYouMention key={`m-${row.id}`} mention={row.mention} />
+					),
+				)}
+			</Card>
+			{more > 0 && (
+				<div className="mt-2 text-center">
+					<Link
+						to="/home/inbox"
+						className="text-[12px] text-info-soft-fg hover:underline"
+						data-testid="home-needs-you-more"
+					>
+						Show {more} more
+					</Link>
+				</div>
+			)}
+		</section>
+	);
+}
+
+const ACTION_LINK_CLASS =
+	'shrink-0 rounded-md border border-border px-2 py-1 text-[12px] text-text-1 hover:bg-surface-2';
+
+function NeedsYouRowShell({
+	tag,
+	tagColor,
+	children,
+	project,
+	createdAt,
+	actionLink,
+}: {
+	tag: string;
+	tagColor: 'accent' | 'info';
+	children: ReactNode;
+	project: string | null;
+	createdAt: string;
+	actionLink: ReactNode;
+}) {
+	return (
+		<div className="flex items-center gap-3 px-3 py-2.5" data-testid="home-needs-you-row">
+			<Badge color={tagColor} mono className="shrink-0">
+				{tag}
+			</Badge>
+			<span className="min-w-0 flex-1 truncate text-[13px] text-text-1">{children}</span>
+			<span className="shrink-0 font-mono text-[11px] text-text-3">
+				{project ? `${project} · ` : ''}
+				{relativeTime(createdAt)}
+			</span>
+			{actionLink}
+		</div>
+	);
+}
+
+function NeedsYouAction({ approval }: { approval: Approval }) {
+	return (
+		<NeedsYouRowShell
+			tag="action"
+			tagColor="accent"
+			project={approval.payload_project_slug}
+			createdAt={approval.created_at}
+			actionLink={
+				<Link
+					to="/projects/$projectId/inbox"
+					params={{ projectId: approval.payload_project_slug ?? '' }}
+					className={ACTION_LINK_CLASS}
+				>
+					{approvalActionLabel(approval.type)}
+				</Link>
+			}
+		>
+			{approvalText(approval)}
+		</NeedsYouRowShell>
+	);
+}
+
+function NeedsYouMention({ mention }: { mention: AdminMentionItem }) {
+	return (
+		<NeedsYouRowShell
+			tag="mention"
+			tagColor="info"
+			project={mention.project_slug}
+			createdAt={mention.created_at}
+			actionLink={
+				<Link
+					to="/projects/$projectId/tasks/$taskId"
+					params={{
+						projectId: mention.project_slug,
+						taskId: mention.task_identifier.toLowerCase(),
+					}}
+					hash={`comment-${mention.comment_public_id}`}
+					className={ACTION_LINK_CLASS}
+				>
+					Reply
+				</Link>
+			}
+		>
+			<span className="font-medium">@{mention.author_slug ?? mention.author_display_name}</span>{' '}
+			{mention.snippet}
+		</NeedsYouRowShell>
+	);
+}
 
 function WelcomeCard({ onCreate }: { onCreate: () => void }) {
 	return (
@@ -35,74 +235,135 @@ function WelcomeCard({ onCreate }: { onCreate: () => void }) {
 	);
 }
 
-function HomeProjectsSection({
+function ActiveProjectCard({
+	project,
+	needsYou,
+	showTeamName,
+}: {
+	project: ProjectWithTeam;
+	needsYou: number;
+	showTeamName: boolean;
+}) {
+	return (
+		<Link to="/projects/$projectId" params={{ projectId: project.slug }}>
+			<Card className="cursor-pointer h-full" data-testid="home-active-card">
+				<div className="flex items-start gap-3">
+					<Avatar
+						initials={getInitials(project.name)}
+						color={avatarColorFromString(project.name)}
+					/>
+					<div className="flex flex-col gap-1 min-w-0 flex-1">
+						<div className="flex items-center justify-between gap-2">
+							<h3 className="text-[15px] font-medium text-text-1 truncate">{project.name}</h3>
+							{needsYou > 0 ? (
+								<Badge color="accent" className="shrink-0">
+									{needsYou} need you
+								</Badge>
+							) : project.running_agents_count > 0 ? (
+								<Badge color="live" className="shrink-0">
+									running
+								</Badge>
+							) : null}
+						</div>
+						{showTeamName && <p className="text-xs text-text-2 truncate">{project.teamName}</p>}
+						{project.description && (
+							<p className="text-xs text-text-2 line-clamp-2">{project.description}</p>
+						)}
+						<div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 font-mono text-[11px] text-text-3">
+							{project.running_agents_count > 0 && (
+								<span className="text-live">{project.running_agents_count} running</span>
+							)}
+							<span>{project.open_task_count} tasks</span>
+							<span>{formatMoney(project.today_spend_cents)} today</span>
+						</div>
+					</div>
+				</div>
+			</Card>
+		</Link>
+	);
+}
+
+function OtherProjectRow({ project }: { project: ProjectWithTeam }) {
+	const paused = project.container_status === 'stopped' || project.container_status === 'error';
+	return (
+		<Link
+			to="/projects/$projectId"
+			params={{ projectId: project.slug }}
+			data-testid="home-other-row"
+		>
+			<div className="flex items-center gap-3 px-3 py-2.5 hover:bg-surface-2">
+				<Avatar
+					initials={getInitials(project.name)}
+					color={avatarColorFromString(project.name)}
+					size="sm"
+				/>
+				<span className="min-w-0 flex-1 truncate text-[13px] text-text-1">{project.name}</span>
+				<span className="shrink-0 font-mono text-[11px] text-text-3">
+					{paused ? 'paused' : 'idle'}
+				</span>
+				<span className="shrink-0 font-mono text-[11px] text-text-3">
+					{project.open_task_count} tasks · {relativeTime(project.last_activity_at)} ago
+				</span>
+			</div>
+		</Link>
+	);
+}
+
+function ProjectsDashboard({
 	teams,
 	projects,
-	isLoading,
+	needsYouBySlug,
 	onCreate,
 }: {
 	teams: NonNullable<ReturnType<typeof useTeams>['data']>;
-	projects: ReturnType<typeof useAllVisibleProjects>['projects'];
-	isLoading: boolean;
+	projects: ProjectWithTeam[];
+	needsYouBySlug: Map<string, number>;
 	onCreate: () => void;
 }) {
 	const showTeamName = teams.length > 1;
-
-	if (isLoading) {
-		return (
-			<div className="text-text-2 text-[13px] py-8 text-center" data-testid="home-projects-loading">
-				Loading projects...
-			</div>
-		);
-	}
-
-	if (projects.length === 0) {
-		return null;
-	}
+	const isActive = (p: ProjectWithTeam) =>
+		p.running_agents_count > 0 || (needsYouBySlug.get(p.slug) ?? 0) > 0;
+	const active = projects.filter(isActive);
+	const other = projects.filter((p) => !isActive(p));
 
 	return (
-		<section data-testid="home-projects-list">
-			<div className="flex items-center justify-between mb-4">
-				<h2 className="text-[18px] md:text-[22px] font-medium">Projects</h2>
-				<Button variant="secondary" size="sm" onClick={onCreate}>
+		<div data-testid="home-projects">
+			<div className="mb-4 flex items-center justify-between">
+				<h2 className="text-eyebrow">Active projects · {active.length}</h2>
+				<Button variant="secondary" size="sm" onClick={onCreate} data-testid="home-new-project">
 					<Plus className="w-4 h-4" />
 					New project
 				</Button>
 			</div>
-			<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-				{projects.map((p) => (
-					<Link key={p.id} to="/projects/$projectId" params={{ projectId: p.slug }}>
-						<Card className="cursor-pointer h-full">
-							<div className="flex items-start gap-3">
-								<Avatar initials={getInitials(p.name)} color={avatarColorFromString(p.name)} />
-								<div className="flex flex-col gap-1 min-w-0 flex-1">
-									<div className="flex items-center justify-between gap-2">
-										<h3 className="text-[15px] font-medium text-text-1 truncate">{p.name}</h3>
-										{p.container_status && p.container_status !== 'running' && (
-											<Tooltip content={`Container ${p.container_status}`}>
-												<span
-													role="img"
-													aria-label={`Container ${p.container_status}`}
-													className="w-2 h-2 rounded-full bg-danger shrink-0"
-												/>
-											</Tooltip>
-										)}
-									</div>
-									{showTeamName && <p className="text-xs text-text-2 truncate">{p.teamName}</p>}
-									{p.description && (
-										<p className="text-xs text-text-2 line-clamp-2">{p.description}</p>
-									)}
-									<div className="flex gap-3 text-xs text-text-2 mt-1">
-										<span>{p.open_task_count} tasks</span>
-										<span>{p.repo_count} repos</span>
-									</div>
-								</div>
-							</div>
-						</Card>
-					</Link>
-				))}
-			</div>
-		</section>
+			{active.length > 0 ? (
+				<div
+					className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3"
+					data-testid="home-active"
+				>
+					{active.map((p) => (
+						<ActiveProjectCard
+							key={p.id}
+							project={p}
+							needsYou={needsYouBySlug.get(p.slug) ?? 0}
+							showTeamName={showTeamName}
+						/>
+					))}
+				</div>
+			) : (
+				<p className="text-[13px] text-text-3">No active projects right now.</p>
+			)}
+
+			{other.length > 0 && (
+				<section className="mt-6" data-testid="home-other">
+					<h2 className="text-eyebrow mb-2">Other projects · {other.length}</h2>
+					<Card className="divide-y divide-border p-0">
+						{other.map((p) => (
+							<OtherProjectRow key={p.id} project={p} />
+						))}
+					</Card>
+				</section>
+			)}
+		</div>
 	);
 }
 
@@ -110,6 +371,26 @@ function HomePage() {
 	const { data: teams, isLoading: teamsLoading } = useTeams();
 	const { projects, isLoading: projectsLoading } = useAllVisibleProjects();
 	const [createOpen, setCreateOpen] = useState(false);
+
+	const projectSlugs = projects.map((p) => p.slug);
+	const { data: approvals } = useAllApprovals(projectSlugs);
+	const { data: mentions } = useAllAdminMentions(projectSlugs);
+
+	// Per-project "needs you" tally (pending approvals + unread mentions), used to
+	// rank projects into Active vs Other and to badge the cards.
+	const needsYouBySlug = new Map<string, number>();
+	for (const a of approvals ?? []) {
+		if (a.status === ApprovalStatus.Pending && a.payload_project_slug) {
+			needsYouBySlug.set(
+				a.payload_project_slug,
+				(needsYouBySlug.get(a.payload_project_slug) ?? 0) + 1,
+			);
+		}
+	}
+	for (const m of mentions ?? []) {
+		if (!m.read_at)
+			needsYouBySlug.set(m.project_slug, (needsYouBySlug.get(m.project_slug) ?? 0) + 1);
+	}
 
 	// The CEO-assisted intake lives in HQ and is instance-wide; only surface it
 	// while the welcome view is showing (no user-facing projects yet).
@@ -123,9 +404,26 @@ function HomePage() {
 	const hasProject = projects.length > 0;
 	const hasIntake = !!intake;
 	const showWelcome = !hasProject && !hasIntake;
+	const now = new Date();
+	const dateLabel = now
+		.toLocaleString(undefined, {
+			weekday: 'short',
+			day: 'numeric',
+			month: 'short',
+			hour: '2-digit',
+			minute: '2-digit',
+		})
+		.toLowerCase();
 
 	return (
 		<div className="max-w-7xl mx-auto w-full px-4 py-4 md:px-6 md:py-5 lg:px-8 lg:py-6">
+			<div className="mb-5 flex items-baseline justify-between gap-3">
+				<h1 className="text-[22px] md:text-[28px] font-semibold tracking-[-0.02em]">Home</h1>
+				<span className="font-mono text-[12px] text-text-3" data-testid="home-date">
+					{dateLabel}
+				</span>
+			</div>
+
 			{showWelcome && <WelcomeCard onCreate={() => setCreateOpen(true)} />}
 
 			{hasIntake && intake && (
@@ -135,12 +433,24 @@ function HomePage() {
 			)}
 
 			{hasProject && (
-				<HomeProjectsSection
-					teams={teams ?? []}
-					projects={projects}
-					isLoading={projectsLoading}
-					onCreate={() => setCreateOpen(true)}
-				/>
+				<>
+					<NeedsYouSection projectSlugs={projectSlugs} />
+					{projectsLoading ? (
+						<div
+							className="text-text-2 text-[13px] py-8 text-center"
+							data-testid="home-projects-loading"
+						>
+							Loading projects...
+						</div>
+					) : (
+						<ProjectsDashboard
+							teams={teams ?? []}
+							projects={projects}
+							needsYouBySlug={needsYouBySlug}
+							onCreate={() => setCreateOpen(true)}
+						/>
+					)}
+				</>
 			)}
 
 			<CreateProjectWithTeamDialog open={createOpen} onOpenChange={setCreateOpen} />

--- a/packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx
@@ -7,6 +7,11 @@ import { CommentComposer } from '../../../../components/task-detail/comment-comp
 import { CommentsSection } from '../../../../components/task-detail/comments-section';
 import { DependenciesSection } from '../../../../components/task-detail/dependencies-section';
 import { LastRunFailedBanner } from '../../../../components/task-detail/last-run-failed-banner';
+import {
+	type PreviewItem,
+	PreviewProvider,
+} from '../../../../components/task-detail/preview-context';
+import { PreviewPanel } from '../../../../components/task-detail/preview-panel';
 import { SubTasksSection } from '../../../../components/task-detail/sub-tasks-section';
 import { TaskHeader } from '../../../../components/task-detail/task-header';
 import { TaskSidebar } from '../../../../components/task-detail/task-sidebar';
@@ -55,6 +60,9 @@ function TaskDetailPage() {
 	// leave effort unset on submit and let the server resolve the agent default.
 	const [commentEffort, setCommentEffort] = useState<AgentEffort | null>(null);
 	const [replyTarget, setReplyTarget] = useState<Comment | null>(null);
+	// A doc/asset clicked in a comment opens in the right-rail preview panel
+	// (replacing the metadata sidebar until closed).
+	const [preview, setPreview] = useState<PreviewItem | null>(null);
 	const commentFormRef = useRef<HTMLFormElement>(null);
 	const commentTextareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -86,78 +94,86 @@ function TaskDetailPage() {
 
 	return (
 		<>
-			<div className="grid grid-cols-1 lg:grid-cols-[1fr_190px] gap-5">
-				<div className="min-w-0">
-					<LastRunFailedBanner task={task} projectId={projectId} taskId={taskId} />
-					<TaskHeader
-						task={task}
-						projectId={projectId}
-						taskId={taskId}
-						taskProjectSlug={taskProjectSlug}
-					/>
+			<div
+				className={`grid grid-cols-1 gap-5 ${preview ? 'lg:grid-cols-[1fr_360px]' : 'lg:grid-cols-[1fr_190px]'}`}
+			>
+				<PreviewProvider value={setPreview}>
+					<div className="min-w-0">
+						<LastRunFailedBanner task={task} projectId={projectId} taskId={taskId} />
+						<TaskHeader
+							task={task}
+							projectId={projectId}
+							taskId={taskId}
+							taskProjectSlug={taskProjectSlug}
+						/>
 
-					<TaskSummary
-						task={task}
-						projectId={projectId}
-						taskProjectSlug={taskProjectSlug}
-						updateTask={updateTask}
-					/>
+						<TaskSummary
+							task={task}
+							projectId={projectId}
+							taskProjectSlug={taskProjectSlug}
+							updateTask={updateTask}
+						/>
 
-					<SubTasksSection
-						projectId={projectId}
-						taskId={taskId}
-						parentTaskId={task.id}
-						taskProjectSlug={taskProjectSlug}
-					/>
+						<SubTasksSection
+							projectId={projectId}
+							taskId={taskId}
+							parentTaskId={task.id}
+							taskProjectSlug={taskProjectSlug}
+						/>
 
-					<DependenciesSection projectId={projectId} taskId={taskId} />
+						<DependenciesSection projectId={projectId} taskId={taskId} />
 
-					<div className="border-t border-border pt-4">
-						<div className="flex items-center gap-1.5 mb-4">
-							<h3 className="text-[13px] text-text-1 font-medium">Comments</h3>
-							<span className="bg-surface-2 px-[7px] py-px rounded-full text-[11px] text-text-2">
-								{comments?.length ?? 0}
-							</span>
+						<div className="border-t border-border pt-4">
+							<div className="flex items-center gap-1.5 mb-4">
+								<h3 className="text-[13px] text-text-1 font-medium">Comments</h3>
+								<span className="bg-surface-2 px-[7px] py-px rounded-full text-[11px] text-text-2">
+									{comments?.length ?? 0}
+								</span>
+							</div>
+
+							<CommentsSection
+								task={task}
+								projectId={projectId}
+								taskId={taskId}
+								taskProjectSlug={taskProjectSlug}
+								scrollParent={scrollParent}
+								onStartReply={startReply}
+							/>
+
+							<CommentComposer
+								task={task}
+								projectId={projectId}
+								taskId={taskId}
+								taskProjectSlug={taskProjectSlug}
+								comments={comments}
+								createComment={createComment}
+								commentEffort={commentEffort}
+								setCommentEffort={setCommentEffort}
+								replyTarget={replyTarget}
+								setReplyTarget={setReplyTarget}
+								jumpToComment={jumpToComment}
+								commentFormRef={commentFormRef}
+								commentTextareaRef={commentTextareaRef}
+							/>
 						</div>
-
-						<CommentsSection
-							task={task}
-							projectId={projectId}
-							taskId={taskId}
-							taskProjectSlug={taskProjectSlug}
-							scrollParent={scrollParent}
-							onStartReply={startReply}
-						/>
-
-						<CommentComposer
-							task={task}
-							projectId={projectId}
-							taskId={taskId}
-							taskProjectSlug={taskProjectSlug}
-							comments={comments}
-							createComment={createComment}
-							commentEffort={commentEffort}
-							setCommentEffort={setCommentEffort}
-							replyTarget={replyTarget}
-							setReplyTarget={setReplyTarget}
-							jumpToComment={jumpToComment}
-							commentFormRef={commentFormRef}
-							commentTextareaRef={commentTextareaRef}
-						/>
 					</div>
-				</div>
+				</PreviewProvider>
 
-				<TaskSidebar
-					task={task}
-					projectId={projectId}
-					agents={agents}
-					lock={lock}
-					comments={comments}
-					updateTask={updateTask}
-					commentEffort={commentEffort}
-					setCommentEffort={setCommentEffort}
-					scrollToBottom={scrollToBottom}
-				/>
+				{preview ? (
+					<PreviewPanel item={preview} onClose={() => setPreview(null)} />
+				) : (
+					<TaskSidebar
+						task={task}
+						projectId={projectId}
+						agents={agents}
+						lock={lock}
+						comments={comments}
+						updateTask={updateTask}
+						commentEffort={commentEffort}
+						setCommentEffort={setCommentEffort}
+						scrollToBottom={scrollToBottom}
+					/>
+				)}
 			</div>
 
 			{/* Sits above the persistent CEO chat launcher (fixed bottom-right) so

--- a/packages/web/test/create-project-from-team.test.tsx
+++ b/packages/web/test/create-project-from-team.test.tsx
@@ -14,8 +14,8 @@ async function openNewProjectDialog() {
 			sessionStorage.setItem('hezo:activeTeamSlug', ws.team.slug);
 		},
 	});
-	const section = await utils.findByTestId('home-projects-list', undefined, { timeout: 15_000 });
-	await utils.user.click(within(section).getByRole('button', { name: 'New project' }));
+	const section = await utils.findByTestId('home-projects', undefined, { timeout: 15_000 });
+	await utils.user.click(within(section).getByTestId('home-new-project'));
 	await screen.findByTestId('create-project-submit');
 	return { ...utils, ws };
 }

--- a/packages/web/test/home-dashboard.test.tsx
+++ b/packages/web/test/home-dashboard.test.tsx
@@ -1,0 +1,41 @@
+import { expect, test } from 'vitest';
+import { getTestContext, renderApp } from './helpers/render';
+import { seedProject, seedWorkspace } from './helpers/seed';
+
+// The /home page is the Mission-control dashboard: a date header and project
+// cards split into Active / Other, with live running / tasks / $-today stats.
+test('home shows the dashboard with an active project card carrying live stats', async () => {
+	const ref = { name: '' };
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Mission Demo' });
+			const agent = ws.agents[0];
+			const db = getTestContext().db;
+			// One running agent + $4.82 spent today → an Active card with live stats.
+			await db.query(
+				`UPDATE member_agents SET runtime_status = 'active'::agent_runtime_status WHERE id = $1`,
+				[agent.id],
+			);
+			await db.query(
+				`INSERT INTO cost_entries (member_id, project_id, amount_cents) VALUES ($1, $2, 482)`,
+				[agent.id, project.id],
+			);
+			ref.name = project.name;
+		},
+	});
+
+	await router.navigate({ to: '/home' });
+
+	// Date header + Active section render.
+	await findByTestId('home-date', undefined, { timeout: 15_000 });
+	const active = await findByTestId('home-active', undefined, { timeout: 15_000 });
+	expect(active.textContent).toContain(ref.name);
+
+	// The card carries the running indicator and the $-today figure.
+	const card = await findByTestId('home-active-card');
+	expect(card.textContent).toContain('running');
+	expect(card.textContent).toContain('tasks');
+	expect(card.textContent).toContain('$4.82 today');
+});

--- a/packages/web/test/home-new-project.test.tsx
+++ b/packages/web/test/home-new-project.test.tsx
@@ -16,10 +16,11 @@ test('home "New project" opens the create-project-with-team dialog (type picker)
 		},
 	});
 
-	// The projects section renders once the team has a project. Scope to it — the
-	// team rail also exposes a "New project" affordance.
-	const section = await findByTestId('home-projects-list', undefined, { timeout: 15_000 });
-	await user.click(within(section).getByRole('button', { name: 'New project' }));
+	// The dashboard's projects section renders once the team has a project; its
+	// own "New project" button is testid-scoped so the team rail's affordance
+	// (same label) can't match.
+	const section = await findByTestId('home-projects', undefined, { timeout: 15_000 });
+	await user.click(within(section).getByTestId('home-new-project'));
 
 	// The project-with-team dialog (not the old team-scoped one) has a type picker.
 	await screen.findByTestId('create-project-submit');

--- a/packages/web/test/project-assets.test.tsx
+++ b/packages/web/test/project-assets.test.tsx
@@ -51,9 +51,9 @@ test('an asset can be deleted from the library', async () => {
 	await waitFor(() => expect(queryByText('remove-me.png')).toBeNull());
 });
 
-test('an assets/<name> reference in a comment links to the asset and opens it in a new tab', async () => {
+test('an assets/<name> reference in a task comment opens the preview panel instead of a new tab', async () => {
 	let ctx!: { projectSlug: string; taskId: string };
-	const { findByTestId, router } = await renderApp({
+	const { container, findByTestId, user, router } = await renderApp({
 		initialPath: '/',
 		seed: async () => {
 			const ws = await seedWorkspace();
@@ -70,15 +70,18 @@ test('an assets/<name> reference in a comment links to the asset and opens it in
 		params: { projectId: ctx.projectSlug, taskId: ctx.taskId },
 	});
 
-	await findByTestId('text-comment-body', undefined, { timeout: 15_000 });
+	// In a task comment the asset mention is a button (opens the panel) with no
+	// trailing new-tab suffix link.
 	const link = await findByTestId('asset-mention-link', undefined, { timeout: 15_000 });
+	expect(link.tagName).toBe('BUTTON');
 	expect(link.textContent).toContain('assets/login.png');
-	// Clicking the name now does the same as the icon: open the asset in a new tab.
-	expect(link.getAttribute('href')).toMatch(/^\/api\/assets\/[0-9a-f-]+\?exp=\d+&sig=/);
-	expect(link.getAttribute('target')).toBe('_blank');
-	const preview = await findByTestId('asset-mention-preview-link', undefined, { timeout: 15_000 });
-	expect(preview.getAttribute('href')).toMatch(/^\/api\/assets\/[0-9a-f-]+\?exp=\d+&sig=/);
-	expect(preview.getAttribute('target')).toBe('_blank');
+	expect(container.querySelector('[data-testid="asset-mention-preview-link"]')).toBeNull();
+
+	// The panel opens and exposes the signed-URL open-in-new-tab affordance.
+	await user.click(link);
+	const openTab = (await findByTestId('preview-open-tab')) as HTMLAnchorElement;
+	expect(openTab.getAttribute('href')).toMatch(/^\/api\/assets\/[0-9a-f-]+\?exp=\d+&sig=/);
+	expect(openTab.getAttribute('target')).toBe('_blank');
 });
 
 test('uploading a file through the picker adds it to the library', async () => {

--- a/packages/web/test/project-crud.test.tsx
+++ b/packages/web/test/project-crud.test.tsx
@@ -69,7 +69,7 @@ test('creates a project from Home (Create now) and lands on the Captain planning
 	await waitFor(() => expect(router.state.location.pathname).toMatch(/^\/projects\/.+\/tasks\//));
 }, 60_000);
 
-test('Home lists a seeded project with task and repo counts', async () => {
+test('Home lists a seeded project with its task count and activity', async () => {
 	const name = uniqueName('Count Test');
 	const { router } = await renderApp({
 		initialPath: '/',
@@ -82,6 +82,8 @@ test('Home lists a seeded project with task and repo counts', async () => {
 
 	await router.navigate({ to: '/home' });
 
+	// An idle project (no running agents) lands in the dashboard's Other-projects
+	// list: task count + idle status + last-activity, not the old "N repos".
 	const card = await waitFor(
 		() => {
 			const main = document.querySelector('main');
@@ -91,7 +93,7 @@ test('Home lists a seeded project with task and repo counts', async () => {
 		{ timeout: 15_000 },
 	);
 	expect(card.textContent).toMatch(/tasks/);
-	expect(card.textContent).toMatch(/repos/);
+	expect(card.textContent).toMatch(/idle/);
 }, 60_000);
 
 test('Home project card links to the project detail', async () => {

--- a/packages/web/test/project-doc-preview.test.tsx
+++ b/packages/web/test/project-doc-preview.test.tsx
@@ -106,9 +106,9 @@ test('standalone preview route renders a markdown doc without an iframe', async 
 	expect(queryByTestId('mobile-nav-toggle')).toBeNull();
 });
 
-test('a doc mention in a task comment gets a suffix link to the standalone preview', async () => {
+test('a doc mention in a task comment opens the preview panel instead of a new tab', async () => {
 	let ctx!: { projectSlug: string; taskId: string };
-	const { findByTestId, router } = await renderApp({
+	const { container, findByTestId, user, router } = await renderApp({
 		initialPath: '/',
 		seed: async () => {
 			const ws = await seedWorkspace();
@@ -125,14 +125,15 @@ test('a doc mention in a task comment gets a suffix link to the standalone previ
 		params: { projectId: ctx.projectSlug, taskId: ctx.taskId },
 	});
 
-	// The mention resolves (doc-mention-link) and gains the new tab affordance.
-	await findByTestId('text-comment-body', undefined, { timeout: 15_000 });
-	const preview = await findByTestId('doc-mention-preview-link', undefined, { timeout: 15_000 });
-	expect(preview.getAttribute('href')).toBe(`/preview/${ctx.projectSlug}/ui-mockups.md`);
-	expect(preview.getAttribute('target')).toBe('_blank');
+	// In a task comment the mention is a button that opens the in-page panel —
+	// no trailing new-tab suffix link.
+	const name = await findByTestId('doc-mention-link', undefined, { timeout: 15_000 });
+	expect(name.tagName).toBe('BUTTON');
+	expect(container.querySelector('[data-testid="doc-mention-preview-link"]')).toBeNull();
 
-	// Clicking the name now does the same as the icon: open the preview in a new tab.
-	const name = await findByTestId('doc-mention-link');
-	expect(name.getAttribute('href')).toBe(`/preview/${ctx.projectSlug}/ui-mockups.md`);
-	expect(name.getAttribute('target')).toBe('_blank');
+	// The new-tab affordance now lives on the panel and points at the standalone preview.
+	await user.click(name);
+	const openTab = (await findByTestId('preview-open-tab')) as HTMLAnchorElement;
+	expect(openTab.getAttribute('href')).toBe(`/preview/${ctx.projectSlug}/ui-mockups.md`);
+	expect(openTab.getAttribute('target')).toBe('_blank');
 });

--- a/packages/web/test/route-redirects.test.tsx
+++ b/packages/web/test/route-redirects.test.tsx
@@ -24,7 +24,7 @@ test('invalid team slug redirects to /home', async () => {
 		async () => {
 			const main = document.querySelector('main');
 			if (!main) throw new Error('main not mounted');
-			return within(main as HTMLElement).getByTestId('home-projects-list');
+			return within(main as HTMLElement).getByTestId('home-projects');
 		},
 		{ timeout: 10_000 },
 	);

--- a/packages/web/test/task-comment-doc-preview.test.tsx
+++ b/packages/web/test/task-comment-doc-preview.test.tsx
@@ -1,0 +1,50 @@
+import { expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+import { seedComment, seedProject, seedTask, seedWorkspace } from './helpers/seed';
+
+// A document mention inside a task comment opens in the in-page preview panel
+// (with the "open in new tab" affordance moved onto the panel) instead of a new
+// tab — and the mention drops its trailing external-link icon.
+test('doc mention in a task comment opens the preview panel, not a new tab', async () => {
+	const ref = { projectSlug: '', taskId: '' };
+	const { container, findByTestId, findByText, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async ({ apiBase, token }) => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Preview Project' });
+			const content = ['# Product Requirements', '', 'An unmistakable document body.'].join('\n');
+			const res = await apiBase(`/api/projects/${project.slug}/docs/prd.md`, {
+				method: 'PUT',
+				headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+				body: JSON.stringify({ content }),
+			});
+			if (!res.ok) throw new Error(`seed prd.md failed: ${res.status}`);
+			const task = await seedTask(ws, project, { title: 'Review the spec' });
+			await seedComment(ws, task, 'Please review prd.md before we ship.');
+			ref.projectSlug = project.slug;
+			ref.taskId = task.identifier.toLowerCase();
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: ref.projectSlug, taskId: ref.taskId },
+	});
+
+	// The mention resolves and renders as a button (opens the panel), with no
+	// new-tab icon beside it and no panel open yet.
+	const mention = await findByTestId('doc-mention-link', undefined, { timeout: 15_000 });
+	expect(mention.tagName).toBe('BUTTON');
+	expect(container.querySelector('[data-testid="doc-mention-preview-link"]')).toBeNull();
+	expect(container.querySelector('[data-testid="preview-panel"]')).toBeNull();
+
+	await user.click(mention);
+
+	// The panel opens with the document, its rendered body, and an open-in-new-tab link.
+	await findByTestId('preview-panel');
+	expect((await findByTestId('preview-panel-filename')).textContent).toBe('prd.md');
+	await findByText(/unmistakable document body/i);
+	const openTab = (await findByTestId('preview-open-tab')) as HTMLAnchorElement;
+	expect(openTab.getAttribute('target')).toBe('_blank');
+	expect(openTab.getAttribute('href')).toContain('/preview/');
+});

--- a/packages/web/test/task-header-summary.test.tsx
+++ b/packages/web/test/task-header-summary.test.tsx
@@ -1,0 +1,48 @@
+import { expect, test } from 'vitest';
+import { getTestContext, renderApp } from './helpers/render';
+import { seedProject, seedTask, seedWorkspace } from './helpers/seed';
+
+// The Wire task header renders status / priority / assignee as inline mono
+// metadata (not quiet-tint pills) with a runs · duration · cost summary derived
+// from the task's runs + cost entries.
+test('task header renders inline mono status + a runs/duration/cost summary', async () => {
+	const ref = { projectSlug: '', taskId: '' };
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Header Demo' });
+			const agent = ws.agents[0];
+			const task = await seedTask(ws, project, { title: 'Header task', assignee_id: agent.id });
+			const db = getTestContext().db;
+			// One finished 41s run + a $1.86 cost entry (cost_entries has no team_id since 004).
+			await db.query(
+				`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at, finished_at)
+				 VALUES ($1,$2,$3,'succeeded'::heartbeat_run_status,'2026-01-01T00:00:00Z','2026-01-01T00:00:41Z')`,
+				[agent.id, ws.team.id, task.id],
+			);
+			await db.query(
+				`INSERT INTO cost_entries (member_id, task_id, project_id, amount_cents)
+				 VALUES ($1,$2,$3,186)`,
+				[agent.id, task.id, project.id],
+			);
+			ref.projectSlug = project.slug;
+			ref.taskId = task.identifier.toLowerCase();
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: ref.projectSlug, taskId: ref.taskId },
+	});
+
+	// Status is the raw lowercase enum in mono — not the capitalized quiet-tint pill.
+	const status = await findByTestId('task-status-inline');
+	expect(status.textContent).toMatch(/^[a-z_]+$/);
+	expect(status.parentElement?.className ?? '').toContain('font-mono');
+
+	const summary = await findByTestId('task-run-summary');
+	expect(summary.textContent).toContain('1 run');
+	expect(summary.textContent).toContain('41s');
+	expect(summary.textContent).toContain('$1.86');
+});


### PR DESCRIPTION
Continues matching the app to the Wire design system. Three slices (task-detail header, the reusable preview panel, and the Home dashboard) landed on one branch.

## 1. Task header → Wire spec
Inline **monospace** `status · priority · assignee` + a `N runs · duration · cost` summary, replacing the quiet-tint pills. Backend adds per-task `run_count` / `total_duration_seconds` / `total_cost_cents` / `assignee_slug` aggregates to the task detail endpoint.

## 2. Reusable preview panel (docs + assets, from a comment)
Clicking a **document or asset mention in a task comment** opens it in an **in-page preview panel** (docs render markdown; assets render by content-type) instead of a new tab; the mention's **external-link icon is gone**, and the **"open in new tab"** affordance lives on the panel. Docs/Assets pages and CEO chat keep their new-tab links (a `PreviewProvider` context gates the behavior per surface).

## 3. Home → Mission-control dashboard
Replaces the plain Projects list with: a **date header**, a **NEEDS YOU** feed (pending approvals + unread admin mentions across projects, newest first, each with a type tag + project · time + action), and project cards split into **Active / Other** with a `N running · N tasks · $X today` stat line and a "N need you" / "running" badge.

Backend: the projects index aggregates `running_agents_count`, `today_spend_cents` (UTC-day), and `last_activity_at` per project.

## Tests
- **server**: `task-detail-aggregates`, `projects-dashboard-stats`.
- **web**: `task-header-summary`, `task-comment-doc-preview`, `home-dashboard`; updated `project-doc-preview` / `project-assets` (new-tab → panel contract) and the home anchor in `home-new-project` / `create-project-from-team` / `route-redirects`.
- Full `turbo typecheck` + production build pass on every commit (pre-commit hook); server projects suite (47) + targeted web suites green; full web suite running as the gate.

## Context
Builds on #277 (run-log colors, cyan "running", sidebar status). Foundations / Inbox / Budget already matched the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4S6XkbBFnJGF7zQ4TvDiL