### PR TITLE
docs: remove "Next" sections from doc pages

### DIFF
--- a/docs/ai-models.md
+++ b/docs/ai-models.md
@@ -46,8 +46,3 @@ for any individual agent.** One agent can run on Claude while another on the sam
 runs on Gemini or a model from OpenRouter — whatever fits its job. Set it when you hire
 the agent or any time afterward from its settings. See
 [Hiring & customizing agents](/docs/concepts/hiring-and-agents).
-
-## Next
-
-- [Hezo's MCP server](/docs/mcp/hezo-mcp-server) — let any agent drive Hezo.
-- [Connecting MCP servers](/docs/mcp/connecting-mcp-servers) — give your agents more tools.

--- a/docs/concepts/assets.md
+++ b/docs/concepts/assets.md
@@ -42,9 +42,3 @@ deliverable — a mockup, a dashboard, a report — you can open it and click th
 Hezo, rendered live, without checking anything out or running it yourself. HTML previews run
 in a **sandbox**, isolated from your instance and your data, so viewing an agent's output is
 safe by default.
-
-## Next
-
-- [Documents & long-term memory](/docs/concepts/documents-and-memory) — the markdown
-  knowledge layer.
-- [Tasks, rules & summaries](/docs/concepts/tasks) — where assets get attached and discussed.

--- a/docs/concepts/budgets-and-costs.md
+++ b/docs/concepts/budgets-and-costs.md
@@ -37,8 +37,3 @@ its runs are **paused**. The agent automatically resumes when that window rolls 
 to babysit it: set a daily cap and a runaway agent simply stops until tomorrow.
 
 You can also pause and resume agents yourself at any time, independently of budgets.
-
-## Next
-
-- [AI model support](/docs/ai-models) — choosing models (and their cost).
-- [Hiring & customizing agents](/docs/concepts/hiring-and-agents) — set budgets per agent.

--- a/docs/concepts/documents-and-memory.md
+++ b/docs/concepts/documents-and-memory.md
@@ -50,9 +50,3 @@ Both are memory, at different scopes:
   stands right now. See [Tasks, rules & summaries](/docs/concepts/tasks).
 - **Documents** are *project-wide* knowledge that many tasks and agents draw on — the spec,
   the plan, the research.
-
-## Next
-
-- [Assets & previews](/docs/concepts/assets) — files and deliverables that aren't markdown.
-- [Hezo's MCP server](/docs/mcp/hezo-mcp-server) — the tools agents use to read and write
-  documents.

--- a/docs/concepts/hiring-and-agents.md
+++ b/docs/concepts/hiring-and-agents.md
@@ -56,8 +56,3 @@ instance-wide CEO and Coach can't be retired this way.)
 You can also adjust an agent's heartbeat interval and budgets over time, and pause or
 resume agents when you need to. Standing preferences you give the CEO in chat are
 remembered and applied going forward.
-
-## Next
-
-- [AI model support](/docs/ai-models) — the models agents can run on.
-- [Budgets & cost control](/docs/concepts/budgets-and-costs) — capping spend.

--- a/docs/concepts/projects-and-teams.md
+++ b/docs/concepts/projects-and-teams.md
@@ -100,9 +100,3 @@ instance-level settings live (model providers, shared connections, and the like)
 also where you [chat with the CEO](/docs/concepts/roles-and-coordination#chatting-with-the-ceo):
 when you talk to it to create a new project or check in on any team, you're talking to the
 CEO in HQ. See [Roles & the CEO](/docs/concepts/roles-and-coordination).
-
-## Next
-
-- [Roles & the CEO](/docs/concepts/roles-and-coordination) — who does what.
-- [Hiring & customizing agents](/docs/concepts/hiring-and-agents) — change a team's
-  roster and behaviour.

--- a/docs/concepts/roles-and-coordination.md
+++ b/docs/concepts/roles-and-coordination.md
@@ -82,8 +82,3 @@ in plain language; the CEO proposes the change and asks you to approve anything 
 matters. Standing preferences you ask it to remember persist in the CEO's
 [chatbox memory](/docs/concepts/documents-and-memory#chatbox-memory), so you don't repeat
 yourself.
-
-## Next
-
-- [Tasks, rules & summaries](/docs/concepts/tasks) — how work is tracked.
-- [Hiring & customizing agents](/docs/concepts/hiring-and-agents) — shape your roster.

--- a/docs/concepts/tasks.md
+++ b/docs/concepts/tasks.md
@@ -42,11 +42,3 @@ screenshots, PDFs, or other references — to a task or a comment; see
 When work finishes, the **Coach** reviews completed tickets across your projects,
 capturing lessons that feed back into how the teams improve. See
 [Roles & the CEO](/docs/concepts/roles-and-coordination).
-
-## Next
-
-- [Documents & long-term memory](/docs/concepts/documents-and-memory) — the knowledge the
-  work draws on.
-- [Assets & previews](/docs/concepts/assets) — files and deliverables.
-- [Hiring & customizing agents](/docs/concepts/hiring-and-agents) — who works the tasks.
-- [Budgets & cost control](/docs/concepts/budgets-and-costs) — what the work costs.

--- a/docs/deployment/backup-and-recovery.md
+++ b/docs/deployment/backup-and-recovery.md
@@ -51,8 +51,3 @@ hezo --reset
 
 This **wipes the database** and starts fresh. There's no other recovery path for a lost
 master key, so treat `--reset` as the last resort it is.
-
-## Next
-
-- [Configuration reference](/docs/deployment/configuration)
-- [Self-hosting](/docs/deployment/self-hosting)

--- a/docs/deployment/cloud.md
+++ b/docs/deployment/cloud.md
@@ -50,8 +50,3 @@ should never sit on a public address without protection. The simplest and safest
 approach is to keep it on a **private network** and not expose the port publicly at all —
 see [Secure remote access](/docs/deployment/secure-remote-access) for the recommended
 options (Tailscale, Cloudflare Tunnel, and others).
-
-## Next
-
-- [Secure remote access](/docs/deployment/secure-remote-access)
-- [Backup & recovery](/docs/deployment/backup-and-recovery)

--- a/docs/deployment/secure-remote-access.md
+++ b/docs/deployment/secure-remote-access.md
@@ -52,8 +52,3 @@ raw Hezo port directly.
 Prefer a private network (Tailscale/WireGuard) or an authenticated tunnel. Treat a
 public, internet-facing Hezo as something that always needs both TLS and an auth layer
 in front of it.
-
-## Next
-
-- [Deploying to the cloud](/docs/deployment/cloud)
-- [Configuration reference](/docs/deployment/configuration)

--- a/docs/deployment/self-hosting.md
+++ b/docs/deployment/self-hosting.md
@@ -54,9 +54,3 @@ Only the server port needs to be reachable by the people using Hezo.
 Upgrading is replacing the binary. On startup Hezo runs any required database
 migrations automatically, taking a snapshot first so an upgrade is safe to roll back.
 See [Backup & recovery](/docs/deployment/backup-and-recovery).
-
-## Next
-
-- [Deploying to the cloud](/docs/deployment/cloud) — run it on a server.
-- [Secure remote access](/docs/deployment/secure-remote-access) — reach it safely.
-- [Configuration reference](/docs/deployment/configuration) — every flag and variable.

--- a/docs/getting-started/first-project.md
+++ b/docs/getting-started/first-project.md
@@ -44,9 +44,3 @@ you driving each step.
   it needs (which it will only ever use as a [protected placeholder](/docs/security/secret-protection)).
 - **Keep an eye on spend** from the budget view. See
   [Budgets & cost control](/docs/concepts/budgets-and-costs).
-
-## Next
-
-- [How Hezo works](/docs/concepts/how-hezo-works) — the moving parts behind the scenes.
-- [Roles & the CEO](/docs/concepts/roles-and-coordination) — who does what, and how to
-  action things through the CEO.

--- a/docs/getting-started/first-run.md
+++ b/docs/getting-started/first-run.md
@@ -38,8 +38,3 @@ Google (Gemini), DeepSeek, Z.ai, OpenRouter, or Kimi.
 
 You can add more than one provider and switch between them later, including giving an
 individual agent its own model. See [AI model support](/docs/ai-models).
-
-## Next
-
-You're ready to put a team to work. Continue to
-[Your first project](/docs/getting-started/first-project).

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -75,8 +75,3 @@ environment variable.
 ```sh
 hezo --version
 ```
-
-## Next
-
-The first time you open the web app, Hezo walks you through creating a **master key**
-and connecting a model. Continue to [First-run setup](/docs/getting-started/first-run).

--- a/docs/mcp/connecting-mcp-servers.md
+++ b/docs/mcp/connecting-mcp-servers.md
@@ -48,9 +48,3 @@ project while everything else uses the shared one.
 Register connections from the web app, or let an agent add one itself when it needs a
 tool (subject to your approval). Either way the connection is scoped, stored, and made
 available to the relevant runs.
-
-## Next
-
-- [Hezo's MCP server](/docs/mcp/hezo-mcp-server) — let external agents drive Hezo.
-- [Secret protection & egress](/docs/security/secret-protection) — how connection
-  secrets are kept safe.

--- a/docs/mcp/hezo-mcp-server.md
+++ b/docs/mcp/hezo-mcp-server.md
@@ -120,8 +120,3 @@ curl -X POST http://localhost:3100/mcp/assets \
 
 The response returns the stored asset and a signed read URL, and the file then shows up in
 the `list_project_assets` and `read_project_asset` tools.
-
-## Next
-
-- [Connecting MCP servers](/docs/mcp/connecting-mcp-servers) — the other direction:
-  giving Hezo's own agents access to external MCP servers.

--- a/docs/security/activity-log.md
+++ b/docs/security/activity-log.md
@@ -69,9 +69,3 @@ The activity log makes Hezo's autonomy accountable. Agents act on their own, but
 action they take — and every secret they use — is on the record, attributed, and impossible
 to rewrite. When something looks off, you can trace exactly what happened and roll back from
 a position of knowledge.
-
-## Next
-
-- [Secret protection & egress](/docs/security/secret-protection) — how the outbound audit is produced.
-- [Container isolation](/docs/security/container-isolation) — why agents can't bypass the proxy.
-- [Master key & encryption](/docs/security/master-key) — how the vault is protected.

--- a/docs/security/container-isolation.md
+++ b/docs/security/container-isolation.md
@@ -47,8 +47,3 @@ and container isolation — a compromised agent is boxed in on every side: it ca
 your secrets, can't reach your host, can't escape its project, and can't smuggle data
 out. You get the upside of autonomous agents running real code without betting your
 system on every line of it being safe.
-
-## Next
-
-- [Secret protection & egress](/docs/security/secret-protection)
-- [Master key & encryption](/docs/security/master-key)

--- a/docs/security/master-key.md
+++ b/docs/security/master-key.md
@@ -53,9 +53,3 @@ There is intentionally **no backdoor.** If you lose the master key, the encrypte
 can't be recovered — your only path forward is to reset the instance and start over
 (`hezo --reset`, see [Backup & recovery](/docs/deployment/backup-and-recovery)). Keep
 the phrase somewhere you trust.
-
-## Next
-
-- [Secret protection & egress](/docs/security/secret-protection) — how secrets are used
-  without exposing them.
-- [Container isolation](/docs/security/container-isolation) — the third pillar.

--- a/docs/security/secret-protection.md
+++ b/docs/security/secret-protection.md
@@ -67,8 +67,3 @@ You're always the one who provides a secret:
 The net effect: a buggy, jailbroken, or outright malicious agent **cannot exfiltrate
 your secrets.** It never sees them, it can only use them against hosts you allowed, and
 every use is on the record.
-
-## Next
-
-- [Master key & encryption](/docs/security/master-key) — how the vault is protected.
-- [Container isolation](/docs/security/container-isolation) — why egress can't be bypassed.


### PR DESCRIPTION
## What

Removes the trailing **"Next"** section from every docs page. Each page ended with a `## Next` heading followed by a short list of related-page links (the orange-link block at the bottom of each doc page).

## Scope

21 pages updated, deletions only (116 lines removed):

- `getting-started/` — installation, first-run, first-project
- `concepts/` — projects-and-teams, roles-and-coordination, tasks, hiring-and-agents, assets, budgets-and-costs, documents-and-memory
- `ai-models.md`
- `mcp/` — hezo-mcp-server, connecting-mcp-servers
- `security/` — activity-log, master-key, secret-protection, container-isolation
- `deployment/` — secure-remote-access, backup-and-recovery, self-hosting, cloud

In every file `## Next` was the last heading, so each section was removed cleanly down to EOF, leaving the prior content paragraph as the new ending. No other content changed.

## Verification

- `grep` confirms no `## Next` sections remain under `docs/`.
- File endings checked — each ends on its last real content line with a single trailing newline; no dangling blank lines.
- `packages/server/test/docs-bundle.test.ts` passes (the docs bundle that ships in the binary / feeds the CEO chat still builds; its assertions are on frontmatter-derived nav, not these link lists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01STR9HGLxs3mFM2JHVad5FA

---
_Generated by [Claude Code](https://claude.ai/code/session_01STR9HGLxs3mFM2JHVad5FA)_