### PR TITLE
feat: modal backdrop for the expanded CEO chat + Escape to close

### DIFF
--- a/docs/concepts/roles-and-coordination.md
+++ b/docs/concepts/roles-and-coordination.md
@@ -74,8 +74,9 @@ follow its thinking instead of waiting for a finished block of text.
 Keep working alongside it: **minimize** the chat to the corner button and a badge appears
 there when a CEO reply lands while you're away — the same unread indicator the inbox uses
 — clearing the moment you reopen it. When you want more room, **expand** the chat to fill
-the screen below the top navigation bar, and collapse it back to the anchored panel when
-you're done.
+the screen below the top navigation bar; expanding dims the rest of the page into a focused,
+modal view. Collapse it back to the anchored panel when you're done, or press **Escape**
+(or click the dimmed area) to close the chat.
 
 Because the CEO works across the whole instance, you can ask about anything without
 opening a project first: "how's the marketing site coming along?", "what's the engineering

--- a/packages/web/src/components/ceo-chat/ceo-chat-widget.tsx
+++ b/packages/web/src/components/ceo-chat/ceo-chat-widget.tsx
@@ -29,6 +29,16 @@ export function CeoChatWidget() {
 		el.scrollTop = el.scrollHeight;
 	}, [lastId, lastLen, streaming, open]);
 
