### PR TITLE
Warm HQ container at startup; gate CEO chat + project creation on it

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -215,6 +215,15 @@ project.
 - **Coach** — reviews completed tickets across **every** project to improve agent system
   prompts; woken on any task completion.
 
+The **HQ container** is warmed as early as possible after boot: once the master key is
+unlocked (provisioning needs secrets/egress), `JobManager.ensureHqContainerRunning` runs
+after the container-restart reconcile pass and brings HQ up via
+`ensureProjectContainerRunning` (no-op if already running, start-in-place if stopped,
+provision if missing) — fire-and-forget so a slow image pull doesn't delay startup. This is
+unconditional because the standard restart pass deliberately leaves `stopped` projects
+alone, whereas HQ — home of the always-on CEO/Coach — should run whenever the instance does.
+The live CEO chat (`ceo-session-manager.ts`) also provisions it on demand as a fallback.
+
 HQ also exposes the standard **assets library** — the one internal-project surface that
 isn't hidden in the UI (Budget/Settings still are). Files the CEO produces for the operator
 in the live chat (a quick mockup, demo, or export) are saved via `write_project_asset` and

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -8,6 +8,7 @@ import {
 	COACH_AGENT_SLUG,
 	CommentContentType,
 	ContainerStatus,
+	DEFAULT_TEAM_ID,
 	HeartbeatRunStatus,
 	INSTANCE_AGENT_SLUGS,
 	TaskPriority,
@@ -41,6 +42,7 @@ import {
 	type ContainerDeps,
 	type ContainerExitReason,
 	type ContainerTransition,
+	ensureProjectContainerRunning,
 	failProjectRuns,
 	provisionContainer,
 	rebuildContainer,
@@ -600,6 +602,31 @@ export class JobManager {
 		await this.selfHealErroredContainers(docker);
 		await this.restartStoppedRunningContainers(docker);
 		await this.repairStaleContainerMounts(docker);
+	}
+
+	/**
+	 * Bring the HQ container up as early as possible after boot. The startup
+	 * restart pass deliberately leaves `stopped` projects alone, but HQ — home of
+	 * the always-on CEO and Coach — should be running whenever the instance is.
+	 * `ensureProjectContainerRunning` no-ops when Docker confirms it is already
+	 * running, starts a stopped container in place, and provisions a missing one,
+	 * so this is safe to call unconditionally. Provisioning needs the master key
+	 * (secrets/egress), so the caller runs this only after unlock; it is kicked
+	 * fire-and-forget there so a slow image pull never delays the rest of startup.
+	 */
+	async ensureHqContainerRunning(): Promise<void> {
+		const reachable = await this.deps.docker.ping();
+		if (!reachable) {
+			log.warn('Docker not reachable at startup; skipping HQ container warm-up');
+			return;
+		}
+		const hq = await this.deps.db.query<{ id: string }>(
+			`SELECT id FROM projects WHERE team_id = $1 AND is_internal = true`,
+			[DEFAULT_TEAM_ID],
+		);
+		const hqProjectId = hq.rows[0]?.id;
+		if (!hqProjectId) return;
+		await ensureProjectContainerRunning(this.buildContainerDeps(), hqProjectId);
 	}
 
 	/**

--- a/packages/server/src/services/teams.ts
+++ b/packages/server/src/services/teams.ts
@@ -10,12 +10,10 @@ import {
 	MemberType,
 } from '@hezo/shared';
 import type { MasterKeyManager } from '../crypto/master-key';
-import { trackBackground } from '../lib/background';
 import { toSlug, uniqueSlug } from '../lib/slug';
 import { withTransaction } from '../lib/sql';
 import { logger } from '../logger';
 import type { ContainerLogStreamer } from './container-logs';
-import { type ProjectRow, provisionContainer } from './containers';
 import type { DockerClient } from './docker';
 import type { LogStreamBroker } from './log-stream-broker';
 import {
@@ -156,11 +154,11 @@ export async function createTeam(
  * every project-team's Captain reports up to the CEO that lives here.
  */
 export async function seedDefaultTeam(deps: CreateTeamDeps): Promise<void> {
-	const { db, docker, dataDir, wsManager, masterKeyManager, logs } = deps;
+	const { db } = deps;
 	const existing = await db.query('SELECT 1 FROM teams WHERE id = $1', [DEFAULT_TEAM_ID]);
 	if (existing.rows.length > 0) return;
 
-	const hqProjectId = await withTransaction(db, async () => {
+	await withTransaction(db, async () => {
 		await db.query(
 			`INSERT INTO teams (id, name, slug, description, summary) VALUES ($1, $2, $3, '', '')`,
 			[DEFAULT_TEAM_ID, DEFAULT_TEAM_NAME, DEFAULT_TEAM_SLUG],
@@ -174,7 +172,6 @@ export async function seedDefaultTeam(deps: CreateTeamDeps): Promise<void> {
 		await db.query('INSERT INTO project_task_counters (project_id, next_number) VALUES ($1, 1)', [
 			projectResult.rows[0].id,
 		]);
-		return projectResult.rows[0].id;
 	});
 
 	// The chatbox memory doc lives in the HQ project. Ensure it exists rather than
@@ -185,31 +182,9 @@ export async function seedDefaultTeam(deps: CreateTeamDeps): Promise<void> {
 	await ensureInstanceCeo(db, DEFAULT_TEAM_ID);
 	await ensureInstanceCoach(db, DEFAULT_TEAM_ID);
 
-	const hqProject = await db.query<ProjectRow>(
-		`SELECT id, team_id, slug, docker_base_image, container_id, container_status, dev_ports
-		 FROM projects WHERE id = $1`,
-		[hqProjectId],
-	);
-	if (hqProject.rows[0]) {
-		trackBackground(
-			provisionContainer(
-				{
-					db,
-					docker,
-					dataDir,
-					wsManager,
-					masterKeyManager,
-					logs,
-					containerLogStreamer: deps.containerLogStreamer,
-					egressCAPath: deps.egressCAPath ?? null,
-				},
-				hqProject.rows[0],
-				DEFAULT_TEAM_SLUG,
-			).catch((error) => {
-				log.error('Failed to provision container for HQ project:', error);
-			}),
-		);
-	}
+	// The HQ container is brought up by the startup reconciliation pass
+	// (JobManager.ensureHqContainerRunning), which runs after the master key is
+	// unlocked — provisioning needs secrets/egress that aren't available here.
 
 	log.info(`Seeded HQ team (${DEFAULT_TEAM_SLUG}) with CEO + Coach`);
 }

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -15,6 +15,7 @@ import type { Migration } from './db/migrate';
 import { BASE_SCHEMA } from './db/schema';
 import { registerAuditObserver } from './events/audit-observer';
 import { DomainEventBus } from './events/bus';
+import { trackBackground } from './lib/background';
 import { getInstanceBaseUrl } from './lib/system-meta';
 import type { Env } from './lib/types';
 import { generateLlmsTxt } from './mcp/llms-txt';
@@ -217,7 +218,18 @@ export async function startup(config: HezoConfig): Promise<StartupResult> {
 		jobManager
 			.reconcileOnStartup()
 			.catch((err) => log.error('Startup reconciliation failed:', err))
-			.finally(() => jobManager.start());
+			.finally(() => {
+				jobManager.start();
+				// Warm the HQ container as soon as the instance is unlocked so the CEO
+				// chat and project creation are ready without waiting for first use.
+				// Provisioning needs the master key, hence after unlock; fire-and-forget
+				// so a slow image pull doesn't hold up the rest of startup.
+				trackBackground(
+					jobManager
+						.ensureHqContainerRunning()
+						.catch((err) => log.error('Failed to warm HQ container on startup:', err)),
+				);
+			});
 		ceoSessionManager
 			.reconcileOnStartup()
 			.catch((err) => log.error('CEO session reconciliation failed:', err))

--- a/packages/server/test/job-manager-workflows.test.ts
+++ b/packages/server/test/job-manager-workflows.test.ts
@@ -2163,6 +2163,110 @@ describe('JobManager workflow methods', () => {
 		});
 	});
 
+	describe('ensureHqContainerRunning', () => {
+		async function hqProject(): Promise<{ id: string }> {
+			const r = await db.query<{ id: string }>(
+				`SELECT id FROM projects WHERE is_internal = true LIMIT 1`,
+			);
+			return r.rows[0];
+		}
+
+		afterEach(async () => {
+			await db.query(
+				`UPDATE projects SET container_status = NULL, container_id = NULL, container_error = NULL
+				 WHERE is_internal = true`,
+			);
+		});
+
+		it('starts the stopped HQ container in place and marks it running', async () => {
+			const hq = await hqProject();
+			await db.query(
+				`UPDATE projects SET container_status = 'stopped'::container_status, container_id = 'hq-box'
+				 WHERE id = $1`,
+				[hq.id],
+			);
+
+			const startCalls: string[] = [];
+			const manager = createJobManager({
+				docker: createStubDocker({
+					inspectContainer: async (id: string) => ({
+						Id: id,
+						State: { Status: 'exited', Running: false, Pid: 0, ExitCode: 0 },
+						Config: { Image: 'stub' },
+					}),
+					startContainer: async (id: string) => {
+						startCalls.push(id);
+					},
+				}),
+			});
+
+			await manager.ensureHqContainerRunning();
+
+			expect(startCalls).toEqual(['hq-box']);
+			const row = await db.query<{ container_status: string }>(
+				'SELECT container_status FROM projects WHERE id = $1',
+				[hq.id],
+			);
+			expect(row.rows[0].container_status).toBe('running');
+
+			manager.shutdown();
+		});
+
+		it('leaves an already-running HQ container alone', async () => {
+			const hq = await hqProject();
+			await db.query(
+				`UPDATE projects SET container_status = 'running'::container_status, container_id = 'hq-box'
+				 WHERE id = $1`,
+				[hq.id],
+			);
+
+			const startCalls: string[] = [];
+			const manager = createJobManager({
+				docker: createStubDocker({
+					inspectContainer: async (id: string) => ({
+						Id: id,
+						State: { Status: 'running', Running: true, Pid: 1, ExitCode: 0 },
+						Config: { Image: 'stub' },
+					}),
+					startContainer: async (id: string) => {
+						startCalls.push(id);
+					},
+				}),
+			});
+
+			await manager.ensureHqContainerRunning();
+
+			expect(startCalls).toEqual([]);
+
+			manager.shutdown();
+		});
+
+		it('skips the warm-up when Docker is unreachable', async () => {
+			const hq = await hqProject();
+			await db.query(
+				`UPDATE projects SET container_status = 'stopped'::container_status, container_id = 'hq-box'
+				 WHERE id = $1`,
+				[hq.id],
+			);
+
+			const startCalls: string[] = [];
+			const manager = createJobManager({
+				docker: createStubDocker({
+					ping: async () => false,
+					startContainer: async (id: string) => {
+						startCalls.push(id);
+					},
+				}),
+			});
+
+			await manager.ensureHqContainerRunning();
+
+			expect(startCalls).toEqual([]);
+
+			manager.shutdown();
+		});
+	});
+
 	describe('live-run registry', () => {
 		it('register / unregister updates getLiveRunIds and getLiveRunsForProject', () => {
 			const manager = createJobManager();

--- a/packages/web/src/components/ceo-chat/ceo-chat-widget.tsx
+++ b/packages/web/src/components/ceo-chat/ceo-chat-widget.tsx
@@ -2,6 +2,9 @@ import { HQ_PROJECT_NAME } from '@hezo/shared';
 import { ArrowRight, Loader2, Maximize2, MessageSquare, Minimize2, X } from 'lucide-react';
 import { type ReactNode, useEffect, useRef, useState } from 'react';
 import { type CeoMessage, useCeoChat } from '../../hooks/use-ceo-chat';
+import { useContainerHealth } from '../../hooks/use-container-health';
+import { useHqProject } from '../../hooks/use-projects';
+import { HqContainerNotice } from '../hq-container-notice';
 import { MarkdownProse } from '../markdown-prose';
 import { CountOverlayBadge } from '../ui/count-overlay-badge';
 import { Tooltip } from '../ui/tooltip';
@@ -17,6 +20,11 @@ export function CeoChatWidget() {
 	const [open, setOpen] = useState(false);
 	const [expanded, setExpanded] = useState(false);
 	const { messages, send, streaming, loaded, unread } = useCeoChat(open);
+	const hq = useHqProject();
+	const hqHealth = useContainerHealth(hq);
+	// The CEO can only act while the HQ container is up. When it isn't, the chat
+	// stays openable but swaps its body for the container state + a link to fix it.
+	const blockedHealth = hqHealth && hqHealth.kind !== 'healthy' ? hqHealth : null;
 	const [draft, setDraft] = useState('');
 	const scrollRef = useRef<HTMLDivElement>(null);
 
@@ -121,56 +129,71 @@ export function CeoChatWidget() {
 					</div>
 				</header>
 
-				<div
-					ref={scrollRef}
-					data-testid="ceo-chat-messages"
-					className="flex flex-1 flex-col gap-4 overflow-y-auto px-4 py-4 scroll-smooth"
-				>
-					{!loaded && (
-						<div className="flex items-center justify-center py-6 text-[13px] text-text-2">
-							<Loader2 className="mr-2 h-4 w-4 animate-spin" />
-							Loading…
-						</div>
-					)}
-					{loaded && messages.length === 0 && (
-						<p className="px-1 py-6 text-center text-[13px] text-text-2">
-							Say hello to the CEO. Ask about anything, including active projects, notifications,
-							task blockers, etc
-						</p>
-					)}
-					{messages.map((m) => (
-						<MessageBubble key={m.id} message={m} />
-					))}
-				</div>
-
-				<div className="border-t border-border p-3">
-					<div className="flex items-end gap-2 rounded-2xl border border-border bg-surface px-2 py-1.5 transition-colors focus-within:border-border-strong">
-						<textarea
-							value={draft}
-							onChange={(e) => setDraft(e.target.value)}
-							onKeyDown={(e) => {
-								if (e.key === 'Enter' && !e.shiftKey) {
-									e.preventDefault();
-									submit();
-								}
-							}}
-							rows={1}
-							placeholder="Ask the CEO anything, across every project…"
-							data-testid="ceo-chat-input"
-							className="max-h-32 min-h-[2.25rem] flex-1 resize-none bg-transparent px-2 py-2 text-[13px] leading-5 text-text-1 outline-none placeholder:text-text-3"
+				{hq && blockedHealth ? (
+					<div
+						data-testid="ceo-chat-messages"
+						className="flex flex-1 items-center justify-center overflow-y-auto"
+					>
+						<HqContainerNotice
+							health={blockedHealth}
+							slug={hq.slug}
+							description="The CEO is unavailable until the HQ container is running."
 						/>
-						<button
-							type="button"
-							onClick={submit}
-							disabled={!draft.trim()}
-							aria-label="Send message"
-							data-testid="ceo-chat-send"
-							className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-accent-solid text-accent-solid-fg transition-colors hover:bg-accent-hover disabled:opacity-40"
-						>
-							<ArrowRight className="h-4 w-4" />
-						</button>
 					</div>
-				</div>
+				) : (
+					<>
+						<div
+							ref={scrollRef}
+							data-testid="ceo-chat-messages"
+							className="flex flex-1 flex-col gap-4 overflow-y-auto px-4 py-4 scroll-smooth"
+						>
+							{!loaded && (
+								<div className="flex items-center justify-center py-6 text-[13px] text-text-2">
+									<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+									Loading…
+								</div>
+							)}
+							{loaded && messages.length === 0 && (
+								<p className="px-1 py-6 text-center text-[13px] text-text-2">
+									Say hello to the CEO. Ask about anything, including active projects,
+									notifications, task blockers, etc
+								</p>
+							)}
+							{messages.map((m) => (
+								<MessageBubble key={m.id} message={m} />
+							))}
+						</div>
+
+						<div className="border-t border-border p-3">
+							<div className="flex items-end gap-2 rounded-2xl border border-border bg-surface px-2 py-1.5 transition-colors focus-within:border-border-strong">
+								<textarea
+									value={draft}
+									onChange={(e) => setDraft(e.target.value)}
+									onKeyDown={(e) => {
+										if (e.key === 'Enter' && !e.shiftKey) {
+											e.preventDefault();
+											submit();
+										}
+									}}
+									rows={1}
+									placeholder="Ask the CEO anything, across every project…"
+									data-testid="ceo-chat-input"
+									className="max-h-32 min-h-[2.25rem] flex-1 resize-none bg-transparent px-2 py-2 text-[13px] leading-5 text-text-1 outline-none placeholder:text-text-3"
+								/>
+								<button
+									type="button"
+									onClick={submit}
+									disabled={!draft.trim()}
+									aria-label="Send message"
+									data-testid="ceo-chat-send"
+									className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-accent-solid text-accent-solid-fg transition-colors hover:bg-accent-hover disabled:opacity-40"
+								>
+									<ArrowRight className="h-4 w-4" />
+								</button>
+							</div>
+						</div>
+					</>
+				)}
 			</div>
 		</>
 	);

--- a/packages/web/src/components/container-status-banner.tsx
+++ b/packages/web/src/components/container-status-banner.tsx
@@ -1,8 +1,7 @@
-import { ContainerStatus } from '@hezo/shared';
 import { Link } from '@tanstack/react-router';
 import { AlertTriangle, Loader2, RefreshCw } from 'lucide-react';
 import { useCallback, useState } from 'react';
-import { useImageBuild } from '../hooks/use-image-build';
+import { useContainerHealth } from '../hooks/use-container-health';
 import { useProjectMeta } from '../hooks/use-projects';
 import { api } from '../lib/api';
 import { queryClient } from '../lib/query-client';
@@ -15,7 +14,7 @@ const BANNER_INNER = 'flex items-center gap-2 px-4 py-2 text-[13px] font-medium'
 
 export function ContainerStatusBanner({ projectId }: { projectId: string }) {
 	const project = useProjectMeta(projectId);
-	const imageBuild = useImageBuild(project?.docker_base_image);
+	const health = useContainerHealth(project);
 	const [isRebuilding, setIsRebuilding] = useState(false);
 
 	const bannerRef = useCallback((node: HTMLDivElement | null) => {
@@ -31,17 +30,12 @@ export function ContainerStatusBanner({ projectId }: { projectId: string }) {
 		};
 	}, []);
 
-	if (!project) return null;
-
-	const status = project.container_status;
+	if (!project || !health || health.kind === 'healthy') return null;
 
 	// The shared base image is (re)building. Surface the rebuilding status with a
-	// determinate progress bar. Shown whenever a build is in flight unless the
-	// operator deliberately stopped the container — a "rebuilding" container can
-	// still read a stale `running`/`creating` status, and the build gates every
-	// container that needs the fresh image.
-	const rebuilding = !!imageBuild?.building && status !== ContainerStatus.Stopped;
-	if (rebuilding && imageBuild) {
+	// determinate progress bar — the build gates every container that needs the
+	// fresh image.
+	if (health.kind === 'rebuilding') {
 		return (
 			<div ref={bannerRef} className={BANNER_OUTER}>
 				<Link
@@ -56,9 +50,9 @@ export function ContainerStatusBanner({ projectId }: { projectId: string }) {
 						<span data-testid="container-status-banner-message" className="min-w-0 truncate">
 							Rebuilding {project.name}'s base image…
 						</span>
-						<span className="ml-auto shrink-0 tabular-nums">{imageBuild.percent}%</span>
+						<span className="ml-auto shrink-0 tabular-nums">{health.percent}%</span>
 					</div>
-					<Progress value={imageBuild.percent} label="Base image build progress" />
+					<Progress value={health.percent} label="Base image build progress" />
 				</Link>
 			</div>
 		);
@@ -66,10 +60,9 @@ export function ContainerStatusBanner({ projectId }: { projectId: string }) {
 
 	// Provisioning / shutting down: a transient state that resolves on its own.
 	// Show a loading banner that links to the container page for live logs.
-	const provisioning = status === ContainerStatus.Creating || status === ContainerStatus.Stopping;
-	if (provisioning) {
+	if (health.kind === 'provisioning') {
 		const message =
-			status === ContainerStatus.Stopping
+			health.transient === 'stopping'
 				? `Stopping ${project.name}'s container…`
 				: `Provisioning ${project.name}'s container…`;
 		return (
@@ -91,13 +84,14 @@ export function ContainerStatusBanner({ projectId }: { projectId: string }) {
 		);
 	}
 
-	const unhealthy = status === ContainerStatus.Stopped || status === ContainerStatus.Error;
-	if (!unhealthy) return null;
-
-	const hasError = status === ContainerStatus.Error;
+	// Stopped or errored — the container needs a rebuild. The banner body links to
+	// the container page; the Restart button rebuilds in place without navigating.
+	const hasError = health.kind === 'error';
 	const message = `${project.name} container is not running`;
 
-	const rebuild = async () => {
+	const rebuild = async (e: React.MouseEvent) => {
+		e.preventDefault();
+		e.stopPropagation();
 		if (isRebuilding) return;
 		setIsRebuilding(true);
 		try {
@@ -108,11 +102,19 @@ export function ContainerStatusBanner({ projectId }: { projectId: string }) {
 		}
 	};
 
-	const tone = hasError ? 'bg-danger/10 text-danger' : 'bg-warning/10 text-warning';
+	const tone = hasError
+		? 'bg-danger/10 text-danger hover:bg-danger/20'
+		: 'bg-warning/10 text-warning hover:bg-warning/20';
 
 	return (
 		<div ref={bannerRef} className={BANNER_OUTER}>
-			<div data-testid="container-status-banner" className={`${BANNER_INNER} ${tone}`}>
+			<Link
+				to="/projects/$projectId/container"
+				params={{ projectId }}
+				data-testid="container-status-banner"
+				aria-label={`${message}. View container`}
+				className={`${BANNER_INNER} ${tone} transition-colors`}
+			>
 				<AlertTriangle className="w-3.5 h-3.5 shrink-0" />
 				<span data-testid="container-status-banner-message" className="min-w-0 truncate">
 					{message}
@@ -132,7 +134,7 @@ export function ContainerStatusBanner({ projectId }: { projectId: string }) {
 					)}
 					<span>Restart</span>
 				</Button>
-			</div>
+			</Link>
 		</div>
 	);
 }

--- a/packages/web/src/components/create-project-with-team-dialog.tsx
+++ b/packages/web/src/components/create-project-with-team-dialog.tsx
@@ -3,9 +3,15 @@ import { useNavigate } from '@tanstack/react-router';
 import { Loader2, MessagesSquare, Sparkles } from 'lucide-react';
 import { useState } from 'react';
 import { setActiveTeamSlug } from '../hooks/use-active-team-slug';
+import { useContainerHealth } from '../hooks/use-container-health';
 import { useStartProjectIntake } from '../hooks/use-project-intake';
-import { useAllVisibleProjects, useCreateProjectWithTeam } from '../hooks/use-projects';
+import {
+	useAllVisibleProjects,
+	useCreateProjectWithTeam,
+	useHqProject,
+} from '../hooks/use-projects';
 import { useTeamTemplates } from '../hooks/use-team-templates';
+import { HqContainerNotice } from './hq-container-notice';
 import { ProjectPlanUpload } from './project-plan-upload';
 import { Button } from './ui/button';
 import { Card } from './ui/card';
@@ -57,6 +63,11 @@ export function CreateProjectWithTeamDialog({
 	const createProject = useCreateProjectWithTeam();
 	const startIntake = useStartProjectIntake();
 	const navigate = useNavigate();
+	const hq = useHqProject();
+	const hqHealth = useContainerHealth(hq);
+	// Project intake/creation is driven by the CEO in HQ, so it can't proceed
+	// until the HQ container is running. Block the form until then.
+	const blockedHealth = hqHealth && hqHealth.kind !== 'healthy' ? hqHealth : null;
 
 	// Existing teams the new project's team can be cloned from, reached through
 	// each project. HQ (the internal team) is already excluded by
@@ -137,157 +148,174 @@ export function CreateProjectWithTeamDialog({
 				<Dialog.Overlay className={dialogOverlayClassName} />
 				<Dialog.Content className={dialogContentClassName.lg}>
 					<Dialog.Title className="text-base font-medium mb-1">New project</Dialog.Title>
-					<Dialog.Description className="text-sm text-text-2 mb-4">
-						Each project gets its own team. Pick a team type to staff it, then create it now or let
-						the CEO scope it with you first.
-					</Dialog.Description>
-					<form
-						onSubmit={(e) => {
-							e.preventDefault();
-							void handleCreateNow();
-						}}
-						className="flex flex-col gap-4"
-					>
-						<Input
-							label="Project name"
-							value={name}
-							onChange={(e) => setName(e.target.value)}
-							placeholder="e.g. Marketing Site"
-							required
-						/>
-						<Textarea
-							label="Description"
-							value={description}
-							onChange={(e) => setDescription(e.target.value)}
-							required
-							rows={4}
-							placeholder="What is this project? Domain, users, and the core problem it solves."
-						/>
-						<div className="flex flex-col gap-1.5">
-							<span className="flex items-center gap-1.5 text-[13px] font-medium text-text-1">
-								Project plan document (optional)
-								<InfoTooltip
-									label="What is a project plan document?"
-									data-testid="project-plan-help"
-									content="Attach a fuller document describing what this project is for when the description above isn't enough — goals, scope, context, constraints. For a software team the Captain uses it to write the formal PRD; for other teams it's used directly as the plan."
-								/>
-							</span>
-							<ProjectPlanUpload
-								value={projectPlan}
-								filename={projectPlanFilename}
-								onChange={(v, f) => {
-									setProjectPlan(v);
-									setProjectPlanFilename(f);
-								}}
+					{hq && blockedHealth ? (
+						<>
+							<Dialog.Description className="sr-only">
+								Waiting for the HQ container before a project can be created.
+							</Dialog.Description>
+							<HqContainerNotice
+								health={blockedHealth}
+								slug={hq.slug}
+								description="A new project is scoped by the CEO in HQ, so it can't be created until the HQ container is running."
 							/>
-						</div>
-						<div>
-							<span className="text-[13px] font-medium text-text-1">Team type</span>
-							{isLoading ? (
-								<div className="flex items-center gap-2 text-text-2 text-[13px] py-4">
-									<Loader2 className="w-4 h-4 animate-spin" /> Loading types…
-								</div>
-							) : (
-								<div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-2">
-									{(templates ?? []).map((tpl) => {
-										const selected = selection?.kind === 'template' && selection.id === tpl.id;
-										return (
-											<button
-												key={tpl.id}
-												type="button"
-												onClick={() => setSelection({ kind: 'template', id: tpl.id })}
-												className="text-left"
-												data-testid={`team-type-card-${tpl.name}`}
-												aria-pressed={selected}
-											>
-												<Card
-													className={`p-3 h-full transition-colors ${cardStateClass(selected)}`}
-												>
-													<h3 className="text-[14px] font-medium mb-1">{tpl.name}</h3>
-													{tpl.description && (
-														<p className="text-[12px] text-text-2 mb-2 line-clamp-2">
-															{tpl.description}
-														</p>
-													)}
-													<p className="text-[11px] text-text-2">
-														{tpl.agent_types.length === 0
-															? 'Captain only'
-															: `${tpl.agent_types.length} agent role${
-																	tpl.agent_types.length === 1 ? '' : 's'
-																}`}
-													</p>
-												</Card>
-											</button>
-										);
-									})}
-								</div>
-							)}
-						</div>
-						{sourceTeams.length > 0 && (
-							<div>
-								<span className="text-[13px] font-medium text-text-1">Copy an existing team</span>
-								<p className="text-[12px] text-text-2">
-									Start from another team's roster. A reusable team type is saved from its current
-									setup.
-								</p>
-								<div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-2">
-									{sourceTeams.map((team) => {
-										const selected = selection?.kind === 'team' && selection.id === team.id;
-										return (
-											<button
-												key={team.id}
-												type="button"
-												onClick={() => setSelection({ kind: 'team', id: team.id })}
-												className="text-left"
-												data-testid={`source-team-card-${team.slug}`}
-												aria-pressed={selected}
-											>
-												<Card
-													className={`p-3 h-full transition-colors ${cardStateClass(selected)}`}
-												>
-													<h3 className="text-[14px] font-medium mb-1">{team.name}</h3>
-													<p className="text-[11px] text-text-2">
-														{team.agent_count === 0
-															? 'No agents yet'
-															: `${team.agent_count} agent${team.agent_count === 1 ? '' : 's'}`}
-													</p>
-												</Card>
-											</button>
-										);
-									})}
-								</div>
-							</div>
-						)}
-						{error && (
-							<p className="text-[13px] text-danger">
-								{(error as { message?: string }).message || 'Failed to create project'}
-							</p>
-						)}
-						<div className="flex flex-col-reverse sm:flex-row sm:justify-end gap-2 mt-2">
-							<Button
-								type="button"
-								variant="secondary"
-								onClick={handlePlanWithCeo}
-								disabled={!canSubmit}
-								data-testid="plan-with-ceo-submit"
+						</>
+					) : (
+						<>
+							<Dialog.Description className="text-sm text-text-2 mb-4">
+								Each project gets its own team. Pick a team type to staff it, then create it now or
+								let the CEO scope it with you first.
+							</Dialog.Description>
+							<form
+								onSubmit={(e) => {
+									e.preventDefault();
+									void handleCreateNow();
+								}}
+								className="flex flex-col gap-4"
 							>
-								{startIntake.isPending ? (
-									<Loader2 className="w-4 h-4 animate-spin" />
-								) : (
-									<MessagesSquare className="w-4 h-4" />
+								<Input
+									label="Project name"
+									value={name}
+									onChange={(e) => setName(e.target.value)}
+									placeholder="e.g. Marketing Site"
+									required
+								/>
+								<Textarea
+									label="Description"
+									value={description}
+									onChange={(e) => setDescription(e.target.value)}
+									required
+									rows={4}
+									placeholder="What is this project? Domain, users, and the core problem it solves."
+								/>
+								<div className="flex flex-col gap-1.5">
+									<span className="flex items-center gap-1.5 text-[13px] font-medium text-text-1">
+										Project plan document (optional)
+										<InfoTooltip
+											label="What is a project plan document?"
+											data-testid="project-plan-help"
+											content="Attach a fuller document describing what this project is for when the description above isn't enough — goals, scope, context, constraints. For a software team the Captain uses it to write the formal PRD; for other teams it's used directly as the plan."
+										/>
+									</span>
+									<ProjectPlanUpload
+										value={projectPlan}
+										filename={projectPlanFilename}
+										onChange={(v, f) => {
+											setProjectPlan(v);
+											setProjectPlanFilename(f);
+										}}
+									/>
+								</div>
+								<div>
+									<span className="text-[13px] font-medium text-text-1">Team type</span>
+									{isLoading ? (
+										<div className="flex items-center gap-2 text-text-2 text-[13px] py-4">
+											<Loader2 className="w-4 h-4 animate-spin" /> Loading types…
+										</div>
+									) : (
+										<div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-2">
+											{(templates ?? []).map((tpl) => {
+												const selected = selection?.kind === 'template' && selection.id === tpl.id;
+												return (
+													<button
+														key={tpl.id}
+														type="button"
+														onClick={() => setSelection({ kind: 'template', id: tpl.id })}
+														className="text-left"
+														data-testid={`team-type-card-${tpl.name}`}
+														aria-pressed={selected}
+													>
+														<Card
+															className={`p-3 h-full transition-colors ${cardStateClass(selected)}`}
+														>
+															<h3 className="text-[14px] font-medium mb-1">{tpl.name}</h3>
+															{tpl.description && (
+																<p className="text-[12px] text-text-2 mb-2 line-clamp-2">
+																	{tpl.description}
+																</p>
+															)}
+															<p className="text-[11px] text-text-2">
+																{tpl.agent_types.length === 0
+																	? 'Captain only'
+																	: `${tpl.agent_types.length} agent role${
+																			tpl.agent_types.length === 1 ? '' : 's'
+																		}`}
+															</p>
+														</Card>
+													</button>
+												);
+											})}
+										</div>
+									)}
+								</div>
+								{sourceTeams.length > 0 && (
+									<div>
+										<span className="text-[13px] font-medium text-text-1">
+											Copy an existing team
+										</span>
+										<p className="text-[12px] text-text-2">
+											Start from another team's roster. A reusable team type is saved from its
+											current setup.
+										</p>
+										<div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-2">
+											{sourceTeams.map((team) => {
+												const selected = selection?.kind === 'team' && selection.id === team.id;
+												return (
+													<button
+														key={team.id}
+														type="button"
+														onClick={() => setSelection({ kind: 'team', id: team.id })}
+														className="text-left"
+														data-testid={`source-team-card-${team.slug}`}
+														aria-pressed={selected}
+													>
+														<Card
+															className={`p-3 h-full transition-colors ${cardStateClass(selected)}`}
+														>
+															<h3 className="text-[14px] font-medium mb-1">{team.name}</h3>
+															<p className="text-[11px] text-text-2">
+																{team.agent_count === 0
+																	? 'No agents yet'
+																	: `${team.agent_count} agent${team.agent_count === 1 ? '' : 's'}`}
+															</p>
+														</Card>
+													</button>
+												);
+											})}
+										</div>
+									</div>
 								)}
-								Plan with the CEO
-							</Button>
-							<Button type="submit" disabled={!canSubmit} data-testid="create-project-submit">
-								{createProject.isPending ? (
-									<Loader2 className="w-4 h-4 animate-spin" />
-								) : (
-									<Sparkles className="w-4 h-4" />
+								{error && (
+									<p className="text-[13px] text-danger">
+										{(error as { message?: string }).message || 'Failed to create project'}
+									</p>
 								)}
-								Create now
-							</Button>
-						</div>
-					</form>
+								<div className="flex flex-col-reverse sm:flex-row sm:justify-end gap-2 mt-2">
+									<Button
+										type="button"
+										variant="secondary"
+										onClick={handlePlanWithCeo}
+										disabled={!canSubmit}
+										data-testid="plan-with-ceo-submit"
+									>
+										{startIntake.isPending ? (
+											<Loader2 className="w-4 h-4 animate-spin" />
+										) : (
+											<MessagesSquare className="w-4 h-4" />
+										)}
+										Plan with the CEO
+									</Button>
+									<Button type="submit" disabled={!canSubmit} data-testid="create-project-submit">
+										{createProject.isPending ? (
+											<Loader2 className="w-4 h-4 animate-spin" />
+										) : (
+											<Sparkles className="w-4 h-4" />
+										)}
+										Create now
+									</Button>
+								</div>
+							</form>
+						</>
+					)}
 				</Dialog.Content>
 			</Dialog.Portal>
 		</Dialog.Root>

--- a/packages/web/src/components/hq-container-notice.tsx
+++ b/packages/web/src/components/hq-container-notice.tsx
@@ -1,0 +1,63 @@
+import { Link } from '@tanstack/react-router';
+import { AlertTriangle, ArrowRight, Loader2 } from 'lucide-react';
+import type { ContainerHealth } from '../hooks/use-container-health';
+
+/**
+ * Shared waiting/blocked panel shown wherever a feature depends on the HQ
+ * container being up — the CEO chat and the create-project flow. Mirrors the
+ * container status banner's states (rebuilding / provisioning / stopped /
+ * error) and always offers a link to the HQ container page for diagnostics.
+ */
+export function HqContainerNotice({
+	health,
+	slug,
+	description,
+}: {
+	health: Exclude<ContainerHealth, { kind: 'healthy' }>;
+	slug: string;
+	description: string;
+}) {
+	const pending = health.kind === 'rebuilding' || health.kind === 'provisioning';
+	const title = noticeTitle(health);
+
+	return (
+		<div
+			data-testid="hq-container-notice"
+			className="flex flex-col items-center gap-3 px-6 py-8 text-center"
+		>
+			{pending ? (
+				<Loader2 className="h-6 w-6 animate-spin text-text-2" />
+			) : (
+				<AlertTriangle className="h-6 w-6 text-danger" />
+			)}
+			<div className="flex flex-col gap-1">
+				<p className="text-[13px] font-medium text-text-1">{title}</p>
+				<p className="text-[13px] text-text-2">{description}</p>
+			</div>
+			<Link
+				to="/projects/$projectId/container"
+				params={{ projectId: slug }}
+				data-testid="hq-container-notice-link"
+				className="inline-flex items-center gap-1 text-[13px] font-medium text-accent hover:underline"
+			>
+				View container
+				<ArrowRight className="h-3.5 w-3.5" />
+			</Link>
+		</div>
+	);
+}
+
+function noticeTitle(health: Exclude<ContainerHealth, { kind: 'healthy' }>): string {
+	switch (health.kind) {
+		case 'rebuilding':
+			return 'Rebuilding the HQ container…';
+		case 'provisioning':
+			return health.transient === 'stopping'
+				? 'Stopping the HQ container…'
+				: 'Starting the HQ container…';
+		case 'stopped':
+			return 'The HQ container isn’t running';
+		case 'error':
+			return 'The HQ container has an error';
+	}
+}

--- a/packages/web/src/hooks/use-container-health.ts
+++ b/packages/web/src/hooks/use-container-health.ts
@@ -1,0 +1,43 @@
+import { ContainerStatus } from '@hezo/shared';
+import { useImageBuild } from './use-image-build';
+import type { Project } from './use-projects';
+
+/**
+ * Normalised health of a project's container, derived from its stored status
+ * plus any in-flight base-image build. A single source of truth shared by the
+ * container status banner, the CEO chat, and the create-project gate so they
+ * never disagree about whether a container is usable.
+ *
+ * `provisioning` covers the transient setup/teardown states (creating, stopping)
+ * and the not-yet-provisioned `null` status — anything that should resolve to
+ * running on its own. Only `running` (and not mid-rebuild) is `healthy`.
+ */
+export type ContainerHealth =
+	| { kind: 'healthy' }
+	| { kind: 'rebuilding'; percent: number }
+	| { kind: 'provisioning'; transient: 'creating' | 'stopping' }
+	| { kind: 'stopped' }
+	| { kind: 'error' };
+
+/** Returns null while the project is unknown (index still loading). */
+export function useContainerHealth(project: Project | undefined): ContainerHealth | null {
+	const imageBuild = useImageBuild(project?.docker_base_image);
+	if (!project) return null;
+
+	const status = project.container_status;
+
+	// A base-image rebuild gates every container that needs the fresh image,
+	// unless the operator deliberately stopped this one.
+	if (imageBuild?.building && status !== ContainerStatus.Stopped) {
+		return { kind: 'rebuilding', percent: imageBuild.percent };
+	}
+	if (status === ContainerStatus.Error) return { kind: 'error' };
+	if (status === ContainerStatus.Stopped) return { kind: 'stopped' };
+	if (status === ContainerStatus.Running) return { kind: 'healthy' };
+
+	// creating, stopping, or null (never provisioned / warming up at boot).
+	return {
+		kind: 'provisioning',
+		transient: status === ContainerStatus.Stopping ? 'stopping' : 'creating',
+	};
+}

--- a/packages/web/src/routes/home/index.tsx
+++ b/packages/web/src/routes/home/index.tsx
@@ -3,6 +3,7 @@ import { createFileRoute, Link } from '@tanstack/react-router';
 import { Building2, Plus } from 'lucide-react';
 import { type ReactNode, useState } from 'react';
 import { CreateProjectWithTeamDialog } from '../../components/create-project-with-team-dialog';
+import { HqContainerNotice } from '../../components/hq-container-notice';
 import { ProjectIntakeHomePanel } from '../../components/project-intake-home-panel';
 import { Avatar, avatarColorFromString, getInitials } from '../../components/ui/avatar';
 import { Badge } from '../../components/ui/badge';
@@ -10,8 +11,13 @@ import { Button } from '../../components/ui/button';
 import { Card } from '../../components/ui/card';
 import { useAllAdminMentions } from '../../hooks/use-admin-mentions';
 import { type Approval, useAllApprovals } from '../../hooks/use-approvals';
+import { useContainerHealth } from '../../hooks/use-container-health';
 import { useProjectIntake } from '../../hooks/use-project-intake';
-import { type ProjectWithTeam, useAllVisibleProjects } from '../../hooks/use-projects';
+import {
+	type ProjectWithTeam,
+	useAllVisibleProjects,
+	useHqProject,
+} from '../../hooks/use-projects';
 
 const RELATIVE_UNITS: Array<[Intl.RelativeTimeFormatUnit, number]> = [
 	['day', 86400],
@@ -209,25 +215,39 @@ function NeedsYouMention({ mention }: { mention: AdminMentionItem }) {
 }
 
 function WelcomeCard({ onCreate }: { onCreate: () => void }) {
+	const hq = useHqProject();
+	const hqHealth = useContainerHealth(hq);
+	// A project is scoped by the CEO in HQ, so the first project can't be created
+	// until the HQ container is up — surface that wait here rather than at click.
+	const blockedHealth = hqHealth && hqHealth.kind !== 'healthy' ? hqHealth : null;
+
 	return (
 		<Card className="mb-6 p-0 overflow-hidden" data-testid="home-welcome-card">
-			<div
-				className="flex flex-col items-center gap-3 px-4 py-8 text-center"
-				data-testid="home-welcome"
-			>
-				<Building2 className="w-8 h-8 text-text-2 shrink-0" />
-				<div>
-					<h1 className="text-base font-semibold text-text-1">Get started with Hezo</h1>
-					<p className="text-[13px] text-text-2 mt-1 max-w-md">
-						Create your first project. Each one gets its own team — spin it up from a template, or
-						let the CEO scope it with you first.
-					</p>
+			{hq && blockedHealth ? (
+				<HqContainerNotice
+					health={blockedHealth}
+					slug={hq.slug}
+					description="Setting up Hezo. You can create your first project once the HQ container is running."
+				/>
+			) : (
+				<div
+					className="flex flex-col items-center gap-3 px-4 py-8 text-center"
+					data-testid="home-welcome"
+				>
+					<Building2 className="w-8 h-8 text-text-2 shrink-0" />
+					<div>
+						<h1 className="text-base font-semibold text-text-1">Get started with Hezo</h1>
+						<p className="text-[13px] text-text-2 mt-1 max-w-md">
+							Create your first project. Each one gets its own team — spin it up from a template, or
+							let the CEO scope it with you first.
+						</p>
+					</div>
+					<Button onClick={onCreate} data-testid="home-welcome-create">
+						<Plus className="w-4 h-4" />
+						New project
+					</Button>
 				</div>
-				<Button onClick={onCreate} data-testid="home-welcome-create">
-					<Plus className="w-4 h-4" />
-					New project
-				</Button>
-			</div>
+			)}
 		</Card>
 	);
 }

--- a/packages/web/test/ceo-chat.test.tsx
+++ b/packages/web/test/ceo-chat.test.tsx
@@ -71,6 +71,35 @@ test('the header identifies the CEO with the HQ badge and the composer invites c
 	expect(input.placeholder).toBe('Ask the CEO anything, across every project…');
 });
 
+test('blocks the composer and links to the container page when the HQ container is down', async () => {
+	const { findByTestId } = await renderApp({
+		initialPath: '/home',
+		seed: async (ctx) => {
+			await ctx.db.query(
+				`UPDATE projects SET container_status = 'error',
+				        container_error = 'pull access denied'
+				 WHERE is_internal = true`,
+			);
+		},
+	});
+
+	(await findByTestId('ceo-chat-launcher')).click();
+	const panel = await findByTestId('ceo-chat-panel');
+
+	// The container-state notice replaces the composer inside the chat panel.
+	const notice = await waitFor(() => {
+		const el = panel.querySelector('[data-testid="hq-container-notice"]');
+		if (!el) throw new Error('notice not yet rendered');
+		return el as HTMLElement;
+	});
+	expect(notice.textContent ?? '').toContain('error');
+	expect(panel.querySelector('[data-testid="ceo-chat-input"]')).toBeNull();
+
+	// It links to the HQ container page.
+	const link = notice.querySelector('[data-testid="hq-container-notice-link"]');
+	expect(link?.getAttribute('href')).toContain('/projects/hq/container');
+});
+
 test('each message carries its role eyebrow — "You" for the operator, "CEO · HQ" for the CEO', async () => {
 	const { findByTestId, findByText } = await renderApp({ initialPath: '/home' });
 	(await findByTestId('ceo-chat-launcher')).click();

--- a/packages/web/test/container-management.test.tsx
+++ b/packages/web/test/container-management.test.tsx
@@ -139,6 +139,10 @@ test('banner flags the active project as failed and rebuilds it', async () => {
 	const message = await findByTestId('container-status-banner-message');
 	expect(message.textContent ?? '').toContain('Failed Banner');
 
+	// The whole banner links to the container page for diagnostics.
+	expect(banner.getAttribute('href') ?? '').toContain(`/projects/${projectSlug}/container`);
+
+	// Clicking Restart rebuilds in place without following the banner link.
 	const rebuildBtn = banner.querySelector(
 		'button[aria-label="Restart failed container"]',
 	) as HTMLButtonElement;

--- a/packages/web/test/helpers/render.tsx
+++ b/packages/web/test/helpers/render.tsx
@@ -97,6 +97,16 @@ beforeEach(async () => {
 		}),
 	});
 
+	// A booted instance has its HQ container running; the harness skips real
+	// container provisioning, so reflect the healthy steady state by default.
+	// Specs exercising the container-down/rebuilding gates set the status
+	// explicitly (via DB or a fetch override of the projects index).
+	await test.db.query(
+		`UPDATE projects SET container_status = 'running',
+		        container_id = COALESCE(container_id, 'test-hq-container')
+		 WHERE is_internal = true`,
+	);
+
 	// Reroute fetch through the in-process Hono app. Bypasses the real network
 	// entirely; matches the way the dev Vite proxy forwards /api, /oauth, /mcp,
 	// /health, /SKILL.md, and /llms.txt to the server.

--- a/packages/web/test/home-new-project.test.tsx
+++ b/packages/web/test/home-new-project.test.tsx
@@ -27,3 +27,28 @@ test('home "New project" opens the create-project-with-team dialog (type picker)
 	expect(screen.getByText('Team type')).toBeTruthy();
 	expect(screen.getByPlaceholderText('e.g. Marketing Site')).toBeTruthy();
 });
+
+test('the create-project dialog blocks on the container state when HQ is down', async () => {
+	let ws!: SeededWorkspace;
+	const { findByTestId, user } = await renderApp({
+		initialPath: '/home',
+		seed: async (ctx) => {
+			ws = await seedWorkspace();
+			await seedProject(ws, { name: 'Existing Project' });
+			sessionStorage.setItem('hezo:activeTeamSlug', ws.team.slug);
+			await ctx.db.query(`UPDATE projects SET container_status = 'error' WHERE is_internal = true`);
+		},
+	});
+
+	const section = await findByTestId('home-projects', undefined, { timeout: 15_000 });
+	await user.click(within(section).getByTestId('home-new-project'));
+
+	// The form is replaced by the container-state notice + a link to the HQ
+	// container page; the create button is gone.
+	const notice = await screen.findByTestId('hq-container-notice');
+	expect(notice.textContent ?? '').toContain('error');
+	expect(screen.queryByTestId('create-project-submit')).toBeNull();
+	expect(screen.getByTestId('hq-container-notice-link').getAttribute('href')).toContain(
+		'/projects/hq/container',
+	);
+});


### PR DESCRIPTION
## Why

The HQ container was only provisioned on the **first-ever** boot — `seedDefaultTeam` early-returns once the team exists — so every subsequent restart left HQ down until the CEO chat lazily brought it up on first use (#398). The screenshot case (a user landing on an empty "no container provisioned" state, or a `pull access denied` error) is the gap before that lazy path fires. The user wants HQ up as soon as possible, and the create-project / CEO-chat surfaces to reflect when it isn't.

## What

**Eager HQ warm-up**
- New `JobManager.ensureHqContainerRunning()` finds the HQ (`is_internal`) project and calls the existing `ensureProjectContainerRunning` — start-in-place if stopped, provision if missing, no-op if running.
- Fired fire-and-forget in `startup.ts` right after `reconcileOnStartup` in the `onUnlock` callback (provisioning needs the master key for secrets/egress), so a slow image pull never blocks startup.
- Removed the first-boot-only background provisioning from `seedDefaultTeam`; the warm-up now covers **every** boot and runs after unlock, eliminating the old pre-unlock race. The CEO-chat on-demand path stays as a fallback.
- Kept this as a standalone method rather than folding it into `reconcileOnStartup`, since that pass deliberately leaves `stopped` projects alone and its tests assert exact `startContainer` calls.

**UI surfacing**
- The stopped/error container **banner** is now a link to the container page (rebuilding/provisioning variants already were); Restart still rebuilds in place without navigating.
- The **CEO chat**, **create-project dialog**, and **home welcome card** swap their body for a shared `HqContainerNotice` (container state + a link to the container page) whenever HQ isn't running — users can't act against a down container and can see why.
- Health derivation centralised in a new `useContainerHealth` hook, reused by all four surfaces.

## Notes
- A `null` container_status (never-provisioned) now reads as "provisioning" in the banner rather than rendering nothing — a brief, more-correct "Provisioning…" state for a fresh HQ. No test depended on the old silence.
- The web render harness now marks HQ `running` by default (a booted instance's real steady state, which the harness previously skipped). Blocked-state specs set the status explicitly.

## Tests
- Server: HQ warm-up start / no-op / Docker-unreachable.
- Web: error banner is a link (Restart doesn't navigate); CEO chat blocked state; create-project dialog blocked state.
- Full web suite (435) + touched server suites (job-manager-workflows, teams, containers, startup, ceo-session) green; typecheck + lint clean. `.dev/architecture.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWwhQzR3xSbQNw8fnx6kRj