### PR TITLE
feat: redesign AI providers settings list + add modal, settings breadcrumbs

### DIFF
--- a/packages/web/src/components/add-ai-provider-dialog.tsx
+++ b/packages/web/src/components/add-ai-provider-dialog.tsx
@@ -1,0 +1,223 @@
+import { AI_PROVIDER_INFO, AiAuthMethod, AiProvider } from '@hezo/shared';
+import * as Dialog from '@radix-ui/react-dialog';
+import { Loader2, X } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import {
+	type AiProviderConfig,
+	useAiProviders,
+	useCreateAiProvider,
+} from '../hooks/use-ai-providers';
+import { SUBSCRIPTION_INSTRUCTIONS, SubscriptionInstructions } from './subscription-paste-form';
+import { Button } from './ui/button';
+import { dialogContentClassName, dialogOverlayClassName } from './ui/dialog';
+import { Input } from './ui/input';
+
+// Display order mirrors the catalogue order used elsewhere in the app.
+const ADD_PROVIDER_ORDER: AiProvider[] = [
+	AiProvider.DeepSeek,
+	AiProvider.ZAi,
+	AiProvider.Anthropic,
+	AiProvider.OpenAI,
+	AiProvider.Google,
+	AiProvider.OpenRouter,
+	AiProvider.Kimi,
+];
+
+/**
+ * Generate a friendly default name for a new config based on the selected
+ * provider, skipping labels already used for that provider so the
+ * `UNIQUE(provider, label)` constraint never trips on the suggested default.
+ */
+function defaultLabel(provider: AiProvider, configs: AiProviderConfig[] | undefined): string {
+	const info = AI_PROVIDER_INFO[provider];
+	const used = new Set((configs ?? []).filter((c) => c.provider === provider).map((c) => c.label));
+	if (!used.has(info.name)) return info.name;
+	let n = 2;
+	while (used.has(`${info.name} ${n}`)) n++;
+	return `${info.name} ${n}`;
+}
+
+interface AddAiProviderDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}
+
+export function AddAiProviderDialog({ open, onOpenChange }: AddAiProviderDialogProps) {
+	const { data: configs } = useAiProviders();
+	const createProvider = useCreateAiProvider();
+
+	const [provider, setProvider] = useState<AiProvider>(AiProvider.Anthropic);
+	const [authMethod, setAuthMethod] = useState<AiAuthMethod>(AiAuthMethod.ApiKey);
+	const [name, setName] = useState('');
+	const [nameEdited, setNameEdited] = useState(false);
+	const [apiKey, setApiKey] = useState('');
+	const [authJson, setAuthJson] = useState('');
+	const [error, setError] = useState<string | null>(null);
+
+	const info = AI_PROVIDER_INFO[provider];
+	const generatedName = useMemo(() => defaultLabel(provider, configs), [provider, configs]);
+
+	// Reset the whole form each time the dialog opens.
+	useEffect(() => {
+		if (!open) return;
+		setProvider(AiProvider.Anthropic);
+		setAuthMethod(AiAuthMethod.ApiKey);
+		setNameEdited(false);
+		setApiKey('');
+		setAuthJson('');
+		setError(null);
+	}, [open]);
+
+	// Keep the name pinned to the generated default until the user edits it
+	// (also re-syncs once the async configs query resolves).
+	useEffect(() => {
+		if (!nameEdited) setName(generatedName);
+	}, [generatedName, nameEdited]);
+
+	function handleProviderChange(next: AiProvider) {
+		setProvider(next);
+		setNameEdited(false);
+		setApiKey('');
+		setAuthJson('');
+		setError(null);
+		if (!AI_PROVIDER_INFO[next].supportsSubscription) setAuthMethod(AiAuthMethod.ApiKey);
+	}
+
+	const credential = authMethod === AiAuthMethod.Subscription ? authJson : apiKey;
+
+	async function handleSubmit(e: React.FormEvent) {
+		e.preventDefault();
+		setError(null);
+		if (!credential.trim()) return;
+		try {
+			await createProvider.mutateAsync({
+				provider,
+				api_key: credential,
+				label: name.trim() || undefined,
+				auth_method: authMethod,
+			});
+			onOpenChange(false);
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Failed to add provider');
+		}
+	}
+
+	return (
+		<Dialog.Root open={open} onOpenChange={onOpenChange}>
+			<Dialog.Portal>
+				<Dialog.Overlay className={dialogOverlayClassName} />
+				<Dialog.Content className={dialogContentClassName.md}>
+					<div className="flex items-center justify-between mb-1">
+						<Dialog.Title className="text-lg font-semibold">Add AI provider</Dialog.Title>
+						<Dialog.Close asChild>
+							<button
+								type="button"
+								className="text-text-2 hover:text-text-1 p-2 -m-2"
+								aria-label="Close"
+							>
+								<X className="w-4 h-4" />
+							</button>
+						</Dialog.Close>
+					</div>
+					<Dialog.Description className="text-[13px] text-text-2 mb-4">
+						API keys for AI coding agents. Shared across every team in this Hezo instance.
+					</Dialog.Description>
+
+					<form onSubmit={handleSubmit} className="flex flex-col gap-4">
+						<label className="flex flex-col gap-1.5">
+							<span className="text-eyebrow text-text-2">Provider</span>
+							<select
+								aria-label="Provider"
+								value={provider}
+								onChange={(e) => handleProviderChange(e.target.value as AiProvider)}
+								className="h-8 rounded-md border border-border-strong bg-surface px-2.5 text-[13px] text-text-1 outline-none focus:border-accent"
+							>
+								{ADD_PROVIDER_ORDER.map((p) => (
+									<option key={p} value={p}>
+										{AI_PROVIDER_INFO[p].name} · {AI_PROVIDER_INFO[p].runtimeLabel}
+									</option>
+								))}
+							</select>
+						</label>
+
+						{info.supportsSubscription && (
+							<div className="flex flex-col gap-1.5">
+								<span className="text-eyebrow text-text-2">Authentication</span>
+								<div className="flex gap-2">
+									<Button
+										type="button"
+										size="sm"
+										variant={authMethod === AiAuthMethod.ApiKey ? 'primary' : 'secondary'}
+										onClick={() => {
+											setAuthMethod(AiAuthMethod.ApiKey);
+											setError(null);
+										}}
+									>
+										API key
+									</Button>
+									<Button
+										type="button"
+										size="sm"
+										variant={authMethod === AiAuthMethod.Subscription ? 'primary' : 'secondary'}
+										onClick={() => {
+											setAuthMethod(AiAuthMethod.Subscription);
+											setError(null);
+										}}
+									>
+										{info.runtimeLabel} subscription
+									</Button>
+								</div>
+							</div>
+						)}
+
+						<Input
+							label="Name"
+							value={name}
+							placeholder={info.name}
+							onChange={(e) => {
+								setName(e.target.value);
+								setNameEdited(true);
+							}}
+						/>
+
+						{authMethod === AiAuthMethod.Subscription ? (
+							<div className="flex flex-col gap-2">
+								<SubscriptionInstructions provider={provider} />
+								<textarea
+									required
+									aria-label="Subscription credential"
+									value={authJson}
+									onChange={(e) => setAuthJson(e.target.value)}
+									placeholder={SUBSCRIPTION_INSTRUCTIONS[provider]?.placeholder}
+									rows={6}
+									spellCheck={false}
+									className="w-full rounded-md border border-border bg-surface-2 px-2 py-1.5 text-xs font-mono text-text-1 outline-none focus:border-border-strong"
+								/>
+							</div>
+						) : (
+							<Input
+								label="API key"
+								type="password"
+								placeholder={info.keyPlaceholder}
+								value={apiKey}
+								onChange={(e) => setApiKey(e.target.value)}
+							/>
+						)}
+
+						{error && <p className="text-[13px] text-danger">{error}</p>}
+
+						<div className="flex justify-end gap-2">
+							<Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
+								Cancel
+							</Button>
+							<Button type="submit" disabled={!credential.trim() || createProvider.isPending}>
+								{createProvider.isPending && <Loader2 className="w-4 h-4 animate-spin" />}
+								Add provider
+							</Button>
+						</div>
+					</form>
+				</Dialog.Content>
+			</Dialog.Portal>
+		</Dialog.Root>
+	);
+}

