### PR TITLE
fix(tasks): count cancelled sub-tasks as resolved when closing a parent

### DIFF
--- a/packages/server/src/lib/task-relationships.ts
+++ b/packages/server/src/lib/task-relationships.ts
@@ -28,13 +28,20 @@ export async function assertChildDepthAllowed(
 	return { ok: true };
 }
 
+// Sub-task statuses that still block the parent from being marked done/closed.
+// A parent can only close once every sub-task has reached a *resolved* terminal
+// state — `closed` (Coach-reviewed) or `cancelled` (abandoned). `done` still
+// blocks because it's awaiting Coach review. `cancelled` is intentionally absent:
+// a cancelled sub-task counts the same as a closed one — it's terminal and will
+// never be Coach-reviewed, so gating on it would strand the parent permanently.
+// This mirrors `hasOpenBlockers` in dependencies.ts, where a `cancelled` upstream
+// likewise satisfies a dependency.
 const OPEN_CHILD_STATUSES = [
 	TaskStatus.Backlog,
 	TaskStatus.InProgress,
 	TaskStatus.Review,
 	TaskStatus.Blocked,
 	TaskStatus.Done,
-	TaskStatus.Cancelled,
 ];
 
 export async function assertChildrenAllClosed(

--- a/packages/server/test/parent-cascade.test.ts
+++ b/packages/server/test/parent-cascade.test.ts
@@ -201,7 +201,7 @@ describe('parent cascade — sub-task closure wakes parent agent', () => {
 		expect(after).toBeDefined();
 	});
 
-	it('cancelled sub-task does not wake parent — parent stays gated on Closed', async () => {
+	it('cancelled sub-task wakes parent — cancelled counts the same as Closed', async () => {
 		const parent = await createTask('parent cancel', architectId);
 		const child = await createTask('to be cancelled', uiDesignerId, parent.id);
 		await clearWakeups(architectId);
@@ -211,6 +211,30 @@ describe('parent cascade — sub-task closure wakes parent agent', () => {
 			db,
 			teamId,
 			child.id,
+			TaskStatus.Backlog,
+			TaskStatus.Cancelled,
+			null,
+			undefined,
+		);
+
+		const wakeups = await listWakeups(architectId, parent.id);
+		const childrenClosed = wakeups.find((w) => w.payload.reason === 'children_closed');
+		expect(childrenClosed).toBeDefined();
+		expect(childrenClosed?.source).toBe('assignment');
+		expect(childrenClosed?.idempotency_key).toBe(`children-closed:${parent.id}`);
+	});
+
+	it('does not wake parent while a sibling is open even though one sub-task is cancelled', async () => {
+		const parent = await createTask('parent cancel + open sibling', architectId);
+		const cancelled = await createTask('cancelled child', uiDesignerId, parent.id);
+		await createTask('still open child', engineerId, parent.id);
+		await clearWakeups(architectId);
+
+		await setStatusDirect(cancelled.id, TaskStatus.Cancelled);
+		await triggerStatusAutomations(
+			db,
+			teamId,
+			cancelled.id,
 			TaskStatus.Backlog,
 			TaskStatus.Cancelled,
 			null,

--- a/packages/server/test/tasks.test.ts
+++ b/packages/server/test/tasks.test.ts
@@ -1031,6 +1031,43 @@ describe('closure rules — sub-tasks must be closed before parent', () => {
 		expect((await res.json()).data.status).toBe('done');
 	});
 
+	it('allows done when the only sub-task is cancelled (cancelled counts as closed)', async () => {
+		const parent = await createParent();
+		const child = await createChild(parent.id);
+		await forceStatus(child.id, 'cancelled');
+
+		const res = await setStatus(parent.id, 'done');
+		expect(res.status).toBe(200);
+		expect((await res.json()).data.status).toBe('done');
+	});
+
+	it('allows done when sub-tasks are a mix of closed and cancelled', async () => {
+		const parent = await createParent();
+		const closedChild = await createChild(parent.id);
+		const cancelledChild = await createChild(parent.id);
+		await forceStatus(closedChild.id, 'closed');
+		await forceStatus(cancelledChild.id, 'cancelled');
+
+		const res = await setStatus(parent.id, 'done');
+		expect(res.status).toBe(200);
+		expect((await res.json()).data.status).toBe('done');
+	});
+
+	it('still rejects done when a cancelled sub-task sits beside an open one', async () => {
+		const parent = await createParent();
+		const cancelledChild = await createChild(parent.id);
+		const openChild = await createChild(parent.id);
+		await forceStatus(cancelledChild.id, 'cancelled');
+		await forceStatus(openChild.id, 'in_progress');
+
+		const res = await setStatus(parent.id, 'done');
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		// The open sibling is named as the blocker; the cancelled one is not.
+		expect(body.error.message).toContain(openChild.identifier);
+		expect(body.error.message).not.toContain(cancelledChild.identifier);
+	});
+
 	it('allows done on a parent with no sub-tasks', async () => {
 		const parent = await createParent();
 		const res = await setStatus(parent.id, 'done');


### PR DESCRIPTION
## Problem

A parent task can't be marked **done/closed** while any of its sub-tasks is still "open." But the open-status list included `cancelled`, and a cancelled sub-task can **never** progress to Coach-reviewed `closed` — so any parent with a cancelled child was **permanently stranded**.

This is the exact situation a Captain flagged: a research-pivot planning ticket (`ER-2`) was blocked from closing by two sub-tasks (`ER-4` PRD, `ER-5` Spec) that were **cancelled** during the pivot. Their assignees were disabled, so they couldn't be reopened and re-closed through the normal Coach review flow either — a dead end.

## Fix

Treat a **cancelled** sub-task the same as a **closed** one: both are terminal and resolved, so neither blocks the parent. `done` still blocks, because it's awaiting Coach review.

The change is a single edit to `OPEN_CHILD_STATUSES` in `packages/server/src/lib/task-relationships.ts` (drop `Cancelled`). That list is the shared source of truth for all four call sites, so the fix propagates consistently to:

- the REST `PATCH /tasks` close gate
- the MCP `update_task` close gate
- the parent-cascade wakeup (`wakeParentIfChildrenClosed`)
- the Coach auto-close path in `job-manager`

This also brings the parent/child gate in line with `hasOpenBlockers` in `dependencies.ts`, which **already** counts a `cancelled` upstream as satisfying a dependency (`TERMINAL_TASK_STATUSES` = done/closed/cancelled).

## Tests

- **`tasks.test.ts`** (REST, end-to-end): parent goes `done` when its only sub-task is `cancelled`; when sub-tasks are a mix of `closed`+`cancelled`; and is **still rejected** when a `cancelled` child sits beside an `in_progress` one (only the open sibling is named as the blocker).
- **`parent-cascade.test.ts`**: updated the stale assertion — a cancelled-only sub-task now **wakes** the parent assignee (`children_closed`), and added a case proving the cascade still holds back while a sibling remains open.

All affected suites pass (58 tests); `typecheck` and `build` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2nugkz1zHaKd2Q7D6mCPX

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2nugkz1zHaKd2Q7D6mCPX)_