### PR TITLE
Enable the assets library for HQ so the CEO can produce and link files

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -199,6 +199,16 @@ project.
 - **Coach** — reviews completed tickets across **every** project to improve agent system
   prompts; woken on any task completion.
 
+HQ also exposes the standard **assets library** — the one internal-project surface that
+isn't hidden in the UI (Budget/Settings still are). Files the CEO produces for the operator
+in the live chat (a quick mockup, demo, or export) are saved via `write_project_asset` and
+linked back as `assets/<filename>`, so they are durable and openable over a signed URL rather
+than stranded as loose files in the container's `/workspace`. The CEO scopes such a
+deliverable (and any `write_project_doc` markdown) to **the project the work belongs to**,
+falling back to HQ only for work tied to no project; HQ's chat memory (`chat-memory.md`) also
+carries a rough running summary of those off-project conversations, since they live nowhere
+else once the chat window scrolls.
+
 **Project teams** are provisioned from a team-type template (default **Blank** = Captain
 only; `software-development` = Captain + 9 worker roles). Templates never include the
 CEO/Coach. The roster prose lives in `agents/<template>/`, the instance roles in

--- a/agents/_instance/ceo.md
+++ b/agents/_instance/ceo.md
@@ -29,6 +29,8 @@ In the live chat box you are talking to a human, so write for a human: refer to 
 
 Default to **trackable work** for anything beyond a quick answer: when the effort is non-trivial, prefer creating a ticket (in HQ or the relevant project) or a project over a long inline reply, so progress is visible and resumable.
 
+When you do produce a file for the operator yourself — a quick HTML demo or mockup, an SVG diagram, a plain-text export — rather than routing the work to a team, save it to a project's **assets library** with `write_project_asset` and share it as `assets/<filename>`. Save it to **the project the work belongs to**: if it's for a specific project, use that project's slug (likewise for any markdown you write with `write_project_doc`); reserve **hq** for work tied to no project (ad-hoc research, a one-off demo, instance-level help). Never leave it as a loose file in the workspace (e.g. `/workspace/demo.html`): that path is inside the agent container, so the operator can't open it. The assets library is the only durable, operator-reachable home for files you produce.
+
 ## Helping with Hezo itself
 
 You are the operator's guide to Hezo. Help them understand and set up their instance — projects and teams, agents and roles, AI providers and credentials, connections and integrations — and explain how Hezo's features and APIs/MCP tools work. Walk them through configuration when asked, and use your tools to action setup steps where you can.

--- a/docs/concepts/assets.md
+++ b/docs/concepts/assets.md
@@ -28,6 +28,13 @@ place so references stay stable.
 Anywhere you write text in Hezo — a task, a comment, a document — you can point at an asset
 by writing `assets/<filename>` (for example `assets/login-mockup.png`).
 
+This is also how the **CEO** hands you files from the chat. When you ask the CEO to whip
+something up — a quick mockup, a diagram, a one-off HTML page — it saves the result to an
+assets library and links it back as `assets/<filename>`, so you can open it straight from the
+conversation rather than hunting for a file on a server you can't reach. The CEO files the
+deliverable with whichever **project** the conversation is about, falling back to HQ only when
+the work isn't tied to a project at all.
+
 ## HTML previews
 
 Assets aren't just stored — they're **previewable**. When an agent produces an HTML