--- a/packages/web/src/components/ai-providers-section.tsx
+++ b/packages/web/src/components/ai-providers-section.tsx
@@ -1,267 +1,185 @@
-import { AI_PROVIDER_INFO, AiAuthMethod, AiProvider } from '@hezo/shared';
-import { Check, ClipboardPaste, Key, Loader2, ShieldCheck, Trash2, X } from 'lucide-react';
+import { AI_PROVIDER_INFO, AiAuthMethod, type AiProvider } from '@hezo/shared';
+import { Loader2, Plus, ShieldCheck, Star, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import {
 	type AiProviderConfig,
 	useAiProviderModels,
 	useAiProviders,
-	useCreateAiProvider,
 	useDeleteAiProvider,
 	useSetDefaultAiProvider,
 	useUpdateAiProviderConfig,
 	useVerifyAiProvider,
 } from '../hooks/use-ai-providers';
-import { SubscriptionPasteForm } from './subscription-paste-form';
+import { toast } from '../hooks/use-toast';
+import { AddAiProviderDialog } from './add-ai-provider-dialog';
 import { Badge } from './ui/badge';
 import { Button } from './ui/button';
-import { Input } from './ui/input';
-
-const AI_PROVIDERS_ORDER: AiProvider[] = [
-	AiProvider.DeepSeek,
-	AiProvider.ZAi,
-	AiProvider.Anthropic,
-	AiProvider.OpenAI,
-	AiProvider.Google,
-	AiProvider.OpenRouter,
-	AiProvider.Kimi,
-];
+import { type Column, DataTable } from './ui/data-table';
+import { Tooltip } from './ui/tooltip';
 
 export function AiProvidersSection() {
 	const { data: configs } = useAiProviders();
-	const createProvider = useCreateAiProvider();
 	const deleteProvider = useDeleteAiProvider();
 	const verifyProvider = useVerifyAiProvider();
 	const setDefaultProvider = useSetDefaultAiProvider();
-	const [addingProvider, setAddingProvider] = useState<AiProvider | null>(null);
-	const [pastingProvider, setPastingProvider] = useState<AiProvider | null>(null);
-	const [apiKey, setApiKey] = useState('');
-	const [label, setLabel] = useState('');
-	const [verifyResult, setVerifyResult] = useState<
-		Record<string, { valid: boolean; error?: string }>
-	>({});
+	const [addOpen, setAddOpen] = useState(false);
+	// Per-row transient "verified OK" marker — failures surface as a toast and a
+	// refetched `invalid` status badge, so only successes need an inline cue.
+	const [verifiedOk, setVerifiedOk] = useState<Record<string, boolean>>({});
+	const [verifyingId, setVerifyingId] = useState<string | null>(null);
 
-	async function handleSaveKey(provider: AiProvider) {
-		await createProvider.mutateAsync({ provider, api_key: apiKey, label: label || undefined });
-		setApiKey('');
-		setLabel('');
-		setAddingProvider(null);
-	}
+	const rows = configs ?? [];
 
-	async function handleSavePaste(provider: AiProvider, authJson: string) {
-		await createProvider.mutateAsync({
-			provider,
-			api_key: authJson,
-			auth_method: AiAuthMethod.Subscription,
-		});
-		setPastingProvider(null);
+	function providerCount(provider: string) {
+		return rows.filter((c) => c.provider === provider).length;
 	}
 
 	async function handleVerify(configId: string) {
-		const result = await verifyProvider.mutateAsync(configId);
-		setVerifyResult((prev) => ({ ...prev, [configId]: result }));
+		setVerifyingId(configId);
+		try {
+			const result = await verifyProvider.mutateAsync(configId);
+			setVerifiedOk((prev) => ({ ...prev, [configId]: result.valid }));
+			if (!result.valid) {
+				toast.error(result.message ?? result.error ?? 'Key is invalid or expired');
+			}
+		} catch (e) {
+			toast.error(e instanceof Error ? e.message : 'Could not verify key');
+		} finally {
+			setVerifyingId(null);
+		}
 	}
+
+	const columns: Column<AiProviderConfig>[] = [
+		{
+			key: 'name',
+			header: 'Name',
+			render: (c) => (
+				<span className="flex items-center gap-2">
+					<span className="font-mono text-[13px]">{c.label}</span>
+					{c.is_default && providerCount(c.provider) > 1 && <Badge color="accent">Default</Badge>}
+				</span>
+			),
+		},
+		{
+			key: 'provider',
+			header: 'Provider',
+			render: (c) => {
+				const info = AI_PROVIDER_INFO[c.provider as AiProvider];
+				return (
+					<span className="flex items-center gap-2">
+						<span className="text-[13px]">{info?.name ?? c.provider}</span>
+						{info && <span className="text-xs text-text-3">{info.runtimeLabel}</span>}
+					</span>
+				);
+			},
+		},
+		{
+			key: 'auth',
+			header: 'Auth',
+			hideOnMobile: true,
+			render: (c) => (
+				<Badge color="neutral">
+					{c.auth_method === AiAuthMethod.Subscription ? 'Subscription' : 'API Key'}
+				</Badge>
+			),
+		},
+		{
+			key: 'status',
+			header: 'Status',
+			render: (c) => (
+				<Badge
+					color={c.status === 'active' ? 'success' : c.status === 'invalid' ? 'danger' : 'neutral'}
+				>
+					{c.status}
+				</Badge>
+			),
+		},
+		{
+			key: 'model',
+			header: 'Default model',
+			hideOnMobile: true,
+			render: (c) => <DefaultModelSelector config={c} />,
+		},
+		{
+			key: 'actions',
+			header: '',
+			render: (c) => {
+				const multiple = providerCount(c.provider) > 1;
+				return (
+					<span className="flex items-center gap-2 justify-end">
+						{verifiedOk[c.id] && (
+							<Tooltip content="Key is valid">
+								<ShieldCheck className="w-3.5 h-3.5 text-success-soft-fg" />
+							</Tooltip>
+						)}
+						{multiple && !c.is_default && (
+							<Tooltip content="Set as default">
+								<button
+									type="button"
+									onClick={() => setDefaultProvider.mutate(c.id)}
+									disabled={setDefaultProvider.isPending}
+									aria-label={`Set ${c.label} as default`}
+									className="text-text-3 hover:text-text-1 disabled:opacity-50"
+								>
+									<Star className="w-3.5 h-3.5" />
+								</button>
+							</Tooltip>
+						)}
+						<Tooltip content="Verify">
+							<button
+								type="button"
+								onClick={() => handleVerify(c.id)}
+								disabled={verifyingId === c.id}
+								aria-label={`Verify ${c.label}`}
+								className="text-text-3 hover:text-text-1 disabled:opacity-50"
+							>
+								{verifyingId === c.id ? (
+									<Loader2 className="w-3.5 h-3.5 animate-spin" />
+								) : (
+									<ShieldCheck className="w-3.5 h-3.5" />
+								)}
+							</button>
+						</Tooltip>
+						<Tooltip content="Remove">
+							<button
+								type="button"
+								onClick={() => deleteProvider.mutate(c.id)}
+								aria-label={`Remove ${c.label}`}
+								className="text-text-3 hover:text-danger"
+							>
+								<Trash2 className="w-3.5 h-3.5" />
+							</button>
+						</Tooltip>
+					</span>
+				);
+			},
+		},
+	];
 
 	return (
 		<section>
-			<div className="mb-4">
-				<h2 className="text-base font-medium">AI providers</h2>
-				<p className="text-[13px] text-text-2 mt-1">
-					API keys for AI coding agents. Shared across every team in this Hezo instance.
-				</p>
-			</div>
-			<div className="flex flex-col gap-2">
-				{AI_PROVIDERS_ORDER.map((provider) => {
-					const info = AI_PROVIDER_INFO[provider];
-					const providerConfigs = configs?.filter((c) => c.provider === provider) ?? [];
-					const hasApiKey = providerConfigs.some((c) => c.auth_method === AiAuthMethod.ApiKey);
-					const hasSubscription = providerConfigs.some(
-						(c) => c.auth_method === AiAuthMethod.Subscription,
-					);
-					const canAddSubscription = info.supportsSubscription && !hasSubscription;
-					const canAddApiKey = !hasApiKey;
-					const isAdding = addingProvider === provider;
-					const isPasting = pastingProvider === provider;
-					const showMultipleControls = providerConfigs.length > 1;
-
-					return (
-						<div key={provider} className="border border-border rounded-md p-3 bg-surface">
-							<div className="flex items-center justify-between">
-								<div className="flex items-center gap-2">
-									<span className="text-[13px] font-medium">{info.name}</span>
-									<span className="text-xs text-text-3">{info.runtimeLabel}</span>
-								</div>
-							</div>
-
-							{providerConfigs.map((config) => (
-								<ConfigRow
-									key={config.id}
-									config={config}
-									showDefaultControls={showMultipleControls}
-									verify={verifyResult[config.id]}
-									onVerify={() => handleVerify(config.id)}
-									onRemove={() => deleteProvider.mutate(config.id)}
-									onSetDefault={() => setDefaultProvider.mutate(config.id)}
-									verifyPending={verifyProvider.isPending}
-									setDefaultPending={setDefaultProvider.isPending}
-								/>
-							))}
-
-							{(canAddSubscription || canAddApiKey) && !isAdding && !isPasting && (
-								<div className="flex items-center gap-2 mt-2">
-									{canAddSubscription && (
-										<Button
-											variant="secondary"
-											size="sm"
-											onClick={() => setPastingProvider(provider)}
-										>
-											<ClipboardPaste className="w-3 h-3" /> Use {info.runtimeLabel} subscription
-										</Button>
-									)}
-									{canAddApiKey && (
-										<Button
-											variant="secondary"
-											size="sm"
-											onClick={() => setAddingProvider(provider)}
-										>
-											<Key className="w-3 h-3" /> Enter API key
-										</Button>
-									)}
-								</div>
-							)}
-
-							{isPasting && (
-								<SubscriptionPasteForm
-									provider={provider}
-									onSubmit={(authJson) => handleSavePaste(provider, authJson)}
-									onCancel={() => setPastingProvider(null)}
-									pending={createProvider.isPending}
-								/>
-							)}
-
-							{isAdding && (
-								<div className="flex flex-col gap-2 mt-2">
-									<Input
-										type="password"
-										placeholder={info.keyPlaceholder}
-										value={apiKey}
-										onChange={(e) => setApiKey(e.target.value)}
-									/>
-									<Input
-										placeholder="Label (optional)"
-										value={label}
-										onChange={(e) => setLabel(e.target.value)}
-									/>
-									<div className="flex gap-2">
-										<Button
-											size="sm"
-											onClick={() => handleSaveKey(provider)}
-											disabled={!apiKey.trim() || createProvider.isPending}
-										>
-											{createProvider.isPending && <Loader2 className="w-3 h-3 animate-spin" />}
-											Save
-										</Button>
-										<Button
-											variant="secondary"
-											size="sm"
-											onClick={() => {
-												setAddingProvider(null);
-												setApiKey('');
-												setLabel('');
-											}}
-										>
-											Cancel
-										</Button>
-									</div>
-									{createProvider.error && (
-										<p className="text-[13px] text-danger">
-											{(createProvider.error as { message: string }).message}
-										</p>
-									)}
-								</div>
-							)}
-						</div>
-					);
-				})}
-			</div>
-		</section>
-	);
-}
-
-interface ConfigRowProps {
-	config: AiProviderConfig;
-	showDefaultControls: boolean;
-	verify: { valid: boolean; error?: string } | undefined;
-	onVerify: () => void;
-	onRemove: () => void;
-	onSetDefault: () => void;
-	verifyPending: boolean;
-	setDefaultPending: boolean;
-}
-
-function ConfigRow({
-	config,
-	showDefaultControls,
-	verify,
-	onVerify,
-	onRemove,
-	onSetDefault,
-	verifyPending,
-	setDefaultPending,
-}: ConfigRowProps) {
-	return (
-		<div className="mt-2 border-t border-border pt-2">
-			<div className="flex items-center gap-2 flex-wrap">
-				<Badge color="neutral">
-					{config.auth_method === AiAuthMethod.Subscription ? 'Subscription' : 'API Key'}
-				</Badge>
-				<Badge
-					color={
-						config.status === 'active'
-							? 'success'
-							: config.status === 'invalid'
-								? 'danger'
-								: 'neutral'
-					}
-				>
-					{config.status}
-				</Badge>
-				{showDefaultControls && config.is_default && <Badge color="neutral">Default</Badge>}
-				<span className="text-xs text-text-3 truncate">{config.label}</span>
-				<div className="flex-1" />
-				{showDefaultControls && !config.is_default && (
-					<Button variant="secondary" size="sm" onClick={onSetDefault} disabled={setDefaultPending}>
-						Set default
-					</Button>
-				)}
-				<Button variant="secondary" size="sm" onClick={onVerify} disabled={verifyPending}>
-					{verifyPending ? (
-						<Loader2 className="w-3 h-3 animate-spin" />
-					) : (
-						<ShieldCheck className="w-3 h-3" />
-					)}
-					Verify
-				</Button>
-				<Button variant="danger-text" size="sm" onClick={onRemove}>
-					<Trash2 className="w-3 h-3" /> Remove
-				</Button>
-			</div>
-			<DefaultModelSelector config={config} />
-			{verify && (
-				<div
-					className={`mt-2 flex items-center gap-1.5 text-[13px] ${verify.valid ? 'text-success-soft-fg' : 'text-danger'}`}
-				>
-					{verify.valid ? (
-						<>
-							<Check className="w-3.5 h-3.5" /> Key is valid
-						</>
-					) : (
-						<>
-							<X className="w-3.5 h-3.5" /> {verify.error || 'Key is invalid'}
-						</>
-					)}
+			<div className="flex items-start justify-between gap-3 mb-4">
+				<div>
+					<h2 className="text-base font-medium">AI providers</h2>
+					<p className="text-[13px] text-text-2 mt-1">
+						API keys for AI coding agents. Shared across every team in this Hezo instance.
+					</p>
 				</div>
+				<Button variant="secondary" size="sm" onClick={() => setAddOpen(true)}>
+					<Plus className="w-3 h-3" /> Add provider
+				</Button>
+			</div>
+
+			{rows.length === 0 ? (
+				<p className="text-[13px] text-text-2">
+					No AI providers configured yet. Add one to get started.
+				</p>
+			) : (
+				<DataTable columns={columns} data={rows} rowKey={(c) => c.id} />
 			)}
-		</div>
+
+			<AddAiProviderDialog open={addOpen} onOpenChange={setAddOpen} />
+		</section>
 	);
 }
 
@@ -275,28 +193,25 @@ function DefaultModelSelector({ config }: { config: AiProviderConfig }) {
 	}
 
 	return (
-		<div className="mt-2 flex items-center gap-2 text-[13px]">
-			<label className="flex items-center gap-2">
-				<span className="text-text-2 text-xs">Default model</span>
-				<select
-					aria-label={`Default model for ${config.label}`}
-					value={config.default_model ?? ''}
-					onFocus={() => setOpen(true)}
-					onChange={(e) => handleChange(e.target.value)}
-					className="rounded-md border border-border bg-surface-2 px-2 py-1 text-xs text-text-1 outline-none focus:border-border-strong"
-					disabled={update.isPending}
-				>
-					<option value="">Use CLI default</option>
-					{config.default_model && !models.data?.some((m) => m.id === config.default_model) && (
-						<option value={config.default_model}>{config.default_model}</option>
-					)}
-					{models.data?.map((m) => (
-						<option key={m.id} value={m.id}>
-							{m.label}
-						</option>
-					))}
-				</select>
-			</label>
+		<div className="flex items-center gap-2 text-[13px]">
+			<select
+				aria-label={`Default model for ${config.label}`}
+				value={config.default_model ?? ''}
+				onFocus={() => setOpen(true)}
+				onChange={(e) => handleChange(e.target.value)}
+				className="rounded-md border border-border bg-surface-2 px-2 py-1 text-xs text-text-1 outline-none focus:border-border-strong"
+				disabled={update.isPending}
+			>
+				<option value="">CLI default</option>
+				{config.default_model && !models.data?.some((m) => m.id === config.default_model) && (
+					<option value={config.default_model}>{config.default_model}</option>
+				)}
+				{models.data?.map((m) => (
+					<option key={m.id} value={m.id}>
+						{m.label}
+					</option>
+				))}
+			</select>
 			{(models.isFetching || update.isPending) && (
 				<Loader2 className="w-3 h-3 animate-spin text-text-3" />
 			)}

--- a/packages/web/src/components/settings-breadcrumb.tsx
+++ b/packages/web/src/components/settings-breadcrumb.tsx
@@ -1,0 +1,20 @@
+import { Link } from '@tanstack/react-router';
+import { ChevronRight } from 'lucide-react';
+
+/**
+ * Back-link shown at the top of every Settings subpage so it's one tap to
+ * return to the main Settings page. The main page itself does not render it.
+ */
+export function SettingsBreadcrumb({ label }: { label: string }) {
+	return (
+		<nav aria-label="Breadcrumb" className="mb-4 flex items-center gap-1 text-[13px] text-text-2">
+			<Link to="/settings" className="hover:text-text-1 hover:underline transition-colors">
+				Settings
+			</Link>
+			<ChevronRight className="w-3 h-3 shrink-0 text-text-3" />
+			<span aria-current="page" className="text-text-1">
+				{label}
+			</span>
+		</nav>
+	);
+}

--- a/packages/web/src/components/subscription-paste-form.tsx
+++ b/packages/web/src/components/subscription-paste-form.tsx
@@ -17,7 +17,7 @@ interface ProviderInstructions {
 	placeholder: string;
 }
 
-const INSTRUCTIONS: Partial<Record<AiProvider, ProviderInstructions>> = {
+export const SUBSCRIPTION_INSTRUCTIONS: Partial<Record<AiProvider, ProviderInstructions>> = {
 	[AiProvider.Anthropic]: {
 		title: 'How to get your Claude subscription token',
 		steps: [
@@ -124,6 +124,24 @@ const INSTRUCTIONS: Partial<Record<AiProvider, ProviderInstructions>> = {
 	},
 };
 
+/** The gray, provider-specific "how to get your subscription credential" box. */
+export function SubscriptionInstructions({ provider }: { provider: AiProvider }) {
+	const instructions = SUBSCRIPTION_INSTRUCTIONS[provider];
+	if (!instructions) return null;
+	return (
+		<div className="rounded-md border border-border bg-surface-2 p-3 text-[13px] text-text-2">
+			<p className="font-medium text-text-1 mb-2">{instructions.title}</p>
+			<ol className="list-decimal pl-5 space-y-1">
+				{instructions.steps.map((step, i) => (
+					// biome-ignore lint/suspicious/noArrayIndexKey: instruction list is static
+					<li key={i}>{step}</li>
+				))}
+			</ol>
+			<p className="mt-2">{instructions.footer}</p>
+		</div>
+	);
+}
+
 export function SubscriptionPasteForm({
 	provider,
 	onSubmit,
@@ -131,7 +149,7 @@ export function SubscriptionPasteForm({
 	pending,
 }: SubscriptionPasteFormProps) {
 	const [authJson, setAuthJson] = useState('');
-	const instructions = INSTRUCTIONS[provider];
+	const instructions = SUBSCRIPTION_INSTRUCTIONS[provider];
 
 	if (!instructions) {
 		return (
@@ -148,16 +166,7 @@ export function SubscriptionPasteForm({
 
 	return (
 		<form onSubmit={handleSubmit} className="mt-2 flex flex-col gap-3">
-			<div className="rounded-md border border-border bg-surface-2 p-3 text-[13px] text-text-2">
-				<p className="font-medium text-text-1 mb-2">{instructions.title}</p>
-				<ol className="list-decimal pl-5 space-y-1">
-					{instructions.steps.map((step, i) => (
-						// biome-ignore lint/suspicious/noArrayIndexKey: instruction list is static
-						<li key={i}>{step}</li>
-					))}
-				</ol>
-				<p className="mt-2">{instructions.footer}</p>
-			</div>
+			<SubscriptionInstructions provider={provider} />
 
 			<textarea
 				required

--- a/packages/web/src/hooks/use-ai-providers.ts
+++ b/packages/web/src/hooks/use-ai-providers.ts
@@ -73,8 +73,12 @@ export function useSetDefaultAiProvider() {
 
 export function useVerifyAiProvider() {
 	return useMutation({
+		// The server returns `{ valid, message }` on failure; `error` is kept for
+		// back-compat with any caller still reading it.
 		mutationFn: (configId: string) =>
-			api.post<{ valid: boolean; error?: string }>(`/api/ai-providers/${configId}/verify`),
+			api.post<{ valid: boolean; message?: string; error?: string }>(
+				`/api/ai-providers/${configId}/verify`,
+			),
 		onSuccess: invalidateAll,
 	});
 }

--- a/packages/web/src/routes/settings/ai-providers.tsx
+++ b/packages/web/src/routes/settings/ai-providers.tsx
@@ -1,9 +1,11 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { AiProvidersSection } from '../../components/ai-providers-section';
+import { SettingsBreadcrumb } from '../../components/settings-breadcrumb';
 
 function AiProvidersPage() {
 	return (
 		<div className="max-w-[900px] w-full px-4 py-4 md:px-6 md:py-5 lg:px-8 lg:py-6">
+			<SettingsBreadcrumb label="AI providers" />
 			<AiProvidersSection />
 		</div>
 	);

--- a/packages/web/src/routes/settings/audit-log.tsx
+++ b/packages/web/src/routes/settings/audit-log.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { AuditLogTable } from '../../components/audit-log-table';
+import { SettingsBreadcrumb } from '../../components/settings-breadcrumb';
 import { InfoTooltip } from '../../components/ui/info-tooltip';
 import { useInstanceAuditLog } from '../../hooks/use-audit-log';
 import { useMe } from '../../hooks/use-me';
@@ -35,7 +36,10 @@ function InstanceAuditLogPage() {
 		);
 
 	return (
-		<div className="max-w-[1000px] w-full px-4 py-4 md:px-6 md:py-5 lg:px-8 lg:py-6">{body}</div>
+		<div className="max-w-[1000px] w-full px-4 py-4 md:px-6 md:py-5 lg:px-8 lg:py-6">
+			<SettingsBreadcrumb label="Activity" />
+			{body}
+		</div>
 	);
 }
 

--- a/packages/web/src/routes/settings/chatbox.tsx
+++ b/packages/web/src/routes/settings/chatbox.tsx
@@ -8,6 +8,7 @@ import {
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { Loader2 } from 'lucide-react';
 import { useState } from 'react';
+import { SettingsBreadcrumb } from '../../components/settings-breadcrumb';
 import { Button } from '../../components/ui/button';
 import { InfoTooltip } from '../../components/ui/info-tooltip';
 import { Input } from '../../components/ui/input';
@@ -83,7 +84,10 @@ function ChatboxSettingsPage() {
 		);
 
 	return (
-		<div className="max-w-[900px] w-full px-4 py-4 md:px-6 md:py-5 lg:px-8 lg:py-6">{content}</div>
+		<div className="max-w-[900px] w-full px-4 py-4 md:px-6 md:py-5 lg:px-8 lg:py-6">
+			<SettingsBreadcrumb label="Chatbox" />
+			{content}
+		</div>
 	);
 }
 

--- a/packages/web/src/routes/settings/connected-agents.tsx
+++ b/packages/web/src/routes/settings/connected-agents.tsx
@@ -1,6 +1,7 @@
 import { ConnectedAgentStatus } from '@hezo/shared';
 import { createFileRoute } from '@tanstack/react-router';
 import { Check, Loader2, Unplug, X } from 'lucide-react';
+import { SettingsBreadcrumb } from '../../components/settings-breadcrumb';
 import { Badge } from '../../components/ui/badge';
 import { Button } from '../../components/ui/button';
 import { type Column, DataTable } from '../../components/ui/data-table';
@@ -199,7 +200,10 @@ function ConnectedAgentsPage() {
 		);
 
 	return (
-		<div className="max-w-[900px] w-full px-4 py-4 md:px-6 md:py-5 lg:px-8 lg:py-6">{content}</div>
+		<div className="max-w-[900px] w-full px-4 py-4 md:px-6 md:py-5 lg:px-8 lg:py-6">
+			<SettingsBreadcrumb label="Connected agents" />
+			{content}
+		</div>
 	);
 }
 

--- a/packages/web/src/routes/settings/connectors.tsx
+++ b/packages/web/src/routes/settings/connectors.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { Plus, Trash2 } from 'lucide-react';
 import { useState } from 'react';
+import { SettingsBreadcrumb } from '../../components/settings-breadcrumb';
 import { Badge } from '../../components/ui/badge';
 import { Button } from '../../components/ui/button';
 import { InfoTooltip } from '../../components/ui/info-tooltip';
@@ -156,7 +157,10 @@ function InstanceConnectorsPage() {
 		);
 
 	return (
-		<div className="max-w-[900px] w-full px-4 py-4 md:px-6 md:py-5 lg:px-8 lg:py-6">{content}</div>
+		<div className="max-w-[900px] w-full px-4 py-4 md:px-6 md:py-5 lg:px-8 lg:py-6">
+			<SettingsBreadcrumb label="Connectors" />
+			{content}
+		</div>
 	);
 }
 

--- a/packages/web/src/routes/settings/credentials.tsx
+++ b/packages/web/src/routes/settings/credentials.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { Pencil, Plus, Trash2 } from 'lucide-react';
 import { useState } from 'react';
+import { SettingsBreadcrumb } from '../../components/settings-breadcrumb';
 import { Badge } from '../../components/ui/badge';
 import { Button } from '../../components/ui/button';
 import { type Column, DataTable } from '../../components/ui/data-table';
@@ -284,7 +285,10 @@ function InstanceCredentialsPage() {
 		);
 
 	return (
-		<div className="max-w-[900px] w-full px-4 py-4 md:px-6 md:py-5 lg:px-8 lg:py-6">{content}</div>
+		<div className="max-w-[900px] w-full px-4 py-4 md:px-6 md:py-5 lg:px-8 lg:py-6">
+			<SettingsBreadcrumb label="Credentials" />
+			{content}
+		</div>
 	);
 }
 

--- a/packages/web/src/routes/settings/model-pricing.tsx
+++ b/packages/web/src/routes/settings/model-pricing.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { Plus, RefreshCw, Trash2 } from 'lucide-react';
 import { useState } from 'react';
+import { SettingsBreadcrumb } from '../../components/settings-breadcrumb';
 import { Badge } from '../../components/ui/badge';
 import { Button } from '../../components/ui/button';
 import { type Column, DataTable } from '../../components/ui/data-table';
@@ -257,7 +258,10 @@ function ModelPricingPage() {
 		);
 
 	return (
-		<div className="max-w-[900px] w-full px-4 py-4 md:px-6 md:py-5 lg:px-8 lg:py-6">{content}</div>
+		<div className="max-w-[900px] w-full px-4 py-4 md:px-6 md:py-5 lg:px-8 lg:py-6">
+			<SettingsBreadcrumb label="Model pricing" />
+			{content}
+		</div>
 	);
 }
 

--- a/packages/web/src/routes/settings/skills.tsx
+++ b/packages/web/src/routes/settings/skills.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from '@tanstack/react-router';
 import { ExternalLink, Loader2, Pencil, Plus, Search, Trash2 } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { MarkdownProse } from '../../components/markdown-prose';
+import { SettingsBreadcrumb } from '../../components/settings-breadcrumb';
 import { Badge } from '../../components/ui/badge';
 import { Button } from '../../components/ui/button';
 import { InfoTooltip } from '../../components/ui/info-tooltip';
@@ -291,7 +292,10 @@ function InstanceSkillsPage() {
 		);
 
 	return (
-		<div className="max-w-[900px] w-full px-4 py-4 md:px-6 md:py-5 lg:px-8 lg:py-6">{content_}</div>
+		<div className="max-w-[900px] w-full px-4 py-4 md:px-6 md:py-5 lg:px-8 lg:py-6">
+			<SettingsBreadcrumb label="Skills" />
+			{content_}
+		</div>
 	);
 }
 

--- a/packages/web/test/ai-providers.test.tsx
+++ b/packages/web/test/ai-providers.test.tsx
@@ -33,17 +33,22 @@ async function postProvider(body: Record<string, unknown>) {
 	});
 }
 
-test('lists Anthropic / OpenAI / Google on /settings/ai-providers (no Moonshot, no OAuth)', async () => {
-	const { findByRole, findByText, queryAllByText, queryAllByRole } = await renderApp({
+test('Add provider modal lists Anthropic / OpenAI / Google (no Moonshot, no OAuth)', async () => {
+	const { findByRole, getByRole, queryAllByText, queryAllByRole, user } = await renderApp({
 		initialPath: '/settings/ai-providers',
 	});
 
 	await findByRole('heading', { name: 'AI providers' });
-	await findByText('Anthropic');
-	await findByText('OpenAI');
-	await findByText('Google');
-	await findByText('OpenRouter');
-	await findByText('Kimi');
+	await user.click(getByRole('button', { name: 'Add provider' }));
+
+	const dialog = await findByRole('dialog');
+	const providerSelect = within(dialog).getByLabelText('Provider');
+	const optionText = Array.from(providerSelect.querySelectorAll('option')).map(
+		(o) => o.textContent ?? '',
+	);
+	for (const name of ['Anthropic', 'OpenAI', 'Google', 'OpenRouter', 'Kimi']) {
+		expect(optionText.some((t) => t.includes(name))).toBe(true);
+	}
 	expect(queryAllByText('Moonshot').length).toBe(0);
 	expect(queryAllByRole('button', { name: /OAuth/i }).length).toBe(0);
 });
@@ -227,8 +232,8 @@ test('offers Gemini subscription paste flow for Google', async () => {
 	await findByText('Subscription', undefined, { timeout: 15_000 });
 });
 
-test('renders API key + Subscription side-by-side and can flip the default', async () => {
-	const { container, findByRole, findByText, user, ctx } = await renderApp({
+test('lists API key + Subscription rows for a provider and flips the default', async () => {
+	const { findByRole, findByText, getByRole, queryAllByText, user, ctx } = await renderApp({
 		initialPath: '/settings/ai-providers',
 		seed: async () => {
 			await clearAiProviders();
@@ -251,26 +256,20 @@ test('renders API key + Subscription side-by-side and can flip the default', asy
 
 	await findByRole('heading', { name: 'AI providers' });
 
-	const settingCards = Array.from(
-		container.querySelectorAll<HTMLElement>('div.border.border-border.rounded-md.p-3'),
-	);
-	const openaiCard = settingCards.find((el) => el.textContent?.includes('OpenAI'));
-	expect(openaiCard).toBeTruthy();
-
-	// Wait for the config rows to render — useAiProviders is async even though
-	// we already POSTed the configs in seed.
+	// Both configs render as their own rows in the table.
+	await findByText('openai-mix-api');
+	await findByText('openai-mix-subscription');
 	await waitFor(
 		() => {
-			expect(within(openaiCard!).queryAllByText('Subscription').length).toBeGreaterThan(0);
-			expect(within(openaiCard!).queryAllByText('API Key').length).toBeGreaterThan(0);
+			expect(queryAllByText('Subscription').length).toBeGreaterThan(0);
+			expect(queryAllByText('API Key').length).toBeGreaterThan(0);
 		},
 		{ timeout: 15_000 },
 	);
-	expect(within(openaiCard!).queryByText('Default')).toBeTruthy();
-	expect(within(openaiCard!).queryByRole('button', { name: /Use Codex subscription/i })).toBeNull();
-	expect(within(openaiCard!).queryByRole('button', { name: 'Enter API key' })).toBeNull();
+	// The first-created config is the default; the badge only shows when >1 exist.
+	expect(queryAllByText('Default').length).toBeGreaterThan(0);
 
-	const setDefaultBtn = within(openaiCard!).getAllByRole('button', { name: 'Set default' })[0];
+	const setDefaultBtn = getByRole('button', { name: 'Set openai-mix-subscription as default' });
 	fireEvent.click(setDefaultBtn);
 
 	await waitFor(
@@ -291,6 +290,91 @@ test('renders API key + Subscription side-by-side and can flip the default', asy
 		},
 		{ timeout: 15_000 },
 	);
+});
+
+test('Add provider modal pre-fills a default name from the selected provider', async () => {
+	const { findByRole, getByRole, user } = await renderApp({
+		initialPath: '/settings/ai-providers',
+	});
+
+	await findByRole('heading', { name: 'AI providers' });
+	await user.click(getByRole('button', { name: 'Add provider' }));
+
+	const dialog = await findByRole('dialog');
+	const nameInput = within(dialog).getByLabelText('Name') as HTMLInputElement;
+	// Default seed only uses the label "test-default", so "Anthropic" is free.
+	await waitFor(() => expect(nameInput.value).toBe('Anthropic'));
+
+	await user.selectOptions(within(dialog).getByLabelText('Provider'), 'google');
+	await waitFor(() => expect(nameInput.value).toBe('Google'));
+});
+
+test('Add provider modal increments the default name when the label is taken', async () => {
+	const { findByRole, getByRole, user } = await renderApp({
+		initialPath: '/settings/ai-providers',
+		seed: async () => {
+			await clearAiProviders();
+			const res = await postProvider({
+				provider: 'anthropic',
+				api_key: 'sk-ant-existing',
+				label: 'Anthropic',
+			});
+			expect(res.status).toBe(201);
+		},
+	});
+
+	await findByRole('heading', { name: 'AI providers' });
+	await user.click(getByRole('button', { name: 'Add provider' }));
+
+	const dialog = await findByRole('dialog');
+	const nameInput = within(dialog).getByLabelText('Name') as HTMLInputElement;
+	await waitFor(() => expect(nameInput.value).toBe('Anthropic 2'));
+});
+
+test('adds an API key provider via the Add modal', async () => {
+	const { findByRole, findByText, getByRole, user } = await renderApp({
+		initialPath: '/settings/ai-providers',
+	});
+
+	await findByRole('heading', { name: 'AI providers' });
+	await user.click(getByRole('button', { name: 'Add provider' }));
+
+	const dialog = await findByRole('dialog');
+	await user.selectOptions(within(dialog).getByLabelText('Provider'), 'google');
+
+	const nameInput = within(dialog).getByLabelText('Name') as HTMLInputElement;
+	fireEvent.change(nameInput, { target: { value: 'My Gemini' } });
+	const keyInput = within(dialog).getByLabelText('API key') as HTMLInputElement;
+	fireEvent.change(keyInput, { target: { value: 'gm-test-key-123' } });
+
+	await user.click(within(dialog).getByRole('button', { name: 'Add provider' }));
+
+	// Modal closes and the new row appears under its label.
+	await findByText('My Gemini', undefined, { timeout: 15_000 });
+});
+
+test('adds a subscription credential via the Add modal', async () => {
+	const { findByRole, findByText, getByRole, user } = await renderApp({
+		initialPath: '/settings/ai-providers',
+	});
+
+	await findByRole('heading', { name: 'AI providers' });
+	await user.click(getByRole('button', { name: 'Add provider' }));
+
+	const dialog = await findByRole('dialog');
+	await user.selectOptions(within(dialog).getByLabelText('Provider'), 'openai');
+	await user.click(within(dialog).getByRole('button', { name: /Codex subscription/i }));
+
+	// "codex login" appears in both a step and the footer, so match all.
+	await within(dialog).findAllByText(/codex login/i);
+	const textarea = within(dialog).getByLabelText('Subscription credential') as HTMLTextAreaElement;
+	fireEvent.change(textarea, {
+		target: { value: JSON.stringify({ tokens: { refresh_token: 'rt-modal' } }) },
+	});
+
+	await user.click(within(dialog).getByRole('button', { name: 'Add provider' }));
+
+	await findByText('Subscription', undefined, { timeout: 15_000 });
 });
 
 test('blocks the app when no provider is configured and drops once one is added', async () => {

--- a/packages/web/test/instance-connectors.test.tsx
+++ b/packages/web/test/instance-connectors.test.tsx
@@ -27,7 +27,7 @@ test('lists seeded instance connectors and creates a new one via the form', asyn
 		},
 	});
 
-	await findByText('Connectors');
+	await findByText('Connectors', { selector: 'h1' });
 	await findByText('Seeded Docs');
 
 	await user.click(getByRole('button', { name: 'Add' }));

--- a/packages/web/test/instance-credentials.test.tsx
+++ b/packages/web/test/instance-credentials.test.tsx
@@ -27,7 +27,7 @@ test('lists seeded instance credentials and creates a new one via the form', asy
 	});
 
 	// Heading + the seeded credential render.
-	await findByText('Credentials');
+	await findByText('Credentials', { selector: 'h1' });
 	await findByText('SEEDED_KEY');
 
 	// Open the create form and add a new credential.

--- a/packages/web/test/instance-skills.test.tsx
+++ b/packages/web/test/instance-skills.test.tsx
@@ -22,7 +22,7 @@ test('lists seeded instance skills and creates a new one via the form', async ()
 		},
 	});
 
-	await findByText('Skills');
+	await findByText('Skills', { selector: 'h1' });
 	await findByText('Seeded Skill');
 
 	await user.click(getByRole('button', { name: 'Add' }));

--- a/packages/web/test/model-pricing.test.tsx
+++ b/packages/web/test/model-pricing.test.tsx
@@ -27,7 +27,7 @@ test('lists a seeded override and creates a new one via the form', async () => {
 	});
 
 	// Heading + the seeded override (and its $/Mtok rendering) show.
-	await findByText('Model pricing');
+	await findByText('Model pricing', { selector: 'h1' });
 	await findByText('seeded-model');
 	await findByText('$3.00');
 

--- a/packages/web/test/settings-breadcrumb.test.tsx
+++ b/packages/web/test/settings-breadcrumb.test.tsx
@@ -1,0 +1,18 @@
+import { waitFor, within } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+
+test('settings subpage shows a breadcrumb back to the Settings page', async () => {
+	const { findByRole, router, user } = await renderApp({
+		initialPath: '/settings/credentials',
+	});
+
+	// The breadcrumb renders above the page content regardless of admin access.
+	const nav = await findByRole('navigation', { name: 'Breadcrumb' });
+	const back = within(nav).getByRole('link', { name: 'Settings' });
+
+	await user.click(back);
+
+	await waitFor(() => expect(router.state.location.pathname).toBe('/settings'));
+	await findByRole('heading', { name: 'Settings' });
+});


### PR DESCRIPTION
## Why

The **Settings → AI providers** page rendered a fixed catalogue of all seven provider types, each with inline "Enter API key" / "Use … subscription" buttons. Configured credentials showed up as small rows tucked under their provider's card, so the page read as a grid of empty slots rather than "the providers I've added" — which is why existing providers didn't feel listed.

## What changed

**AI providers page → list + add modal**
- The page now shows a **table of the configured providers** (Name, Provider/runtime, Auth, Status, Default model, and Verify / Set-default / Remove actions), with an empty state when nothing is configured.
- An **"Add provider"** button opens a modal that:
  - picks a provider,
  - chooses **API key** vs **subscription** (where the provider supports it),
  - takes the credential (password field, or the provider-specific subscription paste instructions + textarea), and
  - **names** the config — the name is pre-filled with a generated default based on the selection (e.g. `Anthropic`, then `Anthropic 2`, skipping labels already in use) and stays editable.
- Verify failures surface as a toast and the refetched `invalid` status badge; a successful verify shows an inline check.

**Settings breadcrumbs**
- Every settings subpage (AI providers, Chatbox, Connectors, Credentials, Connected agents, Skills, Model pricing, Activity) now has a breadcrumb at the top linking back to the main Settings page.

## Notes / scope

- **Frontend-only.** The `ai_provider_configs` model and `/api/ai-providers` routes already supported per-config labels, auth methods, multiple configs per provider, and default selection — no schema, API, or migration changes.
- The **first-run setup gate** keeps its catalogue layout (it's the right UX for choosing your first provider). Subscription instructions were extracted into a shared component reused by both the gate and the new modal.
- Reuses existing primitives: `DataTable` (as on the Credentials page), the Radix dialog pattern, and the existing `use-ai-providers` hooks.

## Testing

- `bun run typecheck` ✅, `bun run check` ✅ (0 errors)
- Full web component suite: **419 tests across 113 files passing** ✅
- Rewrote the two catalogue-coupled AI-providers specs for the new list/modal, added modal-flow + breadcrumb coverage, and scoped the four settings-subpage heading assertions to the `<h1>` (a breadcrumb now repeats the page title).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017agF2pau5zMrkgGWDX9CeS

---
_Generated by [Claude Code](https://claude.ai/code/session_017agF2pau5zMrkgGWDX9CeS)_