### PR TITLE
feat(web): show per-project inbox count badges on the project rail

### DIFF
--- a/packages/web/src/components/app-header.tsx
+++ b/packages/web/src/components/app-header.tsx
@@ -2,6 +2,7 @@ import { Link } from '@tanstack/react-router';
 import { BookOpen, FolderKanban, Inbox, Menu, Search, Settings } from 'lucide-react';
 import { useGlobalInboxUnreadCount } from '../hooks/use-inbox-count';
 import { useMe } from '../hooks/use-me';
+import { CountOverlayBadge } from './ui/count-overlay-badge';
 import { Logo } from './ui/logo';
 import { ThemeSwitcher } from './ui/theme-switcher';
 
@@ -71,14 +72,7 @@ export function AppHeader({
 				>
 					<span className="relative inline-flex">
 						<Inbox className="w-4 h-4" />
-						{inboxUnread > 0 && (
-							<span
-								data-testid="app-header-inbox-badge"
-								className="absolute -top-1.5 -right-1.5 min-w-[14px] h-[14px] px-1 rounded-full bg-pink text-pink-fg text-[9px] leading-none font-medium flex items-center justify-center"
-							>
-								{inboxUnread > 99 ? '99+' : inboxUnread}
-							</span>
-						)}
+						<CountOverlayBadge count={inboxUnread} testId="app-header-inbox-badge" />
 					</span>
 				</Link>
 				<Link

--- a/packages/web/src/components/project-rail.tsx
+++ b/packages/web/src/components/project-rail.tsx
@@ -2,10 +2,12 @@ import { Link } from '@tanstack/react-router';
 import { Building2, Plus } from 'lucide-react';
 import { useState } from 'react';
 import { useActiveProject } from '../hooks/use-active-project';
+import { useInboxUnreadCount, useInboxUnreadCountsBySlug } from '../hooks/use-inbox-count';
 import { useMe } from '../hooks/use-me';
 import { useAllVisibleProjects, useHqProject } from '../hooks/use-projects';
 import { CreateProjectWithTeamDialog } from './create-project-with-team-dialog';
 import { Avatar, avatarColorFromString, getInitials } from './ui/avatar';
+import { CountOverlayBadge } from './ui/count-overlay-badge';
 import { Tooltip } from './ui/tooltip';
 
 /**
@@ -21,6 +23,10 @@ export function ProjectRail() {
 	const { projects } = useAllVisibleProjects();
 	const hq = useHqProject();
 	const active = useActiveProject();
+	const inboxCounts = useInboxUnreadCountsBySlug();
+	// HQ is excluded from the visible-project map (it's internal), so fetch its
+	// outstanding count separately to badge the pinned HQ entry.
+	const { data: hqInbox } = useInboxUnreadCount(hq?.slug ?? '', !!hq);
 	const [createOpen, setCreateOpen] = useState(false);
 	const hqActive = !!hq && active?.slug === hq.slug;
 
@@ -41,11 +47,15 @@ export function ProjectRail() {
 									params={{ projectId: p.slug }}
 									aria-label={p.name}
 									data-testid={`project-rail-avatar-${p.slug}`}
-									className={`rounded-full transition-shadow ${
+									className={`relative rounded-full transition-shadow ${
 										isActive ? 'ring-2 ring-inverse ring-offset-1 ring-offset-surface-2' : ''
 									}`}
 								>
 									<Avatar initials={getInitials(p.name)} color={avatarColorFromString(p.name)} />
+									<CountOverlayBadge
+										count={inboxCounts[p.slug] ?? 0}
+										testId={`project-rail-inbox-badge-${p.slug}`}
+									/>
 								</Link>
 							</Tooltip>
 						);
@@ -74,11 +84,15 @@ export function ProjectRail() {
 								params={{ projectId: hq.slug }}
 								aria-label={hq.name}
 								data-testid="project-rail-hq"
-								className={`w-9 h-9 rounded-full flex items-center justify-center text-text-2 hover:text-text-1 hover:bg-surface border border-border bg-surface transition-colors ${
+								className={`relative w-9 h-9 rounded-full flex items-center justify-center text-text-2 hover:text-text-1 hover:bg-surface border border-border bg-surface transition-colors ${
 									hqActive ? 'ring-2 ring-inverse ring-offset-1 ring-offset-surface-2' : ''
 								}`}
 							>
 								<Building2 className="w-4 h-4" />
+								<CountOverlayBadge
+									count={hqInbox?.unread ?? 0}
+									testId="project-rail-hq-inbox-badge"
+								/>
 							</Link>
 						</Tooltip>
 					</div>

--- a/packages/web/src/components/ui/count-overlay-badge.tsx
+++ b/packages/web/src/components/ui/count-overlay-badge.tsx
@@ -1,0 +1,17 @@
+/**
+ * A small pink count badge that overlays the top-right corner of an icon or
+ * avatar — the at-a-glance "unread/outstanding" indicator used by the global
+ * inbox icon and the per-project rail avatars. Renders nothing when the count
+ * is zero. The parent element must establish a positioning context (`relative`).
+ */
+export function CountOverlayBadge({ count, testId }: { count: number; testId?: string }) {
+	if (count <= 0) return null;
+	return (
+		<span
+			data-testid={testId}
+			className="absolute -top-1.5 -right-1.5 min-w-[14px] h-[14px] px-1 rounded-full bg-pink text-pink-fg text-[9px] leading-none font-medium flex items-center justify-center"
+		>
+			{count > 99 ? '99+' : count}
+		</span>
+	);
+}

--- a/packages/web/src/hooks/use-inbox-count.ts
+++ b/packages/web/src/hooks/use-inbox-count.ts
@@ -12,11 +12,12 @@ export function useInboxUnreadCount(projectId: string, enabled = true) {
 }
 
 /**
- * Total unread inbox items across every project the user can see — the count for
- * the global inbox. Shares per-project query keys with useInboxUnreadCount so
- * WebSocket-driven invalidations keep it live.
+ * Per-project unread inbox counts keyed by project slug, for every visible
+ * project. Backs both the global inbox total and the per-avatar rail badges.
+ * Shares per-project query keys with useInboxUnreadCount so WebSocket-driven
+ * invalidations keep every consumer live.
  */
-export function useGlobalInboxUnreadCount(): number {
+export function useInboxUnreadCountsBySlug(): Record<string, number> {
 	const { projects } = useAllVisibleProjects();
 	const queries = useQueries({
 		queries: projects.map((p) => ({
@@ -25,5 +26,17 @@ export function useGlobalInboxUnreadCount(): number {
 			enabled: !!p.slug,
 		})),
 	});
-	return queries.reduce((sum, q) => sum + (q.data?.unread ?? 0), 0);
+	const bySlug: Record<string, number> = {};
+	projects.forEach((p, i) => {
+		bySlug[p.slug] = queries[i]?.data?.unread ?? 0;
+	});
+	return bySlug;
+}
+
+/**
+ * Total unread inbox items across every project the user can see — the count for
+ * the global inbox.
+ */
+export function useGlobalInboxUnreadCount(): number {
+	return Object.values(useInboxUnreadCountsBySlug()).reduce((sum, n) => sum + n, 0);
 }

--- a/packages/web/test/project-rail.test.tsx
+++ b/packages/web/test/project-rail.test.tsx
@@ -1,7 +1,61 @@
 import { screen, waitFor } from '@testing-library/react';
 import { expect, test } from 'vitest';
-import { renderApp } from './helpers/render';
-import { type SeededWorkspace, seedProject, seedWorkspace } from './helpers/seed';
+import { getTestContext, renderApp } from './helpers/render';
+import {
+	type SeededTask,
+	type SeededWorkspace,
+	seedProject,
+	seedTask,
+	seedWorkspace,
+} from './helpers/seed';
+
+/** Insert an unread @admin mention on a task — one outstanding inbox item for the team. */
+async function seedUnreadAdminMention(
+	workspace: SeededWorkspace,
+	task: SeededTask,
+	text: string,
+): Promise<void> {
+	const { db } = getTestContext();
+	const architect = workspace.agents.find((a) => a.slug === 'architect');
+	if (!architect) throw new Error('seedUnreadAdminMention: architect agent missing');
+
+	const userRow = await db.query<{ user_id: string }>(
+		`SELECT mu.user_id FROM member_users mu
+		 JOIN members m ON m.id = mu.id
+		 WHERE m.team_id = $1 AND mu.role = 'admin'
+		 LIMIT 1`,
+		[workspace.team.id],
+	);
+	const userId = userRow.rows[0]?.user_id;
+	if (!userId) throw new Error('seedUnreadAdminMention: no admin on team');
+
+	const commentRow = await db.query<{ id: string }>(
+		`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
+		 VALUES ($1, $2, 'text'::comment_content_type, $3::jsonb)
+		 RETURNING id`,
+		[task.id, architect.id, JSON.stringify({ text })],
+	);
+	await db.query(
+		`INSERT INTO admin_mentions (team_id, task_id, comment_id, user_id)
+		 VALUES ($1, $2, $3, $4)`,
+		[workspace.team.id, task.id, commentRow.rows[0].id, userId],
+	);
+}
+
+/** Insert a pending approval on the HQ (internal) team — one outstanding HQ inbox item. */
+async function seedHqPendingApproval(): Promise<void> {
+	const { db } = getTestContext();
+	const hqRow = await db.query<{ team_id: string }>(
+		`SELECT team_id FROM projects WHERE is_internal = true LIMIT 1`,
+	);
+	const teamId = hqRow.rows[0]?.team_id;
+	if (!teamId) throw new Error('seedHqPendingApproval: HQ project missing');
+	await db.query(
+		`INSERT INTO approvals (team_id, type, status, payload)
+		 VALUES ($1, 'hire'::approval_type, 'pending'::approval_status, '{}'::jsonb)`,
+		[teamId],
+	);
+}
 
 test('the project rail lists an avatar for every visible project across teams', async () => {
 	let alphaSlug = '';
@@ -101,4 +155,48 @@ test('superuser creates a new project from the rail-pinned create button', async
 	await waitFor(() =>
 		expect(router.state.location.pathname).toMatch(/^\/projects\/research-squad\/tasks\//),
 	);
+});
+
+test('rail avatars badge each project with its outstanding inbox count', async () => {
+	let alphaSlug = '';
+	let betaSlug = '';
+	const { findByTestId, queryByTestId } = await renderApp({
+		initialPath: '/home',
+		seed: async () => {
+			// Alpha has one unread @admin mention — an outstanding inbox item.
+			const a = await seedWorkspace();
+			const alpha = await seedProject(a, { name: 'Alpha' });
+			const task = await seedTask(a, alpha, { title: 'Decide on the rollout' });
+			await seedUnreadAdminMention(a, task, '@admin please weigh in on shipping.');
+			alphaSlug = alpha.slug;
+
+			// Beta (a separate team/project) has nothing outstanding.
+			const b = await seedWorkspace();
+			const beta = await seedProject(b, { name: 'Beta' });
+			betaSlug = beta.slug;
+		},
+	});
+
+	// Alpha's avatar carries a pink overlay badge with its unread count.
+	const badge = await findByTestId(`project-rail-inbox-badge-${alphaSlug}`, undefined, {
+		timeout: 15_000,
+	});
+	expect(badge.textContent).toContain('1');
+
+	// Beta renders an avatar but no badge — a count of 0 never shows.
+	await findByTestId(`project-rail-avatar-${betaSlug}`, undefined, { timeout: 15_000 });
+	expect(queryByTestId(`project-rail-inbox-badge-${betaSlug}`)).toBeNull();
+});
+
+test('the pinned HQ entry badges HQ outstanding inbox items', async () => {
+	const { findByTestId } = await renderApp({
+		initialPath: '/home',
+		seed: async () => {
+			await seedWorkspace();
+			await seedHqPendingApproval();
+		},
+	});
+
+	const badge = await findByTestId('project-rail-hq-inbox-badge', undefined, { timeout: 15_000 });
+	expect(Number(badge.textContent)).toBeGreaterThanOrEqual(1);
 });


### PR DESCRIPTION
## What & why

The left **project rail** (the column of project avatars, plus the pinned HQ entry) is the primary navigation axis — one avatar per project — but it showed **no indication** of which projects had outstanding inbox items, so you had to open each project to discover unhandled work.

The global inbox icon in the top header already solves this instance-wide with a small **pink corner overlay badge**. This PR brings that same at-a-glance signal **per project, onto the rail**: each avatar (and the HQ entry) now shows a pink count overlay for that project's outstanding inbox items (unread @admin mentions + pending approvals).

## How

This is almost entirely wiring of pieces that already existed:

- **Extract** the overlay badge into a shared `CountOverlayBadge` component (`packages/web/src/components/ui/count-overlay-badge.tsx`) and reuse it in the app header, which previously had the markup inline. The header keeps its `app-header-inbox-badge` testId.
- **Add** `useInboxUnreadCountsBySlug()` so the rail can read every visible project's count from one batched `useQueries` set (a hook can't be called inside `projects.map`); `useGlobalInboxUnreadCount()` now derives from it. HQ is excluded from the visible-project map (it's internal), so its count is fetched separately to badge the pinned HQ entry.
- Counts reuse the existing `GET /api/projects/:projectId/inbox/count` endpoint and the `inboxCount` query key, so the existing WebSocket invalidations on `admin_mentions`/`approvals` keep the badges **live** without a reload.

No backend, migration, or schema changes. The rail mounts at every breakpoint (desktop/tablet inline, mobile via the nav drawer), so the badge is responsive with no extra layout work.

## Testing

- New component tests in `packages/web/test/project-rail.test.tsx`:
  - a project with an unread @admin mention renders `project-rail-inbox-badge-<slug>` showing `1`, while a sibling project with nothing outstanding renders no badge;
  - the pinned HQ entry renders `project-rail-hq-inbox-badge` when HQ has a pending approval.
- `inbox-global.test.tsx` still green (verifies the header badge refactor).
- Full web vitest tier: **104 files / 379 tests passing**. `bun run typecheck` and `bun run check` clean for the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FSBvUEjkjtoAdtbPNAU8GM

---
_Generated by [Claude Code](https://claude.ai/code/session_01FSBvUEjkjtoAdtbPNAU8GM)_