### PR TITLE
fix(web): restore colour-coded tint pills in the task header

### DIFF
--- a/packages/web/src/components/task-detail/task-header.tsx
+++ b/packages/web/src/components/task-detail/task-header.tsx
@@ -2,6 +2,8 @@ import { Link } from '@tanstack/react-router';
 import { ChevronRight } from 'lucide-react';
 import { type Task, useTaskAncestors } from '../../hooks/use-tasks';
 import { MarkdownProse } from '../markdown-prose';
+import { TaskPriorityBadge } from '../task-priority-badge';
+import { TaskStatusBadge } from '../task-status-badge';
 import { Badge } from '../ui/badge';
 
 /** Compact wall-clock duration ("35s", "7m 41s", "1h 4m") from a seconds total. */
@@ -61,23 +63,20 @@ export function TaskHeader({ task, projectId, taskId, taskProjectSlug }: TaskHea
 			</nav>
 			<h1 className="text-xl font-medium mb-3">{task.title}</h1>
 
-			{/* Wire spec — task header reads as inline mono metadata (status · priority ·
-			    assignee) with a runs / duration / cost summary pushed right; the
-			    quiet-tint pills move out of the header. */}
-			<div className="mb-4 flex flex-wrap items-center gap-x-3 gap-y-1.5 font-mono text-[13px]">
-				<span className="text-text-2" data-testid="task-status-inline">
-					{task.status}
-				</span>
-				<span className="text-text-2" data-testid="task-priority-inline">
-					{task.priority}
-				</span>
+			{/* Wire spec — status / priority / assignee render as quiet-tint badges
+			    (treatment A, the default), color-coding state at a glance the same way
+			    the task list does, with a mono runs / duration / cost summary pushed
+			    right. Assignee carries no semantic state, so it stays neutral. */}
+			<div className="mb-4 flex flex-wrap items-center gap-x-2 gap-y-1.5">
+				<TaskStatusBadge status={task.status} testId="task-status-inline" />
+				<TaskPriorityBadge priority={task.priority} testId="task-priority-inline" />
 				{task.assignee_id && (
-					<span className="min-w-0 truncate text-text-2" data-testid="task-assignee-inline">
-						{task.assignee_slug ?? task.assignee_name}
-					</span>
+					<Badge color="neutral" className="max-w-[12rem]" testId="task-assignee-inline">
+						<span className="truncate">{task.assignee_slug ?? task.assignee_name}</span>
+					</Badge>
 				)}
 				{!task.has_active_run && task.queued_wakeup && (
-					<Badge color="blue" className="gap-1" data-testid="task-queued-badge">
+					<Badge color="blue" className="gap-1" testId="task-queued-badge">
 						<span className="inline-block w-1.5 h-1.5 rounded-full bg-info-soft-fg" />
 						{task.queued_wakeup.reason === 'project_at_capacity'
 							? 'Queued — project at capacity'
@@ -85,7 +84,10 @@ export function TaskHeader({ task, projectId, taskId, taskProjectSlug }: TaskHea
 					</Badge>
 				)}
 				{task.run_count > 0 && (
-					<span className="text-text-3 sm:ml-auto" data-testid="task-run-summary">
+					<span
+						className="font-mono text-[13px] text-text-3 sm:ml-auto"
+						data-testid="task-run-summary"
+					>
 						{task.run_count} {task.run_count === 1 ? 'run' : 'runs'}
 						{task.total_duration_seconds > 0 && ` · ${formatDuration(task.total_duration_seconds)}`}
 						{task.total_cost_cents > 0 && ` · $${(task.total_cost_cents / 100).toFixed(2)}`}

--- a/packages/web/src/components/task-list.tsx
+++ b/packages/web/src/components/task-list.tsx
@@ -9,6 +9,7 @@ import { nestTasksForDisplay } from '../lib/nest-tasks-for-display';
 import { AdminApprovalsBanner } from './admin-approvals-banner';
 import { CreateTaskDialog } from './create-task-dialog';
 import { ProjectTaskListHeader } from './project-task-list-header';
+import { TaskPriorityBadge } from './task-priority-badge';
 import { TaskRunDot } from './task-run-dot';
 import { TaskStatusBadge } from './task-status-badge';
 import { Badge } from './ui/badge';
@@ -17,13 +18,6 @@ import { type Column, DataTable } from './ui/data-table';
 import { EmptyState } from './ui/empty-state';
 import { MultiSelect, type MultiSelectOption } from './ui/multi-select';
 import { Tooltip } from './ui/tooltip';
-
-const priorityColors: Record<string, string> = {
-	urgent: 'danger',
-	high: 'warning',
-	medium: 'info',
-	low: 'neutral',
-};
 
 const ALL_STATUSES = Object.values(TaskStatus) as string[];
 const TERMINAL_STATUS_SET = new Set<string>(TERMINAL_TASK_STATUSES);
@@ -323,9 +317,7 @@ export function TaskList({ projectId }: TaskListProps) {
 			header: 'Priority',
 			width: '80px',
 			hideOnMobile: true,
-			render: (row) => (
-				<Badge color={priorityColors[row.priority] as 'neutral'}>{row.priority}</Badge>
-			),
+			render: (row) => <TaskPriorityBadge priority={row.priority} />,
 		},
 		{
 			key: 'assignee',

--- a/packages/web/src/components/task-priority-badge.tsx
+++ b/packages/web/src/components/task-priority-badge.tsx
@@ -1,0 +1,18 @@
+import { taskPriorityColor } from '../lib/status-meta';
+import { Badge } from './ui/badge';
+
+export function TaskPriorityBadge({
+	priority,
+	className,
+	testId,
+}: {
+	priority: string;
+	className?: string;
+	testId?: string;
+}) {
+	return (
+		<Badge color={taskPriorityColor(priority)} className={className} testId={testId}>
+			{priority}
+		</Badge>
+	);
+}

--- a/packages/web/src/components/task-status-badge.tsx
+++ b/packages/web/src/components/task-status-badge.tsx
@@ -2,9 +2,17 @@ import { formatTaskStatus } from '@hezo/shared';
 import { taskStatusColor } from '../lib/status-meta';
 import { Badge } from './ui/badge';
 
-export function TaskStatusBadge({ status, className }: { status: string; className?: string }) {
+export function TaskStatusBadge({
+	status,
+	className,
+	testId,
+}: {
+	status: string;
+	className?: string;
+	testId?: string;
+}) {
 	return (
-		<Badge color={taskStatusColor(status)} className={className}>
+		<Badge color={taskStatusColor(status)} className={className} testId={testId}>
 			{formatTaskStatus(status)}
 		</Badge>
 	);

--- a/packages/web/src/components/ui/badge.tsx
+++ b/packages/web/src/components/ui/badge.tsx
@@ -74,6 +74,8 @@ interface BadgeProps {
 	mono?: boolean;
 	children: ReactNode;
 	className?: string;
+	/** Rendered as `data-testid` so callers can target the pill in tests. */
+	testId?: string;
 }
 
 export function Badge({
@@ -82,6 +84,7 @@ export function Badge({
 	mono = false,
 	children,
 	className = '',
+	testId,
 }: BadgeProps) {
 	const tone = resolveTone(color);
 	const base =
@@ -90,7 +93,10 @@ export function Badge({
 
 	if (variant === 'dot') {
 		return (
-			<span className={`${base} bg-transparent px-0.5 text-text-2 ${fontCls} ${className}`}>
+			<span
+				className={`${base} bg-transparent px-0.5 text-text-2 ${fontCls} ${className}`}
+				data-testid={testId}
+			>
 				<span className={`h-[7px] w-[7px] shrink-0 rounded-full ${dotMap[tone]}`} />
 				{children}
 			</span>
@@ -100,11 +106,16 @@ export function Badge({
 		return (
 			<span
 				className={`${base} border border-border-strong bg-transparent text-text-2 ${fontCls} ${className}`}
+				data-testid={testId}
 			>
 				{children}
 			</span>
 		);
 	}
 	const toneCls = variant === 'solid' ? solidMap[tone] : tintMap[tone];
-	return <span className={`${base} ${toneCls} ${fontCls} ${className}`}>{children}</span>;
+	return (
+		<span className={`${base} ${toneCls} ${fontCls} ${className}`} data-testid={testId}>
+			{children}
+		</span>
+	);
 }

--- a/packages/web/src/lib/status-meta.ts
+++ b/packages/web/src/lib/status-meta.ts
@@ -1,4 +1,10 @@
-import { AgentRuntimeStatus, ApprovalType, formatTaskStatus, TaskStatus } from '@hezo/shared';
+import {
+	AgentRuntimeStatus,
+	ApprovalType,
+	formatTaskStatus,
+	TaskPriority,
+	TaskStatus,
+} from '@hezo/shared';
 import type { BadgeColor } from '../components/ui/badge';
 
 /**
@@ -36,6 +42,20 @@ export function taskStatusColor(status: string): BadgeColor {
 /** Color + label for a task status (label sourced from the shared label map). */
 export function taskStatusMeta(status: string): BadgeMeta {
 	return { color: taskStatusColor(status), label: formatTaskStatus(status) };
+}
+
+// Priority maps to the spec's semantic tints: urgent = danger, high = warning,
+// medium = info, low = neutral (the "Quiet tint" badge treatment).
+const TASK_PRIORITY_COLORS: Record<TaskPriority, BadgeColor> = {
+	[TaskPriority.Urgent]: 'danger',
+	[TaskPriority.High]: 'warning',
+	[TaskPriority.Medium]: 'info',
+	[TaskPriority.Low]: 'neutral',
+};
+
+/** Badge color for a task priority, defaulting to neutral for unknown values. */
+export function taskPriorityColor(priority: string): BadgeColor {
+	return TASK_PRIORITY_COLORS[priority as TaskPriority] ?? 'neutral';
 }
 
 export const AGENT_RUNTIME_STATUS_META: Record<AgentRuntimeStatus, BadgeMeta> = {

--- a/packages/web/test/task-header-summary.test.tsx
+++ b/packages/web/test/task-header-summary.test.tsx
@@ -2,10 +2,10 @@ import { expect, test } from 'vitest';
 import { getTestContext, renderApp } from './helpers/render';
 import { seedProject, seedTask, seedWorkspace } from './helpers/seed';
 
-// The Wire task header renders status / priority / assignee as inline mono
-// metadata (not quiet-tint pills) with a runs · duration · cost summary derived
-// from the task's runs + cost entries.
-test('task header renders inline mono status + a runs/duration/cost summary', async () => {
+// The Wire task header renders status / priority / assignee as quiet-tint badges
+// (treatment A — colour-coded rounded pills, the design-system default) plus a
+// mono runs · duration · cost summary derived from the task's runs + cost entries.
+test('task header renders colour-coded status/priority pills + a runs/duration/cost summary', async () => {
 	const ref = { projectSlug: '', taskId: '' };
 	const { findByTestId, router } = await renderApp({
 		initialPath: '/',
@@ -15,6 +15,11 @@ test('task header renders inline mono status + a runs/duration/cost summary', as
 			const agent = ws.agents[0];
 			const task = await seedTask(ws, project, { title: 'Header task', assignee_id: agent.id });
 			const db = getTestContext().db;
+			// Pin a known status + priority so the colour-coded tints are deterministic.
+			await db.query(
+				`UPDATE tasks SET status='in_progress'::task_status, priority='high'::task_priority WHERE id=$1`,
+				[task.id],
+			);
 			// One finished 41s run + a $1.86 cost entry (cost_entries has no team_id since 004).
 			await db.query(
 				`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at, finished_at)
@@ -36,13 +41,28 @@ test('task header renders inline mono status + a runs/duration/cost summary', as
 		params: { projectId: ref.projectSlug, taskId: ref.taskId },
 	});
 
-	// Status is the raw lowercase enum in mono — not the capitalized quiet-tint pill.
+	// Status is now a quiet-tint pill: the capitalized label on a rounded soft
+	// background, not the raw lowercase enum in mono.
 	const status = await findByTestId('task-status-inline');
-	expect(status.textContent).toMatch(/^[a-z_]+$/);
-	expect(status.parentElement?.className ?? '').toContain('font-mono');
+	expect(status.textContent).toBe('In Progress');
+	expect(status.className).toContain('rounded-full');
+	expect(status.className).toContain('bg-warning-soft');
+	expect(status.className).not.toContain('font-mono');
 
+	// Priority is colour-coded too (high → warning tint).
+	const priority = await findByTestId('task-priority-inline');
+	expect(priority.textContent).toBe('high');
+	expect(priority.className).toContain('bg-warning-soft');
+
+	// Assignee carries no semantic state, so it renders as a neutral pill.
+	const assignee = await findByTestId('task-assignee-inline');
+	expect(assignee.className).toContain('rounded-full');
+	expect(assignee.className).toContain('bg-neutral-soft');
+
+	// The runs/duration/cost summary stays mono.
 	const summary = await findByTestId('task-run-summary');
 	expect(summary.textContent).toContain('1 run');
 	expect(summary.textContent).toContain('41s');
 	expect(summary.textContent).toContain('$1.86');
+	expect(summary.className).toContain('font-mono');
 });


### PR DESCRIPTION
## What & why

The task-detail header rendered **status / priority / assignee** as flat mono text (badge **treatment C** in the design spec), so the colour-coded rounded backgrounds the design system defines for these tags were missing — the regression called out against the attached design spec.

The spec's component library defines **treatment A "Quiet tint" as the default** for status/priority badges (soft tinted background + colour-coded foreground). Every other task surface (task list, sub-tasks, dependencies, home list) already uses these pills via `TaskStatusBadge`; the header was the lone outlier left on plain text.

## Changes

- **`task-header.tsx`** — status → `TaskStatusBadge`, priority → new `TaskPriorityBadge` (both colour-coded quiet-tint pills), assignee → neutral pill (it carries no semantic state). The runs / duration / cost summary stays mono.
- **`status-meta.ts`** — added `taskPriorityColor()` backed by a `Record<TaskPriority, BadgeColor>` map (`urgent→danger, high→warning, medium→info, low→neutral`), consolidating the map that was previously duplicated inline in `task-list.tsx`.
- **`task-priority-badge.tsx`** — new component, parallel to `TaskStatusBadge`.
- **`task-list.tsx`** — priority column now uses `TaskPriorityBadge`; removed the local `priorityColors` map.
- **`badge.tsx`** — added a `testId` passthrough (rendered as `data-testid`) so the pills keep their test hooks.

Colours come from the existing `--*-soft` / `--*-soft-fg` OKLCH tokens already defined in `index.css` (matching design-spec page 2) — no new tokens.

## Verification

- `bun run typecheck` ✅ · `bunx biome check .` ✅ · full build (pre-commit hook) ✅
- Updated `task-header-summary.test.tsx` (it previously asserted the old mono treatment C) to assert the quiet-tint pills: `In Progress` label on a `rounded-full bg-warning-soft` pill, `high` on warning tint, assignee on `bg-neutral-soft`, summary still mono. Re-ran `task-header-summary`, `task-list`, `task-create` tests — all green.
- Rendered the result in Chromium (light + dark) to confirm it matches the spec's "Quiet tint" treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUKxmab4rZX6WfNKLHBvNL

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUKxmab4rZX6WfNKLHBvNL)_