### PR TITLE
fix(web): surface run task details above the timing box, more prominently

### DIFF
--- a/packages/web/src/routes/projects/$projectId/agents/$agentId/executions/$runId.tsx
+++ b/packages/web/src/routes/projects/$projectId/agents/$agentId/executions/$runId.tsx
@@ -80,9 +80,9 @@ function ExecutionDetailPage() {
 	const projectLabel = run.project_name ?? run.project_slug;
 	const taskLineInner = (
 		<>
-			<span>Task:</span>
-			<span className="font-mono text-text-1">{run.task_identifier}</span>
-			{run.task_title && <span>{run.task_title}</span>}
+			<span className="text-text-3">Task:</span>
+			<span className="font-mono font-semibold text-text-1">{run.task_identifier}</span>
+			{run.task_title && <span className="font-medium text-text-1">{run.task_title}</span>}
 			{isInstanceAgent && projectLabel && (
 				<span data-testid="run-task-project" className="text-text-3">
 					· {projectLabel}
@@ -90,6 +90,28 @@ function ExecutionDetailPage() {
 			)}
 		</>
 	);
+
+	const taskBlock = run.task_identifier ? (
+		<div className="mb-4" data-testid="run-task">
+			{run.task_id ? (
+				<Link
+					to="/projects/$projectId/tasks/$taskId"
+					params={{
+						projectId: run.project_slug ?? projectId,
+						taskId: run.task_identifier.toLowerCase(),
+					}}
+					{...(run.run_comment_public_id ? { hash: `comment-${run.run_comment_public_id}` } : {})}
+					className="inline-flex items-baseline gap-2 flex-wrap text-sm text-text-2 hover:underline"
+				>
+					{taskLineInner}
+				</Link>
+			) : (
+				<div className="inline-flex items-baseline gap-2 flex-wrap text-sm text-text-2">
+					{taskLineInner}
+				</div>
+			)}
+		</div>
+	) : null;
 
 	return (
 		<div>
@@ -105,6 +127,8 @@ function ExecutionDetailPage() {
 				<h2 className="text-sm font-medium">Run {run.id.slice(0, 8)}</h2>
 				<Badge color={statusColor(run.status) as 'green'}>{run.status}</Badge>
 			</div>
+
+			{taskBlock}
 
 			{(() => {
 				const trigger = formatTriggerReason(run, projectId);
@@ -167,25 +191,6 @@ function ExecutionDetailPage() {
 					</div>
 				);
 			})()}
-
-			{run.task_identifier &&
-				(run.task_id ? (
-					<Link
-						to="/projects/$projectId/tasks/$taskId"
-						params={{
-							projectId: run.project_slug ?? projectId,
-							taskId: run.task_identifier.toLowerCase(),
-						}}
-						{...(run.run_comment_public_id ? { hash: `comment-${run.run_comment_public_id}` } : {})}
-						className="mb-4 inline-flex items-baseline gap-1 text-xs text-text-2 hover:text-text-1"
-					>
-						{taskLineInner}
-					</Link>
-				) : (
-					<div className="mb-4 inline-flex items-baseline gap-1 text-xs text-text-2">
-						{taskLineInner}
-					</div>
-				))}
 
 			{displayedCommand && (
 				<div className="mb-3">


### PR DESCRIPTION
## What

On the agent **run-detail page** (`/projects/:projectId/agents/:agentId/executions/:runId`), the task line previously sat **below** the Timing/Usage grid in small, muted text (`text-xs text-text-2`), making the single most important piece of context — *what task this run is working on* — easy to miss.

This moves the task block **directly under the run header**, above the "Triggered by" line and the timing box, and renders it more prominently.

## Changes

- **Reposition:** the task block now renders right after the `Run <id> [status]` header, ahead of the trigger reason and the Timing/Usage grid.
- **Prominence:** bumped from `text-xs` → `text-sm`; the task **identifier** is now `font-mono font-semibold text-text-1` and the **title** is `font-medium text-text-1` (was muted `text-text-2`). The `Task:` label and cross-project suffix stay muted (`text-text-3`) so the identifier/title read as the headline.
- Link affordance changed to `hover:underline`.

## Before → After (layout order)

| Before | After |
|---|---|
| Run header | Run header |
| Triggered by | **Task: T0-13 — …** |
| Timing / Usage box | Triggered by |
| Task: T0-13 — … | Timing / Usage box |
| Invocation | Invocation |

## Compatibility / tests

- Kept the `Task:` prefix and child order, so the Playwright accessible-name matcher (`^Task: <identifier>` in `test/browser/agent-run-logs.spec.ts`) still matches.
- Kept the `data-testid="run-task-project"` cross-project suffix (rendered only for instance agents), so `packages/web/test/agent-executions-project.test.tsx` passes unchanged.
- Verified locally: `agent-executions-project`, `run-created-tasks`, `run-termination` component tests (8 passed), `biome check` clean, web-package `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T7JuVFhTeg2ZjRPebJyzHg

---
_Generated by [Claude Code](https://claude.ai/code/session_01T7JuVFhTeg2ZjRPebJyzHg)_