### PR TITLE
docs: explain CEO, Coach, HQ and realtime CEO chat

### DIFF
--- a/docs/concepts/projects-and-teams.md
+++ b/docs/concepts/projects-and-teams.md
@@ -42,11 +42,12 @@ the other.
 
 ## HQ — the home team
 
-**HQ** is the one special, instance-wide team. It hosts the two roles that work across
-every project — the **CEO** and the **Coach** — and it's where instance-level settings
-live (model providers, shared connections, and the like). When you chat to create a
-new project, you're talking to the CEO in HQ. See
-[Roles & the CEO](/docs/concepts/roles-and-coordination).
+**HQ** is the one special, instance-wide team. It's the permanent home of the two roles
+that work across every project — the **CEO** and the **Coach** — and it's where
+instance-level settings live (model providers, shared connections, and the like). HQ is
+also where you [chat with the CEO](/docs/concepts/roles-and-coordination#chatting-with-the-ceo):
+when you talk to it to create a new project or check in on any team, you're talking to the
+CEO in HQ. See [Roles & the CEO](/docs/concepts/roles-and-coordination).
 
 ## Next
 

--- a/docs/concepts/roles-and-coordination.md
+++ b/docs/concepts/roles-and-coordination.md
@@ -10,8 +10,10 @@ Hezo organises agents like a company. A few roles coordinate; the rest do the wo
 
 ## The CEO
 
-The **CEO** is the instance-wide executive, and your main point of contact. You chat
-with the CEO to get things done across the whole instance:
+The **CEO** is the instance-wide executive, and your main point of contact. There is
+exactly one CEO, and it lives in [HQ](/docs/concepts/projects-and-teams#hq--the-home-team) —
+so it can see and act across every project. You chat with the CEO to get things done
+across the whole instance:
 
 - **Intake** — describe a new project and the CEO scopes it and provisions the team
   (see [Your first project](/docs/getting-started/first-project)).
@@ -28,8 +30,13 @@ Because the CEO can make consequential changes, significant actions surface as
 
 ## The Coach
 
-The **Coach** reviews completed work across every project, capturing what went well and
-what to improve so the teams get better over time.
+The **Coach** is the second instance-wide role that lives in HQ. Whenever a ticket is
+completed — in any project — the Coach automatically reviews how it went: it reads the
+whole thread, notices where an agent struggled, got pushback, or needed several attempts,
+and captures what went well and what to improve. It then writes those lessons back as
+durable **learned rules** on the agents that need them (and sometimes updates a project
+document or skill), so the same mistake doesn't happen twice. The teams get better the
+more they ship, without you having to tune prompts by hand.
 
 ## The Captain
 
@@ -43,12 +50,22 @@ The rest of the roster are **workers** — domain specialists such as engineers,
 designers, QA, or researchers, depending on the team template. They pick up tasks,
 do the work, and report up to the Captain.
 
-## Acting through the chat
+## Chatting with the CEO
 
-The chat is the control surface for the things that are awkward to click through:
-scoping work, reorganising a team, or changing how an agent behaves. State what you
-want in plain language; the CEO proposes the change and asks you to approve anything
-that matters. Standing preferences you ask it to remember persist in the CEO's
+The CEO is always one click away. A chat opens from any page in the app, and there's a
+single ongoing conversation — pick up where you left off rather than starting a new
+thread each time. As the CEO works, its reply **streams back in real time**, so you can
+follow its thinking instead of waiting for a finished block of text.
+
+Because the CEO works across the whole instance, you can ask about anything without
+opening a project first: "how's the marketing site coming along?", "what's the engineering
+team stuck on?", "spin up a team to research competitors". It answers with knowledge of
+every project, ticket, and roster.
+
+The chat is also the control surface for the things that are awkward to click through:
+scoping work, reorganising a team, or changing how an agent behaves. State what you want
+in plain language; the CEO proposes the change and asks you to approve anything that
+matters. Standing preferences you ask it to remember persist in the CEO's
 [chatbox memory](/docs/concepts/documents-and-memory#chatbox-memory), so you don't repeat
 yourself.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -34,9 +34,9 @@ agent can't hurt you. Three guarantees sit underneath everything:
 
 - **Spin up a team per project** from a template, or reuse an existing team's setup
   for a new project. See [Projects & teams](/docs/concepts/projects-and-teams).
-- **Chat with the CEO** to scope work, create projects, hire new agents, edit system
-  prompts, and adjust settings — all from one conversation. See
-  [Roles & the CEO](/docs/concepts/roles-and-coordination).
+- **Chat with the CEO in real time** to scope work, create projects, hire new agents, edit
+  system prompts, and adjust settings — all from one conversation, with replies streaming
+  back as it works. See [Roles & the CEO](/docs/concepts/roles-and-coordination).
 - **Bring your own models.** Claude, ChatGPT, Gemini, DeepSeek, Z.ai, OpenRouter, and
   Kimi are all supported, and you can give any individual agent its own model. See
   [AI model support](/docs/ai-models).


### PR DESCRIPTION
## What

Deepens the user-facing concept docs around Hezo's special instance-wide roles and the realtime chat experience, which were only mentioned lightly before.

### `docs/concepts/roles-and-coordination.md`
- **CEO**: make explicit it's the single instance-wide role living in HQ, working across every project.
- **Chatting with the CEO** (new section, replacing "Acting through the chat"): describes the realtime chat as a concrete feature — always one click away on any page, a single ongoing conversation, replies that **stream back in real time**, cross-project awareness, approvals for consequential changes, and chatbox memory for standing preferences.
- **Coach**: expanded to explain it runs automatically when a ticket is completed (in any project), reviews the whole thread, and writes lessons back as durable **learned rules** on the relevant agents.

### `docs/concepts/projects-and-teams.md`
- Note HQ is where you chat with the CEO and is the permanent home of the CEO and Coach.

### `docs/introduction.md`
- Clarify the CEO chat is realtime with streaming replies.

## Verification

Built the website locally (which sources these docs via `vendor/hezo/docs`); all 25 doc pages generate and the new cross-links resolve to real heading anchors (`#chatting-with-the-ceo`, `#hq--the-home-team`).

## Scope

Pure docs content — no API/route/MCP changes, so SKILL.md / llms.txt / reference pages are untouched. Homepage USP changes for the same features ship in the `hezo-ai/website` repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfeeJS8eGgyk4ShqzcYhDr

---
_Generated by [Claude Code](https://claude.ai/code/session_01VfeeJS8eGgyk4ShqzcYhDr)_