### PR TITLE
feat(mcp): warn agents who address a teammate by bold/bare name

### DIFF
--- a/packages/server/src/lib/mentions.ts
+++ b/packages/server/src/lib/mentions.ts
@@ -1,6 +1,9 @@
 const MENTION_RE = /(?<![\w@])@([a-z0-9][\w-]*)/gi;
 const FENCED_CODE_RE = /(?:^|\n)(?:```|~~~)[^\n]*\n[\s\S]*?(?:```|~~~)(?=\n|$)/g;
 const INLINE_CODE_RE = /`[^`]*`/g;
+// Captures a slug behind one or two leading @ — i.e. both active (@slug) and
+// passive (@@slug) references, so a deliberately-linked name is never flagged.
+const LINKED_MENTION_RE = /(?<![\w@])@@?([a-z0-9][\w-]*)/gi;
 
 export function extractMentionSlugs(content: unknown): string[] {
 	const text = flattenTextFields(content);
@@ -14,6 +17,46 @@ export function extractMentionSlugs(content: unknown): string[] {
 		match = MENTION_RE.exec(stripped);
 	}
 	return Array.from(slugs);
+}
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Flags teammate slugs that are addressed in the comment by bold or bare name
+ * rather than a mention prefix, so nothing notifies the named teammate. Detects
+ * the two unambiguous addressing forms — an emphasised name (`**slug**` /
+ * `__slug__`) and a leading-line address (`slug —` / `slug:`) — while leaving
+ * ordinary prose references untouched. A name already carrying an `@` or `@@`
+ * prefix is deliberate and never flagged.
+ */
+export function detectUnlinkedTeammateReferences(content: unknown, knownSlugs: string[]): string[] {
+	const text = flattenTextFields(content);
+	if (!text) return [];
+	const stripped = text.replace(FENCED_CODE_RE, ' ').replace(INLINE_CODE_RE, ' ');
+
+	const linked = new Set<string>();
+	LINKED_MENTION_RE.lastIndex = 0;
+	let linkedMatch = LINKED_MENTION_RE.exec(stripped);
+	while (linkedMatch !== null) {
+		linked.add(linkedMatch[1].toLowerCase());
+		linkedMatch = LINKED_MENTION_RE.exec(stripped);
+	}
+
+	const flagged = new Set<string>();
+	for (const rawSlug of knownSlugs) {
+		const slug = rawSlug.toLowerCase();
+		if (linked.has(slug)) continue;
+		const s = escapeRegExp(slug);
+		// Emphasised name: **slug** or __slug__, not already @-prefixed.
+		const bold = new RegExp(String.raw`(?<!@)(\*\*|__)${s}\1`, 'i');
+		// Leading-line address: start of a line, the bare name, an addressing
+		// separator (em/en dash, hyphen, colon, comma), then whitespace or EOL.
+		const lead = new RegExp(String.raw`(?:^|\n)\s*${s}\s*[—–\-:,](?:\s|$)`, 'i');
+		if (bold.test(stripped) || lead.test(stripped)) flagged.add(slug);
+	}
+	return Array.from(flagged);
 }
 
 function flattenTextFields(value: unknown): string {

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -2,6 +2,7 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import type { PGlite } from '@electric-sql/pglite';
 import type { SearchScope } from '@hezo/shared';
 import {
+	ADMIN_MENTION_SLUG,
 	ApprovalStatus,
 	ApprovalType,
 	ATTACHMENT_EXTENSIONS,
@@ -14,6 +15,7 @@ import {
 	CredentialInputType,
 	CredentialKind,
 	credentialKindRequiresAllowedHosts,
+	DEFAULT_TEAM_ID,
 	DocumentType,
 	extensionOf,
 	getConnectorCapability,
@@ -44,6 +46,7 @@ import {
 	wakeIfReady,
 	wouldCreateCycle,
 } from '../lib/dependencies';
+import { detectUnlinkedTeammateReferences } from '../lib/mentions';
 import {
 	actorTypeFromAuth,
 	connectedAgentIdFromAuth,
@@ -143,6 +146,37 @@ const MCP_WRITE_TOOLS: ReadonlySet<string> = new Set([
 /** A handler result that signals failure rather than a persisted write. */
 function isErrorResult(result: unknown): boolean {
 	return typeof result === 'object' && result !== null && 'error' in result;
+}
+
+/**
+ * Returns a warning string when a comment addresses a teammate by bold/bare name
+ * instead of a mention, or null when nothing is amiss. The author's own slug is
+ * excluded so a self-reference never warns; resolution mirrors the mention-wakeup
+ * scoping (the task's team plus the HQ instance agents) and includes @admin.
+ */
+async function buildUnlinkedMentionWarning(
+	db: PGlite,
+	teamId: string,
+	authorMemberId: string,
+	content: string,
+): Promise<string | null> {
+	const roster = await db.query<{ slug: string }>(
+		`SELECT ma.slug FROM member_agents ma
+		 JOIN members m ON m.id = ma.id
+		 WHERE (m.team_id = $1 OR m.team_id = $2) AND ma.id <> $3`,
+		[teamId, DEFAULT_TEAM_ID, authorMemberId],
+	);
+	const knownSlugs = [...roster.rows.map((r) => r.slug), ADMIN_MENTION_SLUG];
+	const offenders = detectUnlinkedTeammateReferences(content, knownSlugs);
+	if (offenders.length === 0) return null;
+	const named = offenders.map((s) => `**${s}**`).join(', ');
+	const fixes = offenders.map((s) => `@${s}`).join(', ');
+	return (
+		`You referenced teammate(s) ${named} by bold/plain name — that renders as text ` +
+		`and notifies no one, so no wakeup was created. If you need them to act on this ` +
+		`ticket, post a follow-up using an active mention (${fixes}); if you were only ` +
+		`referring to them, use the passive form (@@${offenders[0]}).`
+	);
 }
 
 /** Flag an agent run as having produced output. Idempotent and self-contained. */
@@ -1605,6 +1639,22 @@ export function registerTools(
 					wsManager,
 				).catch((e) => log.error('Failed to record task links from comment:', e)),
 			);
+			// An agent that addresses a teammate by bold/bare name (no @ prefix)
+			// notifies no one and the handoff silently stalls. Best-effort warn the
+			// author so they can re-post with the proper mention; never block the
+			// already-persisted comment on this check.
+			if (authorMemberId) {
+				const warning = await buildUnlinkedMentionWarning(
+					db,
+					teamId,
+					authorMemberId,
+					args.content as string,
+				).catch((e) => {
+					log.error('Failed to check comment for unlinked teammate references:', e);
+					return null;
+				});
+				if (warning) return { ...r.rows[0], warning };
+			}
 			return r.rows[0];
 		},
 		db,

--- a/packages/server/test/unlinked-mention-warning.test.ts
+++ b/packages/server/test/unlinked-mention-warning.test.ts
@@ -1,0 +1,189 @@
+import type { PGlite } from '@electric-sql/pglite';
+import { WakeupSource } from '@hezo/shared';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import type { MasterKeyManager } from '../src/crypto/master-key';
+import { detectUnlinkedTeammateReferences } from '../src/lib/mentions';
+import type { Env } from '../src/lib/types';
+import { safeClose } from './helpers';
+import {
+	authHeader,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+	mintAgentToken,
+} from './helpers/app';
+
+describe('detectUnlinkedTeammateReferences', () => {
+	const slugs = ['architect', 'qa-engineer', 'engineer', 'admin'];
+
+	it('flags a teammate addressed by bold name (the stalled-handoff case)', () => {
+		expect(
+			detectUnlinkedTeammateReferences('**architect** — my plan review is complete.', slugs),
+		).toEqual(['architect']);
+	});
+
+	it('flags a teammate addressed by a leading bare name', () => {
+		expect(detectUnlinkedTeammateReferences('architect: please review this.', slugs)).toEqual([
+			'architect',
+		]);
+	});
+
+	it('does not flag an active @mention', () => {
+		expect(detectUnlinkedTeammateReferences('@architect — please consolidate.', slugs)).toEqual([]);
+	});
+
+	it('does not flag a passive @@mention', () => {
+		expect(detectUnlinkedTeammateReferences('@@architect handled the review.', slugs)).toEqual([]);
+	});
+
+	it('does not flag an ordinary mid-prose reference', () => {
+		expect(
+			detectUnlinkedTeammateReferences('I think the architect decided to refactor.', slugs),
+		).toEqual([]);
+	});
+
+	it('ignores names inside inline code and fenced blocks', () => {
+		expect(detectUnlinkedTeammateReferences('inert: `**architect**` here', slugs)).toEqual([]);
+		expect(detectUnlinkedTeammateReferences('```\n**architect** — go\n```', slugs)).toEqual([]);
+	});
+
+	it('does not flag a bold word that is not a teammate slug', () => {
+		expect(detectUnlinkedTeammateReferences('**database** — migrate it', slugs)).toEqual([]);
+	});
+
+	it('flags @admin addressed by bold name', () => {
+		expect(detectUnlinkedTeammateReferences('**admin** — please approve.', slugs)).toEqual([
+			'admin',
+		]);
+	});
+});
+
+describe('MCP create_comment warns on unlinked teammate references', () => {
+	let app: Hono<Env>;
+	let db: PGlite;
+	let token: string;
+	let masterKeyManager: MasterKeyManager;
+
+	let teamId: string;
+	let projectId: string;
+	let architectId: string;
+	let captainId: string;
+	let productLeadId: string;
+
+	async function insertTask(assigneeId: string, title: string): Promise<string> {
+		const meta = await db.query<{ task_prefix: string; number: number }>(
+			`SELECT p.task_prefix, next_project_task_number(p.id) AS number
+			 FROM projects p WHERE p.id = $1`,
+			[projectId],
+		);
+		const n = meta.rows[0].number;
+		const res = await db.query<{ id: string }>(
+			`INSERT INTO tasks (team_id, project_id, assignee_id, number, identifier, title, status, priority, labels)
+			 VALUES ($1, $2, $3, $4, $5, $6, 'backlog'::task_status, 'medium'::task_priority, '[]'::jsonb)
+			 RETURNING id`,
+			[teamId, projectId, assigneeId, n, `${meta.rows[0].task_prefix}-${n}`, title],
+		);
+		return res.rows[0].id;
+	}
+
+	async function postComment(
+		authorAgentId: string,
+		taskId: string,
+		content: string,
+	): Promise<{ id: string; warning?: string }> {
+		const { token: agentToken } = await mintAgentToken(
+			db,
+			masterKeyManager,
+			authorAgentId,
+			teamId,
+			taskId,
+		);
+		const res = await app.request('/mcp', {
+			method: 'POST',
+			headers: { ...authHeader(agentToken), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				jsonrpc: '2.0',
+				method: 'tools/call',
+				params: {
+					name: 'create_comment',
+					arguments: { project: projectId, task_id: taskId, content },
+				},
+				id: 1,
+			}),
+		});
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			result: { content: Array<{ type: string; text: string }> };
+		};
+		return JSON.parse(body.result.content[0].text) as { id: string; warning?: string };
+	}
+
+	async function mentionWakeupExists(commentId: string, memberId: string): Promise<boolean> {
+		const res = await db.query(
+			`SELECT 1 FROM agent_wakeup_requests
+			 WHERE payload->>'comment_id' = $1 AND member_id = $2 AND source = $3::wakeup_source`,
+			[commentId, memberId, WakeupSource.Mention],
+		);
+		return res.rows.length > 0;
+	}
+
+	beforeAll(async () => {
+		const ctx = await createTestApp();
+		app = ctx.app;
+		db = ctx.db;
+		token = ctx.token;
+		masterKeyManager = ctx.masterKeyManager;
+
+		const typesRes = await app.request('/api/team-templates', { headers: authHeader(token) });
+		const typeId = (await typesRes.json()).data.find(
+			(t: Record<string, unknown>) => t.name === 'Startup',
+		).id;
+
+		const teamRes = await createTestTeam(db, { name: 'Warn Co', template_id: typeId });
+		teamId = (await teamRes.json()).data.id;
+
+		const setupSlug = (await (await createTestProject(db, teamId, { name: 'Setup' })).json()).data
+			.slug;
+		const agentsRes = await app.request(`/api/projects/${setupSlug}/agents`, {
+			headers: authHeader(token),
+		});
+		const agents = (await agentsRes.json()).data as Array<{ id: string; slug: string }>;
+		captainId = agents.find((a) => a.slug === 'captain')!.id;
+		architectId = agents.find((a) => a.slug === 'architect')!.id;
+		productLeadId = agents.find((a) => a.slug === 'product-lead')!.id;
+
+		const projectData = (await (await createTestProject(db, teamId, { name: 'Project' })).json())
+			.data;
+		projectId = projectData.id;
+	});
+
+	afterAll(async () => {
+		await safeClose(db);
+	});
+
+	beforeEach(async () => {
+		await db.query('DELETE FROM agent_wakeup_requests');
+	});
+
+	it('warns and wakes no one when a teammate is addressed in bold', async () => {
+		const taskId = await insertTask(captainId, 'Bold handoff');
+		const result = await postComment(productLeadId, taskId, '**architect** — review done');
+		expect(result.warning).toBeDefined();
+		expect(result.warning).toContain('architect');
+		expect(await mentionWakeupExists(result.id, architectId)).toBe(false);
+	});
+
+	it('does not warn and wakes the teammate on a real @mention', async () => {
+		const taskId = await insertTask(captainId, 'Active handoff');
+		const result = await postComment(productLeadId, taskId, '@architect — review done');
+		expect(result.warning).toBeUndefined();
+		expect(await mentionWakeupExists(result.id, architectId)).toBe(true);
+	});
+
+	it('does not warn on a self-reference in bold', async () => {
+		const taskId = await insertTask(architectId, 'Architect own ticket');
+		const result = await postComment(architectId, taskId, '**architect** notes to self');
+		expect(result.warning).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Problem

An agent that writes a teammate's name in **bold** or plain text (e.g. `**architect** — review done`) instead of an active `@architect` mention notifies no one. Only an `@`-prefixed slug fires a `WakeupSource.Mention` wakeup, so a bold/bare name renders as inert text and the handoff **silently stalls** — exactly what happened on a live run where the qa-engineer's "ready for consolidation" plan-review never woke the architect.

The prompt guidance already covers this (`qa-engineer.md:38`, plus the exact `**<slug>**` anti-example in `SHARED_INSTRUCTIONS`) but was ignored, so this adds a deterministic safety net rather than more prose.

## Change

- **`packages/server/src/lib/mentions.ts`** — new pure `detectUnlinkedTeammateReferences(content, knownSlugs)`. After stripping code spans/fences, flags a known teammate slug addressed by **bold** (`**slug**`/`__slug__`) or **leading-line address** (`slug —`/`slug:`) without an `@`/`@@` prefix. Ordinary mid-prose references are left alone.
- **`packages/server/src/mcp/tools.ts`** — in the agent-facing `create_comment` handler, after persisting the comment, resolve the team roster (task team ∪ HQ instance agents, plus `@admin`, excluding the author's own slug) and run the detector. On a hit, return a non-blocking `warning` string in the tool response so the author can re-post with the proper mention. The check fails open and never blocks the already-persisted comment. MCP-only — humans post via the editor with mention autocomplete and don't read the JSON response.

## Tests

`packages/server/test/unlinked-mention-warning.test.ts` — 8 pure-detector cases (bold handoff, leading address, `@`/`@@` not flagged, mid-prose not flagged, code-stripped, non-slug bold, `@admin`) + 3 MCP integration cases (bold → warning + no wakeup; `@architect` → no warning + wakeup fires; self-reference → no warning).

- New test: 11/11 pass.
- No regression: `comment-wakeups`, `comments`, `mcp-tools` → 119/119 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)