### PR TITLE
docs: clarify API keys are MCP-only and document /mcp/assets upload

### DIFF
--- a/docs/mcp/hezo-mcp-server.md
+++ b/docs/mcp/hezo-mcp-server.md
@@ -27,6 +27,11 @@ Create an API key from the web app. The key is **scoped to a team**, so a client
 it acts within that team and its projects — exactly the same authorization an agent
 would have. Copy the key when it's shown; it isn't displayed again.
 
+An API key authenticates the **MCP endpoint only** — `POST /mcp` and the `/mcp/assets`
+upload below. It is **not** accepted on Hezo's REST API or its realtime WebSocket: those
+back the web app, which uses your signed-in session instead. So a `hezo_` key is for
+driving Hezo over MCP, nothing else.
+
 ## Connecting as a connected agent (instance-wide)
 
 An external agent can **self-register** for instance-wide access instead of using a
@@ -94,6 +99,22 @@ Once connected, your agent can manage work in Hezo the way a teammate would — 
 example list and create projects, create and update tasks (including their rules and
 progress summaries), comment on tasks, and inspect the team's agents. The connected
 client discovers the full, current tool list automatically on connect.
+
+## File uploads
+
+A binary file (an image, a PDF, …) can't ride inside a JSON-RPC tool call. To upload one,
+POST it as `multipart/form-data` to `/mcp/assets` with the same `Authorization: Bearer`
+header and a `file` field — add an optional `project` field when you're acting across
+projects:
+
+```sh
+curl -X POST http://localhost:3100/mcp/assets \
+  -H "Authorization: Bearer hezo_your_api_key" \
+  -F file=@diagram.png
+```
+
+The response returns the stored asset and a signed read URL, and the file then shows up in
+the `list_project_assets` and `read_project_asset` tools.
 
 ## Next
 


### PR DESCRIPTION
## What

Brings the user-facing MCP doc (`docs/mcp/hezo-mcp-server.md`) in line with the API-key + upload changes from #309. Two additions to that one page:

1. **API keys are MCP-only.** A new note in the "Get an API key" section states a `hezo_` key authenticates the **MCP endpoint only** — it's rejected on the REST API and the realtime WebSocket (those back the web app and use your signed-in session). Previously the doc said keys were team-scoped and worked on `/mcp`, but never that they're *rejected* elsewhere — so a user with a key might try it on the REST API and be confused.
2. **File uploads.** A new "File uploads" section documenting `POST /mcp/assets` (multipart, same Bearer auth, optional `project` field) with a `curl` example, noting the result is retrievable via the `list_project_assets` / `read_project_asset` tools. This endpoint was only discoverable via the generated `/SKILL.md` before.

## Why

An audit of `docs/` found that the connected-agent (`hezoc_`) flow is already documented correctly (#308), and there are no stray `/agent-api` references — these two items were the only gaps tied to the recent changes. Matches the existing page's tone and code-block style; the claims are grounded in `middleware/auth.ts` (API key → 401 on REST), `index.ts` (WebSocket rejects API keys), and `startup.ts` (`POST /mcp/assets`).

## Scope

Docs-only, one file (+21 lines). Deliberately left out broader pre-existing gaps the audit surfaced (no single "auth models" overview page; the connected-agent approval UI isn't covered in `security/`/`deployment/`; `secure-remote-access.md` doesn't split REST vs MCP) — those aren't tied to the recent changes and would balloon a small pass.

## Verification

Markdown isn't processed by biome (so it's untouched by lint); the repo-wide `biome check .` and the cached typecheck/build all pass in the pre-commit hook. Re-read the page for flow; the internal link to `/docs/deployment/secure-remote-access` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0139KMHtzVnf2F86tQp5sn7g)_