### PR TITLE
feat(tasks): persist task list filters per project

### DIFF
--- a/packages/web/src/components/task-list.tsx
+++ b/packages/web/src/components/task-list.tsx
@@ -1,11 +1,19 @@
 import { formatTaskStatus, TaskStatus, TERMINAL_TASK_STATUSES } from '@hezo/shared';
 import { useNavigate } from '@tanstack/react-router';
 import { AlertTriangle, AtSign, ChevronDown, ListPlus, Plus, Search } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAgents } from '../hooks/use-agents';
 import { useProjectMeta } from '../hooks/use-projects';
 import { type Task, type TaskFilters, useTasks } from '../hooks/use-tasks';
 import { nestTasksForDisplay } from '../lib/nest-tasks-for-display';
+import {
+	clearStoredTaskFilters,
+	readStoredTaskFilters,
+	type TaskSortDir as SortDir,
+	type TaskSortField as SortField,
+	type StoredTaskFilters,
+	writeStoredTaskFilters,
+} from '../lib/task-filter-storage';
 import { AdminApprovalsBanner } from './admin-approvals-banner';
 import { CreateTaskDialog } from './create-task-dialog';
 import { ProjectTaskListHeader } from './project-task-list-header';
@@ -36,9 +44,6 @@ const todoStatusOptions: MultiSelectOption[] = ALL_STATUSES.filter(
 	value: s,
 	label: formatTaskStatus(s),
 }));
-
-type SortField = 'work_order' | 'created_at' | 'updated_at';
-type SortDir = 'asc' | 'desc';
 
 const sortLabels: Record<`${SortField}:${SortDir}`, string> = {
 	'work_order:asc': 'Work order',
@@ -111,12 +116,16 @@ export function TaskList({ projectId }: TaskListProps) {
 	const showProjectProgress = project != null && !project.is_internal;
 	const { data: agents } = useAgents(projectId);
 	const [expanded, setExpanded] = useState(false);
-	const [search, setSearch] = useState('');
-	const [debouncedSearch, setDebouncedSearch] = useState('');
-	const [statusValues, setStatusValues] = useState<string[]>(() => [...DEFAULT_TODO_STATUSES]);
-	const [ownerValues, setOwnerValues] = useState<string[]>([]);
-	const [sortField, setSortField] = useState<SortField>('work_order');
-	const [sortDir, setSortDir] = useState<SortDir>('asc');
+	// Hydrate the filter bar from this project's last-set selections (or defaults).
+	const [stored] = useState(() => readStoredTaskFilters(projectId));
+	const [search, setSearch] = useState(stored?.search ?? '');
+	const [debouncedSearch, setDebouncedSearch] = useState((stored?.search ?? '').trim());
+	const [statusValues, setStatusValues] = useState<string[]>(
+		stored?.statusValues ?? [...DEFAULT_TODO_STATUSES],
+	);
+	const [ownerValues, setOwnerValues] = useState<string[]>(stored?.ownerValues ?? []);
+	const [sortField, setSortField] = useState<SortField>(stored?.sortField ?? 'work_order');
+	const [sortDir, setSortDir] = useState<SortDir>(stored?.sortDir ?? 'asc');
 	const [page, setPage] = useState(1);
 	const [createOpen, setCreateOpen] = useState(false);
 
@@ -127,6 +136,41 @@ export function TaskList({ projectId }: TaskListProps) {
 		}, 250);
 		return () => clearTimeout(handle);
 	}, [search]);
