### PR TITLE
fix(egress): cross-host cert mis-routing, hop-by-hop relay, and per-run upstream sockets (GitHub MCP failure)

### DIFF
--- a/packages/server/src/services/egress/proxy.ts
+++ b/packages/server/src/services/egress/proxy.ts
@@ -33,6 +33,12 @@ import {
 
 const log = logger.child('egress-proxy');
 
+/** When set, the proxy emits per-connection lifecycle traces (socket open/close/
+ * error/timeout per leg, plus the host→dialed-port→owner of each CONNECT). Off by
+ * default; the only reliable way to pin Bun's connection-accounting divergences,
+ * which Node/vitest never reproduce. Enable in a real run with `HEZO_EGRESS_DEBUG=1`. */
+const EGRESS_DEBUG = !!process.env.HEZO_EGRESS_DEBUG;
+
 const PROXY_HOST = 'host.docker.internal';
 const PROXY_BIND_HOST = '127.0.0.1';
 
@@ -241,14 +247,37 @@ class RunProxyInstance {
 
 	constructor(private readonly cfg: RunProxyConfig) {}
 
-	/** Register a socket for forced teardown; auto-untracks when it closes. */
-	private trackSocket(sock: Socket): void {
+	/** Debug-gated lifecycle logging. Enable with `HEZO_EGRESS_DEBUG=1` to trace
+	 * which connection leg dies and when. */
+	private dbg(msg: string, meta: Record<string, unknown> = {}): void {
+		if (!EGRESS_DEBUG) return;
+		log.info(`[egress-dbg] ${msg}`, {
+			run: ref(this.cfg.scope.label, this.cfg.runId),
+			...meta,
+		});
+	}
+
+	/** Register a socket for forced teardown; auto-untracks when it closes. The
+	 * optional `leg` names which hop it is (agent CONNECT, per-host accept, loopback
+	 * bridge, upstream) so debug traces can attribute a death to the right side. */
+	private trackSocket(sock: Socket, leg = 'socket'): void {
 		if (this.closed || sock.destroyed) {
 			sock.destroy();
 			return;
 		}
 		this.liveSockets.add(sock);
 		sock.once('close', () => this.liveSockets.delete(sock));
+		if (EGRESS_DEBUG) {
+			const at = Date.now();
+			this.dbg('socket open', { leg, local: sock.localPort, remote: sock.remotePort });
+			sock.on('timeout', () => this.dbg('socket timeout event', { leg, ageMs: Date.now() - at }));
+			sock.once('error', (e: Error) =>
+				this.dbg('socket error', { leg, ageMs: Date.now() - at, error: e.message }),
+			);
+			sock.once('close', (hadError: boolean) =>
+				this.dbg('socket close', { leg, ageMs: Date.now() - at, hadError }),
+			);
+		}
 	}
 
 	/** Register an upstream request for forced abort; auto-untracks on settle.
@@ -264,7 +293,7 @@ class RunProxyInstance {
 		const cleanup = () => this.liveUpstreams.delete(reqOut);
 		reqOut.once('close', cleanup);
 		reqOut.once('error', cleanup);
-		reqOut.on('socket', (sock) => this.trackSocket(sock));
+		reqOut.on('socket', (sock) => this.trackSocket(sock, 'upstream'));
 	}
 
 	get port(): number {
@@ -281,7 +310,7 @@ class RunProxyInstance {
 		// Track every accepted socket (plain-request and CONNECT alike) so close
 		// can sever it — a hijacked CONNECT socket leaves the server's own
 		// connection list under Bun.
-		front.on('connection', (socket) => this.trackSocket(socket as Socket));
+		front.on('connection', (socket) => this.trackSocket(socket as Socket, 'agent-front'));
 		front.on('request', (req, res) => {
 			this.forward(false, null, req, res).catch((e: Error) => this.onHandlerError(res, e));
 		});
@@ -362,8 +391,17 @@ class RunProxyInstance {
 			client.destroy();
 			return;
 		}
+		if (EGRESS_DEBUG) {
+			// The cross-host cert leak (a host served another host's leaf cert) shows
+			// up here: the port about to be dialed must be owned by THIS host's server
+			// and no other. Log the owner(s) so a mis-route is caught red-handed.
+			const owners = [...this.hostServers.entries()]
+				.filter(([, r]) => r.port === rec.port)
+				.map(([h]) => h);
+			this.dbg('connect dial', { host, dialPort: rec.port, owners });
+		}
 		const up = netConnect({ host: '127.0.0.1', port: rec.port }, () => {
-			this.trackSocket(up);
+			this.trackSocket(up, `bridge:${host}`);
 			client.write('HTTP/1.1 200 Connection Established\r\n\r\n');
 			if (head?.length) up.write(head);
 			client.pipe(up);
@@ -405,7 +443,7 @@ class RunProxyInstance {
 		const server = createHttpsServer({ key: leaf.key, cert: leaf.cert }, (req, res) => {
 			this.forward(true, host, req, res).catch((e: Error) => this.onHandlerError(res, e));
 		});
-		server.on('connection', (socket) => this.trackSocket(socket as Socket));
+		server.on('connection', (socket) => this.trackSocket(socket as Socket, `perhost:${host}`));
 		server.on('clientError', (_err, socket) => socket.destroy());
 		server.on('error', (err) => {
 			log.warn('egress per-host server error', {

--- a/packages/server/src/services/egress/proxy.ts
+++ b/packages/server/src/services/egress/proxy.ts
@@ -99,16 +99,12 @@ export class EgressProxy {
 	private readonly portAllocator: PortAllocator;
 	private readonly proxyHost: string;
 	private readonly proxyBindHost: string;
-	private readonly upstreamHttpsAgent?: HttpsAgent;
 	private mintCa: Promise<CA> | null = null;
 
 	constructor(private readonly deps: EgressProxyDeps) {
 		this.portAllocator = deps.portAllocator ?? new PortAllocator();
 		this.proxyHost = deps.proxyHost ?? PROXY_HOST;
 		this.proxyBindHost = deps.proxyBindHost ?? PROXY_BIND_HOST;
-		this.upstreamHttpsAgent = deps.extraUpstreamTrustedCAs
-			? new HttpsAgent({ keepAlive: true, ca: deps.extraUpstreamTrustedCAs })
-			: undefined;
 	}
 
 	get caCertPath(): string {
@@ -150,7 +146,7 @@ export class EgressProxy {
 					db: this.deps.db,
 					masterKeyManager: this.deps.masterKeyManager,
 					getMintCa: () => this.getMintCa(),
-					upstreamHttpsAgent: this.upstreamHttpsAgent,
+					upstreamTrustedCAs: this.deps.extraUpstreamTrustedCAs,
 				});
 
 				try {
@@ -208,7 +204,7 @@ interface RunProxyConfig {
 	db: PGlite;
 	masterKeyManager: MasterKeyManager;
 	getMintCa: () => Promise<CA>;
-	upstreamHttpsAgent?: HttpsAgent;
+	upstreamTrustedCAs?: string | string[];
 }
 
 /** A per-host internal TLS-terminating server. The agent's CONNECT socket is
@@ -250,8 +246,22 @@ class RunProxyInstance {
 	 * upstream connection (the SSE channel to api.githubcopilot.com) leaks unless
 	 * the request itself is aborted on teardown. */
 	private readonly liveUpstreams = new Set<ClientRequest>();
+	/** This run's own agent for proxy→upstream HTTPS, with keep-alive OFF and owned
+	 * per run rather than shared with the process-global agent. Keep-alive off means
+	 * an upstream socket is never parked idle in a pool — it closes when its
+	 * response ends — so only genuinely in-flight requests (aborted via
+	 * `liveUpstreams`) hold a socket at teardown. Idle pooled sockets can't be
+	 * reliably closed under Bun (a pooled socket's handle no longer maps to the live
+	 * connection), so not pooling them is what keeps them from outliving the run and
+	 * accumulating against a remote MCP host. */
+	private readonly upstreamAgent: HttpsAgent;
 
-	constructor(private readonly cfg: RunProxyConfig) {}
+	constructor(private readonly cfg: RunProxyConfig) {
+		this.upstreamAgent = new HttpsAgent({
+			keepAlive: false,
+			...(cfg.upstreamTrustedCAs ? { ca: cfg.upstreamTrustedCAs } : {}),
+		});
+	}
 
 	/** Debug-gated lifecycle logging. Enable with `HEZO_EGRESS_DEBUG=1` to trace
 	 * which connection leg dies and when. */
@@ -350,6 +360,8 @@ class RunProxyInstance {
 		this.liveSockets.clear();
 		for (const up of this.liveUpstreams) up.destroy();
 		this.liveUpstreams.clear();
+		// Tear down the run's upstream agent so nothing it holds outlives the run.
+		this.upstreamAgent.destroy();
 
 		const closables: Array<Promise<void>> = [];
 		for (const [host, { server }] of this.hostServers.entries()) {
@@ -614,7 +626,7 @@ class RunProxyInstance {
 				method,
 				path,
 				headers,
-				...(isSSL ? { servername: host, agent: this.cfg.upstreamHttpsAgent } : {}),
+				...(isSSL ? { servername: host, agent: this.upstreamAgent } : {}),
 			},
 			(upstreamRes) => {
 				res.writeHead(upstreamRes.statusCode ?? 502, upstreamRes.headers);

--- a/packages/server/src/services/egress/proxy.ts
+++ b/packages/server/src/services/egress/proxy.ts
@@ -424,7 +424,15 @@ class RunProxyInstance {
 	 * one in-flight build so the run never spins up duplicate servers. */
 	private ensureHostServer(host: string): Promise<HostServer> {
 		const existing = this.hostServers.get(host);
-		if (existing && serverOwnsPort(existing)) return Promise.resolve(existing);
+		// Reuse only a live entry that is the *sole* claimant of its port. Under Bun
+		// a stale entry can keep reporting a port that another host's live server has
+		// since taken over (`address()` lies), so `serverOwnsPort` alone can't tell a
+		// real owner from a zombie pointing at someone else's port — dialing it would
+		// serve the other host's leaf cert. Requiring unique ownership forces a
+		// rebuild onto a fresh, exclusive port instead.
+		if (existing && serverOwnsPort(existing) && this.portUniquelyOwnedBy(host, existing.port)) {
+			return Promise.resolve(existing);
+		}
 
 		const pending = this.pendingHostServers.get(host);
 		if (pending) return pending;
@@ -473,9 +481,27 @@ class RunProxyInstance {
 			throw new Error('proxy closed');
 		}
 
-		const rec: HostServer = { server, port: (server.address() as { port: number }).port };
+		const port = (server.address() as { port: number }).port;
+		// The OS just handed this port to the new server, so any other host entry
+		// still claiming it lost it and is stale — drop those entries so no two
+		// hosts ever map to one port (the cross-host wrong-cert invariant). The
+		// orphaned server is already off the port; let it be GC'd rather than
+		// risk closing a live server on a mis-reported port.
+		for (const [h, r] of this.hostServers) {
+			if (h !== host && r.port === port) this.hostServers.delete(h);
+		}
+		const rec: HostServer = { server, port };
 		this.hostServers.set(host, rec);
 		return rec;
+	}
+
+	/** Whether `host` is the only entry claiming `port`. A port belongs to exactly
+	 * one per-host server; a second claimant is a stale entry that lost the port. */
+	private portUniquelyOwnedBy(host: string, port: number): boolean {
+		for (const [h, r] of this.hostServers) {
+			if (h !== host && r.port === port) return false;
+		}
+		return true;
 	}
 
 	/** Scan the decrypted (or plain) request for secret placeholders, substitute

--- a/packages/server/src/services/egress/proxy.ts
+++ b/packages/server/src/services/egress/proxy.ts
@@ -39,6 +39,12 @@ const log = logger.child('egress-proxy');
  * which Node/vitest never reproduce. Enable in a real run with `HEZO_EGRESS_DEBUG=1`. */
 const EGRESS_DEBUG = !!process.env.HEZO_EGRESS_DEBUG;
 
+/** Connection-management headers scoped to a single transport hop, which a proxy
+ * must not relay to the upstream (RFC 7230 §6.1). `proxy-*` are dropped
+ * separately. Transfer-encoding / content-length are intentionally not here — the
+ * runtime recomputes body framing for the re-issued request. */
+const HOP_BY_HOP_HEADERS = new Set(['connection', 'keep-alive', 'upgrade']);
+
 const PROXY_HOST = 'host.docker.internal';
 const PROXY_BIND_HOST = '127.0.0.1';
 
@@ -488,8 +494,12 @@ class RunProxyInstance {
 		const method = req.method ?? 'GET';
 		const headers: Record<string, string | string[] | undefined> = {};
 		for (const [name, value] of Object.entries(req.headers)) {
-			// Strip hop-by-hop proxy headers; they must not reach the upstream.
-			if (/^proxy-/i.test(name)) continue;
+			// Strip hop-by-hop headers (RFC 7230 §6.1) and all proxy-* headers: they
+			// describe the agent↔proxy hop, not the proxy↔upstream one, and a proxy
+			// must not relay them. Relaying the client's `connection: keep-alive` in
+			// particular tells the upstream to hold the socket open on the client's
+			// behalf, against the proxy's own connection management.
+			if (/^proxy-/i.test(name) || HOP_BY_HOP_HEADERS.has(name.toLowerCase())) continue;
 			headers[name] = value;
 		}
 

--- a/packages/server/test/bun/egress-proxy.bun.test.ts
+++ b/packages/server/test/bun/egress-proxy.bun.test.ts
@@ -261,6 +261,51 @@ describe('EgressProxy under Bun', () => {
 			await proxy.releaseRunProxy(runId);
 		}
 	}, 30_000);
+
+	// The cross-host leak (production: registry.npmjs.org served the SAN of
+	// api.githubcopilot.com): under Bun a stale entry can keep reporting a port
+	// that a *different* host's live server has since taken over, so two hosts map
+	// to one port and `serverOwnsPort` (which only checks the entry's own
+	// liveness) can't tell them apart — dialing the stale one serves the other
+	// host's cert. A port must belong to at most one host: a second claimant is
+	// rebuilt onto a fresh port rather than dialed.
+	test('never serves one host the cert of another that shares its recorded port', async () => {
+		const runId = `bun-crosshost-${process.pid}`;
+		const liveHost = 'live.hezo-egress-test';
+		const ghostHost = 'ghost.hezo-egress-test';
+		const allocated = await proxy.allocateRunProxy(runId, { teamId, agentId });
+		try {
+			// Stand up a real, live per-host server for liveHost.
+			const liveSan = await servedSanThroughProxy(allocated.proxyPort, liveHost, ca.cert);
+			expect(liveSan).toContain(liveHost);
+			const map = getHostServers(proxy, runId);
+			const liveRec = map.get(liveHost);
+			if (!liveRec) throw new Error('live per-host server missing');
+
+			// Forge the desync: a stale ghost entry that lies it still owns liveHost's
+			// (live) port. serverOwnsPort(ghost) passes; only port-uniqueness exposes it.
+			map.set(ghostHost, {
+				port: liveRec.port,
+				server: {
+					listening: true,
+					address: () => ({ port: liveRec.port }),
+					close: liveRec.server.close.bind(liveRec.server),
+				} as unknown as HttpsServer,
+			});
+
+			// ghostHost must get ITS OWN cert, never liveHost's leaf.
+			const ghostSan = await servedSanThroughProxy(allocated.proxyPort, ghostHost, ca.cert);
+			expect(ghostSan).toContain(ghostHost);
+			expect(ghostSan).not.toContain(liveHost);
+			// ghost was rebuilt onto a port distinct from liveHost's.
+			expect(map.get(ghostHost)?.port).not.toBe(liveRec.port);
+			// liveHost still serves its own cert afterward.
+			const liveAgain = await servedSanThroughProxy(allocated.proxyPort, liveHost, ca.cert);
+			expect(liveAgain).toContain(liveHost);
+		} finally {
+			await proxy.releaseRunProxy(runId);
+		}
+	}, 30_000);
 });
 
 /** Reach into the proxy's per-run internal per-host server map for assertions. */

--- a/packages/server/test/bun/egress-proxy.bun.test.ts
+++ b/packages/server/test/bun/egress-proxy.bun.test.ts
@@ -88,6 +88,44 @@ describe('EgressProxy under Bun', () => {
 		}
 	}, 30_000);
 
+	// A proxy must not relay hop-by-hop headers (RFC 7230 §6.1) to the upstream.
+	// Relaying the client's `connection: keep-alive` / `keep-alive` / `upgrade`
+	// lets the client dictate the upstream socket's lifetime against the proxy's
+	// own connection management — a contributor to upstream sockets lingering past
+	// the run. Normal end-to-end headers (and secret substitution) still pass.
+	test('does not relay hop-by-hop headers to the upstream', async () => {
+		const upstream = await startHttpsUpstream(ca);
+		const upstreamPort = (upstream.address() as { port: number }).port;
+		const runId = `bun-run-${process.pid}-hopbyhop`;
+		await insertSecret('BUN_HOPBYHOP', 'real-value', ['localhost']);
+		const allocated = await proxy.allocateRunProxy(runId, { teamId, agentId });
+		try {
+			const res = await fetchHttpsThroughProxy({
+				proxyHost: '127.0.0.1',
+				proxyPort: allocated.proxyPort,
+				targetHost: 'localhost',
+				targetPort: upstreamPort,
+				path: '/echo',
+				headers: {
+					authorization: 'Bearer __HEZO_SECRET_BUN_HOPBYHOP__',
+					'keep-alive': 'timeout=5, max=1000',
+				},
+				caCert: ca.cert,
+			});
+			expect(res.status).toBe(200);
+			const received = httpsHits.at(-1) ?? {};
+			// The client's hop-by-hop `keep-alive` header must not reach the upstream
+			// (the proxy's own client never adds this header, so its presence would
+			// mean the client's copy was relayed).
+			expect(received['keep-alive']).toBeUndefined();
+			// End-to-end headers still pass, and the secret is still substituted.
+			expect(received.authorization).toBe('Bearer real-value');
+		} finally {
+			await proxy.releaseRunProxy(runId);
+			await new Promise<void>((resolve) => upstream.close(() => resolve()));
+		}
+	}, 30_000);
+
 	test('handles concurrent run allocate/connect/release churn without hanging', async () => {
 		const upstream = await startHttpsUpstream(ca);
 		const upstreamPort = (upstream.address() as { port: number }).port;

--- a/packages/server/test/bun/egress-proxy.bun.test.ts
+++ b/packages/server/test/bun/egress-proxy.bun.test.ts
@@ -306,6 +306,42 @@ describe('EgressProxy under Bun', () => {
 			await proxy.releaseRunProxy(runId);
 		}
 	}, 30_000);
+
+	// Upstream connection policy: each run owns a keep-alive-OFF agent rather than
+	// sharing the process-global pool. Keep-alive off means no upstream socket is
+	// parked idle in a pool to outlive the run (idle pooled sockets can't be
+	// reliably closed under Bun), and per-run ownership keeps one run's upstream
+	// connections from being shared with another's. Asserted at the config level —
+	// deterministic, unlike socket-close timing under Bun.
+	test('gives each run its own keep-alive-off upstream agent', async () => {
+		const idA = `bun-agent-a-${process.pid}`;
+		const idB = `bun-agent-b-${process.pid}`;
+		const a = await proxy.allocateRunProxy(idA, { teamId, agentId });
+		const b = await proxy.allocateRunProxy(idB, { teamId, agentId });
+		try {
+			const runs = (
+				proxy as unknown as {
+					runs: Map<
+						string,
+						{ upstreamAgent: { keepAlive?: boolean; options?: { keepAlive?: boolean } } }
+					>;
+				}
+			).runs;
+			const agentA = runs.get(idA)?.upstreamAgent;
+			const agentB = runs.get(idB)?.upstreamAgent;
+			if (!agentA || !agentB) throw new Error('per-run upstream agent missing');
+			// Per-run isolation — not one shared/global agent.
+			expect(agentA).not.toBe(agentB);
+			// Keep-alive disabled (Node exposes it as `keepAlive`; the options bag
+			// carries what was passed) so upstream sockets are never pooled idle.
+			const keepAlive = agentA.keepAlive ?? agentA.options?.keepAlive;
+			expect(keepAlive).toBe(false);
+		} finally {
+			await proxy.releaseRunProxy(idA);
+			await proxy.releaseRunProxy(idB);
+		}
+		expect(a.proxyPort).not.toBe(b.proxyPort);
+	}, 30_000);
 });
 
 /** Reach into the proxy's per-run internal per-host server map for assertions. */

--- a/packages/server/test/bun/egress-streaming.bun.test.ts
+++ b/packages/server/test/bun/egress-streaming.bun.test.ts
@@ -81,6 +81,10 @@ async function tunnelTo(proxyPort: number, host: string, port: number): Promise<
 		const s = netConnect({ host: '127.0.0.1', port: proxyPort });
 		const onData = (chunk: Buffer) => {
 			s.removeListener('data', onData);
+			// The timeout only bounds the CONNECT handshake; clear it once the tunnel
+			// is up, or it would reap the idle socket mid-test and masquerade as a
+			// proxy-side idle reap.
+			s.setTimeout(0);
 			if (/^HTTP\/1\.[01] 200/.test(chunk.toString().split('\r\n')[0] ?? '')) resolve(s);
 			else reject(new Error(`CONNECT failed: ${chunk.toString().split('\r\n')[0]}`));
 		};
@@ -278,4 +282,50 @@ describe('EgressProxy streaming + teardown under Bun', () => {
 			await new Promise<void>((r) => upstream.close(() => r()));
 		}
 	}, 30_000);
+
+	// A remote Streamable-HTTP MCP (api.githubcopilot.com) holds its SSE channel
+	// open but quiet between tool calls — often for many minutes. The proxy must
+	// not impose an inactivity timeout of its own that would reap the channel and
+	// surface to the agent as "socket connection was closed unexpectedly". Every
+	// other test here keeps traffic flowing within ~2s, so this is the only one
+	// that would catch a regression that added an idle timeout to the tunnel.
+	const IDLE_GAP_MS = 15_000;
+
+	test('keeps a quiet SSE stream open across a long idle gap', async () => {
+		const { cert, key } = await mintCertFromCA(ca, 'localhost');
+		// Writes one event, then stays silent past the idle window, then one more.
+		// A reaped connection never delivers the second event.
+		const upstream: HttpsServer = createHttpsServer({ cert, key }, (_req, res) => {
+			res.writeHead(200, { 'content-type': 'text/event-stream' });
+			res.write('data: first\n\n');
+			setTimeout(() => res.write('data: second\n\n'), IDLE_GAP_MS);
+		});
+		await new Promise<void>((r) => upstream.listen(0, '127.0.0.1', () => r()));
+		const upstreamPort = (upstream.address() as { port: number }).port;
+		await insertSecret('IDLE_SSE', 'tok', ['localhost']);
+		const runId = `idle-sse-${process.pid}`;
+		const allocated = await proxy.allocateRunProxy(runId, { teamId, agentId });
+
+		try {
+			const tls = await tunnelTo(allocated.proxyPort, 'localhost', upstreamPort);
+			let acc = '';
+			const sawSecond = new Promise<boolean>((resolve) => {
+				tls.on('data', (c: Buffer) => {
+					acc += c.toString();
+					if (acc.includes('second')) resolve(true);
+				});
+				tls.on('close', () => resolve(false));
+				tls.setTimeout(IDLE_GAP_MS + 10_000, () => resolve(false));
+			});
+			tls.write(
+				`GET /sse HTTP/1.1\r\nHost: localhost:${upstreamPort}\r\nAccept: text/event-stream\r\n` +
+					`Authorization: Bearer __HEZO_SECRET_IDLE_SSE__\r\n\r\n`,
+			);
+			expect(await sawSecond).toBe(true);
+			tls.destroy();
+		} finally {
+			await proxy.releaseRunProxy(runId);
+			await new Promise<void>((r) => upstream.close(() => r()));
+		}
+	}, 40_000);
 });


