### PR TITLE
feat(projects): attach a project plan document instead of a PRD

### DIFF
--- a/docs/concepts/projects-and-teams.md
+++ b/docs/concepts/projects-and-teams.md
@@ -17,15 +17,67 @@ all belong to that project and nothing leaks between them.
 
 ## Team templates
 
-When you create a project you choose a **template**, which decides the starting roster:
-
-- **Blank** — just a Captain. The minimal baseline; hire roles as you need them.
-- **Software development** — a Captain plus a full delivery roster (for example an
-  architect, engineers, QA, a designer, and supporting roles).
-- Other templates for different kinds of work.
-
+When you create a project you choose a **template**, which decides the starting roster.
 Every template gives the team a **Captain** to lead it. The instance-wide CEO and Coach
 are never part of a template — they live in HQ (below).
+
+Hezo ships with two built-in templates. Each agent's behaviour comes from a **system
+prompt** that you can read (and, once hired, customise — see
+[Hiring & customizing agents](/docs/concepts/hiring-and-agents)). The links below point
+at the source prompt for each role.
+
+### Blank team
+
+Just a **Captain** — the minimal baseline. Hire roles as you need them.
+
+- [Captain](https://github.com/hezo-ai/hezo/blob/main/agents/blank/captain.md) — leads
+  the team, turns the brief (and any attached [project plan](#the-project-plan-document))
+  into an execution plan, and escalates to the CEO. Because the team starts with only the
+  Captain, this Captain produces a plain **project plan** rather than a formal product
+  requirements document (PRD).
+
+### Software development team
+
+A **Captain** plus a full delivery roster:
+
+- [Captain](https://github.com/hezo-ai/hezo/blob/main/agents/software-development/captain.md) —
+  leads the team, breaks the goal into tickets, and coordinates delivery.
+- [Architect](https://github.com/hezo-ai/hezo/blob/main/agents/software-development/architect.md) —
+  technical vision, specs, and architecture decisions; gates and schedules the deploy.
+- [Product Lead](https://github.com/hezo-ai/hezo/blob/main/agents/software-development/product-lead.md) —
+  owns scope and requirements; turns the brief (and any attached project plan) into the
+  formal **PRD**.
+- [Engineer](https://github.com/hezo-ai/hezo/blob/main/agents/software-development/engineer.md) —
+  implementation, tests, and code.
+- [QA Engineer](https://github.com/hezo-ai/hezo/blob/main/agents/software-development/qa-engineer.md) —
+  testing, code quality, and the final approval gate.
+- [Security Engineer](https://github.com/hezo-ai/hezo/blob/main/agents/software-development/security-engineer.md) —
+  security review, threat modelling, and vulnerability analysis.
+- [UI Designer](https://github.com/hezo-ai/hezo/blob/main/agents/software-development/ui-designer.md) —
+  visual and interaction design, component architecture, and HTML mockups.
+- [DevOps Engineer](https://github.com/hezo-ai/hezo/blob/main/agents/software-development/devops-engineer.md) —
+  infrastructure, CI/CD, and staging/production deployment.
+- [Marketing Lead](https://github.com/hezo-ai/hezo/blob/main/agents/software-development/marketing-lead.md) —
+  marketing strategy, content, public documentation, and launch.
+- [Researcher](https://github.com/hezo-ai/hezo/blob/main/agents/software-development/researcher.md) —
+  competitive analysis, technical research, and feasibility studies.
+
+## The project plan document
+
+When you create a project you can optionally attach a **project plan document** — a
+fuller brief than the description field, describing what the project is for: goals,
+scope, context, and constraints. It's saved into the project's docs as `project-plan.md`
+and the Captain is told to use it as the starting point for planning.
+
+How it's used depends on the team:
+
+- On a **software development** team, the project plan is the input the Product Lead turns
+  into the formal PRD, which then feeds the spec and implementation work.
+- On a **blank** (or other non-software) team, the Captain uses the project plan directly
+  as the plan — there's no PRD step.
+
+Attaching a plan is always optional; leave it off and the Captain works from the
+description alone.
 
 ## Reusing a team setup
 

--- a/docs/concepts/roles-and-coordination.md
+++ b/docs/concepts/roles-and-coordination.md
@@ -28,6 +28,9 @@ across the whole instance:
 Because the CEO can make consequential changes, significant actions surface as
 **approvals** for you to confirm.
 
+The CEO's behaviour comes from its
+[system prompt](https://github.com/hezo-ai/hezo/blob/main/agents/_instance/ceo.md).
+
 ## The Coach
 
 The **Coach** is the second instance-wide role that lives in HQ. Whenever a ticket is
@@ -37,6 +40,13 @@ and captures what went well and what to improve. It then writes those lessons ba
 durable **learned rules** on the agents that need them (and sometimes updates a project
 document or skill), so the same mistake doesn't happen twice. The teams get better the
 more they ship, without you having to tune prompts by hand.
+
+The Coach's behaviour comes from its
+[system prompt](https://github.com/hezo-ai/hezo/blob/main/agents/_instance/coach.md).
+
+Both the CEO and the Coach are instance-wide singletons that live in
+[HQ](/docs/concepts/projects-and-teams#hq--the-home-team) — the one special team — and
+act across every project's team. They are never part of a project template.
 
 ## The Captain
 
@@ -48,7 +58,9 @@ escalates to the CEO when needed.
 
 The rest of the roster are **workers** — domain specialists such as engineers,
 designers, QA, or researchers, depending on the team template. They pick up tasks,
-do the work, and report up to the Captain.
+do the work, and report up to the Captain. For the full roster of each built-in
+template — and a link to every role's system prompt — see
+[Team templates](/docs/concepts/projects-and-teams#team-templates).
 
 ## Chatting with the CEO
 

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -1335,10 +1335,10 @@ export function registerTools(
 				.string()
 				.optional()
 				.describe('Optional 2-4 char uppercase ticket prefix; derived from the name when omitted'),
-			initial_prd: z
+			initial_project_plan: z
 				.string()
 				.optional()
-				.describe('Optional initial requirements document (markdown), seeded as initial-prd.md'),
+				.describe('Optional project plan document (markdown), seeded as project-plan.md'),
 			template_id: z
 				.string()
 				.optional()
@@ -1406,7 +1406,8 @@ export function registerTools(
 					templateId: typeof args.template_id === 'string' ? args.template_id : undefined,
 					sourceTeamId: typeof args.source_team_id === 'string' ? args.source_team_id : undefined,
 					taskPrefix: typeof args.task_prefix === 'string' ? args.task_prefix : undefined,
-					initialPrd: typeof args.initial_prd === 'string' ? args.initial_prd : null,
+					initialProjectPlan:
+						typeof args.initial_project_plan === 'string' ? args.initial_project_plan : null,
 					actorType: 'agent',
 					actorMemberId: auth.memberId,
 				},

--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -121,7 +121,7 @@ projectsRoutes.post('/projects', async (c) => {
 		template_id?: string;
 		source_team_id?: string;
 		task_prefix?: string;
-		initial_prd?: string;
+		initial_project_plan?: string;
 		docker_base_image?: string;
 	}>();
 
@@ -137,7 +137,7 @@ projectsRoutes.post('/projects', async (c) => {
 			templateId: body.template_id,
 			sourceTeamId: body.source_team_id,
 			taskPrefix: body.task_prefix,
-			initialPrd: body.initial_prd?.trim() || null,
+			initialProjectPlan: body.initial_project_plan?.trim() || null,
 			dockerBaseImage: body.docker_base_image,
 			creatorUserId: auth.type === AuthType.Admin ? auth.userId : undefined,
 			actorType: 'admin',
@@ -177,7 +177,7 @@ projectsRoutes.post('/project-intakes', async (c) => {
 		description?: string;
 		template_id?: string;
 		source_team_id?: string;
-		initial_prd?: string;
+		initial_project_plan?: string;
 	}>();
 
 	if (!body.name?.trim()) return err(c, 'INVALID_REQUEST', 'name is required', 400);
@@ -225,7 +225,7 @@ projectsRoutes.post('/project-intakes', async (c) => {
 		{
 			name: body.name.trim(),
 			description: body.description.trim(),
-			initialPrd: body.initial_prd?.trim() || null,
+			initialProjectPlan: body.initial_project_plan?.trim() || null,
 			baselineTemplateId: templateId,
 			baselineSourceTeamId: sourceTeamId,
 			baselineTeamTypeName,

--- a/packages/server/src/services/project-create.ts
+++ b/packages/server/src/services/project-create.ts
@@ -69,7 +69,7 @@ export interface CreateProjectWithPlanningInput {
 	taskPrefix: string;
 	description: string;
 	dockerBaseImage?: string;
-	initialPrd?: string | null;
+	initialProjectPlan?: string | null;
 	/** Optional audit context: who created the project and the bus to emit on. */
 	events?: DomainEventBus;
 	actorType?: AuditActorType;
@@ -87,8 +87,8 @@ export interface CreateProjectWithPlanningResult extends CreateProjectResult {
 }
 
 /**
- * Create the project row, its task counter, and seed docs (incl. any initial
- * PRD). The planning task is created separately by `createPlanningTask` so a
+ * Create the project row, its task counter, and seed docs (incl. any attached
+ * project plan). The planning task is created separately by `createPlanningTask` so a
  * caller can slot other tickets (e.g. the CEO coherence review) ahead of it and
  * control identifier ordering. Emits the project.created audit event.
  */
@@ -98,7 +98,7 @@ export async function createProject(
 ): Promise<CreateProjectResult> {
 	const projectName = input.name.trim();
 	const projectDescription = input.description.trim();
-	const initialPrd = input.initialPrd?.trim() || null;
+	const initialProjectPlan = input.initialProjectPlan?.trim() || null;
 
 	const result = await withTransaction(db, async () => {
 		await db.query('SELECT id FROM teams WHERE id = $1 FOR UPDATE', [input.teamId]);
@@ -128,11 +128,11 @@ export async function createProject(
 			project.id,
 		]);
 
-		if (initialPrd) {
+		if (initialProjectPlan) {
 			await db.query(
 				`INSERT INTO documents (project_id, team_id, type, slug, content)
-				 VALUES ($1, $2, 'project_doc', 'initial-prd.md', $3)`,
-				[project.id, input.teamId, initialPrd],
+				 VALUES ($1, $2, 'project_doc', 'project-plan.md', $3)`,
+				[project.id, input.teamId, initialProjectPlan],
 			);
 		}
 
@@ -173,18 +173,18 @@ export async function createPlanningTask(
 		captainMemberId: string;
 		name: string;
 		description: string;
-		initialPrd?: string | null;
+		initialProjectPlan?: string | null;
 	},
 ): Promise<{ planningTask: Record<string, unknown> }> {
 	const projectName = input.name.trim();
 	const projectDescription = input.description.trim();
-	const initialPrd = input.initialPrd?.trim() || null;
+	const initialProjectPlan = input.initialProjectPlan?.trim() || null;
 	const projectId = input.project.id as string;
 
 	const { number: taskNumber, identifier } = await allocateTaskIdentifier(db, projectId);
 
-	const initialPrdNote = initialPrd
-		? `\n\n> **Note:** The admin has provided an initial requirements document saved as \`initial-prd.md\` in this project's docs. Direct the Researcher and Product Lead to consult this document as a starting point for research and the formal PRD.`
+	const initialProjectPlanNote = initialProjectPlan
+		? `\n\n> **Note:** The admin has provided a project plan document saved as \`project-plan.md\` in this project's docs. Use it as the starting point for planning — for a software team this is the brief the Product Lead turns into the formal PRD; otherwise consult it directly as the plan.`
 		: '';
 
 	const taskBody = `## Draft the execution plan for this new project
@@ -195,7 +195,7 @@ A new project has just been created. Please read the description below carefully
 
 **Description**
 
-${projectDescription}${initialPrdNote}
+${projectDescription}${initialProjectPlanNote}
 
 ### Your task
 
@@ -247,7 +247,7 @@ export async function createProjectWithPlanningTask(
 		captainMemberId: input.captainMemberId,
 		name: input.name,
 		description: input.description,
-		initialPrd: input.initialPrd,
+		initialProjectPlan: input.initialProjectPlan,
 	});
 	return { project, planningTask, deferCaptainPlanningWake };
 }
@@ -395,7 +395,7 @@ export interface CreateProjectWithTeamInput {
 	/** Existing team to clone (snapshotted into a fresh template); mutually exclusive with templateId. */
 	sourceTeamId?: string;
 	taskPrefix?: string;
-	initialPrd?: string | null;
+	initialProjectPlan?: string | null;
 	dockerBaseImage?: string;
 	/** Added as the new team's admin member (any human admin who creates it). */
 	creatorUserId?: string;
@@ -503,7 +503,7 @@ export async function createProjectWithTeam(
 		slug,
 		taskPrefix: prefixResult.prefix,
 		description,
-		initialPrd: input.initialPrd ?? null,
+		initialProjectPlan: input.initialProjectPlan ?? null,
 		dockerBaseImage: input.dockerBaseImage,
 		events: opts.events,
 		actorType: input.actorType ?? 'admin',
@@ -520,7 +520,7 @@ export async function createProjectWithTeam(
 		captainMemberId,
 		name,
 		description,
-		initialPrd: input.initialPrd ?? null,
+		initialProjectPlan: input.initialProjectPlan ?? null,
 	});
 
 	if (deps.wsManager) {

--- a/packages/server/src/services/project-intake.ts
+++ b/packages/server/src/services/project-intake.ts
@@ -25,7 +25,7 @@ export const PROJECT_INTAKE_MARKER = '<!-- project-intake -->';
 export interface CreateProjectIntakeInput {
 	name: string;
 	description: string;
-	initialPrd: string | null;
+	initialProjectPlan: string | null;
 	/** The team-type the admin picked in the dialog — the CEO's baseline suggestion. */
 	baselineTemplateId?: string;
 	/** Set instead of baselineTemplateId when the admin chose to clone an existing team. */
@@ -56,10 +56,10 @@ function buildGreetingText(input: CreateProjectIntakeInput): string {
 		lines.push(`**Suggested team type:** ${input.baselineTeamTypeName}`);
 	}
 	lines.push('**Description:**', '', input.description);
-	if (input.initialPrd) {
+	if (input.initialProjectPlan) {
 		lines.push(
 			'',
-			`I'll attach your requirements document as a separate comment below so I can refer back to it.`,
+			`I'll attach your project plan document as a separate comment below so I can refer back to it.`,
 		);
 	}
 	lines.push(
@@ -90,7 +90,7 @@ The admin submitted the Create Project form and chose to plan it with you. Use t
 
 - **Name:** ${input.name}
 ${buildBaselineLine(input)}
-- **Has requirements doc:** ${input.initialPrd ? 'yes — see comments below' : 'no'}
+- **Has project plan doc:** ${input.initialProjectPlan ? 'yes — see comments below' : 'no'}
 
 **Description:**
 
@@ -164,7 +164,7 @@ export async function createProjectIntake(
 				],
 			);
 
-			if (input.initialPrd) {
+			if (input.initialProjectPlan) {
 				await db.query(
 					`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
 				 VALUES ($1, $2, $3::comment_content_type, $4::jsonb)`,
@@ -173,7 +173,7 @@ export async function createProjectIntake(
 						ctx.ceoMemberId,
 						CommentContentType.Text,
 						JSON.stringify({
-							text: `**Requirements document attached to this intake:**\n\n${input.initialPrd}`,
+							text: `**Project plan attached to this intake:**\n\n${input.initialProjectPlan}`,
 						}),
 					],
 				);

--- a/packages/server/test/helpers/app.ts
+++ b/packages/server/test/helpers/app.ts
@@ -361,7 +361,7 @@ export async function createTestProject(
 		name: string;
 		description?: string;
 		task_prefix?: string;
-		initial_prd?: string | null;
+		initial_project_plan?: string | null;
 		docker_base_image?: string;
 	},
 ): Promise<{
@@ -427,7 +427,7 @@ export async function createTestProject(
 		taskPrefix: prefixResult.prefix,
 		description: input.description ?? '',
 		dockerBaseImage: input.docker_base_image,
-		initialPrd: input.initial_prd ?? null,
+		initialProjectPlan: input.initial_project_plan ?? null,
 	});
 
 	const data: CreatedTestProject = {

--- a/packages/server/test/projects.test.ts
+++ b/packages/server/test/projects.test.ts
@@ -21,7 +21,7 @@ async function createProject(opts: {
 	description?: string;
 	template_id?: string;
 	task_prefix?: string;
-	initial_prd?: string;
+	initial_project_plan?: string;
 	docker_base_image?: string;
 }): Promise<{ status: number; json: () => Promise<{ data: Record<string, unknown> }> }> {
 	const res = await app.request('/api/projects', {
@@ -222,31 +222,30 @@ describe('projects CRUD', () => {
 	});
 });
 
-describe('initial PRD upload', () => {
-	it('saves initial_prd as a project doc and references it in the planning task', async () => {
-		const prdContent = '# My Product\n\n## Overview\nA tool for managing widgets.';
+describe('initial project plan upload', () => {
+	it('saves initial_project_plan as a project doc and references it in the planning task', async () => {
+		const planContent = '# My Product\n\n## Overview\nA tool for managing widgets.';
 		const res = await createProject({
-			name: 'PRD Upload Project',
+			name: 'Project Plan Upload Project',
 			description: VALID_DESCRIPTION,
-			initial_prd: prdContent,
+			initial_project_plan: planContent,
 		});
 		expect(res.status).toBe(201);
 		const project = (await res.json()).data;
 
 		const docResult = await db.query<{ filename: string; content: string }>(
 			"SELECT slug AS filename, content FROM documents WHERE type = 'project_doc' AND project_id = $1 AND slug = $2",
-			[project.id, 'initial-prd.md'],
+			[project.id, 'project-plan.md'],
 		);
 		expect(docResult.rows.length).toBe(1);
-		expect(docResult.rows[0].content).toBe(prdContent);
+		expect(docResult.rows[0].content).toBe(planContent);
 
 		const taskResult = await db.query<{ description: string }>(
 			`SELECT description FROM tasks WHERE project_id = $1 AND labels @> '["planning"]'::jsonb`,
 			[project.id],
 		);
-		expect(taskResult.rows[0].description).toContain('initial-prd.md');
-		expect(taskResult.rows[0].description).toContain('Researcher');
-		expect(taskResult.rows[0].description).toContain('Product Lead');
+		expect(taskResult.rows[0].description).toContain('project-plan.md');
+		expect(taskResult.rows[0].description).toContain('starting point for planning');
 	});
 
 	it('creates the coherence review as the first ticket, blocking the planning task', async () => {
@@ -275,9 +274,9 @@ describe('initial PRD upload', () => {
 		expect(dep.rows.length).toBe(1);
 	});
 
-	it('does not create initial-prd.md when initial_prd is not provided', async () => {
+	it('does not create project-plan.md when initial_project_plan is not provided', async () => {
 		const res = await createProject({
-			name: 'No PRD Project',
+			name: 'No Plan Project',
 			description: VALID_DESCRIPTION,
 		});
 		expect(res.status).toBe(201);
@@ -285,7 +284,7 @@ describe('initial PRD upload', () => {
 
 		const docResult = await db.query(
 			"SELECT 1 FROM documents WHERE type = 'project_doc' AND project_id = $1 AND slug = $2",
-			[project.id, 'initial-prd.md'],
+			[project.id, 'project-plan.md'],
 		);
 		expect(docResult.rows.length).toBe(0);
 
@@ -293,21 +292,21 @@ describe('initial PRD upload', () => {
 			'SELECT description FROM tasks WHERE project_id = $1',
 			[project.id],
 		);
-		expect(taskResult.rows[0].description).not.toContain('initial-prd.md');
+		expect(taskResult.rows[0].description).not.toContain('project-plan.md');
 	});
 
-	it('ignores empty/whitespace-only initial_prd', async () => {
+	it('ignores empty/whitespace-only initial_project_plan', async () => {
 		const res = await createProject({
-			name: 'Empty PRD Project',
+			name: 'Empty Plan Project',
 			description: VALID_DESCRIPTION,
-			initial_prd: '   ',
+			initial_project_plan: '   ',
 		});
 		expect(res.status).toBe(201);
 		const project = (await res.json()).data;
 
 		const docResult = await db.query(
 			"SELECT 1 FROM documents WHERE type = 'project_doc' AND project_id = $1 AND slug = $2",
-			[project.id, 'initial-prd.md'],
+			[project.id, 'project-plan.md'],
 		);
 		expect(docResult.rows.length).toBe(0);
 	});
@@ -331,11 +330,11 @@ describe('default project docs', () => {
 		expect(docResult.rows[0].content.length).toBeGreaterThan(0);
 	});
 
-	it('seeds the architecture-guidelines.md default alongside an initial PRD', async () => {
+	it('seeds the architecture-guidelines.md default alongside an initial project plan', async () => {
 		const res = await createProject({
-			name: 'Defaults With PRD Project',
+			name: 'Defaults With Plan Project',
 			description: VALID_DESCRIPTION,
-			initial_prd: '# PRD\n\nSome requirements.',
+			initial_project_plan: '# Plan\n\nSome requirements.',
 		});
 		expect(res.status).toBe(201);
 		const project = (await res.json()).data;
@@ -346,7 +345,7 @@ describe('default project docs', () => {
 		);
 		const slugs = docResult.rows.map((d) => d.slug);
 		expect(slugs).toContain('architecture-guidelines.md');
-		expect(slugs).toContain('initial-prd.md');
+		expect(slugs).toContain('project-plan.md');
 	});
 });
 

--- a/packages/web/src/components/create-project-with-team-dialog.tsx
+++ b/packages/web/src/components/create-project-with-team-dialog.tsx
@@ -6,9 +6,11 @@ import { setActiveTeamSlug } from '../hooks/use-active-team-slug';
 import { useStartProjectIntake } from '../hooks/use-project-intake';
 import { useAllVisibleProjects, useCreateProjectWithTeam } from '../hooks/use-projects';
 import { useTeamTemplates } from '../hooks/use-team-templates';
+import { ProjectPlanUpload } from './project-plan-upload';
 import { Button } from './ui/button';
 import { Card } from './ui/card';
 import { dialogContentClassName, dialogOverlayClassName } from './ui/dialog';
+import { InfoTooltip } from './ui/info-tooltip';
 import { Input } from './ui/input';
 import { Textarea } from './ui/textarea';
 
@@ -49,6 +51,8 @@ export function CreateProjectWithTeamDialog({
 	const { projects } = useAllVisibleProjects();
 	const [name, setName] = useState('');
 	const [description, setDescription] = useState('');
+	const [projectPlan, setProjectPlan] = useState('');
+	const [projectPlanFilename, setProjectPlanFilename] = useState<string | null>(null);
 	const [selection, setSelection] = useState<Selection>(null);
 	const createProject = useCreateProjectWithTeam();
 	const startIntake = useStartProjectIntake();
@@ -80,6 +84,8 @@ export function CreateProjectWithTeamDialog({
 	function reset() {
 		setName('');
 		setDescription('');
+		setProjectPlan('');
+		setProjectPlanFilename(null);
 		setSelection(null);
 	}
 
@@ -88,6 +94,7 @@ export function CreateProjectWithTeamDialog({
 		const res = await createProject.mutateAsync({
 			name: name.trim(),
 			description: description.trim(),
+			initial_project_plan: projectPlan.trim() || undefined,
 			...sourceFields,
 		});
 		setActiveTeamSlug(res.team_slug);
@@ -108,6 +115,7 @@ export function CreateProjectWithTeamDialog({
 		const res = await startIntake.mutateAsync({
 			name: name.trim(),
 			description: description.trim(),
+			initial_project_plan: projectPlan.trim() || undefined,
 			...sourceFields,
 		});
 		onOpenChange(false);
@@ -155,6 +163,24 @@ export function CreateProjectWithTeamDialog({
 							rows={4}
 							placeholder="What is this project? Domain, users, and the core problem it solves."
 						/>
+						<div className="flex flex-col gap-1.5">
+							<span className="flex items-center gap-1.5 text-[13px] font-medium text-text-1">
+								Project plan document (optional)
+								<InfoTooltip
+									label="What is a project plan document?"
+									data-testid="project-plan-help"
+									content="Attach a fuller document describing what this project is for when the description above isn't enough — goals, scope, context, constraints. For a software team the Captain uses it to write the formal PRD; for other teams it's used directly as the plan."
+								/>
+							</span>
+							<ProjectPlanUpload
+								value={projectPlan}
+								filename={projectPlanFilename}
+								onChange={(v, f) => {
+									setProjectPlan(v);
+									setProjectPlanFilename(f);
+								}}
+							/>
+						</div>
 						<div>
 							<span className="text-[13px] font-medium text-text-1">Team type</span>
 							{isLoading ? (

--- a/packages/web/src/components/project-plan-upload.tsx
+++ b/packages/web/src/components/project-plan-upload.tsx
@@ -1,13 +1,13 @@
 import { FileText, Upload, X } from 'lucide-react';
 import { useCallback, useRef } from 'react';
 
-interface PrdUploadProps {
+interface ProjectPlanUploadProps {
 	value: string;
 	filename: string | null;
 	onChange: (value: string, filename: string | null) => void;
 }
 
-export function PrdUpload({ value, filename, onChange }: PrdUploadProps) {
+export function ProjectPlanUpload({ value, filename, onChange }: ProjectPlanUploadProps) {
 	const fileInputRef = useRef<HTMLInputElement>(null);
 
 	const handleFileUpload = useCallback(
@@ -26,9 +26,6 @@ export function PrdUpload({ value, filename, onChange }: PrdUploadProps) {
 
 	return (
 		<div className="flex flex-col gap-1.5">
-			<span className="text-xs font-medium uppercase tracking-wider text-text-2">
-				Requirements Document (optional)
-			</span>
 			{value ? (
 				<div className="rounded-md border border-border bg-surface px-3 py-2 text-[13px]">
 					<div className="flex items-center justify-between mb-2">
@@ -40,6 +37,7 @@ export function PrdUpload({ value, filename, onChange }: PrdUploadProps) {
 							type="button"
 							onClick={() => onChange('', null)}
 							className="text-text-3 hover:text-text-1 p-0.5"
+							aria-label="Remove project plan document"
 						>
 							<X className="w-3.5 h-3.5" />
 						</button>

--- a/packages/web/src/hooks/use-project-intake.ts
+++ b/packages/web/src/hooks/use-project-intake.ts
@@ -19,7 +19,7 @@ export interface StartProjectIntakeInput {
 	template_id?: string;
 	source_team_id?: string;
 	task_prefix?: string;
-	initial_prd?: string;
+	initial_project_plan?: string;
 }
 
 export interface StartProjectIntakeResult {

--- a/packages/web/src/hooks/use-projects.ts
+++ b/packages/web/src/hooks/use-projects.ts
@@ -142,7 +142,7 @@ export function useCreateProjectWithTeam() {
 			description: string;
 			template_id?: string;
 			source_team_id?: string;
-			initial_prd?: string;
+			initial_project_plan?: string;
 			task_prefix?: string;
 		}) => api.post<ProjectWithTeamResponse>('/api/projects', data),
 		onSuccess: () => {

--- a/packages/web/test/project-crud.test.tsx
+++ b/packages/web/test/project-crud.test.tsx
@@ -124,9 +124,9 @@ test('Home project card links to the project detail', async () => {
 	expect(router.state.location.pathname).toMatch(new RegExp(`^/projects/${projectSlug}`));
 }, 60_000);
 
-test('initial PRD passed at creation is persisted as a project doc', async () => {
-	const name = uniqueName('PRD Test Project');
-	const prdContent = '# Widget App\n\nA tool for managing widgets efficiently.';
+test('initial project plan passed at creation is persisted as a project doc', async () => {
+	const name = uniqueName('Plan Test Project');
+	const planContent = '# Widget App\n\nA tool for managing widgets efficiently.';
 	let docBody: { content: string; filename: string } | null = null;
 	let seedError: unknown = null;
 
@@ -136,16 +136,16 @@ test('initial PRD passed at creation is persisted as a project doc', async () =>
 			try {
 				const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
 
-				// The dialog no longer carries a PRD field; direct creation accepts
-				// `initial_prd` on POST /api/projects, which provisions the team +
-				// project + planning task and saves the PRD as a project doc.
+				// Direct creation accepts `initial_project_plan` on POST /api/projects,
+				// which provisions the team + project + planning task and saves the
+				// project plan as a project doc.
 				const createRes = await apiBase('/api/projects', {
 					method: 'POST',
 					headers,
 					body: JSON.stringify({
 						name,
-						description: 'Testing initial PRD upload.',
-						initial_prd: prdContent,
+						description: 'Testing initial project plan upload.',
+						initial_project_plan: planContent,
 					}),
 				});
 				const createJson = (await createRes.json()) as {
@@ -155,7 +155,7 @@ test('initial PRD passed at creation is persisted as a project doc', async () =>
 				if (!createJson.data) throw new Error(`create failed: ${JSON.stringify(createJson)}`);
 				const { slug } = createJson.data;
 
-				const docRes = await apiBase(`/api/projects/${slug}/docs/initial-prd.md`, {
+				const docRes = await apiBase(`/api/projects/${slug}/docs/project-plan.md`, {
 					headers: { Authorization: `Bearer ${token}` },
 				});
 				if (!docRes.ok) {
@@ -171,8 +171,63 @@ test('initial PRD passed at creation is persisted as a project doc', async () =>
 	if (seedError) throw seedError;
 
 	expect(docBody).toBeTruthy();
-	expect(docBody!.content).toBe(prdContent);
-	expect(docBody!.filename).toBe('initial-prd.md');
+	expect(docBody!.content).toBe(planContent);
+	expect(docBody!.filename).toBe('project-plan.md');
+}, 60_000);
+
+test('dialog attaches a project plan document, with a help tooltip, and persists it', async () => {
+	const name = uniqueName('Plan Dialog Project');
+	const { findByPlaceholderText, findByTestId, findByText, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			// Seed one project so Home shows the New project button.
+			await seedProject(ws, { name: uniqueName('Existing') });
+		},
+	});
+
+	await router.navigate({ to: '/home' });
+	const mainEl = await waitFor(() => {
+		const el = document.querySelector('main');
+		if (!el) throw new Error('main not mounted');
+		return el as HTMLElement;
+	});
+	await user.click(await within(mainEl).findByRole('button', { name: 'New project' }));
+
+	// The field is labelled "Project plan document" with a help-icon tooltip.
+	await findByText('Project plan document (optional)');
+	await findByTestId('project-plan-help');
+
+	// Attach the plan via the (hidden) file input — the component reads it as text.
+	const planContent = '# Detailed Plan\n\nGoals, scope, and constraints for this project.';
+	const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+	expect(fileInput).toBeTruthy();
+	await user.upload(fileInput, new File([planContent], 'plan.md', { type: 'text/markdown' }));
+	// The uploaded filename shows in the preview, confirming the attach landed.
+	await findByText('plan.md');
+
+	await user.type(await findByPlaceholderText('e.g. Marketing Site'), name);
+	await user.type(
+		await findByPlaceholderText(/What is this project/),
+		'A project whose plan is fuller than the description.',
+	);
+	await user.click(await findByTestId('team-type-card-Blank'));
+	await user.click(await findByTestId('create-project-submit'));
+
+	await waitFor(() => expect(router.state.location.pathname).toMatch(/^\/projects\/.+\/tasks\//), {
+		timeout: 30_000,
+	});
+	const slug = router.state.location.pathname.split('/')[2];
+
+	// The attached plan is persisted as project-plan.md in the new project's docs.
+	const { apiBase, token } = getTestContext();
+	const docRes = await apiBase(`/api/projects/${slug}/docs/project-plan.md`, {
+		headers: { Authorization: `Bearer ${token}` },
+	});
+	expect(docRes.ok).toBe(true);
+	const docBody = ((await docRes.json()) as { data: { content: string; filename: string } }).data;
+	expect(docBody.content).toBe(planContent);
+	expect(docBody.filename).toBe('project-plan.md');
 }, 60_000);
 
 test('Create button stays disabled until name, description, and a team type are set', async () => {

--- a/test/browser/helpers.ts
+++ b/test/browser/helpers.ts
@@ -225,7 +225,7 @@ export async function createProjectAndClearPlanning(
 	data: {
 		name: string;
 		description?: string;
-		initial_prd?: string;
+		initial_project_plan?: string;
 		task_prefix?: string;
 		template_id?: string;
 	},


### PR DESCRIPTION
## Why

The Create Project flow was built around attaching a **PRD (product requirements document)**, but not every project builds a software product. This renames the attachment to a generic **project plan document**: a fuller brief the operator can attach when the Description field isn't enough. The PRD-specific framing now lives only where it belongs — the software team's `research → PRD → spec` flow.

## What changed

**Create Project dialog**
- The upload component existed (`prd-upload.tsx`) but was **never wired into any dialog** and had **no help tooltip**. It's now renamed to `ProjectPlanUpload` and wired into `CreateProjectWithTeamDialog` as **"Project plan document (optional)"**, with an `InfoTooltip` help icon explaining what it's for and how its use differs by team type.
- The attachment is passed into both **Create now** and **Plan with the CEO** flows.

**End-to-end rename**
- Request field `initial_prd` → `initial_project_plan` (REST `POST /api/projects` + `POST /api/project-intakes`, and the CEO's `create_project` MCP tool param).
- Seeded doc slug `initial-prd.md` → `project-plan.md`.
- Service params/locals `initialPrd` → `initialProjectPlan`.
- The auto-generated Captain planning note is **reworded to be team-neutral**: it points at `project-plan.md` as the planning starting point. For a software team the Product Lead still turns it into the formal PRD via existing role prompts; for a blank team the Captain uses the plan directly.

**Docs** (extended existing pages, no new page)
- `projects-and-teams.md`: catalogs the built-in **Blank** and **Software development** teams, each agent role with a **GitHub link to its system prompt**, plus a section explaining the project plan document attachment.
- `roles-and-coordination.md`: links the **CEO** and **Coach** system prompts, documents them as instance-wide HQ singletons, and points the worker-roster section at the team catalog.

**Tests**
- Updated server (`projects.test.ts`, `helpers/app.ts`), web (`project-crud.test.tsx`), and browser (`helpers.ts`) references.
- Added a new component test that drives the dialog: asserts the label + help tooltip render, uploads a plan file, submits, and confirms it persists as `project-plan.md`.

The MCP `create_project` tool's param is not surfaced in `docs/mcp/`, `skill-file.ts`, or `llms.txt`, so the agent-facing-surface propagation rule doesn't pull those in.

## Verification

- `bunx turbo typecheck` ✅ (also runs in pre-commit)
- `packages/server`: `projects.test.ts`, `mcp-tools.test.ts`, `approval-handlers.test.ts` — 108 passed ✅
- `packages/web`: `project-crud.test.tsx`, `prd-approval-linkback.test.tsx` — 7 passed ✅ (incl. new dialog test)
- `biome check` clean (only pre-existing warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rwSGSrjuYhBHHMTf8yQJ3

---
_Generated by [Claude Code](https://claude.ai/code/session_017rwSGSrjuYhBHHMTf8yQJ3)_