### PR TITLE
feat(server): suggest --port when the configured port is already in use

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -14,6 +14,7 @@ import { DockerClient } from './services/docker';
 import { evaluateDockerPreflight, formatDockerPreflightMessage } from './services/docker-preflight';
 import { getSharedImageBuildTracker } from './services/image-build-tracker';
 import type { LogStreamBroker } from './services/log-stream-broker';
+import { formatPortInUseMessage, probePort } from './services/port-preflight';
 import type { WebSocketManager, WsData, WsSocket } from './services/ws';
 import { handleWsSubscribe, handleWsUnsubscribe } from './services/ws-subscribe-handler';
 import { type StartupResult, startup } from './startup';
@@ -26,6 +27,13 @@ interface HezoDevRuntime {
 
 declare global {
 	var __hezoDevRuntime: HezoDevRuntime | undefined;
+	/**
+	 * Set once the cold-start port preflight has run. Persists across `bun --hot`
+	 * reloads (Bun preserves the global scope), so a reload — where our own
+	 * already-running server legitimately holds the port — skips the re-probe
+	 * instead of mistaking it for a conflict and exiting.
+	 */
+	var __hezoPortProbed: boolean | undefined;
 }
 
 async function shutdownPreviousRuntime(): Promise<void> {
@@ -77,6 +85,20 @@ if (await runRestore()) {
 const config = parseConfig();
 setLogLevel(config.logLevel);
 setKeepOldContainers(config.keepOldContainers);
+
+// Port preflight: Bun binds the port itself from the default export below, so an
+// already-taken port would otherwise surface as a bare `EADDRINUSE` crash. Probe
+// it first and exit with guidance pointing at `--port`/`HEZO_PORT`. Guarded so it
+// runs only on a cold start, never on a `bun --hot` reload (where the dev server
+// keeps the port bound across reloads and a re-probe would falsely see a conflict).
+if (!globalThis.__hezoPortProbed) {
+	globalThis.__hezoPortProbed = true;
+	const probe = await probePort(config.port);
+	if (!probe.available && probe.code === 'EADDRINUSE') {
+		log.error(`\n${formatPortInUseMessage(config.port)}\n`);
+		process.exit(1);
+	}
+}
 
 // Docker is a hard prerequisite — every agent runs in a per-project container.
 // Detect a missing or unreachable daemon at launch and exit with actionable

--- a/packages/server/src/services/port-preflight.ts
+++ b/packages/server/src/services/port-preflight.ts
@@ -1,0 +1,57 @@
+import { createServer } from 'node:net';
+
+/**
+ * Outcome of probing whether the configured server port can be bound.
+ * `available` is the gate; `code` carries the failing bind's errno (e.g.
+ * `EADDRINUSE`, `EACCES`) so the caller can react only to "already in use"
+ * and let Bun surface anything else with its own native error.
+ */
+export interface PortProbeResult {
+	available: boolean;
+	code?: string;
+}
+
+/**
+ * Probe whether `port` can be bound on `host` by opening — and immediately
+ * closing — a throwaway listener. `Bun.serve` binds `0.0.0.0` by default, so we
+ * probe the same wildcard address: a process already listening there (commonly a
+ * Hezo server the operator forgot was running) makes the bind fail with
+ * `EADDRINUSE`, which we report as unavailable.
+ *
+ * This is a best-effort preflight, not a lock — there is an unavoidable gap
+ * between the probe closing its socket and Bun binding for real. In the
+ * single-operator local scenario this targets, nothing races for the port in
+ * that gap; the payoff is turning Bun's bare `EADDRINUSE` crash into actionable
+ * guidance. `node:net` (rather than `Bun.serve`) keeps the helper runnable and
+ * testable under Node/vitest.
+ */
+export function probePort(port: number, host = '0.0.0.0'): Promise<PortProbeResult> {
+	return new Promise((resolve) => {
+		const tester = createServer();
+		tester.once('error', (err: NodeJS.ErrnoException) => {
+			resolve({ available: false, code: err.code });
+		});
+		tester.once('listening', () => {
+			tester.close(() => resolve({ available: true }));
+		});
+		tester.listen(port, host);
+	});
+}
+
+/**
+ * Operator-actionable guidance when the configured port is already taken,
+ * printed to the log right before the server exits. Mirrors the Docker
+ * preflight: a one-line diagnosis, then the exact remedy — pick another port via
+ * the `--port` flag or the `HEZO_PORT` env var (the two paths `parseConfig`
+ * already supports).
+ */
+export function formatPortInUseMessage(port: number): string {
+	return [
+		`Port ${port} is already in use — another process (often a Hezo server you already started) is listening on it.`,
+		'',
+		'Free that port, or start Hezo on a different one:',
+		'',
+		`  hezo --port <port>        e.g. hezo --port ${port + 1}`,
+		'  HEZO_PORT=<port> hezo',
+	].join('\n');
+}

--- a/packages/server/test/port-preflight.test.ts
+++ b/packages/server/test/port-preflight.test.ts
@@ -1,0 +1,69 @@
+import { createServer, type Server } from 'node:net';
+import { afterEach, describe, expect, it } from 'vitest';
+import { formatPortInUseMessage, probePort } from '../src/services/port-preflight';
+
+/** Bind a throwaway listener on an OS-assigned free port and return both. */
+function listenOnFreePort(host = '0.0.0.0'): Promise<{ server: Server; port: number }> {
+	return new Promise((resolve, reject) => {
+		const server = createServer();
+		server.once('error', reject);
+		server.listen(0, host, () => {
+			const addr = server.address();
+			if (addr && typeof addr === 'object') resolve({ server, port: addr.port });
+			else reject(new Error('no port assigned'));
+		});
+	});
+}
+
+function close(server: Server): Promise<void> {
+	return new Promise((resolve) => server.close(() => resolve()));
+}
+
+describe('probePort', () => {
+	let occupied: Server | null = null;
+	afterEach(async () => {
+		if (occupied) await close(occupied);
+		occupied = null;
+	});
+
+	it('reports a free port as available', async () => {
+		// Grab a free port, release it, then probe it — nothing is listening, so the
+		// probe must be able to bind.
+		const { server, port } = await listenOnFreePort();
+		await close(server);
+		const result = await probePort(port);
+		expect(result.available).toBe(true);
+		expect(result.code).toBeUndefined();
+	});
+
+	it('reports a port held by another listener as unavailable with EADDRINUSE', async () => {
+		const { server, port } = await listenOnFreePort();
+		occupied = server;
+		const result = await probePort(port);
+		expect(result.available).toBe(false);
+		expect(result.code).toBe('EADDRINUSE');
+	});
+
+	it('does not leave its own listener bound (the port is free again afterwards)', async () => {
+		// A free-port probe must release the throwaway socket so Bun can bind for
+		// real; a second probe of the same port therefore still reports available.
+		const { server, port } = await listenOnFreePort();
+		await close(server);
+		expect((await probePort(port)).available).toBe(true);
+		expect((await probePort(port)).available).toBe(true);
+	});
+});
+
+describe('formatPortInUseMessage', () => {
+	it('names the taken port and points at both --port and HEZO_PORT', () => {
+		const msg = formatPortInUseMessage(3100);
+		expect(msg).toContain('3100');
+		expect(msg).toContain('--port');
+		expect(msg).toContain('HEZO_PORT');
+	});
+
+	it('suggests a concrete alternative port', () => {
+		// The example nudges the operator to a port they can actually try.
+		expect(formatPortInUseMessage(3100)).toContain('3101');
+	});
+});


### PR DESCRIPTION
## Problem

The server entry (`packages/server/src/index.ts`) hands Bun a `export default { port, fetch, websocket }`, so **Bun binds the port itself, after module evaluation**. There is no user code wrapping the bind, so when the configured port is already taken (most commonly: a Hezo server the operator already started) it surfaced as a bare `EADDRINUSE` crash with an unhelpful stack trace and no guidance on what to do.

## Fix

Add a startup **port preflight**, mirroring the existing Docker preflight right above it:

- Probe the configured port *before* the default export is returned. On `EADDRINUSE`, print an actionable message and exit cleanly with code 1 instead of crashing:

  ```
  Port 3100 is already in use — another process (often a Hezo server you already started) is listening on it.

  Free that port, or start Hezo on a different one:

    hezo --port <port>        e.g. hezo --port 3101
    HEZO_PORT=<port> hezo
  ```

- The probe is a best-effort `node:net` bind-and-release on `0.0.0.0` (the address Bun binds by default). Only `EADDRINUSE` is treated as a conflict; any other bind error (e.g. `EACCES`) is left to Bun's own reporting.
- Guarded by a `globalThis` flag so it runs **only on a cold start** and is skipped on `bun --hot` reloads — where the dev server legitimately keeps the port bound across reloads, and a re-probe would otherwise see our own server and falsely abort. This reuses the same global-persistence mechanism the existing `__hezoDevRuntime` reload-shutdown logic already relies on.

## Changes

- `packages/server/src/services/port-preflight.ts` — new: `probePort` (best-effort probe) + `formatPortInUseMessage`.
- `packages/server/src/index.ts` — wire the guarded probe in just before the Docker preflight.
- `packages/server/test/port-preflight.test.ts` — new: free vs. held port, socket release (free again afterwards), and message contents (`--port`, `HEZO_PORT`, concrete alternative).

## Verification

- New unit tests pass (5/5); related `cli` / `docker-preflight` / `startup` suites still green (50/50).
- `typecheck` + `biome check` clean.
- End-to-end, against the real entry point:
  - **Occupied port** → friendly message printed, exits `1` (no Bun stack trace).
  - **Free port** → boots normally, `/api/status` responds in ~4s, zero false aborts (confirms the probe releases its socket so Bun can bind for real).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBJvZ4DJeiDyHbDNaxCbxX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBJvZ4DJeiDyHbDNaxCbxX)_