### PR TITLE
fix(web): proxy /llms.txt to the server in dev

### DIFF
--- a/packages/web/test/helpers/render.tsx
+++ b/packages/web/test/helpers/render.tsx
@@ -99,7 +99,7 @@ beforeEach(async () => {
 
 	// Reroute fetch through the in-process Hono app. Bypasses the real network
 	// entirely; matches the way the dev Vite proxy forwards /api, /oauth, /mcp,
-	// /health, and /SKILL.md to the server.
+	// /health, /SKILL.md, and /llms.txt to the server.
 	realFetch = globalThis.fetch;
 	// Close over the captured fetch rather than reading `realFetch` at call
 	// time: a debounced/in-flight request can land after afterEach nulls the
@@ -121,7 +121,8 @@ beforeEach(async () => {
 			path.startsWith('/oauth') ||
 			path.startsWith('/mcp') ||
 			path.startsWith('/health') ||
-			path === '/SKILL.md'
+			path === '/SKILL.md' ||
+			path === '/llms.txt'
 		) {
 			return test.app.fetch(req);
 		}

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
 			'/health': serverUrl,
 			'/mcp': serverUrl,
 			'/SKILL.md': serverUrl,
+			'/llms.txt': serverUrl,
 			'/ws': {
 				target: serverUrl.replace('http', 'ws'),
 				ws: true,


### PR DESCRIPTION
## Problem

Visiting `/llms.txt` on the dev server redirected to the home page.

The Vite dev proxy (`packages/web/vite.config.ts`) forwarded `/SKILL.md` to the backend but **not** `/llms.txt`. So in dev a request to `/llms.txt` hit Vite (port 5173) instead of the server, fell through to the SPA's `index.html`, and the TanStack router — not recognizing `/llms.txt` as a route — redirected to home.

The bug only showed up in dev: in the production binary the server serves `/llms.txt` and `/SKILL.md` directly, so both work there. The server route itself is correct and already covered by `packages/server/test/llms-txt.test.ts`.

`/SKILL.md` was already proxied, so it has always been accessible in dev at its canonical (uppercase) path.

## Fix

- Add `/llms.txt` to the Vite dev proxy, alongside `/SKILL.md`, so the dev server serves the same body as the production binary.
- Mirror `/llms.txt` in the web test harness passthrough list (`packages/web/test/helpers/render.tsx`) so the in-process fetch reroute and its descriptive comment stay in sync with the proxy.

## Testing

This is dev-server proxy orchestration — it isn't exercised by any of the test tiers (server/web/Playwright/Bun), which run against the in-process Hono app rather than through Vite. The underlying server route is already verified by `packages/server/test/llms-txt.test.ts` (200 + `text/markdown`). Verified manually that `bunx biome check` is clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Dv2doqbQScUufRDnbmwXV

---
_Generated by [Claude Code](https://claude.ai/code/session_015Dv2doqbQScUufRDnbmwXV)_