### PR TITLE
feat(search): show matched context with highlights in results

### DIFF
--- a/packages/server/src/lib/snippet.ts
+++ b/packages/server/src/lib/snippet.ts
@@ -1,0 +1,173 @@
+import { HIGHLIGHT_SENTINEL } from '@hezo/shared';
+
+/**
+ * Builds the gray preview line for a search result. Search ranks by embedding
+ * similarity, so the typed term often isn't in the text at all (a semantic hit) —
+ * when it *is*, we centre a window on it and wrap each occurrence in
+ * {@link HIGHLIGHT_SENTINEL} so the web palette can render `<mark>`; when it
+ * isn't, we fall back to the lead text (today's behaviour) with no markers.
+ *
+ * Pure (no DB / model) so it runs identically under Node (vitest), Bun (prod),
+ * and is unit-testable in isolation. Generalises `buildSnippet` in
+ * `routes/inbox.ts`.
+ */
+
+const SNIPPET_MAX_LEN = 200;
+/** Context chars kept before the first match so it isn't flush-left. */
+const WINDOW_PAD = 60;
+/** Only terms this long get a morphological (stem) fallback. */
+const MIN_STEM_TERM_LEN = 4;
+/** Cap wrapped occurrences so a common short term doesn't make a sea of marks. */
+const MAX_HIGHLIGHTS = 8;
+
+export interface HighlightedSnippet {
+	snippet: string;
+	/** True when the query matched literally in `raw` (drives `<mark>` + the label). */
+	matched: boolean;
+}
+
+/**
+ * Collapse whitespace and strip the markdown syntax that would otherwise land
+ * inside a highlight (`##`, list/quote markers, link/image wrappers, code
+ * backticks). Conservative — keeps the visible text, only drops markup. Runs
+ * before any windowing so offsets stay stable.
+ */
+function normalize(raw: string | null | undefined): string {
+	if (!raw) return '';
+	let text = raw.split(HIGHLIGHT_SENTINEL).join(''); // defensive; NUL can't occur in corpus
+	text = text.replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1'); // image → alt
+	text = text.replace(/\[([^\]]*)\]\([^)]*\)/g, '$1'); // link → text
+	text = text.replace(/`+/g, ''); // code fences/backticks → inner text
+	text = text.replace(/^[ \t]*(?:#{1,6}|[-*+>]|\d+\.)\s+/gm, ''); // leading block markers
+	return text.replace(/\s+/g, ' ').trim();
+}
+
+/** Lowercased query tokens; drop sub-2-char tokens unless that empties the set. */
+function queryTerms(query: string): string[] {
+	const all = query
+		.toLowerCase()
+		.split(/\s+/)
+		.map((t) => t.replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, ''))
+		.filter((t) => t.length > 0);
+	const longer = all.filter((t) => t.length >= 2);
+	return longer.length > 0 ? longer : all;
+}
+
+/** Crude English suffix stripper so "marking"/"marked" share the stem "mark". */
+function stem(term: string): string {
+	for (const suffix of ['ing', 'edly', 'ed', 'es', 'ly', 's']) {
+		if (term.endsWith(suffix) && term.length - suffix.length >= 3) {
+			return term.slice(0, -suffix.length);
+		}
+	}
+	return term;
+}
+
+function isWordChar(ch: string | undefined): boolean {
+	return ch !== undefined && /[a-z0-9]/.test(ch);
+}
+
+/** The needle to search for a term, or null when it occurs nowhere in `lower`. */
+function needleFor(term: string, lower: string): string | null {
+	if (lower.includes(term)) return term;
+	if (term.length >= MIN_STEM_TERM_LEN) {
+		const s = stem(term);
+		if (s !== term && s.length >= 3 && lower.includes(s)) return s;
+	}
+	return null;
+}
+
+function mergeOverlapping(ranges: Array<[number, number]>): Array<[number, number]> {
+	const merged: Array<[number, number]> = [];
+	for (const [s, e] of ranges) {
+		const last = merged[merged.length - 1];
+		if (last && s <= last[1]) last[1] = Math.max(last[1], e);
+		else merged.push([s, e]);
+	}
+	return merged;
+}
+
+/** Sorted, merged match ranges for all terms; short (≤2 char) needles must be word-bounded. */
+function findRanges(text: string, terms: string[]): Array<[number, number]> {
+	const lower = text.toLowerCase();
+	const ranges: Array<[number, number]> = [];
+	for (const term of terms) {
+		const needle = needleFor(term, lower);
+		if (!needle) continue;
+		const wordBoundary = needle.length <= 2;
+		let from = 0;
+		for (;;) {
+			const idx = lower.indexOf(needle, from);
+			if (idx === -1) break;
+			const end = idx + needle.length;
+			if (!wordBoundary || (!isWordChar(lower[idx - 1]) && !isWordChar(lower[end]))) {
+				ranges.push([idx, end]);
+			}
+			from = end;
+		}
+	}
+	ranges.sort((a, b) => a[0] - b[0]);
+	return mergeOverlapping(ranges);
+}
+
+function truncateLead(text: string): string {
+	if (text.length <= SNIPPET_MAX_LEN) return text;
+	return `${text.slice(0, SNIPPET_MAX_LEN).trimEnd()}…`;
+}
+
+/** Slice `[start,end)` of `text`, wrapping in-window ranges with the sentinel. */
+function wrapWindow(
+	text: string,
+	start: number,
+	end: number,
+	ranges: Array<[number, number]>,
+): string {
+	let out = '';
+	let cursor = start;
+	let count = 0;
+	for (const [rs, re] of ranges) {
+		if (re <= start || rs >= end) continue;
+		if (count >= MAX_HIGHLIGHTS) break;
+		const s = Math.max(rs, start);
+		const e = Math.min(re, end);
+		if (s > cursor) out += text.slice(cursor, s);
+		out += `${HIGHLIGHT_SENTINEL}${text.slice(s, e)}${HIGHLIGHT_SENTINEL}`;
+		cursor = e;
+		count++;
+	}
+	if (cursor < end) out += text.slice(cursor, end);
+	return out;
+}
+
+export function buildHighlightedSnippet(
+	raw: string | null | undefined,
+	query: string,
+): HighlightedSnippet {
+	const text = normalize(raw);
+	if (!text) return { snippet: '', matched: false };
+
+	const ranges = findRanges(text, queryTerms(query));
+	if (ranges.length === 0) {
+		return { snippet: truncateLead(text), matched: false };
+	}
+
+	const firstStart = ranges[0][0];
+	let start = Math.max(0, firstStart - WINDOW_PAD);
+	const end = Math.min(text.length, start + SNIPPET_MAX_LEN);
+	start = Math.max(0, end - SNIPPET_MAX_LEN); // backfill the window if we hit the end
+
+	const windowed = wrapWindow(text, start, end, ranges);
+	const prefix = start > 0 ? '…' : '';
+	const suffix = end < text.length ? '…' : '';
+	return { snippet: `${prefix}${windowed}${suffix}`, matched: true };
+}
+
+/**
+ * Whether any query term occurs (literally or by stem) in `text`. Used to check a
+ * result's title so a title-only match isn't mislabeled a semantic-only hit.
+ */
+export function hasLiteralMatch(text: string | null | undefined, query: string): boolean {
+	const normalized = normalize(text);
+	if (!normalized) return false;
+	return findRanges(normalized, queryTerms(query)).length > 0;
+}

--- a/packages/server/src/services/embeddings.ts
+++ b/packages/server/src/services/embeddings.ts
@@ -1,5 +1,6 @@
 import type { PGlite } from '@electric-sql/pglite';
 import type { SearchResult, SearchScope } from '@hezo/shared';
+import { buildHighlightedSnippet, hasLiteralMatch } from '../lib/snippet';
 import { logger } from '../logger';
 
 const log = logger.child('embeddings');
@@ -104,7 +105,7 @@ export async function semanticSearch(
 			project_slug: string;
 			score: number;
 		}>(
-			`SELECT d.id, d.title, d.slug, LEFT(d.content, 200) AS content,
+			`SELECT d.id, d.title, d.slug, LEFT(d.content, 4000) AS content,
 			        p.slug AS project_slug, 1 - (d.embedding <=> $1::vector) AS score
 			 FROM documents d
 			 JOIN projects p ON p.id = d.project_id
@@ -114,11 +115,14 @@ export async function semanticSearch(
 			[vectorStr, teamIds, limit],
 		);
 		for (const r of docResults.rows) {
+			const title = r.title || r.slug;
+			const { snippet, matched } = buildHighlightedSnippet(r.content, query);
 			results.push({
 				type: 'project_doc',
 				id: r.id,
-				title: r.title || r.slug,
-				snippet: r.content,
+				title,
+				snippet,
+				semanticOnly: !matched && !hasLiteralMatch(title, query),
 				score: r.score,
 				projectSlug: r.project_slug,
 				docSlug: r.slug,
@@ -135,7 +139,7 @@ export async function semanticSearch(
 			project_slug: string;
 			score: number;
 		}>(
-			`SELECT t.id, t.title, LEFT(t.description, 200) AS description, t.identifier,
+			`SELECT t.id, t.title, LEFT(t.description, 4000) AS description, t.identifier,
 			        p.slug AS project_slug, 1 - (t.embedding <=> $1::vector) AS score
 			 FROM tasks t
 			 JOIN projects p ON p.id = t.project_id
@@ -145,11 +149,14 @@ export async function semanticSearch(
 			[vectorStr, teamIds, limit],
 		);
 		for (const r of taskResults.rows) {
+			const title = `${r.identifier} — ${r.title}`;
+			const { snippet, matched } = buildHighlightedSnippet(r.description, query);
 			results.push({
 				type: 'task',
 				id: r.id,
-				title: `${r.identifier} — ${r.title}`,
-				snippet: r.description,
+				title,
+				snippet,
+				semanticOnly: !matched && !hasLiteralMatch(title, query),
 				score: r.score,
 				projectSlug: r.project_slug,
 				taskIdentifier: r.identifier,
@@ -168,7 +175,7 @@ export async function semanticSearch(
 			score: number;
 		}>(
 			`SELECT c.id, c.public_id, t.identifier, t.title AS task_title,
-			        p.slug AS project_slug, LEFT(c.content->>'text', 200) AS snippet,
+			        p.slug AS project_slug, LEFT(c.content->>'text', 4000) AS snippet,
 			        1 - (c.embedding <=> $1::vector) AS score
 			 FROM task_comments c
 			 JOIN tasks t ON t.id = c.task_id
@@ -179,11 +186,14 @@ export async function semanticSearch(
 			[vectorStr, teamIds, limit],
 		);
 		for (const r of commentResults.rows) {
+			const title = `${r.identifier} — ${r.task_title}`;
+			const { snippet, matched } = buildHighlightedSnippet(r.snippet, query);
 			results.push({
 				type: 'comment',
 				id: r.id,
-				title: `${r.identifier} — ${r.task_title}`,
-				snippet: r.snippet,
+				title,
+				snippet,
+				semanticOnly: !matched && !hasLiteralMatch(title, query),
 				score: r.score,
 				projectSlug: r.project_slug,
 				taskIdentifier: r.identifier,
@@ -199,7 +209,7 @@ export async function semanticSearch(
 			content: string;
 			score: number;
 		}>(
-			`SELECT id, name, LEFT(content, 200) AS content, 1 - (embedding <=> $1::vector) AS score
+			`SELECT id, name, LEFT(content, 4000) AS content, 1 - (embedding <=> $1::vector) AS score
 			 FROM skills
 			 WHERE embedding IS NOT NULL AND is_active = true
 			 ORDER BY embedding <=> $1::vector
@@ -207,7 +217,15 @@ export async function semanticSearch(
 			[vectorStr, limit],
 		);
 		for (const r of skillResults.rows) {
-			results.push({ type: 'skill', id: r.id, title: r.name, snippet: r.content, score: r.score });
+			const { snippet, matched } = buildHighlightedSnippet(r.content, query);
+			results.push({
+				type: 'skill',
+				id: r.id,
+				title: r.name,
+				snippet,
+				semanticOnly: !matched && !hasLiteralMatch(r.name, query),
+				score: r.score,
+			});
 		}
 	}
 

--- a/packages/server/test/embeddings.test.ts
+++ b/packages/server/test/embeddings.test.ts
@@ -1,5 +1,7 @@
 import type { PGlite } from '@electric-sql/pglite';
+import { HIGHLIGHT_SENTINEL } from '@hezo/shared';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildHighlightedSnippet, hasLiteralMatch } from '../src/lib/snippet';
 import {
 	EMBEDDING_DIMENSIONS,
 	embedAndStore,
@@ -280,6 +282,45 @@ describe('comment search with pre-populated embeddings', () => {
 			expect(row.content_type).toBe('text');
 			expect(row.text.trim().length).toBeGreaterThan(0);
 		}
+	});
+});
+
+describe('snippet shaping over real DB rows', () => {
+	// The seeded comment text is "We should retry failed Stripe webhooks" on a
+	// task titled "Payment flow" (see the comment-search beforeAll above).
+	async function fetchCommentRow() {
+		// Mirrors the production comment query's widened projection.
+		const r = await db.query<{ snippet: string; identifier: string; task_title: string }>(
+			`SELECT LEFT(c.content->>'text', 4000) AS snippet, t.identifier, t.title AS task_title
+			 FROM task_comments c
+			 JOIN tasks t ON t.id = c.task_id
+			 WHERE c.content_type = 'text' AND c.content->>'text' ILIKE '%Stripe%'
+			 LIMIT 1`,
+		);
+		expect(r.rows.length).toBe(1);
+		return r.rows[0];
+	}
+
+	it('builds a highlighted snippet from the widened select; not semantic-only', async () => {
+		const row = await fetchCommentRow();
+		const { snippet, matched } = buildHighlightedSnippet(row.snippet, 'stripe');
+		expect(matched).toBe(true);
+		// Case-insensitive match, original casing preserved inside the marker pair.
+		expect(snippet).toContain(`${HIGHLIGHT_SENTINEL}Stripe${HIGHLIGHT_SENTINEL}`);
+
+		const title = `${row.identifier} — ${row.task_title}`;
+		expect(!matched && !hasLiteralMatch(title, 'stripe')).toBe(false);
+	});
+
+	it('flags semantic-only when the term is in neither body nor title', async () => {
+		const row = await fetchCommentRow();
+		const query = 'kubernetes'; // absent from both the comment and the task title
+		const { snippet, matched } = buildHighlightedSnippet(row.snippet, query);
+		expect(matched).toBe(false);
+		expect(snippet).not.toContain(HIGHLIGHT_SENTINEL); // lead-text fallback, no marker
+
+		const title = `${row.identifier} — ${row.task_title}`;
+		expect(!matched && !hasLiteralMatch(title, query)).toBe(true);
 	});
 });
 

--- a/packages/server/test/snippet.test.ts
+++ b/packages/server/test/snippet.test.ts
@@ -1,0 +1,146 @@
+import { HIGHLIGHT_SENTINEL } from '@hezo/shared';
+import { describe, expect, it } from 'vitest';
+import { buildHighlightedSnippet, hasLiteralMatch } from '../src/lib/snippet';
+
+const S = HIGHLIGHT_SENTINEL;
+
+/** The user-visible text: matched markers and ellipses stripped. */
+function visible(snippet: string): string {
+	return snippet.split(S).join('').replace(/…/g, '');
+}
+
+/** Count of highlighted spans (each wrapped in a pair of sentinels). */
+function highlightCount(snippet: string): number {
+	const sentinels = snippet.split(S).length - 1;
+	return sentinels / 2;
+}
+
+describe('buildHighlightedSnippet', () => {
+	it('centers a window on a mid-text match and highlights the term', () => {
+		const text = `${'Lorem ipsum dolor sit amet '.repeat(5)}configure the webhook retry ${'consectetur adipiscing elit '.repeat(5)}`;
+		const { snippet, matched } = buildHighlightedSnippet(text, 'webhook');
+
+		expect(matched).toBe(true);
+		expect(snippet).toContain(`${S}webhook${S}`);
+		expect(snippet.startsWith('…')).toBe(true); // context trimmed on the left
+		expect(snippet.endsWith('…')).toBe(true); // ...and the right
+		expect(visible(snippet).length).toBeLessThanOrEqual(200);
+	});
+
+	it('falls back to the lead text with no markers when nothing matches', () => {
+		const { snippet, matched } = buildHighlightedSnippet('the quick brown fox', 'zzz');
+		expect(matched).toBe(false);
+		expect(snippet).toBe('the quick brown fox');
+		expect(snippet).not.toContain(S);
+	});
+
+	it('truncates the lead-text fallback with an ellipsis', () => {
+		const text = 'word '.repeat(100); // 500 chars, no match
+		const { snippet, matched } = buildHighlightedSnippet(text, 'zzz');
+		expect(matched).toBe(false);
+		expect(snippet).not.toContain(S);
+		expect(snippet.endsWith('…')).toBe(true);
+		expect(visible(snippet).length).toBeLessThanOrEqual(200);
+	});
+
+	it('highlights every present term in a multi-word query', () => {
+		const { snippet, matched } = buildHighlightedSnippet(
+			'please retry the webhook now',
+			'retry webhook',
+		);
+		expect(matched).toBe(true);
+		expect(snippet).toContain(`${S}retry${S}`);
+		expect(snippet).toContain(`${S}webhook${S}`);
+	});
+
+	it('skips query terms that are absent', () => {
+		const { snippet, matched } = buildHighlightedSnippet('please retry now', 'retry missingword');
+		expect(matched).toBe(true);
+		expect(snippet).toContain(`${S}retry${S}`);
+		expect(snippet).not.toContain('missingword');
+	});
+
+	it('omits the leading ellipsis when the match is at the start', () => {
+		const text = `webhook ${'alpha beta gamma '.repeat(20)}`;
+		const { snippet } = buildHighlightedSnippet(text, 'webhook');
+		expect(snippet.startsWith('…')).toBe(false);
+		expect(snippet.startsWith(`${S}webhook${S}`)).toBe(true);
+		expect(snippet.endsWith('…')).toBe(true);
+	});
+
+	it('omits the trailing ellipsis when the match is at the end', () => {
+		const text = `${'alpha beta gamma '.repeat(20)}finalword`;
+		const { snippet } = buildHighlightedSnippet(text, 'finalword');
+		expect(snippet.startsWith('…')).toBe(true);
+		expect(snippet.endsWith('…')).toBe(false);
+		expect(snippet.endsWith(`${S}finalword${S}`)).toBe(true);
+	});
+
+	it('matches case-insensitively but preserves the source casing', () => {
+		const { snippet } = buildHighlightedSnippet('Open the Login Page now', 'login');
+		expect(snippet).toContain(`${S}Login${S}`);
+	});
+
+	it('matches morphological variants via stemming (marking → marked)', () => {
+		const { snippet, matched } = buildHighlightedSnippet('we marked it done', 'marking');
+		expect(matched).toBe(true);
+		expect(snippet).toContain(`${S}mark${S}`);
+	});
+
+	it('matches a longer word from a shorter query term (mark → marking)', () => {
+		const { snippet, matched } = buildHighlightedSnippet('marking tasks complete', 'mark');
+		expect(matched).toBe(true);
+		expect(snippet).toContain(`${S}mark${S}`);
+	});
+
+	it('strips markdown syntax so highlights land on words, not markup', () => {
+		const text = '## Deploy guide\n\nSee [the deploy doc](/x) for `deploy` steps';
+		const { snippet } = buildHighlightedSnippet(text, 'deploy');
+		expect(snippet).toContain(`${S}Deploy${S}`);
+		expect(snippet).not.toContain('#');
+		expect(snippet).not.toContain('`');
+		expect(snippet).not.toContain('](');
+	});
+
+	it('caps the number of highlighted occurrences', () => {
+		const { snippet } = buildHighlightedSnippet('spam '.repeat(80), 'spam');
+		expect(highlightCount(snippet)).toBeLessThanOrEqual(8);
+	});
+
+	it('requires a word boundary for very short (≤2 char) terms', () => {
+		// "to" should not light up "today"/"stop"; it should match the standalone word.
+		const { snippet, matched } = buildHighlightedSnippet('today we stop to rest', 'to');
+		expect(matched).toBe(true);
+		expect(snippet).toContain(`${S}to${S}`);
+		expect(snippet).not.toContain(`${S}to${S}day`);
+	});
+
+	it('returns empty for null/blank input', () => {
+		expect(buildHighlightedSnippet(null, 'x')).toEqual({ snippet: '', matched: false });
+		expect(buildHighlightedSnippet('   ', 'x')).toEqual({ snippet: '', matched: false });
+	});
+
+	it('never emits a stray sentinel from sentinel-bearing source (defensive)', () => {
+		const { snippet } = buildHighlightedSnippet(`a${S}b nothing here`, 'zzz');
+		expect(snippet).not.toContain(S);
+	});
+});
+
+describe('hasLiteralMatch', () => {
+	it('is true when a term appears in the text', () => {
+		expect(hasLiteralMatch('EP-3 — Fix login bug', 'login')).toBe(true);
+	});
+
+	it('is true via stemming', () => {
+		expect(hasLiteralMatch('EP-3 — Fix marked items', 'marking')).toBe(true);
+	});
+
+	it('is false when no term appears', () => {
+		expect(hasLiteralMatch('EP-3 — Fix login bug', 'logout')).toBe(false);
+	});
+
+	it('is false for null/blank input', () => {
+		expect(hasLiteralMatch(null, 'x')).toBe(false);
+		expect(hasLiteralMatch('   ', 'x')).toBe(false);
+	});
+});

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -151,12 +151,28 @@ export type SearchScope = (typeof SEARCH_SCOPES)[number];
 export const SEARCH_RESULT_TYPES = ['task', 'skill', 'project_doc', 'comment'] as const;
 export type SearchResultType = (typeof SEARCH_RESULT_TYPES)[number];
 
+/**
+ * Marks the start/end of a matched term inside `SearchResult.snippet`. The server
+ * wraps each highlighted span in this sentinel and the web palette splits on it to
+ * render `<mark>` (never via `dangerouslySetInnerHTML`). NUL is used because
+ * Postgres `text`/`jsonb` reject NUL bytes on insert, so the indexed corpus can
+ * never contain it — the marker is collision-free by construction, and it
+ * round-trips cleanly through JSON.
+ */
+export const HIGHLIGHT_SENTINEL = '\u0000';
+
 export interface SearchResult {
 	type: SearchResultType;
 	id: string;
 	title: string;
 	snippet: string;
 	score: number;
+	/**
+	 * True when the query term appears nowhere literally (neither title nor body)
+	 * and the result surfaced purely via embedding similarity. Drives the
+	 * "related" label so the absence of a highlight is explained.
+	 */
+	semanticOnly?: boolean;
 	/** Project slug for the destination route (tasks, comments, project docs). */
 	projectSlug?: string;
 	/** Friendly task identifier, e.g. `TO-4` (tasks and comments). */

--- a/packages/web/src/components/search-results.tsx
+++ b/packages/web/src/components/search-results.tsx
@@ -1,7 +1,7 @@
-import type { SearchResult, SearchResultType } from '@hezo/shared';
+import { HIGHLIGHT_SENTINEL, type SearchResult, type SearchResultType } from '@hezo/shared';
 import { Link } from '@tanstack/react-router';
 import { BookOpen, CheckSquare, FileText, type LucideIcon, MessageSquare } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { Fragment, type ReactNode, useMemo, useState } from 'react';
 
 const TYPE_META: Record<SearchResultType, { label: string; Icon: LucideIcon }> = {
 	task: { label: 'Tasks', Icon: CheckSquare },
@@ -88,6 +88,27 @@ export function SearchResults({
 
 const ROW_CLASS = 'mx-1 flex items-start gap-2 rounded-md px-3 py-2 hover:bg-surface-2';
 
+/**
+ * Render a snippet whose matched terms the server wrapped in
+ * {@link HIGHLIGHT_SENTINEL}. Splitting on the sentinel and rendering each segment
+ * as a React text node keeps this XSS-safe — content is never interpreted as HTML
+ * (no `dangerouslySetInnerHTML`). Odd segments are the matched spans.
+ */
+function renderHighlighted(snippet: string): ReactNode {
+	if (!snippet.includes(HIGHLIGHT_SENTINEL)) return snippet;
+	return snippet.split(HIGHLIGHT_SENTINEL).map((segment, i) =>
+		i % 2 === 1 ? (
+			// biome-ignore lint/suspicious/noArrayIndexKey: segments are positional and stable per render
+			<mark key={i} className="rounded-sm bg-accent/20 px-0.5 text-text-1">
+				{segment}
+			</mark>
+		) : (
+			// biome-ignore lint/suspicious/noArrayIndexKey: segments are positional and stable per render
+			<Fragment key={i}>{segment}</Fragment>
+		),
+	);
+}
+
 function SearchResultRow({ result, onSelect }: { result: SearchResult; onSelect: () => void }) {
 	const { Icon } = TYPE_META[result.type];
 	const testId = `search-result-${result.type}`;
@@ -95,8 +116,22 @@ function SearchResultRow({ result, onSelect }: { result: SearchResult; onSelect:
 		<>
 			<Icon className="mt-0.5 h-4 w-4 shrink-0 text-text-3" />
 			<span className="flex min-w-0 flex-col">
-				<span className="truncate text-[13px] text-text-1">{result.title}</span>
-				{result.snippet && <span className="truncate text-xs text-text-3">{result.snippet}</span>}
+				<span className="flex min-w-0 items-center gap-1.5">
+					<span className="truncate text-[13px] text-text-1">{result.title}</span>
+					{result.semanticOnly && (
+						<span
+							className="shrink-0 rounded bg-surface-2 px-1 text-[10px] uppercase tracking-wide text-text-3"
+							data-testid="search-result-related"
+						>
+							related
+						</span>
+					)}
+				</span>
+				{result.snippet && (
+					<span className="line-clamp-2 text-xs text-text-3">
+						{renderHighlighted(result.snippet)}
+					</span>
+				)}
 			</span>
 		</>
 	);

--- a/packages/web/test/global-search.test.tsx
+++ b/packages/web/test/global-search.test.tsx
@@ -1,6 +1,6 @@
-import type { SearchResult } from '@hezo/shared';
+import { HIGHLIGHT_SENTINEL, type SearchResult } from '@hezo/shared';
 import { api } from '@hezo/web/lib/api';
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import { afterEach, expect, test, vi } from 'vitest';
 import { renderApp } from './helpers/render';
 import { seedProject, seedTask, seedWorkspace } from './helpers/seed';
@@ -129,4 +129,81 @@ test('renders per-type tabs with counts, deep-links comments, and closes on sele
 	// Selecting a result closes the palette.
 	await user.click(commentRows[0]);
 	await dialogGone();
+});
+
+test('highlights matched terms, labels semantic-only hits, and escapes HTML', async () => {
+	let projectSlug = '';
+	let identifier = '';
+	const { user } = await renderApp({
+		initialPath: '/home',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Ops' });
+			const task = await seedTask(ws, project, { title: 'Fix login' });
+			projectSlug = project.slug;
+			identifier = task.identifier;
+		},
+	});
+
+	const S = HIGHLIGHT_SENTINEL;
+	const fixtures: SearchResult[] = [
+		{
+			type: 'task',
+			id: 't1',
+			title: `${identifier} — Fix login`,
+			snippet: `before ${S}login${S} after`,
+			score: 0.9,
+			projectSlug,
+			taskIdentifier: identifier,
+		},
+		{
+			type: 'task',
+			id: 't2',
+			title: `${identifier} — Related task`,
+			snippet: 'matched purely by meaning',
+			semanticOnly: true,
+			score: 0.7,
+			projectSlug,
+			taskIdentifier: identifier,
+		},
+		{
+			type: 'task',
+			id: 't3',
+			title: `${identifier} — XSS task`,
+			snippet: `safe ${S}<b>x</b>${S} text`,
+			score: 0.6,
+			projectSlug,
+			taskIdentifier: identifier,
+		},
+	];
+
+	const realGet = api.get.bind(api);
+	vi.spyOn(api, 'get').mockImplementation(((
+		path: string,
+		params?: Record<string, string | undefined>,
+	) => {
+		if (path === '/api/search') return Promise.resolve({ results: fixtures });
+		return realGet(path, params);
+	}) as typeof api.get);
+
+	await user.click(await screen.findByTestId('app-header-search'));
+	await user.type(await screen.findByTestId('global-search-input'), 'login');
+
+	const rows = await screen.findAllByTestId('search-result-task');
+	expect(rows).toHaveLength(3);
+
+	// 1. The matched term is wrapped in <mark>; surrounding text stays plain and the
+	//    sentinel is never shown to the user.
+	expect(rows[0].querySelector('mark')?.textContent).toBe('login');
+	expect(rows[0].textContent).toContain('before login after');
+	expect(rows[0].textContent).not.toContain(S);
+	expect(within(rows[0]).queryByTestId('search-result-related')).toBeNull();
+
+	// 2. A semantic-only hit shows the "related" label and no highlight.
+	expect(rows[1].querySelector('mark')).toBeNull();
+	expect(within(rows[1]).getByTestId('search-result-related').textContent).toBe('related');
+
+	// 3. HTML inside a highlighted span is escaped (rendered as text, not an element).
+	expect(rows[2].querySelector('b')).toBeNull();
+	expect(rows[2].querySelector('mark')?.textContent).toBe('<b>x</b>');
 });


### PR DESCRIPTION
## Why

Each search result's gray preview is just the first 200 chars of the item's text (`LEFT(field, 200)`). Because search ranks by **embedding similarity**, the typed term frequently doesn't appear in that lead text at all — so the preview never shows *why* a result matched (e.g. searching "mark" returns relevant items whose previews don't contain "mark").

This makes the preview a **context window centered on the query term, with the term highlighted**, so the match is self-explanatory.

### On the "should we switch to lunr.js?" question — no
- lunr is a **client-side** index, so adopting it would mean shipping every team's tasks/comments/docs the user can access to the browser to build the index — that breaks the team-scoped authorization model and leaks cross-team data.
- It also throws away semantic recall (synonyms, typos, conceptual matches) and wouldn't produce snippets for free anyway.

The feature is achievable on top of the existing embeddings with **no engine swap, no migration, and no new dependency**.

## What changed
- **`packages/server/src/lib/snippet.ts`** (new, pure util): builds a context window centered on the first literal match and wraps occurrences in a NUL sentinel. Strips markdown noise, handles multi-word queries, is case-insensitive with light stemming (`marking` ↔ `marked`), caps highlight count, and requires a word boundary for ≤2-char terms. Falls back to lead text on no match. `hasLiteralMatch` checks titles so a title-only match isn't mislabeled semantic-only.
- **`embeddings.ts`**: widen the 4 per-type snippet selects (`200` → `4000`) and shape each result through the util, setting the new `semanticOnly` flag.
- **shared**: add `HIGHLIGHT_SENTINEL` + optional `SearchResult.semanticOnly`.
- **web `search-results.tsx`**: render highlighted spans as `<mark>` by splitting on the sentinel (XSS-safe — React escapes each segment, no `dangerouslySetInnerHTML`), switch the snippet line from `truncate` to `line-clamp-2`, and show a small **"related"** pill for semantic-only hits (so the absence of a highlight is explained).

## Behavior
- **Literal hit** → window centered on the term, every in-window occurrence highlighted, leading/trailing `…` as appropriate.
- **Semantic-only hit** (term in neither body nor title) → lead text, no highlight, **"related"** label.
- **Title-only hit** → lead-text body (no body highlight), no "related" label.

## Tests
- `packages/server/test/snippet.test.ts` (new): windowing, highlight, fallback, multi-word, start/middle/end ellipsis rules, case preservation, stemming, markdown stripping, short-term word boundary, null/empty, sentinel safety.
- `packages/server/test/embeddings.test.ts` (extended): proves the widened SQL + util compose over real PGlite rows and the `semanticOnly` logic.
- `packages/web/test/global-search.test.tsx` (extended): highlight rendering, the "related" label, and HTML escaping.

## Verification
- `bun run typecheck` ✓ · `bun run check` ✓ (0 errors)
- New/affected suites green: snippet (19), embeddings (17), web global-search (5)
- Full `bun run test --skip-browser`: server `2182 passed` / web `372 passed`. The only failures are 10 pre-existing, environment-related tests in `git.test.ts`/`ssh-agent-server.test.ts` (missing `ssh-keygen`/`ssh-add`) — verified identical on the clean baseline with these changes stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M9diLotdJEM3MraKaHwiev

---
_Generated by [Claude Code](https://claude.ai/code/session_01M9diLotdJEM3MraKaHwiev)_