### PR TITLE
refactor(api): remove bare team-centric /api/teams routes

### DIFF
--- a/.dev/api.md
+++ b/.dev/api.md
@@ -118,45 +118,7 @@ Members (both agents and users) with role='member' are restricted by `project_id
 
 ### Teams
 
-#### `GET /teams`
-List all teams.
-
-Response:
-```json
-{
-  "data": [
-    {
-      "id": "uuid",
-      "name": "NoteGenius AI",
-      "description": "Build the #1 AI note-taking app",
-      "agent_count": 6,
-      "open_task_count": 14,
-      "total_budget_cents": 24000,
-      "total_used_cents": 12700,
-      "created_at": "...",
-      "updated_at": "..."
-    }
-  ]
-}
-```
-
-#### `POST /teams`
-Create a team. Optionally seed from a template.
-
-Request:
-```json
-{
-  "name": "NoteGenius AI",
-  "description": "Build the #1 AI note-taking app",
-  "template_id": "uuid"
-}
-```
-
-`template_id` is optional. When set, agents are provisioned from the selected template with their configurations (titles, prompts, org chart, runtimes, budgets). Task prefixes are configured per project, not at the team level.
-
-Response: full team object. On creation the server provisions the agent roster (Captain + template roles); it does **not** create a project. Under the 1:1 model a project is created together with its team via `POST /projects` (direct) or `POST /project-intakes` (CEO-assisted), and the project's container is provisioned at that point. A bare `POST /teams` is primarily an internal/test building block.
-
-The board lands on a team with 11 agents.
+Teams are never addressed directly — there are no bare `GET /teams` or `POST /teams` endpoints. A team is reached through its project (1:1) and is provisioned together with its project via `POST /projects` (direct) or `POST /project-intakes` (CEO-assisted). To enumerate teams, list projects (`GET /projects`): each row carries its backing `team_id`, `team_slug`, `team_name`, and `agent_count`.
 
 #### `GET /projects/:projectId/team`
 Get team detail. The team is resolved from the project handle.

--- a/.dev/schema.md
+++ b/.dev/schema.md
@@ -362,7 +362,7 @@ windowed budgets (see "Budget enforcement (windowed)").
 
 ### Team onboarding
 
-When a team is created via `POST /teams`, the server automatically:
+When a team is created (together with its project, via `POST /projects` or `POST /project-intakes`), the server automatically:
 1. Creates the `~/.hezo/teams/{slug}/` folder structure
 2. Creates the full 11-agent team (Captain, Product Lead, Architect, Engineer, QA Engineer,
    Security Engineer, UI Designer, DevOps Engineer, Marketing Lead, Researcher, Coach)
@@ -378,7 +378,7 @@ This ensures the user never lands on an empty team.
 
 ### Team type provisioning
 
-`POST /teams` accepts an optional `template_id` (a single team type UUID). The server provisions
+Team creation accepts an optional `template_id` (a single team type UUID). The server provisions
 agents from the selected team type via the `team_template_agent_types` join table:
 
 1. Queries `team_template_agent_types JOIN agent_types` for the selected template, ordered by `sort_order`

--- a/packages/server/src/middleware/auth.ts
+++ b/packages/server/src/middleware/auth.ts
@@ -5,7 +5,7 @@ import type { Context } from 'hono';
 import { createMiddleware } from 'hono/factory';
 import { sign, verify } from 'hono/jwt';
 import type { MasterKeyManager } from '../crypto/master-key';
-import { resolveProject, resolveTeamId } from '../lib/resolve';
+import { resolveProject } from '../lib/resolve';
 import type { AuthInfo, Env } from '../lib/types';
 
 const AGENT_JWT_TTL_SECONDS = 60 * 60 * 4;
@@ -286,48 +286,6 @@ async function assertTeamAccess(
 	}
 	return null;
 }
-
-export async function requireTeamAccess(c: Context<Env>): Promise<{ teamId: string } | Response> {
-	const raw = c.req.param('teamId');
-	if (!raw) {
-		return c.json({ error: { code: 'BAD_REQUEST', message: 'Missing teamId' } }, 400);
-	}
-
-	const db = c.get('db');
-	const teamId = await resolveTeamId(db, raw);
-	if (!teamId) {
-		return c.json({ error: { code: 'NOT_FOUND', message: 'Team not found' } }, 404);
-	}
-
-	const denied = await assertTeamAccess(db, c.get('auth'), c, teamId);
-	if (denied) return denied;
-	return { teamId };
-}
-
-/**
- * Hono middleware variant of {@link requireTeamAccess} for routes mounted under
- * `/api/teams/:teamId/*`. Resolves the `:teamId` URL param (slug or UUID),
- * runs the shared team-access check, and exposes the resolved UUID at
- * `c.var.teamId` for downstream handlers to read via `c.get('teamId')`.
- */
-export const requireTeamAccessMiddleware = createMiddleware<Env>(async (c, next) => {
-	const raw = c.req.param('teamId');
-	if (!raw) {
-		return c.json({ error: { code: 'BAD_REQUEST', message: 'Missing teamId' } }, 400);
-	}
-
-	const db = c.get('db');
-	const teamId = await resolveTeamId(db, raw);
-	if (!teamId) {
-		return c.json({ error: { code: 'NOT_FOUND', message: 'Team not found' } }, 404);
-	}
-
-	const denied = await assertTeamAccess(db, c.get('auth'), c, teamId);
-	if (denied) return denied;
-
-	c.set('teamId', teamId);
-	return next();
-});
 
 /**
  * Hono middleware for routes mounted under `/api/projects/:projectId/*`. The

--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -4,6 +4,7 @@ import {
 	AuthType,
 	CAPTAIN_AGENT_SLUG,
 	ContainerStatus,
+	MemberType,
 	WakeupSource,
 	wsRoom,
 } from '@hezo/shared';
@@ -140,8 +141,10 @@ projectsRoutes.get('/projects', async (c) => {
 	const isAdmin = auth.type === AuthType.Admin;
 
 	const ts = terminalStatusParams(1);
-	const params: unknown[] = [...ts.values];
+	const agentTypeIdx = ts.values.length + 1;
+	const params: unknown[] = [...ts.values, MemberType.Agent];
 	const base = `SELECT p.*, t.slug AS team_slug, t.name AS team_name,
+       (SELECT count(*) FROM members m WHERE m.team_id = p.team_id AND m.member_type = $${agentTypeIdx})::int AS agent_count,
        (SELECT count(*) FROM repos r WHERE r.project_id = p.id)::int AS repo_count,
        (SELECT count(*) FROM tasks i WHERE i.project_id = p.id AND i.status NOT IN (${ts.placeholders}))::int AS open_task_count,
        (SELECT count(*) FROM member_agents ma JOIN members mm ON mm.id = ma.id

--- a/packages/server/src/routes/teams.ts
+++ b/packages/server/src/routes/teams.ts
@@ -1,4 +1,4 @@
-import { AuthType, MemberType } from '@hezo/shared';
+import { MemberType } from '@hezo/shared';
 import { Hono } from 'hono';
 import { resolveTaskId } from '../lib/resolve';
 import { err, ok } from '../lib/response';
@@ -9,84 +9,8 @@ import { requireSuperuser } from '../middleware/auth';
 import { postSkipQuestionsSignalForProjectIntake } from '../services/project-intake';
 import { applyTemplateToTeam } from '../services/team-template-apply';
 import { snapshotTeamAsTemplate } from '../services/team-template-snapshot';
-import { createTeam } from '../services/teams';
 
 export const teamsRoutes = new Hono<Env>();
-
-teamsRoutes.get('/teams', async (c) => {
-	const db = c.get('db');
-	const auth = c.get('auth');
-
-	const isSuperuser = auth.type === AuthType.Admin && auth.isSuperuser;
-	const isAdmin = auth.type === AuthType.Admin;
-
-	let query: string;
-	const params: unknown[] = [MemberType.Agent];
-	const ts = terminalStatusParams(2);
-	params.push(...ts.values);
-	const nextIdx = 2 + ts.values.length;
-
-	if (!isAdmin || isSuperuser) {
-		query = `SELECT c.*,
-       (SELECT count(*) FROM members m WHERE m.team_id = c.id AND m.member_type = $1)::int AS agent_count,
-       (SELECT count(*) FROM tasks i WHERE i.team_id = c.id AND i.status NOT IN (${ts.placeholders}))::int AS open_task_count,
-       (SELECT tt.name FROM team_template_assignments tta JOIN team_templates tt ON tt.id = tta.team_template_id WHERE tta.team_id = c.id ORDER BY tt.is_builtin DESC LIMIT 1) AS primary_template_name,
-       EXISTS (SELECT 1 FROM projects p WHERE p.team_id = c.id AND p.is_internal = true) AS is_internal
-     FROM teams c
-     ORDER BY c.created_at DESC`;
-	} else {
-		query = `SELECT c.*,
-       (SELECT count(*) FROM members m WHERE m.team_id = c.id AND m.member_type = $1)::int AS agent_count,
-       (SELECT count(*) FROM tasks i WHERE i.team_id = c.id AND i.status NOT IN (${ts.placeholders}))::int AS open_task_count,
-       (SELECT tt.name FROM team_template_assignments tta JOIN team_templates tt ON tt.id = tta.team_template_id WHERE tta.team_id = c.id ORDER BY tt.is_builtin DESC LIMIT 1) AS primary_template_name,
-       EXISTS (SELECT 1 FROM projects p WHERE p.team_id = c.id AND p.is_internal = true) AS is_internal
-     FROM teams c
-     JOIN members m2 ON m2.team_id = c.id
-     JOIN member_users mu ON mu.id = m2.id
-     WHERE mu.user_id = $${nextIdx}
-     ORDER BY c.created_at DESC`;
-		params.push(auth.userId);
-	}
-
-	const result = await db.query(query, params);
-	return ok(c, result.rows);
-});
-
-teamsRoutes.post('/teams', async (c) => {
-	const denied = requireSuperuser(c);
-	if (denied) return denied;
-
-	const body = await c.req.json<{
-		name: string;
-		description?: string;
-		template_id?: string;
-	}>();
-
-	if (!body.name?.trim()) {
-		return err(c, 'INVALID_REQUEST', 'name is required', 400);
-	}
-
-	const auth = c.get('auth');
-	const team = await createTeam(
-		{
-			db: c.get('db'),
-			docker: c.get('docker'),
-			dataDir: c.get('dataDir'),
-			wsManager: c.get('wsManager'),
-			masterKeyManager: c.get('masterKeyManager'),
-			logs: c.get('logs'),
-			egressCAPath: c.get('egressProxy')?.caCertPath ?? null,
-		},
-		{
-			name: body.name.trim(),
-			description: body.description,
-			templateId: body.template_id,
-			creatorUserId: auth.type === AuthType.Admin ? auth.userId : undefined,
-		},
-	);
-
-	return ok(c, team, 201);
-});
 
 teamsRoutes.post('/projects/:projectId/project-intake/:taskId/skip-questions', async (c) => {
 	const teamId = c.get('teamId') as string;

--- a/packages/server/test/admin-mentions.test.ts
+++ b/packages/server/test/admin-mentions.test.ts
@@ -9,6 +9,7 @@ import {
 	authHeader,
 	createTestApp,
 	createTestProject,
+	createTestTeam,
 	mintAgentToken,
 	projectSlugFor,
 } from './helpers/app';
@@ -149,13 +150,9 @@ beforeAll(async () => {
 		(t: Record<string, unknown>) => t.name === 'Startup',
 	).id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({
-			name: 'Admin Mentions Co',
-			template_id: typeId,
-		}),
+	const teamRes = await createTestTeam(db, {
+		name: 'Admin Mentions Co',
+		template_id: typeId,
 	});
 	const teamData = (await teamRes.json()).data;
 	teamId = teamData.id;

--- a/packages/server/test/agent-api.test.ts
+++ b/packages/server/test/agent-api.test.ts
@@ -4,7 +4,13 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { MasterKeyManager } from '../src/crypto/master-key';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject, mintAgentToken } from './helpers/app';
+import {
+	authHeader,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+	mintAgentToken,
+} from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -26,14 +32,10 @@ beforeAll(async () => {
 	const typesRes = await app.request('/api/team-templates', { headers: authHeader(adminToken) });
 	const teamTemplateId = (await typesRes.json()).data.find((t: any) => t.name === 'Startup').id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(adminToken), 'Content-Type': 'application/json' },
-		body: JSON.stringify({
-			name: 'Agent API Co',
+	const teamRes = await createTestTeam(db, {
+		name: 'Agent API Co',
 
-			template_id: teamTemplateId,
-		}),
+		template_id: teamTemplateId,
 	});
 	const teamData = (await teamRes.json()).data;
 	teamId = teamData.id;

--- a/packages/server/test/agent-autonomy.test.ts
+++ b/packages/server/test/agent-autonomy.test.ts
@@ -1,6 +1,6 @@
 import { ApprovalType, TaskStatus } from '@hezo/shared';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { authHeader, createTestProject, instanceCoachId } from './helpers/app';
+import { authHeader, createTestProject, createTestTeam, instanceCoachId } from './helpers/app';
 import { createTestContext, destroyTestContext, type ServerTestContext } from './helpers/context';
 
 let ctx: ServerTestContext;
@@ -24,15 +24,11 @@ beforeAll(async () => {
 	const softDevType = types.data.find((t: any) => t.name === 'Startup');
 
 	// Create a team with auto-created agents
-	const teamRes = await ctx.app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(ctx.token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({
-			name: 'Autonomy Test Co',
+	const teamRes = await createTestTeam(ctx.db, {
+		name: 'Autonomy Test Co',
 
-			description: 'Testing agent autonomy',
-			template_id: softDevType.id,
-		}),
+		description: 'Testing agent autonomy',
+		template_id: softDevType.id,
 	});
 	const teamData = ((await teamRes.json()) as any).data;
 	teamId = teamData.id;

--- a/packages/server/test/agent-runner.test.ts
+++ b/packages/server/test/agent-runner.test.ts
@@ -25,7 +25,7 @@ import type { DockerClient } from '../src/services/docker';
 import { LogStreamBroker } from '../src/services/log-stream-broker';
 import { PricingService, upsertManualRate } from '../src/services/pricing';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject } from './helpers/app';
+import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
 
 function readPromptFromExec(
 	opts: { Env: string[] },
@@ -64,11 +64,7 @@ beforeAll(async () => {
 	const typesRes = await app.request('/api/team-templates', { headers: authHeader(adminToken) });
 	const typeId = (await typesRes.json()).data.find((t: any) => t.name === 'Startup').id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(adminToken), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Runner Co', template_id: typeId }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Runner Co', template_id: typeId });
 	const teamData = (await teamRes.json()).data;
 	teamId = teamData.id;
 

--- a/packages/server/test/agent-runtime-status.test.ts
+++ b/packages/server/test/agent-runtime-status.test.ts
@@ -10,7 +10,7 @@ import {
 	setAgentIdleIfNoActiveRuns,
 } from '../src/services/agent-runtime-status';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject } from './helpers/app';
+import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
 
 let db: PGlite;
 let app: Hono<Env>;
@@ -28,10 +28,9 @@ beforeAll(async () => {
 	const typesRes = await app.request('/api/team-templates', { headers: authHeader(token) });
 	const teamTemplateId = (await typesRes.json()).data.find((t: any) => t.name === 'Startup').id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Runtime Status Test', template_id: teamTemplateId }),
+	const teamRes = await createTestTeam(db, {
+		name: 'Runtime Status Test',
+		template_id: teamTemplateId,
 	});
 	const teamData = (await teamRes.json()).data;
 	teamId = teamData.id;

--- a/packages/server/test/agent-triggering.test.ts
+++ b/packages/server/test/agent-triggering.test.ts
@@ -4,7 +4,13 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { MasterKeyManager } from '../src/crypto/master-key';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject, mintAgentToken } from './helpers/app';
+import {
+	authHeader,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+	mintAgentToken,
+} from './helpers/app';
 
 let db: PGlite;
 let app: Hono<Env>;
@@ -25,14 +31,10 @@ beforeAll(async () => {
 	const typesRes = await app.request('/api/team-templates', { headers: authHeader(token) });
 	const teamTemplateId = (await typesRes.json()).data.find((t: any) => t.name === 'Startup').id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({
-			name: 'Agent Trigger Co',
+	const teamRes = await createTestTeam(db, {
+		name: 'Agent Trigger Co',
 
-			template_id: teamTemplateId,
-		}),
+		template_id: teamTemplateId,
 	});
 	const teamData = (await teamRes.json()).data;
 	teamId = teamData.id;

--- a/packages/server/test/agent-types.test.ts
+++ b/packages/server/test/agent-types.test.ts
@@ -3,7 +3,7 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject } from './helpers/app';
+import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -262,13 +262,9 @@ describe('team creation with agent types', () => {
 		});
 		const builtinType = (await typesRes.json()).data.find((t: any) => t.name === 'Startup');
 
-		const teamRes = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({
-				name: 'Agent Type Test Co',
-				template_id: builtinType.id,
-			}),
+		const teamRes = await createTestTeam(db, {
+			name: 'Agent Type Test Co',
+			template_id: builtinType.id,
 		});
 		const teamData = (await teamRes.json()).data;
 		const projectSlug = (

--- a/packages/server/test/agents-extended.test.ts
+++ b/packages/server/test/agents-extended.test.ts
@@ -4,7 +4,7 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject } from './helpers/app';
+import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -25,13 +25,9 @@ beforeAll(async () => {
 		(t: Record<string, unknown>) => t.name === 'Startup',
 	).id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({
-			name: 'Extended Agent Test Co',
-			template_id: typeId,
-		}),
+	const teamRes = await createTestTeam(db, {
+		name: 'Extended Agent Test Co',
+		template_id: typeId,
 	});
 	const teamData = (await teamRes.json()).data;
 	teamId = teamData.id;

--- a/packages/server/test/agents-system-prompts-batch.test.ts
+++ b/packages/server/test/agents-system-prompts-batch.test.ts
@@ -3,7 +3,7 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, projectSlugFor } from './helpers/app';
+import { authHeader, createTestApp, createTestTeam, projectSlugFor } from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -22,11 +22,7 @@ beforeAll(async () => {
 	token = ctx.token;
 
 	const makeTeam = async (name: string) => {
-		const r = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({ name }),
-		});
+		const r = await createTestTeam(db, { name });
 		return (await r.json()).data as { id: string; slug: string };
 	};
 

--- a/packages/server/test/agents.test.ts
+++ b/packages/server/test/agents.test.ts
@@ -3,7 +3,7 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, projectSlugFor } from './helpers/app';
+import { authHeader, createTestApp, createTestTeam, projectSlugFor } from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -24,13 +24,9 @@ beforeAll(async () => {
 		(t: Record<string, unknown>) => t.name === 'Startup',
 	).id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({
-			name: 'Agent Test Co',
-			template_id: typeId,
-		}),
+	const teamRes = await createTestTeam(db, {
+		name: 'Agent Test Co',
+		template_id: typeId,
 	});
 	const team = (await teamRes.json()).data;
 	teamId = team.id;

--- a/packages/server/test/api-keys.test.ts
+++ b/packages/server/test/api-keys.test.ts
@@ -3,7 +3,7 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, projectSlugFor } from './helpers/app';
+import { authHeader, createTestApp, createTestTeam, projectSlugFor } from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -16,11 +16,7 @@ beforeAll(async () => {
 	db = ctx.db;
 	token = ctx.token;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'API Key Co' }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'API Key Co' });
 	const team = (await teamRes.json()).data;
 	projectSlug = `${await projectSlugFor(db, team.id)}`;
 });

--- a/packages/server/test/approvals-blocked-tickets.test.ts
+++ b/packages/server/test/approvals-blocked-tickets.test.ts
@@ -3,7 +3,13 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject, projectSlugFor } from './helpers/app';
+import {
+	authHeader,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+	projectSlugFor,
+} from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -68,18 +74,10 @@ beforeAll(async () => {
 		(t: { name: string }) => t.name === 'Startup',
 	).id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Blocked Co', template_id: typeId }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Blocked Co', template_id: typeId });
 	teamId = (await teamRes.json()).data.id;
 
-	const otherRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Other Co', template_id: typeId }),
-	});
+	const otherRes = await createTestTeam(db, { name: 'Other Co', template_id: typeId });
 	const otherTeam = (await otherRes.json()).data;
 	otherTeamId = otherTeam.id;
 	otherProjectSlug = `${await projectSlugFor(db, otherTeam.id)}`;

--- a/packages/server/test/approvals-extended.test.ts
+++ b/packages/server/test/approvals-extended.test.ts
@@ -4,7 +4,13 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject, projectSlugFor } from './helpers/app';
+import {
+	authHeader,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+	projectSlugFor,
+} from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -26,13 +32,9 @@ beforeAll(async () => {
 		(t: Record<string, unknown>) => t.name === 'Startup',
 	).id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({
-			name: 'Approval Extended Co',
-			template_id: typeId,
-		}),
+	const teamRes = await createTestTeam(db, {
+		name: 'Approval Extended Co',
+		template_id: typeId,
 	});
 	const team = (await teamRes.json()).data;
 	teamId = team.id;

--- a/packages/server/test/approvals.test.ts
+++ b/packages/server/test/approvals.test.ts
@@ -3,7 +3,7 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, projectSlugFor } from './helpers/app';
+import { authHeader, createTestApp, createTestTeam, projectSlugFor } from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -24,13 +24,9 @@ beforeAll(async () => {
 		(t: Record<string, unknown>) => t.name === 'Startup',
 	).id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({
-			name: 'Approval Co',
-			template_id: typeId,
-		}),
+	const teamRes = await createTestTeam(db, {
+		name: 'Approval Co',
+		template_id: typeId,
 	});
 	projectSlug = await projectSlugFor(db, (await teamRes.json()).data.id);
 

--- a/packages/server/test/assignment-hierarchy.test.ts
+++ b/packages/server/test/assignment-hierarchy.test.ts
@@ -13,6 +13,7 @@ import {
 	authHeader,
 	createTestApp,
 	createTestProject,
+	createTestTeam,
 	instanceCoachId,
 	mintAgentToken,
 } from './helpers/app';
@@ -64,11 +65,7 @@ beforeAll(async () => {
 		(t: Record<string, unknown>) => t.name === 'Startup',
 	).id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Hierarchy Test Co', template_id: typeId }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Hierarchy Test Co', template_id: typeId });
 	const team = (await teamRes.json()).data;
 	teamId = team.id;
 	const projectSlug = (

--- a/packages/server/test/audit-events.test.ts
+++ b/packages/server/test/audit-events.test.ts
@@ -6,7 +6,7 @@ import { mapEventToAudit } from '../src/events/audit-observer';
 import { waitForBackground } from '../src/lib/background';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject } from './helpers/app';
+import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -21,11 +21,7 @@ beforeAll(async () => {
 	db = ctx.db;
 	token = ctx.token;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Events Co' }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Events Co' });
 	teamId = (await teamRes.json()).data.id;
 
 	const project = await createTestProject(db, teamId, { name: 'Events Project' });

--- a/packages/server/test/audit-log.test.ts
+++ b/packages/server/test/audit-log.test.ts
@@ -6,7 +6,7 @@ import { auditLog } from '../src/lib/audit';
 import type { Env } from '../src/lib/types';
 import { signAdminJwt } from '../src/middleware/auth';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject } from './helpers/app';
+import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -24,11 +24,7 @@ beforeAll(async () => {
 	token = ctx.token;
 	masterKeyManager = ctx.masterKeyManager;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Audit Co' }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Audit Co' });
 	const teamData = (await teamRes.json()).data;
 	teamId = teamData.id;
 	teamSlug = teamData.slug;

--- a/packages/server/test/auth-middleware.test.ts
+++ b/packages/server/test/auth-middleware.test.ts
@@ -18,6 +18,7 @@ import {
 	createAgentRun,
 	createTestApp,
 	createTestProject,
+	createTestTeam,
 	finalizeAgentRun,
 	mintAgentToken,
 } from './helpers/app';
@@ -43,11 +44,7 @@ beforeAll(async () => {
 	const typesRes = await app.request('/api/team-templates', { headers: authHeader(adminToken) });
 	const typeId = (await typesRes.json()).data.find((t: any) => t.name === 'Startup').id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(adminToken), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Auth Test Co', template_id: typeId }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Auth Test Co', template_id: typeId });
 	const teamData = (await teamRes.json()).data;
 	teamId = teamData.id;
 	teamSlug = teamData.slug;
@@ -329,19 +326,19 @@ describe('authMiddleware (via HTTP)', () => {
 	});
 
 	it('allows API requests without auth header (anonymous admin while unlocked)', async () => {
-		const res = await app.request('/api/teams');
+		const res = await app.request('/api/projects');
 		expect(res.status).toBe(200);
 	});
 
 	it('allows API requests with non-Bearer auth header (treated as anonymous)', async () => {
-		const res = await app.request('/api/teams', {
+		const res = await app.request('/api/projects', {
 			headers: { Authorization: 'Basic abc123' },
 		});
 		expect(res.status).toBe(200);
 	});
 
 	it('rejects API requests with invalid token', async () => {
-		const res = await app.request('/api/teams', {
+		const res = await app.request('/api/projects', {
 			headers: { Authorization: 'Bearer invalid.token.here' },
 		});
 		expect(res.status).toBe(401);
@@ -350,7 +347,7 @@ describe('authMiddleware (via HTTP)', () => {
 	});
 
 	it('allows API requests with valid admin token', async () => {
-		const res = await app.request('/api/teams', {
+		const res = await app.request('/api/projects', {
 			headers: authHeader(adminToken),
 		});
 		expect(res.status).toBe(200);
@@ -425,7 +422,7 @@ describe('authMiddleware on a locked server', () => {
 				createStubDocker(),
 			);
 
-			const res = await lockedApp.request('/api/teams');
+			const res = await lockedApp.request('/api/projects');
 			expect(res.status).toBe(401);
 		} finally {
 			await safeClose(lockedDb);
@@ -433,8 +430,8 @@ describe('authMiddleware on a locked server', () => {
 	});
 });
 
-describe('requireTeamAccess (via route)', () => {
-	it('rejects access to nonexistent team by slug', async () => {
+describe('requireProjectAccessMiddleware (via route)', () => {
+	it('rejects access to nonexistent project by slug', async () => {
 		const res = await app.request('/api/projects/nonexistent-slug/agents', {
 			headers: authHeader(adminToken),
 		});
@@ -453,12 +450,11 @@ describe('requireSuperuser (via route)', () => {
 
 		const normalToken = await signAdminJwt(masterKeyManager, userId);
 
-		// team-templates POST requires superuser (if such an endpoint exists)
-		// Instead, verify that the token works but user has limited access
-		const res = await app.request('/api/teams', {
+		// A non-superuser admin token still works for non-superuser-gated reads.
+		const res = await app.request('/api/projects', {
 			headers: authHeader(normalToken),
 		});
-		// Non-superuser should still be able to list teams they are members of
+		// Non-superuser should still be able to list projects they are members of.
 		expect(res.status).toBe(200);
 	});
 });

--- a/packages/server/test/auth-routes.test.ts
+++ b/packages/server/test/auth-routes.test.ts
@@ -251,8 +251,8 @@ describe('login flow on an enrolled, unlocked server', () => {
 	it('the token grants access to protected endpoints', async () => {
 		const res = await loginViaAuthApi(app, mnemonic);
 		const { token } = (await res.json()).data;
-		const teamsRes = await app.request('/api/teams', { headers: authHeader(token) });
-		expect(teamsRes.status).toBe(200);
+		const projectsRes = await app.request('/api/projects', { headers: authHeader(token) });
+		expect(projectsRes.status).toBe(200);
 	});
 
 	it('rejects a replayed challenge', async () => {

--- a/packages/server/test/budget-windows-routes.test.ts
+++ b/packages/server/test/budget-windows-routes.test.ts
@@ -3,7 +3,7 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject } from './helpers/app';
+import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -26,11 +26,7 @@ beforeAll(async () => {
 	const templates = (await typesRes.json()) as { data: Array<{ id: string; name: string }> };
 	const typeId = templates.data.find((t) => t.name === 'Startup')?.id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: jsonHeaders(),
-		body: JSON.stringify({ name: 'Budget Rules Co', template_id: typeId }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Budget Rules Co', template_id: typeId });
 	const teamSlug = (await teamRes.json()).data.slug;
 	teamId = (await db.query<{ id: string }>('SELECT id FROM teams WHERE slug = $1', [teamSlug]))
 		.rows[0].id;

--- a/packages/server/test/budget.test.ts
+++ b/packages/server/test/budget.test.ts
@@ -10,7 +10,7 @@ import {
 	recordRunCost,
 } from '../src/services/budget';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject } from './helpers/app';
+import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -30,11 +30,7 @@ beforeAll(async () => {
 	// biome-ignore lint/suspicious/noExplicitAny: test JSON
 	const typeId = (await typesRes.json()).data.find((t: any) => t.name === 'Startup').id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Budget Co', template_id: typeId }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Budget Co', template_id: typeId });
 	const teamSlug = (await teamRes.json()).data.slug;
 
 	const teamRow = await db.query<{ id: string }>('SELECT id FROM teams WHERE slug = $1', [
@@ -42,7 +38,7 @@ beforeAll(async () => {
 	]);
 	teamId = teamRow.rows[0].id;
 
-	// POST /api/teams creates the team + roster; the project is provisioned here.
+	// createTestTeam stands up the team + roster; the project is provisioned here.
 	const projectRes = await createTestProject(db, teamId, { name: 'Budget Project' });
 	const project = (await projectRes.json()).data;
 	projectId = project.id;

--- a/packages/server/test/bun/egress-proxy.bun.test.ts
+++ b/packages/server/test/bun/egress-proxy.bun.test.ts
@@ -10,7 +10,7 @@ import { encrypt } from '../../src/crypto/encryption';
 import type { MasterKeyManager } from '../../src/crypto/master-key';
 import { type HezoCA, loadOrCreateCA } from '../../src/services/egress/ca';
 import { EgressProxy } from '../../src/services/egress/proxy';
-import { createTestApp, createTestProject } from '../helpers/app';
+import { createTestApp, createTestProject, createTestTeam } from '../helpers/app';
 import { mintCertFromCA } from '../helpers/self-signed-cert';
 
 // Runtime tier: this spec runs under `bun test`, exercising the egress proxy on
@@ -36,11 +36,7 @@ beforeAll(async () => {
 	masterKeyManager = ctx.masterKeyManager;
 	dataDir = mkdtempSync(join(tmpdir(), 'hezo-egress-bun-'));
 
-	const teamRes = await ctx.app.request('/api/teams', {
-		method: 'POST',
-		headers: { Authorization: `Bearer ${ctx.token}`, 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Egress Bun Co' }),
-	});
+	const teamRes = await createTestTeam(ctx.db, { name: 'Egress Bun Co' });
 	const teamData = (await teamRes.json()).data;
 	teamId = teamData.id;
 	const projectSlug = (

--- a/packages/server/test/bun/egress-streaming.bun.test.ts
+++ b/packages/server/test/bun/egress-streaming.bun.test.ts
@@ -10,7 +10,7 @@ import { encrypt } from '../../src/crypto/encryption';
 import type { MasterKeyManager } from '../../src/crypto/master-key';
 import { type HezoCA, loadOrCreateCA } from '../../src/services/egress/ca';
 import { EgressProxy } from '../../src/services/egress/proxy';
-import { createTestApp, createTestProject } from '../helpers/app';
+import { createTestApp, createTestProject, createTestTeam } from '../helpers/app';
 import { mintCertFromCA } from '../helpers/self-signed-cert';
 
 // Runtime tier: runs under `bun test` on the production Bun runtime. It guards
@@ -36,11 +36,7 @@ beforeAll(async () => {
 	masterKeyManager = ctx.masterKeyManager;
 	dataDir = mkdtempSync(join(tmpdir(), 'hezo-egress-stream-'));
 
-	const teamRes = await ctx.app.request('/api/teams', {
-		method: 'POST',
-		headers: { Authorization: `Bearer ${ctx.token}`, 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Egress Stream Co' }),
-	});
+	const teamRes = await createTestTeam(ctx.db, { name: 'Egress Stream Co' });
 	teamId = (await teamRes.json()).data.id;
 	const projectSlug = (
 		await (await createTestProject(db, teamId, { name: 'Stream Project' })).json()

--- a/packages/server/test/ceo-message-render.test.ts
+++ b/packages/server/test/ceo-message-render.test.ts
@@ -6,7 +6,7 @@ import { INSTANCE_BASE_URL_KEY, setSystemMeta } from '../src/lib/system-meta';
 import type { Env } from '../src/lib/types';
 import { renderCeoMessageForChannel } from '../src/services/ceo-message-render';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject } from './helpers/app';
+import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -27,11 +27,7 @@ beforeAll(async () => {
 	const typeId = (await typesRes.json()).data.find(
 		(t: Record<string, unknown>) => t.name === 'Startup',
 	).id;
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Render Co', template_id: typeId }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Render Co', template_id: typeId });
 	const teamId = (await teamRes.json()).data.id;
 	const projectRes = await createTestProject(db, teamId, { name: 'Render Project' });
 	const project = (await projectRes.json()).data;

--- a/packages/server/test/ceo.test.ts
+++ b/packages/server/test/ceo.test.ts
@@ -9,7 +9,7 @@ import {
 	linkTeamCaptainToInstanceCeo,
 } from '../src/services/team-template-apply';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp } from './helpers/app';
+import { authHeader, createTestApp, createTestTeam } from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -77,11 +77,7 @@ describe('instance CEO agent type', () => {
 
 describe('instance CEO provisioning + Captain reporting line', () => {
 	async function createTeamViaApi(name: string): Promise<string> {
-		const res = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({ name }),
-		});
+		const res = await createTestTeam(db, { name });
 		expect(res.status).toBe(201);
 		return (await res.json()).data.id as string;
 	}

--- a/packages/server/test/chat-memory.test.ts
+++ b/packages/server/test/chat-memory.test.ts
@@ -20,7 +20,7 @@ import { formatChatMemoryBlock } from '../src/services/ceo-session-manager';
 import { ensureChatMemoryDoc } from '../src/services/teams';
 import { resolveSystemPrompt } from '../src/services/template-resolver';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp } from './helpers/app';
+import { authHeader, createTestApp, createTestTeam } from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -146,11 +146,7 @@ describe('chat-memory delete guard', () => {
 	});
 
 	it('does not guard a same-named doc in a non-HQ project', async () => {
-		const teamRes = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({ name: 'Other Co' }),
-		});
+		const teamRes = await createTestTeam(db, { name: 'Other Co' });
 		const teamSlug = (await teamRes.json()).data.slug as string;
 		const projRes = await app.request('/api/projects', {
 			method: 'POST',

--- a/packages/server/test/coach.test.ts
+++ b/packages/server/test/coach.test.ts
@@ -5,7 +5,13 @@ import type { MasterKeyManager } from '../src/crypto/master-key';
 import type { Env } from '../src/lib/types';
 import { buildCoachReviewPrompt, type TaskInfo } from '../src/services/agent-runner';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject, mintAgentToken } from './helpers/app';
+import {
+	authHeader,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+	mintAgentToken,
+} from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -34,13 +40,9 @@ beforeAll(async () => {
 	const typesRes = await app.request('/api/team-templates', { headers: authHeader(adminToken) });
 	const teamTemplateId = (await typesRes.json()).data.find((t: any) => t.name === 'Startup').id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(adminToken), 'Content-Type': 'application/json' },
-		body: JSON.stringify({
-			name: 'Coach Test Co',
-			template_id: teamTemplateId,
-		}),
+	const teamRes = await createTestTeam(db, {
+		name: 'Coach Test Co',
+		template_id: teamTemplateId,
 	});
 	const teamData = (await teamRes.json()).data;
 	teamId = teamData.id;

--- a/packages/server/test/comment-attachments.test.ts
+++ b/packages/server/test/comment-attachments.test.ts
@@ -8,7 +8,7 @@ import type { MasterKeyManager } from '../src/crypto/master-key';
 import { signAssetUrl } from '../src/lib/asset-urls';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject } from './helpers/app';
+import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -60,11 +60,7 @@ beforeAll(async () => {
 	masterKeyManager = ctx.masterKeyManager;
 	dataDir = ctx.dataDir;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Attach Co' }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Attach Co' });
 	const teamData = (await teamRes.json()).data;
 	teamId = teamData.id;
 	teamSlug = teamData.slug;
@@ -100,11 +96,7 @@ beforeAll(async () => {
 
 	// A team owns exactly one project, so the cross-project isolation case needs a
 	// second team to host the "other" project.
-	const otherTeamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Other Attach Co' }),
-	});
+	const otherTeamRes = await createTestTeam(db, { name: 'Other Attach Co' });
 	const otherTeamId = (await otherTeamRes.json()).data.id;
 
 	const otherProjectRes = await createTestProject(db, otherTeamId, {

--- a/packages/server/test/comment-wakeups.test.ts
+++ b/packages/server/test/comment-wakeups.test.ts
@@ -9,6 +9,7 @@ import {
 	authHeader,
 	createTestApp,
 	createTestProject,
+	createTestTeam,
 	instanceCeoId,
 	mintAgentToken,
 } from './helpers/app';
@@ -135,13 +136,9 @@ beforeAll(async () => {
 		(t: Record<string, unknown>) => t.name === 'Startup',
 	).id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({
-			name: 'Comment Wakeups Co',
-			template_id: typeId,
-		}),
+	const teamRes = await createTestTeam(db, {
+		name: 'Comment Wakeups Co',
+		template_id: typeId,
 	});
 	const teamData = (await teamRes.json()).data;
 	teamId = teamData.id;

--- a/packages/server/test/comments.test.ts
+++ b/packages/server/test/comments.test.ts
@@ -4,7 +4,13 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { MasterKeyManager } from '../src/crypto/master-key';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject, mintAgentToken } from './helpers/app';
+import {
+	authHeader,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+	mintAgentToken,
+} from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -26,11 +32,7 @@ beforeAll(async () => {
 	token = ctx.token;
 	masterKeyManager = ctx.masterKeyManager;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Comment Co' }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Comment Co' });
 	const teamData = (await teamRes.json()).data;
 	teamId = teamData.id;
 	teamSlug = teamData.slug;

--- a/packages/server/test/connectors.test.ts
+++ b/packages/server/test/connectors.test.ts
@@ -18,7 +18,13 @@ import {
 	probeForProtectedResourceMetadata,
 } from '../src/services/oauth/prm-discovery';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject, mintAgentToken } from './helpers/app';
+import {
+	authHeader,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+	mintAgentToken,
+} from './helpers/app';
 import { type FakeMcpServer, startFakeMcpServer } from './helpers/fake-mcp-server';
 
 let app: Hono<Env>;
@@ -45,11 +51,7 @@ beforeAll(async () => {
 		(t: Record<string, unknown>) => t.name === 'Startup',
 	).id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Connectors Test Co', template_id: typeId }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Connectors Test Co', template_id: typeId });
 	const teamData = (await teamRes.json()).data;
 	teamId = teamData.id;
 	teamSlug = teamData.slug;

--- a/packages/server/test/container-rebuild-broadcast.test.ts
+++ b/packages/server/test/container-rebuild-broadcast.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import type { Env } from '../src/lib/types';
 import { WebSocketManager, type WsEvent } from '../src/services/ws';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject } from './helpers/app';
+import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
 
 interface CapturedBroadcast {
 	room: string;
@@ -28,10 +28,9 @@ describe('container lifecycle broadcasts carry team_id', () => {
 			(t: { name: string }) => t.name === 'Blank',
 		).id;
 
-		const teamRes = await ctx.app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(ctx.token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({ name: 'Container Broadcast Co', template_id: typeId }),
+		const teamRes = await createTestTeam(ctx.db, {
+			name: 'Container Broadcast Co',
+			template_id: typeId,
 		});
 		teamId = (await teamRes.json()).data.id;
 

--- a/packages/server/test/container-sync.test.ts
+++ b/packages/server/test/container-sync.test.ts
@@ -18,7 +18,13 @@ import type { DockerClient } from '../src/services/docker';
 import { LogStreamBroker } from '../src/services/log-stream-broker';
 import type { WebSocketManager } from '../src/services/ws';
 import { safeClose } from './helpers';
-import { authHeader, createStubDocker, createTestApp, createTestProject } from './helpers/app';
+import {
+	authHeader,
+	createStubDocker,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+} from './helpers/app';
 
 function deps(docker: DockerClient, wsManager?: WebSocketManager): ContainerDeps {
 	return { db, docker, dataDir: '/tmp/hezo-test-unused', wsManager };
@@ -38,14 +44,10 @@ beforeAll(async () => {
 	const typesRes = await app.request('/api/team-templates', { headers: authHeader(token) });
 	const teamTemplateId = (await typesRes.json()).data.find((t: any) => t.name === 'Startup').id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({
-			name: 'Container Sync Co',
+	const teamRes = await createTestTeam(db, {
+		name: 'Container Sync Co',
 
-			template_id: teamTemplateId,
-		}),
+		template_id: teamTemplateId,
 	});
 	teamId = (await teamRes.json()).data.id;
 });

--- a/packages/server/test/containers-recovery.test.ts
+++ b/packages/server/test/containers-recovery.test.ts
@@ -17,6 +17,7 @@ import {
 	createStubDocker,
 	createTestApp,
 	createTestProject,
+	createTestTeam,
 	projectSlugFor,
 } from './helpers/app';
 
@@ -49,11 +50,7 @@ beforeAll(async () => {
 	const typesRes = await app.request('/api/team-templates', { headers: authHeader(token) });
 	const typeId = (await typesRes.json()).data.find((t: any) => t.name === 'Startup').id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Recovery Test Co', template_id: typeId }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Recovery Test Co', template_id: typeId });
 	const team = (await teamRes.json()).data;
 	teamId = team.id;
 	teamSlug = team.slug;

--- a/packages/server/test/costs-extended.test.ts
+++ b/packages/server/test/costs-extended.test.ts
@@ -3,7 +3,13 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject, projectSlugFor } from './helpers/app';
+import {
+	authHeader,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+	projectSlugFor,
+} from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -29,13 +35,9 @@ beforeAll(async () => {
 	});
 	const typeId = (await typesRes.json()).data.find((t: any) => t.name === 'Startup').id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({
-			name: 'Extended Cost Co',
-			template_id: typeId,
-		}),
+	const teamRes = await createTestTeam(db, {
+		name: 'Extended Cost Co',
+		template_id: typeId,
 	});
 	const team = (await teamRes.json()).data;
 	teamId = team.id;
@@ -154,11 +156,7 @@ describe('costs – project scoping', () => {
 		// team. None of our cost entries belong to it, so it should read empty.
 		const typesRes = await app.request('/api/team-templates', { headers: authHeader(token) });
 		const typeId = (await typesRes.json()).data.find((t: any) => t.name === 'Startup').id;
-		const team2Res = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({ name: 'Other Cost Co', template_id: typeId }),
-		});
+		const team2Res = await createTestTeam(db, { name: 'Other Cost Co', template_id: typeId });
 		const team2Id = (await team2Res.json()).data.id;
 		const other = await createTestProject(db, team2Id, { name: 'Project Beta' });
 		const otherSlug = (await other.json()).data.slug;

--- a/packages/server/test/costs.test.ts
+++ b/packages/server/test/costs.test.ts
@@ -3,7 +3,13 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, projectSlugFor, projectSlugForTeamSlug } from './helpers/app';
+import {
+	authHeader,
+	createTestApp,
+	createTestTeam,
+	projectSlugFor,
+	projectSlugForTeamSlug,
+} from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -22,13 +28,9 @@ beforeAll(async () => {
 	});
 	const typeId = (await typesRes.json()).data.find((t: any) => t.name === 'Startup').id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({
-			name: 'Cost Co',
-			template_id: typeId,
-		}),
+	const teamRes = await createTestTeam(db, {
+		name: 'Cost Co',
+		template_id: typeId,
 	});
 	teamSlug = (await teamRes.json()).data.slug;
 

--- a/packages/server/test/credential-requests.test.ts
+++ b/packages/server/test/credential-requests.test.ts
@@ -9,6 +9,7 @@ import {
 	authHeader,
 	createTestApp,
 	createTestProject,
+	createTestTeam,
 	mintAgentToken,
 	projectSlugFor,
 } from './helpers/app';
@@ -32,11 +33,7 @@ beforeAll(async () => {
 	token = ctx.token;
 	masterKeyManager = ctx.masterKeyManager;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Cred Co' }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Cred Co' });
 	const team = (await teamRes.json()).data;
 	teamId = team.id;
 	teamSlug = team.slug;
@@ -159,11 +156,7 @@ describe('request_credential MCP tool', () => {
 	});
 
 	it('rejects access from a different team', async () => {
-		const otherTeamRes = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({ name: 'Other Co' }),
-		});
+		const otherTeamRes = await createTestTeam(db, { name: 'Other Co' });
 		const otherTeamId = (await otherTeamRes.json()).data.id;
 		const otherProject = (
 			await (await createTestProject(db, otherTeamId, { name: 'Other Main' })).json()

--- a/packages/server/test/cross-team-isolation.test.ts
+++ b/packages/server/test/cross-team-isolation.test.ts
@@ -9,6 +9,7 @@ import {
 	authHeader,
 	createTestApp,
 	createTestProject,
+	createTestTeam,
 	mintAgentToken,
 	projectSlugForTeamSlug,
 } from './helpers/app';
@@ -49,21 +50,13 @@ beforeAll(async () => {
 	const typeId = (await typesRes.json()).data.find((t: any) => t.name === 'Startup').id;
 
 	// Create Team A
-	const teamARes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(superuserToken), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Team Alpha', template_id: typeId }),
-	});
+	const teamARes = await createTestTeam(db, { name: 'Team Alpha', template_id: typeId });
 	const teamA = (await teamARes.json()).data;
 	teamAId = teamA.id;
 	teamASlug = teamA.slug;
 
 	// Create Team B
-	const teamBRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(superuserToken), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Team Beta', template_id: typeId }),
-	});
+	const teamBRes = await createTestTeam(db, { name: 'Team Beta', template_id: typeId });
 	const teamB = (await teamBRes.json()).data;
 	teamBId = teamB.id;
 	teamBSlug = teamB.slug;
@@ -251,19 +244,19 @@ describe('Admin user cross-team isolation', () => {
 		expect(res.status).toBe(200);
 	});
 
-	it('GET /teams lists only the teams the non-superuser belongs to', async () => {
-		const res = await app.request('/api/teams', { headers: authHeader(userAToken) });
+	it('GET /projects lists only the projects whose team the non-superuser belongs to', async () => {
+		const res = await app.request('/api/projects', { headers: authHeader(userAToken) });
 		expect(res.status).toBe(200);
-		const ids = ((await res.json()).data as { id: string }[]).map((t) => t.id);
-		expect(ids).toContain(teamAId);
-		expect(ids).not.toContain(teamBId);
+		const teamIds = ((await res.json()).data as { team_id: string }[]).map((p) => p.team_id);
+		expect(teamIds).toContain(teamAId);
+		expect(teamIds).not.toContain(teamBId);
 	});
 
-	it('GET /teams lists every team for the superuser', async () => {
-		const res = await app.request('/api/teams', { headers: authHeader(superuserToken) });
-		const ids = ((await res.json()).data as { id: string }[]).map((t) => t.id);
-		expect(ids).toContain(teamAId);
-		expect(ids).toContain(teamBId);
+	it('GET /projects lists every team’s project for the superuser', async () => {
+		const res = await app.request('/api/projects', { headers: authHeader(superuserToken) });
+		const teamIds = ((await res.json()).data as { team_id: string }[]).map((p) => p.team_id);
+		expect(teamIds).toContain(teamAId);
+		expect(teamIds).toContain(teamBId);
 	});
 });
 

--- a/packages/server/test/description-tasks.test.ts
+++ b/packages/server/test/description-tasks.test.ts
@@ -4,7 +4,13 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import type { Env } from '../src/lib/types';
 import { enqueueTeamCoherenceReviewTask } from '../src/services/description-tasks';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject, instanceCeoId } from './helpers/app';
+import {
+	authHeader,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+	instanceCeoId,
+} from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -23,11 +29,7 @@ beforeAll(async () => {
 		(t: Record<string, unknown>) => t.name === 'Startup',
 	).id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Description Tasks Co', template_id: typeId }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Description Tasks Co', template_id: typeId });
 	teamId = (await teamRes.json()).data.id;
 	// Coordination tasks live in the team's own project, owned by the instance CEO.
 	await createTestProject(db, teamId, { name: 'Description Tasks Project' });
@@ -127,11 +129,7 @@ describe('enqueueTeamCoherenceReviewTask', () => {
 	});
 
 	it('returns null and does not create a task when the team has no project yet', async () => {
-		const blankRes = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({ name: 'No Project Co' }),
-		});
+		const blankRes = await createTestTeam(db, { name: 'No Project Co' });
 		const blankTeamId = (await blankRes.json()).data.id;
 
 		const result = await enqueueTeamCoherenceReviewTask(db, blankTeamId, 'agent_hired');

--- a/packages/server/test/dispatch-wakeup-now.test.ts
+++ b/packages/server/test/dispatch-wakeup-now.test.ts
@@ -9,7 +9,13 @@ import type { DockerClient } from '../src/services/docker';
 import { JobManager } from '../src/services/job-manager';
 import { LogStreamBroker } from '../src/services/log-stream-broker';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject, projectSlugFor } from './helpers/app';
+import {
+	authHeader,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+	projectSlugFor,
+} from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -73,11 +79,7 @@ beforeAll(async () => {
 	const typesRes = await app.request('/api/team-templates', { headers: authHeader(token) });
 	const typeId = (await typesRes.json()).data.find((t: any) => t.name === 'Startup').id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), ...json },
-		body: JSON.stringify({ name: 'Dispatch Now Co', template_id: typeId }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Dispatch Now Co', template_id: typeId });
 	const team = (await teamRes.json()).data;
 	teamId = team.id;
 	teamSlug = team.slug;

--- a/packages/server/test/egress-proxy-docker.test.ts
+++ b/packages/server/test/egress-proxy-docker.test.ts
@@ -21,7 +21,7 @@ import type { MasterKeyManager } from '../src/crypto/master-key';
 import { loadOrCreateCA } from '../src/services/egress/ca';
 import { EgressProxy } from '../src/services/egress/proxy';
 import { safeClose } from './helpers';
-import { createTestApp, projectSlugFor } from './helpers/app';
+import { createTestApp, createTestTeam, projectSlugFor } from './helpers/app';
 
 const dockerAvailable = await checkDocker();
 const skipReason =
@@ -61,11 +61,7 @@ beforeAll(async () => {
 	masterKeyManager = ctx.masterKeyManager;
 	dataDir = mkdtempSync(join(tmpdir(), 'hezo-egress-docker-'));
 
-	const teamRes = await ctx.app.request('/api/teams', {
-		method: 'POST',
-		headers: { Authorization: `Bearer ${ctx.token}`, 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Egress Docker Co' }),
-	});
+	const teamRes = await createTestTeam(ctx.db, { name: 'Egress Docker Co' });
 	const team = (await teamRes.json()).data;
 	teamId = team.id;
 	const agentRes = await ctx.app.request(

--- a/packages/server/test/egress-proxy.test.ts
+++ b/packages/server/test/egress-proxy.test.ts
@@ -12,7 +12,7 @@ import { type HezoCA, loadOrCreateCA } from '../src/services/egress/ca';
 import { PortAllocator } from '../src/services/egress/port-allocator';
 import { EgressProxy } from '../src/services/egress/proxy';
 import { safeClose } from './helpers';
-import { createTestApp, createTestProject } from './helpers/app';
+import { createTestApp, createTestProject, createTestTeam } from './helpers/app';
 
 let db: PGlite;
 let masterKeyManager: MasterKeyManager;
@@ -40,11 +40,7 @@ beforeAll(async () => {
 	masterKeyManager = ctx.masterKeyManager;
 	dataDir = mkdtempSync(join(tmpdir(), 'hezo-egress-proxy-'));
 
-	const teamRes = await ctx.app.request('/api/teams', {
-		method: 'POST',
-		headers: { Authorization: `Bearer ${ctx.token}`, 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Egress Co' }),
-	});
+	const teamRes = await createTestTeam(ctx.db, { name: 'Egress Co' });
 	const team = (await teamRes.json()).data;
 	teamId = team.id;
 	const projectSlug = (

--- a/packages/server/test/execution-locks.test.ts
+++ b/packages/server/test/execution-locks.test.ts
@@ -3,7 +3,7 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject } from './helpers/app';
+import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -24,14 +24,10 @@ beforeAll(async () => {
 	const typesRes = await app.request('/api/team-templates', { headers: authHeader(token) });
 	const teamTemplateId = (await typesRes.json()).data.find((t: any) => t.name === 'Startup').id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({
-			name: 'Lock Test Co',
+	const teamRes = await createTestTeam(db, {
+		name: 'Lock Test Co',
 
-			template_id: teamTemplateId,
-		}),
+		template_id: teamTemplateId,
 	});
 	const team = (await teamRes.json()).data;
 	teamId = team.id;

--- a/packages/server/test/heartbeat-runs.test.ts
+++ b/packages/server/test/heartbeat-runs.test.ts
@@ -9,7 +9,13 @@ import {
 	type HeartbeatRunBroadcast,
 } from '../src/services/agent-runner';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject, mintAgentToken } from './helpers/app';
+import {
+	authHeader,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+	mintAgentToken,
+} from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -38,11 +44,7 @@ beforeAll(async () => {
 	token = ctx.token;
 	masterKeyManager = ctx.masterKeyManager;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Run Test Co' }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Run Test Co' });
 	const team = (await teamRes.json()).data;
 	teamId = team.id;
 

--- a/packages/server/test/helpers/app.ts
+++ b/packages/server/test/helpers/app.ts
@@ -27,7 +27,7 @@ import type { DockerClient } from '../../src/services/docker';
 import { JobManager } from '../../src/services/job-manager';
 import { LogStreamBroker } from '../../src/services/log-stream-broker';
 import { createProjectWithPlanningTask } from '../../src/services/project-create';
-import { seedDefaultTeam } from '../../src/services/teams';
+import { type CreatedTeamRow, createTeam, seedDefaultTeam } from '../../src/services/teams';
 import { WebSocketManager } from '../../src/services/ws';
 import { buildApp } from '../../src/startup';
 import { createTestDbWithMigrations } from './db';
@@ -344,9 +344,9 @@ export interface CreatedTestProject {
 
 /**
  * Test-only helper: creates a user-facing project plus its planning task by
- * calling the project service directly. Bypasses the captain intake flow that
- * `POST /api/teams/:teamId/projects` now triggers (which opens an intake ticket
- * and a pending approval). Use in tests that need a ready-to-use project.
+ * calling the project service directly. Bypasses the CEO-assisted intake flow
+ * that project creation can trigger (an intake ticket and a pending approval).
+ * Use in tests that need a ready-to-use project.
  *
  * The return value is shaped like a `fetch` Response so existing tests that
  * call `.json()` followed by `.data.id` extraction keep working unchanged
@@ -447,6 +447,50 @@ export async function createTestProject(
 		status: 201,
 		json: async () => ({ data }),
 	};
+}
+
+/**
+ * Test-only: stand up a team (roster + optional template) by calling the
+ * `createTeam` service directly, the way `POST /api/teams` used to before that
+ * route was removed. Returns a `fetch`-Response-shaped object so existing
+ * `.json()` → `.data.slug` / `.data.id` extraction in call sites keeps working
+ * after swapping the `app.request('/api/teams', { method: 'POST' })` block.
+ *
+ * `createTeam` provisions no container (only the roster), so the stub docker is
+ * never exercised; the throwaway `dataDir` only matters for skill provisioning,
+ * which no-ops when no skills are installed (the default test state).
+ *
+ * Mirrors `POST /api/teams` called with the admin token: the creating admin
+ * becomes a member of the new team. Defaults `creatorUserId` to the seeded
+ * superuser so admin-authored actions (mentions, reactions, `created_by`,
+ * actor names, ui-state) resolve to a real member row, as they did when the
+ * route created the team. Pass `creatorUserId` explicitly to override.
+ */
+export async function createTestTeam(
+	db: PGlite,
+	input: { name: string; description?: string; template_id?: string; creatorUserId?: string },
+): Promise<{ status: 201; json: () => Promise<{ data: CreatedTeamRow }> }> {
+	let creatorUserId = input.creatorUserId;
+	if (creatorUserId === undefined) {
+		const admin = await db.query<{ id: string }>(
+			'SELECT id FROM users WHERE is_superuser = true ORDER BY created_at LIMIT 1',
+		);
+		creatorUserId = admin.rows[0]?.id;
+	}
+	const team = await createTeam(
+		{
+			db,
+			docker: createStubDocker(),
+			dataDir: mkdtempSync(join(tmpdir(), 'hezo-test-team-')),
+		},
+		{
+			name: input.name.trim(),
+			description: input.description,
+			templateId: input.template_id,
+			creatorUserId,
+		},
+	);
+	return { status: 201, json: async () => ({ data: team }) };
 }
 
 export async function finalizeAgentRun(

--- a/packages/server/test/hire-proposal.test.ts
+++ b/packages/server/test/hire-proposal.test.ts
@@ -5,7 +5,13 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { MasterKeyManager } from '../src/crypto/master-key';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject, mintAgentToken } from './helpers/app';
+import {
+	authHeader,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+	mintAgentToken,
+} from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -50,11 +56,7 @@ beforeAll(async () => {
 		(t: Record<string, unknown>) => t.name === 'Startup',
 	).id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Hire Proposal Co', template_id: typeId }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Hire Proposal Co', template_id: typeId });
 	const team = (await teamRes.json()).data;
 	teamId = team.id;
 	const projData = (await (await createTestProject(db, teamId, { name: 'Setup Project' })).json())

