### PR TITLE
feat(updates): background-download before showing "Install & restart"

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -684,12 +684,17 @@ and on the worker's exit either propagates the code (normal exit/crash → exter
 policies behave as before) or, on the **restart sentinel** `UPDATE_RESTART_EXIT_CODE` (75),
 applies the staged binary and relaunches. The supervisor branch sits in `index.ts` right
 after the `restore` subcommand and before preflights, so dev (`bun run`) and `hezo restore`
-never supervise. The `updater.ts` service handles the rest: a daily `update-check` cron
-(`HEZO_UPDATE_CHECK_CRON`) and `POST /api/updates/download` download the platform asset +
-`SHA256SUMS`, verify the hash, and stage to `<dataDir>/.update/staged[.exe]` (recording
-lifecycle in `state.json`); `POST /api/updates/apply` (superuser) gracefully shuts the
-worker down (`shutdownRuntime` in `runtime-control.ts`, also wired to signals) and exits
-with the sentinel. `applyStagedUpdate()` does the swap *while the worker is down*: copy
+never supervise. The `updater.ts` service handles the rest. Staging is **proactive**: the
+idempotent `ensureUpdateStaged()` downloads the platform asset + `SHA256SUMS`, verifies the
+hash, and stages to `<dataDir>/.update/staged[.exe]` (recording lifecycle in `state.json`),
+retrying once on failure (a second failure leaves `state.json` in `Error` for that version,
+honored as "retry exhausted" so polls don't re-download). It runs from `GET /api/updates/status`
+(fire-and-forget on every banner poll, gated on `isSupervisedWorker()`) and the daily
+`update-check` cron (`HEZO_UPDATE_CHECK_CRON`), so a running instance usually stages a new
+release within seconds. `POST /api/updates/download` (superuser) is the same download path on
+demand; `POST /api/updates/apply` (superuser) gracefully shuts the worker down (`shutdownRuntime`
+in `runtime-control.ts`, also wired to signals) and exits with the sentinel.
+`applyStagedUpdate()` does the swap *while the worker is down*: copy
 staged → a temp file adjacent to the target (avoids `EXDEV`), then **Unix** atomic `rename`
 over the binary, or **Windows** rename-trick (rename the locked `.exe` aside, move the new
 one in, verify, roll back on failure; stale `-old-` files swept on next supervisor start).
@@ -697,7 +702,10 @@ State survives the restart via the normal recovery path (`reconcileOnStartup`), 
 instance returns **locked** unless `HEZO_MASTER_KEY` is set (the web restart overlay polls
 `/api/status` and reloads onto the master-key gate). `GET /api/updates/status` surfaces the
 staged-update state plus an `autoUnlock` hint so the UI's confirmation can warn about the
-master-key re-unlock.
+master-key re-unlock. The web banner shows an **"Install & restart"** button only once the
+binary is `Staged` (so the restart is instant); while the background download is in flight it
+stays hidden, and on a download `Error` (or for any instance that can't self-apply) it falls
+back to a **"Download"** link to the GitHub release page.
 
 **Known limits.** macOS binaries are unsigned (built on Linux; clear quarantine with `xattr -d`);
 on Apple Silicon an unsigned replacement may still be Gatekeeper-blocked. Windows self-update

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -23,8 +23,8 @@ handy for baking defaults into a service definition while still overriding per r
 | `--open` | `HEZO_OPEN` | off | Open the web app in your browser on startup. |
 | `--log-level <level>` | `HEZO_LOG_LEVEL` | `info` | Logging verbosity: `debug`, `info`, `warn`, or `error`. |
 | `--keep-old-containers` | `HEZO_KEEP_OLD_CONTAINERS` | off | Keep old project containers instead of removing them — for debugging a crashed container. |
-| — | `HEZO_DISABLE_AUTO_UPDATE` | off | Disable the in-app auto-update (release check, download, and the "Download & Restart" banner). |
-| — | `HEZO_UPDATE_CHECK_CRON` | `0 0 4 * * *` | Cron schedule (seconds-precision) for the daily check that downloads and stages a newer release. |
+| — | `HEZO_DISABLE_AUTO_UPDATE` | off | Disable the in-app auto-update (release check, the background download, and the "Install & restart" banner). When disabled the banner instead links to the GitHub release page. |
+| — | `HEZO_UPDATE_CHECK_CRON` | `0 0 4 * * *` | Cron schedule (seconds-precision) for the daily check that downloads and stages a newer release. A running instance also stages as soon as it detects an update, so the banner's "Install & restart" is instant. |
 
 ## Examples
 

--- a/docs/deployment/self-hosting.md
+++ b/docs/deployment/self-hosting.md
@@ -138,11 +138,13 @@ server brokers itself — there is no separate gateway service or port.
 
 ### In-app auto-update
 
-Hezo checks GitHub Releases daily and, when a newer version is available,
-downloads and verifies the binary for your platform in the background. A bar
-then appears at the bottom of the web UI; a superuser clicks **Update &
-restart** and confirms. Hezo shuts down gracefully, swaps in the new binary, and
-restarts onto it — no manual file replacement.
+Hezo checks GitHub Releases and, when a newer version is available, downloads and
+verifies the binary for your platform in the background. Once it's staged, a bar
+appears in the web UI; a superuser clicks **Install & restart** and confirms.
+Because the download already happened, the restart is instant — Hezo shuts down
+gracefully, swaps in the new binary, and restarts onto it, with no manual file
+replacement. (If the background download is disabled or can't run — for example
+inside a container — the bar instead links to the GitHub release page.)
 
 Because the restart re-locks the instance, **you'll need your 12-word master key
 to unlock Hezo again afterward** — unless you run Hezo with the master key set in

--- a/packages/server/src/routes/updates.ts
+++ b/packages/server/src/routes/updates.ts
@@ -6,7 +6,12 @@ import type { Env } from '../lib/types';
 import { logger } from '../logger';
 import { requireSuperuser } from '../middleware/auth';
 import { getActiveRuntime, shutdownRuntime } from '../runtime-control';
-import { downloadAndStage, isAutoUpdateEnabled, readUpdateState } from '../services/updater';
+import {
+	downloadAndStage,
+	ensureUpdateStaged,
+	isSupervisedWorker,
+	readUpdateState,
+} from '../services/updater';
 import { HEZO_VERSION } from '../version';
 
 const log = logger.child('updates');
@@ -78,11 +83,6 @@ export async function getLatestInfo(): Promise<UpdateInfo> {
 	return cache.data;
 }
 
-/** True only in a supervised worker that can actually restart-with-swap. */
-function isSupervisedWorker(): boolean {
-	return isAutoUpdateEnabled() && process.env.HEZO_WORKER === '1';
-}
-
 /**
  * Build the updates router. `autoUnlock` reflects whether a master key is
  * configured at startup (env/CLI) — when true the instance auto-unlocks after a
@@ -98,6 +98,15 @@ export function buildUpdatesRoutes(opts: { autoUnlock: boolean }): Hono<Env> {
 	routes.get('/updates/status', async (c) => {
 		const dataDir = c.get('dataDir');
 		const [latest, state] = await Promise.all([getLatestInfo(), readUpdateState(dataDir)]);
+		// Kick a background download as soon as the UI knows an update exists, so the
+		// banner's "Install & restart" is instant. Idempotent — repeated polls no-op.
+		if (isSupervisedWorker()) {
+			trackBackground(
+				ensureUpdateStaged(dataDir, getLatestInfo).catch((e) =>
+					log.error('auto-stage trigger failed', e),
+				),
+			);
+		}
 		return c.json({
 			...latest,
 			state: state.state,

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -13,7 +13,6 @@ import {
 	TaskPriority,
 	TaskStatus,
 	TERMINAL_TASK_STATUSES,
-	UpdateState,
 	WakeupSkipReason,
 	WakeupSource,
 	WakeupStatus,
@@ -58,7 +57,7 @@ import { ensureRepoSetupAction } from './repo-setup';
 import { getProjectConcurrency, isTaskBusyInDb } from './run-concurrency';
 import type { SshAgentServer } from './ssh-agent';
 import { triggerStatusAutomations } from './task-automation';
-import { downloadAndStage, isAutoUpdateEnabled, readUpdateState } from './updater';
+import { ensureUpdateStaged, isSupervisedWorker } from './updater';
 import { absorbQueuedTaskWakeups, assignmentWakeupAlreadyServed, createWakeup } from './wakeup';
 import type { WebSocketManager } from './ws';
 
@@ -2037,16 +2036,12 @@ export class JobManager {
 	/**
 	 * Daily auto-update check. When the feature is enabled (supervised compiled
 	 * binary) and a newer release exists that isn't already staged/downloading,
-	 * download+verify+stage it so an operator "Update & restart" is instant.
+	 * download+verify+stage it so an operator "Install & restart" is instant. The
+	 * status poll triggers the same idempotent helper, so a running instance
+	 * usually stages well before this daily run.
 	 */
 	private async checkForUpdate(): Promise<void> {
-		if (!isAutoUpdateEnabled() || process.env.HEZO_WORKER !== '1') return;
-		const latest = await getLatestInfo();
-		if (!latest.updateAvailable || !latest.latest) return;
-		const state = await readUpdateState(this.deps.dataDir);
-		if (state.state === UpdateState.Downloading) return;
-		if (state.state === UpdateState.Staged && state.targetVersion === latest.latest) return;
-		log.info(`Auto-update: staging release ${latest.latest}`);
-		await downloadAndStage(latest.latest, this.deps.dataDir);
+		if (!isSupervisedWorker()) return;
+		await ensureUpdateStaged(this.deps.dataDir, getLatestInfo);
 	}
 }

--- a/packages/server/src/services/updater.ts
+++ b/packages/server/src/services/updater.ts
@@ -71,6 +71,16 @@ export function isAutoUpdateEnabled(): boolean {
 }
 
 /**
+ * True only in a supervised worker that can actually restart-with-swap: the
+ * feature is enabled *and* we're the worker process (`HEZO_WORKER=1`) that the
+ * supervisor relaunches. The status route, download/apply routes, and the cron
+ * all gate on this before kicking any background staging.
+ */
+export function isSupervisedWorker(): boolean {
+	return isAutoUpdateEnabled() && process.env.HEZO_WORKER === '1';
+}
+
+/**
  * Release asset name for the current platform, matching the `TARGETS` mapping in
  * `scripts/build.ts` (`hezo-{os}-{arch}[.exe]`). Throws on an unsupported combo
  * (e.g. windows/arm64, for which we ship no binary).
@@ -199,6 +209,46 @@ export async function downloadAndStage(version: string, dataDir: string): Promis
 		});
 		await rm(stagedPath(dataDir), { force: true }).catch(() => {});
 		throw err;
+	}
+}
+
+/**
+ * Idempotent "make sure the latest release is staged" entry point, safe to call
+ * fire-and-forget from the status poll, the daily cron, and startup. Downloads in
+ * the background so an operator's "Install & restart" is instant. Callers gate on
+ * `isSupervisedWorker()` first; this helper assumes the feature is available.
+ *
+ * Retries the download once on failure; a second failure leaves `state.json` in
+ * `Error` for that version, which is then honored as "retry exhausted" so we
+ * don't re-download on every subsequent status poll. The web banner falls back
+ * to a release-page link in that case.
+ *
+ * `latestInfo` is injectable so the route/cron can reuse their cached lookup and
+ * tests can stub it without network.
+ */
+export async function ensureUpdateStaged(
+	dataDir: string,
+	latestInfo: () => Promise<{ latest: string | null; updateAvailable: boolean }>,
+): Promise<void> {
+	const latest = await latestInfo();
+	if (!latest.updateAvailable || !latest.latest) return;
+	const version = latest.latest;
+
+	const state = await readUpdateState(dataDir);
+	if (state.state === UpdateState.Downloading) return;
+	if (state.state === UpdateState.Staged && state.targetVersion === version) return;
+	if (state.state === UpdateState.Error && state.targetVersion === version) return;
+
+	try {
+		await downloadAndStage(version, dataDir);
+	} catch {
+		// One retry — `downloadAndStage` has already recorded the Error state and
+		// cleared the partial binary; a second throw leaves it Error (retry done).
+		try {
+			await downloadAndStage(version, dataDir);
+		} catch (err) {
+			log.error('auto-stage failed after retry', err);
+		}
 	}
 }
 

--- a/packages/server/test/updater.test.ts
+++ b/packages/server/test/updater.test.ts
@@ -9,6 +9,7 @@ import {
 	applyStagedUpdate,
 	currentAssetName,
 	downloadAndStage,
+	ensureUpdateStaged,
 	readUpdateState,
 } from '../src/services/updater';
 
@@ -76,6 +77,121 @@ describe('downloadAndStage', () => {
 			expect(existsSync(join(dir, '.update', 'staged'))).toBe(false);
 			const state = await readUpdateState(dir);
 			expect(state.state).toBe(UpdateState.Error);
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe('ensureUpdateStaged', () => {
+	afterEach(() => vi.restoreAllMocks());
+
+	/** A stubbed latest-release lookup (no network). */
+	const latest =
+		(updateAvailable = true, version: string | null = '9.9.9') =>
+		async () => ({ updateAvailable, latest: version });
+
+	async function seedState(dir: string, s: Record<string, unknown>): Promise<void> {
+		await mkdir(join(dir, '.update'), { recursive: true });
+		await writeFile(join(dir, '.update', 'state.json'), JSON.stringify(s));
+	}
+
+	/** Mock a healthy release; `onAsset` lets a test fail specific attempts. */
+	function mockRelease(bytes: Buffer, onAsset?: () => Response | null) {
+		const sha = createHash('sha256').update(bytes).digest('hex');
+		return vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+			const url = String(input);
+			if (url.endsWith('/SHA256SUMS')) {
+				return new Response(`${sha}  ${currentAssetName()}\n`, { status: 200 });
+			}
+			return onAsset?.() ?? new Response(bytes, { status: 200 });
+		});
+	}
+
+	it('stages when idle and an update is available', async () => {
+		const dir = await tmp('hezo-ensure-idle-');
+		try {
+			const fetchSpy = mockRelease(Buffer.from('new binary'));
+			await ensureUpdateStaged(dir, latest());
+			expect(fetchSpy).toHaveBeenCalled();
+			const state = await readUpdateState(dir);
+			expect(state.state).toBe(UpdateState.Staged);
+			expect(state.targetVersion).toBe('9.9.9');
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	it('no-ops when no newer release is available', async () => {
+		const dir = await tmp('hezo-ensure-none-');
+		try {
+			const fetchSpy = vi.spyOn(globalThis, 'fetch');
+			await ensureUpdateStaged(dir, latest(false, null));
+			expect(fetchSpy).not.toHaveBeenCalled();
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	it('no-ops when already staged for the same version', async () => {
+		const dir = await tmp('hezo-ensure-staged-');
+		try {
+			await seedState(dir, { state: UpdateState.Staged, targetVersion: '9.9.9' });
+			const fetchSpy = vi.spyOn(globalThis, 'fetch');
+			await ensureUpdateStaged(dir, latest());
+			expect(fetchSpy).not.toHaveBeenCalled();
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	it('no-ops while a download is in flight', async () => {
+		const dir = await tmp('hezo-ensure-downloading-');
+		try {
+			await seedState(dir, { state: UpdateState.Downloading, targetVersion: '9.9.9' });
+			const fetchSpy = vi.spyOn(globalThis, 'fetch');
+			await ensureUpdateStaged(dir, latest());
+			expect(fetchSpy).not.toHaveBeenCalled();
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	it('does not re-download once it has errored for that version (retry exhausted)', async () => {
+		const dir = await tmp('hezo-ensure-errored-');
+		try {
+			await seedState(dir, { state: UpdateState.Error, targetVersion: '9.9.9' });
+			const fetchSpy = vi.spyOn(globalThis, 'fetch');
+			await ensureUpdateStaged(dir, latest());
+			expect(fetchSpy).not.toHaveBeenCalled();
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	it('retries the download once before succeeding', async () => {
+		const dir = await tmp('hezo-ensure-retry-ok-');
+		try {
+			let assetCalls = 0;
+			mockRelease(Buffer.from('new binary'), () => {
+				assetCalls++;
+				return assetCalls === 1 ? new Response('boom', { status: 500 }) : null;
+			});
+			await ensureUpdateStaged(dir, latest());
+			expect(assetCalls).toBe(2); // first attempt failed, retry succeeded
+			expect((await readUpdateState(dir)).state).toBe(UpdateState.Staged);
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	it('records an error (and swallows it) after the retry also fails', async () => {
+		const dir = await tmp('hezo-ensure-retry-fail-');
+		try {
+			vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('nope', { status: 500 }));
+			// Must not throw — it's fire-and-forget from the status poll/cron.
+			await expect(ensureUpdateStaged(dir, latest())).resolves.toBeUndefined();
+			expect((await readUpdateState(dir)).state).toBe(UpdateState.Error);
 		} finally {
 			await rm(dir, { recursive: true, force: true });
 		}

--- a/packages/web/src/components/update-banner.tsx
+++ b/packages/web/src/components/update-banner.tsx
@@ -1,8 +1,8 @@
 import { UpdateState } from '@hezo/shared';
 import { X } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useMe } from '../hooks/use-me';
-import { useApplyUpdate, useDownloadUpdate, useUpdateStatus } from '../hooks/use-update-check';
+import { useApplyUpdate, useUpdateStatus } from '../hooks/use-update-check';
 import { Button } from './ui/button';
 import { ConfirmDialog } from './ui/confirm-dialog';
 import { UpdateRestartOverlay } from './update-restart-overlay';
@@ -36,34 +36,26 @@ function readDismissed(): Dismissal | null {
 
 /**
  * Full-width "update available" banner pinned at the top of the shell, below the
- * nav and above content. When this instance can apply-and-restart (a supervised
- * compiled binary) and the caller is a superuser, a single "Download & Restart"
- * button stages the new binary then — after a confirmation that warns about the
- * master-key re-unlock — restarts onto it. Otherwise it falls back to a link to
- * the GitHub Release. Dismissal lasts until the next calendar day (or until a
- * newer version ships).
+ * nav and above content. The server downloads and stages the new binary in the
+ * background; when this instance can apply-and-restart (a supervised compiled
+ * binary), the caller is a superuser, and the binary is staged, an "Install &
+ * restart" button — after a confirmation that warns about the master-key
+ * re-unlock — restarts onto it instantly. While the background download is still
+ * in flight the banner stays hidden; on a download error (and for any instance
+ * that can't self-apply) it falls back to a link to the GitHub Release.
+ * Dismissal lasts until the next calendar day (or until a newer version ships).
  */
 export function UpdateBanner() {
 	const { data } = useUpdateStatus();
 	const { data: me } = useMe();
-	const download = useDownloadUpdate();
 	const apply = useApplyUpdate();
 	const [applying, setApplying] = useState(false);
 	const [confirmOpen, setConfirmOpen] = useState(false);
-	// Set when the user clicks "Download & Restart" before the binary is staged, so
-	// the confirmation opens automatically once staging finishes — one click, not two.
-	const [restartIntent, setRestartIntent] = useState(false);
 	const [dismissed, setDismissed] = useState<Dismissal | null>(readDismissed);
 
 	const latest = data?.latest ?? null;
 	const staged = data?.state === UpdateState.Staged;
-
-	useEffect(() => {
-		if (restartIntent && staged) {
-			setConfirmOpen(true);
-			setRestartIntent(false);
-		}
-	}, [restartIntent, staged]);
+	const errored = data?.state === UpdateState.Error;
 
 	if (applying) {
 		return <UpdateRestartOverlay targetVersion={data?.targetVersion ?? data?.latest ?? null} />;
@@ -72,6 +64,12 @@ export function UpdateBanner() {
 	const isDismissed =
 		dismissed !== null && dismissed.version === latest && dismissed.day === todayKey();
 	if (!data?.updateAvailable || !latest || isDismissed) return null;
+
+	const canApply = data.canApply && me?.is_superuser === true;
+	// While the server is still downloading/staging in the background there's
+	// nothing actionable yet — stay hidden until it's staged (or has errored, in
+	// which case we surface the release-page link below).
+	if (canApply && !staged && !errored) return null;
 
 	const dismiss = () => {
 		const record: Dismissal = { version: latest, day: todayKey() };
@@ -83,19 +81,9 @@ export function UpdateBanner() {
 		setDismissed(record);
 	};
 
-	const canApply = data.canApply && me?.is_superuser === true;
-	const downloading = data.state === UpdateState.Downloading || download.isPending;
-
-	// One-click "Download & Restart": stage the binary if needed, then surface the
-	// restart confirmation. If it's already staged, jump straight to the confirm.
-	const onDownloadAndRestart = () => {
-		if (staged) {
-			setConfirmOpen(true);
-			return;
-		}
-		setRestartIntent(true);
-		download.mutate();
-	};
+	// Instant restart only once the binary is staged; otherwise (download errored,
+	// or this instance can't self-apply) fall back to the release-page download.
+	const showInstall = canApply && staged;
 
 	const confirmDescription = (
 		<>
@@ -122,16 +110,15 @@ export function UpdateBanner() {
 				.
 			</span>
 			<div className="flex items-center gap-2 sm:gap-3">
-				{canApply ? (
+				{showInstall ? (
 					<Button
 						type="button"
 						variant="primary"
 						size="sm"
 						data-testid="update-restart-button"
-						onClick={onDownloadAndRestart}
-						disabled={downloading}
+						onClick={() => setConfirmOpen(true)}
 					>
-						{downloading ? 'Preparing…' : 'Download & Restart'}
+						Install & restart
 					</Button>
 				) : (
 					data.url && (
@@ -159,9 +146,9 @@ export function UpdateBanner() {
 			<ConfirmDialog
 				open={confirmOpen}
 				onOpenChange={setConfirmOpen}
-				title="Update & restart Hezo?"
+				title="Install & restart Hezo?"
 				description={confirmDescription}
-				confirmLabel="Update & restart"
+				confirmLabel="Install & restart"
 				onConfirm={async () => {
 					await apply.mutateAsync();
 					setApplying(true);

--- a/packages/web/src/hooks/use-update-check.ts
+++ b/packages/web/src/hooks/use-update-check.ts
@@ -1,5 +1,5 @@
 import type { UpdateState } from '@hezo/shared';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { api } from '../lib/api';
 import { queryKeys } from '../lib/query-keys';
 
@@ -37,7 +37,7 @@ export function useUpdateCheck() {
 
 /**
  * Latest-release info plus the staged-update lifecycle and whether this instance
- * can apply-and-restart. Drives the "Update & restart" affordance.
+ * can apply-and-restart. Drives the "Install & restart" affordance.
  */
 export function useUpdateStatus() {
 	return useQuery({
@@ -46,16 +46,6 @@ export function useUpdateStatus() {
 		staleTime: 60 * 60 * 1000,
 		gcTime: 60 * 60 * 1000,
 		retry: false,
-	});
-}
-
-/** Kick a background download+verify+stage of the latest release (superuser). */
-export function useDownloadUpdate() {
-	const qc = useQueryClient();
-	return useMutation({
-		mutationFn: () =>
-			api.post<{ state: UpdateState; targetVersion: string }>('/api/updates/download'),
-		onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.updateStatus() }),
 	});
 }
 

--- a/packages/web/test/update-banner.test.tsx
+++ b/packages/web/test/update-banner.test.tsx
@@ -61,43 +61,30 @@ test('non-superuser / non-supervised falls back to a release download link', () 
 	expect(link.getAttribute('href')).toBe('https://github.com/hezo-ai/hezo/releases/0.2.0');
 });
 
-test('supervised + superuser shows a single "Download & Restart" button', () => {
-	const { getByTestId } = renderBanner({ state: UpdateState.Idle });
+test('supervised + superuser shows an "Install & restart" button when staged', () => {
+	const { getByTestId } = renderBanner({ state: UpdateState.Staged });
 	const button = getByTestId('update-restart-button');
-	expect(button.textContent).toContain('Download & Restart');
+	expect(button.textContent).toContain('Install & restart');
 });
 
-test('Download & Restart stages the binary before any confirmation', async () => {
-	const user = userEvent.setup();
-	// Refetch after the mutation invalidates the query — keep it inert/idle.
-	vi.spyOn(api, 'get').mockResolvedValue({ ...BASE, state: UpdateState.Idle });
-	const postSpy = vi
-		.spyOn(api, 'post')
-		.mockResolvedValue({ state: UpdateState.Downloading, targetVersion: '0.2.0' });
-
-	const { getByTestId, queryByTestId } = renderBanner({ state: UpdateState.Idle });
-
-	await user.click(getByTestId('update-restart-button'));
-	await waitFor(() => expect(postSpy).toHaveBeenCalledWith('/api/updates/download'));
-	// Not staged yet → no confirmation shown.
-	expect(queryByTestId('confirm-dialog')).toBeNull();
+test('banner stays hidden while the background download is in flight', () => {
+	for (const state of [UpdateState.Idle, UpdateState.Checking, UpdateState.Downloading] as const) {
+		const { queryByTestId, unmount } = renderBanner({ state });
+		expect(queryByTestId('update-banner')).toBeNull();
+		unmount();
+	}
 });
 
-test('Download & Restart auto-opens the confirmation once staging finishes', async () => {
-	const user = userEvent.setup();
-	// The post kicks staging; the status refetch it triggers reports it staged.
-	vi.spyOn(api, 'get').mockResolvedValue({ ...BASE, state: UpdateState.Staged });
-	vi.spyOn(api, 'post').mockResolvedValue({
-		state: UpdateState.Downloading,
-		targetVersion: '0.2.0',
-	});
-
-	const { getByTestId, findByTestId } = renderBanner({ state: UpdateState.Idle });
-	await user.click(getByTestId('update-restart-button'));
-	expect(await findByTestId('confirm-dialog')).toBeTruthy();
+test('a download error falls back to the release-page download link', () => {
+	const { getByTestId, getByText, queryByTestId } = renderBanner({ state: UpdateState.Error });
+	expect(getByTestId('update-banner')).toBeTruthy();
+	// No instant-restart button — the staged binary never landed.
+	expect(queryByTestId('update-restart-button')).toBeNull();
+	const link = getByText('Download') as HTMLAnchorElement;
+	expect(link.getAttribute('href')).toBe('https://github.com/hezo-ai/hezo/releases/0.2.0');
 });
 
-test('Update & restart asks for confirmation (with master-key warning) before applying', async () => {
+test('Install & restart asks for confirmation (with master-key warning) before applying', async () => {
 	const user = userEvent.setup();
 	const postSpy = vi
 		.spyOn(api, 'post')


### PR DESCRIPTION
## What & why

The update banner previously showed a single **"Download & Restart"** button. For a supervised binary + superuser, clicking it kicked the binary download, waited (`Preparing…`), then opened the restart confirmation — so the operator waited on a network download *after* deciding to update. A daily cron already pre-staged binaries, but only once a day; between runs the banner still downloaded on click.

Now the server **downloads and stages the new release in the background proactively**, and the banner only surfaces an **instant "Install & restart"** button once the binary is staged. This also brings the implementation in line with what `docs/deployment/self-hosting.md` already described.

## Behavior

- **Auto-update available (supervised binary + superuser):** the server stages the release in the background; the banner stays **hidden while downloading**, then shows **"Install & restart"** once staged → confirm → instant restart.
- **Download error:** the server **retries once**; if it still fails, the banner falls back to a **"Download"** link to the GitHub release page.
- **Self-update disabled / containerized / non-supervised / non-superuser:** unchanged — a **"Download"** link to the release page.

## How

- **`ensureUpdateStaged(dataDir, latestInfo)`** (`services/updater.ts`): one idempotent, retry-once staging entry point reused by the status poll, the daily cron, and (potentially) startup. Guards on staged/downloading/errored state so repeated polls don't re-download. Enablement is gated by a shared **`isSupervisedWorker()`** (moved into `updater.ts`).
- **`GET /api/updates/status`** fire-and-forgets `ensureUpdateStaged` (gated on `isSupervisedWorker()`), so staging starts the moment the UI knows about an update.
- **Cron `checkForUpdate`** now delegates to the same helper.
- **`update-banner.tsx`**: hide while downloading, "Install & restart" only when staged, release-link fallback on error / can't-self-apply. Removed the on-click download flow and the now-dead `useDownloadUpdate` hook (the `POST /api/updates/download` route stays as the on-demand path).
- Docs/architecture synced: `.dev/architecture.md`, `docs/deployment/configuration.md`, `docs/deployment/self-hosting.md`.

## Tests

- `packages/server/test/updater.test.ts`: new `ensureUpdateStaged` cases — stages when idle, no-ops when no update / already staged / downloading / errored-same-version, retries once then succeeds, records error (and swallows it) after the retry also fails.
- `packages/web/test/update-banner.test.tsx`: staged → "Install & restart"; hidden while downloading; error → release-link fallback; existing confirm/apply/dismissal cases retained.
- `typecheck`, `biome check`, and the full pre-commit build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X8X2bm3innwtdosBnQMv6P

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8X2bm3innwtdosBnQMv6P)_