### PR TITLE
feat(web): float update banner at top with one-click Download & Restart

### DIFF
--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -23,7 +23,7 @@ handy for baking defaults into a service definition while still overriding per r
 | `--open` | `HEZO_OPEN` | off | Open the web app in your browser on startup. |
 | `--log-level <level>` | `HEZO_LOG_LEVEL` | `info` | Logging verbosity: `debug`, `info`, `warn`, or `error`. |
 | `--keep-old-containers` | `HEZO_KEEP_OLD_CONTAINERS` | off | Keep old project containers instead of removing them — for debugging a crashed container. |
-| — | `HEZO_DISABLE_AUTO_UPDATE` | off | Disable the in-app auto-update (release check, download, and "Update & restart"). |
+| — | `HEZO_DISABLE_AUTO_UPDATE` | off | Disable the in-app auto-update (release check, download, and the "Download & Restart" banner). |
 | — | `HEZO_UPDATE_CHECK_CRON` | `0 0 4 * * *` | Cron schedule (seconds-precision) for the daily check that downloads and stages a newer release. |
 
 ## Examples

--- a/packages/web/src/components/update-banner.tsx
+++ b/packages/web/src/components/update-banner.tsx
@@ -1,27 +1,47 @@
 import { UpdateState } from '@hezo/shared';
 import { X } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useMe } from '../hooks/use-me';
 import { useApplyUpdate, useDownloadUpdate, useUpdateStatus } from '../hooks/use-update-check';
+import { Button } from './ui/button';
 import { ConfirmDialog } from './ui/confirm-dialog';
 import { UpdateRestartOverlay } from './update-restart-overlay';
 
 const DISMISS_KEY = 'hezo:update-dismissed';
 
