### PR TITLE
test: drive line coverage from ~86% toward ≥92%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,35 @@ jobs:
           fail-on-error: false
           allow-empty: true
 
+  # The pure-logic shared package (packages/shared) has no DB/DOM/browser
+  # dependencies, so it runs as a single fast job (no sharding). Its coverage
+  # joins the same Coveralls parallel build under the `shared` flag.
+  test-shared:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+      - uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
+      - run: bun install --frozen-lockfile
+      - run: bun run test --package shared --coverage
+      - name: Upload shared coverage
+        if: always()
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: packages/shared/coverage/lcov.info
+          flag-name: shared
+          parallel: true
+          fail-on-error: false
+          allow-empty: true
+
   test-browser:
     runs-on: ubuntu-latest
     timeout-minutes: 40
@@ -231,6 +260,13 @@ jobs:
     steps:
       - run: '[ "${{ needs.test-integration.result }}" = "success" ]'
 
+  test-shared-complete:
+    if: always()
+    needs: test-shared
+    runs-on: ubuntu-latest
+    steps:
+      - run: '[ "${{ needs.test-shared.result }}" = "success" ]'
+
   # Closes the Coveralls parallel build once every shard/tier has uploaded, so
   # Coveralls merges them into a single coverage total for the commit. Runs
   # regardless of test outcome (if:always) so a failed shard still finalizes the
@@ -238,7 +274,7 @@ jobs:
   # blocks a merge. Requires the repo to be enabled on Coveralls (see AGENTS.md).
   coverage-finished:
     if: always()
-    needs: [test-backend, test-integration]
+    needs: [test-backend, test-integration, test-shared]
     runs-on: ubuntu-latest
     steps:
       - name: Close Coveralls parallel build
@@ -246,5 +282,5 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
-          carryforward: "backend-vitest-1,backend-vitest-2,backend-bun,web-1,web-2,web-3"
+          carryforward: "backend-vitest-1,backend-vitest-2,backend-bun,web-1,web-2,web-3,shared"
           fail-on-error: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,15 +2,15 @@
 
 ## Commands
 
-- `bun run test` — server unit/integration (vitest, Node) + server Bun-native tier (`bun test`) + web component tier (vitest) + browser (Playwright), in that order
-- `bun run test --skip-browser` — drop Playwright; runs server + web vitest only (~30s)
+- `bun run test` — server unit/integration (vitest, Node) + server Bun-native tier (`bun test`) + web component tier (vitest) + shared pure-logic unit tier (vitest) + browser (Playwright), in that order
+- `bun run test --skip-browser` — drop Playwright; runs server, web, and shared vitest only (~30s)
 - `bun run test --browser` — Playwright only
 - `bun run test --pattern <substring>` — filter by file-path substring (works across all tiers; combine with `--browser` to narrow browser tests)
-- `bun run test --package <server|web>` — restrict vitest run to one package
+- `bun run test --package <server|web|shared>` — restrict vitest run to one package
 - `bun run test --concurrency <n>` — override worker count (default 10)
-- `bun run test --shard <index>/<count>` — run one vitest shard (e.g. `1/3`); CI fans `test-backend` (2 shards) and `test-integration` (3 shards) across runners this way. The Bun-native tier runs only on shard 1. Composes with `--package`/`--concurrency`.
+- `bun run test --shard <index>/<count>` — run one vitest shard (e.g. `1/3`); CI fans `test-backend` (2 shards) and `test-integration` (3 shards) across runners this way; the pure-logic `shared` package runs unsharded as a single `test-shared` job. The Bun-native tier runs only on shard 1. Composes with `--package`/`--concurrency`.
 - `bun run test --bail` — stop on first failure
-- `bun run test --coverage` — instrument the vitest (server + web) and Bun-native tiers with V8 coverage; writes lcov/json to `packages/<pkg>/coverage` (plus `packages/server/coverage-bun` for the Bun tier). lcov reports are normalized before upload — `SF:` paths rewritten to be repo-root-relative so they map across the monorepo, and records scoped to `src/` only (the Bun tier otherwise instruments loaded test helpers). Off by default so normal runs stay fast. Composes with `--package`/`--shard`. CI uploads each shard/tier's lcov to Coveralls as a parallel build (unique `flag-name` each); a final `coverage-finished` job closes the build so Coveralls merges them into one total. Playwright is not yet instrumented.
+- `bun run test --coverage` — instrument the vitest (server, web, and shared) and Bun-native tiers with V8 coverage; writes lcov/json to `packages/<pkg>/coverage` (plus `packages/server/coverage-bun` for the Bun tier). lcov reports are normalized before upload — `SF:` paths rewritten to be repo-root-relative so they map across the monorepo, and records scoped to `src/` only (the Bun tier otherwise instruments loaded test helpers). Off by default so normal runs stay fast. Composes with `--package`/`--shard`. CI uploads each shard/tier's lcov to Coveralls as a parallel build (unique `flag-name` each — `backend-vitest-*`, `backend-bun`, `web-*`, `shared`); a final `coverage-finished` job closes the build so Coveralls merges them into one total. Playwright is not yet instrumented.
 - `bun run build` / `check` / `check:fix` / `typecheck` / `dev`
 
 `scripts/test.ts` is a commander CLI — it rejects unknown flags and `--` passthrough. To narrow by test name, use `test.only` / `describe.only` and revert before commit. Never call `npx playwright` or `npx vitest` directly (vitest's global `expect` clashes with Playwright outside the runner).
@@ -120,12 +120,13 @@ describe('017_example migration', () => {
 
 ## Testing
 
-All changes ship with tests that exercise functionality (not "code runs without throwing"). Prefer integration over heavily-mocked unit tests. Four tiers:
+All changes ship with tests that exercise functionality (not "code runs without throwing"). Prefer integration over heavily-mocked unit tests. Five tiers:
 
 | Tier | Where | Run cost | What it tests | When to use |
 |---|---|---|---|---|
 | Server unit/integration | `packages/server/test/**/*.test.ts` | ~ms each | API handlers, DB queries, services, MCP tools, agent run plumbing. Each test boots a fresh PGlite + Hono app via `createTestContext()`. | Everything backend. |
 | Web component | `packages/web/test/**/*.test.tsx` | ~100-700ms each | React tree rendered in happy-dom against an **in-process** Hono + PGlite backend via `renderApp()` in `packages/web/test/helpers/render.tsx`. Asserts on DOM, forms, React Query refetches, navigation, mention rendering. Stubs WebSocket (`reconnecting-websocket`'s constructor checks) and `IntersectionObserver`. | Anything render-driven that doesn't depend on a real browser layout engine or WebSocket stream. ~80% of what would otherwise be a browser test. |
+| Shared pure-logic unit | `packages/shared/test/**/*.test.ts` | ~ms each | Pure functions in `@hezo/shared` (crypto/auth, mnemonic, mention parsing, budget/pricing math, task-progress, enum/type guards) — no DB, no DOM, plain Node via vitest. Counted in the Coveralls total alongside server/web. | The shared package's logic. |
 | Playwright browser | `test/browser/**/*.spec.ts` | ~10-30s each | Real Chromium. Mobile viewport (responsive checks at 375px), drag-drop file events, `boundingBox()` / sticky positioning, Virtuoso virtualization windows + scroll, scroll-to-bottom buttons, real `clientHeight`/`scrollHeight` comparisons, real WebSocket-streamed logs, the master-key gate flow before any token is set. | The thin slice that genuinely needs the browser. Default: write a component test instead. |
 | Bun-native runtime | `packages/server/test/bun/**/*.bun.test.ts` | ~ms each | Code whose behaviour diverges between Node and Bun, exercised on the **production Bun runtime** via `bun test` (not vitest, which runs under Node). Today: the egress proxy's TLS MITM path. Imports `bun:test`; reuses the server helpers (`createTestApp`, etc.). | Anything that relies on runtime-specific `node:` API behaviour (TLS, `net`, `crypto`, `child_process`) where a Node-only test would give false confidence. |
 

--- a/bun.lock
+++ b/bun.lock
@@ -27,7 +27,7 @@
     },
     "packages/server": {
       "name": "@hezo/server",
-      "version": "0.3.0",
+      "version": "0.6.1",
       "dependencies": {
         "@electric-sql/pglite": "^0.2",
         "@hezo/shared": "workspace:*",
@@ -50,19 +50,21 @@
     },
     "packages/shared": {
       "name": "@hezo/shared",
-      "version": "0.3.0",
+      "version": "0.6.1",
       "dependencies": {
         "@noble/curves": "^1.9.1",
         "@noble/hashes": "^1.8.0",
         "@scure/bip39": "^1.6.0",
       },
       "devDependencies": {
+        "@vitest/coverage-v8": "3.2.4",
         "typescript": "^5",
+        "vitest": "^3",
       },
     },
     "packages/web": {
       "name": "@hezo/web",
-      "version": "0.3.0",
+      "version": "0.6.1",
       "dependencies": {
         "@hezo/shared": "workspace:*",
         "@radix-ui/react-alert-dialog": "^1",

--- a/packages/server/test/agent-chat-parser.test.ts
+++ b/packages/server/test/agent-chat-parser.test.ts
@@ -1,0 +1,336 @@
+import { AgentRuntime } from '@hezo/shared';
+import { describe, expect, it } from 'vitest';
+import {
+	type AgentChatTurnEvent,
+	createAgentChatParser,
+	createAgentStreamParser,
+} from '../src/services/agent-stream-parser';
+
+/**
+ * The chat parser feeds the CEO real-time chat: it turns each runtime's
+ * stream-json events into assistant text blocks (for the streaming bubble),
+ * tool-activity hints (for the "working…" status line), and the terminal token
+ * usage. It is pure logic, so we drive each runtime's parser with representative
+ * event lines and assert the structured turn events it yields.
+ */
+
+const line = (event: unknown) => `${JSON.stringify(event)}\n`;
+
+/** Collect both onStdout + flush output for an array of event objects. */
+function feed(parser: ReturnType<typeof createAgentChatParser>, events: unknown[]) {
+	const out: AgentChatTurnEvent[] = [];
+	for (const e of events) out.push(...parser.onStdout(line(e)));
+	out.push(...parser.flush());
+	return out;
+}
+
+describe('agent-chat-parser — Claude Code', () => {
+	it('emits assistant text blocks and tool activity, skipping empty text', () => {
+		const parser = createAgentChatParser(AgentRuntime.ClaudeCode);
+		const events = feed(parser, [
+			{
+				type: 'assistant',
+				message: {
+					role: 'assistant',
+					content: [
+						{ type: 'text', text: 'Hello there' },
+						{ type: 'text', text: '   ' }, // whitespace-only is dropped
+						{ type: 'tool_use', name: 'Edit', input: { file_path: '/a.ts' } },
+					],
+				},
+			},
+		]);
+		expect(events).toEqual([{ text: 'Hello there' }, { toolActivity: 'Edit' }]);
+	});
+
+	it('falls back to a generic tool label when the tool_use has no name', () => {
+		const parser = createAgentChatParser(AgentRuntime.ClaudeCode);
+		const events = feed(parser, [
+			{ type: 'assistant', message: { role: 'assistant', content: [{ type: 'tool_use' }] } },
+		]);
+		expect(events).toEqual([{ toolActivity: 'tool' }]);
+	});
+
+	it('captures usage from the terminal result, summing cache buckets into input', () => {
+		const parser = createAgentChatParser(AgentRuntime.ClaudeCode);
+		feed(parser, [
+			{
+				type: 'result',
+				total_cost_usd: 0.25,
+				usage: {
+					input_tokens: 100,
+					output_tokens: 50,
+					cache_creation_input_tokens: 20,
+					cache_read_input_tokens: 30,
+				},
+			},
+		]);
+		expect(parser.getUsage()).toEqual({ inputTokens: 150, outputTokens: 50, costCents: 25 });
+	});
+
+	it('handles a result event with no usage object (defaults to zero)', () => {
+		const parser = createAgentChatParser(AgentRuntime.ClaudeCode);
+		feed(parser, [{ type: 'result' }]);
+		expect(parser.getUsage()).toEqual({ inputTokens: 0, outputTokens: 0, costCents: 0 });
+	});
+
+	it('reports null usage before any terminal event', () => {
+		const parser = createAgentChatParser(AgentRuntime.ClaudeCode);
+		expect(parser.getUsage()).toBeNull();
+	});
+
+	it('normalizes a string message body into a single text block', () => {
+		const parser = createAgentChatParser(AgentRuntime.ClaudeCode);
+		const events = feed(parser, [
+			{ type: 'assistant', message: { role: 'assistant', content: 'plain string body' } },
+		]);
+		expect(events).toEqual([{ text: 'plain string body' }]);
+	});
+
+	it('drops lines that fail to parse and unknown event types', () => {
+		const parser = createAgentChatParser(AgentRuntime.ClaudeCode);
+		expect(parser.onStdout('not json\n')).toEqual([]);
+		expect(parser.onStdout(line({ type: 'system', subtype: 'init', model: 'x' }))).toEqual([]);
+	});
+});
+
+describe('agent-chat-parser — Codex', () => {
+	it('renders an agent_message item as assistant text', () => {
+		const parser = createAgentChatParser(AgentRuntime.Codex);
+		const events = feed(parser, [
+			{ type: 'item.completed', item: { type: 'agent_message', text: 'Done.' } },
+		]);
+		expect(events).toEqual([{ text: 'Done.' }]);
+	});
+
+	it('reads assistant_message text from the message field', () => {
+		const parser = createAgentChatParser(AgentRuntime.Codex);
+		const events = feed(parser, [
+			{ type: 'item.completed', item: { item_type: 'assistant_message', message: 'Via message' } },
+		]);
+		expect(events).toEqual([{ text: 'Via message' }]);
+	});
+
+	it('maps command execution and tool calls to tool-activity hints', () => {
+		const parser = createAgentChatParser(AgentRuntime.Codex);
+		const events = feed(parser, [
+			{ type: 'item.completed', item: { type: 'command_execution', command: 'ls' } },
+			{ type: 'item.completed', item: { type: 'mcp_tool_call', name: 'search' } },
+			{ type: 'item.completed', item: { type: 'tool_call' } }, // no name → 'tool'
+		]);
+		expect(events).toEqual([
+			{ toolActivity: 'shell' },
+			{ toolActivity: 'search' },
+			{ toolActivity: 'tool' },
+		]);
+	});
+
+	it('captures usage from turn.completed, folding reasoning into output', () => {
+		const parser = createAgentChatParser(AgentRuntime.Codex);
+		const events = feed(parser, [
+			{
+				type: 'turn.completed',
+				usage: { input_tokens: 500, output_tokens: 40, reasoning_output_tokens: 10 },
+			},
+		]);
+		expect(events).toEqual([]); // terminal events yield no chat text
+		expect(parser.getUsage()).toEqual({ inputTokens: 500, outputTokens: 50, costCents: 0 });
+	});
+
+	it('captures usage from turn.failed too', () => {
+		const parser = createAgentChatParser(AgentRuntime.Codex);
+		feed(parser, [{ type: 'turn.failed', usage: { input_tokens: 7, output_tokens: 3 } }]);
+		expect(parser.getUsage()).toEqual({ inputTokens: 7, outputTokens: 3, costCents: 0 });
+	});
+
+	it('drops empty agent messages and unknown item kinds', () => {
+		const parser = createAgentChatParser(AgentRuntime.Codex);
+		const events = feed(parser, [
+			{ type: 'item.completed', item: { type: 'agent_message', text: '   ' } },
+			{ type: 'item.completed', item: { type: 'reasoning', text: 'thinking quietly' } },
+			{ type: 'thread.started', model: 'codex-x' },
+		]);
+		expect(events).toEqual([]);
+	});
+});
+
+describe('agent-chat-parser — Gemini', () => {
+	it('renders assistant message content and skips the user echo', () => {
+		const parser = createAgentChatParser(AgentRuntime.Gemini);
+		const events = feed(parser, [
+			{ type: 'message', role: 'user', content: 'the prompt' },
+			{ type: 'message', role: 'assistant', content: 'The answer.' },
+		]);
+		expect(events).toEqual([{ text: 'The answer.' }]);
+	});
+
+	it('falls back to the text field when content is absent', () => {
+		const parser = createAgentChatParser(AgentRuntime.Gemini);
+		const events = feed(parser, [{ type: 'message', text: 'from text field' }]);
+		expect(events).toEqual([{ text: 'from text field' }]);
+	});
+
+	it('maps tool_use to a tool-activity hint', () => {
+		const parser = createAgentChatParser(AgentRuntime.Gemini);
+		const events = feed(parser, [
+			{ type: 'tool_use', name: 'web_search' },
+			{ type: 'tool_use' }, // no name → 'tool'
+		]);
+		expect(events).toEqual([{ toolActivity: 'web_search' }, { toolActivity: 'tool' }]);
+	});
+
+	it('captures usage from the result event across models', () => {
+		const parser = createAgentChatParser(AgentRuntime.Gemini);
+		feed(parser, [
+			{
+				type: 'result',
+				stats: {
+					models: {
+						'gemini-2.5-pro': { tokens: { prompt: 1000, candidates: 100, thoughts: 20 } },
+					},
+				},
+			},
+		]);
+		expect(parser.getUsage()).toEqual({ inputTokens: 1000, outputTokens: 120, costCents: 0 });
+	});
+
+	it('drops whitespace-only assistant messages', () => {
+		const parser = createAgentChatParser(AgentRuntime.Gemini);
+		const events = feed(parser, [{ type: 'message', role: 'assistant', content: '   ' }]);
+		expect(events).toEqual([]);
+	});
+});
+
+describe('agent-chat-parser — generic (OpenCode / Kimi)', () => {
+	it('renders assistant text and tool activity, skipping user-role events', () => {
+		const parser = createAgentChatParser(AgentRuntime.OpenCode);
+		const events = feed(parser, [
+			{ type: 'message', role: 'user', text: 'prompt' },
+			{ type: 'message', role: 'assistant', text: 'Hi' },
+			{ type: 'tool_use', name: 'bash', input: { command: 'ls' } },
+		]);
+		expect(events).toEqual([{ text: 'Hi' }, { toolActivity: 'bash' }]);
+	});
+
+	it('captures usage from a terminal event carrying tokens', () => {
+		const parser = createAgentChatParser(AgentRuntime.Kimi);
+		feed(parser, [
+			{ type: 'init', model: 'kimi-for-coding' },
+			{ type: 'result', usage: { input_tokens: 300, output_tokens: 60 } },
+		]);
+		expect(parser.getUsage()).toEqual({ inputTokens: 300, outputTokens: 60, costCents: 0 });
+	});
+
+	it('drops non-object lines and unrecognized events', () => {
+		const parser = createAgentChatParser(AgentRuntime.OpenCode);
+		expect(parser.onStdout('123\n')).toEqual([]); // valid JSON, but not a record
+		expect(parser.onStdout(line({ type: 'session.status', status: 'busy' }))).toEqual([]);
+	});
+
+	it('flushes a trailing partial line with no newline', () => {
+		const parser = createAgentChatParser(AgentRuntime.OpenCode);
+		const serialized = JSON.stringify({ type: 'message', role: 'assistant', text: 'tail' });
+		const half = Math.floor(serialized.length / 2);
+		expect(parser.onStdout(serialized.slice(0, half))).toEqual([]);
+		expect(parser.onStdout(serialized.slice(half))).toEqual([]); // still buffered, no newline
+		expect(parser.flush()).toEqual([{ text: 'tail' }]);
+	});
+});
+
+describe('agent-chat-parser — unsupported runtime', () => {
+	it('returns a no-op parser for an unknown runtime', () => {
+		const parser = createAgentChatParser('made_up' as AgentRuntime);
+		expect(parser.onStdout(line({ type: 'message', text: 'x' }))).toEqual([]);
+		expect(parser.flush()).toEqual([]);
+		expect(parser.getUsage()).toBeNull();
+	});
+});
+
+/**
+ * A handful of log-parser branches that the existing agent-stream-parser.test.ts
+ * doesn't reach: the passthrough runtime, empty-string error classification, the
+ * Codex `error` event, Gemini `tool_result`/`error` rendering, the empty
+ * thinking block, and array-shaped tool_result content.
+ */
+describe('agent-stream-parser — remaining log branches', () => {
+	it('passthrough runtime echoes raw stdout/stderr verbatim', () => {
+		const parser = createAgentStreamParser('totally_unknown' as AgentRuntime);
+		expect(parser.onStdout('raw line\n')).toBe('raw line\n');
+		expect(parser.onStderr('err line\n')).toBe('err line\n');
+		expect(parser.flush()).toBe('');
+		expect(parser.getUsage()).toBeNull();
+		expect(parser.getTerminalError()).toBeNull();
+	});
+
+	it('Codex surfaces an error event as a [tool-error] line', () => {
+		const parser = createAgentStreamParser(AgentRuntime.Codex);
+		const out = parser.onStdout(line({ type: 'error', error: { message: 'rate   limited' } }));
+		expect(out).toBe('[tool-error] rate limited\n');
+	});
+
+	it('Codex drops an error event with no message', () => {
+		const parser = createAgentStreamParser(AgentRuntime.Codex);
+		expect(parser.onStdout(line({ type: 'error' }))).toBe('');
+	});
+
+	it('Gemini renders a tool_result and a tool_error distinctly', () => {
+		const parser = createAgentStreamParser(AgentRuntime.Gemini);
+		expect(parser.onStdout(line({ type: 'tool_result', output: 'all good' }))).toBe(
+			'[tool-result] all good\n',
+		);
+		expect(parser.onStdout(line({ type: 'tool_result', is_error: true, result: 'boom' }))).toBe(
+			'[tool-error] boom\n',
+		);
+	});
+
+	it('Gemini renders a bare tool_result label when the body is empty', () => {
+		const parser = createAgentStreamParser(AgentRuntime.Gemini);
+		expect(parser.onStdout(line({ type: 'tool_result' }))).toBe('[tool-result]\n');
+	});
+
+	it('Gemini surfaces an error event as a plain line and marks the result error', () => {
+		const parser = createAgentStreamParser(AgentRuntime.Gemini);
+		expect(parser.onStdout(line({ type: 'error', message: 'quota exceeded' }))).toBe(
+			'quota exceeded\n',
+		);
+		const done = parser.onStdout(line({ type: 'result', error: { message: 'x' }, stats: {} }));
+		expect(done).toBe('[done] error tokens=0/0\n');
+	});
+
+	it('renders a tool_use tool with object input the runner can preview', () => {
+		const parser = createAgentStreamParser(AgentRuntime.Gemini);
+		const out = parser.onStdout(line({ type: 'tool_use', name: 'grep', args: { pattern: 'foo' } }));
+		expect(out).toContain('[tool] grep(');
+		expect(out).toContain('pattern=foo');
+	});
+
+	it('renders an empty thinking block as the bare [thinking] label', () => {
+		const parser = createAgentStreamParser(AgentRuntime.ClaudeCode);
+		const out = parser.onStdout(
+			line({
+				type: 'assistant',
+				message: { role: 'assistant', content: [{ type: 'thinking', thinking: '   ' }] },
+			}),
+		);
+		expect(out).toBe('[thinking]\n');
+	});
+
+	it('extracts array-shaped tool_result content (Claude)', () => {
+		const parser = createAgentStreamParser(AgentRuntime.ClaudeCode);
+		const out = parser.onStdout(
+			line({
+				type: 'user',
+				message: {
+					role: 'user',
+					content: [
+						{
+							type: 'tool_result',
+							content: [{ type: 'text', text: 'part one' }, 'part two', { irrelevant: true }],
+						},
+					],
+				},
+			}),
+		);
+		expect(out).toBe('[tool-result] part one part two\n');
+	});
+});

--- a/packages/server/test/agent-roles.test.ts
+++ b/packages/server/test/agent-roles.test.ts
@@ -1,0 +1,105 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+	loadAgentRoles,
+	loadBundledAgentRoles,
+	loadFilesystemAgentRoles,
+} from '../src/db/agent-roles';
+
+let root: string;
+
+beforeEach(() => {
+	root = mkdtempSync(join(tmpdir(), 'agent-roles-'));
+});
+
+afterEach(() => {
+	rmSync(root, { recursive: true, force: true });
+});
+
+describe('loadFilesystemAgentRoles', () => {
+	it('recursively walks a directory, keying each .md by its relative posix path', async () => {
+		mkdirSync(join(root, 'software-development'), { recursive: true });
+		mkdirSync(join(root, 'blank'), { recursive: true });
+		writeFileSync(join(root, 'software-development', 'engineer.md'), '# Engineer');
+		writeFileSync(join(root, 'software-development', 'qa.md'), '# QA');
+		writeFileSync(join(root, 'blank', 'captain.md'), '# Captain');
+		// Non-markdown files are ignored.
+		writeFileSync(join(root, 'README.txt'), 'ignore me');
+
+		const roles = await loadFilesystemAgentRoles(root);
+		expect(Object.keys(roles).sort()).toEqual([
+			'blank/captain.md',
+			'software-development/engineer.md',
+			'software-development/qa.md',
+		]);
+		expect(roles['software-development/engineer.md']).toBe('# Engineer');
+		expect(roles['blank/captain.md']).toBe('# Captain');
+	});
+
+	it('returns an empty map for an empty directory', async () => {
+		const roles = await loadFilesystemAgentRoles(root);
+		expect(roles).toEqual({});
+	});
+});
+
+describe('loadAgentRoles (HEZO_AGENTS_DIR override + partial resolution)', () => {
+	let prev: string | undefined;
+
+	beforeEach(() => {
+		prev = process.env.HEZO_AGENTS_DIR;
+	});
+
+	afterEach(() => {
+		if (prev === undefined) delete process.env.HEZO_AGENTS_DIR;
+		else process.env.HEZO_AGENTS_DIR = prev;
+	});
+
+	it('loads from HEZO_AGENTS_DIR and resolves {{> partials/...}} includes', async () => {
+		mkdirSync(join(root, '_partials'), { recursive: true });
+		mkdirSync(join(root, 'team'), { recursive: true });
+		writeFileSync(join(root, '_partials', 'shared.md'), 'SHARED BLOCK');
+		writeFileSync(join(root, 'team', 'lead.md'), '# Lead\n{{> partials/shared}}\nend');
+
+		process.env.HEZO_AGENTS_DIR = root;
+		const roles = await loadAgentRoles();
+
+		// The partial file itself is not surfaced as a role.
+		expect(roles['_partials/shared.md']).toBeUndefined();
+		// The directive was expanded inline.
+		expect(roles['team/lead.md']).toBe('# Lead\nSHARED BLOCK\nend');
+	});
+
+	it('throws a clear error when a partial reference is unknown', async () => {
+		mkdirSync(join(root, 'team'), { recursive: true });
+		writeFileSync(join(root, 'team', 'lead.md'), '{{> partials/does-not-exist}}');
+		process.env.HEZO_AGENTS_DIR = root;
+		await expect(loadAgentRoles()).rejects.toThrow(/Unknown partial reference/);
+	});
+
+	it('loads built-in roles via the bundle/fallback when no override is set', async () => {
+		// No HEZO_AGENTS_DIR → loadAgentRoles goes through loadBundledAgentRoles,
+		// falling back to the filesystem walk of the repo `agents/` dir if the
+		// bundle is an empty stub. Either way the seeded built-ins (CEO, Captain)
+		// must resolve, since createTestApp depends on them.
+		delete process.env.HEZO_AGENTS_DIR;
+		const roles = await loadAgentRoles();
+		expect(Object.keys(roles).length).toBeGreaterThan(0);
+		expect(roles['_instance/ceo.md']).toBeTruthy();
+	});
+});
+
+describe('loadBundledAgentRoles', () => {
+	it('either returns the embedded bundle or throws a build-required error', async () => {
+		// In a built workspace the bundle is populated; without `bun run build:agents`
+		// it is an empty stub and the loader throws so loadAgentRoles can fall back.
+		try {
+			const bundle = await loadBundledAgentRoles();
+			expect(Object.keys(bundle).length).toBeGreaterThan(0);
+			expect(typeof bundle['_instance/ceo.md']).toBe('string');
+		} catch (e) {
+			expect((e as Error).message).toMatch(/bundle (is empty|)|build:agents/i);
+		}
+	});
+});

--- a/packages/server/test/agent-runner-extended.test.ts
+++ b/packages/server/test/agent-runner-extended.test.ts
@@ -1,0 +1,1086 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import type { PGlite } from '@electric-sql/pglite';
+import {
+	AiAuthMethod,
+	AiProvider,
+	ContainerStatus,
+	HeartbeatRunStatus,
+	WakeupSource,
+} from '@hezo/shared';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { decrypt } from '../src/crypto/encryption';
+import type { MasterKeyManager } from '../src/crypto/master-key';
+import { DomainEventBus } from '../src/events/bus';
+import type { Env } from '../src/lib/types';
+import {
+	buildTaskPrompt,
+	getHostPromptPath,
+	getHostSubscriptionRoot,
+	loadMentionContext,
+	loadReplyContext,
+	loadSpawnedFromTask,
+	type RunnerDeps,
+	runAgent,
+} from '../src/services/agent-runner';
+import type { DockerClient } from '../src/services/docker';
+import { LogStreamBroker } from '../src/services/log-stream-broker';
+import { PricingService, upsertManualRate } from '../src/services/pricing';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
+
+// Read the prompt the run wrote to its host prompt file, located from the
+// HEZO_PROMPT_FILE env var captured off the exec opts.
+function readPromptFromExec(
+	opts: { Env: string[] },
+	dataDir: string,
+	project: { team_id: string; id: string },
+): string {
+	const entry = opts.Env.find((e) => e.startsWith('HEZO_PROMPT_FILE='));
+	if (!entry) throw new Error('HEZO_PROMPT_FILE env var missing from exec');
+	const runId = entry
+		.slice('HEZO_PROMPT_FILE='.length)
+		.split('/')
+		.pop()!
+		.replace(/\.txt$/, '');
+	return readFileSync(getHostPromptPath(dataDir, project.team_id, project.id, runId), 'utf8');
+}
+
+// Same exec-driven side effect the sibling agent-runner.test.ts uses: flip a
+// run's produced_output (or reported_no_work) mid-exec so an exit-0 mock reads
+// as a genuine success/no-op rather than tripping the "no output" failure path.
+function createMockDocker(taskId: string, overrides: Record<string, any> = {}): DockerClient {
+	const {
+		execStart: execStartOverride,
+		producesOutput = true,
+		reportsNoWork = false,
+		noWorkReason = 'nothing to do this run',
+		...rest
+	} = overrides;
+	const innerExecStart = execStartOverride ?? (async () => ({ stdout: 'done', stderr: '' }));
+	return {
+		ping: async () => true,
+		imageExists: async () => true,
+		pullImage: async () => {},
+		createContainer: async () => ({ Id: 'container-123', Warnings: [] }),
+		startContainer: async () => {},
+		stopContainer: async () => {},
+		removeContainer: async () => {},
+		inspectContainer: async () => ({
+			Id: 'container-123',
+			State: { Status: 'running', Running: true, Pid: 1, ExitCode: 0 },
+			Config: { Image: 'test' },
+		}),
+		containerLogs: async () => new ReadableStream(),
+		execCreate: async () => 'exec-123',
+		execInspect: async () => ({ ExitCode: 0, Running: false, Pid: 0 }),
+		...rest,
+		execStart: async (...args: unknown[]) => {
+			if (producesOutput) {
+				await db.query(
+					`UPDATE heartbeat_runs SET produced_output = true WHERE task_id = $1 AND status = 'running'`,
+					[taskId],
+				);
+			}
+			if (reportsNoWork) {
+				await db.query(
+					`UPDATE heartbeat_runs SET reported_no_work = true, no_work_reason = $2 WHERE task_id = $1 AND status = 'running'`,
+					[taskId, noWorkReason],
+				);
+			}
+			return (innerExecStart as (...a: unknown[]) => unknown)(...args);
+		},
+	} as unknown as DockerClient;
+}
+
+let app: Hono<Env>;
+let db: PGlite;
+let adminToken: string;
+let masterKeyManager: MasterKeyManager;
+let teamId: string;
+let projectId: string;
+let projectSlug: string;
+let taskId: string;
+let agentId: string;
+let agentSlug: string | null;
+
+const originalFetch = globalThis.fetch;
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	adminToken = ctx.token;
+	masterKeyManager = ctx.masterKeyManager;
+
+	const typesRes = await app.request('/api/team-templates', { headers: authHeader(adminToken) });
+	const typeId = (await typesRes.json()).data.find((t: any) => t.name === 'Startup').id;
+
+	const teamRes = await createTestTeam(db, { name: 'Ext Co', template_id: typeId });
+	teamId = (await teamRes.json()).data.id;
+
+	globalThis.fetch = vi.fn().mockResolvedValue({ ok: true }) as unknown as typeof fetch;
+	await app.request('/api/ai-providers', {
+		method: 'POST',
+		headers: { ...authHeader(adminToken), 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			provider: 'anthropic',
+			api_key: 'sk-ant-ext-key',
+			label: 'anthropic-ext',
+		}),
+	});
+	globalThis.fetch = originalFetch;
+
+	const projectRes = await createTestProject(db, teamId, {
+		name: 'Ext Project',
+		description: 'Extended test project.',
+	});
+	const projectData = (await projectRes.json()).data;
+	projectId = projectData.id;
+	projectSlug = projectData.slug;
+
+	const agentsRes = await app.request(`/api/projects/${projectSlug}/agents`, {
+		headers: authHeader(adminToken),
+	});
+	const agentRow = (await agentsRes.json()).data[0];
+	agentId = agentRow.id;
+	agentSlug = agentRow.slug ?? null;
+
+	const taskRes = await app.request(`/api/projects/${projectSlug}/tasks`, {
+		method: 'POST',
+		headers: { ...authHeader(adminToken), 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			project_id: projectId,
+			title: 'Ext Task',
+			description: 'Ext description',
+			assignee_id: agentId,
+		}),
+	});
+	taskId = (await taskRes.json()).data.id;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+async function setAgentPrompt(content: string) {
+	await db.query(
+		`INSERT INTO documents (team_id, member_agent_id, type, slug, content)
+		 VALUES ($1, $2, 'agent_system_prompt', 'system-prompt', $3)
+		 ON CONFLICT (member_agent_id) WHERE type = 'agent_system_prompt'
+		 DO UPDATE SET content = EXCLUDED.content`,
+		[teamId, agentId, content],
+	);
+}
+
+function makeAgent() {
+	return { id: agentId, title: 'Test Agent', slug: agentSlug, team_id: teamId };
+}
+
+function makeTask(overrides: Record<string, unknown> = {}) {
+	return {
+		id: taskId,
+		identifier: 'EX-1',
+		title: 'Ext Task',
+		description: 'Ext description',
+		status: 'backlog',
+		priority: 'medium',
+		project_id: projectId,
+		rules: null,
+		progress_summary: null,
+		...overrides,
+	};
+}
+
+function makeProject(overrides: Record<string, unknown> = {}) {
+	return {
+		id: projectId,
+		slug: projectSlug,
+		team_id: teamId,
+		team_slug: 'ext-co',
+		container_id: 'container-123',
+		container_status: ContainerStatus.Running,
+		designated_repo_id: null,
+		is_internal: false,
+		...overrides,
+	};
+}
+
+function baseDeps(docker: DockerClient, extra: Partial<RunnerDeps> = {}): RunnerDeps {
+	return {
+		db,
+		docker,
+		masterKeyManager,
+		serverPort: 3000,
+		dataDir: '/tmp/test-data',
+		logs: new LogStreamBroker(),
+		...extra,
+	};
+}
+
+/** Minimal in-process fake of the egress proxy used by runAgent. */
+function fakeEgressProxy() {
+	const calls = { allocated: [] as string[], released: [] as string[] };
+	return {
+		calls,
+		proxy: {
+			allocateRunProxy: async (runId: string, _ctx: unknown) => {
+				calls.allocated.push(runId);
+				return { proxyHost: '127.0.0.1', proxyPort: 18080 };
+			},
+			releaseRunProxy: async (runId: string) => {
+				calls.released.push(runId);
+			},
+		} as any,
+	};
+}
+
+/** Minimal in-process fake of the SSH agent server used by runAgent. */
+function fakeSshAgentServer() {
+	const calls = { allocated: [] as string[], released: [] as string[] };
+	return {
+		calls,
+		server: {
+			allocateRunSocket: async (runId: string, _ident: unknown, hostPath: string) => {
+				calls.allocated.push(runId);
+				return {
+					socketHostPath: hostPath,
+					tcpHostPort: 41000,
+					tokenHex: 'a'.repeat(32),
+				};
+			},
+			releaseRunSocket: async (runId: string) => {
+				calls.released.push(runId);
+			},
+		} as any,
+	};
+}
+
+describe('runAgent — egress proxy + ssh agent env injection', () => {
+	it('injects proxy/CA/SSH env vars and allocates+releases both run-scoped resources', async () => {
+		let capturedEnv: string[] = [];
+		const docker = createMockDocker(taskId, {
+			execCreate: async (_id: string, opts: any) => {
+				capturedEnv = opts.Env;
+				return 'exec-egress';
+			},
+			execStart: async () => ({ stdout: 'ok', stderr: '' }),
+			execInspect: async () => ({ ExitCode: 0, Running: false, Pid: 0 }),
+		});
+
+		const egress = fakeEgressProxy();
+		const ssh = fakeSshAgentServer();
+		const deps = baseDeps(docker, {
+			egressProxy: egress.proxy,
+			egressCAPath: '/tmp/test-data/egress-ca.crt',
+			sshAgentServer: ssh.server,
+		});
+
+		const result = await runAgent(deps, makeAgent(), makeTask(), makeProject());
+		expect(result.success).toBe(true);
+
+		// Egress proxy env: both upper- and lower-case proxy vars, NO_PROXY, and the
+		// three CA-bundle pointers the in-container tooling reads.
+		const proxyUrl = 'http://127.0.0.1:18080';
+		expect(capturedEnv).toContain(`HTTP_PROXY=${proxyUrl}`);
+		expect(capturedEnv).toContain(`http_proxy=${proxyUrl}`);
+		expect(capturedEnv).toContain(`HTTPS_PROXY=${proxyUrl}`);
+		expect(capturedEnv).toContain(`https_proxy=${proxyUrl}`);
+		// NO_PROXY excludes the proxy host itself + loopback (plus the provider's
+		// direct upstream hosts); host.docker.internal is NOT in it.
+		expect(
+			capturedEnv.some(
+				(e) => e.startsWith('NO_PROXY=') && e.includes('127.0.0.1') && e.includes('localhost'),
+			),
+		).toBe(true);
+		expect(capturedEnv.some((e) => e.startsWith('no_proxy='))).toBe(true);
+		expect(
+			capturedEnv.some(
+				(e) => e === 'NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/hezo-egress.crt',
+			),
+		).toBe(true);
+		expect(
+			capturedEnv.some(
+				(e) => e === 'CURL_CA_BUNDLE=/usr/local/share/ca-certificates/hezo-egress.crt',
+			),
+		).toBe(true);
+		expect(
+			capturedEnv.some(
+				(e) => e === 'GIT_SSL_CAINFO=/usr/local/share/ca-certificates/hezo-egress.crt',
+			),
+		).toBe(true);
+
+		// SSH socket env points at the per-run bridge socket.
+		expect(
+			capturedEnv.some((e) => e === `SSH_AUTH_SOCK=/run/hezo/${result.heartbeatRunId}.sock`),
+		).toBe(true);
+
+		// Both resources allocated then released for this run.
+		expect(egress.calls.allocated).toContain(result.heartbeatRunId);
+		expect(egress.calls.released).toContain(result.heartbeatRunId);
+		expect(ssh.calls.allocated).toContain(result.heartbeatRunId);
+		expect(ssh.calls.released).toContain(result.heartbeatRunId);
+	});
+
+	it('wraps the exec command with the ssh bridge runner argv when an agent server is present', async () => {
+		let capturedExecCmd: string[] = [];
+		const docker = createMockDocker(taskId, {
+			execCreate: async (_id: string, opts: any) => {
+				capturedExecCmd = opts.Cmd;
+				return 'exec-bridge';
+			},
+			execStart: async () => ({ stdout: 'ok', stderr: '' }),
+			execInspect: async () => ({ ExitCode: 0, Running: false, Pid: 0 }),
+		});
+
+		const ssh = fakeSshAgentServer();
+		const deps = baseDeps(docker, { sshAgentServer: ssh.server });
+
+		const result = await runAgent(deps, makeAgent(), makeTask(), makeProject());
+		expect(result.success).toBe(true);
+
+		// With a bridge, the wrapper is the bridge-runner binary, not the bare
+		// `sh -c PROMPT_DELIVERY_SH` form (which is asserted in the sibling file).
+		expect(capturedExecCmd[0]).not.toBe('sh');
+		// The bridge runner forwards the per-run socket path as one of its argv.
+		expect(capturedExecCmd).toContain(`/run/hezo/${result.heartbeatRunId}.sock`);
+		expect(ssh.calls.released).toContain(result.heartbeatRunId);
+	});
+});
+
+describe('runAgent — provider/credential resolution failures', () => {
+	it('fails with a clear message when no AI provider credentials exist at all', async () => {
+		// Stand up an isolated team/project with NO provider configured so resolution
+		// returns null. (The instance-wide configs live in the shared db, so we must
+		// route through a fresh app+db to get a clean "no providers" state.)
+		const isoCtx = await createTestApp();
+		try {
+			const typesRes = await isoCtx.app.request('/api/team-templates', {
+				headers: authHeader(isoCtx.token),
+			});
+			const typeId = (await typesRes.json()).data.find((t: any) => t.name === 'Startup').id;
+			const teamRes = await createTestTeam(isoCtx.db, { name: 'No Prov', template_id: typeId });
+			const isoTeamId = (await teamRes.json()).data.id;
+			const projRes = await createTestProject(isoCtx.db, isoTeamId, { name: 'No Prov Proj' });
+			const proj = (await projRes.json()).data;
+			const agentsRes = await isoCtx.app.request(`/api/projects/${proj.slug}/agents`, {
+				headers: authHeader(isoCtx.token),
+			});
+			const iAgent = (await agentsRes.json()).data[0];
+			const taskRes = await isoCtx.app.request(`/api/projects/${proj.slug}/tasks`, {
+				method: 'POST',
+				headers: { ...authHeader(isoCtx.token), 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					project_id: proj.id,
+					title: 'T',
+					description: 'd',
+					assignee_id: iAgent.id,
+				}),
+			});
+			const iTaskId = (await taskRes.json()).data.id;
+
+			const docker = createMockDocker(iTaskId, {
+				execCreate: async () => {
+					throw new Error('should not exec when no provider resolves');
+				},
+			});
+			const deps: RunnerDeps = {
+				db: isoCtx.db,
+				docker,
+				masterKeyManager: isoCtx.masterKeyManager,
+				serverPort: 3000,
+				dataDir: isoCtx.dataDir,
+				logs: new LogStreamBroker(),
+			};
+
+			const result = await runAgent(
+				deps,
+				{ id: iAgent.id, title: 'A', slug: iAgent.slug, team_id: isoTeamId },
+				{
+					id: iTaskId,
+					identifier: 'NP-1',
+					title: 'T',
+					description: 'd',
+					status: 'backlog',
+					priority: 'medium',
+					project_id: proj.id,
+					rules: null,
+					progress_summary: null,
+				},
+				{
+					id: proj.id,
+					slug: proj.slug,
+					team_id: isoTeamId,
+					team_slug: 'no-prov',
+					container_id: 'container-123',
+					container_status: ContainerStatus.Running,
+					designated_repo_id: null,
+					is_internal: false,
+				},
+			);
+
+			expect(result.success).toBe(false);
+			const run = await isoCtx.db.query<{ status: string; error: string | null }>(
+				'SELECT status, error FROM heartbeat_runs WHERE id = $1',
+				[result.heartbeatRunId],
+			);
+			expect(run.rows[0].status).toBe(HeartbeatRunStatus.Failed);
+			expect(run.rows[0].error).toContain('No AI provider credentials configured');
+		} finally {
+			await safeClose(isoCtx.db);
+		}
+	});
+
+	it('fails when the override provider has no credential configured', async () => {
+		// google is not configured in this suite's db, so a google override resolves
+		// a runtime but finds no credential.
+		await db.query(`DELETE FROM ai_provider_configs WHERE provider = 'google'`);
+
+		const docker = createMockDocker(taskId, {
+			execCreate: async () => {
+				throw new Error('should not exec without a credential');
+			},
+		});
+		const deps = baseDeps(docker);
+
+		const result = await runAgent(
+			deps,
+			{ ...makeAgent(), model_override_provider: 'google', model_override_model: 'gemini-x' },
+			makeTask(),
+			makeProject(),
+		);
+
+		expect(result.success).toBe(false);
+		const run = await db.query<{ status: string; error: string | null }>(
+			'SELECT status, error FROM heartbeat_runs WHERE id = $1',
+			[result.heartbeatRunId],
+		);
+		expect(run.rows[0].status).toBe(HeartbeatRunStatus.Failed);
+		expect(run.rows[0].error).toContain('No google credential configured');
+	});
+});
+
+describe('runAgent — abort with a terminal container reason', () => {
+	it('records failed status with error=container_stopped when aborted at the pre-exec checkpoint', async () => {
+		// Abort with a terminal reason during prepareWorktrees-adjacent setup: the
+		// signal is already aborted by the time the post-context cleanup checkpoint
+		// runs, so finalizeAbort maps the reason to a Failed status.
+		const ac = new AbortController();
+		const docker = createMockDocker(taskId, {
+			// execCreate would only run after the abort checkpoints; assert it doesn't.
+			execCreate: async () => {
+				throw new Error('exec must not run after abort');
+			},
+		});
+
+		// A fake egress proxy whose allocate aborts the signal — by the time
+		// buildRunContext returns and the cleanup checkpoint is evaluated, the
+		// signal carries the container_stopped reason.
+		const deps = baseDeps(docker, {
+			egressProxy: {
+				allocateRunProxy: async () => {
+					ac.abort('container_stopped');
+					return { proxyHost: '127.0.0.1', proxyPort: 9 };
+				},
+				releaseRunProxy: async () => {},
+			} as any,
+			egressCAPath: '/tmp/test-data/egress-ca.crt',
+		});
+
+		const result = await runAgent(
+			deps,
+			makeAgent(),
+			makeTask(),
+			makeProject(),
+			undefined,
+			ac.signal,
+		);
+
+		expect(result.success).toBe(false);
+		expect(result.stderr).toBe('container_stopped');
+		const run = await db.query<{ status: string; error: string | null }>(
+			'SELECT status, error FROM heartbeat_runs WHERE id = $1',
+			[result.heartbeatRunId],
+		);
+		expect(run.rows[0].status).toBe(HeartbeatRunStatus.Failed);
+		expect(run.rows[0].error).toBe('container_stopped');
+	});
+
+	it('records cancelled status when aborted at the pre-exec checkpoint without a terminal reason', async () => {
+		const ac = new AbortController();
+		const docker = createMockDocker(taskId, {
+			execCreate: async () => {
+				throw new Error('exec must not run after abort');
+			},
+		});
+
+		const deps = baseDeps(docker, {
+			egressProxy: {
+				allocateRunProxy: async () => {
+					ac.abort(); // no reason → plain cancellation
+					return { proxyHost: '127.0.0.1', proxyPort: 9 };
+				},
+				releaseRunProxy: async () => {},
+			} as any,
+			egressCAPath: '/tmp/test-data/egress-ca.crt',
+		});
+
+		const result = await runAgent(
+			deps,
+			makeAgent(),
+			makeTask(),
+			makeProject(),
+			undefined,
+			ac.signal,
+		);
+
+		expect(result.success).toBe(false);
+		expect(result.stderr).toBe('Aborted');
+		const run = await db.query<{ status: string }>(
+			'SELECT status FROM heartbeat_runs WHERE id = $1',
+			[result.heartbeatRunId],
+		);
+		expect(run.rows[0].status).toBe(HeartbeatRunStatus.Cancelled);
+	});
+});
+
+describe('runAgent — requester_context substitution', () => {
+	it('replaces {{requester_context}} with the task creator description', async () => {
+		await setAgentPrompt('System prelude.\n\nRequester: {{requester_context}}');
+		// Point the task's creator at a known member (the agent) so the join in the
+		// substitution query resolves a display_name + member_type row.
+		await db.query('UPDATE tasks SET created_by_member_id = $1 WHERE id = $2', [agentId, taskId]);
+		const project = makeProject();
+		let capturedPrompt = '';
+		const docker = createMockDocker(taskId, {
+			execCreate: async (_id: string, opts: any) => {
+				capturedPrompt = readPromptFromExec(opts, '/tmp/test-data', project);
+				return 'exec-req-ctx';
+			},
+			execStart: async () => ({ stdout: 'ok', stderr: '' }),
+			execInspect: async () => ({ ExitCode: 0, Running: false, Pid: 0 }),
+		});
+
+		const deps = baseDeps(docker);
+		const result = await runAgent(deps, makeAgent(), makeTask(), project);
+		expect(result.success).toBe(true);
+
+		// The substitution executes and strips the raw placeholder. (The rendered
+		// requester text is empty here because the makeTask() object runAgent uses
+		// is distinct from the DB row updated above, so the creator join resolves
+		// no display_name — the point of this case is that the {{requester_context}}
+		// branch in agent-runner runs and removes the token.)
+		expect(capturedPrompt).not.toContain('{{requester_context}}');
+
+		// Restore the default (empty) prompt + creator so later tests are unaffected.
+		await db.query('UPDATE tasks SET created_by_member_id = NULL WHERE id = $1', [taskId]);
+		await setAgentPrompt('');
+	});
+});
+
+describe('runAgent — mention handoff', () => {
+	it('renders the mention handoff block from a triggering comment', async () => {
+		// Seed a human comment that @-mentions the agent, then wake the agent with a
+		// mention payload pointing at it.
+		const commentRes = await db.query<{ id: string }>(
+			`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
+			 VALUES ($1, NULL, 'text', $2::jsonb)
+			 RETURNING id`,
+			[taskId, JSON.stringify({ text: 'Hey @agent please look into the parser bug.' })],
+		);
+		const commentId = commentRes.rows[0].id;
+
+		const project = makeProject();
+		let capturedPrompt = '';
+		const docker = createMockDocker(taskId, {
+			execCreate: async (_id: string, opts: any) => {
+				capturedPrompt = readPromptFromExec(opts, '/tmp/test-data', project);
+				return 'exec-mention';
+			},
+			execStart: async () => ({ stdout: 'ok', stderr: '' }),
+			execInspect: async () => ({ ExitCode: 0, Running: false, Pid: 0 }),
+		});
+
+		const deps = baseDeps(docker);
+		const result = await runAgent(deps, makeAgent(), makeTask(), project, {
+			source: WakeupSource.Mention,
+			comment_id: commentId,
+		});
+		expect(result.success).toBe(true);
+
+		expect(capturedPrompt).toContain('## Mention Handoff');
+		expect(capturedPrompt).toContain('please look into the parser bug');
+		expect(capturedPrompt).toContain(`add_reaction(comment_id='${commentId}', kind='ack')`);
+
+		await db.query('DELETE FROM task_comments WHERE id = $1', [commentId]);
+	});
+
+	it('loadMentionContext returns null when the payload has no comment id', async () => {
+		const ctx = await loadMentionContext(db, agentId, teamId, {});
+		expect(ctx).toBeNull();
+	});
+
+	it('loadMentionContext loads the author, excerpt, and open tickets', async () => {
+		const commentRes = await db.query<{ id: string }>(
+			`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
+			 VALUES ($1, NULL, 'text', $2::jsonb)
+			 RETURNING id`,
+			[taskId, JSON.stringify({ text: 'Direct mention body.' })],
+		);
+		const commentId = commentRes.rows[0].id;
+
+		const ctx = await loadMentionContext(db, agentId, teamId, { comment_id: commentId });
+		expect(ctx).not.toBeNull();
+		expect(ctx!.excerpt).toBe('Direct mention body.');
+		expect(ctx!.triggeringCommentId).toBe(commentId);
+		// The seeded task is assigned to this agent and not terminal → appears.
+		expect(ctx!.openTickets.some((t) => t.identifier === 'EX-1' || t.title === 'Ext Task')).toBe(
+			true,
+		);
+
+		await db.query('DELETE FROM task_comments WHERE id = $1', [commentId]);
+	});
+});
+
+describe('runAgent — reply handoff', () => {
+	it('renders the reply handoff block from a reply + triggering comment', async () => {
+		// The agent posted an original comment; a human replied referencing a ticket.
+		const original = await db.query<{ id: string }>(
+			`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
+			 VALUES ($1, $2, 'text', $3::jsonb) RETURNING id`,
+			[taskId, agentId, JSON.stringify({ text: 'My original question about EX-1.' })],
+		);
+		const originalId = original.rows[0].id;
+		const reply = await db.query<{ id: string }>(
+			`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
+			 VALUES ($1, NULL, 'text', $2::jsonb) RETURNING id`,
+			[taskId, JSON.stringify({ text: 'Replying — see EX-1 for the answer.' })],
+		);
+		const replyId = reply.rows[0].id;
+
+		const project = makeProject();
+		let capturedPrompt = '';
+		const docker = createMockDocker(taskId, {
+			execCreate: async (_id: string, opts: any) => {
+				capturedPrompt = readPromptFromExec(opts, '/tmp/test-data', project);
+				return 'exec-reply';
+			},
+			execStart: async () => ({ stdout: 'ok', stderr: '' }),
+			execInspect: async () => ({ ExitCode: 0, Running: false, Pid: 0 }),
+		});
+
+		const deps = baseDeps(docker);
+		const result = await runAgent(deps, makeAgent(), makeTask(), project, {
+			source: WakeupSource.Reply,
+			comment_id: replyId,
+			triggering_comment_id: originalId,
+		});
+		expect(result.success).toBe(true);
+
+		expect(capturedPrompt).toContain('## Reply Received');
+		expect(capturedPrompt).toContain('My original question about EX-1');
+		expect(capturedPrompt).toContain('Replying — see EX-1 for the answer');
+		// The reply references EX-1, which resolves to a known ticket row.
+		expect(capturedPrompt).toContain('### Tickets referenced by the reply');
+
+		await db.query('DELETE FROM task_comments WHERE id = ANY($1::uuid[])', [[originalId, replyId]]);
+	});
+
+	it('loadReplyContext returns null when the triggering comment id is missing', async () => {
+		const ctx = await loadReplyContext(db, { comment_id: 'x' });
+		expect(ctx).toBeNull();
+	});
+});
+
+describe('runAgent — spawned-from / parent provenance', () => {
+	it('loadSpawnedFromTask returns null when the task has neither parent nor spawning run', async () => {
+		const out = await loadSpawnedFromTask(db, makeTask());
+		expect(out).toBeNull();
+	});
+
+	it('renders parent + spawned-from lines in the task prompt', async () => {
+		// Create a parent task and a run on it; mark the seeded task as spawned from
+		// that run with a distinct parent, so both provenance lines render.
+		const parentRes = await app.request(`/api/projects/${projectSlug}/tasks`, {
+			method: 'POST',
+			headers: { ...authHeader(adminToken), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				project_id: projectId,
+				title: 'Parent Ticket',
+				description: 'p',
+				assignee_id: agentId,
+			}),
+		});
+		const parent = (await parentRes.json()).data;
+
+		// A separate "spawning" task + a completed run on it.
+		const spawnTaskRes = await app.request(`/api/projects/${projectSlug}/tasks`, {
+			method: 'POST',
+			headers: { ...authHeader(adminToken), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				project_id: projectId,
+				title: 'Spawning Ticket',
+				description: 's',
+				assignee_id: agentId,
+			}),
+		});
+		const spawnTask = (await spawnTaskRes.json()).data;
+		const wakeup = await db.query<{ id: string }>(
+			`INSERT INTO agent_wakeup_requests (member_id, team_id, source, status, payload, claimed_at)
+			 VALUES ($1, $2, 'on_demand'::wakeup_source, 'claimed'::wakeup_status, '{}'::jsonb, now())
+			 RETURNING id`,
+			[agentId, teamId],
+		);
+		const spawnRun = await db.query<{ id: string }>(
+			`INSERT INTO heartbeat_runs (member_id, team_id, task_id, wakeup_id, status)
+			 VALUES ($1, $2, $3, $4, 'succeeded'::heartbeat_run_status) RETURNING id`,
+			[agentId, teamId, spawnTask.id, wakeup.rows[0].id],
+		);
+
+		const taskInfo = makeTask({
+			parent_task_id: parent.id,
+			created_by_run_id: spawnRun.rows[0].id,
+		});
+
+		const out = await loadSpawnedFromTask(db, taskInfo);
+		expect(out).not.toBeNull();
+		expect(out!.parentLine).toContain('Parent ticket');
+		expect(out!.parentLine).toContain('Parent Ticket');
+		expect(out!.spawnLine).toContain('Spawned from');
+		expect(out!.spawnLine).toContain('Spawning Ticket');
+
+		// And through buildTaskPrompt the lines land in the rendered prompt.
+		const prompt = buildTaskPrompt('SYS', taskInfo, undefined, { spawnedFrom: out });
+		expect(prompt).toContain('**Parent ticket:** ');
+		expect(prompt).toContain('**Spawned from:** ');
+
+		await db.query('DELETE FROM heartbeat_runs WHERE id = $1', [spawnRun.rows[0].id]);
+		await db.query('DELETE FROM tasks WHERE id = ANY($1::uuid[])', [[parent.id, spawnTask.id]]);
+	});
+
+	it('collapses to a single parent line when parent == spawning task', async () => {
+		const parentRes = await app.request(`/api/projects/${projectSlug}/tasks`, {
+			method: 'POST',
+			headers: { ...authHeader(adminToken), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				project_id: projectId,
+				title: 'Combined Parent',
+				description: 'c',
+				assignee_id: agentId,
+			}),
+		});
+		const parent = (await parentRes.json()).data;
+		const wakeup = await db.query<{ id: string }>(
+			`INSERT INTO agent_wakeup_requests (member_id, team_id, source, status, payload, claimed_at)
+			 VALUES ($1, $2, 'on_demand'::wakeup_source, 'claimed'::wakeup_status, '{}'::jsonb, now())
+			 RETURNING id`,
+			[agentId, teamId],
+		);
+		// Run lives on the parent task itself, so spawning task id == parent id.
+		const run = await db.query<{ id: string }>(
+			`INSERT INTO heartbeat_runs (member_id, team_id, task_id, wakeup_id, status)
+			 VALUES ($1, $2, $3, $4, 'succeeded'::heartbeat_run_status) RETURNING id`,
+			[agentId, teamId, parent.id, wakeup.rows[0].id],
+		);
+
+		const out = await loadSpawnedFromTask(
+			db,
+			makeTask({ parent_task_id: parent.id, created_by_run_id: run.rows[0].id }),
+		);
+		expect(out).not.toBeNull();
+		expect(out!.parentLine).toContain('Combined Parent');
+		expect(out!.spawnLine).toBeNull();
+
+		await db.query('DELETE FROM heartbeat_runs WHERE id = $1', [run.rows[0].id]);
+		await db.query('DELETE FROM tasks WHERE id = $1', [parent.id]);
+	});
+});
+
+describe('buildTaskPrompt — retry block', () => {
+	it('renders the previous-failure retry section', () => {
+		const prompt = buildTaskPrompt('SYS', makeTask(), {
+			retry_count: 2,
+			max_retries: 3,
+			previous_failure: {
+				exit_code: 1,
+				stderr_tail: 'TypeError: boom',
+				stdout_tail: 'partial output',
+			},
+		});
+		expect(prompt).toContain('## Retry Attempt 2/3');
+		expect(prompt).toContain('The previous attempt FAILED');
+		expect(prompt).toContain('**Exit code:** 1');
+		expect(prompt).toContain('TypeError: boom');
+		expect(prompt).toContain('partial output');
+	});
+});
+
+describe('runAgent — domain events', () => {
+	it('emits agent_run.started and agent_run.completed with enrichment from the wakeup', async () => {
+		const events = new DomainEventBus();
+		const captured: Array<Record<string, unknown>> = [];
+		events.subscribe((e) => captured.push(e as unknown as Record<string, unknown>));
+
+		const docker = createMockDocker(taskId, {
+			execCreate: async () => 'exec-events',
+			execStart: async () => ({ stdout: 'ok', stderr: '' }),
+			execInspect: async () => ({ ExitCode: 0, Running: false, Pid: 0 }),
+		});
+		const deps = baseDeps(docker, { events });
+
+		const result = await runAgent(deps, makeAgent(), makeTask(), makeProject(), {
+			source: WakeupSource.Mention,
+			author_member_id: agentId,
+		});
+		expect(result.success).toBe(true);
+
+		// Both lifecycle events fire and carry the run id + terminal status. (The
+		// triggerSource/triggeredBy enrichment is sourced from the persisted wakeup
+		// row, not this passed object, so it defaults here — asserting it would
+		// require seeding the heartbeat_runs/wakeup rows the enrichment reads.)
+		const started = captured.find((c) => c.type === 'agent_run.started');
+		const completed = captured.find((c) => c.type === 'agent_run.completed');
+		expect(started).toBeDefined();
+		expect(started!.runId).toBe(result.heartbeatRunId);
+		expect(completed).toBeDefined();
+		expect(completed!.status).toBe(HeartbeatRunStatus.Succeeded);
+		expect(completed!.exitCode).toBe(0);
+	});
+});
+
+describe('runAgent — cost recording + budget enforcement', () => {
+	it('records the run cost as a cost_entries row and broadcasts it', async () => {
+		const pricing = new PricingService(db);
+		await upsertManualRate(db, {
+			model_id: 'claude-opus-4-7',
+			input_per_token: 0.0001,
+			output_per_token: 0.0002,
+		});
+		await pricing.reload();
+
+		// Ensure this run uses the priced model and a generous budget so it is not
+		// paused. Clear prior cost rows to assert on exactly this run's entry.
+		await db.query(
+			`UPDATE ai_provider_configs SET default_model = 'claude-opus-4-7' WHERE provider = 'anthropic'`,
+		);
+		await db.query('DELETE FROM cost_entries WHERE member_id = $1', [agentId]);
+		await db.query(
+			`UPDATE member_agents SET daily_budget_cents = 0, weekly_budget_cents = 0, monthly_budget_cents = 0 WHERE id = $1`,
+			[agentId],
+		);
+
+		// The Claude Code parser sources the model id from the system/init event;
+		// cost is only computed when a priced model is known.
+		const initEvent = JSON.stringify({
+			type: 'system',
+			subtype: 'init',
+			model: 'claude-opus-4-7',
+			tools: [],
+		});
+		const resultEvent = JSON.stringify({
+			type: 'result',
+			subtype: 'success',
+			num_turns: 1,
+			is_error: false,
+			usage: { input_tokens: 1000, output_tokens: 500 },
+		});
+		const docker = createMockDocker(taskId, {
+			execCreate: async () => 'exec-cost',
+			execStart: async (_id: string, opts: any) => {
+				if (opts?.onChunk) {
+					await opts.onChunk({ stream: 'stdout', text: `${initEvent}\n` });
+					await opts.onChunk({ stream: 'stdout', text: `${resultEvent}\n` });
+				}
+				return { stdout: '', stderr: '' };
+			},
+			execInspect: async () => ({ ExitCode: 0, Running: false, Pid: 0 }),
+		});
+
+		const broadcasts: Array<{ table?: string; action?: string; row?: any }> = [];
+		const wsManager = {
+			broadcast: (_room: string, event: any) => broadcasts.push(event),
+			subscribe: () => {},
+			unsubscribe: () => {},
+			unsubscribeAll: () => {},
+			getRoomSize: () => 0,
+			getTotalConnections: () => 0,
+		} as any;
+		const logs = new LogStreamBroker();
+		logs.setWsManager(wsManager);
+		const deps = baseDeps(docker, { pricing, wsManager, logs });
+
+		const result = await runAgent(deps, makeAgent(), makeTask(), makeProject());
+		expect(result.success).toBe(true);
+
+		// 1000*0.0001 + 500*0.0002 = 0.10 + 0.10 = 0.20 → 20 cents.
+		const entry = await db.query<{ amount_cents: number }>(
+			'SELECT amount_cents FROM cost_entries WHERE member_id = $1 ORDER BY created_at DESC LIMIT 1',
+			[agentId],
+		);
+		expect(entry.rows[0].amount_cents).toBe(20);
+
+		// A cost_entries INSERT was broadcast.
+		expect(broadcasts.some((b) => b?.table === 'cost_entries' && b?.action === 'INSERT')).toBe(
+			true,
+		);
+
+		await db.query(
+			`UPDATE ai_provider_configs SET default_model = NULL WHERE provider = 'anthropic'`,
+		);
+	});
+
+	it('pauses the agent when the run pushes it over its daily budget', async () => {
+		const pricing = new PricingService(db);
+		await upsertManualRate(db, {
+			model_id: 'claude-opus-4-7',
+			input_per_token: 0.0001,
+			output_per_token: 0.0002,
+		});
+		await pricing.reload();
+
+		await db.query(
+			`UPDATE ai_provider_configs SET default_model = 'claude-opus-4-7' WHERE provider = 'anthropic'`,
+		);
+		await db.query('DELETE FROM cost_entries WHERE member_id = $1', [agentId]);
+		// A 1-cent daily cap that this ~20c run will blow past.
+		await db.query(
+			`UPDATE member_agents SET daily_budget_cents = 1, weekly_budget_cents = 0, monthly_budget_cents = 0, runtime_status = 'idle'::agent_runtime_status WHERE id = $1`,
+			[agentId],
+		);
+
+		const initEvent = JSON.stringify({
+			type: 'system',
+			subtype: 'init',
+			model: 'claude-opus-4-7',
+			tools: [],
+		});
+		const resultEvent = JSON.stringify({
+			type: 'result',
+			subtype: 'success',
+			num_turns: 1,
+			is_error: false,
+			usage: { input_tokens: 1000, output_tokens: 500 },
+		});
+		const docker = createMockDocker(taskId, {
+			execCreate: async () => 'exec-budget',
+			execStart: async (_id: string, opts: any) => {
+				if (opts?.onChunk) {
+					await opts.onChunk({ stream: 'stdout', text: `${initEvent}\n` });
+					await opts.onChunk({ stream: 'stdout', text: `${resultEvent}\n` });
+				}
+				return { stdout: '', stderr: '' };
+			},
+			execInspect: async () => ({ ExitCode: 0, Running: false, Pid: 0 }),
+		});
+		const deps = baseDeps(docker, { pricing });
+
+		const result = await runAgent(deps, makeAgent(), makeTask(), makeProject());
+		expect(result.success).toBe(true);
+
+		const agentRow = await db.query<{ runtime_status: string }>(
+			'SELECT runtime_status FROM member_agents WHERE id = $1',
+			[agentId],
+		);
+		// Over-budget → runtime_status flipped to a budget-pause state (not idle).
+		expect(agentRow.rows[0].runtime_status).not.toBe('idle');
+
+		// Reset for any later tests.
+		await db.query(
+			`UPDATE member_agents SET daily_budget_cents = 0, runtime_status = 'idle'::agent_runtime_status WHERE id = $1`,
+			[agentId],
+		);
+		await db.query(
+			`UPDATE ai_provider_configs SET default_model = NULL WHERE provider = 'anthropic'`,
+		);
+		await db.query('DELETE FROM cost_entries WHERE member_id = $1', [agentId]);
+	});
+});
+
+describe('runAgent — rotated subscription auth tombstone', () => {
+	it('skips write-back when the CLI rewrites auth.json with an invalid (tombstone) credential', async () => {
+		const validAuthJson = JSON.stringify({
+			tokens: {
+				id_token: 'header.payload.sig',
+				access_token: 'header.payload.sig',
+				refresh_token: 'rt-original',
+				account_id: 'acct-tomb',
+			},
+		});
+		await db.query(`DELETE FROM ai_provider_configs WHERE provider = 'openai'`);
+		await app.request('/api/ai-providers', {
+			method: 'POST',
+			headers: { ...authHeader(adminToken), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				provider: 'openai',
+				api_key: validAuthJson,
+				auth_method: AiAuthMethod.Subscription,
+				label: 'openai-tombstone',
+			}),
+		});
+		const configId = (
+			await db.query<{ id: string }>(
+				`SELECT id FROM ai_provider_configs WHERE provider = 'openai' LIMIT 1`,
+			)
+		).rows[0].id;
+
+		const docker = createMockDocker(taskId, {
+			execCreate: async (_id: string, opts: any) => {
+				const codexHomeEntry = (opts.Env as string[]).find((e: string) =>
+					e.startsWith('CODEX_HOME='),
+				)!;
+				const runId = codexHomeEntry.slice('CODEX_HOME='.length).split('/').pop()!;
+				const hostFile = `${getHostSubscriptionRoot(
+					AiProvider.OpenAI,
+					'/tmp/test-data',
+					teamId,
+					projectId,
+					runId,
+				)}/auth.json`;
+				// CLI writes an empty-token tombstone (a failed refresh): differs from the
+				// stored credential but does NOT validate, so it must not be persisted.
+				writeFileSync(
+					hostFile,
+					JSON.stringify({ tokens: { access_token: '', refresh_token: '', account_id: '' } }),
+				);
+				return 'exec-tombstone';
+			},
+			execStart: async () => ({ stdout: '', stderr: '' }),
+			execInspect: async () => ({ ExitCode: 0, Running: false, Pid: 0 }),
+		});
+
+		const deps = baseDeps(docker);
+		const result = await runAgent(
+			deps,
+			makeAgent(),
+			{ ...makeTask(), runtime_type: 'codex' as const },
+			makeProject(),
+		);
+		expect(result.success).toBe(true);
+
+		// The stored credential must be unchanged: the tombstone failed validation, so
+		// the write-back was skipped. Decrypt the row and confirm it is still the
+		// original valid blob (a persisted tombstone would have wiped the tokens).
+		const cfg = await db.query<{ encrypted_credential: string; status: string }>(
+			'SELECT encrypted_credential, status FROM ai_provider_configs WHERE id = $1',
+			[configId],
+		);
+		expect(cfg.rows[0].status).toBe('active');
+		expect(decrypt(cfg.rows[0].encrypted_credential, masterKeyManager.getKey())).toBe(
+			validAuthJson,
+		);
+
+		// Restore an api-key openai config so the suite's other state stays sane.
+		await db.query(`DELETE FROM ai_provider_configs WHERE provider = 'openai'`);
+		globalThis.fetch = vi.fn().mockResolvedValue({ ok: true }) as unknown as typeof fetch;
+		await app.request('/api/ai-providers', {
+			method: 'POST',
+			headers: { ...authHeader(adminToken), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				provider: 'openai',
+				api_key: 'sk-test-restore-tomb',
+				label: 'openai-restore-tomb',
+			}),
+		});
+		globalThis.fetch = originalFetch;
+	});
+});

--- a/packages/server/test/ai-providers-verify.test.ts
+++ b/packages/server/test/ai-providers-verify.test.ts
@@ -1,0 +1,181 @@
+import type { PGlite } from '@electric-sql/pglite';
+import type { Hono } from 'hono';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Env } from '../src/lib/types';
+import { signAdminJwt } from '../src/middleware/auth';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp } from './helpers/app';
+
+/**
+ * Covers the AI-provider verify endpoint and the duplicate-config branch that
+ * ai-providers.test.ts doesn't reach: POST /ai-providers/:configId/verify
+ * (valid / invalid-and-marked / unreachable / authorization / 404), and the 409
+ * DUPLICATE path when a provider+label collides. The provider HTTP call is
+ * stubbed via globalThis.fetch; key-format validation on add is bypassed with
+ * SKIP_AI_KEY_VALIDATION so setup is deterministic.
+ */
+
+let app: Hono<Env>;
+let db: PGlite;
+let token: string;
+let nonSuperuserToken: string;
+
+const originalFetch = globalThis.fetch;
+let prevSkip: string | undefined;
+
+beforeAll(async () => {
+	prevSkip = process.env.SKIP_AI_KEY_VALIDATION;
+	process.env.SKIP_AI_KEY_VALIDATION = '1';
+
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+
+	const nonAdmin = await db.query<{ id: string }>(
+		"INSERT INTO users (display_name, is_superuser) VALUES ('Plain Admin', false) RETURNING id",
+	);
+	nonSuperuserToken = await signAdminJwt(ctx.masterKeyManager, nonAdmin.rows[0].id);
+});
+
+beforeEach(() => {
+	globalThis.fetch = vi.fn().mockResolvedValue({ ok: true }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+});
+
+afterAll(async () => {
+	process.env.SKIP_AI_KEY_VALIDATION = prevSkip;
+	await safeClose(db);
+});
+
+// deepseek has no key-prefix constraint, so a free-form key is accepted even
+// though the prefix check still runs under SKIP_AI_KEY_VALIDATION.
+async function addProvider(provider: string, apiKey: string, label: string): Promise<string> {
+	const res = await app.request('/api/ai-providers', {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ provider, api_key: apiKey, label }),
+	});
+	if (res.status !== 201) throw new Error(`addProvider failed: ${res.status}`);
+	return (await res.json()).data.id;
+}
+
+describe('POST /ai-providers/:configId/verify', () => {
+	let configId: string;
+
+	beforeAll(async () => {
+		await db.query('DELETE FROM ai_provider_configs');
+		configId = await addProvider('deepseek', 'sk-deepseek-verify', 'verify-target');
+	});
+
+	it('returns valid:true when the provider accepts the key', async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue({ ok: true }) as unknown as typeof fetch;
+		const res = await app.request(`/api/ai-providers/${configId}/verify`, {
+			method: 'POST',
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		expect((await res.json()).data.valid).toBe(true);
+	});
+
+	it('returns valid:false and marks the config invalid when the provider rejects', async () => {
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValue({ ok: false, status: 401 }) as unknown as typeof fetch;
+		const res = await app.request(`/api/ai-providers/${configId}/verify`, {
+			method: 'POST',
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data.valid).toBe(false);
+		expect(body.data.message).toContain('invalid');
+
+		const status = await db.query<{ status: string }>(
+			'SELECT status FROM ai_provider_configs WHERE id = $1',
+			[configId],
+		);
+		expect(status.rows[0].status).toBe('invalid');
+	});
+
+	it('returns valid:false when the provider is unreachable', async () => {
+		globalThis.fetch = vi.fn().mockRejectedValue(new Error('net')) as unknown as typeof fetch;
+		const res = await app.request(`/api/ai-providers/${configId}/verify`, {
+			method: 'POST',
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data.valid).toBe(false);
+		expect(body.data.message).toContain('Could not reach provider');
+	});
+
+	it('returns 404 for an unknown config id', async () => {
+		const res = await app.request('/api/ai-providers/00000000-0000-0000-0000-000000000000/verify', {
+			method: 'POST',
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(404);
+	});
+
+	it('rejects a non-superuser', async () => {
+		const res = await app.request(`/api/ai-providers/${configId}/verify`, {
+			method: 'POST',
+			headers: authHeader(nonSuperuserToken),
+		});
+		expect(res.status).toBe(403);
+	});
+
+	it('treats a subscription config as always valid without an HTTP call', async () => {
+		await db.query('DELETE FROM ai_provider_configs');
+		const create = await app.request('/api/ai-providers', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				provider: 'anthropic',
+				api_key: 'sk-ant-oat01-live-token',
+				auth_method: 'subscription',
+				label: 'sub-verify',
+			}),
+		});
+		expect(create.status).toBe(201);
+		const subId = (await create.json()).data.id;
+
+		const fetchSpy = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+		globalThis.fetch = fetchSpy as unknown as typeof fetch;
+		const res = await app.request(`/api/ai-providers/${subId}/verify`, {
+			method: 'POST',
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		expect((await res.json()).data.valid).toBe(true);
+		// Subscription auth short-circuits before any provider HTTP call.
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+});
+
+describe('POST /ai-providers duplicate handling', () => {
+	beforeAll(async () => {
+		await db.query('DELETE FROM ai_provider_configs');
+	});
+
+	it('returns 409 DUPLICATE when the same provider+label is added twice', async () => {
+		const first = await app.request('/api/ai-providers', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ provider: 'openai', api_key: 'sk-dup-1', label: 'dup-label' }),
+		});
+		expect(first.status).toBe(201);
+
+		const second = await app.request('/api/ai-providers', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ provider: 'openai', api_key: 'sk-dup-2', label: 'dup-label' }),
+		});
+		expect(second.status).toBe(409);
+		expect((await second.json()).error.code).toBe('DUPLICATE');
+	});
+});

--- a/packages/server/test/container-logs-streaming.test.ts
+++ b/packages/server/test/container-logs-streaming.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ContainerLogStreamer } from '../src/services/container-logs';
+import type { DockerClient } from '../src/services/docker';
+import { LogStreamBroker } from '../src/services/log-stream-broker';
+import { WebSocketManager } from '../src/services/ws';
+
+// Exercises the docker multiplexed-frame parsing loop in startStreaming, which
+// the existing container-logs.test.ts never reaches (it always closes the
+// stream immediately). Docker stream framing: 8-byte header per frame —
+// byte[0] = stream type (1 stdout, 2 stderr), bytes[4..7] = big-endian payload
+// length, followed by that many payload bytes.
+
+function frame(stream: 'stdout' | 'stderr', text: string): Uint8Array {
+	const payload = new TextEncoder().encode(text);
+	const header = new Uint8Array(8);
+	header[0] = stream === 'stderr' ? 2 : 1;
+	const len = payload.length;
+	header[4] = (len >> 24) & 0xff;
+	header[5] = (len >> 16) & 0xff;
+	header[6] = (len >> 8) & 0xff;
+	header[7] = len & 0xff;
+	const out = new Uint8Array(8 + len);
+	out.set(header);
+	out.set(payload, 8);
+	return out;
+}
+
+/** A docker client whose containerLogs streams the given byte chunks then closes. */
+function streamingDocker(chunks: Uint8Array[]): DockerClient {
+	return {
+		containerLogs: async () =>
+			new Response(
+				new ReadableStream({
+					start(c) {
+						for (const ch of chunks) c.enqueue(ch);
+						c.close();
+					},
+				}),
+			),
+	} as unknown as DockerClient;
+}
+
+const streamId = (projectId: string) => `container:${projectId}`;
+
+describe('ContainerLogStreamer — frame parsing', () => {
+	let streamer: ContainerLogStreamer;
+	let logs: LogStreamBroker;
+
+	beforeEach(() => {
+		streamer = new ContainerLogStreamer();
+		logs = new LogStreamBroker();
+		logs.setWsManager(new WebSocketManager());
+	});
+
+	afterEach(() => {
+		streamer.stopAll(logs);
+	});
+
+	it('parses complete frames and emits stdout/stderr lines into the broker', async () => {
+		const docker = streamingDocker([
+			frame('stdout', 'hello world\n'),
+			frame('stderr', 'a warning\n'),
+		]);
+		streamer.subscribe('p1', 'c1', logs, docker);
+
+		await vi.waitFor(() => {
+			const text = logs.getLogText(streamId('p1'));
+			expect(text).toContain('hello world');
+			expect(text).toContain('a warning');
+		});
+	});
+
+	it('reassembles a frame whose header and payload arrive in separate reads', async () => {
+		const whole = frame('stdout', 'split across reads\n');
+		// Split mid-payload: first chunk carries the header + a few payload bytes.
+		const docker = streamingDocker([whole.slice(0, 11), whole.slice(11)]);
+		streamer.subscribe('p2', 'c2', logs, docker);
+
+		await vi.waitFor(() => {
+			expect(logs.getLogText(streamId('p2'))).toContain('split across reads');
+		});
+	});
+
+	it('handles multiple frames concatenated into a single read', async () => {
+		const a = frame('stdout', 'line-A\n');
+		const b = frame('stdout', 'line-B\n');
+		const combined = new Uint8Array(a.length + b.length);
+		combined.set(a);
+		combined.set(b, a.length);
+		const docker = streamingDocker([combined]);
+		streamer.subscribe('p3', 'c3', logs, docker);
+
+		await vi.waitFor(() => {
+			const text = logs.getLogText(streamId('p3'));
+			expect(text).toContain('line-A');
+			expect(text).toContain('line-B');
+		});
+	});
+
+	it('returns early without throwing when containerLogs yields null', async () => {
+		const docker = { containerLogs: async () => null } as unknown as DockerClient;
+		streamer.subscribe('p4', 'c4', logs, docker);
+		// Give the async startStreaming a tick; nothing should be emitted.
+		await new Promise((r) => setTimeout(r, 10));
+		expect(logs.getLogText(streamId('p4'))).toBe('');
+	});
+
+	it('returns early when the response has no readable body', async () => {
+		const docker = {
+			containerLogs: async () => new Response(null),
+		} as unknown as DockerClient;
+		streamer.subscribe('p5', 'c5', logs, docker);
+		await new Promise((r) => setTimeout(r, 10));
+		expect(logs.getLogText(streamId('p5'))).toBe('');
+	});
+
+	it('swallows an AbortError raised mid-stream without rejecting', async () => {
+		const docker = {
+			containerLogs: async (_id: string, _opts: unknown, signal?: AbortSignal) =>
+				new Response(
+					new ReadableStream({
+						async pull(c) {
+							// Emit one frame, then abort and surface an AbortError on the next read.
+							c.enqueue(frame('stdout', 'before abort\n'));
+							await new Promise((r) => setTimeout(r, 5));
+							if (signal?.aborted) {
+								const e = new Error('aborted');
+								e.name = 'AbortError';
+								c.error(e);
+							}
+						},
+					}),
+				),
+		} as unknown as DockerClient;
+
+		streamer.subscribe('p6', 'c6', logs, docker);
+		await vi.waitFor(() => {
+			expect(logs.getLogText(streamId('p6'))).toContain('before abort');
+		});
+		// Aborting triggers the AbortError path in the reader loop's catch.
+		streamer.unsubscribe('p6');
+		// No unhandled rejection / throw escapes; a follow-up unsubscribe is a no-op.
+		expect(() => streamer.unsubscribe('p6')).not.toThrow();
+	});
+
+	it('cleans up the stream when startStreaming rejects (containerLogs throws)', async () => {
+		const docker = {
+			containerLogs: async () => {
+				throw new Error('docker exploded');
+			},
+		} as unknown as DockerClient;
+
+		streamer.subscribe('p8', 'c8', logs, docker);
+		// The .catch in subscribe deletes the streamer entry and ends the broker
+		// stream. Wait for the rejection to settle, then confirm the broker no
+		// longer reports the stream as active.
+		await vi.waitFor(() => {
+			expect(logs.isActive(streamId('p8'))).toBe(false);
+		});
+		expect(() => streamer.unsubscribe('p8')).not.toThrow();
+	});
+
+	it('emits a replace-snapshot via buildSnapshot when the room is replayed', async () => {
+		const docker = streamingDocker([frame('stdout', 'snapshot line\n')]);
+		streamer.subscribe('p9', 'c9', logs, docker);
+		await vi.waitFor(() => {
+			expect(logs.getLogText(streamId('p9'))).toContain('snapshot line');
+		});
+
+		const sent: unknown[] = [];
+		logs.replay('container-logs:p9', (payload) => sent.push(payload));
+		expect(sent.length).toBe(1);
+		const snap = sent[0] as { projectId: string; replace: boolean; text: string; stream: string };
+		expect(snap.projectId).toBe('p9');
+		expect(snap.replace).toBe(true);
+		expect(snap.stream).toBe('stdout');
+		expect(snap.text).toContain('snapshot line');
+	});
+
+	it('deletes the stream entry from the streamer once the source closes', async () => {
+		const docker = streamingDocker([frame('stdout', 'done\n')]);
+		streamer.subscribe('p7', 'c7', logs, docker);
+		await vi.waitFor(() => {
+			expect(logs.getLogText(streamId('p7'))).toContain('done');
+		});
+		// After the source stream completes, startStreaming's finally deletes the
+		// entry, so a subsequent unsubscribe is a no-op rather than a double-abort.
+		await new Promise((r) => setTimeout(r, 10));
+		expect(() => streamer.unsubscribe('p7')).not.toThrow();
+	});
+});

--- a/packages/server/test/credential-validator.test.ts
+++ b/packages/server/test/credential-validator.test.ts
@@ -1,0 +1,148 @@
+import { generateKeyPairSync } from 'node:crypto';
+import { CredentialKind } from '@hezo/shared';
+import { describe, expect, it } from 'vitest';
+import { validateCredentialValue } from '../src/lib/credential-validator';
+
+describe('validateCredentialValue — generic value checks', () => {
+	it('rejects an empty string', () => {
+		const r = validateCredentialValue(CredentialKind.ApiKey, '');
+		expect(r.valid).toBe(false);
+		if (!r.valid) expect(r.error).toBe('value is required');
+	});
+
+	it('rejects a non-string value', () => {
+		// The function is declared with `value: string` but guards at runtime too.
+		const r = validateCredentialValue(CredentialKind.ApiKey, undefined as unknown as string);
+		expect(r.valid).toBe(false);
+		if (!r.valid) expect(r.error).toBe('value is required');
+	});
+
+	it('rejects a value over the 64KB limit', () => {
+		const big = 'a'.repeat(64 * 1024 + 1);
+		const r = validateCredentialValue(CredentialKind.ApiKey, big);
+		expect(r.valid).toBe(false);
+		if (!r.valid) expect(r.error).toBe('value exceeds 64KB limit');
+	});
+
+	it('accepts a value exactly at the 64KB boundary', () => {
+		const exactly = 'a'.repeat(64 * 1024);
+		const r = validateCredentialValue(CredentialKind.ApiKey, exactly);
+		expect(r.valid).toBe(true);
+	});
+
+	it('rejects an unknown credential kind', () => {
+		const r = validateCredentialValue('definitely-not-a-kind', 'something');
+		expect(r.valid).toBe(false);
+		if (!r.valid) expect(r.error).toBe('unknown credential kind: definitely-not-a-kind');
+	});
+});
+
+describe('validateCredentialValue — pass-through kinds', () => {
+	for (const kind of [
+		CredentialKind.ApiKey,
+		CredentialKind.OauthToken,
+		CredentialKind.WebhookSecret,
+		CredentialKind.Other,
+	]) {
+		it(`accepts any non-empty value for ${kind}`, () => {
+			const r = validateCredentialValue(kind, 'whatever-token-value-123');
+			expect(r.valid).toBe(true);
+		});
+	}
+});
+
+describe('validateCredentialValue — SSH private key', () => {
+	it('accepts a real RSA PEM private key', () => {
+		const { privateKey } = generateKeyPairSync('rsa', {
+			modulusLength: 2048,
+			privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+			publicKeyEncoding: { type: 'spki', format: 'pem' },
+		});
+		const r = validateCredentialValue(CredentialKind.SshPrivateKey, privateKey);
+		expect(r.valid).toBe(true);
+	});
+
+	it('accepts a real EC PEM private key with a typed BEGIN header', () => {
+		const { privateKey } = generateKeyPairSync('ec', {
+			namedCurve: 'prime256v1',
+			privateKeyEncoding: { type: 'sec1', format: 'pem' },
+			publicKeyEncoding: { type: 'spki', format: 'pem' },
+		});
+		// sec1 emits "-----BEGIN EC PRIVATE KEY-----", exercising the optional
+		// "([A-Z]+ )?" group in the PEM regex.
+		expect(privateKey).toContain('BEGIN EC PRIVATE KEY');
+		const r = validateCredentialValue(CredentialKind.SshPrivateKey, privateKey);
+		expect(r.valid).toBe(true);
+	});
+
+	it('trims surrounding whitespace before validating a PEM key', () => {
+		const { privateKey } = generateKeyPairSync('rsa', {
+			modulusLength: 2048,
+			privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+			publicKeyEncoding: { type: 'spki', format: 'pem' },
+		});
+		const r = validateCredentialValue(CredentialKind.SshPrivateKey, `\n\n  ${privateKey}  \n`);
+		expect(r.valid).toBe(true);
+	});
+
+	it('treats an OpenSSH header as PEM (regex matches OPENSSH) and parses the body', () => {
+		// The PEM regex `^-----BEGIN ([A-Z]+ )?PRIVATE KEY-----` matches "OPENSSH
+		// PRIVATE KEY" too, so isPem wins and createPrivateKey runs. A fake body
+		// therefore fails to parse. (This makes the dedicated OpenSSH return at
+		// lines 50-51 effectively unreachable — any string that satisfies the
+		// OpenSSH startsWith also satisfies the PEM regex.)
+		const openssh =
+			'-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAA\n-----END OPENSSH PRIVATE KEY-----';
+		const r = validateCredentialValue(CredentialKind.SshPrivateKey, openssh);
+		expect(r.valid).toBe(false);
+		if (!r.valid) expect(r.error).toContain('failed to parse private key');
+	});
+
+	it('rejects a value that is not a PEM or OpenSSH key', () => {
+		const r = validateCredentialValue(CredentialKind.SshPrivateKey, 'just some random text');
+		expect(r.valid).toBe(false);
+		if (!r.valid) expect(r.error).toContain('does not look like a PEM or OpenSSH private key');
+	});
+
+	it('rejects a PEM-headered value with corrupt body', () => {
+		const corrupt =
+			'-----BEGIN PRIVATE KEY-----\nnot-actually-valid-base64-key-material!!!\n-----END PRIVATE KEY-----';
+		const r = validateCredentialValue(CredentialKind.SshPrivateKey, corrupt);
+		expect(r.valid).toBe(false);
+		if (!r.valid) expect(r.error).toContain('failed to parse private key');
+	});
+});
+
+describe('validateCredentialValue — GitHub PAT', () => {
+	it('accepts a classic ghp_ token', () => {
+		const r = validateCredentialValue(CredentialKind.GithubPat, `ghp_${'a'.repeat(36)}`);
+		expect(r.valid).toBe(true);
+	});
+
+	it('accepts a fine-grained github_pat_ token', () => {
+		const r = validateCredentialValue(CredentialKind.GithubPat, `github_pat_${'A1b2_3'.repeat(6)}`);
+		expect(r.valid).toBe(true);
+	});
+
+	it('accepts a gho_ OAuth token', () => {
+		const r = validateCredentialValue(CredentialKind.GithubPat, `gho_${'Z'.repeat(36)}`);
+		expect(r.valid).toBe(true);
+	});
+
+	it('trims whitespace before matching the prefix', () => {
+		const r = validateCredentialValue(CredentialKind.GithubPat, `   ghp_${'a'.repeat(40)}\n`);
+		expect(r.valid).toBe(true);
+	});
+
+	it('rejects a token without a recognised prefix', () => {
+		const r = validateCredentialValue(CredentialKind.GithubPat, 'pat_1234567890abcdef');
+		expect(r.valid).toBe(false);
+		if (!r.valid) expect(r.error).toContain('does not look like a GitHub PAT');
+	});
+
+	it('rejects a ghp_ token that is too short', () => {
+		const r = validateCredentialValue(CredentialKind.GithubPat, 'ghp_short');
+		expect(r.valid).toBe(false);
+		if (!r.valid) expect(r.error).toContain('does not look like a GitHub PAT');
+	});
+});

--- a/packages/server/test/docs-bundle-fs.test.ts
+++ b/packages/server/test/docs-bundle-fs.test.ts
@@ -1,0 +1,107 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+	buildHezoDocsBlock,
+	loadDocs,
+	loadFilesystemDocs,
+	resetDocsBlockCache,
+} from '../src/services/docs-bundle';
+
+// Covers the filesystem-walk paths (loadFilesystemDocs / loadDocs via
+// HEZO_DOCS_DIR) and the cache reset, which the bundled-import test never hits.
+
+let docsDir: string;
+const realDocsDirEnv = process.env.HEZO_DOCS_DIR;
+
+beforeEach(() => {
+	docsDir = mkdtempSync(join(tmpdir(), 'hezo-docs-test-'));
+});
+
+afterEach(() => {
+	rmSync(docsDir, { recursive: true, force: true });
+	if (realDocsDirEnv === undefined) delete process.env.HEZO_DOCS_DIR;
+	else process.env.HEZO_DOCS_DIR = realDocsDirEnv;
+	resetDocsBlockCache();
+});
+
+describe('loadFilesystemDocs', () => {
+	it('walks nested directories and keys docs by posix-relative path', async () => {
+		writeFileSync(join(docsDir, 'intro.md'), '---\ntitle: Intro\n---\nbody');
+		mkdirSync(join(docsDir, 'guide'), { recursive: true });
+		writeFileSync(join(docsDir, 'guide', 'setup.md'), '---\ntitle: Setup\n---\nsetup body');
+		// Non-markdown files are ignored.
+		writeFileSync(join(docsDir, 'ignore.txt'), 'not markdown');
+
+		const docs = await loadFilesystemDocs(docsDir);
+		expect(Object.keys(docs).sort()).toEqual(['guide/setup.md', 'intro.md']);
+		expect(docs['intro.md']).toContain('body');
+		expect(docs['guide/setup.md']).toContain('setup body');
+	});
+
+	it('returns an empty map for a directory with no markdown', async () => {
+		writeFileSync(join(docsDir, 'readme.txt'), 'nope');
+		const docs = await loadFilesystemDocs(docsDir);
+		expect(docs).toEqual({});
+	});
+});
+
+describe('loadDocs via HEZO_DOCS_DIR', () => {
+	it('reads from the override directory instead of the bundle', async () => {
+		writeFileSync(
+			join(docsDir, 'a.md'),
+			'---\ntitle: Alpha\norder: 1\nsection: S\n---\nalpha body',
+		);
+		process.env.HEZO_DOCS_DIR = docsDir;
+		const docs = await loadDocs();
+		expect(docs['a.md']).toContain('alpha body');
+	});
+});
+
+describe('buildHezoDocsBlock with overridden docs dir + cache reset', () => {
+	it('builds the block from the filesystem docs and caches it', async () => {
+		writeFileSync(
+			join(docsDir, 'first.md'),
+			'---\ntitle: First Doc\norder: 1\nsection: Alpha\n---\nfirst content',
+		);
+		writeFileSync(
+			join(docsDir, 'second.md'),
+			'---\ntitle: Second Doc\norder: 2\nsection: Alpha\n---\nsecond content',
+		);
+		process.env.HEZO_DOCS_DIR = docsDir;
+		resetDocsBlockCache();
+
+		const block = await buildHezoDocsBlock();
+		expect(block.startsWith('# Hezo documentation')).toBe(true);
+		expect(block).toContain('## Alpha');
+		expect(block).toContain('### First Doc');
+		expect(block).toContain('first content');
+		// order: First (1) precedes Second (2).
+		expect(block.indexOf('First Doc')).toBeLessThan(block.indexOf('Second Doc'));
+
+		// Second call returns the cached value (same dir, identical output).
+		const again = await buildHezoDocsBlock();
+		expect(again).toBe(block);
+	});
+
+	it('resetDocsBlockCache lets a different docs dir take effect', async () => {
+		writeFileSync(join(docsDir, 'only.md'), '---\ntitle: OnlyOne\norder: 1\n---\noriginal');
+		process.env.HEZO_DOCS_DIR = docsDir;
+		resetDocsBlockCache();
+		const first = await buildHezoDocsBlock();
+		expect(first).toContain('OnlyOne');
+
+		const dir2 = mkdtempSync(join(tmpdir(), 'hezo-docs-test2-'));
+		try {
+			writeFileSync(join(dir2, 'other.md'), '---\ntitle: Different\norder: 1\n---\nfresh');
+			process.env.HEZO_DOCS_DIR = dir2;
+			resetDocsBlockCache();
+			const second = await buildHezoDocsBlock();
+			expect(second).toContain('Different');
+			expect(second).not.toContain('OnlyOne');
+		} finally {
+			rmSync(dir2, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/server/test/fake-docker.test.ts
+++ b/packages/server/test/fake-docker.test.ts
@@ -1,0 +1,164 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { ExecLogChunk } from '../src/services/docker';
+import { createFakeDockerClient } from '../src/services/fake-docker';
+import { createAgentRun } from './helpers/app';
+import { createTestContext, destroyTestContext, type ServerTestContext } from './helpers/context';
+
+// Exercises the in-process Docker fake (createFakeDockerClient) directly: the
+// container lifecycle map, the synthetic exec script, and the heartbeat-run
+// produced_output side-effect that distinguishes it from a bare docker stub.
+
+describe('createFakeDockerClient — container lifecycle (no db)', () => {
+	const docker = createFakeDockerClient();
+
+	it('ping / imageExists / pullImage all resolve happily', async () => {
+		expect(await docker.ping()).toBe(true);
+		expect(await docker.imageExists('anything')).toBe(true);
+		await expect(docker.pullImage('anything')).resolves.toBeUndefined();
+	});
+
+	it('createContainer returns a deterministic noop id derived from the name', async () => {
+		const res = await docker.createContainer('my-container');
+		expect(res.Id).toBe('noop-my-container');
+		expect(res.Warnings).toEqual([]);
+	});
+
+	it('a freshly created container inspects as exited (not yet started)', async () => {
+		await docker.createContainer('lifecycle');
+		const info = await docker.inspectContainer('noop-lifecycle');
+		expect(info.State.Running).toBe(false);
+		expect(info.State.Status).toBe('exited');
+		expect(info.State.Pid).toBe(0);
+		expect(info.Config.Image).toBe('noop');
+	});
+
+	it('startContainer flips the tracked container to running', async () => {
+		await docker.createContainer('lifecycle2');
+		await docker.startContainer('noop-lifecycle2');
+		const info = await docker.inspectContainer('noop-lifecycle2');
+		expect(info.State.Running).toBe(true);
+		expect(info.State.Status).toBe('running');
+		expect(info.State.Pid).toBe(1);
+	});
+
+	it('starting an unknown container id creates a running entry on the fly', async () => {
+		await docker.startContainer('never-created');
+		const info = await docker.inspectContainer('never-created');
+		expect(info.State.Running).toBe(true);
+	});
+
+	it('stopContainer flips a running container back to stopped', async () => {
+		await docker.createContainer('lifecycle3');
+		await docker.startContainer('noop-lifecycle3');
+		await docker.stopContainer('noop-lifecycle3');
+		const info = await docker.inspectContainer('noop-lifecycle3');
+		expect(info.State.Running).toBe(false);
+	});
+
+	it('stopping an unknown container is a no-op', async () => {
+		await expect(docker.stopContainer('ghost')).resolves.toBeUndefined();
+	});
+
+	it('removeContainer drops the entry so inspect defaults to running=true', async () => {
+		await docker.createContainer('lifecycle4');
+		await docker.removeContainer('noop-lifecycle4');
+		// Unknown-after-removal: inspect falls back to running=true.
+		const info = await docker.inspectContainer('noop-lifecycle4');
+		expect(info.State.Running).toBe(true);
+	});
+
+	it('containerLogs returns an empty Response body', async () => {
+		const res = await docker.containerLogs('any', { follow: false });
+		expect(res).not.toBeNull();
+		const buf = await (res as Response).arrayBuffer();
+		expect(buf.byteLength).toBe(0);
+	});
+});
+
+describe('createFakeDockerClient — exec without onChunk', () => {
+	const docker = createFakeDockerClient();
+
+	it('returns empty stdout/stderr and runs no synthetic script', async () => {
+		const execId = await docker.execCreate('cid', { Cmd: ['echo'] });
+		expect(execId).toContain('noop-exec-');
+		const result = await docker.execStart(execId, {});
+		expect(result).toEqual({ stdout: '', stderr: '' });
+	});
+
+	it('execInspect reports a clean exit', async () => {
+		const info = await docker.execInspect('noop-exec-1');
+		expect(info.ExitCode).toBe(0);
+		expect(info.Running).toBe(false);
+	});
+});
+
+describe('createFakeDockerClient — synthetic exec with onChunk', () => {
+	let ctx: ServerTestContext;
+	let agentId: string;
+	let teamId: string;
+
+	beforeAll(async () => {
+		ctx = await createTestContext();
+		const r = await ctx.db.query<{ id: string; team_id: string }>(
+			"SELECT id, team_id FROM members WHERE member_type = 'agent'::member_type LIMIT 1",
+		);
+		agentId = r.rows[0].id;
+		teamId = r.rows[0].team_id;
+	});
+	afterAll(() => destroyTestContext(ctx));
+
+	it('streams the deterministic synthetic script through onChunk', async () => {
+		const docker = createFakeDockerClient();
+		const execId = await docker.execCreate('cid', { Cmd: ['agent'] });
+		const chunks: ExecLogChunk[] = [];
+		const result = await docker.execStart(execId, {
+			onChunk: (c) => {
+				chunks.push(c);
+			},
+		});
+		expect(chunks.length).toBe(4);
+		expect(chunks.every((c) => c.stream === 'stdout')).toBe(true);
+		expect(result.stdout).toContain('[synthetic] starting agent run');
+		expect(result.stdout).toContain('[synthetic] task complete');
+		expect(result.stderr).toBe('');
+	});
+
+	it('marks the heartbeat run as having produced output when run id env + db are present', async () => {
+		const runId = await createAgentRun(ctx.db, agentId, teamId, null);
+		const docker = createFakeDockerClient(ctx.db);
+		const execId = await docker.execCreate('cid', {
+			Env: [`HEZO_HEARTBEAT_RUN_ID=${runId}`, 'OTHER=1'],
+		});
+		await docker.execStart(execId, { onChunk: () => {} });
+
+		const row = await ctx.db.query<{ produced_output: boolean }>(
+			'SELECT produced_output FROM heartbeat_runs WHERE id = $1',
+			[runId],
+		);
+		expect(row.rows[0].produced_output).toBe(true);
+	});
+
+	it('does not touch the db when no run id env was supplied at exec-create', async () => {
+		const runId = await createAgentRun(ctx.db, agentId, teamId, null);
+		const docker = createFakeDockerClient(ctx.db);
+		// No HEZO_HEARTBEAT_RUN_ID in env → execRunIds maps to null → no update.
+		const execId = await docker.execCreate('cid', { Env: ['UNRELATED=1'] });
+		await docker.execStart(execId, { onChunk: () => {} });
+
+		const row = await ctx.db.query<{ produced_output: boolean }>(
+			'SELECT produced_output FROM heartbeat_runs WHERE id = $1',
+			[runId],
+		);
+		expect(row.rows[0].produced_output).toBe(false);
+	});
+
+	it('aborts the synthetic script when the signal is already aborted', async () => {
+		const docker = createFakeDockerClient();
+		const execId = await docker.execCreate('cid');
+		const controller = new AbortController();
+		controller.abort();
+		await expect(
+			docker.execStart(execId, { signal: controller.signal, onChunk: () => {} }),
+		).rejects.toThrow(/Aborted/);
+	});
+});

--- a/packages/server/test/git-worktree-state.test.ts
+++ b/packages/server/test/git-worktree-state.test.ts
@@ -1,0 +1,110 @@
+import { execSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+	createWorktree,
+	getWorktreeHead,
+	initRepoInPlace,
+	type RepoLoc,
+	type WorktreeLoc,
+	worktreeHasChanges,
+} from '../src/services/git';
+import { HostGitExecutor } from '../src/services/git-executor';
+
+const root = mkdtempSync(join(tmpdir(), 'git-wt-state-'));
+const exec = new HostGitExecutor();
+// Force SSH ops to fail without touching the network (for initRepoInPlace).
+const failSshExec = new HostGitExecutor({ GIT_SSH_COMMAND: 'false', GIT_TERMINAL_PROMPT: '0' });
+const repoLoc = (p: string): RepoLoc => ({ hostPath: p, containerPath: p });
+const wtLoc = (p: string): WorktreeLoc => ({ hostPath: p, containerPath: p });
+
+function run(cmd: string, cwd?: string) {
+	execSync(cmd, { cwd, stdio: 'pipe' });
+}
+
+let cloneDir: string;
+let worktreeDir: string;
+
+beforeAll(() => {
+	const bare = join(root, 'bare.git');
+	cloneDir = join(root, 'clone');
+	worktreeDir = join(root, 'wt');
+	run(`git init --bare ${bare}`);
+	run(`git clone ${bare} ${cloneDir}`);
+	run('git config user.name Test', cloneDir);
+	run('git config user.email test@test.com', cloneDir);
+	run('git config commit.gpgsign false', cloneDir);
+	writeFileSync(join(cloneDir, 'README.md'), '# hi');
+	run('git add .', cloneDir);
+	run('git commit -m init', cloneDir);
+	run('git push', cloneDir);
+});
+
+afterAll(() => {
+	rmSync(root, { recursive: true, force: true });
+});
+
+describe('getWorktreeHead', () => {
+	it('returns null for a path with no .git', async () => {
+		const head = await getWorktreeHead(exec, wtLoc(join(root, 'nope')));
+		expect(head).toBeNull();
+	});
+
+	it('returns the current commit sha for a real worktree', async () => {
+		const created = await createWorktree(exec, repoLoc(cloneDir), wtLoc(worktreeDir), 'feat/state');
+		expect(created.success).toBe(true);
+		const head = await getWorktreeHead(exec, wtLoc(worktreeDir));
+		expect(head).toMatch(/^[0-9a-f]{40}$/);
+		// Matches what git reports directly.
+		const direct = execSync('git rev-parse HEAD', { cwd: worktreeDir }).toString().trim();
+		expect(head).toBe(direct);
+	});
+});
+
+describe('worktreeHasChanges', () => {
+	it('returns false for a missing worktree', async () => {
+		expect(await worktreeHasChanges(exec, wtLoc(join(root, 'gone')), null)).toBe(false);
+	});
+
+	it('returns false for a clean, unchanged worktree', async () => {
+		const head = await getWorktreeHead(exec, wtLoc(worktreeDir));
+		expect(await worktreeHasChanges(exec, wtLoc(worktreeDir), head)).toBe(false);
+	});
+
+	it('detects an uncommitted/untracked change', async () => {
+		const head = await getWorktreeHead(exec, wtLoc(worktreeDir));
+		writeFileSync(join(worktreeDir, 'new-file.txt'), 'dirty');
+		expect(await worktreeHasChanges(exec, wtLoc(worktreeDir), head)).toBe(true);
+	});
+
+	it('detects an advanced branch tip (commit since headBefore)', async () => {
+		const headBefore = await getWorktreeHead(exec, wtLoc(worktreeDir));
+		// Commit the untracked file so the tree is clean but the tip advanced.
+		run('git add .', worktreeDir);
+		run('git config user.name Test', worktreeDir);
+		run('git config user.email test@test.com', worktreeDir);
+		run('git config commit.gpgsign false', worktreeDir);
+		run('git commit -m advance', worktreeDir);
+		expect(await worktreeHasChanges(exec, wtLoc(worktreeDir), headBefore)).toBe(true);
+	});
+});
+
+describe('initRepoInPlace (SSH transport)', () => {
+	it('returns { success: false, error } when the SSH remote is unreachable', async () => {
+		// A populated directory connected to an SSH remote that cannot be reached:
+		// init + remote add succeed, the ls-remote over SSH fails → graceful failure.
+		const dir = join(root, 'in-place');
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(join(dir, 'app.ts'), 'export const x = 1;');
+		const result = await initRepoInPlace(
+			failSshExec,
+			'nonexistent-org-hezo/nonexistent-repo',
+			repoLoc(dir),
+		);
+		expect(result.success).toBe(false);
+		expect(typeof result.error).toBe('string');
+		expect(result.error).toBeTruthy();
+	});
+});

--- a/packages/server/test/github-service-extended.test.ts
+++ b/packages/server/test/github-service-extended.test.ts
@@ -1,0 +1,260 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+	computeScopeStatus,
+	createGitHubRepo,
+	listAccessibleRepos,
+	listUserOrgs,
+	parseGitHubUrl,
+	registerAuthKey,
+	requiredRepoSetupScopes,
+	validateRepoAccess,
+} from '../src/services/github';
+import { createGitHubSim, type GitHubSim } from './helpers/github-sim';
+
+let sim: GitHubSim;
+let prevApi: string | undefined;
+
+beforeAll(async () => {
+	sim = await createGitHubSim();
+	prevApi = process.env.GITHUB_API_BASE_URL;
+	process.env.GITHUB_API_BASE_URL = sim.baseUrl;
+});
+
+afterAll(async () => {
+	process.env.GITHUB_API_BASE_URL = prevApi;
+	await sim.destroy();
+});
+
+describe('parseGitHubUrl', () => {
+	it('parses SSH, HTTPS, http, bare-host, and owner/repo shorthand forms', () => {
+		expect(parseGitHubUrl('git@github.com:octo/repo.git')).toEqual({ owner: 'octo', repo: 'repo' });
+		expect(parseGitHubUrl('https://github.com/octo/repo')).toEqual({ owner: 'octo', repo: 'repo' });
+		expect(parseGitHubUrl('https://github.com/octo/repo.git')).toEqual({
+			owner: 'octo',
+			repo: 'repo',
+		});
+		expect(parseGitHubUrl('http://github.com/octo/repo/')).toEqual({ owner: 'octo', repo: 'repo' });
+		expect(parseGitHubUrl('github.com/octo/repo')).toEqual({ owner: 'octo', repo: 'repo' });
+		expect(parseGitHubUrl('octo/repo')).toEqual({ owner: 'octo', repo: 'repo' });
+	});
+
+	it('returns null for a non-GitHub or malformed URL', () => {
+		expect(parseGitHubUrl('https://gitlab.com/octo/repo')).toBeNull();
+		expect(parseGitHubUrl('not a url')).toBeNull();
+		expect(parseGitHubUrl('octo')).toBeNull();
+	});
+});
+
+describe('computeScopeStatus', () => {
+	it('lists the required scopes and reports missing ones', () => {
+		const required = requiredRepoSetupScopes();
+		expect(computeScopeStatus([]).sufficient).toBe(false);
+		expect(computeScopeStatus([]).missing).toEqual(required);
+		expect(computeScopeStatus(required).sufficient).toBe(true);
+		expect(computeScopeStatus(null).sufficient).toBe(false);
+		const partial = computeScopeStatus(['repo']);
+		expect(partial.sufficient).toBe(false);
+		expect(partial.missing).not.toContain('repo');
+	});
+});
+
+describe('validateRepoAccess', () => {
+	it('returns accessible=true (200) for a repo the token can see', async () => {
+		sim.seed({
+			token: 'gho_access',
+			user: { id: 5, login: 'acc', avatar_url: '', email: null },
+			repos: [
+				{
+					id: 1,
+					name: 'visible',
+					full_name: 'acc/visible',
+					owner: { login: 'acc' },
+					private: false,
+					default_branch: 'main',
+					clone_url: 'https://github.com/acc/visible.git',
+					ssh_url: 'git@github.com:acc/visible.git',
+				},
+			],
+		});
+		const res = await validateRepoAccess('acc', 'visible', 'gho_access');
+		expect(res.accessible).toBe(true);
+		expect(res.status).toBe(200);
+	});
+
+	it('returns accessible=false (404) for a repo that does not exist', async () => {
+		sim.seed({ token: 'gho_access', repos: [] });
+		const res = await validateRepoAccess('acc', 'nope', 'gho_access');
+		expect(res.accessible).toBe(false);
+		expect(res.status).toBe(404);
+	});
+});
+
+describe('listUserOrgs', () => {
+	it('prepends the authenticated user as a personal org, then lists real orgs', async () => {
+		sim.seed({
+			token: 'gho_orgs',
+			user: { id: 9, login: 'me', avatar_url: 'http://av/me', email: null },
+			orgs: [
+				{ login: 'acme', avatar_url: 'http://av/acme' },
+				{ login: 'globex', avatar_url: 'http://av/globex' },
+			],
+		});
+		const orgs = await listUserOrgs('gho_orgs');
+		expect(orgs[0]).toEqual({ login: 'me', avatar_url: 'http://av/me', is_personal: true });
+		expect(orgs.map((o) => o.login)).toEqual(['me', 'acme', 'globex']);
+		expect(orgs.find((o) => o.login === 'acme')?.is_personal).toBe(false);
+	});
+
+	it('returns an empty list when the token is invalid', async () => {
+		sim.seed({ token: 'gho_valid', orgs: [] });
+		const orgs = await listUserOrgs('gho_invalid');
+		// fetchAuthenticatedUser → null (no personal), /user/orgs → 401 → personal only ([]).
+		expect(orgs).toEqual([]);
+	});
+});
+
+describe('listAccessibleRepos', () => {
+	it('lists the personal repos (affiliation path) and filters by query', async () => {
+		sim.seed({
+			token: 'gho_repos',
+			user: { id: 11, login: 'dev', avatar_url: '', email: null },
+			repos: [
+				{
+					id: 1,
+					name: 'alpha',
+					full_name: 'dev/alpha',
+					owner: { login: 'dev' },
+					private: false,
+					default_branch: 'main',
+					clone_url: '',
+					ssh_url: '',
+				},
+				{
+					id: 2,
+					name: 'beta',
+					full_name: 'dev/beta',
+					owner: { login: 'dev' },
+					private: true,
+					default_branch: 'main',
+					clone_url: '',
+					ssh_url: '',
+				},
+			],
+		});
+		const all = await listAccessibleRepos('dev', undefined, 'gho_repos');
+		expect(all.map((r) => r.name).sort()).toEqual(['alpha', 'beta']);
+
+		const filtered = await listAccessibleRepos('dev', 'alph', 'gho_repos');
+		expect(filtered.map((r) => r.name)).toEqual(['alpha']);
+	});
+
+	it('uses the org path when the owner is not the authenticated user', async () => {
+		sim.seed({
+			token: 'gho_org_repos',
+			user: { id: 12, login: 'someone', avatar_url: '', email: null },
+			repos: [
+				{
+					id: 3,
+					name: 'orgrepo',
+					full_name: 'acme/orgrepo',
+					owner: { login: 'acme' },
+					private: false,
+					default_branch: 'main',
+					clone_url: '',
+					ssh_url: '',
+				},
+			],
+		});
+		const repos = await listAccessibleRepos('acme', undefined, 'gho_org_repos');
+		expect(repos.map((r) => r.full_name)).toEqual(['acme/orgrepo']);
+	});
+});
+
+describe('createGitHubRepo', () => {
+	it('creates a personal repo (status created)', async () => {
+		sim.seed({
+			token: 'gho_create',
+			user: { id: 20, login: 'creator', avatar_url: '', email: null },
+			repos: [],
+		});
+		const result = await createGitHubRepo('creator', 'brand-new', true, 'gho_create');
+		expect(result.status).toBe('created');
+		if (result.status === 'created') {
+			expect(result.full_name).toBe('creator/brand-new');
+			expect(result.private).toBe(true);
+			expect(result.default_branch).toBe('main');
+		}
+	});
+
+	it('surfaces a duplicate name as already_exists rather than throwing', async () => {
+		sim.seed({
+			token: 'gho_dupe_repo',
+			user: { id: 21, login: 'creator2', avatar_url: '', email: null },
+			repos: [
+				{
+					id: 9,
+					name: 'taken',
+					full_name: 'creator2/taken',
+					owner: { login: 'creator2' },
+					private: false,
+					default_branch: 'main',
+					clone_url: '',
+					ssh_url: '',
+				},
+			],
+		});
+		const result = await createGitHubRepo('creator2', 'taken', false, 'gho_dupe_repo');
+		expect(result.status).toBe('already_exists');
+		expect(result.owner).toBe('creator2');
+		expect(result.name).toBe('taken');
+	});
+
+	it('creates an org repo when the owner is not the authenticated user', async () => {
+		sim.seed({
+			token: 'gho_org_create',
+			user: { id: 22, login: 'notowner', avatar_url: '', email: null },
+			repos: [],
+		});
+		const result = await createGitHubRepo('acme', 'org-new', true, 'gho_org_create');
+		expect(result.status).toBe('created');
+		if (result.status === 'created') expect(result.full_name).toBe('acme/org-new');
+	});
+});
+
+describe('registerAuthKey', () => {
+	it('registers an authentication key', async () => {
+		sim.seed({ token: 'gho_authkey', authKeys: [] });
+		const result = await registerAuthKey(
+			'gho_authkey',
+			'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5 auth',
+			'Hezo authentication key',
+		);
+		expect(result.status).toBe('created');
+		if (result.status === 'created') expect(result.title).toBe('Hezo authentication key');
+		expect(sim.state.authKeys).toHaveLength(1);
+	});
+
+	it('treats a duplicate auth key as already_exists', async () => {
+		const key = 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5 auth-dup';
+		sim.seed({ token: 'gho_authdup', authKeys: [{ id: 7, title: 'old', key }] });
+		const result = await registerAuthKey('gho_authdup', key, 'Hezo authentication key');
+		expect(result.status).toBe('already_exists');
+	});
+
+	it('throws on a non-422 failure (e.g. 401 unauthorized)', async () => {
+		sim.seed({ token: 'gho_valid_key' });
+		await expect(
+			registerAuthKey('gho_wrong_key', 'ssh-ed25519 AAAA x', 'Hezo authentication key'),
+		).rejects.toThrow(/\/user\/keys failed \(401\)/);
+	});
+});
+
+describe('createGitHubRepo error path', () => {
+	it('throws when the API rejects with a non-422 status', async () => {
+		// A bad token → 401 from the sim's create endpoint → thrown error (not already_exists).
+		sim.seed({ token: 'gho_valid_create', repos: [] });
+		await expect(createGitHubRepo('whoever', 'x', true, 'gho_bad_create')).rejects.toThrow(
+			/Failed to create GitHub repo \(401\)/,
+		);
+	});
+});

--- a/packages/server/test/job-manager-extended.test.ts
+++ b/packages/server/test/job-manager-extended.test.ts
@@ -1,0 +1,1086 @@
+import type { PGlite } from '@electric-sql/pglite';
+import {
+	AgentRuntimeStatus,
+	ContainerStatus,
+	HeartbeatRunStatus,
+	TaskStatus,
+	WakeupSkipReason,
+	WakeupStatus,
+} from '@hezo/shared';
+import type { Hono } from 'hono';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import type { MasterKeyManager } from '../src/crypto/master-key';
+import { waitForBackground } from '../src/lib/background';
+import type { Env } from '../src/lib/types';
+import { ContainerLogStreamer } from '../src/services/container-logs';
+import { JobManager, type JobManagerDeps } from '../src/services/job-manager';
+import { LogStreamBroker } from '../src/services/log-stream-broker';
+import { safeClose } from './helpers';
+import {
+	authHeader,
+	createStubDocker,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+} from './helpers/app';
+
+// This suite drives the run-scheduling, task-selection, dispatch, and budget /
+// container-transition branches of JobManager that the existing
+// job-manager{,-workflows}.test.ts files don't reach. Every manager is built
+// from the real PGlite + Hono test context; docker is always a *complete*
+// createStubDocker (never a partial), so the startup self-heal / sync passes
+// that fire as side-effects never throw "x is not a function".
+
+let app: Hono<Env>;
+let db: PGlite;
+let token: string;
+let masterKeyManager: MasterKeyManager;
+let dataDir: string;
+let teamId: string;
+let projectId: string;
+let projectSlug: string;
+let taskId: string;
+let agentId: string;
+let secondAgentId: string;
+
+const json = { 'Content-Type': 'application/json' };
+
+function createJobManager(overrides: Partial<JobManagerDeps> = {}): JobManager {
+	return new JobManager({
+		db,
+		docker: createStubDocker(),
+		masterKeyManager,
+		serverPort: 3100,
+		dataDir,
+		wsManager: { broadcast: () => {} } as unknown as JobManagerDeps['wsManager'],
+		logs: new LogStreamBroker(),
+		containerLogStreamer: new ContainerLogStreamer(),
+		...overrides,
+	});
+}
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+	masterKeyManager = ctx.masterKeyManager;
+	dataDir = ctx.dataDir;
+
+	const typesRes = await app.request('/api/team-templates', { headers: authHeader(token) });
+	const typeId = (await typesRes.json()).data.find(
+		(t: { name: string }) => t.name === 'Startup',
+	).id;
+
+	const teamRes = await createTestTeam(db, { name: 'Extended JM Co', template_id: typeId });
+	teamId = (await teamRes.json()).data.id;
+
+	const projectRes = await createTestProject(db, teamId, {
+		name: 'Extended JM Project',
+		description: 'Test project.',
+	});
+	const project = (await projectRes.json()).data;
+	projectId = project.id;
+	projectSlug = project.slug;
+
+	const agentsRes = await app.request(`/api/projects/${projectSlug}/agents`, {
+		headers: authHeader(token),
+	});
+	const agents = (await agentsRes.json()).data as Array<{ id: string }>;
+	agentId = agents[0].id;
+	secondAgentId = agents[1].id;
+
+	const taskRes = await app.request(`/api/projects/${projectSlug}/tasks`, {
+		method: 'POST',
+		headers: { ...authHeader(token), ...json },
+		body: JSON.stringify({ project_id: projectId, title: 'Extended Task', assignee_id: agentId }),
+	});
+	const createdTask = (await taskRes.json()).data;
+	taskId = createdTask.id;
+
+	// Pass activateAgent's designated-repo + container gates so a dispatch can
+	// reach the launch path. Individual tests override container_status / repo as
+	// needed to exercise the gates themselves.
+	const repoRes = await db.query<{ id: string }>(
+		`INSERT INTO repos (project_id, repo_identifier, host_type)
+		 VALUES ($1, 'test-org/test-repo', 'github'::repo_host_type)
+		 RETURNING id`,
+		[projectId],
+	);
+	await db.query(
+		`UPDATE projects
+		 SET designated_repo_id = $1, container_id = 'test-container', container_status = 'running'
+		 WHERE id = $2`,
+		[repoRes.rows[0].id, projectId],
+	);
+
+	// Let the fire-and-forget assignment wakeup from task creation settle, then drop it.
+	await waitForBackground();
+	await db.query("DELETE FROM agent_wakeup_requests WHERE payload->>'task_id' = $1::text", [
+		taskId,
+	]);
+});
+
+afterEach(async () => {
+	// Drain in-flight launchTask (background runAgent) promises before the next
+	// test mutates the shared single-connection PGlite.
+	await waitForBackground();
+	// Common reset so each test starts from a clean scheduler-visible state.
+	await db.query('DELETE FROM agent_wakeup_requests WHERE member_id = ANY($1)', [
+		[agentId, secondAgentId],
+	]);
+	await db.query(
+		'UPDATE execution_locks SET released_at = now() WHERE member_id = ANY($1) AND released_at IS NULL',
+		[[agentId, secondAgentId]],
+	);
+	await db.query('DELETE FROM heartbeat_runs WHERE team_id = $1', [teamId]);
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+async function insertQueuedWakeup(
+	memberId: string,
+	source = 'mention',
+	payload: Record<string, unknown> = { task_id: taskId },
+	ageSeconds = 30,
+): Promise<string> {
+	const r = await db.query<{ id: string }>(
+		`INSERT INTO agent_wakeup_requests (member_id, team_id, source, status, payload, created_at)
+		 VALUES ($1, $2, $3::wakeup_source, 'queued'::wakeup_status, $4::jsonb,
+		         now() - ($5 || ' seconds')::interval)
+		 RETURNING id`,
+		[memberId, teamId, source, JSON.stringify(payload), String(ageSeconds)],
+	);
+	return r.rows[0].id;
+}
+
+async function wakeupStatus(id: string): Promise<{
+	status: string;
+	last_skipped_reason: string | null;
+	last_skipped_blocker_task_id: string | null;
+}> {
+	const r = await db.query<{
+		status: string;
+		last_skipped_reason: string | null;
+		last_skipped_blocker_task_id: string | null;
+	}>(
+		`SELECT status, last_skipped_reason, last_skipped_blocker_task_id
+		 FROM agent_wakeup_requests WHERE id = $1`,
+		[id],
+	);
+	return r.rows[0];
+}
+
+describe('JobManager — extended coverage', () => {
+	describe('live-run cancellation', () => {
+		it('cancelLiveRun cancels the backing task and removes the live run', () => {
+			const manager = createJobManager();
+			const key = `${agentId}:${projectId}`;
+			let aborted = false;
+			manager.launchTask(
+				key,
+				(signal) =>
+					new Promise<void>((resolve) => {
+						signal.addEventListener('abort', () => {
+							aborted = true;
+							resolve();
+						});
+					}),
+				60_000,
+			);
+			manager.registerLiveRun({
+				runId: 'run-x',
+				memberId: agentId,
+				taskId,
+				projectId,
+				teamId,
+				taskKey: key,
+			});
+
+			expect(manager.cancelLiveRun('run-x')).toBe(true);
+			expect(manager.getLiveRunIds().has('run-x')).toBe(false);
+			expect(aborted).toBe(true);
+			// Unknown run id is a no-op false.
+			expect(manager.cancelLiveRun('nope')).toBe(false);
+
+			manager.shutdown();
+		});
+
+		it('cancelLiveRunsForProject cancels every run in the project and returns the count', () => {
+			const manager = createJobManager();
+			const keyA = `${agentId}:${projectId}`;
+			const keyB = `${secondAgentId}:${projectId}`;
+			const aborts: string[] = [];
+			for (const [key, who] of [
+				[keyA, 'a'],
+				[keyB, 'b'],
+			] as const) {
+				manager.launchTask(
+					key,
+					(signal) =>
+						new Promise<void>((resolve) => {
+							signal.addEventListener('abort', () => {
+								aborts.push(who);
+								resolve();
+							});
+						}),
+					60_000,
+				);
+			}
+			manager.registerLiveRun({
+				runId: 'r-a',
+				memberId: agentId,
+				taskId,
+				projectId,
+				teamId,
+				taskKey: keyA,
+			});
+			manager.registerLiveRun({
+				runId: 'r-b',
+				memberId: secondAgentId,
+				taskId,
+				projectId,
+				teamId,
+				taskKey: keyB,
+			});
+			// A run in a different project must be left alone.
+			manager.registerLiveRun({
+				runId: 'r-other',
+				memberId: agentId,
+				taskId,
+				projectId: 'other-project',
+				teamId,
+				taskKey: `${agentId}:other-project`,
+			});
+
+			const cancelled = manager.cancelLiveRunsForProject(projectId, 'container_stopped');
+			expect(cancelled).toBe(2);
+			expect(aborts.sort()).toEqual(['a', 'b']);
+			expect(manager.getLiveRunIds()).toEqual(new Set(['r-other']));
+
+			manager.shutdown();
+		});
+	});
+
+	describe('dispatchWakeupNow gating', () => {
+		it('returns task_busy and records the skip when the task already has an active run', async () => {
+			const manager = createJobManager();
+			await db.query(
+				`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at)
+				 VALUES ($1, $2, $3, $4::heartbeat_run_status, now())`,
+				[secondAgentId, teamId, taskId, HeartbeatRunStatus.Running],
+			);
+			const wakeupId = await insertQueuedWakeup(agentId);
+
+			const result = await manager.dispatchWakeupNow(wakeupId);
+			expect(result).toEqual({ dispatched: false, reason: 'task_busy' });
+
+			const ws = await wakeupStatus(wakeupId);
+			expect(ws.status).toBe(WakeupStatus.Queued);
+			expect(ws.last_skipped_reason).toBe(WakeupSkipReason.TaskBusy);
+			expect(ws.last_skipped_blocker_task_id).toBe(taskId);
+
+			manager.shutdown();
+		});
+
+		it('returns project_at_capacity and records the skip when the project is at its run limit', async () => {
+			const manager = createJobManager();
+			await db.query('UPDATE projects SET max_concurrent_runs = 1 WHERE id = $1', [projectId]);
+
+			const sibRes = await app.request(`/api/projects/${projectSlug}/tasks`, {
+				method: 'POST',
+				headers: { ...authHeader(token), ...json },
+				body: JSON.stringify({ project_id: projectId, title: 'Sib busy', assignee_id: agentId }),
+			});
+			const sibId = (await sibRes.json()).data.id as string;
+			await db.query(
+				`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at)
+				 VALUES ($1, $2, $3, $4::heartbeat_run_status, now())`,
+				[agentId, teamId, sibId, HeartbeatRunStatus.Running],
+			);
+			const wakeupId = await insertQueuedWakeup(agentId);
+
+			const result = await manager.dispatchWakeupNow(wakeupId);
+			expect(result).toEqual({ dispatched: false, reason: 'project_at_capacity' });
+			const ws = await wakeupStatus(wakeupId);
+			expect(ws.status).toBe(WakeupStatus.Queued);
+			expect(ws.last_skipped_reason).toBe(WakeupSkipReason.ProjectAtCapacity);
+
+			await db.query('UPDATE projects SET max_concurrent_runs = 3 WHERE id = $1', [projectId]);
+			await db.query('DELETE FROM tasks WHERE id = $1', [sibId]);
+			manager.shutdown();
+		});
+
+		it('returns agent_busy when the same agent already runs in the project', async () => {
+			const manager = createJobManager();
+			await db.query('UPDATE projects SET max_concurrent_runs = 3 WHERE id = $1', [projectId]);
+
+			const sibRes = await app.request(`/api/projects/${projectSlug}/tasks`, {
+				method: 'POST',
+				headers: { ...authHeader(token), ...json },
+				body: JSON.stringify({ project_id: projectId, title: 'Agent busy', assignee_id: agentId }),
+			});
+			const sibId = (await sibRes.json()).data.id as string;
+			// Same agent already has an in-flight run in this project (on a different task),
+			// but the project is below capacity, so only the per-agent guard trips.
+			await db.query(
+				`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at)
+				 VALUES ($1, $2, $3, $4::heartbeat_run_status, now())`,
+				[agentId, teamId, sibId, HeartbeatRunStatus.Running],
+			);
+			const wakeupId = await insertQueuedWakeup(agentId);
+
+			const result = await manager.dispatchWakeupNow(wakeupId);
+			expect(result).toEqual({ dispatched: false, reason: 'agent_busy' });
+			const ws = await wakeupStatus(wakeupId);
+			expect(ws.status).toBe(WakeupStatus.Queued);
+			expect(ws.last_skipped_reason).toBe(WakeupSkipReason.AgentRunning);
+
+			await db.query('DELETE FROM tasks WHERE id = $1', [sibId]);
+			manager.shutdown();
+		});
+
+		it('defers the wakeup (blocked) when the target task has an open blocker', async () => {
+			const manager = createJobManager();
+
+			const blockerRes = await app.request(`/api/projects/${projectSlug}/tasks`, {
+				method: 'POST',
+				headers: { ...authHeader(token), ...json },
+				body: JSON.stringify({
+					project_id: projectId,
+					title: 'Open blocker',
+					assignee_id: secondAgentId,
+				}),
+			});
+			const blockerId = (await blockerRes.json()).data.id as string;
+			await db.query(
+				`INSERT INTO task_dependencies (task_id, blocked_by_task_id) VALUES ($1, $2)`,
+				[taskId, blockerId],
+			);
+			// 'assignment' is a blocker-gated source; the blocker is non-terminal.
+			const wakeupId = await insertQueuedWakeup(agentId, 'assignment');
+
+			const result = await manager.dispatchWakeupNow(wakeupId);
+			expect(result).toEqual({ dispatched: false, reason: 'blocked' });
+			const r = await db.query<{ status: string; payload: Record<string, unknown> }>(
+				'SELECT status, payload FROM agent_wakeup_requests WHERE id = $1',
+				[wakeupId],
+			);
+			expect(r.rows[0].status).toBe(WakeupStatus.Deferred);
+			expect(r.rows[0].payload.reason).toBe('blocked');
+
+			await db.query('DELETE FROM task_dependencies WHERE task_id = $1', [taskId]);
+			await db.query('DELETE FROM tasks WHERE id = $1', [blockerId]);
+			manager.shutdown();
+		});
+
+		it('marks the wakeup failed and rethrows when activateAgent throws', async () => {
+			// activateAgent broadcasts the agent's Active status synchronously (before
+			// launchTask). A wsManager that throws only on the member_agents table makes
+			// activateAgent throw inside dispatchWakeupNow's try, exercising the
+			// catch (mark Failed) + rethrow branch — without disturbing the earlier
+			// tasks broadcast.
+			await db.query('UPDATE tasks SET assignee_id = $1 WHERE id = $2', [agentId, taskId]);
+			await db.query(
+				`UPDATE projects SET container_id = 'test-container', container_status = 'running', max_concurrent_runs = 3 WHERE id = $1`,
+				[projectId],
+			);
+			const throwingWs = {
+				broadcast: (_room: string, msg: { table: string }) => {
+					if (msg.table === 'member_agents') throw new Error('synthetic broadcast failure');
+				},
+			} as unknown as JobManagerDeps['wsManager'];
+			const manager = createJobManager({ wsManager: throwingWs });
+			const wakeupId = await insertQueuedWakeup(agentId);
+
+			await expect(manager.dispatchWakeupNow(wakeupId)).rejects.toThrow(
+				'synthetic broadcast failure',
+			);
+			await waitForBackground();
+
+			const r = await db.query<{ status: string }>(
+				'SELECT status FROM agent_wakeup_requests WHERE id = $1',
+				[wakeupId],
+			);
+			expect(r.rows[0].status).toBe(WakeupStatus.Failed);
+
+			// Release the lock activateAgent inserted before throwing, so it doesn't
+			// linger into the next test's view.
+			await db.query(
+				'UPDATE execution_locks SET released_at = now() WHERE task_id = $1 AND member_id = $2 AND released_at IS NULL',
+				[taskId, agentId],
+			);
+			manager.shutdown();
+		});
+	});
+
+	describe('processWakeups gating branches', () => {
+		it('skips a task wakeup with agent_running when the agent already runs in the project', async () => {
+			const manager = createJobManager();
+			await db.query('UPDATE projects SET max_concurrent_runs = 3 WHERE id = $1', [projectId]);
+
+			const sibRes = await app.request(`/api/projects/${projectSlug}/tasks`, {
+				method: 'POST',
+				headers: { ...authHeader(token), ...json },
+				body: JSON.stringify({ project_id: projectId, title: 'Busy sib', assignee_id: agentId }),
+			});
+			const sibId = (await sibRes.json()).data.id as string;
+			await db.query(
+				`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at)
+				 VALUES ($1, $2, $3, $4::heartbeat_run_status, now())`,
+				[agentId, teamId, sibId, HeartbeatRunStatus.Running],
+			);
+			const wakeupId = await insertQueuedWakeup(agentId);
+
+			await (manager as unknown as { processWakeups(): Promise<void> }).processWakeups();
+
+			const ws = await wakeupStatus(wakeupId);
+			expect(ws.status).toBe(WakeupStatus.Queued);
+			expect(ws.last_skipped_reason).toBe(WakeupSkipReason.AgentRunning);
+
+			await db.query('DELETE FROM tasks WHERE id = $1', [sibId]);
+			manager.shutdown();
+		});
+
+		it('retires a stale assignment wakeup already served by a completed run', async () => {
+			const manager = createJobManager();
+			// A completed run that started AFTER the wakeup was created — so the run
+			// read the task at boot and served the assignment, making the still-queued
+			// sibling wakeup redundant.
+			const wakeupId = await insertQueuedWakeup(agentId, 'assignment', { task_id: taskId }, 120);
+			await db.query(
+				`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at, finished_at, exit_code)
+				 VALUES ($1, $2, $3, $4::heartbeat_run_status, now() - interval '30 seconds', now() - interval '10 seconds', 0)`,
+				[agentId, teamId, taskId, HeartbeatRunStatus.Succeeded],
+			);
+
+			await (manager as unknown as { processWakeups(): Promise<void> }).processWakeups();
+
+			const r = await db.query<{ status: string }>(
+				'SELECT status FROM agent_wakeup_requests WHERE id = $1',
+				[wakeupId],
+			);
+			expect(r.rows[0].status).toBe(WakeupStatus.Coalesced);
+
+			manager.shutdown();
+		});
+
+		it('defers a blocker-gated wakeup whose task has an open blocker', async () => {
+			const manager = createJobManager();
+			const blockerRes = await app.request(`/api/projects/${projectSlug}/tasks`, {
+				method: 'POST',
+				headers: { ...authHeader(token), ...json },
+				body: JSON.stringify({
+					project_id: projectId,
+					title: 'PW blocker',
+					assignee_id: secondAgentId,
+				}),
+			});
+			const blockerId = (await blockerRes.json()).data.id as string;
+			await db.query(
+				`INSERT INTO task_dependencies (task_id, blocked_by_task_id) VALUES ($1, $2)`,
+				[taskId, blockerId],
+			);
+			const wakeupId = await insertQueuedWakeup(agentId, 'assignment');
+
+			await (manager as unknown as { processWakeups(): Promise<void> }).processWakeups();
+
+			const r = await db.query<{ status: string; payload: Record<string, unknown> }>(
+				'SELECT status, payload FROM agent_wakeup_requests WHERE id = $1',
+				[wakeupId],
+			);
+			expect(r.rows[0].status).toBe(WakeupStatus.Deferred);
+			expect(r.rows[0].payload.reason).toBe('blocked');
+
+			await db.query('DELETE FROM task_dependencies WHERE task_id = $1', [taskId]);
+			await db.query('DELETE FROM tasks WHERE id = $1', [blockerId]);
+			manager.shutdown();
+		});
+	});
+
+	describe('activateAgent re-queue and gate branches', () => {
+		beforeEach(async () => {
+			// Default healthy project state for this block: container up, capacity
+			// available, repo designated, no budget limit and no prior spend, agent
+			// idle and enabled. Each test then perturbs exactly one gate.
+			const repo = await db.query<{ id: string }>(
+				'SELECT id FROM repos WHERE project_id = $1 LIMIT 1',
+				[projectId],
+			);
+			await db.query(
+				`UPDATE projects
+				 SET container_id = 'test-container', container_status = 'running',
+				     max_concurrent_runs = 3, designated_repo_id = $2
+				 WHERE id = $1`,
+				[projectId, repo.rows[0].id],
+			);
+			await db.query('UPDATE tasks SET assignee_id = $1 WHERE id = $2', [agentId, taskId]);
+			await db.query('DELETE FROM cost_entries WHERE member_id = $1', [agentId]);
+			await db.query(
+				`UPDATE member_agents
+				 SET daily_budget_cents = 0, weekly_budget_cents = 0, monthly_budget_cents = 0,
+				     touches_code = false, runtime_status = $1, admin_status = 'enabled'
+				 WHERE id = $2`,
+				[AgentRuntimeStatus.Idle, agentId],
+			);
+		});
+
+		it('re-queues the wakeup when the project is at capacity at activation time', async () => {
+			const manager = createJobManager();
+			await db.query('UPDATE projects SET max_concurrent_runs = 1 WHERE id = $1', [projectId]);
+
+			const sibRes = await app.request(`/api/projects/${projectSlug}/tasks`, {
+				method: 'POST',
+				headers: { ...authHeader(token), ...json },
+				body: JSON.stringify({ project_id: projectId, title: 'Cap sib', assignee_id: agentId }),
+			});
+			const sibId = (await sibRes.json()).data.id as string;
+			await db.query(
+				`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at)
+				 VALUES ($1, $2, $3, $4::heartbeat_run_status, now())`,
+				[secondAgentId, teamId, sibId, HeartbeatRunStatus.Running],
+			);
+			const wakeupId = await insertQueuedWakeup(agentId, 'mention');
+			await db.query("UPDATE agent_wakeup_requests SET status = 'claimed' WHERE id = $1", [
+				wakeupId,
+			]);
+
+			await (
+				manager as unknown as {
+					activateAgent(
+						m: string,
+						t: string,
+						w: string,
+						p: Record<string, unknown>,
+						s: string,
+					): Promise<void>;
+				}
+			).activateAgent(agentId, teamId, wakeupId, { task_id: taskId }, 'mention');
+
+			const r = await db.query<{ status: string; claimed_at: string | null }>(
+				'SELECT status, claimed_at FROM agent_wakeup_requests WHERE id = $1',
+				[wakeupId],
+			);
+			expect(r.rows[0].status).toBe(WakeupStatus.Queued);
+			expect(r.rows[0].claimed_at).toBeNull();
+
+			await db.query('UPDATE projects SET max_concurrent_runs = 3 WHERE id = $1', [projectId]);
+			await db.query('DELETE FROM tasks WHERE id = $1', [sibId]);
+			manager.shutdown();
+		});
+
+		it('re-queues the wakeup when the agent is already busy in the project at activation time', async () => {
+			const manager = createJobManager();
+			const sibRes = await app.request(`/api/projects/${projectSlug}/tasks`, {
+				method: 'POST',
+				headers: { ...authHeader(token), ...json },
+				body: JSON.stringify({ project_id: projectId, title: 'Busy2', assignee_id: agentId }),
+			});
+			const sibId = (await sibRes.json()).data.id as string;
+			await db.query(
+				`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at)
+				 VALUES ($1, $2, $3, $4::heartbeat_run_status, now())`,
+				[agentId, teamId, sibId, HeartbeatRunStatus.Running],
+			);
+			const wakeupId = await insertQueuedWakeup(agentId, 'mention');
+			await db.query("UPDATE agent_wakeup_requests SET status = 'claimed' WHERE id = $1", [
+				wakeupId,
+			]);
+
+			await (
+				manager as unknown as {
+					activateAgent(
+						m: string,
+						t: string,
+						w: string,
+						p: Record<string, unknown>,
+						s: string,
+					): Promise<void>;
+				}
+			).activateAgent(agentId, teamId, wakeupId, { task_id: taskId }, 'mention');
+
+			const r = await db.query<{ status: string }>(
+				'SELECT status FROM agent_wakeup_requests WHERE id = $1',
+				[wakeupId],
+			);
+			expect(r.rows[0].status).toBe(WakeupStatus.Queued);
+
+			await db.query('DELETE FROM tasks WHERE id = $1', [sibId]);
+			manager.shutdown();
+		});
+
+		it('pauses the agent and marks the wakeup over_budget when the agent is over its daily budget', async () => {
+			const manager = createJobManager();
+			await db.query('DELETE FROM cost_entries WHERE member_id = $1', [agentId]);
+			await db.query(
+				'UPDATE member_agents SET daily_budget_cents = 100, runtime_status = $1 WHERE id = $2',
+				[AgentRuntimeStatus.Idle, agentId],
+			);
+			await db.query(
+				`INSERT INTO cost_entries (member_id, project_id, amount_cents) VALUES ($1, $2, 500)`,
+				[agentId, projectId],
+			);
+			const wakeupId = await insertQueuedWakeup(agentId, 'mention');
+			await db.query("UPDATE agent_wakeup_requests SET status = 'claimed' WHERE id = $1", [
+				wakeupId,
+			]);
+
+			await (
+				manager as unknown as {
+					activateAgent(
+						m: string,
+						t: string,
+						w: string,
+						p: Record<string, unknown>,
+						s: string,
+					): Promise<void>;
+				}
+			).activateAgent(agentId, teamId, wakeupId, { task_id: taskId }, 'mention');
+
+			// The budget gate records the skip reason (markWakeupSkipped leaves the
+			// status as-is — here 'claimed') and reactively pauses the agent.
+			const ws = await wakeupStatus(wakeupId);
+			expect(ws.last_skipped_reason).toBe(WakeupSkipReason.OverBudget);
+
+			const agent = await db.query<{ runtime_status: string }>(
+				'SELECT runtime_status FROM member_agents WHERE id = $1',
+				[agentId],
+			);
+			expect(agent.rows[0].runtime_status).toBe(AgentRuntimeStatus.OutOfAgentBudget);
+
+			// No heartbeat run was created (budget gate skips before launch).
+			const runs = await db.query<{ c: string }>(
+				'SELECT count(*)::text AS c FROM heartbeat_runs WHERE task_id = $1',
+				[taskId],
+			);
+			expect(runs.rows[0].c).toBe('0');
+
+			await db.query('DELETE FROM cost_entries WHERE member_id = $1', [agentId]);
+			await db.query(
+				'UPDATE member_agents SET daily_budget_cents = 0, runtime_status = $1 WHERE id = $2',
+				[AgentRuntimeStatus.Idle, agentId],
+			);
+			manager.shutdown();
+		});
+
+		it('defers a code-touching wakeup with awaiting_repo_setup when the project has no designated repo', async () => {
+			const manager = createJobManager();
+			// Code-touching agent + no designated repo + a non-conversational source
+			// (timer) hits the repo-setup gate.
+			await db.query('UPDATE member_agents SET touches_code = true WHERE id = $1', [agentId]);
+			await db.query('UPDATE projects SET designated_repo_id = NULL WHERE id = $1', [projectId]);
+			const wakeupId = await insertQueuedWakeup(agentId, 'timer');
+			await db.query("UPDATE agent_wakeup_requests SET status = 'claimed' WHERE id = $1", [
+				wakeupId,
+			]);
+
+			await (
+				manager as unknown as {
+					activateAgent(
+						m: string,
+						t: string,
+						w: string,
+						p: Record<string, unknown>,
+						s: string,
+					): Promise<void>;
+				}
+			).activateAgent(agentId, teamId, wakeupId, { task_id: taskId }, 'timer');
+
+			const r = await db.query<{ status: string; payload: Record<string, unknown> }>(
+				'SELECT status, payload FROM agent_wakeup_requests WHERE id = $1',
+				[wakeupId],
+			);
+			expect(r.rows[0].status).toBe(WakeupStatus.Deferred);
+			expect(r.rows[0].payload.reason).toBe('awaiting_repo_setup');
+			expect(r.rows[0].payload.task_id).toBe(taskId);
+
+			// Restore the designated repo for downstream tests.
+			const repo = await db.query<{ id: string }>(
+				'SELECT id FROM repos WHERE project_id = $1 LIMIT 1',
+				[projectId],
+			);
+			await db.query('UPDATE projects SET designated_repo_id = $1 WHERE id = $2', [
+				repo.rows[0].id,
+				projectId,
+			]);
+			manager.shutdown();
+		});
+	});
+
+	describe('postFailurePing error truncation', () => {
+		it('truncates an over-long run error to 500 chars + ellipsis in the system comment', async () => {
+			const manager = createJobManager();
+			const longError = 'E'.repeat(900);
+			const run = await db.query<{ id: string }>(
+				`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, error, started_at)
+				 VALUES ($1, $2, $3, $4::heartbeat_run_status, $5, now())
+				 RETURNING id`,
+				[agentId, teamId, taskId, HeartbeatRunStatus.Failed, longError],
+			);
+			await db.query("DELETE FROM task_comments WHERE task_id = $1 AND content_type = 'system'", [
+				taskId,
+			]);
+
+			await (
+				manager as unknown as {
+					onAgentComplete(
+						m: string,
+						s: string,
+						t: string,
+						ti: string,
+						team: string,
+						w: string | undefined,
+						p: Record<string, unknown> | undefined,
+						r: {
+							success: boolean;
+							exitCode: number;
+							stdout: string;
+							stderr: string;
+							heartbeatRunId: string;
+						},
+					): Promise<void>;
+				}
+			).onAgentComplete(agentId, 'researcher', taskId, 'EXT-1', teamId, undefined, undefined, {
+				success: false,
+				exitCode: -1,
+				stdout: '',
+				stderr: longError,
+				heartbeatRunId: run.rows[0].id,
+			});
+
+			const comment = await db.query<{ content: { error: string } }>(
+				`SELECT content FROM task_comments
+				 WHERE task_id = $1 AND content_type = 'system' AND content->>'kind' = 'run_failed'
+				 ORDER BY created_at DESC LIMIT 1`,
+				[taskId],
+			);
+			const err = comment.rows[0].content.error;
+			expect(err.endsWith('…')).toBe(true);
+			// 500 chars + the single-character ellipsis.
+			expect(err.length).toBe(501);
+
+			await db.query("DELETE FROM task_comments WHERE task_id = $1 AND content_type = 'system'", [
+				taskId,
+			]);
+			manager.shutdown();
+		});
+	});
+
+	describe('container transition handling', () => {
+		it('handleContainerTransition fails project runs and cancels live runs on running→error', async () => {
+			const manager = createJobManager();
+			const key = `${agentId}:${projectId}`;
+			let aborted = false;
+			manager.launchTask(
+				key,
+				(signal) =>
+					new Promise<void>((resolve) => {
+						signal.addEventListener('abort', () => {
+							aborted = true;
+							resolve();
+						});
+					}),
+				60_000,
+			);
+			const run = await db.query<{ id: string }>(
+				`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at)
+				 VALUES ($1, $2, $3, $4::heartbeat_run_status, now())
+				 RETURNING id`,
+				[agentId, teamId, taskId, HeartbeatRunStatus.Running],
+			);
+			manager.registerLiveRun({
+				runId: run.rows[0].id,
+				memberId: agentId,
+				taskId,
+				projectId,
+				teamId,
+				taskKey: key,
+			});
+
+			await (
+				manager as unknown as {
+					handleContainerTransition(t: {
+						projectId: string;
+						projectSlug: string;
+						teamId: string;
+						oldStatus: string;
+						newStatus: string;
+					}): Promise<void>;
+				}
+			).handleContainerTransition({
+				projectId,
+				projectSlug,
+				teamId,
+				oldStatus: ContainerStatus.Running,
+				newStatus: ContainerStatus.Error,
+			});
+
+			expect(aborted).toBe(true);
+			expect(manager.getLiveRunIds().has(run.rows[0].id)).toBe(false);
+			const r = await db.query<{ status: string }>(
+				'SELECT status FROM heartbeat_runs WHERE id = $1',
+				[run.rows[0].id],
+			);
+			expect(r.rows[0].status).toBe(HeartbeatRunStatus.Failed);
+
+			await waitForBackground();
+			manager.shutdown();
+		});
+
+		it('handleContainerTransition is a no-op for an unrelated transition (creating→running)', async () => {
+			const manager = createJobManager();
+			const run = await db.query<{ id: string }>(
+				`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at)
+				 VALUES ($1, $2, $3, $4::heartbeat_run_status, now())
+				 RETURNING id`,
+				[agentId, teamId, taskId, HeartbeatRunStatus.Running],
+			);
+
+			await (
+				manager as unknown as {
+					handleContainerTransition(t: {
+						projectId: string;
+						projectSlug: string;
+						teamId: string;
+						oldStatus: string;
+						newStatus: string;
+					}): Promise<void>;
+				}
+			).handleContainerTransition({
+				projectId,
+				projectSlug,
+				teamId,
+				oldStatus: ContainerStatus.Creating,
+				newStatus: ContainerStatus.Running,
+			});
+
+			// Run untouched (still running) since the transition isn't a failure.
+			const r = await db.query<{ status: string }>(
+				'SELECT status FROM heartbeat_runs WHERE id = $1',
+				[run.rows[0].id],
+			);
+			expect(r.rows[0].status).toBe(HeartbeatRunStatus.Running);
+			manager.shutdown();
+		});
+
+		it('syncContainerStatuses returns early when Docker is unreachable', async () => {
+			const manager = createJobManager({ docker: createStubDocker({ ping: async () => false }) });
+			// Should not throw and should reach no transition logic.
+			await (
+				manager as unknown as { syncContainerStatuses(): Promise<void> }
+			).syncContainerStatuses();
+			manager.shutdown();
+		});
+	});
+
+	describe('detectOrphanedRuns sweep', () => {
+		it('runs detect + stale-dispatch sweep + heal without error', async () => {
+			const manager = createJobManager();
+			await (manager as unknown as { detectOrphanedRuns(): Promise<void> }).detectOrphanedRuns();
+			manager.shutdown();
+		});
+	});
+
+	describe('inbox archive sweep', () => {
+		it('archives admin mentions read longer ago than the retention window', async () => {
+			const manager = createJobManager();
+			const userRes = await db.query<{ id: string }>('SELECT id FROM users LIMIT 1');
+			// admin_mentions needs a backing comment (FK). Seed one, then an old read mention.
+			const commentRes = await db.query<{ id: string }>(
+				`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
+				 VALUES ($1, NULL, 'system'::comment_content_type, '{"kind":"test"}'::jsonb)
+				 RETURNING id`,
+				[taskId],
+			);
+			const mentionRes = await db.query<{ id: string }>(
+				`INSERT INTO admin_mentions (team_id, task_id, comment_id, user_id, created_at, read_at, archived_at)
+				 VALUES ($1, $2, $3, $4, now() - interval '100 days', now() - interval '100 days', NULL)
+				 RETURNING id`,
+				[teamId, taskId, commentRes.rows[0].id, userRes.rows[0].id],
+			);
+
+			await (manager as unknown as { archiveInboxItems(): Promise<void> }).archiveInboxItems();
+
+			const archived = await db.query<{ archived_at: string | null }>(
+				'SELECT archived_at FROM admin_mentions WHERE id = $1',
+				[mentionRes.rows[0].id],
+			);
+			expect(archived.rows[0].archived_at).not.toBeNull();
+
+			await db.query('DELETE FROM admin_mentions WHERE id = $1', [mentionRes.rows[0].id]);
+			await db.query('DELETE FROM task_comments WHERE id = $1', [commentRes.rows[0].id]);
+			manager.shutdown();
+		});
+	});
+
+	describe('auto-update check', () => {
+		it('checkForUpdate no-ops when not a supervised worker', async () => {
+			const manager = createJobManager();
+			// In the test runtime isSupervisedWorker() is false, so this returns
+			// immediately without touching the filesystem / network.
+			await (manager as unknown as { checkForUpdate(): Promise<void> }).checkForUpdate();
+			manager.shutdown();
+		});
+	});
+
+	describe('startup container passes', () => {
+		// HQ and other projects can be provisioned in the background during file
+		// setup. Reset all container columns around each test so the passes only
+		// see the row the test seeds.
+		beforeEach(async () => {
+			await db.query(
+				`UPDATE projects SET container_status = NULL, container_id = NULL, container_error = NULL`,
+			);
+		});
+		afterEach(async () => {
+			await db.query(
+				`UPDATE projects SET container_status = NULL, container_id = NULL, container_error = NULL`,
+			);
+			// Restore the working project's container for the rest of the suite.
+			await db.query(
+				`UPDATE projects SET container_id = 'test-container', container_status = 'running' WHERE id = $1`,
+				[projectId],
+			);
+		});
+
+		it('rebuilds a running container whose /workspace mount is unreachable', async () => {
+			// Drop the repo row so the rebuild's downstream bring-up (provisionContainer
+			// → ensureProjectRepos) has nothing to clone — avoids an incidental
+			// repo-sync error from the stubbed exec. Restored below.
+			const savedRepo = await db.query<{ id: string; repo_identifier: string; host_type: string }>(
+				'SELECT id, repo_identifier, host_type::text AS host_type FROM repos WHERE project_id = $1 LIMIT 1',
+				[projectId],
+			);
+			await db.query('UPDATE projects SET designated_repo_id = NULL WHERE id = $1', [projectId]);
+			await db.query('DELETE FROM repos WHERE project_id = $1', [projectId]);
+			await db.query(
+				`UPDATE projects SET container_status = 'running'::container_status, container_id = 'stale-box' WHERE id = $1`,
+				[projectId],
+			);
+
+			// Only the '/workspace' probe exec reports a non-zero exit (mount
+			// unreachable); every other exec (used by the rebuild's bring-up)
+			// succeeds, so the rebuild completes quietly.
+			let probeExecId = '';
+			let rebuilt = false;
+			const manager = createJobManager({
+				docker: createStubDocker({
+					execCreate: async (_id: string, opts: { Cmd: string[] }) => {
+						const isProbe = opts.Cmd.join(' ').includes('/workspace');
+						const execId = isProbe ? 'probe-exec' : `exec-${Math.random()}`;
+						if (isProbe) probeExecId = execId;
+						return execId;
+					},
+					execStart: async () => ({ stdout: '', stderr: '' }),
+					execInspect: async (execId: string) => ({
+						ExitCode: execId === probeExecId ? 1 : 0,
+						Running: false,
+						Pid: 0,
+					}),
+					createContainer: async () => {
+						rebuilt = true;
+						return { Id: 'rebuilt-box', Warnings: [] };
+					},
+				}),
+			});
+
+			await (
+				manager as unknown as { repairStaleContainerMounts(d: unknown): Promise<void> }
+			).repairStaleContainerMounts(
+				(manager as unknown as { deps: { docker: unknown } }).deps.docker,
+			);
+
+			expect(rebuilt).toBe(true);
+
+			// Restore the repo row + designation for the rest of the suite.
+			const r = await db.query<{ id: string }>(
+				`INSERT INTO repos (project_id, repo_identifier, host_type)
+				 VALUES ($1, $2, $3::repo_host_type) RETURNING id`,
+				[projectId, savedRepo.rows[0].repo_identifier, savedRepo.rows[0].host_type],
+			);
+			await db.query('UPDATE projects SET designated_repo_id = $1 WHERE id = $2', [
+				r.rows[0].id,
+				projectId,
+			]);
+			manager.shutdown();
+		});
+
+		it('self-heals an errored project by re-attaching to a live container', async () => {
+			await db.query(
+				`UPDATE projects SET container_status = 'error'::container_status, container_id = NULL WHERE id = $1`,
+				[projectId],
+			);
+
+			const manager = createJobManager({
+				docker: createStubDocker({
+					findContainerByNamePrefix: async (name: string) => ({
+						Id: 'live-box',
+						Names: [`/${name}`],
+						State: { Status: 'running', Running: true, Pid: 1, ExitCode: 0 },
+						Config: { Image: 'stub' },
+					}),
+				}),
+			});
+
+			await (
+				manager as unknown as { selfHealErroredContainers(d: unknown): Promise<void> }
+			).selfHealErroredContainers(
+				(manager as unknown as { deps: { docker: unknown } }).deps.docker,
+			);
+
+			const row = await db.query<{ container_id: string | null; container_status: string }>(
+				'SELECT container_id, container_status FROM projects WHERE id = $1',
+				[projectId],
+			);
+			expect(row.rows[0].container_id).toBe('live-box');
+			expect(row.rows[0].container_status).toBe(ContainerStatus.Running);
+			manager.shutdown();
+		});
+	});
+
+	describe('guarded job error handling', () => {
+		it('swallows and logs an error thrown by a guarded job body', async () => {
+			const manager = createJobManager();
+			// guarded() must not let a throwing body escape — it logs and resets the guard.
+			await expect(
+				(
+					manager as unknown as {
+						guarded(name: string, fn: () => Promise<void>): Promise<void>;
+					}
+				).guarded('synthetic-test-job', async () => {
+					throw new Error('expected: guarded swallows this');
+				}),
+			).resolves.toBeUndefined();
+			manager.shutdown();
+		});
+
+		it('skips re-entrant guarded execution while the same job is in flight', async () => {
+			const manager = createJobManager();
+			let running = 0;
+			let maxConcurrent = 0;
+			let release: (() => void) | undefined;
+			const body = () =>
+				new Promise<void>((resolve) => {
+					running++;
+					maxConcurrent = Math.max(maxConcurrent, running);
+					release = () => {
+						running--;
+						resolve();
+					};
+				});
+			const guarded = (
+				manager as unknown as { guarded(name: string, fn: () => Promise<void>): Promise<void> }
+			).guarded.bind(manager);
+
+			const first = guarded('reentrant-test', body);
+			// Second call while the first is in flight must be skipped (no second body run).
+			await guarded('reentrant-test', body);
+			expect(maxConcurrent).toBe(1);
+			release?.();
+			await first;
+			manager.shutdown();
+		});
+	});
+});

--- a/packages/server/test/mcp-connections-routes.test.ts
+++ b/packages/server/test/mcp-connections-routes.test.ts
@@ -1,0 +1,290 @@
+import { McpConnectionKind } from '@hezo/shared';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { MasterKeyManager } from '../src/crypto/master-key';
+import { signAdminJwt } from '../src/middleware/auth';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp, createTestTeam, projectSlugFor } from './helpers/app';
+
+/**
+ * Route coverage for the MCP-connections surface that the existing
+ * mcp-connections.test.ts doesn't reach: the instance-global Admin routes
+ * (un-prefixed GET/POST/DELETE /mcp-connections), the project-scoped GET-by-id,
+ * DELETE, and revoke, plus their not-found / authorization branches.
+ *
+ * Boots the in-process Hono app directly (createTestApp), so no live HTTP
+ * server / port is involved — requests go through ctx.app.request.
+ */
+
+type Ctx = Awaited<ReturnType<typeof createTestApp>>;
+
+let ctx: Ctx;
+let token: string;
+let nonAdminToken: string;
+let masterKeyManager: MasterKeyManager;
+let projectSlug: string;
+
+beforeAll(async () => {
+	ctx = await createTestApp();
+	token = ctx.token;
+	masterKeyManager = ctx.masterKeyManager;
+
+	const teamRes = await createTestTeam(ctx.db, { name: 'MCP Routes Co' });
+	const teamId = (await teamRes.json()).data.id;
+	projectSlug = await projectSlugFor(ctx.db, teamId);
+
+	const nonAdmin = await ctx.db.query<{ id: string }>(
+		"INSERT INTO users (display_name, is_superuser) VALUES ('Plain User', false) RETURNING id",
+	);
+	nonAdminToken = await signAdminJwt(masterKeyManager, nonAdmin.rows[0].id);
+});
+
+afterAll(async () => {
+	await safeClose(ctx.db);
+});
+
+describe('admin (instance-global) /mcp-connections routes', () => {
+	let createdId: string;
+
+	it('rejects a non-superuser from listing the global catalog', async () => {
+		const res = await ctx.app.request('/api/mcp-connections', {
+			headers: authHeader(nonAdminToken),
+		});
+		expect(res.status).toBe(403);
+	});
+
+	it('creates a saas connector via the admin route and lists it', async () => {
+		const create = await ctx.app.request('/api/mcp-connections', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				name: 'admin-exa',
+				display_name: 'Admin Exa',
+				kind: 'saas',
+				config: { url: 'https://mcp.exa.ai/mcp' },
+			}),
+		});
+		expect(create.status).toBe(201);
+		const created = (await create.json()).data as { id: string; install_status: string };
+		expect(created.install_status).toBe('installed');
+		createdId = created.id;
+
+		const list = await ctx.app.request('/api/mcp-connections', { headers: authHeader(token) });
+		expect(list.status).toBe(200);
+		const rows = (await list.json()).data as Array<{ id: string; display_name: string }>;
+		expect(rows.find((r) => r.id === createdId)?.display_name).toBe('Admin Exa');
+	});
+
+	it('upserts on name conflict, updating config in place', async () => {
+		const res = await ctx.app.request('/api/mcp-connections', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				name: 'admin-exa',
+				display_name: 'Admin Exa v2',
+				kind: 'saas',
+				config: { url: 'https://mcp.exa.ai/v2' },
+			}),
+		});
+		expect(res.status).toBe(201);
+		const row = (await res.json()).data as {
+			id: string;
+			display_name: string;
+			config: { url: string };
+		};
+		expect(row.id).toBe(createdId);
+		expect(row.display_name).toBe('Admin Exa v2');
+		expect(row.config.url).toBe('https://mcp.exa.ai/v2');
+	});
+
+	it('rejects an admin create with no name', async () => {
+		const res = await ctx.app.request('/api/mcp-connections', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name: '  ', kind: 'saas', config: { url: 'https://x/mcp' } }),
+		});
+		expect(res.status).toBe(400);
+		expect((await res.json()).error.message).toContain('name is required');
+	});
+
+	it('rejects a non-saas kind on the admin route', async () => {
+		const res = await ctx.app.request('/api/mcp-connections', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				name: 'admin-local',
+				kind: 'local',
+				config: { command: 'npx' },
+			}),
+		});
+		expect(res.status).toBe(400);
+		expect((await res.json()).error.message).toContain('saas');
+	});
+
+	it('rejects a saas connector missing config.url', async () => {
+		const res = await ctx.app.request('/api/mcp-connections', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name: 'admin-nourl', kind: 'saas', config: {} }),
+		});
+		expect(res.status).toBe(400);
+		expect((await res.json()).error.message).toContain('config.url');
+	});
+
+	it('rejects a non-superuser DELETE on the admin route', async () => {
+		const res = await ctx.app.request(`/api/mcp-connections/${createdId}`, {
+			method: 'DELETE',
+			headers: authHeader(nonAdminToken),
+		});
+		expect(res.status).toBe(403);
+	});
+
+	it('returns 404 deleting an unknown connector', async () => {
+		const res = await ctx.app.request('/api/mcp-connections/00000000-0000-0000-0000-000000000000', {
+			method: 'DELETE',
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(404);
+		expect((await res.json()).error.code).toBe('NOT_FOUND');
+	});
+
+	it('deletes a connector and returns data:null', async () => {
+		const res = await ctx.app.request(`/api/mcp-connections/${createdId}`, {
+			method: 'DELETE',
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		expect((await res.json()).data).toBeNull();
+
+		const gone = await ctx.db.query('SELECT 1 FROM mcp_connections WHERE id = $1', [createdId]);
+		expect(gone.rows.length).toBe(0);
+	});
+});
+
+describe('project-scoped /projects/:projectId/mcp-connections/:id', () => {
+	async function seedSaasConnector(name: string): Promise<string> {
+		const r = await ctx.db.query<{ id: string }>(
+			`INSERT INTO mcp_connections (name, kind, config, install_status)
+			 VALUES ($1, $2::mcp_connection_kind, '{"url": "https://svc/mcp"}'::jsonb, 'installed')
+			 RETURNING id`,
+			[name, McpConnectionKind.Saas],
+		);
+		return r.rows[0].id;
+	}
+
+	it('reads a single connector by id', async () => {
+		const id = await seedSaasConnector('proj-read');
+		const res = await ctx.app.request(`/api/projects/${projectSlug}/mcp-connections/${id}`, {
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		const row = (await res.json()).data as { id: string; name: string };
+		expect(row.id).toBe(id);
+		expect(row.name).toBe('proj-read');
+	});
+
+	it('returns 404 reading an unknown connector', async () => {
+		const res = await ctx.app.request(
+			`/api/projects/${projectSlug}/mcp-connections/00000000-0000-0000-0000-000000000000`,
+			{ headers: authHeader(token) },
+		);
+		expect(res.status).toBe(404);
+	});
+
+	it('returns 404 deleting an unknown connector', async () => {
+		const res = await ctx.app.request(
+			`/api/projects/${projectSlug}/mcp-connections/00000000-0000-0000-0000-000000000000`,
+			{ method: 'DELETE', headers: authHeader(token) },
+		);
+		expect(res.status).toBe(404);
+		expect((await res.json()).error.message).toContain('MCP connection not found');
+	});
+
+	it('deletes a connector via the project-scoped route', async () => {
+		const id = await seedSaasConnector('proj-del');
+		const res = await ctx.app.request(`/api/projects/${projectSlug}/mcp-connections/${id}`, {
+			method: 'DELETE',
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		expect((await res.json()).data).toBeNull();
+		const gone = await ctx.db.query('SELECT 1 FROM mcp_connections WHERE id = $1', [id]);
+		expect(gone.rows.length).toBe(0);
+	});
+
+	it('revokes a connector (no oauth connection attached)', async () => {
+		const id = await seedSaasConnector('proj-revoke');
+		const res = await ctx.app.request(`/api/projects/${projectSlug}/mcp-connections/${id}/revoke`, {
+			method: 'POST',
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		const row = (await res.json()).data as { id: string; revoked_at: string | null };
+		expect(row.id).toBe(id);
+		expect(row.revoked_at).toBeTruthy();
+	});
+
+	it('returns 404 revoking an unknown connector', async () => {
+		const res = await ctx.app.request(
+			`/api/projects/${projectSlug}/mcp-connections/00000000-0000-0000-0000-000000000000/revoke`,
+			{ method: 'POST', headers: authHeader(token) },
+		);
+		expect(res.status).toBe(404);
+	});
+});
+
+describe('project-scoped POST /mcp-connections branches', () => {
+	it('rejects an unknown oauth_connection_id with 404', async () => {
+		const res = await ctx.app.request(`/api/projects/${projectSlug}/mcp-connections`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				name: 'with-bad-oauth',
+				kind: 'saas',
+				config: { url: 'https://svc/mcp' },
+				oauth_connection_id: '00000000-0000-0000-0000-000000000000',
+			}),
+		});
+		expect(res.status).toBe(404);
+		expect((await res.json()).error.message).toContain('oauth_connection_id not found');
+	});
+
+	it('rejects an unknown kind with 400', async () => {
+		const res = await ctx.app.request(`/api/projects/${projectSlug}/mcp-connections`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name: 'weird', kind: 'grpc', config: {} }),
+		});
+		expect(res.status).toBe(400);
+		expect((await res.json()).error.message).toContain('kind must be');
+	});
+
+	it('rejects a local connection missing config.command with 400', async () => {
+		const res = await ctx.app.request(`/api/projects/${projectSlug}/mcp-connections`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name: 'local-nocmd', kind: 'local', config: { args: [] } }),
+		});
+		expect(res.status).toBe(400);
+		expect((await res.json()).error.message).toContain('config.command');
+	});
+
+	it('rejects a project-scoped create with no name', async () => {
+		const res = await ctx.app.request(`/api/projects/${projectSlug}/mcp-connections`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ kind: 'saas', config: { url: 'https://svc/mcp' } }),
+		});
+		expect(res.status).toBe(400);
+		expect((await res.json()).error.message).toContain('name is required');
+	});
+
+	it('rejects connectors/ensure with no provider_id', async () => {
+		const res = await ctx.app.request(`/api/projects/${projectSlug}/connectors/ensure`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({}),
+		});
+		expect(res.status).toBe(400);
+		expect((await res.json()).error.message).toContain('provider_id is required');
+	});
+});

--- a/packages/server/test/mcp-tools-extended.test.ts
+++ b/packages/server/test/mcp-tools-extended.test.ts
@@ -1,0 +1,1568 @@
+import type { PGlite } from '@electric-sql/pglite';
+import { CredentialKind, DEFAULT_TEAM_ID, ReactionKind } from '@hezo/shared';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { MasterKeyManager } from '../src/crypto/master-key';
+import type { Env } from '../src/lib/types';
+import { safeClose } from './helpers';
+import {
+	authHeader,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+	encrypt,
+	instanceCeoId,
+	instanceCoachId,
+	mintAgentToken,
+} from './helpers/app';
+
+// These extend the coverage of packages/server/src/mcp/tools.ts beyond what
+// mcp-tools.test.ts / mcp.test.ts / mcp-project-scope.test.ts already exercise:
+// the tool handlers and validation / authorization / not-found branches that
+// were never reached over the /mcp HTTP surface. Each call asserts on the tool's
+// JSON result (an `error` field on the failure paths), not an HTTP 500.
+
+let app: Hono<Env>;
+let db: PGlite;
+let token: string;
+let masterKeyManager: MasterKeyManager;
+
+let teamId: string;
+let projectId: string;
+let projectSlug: string;
+let agentId: string; // engineer (a non-Captain worker on team A)
+let captainId: string;
+let taskId: string; // a task assigned to the engineer on team A
+
+let teamBId: string;
+let projectBId: string;
+let agentBId: string;
+let taskInBId: string;
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+	masterKeyManager = ctx.masterKeyManager;
+
+	const typesRes = await app.request('/api/team-templates', { headers: authHeader(token) });
+	const typeId = (await typesRes.json()).data.find(
+		(t: { name: string }) => t.name === 'Startup',
+	).id;
+
+	// Team A — the team-under-test.
+	const teamRes = await createTestTeam(db, { name: 'MCP Extended Co', template_id: typeId });
+	teamId = (await teamRes.json()).data.id;
+
+	const projectRes = await createTestProject(db, teamId, {
+		name: 'Extended Project',
+		description: 'Extended coverage project.',
+	});
+	const projectData = (await projectRes.json()).data;
+	projectId = projectData.id;
+	projectSlug = projectData.slug;
+
+	const eng = await db.query<{ id: string }>(
+		`SELECT ma.id FROM member_agents ma JOIN members m ON m.id = ma.id
+		 WHERE m.team_id = $1 AND ma.slug = 'engineer'`,
+		[teamId],
+	);
+	agentId = eng.rows[0].id;
+	const cap = await db.query<{ id: string }>(
+		`SELECT ma.id FROM member_agents ma JOIN members m ON m.id = ma.id
+		 WHERE m.team_id = $1 AND ma.slug = 'captain'`,
+		[teamId],
+	);
+	captainId = cap.rows[0].id;
+
+	const taskRes = await app.request(`/api/projects/${projectSlug}/tasks`, {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			project_id: projectId,
+			title: 'Extended Seed Task',
+			assignee_id: agentId,
+		}),
+	});
+	taskId = (await taskRes.json()).data.id;
+
+	// Team B — gives us a cross-team boundary for authorization-rejection tests.
+	const teamBRes = await createTestTeam(db, { name: 'MCP Extended Co B', template_id: typeId });
+	teamBId = (await teamBRes.json()).data.id;
+	const projectBRes = await createTestProject(db, teamBId, {
+		name: 'Extended Project B',
+		description: 'Team B project.',
+	});
+	const projectBData = (await projectBRes.json()).data;
+	projectBId = projectBData.id;
+	const projectBSlug = projectBData.slug;
+	const engB = await db.query<{ id: string }>(
+		`SELECT ma.id FROM member_agents ma JOIN members m ON m.id = ma.id
+		 WHERE m.team_id = $1 AND ma.slug = 'engineer'`,
+		[teamBId],
+	);
+	agentBId = engB.rows[0].id;
+	const taskBRes = await app.request(`/api/projects/${projectBSlug}/tasks`, {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ project_id: projectBId, title: 'Task in B', assignee_id: agentBId }),
+	});
+	taskInBId = (await taskBRes.json()).data.id;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+/** Call an MCP tool with the admin token and return its parsed result. */
+async function callTool(toolName: string, args: Record<string, unknown>): Promise<unknown> {
+	return callToolAs(token, toolName, args);
+}
+
+/** Call an MCP tool as an arbitrary principal token and return its parsed result. */
+async function callToolAs(
+	tokenStr: string,
+	toolName: string,
+	args: Record<string, unknown>,
+): Promise<unknown> {
+	const res = await app.request('/mcp', {
+		method: 'POST',
+		headers: { ...authHeader(tokenStr), 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			jsonrpc: '2.0',
+			method: 'tools/call',
+			params: { name: toolName, arguments: args },
+			id: 1,
+		}),
+	});
+	expect(res.status).toBe(200);
+	const body = (await res.json()) as {
+		result: { content: Array<{ type: string; text: string }> };
+	};
+	return JSON.parse(body.result.content[0].text);
+}
+
+type ToolResult = Record<string, unknown> & { error?: string };
+
+async function createTask(title: string, assignee = agentId): Promise<string> {
+	const r = (await callTool('create_task', {
+		project: projectId,
+		title,
+		assignee_id: assignee,
+	})) as { id: string };
+	return r.id;
+}
+
+async function captainToken(): Promise<string> {
+	const { token: t } = await mintAgentToken(db, masterKeyManager, captainId, teamId);
+	return t;
+}
+
+describe('MCP get_team / list_team_templates', () => {
+	it('get_team returns the team backing the project', async () => {
+		const team = (await callTool('get_team', { project: projectId })) as {
+			id: string;
+			name: string;
+		};
+		expect(team.id).toBe(teamId);
+		expect(team.name).toBe('MCP Extended Co');
+	});
+
+	it('get_team without a project arg errors for an instance principal (api key)', async () => {
+		const result = (await callTool('get_team', {})) as ToolResult;
+		expect(result.error).toContain('`project` is required');
+	});
+
+	it('list_team_templates returns the built-in templates with their roles', async () => {
+		const rows = (await callTool('list_team_templates', {})) as Array<{
+			name: string;
+			is_builtin: boolean;
+			agent_types: Array<{ slug: string }>;
+		}>;
+		expect(Array.isArray(rows)).toBe(true);
+		const startup = rows.find((r) => r.name === 'Startup');
+		expect(startup).toBeDefined();
+		expect(startup?.is_builtin).toBe(true);
+		expect(startup?.agent_types.map((a) => a.slug)).toContain('engineer');
+	});
+});
+
+describe('MCP create_team', () => {
+	it('superuser can create a team', async () => {
+		const result = (await callTool('create_team', { name: 'Spun Up Co', description: 'made' })) as {
+			id?: string;
+			slug?: string;
+			error?: string;
+		};
+		expect(result.error).toBeUndefined();
+		expect(result.id).toBeTruthy();
+		expect(result.slug).toBe('spun-up-co');
+	});
+
+	it('rejects a non-superuser agent', async () => {
+		const result = (await callToolAs(await captainToken(), 'create_team', {
+			name: 'Agent Team',
+		})) as ToolResult;
+		expect(result.error).toContain('superuser required');
+	});
+});
+
+describe('MCP list_tasks filters', () => {
+	it('filters by status (comma-separated list)', async () => {
+		const id = await createTask('Status filter target');
+		await db.query("UPDATE tasks SET status = 'review'::task_status WHERE id = $1", [id]);
+		const rows = (await callTool('list_tasks', {
+			project: projectId,
+			status: 'review,blocked',
+		})) as Array<{ id: string; status: string }>;
+		expect(rows.some((r) => r.id === id)).toBe(true);
+		for (const row of rows) expect(['review', 'blocked']).toContain(row.status);
+	});
+
+	it('filters by assignee_slug', async () => {
+		const rows = (await callTool('list_tasks', {
+			project: projectId,
+			assignee_slug: 'engineer',
+		})) as Array<{ assignee_id: string }>;
+		expect(rows.length).toBeGreaterThan(0);
+		for (const row of rows) expect(row.assignee_id).toBe(agentId);
+	});
+
+	it('returns an empty list for an unknown assignee_slug', async () => {
+		const rows = (await callTool('list_tasks', {
+			project: projectId,
+			assignee_slug: 'no-such-role',
+		})) as unknown[];
+		expect(rows).toEqual([]);
+	});
+});
+
+describe('MCP create_task / create_tasks error & batch branches', () => {
+	it('create_task surfaces a CreateTaskError as a tool error (unknown assignee_slug)', async () => {
+		const result = (await callTool('create_task', {
+			project: projectId,
+			title: 'Bad assignee',
+			assignee_slug: 'nobody-here',
+		})) as ToolResult;
+		expect(typeof result.error).toBe('string');
+		expect(result.error).not.toBe('');
+	});
+
+	it('create_tasks creates a batch and chains blockers by index token', async () => {
+		const results = (await callTool('create_tasks', {
+			project: projectId,
+			items: [
+				{ title: 'Phase 1', assignee_id: agentId },
+				{ title: 'Phase 2', assignee_id: agentId, blocked_by_task_ids: ['#0'] },
+			],
+		})) as Array<{ ok: boolean; index: number; task?: { id: string } }>;
+		expect(results.length).toBe(2);
+		expect(results[0].ok).toBe(true);
+		expect(results[1].ok).toBe(true);
+		// Phase 2 is blocked by Phase 1.
+		const dep = await db.query<{ n: number }>(
+			`SELECT count(*)::int AS n FROM task_dependencies
+			 WHERE task_id = $1 AND blocked_by_task_id = $2`,
+			[results[1].task?.id, results[0].task?.id],
+		);
+		expect(dep.rows[0].n).toBe(1);
+	});
+
+	it('create_tasks returns a per-item error without aborting the rest', async () => {
+		const results = (await callTool('create_tasks', {
+			project: projectId,
+			items: [
+				{ title: 'Good item', assignee_id: agentId },
+				{ title: 'Bad item', assignee_slug: 'nobody-here' },
+			],
+		})) as Array<{ ok: boolean; index: number; error?: string }>;
+		expect(results[0].ok).toBe(true);
+		expect(results[1].ok).toBe(false);
+		expect(typeof results[1].error).toBe('string');
+	});
+
+	it('create_tasks as an agent attaches a backtick advisory per created item', async () => {
+		// The agent path (auth.type === Agent) folds withBacktickWarning over each
+		// created task — distinct from the admin path that returns raw results.
+		// A Captain may always assign to itself; this drives the agent fold over the
+		// batch (withBacktickWarning per created item) rather than the admin path.
+		const results = (await callToolAs(await captainToken(), 'create_tasks', {
+			project: projectId,
+			items: [{ title: 'Agent batch item', assignee_id: captainId }],
+		})) as Array<{ ok: boolean; task?: { id: string } }>;
+		expect(results[0].ok).toBe(true);
+		expect(results[0].task?.id).toBeTruthy();
+	});
+});
+
+describe('MCP add_task_blocker / remove_task_blocker', () => {
+	it('add_task_blocker links two tasks and remove clears it', async () => {
+		const downstream = await createTask('Blocker downstream');
+		const upstream = await createTask('Blocker upstream');
+
+		const added = (await callTool('add_task_blocker', {
+			project: projectId,
+			task_id: downstream,
+			blocked_by_task_id: upstream,
+		})) as { id?: string; error?: string };
+		expect(added.error).toBeUndefined();
+		expect(added.id).toBeTruthy();
+
+		// Duplicate is rejected.
+		const dup = (await callTool('add_task_blocker', {
+			project: projectId,
+			task_id: downstream,
+			blocked_by_task_id: upstream,
+		})) as ToolResult;
+		expect(dup.error).toContain('already exists');
+
+		const removed = (await callTool('remove_task_blocker', {
+			project: projectId,
+			task_id: downstream,
+			blocked_by_task_id: upstream,
+		})) as { removed?: boolean; error?: string };
+		expect(removed.removed).toBe(true);
+
+		// Removing a non-existent dependency errors.
+		const removeAgain = (await callTool('remove_task_blocker', {
+			project: projectId,
+			task_id: downstream,
+			blocked_by_task_id: upstream,
+		})) as ToolResult;
+		expect(removeAgain.error).toContain('Dependency not found');
+	});
+
+	it('add_task_blocker rejects a self-block', async () => {
+		const t = await createTask('Self block target');
+		const result = (await callTool('add_task_blocker', {
+			project: projectId,
+			task_id: t,
+			blocked_by_task_id: t,
+		})) as ToolResult;
+		expect(result.error).toContain('cannot block itself');
+	});
+
+	it('add_task_blocker rejects a cycle', async () => {
+		const a = await createTask('Cycle A');
+		const b = await createTask('Cycle B');
+		await callTool('add_task_blocker', {
+			project: projectId,
+			task_id: a,
+			blocked_by_task_id: b,
+		});
+		// b -> a would close the loop.
+		const result = (await callTool('add_task_blocker', {
+			project: projectId,
+			task_id: b,
+			blocked_by_task_id: a,
+		})) as ToolResult;
+		expect(result.error).toContain('cycle');
+	});
+
+	it('add_task_blocker errors for an unknown blocker identifier', async () => {
+		const t = await createTask('Unknown blocker target');
+		const result = (await callTool('add_task_blocker', {
+			project: projectId,
+			task_id: t,
+			blocked_by_task_id: 'ZZ-99999',
+		})) as ToolResult;
+		expect(result.error).toContain('Blocking task not found');
+	});
+
+	it('remove_task_blocker errors for an unknown blocker identifier', async () => {
+		const t = await createTask('Unknown remove blocker target');
+		const result = (await callTool('remove_task_blocker', {
+			project: projectId,
+			task_id: t,
+			blocked_by_task_id: 'ZZ-99999',
+		})) as ToolResult;
+		expect(result.error).toContain('Blocking task not found');
+	});
+});
+
+describe('MCP reactions (add_reaction / remove_reaction)', () => {
+	it('add then remove a reaction round-trips and broadcasts', async () => {
+		const t = await createTask('Reaction target');
+		const inserted = await db.query<{ id: string }>(
+			`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
+			 VALUES ($1, $2, 'text'::comment_content_type, $3::jsonb) RETURNING id`,
+			[t, agentId, JSON.stringify({ text: 'react to me' })],
+		);
+		const commentId = inserted.rows[0].id;
+
+		const captain = await captainToken();
+		const added = (await callToolAs(captain, 'add_reaction', {
+			project: projectId,
+			task_id: t,
+			comment_id: commentId,
+			kind: ReactionKind.Ack,
+		})) as { comment_id?: string; kind?: string; reactions?: unknown[]; error?: string };
+		expect(added.error).toBeUndefined();
+		expect(added.comment_id).toBe(commentId);
+		expect(added.kind).toBe(ReactionKind.Ack);
+
+		const removed = (await callToolAs(captain, 'remove_reaction', {
+			project: projectId,
+			task_id: t,
+			comment_id: commentId,
+			kind: ReactionKind.Ack,
+		})) as { reactions?: unknown[]; error?: string };
+		expect(removed.error).toBeUndefined();
+	});
+
+	it('add_reaction on a comment from another task is rejected by the reaction service', async () => {
+		const t1 = await createTask('Reaction task one');
+		const t2 = await createTask('Reaction task two');
+		const inserted = await db.query<{ id: string }>(
+			`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
+			 VALUES ($1, $2, 'text'::comment_content_type, $3::jsonb) RETURNING id`,
+			[t2, agentId, JSON.stringify({ text: 'on task two' })],
+		);
+		const result = (await callToolAs(await captainToken(), 'add_reaction', {
+			project: projectId,
+			task_id: t1,
+			comment_id: inserted.rows[0].id,
+			kind: ReactionKind.Ack,
+		})) as ToolResult;
+		expect(typeof result.error).toBe('string');
+	});
+});
+
+describe('MCP create_comment warnings & threading', () => {
+	it('warns when an agent references a teammate by bold/plain name (no @)', async () => {
+		const t = await createTask('Unlinked mention target');
+		const result = (await callToolAs(await captainToken(), 'create_comment', {
+			project: projectId,
+			task_id: t,
+			content: 'Hey **engineer**, please pick this up.',
+		})) as { id?: string; warning?: string; error?: string };
+		expect(result.error).toBeUndefined();
+		expect(result.id).toBeTruthy();
+		expect(result.warning).toContain('engineer');
+		expect(result.warning).toContain('@engineer');
+	});
+
+	it('warns when an agent backticks a real task identifier and teammate slug', async () => {
+		const ref = (await callTool('create_task', {
+			project: projectId,
+			title: 'Backtick reference target',
+			assignee_id: agentId,
+		})) as { identifier: string };
+		const t = await createTask('Backtick comment host');
+		const result = (await callToolAs(await captainToken(), 'create_comment', {
+			project: projectId,
+			task_id: t,
+			content: `See \`${ref.identifier}\` and ask \`engineer\` about it.`,
+		})) as { id?: string; warning?: string; error?: string };
+		expect(result.error).toBeUndefined();
+		expect(result.warning).toContain('backticks');
+		expect(result.warning).toContain(ref.identifier);
+	});
+
+	it('threads a reply when parent_comment_id belongs to the task', async () => {
+		const t = await createTask('Reply threading target');
+		const parent = await db.query<{ id: string }>(
+			`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
+			 VALUES ($1, $2, 'text'::comment_content_type, $3::jsonb) RETURNING id`,
+			[t, agentId, JSON.stringify({ text: 'original' })],
+		);
+		const result = (await callToolAs(await captainToken(), 'create_comment', {
+			project: projectId,
+			task_id: t,
+			content: 'A direct reply.',
+			parent_comment_id: parent.rows[0].id,
+		})) as { id?: string; parent_comment_id?: string; error?: string };
+		expect(result.error).toBeUndefined();
+		expect(result.parent_comment_id).toBe(parent.rows[0].id);
+	});
+
+	it('rejects a parent_comment_id from a different task', async () => {
+		const t1 = await createTask('Reply host one');
+		const t2 = await createTask('Reply host two');
+		const foreign = await db.query<{ id: string }>(
+			`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
+			 VALUES ($1, $2, 'text'::comment_content_type, $3::jsonb) RETURNING id`,
+			[t2, agentId, JSON.stringify({ text: 'elsewhere' })],
+		);
+		const result = (await callToolAs(await captainToken(), 'create_comment', {
+			project: projectId,
+			task_id: t1,
+			content: 'Bad parent.',
+			parent_comment_id: foreign.rows[0].id,
+		})) as ToolResult;
+		expect(result.error).toContain('does not belong to this task');
+	});
+});
+
+describe('MCP request_credential', () => {
+	it('posts a credential request and returns a placeholder', async () => {
+		const result = (await callToolAs(await captainToken(), 'request_credential', {
+			project: projectId,
+			task_id: taskId,
+			name: 'NETLIFY_API_KEY',
+			kind: CredentialKind.ApiKey,
+			instructions: 'Need a Netlify key with deploy scope.',
+			allowed_hosts: ['api.netlify.com'],
+		})) as { placeholder?: string; status?: string; reused?: boolean; error?: string };
+		expect(result.error).toBeUndefined();
+		expect(result.placeholder).toBe('__HEZO_SECRET_NETLIFY_API_KEY__');
+		expect(result.status).toBe('pending');
+		expect(result.reused).toBe(false);
+
+		// A second identical request reuses the open comment.
+		const again = (await callToolAs(await captainToken(), 'request_credential', {
+			project: projectId,
+			task_id: taskId,
+			name: 'NETLIFY_API_KEY',
+			kind: CredentialKind.ApiKey,
+			instructions: 'Need a Netlify key with deploy scope.',
+			allowed_hosts: ['api.netlify.com'],
+		})) as { reused?: boolean };
+		expect(again.reused).toBe(true);
+	});
+
+	it('rejects an invalid secret name', async () => {
+		const result = (await callToolAs(await captainToken(), 'request_credential', {
+			project: projectId,
+			task_id: taskId,
+			name: 'lower-case-bad',
+			kind: CredentialKind.Other,
+			instructions: 'whatever',
+		})) as ToolResult;
+		expect(result.error).toContain('name must match');
+	});
+
+	it('requires allowed_hosts for HTTP-auth kinds', async () => {
+		const result = (await callToolAs(await captainToken(), 'request_credential', {
+			project: projectId,
+			task_id: taskId,
+			name: 'SOME_TOKEN',
+			kind: CredentialKind.OauthToken,
+			instructions: 'no hosts given',
+		})) as ToolResult;
+		expect(result.error).toContain('allowed_hosts');
+	});
+
+	it('allows a confirmation request without allowed_hosts', async () => {
+		const result = (await callToolAs(await captainToken(), 'request_credential', {
+			project: projectId,
+			task_id: taskId,
+			name: 'CONFIRM_KEY_ADDED',
+			kind: CredentialKind.GithubPat,
+			instructions: 'Confirm the deploy key is present.',
+			confirmation_text: 'Have you added the key?',
+		})) as { placeholder?: string; error?: string };
+		expect(result.error).toBeUndefined();
+		expect(result.placeholder).toBe('__HEZO_SECRET_CONFIRM_KEY_ADDED__');
+	});
+});
+
+describe('MCP register_connector', () => {
+	it('registers a pending SaaS connector and posts a connect_required comment', async () => {
+		const result = (await callToolAs(await captainToken(), 'register_connector', {
+			project: projectId,
+			task_id: taskId,
+			display_name: 'DatoCMS',
+			mcp_url: 'https://mcp.datocms.com/',
+		})) as {
+			connector_id?: string;
+			status?: string;
+			comment_id?: string;
+			name?: string;
+			error?: string;
+		};
+		expect(result.error).toBeUndefined();
+		expect(result.connector_id).toBeTruthy();
+		expect(result.status).toBe('pending');
+		expect(result.comment_id).toBeTruthy();
+		expect(result.name).toBe('datocms');
+
+		// Idempotent: re-registering reuses the same connector + comment.
+		const again = (await callToolAs(await captainToken(), 'register_connector', {
+			project: projectId,
+			task_id: taskId,
+			display_name: 'DatoCMS',
+			mcp_url: 'https://mcp.datocms.com/',
+		})) as { connector_id?: string; reused?: boolean; comment_id?: string };
+		expect(again.connector_id).toBe(result.connector_id);
+		expect(again.reused).toBe(true);
+		expect(again.comment_id).toBe(result.comment_id);
+	});
+
+	it('rejects a display_name that produces an empty slug', async () => {
+		const result = (await callToolAs(await captainToken(), 'register_connector', {
+			project: projectId,
+			task_id: taskId,
+			display_name: '!!!',
+			mcp_url: 'https://example.com/mcp',
+		})) as ToolResult;
+		expect(result.error).toContain('empty slug');
+	});
+
+	it('returns the active state (no connect comment) when the connector is already active', async () => {
+		// Seed a connector that is already OAuth-active under a known slug, then
+		// register_connector with a display_name that slugs to the same name.
+		const key = masterKeyManager.getKey();
+		if (!key) throw new Error('master key locked');
+		const secret = await db.query<{ id: string }>(
+			`INSERT INTO secrets (name, encrypted_value, allowed_hosts)
+			 VALUES ('ALREADY_ACTIVE_TOKEN', $1, $2) RETURNING id`,
+			[encrypt('tok', key), ['api.active.com']],
+		);
+		const oauth = await db.query<{ id: string }>(
+			`INSERT INTO oauth_connections (provider, provider_account_id, provider_account_label, access_token_secret_id)
+			 VALUES ('already-active', 'acct', 'acct', $1) RETURNING id`,
+			[secret.rows[0].id],
+		);
+		await db.query(
+			`INSERT INTO mcp_connections (name, display_name, kind, config, install_status, oauth_connection_id, activated_at)
+			 VALUES ('already-active', 'Already Active', 'saas'::mcp_connection_kind, $1::jsonb, 'installed'::mcp_install_status, $2, now())`,
+			[JSON.stringify({ url: 'https://mcp.active.com/' }), oauth.rows[0].id],
+		);
+
+		const result = (await callToolAs(await captainToken(), 'register_connector', {
+			project: projectId,
+			task_id: taskId,
+			display_name: 'Already Active',
+			provider_id: 'already-active',
+			mcp_url: 'https://mcp.active.com/',
+		})) as { status?: string; reused?: boolean; comment_id?: string; error?: string };
+		expect(result.error).toBeUndefined();
+		expect(result.status).toBe('active');
+		expect(result.reused).toBe(true);
+		// No connect_required comment for an already-active connector.
+		expect(result.comment_id).toBeUndefined();
+	});
+});
+
+describe('MCP fetch_skill_file validation', () => {
+	it('rejects a malformed URL', async () => {
+		const result = (await callTool('fetch_skill_file', {
+			project: projectId,
+			url: 'not a url',
+		})) as ToolResult;
+		expect(result.error).toBe('Invalid URL');
+	});
+
+	it('rejects a non-http(s) scheme', async () => {
+		const result = (await callTool('fetch_skill_file', {
+			project: projectId,
+			url: 'ftp://example.com/skill.md',
+		})) as ToolResult;
+		expect(result.error).toContain('Only http/https');
+	});
+});
+
+describe('MCP list_approvals / resolve_approval', () => {
+	it('list_approvals returns pending approvals, with excerpt truncation', async () => {
+		await db.query(
+			`INSERT INTO approvals (team_id, type, payload)
+			 VALUES ($1, 'skill_proposal'::approval_type, $2::jsonb)`,
+			[teamId, JSON.stringify({ skill_name: 'X', content: 'y'.repeat(2000) })],
+		);
+		const rows = (await callTool('list_approvals', {
+			project: projectId,
+			excerpt_chars: 100,
+		})) as Array<{ payload: Record<string, unknown> }>;
+		expect(rows.length).toBeGreaterThanOrEqual(1);
+	});
+
+	it('resolve_approval errors for an unknown approval', async () => {
+		const result = (await callTool('resolve_approval', {
+			approval_id: '00000000-0000-0000-0000-000000000000',
+			status: 'approved',
+		})) as ToolResult;
+		expect(result.error).toContain('Approval not found');
+	});
+
+	it('resolve_approval (team-keyed) approves a strategy approval as admin', async () => {
+		const r = await db.query<{ id: string }>(
+			`INSERT INTO approvals (team_id, type, payload)
+			 VALUES ($1, 'strategy'::approval_type, '{"plan":"go"}'::jsonb) RETURNING id`,
+			[teamId],
+		);
+		const result = (await callTool('resolve_approval', {
+			approval_id: r.rows[0].id,
+			status: 'approved',
+			resolution_note: 'ok',
+		})) as { status?: string; error?: string };
+		expect(result.error).toBeUndefined();
+		expect(result.status).toBe('approved');
+	});
+
+	it('resolve_approval denies a team-keyed approval to a foreign-team agent', async () => {
+		const r = await db.query<{ id: string }>(
+			`INSERT INTO approvals (team_id, type, payload)
+			 VALUES ($1, 'strategy'::approval_type, '{"plan":"go"}'::jsonb) RETURNING id`,
+			[teamId],
+		);
+		const { token: bToken } = await mintAgentToken(db, masterKeyManager, agentBId, teamBId);
+		const result = (await callToolAs(bToken, 'resolve_approval', {
+			approval_id: r.rows[0].id,
+			status: 'approved',
+		})) as ToolResult;
+		expect(result.error).toContain('Access denied');
+	});
+
+	it('resolve_approval authorizes via the project scope when payload carries project_id', async () => {
+		const r = await db.query<{ id: string }>(
+			`INSERT INTO approvals (team_id, type, payload)
+			 VALUES ($1, 'strategy'::approval_type, $2::jsonb) RETURNING id`,
+			[teamId, JSON.stringify({ plan: 'scoped', project_id: projectId })],
+		);
+		const result = (await callTool('resolve_approval', {
+			approval_id: r.rows[0].id,
+			status: 'approved',
+		})) as { status?: string; error?: string };
+		expect(result.error).toBeUndefined();
+		expect(result.status).toBe('approved');
+	});
+
+	it('resolve_approval denies a foreign-team agent on a project-scoped approval', async () => {
+		const r = await db.query<{ id: string }>(
+			`INSERT INTO approvals (team_id, type, payload)
+			 VALUES ($1, 'strategy'::approval_type, $2::jsonb) RETURNING id`,
+			[teamId, JSON.stringify({ plan: 'scoped', project_id: projectId })],
+		);
+		const { token: bToken } = await mintAgentToken(db, masterKeyManager, agentBId, teamBId);
+		const result = (await callToolAs(bToken, 'resolve_approval', {
+			approval_id: r.rows[0].id,
+			status: 'approved',
+		})) as ToolResult;
+		expect(result.error).toContain('Access denied');
+	});
+
+	it('resolve_approval rejects a project-scoped run for a non-cross-project approval', async () => {
+		const r = await db.query<{ id: string }>(
+			`INSERT INTO approvals (team_id, type, payload)
+			 VALUES ($1, 'strategy'::approval_type, '{"plan":"go"}'::jsonb) RETURNING id`,
+			[teamId],
+		);
+		const { token: agentToken } = await mintAgentToken(
+			db,
+			masterKeyManager,
+			agentId,
+			teamId,
+			null,
+			{
+				projectId,
+				crossProject: false,
+			},
+		);
+		const result = (await callToolAs(agentToken, 'resolve_approval', {
+			approval_id: r.rows[0].id,
+			status: 'approved',
+		})) as ToolResult;
+		expect(result.error).toContain('not scoped to resolve this approval');
+	});
+});
+
+describe('MCP get_costs grouping', () => {
+	beforeAll(async () => {
+		await db.query(
+			`INSERT INTO cost_entries (project_id, member_id, amount_cents)
+			 VALUES ($1, $2, 150)`,
+			[projectId, agentId],
+		);
+	});
+
+	it('group_by=agent returns per-agent totals', async () => {
+		const rows = (await callTool('get_costs', {
+			project: projectId,
+			group_by: 'agent',
+		})) as Array<{ member_id: string; total_cents: number }>;
+		expect(rows.some((r) => r.member_id === agentId && r.total_cents >= 150)).toBe(true);
+	});
+
+	it('group_by=day returns per-day totals', async () => {
+		const rows = (await callTool('get_costs', {
+			project: projectId,
+			group_by: 'day',
+		})) as Array<{ day: string; total_cents: number }>;
+		expect(rows.length).toBeGreaterThanOrEqual(1);
+	});
+
+	it('no grouping returns a single summary object', async () => {
+		const summary = (await callTool('get_costs', { project: projectId })) as {
+			total_cents: number;
+			entry_count: number;
+		};
+		expect(summary.total_cents).toBeGreaterThanOrEqual(150);
+		expect(summary.entry_count).toBeGreaterThanOrEqual(1);
+	});
+});
+
+describe('MCP agent system prompt tools', () => {
+	it('get_agent_system_prompt errors for an unknown agent', async () => {
+		const result = (await callTool('get_agent_system_prompt', {
+			project: projectId,
+			agent_id: '00000000-0000-0000-0000-000000000000',
+		})) as ToolResult;
+		expect(result.error).toContain('Agent not found');
+	});
+
+	it('get_agent_system_prompts batches results and reports per-item errors', async () => {
+		const results = (await callTool('get_agent_system_prompts', {
+			project: projectId,
+			items: [{ agent_id: 'engineer' }, { agent_id: 'no-such-agent', mode: 'raw' }],
+		})) as Array<{ index: number; ok: boolean; system_prompt?: string; error?: string }>;
+		expect(results.length).toBe(2);
+		const ok = results.find((r) => r.ok);
+		const bad = results.find((r) => !r.ok);
+		expect(ok?.system_prompt).toBeTruthy();
+		expect(bad?.error).toBeTruthy();
+	});
+
+	it('update_agent_system_prompt is allowed for the Captain and stores a revision', async () => {
+		const result = (await callToolAs(await captainToken(), 'update_agent_system_prompt', {
+			project: projectId,
+			agent_id: agentId,
+			new_system_prompt: 'You are the engineer. Updated by the Captain.',
+			change_summary: 'coherence review',
+		})) as { applied?: boolean; document_id?: string; error?: string };
+		expect(result.error).toBeUndefined();
+		expect(result.applied).toBe(true);
+		expect(result.document_id).toBeTruthy();
+	});
+
+	it('update_agent_system_prompt denies a plain worker agent', async () => {
+		const { token: workerToken } = await mintAgentToken(db, masterKeyManager, agentId, teamId);
+		const result = (await callToolAs(workerToken, 'update_agent_system_prompt', {
+			project: projectId,
+			agent_id: agentId,
+			new_system_prompt: 'should be rejected',
+			change_summary: 'nope',
+		})) as ToolResult;
+		expect(result.error).toContain('Access denied');
+	});
+
+	it('update_agent_system_prompt errors for an unknown agent', async () => {
+		const result = (await callToolAs(await captainToken(), 'update_agent_system_prompt', {
+			project: projectId,
+			agent_id: '00000000-0000-0000-0000-000000000000',
+			new_system_prompt: 'x',
+			change_summary: 'y',
+		})) as ToolResult;
+		expect(result.error).toContain('Agent not found');
+	});
+});
+
+describe('MCP agent summary / team summary validation', () => {
+	it('set_agent_summary writes for an agent in the same team', async () => {
+		const result = (await callToolAs(await captainToken(), 'set_agent_summary', {
+			project: projectId,
+			agent_id: agentId,
+			summary: 'Ships backend features.',
+		})) as { updated?: boolean; error?: string };
+		expect(result.error).toBeUndefined();
+		expect(result.updated).toBe(true);
+	});
+
+	it('set_agent_summary rejects an empty summary', async () => {
+		const result = (await callToolAs(await captainToken(), 'set_agent_summary', {
+			project: projectId,
+			agent_id: agentId,
+			summary: '   ',
+		})) as ToolResult;
+		expect(result.error).toContain('non-empty');
+	});
+
+	it('set_agent_summary rejects an over-length summary', async () => {
+		const result = (await callToolAs(await captainToken(), 'set_agent_summary', {
+			project: projectId,
+			agent_id: agentId,
+			summary: 'x'.repeat(1001),
+		})) as ToolResult;
+		expect(result.error).toContain('too long');
+	});
+
+	it('set_agent_summary errors for an agent not in this team', async () => {
+		const result = (await callToolAs(await captainToken(), 'set_agent_summary', {
+			project: projectId,
+			agent_id: agentBId,
+			summary: 'cross-team write',
+		})) as ToolResult;
+		expect(result.error).toContain('Agent not found');
+	});
+
+	it('set_team_summary rejects an over-length summary', async () => {
+		const result = (await callToolAs(await captainToken(), 'set_team_summary', {
+			project: projectId,
+			summary: 'x'.repeat(4001),
+		})) as ToolResult;
+		expect(result.error).toContain('too long');
+	});
+
+	it('set_team_summary rejects an empty summary', async () => {
+		const result = (await callToolAs(await captainToken(), 'set_team_summary', {
+			project: projectId,
+			summary: '   ',
+		})) as ToolResult;
+		expect(result.error).toContain('non-empty');
+	});
+});
+
+describe('MCP report_no_work guards', () => {
+	it('rejects a non-agent caller', async () => {
+		const result = (await callTool('report_no_work', { reason: 'nothing' })) as ToolResult;
+		expect(result.error).toContain('within an agent run');
+	});
+});
+
+describe('MCP set_agent_team_context / get_agent_team_context', () => {
+	it('Captain writes and reads back an agent team context', async () => {
+		const captain = await captainToken();
+		const written = (await callToolAs(captain, 'set_agent_team_context', {
+			project: projectId,
+			agent_id: agentId,
+			content: 'You report to the Architect and pair with QA.',
+		})) as { updated?: boolean; error?: string };
+		expect(written.error).toBeUndefined();
+		expect(written.updated).toBe(true);
+
+		const read = (await callToolAs(captain, 'get_agent_team_context', {
+			project: projectId,
+			agent_id: agentId,
+		})) as { team_context?: string; slug?: string; error?: string };
+		expect(read.error).toBeUndefined();
+		expect(read.team_context).toContain('Architect');
+	});
+
+	it('set_agent_team_context denies a plain worker agent', async () => {
+		const { token: workerToken } = await mintAgentToken(db, masterKeyManager, agentId, teamId);
+		const result = (await callToolAs(workerToken, 'set_agent_team_context', {
+			project: projectId,
+			agent_id: agentId,
+			content: 'nope',
+		})) as ToolResult;
+		expect(result.error).toContain('Access denied');
+	});
+
+	it('set_agent_team_context rejects an empty body', async () => {
+		const result = (await callToolAs(await captainToken(), 'set_agent_team_context', {
+			project: projectId,
+			agent_id: agentId,
+			content: '   ',
+		})) as ToolResult;
+		expect(result.error).toContain('non-empty');
+	});
+
+	it('set_agent_team_context rejects an over-length body', async () => {
+		const result = (await callToolAs(await captainToken(), 'set_agent_team_context', {
+			project: projectId,
+			agent_id: agentId,
+			content: 'x'.repeat(6001),
+		})) as ToolResult;
+		expect(result.error).toContain('too long');
+	});
+
+	it('get_agent_team_context errors for an unknown agent', async () => {
+		const result = (await callToolAs(await captainToken(), 'get_agent_team_context', {
+			project: projectId,
+			agent_id: '00000000-0000-0000-0000-000000000000',
+		})) as ToolResult;
+		expect(result.error).toContain('Agent not found');
+	});
+});
+
+describe('MCP set_agent_status', () => {
+	it('Captain disables then re-enables a worker agent', async () => {
+		// A dedicated project so unassign side effects don't disturb other tests.
+		const teamRes = await createTestTeam(db, {
+			name: 'Retire Co',
+			template_id: (
+				await (await app.request('/api/team-templates', { headers: authHeader(token) })).json()
+			).data.find((t: { name: string }) => t.name === 'Startup').id,
+		});
+		const retireTeamId = (await teamRes.json()).data.id;
+		const retireProjectRes = await createTestProject(db, retireTeamId, {
+			name: 'Retire Project',
+			description: 'x',
+		});
+		const retireProjectId = (await retireProjectRes.json()).data.id;
+		const retireCaptain = await db.query<{ id: string }>(
+			`SELECT ma.id FROM member_agents ma JOIN members m ON m.id = ma.id
+			 WHERE m.team_id = $1 AND ma.slug = 'captain'`,
+			[retireTeamId],
+		);
+		const { token: capTok } = await mintAgentToken(
+			db,
+			masterKeyManager,
+			retireCaptain.rows[0].id,
+			retireTeamId,
+		);
+
+		const disabled = (await callToolAs(capTok, 'set_agent_status', {
+			project: retireProjectId,
+			agent: 'engineer',
+			status: 'disabled',
+		})) as { updated?: boolean; admin_status?: string; error?: string };
+		expect(disabled.error).toBeUndefined();
+		expect(disabled.updated).toBe(true);
+		expect(disabled.admin_status).toBe('disabled');
+
+		// Disabling again is a no-op error.
+		const again = (await callToolAs(capTok, 'set_agent_status', {
+			project: retireProjectId,
+			agent: 'engineer',
+			status: 'disabled',
+		})) as ToolResult;
+		expect(again.error).toContain('already disabled');
+
+		const enabled = (await callToolAs(capTok, 'set_agent_status', {
+			project: retireProjectId,
+			agent: 'engineer',
+			status: 'enabled',
+		})) as { updated?: boolean; error?: string };
+		expect(enabled.error).toBeUndefined();
+		expect(enabled.updated).toBe(true);
+	});
+
+	it('refuses to disable the protected Captain role', async () => {
+		const result = (await callToolAs(await captainToken(), 'set_agent_status', {
+			project: projectId,
+			agent: 'captain',
+			status: 'disabled',
+		})) as ToolResult;
+		expect(result.error).toContain('essential');
+	});
+
+	it('errors for an unknown agent reference', async () => {
+		const result = (await callToolAs(await captainToken(), 'set_agent_status', {
+			project: projectId,
+			agent: 'ghost-role',
+			status: 'disabled',
+		})) as ToolResult;
+		expect(result.error).toContain('Agent not found');
+	});
+
+	it('denies a plain worker agent', async () => {
+		const { token: workerToken } = await mintAgentToken(db, masterKeyManager, agentId, teamId);
+		const result = (await callToolAs(workerToken, 'set_agent_status', {
+			project: projectId,
+			agent: 'qa-engineer',
+			status: 'disabled',
+		})) as ToolResult;
+		expect(result.error).toContain('Access denied');
+	});
+
+	it('is not callable by an admin (agents only)', async () => {
+		const result = (await callTool('set_agent_status', {
+			project: projectId,
+			agent: 'qa-engineer',
+			status: 'disabled',
+		})) as ToolResult;
+		expect(result.error).toContain('only callable by agents');
+	});
+});
+
+describe('MCP project docs & assets', () => {
+	it('write_project_doc rejects a non-markdown filename', async () => {
+		const result = (await callTool('write_project_doc', {
+			project: projectId,
+			filename: 'notes.txt',
+			content: 'hi',
+		})) as ToolResult;
+		expect(result.error).toContain('markdown');
+	});
+
+	it('write_project_doc then read_project_doc and list_project_docs round-trip', async () => {
+		const written = (await callTool('write_project_doc', {
+			project: projectId,
+			filename: 'design.md',
+			content: '# Design\nbody',
+		})) as { written?: boolean; error?: string };
+		expect(written.error).toBeUndefined();
+		expect(written.written).toBe(true);
+
+		const read = (await callTool('read_project_doc', {
+			project: projectId,
+			filename: 'design.md',
+		})) as { content?: string; error?: string };
+		expect(read.content).toBe('# Design\nbody');
+
+		const listed = (await callTool('list_project_docs', { project: projectId })) as {
+			files: Array<{ filename: string }>;
+		};
+		expect(listed.files.some((f) => f.filename === 'design.md')).toBe(true);
+	});
+
+	it('read_project_doc errors for an unknown file', async () => {
+		const result = (await callTool('read_project_doc', {
+			project: projectId,
+			filename: 'missing.md',
+		})) as ToolResult;
+		expect(result.error).toContain('not found');
+	});
+
+	it('list_project_assets returns the assets written via write_project_asset', async () => {
+		await callTool('write_project_asset', {
+			project: projectId,
+			filename: 'diagram.svg',
+			content: '<svg></svg>',
+		});
+		const listed = (await callTool('list_project_assets', { project: projectId })) as {
+			files: Array<{ filename: string; content_type: string }>;
+		};
+		expect(listed.files.some((f) => f.filename === 'diagram.svg')).toBe(true);
+	});
+
+	it('write_project_asset rejects a disallowed extension', async () => {
+		const result = (await callTool('write_project_asset', {
+			project: projectId,
+			filename: 'evil.exe',
+			content: 'binary',
+		})) as ToolResult;
+		expect(result.error).toContain('text-based');
+	});
+
+	it('read_project_asset reports a binary asset as a container path', async () => {
+		// Seed an asset row directly with a binary content type; the read path
+		// returns a path rather than inlining content.
+		const assetId = crypto.randomUUID();
+		await db.query(
+			`INSERT INTO assets (id, team_id, project_id, original_filename, content_type, byte_size, sha256)
+			 VALUES ($1, $2, $3, 'photo.png', 'image/png', 1234, 'deadbeef')`,
+			[assetId, teamId, projectId],
+		);
+		const result = (await callTool('read_project_asset', {
+			project: projectId,
+			filename: 'photo.png',
+		})) as { binary?: boolean; path?: string; content?: string; error?: string };
+		expect(result.error).toBeUndefined();
+		expect(result.binary).toBe(true);
+		expect(result.path).toContain(assetId);
+		expect(result.content).toBeUndefined();
+	});
+});
+
+describe('MCP skills (propose / list / get / create / semantic_search)', () => {
+	it('propose_skill creates a skill_proposal approval', async () => {
+		const result = (await callToolAs(await captainToken(), 'propose_skill', {
+			project: projectId,
+			skill_name: 'Deploy Flow',
+			skill_slug: 'deploy-flow',
+			content: '# Deploy\nsteps',
+			reason: 'reusable',
+		})) as { approval_id?: string; status?: string; error?: string };
+		expect(result.error).toBeUndefined();
+		expect(result.approval_id).toBeTruthy();
+		expect(result.status).toBeTruthy();
+	});
+
+	it('create_skill upserts a skill and get_skill loads it; list_skills filters by tag', async () => {
+		const created = (await callTool('create_skill', {
+			project: projectId,
+			name: 'Lint Setup',
+			slug: 'lint-setup',
+			content: '# Lint\nrun biome',
+			tags: 'ci,quality',
+		})) as { id?: string; slug?: string; error?: string };
+		expect(created.error).toBeUndefined();
+		expect(created.slug).toBe('lint-setup');
+
+		const got = (await callTool('get_skill', {
+			project: projectId,
+			slug: 'lint-setup',
+		})) as { name?: string; content?: string; error?: string };
+		expect(got.name).toBe('Lint Setup');
+		expect(got.content).toContain('biome');
+
+		const listed = (await callTool('list_skills', {
+			project: projectId,
+			tags: 'ci',
+		})) as { skills: Array<{ slug: string }> };
+		expect(listed.skills.some((s) => s.slug === 'lint-setup')).toBe(true);
+	});
+
+	it('get_skill errors for an unknown slug', async () => {
+		const result = (await callTool('get_skill', {
+			project: projectId,
+			slug: 'no-such-skill',
+		})) as ToolResult;
+		expect(result.error).toContain('Skill not found');
+	});
+
+	it('semantic_search returns ranked results across team content', async () => {
+		await callTool('create_skill', {
+			project: projectId,
+			name: 'Searchable Skill',
+			slug: 'searchable-skill',
+			content: 'A unique zorptacular keyword for full text search.',
+		});
+		const result = (await callTool('semantic_search', {
+			project: projectId,
+			query: 'zorptacular',
+		})) as { results: unknown[]; count: number };
+		expect(typeof result.count).toBe('number');
+		expect(Array.isArray(result.results)).toBe(true);
+	});
+});
+
+describe('MCP MCP-connection tools', () => {
+	it('add_mcp_connection (saas) then list and remove round-trip', async () => {
+		const added = (await callTool('add_mcp_connection', {
+			project: projectId,
+			name: 'extra-saas',
+			kind: 'saas',
+			config: { url: 'https://mcp.example.com/' },
+		})) as { id?: string; install_status?: string; note?: string; error?: string };
+		expect(added.error).toBeUndefined();
+		expect(added.id).toBeTruthy();
+		expect(added.install_status).toBe('installed');
+
+		const listed = (await callTool('list_mcp_connections', { project: projectId })) as Array<{
+			id: string;
+			name: string;
+			oauth_status: string;
+		}>;
+		const row = listed.find((r) => r.name === 'extra-saas');
+		expect(row).toBeDefined();
+		expect(row?.oauth_status).toBe('none');
+
+		const removed = (await callTool('remove_mcp_connection', {
+			project: projectId,
+			id: added.id,
+		})) as { removed?: boolean; error?: string };
+		expect(removed.removed).toBe(true);
+	});
+
+	it('add_mcp_connection (local) registers with pending status', async () => {
+		const added = (await callTool('add_mcp_connection', {
+			project: projectId,
+			name: 'extra-local',
+			kind: 'local',
+			config: { command: 'mcp-server' },
+		})) as { install_status?: string; note?: string; error?: string };
+		expect(added.install_status).toBe('pending');
+		expect(added.note).toContain('pending');
+	});
+
+	it('add_mcp_connection rejects a saas config without url', async () => {
+		const result = (await callTool('add_mcp_connection', {
+			project: projectId,
+			name: 'bad-saas',
+			kind: 'saas',
+			config: {},
+		})) as ToolResult;
+		expect(result.error).toContain('config.url');
+	});
+
+	it('add_mcp_connection rejects a local config without command', async () => {
+		const result = (await callTool('add_mcp_connection', {
+			project: projectId,
+			name: 'bad-local',
+			kind: 'local',
+			config: {},
+		})) as ToolResult;
+		expect(result.error).toContain('config.command');
+	});
+
+	it('remove_mcp_connection errors for an unknown id', async () => {
+		const result = (await callTool('remove_mcp_connection', {
+			project: projectId,
+			id: '00000000-0000-0000-0000-000000000000',
+		})) as ToolResult;
+		expect(result.error).toContain('not found');
+	});
+
+	it('test_connector errors for an unknown connector', async () => {
+		const result = (await callTool('test_connector', {
+			project: projectId,
+			connector_id: '00000000-0000-0000-0000-000000000000',
+		})) as ToolResult;
+		expect(result.error).toContain('connector not found');
+	});
+
+	it('test_connector refuses a non-saas connector', async () => {
+		const added = (await callTool('add_mcp_connection', {
+			project: projectId,
+			name: 'local-for-test',
+			kind: 'local',
+			config: { command: 'x' },
+		})) as { id: string };
+		const result = (await callTool('test_connector', {
+			project: projectId,
+			connector_id: added.id,
+		})) as ToolResult;
+		expect(result.error).toContain('kind=saas');
+	});
+
+	it('test_connector reports a missing url on a saas connector with no url', async () => {
+		// add_mcp_connection enforces url for saas, so insert a urless saas row directly.
+		const r = await db.query<{ id: string }>(
+			`INSERT INTO mcp_connections (name, kind, config, install_status)
+			 VALUES ('urless-saas', 'saas'::mcp_connection_kind, '{}'::jsonb, 'installed'::mcp_install_status)
+			 RETURNING id`,
+		);
+		const result = (await callTool('test_connector', {
+			project: projectId,
+			connector_id: r.rows[0].id,
+		})) as ToolResult;
+		expect(result.error).toContain('no mcp url');
+	});
+
+	// Seed an OAuth-backed SaaS connector: a secret holding an encrypted token, an
+	// oauth_connections row referencing it, and a connector linked to that. The
+	// `127.0.0.1:1` URL refuses instantly so the probe never leaves the host.
+	async function seedOauthConnector(opts: {
+		name: string;
+		hosts?: string[];
+		activated?: boolean;
+	}): Promise<{ connectorId: string; secretId: string; oauthId: string }> {
+		const key = masterKeyManager.getKey();
+		if (!key) throw new Error('master key locked in test');
+		const enc = encrypt('super-secret-token-value', key);
+		const secret = await db.query<{ id: string }>(
+			`INSERT INTO secrets (name, encrypted_value, allowed_hosts)
+			 VALUES ($1, $2, $3) RETURNING id`,
+			[`${opts.name.toUpperCase().replace(/[^A-Z0-9]/g, '_')}_TOKEN`, enc, opts.hosts ?? []],
+		);
+		const oauth = await db.query<{ id: string }>(
+			`INSERT INTO oauth_connections (provider, provider_account_id, provider_account_label, access_token_secret_id, scopes)
+			 VALUES ($1, $2, 'acct', $3, $4) RETURNING id`,
+			[opts.name, `acct-${opts.name}`, secret.rows[0].id, ['read']],
+		);
+		const connector = await db.query<{ id: string }>(
+			`INSERT INTO mcp_connections (name, kind, config, install_status, oauth_connection_id, activated_at)
+			 VALUES ($1, 'saas'::mcp_connection_kind, $2::jsonb, 'installed'::mcp_install_status, $3, $4)
+			 RETURNING id`,
+			[
+				opts.name,
+				JSON.stringify({ url: 'http://127.0.0.1:1/' }),
+				oauth.rows[0].id,
+				opts.activated ? new Date().toISOString() : null,
+			],
+		);
+		return {
+			connectorId: connector.rows[0].id,
+			secretId: secret.rows[0].id,
+			oauthId: oauth.rows[0].id,
+		};
+	}
+
+	it('test_connector decrypts the stored token and reports a failed network probe', async () => {
+		const { connectorId } = await seedOauthConnector({ name: 'probe-fail-conn' });
+		const result = (await callTool('test_connector', {
+			project: projectId,
+			connector_id: connectorId,
+		})) as {
+			ok?: boolean;
+			error?: string;
+			secret_name?: string;
+			token_prefix?: string;
+			mcp_url?: string;
+		};
+		// Decryption succeeded (secret name + token prefix surfaced); the probe to
+		// 127.0.0.1:1 fails fast → the network-probe-failed branch.
+		expect(result.ok).toBe(false);
+		expect(result.error).toContain('network probe failed');
+		expect(result.secret_name).toContain('TOKEN');
+		expect(result.token_prefix).toBe('super-se');
+	});
+
+	it('test_connector reports a decrypt failure when the stored ciphertext is malformed', async () => {
+		const secret = await db.query<{ id: string }>(
+			`INSERT INTO secrets (name, encrypted_value) VALUES ('BROKEN_TOKEN', 'not-valid-ciphertext') RETURNING id`,
+		);
+		const oauth = await db.query<{ id: string }>(
+			`INSERT INTO oauth_connections (provider, provider_account_id, provider_account_label, access_token_secret_id)
+			 VALUES ('broken', 'broken-acct', 'acct', $1) RETURNING id`,
+			[secret.rows[0].id],
+		);
+		const connector = await db.query<{ id: string }>(
+			`INSERT INTO mcp_connections (name, kind, config, install_status, oauth_connection_id)
+			 VALUES ('broken-conn', 'saas'::mcp_connection_kind, $1::jsonb, 'installed'::mcp_install_status, $2)
+			 RETURNING id`,
+			[JSON.stringify({ url: 'http://127.0.0.1:1/' }), oauth.rows[0].id],
+		);
+		const result = (await callTool('test_connector', {
+			project: projectId,
+			connector_id: connector.rows[0].id,
+		})) as { error?: string; secret_name?: string };
+		expect(result.error).toContain('failed to decrypt stored token');
+		expect(result.secret_name).toBe('BROKEN_TOKEN');
+	});
+
+	it('list_mcp_connections surfaces oauth_status=active and rest_auth for a host-scoped active connector', async () => {
+		await seedOauthConnector({
+			name: 'active-conn',
+			hosts: ['api.example.com'],
+			activated: true,
+		});
+		const rows = (await callTool('list_mcp_connections', { project: projectId })) as Array<{
+			name: string;
+			oauth_status: string;
+			rest_auth: { placeholder: string; allowed_hosts: string[] } | null;
+		}>;
+		const active = rows.find((r) => r.name === 'active-conn');
+		expect(active?.oauth_status).toBe('active');
+		expect(active?.rest_auth).not.toBeNull();
+		expect(active?.rest_auth?.placeholder).toContain('__HEZO_SECRET_');
+		expect(active?.rest_auth?.allowed_hosts).toContain('api.example.com');
+	});
+});
+
+describe('MCP create_hire_proposal / update_hire_proposal', () => {
+	it('Captain creates a hire proposal, then revises it', async () => {
+		const captain = await captainToken();
+		const created = (await callToolAs(captain, 'create_hire_proposal', {
+			project: projectId,
+			title: 'Data Scientist',
+			role_description: 'Owns analytics.',
+			system_prompt: 'You are the data scientist.',
+		})) as { approval_id?: string; status?: string; error?: string };
+		expect(created.error).toBeUndefined();
+		expect(created.approval_id).toBeTruthy();
+
+		const revised = (await callToolAs(captain, 'update_hire_proposal', {
+			approval_id: created.approval_id,
+			role_description: 'Owns analytics and dashboards.',
+			monthly_budget_cents: 5000,
+		})) as { id?: string; payload?: Record<string, unknown>; error?: string };
+		expect(revised.error).toBeUndefined();
+		expect(revised.payload?.role_description).toBe('Owns analytics and dashboards.');
+	});
+
+	it('create_hire_proposal rejects an invalid default_effort', async () => {
+		const result = (await callToolAs(await captainToken(), 'create_hire_proposal', {
+			project: projectId,
+			title: 'Bad Effort Hire',
+			default_effort: 'turbo',
+		})) as ToolResult;
+		expect(result.error).toContain('default_effort');
+	});
+
+	it('create_hire_proposal rejects a non-existent task_id link', async () => {
+		const result = (await callToolAs(await captainToken(), 'create_hire_proposal', {
+			project: projectId,
+			title: 'Linked Hire',
+			task_id: '00000000-0000-0000-0000-000000000000',
+		})) as ToolResult;
+		expect(result.error).toContain('task_id not found');
+	});
+
+	it('create_hire_proposal rejects a non-Captain/CEO agent', async () => {
+		const { token: workerToken } = await mintAgentToken(db, masterKeyManager, agentId, teamId);
+		const result = (await callToolAs(workerToken, 'create_hire_proposal', {
+			project: projectId,
+			title: 'Worker Hire',
+		})) as ToolResult;
+		expect(result.error).toContain('Only the Captain or CEO');
+	});
+
+	it('create_hire_proposal rejects an admin (agents only)', async () => {
+		const result = (await callTool('create_hire_proposal', {
+			project: projectId,
+			title: 'Admin Hire',
+		})) as ToolResult;
+		expect(result.error).toContain('only callable by agents');
+	});
+
+	it('update_hire_proposal rejects an admin (agents only)', async () => {
+		const result = (await callTool('update_hire_proposal', {
+			approval_id: '00000000-0000-0000-0000-000000000000',
+			title: 'x',
+		})) as ToolResult;
+		expect(result.error).toContain('only callable by agents');
+	});
+
+	it('update_hire_proposal rejects a non-Captain agent', async () => {
+		const { token: workerToken } = await mintAgentToken(db, masterKeyManager, agentId, teamId);
+		const result = (await callToolAs(workerToken, 'update_hire_proposal', {
+			approval_id: '00000000-0000-0000-0000-000000000000',
+			title: 'x',
+		})) as ToolResult;
+		expect(result.error).toContain('Only the Captain');
+	});
+
+	it('update_hire_proposal errors when the approval does not exist', async () => {
+		const result = (await callToolAs(await captainToken(), 'update_hire_proposal', {
+			approval_id: '00000000-0000-0000-0000-000000000000',
+			title: 'x',
+		})) as ToolResult;
+		expect(result.error).toContain('Approval not found');
+	});
+
+	it('update_hire_proposal rejects a non-hire approval', async () => {
+		const r = await db.query<{ id: string }>(
+			`INSERT INTO approvals (team_id, type, payload)
+			 VALUES ($1, 'strategy'::approval_type, '{"plan":"x"}'::jsonb) RETURNING id`,
+			[teamId],
+		);
+		const result = (await callToolAs(await captainToken(), 'update_hire_proposal', {
+			approval_id: r.rows[0].id,
+			title: 'x',
+		})) as ToolResult;
+		expect(result.error).toContain('not a hire request');
+	});
+
+	it('update_hire_proposal errors when no fields are provided', async () => {
+		const captain = await captainToken();
+		const created = (await callToolAs(captain, 'create_hire_proposal', {
+			project: projectId,
+			title: 'No-op Revise Hire',
+		})) as { approval_id: string };
+		const result = (await callToolAs(captain, 'update_hire_proposal', {
+			approval_id: created.approval_id,
+		})) as ToolResult;
+		expect(result.error).toContain('no fields to update');
+	});
+
+	it('update_hire_proposal rejects a cross-team approval id', async () => {
+		// A hire approval on team B, revised by team A's Captain → team mismatch.
+		const r = await db.query<{ id: string }>(
+			`INSERT INTO approvals (team_id, type, status, payload)
+			 VALUES ($1, 'hire'::approval_type, 'pending'::approval_status, $2::jsonb) RETURNING id`,
+			[teamBId, JSON.stringify({ title: 'B Hire', slug: 'b-hire' })],
+		);
+		const result = (await callToolAs(await captainToken(), 'update_hire_proposal', {
+			approval_id: r.rows[0].id,
+			title: 'x',
+		})) as ToolResult;
+		expect(result.error).toContain('team mismatch');
+	});
+});
+
+describe('MCP cross-team CEO discovery on extended tools', () => {
+	it('the CEO chat session (cross-team) can resolve set_agent_status across teams', async () => {
+		// The CEO running cross-team into team A is an HQ instance agent and may
+		// change agent status even though its run is scoped to HQ.
+		const ceoId = await instanceCeoId(db);
+		const { token: ceoToken } = await mintAgentToken(
+			db,
+			masterKeyManager,
+			ceoId,
+			DEFAULT_TEAM_ID,
+			null,
+			{ crossProject: true },
+		);
+		// crossProject token still scopes to its own team for authorizeScope; the
+		// CEO discovery path here just confirms the tool is reachable and returns a
+		// structured result rather than a 500. Re-enable an already-enabled agent.
+		const result = (await callToolAs(ceoToken, 'set_agent_status', {
+			project: projectId,
+			agent: 'qa-engineer',
+			status: 'enabled',
+		})) as ToolResult;
+		// Either "already enabled" (no-op) or updated — both are structured, not a throw.
+		expect(typeof result).toBe('object');
+		expect(result).not.toBeNull();
+	});
+});
+
+describe('MCP Coach can resolve update_agent_system_prompt cross-team', () => {
+	it('the Coach updates a worker prompt while running in the team', async () => {
+		const coachId = await instanceCoachId(db);
+		const { token: coachToken } = await mintAgentToken(db, masterKeyManager, coachId, teamId);
+		const result = (await callToolAs(coachToken, 'update_agent_system_prompt', {
+			project: projectId,
+			agent_id: agentId,
+			new_system_prompt: 'You are the engineer. Coach-tuned rules.',
+			change_summary: 'post-task learned rules',
+		})) as { applied?: boolean; error?: string };
+		expect(result.error).toBeUndefined();
+		expect(result.applied).toBe(true);
+	});
+});

--- a/packages/server/test/oauth-routes-extended.test.ts
+++ b/packages/server/test/oauth-routes-extended.test.ts
@@ -1,0 +1,505 @@
+import { createServer, type Server } from 'node:http';
+import type { PGlite } from '@electric-sql/pglite';
+import type { Hono } from 'hono';
+import { Hono as HonoApp } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Env } from '../src/lib/types';
+import { createOrFetchConnector, getConnector } from '../src/services/connectors/lifecycle';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp, createTestTeam, projectSlugFor } from './helpers/app';
+import { startFakeMcpServer } from './helpers/fake-mcp-server';
+
+/**
+ * A minimal generic OAuth Authorization Server. Serves the AS-metadata
+ * well-known doc, an `/authorize` endpoint that auto-approves and 302s back to
+ * the redirect_uri with `code` + the passed-through `state`, and a `/token`
+ * endpoint. Drives the manual auth-code flow on `oauth.ts` (the `/oauth/callback`
+ * + `/projects/:id/oauth/auth-code/start` routes), which the existing suite —
+ * focused on the MCP-connector/device-flow paths — never exercises.
+ */
+interface GenericOAuthSim {
+	server: Server;
+	baseUrl: string;
+	destroy(): Promise<void>;
+}
+
+async function startGenericOAuthSim(
+	opts: { withMetadata?: boolean; rejectExchange?: boolean; tokenScope?: string | null } = {},
+): Promise<GenericOAuthSim> {
+	const withMetadata = opts.withMetadata ?? true;
+	const app = new HonoApp();
+
+	if (withMetadata) {
+		app.get('/.well-known/oauth-authorization-server', (c) => {
+			const origin = new URL(c.req.url).origin;
+			return c.json({
+				issuer: origin,
+				authorization_endpoint: `${origin}/authorize`,
+				token_endpoint: `${origin}/token`,
+				code_challenge_methods_supported: ['S256'],
+				scopes_supported: ['read', 'write'],
+			});
+		});
+	}
+
+	app.get('/authorize', (c) => {
+		const redirectUri = c.req.query('redirect_uri');
+		const state = c.req.query('state');
+		if (!redirectUri || !state) return c.text('missing redirect_uri or state', 400);
+		const url = new URL(redirectUri);
+		url.searchParams.set('code', 'auth-code-xyz');
+		url.searchParams.set('state', state);
+		return c.redirect(url.toString(), 302);
+	});
+
+	app.post('/token', async (c) => {
+		if (opts.rejectExchange) {
+			c.status(400);
+			return c.json({ error: 'invalid_grant', error_description: 'bad code' });
+		}
+		const body = (await c.req.parseBody()) as Record<string, string>;
+		const resp: Record<string, unknown> = {
+			access_token: `gen-tok-${body.code ?? 'x'}`,
+			refresh_token: 'gen-ref',
+			token_type: 'bearer',
+			expires_in: 3600,
+		};
+		// tokenScope null → omit scope (exercises the "fall back to manual_config.scopes" branch).
+		if (opts.tokenScope !== null) resp.scope = opts.tokenScope ?? 'read write';
+		return c.json(resp);
+	});
+
+	const server = createServer(async (req, res) => {
+		const url = `http://localhost${req.url}`;
+		const headers = new Headers();
+		for (const [k, v] of Object.entries(req.headers)) {
+			if (v) headers.set(k, Array.isArray(v) ? v.join(', ') : v);
+		}
+		const chunks: Buffer[] = [];
+		for await (const chunk of req) chunks.push(chunk);
+		const reqBody = chunks.length > 0 ? Buffer.concat(chunks) : undefined;
+		const response = await app.fetch(
+			new Request(url, {
+				method: req.method,
+				headers,
+				body: reqBody && req.method !== 'GET' && req.method !== 'HEAD' ? reqBody : undefined,
+			}),
+		);
+		res.writeHead(response.status, Object.fromEntries(response.headers.entries()));
+		res.end(Buffer.from(await response.arrayBuffer()));
+	});
+	await new Promise<void>((resolve) => server.listen(0, resolve));
+	const addr = server.address();
+	const port = typeof addr === 'object' && addr ? addr.port : 0;
+	return {
+		server,
+		baseUrl: `http://localhost:${port}`,
+		async destroy() {
+			await new Promise<void>((resolve) => server.close(() => resolve()));
+		},
+	};
+}
+
+let app: Hono<Env>;
+let db: PGlite;
+let token: string;
+let teamId: string;
+let projectSlug: string;
+let sim: GenericOAuthSim;
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+
+	const teamRes = await createTestTeam(db, { name: 'OAuth Routes Co' });
+	teamId = (await teamRes.json()).data.id;
+	projectSlug = await projectSlugFor(db, teamId);
+
+	sim = await startGenericOAuthSim();
+});
+
+afterAll(async () => {
+	await sim.destroy();
+	await safeClose(db);
+});
+
+/** POST a manual-config auth-code start; returns the parsed response + status. */
+async function startAuthCode(body: Record<string, unknown>) {
+	const res = await app.request(`/api/projects/${projectSlug}/oauth/auth-code/start`, {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify(body),
+	});
+	return { status: res.status, body: (await res.json()) as Record<string, unknown> };
+}
+
+function manualConfig(base: string) {
+	return {
+		authorize_url: `${base}/authorize`,
+		token_url: `${base}/token`,
+		client_id: 'cli-123',
+		client_secret: 'sec-456',
+		scopes: ['read', 'write'],
+	};
+}
+
+describe('POST /projects/:projectId/oauth/auth-code/start (manual config)', () => {
+	it('rejects a missing provider', async () => {
+		const { status, body } = await startAuthCode({ manual_config: manualConfig(sim.baseUrl) });
+		expect(status).toBe(400);
+		expect((body.error as { code: string }).code).toBe('INVALID_REQUEST');
+	});
+
+	it('rejects when neither server_url nor manual_config is supplied', async () => {
+		const { status, body } = await startAuthCode({ provider: 'notion' });
+		expect(status).toBe(400);
+		expect((body.error as { message: string }).message).toMatch(/server_url.*manual_config/);
+	});
+
+	it('builds an authorize URL from manual_config with PKCE + state', async () => {
+		const { status, body } = await startAuthCode({
+			provider: 'notion',
+			manual_config: manualConfig(sim.baseUrl),
+			return_to: '/projects/x',
+		});
+		expect(status).toBe(200);
+		const authUrl = (body.data as { auth_url: string }).auth_url;
+		const parsed = new URL(authUrl);
+		expect(parsed.origin + parsed.pathname).toBe(`${sim.baseUrl}/authorize`);
+		expect(parsed.searchParams.get('client_id')).toBe('cli-123');
+		expect(parsed.searchParams.get('code_challenge')).toBeTruthy();
+		expect(parsed.searchParams.get('code_challenge_method')).toBe('S256');
+		expect(parsed.searchParams.get('state')).toBeTruthy();
+	});
+
+	it('spec-discovery mode without manual_config returns OAUTH_MANUAL_CONFIG_REQUIRED', async () => {
+		// server_url present, metadata discoverable, but no manual_config → DCR isn't
+		// implemented for this route, so it must ask for manual_config.
+		const { status, body } = await startAuthCode({
+			provider: 'notion',
+			server_url: `${sim.baseUrl}/mcp`,
+		});
+		expect(status).toBe(400);
+		expect((body.error as { code: string }).code).toBe('OAUTH_MANUAL_CONFIG_REQUIRED');
+	});
+
+	it('returns OAUTH_DISCOVERY_FAILED (503) when metadata discovery fails', async () => {
+		const noMeta = await startGenericOAuthSim({ withMetadata: false });
+		try {
+			const res = await app.request(`/api/projects/${projectSlug}/oauth/auth-code/start`, {
+				method: 'POST',
+				headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+				body: JSON.stringify({ provider: 'notion', server_url: `${noMeta.baseUrl}/mcp` }),
+			});
+			expect(res.status).toBe(503);
+			expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+				'OAUTH_DISCOVERY_FAILED',
+			);
+		} finally {
+			await noMeta.destroy();
+		}
+	});
+});
+
+describe('GET /oauth/callback (generic auth-code callback)', () => {
+	it('completes the flow end-to-end: stores token in an oauth_connections row', async () => {
+		const { body } = await startAuthCode({
+			provider: 'notion',
+			manual_config: manualConfig(sim.baseUrl),
+			mcp_connection_name: 'My Notion',
+		});
+		const authUrl = (body.data as { auth_url: string }).auth_url;
+		const authorizeRes = await fetch(authUrl, { redirect: 'manual' });
+		expect(authorizeRes.status).toBe(302);
+		const loc = new URL(authorizeRes.headers.get('location')!);
+		const code = loc.searchParams.get('code')!;
+		const state = loc.searchParams.get('state')!;
+
+		const before = await db.query<{ c: number }>(
+			`SELECT count(*)::int AS c FROM oauth_connections WHERE provider = 'notion'`,
+		);
+
+		const cb = await app.request(
+			`/api/oauth/callback?code=${encodeURIComponent(code)}&state=${encodeURIComponent(state)}`,
+		);
+		expect(cb.status).toBe(200);
+		expect(await cb.text()).toContain('OAuth connection complete');
+
+		const after = await db.query<{ provider: string; provider_account_label: string }>(
+			`SELECT provider, provider_account_label FROM oauth_connections WHERE provider = 'notion'`,
+		);
+		expect(after.rows.length).toBe(before.rows[0].c + 1);
+		expect(after.rows[after.rows.length - 1].provider_account_label).toBe('My Notion');
+
+		// Token value never leaks into the row; it lives encrypted in secrets.
+		const secret = await db.query<{ allowed_hosts: string[] }>(
+			`SELECT s.allowed_hosts FROM oauth_connections oc
+			 JOIN secrets s ON s.id = oc.access_token_secret_id
+			 WHERE oc.provider = 'notion' ORDER BY oc.created_at DESC LIMIT 1`,
+		);
+		// allowed_hosts inferred from the token_url host.
+		expect(secret.rows[0].allowed_hosts.some((h) => h.startsWith('localhost'))).toBe(true);
+	});
+
+	it('links an mcp_connection row when mcp_connection_id is in the state', async () => {
+		const { row } = await createOrFetchConnector(db, {
+			name: 'linktest',
+			displayName: 'LinkTest',
+			mcpUrl: `${sim.baseUrl}/mcp`,
+			mcpTransport: 'http',
+		});
+		const { body } = await startAuthCode({
+			provider: 'linktest',
+			manual_config: manualConfig(sim.baseUrl),
+			mcp_connection_id: row.id,
+		});
+		const authUrl = (body.data as { auth_url: string }).auth_url;
+		const authorizeRes = await fetch(authUrl, { redirect: 'manual' });
+		const loc = new URL(authorizeRes.headers.get('location')!);
+		const code = loc.searchParams.get('code')!;
+		const state = loc.searchParams.get('state')!;
+
+		const cb = await app.request(
+			`/api/oauth/callback?code=${encodeURIComponent(code)}&state=${encodeURIComponent(state)}`,
+		);
+		expect(cb.status).toBe(200);
+
+		const linked = await db.query<{ oauth_connection_id: string | null }>(
+			`SELECT oauth_connection_id FROM mcp_connections WHERE id = $1`,
+			[row.id],
+		);
+		expect(linked.rows[0].oauth_connection_id).toBeTruthy();
+	});
+
+	it('renders an error page (200) when the provider returns ?error', async () => {
+		const cb = await app.request('/api/oauth/callback?error=access_denied');
+		expect(cb.status).toBe(200);
+		expect(await cb.text()).toContain('access_denied');
+	});
+
+	it('renders missing_code_or_state when code/state are absent', async () => {
+		const cb = await app.request('/api/oauth/callback');
+		expect(cb.status).toBe(200);
+		expect(await cb.text()).toContain('missing_code_or_state');
+	});
+
+	it('renders invalid_state for a tampered state param', async () => {
+		const cb = await app.request('/api/oauth/callback?code=abc&state=not.a.valid.state');
+		expect(cb.status).toBe(200);
+		expect(await cb.text()).toContain('invalid_state');
+	});
+
+	it('renders exchange_failed when the token endpoint rejects the code', async () => {
+		const broken = await startGenericOAuthSim({ rejectExchange: true });
+		try {
+			const res = await app.request(`/api/projects/${projectSlug}/oauth/auth-code/start`, {
+				method: 'POST',
+				headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+				body: JSON.stringify({ provider: 'brk', manual_config: manualConfig(broken.baseUrl) }),
+			});
+			const authUrl = ((await res.json()) as { data: { auth_url: string } }).data.auth_url;
+			const authorizeRes = await fetch(authUrl, { redirect: 'manual' });
+			const loc = new URL(authorizeRes.headers.get('location')!);
+			const code = loc.searchParams.get('code')!;
+			const state = loc.searchParams.get('state')!;
+			const cb = await app.request(
+				`/api/oauth/callback?code=${encodeURIComponent(code)}&state=${encodeURIComponent(state)}`,
+			);
+			expect(cb.status).toBe(200);
+			expect(await cb.text()).toContain('exchange_failed');
+		} finally {
+			await broken.destroy();
+		}
+	});
+
+	it('falls back to manual_config.scopes when the token response omits scope', async () => {
+		const noScope = await startGenericOAuthSim({ tokenScope: null });
+		try {
+			const res = await app.request(`/api/projects/${projectSlug}/oauth/auth-code/start`, {
+				method: 'POST',
+				headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+				body: JSON.stringify({ provider: 'noscope', manual_config: manualConfig(noScope.baseUrl) }),
+			});
+			const authUrl = ((await res.json()) as { data: { auth_url: string } }).data.auth_url;
+			const authorizeRes = await fetch(authUrl, { redirect: 'manual' });
+			const loc = new URL(authorizeRes.headers.get('location')!);
+			const code = loc.searchParams.get('code')!;
+			const state = loc.searchParams.get('state')!;
+			const cb = await app.request(
+				`/api/oauth/callback?code=${encodeURIComponent(code)}&state=${encodeURIComponent(state)}`,
+			);
+			expect(cb.status).toBe(200);
+			const conn = await db.query<{ scopes: string[] }>(
+				`SELECT scopes FROM oauth_connections WHERE provider = 'noscope' ORDER BY created_at DESC LIMIT 1`,
+			);
+			expect(conn.rows[0].scopes).toEqual(['read', 'write']);
+		} finally {
+			await noScope.destroy();
+		}
+	});
+});
+
+describe('POST /projects/:projectId/auth-start (connector error branches)', () => {
+	it('404s for an unknown connector id', async () => {
+		const res = await app.request(`/api/projects/${projectSlug}/auth-start`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ connector_id: crypto.randomUUID() }),
+		});
+		expect(res.status).toBe(404);
+	});
+
+	it('400s when connector_id is missing', async () => {
+		const res = await app.request(`/api/projects/${projectSlug}/auth-start`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({}),
+		});
+		expect(res.status).toBe(400);
+	});
+
+	it('400 CONNECTOR_REVOKED for a revoked connector', async () => {
+		const { row } = await createOrFetchConnector(db, {
+			name: 'revoked-conn',
+			displayName: 'Revoked',
+			mcpUrl: `${sim.baseUrl}/mcp`,
+			mcpTransport: 'http',
+		});
+		await db.query(`UPDATE mcp_connections SET revoked_at = now() WHERE id = $1`, [row.id]);
+		const res = await app.request(`/api/projects/${projectSlug}/auth-start`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ connector_id: row.id }),
+		});
+		expect(res.status).toBe(400);
+		expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+			'CONNECTOR_REVOKED',
+		);
+	});
+
+	it('400 when the connector is not a saas MCP connector', async () => {
+		const ins = await db.query<{ id: string }>(
+			`INSERT INTO mcp_connections (name, display_name, kind, config, install_status)
+			 VALUES ('local-kind', 'Local', 'local'::mcp_connection_kind, '{}'::jsonb, 'installed')
+			 RETURNING id`,
+		);
+		const res = await app.request(`/api/projects/${projectSlug}/auth-start`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ connector_id: ins.rows[0].id }),
+		});
+		expect(res.status).toBe(400);
+		expect(((await res.json()) as { error: { message: string } }).error.message).toMatch(
+			/saas MCP connectors/,
+		);
+	});
+
+	it('400 when a saas connector has no MCP server url', async () => {
+		const ins = await db.query<{ id: string }>(
+			`INSERT INTO mcp_connections (name, display_name, kind, config, install_status)
+			 VALUES ('nourl-conn', 'NoUrl', 'saas'::mcp_connection_kind, '{}'::jsonb, 'installed')
+			 RETURNING id`,
+		);
+		const res = await app.request(`/api/projects/${projectSlug}/auth-start`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ connector_id: ins.rows[0].id }),
+		});
+		expect(res.status).toBe(400);
+		expect(((await res.json()) as { error: { message: string } }).error.message).toMatch(
+			/no MCP server url/,
+		);
+	});
+});
+
+describe('GET /oauth/mcp-callback (error branches)', () => {
+	it('renders missing_code_or_state when params are absent', async () => {
+		const cb = await app.request('/api/oauth/mcp-callback');
+		expect(cb.status).toBe(200);
+		expect(await cb.text()).toContain('missing_code_or_state');
+	});
+
+	it('surfaces the provider error code', async () => {
+		const cb = await app.request('/api/oauth/mcp-callback?error=server_error');
+		expect(cb.status).toBe(200);
+		expect(await cb.text()).toContain('server_error');
+	});
+
+	it('renders invalid_state for a bad state param', async () => {
+		const cb = await app.request('/api/oauth/mcp-callback?code=abc&state=bogus.sig');
+		expect(cb.status).toBe(200);
+		expect(await cb.text()).toContain('invalid_state');
+	});
+});
+
+describe('oauth-connections delete + scope-status not-found', () => {
+	it('404s deleting a connection that does not exist', async () => {
+		const res = await app.request(
+			`/api/projects/${projectSlug}/oauth-connections/${crypto.randomUUID()}`,
+			{ method: 'DELETE', headers: authHeader(token) },
+		);
+		expect(res.status).toBe(404);
+	});
+
+	it('scope-status 404s for an unknown connection', async () => {
+		const res = await app.request(
+			`/api/projects/${projectSlug}/oauth-connections/${crypto.randomUUID()}/scope-status`,
+			{ headers: authHeader(token) },
+		);
+		expect(res.status).toBe(404);
+	});
+});
+
+describe('POST /projects/:projectId/auth-start (DCR discovery/registration failures)', () => {
+	it('marks the connector failed + returns OAUTH_DCR_UNSUPPORTED when the AS omits a registration endpoint', async () => {
+		const fake = await startFakeMcpServer({ noRegistrationEndpoint: true });
+		try {
+			const { row } = await createOrFetchConnector(db, {
+				name: 'no-dcr',
+				displayName: 'NoDCR',
+				mcpUrl: `${fake.url}/mcp`,
+				mcpTransport: 'http',
+			});
+			const res = await app.request(`/api/projects/${projectSlug}/auth-start`, {
+				method: 'POST',
+				headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+				body: JSON.stringify({ connector_id: row.id }),
+			});
+			expect(res.status).toBe(400);
+			expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+				'OAUTH_DCR_UNSUPPORTED',
+			);
+			const connector = await getConnector(db, row.id);
+			expect(connector?.auth_error).toMatch(/registration_endpoint/);
+		} finally {
+			await fake.close();
+		}
+	});
+
+	it('marks the connector failed + returns OAUTH_DCR_FAILED when registration is rejected', async () => {
+		const fake = await startFakeMcpServer({ rejectDcr: true });
+		try {
+			const { row } = await createOrFetchConnector(db, {
+				name: 'bad-dcr',
+				displayName: 'BadDCR',
+				mcpUrl: `${fake.url}/mcp`,
+				mcpTransport: 'http',
+			});
+			const res = await app.request(`/api/projects/${projectSlug}/auth-start`, {
+				method: 'POST',
+				headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+				body: JSON.stringify({ connector_id: row.id }),
+			});
+			expect(res.status).toBe(503);
+			expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+				'OAUTH_DCR_FAILED',
+			);
+			const connector = await getConnector(db, row.id);
+			expect(connector?.auth_error).toMatch(/DCR:/);
+		} finally {
+			await fake.close();
+		}
+	});
+});

--- a/packages/server/test/project-intake-extended.test.ts
+++ b/packages/server/test/project-intake-extended.test.ts
@@ -1,0 +1,202 @@
+import type { PGlite } from '@electric-sql/pglite';
+import { TaskStatus } from '@hezo/shared';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+	completeProjectIntakeAfterProvisioning,
+	createProjectIntake,
+	getOpenProjectIntakeForHome,
+	getOpenProjectIntakeTasks,
+} from '../src/services/project-intake';
+import { safeClose } from './helpers';
+import { createTestApp } from './helpers/app';
+
+let db: PGlite;
+
+beforeAll(async () => {
+	// createTestApp seeds the HQ team + CEO so loadCoordinationContext resolves.
+	const ctx = await createTestApp();
+	db = ctx.db;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+beforeEach(async () => {
+	// Each test starts from a clean intake slate (intakes all live in HQ).
+	await db.query(`DELETE FROM task_comments WHERE task_id IN
+		(SELECT id FROM tasks WHERE labels @> '["project-intake"]'::jsonb)`);
+	await db.query(`DELETE FROM tasks WHERE labels @> '["project-intake"]'::jsonb`);
+	await db.query('DELETE FROM agent_wakeup_requests');
+});
+
+describe('createProjectIntake (service)', () => {
+	it('attaches the initial project plan as a second CEO comment', async () => {
+		const result = await createProjectIntake(db, {
+			name: 'Planned App',
+			description: 'An app with a plan',
+			initialProjectPlan: '# The Plan\n\nDo the thing.',
+			baselineTeamTypeName: 'Startup',
+			baselineTemplateId: '00000000-0000-0000-0000-0000000000aa',
+		});
+		expect(result).not.toBeNull();
+
+		const comments = await db.query<{ content: { text: string } }>(
+			`SELECT content FROM task_comments WHERE task_id = $1 ORDER BY created_at ASC`,
+			[result!.intakeTaskId],
+		);
+		// Greeting + plan attachment.
+		expect(comments.rows.length).toBe(2);
+		expect(comments.rows[0].content.text).toContain("I'm the CEO");
+		expect(comments.rows[1].content.text).toContain('Project plan attached');
+		expect(comments.rows[1].content.text).toContain('Do the thing.');
+
+		// The greeting mentions the suggested team type and the plan attachment.
+		expect(comments.rows[0].content.text).toContain('Startup');
+		expect(comments.rows[0].content.text).toContain("I'll attach your project plan");
+
+		// An Assignment wakeup fired for the CEO.
+		const wakeup = await db.query<{ c: number }>(
+			`SELECT count(*)::int AS c FROM agent_wakeup_requests
+			 WHERE member_id = $1 AND source = 'assignment'::wakeup_source`,
+			[result!.ceoMemberId],
+		);
+		expect(wakeup.rows[0].c).toBeGreaterThan(0);
+	});
+
+	it('records a clone baseline line when a source team id is supplied', async () => {
+		const result = await createProjectIntake(db, {
+			name: 'Cloned App',
+			description: 'desc',
+			initialProjectPlan: null,
+			baselineSourceTeamId: '11111111-1111-1111-1111-111111111111',
+			baselineTeamTypeName: 'Existing Co',
+		});
+		expect(result).not.toBeNull();
+		const task = await db.query<{ description: string }>(
+			`SELECT description FROM tasks WHERE id = $1`,
+			[result!.intakeTaskId],
+		);
+		expect(task.rows[0].description).toContain('clone of "Existing Co"');
+		expect(task.rows[0].description).toContain('11111111-1111-1111-1111-111111111111');
+	});
+});
+
+describe('getOpenProjectIntakeForHome / getOpenProjectIntakeTasks', () => {
+	it('returns null when there are no open intakes', async () => {
+		expect(await getOpenProjectIntakeForHome(db)).toBeNull();
+		expect(await getOpenProjectIntakeTasks(db)).toEqual([]);
+	});
+
+	it('surfaces the first open intake enriched with the CEO greeting + identity', async () => {
+		const created = await createProjectIntake(db, {
+			name: 'Home App',
+			description: 'home desc',
+			initialProjectPlan: null,
+		});
+		expect(created).not.toBeNull();
+
+		const home = await getOpenProjectIntakeForHome(db);
+		expect(home).not.toBeNull();
+		expect(home!.task_id).toBe(created!.intakeTaskId);
+		expect(home!.project_slug).toBe('hq');
+		expect(home!.greeting).toContain("I'm the CEO");
+		expect(home!.ceo_member_id).toBeTruthy();
+		expect(home!.ceo_title).toBeTruthy();
+
+		const all = await getOpenProjectIntakeTasks(db);
+		expect(all.length).toBe(1);
+		expect(all[0].task_id).toBe(created!.intakeTaskId);
+	});
+
+	it('excludes intakes once their task reaches a terminal status', async () => {
+		const created = await createProjectIntake(db, {
+			name: 'Done App',
+			description: 'will be closed',
+			initialProjectPlan: null,
+		});
+		await db.query(`UPDATE tasks SET status = $1::task_status WHERE id = $2`, [
+			TaskStatus.Done,
+			created!.intakeTaskId,
+		]);
+		expect(await getOpenProjectIntakeTasks(db)).toEqual([]);
+		expect(await getOpenProjectIntakeForHome(db)).toBeNull();
+	});
+});
+
+describe('completeProjectIntakeAfterProvisioning', () => {
+	it('posts a setup-complete comment and moves the intake to Done', async () => {
+		const created = await createProjectIntake(db, {
+			name: 'Ship It',
+			description: 'desc',
+			initialProjectPlan: null,
+		});
+
+		const { summaryComment, task } = await completeProjectIntakeAfterProvisioning(
+			db,
+			created!.intakeTaskId,
+			'Ship It',
+			'ship-it',
+		);
+
+		expect(task).not.toBeNull();
+		expect((task as { status: string }).status).toBe(TaskStatus.Done);
+		expect(summaryComment).not.toBeNull();
+		expect((summaryComment!.content as { text: string }).text).toContain('Setup complete');
+		expect((summaryComment!.content as { text: string }).text).toContain('ship-it');
+
+		// The intake task is terminal in the DB.
+		const row = await db.query<{ status: string }>(
+			`SELECT status::text AS status FROM tasks WHERE id = $1`,
+			[created!.intakeTaskId],
+		);
+		expect(row.rows[0].status).toBe(TaskStatus.Done);
+
+		// A status-change system comment was recorded (recordStatusChange).
+		const sys = await db.query<{ c: number }>(
+			`SELECT count(*)::int AS c FROM task_comments
+			 WHERE task_id = $1 AND content_type = 'system'::comment_content_type`,
+			[created!.intakeTaskId],
+		);
+		expect(sys.rows[0].c).toBeGreaterThan(0);
+	});
+
+	it('is a no-op when the intake is already terminal (idempotent)', async () => {
+		const created = await createProjectIntake(db, {
+			name: 'Already Closed',
+			description: 'desc',
+			initialProjectPlan: null,
+		});
+		await db.query(`UPDATE tasks SET status = $1::task_status WHERE id = $2`, [
+			TaskStatus.Cancelled,
+			created!.intakeTaskId,
+		]);
+
+		const { summaryComment, task } = await completeProjectIntakeAfterProvisioning(
+			db,
+			created!.intakeTaskId,
+			'Already Closed',
+			'already-closed',
+		);
+		expect(summaryComment).toBeNull();
+		expect(task).toBeNull();
+
+		// Status stays Cancelled — not flipped to Done.
+		const row = await db.query<{ status: string }>(
+			`SELECT status::text AS status FROM tasks WHERE id = $1`,
+			[created!.intakeTaskId],
+		);
+		expect(row.rows[0].status).toBe(TaskStatus.Cancelled);
+	});
+
+	it('is a no-op for an unknown task id', async () => {
+		const { summaryComment, task } = await completeProjectIntakeAfterProvisioning(
+			db,
+			'00000000-0000-0000-0000-000000000000',
+			'Ghost',
+			'ghost',
+		);
+		expect(summaryComment).toBeNull();
+		expect(task).toBeNull();
+	});
+});

--- a/packages/server/test/projects-routes-extended.test.ts
+++ b/packages/server/test/projects-routes-extended.test.ts
@@ -1,0 +1,306 @@
+import type { PGlite } from '@electric-sql/pglite';
+import { ContainerStatus } from '@hezo/shared';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Env } from '../src/lib/types';
+import { signAdminJwt } from '../src/middleware/auth';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
+
+let app: Hono<Env>;
+let db: PGlite;
+let token: string;
+let teamId: string;
+let projectId: string;
+let projectSlug: string;
+let memberUserToken: string;
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+
+	const teamRes = await createTestTeam(db, { name: 'Projects Ext Co' });
+	teamId = (await teamRes.json()).data.id;
+
+	// A non-superuser admin who is a member of this team — exercises the
+	// board-user-filtered branch of GET /projects.
+	const memberUser = await db.query<{ id: string }>(
+		"INSERT INTO users (display_name, is_superuser) VALUES ('Board User', false) RETURNING id",
+	);
+	const memberUserId = memberUser.rows[0].id;
+	const member = await db.query<{ id: string }>(
+		`INSERT INTO members (team_id, member_type, display_name)
+		 VALUES ($1, 'user', 'Board User') RETURNING id`,
+		[teamId],
+	);
+	await db.query(`INSERT INTO member_users (id, user_id) VALUES ($1, $2)`, [
+		member.rows[0].id,
+		memberUserId,
+	]);
+	memberUserToken = await signAdminJwt(ctx.masterKeyManager, memberUserId);
+	const projRes = await createTestProject(db, teamId, {
+		name: 'Ext Project',
+		description: 'A project for exercising the route edges.',
+	});
+	const proj = (await projRes.json()).data;
+	projectId = proj.id;
+	projectSlug = proj.slug;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+async function patch(body: Record<string, unknown>) {
+	const res = await app.request(`/api/projects/${projectSlug}`, {
+		method: 'PATCH',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify(body),
+	});
+	return { status: res.status, body: (await res.json()) as Record<string, unknown> };
+}
+
+describe('GET /projects — board-user filtered list', () => {
+	it('returns only the projects of teams the non-superuser belongs to', async () => {
+		const res = await app.request('/api/projects', { headers: authHeader(memberUserToken) });
+		expect(res.status).toBe(200);
+		const data = (await res.json()).data as Array<{ team_id: string }>;
+		expect(data.length).toBeGreaterThan(0);
+		// The board user only sees projects in their team, not HQ or other teams.
+		expect(data.every((p) => p.team_id === teamId)).toBe(true);
+	});
+});
+
+describe('PATCH /projects/:projectId — validation + reshaping', () => {
+	it('renames the project and regenerates a unique slug', async () => {
+		const { status, body } = await patch({ name: 'Renamed Ext Project' });
+		expect(status).toBe(200);
+		const data = body.data as { name: string; slug: string };
+		expect(data.name).toBe('Renamed Ext Project');
+		expect(data.slug).toBe('renamed-ext-project');
+		projectSlug = data.slug; // keep the handle current for later tests
+	});
+
+	it('rejects a non-integer max_concurrent_runs', async () => {
+		const { status, body } = await patch({ max_concurrent_runs: 0 });
+		expect(status).toBe(400);
+		expect((body.error as { message: string }).message).toMatch(/max_concurrent_runs/);
+	});
+
+	it('accepts a valid max_concurrent_runs', async () => {
+		const { status, body } = await patch({ max_concurrent_runs: 4 });
+		expect(status).toBe(200);
+		expect((body.data as { max_concurrent_runs: number }).max_concurrent_runs).toBe(4);
+	});
+
+	it('rejects a memory_limit_gib below 1', async () => {
+		const { status } = await patch({ memory_limit_gib: 0 });
+		expect(status).toBe(400);
+	});
+
+	it('accepts a valid memory_limit_gib', async () => {
+		const { status, body } = await patch({ memory_limit_gib: 8 });
+		expect(status).toBe(200);
+		expect((body.data as { memory_limit_gib: number }).memory_limit_gib).toBe(8);
+	});
+
+	it('updates budget windows when consistent', async () => {
+		// weekly ≥ daily×7, monthly ≥ daily×~30.4.
+		const { status, body } = await patch({
+			daily_budget_cents: 1000,
+			weekly_budget_cents: 8000,
+			monthly_budget_cents: 40000,
+		});
+		expect(status).toBe(200);
+		expect((body.data as { daily_budget_cents: number }).daily_budget_cents).toBe(1000);
+	});
+
+	it('rejects an inconsistent budget trio (daily > weekly)', async () => {
+		const { status, body } = await patch({ daily_budget_cents: 9999, weekly_budget_cents: 100 });
+		expect(status).toBe(400);
+		expect((body.error as { code: string }).code).toBe('INVALID_REQUEST');
+	});
+
+	it('treats an empty PATCH body as a no-op and returns the current project', async () => {
+		const { status, body } = await patch({});
+		expect(status).toBe(200);
+		expect((body.data as { id: string }).id).toBe(projectId);
+	});
+
+	it('404s for a project the caller cannot resolve', async () => {
+		const res = await app.request('/api/projects/does-not-exist-slug', {
+			method: 'PATCH',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ description: 'x' }),
+		});
+		expect(res.status).toBe(404);
+	});
+});
+
+describe('DELETE /projects/:projectId — guards', () => {
+	it('409s when the project still has open tasks', async () => {
+		// The seeded planning task is open.
+		const res = await app.request(`/api/projects/${projectSlug}`, {
+			method: 'DELETE',
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(409);
+		expect(((await res.json()) as { error: { code: string } }).error.code).toBe('CONFLICT');
+	});
+
+	it('403s when deleting the internal HQ project', async () => {
+		// HQ is the only is_internal project; resolve it by slug.
+		const res = await app.request('/api/projects/hq', {
+			method: 'DELETE',
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(403);
+	});
+});
+
+describe('POST /project-intakes — validation branches', () => {
+	async function startIntake(body: Record<string, unknown>) {
+		const res = await app.request('/api/project-intakes', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify(body),
+		});
+		return { status: res.status, body: (await res.json()) as Record<string, unknown> };
+	}
+
+	it('rejects supplying both template_id and source_team_id', async () => {
+		const { status, body } = await startIntake({
+			name: 'Both',
+			description: 'desc',
+			template_id: '11111111-1111-1111-1111-111111111111',
+			source_team_id: '22222222-2222-2222-2222-222222222222',
+		});
+		expect(status).toBe(400);
+		expect((body.error as { message: string }).message).toMatch(
+			/either template_id or source_team_id/,
+		);
+	});
+
+	it('404s for an unknown source_team_id', async () => {
+		const { status } = await startIntake({
+			name: 'Ghost Source',
+			description: 'desc',
+			source_team_id: '33333333-3333-3333-3333-333333333333',
+		});
+		expect(status).toBe(404);
+	});
+
+	it('rejects using the HQ team as a source team', async () => {
+		const hq = await db.query<{ id: string }>(
+			`SELECT t.id FROM teams t
+			 JOIN projects p ON p.team_id = t.id AND p.is_internal = true LIMIT 1`,
+		);
+		const { status, body } = await startIntake({
+			name: 'HQ Clone',
+			description: 'desc',
+			source_team_id: hq.rows[0].id,
+		});
+		expect(status).toBe(400);
+		expect((body.error as { message: string }).message).toMatch(/HQ team cannot be used/);
+	});
+
+	it('records a real source team as the baseline', async () => {
+		const { status, body } = await startIntake({
+			name: 'Clone Of Ext',
+			description: 'desc',
+			source_team_id: teamId,
+		});
+		expect(status).toBe(201);
+		const intake = body.data as { intake_task_id: string };
+		const task = await db.query<{ description: string }>(
+			`SELECT description FROM tasks WHERE id = $1`,
+			[intake.intake_task_id],
+		);
+		// Baseline line names the cloned team.
+		expect(task.rows[0].description).toContain('clone of');
+		// Clean up so the home-intake list stays predictable for other suites.
+		await db.query(`DELETE FROM tasks WHERE id = $1`, [intake.intake_task_id]);
+	});
+});
+
+describe('container lifecycle routes', () => {
+	it('container/start returns NO_CONTAINER when none is provisioned', async () => {
+		const res = await app.request(`/api/projects/${projectSlug}/container/start`, {
+			method: 'POST',
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(400);
+		expect(((await res.json()) as { error: { code: string } }).error.code).toBe('NO_CONTAINER');
+	});
+
+	it('container/start starts the container when one exists (stub docker)', async () => {
+		await db.query(
+			`UPDATE projects SET container_id = 'stub-container',
+			        container_status = 'stopped'::container_status WHERE id = $1`,
+			[projectId],
+		);
+		const res = await app.request(`/api/projects/${projectSlug}/container/start`, {
+			method: 'POST',
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		expect(
+			((await res.json()) as { data: { container_status: string } }).data.container_status,
+		).toBe(ContainerStatus.Running);
+		const row = await db.query<{ container_status: string }>(
+			`SELECT container_status::text AS container_status FROM projects WHERE id = $1`,
+			[projectId],
+		);
+		expect(row.rows[0].container_status).toBe(ContainerStatus.Running);
+	});
+
+	it('container/stop sets stopped immediately when no container id is present', async () => {
+		await db.query(
+			`UPDATE projects SET container_id = NULL,
+			        container_status = 'running'::container_status WHERE id = $1`,
+			[projectId],
+		);
+		const res = await app.request(`/api/projects/${projectSlug}/container/stop`, {
+			method: 'POST',
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		expect(
+			((await res.json()) as { data: { container_status: string } }).data.container_status,
+		).toBe(ContainerStatus.Stopped);
+	});
+
+	it('container/stop transitions to stopping when a container exists', async () => {
+		await db.query(
+			`UPDATE projects SET container_id = 'stub-container',
+			        container_status = 'running'::container_status WHERE id = $1`,
+			[projectId],
+		);
+		const res = await app.request(`/api/projects/${projectSlug}/container/stop`, {
+			method: 'POST',
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		expect(
+			((await res.json()) as { data: { container_status: string } }).data.container_status,
+		).toBe(ContainerStatus.Stopping);
+	});
+
+	it('container/rebuild kicks off a rebuild and reports creating', async () => {
+		const res = await app.request(`/api/projects/${projectSlug}/container/rebuild`, {
+			method: 'POST',
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		expect(
+			((await res.json()) as { data: { container_status: string } }).data.container_status,
+		).toBe(ContainerStatus.Creating);
+		const row = await db.query<{ container_status: string }>(
+			`SELECT container_status::text AS container_status FROM projects WHERE id = $1`,
+			[projectId],
+		);
+		expect(row.rows[0].container_status).toBe(ContainerStatus.Creating);
+	});
+});

--- a/packages/server/test/repo-setup-ensure.test.ts
+++ b/packages/server/test/repo-setup-ensure.test.ts
@@ -1,0 +1,149 @@
+import type { PGlite } from '@electric-sql/pglite';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { enqueueRepoSetupResumeWakeups, ensureRepoSetupAction } from '../src/services/repo-setup';
+import { safeClose } from './helpers';
+import { createTestDbWithMigrations } from './helpers/db';
+
+let db: PGlite;
+
+async function seedTeamProjectTask(): Promise<{
+	teamId: string;
+	projectId: string;
+	taskId: string;
+}> {
+	const team = await db.query<{ id: string }>(
+		`INSERT INTO teams (name, slug) VALUES ('Ensure Co', 'ensure-co') RETURNING id`,
+	);
+	const teamId = team.rows[0].id;
+	const project = await db.query<{ id: string }>(
+		`INSERT INTO projects (team_id, name, slug, task_prefix)
+		 VALUES ($1, 'Ensure Project', 'ensure-project', 'E') RETURNING id`,
+		[teamId],
+	);
+	const projectId = project.rows[0].id;
+	const task = await db.query<{ id: string }>(
+		`INSERT INTO tasks (team_id, project_id, number, identifier, title)
+		 VALUES ($1, $2, 1, 'E-1', 'Needs repo') RETURNING id`,
+		[teamId, projectId],
+	);
+	return { teamId, projectId, taskId: task.rows[0].id };
+}
+
+beforeEach(async () => {
+	db = await createTestDbWithMigrations();
+});
+
+afterEach(async () => {
+	await safeClose(db);
+});
+
+describe('ensureRepoSetupAction', () => {
+	it('creates a pending designated-repo approval and a setup-repo action comment on first call', async () => {
+		const { teamId, projectId, taskId } = await seedTeamProjectTask();
+
+		const result = await ensureRepoSetupAction(db, { teamId, projectId, taskId });
+
+		expect(result.approvalCreated).toBe(true);
+		expect(result.commentCreated).toBe(true);
+		expect(result.approvalId).toBeTruthy();
+		expect(result.commentId).toBeTruthy();
+		// Freshly-created rows are exposed for broadcast.
+		expect(result.approvalRow?.id).toBe(result.approvalId);
+		expect(result.commentRow?.id).toBe(result.commentId);
+
+		const approval = await db.query<{
+			type: string;
+			status: string;
+			payload: Record<string, string>;
+		}>(`SELECT type::text AS type, status::text AS status, payload FROM approvals WHERE id = $1`, [
+			result.approvalId,
+		]);
+		expect(approval.rows[0].type).toBe('designated_repo_request');
+		expect(approval.rows[0].status).toBe('pending');
+		expect(approval.rows[0].payload.project_id).toBe(projectId);
+		expect(approval.rows[0].payload.task_id).toBe(taskId);
+
+		const comment = await db.query<{ content_type: string; content: Record<string, string> }>(
+			`SELECT content_type::text AS content_type, content FROM task_comments WHERE id = $1`,
+			[result.commentId],
+		);
+		expect(comment.rows[0].content_type).toBe('action');
+		expect(comment.rows[0].content.kind).toBe('setup_repo');
+		expect(comment.rows[0].content.approval_id).toBe(result.approvalId);
+	});
+
+	it('is idempotent on the same task: reuses the approval + comment without creating duplicates', async () => {
+		const { teamId, projectId, taskId } = await seedTeamProjectTask();
+
+		const first = await ensureRepoSetupAction(db, { teamId, projectId, taskId });
+		const second = await ensureRepoSetupAction(db, { teamId, projectId, taskId });
+
+		expect(second.approvalId).toBe(first.approvalId);
+		expect(second.commentId).toBe(first.commentId);
+		expect(second.approvalCreated).toBe(false);
+		expect(second.commentCreated).toBe(false);
+		// No fresh rows surfaced when nothing was created.
+		expect(second.approvalRow).toBeUndefined();
+		expect(second.commentRow).toBeUndefined();
+
+		const approvals = await db.query<{ c: number }>(
+			`SELECT count(*)::int AS c FROM approvals WHERE team_id = $1`,
+			[teamId],
+		);
+		expect(approvals.rows[0].c).toBe(1);
+		const comments = await db.query<{ c: number }>(
+			`SELECT count(*)::int AS c FROM task_comments WHERE task_id = $1`,
+			[taskId],
+		);
+		expect(comments.rows[0].c).toBe(1);
+	});
+
+	it('reuses an existing pending approval but creates a fresh action comment on a second task', async () => {
+		const { teamId, projectId, taskId } = await seedTeamProjectTask();
+		const secondTask = await db.query<{ id: string }>(
+			`INSERT INTO tasks (team_id, project_id, number, identifier, title)
+			 VALUES ($1, $2, 2, 'E-2', 'Also needs repo') RETURNING id`,
+			[teamId, projectId],
+		);
+
+		const first = await ensureRepoSetupAction(db, { teamId, projectId, taskId });
+		const second = await ensureRepoSetupAction(db, {
+			teamId,
+			projectId,
+			taskId: secondTask.rows[0].id,
+		});
+
+		// Same project-level approval is shared; a new action comment lands on task 2.
+		expect(second.approvalId).toBe(first.approvalId);
+		expect(second.approvalCreated).toBe(false);
+		expect(second.commentCreated).toBe(true);
+		expect(second.commentId).not.toBe(first.commentId);
+
+		const approvals = await db.query<{ c: number }>(
+			`SELECT count(*)::int AS c FROM approvals WHERE team_id = $1`,
+			[teamId],
+		);
+		expect(approvals.rows[0].c).toBe(1);
+	});
+});
+
+describe('enqueueRepoSetupResumeWakeups (edge cases)', () => {
+	it('skips deferred wakeups that carry no task id', async () => {
+		const { teamId } = await seedTeamProjectTask();
+		const member = await db.query<{ id: string }>(
+			`INSERT INTO members (team_id, member_type, display_name)
+			 VALUES ($1, 'agent', 'Solo') RETURNING id`,
+			[teamId],
+		);
+
+		await enqueueRepoSetupResumeWakeups(db, teamId, 'repo-1', 'approval-1', [
+			{ memberId: member.rows[0].id, taskId: '', wakeupId: 'w-1' },
+		]);
+
+		const resumed = await db.query<{ c: number }>(
+			`SELECT count(*)::int AS c FROM agent_wakeup_requests WHERE team_id = $1`,
+			[teamId],
+		);
+		expect(resumed.rows[0].c).toBe(0);
+	});
+});

--- a/packages/server/test/repos-routes-extended.test.ts
+++ b/packages/server/test/repos-routes-extended.test.ts
@@ -1,0 +1,244 @@
+import type { PGlite } from '@electric-sql/pglite';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { MasterKeyManager } from '../src/crypto/master-key';
+import type { Env } from '../src/lib/types';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
+import { createGitHubSim, type GitHubSim } from './helpers/github-sim';
+
+/**
+ * Extends repos-create-github.test.ts with the request-validation branches and
+ * the org/repo listing endpoints in routes/repos.ts that the happy-path tests
+ * don't exercise: mode validation, OAuth-connection resolution failures, token
+ * availability, REPO_NOT_ACCESSIBLE, and the two GitHub list proxies — all
+ * driven against the local GitHub simulator.
+ */
+
+let app: Hono<Env>;
+let db: PGlite;
+let masterKeyManager: MasterKeyManager;
+let token: string;
+let teamId: string;
+let projectId: string;
+let githubConnId: string;
+let nonGithubConnId: string;
+let sim: GitHubSim;
+
+let prevApi: string | undefined;
+const accessToken = 'gho_repos_ext_token';
+
+async function seedGitHubOAuthConnection(login: string): Promise<string> {
+	const { encrypt } = await import('../src/crypto/encryption');
+	const key = masterKeyManager.getKey();
+	if (!key) throw new Error('master key not available');
+	const encrypted = encrypt(accessToken, key);
+
+	const secretRes = await db.query<{ id: string }>(
+		`INSERT INTO secrets (name, encrypted_value, category, allowed_hosts)
+		 VALUES ($1, $2, 'api_token', ARRAY['github.com'])
+		 RETURNING id`,
+		[`OAUTH_GITHUB_${Math.random().toString(16).slice(2, 10)}`, encrypted],
+	);
+	const connRes = await db.query<{ id: string }>(
+		`INSERT INTO oauth_connections (provider, provider_account_id, provider_account_label, access_token_secret_id, scopes)
+		 VALUES ('github', $1, $2, $3, ARRAY['repo','read:org'])
+		 RETURNING id`,
+		['9001', login, secretRes.rows[0].id],
+	);
+	return connRes.rows[0].id;
+}
+
+beforeAll(async () => {
+	sim = await createGitHubSim();
+	prevApi = process.env.GITHUB_API_BASE_URL;
+	process.env.GITHUB_API_BASE_URL = sim.baseUrl;
+
+	sim.seed({
+		token: accessToken,
+		user: { id: 9001, login: 'octo-ext', avatar_url: 'http://a/u', email: 'octo@e2e' },
+		orgs: [{ login: 'acme-org', avatar_url: 'http://a/o' }],
+		repos: [
+			{
+				id: 1,
+				name: 'visible-repo',
+				full_name: 'octo-ext/visible-repo',
+				owner: { login: 'octo-ext' },
+				private: false,
+				default_branch: 'main',
+				clone_url: 'https://github.com/octo-ext/visible-repo.git',
+				ssh_url: 'git@github.com:octo-ext/visible-repo.git',
+			},
+			{
+				id: 2,
+				name: 'org-repo',
+				full_name: 'acme-org/org-repo',
+				owner: { login: 'acme-org' },
+				private: true,
+				default_branch: 'main',
+				clone_url: 'https://github.com/acme-org/org-repo.git',
+				ssh_url: 'git@github.com:acme-org/org-repo.git',
+			},
+		],
+	});
+
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	masterKeyManager = ctx.masterKeyManager;
+	token = ctx.token;
+
+	const typesRes = await app.request('/api/team-templates', { headers: authHeader(token) });
+	const typeId = (await typesRes.json()).data.find(
+		(t: { name: string }) => t.name === 'Startup',
+	).id;
+	const teamRes = await createTestTeam(db, { name: 'Repos Ext Co', template_id: typeId });
+	teamId = (await teamRes.json()).data.id;
+
+	const projectRes = await createTestProject(db, teamId, { name: 'Repos Ext Project' });
+	projectId = (await projectRes.json()).data.id;
+
+	githubConnId = await seedGitHubOAuthConnection('octo-ext');
+
+	// A non-GitHub oauth connection to exercise the provider mismatch branch.
+	const secretRes = await db.query<{ id: string }>(
+		`INSERT INTO secrets (name, encrypted_value) VALUES ('OAUTH_OTHER_X', 'enc') RETURNING id`,
+	);
+	const otherConn = await db.query<{ id: string }>(
+		`INSERT INTO oauth_connections (provider, provider_account_id, provider_account_label, access_token_secret_id)
+		 VALUES ('gitlab', 'acct', 'Other', $1) RETURNING id`,
+		[secretRes.rows[0].id],
+	);
+	nonGithubConnId = otherConn.rows[0].id;
+});
+
+afterAll(async () => {
+	process.env.GITHUB_API_BASE_URL = prevApi;
+	await sim.destroy();
+	await safeClose(db);
+});
+
+describe('POST /repos request validation', () => {
+	const post = (body: unknown) =>
+		app.request(`/api/projects/${projectId}/repos`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify(body),
+		});
+
+	it('rejects an unknown mode', async () => {
+		const res = await post({ mode: 'fork', oauth_connection_id: githubConnId });
+		expect(res.status).toBe(400);
+		expect((await res.json()).error.message).toContain('mode must be');
+	});
+
+	it('rejects mode=create missing owner/name', async () => {
+		const res = await post({ mode: 'create', oauth_connection_id: githubConnId });
+		expect(res.status).toBe(400);
+		expect((await res.json()).error.message).toContain('owner and name are required');
+	});
+
+	it('rejects a link request missing oauth_connection_id', async () => {
+		const res = await post({ mode: 'link', url: 'https://github.com/octo-ext/visible-repo' });
+		expect(res.status).toBe(400);
+		expect((await res.json()).error.message).toContain('oauth_connection_id is required');
+	});
+
+	it('returns 404 for an unknown oauth_connection_id', async () => {
+		const res = await post({
+			mode: 'link',
+			url: 'https://github.com/octo-ext/visible-repo',
+			oauth_connection_id: '00000000-0000-0000-0000-000000000000',
+		});
+		expect(res.status).toBe(404);
+		expect((await res.json()).error.message).toContain('oauth connection not found');
+	});
+
+	it('rejects a non-GitHub oauth connection', async () => {
+		const res = await post({
+			mode: 'link',
+			url: 'https://github.com/octo-ext/visible-repo',
+			oauth_connection_id: nonGithubConnId,
+		});
+		expect(res.status).toBe(400);
+		expect((await res.json()).error.message).toContain('not for GitHub');
+	});
+
+	it('returns 403 REPO_NOT_ACCESSIBLE when the token cannot reach the repo', async () => {
+		const res = await post({
+			mode: 'link',
+			url: 'https://github.com/octo-ext/does-not-exist',
+			oauth_connection_id: githubConnId,
+		});
+		expect(res.status).toBe(403);
+		const body = await res.json();
+		expect(body.error.code).toBe('REPO_NOT_ACCESSIBLE');
+		expect(body.error.message).toContain('octo-ext/does-not-exist');
+	});
+});
+
+describe('GET /oauth-connections/:id/orgs', () => {
+	it('lists the personal account plus orgs', async () => {
+		const res = await app.request(
+			`/api/projects/${projectId}/oauth-connections/${githubConnId}/orgs`,
+			{ headers: authHeader(token) },
+		);
+		expect(res.status).toBe(200);
+		const orgs = (await res.json()).data as Array<{ login: string; is_personal: boolean }>;
+		expect(orgs.find((o) => o.login === 'octo-ext')?.is_personal).toBe(true);
+		expect(orgs.some((o) => o.login === 'acme-org')).toBe(true);
+	});
+
+	it('returns 404 for a non-GitHub connection', async () => {
+		const res = await app.request(
+			`/api/projects/${projectId}/oauth-connections/${nonGithubConnId}/orgs`,
+			{ headers: authHeader(token) },
+		);
+		expect(res.status).toBe(404);
+	});
+});
+
+describe('GET /oauth-connections/:id/repos', () => {
+	it('requires the owner query parameter', async () => {
+		const res = await app.request(
+			`/api/projects/${projectId}/oauth-connections/${githubConnId}/repos`,
+			{ headers: authHeader(token) },
+		);
+		expect(res.status).toBe(400);
+		expect((await res.json()).error.message).toContain('owner query parameter is required');
+	});
+
+	it('lists the authenticated user own repos', async () => {
+		const res = await app.request(
+			`/api/projects/${projectId}/oauth-connections/${githubConnId}/repos?owner=octo-ext`,
+			{ headers: authHeader(token) },
+		);
+		expect(res.status).toBe(200);
+		const repos = (await res.json()).data as Array<{ name: string }>;
+		expect(repos.some((r) => r.name === 'visible-repo')).toBe(true);
+	});
+
+	it('lists org repos and honours the q filter', async () => {
+		const res = await app.request(
+			`/api/projects/${projectId}/oauth-connections/${githubConnId}/repos?owner=acme-org&q=org`,
+			{ headers: authHeader(token) },
+		);
+		expect(res.status).toBe(200);
+		const repos = (await res.json()).data as Array<{ name: string }>;
+		expect(repos.some((r) => r.name === 'org-repo')).toBe(true);
+
+		const noMatch = await app.request(
+			`/api/projects/${projectId}/oauth-connections/${githubConnId}/repos?owner=acme-org&q=zzz`,
+			{ headers: authHeader(token) },
+		);
+		expect(((await noMatch.json()).data as unknown[]).length).toBe(0);
+	});
+
+	it('returns 404 for a non-GitHub connection', async () => {
+		const res = await app.request(
+			`/api/projects/${projectId}/oauth-connections/${nonGithubConnId}/repos?owner=octo-ext`,
+			{ headers: authHeader(token) },
+		);
+		expect(res.status).toBe(404);
+	});
+});

--- a/packages/server/test/skill-downloader-download.test.ts
+++ b/packages/server/test/skill-downloader-download.test.ts
@@ -1,0 +1,175 @@
+import { createHash } from 'node:crypto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	downloadSkillContent,
+	SkillDownloadError,
+	syncSkillFromUrl,
+} from '../src/services/skill-downloader';
+
+// Drives downloadSkillContent / syncSkillFromUrl by stubbing the global fetch.
+// No real network is touched.
+
+const realFetch = globalThis.fetch;
+const realNodeEnv = process.env.NODE_ENV;
+
+function mockResponse(opts: {
+	ok?: boolean;
+	status?: number;
+	contentLength?: string | null;
+	body?: string;
+}): Response {
+	const body = opts.body ?? '';
+	const headers = new Headers();
+	if (opts.contentLength !== null && opts.contentLength !== undefined) {
+		headers.set('content-length', opts.contentLength);
+	}
+	return {
+		ok: opts.ok ?? true,
+		status: opts.status ?? 200,
+		headers,
+		arrayBuffer: async () => new TextEncoder().encode(body).buffer as ArrayBuffer,
+	} as unknown as Response;
+}
+
+afterEach(() => {
+	globalThis.fetch = realFetch;
+	if (realNodeEnv === undefined) delete process.env.NODE_ENV;
+	else process.env.NODE_ENV = realNodeEnv;
+	vi.restoreAllMocks();
+});
+
+describe('downloadSkillContent — happy path', () => {
+	it('fetches content and returns the sha256 hash', async () => {
+		const content = '# A skill\n\nbody text';
+		const fetchMock = vi.fn(async () => mockResponse({ body: content }));
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const result = await downloadSkillContent('https://example.com/skill.md');
+		expect(result.content).toBe(content);
+		expect(result.hash).toBe(createHash('sha256').update(content).digest('hex'));
+		// The resolved URL is passed straight through for a non-github host.
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://example.com/skill.md',
+			expect.objectContaining({ redirect: 'follow' }),
+		);
+	});
+
+	it('resolves a github.com blob URL to raw.githubusercontent.com before fetching', async () => {
+		const fetchMock = vi.fn(async () => mockResponse({ body: 'x' }));
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		await downloadSkillContent('https://github.com/owner/repo/blob/main/skills/x.md');
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://raw.githubusercontent.com/owner/repo/main/skills/x.md',
+			expect.anything(),
+		);
+	});
+
+	it('syncSkillFromUrl delegates to downloadSkillContent', async () => {
+		const fetchMock = vi.fn(async () => mockResponse({ body: 'sync-body' }));
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const result = await syncSkillFromUrl('https://example.com/skill.md');
+		expect(result.content).toBe('sync-body');
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('downloadSkillContent — scheme enforcement', () => {
+	it('rejects an http URL in production with forbidden_scheme', async () => {
+		process.env.NODE_ENV = 'production';
+		const fetchMock = vi.fn(async () => mockResponse({ body: 'x' }));
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		await expect(downloadSkillContent('http://example.com/skill.md')).rejects.toMatchObject({
+			reason: 'forbidden_scheme',
+		});
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('allows an http URL outside production', async () => {
+		process.env.NODE_ENV = 'test';
+		const fetchMock = vi.fn(async () => mockResponse({ body: 'ok' }));
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const result = await downloadSkillContent('http://example.com/skill.md');
+		expect(result.content).toBe('ok');
+	});
+
+	it('rejects a non-http(s) scheme', async () => {
+		const fetchMock = vi.fn(async () => mockResponse({ body: 'x' }));
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+		await expect(downloadSkillContent('ftp://example.com/skill.md')).rejects.toMatchObject({
+			reason: 'forbidden_scheme',
+		});
+	});
+});
+
+describe('downloadSkillContent — error paths', () => {
+	it('maps a 404 response to not_found', async () => {
+		globalThis.fetch = vi.fn(async () =>
+			mockResponse({ ok: false, status: 404 }),
+		) as unknown as typeof fetch;
+		await expect(downloadSkillContent('https://example.com/missing.md')).rejects.toMatchObject({
+			reason: 'not_found',
+		});
+	});
+
+	it('maps a non-404 error status to network', async () => {
+		globalThis.fetch = vi.fn(async () =>
+			mockResponse({ ok: false, status: 500 }),
+		) as unknown as typeof fetch;
+		await expect(downloadSkillContent('https://example.com/boom.md')).rejects.toMatchObject({
+			reason: 'network',
+		});
+	});
+
+	it('maps a thrown network error to network', async () => {
+		globalThis.fetch = vi.fn(async () => {
+			throw new Error('connection refused');
+		}) as unknown as typeof fetch;
+		const err = await downloadSkillContent('https://example.com/x.md').catch((e) => e);
+		expect(err).toBeInstanceOf(SkillDownloadError);
+		expect(err.reason).toBe('network');
+		expect(err.message).toContain('connection refused');
+	});
+
+	it('maps an AbortError to timeout', async () => {
+		globalThis.fetch = vi.fn(async () => {
+			const e = new Error('aborted');
+			e.name = 'AbortError';
+			throw e;
+		}) as unknown as typeof fetch;
+		await expect(downloadSkillContent('https://example.com/slow.md')).rejects.toMatchObject({
+			reason: 'timeout',
+		});
+	});
+
+	it('rejects when content-length header exceeds the size cap', async () => {
+		globalThis.fetch = vi.fn(async () =>
+			mockResponse({ contentLength: String(512 * 1024 + 1), body: 'small' }),
+		) as unknown as typeof fetch;
+		await expect(downloadSkillContent('https://example.com/big.md')).rejects.toMatchObject({
+			reason: 'too_large',
+		});
+	});
+
+	it('rejects when the actual body exceeds the size cap despite no/short content-length', async () => {
+		const big = 'a'.repeat(512 * 1024 + 10);
+		globalThis.fetch = vi.fn(async () =>
+			mockResponse({ contentLength: null, body: big }),
+		) as unknown as typeof fetch;
+		await expect(downloadSkillContent('https://example.com/sneaky.md')).rejects.toMatchObject({
+			reason: 'too_large',
+		});
+	});
+
+	it('rejects an unparseable URL before fetching (invalid_url)', async () => {
+		const fetchMock = vi.fn();
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+		await expect(downloadSkillContent('not a url')).rejects.toMatchObject({
+			reason: 'invalid_url',
+		});
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+});

--- a/packages/server/test/updates-fetch-error.test.ts
+++ b/packages/server/test/updates-fetch-error.test.ts
@@ -1,0 +1,43 @@
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import type { Env } from '../src/lib/types';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp } from './helpers/app';
+
+// Isolated file: getLatestInfo memoizes for an hour, so the network-failure path
+// must run against a cold cache with no successful fetch ahead of it. A dedicated
+// file gives this its own fresh module instance (vitest isolates per file).
+
+let app: Hono<Env>;
+let db: Awaited<ReturnType<typeof createTestApp>>['db'];
+let token: string;
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+describe('GET /updates/latest — network failure fails soft', () => {
+	it('reports no update (latest=null) when the GitHub release check throws', async () => {
+		const fetchSpy = vi
+			.spyOn(globalThis, 'fetch')
+			.mockRejectedValue(new Error('getaddrinfo ENOTFOUND api.github.com'));
+		try {
+			const res = await app.request('/api/updates/latest', { headers: authHeader(token) });
+			expect(res.status).toBe(200);
+			const body = await res.json();
+			expect(body.latest).toBeNull();
+			expect(body.updateAvailable).toBe(false);
+			expect(body.url).toBeNull();
+			expect(typeof body.current).toBe('string');
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+});

--- a/packages/server/test/updates-routes-extended.test.ts
+++ b/packages/server/test/updates-routes-extended.test.ts
@@ -1,0 +1,91 @@
+import { UpdateState } from '@hezo/shared';
+import type { Hono } from 'hono';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import type { Env } from '../src/lib/types';
+import * as updater from '../src/services/updater';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp } from './helpers/app';
+
+let app: Hono<Env>;
+let db: Awaited<ReturnType<typeof createTestApp>>['db'];
+let token: string;
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+/** Make the latest-release check return an available update deterministically. */
+function mockAvailableUpdate() {
+	return vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+		new Response(
+			JSON.stringify({
+				tag_name: '99.9.9',
+				html_url: 'https://github.com/hezo-ai/hezo/releases/99.9.9',
+			}),
+			{ status: 200, headers: { 'Content-Type': 'application/json' } },
+		),
+	);
+}
+
+describe('GET /updates/status (supervised auto-stage)', () => {
+	it('triggers a background stage and reports canApply=true when supervised', async () => {
+		mockAvailableUpdate();
+		vi.spyOn(updater, 'isSupervisedWorker').mockReturnValue(true);
+		const stageSpy = vi
+			.spyOn(updater, 'ensureUpdateStaged')
+			.mockResolvedValue(
+				undefined as unknown as Awaited<ReturnType<typeof updater.ensureUpdateStaged>>,
+			);
+		vi.spyOn(updater, 'readUpdateState').mockResolvedValue({ state: UpdateState.Idle });
+
+		const res = await app.request('/api/updates/status', { headers: authHeader(token) });
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.canApply).toBe(true);
+		// The auto-stage trigger fired (idempotent in production; here it's stubbed).
+		expect(stageSpy).toHaveBeenCalled();
+	});
+});
+
+describe('POST /updates/download (supervised)', () => {
+	it('kicks off a background download+stage and returns 202 Downloading', async () => {
+		mockAvailableUpdate();
+		vi.spyOn(updater, 'isSupervisedWorker').mockReturnValue(true);
+		const dlSpy = vi.spyOn(updater, 'downloadAndStage').mockResolvedValue(undefined);
+
+		const res = await app.request('/api/updates/download', {
+			method: 'POST',
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(202);
+		const body = (await res.json()) as { data: { state: string; targetVersion: string } };
+		expect(body.data.state).toBe(UpdateState.Downloading);
+		expect(body.data.targetVersion).toBe('99.9.9');
+		expect(dlSpy).toHaveBeenCalledWith('99.9.9', expect.any(String));
+	});
+});
+
+describe('POST /updates/apply (supervised, no exit triggered)', () => {
+	it('returns 409 NO_STAGED_UPDATE when there is no staged update', async () => {
+		vi.spyOn(updater, 'isSupervisedWorker').mockReturnValue(true);
+		vi.spyOn(updater, 'readUpdateState').mockResolvedValue({ state: UpdateState.Idle });
+
+		const res = await app.request('/api/updates/apply', {
+			method: 'POST',
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(409);
+		expect(((await res.json()) as { error: { code: string } }).error.code).toBe('NO_STAGED_UPDATE');
+	});
+});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -8,6 +8,7 @@
 	"main": "./src/index.ts",
 	"scripts": {
 		"build": "tsc",
+		"test": "vitest run",
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
@@ -16,6 +17,8 @@
 		"@scure/bip39": "^1.6.0"
 	},
 	"devDependencies": {
-		"typescript": "^5"
+		"@vitest/coverage-v8": "3.2.4",
+		"typescript": "^5",
+		"vitest": "^3"
 	}
 }

--- a/packages/shared/test/budget.test.ts
+++ b/packages/shared/test/budget.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import {
+	centsToDollars,
+	dollarsToCents,
+	minMonthlyCents,
+	minWeeklyCents,
+	normalizeBudgetWindowsUp,
+	validateBudgetWindows,
+} from '../src/budget';
+
+describe('centsToDollars / dollarsToCents', () => {
+	it('formats cents as fixed-2 dollars', () => {
+		expect(centsToDollars(2000)).toBe('20.00');
+		expect(centsToDollars(199)).toBe('1.99');
+		expect(centsToDollars(0)).toBe('0.00');
+	});
+
+	it('parses dollar strings to non-negative integer cents', () => {
+		expect(dollarsToCents('20')).toBe(2000);
+		expect(dollarsToCents('1.999')).toBe(200);
+		expect(dollarsToCents('')).toBe(0);
+		expect(dollarsToCents('abc')).toBe(0);
+		expect(dollarsToCents('-5')).toBe(0);
+	});
+});
+
+describe('window floors', () => {
+	it('minWeeklyCents is daily × 7, or 0 when daily is unlimited', () => {
+		expect(minWeeklyCents(100)).toBe(700);
+		expect(minWeeklyCents(0)).toBe(0);
+	});
+
+	it('minMonthlyCents takes the larger of the daily/weekly implied floors', () => {
+		expect(minMonthlyCents(100, 0)).toBe(3042); // ceil(100 * 365/12)
+		expect(minMonthlyCents(0, 1000)).toBe(4334); // ceil(1000 * 52/12)
+		expect(minMonthlyCents(0, 0)).toBe(0);
+	});
+});
+
+describe('validateBudgetWindows', () => {
+	it('returns no violations for a coherent trio (or all-disabled)', () => {
+		expect(
+			validateBudgetWindows({
+				daily_budget_cents: 100,
+				weekly_budget_cents: 700,
+				monthly_budget_cents: 3042,
+			}),
+		).toEqual([]);
+		expect(
+			validateBudgetWindows({
+				daily_budget_cents: 0,
+				weekly_budget_cents: 0,
+				monthly_budget_cents: 0,
+			}),
+		).toEqual([]);
+	});
+
+	it('flags a weekly budget below the daily-implied floor', () => {
+		const v = validateBudgetWindows({
+			daily_budget_cents: 100,
+			weekly_budget_cents: 500,
+			monthly_budget_cents: 0,
+		});
+		expect(v).toHaveLength(1);
+		expect(v[0]).toMatchObject({ field: 'weekly_budget_cents', minCents: 700 });
+	});
+
+	it('flags a monthly budget below the weekly-implied floor', () => {
+		const v = validateBudgetWindows({
+			daily_budget_cents: 0,
+			weekly_budget_cents: 1000,
+			monthly_budget_cents: 1000,
+		});
+		expect(v).toHaveLength(1);
+		expect(v[0]).toMatchObject({ field: 'monthly_budget_cents', minCents: 4334 });
+		expect(v[0].message).toContain('weekly budget (weekly × 52/12)');
+	});
+});
+
+describe('normalizeBudgetWindowsUp', () => {
+	it('raises enabled longer windows up to their floors', () => {
+		expect(
+			normalizeBudgetWindowsUp({
+				daily_budget_cents: 100,
+				weekly_budget_cents: 500,
+				monthly_budget_cents: 0,
+			}),
+		).toEqual({ daily_budget_cents: 100, weekly_budget_cents: 700, monthly_budget_cents: 0 });
+	});
+
+	it('feeds the daily floor into the monthly when weekly is disabled', () => {
+		expect(
+			normalizeBudgetWindowsUp({
+				daily_budget_cents: 100,
+				weekly_budget_cents: 0,
+				monthly_budget_cents: 1000,
+			}),
+		).toEqual({ daily_budget_cents: 100, weekly_budget_cents: 0, monthly_budget_cents: 3042 });
+	});
+
+	it('leaves a coherent trio unchanged', () => {
+		const coherent = {
+			daily_budget_cents: 100,
+			weekly_budget_cents: 700,
+			monthly_budget_cents: 3042,
+		};
+		expect(normalizeBudgetWindowsUp(coherent)).toEqual(coherent);
+	});
+});

--- a/packages/shared/test/common.test.ts
+++ b/packages/shared/test/common.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest';
+import {
+	AgentEffort,
+	AgentRuntimeStatus,
+	AiProvider,
+	assetContentDisposition,
+	assetServeCsp,
+	CredentialKind,
+	claudeCodeModelArg,
+	credentialKindRequiresAllowedHosts,
+	extensionOf,
+	formatTaskStatus,
+	isAgentAuthorableAssetMime,
+	isAgentEffort,
+	isAllowedAttachmentExtension,
+	isAllowedAttachmentMime,
+	isBudgetPauseStatus,
+	isMarkdownDocSlug,
+	isReactionKind,
+	normalizeAssetFilename,
+	opencodeModelArg,
+	parseProviderModels,
+	providerDirectUpstreamHosts,
+	ReactionKind,
+	TaskStatus,
+} from '../src/types/common';
+
+describe('enum guards', () => {
+	it('isAgentEffort', () => {
+		expect(isAgentEffort(AgentEffort.High)).toBe(true);
+		expect(isAgentEffort('medium')).toBe(true);
+		expect(isAgentEffort('bogus')).toBe(false);
+		expect(isAgentEffort(3)).toBe(false);
+		expect(isAgentEffort(null)).toBe(false);
+	});
+
+	it('isBudgetPauseStatus', () => {
+		expect(isBudgetPauseStatus(AgentRuntimeStatus.OutOfAgentBudget)).toBe(true);
+		expect(isBudgetPauseStatus(AgentRuntimeStatus.OutOfProjectBudget)).toBe(true);
+		expect(isBudgetPauseStatus(AgentRuntimeStatus.Active)).toBe(false);
+	});
+
+	it('isReactionKind', () => {
+		expect(isReactionKind(ReactionKind.Ack)).toBe(true);
+		expect(isReactionKind('nope')).toBe(false);
+		expect(isReactionKind(42)).toBe(false);
+	});
+
+	it('credentialKindRequiresAllowedHosts', () => {
+		expect(credentialKindRequiresAllowedHosts(CredentialKind.ApiKey)).toBe(true);
+		expect(credentialKindRequiresAllowedHosts(CredentialKind.OauthToken)).toBe(true);
+		expect(credentialKindRequiresAllowedHosts(CredentialKind.GithubPat)).toBe(true);
+		expect(credentialKindRequiresAllowedHosts(CredentialKind.SshPrivateKey)).toBe(false);
+		expect(credentialKindRequiresAllowedHosts(CredentialKind.Other)).toBe(false);
+	});
+});
+
+describe('formatTaskStatus', () => {
+	it('maps known statuses to labels and passes through unknown', () => {
+		expect(formatTaskStatus(TaskStatus.InProgress)).toBe('In Progress');
+		expect(formatTaskStatus('weird')).toBe('weird');
+	});
+});
+
+describe('asset / attachment helpers', () => {
+	it('forces download only for inline-unsafe mime', () => {
+		expect(assetContentDisposition('image/svg+xml')).toBe('attachment');
+		expect(assetContentDisposition('image/png')).toBe('inline');
+	});
+
+	it('emits a sandbox CSP only for html', () => {
+		expect(assetServeCsp('text/html')).toContain('sandbox');
+		expect(assetServeCsp('image/png')).toBeNull();
+	});
+
+	it('classifies agent-authorable mime', () => {
+		expect(isAgentAuthorableAssetMime('text/html')).toBe(true);
+		expect(isAgentAuthorableAssetMime('image/png')).toBe(false);
+	});
+
+	it('normalizeAssetFilename strips paths and unsafe chars', () => {
+		expect(normalizeAssetFilename('foo/bar baz.png')).toBe('bar-baz.png');
+		expect(normalizeAssetFilename('..\\weird@@name!.txt')).toBe('weird-name.txt');
+		expect(normalizeAssetFilename('////')).toBe('file');
+	});
+
+	it('extensionOf', () => {
+		expect(extensionOf('a.PNG')).toBe('png');
+		expect(extensionOf('a.b.c')).toBe('c');
+		expect(extensionOf('noext')).toBeNull();
+		expect(extensionOf('trailing.')).toBeNull();
+	});
+
+	it('attachment allowlists', () => {
+		expect(isAllowedAttachmentExtension('photo.png')).toBe(true);
+		expect(isAllowedAttachmentExtension('script.exe')).toBe(false);
+		expect(isAllowedAttachmentMime('image/png')).toBe(true);
+		expect(isAllowedAttachmentMime('application/x-evil')).toBe(false);
+	});
+
+	it('isMarkdownDocSlug', () => {
+		expect(isMarkdownDocSlug('readme.md')).toBe(true);
+		expect(isMarkdownDocSlug('Notes.MD')).toBe(true);
+		expect(isMarkdownDocSlug('image.png')).toBe(false);
+		expect(isMarkdownDocSlug('.md')).toBe(false);
+	});
+});
+
+describe('provider helpers', () => {
+	it('providerDirectUpstreamHosts uses the base-url host when set, else the default', () => {
+		expect(providerDirectUpstreamHosts(AiProvider.Anthropic)).toEqual(['api.anthropic.com']);
+		expect(providerDirectUpstreamHosts(AiProvider.DeepSeek)).toEqual(['api.deepseek.com']);
+		expect(providerDirectUpstreamHosts(AiProvider.ZAi)).toEqual(['api.z.ai']);
+	});
+
+	it('claudeCodeModelArg strips the [1m] suffix only for DeepSeek', () => {
+		expect(claudeCodeModelArg(AiProvider.DeepSeek, 'deepseek-v4-pro[1m]')).toBe('deepseek-v4-pro');
+		expect(claudeCodeModelArg(AiProvider.Anthropic, 'claude-opus-4[1m]')).toBe('claude-opus-4[1m]');
+	});
+
+	it('opencodeModelArg qualifies bare ids for OpenRouter only', () => {
+		expect(opencodeModelArg(AiProvider.OpenRouter, 'anthropic/claude')).toBe(
+			'openrouter/anthropic/claude',
+		);
+		expect(opencodeModelArg(AiProvider.OpenRouter, 'openrouter/x')).toBe('openrouter/x');
+		expect(opencodeModelArg(AiProvider.Anthropic, 'claude-opus-4')).toBe('claude-opus-4');
+	});
+});
+
+describe('parseProviderModels', () => {
+	it('returns [] for non-object input', () => {
+		expect(parseProviderModels(AiProvider.OpenAI, null)).toEqual([]);
+		expect(parseProviderModels(AiProvider.OpenAI, 'nope')).toEqual([]);
+	});
+
+	it('parses Google models filtered by generateContent', () => {
+		const out = parseProviderModels(AiProvider.Google, {
+			models: [
+				{
+					name: 'models/gemini-1.5-pro',
+					displayName: 'Gemini 1.5 Pro',
+					supportedGenerationMethods: ['generateContent'],
+				},
+				{ name: 'models/embedding-001', supportedGenerationMethods: ['embedContent'] },
+			],
+		});
+		expect(out).toEqual([{ id: 'gemini-1.5-pro', label: 'Gemini 1.5 Pro' }]);
+	});
+
+	it('parses OpenAI-style data and filters non-chat ids', () => {
+		const out = parseProviderModels(AiProvider.OpenAI, {
+			data: [
+				{ id: 'gpt-4o', display_name: 'GPT-4o' },
+				{ id: 'text-embedding-3-small' },
+				{ id: 'whisper-1' },
+			],
+		});
+		expect(out).toEqual([{ id: 'gpt-4o', label: 'GPT-4o' }]);
+	});
+
+	it('falls back to the id when no display name is present', () => {
+		const out = parseProviderModels(AiProvider.OpenRouter, {
+			data: [{ id: 'anthropic/claude-sonnet' }],
+		});
+		expect(out).toEqual([{ id: 'anthropic/claude-sonnet', label: 'anthropic/claude-sonnet' }]);
+	});
+});

--- a/packages/shared/test/crypto-auth.test.ts
+++ b/packages/shared/test/crypto-auth.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import {
+	buildLoginMessage,
+	buildSetupMessage,
+	buildUnlockMessage,
+	deriveAuthKeyPair,
+	deriveUnlockKey,
+	signAuthMessage,
+	verifyAuthSignature,
+} from '../src/crypto/auth';
+
+// mnemonicToSeedSync does not validate the BIP39 checksum, so any phrase derives
+// deterministically — these fixtures are stable inputs, not security material.
+const PHRASE = 'test test test test test test test test test test test junk';
+const OTHER = 'legal winner thank year wave sausage worth useful legal winner thank yellow';
+
+describe('deriveUnlockKey', () => {
+	it('is deterministic and returns 64-char lowercase hex', () => {
+		const a = deriveUnlockKey(PHRASE);
+		expect(a).toBe(deriveUnlockKey(PHRASE));
+		expect(a).toMatch(/^[0-9a-f]{64}$/);
+	});
+
+	it('normalizes whitespace and case before deriving', () => {
+		const messy = '  TEST   test\ttest test test test test test test test test junk  ';
+		expect(deriveUnlockKey(messy)).toBe(deriveUnlockKey(PHRASE));
+	});
+
+	it('differs for a different phrase', () => {
+		expect(deriveUnlockKey(PHRASE)).not.toBe(deriveUnlockKey(OTHER));
+	});
+});
+
+describe('deriveAuthKeyPair', () => {
+	it('derives a deterministic 32-byte private key and 64-char hex public key', () => {
+		const a = deriveAuthKeyPair(PHRASE);
+		const b = deriveAuthKeyPair(PHRASE);
+		expect(a.privateKey).toEqual(b.privateKey);
+		expect(a.privateKey).toHaveLength(32);
+		expect(a.publicKeyHex).toBe(b.publicKeyHex);
+		expect(a.publicKeyHex).toMatch(/^[0-9a-f]{64}$/);
+	});
+
+	it('is salt-separated from the unlock key', () => {
+		expect(deriveAuthKeyPair(PHRASE).publicKeyHex).not.toBe(deriveUnlockKey(PHRASE));
+	});
+});
+
+describe('signAuthMessage / verifyAuthSignature', () => {
+	it('round-trips a valid signature', () => {
+		const { privateKey, publicKeyHex } = deriveAuthKeyPair(PHRASE);
+		const sig = signAuthMessage(privateKey, 'hello');
+		expect(sig).toMatch(/^[0-9a-f]{128}$/);
+		expect(verifyAuthSignature(publicKeyHex, 'hello', sig)).toBe(true);
+	});
+
+	it('rejects a tampered message', () => {
+		const { privateKey, publicKeyHex } = deriveAuthKeyPair(PHRASE);
+		const sig = signAuthMessage(privateKey, 'hello');
+		expect(verifyAuthSignature(publicKeyHex, 'hello!', sig)).toBe(false);
+	});
+
+	it('rejects a signature from a different key', () => {
+		const a = deriveAuthKeyPair(PHRASE);
+		const b = deriveAuthKeyPair(OTHER);
+		const sig = signAuthMessage(a.privateKey, 'hello');
+		expect(verifyAuthSignature(b.publicKeyHex, 'hello', sig)).toBe(false);
+	});
+
+	it('returns false (never throws) on malformed hex', () => {
+		expect(verifyAuthSignature('not-hex', 'hello', 'also-not-hex')).toBe(false);
+		expect(verifyAuthSignature('', '', '')).toBe(false);
+	});
+});
+
+describe('canonical signed payloads', () => {
+	it('builds versioned, domain-separated messages', () => {
+		expect(buildSetupMessage('PUB', 'UNLOCK')).toBe('hezo-auth-v1:setup:PUB:UNLOCK');
+		expect(buildLoginMessage('NONCE')).toBe('hezo-auth-v1:login:NONCE');
+		expect(buildUnlockMessage('NONCE', 'UNLOCK')).toBe('hezo-auth-v1:unlock:NONCE:UNLOCK');
+	});
+});

--- a/packages/shared/test/crypto-mnemonic.test.ts
+++ b/packages/shared/test/crypto-mnemonic.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { generateMnemonic, normalizeMnemonic, validateMnemonic } from '../src/crypto/mnemonic';
+
+describe('generateMnemonic', () => {
+	it('produces a valid 12-word BIP39 phrase', () => {
+		const m = generateMnemonic();
+		expect(m.split(' ')).toHaveLength(12);
+		expect(validateMnemonic(m)).toBe(true);
+	});
+
+	it('produces a fresh phrase each call', () => {
+		expect(generateMnemonic()).not.toBe(generateMnemonic());
+	});
+});
+
+describe('normalizeMnemonic', () => {
+	it('trims, collapses whitespace, and lowercases', () => {
+		expect(normalizeMnemonic('  Hello   World\n\tFoo ')).toBe('hello world foo');
+	});
+});
+
+describe('validateMnemonic', () => {
+	it('accepts a valid phrase regardless of case/whitespace', () => {
+		const valid = ' LEGAL winner thank year wave sausage worth useful legal winner thank yellow ';
+		expect(validateMnemonic(valid)).toBe(true);
+	});
+
+	it('rejects a non-BIP39 phrase', () => {
+		expect(validateMnemonic('foo bar baz')).toBe(false);
+	});
+});

--- a/packages/shared/test/mentions-paths.test.ts
+++ b/packages/shared/test/mentions-paths.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import {
+	agentPath,
+	assetPath,
+	commentPath,
+	GLOBAL_INBOX_PATH,
+	projectDocPath,
+	projectInboxPath,
+	SKILLS_SETTINGS_PATH,
+	taskPath,
+} from '../src/mentions/paths';
+
+describe('mention paths', () => {
+	it('builds task and comment paths with a lowercased identifier', () => {
+		expect(taskPath('ops', 'IN-42')).toBe('/projects/ops/tasks/in-42');
+		expect(commentPath('ops', 'IN-42', '20261009112345')).toBe(
+			'/projects/ops/tasks/in-42#comment-20261009112345',
+		);
+	});
+
+	it('url-encodes filenames in doc and asset paths', () => {
+		expect(projectDocPath('ops', 'my file.md')).toBe('/projects/ops/documents?file=my%20file.md');
+		expect(assetPath('ops', 'a&b.png')).toBe('/projects/ops/assets?file=a%26b.png');
+	});
+
+	it('builds agent and inbox paths', () => {
+		expect(agentPath('ops', 'captain')).toBe('/projects/ops/agents/captain');
+		expect(projectInboxPath('ops')).toBe('/projects/ops/inbox');
+	});
+
+	it('exposes static instance paths', () => {
+		expect(GLOBAL_INBOX_PATH).toBe('/home/inbox');
+		expect(SKILLS_SETTINGS_PATH).toBe('/settings/skills');
+	});
+});

--- a/packages/shared/test/mentions-tokens.test.ts
+++ b/packages/shared/test/mentions-tokens.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import {
+	buildMentionRegex,
+	extractBacktickedMentionCandidates,
+	extractDocCandidates,
+	extractMentionCandidates,
+	extractTaskCandidates,
+	type MentionToken,
+	parseMentionMatch,
+	stripCode,
+	transformMentionsOutsideCode,
+} from '../src/mentions/tokens';
+
+const sorted = (a: string[]): string[] => [...a].sort();
+
+describe('parseMentionMatch via buildMentionRegex', () => {
+	it('classifies every token kind', () => {
+		const input = '@@bob @alice IN-42 TO-7#comment-20261009112345 readme.md assets/diagram.png';
+		const tokens: MentionToken[] = [];
+		const re = buildMentionRegex();
+		let m = re.exec(input);
+		while (m !== null) {
+			tokens.push(parseMentionMatch(m));
+			m = re.exec(input);
+		}
+		const byKind = Object.fromEntries(tokens.map((t) => [t.kind, t]));
+		expect(byKind.passive_agent).toMatchObject({ kind: 'passive_agent', slug: 'bob' });
+		expect(byKind.agent).toMatchObject({ kind: 'agent', slug: 'alice' });
+		expect(byKind.task).toMatchObject({ kind: 'task', identifier: 'in-42' });
+		expect(byKind.comment).toMatchObject({
+			kind: 'comment',
+			taskIdentifier: 'to-7',
+			commentId: '20261009112345',
+		});
+		expect(byKind.filename).toMatchObject({ kind: 'filename', filename: 'readme.md' });
+		expect(byKind.asset).toMatchObject({ kind: 'asset', filename: 'diagram.png' });
+	});
+
+	it('returns a fresh regex instance each call', () => {
+		const a = buildMentionRegex();
+		const b = buildMentionRegex();
+		expect(a).not.toBe(b);
+		a.exec('@alice');
+		expect(b.lastIndex).toBe(0);
+	});
+});
+
+describe('extractMentionCandidates', () => {
+	it('extracts deduped, normalized references and skips code', () => {
+		const input = [
+			'@alice and @@bob, cc @admin on IN-42 and TO-7#comment-20261009112345',
+			'docs: readme.md and asset assets/diagram.png; dup IN-42',
+			'```',
+			'@charlie ZZ-99 ignored.md',
+			'```',
+			'inline `@dave EX-1` ignored too',
+		].join('\n');
+		const c = extractMentionCandidates(input);
+		expect(sorted(c.tasks)).toEqual(['in-42', 'to-7']);
+		expect(c.filenames).toEqual(['readme.md']);
+		expect(c.assets).toEqual(['diagram.png']);
+		expect(sorted(c.agents)).toEqual(['alice', 'bob']);
+	});
+});
+
+describe('extractBacktickedMentionCandidates', () => {
+	it('finds references inside inline code, ignoring fenced blocks', () => {
+		const input = [
+			'plain @alice IN-1',
+			'inline `@bob TO-2 spec.md` here',
+			'```',
+			'@charlie IN-3',
+			'```',
+		].join('\n');
+		const c = extractBacktickedMentionCandidates(input);
+		expect(c.tasks).toEqual(['to-2']);
+		expect(c.agents).toEqual(['bob']);
+		expect(c.filenames).toEqual(['spec.md']);
+		expect(c.assets).toEqual([]);
+	});
+});
+
+describe('extractTaskCandidates', () => {
+	it('returns deduped lowercased task ids outside code', () => {
+		const out = extractTaskCandidates('IN-1 in-1? no, IN-1 and AB-22; `IN-9` skipped');
+		expect(sorted(out)).toEqual(['ab-22', 'in-1']);
+	});
+});
+
+describe('extractDocCandidates', () => {
+	it('returns only kb slugs when no project slug is given', () => {
+		const c = extractDocCandidates('see readme.md and assets/Plan.png');
+		expect(c.kbSlugs).toEqual(['readme.md']);
+		expect(c.projectDocs).toEqual([]);
+		expect(c.assets).toEqual([]);
+	});
+
+	it('scopes project docs and assets to a lowercased project slug', () => {
+		const c = extractDocCandidates('see myDoc.md and assets/diagram.png', 'Ops');
+		expect(c.kbSlugs).toEqual(['mydoc.md']);
+		expect(c.projectDocs).toEqual([{ project_slug: 'ops', filename: 'myDoc.md' }]);
+		expect(c.assets).toEqual([{ project_slug: 'ops', filename: 'diagram.png' }]);
+	});
+});
+
+describe('stripCode', () => {
+	it('blanks fenced and inline code', () => {
+		expect(stripCode('a `b` c')).toBe('a   c');
+		expect(stripCode('x\n```\ncode\n```\ny').includes('code')).toBe(false);
+	});
+});
+
+describe('transformMentionsOutsideCode', () => {
+	it('rewrites tokens outside code and leaves code spans intact', () => {
+		const out = transformMentionsOutsideCode('@alice see IN-1 and `@bob IN-2`', (t) =>
+			t.kind === 'agent' ? `<${t.slug}>` : null,
+		);
+		expect(out).toBe('<alice> see IN-1 and `@bob IN-2`');
+	});
+});

--- a/packages/shared/test/pricing.test.ts
+++ b/packages/shared/test/pricing.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { costCentsFromRate } from '../src/pricing';
+
+describe('costCentsFromRate', () => {
+	it('sums each token bucket at its own rate and rounds to cents', () => {
+		const cents = costCentsFromRate(
+			{
+				inputPerToken: 0.001,
+				outputPerToken: 0.002,
+				cacheReadPerToken: 0.0001,
+				cacheCreationPerToken: 0.005,
+			},
+			{ inputTokens: 1000, cacheReadTokens: 2000, cacheCreationTokens: 100, outputTokens: 500 },
+		);
+		// 1 + 0.2 + 0.5 + 1 = 2.7 dollars
+		expect(cents).toBe(270);
+	});
+
+	it('falls back to the input rate when cache rates are absent or null', () => {
+		const cents = costCentsFromRate(
+			{
+				inputPerToken: 0.001,
+				outputPerToken: 0.002,
+				cacheReadPerToken: null,
+				cacheCreationPerToken: null,
+			},
+			{ inputTokens: 0, cacheReadTokens: 1000, cacheCreationTokens: 1000, outputTokens: 0 },
+		);
+		// (1000 + 1000) * 0.001 = 2 dollars
+		expect(cents).toBe(200);
+	});
+
+	it('treats undefined or negative bucket counts as zero', () => {
+		const cents = costCentsFromRate(
+			{ inputPerToken: 0.001, outputPerToken: 0.002 },
+			{ inputTokens: -5, outputTokens: 100 },
+		);
+		expect(cents).toBe(20);
+	});
+});

--- a/packages/shared/test/task-progress.test.ts
+++ b/packages/shared/test/task-progress.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+import {
+	buildTaskProgressSummary,
+	deriveProjectStatus,
+	deriveProjectTaskListPhaseBanner,
+	formatProjectStatus,
+	hasPlanningLabel,
+	isExecutionScopeTask,
+	isLastRunFailed,
+	isPlanningPhaseComplete,
+	ProjectStatus,
+	type TaskProgressStatusRow,
+	taskProgressBucket,
+} from '../src/task-progress';
+import { TaskStatus } from '../src/types/common';
+
+const row = (over: Partial<TaskProgressStatusRow> & { id: string }): TaskProgressStatusRow => ({
+	status: TaskStatus.Backlog,
+	parent_task_id: null,
+	labels: [],
+	has_active_run: false,
+	last_run_status: null,
+	...over,
+});
+
+describe('taskProgressBucket', () => {
+	it('buckets terminal, in-progress, and not-done statuses', () => {
+		expect(taskProgressBucket(TaskStatus.Done)).toBe('complete');
+		expect(taskProgressBucket(TaskStatus.Closed)).toBe('complete');
+		expect(taskProgressBucket(TaskStatus.Cancelled)).toBe('complete');
+		expect(taskProgressBucket(TaskStatus.InProgress)).toBe('in_progress');
+		expect(taskProgressBucket(TaskStatus.Review)).toBe('in_progress');
+		expect(taskProgressBucket(TaskStatus.Backlog)).toBe('not_done');
+		expect(taskProgressBucket(TaskStatus.Blocked)).toBe('not_done');
+	});
+});
+
+describe('scope helpers', () => {
+	it('detects the planning label', () => {
+		expect(hasPlanningLabel(['planning'])).toBe(true);
+		expect(hasPlanningLabel(['other'])).toBe(false);
+	});
+
+	it('excludes the planning epic, its direct children, and planning-labelled tasks', () => {
+		expect(isExecutionScopeTask(row({ id: 'epic' }), 'epic')).toBe(false);
+		expect(isExecutionScopeTask(row({ id: 'child', parent_task_id: 'epic' }), 'epic')).toBe(false);
+		expect(isExecutionScopeTask(row({ id: 'lbl', labels: ['planning'] }), 'epic')).toBe(false);
+		expect(isExecutionScopeTask(row({ id: 'work' }), 'epic')).toBe(true);
+		expect(isExecutionScopeTask(row({ id: 'work' }), null)).toBe(true);
+	});
+
+	it('marks planning complete only when the epic is closed', () => {
+		expect(isPlanningPhaseComplete(TaskStatus.Closed)).toBe(true);
+		expect(isPlanningPhaseComplete(TaskStatus.InProgress)).toBe(false);
+		expect(isPlanningPhaseComplete(null)).toBe(false);
+	});
+
+	it('flags a failed last run only when no run is active', () => {
+		expect(isLastRunFailed(false, 'failed')).toBe(true);
+		expect(isLastRunFailed(false, 'timed_out')).toBe(true);
+		expect(isLastRunFailed(true, 'failed')).toBe(false);
+		expect(isLastRunFailed(false, 'succeeded')).toBe(false);
+	});
+});
+
+describe('formatProjectStatus / phase banner', () => {
+	it('formats project status labels', () => {
+		expect(formatProjectStatus(ProjectStatus.Working)).toBe('Working');
+		expect(formatProjectStatus(ProjectStatus.Idle)).toBe('Idle');
+	});
+
+	it('shows the onboarding banner only while a coherence review is open', () => {
+		expect(deriveProjectTaskListPhaseBanner({ coherenceReviewStatus: TaskStatus.InProgress })).toBe(
+			'onboarding',
+		);
+		expect(
+			deriveProjectTaskListPhaseBanner({ coherenceReviewStatus: TaskStatus.Closed }),
+		).toBeNull();
+		expect(deriveProjectTaskListPhaseBanner({ coherenceReviewStatus: null })).toBeNull();
+	});
+});
+
+describe('deriveProjectStatus', () => {
+	it('returns null when there are no execution-scope tasks', () => {
+		expect(deriveProjectStatus([], null)).toBeNull();
+		expect(deriveProjectStatus([row({ id: 'epic' })], 'epic')).toBeNull();
+	});
+
+	it('is Completed when every scoped task is terminal', () => {
+		const tasks = [
+			row({ id: 'a', status: TaskStatus.Done }),
+			row({ id: 'b', status: TaskStatus.Closed }),
+		];
+		expect(deriveProjectStatus(tasks, null)).toBe(ProjectStatus.Completed);
+	});
+
+	it('is Working when any scoped task has an active run', () => {
+		const tasks = [row({ id: 'a', status: TaskStatus.InProgress, has_active_run: true })];
+		expect(deriveProjectStatus(tasks, null)).toBe(ProjectStatus.Working);
+	});
+
+	it('is Error when in-progress tasks all have a failed last run', () => {
+		const tasks = [row({ id: 'a', status: TaskStatus.InProgress, last_run_status: 'failed' })];
+		expect(deriveProjectStatus(tasks, null)).toBe(ProjectStatus.Error);
+	});
+
+	it('is Idle otherwise', () => {
+		expect(deriveProjectStatus([row({ id: 'a', status: TaskStatus.Backlog })], null)).toBe(
+			ProjectStatus.Idle,
+		);
+	});
+});
+
+describe('buildTaskProgressSummary', () => {
+	it('reports zeroed progress until planning is complete', () => {
+		const s = buildTaskProgressSummary({
+			planningTaskId: 'epic',
+			planningTaskStatus: TaskStatus.InProgress,
+			coherenceReviewStatus: null,
+			projectName: 'Demo',
+			tasks: [row({ id: 'a', status: TaskStatus.Done })],
+		});
+		expect(s.planning_complete).toBe(false);
+		expect(s.total).toBe(0);
+		expect(s.percent_complete).toBe(0);
+		expect(s.project_status).toBeNull();
+		expect(s.project_name).toBe('Demo');
+	});
+
+	it('counts execution-scope tasks once planning is closed', () => {
+		const s = buildTaskProgressSummary({
+			planningTaskId: 'epic',
+			planningTaskStatus: TaskStatus.Closed,
+			coherenceReviewStatus: null,
+			projectName: 'Demo',
+			tasks: [
+				row({ id: 'epic', status: TaskStatus.Closed }),
+				row({ id: 'a', status: TaskStatus.Done }),
+				row({ id: 'b', status: TaskStatus.InProgress }),
+				row({ id: 'c', status: TaskStatus.Backlog }),
+			],
+		});
+		expect(s.total).toBe(3);
+		expect(s.complete).toBe(1);
+		expect(s.in_progress).toBe(1);
+		expect(s.not_done).toBe(1);
+		expect(s.percent_complete).toBe(33);
+		expect(s.by_status[TaskStatus.Done]).toBe(1);
+	});
+});

--- a/packages/shared/test/types.test.ts
+++ b/packages/shared/test/types.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import {
+	CONNECTOR_CAPABILITIES,
+	getConnectorCapability,
+} from '../src/types/connector-capabilities';
+import { WsClientAction, WsMessageType } from '../src/types/websocket';
+
+describe('websocket message enums', () => {
+	it('exposes stable wire values', () => {
+		expect(WsMessageType.RowChange).toBe('row_change');
+		expect(WsMessageType.CeoMessageDelta).toBe('ceo_message_delta');
+		expect(WsClientAction.Subscribe).toBe('subscribe');
+		expect(WsClientAction.Unsubscribe).toBe('unsubscribe');
+	});
+});
+
+describe('connector capabilities', () => {
+	it('looks up a known connector and its device-auth config', () => {
+		const gh = getConnectorCapability('github');
+		expect(gh?.displayName).toBe('GitHub');
+		expect(gh?.allowedHosts).toContain('github.com');
+		expect(gh?.scopes).toContain('repo');
+		expect(gh?.deviceAuth?.clientIdEnv).toBe('GITHUB_OAUTH_CLIENT_ID');
+	});
+
+	it('returns undefined for an unknown connector', () => {
+		expect(getConnectorCapability('does-not-exist')).toBeUndefined();
+	});
+
+	it('keeps every registry entry id in sync with its key', () => {
+		for (const [key, cap] of Object.entries(CONNECTOR_CAPABILITIES)) {
+			expect(cap.id).toBe(key);
+			expect(cap.mcpServer.transport).toBeTruthy();
+		}
+	});
+});

--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig } from 'vitest/config';
+
+// Unit-tier config for the pure-logic shared package (crypto, mentions, budget,
+// pricing, task-progress, enums/constants). No DOM, no backend — plain Node.
+// scripts/test.ts runs this package alongside server/web and normalizes its lcov
+// to repo-root-relative paths so Coveralls counts packages/shared/src/** too.
+export default defineConfig({
+	test: {
+		globals: true,
+		include: ['test/**/*.test.ts'],
+		// Off by default so normal runs stay uninstrumented; scripts/test.ts flips
+		// `enabled` on with --coverage. Uploaded to Coveralls under the `shared`
+		// flag as part of the same parallel build as server/web.
+		coverage: {
+			provider: 'v8',
+			enabled: false,
+			reporter: ['text-summary', 'json', 'lcov'],
+			reportsDirectory: './coverage',
+			reportOnFailure: true,
+			all: false,
+			include: ['src/**/*.ts'],
+			exclude: [
+				'src/**/*.d.ts',
+				// Pure re-export barrels and type-only modules carry no testable logic.
+				'src/index.ts',
+				'src/types/index.ts',
+				'src/types/config.ts',
+				'src/mentions/index.ts',
+				'src/**/*.test.ts',
+				'test/**',
+				'dist/**',
+			],
+		},
+	},
+});

--- a/packages/web/test/agent-executions-list.test.tsx
+++ b/packages/web/test/agent-executions-list.test.tsx
@@ -1,0 +1,246 @@
+// Coverage for the agent Executions *list* page
+// (routes/projects/$projectId/agents/$agentId/executions/index.tsx) — the row
+// renderer, the instance-agent project suffix, cost / exit-code / status
+// rendering, and the empty + loading states. Render-driven (no real layout,
+// viewport, or WebSocket), so it lives in the component tier. The heartbeat-runs
+// list is fetch-mocked (same pattern as agent-executions-project.test.tsx)
+// because synthesising a realistic multi-run history against the real backend is
+// impractical; the server's own list shape is covered by
+// packages/server/test/heartbeat-runs.test.ts.
+
+import { INSTANCE_AGENT_SLUGS } from '@hezo/shared';
+import { afterEach, expect, test } from 'vitest';
+import type { HeartbeatRun } from '../src/hooks/use-heartbeat-runs';
+import { renderApp } from './helpers/render';
+import { seedProject, seedWorkspace } from './helpers/seed';
+
+let restoreFetch: (() => void) | null = null;
+afterEach(() => {
+	restoreFetch?.();
+	restoreFetch = null;
+});
+
+function makeRun(overrides: Partial<HeartbeatRun>): HeartbeatRun {
+	return {
+		id: 'run-default',
+		member_id: 'm-1',
+		team_id: 't-1',
+		wakeup_id: null,
+		task_id: 'task-1',
+		task_identifier: 'DEMO-1',
+		task_title: 'Do the thing',
+		project_id: 'p-1',
+		project_slug: 'demo',
+		project_name: 'Demo Project',
+		status: 'succeeded',
+		queued_reason: null,
+		started_at: '2026-06-07T20:58:30Z',
+		finished_at: '2026-06-07T20:59:50Z',
+		exit_code: 0,
+		error: null,
+		input_tokens: 0,
+		output_tokens: 0,
+		cost_cents: 0,
+		usage_partial: false,
+		invocation_command: null,
+		log_text: null,
+		working_dir: null,
+		trigger_source: 'assignment',
+		trigger_payload: null,
+		trigger_comment_id: null,
+		trigger_comment_public_id: null,
+		trigger_actor_member_id: null,
+		trigger_actor_slug: null,
+		trigger_actor_title: null,
+		trigger_comment_task_id: null,
+		trigger_comment_task_identifier: null,
+		trigger_comment_project_slug: null,
+		run_comment_id: null,
+		run_comment_public_id: null,
+		created_tasks: [],
+		created_docs: [],
+		created_skills: [],
+		proposed_skills: [],
+		...overrides,
+	};
+}
+
+/**
+ * Override the heartbeat-runs *list* endpoint (and, for instance-agent tests,
+ * the agent slug) so the page renders against a known set of runs. Everything
+ * else (the agent layout's own useAgent fetch, the project shell) goes to the
+ * real in-process server.
+ */
+function installRunsListMock(opts: {
+	agentId: string;
+	runs: HeartbeatRun[];
+	agentSlugOverride?: string;
+}) {
+	const original = globalThis.fetch;
+	restoreFetch = () => {
+		globalThis.fetch = original;
+	};
+	globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+		const url = typeof input === 'string' ? input : (input as Request).url;
+		const method = init?.method ?? (input instanceof Request ? input.method : 'GET');
+
+		if (
+			method === 'GET' &&
+			new RegExp(`/api/projects/[^/]+/agents/${opts.agentId}/heartbeat-runs(\\?.*)?$`).test(url)
+		) {
+			return new Response(JSON.stringify({ data: opts.runs }), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			});
+		}
+
+		// Rewrite the agent's own slug so the page treats it as an instance agent
+		// (CEO/Coach) without needing a real instance member in the DB.
+		if (
+			opts.agentSlugOverride &&
+			method === 'GET' &&
+			new RegExp(`/api/projects/[^/]+/agents/${opts.agentId}(\\?.*)?$`).test(url)
+		) {
+			const res = await original(input as RequestInfo, init);
+			const body = (await res.json()) as { data?: { slug?: string } };
+			if (body.data) body.data.slug = opts.agentSlugOverride;
+			return new Response(JSON.stringify(body), {
+				status: res.status,
+				headers: { 'Content-Type': 'application/json' },
+			});
+		}
+
+		return original(input as RequestInfo, init);
+	}) as typeof globalThis.fetch;
+}
+
+async function renderExecutions(runs: HeartbeatRun[], opts?: { agentSlugOverride?: string }) {
+	const seeded = { projectSlug: '', agentId: '' };
+	const helpers = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const captain = ws.agents.find((a) => a.slug === 'captain') ?? ws.agents[0];
+			const project = await seedProject(ws, { name: 'Exec List Project' });
+			seeded.projectSlug = project.slug;
+			seeded.agentId = captain.id;
+			installRunsListMock({
+				agentId: captain.id,
+				runs: runs.map((r) => ({ ...r, member_id: captain.id })),
+				agentSlugOverride: opts?.agentSlugOverride,
+			});
+		},
+	});
+	await helpers.router.navigate({
+		to: '/projects/$projectId/agents/$agentId/executions',
+		params: { projectId: seeded.projectSlug, agentId: seeded.agentId },
+	});
+	return { ...helpers, seeded };
+}
+
+test('renders a succeeded run row with status badge, task identifier+title, and links to the run detail', async () => {
+	const { findByRole, seeded } = await renderExecutions([
+		makeRun({ id: 'run-1', status: 'succeeded', task_identifier: 'DEMO-7', task_title: 'Ship it' }),
+	]);
+
+	// The row is a link to the run-detail route. The whole row text is the
+	// accessible name, so match by a substring regex.
+	const row = await findByRole('link', { name: /DEMO-7/ }, { timeout: 20_000 });
+	expect(row.getAttribute('href')).toBe(
+		`/projects/${seeded.projectSlug}/agents/${seeded.agentId}/executions/run-1`,
+	);
+	expect(row.textContent).toContain('succeeded');
+	expect(row.textContent).toContain('Ship it');
+});
+
+test('a non-zero exit code and a non-zero cost are surfaced on the row', async () => {
+	const { findByText } = await renderExecutions([
+		makeRun({
+			id: 'run-2',
+			status: 'failed',
+			exit_code: 137,
+			cost_cents: 425,
+			task_identifier: 'DEMO-9',
+		}),
+	]);
+
+	// $4.25 from cost_cents=425, and the exit code suffix.
+	await findByText('$4.25', undefined, { timeout: 20_000 });
+	await findByText('exit: 137');
+});
+
+test('a running row shows the pulsing dot via the queued/running status and reads "queued" when not yet started', async () => {
+	const { findByRole } = await renderExecutions([
+		makeRun({
+			id: 'run-3',
+			status: 'queued',
+			started_at: null,
+			finished_at: null,
+			task_identifier: 'DEMO-3',
+		}),
+	]);
+
+	const row = await findByRole('link', { name: /DEMO-3/ }, { timeout: 20_000 });
+	expect(row.textContent).toContain('queued');
+	// The animated indicator span renders for queued/running rows.
+	expect(row.querySelector('.animate-pulse')).not.toBeNull();
+});
+
+test("an instance agent (CEO) surfaces the run's own project as a suffix on the task line", async () => {
+	// Sanity: captain is the seeded agent we override the slug for; confirm 'ceo'
+	// is actually treated as an instance slug so the assertion below is meaningful.
+	expect((INSTANCE_AGENT_SLUGS as readonly string[]).includes('ceo')).toBe(true);
+
+	const { findByTestId } = await renderExecutions(
+		[
+			makeRun({
+				id: 'run-4',
+				task_identifier: 'ACME-12',
+				task_title: 'Cross-project review',
+				project_name: 'Acme Robotics',
+				project_slug: 'acme-robotics',
+			}),
+		],
+		{ agentSlugOverride: 'ceo' },
+	);
+
+	const suffix = await findByTestId('run-row-project', undefined, { timeout: 20_000 });
+	expect(suffix.textContent).toContain('Acme Robotics');
+});
+
+test('a non-instance agent omits the project suffix even when the run carries a project name', async () => {
+	const { findByRole, queryByTestId } = await renderExecutions([
+		makeRun({
+			id: 'run-5',
+			task_identifier: 'DEMO-5',
+			project_name: 'Some Project',
+			project_slug: 'some-project',
+		}),
+	]);
+
+	await findByRole('link', { name: /DEMO-5/ }, { timeout: 20_000 });
+	expect(queryByTestId('run-row-project')).toBeNull();
+});
+
+test('shows the empty state when the agent has no runs', async () => {
+	const { findByText } = await renderExecutions([]);
+	await findByText('No executions yet.', undefined, { timeout: 20_000 });
+});
+
+test('a cancelled run renders with the neutral status (no exit/cost suffixes)', async () => {
+	const { findByRole } = await renderExecutions([
+		makeRun({
+			id: 'run-6',
+			status: 'cancelled',
+			exit_code: null,
+			cost_cents: 0,
+			task_identifier: 'DEMO-6',
+		}),
+	]);
+
+	const row = await findByRole('link', { name: /DEMO-6/ }, { timeout: 20_000 });
+	expect(row.textContent).toContain('cancelled');
+	// exit_code null and cost 0 → neither the exit-code nor the $ suffix renders.
+	expect(row.textContent).not.toContain('exit:');
+	expect(row.textContent).not.toContain('$');
+});

--- a/packages/web/test/approval-card.test.tsx
+++ b/packages/web/test/approval-card.test.tsx
@@ -1,0 +1,255 @@
+import { waitFor, within } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { getTestContext, renderApp } from './helpers/render';
+import {
+	type SeededProject,
+	type SeededWorkspace,
+	seedProject,
+	seedTask,
+	seedWorkspace,
+} from './helpers/seed';
+
+// Component tier (happy-dom). ApprovalCard is rendered through the real inbox
+// (`/projects/$projectId/inbox` for showTeam=false, `/home/inbox` for
+// showTeam=true). We seed approval rows directly so we can control `status`,
+// `resolution_note`, and the typed `payload` that drives each ApprovalMessage
+// branch — the approvals GET route enriches them with payload_* JOINs.
+//
+// inbox-approvals.test.tsx already covers the strategy/hire happy paths and
+// approve/deny; this file targets the message-branch and resolved/read-only
+// states that those don't reach.
+
+/** Insert an approval row directly (lets us set status + resolution_note). */
+async function insertApproval(
+	ws: SeededWorkspace,
+	input: {
+		type: string;
+		payload: Record<string, unknown>;
+		status?: 'pending' | 'approved' | 'denied';
+		resolutionNote?: string | null;
+		requestedByMemberId?: string | null;
+	},
+): Promise<{ id: string }> {
+	const { db } = getTestContext();
+	const res = await db.query<{ id: string }>(
+		`INSERT INTO approvals (team_id, type, status, payload, resolution_note, requested_by_member_id)
+		 VALUES ($1, $2::approval_type, $3::approval_status, $4::jsonb, $5, $6)
+		 RETURNING id`,
+		[
+			ws.team.id,
+			input.type,
+			input.status ?? 'pending',
+			JSON.stringify(input.payload),
+			input.resolutionNote ?? null,
+			input.requestedByMemberId ?? null,
+		],
+	);
+	return res.rows[0];
+}
+
+interface Ctx {
+	ws: SeededWorkspace;
+	project: SeededProject;
+	projectSlug: string;
+	projectId: string;
+}
+
+/** Seed a workspace + named project, run `build`, then open the team inbox. */
+async function renderTeamInbox(build: (ctx: Ctx) => Promise<void>) {
+	const ref: { projectSlug: string } = { projectSlug: '' };
+	const helpers = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Approval Project' });
+			ref.projectSlug = project.slug;
+			await build({ ws, project, projectSlug: project.slug, projectId: project.id });
+		},
+	});
+	await helpers.router.navigate({
+		to: '/projects/$projectId/inbox',
+		params: { projectId: ref.projectSlug },
+	});
+	return { ...helpers, ref };
+}
+
+test('a skill-proposal approval renders its message and reason', async () => {
+	const { findByText } = await renderTeamInbox(async ({ ws }) => {
+		await insertApproval(ws, {
+			type: 'skill_proposal',
+			payload: { skill_name: 'Deploy Helper', reason: 'Speeds up rollouts' },
+		});
+	});
+
+	await findByText(/Proposing new skill/, undefined, { timeout: 15_000 });
+	await findByText(/Deploy Helper/);
+	await findByText('Speeds up rollouts');
+});
+
+test('a plan-review approval renders its message and reason', async () => {
+	const { findByText } = await renderTeamInbox(async ({ ws }) => {
+		await insertApproval(ws, {
+			type: 'plan_review',
+			payload: { reason: 'Plan ready for sign-off' },
+		});
+	});
+
+	await findByText('Requesting plan review', undefined, { timeout: 15_000 });
+	await findByText('Plan ready for sign-off');
+});
+
+test('a deploy-production approval names the target environment', async () => {
+	const { findByText } = await renderTeamInbox(async ({ ws }) => {
+		await insertApproval(ws, {
+			type: 'deploy_production',
+			payload: { target: 'prod-eu', reason: 'Release 1.4' },
+		});
+	});
+
+	await findByText('Requesting deploy to', undefined, { timeout: 15_000 });
+	await findByText('prod-eu');
+	await findByText('Release 1.4');
+});
+
+test('a resolved (approved) approval is read-only history: status badge, resolution note, no buttons', async () => {
+	const { findByText, queryByRole } = await renderTeamInbox(async ({ ws }) => {
+		await insertApproval(ws, {
+			type: 'strategy',
+			payload: { plan: 'Old launch plan' },
+			status: 'approved',
+			resolutionNote: 'Looks good, proceed.',
+		});
+	});
+
+	await findByText('Old launch plan', undefined, { timeout: 15_000 });
+	// Resolved approvals show the status badge + resolution note.
+	await findByText('approved');
+	await findByText(/Looks good, proceed\./);
+	// No action buttons on a resolved card.
+	expect(queryByRole('button', { name: 'Approve' })).toBeNull();
+	expect(queryByRole('button', { name: 'Deny' })).toBeNull();
+});
+
+test('a denied approval shows a red denied badge', async () => {
+	const { findByText } = await renderTeamInbox(async ({ ws }) => {
+		await insertApproval(ws, {
+			type: 'strategy',
+			payload: { plan: 'Rejected plan' },
+			status: 'denied',
+			resolutionNote: 'Not now.',
+		});
+	});
+
+	await findByText('Rejected plan', undefined, { timeout: 15_000 });
+	await findByText('denied');
+	await findByText(/Not now\./);
+});
+
+test('a pending hire approval with a task link renders an Edit & review action and the task link', async () => {
+	const { findByTestId, findAllByTestId } = await renderTeamInbox(
+		async ({ ws, project, projectId }) => {
+			const task = await seedTask(ws, project, { title: 'Hire context task' });
+			await insertApproval(ws, {
+				type: 'hire',
+				payload: {
+					title: 'New Researcher',
+					project_id: projectId,
+					task_id: task.id,
+				},
+			});
+		},
+	);
+
+	// The hire card is unread → shows the "Edit & review" link.
+	const edit = await findByTestId('approval-edit', undefined, { timeout: 15_000 });
+	expect(edit.textContent).toContain('Edit & review');
+
+	// The hire message links to the originating task.
+	const cards = await findAllByTestId('approval-card');
+	const hireCard = cards.find((c) => /Proposing to hire/.test(c.textContent ?? ''));
+	expect(hireCard).toBeTruthy();
+	const taskLink = within(hireCard as HTMLElement)
+		.getAllByRole('link')
+		.find((a) => /\/tasks\//.test(a.getAttribute('href') ?? ''));
+	expect(taskLink).toBeTruthy();
+	expect(taskLink?.getAttribute('href')).toMatch(/\/tasks\//);
+});
+
+test('a designated-repo request with reason repo_add links to project settings', async () => {
+	const { findAllByTestId } = await renderTeamInbox(async ({ ws, projectId }) => {
+		await insertApproval(ws, {
+			type: 'designated_repo_request',
+			payload: {
+				platform: 'GitHub',
+				reason: 'repo_add',
+				project_id: projectId,
+			},
+		});
+	});
+
+	const cards = await findAllByTestId('approval-card', undefined, { timeout: 15_000 });
+	const repoCard = cards.find((c) => /Requesting GitHub OAuth/.test(c.textContent ?? ''));
+	expect(repoCard).toBeTruthy();
+	// The whole card is a Link to the project settings page for repo_add.
+	expect((repoCard as HTMLElement).getAttribute('href')).toContain('/settings');
+	expect(repoCard?.textContent).toContain('add a repo to');
+});
+
+test('a designated-repo request with no reason links to the team general settings', async () => {
+	const { findAllByTestId } = await renderTeamInbox(async ({ ws }) => {
+		await insertApproval(ws, {
+			type: 'designated_repo_request',
+			payload: { platform: 'GitHub' },
+		});
+	});
+
+	const cards = await findAllByTestId('approval-card', undefined, { timeout: 15_000 });
+	const repoCard = cards.find((c) => /Requesting GitHub OAuth to access/.test(c.textContent ?? ''));
+	expect(repoCard).toBeTruthy();
+	expect((repoCard as HTMLElement).getAttribute('href')).toContain('/team-settings/general');
+});
+
+test('an approval type with no dedicated message branch falls back to the de-underscored type label', async () => {
+	const { findAllByText } = await renderTeamInbox(async ({ ws }) => {
+		await insertApproval(ws, {
+			type: 'project_creation',
+			payload: {},
+		});
+	});
+
+	// project_creation has no dedicated ApprovalMessage branch → default label
+	// (`type.replace(/_/g,' ')`). seedWorkspace also seeds a resolved
+	// project_creation approval, so there may be more than one such card; the
+	// default-branch rendering is proven by at least one being present.
+	const labels = await findAllByText('project creation', undefined, { timeout: 15_000 });
+	expect(labels.length).toBeGreaterThanOrEqual(1);
+});
+
+test('the global inbox shows the team name on each card (showTeam)', async () => {
+	const seededTeamName: { name: string } = { name: '' };
+	const { findAllByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Global Approval Project' });
+			void project;
+			// Read the team's display name to assert it surfaces on the card.
+			const { db } = getTestContext();
+			const r = await db.query<{ name: string }>(`SELECT name FROM teams WHERE id = $1`, [
+				ws.team.id,
+			]);
+			seededTeamName.name = r.rows[0].name;
+			await insertApproval(ws, {
+				type: 'strategy',
+				payload: { plan: 'Global-scope plan' },
+			});
+		},
+	});
+
+	await router.navigate({ to: '/home/inbox' });
+
+	const cards = await findAllByTestId('approval-card', undefined, { timeout: 15_000 });
+	const planCard = cards.find((c) => /Global-scope plan/.test(c.textContent ?? ''));
+	expect(planCard).toBeTruthy();
+	await waitFor(() => expect(planCard?.textContent).toContain(seededTeamName.name));
+});

--- a/packages/web/test/connect-required-comment.test.tsx
+++ b/packages/web/test/connect-required-comment.test.tsx
@@ -1,0 +1,353 @@
+import { waitFor } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { getTestContext, renderApp } from './helpers/render';
+import { type SeededWorkspace, seedProject, seedTask, seedWorkspace } from './helpers/seed';
+
+// Component tier (happy-dom). The ConnectRequiredComment renderer is reached
+// through the real task-comments list: we insert an `mcp_connections` row plus a
+// `connect_required` comment that references it, then navigate to the task page.
+//
+// None of branches 1-6 (the Playwright decision tree) apply — this is pure
+// content rendering + click/mutation behaviour, so it stays in the component tier.
+
+interface ConnectorRow {
+	id: string;
+	name: string;
+	display_name: string | null;
+	oauth_connection_id: string | null;
+	activated_at: string | null;
+	revoked_at: string | null;
+	auth_error: string | null;
+}
+
+/** Insert an mcp_connections row directly (the catalog the renderer reads via useMcpConnection). */
+async function insertConnector(input: {
+	name: string;
+	displayName?: string | null;
+	oauthConnectionId?: string | null;
+	activatedAt?: string | null;
+	revokedAt?: string | null;
+	authError?: string | null;
+}): Promise<ConnectorRow> {
+	const { db } = getTestContext();
+	const res = await db.query<ConnectorRow>(
+		`INSERT INTO mcp_connections
+		   (name, display_name, kind, config, oauth_connection_id, install_status,
+		    activated_at, revoked_at, auth_error)
+		 VALUES ($1, $2, 'saas'::mcp_connection_kind, '{"url":"https://mcp.example.com"}'::jsonb,
+		         $3, 'installed'::mcp_install_status, $4, $5, $6)
+		 RETURNING id, name, display_name, oauth_connection_id, activated_at, revoked_at, auth_error`,
+		[
+			input.name,
+			input.displayName ?? null,
+			input.oauthConnectionId ?? null,
+			input.activatedAt ?? null,
+			input.revokedAt ?? null,
+			input.authError ?? null,
+		],
+	);
+	return res.rows[0];
+}
+
+/** A secret + oauth_connections row so a connector can be put in the "active" state (FK targets). */
+async function insertActiveOauthConnection(): Promise<string> {
+	const { db } = getTestContext();
+	const secret = await db.query<{ id: string }>(
+		`INSERT INTO secrets (name, encrypted_value, category)
+		 VALUES ($1, 'enc', 'api_token'::secret_category) RETURNING id`,
+		[`tok-${Math.random().toString(36).slice(2)}`],
+	);
+	const conn = await db.query<{ id: string }>(
+		`INSERT INTO oauth_connections
+		   (provider, provider_account_id, provider_account_label, access_token_secret_id, scopes)
+		 VALUES ('datocms', $1, 'acct', $2, '{}') RETURNING id`,
+		[`acct-${Math.random().toString(36).slice(2)}`, secret.rows[0].id],
+	);
+	return conn.rows[0].id;
+}
+
+/** Post a connect_required comment that points at `connectorId`. */
+async function insertConnectRequiredComment(
+	taskId: string,
+	authorMemberId: string,
+	content: { connector_id: string; display_name: string; provider_id?: string },
+): Promise<void> {
+	const { db } = getTestContext();
+	await db.query(
+		`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
+		 VALUES ($1, $2, 'connect_required'::comment_content_type, $3::jsonb)`,
+		[taskId, authorMemberId, JSON.stringify(content)],
+	);
+}
+
+interface Seeded {
+	projectSlug: string;
+	taskId: string;
+	agentId: string;
+}
+
+async function setup(
+	build: (ws: SeededWorkspace, taskId: string, agentId: string) => Promise<void>,
+) {
+	const seeded: Seeded = { projectSlug: '', taskId: '', agentId: '' };
+	const helpers = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Connect Project' });
+			const task = await seedTask(ws, project, { title: 'Connect Task' });
+			seeded.projectSlug = project.slug;
+			seeded.taskId = task.identifier.toLowerCase();
+			seeded.agentId = ws.agents[0].id;
+			await build(ws, task.id, ws.agents[0].id);
+		},
+	});
+	await helpers.router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
+	});
+	return { ...helpers, seeded };
+}
+
+test('pending connector renders the connect prompt with provider code and links', async () => {
+	const { findByTestId } = await setup(async (_ws, taskId, agentId) => {
+		const connector = await insertConnector({ name: 'datocms', displayName: 'DatoCMS' });
+		await insertConnectRequiredComment(taskId, agentId, {
+			connector_id: connector.id,
+			display_name: 'DatoCMS',
+			provider_id: 'datocms',
+		});
+	});
+
+	const card = await findByTestId('connect-required');
+	expect(card.getAttribute('data-status')).toBe('pending');
+	// display_name, provider_id code chip, and the default "connect to authorize" label.
+	expect(card.textContent).toContain('DatoCMS');
+	expect(card.textContent).toContain('datocms');
+	expect(card.textContent).toContain("authorize this agent's access");
+
+	// The Connect button and the "Open in Connectors" deep link both render.
+	const connectBtn = await findByTestId('connect-button');
+	expect(connectBtn.textContent).toContain('Connect');
+	expect((connectBtn as HTMLButtonElement).disabled).toBe(false);
+
+	const link = await findByTestId('connect-required-link');
+	expect(link.getAttribute('href')).toContain('/connectors?focus=');
+});
+
+test('failed connector shows the failure label plus the auth_error detail', async () => {
+	const { findByTestId } = await setup(async (_ws, taskId, agentId) => {
+		const connector = await insertConnector({
+			name: 'datocms',
+			displayName: 'DatoCMS',
+			authError: 'token exchange rejected',
+		});
+		await insertConnectRequiredComment(taskId, agentId, {
+			connector_id: connector.id,
+			display_name: 'DatoCMS',
+			provider_id: 'datocms',
+		});
+	});
+
+	const card = await findByTestId('connect-required');
+	// Wait for the connector query to resolve and flip the status off the initial
+	// optimistic "pending" placeholder.
+	await waitFor(() => expect(card.getAttribute('data-status')).toBe('failed'));
+	expect(card.textContent).toContain('Last connect attempt failed');
+	expect(card.textContent).toContain('token exchange rejected');
+});
+
+test('revoked connector shows the reconnect label', async () => {
+	const { findByTestId } = await setup(async (_ws, taskId, agentId) => {
+		const connector = await insertConnector({
+			name: 'datocms',
+			displayName: 'DatoCMS',
+			revokedAt: new Date().toISOString(),
+		});
+		await insertConnectRequiredComment(taskId, agentId, {
+			connector_id: connector.id,
+			display_name: 'DatoCMS',
+			provider_id: 'datocms',
+		});
+	});
+
+	const card = await findByTestId('connect-required');
+	await waitFor(() => expect(card.getAttribute('data-status')).toBe('revoked'));
+	expect(card.textContent).toContain('Connector revoked');
+});
+
+test('active connector renders the success state as a manage link', async () => {
+	const { findByTestId } = await setup(async (_ws, taskId, agentId) => {
+		const oauthId = await insertActiveOauthConnection();
+		const connector = await insertConnector({
+			name: 'datocms',
+			displayName: 'DatoCMS',
+			oauthConnectionId: oauthId,
+			activatedAt: new Date().toISOString(),
+		});
+		await insertConnectRequiredComment(taskId, agentId, {
+			connector_id: connector.id,
+			display_name: 'DatoCMS',
+			provider_id: 'datocms',
+		});
+	});
+
+	const active = await findByTestId('connect-required-active');
+	expect(active.textContent).toContain('DatoCMS connected');
+	expect(active.textContent).toContain('Available to every agent run');
+	expect(active.getAttribute('href')).toContain('/connectors?focus=');
+});
+
+test('clicking Connect on a redirect (non-device) connector opens an OAuth popup with the auth_url', async () => {
+	const { findByTestId, user } = await setup(async (_ws, taskId, agentId) => {
+		const connector = await insertConnector({ name: 'datocms', displayName: 'DatoCMS' });
+		await insertConnectRequiredComment(taskId, agentId, {
+			connector_id: connector.id,
+			display_name: 'DatoCMS',
+			provider_id: 'datocms',
+		});
+	});
+
+	await findByTestId('connect-required');
+
+	// Stub auth-start so the click doesn't drive the real DCR discovery machinery
+	// (network), and capture the popup the renderer opens with the returned URL.
+	const original = globalThis.fetch;
+	globalThis.fetch = Object.assign(async (input: RequestInfo | URL, init?: RequestInit) => {
+		const url = typeof input === 'string' ? input : input.toString();
+		if (init?.method === 'POST' && /\/auth-start$/.test(url)) {
+			return new Response(
+				JSON.stringify({ data: { auth_url: 'https://as.example.com/authorize' } }),
+				{
+					status: 200,
+					headers: { 'Content-Type': 'application/json' },
+				},
+			);
+		}
+		return original(input, init);
+	}, original);
+
+	const opened: Array<{ url?: string | URL; name?: string }> = [];
+	const originalOpen = window.open;
+	// Return a truthy popup object so the "pop-up blocked" error path isn't taken.
+	window.open = ((url?: string | URL, name?: string) => {
+		opened.push({ url, name });
+		return {} as Window;
+	}) as typeof window.open;
+
+	try {
+		await user.click(await findByTestId('connect-button'));
+		await new Promise((r) => setTimeout(r, 0));
+		expect(opened.length).toBe(1);
+		expect(opened[0].url).toBe('https://as.example.com/authorize');
+		expect(opened[0].name).toBe('hezo-connect');
+	} finally {
+		window.open = originalOpen;
+		globalThis.fetch = original;
+	}
+});
+
+test('a blocked popup surfaces the pop-up-blocked error', async () => {
+	const { findByTestId, findByText, user } = await setup(async (_ws, taskId, agentId) => {
+		const connector = await insertConnector({ name: 'datocms', displayName: 'DatoCMS' });
+		await insertConnectRequiredComment(taskId, agentId, {
+			connector_id: connector.id,
+			display_name: 'DatoCMS',
+			provider_id: 'datocms',
+		});
+	});
+
+	await findByTestId('connect-required');
+
+	const original = globalThis.fetch;
+	globalThis.fetch = Object.assign(async (input: RequestInfo | URL, init?: RequestInit) => {
+		const url = typeof input === 'string' ? input : input.toString();
+		if (init?.method === 'POST' && /\/auth-start$/.test(url)) {
+			return new Response(
+				JSON.stringify({ data: { auth_url: 'https://as.example.com/authorize' } }),
+				{
+					status: 200,
+					headers: { 'Content-Type': 'application/json' },
+				},
+			);
+		}
+		return original(input, init);
+	}, original);
+
+	const originalOpen = window.open;
+	// Null return = browser blocked the popup.
+	window.open = (() => null) as typeof window.open;
+
+	try {
+		await user.click(await findByTestId('connect-button'));
+		await findByText(/Pop-up blocked/);
+	} finally {
+		window.open = originalOpen;
+		globalThis.fetch = original;
+	}
+});
+
+test('clicking Connect on a device-flow connector (github) opens the device-flow dialog instead of a popup', async () => {
+	const { findByTestId, user } = await setup(async (_ws, taskId, agentId) => {
+		// `github` is the lone capability with deviceAuth, so usesDeviceFlow is true.
+		const connector = await insertConnector({ name: 'github', displayName: 'GitHub' });
+		await insertConnectRequiredComment(taskId, agentId, {
+			connector_id: connector.id,
+			display_name: 'GitHub',
+			provider_id: 'github',
+		});
+	});
+
+	await findByTestId('connect-required');
+
+	// Stub the device-start POST so opening the dialog doesn't drive real GitHub
+	// network calls; the renderer's job here is just to mount the dialog.
+	const original = globalThis.fetch;
+	globalThis.fetch = Object.assign(async (input: RequestInfo | URL, init?: RequestInit) => {
+		const url = typeof input === 'string' ? input : input.toString();
+		if (init?.method === 'POST' && /\/device\/start$/.test(url)) {
+			return new Response(
+				JSON.stringify({
+					data: {
+						flow_id: 'flow-1',
+						user_code: 'ABCD-1234',
+						verification_uri: 'https://github.com/login/device',
+						expires_in: 900,
+						interval: 5,
+					},
+				}),
+				{ status: 200, headers: { 'Content-Type': 'application/json' } },
+			);
+		}
+		// Swallow the subsequent device/poll so the polling loop stays inert/quiet.
+		if (init?.method === 'POST' && /\/device\/poll$/.test(url)) {
+			return new Response(JSON.stringify({ data: { status: 'pending', retry_after: 9999 } }), {
+				status: 202,
+				headers: { 'Content-Type': 'application/json' },
+			});
+		}
+		return original(input, init);
+	}, original);
+
+	const opened: unknown[] = [];
+	const originalOpen = window.open;
+	window.open = ((url?: string | URL) => {
+		opened.push(url);
+		return {} as Window;
+	}) as typeof window.open;
+
+	try {
+		await user.click(await findByTestId('connect-button'));
+		// The device-flow dialog mounts into a Radix portal on document.body.
+		const dialog = await findByTestId('connector-device-flow-dialog');
+		expect(dialog).toBeTruthy();
+		expect(dialog.textContent).toContain('Connect GitHub');
+		// The redirect-popup path (window.open with the named 'hezo-connect' window)
+		// was NOT taken — device flow uses the dialog, not the connect popup.
+		const namedPopups = opened.filter((u) => u === undefined);
+		expect(namedPopups.length).toBe(0);
+	} finally {
+		window.open = originalOpen;
+		globalThis.fetch = original;
+	}
+});

--- a/packages/web/test/connectors-page.test.tsx
+++ b/packages/web/test/connectors-page.test.tsx
@@ -1,0 +1,285 @@
+import { createGitHubSim, type GitHubSim } from '@hezo/server/test/helpers/github-sim';
+import { waitFor, within } from '@testing-library/react';
+import { afterEach, expect, test, vi } from 'vitest';
+import { getTestContext, renderApp } from './helpers/render';
+import { type SeededWorkspace, seedWorkspace } from './helpers/seed';
+
+// Seed a global (instance-wide) saas MCP connector via the project-scoped route.
+// `config.dcr` is pre-baked so the redirect "Connect" path can build an authorize
+// URL entirely in-process (no PRM discovery / DCR network call).
+async function seedSaasConnector(
+	ws: SeededWorkspace,
+	input: { name: string; url: string; withDcr?: boolean },
+): Promise<{ id: string; name: string }> {
+	const { apiBase } = getTestContext();
+	const config: Record<string, unknown> = { url: input.url };
+	if (input.withDcr) {
+		config.dcr = {
+			client_id: 'dcr-client-id',
+			authorization_server_url: 'https://as.example',
+			authorization_endpoint: 'https://as.example/authorize',
+			token_endpoint: 'https://as.example/token',
+			scopes_supported: ['read', 'write'],
+		};
+	}
+	const res = await apiBase(`/api/projects/${ws.internalSlug}/mcp-connections`, {
+		method: 'POST',
+		headers: ws.headers,
+		body: JSON.stringify({ name: input.name, kind: 'saas', config }),
+	});
+	if (res.status !== 201) throw new Error(`seedSaasConnector failed: ${res.status}`);
+	return (await res.json()).data;
+}
+
+// Seed an "active" GitHub OAuth connection straight into the DB (the same shape
+// finalizeConnectorConnection produces) so the GitHub row renders its connected
+// state without driving the full device flow.
+async function seedGithubOAuth(scopes: string[]): Promise<{ id: string }> {
+	const { db } = getTestContext();
+	const secret = await db.query<{ id: string }>(
+		`INSERT INTO secrets (name, encrypted_value, category, allowed_hosts)
+		 VALUES ($1, 'placeholder', 'api_token', ARRAY['github.com'])
+		 RETURNING id`,
+		[`OAUTH_GITHUB_${Math.random().toString(16).slice(2, 10)}`],
+	);
+	const conn = await db.query<{ id: string }>(
+		`INSERT INTO oauth_connections
+		   (provider, provider_account_id, provider_account_label, access_token_secret_id, scopes)
+		 VALUES ('github', $1, 'octocat', $2, $3)
+		 RETURNING id`,
+		[Math.random().toString(16).slice(2, 10), secret.rows[0].id, scopes],
+	);
+	return conn.rows[0];
+}
+
+// Flip a seeded saas connector to the "active" state (oauth_connection_id +
+// activated_at) the way markActive does, so its ConnectorRow shows Disconnect.
+async function markConnectorActive(connectorId: string, oauthConnectionId: string): Promise<void> {
+	const { db } = getTestContext();
+	await db.query(
+		`UPDATE mcp_connections SET oauth_connection_id = $2, activated_at = now(), updated_at = now()
+		 WHERE id = $1`,
+		[connectorId, oauthConnectionId],
+	);
+}
+
+const CONNECTORS_ROUTE = '/projects/$projectId/connectors';
+
+let sim: GitHubSim | null = null;
+const savedEnv: Record<string, string | undefined> = {};
+
+afterEach(async () => {
+	if (sim) {
+		await sim.destroy();
+		sim = null;
+	}
+	for (const [k, v] of Object.entries(savedEnv)) {
+		if (v === undefined) delete process.env[k];
+		else process.env[k] = v;
+	}
+	for (const k of Object.keys(savedEnv)) delete savedEnv[k];
+});
+
+test('lists a seeded MCP connector alongside the always-present GitHub row', async () => {
+	let slug = '';
+	const { findByText, getByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			slug = ws.internalSlug;
+			await seedSaasConnector(ws, { name: 'linear', url: 'https://mcp.linear.example/mcp' });
+		},
+	});
+	await router.navigate({ to: CONNECTORS_ROUTE, params: { projectId: slug } });
+
+	await findByText('Connectors', { selector: 'h1' });
+	// The GitHub row is rendered unconditionally.
+	await findByText('GitHub');
+	// The seeded saas connector renders as its own row with its url.
+	await findByText('linear');
+	await findByText('https://mcp.linear.example/mcp');
+
+	// The GitHub row, with no connection, shows the pending-connect affordance.
+	const list = getByTestId('connectors-list');
+	expect(list.querySelector('[data-connector-name="github"][data-status="pending"]')).toBeTruthy();
+});
+
+test('shows the empty-state hint when there are no connectors or OAuth connections', async () => {
+	let slug = '';
+	const { findByText, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			slug = ws.internalSlug;
+		},
+	});
+	await router.navigate({ to: CONNECTORS_ROUTE, params: { projectId: slug } });
+
+	await findByText('Connectors', { selector: 'h1' });
+	await findByText(/No third-party MCP servers yet/);
+});
+
+test('GitHub row renders the connected state and disconnects', async () => {
+	window.confirm = () => true;
+	let slug = '';
+	const { findByText, findByTestId, queryByText, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			slug = ws.internalSlug;
+			await seedGithubOAuth(['repo', 'workflow', 'read:org']);
+		},
+	});
+	await router.navigate({ to: CONNECTORS_ROUTE, params: { projectId: slug } });
+
+	await findByText('Connectors', { selector: 'h1' });
+	// Connected copy + scopes render.
+	await findByText(/Connected as/);
+	await findByText('octocat');
+	await findByText(/repo workflow read:org/);
+
+	// Disconnect calls DELETE /oauth-connections/:id then invalidates the list.
+	const disconnect = (await findByTestId('connector-revoke')) as HTMLButtonElement;
+	disconnect.click();
+
+	// After deletion the row falls back to the disconnected ("Connect") state.
+	await findByTestId('connector-connect');
+	await waitFor(() => expect(queryByText('octocat')).toBeNull());
+});
+
+test('Connect on a redirect (non-device) connector surfaces the popup-blocked error', async () => {
+	// window.open returns null → the component reports the pop-up was blocked.
+	const openSpy = vi.spyOn(window, 'open').mockReturnValue(null);
+	let slug = '';
+	const { findByText, getByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			slug = ws.internalSlug;
+			await seedSaasConnector(ws, {
+				name: 'linear',
+				url: 'https://mcp.linear.example/mcp',
+				withDcr: true,
+			});
+		},
+	});
+	await router.navigate({ to: CONNECTORS_ROUTE, params: { projectId: slug } });
+
+	await findByText('linear');
+	// Scope to the linear (non-github) connector row's Connect button.
+	const linearRow = within(getByTestId('connectors-list'))
+		.getAllByTestId('connector-row')
+		.find((li) => li.getAttribute('data-connector-id'));
+	if (!linearRow) throw new Error('linear connector row not found');
+	const connectBtn = within(linearRow).getByTestId('connector-connect');
+	connectBtn.click();
+
+	// auth-start resolves an authorize URL (in-process, dcr pre-baked); window.open
+	// was stubbed to null, so the row shows the pop-up-blocked message.
+	await findByText(/Pop-up blocked/);
+	expect(openSpy).toHaveBeenCalledTimes(1);
+});
+
+test('an active non-GitHub connector renders Disconnect and revokes', async () => {
+	window.confirm = () => true;
+	let slug = '';
+	const { findByText, getByTestId, findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			slug = ws.internalSlug;
+			const connector = await seedSaasConnector(ws, {
+				name: 'linear',
+				url: 'https://mcp.linear.example/mcp',
+			});
+			// An active connector needs a linked oauth connection + activated_at.
+			const oauth = await seedGithubOAuth(['repo']);
+			await markConnectorActive(connector.id, oauth.id);
+		},
+	});
+	await router.navigate({ to: CONNECTORS_ROUTE, params: { projectId: slug } });
+
+	await findByText('linear');
+	// connectorStatus → 'active' (oauth_connection_id + activated_at) renders the
+	// Connected badge + a Disconnect button on the connector row.
+	const linearRow = within(getByTestId('connectors-list'))
+		.getAllByTestId('connector-row')
+		.find((li) => li.getAttribute('data-connector-id'));
+	if (!linearRow) throw new Error('linear connector row not found');
+	expect(linearRow.getAttribute('data-status')).toBe('active');
+
+	const revoke = within(linearRow).getByTestId('connector-revoke');
+	revoke.click();
+
+	// Revoke (POST .../revoke → markRevoked) flips the row to revoked; the list
+	// re-renders with the revoked status badge.
+	await waitFor(() => {
+		const row = within(getByTestId('connectors-list'))
+			.getAllByTestId('connector-row')
+			.find((li) => li.getAttribute('data-connector-id'));
+		expect(row?.getAttribute('data-status')).toBe('revoked');
+	});
+	await findByTestId('connector-connect');
+});
+
+test('GitHub Connect drives the device flow to a connected OAuth connection', async () => {
+	// Stand up the GitHub simulator and point the device-flow endpoints at it so
+	// the in-process device/start + poll round-trip to a real (local) AS.
+	sim = await createGitHubSim();
+	savedEnv.GITHUB_OAUTH_BASE_URL = process.env.GITHUB_OAUTH_BASE_URL;
+	savedEnv.GITHUB_OAUTH_CLIENT_ID = process.env.GITHUB_OAUTH_CLIENT_ID;
+	savedEnv.GITHUB_API_BASE_URL = process.env.GITHUB_API_BASE_URL;
+	process.env.GITHUB_OAUTH_BASE_URL = sim.baseUrl;
+	process.env.GITHUB_OAUTH_CLIENT_ID = 'test-client-id';
+	// finalize resolves the GitHub identity + registers the team key against the
+	// REST API, which uses GITHUB_API_BASE_URL — the simulator serves both.
+	process.env.GITHUB_API_BASE_URL = sim.baseUrl;
+
+	// Approve every device flow the moment the sim issues a code, so the first
+	// poll succeeds and the loop returns (no in-flight poll racing teardown).
+	const approveNewFlows = () => {
+		if (!sim) return;
+		for (const flow of sim.state.deviceFlows.values()) {
+			if (!flow.approvedToken) flow.approvedToken = sim.state.token;
+		}
+	};
+
+	const openSpy = vi.spyOn(window, 'open').mockReturnValue(null);
+	let slug = '';
+	const { findByText, findByTestId, getByTestId, queryByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			slug = ws.internalSlug;
+		},
+	});
+	await router.navigate({ to: CONNECTORS_ROUTE, params: { projectId: slug } });
+
+	await findByText('GitHub');
+	// The GitHub row's Connect button: ensures the connector, then opens the dialog.
+	const githubRow = getByTestId('connectors-list').querySelector(
+		'[data-connector-name="github"]',
+	) as HTMLElement;
+	const connectBtn = within(githubRow).getByTestId('connector-connect');
+	connectBtn.click();
+
+	// The device-flow dialog mounts (in a portal on document.body) and renders the
+	// user code returned by the simulator.
+	const dialog = await findByTestId('connector-device-flow-dialog');
+	expect(dialog).toBeTruthy();
+	const code = await findByTestId('connector-device-code');
+	expect(code.textContent).toMatch(/^USR-/);
+	// The verification URI was opened in a new tab.
+	await waitFor(() => expect(openSpy).toHaveBeenCalled());
+
+	// Approve the flow; the next poll finalizes the connection and the dialog
+	// closes itself. Waiting for that close guarantees the polling loop has
+	// returned before afterEach tears the simulator down.
+	approveNewFlows();
+	await waitFor(() => expect(queryByTestId('connector-device-flow-dialog')).toBeNull(), {
+		timeout: 15_000,
+	});
+
+	// The finalized connection now shows in the GitHub row as connected.
+	await findByText(/Connected as/);
+}, 30_000);

--- a/packages/web/test/container-states.test.tsx
+++ b/packages/web/test/container-states.test.tsx
@@ -1,0 +1,216 @@
+// Coverage for routes/projects/$projectId/container.tsx states the existing
+// container-management spec doesn't reach: the error banner + dev-ports list, the
+// stop / restart confirm-dialog action paths, and the LogViewer empty-state copy
+// for the stopping / stopped / no-container phases. The project endpoint is
+// fetch-mocked per state (matching the existing container spec). Component tier —
+// the log scroll/virtualization that genuinely needs a browser is out of scope
+// here (decision-tree items 1 & 5); this covers the render branches the tier can.
+
+import { waitFor } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+import { type SeededWorkspace, seedWorkspace } from './helpers/seed';
+
+interface FakeProjectOpts {
+	slug: string;
+	container_status: string;
+	container_id?: string | null;
+	container_error?: string | null;
+	container_last_logs?: string | null;
+	docker_base_image?: string | null;
+	dev_ports?: Array<{ host: number; container: number }>;
+}
+
+function fakeProject(teamId: string, o: FakeProjectOpts) {
+	return {
+		id: `00000000-0000-0000-0000-${Math.random().toString(16).slice(2, 14).padStart(12, '0')}`,
+		slug: o.slug,
+		name: o.slug,
+		team_id: teamId,
+		task_prefix: 'CT',
+		description: '',
+		docker_base_image: o.docker_base_image ?? null,
+		container_id: o.container_id ?? null,
+		container_status: o.container_status,
+		container_error: o.container_error ?? null,
+		container_last_logs: o.container_last_logs ?? null,
+		dev_ports: o.dev_ports ?? [],
+		repo_count: 0,
+		open_task_count: 0,
+		is_internal: false,
+		max_concurrent_runs: 1,
+		memory_limit_gib: 16,
+		created_at: new Date().toISOString(),
+	};
+}
+
+/** Render the container page for a fetch-mocked project in a given state. */
+async function renderContainer(
+	build: (teamId: string) => ReturnType<typeof fakeProject>,
+	opts?: { onStop?: () => void; onRebuild?: () => void },
+) {
+	let ws!: SeededWorkspace;
+	const ref = { slug: '' };
+	const helpers = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			ws = await seedWorkspace();
+			const project = build(ws.team.id);
+			ref.slug = project.slug;
+			const originalFetch = globalThis.fetch;
+			globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+				const url = typeof input === 'string' ? input : (input as Request).url;
+				const method = init?.method ?? (input instanceof Request ? input.method : 'GET');
+				if (method === 'GET' && new RegExp(`/api/projects/${project.slug}$`).test(url)) {
+					return new Response(JSON.stringify({ data: project }), {
+						status: 200,
+						headers: { 'Content-Type': 'application/json' },
+					});
+				}
+				if (method === 'POST' && /\/projects\/[^/]+\/container\/stop$/.test(url)) {
+					opts?.onStop?.();
+					return new Response(JSON.stringify({ data: { ok: true } }), {
+						status: 200,
+						headers: { 'Content-Type': 'application/json' },
+					});
+				}
+				if (method === 'POST' && /\/projects\/[^/]+\/container\/rebuild$/.test(url)) {
+					opts?.onRebuild?.();
+					return new Response(JSON.stringify({ data: { ok: true } }), {
+						status: 200,
+						headers: { 'Content-Type': 'application/json' },
+					});
+				}
+				return originalFetch(input as RequestInfo, init);
+			}) as typeof globalThis.fetch;
+		},
+	});
+	await helpers.router.navigate({
+		to: '/projects/$projectId/container',
+		params: { projectId: ref.slug },
+	});
+	return { ...helpers, ref };
+}
+
+test('an errored container shows the error banner and the captured error text', async () => {
+	const r = await renderContainer((teamId) =>
+		fakeProject(teamId, {
+			slug: 'errored-container',
+			container_status: 'error',
+			container_id: 'cafef00dbabe',
+			container_error: 'pull access denied for hezo/agent-base',
+		}),
+	);
+
+	// The status badge reads Error and the error banner surfaces the message.
+	await r.findByText('Error', undefined, { timeout: 20_000 });
+	await r.findByText('Container error');
+	await r.findByText(/pull access denied for hezo\/agent-base/);
+});
+
+test('dev ports render as localhost links to the mapped host port', async () => {
+	const r = await renderContainer((teamId) =>
+		fakeProject(teamId, {
+			slug: 'ports-container',
+			container_status: 'running',
+			container_id: 'deadbeef0000',
+			docker_base_image: 'hezo/agent-base:latest',
+			dev_ports: [{ host: 5181, container: 3000 }],
+		}),
+	);
+
+	await r.findByText('Dev Ports', undefined, { timeout: 20_000 });
+	const link = await r.findByText('3000→5181');
+	expect((link.closest('a') as HTMLAnchorElement).getAttribute('href')).toBe(
+		'http://localhost:5181',
+	);
+});
+
+test('stopped container with no logs shows the "not running and no logs were captured" empty state', async () => {
+	const r = await renderContainer((teamId) =>
+		fakeProject(teamId, {
+			slug: 'stopped-container',
+			container_status: 'stopped',
+			container_id: 'abcabcabcabc',
+			docker_base_image: 'hezo/agent-base:latest',
+			container_last_logs: null,
+		}),
+	);
+
+	await r.findByText('Stopped', undefined, { timeout: 20_000 });
+	await r.findByText('Container is not running and no logs were captured.');
+});
+
+test('a never-provisioned container (no container_id) shows the "No container provisioned" empty state and the No-container badge', async () => {
+	const r = await renderContainer((teamId) =>
+		fakeProject(teamId, {
+			slug: 'no-container',
+			container_status: null as unknown as string,
+			container_id: null,
+			docker_base_image: null,
+		}),
+	);
+
+	await r.findByText('No container', undefined, { timeout: 20_000 });
+	await r.findByText('No container provisioned.');
+});
+
+test('a stopped container with a captured snapshot log shows the "Last known logs" badge', async () => {
+	const r = await renderContainer((teamId) =>
+		fakeProject(teamId, {
+			slug: 'snapshot-container',
+			container_status: 'stopped',
+			container_id: 'feedfacefeed',
+			docker_base_image: 'hezo/agent-base:latest',
+			container_last_logs: 'line one\nline two\nline three',
+		}),
+	);
+
+	await r.findByText('Last known logs', undefined, { timeout: 20_000 });
+	// The snapshot lines are split and rendered.
+	await r.findByText('line two');
+});
+
+test('the Stop control opens a confirm dialog whose confirm posts to the stop endpoint', async () => {
+	let stopped = false;
+	const r = await renderContainer(
+		(teamId) =>
+			fakeProject(teamId, {
+				slug: 'stop-flow',
+				container_status: 'running',
+				container_id: 'aaaabbbbcccc',
+				docker_base_image: 'hezo/agent-base:latest',
+			}),
+		{ onStop: () => (stopped = true) },
+	);
+
+	// Stop is enabled while running.
+	const stopBtn = await r.findByRole('button', { name: /Stop/ }, { timeout: 20_000 });
+	await r.user.click(stopBtn);
+
+	// ConfirmDialog renders into a portal on document.body.
+	await r.findByText('Stop this container?');
+	await r.user.click(await r.findByRole('button', { name: 'Stop' }));
+	await waitFor(() => expect(stopped).toBe(true), { timeout: 15_000 });
+});
+
+test('the Restart control opens a confirm dialog whose confirm posts to the rebuild endpoint', async () => {
+	let rebuilt = false;
+	const r = await renderContainer(
+		(teamId) =>
+			fakeProject(teamId, {
+				slug: 'restart-flow',
+				container_status: 'running',
+				container_id: 'ddddeeeeffff',
+				docker_base_image: 'hezo/agent-base:latest',
+			}),
+		{ onRebuild: () => (rebuilt = true) },
+	);
+
+	const restartBtn = await r.findByRole('button', { name: /Restart/ }, { timeout: 20_000 });
+	await r.user.click(restartBtn);
+
+	await r.findByText('Restart container?');
+	await r.user.click(await r.findByRole('button', { name: 'Restart' }));
+	await waitFor(() => expect(rebuilt).toBe(true), { timeout: 15_000 });
+});

--- a/packages/web/test/credential-request-comment.test.tsx
+++ b/packages/web/test/credential-request-comment.test.tsx
@@ -1,3 +1,4 @@
+import { waitFor } from '@testing-library/react';
 import { expect, test } from 'vitest';
 import { getTestContext, renderApp } from './helpers/render';
 import {
@@ -93,4 +94,185 @@ test('credential request with allowed_hosts shows the scoped-hosts line', async 
 	await findByText(/api\.netlify\.com/);
 	// The not-scoped warning must NOT appear when the request is host-scoped.
 	expect(queryByTestId('credential-no-hosts-warning')).toBeNull();
+});
+
+// --- Additional branches: kind badge / instructions, input types, confirmation,
+// --- already-fulfilled, and the inline server-validation error path. ---
+
+interface CredentialContent {
+	name: string;
+	kind: string;
+	instructions?: string;
+	input_type?: string;
+	confirmation_text?: string | null;
+	allowed_hosts?: string[];
+	placeholder?: string;
+}
+
+/** Insert a credential_request comment with full control over content + fulfillment. */
+async function seedCredentialRequestFull(
+	ws: SeededWorkspace,
+	task: SeededTask,
+	content: CredentialContent,
+	opts?: { fulfilledSecretId?: string },
+): Promise<void> {
+	const { db } = getTestContext();
+	const chosen = opts?.fulfilledSecretId
+		? JSON.stringify({ secret_id: opts.fulfilledSecretId, fulfilled_at: new Date().toISOString() })
+		: null;
+	await db.query(
+		`INSERT INTO task_comments (task_id, author_member_id, content_type, content, chosen_option)
+		 VALUES ($1, $2, 'credential_request'::comment_content_type, $3::jsonb, $4::jsonb)`,
+		[task.id, ws.agents[0].id, JSON.stringify(content), chosen],
+	);
+}
+
+async function renderTaskWithCredentialContent(
+	content: CredentialContent,
+	opts?: { fulfilledSecretName?: string },
+) {
+	const seeded = { projectSlug: '', taskId: '' };
+	const helpers = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Cred Branch Project' });
+			const task = await seedTask(ws, project, { title: 'Cred Branch Task' });
+			let fulfilledSecretId: string | undefined;
+			if (opts?.fulfilledSecretName) {
+				const { db } = getTestContext();
+				const r = await db.query<{ id: string }>(
+					`INSERT INTO secrets (name, encrypted_value, category)
+					 VALUES ($1, 'enc', 'credential'::secret_category) RETURNING id`,
+					[opts.fulfilledSecretName],
+				);
+				fulfilledSecretId = r.rows[0].id;
+			}
+			await seedCredentialRequestFull(ws, task, content, { fulfilledSecretId });
+			seeded.projectSlug = project.slug;
+			seeded.taskId = task.identifier.toLowerCase();
+		},
+	});
+	await helpers.router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
+	});
+	return helpers;
+}
+
+test('renders the kind badge and markdown instructions', async () => {
+	const { findByTestId } = await renderTaskWithCredentialContent({
+		name: 'DEPLOY_KEY',
+		kind: 'api_key',
+		instructions: '## How to get it\n\nOpen the dashboard.',
+		input_type: 'text',
+		allowed_hosts: ['api.example.com'],
+	});
+
+	const card = await findByTestId('credential-request', undefined, { timeout: 15_000 });
+	expect(card.textContent).toContain('DEPLOY_KEY');
+	expect(card.textContent).toContain('api_key');
+	expect(card.querySelector('h2')?.textContent).toBe('How to get it');
+});
+
+test('submit is disabled until a value is typed, then stores and shows the fulfilled state', async () => {
+	const { findByTestId, user } = await renderTaskWithCredentialContent({
+		name: 'OPENAI_TOKEN',
+		kind: 'other',
+		input_type: 'text',
+		allowed_hosts: ['api.openai.com'],
+	});
+
+	const submit = (await findByTestId('credential-submit', undefined, {
+		timeout: 15_000,
+	})) as HTMLButtonElement;
+	expect(submit.disabled).toBe(true);
+
+	await user.type(await findByTestId('credential-input'), 'super-secret-value');
+	expect(submit.disabled).toBe(false);
+
+	await user.click(submit);
+
+	const fulfilled = await findByTestId('credential-fulfilled', undefined, { timeout: 15_000 });
+	expect(fulfilled.textContent).toContain('OPENAI_TOKEN provided');
+	expect(fulfilled.textContent).toContain('__HEZO_SECRET_OPENAI_TOKEN__');
+});
+
+test('an invalid github_pat value triggers the rejected-submission error branch inline', async () => {
+	const { findByTestId, findByText, queryByTestId, user } = await renderTaskWithCredentialContent({
+		name: 'GH_PAT',
+		kind: 'github_pat',
+		input_type: 'text',
+		allowed_hosts: ['api.github.com'],
+	});
+
+	await user.type(
+		await findByTestId('credential-input', undefined, { timeout: 15_000 }),
+		'not-a-real-pat',
+	);
+	await user.click(await findByTestId('credential-submit'));
+
+	// The route rejects a value that doesn't look like a GitHub PAT (400). The
+	// renderer's onError surfaces the inline error and the card stays un-fulfilled
+	// (the api client throws a plain ApiError, so the renderer shows its fallback
+	// "Failed to submit" copy — the load-bearing thing is the error branch + that
+	// no fulfilled state is shown).
+	await findByText('Failed to submit');
+	expect(queryByTestId('credential-fulfilled')).toBeNull();
+	expect((await findByTestId('credential-request')).getAttribute('data-credential-name')).toBe(
+		'GH_PAT',
+	);
+});
+
+test('confirmation-style request renders a Confirm button (no value input) and confirms', async () => {
+	const { findByTestId, findByText, queryByTestId, user } = await renderTaskWithCredentialContent({
+		name: 'ACK_DEPLOY',
+		kind: 'other',
+		confirmation_text: 'Do you approve the production deploy?',
+	});
+
+	await findByText('Do you approve the production deploy?', undefined, { timeout: 15_000 });
+	// No value input and no host warning in the confirmation flow.
+	expect(queryByTestId('credential-input')).toBeNull();
+	expect(queryByTestId('credential-no-hosts-warning')).toBeNull();
+
+	const confirm = (await findByTestId('credential-confirm')) as HTMLButtonElement;
+	expect(confirm.disabled).toBe(false);
+	await user.click(confirm);
+
+	const fulfilled = await findByTestId('credential-fulfilled', undefined, { timeout: 15_000 });
+	expect(fulfilled.textContent).toContain('ACK_DEPLOY provided');
+});
+
+test('an already-fulfilled request renders the fulfilled state directly', async () => {
+	const { findByTestId } = await renderTaskWithCredentialContent(
+		{
+			name: 'PREFILLED_TOKEN',
+			kind: 'api_key',
+			placeholder: '__HEZO_SECRET_PREFILLED_TOKEN__',
+		},
+		{ fulfilledSecretName: 'PREFILLED_TOKEN' },
+	);
+
+	const fulfilled = await findByTestId('credential-fulfilled', undefined, { timeout: 15_000 });
+	expect(fulfilled.textContent).toContain('PREFILLED_TOKEN provided');
+	expect(fulfilled.textContent).toContain('__HEZO_SECRET_PREFILLED_TOKEN__');
+});
+
+test('textarea input_type renders a multi-line value field; host override seeds from the request', async () => {
+	const { findByTestId, user } = await renderTaskWithCredentialContent({
+		name: 'PRIVATE_BLOB',
+		kind: 'other',
+		input_type: 'textarea',
+		allowed_hosts: ['api.example.com'],
+	});
+
+	const input = await findByTestId('credential-input', undefined, { timeout: 15_000 });
+	expect(input.tagName).toBe('TEXTAREA');
+
+	const hosts = (await findByTestId('credential-hosts-input')) as HTMLInputElement;
+	await waitFor(() => expect(hosts.value).toBe('api.example.com'));
+	await user.clear(hosts);
+	await user.type(hosts, 'api.override.com');
+	expect(hosts.value).toBe('api.override.com');
 });

--- a/packages/web/test/github-section-states.test.tsx
+++ b/packages/web/test/github-section-states.test.tsx
@@ -1,0 +1,209 @@
+// Coverage for components/github-section.tsx beyond the disconnected CTA that
+// project-settings.test.tsx already hits: the connected state, the repo list
+// (web link + designated lock + deletable rows), the reauth/needs-permissions
+// banner, and the startConnect error path. Rendered through the project settings
+// page. The OAuth-connection / scope-status / repos / mcp-connections endpoints
+// are fetch-mocked (matching agent-executions-project.test.tsx) because seeding a
+// realistic GitHub OAuth connection + repos against the real backend is heavy and
+// orthogonal to what this component renders. Component tier — no real layout/WS.
+
+import { afterEach, expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+import { seedProject, seedWorkspace } from './helpers/seed';
+
+let restoreFetch: (() => void) | null = null;
+afterEach(() => {
+	restoreFetch?.();
+	restoreFetch = null;
+});
+
+interface MockRepo {
+	id: string;
+	repo_identifier: string;
+	host_type: string;
+	is_designated: boolean;
+}
+
+/**
+ * Override the four endpoints GitHubSection reads. `connection` null → the
+ * disconnected CTA; with a connection + sufficient scopes → connected/ready;
+ * with `sufficient:false` → the reauth banner. `ensureFails` makes the
+ * connectors/ensure POST 500 so the connect button surfaces its error.
+ */
+function installGitHubMock(opts: {
+	connection?: { id: string; provider_account_label: string } | null;
+	scopeSufficient?: boolean;
+	scopeMissing?: string[];
+	repos?: MockRepo[];
+	ensureFails?: boolean;
+}) {
+	const original = globalThis.fetch;
+	restoreFetch = () => {
+		globalThis.fetch = original;
+	};
+	const conn = opts.connection ?? null;
+	globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+		const url = typeof input === 'string' ? input : (input as Request).url;
+		const method = init?.method ?? (input instanceof Request ? input.method : 'GET');
+
+		if (method === 'GET' && /\/api\/projects\/[^/]+\/oauth-connections$/.test(url)) {
+			const data = conn
+				? [
+						{
+							id: conn.id,
+							provider: 'github',
+							provider_account_id: 'gh-1',
+							provider_account_label: conn.provider_account_label,
+							scopes: ['repo'],
+							expires_at: null,
+							metadata: {},
+							created_at: new Date().toISOString(),
+							updated_at: new Date().toISOString(),
+						},
+					]
+				: [];
+			return jsonRes(data);
+		}
+		if (method === 'GET' && /\/api\/projects\/[^/]+\/mcp-connections/.test(url)) {
+			return jsonRes([]);
+		}
+		if (
+			method === 'GET' &&
+			/\/api\/projects\/[^/]+\/oauth-connections\/[^/]+\/scope-status$/.test(url)
+		) {
+			return jsonRes({
+				sufficient: opts.scopeSufficient ?? true,
+				missing: opts.scopeMissing ?? [],
+				required: ['repo', 'read:org'],
+			});
+		}
+		if (method === 'GET' && /\/api\/projects\/[^/]+\/repos$/.test(url)) {
+			return jsonRes(opts.repos ?? []);
+		}
+		if (method === 'POST' && /\/api\/projects\/[^/]+\/connectors\/ensure$/.test(url)) {
+			if (opts.ensureFails) {
+				return new Response(
+					JSON.stringify({ error: { code: 'OAUTH_ERROR', message: 'connector setup failed' } }),
+					{ status: 500, headers: { 'Content-Type': 'application/json' } },
+				);
+			}
+			return jsonRes({ id: 'connector-1', name: 'github' });
+		}
+		if (method === 'DELETE' && /\/api\/projects\/[^/]+\/repos\/[^/]+$/.test(url)) {
+			return jsonRes({ ok: true });
+		}
+		return original(input as RequestInfo, init);
+	}) as typeof globalThis.fetch;
+}
+
+function jsonRes(data: unknown, status = 200): Response {
+	return new Response(JSON.stringify({ data }), {
+		status,
+		headers: { 'Content-Type': 'application/json' },
+	});
+}
+
+async function renderSettings(mock: Parameters<typeof installGitHubMock>[0]) {
+	const seeded = { projectSlug: '' };
+	const helpers = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'GH Section Project' });
+			seeded.projectSlug = project.slug;
+			installGitHubMock(mock);
+		},
+	});
+	await helpers.router.navigate({
+		to: '/projects/$projectId/settings',
+		params: { projectId: seeded.projectSlug },
+	});
+	return { ...helpers, seeded };
+}
+
+test('connected with sufficient scopes shows the "Connected as" line', async () => {
+	const r = await renderSettings({
+		connection: { id: 'conn-1', provider_account_label: 'octocat' },
+		scopeSufficient: true,
+		repos: [],
+	});
+
+	// "Connected as octocat." renders once the scope check resolves sufficient.
+	await r.findByText('octocat', undefined, { timeout: 20_000 });
+	// With no repos yet, the ready empty-state card is shown.
+	await r.findByTestId('github-state-ready');
+});
+
+test('connected with repos lists each repo with a web link; designated is locked, others deletable', async () => {
+	const r = await renderSettings({
+		connection: { id: 'conn-1', provider_account_label: 'octocat' },
+		scopeSufficient: true,
+		repos: [
+			{ id: 'r1', repo_identifier: 'octocat/web-app', host_type: 'github', is_designated: true },
+			{ id: 'r2', repo_identifier: 'octocat/lib', host_type: 'github', is_designated: false },
+		],
+	});
+
+	// "Set up repo" header affordance appears once ready + has repos. The repos
+	// query can resolve before scope-status, so await this isReady-gated element
+	// before asserting on the rest of the rendered state.
+	const setupButtons = await r.findAllByTestId('repo-setup-add', undefined, { timeout: 20_000 });
+	expect(setupButtons.length).toBeGreaterThan(0);
+
+	// Web link for the designated repo points at github.com.
+	const link = await r.findByTestId('repo-link-web-app');
+	expect(link.getAttribute('href')).toBe('https://github.com/octocat/web-app');
+	expect(link.getAttribute('target')).toBe('_blank');
+
+	// Designated → lock affordance, no delete button.
+	expect(r.queryByTestId('repo-locked-web-app')).not.toBeNull();
+	expect(r.queryByTestId('repo-delete-web-app')).toBeNull();
+
+	// Non-designated → delete button present, no lock.
+	expect(r.queryByTestId('repo-delete-lib')).not.toBeNull();
+	expect(r.queryByTestId('repo-locked-lib')).toBeNull();
+});
+
+test('a non-github host repo renders the identifier as plain text (no web link)', async () => {
+	const r = await renderSettings({
+		connection: { id: 'conn-1', provider_account_label: 'octocat' },
+		scopeSufficient: true,
+		repos: [
+			{ id: 'r1', repo_identifier: 'gitlab-org/thing', host_type: 'gitlab', is_designated: false },
+		],
+	});
+
+	// repoWebUrl returns null for non-github hosts → no anchor, plain text instead.
+	await r.findByText('gitlab-org/thing', undefined, { timeout: 20_000 });
+	expect(r.queryByTestId('repo-link-thing')).toBeNull();
+});
+
+test('insufficient scopes show the needs-permissions reauth banner with the missing scopes', async () => {
+	const r = await renderSettings({
+		connection: { id: 'conn-1', provider_account_label: 'octocat' },
+		scopeSufficient: false,
+		scopeMissing: ['read:org', 'write:public_key'],
+		repos: [],
+	});
+
+	const banner = await r.findByTestId('github-state-reauth', undefined, { timeout: 20_000 });
+	expect(banner.textContent).toContain('Permissions needed');
+	expect(banner.textContent).toContain('read:org, write:public_key');
+	// The re-authorize button is present.
+	await r.findByTestId('github-reauth');
+});
+
+test('a failing connector-ensure surfaces an inline error under the GitHub heading', async () => {
+	const r = await renderSettings({
+		connection: null,
+		ensureFails: true,
+	});
+
+	// Disconnected CTA renders; clicking Connect kicks off ensureConnector, which
+	// 500s here → the catch sets the inline error. The thrown ApiError is a plain
+	// object (not an Error instance), so startConnect falls back to its generic
+	// message rather than the server's text.
+	const connectBtn = await r.findByTestId('github-connect', undefined, { timeout: 20_000 });
+	await r.user.click(connectBtn);
+	await r.findByText('Failed to start GitHub OAuth');
+});

--- a/packages/web/test/home-needs-you.test.tsx
+++ b/packages/web/test/home-needs-you.test.tsx
@@ -1,0 +1,196 @@
+// Coverage for routes/home/index.tsx beyond the active-card dashboard the
+// existing home-dashboard spec covers: the "Needs you" section (pending approvals
+// of several types + unread admin mentions, the per-type action labels and text,
+// the "Show N more" overflow link), the needs-you → Active-card badge, and the
+// paused OtherProjectRow state. Approvals + admin mentions are seeded directly in
+// the DB (the same way approval-card / inbox-global specs do) and read back
+// through the real cross-project aggregation endpoints. Component tier.
+
+import { ApprovalType } from '@hezo/shared';
+import { waitFor, within } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { getTestContext, renderApp } from './helpers/render';
+import {
+	type SeededProject,
+	type SeededTask,
+	type SeededWorkspace,
+	seedProject,
+	seedTask,
+	seedWorkspace,
+} from './helpers/seed';
+
+async function seedApproval(
+	ws: SeededWorkspace,
+	project: SeededProject,
+	type: string,
+	requestedByMemberId?: string,
+): Promise<void> {
+	const { db } = getTestContext();
+	await db.query(
+		`INSERT INTO approvals (team_id, type, status, payload, requested_by_member_id)
+		 VALUES ($1, $2::approval_type, 'pending'::approval_status, $3::jsonb, $4)`,
+		[ws.team.id, type, JSON.stringify({ project_id: project.id }), requestedByMemberId ?? null],
+	);
+}
+
+async function seedAdminMention(
+	ws: SeededWorkspace,
+	task: SeededTask,
+	text: string,
+): Promise<void> {
+	const { db } = getTestContext();
+	const author = ws.agents.find((a) => a.slug === 'architect') ?? ws.agents[0];
+	const userRow = await db.query<{ user_id: string }>(
+		`SELECT mu.user_id FROM member_users mu
+		 JOIN members m ON m.id = mu.id
+		 WHERE m.team_id = $1 AND mu.role = 'admin' LIMIT 1`,
+		[ws.team.id],
+	);
+	const userId = userRow.rows[0]?.user_id;
+	if (!userId) throw new Error('no admin user on team');
+	const commentRow = await db.query<{ id: string }>(
+		`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
+		 VALUES ($1, $2, 'text'::comment_content_type, $3::jsonb) RETURNING id`,
+		[task.id, author.id, JSON.stringify({ text })],
+	);
+	await db.query(
+		`INSERT INTO admin_mentions (team_id, task_id, comment_id, user_id)
+		 VALUES ($1, $2, $3, $4)`,
+		[ws.team.id, task.id, commentRow.rows[0].id, userId],
+	);
+}
+
+test('the Needs-you section lists a pending approval with its type-specific text and action label', async () => {
+	const ref = { agentTitle: '' };
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Approvals Home' });
+			const captain = ws.agents.find((a) => a.slug === 'captain') ?? ws.agents[0];
+			ref.agentTitle = captain.title;
+			await seedApproval(ws, project, ApprovalType.PlanReview, captain.id);
+		},
+	});
+
+	await router.navigate({ to: '/home' });
+
+	const section = await findByTestId('home-needs-you', undefined, { timeout: 20_000 });
+	// PlanReview → "<who> drafted a plan to review" + an "Open plan" action.
+	expect(section.textContent).toContain('drafted a plan to review');
+	const row = await findByTestId('home-needs-you-row');
+	expect(within(row).getByRole('link').textContent).toBe('Open plan');
+});
+
+test('a designated-repo-request approval surfaces the GitHub-access text and "Set up" action', async () => {
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Repo Approval Home' });
+			// No requested_by_member_id → the "An agent" fallback in approvalText.
+			await seedApproval(ws, project, ApprovalType.DesignatedRepoRequest);
+		},
+	});
+
+	await router.navigate({ to: '/home' });
+
+	const section = await findByTestId('home-needs-you', undefined, { timeout: 20_000 });
+	expect(section.textContent).toContain('An agent');
+	expect(section.textContent).toContain('needs GitHub access to set up the repo');
+	const row = await findByTestId('home-needs-you-row');
+	expect(within(row).getByRole('link').textContent).toBe('Set up');
+});
+
+test('an unread admin mention renders as a mention row linking to the comment with a Reply action', async () => {
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Mention Home' });
+			const task = await seedTask(ws, project, { title: 'Decision Ticket' });
+			await seedAdminMention(ws, task, '@admin please confirm the rollout window.');
+		},
+	});
+
+	await router.navigate({ to: '/home' });
+
+	const section = await findByTestId('home-needs-you', undefined, { timeout: 20_000 });
+	expect(section.textContent).toContain('please confirm the rollout window');
+	const row = await findByTestId('home-needs-you-row');
+	const link = within(row).getByRole('link');
+	expect(link.textContent).toBe('Reply');
+	expect(link.getAttribute('href')).toContain('#comment-');
+});
+
+test('more than five needs-you items collapse behind a "Show N more" link to the inbox', async () => {
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Overflow Home' });
+			// Seed 7 pending approvals → 5 shown, "Show 2 more".
+			for (let i = 0; i < 7; i++) {
+				await seedApproval(ws, project, ApprovalType.Hire);
+			}
+		},
+	});
+
+	await router.navigate({ to: '/home' });
+
+	const section = await findByTestId('home-needs-you', undefined, { timeout: 20_000 });
+	// The heading counts all 7.
+	expect(section.textContent).toContain('Needs you · 7');
+	const more = await findByTestId('home-needs-you-more');
+	expect(more.textContent).toContain('Show 2 more');
+	expect(more.getAttribute('href')).toBe('/home/inbox');
+});
+
+test('a project with pending needs-you items ranks as Active and the card shows the "N need you" badge', async () => {
+	const ref = { name: '' };
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Needs You Card' });
+			ref.name = project.name;
+			await seedApproval(ws, project, ApprovalType.Strategy);
+			await seedApproval(ws, project, ApprovalType.ProjectCreation);
+		},
+	});
+
+	await router.navigate({ to: '/home' });
+
+	// Two pending approvals on the project → it lands in Active with a "2 need you".
+	const active = await findByTestId('home-active', undefined, { timeout: 20_000 });
+	expect(active.textContent).toContain(ref.name);
+	const card = await findByTestId('home-active-card');
+	expect(card.textContent).toContain('2 need you');
+});
+
+test('an idle project with a stopped container renders as a paused Other-projects row', async () => {
+	const ref = { name: '' };
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Paused Project' });
+			ref.name = project.name;
+			// Stopped container, no running agents, no needs-you → an "Other" paused row.
+			await getTestContext().db.query(
+				`UPDATE projects SET container_status = 'stopped' WHERE id = $1`,
+				[project.id],
+			);
+		},
+	});
+
+	await router.navigate({ to: '/home' });
+
+	const other = await findByTestId('home-other', undefined, { timeout: 20_000 });
+	const row = await waitFor(() => {
+		const el = within(other).getByTestId('home-other-row');
+		return el;
+	});
+	expect(row.textContent).toContain(ref.name);
+	expect(row.textContent).toContain('paused');
+});

--- a/packages/web/test/markdown-prose-mentions.test.tsx
+++ b/packages/web/test/markdown-prose-mentions.test.tsx
@@ -1,0 +1,146 @@
+// Coverage for components/markdown-prose.tsx mention-link rendering branches the
+// existing comment / ceo-chat specs don't reach: the KB-doc (skill) mention link,
+// the @admin inbox mention, the passive @@agent mention attribute + bare-slug
+// label, and the plain external-link fallback. Driven through the real task-
+// comment surface so the resolve hooks populate the mention maps against the real
+// backend. Component tier — pure render logic, no layout/WS.
+
+import { waitFor } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { getTestContext, renderApp } from './helpers/render';
+import { seedComment, seedProject, seedTask, seedWorkspace } from './helpers/seed';
+
+async function seedSkill(name: string, slug: string): Promise<void> {
+	const { apiBase, token } = getTestContext();
+	const res = await apiBase('/api/skills', {
+		method: 'POST',
+		headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+		body: JSON.stringify({ name, slug, content: `# ${name}\nbody`, description: 'A KB doc.' }),
+	});
+	if (res.status !== 201) throw new Error(`seed skill failed: ${res.status}`);
+}
+
+test('a bare doc-style reference resolving to a skill renders a KB-doc link to the Skills page', async () => {
+	const seeded = { projectSlug: '', taskId: '' };
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			// A doc-style filename candidate (`runbook.md`) resolves to a skill only
+			// when a skill carries that exact slug — the extracted kb candidate keeps
+			// the extension, so the skill slug must too.
+			await seedSkill('Runbook', 'runbook.md');
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'KB Mention Project' });
+			const task = await seedTask(ws, project, { title: 'KB Mention Task' });
+			// Bare (not backticked — code spans are stripped from candidate extraction).
+			await seedComment(ws, task, 'Follow runbook.md when deploying.');
+			seeded.projectSlug = project.slug;
+			seeded.taskId = task.identifier.toLowerCase();
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
+	});
+
+	// findByTestId auto-waits for the docs/resolve roundtrip + re-render.
+	const link = (await findByTestId('kb-mention-link', undefined, {
+		timeout: 20_000,
+	})) as HTMLAnchorElement;
+	expect(link.getAttribute('href')).toBe('/settings/skills');
+	expect(link.textContent).toContain('runbook.md');
+});
+
+test('@admin in a comment renders an inbox mention link scoped to the project', async () => {
+	const seeded = { projectSlug: '', taskId: '' };
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Admin Mention Project' });
+			const task = await seedTask(ws, project, { title: 'Admin Mention Task' });
+			await seedComment(ws, task, 'Hey @admin can you confirm the budget?');
+			seeded.projectSlug = project.slug;
+			seeded.taskId = task.identifier.toLowerCase();
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
+	});
+
+	const link = (await findByTestId('admin-mention-link', undefined, {
+		timeout: 20_000,
+	})) as HTMLAnchorElement;
+	expect(link.getAttribute('href')).toBe(`/projects/${seeded.projectSlug}/inbox`);
+	expect(link.textContent).toContain('@admin');
+});
+
+test('a plain external markdown link renders as a new-tab anchor (the non-mention fallback)', async () => {
+	const seeded = { projectSlug: '', taskId: '' };
+	const { container, findByText, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'External Link Project' });
+			const task = await seedTask(ws, project, { title: 'External Link Task' });
+			await seedComment(ws, task, 'Docs live at [the site](https://example.com/docs).');
+			seeded.projectSlug = project.slug;
+			seeded.taskId = task.identifier.toLowerCase();
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
+	});
+
+	await findByText(/Docs live at/, undefined, { timeout: 20_000 });
+	const anchor = Array.from(container.querySelectorAll('a')).find(
+		(a) => a.getAttribute('href') === 'https://example.com/docs',
+	) as HTMLAnchorElement | undefined;
+	expect(anchor).toBeTruthy();
+	expect(anchor?.getAttribute('target')).toBe('_blank');
+	expect(anchor?.getAttribute('rel')).toBe('noopener noreferrer');
+	expect(anchor?.textContent).toBe('the site');
+});
+
+test('a passive @@agent mention renders the bare slug as a passive-flagged link', async () => {
+	const seeded = { projectSlug: '', taskId: '', agentSlug: '' };
+	const { container, findByText, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Passive Mention Project' });
+			const task = await seedTask(ws, project, { title: 'Passive Mention Task' });
+			const agentSlug = ws.agents.find((a) => a.slug === 'captain')?.slug ?? ws.agents[0].slug;
+			// `@@slug` is a *passive* mention — links to the agent but renders the bare
+			// slug (no leading @) and carries data-mention-passive.
+			await seedComment(ws, task, `Context for @@${agentSlug} without pinging them.`);
+			seeded.projectSlug = project.slug;
+			seeded.taskId = task.identifier.toLowerCase();
+			seeded.agentSlug = agentSlug;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
+	});
+
+	await findByText(/without pinging them/, undefined, { timeout: 20_000 });
+	const passiveLink = await waitFor(() => {
+		const el = container.querySelector(
+			'[data-testid="agent-mention-link"][data-mention-passive="true"]',
+		) as HTMLAnchorElement | null;
+		if (!el) throw new Error('passive mention link not yet resolved');
+		return el;
+	});
+	expect(passiveLink.getAttribute('href')).toBe(
+		`/projects/${seeded.projectSlug}/agents/${seeded.agentSlug}`,
+	);
+	// Passive form drops the leading "@" in the visible label.
+	expect(passiveLink.textContent).toBe(seeded.agentSlug);
+});

--- a/packages/web/test/mention-autocomplete.test.tsx
+++ b/packages/web/test/mention-autocomplete.test.tsx
@@ -1,0 +1,157 @@
+// Coverage for components/mention-textarea.tsx + components/mention-picker.tsx —
+// the @-mention autocomplete. Driven through the real task-comment composer (it
+// wraps a MentionTextarea) against the real in-process backend's mention search,
+// so the picker renders real agent results. Exercises: opening on "@", rendering
+// options, keyboard navigation + selection, mouse selection, Escape, the "no
+// matches" empty state, and the not-a-trigger case. Component tier — no real
+// layout / viewport / WebSocket (the picker's scrollIntoView is a no-op in
+// happy-dom but the surrounding logic is fully reachable).
+
+import { waitFor } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+import { seedProject, seedTask, seedWorkspace } from './helpers/seed';
+
+async function setupComposer() {
+	const seeded = { projectSlug: '', taskId: '', captainSlug: '' };
+	const helpers = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Mention AC Project' });
+			const task = await seedTask(ws, project, { title: 'Mention AC Task' });
+			seeded.projectSlug = project.slug;
+			seeded.taskId = task.identifier.toLowerCase();
+			seeded.captainSlug = ws.agents.find((a) => a.slug === 'captain')?.slug ?? ws.agents[0].slug;
+		},
+	});
+	await helpers.router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
+	});
+	const composer = (await helpers.findByPlaceholderText('Add a comment...', undefined, {
+		timeout: 15_000,
+	})) as HTMLTextAreaElement;
+	return { ...helpers, seeded, composer };
+}
+
+test('typing "@" opens the picker and shows the searching/results state, with agent options', async () => {
+	const { composer, findByTestId, user } = await setupComposer();
+
+	await user.type(composer, 'Hey @cap');
+
+	// The picker opens and (after the debounced search) renders agent options.
+	await findByTestId('mention-picker', undefined, { timeout: 15_000 });
+	const option = await findByTestId('mention-option-agent', undefined, { timeout: 15_000 });
+	// The agent option surfaces the @handle in its sublabel line.
+	expect(option.textContent).toContain('@');
+	// The kind label is shown on the right.
+	expect(option.textContent?.toLowerCase()).toContain('agent');
+});
+
+test('selecting an agent option with a mouse inserts "@slug " into the textarea', async () => {
+	const { composer, findByTestId, user, seeded } = await setupComposer();
+
+	await user.type(composer, 'Ping @cap');
+	const option = await findByTestId('mention-option-agent', undefined, { timeout: 15_000 });
+	// onMouseDown drives selection (the composer keeps focus).
+	await user.click(option);
+
+	await waitFor(() => {
+		// The partial "@cap" is replaced with the full "@<slug> " insertion.
+		expect(composer.value).toMatch(new RegExp(`Ping @${seeded.captainSlug} $`));
+	});
+});
+
+test('ArrowDown/ArrowUp move the highlight and Enter selects the highlighted option', async () => {
+	const { composer, findByTestId, getAllByTestId, user, seeded } = await setupComposer();
+
+	// Empty query lists the whole roster (server returns all enabled agents on q='').
+	await user.type(composer, '@');
+	await findByTestId('mention-picker', undefined, { timeout: 15_000 });
+	await waitFor(() => expect(getAllByTestId('mention-option-agent').length).toBeGreaterThan(1), {
+		timeout: 15_000,
+	});
+
+	// Move down then back up — exercises both branches; lands back on index 0.
+	await user.keyboard('{ArrowDown}');
+	await user.keyboard('{ArrowUp}');
+	// Enter selects the highlighted option and inserts its handle.
+	await user.keyboard('{Enter}');
+
+	await waitFor(() => expect(composer.value).toMatch(/^@[a-z0-9-]+ $/));
+	// The picker closes after a selection.
+	await waitFor(() => expect(document.querySelector('[data-testid="mention-picker"]')).toBeNull());
+	// Sanity: at least one inserted handle is a real agent slug from this team.
+	expect(composer.value.trim().startsWith('@')).toBe(true);
+	expect(seeded.captainSlug.length).toBeGreaterThan(0);
+});
+
+test('Tab also selects the highlighted option', async () => {
+	const { composer, findByTestId, user } = await setupComposer();
+
+	await user.type(composer, '@cap');
+	await findByTestId('mention-option-agent', undefined, { timeout: 15_000 });
+	await user.keyboard('{Tab}');
+
+	await waitFor(() => expect(composer.value).toMatch(/^@[a-z0-9-]+ $/));
+});
+
+test('Escape closes the picker without inserting anything', async () => {
+	const { composer, findByTestId, user } = await setupComposer();
+
+	await user.type(composer, '@cap');
+	await findByTestId('mention-picker', undefined, { timeout: 15_000 });
+	await user.keyboard('{Escape}');
+
+	await waitFor(() => expect(document.querySelector('[data-testid="mention-picker"]')).toBeNull());
+	// The typed text is left intact; only the popup closed.
+	expect(composer.value).toBe('@cap');
+});
+
+test('a query with no matches shows the "No matches" empty state inside the picker', async () => {
+	const { composer, findByText, user } = await setupComposer();
+
+	await user.type(composer, '@zzzznotarealhandle');
+	// The picker stays open and renders the no-matches line for the query.
+	await findByText(/No matches for @zzzznotarealhandle/, undefined, { timeout: 15_000 });
+});
+
+test('an "@" glued to a preceding word character is not treated as a mention trigger', async () => {
+	const { composer, queryByTestId, user } = await setupComposer();
+
+	// "email@" — the char before "@" is a word char, so detectTrigger bails and the
+	// picker never opens.
+	await user.type(composer, 'reach me at email@');
+	// Give the debounce/search a beat; the picker must not appear.
+	await new Promise((r) => setTimeout(r, 300));
+	expect(queryByTestId('mention-picker')).toBeNull();
+});
+
+test('Cmd/Ctrl+Enter while the picker is open closes it and submits the comment', async () => {
+	const { composer, findByText, findByTestId, user } = await setupComposer();
+
+	// Open the picker, then submit via the keyboard shortcut. The shortcut closes
+	// the picker (not selects an option) and forwards to the composer's onKeyDown,
+	// which submits the comment.
+	await user.type(composer, 'ship it @cap');
+	await findByTestId('mention-picker', undefined, { timeout: 15_000 });
+	await user.keyboard('{Meta>}{Enter}{/Meta}');
+
+	// The picker is dismissed and the comment posts with the literal "@cap" text.
+	await waitFor(() => expect(document.querySelector('[data-testid="mention-picker"]')).toBeNull());
+	await findByText(/ship it @cap/, undefined, { timeout: 15_000 });
+});
+
+test('blurring the textarea closes the open picker', async () => {
+	const { composer, findByTestId, user } = await setupComposer();
+
+	await user.type(composer, '@cap');
+	await findByTestId('mention-picker', undefined, { timeout: 15_000 });
+
+	// Tab out / blur — the close is debounced ~100ms, so wait for it to settle.
+	composer.blur();
+	await waitFor(() => expect(document.querySelector('[data-testid="mention-picker"]')).toBeNull(), {
+		timeout: 2_000,
+	});
+});

--- a/packages/web/test/project-assets-states.test.tsx
+++ b/packages/web/test/project-assets-states.test.tsx
@@ -1,0 +1,273 @@
+// Coverage for routes/projects/$projectId/assets.tsx beyond the existing
+// project-assets spec: the per-content-type AssetIcon variants, the HTML-asset
+// iframe preview, the drag-and-drop overlay toggle, the client-side upload-error
+// chip, and the "attached to N comments" delete-confirm copy. The asset list is
+// fetch-mocked where a specific content_type / attachment count is needed (the
+// upload validator only admits real media types, and wiring a real comment
+// attachment is orthogonal). Real native file-drop with an OS DataTransfer is
+// Playwright territory (decision-tree item 3); here the drag *handlers* are
+// exercised with synthetic events carrying a Files type. Component tier.
+
+import { fireEvent, waitFor } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+import { type SeededWorkspace, seedProject, seedWorkspace } from './helpers/seed';
+
+interface FakeAsset {
+	id: string;
+	content_type: string;
+	byte_size: number;
+	original_filename: string;
+	comment_attachment_count?: number;
+}
+
+function asset(o: FakeAsset) {
+	return {
+		id: o.id,
+		content_type: o.content_type,
+		byte_size: o.byte_size,
+		original_filename: o.original_filename,
+		created_at: new Date().toISOString(),
+		url: `/api/assets/${o.id}?exp=9999999999&sig=deadbeef`,
+		comment_attachment_count: o.comment_attachment_count ?? 0,
+	};
+}
+
+/** Render the assets page with a fetch-mocked asset list. */
+async function renderAssetsWith(assets: ReturnType<typeof asset>[], onDelete?: () => void) {
+	let ws!: SeededWorkspace;
+	const ref = { slug: '' };
+	const helpers = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Asset States Project' });
+			ref.slug = project.slug;
+			const originalFetch = globalThis.fetch;
+			globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+				const url = typeof input === 'string' ? input : (input as Request).url;
+				const method = init?.method ?? (input instanceof Request ? input.method : 'GET');
+				if (method === 'GET' && new RegExp(`/api/projects/${project.slug}/assets$`).test(url)) {
+					return new Response(JSON.stringify({ data: assets }), {
+						status: 200,
+						headers: { 'Content-Type': 'application/json' },
+					});
+				}
+				if (method === 'DELETE' && /\/api\/projects\/[^/]+\/assets\/[^/]+$/.test(url)) {
+					onDelete?.();
+					return new Response(JSON.stringify({ data: { ok: true } }), {
+						status: 200,
+						headers: { 'Content-Type': 'application/json' },
+					});
+				}
+				return originalFetch(input as RequestInfo, init);
+			}) as typeof globalThis.fetch;
+		},
+	});
+	await helpers.router.navigate({
+		to: '/projects/$projectId/assets',
+		params: { projectId: ref.slug },
+	});
+	return { ...helpers, ref };
+}
+
+test('an HTML asset renders a sandboxed iframe preview; non-media types fall back to a file icon', async () => {
+	const r = await renderAssetsWith([
+		asset({
+			id: 'a-html',
+			content_type: 'text/html',
+			byte_size: 2048,
+			original_filename: 'report.html',
+		}),
+		asset({
+			id: 'a-pdf',
+			content_type: 'application/pdf',
+			byte_size: 4096,
+			original_filename: 'spec.pdf',
+		}),
+		asset({
+			id: 'a-audio',
+			content_type: 'audio/mpeg',
+			byte_size: 8192,
+			original_filename: 'voice.mp3',
+		}),
+		asset({
+			id: 'a-video',
+			content_type: 'video/mp4',
+			byte_size: 1048576,
+			original_filename: 'clip.mp4',
+		}),
+		asset({
+			id: 'a-bin',
+			content_type: 'application/octet-stream',
+			byte_size: 10,
+			original_filename: 'data.bin',
+		}),
+	]);
+
+	// The HTML asset gets a sandboxed iframe pointed at its signed URL.
+	const card = await r.findByText('report.html', undefined, { timeout: 20_000 });
+	const li = card.closest('li') as HTMLElement;
+	const iframe = li.querySelector('iframe') as HTMLIFrameElement;
+	expect(iframe).not.toBeNull();
+	expect(iframe.getAttribute('sandbox')).toBe('');
+	expect(iframe.getAttribute('src')).toContain('/api/assets/a-html');
+
+	// The other rows render (icon branches: pdf, audio, video, generic file).
+	await r.findByText('spec.pdf');
+	await r.findByText('voice.mp3');
+	await r.findByText('clip.mp4');
+	await r.findByText('data.bin');
+	// Byte-size formatting: 1 MB video, 8.0 KB audio.
+	expect(li.ownerDocument.body.textContent).toContain('1.0 MB');
+});
+
+test('deleting an asset attached to comments warns how many comments it will be removed from', async () => {
+	const r = await renderAssetsWith([
+		asset({
+			id: 'a-attached',
+			content_type: 'image/png',
+			byte_size: 512,
+			original_filename: 'shared.png',
+			comment_attachment_count: 3,
+		}),
+	]);
+
+	await r.findByText('shared.png', undefined, { timeout: 20_000 });
+	await r.user.click(await r.findByTestId('asset-delete'));
+	// ConfirmDialog (portal on document.body) shows the attachment-aware copy.
+	await r.findByText(/attached to 3 comments and will be removed from them/);
+});
+
+test('a singular attachment count uses singular comment / it wording', async () => {
+	const r = await renderAssetsWith([
+		asset({
+			id: 'a-one',
+			content_type: 'image/png',
+			byte_size: 256,
+			original_filename: 'one.png',
+			comment_attachment_count: 1,
+		}),
+	]);
+
+	await r.findByText('one.png', undefined, { timeout: 20_000 });
+	await r.user.click(await r.findByTestId('asset-delete'));
+	await r.findByText(/attached to 1 comment and will be removed from it/);
+});
+
+test('confirming delete posts to the delete endpoint', async () => {
+	let deleted = false;
+	const r = await renderAssetsWith(
+		[
+			asset({
+				id: 'a-del',
+				content_type: 'image/png',
+				byte_size: 128,
+				original_filename: 'gone.png',
+			}),
+		],
+		() => {
+			deleted = true;
+		},
+	);
+
+	await r.findByText('gone.png', undefined, { timeout: 20_000 });
+	await r.user.click(await r.findByTestId('asset-delete'));
+	// Plain (no-attachment) confirm copy.
+	await r.findByText(/permanently removed/);
+	await r.user.click(await r.findByRole('button', { name: 'Delete' }));
+	await waitFor(() => expect(deleted).toBe(true), { timeout: 15_000 });
+});
+
+test('dragging files over the drop zone shows the "Drop to upload" overlay, which clears on leave', async () => {
+	let ws!: SeededWorkspace;
+	const ref = { slug: '' };
+	const { findByText, findByTestId, queryByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Drag Zone Project' });
+			ref.slug = project.slug;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/assets',
+		params: { projectId: ref.slug },
+	});
+
+	const zone = await findByTestId('asset-drop-zone', undefined, { timeout: 20_000 });
+
+	// happy-dom doesn't synthesize a real OS DataTransfer; pass a minimal stub
+	// whose `types` includes 'Files' so the handlers run. The overlay-toggle logic
+	// is what's under test (real file payload handling is Playwright's job).
+	const dataTransfer = { types: ['Files'], files: [] } as unknown as DataTransfer;
+
+	fireEvent.dragEnter(zone, { dataTransfer });
+	await findByText('Drop to upload');
+	expect(queryByTestId('asset-drop-overlay')).not.toBeNull();
+
+	// dragOver keeps the overlay; dragLeave (depth back to 0) removes it.
+	fireEvent.dragOver(zone, { dataTransfer });
+	fireEvent.dragLeave(zone, { dataTransfer });
+	await waitFor(() => expect(queryByTestId('asset-drop-overlay')).toBeNull());
+});
+
+test('dropping files onto the zone clears the overlay and routes them to the uploader', async () => {
+	let ws!: SeededWorkspace;
+	const ref = { slug: '' };
+	const { findByTestId, queryByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Drop Project' });
+			ref.slug = project.slug;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/assets',
+		params: { projectId: ref.slug },
+	});
+
+	const zone = await findByTestId('asset-drop-zone', undefined, { timeout: 20_000 });
+	const file = new File([new Uint8Array([1, 2, 3])], 'dropped.png', { type: 'image/png' });
+	const dataTransfer = { types: ['Files'], files: [file] } as unknown as DataTransfer;
+
+	fireEvent.dragEnter(zone, { dataTransfer });
+	await findByTestId('asset-drop-overlay');
+	// Drop resets the overlay and hands the file list to handleFiles (real upload).
+	fireEvent.drop(zone, { dataTransfer });
+	await waitFor(() => expect(queryByTestId('asset-drop-overlay')).toBeNull());
+	// The dropped PNG uploads through the real backend and lands in the library.
+	await findByTestId('asset-card', undefined, { timeout: 20_000 });
+});
+
+test('uploading a disallowed file type surfaces a transient error chip', async () => {
+	let ws!: SeededWorkspace;
+	const ref = { slug: '' };
+	const { findByTestId, router, user } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Upload Error Project' });
+			ref.slug = project.slug;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/assets',
+		params: { projectId: ref.slug },
+	});
+
+	const input = (await findByTestId('asset-file-input', undefined, {
+		timeout: 20_000,
+	})) as HTMLInputElement;
+	// The upload hook rejects unsupported extensions client-side → the error chip
+	// renders with the filename + message.
+	const bad = new File([new Uint8Array([0])], 'malware.exe', { type: 'application/x-msdownload' });
+	await user.upload(input, bad);
+
+	const chip = await findByTestId('asset-upload-error');
+	expect(chip.textContent).toContain('malware.exe');
+});

--- a/packages/web/test/project-task-list-header.test.tsx
+++ b/packages/web/test/project-task-list-header.test.tsx
@@ -1,0 +1,93 @@
+import { waitFor } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { getTestContext, renderApp } from './helpers/render';
+import {
+	type SeededProject,
+	type SeededWorkspace,
+	seedProject,
+	seedTask,
+	seedWorkspace,
+} from './helpers/seed';
+
+// Component tier (happy-dom). ProjectTaskListHeader renders the onboarding phase
+// banner when the project has an OPEN `team-coherence-review` task (the CEO is
+// still onboarding the team). The progress-bar branch is intentionally disabled
+// in the source (SHOW_TASK_PROGRESS_BAR=false) and already covered by
+// task-progress-summary.test.tsx; this file covers the phase-banner path, which
+// those tests don't reach.
+//
+// The banner is pure content driven by the real /tasks/progress-summary route —
+// no real layout / WebSocket / viewport behaviour — so it stays component-tier.
+
+/** Label a seeded task as an OPEN team-coherence-review so phase_banner fires. */
+async function makeCoherenceReviewTask(taskId: string, status = 'in_progress'): Promise<void> {
+	const { db } = getTestContext();
+	await db.query(
+		`UPDATE tasks
+		   SET labels = '["team-coherence-review"]'::jsonb,
+		       status = $2::task_status
+		 WHERE id = $1`,
+		[taskId, status],
+	);
+}
+
+async function renderTasksPage(
+	build: (ws: SeededWorkspace, project: SeededProject) => Promise<void>,
+) {
+	const ref = { projectSlug: '' };
+	const helpers = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Header Project' });
+			ref.projectSlug = project.slug;
+			await build(ws, project);
+		},
+	});
+	await helpers.router.navigate({
+		to: '/projects/$projectId/tasks',
+		params: { projectId: ref.projectSlug },
+	});
+	return { ...helpers, ref };
+}
+
+test('renders the onboarding phase banner while a coherence-review task is open', async () => {
+	const { findByTestId } = await renderTasksPage(async (ws, project) => {
+		const task = await seedTask(ws, project, { title: 'Coherence review' });
+		await makeCoherenceReviewTask(task.id);
+	});
+
+	const banner = await findByTestId('project-task-list-phase-banner-onboarding', undefined, {
+		timeout: 15_000,
+	});
+	expect(banner.textContent).toContain('Please wait whilst the CEO onboards your new team members');
+	// It's announced as a status region for assistive tech.
+	expect(banner.getAttribute('role')).toBe('status');
+});
+
+test('does NOT render the banner once the coherence-review task is closed', async () => {
+	const { findByTestId, queryByTestId } = await renderTasksPage(async (ws, project) => {
+		const task = await seedTask(ws, project, { title: 'Coherence review' });
+		// Closed → excluded from the coherence query → phase_banner is null.
+		await makeCoherenceReviewTask(task.id, 'closed');
+	});
+
+	// The task list mounts, but no onboarding banner is shown.
+	await findByTestId('task-list-main', undefined, { timeout: 15_000 });
+	await waitFor(() => {
+		expect(queryByTestId('project-task-list-phase-banner-onboarding')).toBeNull();
+	});
+	// And the (disabled) progress bar stays hidden too.
+	expect(queryByTestId('task-progress-bar')).toBeNull();
+});
+
+test('does NOT render the banner for a plain project with no coherence-review task', async () => {
+	const { findByTestId, queryByTestId } = await renderTasksPage(async (ws, project) => {
+		await seedTask(ws, project, { title: 'Ordinary task' });
+	});
+
+	await findByTestId('task-list-main', undefined, { timeout: 15_000 });
+	await waitFor(() => {
+		expect(queryByTestId('project-task-list-phase-banner-onboarding')).toBeNull();
+	});
+});

--- a/packages/web/test/run-trigger.test.ts
+++ b/packages/web/test/run-trigger.test.ts
@@ -1,0 +1,214 @@
+import { WakeupSource } from '@hezo/shared';
+import { expect, test } from 'vitest';
+import type { HeartbeatRun } from '../src/hooks/use-heartbeat-runs';
+import { formatTriggerReason } from '../src/lib/run-trigger';
+
+const TEAM = 'acme';
+
+// A fully-populated run with every trigger/deep-link field present. Tests start
+// from this and null out fields to drive the fallback branches.
+function run(overrides: Partial<HeartbeatRun>): HeartbeatRun {
+	return {
+		id: 'run-1',
+		member_id: 'm-1',
+		team_id: 't-1',
+		wakeup_id: null,
+		task_id: 'task-1',
+		task_identifier: 'ACME-7',
+		task_title: 'Do the thing',
+		project_id: 'p-1',
+		project_slug: 'web-app',
+		project_name: 'Web App',
+		status: 'succeeded',
+		queued_reason: null,
+		started_at: null,
+		finished_at: null,
+		exit_code: 0,
+		error: null,
+		input_tokens: 0,
+		output_tokens: 0,
+		cost_cents: 0,
+		usage_partial: false,
+		invocation_command: null,
+		log_text: null,
+		working_dir: null,
+		trigger_source: null,
+		trigger_payload: null,
+		trigger_comment_id: null,
+		trigger_comment_public_id: 'c-pub-99',
+		trigger_actor_member_id: null,
+		trigger_actor_slug: 'alice',
+		trigger_actor_title: 'Alice',
+		trigger_comment_task_id: 'task-1',
+		trigger_comment_task_identifier: 'ACME-7',
+		trigger_comment_project_slug: 'web-app',
+		run_comment_id: null,
+		run_comment_public_id: null,
+		created_tasks: [],
+		created_docs: [],
+		created_skills: [],
+		proposed_skills: [],
+		...overrides,
+	};
+}
+
+test('mention with actor + task links to the triggering comment', () => {
+	const label = formatTriggerReason(run({ trigger_source: WakeupSource.Mention }), TEAM);
+	expect(label.source).toBe(WakeupSource.Mention);
+	expect(label.text).toBe('Mentioned by @alice in ACME-7');
+	expect(label.href).toBe('/teams/acme/projects/web-app/tasks/ACME-7#comment-c-pub-99');
+});
+
+test('mention without actor/task falls back to generic copy but keeps the comment href when available', () => {
+	const label = formatTriggerReason(
+		run({
+			trigger_source: WakeupSource.Mention,
+			trigger_actor_slug: null,
+			trigger_comment_task_identifier: null,
+			task_identifier: null,
+		}),
+		TEAM,
+	);
+	expect(label.text).toBe('Mentioned in a comment');
+	// commentHref still resolves: it depends on task_identifier of the *comment*,
+	// project slug, and the comment public id — only the actor was dropped here,
+	// but the comment task identifier was nulled too, so href is undefined.
+	expect(label.href).toBeUndefined();
+});
+
+test('reply with actor + task links to the comment', () => {
+	const label = formatTriggerReason(run({ trigger_source: WakeupSource.Reply }), TEAM);
+	expect(label.text).toBe('Reply from @alice in ACME-7');
+	expect(label.href).toBe('/teams/acme/projects/web-app/tasks/ACME-7#comment-c-pub-99');
+});
+
+test('reply without actor uses fallback copy', () => {
+	const label = formatTriggerReason(
+		run({ trigger_source: WakeupSource.Reply, trigger_actor_slug: null, task_identifier: null }),
+		TEAM,
+	);
+	expect(label.text).toBe('Reply to your earlier comment');
+});
+
+test('comment uses the comment href when present', () => {
+	const label = formatTriggerReason(run({ trigger_source: WakeupSource.Comment }), TEAM);
+	expect(label.text).toBe('New comment on ACME-7');
+	expect(label.href).toBe('/teams/acme/projects/web-app/tasks/ACME-7#comment-c-pub-99');
+});
+
+test('comment falls back to the task href when no comment public id', () => {
+	const label = formatTriggerReason(
+		run({ trigger_source: WakeupSource.Comment, trigger_comment_public_id: null }),
+		TEAM,
+	);
+	expect(label.text).toBe('New comment on ACME-7');
+	// No comment id → commentHref undefined → taskHref used instead.
+	expect(label.href).toBe('/teams/acme/projects/web-app/tasks/ACME-7');
+});
+
+test('comment with no task id at all gets generic copy and no href', () => {
+	const label = formatTriggerReason(
+		run({
+			trigger_source: WakeupSource.Comment,
+			trigger_comment_task_identifier: null,
+			task_identifier: null,
+		}),
+		TEAM,
+	);
+	expect(label.text).toBe('New comment on assigned task');
+	expect(label.href).toBeUndefined();
+});
+
+test('assignment links to the task', () => {
+	const label = formatTriggerReason(
+		run({
+			trigger_source: WakeupSource.Assignment,
+			trigger_comment_task_identifier: null,
+			trigger_comment_project_slug: null,
+		}),
+		TEAM,
+	);
+	expect(label.text).toBe('Assigned to ACME-7');
+	// taskHref falls back to task_identifier/project_slug when the comment fields are absent.
+	expect(label.href).toBe('/teams/acme/projects/web-app/tasks/ACME-7');
+});
+
+test('assignment without a task id uses generic copy', () => {
+	const label = formatTriggerReason(
+		run({
+			trigger_source: WakeupSource.Assignment,
+			trigger_comment_task_identifier: null,
+			task_identifier: null,
+		}),
+		TEAM,
+	);
+	expect(label.text).toBe('Assigned to an task');
+	expect(label.href).toBeUndefined();
+});
+
+test('automation reads the kind from the payload', () => {
+	const label = formatTriggerReason(
+		run({ trigger_source: WakeupSource.Automation, trigger_payload: { kind: 'stale-pr-nudge' } }),
+		TEAM,
+	);
+	expect(label.text).toBe('Automation: stale-pr-nudge');
+});
+
+test('automation falls back to the reason field, then to bare label', () => {
+	const withReason = formatTriggerReason(
+		run({ trigger_source: WakeupSource.Automation, trigger_payload: { reason: 'budget-reset' } }),
+		TEAM,
+	);
+	expect(withReason.text).toBe('Automation: budget-reset');
+
+	const bare = formatTriggerReason(
+		run({ trigger_source: WakeupSource.Automation, trigger_payload: null }),
+		TEAM,
+	);
+	expect(bare.text).toBe('Automation');
+
+	// Non-string payload values are ignored by getString.
+	const nonString = formatTriggerReason(
+		run({ trigger_source: WakeupSource.Automation, trigger_payload: { kind: 42 } }),
+		TEAM,
+	);
+	expect(nonString.text).toBe('Automation');
+});
+
+test('heartbeat is a fixed label', () => {
+	const label = formatTriggerReason(run({ trigger_source: WakeupSource.Heartbeat }), TEAM);
+	expect(label.text).toBe('Scheduled heartbeat');
+	expect(label.href).toBeUndefined();
+});
+
+test('timer reads the reason from the payload, with a fallback', () => {
+	const withReason = formatTriggerReason(
+		run({ trigger_source: WakeupSource.Timer, trigger_payload: { reason: 'no-output' } }),
+		TEAM,
+	);
+	expect(withReason.text).toBe('Recovery timer: no-output');
+
+	const bare = formatTriggerReason(
+		run({ trigger_source: WakeupSource.Timer, trigger_payload: {} }),
+		TEAM,
+	);
+	expect(bare.text).toBe('Recovery timer');
+});
+
+test('on-demand is a fixed label', () => {
+	const label = formatTriggerReason(run({ trigger_source: WakeupSource.OnDemand }), TEAM);
+	expect(label.text).toBe('Manually started');
+});
+
+test('unknown / null trigger source falls through to the default branch', () => {
+	const nullSource = formatTriggerReason(run({ trigger_source: null }), TEAM);
+	expect(nullSource.text).toBe('Unknown trigger');
+	expect(nullSource.source).toBeNull();
+
+	// CredentialProvided has no case in the switch, so it hits default too.
+	const credential = formatTriggerReason(
+		run({ trigger_source: WakeupSource.CredentialProvided }),
+		TEAM,
+	);
+	expect(credential.text).toBe('Unknown trigger');
+});

--- a/packages/web/test/settings-skills-registry.test.tsx
+++ b/packages/web/test/settings-skills-registry.test.tsx
@@ -1,0 +1,291 @@
+// Coverage for the skills.sh registry search panel and the delete flow on
+// routes/settings/skills.tsx — the parts the existing instance-skills /
+// settings-skills specs don't reach: saving a token, the configured search form,
+// rendering + installing a result, the no-results and error states, and the
+// list-row delete confirm. Component tier (no real layout / WS). The token is set
+// for real via the API (PUT /api/skills/registry/token) so the panel renders its
+// *configured* search form; only the search / install responses are fetch-mocked,
+// because those reach the external skills.sh service server-side.
+
+import type { RegistrySkillSearchResult } from '@hezo/shared';
+import { waitFor } from '@testing-library/react';
+import { afterEach, expect, test } from 'vitest';
+import { getTestContext, renderApp } from './helpers/render';
+
+let restoreFetch: (() => void) | null = null;
+afterEach(() => {
+	restoreFetch?.();
+	restoreFetch = null;
+});
+
+function result(overrides: Partial<RegistrySkillSearchResult>): RegistrySkillSearchResult {
+	return {
+		id: 'octo/repo/stripe-helper',
+		name: 'Stripe Helper',
+		source: 'octo/repo',
+		slug: 'stripe-helper',
+		installs: 1234,
+		url: 'https://skills.sh/octo/repo/stripe-helper',
+		...overrides,
+	};
+}
+
+async function setRegistryToken(): Promise<void> {
+	const { apiBase, token } = getTestContext();
+	const res = await apiBase('/api/skills/registry/token', {
+		method: 'PUT',
+		headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+		body: JSON.stringify({ token: 'sk-registry-test-token' }),
+	});
+	if (res.status !== 200) throw new Error(`set token failed: ${res.status}`);
+}
+
+/**
+ * Mock just the registry search + install endpoints (these talk to skills.sh
+ * server-side). Must be installed after renderApp's seed has run so it captures
+ * the harness fetch as the passthrough. The token-status GET is left to the real
+ * backend, which reports configured:true once {@link setRegistryToken} ran.
+ */
+function installSearchMock(opts: {
+	searchResults?: RegistrySkillSearchResult[];
+	searchStatus?: number;
+	searchError?: { message: string };
+}) {
+	const original = globalThis.fetch;
+	restoreFetch = () => {
+		globalThis.fetch = original;
+	};
+	globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+		const url = typeof input === 'string' ? input : (input as Request).url;
+		const method = init?.method ?? (input instanceof Request ? input.method : 'GET');
+
+		if (method === 'GET' && /\/api\/skills\/registry\/search/.test(url)) {
+			if (opts.searchError) {
+				return new Response(
+					JSON.stringify({ error: { code: 'REGISTRY_ERROR', message: opts.searchError.message } }),
+					{ status: opts.searchStatus ?? 400, headers: { 'Content-Type': 'application/json' } },
+				);
+			}
+			return new Response(JSON.stringify({ data: opts.searchResults ?? [] }), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			});
+		}
+		if (method === 'POST' && /\/api\/skills\/registry\/install$/.test(url)) {
+			return new Response(
+				JSON.stringify({ data: { slug: 'stripe-helper', name: 'Stripe Helper' } }),
+				{ status: 201, headers: { 'Content-Type': 'application/json' } },
+			);
+		}
+		return original(input as RequestInfo, init);
+	}) as typeof globalThis.fetch;
+}
+
+test('with no token configured, the search panel prompts to save a token and gates Save on input', async () => {
+	const r = await renderApp({ initialPath: '/settings/skills' });
+
+	await r.user.click(await r.findByTestId('toggle-search'));
+	const tokenInput = await r.findByLabelText('skills.sh API token');
+	expect((tokenInput as HTMLInputElement).type).toBe('password');
+
+	const saveBtn = (await r.findByRole('button', { name: 'Save token' })) as HTMLButtonElement;
+	expect(saveBtn.disabled).toBe(true);
+	await r.user.type(tokenInput, 'sk-registry-123');
+	expect(saveBtn.disabled).toBe(false);
+});
+
+test('a configured token shows the search form and renders a result with source, install count, and skills.sh link', async () => {
+	const r = await renderApp({
+		initialPath: '/settings/skills',
+		seed: async () => {
+			await setRegistryToken();
+			installSearchMock({
+				searchResults: [result({ name: 'Stripe Helper', source: 'octo/repo', installs: 4200 })],
+			});
+		},
+	});
+
+	await r.user.click(await r.findByTestId('toggle-search'));
+	const searchInput = await r.findByLabelText('Search skills.sh', undefined, { timeout: 15_000 });
+
+	// The form's Search submit button is disabled under 2 chars; type a real query
+	// and submit via Enter (two buttons normalize to the name "Search", so the
+	// keyboard submit is the unambiguous trigger).
+	const searchSubmit = (await r.findByText('Search', { selector: 'button' })) as HTMLButtonElement;
+	expect(searchSubmit.disabled).toBe(true);
+	await r.user.type(searchInput, 'stripe');
+	expect(searchSubmit.disabled).toBe(false);
+	await r.user.keyboard('{Enter}');
+
+	await r.findByText('Stripe Helper');
+	await r.findByText(/octo\/repo · 4,200 installs/);
+	const link = await r.findByLabelText('Open Stripe Helper on skills.sh');
+	expect(link.getAttribute('href')).toBe('https://skills.sh/octo/repo/stripe-helper');
+	expect(link.getAttribute('target')).toBe('_blank');
+});
+
+test('clicking Add on a result installs it via the registry endpoint', async () => {
+	let installed = false;
+	const r = await renderApp({
+		initialPath: '/settings/skills',
+		seed: async () => {
+			await setRegistryToken();
+			// Wrap the install mock to record that it fired.
+			const original = globalThis.fetch;
+			restoreFetch = () => {
+				globalThis.fetch = original;
+			};
+			globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+				const url = typeof input === 'string' ? input : (input as Request).url;
+				const method = init?.method ?? (input instanceof Request ? input.method : 'GET');
+				if (method === 'GET' && /\/api\/skills\/registry\/search/.test(url)) {
+					return new Response(JSON.stringify({ data: [result({ name: 'Stripe Helper' })] }), {
+						status: 200,
+						headers: { 'Content-Type': 'application/json' },
+					});
+				}
+				if (method === 'POST' && /\/api\/skills\/registry\/install$/.test(url)) {
+					installed = true;
+					return new Response(
+						JSON.stringify({ data: { slug: 'stripe-helper', name: 'Stripe Helper' } }),
+						{ status: 201, headers: { 'Content-Type': 'application/json' } },
+					);
+				}
+				return original(input as RequestInfo, init);
+			}) as typeof globalThis.fetch;
+		},
+	});
+
+	await r.user.click(await r.findByTestId('toggle-search'));
+	await r.user.type(
+		await r.findByLabelText('Search skills.sh', undefined, { timeout: 15_000 }),
+		'stripe',
+	);
+	await r.user.keyboard('{Enter}');
+
+	await r.findByText('Stripe Helper');
+	const addButtons = await r.findAllByRole('button', { name: /Add/ });
+	await r.user.click(addButtons[addButtons.length - 1]);
+	await waitFor(() => expect(installed).toBe(true));
+});
+
+test('a registry search error surfaces the error message', async () => {
+	const r = await renderApp({
+		initialPath: '/settings/skills',
+		seed: async () => {
+			await setRegistryToken();
+			installSearchMock({
+				searchError: { message: 'skills.sh is unavailable' },
+				searchStatus: 503,
+			});
+		},
+	});
+
+	await r.user.click(await r.findByTestId('toggle-search'));
+	await r.user.type(
+		await r.findByLabelText('Search skills.sh', undefined, { timeout: 15_000 }),
+		'react',
+	);
+	await r.user.keyboard('{Enter}');
+
+	await r.findByText('skills.sh is unavailable');
+});
+
+test('a configured search with no results shows the empty-results message', async () => {
+	const r = await renderApp({
+		initialPath: '/settings/skills',
+		seed: async () => {
+			await setRegistryToken();
+			installSearchMock({ searchResults: [] });
+		},
+	});
+
+	await r.user.click(await r.findByTestId('toggle-search'));
+	await r.user.type(
+		await r.findByLabelText('Search skills.sh', undefined, { timeout: 15_000 }),
+		'nonexistent-xyz',
+	);
+	await r.user.keyboard('{Enter}');
+
+	await r.findByText(/No results for/);
+});
+
+test('the Clear token control resets the panel back to the token prompt', async () => {
+	const r = await renderApp({
+		initialPath: '/settings/skills',
+		seed: async () => {
+			await setRegistryToken();
+		},
+	});
+
+	await r.user.click(await r.findByTestId('toggle-search'));
+	// Configured form is showing.
+	await r.findByLabelText('Search skills.sh', undefined, { timeout: 15_000 });
+
+	await r.user.click(await r.findByRole('button', { name: 'Clear token' }));
+	// Clearing the token flips the panel back to the "paste a token" prompt.
+	await r.findByLabelText('skills.sh API token');
+});
+
+test('a non-superuser sees the "managed by the Admin" notice instead of the skills UI', async () => {
+	const r = await renderApp({
+		initialPath: '/settings/skills',
+		seed: async (ctx) => {
+			// Demote the seeded admin so me.is_superuser is false.
+			await ctx.db.query('UPDATE users SET is_superuser = false');
+		},
+	});
+
+	await r.findByText(/Instance skills are managed by the Admin/i);
+	// The add/search controls are not rendered for a non-admin.
+	expect(r.queryByTestId('toggle-search')).toBeNull();
+});
+
+test('confirming the delete dialog removes a skill from the list', async () => {
+	const r = await renderApp({
+		initialPath: '/settings/skills',
+		seed: async (ctx) => {
+			await ctx.apiBase('/api/skills', {
+				method: 'POST',
+				headers: { Authorization: `Bearer ${ctx.token}`, 'Content-Type': 'application/json' },
+				body: JSON.stringify({ name: 'Disposable Skill', content: '# body' }),
+			});
+		},
+	});
+
+	await r.findByText('Disposable Skill');
+
+	// The row delete uses window.confirm; accept it.
+	const originalConfirm = window.confirm;
+	window.confirm = () => true;
+	try {
+		await r.user.click(await r.findByLabelText('Delete Disposable Skill'));
+		await waitFor(() => expect(r.queryByText('Disposable Skill')).toBeNull());
+	} finally {
+		window.confirm = originalConfirm;
+	}
+});
+
+test('declining the delete confirm keeps the skill in the list', async () => {
+	const r = await renderApp({
+		initialPath: '/settings/skills',
+		seed: async (ctx) => {
+			await ctx.apiBase('/api/skills', {
+				method: 'POST',
+				headers: { Authorization: `Bearer ${ctx.token}`, 'Content-Type': 'application/json' },
+				body: JSON.stringify({ name: 'Keep Me Skill', content: '# body' }),
+			});
+		},
+	});
+
+	await r.findByText('Keep Me Skill');
+
+	const originalConfirm = window.confirm;
+	window.confirm = () => false;
+	try {
+		await r.user.click(await r.findByLabelText('Delete Keep Me Skill'));
+		await waitFor(() => expect(r.queryByText('Keep Me Skill')).not.toBeNull());
+	} finally {
+		window.confirm = originalConfirm;
+	}
+});

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -32,7 +32,7 @@ const shard = opts.shard as string | undefined;
 const shardIndex = shard ? Number.parseInt(shard.split('/')[0], 10) : undefined;
 const coverage = opts.coverage as boolean;
 
-const TEST_PACKAGES = ['packages/server', 'packages/web'];
+const TEST_PACKAGES = ['packages/server', 'packages/web', 'packages/shared'];
 
 async function buildShared() {
 	console.log('Building shared...');


### PR DESCRIPTION
## Goal

Raise overall Coveralls **line coverage above 90%, targeting ~92%** for headroom. (The operator will configure the Coveralls regression threshold themselves — no CI gate is added here.)

## Baseline (measured on this branch)

Merging the vitest tiers the way Coveralls does (`server` + `web` + new `shared`):

| Package | Lines | Coverage |
|---|---|---|
| server | 25,317 / 29,527 | 85.74% |
| web | 16,880 / 19,841 | 85.08% |
| shared | 1,241 / 1,254 | 98.96% |
| **total** | **43,438 / 50,622** | **85.81%** |

> Note: the originally-linked Coveralls build (83.27%) was an older commit; the current branch measures ~85.8%. Reaching 92% needs roughly **+3,100 covered lines**.

## Approach

**(A) Bring `packages/shared` into the coverage pipeline — done in this commit.**
`packages/shared` (crypto, mentions, budget, pricing, task-progress, enums) was *uninstrumented* and excluded from the Coveralls denominator entirely. This wires it in (vitest config, `TEST_PACKAGES`, a `test-shared` CI job + `shared` Coveralls flag + parallel-build carryforward) and adds a pure-logic unit suite — **98.96% line coverage, 78 tests**.

**(B) Fill the highest-uncovered gaps in `server/src` and `web/src` — in progress.**
Targeting the ranked uncovered files (e.g. `mcp/tools.ts`, `agent-stream-parser.ts`, OAuth/MCP/repo routes; web `connectors.tsx`, `connector-device-flow-dialog.tsx`, comment renderers, hooks) via the existing integration (`createTestContext`) and component (`renderApp`) harnesses. Runtime-only code (docker client, egress proxy) is left alone — it's covered via the Bun tier or needs a live daemon.

## Status

- [x] Wire `packages/shared` into test + coverage pipeline
- [x] `packages/shared` unit suite (98.96%)
- [ ] Server gap-fill tests
- [ ] Web gap-fill tests
- [ ] Verify combined ≥92% + docs sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8gu1mprGGmX3yRPLRRU16

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8gu1mprGGmX3yRPLRRU16)_