### PR TITLE
feat: in-app self-update via supervisor process

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -662,11 +662,37 @@ master key) → run the previous binary.
 
 **Releases & updates.** A PR flow (`.github/workflows/`): `release.yml` computes the next
 version from Conventional Commits and opens a `release/<version>` PR; merging fires
-`release-publish.yml`, which tags, cross-compiles, and publishes a GitHub Release. The
-running instance polls `GET /api/updates/latest` (cached ~1 h, fails soft) and shows a
-dismissible banner.
+`release-publish.yml`, which tags, cross-compiles, and publishes a GitHub Release (assets
+`hezo-{os}-{arch}[.exe]` + `SHA256SUMS`). The running instance polls
+`GET /api/updates/latest` (cached ~1 h, fails soft) and shows a bottom banner.
 
-**Known limits.** macOS binaries are unsigned (built on Linux; clear quarantine with `xattr -d`).
+**Self-update & supervisor.** A compiled binary with auto-update enabled
+(`isAutoUpdateEnabled()` — compiled, not `HEZO_DISABLE_AUTO_UPDATE`, not in a container)
+runs as a thin **supervisor** (`supervisor.ts`): it spawns the real server as a **worker**
+(`Bun.spawn` of `[execPath, ...argv]` with `HEZO_WORKER=1`), forwards `SIGTERM`/`SIGINT`,
+and on the worker's exit either propagates the code (normal exit/crash → external restart
+policies behave as before) or, on the **restart sentinel** `UPDATE_RESTART_EXIT_CODE` (75),
+applies the staged binary and relaunches. The supervisor branch sits in `index.ts` right
+after the `restore` subcommand and before preflights, so dev (`bun run`) and `hezo restore`
+never supervise. The `updater.ts` service handles the rest: a daily `update-check` cron
+(`HEZO_UPDATE_CHECK_CRON`) and `POST /api/updates/download` download the platform asset +
+`SHA256SUMS`, verify the hash, and stage to `<dataDir>/.update/staged[.exe]` (recording
+lifecycle in `state.json`); `POST /api/updates/apply` (superuser) gracefully shuts the
+worker down (`shutdownRuntime` in `runtime-control.ts`, also wired to signals) and exits
+with the sentinel. `applyStagedUpdate()` does the swap *while the worker is down*: copy
+staged → a temp file adjacent to the target (avoids `EXDEV`), then **Unix** atomic `rename`
+over the binary, or **Windows** rename-trick (rename the locked `.exe` aside, move the new
+one in, verify, roll back on failure; stale `-old-` files swept on next supervisor start).
+State survives the restart via the normal recovery path (`reconcileOnStartup`), and the
+instance returns **locked** unless `HEZO_MASTER_KEY` is set (the web restart overlay polls
+`/api/status` and reloads onto the master-key gate). `GET /api/updates/status` surfaces the
+staged-update state plus an `autoUnlock` hint so the UI's confirmation can warn about the
+master-key re-unlock.
+
+**Known limits.** macOS binaries are unsigned (built on Linux; clear quarantine with `xattr -d`);
+on Apple Silicon an unsigned replacement may still be Gatekeeper-blocked. Windows self-update
+relies on the rename-trick and is not exercised by CI (manual validation). The supervisor keeps
+running its own old code until a full process restart — only the worker is refreshed.
 
 ---
 

--- a/.dev/self-updating-plan.md
+++ b/.dev/self-updating-plan.md
@@ -163,10 +163,19 @@ once unlocked.
 
 ### Docs & architecture
 
+- `README.md` — add self-updating to the feature list / highlights: Hezo can
+  check GitHub Releases, download the new binary, and update + restart in place
+  from the web UI, so operators no longer have to swap the binary by hand. Link
+  to the self-hosting "Updating" section.
 - `docs/deployment/self-hosting.md` "Updating" — describe the in-app auto-update,
-  supervisor, "Update & restart", and the relock-on-restart caveat. Do **not**
-  surface `HEZO_WORKER` (internal); document `HEZO_DISABLE_AUTO_UPDATE` /
+  supervisor, "Update & restart", the apply-time confirmation + master-key
+  re-unlock warning, and the relock-on-restart caveat. Do **not** surface
+  `HEZO_WORKER` (internal); document `HEZO_DISABLE_AUTO_UPDATE` /
   `HEZO_UPDATE_CHECK_CRON` in `docs/deployment/configuration`.
+- Surface self-updating wherever the user-facing docs introduce features (e.g.
+  the docs overview/landing page), not only the deployment reference — it is a
+  user-visible capability, and the full `docs/` tree is bundled into the binary
+  and injected into the CEO chat, so the CEO can answer "how do I update Hezo?".
 - `.dev/architecture.md` — add a "Self-update & supervisor" section (process model,
   swap-per-platform, exit sentinel, state recovery).
 

--- a/.dev/self-updating-plan.md
+++ b/.dev/self-updating-plan.md
@@ -61,9 +61,19 @@ once unlocked.
 
 1. **Restart mechanism:** built-in supervisor process (above).
 2. **Apply mode:** auto-download/stage in background; **apply + restart only on
-   user click** ("Update & restart"). No surprise restarts.
+   user click** ("Update & restart"). No surprise restarts. The click does not
+   apply immediately — it opens a **confirmation dialog** that restates the
+   consequences (shutdown + restart on the new version, in-flight runs aborted
+   and auto-recovered) and **warns the operator they will need their 12-word
+   master key to unlock Hezo again after the restart**. `POST /updates/apply`
+   fires only on explicit confirm.
 3. **Re-unlock:** restart even without an env key; show the unlock screen on the
-   way back up.
+   way back up. The instance only returns **locked** when no `HEZO_MASTER_KEY`
+   is configured in the server env — if it is, boot auto-unlocks and no key
+   entry is needed. Surface a boolean (e.g. `masterKeyInEnv` / `autoUnlock`)
+   from `GET /updates/status` (or `/api/status`) so the confirmation copy is
+   accurate, and **default to showing the master-key warning when the state is
+   unknown**.
 
 ## What already exists (reuse, don't rebuild)
 
@@ -133,15 +143,23 @@ once unlocked.
 
 2. **Global bottom banner** — reposition/extend `UpdateBanner` to a full-width
    **sticky bottom** bar shown on every page when `updateAvailable`. Replace the
-   passive dismiss with an **"Update & restart"** action (apply mode = confirmed)
-   plus version + release link; keep per-version localStorage dismiss for "later".
+   passive dismiss with an **"Update & restart"** action plus version + release
+   link; keep per-version localStorage dismiss for "later". The action does
+   **not** apply on click — it opens a confirmation `AlertDialog` (mobile-first)
+   restating the consequences and **warning that the operator will need their
+   12-word master key to unlock Hezo again after the restart** (soften the copy
+   to "Hezo will restart and resume automatically" when `autoUnlock` is true).
+   Only the dialog's primary confirm fires `POST /updates/apply`; "Cancel"
+   dismisses with no effect.
 
-3. **Restart overlay** — new full-screen component. On "Update & restart":
-   `POST /updates/apply`, then mount the overlay ("Updating to vX.Y.Z…"). Poll
-   `/api/status` (reuse `useStatus` retry semantics) / watch `useSocket().connected`;
-   while unreachable show "restarting", and when status returns reload the app.
-   `AppShell` already gates on `/api/status`, so a locked return naturally lands on
-   the master-key screen. `useInvalidateOnReconnect` refreshes data.
+3. **Restart overlay** — new full-screen component. On confirm:
+   `POST /updates/apply`, then mount the overlay ("Updating to vX.Y.Z…"). The
+   overlay copy reiterates the master-key unlock requirement so it stays visible
+   while the instance is down. Poll `/api/status` (reuse `useStatus` retry
+   semantics) / watch `useSocket().connected`; while unreachable show
+   "restarting", and when status returns reload the app. `AppShell` already gates
+   on `/api/status`, so a locked return naturally lands on the master-key screen.
+   `useInvalidateOnReconnect` refreshes data.
 
 ### Docs & architecture
 
@@ -174,8 +192,10 @@ once unlocked.
   shutdown + sentinel exit (mock exit); daily `update-check` job registered/guarded.
 - **Web component** (`packages/web/test/**`, `renderApp`): settings footer renders
   version + correct release link; bottom banner appears when `updateAvailable` and
