### PR TITLE
Redesign CEO chat widget to match mockup

### DIFF
--- a/packages/web/src/components/ceo-chat/ceo-chat-widget.tsx
+++ b/packages/web/src/components/ceo-chat/ceo-chat-widget.tsx
@@ -1,20 +1,16 @@
-import { Loader2, MessageSquare, Send, X } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { HQ_PROJECT_NAME } from '@hezo/shared';
+import { ArrowRight, Loader2, MessageSquare, X } from 'lucide-react';
+import { type ReactNode, useEffect, useRef, useState } from 'react';
 import { type CeoMessage, useCeoChat } from '../../hooks/use-ceo-chat';
 import { MarkdownProse } from '../markdown-prose';
 import { Tooltip } from '../ui/tooltip';
 
-function formatTime(iso: string): string {
-	const d = new Date(iso);
-	if (Number.isNaN(d.getTime())) return '';
-	return d.toLocaleString(undefined, { hour: 'numeric', minute: '2-digit' });
-}
-
 /**
- * LinkedIn-style floating chat with the CEO, pinned bottom-right. Talks to the
- * single global CEO conversation; messages stream in over the `ceo:global`
- * WebSocket room. Sending a new message while a reply is in flight interrupts
- * it (handled server-side) and starts a fresh turn.
+ * Floating chat with the CEO, pinned bottom-right. Talks to the single global CEO
+ * conversation; messages stream in over the `ceo:global` WebSocket room. Sending a
+ * new message while a reply is in flight interrupts it (handled server-side) and
+ * starts a fresh turn. The CEO is the instance-level singleton living in the HQ
+ * team, so every reply is labelled `CEO · HQ`.
  */
 export function CeoChatWidget() {
 	const [open, setOpen] = useState(false);
@@ -57,19 +53,21 @@ export function CeoChatWidget() {
 	return (
 		<div
 			data-testid="ceo-chat-panel"
-			className="fixed z-50 flex flex-col border border-border bg-surface shadow-xl inset-x-2 bottom-2 top-16 rounded-md md:inset-auto md:bottom-4 md:right-4 md:top-auto md:h-[560px] md:w-[380px]"
+			className="fixed z-50 flex flex-col overflow-hidden border border-border bg-surface shadow-xl inset-x-2 bottom-2 top-16 rounded-2xl md:inset-auto md:bottom-4 md:right-4 md:top-auto md:h-[560px] md:w-[420px]"
 		>
-			<header className="flex items-center justify-between border-b border-border px-3 py-2.5">
-				<div className="flex flex-col">
-					<span className="text-sm font-semibold text-text-1">🧑‍💼 CEO</span>
-					<span className="text-[11px] text-text-2">Ask about any project</span>
+			<header className="flex items-center justify-between border-b border-border px-4 py-3">
+				<div className="flex items-center gap-2">
+					<span className="text-sm font-semibold text-text-1">CEO</span>
+					<span className="rounded-sm border border-border px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-text-2">
+						{HQ_PROJECT_NAME}
+					</span>
 				</div>
 				<button
 					type="button"
 					onClick={() => setOpen(false)}
 					aria-label="Close chat"
 					data-testid="ceo-chat-close"
-					className="flex h-9 w-9 items-center justify-center rounded-md text-text-2 hover:text-text-1 hover:bg-surface-2"
+					className="flex h-9 w-9 items-center justify-center rounded-md text-text-2 hover:bg-surface-2 hover:text-text-1"
 				>
 					<X className="h-4 w-4" />
 				</button>
@@ -78,7 +76,7 @@ export function CeoChatWidget() {
 			<div
 				ref={scrollRef}
 				data-testid="ceo-chat-messages"
-				className="flex flex-1 flex-col gap-3 overflow-y-auto px-3 py-3 scroll-smooth"
+				className="flex flex-1 flex-col gap-4 overflow-y-auto px-4 py-4 scroll-smooth"
 			>
 				{!loaded && (
 					<div className="flex items-center justify-center py-6 text-[13px] text-text-2">
@@ -97,8 +95,8 @@ export function CeoChatWidget() {
 				))}
 			</div>
 
-			<div className="border-t border-border p-2">
-				<div className="flex items-end gap-2">
+			<div className="border-t border-border p-3">
+				<div className="flex items-end gap-2 rounded-2xl border border-border bg-surface px-2 py-1.5 transition-colors focus-within:border-border-strong">
 					<textarea
 						value={draft}
 						onChange={(e) => setDraft(e.target.value)}
@@ -109,9 +107,9 @@ export function CeoChatWidget() {
 							}
 						}}
 						rows={1}
-						placeholder="Message the CEO…"
+						placeholder="Ask the CEO anything, across every project…"
 						data-testid="ceo-chat-input"
-						className="max-h-32 min-h-[2.25rem] flex-1 resize-none rounded-md border border-border bg-surface-2 px-3 py-2 text-[13px] text-text-1 outline-none focus:border-inverse"
+						className="max-h-32 min-h-[2.25rem] flex-1 resize-none bg-transparent px-2 py-2 text-[13px] leading-5 text-text-1 outline-none placeholder:text-text-3"
 					/>
 					<button
 						type="button"
@@ -119,14 +117,19 @@ export function CeoChatWidget() {
 						disabled={!draft.trim()}
 						aria-label="Send message"
 						data-testid="ceo-chat-send"
-						className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-inverse text-inverse-fg disabled:opacity-40 hover:opacity-90"
+						className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-accent-solid text-accent-solid-fg transition-colors hover:bg-accent-hover disabled:opacity-40"
 					>
-						<Send className="h-4 w-4" />
+						<ArrowRight className="h-4 w-4" />
 					</button>
 				</div>
 			</div>
 		</div>
 	);
+}
+
+/** The small uppercase eyebrow above each bubble ("YOU" / "CEO · HQ"). */
+function RoleLabel({ children }: { children: ReactNode }) {
+	return <span className="text-eyebrow px-1 text-text-3">{children}</span>;
 }
 
 function MessageBubble({ message }: { message: CeoMessage }) {
@@ -143,11 +146,12 @@ function MessageBubble({ message }: { message: CeoMessage }) {
 		}
 		return (
 			<div
-				className="flex flex-col gap-1 max-w-[90%]"
+				className="flex max-w-[90%] flex-col gap-1"
 				data-testid="ceo-chat-message"
 				data-role="ceo"
 			>
-				<div className="rounded-md rounded-bl-sm border border-border bg-surface-2 px-3 py-2 text-text-1">
+				<RoleLabel>CEO · {HQ_PROJECT_NAME}</RoleLabel>
+				<div className="rounded-2xl rounded-bl-sm bg-surface-2 px-3.5 py-2.5 text-text-1">
 					{/* The CEO's replies are LLM-authored markdown. The global chat has
 					    no single project scope, so mentions resolve instance-wide:
 					    references that are unique across all projects (TO-1, prd.md,
@@ -161,68 +165,72 @@ function MessageBubble({ message }: { message: CeoMessage }) {
 						<span className="text-[13px] leading-relaxed">Something went wrong.</span>
 					) : null}
 					{interrupted && <div className="mt-1 text-[11px] italic text-text-3">(interrupted)</div>}
-					{/* Reply has begun but the CEO is still working → dots pinned to
-					    the bottom of the same bubble. */}
-					{streaming && <StreamingDots />}
 				</div>
-				<span className="text-[10px] text-text-3">{formatTime(message.created_at)}</span>
+				{/* Reply has begun but the CEO is still working → dots sit just below
+				    the same bubble. */}
+				{streaming && <StreamingDots />}
 			</div>
 		);
 	}
 
 	return (
 		<div
-			className="flex flex-col items-end gap-1 self-end max-w-[90%]"
+			className="flex max-w-[90%] flex-col items-end gap-1 self-end"
 			data-testid="ceo-chat-message"
 			data-role="user"
 		>
-			<div className="rounded-md rounded-br-sm border border-info-soft-fg/20 bg-info-soft px-3 py-2 text-sm leading-relaxed text-text-1 whitespace-pre-wrap">
+			<RoleLabel>You</RoleLabel>
+			<div className="rounded-2xl rounded-br-sm bg-inverse px-3.5 py-2.5 text-sm leading-relaxed text-inverse-fg whitespace-pre-wrap">
 				{message.content}
 			</div>
-			<span className="text-[10px] text-text-3">{formatTime(message.created_at)}</span>
 		</div>
 	);
 }
 
