### PR TITLE
feat(web): restyle settings version line and add feedback link

### DIFF
--- a/packages/web/src/routes/settings/index.tsx
+++ b/packages/web/src/routes/settings/index.tsx
@@ -78,18 +78,32 @@ function GlobalSettingsPage() {
 							data-testid="settings-version"
 							className="mt-3 pt-3 px-3 border-t border-border text-[12px] text-text-2"
 						>
-							{RELEASE_TAG.test(update.current) ? (
+							<div className="italic">
+								version:{' '}
+								{RELEASE_TAG.test(update.current) ? (
+									<a
+										href={`https://github.com/hezo-ai/hezo/releases/tag/${update.current}`}
+										target="_blank"
+										rel="noreferrer"
+										className="hover:underline hover:text-text-1 transition-colors"
+									>
+										{update.current}
+									</a>
+								) : (
+									<span>{update.current}</span>
+								)}
+							</div>
+							<div className="mt-1.5">
+								Got feedback?{' '}
 								<a
-									href={`https://github.com/hezo-ai/hezo/releases/tag/${update.current}`}
+									href="https://x.com/taoofdev"
 									target="_blank"
 									rel="noreferrer"
 									className="hover:underline hover:text-text-1 transition-colors"
 								>
-									Hezo v{update.current}
+									@taoofdev
 								</a>
-							) : (
-								<span>Hezo v{update.current}</span>
-							)}
+							</div>
 						</div>
 					)}
 				</nav>

--- a/packages/web/test/settings-version.test.tsx
+++ b/packages/web/test/settings-version.test.tsx
@@ -20,11 +20,13 @@ test('settings footer shows the version and links to its GitHub release tag', as
 	const { findByTestId } = await renderApp({ initialPath: '/settings' });
 
 	const footer = await findByTestId('settings-version');
-	expect(footer.textContent).toContain('Hezo v0.2.0');
+	expect(footer.textContent).toContain('version: 0.2.0');
 
-	const link = footer.querySelector('a') as HTMLAnchorElement;
-	expect(link).toBeTruthy();
-	expect(link.getAttribute('href')).toBe('https://github.com/hezo-ai/hezo/releases/tag/0.2.0');
+	const releaseLink = footer.querySelector(
+		'a[href="https://github.com/hezo-ai/hezo/releases/tag/0.2.0"]',
+	) as HTMLAnchorElement | null;
+	expect(releaseLink).toBeTruthy();
+	expect(releaseLink?.textContent).toContain('0.2.0');
 });
 
 test('settings footer shows a non-release version as plain text (no broken tag link)', async () => {
@@ -32,6 +34,21 @@ test('settings footer shows a non-release version as plain text (no broken tag l
 	const { findByTestId } = await renderApp({ initialPath: '/settings' });
 
 	const footer = await findByTestId('settings-version');
-	expect(footer.textContent).toContain('Hezo v0.0.0-dev');
-	expect(footer.querySelector('a')).toBeNull();
+	expect(footer.textContent).toContain('version: 0.0.0-dev');
+	// No release-tag link for a non-release version (the feedback link still renders).
+	expect(footer.querySelector('a[href*="/releases/tag/"]')).toBeNull();
+});
+
+test('settings footer links the feedback handle to the taoofdev X account', async () => {
+	seedVersion('0.2.0');
+	const { findByTestId } = await renderApp({ initialPath: '/settings' });
+
+	const footer = await findByTestId('settings-version');
+	expect(footer.textContent).toContain('Got feedback? @taoofdev');
+
+	const feedbackLink = footer.querySelector(
+		'a[href="https://x.com/taoofdev"]',
+	) as HTMLAnchorElement | null;
+	expect(feedbackLink).toBeTruthy();
+	expect(feedbackLink?.textContent).toContain('@taoofdev');
 });


### PR DESCRIPTION
## Summary

Updates how the running version is shown in the global settings menu and adds a feedback link.

- The version line is now **italic** and reads `version: <n>`, with the version number linking to its GitHub release tag (`releases/tag/<n>`).
- Non-release builds (e.g. `0.0.0-dev`) still render as plain text — no broken tag link.
- Adds a **"Got feedback? @taoofdev"** line, with `@taoofdev` linking to the [taoofdev X account](https://x.com/taoofdev).

## Before / After

| Before | After |
|---|---|
| `Hezo v0.3.0` (linked) | *version: 0.3.0* (number linked) |
| — | Got feedback? @taoofdev |

## Tests

`packages/web/test/settings-version.test.tsx` updated for the new copy and link structure, plus a new test asserting the feedback link points at `https://x.com/taoofdev`. All three pass; web typecheck and biome are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Mj5w8zNtw7gxdp8hDtZJu

---
_Generated by [Claude Code](https://claude.ai/code/session_011Mj5w8zNtw7gxdp8hDtZJu)_