--- a/packages/server/test/instance-connectors.test.ts
+++ b/packages/server/test/instance-connectors.test.ts
@@ -6,7 +6,7 @@ import type { Env } from '../src/lib/types';
 import { signAdminJwt } from '../src/middleware/auth';
 import { loadMcpConnectionsForRun } from '../src/services/mcp-connections';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp } from './helpers/app';
+import { authHeader, createTestApp, createTestTeam } from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -24,11 +24,7 @@ async function makeProject(teamId: string, slug: string): Promise<string> {
 }
 
 async function makeTeam(name: string): Promise<string> {
-	const res = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name }),
-	});
+	const res = await createTestTeam(db, { name });
 	return (await res.json()).data.id;
 }
 

--- a/packages/server/test/instance-mentions.test.ts
+++ b/packages/server/test/instance-mentions.test.ts
@@ -6,7 +6,13 @@ import type { MasterKeyManager } from '../src/crypto/master-key';
 import type { Env } from '../src/lib/types';
 import { signAdminJwt } from '../src/middleware/auth';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, mintAgentToken, projectSlugFor } from './helpers/app';
+import {
+	authHeader,
+	createTestApp,
+	createTestTeam,
+	mintAgentToken,
+	projectSlugFor,
+} from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -95,11 +101,7 @@ beforeAll(async () => {
 	).id;
 
 	for (const name of ['Mention Co Alpha', 'Mention Co Beta']) {
-		const teamRes = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({ name, template_id: typeId }),
-		});
+		const teamRes = await createTestTeam(db, { name, template_id: typeId });
 		const teamData = (await teamRes.json()).data;
 		if (name.endsWith('Alpha')) teamAId = teamData.id;
 		else teamBId = teamData.id;

