### PR TITLE
fix(web): make the selected team-type card visibly highlighted

### DIFF
--- a/packages/web/src/components/create-project-with-team-dialog.tsx
+++ b/packages/web/src/components/create-project-with-team-dialog.tsx
@@ -24,6 +24,19 @@ interface CreateProjectWithTeamDialogProps {
 type Selection = { kind: 'template'; id: string } | { kind: 'team'; id: string } | null;
 
 /**
+ * Card highlight for the picked team type / source team. A selected card gets the
+ * app's "active" treatment — a bold inverse ring + filled tint (matching the
+ * project rail) — so the choice reads clearly at a glance; unselected cards keep
+ * the hairline border with a hover cue. The ring carries the signal regardless of
+ * hover, and `hover:border-inverse` stops a hovered selection from dimming.
+ */
+function cardStateClass(selected: boolean): string {
+	return selected
+		? 'border-inverse hover:border-inverse ring-2 ring-inverse bg-surface-2'
+		: 'hover:border-border-strong';
+}
+
+/**
  * Projects-primary "New project": each project owns its own team. Pick a team
  * type, name the project, describe it, then either create it straight away or
  * hand the brief to the CEO, who scopes it with you in HQ before it opens.
@@ -162,9 +175,7 @@ export function CreateProjectWithTeamDialog({
 												aria-pressed={selected}
 											>
 												<Card
-													className={`p-3 h-full transition-colors ${
-														selected ? 'border-inverse' : 'hover:border-border-strong'
-													}`}
+													className={`p-3 h-full transition-colors ${cardStateClass(selected)}`}
 												>
 													<h3 className="text-[14px] font-medium mb-1">{tpl.name}</h3>
 													{tpl.description && (
@@ -206,9 +217,7 @@ export function CreateProjectWithTeamDialog({
 												aria-pressed={selected}
 											>
 												<Card
-													className={`p-3 h-full transition-colors ${
-														selected ? 'border-inverse' : 'hover:border-border-strong'
-													}`}
+													className={`p-3 h-full transition-colors ${cardStateClass(selected)}`}
 												>
 													<h3 className="text-[14px] font-medium mb-1">{team.name}</h3>
 													<p className="text-[11px] text-text-2">

--- a/packages/web/test/team-type-selection.test.tsx
+++ b/packages/web/test/team-type-selection.test.tsx
@@ -1,0 +1,42 @@
+import { expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+
+// The team-type / source-team cards in the New Project dialog must show a clearly
+// visible highlight on the picked card — a bold inverse ring (`ring-2`), not just
+// a hairline border-color flip. happy-dom can't measure the rendered ring, but it
+// can assert the highlight class + `aria-pressed` land on the selected card and
+// nowhere else, which is what makes the choice legible. (No layout/CSS dependency,
+// so this is a component test, not Playwright.)
+test('selecting a team type visibly highlights only the chosen card', async () => {
+	const { findByTestId, user } = await renderApp({ initialPath: '/home', seed: async () => {} });
+
+	const create = await findByTestId('home-welcome-create', undefined, { timeout: 15_000 });
+	await user.click(create);
+
+	const blankBtn = await findByTestId('team-type-card-Blank', undefined, { timeout: 15_000 });
+	const startupBtn = await findByTestId('team-type-card-Startup');
+	// The inner Card <div> carries the highlight classes.
+	const blankCard = () => blankBtn.querySelector('div');
+	const startupCard = () => startupBtn.querySelector('div');
+
+	// Nothing is selected initially: no ring, not pressed.
+	expect(blankBtn.getAttribute('aria-pressed')).toBe('false');
+	expect(blankCard()?.className).not.toContain('ring-2');
+	expect(startupCard()?.className).not.toContain('ring-2');
+
+	// Pick Blank → it gets the visible ring + pressed state.
+	await user.click(blankBtn);
+	expect(blankBtn.getAttribute('aria-pressed')).toBe('true');
+	expect(blankCard()?.className).toContain('ring-2');
+	expect(blankCard()?.className).toContain('ring-inverse');
+	// And the highlight is exclusive — Startup stays plain.
+	expect(startupBtn.getAttribute('aria-pressed')).toBe('false');
+	expect(startupCard()?.className).not.toContain('ring-2');
+
+	// Switching to Startup moves the highlight off Blank.
+	await user.click(startupBtn);
+	expect(startupBtn.getAttribute('aria-pressed')).toBe('true');
+	expect(startupCard()?.className).toContain('ring-2');
+	expect(blankBtn.getAttribute('aria-pressed')).toBe('false');
+	expect(blankCard()?.className).not.toContain('ring-2');
+});


### PR DESCRIPTION
## What & why

In the **New Project** dialog, picking a team type (or a "Copy an existing team" source) only flipped a 1px border color (`border-inverse`) on the chosen card. That change is barely perceptible — as the screenshot below shows, the selected card looks identical to the others, so there's no clear feedback about what you've picked.

This gives the selected card the app's established **"active" treatment** instead — the same bold inverse ring used by the project rail — so the choice reads clearly at a glance.

## Changes

- New `cardStateClass(selected)` helper in `create-project-with-team-dialog.tsx`. Selected cards get `ring-2 ring-inverse` (bold outline, no layout shift), a `bg-surface-2` tint, and a sticky `hover:border-inverse` so the highlight doesn't dim when hovered. Unselected cards keep the hairline border + hover cue.
- Both card grids (team-type templates **and** copy-existing-team sources) share the helper, so they stay in sync.
- No behavior change — selection state, `aria-pressed`, and submit wiring are untouched; this is purely the visual affordance.

## Design notes

- **Ring over thicker border** → avoids the 1px layout shift a `border-2` would cause, and the ring stays visible regardless of the base card's hover border-color rule.
- Reuses the existing `inverse` "selected/active" language already used by `project-rail.tsx`, `setup/stepper.tsx`, and `filter-pills.tsx` rather than introducing the brand accent color (reserved for primary/destructive actions).

## Testing

- New component test `packages/web/test/team-type-selection.test.tsx` asserts the highlight class + `aria-pressed` land **only** on the picked card and move when the selection changes.
- Existing `home-new-project` and `onboarding-direct` dialog tests still pass.
- `typecheck` and `biome check` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D2TPNrV25VwV7wjzY7dzNE

---
_Generated by [Claude Code](https://claude.ai/code/session_01D2TPNrV25VwV7wjzY7dzNE)_