### PR TITLE
fix(auth): let connected agents reach realtime WebSocket rooms

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -5,8 +5,9 @@ import { parseConfig, runRestore } from './cli';
 import type { MasterKeyManager } from './crypto/master-key';
 import { PgDataCorruptError } from './db/client';
 import { DbNewerThanAppError, MigrationFailedError } from './db/migrate-errors';
+import type { AuthInfo } from './lib/types';
 import { logger, setLogLevel } from './logger';
-import { loadAdminAuth, verifyToken } from './middleware/auth';
+import { canAuthAccessTeam, loadAdminAuth, verifyToken } from './middleware/auth';
 import type { ContainerLogStreamer } from './services/container-logs';
 import { setKeepOldContainers } from './services/containers';
 import { getSharedImageBuildTracker } from './services/image-build-tracker';
@@ -107,19 +108,12 @@ async function validateAnonymous(): Promise<WsData['auth'] | null> {
 }
 
 async function canAccessTeam(auth: WsData['auth'], teamId: string): Promise<boolean> {
-	if (auth.type === AuthType.ApiKey || auth.type === AuthType.Agent) {
-		return auth.teamId === teamId;
-	}
-	if (auth.type === AuthType.Admin) {
-		if (auth.isSuperuser) return true;
-		if (!dbRef) return false;
-		const result = await dbRef.query(
-			'SELECT m.id FROM members m JOIN member_users mu ON mu.id = m.id WHERE mu.user_id = $1 AND m.team_id = $2',
-			[auth.userId, teamId],
-		);
-		return result.rows.length > 0;
-	}
-	return false;
+	if (!dbRef) return false;
+	// By the time a socket subscribes, `open` has replaced the placeholder with a
+	// validated AuthInfo; WsData widens it to a loose bag, so re-narrow here. The
+	// team rule itself lives in one place — auth.ts:canAuthAccessTeam — shared with
+	// REST, so connected agents (and cross-team CEO sessions) reach realtime rooms too.
+	return canAuthAccessTeam(dbRef, auth as AuthInfo, teamId);
 }
 
 function startingResponse(): Response {

--- a/packages/server/src/middleware/auth.ts
+++ b/packages/server/src/middleware/auth.ts
@@ -307,7 +307,37 @@ export function safeCompareHex(a: string, b: string): boolean {
 
 /**
  * Single source of truth for "does this auth principal have access to this team?".
- * Returns `null` on success, or a 403 `Response` to short-circuit the handler.
+ * Shared by the HTTP gate (`assertTeamAccess`) and the WebSocket room-access check
+ * (`canAccessTeam` in `index.ts`) so the two can't drift — a connected agent must
+ * reach its realtime rooms just as it reaches REST. Mirrors `getAccessibleTeamIds`:
+ * API keys and ordinary agents are bound to their single team; the instance CEO
+ * chat session (`crossTeam`) and approved connected agents span every team; a human
+ * superuser spans all teams; a board user gets the teams they belong to.
+ */
+export async function canAuthAccessTeam(
+	db: PGlite,
+	auth: AuthInfo,
+	teamId: string,
+): Promise<boolean> {
+	if (auth.type === AuthType.ApiKey || auth.type === AuthType.Agent) {
+		// The instance CEO chat session acts across every team (gated at mint time).
+		if (auth.type === AuthType.Agent && auth.crossTeam) return true;
+		return auth.teamId === teamId;
+	}
+	// An approved connected agent is admin-equivalent across every team.
+	if (auth.type === AuthType.ConnectedAgent) return true;
+	if (auth.isSuperuser) return true;
+
+	const result = await db.query(
+		'SELECT m.id FROM members m JOIN member_users mu ON mu.id = m.id WHERE mu.user_id = $1 AND m.team_id = $2',
+		[auth.userId, teamId],
+	);
+	return result.rows.length > 0;
+}
+
+/**
+ * HTTP gate wrapping `canAuthAccessTeam`: returns `null` on success, or a 403
+ * `Response` to short-circuit the handler.
  */
 async function assertTeamAccess(
 	db: PGlite,
@@ -315,30 +345,8 @@ async function assertTeamAccess(
 	c: Context<Env>,
 	teamId: string,
 ): Promise<Response | null> {
-	if (auth.type === AuthType.ApiKey || auth.type === AuthType.Agent) {
-		// The instance CEO chat session acts across every team (gated at mint time).
-		if (auth.type === AuthType.Agent && auth.crossTeam) return null;
-		if (auth.teamId !== teamId) {
-			return c.json({ error: { code: 'FORBIDDEN', message: 'Access denied' } }, 403);
-		}
-		return null;
-	}
-
-	// An approved connected agent is admin-equivalent across every team.
-	if (auth.type === AuthType.ConnectedAgent) return null;
-
-	if (auth.isSuperuser) {
-		return null;
-	}
-
-	const result = await db.query(
-		'SELECT m.id FROM members m JOIN member_users mu ON mu.id = m.id WHERE mu.user_id = $1 AND m.team_id = $2',
-		[auth.userId, teamId],
-	);
-	if (result.rows.length === 0) {
-		return c.json({ error: { code: 'FORBIDDEN', message: 'Access denied' } }, 403);
-	}
-	return null;
+	if (await canAuthAccessTeam(db, auth, teamId)) return null;
+	return c.json({ error: { code: 'FORBIDDEN', message: 'Access denied' } }, 403);
 }
 
 /**

--- a/packages/server/test/auth-middleware.test.ts
+++ b/packages/server/test/auth-middleware.test.ts
@@ -4,8 +4,9 @@ import { AuthType, HeartbeatRunStatus } from '@hezo/shared';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { MasterKeyManager } from '../src/crypto/master-key';
-import type { Env } from '../src/lib/types';
+import type { AuthInfo, Env } from '../src/lib/types';
 import {
+	canAuthAccessTeam,
 	loadAdminAuth,
 	safeCompareHex,
 	signAdminJwt,
@@ -399,6 +400,83 @@ describe('loadAdminAuth', () => {
 		} finally {
 			await safeClose(freshDb);
 		}
+	});
+});
+
+describe('canAuthAccessTeam', () => {
+	const otherTeamId = '00000000-0000-0000-0000-0000000000ff';
+
+	it('lets an approved connected agent reach every team', async () => {
+		// Connected agents are admin-equivalent/cross-team (auth.ts), so they must
+		// reach realtime WS rooms too — the gap this shared predicate closes.
+		const auth: AuthInfo = {
+			type: AuthType.ConnectedAgent,
+			connectedAgentId: 'ca-1',
+			isSuperuser: true,
+			crossTeam: true,
+		};
+		expect(await canAuthAccessTeam(db, auth, teamId)).toBe(true);
+		expect(await canAuthAccessTeam(db, auth, otherTeamId)).toBe(true);
+	});
+
+	it('lets a human superuser reach every team', async () => {
+		const auth: AuthInfo = { type: AuthType.Admin, userId: 'irrelevant', isSuperuser: true };
+		expect(await canAuthAccessTeam(db, auth, teamId)).toBe(true);
+		expect(await canAuthAccessTeam(db, auth, otherTeamId)).toBe(true);
+	});
+
+	it('lets a board user reach only the teams they belong to', async () => {
+		const userId = (
+			await db.query<{ id: string }>(
+				"INSERT INTO users (display_name, is_superuser) VALUES ('Board Member', false) RETURNING id",
+			)
+		).rows[0].id;
+		const memberId = (
+			await db.query<{ id: string }>(
+				"INSERT INTO members (team_id, member_type, display_name) VALUES ($1, 'user', 'BM') RETURNING id",
+				[teamId],
+			)
+		).rows[0].id;
+		await db.query("INSERT INTO member_users (id, user_id, role) VALUES ($1, $2, 'member')", [
+			memberId,
+			userId,
+		]);
+
+		const auth: AuthInfo = { type: AuthType.Admin, userId, isSuperuser: false };
+		expect(await canAuthAccessTeam(db, auth, teamId)).toBe(true);
+		expect(await canAuthAccessTeam(db, auth, otherTeamId)).toBe(false);
+	});
+
+	it('binds an API key to its own team', async () => {
+		const auth: AuthInfo = { type: AuthType.ApiKey, teamId };
+		expect(await canAuthAccessTeam(db, auth, teamId)).toBe(true);
+		expect(await canAuthAccessTeam(db, auth, otherTeamId)).toBe(false);
+	});
+
+	it('binds an ordinary agent to its own team but lets a cross-team session span all', async () => {
+		const agent: AuthInfo = {
+			type: AuthType.Agent,
+			memberId: 'm',
+			teamId,
+			runId: 'r',
+			taskId: null,
+			projectId: 'p',
+			crossProject: false,
+		};
+		const crossTeamSession: AuthInfo = {
+			type: AuthType.Agent,
+			memberId: 'm',
+			teamId,
+			runId: null,
+			taskId: null,
+			projectId: 'p',
+			crossProject: true,
+			sessionId: 's',
+			crossTeam: true,
+		};
+		expect(await canAuthAccessTeam(db, agent, teamId)).toBe(true);
+		expect(await canAuthAccessTeam(db, agent, otherTeamId)).toBe(false);
+		expect(await canAuthAccessTeam(db, crossTeamSession, otherTeamId)).toBe(true);
 	});
 });
 

--- a/packages/server/test/ws-subscribe-handler.test.ts
+++ b/packages/server/test/ws-subscribe-handler.test.ts
@@ -1,6 +1,8 @@
 import type { PGlite } from '@electric-sql/pglite';
 import { AuthType, WsMessageType, wsRoom } from '@hezo/shared';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AuthInfo } from '../src/lib/types';
+import { canAuthAccessTeam } from '../src/middleware/auth';
 import { ContainerLogStreamer } from '../src/services/container-logs';
 import type { DockerClient } from '../src/services/docker';
 import { ImageBuildTracker } from '../src/services/image-build-tracker';
@@ -55,20 +57,11 @@ async function seedTeamWithProject(
 }
 
 function canAccessTeamFactory(db: PGlite) {
-	return async (auth: WsData['auth'], teamId: string): Promise<boolean> => {
-		if (auth.type === AuthType.ApiKey || auth.type === AuthType.Agent) {
-			return auth.teamId === teamId;
-		}
-		if (auth.type === AuthType.Admin) {
-			if (auth.isSuperuser) return true;
-			const result = await db.query(
-				'SELECT m.id FROM members m JOIN member_users mu ON mu.id = m.id WHERE mu.user_id = $1 AND m.team_id = $2',
-				[auth.userId, teamId],
-			);
-			return result.rows.length > 0;
-		}
-		return false;
-	};
+	// Delegate to the production predicate instead of re-implementing it, so this
+	// mock can't drift from the real team-access rule. WsData widens AuthInfo to a
+	// loose bag (the production `canAccessTeam` re-narrows the same way).
+	return (auth: WsData['auth'], teamId: string): Promise<boolean> =>
+		canAuthAccessTeam(db, auth as AuthInfo, teamId);
 }
 
 describe('handleWsSubscribe', () => {
@@ -173,6 +166,23 @@ describe('handleWsSubscribe', () => {
 	it('subscribes a the admin to team room when canAccessTeam passes', async () => {
 		const { userId, teamId } = await seedTeamWithProject(db);
 		const ws = createMockWs({ type: AuthType.Admin, userId });
+
+		await handleWsSubscribe(ws, wsRoom.team(teamId), deps());
+
+		expect(wsManager.getRoomSize(wsRoom.team(teamId))).toBe(1);
+	});
+
+	it('subscribes an approved connected agent to a team room (admin-equivalent)', async () => {
+		const { teamId } = await seedTeamWithProject(db);
+		// A connected agent belongs to no team membership, but is admin-equivalent
+		// and cross-team — it must still reach realtime rooms.
+		const auth: AuthInfo = {
+			type: AuthType.ConnectedAgent,
+			connectedAgentId: 'ca-1',
+			isSuperuser: true,
+			crossTeam: true,
+		};
+		const ws = createMockWs(auth);
 
 		await handleWsSubscribe(ws, wsRoom.team(teamId), deps());
 


### PR DESCRIPTION
## Context

This came out of a cross-PR coherence audit of everything merged into `main` over 06-20/06-21 — checking that the ~25 recently-merged PRs work together (no semantic merge conflicts, dead references, or half-wired changes), rather than just merging cleanly at the text level.

**The merges are broadly coherent.** The follow-up commits (#313 agent-api orphan cleanup, #314 docs, #315 migration collapse) already resolved the larger integration concerns, and the migration collapse checks out (the single `001` baseline reproduces the old chain, guarded by `migrate-baseline-schema.test.ts`; no GitHub-Actions-toolset regression since the `actions` toolset lives in the connector capability definition). The audit surfaced **one** real gap, fixed here.

## The gap

`#308` introduced `AuthType.ConnectedAgent` (an approved external MCP client — admin-equivalent, cross-team) and wired it through the auth model in `auth.ts` (`assertTeamAccess`, `getAccessibleTeamIds`, `isAdminEquivalent`). But the **WebSocket** room-access gate, `canAccessTeam` in `index.ts`, only handled `ApiKey`/`Agent`/`Admin` and fell through to `return false` for everything else — so a connected agent was denied **every** realtime room.

It's reachable: a `hezoc_` token authenticates the WS (`validateToken` only rejects `ApiKey`), so the socket connects but can subscribe to nothing. The rule had drifted into **three** copies (the canonical one in `auth.ts`, the WS copy in `index.ts`, and a third hand-rolled copy in the WS test's own mock) — which is exactly how the omission slipped through.

## The fix

Collapse the three copies onto one exported predicate, `canAuthAccessTeam(db, auth, teamId)` in `middleware/auth.ts`:

- `assertTeamAccess` (HTTP gate) now delegates to it.
- `canAccessTeam` (WS gate, `index.ts`) now delegates to it.
- The WS test mock delegates to it too, so it can't drift again.

Connected agents now reach realtime rooms, consistent with their REST access; cross-team CEO sessions do too (the WS copy had also missed `Agent.crossTeam`).

## Testing

- New unit coverage for `canAuthAccessTeam` across **every** auth type (ApiKey, Agent, cross-team Agent, Admin superuser, board user, ConnectedAgent) in `auth-middleware.test.ts`.
- New `ConnectedAgent` WS-subscribe integration test in `ws-subscribe-handler.test.ts`.
- `bun run typecheck` ✅, `biome check` ✅ (changed files), affected test files 50/50 ✅, web tier 386/386 ✅. No schema change, so the frozen `001` baseline is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMat1HC5xAYiYuoWSfLZsK

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMat1HC5xAYiYuoWSfLZsK)_