### PR TITLE
fix(dev): use a project-local data dir for the dev server

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -25,8 +25,9 @@ bun run dev
 
 This starts the **Hezo Server** (port 3100) — the main application with the embedded
 PGlite database — and the **Vite dev server** for the web UI (port 5173). The production
-binary serves the UI itself from port 3100. The server creates its database at
-`~/.hezo/pgdata` on first run.
+binary serves the UI itself from port 3100. In dev the server creates its database under
+`.hezo-dev/pgdata` in the repo root (gitignored), keeping local dev isolated from a
+production instance at `~/.hezo`. Override the location with `--data-dir` or `HEZO_DATA_DIR`.
 
 ### Server CLI flags
 

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ packages/server/src/generated/
 packages/server/static/
 *.db
 .hezo/
+.hezo-dev/
 .claude/
 .plans/
 test-results/

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -22,7 +22,7 @@ bun install
 bun run dev
 ```
 
-Starts the server on port 3100 with hot reload. PGlite data persists at `~/.hezo/pgdata` between restarts.
+Starts the server on port 3100 with hot reload. In dev, PGlite data persists at `.hezo-dev/pgdata` in the repo root (gitignored) between restarts, isolated from a production instance; the production binary uses `~/.hezo`. Override with `--data-dir` or `HEZO_DATA_DIR`.
 
 ## CLI Flags
 

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -26,6 +26,39 @@ function resolveDataDir(raw: string): string {
 	return raw.startsWith('~') ? resolve(homedir(), raw.slice(2)) : resolve(raw);
 }
 
+export interface DevDataDir {
+	dataDir: string;
+	/**
+	 * True only when neither HEZO_DATA_DIR nor --data-dir was set — `bun run dev`
+	 * must then forward the project-local default to the server it spawns, which
+	 * would otherwise fall back to the production default (~/.hezo).
+	 */
+	usedDefault: boolean;
+}
+
+/**
+ * Resolve the data dir for `bun run dev`. Mirrors parseConfig's precedence
+ * (env HEZO_DATA_DIR > --data-dir > default) but swaps the production default
+ * (~/.hezo) for a project-local dir so local dev never shares the production
+ * database. Both env and CLI values flow through resolveDataDir, so a leading
+ * `~` expands exactly as the server does. An empty env value is treated as
+ * unset, matching parseConfig's `pick`.
+ */
+export function resolveDevDataDir(
+	defaultDir: string,
+	cliDataDir: string | undefined,
+	env: NodeJS.ProcessEnv = process.env,
+): DevDataDir {
+	const envValue = env.HEZO_DATA_DIR;
+	if (envValue !== undefined && envValue !== '') {
+		return { dataDir: resolveDataDir(envValue), usedDefault: false };
+	}
+	if (cliDataDir !== undefined && cliDataDir !== '') {
+		return { dataDir: resolveDataDir(cliDataDir), usedDefault: false };
+	}
+	return { dataDir: resolve(defaultDir), usedDefault: true };
+}
+
 function parsePort(raw: string): number {
 	const n = Number.parseInt(raw, 10);
 	if (Number.isNaN(n) || n < 1 || n > 65535) {

--- a/packages/server/test/cli.test.ts
+++ b/packages/server/test/cli.test.ts
@@ -2,7 +2,7 @@ import { homedir } from 'node:os';
 import { resolve } from 'node:path';
 import { deriveAuthKeyPair, deriveUnlockKey } from '@hezo/shared';
 import { describe, expect, it } from 'vitest';
-import { parseConfig } from '../src/cli';
+import { parseConfig, resolveDevDataDir } from '../src/cli';
 
 // Canonical BIP39 vector — parseMasterKey only accepts a valid mnemonic.
 const PHRASE =
@@ -148,5 +148,46 @@ describe('parseConfig', () => {
 			const config = parseConfig(argv('--port', '8080'), { HEZO_PORT: '' });
 			expect(config.port).toBe(8080);
 		});
+	});
+});
+
+describe('resolveDevDataDir', () => {
+	// `bun run dev` passes an absolute project-local default here.
+	const DEFAULT = '/repo/.hezo-dev';
+
+	it('uses the project-local default when neither env nor flag is set', () => {
+		const r = resolveDevDataDir(DEFAULT, undefined, EMPTY_ENV);
+		expect(r.dataDir).toBe(resolve(DEFAULT));
+		expect(r.usedDefault).toBe(true);
+	});
+
+	it('honors --data-dir over the default', () => {
+		const r = resolveDevDataDir(DEFAULT, '/cli/path', EMPTY_ENV);
+		expect(r.dataDir).toBe('/cli/path');
+		expect(r.usedDefault).toBe(false);
+	});
+
+	it('HEZO_DATA_DIR wins over --data-dir', () => {
+		const r = resolveDevDataDir(DEFAULT, '/cli/path', { HEZO_DATA_DIR: '/env/path' });
+		expect(r.dataDir).toBe('/env/path');
+		expect(r.usedDefault).toBe(false);
+	});
+
+	it('expands a leading ~ in HEZO_DATA_DIR like the server does', () => {
+		const r = resolveDevDataDir(DEFAULT, undefined, { HEZO_DATA_DIR: '~/custom' });
+		expect(r.dataDir).toBe(resolve(homedir(), 'custom'));
+		expect(r.usedDefault).toBe(false);
+	});
+
+	it('expands a leading ~ in --data-dir', () => {
+		const r = resolveDevDataDir(DEFAULT, '~/custom', EMPTY_ENV);
+		expect(r.dataDir).toBe(resolve(homedir(), 'custom'));
+		expect(r.usedDefault).toBe(false);
+	});
+
+	it('ignores an empty HEZO_DATA_DIR and falls back to the default', () => {
+		const r = resolveDevDataDir(DEFAULT, undefined, { HEZO_DATA_DIR: '' });
+		expect(r.dataDir).toBe(resolve(DEFAULT));
+		expect(r.usedDefault).toBe(true);
 	});
 });

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env bun
 import { existsSync, rmSync } from 'node:fs';
-import { homedir } from 'node:os';
 import { resolve } from 'node:path';
 import { Command } from 'commander';
+import { resolveDevDataDir } from '../packages/server/src/cli';
 import { clearAllProjectWorkspaces } from '../packages/server/src/services/workspace';
 
 const ROOT = resolve(import.meta.dir, '..');
@@ -38,7 +38,14 @@ const program = new Command()
 
 const opts = program.opts();
 
-const dataDir = opts.dataDir ? resolve(opts.dataDir) : resolve(homedir(), '.hezo');
+// Default to a project-local, gitignored dir (<repo>/.hezo-dev) so local dev
+// never shares the production database at ~/.hezo. An explicit --data-dir or
+// HEZO_DATA_DIR still wins (and is then already visible to the spawned server).
+const { dataDir, usedDefault } = resolveDevDataDir(
+	resolve(ROOT, '.hezo-dev'),
+	opts.dataDir,
+	process.env,
+);
 
 if (opts.reset) {
 	const pgDataPath = resolve(dataDir, 'pgdata');
@@ -61,6 +68,9 @@ const webPort = process.env.HEZO_WEB_PORT ?? '5173';
 const hasWebUrl = forwardedArgs.some((a) => a === '--web-url' || a.startsWith('--web-url='));
 const serverArgs: string[] = [
 	...(hasWebUrl ? [] : ['--web-url', `http://localhost:${webPort}`]),
