### PR TITLE
feat(web): live countdown to an agent's next heartbeat

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -270,7 +270,11 @@ Work reaches an agent through the **wakeup → job-manager → agent-runner** pi
 `mention`, `reply`, `comment` (opt-in assignee wake), `on_demand`, `automation`.
 Event-based triggers wake agents immediately; scheduled heartbeats are the idle-agent
 fallback. Duplicate wakeups for the same agent dedupe via `idempotency_key` and **coalesce**
-(`coalesced_count`), merging context instead of spawning redundant runs.
+(`coalesced_count`), merging context instead of spawning redundant runs. The agents API
+derives (does not store) each agent's `next_heartbeat_at` as
+`last_heartbeat_at + max(heartbeat_interval_min, floor)` — null when the agent is off the
+schedule (disabled or budget-paused) — sharing the floor constant with the scheduler
+(`services/heartbeat-schedule.ts`) so the web UI's live countdown matches the enforced cadence.
 
 **Dispatch.** `JobManager` runs a ~1 Hz cron that also does container sync, container
 health, and orphan recovery. Per project-concurrency-limited, it: loads queued wakeups →

--- a/docs/concepts/hiring-and-agents.md
+++ b/docs/concepts/hiring-and-agents.md
@@ -19,7 +19,8 @@ agent you set:
   reference team and project context so the prompt stays in sync as things change.
 - **Model** — which provider/model it runs on (defaults to the team's model; override
   per agent if you want).
-- **Heartbeat** — how often it wakes to look for work.
+- **Heartbeat** — how often it wakes to look for work. The agent's page shows a live
+  countdown to its next heartbeat (hidden while the agent is disabled or paused).
 - **Budget** — optional spending limits (see
   [Budgets & cost control](/docs/concepts/budgets-and-costs)).
 - **Code access** — whether the agent works in the project's code workspace.

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -46,6 +46,7 @@ import {
 	restoreRevision,
 	upsertDocument,
 } from '../services/documents';
+import { NEXT_HEARTBEAT_AT_SQL } from '../services/heartbeat-schedule';
 import { loadTeamCoordinationContext } from '../services/internal-intake';
 import { terminateHeartbeatRun } from '../services/run-termination';
 import { resolveSystemPrompt } from '../services/template-resolver';
@@ -61,6 +62,7 @@ export const agentsRoutes = new Hono<Env>();
 /**
  * Common projection for agent rows. JOIN against `members m` and `member_agents ma`.
  * `assigned_task_count` requires the caller to bind terminal statuses via `terminalStatusParams`.
+ * `next_heartbeat_at` is computed (not stored) — NULL when the agent is off the schedule.
  */
 const AGENT_BASE_COLUMNS = `m.id, m.team_id, m.display_name, m.created_at,
 	ma.agent_type_id, ma.title, ma.slug, ma.role_description, ma.summary, ma.team_context,
@@ -69,7 +71,8 @@ const AGENT_BASE_COLUMNS = `m.id, m.team_id, m.display_name, m.created_at,
 	ma.daily_budget_cents, ma.weekly_budget_cents, ma.monthly_budget_cents,
 	ma.touches_code,
 	ma.runtime_status, ma.admin_status, ma.last_heartbeat_at, ma.reports_to,
