### PR TITLE
feat: expand-to-fullscreen and unread indicator for the CEO chat

### DIFF
--- a/docs/concepts/roles-and-coordination.md
+++ b/docs/concepts/roles-and-coordination.md
@@ -71,6 +71,12 @@ single ongoing conversation — pick up where you left off rather than starting 
 thread each time. As the CEO works, its reply **streams back in real time**, so you can
 follow its thinking instead of waiting for a finished block of text.
 
+Keep working alongside it: **minimize** the chat to the corner button and a badge appears
+there when a CEO reply lands while you're away — the same unread indicator the inbox uses
+— clearing the moment you reopen it. When you want more room, **expand** the chat to fill
+the screen below the top navigation bar, and collapse it back to the anchored panel when
+you're done.
+
 Because the CEO works across the whole instance, you can ask about anything without
 opening a project first: "how's the marketing site coming along?", "what's the engineering
 team stuck on?", "spin up a team to research competitors". It answers with knowledge of

--- a/packages/web/src/components/ceo-chat/ceo-chat-widget.tsx
+++ b/packages/web/src/components/ceo-chat/ceo-chat-widget.tsx
@@ -1,8 +1,9 @@
 import { HQ_PROJECT_NAME } from '@hezo/shared';
-import { ArrowRight, Loader2, MessageSquare, X } from 'lucide-react';
+import { ArrowRight, Loader2, Maximize2, MessageSquare, Minimize2, X } from 'lucide-react';
 import { type ReactNode, useEffect, useRef, useState } from 'react';
 import { type CeoMessage, useCeoChat } from '../../hooks/use-ceo-chat';
 import { MarkdownProse } from '../markdown-prose';
+import { CountOverlayBadge } from '../ui/count-overlay-badge';
 import { Tooltip } from '../ui/tooltip';
 
 /**
@@ -14,7 +15,8 @@ import { Tooltip } from '../ui/tooltip';
  */
 export function CeoChatWidget() {
 	const [open, setOpen] = useState(false);
-	const { messages, send, streaming, loaded } = useCeoChat(open);
+	const [expanded, setExpanded] = useState(false);
+	const { messages, send, streaming, loaded, unread } = useCeoChat(open);
 	const [draft, setDraft] = useState('');
 	const scrollRef = useRef<HTMLDivElement>(null);
 
@@ -41,19 +43,29 @@ export function CeoChatWidget() {
 					type="button"
 					onClick={() => setOpen(true)}
 					data-testid="ceo-chat-launcher"
-					aria-label="Chat with the CEO"
+					aria-label={unread > 0 ? `Chat with the CEO (${unread} unread)` : 'Chat with the CEO'}
 					className="fixed bottom-4 right-4 z-50 flex h-12 w-12 items-center justify-center rounded-full bg-inverse text-inverse-fg shadow-lg hover:opacity-90"
 				>
 					<MessageSquare className="h-5 w-5" />
+					{/* Unread CEO replies overlay the launcher, mirroring the inbox icon. */}
+					<CountOverlayBadge count={unread} testId="ceo-chat-unread-badge" />
 				</button>
 			</Tooltip>
 		);
 	}
 
