### PR TITLE
fix(binary): build agent-base image locally when it can't be pulled

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -641,8 +641,13 @@ what's reachable through the **module graph** (not runtime `readFile`/`new URL`)
 asset is pulled in as a static import and served **from memory**: migrations
 (`migrations-bundle.json`), agent roles (`agents-bundle.json`), the React frontend
 (`static-bundle.json`, base64), and the PGlite runtime (`postgres.wasm`/`.data`
-embedded). In dev (`bun run`) the bundles don't exist and every loader falls
-back to the filesystem. The version is injected at compile time
+embedded). The **agent-base Docker build context** (`docker/`) is embedded the same
+way (`docker-bundle.json`, base64) because the `hezo/agent-base` image is published to
+no registry — at startup the binary extracts it to `<dataDir>/agent-base-context` and
+points the image resolver (`setDockerBaseDir`) at it, so the first container provision
+**builds the image locally** instead of failing to pull. In dev (`bun run`) the bundles
+don't exist and every loader falls back to the filesystem (the docker context to the
+repo's `docker/` dir). The version is injected at compile time
 (`--define process.env.HEZO_VERSION`) and surfaced at `/api/status`.
 
 **Migrations.** Real, tracked, **append-only** SQL under `packages/server/migrations/`

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ migrations-bundle.json
 agents-bundle.json
 docs-bundle.json
 static-bundle.json
+docker-bundle.json
 packages/server/src/generated/
 packages/server/static/
 *.db

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -11,7 +11,8 @@
 		"build:agents": "bun run scripts/bundle-agents.ts",
 		"build:docs": "bun run scripts/build-mcp-reference.ts && bun run scripts/bundle-docs.ts",
 		"build:static": "bun run scripts/bundle-static.ts",
-		"build:pglite": "bun run scripts/bundle-pglite.ts"
+		"build:pglite": "bun run scripts/bundle-pglite.ts",
+		"build:docker": "bun run scripts/bundle-docker.ts"
 	},
 	"dependencies": {
 		"@electric-sql/pglite": "^0.2",

--- a/packages/server/scripts/bundle-docker.ts
+++ b/packages/server/scripts/bundle-docker.ts
@@ -1,0 +1,38 @@
+import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join, relative, sep } from 'node:path';
+
+// Bundle the agent-base Docker build context (`docker/`) into a single JSON map
+// that `src/services/docker-assets.ts` imports via a literal dynamic import, so
+// `bun build --compile` embeds it into the binary's virtual FS. A compiled
+// binary has no repo checkout on disk, so without this the agent-base image can
+// neither be pulled (it is published to no registry) nor built (no Dockerfile on
+// disk) — provisioning the first container would 404. At startup the binary
+// extracts this bundle to the data dir and builds the image locally from it.
+// Files are base64-encoded so the JSON carries exact bytes (the Dockerfile chmods
+// its own scripts, so host-side exec bits don't need to survive).
+const dockerDir = join(import.meta.dir, '..', '..', '..', 'docker');
+const outputPath = join(import.meta.dir, '..', 'src', 'docker-bundle.json');
+
+async function walk(dir: string): Promise<string[]> {
+	const entries = await readdir(dir, { withFileTypes: true });
+	const out: string[] = [];
+	for (const entry of entries) {
+		const full = join(dir, entry.name);
+		if (entry.isDirectory()) out.push(...(await walk(full)));
+		else if (entry.isFile()) out.push(full);
+	}
+	return out;
+}
+
+const files = (await walk(dockerDir)).sort();
+const bundle: Record<string, string> = {};
+for (const full of files) {
+	// Key relative to the repo root (`docker/...`) so extraction reproduces the
+	// same layout `resolveLocalImage` expects under its base dir.
+	const key = `docker/${relative(dockerDir, full).split(sep).join('/')}`;
+	bundle[key] = (await readFile(full)).toString('base64');
+}
+
+await mkdir(dirname(outputPath), { recursive: true });
+await writeFile(outputPath, JSON.stringify(bundle));
+console.log(`Bundled ${files.length} docker context file(s) → ${outputPath}`);

