### PR TITLE
feat(web): show current version + release link in settings

### DIFF
--- a/packages/web/src/routes/settings/index.tsx
+++ b/packages/web/src/routes/settings/index.tsx
@@ -4,6 +4,10 @@ import { AiProvidersSection } from '../../components/ai-providers-section';
 import { InstanceSettingsSection } from '../../components/instance-settings-section';
 import { InfoTooltip } from '../../components/ui/info-tooltip';
 import { useMe } from '../../hooks/use-me';
+import { useUpdateCheck } from '../../hooks/use-update-check';
+
+/** Release tags are plain `MAJOR.MINOR.PATCH` (no `v` prefix) — only those have a GitHub tag page. */
+const RELEASE_TAG = /^\d+\.\d+\.\d+$/;
 
 const settingsNav = [
 	{ id: 'ai-providers', label: 'AI providers' },
@@ -23,6 +27,7 @@ const instanceNav = [
 
 function GlobalSettingsPage() {
 	const { data: me } = useMe();
+	const { data: update } = useUpdateCheck();
 	const [activeSection, setActiveSection] = useState('ai-providers');
 
 	function scrollTo(id: string) {
@@ -68,6 +73,25 @@ function GlobalSettingsPage() {
 								{item.label}
 							</Link>
 						))}
+					{update?.current && (
+						<div
+							data-testid="settings-version"
+							className="mt-3 pt-3 px-3 border-t border-border text-[12px] text-text-2"
+						>
+							{RELEASE_TAG.test(update.current) ? (
+								<a
+									href={`https://github.com/hezo-ai/hezo/releases/tag/${update.current}`}
+									target="_blank"
+									rel="noreferrer"
+									className="hover:underline hover:text-text-1 transition-colors"
+								>
+									Hezo v{update.current}
+								</a>
+							) : (
+								<span>Hezo v{update.current}</span>
+							)}
+						</div>
+					)}
 				</nav>
 				<div className="space-y-8">
 					<div id="settings-ai-providers">

--- a/packages/web/test/settings-version.test.tsx
+++ b/packages/web/test/settings-version.test.tsx
@@ -1,0 +1,37 @@
+import { expect, test } from 'vitest';
+import { queryClient } from '../src/lib/query-client';
+import { queryKeys } from '../src/lib/query-keys';
+import { renderApp } from './helpers/render';
+
+// The settings page reads the running version via useUpdateCheck(); the app tree
+// pulls from the singleton query client (__root re-wraps with it), so seed that
+// cache to render the footer deterministically without an upstream GitHub call.
+function seedVersion(current: string) {
+	queryClient.setQueryData(queryKeys.updateCheck(), {
+		current,
+		latest: null,
+		updateAvailable: false,
+		url: null,
+	});
+}
+
+test('settings footer shows the version and links to its GitHub release tag', async () => {
+	seedVersion('0.2.0');
+	const { findByTestId } = await renderApp({ initialPath: '/settings' });
+
+	const footer = await findByTestId('settings-version');
+	expect(footer.textContent).toContain('Hezo v0.2.0');
+
+	const link = footer.querySelector('a') as HTMLAnchorElement;
+	expect(link).toBeTruthy();
+	expect(link.getAttribute('href')).toBe('https://github.com/hezo-ai/hezo/releases/tag/0.2.0');
+});
+
+test('settings footer shows a non-release version as plain text (no broken tag link)', async () => {
+	seedVersion('0.0.0-dev');
+	const { findByTestId } = await renderApp({ initialPath: '/settings' });
+
+	const footer = await findByTestId('settings-version');
+	expect(footer.textContent).toContain('Hezo v0.0.0-dev');
+	expect(footer.querySelector('a')).toBeNull();
+});


### PR DESCRIPTION
## What

Adds a small **version footer** to the global settings sidebar nav showing the running Hezo version, linked to its GitHub release.

This is the **display-only slice** of the deferred self-updating plan (`.dev/self-updating-plan.md`). Per the request, it implements only what's user-visible without touching download/restart machinery.

## Scope clarification

The plan named two display pieces. Investigation found that **the "new version available" banner already exists and works** — `GET /api/updates/latest` (`routes/updates.ts`), the `useUpdateCheck()` hook, and the dismissible `UpdateBanner` mounted in `__root.tsx` (with a Download link to the GitHub release). So the banner was left unchanged, and the only new work was the settings version display, which did not exist.

## Change

- `packages/web/src/routes/settings/index.tsx` — version footer at the bottom of the settings sidebar nav. Reuses `useUpdateCheck()` (its `current` field is always populated, even when the upstream GitHub check fails soft), so no new endpoint or query.
  - Clean `MAJOR.MINOR.PATCH` versions link to `https://github.com/hezo-ai/hezo/releases/tag/<version>` (our release tags have no `v` prefix, per `parseSemver` in `updates.ts`).
  - Non-release builds (e.g. `0.0.0-dev`) render as plain text to avoid a broken tag link.
  - Mobile-first, matching the existing nav's Tailwind idiom.

## Out of scope (still deferred in `.dev/self-updating-plan.md`)

Supervisor process, updater service, `/updates/{status,download,apply}` routes, daily update-check cron, restart sentinel/graceful-shutdown, restart overlay, and the banner restyle / "Update & restart" action.

## Testing

- New component test `packages/web/test/settings-version.test.tsx`: asserts the footer renders the version and the correct release-tag `href` for a clean semver, and renders a dev version as plain text (no link). Seeds the `update-check` query cache so it's deterministic without an upstream call.
- `bun run test --package web` (399 tests, 111 files) green; `bun run typecheck` and `bun run check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BR8a1ifrRWKM912PSY2wci)_