### PR TITLE
fix(web): make clipboard copy work in insecure contexts

### DIFF
--- a/packages/web/src/components/connector-device-flow-dialog.tsx
+++ b/packages/web/src/components/connector-device-flow-dialog.tsx
@@ -7,6 +7,7 @@ import {
 	pollDeviceFlow,
 	useDeviceStart,
 } from '../hooks/use-oauth-connections';
+import { copyToClipboard } from '../lib/clipboard';
 import { Button } from './ui/button';
 import { dialogContentClassName, dialogOverlayClassName } from './ui/dialog';
 
@@ -116,9 +117,10 @@ export function ConnectorDeviceFlowDialog({
 
 	const handleCopyCode = async () => {
 		if (!deviceFlow) return;
-		await navigator.clipboard.writeText(deviceFlow.user_code);
-		setCodeCopied(true);
-		setTimeout(() => setCodeCopied(false), 2000);
+		if (await copyToClipboard(deviceFlow.user_code)) {
+			setCodeCopied(true);
+			setTimeout(() => setCodeCopied(false), 2000);
+		}
 	};
 
 	return (

--- a/packages/web/src/components/log-viewer.tsx
+++ b/packages/web/src/components/log-viewer.tsx
@@ -1,6 +1,7 @@
 import * as Dialog from '@radix-ui/react-dialog';
 import { AlignLeft, Check, Code, Copy, Maximize2, Minimize2, MoveVertical } from 'lucide-react';
 import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import { copyToClipboard } from '../lib/clipboard';
 import type { CommentRefTask } from '../lib/remark-comment-refs';
 import { FormattedLogView } from './formatted-log-view';
 import { Button } from './ui/button';
@@ -99,13 +100,10 @@ export function LogViewer({
 
 	const handleCopy = async () => {
 		const text = lines.map((l) => l.text).join('\n');
-		try {
-			await navigator.clipboard.writeText(text);
+		if (await copyToClipboard(text)) {
 			setCopied(true);
 			if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
 			copyTimeoutRef.current = setTimeout(() => setCopied(false), 1500);
-		} catch {
-			// clipboard write failed (e.g. insecure context) — leave state unchanged
 		}
 	};
 

--- a/packages/web/src/components/master-key-gate.tsx
+++ b/packages/web/src/components/master-key-gate.tsx
@@ -8,6 +8,7 @@ import * as Dialog from '@radix-ui/react-dialog';
 import { KeyRound, Loader2, ShieldCheck } from 'lucide-react';
 import { useState } from 'react';
 import { authenticateWithMnemonic } from '../lib/auth';
+import { copyToClipboard } from '../lib/clipboard';
 import { queryClient } from '../lib/query-client';
 import { queryKeys } from '../lib/query-keys';
 import { Button } from './ui/button';
@@ -55,9 +56,10 @@ export function MasterKeyForm({ state, embedded }: MasterKeyFormProps) {
 	}
 
 	async function handleCopy() {
-		await navigator.clipboard.writeText(generatedKey ?? '');
-		setCopied(true);
-		setTimeout(() => setCopied(false), 2000);
+		if (await copyToClipboard(generatedKey ?? '')) {
+			setCopied(true);
+			setTimeout(() => setCopied(false), 2000);
+		}
 	}
 
 	return (

--- a/packages/web/src/components/task-detail/comments-section.tsx
+++ b/packages/web/src/components/task-detail/comments-section.tsx
@@ -6,6 +6,7 @@ import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso';
 import { useAgents } from '../../hooks/use-agents';
 import { type Comment, useComments } from '../../hooks/use-comments';
 import type { Task } from '../../hooks/use-tasks';
+import { copyToClipboard } from '../../lib/clipboard';
 import { AgentLink } from '../agent-link';
 import {
 	type CommentData,
@@ -37,13 +38,10 @@ function CopyCommentButton({ text }: { text: string }) {
 	}, []);
 
 	const handleCopy = async () => {
-		try {
-			await navigator.clipboard.writeText(text);
+		if (await copyToClipboard(text)) {
 			setCopied(true);
 			if (timeoutRef.current) clearTimeout(timeoutRef.current);
 			timeoutRef.current = setTimeout(() => setCopied(false), 1500);
-		} catch {
-			// clipboard write failed (e.g. insecure context) — leave state unchanged
 		}
 	};
 

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -1,3 +1,5 @@
+import { readStored, removeStored, writeStored } from './safe-storage';
+
 const TOKEN_KEY = 'hezo_token';
 
 export interface ApiError {
@@ -13,7 +15,7 @@ export interface PaginationMeta {
 }
 
 class ApiClient {
-	private token: string | null = localStorage.getItem(TOKEN_KEY);
+	private token: string | null = readStored(TOKEN_KEY);
 
 	getToken(): string | null {
 		return this.token;
@@ -21,12 +23,12 @@ class ApiClient {
 
 	setToken(token: string) {
 		this.token = token;
-		localStorage.setItem(TOKEN_KEY, token);
+		writeStored(TOKEN_KEY, token);
 	}
 
 	clearToken() {
 		this.token = null;
-		localStorage.removeItem(TOKEN_KEY);
+		removeStored(TOKEN_KEY);
 	}
 
 	private authHeaders(contentType = 'application/json'): Record<string, string> {

--- a/packages/web/src/lib/clipboard.ts
+++ b/packages/web/src/lib/clipboard.ts
@@ -1,0 +1,40 @@
+/**
+ * Copy text to the clipboard, working in both secure and insecure contexts.
+ *
+ * The async Clipboard API is only available in secure contexts (HTTPS or
+ * localhost). When the UI is served over plain HTTP on a remote host
+ * `navigator.clipboard` is undefined, so fall back to a hidden textarea and the
+ * legacy copy command. Never throws — resolves to whether the copy succeeded.
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+	if (navigator.clipboard?.writeText) {
+		try {
+			await navigator.clipboard.writeText(text);
+			return true;
+		} catch {
+			// Fall through to the legacy path below.
+		}
+	}
+
+	return legacyCopy(text);
+}
+
+function legacyCopy(text: string): boolean {
+	const textarea = document.createElement('textarea');
+	textarea.value = text;
+	// Keep the element out of view and prevent it from affecting layout or scroll.
+	textarea.setAttribute('readonly', '');
+	textarea.style.position = 'fixed';
+	textarea.style.top = '-9999px';
+	textarea.style.opacity = '0';
+	document.body.appendChild(textarea);
+
+	try {
+		textarea.select();
+		return document.execCommand('copy');
+	} catch {
+		return false;
+	} finally {
+		document.body.removeChild(textarea);
+	}
+}

--- a/packages/web/src/lib/safe-storage.ts
+++ b/packages/web/src/lib/safe-storage.ts
@@ -1,0 +1,29 @@
+/**
+ * localStorage access that never throws. Reading or writing storage throws in
+ * private-browsing modes and when the quota is exceeded; these helpers swallow
+ * those failures so storage being unavailable degrades gracefully instead of
+ * crashing app initialization.
+ */
+export function readStored(key: string): string | null {
+	try {
+		return localStorage.getItem(key);
+	} catch {
+		return null;
+	}
+}
+
+export function writeStored(key: string, value: string): void {
+	try {
+		localStorage.setItem(key, value);
+	} catch {
+		// storage unavailable — ignore
+	}
+}
+
+export function removeStored(key: string): void {
+	try {
+		localStorage.removeItem(key);
+	} catch {
+		// storage unavailable — ignore
+	}
+}

--- a/packages/web/src/lib/theme.tsx
+++ b/packages/web/src/lib/theme.tsx
@@ -1,4 +1,5 @@
 import { createContext, type ReactNode, useCallback, useContext, useEffect, useState } from 'react';
+import { readStored, writeStored } from './safe-storage';
 
 export type ThemePreference = 'system' | 'light' | 'dark';
 export type ResolvedTheme = 'light' | 'dark';
@@ -32,7 +33,7 @@ function applyTheme(theme: ResolvedTheme) {
 export function ThemeProvider({ children }: { children: ReactNode }) {
 	const [preference, setPreferenceState] = useState<ThemePreference>(() => {
 		if (typeof window === 'undefined') return 'system';
-		const stored = localStorage.getItem(STORAGE_KEY);
+		const stored = readStored(STORAGE_KEY);
 		if (stored === 'light' || stored === 'dark' || stored === 'system') return stored;
 		return 'system';
 	});
@@ -41,7 +42,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
 
 	const setPreference = useCallback((newPreference: ThemePreference) => {
 		setPreferenceState(newPreference);
-		localStorage.setItem(STORAGE_KEY, newPreference);
+		writeStored(STORAGE_KEY, newPreference);
 	}, []);
 
 	useEffect(() => {

--- a/packages/web/src/routes/settings/api-keys.tsx
+++ b/packages/web/src/routes/settings/api-keys.tsx
@@ -17,6 +17,7 @@ import {
 	useDeleteApiKey,
 } from '../../hooks/use-api-keys';
 import { useMe } from '../../hooks/use-me';
+import { copyToClipboard } from '../../lib/clipboard';
 
 function formatRelative(iso: string | null): string {
 	if (!iso) return 'never';
@@ -198,11 +199,7 @@ function ApiKeysPage() {
 						</p>
 						<div className="flex items-center gap-2">
 							<code className="text-xs font-mono break-all flex-1">{newKey}</code>
-							<Button
-								variant="secondary"
-								size="sm"
-								onClick={() => navigator.clipboard.writeText(newKey)}
-							>
+							<Button variant="secondary" size="sm" onClick={() => copyToClipboard(newKey)}>
 								<Copy className="w-3 h-3" />
 							</Button>
 						</div>

--- a/packages/web/test/clipboard.test.ts
+++ b/packages/web/test/clipboard.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, expect, test, vi } from 'vitest';
+import { copyToClipboard } from '../src/lib/clipboard';
+
+const originalClipboard = navigator.clipboard;
+const originalExecCommand = document.execCommand;
+
+afterEach(() => {
+	Object.defineProperty(navigator, 'clipboard', {
+		value: originalClipboard,
+		configurable: true,
+	});
+	document.execCommand = originalExecCommand;
+	vi.restoreAllMocks();
+});
+
+function setClipboard(value: unknown) {
+	Object.defineProperty(navigator, 'clipboard', { value, configurable: true });
+}
+
+test('uses the async Clipboard API when available', async () => {
+	const writeText = vi.fn().mockResolvedValue(undefined);
+	setClipboard({ writeText });
+
+	expect(await copyToClipboard('secret words')).toBe(true);
+	expect(writeText).toHaveBeenCalledWith('secret words');
+});
+
+test('falls back to execCommand in an insecure context', async () => {
+	setClipboard(undefined);
+	const execCommand = vi.fn().mockReturnValue(true);
+	document.execCommand = execCommand;
+
+	expect(await copyToClipboard('fallback words')).toBe(true);
+	expect(execCommand).toHaveBeenCalledWith('copy');
+	expect(document.querySelector('textarea')).toBeNull();
+});
+
+test('falls back to execCommand when the async API rejects', async () => {
+	setClipboard({ writeText: vi.fn().mockRejectedValue(new Error('denied')) });
+	const execCommand = vi.fn().mockReturnValue(true);
+	document.execCommand = execCommand;
+
+	expect(await copyToClipboard('words')).toBe(true);
+	expect(execCommand).toHaveBeenCalledWith('copy');
+});
+
+test('returns false when every copy path fails', async () => {
+	setClipboard(undefined);
+	document.execCommand = vi.fn().mockReturnValue(false);
+
+	expect(await copyToClipboard('words')).toBe(false);
+	expect(document.querySelector('textarea')).toBeNull();
+});


### PR DESCRIPTION
## Problem

Running the Hezo binary and accessing the web UI over **plain HTTP on a non-localhost host** means the page is not a *secure context*. The async Clipboard API is secure-context-only, so `navigator.clipboard` is `undefined` there. The master-key screen's "Copy to clipboard" button called it unguarded, producing an unhandled rejection:

```
TypeError: Cannot read properties of undefined (reading 'writeText')
  at handleCopy (master-key-gate.tsx)
```

Two other copy buttons (connector device-flow code, new API key) had the same bug; two more (log viewer, comment copy) swallowed the error but then silently did nothing.

## Fix

- **New shared helper `lib/clipboard.ts`** — `copyToClipboard(text)` uses the async Clipboard API when present, otherwise falls back to a hidden-`<textarea>` + `document.execCommand('copy')`, so copy actually **works** over plain HTTP (not just "doesn't crash"). Never throws.
- **Routed all five clipboard call sites** through it, setting the "Copied!" state only on success. Removes the now-redundant inline try/catch in the two already-guarded sites.
- **Secondary hardening** — new `lib/safe-storage.ts` wraps `localStorage` so private/incognito mode never crashes app load; applied to the `api.ts` token read/write and `theme.tsx`.

## Verified safe across HTTP / HTTPS / proxy / direct (no change needed)

A full sweep of `packages/web/src` for secure-context-only / browser-capability APIs confirmed:

- **Auth / master key** derives keys with pure-JS `@noble`/`@scure` (not WebCrypto `crypto.subtle`) → login works over plain HTTP.
- **REST + MCP** (`api.ts`) `fetch()`es relative paths → inherits the page origin, so it works behind an HTTPS proxy, over HTTP, or direct, with no mixed-content.
- **WebSocket** (`ws.ts`) derives `ws://`/`wss://` from `window.location.protocol`.
- No usage anywhere of other secure-context-only APIs (service workers, `mediaDevices`, WebAuthn, `navigator.share`, etc.).

## Tests

- New `packages/web/test/clipboard.test.ts` — 4 tests: async path, insecure `execCommand` fallback, async-rejection fallback, total-failure → `false`.
- `bun run typecheck` ✓, biome clean on touched files, full web vitest suite **433/433 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)