### PR TITLE
feat: auto-open the browser on startup, skipping headless environments

### DIFF
--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -20,7 +20,7 @@ handy for baking defaults into a service definition while still overriding per r
 | `--master-key <phrase>` | `HEZO_MASTER_KEY` | — | The twelve-word master key, to set up or unlock without the web gate. |
 | `--web-url <url>` | `HEZO_WEB_URL` | same origin | Public base URL, used so account sign-ins redirect back correctly. |
 | `--reset` | `HEZO_RESET` | off | Start fresh with an empty database (the existing `pgdata` is renamed aside, not deleted). |
-| `--open` | `HEZO_OPEN` | off | Open the web app in your browser on startup. |
+| `--no-open` | `HEZO_OPEN` | on | Auto-open the web app in your browser on startup. On by default; automatically skipped in environments without a browser (CI, containers, SSH, headless Linux). Pass `--no-open` or set `HEZO_OPEN=0` to disable. |
 | `--log-level <level>` | `HEZO_LOG_LEVEL` | `info` | Logging verbosity: `debug`, `info`, `warn`, or `error`. |
 | `--keep-old-containers` | `HEZO_KEEP_OLD_CONTAINERS` | off | Keep old project containers instead of removing them — for debugging a crashed container. |
 | — | `HEZO_DISABLE_AUTO_UPDATE` | off | Disable the in-app auto-update (release check, download, and the "Download & Restart" banner). |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -28,8 +28,13 @@ hezo --port 8080                 # listen on a different port
 hezo --data-dir /var/lib/hezo    # use a specific data directory
 hezo --master-key "<phrase>"     # set up or unlock without the web gate
 hezo --web-url https://hezo.example.com   # public base URL for sign-in redirects