+
+	// The route reuses this component across projects (param change, no remount),
+	// so re-hydrate the filter bar when the project changes. The initial project is
+	// already hydrated above; skip it to avoid clobbering the lazy-init values.
+	const hydratedProjectRef = useRef(projectId);
+	useEffect(() => {
+		if (hydratedProjectRef.current === projectId) return;
+		hydratedProjectRef.current = projectId;
+		const next = readStoredTaskFilters(projectId);
+		setSearch(next?.search ?? '');
+		setDebouncedSearch((next?.search ?? '').trim());
+		setStatusValues(next?.statusValues ?? [...DEFAULT_TODO_STATUSES]);
+		setOwnerValues(next?.ownerValues ?? []);
+		setSortField(next?.sortField ?? 'work_order');
+		setSortDir(next?.sortDir ?? 'asc');
+		setPage(1);
+	}, [projectId]);
+
+	// Persist the full filter set on every change, overriding the one field that
+	// changed (state setters above haven't flushed into this closure yet). Writing
+	// from the change handlers — rather than an effect watching the values — keeps
+	// the project-switch re-hydration from racing a stale write back to storage.
+	const persistFilters = useCallback(
+		(override: Partial<StoredTaskFilters>) => {
+			writeStoredTaskFilters(projectId, {
+				search,
+				statusValues,
+				ownerValues,
+				sortField,
+				sortDir,
+				...override,
+			});
+		},
+		[projectId, search, statusValues, ownerValues, sortField, sortDir],
+	);
 
 	const ownerOptions: MultiSelectOption[] = useMemo(
 		() =>
@@ -207,23 +251,32 @@ export function TaskList({ projectId }: TaskListProps) {
 		...(debouncedSearch ? [`Matching "${debouncedSearch}"`] : []),
 	];
 
+	function handleSearchChange(next: string) {
+		setSearch(next);
+		persistFilters({ search: next });
+	}
+
 	function handleStatusChange(next: string[]) {
 		setStatusValues(next);
+		persistFilters({ statusValues: next });
 		setPage(1);
 	}
 
 	function handleOwnerChange(next: string[]) {
 		setOwnerValues(next);
+		persistFilters({ ownerValues: next });
 		setPage(1);
 	}
 
 	function handleSortFieldChange(next: SortField) {
 		setSortField(next);
+		persistFilters({ sortField: next });
 		setPage(1);
 	}
 
 	function handleSortDirChange(next: SortDir) {
 		setSortDir(next);
+		persistFilters({ sortDir: next });
 		setPage(1);
 	}
 
@@ -234,6 +287,7 @@ export function TaskList({ projectId }: TaskListProps) {
 		setSortField('work_order');
 		setSortDir('asc');
 		setPage(1);
+		clearStoredTaskFilters(projectId);
 	}
 
 	const columns: Column<TaskRow>[] = [
@@ -373,7 +427,7 @@ export function TaskList({ projectId }: TaskListProps) {
 							<input
 								type="text"
 								value={search}
-								onChange={(e) => setSearch(e.target.value)}
+								onChange={(e) => handleSearchChange(e.target.value)}
 								placeholder="Filter by title..."
 								data-testid="task-filter-search"
 								className="w-full rounded-md border border-border bg-surface pl-8 pr-2.5 py-1.5 text-xs text-text-1 outline-none focus:border-border-strong"

--- a/packages/web/src/lib/task-filter-storage.ts
+++ b/packages/web/src/lib/task-filter-storage.ts
@@ -1,0 +1,76 @@
+// Per-project persistence for the task list's filter bar. The user's last-set
+// search / status / owner / sort selections are written to localStorage keyed by
+// project slug, so returning to the same project's task page restores them.
+// Keyed by the route-param project slug (the same handle the component already
+// holds), never a resolved UUID.
+
+export type TaskSortField = 'work_order' | 'created_at' | 'updated_at';
+export type TaskSortDir = 'asc' | 'desc';
+
+export interface StoredTaskFilters {
+	search: string;
+	statusValues: string[];
+	ownerValues: string[];
+	sortField: TaskSortField;
+	sortDir: TaskSortDir;
+}
+
+const STORAGE_PREFIX = 'hezo:task-filters:';
+const SORT_FIELDS: readonly TaskSortField[] = ['work_order', 'created_at', 'updated_at'];
+const SORT_DIRS: readonly TaskSortDir[] = ['asc', 'desc'];
+
+function keyFor(projectId: string): string {
+	return `${STORAGE_PREFIX}${projectId}`;
+}
+
+function stringArray(value: unknown): string[] {
+	return Array.isArray(value) ? value.filter((v): v is string => typeof v === 'string') : [];
+}
+
+/**
+ * Read the persisted filters for a project, or `null` when nothing is stored (so
+ * the caller can fall back to its own defaults). Tolerates malformed / stale JSON
+ * by returning `null`, and coerces each field to a safe shape so a tampered or
+ * out-of-date entry can never feed garbage into the API query.
+ */
+export function readStoredTaskFilters(projectId: string): StoredTaskFilters | null {
+	if (typeof window === 'undefined' || !projectId) return null;
+	try {
+		const raw = localStorage.getItem(keyFor(projectId));
+		if (!raw) return null;
+		const parsed = JSON.parse(raw) as unknown;
+		if (typeof parsed !== 'object' || parsed === null) return null;
+		const obj = parsed as Record<string, unknown>;
+		return {
+			search: typeof obj.search === 'string' ? obj.search : '',
+			statusValues: stringArray(obj.statusValues),
+			ownerValues: stringArray(obj.ownerValues),
+			sortField: SORT_FIELDS.includes(obj.sortField as TaskSortField)
+				? (obj.sortField as TaskSortField)
+				: 'work_order',
+			sortDir: SORT_DIRS.includes(obj.sortDir as TaskSortDir)
+				? (obj.sortDir as TaskSortDir)
+				: 'asc',
+		};
+	} catch {
+		return null;
+	}
+}
+
+export function writeStoredTaskFilters(projectId: string, filters: StoredTaskFilters): void {
+	if (typeof window === 'undefined' || !projectId) return;
+	try {
+		localStorage.setItem(keyFor(projectId), JSON.stringify(filters));
+	} catch {
+		// ignore storage failures (private mode, quota, etc.)
+	}
+}
+
+export function clearStoredTaskFilters(projectId: string): void {
+	if (typeof window === 'undefined' || !projectId) return;
+	try {
+		localStorage.removeItem(keyFor(projectId));
+	} catch {
+		// ignore storage failures (private mode, quota, etc.)
+	}
+}

--- a/packages/web/test/task-list-filter-persistence.test.tsx
+++ b/packages/web/test/task-list-filter-persistence.test.tsx
@@ -1,0 +1,153 @@
+import { waitFor } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { getTestContext, renderApp } from './helpers/render';
+import { type SeededWorkspace, seedProject, seedTask, seedWorkspace } from './helpers/seed';
+
+async function patchStatus(ws: SeededWorkspace, taskId: string, status: string) {
+	const { apiBase } = getTestContext();
+	const res = await apiBase(`/api/projects/${ws.internalSlug}/tasks/${taskId}`, {
+		method: 'PATCH',
+		headers: ws.headers,
+		body: JSON.stringify({ status }),
+	});
+	if (!res.ok) throw new Error(`patchStatus failed: ${res.status} ${await res.text()}`);
+}
+
+test('filter selections persist for the same project across navigation away and back', async () => {
+	let projectSlug = '';
+
+	const { findByText, findByTestId, findByRole, queryByText, queryByTestId, router, user } =
+		await renderApp({
+			initialPath: '/',
+			seed: async () => {
+				const ws = await seedWorkspace();
+				const project = await seedProject(ws, { name: 'Persist Project' });
+				const agentId = ws.agents[0].id;
+				await seedTask(ws, project, { title: 'Backlog Task', assignee_id: agentId });
+				const done = await seedTask(ws, project, { title: 'Done Task', assignee_id: agentId });
+				await patchStatus(ws, done.id, 'done');
+				projectSlug = project.slug;
+			},
+		});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks',
+		params: { projectId: projectSlug },
+	});
+
+	// Default view: open tasks show, terminal (done) tasks are hidden.
+	await findByText('Backlog Task', undefined, { timeout: 10_000 });
+	expect(queryByText('Done Task')).toBeNull();
+
+	// Set a non-default filter set: status → Done only, plus a sort change.
+	const toggle = await findByTestId('task-filter-toggle');
+	await user.click(toggle);
+	await findByTestId('task-filter-panel');
+
+	const statusBtn = await findByTestId('task-filter-status');
+	await user.click(statusBtn);
+	const clear = await findByRole('button', { name: 'Clear selection' });
+	await user.click(clear);
+	const doneOption = await findByRole('button', { name: 'Done' });
+	await user.click(doneOption);
+	await user.click(statusBtn);
+
+	const sortField = (await findByTestId('task-filter-sort-field')) as HTMLSelectElement;
+	await user.selectOptions(sortField, 'created_at');
+
+	// Filter applied: the done task surfaces, the backlog task drops out.
+	await waitFor(
+		() => {
+			expect(queryByText('Done Task')).not.toBeNull();
+			expect(queryByText('Backlog Task')).toBeNull();
+		},
+		{ timeout: 10_000 },
+	);
+
+	// Navigate away (TaskList unmounts) ...
+	await router.navigate({
+		to: '/projects/$projectId/documents',
+		params: { projectId: projectSlug },
+	});
+	await waitFor(() => expect(queryByTestId('task-filter-bar')).toBeNull());
+
+	// ... and back. The filter bar should restore the last-set selections without
+	// any re-interaction: the done task is still the one shown.
+	await router.navigate({
+		to: '/projects/$projectId/tasks',
+		params: { projectId: projectSlug },
+	});
+
+	await waitFor(
+		() => {
+			expect(queryByText('Done Task')).not.toBeNull();
+			expect(queryByText('Backlog Task')).toBeNull();
+		},
+		{ timeout: 10_000 },
+	);
+
+	// The persisted sort selection is reflected in the (collapsed → reopened) panel.
+	await user.click(await findByTestId('task-filter-toggle'));
+	const restoredSort = (await findByTestId('task-filter-sort-field')) as HTMLSelectElement;
+	expect(restoredSort.value).toBe('created_at');
+});
+
+test('one project does not inherit another project filters', async () => {
+	let projectA = '';
+	let projectB = '';
+
+	const { findByText, findByTestId, findByRole, queryByText, router, user } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const wsA = await seedWorkspace();
+			const pA = await seedProject(wsA, { name: 'Project Alpha' });
+			const doneA = await seedTask(wsA, pA, { title: 'Alpha Done', assignee_id: wsA.agents[0].id });
+			await seedTask(wsA, pA, { title: 'Alpha Backlog', assignee_id: wsA.agents[0].id });
+			await patchStatus(wsA, doneA.id, 'done');
+			projectA = pA.slug;
+
+			const wsB = await seedWorkspace();
+			const pB = await seedProject(wsB, { name: 'Project Beta' });
+			await seedTask(wsB, pB, { title: 'Beta Backlog', assignee_id: wsB.agents[0].id });
+			projectB = pB.slug;
+		},
+	});
+
+	// Project A: narrow the status filter to Done.
+	await router.navigate({
+		to: '/projects/$projectId/tasks',
+		params: { projectId: projectA },
+	});
+	await findByText('Alpha Backlog', undefined, { timeout: 10_000 });
+
+	await user.click(await findByTestId('task-filter-toggle'));
+	await findByTestId('task-filter-panel');
+	const statusBtn = await findByTestId('task-filter-status');
+	await user.click(statusBtn);
+	await user.click(await findByRole('button', { name: 'Clear selection' }));
+	await user.click(await findByRole('button', { name: 'Done' }));
+	await user.click(statusBtn);
+
+	await waitFor(
+		() => {
+			expect(queryByText('Alpha Done')).not.toBeNull();
+			expect(queryByText('Alpha Backlog')).toBeNull();
+		},
+		{ timeout: 10_000 },
+	);
+
+	// Switch to project B (same route, different param — no remount). B has no
+	// stored filters, so it must fall back to its own defaults and show its open
+	// task — not inherit Alpha's Done-only filter.
+	await router.navigate({
+		to: '/projects/$projectId/tasks',
+		params: { projectId: projectB },
+	});
+
+	await findByText('Beta Backlog', undefined, { timeout: 10_000 });
+
+	// The collapsed summary reflects the default selection, not Alpha's.
+	const summary = await findByTestId('task-filter-toggle');
+	await waitFor(() => expect(summary.textContent).toContain('Open tasks'));
+	expect(summary.textContent).not.toContain('Status: Done');
+});