-  hides otherwise; "Update & restart" calls `POST /updates/apply` and mounts the
-  overlay; overlay polls and resumes when `/api/status` recovers.
+  hides otherwise; "Update & restart" opens the confirmation dialog showing the
+  master-key warning and does **not** call `POST /updates/apply` on the initial
+  click; the dialog's confirm calls `POST /updates/apply` and mounts the overlay
+  (and "Cancel" does not); overlay polls and resumes when `/api/status` recovers.
 - **Manual cross-platform** (can't be automated): build two versions, run the
   supervisor, trigger "Update & restart", confirm the worker relaunches on the new
   version and reconciliation resumes agents — on Linux, macOS (incl. quarantine
@@ -185,8 +205,47 @@ once unlocked.
 ## Risks / notes
 
 - **Supervisor stays on old code** until a full restart (worker is fresh) — accepted.
-- **macOS Gatekeeper**: unsigned downloaded binaries may be blocked even after
-  quarantine strip; proper notarization is a follow-up.
 - **Dev mode**: feature is hard-disabled for non-compiled runs.
 - Restart aborts in-flight runs (auto-recovered) and disconnects sockets
   (auto-reconnect) — surfaced in the overlay copy.
+
+The swap design follows established updater patterns and is sound in principle,
+but the per-platform behaviour below is **not guaranteed** and is why the
+cross-platform validation above is manual and unautomatable. Treat these as open
+items to resolve during implementation, not settled facts:
+
+- **Cross-filesystem staging (`EXDEV`).** `rename(2)` is atomic only on the same
+  filesystem. Staging lives in `<dataDir>/.update/` but the swap renames over
+  `process.execPath`; if those are different mounts the rename fails with
+  `EXDEV`. The swap must first **copy** the staged file to a temp path *adjacent
+  to the binary*, then rename.
+- **Write permission on the install dir (`EACCES`).** A common layout is systemd
+  running as an unprivileged user with the binary in a root-owned dir
+  (`/usr/local/bin`, `/opt`); the process then cannot rename over its own binary.
+  Needs a documented failure mode / preflight check rather than a mid-apply crash.
+- **Failed-swap rollback is unspecified.** Unix atomic rename is all-or-nothing,
+  but the **Windows swap is multi-step and non-atomic** (rename old → write new);
+  a crash in between leaves `hezo.exe` missing or partial. The supervisor needs an
+  explicit verify + rollback path before relaunching the worker.
+- **Windows signal semantics.** "Forward SIGTERM/SIGINT to the child" is a Unix
+  model. Windows has no real `SIGTERM` (signals are emulated; console-control
+  events behave differently), so graceful-shutdown-via-forwarded-signal differs
+  there and needs its own handling.
+- **macOS arm64 codesigning.** Stripping `com.apple.quarantine` only clears the
+  Gatekeeper *prompt*. Apple Silicon **requires** a valid (≥ ad-hoc) signature to
+  execute — an invalid one is `SIGKILL`ed, not prompted. This can be a hard
+  blocker on arm64, not just a notarization follow-up.
+- **Windows SmartScreen / Defender (and AV generally).** A freshly downloaded,
+  unsigned or replaced `.exe` may be quarantined or locked by real-time AV,
+  blocking the relaunch — the same risk class as macOS Gatekeeper.
+- **Bun runtime divergence.** The supervisor leans entirely on runtime primitives
+  (`Bun.spawn`/`child_process` `stdio:'inherit'`, signal forwarding, exit-code
+  propagation, compiled-binary `process.execPath`/argv reconstruction). This repo
+  maintains a dedicated Bun-native test tier precisely because Bun's `node:`
+  behaviour diverges from Node and vitest (Node) gives false confidence here. The
+  supervisor needs Bun-native tests (`packages/server/test/bun/**`) per platform;
+  even those cannot exercise the Windows/macOS swap under Linux CI.
+- **Deployment model.** In-place self-update assumes a **bare-binary** install. If
+  Hezo itself runs inside a container, the swap is the wrong model (the change is
+  lost on container recreate — the image should be updated instead). The feature
+  should detect or document that it does not apply in that case.

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Each feature links to its documentation.
 - **[External MCP servers](./docs/mcp/connecting-mcp-servers.md)** — give your agents the tools you already use, scoped per instance, team, or project.
 - **[Self-hosted single binary](./docs/getting-started/installation.md)** — no runtime or external database; Docker is the only prerequisite. [Configurable](./docs/deployment/configuration.md) by flag or env, with a small [CLI](./docs/reference/cli.md).
 - **[Deploy anywhere Docker runs](./docs/deployment/self-hosting.md)** — laptop, home server, or [cloud VPS](./docs/deployment/cloud.md), with [secure remote access](./docs/deployment/secure-remote-access.md) and [safe-rollback backups](./docs/deployment/backup-and-recovery.md).
+- **[In-app self-update](./docs/deployment/self-hosting.md#updating)** — Hezo checks for new releases, downloads and verifies the binary, then swaps it in and restarts from the web UI — no manual binary replacement.
 - **Mobile-first web app** — oversee, chat, and approve from any device.
 
 ## How Hezo compares

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -22,6 +22,8 @@ into a service definition while still overriding per run.
 | `--open` | `HEZO_OPEN` | off | Open the web app in your browser on startup. |
 | `--log-level <level>` | `HEZO_LOG_LEVEL` | `info` | Logging verbosity: `debug`, `info`, `warn`, or `error`. |
 | `--keep-old-containers` | `HEZO_KEEP_OLD_CONTAINERS` | off | Keep old project containers instead of removing them — for debugging a crashed container. |
+| — | `HEZO_DISABLE_AUTO_UPDATE` | off | Disable the in-app auto-update (release check, download, and "Update & restart"). |
+| — | `HEZO_UPDATE_CHECK_CRON` | `0 0 4 * * *` | Cron schedule (seconds-precision) for the daily check that downloads and stages a newer release. |
 
 ## Examples
 

--- a/docs/deployment/self-hosting.md
+++ b/docs/deployment/self-hosting.md
@@ -51,6 +51,28 @@ Only the server port needs to be reachable by the people using Hezo.
 
 ## Updating
 
-Upgrading is replacing the binary. On startup Hezo runs any required database
-migrations automatically, taking a snapshot first so an upgrade is safe to roll back.
-See [Backup & recovery](/docs/deployment/backup-and-recovery).
+### In-app auto-update
+
+Hezo checks GitHub Releases daily and, when a newer version is available,
+downloads and verifies the binary for your platform in the background. A bar
+then appears at the bottom of the web UI; a superuser clicks **Update &
+restart** and confirms. Hezo shuts down gracefully, swaps in the new binary, and
+restarts onto it — no manual file replacement.
+
+Because the restart re-locks the instance, **you'll need your 12-word master key
+to unlock Hezo again afterward** — unless you run Hezo with the master key set in
+the environment (`HEZO_MASTER_KEY`), in which case it unlocks itself on restart.
+The confirmation dialog tells you which case applies. In-flight agent runs are
+aborted and recovered automatically, and connected browsers reconnect on their
+own.
+
+Auto-update applies to the self-managed single binary. It is disabled when Hezo
+runs inside a container (update the image instead) and can be turned off with
+`HEZO_DISABLE_AUTO_UPDATE`. The daily check schedule is configurable via
+`HEZO_UPDATE_CHECK_CRON`. See [Configuration](/docs/deployment/configuration).
+
+### Updating manually
+
+You can always upgrade by replacing the binary yourself. On startup Hezo runs any
+required database migrations automatically, taking a snapshot first so an upgrade
+is safe to roll back. See [Backup & recovery](/docs/deployment/backup-and-recovery).

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -8,6 +8,7 @@ import { DbNewerThanAppError, MigrationFailedError } from './db/migrate-errors';
 import type { AuthInfo } from './lib/types';
 import { logger, setLogLevel } from './logger';
 import { canAuthAccessTeam, loadAdminAuth, verifyToken } from './middleware/auth';
+import { getActiveRuntime, setActiveRuntime, shutdownRuntime } from './runtime-control';
 import type { ContainerLogStreamer } from './services/container-logs';
 import { setKeepOldContainers } from './services/containers';
 import { DockerClient } from './services/docker';
@@ -15,9 +16,11 @@ import { evaluateDockerPreflight, formatDockerPreflightMessage } from './service
 import { getSharedImageBuildTracker } from './services/image-build-tracker';
 import type { LogStreamBroker } from './services/log-stream-broker';
 import { formatPortInUseMessage, probePort } from './services/port-preflight';
+import { isAutoUpdateEnabled } from './services/updater';
 import type { WebSocketManager, WsData, WsSocket } from './services/ws';
 import { handleWsSubscribe, handleWsUnsubscribe } from './services/ws-subscribe-handler';
 import { type StartupResult, startup } from './startup';
+import { runSupervisor } from './supervisor';
 
 const log = logger.child('server');
 
@@ -48,14 +51,11 @@ async function shutdownPreviousRuntime(): Promise<void> {
 }
 
 function registerRuntime(result: StartupResult): void {
+	setActiveRuntime(result);
 	globalThis.__hezoDevRuntime = {
 		shutdown: async () => {
 			serverReady = false;
-			result.jobManager.shutdown();
-			await result.ceoSessionManager.stop();
-			await result.egressProxy.releaseAll();
-			await result.sshAgentServer.releaseAll();
-			await result.db.close();
+			await shutdownRuntime(result);
 		},
 	};
 }
@@ -84,7 +84,38 @@ if (await runRestore()) {
 
 const config = parseConfig();
 setLogLevel(config.logLevel);
+
+// Self-update supervisor. A compiled binary with auto-update enabled runs as a
+// thin supervisor that spawns the real server as a worker (HEZO_WORKER=1),
+// applies staged updates between restarts, and otherwise propagates the worker's
+// exit code. The worker re-enters this file with HEZO_WORKER set and skips this
+// branch, running the server below. Dev (`bun run`, non-compiled) and the
+// `restore` subcommand never reach here, so they never supervise. runSupervisor
+// never returns.
+if (!process.env.HEZO_WORKER && isAutoUpdateEnabled()) {
+	await runSupervisor(config.dataDir);
+}
+
 setKeepOldContainers(config.keepOldContainers);
+
+// Graceful shutdown on termination signals (the supervisor forwards these to the
+// worker). Close the runtime cleanly, then exit 0 so the supervisor sees a
+// normal — non-sentinel — code and exits too rather than relaunching.
+for (const sig of ['SIGTERM', 'SIGINT'] as const) {
+	process.on(sig, () => {
+		void (async () => {
+			const runtime = getActiveRuntime();
+			if (runtime) {
+				try {
+					await shutdownRuntime(runtime);
+				} catch (err) {
+					log.error('Graceful shutdown error:', err);
+				}
+			}
+			process.exit(0);
+		})();
+	});
+}
 
 // Port preflight: Bun binds the port itself from the default export below, so an
 // already-taken port would otherwise surface as a bare `EADDRINUSE` crash. Probe

--- a/packages/server/src/routes/updates.ts
+++ b/packages/server/src/routes/updates.ts
@@ -1,5 +1,12 @@
+import { UPDATE_RESTART_EXIT_CODE, UpdateState } from '@hezo/shared';
 import { Hono } from 'hono';
+import { trackBackground } from '../lib/background';
+import { err, ok } from '../lib/response';
+import type { Env } from '../lib/types';
 import { logger } from '../logger';
+import { requireSuperuser } from '../middleware/auth';
+import { getActiveRuntime, shutdownRuntime } from '../runtime-control';
+import { downloadAndStage, isAutoUpdateEnabled, readUpdateState } from '../services/updater';
 import { HEZO_VERSION } from '../version';
 
 const log = logger.child('updates');
@@ -63,11 +70,91 @@ async function fetchLatest(): Promise<UpdateInfo> {
 	}
 }
 
-export const updatesRoutes = new Hono();
-
-updatesRoutes.get('/updates/latest', async (c) => {
+/** Cached latest-release info (1h TTL), shared by the route and the update-check cron. */
+export async function getLatestInfo(): Promise<UpdateInfo> {
 	if (!cache || Date.now() - cache.at >= TTL_MS) {
 		cache = { at: Date.now(), data: await fetchLatest() };
 	}
-	return c.json(cache.data);
-});
+	return cache.data;
+}
+
+/** True only in a supervised worker that can actually restart-with-swap. */
+function isSupervisedWorker(): boolean {
+	return isAutoUpdateEnabled() && process.env.HEZO_WORKER === '1';
+}
+
+/**
+ * Build the updates router. `autoUnlock` reflects whether a master key is
+ * configured at startup (env/CLI) — when true the instance auto-unlocks after a
+ * restart, so the UI can soften the "you'll need your master key" warning.
+ */
+export function buildUpdatesRoutes(opts: { autoUnlock: boolean }): Hono<Env> {
+	const routes = new Hono<Env>();
+
+	// Any authed user: passive "is an update available" check (banner + settings).
+	routes.get('/updates/latest', async (c) => c.json(await getLatestInfo()));
+
+	// Any authed user: latest info + staged-update lifecycle + auto-unlock hint.
+	routes.get('/updates/status', async (c) => {
+		const dataDir = c.get('dataDir');
+		const [latest, state] = await Promise.all([getLatestInfo(), readUpdateState(dataDir)]);
+		return c.json({
+			...latest,
+			state: state.state,
+			targetVersion: state.targetVersion ?? null,
+			error: state.error ?? null,
+			autoUnlock: opts.autoUnlock,
+			canApply: isSupervisedWorker(),
+		});
+	});
+
+	// Superuser: kick a background download+verify+stage of the latest release.
+	routes.post('/updates/download', async (c) => {
+		const denied = requireSuperuser(c);
+		if (denied) return denied;
+		if (!isSupervisedWorker()) {
+			return err(c, 'UPDATE_UNAVAILABLE', 'Auto-update is not available in this environment', 409);
+		}
+		const latest = await getLatestInfo();
+		if (!latest.updateAvailable || !latest.latest) {
+			return err(c, 'NO_UPDATE', 'No newer release is available', 409);
+		}
+		const dataDir = c.get('dataDir');
+		const version = latest.latest;
+		trackBackground(
+			downloadAndStage(version, dataDir).catch((e) => log.error('download/stage failed', e)),
+		);
+		return c.json({ data: { state: UpdateState.Downloading, targetVersion: version } }, 202);
+	});
+
+	// Superuser: shut down gracefully and exit with the restart sentinel so the
+	// supervisor applies the staged binary and relaunches. Responds *before*
+	// exiting so the HTTP response flushes.
+	routes.post('/updates/apply', async (c) => {
+		const denied = requireSuperuser(c);
+		if (denied) return denied;
+		if (!isSupervisedWorker()) {
+			return err(c, 'UPDATE_UNAVAILABLE', 'Auto-update is not available in this environment', 409);
+		}
+		const dataDir = c.get('dataDir');
+		const state = await readUpdateState(dataDir);
+		if (state.state !== UpdateState.Staged) {
+			return err(c, 'NO_STAGED_UPDATE', 'No staged update to apply', 409);
+		}
+		setTimeout(() => {
+			void (async () => {
+				const runtime = getActiveRuntime();
+				try {
+					if (runtime) await shutdownRuntime(runtime);
+				} catch (e) {
+					log.error('shutdown before update-apply failed', e);
+				}
+				log.info('Exiting with restart sentinel to apply staged update');
+				process.exit(UPDATE_RESTART_EXIT_CODE);
+			})();
+		}, 100);
+		return ok(c, { state: UpdateState.Applying, targetVersion: state.targetVersion ?? null });
+	});
+
+	return routes;
+}

--- a/packages/server/src/runtime-control.ts
+++ b/packages/server/src/runtime-control.ts
@@ -1,0 +1,33 @@
+import type { StartupResult } from './startup';
+
+/**
+ * Holds the live server runtime so request handlers (e.g. the update-apply
+ * route) and signal handlers can trigger a graceful shutdown without importing
+ * the entry module `index.ts` (which has top-level side effects). Set once the
+ * startup IIFE completes.
+ */
+let active: StartupResult | null = null;
+let shuttingDown = false;
+
+export function setActiveRuntime(result: StartupResult): void {
+	active = result;
+}
+
+export function getActiveRuntime(): StartupResult | null {
+	return active;
+}
+
+/**
+ * Graceful shutdown: stop scheduled jobs and CEO sessions, release the egress
+ * proxy + ssh agent, and close the database. Idempotent — safe to call from both
+ * a termination-signal handler and the update-apply path.
+ */
+export async function shutdownRuntime(result: StartupResult): Promise<void> {
+	if (shuttingDown) return;
+	shuttingDown = true;
+	result.jobManager.shutdown();
+	await result.ceoSessionManager.stop();
+	await result.egressProxy.releaseAll();
+	await result.sshAgentServer.releaseAll();
+	await result.db.close();
+}

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -13,6 +13,7 @@ import {
 	TaskPriority,
 	TaskStatus,
 	TERMINAL_TASK_STATUSES,
+	UpdateState,
 	WakeupSkipReason,
 	WakeupSource,
 	WakeupStatus,
@@ -27,6 +28,7 @@ import { shouldDeferWakeupForBlockers } from '../lib/dependencies';
 import { ref } from '../lib/log-ref';
 import { assertChildrenAllClosed } from '../lib/task-relationships';
 import { logger } from '../logger';
+import { getLatestInfo } from '../routes/updates';
 import { type RunnerDeps, type RunResult, recordRunCostAndEnforce, runAgent } from './agent-runner';
 import {
 	pauseAgentForBudget,
@@ -56,6 +58,7 @@ import { ensureRepoSetupAction } from './repo-setup';
 import { getProjectConcurrency, isTaskBusyInDb } from './run-concurrency';
 import type { SshAgentServer } from './ssh-agent';
 import { triggerStatusAutomations } from './task-automation';
+import { downloadAndStage, isAutoUpdateEnabled, readUpdateState } from './updater';
 import { absorbQueuedTaskWakeups, assignmentWakeupAlreadyServed, createWakeup } from './wakeup';
 import type { WebSocketManager } from './ws';
 
@@ -137,6 +140,9 @@ const COALESCING_WINDOW_MS = Number(process.env.HEZO_WAKEUP_COALESCING_MS ?? 2_0
 const WAKEUP_CRON = process.env.HEZO_WAKEUP_CRON ?? '*/5 * * * * *';
 const HEARTBEAT_CRON = process.env.HEZO_HEARTBEAT_CRON ?? '*/5 * * * * *';
 const INBOX_ARCHIVE_CRON = process.env.HEZO_INBOX_ARCHIVE_CRON ?? '0 0 3 * * *';
+// Daily check for a newer release; when auto-update is enabled and one is found,
+// download+verify+stage it so an operator "Update & restart" is instant.
+const UPDATE_CHECK_CRON = process.env.HEZO_UPDATE_CHECK_CRON ?? '0 0 4 * * *';
 // How often to re-evaluate budget-paused agents. Spend is summed over rolling
 // UTC windows, so a daily/weekly/monthly window rolling over silently frees an
 // agent's budget with no event — this sweep notices and lifts the reactive
@@ -387,6 +393,11 @@ export class JobManager {
 			cron: BUDGET_RESUME_CRON,
 			log: cronLog,
 			onTick: () => this.guarded('budget-resume', () => this.processBudgetResumes()),
+		});
+		this.cron.createJob('update-check', {
+			cron: UPDATE_CHECK_CRON,
+			log: cronLog,
+			onTick: () => this.guarded('update-check', () => this.checkForUpdate()),
 		});
 		log.info('Job manager started.');
 	}
@@ -2021,5 +2032,21 @@ export class JobManager {
 		if (count > 0) {
 			log.debug(`Archived ${count} inbox item(s)`);
 		}
+	}
+
+	/**
+	 * Daily auto-update check. When the feature is enabled (supervised compiled
+	 * binary) and a newer release exists that isn't already staged/downloading,
+	 * download+verify+stage it so an operator "Update & restart" is instant.
+	 */
+	private async checkForUpdate(): Promise<void> {
+		if (!isAutoUpdateEnabled() || process.env.HEZO_WORKER !== '1') return;
+		const latest = await getLatestInfo();
+		if (!latest.updateAvailable || !latest.latest) return;
+		const state = await readUpdateState(this.deps.dataDir);
+		if (state.state === UpdateState.Downloading) return;
+		if (state.state === UpdateState.Staged && state.targetVersion === latest.latest) return;
+		log.info(`Auto-update: staging release ${latest.latest}`);
+		await downloadAndStage(latest.latest, this.deps.dataDir);
 	}
 }

--- a/packages/server/src/services/updater.ts
+++ b/packages/server/src/services/updater.ts
@@ -1,0 +1,286 @@
+import { spawn } from 'node:child_process';
+import { createHash, timingSafeEqual } from 'node:crypto';
+import { existsSync } from 'node:fs';
+import {
+	chmod,
+	copyFile,
+	mkdir,
+	readdir,
+	readFile,
+	rename,
+	rm,
+	stat,
+	writeFile,
+} from 'node:fs/promises';
+import { basename, dirname, join } from 'node:path';
+import { UpdateState } from '@hezo/shared';
+import { logger } from '../logger';
+import { HEZO_VERSION } from '../version';
+
+const log = logger.child('updater');
+
+/** The repo whose GitHub Releases we download binaries from. */
+const REPO = 'hezo-ai/hezo';
+
+/**
+ * Thrown by `applyStagedUpdate` when the on-disk swap fails in an
+ * operator-actionable way (e.g. the install dir isn't writable). The supervisor
+ * logs it and relaunches the existing binary rather than crash-looping.
+ */
+export class UpdateApplyError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'UpdateApplyError';
+	}
+}
+
+export interface UpdateStateFile {
+	state: UpdateState;
+	targetVersion?: string;
+	asset?: string;
+	error?: string;
+}
+
+/**
+ * True only when this process is a `bun build --compile` standalone binary. In
+ * dev (`bun run`) `process.execPath` is the Bun runtime itself (`.../bun`); in
+ * the compiled binary it is the Hezo executable. Corroborated by the embedded
+ * asset loaders (`loadStaticBundle`/`loadPgliteAssets`), which only return
+ * content in the compiled binary.
+ */
+export function isCompiledBinary(): boolean {
+	const exe = basename(process.execPath).toLowerCase();
+	return exe !== 'bun' && exe !== 'bun.exe';
+}
+
+/** Best-effort detection of running inside a container, where in-place swap is wrong. */
+export function isRunningInContainer(): boolean {
+	return existsSync('/.dockerenv');
+}
+
+/**
+ * The auto-update feature is available only for a self-managed bare binary:
+ * compiled, not explicitly disabled, and not running inside a container (where
+ * the image, not the binary, should be updated).
+ */
+export function isAutoUpdateEnabled(): boolean {
+	if (process.env.HEZO_DISABLE_AUTO_UPDATE) return false;
+	if (!isCompiledBinary()) return false;
+	if (isRunningInContainer()) return false;
+	return true;
+}
+
+/**
+ * Release asset name for the current platform, matching the `TARGETS` mapping in
+ * `scripts/build.ts` (`hezo-{os}-{arch}[.exe]`). Throws on an unsupported combo
+ * (e.g. windows/arm64, for which we ship no binary).
+ */
+export function currentAssetName(
+	platform: NodeJS.Platform = process.platform,
+	arch: string = process.arch,
+): string {
+	const os =
+		platform === 'win32'
+			? 'windows'
+			: platform === 'darwin'
+				? 'darwin'
+				: platform === 'linux'
+					? 'linux'
+					: null;
+	const cpu = arch === 'x64' ? 'x64' : arch === 'arm64' ? 'arm64' : null;
+	if (!os || !cpu) throw new Error(`Unsupported platform for auto-update: ${platform}/${arch}`);
+	if (os === 'windows' && cpu !== 'x64') {
+		throw new Error(`No release binary for ${os}/${cpu}`);
+	}
+	return `hezo-${os}-${cpu}${os === 'windows' ? '.exe' : ''}`;
+}
+
+function updateDir(dataDir: string): string {
+	return join(dataDir, '.update');
+}
+
+function stagedPath(dataDir: string): string {
+	return join(updateDir(dataDir), process.platform === 'win32' ? 'staged.exe' : 'staged');
+}
+
+function stateFilePath(dataDir: string): string {
+	return join(updateDir(dataDir), 'state.json');
+}
+
+export async function readUpdateState(dataDir: string): Promise<UpdateStateFile> {
+	try {
+		const raw = await readFile(stateFilePath(dataDir), 'utf8');
+		return JSON.parse(raw) as UpdateStateFile;
+	} catch {
+		return { state: UpdateState.Idle };
+	}
+}
+
+async function writeState(dataDir: string, s: UpdateStateFile): Promise<void> {
+	await mkdir(updateDir(dataDir), { recursive: true });
+	await writeFile(stateFilePath(dataDir), `${JSON.stringify(s, null, 2)}\n`);
+}
+
+/** Parse a `sha256sum`-style manifest, returning the lowercase hash for `asset`. */
+function expectedSha(sums: string, asset: string): string | null {
+	for (const line of sums.split('\n')) {
+		// Lines are `<64-hex>  <filename>` (build.ts) or `<hex> *<filename>` (binary mode).
+		const m = /^([0-9a-f]{64})\s+\*?(.+)$/i.exec(line.trim());
+		if (m && m[2] === asset) return m[1].toLowerCase();
+	}
+	return null;
+}
+
+function timingSafeHexEqual(a: string, b: string): boolean {
+	const ba = Buffer.from(a, 'hex');
+	const bb = Buffer.from(b, 'hex');
+	if (ba.length === 0 || ba.length !== bb.length) return false;
+	return timingSafeEqual(ba, bb);
+}
+
+/** macOS: clear the quarantine xattr so Gatekeeper doesn't block the relaunch. Best-effort. */
+async function stripQuarantine(file: string): Promise<void> {
+	await new Promise<void>((resolve) => {
+		try {
+			const proc = spawn('xattr', ['-d', 'com.apple.quarantine', file], { stdio: 'ignore' });
+			// xattr may be absent or the attribute may not exist — neither is fatal.
+			proc.on('error', () => resolve());
+			proc.on('close', () => resolve());
+		} catch {
+			resolve();
+		}
+	});
+}
+
+/**
+ * Download the release asset for `version` + its SHA256SUMS, verify the hash, and
+ * write it to `<dataDir>/.update/staged[.exe]`. Records progress in the state
+ * file. Throws (and records `error` state) on download/verify failure.
+ */
+export async function downloadAndStage(version: string, dataDir: string): Promise<void> {
+	const asset = currentAssetName();
+	await mkdir(updateDir(dataDir), { recursive: true });
+	await writeState(dataDir, { state: UpdateState.Downloading, targetVersion: version, asset });
+	try {
+		const base = `https://github.com/${REPO}/releases/download/${version}`;
+		const [binRes, sumsRes] = await Promise.all([
+			fetch(`${base}/${asset}`, {
+				headers: { 'User-Agent': 'hezo' },
+				signal: AbortSignal.timeout(120_000),
+			}),
+			fetch(`${base}/SHA256SUMS`, {
+				headers: { 'User-Agent': 'hezo' },
+				signal: AbortSignal.timeout(30_000),
+			}),
+		]);
+		if (!binRes.ok) throw new Error(`asset download failed: HTTP ${binRes.status}`);
+		if (!sumsRes.ok) throw new Error(`SHA256SUMS download failed: HTTP ${sumsRes.status}`);
+
+		const bytes = Buffer.from(await binRes.arrayBuffer());
+		const expected = expectedSha(await sumsRes.text(), asset);
+		if (!expected) throw new Error(`no SHA256 entry for ${asset}`);
+		const actual = createHash('sha256').update(bytes).digest('hex');
+		if (!timingSafeHexEqual(actual, expected))
+			throw new Error('SHA256 mismatch — refusing to stage');
+
+		const staged = stagedPath(dataDir);
+		await writeFile(staged, bytes);
+		if (process.platform !== 'win32') await chmod(staged, 0o755);
+		if (process.platform === 'darwin') await stripQuarantine(staged);
+
+		await writeState(dataDir, { state: UpdateState.Staged, targetVersion: version, asset });
+		log.info(`Staged update ${version} (${asset}, ${bytes.length} bytes)`);
+	} catch (err) {
+		await writeState(dataDir, {
+			state: UpdateState.Error,
+			targetVersion: version,
+			asset,
+			error: err instanceof Error ? err.message : String(err),
+		});
+		await rm(stagedPath(dataDir), { force: true }).catch(() => {});
+		throw err;
+	}
+}
+
+async function clearStaging(dataDir: string): Promise<void> {
+	await rm(updateDir(dataDir), { recursive: true, force: true }).catch(() => {});
+}
+
+/**
+ * Swap the staged binary in over `targetPath` (defaults to the running
+ * executable) and clear staging. Called by the supervisor while the worker is
+ * down, so the target file is never busy/locked.
+ *
+ * - Copies staged → a temp file *adjacent to the target* first, so the final
+ *   move is a same-filesystem rename (atomic; avoids `EXDEV`).
+ * - Unix: a single atomic `rename` replaces the file.
+ * - Windows: the live `.exe` is locked, so rename it aside, move the new binary
+ *   into place, verify, and roll back on failure.
+ *
+ * `targetPath` is injectable so the swap logic is unit-testable against a temp dir.
+ */
+export async function applyStagedUpdate(
+	dataDir: string,
+	targetPath: string = process.execPath,
+): Promise<void> {
+	const staged = stagedPath(dataDir);
+	if (!existsSync(staged)) throw new UpdateApplyError(`no staged binary at ${staged}`);
+
+	const dir = dirname(targetPath);
+	const isWindows = process.platform === 'win32' || targetPath.toLowerCase().endsWith('.exe');
+	const tmpAdjacent = join(dir, `.hezo-update-tmp${isWindows ? '.exe' : ''}`);
+
+	try {
+		await copyFile(staged, tmpAdjacent);
+		if (!isWindows) await chmod(tmpAdjacent, 0o755);
+
+		if (isWindows) {
+			const backup = join(dir, `${basename(targetPath, '.exe')}-old-${HEZO_VERSION}.exe`);
+			await rm(backup, { force: true }).catch(() => {});
+			await rename(targetPath, backup); // permitted while running
+			try {
+				await rename(tmpAdjacent, targetPath);
+				const st = await stat(targetPath);
+				if (st.size === 0) throw new Error('replaced binary is empty');
+			} catch (err) {
+				// Roll back: restore the original so we never leave a missing/partial exe.
+				await rename(backup, targetPath).catch(() => {});
+				throw err;
+			}
+		} else {
+			await rename(tmpAdjacent, targetPath); // atomic same-FS replace
+		}
+
+		await clearStaging(dataDir);
+		log.info(`Applied staged update over ${targetPath}`);
+	} catch (err) {
+		await rm(tmpAdjacent, { force: true }).catch(() => {});
+		const code = (err as NodeJS.ErrnoException).code;
+		if (code === 'EACCES' || code === 'EPERM') {
+			throw new UpdateApplyError(
+				`cannot replace ${targetPath} (${code}) — the binary's directory is not writable by this user`,
+			);
+		}
+		throw err instanceof UpdateApplyError ? err : new UpdateApplyError(String(err));
+	}
+}
+
+/**
+ * Remove stale `<name>-old-<ver>.exe` files left by a previous Windows swap. The
+ * old supervisor keeps its renamed file locked until the next full restart, so
+ * cleanup happens on the following supervisor start. No-op off Windows.
+ */
+export async function sweepStaleBinaries(targetPath: string = process.execPath): Promise<void> {
+	if (process.platform !== 'win32') return;
+	const dir = dirname(targetPath);
+	const prefix = `${basename(targetPath, '.exe')}-old-`;
+	try {
+		for (const f of await readdir(dir)) {
+			if (f.startsWith(prefix) && f.toLowerCase().endsWith('.exe')) {
+				await rm(join(dir, f), { force: true }).catch(() => {});
+			}
+		}
+	} catch {
+		// directory unreadable — nothing to sweep.
+	}
+}

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -56,7 +56,7 @@ import { tasksRoutes } from './routes/tasks';
 import { teamTemplatesRoutes } from './routes/team-templates';
 import { teamsRoutes } from './routes/teams';
 import { uiStateRoutes } from './routes/ui-state';
-import { updatesRoutes } from './routes/updates';
+import { buildUpdatesRoutes } from './routes/updates';
 import { AuthChallengeStore } from './services/auth-challenges';
 import { CeoSessionManager } from './services/ceo-session-manager';
 import { ContainerLogStreamer } from './services/container-logs';
@@ -80,6 +80,8 @@ export type MasterKeyState = 'unset' | 'locked' | 'unlocked';
 export interface AppConfig {
 	dataDir: string;
 	webUrl: string;
+	/** A master key was configured at startup (env/CLI), so the instance auto-unlocks after a restart. */
+	autoUnlock?: boolean;
 }
 
 export interface StartupResult {
@@ -215,6 +217,7 @@ export async function startup(config: HezoConfig): Promise<StartupResult> {
 		{
 			dataDir: config.dataDir,
 			webUrl: config.webUrl,
+			autoUnlock: config.masterKey !== undefined,
 		},
 		docker,
 		wsManager,
@@ -400,7 +403,7 @@ export function buildApp(
 	app.route('/api', oauthRoutes);
 	app.route('/api', previewRoutes);
 	app.route('/api', searchRoutes);
-	app.route('/api', updatesRoutes);
+	app.route('/api', buildUpdatesRoutes({ autoUnlock: config.autoUnlock ?? false }));
 	app.route('/api', ceoChatRoutes);
 
 	// Frontend (SPA) serving. The compiled binary serves from the in-memory

--- a/packages/server/src/supervisor.ts
+++ b/packages/server/src/supervisor.ts
@@ -1,0 +1,63 @@
+import { UPDATE_RESTART_EXIT_CODE } from '@hezo/shared';
+import { logger } from './logger';
+import { applyStagedUpdate, sweepStaleBinaries, UpdateApplyError } from './services/updater';
+
+const log = logger.child('supervisor');
+
+/**
+ * Run as a thin supervisor over the real server. Spawns the worker (this same
+ * binary with `HEZO_WORKER=1`), forwards termination signals to it, and on the
+ * worker's restart-sentinel exit applies the staged update and relaunches. Any
+ * other exit code is propagated unchanged, so external restart policies
+ * (systemd/launchd/Docker) behave exactly as before the supervisor existed.
+ *
+ * Never returns — it loops until the worker exits non-sentinel, then exits the
+ * process with the worker's code.
+ */
+export async function runSupervisor(dataDir: string): Promise<never> {
+	// Clean up any binary left renamed-aside by a previous Windows swap.
+	await sweepStaleBinaries();
+	log.info('Supervisor starting; launching worker');
+
+	for (;;) {
+		// Re-exec this binary with the same user args (argv[0]=runtime, argv[1]=entry).
+		const child = Bun.spawn([process.execPath, ...process.argv.slice(2)], {
+			env: { ...process.env, HEZO_WORKER: '1' },
+			stdin: 'inherit',
+			stdout: 'inherit',
+			stderr: 'inherit',
+		});
+
+		const forward = (sig: NodeJS.Signals) => () => {
+			try {
+				child.kill(sig);
+			} catch {
+				// child already exited
+			}
+		};
+		const onTerm = forward('SIGTERM');
+		const onInt = forward('SIGINT');
+		process.on('SIGTERM', onTerm);
+		process.on('SIGINT', onInt);
+
+		const code = await child.exited;
+
+		process.off('SIGTERM', onTerm);
+		process.off('SIGINT', onInt);
+
+		if (code === UPDATE_RESTART_EXIT_CODE) {
+			log.info('Worker requested update restart; applying staged update');
+			try {
+				await applyStagedUpdate(dataDir);
+				log.info('Update applied; relaunching worker on the new binary');
+			} catch (err) {
+				const msg = err instanceof UpdateApplyError ? err.message : String(err);
+				log.error(`Update apply failed; relaunching the previous version: ${msg}`);
+			}
+			continue; // relaunch — new binary on success, previous binary on failure
+		}
+
+		log.info(`Worker exited with code ${code}; supervisor exiting`);
+		process.exit(code ?? 0);
+	}
+}

--- a/packages/server/test/bun/updater.bun.test.ts
+++ b/packages/server/test/bun/updater.bun.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { existsSync } from 'node:fs';
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { UpdateState } from '@hezo/shared';
@@ -8,8 +8,24 @@ import { applyStagedUpdate } from '../../src/services/updater';
 
 // Runtime tier: the supervisor detects the restart sentinel via `Bun.spawn`'s
 // exit-code propagation, and `applyStagedUpdate` swaps the binary with node:fs
-// primitives. vitest runs under Node, so these contracts are pinned here on the
-// production Bun runtime where the supervisor actually runs.
+// primitives whose behaviour depends on the host OS. vitest runs under Node, so
+// these contracts are pinned here on the production Bun runtime.
+//
+// The swap test below is PLATFORM-ADAPTIVE: it builds a real, running executable
+// for whatever OS you run it on and replaces it in place, so running
+// `bun test test/bun/updater.bun.test.ts` on Windows exercises the Windows
+// rename-trick, and on macOS/Linux the atomic rename — each against the real
+// file-locking semantics that production hits. (Branch-level coverage of both
+// strategies on any OS lives in the fast vitest tier, test/updater.test.ts.)
+
+async function seedStaged(dataDir: string, content: string): Promise<void> {
+	await mkdir(join(dataDir, '.update'), { recursive: true });
+	await writeFile(join(dataDir, '.update', 'staged'), content);
+	await writeFile(
+		join(dataDir, '.update', 'state.json'),
+		JSON.stringify({ state: UpdateState.Staged, targetVersion: '9.9.9' }),
+	);
+}
 
 describe('Bun.spawn exit-code propagation (supervisor sentinel routing)', () => {
 	async function spawnExit(code: number): Promise<number> {
@@ -33,44 +49,46 @@ describe('Bun.spawn exit-code propagation (supervisor sentinel routing)', () => 
 	});
 });
 
-describe('applyStagedUpdate on the Bun runtime', () => {
-	async function seed(dataDir: string, content: string): Promise<void> {
-		await mkdir(join(dataDir, '.update'), { recursive: true });
-		await writeFile(join(dataDir, '.update', 'staged'), content);
-		await writeFile(
-			join(dataDir, '.update', 'state.json'),
-			JSON.stringify({ state: UpdateState.Staged, targetVersion: '9.9.9' }),
-		);
-	}
+describe('applyStagedUpdate replaces a live binary on this platform', () => {
+	// Runs the real swap strategy for `process.platform` against a genuine,
+	// currently-executing binary — the production condition the unit tests can't
+	// reproduce (Windows locks the running .exe; Unix holds the executing inode).
+	test(`swaps a running ${process.platform} executable in place`, async () => {
+		const dataDir = await mkdtemp(join(tmpdir(), 'hezo-live-data-'));
+		const binDir = await mkdtemp(join(tmpdir(), 'hezo-live-bin-'));
+		const isWindows = process.platform === 'win32';
+		const target = join(binDir, isWindows ? 'hezo.exe' : 'hezo');
+		let child: ReturnType<typeof Bun.spawn> | undefined;
 
-	test('Unix atomic rename replaces the target binary', async () => {
-		const dataDir = await mkdtemp(join(tmpdir(), 'hezo-bun-apply-'));
-		const binDir = await mkdtemp(join(tmpdir(), 'hezo-bun-bin-'));
-		const target = join(binDir, 'hezo');
 		try {
-			await writeFile(target, 'OLD');
-			await seed(dataDir, 'NEW');
+			// A real executable for THIS platform: a copy of the running runtime.
+			await copyFile(process.execPath, target);
+			if (!isWindows) await chmod(target, 0o755);
+
+			// Keep it running so the OS holds the file exactly as it would the live
+			// server binary (locked on Windows, an executing inode on Unix).
+			const sleeper = join(binDir, 'stay-alive.js');
+			await writeFile(sleeper, 'setTimeout(() => {}, 60_000);');
+			child = Bun.spawn([target, sleeper], { stdout: 'ignore', stderr: 'ignore' });
+			// Give it a moment to actually start executing the target file.
+			await new Promise((resolve) => setTimeout(resolve, 750));
+			expect(child.pid).toBeGreaterThan(0);
+			expect(child.exitCode).toBeNull(); // genuinely running
+
+			await seedStaged(dataDir, 'REPLACED BINARY');
+			// process.platform selects the right strategy for this OS.
 			await applyStagedUpdate(dataDir, target);
-			expect(await readFile(target, 'utf8')).toBe('NEW');
+
+			// The on-disk binary is the new one, and staging is cleared.
+			expect(await readFile(target, 'utf8')).toBe('REPLACED BINARY');
 			expect(existsSync(join(dataDir, '.update'))).toBe(false);
+			// The already-running process is untouched by the swap.
+			expect(child.exitCode).toBeNull();
 		} finally {
-			await rm(dataDir, { recursive: true, force: true });
-			await rm(binDir, { recursive: true, force: true });
-		}
-	});
-
-	test('Windows rename-trick branch replaces the .exe target', async () => {
-		const dataDir = await mkdtemp(join(tmpdir(), 'hezo-bun-applyw-'));
-		const binDir = await mkdtemp(join(tmpdir(), 'hezo-bun-binw-'));
-		const target = join(binDir, 'hezo.exe');
-		try {
-			await writeFile(target, 'OLD');
-			await seed(dataDir, 'NEW');
-			await applyStagedUpdate(dataDir, target);
-			expect(await readFile(target, 'utf8')).toBe('NEW');
-		} finally {
-			await rm(dataDir, { recursive: true, force: true });
-			await rm(binDir, { recursive: true, force: true });
+			child?.kill();
+			await child?.exited;
+			await rm(dataDir, { recursive: true, force: true }).catch(() => {});
+			await rm(binDir, { recursive: true, force: true }).catch(() => {});
 		}
 	});
 });

--- a/packages/server/test/bun/updater.bun.test.ts
+++ b/packages/server/test/bun/updater.bun.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from 'bun:test';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { UpdateState } from '@hezo/shared';
+import { applyStagedUpdate } from '../../src/services/updater';
+
+// Runtime tier: the supervisor detects the restart sentinel via `Bun.spawn`'s
+// exit-code propagation, and `applyStagedUpdate` swaps the binary with node:fs
+// primitives. vitest runs under Node, so these contracts are pinned here on the
+// production Bun runtime where the supervisor actually runs.
+
+describe('Bun.spawn exit-code propagation (supervisor sentinel routing)', () => {
+	async function spawnExit(code: number): Promise<number> {
+		const dir = await mkdtemp(join(tmpdir(), 'hezo-spawn-'));
+		const script = join(dir, 'exit.js');
+		await writeFile(script, `process.exit(${code});`);
+		try {
+			const child = Bun.spawn([process.execPath, script], { stdout: 'ignore', stderr: 'ignore' });
+			return await child.exited;
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	}
+
+	test('propagates the restart sentinel code 75', async () => {
+		expect(await spawnExit(75)).toBe(75);
+	});
+
+	test('propagates a normal exit code 0', async () => {
+		expect(await spawnExit(0)).toBe(0);
+	});
+});
+
+describe('applyStagedUpdate on the Bun runtime', () => {
+	async function seed(dataDir: string, content: string): Promise<void> {
+		await mkdir(join(dataDir, '.update'), { recursive: true });
+		await writeFile(join(dataDir, '.update', 'staged'), content);
+		await writeFile(
+			join(dataDir, '.update', 'state.json'),
+			JSON.stringify({ state: UpdateState.Staged, targetVersion: '9.9.9' }),
+		);
+	}
+
+	test('Unix atomic rename replaces the target binary', async () => {
+		const dataDir = await mkdtemp(join(tmpdir(), 'hezo-bun-apply-'));
+		const binDir = await mkdtemp(join(tmpdir(), 'hezo-bun-bin-'));
+		const target = join(binDir, 'hezo');
+		try {
+			await writeFile(target, 'OLD');
+			await seed(dataDir, 'NEW');
+			await applyStagedUpdate(dataDir, target);
+			expect(await readFile(target, 'utf8')).toBe('NEW');
+			expect(existsSync(join(dataDir, '.update'))).toBe(false);
+		} finally {
+			await rm(dataDir, { recursive: true, force: true });
+			await rm(binDir, { recursive: true, force: true });
+		}
+	});
+
+	test('Windows rename-trick branch replaces the .exe target', async () => {
+		const dataDir = await mkdtemp(join(tmpdir(), 'hezo-bun-applyw-'));
+		const binDir = await mkdtemp(join(tmpdir(), 'hezo-bun-binw-'));
+		const target = join(binDir, 'hezo.exe');
+		try {
+			await writeFile(target, 'OLD');
+			await seed(dataDir, 'NEW');
+			await applyStagedUpdate(dataDir, target);
+			expect(await readFile(target, 'utf8')).toBe('NEW');
+		} finally {
+			await rm(dataDir, { recursive: true, force: true });
+			await rm(binDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/server/test/updater.test.ts
+++ b/packages/server/test/updater.test.ts
@@ -1,0 +1,139 @@
+import { createHash } from 'node:crypto';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { UpdateState } from '@hezo/shared';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+	applyStagedUpdate,
+	currentAssetName,
+	downloadAndStage,
+	readUpdateState,
+} from '../src/services/updater';
+
+async function tmp(prefix: string): Promise<string> {
+	return mkdtemp(join(tmpdir(), prefix));
+}
+
+describe('currentAssetName', () => {
+	it('maps platform/arch to the release asset name', () => {
+		expect(currentAssetName('linux', 'x64')).toBe('hezo-linux-x64');
+		expect(currentAssetName('linux', 'arm64')).toBe('hezo-linux-arm64');
+		expect(currentAssetName('darwin', 'arm64')).toBe('hezo-darwin-arm64');
+		expect(currentAssetName('win32', 'x64')).toBe('hezo-windows-x64.exe');
+	});
+
+	it('throws on unsupported platform/arch', () => {
+		expect(() => currentAssetName('freebsd', 'x64')).toThrow();
+		expect(() => currentAssetName('linux', 'mips')).toThrow();
+		expect(() => currentAssetName('win32', 'arm64')).toThrow();
+	});
+});
+
+describe('downloadAndStage', () => {
+	afterEach(() => vi.restoreAllMocks());
+
+	function mockRelease(assetBytes: Buffer, sumsText: string) {
+		vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+			const url = String(input);
+			if (url.endsWith('/SHA256SUMS')) {
+				return new Response(sumsText, { status: 200 });
+			}
+			return new Response(assetBytes, { status: 200 });
+		});
+	}
+
+	it('verifies the sha256 and stages the binary', async () => {
+		const dir = await tmp('hezo-stage-ok-');
+		try {
+			const bytes = Buffer.from('a brand new hezo binary');
+			const asset = currentAssetName();
+			const sha = createHash('sha256').update(bytes).digest('hex');
+			mockRelease(bytes, `${sha}  ${asset}\n`);
+
+			await downloadAndStage('9.9.9', dir);
+
+			const staged = await readFile(join(dir, '.update', 'staged'));
+			expect(Buffer.compare(staged, bytes)).toBe(0);
+			const state = await readUpdateState(dir);
+			expect(state.state).toBe(UpdateState.Staged);
+			expect(state.targetVersion).toBe('9.9.9');
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	it('rejects a tampered binary and records an error state', async () => {
+		const dir = await tmp('hezo-stage-bad-');
+		try {
+			const bytes = Buffer.from('a brand new hezo binary');
+			const asset = currentAssetName();
+			mockRelease(bytes, `${'0'.repeat(64)}  ${asset}\n`); // wrong hash
+
+			await expect(downloadAndStage('9.9.9', dir)).rejects.toThrow(/SHA256/);
+
+			expect(existsSync(join(dir, '.update', 'staged'))).toBe(false);
+			const state = await readUpdateState(dir);
+			expect(state.state).toBe(UpdateState.Error);
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe('applyStagedUpdate', () => {
+	async function seedStaged(dataDir: string, content: string): Promise<void> {
+		await mkdir(join(dataDir, '.update'), { recursive: true });
+		await writeFile(join(dataDir, '.update', 'staged'), content);
+		await writeFile(
+			join(dataDir, '.update', 'state.json'),
+			JSON.stringify({ state: UpdateState.Staged, targetVersion: '9.9.9' }),
+		);
+	}
+
+	it('atomically replaces the target binary (Unix rename) and clears staging', async () => {
+		const dataDir = await tmp('hezo-apply-unix-');
+		const binDir = await tmp('hezo-bin-unix-');
+		const target = join(binDir, 'hezo');
+		try {
+			await writeFile(target, 'OLD BINARY');
+			await seedStaged(dataDir, 'NEW BINARY');
+
+			await applyStagedUpdate(dataDir, target);
+
+			expect(await readFile(target, 'utf8')).toBe('NEW BINARY');
+			expect(existsSync(join(dataDir, '.update'))).toBe(false);
+		} finally {
+			await rm(dataDir, { recursive: true, force: true });
+			await rm(binDir, { recursive: true, force: true });
+		}
+	});
+
+	it('replaces the target via the Windows rename-trick branch (.exe target)', async () => {
+		const dataDir = await tmp('hezo-apply-win-');
+		const binDir = await tmp('hezo-bin-win-');
+		const target = join(binDir, 'hezo.exe');
+		try {
+			await writeFile(target, 'OLD BINARY');
+			await seedStaged(dataDir, 'NEW BINARY');
+
+			await applyStagedUpdate(dataDir, target);
+
+			expect(await readFile(target, 'utf8')).toBe('NEW BINARY');
+			expect(existsSync(join(dataDir, '.update'))).toBe(false);
+		} finally {
+			await rm(dataDir, { recursive: true, force: true });
+			await rm(binDir, { recursive: true, force: true });
+		}
+	});
+
+	it('throws when there is no staged binary', async () => {
+		const dataDir = await tmp('hezo-apply-none-');
+		try {
+			await expect(applyStagedUpdate(dataDir, join(dataDir, 'hezo'))).rejects.toThrow();
+		} finally {
+			await rm(dataDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/server/test/updates-routes.test.ts
+++ b/packages/server/test/updates-routes.test.ts
@@ -1,0 +1,85 @@
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import type { Env } from '../src/lib/types';
+import { signAdminJwt } from '../src/middleware/auth';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp } from './helpers/app';
+
+describe('update routes (status / download / apply)', () => {
+	let app: Hono<Env>;
+	let db: Awaited<ReturnType<typeof createTestApp>>['db'];
+	let superToken: string;
+	let userToken: string;
+
+	beforeAll(async () => {
+		const ctx = await createTestApp();
+		app = ctx.app;
+		db = ctx.db;
+		superToken = ctx.token;
+		// A second, non-superuser user.
+		const u = await db.query<{ id: string }>(
+			"INSERT INTO users (display_name, is_superuser) VALUES ('Member', false) RETURNING id",
+		);
+		userToken = await signAdminJwt(ctx.masterKeyManager, u.rows[0].id);
+
+		// Keep the GitHub release check off the network and deterministic.
+		vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					tag_name: '9.9.9',
+					html_url: 'https://github.com/hezo-ai/hezo/releases/9.9.9',
+				}),
+				{ status: 200, headers: { 'Content-Type': 'application/json' } },
+			),
+		);
+	});
+
+	afterAll(async () => {
+		vi.restoreAllMocks();
+		await safeClose(db);
+	});
+
+	it('GET /updates/status returns lifecycle + autoUnlock for any authed user', async () => {
+		const res = await app.request('/api/updates/status', { headers: authHeader(userToken) });
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.updateAvailable).toBe(true);
+		expect(body.state).toBe('idle');
+		// createTestApp configures no master key, so the instance does not auto-unlock.
+		expect(body.autoUnlock).toBe(false);
+		// Tests don't run as a supervised compiled binary.
+		expect(body.canApply).toBe(false);
+	});
+
+	it('POST /updates/download requires superuser', async () => {
+		const res = await app.request('/api/updates/download', {
+			method: 'POST',
+			headers: authHeader(userToken),
+		});
+		expect(res.status).toBe(403);
+	});
+
+	it('POST /updates/download is 409 when auto-update is unavailable (not supervised)', async () => {
+		const res = await app.request('/api/updates/download', {
+			method: 'POST',
+			headers: authHeader(superToken),
+		});
+		expect(res.status).toBe(409);
+	});
+
+	it('POST /updates/apply requires superuser', async () => {
+		const res = await app.request('/api/updates/apply', {
+			method: 'POST',
+			headers: authHeader(userToken),
+		});
+		expect(res.status).toBe(403);
+	});
+
+	it('POST /updates/apply is 409 when auto-update is unavailable (not supervised)', async () => {
+		const res = await app.request('/api/updates/apply', {
+			method: 'POST',
+			headers: authHeader(superToken),
+		});
+		expect(res.status).toBe(409);
+	});
+});

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -176,6 +176,25 @@ export interface SearchResult {
 	docSlug?: string;
 }
 
+/**
+ * Exit code the server (worker) uses to tell its supervisor "swap in the staged
+ * binary and relaunch me" rather than exit for good. Any other exit code is
+ * propagated by the supervisor so existing restart policies behave as before.
+ * 75 = EX_TEMPFAIL in sysexits(3), chosen to avoid clashing with 0/1/2.
+ */
+export const UPDATE_RESTART_EXIT_CODE = 75;
+
+/** Lifecycle of a staged self-update, surfaced by `GET /updates/status`. */
+export const UpdateState = {
+	Idle: 'idle',
+	Checking: 'checking',
+	Downloading: 'downloading',
+	Staged: 'staged',
+	Applying: 'applying',
+	Error: 'error',
+} as const;
+export type UpdateState = (typeof UpdateState)[keyof typeof UpdateState];
+
 export const ATTACHMENT_MAX_BYTES = 10 * 1024 * 1024;
 export const ATTACHMENT_SIGNED_URL_TTL_SECONDS = 3600;
 

--- a/packages/web/src/components/update-banner.tsx
+++ b/packages/web/src/components/update-banner.tsx
@@ -1,6 +1,10 @@
+import { UpdateState } from '@hezo/shared';
 import { X } from 'lucide-react';
 import { useState } from 'react';
-import { useUpdateCheck } from '../hooks/use-update-check';
+import { useMe } from '../hooks/use-me';
+import { useApplyUpdate, useDownloadUpdate, useUpdateStatus } from '../hooks/use-update-check';
+import { ConfirmDialog } from './ui/confirm-dialog';
+import { UpdateRestartOverlay } from './update-restart-overlay';
 
 const DISMISS_KEY = 'hezo:update-dismissed';
 
@@ -13,13 +17,24 @@ function readDismissed(): string | null {
 }
 
 /**
- * Dismissible "update available" banner. A newer release is detected by the
- * server (`/api/updates/latest`); clicking through opens the GitHub Release to
- * download. Dismissal is remembered per-version so it won't nag for the same one.
+ * Sticky bottom "update available" bar. When this instance can apply-and-restart
+ * (a supervised compiled binary) and the caller is a superuser, it offers an
+ * in-app "Update & restart" flow — staging the binary, then a confirmation that
+ * warns about the master-key re-unlock, then the restart overlay. Otherwise it
+ * falls back to a link to the GitHub Release. Dismissal is per-version.
  */
 export function UpdateBanner() {
-	const { data } = useUpdateCheck();
+	const { data } = useUpdateStatus();
+	const { data: me } = useMe();
+	const download = useDownloadUpdate();
+	const apply = useApplyUpdate();
+	const [applying, setApplying] = useState(false);
+	const [confirmOpen, setConfirmOpen] = useState(false);
 	const [dismissed, setDismissed] = useState<string | null>(readDismissed);
+
+	if (applying) {
+		return <UpdateRestartOverlay targetVersion={data?.targetVersion ?? data?.latest ?? null} />;
+	}
 
 	if (!data?.updateAvailable || !data.latest || dismissed === data.latest) return null;
 
@@ -32,25 +47,67 @@ export function UpdateBanner() {
 		setDismissed(data.latest);
 	};
 
+	const canApply = data.canApply && me?.is_superuser === true;
+
+	const confirmDescription = (
+		<>
+			Hezo will shut down and restart on <span className="font-medium">{data.latest}</span>.
+			In-flight agent runs are paused and resume automatically.
+			{!data.autoUnlock && (
+				<>
+					{' '}
+					<span className="font-medium text-text-1">
+						You'll need your 12-word master key to unlock Hezo again once it restarts.
+					</span>
+				</>
+			)}
+		</>
+	);
+
 	return (
 		<div
 			data-testid="update-banner"
-			className="flex flex-col sm:flex-row sm:items-center gap-2 px-4 py-2 text-[13px] bg-surface border-b border-border text-text-1"
+			className="sticky bottom-0 z-40 flex flex-col sm:flex-row sm:items-center gap-2 px-4 py-2 text-[13px] bg-surface border-t border-border text-text-1"
 		>
 			<span className="flex-1">
 				Hezo <span className="font-medium">{data.latest}</span> is available — you're on{' '}
 				{data.current}.
 			</span>
 			<div className="flex items-center gap-3">
-				{data.url && (
-					<a
-						href={data.url}
-						target="_blank"
-						rel="noreferrer"
-						className="font-medium text-text-1 hover:underline"
-					>
-						Download
-					</a>
+				{canApply ? (
+					data.state === UpdateState.Staged ? (
+						<button
+							type="button"
+							data-testid="update-restart-button"
+							onClick={() => setConfirmOpen(true)}
+							className="font-medium text-inverse-fg bg-inverse hover:opacity-85 px-2.5 py-1 rounded-md"
+						>
+							Update &amp; restart
+						</button>
+					) : data.state === UpdateState.Downloading ? (
+						<span className="text-text-2">Preparing update…</span>
+					) : (
+						<button
+							type="button"
+							data-testid="update-prepare-button"
+							onClick={() => download.mutate()}
+							disabled={download.isPending}
+							className="font-medium text-text-1 hover:underline disabled:opacity-50"
+						>
+							{download.isPending ? 'Preparing…' : 'Prepare update'}
+						</button>
+					)
+				) : (
+					data.url && (
+						<a
+							href={data.url}
+							target="_blank"
+							rel="noreferrer"
+							className="font-medium text-text-1 hover:underline"
+						>
+							Download
+						</a>
+					)
 				)}
 				<button
 					type="button"
@@ -61,6 +118,18 @@ export function UpdateBanner() {
 					<X className="w-4 h-4" />
 				</button>
 			</div>
+
+			<ConfirmDialog
+				open={confirmOpen}
+				onOpenChange={setConfirmOpen}
+				title="Update & restart Hezo?"
+				description={confirmDescription}
+				confirmLabel="Update & restart"
+				onConfirm={async () => {
+					await apply.mutateAsync();
+					setApplying(true);
+				}}
+			/>
 		</div>
 	);
 }

--- a/packages/web/src/components/update-restart-overlay.tsx
+++ b/packages/web/src/components/update-restart-overlay.tsx
@@ -1,0 +1,61 @@
+import { Loader2 } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * Full-screen overlay shown while the server restarts onto a new binary. Polls
+ * `/api/status` (the same public endpoint the app shell gates on); once the
+ * server has gone down and come back, it reloads the page. A locked return lands
+ * on the master-key gate via `AppShell`, which is why the copy reminds the
+ * operator they'll need their master key.
+ */
+export function UpdateRestartOverlay({ targetVersion }: { targetVersion: string | null }) {
+	const [reachableAgain, setReachableAgain] = useState(false);
+	const wentDown = useRef(false);
+
+	useEffect(() => {
+		let cancelled = false;
+		let timer: ReturnType<typeof setTimeout>;
+
+		const poll = async () => {
+			try {
+				const res = await fetch('/api/status', { cache: 'no-store' });
+				if (res.ok && wentDown.current) {
+					// Server went away and is back — reload onto the new version.
+					if (!cancelled) {
+						setReachableAgain(true);
+						window.location.reload();
+					}
+					return;
+				}
+				if (!res.ok) wentDown.current = true;
+			} catch {
+				// Network error → the worker is down mid-restart.
+				wentDown.current = true;
+			}
+			if (!cancelled) timer = setTimeout(poll, 1500);
+		};
+
+		timer = setTimeout(poll, 1500);
+		return () => {
+			cancelled = true;
+			clearTimeout(timer);
+		};
+	}, []);
+
+	return (
+		<div
+			data-testid="update-restart-overlay"
+			className="fixed inset-0 z-[100] flex flex-col items-center justify-center gap-4 bg-[var(--overlay)] backdrop-blur-sm p-6 text-center"
+		>
+			<Loader2 className="w-8 h-8 animate-spin text-text-1" />
+			<div className="text-base font-semibold text-text-1">
+				{reachableAgain ? 'Reloading…' : 'Updating Hezo…'}
+			</div>
+			<p className="max-w-sm text-[13px] text-text-2 leading-relaxed">
+				{targetVersion ? `Restarting onto ${targetVersion}. ` : 'Restarting. '}
+				In-flight agent runs are paused and resume automatically. When Hezo comes back you'll need
+				your 12-word master key to unlock it again.
+			</p>
+		</div>
+	);
+}

--- a/packages/web/src/hooks/use-update-check.ts
+++ b/packages/web/src/hooks/use-update-check.ts
@@ -1,4 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
+import type { UpdateState } from '@hezo/shared';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { api } from '../lib/api';
 import { queryKeys } from '../lib/query-keys';
 
@@ -7,6 +8,17 @@ export interface UpdateInfo {
 	latest: string | null;
 	updateAvailable: boolean;
 	url: string | null;
+}
+
+export interface UpdateStatusInfo extends UpdateInfo {
+	/** Lifecycle of any staged update on the server. */
+	state: UpdateState;
+	targetVersion: string | null;
+	error: string | null;
+	/** A master key is configured, so the instance auto-unlocks after a restart. */
+	autoUnlock: boolean;
+	/** The server can actually apply-and-restart (supervised compiled binary). */
+	canApply: boolean;
 }
 
 /**
@@ -20,5 +32,41 @@ export function useUpdateCheck() {
 		staleTime: 60 * 60 * 1000,
 		gcTime: 60 * 60 * 1000,
 		retry: false,
+	});
+}
+
+/**
+ * Latest-release info plus the staged-update lifecycle and whether this instance
+ * can apply-and-restart. Drives the "Update & restart" affordance.
+ */
+export function useUpdateStatus() {
+	return useQuery({
+		queryKey: queryKeys.updateStatus(),
+		queryFn: () => api.get<UpdateStatusInfo>('/api/updates/status'),
+		staleTime: 60 * 60 * 1000,
+		gcTime: 60 * 60 * 1000,
+		retry: false,
+	});
+}
+
+/** Kick a background download+verify+stage of the latest release (superuser). */
+export function useDownloadUpdate() {
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: () =>
+			api.post<{ state: UpdateState; targetVersion: string }>('/api/updates/download'),
+		onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.updateStatus() }),
+	});
+}
+
+/**
+ * Apply the staged update: the server shuts down and exits with the restart
+ * sentinel, the supervisor swaps the binary and relaunches. The response lands
+ * before the process exits; the caller then shows the restart overlay.
+ */
+export function useApplyUpdate() {
+	return useMutation({
+		mutationFn: () =>
+			api.post<{ state: UpdateState; targetVersion: string | null }>('/api/updates/apply'),
 	});
 }

--- a/packages/web/src/lib/query-keys.ts
+++ b/packages/web/src/lib/query-keys.ts
@@ -21,6 +21,7 @@ export const queryKeys = {
 	me: () => ['me'],
 	status: () => ['status'],
 	updateCheck: () => ['update-check'],
+	updateStatus: () => ['update-status'],
 	teamTemplates: () => ['team-templates'],
 	aiProviderModels: (configId: string) => ['ai-providers', configId, 'models'],
 	instanceAuditLog: (filters: KeyParam) => ['instance', 'audit-log', filters],

--- a/packages/web/src/routes/__root.tsx
+++ b/packages/web/src/routes/__root.tsx
@@ -178,8 +178,8 @@ function ShellChrome() {
 						</div>
 					)}
 					<main ref={mainRef} className="flex-1 min-w-0 overflow-auto relative">
-						<UpdateBanner />
 						<Outlet />
+						<UpdateBanner />
 					</main>
 				</div>
 			</div>

--- a/packages/web/test/update-banner.test.tsx
+++ b/packages/web/test/update-banner.test.tsx
@@ -1,14 +1,29 @@
+import { UpdateState } from '@hezo/shared';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { afterEach, expect, test } from 'vitest';
+import { afterEach, expect, test, vi } from 'vitest';
 import { UpdateBanner } from '../src/components/update-banner';
-import type { UpdateInfo } from '../src/hooks/use-update-check';
+import type { UpdateStatusInfo } from '../src/hooks/use-update-check';
+import { api } from '../src/lib/api';
 
-function renderBanner(data: UpdateInfo) {
+const BASE: UpdateStatusInfo = {
+	current: '0.1.0',
+	latest: '0.2.0',
+	updateAvailable: true,
+	url: 'https://github.com/hezo-ai/hezo/releases/0.2.0',
+	state: UpdateState.Staged,
+	targetVersion: '0.2.0',
+	error: null,
+	autoUnlock: false,
+	canApply: true,
+};
+
+function renderBanner(status: Partial<UpdateStatusInfo> = {}, isSuperuser = true) {
 	const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-	// Seed the cache so the component renders without hitting the network.
-	qc.setQueryData(['update-check'], data);
+	// Seed both caches so the component renders without hitting the network.
+	qc.setQueryData(['update-status'], { ...BASE, ...status });
+	qc.setQueryData(['me'], { type: 'admin', is_superuser: isSuperuser });
 	return render(
 		<QueryClientProvider client={qc}>
 			<UpdateBanner />
@@ -18,38 +33,55 @@ function renderBanner(data: UpdateInfo) {
 
 afterEach(() => {
 	localStorage.clear();
+	vi.restoreAllMocks();
 });
 
-test('shows when an update is available and links to the release', () => {
-	const { getByTestId, getByText } = renderBanner({
-		current: '0.1.0',
-		latest: '0.2.0',
-		updateAvailable: true,
-		url: 'https://github.com/hezo-ai/hezo/releases/0.2.0',
-	});
+test('hidden when no update is available', () => {
+	const { queryByTestId } = renderBanner({ updateAvailable: false, latest: '0.1.0' });
+	expect(queryByTestId('update-banner')).toBeNull();
+});
+
+test('non-superuser / non-supervised falls back to a release download link', () => {
+	const { getByTestId, getByText, queryByTestId } = renderBanner({ canApply: false }, false);
 	expect(getByTestId('update-banner')).toBeTruthy();
+	expect(queryByTestId('update-restart-button')).toBeNull();
 	const link = getByText('Download') as HTMLAnchorElement;
 	expect(link.getAttribute('href')).toBe('https://github.com/hezo-ai/hezo/releases/0.2.0');
 });
 
-test('hidden when no update is available', () => {
-	const { queryByTestId } = renderBanner({
-		current: '0.1.0',
-		latest: '0.1.0',
-		updateAvailable: false,
-		url: null,
-	});
-	expect(queryByTestId('update-banner')).toBeNull();
+test('Update & restart asks for confirmation (with master-key warning) before applying', async () => {
+	const user = userEvent.setup();
+	const postSpy = vi
+		.spyOn(api, 'post')
+		.mockResolvedValue({ state: UpdateState.Applying, targetVersion: '0.2.0' });
+
+	const { getByTestId, findByTestId, queryByTestId } = renderBanner();
+
+	// Clicking the action opens the dialog — it does NOT apply yet.
+	await user.click(getByTestId('update-restart-button'));
+	const dialog = await findByTestId('confirm-dialog');
+	expect(dialog.textContent).toContain('master key');
+	expect(postSpy).not.toHaveBeenCalled();
+	expect(queryByTestId('update-restart-overlay')).toBeNull();
+
+	// Confirming applies and mounts the restart overlay.
+	await user.click(getByTestId('confirm-dialog-confirm'));
+	await waitFor(() => expect(postSpy).toHaveBeenCalledWith('/api/updates/apply'));
+	expect(await findByTestId('update-restart-overlay')).toBeTruthy();
+});
+
+test('confirmation omits the master-key warning when the instance auto-unlocks', async () => {
+	const user = userEvent.setup();
+	vi.spyOn(api, 'post').mockResolvedValue({ state: UpdateState.Applying, targetVersion: '0.2.0' });
+	const { getByTestId, findByTestId } = renderBanner({ autoUnlock: true });
+	await user.click(getByTestId('update-restart-button'));
+	const dialog = await findByTestId('confirm-dialog');
+	expect(dialog.textContent).not.toContain('master key');
 });
 
 test('dismiss hides the banner and remembers the version', async () => {
 	const user = userEvent.setup();
-	const { getByTestId, queryByTestId, getByLabelText } = renderBanner({
-		current: '0.1.0',
-		latest: '0.2.0',
-		updateAvailable: true,
-		url: 'https://github.com/hezo-ai/hezo/releases/0.2.0',
-	});
+	const { getByTestId, queryByTestId, getByLabelText } = renderBanner();
 	expect(getByTestId('update-banner')).toBeTruthy();
 	await user.click(getByLabelText('Dismiss update notification'));
 	expect(queryByTestId('update-banner')).toBeNull();


### PR DESCRIPTION
## What

Implements the self-updating binary designed in `.dev/self-updating-plan.md`: Hezo checks GitHub Releases, downloads + verifies the new binary, and on a superuser-confirmed click swaps it in and restarts onto the new version — driven from the web UI. (This PR began as the design-doc update and now carries the full implementation.)

### Server
- **Supervisor** (`supervisor.ts`) spawns the server as a worker (`HEZO_WORKER=1`), forwards `SIGTERM`/`SIGINT`, and on the restart sentinel (`UPDATE_RESTART_EXIT_CODE = 75`) applies the staged binary and relaunches; any other exit code propagates so systemd/launchd/Docker restart policies are unchanged. The `index.ts` branch is gated on a compiled binary with auto-update enabled, so `bun run dev` and `hezo restore` never supervise.
- **Updater** (`updater.ts`): `currentAssetName`, `downloadAndStage` (download + SHA256 verify + macOS quarantine strip → `<dataDir>/.update/`), `applyStagedUpdate` (Unix atomic `rename`; Windows rename-trick with verify + rollback), plus container detection and `HEZO_DISABLE_AUTO_UPDATE` opt-out.
- **Graceful shutdown** extracted to `runtime-control.ts` (reused by the apply path and the new worker signal handlers).
- **Routes** (`updates.ts`): `GET /updates/status`, `POST /updates/download`, `POST /updates/apply` (superuser, supervised-only); a daily `update-check` cron (`HEZO_UPDATE_CHECK_CRON`) auto-stages so "Update & restart" is instant.

### Frontend
- `useUpdateStatus` / `useDownloadUpdate` / `useApplyUpdate` hooks.
- `UpdateBanner` → sticky bottom bar with an **"Update & restart"** confirmation that **warns the operator they'll need their 12-word master key** to unlock Hezo after the restart (softened when the instance auto-unlocks via `HEZO_MASTER_KEY`), then a full-screen restart overlay that polls `/api/status` and reloads.

### Docs
README highlight, `docs/deployment/self-hosting.md` "Updating", `configuration.md` env vars, and a `.dev/architecture.md` "Self-update & supervisor" section (with the platform caveats already in the design doc).

## Testing
- `bun run typecheck`, `bunx biome check` (changed files), and `bun run build --compile` all green.
- **Server**: updater unit tests (asset mapping, SHA256 verify good/tampered, Unix + Windows swap branches) and route authz (superuser + supervised-only 409s).
- **Bun-native** (`test/bun/updater.bun.test.ts`): `Bun.spawn` exit-code routing (sentinel) and the swap on the production Bun runtime.
- **Web**: banner confirm flow (master-key warning, apply only after confirm) + overlay mount.
- **Manual smoke test of the compiled binary**: supervisor launches the worker, the worker boots the server, and on `SIGTERM` the worker shuts down gracefully (exit 0) and the supervisor propagates it.
- Cross-platform swap (esp. Windows rename-trick, macOS arm64 signing) still needs manual validation — see the caveats in `.dev/self-updating-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)