### PR TITLE
feat(docker): publish agent-base image per release, pull it for matching versions

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -654,13 +654,21 @@ asset is pulled in as a static import and served **from memory**: migrations
 (`migrations-bundle.json`), agent roles (`agents-bundle.json`), the React frontend
 (`static-bundle.json`, base64), and the PGlite runtime (`postgres.wasm`/`.data`
 embedded). The **agent-base Docker build context** (`docker/`) is embedded the same
-way (`docker-bundle.json`, base64) because the `hezo/agent-base` image is published to
-no registry — at startup the binary extracts it to `<dataDir>/agent-base-context` and
-points the image resolver (`setDockerBaseDir`) at it, so the first container provision
-**builds the image locally** instead of failing to pull. In dev (`bun run`) the bundles
-don't exist and every loader falls back to the filesystem (the docker context to the
-repo's `docker/` dir). The version is injected at compile time
-(`--define process.env.HEZO_VERSION`) and surfaced at `/api/status`.
+way (`docker-bundle.json`, base64) so the image can always be built on the host as a
+fallback. A release binary first **pulls** the image published for its own version —
+`ghcr.io/hezo-ai/agent-base:<version>` (multi-arch amd64/arm64), pushed per release by
+`.github/workflows/release-publish.yml` to a public GHCR package — and only **builds
+locally** when that pull fails (not published yet, offline, private fork): at startup it
+extracts the embedded context to `<dataDir>/agent-base-context` and points the resolver
+(`setDockerBaseDir`) at it, so the fallback build needs no checkout. `resolveAgentBaseImage`
+(`image-registry.ts`) maps the stored `hezo/agent-base:latest` sentinel to the
+version-pinned GHCR ref with `preferPull`, and `ensureImage` does pull-then-build; custom
+per-project `docker_base_image` values are pulled as-is. Pulling is gated on
+`IS_PACKAGED_BUILD` (set by the compile-time `--define process.env.HEZO_VERSION`), so in
+dev (`bun run`) and tests the bundles don't exist, loaders fall back to the filesystem
+(docker context → repo's `docker/` dir), and the image is always built from the
+working-tree Dockerfile so edits take effect immediately. The version is also surfaced at
+`/api/status`.
 
 **Migrations.** Real, tracked, **append-only** SQL under `packages/server/migrations/`
 (`001_initial_schema.sql` is the frozen baseline — never edit a shipped migration; each is

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -64,3 +64,48 @@ jobs:
           bun run release --notes "$version" > /tmp/release-notes.md
           gh release create "$version" --title "$version" --notes-file /tmp/release-notes.md \
             dist/binaries/*
+
+  # Build the agent-base image and publish it to GHCR tagged with this release's
+  # version (+ :latest). Release binaries of this version pull
+  # ghcr.io/hezo-ai/agent-base:<version> at provision time instead of building it
+  # locally (packages/server/src/services/image-registry.ts) — so the GHCR package
+  # must be public for the server's anonymous pull. Multi-arch so amd64 and arm64
+  # hosts both pull rather than fall back to a local build; arm64 compiles git from
+  # source under QEMU emulation, hence the long timeout. Runs in parallel with the
+  # binary publish job above — neither depends on the other.
+  publish-agent-image:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    if: >-
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/')
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: main # post-merge main, matching the published binaries
+      - id: meta
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: echo "version=${HEAD_REF#release/}" >> "$GITHUB_OUTPUT"
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # cache-from reuses the amd64 layers ci.yml warms on main; arm64 builds cold.
+      - uses: docker/build-push-action@v6
+        with:
+          context: docker
+          file: docker/Dockerfile.agent-base
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/hezo-ai/agent-base:${{ steps.meta.outputs.version }}
+            ghcr.io/hezo-ai/agent-base:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/packages/server/src/services/containers.ts
+++ b/packages/server/src/services/containers.ts
@@ -19,6 +19,7 @@ import type { ContainerLogStreamer } from './container-logs';
 import type { DockerClient } from './docker';
 import { ensureImage } from './ensure-image';
 import { ContainerGitExecutor } from './git-executor';
+import { resolveAgentBaseImage } from './image-registry';
 import type { LogStreamBroker } from './log-stream-broker';
 import { ensureProjectRepos } from './repo-sync';
 import { type BridgeRunnerArgs, type SshAgentServer, withProvisionBridge } from './ssh-agent';
@@ -272,18 +273,23 @@ export async function provisionContainer(
 
 		const env: string[] = [];
 
-		emit('stdout', `→ Resolving image ${project.docker_base_image}`);
+		// The stored image is the managed sentinel/default for most projects; in a
+		// release binary it resolves to the version-pinned GHCR image (pulled, with a
+		// local-build fallback). Custom per-project images pass through unchanged.
+		const { image: baseImage, preferPull } = resolveAgentBaseImage(project.docker_base_image);
+		emit('stdout', `→ Resolving image ${baseImage}`);
 		// Docker writes its build trace to stderr even on success; surface it as
 		// informational stdout so a clean build isn't a wall of red. A real build
 		// failure still throws (non-zero exit) and is reported by the catch below.
-		await ensureImage(docker, project.docker_base_image, {
+		await ensureImage(docker, baseImage, {
+			preferPull,
 			onLine: (_stream, text) => emit('stdout', text),
 		});
 
 		emit('stdout', `→ Creating container ${containerName}`);
 
 		const { Id } = await docker.createContainer(containerName, {
-			Image: project.docker_base_image,
+			Image: baseImage,
 			Cmd: ['sleep', 'infinity'],
 			Env: env,
 			WorkingDir: '/workspace',

--- a/packages/server/src/services/ensure-image.ts
+++ b/packages/server/src/services/ensure-image.ts
@@ -17,6 +17,12 @@ export interface EnsureImageDeps {
 	onLine?: BuildOnLine;
 	/** Receives build start/progress/finish; defaults to the process singleton. */
 	tracker?: ImageBuildTracker | null;
+	/**
+	 * When true, pull `image` first and only build locally if the pull fails.
+	 * Set for the managed agent-base image published per release (the version-
+	 * pinned GHCR ref). For any other image a pull failure stays terminal.
+	 */
+	preferPull?: boolean;
 }
 
 interface InFlightBuild {
@@ -41,6 +47,22 @@ export async function ensureImage(
 
 	const resolver = deps.resolveLocal ?? resolveLocalImage;
 	const local = resolver(image);
+
+	// Managed agent-base in a release binary: prefer the image published for this
+	// version, falling back to a local build when the pull fails (not published
+	// yet, offline, private fork). Only swallow the pull error when a local spec
+	// lets us rebuild; otherwise a failed pull stays terminal.
+	if (deps.preferPull) {
+		try {
+			await docker.pullImage(image);
+			return;
+		} catch (err) {
+			if (!local) throw err;
+			const msg = err instanceof Error ? err.message : String(err);
+			log.warn(`Pull of ${image} failed; building agent-base locally: ${msg}`);
+		}
+	}
+
 	if (local) {
 		await buildLocalImageOnce(docker, local, deps);
 		return;

--- a/packages/server/src/services/image-registry.ts
+++ b/packages/server/src/services/image-registry.ts
@@ -3,6 +3,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { logger } from '../logger';
+import { HEZO_VERSION, IS_PACKAGED_BUILD } from '../version';
 import type { DockerClient } from './docker';
 
 const log = logger.child('image-registry');
@@ -12,12 +13,71 @@ interface LocalImageSpec {
 	context: string;
 }
 
-const LOCAL_IMAGES: Record<string, LocalImageSpec> = {
-	'hezo/agent-base:latest': {
-		dockerfile: 'docker/Dockerfile.agent-base',
-		context: 'docker',
-	},
+/**
+ * The DB sentinel / default `projects.docker_base_image`. At provision time
+ * `resolveAgentBaseImage` maps it to either the published GHCR image (in a
+ * release binary whose version is published) or a local build of `AGENT_BASE_SPEC`.
+ */
+export const MANAGED_AGENT_BASE_IMAGE = 'hezo/agent-base:latest';
+
+/**
+ * Registry repo the agent-base image is published to — one tag per release
+ * (`<repo>:<version>`), pushed by `.github/workflows/release-publish.yml`. The
+ * server pulls `<repo>:<HEZO_VERSION>` anonymously, so the GHCR package must be
+ * public.
+ */
+export const AGENT_BASE_GHCR_REPO = 'ghcr.io/hezo-ai/agent-base';
+
+/**
+ * Build spec (Dockerfile + context, relative to the repo root or the extracted
+ * bundle dir) for the agent-base image — used for the dev/local build and as the
+ * fallback when pulling the published image fails.
+ */
+const AGENT_BASE_SPEC: LocalImageSpec = {
+	dockerfile: 'docker/Dockerfile.agent-base',
+	context: 'docker',
 };
+
+const LOCAL_IMAGES: Record<string, LocalImageSpec> = {
+	[MANAGED_AGENT_BASE_IMAGE]: AGENT_BASE_SPEC,
+};
+
+/** A plain `MAJOR.MINOR.PATCH` version, matching the no-`v`-prefix release tags
+ *  cut by `release-publish.yml`. Dev/test versions (`0.0.0-dev`, pre-release, …)
+ *  don't match, so they never resolve to a published image. */
+export function isReleaseVersion(version: string): boolean {
+	return /^\d+\.\d+\.\d+$/.test(version);
+}
+
+/**
+ * The published agent-base ref for the running build, or `null` when none should
+ * exist — i.e. anything but a compiled release binary at a real release version
+ * (dev, tests, pre-release builds). When `null`, the managed image is always
+ * built locally. Params default to the module constants; they're injectable so
+ * the pure logic is unit-testable without env munging.
+ */
+export function publishedAgentBaseRef(
+	version: string = HEZO_VERSION,
+	packaged: boolean = IS_PACKAGED_BUILD,
+): string | null {
+	return packaged && isReleaseVersion(version) ? `${AGENT_BASE_GHCR_REPO}:${version}` : null;
+}
+
+/**
+ * Resolve a project's stored `docker_base_image` to the image to actually
+ * pull/build and run a container from. For the managed default in a release
+ * binary, prefer the published GHCR image (pull, with a local-build fallback);
+ * custom per-project images are returned untouched and never pulled-as-managed.
+ */
+export function resolveAgentBaseImage(
+	storedImage: string,
+	publishedRef: string | null = publishedAgentBaseRef(),
+): { image: string; preferPull: boolean } {
+	if (storedImage === MANAGED_AGENT_BASE_IMAGE && publishedRef) {
+		return { image: publishedRef, preferPull: true };
+	}
+	return { image: storedImage, preferPull: false };
+}
 
 /**
  * Label key stamped onto every locally-built bundled image. The value is the
@@ -71,8 +131,16 @@ export function findRepoRoot(startDir?: string): string | null {
 	}
 }
 
-export function resolveLocalImage(image: string): ResolvedLocalImage | null {
-	const spec = LOCAL_IMAGES[image];
+export function resolveLocalImage(
+	image: string,
+	publishedRef: string | null = publishedAgentBaseRef(),
+): ResolvedLocalImage | null {
+	// The managed sentinel maps to the bundled spec directly; the published GHCR
+	// ref for this build maps to the same spec so a failed pull can fall back to a
+	// local build of the identical Dockerfile/context. The published ref is
+	// deliberately not in LOCAL_IMAGES so `pruneStaleBundledImages` never removes a
+	// pulled (label-less) image — version-in-tag handles staleness across upgrades.
+	const spec = LOCAL_IMAGES[image] ?? (image === publishedRef ? AGENT_BASE_SPEC : undefined);
 	if (!spec) return null;
 
 	const root = dockerBaseDirOverride ?? findRepoRoot();

--- a/packages/server/src/version.ts
+++ b/packages/server/src/version.ts
@@ -22,3 +22,12 @@ function readDevVersion(): string {
 }
 
 export const HEZO_VERSION: string = process.env.HEZO_VERSION ?? readDevVersion();
+
+/**
+ * True only in a compiled release binary, where `bun build --define` injected
+ * `process.env.HEZO_VERSION` (so the lookup folds to a literal). In dev
+ * (`bun run`) and tests the env var is absent, so this is `false` — the
+ * agent-base image is then always built from the working-tree Dockerfile rather
+ * than pulled from the registry, so Dockerfile edits take effect immediately.
+ */
+export const IS_PACKAGED_BUILD: boolean = process.env.HEZO_VERSION !== undefined;

--- a/packages/server/test/ensure-image.test.ts
+++ b/packages/server/test/ensure-image.test.ts
@@ -283,4 +283,73 @@ describe('ensureImage', () => {
 			expect.stringContaining('exited with code 1'),
 		);
 	});
+
+	it('pulls first and skips the build when preferPull is set and the pull succeeds', async () => {
+		const docker = {
+			imageExists: vi.fn().mockResolvedValue(false),
+			pullImage: vi.fn().mockResolvedValue(undefined),
+		} as unknown as DockerClient;
+		const resolveLocal = vi.fn().mockReturnValue({
+			image: 'ghcr.io/hezo-ai/agent-base:1.2.3',
+			dockerfile: '/repo/docker/Dockerfile.agent-base',
+			context: '/repo/docker',
+			bundleSourceHash: 'a'.repeat(64),
+		});
+		const build = vi.fn();
+
+		await ensureImage(docker, 'ghcr.io/hezo-ai/agent-base:1.2.3', {
+			resolveLocal,
+			build,
+			preferPull: true,
+		});
+
+		expect(docker.pullImage).toHaveBeenCalledWith('ghcr.io/hezo-ai/agent-base:1.2.3');
+		expect(build).not.toHaveBeenCalled();
+	});
+
+	it('falls back to a local build when the preferPull pull fails and a local spec exists', async () => {
+		const docker = {
+			imageExists: vi.fn().mockResolvedValue(false),
+			pullImage: vi.fn().mockRejectedValue(new Error('manifest unknown')),
+		} as unknown as DockerClient;
+		const resolveLocal = vi.fn().mockReturnValue({
+			image: 'ghcr.io/hezo-ai/agent-base:1.2.3',
+			dockerfile: '/repo/docker/Dockerfile.agent-base',
+			context: '/repo/docker',
+			bundleSourceHash: 'a'.repeat(64),
+		});
+		const build = vi.fn().mockResolvedValue(undefined);
+
+		await ensureImage(docker, 'ghcr.io/hezo-ai/agent-base:1.2.3', {
+			resolveLocal,
+			build,
+			preferPull: true,
+		});
+
+		expect(docker.pullImage).toHaveBeenCalledTimes(1);
+		expect(build).toHaveBeenCalledWith(
+			'ghcr.io/hezo-ai/agent-base:1.2.3',
+			'/repo/docker',
+			'/repo/docker/Dockerfile.agent-base',
+			expect.objectContaining({ labels: { 'hezo.bundle.sha': 'a'.repeat(64) } }),
+		);
+	});
+
+	it('propagates the preferPull pull error when no local spec is available', async () => {
+		const docker = {
+			imageExists: vi.fn().mockResolvedValue(false),
+			pullImage: vi.fn().mockRejectedValue(new Error('manifest unknown')),
+		} as unknown as DockerClient;
+		const resolveLocal = vi.fn().mockReturnValue(null);
+		const build = vi.fn();
+
+		await expect(
+			ensureImage(docker, 'ghcr.io/hezo-ai/agent-base:1.2.3', {
+				resolveLocal,
+				build,
+				preferPull: true,
+			}),
+		).rejects.toThrow('manifest unknown');
+		expect(build).not.toHaveBeenCalled();
+	});
 });

--- a/packages/server/test/image-registry.test.ts
+++ b/packages/server/test/image-registry.test.ts
@@ -3,9 +3,14 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
+	AGENT_BASE_GHCR_REPO,
 	BUNDLE_SHA_LABEL,
 	computeBundleSourceHash,
 	findRepoRoot,
+	isReleaseVersion,
+	MANAGED_AGENT_BASE_IMAGE,
+	publishedAgentBaseRef,
+	resolveAgentBaseImage,
 	resolveLocalImage,
 	setDockerBaseDir,
 } from '../src/services/image-registry';
@@ -35,6 +40,68 @@ describe('image-registry', () => {
 	it('returns null for unregistered images', () => {
 		expect(resolveLocalImage('alpine:latest')).toBeNull();
 		expect(resolveLocalImage('some/other:tag')).toBeNull();
+	});
+
+	describe('isReleaseVersion', () => {
+		it('accepts plain MAJOR.MINOR.PATCH', () => {
+			expect(isReleaseVersion('0.6.1')).toBe(true);
+			expect(isReleaseVersion('1.2.3')).toBe(true);
+			expect(isReleaseVersion('10.20.30')).toBe(true);
+		});
+		it('rejects dev, partial, prefixed, and pre-release versions', () => {
+			expect(isReleaseVersion('0.0.0-dev')).toBe(false);
+			expect(isReleaseVersion('1.2')).toBe(false);
+			expect(isReleaseVersion('v1.2.3')).toBe(false);
+			expect(isReleaseVersion('1.2.3-rc.1')).toBe(false);
+		});
+	});
+
+	describe('publishedAgentBaseRef', () => {
+		it('returns the versioned GHCR ref for a packaged release build', () => {
+			expect(publishedAgentBaseRef('0.6.1', true)).toBe(`${AGENT_BASE_GHCR_REPO}:0.6.1`);
+		});
+		it('returns null for an unpackaged (dev/test) build', () => {
+			expect(publishedAgentBaseRef('0.6.1', false)).toBeNull();
+		});
+		it('returns null for a non-release version even when packaged', () => {
+			expect(publishedAgentBaseRef('0.0.0-dev', true)).toBeNull();
+		});
+	});
+
+	describe('resolveAgentBaseImage', () => {
+		const ref = `${AGENT_BASE_GHCR_REPO}:0.6.1`;
+		it('maps the managed sentinel to the published ref with preferPull', () => {
+			expect(resolveAgentBaseImage(MANAGED_AGENT_BASE_IMAGE, ref)).toEqual({
+				image: ref,
+				preferPull: true,
+			});
+		});
+		it('keeps the sentinel and builds locally when no published ref exists', () => {
+			expect(resolveAgentBaseImage(MANAGED_AGENT_BASE_IMAGE, null)).toEqual({
+				image: MANAGED_AGENT_BASE_IMAGE,
+				preferPull: false,
+			});
+		});
+		it('passes custom per-project images through untouched', () => {
+			expect(resolveAgentBaseImage('registry.example.com/custom:tag', ref)).toEqual({
+				image: 'registry.example.com/custom:tag',
+				preferPull: false,
+			});
+		});
+	});
+
+	describe('resolveLocalImage published-ref fallback', () => {
+		const ref = `${AGENT_BASE_GHCR_REPO}:0.6.1`;
+		it('resolves the published ref for this build to the agent-base Dockerfile', () => {
+			const resolved = resolveLocalImage(ref, ref);
+			expect(resolved).not.toBeNull();
+			expect(resolved?.image).toBe(ref);
+			expect(resolved?.dockerfile.endsWith('docker/Dockerfile.agent-base')).toBe(true);
+			expect(resolved?.bundleSourceHash).toMatch(/^[0-9a-f]{64}$/);
+		});
+		it('returns null for a published ref that does not match this build', () => {
+			expect(resolveLocalImage(`${AGENT_BASE_GHCR_REPO}:9.9.9`, ref)).toBeNull();
+		});
 	});
 
 	describe('setDockerBaseDir override (compiled binary)', () => {


### PR DESCRIPTION
## What & why

Today the agent-base container image (`hezo/agent-base:latest`) is **only ever built locally** — a compiled binary embeds the `docker/` build context and the first container provision compiles the image on the host (~5–10 min, since git is built from source). CI already pushes `ghcr.io/hezo-ai/agent-base:<sha>` for its own test runners, but **nothing publishes a versioned image on release**.

This PR:
1. **Publishes** a **multi-arch** `ghcr.io/hezo-ai/agent-base:<version>` (+ `:latest`) to GHCR as part of every GitHub release.
2. Makes a running **release binary pull the image matching its own version** at provision time instead of building it — **falling back to the existing local build** if the pull fails (image not published yet, offline, private fork).
3. Keeps **dev (`bun run`) and tests building from the working-tree Dockerfile**, so Dockerfile edits still take effect immediately.

## How it works

- `hezo/agent-base:latest` stays the **DB sentinel/default** (no migration, no schema change). At provision time `resolveAgentBaseImage()` maps it to the version-pinned GHCR ref **only in a packaged release binary** (`IS_PACKAGED_BUILD && isReleaseVersion(HEZO_VERSION)`); otherwise it returns the sentinel unchanged for a local build. Custom per-project `docker_base_image` values pass through untouched.
- `ensureImage()` gains `preferPull`: pull-first, then local-build fallback (the published ref resolves to the same bundled Dockerfile/context).
- Because the version is in the tag, upgrades naturally resolve to a new ref — no stale-image dance. Prune stays scoped to the sentinel, so a pulled (label-less) image is never removed. No code compares a running container's image to the stored value, so running off the GHCR ref while the DB keeps the sentinel is safe.

## Files

- **Runtime:** `version.ts` (`IS_PACKAGED_BUILD`), `image-registry.ts` (constants + `isReleaseVersion`/`publishedAgentBaseRef`/`resolveAgentBaseImage`, `resolveLocalImage` matches the published ref), `ensure-image.ts` (`preferPull`), `containers.ts` (resolve effective image in `provisionContainer`).
- **CI:** `release-publish.yml` — new `publish-agent-image` job (QEMU multi-arch amd64+arm64, `packages: write`, GHA cache).
- **Docs:** `.dev/architecture.md` §12 rewritten (no user-facing `docs/` page references the image; no MCP/REST/CLI surface changed, so no generated-doc rebuild needed).
- **Tests:** new `preferPull` cases in `ensure-image.test.ts`; `isReleaseVersion`/`publishedAgentBaseRef`/`resolveAgentBaseImage`/published-ref-fallback cases in `image-registry.test.ts`.

## ⚠️ One-time ops prerequisite

The GHCR `agent-base` package must be set **Public** (repo/org → Packages → `agent-base` → Package settings → Visibility → Public) so the server's **anonymous** pull works. Until then every install simply falls back to the local build — **no breakage**, just no speed-up.

## Decisions (confirmed)

Public anonymous pull · multi-arch amd64+arm64 · name `ghcr.io/hezo-ai/agent-base` (reuse existing).

## Test plan

- [x] `bun run check` clean, `bun run typecheck` green (5/5).
- [x] `bun run test --package server --pattern image` → 56 passed (incl. new cases; the fallback log line confirms pull→build path).
- [x] `bun run test --package server --pattern container` → 56 passed (provisioning unaffected — in tests `IS_PACKAGED_BUILD` is false).
- [ ] After merge + a release that publishes the image (and the package is public): a released binary logs `→ Resolving image ghcr.io/hezo-ai/agent-base:<version>` and pulls in seconds; blocking egress to ghcr.io shows the local-build fallback.
- [ ] `docker manifest inspect ghcr.io/hezo-ai/agent-base:<version>` lists `linux/amd64` and `linux/arm64`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UNss4fsbpux1Y36GF83Dc9

---
_Generated by [Claude Code](https://claude.ai/code/session_01UNss4fsbpux1Y36GF83Dc9)_