### PR TITLE
fix(agents): stop idle agents stuck on "Next heartbeat due now"

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -269,12 +269,18 @@ Work reaches an agent through the **wakeup → job-manager → agent-runner** pi
 (scheduled fallback tick), `timer` (recovery: orphan detector, retry), `assignment`,
 `mention`, `reply`, `comment` (opt-in assignee wake), `on_demand`, `automation`.
 Event-based triggers wake agents immediately; scheduled heartbeats are the idle-agent
-fallback. Duplicate wakeups for the same agent dedupe via `idempotency_key` and **coalesce**
-(`coalesced_count`), merging context instead of spawning redundant runs. The agents API
-derives (does not store) each agent's `next_heartbeat_at` as
-`last_heartbeat_at + max(heartbeat_interval_min, floor)` — null when the agent is off the
-schedule (disabled or budget-paused) — sharing the floor constant with the scheduler
-(`services/heartbeat-schedule.ts`) so the web UI's live countdown matches the enforced cadence.
+fallback. A scheduled heartbeat that fires but finds no actionable task is a no-op that
+still **advances `last_heartbeat_at`** (the same field a completed run stamps), so the
+scheduler throttles the next tick a full interval out instead of re-selecting the agent
+every cron tick — a `NULL` `last_heartbeat_at` is perpetually "due". Duplicate wakeups for
+the same agent dedupe via `idempotency_key` and **coalesce** (`coalesced_count`), merging
+context instead of spawning redundant runs. The agents API derives (does not store) each
+agent's `next_heartbeat_at` as `last_heartbeat_at + max(heartbeat_interval_min, floor)` —
+null when the agent is off the schedule (disabled or budget-paused) — sharing the floor
+constant with the scheduler (`services/heartbeat-schedule.ts`) so the web UI's live
+countdown matches the enforced cadence. Alongside it the API derives `has_actionable_work`
+(mirrors the scheduler's task selection: a non-terminal, unblocked assigned task); when
+false the next heartbeat would no-op, so the UI shows a dash rather than a countdown.
 
 **Dispatch.** `JobManager` runs a ~1 Hz cron that also does container sync, container
 health, and orphan recovery. Per project-concurrency-limited, it: loads queued wakeups →

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -47,7 +47,7 @@ import {
 	restoreRevision,
 	upsertDocument,
 } from '../services/documents';
-import { NEXT_HEARTBEAT_AT_SQL } from '../services/heartbeat-schedule';
+import { HAS_ACTIONABLE_WORK_SQL, NEXT_HEARTBEAT_AT_SQL } from '../services/heartbeat-schedule';
 import { loadTeamCoordinationContext } from '../services/internal-intake';
 import { terminateHeartbeatRun } from '../services/run-termination';
 import { resolveSystemPrompt } from '../services/template-resolver';
@@ -64,6 +64,7 @@ export const agentsRoutes = new Hono<Env>();
  * Common projection for agent rows. JOIN against `members m` and `member_agents ma`.
  * `assigned_task_count` requires the caller to bind terminal statuses via `terminalStatusParams`.
  * `next_heartbeat_at` is computed (not stored) — NULL when the agent is off the schedule.
+ * `has_actionable_work` is computed — false when the agent's next heartbeat would no-op.
  */
 const AGENT_BASE_COLUMNS = `m.id, m.team_id, m.display_name, m.created_at,
 	ma.agent_type_id, ma.title, ma.slug, ma.role_description, ma.summary, ma.team_context,
@@ -73,7 +74,8 @@ const AGENT_BASE_COLUMNS = `m.id, m.team_id, m.display_name, m.created_at,
 	ma.touches_code,
 	ma.runtime_status, ma.admin_status, ma.last_heartbeat_at, ma.reports_to,
 	ma.mcp_servers, ma.model_override_provider, ma.model_override_model, ma.updated_at,
-	${NEXT_HEARTBEAT_AT_SQL} AS next_heartbeat_at`;
+	${NEXT_HEARTBEAT_AT_SQL} AS next_heartbeat_at,
+	${HAS_ACTIONABLE_WORK_SQL} AS has_actionable_work`;
 
 const HEARTBEAT_RUN_COLUMNS = `hr.id, hr.member_id, hr.team_id, hr.wakeup_id, hr.task_id,
 	hr.status, hr.queued_reason, hr.started_at, hr.finished_at, hr.exit_code, hr.error,

--- a/packages/server/src/services/heartbeat-schedule.ts
+++ b/packages/server/src/services/heartbeat-schedule.ts
@@ -1,4 +1,4 @@
-import { AgentAdminStatus, BUDGET_PAUSE_STATUSES } from '@hezo/shared';
+import { AgentAdminStatus, BUDGET_PAUSE_STATUSES, TERMINAL_TASK_STATUSES } from '@hezo/shared';
 
 /**
  * Lower bound on how often a heartbeat can fire, regardless of an agent's
@@ -16,6 +16,7 @@ export const HEARTBEAT_INTERVAL_FLOOR_MIN = Number.isFinite(rawFloorMin) ? rawFl
 // Fixed enum values from `@hezo/shared` — safe to interpolate as a Postgres
 // array literal.
 const BUDGET_PAUSE_ARRAY_PG = `{${BUDGET_PAUSE_STATUSES.join(',')}}`;
+const TERMINAL_TASK_STATUSES_PG = `{${TERMINAL_TASK_STATUSES.join(',')}}`;
 
 /**
  * SQL expression yielding an agent's next scheduled heartbeat as a TIMESTAMPTZ,
@@ -38,3 +39,29 @@ export const NEXT_HEARTBEAT_AT_SQL = `CASE
 	WHEN ma.last_heartbeat_at IS NULL THEN now()
 	ELSE ma.last_heartbeat_at + (GREATEST(ma.heartbeat_interval_min, ${HEARTBEAT_INTERVAL_FLOOR_MIN}) || ' minutes')::interval
 END`;
+
+/**
+ * SQL boolean — does this agent have an actionable task *right now*? Mirrors the
+ * task selection in `JobManager.activateAgent`: a non-terminal task assigned to
+ * the agent whose blockers are all closed. When false, a scheduled heartbeat
+ * fires but finds nothing to do (a no-op), so the UI shows a dash instead of a
+ * countdown — a "next heartbeat" that will not actually run anything would only
+ * mislead.
+ *
+ * Keyed on `ma.id` alone, so it composes into any projection joining
+ * `member_agents AS ma`. Like the scheduler's own selection it carries no team
+ * filter — keying on the specific agent (`assignee_id = ma.id`) keeps it correct
+ * for both team-scoped agents and the cross-team instance agents (CEO/Coach).
+ * Interpolates fixed enum constants only (no user input).
+ */
+export const HAS_ACTIONABLE_WORK_SQL = `EXISTS (
+	SELECT 1 FROM tasks i
+	WHERE i.assignee_id = ma.id
+	  AND i.status <> ALL('${TERMINAL_TASK_STATUSES_PG}'::task_status[])
+	  AND NOT EXISTS (
+	    SELECT 1 FROM task_dependencies d
+	    JOIN tasks b ON b.id = d.blocked_by_task_id
+	    WHERE d.task_id = i.id
+	      AND b.status <> ALL('${TERMINAL_TASK_STATUSES_PG}'::task_status[])
+	  )
+)`;

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -1306,6 +1306,16 @@ export class JobManager {
 			);
 			if (tasks.rows.length === 0) {
 				log.debug(`No actionable tasks for agent ${ref(agent.rows[0].slug, memberId)}`);
+				// The agent woke (heartbeat / task-less nudge) and found nothing to do.
+				// Stamp the check so the scheduler throttles the next heartbeat to a
+				// full interval out instead of re-selecting this agent every cron tick
+				// (`last_heartbeat_at IS NULL` is perpetually "due"), which would also
+				// leave the UI countdown stuck on "due now" and churn throwaway wakeup
+				// rows. A real run advances this via setAgentIdleIfNoActiveRuns; a no-op
+				// scan has no run to hang it on, so we advance it here.
+				await db.query('UPDATE member_agents SET last_heartbeat_at = now() WHERE id = $1', [
+					memberId,
+				]);
 				if (wakeupId) {
 					await db.query(
 						`UPDATE agent_wakeup_requests SET status = $1::wakeup_status, completed_at = now() WHERE id = $2`,

--- a/packages/server/test/agents-next-heartbeat.test.ts
+++ b/packages/server/test/agents-next-heartbeat.test.ts
@@ -9,6 +9,8 @@ let app: Hono<Env>;
 let db: PGlite;
 let token: string;
 let projectSlug: string;
+let projectId: string;
+let teamId: string;
 let agentId: string;
 
 async function fetchAgent(): Promise<Record<string, unknown>> {
@@ -17,6 +19,22 @@ async function fetchAgent(): Promise<Record<string, unknown>> {
 	});
 	expect(res.status).toBe(200);
 	return (await res.json()).data as Record<string, unknown>;
+}
+
+async function insertTask(assigneeId: string | null, status = 'backlog'): Promise<string> {
+	const meta = await db.query<{ task_prefix: string; number: number }>(
+		`SELECT p.task_prefix, next_project_task_number(p.id) AS number
+		 FROM projects p WHERE p.id = $1`,
+		[projectId],
+	);
+	const n = meta.rows[0].number;
+	const res = await db.query<{ id: string }>(
+		`INSERT INTO tasks (team_id, project_id, assignee_id, number, identifier, title, status, priority, labels)
+		 VALUES ($1, $2, $3, $4, $5, 'Work', $6::task_status, 'medium'::task_priority, '[]'::jsonb)
+		 RETURNING id`,
+		[teamId, projectId, assigneeId, n, `${meta.rows[0].task_prefix}-${n}`, status],
+	);
+	return res.rows[0].id;
 }
 
 beforeAll(async () => {
@@ -31,7 +49,12 @@ beforeAll(async () => {
 	).id;
 	const teamRes = await createTestTeam(db, { name: 'Heartbeat Co', template_id: typeId });
 	const team = (await teamRes.json()).data;
+	teamId = team.id;
 	projectSlug = await projectSlugFor(db, team.id);
+	const projectRow = await db.query<{ id: string }>('SELECT id FROM projects WHERE slug = $1', [
+		projectSlug,
+	]);
+	projectId = projectRow.rows[0].id;
 
 	const listRes = await app.request(`/api/projects/${projectSlug}/agents`, {
 		headers: authHeader(token),
@@ -98,5 +121,51 @@ describe('agents API next_heartbeat_at', () => {
 		);
 		const agent = await fetchAgent();
 		expect(agent.next_heartbeat_at).toBeNull();
+	});
+});
+
+describe('agents API has_actionable_work', () => {
+	beforeAll(async () => {
+		// Detach any tasks the template seeded onto this agent so each case below
+		// controls its own actionable-work state.
+		await db.query('UPDATE tasks SET assignee_id = NULL WHERE assignee_id = $1', [agentId]);
+	});
+
+	it('is false when the agent has no assigned task', async () => {
+		const agent = await fetchAgent();
+		expect(agent.has_actionable_work).toBe(false);
+	});
+
+	it('is true for an open task assigned to the agent', async () => {
+		const taskId = await insertTask(agentId, 'backlog');
+		const agent = await fetchAgent();
+		expect(agent.has_actionable_work).toBe(true);
+		await db.query('DELETE FROM tasks WHERE id = $1', [taskId]);
+	});
+
+	it('is false when the only assigned task is terminal (done/closed/cancelled)', async () => {
+		const taskId = await insertTask(agentId, 'done');
+		const agent = await fetchAgent();
+		expect(agent.has_actionable_work).toBe(false);
+		await db.query('DELETE FROM tasks WHERE id = $1', [taskId]);
+	});
+
+	it('is false when the assigned task is blocked by an open task, true once the blocker closes', async () => {
+		const taskId = await insertTask(agentId, 'backlog');
+		const blockerId = await insertTask(null, 'in_progress');
+		await db.query('INSERT INTO task_dependencies (task_id, blocked_by_task_id) VALUES ($1, $2)', [
+			taskId,
+			blockerId,
+		]);
+
+		const blocked = await fetchAgent();
+		expect(blocked.has_actionable_work).toBe(false);
+
+		await db.query(`UPDATE tasks SET status = 'done'::task_status WHERE id = $1`, [blockerId]);
+		const unblocked = await fetchAgent();
+		expect(unblocked.has_actionable_work).toBe(true);
+
+		await db.query('DELETE FROM task_dependencies WHERE task_id = $1', [taskId]);
+		await db.query('DELETE FROM tasks WHERE id = ANY($1::uuid[])', [[taskId, blockerId]]);
 	});
 });

--- a/packages/server/test/job-manager-workflows.test.ts
+++ b/packages/server/test/job-manager-workflows.test.ts
@@ -414,7 +414,7 @@ describe('JobManager workflow methods', () => {
 			await db.query('DELETE FROM agent_wakeup_requests WHERE id = $1', [wakeupId]);
 		});
 
-		it('marks wakeup as completed when agent has no assigned tasks', async () => {
+		it('marks wakeup completed and advances last_heartbeat_at when agent has no assigned tasks', async () => {
 			const manager = createJobManager();
 
 			// Ensure agent has no open tasks assigned to it
@@ -422,6 +422,9 @@ describe('JobManager workflow methods', () => {
 				"UPDATE tasks SET assignee_id = NULL WHERE assignee_id = $1 AND status NOT IN ('done', 'closed', 'cancelled')",
 				[agentId],
 			);
+			// A never-heartbeated agent is perpetually "due"; the no-op scan must stamp
+			// last_heartbeat_at so the scheduler throttles instead of re-firing each tick.
+			await db.query('UPDATE member_agents SET last_heartbeat_at = NULL WHERE id = $1', [agentId]);
 
 			const wakeupRes = await db.query<{ id: string }>(
 				`INSERT INTO agent_wakeup_requests (member_id, team_id, source, status, created_at)
@@ -439,6 +442,12 @@ describe('JobManager workflow methods', () => {
 			);
 			expect(result.rows[0].status).toBe(WakeupStatus.Completed);
 			expect(result.rows[0].completed_at).not.toBeNull();
+
+			const agentRow = await db.query<{ last_heartbeat_at: string | null }>(
+				'SELECT last_heartbeat_at FROM member_agents WHERE id = $1',
+				[agentId],
+			);
+			expect(agentRow.rows[0].last_heartbeat_at).not.toBeNull();
 
 			manager.shutdown();
 			await db.query('DELETE FROM agent_wakeup_requests WHERE id = $1', [wakeupId]);

--- a/packages/web/src/components/next-heartbeat-indicator.tsx
+++ b/packages/web/src/components/next-heartbeat-indicator.tsx
@@ -5,29 +5,46 @@ import { useNextHeartbeatCountdown } from '../hooks/use-next-heartbeat';
  * Live "Next heartbeat in …" countdown for an agent. Renders nothing when the
  * agent is off the schedule (disabled or budget-paused), in which case
  * `nextHeartbeatAt` is null.
+ *
+ * When the agent has no actionable work (`hasActionableWork` is false) the next
+ * heartbeat would fire but find nothing to do — a no-op — so we show a dash
+ * instead of a misleading "due now" / countdown. The heartbeat clock keeps
+ * ticking server-side; there is simply nothing for it to act on yet.
  */
 export function NextHeartbeatIndicator({
 	nextHeartbeatAt,
+	hasActionableWork,
 	className = '',
 }: {
 	nextHeartbeatAt: string | null;
+	hasActionableWork: boolean;
 	className?: string;
 }) {
-	const countdown = useNextHeartbeatCountdown(nextHeartbeatAt);
-	if (!countdown || !nextHeartbeatAt) return null;
+	// Only run the live timer when there is work to count down to; passing null
+	// when idle stops the per-second interval.
+	const countdown = useNextHeartbeatCountdown(hasActionableWork ? nextHeartbeatAt : null);
+	if (!nextHeartbeatAt) return null;
+	if (hasActionableWork && !countdown) return null;
+
+	const label = hasActionableWork ? countdown!.label : '—';
+	const isDue = hasActionableWork && countdown!.isDue;
 
 	return (
 		<span
 			data-testid="next-heartbeat"
-			title={`Next heartbeat ${new Date(nextHeartbeatAt).toLocaleString()}`}
+			title={
+				hasActionableWork
+					? `Next heartbeat ${new Date(nextHeartbeatAt).toLocaleString()}`
+					: 'No tasks to work on yet'
+			}
 			className={`inline-flex items-center gap-1.5 text-xs text-text-2 ${className}`}
 		>
 			<Activity
-				className={`h-3.5 w-3.5 text-text-3 ${countdown.isDue ? 'animate-pulse' : ''}`}
+				className={`h-3.5 w-3.5 text-text-3 ${isDue ? 'animate-pulse' : ''}`}
 				aria-hidden="true"
 			/>
 			<span className="whitespace-nowrap">
-				<span className="text-text-3">Next heartbeat</span> {countdown.label}
+				<span className="text-text-3">Next heartbeat</span> {label}
 			</span>
 		</span>
 	);

--- a/packages/web/src/hooks/use-agents.ts
+++ b/packages/web/src/hooks/use-agents.ts
@@ -27,6 +27,10 @@ export interface Agent {
 	/** Computed: when the next scheduled heartbeat is due. Null when the agent is
 	 *  off the schedule (disabled or budget-paused). */
 	next_heartbeat_at: string | null;
+	/** Computed: whether the agent has an actionable task right now. False when its
+	 *  next heartbeat would fire but find nothing to do (so the UI shows a dash
+	 *  instead of a countdown). */
+	has_actionable_work: boolean;
 	reports_to: string | null;
 	reports_to_title: string | null;
 	assigned_task_count: number;

--- a/packages/web/src/routes/projects/$projectId/agents/$agentId/route.tsx
+++ b/packages/web/src/routes/projects/$projectId/agents/$agentId/route.tsx
@@ -48,6 +48,7 @@ function AgentLayout() {
 				</Badge>
 				<NextHeartbeatIndicator
 					nextHeartbeatAt={agent.next_heartbeat_at}
+					hasActionableWork={agent.has_actionable_work}
 					className="w-full sm:w-auto sm:ml-auto"
 				/>
 			</div>

--- a/packages/web/test/agent-detail.test.tsx
+++ b/packages/web/test/agent-detail.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, waitFor, within } from '@testing-library/react';
 import { expect, test } from 'vitest';
 import { queryClient } from '../src/lib/query-client';
 import { getTestContext, renderApp } from './helpers/render';
-import { seedWorkspace } from './helpers/seed';
+import { seedProject, seedTask, seedWorkspace } from './helpers/seed';
 
 test('team org chart renders with status legend', async () => {
 	let teamSlug = '';
@@ -184,15 +184,19 @@ test('agent settings tab edits the title and persists across reload', async () =
 	);
 });
 
-test('agent header shows a live next-heartbeat countdown', async () => {
-	let teamSlug = '';
+test('agent header shows a live next-heartbeat countdown when the agent has work', async () => {
+	let projectSlug = '';
 	let agentId = '';
 	const { findByTestId, router } = await renderApp({
 		initialPath: '/',
 		seed: async () => {
 			const ws = await seedWorkspace();
-			teamSlug = ws.internalSlug;
 			agentId = ws.agents[0].id;
+			// Give the agent an actionable task; without one the indicator shows a
+			// dash (the next heartbeat would no-op) rather than a countdown.
+			const project = await seedProject(ws, { name: 'Demo' });
+			await seedTask(ws, project, { title: 'Do work', assignee_id: agentId });
+			projectSlug = ws.internalSlug; // seedProject reslugs the project
 			// Stamp a recent heartbeat so next_heartbeat_at is ~an hour out and the
 			// countdown renders a stable, non-due value.
 			const { db } = getTestContext();
@@ -201,11 +205,38 @@ test('agent header shows a live next-heartbeat countdown', async () => {
 	});
 	await router.navigate({
 		to: '/projects/$projectId/agents/$agentId',
-		params: { projectId: teamSlug, agentId },
+		params: { projectId: projectSlug, agentId },
 	});
 
 	const indicator = await findByTestId('next-heartbeat');
 	expect(indicator.textContent).toMatch(/Next heartbeat in/);
+});
+
+test('agent header shows a dash when the agent has no work to do', async () => {
+	let teamSlug = '';
+	let agentId = '';
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			teamSlug = ws.internalSlug;
+			agentId = ws.agents[0].id;
+			// Detach any seeded task so the agent has nothing actionable. Its next
+			// heartbeat would fire but no-op, so the indicator must render a dash
+			// instead of a misleading "due now".
+			const { db } = getTestContext();
+			await db.query('UPDATE tasks SET assignee_id = NULL WHERE assignee_id = $1', [agentId]);
+		},
+	});
+	await router.navigate({
+		to: '/projects/$projectId/agents/$agentId',
+		params: { projectId: teamSlug, agentId },
+	});
+
+	const indicator = await findByTestId('next-heartbeat');
+	expect(indicator.textContent).toContain('Next heartbeat');
+	expect(indicator.textContent).toContain('—');
+	expect(indicator.textContent).not.toMatch(/due now|in \d/);
 });
 
 test('agent header hides the countdown for a disabled (off-schedule) agent', async () => {


### PR DESCRIPTION
## Problem

An agent with nothing to work on (e.g. a freshly created "Marketing Lead" with *No executions yet*) showed a perpetual **"Next heartbeat due now"** in its header — and it never moved off "due now".

Two root causes, same place:

- The computed `next_heartbeat_at` is `now()` whenever `last_heartbeat_at IS NULL`. A scheduled heartbeat that fires but finds **no actionable task** returned early in `activateAgent` *without advancing `last_heartbeat_at`*, so it stayed `NULL` forever → the countdown was stuck on "due now".
- Because the agent stayed perpetually "due", the scheduler re-selected it **every cron tick (~5s)**, creating and discarding a throwaway wakeup row each time.

As the user put it: if there's nothing for the agent to work on, the next heartbeat won't *do* anything, so it shouldn't say "due now".

## Changes

- **`job-manager`** — a scan-for-work wakeup that finds nothing now stamps `last_heartbeat_at = now()` before completing, so the scheduler throttles the next heartbeat a full interval out instead of re-firing each tick. (A real run already advances this on completion via `setAgentIdleIfNoActiveRuns`; a no-op scan had no run to hang it on.)
- **agents API** — derive `has_actionable_work` next to `next_heartbeat_at`, mirroring the scheduler's task selection (a non-terminal, unblocked assigned task). Shared SQL fragment in `heartbeat-schedule.ts`, keyed on `ma.id` so it composes into the existing projection and stays correct for cross-team instance agents (CEO/Coach).
- **web** — the next-heartbeat indicator renders a dash (**"—"**) when the agent has no actionable work, since the next heartbeat would no-op, rather than a misleading countdown / "due now". The live timer is also paused in that state.

## Tests

- `has_actionable_work`: false with no task, true for an open assigned task, false when the only task is terminal, false while blocked → true once the blocker closes.
- `last_heartbeat_at` advances on a no-op scan (was `NULL`, becomes set).
- Web: indicator shows a countdown when the agent has work, and a dash when it doesn't.

Also updates `.dev/architecture.md`. `typecheck`, the full `build`, and the touched test suites are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECh2nxF25FCghrfKXcW6Jp

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECh2nxF25FCghrfKXcW6Jp)_