### PR TITLE
docs: explain the Hezo name in the introduction

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -15,7 +15,8 @@ spend, and the data.
 Think of it as the company around the agents: org charts, projects, budgets,
 approvals, and coordination, instead of twenty terminal tabs you babysit by hand.
 
-> 💡 **Did you know?** The name *Hezo* is a play on *hézuò* (合作), the Mandarin
+> [!TIP]
+> **Did you know?** The name *Hezo* is a play on *hézuò* (合作), the Mandarin
 > word for "to collaborate" or "cooperate" — which is what the whole platform is
 > about: agents working together, and working with you, to get real projects done.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -15,11 +15,9 @@ spend, and the data.
 Think of it as the company around the agents: org charts, projects, budgets,
 approvals, and coordination, instead of twenty terminal tabs you babysit by hand.
 
-## Why "Hezo"?
-
-The name is a play on *hézuò* (合作), the Mandarin word for "to collaborate" or
-"cooperate" — which is what the whole platform is about: agents working together,
-and working with you, to get real projects done.
+> 💡 **Did you know?** The name *Hezo* is a play on *hézuò* (合作), the Mandarin
+> word for "to collaborate" or "cooperate" — which is what the whole platform is
+> about: agents working together, and working with you, to get real projects done.
 
 ## Secure by design
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -15,6 +15,12 @@ spend, and the data.
 Think of it as the company around the agents: org charts, projects, budgets,
 approvals, and coordination, instead of twenty terminal tabs you babysit by hand.
 
+## Why "Hezo"?
+
+The name is a play on *hézuò* (合作), the Mandarin word for "to collaborate" or
+"cooperate" — which is what the whole platform is about: agents working together,
+and working with you, to get real projects done.
+
 ## Secure by design
 
 Agents run arbitrary code, so Hezo is built so that a misbehaving or compromised


### PR DESCRIPTION
## What

Adds a short note to the **Introduction** docs page explaining where the name *Hezo* comes from: it's a play on *hézuò* (合作), the Mandarin word for "to collaborate / cooperate".

It's presented as a "Did you know?" highlight box, placed right after the opening framing and before "Secure by design".

## Why a blockquote callout (vs. a framework-specific one)

The public docs site (`hezo.ai/docs`) is rendered by an external **Gatsby** app, and these same `.md` files are also rendered in the CEO real-time chat by react-markdown + remark-gfm. Neither renderer's callout support is visible from this repo, and there are no existing callouts in `docs/` to mirror. A framework-specific syntax (`> [!TIP]` / `:::tip`) would render as broken literal text wherever the plugin isn't configured.

A blockquote led by 💡 **Did you know?** renders as a highlighted box in every renderer (Gatsby, GitHub, and the in-app prose styles blockquotes with a left border) and degrades gracefully — no broken syntax anywhere. If the Gatsby theme has a dedicated callout component, point me at its syntax and I'll switch to it.

## Notes

- Body-only edit to an existing page — no frontmatter, page, or bundle changes. `docs-bundle.json` is a gitignored build artifact regenerated by `build:docs`, so the change flows to the CEO chat automatically.
- `packages/server/test/docs-bundle.test.ts` passes.

```
> 💡 **Did you know?** The name *Hezo* is a play on *hézuò* (合作), the Mandarin
> word for "to collaborate" or "cooperate" — which is what the whole platform is
> about: agents working together, and working with you, to get real projects done.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PnaVdKh7FbQMVkQgwJaJS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnaVdKh7FbQMVkQgwJaJS9)_