--- a/packages/server/src/services/ceo-session-manager.ts
+++ b/packages/server/src/services/ceo-session-manager.ts
@@ -63,9 +63,18 @@ Your context carries a **Chatbox memory** block (below the guide, above the conv
 Use it for **durable, standing knowledge only**:
 
 - **Record:** operator preferences and guidelines (how they like things done, tone, defaults, recurring decisions), and **anything the operator explicitly asks you to remember** — record that regardless of what it is.
+- **Summarize off-project conversations:** keep a short running summary of any substantial thread that isn't tied to a Hezo project — ad-hoc research, advice, a one-off thing you built for the operator (e.g. "explored 3D engines for a browser game, recommended Babylon.js, built a demo at assets/babylon-demo.html"). Unlike project state, these chats are stored nowhere else, so once the messages scroll out of the window they are lost unless the gist is captured here. Update the summary as such a thread develops, and keep it rough — a line or two per topic, not a transcript.
 - **Do NOT record:** live data you can already fetch each turn — project/ticket/comment contents or status, rosters, counts, or any metadata about them. That is rebuilt into your context from the live database every turn; copying it into memory only goes stale. The roster and the tools are the source of truth for state, not this memory.
 
-When something belongs in memory, update it by **rewriting the whole document via \`write_project_doc\` (project: hq, filename: chat-memory.md)** — read the current memory block, merge the new fact in, and write the full result back. Do not blindly append; keep it short, curated, and free of stale entries. There is no separate "remember" tool — \`write_project_doc\` is how you maintain it.`;
+When something belongs in memory, update it by **rewriting the whole document via \`write_project_doc\` (project: hq, filename: chat-memory.md)** — read the current memory block, merge the new fact in, and write the full result back. Do not blindly append; keep it short, curated, and free of stale entries. There is no separate "remember" tool — \`write_project_doc\` is how you maintain it.
+
+## Producing files for the operator
+
+When the operator asks you to produce a file directly in this chat — an HTML demo or mockup, an SVG diagram, a plain-text export — save it to an **assets library** with \`write_project_asset\`, then reference it **bare** as \`assets/<filename>\` in your reply so it renders as a link the operator can open (HTML opens interactively in a new tab). The library takes text-based files (.html, .svg, .txt); re-saving the same filename overwrites it, so the reference stays stable as you iterate.
+
+**Save it to the project the work belongs to.** If the conversation is about a specific project — or you're doing something for one — pass that project's slug, so the deliverable lives with its project (the same goes for any markdown you write with \`write_project_doc\`). Only when the work is **not** tied to any project — ad-hoc research, a one-off demo, instance-level help — save it to **hq** (project: hq). When unsure which project something belongs to, ask the operator rather than defaulting to hq.
+
+Do **NOT** write the file loose into the workspace (e.g. \`/workspace/demo.html\`) and hand the operator that path — \`/workspace\` lives inside the agent container, not on their machine, so they cannot open it and the file is invisible to them. The asset library is the only durable, operator-reachable home for files you produce here. For a binary deliverable the library can't author (a generated image or PDF), say so rather than pointing at a container path.`;
 
 /**
  * Render the persistent chatbox-memory data block injected into every turn. The

--- a/packages/server/test/ceo-session.test.ts
+++ b/packages/server/test/ceo-session.test.ts
@@ -225,6 +225,27 @@ describe('CeoSessionManager', () => {
 		await manager.stop();
 	});
 
+	test('the chat prompt steers file production, project scoping and off-project memory', async () => {
+		const chat = makeChatDocker(ctx.dataDir, projectId);
+		const { manager } = makeManager(ctx, chat.docker);
+
+		await manager.sendTurn({ text: 'whip up a quick demo for me' });
+		await poll(async () => chat.prompts.length >= 1);
+
+		const prompt = chat.prompts[0];
+		// Persist operator-facing deliverables to an assets library and link them,
+		// instead of dropping a loose /workspace file the operator can't reach.
+		expect(prompt).toContain('write_project_asset');
+		expect(prompt).toContain('assets/<filename>');
+		// Scope the deliverable to the relevant project, not HQ by default.
+		expect(prompt).toContain('the project the work belongs to');
+		// Off-project conversations get a rough summary in chat memory (they live
+		// nowhere else once the window scrolls).
+		expect(prompt).toContain('Summarize off-project conversations');
+
+		await manager.stop();
+	});
+
 	test('a new message interrupts the in-flight reply', async () => {
 		const chat = makeChatDocker(ctx.dataDir, projectId);
 		chat.scenario.mode = 'block';

--- a/packages/web/src/components/project-sidebar.tsx
+++ b/packages/web/src/components/project-sidebar.tsx
@@ -69,21 +69,19 @@ export function ProjectSidebar() {
 			count: project?.open_task_count,
 			testId: 'project-sidebar-tasks',
 		},
-		// HQ (internal) exposes Documents for the chatbox memory doc, but not Assets.
+		// HQ (internal) exposes Documents (the chatbox memory doc) and Assets (where
+		// the CEO saves files it produces for the operator in chat); Budget and
+		// Settings stay hidden below.
 		{
 			to: '/projects/$projectId/documents',
 			params: projectParams,
 			label: 'Documents',
 		},
-		...(isInternal
-			? []
-			: [
-					{
-						to: '/projects/$projectId/assets',
-						params: projectParams,
-						label: 'Assets',
-					},
-				]),
+		{
+			to: '/projects/$projectId/assets',
+			params: projectParams,
+			label: 'Assets',
+		},
 		{
 			to: '/projects/$projectId/container',
 			params: projectParams,

--- a/packages/web/src/routes/projects/$projectId/assets.tsx
+++ b/packages/web/src/routes/projects/$projectId/assets.tsx
@@ -1,5 +1,4 @@
-import { HQ_PROJECT_SLUG } from '@hezo/shared';
-import { createFileRoute, redirect } from '@tanstack/react-router';
+import { createFileRoute } from '@tanstack/react-router';
 import {
 	Code,
 	ExternalLink,
@@ -328,14 +327,8 @@ export const Route = createFileRoute('/projects/$projectId/assets')({
 	validateSearch: (search: Record<string, unknown>): AssetsSearch => ({
 		file: typeof search.file === 'string' ? search.file : undefined,
 	}),
-	beforeLoad: ({ params }) => {
-		if (params.projectId === HQ_PROJECT_SLUG) {
-			throw redirect({
-				to: '/projects/$projectId/tasks',
-				params,
-				replace: true,
-			});
-		}
-	},
+	// HQ (the internal coordination project) exposes Assets too: it's where the
+	// CEO saves files it produces for the operator in chat (write_project_asset),
+	// so `assets/<filename>` references in the chat resolve to a real page.
 	component: ProjectAssetsPage,
 });

--- a/packages/web/test/internal-project.test.tsx
+++ b/packages/web/test/internal-project.test.tsx
@@ -1,15 +1,16 @@
 import { HQ_PROJECT_SLUG } from '@hezo/shared';
 import { waitFor } from '@testing-library/react';
 import { expect, test } from 'vitest';
-import { renderApp } from './helpers/render';
+import { getTestContext, renderApp } from './helpers/render';
 import { seedWorkspace } from './helpers/seed';
 
 // HQ is the only internal project: the instance-wide coordination project that
 // hosts the CEO and Coach. Its slug is HQ_PROJECT_SLUG and `is_internal` is
-// true, so it gets the restricted sidebar (no Assets, no Settings) and the
-// coordination info tooltip beside its name. It DOES expose Documents — that's
-// where the chatbox memory (chat-memory.md) is viewed/edited — and the settings
-// route still redirects to tasks.
+// true, so it gets the restricted sidebar (no Budget, no Settings) and the
+// coordination info tooltip beside its name. It DOES expose Documents — where
+// the chatbox memory (chat-memory.md) is viewed/edited — and Assets — where the
+// CEO saves files it produces for the operator in chat. The settings route
+// still redirects to tasks.
 
 test('HQ task list does not show the project progress bar', async () => {
 	const { findAllByRole, queryByTestId, router } = await renderApp({
@@ -30,7 +31,7 @@ test('HQ task list does not show the project progress bar', async () => {
 	expect(queryByTestId('project-task-list-phase-banner-planning')).toBeNull();
 });
 
-test('sidebar exposes Tasks, Documents and Container for the HQ project (not Assets/Settings)', async () => {
+test('sidebar exposes Tasks, Documents, Assets and Container for the HQ project (not Settings)', async () => {
 	const { findAllByRole, queryAllByRole, container, router } = await renderApp({
 		initialPath: '/',
 		seed: async () => {
@@ -51,16 +52,14 @@ test('sidebar exposes Tasks, Documents and Container for the HQ project (not Ass
 	const tasksLinks = queryAllByRole('link', { name: 'Tasks' });
 	expect(tasksLinks.length).toBeGreaterThan(0);
 
-	// Documents is exposed for HQ (the chatbox memory lives here); Assets is not.
+	// Documents (chatbox memory) and Assets (CEO-produced files) are both exposed
+	// for HQ. `is_internal` arrives with the project-meta query, so the link must
+	// remain present once the restricted HQ nav settles — wait for that rather
+	// than reading synchronously.
 	await waitFor(() =>
 		expect(queryAllByRole('link', { name: 'Documents' }).length).toBeGreaterThan(0),
 	);
-	// `is_internal` arrives with the project-meta query; until it resolves the
-	// generic nav (with Assets + a project Settings link) renders, then the
-	// restricted HQ nav swaps in. Wait for that to settle rather than snapshotting
-	// synchronously — otherwise a slow meta query (e.g. a loaded CI shard) catches
-	// the transient generic nav and sees an Assets link.
-	await waitFor(() => expect(queryAllByRole('link', { name: 'Assets' }).length).toBe(0));
+	await waitFor(() => expect(queryAllByRole('link', { name: 'Assets' }).length).toBeGreaterThan(0));
 
 	// No settings link pointing at the HQ project.
 	const settingsLinks = queryAllByRole('link', { name: 'Settings' });
@@ -96,7 +95,7 @@ test('coordination info tooltip sits beside the HQ name', async () => {
 	);
 });
 
-test('HQ /documents renders (chatbox memory) while /settings still redirects to /tasks', async () => {
+test('HQ /documents and /assets render while /settings still redirects to /tasks', async () => {
 	const { router } = await renderApp({
 		initialPath: '/',
 		seed: async () => {
@@ -112,6 +111,15 @@ test('HQ /documents renders (chatbox memory) while /settings still redirects to 
 	await new Promise((r) => setTimeout(r, 200));
 	expect(router.state.location.pathname).toBe(`/projects/${HQ_PROJECT_SLUG}/documents`);
 
+	// Assets is a real page for HQ too — the CEO saves operator-facing files here,
+	// so the route no longer redirects away.
+	await router.navigate({
+		to: '/projects/$projectId/assets',
+		params: { projectId: HQ_PROJECT_SLUG },
+	});
+	await new Promise((r) => setTimeout(r, 200));
+	expect(router.state.location.pathname).toBe(`/projects/${HQ_PROJECT_SLUG}/assets`);
+
 	// Settings still redirects to tasks.
 	await router.navigate({
 		to: '/projects/$projectId/settings',
@@ -119,4 +127,38 @@ test('HQ /documents renders (chatbox memory) while /settings still redirects to 
 	});
 	await new Promise((r) => setTimeout(r, 200));
 	expect(router.state.location.pathname).toBe(`/projects/${HQ_PROJECT_SLUG}/tasks`);
+});
+
+test('the HQ assets library lists a file the CEO saved there', async () => {
+	const { findByText, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			await seedWorkspace();
+			// Mirror what the CEO does in chat via write_project_asset for off-project
+			// work: the deliverable lands in HQ's assets library. (Plain text so the
+			// card renders an icon rather than an HTML-preview iframe that would fetch
+			// the signed URL and abort on teardown.)
+			const { apiBase, token } = getTestContext();
+			const fd = new FormData();
+			fd.set(
+				'file',
+				new File(['Recommended Babylon.js for the browser game.'], 'engine-research.txt', {
+					type: 'text/plain',
+				}),
+			);
+			const res = await apiBase(`/api/projects/${HQ_PROJECT_SLUG}/assets`, {
+				method: 'POST',
+				headers: { Authorization: `Bearer ${token}` },
+				body: fd,
+			});
+			if (!res.ok) throw new Error(`HQ asset upload failed: ${res.status}`);
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/assets',
+		params: { projectId: HQ_PROJECT_SLUG },
+	});
+
+	await findByText('engine-research.txt');
 });


### PR DESCRIPTION
## Problem

The CEO runs inside the HQ container. When the operator asked it to "whip up a demo" in the live chat, it wrote a loose file to `/workspace/<name>.html` — a path **inside the agent container** the operator can't reach — and then pointed them at that path. The deliverable was effectively lost (no DB row, no URL, invisible to the operator).

The asset library already supports this end-to-end on the server (project-scoped storage on disk, HMAC-signed URLs, `assets/<filename>` references that render as links in chat, and the `write_project_asset` MCP tool). But the **HQ project was deliberately excluded from Assets in the web UI** in two places, so even a correctly-saved asset had nowhere to land or be opened:

- `/projects/hq/assets` redirected away to tasks.
- The sidebar omitted the **Assets** nav for internal projects.

## Changes

**Web — enable HQ Assets**
- Drop the HQ redirect on the assets route; show the **Assets** nav item for HQ (Budget/Settings stay hidden). `assets/<filename>` links from the CEO chat now resolve to a real page.

**CEO guidance — produce into the right library, link it**
- Live-chat guide + role doc now steer the CEO to persist operator-facing deliverables via `write_project_asset` and reference them as `assets/<filename>`, **never** as a loose `/workspace` path.
- **Project-scoping:** save the deliverable (and any `write_project_doc` markdown) to **the project the work belongs to**; reserve **HQ** only for work tied to no project (ad-hoc research, one-off demos, instance-level help). The CEO chat token is already cross-project, so this needed only guidance, no auth change.

**CEO chat memory — don't lose off-project threads**
- The CEO now keeps a rough running summary of conversations that aren't tied to any Hezo project (research, one-off builds) in `chat-memory.md`, since those live nowhere else once the chat window scrolls.

**Docs + architecture** updated to match. No MCP tool / REST route / response-shape changes, so the agent-facing reference surfaces (SKILL.md, llms.txt, docs/reference) are untouched.

## Tests
- `internal-project.test.tsx`: HQ exposes the Assets nav, `/projects/hq/assets` renders (no redirect), and a file the CEO saved to HQ lists on the page.
- `ceo-session.test.ts`: the composed chat prompt carries the production / project-scoping / off-project-memory guidance.
- Existing `project-assets` and `project-sidebar` suites still pass; run logs stay quiet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PxBHYZxHeMXuMWa3eRkvK2

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxBHYZxHeMXuMWa3eRkvK2)_