### PR DESCRIPTION
## Why

An agent run's GitHub MCP calls (`api.githubcopilot.com`, Streamable-HTTP via the per-run egress proxy) all failed mid-run with `The socket connection was closed unexpectedly`, so the agent never opened its PR. Logs also showed a cross-host cert mis-route (`registry.npmjs.org` served `api.githubcopilot.com`'s SAN) and recurring `server close timed out … api.githubcopilot.com` teardown warnings. This PR fixes all three.

## Fixes

### 1. Cross-host cert mis-routing — enforce one host per port *(reproduced + verified)*
Each CONNECT is routed to a per-host TLS server by port. `serverOwnsPort` only checked an entry's *own* liveness; under Bun a stale entry can keep reporting a port a **different** host's live server has taken over, so two hosts claim one port and the stale one routes into the wrong server, serving its leaf cert — the production symptom and a direct way for the GitHub MCP's TLS to break. Fix: a port belongs to at most one host (reuse only the sole claimant, else rebuild; evict stale same-port entries on build). Test forges the desync: wrong SAN without the fix, correct with it.

### 2. Hop-by-hop header relay — don't forward Connection/Keep-Alive/Upgrade *(reproduced + verified)*
The proxy forwarded the client's hop-by-hop headers to the upstream (RFC 7230 §6.1 violation). Relaying `connection: keep-alive` lets the client hold the upstream socket open against the proxy's policy. Fix strips them; test confirms a client `keep-alive` no longer reaches the upstream while end-to-end headers + secret substitution are unaffected.

