### PR TITLE
docs: sharpen README to be concrete and distinctive

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,62 +1,102 @@
-<!-- TODO(founder): add a banner/hero image. Drop the asset in the repo (e.g. .github/assets/banner.png) or host it, then set the src below. -->
 <p align="center">
-  <!-- <img src=".github/assets/banner.png" alt="Hezo" width="640" /> -->
+  <img src="assets/logo.svg" alt="Hezo" width="96" height="96" />
 </p>
 
 <h1 align="center">Hezo</h1>
 
 <p align="center">
-  <strong>Self-hosted, secure orchestration for teams of AI agents.</strong>
+  <strong>A company for your AI agents — self-hosted, and secure by design.</strong>
 </p>
 
 <p align="center">
-  Run a whole company of AI agents on hardware you own — with their secrets, costs,<br/>
-  and blast radius under your control. If a coding agent is a contractor,<br/>
-  Hezo is the company that hires, secures, pays, and manages them.
+  A coding agent is a contractor. Hezo is the company that hires it, gives it a role and a<br/>
+  budget, hands it the keys without letting it keep them, and ships its work —<br/>
+  all on hardware you own.
 </p>
 
 <p align="center">
   <a href="#quickstart">Quickstart</a>
   · <!-- TODO(founder): point at the live docs site once published, e.g. https://hezo.ai/docs -->
   <a href="./docs/introduction.md">Docs</a>
-  · <a href="https://github.com/hezo-ai/hezo">GitHub</a>
   · <a href="https://hezo.ai">Website</a>
-  <!-- TODO(founder): add community links once they exist -->
-  <!-- · <a href="#">Discord</a> -->
-  <!-- · <a href="#">X / Twitter</a> -->
+  · <a href="https://github.com/hezo-ai/hezo">GitHub</a>
+  <!-- TODO(founder): add Discord / X links here once they exist. -->
 </p>
 