--- a/packages/server/src/services/docker-assets.ts
+++ b/packages/server/src/services/docker-assets.ts
@@ -1,0 +1,81 @@
+/**
+ * Embedded agent-base Docker build context for the compiled binary.
+ *
+ * `scripts/bundle-docker.ts` generates `docker-bundle.json` (a `{ relPath: b64 }`
+ * map of the repo's `docker/` dir). A *literal* dynamic import lets
+ * `bun build --compile` embed it into the binary's virtual FS. A compiled binary
+ * has no repo checkout, so the agent-base image can neither be pulled (it is
+ * published to no registry) nor built straight from disk — at startup we extract
+ * this bundle to the data dir and point the image resolver at it so the image
+ * builds locally. In dev (`bun run`) the bundle is absent, the import rejects,
+ * and callers fall back to building from the repo's `docker/` dir.
+ */
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { logger } from '../logger';
+
+const log = logger.child('docker-assets');
+
+/** Subdirectory under the data dir where the embedded context is extracted. */
+export const AGENT_BASE_CONTEXT_DIR = 'agent-base-context';
+
+let cache: Record<string, string> | null | undefined;
+
+/**
+ * The embedded Docker build context, or `null` in dev/tests (bundle not
+ * generated). The map is keyed by repo-relative path (`docker/...`) with
+ * base64-encoded file bytes.
+ */
+export async function loadDockerBundle(): Promise<Record<string, string> | null> {
+	if (cache !== undefined) return cache;
+	let mod: { default: Record<string, string> };
+	try {
+		mod = (await import('../docker-bundle.json')) as { default: Record<string, string> };
+	} catch {
+		cache = null;
+		return null;
+	}
+	// An empty stub (written by `scripts/ensure-bundles.ts` so tsc/vite can
+	// resolve the literal import) means the bundle was never generated — treat it
+	// as absent so callers fall back to the repo's `docker/` dir.
+	if (Object.keys(mod.default).length === 0) {
+		cache = null;
+		return null;
+	}
+	cache = mod.default;
+	return cache;
+}
+
+/**
+ * Write a docker-context bundle map under `<dataDir>/<AGENT_BASE_CONTEXT_DIR>`,
+ * reproducing its `docker/...` layout, and return the base dir the keys are
+ * relative to (so `resolveLocalImage` resolves `docker/Dockerfile.agent-base`
+ * under it). Files are written verbatim; the agent-base Dockerfile chmods its
+ * own scripts, so host-side exec bits don't matter.
+ */
+export async function extractDockerContext(
+	dataDir: string,
+	bundle: Record<string, string>,
+): Promise<string> {
+	const root = join(dataDir, AGENT_BASE_CONTEXT_DIR);
+	for (const [relPath, b64] of Object.entries(bundle)) {
+		const dest = join(root, relPath);
+		await mkdir(dirname(dest), { recursive: true });
+		await writeFile(dest, Buffer.from(b64, 'base64'));
+	}
+	return root;
+}
+
+/**
+ * Extract the embedded agent-base build context to the data dir and return the
+ * base dir to resolve it from, or `null` when no bundle is embedded (dev/source
+ * — the caller then builds from the repo's `docker/` dir).
+ */
+export async function extractBundledDockerContext(dataDir: string): Promise<string | null> {
+	const bundle = await loadDockerBundle();
+	if (!bundle) return null;
+	const root = await extractDockerContext(dataDir, bundle);
+	log.info(`Extracted embedded agent-base build context to ${root}`);
+	return root;
+}

--- a/packages/server/src/services/image-registry.ts
+++ b/packages/server/src/services/image-registry.ts
@@ -35,6 +35,24 @@ export interface ResolvedLocalImage {
 	bundleSourceHash: string;
 }
 
