### PR TITLE
feat(web): nest Container and Activity under Settings in the project sidebar

### DIFF
--- a/packages/web/src/components/project-sidebar.tsx
+++ b/packages/web/src/components/project-sidebar.tsx
@@ -61,6 +61,37 @@ export function ProjectSidebar() {
 	const ownAgents = enabledAgents.filter((a) => !a.is_instance).sort(byCreatedAt);
 	const instanceAgents = enabledAgents.filter((a) => a.is_instance).sort(byCreatedAt);
 
+	// Container and Activity: top-level on HQ (which has no Settings page to nest
+	// under), but sub-items of Settings on a normal project — see below.
+	const containerPage = {
+		to: '/projects/$projectId/container',
+		params: projectParams,
+		testId: 'project-sidebar-container',
+		label: (
+			<span className="inline-flex items-center gap-1.5">
+				<span>Container</span>
+				{containerFailed && (
+					<Tooltip content="Container failed — click for details" side="right">
+						<span
+							role="img"
+							data-testid="project-sidebar-container-error"
+							aria-label="Container failed"
+							className="inline-flex shrink-0 text-danger"
+						>
+							<AlertTriangle className="w-3 h-3" aria-hidden="true" />
+						</span>
+					</Tooltip>
+				)}
+			</span>
+		),
+	};
+	const activityPage = {
+		to: '/projects/$projectId/audit-log',
+		params: projectParams,
+		label: 'Activity',
+		testId: 'project-sidebar-activity',
+	};
+
 	const projectPages = [
 		{
 			to: '/projects/$projectId/tasks',
@@ -82,34 +113,9 @@ export function ProjectSidebar() {
 			params: projectParams,
 			label: 'Assets',
 		},
-		{
-			to: '/projects/$projectId/container',
-			params: projectParams,
-			label: (
-				<span className="inline-flex items-center gap-1.5">
-					<span>Container</span>
-					{containerFailed && (
-						<Tooltip content="Container failed — click for details" side="right">
-							<span
-								role="img"
-								data-testid="project-sidebar-container-error"
-								aria-label="Container failed"
-								className="inline-flex shrink-0 text-danger"
-							>
-								<AlertTriangle className="w-3 h-3" aria-hidden="true" />
-							</span>
-						</Tooltip>
-					)}
-				</span>
-			),
-		},
-		{
-			to: '/projects/$projectId/audit-log',
-			params: projectParams,
-			label: 'Activity',
-		},
 		...(isInternal
-			? []
+			? // HQ has no Settings — keep Container and Activity at the top level.
+				[containerPage, activityPage]
 			: [
 					{
 						to: '/projects/$projectId/budget',
@@ -122,6 +128,9 @@ export function ProjectSidebar() {
 						params: projectParams,
 						label: 'Settings',
 						testId: 'project-sidebar-settings',
+						// Container and Activity disclose under Settings when it (or one of
+						// them) is the active route.
+						subItems: [containerPage, activityPage],
 					},
 				]),
 	];

--- a/packages/web/src/components/sidebar-nav.tsx
+++ b/packages/web/src/components/sidebar-nav.tsx
@@ -1,5 +1,6 @@
 import { Link, useMatchRoute } from '@tanstack/react-router';
 import { Plus } from 'lucide-react';
+import { Fragment } from 'react';
 import { Tooltip } from './ui/tooltip';
 
 interface SidebarNavItem {
@@ -14,6 +15,43 @@ interface SidebarNavItem {
 function CountBadge({ value }: { value: number | undefined }) {
 	if (!value) return null;
 	return <span className="ml-auto pl-2 font-mono text-[11px] text-text-3">{value}</span>;
+}
+
+/**
+ * Renders an item's nested sub-items, indented a level beyond the parent. The
+ * caller decides whether to mount this (a sub-item disclosure opens when the
+ * parent — or one of these sub-items — is the active route).
+ */
+function SubItemList({
+	subItems,
+	matchRoute,
+}: {
+	subItems: SidebarNavItem[];
+	matchRoute: ReturnType<typeof useMatchRoute>;
+}) {
+	return (
+		<>
+			{subItems.map((subItem) => {
+				const isSubActive = matchRoute({ to: subItem.to, params: subItem.params });
+				return (
+					<Link
+						key={`${subItem.to}-${JSON.stringify(subItem.params)}`}
+						to={subItem.to}
+						params={subItem.params ?? {}}
+						data-testid={subItem.testId}
+						className={`flex items-center text-left text-[12px] pl-7 pr-2 py-0.5 rounded-md transition-colors ${
+							isSubActive
+								? 'text-text-1 font-medium bg-surface-2'
+								: 'text-text-2 hover:text-text-1 hover:bg-surface-2'
+						}`}
+					>
+						{subItem.label}
+						<CountBadge value={subItem.count} />
+					</Link>
+				);
+			})}
+		</>
+	);
 }
 
 export interface SidebarNavSection {
@@ -46,10 +84,16 @@ export function SidebarNav({ sections }: SidebarNavProps) {
 					{(!section.collapsible || !section.collapsed) &&
 						section.items.map((item) => {
 							const isActive = matchRoute({ to: item.to, params: item.params, fuzzy: true });
+							// A sub-item disclosure also stays open while the user is on one of the
+							// sub-item routes (which don't fuzzy-match the parent's own route).
+							const subActive =
+								item.subItems?.some((s) =>
+									matchRoute({ to: s.to, params: s.params, fuzzy: true }),
+								) ?? false;
 							const paddingClass = section.title ? 'pl-4 pr-2 py-0.5' : 'px-2.5 py-1';
-							return (
+							const key = `${item.to}-${JSON.stringify(item.params)}`;
+							const link = (
 								<Link
-									key={`${item.to}-${JSON.stringify(item.params)}`}
 									to={item.to}
 									params={item.params ?? {}}
 									data-testid={item.testId}
@@ -62,6 +106,17 @@ export function SidebarNav({ sections }: SidebarNavProps) {
 									{item.label}
 									<CountBadge value={item.count} />
 								</Link>
+							);
+							// Plain items render exactly as before (no wrapper). Items with
+							// sub-items wrap so the disclosure can sit beneath the parent.
+							if (!item.subItems?.length) return <Fragment key={key}>{link}</Fragment>;
+							return (
+								<div key={key}>
+									{link}
+									{(isActive || subActive) && (
+										<SubItemList subItems={item.subItems} matchRoute={matchRoute} />
+									)}
+								</div>
 							);
 						})}
 					{section.collapsible &&
@@ -81,29 +136,9 @@ export function SidebarNav({ sections }: SidebarNavProps) {
 									>
 										{item.label}
 									</Link>
-									{isActive &&
-										item.subItems?.map((subItem) => {
-											const isSubActive = matchRoute({
-												to: subItem.to,
-												params: subItem.params,
-											});
-											return (
-												<Link
-													key={`${subItem.to}-${JSON.stringify(subItem.params)}`}
-													to={subItem.to}
-													params={subItem.params ?? {}}
-													data-testid={subItem.testId}
-													className={`flex items-center text-left text-[12px] pl-7 pr-2 py-0.5 rounded-md transition-colors ${
-														isSubActive
-															? 'text-text-1 font-medium bg-surface-2'
-															: 'text-text-2 hover:text-text-1 hover:bg-surface-2'
-													}`}
-												>
-													{subItem.label}
-													<CountBadge value={subItem.count} />
-												</Link>
-											);
-										})}
+									{isActive && item.subItems && (
+										<SubItemList subItems={item.subItems} matchRoute={matchRoute} />
+									)}
 								</div>
 							);
 						})}

--- a/packages/web/test/project-sidebar.test.tsx
+++ b/packages/web/test/project-sidebar.test.tsx
@@ -33,7 +33,11 @@ test('the project menu leads with Inbox, lists the project pages, and has a Team
 	expect(within(nav).getByRole('link', { name: 'Inbox' })).toBeTruthy();
 	expect(within(nav).getByRole('link', { name: 'Documents' })).toBeTruthy();
 	expect(within(nav).getByRole('link', { name: 'Assets' })).toBeTruthy();
-	expect(within(nav).getByRole('link', { name: 'Container' })).toBeTruthy();
+	expect(within(nav).getByRole('link', { name: 'Settings' })).toBeTruthy();
+	// Container and Activity now nest under Settings — hidden until it (or one of
+	// them) is the active route.
+	expect(within(nav).queryByRole('link', { name: 'Container' })).toBeNull();
+	expect(within(nav).queryByRole('link', { name: 'Activity' })).toBeNull();
 
 	// A Team section lists the team's agents (presented as the project's own).
 	expect(within(nav).getByRole('link', { name: 'Team' })).toBeTruthy();
@@ -44,6 +48,50 @@ test('the project menu leads with Inbox, lists the project pages, and has a Team
 	// No cross-project landing affordances.
 	expect(within(nav).queryByRole('link', { name: 'All Projects' })).toBeNull();
 	expect(queryByTestId('project-sidebar-back')).toBeNull();
+});
+
+test('Container and Activity nest under Settings, disclosed when Settings is the active route', async () => {
+	let ws!: SeededWorkspace;
+	let projectSlug = '';
+	const { container, findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Operations' });
+			projectSlug = project.slug;
+		},
+	});
+
+	// On a non-settings page the sub-items stay collapsed.
+	await router.navigate({
+		to: '/projects/$projectId/tasks',
+		params: { projectId: projectSlug },
+	});
+	await findByTestId('project-sidebar-name', undefined, { timeout: 15_000 });
+	expect(within(getNav(container)).queryByRole('link', { name: 'Container' })).toBeNull();
+	expect(within(getNav(container)).queryByRole('link', { name: 'Activity' })).toBeNull();
+
+	// Selecting Settings discloses Container and Activity beneath it.
+	await router.navigate({
+		to: '/projects/$projectId/settings',
+		params: { projectId: projectSlug },
+	});
+	await waitFor(() =>
+		expect(within(getNav(container)).getByRole('link', { name: 'Container' })).toBeTruthy(),
+	);
+	expect(within(getNav(container)).getByRole('link', { name: 'Activity' })).toBeTruthy();
+	expect(within(getNav(container)).getByRole('link', { name: 'Settings' })).toBeTruthy();
+
+	// Clicking into Container keeps the disclosure open — its route doesn't
+	// fuzzy-match Settings, so a parent-only check would collapse it on navigation.
+	await router.navigate({
+		to: '/projects/$projectId/container',
+		params: { projectId: projectSlug },
+	});
+	await waitFor(() =>
+		expect(within(getNav(container)).getByRole('link', { name: 'Activity' })).toBeTruthy(),
+	);
+	expect(within(getNav(container)).getByRole('link', { name: 'Container' })).toBeTruthy();
 });
 
 test('the Team section collapses and expands, hiding the agent list', async () => {


### PR DESCRIPTION
## What

In the project sidebar, **Container** and **Activity** move from top-level nav items to **sub-items of Settings**, disclosed only when **Settings** — or one of those routes — is the active route.

Before: `Tasks · Documents · Assets · Container · Activity · Budget · Settings`
After: `Tasks · Documents · Assets · Budget · Settings` → Settings discloses `Container` and `Activity` beneath it when selected.

## How

- **`sidebar-nav.tsx`** — The `SidebarNavItem.subItems` field already existed but was only rendered in the (never-populated) collapsible `section.children` path. This wires sub-item rendering into the regular `section.items` path and extracts a shared `SubItemList` component used by both paths.
  - The disclosure opens when the parent is active **or** when the user is on a sub-item's own route (`subActive`). This matters because `/container` and `/audit-log` don't fuzzy-match Settings' route — a parent-only check would collapse the sub-menu the instant you clicked into Container or Activity. The parent's own highlight stays tied to its own route only, so just the active child row highlights (standard nested-nav behavior).
  - Plain items (no `subItems`) render exactly as before — no DOM change.
- **`project-sidebar.tsx`** — `Container`/`Activity` are defined once and attached as Settings' `subItems` on normal projects. **HQ (internal)** has no Settings page (`/settings` redirects to `/tasks`), so it keeps Container/Activity at the top level — unchanged, preserving the internal-project nav.

## Edge cases

- **HQ / internal projects**: no Settings to nest under → Container & Activity remain top-level (covered by existing `internal-project.test.tsx`).
- The container-failed error indicator still rides on the Container item — now surfaced once Settings is selected.

## Tests

- Updated `project-sidebar.test.tsx`: on `/tasks`, Container/Activity are no longer top-level (Settings is); added a disclosure test that navigates to `/settings` (Container & Activity appear) then to `/container` (they stay visible — disclosure doesn't collapse on navigation).
- Full web component suite green (**111 files / 402 tests**), typecheck, biome, and production build all pass.

No API/route/behavior change, so no `docs/` or `.dev/architecture.md` updates were needed (verified no docs enumerate the sidebar nav).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0154fu2g8aadqmKiYxMcMFEN

---
_Generated by [Claude Code](https://claude.ai/code/session_0154fu2g8aadqmKiYxMcMFEN)_