+/** Three pulsing dots — the CEO's resting "thinking" / "still typing" animation. */
+function Dots() {
+	return (
+		<span className="flex items-center gap-1.5" aria-hidden>
+			<span className="h-1.5 w-1.5 rounded-full bg-text-3 animate-pulse" />
+			<span className="h-1.5 w-1.5 rounded-full bg-text-3 animate-pulse [animation-delay:150ms]" />
+			<span className="h-1.5 w-1.5 rounded-full bg-text-3 animate-pulse [animation-delay:300ms]" />
+		</span>
+	);
+}
+
+/**
+ * The CEO has begun a reply but produced no text yet — the label + bare dots
+ * stand in for the (otherwise empty) bubble until the first tokens land.
+ */
 function TypingIndicator() {
 	return (
 		<div
-			className="flex items-center gap-2 max-w-[90%]"
+			className="flex max-w-[90%] flex-col gap-1.5"
 			data-testid="ceo-chat-typing"
 			role="status"
 			aria-label="CEO is typing"
 		>
-			<span
-				aria-hidden
-				className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-surface-2 text-base leading-none"
-			>
-				🧑‍💼
+			<RoleLabel>CEO · {HQ_PROJECT_NAME}</RoleLabel>
+			<span className="px-1">
+				<Dots />
 			</span>
-			<div className="flex items-center gap-1.5 rounded-md rounded-bl-sm border border-border bg-surface-2 px-3 py-3">
-				<span className="h-2.5 w-2.5 rounded-full bg-text-3 animate-pulse" />
-				<span className="h-2.5 w-2.5 rounded-full bg-text-3 animate-pulse [animation-delay:150ms]" />
-				<span className="h-2.5 w-2.5 rounded-full bg-text-3 animate-pulse [animation-delay:300ms]" />
-			</div>
 		</div>
 	);
 }
 
 /**
- * Small dots pinned to the bottom of an in-flight reply bubble — signals the CEO
- * is still working after the first tokens have already landed. (Display:flex
- * breaks it onto its own line below the streamed text.)
+ * Dots pinned just below an in-flight reply bubble — signals the CEO is still
+ * working after the first tokens have already landed.
  */
 function StreamingDots() {
 	return (
 		<span
-			className="mt-1.5 flex items-center gap-1"
+			className="px-1 pt-0.5"
 			data-testid="ceo-chat-streaming-dots"
 			role="status"
 			aria-label="CEO is still typing"
 		>
-			<span className="h-1.5 w-1.5 rounded-full bg-text-3 animate-pulse" />
-			<span className="h-1.5 w-1.5 rounded-full bg-text-3 animate-pulse [animation-delay:150ms]" />
-			<span className="h-1.5 w-1.5 rounded-full bg-text-3 animate-pulse [animation-delay:300ms]" />
+			<Dots />
 		</span>
 	);
 }

