### PR TITLE
fix(budget): drop redundant Edit caps button and Spend by model section

### DIFF
--- a/packages/web/src/components/budget/project-budget-panel.tsx
+++ b/packages/web/src/components/budget/project-budget-panel.tsx
@@ -271,18 +271,13 @@ export function ProjectBudgetPanel({
 		setEditing(false);
 	}
 
-	const description =
-		variant === 'spend'
-			? 'Spend across every agent in this project. Runs pause when a window cap is reached — the one place Hezo gates on cost.'
-			: 'Spend across all agents in this project. A run is blocked when any window is exceeded. Disable a window to leave it uncapped.';
-
 	return (
 		<section>
 			<SectionHeader
 				icon={Clock}
 				title="Project budget"
-				description={description}
 				action={
+					variant === 'limits' &&
 					!editing && (
 						<Button
 							variant="ghost"

--- a/packages/web/src/routes/projects/$projectId/budget.tsx
+++ b/packages/web/src/routes/projects/$projectId/budget.tsx
@@ -1,7 +1,6 @@
 import { centsToDollars, HQ_PROJECT_SLUG } from '@hezo/shared';
 import { createFileRoute, redirect } from '@tanstack/react-router';
-import { BarChart3, Cpu, Users } from 'lucide-react';
-import { useMemo } from 'react';
+import { BarChart3, Users } from 'lucide-react';
 import { BudgetCharts } from '../../../components/budget/budget-charts';
 import { ProjectBudgetPanel } from '../../../components/budget/project-budget-panel';
 import { type SpendCell, StackedSpendChart } from '../../../components/budget/stacked-spend-chart';
@@ -81,19 +80,6 @@ function BudgetPage() {
 	const { data: agentSeries, isLoading: agentLoading } = useAgentDailyCostSeries(projectId);
 	const { data: adapterSeries, isLoading: adapterLoading } = useAdapterDailyCostSeries(projectId);
 
-	// Totals per adapter/model across the series — the Wire "Sonnet · $… / Opus · $…" list.
-	const adapterTotals = useMemo(() => {
-		const map = new Map<string, { label: string; cents: number }>();
-		for (const p of adapterSeries?.summary ?? []) {
-			const key = p.ai_provider_config_id ?? UNATTRIBUTED_KEY;
-			const label = p.adapter_label ?? p.provider ?? 'Unattributed';
-			const cur = map.get(key) ?? { label, cents: 0 };
-			cur.cents += p.total_cents;
-			map.set(key, cur);
-		}
-		return [...map.values()].sort((a, b) => b.cents - a.cents);
-	}, [adapterSeries]);
-
 	return (
 		<div className="flex flex-col gap-8">
 			<div>
@@ -107,27 +93,6 @@ function BudgetPage() {
 
 			{/* Hero + per-window caps + binding-window banner. */}
 			<ProjectBudgetPanel projectId={projectId} variant="spend" />
-
-			{adapterTotals.length > 0 && (
-				<section>
-					<SectionHeader
-						icon={Cpu}
-						title="Spend by model"
-						description="Total spend grouped by the AI adapter that ran it."
-					/>
-					<div className="divide-y divide-border rounded-lg border border-border bg-surface shadow-xs">
-						{adapterTotals.map((a) => (
-							<div
-								key={a.label}
-								className="flex items-center justify-between px-4 py-2.5 text-[13px]"
-							>
-								<span className="truncate text-text-2">{a.label}</span>
-								<span className="font-mono tabular-nums text-text-1">{dollars(a.cents)}</span>
-							</div>
-						))}
-					</div>
-				</section>
-			)}
 
 			<section>
 				<SectionHeader

--- a/packages/web/test/budget-page.test.tsx
+++ b/packages/web/test/budget-page.test.tsx
@@ -106,8 +106,9 @@ test('Budget page: editing limits inline updates the spend progress cards', asyn
 
 	await router.navigate({ to: '/projects/$projectId/budget', params: { projectId: teamSlug } });
 
-	// The progress display and the editor are one section: edit limits in place.
-	await user.click(await findByTestId('edit-project-budget'));
+	// The progress display and the editor are one section: edit limits in place
+	// via the inline per-window pencil.
+	await user.click(await findByRole('button', { name: 'Edit Today cap' }));
 	await user.click(await findByTestId('budget-daily-toggle'));
 	const daily = (await findByTestId('budget-daily')) as HTMLInputElement;
 	await user.clear(daily);


### PR DESCRIPTION
## What

On the project **Budget page**:

- **Remove the dedicated "Edit caps" header button.** Each per-window column already has an inline pencil icon that opens the same cap editor, so the header button was redundant. It's now gated to the **settings (limits) variant** of the shared `ProjectBudgetPanel`, where the read-only cap cells have no pencils and the button is the only edit affordance.
- **Remove the "Spend by model" section entirely.** It duplicated the "Spend per day by AI adapter" stacked chart further down the page. The chart stays.

## Notes

- `ProjectBudgetPanel` is shared between the Budget page (`variant="spend"`) and Project settings (`variant="limits"`); the change preserves editing on both surfaces.
- Dropped the now-unused `adapterTotals` memo and `Cpu`/`useMemo` imports from `budget.tsx`.

## Testing

- `bunx vitest run test/budget-page.test.tsx test/project-settings.test.tsx` — 10/10 pass. The budget-page inline-edit test now enters edit mode via the "Edit Today cap" pencil instead of the removed header button.
- `bun run typecheck` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)