+	// Only inject when we fell back to the dev default — otherwise the server
+	// already sees the user's choice via inherited env or forwardedArgs.
+	...(usedDefault ? ['--data-dir', dataDir] : []),
 	...forwardedArgs,
 ];
 


### PR DESCRIPTION
## Problem

`bun run dev` defaulted to `~/.hezo` — the **same** data directory a production Hezo binary uses. So local development shared one PGlite database, project-workspace tree, embedding-model cache, and DB backups with any real instance on the machine. Dev migrations, `--reset` wipes, seed data, and workspace clearing all hit production state.

Root cause: `scripts/dev.ts` hard-defaulted to `resolve(homedir(), '.hezo')`, and although it forwards args to the server it spawns, it never overrode the data dir — so the spawned server's `parseConfig()` also fell back to `DEFAULT_DATA_DIR` (`~/.hezo`).

## Change

Default the dev server to a gitignored, project-local `.hezo-dev` directory in the repo root instead. The fix stays entirely on the dev seam — **the production binary is untouched and still defaults to `~/.hezo`**.

- **`packages/server/src/cli.ts`** — new exported `resolveDevDataDir(defaultDir, cliDataDir, env)` that mirrors `parseConfig`'s precedence (**env `HEZO_DATA_DIR` > `--data-dir` > project-local default**), reusing the existing tilde-aware `resolveDataDir`. Returns `usedDefault` so the caller knows whether to forward the path. This also fixes a pre-existing dev quirk where `--data-dir '~/x'` made dev clear `<cwd>/~/x`.
- **`scripts/dev.ts`** — resolves the data dir via `resolveDevDataDir(resolve(ROOT, '.hezo-dev'), ...)` (keeping the `--reset` wipe and workspace-clear consistent with the server) and injects `--data-dir <devDir>` into the spawned server **only when neither `--data-dir` nor `HEZO_DATA_DIR` was set**. Explicit overrides still win and reach the server via inherited env / forwarded args.
- **`.gitignore`** — ignore `.hezo-dev/` (the existing `.hezo/` pattern only matches a dir named exactly `.hezo`).
- **Docs** — updated the two contributor docs that stated dev uses `~/.hezo/pgdata` (`.github/CONTRIBUTING.md`, `packages/server/README.md`). No `docs/` change: this alters contributor dev behavior only, so operator-facing `~/.hezo` references stay accurate.

## Tests / verification

- **Unit** — added a `resolveDevDataDir` block to `packages/server/test/cli.test.ts` covering env-wins-over-flag precedence, tilde expansion (env + flag), and the empty-env fallback. `bunx vitest run test/cli.test.ts` → 27 passing.
- **Manual** — booted `bun run dev` and confirmed it creates `<repo>/.hezo-dev/pgdata` (server logged its egress CA under `.hezo-dev/ca/...`), leaving `~/.hezo` untouched; `git check-ignore .hezo-dev/` confirms it's ignored.
- **Gates** — `bun run typecheck` and `bun run check` pass.

## Note for existing dev environments

One-time switch: local state in `~/.hezo` won't be picked up — dev starts fresh in `.hezo-dev`. To keep old data, copy `~/.hezo` → `.hezo-dev`, or run with `--data-dir ~/.hezo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUFf4e93Xqiiz8U7QhrHWE

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUFf4e93Xqiiz8U7QhrHWE)_