### PR TITLE
fix(realtime): render agent comments and reactions live without refresh

### DIFF
--- a/packages/server/src/lib/broadcast.ts
+++ b/packages/server/src/lib/broadcast.ts
@@ -27,6 +27,32 @@ export function broadcastChange(
 	broadcastRowChange(c.get('wsManager'), room, table, action, row);
 }
 
+/**
+ * Broadcast a comment-family row (`task_comments`, `comment_reactions`,
+ * `comment_attachments`) enriched with `project_id`.
+ *
+ * These tables have no `team_id`/`project_id` column, but the web client's
+ * realtime subscriber (`useShellWebSockets`) resolves the project slug it
+ * invalidates on from `row.project_id` (falling back to `row.team_id`). The
+ * team fallback excludes `is_internal` projects, so a bare row — or one keyed
+ * only by `team_id` — never resolves for HQ tasks. Injecting `project_id`
+ * (resolved with no internal-project filter) makes the change render live for
+ * internal and ordinary projects alike. `teamId` still selects the WS room.
+ */
+export function broadcastCommentFamilyChange(
+	wsManager: WebSocketManager | undefined,
+	teamId: string,
+	projectId: string,
+	table: string,
+	action: ChangeAction,
+	row: Record<string, unknown>,
+): void {
+	broadcastRowChange(wsManager, wsRoom.team(teamId), table, action, {
+		...row,
+		project_id: projectId,
+	});
+}
+
 export function broadcastEvent(
 	wsManager: WebSocketManager,
 	room: string,

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -39,7 +39,7 @@ import { isCoach, isVirtualHqMemberInTeam } from '../lib/agent-roles';
 import { upsertProjectAsset } from '../lib/asset-name';
 import { assertSubordinateAssignee } from '../lib/assignment-hierarchy';
 import { trackBackground } from '../lib/background';
-import { broadcastRowChange } from '../lib/broadcast';
+import { broadcastCommentFamilyChange, broadcastRowChange } from '../lib/broadcast';
 import { credentialPlaceholder, validateSecretName } from '../lib/credential-placeholder';
 import {
 	coerceTargetStatusForBlockers,
@@ -1654,12 +1654,19 @@ export function registerTools(
 				memberId,
 			});
 			if (!result.ok) return { error: result.message };
-			broadcastRowChange(wsManager, wsRoom.team(teamId), 'comment_reactions', 'INSERT', {
-				comment_id: args.comment_id,
-				task_id: taskId,
-				member_id: memberId,
-				kind: args.kind,
-			});
+			broadcastCommentFamilyChange(
+				wsManager,
+				teamId,
+				scope.projectId,
+				'comment_reactions',
+				'INSERT',
+				{
+					comment_id: args.comment_id,
+					task_id: taskId,
+					member_id: memberId,
+					kind: args.kind,
+				},
+			);
 			return {
 				comment_id: args.comment_id,
 				kind: args.kind,
@@ -1701,12 +1708,19 @@ export function registerTools(
 				memberId,
 			});
 			if (!result.ok) return { error: result.message };
-			broadcastRowChange(wsManager, wsRoom.team(teamId), 'comment_reactions', 'DELETE', {
-				comment_id: args.comment_id,
-				task_id: taskId,
-				member_id: memberId,
-				kind: args.kind,
-			});
+			broadcastCommentFamilyChange(
+				wsManager,
+				teamId,
+				scope.projectId,
+				'comment_reactions',
+				'DELETE',
+				{
+					comment_id: args.comment_id,
+					task_id: taskId,
+					member_id: memberId,
+					kind: args.kind,
+				},
+			);
 			return {
 				comment_id: args.comment_id,
 				kind: args.kind,
@@ -1761,6 +1775,18 @@ export function registerTools(
 					CommentContentType.Text,
 					JSON.stringify(content),
 				],
+			);
+			// Realtime: notify open task pages. Agent comments come through MCP,
+			// which (unlike the REST POST path) never broadcast — so they only
+			// appeared on refresh. task_comments has no project_id column, so the
+			// helper injects it for the web client's slug resolution.
+			broadcastCommentFamilyChange(
+				wsManager,
+				teamId,
+				scope.projectId,
+				'task_comments',
+				'INSERT',
+				r.rows[0],
 			);
 			await fireCommentWakeups({
 				db,
@@ -1928,8 +1954,16 @@ export function registerTools(
 			const inserted = await db.query<{ id: string }>(
 				`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
 				 VALUES ($1, $2, 'credential_request'::comment_content_type, $3::jsonb)
-				 RETURNING id`,
+				 RETURNING *`,
 				[taskId, authorMemberId, JSON.stringify(content)],
+			);
+			broadcastCommentFamilyChange(
+				wsManager,
+				teamId,
+				scope.projectId,
+				'task_comments',
+				'INSERT',
+				inserted.rows[0],
 			);
 
 			events?.emit({
@@ -2073,10 +2107,18 @@ export function registerTools(
 				const inserted = await db.query<{ id: string }>(
 					`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
 					 VALUES ($1, $2, 'connect_required'::comment_content_type, $3::jsonb)
-					 RETURNING id`,
+					 RETURNING *`,
 					[taskId, authorMemberId, JSON.stringify(content)],
 				);
 				commentId = inserted.rows[0].id;
+				broadcastCommentFamilyChange(
+					wsManager,
+					teamId,
+					scope.projectId,
+					'task_comments',
+					'INSERT',
+					inserted.rows[0],
+				);
 			}
 
 			return {

--- a/packages/server/src/routes/comments.ts
+++ b/packages/server/src/routes/comments.ts
@@ -1,8 +1,8 @@
-import { AuthType, CommentContentType, WakeupSource, wsRoom } from '@hezo/shared';
+import { AuthType, CommentContentType, WakeupSource } from '@hezo/shared';
 import { Hono } from 'hono';
 import { encrypt } from '../crypto/encryption';
 import { signAssetUrl } from '../lib/asset-urls';
-import { broadcastChange } from '../lib/broadcast';
+import { broadcastCommentFamilyChange } from '../lib/broadcast';
 import { validateCredentialValue } from '../lib/credential-validator';
 import {
 	connectedAgentIdFromAuth,
@@ -90,12 +90,19 @@ commentsRoutes.put(
 			return err(c, result.code, result.message, status);
 		}
 
-		broadcastChange(c, wsRoom.team(teamId), 'comment_reactions', 'INSERT', {
-			comment_id: commentId,
-			task_id: taskId,
-			member_id: memberId,
-			kind,
-		});
+		broadcastCommentFamilyChange(
+			c.get('wsManager'),
+			teamId,
+			c.get('projectId') as string,
+			'comment_reactions',
+			'INSERT',
+			{
+				comment_id: commentId,
+				task_id: taskId,
+				member_id: memberId,
+				kind,
+			},
+		);
 		return ok(c, { comment_id: commentId, kind, reactions: result.reactions });
 	},
 );
@@ -128,12 +135,19 @@ commentsRoutes.delete(
 			return err(c, result.code, result.message, status);
 		}
 
-		broadcastChange(c, wsRoom.team(teamId), 'comment_reactions', 'DELETE', {
-			comment_id: commentId,
-			task_id: taskId,
-			member_id: memberId,
-			kind,
-		});
+		broadcastCommentFamilyChange(
+			c.get('wsManager'),
+			teamId,
+			c.get('projectId') as string,
+			'comment_reactions',
+			'DELETE',
+			{
+				comment_id: commentId,
+				task_id: taskId,
+				member_id: memberId,
+				kind,
+			},
+		);
 		return ok(c, { comment_id: commentId, kind, reactions: result.reactions });
 	},
 );
@@ -280,18 +294,26 @@ commentsRoutes.post('/projects/:projectId/tasks/:taskId/comments', async (c) => 
 		).catch((e) => log.error('Failed to record task links from comment:', e));
 	}
 
