### PR TITLE
feat(web): move run Retry button onto the failed run-entry comment

### DIFF
--- a/packages/web/src/components/comment-renderers/index.tsx
+++ b/packages/web/src/components/comment-renderers/index.tsx
@@ -45,16 +45,17 @@ const renderers: RendererRegistry = {
 		<TextComment comment={comment} projectId={projectId} projectSlug={projectSlug} />
 	),
 	[CommentContentType.Preview]: ({ comment }) => <PreviewComment comment={comment} />,
-	[CommentContentType.System]: ({ comment, projectId, taskId, retryableRunId }) => (
-		<SystemComment
+	[CommentContentType.System]: ({ comment, projectId }) => (
+		<SystemComment comment={comment} projectId={projectId} />
+	),
+	[CommentContentType.Run]: ({ comment, projectId, taskId, retryableRunId, inline }) => (
+		<RunComment
 			comment={comment}
 			projectId={projectId}
 			taskId={taskId}
 			retryableRunId={retryableRunId}
+			inline={inline}
 		/>
-	),
-	[CommentContentType.Run]: ({ comment, projectId, inline }) => (
-		<RunComment comment={comment} projectId={projectId} inline={inline} />
 	),
 	[CommentContentType.Action]: ({ comment, projectId, taskId }) => (
 		<ActionComment comment={comment} projectId={projectId} taskId={taskId} />

--- a/packages/web/src/components/comment-renderers/run-comment.tsx
+++ b/packages/web/src/components/comment-renderers/run-comment.tsx
@@ -214,33 +214,44 @@ function RunCommentBody({
 		</span>
 	);
 
+	// The expand/collapse toggle. `flex-1` is added only when a sibling Retry
+	// button shares the row; without it the markup stays byte-identical to the
+	// pre-Retry header, so a non-retryable run's clickable geometry is unchanged.
+	const expandToggle = (
+		<button
+			type="button"
+			onClick={() => setExpanded((v) => !v)}
+			aria-expanded={expanded}
+			aria-controls={logRegionId}
+			data-testid="run-comment-header"
+			className={`flex items-center gap-2 min-h-[26px] min-w-0 text-left -mx-1 px-1 rounded-md hover:bg-surface-3 cursor-pointer${
+				canRetry && taskId ? ' flex-1' : ''
+			}`}
+		>
+			{summaryRow}
+			<svg
+				aria-hidden="true"
+				className={`w-3 h-3 shrink-0 text-text-3 transition-transform ${expanded ? 'rotate-90' : ''}`}
+				viewBox="0 0 16 16"
+				fill="currentColor"
+			>
+				<path d="M6 3l5 5-5 5V3z" />
+			</svg>
+		</button>
+	);
+
 	return (
 		<>
 			{inline &&
 				(completed ? (
-					<div className="flex items-center gap-1 min-w-0">
-						<button
-							type="button"
-							onClick={() => setExpanded((v) => !v)}
-							aria-expanded={expanded}
-							aria-controls={logRegionId}
-							data-testid="run-comment-header"
-							className="flex flex-1 items-center gap-2 min-h-[26px] min-w-0 text-left -mx-1 px-1 rounded-md hover:bg-surface-3 cursor-pointer"
-						>
-							{summaryRow}
-							<svg
-								aria-hidden="true"
-								className={`w-3 h-3 shrink-0 text-text-3 transition-transform ${expanded ? 'rotate-90' : ''}`}
-								viewBox="0 0 16 16"
-								fill="currentColor"
-							>
-								<path d="M6 3l5 5-5 5V3z" />
-							</svg>
-						</button>
-						{canRetry && taskId ? (
+					canRetry && taskId ? (
+						<div className="flex items-center gap-1 min-w-0">
+							{expandToggle}
 							<RunRetryButton projectId={projectId} taskId={taskId} runId={runId} />
-						) : null}
-					</div>
+						</div>
+					) : (
+						expandToggle
+					)
 				) : (
 					<div className="flex items-center min-h-[26px] min-w-0" data-testid="run-comment-header">
 						{summaryRow}

--- a/packages/web/src/components/comment-renderers/run-comment.tsx
+++ b/packages/web/src/components/comment-renderers/run-comment.tsx
@@ -1,5 +1,5 @@
 import { Link } from '@tanstack/react-router';
-import { DoorOpen } from 'lucide-react';
+import { DoorOpen, Loader2, RotateCw } from 'lucide-react';
 import { useState } from 'react';
 import { formatElapsed } from '../../hooks/use-elapsed-duration';
 import {
@@ -7,6 +7,7 @@ import {
 	isActiveRunStatus,
 	useHeartbeatRun,
 } from '../../hooks/use-heartbeat-runs';
+import { useRetryFailedRun } from '../../hooks/use-retry-failed-run';
 import { useRunLogs } from '../../hooks/use-run-logs';
 import { agentPageParams } from '../agent-link';
 import { LazyMount } from '../lazy-mount';
@@ -21,10 +22,13 @@ import { runStatusDotClass, runStatusLabel } from './helpers';
 interface Props {
 	comment: CommentDataOf<'run'>;
 	projectId?: string;
+	taskId?: string;
+	/** The run_id eligible for a Retry button — the latest run, only when none is active/queued. */
+	retryableRunId?: string | null;
 	inline?: boolean;
 }
 
-export function RunComment({ comment, projectId, inline }: Props) {
+export function RunComment({ comment, projectId, taskId, retryableRunId, inline }: Props) {
 	const runId = comment.content?.run_id ?? '';
 	const agentId = comment.content?.agent_id ?? '';
 	const agentTitle = comment.content?.agent_title ?? 'Agent';
@@ -47,6 +51,8 @@ export function RunComment({ comment, projectId, inline }: Props) {
 					actorName={actorName}
 					createdAt={comment.created_at}
 					publicId={comment.public_id}
+					taskId={taskId}
+					retryableRunId={retryableRunId}
 					inline={inline}
 				/>
 			</LazyMount>
@@ -63,6 +69,37 @@ function skillSourceLabel(url: string): string {
 	}
 }
 
+function RunRetryButton({
+	projectId,
+	taskId,
+	runId,
+}: {
+	projectId: string;
+	taskId: string;
+	runId: string;
+}) {
+	const retry = useRetryFailedRun({ projectId, taskId });
+	return (
+		<Tooltip content="Retry this run">
+			<button
+				type="button"
+				onClick={() => retry.mutate(runId)}
+				disabled={retry.isPending}
+				aria-label="Retry failed run"
+				data-testid="retry-failed-run"
+				className="inline-flex h-6 shrink-0 items-center gap-1 rounded-md border border-border px-2 text-[11px] font-medium text-text-2 hover:bg-surface-2 hover:text-text-1 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+			>
+				{retry.isPending ? (
+					<Loader2 className="w-3 h-3 animate-spin" />
+				) : (
+					<RotateCw className="w-3 h-3" />
+				)}
+				Retry
+			</button>
+		</Tooltip>
+	);
+}
+
 function RunCommentBody({
 	projectId,
 	runId,
@@ -72,6 +109,8 @@ function RunCommentBody({
 	actorName,
 	createdAt,
 	publicId,
+	taskId,
+	retryableRunId,
 	inline,
 }: {
 	projectId: string;
@@ -82,12 +121,19 @@ function RunCommentBody({
 	actorName: string | null;
 	createdAt: string;
 	publicId: string;
+	taskId?: string;
+	retryableRunId?: string | null;
 	inline?: boolean;
 }) {
 	const runQuery = useHeartbeatRun(projectId, agentId, runId);
 	const run = runQuery.data;
 	const status = run?.status ?? 'queued';
 	const isActive = isActiveRunStatus(status);
+	// Offer a manual retry on a failed/timed-out run, but only on the latest run
+	// and only when nothing is already running or queued for this task — that's
+	// exactly what `retryableRunId` resolves to (null otherwise).
+	const canRetry =
+		Boolean(taskId) && runId === retryableRunId && (status === 'failed' || status === 'timed_out');
 	const { lines } = useRunLogs(run?.project_id, runId, run?.log_text, isActive);
 	const createdTasks = run?.created_tasks ?? [];
 	const createdDocs = run?.created_docs ?? [];
@@ -172,24 +218,29 @@ function RunCommentBody({
 		<>
 			{inline &&
 				(completed ? (
-					<button
-						type="button"
-						onClick={() => setExpanded((v) => !v)}
-						aria-expanded={expanded}
-						aria-controls={logRegionId}
-						data-testid="run-comment-header"
-						className="flex items-center gap-2 min-h-[26px] min-w-0 text-left -mx-1 px-1 rounded-md hover:bg-surface-3 cursor-pointer"
-					>
-						{summaryRow}
-						<svg
-							aria-hidden="true"
-							className={`w-3 h-3 shrink-0 text-text-3 transition-transform ${expanded ? 'rotate-90' : ''}`}
-							viewBox="0 0 16 16"
-							fill="currentColor"
+					<div className="flex items-center gap-1 min-w-0">
+						<button
+							type="button"
+							onClick={() => setExpanded((v) => !v)}
+							aria-expanded={expanded}
+							aria-controls={logRegionId}
+							data-testid="run-comment-header"
+							className="flex flex-1 items-center gap-2 min-h-[26px] min-w-0 text-left -mx-1 px-1 rounded-md hover:bg-surface-3 cursor-pointer"
 						>
-							<path d="M6 3l5 5-5 5V3z" />
-						</svg>
-					</button>
+							{summaryRow}
+							<svg
+								aria-hidden="true"
+								className={`w-3 h-3 shrink-0 text-text-3 transition-transform ${expanded ? 'rotate-90' : ''}`}
+								viewBox="0 0 16 16"
+								fill="currentColor"
+							>
+								<path d="M6 3l5 5-5 5V3z" />
+							</svg>
+						</button>
+						{canRetry && taskId ? (
+							<RunRetryButton projectId={projectId} taskId={taskId} runId={runId} />
+						) : null}
+					</div>
 				) : (
 					<div className="flex items-center min-h-[26px] min-w-0" data-testid="run-comment-header">
 						{summaryRow}

--- a/packages/web/src/components/comment-renderers/system-comment.tsx
+++ b/packages/web/src/components/comment-renderers/system-comment.tsx
@@ -1,7 +1,5 @@
 import { formatTaskStatus } from '@hezo/shared';
 import { Link } from '@tanstack/react-router';
-import { Loader2, RotateCw } from 'lucide-react';
-import { useRetryFailedRun } from '../../hooks/use-retry-failed-run';
 import { repoWebUrl } from '../../lib/github';
 import type {
 	SystemContent,
@@ -11,15 +9,12 @@ import type {
 	SystemTaskLinkContent,
 } from '../comment-content';
 import { ActorBadge } from '../ui/actor-badge';
-import { Tooltip } from '../ui/tooltip';
 import type { CommentDataOf } from './comment-data';
 import { CommentTimestampLink } from './comment-timestamp-link';
 
 interface Props {
 	comment: CommentDataOf<'system'>;
 	projectId?: string;
-	taskId?: string;
-	retryableRunId?: string | null;
 }
 
 function isTaskLink(c: SystemContent): c is SystemTaskLinkContent {
@@ -35,7 +30,7 @@ function isRepoDesignated(c: SystemContent): c is SystemRepoDesignatedContent {
 	return c.kind === 'repo_designated';
 }
 
-export function SystemComment({ comment, projectId, taskId, retryableRunId }: Props) {
+export function SystemComment({ comment, projectId }: Props) {
 	const content: SystemContent | null =
 		comment.content && typeof comment.content === 'object' ? comment.content : null;
 	const timestamp = (
@@ -63,15 +58,7 @@ export function SystemComment({ comment, projectId, taskId, retryableRunId }: Pr
 	}
 
 	if (content && isRunFailed(content)) {
-		return (
-			<RunFailedBody
-				content={content}
-				projectId={projectId}
-				taskId={taskId}
-				retryableRunId={retryableRunId}
-				timestamp={timestamp}
-			/>
-		);
+		return <RunFailedBody content={content} projectId={projectId} timestamp={timestamp} />;
 	}
 
 	if (content && isRepoDesignated(content)) {
@@ -152,21 +139,16 @@ function StatusChangeBody({
 function RunFailedBody({
 	content,
 	projectId,
-	taskId,
-	retryableRunId,
 	timestamp,
 }: {
 	content: SystemRunFailedContent;
 	projectId?: string;
-	taskId?: string;
-	retryableRunId?: string | null;
 	timestamp: React.ReactNode;
 }) {
 	const agentSlug = typeof content.agent_slug === 'string' ? content.agent_slug : '';
 	const status = typeof content.status === 'string' ? content.status : 'failed';
 	const error =
 		typeof content.error === 'string' && content.error.length > 0 ? content.error : null;
-	const runId = typeof content.run_id === 'string' ? content.run_id : null;
 	const statusLabel = status === 'timed_out' ? 'timed out' : 'failed';
 	const agentNode =
 		agentSlug && projectId ? (
@@ -191,43 +173,9 @@ function RunFailedBody({
 					Run for {agentNode} {statusLabel}
 					{error ? <span className="text-text-3">: {error}</span> : null}.
 				</span>
-				{projectId && taskId && runId && runId === retryableRunId ? (
-					<RetryRunButton projectId={projectId} taskId={taskId} runId={runId} />
-				) : null}
 			</span>
 			{timestamp}
 		</div>
-	);
-}
-
-function RetryRunButton({
-	projectId,
-	taskId,
-	runId,
-}: {
-	projectId: string;
-	taskId: string;
-	runId: string;
-}) {
-	const retry = useRetryFailedRun({ projectId, taskId });
-	return (
-		<Tooltip content="Retry this run">
-			<button
-				type="button"
-				onClick={() => retry.mutate(runId)}
-				disabled={retry.isPending}
-				aria-label="Retry failed run"
-				data-testid="retry-failed-run"
-				className="inline-flex items-center gap-1 self-baseline rounded-md border border-border px-1.5 py-0.5 text-[11px] font-medium text-text-2 hover:bg-surface-2 hover:text-text-1 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-			>
-				{retry.isPending ? (
-					<Loader2 className="w-3 h-3 animate-spin" />
-				) : (
-					<RotateCw className="w-3 h-3" />
-				)}
-				Retry
-			</button>
-		</Tooltip>
 	);
 }
 

--- a/packages/web/src/components/task-detail/comments-section.tsx
+++ b/packages/web/src/components/task-detail/comments-section.tsx
@@ -123,12 +123,13 @@ export function CommentsSection({
 		for (const a of agents ?? []) m.set(a.id, a.slug);
 		return m;
 	}, [agents]);
-	// The run_id whose run_failed comment may show a Retry button: the most
+	// The run_id whose failed run-entry comment may show a Retry button: the most
 	// recent run referenced in the thread, and only when no run is currently
-	// active. Run comments (any outcome) and run_failed comments both carry a
-	// run_id; comments arrive oldest-first, so the last match is the newest run.
-	// Older failed runs — superseded by a later run, or any run while one is
-	// active — resolve to a different id (or null) and hide their Retry button.
+	// active or queued. Run comments (any outcome) and run_failed comments both
+	// carry a run_id; comments arrive oldest-first, so the last match is the
+	// newest run. Older failed runs — superseded by a later run, or any run while
+	// one is active/queued — resolve to a different id (or null) and hide their
+	// Retry button.
 	const retryableRunId = useMemo<string | null>(() => {
 		if (task.has_active_run) return null;
 		let latest: string | null = null;

--- a/packages/web/src/components/task-detail/last-run-failed-banner.tsx
+++ b/packages/web/src/components/task-detail/last-run-failed-banner.tsx
@@ -1,77 +1,31 @@
-import { AlertTriangle, ChevronRight, Loader2, RotateCw } from 'lucide-react';
-import { useRetryFailedRun } from '../../hooks/use-retry-failed-run';
+import { AlertTriangle, ChevronRight } from 'lucide-react';
 import type { Task } from '../../hooks/use-tasks';
 import { jumpToComment } from '../comment-renderers';
 
 interface Props {
 	task: Task;
-	/** Route-param slug — required to wire the Retry action. */
-	projectId?: string;
-	/** Route-param slug — required to wire the Retry action. */
-	taskId?: string;
 }
 
-export function LastRunFailedBanner({ task, projectId, taskId }: Props) {
+export function LastRunFailedBanner({ task }: Props) {
 	const failed = task.last_run_status === 'failed' || task.last_run_status === 'timed_out';
 	if (task.has_active_run || !failed || !task.last_run_comment_public_id) return null;
 
 	const commentId = task.last_run_comment_public_id;
 	return (
-		<div className="mb-4 flex items-stretch gap-2">
-			<a
-				href={`#comment-${commentId}`}
-				onClick={jumpToComment(commentId)}
-				data-testid="last-run-failed-banner"
-				className="flex min-w-0 flex-1 items-center gap-2 rounded-md bg-danger/10 px-4 py-2 text-[13px] font-medium text-danger hover:bg-danger/15 transition-colors"
-			>
-				<AlertTriangle className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
-				<span className="min-w-0 truncate">
-					{task.last_run_status === 'timed_out' ? 'Last run timed out' : 'Last run failed'} — view
-					it
-				</span>
-				<span className="ml-auto flex items-center gap-1 shrink-0">
-					<span className="hidden sm:inline">Jump to run</span>
-					<ChevronRight className="w-3.5 h-3.5" />
-				</span>
-			</a>
-			{/*
-			 * The durable manual-retry path: the inline button on the `run_failed`
-			 * comment disappears once that ping is suppressed (3+ consecutive
-			 * failures), but this banner stays as long as the last run failed and
-			 * nothing is running — so retry must remain reachable here.
-			 */}
-			{projectId && taskId && task.last_run_id ? (
-				<RetryButton projectId={projectId} taskId={taskId} runId={task.last_run_id} />
-			) : null}
-		</div>
-	);
-}
-
-function RetryButton({
-	projectId,
-	taskId,
-	runId,
-}: {
-	projectId: string;
-	taskId: string;
-	runId: string;
-}) {
-	const retry = useRetryFailedRun({ projectId, taskId });
-	return (
-		<button
-			type="button"
-			onClick={() => retry.mutate(runId)}
-			disabled={retry.isPending}
-			aria-label="Retry failed run"
-			data-testid="retry-failed-run-banner"
-			className="inline-flex shrink-0 items-center gap-1 rounded-md bg-danger/10 px-3 text-[13px] font-medium text-danger hover:bg-danger/15 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+		<a
+			href={`#comment-${commentId}`}
+			onClick={jumpToComment(commentId)}
+			data-testid="last-run-failed-banner"
+			className="mb-4 flex items-center gap-2 rounded-md bg-danger/10 px-4 py-2 text-[13px] font-medium text-danger hover:bg-danger/15 transition-colors"
 		>
-			{retry.isPending ? (
-				<Loader2 className="w-3.5 h-3.5 animate-spin" />
-			) : (
-				<RotateCw className="w-3.5 h-3.5" />
-			)}
-			Retry
-		</button>
+			<AlertTriangle className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
+			<span className="min-w-0 truncate">
+				{task.last_run_status === 'timed_out' ? 'Last run timed out' : 'Last run failed'} — view it
+			</span>
+			<span className="ml-auto flex items-center gap-1 shrink-0">
+				<span className="hidden sm:inline">Jump to run</span>
+				<ChevronRight className="w-3.5 h-3.5" />
+			</span>
+		</a>
 	);
 }

--- a/packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx
@@ -99,7 +99,7 @@ function TaskDetailPage() {
 			>
 				<PreviewProvider value={setPreview}>
 					<div className="min-w-0">
-						<LastRunFailedBanner task={task} projectId={projectId} taskId={taskId} />
+						<LastRunFailedBanner task={task} />
 						<TaskHeader
 							task={task}
 							projectId={projectId}

--- a/packages/web/test/run-comment-retry.test.tsx
+++ b/packages/web/test/run-comment-retry.test.tsx
@@ -1,0 +1,278 @@
+import { waitFor } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+import { seedProject, seedTask, seedWorkspace } from './helpers/seed';
+
+// The Retry button on a failed run-entry comment. It must appear only for the
+// latest run and only when nothing is already running or queued for the task —
+// `retryableRunId` (computed in comments-section) encodes both, and the run's
+// own status (fetched per run) decides failed vs succeeded.
+
+const FAILED_RUN_ID = 'cccc0000-0000-0000-0000-000000000111';
+const LATER_RUN_ID = 'cccc0000-0000-0000-0000-000000000222';
+
+type Agent = { id: string; slug: string };
+type Seeded = { projectSlug: string; taskId: string; agentSlug: string };
+type Comment = Record<string, unknown>;
+
+function runComment(
+	id: string,
+	taskRowId: string,
+	runId: string,
+	agent: Agent,
+	createdAt: string,
+): Comment {
+	return {
+		id,
+		task_id: taskRowId,
+		content_type: 'run',
+		content: { run_id: runId, agent_id: agent.id, agent_title: 'Captain', agent_slug: agent.slug },
+		chosen_option: null,
+		created_at: createdAt,
+		author_type: 'agent',
+		author_name: 'Captain',
+		author_member_id: agent.id,
+	};
+}
+
+function runFailedPing(
+	id: string,
+	taskRowId: string,
+	runId: string,
+	agent: Agent,
+	createdAt: string,
+): Comment {
+	return {
+		id,
+		task_id: taskRowId,
+		content_type: 'system',
+		content: {
+			kind: 'run_failed',
+			run_id: runId,
+			status: 'failed',
+			error: 'later boom',
+			member_id: agent.id,
+			agent_slug: agent.slug,
+		},
+		chosen_option: null,
+		created_at: createdAt,
+		author_type: 'admin',
+		author_name: 'Admin',
+		author_member_id: null,
+	};
+}
+
+function runResponse(
+	runId: string,
+	agent: Agent,
+	teamId: string,
+	taskRowId: string,
+	status: string,
+): Record<string, unknown> {
+	const failed = status === 'failed' || status === 'timed_out';
+	return {
+		id: runId,
+		member_id: agent.id,
+		team_id: teamId,
+		task_id: taskRowId,
+		status,
+		started_at: '2026-05-20T11:30:00Z',
+		finished_at: '2026-05-20T11:30:30Z',
+		exit_code: failed ? 1 : 0,
+		error: failed ? 'boom' : null,
+		input_tokens: 0,
+		output_tokens: 0,
+		cost_cents: 0,
+		log_text: 'output',
+		created_tasks: [],
+	};
+}
+
+async function setup(opts: {
+	seeded: Seeded;
+	retryCalls: string[];
+	comments: (ctx: { task: { id: string }; agent: Agent }) => Comment[];
+	runs: (ctx: {
+		task: { id: string };
+		agent: Agent;
+		teamId: string;
+	}) => Record<string, Record<string, unknown>>;
+	taskOverride?: Record<string, unknown>;
+}) {
+	const { seeded, retryCalls, comments, runs, taskOverride } = opts;
+	return renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const captain = ws.agents.find((a) => a.slug === 'captain') ?? ws.agents[0];
+			const project = await seedProject(ws, { name: 'Run Retry Project' });
+			const task = await seedTask(ws, project, {
+				title: 'Run Retry Task',
+				assignee_id: captain.id,
+			});
+
+			seeded.projectSlug = project.slug;
+			seeded.taskId = task.identifier.toLowerCase();
+			seeded.agentSlug = captain.slug;
+
+			const commentList = comments({ task, agent: captain });
+			const runMap = runs({ task, agent: captain, teamId: ws.team.id });
+
+			const originalFetch = globalThis.fetch;
+			globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+				const url = typeof input === 'string' ? input : (input as Request).url;
+				const method = init?.method ?? (input instanceof Request ? input.method : 'GET');
+
+				if (method === 'GET' && /\/api\/projects\/[^/]+\/tasks\/[^/]+\/comments/.test(url)) {
+					return new Response(JSON.stringify({ data: commentList }), {
+						status: 200,
+						headers: { 'Content-Type': 'application/json' },
+					});
+				}
+				const hbMatch = url.match(
+					/\/api\/projects\/[^/]+\/agents\/[^/]+\/heartbeat-runs\/([^/?]+)/,
+				);
+				if (method === 'GET' && hbMatch) {
+					const resp = runMap[hbMatch[1]];
+					if (resp) {
+						return new Response(JSON.stringify({ data: resp }), {
+							status: 200,
+							headers: { 'Content-Type': 'application/json' },
+						});
+					}
+				}
+				if (
+					taskOverride &&
+					method === 'GET' &&
+					/\/api\/projects\/[^/]+\/tasks\/[^/]+(\?|$)/.test(url) &&
+					!url.includes('/comments')
+				) {
+					const res = await originalFetch(input as RequestInfo, init);
+					const body = (await res.json()) as { data: Record<string, unknown> };
+					return new Response(JSON.stringify({ data: { ...body.data, ...taskOverride } }), {
+						status: 200,
+						headers: { 'Content-Type': 'application/json' },
+					});
+				}
+				const retryMatch = url.match(/\/api\/projects\/[^/]+\/tasks\/[^/]+\/runs\/([^/]+)\/retry/);
+				if (method === 'POST' && retryMatch) {
+					retryCalls.push(retryMatch[1]);
+					return new Response(JSON.stringify({ data: { dispatched: true } }), {
+						status: 200,
+						headers: { 'Content-Type': 'application/json' },
+					});
+				}
+				return originalFetch(input as RequestInfo, init);
+			}) as typeof globalThis.fetch;
+		},
+	});
+}
+
+test('failed run-entry comment shows Retry and retries that run on click', async () => {
+	const seeded: Seeded = { projectSlug: '', taskId: '', agentSlug: '' };
+	const retryCalls: string[] = [];
+
+	const { findByTestId, user, router } = await setup({
+		seeded,
+		retryCalls,
+		comments: ({ task, agent }) => [
+			runComment('c1', task.id, FAILED_RUN_ID, agent, '2026-05-20T11:30:00Z'),
+		],
+		runs: ({ task, agent, teamId }) => ({
+			[FAILED_RUN_ID]: runResponse(FAILED_RUN_ID, agent, teamId, task.id, 'failed'),
+		}),
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
+	});
+
+	const retryButton = (await findByTestId('retry-failed-run', undefined, {
+		timeout: 20_000,
+	})) as HTMLButtonElement;
+	expect(retryButton.textContent ?? '').toContain('Retry');
+
+	await user.click(retryButton);
+
+	await waitFor(() => {
+		expect(retryCalls).toEqual([FAILED_RUN_ID]);
+	});
+});
+
+test('failed run-entry comment hides Retry once a later run supersedes it', async () => {
+	const seeded: Seeded = { projectSlug: '', taskId: '', agentSlug: '' };
+	const retryCalls: string[] = [];
+
+	const { findByTestId, queryByTestId, router } = await setup({
+		seeded,
+		retryCalls,
+		comments: ({ task, agent }) => [
+			runComment('c1', task.id, FAILED_RUN_ID, agent, '2026-05-20T11:30:00Z'),
+			// A newer run is referenced after it, so FAILED_RUN_ID is no longer latest.
+			runFailedPing('c2', task.id, LATER_RUN_ID, agent, '2026-05-20T11:35:00Z'),
+		],
+		runs: ({ task, agent, teamId }) => ({
+			[FAILED_RUN_ID]: runResponse(FAILED_RUN_ID, agent, teamId, task.id, 'failed'),
+		}),
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
+	});
+
+	// Wait for the failed run entry to finish loading its status before asserting.
+	await findByTestId('run-comment-summary', undefined, { timeout: 20_000 });
+	expect(queryByTestId('retry-failed-run')).toBeNull();
+});
+
+test('failed run-entry comment hides Retry while a run is active or queued', async () => {
+	const seeded: Seeded = { projectSlug: '', taskId: '', agentSlug: '' };
+	const retryCalls: string[] = [];
+
+	const { findByTestId, queryByTestId, router } = await setup({
+		seeded,
+		retryCalls,
+		comments: ({ task, agent }) => [
+			runComment('c1', task.id, FAILED_RUN_ID, agent, '2026-05-20T11:30:00Z'),
+		],
+		runs: ({ task, agent, teamId }) => ({
+			[FAILED_RUN_ID]: runResponse(FAILED_RUN_ID, agent, teamId, task.id, 'failed'),
+		}),
+		// has_active_run is true for both running and queued runs.
+		taskOverride: { has_active_run: true },
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
+	});
+
+	await findByTestId('run-comment-summary', undefined, { timeout: 20_000 });
+	expect(queryByTestId('retry-failed-run')).toBeNull();
+});
+
+test('succeeded run-entry comment shows no Retry button', async () => {
+	const seeded: Seeded = { projectSlug: '', taskId: '', agentSlug: '' };
+	const retryCalls: string[] = [];
+
+	const { findByTestId, queryByTestId, router } = await setup({
+		seeded,
+		retryCalls,
+		comments: ({ task, agent }) => [
+			runComment('c1', task.id, FAILED_RUN_ID, agent, '2026-05-20T11:30:00Z'),
+		],
+		runs: ({ task, agent, teamId }) => ({
+			[FAILED_RUN_ID]: runResponse(FAILED_RUN_ID, agent, teamId, task.id, 'succeeded'),
+		}),
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
+	});
+
+	await findByTestId('run-comment-summary', undefined, { timeout: 20_000 });
+	expect(queryByTestId('retry-failed-run')).toBeNull();
+});

--- a/packages/web/test/run-failed-comment.test.tsx
+++ b/packages/web/test/run-failed-comment.test.tsx
@@ -3,7 +3,6 @@ import { renderApp } from './helpers/render';
 import { seedProject, seedTask, seedWorkspace } from './helpers/seed';
 
 const FAILED_RUN_ID = 'bbbb0000-0000-0000-0000-000000000777';
-const LATER_RUN_ID = 'bbbb0000-0000-0000-0000-000000000888';
 
 type Seeded = {
 	teamId: string;
@@ -15,17 +14,10 @@ type Seeded = {
 
 type Comment = Record<string, unknown>;
 
-/**
- * Seed a team/project/task and stub the comments fetch with the given list.
- * `taskOverride` patches the live task-detail response (e.g. has_active_run)
- * by mutating the real seeded payload. `retryCalls` records run ids POSTed to
- * the retry endpoint.
- */
+/** Seed a team/project/task and stub the comments fetch with the given list. */
 async function setup(
 	seeded: Seeded,
-	retryCalls: string[],
 	buildComments: (ctx: { task: { id: string }; agent: { id: string; slug: string } }) => Comment[],
-	taskOverride?: Record<string, unknown>,
 ) {
 	return renderApp({
 		initialPath: '/',
@@ -52,29 +44,6 @@ async function setup(
 				const method = init?.method ?? (input instanceof Request ? input.method : 'GET');
 				if (method === 'GET' && /\/api\/projects\/[^/]+\/tasks\/[^/]+\/comments/.test(url)) {
 					return new Response(JSON.stringify({ data: comments }), {
-						status: 200,
-						headers: { 'Content-Type': 'application/json' },
-					});
-				}
-				if (
-					taskOverride &&
-					method === 'GET' &&
-					/\/api\/projects\/[^/]+\/tasks\/[^/]+(\?|$)/.test(url) &&
-					!url.includes('/comments')
-				) {
-					const res = await originalFetch(input as RequestInfo, init);
-					const body = (await res.json()) as { data: Record<string, unknown> };
-					return new Response(JSON.stringify({ data: { ...body.data, ...taskOverride } }), {
-						status: 200,
-						headers: { 'Content-Type': 'application/json' },
-					});
-				}
-				const retryMatch = url.match(
-					/\/api\/projects\/([^/]+)\/tasks\/([^/]+)\/runs\/([^/]+)\/retry/,
-				);
-				if (method === 'POST' && retryMatch) {
-					retryCalls.push(retryMatch[3]);
-					return new Response(JSON.stringify({ data: { dispatched: true } }), {
 						status: 200,
 						headers: { 'Content-Type': 'application/json' },
 					});
@@ -106,11 +75,13 @@ function runFailedComment(taskRowId: string, agentSlug: string, agentId: string)
 	};
 }
 
-test('run_failed comment shows retry when it is the latest run', async () => {
+test('run_failed comment shows the failure and agent link, without a Retry button', async () => {
+	// The Retry affordance lives on the run-entry comment now (always present,
+	// even once this alert ping is suppressed after repeated failures), so the
+	// run_failed ping itself is display-only — see run-comment-retry.test.tsx.
 	const seeded: Seeded = { teamId: '', projectSlug: '', taskId: '', agentId: '', agentSlug: '' };
-	const retryCalls: string[] = [];
 
-	const { findByTestId, router, user } = await setup(seeded, retryCalls, ({ task, agent }) => [
+	const { findByTestId, queryByTestId, router } = await setup(seeded, ({ task, agent }) => [
 		runFailedComment(task.id, agent.slug, agent.id),
 	]);
 
@@ -129,65 +100,5 @@ test('run_failed comment shows retry when it is the latest run', async () => {
 		new RegExp(`/projects/${seeded.projectSlug}/agents/${seeded.agentSlug}$`),
 	);
 
-	const retryButton = (await findByTestId('retry-failed-run')) as HTMLButtonElement;
-	expect(retryButton.textContent ?? '').toContain('Retry');
-	await user.click(retryButton);
-	expect(retryCalls).toEqual([FAILED_RUN_ID]);
-});
-
-test('run_failed comment hides retry when a later run exists', async () => {
-	const seeded: Seeded = { teamId: '', projectSlug: '', taskId: '', agentId: '', agentSlug: '' };
-	const retryCalls: string[] = [];
-
-	const { findByTestId, queryByTestId, router } = await setup(
-		seeded,
-		retryCalls,
-		({ task, agent }) => [
-			runFailedComment(task.id, agent.slug, agent.id),
-			{
-				id: 'aaaa0000-0000-0000-0000-000000000002',
-				task_id: task.id,
-				content_type: 'run',
-				content: {
-					run_id: LATER_RUN_ID,
-					agent_id: agent.id,
-					agent_slug: agent.slug,
-					agent_title: 'Captain',
-				},
-				chosen_option: null,
-				created_at: '2026-05-20T11:35:00Z',
-				author_type: 'agent',
-				author_name: 'Captain',
-				author_member_id: agent.id,
-			},
-		],
-	);
-
-	await router.navigate({
-		to: '/projects/$projectId/tasks/$taskId',
-		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
-	});
-
-	await findByTestId('run-failed-comment', undefined, { timeout: 20_000 });
-	expect(queryByTestId('retry-failed-run')).toBeNull();
-});
-
-test('run_failed comment hides retry while a run is active', async () => {
-	const seeded: Seeded = { teamId: '', projectSlug: '', taskId: '', agentId: '', agentSlug: '' };
-	const retryCalls: string[] = [];
-
-	const { findByTestId, queryByTestId, router } = await setup(
-		seeded,
-		retryCalls,
-		({ task, agent }) => [runFailedComment(task.id, agent.slug, agent.id)],
-		{ has_active_run: true },
-	);
-
-	await router.navigate({
-		to: '/projects/$projectId/tasks/$taskId',
-		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
-	});
-
-	await findByTestId('run-failed-comment', undefined, { timeout: 20_000 });
 	expect(queryByTestId('retry-failed-run')).toBeNull();
 });

--- a/packages/web/test/task-detail-failed-banner.test.tsx
+++ b/packages/web/test/task-detail-failed-banner.test.tsx
@@ -118,62 +118,6 @@ test('banner is hidden when the task has no completed runs', async () => {
 	});
 });
 
-test('banner Retry button retries the last failed run even when no run_failed comment exists', async () => {
-	// Reproduces the 3+ consecutive-failure case: the `run_failed` ping (which
-	// hosts the inline Retry button) is suppressed, so only the `run` comment
-	// remains. The banner must still expose a working manual-retry path.
-	const seeded = { projectSlug: '', taskIdentifier: '', runId: '' };
-	const retryCalls: string[] = [];
-
-	const { findByTestId, queryByTestId, user, router } = await renderApp({
-		initialPath: '/',
-		seed: async () => {
-			const ws = await seedWorkspace();
-			const project = await seedProject(ws, { name: 'Demo' });
-			const task = await seedTask(ws, project, { title: 'Crash Loop Task' });
-			const { runId } = await insertFailedRunWithComment(ws, task, 'failed');
-			seeded.projectSlug = project.slug;
-			seeded.taskIdentifier = task.identifier.toLowerCase();
-			seeded.runId = runId;
-
-			// Intercept the retry POST so we assert on the call without driving a
-			// real container dispatch; everything else falls through to the
-			// in-process backend so the task GET returns a real `last_run_id`.
-			const passthrough = globalThis.fetch;
-			globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
-				const url = typeof input === 'string' ? input : (input as Request).url;
-				const method = init?.method ?? (input instanceof Request ? input.method : 'GET');
-				const retryMatch = url.match(/\/api\/projects\/[^/]+\/tasks\/[^/]+\/runs\/([^/]+)\/retry/);
-				if (method === 'POST' && retryMatch) {
-					retryCalls.push(retryMatch[1]);
-					return new Response(JSON.stringify({ data: { dispatched: true } }), {
-						status: 200,
-						headers: { 'Content-Type': 'application/json' },
-					});
-				}
-				return passthrough(input as RequestInfo, init);
-			}) as typeof globalThis.fetch;
-		},
-	});
-
-	await router.navigate({
-		to: '/projects/$projectId/tasks/$taskId',
-		params: { projectId: seeded.projectSlug, taskId: seeded.taskIdentifier },
-	});
-
-	const retryButton = (await findByTestId('retry-failed-run-banner', undefined, {
-		timeout: 10_000,
-	})) as HTMLButtonElement;
-	// No inline run_failed retry in this scenario — the banner is the only path.
-	expect(queryByTestId('retry-failed-run')).toBeNull();
-
-	await user.click(retryButton);
-
-	await waitFor(() => {
-		expect(retryCalls).toEqual([seeded.runId]);
-	});
-});
-
 test('banner is suppressed while a retry is currently running', async () => {
 	const seeded = { projectSlug: '', taskIdentifier: '' };
 	const { findByRole, queryByTestId, router } = await renderApp({


### PR DESCRIPTION
## What

Adds a **Retry** button to a failed/timed-out **run-entry comment** in the task comment list, and removes the now-redundant Retry button from the `run_failed` alert ping.

This is the follow-up to #327 (which removed the top "Last run failed" banner, including its Retry button). Retry now lives on the run entry in the thread.

## Behaviour

The button shows on a run-entry comment only when **all** of:
- the run's status is `failed` or `timed_out`, **and**
- it's the latest run referenced in the thread (an older run superseded by a newer one hides it), **and**
- nothing is already **running or queued** for the task.

The last two are exactly what the existing `retryableRunId` memo already resolves to (it returns `null` when `has_active_run` is true — and `has_active_run` is `true` for both `running` **and** `queued` runs server-side). So the two requested guards — *"don't show if that agent is currently running again"* and *"don't show if the agent is already in the run queue"* — are both covered.

## Why move it off the ping

The `run_failed` ping is **suppressed after 3+ consecutive failures**, but the run-entry comment is **always present**. Putting Retry on the run entry makes it the durable manual-retry path (the same gap the old banner filled). Keeping it on both would render **two identical Retry buttons** for a single failure (failures 1–3 have both comments), so the ping is now display-only.

## Changes

- `run-comment.tsx` — add the gated `RunRetryButton` to the failed run entry's header (sibling of the expand toggle, since a button can't nest in a button); thread `taskId` / `retryableRunId` through.
- `system-comment.tsx` — drop `RetryRunButton` and its props from the `run_failed` ping.
- `index.tsx` — forward `taskId` / `retryableRunId` to `RunComment`; stop passing them to `SystemComment`.
- `comments-section.tsx` — update the `retryableRunId` doc comment.
- Tests: new `run-comment-retry.test.tsx` (shows + click retries; hidden when superseded / active-or-queued / succeeded); `run-failed-comment.test.tsx` updated to assert the ping is display-only.

## Testing

- Full web vitest tier: **386 passed** (`bun run test --package web --skip-browser`)
- `tsc --noEmit` clean · `biome check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WR5iCxv9vXGvLgSnCnUoBa)_