-hezo --open                      # open the web app in your browser on start
+hezo --no-open                   # don't open the web app in your browser on start
 ```
+
+On a desktop machine Hezo opens the web app in your default browser once the server is
+ready. It skips this automatically in environments without a browser — CI, containers,
+SSH sessions, and headless Linux (no `DISPLAY`/`WAYLAND_DISPLAY`) — and logs where to
+point your browser instead. Use `--no-open` (or `HEZO_OPEN=0`) to turn it off.
 
 ## Restore a snapshot
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -32,7 +32,7 @@ Starts the server on port 3100 with hot reload. In dev, PGlite data persists at 
 | `--master-key <phrase>` | — | Twelve-word master key to set up/unlock on startup (env: `HEZO_MASTER_KEY`) |
 | `--web-url <url>` | same origin | Public base URL for sign-in redirects (env: `HEZO_WEB_URL`) |
 | `--reset` | `false` | Start fresh (existing `pgdata` is renamed aside, not deleted) (env: `HEZO_RESET`) |
-| `--open` | `false` | Open the web app in the browser on startup (env: `HEZO_OPEN`) |
+| `--no-open` | open on | Auto-open the web app in the browser on startup (on by default; skipped automatically in CI/containers/SSH/headless Linux). Disable with `--no-open` or `HEZO_OPEN=0` |
 | `--log-level <level>` | `info` | Logging verbosity: `debug`, `info`, `warn`, `error` (env: `HEZO_LOG_LEVEL`) |
 | `--keep-old-containers` | `false` | Keep old project containers instead of removing them, for debugging (env: `HEZO_KEEP_OLD_CONTAINERS`) |
 

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -143,7 +143,7 @@ export function parseConfig(
 		)
 		.option('--web-url <url>', 'Web UI base URL for redirects (env: HEZO_WEB_URL)', '')
 		.option('--reset', 'Reset database and start fresh (env: HEZO_RESET)')
-		.option('--open', 'Auto-open the browser (env: HEZO_OPEN)')
+		.option('--no-open', 'Do not auto-open the browser on startup (env: HEZO_OPEN=0)')
 		.option(
 			'--log-level <level>',
 			'Log level: debug | info | warn | error (env: HEZO_LOG_LEVEL)',
@@ -171,6 +171,14 @@ export function parseConfig(
 		if (e !== undefined) return parseBool(e);
 		return cliValue === true;
 	};
+	// Like pickBool but defaults to ON. Commander's `--no-open` sets cli.open to
+	// false when passed and true otherwise, so the only way to disable via CLI is
+	// `--no-open`; the env var still wins when set.
+	const pickOpen = (envName: string, cliValue: unknown): boolean => {
+		const e = env[envName];
+		if (e !== undefined && e !== '') return parseBool(e);
+		return cliValue !== false;
+	};
 
 	const masterKeyRaw = pick('HEZO_MASTER_KEY', cli.masterKey);
 
@@ -180,7 +188,10 @@ export function parseConfig(
 		masterKey: masterKeyRaw ? parseMasterKey(masterKeyRaw) : undefined,
 		webUrl: pick('HEZO_WEB_URL', cli.webUrl) ?? '',
 		reset: pickBool('HEZO_RESET', cli.reset),
-		open: pickBool('HEZO_OPEN', cli.open),
+		// Auto-open is on by default; headless detection at startup decides whether
+		// a browser actually launches. HEZO_OPEN=0 / --no-open disables it. With
+		// `--no-open` commander sets cli.open=false; absent, it defaults to true.
+		open: pickOpen('HEZO_OPEN', cli.open),
 		logLevel: parseLogLevel(pick('HEZO_LOG_LEVEL', cli.logLevel) ?? 'info'),
 		keepOldContainers: pickBool('HEZO_KEEP_OLD_CONTAINERS', cli.keepOldContainers),
 	};

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,10 +1,12 @@
+import { existsSync } from 'node:fs';
 import type { PGlite } from '@electric-sql/pglite';
-import { AuthType, DEFAULT_WEB_PORT } from '@hezo/shared';
+import { AuthType } from '@hezo/shared';
 import { app } from './app';
 import { parseConfig, runRestore } from './cli';
 import type { MasterKeyManager } from './crypto/master-key';
 import { PgDataCorruptError } from './db/client';
 import { DbNewerThanAppError, MigrationFailedError } from './db/migrate-errors';
+import { browserAvailable, openBrowser } from './lib/open-browser';
 import type { AuthInfo } from './lib/types';
 import { logger, setLogLevel } from './logger';
 import { canAuthAccessTeam, loadAdminAuth, verifyToken } from './middleware/auth';
@@ -213,7 +215,20 @@ void (async () => {
 		const url = `http://localhost:${result.port}`;
 		log.info(`Hezo server running at ${url} [${result.masterKeyState}]`);
 		if (config.open) {
-			Bun.spawn(['open', `http://localhost:${DEFAULT_WEB_PORT}`]);
+			// In dev the SPA is served by Vite (config.webUrl); the compiled
+			// binary serves it from the server port. Prefer the configured web URL.
+			const target = config.webUrl || url;
+			const decision = browserAvailable({
+				platform: process.platform,
+				env: process.env,
+				hasDockerEnv: existsSync('/.dockerenv'),
+			});
+			if (decision.available) {
+				log.info(`Opening ${target} in your browser…`);
+				openBrowser(target);
+			} else {
+				log.info(`Not opening a browser (${decision.reason}). Visit ${target}`);
+			}
 		}
 	} catch (err) {
 		if (thisStartupGeneration !== startupGeneration) return;

--- a/packages/server/src/lib/open-browser.ts
+++ b/packages/server/src/lib/open-browser.ts
@@ -1,0 +1,72 @@
+import { logger } from '../logger';
+
+const log = logger.child('open-browser');
+
+export interface BrowserAvailabilityInput {
+	platform: NodeJS.Platform;
+	env: NodeJS.ProcessEnv;
+	/** True when `/.dockerenv` exists — a strong signal we're inside a container. */
+	hasDockerEnv: boolean;
+}
+
+export interface BrowserAvailability {
+	available: boolean;
+	/** Human-readable reason why a browser can't/shouldn't be opened. */
+	reason?: string;
+}
+
+/**
+ * Decide whether it's sensible to auto-open a browser in the current
+ * environment. Pure and deterministic given its input so it can be unit-tested
+ * across platforms without touching the host. The caller is responsible for
+ * gathering the inputs (process.platform, process.env, /.dockerenv existence).
+ *
+ * Returns unavailable for the environments where a GUI browser either doesn't
+ * exist or opening one would be wrong: CI, containers, SSH sessions, and
+ * headless Linux (no X/Wayland display). Desktop macOS and Windows are assumed
+ * to have a browser.
+ */
+export function browserAvailable(input: BrowserAvailabilityInput): BrowserAvailability {
+	const { platform, env, hasDockerEnv } = input;
+
+	if (env.CI) {
+		return { available: false, reason: 'running in CI' };
+	}
+	if (hasDockerEnv || env.container) {
+		return { available: false, reason: 'running in a container' };
+	}
+	if (env.SSH_CONNECTION || env.SSH_CLIENT || env.SSH_TTY) {
+		return { available: false, reason: 'running over SSH' };
+	}
+	// Linux without an X11 or Wayland display has no GUI to open into. macOS and
+	// Windows always have a windowing system available to a desktop session.
+	if (platform === 'linux' && !env.DISPLAY && !env.WAYLAND_DISPLAY) {
+		return { available: false, reason: 'no display detected' };
+	}
+	return { available: true };
+}
+
+/**
+ * The platform-appropriate launcher command for opening `url` in the default
+ * browser: `open` on macOS, `start` (via cmd) on Windows, `xdg-open` elsewhere.
+ * Pure so the mapping can be unit-tested without spawning a process.
+ */
+export function browserOpenCommand(platform: NodeJS.Platform, url: string): string[] {
+	if (platform === 'darwin') return ['open', url];
+	if (platform === 'win32') return ['cmd', '/c', 'start', '""', url];
+	return ['xdg-open', url];
+}
+
+/**
+ * Open `url` in the user's default browser. Fire-and-forget and best-effort:
+ * never throws — a failure to launch must not take down the server. Callers
+ * should gate this with {@link browserAvailable}.
+ */
+export function openBrowser(url: string): void {
+	const cmd = browserOpenCommand(process.platform, url);
+	try {
+		Bun.spawn(cmd, { stdio: ['ignore', 'ignore', 'ignore'] });
+	} catch (err) {
+		log.warn(`Failed to open browser at ${url}:`, err);
+	}
+}

--- a/packages/server/test/cli.test.ts
+++ b/packages/server/test/cli.test.ts
@@ -22,7 +22,7 @@ describe('parseConfig', () => {
 		expect(config.dataDir).toBe(resolve(homedir(), '.hezo'));
 		expect(config.masterKey).toBeUndefined();
 		expect(config.reset).toBe(false);
-		expect(config.open).toBe(false);
+		expect(config.open).toBe(true);
 		expect(config.logLevel).toBe('info');
 		expect(config.keepOldContainers).toBe(false);
 	});
@@ -78,9 +78,18 @@ describe('parseConfig', () => {
 		expect(config.reset).toBe(true);
 	});
 
-	it('parses --open', () => {
-		const config = parseConfig(argv('--open'), EMPTY_ENV);
-		expect(config.open).toBe(true);
+	it('defaults open to true and disables it with --no-open', () => {
+		expect(parseConfig(argv(), EMPTY_ENV).open).toBe(true);
+		expect(parseConfig(argv('--no-open'), EMPTY_ENV).open).toBe(false);
+	});
+
+	it('lets HEZO_OPEN override the default and --no-open', () => {
+		// Env wins over both the default and the CLI flag.
+		expect(parseConfig(argv(), { HEZO_OPEN: '0' }).open).toBe(false);
+		expect(parseConfig(argv(), { HEZO_OPEN: 'false' }).open).toBe(false);
+		expect(parseConfig(argv('--no-open'), { HEZO_OPEN: '1' }).open).toBe(true);
+		// An empty env value falls through to the CLI/default.
+		expect(parseConfig(argv(), { HEZO_OPEN: '' }).open).toBe(true);
 	});
 
 	it('parses --log-level', () => {
@@ -107,7 +116,7 @@ describe('parseConfig', () => {
 				'--master-key',
 				PHRASE,
 				'--reset',
-				'--open',
+				'--no-open',
 			),
 			EMPTY_ENV,
 		);
@@ -115,7 +124,7 @@ describe('parseConfig', () => {
 		expect(config.dataDir).toBe('/tmp/hezo');
 		expect(config.masterKey?.unlockKeyHex).toBe(deriveUnlockKey(PHRASE));
 		expect(config.reset).toBe(true);
-		expect(config.open).toBe(true);
+		expect(config.open).toBe(false);
 	});
 
 	describe('env vars take precedence over CLI args', () => {

--- a/packages/server/test/open-browser.test.ts
+++ b/packages/server/test/open-browser.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import {
+	type BrowserAvailabilityInput,
+	browserAvailable,
+	browserOpenCommand,
+} from '../src/lib/open-browser';
+
+const base: BrowserAvailabilityInput = {
+	platform: 'darwin',
+	env: {},
+	hasDockerEnv: false,
+};
+
+describe('browserAvailable', () => {
+	it('reports available on desktop platforms', () => {
+		expect(browserAvailable({ ...base, platform: 'darwin' }).available).toBe(true);
+		expect(browserAvailable({ ...base, platform: 'win32' }).available).toBe(true);
+		// Linux with a display present is fine.
+		expect(browserAvailable({ ...base, platform: 'linux', env: { DISPLAY: ':0' } }).available).toBe(
+			true,
+		);
+		expect(
+			browserAvailable({ ...base, platform: 'linux', env: { WAYLAND_DISPLAY: 'wayland-0' } })
+				.available,
+		).toBe(true);
+	});
+
+	it('skips in CI regardless of platform', () => {
+		const r = browserAvailable({ ...base, env: { CI: 'true' } });
+		expect(r.available).toBe(false);
+		expect(r.reason).toMatch(/CI/);
+	});
+
+	it('skips inside a container (dockerenv or container env)', () => {
+		expect(browserAvailable({ ...base, hasDockerEnv: true }).available).toBe(false);
+		const r = browserAvailable({ ...base, env: { container: 'podman' } });
+		expect(r.available).toBe(false);
+		expect(r.reason).toMatch(/container/);
+	});
+
+	it('skips over SSH sessions', () => {
+		for (const key of ['SSH_CONNECTION', 'SSH_CLIENT', 'SSH_TTY']) {
+			const r = browserAvailable({ ...base, env: { [key]: 'x' } });
+			expect(r.available).toBe(false);
+			expect(r.reason).toMatch(/SSH/);
+		}
+	});
+
+	it('skips on headless Linux with no display', () => {
+		const r = browserAvailable({ ...base, platform: 'linux', env: {} });
+		expect(r.available).toBe(false);
+		expect(r.reason).toMatch(/display/);
+	});
+
+	it('does not require a display on macOS/Windows', () => {
+		expect(browserAvailable({ ...base, platform: 'darwin', env: {} }).available).toBe(true);
+		expect(browserAvailable({ ...base, platform: 'win32', env: {} }).available).toBe(true);
+	});
+});
+
+describe('browserOpenCommand', () => {
+	it('picks the platform launcher', () => {
+		expect(browserOpenCommand('darwin', 'http://x')).toEqual(['open', 'http://x']);
+		expect(browserOpenCommand('win32', 'http://x')).toEqual([
+			'cmd',
+			'/c',
+			'start',
+			'""',
+			'http://x',
+		]);
+		expect(browserOpenCommand('linux', 'http://x')).toEqual(['xdg-open', 'http://x']);
+	});
+});

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -66,7 +66,13 @@ const webPort = process.env.HEZO_WEB_PORT ?? '5173';
 // Default the web URL for redirects unless the caller set their own, then
 // forward every flag through untouched.
 const hasWebUrl = forwardedArgs.some((a) => a === '--web-url' || a.startsWith('--web-url='));
+// Auto-open is the server's default, but dev is restarted constantly — spawning
+// a browser tab each time is noise. Suppress it by default; HEZO_OPEN=1 in the
+// inherited env still wins (the env var takes precedence over this flag), and we
+// don't double-pass if the caller already forwarded --no-open.
+const hasNoOpen = forwardedArgs.includes('--no-open');
 const serverArgs: string[] = [
+	...(hasNoOpen ? [] : ['--no-open']),
 	...(hasWebUrl ? [] : ['--web-url', `http://localhost:${webPort}`]),
 	// Only inject when we fell back to the dev default — otherwise the server
 	// already sees the user's choice via inherited env or forwardedArgs.


### PR DESCRIPTION
## What & why

Running `hezo` from the command line now **automatically opens the web app in the default browser** once the server is ready, instead of printing the URL and leaving the user to copy it. Crucially, it **skips environments where no browser/UI is available** and logs where to point a browser instead.

The previous `--open` flag was opt-in, macOS-only (`open`), and opened the wrong (hardcoded dev) port. This makes auto-open the default and does it correctly and safely.

## Behaviour

- **On by default.** A desktop session opens the web app automatically.
- **Auto-skips** when a browser isn't available: CI (`CI`), containers (`/.dockerenv` or `container`), SSH sessions (`SSH_CONNECTION`/`SSH_CLIENT`/`SSH_TTY`), and headless Linux (no `DISPLAY`/`WAYLAND_DISPLAY`). In those cases it logs `Not opening a browser (<reason>). Visit <url>` and keeps serving.
- **Disable** with `--no-open` or `HEZO_OPEN=0`.
- **Correct URL:** opens `config.webUrl` when set, otherwise the actual server URL (`http://localhost:<port>`) — the compiled binary serves the SPA from the server port.
- **Cross-platform launcher:** `open` (macOS), `start` (Windows), `xdg-open` (Linux).
- **`bun run dev` stays quiet** — the dev script forwards `--no-open` so frequent restarts don't spawn tabs.

## Changes

- **New** `packages/server/src/lib/open-browser.ts` — `browserAvailable()` (pure, testable headless detection), `browserOpenCommand()` (pure launcher mapping), and fire-and-forget `openBrowser()` (never throws).
- `packages/server/src/cli.ts` — auto-open default-on; `--open` replaced by `--no-open`; env precedence preserved.
- `packages/server/src/index.ts` — wires detection + correct target URL into startup.
- `scripts/dev.ts` — forwards `--no-open`.
- Tests: `test/open-browser.test.ts` (detection + command selection), updated `test/cli.test.ts` (flipped default, `--no-open`, `HEZO_OPEN` precedence).
- Docs: `docs/reference/cli.md`, `docs/deployment/configuration.md`, `packages/server/README.md`.

## Verification

- `bunx vitest run test/open-browser.test.ts test/cli.test.ts` — 35 passing.
- `bun run typecheck` — clean. Docs-bundle drift test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NpADPPL6rhvDhPpu1ZRTK4

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpADPPL6rhvDhPpu1ZRTK4)_