+	// Escape closes the chat from any open state (anchored or the expanded modal).
+	useEffect(() => {
+		if (!open) return;
+		const onKey = (e: KeyboardEvent) => {
+			if (e.key === 'Escape') setOpen(false);
+		};
+		window.addEventListener('keydown', onKey);
+		return () => window.removeEventListener('keydown', onKey);
+	}, [open]);
+
 	const submit = () => {
 		const text = draft.trim();
 		if (!text) return;
@@ -62,93 +72,107 @@ export function CeoChatWidget() {
 		: 'inset-x-2 bottom-2 top-16 md:inset-auto md:bottom-4 md:right-4 md:top-auto md:h-[560px] md:w-[420px]';
 
 	return (
-		<div
-			data-testid="ceo-chat-panel"
-			data-expanded={expanded}
-			className={`fixed z-50 flex flex-col overflow-hidden rounded-2xl border border-border bg-surface shadow-xl ${sizeClass}`}
-		>
-			<header className="flex items-center justify-between border-b border-border px-4 py-3">
-				<div className="flex items-center gap-2">
-					<span className="text-sm font-semibold text-text-1">CEO</span>
-					<span className="rounded-sm border border-border px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-text-2">
-						{HQ_PROJECT_NAME}
-					</span>
-				</div>
-				<div className="flex items-center gap-1">
-					{/* Expand/collapse is desktop-only; the panel is already near-full-screen
-					    on mobile, where the toggle would be a no-op. */}
-					<button
-						type="button"
-						onClick={() => setExpanded((v) => !v)}
-						aria-label={expanded ? 'Collapse chat' : 'Expand chat'}
-						data-testid="ceo-chat-expand"
-						className="hidden h-9 w-9 items-center justify-center rounded-md text-text-2 hover:bg-surface-2 hover:text-text-1 md:flex"
-					>
-						{expanded ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
-					</button>
-					<button
-						type="button"
-						onClick={() => setOpen(false)}
-						aria-label="Close chat"
-						data-testid="ceo-chat-close"
-						className="flex h-9 w-9 items-center justify-center rounded-md text-text-2 hover:bg-surface-2 hover:text-text-1"
-					>
-						<X className="h-4 w-4" />
-					</button>
-				</div>
-			</header>
-
+		<>
+			{/* In expanded mode the chat is modal: a scrim dims and occludes the page
+			    content below the nav bar (the header stays clear and usable, matching
+			    the panel's own top-12 boundary). Clicking it dismisses the chat. */}
+			{expanded && (
+				<button
+					type="button"
+					aria-label="Close chat"
+					data-testid="ceo-chat-overlay"
+					onClick={() => setOpen(false)}
+					className="fixed inset-x-0 bottom-0 top-12 z-40 bg-[var(--overlay)] cursor-default"
+				/>
+			)}
 			<div
-				ref={scrollRef}
-				data-testid="ceo-chat-messages"
-				className="flex flex-1 flex-col gap-4 overflow-y-auto px-4 py-4 scroll-smooth"
+				data-testid="ceo-chat-panel"
+				data-expanded={expanded}
+				className={`fixed z-50 flex flex-col overflow-hidden rounded-2xl border border-border bg-surface shadow-xl ${sizeClass}`}
 			>
-				{!loaded && (
-					<div className="flex items-center justify-center py-6 text-[13px] text-text-2">
-						<Loader2 className="mr-2 h-4 w-4 animate-spin" />
-						Loading…
+				<header className="flex items-center justify-between border-b border-border px-4 py-3">
+					<div className="flex items-center gap-2">
+						<span className="text-sm font-semibold text-text-1">CEO</span>
+						<span className="rounded-sm border border-border px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-text-2">
+							{HQ_PROJECT_NAME}
+						</span>
 					</div>
-				)}
-				{loaded && messages.length === 0 && (
-					<p className="px-1 py-6 text-center text-[13px] text-text-2">
-						Say hello to the CEO. Ask about anything, including active projects, notifications, task
-						blockers, etc
-					</p>
-				)}
-				{messages.map((m) => (
-					<MessageBubble key={m.id} message={m} />
-				))}
-			</div>
+					<div className="flex items-center gap-1">
+						{/* Expand/collapse is desktop-only; the panel is already near-full-screen
+					    on mobile, where the toggle would be a no-op. */}
+						<button
+							type="button"
+							onClick={() => setExpanded((v) => !v)}
+							aria-label={expanded ? 'Collapse chat' : 'Expand chat'}
+							data-testid="ceo-chat-expand"
+							className="hidden h-9 w-9 items-center justify-center rounded-md text-text-2 hover:bg-surface-2 hover:text-text-1 md:flex"
+						>
+							{expanded ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
+						</button>
+						<button
+							type="button"
+							onClick={() => setOpen(false)}
+							aria-label="Close chat"
+							data-testid="ceo-chat-close"
+							className="flex h-9 w-9 items-center justify-center rounded-md text-text-2 hover:bg-surface-2 hover:text-text-1"
+						>
+							<X className="h-4 w-4" />
+						</button>
+					</div>
+				</header>
 
-			<div className="border-t border-border p-3">
-				<div className="flex items-end gap-2 rounded-2xl border border-border bg-surface px-2 py-1.5 transition-colors focus-within:border-border-strong">
-					<textarea
-						value={draft}
-						onChange={(e) => setDraft(e.target.value)}
-						onKeyDown={(e) => {
-							if (e.key === 'Enter' && !e.shiftKey) {
-								e.preventDefault();
-								submit();
-							}
-						}}
-						rows={1}
-						placeholder="Ask the CEO anything, across every project…"
-						data-testid="ceo-chat-input"
-						className="max-h-32 min-h-[2.25rem] flex-1 resize-none bg-transparent px-2 py-2 text-[13px] leading-5 text-text-1 outline-none placeholder:text-text-3"
-					/>
-					<button
-						type="button"
-						onClick={submit}
-						disabled={!draft.trim()}
-						aria-label="Send message"
-						data-testid="ceo-chat-send"
-						className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-accent-solid text-accent-solid-fg transition-colors hover:bg-accent-hover disabled:opacity-40"
-					>
-						<ArrowRight className="h-4 w-4" />
-					</button>
+				<div
+					ref={scrollRef}
+					data-testid="ceo-chat-messages"
+					className="flex flex-1 flex-col gap-4 overflow-y-auto px-4 py-4 scroll-smooth"
+				>
+					{!loaded && (
+						<div className="flex items-center justify-center py-6 text-[13px] text-text-2">
+							<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+							Loading…
+						</div>
+					)}
+					{loaded && messages.length === 0 && (
+						<p className="px-1 py-6 text-center text-[13px] text-text-2">
+							Say hello to the CEO. Ask about anything, including active projects, notifications,
+							task blockers, etc
+						</p>
+					)}
+					{messages.map((m) => (
+						<MessageBubble key={m.id} message={m} />
+					))}
+				</div>
+
+				<div className="border-t border-border p-3">
+					<div className="flex items-end gap-2 rounded-2xl border border-border bg-surface px-2 py-1.5 transition-colors focus-within:border-border-strong">
+						<textarea
+							value={draft}
+							onChange={(e) => setDraft(e.target.value)}
+							onKeyDown={(e) => {
+								if (e.key === 'Enter' && !e.shiftKey) {
+									e.preventDefault();
+									submit();
+								}
+							}}
+							rows={1}
+							placeholder="Ask the CEO anything, across every project…"
+							data-testid="ceo-chat-input"
+							className="max-h-32 min-h-[2.25rem] flex-1 resize-none bg-transparent px-2 py-2 text-[13px] leading-5 text-text-1 outline-none placeholder:text-text-3"
+						/>
+						<button
+							type="button"
+							onClick={submit}
+							disabled={!draft.trim()}
+							aria-label="Send message"
+							data-testid="ceo-chat-send"
+							className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-accent-solid text-accent-solid-fg transition-colors hover:bg-accent-hover disabled:opacity-40"
+						>
+							<ArrowRight className="h-4 w-4" />
+						</button>
+					</div>
 				</div>
 			</div>
-		</div>
+		</>
 	);
 }
 

--- a/packages/web/test/ceo-chat.test.tsx
+++ b/packages/web/test/ceo-chat.test.tsx
@@ -266,6 +266,62 @@ test('the expand toggle fills the viewport below the nav, then restores the anch
 	expect(panel.className).toContain('md:w-[420px]');
 });
 
+test('expanded mode lays a modal backdrop that dismisses the chat when clicked', async () => {
+	const { findByTestId, queryByTestId, getByTestId } = await renderApp({ initialPath: '/home' });
+	(await findByTestId('ceo-chat-launcher')).click();
+	await findByTestId('ceo-chat-panel');
+
+	// Anchored: no backdrop — the rest of the page stays interactive.
+	expect(queryByTestId('ceo-chat-overlay')).toBeNull();
+
+	// Expanding makes it modal: a scrim appears behind the panel.
+	getByTestId('ceo-chat-expand').click();
+	const overlay = await findByTestId('ceo-chat-overlay');
+	expect(overlay).toBeTruthy();
+
+	// Clicking the backdrop dismisses the chat entirely.
+	overlay.click();
+	await findByTestId('ceo-chat-launcher');
+	expect(queryByTestId('ceo-chat-panel')).toBeNull();
+	expect(queryByTestId('ceo-chat-overlay')).toBeNull();
+});
+
+test('collapsing out of expanded removes the backdrop but keeps the chat open', async () => {
+	const { findByTestId, queryByTestId, getByTestId } = await renderApp({ initialPath: '/home' });
+	(await findByTestId('ceo-chat-launcher')).click();
+	await findByTestId('ceo-chat-panel');
+
+	getByTestId('ceo-chat-expand').click();
+	await findByTestId('ceo-chat-overlay');
+
+	// The collapse toggle exits modal mode: backdrop gone, panel still open.
+	getByTestId('ceo-chat-expand').click();
+	await waitFor(() => expect(queryByTestId('ceo-chat-overlay')).toBeNull());
+	expect(getByTestId('ceo-chat-panel')).toBeTruthy();
+});
+
+test('Escape closes the chat from both the anchored and the expanded view', async () => {
+	const { findByTestId, queryByTestId, user } = await renderApp({
+		initialPath: '/home',
+	});
+
+	// Anchored → Escape closes back to the launcher.
+	(await findByTestId('ceo-chat-launcher')).click();
+	await findByTestId('ceo-chat-panel');
+	await user.keyboard('{Escape}');
+	await findByTestId('ceo-chat-launcher');
+	expect(queryByTestId('ceo-chat-panel')).toBeNull();
+
+	// Expanded (modal) → Escape closes it too, scrim and all.
+	(await findByTestId('ceo-chat-launcher')).click();
+	(await findByTestId('ceo-chat-expand')).click();
+	await findByTestId('ceo-chat-overlay');
+	await user.keyboard('{Escape}');
+	await findByTestId('ceo-chat-launcher');
+	expect(queryByTestId('ceo-chat-panel')).toBeNull();
+	expect(queryByTestId('ceo-chat-overlay')).toBeNull();
+});
+
 test('a user message is shown as typed, not parsed as markdown', async () => {
 	const { findByTestId, findByText } = await renderApp({ initialPath: '/home' });
 	(await findByTestId('ceo-chat-launcher')).click();

--- a/test/browser/ceo-chat.spec.ts
+++ b/test/browser/ceo-chat.spec.ts
@@ -72,11 +72,37 @@ test.describe('CEO chat widget — responsive layout', () => {
 		expect(headerBottom).toBeGreaterThan(0);
 		expect(expandedBox?.y ?? 0).toBeGreaterThanOrEqual(headerBottom - 1);
 
-		// Collapse restores the anchored corner panel.
+		// A modal scrim now occludes the page content below the nav: full viewport
+		// width, starting at the header's bottom (the nav itself stays uncovered).
+		const overlay = page.getByTestId('ceo-chat-overlay');
+		await expect(overlay).toBeVisible();
+		const overlayBox = await overlay.boundingBox();
+		expect(overlayBox?.width ?? 0).toBeGreaterThan(1200);
+		expect(overlayBox?.y ?? 0).toBeGreaterThanOrEqual(headerBottom - 1);
+
+		// Collapse restores the anchored corner panel and removes the scrim.
 		await page.getByTestId('ceo-chat-expand').click();
 		await expect(panel).toHaveAttribute('data-expanded', 'false');
+		await expect(overlay).toBeHidden();
 		const restored = await panel.boundingBox();
 		expect(restored?.width ?? 0).toBeLessThan(440);
+	});
+
+	test('Escape closes the chat', async ({ sharedPage, sharedWorkspace }) => {
+		const page = sharedPage;
+
+		await page.setViewportSize({ width: 1280, height: 800 });
+		await page.goto(`/projects/${sharedWorkspace.projectSlug}/tasks`);
+		await waitForPageLoad(page);
+
+		const launcher = page.getByTestId('ceo-chat-launcher');
+		await expect(launcher).toBeVisible({ timeout: 15000 });
+		await launcher.click();
+		await expect(page.getByTestId('ceo-chat-panel')).toBeVisible();
+
+		await page.keyboard.press('Escape');
+		await expect(page.getByTestId('ceo-chat-panel')).toBeHidden();
+		await expect(launcher).toBeVisible();
 	});
 
 	test('the expand toggle is desktop-only — hidden on mobile', async ({


### PR DESCRIPTION
## What & why

Follow-up to #369. Two refinements to the CEO chat widget:

1. **Expanded mode is now modal** — expanding the chat dims the page behind it with a scrim that occludes the page content, so the big view reads as a focused modal rather than a panel floating over live content.
2. **Escape closes the chat** — you can dismiss the chat with the keyboard from any open state.

## How it works

- **Modal scrim:** in expanded mode only, a `bg-[var(--overlay)]` backdrop (the same scrim token the mobile nav drawer uses) renders behind the panel. It's `fixed inset-x-0 bottom-0 top-12 z-40` — full width, starting at the 48px header's bottom so it occludes the page content **below the nav while leaving the nav bar itself clear and usable** (consistent with the original "expanded never covers the nav" requirement). `z-40` keeps it under the `z-50` panel but over the page. Clicking the scrim dismisses the chat.
- **Escape:** a `keydown` listener (active only while the chat is open) closes it on Escape, from both the anchored panel and the expanded modal — matching the scrim-click behaviour. The draft survives, since the widget stays mounted, so reopening restores in-progress text.

**Dismissal model:** the header keeps its explicit **collapse** (back to the anchored panel, chat stays open) and **close** buttons; the scrim-click and Escape both **close** the chat entirely, which is the conventional modal gesture. Happy to switch scrim-click to "collapse" instead if you'd prefer it be non-destructive — easy change.

## Tests

- **Component** (`packages/web/test/ceo-chat.test.tsx`): the backdrop is absent in anchored mode and present once expanded; clicking it dismisses the chat; collapsing out of expanded removes the scrim while keeping the chat open; Escape closes from both the anchored and expanded views.
- **Playwright** (`test/browser/ceo-chat.spec.ts`): the scrim is visible in expanded mode, spans the full viewport width, and starts at/below the header's bottom (nav stays uncovered); it's gone after collapse; Escape closes the panel. These are the real-layout/`boundingBox` assertions the decision tree routes to Playwright.
- **Docs** (`docs/concepts/roles-and-coordination.md`): the "Chatting with the CEO" section now notes the modal dim and Escape/click-to-close.

## Verification

- `bun run typecheck` ✅
- `bunx biome check` (changed files) ✅
- CEO chat component suite: **17 tests passed** (incl. the 3 new ones) ✅
- The Playwright tier was **not executed locally** (the browser binary download is blocked by this environment's egress policy) — it runs in CI's `test-browser` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01THSYU8F5eMbPRuhieqm99a

---
_Generated by [Claude Code](https://claude.ai/code/session_01THSYU8F5eMbPRuhieqm99a)_