--- a/packages/web/test/ceo-chat.test.tsx
+++ b/packages/web/test/ceo-chat.test.tsx
@@ -58,6 +58,47 @@ test('shows the empty state once history loads', async () => {
 	expect(await findByText(/Say hello to the CEO/i)).toBeTruthy();
 });
 
+test('the header identifies the CEO with the HQ badge and the composer invites cross-project questions', async () => {
+	const { findByTestId, getByTestId, getByText } = await renderApp({ initialPath: '/home' });
+	(await findByTestId('ceo-chat-launcher')).click();
+	await findByTestId('ceo-chat-panel');
+
+	// Header reads "CEO" alongside the HQ team badge (the CEO lives in HQ).
+	expect(getByText('CEO')).toBeTruthy();
+	expect(getByText('HQ')).toBeTruthy();
+	// The placeholder reflects the global, every-project scope of the chat.
+	const input = getByTestId('ceo-chat-input') as HTMLTextAreaElement;
+	expect(input.placeholder).toBe('Ask the CEO anything, across every project…');
+});
+
+test('each message carries its role eyebrow — "You" for the operator, "CEO · HQ" for the CEO', async () => {
+	const { findByTestId, findByText } = await renderApp({ initialPath: '/home' });
+	(await findByTestId('ceo-chat-launcher')).click();
+	await findByTestId('ceo-chat-panel');
+
+	seedConversation([
+		{
+			id: 'u1',
+			role: 'user',
+			channel: 'web',
+			status: 'complete',
+			content: 'Hi',
+			created_at: now(),
+		},
+		{
+			id: 'a1',
+			role: 'assistant',
+			channel: 'web',
+			status: 'complete',
+			content: 'Hello',
+			created_at: now(),
+		},
+	]);
+
+	expect(await findByText('You')).toBeTruthy();
+	expect(await findByText('CEO · HQ')).toBeTruthy();
+});
+
 test('the closed launcher button exposes a "Chat with CEO" tooltip on hover', async () => {
 	const { findByTestId, getAllByText, user } = await renderApp({ initialPath: '/home' });
 	const launcher = await findByTestId('ceo-chat-launcher');
@@ -87,7 +128,7 @@ test('streaming with no text yet shows the typing indicator, not an empty bubble
 	expect(queryByTestId('ceo-chat-streaming-dots')).toBeNull();
 });
 
-test('streaming with text shows the reply plus in-bubble dots, not the standalone indicator', async () => {
+test('streaming with text shows the reply plus trailing dots, not the standalone indicator', async () => {
 	const { findByTestId, findByText, getByTestId, queryByTestId } = await renderApp({
 		initialPath: '/home',
 	});
@@ -106,7 +147,7 @@ test('streaming with text shows the reply plus in-bubble dots, not the standalon
 	]);
 
 	expect(await findByText('Working on it')).toBeTruthy();
-	// Dots move into the bottom of the reply bubble; the standalone "thinking"
+	// Dots sit just below the reply bubble; the standalone "thinking"
 	// indicator is gone now that the answer has started.
 	expect(await findByTestId('ceo-chat-streaming-dots')).toBeTruthy();
 	expect(getByTestId('ceo-chat-message')).toBeTruthy();

--- a/test/browser/ceo-chat.spec.ts
+++ b/test/browser/ceo-chat.spec.ts
@@ -29,7 +29,7 @@ test.describe('CEO chat widget — responsive layout', () => {
 		expect(mobileBox).not.toBeNull();
 		expect(mobileBox?.width ?? 0).toBeGreaterThan(340);
 
-		// Desktop: the same open panel re-lays out to the anchored ~380px width.
+		// Desktop: the same open panel re-lays out to the anchored ~420px width.
 		await page.setViewportSize({ width: 1280, height: 800 });
 		await expect(panel).toBeVisible();
 		const desktopBox = await panel.boundingBox();


### PR DESCRIPTION
## What

Restyles the floating CEO chat widget to match the attached design mockup.

**Before** → **After**
- Header `🧑‍💼 CEO` + "Ask about any project" subtitle → **`CEO`** with an **`HQ`** team badge
- User bubble: light-blue, left timestamp → **dark (`bg-inverse`) bubble** under a **`YOU`** eyebrow, right-aligned
- CEO bubble: bordered gray, left timestamp → flat **`bg-surface-2`** bubble under a **`CEO · HQ`** eyebrow
- "thinking" dots → bare pulsing dots **just below** the reply (and label + dots while composing)
- Composer: bordered textarea + dark square send → unified rounded field, **`Ask the CEO anything, across every project…`** placeholder, and an **orange circular arrow** send button
- Bubbles/panel use a softer `rounded-2xl`; timestamps are dropped in favour of the role eyebrows

The desktop panel widens `380px → 420px` (still well under the layout test's `< 440px` bound) so the longer placeholder fits on one line, as in the mockup.

## Rendered result

A faithful render compiled with the app's real OKLCH design tokens:

- `CEO` + `HQ` badge header with close affordance
- `YOU` / dark bubble, `CEO · HQ` / gray bubble with bold **Market Research**
- thinking dots beneath the reply
- one-line placeholder + orange circular `→` button

## Notes / scope

- All `data-testid`s and streaming/markdown/mention behavior are preserved — purely presentational.
- `HQ` is sourced from the shared `HQ_PROJECT_NAME` constant (the CEO is the instance-level singleton in the HQ team), not hardcoded.

## Tests

- Extends `packages/web/test/ceo-chat.test.tsx` with coverage for the header `HQ` badge, the `You` / `CEO · HQ` role eyebrows, and the new placeholder.
- `bun run test --pattern ceo-chat` (web component tier): **15 passing**.
- `turbo typecheck` and `biome check` clean; production build green.
- Playwright `test/browser/ceo-chat.spec.ts` (responsive layout) comment updated for the new width; its assertions (`> 340`, `< 440`) still hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018cmSPpsveRjA1gc9qrjbNT

---
_Generated by [Claude Code](https://claude.ai/code/session_018cmSPpsveRjA1gc9qrjbNT)_