### PR TITLE
fix: stop project-rail count badge being clipped at the top

### DIFF
--- a/packages/web/src/components/project-rail.tsx
+++ b/packages/web/src/components/project-rail.tsx
@@ -37,7 +37,16 @@ export function ProjectRail() {
 				data-testid="project-rail"
 				aria-label="Projects"
 			>
-				<div className="flex-1 min-h-0 w-full overflow-y-auto flex flex-col items-center gap-2 py-1">
+				{/*
+				  `overflow-y-auto` clips to the padding box, so the count badge
+				  (`-top-1.5`, 6px above each avatar) on the topmost avatar would be
+				  cut off without enough top padding. `pt-2.5` (10px) clears the
+				  overhang plus the active ring.
+				*/}
+				<div
+					className="flex-1 min-h-0 w-full overflow-y-auto flex flex-col items-center gap-2 pt-2.5 pb-1"
+					data-testid="project-rail-scroll"
+				>
 					{projects.map((p) => {
 						const isActive = active?.slug === p.slug && active?.teamSlug === p.teamSlug;
 						return (

--- a/test/browser/project-rail-badge-clip.spec.ts
+++ b/test/browser/project-rail-badge-clip.spec.ts
@@ -1,0 +1,48 @@
+// The project rail's avatar list scrolls (`overflow-y-auto`), and an overflow
+// scroll container clips its content to the padding box. The unread-count overlay
+// badge sits 6px above each avatar (`-top-1.5`), so without enough top padding the
+// badge on the TOPMOST avatar gets clipped — the top of the number is sheared off.
+// Asserting "not clipped" means comparing the badge's real layout box against the
+// scroll container's top edge, which only a browser engine resolves (decision tree
+// point 1: real CSS layout / overflow clipping). happy-dom reports 0 for
+// boundingBox, so this cannot be a component test.
+
+import { expect, test } from './fixtures';
+import { waitForPageLoad } from './helpers';
+
+test('the topmost rail avatar count badge is not clipped by the scroll container', async ({
+	sharedPage: page,
+}) => {
+	// Force a non-zero unread count for every project so a badge renders on the
+	// topmost avatar (the one the scroll container would clip). Page-scoped — the
+	// sharedPage fixture unroutes on teardown, so sibling tests are unaffected.
+	await page.route('**/api/projects/*/inbox/count', (route) =>
+		route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({ data: { unread: 3 } }),
+		}),
+	);
+
+	await page.goto('/home');
+	await waitForPageLoad(page);
+
+	await expect(page.getByTestId('project-rail')).toBeVisible({ timeout: 15_000 });
+
+	const scroller = page.getByTestId('project-rail-scroll');
+	// The first badge in DOM order is the topmost avatar's (flex column → DOM
+	// order is top-to-bottom), which is the one at risk of top clipping.
+	const topBadge = page.locator('[data-testid^="project-rail-inbox-badge-"]').first();
+	await expect(topBadge).toBeVisible({ timeout: 15_000 });
+
+	const scrollerBox = await scroller.boundingBox();
+	const badgeBox = await topBadge.boundingBox();
+	if (!scrollerBox || !badgeBox) {
+		throw new Error('rail scroll container or badge has no layout box');
+	}
+
+	// The badge's top edge must sit at or below the scroll container's top edge;
+	// anything above it is clipped away. The sub-pixel tolerance absorbs rounding —
+	// the regression sheared off a full ~2px.
+	expect(badgeBox.y).toBeGreaterThanOrEqual(scrollerBox.y - 0.5);
+});


### PR DESCRIPTION
## Problem

The unread-count overlay badge on the project rail had the top of its number sheared off (see the reported screenshot — the "1" badge is cut at the top).

## Root cause

The rail's scrolling avatar list is an `overflow-y-auto` container, which clips its content to the **padding box** (the clipping is in effect even with a single avatar and no scrollbar — `auto` only governs whether the scrollbar shows). The `CountOverlayBadge` is positioned `-top-1.5` (**6px** above each avatar), but the container only had `py-1` (**4px**) of top padding. So the top `6px − 4px = 2px` of the badge on the **topmost** avatar pokes above the padding box and gets clipped.

The shared `CountOverlayBadge` itself is fine — the HQ pinned entry and the app-header inbox icon both sit in non-clipping containers — so the fix belongs on the rail's scroll container, not the badge.

## Fix

Bump the scroll container's top padding from `py-1` (4px) to `pt-2.5` (10px), which clears the 6px badge overhang plus the active avatar's ring offset. Bottom padding stays `pb-1` (no bottom overhang to clear).

## Test

Added a Playwright regression test (`test/browser/project-rail-badge-clip.spec.ts`). Overflow clipping only resolves in a real browser engine (happy-dom reports `0` for `boundingBox`), so per the testing decision tree this is a browser test, not a component test. It forces a non-zero inbox count via a page-scoped route intercept, then asserts the topmost badge's real layout box sits at/below the scroll container's top edge.

Verified it **fails on the old padding** (`badgeBox.y` measured ~2px above the container top) and **passes with the fix**. Existing `project-rail.test.tsx` component tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NkdXfYbRgPY4g53DZRuWw2

---
_Generated by [Claude Code](https://claude.ai/code/session_01NkdXfYbRgPY4g53DZRuWw2)_