### PR DESCRIPTION
## What

The task list filter bar (search, status, owner, sort) reset to defaults on every visit. This persists the last-set selections **per project** and restores them when the user returns to the same project's task page.

## Changes

- **New `packages/web/src/lib/task-filter-storage.ts`** — reads/writes/clears per-project filters in `localStorage`, keyed by the route-param **project slug** (never a resolved UUID). Read is shape-validated so a stale or tampered entry can't feed garbage into the API query: unknown sort fields/dirs fall back to defaults, non-string array members are dropped, malformed JSON yields `null` (→ caller defaults).
- **`TaskList`**:
  - Lazy-hydrates filter state from storage on mount (no flash of defaults).
  - Re-hydrates when the `projectId` param changes — the `/projects/$projectId/tasks` route reuses the same component instance across projects (prop change, no remount), so switching projects loads that project's own filters (or defaults), never the previous project's in-memory state.
  - Writes through from each change handler (search / status / owner / sort), overriding the single changed field. Persisting from the handlers rather than an effect watching the values keeps the project-switch re-hydration from racing a stale write back to storage.
  - **Reset** clears the stored entry.
- The filter-panel open/closed toggle and pagination stay transient (not persisted) — the collapsed summary already communicates the active filters.

## Testing

New component tests in `packages/web/test/task-list-filter-persistence.test.tsx`:

- **Same project, navigate away and back** — set status→Done + a sort change, navigate to the documents page (unmounts `TaskList`), navigate back: the Done-only filter and sort selection are restored without re-interaction.
- **Cross-project isolation** — narrow project A to Done-only, switch to project B (same route, different param): B shows its own defaults and never inherits A's filter.

`bunx vitest run test/task-list-filter-persistence.test.tsx test/task-list.test.tsx` → 11/11 pass. `bun run typecheck` clean; Biome clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABkMPq6ZNMcwQW5trKeMKt

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABkMPq6ZNMcwQW5trKeMKt)_