-	broadcastChange(
-		c,
-		wsRoom.team(teamId),
+	broadcastCommentFamilyChange(
+		c.get('wsManager'),
+		teamId,
+		c.get('projectId') as string,
 		'task_comments',
 		'INSERT',
 		result.rows[0] as Record<string, unknown>,
 	);
 	if (attachmentIds.length > 0) {
-		broadcastChange(c, wsRoom.team(teamId), 'comment_attachments', 'INSERT', {
-			comment_id: result.rows[0].id,
-			asset_ids: attachmentIds,
-		});
+		broadcastCommentFamilyChange(
+			c.get('wsManager'),
+			teamId,
+			c.get('projectId') as string,
+			'comment_attachments',
+			'INSERT',
+			{
+				comment_id: result.rows[0].id,
+				asset_ids: attachmentIds,
+			},
+		);
 	}
 
 	const masterKeyManager = c.get('masterKeyManager');
@@ -443,7 +465,14 @@ commentsRoutes.post(
 			}
 		}
 
-		broadcastChange(c, wsRoom.team(teamId), 'task_comments', 'UPDATE', updatedComment);
+		broadcastCommentFamilyChange(
+			c.get('wsManager'),
+			teamId,
+			c.get('projectId') as string,
+			'task_comments',
+			'UPDATE',
+			updatedComment,
+		);
 		const actor = await resolveActor(db, c.get('auth'), teamId);
 		c.get('events').emit({
 			type: 'credential.fulfilled',

--- a/packages/server/test/comment-realtime-broadcast.test.ts
+++ b/packages/server/test/comment-realtime-broadcast.test.ts
@@ -1,0 +1,214 @@
+import { CredentialKind, ReactionKind, WsMessageType, wsRoom } from '@hezo/shared';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { WebSocketManager, type WsEvent } from '../src/services/ws';
+import { safeClose } from './helpers';
+import {
+	authHeader,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+	mintAgentToken,
+} from './helpers/app';
+
+interface CapturedBroadcast {
+	room: string;
+	event: WsEvent;
+}
+
+/**
+ * Comment-family rows (`task_comments`, `comment_reactions`, …) have no
+ * `team_id`/`project_id` column, but the web client's realtime subscriber
+ * resolves the project slug it invalidates on from `row.project_id` (the
+ * `team_id` fallback can't resolve `is_internal` HQ tasks). So every
+ * comment-family broadcast MUST carry `project_id`, and `create_comment` —
+ * which previously never broadcast — must broadcast at all. Without these,
+ * agent comments/reactions only appear after a page refresh.
+ */
+describe('comment-family realtime broadcasts carry project_id', () => {
+	let ctx: Awaited<ReturnType<typeof createTestApp>>;
+	let teamId: string;
+	let projectId: string;
+	let projectSlug: string;
+	let agentId: string;
+	let taskId: string;
+	let captured: CapturedBroadcast[];
+	let broadcastSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeAll(async () => {
+		ctx = await createTestApp();
+
+		const typesRes = await ctx.app.request('/api/team-templates', {
+			headers: authHeader(ctx.token),
+		});
+		const typeId = (await typesRes.json()).data.find(
+			(t: { name: string }) => t.name === 'Startup',
+		).id;
+
+		const teamRes = await createTestTeam(ctx.db, {
+			name: 'Comment Realtime Co',
+			template_id: typeId,
+		});
+		teamId = (await teamRes.json()).data.id;
+
+		const projectRes = await createTestProject(ctx.db, teamId, {
+			name: 'Comment Realtime Project',
+		});
+		const project = (await projectRes.json()).data;
+		projectId = project.id;
+		projectSlug = project.slug;
+
+		const agentsRes = await ctx.app.request(`/api/projects/${projectSlug}/agents`, {
+			headers: authHeader(ctx.token),
+		});
+		agentId = (await agentsRes.json()).data[0].id;
+
+		const taskRes = await ctx.app.request(`/api/projects/${projectSlug}/tasks`, {
+			method: 'POST',
+			headers: { ...authHeader(ctx.token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ project_id: projectId, title: 'Realtime Seed', assignee_id: agentId }),
+		});
+		taskId = (await taskRes.json()).data.id;
+
+		captured = [];
+		broadcastSpy = vi.spyOn(WebSocketManager.prototype, 'broadcast').mockImplementation(function (
+			this: WebSocketManager,
+			room: string,
+			event: WsEvent,
+		) {
+			captured.push({ room, event });
+		});
+	});
+
+	afterAll(async () => {
+		broadcastSpy.mockRestore();
+		await safeClose(ctx.db);
+	});
+
+	beforeEach(() => {
+		captured.length = 0;
+	});
+
+	function findRow(table: string, action: string): Record<string, unknown> | undefined {
+		const room = wsRoom.team(teamId);
+		const entry = captured.find(
+			(e) =>
+				e.room === room &&
+				e.event.type === WsMessageType.RowChange &&
+				e.event.table === table &&
+				e.event.action === action,
+		);
+		return entry?.event.row as Record<string, unknown> | undefined;
+	}
+
+	async function callMcp(
+		agentToken: string,
+		name: string,
+		args: Record<string, unknown>,
+	): Promise<Record<string, unknown>> {
+		const res = await ctx.app.request('/mcp', {
+			method: 'POST',
+			headers: { ...authHeader(agentToken), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				jsonrpc: '2.0',
+				method: 'tools/call',
+				params: { name, arguments: args },
+				id: 1,
+			}),
+		});
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { result: { content: Array<{ text: string }> } };
+		return JSON.parse(body.result.content[0].text) as Record<string, unknown>;
+	}
+
+	async function seedComment(text: string): Promise<string> {
+		const r = await ctx.db.query<{ id: string }>(
+			`INSERT INTO task_comments (task_id, content_type, content)
+			 VALUES ($1, 'text'::comment_content_type, $2::jsonb) RETURNING id`,
+			[taskId, JSON.stringify({ text })],
+		);
+		return r.rows[0].id;
+	}
+
+	it('MCP create_comment broadcasts task_comments INSERT with project_id (Bug B + A)', async () => {
+		const { token: agentToken } = await mintAgentToken(
+			ctx.db,
+			ctx.masterKeyManager,
+			agentId,
+			teamId,
+		);
+		await callMcp(agentToken, 'create_comment', {
+			project: projectId,
+			task_id: taskId,
+			content: 'live agent comment',
+		});
+
+		const row = findRow('task_comments', 'INSERT');
+		expect(row).toBeDefined();
+		expect(row?.project_id).toBe(projectId);
+	});
+
+	it('REST POST comment broadcasts task_comments INSERT with project_id', async () => {
+		const res = await ctx.app.request(`/api/projects/${projectSlug}/tasks/${taskId}/comments`, {
+			method: 'POST',
+			headers: { ...authHeader(ctx.token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ content: { text: 'human live comment' } }),
+		});
+		expect(res.status).toBe(201);
+
+		const row = findRow('task_comments', 'INSERT');
+		expect(row).toBeDefined();
+		expect(row?.project_id).toBe(projectId);
+	});
+
+	it('MCP add_reaction / remove_reaction broadcast comment_reactions with project_id', async () => {
+		const commentId = await seedComment('react to me');
+		const { token: agentToken } = await mintAgentToken(
+			ctx.db,
+			ctx.masterKeyManager,
+			agentId,
+			teamId,
+		);
+
+		await callMcp(agentToken, 'add_reaction', {
+			project: projectId,
+			task_id: taskId,
+			comment_id: commentId,
+			kind: ReactionKind.Ack,
+		});
+		const insert = findRow('comment_reactions', 'INSERT');
+		expect(insert).toBeDefined();
+		expect(insert?.project_id).toBe(projectId);
+
+		captured.length = 0;
+		await callMcp(agentToken, 'remove_reaction', {
+			project: projectId,
+			task_id: taskId,
+			comment_id: commentId,
+			kind: ReactionKind.Ack,
+		});
+		const remove = findRow('comment_reactions', 'DELETE');
+		expect(remove).toBeDefined();
+		expect(remove?.project_id).toBe(projectId);
+	});
+
+	it('MCP request_credential broadcasts task_comments INSERT with project_id', async () => {
+		const { token: agentToken } = await mintAgentToken(
+			ctx.db,
+			ctx.masterKeyManager,
+			agentId,
+			teamId,
+		);
+		const result = await callMcp(agentToken, 'request_credential', {
+			project: projectId,
+			task_id: taskId,
+			name: 'TEST_SECRET',
+			kind: CredentialKind.Other,
+			instructions: 'Paste the test secret value.',
+		});
+		expect(result.comment_id).toBeDefined();
+
+		const row = findRow('task_comments', 'INSERT');
+		expect(row).toBeDefined();
+		expect(row?.project_id).toBe(projectId);
+	});
+});

--- a/packages/web/src/hooks/use-websocket.ts
+++ b/packages/web/src/hooks/use-websocket.ts
@@ -108,6 +108,29 @@ export function invalidateQueriesForRowChange(
 	}
 }
 
