### PR TITLE
feat(tasks): split terminal tickets into a Done section

### DIFF
--- a/packages/web/src/components/task-list.tsx
+++ b/packages/web/src/components/task-list.tsx
@@ -214,14 +214,28 @@ export function TaskList({ projectId }: TaskListProps) {
 		() => nestTasksForDisplay(inProgressResult?.data ?? []),
 		[inProgressResult?.data],
 	);
-	const tasks = useMemo(() => {
-		if (!todoListEnabled) return [];
+	// Split the filtered main list into "Backlog" (open work) and "Done" (terminal:
+	// done/closed/cancelled). Each group nests independently so a child whose parent
+	// sits in the other group surfaces at the top level of its own section — the same
+	// way the In-progress / Backlog split already behaves across separate queries.
+	const { backlogTasks, doneTasks } = useMemo<{
+		backlogTasks: TaskRow[];
+		doneTasks: TaskRow[];
+	}>(() => {
+		if (!todoListEnabled) return { backlogTasks: [], doneTasks: [] };
 		const rows = (result?.data ?? []).filter((t) => !PINNED_STATUS_SET.has(t.status));
-		return nestTasksForDisplay(rows);
+		return {
+			backlogTasks: nestTasksForDisplay(rows.filter((t) => !TERMINAL_STATUS_SET.has(t.status))),
+			doneTasks: nestTasksForDisplay(rows.filter((t) => TERMINAL_STATUS_SET.has(t.status))),
+		};
 	}, [result?.data, todoListEnabled]);
 
 	const hasNoTasksAtAll =
-		!inProgressLoading && !mainLoading && inProgressTasks.length === 0 && tasks.length === 0;
+		!inProgressLoading &&
+		!mainLoading &&
+		inProgressTasks.length === 0 &&
+		backlogTasks.length === 0 &&
+		doneTasks.length === 0;
 
 	const ownerLabelById = useMemo(() => {
 		const map = new Map<string, string>();
@@ -527,74 +541,85 @@ export function TaskList({ projectId }: TaskListProps) {
 				/>
 			)}
 
-			<section data-testid="task-list-main" className="mb-6 last:mb-0">
-				<h2 className="text-[11px] font-medium uppercase tracking-wider text-text-3 mb-2 px-0.5">
-					Backlog
-				</h2>
-
-				{mainLoading ? (
-					<div className="text-text-2 text-[13px] py-8 text-center">Loading...</div>
-				) : hasNoTasksAtAll ? (
-					<EmptyState
-						variant="hero"
-						icon={<ListPlus className="w-8 h-8" />}
-						title="No tasks yet"
-						description="Create a task to get the team moving."
-						action={
-							<Button
-								size="lg"
-								onClick={() => setCreateOpen(true)}
-								data-testid="task-list-empty-create"
-							>
-								<Plus className="w-4 h-4" />
-								Create a task
-							</Button>
-						}
-					/>
-				) : tasks.length > 0 ? (
-					<DataTable
+			{mainLoading ? (
+				<div
+					data-testid="task-list-loading"
+					className="text-text-2 text-[13px] py-8 text-center mb-6"
+				>
+					Loading...
+				</div>
+			) : hasNoTasksAtAll ? (
+				<EmptyState
+					variant="hero"
+					icon={<ListPlus className="w-8 h-8" />}
+					title="No tasks yet"
+					description="Create a task to get the team moving."
+					action={
+						<Button
+							size="lg"
+							onClick={() => setCreateOpen(true)}
+							data-testid="task-list-empty-create"
+						>
+							<Plus className="w-4 h-4" />
+							Create a task
+						</Button>
+					}
+				/>
+			) : (
+				<>
+					{/* Open work and finished work each get their own section; an empty one
+					    is omitted entirely (TaskListSection returns null). */}
+					<TaskListSection
+						title="Backlog"
+						testId="task-list-main"
+						tasks={backlogTasks}
 						columns={columns}
-						data={tasks}
-						rowKey={(row) => row.id}
 						onRowClick={handleRowClick}
-						getRowDepth={(row) => row.depth}
-						indentColumnKey="title"
 					/>
-				) : (
-					<p
-						className="text-text-2 text-[13px] py-6 text-center"
-						data-testid="task-list-todo-empty"
-					>
-						No matching tasks
-					</p>
-				)}
+					<TaskListSection
+						title="Done"
+						testId="task-list-done"
+						tasks={doneTasks}
+						columns={columns}
+						onRowClick={handleRowClick}
+					/>
 
-				{result?.meta && result.meta.total > result.meta.per_page && (
-					<div className="flex items-center justify-between mt-4 text-xs text-text-2">
-						<span>
-							Showing {tasks.length} of {result.meta.total}
-						</span>
-						<div className="flex gap-2">
-							<Button
-								variant="secondary"
-								size="sm"
-								disabled={result.meta.page <= 1}
-								onClick={() => setPage((p) => Math.max(1, p - 1))}
-							>
-								Previous
-							</Button>
-							<Button
-								variant="secondary"
-								size="sm"
-								disabled={result.meta.page * result.meta.per_page >= result.meta.total}
-								onClick={() => setPage((p) => p + 1)}
-							>
-								Next
-							</Button>
+					{backlogTasks.length === 0 && doneTasks.length === 0 && (
+						<p
+							className="text-text-2 text-[13px] py-6 text-center"
+							data-testid="task-list-todo-empty"
+						>
+							No matching tasks
+						</p>
+					)}
+
+					{result?.meta && result.meta.total > result.meta.per_page && (
+						<div className="flex items-center justify-between mt-4 text-xs text-text-2">
+							<span>
+								Showing {backlogTasks.length + doneTasks.length} of {result.meta.total}
+							</span>
+							<div className="flex gap-2">
+								<Button
+									variant="secondary"
+									size="sm"
+									disabled={result.meta.page <= 1}
+									onClick={() => setPage((p) => Math.max(1, p - 1))}
+								>
+									Previous
+								</Button>
+								<Button
+									variant="secondary"
+									size="sm"
+									disabled={result.meta.page * result.meta.per_page >= result.meta.total}
+									onClick={() => setPage((p) => p + 1)}
+								>
+									Next
+								</Button>
+							</div>
 						</div>
-					</div>
-				)}
-			</section>
+					)}
+				</>
+			)}
 
 			<CreateTaskDialog projectId={projectId} open={createOpen} onOpenChange={setCreateOpen} />
 		</div>

--- a/packages/web/test/task-list.test.tsx
+++ b/packages/web/test/task-list.test.tsx
@@ -164,6 +164,105 @@ test('multi-select status filter narrows results and reset restores defaults', a
 	);
 });
 
+test('terminal tasks render in a Done section split out from the Backlog', async () => {
+	let projectSlug = '';
+
+	const { findByTestId, findByText, findByRole, queryByTestId, queryByText, router, user } =
+		await renderApp({
+			initialPath: '/',
+			seed: async () => {
+				const ws = await seedWorkspace();
+				const project = await seedProject(ws, { name: 'Done Split Project' });
+				projectSlug = project.slug;
+				const agentId = ws.agents[0].id;
+				await seedTask(ws, project, { title: 'Backlog Task', assignee_id: agentId });
+				const done = await seedTask(ws, project, { title: 'Done Task', assignee_id: agentId });
+				const closed = await seedTask(ws, project, { title: 'Closed Task', assignee_id: agentId });
+				await patchStatus(ws, done.id, 'done');
+				await patchStatus(ws, closed.id, 'closed');
+			},
+		});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks',
+		params: { projectId: projectSlug },
+	});
+
+	// Default view excludes terminal statuses, so the Done section is absent.
+	await findByText('Backlog Task', undefined, { timeout: 10_000 });
+	expect(queryByTestId('task-list-done')).toBeNull();
+	expect(queryByText('Done Task')).toBeNull();
+	expect(queryByText('Closed Task')).toBeNull();
+
+	// Add the terminal statuses to the filter so the finished work is fetched.
+	const toggle = await findByTestId('task-filter-toggle');
+	await user.click(toggle);
+	const statusBtn = await findByTestId('task-filter-status');
+	await user.click(statusBtn);
+	const doneOption = await findByRole('button', { name: 'Done' });
+	await user.click(doneOption);
+	const closedOption = await findByRole('button', { name: 'Closed' });
+	await user.click(closedOption);
+	await user.click(statusBtn);
+
+	// Terminal tasks land under "Done"; the Backlog keeps only open work.
+	const doneSection = await findByTestId('task-list-done');
+	await waitFor(
+		() => {
+			expect(doneSection.textContent).toContain('Done Task');
+			expect(doneSection.textContent).toContain('Closed Task');
+		},
+		{ timeout: 10_000 },
+	);
+	expect(doneSection.querySelector('h2')?.textContent).toBe('Done');
+	expect(doneSection.textContent).not.toContain('Backlog Task');
+
+	const backlogSection = await findByTestId('task-list-main');
+	expect(backlogSection.querySelector('h2')?.textContent).toBe('Backlog');
+	expect(backlogSection.textContent).toContain('Backlog Task');
+	expect(backlogSection.textContent).not.toContain('Done Task');
+	expect(backlogSection.textContent).not.toContain('Closed Task');
+});
+
+test('Done section hides when only terminal tasks remain after filtering them out', async () => {
+	let projectSlug = '';
+
+	const { findByTestId, findByText, findByRole, queryByTestId, router, user } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Only Done Project' });
+			projectSlug = project.slug;
+			const agentId = ws.agents[0].id;
+			const done = await seedTask(ws, project, { title: 'Finished Task', assignee_id: agentId });
+			await patchStatus(ws, done.id, 'done');
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks',
+		params: { projectId: projectSlug },
+	});
+
+	// Filter to just "Done": only the Done section renders, no empty Backlog header.
+	const toggle = await findByTestId('task-filter-toggle');
+	await user.click(toggle);
+	const statusBtn = await findByTestId('task-filter-status');
+	await user.click(statusBtn);
+	const clear = await findByRole('button', { name: 'Clear selection' });
+	await user.click(clear);
+	const doneOption = await findByRole('button', { name: 'Done' });
+	await user.click(doneOption);
+	await user.click(statusBtn);
+
+	await findByText('Finished Task', undefined, { timeout: 10_000 });
+	await waitFor(() => {
+		expect(queryByTestId('task-list-done')).not.toBeNull();
+	});
+	// No open work matches, so the Backlog section is omitted entirely.
+	expect(queryByTestId('task-list-main')).toBeNull();
+});
+
 test('filter bar collapses/expands and applies search + sort', async () => {
 	let projectSlug = '';
 


### PR DESCRIPTION
## What

The project task list lumped finished work (done / closed / cancelled) in with open work under the **Backlog** header whenever a terminal status was part of the active filter. This splits the filtered main list into up to three sections:

- **In progress** — pinned in-progress/review work (unchanged)
- **Backlog** — open, non-terminal work
- **Done** — terminal work (done / closed / cancelled)

Each section is omitted entirely when it has no tickets, so the list only ever shows the sections that have work in them.

## Why

Closed/done tickets appearing under a header literally titled "Backlog" was confusing — finished work read as if it were still queued. Grouping terminal tickets under their own "Done" heading makes the list's state obvious at a glance.

## How

- `task-list.tsx` splits the filtered main-list rows into `backlogTasks` (non-terminal) and `doneTasks` (terminal) using the shared `TERMINAL_TASK_STATUSES` set. Each group runs through `nestTasksForDisplay` **independently**, so a child whose parent sits in the other group surfaces at the top level of its own section — the same behaviour the existing In-progress / Backlog split already has across separate queries.
- Both new sections render through the existing `TaskListSection`, which already returns `null` for an empty group — that gives the "hide empty sections" behaviour for free.
- The empty-state hero, "No matching tasks" message, and pagination footer are preserved. Pagination now reports `backlogTasks.length + doneTasks.length`.
- The default status filter still excludes terminal statuses, so the **Done** section only appears once a terminal status is in the active filter (i.e. exactly when finished tickets are actually being shown).

## Tests

Two new component tests in `task-list.test.tsx`:
- Terminal tasks render under **Done** (with a `Done` heading) and stay out of the **Backlog** section; the Backlog keeps only open work.
- Filtering to only a terminal status renders the **Done** section and omits the empty **Backlog** section.

All existing task-list and task-progress-summary tests continue to pass (including the planning-only project case that relies on the `task-list-main` section rendering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXuZS1hP4hYyxnevrF9K4p

---
_Generated by [Claude Code](https://claude.ai/code/session_01MXuZS1hP4hYyxnevrF9K4p)_