-	ma.mcp_servers, ma.model_override_provider, ma.model_override_model, ma.updated_at`;
+	ma.mcp_servers, ma.model_override_provider, ma.model_override_model, ma.updated_at,
+	${NEXT_HEARTBEAT_AT_SQL} AS next_heartbeat_at`;
 
 const HEARTBEAT_RUN_COLUMNS = `hr.id, hr.member_id, hr.team_id, hr.wakeup_id, hr.task_id,
 	hr.status, hr.queued_reason, hr.started_at, hr.finished_at, hr.exit_code, hr.error,

--- a/packages/server/src/services/heartbeat-schedule.ts
+++ b/packages/server/src/services/heartbeat-schedule.ts
@@ -1,0 +1,40 @@
+import { AgentAdminStatus, BUDGET_PAUSE_STATUSES } from '@hezo/shared';
+
+/**
+ * Lower bound on how often a heartbeat can fire, regardless of an agent's
+ * configured `heartbeat_interval_min`. Defends against misconfigured low/zero
+ * intervals producing a tight scheduler loop on the same agent.
+ *
+ * Single source of truth for both the scheduler (`JobManager`) and the agents
+ * API's computed `next_heartbeat_at` (see `NEXT_HEARTBEAT_AT_SQL`), so the
+ * displayed countdown matches the cadence the scheduler actually enforces.
+ * Coerced NaN-safe because it is interpolated into SQL below.
+ */
+const rawFloorMin = Number(process.env.HEZO_HEARTBEAT_FLOOR_MIN ?? 60);
+export const HEARTBEAT_INTERVAL_FLOOR_MIN = Number.isFinite(rawFloorMin) ? rawFloorMin : 60;
+
+// Fixed enum values from `@hezo/shared` — safe to interpolate as a Postgres
+// array literal.
+const BUDGET_PAUSE_ARRAY_PG = `{${BUDGET_PAUSE_STATUSES.join(',')}}`;
+
+/**
+ * SQL expression yielding an agent's next scheduled heartbeat as a TIMESTAMPTZ,
+ * computed from a joined `member_agents ma` row. Mirrors the eligibility and
+ * cadence in `JobManager.processScheduledHeartbeats`:
+ *
+ * - `NULL` when the agent is off the schedule — admin-disabled, or reactively
+ *   paused for budget — so the UI shows no countdown for an agent that won't tick.
+ * - `now()` when it has never run a heartbeat (`last_heartbeat_at IS NULL`): the
+ *   scheduler treats it as immediately due.
+ * - otherwise `last_heartbeat_at + max(interval, floor)`.
+ *
+ * Only references `ma.*`, so it composes into any projection that joins
+ * `member_agents AS ma`. The interpolated values are a coerced number and fixed
+ * enum constants (no user input).
+ */
+export const NEXT_HEARTBEAT_AT_SQL = `CASE
+	WHEN ma.admin_status <> '${AgentAdminStatus.Enabled}'::agent_admin_status THEN NULL
+	WHEN ma.runtime_status = ANY('${BUDGET_PAUSE_ARRAY_PG}'::agent_runtime_status[]) THEN NULL
+	WHEN ma.last_heartbeat_at IS NULL THEN now()
+	ELSE ma.last_heartbeat_at + (GREATEST(ma.heartbeat_interval_min, ${HEARTBEAT_INTERVAL_FLOOR_MIN}) || ' minutes')::interval
+END`;

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -48,6 +48,7 @@ import {
 } from './containers';
 import type { DockerClient } from './docker';
 import type { EgressProxy } from './egress';
+import { HEARTBEAT_INTERVAL_FLOOR_MIN } from './heartbeat-schedule';
 import type { LogStreamBroker } from './log-stream-broker';
 import { detectOrphans, healStaleRunState, STALE_STATE_GRACE_SECONDS } from './orphan-detector';
 import type { PricingService } from './pricing';
@@ -147,10 +148,9 @@ const BUDGET_RESUME_CRON = process.env.HEZO_BUDGET_RESUME_CRON ?? '*/30 * * * * 
 // literal for the `<> ALL(...)` / `= ANY(...)` enum-array params.
 const BUDGET_PAUSE_STATUSES_PG = `{${BUDGET_PAUSE_STATUSES.join(',')}}`;
 const INBOX_RETENTION_DAYS = Number(process.env.HEZO_INBOX_RETENTION_DAYS ?? 30);
-// Lower bound on how often a heartbeat can fire, regardless of an agent's
-// configured `heartbeat_interval_min`. Defends against misconfigured low/zero
-// intervals producing a tight 5-second-cron loop on the same agent.
-const HEARTBEAT_INTERVAL_FLOOR_MIN = Number(process.env.HEZO_HEARTBEAT_FLOOR_MIN ?? 60);
+// Lower bound on how often a heartbeat can fire (`HEARTBEAT_INTERVAL_FLOOR_MIN`,
+// from ./heartbeat-schedule) is shared with the agents API's computed
+// `next_heartbeat_at` so the UI countdown matches the cadence enforced here.
 // Quiet window after a run completes before that agent is eligible for another
 // heartbeat. Prevents back-to-back runs when the configured interval is shorter
 // than the run itself.

--- a/packages/server/test/agents-next-heartbeat.test.ts
+++ b/packages/server/test/agents-next-heartbeat.test.ts
@@ -1,0 +1,102 @@
+import type { PGlite } from '@electric-sql/pglite';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Env } from '../src/lib/types';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp, createTestTeam, projectSlugFor } from './helpers/app';
+
+let app: Hono<Env>;
+let db: PGlite;
+let token: string;
+let projectSlug: string;
+let agentId: string;
+
+async function fetchAgent(): Promise<Record<string, unknown>> {
+	const res = await app.request(`/api/projects/${projectSlug}/agents/${agentId}`, {
+		headers: authHeader(token),
+	});
+	expect(res.status).toBe(200);
+	return (await res.json()).data as Record<string, unknown>;
+}
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+
+	const typesRes = await app.request('/api/team-templates', { headers: authHeader(token) });
+	const typeId = (await typesRes.json()).data.find(
+		(t: Record<string, unknown>) => t.name === 'Startup',
+	).id;
+	const teamRes = await createTestTeam(db, { name: 'Heartbeat Co', template_id: typeId });
+	const team = (await teamRes.json()).data;
+	projectSlug = await projectSlugFor(db, team.id);
+
+	const listRes = await app.request(`/api/projects/${projectSlug}/agents`, {
+		headers: authHeader(token),
+	});
+	const agents = (await listRes.json()).data as Array<Record<string, unknown>>;
+	const agent = agents.find((a) => !a.is_instance && a.admin_status === 'enabled');
+	expect(agent).toBeDefined();
+	agentId = agent!.id as string;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+describe('agents API next_heartbeat_at', () => {
+	it('is last_heartbeat_at + configured interval for an enabled agent', async () => {
+		await db.query(
+			`UPDATE member_agents SET last_heartbeat_at = $2, heartbeat_interval_min = 90 WHERE id = $1`,
+			[agentId, '2026-01-01T00:00:00Z'],
+		);
+		const agent = await fetchAgent();
+		// interval 90 > floor 60, so the 90-minute cadence wins.
+		expect(Date.parse(agent.next_heartbeat_at as string)).toBe(Date.parse('2026-01-01T01:30:00Z'));
+	});
+
+	it('clamps a sub-floor interval up to the 60-minute floor', async () => {
+		await db.query(
+			`UPDATE member_agents SET last_heartbeat_at = $2, heartbeat_interval_min = 5 WHERE id = $1`,
+			[agentId, '2026-01-01T00:00:00Z'],
+		);
+		const agent = await fetchAgent();
+		// 5-minute interval is below the floor — next is last + 60m, not last + 5m.
+		expect(Date.parse(agent.next_heartbeat_at as string)).toBe(Date.parse('2026-01-01T01:00:00Z'));
+	});
+
+	it('is ~now when the agent has never run a heartbeat (due immediately)', async () => {
+		await db.query(`UPDATE member_agents SET last_heartbeat_at = NULL WHERE id = $1`, [agentId]);
+		const agent = await fetchAgent();
+		const delta = Math.abs(Date.parse(agent.next_heartbeat_at as string) - Date.now());
+		expect(delta).toBeLessThan(10_000);
+	});
+
+	it('is null for a disabled agent (off the schedule)', async () => {
+		await db.query(
+			`UPDATE member_agents SET admin_status = 'disabled'::agent_admin_status,
+			   last_heartbeat_at = $2 WHERE id = $1`,
+			[agentId, '2026-01-01T00:00:00Z'],
+		);
+		const agent = await fetchAgent();
+		expect(agent.next_heartbeat_at).toBeNull();
+		// restore for the next case
+		await db.query(
+			`UPDATE member_agents SET admin_status = 'enabled'::agent_admin_status WHERE id = $1`,
+			[agentId],
+		);
+	});
+
+	it('is null for a budget-paused agent (off the schedule)', async () => {
+		await db.query(
+			`UPDATE member_agents SET admin_status = 'enabled'::agent_admin_status,
+			   runtime_status = 'out_of_agent_budget'::agent_runtime_status,
+			   last_heartbeat_at = $2 WHERE id = $1`,
+			[agentId, '2026-01-01T00:00:00Z'],
+		);
+		const agent = await fetchAgent();
+		expect(agent.next_heartbeat_at).toBeNull();
+	});
+});

--- a/packages/web/src/components/next-heartbeat-indicator.tsx
+++ b/packages/web/src/components/next-heartbeat-indicator.tsx
@@ -1,0 +1,34 @@
+import { Activity } from 'lucide-react';
+import { useNextHeartbeatCountdown } from '../hooks/use-next-heartbeat';
+
+/**
+ * Live "Next heartbeat in …" countdown for an agent. Renders nothing when the
+ * agent is off the schedule (disabled or budget-paused), in which case
+ * `nextHeartbeatAt` is null.
+ */
+export function NextHeartbeatIndicator({
+	nextHeartbeatAt,
+	className = '',
+}: {
+	nextHeartbeatAt: string | null;
+	className?: string;
+}) {
+	const countdown = useNextHeartbeatCountdown(nextHeartbeatAt);
+	if (!countdown || !nextHeartbeatAt) return null;
+
+	return (
+		<span
+			data-testid="next-heartbeat"
+			title={`Next heartbeat ${new Date(nextHeartbeatAt).toLocaleString()}`}
+			className={`inline-flex items-center gap-1.5 text-xs text-text-2 ${className}`}
+		>
+			<Activity
+				className={`h-3.5 w-3.5 text-text-3 ${countdown.isDue ? 'animate-pulse' : ''}`}
+				aria-hidden="true"
+			/>
+			<span className="whitespace-nowrap">
+				<span className="text-text-3">Next heartbeat</span> {countdown.label}
+			</span>
+		</span>
+	);
+}

--- a/packages/web/src/hooks/use-agents.ts
+++ b/packages/web/src/hooks/use-agents.ts
@@ -24,6 +24,9 @@ export interface Agent {
 	runtime_status: string;
 	admin_status: string;
 	last_heartbeat_at: string | null;
+	/** Computed: when the next scheduled heartbeat is due. Null when the agent is
+	 *  off the schedule (disabled or budget-paused). */
+	next_heartbeat_at: string | null;
 	reports_to: string | null;
 	reports_to_title: string | null;
 	assigned_task_count: number;

--- a/packages/web/src/hooks/use-next-heartbeat.ts
+++ b/packages/web/src/hooks/use-next-heartbeat.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import { formatElapsed } from './use-elapsed-duration';
+
+export interface HeartbeatCountdown {
+	/** Human label, e.g. "in 12m30s" or "due now". */
+	label: string;
+	/** True once the scheduled time has passed — a heartbeat is imminent. */
+	isDue: boolean;
+}
+
+/**
+ * Pure: turn the milliseconds remaining until the next heartbeat into a display
+ * label. At or past the scheduled time the heartbeat is due (the scheduler fires
+ * within a few seconds), so we stop counting down and say "due now".
+ */
+export function describeHeartbeatCountdown(remainingMs: number): HeartbeatCountdown {
+	if (remainingMs <= 0) return { label: 'due now', isDue: true };
+	return { label: `in ${formatElapsed(remainingMs)}`, isDue: false };
+}
+
+/**
+ * Live countdown to an agent's next scheduled heartbeat. Ticks once a second
+ * while a time is set. Returns null when the agent is off the schedule
+ * (`nextHeartbeatAt` is null) or the timestamp is unparseable, so callers can
+ * render nothing. When the heartbeat fires, the realtime `member_agents`
+ * invalidation refetches the agent and `nextHeartbeatAt` rolls forward, which
+ * restarts the timer.
+ */
+export function useNextHeartbeatCountdown(
+	nextHeartbeatAt: string | null,
+): HeartbeatCountdown | null {
+	const [now, setNow] = useState(() => Date.now());
+
+	useEffect(() => {
+		if (!nextHeartbeatAt) return;
+		const id = setInterval(() => setNow(Date.now()), 1000);
+		return () => clearInterval(id);
+	}, [nextHeartbeatAt]);
+
+	if (!nextHeartbeatAt) return null;
+	const target = new Date(nextHeartbeatAt).getTime();
+	if (Number.isNaN(target)) return null;
+	return describeHeartbeatCountdown(target - now);
+}

--- a/packages/web/src/routes/projects/$projectId/agents/$agentId/route.tsx
+++ b/packages/web/src/routes/projects/$projectId/agents/$agentId/route.tsx
@@ -1,6 +1,7 @@
 import { AgentAdminStatus } from '@hezo/shared';
 import { createFileRoute, Link, Outlet, useMatchRoute } from '@tanstack/react-router';
 import { ArrowLeft } from 'lucide-react';
+import { NextHeartbeatIndicator } from '../../../../../components/next-heartbeat-indicator';
 import { Badge } from '../../../../../components/ui/badge';
 import { ExpandableText } from '../../../../../components/ui/expandable-text';
 import { useAgent } from '../../../../../hooks/use-agents';
@@ -35,7 +36,7 @@ function AgentLayout() {
 				<ArrowLeft className="w-3.5 h-3.5" /> Team
 			</Link>
 
-			<div className="flex items-center gap-3 mb-4">
+			<div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 mb-4">
 				<h1
 					className={`text-lg font-semibold${agent.admin_status === AgentAdminStatus.Disabled ? ' text-text-2' : ''}`}
 				>
@@ -45,6 +46,10 @@ function AgentLayout() {
 				<Badge color={agentRuntimeStatusMeta(agent.runtime_status).color}>
 					{agentRuntimeStatusMeta(agent.runtime_status).label}
 				</Badge>
+				<NextHeartbeatIndicator
+					nextHeartbeatAt={agent.next_heartbeat_at}
+					className="w-full sm:w-auto sm:ml-auto"
+				/>
 			</div>
 
 			<div

--- a/packages/web/test/agent-detail.test.tsx
+++ b/packages/web/test/agent-detail.test.tsx
@@ -183,6 +183,58 @@ test('agent settings tab edits the title and persists across reload', async () =
 	);
 });
 
+test('agent header shows a live next-heartbeat countdown', async () => {
+	let teamSlug = '';
+	let agentId = '';
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			teamSlug = ws.internalSlug;
+			agentId = ws.agents[0].id;
+			// Stamp a recent heartbeat so next_heartbeat_at is ~an hour out and the
+			// countdown renders a stable, non-due value.
+			const { db } = getTestContext();
+			await db.query(`UPDATE member_agents SET last_heartbeat_at = now() WHERE id = $1`, [agentId]);
+		},
+	});
+	await router.navigate({
+		to: '/projects/$projectId/agents/$agentId',
+		params: { projectId: teamSlug, agentId },
+	});
+
+	const indicator = await findByTestId('next-heartbeat');
+	expect(indicator.textContent).toMatch(/Next heartbeat in/);
+});
+
+test('agent header hides the countdown for a disabled (off-schedule) agent', async () => {
+	let teamSlug = '';
+	let agentId = '';
+	const { queryByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			teamSlug = ws.internalSlug;
+			agentId = ws.agents[0].id;
+			const { db } = getTestContext();
+			await db.query(
+				`UPDATE member_agents SET admin_status = 'disabled'::agent_admin_status WHERE id = $1`,
+				[agentId],
+			);
+		},
+	});
+	await router.navigate({
+		to: '/projects/$projectId/agents/$agentId',
+		params: { projectId: teamSlug, agentId },
+	});
+
+	// Wait for the (disabled) header to render, then assert there's no countdown.
+	await waitFor(() => {
+		expect(document.querySelector('h1')?.textContent).toMatch(/\(disabled\)/);
+	});
+	expect(queryByTestId('next-heartbeat')).toBeNull();
+});
+
 test('agent disable and enable lifecycle reflects in detail view', async () => {
 	let teamSlug = '';
 	let teamId = '';

--- a/packages/web/test/next-heartbeat.test.ts
+++ b/packages/web/test/next-heartbeat.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from 'vitest';
+import { describeHeartbeatCountdown } from '../src/hooks/use-next-heartbeat';
+
+test('counts down to a future heartbeat', () => {
+	expect(describeHeartbeatCountdown(90_000)).toEqual({ label: 'in 1m30s', isDue: false });
+	expect(describeHeartbeatCountdown(60 * 60_000)).toEqual({ label: 'in 1h0m0s', isDue: false });
+	expect(describeHeartbeatCountdown(5_000)).toEqual({ label: 'in 5s', isDue: false });
+});
+
+test('reports due once the scheduled time has passed', () => {
+	expect(describeHeartbeatCountdown(0)).toEqual({ label: 'due now', isDue: true });
+	expect(describeHeartbeatCountdown(-5_000)).toEqual({ label: 'due now', isDue: true });
+});


### PR DESCRIPTION
## What

Adds a dynamic, ticking **"Next heartbeat in …"** countdown to the agent page header (visible on both the Executions and Settings tabs).

[placement: in the agent detail header, next to the runtime-status badge]

## Why

The agent page already showed the heartbeat interval and the *last* heartbeat, but nothing told you when the agent will next wake to look for work. This surfaces that as a live countdown.

## How it works

- **Computed server-side.** The agents API now returns a computed (non-stored) `next_heartbeat_at`:
  `last_heartbeat_at + max(heartbeat_interval_min, floor)`.
  Computing it on the server matters because the scheduler enforces a **minimum interval floor** (`HEZO_HEARTBEAT_FLOOR_MIN`, default 60 min) that the client can't see — an agent configured at, say, 5 min actually fires hourly, and the countdown reflects that. It's `null` when the agent is **off the schedule** (admin-disabled or budget-paused), and the UI renders no countdown in that case.
- **Single source of truth for the floor.** Extracted into `services/heartbeat-schedule.ts`, imported by both the scheduler (`job-manager.ts`) and the agents API, so the displayed cadence always matches the one actually enforced.
- **Auto-resets in realtime.** When a heartbeat completes, `setAgentIdleIfNoActiveRuns` stamps `last_heartbeat_at` and broadcasts `member_agents`, which the existing WebSocket invalidation already routes to the agent query — so the countdown rolls forward with no new plumbing.
- **Client.** New `useNextHeartbeatCountdown` hook (ticks once a second, with a pure `describeHeartbeatCountdown` helper) and a small `NextHeartbeatIndicator` component. The header wraps responsively (full-width line on mobile, right-aligned on `sm+`).

## Tests

- **Server** (`agents-next-heartbeat.test.ts`): `next_heartbeat_at` equals `last + interval`; clamps a sub-floor interval up to the 60-min floor; `≈ now` when never run; `null` when disabled; `null` when budget-paused.
- **Web unit** (`next-heartbeat.test.ts`): the pure countdown formatter (future → `in 1m30s`, elapsed → `due now`).
- **Web component** (`agent-detail.test.tsx`): header shows the live countdown for a scheduled agent; hides it for a disabled agent.

All targeted suites, full typecheck, lint, and build are green.

## Docs

Updated `docs/concepts/hiring-and-agents.md` (user-facing) and `.dev/architecture.md` (the wakeups/heartbeat section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QFnr9v8YU4eQg7zy5q6mSv

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFnr9v8YU4eQg7zy5q6mSv)_