### PR TITLE
fix(web): show log-viewer toolbar borders only on active toggles

### DIFF
--- a/packages/web/src/components/log-viewer.tsx
+++ b/packages/web/src/components/log-viewer.tsx
@@ -131,7 +131,7 @@ export function LogViewer({
 									onClick={() => setViewMode('formatted')}
 									aria-pressed={viewMode === 'formatted'}
 									aria-label="Formatted view"
-									className={`h-6 px-1.5 ${viewMode === 'formatted' ? 'bg-surface-3 text-text-1 border border-border shadow-inner' : ''}`}
+									className={`h-6 px-1.5 ${viewMode === 'formatted' ? 'bg-surface-3 text-text-1 border border-border shadow-inner' : 'border-transparent!'}`}
 								>
 									<AlignLeft className="w-3 h-3" />
 								</Button>
@@ -143,7 +143,7 @@ export function LogViewer({
 									onClick={() => setViewMode('raw')}
 									aria-pressed={viewMode === 'raw'}
 									aria-label="Raw logs"
-									className={`h-6 px-1.5 ${viewMode === 'raw' ? 'bg-surface-3 text-text-1 border border-border shadow-inner' : ''}`}
+									className={`h-6 px-1.5 ${viewMode === 'raw' ? 'bg-surface-3 text-text-1 border border-border shadow-inner' : 'border-transparent!'}`}
 								>
 									<Code className="w-3 h-3" />
 								</Button>
@@ -159,7 +159,7 @@ export function LogViewer({
 							size="sm"
 							onClick={handleCopy}
 							disabled={lines.length === 0}
-							className="text-xs h-6 px-2"
+							className="text-xs h-6 px-2 border-transparent!"
 							aria-label="Copy logs to clipboard"
 						>
 							{copied ? <Check className="w-3 h-3" /> : <Copy className="w-3 h-3" />}
@@ -172,7 +172,7 @@ export function LogViewer({
 							onClick={() => setAutoScroll((v) => !v)}
 							aria-pressed={autoScroll}
 							aria-label="Toggle auto-scroll"
-							className={`text-xs h-6 px-2 ${autoScroll ? 'bg-surface-3 text-text-1 border border-border shadow-inner' : ''}`}
+							className={`text-xs h-6 px-2 ${autoScroll ? 'bg-surface-3 text-text-1 border border-border shadow-inner' : 'border-transparent!'}`}
 						>
 							<MoveVertical className="w-3 h-3" />
 						</Button>
@@ -183,7 +183,7 @@ export function LogViewer({
 							variant="ghost"
 							size="sm"
 							onClick={toggleExpanded}
-							className="text-xs h-6 px-2"
+							className="text-xs h-6 px-2 border-transparent!"
 							aria-label={isExpanded ? 'Collapse log viewer' : 'Expand log viewer'}
 						>
 							{isExpanded ? <Minimize2 className="w-3 h-3" /> : <Maximize2 className="w-3 h-3" />}

--- a/test/browser/log-viewer-toolbar-borders.spec.ts
+++ b/test/browser/log-viewer-toolbar-borders.spec.ts
@@ -1,0 +1,78 @@
+// Playwright (decision tree #1: real CSS layout). The toolbar's non-toggle
+// buttons must render with no visible border, while an active (depressed) toggle
+// keeps one. That hinges on a `border-transparent!` utility beating the global
+// unlayered `* { border-color: var(--border) }` rule — a real-cascade outcome
+// happy-dom can't compute, so it needs Chromium + the compiled stylesheet.
+import { expect, test } from './fixtures';
+
+const TRANSPARENT = 'rgba(0, 0, 0, 0)';
+
+test('toolbar buttons show a border only when they are an active toggle', async ({
+	sharedPage: page,
+	sharedWorkspace,
+}) => {
+	const { team, agents, projectSlug } = sharedWorkspace;
+	const captain = agents.find((a) => a.slug === 'captain') ?? agents[0];
+
+	const runId = '99999999-9999-9999-9999-0000000border';
+	const runResponse = {
+		id: runId,
+		member_id: captain.id,
+		team_id: team.id,
+		task_id: '22222222-2222-2222-2222-0000000border',
+		task_identifier: 'BORDER-1',
+		task_title: 'Toolbar Border Task',
+		project_id: '11111111-1111-1111-1111-0000000border',
+		status: 'running',
+		started_at: new Date(Date.now() - 60_000).toISOString(),
+		finished_at: null,
+		exit_code: null,
+		error: null,
+		input_tokens: 0,
+		output_tokens: 0,
+		cost_cents: 0,
+		invocation_command: null,
+		log_text: Array.from({ length: 30 }, (_, i) => `[synthetic] line ${i}`).join('\n'),
+		working_dir: null,
+		created_tasks: [],
+	};
+
+	await page.route(
+		`**/api/projects/*/agents/${captain.id}/heartbeat-runs/${runId}`,
+		async (route) => {
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({ data: runResponse }),
+			});
+		},
+	);
+
+	await page.goto(`/projects/${projectSlug}/agents/${captain.id}/executions/${runId}`);
+	await expect(page.getByTestId('run-log')).toBeVisible({ timeout: 15_000 });
+
+	const borderColor = (name: string) =>
+		page
+			.getByRole('button', { name })
+			.first()
+			.evaluate((el) => getComputedStyle(el).borderTopColor);
+
+	// Pure action buttons never have an active state → no visible border.
+	expect(await borderColor('Copy logs to clipboard')).toBe(TRANSPARENT);
+	expect(await borderColor('Expand log viewer')).toBe(TRANSPARENT);
+
+	// Auto-scroll defaults on (depressed) → it keeps a visible border.
+	const autoScroll = page.getByRole('button', { name: 'Toggle auto-scroll' }).first();
+	await expect(autoScroll).toHaveAttribute('aria-pressed', 'true');
+	expect(await autoScroll.evaluate((el) => getComputedStyle(el).borderTopColor)).not.toBe(
+		TRANSPARENT,
+	);
+
+	// Toggling it off removes the depressed state → border goes away too.
+	await autoScroll.click();
+	await page.mouse.move(0, 0); // settle the colour transition without hover
+	await expect(autoScroll).toHaveAttribute('aria-pressed', 'false');
+	await expect
+		.poll(() => autoScroll.evaluate((el) => getComputedStyle(el).borderTopColor))
+		.toBe(TRANSPARENT);
+});


### PR DESCRIPTION
## What

In the agent run **log viewer** toolbar, buttons that have no active/pressed state (Copy, Expand/Collapse) — and the *inactive* Formatted/Raw and auto-scroll toggles — were rendering a visible 1px gray border, so the whole toolbar read as a row of boxed buttons. Borders should appear **only** on a button that can stay depressed *while it is active* (like auto-scroll when on).

| | Before | After |
|---|---|---|
| Copy / Expand | gray border box | no border |
| Auto-scroll **off** | gray border box | no border |
| Auto-scroll **on** (depressed) | border | border (unchanged) |
| Formatted/Raw selected segment | border | border (unchanged) |

## Why it happened

The `ghost` button variant sets `border-transparent`, but `index.css` has a global **unlayered** fallback:

```css
*, *::before, *::after { border-color: var(--border); }
```

Unlayered rules outrank Tailwind's `utilities` layer, so `border-transparent` lost and the base `border` (1px width) showed through with the fallback's gray colour. Confirmed in a real browser — the Copy button computed `border-top-color: oklch(0.92 0.005 255)` (the `--border` gray) despite carrying `border-transparent`.

## Fix

Override the colour with `border-transparent!` (important — beats the unlayered rule) on every non-active toolbar button, keeping the 1px **width** so button sizes don't shift. The active toggle branch keeps `border border-border`, and the `transition-colors` makes the border fade in/out smoothly as you toggle.

## Scope

Deliberately limited to the log-viewer toolbar. The same fallback-vs-`border-transparent` interaction affects other ghost/filled `Button` variants app-wide (e.g. it also gives filled `primary`/`accent` buttons an unintended gray edge and overrides `border-strong` on `secondary`/`outline`). Fixing that at the root (moving the `*` rule into `@layer base`) has app-wide visual blast radius and is left for a separate, design-reviewed change.

## Tests

Added `test/browser/log-viewer-toolbar-borders.spec.ts` (Playwright — computed border colour needs the real CSS cascade, which happy-dom can't evaluate). It asserts the action buttons compute a transparent border, the active auto-scroll toggle does not, and the border disappears once the toggle is switched off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNULHFB7kaq3NDa2Q2jcb3

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNULHFB7kaq3NDa2Q2jcb3)_