### PR TITLE
fix(web): remove Retry button from last-run-failed banner

### DIFF
--- a/packages/web/src/components/task-detail/last-run-failed-banner.tsx
+++ b/packages/web/src/components/task-detail/last-run-failed-banner.tsx
@@ -1,77 +1,31 @@
-import { AlertTriangle, ChevronRight, Loader2, RotateCw } from 'lucide-react';
-import { useRetryFailedRun } from '../../hooks/use-retry-failed-run';
+import { AlertTriangle, ChevronRight } from 'lucide-react';
 import type { Task } from '../../hooks/use-tasks';
 import { jumpToComment } from '../comment-renderers';
 
 interface Props {
 	task: Task;
-	/** Route-param slug — required to wire the Retry action. */
-	projectId?: string;
-	/** Route-param slug — required to wire the Retry action. */
-	taskId?: string;
 }
 
-export function LastRunFailedBanner({ task, projectId, taskId }: Props) {
+export function LastRunFailedBanner({ task }: Props) {
 	const failed = task.last_run_status === 'failed' || task.last_run_status === 'timed_out';
 	if (task.has_active_run || !failed || !task.last_run_comment_public_id) return null;
 
 	const commentId = task.last_run_comment_public_id;
 	return (
-		<div className="mb-4 flex items-stretch gap-2">
-			<a
-				href={`#comment-${commentId}`}
-				onClick={jumpToComment(commentId)}
-				data-testid="last-run-failed-banner"
-				className="flex min-w-0 flex-1 items-center gap-2 rounded-md bg-danger/10 px-4 py-2 text-[13px] font-medium text-danger hover:bg-danger/15 transition-colors"
-			>
-				<AlertTriangle className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
-				<span className="min-w-0 truncate">
-					{task.last_run_status === 'timed_out' ? 'Last run timed out' : 'Last run failed'} — view
-					it
-				</span>
-				<span className="ml-auto flex items-center gap-1 shrink-0">
-					<span className="hidden sm:inline">Jump to run</span>
-					<ChevronRight className="w-3.5 h-3.5" />
-				</span>
-			</a>
-			{/*
-			 * The durable manual-retry path: the inline button on the `run_failed`
-			 * comment disappears once that ping is suppressed (3+ consecutive
-			 * failures), but this banner stays as long as the last run failed and
-			 * nothing is running — so retry must remain reachable here.
-			 */}
-			{projectId && taskId && task.last_run_id ? (
-				<RetryButton projectId={projectId} taskId={taskId} runId={task.last_run_id} />
-			) : null}
-		</div>
-	);
-}
-
-function RetryButton({
-	projectId,
-	taskId,
-	runId,
-}: {
-	projectId: string;
-	taskId: string;
-	runId: string;
-}) {
-	const retry = useRetryFailedRun({ projectId, taskId });
-	return (
-		<button
-			type="button"
-			onClick={() => retry.mutate(runId)}
-			disabled={retry.isPending}
-			aria-label="Retry failed run"
-			data-testid="retry-failed-run-banner"
-			className="inline-flex shrink-0 items-center gap-1 rounded-md bg-danger/10 px-3 text-[13px] font-medium text-danger hover:bg-danger/15 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+		<a
+			href={`#comment-${commentId}`}
+			onClick={jumpToComment(commentId)}
+			data-testid="last-run-failed-banner"
+			className="mb-4 flex items-center gap-2 rounded-md bg-danger/10 px-4 py-2 text-[13px] font-medium text-danger hover:bg-danger/15 transition-colors"
 		>
-			{retry.isPending ? (
-				<Loader2 className="w-3.5 h-3.5 animate-spin" />
-			) : (
-				<RotateCw className="w-3.5 h-3.5" />
-			)}
-			Retry
-		</button>
+			<AlertTriangle className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
+			<span className="min-w-0 truncate">
+				{task.last_run_status === 'timed_out' ? 'Last run timed out' : 'Last run failed'} — view it
+			</span>
+			<span className="ml-auto flex items-center gap-1 shrink-0">
+				<span className="hidden sm:inline">Jump to run</span>
+				<ChevronRight className="w-3.5 h-3.5" />
+			</span>
+		</a>
 	);
 }

--- a/packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx
@@ -99,7 +99,7 @@ function TaskDetailPage() {
 			>
 				<PreviewProvider value={setPreview}>
 					<div className="min-w-0">
-						<LastRunFailedBanner task={task} projectId={projectId} taskId={taskId} />
+						<LastRunFailedBanner task={task} />
 						<TaskHeader
 							task={task}
 							projectId={projectId}

--- a/packages/web/test/task-detail-failed-banner.test.tsx
+++ b/packages/web/test/task-detail-failed-banner.test.tsx
@@ -118,62 +118,6 @@ test('banner is hidden when the task has no completed runs', async () => {
 	});
 });
 
