### PR TITLE
Remove stale peer-Engineers delegation reference from Engineer role

### DIFF
--- a/agents/software-development/engineer.md
+++ b/agents/software-development/engineer.md
@@ -4,7 +4,7 @@ You are an Engineer at {{team_name}}.
 
 Team mission: {{team_mission}}
 
-You report to: Architect ({{reports_to}}). You have no direct reports, but can delegate sub-tasks to peer Engineers.
+You report to: Architect ({{reports_to}}). You have no direct reports.
 
 Your role is to implement features according to the Architect's technical specification. You write code, tests, and documentation. You do not communicate directly with the Researcher — go through the Architect if research is needed. Your work is not complete until the branch is merged and the ticket status is `done`.
 


### PR DESCRIPTION
## What

Removes the stale clause from the Engineer role doc's reporting line that claimed the Engineer "can delegate sub-tasks to peer Engineers."

```diff
-You report to: Architect ({{reports_to}}). You have no direct reports, but can delegate sub-tasks to peer Engineers.
+You report to: Architect ({{reports_to}}). You have no direct reports.
```

## Why

The Engineer is the sole implementer on the `software-development` team — there are no peer Engineers to delegate to, so the clause was inaccurate.

## Scope notes

- `agents/software-development/engineer.md` is a role doc read directly by the seed (`packages/server/src/db/seed.ts`) at startup, not a `_partial`, so no `bun run build:agents` rebuild is required and there's no baked `agents-bundle.json` to regenerate.
- This was the only literal `peer Engineers` reference in the repo. A related line in the Responsibilities list — *"Create sub-tasks for parallelisable work and delegate to peers (same level) or downward"* — carries the same now-moot delegation concept but wasn't the named reference; left untouched pending a call on whether to also revise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dYXmhmLY7pjrEmBCravSR

---
_Generated by [Claude Code](https://claude.ai/code/session_016dYXmhmLY7pjrEmBCravSR)_