+	// `top-16` (64px) keeps both layouts clear of the 48px app header. The default
+	// is an anchored corner panel on desktop; expanded fills the viewport below the
+	// nav bar (full-width with a small margin), never covering the header.
+	const sizeClass = expanded
+		? 'inset-x-2 bottom-2 top-16 md:inset-x-4 md:bottom-4 md:top-16'
+		: 'inset-x-2 bottom-2 top-16 md:inset-auto md:bottom-4 md:right-4 md:top-auto md:h-[560px] md:w-[420px]';
+
 	return (
 		<div
 			data-testid="ceo-chat-panel"
-			className="fixed z-50 flex flex-col overflow-hidden border border-border bg-surface shadow-xl inset-x-2 bottom-2 top-16 rounded-2xl md:inset-auto md:bottom-4 md:right-4 md:top-auto md:h-[560px] md:w-[420px]"
+			data-expanded={expanded}
+			className={`fixed z-50 flex flex-col overflow-hidden rounded-2xl border border-border bg-surface shadow-xl ${sizeClass}`}
 		>
 			<header className="flex items-center justify-between border-b border-border px-4 py-3">
 				<div className="flex items-center gap-2">
@@ -62,15 +74,28 @@ export function CeoChatWidget() {
 						{HQ_PROJECT_NAME}
 					</span>
 				</div>
-				<button
-					type="button"
-					onClick={() => setOpen(false)}
-					aria-label="Close chat"
-					data-testid="ceo-chat-close"
-					className="flex h-9 w-9 items-center justify-center rounded-md text-text-2 hover:bg-surface-2 hover:text-text-1"
-				>
-					<X className="h-4 w-4" />
-				</button>
+				<div className="flex items-center gap-1">
+					{/* Expand/collapse is desktop-only; the panel is already near-full-screen
+					    on mobile, where the toggle would be a no-op. */}
+					<button
+						type="button"
+						onClick={() => setExpanded((v) => !v)}
+						aria-label={expanded ? 'Collapse chat' : 'Expand chat'}
+						data-testid="ceo-chat-expand"
+						className="hidden h-9 w-9 items-center justify-center rounded-md text-text-2 hover:bg-surface-2 hover:text-text-1 md:flex"
+					>
+						{expanded ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
+					</button>
+					<button
+						type="button"
+						onClick={() => setOpen(false)}
+						aria-label="Close chat"
+						data-testid="ceo-chat-close"
+						className="flex h-9 w-9 items-center justify-center rounded-md text-text-2 hover:bg-surface-2 hover:text-text-1"
+					>
+						<X className="h-4 w-4" />
+					</button>
+				</div>
 			</header>
 
 			<div

--- a/packages/web/src/hooks/use-ceo-chat.ts
+++ b/packages/web/src/hooks/use-ceo-chat.ts
@@ -1,7 +1,7 @@
 import {
 	type CeoChannel,
 	type CeoMessageRole,
-	type CeoMessageStatus,
+	CeoMessageStatus,
 	type WsCeoMessageCompleteMessage,
 	type WsCeoMessageDeltaMessage,
 	type WsCeoMessageStartMessage,
@@ -9,7 +9,7 @@ import {
 	wsRoom,
 } from '@hezo/shared';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useSocket } from '../contexts/socket-context';
 import { api } from '../lib/api';
 import { queryKeys } from '../lib/query-keys';
@@ -29,6 +29,33 @@ interface ConversationData {
 }
 
 /**
+ * Unread badge state for the minimized launcher. The CEO conversation has no
+ * server-side read tracking, so we count completed CEO replies that land while
+ * the widget is closed and persist the tally in localStorage (mirrors the
+ * `hezo_token` convention) so a reload still shows the indicator. Opening the
+ * chat clears it. The overlay itself reuses the same component as the inbox.
+ */
+const CEO_UNREAD_KEY = 'hezo_ceo_unread';
+
+function readStoredUnread(): number {
+	try {
+		const n = Number.parseInt(localStorage.getItem(CEO_UNREAD_KEY) ?? '', 10);
+		return Number.isFinite(n) && n > 0 ? n : 0;
+	} catch {
+		return 0;
+	}
+}
+
+function writeStoredUnread(count: number): void {
+	try {
+		if (count > 0) localStorage.setItem(CEO_UNREAD_KEY, String(count));
+		else localStorage.removeItem(CEO_UNREAD_KEY);
+	} catch {
+		// localStorage may be unavailable (private mode); the badge just won't persist.
+	}
+}
+
+/**
  * Drives the single global CEO chat. The TanStack Query cache is the source of
  * truth for messages (keyed by {@link queryKeys.ceoConversation}); the initial
  * history loads via `useQuery` and streamed start/delta/complete events from the
@@ -41,6 +68,13 @@ interface ConversationData {
 export function useCeoChat(active: boolean) {
 	const { subscribe, joinRoom, leaveRoom } = useSocket();
 	const queryClient = useQueryClient();
+	const [unread, setUnread] = useState<number>(readStoredUnread);
+	// The socket handler is wired once; this ref lets it read the live open state
+	// (whether the chat is currently visible) without re-subscribing every toggle.
+	const activeRef = useRef(active);
+	useEffect(() => {
+		activeRef.current = active;
+	}, [active]);
 
 	const query = useQuery({
 		queryKey: queryKeys.ceoConversation(),
@@ -50,12 +84,21 @@ export function useCeoChat(active: boolean) {
 		refetchOnWindowFocus: false,
 	});
 
+	// Opening the chat means the operator is reading it — drop the unread badge.
 	useEffect(() => {
 		if (!active) return;
+		setUnread(0);
+		writeStoredUnread(0);
+	}, [active]);
+
+	// Join the global CEO room for the widget's whole lifetime (it's mounted
+	// app-wide), not just while open, so a reply badges the launcher even when the
+	// chat is minimized. Cache patches below are no-ops until history has loaded.
+	useEffect(() => {
 		const room = wsRoom.ceo();
 		joinRoom(room);
 		return () => leaveRoom(room);
-	}, [active, joinRoom, leaveRoom]);
+	}, [joinRoom, leaveRoom]);
 
 	useEffect(() => {
 		const patch = (fn: (messages: CeoMessage[]) => CeoMessage[]) => {
@@ -94,6 +137,15 @@ export function useCeoChat(active: boolean) {
 					x.id === m.messageId ? { ...x, content: m.content, status: m.status } : x,
 				),
 			);
+			// Complete events fire only for assistant replies. One that finishes
+			// while the widget is closed is an unread CEO message → badge the launcher.
+			if (m.status === CeoMessageStatus.Complete && !activeRef.current) {
+				setUnread((n) => {
+					const next = n + 1;
+					writeStoredUnread(next);
+					return next;
+				});
+			}
 		});
 		return () => {
 			offStart();
@@ -114,5 +166,6 @@ export function useCeoChat(active: boolean) {
 		send: (text: string) => sendMutation.mutateAsync(text.trim()),
 		streaming,
 		loaded: !query.isPending,
+		unread,
 	};
 }

--- a/packages/web/test/ceo-chat.test.tsx
+++ b/packages/web/test/ceo-chat.test.tsx
@@ -206,6 +206,66 @@ test('a CEO reply renders its markdown as formatted HTML, not raw text', async (
 	expect(body.textContent ?? '').not.toContain('**');
 });
 
+// The unread badge is client-tracked in localStorage (the CEO conversation has
+// no server read state) and the WS-driven increment can't run here (sockets are
+// stubbed), so these drive the persisted path: a seeded count renders the
+// overlay, and opening the chat clears both the badge and the stored tally.
+test('the minimized launcher shows an unread overlay for unseen CEO replies', async () => {
+	localStorage.setItem('hezo_ceo_unread', '3');
+	const { findByTestId } = await renderApp({ initialPath: '/home' });
+
+	const badge = await findByTestId('ceo-chat-unread-badge');
+	expect(badge.textContent).toBe('3');
+	// The accessible name surfaces the count too, not just the visual dot.
+	const launcher = await findByTestId('ceo-chat-launcher');
+	expect(launcher.getAttribute('aria-label')).toBe('Chat with the CEO (3 unread)');
+});
+
+test('opening the chat clears the unread overlay and its persisted count', async () => {
+	localStorage.setItem('hezo_ceo_unread', '2');
+	const { findByTestId, queryByTestId } = await renderApp({ initialPath: '/home' });
+
+	// Visible on the closed launcher…
+	expect(await findByTestId('ceo-chat-unread-badge')).toBeTruthy();
+
+	// …open (reads it) then close again.
+	(await findByTestId('ceo-chat-launcher')).click();
+	await findByTestId('ceo-chat-panel');
+	(await findByTestId('ceo-chat-close')).click();
+
+	// Back on the launcher the badge is gone and the stored tally is wiped.
+	await findByTestId('ceo-chat-launcher');
+	await waitFor(() => expect(queryByTestId('ceo-chat-unread-badge')).toBeNull());
+	expect(localStorage.getItem('hezo_ceo_unread')).toBeNull();
+});
+
+test('the expand toggle fills the viewport below the nav, then restores the anchored panel', async () => {
+	const { findByTestId, getByTestId } = await renderApp({ initialPath: '/home' });
+	(await findByTestId('ceo-chat-launcher')).click();
+	const panel = await findByTestId('ceo-chat-panel');
+
+	// Default: anchored desktop panel, clear of the 48px header (top-16).
+	expect(panel.getAttribute('data-expanded')).toBe('false');
+	expect(panel.className).toContain('md:w-[420px]');
+	expect(panel.className).toContain('top-16');
+
+	const expand = getByTestId('ceo-chat-expand');
+	expect(expand.getAttribute('aria-label')).toBe('Expand chat');
+	expand.click();
+
+	// Expanded: fills the viewport (no fixed desktop width) but still below the nav.
+	await waitFor(() => expect(panel.getAttribute('data-expanded')).toBe('true'));
+	expect(panel.className).toContain('md:inset-x-4');
+	expect(panel.className).not.toContain('md:w-[420px]');
+	expect(panel.className).toContain('top-16');
+	expect(getByTestId('ceo-chat-expand').getAttribute('aria-label')).toBe('Collapse chat');
+
+	// Collapse restores the anchored panel.
+	getByTestId('ceo-chat-expand').click();
+	await waitFor(() => expect(panel.getAttribute('data-expanded')).toBe('false'));
+	expect(panel.className).toContain('md:w-[420px]');
+});
+
 test('a user message is shown as typed, not parsed as markdown', async () => {
 	const { findByTestId, findByText } = await renderApp({ initialPath: '/home' });
 	(await findByTestId('ceo-chat-launcher')).click();

--- a/test/browser/ceo-chat.spec.ts
+++ b/test/browser/ceo-chat.spec.ts
@@ -37,4 +37,64 @@ test.describe('CEO chat widget — responsive layout', () => {
 		expect(desktopBox?.width ?? 0).toBeGreaterThan(340);
 		expect(desktopBox?.width ?? 0).toBeLessThan(440);
 	});
+
+	test('expanding fills the viewport but never covers the nav bar', async ({
+		sharedPage,
+		sharedWorkspace,
+	}) => {
+		const page = sharedPage;
+
+		await page.setViewportSize({ width: 1280, height: 800 });
+		await page.goto(`/projects/${sharedWorkspace.projectSlug}/tasks`);
+		await waitForPageLoad(page);
+
+		const launcher = page.getByTestId('ceo-chat-launcher');
+		await expect(launcher).toBeVisible({ timeout: 15000 });
+		await launcher.click();
+
+		const panel = page.getByTestId('ceo-chat-panel');
+		await expect(panel).toBeVisible();
+
+		// Anchored by default: a narrow corner panel.
+		const anchored = await panel.boundingBox();
+		expect(anchored?.width ?? 0).toBeLessThan(440);
+
+		// Expand → fills the viewport width…
+		await page.getByTestId('ceo-chat-expand').click();
+		await expect(panel).toHaveAttribute('data-expanded', 'true');
+		const expandedBox = await panel.boundingBox();
+		expect(expandedBox).not.toBeNull();
+		expect(expandedBox?.width ?? 0).toBeGreaterThan(1000);
+
+		// …but its top stays at or below the header's bottom — the nav stays visible.
+		const header = await page.getByTestId('app-header').boundingBox();
+		const headerBottom = (header?.y ?? 0) + (header?.height ?? 0);
+		expect(headerBottom).toBeGreaterThan(0);
+		expect(expandedBox?.y ?? 0).toBeGreaterThanOrEqual(headerBottom - 1);
+
+		// Collapse restores the anchored corner panel.
+		await page.getByTestId('ceo-chat-expand').click();
+		await expect(panel).toHaveAttribute('data-expanded', 'false');
+		const restored = await panel.boundingBox();
+		expect(restored?.width ?? 0).toBeLessThan(440);
+	});
+
+	test('the expand toggle is desktop-only — hidden on mobile', async ({
+		sharedPage,
+		sharedWorkspace,
+	}) => {
+		const page = sharedPage;
+
+		await page.setViewportSize({ width: 375, height: 800 });
+		await page.goto(`/projects/${sharedWorkspace.projectSlug}/tasks`);
+		await waitForPageLoad(page);
+
+		const launcher = page.getByTestId('ceo-chat-launcher');
+		await expect(launcher).toBeVisible({ timeout: 15000 });
+		await launcher.click();
+		await expect(page.getByTestId('ceo-chat-panel')).toBeVisible();
+
+		// The mobile panel is already near-full-screen, so the control is hidden.
+		await expect(page.getByTestId('ceo-chat-expand')).toBeHidden();
+	});
 });


### PR DESCRIPTION
## What & why

Two improvements to the floating CEO chat widget (`packages/web/src/components/ceo-chat/ceo-chat-widget.tsx`):

1. **Expand to fill the viewport** — the chat can now be expanded to fill the screen **below the top nav bar** (it never covers the 48px app header), then collapsed back to the anchored corner panel.
2. **Unread indicator when minimized** — when the chat is minimized to just the corner button, an overlay badge appears on it when there's an unread CEO reply — using the **same `CountOverlayBadge` component the inbox icon uses** — and clears the moment you reopen the chat.

## How it works

- **Expand/collapse:** a new toggle (`Maximize2`/`Minimize2`) in the panel header. The expanded layout uses `top-16` (64px) so it stays clear of the `h-12` (48px) header in every state. The toggle is desktop-only (`hidden md:flex`) because the panel is already near-full-screen on mobile, where it would be a no-op. The panel carries a `data-expanded` attribute for testability.
- **Unread tracking:** the CEO conversation has no server-side read state, so this is tracked client-side. `useCeoChat` now joins the `ceo:global` WebSocket room for the widget's whole lifetime (not just while open) so a reply is detected even while minimized. A completed CEO reply that lands while the chat is closed increments an unread counter; opening the chat clears it. The tally is persisted in `localStorage` (`hezo_ceo_unread`, mirroring the existing `hezo_token` convention) so a reload still shows the indicator. Complete events are assistant-only on the server, so no role disambiguation is needed.

## Tests

- **Component** (`packages/web/test/ceo-chat.test.tsx`): the launcher renders the unread overlay from a persisted count and surfaces it in the accessible name; opening the chat clears both the badge and the stored tally; the expand toggle swaps to the full-viewport layout (kept clear of the nav) and restores the anchored panel.
- **Playwright** (`test/browser/ceo-chat.spec.ts`): expanding fills the viewport width while its top stays at/below the header's bottom (the nav is never covered), collapse restores the corner panel, and the toggle is hidden at the mobile viewport — these are the real-layout/`boundingBox` assertions the decision tree routes to Playwright.
- **Docs** (`docs/concepts/roles-and-coordination.md`): the "Chatting with the CEO" section now describes the expand and unread behaviours.

## Verification

- `bun run typecheck` ✅
- `bunx biome check` (changed files) ✅
- Full web component suite: **410 tests across 112 files passed** ✅ (confirms the always-on room join doesn't regress any shell-rendering test)
- The Playwright tier was **not executed in this environment** — the Playwright browser binary download is blocked by the egress policy — so it will run in CI. The spec follows the existing pattern already proven in the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01THSYU8F5eMbPRuhieqm99a

---
_Generated by [Claude Code](https://claude.ai/code/session_01THSYU8F5eMbPRuhieqm99a)_