-test('banner Retry button retries the last failed run even when no run_failed comment exists', async () => {
-	// Reproduces the 3+ consecutive-failure case: the `run_failed` ping (which
-	// hosts the inline Retry button) is suppressed, so only the `run` comment
-	// remains. The banner must still expose a working manual-retry path.
-	const seeded = { projectSlug: '', taskIdentifier: '', runId: '' };
-	const retryCalls: string[] = [];
-
-	const { findByTestId, queryByTestId, user, router } = await renderApp({
-		initialPath: '/',
-		seed: async () => {
-			const ws = await seedWorkspace();
-			const project = await seedProject(ws, { name: 'Demo' });
-			const task = await seedTask(ws, project, { title: 'Crash Loop Task' });
-			const { runId } = await insertFailedRunWithComment(ws, task, 'failed');
-			seeded.projectSlug = project.slug;
-			seeded.taskIdentifier = task.identifier.toLowerCase();
-			seeded.runId = runId;
-
-			// Intercept the retry POST so we assert on the call without driving a
-			// real container dispatch; everything else falls through to the
-			// in-process backend so the task GET returns a real `last_run_id`.
-			const passthrough = globalThis.fetch;
-			globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
-				const url = typeof input === 'string' ? input : (input as Request).url;
-				const method = init?.method ?? (input instanceof Request ? input.method : 'GET');
-				const retryMatch = url.match(/\/api\/projects\/[^/]+\/tasks\/[^/]+\/runs\/([^/]+)\/retry/);
-				if (method === 'POST' && retryMatch) {
-					retryCalls.push(retryMatch[1]);
-					return new Response(JSON.stringify({ data: { dispatched: true } }), {
-						status: 200,
-						headers: { 'Content-Type': 'application/json' },
-					});
-				}
-				return passthrough(input as RequestInfo, init);
-			}) as typeof globalThis.fetch;
-		},
-	});
-
-	await router.navigate({
-		to: '/projects/$projectId/tasks/$taskId',
-		params: { projectId: seeded.projectSlug, taskId: seeded.taskIdentifier },
-	});
-
-	const retryButton = (await findByTestId('retry-failed-run-banner', undefined, {
-		timeout: 10_000,
-	})) as HTMLButtonElement;
-	// No inline run_failed retry in this scenario — the banner is the only path.
-	expect(queryByTestId('retry-failed-run')).toBeNull();
-
-	await user.click(retryButton);
-
-	await waitFor(() => {
-		expect(retryCalls).toEqual([seeded.runId]);
-	});
-});
-
 test('banner is suppressed while a retry is currently running', async () => {
 	const seeded = { projectSlug: '', taskIdentifier: '' };
 	const { findByRole, queryByTestId, router } = await renderApp({


### PR DESCRIPTION
## What

Removes the **Retry** button from the "Last run failed — view it" banner at the top of the task detail page. The banner now only links to the failed run (the "Jump to run" affordance is unchanged).

## Why

Per request — the top banner should be a link to the failed run, not host an action button.

## Changes

- `last-run-failed-banner.tsx`: drop the `RetryButton` and the now-unused `projectId` / `taskId` props; the banner is now a single `<a>`.
- `$taskId.tsx`: update the call site to `<LastRunFailedBanner task={task} />`.
- `task-detail-failed-banner.test.tsx`: remove the test that exercised the banner's retry path. The remaining banner tests (appears / timed-out copy / hidden when no runs / suppressed while running) are unchanged and pass.

## Note

The inline **Retry** button on the `run_failed` comment is unchanged, so retry is still reachable there. The removed banner button had been the *durable* retry path for the case where that inline ping is suppressed after 3+ consecutive failures — after this change, there is no top-level retry once the inline ping is gone. Flagging in case that fallback is still wanted.

## Testing

- `bunx vitest run test/task-detail-failed-banner.test.tsx` → 4 passed
- `bunx tsc --noEmit` → clean
- `bunx biome check` on the changed files → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WR5iCxv9vXGvLgSnCnUoBa)_