### PR TITLE
fix(egress): bind per-host MITM servers to explicit ports; pre-install bun+unzip

### DIFF
--- a/.dev/egress.md
+++ b/.dev/egress.md
@@ -20,7 +20,7 @@ The cert is world-readable so the unprivileged in-container `node` user can veri
 
 ## Proxy lifecycle
 
-The proxy is implemented in-house (`packages/server/src/services/egress/proxy.ts`) — no third-party MITM library. One instance per run, listening on `127.0.0.1` in the `[20000, 29999]` port range. The `PortAllocator` reuses the previous port for the same agent ID where possible (debugging-friendly) and probes for binding availability before claiming.
+The proxy is implemented in-house (`packages/server/src/services/egress/proxy.ts`) — no third-party MITM library. One instance per run, its front server listening on `127.0.0.1` in the `[20000, 29999]` port range. The `PortAllocator` reuses the previous port for the same agent ID where possible (debugging-friendly) and probes for binding availability before claiming. Per-host MITM servers use a **separate** allocator over `[30000, 39999]`, so per-host churn never contends with front-proxy binds.
 
 `EgressProxy.allocateRunProxy(runId, scope)` returns `{ proxyHost: 'host.docker.internal', proxyPort }`. `releaseRunProxy(runId)` shuts the instance down at run cleanup, closing the front server and every per-host server.
 
@@ -32,9 +32,9 @@ Each run's proxy is a single front `http.Server` on the allocated port. Plain pr
 
 For a CONNECT, the proxy looks up (or builds) a **per-host `https.Server`** keyed by the CONNECT hostname, minting that host's leaf cert from the CA via mockttp's `getCA`/`generateCertificate`. The agent's raw CONNECT socket is bridged into that per-host server over a loopback `net.connect`; TLS terminates there, the decrypted request runs through substitution, and a fresh upstream request carries the substituted values on.
 
-Per-host servers are keyed **by hostname → live server object**, not by a cached bare port. Before reuse the proxy checks the server still owns its recorded port (`server.listening && server.address().port === recordedPort`); a server that has died or lost its port is rebuilt on the next tunnel. This makes the historical failure mode — a hostname routed to an ephemeral port that has since died (ECONNREFUSED) or been recycled to another host's server (cross-host wrong-SAN cert) — structurally impossible: the hostname never routes through a port that isn't currently owned by that host's live server. Concurrent first-touches for the same host share one in-flight build so a run never spins up duplicate servers.
+Per-host servers are keyed **by hostname → live server object**. Each binds an **explicitly allocated** loopback port (from the dedicated `[30000, 39999]` allocator) and records that chosen port — it is **never** read back from `server.address()`, which is unreliable under Bun (it has reported one shared port for every per-host server in a run, collapsing all hosts onto one server so every host but one was served the wrong leaf cert). Reuse is gated on `server.listening` alone; a server that has died is rebuilt on the next tunnel. The cross-host wrong-SAN failure mode is structurally impossible because the allocator never hands two live servers the same port — a hostname's tunnel always dials the port that hostname's own server was bound to. Concurrent first-touches for the same host share one in-flight build so a run never spins up duplicate servers.
 
-The ownership check and the loopback dial must be **atomic**. The bridge (`bridgeConnect`) re-validates `serverOwnsPort` synchronously and rebuilds a stale record, then calls `net.connect` with **no further `await`** before the dial — so a per-host server that dies after lookup cannot have its freed ephemeral port recycled to another host's server between the check and the connect. Re-checking only at lookup time (with an `await` separating it from the dial) leaves a check→dial window that re-opens the cross-host wrong-SAN serving the per-host keying is meant to close.
+The liveness re-check and the loopback dial must be **atomic**. The bridge (`bridgeConnect`) re-checks `server.listening` synchronously and rebuilds a dead record, then calls `net.connect` with **no further `await`** before the dial — so a per-host server that dies after lookup is never dialed. The dialed port is the explicitly allocated one the server was bound to, so the tunnel always reaches that host's leaf cert.
 
 ## Container wiring
 
@@ -114,6 +114,8 @@ The proxy runs on Bun in dev/prod. Bun's TLS stack diverges from Node's in ways 
 
 So TLS can only be terminated by a genuinely-listening server reached over a socket, and a single SNI-multiplexed server can't serve per-host certs — hence one listening `https.Server` per host, bridged from the CONNECT socket over loopback. Do not re-attempt the broken approaches above to "simplify"; they pass under Node/vitest and fail only on the production Bun runtime, so a Node-only test gives false confidence (this is why the egress proxy has a `bun test` tier).
 
