### PR TITLE
fix: keep right sidebar top spacing put on scroll

### DIFF
--- a/packages/web/src/components/task-detail/task-sidebar.tsx
+++ b/packages/web/src/components/task-detail/task-sidebar.tsx
@@ -84,7 +84,11 @@ export function TaskSidebar({
 		<>
 			<div
 				data-testid="task-sidebar"
-				className="flex flex-col gap-4 text-xs lg:sticky lg:top-[var(--container-banner-h,0px)] lg:self-start"
+				// Sticky offset = container-banner height (clears the sticky status banner
+				// when present) + the project layout's lg:py-6 (1.5rem) padding. Mirroring
+				// the padding keeps the breathing room above the sidebar when it sticks;
+				// without it the sidebar slides flush against the app header on scroll.
+				className="flex flex-col gap-4 text-xs lg:sticky lg:top-[calc(var(--container-banner-h,0px)_+_1.5rem)] lg:self-start"
 			>
 				<AgentQueueSection
 					projectId={projectId}

--- a/test/browser/task-detail.spec.ts
+++ b/test/browser/task-detail.spec.ts
@@ -87,6 +87,11 @@ test.describe('Task detail — right sidebar sticky positioning', () => {
 		expect(scrolled!.y).toBeLessThanOrEqual(initialY);
 		expect(scrolled!.y).toBeGreaterThanOrEqual(0);
 		expect(scrolled!.y + scrolled!.height).toBeLessThanOrEqual(720);
+		// Top spacing stays put: the sticky offset mirrors the project layout's
+		// vertical padding, so the sidebar keeps its breathing room below the app
+		// header instead of sliding flush against it. Without the padding in the
+		// sticky `top`, scrolled.y would drop by ~24px (the lg:py-6 gap).
+		expect(scrolled!.y).toBeGreaterThanOrEqual(initialY - 1);
 
 		const effort = sidebar.getByLabel(
 			'Reasoning effort for the agent run triggered by this comment',


### PR DESCRIPTION
## Problem

The task detail right sidebar (the one with the **Agent Queue**, Priority, Assignee, etc.) is `lg:sticky` with a sticky `top` offset of only `var(--container-banner-h,0px)`. That variable clears the container-status banner when one is showing, but it omits the project layout's content padding (`lg:py-6` = 1.5rem).

As a result, at scroll 0 the sidebar sits 24px below the app header (the padding), but once you scroll past ~24px it pins **flush against the header**, losing that breathing room. The top spacing visibly jumps as the page scrolls.

## Fix

Add the `1.5rem` padding to the sticky offset so it mirrors the layout padding and the gap is preserved when the sidebar sticks:

```diff
- lg:top-[var(--container-banner-h,0px)]
+ lg:top-[calc(var(--container-banner-h,0px)_+_1.5rem)]
```

This is the same approach the docs-library sidebar already uses (`md:top-5 lg:top-6` mirroring `md:py-5 lg:py-6`); the container-banner clearance is retained.

## Testing

- Strengthened the existing `task-detail.spec.ts` sticky test: it previously only asserted the sidebar didn't drift *down*; it now also asserts it doesn't drift *up* (`scrolled.y >= initialY - 1`), so the top spacing genuinely stays put.
- Verified the new assertion is a real regression guard — it **fails** on the old code (sidebar dropped ~24px) and **passes** with the fix.
- Confirmed the Tailwind v4 arbitrary value compiles to valid CSS: `top: calc(var(--container-banner-h,0px) + 1.5rem)`.
- `turbo typecheck` + full build pass (via the pre-commit hook); Biome clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017w9Q5yWPoXReNtAvq7Bmvg

---
_Generated by [Claude Code](https://claude.ai/code/session_017w9Q5yWPoXReNtAvq7Bmvg)_