### PR TITLE
feat: scope API keys to MCP and add MCP file upload

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -465,8 +465,11 @@ domain-separated so signatures can't be replayed or cross-purposed; on unlock
 
 **Four principals.**
 - **User JWT** (HS256, secret derived from the unlock key) — `Authorization: Bearer <jwt>`.
-- **API key** — `Authorization: Bearer hezo_<key>`, bcrypt-hashed, team-scoped, board-level
-  access for external orchestrators; the `hezo_` prefix disambiguates from agent JWTs.
+- **API key** — `Authorization: Bearer hezo_<key>`, SHA-256-hashed, team-scoped. The
+  external **team-scoped** on-ramp: authenticates the **MCP endpoint (`POST /mcp`) only** —
+  rejected on REST and the WebSocket. Humans mint and revoke keys via the REST api-keys
+  routes (user JWT). The `hezo_` prefix disambiguates from agent JWTs (and `hezoc_`
+  connected-agent tokens).
 - **Agent JWT** — minted per run, carrying `{ member_id, team_id, run_id, exp }`. Validated
   on every call against the **`heartbeat_runs` row** (`id=run_id`, member/team match,
   status `running`); when the run finalizes the token is rejected on the next call —
@@ -479,6 +482,13 @@ domain-separated so signatures can't be replayed or cross-purposed; on unlock
   agents — that stays human-superuser-only. Pending registration + status polling go
   through the public onboarding surface (REST and the `/mcp` `register`/`connection_status`
   tools).
+
+By surface: **REST** is the human/browser API (user JWT), also reachable by an approved
+**connected-agent token** (admin-equivalent). **MCP** additionally accepts the **agent JWT**
+(internal per-run) and the **API key** (external, team-scoped). The API key is the one
+credential confined to MCP — an external caller can obtain neither a user JWT (needs the
+master-key seed) nor an agent JWT (minted only for a server-side run), so a team-scoped API
+key (or an admin-approved `hezoc_` token) is its only way in.
 
 **Authorization** (`AGENTS.md` › Route authorization is authoritative). Routes with
 `:projectId` resolve the project → its backing team and verify access **per request** in
@@ -587,8 +597,11 @@ One non-REST surface shares the port: the **MCP endpoint** (`POST /mcp`, Streama
 HTTP), whose tools mirror the REST surface and enforce the same authorization. It is the
 interface agents drive — tasks, comments, approvals, credentials — and external agents
 can drive it too, including **self-registering as a connected agent** (pending admin
-approval, then admin-equivalent across every project/team; § 10). `GET /SKILL.md` serves
-the manifest that teaches an external agent how to use it — including the connect/register
+approval, then admin-equivalent across every project/team; § 10). It also exposes
+`POST /mcp/assets` (multipart) for binary uploads, since JSON-RPC can't carry a file.
+**API keys authenticate the MCP surface only**; REST is the user-JWT (human/browser)
+surface (connected agents excepted — admin-equivalent on both). `GET /SKILL.md` serves the
+manifest that teaches an external agent how to use it — including the connect/register
 flow — and `GET /llms.txt` points to it. Authorization for both the REST and MCP surfaces
 is § 10.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,7 +267,8 @@ The egress audit log records substitution events by **secret name** only, never 
 
 Every route enforces authorization — never trust URL params alone.
 