-<p align="center">
-  <!-- TODO(founder): add badges once available — license (no LICENSE file yet), latest release, Discord, CI. -->
-</p>
+> **Pre-launch.** You can build and run Hezo from source today (see [Quickstart](#quickstart)).
+> One-line installers and prebuilt binaries land at launch. Stars and feedback are very welcome.
 
-> 🚧 **Pre-launch.** Hezo hasn't launched yet. You can build and run it from source
-> today (see [Quickstart](#quickstart)); one-line binary installers and prebuilt
-> releases land at launch. Stars and feedback are very welcome.
-
-<!-- TODO(founder): add a short demo GIF or video here — it's the highest-converting part of the README. -->
+<!-- TODO(founder): a 15–20s demo GIF here is the single highest-converting thing you can add.
+     Record the CEO chat → a team spins up → a task runs live, and drop it at .github/assets/demo.gif. -->
 
 ## What is Hezo?
 
-Hezo is a self-hosted server and web app that lets you **stand up teams of AI agents
-and run them like an organisation** — a CEO, a Captain, engineers, designers,
-researchers, whatever the work needs — with org charts, projects, budgets, approvals,
-and coordination built in.
+Hezo is a self-hosted server and web app for running **teams of AI agents like an
+organisation**. You stand up a CEO, a Captain, engineers, designers, researchers —
+whatever the work needs — with org charts, projects, budgets, and approvals built in. You
+manage goals and projects, not twenty terminal tabs.
 
-You manage **goals and projects**, not twenty terminal tabs. And because agents run
-real, often AI-generated code, Hezo is **secure by design**: agents never see your real
-secrets, everything sensitive is encrypted behind a key only you hold, and every agent
-runs sandboxed in its own container. You own the machine, the model keys, the spend,
-and the data.
+Because those agents run real, often AI-written code, Hezo is **secure by design**: agents
+never see your real secrets, everything sensitive is encrypted behind a key only you hold,
+and every agent runs sandboxed in its own container. You own the machine, the model keys,
+the spend, and the data.
 
-## How it works in three steps
+## How it works
 
-1. **Create a project.** Chat with the CEO in plain language; it scopes the work and
-   provisions a project and a team for you.
-2. **Assemble the team.** Start from a template, hire new roles, edit their system
-   prompts, and give any agent its own model.
-3. **Approve and run.** Agents pick up tasks and work autonomously on a heartbeat. You
-   set the rules, watch progress live, approve sensitive actions, and cap the spend.
+1. **Create a project.** Describe the work to the CEO in plain language; it scopes the
+   project and provisions a team for you.
+2. **Assemble the team.** Start from a template, hire roles, edit their system prompts, and
+   give any agent its own model.
+3. **Approve and run.** Agents pick up tasks and work autonomously on a heartbeat. You set
+   the rules, watch progress live, approve sensitive actions, and cap the spend.
+
+```
+                 ┌──────────────────────────────────────────────────┐
+   you ──▶ web ──│                   Hezo server                     │
+                 │            (one self-contained binary)            │
+                 │                                                   │
+                 │   Web app · API + realtime · MCP server           │
+                 │   Embedded database · Encrypted vault             │
+                 │   Egress proxy · Git signing · Orchestration      │
+                 └───────────────────────┬──────────────────────────┘
+                            provisions &  │  manages
+                 ┌─────────────────────┐  │  ┌─────────────────────┐
+                 │  Project A (Docker) │◀─┴─▶│  Project N (Docker) │
+                 │   agents + tools    │     │   agents + tools    │
+                 └──────────┬──────────┘     └──────────┬──────────┘
+                            │                            │
+                            └──────▶ egress proxy ◀──────┘
+                                secrets substituted,
+                                 allowed hosts only
+                                        │
+                                        ▼
+                             your models & the internet
+```
+
+## Agents never hold your secrets
+
+This is the part most agent setups get wrong, and a big reason Hezo exists. Agents
+reference every credential by a **placeholder** — never the real value:
+
+```http
+Authorization: Bearer __HEZO_SECRET_STRIPE__
+```
+
+The real key lives encrypted in Hezo's vault. When the request leaves the container, the
+**egress proxy** checks the destination against that secret's allowed hosts and swaps in
+the real value only if it matches — say, `api.stripe.com`. Send it anywhere else and the
+proxy blocks the request; the substitution simply never happens.
+
+So a buggy, jailbroken, or outright malicious agent **cannot leak what it never sees**. It
+can only use a secret against the hosts you scoped it to, and every substitution is logged
+by name, never by value. The same posture runs end to end:
+
+- **Encrypted at rest.** API keys, tokens, and signing keys are encrypted (AES-256-GCM)
+  with a master key that lives in memory only and is never written to disk — Hezo can't
+  even unlock itself without you.
+- **Sandboxed.** Every agent runs in a per-project Docker container with no host access and
+  all traffic forced through the proxy. The blast radius of a bad run is one box.
+- **Yours.** Self-hosted, your model accounts, your spend, your data.
 
 ## Works with your models
 
@@ -73,98 +113,51 @@ agent its own model.
 | **Z.ai** | GLM | Claude Code | API key |
 | **OpenRouter** | Many, via one key | OpenCode | API key |
 
-## Hezo is for you if you want to…
-
-- ✅ Run autonomous AI agents **on infrastructure you own**, not someone else's cloud.
-- ✅ Let agents use real credentials **without ever exposing the secrets** to them.
-- ✅ **Sandbox** untrusted, AI-generated code so a bad run can't touch your system.
-- ✅ Coordinate **multiple agents and projects** toward real goals.
-- ✅ Put a **hard ceiling on model spend** with per-agent and per-project budgets.
-- ✅ Oversee and approve work **from your phone**.
-
 ## Features
 
-| | |
-|---|---|
-| 🔌 **Bring your own model** | Claude, ChatGPT, Gemini, DeepSeek, Z.ai, OpenRouter, Kimi — API key or subscription |
-| 🕵️ **Secret substitution** | Agents use placeholders; real keys are swapped in only for allowed hosts |
-| 🔐 **Encrypted at rest** | One master key only you hold protects every secret |
-| 📦 **Container isolation** | Every project runs in its own sandbox |
-| 💰 **Budgets & cost control** | Daily/weekly/monthly caps per agent and per project |
-| 🏢 **Org chart & roles** | CEO, Coach, Captain, and worker agents that coordinate |
-| 🎫 **Task board + rules** | Per-task rules and a living progress summary |
-| 🎚️ **Per-agent models** | Mix providers within one team |
-| 🔗 **Built-in MCP server** | Drive your teams and tasks from any MCP client |
-| ✅ **Verified git commits** | Signed with your project key, host-side |
-| 🗂️ **Multiple projects** | Independent teams, isolated from one another |
-| 📱 **Mobile-first UI** | Oversee everything from any device |
+**Security & control**
+- Secret substitution at the egress proxy — placeholders in, real keys swapped in only for
+  allowed hosts.
+- Encrypted at rest (AES-256-GCM) behind one master key only you hold.
+- Per-project Docker isolation, with all agent traffic forced through the proxy.
+- Verified git commits, signed host-side with your project key.
 
-## Why Hezo is special
+**Orchestration**
+- An org chart of roles — CEO, Coach, Captain, and workers — that coordinate.
+- A task board with per-task rules and an agent-maintained progress summary.
+- Heartbeat execution: agents wake on a schedule to pick up work, gated by budget.
+- Multiple projects, each an independent team in its own isolated container.
 
-- **Agents never hold your secrets.** They reference credentials by name; Hezo's egress
-  proxy substitutes the real value at request time, and only for the hosts you've
-  scoped each secret to. A compromised agent can't exfiltrate what it never sees.
-- **Your data is encrypted behind a key only you hold.** API keys, tokens, and signing
-  keys are encrypted at rest. The master key lives in memory only and is never written
-  to disk — Hezo can't even unlock itself.
-- **Every agent is sandboxed.** Agents run in per-project Docker containers with no host
-  access and all network traffic forced through the egress proxy. The blast radius of a
-  bad run is one project's box.
-- **You own everything.** Self-hosted, your model accounts, your spend, your data.
+**Models & cost**
+- Bring your own providers; mix models freely, down to one per agent.
+- Hard daily / weekly / monthly budget caps per agent and per project.
 
-## Architecture
+**Interface**
+- A mobile-first web app — oversee, chat, and approve from any device.
+- A built-in MCP server, so any MCP client can drive your teams and tasks.
 
-```
-                 ┌──────────────────────────────────────────────────┐
-   you ──▶ web ──│                   Hezo server                     │
-                 │            (one self-contained binary)            │
-                 │                                                   │
-                 │   Web app · API + realtime · MCP server           │
-                 │   Embedded database · Encrypted vault             │
-                 │   Egress proxy · Git signing · Orchestration      │
-                 └───────────────────────┬───────────────────────────┘
-                            provisions &  │  manages
-                 ┌─────────────────────┐  │  ┌─────────────────────┐
-                 │  Project A (Docker) │◀─┴─▶│  Project N (Docker) │
-                 │   agents + tools    │     │   agents + tools    │
-                 └──────────┬──────────┘     └──────────┬──────────┘
-                            │                            │
-                            └──────▶ egress proxy ◀──────┘
-                                secrets substituted,
-                                 allowed hosts only
-                                        │
-                                        ▼
-                             your models & the internet
-```
+## How Hezo compares
 
-## What's under the hood
+|  | Agents in terminal tabs | Hosted agent platforms | Agent frameworks / SDKs | **Hezo** |
+|---|---|---|---|---|
+| Runs on | Your machine, by hand | Someone else's cloud | Wherever you build it | **Hardware you own** |
+| Your secrets | Live in your shell | Held by the vendor | You wire them up | **Never exposed to the agent** |
+| Many agents | Tabs and willpower | Varies | You build it | **An org chart, built in** |
+| Spend control | Watch the meter | Vendor billing | Do it yourself | **Hard budget caps** |
+| You provide | Prompts, by hand | Vendor config | Code | **Goals and rules** |
 
-- **Projects & teams** — each project owns one team (Captain + workers); HQ hosts the
-  instance-wide CEO and Coach.
-- **Tasks** — a board with descriptions, per-task rules, and agent-maintained progress
-  summaries.
-- **Heartbeat execution** — agents wake on a schedule to pick up work, gated by budget.
-- **Secrets & egress** — encrypted vault + placeholder substitution at a single
-  controlled network exit.
-- **Containers** — one isolated Docker workspace per project.
-- **Budgets** — token-cost tracking with hard per-agent and per-project caps.
-- **MCP** — a built-in MCP server, plus the ability to connect external MCP servers to
-  your agents.
+## Hezo is not…
 
-See the [documentation](./docs/introduction.md) for the full picture.
-
-## What Hezo is **not**
-
-- ❌ **Not a chatbot.** Agents have jobs, projects, and reporting lines.
-- ❌ **Not an agent framework or SDK.** It's the company *around* the agents, not a
-  library to build one.
-- ❌ **Not a hosted SaaS.** You run it yourself, on your own hardware.
-- ❌ **Not a no-code workflow builder.** Agents reason and act; you set goals and rules.
+- **…a chatbot.** Agents have jobs, projects, and reporting lines.
+- **…an agent framework or SDK.** It's the company *around* the agents, not a library to
+  build one.
+- **…a hosted SaaS.** You run it yourself, on your own hardware.
+- **…a no-code workflow builder.** Agents reason and act; you set the goals and the rules.
 
 ## Quickstart
 
-> Pre-launch: build from source for now. Prebuilt binaries and the one-line installer
-> arrive at launch.
+> Pre-launch: build from source for now. Prebuilt binaries and a one-line installer arrive
+> at launch.
 
 **Requirements:** [Bun](https://bun.sh/) v1.3.14+ and Docker (agents run in containers).
 
@@ -175,22 +168,18 @@ bun install
 bun run dev
 ```
 
-Then open **http://localhost:3100** and follow the setup flow to create your master key
-and connect a model.
+Open **http://localhost:3100** and follow the setup flow to create your master key and
+connect a model. From there, see [Your first project](./docs/getting-started/first-project.md).
 
 <!-- TODO(founder): once releases are live, document the binary install here:
      curl -fsSL https://hezo.ai/install.sh | sh   (macOS/Linux)
      irm https://hezo.ai/install.ps1 | iex        (Windows) -->
 
-For more, see [Installation](./docs/getting-started/installation.md) and
-[First-run setup](./docs/getting-started/first-run.md).
-
 ## Documentation
 
-Full docs live in [`docs/`](./docs/introduction.md) and render on the website
-<!-- TODO(founder): link the live docs site once published, e.g. https://hezo.ai/docs -->:
+Full docs live in [`docs/`](./docs/introduction.md):
 
-- [Introduction](./docs/introduction.md) and [How Hezo works](./docs/concepts/how-hezo-works.md)
+- [Introduction](./docs/introduction.md) · [How Hezo works](./docs/concepts/how-hezo-works.md)
 - Getting started: [Installation](./docs/getting-started/installation.md) ·
   [First-run setup](./docs/getting-started/first-run.md) ·
   [Your first project](./docs/getting-started/first-project.md)
@@ -204,44 +193,37 @@ Full docs live in [`docs/`](./docs/introduction.md) and render on the website
 
 ## FAQ
 
-**Do I need to host my own models?** No — you bring API keys (or subscriptions) for the
+**Do I need to host my own models?** No — you bring API keys or subscriptions for the
 providers you want. Hezo runs the agents; the models stay with their providers.
 
 **Can agents see my API keys?** No. Agents only ever use placeholders; the real value is
-substituted at the network edge and only for hosts you've allowed.
+substituted at the network edge, and only for hosts you've allowed.
 
-**Is my data sent anywhere?** Hezo is self-hosted. Your data stays in your instance;
-agents reach your chosen model providers (and any hosts you allow) and nothing else.
+**Is my data sent anywhere?** Hezo is self-hosted. Your data stays in your instance; agents
+reach your chosen model providers and any hosts you allow, and nothing else.
 
 **Can I run multiple projects?** Yes — each gets its own team and its own isolated
 container.
 
-**How are agents kept from running up a huge bill?** Set daily/weekly/monthly budgets
-per agent and per project; agents pause when a window is exhausted and resume when it
-rolls over.
+**How are agents kept from running up a huge bill?** Set daily, weekly, or monthly budgets
+per agent and per project; agents pause when a window is exhausted and resume when it rolls
+over.
 
 ## Development
 
-Contributor setup, scripts, and architecture notes are in
+Contributor setup, scripts, and the testing guide live in
 [`.dev/DEVELOPING.md`](./.dev/DEVELOPING.md) and [`AGENTS.md`](./AGENTS.md).
 
 ```sh
 bun install
-bun run dev        # start the server + web UI
-bun run test       # run the test suite
+bun run dev        # server + web UI on http://localhost:3100
+bun run test       # the full test suite
 ```
 
-## Roadmap
+## Community & license
 
-<!-- TODO(founder): add a ROADMAP.md and link it here. -->
-
-## Community
-
-<!-- TODO(founder): add Discord / X (Twitter) / Discussions links once they exist. -->
 Questions and bug reports are welcome via
 [GitHub Issues](https://github.com/hezo-ai/hezo/issues).
 
-## License
-
-<!-- TODO(founder): no LICENSE file exists in the repo yet. Choose a license, add a
-     LICENSE file, and state it here (and add a badge above). -->
+<!-- TODO(founder): add Discord / X links once they exist, and choose a license + add a
+     LICENSE file, then state it here (and a badge above). -->


### PR DESCRIPTION
## What

Reworks the top-level `README.md` so it reads like a confident, hand-crafted project page rather than a generic "AI agent platform" template — and so it stands on its own rather than echoing the conventions of other agent-orchestration projects in the space.

## Research

Studied several widely-admired open-source READMEs and pulled their patterns in. The reference the task pointed at ([`chopratejas/headroom`](https://github.com/chopratejas/headroom)) plus self-hosted / AI exemplars **Ollama, Plausible, Coolify, Cal.com, and Dify**. The consistent lessons:

- Treat readers as competent technical decision-makers — proof and concrete mechanism, not marketing rhetoric (Ollama, Dify).
- Specificity over abstraction (Plausible).
- Position against the *familiar alternatives a reader is actually weighing* (Coolify, Plausible, Cal.com).
- Respect reader time; cut length and repetition.
- Lead with a real visual identity.

## Changes

- **Real logo first.** Wires in the existing `assets/logo.svg` instead of the banner `TODO`.
- **Cut the AI-slop tells.** Removed the emoji-walled "✅ is for you if…" and "Why X is special" sections and the emoji-per-row feature matrix; replaced with confident plain prose and grouped feature bullets.
- **Made the differentiator concrete.** A single **"Agents never hold your secrets"** section with a real `__HEZO_SECRET_STRIPE__` placeholder example and the egress-proxy flow — stated once instead of repeated three times across the page.
- **Added a "How Hezo compares" table** positioning against *categories* (terminal agents you babysit / hosted agent SaaS / agent frameworks), deliberately naming no specific competitor.
- **Consolidated** overlapping sections ("What's under the hood" folded into Features + the architecture diagram) and dropped the empty Roadmap section.

Net: 122 insertions / 140 deletions — shorter, more concrete, more distinctive. All technical claims verified against the codebase (port 3100, Bun 1.3.14+, AES-256-GCM master key in memory only, the `__HEZO_SECRET_<NAME>__` placeholder format, the provider/runtime table).

## Notes

A demo GIF is still the single highest-impact addition and can't be fabricated here — left as a clearly-placed `TODO` for a real recording. License and community links remain `TODO`s pending a chosen LICENSE file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013TdGuUjHC9UbbF69mjxS1n

---
_Generated by [Claude Code](https://claude.ai/code/session_013TdGuUjHC9UbbF69mjxS1n)_