### PR TITLE
docs: deferred plan for self-updating binary & restart

### DIFF
--- a/.dev/self-updating-plan.md
+++ b/.dev/self-updating-plan.md
@@ -1,0 +1,192 @@
+# Auto-update: detect, download, in-place swap & self-restart
+
+> Status: **proposed / deferred.** Captures the feasibility verdict and a concrete
+> design so we can pick this up later. Not yet implemented.
+
+## Context
+
+Hezo ships as a single Bun-compiled binary that operators run themselves; today
+"upgrading is replacing the binary" by hand (`docs/deployment/self-hosting.md`).
+We want Hezo to (1) check GitHub Releases on a schedule, (2) download the new
+binary for the current platform, (3) swap it in place and restart onto the new
+binary, and (4) drive the web UI through the restart — a full-screen "restarting"
+view that auto-resumes, a global bottom banner when a newer version exists, and a
+current-version display in settings that links to its GitHub release.
+
+The gating question is **feasibility**: can we do runtime in-place binary
+replacement + seamless self-restart on Linux, macOS, and Windows?
+
+## Feasibility verdict — YES, with a supervisor process and platform-specific swap
+
+The naive "overwrite my own running binary and restart myself" is unreliable:
+Linux can return `ETXTBSY` overwriting an executing file, and **Windows locks a
+running `.exe`** so it can't be overwritten or deleted at all. The robust,
+cross-platform answer is a **thin supervisor process**:
+
+- `hezo` runs as a **supervisor** that spawns the real server as a child
+  (`[process.execPath, ...argv]` with `HEZO_WORKER=1`). The supervisor forwards
+  signals and, on a normal crash/exit, exits with the child's code (so existing
+  systemd/launchd/Docker restart policies behave exactly as today).
+- The server (worker) downloads + verifies + **stages** the new binary, then on
+  user confirmation shuts down gracefully and exits with a **restart sentinel
+  code**. The supervisor sees the sentinel, performs the on-disk swap *while the
+  worker is down* (no lock/`ETXTBSY` contention), and relaunches the worker from
+  the new binary.
+
+Per-platform swap (all confirmed feasible):
+- **Linux / macOS:** write staged binary next to the target, `rename(2)` over
+  `process.execPath` (atomic, same filesystem). The supervisor keeps executing its
+  old inode; the relaunched worker runs the new file. *(macOS caveat: a downloaded
+  unsigned binary can be Gatekeeper-quarantined; strip `com.apple.quarantine` via
+  `xattr` after download. Long-term, releases should be notarized.)*
+- **Windows:** the running `.exe` is locked, so use the NTFS **rename trick** —
+  rename the live `hezo.exe` → `hezo-<oldver>.exe` (permitted while running), write
+  the new binary to `hezo.exe`, relaunch the worker; clean up the stale file on the
+  next supervisor start.
+
+The supervisor itself keeps running its *old* code until a full process restart;
+only the worker (the part that serves) is refreshed immediately. That's an
+accepted trade-off — the supervisor is tiny and rarely changes.
+
+**State across restart is already safe.** All durable state is in PGlite
+(`<dataDir>/pgdata`) + project workspaces; `jobManager.reconcileOnStartup()` marks
+in-flight `heartbeat_runs` failed and creates recovery wakeups, containers are
+re-verified, and queued wakeups re-dispatch within seconds. The restart aborts
+in-flight agent runs (recovered automatically) and disconnects WebSocket clients
+(they auto-reconnect). The instance is allowed to come back **locked** if no
+`HEZO_MASTER_KEY` is set — the existing master-key gate shows and agents resume
+once unlocked.
+
+## Decisions
+
+1. **Restart mechanism:** built-in supervisor process (above).
+2. **Apply mode:** auto-download/stage in background; **apply + restart only on
+   user click** ("Update & restart"). No surprise restarts.
+3. **Re-unlock:** restart even without an env key; show the unlock screen on the
+   way back up.
+
+## What already exists (reuse, don't rebuild)
+
+- `packages/server/src/routes/updates.ts` — `GET /updates/latest` already queries
+  `hezo-ai/hezo` releases, caches 1h, returns `{current, latest, updateAvailable, url}`
+  and exports `isNewer()`. Extend this module.
+- `packages/server/src/version.ts` — `HEZO_VERSION` (injected via `--define` at
+  compile time; `readDevVersion()` in dev).
+- `scripts/build.ts` — `TARGETS` array defines asset names
+  `hezo-{os}-{arch}[.exe]` + `SHA256SUMS`; reuse the exact mapping for download.
+- `packages/server/src/services/job-manager.ts` — cron job registration pattern
+  (`guarded()`); add the daily check job here.
+- Worker shutdown logic already exists in `registerRuntime().shutdown()` in
+  `index.ts` (jobManager.shutdown → ceoSessionManager.stop → egressProxy/sshAgent
+  releaseAll → db.close) — promote it to a reusable graceful-shutdown function.
+- Frontend: `useUpdateCheck()` (`packages/web/src/hooks/use-update-check.ts`),
+  existing `UpdateBanner` (`packages/web/src/components/update-banner.tsx`, mounted
+  in `__root.tsx`), `useStatus()` retry-polling, `useSocket().connected`,
+  `useInvalidateOnReconnect`.
+
+## Implementation
+
+### Server
+
+1. **`@hezo/shared`** (`packages/shared/src/types/common.ts`): add
+   `UPDATE_RESTART_EXIT_CODE` (e.g. `75`) and an update-state enum
+   (`idle | checking | downloading | staged | applying | error`). No raw strings.
+
+2. **Supervisor** — new `packages/server/src/supervisor.ts`, branched from the
+   entry. In `index.ts`, before the current server bootstrap: if not a subcommand
+   (`hezo restore …` still bypasses) and `HEZO_WORKER` is unset and we're a
+   **compiled binary**, run the supervisor: spawn `[process.execPath, ...args]` with
+   `HEZO_WORKER=1`, inherit stdio, forward SIGTERM/SIGINT. On child exit ===
+   `UPDATE_RESTART_EXIT_CODE` → call `applyStagedUpdate()` then respawn; any other
+   code → exit with it. Guard so dev (`bun run dev`, non-compiled) never supervises.
+
+3. **Updater service** — new `packages/server/src/services/updater.ts`:
+   - `currentAssetName()` from `process.platform`/`process.arch` → `hezo-{os}-{arch}[.exe]`.
+   - `downloadAndStage(version)`: download the release asset + `SHA256SUMS`, verify
+     the sha256, write to `<dataDir>/.update/staged[.exe]`, strip macOS quarantine,
+     record target version.
+   - `applyStagedUpdate()` (called by supervisor): platform swap — atomic rename on
+     Unix; rename-trick on Windows — then clear staging. Pure file logic, unit-testable.
+   - Guard the whole feature behind "is compiled binary" + an opt-out
+     `HEZO_DISABLE_AUTO_UPDATE`.
+
+4. **Routes** (extend `updates.ts`, superuser-only): `GET /updates/status`
+   (download/staged state + target version), `POST /updates/download` (kick a
+   background stage via `trackBackground`), `POST /updates/apply` (graceful shutdown
+   then `process.exit(UPDATE_RESTART_EXIT_CODE)`). Keep `GET /updates/latest`.
+
+5. **Daily scheduled check** — register an `update-check` cron job in
+   `job-manager.ts` (e.g. `0 0 4 * * *`, env-overridable `HEZO_UPDATE_CHECK_CRON`,
+   following the existing override pattern). When an update is available and the
+   feature is enabled, auto-download+stage so "Update & restart" is instant.
+
+6. **Graceful shutdown** — extract the `registerRuntime().shutdown()` body into a
+   reusable function and call it from the apply path (and wire SIGTERM/SIGINT to it
+   so supervisor-forwarded signals shut the worker cleanly).
+
+### Frontend (`packages/web`)
+
+1. **Settings version footer** — add a footer to the settings sidebar nav in
+   `packages/web/src/routes/settings/index.tsx` (currently no bottom element)
+   showing `current` from `useUpdateCheck()`, linking to
+   `https://github.com/hezo-ai/hezo/releases/tag/<current>`. Mobile-first.
+
+2. **Global bottom banner** — reposition/extend `UpdateBanner` to a full-width
+   **sticky bottom** bar shown on every page when `updateAvailable`. Replace the
+   passive dismiss with an **"Update & restart"** action (apply mode = confirmed)
+   plus version + release link; keep per-version localStorage dismiss for "later".
+
+3. **Restart overlay** — new full-screen component. On "Update & restart":
+   `POST /updates/apply`, then mount the overlay ("Updating to vX.Y.Z…"). Poll
+   `/api/status` (reuse `useStatus` retry semantics) / watch `useSocket().connected`;
+   while unreachable show "restarting", and when status returns reload the app.
+   `AppShell` already gates on `/api/status`, so a locked return naturally lands on
+   the master-key screen. `useInvalidateOnReconnect` refreshes data.
+
+### Docs & architecture
+
+- `docs/deployment/self-hosting.md` "Updating" — describe the in-app auto-update,
+  supervisor, "Update & restart", and the relock-on-restart caveat. Do **not**
+  surface `HEZO_WORKER` (internal); document `HEZO_DISABLE_AUTO_UPDATE` /
+  `HEZO_UPDATE_CHECK_CRON` in `docs/deployment/configuration`.
+- `.dev/architecture.md` — add a "Self-update & supervisor" section (process model,
+  swap-per-platform, exit sentinel, state recovery).
+
+## Critical files
+
+- `packages/server/src/index.ts` (supervisor branch + reusable shutdown)
+- `packages/server/src/supervisor.ts` *(new)*
+- `packages/server/src/services/updater.ts` *(new)*
+- `packages/server/src/routes/updates.ts` (status/download/apply)
+- `packages/server/src/services/job-manager.ts` (daily check job)
+- `packages/shared/src/types/common.ts` (exit code + state enum)
+- `packages/web/src/routes/settings/index.tsx` (version footer)
+- `packages/web/src/components/update-banner.tsx` (bottom banner + apply action)
+- `packages/web/src/components/update-restart-overlay.tsx` *(new)*
+- `docs/deployment/self-hosting.md`, `docs/deployment/configuration`, `.dev/architecture.md`
+
+## Verification
+
+- **Server unit/integration** (`packages/server/test/**`, `createTestContext`):
+  asset-name mapping per platform; SHA256 verify (good + tampered); `applyStagedUpdate`
+  swap on a temp dir (assert Unix atomic-rename and Windows rename-trick branches);
+  `/updates/{status,download,apply}` authz (superuser-only) and that apply triggers
+  shutdown + sentinel exit (mock exit); daily `update-check` job registered/guarded.
+- **Web component** (`packages/web/test/**`, `renderApp`): settings footer renders
+  version + correct release link; bottom banner appears when `updateAvailable` and
+  hides otherwise; "Update & restart" calls `POST /updates/apply` and mounts the
+  overlay; overlay polls and resumes when `/api/status` recovers.
+- **Manual cross-platform** (can't be automated): build two versions, run the
+  supervisor, trigger "Update & restart", confirm the worker relaunches on the new
+  version and reconciliation resumes agents — on Linux, macOS (incl. quarantine
+  strip), and Windows (rename-trick).
+- `bun run test`, `bun run typecheck`, `bun run check` green.
+
+## Risks / notes
+
+- **Supervisor stays on old code** until a full restart (worker is fresh) — accepted.
+- **macOS Gatekeeper**: unsigned downloaded binaries may be blocked even after
+  quarantine strip; proper notarization is a follow-up.
+- **Dev mode**: feature is hard-disabled for non-compiled runs.
+- Restart aborts in-flight runs (auto-recovered) and disconnects sockets
+  (auto-reconnect) — surfaced in the overlay copy.


### PR DESCRIPTION
## Summary

Adds `.dev/self-updating-plan.md` — a **proposed / deferred** design doc (no code changes) capturing the feasibility investigation for automatic update detection, download, in-place binary swap, and self-restart.

This is intentionally a planning artifact only; the feature is disruptive so we're parking the design to pick up later.

## Feasibility verdict

In-place binary replacement + self-restart **is feasible on Linux, macOS, and Windows**, but not via naive self-overwrite (Linux `ETXTBSY`, Windows locks a running `.exe`). The doc settles on a **thin supervisor process**:

- `hezo` runs as a supervisor that spawns the server as a child (`HEZO_WORKER=1`).
- The worker downloads + SHA256-verifies + **stages** the new binary, then on user confirmation shuts down gracefully and exits with a restart sentinel code.
- The supervisor swaps the binary *while the worker is down* (atomic `rename` on Unix; NTFS rename-trick on Windows) and relaunches.

State is already safe across restarts (PGlite + `reconcileOnStartup`); restart aborts in-flight runs (auto-recovered) and disconnects sockets (auto-reconnect).

## Decisions baked into the plan

1. Built-in supervisor process for restart.
2. Auto-download/stage in background; **apply + restart only on user click**.
3. Restart even without an env master key; show the unlock screen on the way back.

## What's in the doc

- Per-platform swap mechanics + macOS Gatekeeper / supervisor-staleness caveats.
- Server work: supervisor, updater service, `/updates/{status,download,apply}` routes, daily check job, reusable graceful shutdown.
- Frontend work: settings version footer, global bottom banner with "Update & restart", full-screen restart overlay.
- Reuse of existing pieces (`/updates/latest`, `useUpdateCheck`, `UpdateBanner`, `HEZO_VERSION`, build `TARGETS`/`SHA256SUMS`).
- Verification strategy + risks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZSpJH2uCEJxEyKsTjBzte)_