-- Routes with `:projectId` resolve the project to its backing team and verify the authenticated user has access to that team per request (board users can be in multiple teams; agent / API-key auth carries `teamId` and must match the resolved team). Project resolution + access check run once in `requireProjectAccessMiddleware`, which exposes `c.var.projectId` and `c.var.teamId`.
+- Routes with `:projectId` resolve the project to its backing team and verify the authenticated user has access to that team per request (board users can be in multiple teams; an agent JWT carries `teamId` and must match the resolved team). Project resolution + access check run once in `requireProjectAccessMiddleware`, which exposes `c.var.projectId` and `c.var.teamId`.
+- **API keys authenticate the MCP surface only** — they are rejected on REST (and the WebSocket) in `authMiddleware`; their team scoping is enforced MCP-side by `authorizeScope`/`authorizeTeam` in `mcp/tools.ts`. The REST api-keys routes (key management) stay user-JWT.
 - Nested resources (`:taskId`, `:secretId`, `:commentId`, …) verify the resource belongs to the parent `:projectId` (and its team) via WHERE/JOIN before any read or write.
 - Global endpoints (no `:projectId` in path) still verify the authenticated user has access to the resource's team.
 - WebSocket subscriptions verify team membership matches the room.

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -93,7 +93,11 @@ let containerLogStreamerRef: ContainerLogStreamer | null = null;
 
 async function validateToken(token: string): Promise<WsData['auth'] | null> {
 	if (!mkmRef || !dbRef) return null;
-	return verifyToken(token, dbRef, mkmRef);
+	const auth = await verifyToken(token, dbRef, mkmRef);
+	// API keys authenticate the MCP endpoint only — not the realtime WebSocket.
+	// The browser uses a user JWT here; external callers use MCP request/response.
+	if (auth?.type === AuthType.ApiKey) return null;
+	return auth;
 }
 
 async function validateAnonymous(): Promise<WsData['auth'] | null> {

--- a/packages/server/src/mcp/server.ts
+++ b/packages/server/src/mcp/server.ts
@@ -7,6 +7,7 @@ import type { MasterKeyManager } from '../crypto/master-key';
 import type { DomainEventBus } from '../events/bus';
 import type { AuthInfo, Env } from '../lib/types';
 import { verifyToken } from '../middleware/auth';
+import { storeUploadedAsset } from '../routes/assets';
 import type { WebSocketManager } from '../services/ws';
 import {
 	handleConnectionStatusTool,
@@ -15,7 +16,7 @@ import {
 	ONBOARDING_TOOLS,
 	REGISTER_TOOL,
 } from './onboarding';
-import { authContext, registerTools, type ToolDef } from './tools';
+import { authContext, registerTools, resolveScope, type ToolDef } from './tools';
 
 let mcpServer: McpServer | null = null;
 let toolDefs: ToolDef[] = [];
@@ -160,4 +161,46 @@ export async function handleMcpRequest(c: Context<Env>): Promise<Response> {
 		await client.close();
 		await serverConnection;
 	}
+}
+
+/**
+ * Multipart binary upload for the MCP surface. JSON-RPC can't carry a file, so
+ * external callers (API key) and agent runs (run JWT) POST `multipart/form-data`
+ * here with a `file` field — plus an optional `project` field for an instance
+ * principal that must name the project it's acting in. The bytes are stored as a
+ * project asset through the same path as the REST upload, so the result is
+ * retrievable via the existing `list_project_assets` / `read_project_asset` tools
+ * (and the per-run `/workspace/.hezo/assets` mount).
+ */
+export async function handleMcpAssetUpload(c: Context<Env>): Promise<Response> {
+	const auth = await authenticateRequest(c);
+	if (!auth) {
+		return c.json({ error: { code: 'UNAUTHORIZED', message: 'Unauthorized' } }, 401);
+	}
+
+	let form: Awaited<ReturnType<typeof c.req.parseBody>>;
+	try {
+		form = await c.req.parseBody({ all: false });
+	} catch {
+		return c.json({ error: { code: 'INVALID_REQUEST', message: 'Invalid multipart body' } }, 400);
+	}
+
+	const file = form.file;
+	if (!(file instanceof Blob) || !('name' in file) || typeof file.name !== 'string') {
+		return c.json({ error: { code: 'INVALID_REQUEST', message: 'Missing file field' } }, 400);
+	}
+	const project =
+		typeof form.project === 'string' && form.project.trim().length > 0
+			? form.project.trim()
+			: undefined;
+
+	const scope = await resolveScope(c.get('db'), auth, { project });
+	if ('error' in scope) {
+		return c.json({ error: { code: 'FORBIDDEN', message: scope.error } }, 403);
+	}
+
+	// storeUploadedAsset reads c.get('auth'); /mcp isn't under authMiddleware, so
+	// seed the context from the MCP-authenticated principal.
+	c.set('auth', auth);
+	return storeUploadedAsset(c, scope.teamId, scope.projectId, file as File);
 }

--- a/packages/server/src/mcp/skill-file.ts
+++ b/packages/server/src/mcp/skill-file.ts
@@ -36,6 +36,12 @@ export function generateSkillFile(tools: SkillTool[], opts: { baseUrl?: string }
 			'/api/agent-connections/status`) until it returns `{"status":"approved"}`.',
 		'5. Once approved, the same token grants full instance access on `POST /mcp`. Pass a `project` slug to project-scoped tools (use `list_projects` to discover them).',
 		'',
+		'## File uploads',
+		'',
+		'Binary files (images, PDFs, …) cannot be sent as a JSON-RPC tool call. Upload them with a `multipart/form-data` POST to `' +
+			base +
+			'/mcp/assets` (same Bearer auth) using a `file` field — add an optional `project` field to act across projects. The response returns the stored asset plus a signed read URL, and the file then shows up in `list_project_assets` / `read_project_asset`.',
+		'',
 		'## Available Tools',
 		'',
 	];

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -347,7 +347,7 @@ export interface ToolScope {
  * chat session) names the project it wants to reach. `team_id` is never part of
  * the tool surface; it stays an internal key.
  */
-async function resolveScope(
+export async function resolveScope(
 	db: PGlite,
 	auth: AuthInfo,
 	args: Record<string, unknown>,

--- a/packages/server/src/middleware/auth.ts
+++ b/packages/server/src/middleware/auth.ts
@@ -200,6 +200,21 @@ export const authMiddleware = createMiddleware<Env>(async (c, next) => {
 		return c.json({ error: { code: 'UNAUTHORIZED', message: 'Invalid or expired token' } }, 401);
 	}
 
+	// API keys authenticate the MCP endpoint (POST /mcp) only. REST is the
+	// human/browser surface (user JWT); external/programmatic access goes through MCP.
+	if (auth.type === AuthType.ApiKey) {
+		return c.json(
+			{
+				error: {
+					code: 'UNAUTHORIZED',
+					message:
+						'API keys authenticate the MCP endpoint only; use a session token for the REST API.',
+				},
+			},
+			401,
+		);
+	}
+
 	c.set('auth', auth);
 	return next();
 });

--- a/packages/server/src/routes/assets.ts
+++ b/packages/server/src/routes/assets.ts
@@ -32,7 +32,7 @@ export const assetsRoutes = new Hono<Env>();
  * task-comment upload and the project Assets upload. Returns a `201` response
  * with the stored asset + a freshly-signed read URL, or an error response.
  */
-async function storeUploadedAsset(
+export async function storeUploadedAsset(
 	c: Context<Env>,
 	teamId: string,
 	projectId: string,

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -1,7 +1,9 @@
 import { existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { extname, join, resolve } from 'node:path';
 import type { PGlite } from '@electric-sql/pglite';
+import { ATTACHMENT_MAX_BYTES } from '@hezo/shared';
 import { type Context, Hono } from 'hono';
+import { bodyLimit } from 'hono/body-limit';
 import type { HezoConfig } from './cli';
 import { logger } from './logger';
 
@@ -17,7 +19,7 @@ import { getInstanceBaseUrl } from './lib/system-meta';
 import type { Env } from './lib/types';
 import { generateLlmsTxt } from './mcp/llms-txt';
 import { ONBOARDING_TOOLS } from './mcp/onboarding';
-import { getToolDefs, handleMcpRequest, initMcpServer } from './mcp/server';
+import { getToolDefs, handleMcpAssetUpload, handleMcpRequest, initMcpServer } from './mcp/server';
 import { generateSkillFile } from './mcp/skill-file';
 import { authMiddleware, requireProjectAccessMiddleware } from './middleware/auth';
 import { agentConnectionsRoutes } from './routes/agent-connections';
@@ -326,6 +328,21 @@ export function buildApp(
 	// GET/DELETE return 405 per the MCP Streamable-HTTP transport spec.
 	app.post('/mcp', (c) => handleMcpRequest(c));
 	app.on(['GET', 'DELETE'], '/mcp', (c) => c.text('Method Not Allowed', 405, { Allow: 'POST' }));
+
+	// Binary file upload on the MCP surface (multipart/form-data). JSON-RPC can't
+	// carry a file, so external/agent callers POST here with the same bearer auth.
+	app.post(
+		'/mcp/assets',
+		bodyLimit({
+			maxSize: ATTACHMENT_MAX_BYTES,
+			onError: (c) =>
+				c.json({ error: { code: 'TOO_LARGE', message: 'Attachment exceeds 10 MB' } }, 413),
+		}),
+		(c) => handleMcpAssetUpload(c),
+	);
+	app.on(['GET', 'DELETE'], '/mcp/assets', (c) =>
+		c.text('Method Not Allowed', 405, { Allow: 'POST' }),
+	);
 
 	// Auth routes (token endpoint is public, handled before auth middleware)
 	app.route('/api', authRoutes);

--- a/packages/server/test/agent-connections.test.ts
+++ b/packages/server/test/agent-connections.test.ts
@@ -145,17 +145,15 @@ describe('approval', () => {
 	it('rejects approval from a non-superuser principal', async () => {
 		const { id } = await registerViaRest('victim-bot');
 
-		// A team-scoped API key is a non-superuser principal.
-		const keyRes = await app.request(`/api/projects/${slugA}/api-keys`, {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({ name: 'key' }),
-		});
-		const apiKey = (await keyRes.json()).data.key as string;
+		// An approved connected agent is admin-equivalent but explicitly may NOT
+		// manage connected agents — that stays human-superuser-only. (A team-scoped
+		// API key doesn't apply here: API keys are rejected on REST outright.)
+		const { id: otherId, token: otherToken } = await registerViaRest('other-bot');
+		expect((await approve(otherId)).status).toBe(200);
 
 		const res = await app.request(`/api/agent-connections/${id}/approve`, {
 			method: 'POST',
-			headers: authHeader(apiKey),
+			headers: authHeader(otherToken),
 		});
 		expect(res.status).toBe(403);
 	});

--- a/packages/server/test/api-keys.test.ts
+++ b/packages/server/test/api-keys.test.ts
@@ -51,8 +51,7 @@ describe('API keys CRUD', () => {
 		expect(body.data[0]).not.toHaveProperty('key_hash');
 	});
 
-	it('authenticates with an API key', async () => {
-		// Create a key
+	it('is rejected on REST but authenticates the MCP endpoint', async () => {
 		const createRes = await app.request(`/api/projects/${projectSlug}/api-keys`, {
 			method: 'POST',
 			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
@@ -60,14 +59,31 @@ describe('API keys CRUD', () => {
 		});
 		const rawKey = (await createRes.json()).data.key;
 
-		// Use the key to access an API
-		const res = await app.request(`/api/projects/${projectSlug}/api-keys`, {
+		// REST is the human/browser surface — API keys are not accepted there.
+		const restRes = await app.request(`/api/projects/${projectSlug}/api-keys`, {
 			headers: { Authorization: `Bearer ${rawKey}` },
 		});
-		expect(res.status).toBe(200);
+		expect(restRes.status).toBe(401);
+
+		// The same key authenticates the MCP endpoint (the external on-ramp).
+		const mcpRes = await app.request('/mcp', {
+			method: 'POST',
+			headers: { Authorization: `Bearer ${rawKey}`, 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				jsonrpc: '2.0',
+				method: 'tools/call',
+				params: { name: 'list_tasks', arguments: {} },
+				id: 1,
+			}),
+		});
+		expect(mcpRes.status).toBe(200);
+		const text = (await mcpRes.json()).result.content[0].text;
+		// A real tool result (a JSON array of tasks), not an auth/scope error.
+		expect(text).not.toContain('Access denied');
+		expect(Array.isArray(JSON.parse(text))).toBe(true);
 	});
 
-	it('revokes an API key', async () => {
+	it('revokes an API key (MCP access removed)', async () => {
 		const createRes = await app.request(`/api/projects/${projectSlug}/api-keys`, {
 			method: 'POST',
 			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
@@ -76,16 +92,27 @@ describe('API keys CRUD', () => {
 		const apiKey = (await createRes.json()).data;
 		const rawKey = apiKey.key;
 
+		const toolNames = async (): Promise<string[]> => {
+			const res = await app.request('/mcp', {
+				method: 'POST',
+				headers: { Authorization: `Bearer ${rawKey}`, 'Content-Type': 'application/json' },
+				body: JSON.stringify({ jsonrpc: '2.0', method: 'tools/list', id: 1 }),
+			});
+			const body = await res.json();
+			return (body.result.tools as Array<{ name: string }>).map((t) => t.name);
+		};
+
+		// A valid key is a full principal — it sees the real project tools.
+		expect(await toolNames()).toContain('list_tasks');
+
 		const res = await app.request(`/api/projects/${projectSlug}/api-keys/${apiKey.id}`, {
 			method: 'DELETE',
 			headers: authHeader(token),
 		});
 		expect(res.status).toBe(200);
 
-		// Verify key no longer works
-		const authRes = await app.request(`/api/projects/${projectSlug}/api-keys`, {
-			headers: { Authorization: `Bearer ${rawKey}` },
-		});
-		expect(authRes.status).toBe(401);
+		// After revocation the token is unrecognized, so it drops to the
+		// unauthenticated onboarding surface (connect/register tools only).
+		expect(await toolNames()).not.toContain('list_tasks');
 	});
 });

--- a/packages/server/test/cross-team-isolation.test.ts
+++ b/packages/server/test/cross-team-isolation.test.ts
@@ -282,9 +282,24 @@ describe('Superuser cross-team access', () => {
 	});
 });
 
-describe('API key cross-team isolation', () => {
+describe('API key cross-team isolation (MCP surface)', () => {
 	let apiKeyA: string;
 	let apiKeyB: string;
+
+	async function listAgentsViaMcp(authToken: string, projectSlug: string): Promise<unknown> {
+		const res = await app.request('/mcp', {
+			method: 'POST',
+			headers: { Authorization: `Bearer ${authToken}`, 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				jsonrpc: '2.0',
+				method: 'tools/call',
+				params: { name: 'list_agents', arguments: { project: projectSlug } },
+				id: 1,
+			}),
+		});
+		const body = (await res.json()) as { result: { content: Array<{ text: string }> } };
+		return JSON.parse(body.result.content[0].text);
+	}
 
 	beforeAll(async () => {
 		const resA = await app.request(
@@ -308,44 +323,30 @@ describe('API key cross-team isolation', () => {
 		apiKeyB = (await resB.json()).data.key;
 	});
 
-	it('API key A cannot access Team B', async () => {
-		const res = await app.request(
-			`/api/projects/${await projectSlugForTeamSlug(db, teamBSlug)}/agents`,
-			{
-				headers: authHeader(apiKeyA),
-			},
-		);
-		expect(res.status).toBe(403);
+	it('API key A cannot reach Team B via MCP', async () => {
+		const result = (await listAgentsViaMcp(
+			apiKeyA,
+			await projectSlugForTeamSlug(db, teamBSlug),
+		)) as { error?: string };
+		expect(result.error).toBeDefined();
 	});
 
-	it('API key B cannot access Team A', async () => {
-		const res = await app.request(
-			`/api/projects/${await projectSlugForTeamSlug(db, teamASlug)}/agents`,
-			{
-				headers: authHeader(apiKeyB),
-			},
-		);
-		expect(res.status).toBe(403);
+	it('API key B cannot reach Team A via MCP', async () => {
+		const result = (await listAgentsViaMcp(
+			apiKeyB,
+			await projectSlugForTeamSlug(db, teamASlug),
+		)) as { error?: string };
+		expect(result.error).toBeDefined();
 	});
 
-	it('API key A can access Team A', async () => {
-		const res = await app.request(
-			`/api/projects/${await projectSlugForTeamSlug(db, teamASlug)}/agents`,
-			{
-				headers: authHeader(apiKeyA),
-			},
-		);
-		expect(res.status).toBe(200);
+	it('API key A reaches Team A via MCP', async () => {
+		const result = await listAgentsViaMcp(apiKeyA, await projectSlugForTeamSlug(db, teamASlug));
+		expect(Array.isArray(result)).toBe(true);
 	});
 
-	it('API key B can access Team B', async () => {
-		const res = await app.request(
-			`/api/projects/${await projectSlugForTeamSlug(db, teamBSlug)}/agents`,
-			{
-				headers: authHeader(apiKeyB),
-			},
-		);
-		expect(res.status).toBe(200);
+	it('API key B reaches Team B via MCP', async () => {
+		const result = await listAgentsViaMcp(apiKeyB, await projectSlugForTeamSlug(db, teamBSlug));
+		expect(Array.isArray(result)).toBe(true);
 	});
 });
 

--- a/packages/server/test/project-assets.test.ts
+++ b/packages/server/test/project-assets.test.ts
@@ -85,6 +85,23 @@ async function uploadTaskAsset(filename: string, mime: string, bytes: Uint8Array
 	return (await res.json()).data.id;
 }
 
+async function uploadAssetViaMcp(
+	authToken: string,
+	filename: string,
+	mime: string,
+	bytes: Uint8Array,
+): Promise<Response> {
+	const fd = new FormData();
+	const copy = new Uint8Array(bytes.byteLength);
+	copy.set(bytes);
+	fd.set('file', new File([copy.buffer], filename, { type: mime }));
+	return app.request('/mcp/assets', {
+		method: 'POST',
+		headers: { ...authHeader(authToken) },
+		body: fd,
+	});
+}
+
 beforeAll(async () => {
 	const ctx = await createTestApp();
 	app = ctx.app;
@@ -361,5 +378,81 @@ describe('asset mention resolution', () => {
 		expect(body.assets[0].filename).toBe('resolve-me.png');
 		expect(body.assets[0].content_type).toBe('image/png');
 		expect(body.assets[0].signed_url).toMatch(/^\/api\/assets\/[0-9a-f-]+\?exp=\d+&sig=/);
+	});
+});
+
+describe('MCP asset upload (POST /mcp/assets)', () => {
+	it('an agent run uploads a binary asset, retrievable via the MCP read tools', async () => {
+		const { token: agentToken } = await mintAgentToken(
+			db,
+			masterKeyManager,
+			agentId,
+			teamId,
+			taskId,
+			{
+				projectId,
+			},
+		);
+		const res = await uploadAssetViaMcp(agentToken, 'diagram.png', 'image/png', buildPng(7));
+		expect(res.status).toBe(201);
+		const body = await res.json();
+		expect(body.data.original_filename).toBe('diagram.png');
+		expect(body.data.content_type).toBe('image/png');
+		expect(body.data.url).toMatch(/^\/api\/assets\/[0-9a-f-]+\?exp=\d+&sig=/);
+
+		const onDisk = join(dataDir, 'teams', teamId, 'projects', projectId, 'assets', body.data.id);
+		expect(existsSync(onDisk)).toBe(true);
+
+		// Visible to the agent through the existing read tools.
+		const list = (await callToolViaMcp(agentToken, 'list_project_assets', {})) as {
+			files: Array<{ filename: string }>;
+		};
+		expect(list.files.some((f) => f.filename === 'diagram.png')).toBe(true);
+
+		const read = (await callToolViaMcp(agentToken, 'read_project_asset', {
+			filename: 'diagram.png',
+		})) as { binary?: boolean; path?: string };
+		expect(read.binary).toBe(true);
+		expect(read.path).toContain('/workspace/.hezo/assets/');
+	});
+
+	it('an external API key uploads via MCP', async () => {
+		const createRes = await app.request(`/api/projects/${projectId}/api-keys`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name: 'Upload Key' }),
+		});
+		const rawKey = (await createRes.json()).data.key;
+
+		const res = await uploadAssetViaMcp(rawKey, 'external.png', 'image/png', buildPng(8));
+		expect(res.status).toBe(201);
+		expect((await res.json()).data.original_filename).toBe('external.png');
+	});
+
+	it('rejects a disallowed file type', async () => {
+		const { token: agentToken } = await mintAgentToken(
+			db,
+			masterKeyManager,
+			agentId,
+			teamId,
+			taskId,
+			{
+				projectId,
+			},
+		);
+		const res = await uploadAssetViaMcp(
+			agentToken,
+			'evil.exe',
+			'application/x-msdownload',
+			buildPng(9),
+		);
+		expect(res.status).toBe(400);
+	});
+
+	it('requires authentication', async () => {
+		const fd = new FormData();
+		fd.set('file', new File([buildPng(10)], 'nope.png', { type: 'image/png' }));
+		const res = await app.request('/mcp/assets', { method: 'POST', body: fd });
+		expect(res.status).toBe(401);
 	});
 });


### PR DESCRIPTION
## What

Two related auth/surface changes that fell out of clarifying Hezo's REST vs MCP model:

1. **Scope API keys to the MCP surface only.** REST becomes user-JWT (human/browser) only; API keys are rejected there.
2. **Add `POST /mcp/assets`** — a multipart upload on the MCP surface, closing the one hard REST-only gap for external/agent callers.

## Why

API keys are the **external** on-ramp and are never used by internal agents — those authenticate per-run with an **agent JWT**. So the model is now clean:

- **REST** = user JWT (humans/browser)
- **MCP** = agent JWT (internal per-run) + API key (external)

An external caller can obtain neither a user JWT (needs the master-key seed) nor an agent JWT (minted only for a server-side run), so the API key is its only credential — hence it belongs on MCP, not REST. The frontend was already 100% user-JWT, so nothing in the UI is affected.

## Changes

**Part 1 — API keys → MCP only**
- `middleware/auth.ts`: reject `AuthType.ApiKey` in `authMiddleware` (one check, covers all `/api/*`).
- `index.ts`: reject API keys on the `/ws` WebSocket auth too (the browser uses a user JWT there).
- MCP unchanged — `verifyToken` still parses keys; `authorizeScope`/`authorizeTeam` still enforce team scoping. Key **management** routes stay on REST (user JWT).

**Part 2 — MCP file upload**
- `POST /mcp/assets` (multipart), mounted next to `/mcp`, same bearer auth via `authenticateRequest`. Reuses the REST asset pipeline (`storeUploadedAsset`: validation → `writeAsset` → signed URL) and the MCP `resolveScope` for project resolution. Retrievable through the existing `list_project_assets` / `read_project_asset` tools (binary lands at the per-run `/workspace/.hezo/assets/<id>` mount). Documented in the `/skill.md` manifest.

**Part 3 — Docs**
- `.dev/architecture.md` §10 (principals: API key is SHA-256-hashed — fixed the stale "bcrypt" — and MCP-only) + §13 (upload route + auth split); `AGENTS.md` Route authorization.

## Tests

- `api-keys.test.ts`: a key is **rejected on REST** and **accepted on MCP** (`list_tasks`); revocation verified through MCP.
- `cross-team-isolation.test.ts`: the API-key cross-team isolation block ported to MCP (`list_agents` with a `project` arg — cross-team denied, same-team allowed).
- `project-assets.test.ts`: MCP upload via **agent JWT** and **API key**, disallowed-type → 400, missing-auth → 401, and a round-trip through `list_project_assets` / `read_project_asset`.

## Verification

- `bun run typecheck` ✅, `biome check` ✅ (changed files clean), pre-commit build ✅
- Full server suite: **2177 passed**; the only failures (`git.test.ts` worktrees, `ssh-agent-server.test.ts`) are pre-existing sandbox-environment issues (no `ssh-keygen`, restricted git worktrees) that fail identically on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0139KMHtzVnf2F86tQp5sn7g)_