+Recovering a per-host server's port from `server.address().port` after `listen(0)` is **also unreliable under Bun**: it has returned a single shared port (e.g. `49621`) for *every* per-host server in a run, so all hosts' CONNECT tunnels dialed one server and were served the wrong host's leaf cert (`ERR_TLS_CERT_ALTNAME_INVALID` / "no alternative certificate subject name"). Per-host servers therefore bind an **explicitly allocated** port and treat it as authoritative — they never read it back from `address()`. (One-shot servers elsewhere — the front server, test upstreams — can still use `listen(0)`+`address()` safely; the hazard is specific to a keyed cache of servers dialed by recorded port.)
+
 Upstream cert verification under Bun checks the connection's Host header verbatim, which carries the port for non-default ports and fails against a bare-host SAN. The forwarder drops the client Host header on the TLS path so the runtime regenerates it from the connection target.
 
 Cert generation uses mockttp's CA (`@peculiar/x509`), the same path the tests trust.
@@ -128,5 +130,5 @@ Cert generation uses mockttp's CA (`@peculiar/x509`), the same path the tests tr
 - `egress-proxy-docker.test.ts` — real container exercising substitution through curl with the CA bind-mounted into the trust store
 
 `packages/server/test/bun/` (run under `bun test` on the production runtime — Node/vitest can't see the Bun TLS/connection divergences):
-- `egress-proxy.bun.test.ts` — HTTPS MITM termination + per-host cert routing under Bun
+- `egress-proxy.bun.test.ts` — HTTPS MITM termination + per-host cert routing under Bun, including the held-open-connection / distinct-per-host-port regression for the `address()` collapse
 - `egress-streaming.bun.test.ts` — long-lived SSE responses pipe through incrementally, and an open stream is severed (not leaked) on run teardown without parking the close deadline

--- a/docker/Dockerfile.agent-base
+++ b/docker/Dockerfile.agent-base
@@ -1,8 +1,9 @@
 FROM node:24-slim
 
-# Install common development tools
+# Install common development tools. `unzip` is required by the upstream bun.sh
+# installer and other `curl | bash` installers agents may run at runtime.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl jq openssh-client ca-certificates python3 socat sudo \
+    curl jq unzip openssh-client ca-certificates python3 socat sudo \
     && rm -rf /var/lib/apt/lists/*
 
 # Build git from source. The host creates per-task worktrees with
@@ -48,6 +49,13 @@ RUN npm install -g @anthropic-ai/claude-code \
     && npm install -g @google/gemini-cli \
     && npm install -g opencode-ai \
     && npm install -g @moonshot-ai/kimi-code
+
+# Pre-install Bun (latest) for agent-authored JS/TS projects — the common case,
+# and the runtime Hezo itself uses. Installed globally via npm so `bun`/`bunx`
+# land on the shared PATH for both root and the `node` user (matching the AI CLIs
+# above). The trailing `bun --version` fails the build if the install is broken.
+RUN npm install -g bun \
+    && bun --version
 
 # SSH agent bridge: in-container Unix socket relayed to host TCP. Used so
 # the same wire-up runs on macOS Docker Desktop (which does not forward

--- a/packages/server/src/services/egress/port-allocator.ts
+++ b/packages/server/src/services/egress/port-allocator.ts
@@ -3,6 +3,12 @@ import { createServer } from 'node:net';
 export const EGRESS_PORT_RANGE_START = 20000;
 export const EGRESS_PORT_RANGE_END = 29999;
 
+// Per-host MITM servers get their own loopback range, separate from the
+// front-proxy range above, so per-host churn never contends with front-proxy
+// bind attempts and the two allocators never hand out the same port.
+export const EGRESS_HOST_PORT_RANGE_START = 30000;
+export const EGRESS_HOST_PORT_RANGE_END = 39999;
+
 /**
  * Hand out loopback TCP ports for per-run egress proxies. The allocator
  * remembers the last-used port per `agentId` so debugging sessions land on

--- a/packages/server/src/services/egress/proxy.ts
+++ b/packages/server/src/services/egress/proxy.ts
@@ -22,7 +22,11 @@ import { closeServerWithDeadline } from '../../lib/net';
 import { logger } from '../../logger';
 import { type EgressAuditEvent, recordEgressEvent } from './audit';
 import type { HezoCA } from './ca';
-import { PortAllocator } from './port-allocator';
+import {
+	EGRESS_HOST_PORT_RANGE_END,
+	EGRESS_HOST_PORT_RANGE_START,
+	PortAllocator,
+} from './port-allocator';
 import {
 	loadAllSecrets,
 	PLACEHOLDER_PROBE_REGEX,
@@ -64,6 +68,10 @@ export interface EgressProxyDeps {
 	masterKeyManager: MasterKeyManager;
 	ca: HezoCA;
 	portAllocator?: PortAllocator;
+	/** Allocator for per-host MITM server loopback ports (range [30000,39999]).
+	 * Separate from `portAllocator` (front-proxy range [20000,29999]) so per-host
+	 * churn never contends with front-proxy binds. Injectable for tests. */
+	hostPortAllocator?: PortAllocator;
 	proxyHost?: string;
 	/** Interface the per-run proxy binds to. Defaults to `127.0.0.1`
 	 * (loopback-only — agent containers reach it via `host.docker.internal`,
@@ -94,15 +102,22 @@ export interface AllocatedRunProxy {
 /** How many ports to try binding before giving up allocating a run's proxy. */
 const EGRESS_BIND_ATTEMPTS = 5;
 
+/** How many ports to try binding before giving up on a per-host MITM server. */
+const HOST_BIND_ATTEMPTS = 5;
+
 export class EgressProxy {
 	private readonly runs = new Map<string, RunProxyInstance>();
 	private readonly portAllocator: PortAllocator;
+	private readonly hostPortAllocator: PortAllocator;
 	private readonly proxyHost: string;
 	private readonly proxyBindHost: string;
 	private mintCa: Promise<CA> | null = null;
 
 	constructor(private readonly deps: EgressProxyDeps) {
 		this.portAllocator = deps.portAllocator ?? new PortAllocator();
+		this.hostPortAllocator =
+			deps.hostPortAllocator ??
+			new PortAllocator(EGRESS_HOST_PORT_RANGE_START, EGRESS_HOST_PORT_RANGE_END);
 		this.proxyHost = deps.proxyHost ?? PROXY_HOST;
 		this.proxyBindHost = deps.proxyBindHost ?? PROXY_BIND_HOST;
 	}
@@ -147,6 +162,7 @@ export class EgressProxy {
 					masterKeyManager: this.deps.masterKeyManager,
 					getMintCa: () => this.getMintCa(),
 					upstreamTrustedCAs: this.deps.extraUpstreamTrustedCAs,
+					hostPortAllocator: this.hostPortAllocator,
 				});
 
 				try {
@@ -205,6 +221,7 @@ interface RunProxyConfig {
 	masterKeyManager: MasterKeyManager;
 	getMintCa: () => Promise<CA>;
 	upstreamTrustedCAs?: string | string[];
+	hostPortAllocator: PortAllocator;
 }
 
 /** A per-host internal TLS-terminating server. The agent's CONNECT socket is
@@ -364,7 +381,8 @@ class RunProxyInstance {
 		this.upstreamAgent.destroy();
 
 		const closables: Array<Promise<void>> = [];
-		for (const [host, { server }] of this.hostServers.entries()) {
+		for (const [host, { server, port }] of this.hostServers.entries()) {
+			this.cfg.hostPortAllocator.release(port);
 			closables.push(closeServer(server, `${this.cfg.scope.label}/${host}`));
 		}
 		this.hostServers.clear();
@@ -395,14 +413,14 @@ class RunProxyInstance {
 	}
 
 	/** Bridge a CONNECT tunnel into the host's per-host TLS server. The dial
-	 * re-validates port ownership synchronously and rebuilds a stale server,
-	 * then connects with no further `await` — only synchronous code separates the
-	 * ownership check from the `netConnect`, so a concurrently-built server can
-	 * never recycle the freed ephemeral port in between and route the tunnel to
-	 * another host's leaf cert. */
+	 * re-checks liveness synchronously and rebuilds a dead server, then connects
+	 * with no further `await` — so a server that died after lookup is never dialed.
+	 * The dialed port is the one this host's server was explicitly bound to (never
+	 * read back from `address()`), so the tunnel always reaches that host's leaf
+	 * cert. */
 	private async bridgeConnect(host: string, client: Socket, head: Buffer): Promise<void> {
 		let rec = await this.ensureHostServer(host);
-		while (!this.closed && !serverOwnsPort(rec)) {
+		if (!this.closed && !rec.server.listening) {
 			rec = await this.buildHostServer(host);
 		}
 		if (this.closed) {
@@ -432,17 +450,15 @@ class RunProxyInstance {
 	}
 
 	/** Return a live per-host TLS server, rebuilding it if the cached one has
-	 * stopped owning its port. Concurrent first-touches for the same host share
-	 * one in-flight build so the run never spins up duplicate servers. */
+	 * stopped listening. Concurrent first-touches for the same host share one
+	 * in-flight build so the run never spins up duplicate servers. */
 	private ensureHostServer(host: string): Promise<HostServer> {
 		const existing = this.hostServers.get(host);
-		// Reuse only a live entry that is the *sole* claimant of its port. Under Bun
-		// a stale entry can keep reporting a port that another host's live server has
-		// since taken over (`address()` lies), so `serverOwnsPort` alone can't tell a
-		// real owner from a zombie pointing at someone else's port — dialing it would
-		// serve the other host's leaf cert. Requiring unique ownership forces a
-		// rebuild onto a fresh, exclusive port instead.
-		if (existing && serverOwnsPort(existing) && this.portUniquelyOwnedBy(host, existing.port)) {
+		// Liveness is `server.listening` alone. Each per-host server owns an
+		// explicitly allocated port, so a live entry can never be a zombie pointing
+		// at another host's port (the `address()`-lies failure mode that needed the
+		// old uniqueness check). A closed server is rebuilt onto a fresh port.
+		if (existing?.server.listening) {
 			return Promise.resolve(existing);
 		}
 
@@ -461,59 +477,80 @@ class RunProxyInstance {
 		const stale = this.hostServers.get(host);
 		if (stale) {
 			this.hostServers.delete(host);
+			this.cfg.hostPortAllocator.release(stale.port);
 			void closeServer(stale.server, `${this.cfg.scope.label}/${host}`);
 		}
 
 		const ca = await this.cfg.getMintCa();
 		const leaf = await ca.generateCertificate(host);
-		const server = createHttpsServer({ key: leaf.key, cert: leaf.cert }, (req, res) => {
-			this.forward(true, host, req, res).catch((e: Error) => this.onHandlerError(res, e));
-		});
-		server.on('connection', (socket) => this.trackSocket(socket as Socket, `perhost:${host}`));
-		server.on('clientError', (_err, socket) => socket.destroy());
-		server.on('error', (err) => {
-			log.warn('egress per-host server error', {
-				run: ref(this.cfg.scope.label, this.cfg.runId),
-				host,
-				error: err.message,
-			});
-		});
 
-		await new Promise<void>((resolve, reject) => {
-			const onErr = (err: Error) => reject(err);
-			server.once('error', onErr);
-			server.listen(0, '127.0.0.1', () => {
-				server.removeListener('error', onErr);
-				resolve();
-			});
-		});
+		// Bind to an EXPLICITLY allocated loopback port and treat that port as
+		// authoritative. `server.listen(0)` + `server.address().port` is unreliable
+		// under Bun — it has reported the same port for every per-host server,
+		// collapsing all hosts onto one and serving the wrong leaf cert
+		// (ERR_TLS_CERT_ALTNAME_INVALID). The port must be one we chose, never read
+		// back from `address()`. Allocate-and-bind with retry since a probed-free
+		// port can still lose the bind race (mirrors the front-server allocation).
+		const reserved: number[] = [];
+		let lastReason = 'no bindable loopback port for per-host server';
+		try {
+			for (let attempt = 0; attempt < HOST_BIND_ATTEMPTS; attempt++) {
+				// No agentId: per-host ports need no per-agent stickiness, and passing
+				// it would pollute the front proxy's lastForAgent map.
+				const port = await this.cfg.hostPortAllocator.allocate();
+				reserved.push(port);
 
-		if (this.closed) {
-			await closeServer(server, `${this.cfg.scope.label}/${host}`);
-			throw new Error('proxy closed');
+				const server = createHttpsServer({ key: leaf.key, cert: leaf.cert }, (req, res) => {
+					this.forward(true, host, req, res).catch((e: Error) => this.onHandlerError(res, e));
+				});
+				server.on('connection', (socket) => this.trackSocket(socket as Socket, `perhost:${host}`));
+				server.on('clientError', (_err, socket) => socket.destroy());
+
+				try {
+					await new Promise<void>((resolve, reject) => {
+						const onErr = (err: Error) => reject(err);
+						server.once('error', onErr);
+						server.listen(port, '127.0.0.1', () => {
+							server.removeListener('error', onErr);
+							resolve();
+						});
+					});
+				} catch (e) {
+					// Lost the bind race; keep this port reserved so the next attempt
+					// lands elsewhere, and try another port.
+					lastReason = (e as Error).message;
+					server.close();
+					continue;
+				}
+
+				// Bound — attach the long-lived error logger now (a pre-bind error
+				// rejects the listen promise above instead of being logged here).
+				server.on('error', (err) => {
+					log.warn('egress per-host server error', {
+						run: ref(this.cfg.scope.label, this.cfg.runId),
+						host,
+						error: err.message,
+					});
+				});
+
+				if (this.closed) {
+					for (const p of reserved) this.cfg.hostPortAllocator.release(p);
+					await closeServer(server, `${this.cfg.scope.label}/${host}`);
+					throw new Error('proxy closed');
+				}
+
+				const rec: HostServer = { server, port };
+				this.hostServers.set(host, rec);
+				for (const p of reserved) {
+					if (p !== port) this.cfg.hostPortAllocator.release(p);
+				}
+				return rec;
+			}
+		} catch (e) {
+			lastReason = (e as Error).message;
 		}
-
-		const port = (server.address() as { port: number }).port;
-		// The OS just handed this port to the new server, so any other host entry
-		// still claiming it lost it and is stale — drop those entries so no two
-		// hosts ever map to one port (the cross-host wrong-cert invariant). The
-		// orphaned server is already off the port; let it be GC'd rather than
-		// risk closing a live server on a mis-reported port.
-		for (const [h, r] of this.hostServers) {
-			if (h !== host && r.port === port) this.hostServers.delete(h);
-		}
-		const rec: HostServer = { server, port };
-		this.hostServers.set(host, rec);
-		return rec;
-	}
-
-	/** Whether `host` is the only entry claiming `port`. A port belongs to exactly
-	 * one per-host server; a second claimant is a stale entry that lost the port. */
-	private portUniquelyOwnedBy(host: string, port: number): boolean {
-		for (const [h, r] of this.hostServers) {
-			if (h !== host && r.port === port) return false;
-		}
-		return true;
+		for (const p of reserved) this.cfg.hostPortAllocator.release(p);
+		throw new Error(`egress per-host server bind failed for ${host}: ${lastReason}`);
 	}
 
 	/** Scan the decrypted (or plain) request for secret placeholders, substitute
@@ -756,16 +793,6 @@ function resolveTarget(
 	} catch {
 		return { host: (req.headers.host ?? '').split(':')[0] ?? '', port: 80, path: rawUrl };
 	}
-}
-
-/** Whether the server still owns its recorded port. `address()` returns null
- * once a server closes and two sockets can never share one port, so this is the
- * authoritative liveness signal — a closed or recycled server fails it and is
- * rebuilt on the next request. */
-function serverOwnsPort(rec: HostServer): boolean {
-	if (!rec.server.listening) return false;
-	const addr = rec.server.address();
-	return typeof addr === 'object' && addr !== null && addr.port === rec.port;
 }
 
 function closeServer(server: HttpServer | HttpsServer, label: string): Promise<void> {

--- a/packages/server/test/bun/egress-proxy.bun.test.ts
+++ b/packages/server/test/bun/egress-proxy.bun.test.ts
@@ -4,7 +4,7 @@ import { createServer as createHttpsServer, type Server as HttpsServer } from 'n
 import { connect as netConnect } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { connect as tlsConnect } from 'node:tls';
+import { type TLSSocket, connect as tlsConnect } from 'node:tls';
 import type { PGlite } from '@electric-sql/pglite';
 import { encrypt } from '../../src/crypto/encryption';
 import type { MasterKeyManager } from '../../src/crypto/master-key';
@@ -208,7 +208,6 @@ describe('EgressProxy under Bun', () => {
 			const rec = before.get(host);
 			if (!rec) throw new Error('per-host server missing');
 			expect(rec.server.listening).toBe(true);
-			expect(rec.server.address()?.port).toBe(rec.port);
 
 			// The per-host server dies; its loopback port is now refused. A later
 			// CONNECT must rebuild and still pass strict verification — never dial
@@ -228,81 +227,57 @@ describe('EgressProxy under Bun', () => {
 		}
 	}, 30_000);
 
-	// The liveness check must not trust the `listening` flag alone — a server
-	// observed in production stayed listening=true after losing its port. The
-	// authoritative signal is `address().port === recordedPort`; a server that
-	// lost its port is dead and must be rebuilt even while its flag lies.
-	test('treats a server that lost its port as dead even when its listening flag lies', async () => {
-		const runId = `bun-zombie-${process.pid}`;
-		const host = 'zombie.hezo-egress-test';
+	// Reproduces the production collapse (run engineer/TO-6 cert-altname): a
+	// long-lived TLS connection to host A stayed open (the GitHub MCP SSE channel)
+	// while npm/curl first-touched other hosts. Under Bun, `server.listen(0)` +
+	// `server.address().port` handed every per-host server the SAME port, so the
+	// later hosts collapsed onto A's server and were served A's leaf cert —
+	// `ERR_TLS_CERT_ALTNAME_INVALID` / "no alternative certificate subject name".
+	// The existing multi-host test (above) closes each tunnel before the next host
+	// is built and never inspects ports, so it can't observe the collapse. This
+	// holds A open across the builds and asserts each host gets its own SAN AND a
+	// distinct recorded port (explicit allocation guarantees distinctness by
+	// construction; this also locks against any revert to `listen(0)`/`address()`).
+	test('builds distinct per-host servers while a long-lived connection is held open', async () => {
+		const runId = `bun-heldopen-${process.pid}`;
+		const hostA = 'held-open.hezo-egress-test';
+		const laterHosts = [
+			'bun.sh',
+			...Array.from({ length: 6 }, (_u, i) => `later-${i}.hezo-egress-test`),
+		];
 		const allocated = await proxy.allocateRunProxy(runId, { teamId, agentId });
+		let heldTls: TLSSocket | undefined;
 		try {
-			await servedSanThroughProxy(allocated.proxyPort, host, ca.cert);
-			const map = getHostServers(proxy, runId);
-			const rec = map.get(host);
-			if (!rec) throw new Error('per-host server missing');
-			const realServer = rec.server;
-			await new Promise<void>((resolve) => realServer.close(() => resolve()));
-
-			// Forge the desync: claim a listening server whose socket is gone.
-			map.set(host, {
-				port: rec.port,
-				server: {
-					listening: true,
-					address: () => null,
-					close: realServer.close.bind(realServer),
-				} as unknown as HttpsServer,
+			// 1. Open and KEEP OPEN a strict-verified TLS connection to host A.
+			const heldTunnel = await openConnectTunnel(allocated.proxyPort, hostA);
+			const heldSan = await new Promise<string>((resolve, reject) => {
+				heldTls = tlsConnect(
+					{ socket: heldTunnel, servername: hostA, ca: [ca.cert], rejectUnauthorized: true },
+					() => resolve(heldTls?.getPeerCertificate().subjectaltname ?? ''),
+				);
+				heldTls.on('error', reject);
+				heldTls.setTimeout(20_000, () => heldTls?.destroy(new Error('held handshake timed out')));
 			});
+			expect(heldSan).toContain(hostA);
 
-			const cert = await servedSanThroughProxy(allocated.proxyPort, host, ca.cert);
-			expect(cert).toContain(host);
-			expect(map.get(host)?.server.listening).toBe(true);
-		} finally {
-			await proxy.releaseRunProxy(runId);
-		}
-	}, 30_000);
+			// 2. While A is still open, first-touch B..N. Each must pass strict
+			//    verification (rejectUnauthorized) with its OWN SAN, never A's.
+			const sans = await Promise.all(
+				laterHosts.map((h) => strictHandshakeThroughProxy(allocated.proxyPort, h, ca.cert)),
+			);
+			for (let i = 0; i < laterHosts.length; i++) {
+				expect(sans[i]).toContain(laterHosts[i]);
+			}
 
-	// The cross-host leak (production: registry.npmjs.org served the SAN of
-	// api.githubcopilot.com): under Bun a stale entry can keep reporting a port
-	// that a *different* host's live server has since taken over, so two hosts map
-	// to one port and `serverOwnsPort` (which only checks the entry's own
-	// liveness) can't tell them apart — dialing the stale one serves the other
-	// host's cert. A port must belong to at most one host: a second claimant is
-	// rebuilt onto a fresh port rather than dialed.
-	test('never serves one host the cert of another that shares its recorded port', async () => {
-		const runId = `bun-crosshost-${process.pid}`;
-		const liveHost = 'live.hezo-egress-test';
-		const ghostHost = 'ghost.hezo-egress-test';
-		const allocated = await proxy.allocateRunProxy(runId, { teamId, agentId });
-		try {
-			// Stand up a real, live per-host server for liveHost.
-			const liveSan = await servedSanThroughProxy(allocated.proxyPort, liveHost, ca.cert);
-			expect(liveSan).toContain(liveHost);
+			// 3. Every recorded per-host port is distinct — the direct collapse signal.
 			const map = getHostServers(proxy, runId);
-			const liveRec = map.get(liveHost);
-			if (!liveRec) throw new Error('live per-host server missing');
-
-			// Forge the desync: a stale ghost entry that lies it still owns liveHost's
-			// (live) port. serverOwnsPort(ghost) passes; only port-uniqueness exposes it.
-			map.set(ghostHost, {
-				port: liveRec.port,
-				server: {
-					listening: true,
-					address: () => ({ port: liveRec.port }),
-					close: liveRec.server.close.bind(liveRec.server),
-				} as unknown as HttpsServer,
-			});
-
-			// ghostHost must get ITS OWN cert, never liveHost's leaf.
-			const ghostSan = await servedSanThroughProxy(allocated.proxyPort, ghostHost, ca.cert);
-			expect(ghostSan).toContain(ghostHost);
-			expect(ghostSan).not.toContain(liveHost);
-			// ghost was rebuilt onto a port distinct from liveHost's.
-			expect(map.get(ghostHost)?.port).not.toBe(liveRec.port);
-			// liveHost still serves its own cert afterward.
-			const liveAgain = await servedSanThroughProxy(allocated.proxyPort, liveHost, ca.cert);
-			expect(liveAgain).toContain(liveHost);
+			const ports = [hostA, ...laterHosts]
+				.map((h) => map.get(h)?.port)
+				.filter((p): p is number => p != null);
+			expect(ports.length).toBe(laterHosts.length + 1);
+			expect(new Set(ports).size).toBe(ports.length);
 		} finally {
+			heldTls?.destroy();
 			await proxy.releaseRunProxy(runId);
 		}
 	}, 30_000);
@@ -446,33 +421,6 @@ async function fetchHttpsThroughProxy(
 		});
 		tls.on('error', reject);
 		tls.setTimeout(20_000, () => tls.destroy(new Error('https fetch timed out')));
-	});
-}
-
-// Open a CONNECT tunnel for `targetHost` and return the served leaf's
-// subjectAltName. The SAN — not the CN — is what real clients (curl, OpenSSL,
-// Node with verification on) check, and mockttp sets CN=host unconditionally,
-// so asserting on the CN would pass even when the proxy serves another host's
-// cert. `rejectUnauthorized:false` so a wrong cert still completes the
-// handshake and the caller can inspect which SAN was actually served. No
-// upstream is contacted, so the target host need not resolve.
-async function servedSanThroughProxy(
-	proxyPort: number,
-	targetHost: string,
-	caCert: string,
-): Promise<string> {
-	const tunnel = await openConnectTunnel(proxyPort, targetHost);
-	return new Promise<string>((resolve, reject) => {
-		const tls = tlsConnect(
-			{ socket: tunnel, servername: targetHost, ca: [caCert], rejectUnauthorized: false },
-			() => {
-				const san = tls.getPeerCertificate().subjectaltname ?? '';
-				tls.end();
-				resolve(san);
-			},
-		);
-		tls.on('error', reject);
-		tls.setTimeout(20_000, () => tls.destroy(new Error('tls handshake timed out')));
 	});
 }
 

--- a/packages/server/test/egress-proxy.test.ts
+++ b/packages/server/test/egress-proxy.test.ts
@@ -454,6 +454,19 @@ async function killHostServer(proxy: EgressProxy, runId: string, host: string): 
 	await new Promise<void>((resolve) => server.close(() => resolve()));
 }
 
+/** Reach into the proxy's per-run per-host server map for port assertions. */
+function hostServersOf(
+	proxy: EgressProxy,
+	runId: string,
+): Map<string, { server: HttpsServer; port: number }> {
+	const runs = (
+		proxy as unknown as {
+			runs: Map<string, { hostServers: Map<string, { server: HttpsServer; port: number }> }>;
+		}
+	).runs;
+	return runs.get(runId)?.hostServers ?? new Map();
+}
+
 describe('EgressProxy per-host cert routing', () => {
 	// Each upstream host the agent reaches over TLS gets its own minted leaf
 	// cert served from a dedicated internal server. A connection for one host
@@ -477,6 +490,48 @@ describe('EgressProxy per-host cert routing', () => {
 			}
 		} finally {
 			await httpsProxy.releaseRunProxy(runId);
+		}
+	}, 30_000);
+
+	// Locks the root-cause fix: each per-host server must bind a port handed out
+	// by the host allocator, never one read back from `server.address()` (which
+	// lies under Bun, collapsing every host onto one port and serving the wrong
+	// leaf cert). Inject an allocator with a known sequence and assert each host's
+	// recorded port is exactly what was allocated — a revert to `listen(0)` +
+	// `address()` would record arbitrary ephemeral ports instead and fail here.
+	it('binds each per-host server to its allocated port, not an address()-derived one', async () => {
+		const portA = await reserveFreePort();
+		const portB = await reserveFreePort();
+		class SeqHostAllocator extends PortAllocator {
+			private readonly seq = [portA, portB];
+			private i = 0;
+			async allocate(): Promise<number> {
+				const p = this.seq[this.i++];
+				if (p === undefined) throw new Error('SeqHostAllocator exhausted');
+				return p;
+			}
+			release(): void {}
+		}
+		const hostProxy = new EgressProxy({
+			db,
+			masterKeyManager,
+			ca,
+			extraUpstreamTrustedCAs: ca.cert,
+			hostPortAllocator: new SeqHostAllocator(),
+		});
+		const runId = `run-${Date.now()}-hostports`;
+		const allocated = await hostProxy.allocateRunProxy(runId, { teamId, agentId });
+		try {
+			const a = await servedCertThroughProxy(allocated.proxyPort, 'hosta.egress-test', ca.cert);
+			const b = await servedCertThroughProxy(allocated.proxyPort, 'hostb.egress-test', ca.cert);
+			expect(a).toContain('hosta.egress-test');
+			expect(b).toContain('hostb.egress-test');
+			const map = hostServersOf(hostProxy, runId);
+			expect(map.get('hosta.egress-test')?.port).toBe(portA);
+			expect(map.get('hostb.egress-test')?.port).toBe(portB);
+			expect(portA).not.toBe(portB);
+		} finally {
+			await hostProxy.releaseRunProxy(runId);
 		}
 	}, 30_000);
 


### PR DESCRIPTION
## Why

An agent run building a bun-based project couldn't install its toolchain or dependencies through the egress proxy:

- `npm install` → `npm error Exit handler never called!`, the debug log showing the real cause **`ERR_TLS_CERT_ALTNAME_INVALID`** on every `registry.npmjs.org` fetch.
- `curl https://bun.sh/install` → **`SSL: no alternative certificate subject name matches target host name 'bun.sh'`**, then `unzip is required to install bun`.

Traffic only flowed with TLS verification **off** (`curl --insecure`, `NODE_TLS_REJECT_UNAUTHORIZED=0`). Two independent problems: a real egress-proxy TLS bug, and missing container tooling.

## Root cause (the TLS bug)

Each CONNECT host gets its own per-host `https.Server`. `buildHostServer()` bound with `server.listen(0)` and read the port back via `server.address().port`. **Under Bun that read-back is unreliable** — the `HEZO_EGRESS_DEBUG` trace from the failing run shows every host recording the *same* port:

```
connect dial {host: api.githubcopilot.com, dialPort: 49621, owners:[api.githubcopilot.com]}
connect dial {host: bun.sh,                dialPort: 49621, owners:[bun.sh]}
connect dial {host: registry.npmjs.org,    dialPort: 49621, owners:[registry.npmjs.org]}
```

All CONNECT tunnels collapse onto one per-host server, so clients are served **another host's** leaf cert → `ERR_TLS_CERT_ALTNAME_INVALID`. `api.githubcopilot.com` "worked" only because it was the single server everyone was wrongly routed to. The front server is immune because it binds an **explicit** allocated port and never reads it back.

#283's map-level "one host per port" guard held its invariant (debug `owners` stayed singular) but couldn't prevent the collapse — the *recorded port itself* was fictional. This PR is the root-cause fix the #283 instrumentation was gathering evidence for.

## Fix

- **Per-host servers bind an explicitly allocated loopback port** from a dedicated `PortAllocator` over `[30000,39999]` (separate from the front-proxy range so they never contend), and treat that port as authoritative — never read back from `address()`. Allocate-and-bind with retry, mirroring the front server.
- **Ports are released on every teardown path** (rebuild, close-race, bind-exhaustion, run close); release is idempotent.
- **Liveness is now `server.listening` alone.** Removed the now-dead `serverOwnsPort` / `portUniquelyOwnedBy` / same-port eviction and their two forged-desync Bun tests — their `address()`-based premise (two map entries claiming one port) is structurally unreachable once a global allocator owns the ports.
- #283's **orthogonal** hop-by-hop strip and per-run keep-alive-off upstream agent are untouched.

## Container tooling

Pre-install **`bun` (latest)** and **`unzip`** in `Dockerfile.agent-base` (only `curl jq openssh-client ca-certificates python3 socat sudo` were present). Bun is the runtime Hezo itself uses and the common case for agent JS/TS projects; `unzip` also unblocks other `curl | bash` installers.

## Tests

- **Deterministic Node lock** (`egress-proxy.test.ts`): injects a sequenced host allocator and asserts each per-host server's recorded port is exactly what was allocated — a revert to `listen(0)`+`address()` would record arbitrary ephemeral ports and fail here.
- **Bun held-open regression** (`egress-proxy.bun.test.ts`): holds a long-lived strict-verified TLS connection to host A open while first-touching hosts B…N, asserting each gets its own SAN under strict verification **and** all recorded per-host ports are distinct — the production trigger the existing multi-host test missed (it closed each tunnel before the next host was built and never inspected ports).

## Verification

- `bun test ./test/bun/egress-proxy.bun.test.ts` — 7 pass · `egress-streaming.bun.test.ts` — 4 pass
- `bunx vitest run test/egress-proxy.test.ts test/egress-port-allocator.test.ts test/egress-substitution.test.ts test/egress-ca.test.ts` — 30 pass
- `bun run typecheck` — clean (all 3 packages) · biome — clean on changed files

`.dev/egress.md` (TLS termination + Bun-compatibility) updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QP2sSMMfzfknVnCwsFpdrD

---
_Generated by [Claude Code](https://claude.ai/code/session_01QP2sSMMfzfknVnCwsFpdrD)_