### PR TITLE
feat: badge human vs connected-agent admin actions

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -160,6 +160,18 @@ self-registered, admin-approved, `hezoc_` prefix), `invites`, `admin_mentions` (
 `instance_user_roles`, `notification_preferences`. `plugins`/`plugin_state`/`plugin_jobs`
 are scaffolding for a future plugin runtime — present but not yet exercised.
 
+**Actor attribution (human vs connected agent).** Every recorded admin action carries who
+took it so the UI can flag human vs automated. `audit_actor_type` is
+`admin | agent | system | connected_agent`; alongside the existing `actor_member_id` /
+`author_member_id` foreign keys, `audit_log`, `task_comments`, and `document_revisions` each
+carry a parallel nullable `actor_connected_agent_id` / `author_connected_agent_id` FK (at
+most one of the two is set per row). `resolveActor` maps a `ConnectedAgent` principal to the
+`connected_agent` actor type + id, threaded through task events, the audit observer, and the
+document service. The web surfaces (task activity feed, audit-log table, document revision
+history) render a small badge via the shared `ActorBadge` — a person icon for a human admin,
+a bot icon for a connected agent (tooltip naming it). Roster agents and `system` actors are
+not badged; inline `@admin` mentions in comment bodies are rendered plainly (not an action).
+
 > The migrations are the source of truth for the live schema. Tables an older draft of
 > the docs mentioned — `connected_platforms`, `secret_grants`, `slack_connections` — do
 > **not** exist; OAuth is `oauth_connections`, and secret access is gated by

--- a/packages/server/migrations/018_connected_agent_attribution.sql
+++ b/packages/server/migrations/018_connected_agent_attribution.sql
@@ -1,0 +1,33 @@
+-- Attribute admin actions taken by a connected agent (an approved external MCP
+-- client; see 016_connected_agents.sql) so the UI can flag human-vs-agent.
+--
+-- A connected agent is admin-equivalent but is NOT a team member, so its actions
+-- can't hang off `actor_member_id` / `author_member_id`. It gets its own parallel
+-- nullable FK on each attributed table, alongside the member FK (at most one of
+-- the two is set per row). `audit_actor_type` gains a `connected_agent` value.
+
+-- Extend audit_actor_type with 'connected_agent'. PGlite rejects
+-- `ALTER TYPE ... ADD VALUE` inside a transaction and the runner wraps every
+-- migration in BEGIN/COMMIT, so recreate the type and swap the column over (the
+-- same pattern as 008). Only audit_log.actor_type uses this type.
+CREATE TYPE audit_actor_type_new AS ENUM ('admin', 'agent', 'system', 'connected_agent');
+
+ALTER TABLE audit_log
+    ALTER COLUMN actor_type TYPE audit_actor_type_new
+    USING actor_type::text::audit_actor_type_new;
+
+DROP TYPE audit_actor_type;
+ALTER TYPE audit_actor_type_new RENAME TO audit_actor_type;
+
+-- Parallel connected-agent attribution columns.
+ALTER TABLE audit_log
+    ADD COLUMN actor_connected_agent_id UUID REFERENCES connected_agents(id) ON DELETE SET NULL;
+ALTER TABLE task_comments
+    ADD COLUMN author_connected_agent_id UUID REFERENCES connected_agents(id) ON DELETE SET NULL;
+ALTER TABLE document_revisions
+    ADD COLUMN author_connected_agent_id UUID REFERENCES connected_agents(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_audit_actor_connected_agent ON audit_log(actor_connected_agent_id)
+    WHERE actor_connected_agent_id IS NOT NULL;
+CREATE INDEX idx_comments_author_connected_agent ON task_comments(author_connected_agent_id)
+    WHERE author_connected_agent_id IS NOT NULL;

--- a/packages/server/src/events/audit-observer.ts
+++ b/packages/server/src/events/audit-observer.ts
@@ -196,6 +196,7 @@ type ScopedActor = {
 	projectId?: string | null;
 	actorType: AuditActorType;
 	actorMemberId: string | null;
+	actorConnectedAgentId?: string | null;
 };
 
 function row(
@@ -210,6 +211,7 @@ function row(
 		projectId: event.projectId ?? null,
 		actorType: event.actorType,
 		actorMemberId: event.actorMemberId,
+		actorConnectedAgentId: event.actorConnectedAgentId ?? null,
 		action,
 		entityType,
 		entityId,

--- a/packages/server/src/events/types.ts
+++ b/packages/server/src/events/types.ts
@@ -18,6 +18,8 @@ interface Scope {
 interface Actor {
 	actorType: AuditActorType;
 	actorMemberId: string | null;
+	/** Set when the actor is a connected agent; mutually exclusive with actorMemberId. */
+	actorConnectedAgentId?: string | null;
 }
 
 export type TaskUpdateField = 'title' | 'status' | 'assignee';

--- a/packages/server/src/lib/audit.ts
+++ b/packages/server/src/lib/audit.ts
@@ -8,6 +8,8 @@ export interface AuditLogInput {
 	projectId?: string | null;
 	actorType: AuditActorType;
 	actorMemberId: string | null;
+	/** Set when the actor is a connected agent; mutually exclusive with actorMemberId. */
+	actorConnectedAgentId?: string | null;
 	action: AuditAction;
 	entityType: AuditEntityType;
 	entityId: string | null;
@@ -16,13 +18,14 @@ export interface AuditLogInput {
 
 export async function auditLog(db: PGlite, input: AuditLogInput): Promise<void> {
 	await db.query(
-		`INSERT INTO audit_log (team_id, project_id, actor_type, actor_member_id, action, entity_type, entity_id, details)
-		 VALUES ($1, $2, $3::audit_actor_type, $4, $5, $6, $7, $8::jsonb)`,
+		`INSERT INTO audit_log (team_id, project_id, actor_type, actor_member_id, actor_connected_agent_id, action, entity_type, entity_id, details)
+		 VALUES ($1, $2, $3::audit_actor_type, $4, $5, $6, $7, $8, $9::jsonb)`,
 		[
 			input.teamId,
 			input.projectId ?? null,
 			input.actorType,
 			input.actorMemberId,
+			input.actorConnectedAgentId ?? null,
 			input.action,
 			input.entityType,
 			input.entityId,

--- a/packages/server/src/lib/dependencies.ts
+++ b/packages/server/src/lib/dependencies.ts
@@ -216,6 +216,7 @@ export async function reconcileBlockedStatus(
 		current,
 		target,
 		actorMemberId,
+		null,
 		wsManager,
 		effectiveCascade,
 	);

--- a/packages/server/src/lib/resolve.ts
+++ b/packages/server/src/lib/resolve.ts
@@ -20,24 +20,40 @@ export async function resolveActorMemberId(
 	return null;
 }
 
-/** Map an auth context to its audit actor type. Anything non-agent is an admin (board) actor. */
+/**
+ * Map an auth context to its audit actor type. An agent run is an `agent`; an
+ * approved external MCP client is a `connected_agent`; everything else (board
+ * user, superuser) is an `admin`.
+ */
 export function actorTypeFromAuth(auth: AuthInfo): AuditActorType {
-	return auth.type === AuthType.Agent ? 'agent' : 'admin';
+	if (auth.type === AuthType.Agent) return 'agent';
+	if (auth.type === AuthType.ConnectedAgent) return 'connected_agent';
+	return 'admin';
+}
+
+/** The connected-agent identity behind a request, or null for any other principal. */
+export function connectedAgentIdFromAuth(auth: AuthInfo): string | null {
+	return auth.type === AuthType.ConnectedAgent ? auth.connectedAgentId : null;
 }
 
 /**
- * Resolve both the audit actor type and the acting member id for a request.
- * `teamId` may be null for instance-level actions; the member id only resolves
- * within a team, so it is null at instance scope (the actor is still `admin`).
+ * Resolve the audit actor type, the acting member id, and the connected-agent id
+ * for a request. `teamId` may be null for instance-level actions; the member id
+ * only resolves within a team, so it is null at instance scope. A connected
+ * agent has no member row — it is attributed via `actorConnectedAgentId`.
  */
 export async function resolveActor(
 	db: PGlite,
 	auth: AuthInfo,
 	teamId: string | null,
-): Promise<{ actorType: AuditActorType; actorMemberId: string | null }> {
+): Promise<{
+	actorType: AuditActorType;
+	actorMemberId: string | null;
+	actorConnectedAgentId: string | null;
+}> {
 	const actorType = actorTypeFromAuth(auth);
 	const actorMemberId = teamId ? await resolveActorMemberId(db, auth, teamId) : null;
-	return { actorType, actorMemberId };
+	return { actorType, actorMemberId, actorConnectedAgentId: connectedAgentIdFromAuth(auth) };
 }
 
 export async function resolveTeamId(db: PGlite, raw: string): Promise<string | null> {

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -43,6 +43,8 @@ import {
 	wouldCreateCycle,
 } from '../lib/dependencies';
 import {
+	actorTypeFromAuth,
+	connectedAgentIdFromAuth,
 	projectIdForTeam,
 	resolveActorMemberId,
 	resolveProject,
@@ -305,8 +307,9 @@ async function buildMcpCreateTaskCaller(
 ): Promise<CreateTaskCaller> {
 	const actorMemberId = await resolveActorMemberId(db, auth, teamId);
 	const caller: CreateTaskCaller = {
-		actorType: auth.type === AuthType.Agent ? AuditActorType.Agent : AuditActorType.Admin,
+		actorType: actorTypeFromAuth(auth),
 		actorMemberId,
+		actorConnectedAgentId: connectedAgentIdFromAuth(auth),
 	};
 	if (auth.type === AuthType.Agent) {
 		caller.agentMemberId = auth.memberId;
@@ -925,6 +928,7 @@ export function registerTools(
 			if (!r.rows[0]) return null;
 
 			const actorMemberId = auth.type === AuthType.Agent ? auth.memberId : null;
+			const actorConnectedAgentId = connectedAgentIdFromAuth(auth);
 
 			if (args.description !== undefined) {
 				trackBackground(
@@ -934,6 +938,7 @@ export function registerTools(
 						taskId,
 						args.description as string,
 						actorMemberId,
+						actorConnectedAgentId,
 						wsManager,
 					).catch((e) => log.error('Failed to record task links from description:', e)),
 				);
@@ -948,6 +953,7 @@ export function registerTools(
 						currentStatus,
 						args.status as string,
 						actorMemberId,
+						actorConnectedAgentId,
 						wsManager,
 					);
 				} catch (e) {
@@ -1358,12 +1364,15 @@ export function registerTools(
 				);
 			}
 			const r = await db.query<Record<string, unknown>>(
-				`SELECT ic.id, ic.public_id, ic.task_id, ic.author_member_id, ic.parent_comment_id,
+				`SELECT ic.id, ic.public_id, ic.task_id, ic.author_member_id, ic.author_connected_agent_id,
+				        ic.parent_comment_id,
 				        ic.content_type, ic.content, ic.chosen_option, ic.created_at,
-				        COALESCE(ma.title, m.display_name, 'Admin') AS author_name
+				        CASE WHEN ic.author_connected_agent_id IS NOT NULL THEN 'connected_agent' ELSE m.member_type::text END AS author_type,
+				        COALESCE(ca.name, ma.title, m.display_name, 'Admin') AS author_name
 				 FROM task_comments ic
 				 LEFT JOIN members m ON m.id = ic.author_member_id
 				 LEFT JOIN member_agents ma ON ma.id = ic.author_member_id
+				 LEFT JOIN connected_agents ca ON ca.id = ic.author_connected_agent_id
 				 WHERE ${conditions.join(' AND ')}
 				 ORDER BY ic.created_at DESC, ic.id DESC LIMIT 50`,
 				params,
@@ -1523,12 +1532,20 @@ export function registerTools(
 				parentCommentId = args.parent_comment_id as string;
 			}
 			const authorMemberId = auth.type === AuthType.Agent ? auth.memberId : null;
+			const authorConnectedAgentId = connectedAgentIdFromAuth(auth);
 			const content = { text: args.content };
 			// RETURNING * includes public_id (the timestamp slug for comment links),
 			// so the agent gets it back without a follow-up list_comments.
 			const r = await db.query<{ id: string; public_id: string }>(
-				`INSERT INTO task_comments (task_id, author_member_id, parent_comment_id, content_type, content) VALUES ($1, $2, $3, $4::comment_content_type, $5::jsonb) RETURNING *`,
-				[taskId, authorMemberId, parentCommentId, CommentContentType.Text, JSON.stringify(content)],
+				`INSERT INTO task_comments (task_id, author_member_id, author_connected_agent_id, parent_comment_id, content_type, content) VALUES ($1, $2, $3, $4, $5::comment_content_type, $6::jsonb) RETURNING *`,
+				[
+					taskId,
+					authorMemberId,
+					authorConnectedAgentId,
+					parentCommentId,
+					CommentContentType.Text,
+					JSON.stringify(content),
+				],
 			);
 			await fireCommentWakeups({
 				db,
@@ -1550,6 +1567,7 @@ export function registerTools(
 					taskId,
 					args.content as string,
 					authorMemberId,
+					authorConnectedAgentId,
 					wsManager,
 				).catch((e) => log.error('Failed to record task links from comment:', e)),
 			);

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -324,6 +324,7 @@ agentsRoutes.post('/projects/:projectId/agents', async (c) => {
 		teamId,
 		actorType: createActor.actorType,
 		actorMemberId: createActor.actorMemberId,
+		actorConnectedAgentId: createActor.actorConnectedAgentId,
 		agentMemberId: memberId,
 	});
 
@@ -938,6 +939,7 @@ agentsRoutes.patch('/projects/:projectId/agents/:agentId', async (c) => {
 			teamId,
 			actorType: updateActor.actorType,
 			actorMemberId: updateActor.actorMemberId,
+			actorConnectedAgentId: updateActor.actorConnectedAgentId,
 			agentMemberId: agentId,
 			changes,
 		});
@@ -988,6 +990,7 @@ agentsRoutes.post('/projects/:projectId/agents/:agentId/disable', async (c) => {
 		teamId,
 		actorType: disableActor.actorType,
 		actorMemberId: disableActor.actorMemberId,
+		actorConnectedAgentId: disableActor.actorConnectedAgentId,
 		agentMemberId: agentId,
 	});
 
@@ -1030,6 +1033,7 @@ agentsRoutes.post('/projects/:projectId/agents/:agentId/enable', async (c) => {
 		teamId,
 		actorType: enableActor.actorType,
 		actorMemberId: enableActor.actorMemberId,
+		actorConnectedAgentId: enableActor.actorConnectedAgentId,
 		agentMemberId: agentId,
 	});
 

--- a/packages/server/src/routes/assets.ts
+++ b/packages/server/src/routes/assets.ts
@@ -15,7 +15,13 @@ import { bodyLimit } from 'hono/body-limit';
 import { insertAssetWithUniqueName } from '../lib/asset-name';
 import { signAssetUrl, verifyAssetUrl } from '../lib/asset-urls';
 import { ref } from '../lib/log-ref';
-import { resolveActorMemberId, resolveProjectId, resolveTaskId } from '../lib/resolve';
+import {
+	actorTypeFromAuth,
+	connectedAgentIdFromAuth,
+	resolveActorMemberId,
+	resolveProjectId,
+	resolveTaskId,
+} from '../lib/resolve';
 import { err, ok } from '../lib/response';
 import type { Env } from '../lib/types';
 import { logger } from '../logger';
@@ -84,8 +90,9 @@ export async function storeUploadedAsset(
 		type: 'asset.created',
 		teamId,
 		projectId,
-		actorType: isAgent ? 'agent' : 'admin',
+		actorType: actorTypeFromAuth(auth),
 		actorMemberId: uploadedBy,
+		actorConnectedAgentId: connectedAgentIdFromAuth(auth),
 		assetId: asset.id,
 		filename: asset.original_filename,
 		taskId: taskId ?? (isAgent ? auth.taskId : null),

--- a/packages/server/src/routes/audit-log.ts
+++ b/packages/server/src/routes/audit-log.ts
@@ -72,8 +72,9 @@ async function queryAuditLog(
 	const dataParams = [...params, perPage, offset];
 	const result = await db.query(
 		`SELECT al.id, al.team_id, al.project_id, al.actor_type, al.actor_member_id,
+		        al.actor_connected_agent_id,
 		        al.action, al.entity_type, al.entity_id, al.details, al.created_at,
-		        COALESCE(ma.title, m.display_name) AS actor_name,
+		        COALESCE(ma.title, m.display_name, ca.name) AS actor_name,
 		        t.name AS team_name,
 		        t.slug AS team_slug,
 		        p.slug AS project_slug,
@@ -83,6 +84,7 @@ async function queryAuditLog(
 		 FROM audit_log al
 		 LEFT JOIN members m ON m.id = al.actor_member_id
 		 LEFT JOIN member_agents ma ON ma.id = al.actor_member_id
+		 LEFT JOIN connected_agents ca ON ca.id = al.actor_connected_agent_id
 		 LEFT JOIN teams t ON t.id = al.team_id
 		 LEFT JOIN projects p ON p.id = al.project_id
 		 LEFT JOIN projects ip ON ip.team_id = al.team_id AND ip.is_internal = false

--- a/packages/server/src/routes/comments.ts
+++ b/packages/server/src/routes/comments.ts
@@ -4,7 +4,12 @@ import { encrypt } from '../crypto/encryption';
 import { signAssetUrl } from '../lib/asset-urls';
 import { broadcastChange } from '../lib/broadcast';
 import { validateCredentialValue } from '../lib/credential-validator';
-import { resolveActor, resolveActorMemberId, resolveTaskId } from '../lib/resolve';
+import {
+	connectedAgentIdFromAuth,
+	resolveActor,
+	resolveActorMemberId,
+	resolveTaskId,
+} from '../lib/resolve';
 import { err, ok } from '../lib/response';
 import { withTransaction } from '../lib/sql';
 import type { Env } from '../lib/types';
@@ -31,13 +36,15 @@ commentsRoutes.get('/projects/:projectId/tasks/:taskId/comments', async (c) => {
 
 	const result = await db.query(
 		`SELECT ic.id, ic.public_id, ic.task_id, ic.content_type, ic.content, ic.chosen_option, ic.created_at,
-            m.member_type AS author_type,
-            COALESCE(ma.title, m.display_name, 'Admin') AS author_name,
+            CASE WHEN ic.author_connected_agent_id IS NOT NULL THEN 'connected_agent' ELSE m.member_type::text END AS author_type,
+            COALESCE(ca.name, ma.title, m.display_name, 'Admin') AS author_name,
             ic.author_member_id,
+            ic.author_connected_agent_id,
             ic.parent_comment_id
      FROM task_comments ic
      LEFT JOIN members m ON m.id = ic.author_member_id
      LEFT JOIN member_agents ma ON ma.id = ic.author_member_id
+     LEFT JOIN connected_agents ca ON ca.id = ic.author_connected_agent_id
      WHERE ic.task_id = $1
      ORDER BY ic.created_at ASC`,
 		[taskId],
@@ -210,6 +217,8 @@ commentsRoutes.post('/projects/:projectId/tasks/:taskId/comments', async (c) => 
 	} else if (auth.type === AuthType.Agent) {
 		authorMemberId = auth.memberId;
 	}
+	// A connected agent authors as its first-class identity, not a member.
+	const authorConnectedAgentId = connectedAgentIdFromAuth(auth);
 
 	// Only Admin (human) callers can opt into waking the assignee on a plain
 	// comment. Agent-authored comments (via the /mcp create_comment tool) keep
@@ -218,12 +227,13 @@ commentsRoutes.post('/projects/:projectId/tasks/:taskId/comments', async (c) => 
 
 	const result = await withTransaction(db, async () => {
 		const inserted = await db.query<{ id: string }>(
-			`INSERT INTO task_comments (task_id, author_member_id, parent_comment_id, content_type, content)
-     VALUES ($1, $2, $3, $4::comment_content_type, $5::jsonb)
+			`INSERT INTO task_comments (task_id, author_member_id, author_connected_agent_id, parent_comment_id, content_type, content)
+     VALUES ($1, $2, $3, $4, $5::comment_content_type, $6::jsonb)
      RETURNING *`,
 			[
 				taskId,
 				authorMemberId,
+				authorConnectedAgentId,
 				parentCommentId,
 				body.content_type ?? CommentContentType.Text,
 				JSON.stringify(body.content),
@@ -259,9 +269,15 @@ commentsRoutes.post('/projects/:projectId/tasks/:taskId/comments', async (c) => 
 
 	const commentText = typeof body.content?.text === 'string' ? body.content.text : '';
 	if (commentText) {
-		recordTaskLinks(db, teamId, taskId, commentText, authorMemberId, c.get('wsManager')).catch(
-			(e) => log.error('Failed to record task links from comment:', e),
-		);
+		recordTaskLinks(
+			db,
+			teamId,
+			taskId,
+			commentText,
+			authorMemberId,
+			authorConnectedAgentId,
+			c.get('wsManager'),
+		).catch((e) => log.error('Failed to record task links from comment:', e));
 	}
 
 	broadcastChange(
@@ -435,6 +451,7 @@ commentsRoutes.post(
 			projectId: null,
 			actorType: actor.actorType,
 			actorMemberId: actor.actorMemberId,
+			actorConnectedAgentId: actor.actorConnectedAgentId,
 			secretId,
 			name,
 			requestingAgentId,

--- a/packages/server/src/routes/project-docs.ts
+++ b/packages/server/src/routes/project-docs.ts
@@ -9,7 +9,12 @@ import {
 } from '@hezo/shared';
 import { Hono } from 'hono';
 import { resolveAgentsMdPath } from '../lib/docs';
-import { actorTypeFromAuth, resolveActorMemberId, resolveProjectId } from '../lib/resolve';
+import {
+	actorTypeFromAuth,
+	connectedAgentIdFromAuth,
+	resolveActorMemberId,
+	resolveProjectId,
+} from '../lib/resolve';
 import { err, ok } from '../lib/response';
 import type { Env } from '../lib/types';
 import { broadcastApprovalChange } from '../services/approval-broadcast';
@@ -118,7 +123,12 @@ projectDocsRoutes.put('/projects/:projectId/docs/:filename', async (c) => {
 		content: body.content,
 		changeSummary: body.change_summary,
 		authorMemberId: memberId,
-		audit: { events: c.get('events'), actorType: actorTypeFromAuth(auth) },
+		authorConnectedAgentId: connectedAgentIdFromAuth(auth),
+		audit: {
+			events: c.get('events'),
+			actorType: actorTypeFromAuth(auth),
+			actorConnectedAgentId: connectedAgentIdFromAuth(auth),
+		},
 	});
 
 	return ok(c, {
@@ -152,7 +162,12 @@ projectDocsRoutes.delete('/projects/:projectId/docs/:filename', async (c) => {
 			projectId,
 			slug: filename,
 		},
-		{ events: c.get('events'), actorType: actorTypeFromAuth(c.get('auth')), actorMemberId },
+		{
+			events: c.get('events'),
+			actorType: actorTypeFromAuth(c.get('auth')),
+			actorConnectedAgentId: connectedAgentIdFromAuth(c.get('auth')),
+			actorMemberId,
+		},
 	);
 	if (!removed) return err(c, 'NOT_FOUND', `Document '${filename}' not found`, 404);
 
@@ -209,7 +224,12 @@ projectDocsRoutes.post('/projects/:projectId/docs/:filename/restore', async (c) 
 		documentId: doc.id,
 		revisionNumber: body.revision_number,
 		restoredByMemberId,
-		audit: { events: c.get('events'), actorType: actorTypeFromAuth(auth) },
+		restoredByConnectedAgentId: connectedAgentIdFromAuth(auth),
+		audit: {
+			events: c.get('events'),
+			actorType: actorTypeFromAuth(auth),
+			actorConnectedAgentId: connectedAgentIdFromAuth(auth),
+		},
 	});
 	if (!restored) return err(c, 'NOT_FOUND', 'Revision not found', 404);
 

--- a/packages/server/src/routes/queued-wakeups.ts
+++ b/packages/server/src/routes/queued-wakeups.ts
@@ -2,7 +2,7 @@ import { WakeupSource, WakeupStatus, wsRoom } from '@hezo/shared';
 import { Hono } from 'hono';
 import { broadcastChange } from '../lib/broadcast';
 import { shouldDeferWakeupForBlockers } from '../lib/dependencies';
-import { resolveActorMemberId, resolveTaskId } from '../lib/resolve';
+import { connectedAgentIdFromAuth, resolveActorMemberId, resolveTaskId } from '../lib/resolve';
 import { err, ok } from '../lib/response';
 import type { Env } from '../lib/types';
 import { logger } from '../logger';
@@ -140,6 +140,7 @@ queuedWakeupsRoutes.post(
 		);
 		const agentName = nameRes.rows[0]?.member_name ?? 'an agent';
 		const actorMemberId = await resolveActorMemberId(db, c.get('auth'), teamId);
+		const actorConnectedAgentId = connectedAgentIdFromAuth(c.get('auth'));
 		try {
 			await recordWakeupCancelled(
 				db,
@@ -148,6 +149,7 @@ queuedWakeupsRoutes.post(
 				wakeupId,
 				agentName,
 				actorMemberId,
+				actorConnectedAgentId,
 				c.get('wsManager'),
 			);
 		} catch (e) {

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -21,6 +21,7 @@ import {
 import { buildMeta, parsePagination } from '../lib/pagination';
 import {
 	actorTypeFromAuth,
+	connectedAgentIdFromAuth,
 	getProjectLocator,
 	resolveActorMemberId as resolveAuthActorMemberId,
 	resolveTaskId,
@@ -55,6 +56,7 @@ async function buildCreateTaskCaller(c: Context<Env>, teamId: string): Promise<C
 	const caller: CreateTaskCaller = {
 		actorType: actorTypeFromAuth(auth),
 		actorMemberId,
+		actorConnectedAgentId: connectedAgentIdFromAuth(auth),
 	};
 	if (auth.type === AuthType.Agent) {
 		caller.agentMemberId = auth.memberId;
@@ -591,6 +593,7 @@ tasksRoutes.patch('/projects/:projectId/tasks/:taskId', async (c) => {
 	}
 
 	const actorMemberId = await resolveActorMemberId(c, teamId);
+	const actorConnectedAgentId = connectedAgentIdFromAuth(c.get('auth'));
 	const events = c.get('events');
 	const actorType = actorTypeFromAuth(c.get('auth'));
 	const projectId = existing.rows[0].project_id;
@@ -603,6 +606,7 @@ tasksRoutes.patch('/projects/:projectId/tasks/:taskId', async (c) => {
 				taskId,
 				body.description,
 				actorMemberId,
+				actorConnectedAgentId,
 				c.get('wsManager'),
 			).catch((e) => log.error('Failed to record task links from description:', e)),
 		);
@@ -617,6 +621,7 @@ tasksRoutes.patch('/projects/:projectId/tasks/:taskId', async (c) => {
 				existing.rows[0].title,
 				body.title.trim(),
 				actorMemberId,
+				actorConnectedAgentId,
 				c.get('wsManager'),
 			);
 			events?.emit({
@@ -625,6 +630,7 @@ tasksRoutes.patch('/projects/:projectId/tasks/:taskId', async (c) => {
 				projectId,
 				actorType,
 				actorMemberId,
+				actorConnectedAgentId,
 				taskId,
 				field: 'title',
 				from: existing.rows[0].title,
@@ -644,6 +650,7 @@ tasksRoutes.patch('/projects/:projectId/tasks/:taskId', async (c) => {
 				existing.rows[0].assignee_id,
 				body.assignee_id,
 				actorMemberId,
+				actorConnectedAgentId,
 				c.get('wsManager'),
 			);
 			events?.emit({
@@ -652,6 +659,7 @@ tasksRoutes.patch('/projects/:projectId/tasks/:taskId', async (c) => {
 				projectId,
 				actorType,
 				actorMemberId,
+				actorConnectedAgentId,
 				taskId,
 				field: 'assignee',
 				from: existing.rows[0].assignee_id,
@@ -673,6 +681,7 @@ tasksRoutes.patch('/projects/:projectId/tasks/:taskId', async (c) => {
 				existing.rows[0].status,
 				body.status,
 				actorMemberId,
+				actorConnectedAgentId,
 				c.get('wsManager'),
 			);
 		} catch (e) {
@@ -688,6 +697,7 @@ tasksRoutes.patch('/projects/:projectId/tasks/:taskId', async (c) => {
 					projectId,
 					actorType,
 					actorMemberId,
+					actorConnectedAgentId,
 					taskId,
 					field: 'status',
 					from: existing.rows[0].status,

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -1879,6 +1879,7 @@ export async function createHeartbeatRun(
 			TaskStatus.Backlog,
 			TaskStatus.InProgress,
 			agent.id,
+			null,
 			broadcast.wsManager,
 		);
 	}

--- a/packages/server/src/services/approval-handlers/hire.ts
+++ b/packages/server/src/services/approval-handlers/hire.ts
@@ -96,6 +96,7 @@ export const hireHandler: ApprovalHandler = {
 						oldStatus,
 						TaskStatus.Done,
 						actorMemberId,
+						null,
 						wsManager,
 					);
 				}

--- a/packages/server/src/services/documents.ts
+++ b/packages/server/src/services/documents.ts
@@ -9,6 +9,8 @@ import type { WebSocketManager } from './ws';
 export interface DocumentAuditContext {
 	events?: DomainEventBus;
 	actorType?: AuditActorType;
+	/** Set when the actor is a connected agent. */
+	actorConnectedAgentId?: string | null;
 }
 
 function emitDocumentEvent(
@@ -24,6 +26,7 @@ function emitDocumentEvent(
 		projectId: row.project_id,
 		actorType: ctx.actorType ?? 'admin',
 		actorMemberId,
+		actorConnectedAgentId: ctx.actorConnectedAgentId ?? null,
 		documentId: row.id,
 		documentType: row.type,
 		slug: row.slug,
@@ -62,6 +65,9 @@ export interface DocumentRevisionRow {
 
 export interface DocumentRevisionRowWithAuthor extends DocumentRevisionRow {
 	author_name: string | null;
+	author_connected_agent_id: string | null;
+	/** 'connected_agent' | 'agent' | 'admin' — drives the human/agent badge. */
+	author_type: string;
 }
 
 interface ScopeProjectDoc {
@@ -158,6 +164,8 @@ export interface UpsertDocumentInput {
 	content: string;
 	changeSummary?: string;
 	authorMemberId: string | null;
+	/** Set when the author is a connected agent. */
+	authorConnectedAgentId?: string | null;
 	/** Optional audit context — when present, a document event is emitted. */
 	audit?: DocumentAuditContext;
 }
@@ -187,6 +195,7 @@ export async function upsertDocument(
 				prior.content,
 				input.changeSummary ?? '',
 				input.authorMemberId,
+				input.authorConnectedAgentId ?? null,
 			);
 		}
 		const updateResult = await db.query<DocumentRow>(
@@ -252,6 +261,7 @@ async function recordRevision(
 	content: string,
 	changeSummary: string,
 	authorMemberId: string | null,
+	authorConnectedAgentId: string | null,
 ): Promise<number> {
 	const next = await db.query<{ rev: number }>(
 		'SELECT COALESCE(MAX(revision_number), 0)::int + 1 AS rev FROM document_revisions WHERE document_id = $1',
@@ -259,9 +269,9 @@ async function recordRevision(
 	);
 	const revisionNumber = next.rows[0].rev;
 	await db.query(
-		`INSERT INTO document_revisions (document_id, revision_number, content, change_summary, author_member_id)
-		 VALUES ($1, $2, $3, $4, $5)`,
-		[documentId, revisionNumber, content, changeSummary, authorMemberId],
+		`INSERT INTO document_revisions (document_id, revision_number, content, change_summary, author_member_id, author_connected_agent_id)
+		 VALUES ($1, $2, $3, $4, $5, $6)`,
+		[documentId, revisionNumber, content, changeSummary, authorMemberId, authorConnectedAgentId],
 	);
 	return revisionNumber;
 }
@@ -295,10 +305,17 @@ export async function listRevisions(
 	documentId: string,
 ): Promise<DocumentRevisionRowWithAuthor[]> {
 	const result = await db.query<DocumentRevisionRowWithAuthor>(
-		`SELECT r.*, COALESCE(ma.title, m.display_name) AS author_name
+		`SELECT r.*,
+		        COALESCE(ma.title, m.display_name, ca.name) AS author_name,
+		        CASE
+		            WHEN r.author_connected_agent_id IS NOT NULL THEN 'connected_agent'
+		            WHEN ma.id IS NOT NULL THEN 'agent'
+		            ELSE 'admin'
+		        END AS author_type
 		 FROM document_revisions r
 		 LEFT JOIN members m ON m.id = r.author_member_id
 		 LEFT JOIN member_agents ma ON ma.id = r.author_member_id
+		 LEFT JOIN connected_agents ca ON ca.id = r.author_connected_agent_id
 		 WHERE r.document_id = $1
 		 ORDER BY r.revision_number DESC`,
 		[documentId],
@@ -310,6 +327,8 @@ export interface RestoreRevisionInput {
 	documentId: string;
 	revisionNumber: number;
 	restoredByMemberId: string | null;
+	/** Set when the restorer is a connected agent. */
+	restoredByConnectedAgentId?: string | null;
 	audit?: DocumentAuditContext;
 }
 
@@ -336,6 +355,7 @@ export async function restoreRevision(
 			doc.rows[0].content,
 			`Restored to revision ${input.revisionNumber}`,
 			input.restoredByMemberId,
+			input.restoredByConnectedAgentId ?? null,
 		);
 		const updated = await db.query<DocumentRow>(
 			`UPDATE documents

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -1753,6 +1753,7 @@ export class JobManager {
 						TaskStatus.Done,
 						TaskStatus.Closed,
 						memberId,
+						null,
 						this.deps.wsManager,
 					);
 				}

--- a/packages/server/src/services/project-intake.ts
+++ b/packages/server/src/services/project-intake.ts
@@ -381,6 +381,7 @@ export async function completeProjectIntakeAfterProvisioning(
 			oldStatus,
 			TaskStatus.Done,
 			ctx.ceoMemberId,
+			null,
 			wsManager,
 		);
 		try {

--- a/packages/server/src/services/run-termination.ts
+++ b/packages/server/src/services/run-termination.ts
@@ -75,6 +75,9 @@ export async function terminateHeartbeatRun(
 	}
 
 	if (row.task_id) {
+		// The run-terminated note is a secondary system comment; connected-agent
+		// attribution is not threaded this deep (the primary action is attributed
+		// at its source).
 		await recordRunTerminated(
 			db,
 			row.team_id,
@@ -82,6 +85,7 @@ export async function terminateHeartbeatRun(
 			runId,
 			reason,
 			actorMemberId,
+			null,
 			wsManager,
 		);
 	}

--- a/packages/server/src/services/task-automation.ts
+++ b/packages/server/src/services/task-automation.ts
@@ -160,9 +160,19 @@ export async function triggerStatusAutomations(
 	oldStatus: string,
 	newStatus: string,
 	actorMemberId: string | null,
+	actorConnectedAgentId: string | null,
 	wsManager?: WebSocketManager,
 ): Promise<void> {
-	await recordStatusChange(db, teamId, taskId, oldStatus, newStatus, actorMemberId, wsManager);
+	await recordStatusChange(
+		db,
+		teamId,
+		taskId,
+		oldStatus,
+		newStatus,
+		actorMemberId,
+		actorConnectedAgentId,
+		wsManager,
+	);
 
 	// Downstream blocker state only flips when this task crosses the
 	// terminal boundary. Same-bucket transitions (e.g. done → closed

--- a/packages/server/src/services/task-events.ts
+++ b/packages/server/src/services/task-events.ts
@@ -20,7 +20,23 @@ export function extractTaskIdentifiers(text: string | null | undefined): string[
 	return Array.from(out);
 }
 
-export async function resolveActorName(db: PGlite, actorMemberId: string | null): Promise<string> {
+/**
+ * Human-readable name for an action's actor. A connected agent (approved
+ * external MCP client) is named from `connected_agents`; a member from its
+ * agent title / display name; everything else is "Admin".
+ */
+export async function resolveActorName(
+	db: PGlite,
+	actorMemberId: string | null,
+	actorConnectedAgentId: string | null = null,
+): Promise<string> {
+	if (actorConnectedAgentId) {
+		const r = await db.query<{ name: string | null }>(
+			'SELECT name FROM connected_agents WHERE id = $1',
+			[actorConnectedAgentId],
+		);
+		return r.rows[0]?.name ?? 'Admin';
+	}
 	if (!actorMemberId) return 'Admin';
 	const r = await db.query<{ name: string | null }>(
 		`SELECT COALESCE(ma.title, NULLIF(m.display_name, ''), 'Admin') AS name
@@ -33,11 +49,22 @@ export async function resolveActorName(db: PGlite, actorMemberId: string | null)
 
 interface ActorInfo {
 	name: string;
-	kind: 'agent' | 'user' | 'admin';
+	kind: 'agent' | 'user' | 'admin' | 'connected_agent';
 	slug: string | null;
 }
 
-async function resolveActor(db: PGlite, actorMemberId: string | null): Promise<ActorInfo> {
+async function resolveActor(
+	db: PGlite,
+	actorMemberId: string | null,
+	actorConnectedAgentId: string | null = null,
+): Promise<ActorInfo> {
+	if (actorConnectedAgentId) {
+		const r = await db.query<{ name: string | null }>(
+			'SELECT name FROM connected_agents WHERE id = $1',
+			[actorConnectedAgentId],
+		);
+		return { name: r.rows[0]?.name ?? 'Admin', kind: 'connected_agent', slug: null };
+	}
 	if (!actorMemberId) return { name: 'Admin', kind: 'admin', slug: null };
 	const r = await db.query<{
 		name: string | null;
@@ -72,12 +99,14 @@ export async function recordStatusChange(
 	oldStatus: string,
 	newStatus: string,
 	actorMemberId: string | null,
+	actorConnectedAgentId: string | null,
 	wsManager: WebSocketManager | undefined,
 	cascade?: CascadeContext,
 ): Promise<void> {
 	if (oldStatus === newStatus) return;
 	const isCascade = cascade !== undefined;
 	const authorId = isCascade ? null : actorMemberId;
+	const authorConnectedId = isCascade ? null : actorConnectedAgentId;
 	const content: Record<string, unknown> = {
 		kind: 'status_change',
 		from: oldStatus,
@@ -92,9 +121,9 @@ export async function recordStatusChange(
 		content.triggered_by_actor_id = actorMemberId;
 	}
 	const r = await db.query<Record<string, unknown>>(
-		`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
-		 VALUES ($1, $2, $3::comment_content_type, $4::jsonb) RETURNING *`,
-		[taskId, authorId, CommentContentType.System, JSON.stringify(content)],
+		`INSERT INTO task_comments (task_id, author_member_id, author_connected_agent_id, content_type, content)
+		 VALUES ($1, $2, $3, $4::comment_content_type, $5::jsonb) RETURNING *`,
+		[taskId, authorId, authorConnectedId, CommentContentType.System, JSON.stringify(content)],
 	);
 	if (r.rows[0] && wsManager) {
 		broadcastRowChange(wsManager, wsRoom.team(teamId), 'task_comments', 'INSERT', r.rows[0]);
@@ -108,16 +137,18 @@ export async function recordRunTerminated(
 	runId: string,
 	reason: string,
 	actorMemberId: string | null,
+	actorConnectedAgentId: string | null,
 	wsManager: WebSocketManager | undefined,
 ): Promise<void> {
-	const actorName = await resolveActorName(db, actorMemberId);
+	const actorName = await resolveActorName(db, actorMemberId, actorConnectedAgentId);
 	const text = `${actorName} terminated agent run — ${reason}`;
 	const r = await db.query<Record<string, unknown>>(
-		`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
-		 VALUES ($1, $2, $3::comment_content_type, $4::jsonb) RETURNING *`,
+		`INSERT INTO task_comments (task_id, author_member_id, author_connected_agent_id, content_type, content)
+		 VALUES ($1, $2, $3, $4::comment_content_type, $5::jsonb) RETURNING *`,
 		[
 			taskId,
 			actorMemberId,
+			actorConnectedAgentId,
 			CommentContentType.System,
 			JSON.stringify({
 				kind: 'run_terminated',
@@ -141,16 +172,18 @@ export async function recordWakeupCancelled(
 	wakeupId: string,
 	agentName: string,
 	actorMemberId: string | null,
+	actorConnectedAgentId: string | null,
 	wsManager: WebSocketManager | undefined,
 ): Promise<void> {
-	const actorName = await resolveActorName(db, actorMemberId);
+	const actorName = await resolveActorName(db, actorMemberId, actorConnectedAgentId);
 	const text = `${actorName} cancelled queued run for ${agentName}`;
 	const r = await db.query<Record<string, unknown>>(
-		`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
-		 VALUES ($1, $2, $3::comment_content_type, $4::jsonb) RETURNING *`,
+		`INSERT INTO task_comments (task_id, author_member_id, author_connected_agent_id, content_type, content)
+		 VALUES ($1, $2, $3, $4::comment_content_type, $5::jsonb) RETURNING *`,
 		[
 			taskId,
 			actorMemberId,
+			actorConnectedAgentId,
 			CommentContentType.System,
 			JSON.stringify({
 				kind: 'wakeup_cancelled',
@@ -174,17 +207,19 @@ export async function recordTitleChange(
 	oldTitle: string,
 	newTitle: string,
 	actorMemberId: string | null,
+	actorConnectedAgentId: string | null,
 	wsManager: WebSocketManager | undefined,
 ): Promise<void> {
 	if (oldTitle === newTitle) return;
-	const actorName = await resolveActorName(db, actorMemberId);
+	const actorName = await resolveActorName(db, actorMemberId, actorConnectedAgentId);
 	const text = `${actorName} renamed from "${oldTitle}" to "${newTitle}"`;
 	const r = await db.query<Record<string, unknown>>(
-		`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
-		 VALUES ($1, $2, $3::comment_content_type, $4::jsonb) RETURNING *`,
+		`INSERT INTO task_comments (task_id, author_member_id, author_connected_agent_id, content_type, content)
+		 VALUES ($1, $2, $3, $4::comment_content_type, $5::jsonb) RETURNING *`,
 		[
 			taskId,
 			actorMemberId,
+			actorConnectedAgentId,
 			CommentContentType.System,
 			JSON.stringify({
 				kind: 'title_change',
@@ -207,21 +242,23 @@ export async function recordAssigneeChange(
 	oldAssigneeId: string | null,
 	newAssigneeId: string | null,
 	actorMemberId: string | null,
+	actorConnectedAgentId: string | null,
 	wsManager: WebSocketManager | undefined,
 ): Promise<{ fromName: string; toName: string } | null> {
 	if (oldAssigneeId === newAssigneeId) return null;
 	const [fromName, toName, actorName] = await Promise.all([
 		resolveActorName(db, oldAssigneeId),
 		resolveActorName(db, newAssigneeId),
-		resolveActorName(db, actorMemberId),
+		resolveActorName(db, actorMemberId, actorConnectedAgentId),
 	]);
 	const text = `${actorName} reassigned from ${fromName} to ${toName}`;
 	const r = await db.query<Record<string, unknown>>(
-		`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
-		 VALUES ($1, $2, $3::comment_content_type, $4::jsonb) RETURNING *`,
+		`INSERT INTO task_comments (task_id, author_member_id, author_connected_agent_id, content_type, content)
+		 VALUES ($1, $2, $3, $4::comment_content_type, $5::jsonb) RETURNING *`,
 		[
 			taskId,
 			actorMemberId,
+			actorConnectedAgentId,
 			CommentContentType.System,
 			JSON.stringify({
 				kind: 'assignee_change',
@@ -246,6 +283,7 @@ export async function recordTaskLinks(
 	sourceTaskId: string,
 	text: string | null | undefined,
 	actorMemberId: string | null,
+	actorConnectedAgentId: string | null,
 	wsManager: WebSocketManager | undefined,
 ): Promise<void> {
 	const ids = extractTaskIdentifiers(text);
@@ -267,7 +305,7 @@ export async function recordTaskLinks(
 	);
 	const sourceIdentifier = source.rows[0]?.identifier ?? '';
 	const sourceProjectSlug = source.rows[0]?.project_slug ?? '';
-	const actor = await resolveActor(db, actorMemberId);
+	const actor = await resolveActor(db, actorMemberId, actorConnectedAgentId);
 
 	for (const target of targets.rows) {
 		const exists = await db.query(
@@ -283,11 +321,12 @@ export async function recordTaskLinks(
 
 		const linkText = `Linked from ${sourceIdentifier} by ${actor.name}`;
 		const r = await db.query<Record<string, unknown>>(
-			`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
-			 VALUES ($1, $2, $3::comment_content_type, $4::jsonb) RETURNING *`,
+			`INSERT INTO task_comments (task_id, author_member_id, author_connected_agent_id, content_type, content)
+			 VALUES ($1, $2, $3, $4::comment_content_type, $5::jsonb) RETURNING *`,
 			[
 				target.id,
 				actorMemberId,
+				actorConnectedAgentId,
 				CommentContentType.System,
 				JSON.stringify({
 					kind: 'task_link',

--- a/packages/server/src/services/tasks.ts
+++ b/packages/server/src/services/tasks.ts
@@ -43,6 +43,8 @@ export interface CreateTaskInput {
 export interface CreateTaskCaller {
 	actorType: AuditActorType;
 	actorMemberId: string | null;
+	// Set when the caller is a connected agent; mutually exclusive with actorMemberId.
+	actorConnectedAgentId?: string | null;
 	// Set only when the caller is an agent run — drives the subordinate
 	// assignee check and is recorded as created_by_run_id on the new task.
 	agentMemberId?: string;
@@ -178,6 +180,7 @@ export async function createTask(
 		projectId: input.project_id,
 		actorType: caller.actorType,
 		actorMemberId: caller.actorMemberId,
+		actorConnectedAgentId: caller.actorConnectedAgentId ?? null,
 		taskId: task.id,
 		identifier: task.identifier,
 	});
@@ -190,6 +193,7 @@ export async function createTask(
 				task.id,
 				input.description,
 				caller.actorMemberId,
+				caller.actorConnectedAgentId ?? null,
 				wsManager,
 			).catch((e) => log.error('Failed to record task links from description:', e)),
 		);

--- a/packages/server/test/connected-agent-attribution.test.ts
+++ b/packages/server/test/connected-agent-attribution.test.ts
@@ -1,0 +1,169 @@
+import type { PGlite } from '@electric-sql/pglite';
+
+// biome-ignore lint/suspicious/noExplicitAny: tests parse unpredictable JSON-RPC payloads
+type Json = any;
+
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Env } from '../src/lib/types';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
+
+// A connected agent (approved external MCP client) is admin-equivalent. Its
+// actions — primarily via the MCP endpoint — must be attributed to its identity
+// so the UI can flag them with a bot badge instead of a bare "admin".
+
+let app: Hono<Env>;
+let db: PGlite;
+let token: string; // superuser admin
+let projectSlug: string;
+
+async function registerAndApprove(name: string): Promise<string> {
+	const reg = await app.request('/api/agent-connections/register', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ name }),
+	});
+	expect(reg.status).toBe(201);
+	const { id, token: agentToken } = (await reg.json()).data;
+	const approveRes = await app.request(`/api/agent-connections/${id}/approve`, {
+		method: 'POST',
+		headers: authHeader(token),
+	});
+	expect(approveRes.status).toBe(200);
+	return agentToken as string;
+}
+
+async function mcpTool(
+	agentToken: string,
+	name: string,
+	args: Record<string, unknown>,
+): Promise<Json> {
+	const res = await app.request('/mcp', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${agentToken}` },
+		body: JSON.stringify({
+			jsonrpc: '2.0',
+			method: 'tools/call',
+			params: { name, arguments: args },
+			id: 1,
+		}),
+	});
+	const body = await res.json();
+	if (body.error) throw new Error(`MCP ${name} failed: ${JSON.stringify(body.error)}`);
+	return JSON.parse(body.result.content[0].text);
+}
+
+async function getComments(taskId: string): Promise<Json[]> {
+	const res = await app.request(`/api/projects/${projectSlug}/tasks/${taskId}/comments`, {
+		headers: authHeader(token),
+	});
+	return (await res.json()).data as Json[];
+}
+
+async function waitFor<T>(fn: () => Promise<T | null | undefined>, timeoutMs = 1500): Promise<T> {
+	const start = Date.now();
+	while (Date.now() - start < timeoutMs) {
+		const r = await fn();
+		if (r) return r;
+		await new Promise((res) => setTimeout(res, 20));
+	}
+	throw new Error('waitFor timed out');
+}
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+	const team = (await (await createTestTeam(db, { name: 'Attrib Co' })).json()).data;
+	projectSlug = (await (await createTestProject(db, team.id, { name: 'Attrib Project' })).json())
+		.data.slug;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+describe('connected-agent action attribution', () => {
+	it('attributes a task created via MCP to the connected agent in the audit log', async () => {
+		const agentToken = await registerAndApprove('Audit Bot');
+		const created = await mcpTool(agentToken, 'create_task', {
+			project: projectSlug,
+			title: 'Filed by the connected agent',
+			assignee_slug: 'captain',
+		});
+		expect(created.id ?? created.identifier).toBeTruthy();
+
+		const auditRow = await waitFor(async () => {
+			const r = await db.query<{ actor_type: string; actor_connected_agent_id: string | null }>(
+				`SELECT actor_type, actor_connected_agent_id FROM audit_log
+				 WHERE entity_type = 'task' AND action = 'created' AND actor_type = 'connected_agent'
+				 ORDER BY created_at DESC LIMIT 1`,
+			);
+			return r.rows[0] ?? null;
+		});
+		expect(auditRow.actor_connected_agent_id).not.toBeNull();
+
+		// The connected agent's identity name resolves from connected_agents.
+		const named = await db.query<{ name: string }>(
+			'SELECT name FROM connected_agents WHERE id = $1',
+			[auditRow.actor_connected_agent_id],
+		);
+		expect(named.rows[0].name).toBe('Audit Bot');
+	});
+
+	it('attributes a comment and a status change made via MCP to the connected agent', async () => {
+		const agentToken = await registerAndApprove('Comment Bot');
+
+		// Create a task to act on (as the admin).
+		const taskRes = await app.request(`/api/projects/${projectSlug}/tasks`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ title: 'Work item', assignee_slug: 'captain' }),
+		});
+		const task = (await taskRes.json()).data;
+
+		await mcpTool(agentToken, 'create_comment', {
+			project: projectSlug,
+			task_id: task.identifier,
+			content: 'handled by the connected agent',
+		});
+		await mcpTool(agentToken, 'update_task', {
+			project: projectSlug,
+			task_id: task.identifier,
+			status: 'in_progress',
+		});
+
+		const comments = await getComments(task.id);
+		const authored = comments.find((c) => c.content?.text === 'handled by the connected agent');
+		expect(authored?.author_type).toBe('connected_agent');
+		expect(authored?.author_name).toBe('Comment Bot');
+		expect(authored?.author_connected_agent_id).not.toBeNull();
+
+		const statusComment = comments.find(
+			(c) => c.content_type === 'system' && c.content?.kind === 'status_change',
+		);
+		expect(statusComment?.author_type).toBe('connected_agent');
+		expect(statusComment?.author_connected_agent_id).not.toBeNull();
+	});
+
+	it('attributes a project-doc revision (REST) to the connected agent', async () => {
+		const agentToken = await registerAndApprove('Doc Bot');
+		for (const content of ['v1', 'v2']) {
+			const res = await app.request(`/api/projects/${projectSlug}/docs/notes.md`, {
+				method: 'PUT',
+				headers: { ...authHeader(agentToken), 'Content-Type': 'application/json' },
+				body: JSON.stringify({ content }),
+			});
+			expect(res.status).toBe(200);
+		}
+		const revRes = await app.request(`/api/projects/${projectSlug}/docs/notes.md/revisions`, {
+			headers: authHeader(token),
+		});
+		const revisions = (await revRes.json()).data as Json[];
+		expect(revisions[0].author_type).toBe('connected_agent');
+		expect(revisions[0].author_name).toBe('Doc Bot');
+		expect(revisions[0].author_connected_agent_id).not.toBeNull();
+	});
+});

--- a/packages/server/test/migrate-connected-agent-attribution.test.ts
+++ b/packages/server/test/migrate-connected-agent-attribution.test.ts
@@ -1,0 +1,140 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { PGlite } from '@electric-sql/pglite';
+import { vector } from '@electric-sql/pglite/vector';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { safeClose } from './helpers';
+
+// 018_connected_agent_attribution.sql extends audit_actor_type with
+// 'connected_agent' and adds parallel connected-agent attribution columns to
+// audit_log, task_comments, and document_revisions. This drives the REAL
+// migration path against populated data: existing audit rows of every prior
+// actor_type must survive the enum swap, and a connected_agent row must work.
+
+function migrationsDir(): string {
+	try {
+		return fileURLToPath(new URL('../migrations', import.meta.url));
+	} catch {
+		const override = process.env.HEZO_MIGRATIONS_DIR;
+		if (!override) throw new Error('HEZO_MIGRATIONS_DIR unset and import.meta.url not a file URL');
+		return override;
+	}
+}
+
+function loadMigration(file: string): string {
+	return readFileSync(join(migrationsDir(), file), 'utf-8').replace(
+		/CREATE EXTENSION IF NOT EXISTS "pgcrypto";/g,
+		'',
+	);
+}
+
+const PRE_MIGRATIONS = [
+	'001_initial_schema.sql',
+	'002_migration_smoke.sql',
+	'003_budgeting.sql',
+	'004_cost_provider_tracking.sql',
+	'005_model_pricing.sql',
+	'006_budget_runtime_states.sql',
+	'007_comment_public_id.sql',
+	'008_opencode_kimi_runtimes.sql',
+	'009_skills_builtin.sql',
+	'010_heartbeat_run_produced_output.sql',
+	'011_heartbeat_run_no_work.sql',
+	'012_drop_skills_builtin.sql',
+	'013_remove_options_comment.sql',
+	'014_comments_embedding.sql',
+	'015_heartbeat_run_usage_partial.sql',
+	'016_connected_agents.sql',
+	'017_remove_agent_api_orphans.sql',
+];
+
+describe('018 connected-agent attribution migration', () => {
+	let db: PGlite;
+	let connectedAgentId: string;
+
+	beforeAll(async () => {
+		db = new PGlite({ extensions: { vector } });
+		for (const file of PRE_MIGRATIONS) await db.exec(loadMigration(file));
+
+		// Pre-migration sanity: the actor column doesn't exist yet.
+		const before = await db.query(
+			`SELECT 1 FROM information_schema.columns
+			 WHERE table_name = 'audit_log' AND column_name = 'actor_connected_agent_id'`,
+		);
+		expect(before.rows.length).toBe(0);
+
+		const team = await db.query<{ id: string }>(
+			`INSERT INTO teams (name, slug) VALUES ('Acme', 'acme') RETURNING id`,
+		);
+		const teamId = team.rows[0].id;
+		const agent = await db.query<{ id: string }>(
+			`INSERT INTO connected_agents (name, prefix, token_hash, status)
+			 VALUES ('CRM Bot', 'aaaaaaaa', 'h1', 'approved') RETURNING id`,
+		);
+		connectedAgentId = agent.rows[0].id;
+
+		// One audit row of each existing actor_type — must survive the enum swap.
+		for (const actor of ['admin', 'agent', 'system']) {
+			await db.query(
+				`INSERT INTO audit_log (team_id, actor_type, actor_member_id, action, entity_type, entity_id)
+				 VALUES ($1, $2::audit_actor_type, NULL, 'created', 'task', NULL)`,
+				[teamId, actor],
+			);
+		}
+
+		await db.exec(loadMigration('018_connected_agent_attribution.sql'));
+	});
+
+	afterAll(async () => {
+		await safeClose(db);
+	});
+
+	it('extends audit_actor_type with connected_agent and preserves existing rows', async () => {
+		const surviving = await db.query<{ actor_type: string }>(
+			`SELECT actor_type FROM audit_log ORDER BY actor_type`,
+		);
+		expect(surviving.rows.map((r) => r.actor_type)).toEqual(['admin', 'agent', 'system']);
+
+		const inserted = await db.query<{ actor_type: string }>(
+			`INSERT INTO audit_log (actor_type, actor_connected_agent_id, action, entity_type, entity_id)
+			 VALUES ('connected_agent'::audit_actor_type, $1, 'updated', 'task', NULL)
+			 RETURNING actor_type`,
+			[connectedAgentId],
+		);
+		expect(inserted.rows[0].actor_type).toBe('connected_agent');
+	});
+
+	it('adds nullable connected-agent actor columns to the attributed tables', async () => {
+		for (const [table, column] of [
+			['audit_log', 'actor_connected_agent_id'],
+			['task_comments', 'author_connected_agent_id'],
+			['document_revisions', 'author_connected_agent_id'],
+		]) {
+			const col = await db.query<{ is_nullable: string }>(
+				`SELECT is_nullable FROM information_schema.columns
+				 WHERE table_name = $1 AND column_name = $2`,
+				[table, column],
+			);
+			expect(col.rows[0]?.is_nullable).toBe('YES');
+		}
+	});
+
+	it('cascades the FK to NULL when a connected agent is deleted', async () => {
+		const team = await db.query<{ id: string }>('SELECT id FROM teams LIMIT 1');
+		const agent = await db.query<{ id: string }>(
+			`INSERT INTO connected_agents (name, prefix, token_hash, status)
+			 VALUES ('Temp Bot', 'bbbbbbbb', 'h2', 'approved') RETURNING id`,
+		);
+		await db.query(
+			`INSERT INTO audit_log (team_id, actor_type, actor_connected_agent_id, action, entity_type, entity_id)
+			 VALUES ($1, 'connected_agent'::audit_actor_type, $2, 'updated', 'task', NULL)`,
+			[team.rows[0].id, agent.rows[0].id],
+		);
+		await db.query('DELETE FROM connected_agents WHERE id = $1', [agent.rows[0].id]);
+		const row = await db.query<{ actor_connected_agent_id: string | null }>(
+			`SELECT actor_connected_agent_id FROM audit_log WHERE actor_connected_agent_id IS NULL AND actor_type = 'connected_agent'`,
+		);
+		expect(row.rows.length).toBeGreaterThan(0);
+	});
+});

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -561,7 +561,12 @@ export const DocumentType = {
 } as const;
 export type DocumentType = (typeof DocumentType)[keyof typeof DocumentType];
 
-export const AuditActorType = { Admin: 'admin', Agent: 'agent', System: 'system' } as const;
+export const AuditActorType = {
+	Admin: 'admin',
+	Agent: 'agent',
+	System: 'system',
+	ConnectedAgent: 'connected_agent',
+} as const;
 export type AuditActorType = (typeof AuditActorType)[keyof typeof AuditActorType];
 
 export const RepoHostType = { GitHub: 'github' } as const;

--- a/packages/web/src/components/audit-log-table.tsx
+++ b/packages/web/src/components/audit-log-table.tsx
@@ -1,6 +1,7 @@
 import { Link } from '@tanstack/react-router';
 import type { AuditEntry } from '../hooks/use-audit-log';
 import { auditEntryLink, describeAuditEntry } from '../lib/audit-format';
+import { ActorBadge } from './ui/actor-badge';
 import { type Column, DataTable } from './ui/data-table';
 
 /**
@@ -37,9 +38,12 @@ function buildColumns(showTeam: boolean): Column<AuditEntry>[] {
 			key: 'actor',
 			header: 'Actor',
 			render: (e) => (
-				<span className="text-xs">
-					{e.actor_name || e.actor_type}
-					{e.actor_name ? <span className="text-text-3"> · {e.actor_type}</span> : null}
+				<span className="inline-flex items-center gap-1 text-xs">
+					<span>
+						{e.actor_name || e.actor_type}
+						{e.actor_name ? <span className="text-text-3"> · {e.actor_type}</span> : null}
+					</span>
+					<ActorBadge actorType={e.actor_type} name={e.actor_name} />
 				</span>
 			),
 		},

--- a/packages/web/src/components/comment-renderers/system-comment.tsx
+++ b/packages/web/src/components/comment-renderers/system-comment.tsx
@@ -10,6 +10,7 @@ import type {
 	SystemStatusChangeContent,
 	SystemTaskLinkContent,
 } from '../comment-content';
+import { ActorBadge } from '../ui/actor-badge';
 import { Tooltip } from '../ui/tooltip';
 import type { CommentDataOf } from './comment-data';
 import { CommentTimestampLink } from './comment-timestamp-link';
@@ -85,6 +86,7 @@ export function SystemComment({ comment, projectId, taskId, retryableRunId }: Pr
 	return (
 		<div className="flex items-baseline gap-2 leading-[26px]">
 			<span className="text-xs text-text-2">{text}</span>
+			<ActorBadge actorType={comment.author_type} name={comment.author_name} />
 			{timestamp}
 		</div>
 	);
@@ -141,6 +143,7 @@ function StatusChangeBody({
 				{actorName} changed status from <em className="italic">{formatTaskStatus(from)}</em> to{' '}
 				<em className="italic">{formatTaskStatus(to)}</em>
 			</span>
+			<ActorBadge actorType={comment.author_type} name={actorName} />
 			{timestamp}
 		</div>
 	);
@@ -311,6 +314,7 @@ function TaskLinkSystemBody({
 	return (
 		<span className={textClass}>
 			Linked from {sourceNode} by {actorNode}
+			<ActorBadge actorType={comment.author_type} name={actorName} className="ml-1" />
 		</span>
 	);
 }

--- a/packages/web/src/components/revisions-panel.tsx
+++ b/packages/web/src/components/revisions-panel.tsx
@@ -1,5 +1,6 @@
 import { Clock, RotateCcw } from 'lucide-react';
 import { useState } from 'react';
+import { ActorBadge } from './ui/actor-badge';
 import { Button } from './ui/button';
 import { Card } from './ui/card';
 import { ConfirmDialog } from './ui/confirm-dialog';
@@ -10,6 +11,8 @@ export interface DocumentRevision {
 	content: string;
 	change_summary: string;
 	author_name: string | null;
+	author_type?: string;
+	author_connected_agent_id?: string | null;
 	created_at: string;
 }
 
@@ -44,7 +47,10 @@ export function RevisionsPanel({ revisions, onRestore, isRestoring }: RevisionsP
 							<Card key={rev.id} className="p-3">
 								<div className="flex items-center gap-2 mb-1">
 									<span className="text-xs font-medium text-text-1">Rev {rev.revision_number}</span>
-									<span className="text-xs text-text-2">{rev.author_name || 'Admin'}</span>
+									<span className="inline-flex items-center gap-1 text-xs text-text-2">
+										{rev.author_name || 'Admin'}
+										<ActorBadge actorType={rev.author_type} name={rev.author_name} />
+									</span>
 									<span className="text-xs text-text-3 ml-auto">
 										{new Date(rev.created_at).toLocaleString()}
 									</span>

--- a/packages/web/src/components/task-detail/comments-section.tsx
+++ b/packages/web/src/components/task-detail/comments-section.tsx
@@ -17,6 +17,7 @@ import {
 	isInlineEventType,
 	jumpToComment,
 } from '../comment-renderers';
+import { ActorBadge } from '../ui/actor-badge';
 import { Avatar, avatarColorFromString } from '../ui/avatar';
 
 /**
@@ -424,6 +425,7 @@ export function CommentsSection({
 												{authorName}
 											</span>
 										)}
+										<ActorBadge actorType={c.author_type} name={authorName} />
 										<CommentTimestampLink publicId={c.public_id} createdAt={c.created_at} />
 										<div className="ml-auto flex items-center gap-2">
 											{c.parent_comment_id &&

--- a/packages/web/src/components/ui/actor-badge.tsx
+++ b/packages/web/src/components/ui/actor-badge.tsx
@@ -1,0 +1,53 @@
+import { Bot, UserRound } from 'lucide-react';
+import { Tooltip } from './tooltip';
+
+/**
+ * Small icon suffix that flags whether an action was taken by a human admin
+ * (via the web UI) or by a connected agent (an approved external MCP client).
+ * Roster agents and system/automation actors render nothing — only the
+ * human-vs-connected-agent distinction is surfaced.
+ *
+ * Actor-type values differ by surface: the audit log uses `admin` for humans,
+ * while task comments use the member type `user`. Both are treated as human.
+ */
+export function ActorBadge({
+	actorType,
+	name,
+	className,
+}: {
+	actorType: string | null | undefined;
+	name?: string | null;
+	className?: string;
+}) {
+	if (actorType === 'connected_agent') {
+		return (
+			<Tooltip
+				content={name ? `${name} — connected agent (external MCP client)` : 'Connected agent'}
+			>
+				<span
+					role="img"
+					className={`inline-flex items-center align-middle text-text-3 ${className ?? ''}`}
+					data-testid="actor-badge-connected-agent"
+					aria-label="Connected agent"
+				>
+					<Bot className="w-3 h-3" aria-hidden="true" />
+				</span>
+			</Tooltip>
+		);
+	}
+	if (actorType === 'admin' || actorType === 'user') {
+		return (
+			<Tooltip content={name ? `${name} — human admin (via web)` : 'Human admin (via web)'}>
+				<span
+					role="img"
+					className={`inline-flex items-center align-middle text-text-3 ${className ?? ''}`}
+					data-testid="actor-badge-human"
+					aria-label="Human admin"
+				>
+					<UserRound className="w-3 h-3" aria-hidden="true" />
+				</span>
+			</Tooltip>
+		);
+	}
+	return null;
+}

--- a/packages/web/src/hooks/use-audit-log.ts
+++ b/packages/web/src/hooks/use-audit-log.ts
@@ -8,6 +8,7 @@ export interface AuditEntry {
 	project_id: string | null;
 	actor_type: string;
 	actor_member_id: string | null;
+	actor_connected_agent_id: string | null;
 	actor_name: string | null;
 	team_name: string | null;
 	team_slug: string | null;

--- a/packages/web/src/hooks/use-comments.ts
+++ b/packages/web/src/hooks/use-comments.ts
@@ -40,6 +40,7 @@ export interface Comment {
 	author_type: string;
 	author_name: string;
 	author_member_id: string | null;
+	author_connected_agent_id: string | null;
 	parent_comment_id: string | null;
 	reactions?: ReactionGroup[];
 	attachments?: CommentAttachment[];

--- a/packages/web/test/actor-badge.test.tsx
+++ b/packages/web/test/actor-badge.test.tsx
@@ -1,0 +1,29 @@
+import { render } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { ActorBadge } from '../src/components/ui/actor-badge';
+
+test('renders a bot badge for a connected agent', () => {
+	const { getByTestId, queryByTestId } = render(
+		<ActorBadge actorType="connected_agent" name="CRM Bot" />,
+	);
+	expect(getByTestId('actor-badge-connected-agent').getAttribute('aria-label')).toBe(
+		'Connected agent',
+	);
+	expect(queryByTestId('actor-badge-human')).toBeNull();
+});
+
+test('renders a human badge for admin and user actor types', () => {
+	for (const actorType of ['admin', 'user']) {
+		const { getByTestId, unmount } = render(<ActorBadge actorType={actorType} name="Alice" />);
+		expect(getByTestId('actor-badge-human').getAttribute('aria-label')).toBe('Human admin');
+		unmount();
+	}
+});
+
+test('renders nothing for roster agents and system actors', () => {
+	for (const actorType of ['agent', 'system', null, undefined]) {
+		const { container, unmount } = render(<ActorBadge actorType={actorType} />);
+		expect(container.querySelector('[data-testid^="actor-badge"]')).toBeNull();
+		unmount();
+	}
+});

--- a/packages/web/test/audit-format.test.ts
+++ b/packages/web/test/audit-format.test.ts
@@ -9,6 +9,7 @@ function entry(overrides: Partial<AuditEntry>): AuditEntry {
 		project_id: 'p1',
 		actor_type: 'admin',
 		actor_member_id: null,
+		actor_connected_agent_id: null,
 		actor_name: 'Alice',
 		team_name: 'Acme',
 		team_slug: 'acme',

--- a/packages/web/test/comment-actor-badge.test.tsx
+++ b/packages/web/test/comment-actor-badge.test.tsx
@@ -1,0 +1,37 @@
+import { expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+import { seedProject, seedTask, seedWorkspace } from './helpers/seed';
+
+// Verifies the human-vs-connected-agent badge wiring end-to-end: a comment
+// authored by a connected agent renders with the bot badge in the task
+// activity feed.
+test('flags a connected-agent-authored comment with a bot badge', async () => {
+	let nav!: { projectSlug: string; taskId: string };
+	const { findByText, findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async (ctx) => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Badge Demo' });
+			const task = await seedTask(ws, project, { title: 'Badge Task' });
+			const ca = await ctx.db.query<{ id: string }>(
+				`INSERT INTO connected_agents (name, prefix, token_hash, status)
+				 VALUES ('Ops Bot', 'aaaaaaaa', 'h1', 'approved') RETURNING id`,
+			);
+			await ctx.db.query(
+				`INSERT INTO task_comments (task_id, author_connected_agent_id, content_type, content)
+				 VALUES ($1, $2, 'text', $3::jsonb)`,
+				[task.id, ca.rows[0].id, JSON.stringify({ text: 'handled by the connected agent' })],
+			);
+			nav = { projectSlug: project.slug, taskId: task.identifier.toLowerCase() };
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: nav.projectSlug, taskId: nav.taskId },
+	});
+
+	await findByText('handled by the connected agent');
+	const badge = await findByTestId('actor-badge-connected-agent');
+	expect(badge.getAttribute('aria-label')).toBe('Connected agent');
+});


### PR DESCRIPTION
## What & why

When an admin action is shown in the UI, it was impossible to tell whether a **human admin** (web login) or an **external AI agent** took it — both rendered as a bare "admin". This adds an icon suffix (person vs bot) with a hover tooltip wherever an admin action is attributed.

**Reconciled with `main`.** `main` independently shipped the **`connected_agents`** principal (self-registering, admin-approved external MCP clients, `hezoc_` tokens) — but never *attributed* their actions, so they still showed as "admin". Rather than introduce a parallel principal, this PR is rebased onto main and attributes **main's connected agents**. (API keys remain MCP-only and untouched.)

## How

**Attribution (server)**
- New `connected_agent` value on `audit_actor_type`, plus parallel nullable `actor_connected_agent_id` / `author_connected_agent_id` FKs (→ `connected_agents`) on `audit_log`, `task_comments`, and `document_revisions` — sitting beside the existing `*_member_id` columns (at most one set per row). Migration **018** (enum swap via the 008 create/cast/drop/rename pattern + columns + indexes).
- `resolveActor` maps a `ConnectedAgent` principal to the `connected_agent` actor type + id, threaded through `task-events`, the audit observer, the document service, every `record*`/emit caller, and the **MCP tools** (a connected agent's canonical path: `create_task` / `create_comment` / `update_task`).
- Reads (comments GET, audit-log GET, `listRevisions`, MCP `list_comments`) resolve the connected agent's name + an `author_type`/`actor` discriminator.

**Web**
- Shared `ActorBadge`: a person icon for a human admin (`admin`/`user`), a bot icon for a `connected_agent` (tooltip names it); roster agents and `system` render nothing. Dropped into the **task activity feed, system comments, the audit-log table, and document revision history**.
- Inline `@admin` mentions in comment bodies are **not** badged — they're rendered by the mention renderer, which is untouched.

## Auth boundary (for reviewers)
- **API keys (`hezo_`) are MCP-only** — `authMiddleware` 401s them on REST; not changed here.
- **Connected agents (`hezoc_`)** are admin-equivalent on both REST and MCP (main's decision); attribution covers both surfaces, but the test drives the **MCP endpoint** since that's their real path.

## Testing
- **Server**: `connected-agent-attribution.test.ts` drives `create_task` / `create_comment` / `update_task` through `POST /mcp` with an approved `hezoc_` token and asserts attribution in `audit_log`, the comments API, and (via REST doc edit) `document_revisions`; `migrate-connected-agent-attribution.test.ts` proves the enum swap preserves existing audit rows, the columns are nullable, and the FK nulls on delete.
- **Web**: `actor-badge.test.tsx` (per-actor-type rendering) and `comment-actor-badge.test.tsx` (badge wiring in the comments feed).
- Full `turbo typecheck`, `biome check` (0 new errors), and the server (2206 passing) + web (386 passing) suites pass. The only red server tests are pre-existing environment failures (`git worktree` / missing `ssh-keygen` in the sandbox), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SS1zML9RJxN6DR91xHmngb