### 3. Per-run, keep-alive-off upstream agent — sockets don't outlive a run *(config-verified)*
Upstream requests went through the process-global keep-alive agent, so completed requests left idle sockets pooled — and under Bun an idle pooled socket can't be reliably closed at teardown, so it outlives the run and accumulates against a remote MCP host (the `server close timed out` leak). Each run now owns a keep-alive-**off** agent: an upstream socket closes when its response ends, so only in-flight requests hold a socket at teardown (those are aborted via `liveUpstreams`), and the agent is destroyed on release. With #2 (no relayed keep-alive) nothing pools. Verified deterministically at the config level (distinct per-run agent, `keepAlive=false`) since socket-close timing itself isn't observable under Bun.

## Also in this PR
- **Debug-gated instrumentation** (`HEZO_EGRESS_DEBUG=1`, off by default): per-leg socket open/close/error/timeout + each CONNECT's `host → dialed-port → owning-host` (the probe that pinned #1).
- **Test-helper fix**: the Bun streaming helper armed a 15s CONNECT-handshake timeout and never cleared it (it, not the proxy, killed idle tunnels in an idle-reap theory I disproved). Plus an SSE-idle regression guard.

## Test plan
- `cd packages/server && bun test ./test/bun/` → 16 pass
- `bun run test --package server --pattern egress` → 34 pass
- `tsc --noEmit` clean; `biome check` clean

## Out of scope (separate ticket)
The agent recovered by pointing npm directly at `registry.npmjs.org` (`npm config proxy null`) — the container has direct outbound network alongside the proxy, an egress-containment gap worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)