+/**
+ * Base dir the `LOCAL_IMAGES` paths resolve against when set. The compiled
+ * binary has no repo checkout, so `findRepoRoot` finds nothing and the
+ * agent-base image could neither be pulled (published to no registry) nor built.
+ * At startup the binary extracts the embedded `docker/` context to the data dir
+ * and points us at it here, so `resolveLocalImage` finds the Dockerfile and the
+ * image builds locally. Unset (`null`) in dev/source, where `findRepoRoot` walks
+ * to the repo's `docker/` dir.
+ */
+let dockerBaseDirOverride: string | null = null;
+
+/** Override (or, with `null`, clear) the base dir `resolveLocalImage` resolves
+ *  the bundled Dockerfile/context against. Set once at startup in the compiled
+ *  binary after the embedded context is extracted to the data dir. */
+export function setDockerBaseDir(dir: string | null): void {
+	dockerBaseDirOverride = dir;
+}
+
 export function findRepoRoot(startDir?: string): string | null {
 	let dir = startDir ?? dirname(fileURLToPath(import.meta.url));
 	while (true) {
@@ -57,7 +75,7 @@ export function resolveLocalImage(image: string): ResolvedLocalImage | null {
 	const spec = LOCAL_IMAGES[image];
 	if (!spec) return null;
 
-	const root = findRepoRoot();
+	const root = dockerBaseDirOverride ?? findRepoRoot();
 	if (!root) return null;
 
 	const dockerfile = isAbsolute(spec.dockerfile) ? spec.dockerfile : resolve(root, spec.dockerfile);

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -61,9 +61,10 @@ import { CeoSessionManager } from './services/ceo-session-manager';
 import { ContainerLogStreamer } from './services/container-logs';
 import type { ContainerDeps } from './services/containers';
 import { DockerClient } from './services/docker';
+import { extractBundledDockerContext } from './services/docker-assets';
 import { EgressProxy, loadOrCreateCA } from './services/egress';
 import { ImageBuildTracker, setSharedImageBuildTracker } from './services/image-build-tracker';
-import { pruneStaleBundledImages } from './services/image-registry';
+import { pruneStaleBundledImages, setDockerBaseDir } from './services/image-registry';
 import { JobManager } from './services/job-manager';
 import { LogStreamBroker } from './services/log-stream-broker';
 import { PricingService } from './services/pricing';
@@ -101,6 +102,7 @@ export interface StartupResult {
 
 export async function startup(config: HezoConfig): Promise<StartupResult> {
 	mkdirSync(config.dataDir, { recursive: true });
+	log.info(`Using data directory: ${config.dataDir}`);
 
 	// `db` may be replaced by a fresh handle if migrations run against a copy and
 	// swap it in, so it's a `let` — every consumer below uses the post-migration handle.
@@ -125,6 +127,17 @@ export async function startup(config: HezoConfig): Promise<StartupResult> {
 		docker = createFakeDockerClient(db);
 	} else {
 		docker = new DockerClient();
+		// A compiled binary has no repo checkout, so the agent-base image can't be
+		// built from disk (and is published to no registry to pull). Extract the
+		// embedded build context to the data dir and point the image resolver at it,
+		// so provisioning builds the image locally. No-op in dev/source (returns
+		// null — the resolver falls back to the repo's docker/ dir).
+		try {
+			const contextDir = await extractBundledDockerContext(config.dataDir);
+			if (contextDir) setDockerBaseDir(contextDir);
+		} catch (err) {
+			log.error('Failed to extract bundled agent-base build context (continuing):', err);
+		}
 		try {
 			const outcome = await pruneStaleBundledImages(docker);
 			if (outcome.removed.length > 0 || outcome.skipped.length > 0) {

--- a/packages/server/test/docker-assets.test.ts
+++ b/packages/server/test/docker-assets.test.ts
@@ -1,0 +1,56 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+	AGENT_BASE_CONTEXT_DIR,
+	extractBundledDockerContext,
+	extractDockerContext,
+} from '../src/services/docker-assets';
+
+describe('docker-assets', () => {
+	let dirs: string[] = [];
+
+	function tmp(): string {
+		const d = mkdtempSync(join(tmpdir(), 'hezo-docker-assets-'));
+		dirs.push(d);
+		return d;
+	}
+
+	afterEach(() => {
+		for (const d of dirs) rmSync(d, { recursive: true, force: true });
+		dirs = [];
+	});
+
+	it('extractDockerContext writes the bundle verbatim under the data dir, preserving layout', async () => {
+		const dataDir = tmp();
+		const dockerfile = 'FROM node:24-slim\nRUN echo hi\n';
+		const script = '#!/bin/sh\necho bridge\n';
+		const bundle = {
+			'docker/Dockerfile.agent-base': Buffer.from(dockerfile).toString('base64'),
+			'docker/scripts/hezo-ssh-bridge': Buffer.from(script).toString('base64'),
+		};
+
+		const root = await extractDockerContext(dataDir, bundle);
+
+		expect(root).toBe(join(dataDir, AGENT_BASE_CONTEXT_DIR));
+		// Files land at <root>/docker/... so resolveLocalImage finds them under root.
+		expect(readFileSync(join(root, 'docker', 'Dockerfile.agent-base'), 'utf8')).toBe(dockerfile);
+		expect(readFileSync(join(root, 'docker', 'scripts', 'hezo-ssh-bridge'), 'utf8')).toBe(script);
+	});
+
+	it('extractDockerContext round-trips arbitrary bytes via base64', async () => {
+		const dataDir = tmp();
+		const bytes = Buffer.from([0x00, 0xff, 0x10, 0x7f, 0x80, 0x0a]);
+		const root = await extractDockerContext(dataDir, {
+			'docker/raw.bin': bytes.toString('base64'),
+		});
+		expect(readFileSync(join(root, 'docker', 'raw.bin'))).toEqual(bytes);
+	});
+
+	it('extractBundledDockerContext returns null when no bundle is embedded (dev/tests)', async () => {
+		// The test build leaves docker-bundle.json an empty stub, so the loader
+		// reports "absent" and the caller falls back to the repo docker/ dir.
+		expect(await extractBundledDockerContext(tmp())).toBeNull();
+	});
+});

--- a/packages/server/test/image-registry.test.ts
+++ b/packages/server/test/image-registry.test.ts
@@ -1,12 +1,13 @@
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import {
 	BUNDLE_SHA_LABEL,
 	computeBundleSourceHash,
 	findRepoRoot,
 	resolveLocalImage,
+	setDockerBaseDir,
 } from '../src/services/image-registry';
 
 describe('image-registry', () => {
@@ -34,6 +35,48 @@ describe('image-registry', () => {
 	it('returns null for unregistered images', () => {
 		expect(resolveLocalImage('alpine:latest')).toBeNull();
 		expect(resolveLocalImage('some/other:tag')).toBeNull();
+	});
+
+	describe('setDockerBaseDir override (compiled binary)', () => {
+		// The binary has no repo checkout; it extracts the embedded docker/ context
+		// to the data dir and points the resolver there so the image builds locally.
+		afterEach(() => setDockerBaseDir(null));
+
+		it('resolves the agent-base Dockerfile under the override dir', () => {
+			const base = mkdtempSync(join(tmpdir(), 'hezo-docker-base-'));
+			try {
+				mkdirSync(join(base, 'docker', 'scripts'), { recursive: true });
+				writeFileSync(join(base, 'docker', 'Dockerfile.agent-base'), 'FROM node:24-slim\n');
+				writeFileSync(join(base, 'docker', 'scripts', 'hezo-ssh-bridge'), '#!/bin/sh\n');
+
+				setDockerBaseDir(base);
+				const resolved = resolveLocalImage('hezo/agent-base:latest');
+
+				expect(resolved).not.toBeNull();
+				expect(resolved?.dockerfile).toBe(join(base, 'docker', 'Dockerfile.agent-base'));
+				expect(resolved?.context).toBe(join(base, 'docker'));
+				expect(resolved?.bundleSourceHash).toMatch(/^[0-9a-f]{64}$/);
+			} finally {
+				rmSync(base, { recursive: true, force: true });
+			}
+		});
+
+		it('returns null when the override dir lacks the Dockerfile', () => {
+			const base = mkdtempSync(join(tmpdir(), 'hezo-docker-base-'));
+			try {
+				setDockerBaseDir(base);
+				expect(resolveLocalImage('hezo/agent-base:latest')).toBeNull();
+			} finally {
+				rmSync(base, { recursive: true, force: true });
+			}
+		});
+
+		it('clearing the override (null) restores repo-root resolution', () => {
+			setDockerBaseDir('/nonexistent/override');
+			expect(resolveLocalImage('hezo/agent-base:latest')).toBeNull();
+			setDockerBaseDir(null);
+			expect(resolveLocalImage('hezo/agent-base:latest')).not.toBeNull();
+		});
 	});
 
 	it('exposes a stable BUNDLE_SHA_LABEL constant', () => {

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -76,11 +76,13 @@ await Promise.all([
 	run('packages/web', ['bun', 'run', 'build']),
 ]);
 
-// Binary-only embedding steps: the static bundle (reads packages/web/dist) and
-// the PGlite runtime assets, both needed for a self-contained executable.
+// Binary-only embedding steps: the static bundle (reads packages/web/dist), the
+// PGlite runtime assets, and the agent-base Docker build context — all needed
+// for a self-contained executable (a binary has no repo checkout to read from).
 if (wantBinary) {
 	await run('packages/server', ['bun', 'run', 'build:static']);
 	await run('packages/server', ['bun', 'run', 'build:pglite']);
+	await run('packages/server', ['bun', 'run', 'build:docker']);
 }
 
 console.log('Build complete.');

--- a/scripts/ensure-bundles.ts
+++ b/scripts/ensure-bundles.ts
@@ -19,6 +19,7 @@ const BUNDLES = [
 	'packages/server/src/db/agents-bundle.json',
 	'packages/server/src/services/docs-bundle.json',
 	'packages/server/src/static-bundle.json',
+	'packages/server/src/docker-bundle.json',
 ];
 
 export function ensureBundles(): void {


### PR DESCRIPTION
## Problem

Running a compiled binary on a fresh server fails to provision the first container:

```
[error] <teams> Failed to provision container for HQ project: Error: Docker pullImage failed (404):
{"message":"pull access denied for hezo/agent-base, repository does not exist or may require 'docker login'..."}
```

A compiled binary has **no repo checkout on disk**, so `resolveLocalImage('hezo/agent-base:latest')` can't find `docker/Dockerfile.agent-base` (returns `null`), and `ensureImage` falls through to `docker.pullImage('hezo/agent-base')` — which 404s because the image is **published to no registry**. Every fresh binary install hit this on first provision.

## Fix

Embed the `docker/` build context into the binary the same way migrations, agent roles, the frontend, and the PGlite runtime are already embedded — then build the image locally from it.

- **`packages/server/scripts/bundle-docker.ts`** (new) — walks `docker/` → `docker-bundle.json` (base64). Wired into the binary-only build steps in `scripts/build.ts` (so it ships in `build:compile` / `build:release`), stubbed by `ensure-bundles.ts`, gitignored.
- **`packages/server/src/services/docker-assets.ts`** (new) — at startup, extracts the embedded context to `<dataDir>/agent-base-context`. Returns `null` in dev/source (bundle absent).
- **`packages/server/src/services/image-registry.ts`** — new `setDockerBaseDir()`; `resolveLocalImage` resolves the Dockerfile/context under the extracted dir instead of the (absent) repo root. The extracted bytes are byte-identical and stable per-binary, so the existing `hezo.bundle.sha` prune still rebuilds only after a Dockerfile change (e.g. an upgrade).
- **`packages/server/src/startup.ts`** — extract + set the base dir before `pruneStaleBundledImages` and provisioning.

Dev (`bun run`) is unchanged: the bundle doesn't exist, so the resolver falls back to the repo's `docker/` dir exactly as before.

### Also (second request)

Log the data directory at startup so operators can see which dir is in use:

```
[info] <startup> Using data directory: /root/.hezo
```

## Tests

- **`docker-assets.test.ts`** (new) — verbatim extraction + layout, arbitrary-byte base64 round-trip, and `null` when no bundle is embedded.
- **`image-registry.test.ts`** — `setDockerBaseDir` override resolves under the extracted dir, returns `null` when the dir lacks the Dockerfile, and clearing (`null`) restores repo-root resolution.
- Verified end-to-end (bundle → extract → resolve) that the extracted context's `bundleSourceHash` matches the repo's — i.e. the local build context is byte-identical.

Affected suites green: `docker-assets`, `image-registry`, `ensure-image`, `projects`, `prune-stale-bundled-images`, `image-build-tracker`, `image-builder`, `container-sync`. Typecheck + biome clean. `.dev/architecture.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KcDTguWjQeJf3povxaaFpb

---
_Generated by [Claude Code](https://claude.ai/code/session_01KcDTguWjQeJf3povxaaFpb)_