### PR TITLE
feat(web): open updated-doc links from run comments in the preview panel

### DIFF
--- a/packages/web/src/components/comment-renderers/run-comment.tsx
+++ b/packages/web/src/components/comment-renderers/run-comment.tsx
@@ -11,6 +11,7 @@ import { useRunLogs } from '../../hooks/use-run-logs';
 import { agentPageParams } from '../agent-link';
 import { LazyMount } from '../lazy-mount';
 import { LogViewer } from '../log-viewer';
+import { useOpenPreview } from '../task-detail/preview-context';
 import { TerminateRunButton } from '../terminate-run-button';
 import { Tooltip } from '../ui/tooltip';
 import type { CommentDataOf } from './comment-data';
@@ -99,6 +100,9 @@ function RunCommentBody({
 			: null;
 	const [expanded, setExpanded] = useState(false);
 	const logRegionId = `run-comment-log-${runId}`;
+	// On a surface that hosts the preview panel (task detail), an updated-doc link
+	// opens the doc in the panel; elsewhere it falls back to the documents page.
+	const openPreview = useOpenPreview();
 	// HQ agents link to their canonical page in the HQ project; others to this
 	// project. Falls back to the run's member id when an older comment lacks a slug.
 	const agentLinkParams = agentSlug
@@ -264,17 +268,37 @@ function RunCommentBody({
 			)}
 			{createdDocs.length > 0 && (
 				<div className="flex flex-col gap-1 pt-1" data-testid="run-comment-created-docs">
-					{createdDocs.map((doc) => (
-						<Link
-							key={doc.filename}
-							to="/projects/$projectId/documents"
-							params={{ projectId: doc.project_slug }}
-							search={{ file: doc.filename }}
-							className="text-xs text-info-soft-fg hover:underline self-start"
-						>
-							Updated {doc.filename}
-						</Link>
-					))}
+					{createdDocs.map((doc) =>
+						openPreview ? (
+							<button
+								key={doc.filename}
+								type="button"
+								onClick={() =>
+									openPreview({
+										kind: 'doc',
+										projectId: doc.project_slug,
+										projectSlug: doc.project_slug,
+										filename: doc.filename,
+									})
+								}
+								className="text-xs text-info-soft-fg hover:underline self-start text-left"
+								data-testid="run-comment-doc-link"
+							>
+								Updated {doc.filename}
+							</button>
+						) : (
+							<Link
+								key={doc.filename}
+								to="/projects/$projectId/documents"
+								params={{ projectId: doc.project_slug }}
+								search={{ file: doc.filename }}
+								className="text-xs text-info-soft-fg hover:underline self-start"
+								data-testid="run-comment-doc-link"
+							>
+								Updated {doc.filename}
+							</Link>
+						),
+					)}
 				</div>
 			)}
 			{createdSkills.length > 0 && (

--- a/packages/web/test/run-created-tasks.test.tsx
+++ b/packages/web/test/run-created-tasks.test.tsx
@@ -258,9 +258,9 @@ test('run comment header shows "started by …" chip when actor_name is set', as
 test('run comment links updated docs, skills, and proposed skills', async () => {
 	const seeded = { projectSlug: '', taskId: '' };
 
-	const { findByTestId, router } = await renderApp({
+	const { findByTestId, findByText, user, router } = await renderApp({
 		initialPath: '/',
-		seed: async () => {
+		seed: async ({ apiBase, token }) => {
 			const ws = await seedWorkspace();
 			const captain = ws.agents.find((a) => a.slug === 'captain') ?? ws.agents[0];
 			const project = await seedProject(ws, { name: 'Docs And Skills Project' });
@@ -268,6 +268,15 @@ test('run comment links updated docs, skills, and proposed skills', async () => 
 				title: 'Outputs Parent',
 				assignee_id: captain.id,
 			});
+
+			// Seed the real doc so the preview panel renders its body when opened.
+			const content = ['# Spec', '', 'An unmistakable spec body.'].join('\n');
+			const docRes = await apiBase(`/api/projects/${project.slug}/docs/spec.md`, {
+				method: 'PUT',
+				headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+				body: JSON.stringify({ content }),
+			});
+			if (!docRes.ok) throw new Error(`seed spec.md failed: ${docRes.status}`);
 
 			seeded.projectSlug = project.slug;
 			seeded.taskId = task.identifier.toLowerCase();
@@ -320,14 +329,20 @@ test('run comment links updated docs, skills, and proposed skills', async () => 
 
 	await findByTestId('run-comment', undefined, { timeout: 20_000 });
 
-	const docsSection = await findByTestId('run-comment-created-docs', undefined, {
+	// On the task-detail page (which hosts the preview panel) the updated-doc
+	// link is a button that opens the doc in the right-rail panel — not a link to
+	// the documents page.
+	const docLink = (await findByTestId('run-comment-doc-link', undefined, {
 		timeout: 20_000,
-	});
-	const docLink = docsSection.querySelector('a') as HTMLAnchorElement | null;
-	expect(docLink?.textContent).toBe('Updated spec.md');
-	expect(docLink?.getAttribute('href')).toBe(
-		`/projects/${seeded.projectSlug}/documents?file=spec.md`,
-	);
+	})) as HTMLButtonElement;
+	expect(docLink.tagName).toBe('BUTTON');
+	expect(docLink.textContent).toBe('Updated spec.md');
+
+	await user.click(docLink);
+
+	await findByTestId('preview-panel');
+	expect((await findByTestId('preview-panel-filename')).textContent).toBe('spec.md');
+	await findByText(/unmistakable spec body/i);
 
 	const skillsSection = await findByTestId('run-comment-created-skills');
 	const skillLinks = Array.from(skillsSection.querySelectorAll('a')) as HTMLAnchorElement[];


### PR DESCRIPTION
## What

Clicking an **"Updated `<doc>`"** link in an agent-run comment now opens the document in the task-detail right-rail **preview panel** instead of navigating away to the documents page.

This matches how **doc mentions** in comments already behave (`markdown-prose.tsx` opens the panel via the `PreviewContext`), so the two ways an agent surfaces a doc in a comment now behave consistently.

## How

- `run-comment.tsx` now reads `useOpenPreview()`. When a surface hosts the preview panel (the task-detail page wraps its comments in `<PreviewProvider>`), each updated-doc entry renders as a `<button>` that calls `openPreview({ kind: 'doc', ... })`, opening the doc in the right-rail panel.
- On surfaces that **don't** host a preview panel (e.g. the CEO chat), `openPreview` is `null` and the entry falls back to the existing documents-page `<Link>` — same defensive pattern doc mentions use.

## Behavior

| Before | After |
|---|---|
| Click "Updated spec.md" → navigates to `/projects/:slug/documents?file=spec.md` | Click "Updated spec.md" → opens `spec.md` in the right-rail preview panel (with "open in new tab" affordance on the panel) |

Fallback link is unchanged where no panel is present.

## Tests

Updated `run-created-tasks.test.tsx` ("run comment links updated docs, skills, and proposed skills"): seeds a real `spec.md`, asserts the updated-doc element is a button (not a documents-page link), clicks it, and verifies the preview panel opens showing the doc's rendered body. Per the testing decision tree this is a component test (panel open + content render — no real-layout/viewport/WebSocket dependency).

Verified locally: `typecheck` clean, `biome check` clean on changed files, and the run-comment + preview-panel test files all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Mj8p2PdVMwxbEEB7AbT8D

---
_Generated by [Claude Code](https://claude.ai/code/session_019Mj8p2PdVMwxbEEB7AbT8D)_