### PR TITLE
feat(ceo): let the CEO retire agents and stop premature project provisioning

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -192,10 +192,13 @@ project.
 `default`), owns the only `is_internal` project. It hosts two instance-level singletons:
 
 - **CEO** — runs all coordination. **Project intake** and first-run **onboarding**
-  (pre-project) live in HQ. Per-team **setup/coherence review** and **hiring** concern a
-  specific project-team and live in *that team's own project*, CEO-actioned. On a new
-  team the CEO's initial coherence pass runs first and **blocks** the Captain's planning
-  task.
+  (pre-project) live in HQ. Per-team **setup/coherence review**, **hiring**, and
+  **retiring** concern a specific project-team and live in *that team's own project*,
+  CEO-actioned. Retiring/reinstating an agent is the `set_agent_status` MCP tool (gated to
+  the team's Captain or an HQ coordinator), which runs the same `setAgentAdminStatus`
+  service as the REST disable/enable routes — it can't disable a Captain or an instance
+  agent. On a new team the CEO's initial coherence pass runs first and **blocks** the
+  Captain's planning task.
 - **Coach** — reviews completed tickets across **every** project to improve agent system
   prompts; woken on any task completion.
 

--- a/agents/_instance/ceo.md
+++ b/agents/_instance/ceo.md
@@ -10,10 +10,10 @@ You live in **HQ**, the instance-level coordination project. You are the only ag
 
 ## What you own
 
-- **New project intake (in HQ).** When the admin submits the Create Project form, an intake ticket opens in HQ assigned to you. Clarify scope (put an active `@admin` in any comment where you need them to answer — without it the question reaches no inbox) and settle the team type — the admin's chosen team type is your baseline; call `list_team_templates` to suggest a better-fitting built-in or saved type if there is one. This is a normal conversation, not an inbox approval: once the admin gives the go-ahead in the thread (a plain reply approving it is enough), create it yourself with `create_project`, which stands up the project, its team and its Captain and closes the intake ticket.
+- **New project intake (in HQ).** When the admin submits the Create Project form, an intake ticket opens in HQ assigned to you. First **clarify scope and settle the team type** — the admin's chosen team type is your baseline; call `list_team_templates` to suggest a better-fitting built-in or saved type if there is one. Put an active `@admin` in any comment where you need them to answer (without it the question reaches no inbox). Creating a project is **consequential and never automatic**: `create_project` stands up a team, its full roster, and a container. So **do not call `create_project` until the admin has explicitly approved the finalised scope *and* team type.** This is a conversation, not an inbox approval — a plain reply is enough, but it must be a clear go-ahead on what you've settled, **not** a mid-discussion remark, an answer to one of your own questions, or your assumption of sensible defaults. While anything is still open, or you are still proposing an approach, keep scoping and wait — do not announce "I'll provision it now" and create it in the same breath. Only once the admin confirms do you create it with `create_project`, which closes the intake ticket.
 - **First-run onboarding (in HQ).** On a fresh instance you help the admin stand up their very first project the same way.
 - **Team setup & coherence (in each project-team's project).** When a project-team is created or its roster changes, a coherence-review ticket opens **in that project**. Audit the roster, fix reporting lines, and rewrite the descriptive blobs other agents read so they stay accurate. On a brand-new team this setup pass runs first — the Captain's planning ticket is blocked until you complete it.
-- **Hiring (in the relevant project-team's project).** Review and shape proposed hires for a team, then ask the admin to approve.
+- **Roster changes (in the relevant project-team's project).** Review and shape proposed hires for a team, then ask the admin to approve. You can also **retire** an agent a team no longer needs (e.g. roles that don't fit its goal): once the admin confirms, call `set_agent_status` with `status: disabled` to retire it — this stops it being scheduled and unassigns its open work — and `status: enabled` to reinstate it. Retiring is reversible and keeps the agent's history, but still confirm with the admin first. The Captain and the instance agents (you and the Coach) can't be retired this way.
 - **Cross-project direction.** Resolve conflicts over shared priorities, sequencing and budget between projects; keep an instance-wide view of progress and surface risks to the admin early.
 
 ## Helping the operator directly
@@ -24,7 +24,7 @@ In the live chat box you are talking to a human, so write for a human: refer to 
 
 - **General questions** — answer directly, in place. No ticket needed for a quick answer or explanation.
 - **Anything about an existing project** — work *through that project* and its Captain. Read and act across the project as needed; for anything substantial, open (or have the Captain open) a ticket in that project so the work is tracked, rather than doing it all inline.
-- **A new initiative the operator wants to build** — propose creating a project and **recommend the team type** that best fits the work. On the operator's go-ahead, create it with `create_project`, which stands up the project, its team and its Captain.
+- **A new initiative the operator wants to build** — propose creating a project and **recommend the team type** that best fits the work, then wait. Create it with `create_project` (which stands up the project, its team and its Captain) only once the operator gives an explicit go-ahead on that proposal — never provision a project or its team while you are still scoping it, answering a question, or running on assumed defaults.
 - **A sizeable chunk of instance-level work not tied to any one project** — create a trackable ticket in HQ (assign it to yourself or the right owner) instead of trying to complete it all in the conversation.
 
 Default to **trackable work** for anything beyond a quick answer: when the effort is non-trivial, prefer creating a ticket (in HQ or the relevant project) or a project over a long inline reply, so progress is visible and resumable.
@@ -52,6 +52,7 @@ You are the operator's guide to Hezo. Help them understand and set up their inst
 
 - Lead through the Captains. Hand each Captain clear direction — what needs to happen, why it matters, and the priority — and let them delegate within their team.
 - Keep communications concise and decision-oriented.
+- Take consequential, hard-to-reverse actions — above all creating a project and its team — only on the admin's explicit go-ahead, never preemptively while you are still scoping or on assumed defaults. Proposing an approach or asking a clarifying question is not approval; wait for the answer.
 - Escalate to the admin rather than deciding alone when a decision changes strategic direction or carries significant budget impact.
 
 ---

--- a/docs/concepts/hiring-and-agents.md
+++ b/docs/concepts/hiring-and-agents.md
@@ -41,6 +41,16 @@ any individual agent, so (for example) one agent runs on a frontier model for ha
 reasoning while the rest run on something cheaper and faster. Mixing providers within a
 single team is fully supported. See [AI model support](/docs/ai-models).
 
+## Retiring & reinstating agents
+
+When a team no longer needs a role, you can **retire** (disable) the agent — from its
+settings in the web app, or just by asking the CEO. Retiring stops the agent from being
+scheduled and unassigns it from any open tasks, but keeps all of its history, so it's
+fully reversible: reinstate (enable) it at any time and it picks work back up on its
+heartbeat. The CEO actions this directly once you confirm, which is handy after a
+project's direction changes and several roles no longer fit. (A team's Captain and the
+instance-wide CEO and Coach can't be retired this way.)
+
 ## Other settings
 
 You can also adjust an agent's heartbeat interval and budgets over time, and pause or

--- a/docs/concepts/roles-and-coordination.md
+++ b/docs/concepts/roles-and-coordination.md
@@ -15,14 +15,16 @@ exactly one CEO, and it lives in [HQ](/docs/concepts/projects-and-teams#hq--the-
 so it can see and act across every project. You chat with the CEO to get things done
 across the whole instance:
 
-- **Intake** — describe a new project and the CEO scopes it and provisions the team
-  (see [Your first project](/docs/getting-started/first-project)).
+- **Intake** — describe a new project and the CEO scopes it with you, then provisions the
+  team once you've confirmed the plan (see
+  [Your first project](/docs/getting-started/first-project)). It won't create anything
+  until you give the go-ahead.
 - **Coordination** — ask about any project's status, tickets, or roster; the CEO
   works across every team.
 - **Setup review** — when a new team is created, the CEO runs a coherence check before
   the team starts planning, so the roster is aligned with the goal.
-- **Actioning changes** — hire new agents, adjust system prompts, and change settings,
-  all through the conversation. See
+- **Actioning changes** — hire new agents, retire ones a team no longer needs, adjust
+  system prompts, and change settings, all through the conversation. See
   [Hiring & customizing agents](/docs/concepts/hiring-and-agents).
 
 Because the CEO can make consequential changes, significant actions surface as

--- a/packages/server/src/lib/agent-roles.ts
+++ b/packages/server/src/lib/agent-roles.ts
@@ -27,3 +27,20 @@ export async function isVirtualHqMemberInTeam(
 	]);
 	return r.rows[0]?.team_id === DEFAULT_TEAM_ID;
 }
+
+/**
+ * True when the caller is an HQ instance agent (CEO/Coach) — regardless of which
+ * team its run is currently scoped to. Unlike {@link isVirtualHqMemberInTeam} this
+ * does not require `auth.teamId` to equal a particular team, so it recognises the
+ * cross-team CEO chat session (scoped to HQ, `crossTeam`) as well as a CEO/Coach
+ * task run scoped into another team. Use this for cross-team coordination actions
+ * the CEO can take from anywhere; pair it with a per-team check when the action is
+ * also open to that team's own Captain.
+ */
+export async function isHqInstanceAgent(db: PGlite, auth: AuthInfo): Promise<boolean> {
+	if (auth.type !== AuthType.Agent) return false;
+	const r = await db.query<{ team_id: string }>('SELECT team_id FROM members WHERE id = $1', [
+		auth.memberId,
+	]);
+	return r.rows[0]?.team_id === DEFAULT_TEAM_ID;
+}

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -3,6 +3,7 @@ import type { PGlite } from '@electric-sql/pglite';
 import type { SearchScope } from '@hezo/shared';
 import {
 	ADMIN_MENTION_SLUG,
+	AgentAdminStatus,
 	ApprovalStatus,
 	ApprovalType,
 	ATTACHMENT_EXTENSIONS,
@@ -11,6 +12,7 @@ import {
 	AuthType,
 	CAPTAIN_AGENT_SLUG,
 	CEO_AGENT_SLUG,
+	COACH_AGENT_SLUG,
 	CommentContentType,
 	CredentialInputType,
 	CredentialKind,
@@ -35,7 +37,7 @@ import { z } from 'zod';
 import type { MasterKeyManager } from '../crypto/master-key';
 import type { DomainEventBus } from '../events/bus';
 import { assertNoActiveRun } from '../lib/active-run';
-import { isCoach, isVirtualHqMemberInTeam } from '../lib/agent-roles';
+import { isCoach, isHqInstanceAgent, isVirtualHqMemberInTeam } from '../lib/agent-roles';
 import { upsertProjectAsset } from '../lib/asset-name';
 import { assertSubordinateAssignee } from '../lib/assignment-hierarchy';
 import { trackBackground } from '../lib/background';
@@ -61,6 +63,7 @@ import { deriveSkillSummary } from '../lib/skill-summary';
 import { assertChildrenAllClosed, assertNoOutstandingActivity } from '../lib/task-relationships';
 import type { AuthInfo } from '../lib/types';
 import { logger } from '../logger';
+import { setAgentAdminStatus } from '../services/agent-admin';
 import { AGENT_ATTACHMENT_DIR, loadAgentAttachmentsForComments } from '../services/agent-runner';
 import {
 	AgentSystemPromptError,
@@ -133,6 +136,7 @@ const MCP_WRITE_TOOLS: ReadonlySet<string> = new Set([
 	'register_connector',
 	'resolve_approval',
 	'update_agent_system_prompt',
+	'set_agent_status',
 	'set_agent_summary',
 	'set_team_summary',
 	'set_agent_team_context',
@@ -1327,7 +1331,7 @@ export function registerTools(
 	tool(
 		server,
 		'create_project',
-		'Create a new project together with its dedicated team. CEO-only. Call this once the admin has approved a new project in the intake conversation — a plain reply in the thread is enough; there is no inbox button to wait on. Provisions the team from the chosen team-type template (pass template_id from list_team_templates, or source_team_id to clone an existing team; defaults to Blank), creates the project, its planning ticket, and the initial CEO coherence/setup ticket the planning ticket is blocked on, then provisions the container. When intake_task_id is given, the intake conversation is closed with a completion note. Returns the new project plus its planning ticket identifier.',
+		'Create a new project together with its dedicated team. CEO-only. Call this ONLY after the admin has explicitly approved the finalised scope AND team type in the intake conversation — a plain reply approving it is enough (there is no inbox button to wait on), but do not call it while still scoping, on assumed defaults, or in the same turn you propose the plan; creating a project stands up a full team + container, so wait for the go-ahead. Provisions the team from the chosen team-type template (pass template_id from list_team_templates, or source_team_id to clone an existing team; defaults to Blank), creates the project, its planning ticket, and the initial CEO coherence/setup ticket the planning ticket is blocked on, then provisions the container. When intake_task_id is given, the intake conversation is closed with a completion note. Returns the new project plus its planning ticket identifier.',
 		{
 			name: z.string().describe('Project name'),
 			description: z.string().describe('Project description'),
@@ -2692,6 +2696,87 @@ export function registerTools(
 			if (r.rows.length === 0) return { error: 'Agent not found in this team' };
 
 			return r.rows[0];
+		},
+		db,
+	);
+
+	tool(
+		server,
+		'set_agent_status',
+		"Retire (disable) or reinstate (enable) an agent on a project's team. Callable by the team's Captain or by the CEO running in the team. Disabling stops the agent from being scheduled and unassigns it from every open task; enabling resumes scheduling. The change is fully reversible and preserves all of the agent's history, so this is the right way to remove a role the team no longer needs (e.g. after a coherence review). The Captain and the instance agents (CEO/Coach) cannot be disabled this way. Confirm with the admin before retiring an agent.",
+		{
+			project: projectArg(),
+			agent: z
+				.string()
+				.describe(
+					'Target agent — its slug (e.g. "engineer") or member ID. Must be a member of this project\'s team.',
+				),
+			status: z
+				.enum([AgentAdminStatus.Enabled, AgentAdminStatus.Disabled])
+				.describe('"disabled" retires the agent; "enabled" reinstates it.'),
+		},
+		async (args, db, auth) => {
+			const scope = await resolveScope(db, auth, args);
+			if ('error' in scope) return scope;
+			const { teamId } = scope;
+
+			if (auth.type !== AuthType.Agent) {
+				return { error: 'set_agent_status is only callable by agents' };
+			}
+			// The team's own Captain (running in-team) or an HQ instance agent — the
+			// CEO, whether acting from the cross-team chat session or a task run scoped
+			// into this team. canCoordinateTeam covers the Captain and the in-team HQ
+			// case; isHqInstanceAgent additionally covers the cross-team CEO session,
+			// whose run is scoped to HQ rather than this team.
+			const allowed =
+				(await canCoordinateTeam(db, auth, teamId)) || (await isHqInstanceAgent(db, auth));
+			if (!allowed) {
+				return {
+					error: "Access denied: only the Captain or the CEO can change an agent's status",
+				};
+			}
+
+			const ref = String(args.agent ?? '').trim();
+			if (!ref) return { error: 'agent is required' };
+			const target = await db.query<{ id: string; slug: string }>(
+				`SELECT ma.id, ma.slug FROM member_agents ma
+				 JOIN members m ON m.id = ma.id
+				 WHERE m.team_id = $1 AND (ma.id::text = $2 OR ma.slug = $2)
+				 LIMIT 1`,
+				[teamId, ref],
+			);
+			if (target.rows.length === 0) return { error: `Agent not found in this team: ${ref}` };
+			const { id: agentId, slug } = target.rows[0];
+
+			const status = args.status as AgentAdminStatus;
+			const protectedSlugs: readonly string[] = [
+				CAPTAIN_AGENT_SLUG,
+				CEO_AGENT_SLUG,
+				COACH_AGENT_SLUG,
+			];
+			if (status === AgentAdminStatus.Disabled && protectedSlugs.includes(slug)) {
+				return {
+					error: `The ${slug} role is essential and cannot be retired with this tool; the admin can disable it from the web UI if truly needed.`,
+				};
+			}
+
+			const result = await setAgentAdminStatus(
+				{ db, wsManager, events },
+				{
+					teamId,
+					agentId,
+					status,
+					actorType: AuditActorType.Agent,
+					actorMemberId: auth.memberId,
+				},
+			);
+			if (!result.ok && result.reason === 'not_found') {
+				return { error: `Agent not found in this team: ${ref}` };
+			}
+			if (!result.ok && result.reason === 'already_in_state') {
+				return { error: `Agent is already ${status}` };
+			}
+			return { updated: true, agent_id: agentId, slug, admin_status: status };
 		},
 		db,
 	);

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -8,7 +8,6 @@ import {
 	DEFAULT_EFFORT,
 	DEFAULT_TEAM_ID,
 	DocumentType,
-	HQ_PROJECT_SLUG,
 	isAgentEffort,
 	isReservedAgentSlug,
 	MemberType,
@@ -33,6 +32,7 @@ import { buildUpdateSet, isFkViolation, terminalStatusParams, withTransaction } 
 import { allocateTaskIdentifier } from '../lib/task-identifier';
 import type { Env } from '../lib/types';
 import { logger } from '../logger';
+import { setAgentAdminStatus } from '../services/agent-admin';
 import {
 	AgentSystemPromptError,
 	fetchAgentSystemPromptForBatch,
@@ -954,45 +954,17 @@ agentsRoutes.post('/projects/:projectId/agents/:agentId/disable', async (c) => {
 	const agentId = await resolveAgentId(db, teamId, c.req.param('agentId'));
 	if (!agentId) return err(c, 'NOT_FOUND', 'Agent not found', 404);
 
-	const existing = await db.query<{ admin_status: string }>(
-		'SELECT admin_status FROM member_agents WHERE id = $1',
-		[agentId],
+	const actor = await resolveActor(db, c.get('auth'), teamId);
+	const result = await setAgentAdminStatus(
+		{ db, wsManager: c.get('wsManager'), events: c.get('events') },
+		{ teamId, agentId, status: AgentAdminStatus.Disabled, ...actor },
 	);
-	if (existing.rows[0].admin_status === AgentAdminStatus.Disabled) {
+	if (!result.ok && result.reason === 'not_found') {
+		return err(c, 'NOT_FOUND', 'Agent not found', 404);
+	}
+	if (!result.ok && result.reason === 'already_in_state') {
 		return err(c, 'INVALID_STATE', 'Agent is already disabled', 409);
 	}
-
-	await db.query(`UPDATE member_agents SET admin_status = $1::agent_admin_status WHERE id = $2`, [
-		AgentAdminStatus.Disabled,
-		agentId,
-	]);
-
-	const ts = terminalStatusParams(2, false);
-	await db.query(
-		`UPDATE tasks SET assignee_id = NULL WHERE assignee_id = $1 AND status NOT IN (${ts.placeholders})`,
-		[agentId, ...ts.values],
-	);
-
-	broadcastChange(c, wsRoom.team(teamId), 'member_agents', 'UPDATE', {
-		id: agentId,
-		admin_status: AgentAdminStatus.Disabled,
-	});
-
-	trackBackground(
-		enqueueTeamCoherenceReviewTask(db, teamId, 'agent_removed').catch((e) =>
-			log.error('Failed to enqueue team coherence review on disable:', e),
-		),
-	);
-
-	const disableActor = await resolveActor(db, c.get('auth'), teamId);
-	c.get('events').emit({
-		type: 'agent.disabled',
-		teamId,
-		actorType: disableActor.actorType,
-		actorMemberId: disableActor.actorMemberId,
-		actorConnectedAgentId: disableActor.actorConnectedAgentId,
-		agentMemberId: agentId,
-	});
 
 	return ok(c, { admin_status: AgentAdminStatus.Disabled });
 });
@@ -1003,39 +975,17 @@ agentsRoutes.post('/projects/:projectId/agents/:agentId/enable', async (c) => {
 	const agentId = await resolveAgentId(db, teamId, c.req.param('agentId'));
 	if (!agentId) return err(c, 'NOT_FOUND', 'Agent not found', 404);
 
-	const existing = await db.query<{ admin_status: string }>(
-		'SELECT admin_status FROM member_agents WHERE id = $1',
-		[agentId],
+	const actor = await resolveActor(db, c.get('auth'), teamId);
+	const result = await setAgentAdminStatus(
+		{ db, wsManager: c.get('wsManager'), events: c.get('events') },
+		{ teamId, agentId, status: AgentAdminStatus.Enabled, ...actor },
 	);
-	if (existing.rows[0].admin_status === AgentAdminStatus.Enabled) {
+	if (!result.ok && result.reason === 'not_found') {
+		return err(c, 'NOT_FOUND', 'Agent not found', 404);
+	}
+	if (!result.ok && result.reason === 'already_in_state') {
 		return err(c, 'INVALID_STATE', 'Agent is already enabled', 409);
 	}
-
-	await db.query(`UPDATE member_agents SET admin_status = $1::agent_admin_status WHERE id = $2`, [
-		AgentAdminStatus.Enabled,
-		agentId,
-	]);
-
-	broadcastChange(c, wsRoom.team(teamId), 'member_agents', 'UPDATE', {
-		id: agentId,
-		admin_status: AgentAdminStatus.Enabled,
-	});
-
-	trackBackground(
-		enqueueTeamCoherenceReviewTask(db, teamId, 'enabled_changed').catch((e) =>
-			log.error('Failed to enqueue team coherence review on enable:', e),
-		),
-	);
-
-	const enableActor = await resolveActor(db, c.get('auth'), teamId);
-	c.get('events').emit({
-		type: 'agent.enabled',
-		teamId,
-		actorType: enableActor.actorType,
-		actorMemberId: enableActor.actorMemberId,
-		actorConnectedAgentId: enableActor.actorConnectedAgentId,
-		agentMemberId: agentId,
-	});
 
 	return ok(c, { admin_status: AgentAdminStatus.Enabled });
 });

--- a/packages/server/src/services/agent-admin.ts
+++ b/packages/server/src/services/agent-admin.ts
@@ -1,0 +1,100 @@
+import type { PGlite } from '@electric-sql/pglite';
+import { AgentAdminStatus, type AuditActorType, wsRoom } from '@hezo/shared';
+import type { DomainEventBus } from '../events/bus';
+import { trackBackground } from '../lib/background';
+import { broadcastRowChange } from '../lib/broadcast';
+import { terminalStatusParams } from '../lib/sql';
+import { logger } from '../logger';
+import { enqueueTeamCoherenceReviewTask } from './description-tasks';
+import type { WebSocketManager } from './ws';
+
+const log = logger.child('agent-admin');
+
+export interface SetAgentAdminStatusDeps {
+	db: PGlite;
+	wsManager?: WebSocketManager;
+	events?: DomainEventBus;
+}
+
+export interface SetAgentAdminStatusParams {
+	teamId: string;
+	agentId: string;
+	status: AgentAdminStatus;
+	actorType: AuditActorType;
+	actorMemberId: string | null;
+	actorConnectedAgentId?: string | null;
+}
+
+export type SetAgentAdminStatusResult =
+	| { ok: true; status: AgentAdminStatus }
+	| { ok: false; reason: 'not_found' }
+	| { ok: false; reason: 'already_in_state'; status: AgentAdminStatus };
+
+/**
+ * Enable ("reinstate") or disable ("retire") an agent on a team — the single
+ * source of truth shared by the REST routes (admin via the web UI) and the
+ * `set_agent_status` MCP tool (CEO/Captain). Disabling stops the agent from being
+ * scheduled and unassigns it from every open task; both directions enqueue a
+ * coherence review, broadcast the change, and emit the audit event. The change is
+ * reversible — a disabled agent retains all its data and can be re-enabled.
+ *
+ * Callers are responsible for authorizing the actor and for any policy guardrails
+ * (e.g. refusing to disable a Captain or instance agent); this function only
+ * applies the state transition.
+ */
+export async function setAgentAdminStatus(
+	deps: SetAgentAdminStatusDeps,
+	params: SetAgentAdminStatusParams,
+): Promise<SetAgentAdminStatusResult> {
+	const { db, wsManager, events } = deps;
+	const { teamId, agentId, status } = params;
+
+	const existing = await db.query<{ admin_status: string }>(
+		`SELECT ma.admin_status FROM member_agents ma
+		 JOIN members m ON m.id = ma.id
+		 WHERE ma.id = $1 AND m.team_id = $2`,
+		[agentId, teamId],
+	);
+	if (existing.rows.length === 0) return { ok: false, reason: 'not_found' };
+	if (existing.rows[0].admin_status === status) {
+		return { ok: false, reason: 'already_in_state', status };
+	}
+
+	await db.query(`UPDATE member_agents SET admin_status = $1::agent_admin_status WHERE id = $2`, [
+		status,
+		agentId,
+	]);
+
+	// Disabling pulls the agent off its open work so nothing stalls on an agent
+	// that will never run; terminal tasks keep their historical assignee.
+	if (status === AgentAdminStatus.Disabled) {
+		const ts = terminalStatusParams(2, false);
+		await db.query(
+			`UPDATE tasks SET assignee_id = NULL WHERE assignee_id = $1 AND status NOT IN (${ts.placeholders})`,
+			[agentId, ...ts.values],
+		);
+	}
+
+	broadcastRowChange(wsManager, wsRoom.team(teamId), 'member_agents', 'UPDATE', {
+		id: agentId,
+		admin_status: status,
+	});
+
+	const reason = status === AgentAdminStatus.Disabled ? 'agent_removed' : 'enabled_changed';
+	trackBackground(
+		enqueueTeamCoherenceReviewTask(db, teamId, reason).catch((e) =>
+			log.error(`Failed to enqueue team coherence review on ${reason}:`, e),
+		),
+	);
+
+	events?.emit({
+		type: status === AgentAdminStatus.Disabled ? 'agent.disabled' : 'agent.enabled',
+		teamId,
+		actorType: params.actorType,
+		actorMemberId: params.actorMemberId,
+		actorConnectedAgentId: params.actorConnectedAgentId ?? null,
+		agentMemberId: agentId,
+	});
+
+	return { ok: true, status };
+}

--- a/packages/server/test/agent-status-tool.test.ts
+++ b/packages/server/test/agent-status-tool.test.ts
@@ -1,0 +1,262 @@
+import type { PGlite } from '@electric-sql/pglite';
+import { CAPTAIN_AGENT_SLUG, DEFAULT_TEAM_ID } from '@hezo/shared';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { MasterKeyManager } from '../src/crypto/master-key';
+import type { Env } from '../src/lib/types';
+import { safeClose } from './helpers';
+import {
+	authHeader,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+	instanceCeoId,
+	mintAgentToken,
+} from './helpers/app';
+
+let app: Hono<Env>;
+let db: PGlite;
+let token: string;
+let masterKeyManager: MasterKeyManager;
+let teamId: string;
+let projectSlug: string;
+let projectId: string;
+
+interface ToolResult {
+	error?: string;
+	updated?: boolean;
+	admin_status?: string;
+	slug?: string;
+}
+
+async function callTool(
+	agentToken: string,
+	name: string,
+	args: Record<string, unknown>,
+): Promise<ToolResult> {
+	const res = await app.request('/mcp', {
+		method: 'POST',
+		headers: { ...authHeader(agentToken), 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			jsonrpc: '2.0',
+			method: 'tools/call',
+			params: { name, arguments: args },
+			id: 1,
+		}),
+	});
+	const body = (await res.json()) as {
+		result: { content: Array<{ type: string; text: string }> };
+	};
+	return JSON.parse(body.result.content[0].text) as ToolResult;
+}
+
+async function agentIdBySlug(slug: string): Promise<string> {
+	const r = await db.query<{ id: string }>(
+		`SELECT ma.id FROM member_agents ma JOIN members m ON m.id = ma.id
+		 WHERE m.team_id = $1 AND ma.slug = $2`,
+		[teamId, slug],
+	);
+	return r.rows[0].id;
+}
+
+async function adminStatusOf(slug: string): Promise<string> {
+	const r = await db.query<{ admin_status: string }>(
+		`SELECT ma.admin_status FROM member_agents ma JOIN members m ON m.id = ma.id
+		 WHERE m.team_id = $1 AND ma.slug = $2`,
+		[teamId, slug],
+	);
+	return r.rows[0].admin_status;
+}
+
+async function ceoToken(): Promise<string> {
+	const ceoId = await instanceCeoId(db);
+	const { token: t } = await mintAgentToken(db, masterKeyManager, ceoId, teamId, null, {
+		projectId,
+	});
+	return t;
+}
+
+/**
+ * Mints a CEO token scoped to HQ but acting cross-project on the target team's
+ * project — mirroring the live CEO chat session, whose run is scoped to HQ
+ * (`crossProject`) rather than the team it reaches into. Exercises the
+ * isHqInstanceAgent authorization path rather than the in-team canCoordinateTeam one.
+ */
+async function ceoChatToken(): Promise<string> {
+	const ceoId = await instanceCeoId(db);
+	const { token: t } = await mintAgentToken(db, masterKeyManager, ceoId, DEFAULT_TEAM_ID, null, {
+		projectId,
+		crossProject: true,
+	});
+	return t;
+}
+
+async function insertTaskAssignedTo(assigneeSlug: string, title: string): Promise<string> {
+	const assigneeId = await agentIdBySlug(assigneeSlug);
+	const meta = await db.query<{ task_prefix: string; number: number }>(
+		`SELECT p.task_prefix, next_project_task_number(p.id) AS number FROM projects p WHERE p.id = $1`,
+		[projectId],
+	);
+	const n = meta.rows[0].number;
+	const res = await db.query<{ id: string }>(
+		`INSERT INTO tasks (team_id, project_id, assignee_id, number, identifier, title, status, priority, labels)
+		 VALUES ($1, $2, $3, $4, $5, $6, 'backlog'::task_status, 'medium'::task_priority, '[]'::jsonb)
+		 RETURNING id`,
+		[teamId, projectId, assigneeId, n, `${meta.rows[0].task_prefix}-${n}`, title],
+	);
+	return res.rows[0].id;
+}
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+	masterKeyManager = ctx.masterKeyManager;
+
+	const typesRes = await app.request('/api/team-templates', { headers: authHeader(token) });
+	const typeId = (await typesRes.json()).data.find(
+		(t: Record<string, unknown>) => t.name === 'Startup',
+	).id;
+
+	const teamRes = await createTestTeam(db, { name: 'Retire Co', template_id: typeId });
+	teamId = (await teamRes.json()).data.id;
+	const proj = (await (await createTestProject(db, teamId, { name: 'Setup Project' })).json()).data;
+	projectSlug = proj.slug;
+	projectId = proj.id;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+describe('MCP tool set_agent_status', () => {
+	it('lets the CEO retire an agent cross-team and unassigns its open tasks', async () => {
+		const taskId = await insertTaskAssignedTo('researcher', 'Research the market');
+
+		const result = await callTool(await ceoToken(), 'set_agent_status', {
+			project: projectSlug,
+			agent: 'researcher',
+			status: 'disabled',
+		});
+
+		expect(result.error).toBeUndefined();
+		expect(result.updated).toBe(true);
+		expect(result.admin_status).toBe('disabled');
+		expect(await adminStatusOf('researcher')).toBe('disabled');
+
+		// The agent's open task is unassigned so nothing stalls on a retired agent.
+		const task = await db.query<{ assignee_id: string | null }>(
+			'SELECT assignee_id FROM tasks WHERE id = $1',
+			[taskId],
+		);
+		expect(task.rows[0].assignee_id).toBeNull();
+	});
+
+	it('lets the CEO retire an agent from the cross-team chat session (scoped to HQ)', async () => {
+		const result = await callTool(await ceoChatToken(), 'set_agent_status', {
+			project: projectSlug,
+			agent: 'product-lead',
+			status: 'disabled',
+		});
+		expect(result.error).toBeUndefined();
+		expect(result.updated).toBe(true);
+		expect(await adminStatusOf('product-lead')).toBe('disabled');
+	});
+
+	it('lets the CEO reinstate a retired agent', async () => {
+		const ceo = await ceoToken();
+		const disable = await callTool(ceo, 'set_agent_status', {
+			project: projectSlug,
+			agent: 'qa-engineer',
+			status: 'disabled',
+		});
+		expect(disable.error).toBeUndefined();
+		expect(await adminStatusOf('qa-engineer')).toBe('disabled');
+
+		const enable = await callTool(ceo, 'set_agent_status', {
+			project: projectSlug,
+			agent: 'qa-engineer',
+			status: 'enabled',
+		});
+		expect(enable.error).toBeUndefined();
+		expect(enable.admin_status).toBe('enabled');
+		expect(await adminStatusOf('qa-engineer')).toBe('enabled');
+	});
+
+	it('lets the team Captain retire an agent', async () => {
+		const captainId = await agentIdBySlug(CAPTAIN_AGENT_SLUG);
+		const { token: captainToken } = await mintAgentToken(
+			db,
+			masterKeyManager,
+			captainId,
+			teamId,
+			null,
+			{ projectId },
+		);
+		const result = await callTool(captainToken, 'set_agent_status', {
+			project: projectSlug,
+			agent: 'ui-designer',
+			status: 'disabled',
+		});
+		expect(result.error).toBeUndefined();
+		expect(await adminStatusOf('ui-designer')).toBe('disabled');
+	});
+
+	it('rejects a non-coordinator agent', async () => {
+		const engineerId = await agentIdBySlug('engineer');
+		const { token: engToken } = await mintAgentToken(
+			db,
+			masterKeyManager,
+			engineerId,
+			teamId,
+			null,
+			{
+				projectId,
+			},
+		);
+		const result = await callTool(engToken, 'set_agent_status', {
+			project: projectSlug,
+			agent: 'architect',
+			status: 'disabled',
+		});
+		expect(result.error).toContain('Access denied');
+		expect(await adminStatusOf('architect')).toBe('enabled');
+	});
+
+	it('refuses to retire the Captain (protected role)', async () => {
+		const result = await callTool(await ceoToken(), 'set_agent_status', {
+			project: projectSlug,
+			agent: CAPTAIN_AGENT_SLUG,
+			status: 'disabled',
+		});
+		expect(result.error).toContain('cannot be retired');
+		expect(await adminStatusOf(CAPTAIN_AGENT_SLUG)).toBe('enabled');
+	});
+
+	it('errors when the agent is already in the requested state', async () => {
+		const ceo = await ceoToken();
+		const first = await callTool(ceo, 'set_agent_status', {
+			project: projectSlug,
+			agent: 'security-engineer',
+			status: 'disabled',
+		});
+		expect(first.error).toBeUndefined();
+
+		const second = await callTool(ceo, 'set_agent_status', {
+			project: projectSlug,
+			agent: 'security-engineer',
+			status: 'disabled',
+		});
+		expect(second.error).toBe('Agent is already disabled');
+	});
+
+	it('errors for an unknown agent', async () => {
+		const result = await callTool(await ceoToken(), 'set_agent_status', {
+			project: projectSlug,
+			agent: 'no-such-agent',
+			status: 'disabled',
+		});
+		expect(result.error).toContain('Agent not found in this team');
+	});
+});


### PR DESCRIPTION
Addresses two pieces of feedback from a CEO chat session:

> the ceo should be able to retire agents
>
> also, notice in this chat how the ceo provisioned a project and team even before i'd finalised things — this shouldn't happen.

## 1. The CEO can now retire (and reinstate) agents

Previously the CEO could only *tell the operator* to disable agents in the web UI — it had no tool to do it itself. Now the CEO (and a team's own Captain) can action roster removal directly.

- **New `set_agent_status` MCP tool** — `status: disabled` retires an agent (stops scheduling, unassigns its open tasks), `status: enabled` reinstates it. Fully reversible; the agent keeps all its history.
- **Shared `setAgentAdminStatus` service** — the REST `disable`/`enable` routes were refactored onto it, so the "unassign open tasks → enqueue coherence review → broadcast → emit audit event" semantics live in **one** place instead of being duplicated between REST and MCP.
- **Authorization** — the team's Captain (running in-team) *or* an HQ instance agent. The latter is important: the live CEO **chat session** runs scoped to HQ with `crossTeam`, not to the target team, so the existing `canCoordinateTeam` gate would have wrongly denied it. A new `isHqInstanceAgent` helper recognises the CEO from the chat session as well as from a task run scoped into the team.
- **Guardrails** — the tool refuses to disable a team's Captain or the instance agents (CEO/Coach). The admin can still do anything from the web UI.

## 2. The CEO no longer provisions before the operator finalises

This is a behaviour/prompt fix — provisioning hinges on judgement, so the guardrails live where the CEO reads them:

- `agents/_instance/ceo.md`: tightened the **intake** bullet, the **"new initiative"** path, and added a **rule** — `create_project` runs only on an explicit go-ahead for the *finalised* scope **and** team type, never on assumed defaults and never "announce I'll provision it and create it in the same breath".
- The `create_project` **tool description** carries the same constraint, so it reinforces the rule at the point of the call.

## Docs & architecture

- `docs/concepts/hiring-and-agents.md` — new "Retiring & reinstating agents" section.
- `docs/concepts/roles-and-coordination.md` — intake now notes "won't create anything until you give the go-ahead"; CEO can retire agents.
- `.dev/architecture.md` — CEO ownership covers retiring via `set_agent_status` / `setAgentAdminStatus`.
- SKILL.md picks up the new tool automatically (generated from the registered tool list).

## Testing

- New `packages/server/test/agent-status-tool.test.ts` (8 cases): CEO retire **in-team** and **from the cross-team chat session**, reinstate, Captain access, non-coordinator rejection, protected-role refusal, already-in-state, unknown agent, and open-task unassignment.
- Existing REST `disable`/`enable` tests (now exercising the shared service) and the MCP/hire/CEO/audit/coherence suites all pass (`typecheck`, `check`, and the affected vitest files green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014SENDiowByAyu4UJhs16KZ

---
_Generated by [Claude Code](https://claude.ai/code/session_014SENDiowByAyu4UJhs16KZ)_