### PR TITLE
feat(web): link project names in the instance activity log

### DIFF
--- a/packages/web/src/components/audit-log-table.tsx
+++ b/packages/web/src/components/audit-log-table.tsx
@@ -71,9 +71,20 @@ function buildColumns(showProject: boolean): Column<AuditEntry>[] {
 			key: 'project',
 			header: 'Project',
 			hideOnMobile: true,
-			render: (e) => (
-				<span className="text-xs text-text-2">{e.project_name ?? <em>instance</em>}</span>
-			),
+			render: (e) => {
+				const slug = e.project_slug;
+				// Instance-scoped rows (no owning project) render a plain dash.
+				if (!slug) return <span className="text-xs text-text-2">-</span>;
+				return (
+					<Link
+						to="/projects/$projectId"
+						params={{ projectId: slug }}
+						className="text-xs text-text-2 hover:text-accent hover:underline"
+					>
+						{e.project_name ?? slug}
+					</Link>
+				);
+			},
 		});
 	}
 	return columns;

--- a/packages/web/test/audit-log.test.tsx
+++ b/packages/web/test/audit-log.test.tsx
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest';
-import { renderApp } from './helpers/render';
-import { seedWorkspace } from './helpers/seed';
+import { getTestContext, renderApp } from './helpers/render';
+import { seedProject, seedWorkspace } from './helpers/seed';
 
 test('project Activity page exposes the Outbound traffic (egress) tab', async () => {
 	const seeded = { projectSlug: '' };
@@ -24,3 +24,42 @@ test('project Activity page exposes the Outbound traffic (egress) tab', async ()
 	await findByText(/Every outbound HTTPS request/, undefined, { timeout: 10_000 });
 	expect(await findByText(/No outbound traffic recorded yet/)).toBeTruthy();
 });
+
+test('instance Activity log links project names and shows "-" for instance rows', async () => {
+	const seeded = { slug: '' };
+	const { findByText, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Linked Project' });
+			seeded.slug = project.slug;
+			const { db } = getTestContext();
+			// A project-scoped audit row — its Project cell should link to the project.
+			await db.query(
+				`INSERT INTO audit_log (project_id, actor_type, action, entity_type, entity_id, details)
+				 VALUES ($1, 'admin'::audit_actor_type, 'created', 'secret', NULL, '{"name":"PROJECTSCOPEDSECRET"}'::jsonb)`,
+				[project.id],
+			);
+			// An instance-scoped audit row (no project) — its Project cell shows a plain "-".
+			await db.query(
+				`INSERT INTO audit_log (project_id, actor_type, action, entity_type, entity_id, details)
+				 VALUES (NULL, 'admin'::audit_actor_type, 'created', 'secret', NULL, '{"name":"INSTANCEONLYSECRET"}'::jsonb)`,
+			);
+		},
+	});
+
+	await router.navigate({ to: '/settings/audit-log' });
+
+	// The Project column (last cell) of a project-scoped row links to the project page.
+	const projectRow = await findByText(/PROJECTSCOPEDSECRET/, undefined, { timeout: 20_000 });
+	const projectCell = projectRow.closest('tr')?.querySelector('td:last-child');
+	const projectLink = projectCell?.querySelector('a');
+	expect(projectLink?.getAttribute('href')).toContain(`/projects/${seeded.slug}`);
+	expect(projectLink?.textContent).toBe('Linked Project');
+
+	// The Project column of an instance-scoped row is a plain "-" with no link.
+	const instanceRow = await findByText(/INSTANCEONLYSECRET/);
+	const instanceCell = instanceRow.closest('tr')?.querySelector('td:last-child');
+	expect(instanceCell?.textContent).toBe('-');
+	expect(instanceCell?.querySelector('a')).toBeNull();
+}, 30_000);


### PR DESCRIPTION
## What

In the **instance (superuser) Activity log** (`/settings/audit-log`, the cross-project view rendered with `<AuditLogTable showProject>`), the **Project** column now:

- Renders the project name as a **link to the project page** (`/projects/<slug>`) instead of plain text.
- Shows a plain **`-`** for instance-scoped rows (credential/skill/connector admin actions with no owning project) — previously an italic `instance`.

| Before | After |
|---|---|
| `instance` (italic) for instance rows; project name as plain text | `-` for instance rows; project name is a clickable link |

## Why

Project names in the activity log were dead text — you couldn't jump from an entry to the project it belonged to. And `instance` read like a project name when it was really "no project". This makes the column navigable and unambiguous.

## Scope

- The Project column only appears in the cross-project **instance** view, so the per-project Activity view is unaffected.
- Slug-as-`projectId` follows the established convention used elsewhere (`auditEntryLink`, `search-results`, `markdown-prose`, `run-comment`).
- An earlier ask to deep-link document/asset rows to their resource pages was **withdrawn** by the requester (those resources may have been deleted), so `audit-format.ts` / `auditEntryLink` are untouched.

## Tests

Added a component test for the instance view (the `showProject` column was previously untested): a project-scoped row's Project cell links to `/projects/<slug>` with the project name as text, and an instance-scoped row's Project cell shows `-` with no link.

- `bun run typecheck` ✅
- `bunx biome check` (changed files) ✅
- `bunx vitest run` audit-log / project-audit-log / audit-format ✅ (14 tests)

## Files

- `packages/web/src/components/audit-log-table.tsx` — Project column render.
- `packages/web/test/audit-log.test.tsx` — new instance-view test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018nPSbF9CQF9Hd37fFkjQAU

---
_Generated by [Claude Code](https://claude.ai/code/session_018nPSbF9CQF9Hd37fFkjQAU)_