--- a/packages/server/test/job-manager-workflows.test.ts
+++ b/packages/server/test/job-manager-workflows.test.ts
@@ -10,7 +10,13 @@ import type { DockerClient } from '../src/services/docker';
 import { JobManager, type JobManagerDeps } from '../src/services/job-manager';
 import { LogStreamBroker } from '../src/services/log-stream-broker';
 import { safeClose } from './helpers';
-import { authHeader, createStubDocker, createTestApp, createTestProject } from './helpers/app';
+import {
+	authHeader,
+	createStubDocker,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+} from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -68,11 +74,7 @@ beforeAll(async () => {
 	const typesRes = await app.request('/api/team-templates', { headers: authHeader(token) });
 	const typeId = (await typesRes.json()).data.find((t: any) => t.name === 'Startup').id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Workflow Test Co', template_id: typeId }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Workflow Test Co', template_id: typeId });
 	const team = (await teamRes.json()).data;
 	teamId = team.id;
 
@@ -2342,10 +2344,9 @@ describe('JobManager workflow methods', () => {
 			// need a real, separate project id whose capacity we can check independently.
 			const typesRes = await app.request('/api/team-templates', { headers: authHeader(token) });
 			const typeId = (await typesRes.json()).data.find((t: any) => t.name === 'Startup').id;
-			const teamBRes = await app.request('/api/teams', {
-				method: 'POST',
-				headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-				body: JSON.stringify({ name: `Parallel Team ${Date.now()}`, template_id: typeId }),
+			const teamBRes = await createTestTeam(db, {
+				name: `Parallel Team ${Date.now()}`,
+				template_id: typeId,
 			});
 			const teamBId = (await teamBRes.json()).data.id;
 			const projectBRes = await createTestProject(db, teamBId, {

--- a/packages/server/test/list-tasks-assignee-filter.test.ts
+++ b/packages/server/test/list-tasks-assignee-filter.test.ts
@@ -3,7 +3,7 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject } from './helpers/app';
+import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -28,13 +28,9 @@ beforeAll(async () => {
 		(t: Record<string, unknown>) => t.name === 'Startup',
 	).id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({
-			name: 'List Tasks Filter Co',
-			template_id: typeId,
-		}),
+	const teamRes = await createTestTeam(db, {
+		name: 'List Tasks Filter Co',
+		template_id: typeId,
 	});
 	const teamData = (await teamRes.json()).data;
 	teamId = teamData.id;

--- a/packages/server/test/mcp-connections-docker.test.ts
+++ b/packages/server/test/mcp-connections-docker.test.ts
@@ -30,7 +30,7 @@ import { loadOrCreateCA } from '../src/services/egress/ca';
 import { EgressProxy } from '../src/services/egress/proxy';
 import { loadMcpConnectionDescriptors } from '../src/services/mcp-connections';
 import { safeClose } from './helpers';
-import { createTestApp, createTestProject } from './helpers/app';
+import { createTestApp, createTestProject, createTestTeam } from './helpers/app';
 import { mintCertFromCA } from './helpers/self-signed-cert';
 import { startTestMcpHttpServer, type TestMcpServer } from './helpers/test-mcp-http-server';
 
@@ -66,11 +66,7 @@ beforeAll(async () => {
 	masterKeyManager = ctx.masterKeyManager;
 	dataDir = mkdtempSync(join(tmpdir(), 'hezo-mcp-docker-'));
 
-	const co = await ctx.app.request('/api/teams', {
-		method: 'POST',
-		headers: { Authorization: `Bearer ${ctx.token}`, 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'MCP Docker Co' }),
-	});
+	const co = await createTestTeam(ctx.db, { name: 'MCP Docker Co' });
 	const teamData = (await co.json()).data;
 	teamId = teamData.id;
 

--- a/packages/server/test/mcp-connections.test.ts
+++ b/packages/server/test/mcp-connections.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { MasterKeyManager } from '../src/crypto/master-key';
 import { loadMcpConnectionDescriptors } from '../src/services/mcp-connections';
 import { safeClose } from './helpers';
-import { createTestApp, projectSlugFor } from './helpers/app';
+import { createTestApp, createTestTeam, projectSlugFor } from './helpers/app';
 
 let db: PGlite;
 let teamId: string;
@@ -16,11 +16,7 @@ beforeAll(async () => {
 	token = ctx.token;
 	masterKeyManager = ctx.masterKeyManager;
 
-	const teamRes = await ctx.app.request('/api/teams', {
-		method: 'POST',
-		headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'MCP Co' }),
-	});
+	const teamRes = await createTestTeam(ctx.db, { name: 'MCP Co' });
 	teamId = (await teamRes.json()).data.id;
 
 	await db.query(
@@ -37,11 +33,7 @@ afterAll(async () => {
 describe('mcp_connections REST routes', () => {
 	it('rejects a saas connection without config.url', async () => {
 		const ctx = await createTestApp();
-		const co = await ctx.app.request('/api/teams', {
-			method: 'POST',
-			headers: { Authorization: `Bearer ${ctx.token}`, 'Content-Type': 'application/json' },
-			body: JSON.stringify({ name: 'X' }),
-		});
+		const co = await createTestTeam(ctx.db, { name: 'X' });
 		const team = (await co.json()).data;
 		const res = await ctx.app.request(
 			`/api/projects/${await projectSlugFor(ctx.db, team.id)}/mcp-connections`,
@@ -57,11 +49,7 @@ describe('mcp_connections REST routes', () => {
 
 	it('inserts a saas connection (status=installed) and lists it', async () => {
 		const ctx = await createTestApp();
-		const co = await ctx.app.request('/api/teams', {
-			method: 'POST',
-			headers: { Authorization: `Bearer ${ctx.token}`, 'Content-Type': 'application/json' },
-			body: JSON.stringify({ name: 'Y' }),
-		});
+		const co = await createTestTeam(ctx.db, { name: 'Y' });
 		const team = (await co.json()).data;
 		const projectSlug = await projectSlugFor(ctx.db, team.id);
 		const insert = await ctx.app.request(`/api/projects/${projectSlug}/mcp-connections`, {
@@ -93,11 +81,7 @@ describe('mcp_connections REST routes', () => {
 
 	it('inserts a local connection with status=pending until the installer marks it', async () => {
 		const ctx = await createTestApp();
-		const co = await ctx.app.request('/api/teams', {
-			method: 'POST',
-			headers: { Authorization: `Bearer ${ctx.token}`, 'Content-Type': 'application/json' },
-			body: JSON.stringify({ name: 'Z' }),
-		});
+		const co = await createTestTeam(ctx.db, { name: 'Z' });
 		const team = (await co.json()).data;
 		const res = await ctx.app.request(
 			`/api/projects/${await projectSlugFor(ctx.db, team.id)}/mcp-connections`,
@@ -124,11 +108,7 @@ describe('mcp_connections REST routes', () => {
 describe('POST /teams/:teamId/connectors/ensure', () => {
 	it('creates a connector from the registry on first call, returns the same row on second', async () => {
 		const ctx = await createTestApp();
-		const co = await ctx.app.request('/api/teams', {
-			method: 'POST',
-			headers: { Authorization: `Bearer ${ctx.token}`, 'Content-Type': 'application/json' },
-			body: JSON.stringify({ name: 'Ensure Co' }),
-		});
+		const co = await createTestTeam(ctx.db, { name: 'Ensure Co' });
 		const team = (await co.json()).data;
 
 		const projectSlug = await projectSlugFor(ctx.db, team.id);
@@ -160,11 +140,7 @@ describe('POST /teams/:teamId/connectors/ensure', () => {
 
 	it('rejects unknown provider_id', async () => {
 		const ctx = await createTestApp();
-		const co = await ctx.app.request('/api/teams', {
-			method: 'POST',
-			headers: { Authorization: `Bearer ${ctx.token}`, 'Content-Type': 'application/json' },
-			body: JSON.stringify({ name: 'Unknown Co' }),
-		});
+		const co = await createTestTeam(ctx.db, { name: 'Unknown Co' });
 		const team = (await co.json()).data;
 
 		const res = await ctx.app.request(

--- a/packages/server/test/mcp-installer.test.ts
+++ b/packages/server/test/mcp-installer.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { DockerClient } from '../src/services/docker';
 import { installLocalMcpById, installPendingLocalMcps } from '../src/services/mcp-installer';
 import { safeClose } from './helpers';
-import { createTestApp } from './helpers/app';
+import { createTestApp, createTestTeam } from './helpers/app';
 
 let db: PGlite;
 let teamId: string;
@@ -43,11 +43,7 @@ beforeAll(async () => {
 	const ctx = await createTestApp();
 	db = ctx.db;
 
-	const co = await ctx.app.request('/api/teams', {
-		method: 'POST',
-		headers: { Authorization: `Bearer ${ctx.token}`, 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Inst' }),
-	});
+	const co = await createTestTeam(ctx.db, { name: 'Inst' });
 	teamId = (await co.json()).data.id;
 	const proj = await db.query<{ id: string }>(
 		`INSERT INTO projects (team_id, name, slug, task_prefix, docker_base_image)

--- a/packages/server/test/mcp-project-scope.test.ts
+++ b/packages/server/test/mcp-project-scope.test.ts
@@ -6,7 +6,13 @@ import type { MasterKeyManager } from '../src/crypto/master-key';
 import type { Env } from '../src/lib/types';
 import { signCeoSessionJwt } from '../src/middleware/auth';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject, mintAgentToken } from './helpers/app';
+import {
+	authHeader,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+	mintAgentToken,
+} from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -41,11 +47,7 @@ async function callMcp(token: string, toolName: string, args: Record<string, unk
 }
 
 async function makeTeam(name: string): Promise<{ teamId: string; captainId: string }> {
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(adminToken), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name }),
-	});
+	const teamRes = await createTestTeam(db, { name });
 	const teamId = (await teamRes.json()).data.id as string;
 	const captain = await db.query<{ id: string }>(
 		`SELECT ma.id FROM member_agents ma JOIN members m ON m.id = ma.id

--- a/packages/server/test/mcp-tools.test.ts
+++ b/packages/server/test/mcp-tools.test.ts
@@ -9,6 +9,7 @@ import {
 	authHeader,
 	createTestApp,
 	createTestProject,
+	createTestTeam,
 	instanceCeoId,
 	instanceCoachId,
 	mintAgentToken,
@@ -45,13 +46,9 @@ beforeAll(async () => {
 	).id;
 
 	// Create Team A
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({
-			name: 'MCP Tool Test Co',
-			template_id: typeId,
-		}),
+	const teamRes = await createTestTeam(db, {
+		name: 'MCP Tool Test Co',
+		template_id: typeId,
 	});
 	const teamData = (await teamRes.json()).data;
 	teamId = teamData.id;
@@ -79,13 +76,9 @@ beforeAll(async () => {
 	taskId = (await taskRes.json()).data.id;
 
 	// Create Team B
-	const teamBRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({
-			name: 'MCP Tool Test Co B',
-			template_id: typeId,
-		}),
+	const teamBRes = await createTestTeam(db, {
+		name: 'MCP Tool Test Co B',
+		template_id: typeId,
 	});
 	const teamBData = (await teamBRes.json()).data;
 	teamBId = teamBData.id;

--- a/packages/server/test/mcp.test.ts
+++ b/packages/server/test/mcp.test.ts
@@ -7,6 +7,7 @@ import { safeClose } from './helpers';
 import {
 	authHeader,
 	createTestApp,
+	createTestTeam,
 	finalizeAgentRun,
 	mintAgentToken,
 	projectSlugFor,
@@ -30,11 +31,7 @@ beforeAll(async () => {
 	const typesRes = await app.request('/api/team-templates', { headers: authHeader(token) });
 	const typeId = (await typesRes.json()).data.find((t: any) => t.name === 'Startup').id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'MCP Test Co', template_id: typeId }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'MCP Test Co', template_id: typeId });
 	const teamData = (await teamRes.json()).data;
 	teamId = teamData.id;
 

--- a/packages/server/test/mention-handoff-prompt.test.ts
+++ b/packages/server/test/mention-handoff-prompt.test.ts
@@ -12,7 +12,13 @@ import {
 import { getAgentSystemPrompt } from '../src/services/documents';
 import { resolveSystemPrompt } from '../src/services/template-resolver';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject, projectSlugFor } from './helpers/app';
+import {
+	authHeader,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+	projectSlugFor,
+} from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -47,13 +53,9 @@ beforeAll(async () => {
 		(t: Record<string, unknown>) => t.name === 'Startup',
 	).id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({
-			name: 'Mention Handoff Prompt Co',
-			template_id: typeId,
-		}),
+	const teamRes = await createTestTeam(db, {
+		name: 'Mention Handoff Prompt Co',
+		template_id: typeId,
 	});
 	const teamData = (await teamRes.json()).data;
 	teamId = teamData.id;
@@ -185,13 +187,9 @@ describe('mention handoff prompt (integration)', () => {
 		const typeId = (await typesRes.json()).data.find(
 			(t: Record<string, unknown>) => t.name === 'Startup',
 		).id;
-		const teamRes = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({
-				name: 'No Tickets Co',
-				template_id: typeId,
-			}),
+		const teamRes = await createTestTeam(db, {
+			name: 'No Tickets Co',
+			template_id: typeId,
 		});
 		const soloTeam = (await teamRes.json()).data;
 		const soloTeamId = soloTeam.id;

--- a/packages/server/test/mentions.test.ts
+++ b/packages/server/test/mentions.test.ts
@@ -3,7 +3,13 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject, projectSlugFor } from './helpers/app';
+import {
+	authHeader,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+	projectSlugFor,
+} from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -21,11 +27,7 @@ beforeAll(async () => {
 	token = ctx.token;
 
 	const makeTeam = async (name: string) => {
-		const r = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({ name }),
-		});
+		const r = await createTestTeam(db, { name });
 		return (await r.json()).data as { id: string; slug: string };
 	};
 

--- a/packages/server/test/oauth-github-routes.test.ts
+++ b/packages/server/test/oauth-github-routes.test.ts
@@ -3,7 +3,7 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, projectSlugFor } from './helpers/app';
+import { authHeader, createTestApp, createTestTeam, projectSlugFor } from './helpers/app';
 import { createGitHubSim, type GitHubSim } from './helpers/github-sim';
 
 let app: Hono<Env>;
@@ -42,11 +42,7 @@ beforeAll(async () => {
 	const typeId = (await typesRes.json()).data.find(
 		(t: { name: string }) => t.name === 'Startup',
 	).id;
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'GitHub Co', template_id: typeId }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'GitHub Co', template_id: typeId });
 	const team = (await teamRes.json()).data as { id: string; slug: string };
 	teamId = team.id;
 	projectSlug = `${await projectSlugFor(db, team.id)}`;

--- a/packages/server/test/oauth-scope-status.test.ts
+++ b/packages/server/test/oauth-scope-status.test.ts
@@ -3,7 +3,7 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, projectSlugFor } from './helpers/app';
+import { authHeader, createTestApp, createTestTeam, projectSlugFor } from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -37,11 +37,7 @@ beforeAll(async () => {
 	const typeId = (await typesRes.json()).data.find(
 		(t: { name: string }) => t.name === 'Startup',
 	).id;
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Scope Co', template_id: typeId }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Scope Co', template_id: typeId });
 	const team = (await teamRes.json()).data as { id: string; slug: string };
 	teamId = team.id;
 	projectSlug = `${await projectSlugFor(db, team.id)}`;

--- a/packages/server/test/orphan-detector.test.ts
+++ b/packages/server/test/orphan-detector.test.ts
@@ -11,7 +11,13 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Env } from '../src/lib/types';
 import { detectOrphans, healStaleRunState } from '../src/services/orphan-detector';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject, projectSlugFor } from './helpers/app';
+import {
+	authHeader,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+	projectSlugFor,
+} from './helpers/app';
 
 let db: PGlite;
 let app: Hono<Env>;
@@ -29,14 +35,10 @@ beforeAll(async () => {
 	const typesRes = await app.request('/api/team-templates', { headers: authHeader(token) });
 	const teamTemplateId = (await typesRes.json()).data.find((t: any) => t.name === 'Startup').id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({
-			name: 'Orphan Test Co',
+	const teamRes = await createTestTeam(db, {
+		name: 'Orphan Test Co',
 
-			template_id: teamTemplateId,
-		}),
+		template_id: teamTemplateId,
 	});
 	const team = (await teamRes.json()).data as { id: string; slug: string };
 	teamId = team.id;

--- a/packages/server/test/parent-cascade.test.ts
+++ b/packages/server/test/parent-cascade.test.ts
@@ -5,7 +5,13 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Env } from '../src/lib/types';
 import { triggerStatusAutomations } from '../src/services/task-automation';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject, projectSlugFor } from './helpers/app';
+import {
+	authHeader,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+	projectSlugFor,
+} from './helpers/app';
 
 let db: PGlite;
 let app: Hono<Env>;
@@ -28,10 +34,9 @@ beforeAll(async () => {
 		(t: { name: string }) => t.name === 'Startup',
 	).id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Parent Cascade Co', template_id: teamTemplateId }),
+	const teamRes = await createTestTeam(db, {
+		name: 'Parent Cascade Co',
+		template_id: teamTemplateId,
 	});
 	const teamData = (await teamRes.json()).data;
 	teamId = teamData.id;

--- a/packages/server/test/preferences.test.ts
+++ b/packages/server/test/preferences.test.ts
@@ -3,7 +3,7 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, projectSlugFor } from './helpers/app';
+import { authHeader, createTestApp, createTestTeam, projectSlugFor } from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -16,11 +16,7 @@ beforeAll(async () => {
 	db = ctx.db;
 	token = ctx.token;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Pref Test Co' }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Pref Test Co' });
 	const team = (await teamRes.json()).data as { slug: string };
 	projectSlug = `${await projectSlugFor(db, team.id)}`;
 });
@@ -87,11 +83,7 @@ describe('Team preferences', () => {
 	});
 
 	it('returns empty revisions when no preferences exist', async () => {
-		const coRes = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({ name: 'Empty Prefs Co' }),
-		});
+		const coRes = await createTestTeam(db, { name: 'Empty Prefs Co' });
 		const emptyTeam = (await coRes.json()).data as { slug: string };
 
 		const res = await app.request(

--- a/packages/server/test/preview.test.ts
+++ b/packages/server/test/preview.test.ts
@@ -11,7 +11,7 @@ import type { Env } from '../src/lib/types';
 import { signAdminJwt } from '../src/middleware/auth';
 import { buildApp } from '../src/startup';
 import { safeClose } from './helpers';
-import { createStubDocker, createTestProject } from './helpers/app';
+import { createStubDocker, createTestProject, createTestTeam } from './helpers/app';
 import { createTestDbWithMigrations } from './helpers/db';
 
 let app: Hono<Env>;
@@ -36,11 +36,7 @@ beforeAll(async () => {
 	);
 	token = await signAdminJwt(masterKeyManager, userResult.rows[0].id);
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Preview Co' }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Preview Co' });
 	const team = (await teamRes.json()).data;
 	teamId = team.id;
 

--- a/packages/server/test/project-assets.test.ts
+++ b/packages/server/test/project-assets.test.ts
@@ -6,7 +6,13 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { MasterKeyManager } from '../src/crypto/master-key';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject, mintAgentToken } from './helpers/app';
+import {
+	authHeader,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+	mintAgentToken,
+} from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -87,11 +93,7 @@ beforeAll(async () => {
 	masterKeyManager = ctx.masterKeyManager;
 	dataDir = ctx.dataDir;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Assets Co' }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Assets Co' });
 	teamId = (await teamRes.json()).data.id;
 
 	const projectRes = await createTestProject(db, teamId, { name: 'Main', description: 'Assets.' });

--- a/packages/server/test/project-docs.test.ts
+++ b/packages/server/test/project-docs.test.ts
@@ -11,7 +11,7 @@ import type { Env } from '../src/lib/types';
 import { signAdminJwt } from '../src/middleware/auth';
 import { buildApp } from '../src/startup';
 import { safeClose } from './helpers';
-import { authHeader, createStubDocker, createTestProject } from './helpers/app';
+import { authHeader, createStubDocker, createTestProject, createTestTeam } from './helpers/app';
 import { createTestDbWithMigrations } from './helpers/db';
 
 let app: Hono<Env>;
@@ -36,11 +36,7 @@ beforeAll(async () => {
 	);
 	token = await signAdminJwt(masterKeyManager, userResult.rows[0].id);
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Doc Test Co' }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Doc Test Co' });
 	teamId = (await teamRes.json()).data.id;
 
 	const projectRes = await createTestProject(db, teamId, {
@@ -257,11 +253,7 @@ describe('AGENTS.md (filesystem-based)', () => {
 	let repoProjectId: string;
 
 	const makeTeam = async (name: string) => {
-		const r = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({ name }),
-		});
+		const r = await createTestTeam(db, { name });
 		return (await r.json()).data.id as string;
 	};
 

--- a/packages/server/test/project-status.test.ts
+++ b/packages/server/test/project-status.test.ts
@@ -9,7 +9,13 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject, projectSlugFor } from './helpers/app';
+import {
+	authHeader,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+	projectSlugFor,
+} from './helpers/app';
 
 function row(
 	overrides: Partial<TaskProgressStatusRow> & Pick<TaskProgressStatusRow, 'id'>,
@@ -105,10 +111,9 @@ describe('project_status integration', () => {
 			(t: { name: string }) => t.name === 'Startup',
 		).id;
 
-		const teamRes = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({ name: 'Project Status Co', template_id: teamTemplateId }),
+		const teamRes = await createTestTeam(db, {
+			name: 'Project Status Co',
+			template_id: teamTemplateId,
 		});
 		teamId = (await teamRes.json()).data.id;
 		const internalProjectSlug = await projectSlugFor(db, teamId);

--- a/packages/server/test/projects-dashboard-stats.test.ts
+++ b/packages/server/test/projects-dashboard-stats.test.ts
@@ -3,7 +3,7 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, expect, it } from 'vitest';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject } from './helpers/app';
+import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -18,11 +18,7 @@ beforeAll(async () => {
 	db = ctx.db;
 	token = ctx.token;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Dashboard Co' }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Dashboard Co' });
 	teamId = (await teamRes.json()).data.id;
 
 	const projectRes = await createTestProject(db, teamId, { name: 'Main' });
@@ -78,11 +74,7 @@ it('a project with no active agents and no spend reports zeros', async () => {
 		`UPDATE member_agents SET runtime_status = 'idle'::agent_runtime_status WHERE id = $1`,
 		[agentId],
 	);
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Quiet Co' }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Quiet Co' });
 	const quietTeamId = (await teamRes.json()).data.id;
 	const quietRes = await createTestProject(db, quietTeamId, { name: 'Quiet' });
 	const quietId = (await quietRes.json()).data.id;

--- a/packages/server/test/projects.test.ts
+++ b/packages/server/test/projects.test.ts
@@ -3,7 +3,7 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp } from './helpers/app';
+import { authHeader, createTestApp, createTestTeam } from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -41,11 +41,7 @@ beforeAll(async () => {
 	db = ctx.db;
 	token = ctx.token;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Project Test Co' }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Project Test Co' });
 	const teamData = (await teamRes.json()).data;
 	teamId = teamData.id;
 	teamSlug = teamData.slug;

--- a/packages/server/test/queued-wakeups.test.ts
+++ b/packages/server/test/queued-wakeups.test.ts
@@ -3,7 +3,13 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject, projectSlugFor } from './helpers/app';
+import {
+	authHeader,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+	projectSlugFor,
+} from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -133,11 +139,7 @@ beforeAll(async () => {
 	db = ctx.db;
 	token = ctx.token;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), ...json },
-		body: JSON.stringify({ name: 'Queued Wakeups Co' }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Queued Wakeups Co' });
 	const teamData = (await teamRes.json()).data;
 	teamId = teamData.id;
 	teamSlug = teamData.slug;

--- a/packages/server/test/reactions.test.ts
+++ b/packages/server/test/reactions.test.ts
@@ -9,6 +9,7 @@ import {
 	authHeader,
 	createTestApp,
 	createTestProject,
+	createTestTeam,
 	mintAgentToken,
 	projectSlugFor,
 	projectSlugForTeamSlug,
@@ -115,11 +116,7 @@ beforeAll(async () => {
 		(t: Record<string, unknown>) => t.name === 'Startup',
 	).id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Reactions Co', template_id: typeId }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Reactions Co', template_id: typeId });
 	const teamData = (await teamRes.json()).data;
 	teamId = teamData.id;
 	const teamSlug = teamData.slug;
@@ -290,11 +287,7 @@ describe('REST reactions endpoints', () => {
 		const typeId = (await typesRes.json()).data.find(
 			(t: Record<string, unknown>) => t.name === 'Startup',
 		).id;
-		const otherTeam = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({ name: 'Other Co', template_id: typeId }),
-		});
+		const otherTeam = await createTestTeam(db, { name: 'Other Co', template_id: typeId });
 		const otherTeamData = (await otherTeam.json()).data;
 		const otherTeamId = otherTeamData.id;
 		const otherTeamSlug = otherTeamData.slug;

--- a/packages/server/test/repo-sync.test.ts
+++ b/packages/server/test/repo-sync.test.ts
@@ -11,7 +11,7 @@ import {
 	removeTaskWorktrees,
 } from '../src/services/repo-sync';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject } from './helpers/app';
+import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -29,11 +29,7 @@ beforeAll(async () => {
 	masterKeyManager = ctx.masterKeyManager;
 	dataDir = ctx.dataDir;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Repo Sync Co' }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Repo Sync Co' });
 	const team = (await teamRes.json()).data;
 	teamId = team.id;
 

--- a/packages/server/test/repos-create-github.test.ts
+++ b/packages/server/test/repos-create-github.test.ts
@@ -6,7 +6,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { MasterKeyManager } from '../src/crypto/master-key';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject } from './helpers/app';
+import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
 import { createGitHubSim, type GitHubSim } from './helpers/github-sim';
 
 let app: Hono<Env>;
@@ -76,11 +76,7 @@ beforeAll(async () => {
 	const typeId = (await typesRes.json()).data.find(
 		(t: { name: string }) => t.name === 'Startup',
 	).id;
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Repo Create Co', template_id: typeId }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Repo Create Co', template_id: typeId });
 	teamId = (await teamRes.json()).data.id;
 
 	const projectRes = await createTestProject(db, teamId, { name: 'Repo Create Project' });

--- a/packages/server/test/repos.test.ts
+++ b/packages/server/test/repos.test.ts
@@ -3,7 +3,7 @@ import type { Hono } from 'hono';
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject } from './helpers/app';
+import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -22,11 +22,7 @@ beforeAll(async () => {
 	const types = (await typesRes.json()).data;
 	const builtinTypeId = types.find((t: any) => t.name === 'Startup').id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Repo Test Co', template_id: builtinTypeId }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Repo Test Co', template_id: builtinTypeId });
 	teamId = (await teamRes.json()).data.id;
 
 	// Create project

--- a/packages/server/test/resolve.test.ts
+++ b/packages/server/test/resolve.test.ts
@@ -4,7 +4,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { resolveAgentId, resolveProjectId, resolveTeamId } from '../src/lib/resolve';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject } from './helpers/app';
+import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -23,11 +23,7 @@ beforeAll(async () => {
 	const typesRes = await app.request('/api/team-templates', { headers: authHeader(token) });
 	const typeId = (await typesRes.json()).data.find((t: any) => t.name === 'Startup').id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Resolve Test Co', template_id: typeId }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Resolve Test Co', template_id: typeId });
 	const teamData = (await teamRes.json()).data;
 	teamId = teamData.id;
 	teamSlug = teamData.slug;

--- a/packages/server/test/run-termination.test.ts
+++ b/packages/server/test/run-termination.test.ts
@@ -3,7 +3,13 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject, projectSlugFor } from './helpers/app';
+import {
+	authHeader,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+	projectSlugFor,
+} from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -70,11 +76,7 @@ beforeAll(async () => {
 	db = ctx.db;
 	token = ctx.token;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Terminate Test Co' }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Terminate Test Co' });
 	const teamData = (await teamRes.json()).data;
 	teamId = teamData.id;
 	const teamSlug = teamData.slug;

--- a/packages/server/test/run-trigger-reason.test.ts
+++ b/packages/server/test/run-trigger-reason.test.ts
@@ -5,7 +5,13 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { MasterKeyManager } from '../src/crypto/master-key';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject, projectSlugFor } from './helpers/app';
+import {
+	authHeader,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+	projectSlugFor,
+} from './helpers/app';
 
 interface RunRow {
 	id: string;
@@ -46,11 +52,7 @@ beforeAll(async () => {
 		(t: Record<string, unknown>) => t.name === 'Startup',
 	).id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Trigger Reason Co', template_id: typeId }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Trigger Reason Co', template_id: typeId });
 	const teamData = (await teamRes.json()).data;
 	teamId = teamData.id;
 

--- a/packages/server/test/search.test.ts
+++ b/packages/server/test/search.test.ts
@@ -3,7 +3,13 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, projectSlugFor, projectSlugForTeamSlug } from './helpers/app';
+import {
+	authHeader,
+	createTestApp,
+	createTestTeam,
+	projectSlugFor,
+	projectSlugForTeamSlug,
+} from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -23,11 +29,7 @@ beforeAll(async () => {
 		(t: Record<string, unknown>) => t.name === 'Startup',
 	).id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Search Test Co', template_id: typeId }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Search Test Co', template_id: typeId });
 	const teamSlug = (await teamRes.json()).data.slug;
 	projectSlug = `${await projectSlugForTeamSlug(db, teamSlug)}`;
 });

--- a/packages/server/test/skills.test.ts
+++ b/packages/server/test/skills.test.ts
@@ -13,7 +13,7 @@ import { parseGitHubRawUrl, SkillDownloadError } from '../src/services/skill-dow
 import { resolveSystemPrompt } from '../src/services/template-resolver';
 import { buildApp } from '../src/startup';
 import { safeClose } from './helpers';
-import { authHeader, createStubDocker } from './helpers/app';
+import { authHeader, createStubDocker, createTestTeam } from './helpers/app';
 import { createTestDbWithMigrations } from './helpers/db';
 
 let app: Hono<Env>;
@@ -39,11 +39,7 @@ beforeAll(async () => {
 	);
 	token = await signAdminJwt(masterKeyManager, userResult.rows[0].id);
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Skills Co' }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Skills Co' });
 	teamId = (await teamRes.json()).data.id;
 });
 

--- a/packages/server/test/ssh-agent-docker.test.ts
+++ b/packages/server/test/ssh-agent-docker.test.ts
@@ -23,7 +23,7 @@ import type { MasterKeyManager } from '../src/crypto/master-key';
 import { SshAgentServer, sshPublicKeyToBlob } from '../src/services/ssh-agent/server';
 import { generateTeamSSHKey } from '../src/services/ssh-keys';
 import { safeClose } from './helpers';
-import { createTestApp, createTestProject } from './helpers/app';
+import { createTestApp, createTestProject, createTestTeam } from './helpers/app';
 
 const dockerAvailable = await checkDocker();
 const skipReason =
@@ -52,11 +52,7 @@ beforeAll(async () => {
 	db = ctx.db;
 	masterKeyManager = ctx.masterKeyManager;
 
-	const teamRes = await ctx.app.request('/api/teams', {
-		method: 'POST',
-		headers: { Authorization: `Bearer ${ctx.token}`, 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'SSH Docker Co' }),
-	});
+	const teamRes = await createTestTeam(ctx.db, { name: 'SSH Docker Co' });
 	const teamData = (await teamRes.json()).data;
 	teamId = teamData.id;
 	const projectSlug = (

--- a/packages/server/test/ssh-agent-host.test.ts
+++ b/packages/server/test/ssh-agent-host.test.ts
@@ -14,7 +14,7 @@ import {
 import { SshAgentServer, sshPublicKeyToBlob } from '../src/services/ssh-agent/server';
 import { generateTeamSSHKey } from '../src/services/ssh-keys';
 import { safeClose } from './helpers';
-import { createTestApp } from './helpers/app';
+import { createTestApp, createTestTeam } from './helpers/app';
 
 let db: PGlite;
 let masterKeyManager: MasterKeyManager;
@@ -51,11 +51,7 @@ beforeAll(async () => {
 	db = ctx.db;
 	masterKeyManager = ctx.masterKeyManager;
 
-	const teamRes = await ctx.app.request('/api/teams', {
-		method: 'POST',
-		headers: { Authorization: `Bearer ${ctx.token}`, 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Host Agent Co' }),
-	});
+	const teamRes = await createTestTeam(ctx.db, { name: 'Host Agent Co' });
 	teamId = (await teamRes.json()).data.id;
 
 	const ssh = await generateTeamSSHKey(db, teamId, masterKeyManager);

--- a/packages/server/test/ssh-agent-server.test.ts
+++ b/packages/server/test/ssh-agent-server.test.ts
@@ -17,7 +17,7 @@ import {
 import { SshAgentServer, sshPublicKeyToBlob } from '../src/services/ssh-agent/server';
 import { generateTeamSSHKey } from '../src/services/ssh-keys';
 import { safeClose } from './helpers';
-import { createTestApp, createTestProject } from './helpers/app';
+import { createTestApp, createTestProject, createTestTeam } from './helpers/app';
 
 let db: PGlite;
 let masterKeyManager: MasterKeyManager;
@@ -32,11 +32,7 @@ beforeAll(async () => {
 	db = ctx.db;
 	masterKeyManager = ctx.masterKeyManager;
 
-	const teamRes = await ctx.app.request('/api/teams', {
-		method: 'POST',
-		headers: { Authorization: `Bearer ${ctx.token}`, 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'SSH Test Co' }),
-	});
+	const teamRes = await createTestTeam(ctx.db, { name: 'SSH Test Co' });
 	const teamData = (await teamRes.json()).data;
 	teamId = teamData.id;
 	const projectSlug = (

--- a/packages/server/test/task-dependencies-gate.test.ts
+++ b/packages/server/test/task-dependencies-gate.test.ts
@@ -10,7 +10,13 @@ import {
 } from '../src/lib/dependencies';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject, projectSlugFor } from './helpers/app';
+import {
+	authHeader,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+	projectSlugFor,
+} from './helpers/app';
 
 let db: PGlite;
 let app: Hono<Env>;
@@ -34,11 +40,7 @@ beforeAll(async () => {
 		(t: { name: string }) => t.name === 'Startup',
 	).id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Dep Gate Co', template_id: teamTemplateId }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Dep Gate Co', template_id: teamTemplateId });
 	const teamData = (await teamRes.json()).data;
 	teamId = teamData.id;
 	internalProjectSlug = `${await projectSlugFor(db, teamData.id)}`;

--- a/packages/server/test/task-detail-aggregates.test.ts
+++ b/packages/server/test/task-detail-aggregates.test.ts
@@ -3,7 +3,7 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, expect, it } from 'vitest';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject } from './helpers/app';
+import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -20,11 +20,7 @@ beforeAll(async () => {
 	db = ctx.db;
 	token = ctx.token;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Aggregates Co' }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Aggregates Co' });
 	teamId = (await teamRes.json()).data.id;
 
 	const projectRes = await createTestProject(db, teamId, { name: 'Main' });

--- a/packages/server/test/task-events.test.ts
+++ b/packages/server/test/task-events.test.ts
@@ -10,6 +10,7 @@ import {
 	authHeader,
 	createTestApp,
 	createTestProject,
+	createTestTeam,
 	mintAgentToken,
 	projectSlugFor,
 } from './helpers/app';
@@ -79,11 +80,7 @@ beforeAll(async () => {
 	token = ctx.token;
 	masterKeyManager = ctx.masterKeyManager;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Events Co' }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Events Co' });
 	const teamData = (await teamRes.json()).data;
 	teamId = teamData.id;
 	teamSlug = teamData.slug;
@@ -418,11 +415,7 @@ describe('task link system events', () => {
 	it('does not cross team boundaries', async () => {
 		const targetA = await createTask('Cross-team target');
 
-		const otherTeamRes = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({ name: 'Other Co' }),
-		});
+		const otherTeamRes = await createTestTeam(db, { name: 'Other Co' });
 		const otherTeamData = (await otherTeamRes.json()).data;
 		const otherTeamId = otherTeamData.id;
 		const otherInternalSlug = `${await projectSlugFor(db, otherTeamData.id)}`;

--- a/packages/server/test/task-progress-summary.test.ts
+++ b/packages/server/test/task-progress-summary.test.ts
@@ -9,6 +9,7 @@ import {
 	authHeader,
 	createTestApp,
 	createTestProject,
+	createTestTeam,
 	instanceCeoId,
 	projectSlugFor,
 } from './helpers/app';
@@ -33,10 +34,9 @@ beforeAll(async () => {
 		(t: { name: string }) => t.name === 'Startup',
 	).id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Progress Summary Co', template_id: teamTemplateId }),
+	const teamRes = await createTestTeam(db, {
+		name: 'Progress Summary Co',
+		template_id: teamTemplateId,
 	});
 	teamId = (await teamRes.json()).data.id;
 	const internalProjectSlug = await projectSlugFor(db, teamId);

--- a/packages/server/test/tasks-batch.test.ts
+++ b/packages/server/test/tasks-batch.test.ts
@@ -5,7 +5,13 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { MasterKeyManager } from '../src/crypto/master-key';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject, mintAgentToken } from './helpers/app';
+import {
+	authHeader,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+	mintAgentToken,
+} from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -32,11 +38,7 @@ beforeAll(async () => {
 		(t: Record<string, unknown>) => t.name === 'Startup',
 	).id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Batch Tasks Co', template_id: typeId }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Batch Tasks Co', template_id: typeId });
 	const teamData = (await teamRes.json()).data;
 	teamId = teamData.id;
 

--- a/packages/server/test/tasks-extended.test.ts
+++ b/packages/server/test/tasks-extended.test.ts
@@ -3,7 +3,7 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject } from './helpers/app';
+import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -29,11 +29,7 @@ beforeAll(async () => {
 	token = ctx.token;
 
 	const makeTeam = async (name: string) => {
-		const r = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({ name }),
-		});
+		const r = await createTestTeam(db, { name });
 		return (await r.json()).data.id as string;
 	};
 

--- a/packages/server/test/tasks-last-run.test.ts
+++ b/packages/server/test/tasks-last-run.test.ts
@@ -3,7 +3,7 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject } from './helpers/app';
+import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -28,11 +28,7 @@ beforeAll(async () => {
 	db = ctx.db;
 	token = ctx.token;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Last Run Co' }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Last Run Co' });
 	teamId = (await teamRes.json()).data.id;
 
 	const projectRes = await createTestProject(db, teamId, { name: 'Main' });

--- a/packages/server/test/tasks-resolve.test.ts
+++ b/packages/server/test/tasks-resolve.test.ts
@@ -3,7 +3,13 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject, projectSlugFor } from './helpers/app';
+import {
+	authHeader,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+	projectSlugFor,
+} from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -26,11 +32,7 @@ beforeAll(async () => {
 	token = ctx.token;
 
 	const makeTeam = async (name: string) => {
-		const r = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({ name }),
-		});
+		const r = await createTestTeam(db, { name });
 		return (await r.json()).data as { id: string; slug: string };
 	};
 

--- a/packages/server/test/tasks-sort.test.ts
+++ b/packages/server/test/tasks-sort.test.ts
@@ -4,7 +4,7 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject } from './helpers/app';
+import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -20,11 +20,7 @@ beforeAll(async () => {
 	db = ctx.db;
 	token = ctx.token;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Task Sort Co' }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Task Sort Co' });
 	teamId = (await teamRes.json()).data.id;
 
 	const projectRes = await createTestProject(db, teamId, {

--- a/packages/server/test/tasks.test.ts
+++ b/packages/server/test/tasks.test.ts
@@ -4,7 +4,13 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { MasterKeyManager } from '../src/crypto/master-key';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject, mintAgentToken } from './helpers/app';
+import {
+	authHeader,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+	mintAgentToken,
+} from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -23,11 +29,7 @@ beforeAll(async () => {
 	token = ctx.token;
 	masterKeyManager = ctx.masterKeyManager;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'Task Test Co' }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'Task Test Co' });
 	const teamData = (await teamRes.json()).data;
 	teamId = teamData.id;
 	teamSlug = teamData.slug;

--- a/packages/server/test/team-save-as-template.test.ts
+++ b/packages/server/test/team-save-as-template.test.ts
@@ -3,7 +3,7 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, projectSlugFor } from './helpers/app';
+import { authHeader, createTestApp, createTestTeam, projectSlugFor } from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -26,15 +26,11 @@ afterAll(async () => {
 });
 
 // Creates a team and returns the slug of its single project — the public handle
-// for the team-wide endpoints (agents, save-as-template, apply-type). `POST
-// /api/teams` no longer creates a project, so we materialize the team's one
-// project here (idempotently) and address everything through it.
+// for the team-wide endpoints (agents, save-as-template, apply-type). The
+// createTeam service makes the roster but no project, so we materialize the
+// team's one project here (idempotently) and address everything through it.
 async function createTeam(name: string, templateId?: string): Promise<string> {
-	const res = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify(templateId ? { name, template_id: templateId } : { name }),
-	});
+	const res = await createTestTeam(db, templateId ? { name, template_id: templateId } : { name });
 	expect(res.status).toBe(201);
 	const teamId = (await res.json()).data.id as string;
 	return projectSlugFor(db, teamId);

--- a/packages/server/test/teams.test.ts
+++ b/packages/server/test/teams.test.ts
@@ -3,7 +3,7 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject } from './helpers/app';
+import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -34,16 +34,16 @@ afterAll(async () => {
 	await safeClose(db);
 });
 
-describe('teams CRUD', () => {
+// Teams are provisioned by the createTeam service (reached via project creation,
+// `POST /api/projects`); there is no bare `POST /api/teams` route anymore. These
+// tests exercise that service via the `createTestTeam` helper and read the result
+// back through the project-addressed team routes.
+describe('team provisioning (createTeam service)', () => {
 	it('creates a team from built-in template with auto-created agents and KB docs', async () => {
-		const res = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({
-				name: 'NoteGenius AI',
-				description: 'Build the #1 AI note-taking app',
-				template_id: builtinTypeId,
-			}),
+		const res = await createTestTeam(db, {
+			name: 'NoteGenius AI',
+			description: 'Build the #1 AI note-taking app',
+			template_id: builtinTypeId,
 		});
 		expect(res.status).toBe(201);
 		const body = await res.json();
@@ -63,13 +63,7 @@ describe('teams CRUD', () => {
 	});
 
 	it('creates a team without a type and includes built-in agents', async () => {
-		const res = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({
-				name: 'Solo Project',
-			}),
-		});
+		const res = await createTestTeam(db, { name: 'Solo Project' });
 		expect(res.status).toBe(201);
 		const body = await res.json();
 		expect(body.data.agent_count).toBe(1);
@@ -86,11 +80,10 @@ describe('teams CRUD', () => {
 		expect(slugs).toEqual(['captain']);
 	});
 
-	it('exposes the team type (primary template name) on reads', async () => {
-		const createRes = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({ name: 'Typed Team Co', template_id: builtinTypeId }),
+	it('exposes the team type (primary template name) on the project-addressed read', async () => {
+		const createRes = await createTestTeam(db, {
+			name: 'Typed Team Co',
+			template_id: builtinTypeId,
 		});
 		const created = (await createRes.json()).data;
 
@@ -100,16 +93,8 @@ describe('teams CRUD', () => {
 		});
 		expect((await getRes.json()).data.primary_template_name).toBe('Startup');
 
-		const listRes = await app.request('/api/teams', { headers: authHeader(token) });
-		const listed = (await listRes.json()).data.find((t: { id: string }) => t.id === created.id);
-		expect(listed.primary_template_name).toBe('Startup');
-
 		// A team created without a template has no type.
-		const blankRes = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({ name: 'Typeless Team Co' }),
-		});
+		const blankRes = await createTestTeam(db, { name: 'Typeless Team Co' });
 		const blank = (await blankRes.json()).data;
 		const blankSlug = await projectSlugFor(blank.id);
 		const blankGet = await app.request(`/api/projects/${blankSlug}/team`, {
@@ -118,23 +103,8 @@ describe('teams CRUD', () => {
 		expect((await blankGet.json()).data.primary_template_name).toBeNull();
 	});
 
-	it('lists teams with counts', async () => {
-		const res = await app.request('/api/teams', {
-			headers: authHeader(token),
-		});
-		expect(res.status).toBe(200);
-		const body = await res.json();
-		expect(body.data.length).toBeGreaterThanOrEqual(2);
-		expect(body.data[0]).toHaveProperty('agent_count');
-		expect(body.data[0]).toHaveProperty('open_task_count');
-	});
-
 	it('gets a team by id', async () => {
-		const createRes = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({ name: 'Get By Id Co' }),
-		});
+		const createRes = await createTestTeam(db, { name: 'Get By Id Co' });
 		const team = (await createRes.json()).data;
 		const projectSlug = await projectSlugFor(team.id);
 
@@ -147,11 +117,7 @@ describe('teams CRUD', () => {
 	});
 
 	it('updates a team', async () => {
-		const createRes = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({ name: 'Update Me Co' }),
-		});
+		const createRes = await createTestTeam(db, { name: 'Update Me Co' });
 		const team = (await createRes.json()).data;
 		const projectSlug = await projectSlugFor(team.id);
 
@@ -167,11 +133,7 @@ describe('teams CRUD', () => {
 
 	it('deletes a team', async () => {
 		// Create a throwaway team
-		const createRes = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({ name: 'To Delete' }),
-		});
+		const createRes = await createTestTeam(db, { name: 'To Delete' });
 		const created = (await createRes.json()).data;
 		const projectSlug = await projectSlugFor(created.id);
 
@@ -188,16 +150,8 @@ describe('teams CRUD', () => {
 	});
 
 	it('generates unique slugs for same-named teams', async () => {
-		const res1 = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({ name: 'Duplicate Name' }),
-		});
-		const res2 = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({ name: 'Duplicate Name' }),
-		});
+		const res1 = await createTestTeam(db, { name: 'Duplicate Name' });
+		const res2 = await createTestTeam(db, { name: 'Duplicate Name' });
 		expect(res1.status).toBe(201);
 		expect(res2.status).toBe(201);
 		const slug1 = (await res1.json()).data.slug;
@@ -231,15 +185,7 @@ describe('template-based team creation', () => {
 		expect(typeRes.status).toBe(201);
 		const templateId = (await typeRes.json()).data.id;
 
-		const res = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({
-				name: 'Research Co',
-
-				template_id: templateId,
-			}),
-		});
+		const res = await createTestTeam(db, { name: 'Research Co', template_id: templateId });
 		expect(res.status).toBe(201);
 		const body = await res.json();
 		expect(body.data.agent_count).toBe(2);
@@ -257,13 +203,7 @@ describe('template-based team creation', () => {
 	});
 
 	it('creates only built-in agents without a template', async () => {
-		const res = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({
-				name: 'Blank Co',
-			}),
-		});
+		const res = await createTestTeam(db, { name: 'Blank Co' });
 		expect(res.status).toBe(201);
 		const body = await res.json();
 		expect(body.data.agent_count).toBe(1);
@@ -286,15 +226,7 @@ describe('template-based team creation', () => {
 		});
 		const blankType = (await typesRes.json()).data.find((t: any) => t.name === 'Blank');
 
-		const res = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({
-				name: 'Blank Template Co',
-
-				template_id: blankType.id,
-			}),
-		});
+		const res = await createTestTeam(db, { name: 'Blank Template Co', template_id: blankType.id });
 		expect(res.status).toBe(201);
 		const body = await res.json();
 		expect(body.data.agent_count).toBe(1);
@@ -312,15 +244,7 @@ describe('template-based team creation', () => {
 	});
 
 	it('does not duplicate the Captain when the Startup template already includes it', async () => {
-		const res = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({
-				name: 'Full Template Co',
-
-				template_id: builtinTypeId,
-			}),
-		});
+		const res = await createTestTeam(db, { name: 'Full Template Co', template_id: builtinTypeId });
 		expect(res.status).toBe(201);
 		const body = await res.json();
 		expect(body.data.agent_count).toBe(10);
@@ -359,15 +283,7 @@ describe('template-based team creation', () => {
 		expect(typeRes.status).toBe(201);
 		const templateId = (await typeRes.json()).data.id;
 
-		const res = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({
-				name: 'Researcher Co',
-
-				template_id: templateId,
-			}),
-		});
+		const res = await createTestTeam(db, { name: 'Researcher Co', template_id: templateId });
 		expect(res.status).toBe(201);
 		const body = await res.json();
 		expect(body.data.agent_count).toBe(2);
@@ -385,15 +301,7 @@ describe('template-based team creation', () => {
 	});
 
 	it('populates team_template_assignments join table', async () => {
-		const res = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({
-				name: 'Join Table Co',
-
-				template_id: builtinTypeId,
-			}),
-		});
+		const res = await createTestTeam(db, { name: 'Join Table Co', template_id: builtinTypeId });
 		expect(res.status).toBe(201);
 		const teamId = (await res.json()).data.id;
 
@@ -423,14 +331,7 @@ describe('template-based team creation', () => {
 		expect(typeRes.status).toBe(201);
 		const templateId = (await typeRes.json()).data.id;
 
-		const res = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({
-				name: 'Skills Co',
-				template_id: templateId,
-			}),
-		});
+		const res = await createTestTeam(db, { name: 'Skills Co', template_id: templateId });
 		expect(res.status).toBe(201);
 		expect((await res.json()).data.id).toBeTruthy();
 
@@ -446,11 +347,11 @@ describe('template-based team creation', () => {
 
 describe('slug-based access', () => {
 	it('gets a team by slug', async () => {
-		const listRes = await app.request('/api/teams', {
-			headers: authHeader(token),
-		});
-		const teams = (await listRes.json()).data;
-		const team = teams.find((c: any) => c.slug === 'notegenius-ai');
+		const team = (
+			await db.query<{ id: string; slug: string }>('SELECT id, slug FROM teams WHERE slug = $1', [
+				'notegenius-ai',
+			])
+		).rows[0];
 
 		const projectSlug = await projectSlugFor(team.id);
 		const res = await app.request(`/api/projects/${projectSlug}/team`, {
@@ -470,11 +371,11 @@ describe('slug-based access', () => {
 	});
 
 	it('accesses team sub-resources via slug', async () => {
-		const listRes = await app.request('/api/teams', {
-			headers: authHeader(token),
-		});
-		const teams = (await listRes.json()).data;
-		const team = teams.find((c: any) => c.slug === 'notegenius-ai');
+		const team = (
+			await db.query<{ id: string; slug: string }>('SELECT id, slug FROM teams WHERE slug = $1', [
+				'notegenius-ai',
+			])
+		).rows[0];
 
 		const projectSlug = await projectSlugFor(team.id);
 		const agentsRes = await app.request(`/api/projects/${projectSlug}/agents`, {
@@ -484,5 +385,21 @@ describe('slug-based access', () => {
 		const agentsBody = await agentsRes.json();
 		const own = agentsBody.data.filter((a: any) => !a.is_instance);
 		expect(own.length).toBe(10);
+	});
+});
+
+describe('removed bare team routes', () => {
+	it('GET /api/teams is no longer routed', async () => {
+		const res = await app.request('/api/teams', { headers: authHeader(token) });
+		expect(res.status).toBe(404);
+	});
+
+	it('POST /api/teams is no longer routed', async () => {
+		const res = await app.request('/api/teams', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name: 'Should Not Work' }),
+		});
+		expect(res.status).toBe(404);
 	});
 });

--- a/packages/server/test/template-resolver.test.ts
+++ b/packages/server/test/template-resolver.test.ts
@@ -9,6 +9,7 @@ import {
 	authHeader,
 	createTestApp,
 	createTestProject,
+	createTestTeam,
 	projectSlugForTeamSlug,
 } from './helpers/app';
 
@@ -24,14 +25,10 @@ beforeAll(async () => {
 	app = ctx.app;
 	token = ctx.token;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({
-			name: 'Template Co',
+	const teamRes = await createTestTeam(db, {
+		name: 'Template Co',
 
-			description: 'Build amazing things',
-		}),
+		description: 'Build amazing things',
 	});
 	teamId = (await teamRes.json()).data.id;
 
@@ -101,10 +98,9 @@ describe('template resolver', () => {
 		// The team already owns its one project (created in beforeAll), and the 1:1
 		// invariant forbids a second on the same team — so the docless project lives
 		// on its own fresh team.
-		const doclessTeamRes = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({ name: 'Docless Co', description: 'No docs here' }),
+		const doclessTeamRes = await createTestTeam(db, {
+			name: 'Docless Co',
+			description: 'No docs here',
 		});
 		const doclessTeamId = (await doclessTeamRes.json()).data.id as string;
 		const bare = await db.query<{ id: string }>(
@@ -158,11 +154,7 @@ describe('template resolver', () => {
 	});
 
 	it('sorts the {{project_docs_context}} manifest by filename', async () => {
-		const teamRes = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({ name: 'Sort Co', description: '' }),
-		});
+		const teamRes = await createTestTeam(db, { name: 'Sort Co', description: '' });
 		const sortTeamId = (await teamRes.json()).data.id as string;
 		const proj = await db.query<{ id: string }>(
 			`INSERT INTO projects (team_id, name, slug, task_prefix, description, docker_base_image)
@@ -398,15 +390,11 @@ describe('template resolver with agents', () => {
 		const softDevType = types.data.find((t: any) => t.name === 'Startup');
 
 		// Create a team with the software dev team type to auto-create agents
-		const teamRes = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({
-				name: 'Agent Test Co',
+		const teamRes = await createTestTeam(db, {
+			name: 'Agent Test Co',
 
-				description: 'Test team for agent templates',
-				template_id: softDevType.id,
-			}),
+			description: 'Test team for agent templates',
+			template_id: softDevType.id,
 		});
 		const agentTeamData = ((await teamRes.json()) as any).data;
 		agentTeamId = agentTeamData.id;
@@ -623,14 +611,10 @@ describe('teammates block', () => {
 		const typesRes = await app.request('/api/team-templates', { headers: authHeader(token) });
 		const startup = ((await typesRes.json()) as any).data.find((t: any) => t.name === 'Startup');
 
-		const teamRes = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({
-				name: 'Teammates Co',
-				description: 'Teammates block test team',
-				template_id: startup.id,
-			}),
+		const teamRes = await createTestTeam(db, {
+			name: 'Teammates Co',
+			description: 'Teammates block test team',
+			template_id: startup.id,
 		});
 		const tbTeamData = ((await teamRes.json()) as any).data;
 		tbTeamId = tbTeamData.id;
@@ -701,10 +685,9 @@ describe('teammates block', () => {
 	});
 
 	it('does not include agents from other teams', async () => {
-		const otherRes = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({ name: 'Isolated Co', description: 'builtin agents only' }),
+		const otherRes = await createTestTeam(db, {
+			name: 'Isolated Co',
+			description: 'builtin agents only',
 		});
 		const otherId = ((await otherRes.json()) as any).data.id;
 
@@ -739,14 +722,10 @@ describe('team context block', () => {
 		const typesRes = await app.request('/api/team-templates', { headers: authHeader(token) });
 		const startup = ((await typesRes.json()) as any).data.find((t: any) => t.name === 'Startup');
 
-		const teamRes = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({
-				name: 'Team Context Co',
-				description: 'Team context block test team',
-				template_id: startup.id,
-			}),
+		const teamRes = await createTestTeam(db, {
+			name: 'Team Context Co',
+			description: 'Team context block test team',
+			template_id: startup.id,
 		});
 		const tcTeamData = ((await teamRes.json()) as any).data;
 		tcTeamId = tcTeamData.id;
@@ -840,14 +819,10 @@ describe('project state block', () => {
 		const typesRes = await app.request('/api/team-templates', { headers: authHeader(token) });
 		const startup = ((await typesRes.json()) as any).data.find((t: any) => t.name === 'Startup');
 
-		const teamRes = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({
-				name: 'Project State Co',
-				description: 'PS test team',
-				template_id: startup.id,
-			}),
+		const teamRes = await createTestTeam(db, {
+			name: 'Project State Co',
+			description: 'PS test team',
+			template_id: startup.id,
 		});
 		const psTeamData = ((await teamRes.json()) as any).data;
 		psTeamId = psTeamData.id;
@@ -1010,10 +985,9 @@ describe('repository block', () => {
 	let repoProjectId: string;
 
 	beforeAll(async () => {
-		const teamRes = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({ name: 'Repo Co', description: 'Repository block test team' }),
+		const teamRes = await createTestTeam(db, {
+			name: 'Repo Co',
+			description: 'Repository block test team',
 		});
 		repoTeamId = ((await teamRes.json()) as any).data.id;
 		const projectRes = await createTestProject(db, repoTeamId, {

--- a/packages/server/test/ui-state.test.ts
+++ b/packages/server/test/ui-state.test.ts
@@ -4,7 +4,13 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { MasterKeyManager } from '../src/crypto/master-key';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, mintAgentToken, projectSlugFor } from './helpers/app';
+import {
+	authHeader,
+	createTestApp,
+	createTestTeam,
+	mintAgentToken,
+	projectSlugFor,
+} from './helpers/app';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -22,20 +28,12 @@ beforeAll(async () => {
 	token = ctx.token;
 	masterKeyManager = ctx.masterKeyManager;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'UI State Co' }),
-	});
+	const teamRes = await createTestTeam(db, { name: 'UI State Co' });
 	const team = (await teamRes.json()).data;
 	teamId = team.id;
 	projectSlug = `${await projectSlugFor(db, team.id)}`;
 
-	const team2Res = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({ name: 'UI State Co 2' }),
-	});
+	const team2Res = await createTestTeam(db, { name: 'UI State Co 2' });
 	const team2 = (await team2Res.json()).data;
 	team2Id = team2.id;
 	project2Slug = `${await projectSlugFor(db, team2.id)}`;
@@ -156,11 +154,7 @@ describe('UI state', () => {
 	});
 
 	it('rejects access to team user is not a member of', async () => {
-		const otherTeamRes = await app.request('/api/teams', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({ name: 'UI State Outsider Co' }),
-		});
+		const otherTeamRes = await createTestTeam(db, { name: 'UI State Outsider Co' });
 		const otherTeam = (await otherTeamRes.json()).data;
 		// Drop the creator's membership so the superuser can resolve the project
 		// (access check bypassed) but has no member_users row for its UI state.

--- a/packages/server/test/wakeup.test.ts
+++ b/packages/server/test/wakeup.test.ts
@@ -9,7 +9,7 @@ import {
 	createWakeup,
 } from '../src/services/wakeup';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestProject } from './helpers/app';
+import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
 
 let db: PGlite;
 let app: Hono<Env>;
@@ -27,14 +27,10 @@ beforeAll(async () => {
 	const typesRes = await app.request('/api/team-templates', { headers: authHeader(token) });
 	const teamTemplateId = (await typesRes.json()).data.find((t: any) => t.name === 'Startup').id;
 
-	const teamRes = await app.request('/api/teams', {
-		method: 'POST',
-		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-		body: JSON.stringify({
-			name: 'Wakeup Co',
+	const teamRes = await createTestTeam(db, {
+		name: 'Wakeup Co',
 
-			template_id: teamTemplateId,
-		}),
+		template_id: teamTemplateId,
 	});
 	const team = (await teamRes.json()).data;
 	teamId = team.id;

--- a/packages/web/src/components/create-project-with-team-dialog.tsx
+++ b/packages/web/src/components/create-project-with-team-dialog.tsx
@@ -4,9 +4,8 @@ import { Loader2, MessagesSquare, Sparkles } from 'lucide-react';
 import { useState } from 'react';
 import { setActiveTeamSlug } from '../hooks/use-active-team-slug';
 import { useStartProjectIntake } from '../hooks/use-project-intake';
-import { useCreateProjectWithTeam } from '../hooks/use-projects';
+import { useAllVisibleProjects, useCreateProjectWithTeam } from '../hooks/use-projects';
 import { useTeamTemplates } from '../hooks/use-team-templates';
-import { useTeams } from '../hooks/use-teams';
 import { Button } from './ui/button';
 import { Card } from './ui/card';
 import { dialogContentClassName, dialogOverlayClassName } from './ui/dialog';
@@ -34,7 +33,7 @@ export function CreateProjectWithTeamDialog({
 	onOpenChange,
 }: CreateProjectWithTeamDialogProps) {
 	const { data: templates, isLoading } = useTeamTemplates();
-	const { data: teams } = useTeams();
+	const { projects } = useAllVisibleProjects();
 	const [name, setName] = useState('');
 	const [description, setDescription] = useState('');
 	const [selection, setSelection] = useState<Selection>(null);
@@ -42,9 +41,15 @@ export function CreateProjectWithTeamDialog({
 	const startIntake = useStartProjectIntake();
 	const navigate = useNavigate();
 
-	// Existing teams the new project's team can be cloned from. HQ (the internal
-	// team) is excluded — snapshotting it would carry the CEO/Coach into the roster.
-	const sourceTeams = (teams ?? []).filter((t) => !t.is_internal);
+	// Existing teams the new project's team can be cloned from, reached through
+	// each project. HQ (the internal team) is already excluded by
+	// useAllVisibleProjects — snapshotting it would carry the CEO/Coach into the roster.
+	const sourceTeams = projects.map((p) => ({
+		id: p.team_id,
+		slug: p.team_slug,
+		name: p.team_name,
+		agent_count: p.agent_count,
+	}));
 
 	const pending = createProject.isPending || startIntake.isPending;
 	const canSubmit =

--- a/packages/web/src/hooks/use-ai-providers.ts
+++ b/packages/web/src/hooks/use-ai-providers.ts
@@ -27,7 +27,7 @@ const statusKey = ['ai-providers', 'status'] as const;
 function invalidateAll() {
 	queryClient.invalidateQueries({ queryKey: providersKey });
 	queryClient.invalidateQueries({ queryKey: statusKey });
-	queryClient.invalidateQueries({ queryKey: queryKeys.teams.all() });
+	queryClient.invalidateQueries({ queryKey: queryKeys.projects.all() });
 }
 
 export function useAiProviders() {

--- a/packages/web/src/hooks/use-project-intake.ts
+++ b/packages/web/src/hooks/use-project-intake.ts
@@ -50,7 +50,7 @@ export function useStartProjectIntake() {
 			api.post<StartProjectIntakeResult>('/api/project-intakes', input),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: queryKeys.projectIntakes() });
-			queryClient.invalidateQueries({ queryKey: queryKeys.teams.all() });
+			queryClient.invalidateQueries({ queryKey: queryKeys.projects.all() });
 			// Cloning a team mints a new reusable template — refresh the catalog.
 			queryClient.invalidateQueries({ queryKey: queryKeys.teamTemplates() });
 		},

--- a/packages/web/src/hooks/use-projects.ts
+++ b/packages/web/src/hooks/use-projects.ts
@@ -28,6 +28,8 @@ export interface Project {
 	dev_ports: Array<{ container: number; host: number }>;
 	repo_count: number;
 	open_task_count: number;
+	/** Total Agent members on this project's team (the hired roster size). */
+	agent_count: number;
 	/** Agents currently running on this project's team (runtime_status = active). */
 	running_agents_count: number;
 	/** Spend on this project so far today (UTC), in cents. */
@@ -145,7 +147,6 @@ export function useCreateProjectWithTeam() {
 		}) => api.post<ProjectWithTeamResponse>('/api/projects', data),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: queryKeys.projects.all() });
-			queryClient.invalidateQueries({ queryKey: queryKeys.teams.all() });
 			// Cloning a team mints a new reusable template — refresh the catalog.
 			queryClient.invalidateQueries({ queryKey: queryKeys.teamTemplates() });
 		},

--- a/packages/web/src/hooks/use-teams.ts
+++ b/packages/web/src/hooks/use-teams.ts
@@ -28,13 +28,6 @@ export interface Team {
 	created_at: string;
 }
 
-export function useTeams() {
-	return useQuery({
-		queryKey: queryKeys.teams.all(),
-		queryFn: () => api.get<Team[]>('/api/teams'),
-	});
-}
-
 /** The backing team for a project, addressed via the project slug. */
 export function useTeam(projectId: string, enabled = true) {
 	return useQuery({
@@ -64,7 +57,7 @@ export function useUpdateTeam(projectId: string) {
 			};
 		},
 		mergeResponse: (current, updated) => (current ? { ...current, ...updated } : current),
-		invalidateOnSettled: [queryKeys.teams.all(), queryKeys.projects.all()],
+		invalidateOnSettled: [queryKeys.projects.all()],
 		errorMessage: 'Failed to update team',
 	});
 }
@@ -98,9 +91,8 @@ export function useApplyTeamType(projectId: string) {
 		mutationFn: (vars: { template_id: string }) =>
 			api.post<ApplyTeamTypeResult>(`/api/projects/${projectId}/apply-type`, vars),
 		onSuccess: () => {
-			// A merge can add agents — refetch the roster and team views.
+			// A merge can add agents — refetch the roster and project views.
 			queryClient.invalidateQueries({ queryKey: queryKeys.projects.all() });
-			queryClient.invalidateQueries({ queryKey: queryKeys.teams.all() });
 		},
 	});
 }

--- a/packages/web/src/hooks/use-websocket.ts
+++ b/packages/web/src/hooks/use-websocket.ts
@@ -21,7 +21,6 @@ const TABLE_TO_QUERY_KEY: Record<
 		queryKeys.projects.tasks(cid),
 		queryKeys.projects.tasksProgressSummary(cid),
 		queryKeys.projects.all(),
-		queryKeys.teams.all(),
 		// Prefix of `tasksAll(slugs)` — invalidates every cross-project task index.
 		['tasks', 'all'],
 		queryKeys.projectIntakes(),

--- a/packages/web/src/lib/query-keys.ts
+++ b/packages/web/src/lib/query-keys.ts
@@ -31,7 +31,6 @@ export const queryKeys = {
 	ceoConversation: () => ['ceo', 'conversation'],
 
 	teams: {
-		all: () => ['teams'],
 		mcpConnections: (teamId: string) => ['teams', teamId, 'mcp-connections'],
 		oauthConnections: (teamId: string) => ['teams', teamId, 'oauth-connections'],
 	},

--- a/packages/web/src/routes/__root.tsx
+++ b/packages/web/src/routes/__root.tsx
@@ -7,7 +7,7 @@ import {
 	useNavigate,
 } from '@tanstack/react-router';
 import { X } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { AppHeader } from '../components/app-header';
 import { CeoChatWidget } from '../components/ceo-chat/ceo-chat-widget';
 import { MasterKeyGate } from '../components/master-key-gate';
@@ -17,8 +17,8 @@ import { MasterKeyStep, SetupGate } from '../components/setup/setup-wizard';
 import { UpdateBanner } from '../components/update-banner';
 import { SocketProvider } from '../contexts/socket-context';
 import { useActiveProject } from '../hooks/use-active-project';
+import { useProjectsIndex } from '../hooks/use-projects';
 import { useStatus } from '../hooks/use-status';
-import { useTeams } from '../hooks/use-teams';
 import { useShellWebSockets } from '../hooks/use-websocket';
 import { api } from '../lib/api';
 import { queryClient } from '../lib/query-client';
@@ -90,8 +90,14 @@ function AppShell() {
 }
 
 function ShellLayout() {
-	const { data: teams } = useTeams();
-	useShellWebSockets(teams);
+	// Subscribe to every team room (incl. HQ) by deriving rooms from the project
+	// index — teams are reached through their projects.
+	const { data: projects } = useProjectsIndex();
+	const teamRooms = useMemo(
+		() => projects?.map((p) => ({ id: p.team_id, slug: p.team_slug })),
+		[projects],
+	);
+	useShellWebSockets(teamRooms);
 	const matches = useMatches();
 	const bare = matches.some((m) => m.staticData?.bare);
 

--- a/packages/web/src/routes/home/index.tsx
+++ b/packages/web/src/routes/home/index.tsx
@@ -12,7 +12,6 @@ import { useAllAdminMentions } from '../../hooks/use-admin-mentions';
 import { type Approval, useAllApprovals } from '../../hooks/use-approvals';
 import { useProjectIntake } from '../../hooks/use-project-intake';
 import { type ProjectWithTeam, useAllVisibleProjects } from '../../hooks/use-projects';
-import { useTeams } from '../../hooks/use-teams';
 
 const RELATIVE_UNITS: Array<[Intl.RelativeTimeFormatUnit, number]> = [
 	['day', 86400],
@@ -312,17 +311,15 @@ function OtherProjectRow({ project }: { project: ProjectWithTeam }) {
 }
 
 function ProjectsDashboard({
-	teams,
 	projects,
 	needsYouBySlug,
 	onCreate,
 }: {
-	teams: NonNullable<ReturnType<typeof useTeams>['data']>;
 	projects: ProjectWithTeam[];
 	needsYouBySlug: Map<string, number>;
 	onCreate: () => void;
 }) {
-	const showTeamName = teams.length > 1;
+	const showTeamName = projects.length > 1;
 	const isActive = (p: ProjectWithTeam) =>
 		p.running_agents_count > 0 || (needsYouBySlug.get(p.slug) ?? 0) > 0;
 	const active = projects.filter(isActive);
@@ -370,7 +367,6 @@ function ProjectsDashboard({
 }
 
 function HomePage() {
-	const { data: teams, isLoading: teamsLoading } = useTeams();
 	const { projects, isLoading: projectsLoading } = useAllVisibleProjects();
 	const [createOpen, setCreateOpen] = useState(false);
 
@@ -399,7 +395,7 @@ function HomePage() {
 	const noProjectsYet = !projectsLoading && projects.length === 0;
 	const { data: intake } = useProjectIntake(noProjectsYet);
 
-	if (teamsLoading) {
+	if (projectsLoading) {
 		return <div className="px-4 py-4 md:px-6 md:py-5 lg:px-8 lg:py-6 text-text-2">Loading...</div>;
 	}
 
@@ -446,7 +442,6 @@ function HomePage() {
 						</div>
 					) : (
 						<ProjectsDashboard
-							teams={teams ?? []}
 							projects={projects}
 							needsYouBySlug={needsYouBySlug}
 							onCreate={() => setCreateOpen(true)}

--- a/packages/web/test/helpers/seed.ts
+++ b/packages/web/test/helpers/seed.ts
@@ -6,7 +6,7 @@
 // workspace is therefore a team plus its single project; `seedProject` just
 // names that project (a team can never hold a second one).
 
-import { createTestProject } from '@hezo/server/test/helpers/app';
+import { createTestProject, createTestTeam } from '@hezo/server/test/helpers/app';
 import { getTestContext } from './render';
 
 type Auth = {
@@ -43,12 +43,8 @@ export async function seedWorkspace(): Promise<SeededWorkspace> {
 	).data.find((t) => t.name === 'Startup');
 	if (!startup) throw new Error('seedWorkspace: Startup template missing');
 
-	const teamRes = await apiBase('/api/teams', {
-		method: 'POST',
-		headers,
-		body: JSON.stringify({ name: 'Demo Team', template_id: startup.id }),
-	});
-	const team = ((await teamRes.json()) as { data: { id: string; slug: string } }).data;
+	const teamRes = await createTestTeam(db, { name: 'Demo Team', template_id: startup.id });
+	const team = (await teamRes.json()).data;
 
 	// The team's single project; everything project-scoped resolves through it.
 	const projectRes = await createTestProject(db, team.id, { name: 'Demo Project' });

--- a/packages/web/test/query-keys-websocket.test.ts
+++ b/packages/web/test/query-keys-websocket.test.ts
@@ -27,7 +27,6 @@ describe('invalidateQueriesForRowChange uses the queryKeys factory', () => {
 		invalidateQueriesForRowChange(client, SLUG, 'tasks', {});
 		expect(keys).toContainEqual(queryKeys.projects.tasks(SLUG));
 		expect(keys).toContainEqual(queryKeys.projects.all());
-		expect(keys).toContainEqual(queryKeys.teams.all());
 		expect(keys).toContainEqual(queryKeys.projectIntakes());
 	});
 

--- a/packages/web/test/settings-crud.test.tsx
+++ b/packages/web/test/settings-crud.test.tsx
@@ -1,4 +1,4 @@
-import { createTestProject } from '@hezo/server/test/helpers/app';
+import { createTestProject, createTestTeam } from '@hezo/server/test/helpers/app';
 import { fireEvent, waitFor, within } from '@testing-library/react';
 import { expect, test } from 'vitest';
 import { getTestContext, renderApp } from './helpers/render';
@@ -16,16 +16,12 @@ interface CreatedTeam {
 }
 
 async function createTeam(): Promise<CreatedTeam> {
-	const { apiBase, token, db } = getTestContext();
+	const { db } = getTestContext();
 	const name = `Settings Corp ${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
-	const res = await apiBase('/api/teams', {
-		method: 'POST',
-		headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
-		body: JSON.stringify({
-			name,
-			description: 'Build great things',
-			template_id: await startupTemplateId(),
-		}),
+	const res = await createTestTeam(db, {
+		name,
+		description: 'Build great things',
+		template_id: await startupTemplateId(),
 	});
 	const data = (await res.json()) as { data: Omit<CreatedTeam, 'projectSlug'> };
 	const projectRes = await createTestProject(db, data.data.id, { name: 'Work Project' });

--- a/packages/web/test/team-summary-collapse.test.tsx
+++ b/packages/web/test/team-summary-collapse.test.tsx
@@ -1,14 +1,12 @@
+import { createTestTeam } from '@hezo/server/test/helpers/app';
 import { test } from 'vitest';
 import { getTestContext, renderApp } from './helpers/render';
 import { seedWorkspace } from './helpers/seed';
 
 async function createBareTeam(): Promise<{ slug: string }> {
-	const { apiBase, token } = getTestContext();
-	const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
-	const res = await apiBase('/api/teams', {
-		method: 'POST',
-		headers,
-		body: JSON.stringify({ name: `Light Team ${Math.random().toString(36).slice(2, 8)}` }),
+	const { db } = getTestContext();
+	const res = await createTestTeam(db, {
+		name: `Light Team ${Math.random().toString(36).slice(2, 8)}`,
 	});
 	return ((await res.json()) as { data: { slug: string } }).data;
 }


### PR DESCRIPTION
## What & why

Hezo is project-centric: a project owns exactly one team (1:1) and all project work is addressed by **project slug** (`/api/projects/:projectId/...`). An audit of the full API surface found the codebase was already almost entirely project-centric — the web router is project-centric (legacy `/teams/...` URLs just redirect Home) and nearly every backend route is project-addressed. Only two genuinely **team-addressed** endpoints remained, plus dead middleware. This removes them so there are no team-centric APIs left.

## Changes

**Backend**
- Remove `GET /api/teams` and `POST /api/teams` (`routes/teams.ts`). `POST /api/teams` was a near-duplicate of project creation. The project-addressed handlers (`/api/projects/:projectId/team`, `save-as-template`, `apply-type`, `project-intake/.../skip-questions`) are unchanged.
- Remove the dead `requireTeamAccess` / `requireTeamAccessMiddleware` (`middleware/auth.ts`) — only `requireProjectAccessMiddleware` was ever mounted.
- Extend `GET /api/projects` with an `agent_count` field (the one field the create-project dialog needed from the old team list).

**Frontend**
- Drop `useTeams()` and `queryKeys.teams.all()`. The home page (loading gate), the shell WebSocket room subscriptions, and the create-project "copy an existing team" picker now derive teams from the project index (`useProjectsIndex` / `useAllVisibleProjects`); the shell uses the unfiltered index so the HQ room stays subscribed.
- Repoint team-list cache invalidations (`use-ai-providers`, `use-project-intake`, `use-projects`, `use-teams`, `use-websocket`) to `queryKeys.projects.all()`.

**Tests**
- Add a shared `createTestTeam` helper (`test/helpers/app.ts`) that calls the `createTeam` service directly and — like the old route called with the admin token — adds the admin as a member so admin-authored actions (mentions, reactions, `created_by`, actor names, ui-state) resolve. Returns a `fetch`-Response shape so existing `.json()` → `.data` extraction is unchanged.
- Migrate ~95 server + 3 web test setups off `POST /api/teams` to the helper. Rewrite the team-CRUD, `cross-team-isolation` (membership scoping now asserted against `GET /api/projects`), and `auth-middleware`/`auth-routes` suites against surviving routes. Add a regression test asserting the bare routes now `404`.

**Docs**
- Update `.dev/api.md` (Teams section) and `.dev/schema.md`.

## Verification

- `bun run typecheck` — clean (server + web).
- `bun run check` — exit 0 (only pre-existing warnings).
- Server vitest: all migration-related suites pass. The only failures are **environmental** in this sandbox and unrelated to this change — `git.test.ts` (git-worktree support) and one `ssh-agent-server` signing test (`ssh-keygen` not installed); neither references the team API.
- Web vitest: **364/364 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012KCcrgeQwa2UYJ9hiY4xC1)_