### PR TITLE
feat(web): open asset mentions in a new tab instead of the preview panel

### DIFF
--- a/packages/web/src/components/comment-renderers/run-comment.tsx
+++ b/packages/web/src/components/comment-renderers/run-comment.tsx
@@ -337,7 +337,6 @@ function RunCommentBody({
 								type="button"
 								onClick={() =>
 									openPreview({
-										kind: 'doc',
 										projectId: doc.project_slug,
 										projectSlug: doc.project_slug,
 										filename: doc.filename,

--- a/packages/web/src/components/markdown-prose.tsx
+++ b/packages/web/src/components/markdown-prose.tsx
@@ -67,8 +67,8 @@ export function MarkdownProse({
 	);
 	const { data: resolvedDocs } = useDocMentions(projectId ?? '', docCandidates);
 	const { data: instanceResolved } = useInstanceMentions(children, instance === true && !projectId);
-	// When the surface hosts a preview panel (task detail), doc/asset mentions open
-	// in it; otherwise they keep their new-tab links.
+	// When the surface hosts a preview panel (task detail), doc mentions open in it;
+	// asset mentions always open in a new tab regardless of surface.
 	const openPreview = useOpenPreview();
 
 	const agentsMap = useMemo<Map<string, AgentMentionData>>(() => {
@@ -127,7 +127,6 @@ export function MarkdownProse({
 		for (const a of source) {
 			m.set(a.filename, {
 				id: a.id,
-				contentType: a.content_type,
 				signedUrl: a.signed_url,
 				projectSlug: a.project_slug,
 			});
@@ -201,7 +200,6 @@ export function MarkdownProse({
 					'data-mention-doc-filename'?: string;
 					'data-mention-asset-project-slug'?: string;
 					'data-mention-asset-filename'?: string;
-					'data-mention-asset-content-type'?: string;
 					'data-mention-asset-url'?: string;
 					'data-mention-size'?: string;
 					'data-mention-updated-at'?: string;
@@ -246,7 +244,6 @@ export function MarkdownProse({
 								testId="doc-mention-link"
 								onClick={() =>
 									openPreview({
-										kind: 'doc',
 										projectId: docProject,
 										projectSlug: docProject,
 										filename: docFilename,
@@ -276,27 +273,6 @@ export function MarkdownProse({
 				const assetFilename = attrs['data-mention-asset-filename'];
 				const assetUrl = attrs['data-mention-asset-url'];
 				if (assetProject && assetFilename && mentionsEnabled) {
-					if (openPreview) {
-						return (
-							<PreviewMentionButton
-								testId="asset-mention-link"
-								onClick={() =>
-									openPreview({
-										kind: 'asset',
-										projectId: assetProject,
-										projectSlug: assetProject,
-										filename: assetFilename,
-										contentType: attrs['data-mention-asset-content-type'],
-										url: assetUrl,
-										size: Number(attrs['data-mention-size'] ?? 0) || undefined,
-										updatedAt: attrs['data-mention-updated-at'] || undefined,
-									})
-								}
-							>
-								{props.children}
-							</PreviewMentionButton>
-						);
-					}
 					if (assetUrl) {
 						return (
 							<DedicatedViewMention
@@ -471,9 +447,9 @@ function DedicatedViewMention({
 }
 
 /**
- * A doc/asset mention that opens in the in-page preview panel rather than a new
- * tab. No trailing external-link icon — the new-tab affordance lives on the panel
- * itself. Used only when a surface provides the preview context.
+ * A doc mention that opens in the in-page preview panel rather than a new tab. No
+ * trailing external-link icon — the new-tab affordance lives on the panel itself.
+ * Used only when a surface provides the preview context.
  */
 function PreviewMentionButton({
 	onClick,

--- a/packages/web/src/components/task-detail/preview-context.tsx
+++ b/packages/web/src/components/task-detail/preview-context.tsx
@@ -1,16 +1,11 @@
 import { createContext, useContext } from 'react';
 
-/** A document or asset that can be shown in the task-detail preview panel. */
+/** A document that can be shown in the task-detail preview panel. */
 export interface PreviewItem {
-	kind: 'doc' | 'asset';
 	/** Project slug (route-param form) — used for both the API path and preview URL. */
 	projectId: string;
 	projectSlug: string;
 	filename: string;
-	/** Asset only — MIME type, drives how the asset is rendered. */
-	contentType?: string;
-	/** Asset only — signed URL to fetch/display the asset and open it in a new tab. */
-	url?: string;
 	size?: number;
 	updatedAt?: string;
 }
@@ -19,10 +14,11 @@ type OpenPreview = (item: PreviewItem) => void;
 
 /**
  * Surfaces that host a preview panel (today: the task-detail page) provide an
- * opener through this context. When present, in-comment doc/asset mentions open
- * in the panel instead of a new tab; when absent (docs/assets pages, CEO chat)
- * the mentions keep their new-tab links. Defaulting to `null` is what lets the
- * same MarkdownProse render behave differently per surface without a prop drill.
+ * opener through this context. When present, in-comment doc mentions open in the
+ * panel instead of a new tab; when absent (docs page, CEO chat) they keep their
+ * new-tab links. Asset mentions always open in a new tab regardless of surface,
+ * so they never use this. Defaulting to `null` is what lets the same MarkdownProse
+ * render behave differently per surface without a prop drill.
  */
 const PreviewContext = createContext<OpenPreview | null>(null);
 

--- a/packages/web/src/components/task-detail/preview-panel.tsx
+++ b/packages/web/src/components/task-detail/preview-panel.tsx
@@ -17,16 +17,15 @@ interface PreviewPanelProps {
 }
 
 /**
- * Right-rail preview of a document or asset, opened by clicking its mention in a
- * task comment. Documents render their markdown inline; assets render by MIME
- * type (image / embeddable iframe), with a fallback for everything else. The
- * header carries an "open in new tab" affordance — the new-tab link that used to
- * sit on the mention itself moves here.
+ * Right-rail preview of a document, opened by clicking its mention in a task
+ * comment. The document's markdown renders inline. The header carries an "open in
+ * new tab" affordance — the new-tab link that used to sit on the mention itself
+ * moves here. (Asset mentions no longer open here — they link straight to a new
+ * tab.)
  */
 export function PreviewPanel({ item, onClose }: PreviewPanelProps) {
-	const isDoc = item.kind === 'doc';
-	const docQuery = useProjectDoc(item.projectId, isDoc ? item.filename : null);
-	const openUrl = isDoc ? docPreviewPath(item.projectSlug, item.filename) : (item.url ?? '');
+	const docQuery = useProjectDoc(item.projectId, item.filename);
+	const openUrl = docPreviewPath(item.projectSlug, item.filename);
 	const meta = formatBytes(item.size);
 
 	return (
@@ -42,18 +41,16 @@ export function PreviewPanel({ item, onClose }: PreviewPanelProps) {
 				>
 					{item.filename}
 				</span>
-				{openUrl && (
-					<a
-						href={openUrl}
-						target="_blank"
-						rel="noopener noreferrer"
-						className="inline-flex shrink-0 items-center gap-1 text-[11px] text-info-soft-fg hover:underline"
-						data-testid="preview-open-tab"
-					>
-						open in new tab
-						<ExternalLink className="h-3 w-3" />
-					</a>
-				)}
+				<a
+					href={openUrl}
+					target="_blank"
+					rel="noopener noreferrer"
+					className="inline-flex shrink-0 items-center gap-1 text-[11px] text-info-soft-fg hover:underline"
+					data-testid="preview-open-tab"
+				>
+					open in new tab
+					<ExternalLink className="h-3 w-3" />
+				</a>
 				<button
 					type="button"
 					onClick={onClose}
@@ -71,7 +68,7 @@ export function PreviewPanel({ item, onClose }: PreviewPanelProps) {
 				<PreviewBody
 					item={item}
 					docContent={docQuery.data?.content}
-					docLoading={isDoc && docQuery.isLoading}
+					docLoading={docQuery.isLoading}
 				/>
 			</div>
 		</aside>
@@ -87,41 +84,13 @@ function PreviewBody({
 	docContent?: string;
 	docLoading: boolean;
 }) {
-	if (item.kind === 'doc') {
-		if (docLoading) return <div className="p-3 text-[13px] text-text-3">Loading…</div>;
-		if (!docContent)
-			return <div className="p-3 text-[13px] text-text-3">No content to preview.</div>;
-		return (
-			<div className="p-3" data-testid="preview-doc-body">
-				<MarkdownProse projectId={item.projectId} projectSlug={item.projectSlug}>
-					{docContent}
-				</MarkdownProse>
-			</div>
-		);
-	}
-
-	const contentType = item.contentType ?? '';
-	if (!item.url) return <div className="p-3 text-[13px] text-text-3">No preview available.</div>;
-	if (contentType.startsWith('image/')) {
-		// biome-ignore lint/a11y/useAltText: filename is the best available description
-		return (
-			<img src={item.url} alt={item.filename} className="w-full" data-testid="preview-image" />
-		);
-	}
-	if (contentType === 'text/html' || contentType === 'application/pdf') {
-		return (
-			<iframe
-				src={item.url}
-				title={item.filename}
-				sandbox=""
-				className="h-[60vh] w-full bg-surface"
-				data-testid="preview-iframe"
-			/>
-		);
-	}
+	if (docLoading) return <div className="p-3 text-[13px] text-text-3">Loading…</div>;
+	if (!docContent) return <div className="p-3 text-[13px] text-text-3">No content to preview.</div>;
 	return (
-		<div className="p-3 text-[13px] text-text-3">
-			No inline preview for this file type — use “open in new tab”.
+		<div className="p-3" data-testid="preview-doc-body">
+			<MarkdownProse projectId={item.projectId} projectSlug={item.projectSlug}>
+				{docContent}
+			</MarkdownProse>
 		</div>
 	);
 }

--- a/packages/web/src/lib/remark-mentions.ts
+++ b/packages/web/src/lib/remark-mentions.ts
@@ -64,7 +64,6 @@ export type ProjectDocsMap = Map<string, Map<string, ProjectDocMentionData>>;
 
 export interface AssetMentionData {
 	id: string;
-	contentType: string;
 	signedUrl: string;
 	/** Set in instance scope: the project the asset belongs to. */
 	projectSlug?: string;
@@ -162,7 +161,6 @@ function buildLink(token: MentionToken, opts: Options): LinkNode | null {
 				hProperties: {
 					'data-mention-asset-project-slug': slug,
 					'data-mention-asset-filename': token.filename,
-					'data-mention-asset-content-type': data.contentType,
 					'data-mention-asset-url': data.signedUrl,
 				},
 			},

--- a/packages/web/test/project-assets.test.tsx
+++ b/packages/web/test/project-assets.test.tsx
@@ -51,9 +51,9 @@ test('an asset can be deleted from the library', async () => {
 	await waitFor(() => expect(queryByText('remove-me.png')).toBeNull());
 });
 
-test('an assets/<name> reference in a task comment opens the preview panel instead of a new tab', async () => {
+test('an assets/<name> reference in a task comment opens in a new tab, not the preview panel', async () => {
 	let ctx!: { projectSlug: string; taskId: string };
-	const { container, findByTestId, user, router } = await renderApp({
+	const { container, findByTestId, router } = await renderApp({
 		initialPath: '/',
 		seed: async () => {
 			const ws = await seedWorkspace();
@@ -70,18 +70,22 @@ test('an assets/<name> reference in a task comment opens the preview panel inste
 		params: { projectId: ctx.projectSlug, taskId: ctx.taskId },
 	});
 
-	// In a task comment the asset mention is a button (opens the panel) with no
-	// trailing new-tab suffix link.
-	const link = await findByTestId('asset-mention-link', undefined, { timeout: 15_000 });
-	expect(link.tagName).toBe('BUTTON');
+	// The asset mention is an anchor that opens the signed URL in a new tab, with a
+	// trailing external-link icon — never the in-page preview panel.
+	const link = (await findByTestId('asset-mention-link', undefined, {
+		timeout: 15_000,
+	})) as HTMLAnchorElement;
+	expect(link.tagName).toBe('A');
 	expect(link.textContent).toContain('assets/login.png');
-	expect(container.querySelector('[data-testid="asset-mention-preview-link"]')).toBeNull();
+	expect(link.getAttribute('target')).toBe('_blank');
+	expect(link.getAttribute('href')).toMatch(/^\/api\/assets\/[0-9a-f-]+\?exp=\d+&sig=/);
 
-	// The panel opens and exposes the signed-URL open-in-new-tab affordance.
-	await user.click(link);
-	const openTab = (await findByTestId('preview-open-tab')) as HTMLAnchorElement;
-	expect(openTab.getAttribute('href')).toMatch(/^\/api\/assets\/[0-9a-f-]+\?exp=\d+&sig=/);
-	expect(openTab.getAttribute('target')).toBe('_blank');
+	// The trailing external-link icon points at the same signed URL.
+	const icon = (await findByTestId('asset-mention-preview-link')) as HTMLAnchorElement;
+	expect(icon.getAttribute('href')).toBe(link.getAttribute('href'));
+
+	// Assets no longer route through the in-page preview panel.
+	expect(container.querySelector('[data-testid="preview-panel"]')).toBeNull();
 });
 
 test('uploading a file through the picker adds it to the library', async () => {


### PR DESCRIPTION
## What & why

Asset mentions (`assets/<name>`) inside task comments behaved inconsistently: on the **task-detail page** they opened in the right-rail **preview panel** (replacing the metadata sidebar), but on every other surface (assets page, CEO chat) they opened in a **new tab** with a trailing external-link (↗) icon. This makes asset previews **always default to a new tab** with the icon suffix, on every surface.

Doc mentions (`prd.md`, etc.) are intentionally unchanged — they still open in the preview panel.

## Changes

- **`markdown-prose.tsx`** — drop the `openPreview` branch in the asset block so asset mentions always render via `DedicatedViewMention` (name + ↗ icon, both `target="_blank"`), falling back to the same-tab library link only when there's no signed URL. The ↗ icon comes for free from the existing component — no new icon code.
- **Preview panel is now doc-only** — removed the dead asset rendering path (image `<img>` / `text/html`+`application/pdf` `<iframe>` / fallback) from `preview-panel.tsx`, and narrowed `PreviewItem` (`preview-context.tsx`) to documents (dropped `kind`, `contentType`, `url`).
- **Removed the now-dead asset `contentType` chain** — `AssetMentionData.contentType` and the `data-mention-asset-content-type` attribute it fed (`remark-mentions.ts`), which only existed to drive the panel's MIME-based rendering.

## Testing

- Rewrote the asset-in-comment test in `project-assets.test.tsx` to assert the new-tab behavior: the mention is an `<a target="_blank">` linking to the signed asset URL, the ↗ icon points at the same URL, and **no** preview panel opens.
- Verified docs are unaffected: `task-comment-doc-preview.test.tsx` and `run-created-tasks.test.tsx` still pass (docs still open in the panel).
- Ran the mention/preview/comment web test cluster (CEO-chat mentions, remark-mentions units, task-comments, inbox-mentions) — all green.
- `bun run typecheck` clean across all packages; biome clean on the changed files (one pre-existing, unrelated `projectDocs` warning in `remark-mentions.ts` left untouched).

No `docs/` or architecture changes were needed — a repo-wide search found no reference to the old asset-opens-in-sidebar behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L4c9pWRXVmaatDQozFchkN

---
_Generated by [Claude Code](https://claude.ai/code/session_01L4c9pWRXVmaatDQozFchkN)_