+/**
+ * Resolve the project slug a row_change maps to, from the cached projects index.
+ *
+ * Prefers `row.project_id` — it resolves for *every* project, including the
+ * `is_internal` HQ project. Falls back to `row.team_id`, which maps a team-wide
+ * row to that team's user-facing (non-internal) project; that fallback can't
+ * resolve HQ. Comment-family rows (`task_comments` / `comment_reactions` /
+ * `comment_attachments`) have no `team_id` column, so they depend on the server
+ * setting `project_id` on the broadcast (see `broadcastCommentFamilyChange`).
+ */
+export function resolveProjectSlugForRow(
+	index: Project[],
+	row: Record<string, unknown>,
+): string | undefined {
+	const teamUuid = row.team_id as string | undefined;
+	const projectUuid = row.project_id as string | undefined;
+	const byProjectId = projectUuid ? index.find((p) => p.id === projectUuid) : undefined;
+	const teamUserProject = teamUuid
+		? index.find((p) => p.team_id === teamUuid && !p.is_internal)
+		: undefined;
+	return byProjectId?.slug ?? teamUserProject?.slug;
+}
+
 interface TeamRoom {
 	id: string;
 	slug: string;
@@ -163,16 +186,10 @@ export function useShellWebSockets(teams: TeamRoom[] | undefined): void {
 
 		const unsubscribe = subscribe(WsMessageType.RowChange, (msg) => {
 			const { table, row } = msg as WsRowChangeMessage;
-			const teamUuid = row.team_id as string | undefined;
-			const projectUuid = row.project_id as string | undefined;
 
 			// Resolve the project slug the change maps to from the cached index.
 			const index = queryClient.getQueryData<Project[]>(queryKeys.projects.all()) ?? [];
-			const byProjectId = projectUuid ? index.find((p) => p.id === projectUuid) : undefined;
-			const teamUserProject = teamUuid
-				? index.find((p) => p.team_id === teamUuid && !p.is_internal)
-				: undefined;
-			const cid = byProjectId?.slug ?? teamUserProject?.slug;
+			const cid = resolveProjectSlugForRow(index, row);
 
 			if (cid) {
 				invalidateQueriesForRowChange(queryClient, cid, table, row);

--- a/packages/web/test/query-keys-websocket.test.ts
+++ b/packages/web/test/query-keys-websocket.test.ts
@@ -63,6 +63,21 @@ describe('invalidateQueriesForRowChange uses the queryKeys factory', () => {
 		expect(keys).toContainEqual(queryKeys.projects.skills(SLUG));
 	});
 
+	test('task_comments invalidates the task list (prefix-covers taskComments)', () => {
+		// task_comments maps to projects.tasks(cid); per the queryKeys factory that
+		// prefix also invalidates taskComments(cid, taskId) beneath it, so an
+		// incoming comment refetches the open thread.
+		const { client, keys } = recordingClient();
+		invalidateQueriesForRowChange(client, SLUG, 'task_comments', { task_id: 't1' });
+		expect(keys).toContainEqual(queryKeys.projects.tasks(SLUG));
+	});
+
+	test('comment_reactions invalidates the task list', () => {
+		const { client, keys } = recordingClient();
+		invalidateQueriesForRowChange(client, SLUG, 'comment_reactions', { task_id: 't1' });
+		expect(keys).toContainEqual(queryKeys.projects.tasks(SLUG));
+	});
+
 	test('unknown table is a no-op', () => {
 		const { client, keys } = recordingClient();
 		invalidateQueriesForRowChange(client, SLUG, 'nonexistent', {});

--- a/packages/web/test/resolve-project-slug-for-row.test.ts
+++ b/packages/web/test/resolve-project-slug-for-row.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'vitest';
+import type { Project } from '../src/hooks/use-projects';
+import { resolveProjectSlugForRow } from '../src/hooks/use-websocket';
+
+// resolveProjectSlugForRow only reads id/slug/team_id/is_internal; cast minimal
+// fixtures rather than spelling out every Project field.
+function project(p: { id: string; slug: string; team_id: string; is_internal?: boolean }): Project {
+	return p as unknown as Project;
+}
+
+const HQ = project({ id: 'hq-proj', slug: 'hq', team_id: 'hq-team', is_internal: true });
+const OPS = project({
+	id: 'ops-proj',
+	slug: 'operations',
+	team_id: 'ops-team',
+	is_internal: false,
+});
+const index = [HQ, OPS];
+
+describe('resolveProjectSlugForRow', () => {
+	test('resolves an ordinary project from project_id', () => {
+		expect(resolveProjectSlugForRow(index, { project_id: 'ops-proj' })).toBe('operations');
+	});
+
+	test('resolves the internal HQ project from project_id — team_id cannot', () => {
+		// HQ is is_internal: the team fallback excludes internal projects, so a
+		// comment-family row keyed only by team_id would never resolve for HQ-1.
+		// project_id is the field that makes the realtime fix work for HQ.
+		expect(resolveProjectSlugForRow(index, { project_id: 'hq-proj' })).toBe('hq');
+		expect(resolveProjectSlugForRow(index, { team_id: 'hq-team' })).toBeUndefined();
+	});
+
+	test('falls back to team_id for a non-internal team-wide row', () => {
+		expect(resolveProjectSlugForRow(index, { team_id: 'ops-team' })).toBe('operations');
+	});
+
+	test('prefers project_id over team_id', () => {
+		expect(resolveProjectSlugForRow(index, { project_id: 'ops-proj', team_id: 'hq-team' })).toBe(
+			'operations',
+		);
+	});
+
+	test('returns undefined for a bare row with neither id', () => {
+		// A pre-fix comment-family row (only task_id) is unresolvable — exactly why
+		// the broadcast must inject project_id.
+		expect(resolveProjectSlugForRow(index, { task_id: 't1' })).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Problem

On an open task page, comments and reactions posted by **agent runs** (and by a second human viewer) didn't appear until the page was refreshed. The author's *own* comment/reaction shows immediately via the optimistic mutation, which masked the broken realtime path until an agent (or another person) was the author. The reported example was **HQ-1**, an HQ/internal-project task.

## Root cause — two server-side defects

**Bug A — comment-family broadcast rows weren't resolvable on the client.** The web client's realtime subscriber (`useShellWebSockets`) resolves the project slug to invalidate from `row.project_id` / `row.team_id`. But `task_comments`, `comment_reactions`, and `comment_attachments` have **neither** column, so the broadcast rows carried no resolvable id → `cid` was `undefined` → nothing was invalidated → no refetch. (The `team_id` fallback also excludes `is_internal` projects, so even a team-keyed row would never resolve for HQ.)

**Bug B — the MCP `create_comment` tool never broadcast at all.** Agent comments go through MCP, but unlike the REST `POST` path, `create_comment` never emitted a row-change. `request_credential` and `register_connector` had the same omission.

## Fix

- Add `broadcastCommentFamilyChange` (in `lib/broadcast.ts`) that injects `project_id` into the row — it resolves for **internal and ordinary projects alike** (no `is_internal` filter), unlike `team_id`. `team_id` still selects the WS room.
- Route every comment-family broadcast through it, and add the previously-missing broadcasts to `create_comment`, `request_credential`, and `register_connector` (MCP) plus the existing REST comment/reaction/attachment/fulfill-credential broadcasts.
- Extract the client row→slug resolution into a pure, exported `resolveProjectSlugForRow` so the HQ/`is_internal` case is directly unit-testable. The `TABLE_TO_QUERY_KEY` mapping was already correct (prefix invalidation of `projects.tasks(cid)` covers `taskComments`), so no client invalidation-key change was needed.

## Tests

- **Server** (`comment-realtime-broadcast.test.ts`): broadcast-spy coverage asserting `create_comment`, `add_reaction`/`remove_reaction`, the REST comment POST, and `request_credential` all emit rows carrying `project_id` on the team room.
- **Web** (`resolve-project-slug-for-row.test.ts`): pins that a row with only `project_id` resolves — including for an `is_internal` HQ project — and that a bare row (only `task_id`) does not. Plus `task_comments`/`comment_reactions` cases added to the existing `query-keys-websocket` suite.

Verified: `bun run typecheck`, `bun run check` (0 errors), targeted server + web suites, and existing `mcp-tools` / `comment-wakeups` / web comment component tests all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aytf8EcME2htp2jgG8a7M7)_