### PR TITLE
docs: don't imply every Hezo instance listens on port 3100

### DIFF
--- a/docs/deployment/secure-remote-access.md
+++ b/docs/deployment/secure-remote-access.md
@@ -29,7 +29,9 @@ hostname **without opening any inbound ports**. Pair it with an access policy
 
 ## SSH tunnel
 
-For quick, occasional access, forward the port over SSH from your machine:
+For quick, occasional access, forward the port over SSH from your machine. Hezo listens
+on **3100** by default — if you changed it with `--port`, use that port on the right-hand
+(server) side:
 
 ```sh
 ssh -L 3100:localhost:3100 user@your-server

--- a/docs/mcp/hezo-mcp-server.md
+++ b/docs/mcp/hezo-mcp-server.md
@@ -16,7 +16,11 @@ tools into.
 
 ## Connection details
 
-- **Endpoint:** `POST http://<host>:3100/mcp`
+- **Base URL:** your instance's address. Running locally with default settings that's
+  `http://localhost:3100`; a deployed instance is wherever it's hosted — its own domain
+  or `host:port`, not necessarily port 3100. (The port is set by `--port` / `HEZO_PORT`,
+  default `3100`.)
+- **Endpoint:** `POST <base-url>/mcp`
 - **Transport:** Streamable HTTP
 - **Authentication:** an `Authorization: Bearer <token>` header, where the token is a
   **Hezo API key** (it starts with `hezo_`).
@@ -89,7 +93,8 @@ it at the `/mcp` endpoint and pass your key in the `Authorization` header:
 }
 ```
 
-If your Hezo runs on a remote server, replace `localhost:3100` with its address — and
+If your Hezo runs on a remote server, replace `http://localhost:3100` with its base URL
+— a remote instance may be on a different host and port, or behind a domain on 443 — and
 make sure that address is reached over a secure channel, since the API key travels in
 the header. See [Secure remote access](/docs/deployment/secure-remote-access).
 


### PR DESCRIPTION
## What & why

The MCP connection docs baked `:3100` into the **generic** endpoint and the remote guidance, implying every instance listens on 3100. But `3100` is only the *local default* (`--port` / `HEZO_PORT`); a deployed instance may be on a different host/port or behind a domain on 443.

## Changes (`docs/` only)

- **`docs/mcp/hezo-mcp-server.md`** — add a **Base URL** bullet to *Connection details* (local default `http://localhost:3100` vs. a deployed instance's own address), generalize the endpoint to `POST <base-url>/mcp`, and strengthen the remote note (a remote instance may differ in host **and** port, or be a domain on 443). Local copy-paste examples (`claude mcp add`, JSON config, `/mcp/assets`) intentionally keep `localhost:3100` as the default.
- **`docs/deployment/secure-remote-access.md`** — note the SSH-tunnel's server-side port is Hezo's `--port` (3100 by default).

The deployment/reference docs already qualified 3100 as "default"/configurable, so they're unchanged. The server's generated `/llms.txt` and `/SKILL.md` already use the instance's real base URL (no hardcoded 3100), so the generators and their tests are untouched — this is docs-prose only.

Companion to hezo-ai/website#9 (the website's `llms.txt` gets the same treatment).

## Verification

`grep -rn 3100 docs/` — every remaining hit is local-default access, an explicit "default", or a clearly-labeled local example; the generic endpoint no longer carries `:3100`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZA75RLsLox2sZ4DrX9jB6

---
_Generated by [Claude Code](https://claude.ai/code/session_01BZA75RLsLox2sZ4DrX9jB6)_