-function readDismissed(): string | null {
+interface Dismissal {
+	version: string;
+	day: string;
+}
+
+/** Local calendar-day key (YYYY-MM-DD in the viewer's timezone). */
+function todayKey(): string {
+	return new Date().toLocaleDateString('en-CA');
+}
+
+function readDismissed(): Dismissal | null {
 	try {
-		return localStorage.getItem(DISMISS_KEY);
+		const raw = localStorage.getItem(DISMISS_KEY);
+		if (!raw) return null;
+		const parsed = JSON.parse(raw) as Partial<Dismissal>;
+		if (typeof parsed?.version === 'string' && typeof parsed?.day === 'string') {
+			return { version: parsed.version, day: parsed.day };
+		}
+		return null;
 	} catch {
+		// Unreadable storage or a legacy bare-version value → treat as not dismissed.
 		return null;
 	}
 }
 
 /**
- * Sticky bottom "update available" bar. When this instance can apply-and-restart
- * (a supervised compiled binary) and the caller is a superuser, it offers an
- * in-app "Update & restart" flow — staging the binary, then a confirmation that
- * warns about the master-key re-unlock, then the restart overlay. Otherwise it
- * falls back to a link to the GitHub Release. Dismissal is per-version.
+ * Full-width "update available" banner pinned at the top of the shell, below the
+ * nav and above content. When this instance can apply-and-restart (a supervised
+ * compiled binary) and the caller is a superuser, a single "Download & Restart"
+ * button stages the new binary then — after a confirmation that warns about the
+ * master-key re-unlock — restarts onto it. Otherwise it falls back to a link to
+ * the GitHub Release. Dismissal lasts until the next calendar day (or until a
+ * newer version ships).
  */
 export function UpdateBanner() {
 	const { data } = useUpdateStatus();
@@ -30,29 +50,57 @@ export function UpdateBanner() {
 	const apply = useApplyUpdate();
 	const [applying, setApplying] = useState(false);
 	const [confirmOpen, setConfirmOpen] = useState(false);
-	const [dismissed, setDismissed] = useState<string | null>(readDismissed);
+	// Set when the user clicks "Download & Restart" before the binary is staged, so
+	// the confirmation opens automatically once staging finishes — one click, not two.
+	const [restartIntent, setRestartIntent] = useState(false);
+	const [dismissed, setDismissed] = useState<Dismissal | null>(readDismissed);
+
+	const latest = data?.latest ?? null;
+	const staged = data?.state === UpdateState.Staged;
+
+	useEffect(() => {
+		if (restartIntent && staged) {
+			setConfirmOpen(true);
+			setRestartIntent(false);
+		}
+	}, [restartIntent, staged]);
 
 	if (applying) {
 		return <UpdateRestartOverlay targetVersion={data?.targetVersion ?? data?.latest ?? null} />;
 	}
 
-	if (!data?.updateAvailable || !data.latest || dismissed === data.latest) return null;
+	const isDismissed =
+		dismissed !== null && dismissed.version === latest && dismissed.day === todayKey();
+	if (!data?.updateAvailable || !latest || isDismissed) return null;
 
 	const dismiss = () => {
+		const record: Dismissal = { version: latest, day: todayKey() };
 		try {
-			localStorage.setItem(DISMISS_KEY, data.latest as string);
+			localStorage.setItem(DISMISS_KEY, JSON.stringify(record));
 		} catch {
 			// ignore storage failures — banner just reappears next load
 		}
-		setDismissed(data.latest);
+		setDismissed(record);
 	};
 
 	const canApply = data.canApply && me?.is_superuser === true;
+	const downloading = data.state === UpdateState.Downloading || download.isPending;
+
+	// One-click "Download & Restart": stage the binary if needed, then surface the
+	// restart confirmation. If it's already staged, jump straight to the confirm.
+	const onDownloadAndRestart = () => {
+		if (staged) {
+			setConfirmOpen(true);
+			return;
+		}
+		setRestartIntent(true);
+		download.mutate();
+	};
 
 	const confirmDescription = (
 		<>
-			Hezo will shut down and restart on <span className="font-medium">{data.latest}</span>.
-			In-flight agent runs are paused and resume automatically.
+			Hezo will shut down and restart on <span className="font-medium">{latest}</span>. In-flight
+			agent runs are paused and resume automatically.
 			{!data.autoUnlock && (
 				<>
 					{' '}
@@ -67,43 +115,32 @@ export function UpdateBanner() {
 	return (
 		<div
 			data-testid="update-banner"
-			className="sticky bottom-0 z-40 flex flex-col sm:flex-row sm:items-center gap-2 px-4 py-2 text-[13px] bg-surface border-t border-border text-text-1"
+			className="shrink-0 flex flex-col sm:flex-row sm:items-center gap-2 px-4 py-2.5 text-[13px] bg-accent-soft text-accent-soft-fg border-b border-border"
 		>
 			<span className="flex-1">
-				Hezo <span className="font-medium">{data.latest}</span> is available — you're on{' '}
-				{data.current}.
+				Hezo <span className="font-semibold">{latest}</span> is available — you're on {data.current}
+				.
 			</span>
-			<div className="flex items-center gap-3">
+			<div className="flex items-center gap-2 sm:gap-3">
 				{canApply ? (
-					data.state === UpdateState.Staged ? (
-						<button
-							type="button"
-							data-testid="update-restart-button"
-							onClick={() => setConfirmOpen(true)}
-							className="font-medium text-inverse-fg bg-inverse hover:opacity-85 px-2.5 py-1 rounded-md"
-						>
-							Update &amp; restart
-						</button>
-					) : data.state === UpdateState.Downloading ? (
-						<span className="text-text-2">Preparing update…</span>
-					) : (
-						<button
-							type="button"
-							data-testid="update-prepare-button"
-							onClick={() => download.mutate()}
-							disabled={download.isPending}
-							className="font-medium text-text-1 hover:underline disabled:opacity-50"
-						>
-							{download.isPending ? 'Preparing…' : 'Prepare update'}
-						</button>
-					)
+					<Button
+						type="button"
+						variant="primary"
+						size="sm"
+						data-testid="update-restart-button"
+						onClick={onDownloadAndRestart}
+						disabled={downloading}
+					>
+						{downloading ? 'Preparing…' : 'Download & Restart'}
+					</Button>
 				) : (
 					data.url && (
 						<a
 							href={data.url}
 							target="_blank"
 							rel="noreferrer"
-							className="font-medium text-text-1 hover:underline"
+							data-testid="update-download-link"
+							className="inline-flex items-center justify-center whitespace-nowrap border border-transparent font-medium transition-colors h-[26px] px-2.5 text-[12.5px] rounded-sm bg-inverse text-inverse-fg hover:opacity-90 focus-visible:ring-[3px] focus-visible:ring-ring outline-none"
 						>
 							Download
 						</a>
@@ -113,7 +150,7 @@ export function UpdateBanner() {
 					type="button"
 					onClick={dismiss}
 					aria-label="Dismiss update notification"
-					className="text-text-2 hover:text-text-1"
+					className="text-accent-soft-fg/70 hover:text-accent-soft-fg"
 				>
 					<X className="w-4 h-4" />
 				</button>

--- a/packages/web/src/routes/__root.tsx
+++ b/packages/web/src/routes/__root.tsx
@@ -162,6 +162,7 @@ function ShellChrome() {
 				onOpenSearch={() => setSearchOpen(true)}
 			/>
 			<GlobalSearchDialog open={searchOpen} onOpenChange={setSearchOpen} />
+			<UpdateBanner />
 			<div className="flex flex-row flex-1 overflow-hidden w-full">
 				{/* Rail + project sidebar + scrollable main span the full viewport so
 				    the main-panel scrollbar sits on the browser edge, not mid-screen. */}
@@ -179,7 +180,6 @@ function ShellChrome() {
 					)}
 					<main ref={mainRef} className="flex-1 min-w-0 overflow-auto relative">
 						<Outlet />
-						<UpdateBanner />
 					</main>
 				</div>
 			</div>

--- a/packages/web/test/update-banner.test.tsx
+++ b/packages/web/test/update-banner.test.tsx
@@ -19,16 +19,28 @@ const BASE: UpdateStatusInfo = {
 	canApply: true,
 };
 
+function today(): string {
+	return new Date().toLocaleDateString('en-CA');
+}
+
 function renderBanner(status: Partial<UpdateStatusInfo> = {}, isSuperuser = true) {
-	const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	// staleTime: Infinity stops the seeded queries (incl. `me`) from refetching on
+	// mount — otherwise a mocked api.get feeds `useMe` the wrong shape and the
+	// canApply button unmounts mid-click.
+	const qc = new QueryClient({
+		defaultOptions: { queries: { retry: false, staleTime: Number.POSITIVE_INFINITY } },
+	});
 	// Seed both caches so the component renders without hitting the network.
 	qc.setQueryData(['update-status'], { ...BASE, ...status });
 	qc.setQueryData(['me'], { type: 'admin', is_superuser: isSuperuser });
-	return render(
-		<QueryClientProvider client={qc}>
-			<UpdateBanner />
-		</QueryClientProvider>,
-	);
+	return {
+		qc,
+		...render(
+			<QueryClientProvider client={qc}>
+				<UpdateBanner />
+			</QueryClientProvider>,
+		),
+	};
 }
 
 afterEach(() => {
@@ -49,6 +61,42 @@ test('non-superuser / non-supervised falls back to a release download link', () 
 	expect(link.getAttribute('href')).toBe('https://github.com/hezo-ai/hezo/releases/0.2.0');
 });
 
+test('supervised + superuser shows a single "Download & Restart" button', () => {
+	const { getByTestId } = renderBanner({ state: UpdateState.Idle });
+	const button = getByTestId('update-restart-button');
+	expect(button.textContent).toContain('Download & Restart');
+});
+
+test('Download & Restart stages the binary before any confirmation', async () => {
+	const user = userEvent.setup();
+	// Refetch after the mutation invalidates the query — keep it inert/idle.
+	vi.spyOn(api, 'get').mockResolvedValue({ ...BASE, state: UpdateState.Idle });
+	const postSpy = vi
+		.spyOn(api, 'post')
+		.mockResolvedValue({ state: UpdateState.Downloading, targetVersion: '0.2.0' });
+
+	const { getByTestId, queryByTestId } = renderBanner({ state: UpdateState.Idle });
+
+	await user.click(getByTestId('update-restart-button'));
+	await waitFor(() => expect(postSpy).toHaveBeenCalledWith('/api/updates/download'));
+	// Not staged yet → no confirmation shown.
+	expect(queryByTestId('confirm-dialog')).toBeNull();
+});
+
+test('Download & Restart auto-opens the confirmation once staging finishes', async () => {
+	const user = userEvent.setup();
+	// The post kicks staging; the status refetch it triggers reports it staged.
+	vi.spyOn(api, 'get').mockResolvedValue({ ...BASE, state: UpdateState.Staged });
+	vi.spyOn(api, 'post').mockResolvedValue({
+		state: UpdateState.Downloading,
+		targetVersion: '0.2.0',
+	});
+
+	const { getByTestId, findByTestId } = renderBanner({ state: UpdateState.Idle });
+	await user.click(getByTestId('update-restart-button'));
+	expect(await findByTestId('confirm-dialog')).toBeTruthy();
+});
+
 test('Update & restart asks for confirmation (with master-key warning) before applying', async () => {
 	const user = userEvent.setup();
 	const postSpy = vi
@@ -57,7 +105,7 @@ test('Update & restart asks for confirmation (with master-key warning) before ap
 
 	const { getByTestId, findByTestId, queryByTestId } = renderBanner();
 
-	// Clicking the action opens the dialog — it does NOT apply yet.
+	// Already staged: clicking the action opens the dialog — it does NOT apply yet.
 	await user.click(getByTestId('update-restart-button'));
 	const dialog = await findByTestId('confirm-dialog');
 	expect(dialog.textContent).toContain('master key');
@@ -79,11 +127,39 @@ test('confirmation omits the master-key warning when the instance auto-unlocks',
 	expect(dialog.textContent).not.toContain('master key');
 });
 
-test('dismiss hides the banner and remembers the version', async () => {
+test('dismiss hides the banner for the rest of the day and records version + day', async () => {
 	const user = userEvent.setup();
 	const { getByTestId, queryByTestId, getByLabelText } = renderBanner();
 	expect(getByTestId('update-banner')).toBeTruthy();
 	await user.click(getByLabelText('Dismiss update notification'));
 	expect(queryByTestId('update-banner')).toBeNull();
-	expect(localStorage.getItem('hezo:update-dismissed')).toBe('0.2.0');
+	const stored = JSON.parse(localStorage.getItem('hezo:update-dismissed') ?? 'null');
+	expect(stored).toEqual({ version: '0.2.0', day: today() });
+});
+
+test("today's dismissal of the current version keeps it hidden", () => {
+	localStorage.setItem('hezo:update-dismissed', JSON.stringify({ version: '0.2.0', day: today() }));
+	const { queryByTestId } = renderBanner();
+	expect(queryByTestId('update-banner')).toBeNull();
+});
+
+test('a dismissal from a previous day no longer suppresses the banner', () => {
+	localStorage.setItem(
+		'hezo:update-dismissed',
+		JSON.stringify({ version: '0.2.0', day: '2000-01-01' }),
+	);
+	const { getByTestId } = renderBanner();
+	expect(getByTestId('update-banner')).toBeTruthy();
+});
+
+test("today's dismissal of an older version does not suppress a newer one", () => {
+	localStorage.setItem('hezo:update-dismissed', JSON.stringify({ version: '0.1.9', day: today() }));
+	const { getByTestId } = renderBanner(); // latest is 0.2.0
+	expect(getByTestId('update-banner')).toBeTruthy();
+});
+
+test('a legacy bare-version dismissal is ignored (banner shows)', () => {
+	localStorage.setItem('hezo:update-dismissed', '0.2.0');
+	const { getByTestId } = renderBanner();
+	expect(getByTestId('update-banner')).toBeTruthy();
 });


### PR DESCRIPTION
## What & why

The "Hezo X is available" notice was a low-contrast bar **stuck to the bottom** of the scrollable content, it dismissed **permanently per version**, and it showed either a two-step in-app flow or a plain GitHub **"Download" link**. This makes it prominent, top-anchored, and dismissible-until-tomorrow, with a single **Download & Restart** action.

## Changes

- **Float at the top, below the nav.** Moved `<UpdateBanner />` out of the bottom of `<main>` into a full-width `shrink-0` block right below `AppHeader` (`__root.tsx`), so it sits above content and never scrolls away.
- **Prominent styling.** Soft brand-accent background (`bg-accent-soft` / `text-accent-soft-fg`) with a dark `primary` button, reusing the shared `Button` and the existing banner pattern (no new primitive). Mobile-first: stacked under `sm`, row above.
- **One-click "Download & Restart".** Replaces the two-step *Prepare update → Update & restart*. When the instance can self-update (supervised binary + superuser), one click stages the binary and then auto-opens the existing master-key re-unlock confirmation before restarting. When it can't, it falls back to a **"Download"** button → GitHub release (can't restart from the browser there).
- **Dismiss until the next day.** Storage moved from a bare version string to `{ version, day }`; the banner reappears on a new calendar day or when a newer version ships, instead of being gone forever. Legacy bare-version values are treated as not-dismissed.
- **Docs.** Updated the `HEZO_DISABLE_AUTO_UPDATE` reference to match the new button label.

## Behaviour matrix

| Instance | Action shown |
|---|---|
| Supervised binary + superuser | **Download & Restart** button (stage → confirm → restart) |
| Otherwise | **Download** link → GitHub release |

## Testing

- `packages/web/test/update-banner.test.tsx` (12 tests): button label, the stage-then-auto-confirm flow, the GitHub fallback, the master-key warning, and the new daily-dismiss semantics (same-day hidden, next-day/new-version reappears, legacy value ignored).
- Full web component suite green (429 tests / 113 files) — confirms the `__root.tsx` move doesn't regress the shell.
- `bun run typecheck` and Biome clean; the pre-commit `bun run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L7NUZGJiNLYCapBx9rBZaf)_