### PR TITLE
feat(server): detect Docker at startup and guide install when missing

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -242,6 +242,13 @@ instance-agent task selection).
 
 ## 5. Agent execution & run lifecycle
 
+**Startup Docker gate.** Every run executes in a per-project Docker container, so Docker
+is a hard prerequisite. Before `startup()` boots the server, `index.ts` runs a preflight
+(`services/docker-preflight.ts`): it pings the daemon and, on failure, checks for a
+`docker` binary on PATH to tell *not installed* from *installed-but-stopped*, prints the
+matching guidance (install link / start command), and **exits non-zero**. `HEZO_SKIP_DOCKER`
+(the same flag that swaps in the in-process fake docker for dev/tests) bypasses the gate.
+
 Work reaches an agent through the **wakeup → job-manager → agent-runner** pipeline.
 
 **Wakeups.** Every trigger is an `agent_wakeup_requests` row. Sources: `heartbeat`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,7 @@ All changes ship with tests that exercise functionality (not "code runs without 
 - Always `destroyTestContext()` in `afterAll` (resource leak otherwise).
 - Pure logic tests (crypto, parsing) can call functions directly.
 - GitHub OAuth/repo/SSH-key tests use the local simulator at `packages/server/test/helpers/github-sim.ts` — set `GITHUB_API_BASE_URL` and `GITHUB_OAUTH_BASE_URL` before the test context boots.
+- `HEZO_SKIP_DOCKER=1` swaps the real `DockerClient` for the in-process fake (`services/fake-docker.ts`) so suites (and the startup Docker preflight) run without a Docker daemon. It is wired into the test harnesses (`packages/web/vitest.config.ts`, the browser specs) and is **test/CI-only**. **Never expose it to users** — Docker is a hard prerequisite, so it must not appear in user-facing output (CLI/preflight messages, `docs/`, README, `--help`) or be documented as a supported way to run Hezo. Referencing it in code comments or `.dev/architecture.md` is fine; surfacing it to operators is not.
 
 ### Bun-native runtime rules
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -14,7 +14,10 @@ project's agents in an isolated container.
 ## Prerequisites
 
 - **Docker** — Docker Engine (Linux) or Docker Desktop (macOS/Windows), running and
-  reachable. Hezo launches a container per project through it.
+  reachable. Hezo launches a container per project through it. On startup Hezo checks
+  for a working Docker daemon and, if it's missing or stopped, prints how to install or
+  start it (with a link to [Docker's install page](https://docs.docker.com/get-docker/))
+  and exits — so install Docker first.
 - A machine you're happy to leave running while agents work (a laptop is fine to
   start; a small always-on server is better for long-running teams).
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -17,8 +17,11 @@ hezo [options]
 ```
 
 Boots the Hezo server and web app (default port 3100) against the data directory
-(default `~/.hezo/`). See the [Configuration reference](/docs/deployment/configuration)
-for the full table of flags and their environment-variable equivalents. The most common:
+(default `~/.hezo/`). Docker must be installed and running first — Hezo checks at startup
+and exits with install/start guidance if the daemon isn't reachable (see
+[Installation](/docs/getting-started/installation)). See the
+[Configuration reference](/docs/deployment/configuration) for the full table of flags and
+their environment-variable equivalents. The most common:
 
 ```sh
 hezo --port 8080                 # listen on a different port

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -10,6 +10,8 @@ import { logger, setLogLevel } from './logger';
 import { canAuthAccessTeam, loadAdminAuth, verifyToken } from './middleware/auth';
 import type { ContainerLogStreamer } from './services/container-logs';
 import { setKeepOldContainers } from './services/containers';
+import { DockerClient } from './services/docker';
+import { evaluateDockerPreflight, formatDockerPreflightMessage } from './services/docker-preflight';
 import { getSharedImageBuildTracker } from './services/image-build-tracker';
 import type { LogStreamBroker } from './services/log-stream-broker';
 import type { WebSocketManager, WsData, WsSocket } from './services/ws';
@@ -75,6 +77,19 @@ if (await runRestore()) {
 const config = parseConfig();
 setLogLevel(config.logLevel);
 setKeepOldContainers(config.keepOldContainers);
+
+// Docker is a hard prerequisite — every agent runs in a per-project container.
+// Detect a missing or unreachable daemon at launch and exit with actionable
+// guidance (install link / start instructions) rather than booting a server
+// that can't run a single agent. HEZO_SKIP_DOCKER swaps in the in-process fake
+// docker for UI/dev work and tests, so the gate is skipped when it is set.
+if (!process.env.HEZO_SKIP_DOCKER) {
+	const availability = await evaluateDockerPreflight(new DockerClient());
+	if (availability !== 'ok') {
+		log.error(`\n${formatDockerPreflightMessage(availability)}\n`);
+		process.exit(1);
+	}
+}
 
 /** Bumped on each module load so stale async startup completions are ignored after HMR. */
 let startupGeneration = 0;

--- a/packages/server/src/services/docker-preflight.ts
+++ b/packages/server/src/services/docker-preflight.ts
@@ -73,33 +73,48 @@ export async function evaluateDockerPreflight(
 }
 
 /**
+ * Why Docker is mandatory, shared by both failure messages: the container is a
+ * security sandbox, not just a packaging convenience. Agents run untrusted-ish
+ * code, so isolating them from the host is the whole point.
+ */
+const SANDBOX_RATIONALE = [
+	"Hezo runs each project's AI agents inside isolated Docker containers. That",
+	'sandbox is a security boundary: it keeps agents off your host so a buggy or',
+	"compromised agent can't reach your files, credentials, or wider network.",
+];
+
+const SKIP_HINT =
+	'For development without Docker (agents run in a no-op stub) set HEZO_SKIP_DOCKER=1.';
+
+/**
  * Human-facing guidance for a non-`ok` preflight result, printed to the log
- * right before the server exits. Includes the install link for the
- * not-installed case and start instructions for the not-running case.
+ * right before the server exits. Both variants explain *why* Docker is required
+ * (host isolation / security), then give the relevant next step: the install
+ * link when it's missing, start instructions when the daemon is just stopped.
  */
 export function formatDockerPreflightMessage(status: Exclude<DockerAvailability, 'ok'>): string {
 	if (status === 'not-installed') {
 		return [
 			'Docker is required to run Hezo, but it does not appear to be installed.',
 			'',
-			"Hezo runs each project's agents in an isolated Docker container, so a working",
-			'Docker installation is required. Install Docker, then start Hezo again:',
+			...SANDBOX_RATIONALE,
+			'Docker is required to provide that isolation — install it, then start Hezo again:',
 			'',
 			`  ${DOCKER_INSTALL_URL}`,
 			'',
-			'For development without Docker (agents run in a no-op stub) set HEZO_SKIP_DOCKER=1.',
+			SKIP_HINT,
 		].join('\n');
 	}
 	return [
 		'Docker is installed but the Docker daemon is not reachable.',
 		'',
-		"Hezo runs each project's agents in an isolated Docker container, so the Docker",
-		'daemon must be running. Start Docker Desktop, or on Linux run',
-		'`sudo systemctl start docker`, then start Hezo again.',
+		...SANDBOX_RATIONALE,
+		'The Docker daemon must be running to provide that isolation. Start Docker',
+		'Desktop, or on Linux run `sudo systemctl start docker`, then start Hezo again.',
 		'',
 		'If you just installed Docker, its docs cover starting it and post-install setup:',
 		`  ${DOCKER_INSTALL_URL}`,
 		'',
-		'For development without Docker (agents run in a no-op stub) set HEZO_SKIP_DOCKER=1.',
+		SKIP_HINT,
 	].join('\n');
 }

--- a/packages/server/src/services/docker-preflight.ts
+++ b/packages/server/src/services/docker-preflight.ts
@@ -83,14 +83,14 @@ const SANDBOX_RATIONALE = [
 	"compromised agent can't reach your files, credentials, or wider network.",
 ];
 
-const SKIP_HINT =
-	'For development without Docker (agents run in a no-op stub) set HEZO_SKIP_DOCKER=1.';
-
 /**
  * Human-facing guidance for a non-`ok` preflight result, printed to the log
  * right before the server exits. Both variants explain *why* Docker is required
  * (host isolation / security), then give the relevant next step: the install
  * link when it's missing, start instructions when the daemon is just stopped.
+ *
+ * Never mention HEZO_SKIP_DOCKER here — it's a test-only escape hatch (swaps in
+ * the in-process fake docker) and must not be surfaced to users (see AGENTS.md).
  */
 export function formatDockerPreflightMessage(status: Exclude<DockerAvailability, 'ok'>): string {
 	if (status === 'not-installed') {
@@ -101,8 +101,6 @@ export function formatDockerPreflightMessage(status: Exclude<DockerAvailability,
 			'Docker is required to provide that isolation — install it, then start Hezo again:',
 			'',
 			`  ${DOCKER_INSTALL_URL}`,
-			'',
-			SKIP_HINT,
 		].join('\n');
 	}
 	return [
@@ -114,7 +112,5 @@ export function formatDockerPreflightMessage(status: Exclude<DockerAvailability,
 		'',
 		'If you just installed Docker, its docs cover starting it and post-install setup:',
 		`  ${DOCKER_INSTALL_URL}`,
-		'',
-		SKIP_HINT,
 	].join('\n');
 }

--- a/packages/server/src/services/docker-preflight.ts
+++ b/packages/server/src/services/docker-preflight.ts
@@ -1,0 +1,105 @@
+import { existsSync } from 'node:fs';
+import { delimiter, join } from 'node:path';
+import type { DockerClient } from './docker';
+
+/**
+ * Canonical Docker install page, shown to operators when Docker is missing.
+ * Covers Docker Engine (Linux), Docker Desktop (macOS/Windows), and the
+ * post-install steps for starting the daemon.
+ */
+export const DOCKER_INSTALL_URL = 'https://docs.docker.com/get-docker/';
+
+/**
+ * Outcome of the startup Docker check:
+ * - `ok`            — the daemon answered a ping; Hezo can run agents.
+ * - `not-installed` — no `docker` executable on PATH and the socket is dead.
+ * - `not-running`   — `docker` is installed but the daemon isn't reachable.
+ */
+export type DockerAvailability = 'ok' | 'not-installed' | 'not-running';
+
+export interface DockerPreflightProbes {
+	/** Resolves true when the Docker daemon answers a ping over its socket. */
+	ping: () => Promise<boolean>;
+	/** Resolves true when a `docker` executable is present on PATH. */
+	binaryInstalled: () => boolean | Promise<boolean>;
+}
+
+/**
+ * Decide Docker availability from two independent probes. The daemon ping is
+ * the authoritative "can Hezo actually use Docker" signal; the binary probe
+ * only disambiguates *why* a failed ping happened so we can show the right
+ * guidance ("install it" vs "start it"). It is never used as a gate on its own.
+ */
+export async function checkDockerAvailability(
+	probes: DockerPreflightProbes,
+): Promise<DockerAvailability> {
+	if (await probes.ping()) return 'ok';
+	return (await probes.binaryInstalled()) ? 'not-running' : 'not-installed';
+}
+
+/**
+ * Manual PATH scan for a `docker` executable. Used as the fallback when
+ * `Bun.which` is unavailable (i.e. under Node/vitest). Pure and deterministic
+ * given an `env`, so the preflight decision stays testable off the Bun runtime.
+ */
+export function dockerBinaryOnPath(env: NodeJS.ProcessEnv = process.env): boolean {
+	const candidates = process.platform === 'win32' ? ['docker.exe', 'docker'] : ['docker'];
+	const dirs = (env.PATH ?? '').split(delimiter).filter(Boolean);
+	return dirs.some((dir) => candidates.some((name) => existsSync(join(dir, name))));
+}
+
+/**
+ * Whether a `docker` executable is installed. Prefers Bun's native PATH
+ * resolver in production; falls back to a manual scan under Node.
+ */
+export function dockerBinaryInstalled(env: NodeJS.ProcessEnv = process.env): boolean {
+	const bunWhich = (globalThis as { Bun?: { which?: (cmd: string) => string | null } }).Bun?.which;
+	if (typeof bunWhich === 'function') return bunWhich('docker') !== null;
+	return dockerBinaryOnPath(env);
+}
+
+/**
+ * Wire the real probes — the Docker client's socket ping plus a binary-on-PATH
+ * check — and report availability. Callers gate startup on an `ok` result.
+ */
+export async function evaluateDockerPreflight(
+	docker: Pick<DockerClient, 'ping'>,
+	env: NodeJS.ProcessEnv = process.env,
+): Promise<DockerAvailability> {
+	return checkDockerAvailability({
+		ping: () => docker.ping(),
+		binaryInstalled: () => dockerBinaryInstalled(env),
+	});
+}
+
+/**
+ * Human-facing guidance for a non-`ok` preflight result, printed to the log
+ * right before the server exits. Includes the install link for the
+ * not-installed case and start instructions for the not-running case.
+ */
+export function formatDockerPreflightMessage(status: Exclude<DockerAvailability, 'ok'>): string {
+	if (status === 'not-installed') {
+		return [
+			'Docker is required to run Hezo, but it does not appear to be installed.',
+			'',
+			"Hezo runs each project's agents in an isolated Docker container, so a working",
+			'Docker installation is required. Install Docker, then start Hezo again:',
+			'',
+			`  ${DOCKER_INSTALL_URL}`,
+			'',
+			'For development without Docker (agents run in a no-op stub) set HEZO_SKIP_DOCKER=1.',
+		].join('\n');
+	}
+	return [
+		'Docker is installed but the Docker daemon is not reachable.',
+		'',
+		"Hezo runs each project's agents in an isolated Docker container, so the Docker",
+		'daemon must be running. Start Docker Desktop, or on Linux run',
+		'`sudo systemctl start docker`, then start Hezo again.',
+		'',
+		'If you just installed Docker, its docs cover starting it and post-install setup:',
+		`  ${DOCKER_INSTALL_URL}`,
+		'',
+		'For development without Docker (agents run in a no-op stub) set HEZO_SKIP_DOCKER=1.',
+	].join('\n');
+}

--- a/packages/server/test/docker-preflight.test.ts
+++ b/packages/server/test/docker-preflight.test.ts
@@ -112,7 +112,6 @@ describe('formatDockerPreflightMessage', () => {
 		const msg = formatDockerPreflightMessage('not-installed');
 		expect(msg).toContain(DOCKER_INSTALL_URL);
 		expect(msg).toContain('not appear to be installed');
-		expect(msg).toContain('HEZO_SKIP_DOCKER');
 	});
 
 	it('explains how to start the daemon when not running', () => {
@@ -128,6 +127,12 @@ describe('formatDockerPreflightMessage', () => {
 			expect(msg).toContain('isolated Docker containers');
 			expect(msg).toContain('security boundary');
 			expect(msg).toContain('host');
+		}
+	});
+
+	it('never leaks the test-only HEZO_SKIP_DOCKER escape hatch to users', () => {
+		for (const status of ['not-installed', 'not-running'] as const) {
+			expect(formatDockerPreflightMessage(status)).not.toContain('HEZO_SKIP_DOCKER');
 		}
 	});
 });

--- a/packages/server/test/docker-preflight.test.ts
+++ b/packages/server/test/docker-preflight.test.ts
@@ -121,4 +121,13 @@ describe('formatDockerPreflightMessage', () => {
 		expect(msg).toContain('Start Docker');
 		expect(msg).toContain(DOCKER_INSTALL_URL);
 	});
+
+	it('explains the security rationale (isolation / host protection) in both variants', () => {
+		for (const status of ['not-installed', 'not-running'] as const) {
+			const msg = formatDockerPreflightMessage(status);
+			expect(msg).toContain('isolated Docker containers');
+			expect(msg).toContain('security boundary');
+			expect(msg).toContain('host');
+		}
+	});
 });

--- a/packages/server/test/docker-preflight.test.ts
+++ b/packages/server/test/docker-preflight.test.ts
@@ -1,0 +1,124 @@
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+	checkDockerAvailability,
+	DOCKER_INSTALL_URL,
+	dockerBinaryOnPath,
+	evaluateDockerPreflight,
+	formatDockerPreflightMessage,
+} from '../src/services/docker-preflight';
+
+describe('checkDockerAvailability', () => {
+	it('reports ok when the daemon answers a ping (binary probe not consulted)', async () => {
+		let binaryProbed = false;
+		const result = await checkDockerAvailability({
+			ping: async () => true,
+			binaryInstalled: () => {
+				binaryProbed = true;
+				return false;
+			},
+		});
+		expect(result).toBe('ok');
+		// A reachable daemon is sufficient — we never need to ask whether the CLI exists.
+		expect(binaryProbed).toBe(false);
+	});
+
+	it('reports not-running when the ping fails but the binary is installed', async () => {
+		const result = await checkDockerAvailability({
+			ping: async () => false,
+			binaryInstalled: () => true,
+		});
+		expect(result).toBe('not-running');
+	});
+
+	it('reports not-installed when the ping fails and no binary is present', async () => {
+		const result = await checkDockerAvailability({
+			ping: async () => false,
+			binaryInstalled: () => false,
+		});
+		expect(result).toBe('not-installed');
+	});
+
+	it('awaits an async binary probe', async () => {
+		const result = await checkDockerAvailability({
+			ping: async () => false,
+			binaryInstalled: async () => true,
+		});
+		expect(result).toBe('not-running');
+	});
+});
+
+describe('dockerBinaryOnPath', () => {
+	let dir: string;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), 'hezo-docker-preflight-'));
+	});
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it('finds a docker executable on PATH', () => {
+		const bin = join(dir, process.platform === 'win32' ? 'docker.exe' : 'docker');
+		writeFileSync(bin, '#!/bin/sh\necho docker\n');
+		chmodSync(bin, 0o755);
+		expect(dockerBinaryOnPath({ PATH: dir })).toBe(true);
+	});
+
+	it('returns false when no docker executable is on PATH', () => {
+		expect(dockerBinaryOnPath({ PATH: dir })).toBe(false);
+	});
+
+	it('returns false for an empty PATH', () => {
+		expect(dockerBinaryOnPath({ PATH: '' })).toBe(false);
+		expect(dockerBinaryOnPath({})).toBe(false);
+	});
+});
+
+describe('evaluateDockerPreflight', () => {
+	it('returns ok when the docker client pings successfully', async () => {
+		const result = await evaluateDockerPreflight({ ping: async () => true }, { PATH: '' });
+		expect(result).toBe('ok');
+	});
+
+	it('returns not-installed when the daemon is down and docker is absent from PATH', async () => {
+		const dir = mkdtempSync(join(tmpdir(), 'hezo-docker-preflight-'));
+		try {
+			const result = await evaluateDockerPreflight({ ping: async () => false }, { PATH: dir });
+			expect(result).toBe('not-installed');
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it('returns not-running when the daemon is down but docker is on PATH', async () => {
+		const dir = mkdtempSync(join(tmpdir(), 'hezo-docker-preflight-'));
+		try {
+			const bin = join(dir, process.platform === 'win32' ? 'docker.exe' : 'docker');
+			writeFileSync(bin, '#!/bin/sh\necho docker\n');
+			chmodSync(bin, 0o755);
+			const result = await evaluateDockerPreflight({ ping: async () => false }, { PATH: dir });
+			expect(result).toBe('not-running');
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe('formatDockerPreflightMessage', () => {
+	it('points at the Docker install page when not installed', () => {
+		const msg = formatDockerPreflightMessage('not-installed');
+		expect(msg).toContain(DOCKER_INSTALL_URL);
+		expect(msg).toContain('not appear to be installed');
+		expect(msg).toContain('HEZO_SKIP_DOCKER');
+	});
+
+	it('explains how to start the daemon when not running', () => {
+		const msg = formatDockerPreflightMessage('not-running');
+		expect(msg).toContain('daemon is not reachable');
+		expect(msg).toContain('Start Docker');
+		expect(msg).toContain(DOCKER_INSTALL_URL);
+	});
+});


### PR DESCRIPTION
## What & why

Docker is a hard prerequisite — every agent runs in a per-project container that
sandboxes it from the host. Previously, starting `hezo` without a working Docker
daemon booted a server that silently couldn't run a single agent. This adds a
**startup preflight** that fails fast with actionable, security-aware guidance.

## Behaviour

Before `startup()` boots the server, `index.ts` runs a Docker preflight
(`services/docker-preflight.ts`):

1. Pings the Docker daemon over its socket.
2. On a failed ping, checks for a `docker` binary on PATH to distinguish
   **not installed** from **installed-but-stopped**.
3. Prints the matching guidance — install link for the missing case, start
   command for the stopped case — and **exits non-zero**.

Both messages explain *why* Docker is required: agents run inside isolated
containers that act as a security boundary, keeping a buggy or compromised agent
off the host and away from its files, credentials, and network.

Example (not installed):

```
Docker is required to run Hezo, but it does not appear to be installed.

Hezo runs each project's AI agents inside isolated Docker containers. That
sandbox is a security boundary: it keeps agents off your host so a buggy or
compromised agent can't reach your files, credentials, or wider network.
Docker is required to provide that isolation — install it, then start Hezo again:

  https://docs.docker.com/get-docker/
```

## Notes

- `HEZO_SKIP_DOCKER` (the in-process fake-docker escape hatch) bypasses the gate,
  so test/CI and dev UI work are unaffected. It is **test-only** and deliberately
  **never surfaced** in the user-facing messages — that rule is now documented in
  `AGENTS.md` and guarded by a regression test.
- Decision logic and message formatting live in a small, fully unit-tested module
  (`docker-preflight.test.ts`, 14 tests); `index.ts` just wires it in.

## Docs

- `docs/getting-started/installation.md` — prerequisites note the startup check.
- `docs/reference/cli.md` — "Start the server" heads-up.
- `.dev/architecture.md` — §5 documents the startup Docker gate.

## Testing

- `bunx vitest run test/docker-preflight.test.ts` → 14 passing.
- `bun run typecheck` and `bun run build` green (also via the pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EsBX4MrzgXp37d6vKD9CCM)_