### PR TITLE
chore: hide the project task-list progress bar for now

### DIFF
--- a/packages/web/src/components/project-task-list-header.tsx
+++ b/packages/web/src/components/project-task-list-header.tsx
@@ -86,12 +86,16 @@ function ProgressBar({ summary }: { summary: TaskProgressSummary }) {
 	);
 }
 
+// The project task-progress bar is temporarily disabled. Flip this back to
+// `true` to restore it — the ProgressBar component above is kept intact.
+const SHOW_TASK_PROGRESS_BAR = false;
+
 export function ProjectTaskListHeader({ projectId }: { projectId: string }) {
 	const { data: summary, isLoading } = useTaskProgressSummary(projectId);
 
 	if (isLoading || !summary) return null;
 
-	const showProgressBar = summary.planning_complete && summary.total > 0;
+	const showProgressBar = SHOW_TASK_PROGRESS_BAR && summary.planning_complete && summary.total > 0;
 
 	if (!summary.phase_banner && !showProgressBar) return null;
 

--- a/packages/web/test/task-progress-summary.test.tsx
+++ b/packages/web/test/task-progress-summary.test.tsx
@@ -46,11 +46,14 @@ test('tasks page hides progress area while the planning ticket is open', async (
 	expect(queryByTestId('project-task-list-phase-banner-planning')).toBeNull();
 });
 
-test('tasks page shows segmented progress bar after the planning ticket is closed', async () => {
+// The progress bar is currently disabled via SHOW_TASK_PROGRESS_BAR in
+// project-task-list-header.tsx. It must stay hidden even once the planning
+// ticket is closed and execution tasks exist (the state that used to render it).
+test('tasks page keeps the progress bar hidden after the planning ticket is closed', async () => {
 	let projectSlug = '';
 	let ws!: SeededWorkspace;
 
-	const { findByTestId, findByText, router } = await renderApp({
+	const { findByTestId, queryByTestId, router } = await renderApp({
 		initialPath: '/',
 		seed: async () => {
 			ws = await seedWorkspace();
@@ -80,11 +83,10 @@ test('tasks page shows segmented progress bar after the planning ticket is close
 		params: { projectId: projectSlug },
 	});
 
-	await findByTestId('task-progress-bar', undefined, { timeout: 10_000 });
-	await findByTestId('project-status-idle');
-	await findByText('50% complete');
+	// The task list itself renders, but the progress bar stays hidden.
+	await findByTestId('task-list-main', undefined, { timeout: 10_000 });
 	await waitFor(() => {
-		expect(document.querySelector('[data-testid="task-progress-segment-complete"]')).not.toBeNull();
-		expect(document.querySelector('[data-testid="task-progress-segment-not-done"]')).not.toBeNull();
+		expect(queryByTestId('task-progress-bar')).toBeNull();
 	});
+	expect(queryByTestId('project-status-idle')).toBeNull();
 });

--- a/test/browser/task-list-progress.mobile.spec.ts
+++ b/test/browser/task-list-progress.mobile.spec.ts
@@ -2,7 +2,10 @@ import { expect, test } from './fixtures';
 import { createProjectAndClearPlanning, uniqueName, waitForPageLoad } from './helpers';
 
 test.describe('Project task list — progress header (mobile)', () => {
-	test('shows the segmented progress bar after planning is closed', async ({
+	// Skipped while the project task-progress bar is disabled (see
+	// SHOW_TASK_PROGRESS_BAR in project-task-list-header.tsx). Restore alongside it.
+	// Playwright tier (rule 2): the bar is a mobile-viewport responsive check.
+	test.skip('shows the segmented progress bar after planning is closed', async ({
 		page,
 		sharedWorkspace,
 	}) => {


### PR DESCRIPTION
## What

Hides the segmented **"X% complete / N of M tasks"** progress card from the project task list (the `Idle · 60% complete · 3 of 5 tasks` bar with the green/orange/grey legend).

## How

- Gated the `ProgressBar` render behind a new `SHOW_TASK_PROGRESS_BAR = false` flag in `packages/web/src/components/project-task-list-header.tsx`. The `ProgressBar` component and the `GET /projects/:projectId/tasks/progress-summary` endpoint are **kept intact** — re-enabling is a one-line flip of the flag back to `true`.
- The **onboarding phase banner** ("Please wait whilst the CEO onboards your new team members"), which shares the same header component and endpoint, is **unaffected**.

## Tests

- `packages/web/test/task-progress-summary.test.tsx` — the test that asserted the bar renders after the planning ticket closes now asserts it **stays hidden** in that same state (documents the disabled behaviour). The "hidden while planning is open" test is unchanged.
- `test/browser/task-list-progress.mobile.spec.ts` — the mobile Playwright spec (whose sole purpose is the bar) is `test.skip`-ped with a note to restore it alongside the flag.
- Existing absence assertions in `internal-project.test.tsx` and `project-task-list-phase-banner.test.tsx` continue to pass.

Verified: `biome check` clean (exit 0), web `tsc --noEmit` clean, and the affected web component tests pass (8/8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DyAH97DtVmCZwLuYvJcNGW)_