### PR TITLE
fix(web): reword inbox banner to "items need your attention"

### DIFF
--- a/packages/web/src/components/admin-approvals-banner.tsx
+++ b/packages/web/src/components/admin-approvals-banner.tsx
@@ -7,11 +7,8 @@ function pluralize(count: number, noun: string): string {
 	return `${count} ${noun}${count === 1 ? '' : 's'}`;
 }
 
-function buildMessage(approvalCount: number, mentionCount: number): string {
-	const parts: string[] = [];
-	if (approvalCount > 0) parts.push(pluralize(approvalCount, 'approval'));
-	if (mentionCount > 0) parts.push(pluralize(mentionCount, 'mention'));
-	return `${parts.join(' and ')} ${parts.length > 1 ? 'need' : approvalCount + mentionCount === 1 ? 'needs' : 'need'} your review`;
+function buildMessage(count: number): string {
+	return `${pluralize(count, 'item')} ${count === 1 ? 'needs' : 'need'} your attention`;
 }
 
 /**
@@ -38,7 +35,7 @@ export function AdminApprovalsBanner({ projectId }: { projectId: string }) {
 			className="mb-4 flex items-center gap-2 rounded-md bg-inverse/10 px-4 py-2 text-[13px] font-medium text-text-1 hover:bg-inverse/15 transition-colors"
 		>
 			<Inbox className="w-3.5 h-3.5 shrink-0" />
-			<span className="min-w-0 truncate">{buildMessage(approvalCount, mentionCount)}</span>
+			<span className="min-w-0 truncate">{buildMessage(total)}</span>
 			<span className="ml-auto flex items-center gap-1 shrink-0">
 				<span className="hidden sm:inline">View inbox</span>
 				<ChevronRight className="w-3.5 h-3.5" />

--- a/packages/web/test/admin-approvals-banner.test.tsx
+++ b/packages/web/test/admin-approvals-banner.test.tsx
@@ -37,7 +37,7 @@ test('banner surfaces pending approvals on the task list and links to the inbox'
 	});
 
 	const banner = await findByTestId('admin-approvals-banner', undefined, { timeout: 10_000 });
-	expect(banner.textContent).toContain('2 approvals need your review');
+	expect(banner.textContent).toContain('2 items need your attention');
 	expect(banner.getAttribute('href')).toContain(`/projects/${seeded.projectSlug}/inbox`);
 
 	await user.click(banner);


### PR DESCRIPTION
## What

Rewords the admin inbox banner that appears at the top of the task list.

**Before:** `1 approval needs your review` (and `2 approvals and 1 mention need your review` when both types were present)

**After:** `1 item needs your attention` / `N items need your attention`

## Why

The banner surfaces a mixed backlog (pending approvals + unread mentions). Collapsing the per-type breakdown into a generic "item" count keeps the message short and consistent regardless of what's queued, and "needs your attention" reads as a softer, clearer call to action than "needs your review".

## Changes

- `packages/web/src/components/admin-approvals-banner.tsx` — `buildMessage` now takes the total count and renders `${count} item(s) need(s) your attention`. The component passes the already-computed `total`.
- `packages/web/test/admin-approvals-banner.test.tsx` — updated the wording assertion.

## Testing

- `bunx vitest run test/admin-approvals-banner.test.tsx` — both tests pass (banner renders correct count + links to inbox; banner hidden when backlog is empty).
- Biome check clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGD2oFw5ffqwpDAUduG3Cq

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGD2oFw5ffqwpDAUduG3Cq)_