### PR TITLE
docs: correct config reference claim that every setting has a CLI flag

### DIFF
--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -6,9 +6,10 @@ section: Deployment
 
 # Configuration reference
 
-Every setting can be supplied as a **command-line flag** or an **environment variable**.
-When both are present, the **environment variable wins** — handy for baking defaults
-into a service definition while still overriding per run.
+Most settings can be supplied as a **command-line flag** or an **environment variable**;
+a few are environment-variable only (shown with `—` in the **Flag** column below).
+When a setting supports both and both are present, the **environment variable wins** —
+handy for baking defaults into a service definition while still overriding per run.
 
 ## Options
 


### PR DESCRIPTION
## Problem

The [Configuration reference](https://hezo.ai/docs/deployment/configuration/) page opened with:

> Every setting can be supplied as a **command-line flag** or an **environment variable**.

That isn't true — and the page's own table contradicts it. Two settings are **environment-variable only** (they already show `—` in the **Flag** column):

- `HEZO_DISABLE_AUTO_UPDATE` — read directly via `process.env.HEZO_DISABLE_AUTO_UPDATE` in `packages/server/src/services/updater.ts`
- `HEZO_UPDATE_CHECK_CRON` — read directly via `process.env.HEZO_UPDATE_CHECK_CRON` in `packages/server/src/services/job-manager.ts`

Neither is registered as a commander option in `packages/server/src/cli.ts`, so there is no CLI flag for them. The other 8 settings do have both a flag and an env var.

## Fix

Reword the opening paragraph to say **most** settings support both, note that a few are env-var only, and point readers to the `—` convention the table already uses to mark them. The precedence note (env var wins when both are set) is preserved and scoped to settings that support both.

No code or behavior change — docs only. `docs-bundle.json` is a gitignored build artifact regenerated by `build:docs`, so nothing else needs to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ProkRWASEaZictE1FTVda

---
_Generated by [Claude Code](https://claude.ai/code/session_011ProkRWASEaZictE1FTVda)_