### PR TITLE
fix(server): provision HQ container on demand for CEO chat

### DIFF
--- a/packages/server/src/routes/repos.ts
+++ b/packages/server/src/routes/repos.ts
@@ -6,7 +6,7 @@ import { err, ok } from '../lib/response';
 import { isUniqueViolation, withTransaction } from '../lib/sql';
 import type { Env } from '../lib/types';
 import { logger } from '../logger';
-import { provisionContainer } from '../services/containers';
+import { ensureProjectContainerRunning } from '../services/containers';
 import { ContainerGitExecutor } from '../services/git-executor';
 import { createGitHubRepo, parseGitHubUrl, validateRepoAccess } from '../services/github';
 import { getConnection } from '../services/oauth/connection-store';
@@ -417,53 +417,26 @@ async function loadOAuthAccessToken(
 }
 
 async function ensureProjectContainerUp(c: Context<Env>, projectId: string): Promise<void> {
-	const db = c.get('db');
 	const docker = c.get('docker');
 	const dataDir = c.get('dataDir');
-	const masterKeyManager = c.get('masterKeyManager');
-	const wsManager = c.get('wsManager');
-	const logs = c.get('logs');
-	const containerLogStreamer = c.get('containerLogStreamer');
-	const sshAgentServer = c.get('sshAgentServer');
 	const egressProxy = c.get('egressProxy');
 
 	if (!docker || !dataDir) return;
 
-	const projectRes = await db.query<{
-		id: string;
-		team_id: string;
-		slug: string;
-		docker_base_image: string;
-		container_id: string | null;
-		container_status: string | null;
-		dev_ports: Array<{ container: number; host: number }>;
-		team_slug: string;
-	}>(
-		`SELECT p.id, p.team_id, p.slug, p.docker_base_image, p.container_id, p.container_status,
-		        p.dev_ports, c.slug AS team_slug
-		 FROM projects p JOIN teams c ON c.id = p.team_id
-		 WHERE p.id = $1`,
-		[projectId],
-	);
-	if (projectRes.rows.length === 0) return;
-	const proj = projectRes.rows[0];
-	if (proj.container_status === 'running') return;
-
 	try {
-		await provisionContainer(
+		await ensureProjectContainerRunning(
 			{
-				db,
+				db: c.get('db'),
 				docker,
 				dataDir,
-				wsManager,
-				masterKeyManager,
-				logs,
-				containerLogStreamer,
-				sshAgentServer,
+				wsManager: c.get('wsManager'),
+				masterKeyManager: c.get('masterKeyManager'),
+				logs: c.get('logs'),
+				containerLogStreamer: c.get('containerLogStreamer'),
+				sshAgentServer: c.get('sshAgentServer'),
 				egressCAPath: egressProxy?.caCertPath ?? null,
 			},
-			proj,
-			proj.team_slug,
+			projectId,
 		);
 	} catch (e) {
 		log.error('Failed to auto-start container after repo add:', e);

--- a/packages/server/src/services/ceo-session-manager.ts
+++ b/packages/server/src/services/ceo-session-manager.ts
@@ -33,6 +33,8 @@ import {
 	createAgentChatParser,
 } from './agent-stream-parser';
 import { getProviderCredentialAndModel } from './ai-provider-keys';
+import type { ContainerLogStreamer } from './container-logs';
+import { type ContainerDeps, ensureProjectContainerRunning } from './containers';
 import { getAgentSystemPrompt, getDocument } from './documents';
 import { applyEffortToRuntime, type EffortRuntimeApplication } from './effort';
 import { resolveRuntimeForTask } from './runtime-resolver';
@@ -89,6 +91,7 @@ export function formatChatMemoryBlock(content: string): string {
 
 export interface CeoSessionDeps extends RunnerDeps {
 	wsManager: WebSocketManager;
+	containerLogStreamer?: ContainerLogStreamer;
 }
 
 interface LiveSession {
@@ -240,6 +243,20 @@ export class CeoSessionManager {
 		return this.ensuring;
 	}
 
+	private buildContainerDeps(): ContainerDeps {
+		return {
+			db: this.deps.db,
+			docker: this.deps.docker,
+			dataDir: this.deps.dataDir,
+			wsManager: this.deps.wsManager,
+			masterKeyManager: this.deps.masterKeyManager,
+			logs: this.deps.logs,
+			containerLogStreamer: this.deps.containerLogStreamer,
+			sshAgentServer: this.deps.sshAgentServer,
+			egressCAPath: this.deps.egressCAPath ?? null,
+		};
+	}
+
 	private async startSession(): Promise<LiveSession> {
 		const { db } = this.deps;
 
@@ -263,9 +280,13 @@ export class CeoSessionManager {
 		);
 		const project = proj.rows[0];
 		if (!project) throw new Error('HQ project not found');
-		if (project.container_status !== 'running' || !project.container_id) {
-			throw new Error('HQ container is not running');
-		}
+		// The CEO chat is available app-wide from first load, before any project is
+		// created, so the HQ container may never have been provisioned. Bring it up
+		// on demand rather than failing the turn.
+		const containerId =
+			project.container_status === 'running' && project.container_id
+				? project.container_id
+				: await ensureProjectContainerRunning(this.buildContainerDeps(), project.id);
 
 		const override = await db.query<{ provider: AiProvider | null; model: string | null }>(
 			`SELECT model_override_provider AS provider, model_override_model AS model
@@ -309,7 +330,7 @@ export class CeoSessionManager {
 				ceoMemberId,
 				DEFAULT_TEAM_ID,
 				project.id,
-				project.container_id,
+				containerId,
 				runtimeType,
 				CeoSessionStatus.Starting,
 			],
@@ -404,7 +425,7 @@ export class CeoSessionManager {
 				conversationId,
 				ceoMemberId,
 				projectId: project.id,
-				containerId: project.container_id,
+				containerId,
 				runtimeType,
 				env: invocation.env,
 				execCmd: invocation.execCmd,

--- a/packages/server/src/services/containers.ts
+++ b/packages/server/src/services/containers.ts
@@ -403,6 +403,50 @@ export async function provisionContainer(
 	}
 }
 
+/**
+ * Bring a project's container up on demand and return its running container id.
+ * A container that exists but is stopped is started in place (cheaper, preserves
+ * state); one that is missing or was never created is provisioned from scratch.
+ * Trusts the DB only when Docker agrees the container is actually running, so a
+ * stale `running` row that no longer maps to a live container is repaired.
+ */
+export async function ensureProjectContainerRunning(
+	deps: ContainerDeps,
+	projectId: string,
+): Promise<string> {
+	const { db, docker } = deps;
+	const res = await db.query<ProjectRow & { team_slug: string }>(
+		`SELECT p.id, p.team_id, p.slug, p.docker_base_image, p.container_id, p.container_status,
+		        p.dev_ports, c.slug AS team_slug
+		 FROM projects p JOIN teams c ON c.id = p.team_id
+		 WHERE p.id = $1`,
+		[projectId],
+	);
+	const proj = res.rows[0];
+	if (!proj) throw new Error('Project not found');
+
+	if (proj.container_id) {
+		const info = await docker.inspectContainer(proj.container_id);
+		if (info?.State.Running) return proj.container_id;
+		if (info) {
+			// Container exists but is stopped — start it in place.
+			await docker.startContainer(proj.container_id);
+			await db.query(
+				'UPDATE projects SET container_status = $1::container_status, container_error = NULL WHERE id = $2',
+				[ContainerStatus.Running, proj.id],
+			);
+			if (deps.containerLogStreamer && deps.logs) {
+				deps.containerLogStreamer.subscribe(proj.id, proj.container_id, deps.logs, docker);
+			}
+			await broadcastProjectUpdate(db, deps.wsManager, proj.team_id, proj.id);
+			return proj.container_id;
+		}
+	}
+
+	// No container id, or the stored id no longer exists in Docker — provision.
+	return provisionContainer(deps, proj, proj.team_slug);
+}
+
 export async function teardownContainer(
 	deps: ContainerDeps,
 	projectId: string,

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -191,6 +191,7 @@ export async function startup(config: HezoConfig): Promise<StartupResult> {
 		sshAgentServer,
 		egressProxy,
 		egressCAPath: egressCA.certPath,
+		containerLogStreamer,
 	});
 
 	const { seedDefaultTeam, ensureChatMemoryDoc } = await import('./services/teams.js');

--- a/packages/server/test/ceo-session.test.ts
+++ b/packages/server/test/ceo-session.test.ts
@@ -195,6 +195,38 @@ describe('CeoSessionManager', () => {
 		await manager.stop();
 	});
 
+	test('provisions the HQ container on demand when it is not running', async () => {
+		// A fresh instance exposes the CEO chat before any project is created, so the
+		// HQ container may never have been provisioned. The turn must bring it up
+		// rather than failing with "HQ container is not running".
+		await ctx.db.query(
+			`UPDATE projects SET container_id = NULL, container_status = 'stopped'
+			 WHERE team_id = $1 AND is_internal = true`,
+			[DEFAULT_TEAM_ID],
+		);
+
+		const chat = makeChatDocker(ctx.dataDir, projectId);
+		const { manager } = makeManager(ctx, chat.docker);
+
+		const { assistantMessageId } = await manager.sendTurn({ text: 'Hello CEO' });
+		await poll(async () => {
+			const r = await ctx.db.query<{ status: string }>(
+				'SELECT status FROM ceo_messages WHERE id = $1',
+				[assistantMessageId],
+			);
+			return r.rows[0]?.status === CeoMessageStatus.Complete;
+		});
+
+		const proj = await ctx.db.query<{ container_id: string | null; container_status: string }>(
+			`SELECT container_id, container_status FROM projects WHERE team_id = $1 AND is_internal = true`,
+			[DEFAULT_TEAM_ID],
+		);
+		expect(proj.rows[0].container_status).toBe('running');
+		expect(proj.rows[0].container_id).toBeTruthy();
+
+		await manager.stop();
+	});
+
 	test('second turn composes prior history into the prompt', async () => {
 		const chat = makeChatDocker(ctx.dataDir, projectId);
 		const { manager } = makeManager(ctx, chat.docker);


### PR DESCRIPTION
## Problem

The CEO chat widget is mounted app-wide and reachable from first load — **before any project is created**. The HQ (internal) project's container, however, was only ever started on project creation, repo-add, or a restart of an already-running container. So on a fresh instance, sending a CEO chat message failed:

```
CEO_UNAVAILABLE: HQ container is not running
```

`CeoSessionManager.startSession()` threw because the HQ project's `container_status` was never `running`.

## Fix

Bring the HQ container up **on demand** instead of failing the turn.

- **`containers.ts`** — new shared `ensureProjectContainerRunning(deps, projectId)`: returns the running container id if Docker confirms it, starts a stopped-but-existing container in place, or provisions from scratch when the container is missing / never created. Repairs stale `running` rows that no longer map to a live container.
- **`ceo-session-manager.ts`** — `startSession()` calls the helper when the HQ container isn't running. Threads `containerLogStreamer` through `CeoSessionDeps` + a `buildContainerDeps()` helper so the on-demand HQ provision streams logs.
- **`startup.ts`** — passes `containerLogStreamer` into the manager.
- **`repos.ts`** — refactored `ensureProjectContainerUp` onto the shared helper, removing duplicated provisioning logic (it now also handles the start-in-place case it previously skipped).

## Tests

Added a `ceo-session.test.ts` case: with the HQ container not running, a turn provisions it (project becomes `running` with a container id) and the reply completes. All CEO-session (9) and repos (21) tests pass; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)