### PR TITLE
feat(docker): fetch agent-base :latest (refreshed at startup) instead of the version tag

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -655,17 +655,19 @@ asset is pulled in as a static import and served **from memory**: migrations
 (`static-bundle.json`, base64), and the PGlite runtime (`postgres.wasm`/`.data`
 embedded). The **agent-base Docker build context** (`docker/`) is embedded the same
 way (`docker-bundle.json`, base64) so the image can always be built on the host as a
-fallback. A release binary first **pulls** the image published for its own version —
-`ghcr.io/hezo-ai/agent-base:<version>` (multi-arch amd64/arm64), pushed per release by
-`.github/workflows/release-publish.yml` to a public GHCR package — and only **builds
-locally** when that pull fails (not published yet, offline, private fork): at startup it
-extracts the embedded context to `<dataDir>/agent-base-context` and points the resolver
-(`setDockerBaseDir`) at it, so the fallback build needs no checkout. `resolveAgentBaseImage`
-(`image-registry.ts`) maps the stored `hezo/agent-base:latest` sentinel to the
-version-pinned GHCR ref with `preferPull`, and `ensureImage` does pull-then-build; custom
-per-project `docker_base_image` values are pulled as-is. Pulling is gated on
-`IS_PACKAGED_BUILD` (set by the compile-time `--define process.env.HEZO_VERSION`), so in
-dev (`bun run`) and tests the bundles don't exist, loaders fall back to the filesystem
+fallback. A release binary **pulls** the published image —
+`ghcr.io/hezo-ai/agent-base:latest` (multi-arch amd64/arm64), pushed per release by
+`.github/workflows/release-publish.yml` (alongside a `:<version>` tag) to a public GHCR
+package — and refreshes it once at startup (`refreshPublishedAgentBaseImage`, since Docker
+otherwise caches `:latest` by name), so a long-running install picks up a newer release on
+restart. It only **builds locally** when the pull fails (offline, package missing, private
+fork): at startup it also extracts the embedded context to `<dataDir>/agent-base-context`
+and points the resolver (`setDockerBaseDir`) at it, so the fallback build needs no checkout.
+`resolveAgentBaseImage` (`image-registry.ts`) maps the stored `hezo/agent-base:latest`
+sentinel to `ghcr.io/hezo-ai/agent-base:latest` with `preferPull`, and `ensureImage` does
+pull-then-build; custom per-project `docker_base_image` values are pulled as-is. Pulling is
+gated on `IS_PACKAGED_BUILD` (set by the compile-time `--define process.env.HEZO_VERSION`),
+so in dev (`bun run`) and tests the bundles don't exist, loaders fall back to the filesystem
 (docker context → repo's `docker/` dir), and the image is always built from the
 working-tree Dockerfile so edits take effect immediately. The version is also surfaced at
 `/api/status`.

--- a/packages/server/src/services/image-registry.ts
+++ b/packages/server/src/services/image-registry.ts
@@ -3,7 +3,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { logger } from '../logger';
-import { HEZO_VERSION, IS_PACKAGED_BUILD } from '../version';
+import { IS_PACKAGED_BUILD } from '../version';
 import type { DockerClient } from './docker';
 
 const log = logger.child('image-registry');
@@ -16,15 +16,15 @@ interface LocalImageSpec {
 /**
  * The DB sentinel / default `projects.docker_base_image`. At provision time
  * `resolveAgentBaseImage` maps it to either the published GHCR image (in a
- * release binary whose version is published) or a local build of `AGENT_BASE_SPEC`.
+ * release binary) or a local build of `AGENT_BASE_SPEC`.
  */
 export const MANAGED_AGENT_BASE_IMAGE = 'hezo/agent-base:latest';
 
 /**
- * Registry repo the agent-base image is published to — one tag per release
- * (`<repo>:<version>`), pushed by `.github/workflows/release-publish.yml`. The
- * server pulls `<repo>:<HEZO_VERSION>` anonymously, so the GHCR package must be
- * public.
+ * Registry repo the agent-base image is published to by
+ * `.github/workflows/release-publish.yml` (each release pushes both
+ * `<repo>:<version>` and `<repo>:latest`). The server pulls `<repo>:latest`
+ * anonymously, so the GHCR package must be public.
  */
 export const AGENT_BASE_GHCR_REPO = 'ghcr.io/hezo-ai/agent-base';
 
@@ -42,25 +42,18 @@ const LOCAL_IMAGES: Record<string, LocalImageSpec> = {
 	[MANAGED_AGENT_BASE_IMAGE]: AGENT_BASE_SPEC,
 };
 
-/** A plain `MAJOR.MINOR.PATCH` version, matching the no-`v`-prefix release tags
- *  cut by `release-publish.yml`. Dev/test versions (`0.0.0-dev`, pre-release, …)
- *  don't match, so they never resolve to a published image. */
-export function isReleaseVersion(version: string): boolean {
-	return /^\d+\.\d+\.\d+$/.test(version);
-}
-
 /**
- * The published agent-base ref for the running build, or `null` when none should
- * exist — i.e. anything but a compiled release binary at a real release version
- * (dev, tests, pre-release builds). When `null`, the managed image is always
- * built locally. Params default to the module constants; they're injectable so
- * the pure logic is unit-testable without env munging.
+ * The published agent-base ref to fetch, or `null` when none should exist. Only a
+ * compiled release binary (`IS_PACKAGED_BUILD`) uses the published image; dev
+ * (`bun run`) and tests build from the working-tree Dockerfile so edits take
+ * effect immediately. We fetch the floating `:latest` tag (not the binary's exact
+ * version) so a host always runs the newest published agent-base — `startup.ts`
+ * refreshes it each boot since Docker otherwise caches `:latest` by name. The
+ * `packaged` param defaults to the module constant but is injectable so the logic
+ * is unit-testable without env munging.
  */
-export function publishedAgentBaseRef(
-	version: string = HEZO_VERSION,
-	packaged: boolean = IS_PACKAGED_BUILD,
-): string | null {
-	return packaged && isReleaseVersion(version) ? `${AGENT_BASE_GHCR_REPO}:${version}` : null;
+export function publishedAgentBaseRef(packaged: boolean = IS_PACKAGED_BUILD): string | null {
+	return packaged ? `${AGENT_BASE_GHCR_REPO}:latest` : null;
 }
 
 /**
@@ -77,6 +70,23 @@ export function resolveAgentBaseImage(
 		return { image: publishedRef, preferPull: true };
 	}
 	return { image: storedImage, preferPull: false };
+}
+
+/**
+ * Pull the published agent-base image so a long-running install picks up a newer
+ * release's `:latest` — Docker caches `:latest` by name, so an already-pulled tag
+ * is never refreshed on its own. Called once at startup; best-effort, so a failure
+ * is non-fatal (provisioning falls back to the cached image or a local build).
+ * No-op returning `null` when there's no published ref (dev/tests). The `ref` param
+ * is injectable for tests.
+ */
+export async function refreshPublishedAgentBaseImage(
+	docker: DockerClient,
+	ref: string | null = publishedAgentBaseRef(),
+): Promise<string | null> {
+	if (!ref) return null;
+	await docker.pullImage(ref);
+	return ref;
 }
 
 /**

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -65,7 +65,11 @@ import { DockerClient } from './services/docker';
 import { extractBundledDockerContext } from './services/docker-assets';
 import { EgressProxy, loadOrCreateCA } from './services/egress';
 import { ImageBuildTracker, setSharedImageBuildTracker } from './services/image-build-tracker';
-import { pruneStaleBundledImages, setDockerBaseDir } from './services/image-registry';
+import {
+	pruneStaleBundledImages,
+	refreshPublishedAgentBaseImage,
+	setDockerBaseDir,
+} from './services/image-registry';
 import { JobManager } from './services/job-manager';
 import { LogStreamBroker } from './services/log-stream-broker';
 import { PricingService } from './services/pricing';
@@ -128,11 +132,11 @@ export async function startup(config: HezoConfig): Promise<StartupResult> {
 		docker = createFakeDockerClient(db);
 	} else {
 		docker = new DockerClient();
-		// A compiled binary has no repo checkout, so the agent-base image can't be
-		// built from disk (and is published to no registry to pull). Extract the
-		// embedded build context to the data dir and point the image resolver at it,
-		// so provisioning builds the image locally. No-op in dev/source (returns
-		// null — the resolver falls back to the repo's docker/ dir).
+		// A compiled binary has no repo checkout, so extract the embedded agent-base
+		// build context to the data dir and point the image resolver at it. The
+		// published image is pulled first (refreshed below); this is the local-build
+		// fallback for when that pull fails. No-op in dev/source (returns null — the
+		// resolver falls back to the repo's docker/ dir).
 		try {
 			const contextDir = await extractBundledDockerContext(config.dataDir);
 			if (contextDir) setDockerBaseDir(contextDir);
@@ -148,6 +152,16 @@ export async function startup(config: HezoConfig): Promise<StartupResult> {
 			}
 		} catch (err) {
 			log.error('bundled-image prune failed (continuing startup):', err);
+		}
+		// Refresh the published agent-base image so a long-running install picks up a
+		// newer release's :latest on restart (Docker caches :latest by name, so it is
+		// never refreshed on its own). Best-effort: provisioning falls back to the
+		// cached image or a local build if this fails. No-op in dev/tests.
+		try {
+			const refreshed = await refreshPublishedAgentBaseImage(docker);
+			if (refreshed) log.info(`refreshed published agent-base image ${refreshed}`);
+		} catch (err) {
+			log.warn('agent-base image refresh failed (continuing startup):', err);
 		}
 	}
 	const wsManager = new WebSocketManager();

--- a/packages/server/test/ensure-image.test.ts
+++ b/packages/server/test/ensure-image.test.ts
@@ -290,20 +290,20 @@ describe('ensureImage', () => {
 			pullImage: vi.fn().mockResolvedValue(undefined),
 		} as unknown as DockerClient;
 		const resolveLocal = vi.fn().mockReturnValue({
-			image: 'ghcr.io/hezo-ai/agent-base:1.2.3',
+			image: 'ghcr.io/hezo-ai/agent-base:latest',
 			dockerfile: '/repo/docker/Dockerfile.agent-base',
 			context: '/repo/docker',
 			bundleSourceHash: 'a'.repeat(64),
 		});
 		const build = vi.fn();
 
-		await ensureImage(docker, 'ghcr.io/hezo-ai/agent-base:1.2.3', {
+		await ensureImage(docker, 'ghcr.io/hezo-ai/agent-base:latest', {
 			resolveLocal,
 			build,
 			preferPull: true,
 		});
 
-		expect(docker.pullImage).toHaveBeenCalledWith('ghcr.io/hezo-ai/agent-base:1.2.3');
+		expect(docker.pullImage).toHaveBeenCalledWith('ghcr.io/hezo-ai/agent-base:latest');
 		expect(build).not.toHaveBeenCalled();
 	});
 
@@ -313,14 +313,14 @@ describe('ensureImage', () => {
 			pullImage: vi.fn().mockRejectedValue(new Error('manifest unknown')),
 		} as unknown as DockerClient;
 		const resolveLocal = vi.fn().mockReturnValue({
-			image: 'ghcr.io/hezo-ai/agent-base:1.2.3',
+			image: 'ghcr.io/hezo-ai/agent-base:latest',
 			dockerfile: '/repo/docker/Dockerfile.agent-base',
 			context: '/repo/docker',
 			bundleSourceHash: 'a'.repeat(64),
 		});
 		const build = vi.fn().mockResolvedValue(undefined);
 
-		await ensureImage(docker, 'ghcr.io/hezo-ai/agent-base:1.2.3', {
+		await ensureImage(docker, 'ghcr.io/hezo-ai/agent-base:latest', {
 			resolveLocal,
 			build,
 			preferPull: true,
@@ -328,7 +328,7 @@ describe('ensureImage', () => {
 
 		expect(docker.pullImage).toHaveBeenCalledTimes(1);
 		expect(build).toHaveBeenCalledWith(
-			'ghcr.io/hezo-ai/agent-base:1.2.3',
+			'ghcr.io/hezo-ai/agent-base:latest',
 			'/repo/docker',
 			'/repo/docker/Dockerfile.agent-base',
 			expect.objectContaining({ labels: { 'hezo.bundle.sha': 'a'.repeat(64) } }),
@@ -344,7 +344,7 @@ describe('ensureImage', () => {
 		const build = vi.fn();
 
 		await expect(
-			ensureImage(docker, 'ghcr.io/hezo-ai/agent-base:1.2.3', {
+			ensureImage(docker, 'ghcr.io/hezo-ai/agent-base:latest', {
 				resolveLocal,
 				build,
 				preferPull: true,

--- a/packages/server/test/image-registry.test.ts
+++ b/packages/server/test/image-registry.test.ts
@@ -1,15 +1,16 @@
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { DockerClient } from '../src/services/docker';
 import {
 	AGENT_BASE_GHCR_REPO,
 	BUNDLE_SHA_LABEL,
 	computeBundleSourceHash,
 	findRepoRoot,
-	isReleaseVersion,
 	MANAGED_AGENT_BASE_IMAGE,
 	publishedAgentBaseRef,
+	refreshPublishedAgentBaseImage,
 	resolveAgentBaseImage,
 	resolveLocalImage,
 	setDockerBaseDir,
@@ -42,34 +43,17 @@ describe('image-registry', () => {
 		expect(resolveLocalImage('some/other:tag')).toBeNull();
 	});
 
-	describe('isReleaseVersion', () => {
-		it('accepts plain MAJOR.MINOR.PATCH', () => {
-			expect(isReleaseVersion('0.6.1')).toBe(true);
-			expect(isReleaseVersion('1.2.3')).toBe(true);
-			expect(isReleaseVersion('10.20.30')).toBe(true);
-		});
-		it('rejects dev, partial, prefixed, and pre-release versions', () => {
-			expect(isReleaseVersion('0.0.0-dev')).toBe(false);
-			expect(isReleaseVersion('1.2')).toBe(false);
-			expect(isReleaseVersion('v1.2.3')).toBe(false);
-			expect(isReleaseVersion('1.2.3-rc.1')).toBe(false);
-		});
-	});
-
 	describe('publishedAgentBaseRef', () => {
-		it('returns the versioned GHCR ref for a packaged release build', () => {
-			expect(publishedAgentBaseRef('0.6.1', true)).toBe(`${AGENT_BASE_GHCR_REPO}:0.6.1`);
+		it('returns the :latest GHCR ref for a packaged release build', () => {
+			expect(publishedAgentBaseRef(true)).toBe(`${AGENT_BASE_GHCR_REPO}:latest`);
 		});
 		it('returns null for an unpackaged (dev/test) build', () => {
-			expect(publishedAgentBaseRef('0.6.1', false)).toBeNull();
-		});
-		it('returns null for a non-release version even when packaged', () => {
-			expect(publishedAgentBaseRef('0.0.0-dev', true)).toBeNull();
+			expect(publishedAgentBaseRef(false)).toBeNull();
 		});
 	});
 
 	describe('resolveAgentBaseImage', () => {
-		const ref = `${AGENT_BASE_GHCR_REPO}:0.6.1`;
+		const ref = `${AGENT_BASE_GHCR_REPO}:latest`;
 		it('maps the managed sentinel to the published ref with preferPull', () => {
 			expect(resolveAgentBaseImage(MANAGED_AGENT_BASE_IMAGE, ref)).toEqual({
 				image: ref,
@@ -91,7 +75,7 @@ describe('image-registry', () => {
 	});
 
 	describe('resolveLocalImage published-ref fallback', () => {
-		const ref = `${AGENT_BASE_GHCR_REPO}:0.6.1`;
+		const ref = `${AGENT_BASE_GHCR_REPO}:latest`;
 		it('resolves the published ref for this build to the agent-base Dockerfile', () => {
 			const resolved = resolveLocalImage(ref, ref);
 			expect(resolved).not.toBeNull();
@@ -99,8 +83,26 @@ describe('image-registry', () => {
 			expect(resolved?.dockerfile.endsWith('docker/Dockerfile.agent-base')).toBe(true);
 			expect(resolved?.bundleSourceHash).toMatch(/^[0-9a-f]{64}$/);
 		});
-		it('returns null for a published ref that does not match this build', () => {
-			expect(resolveLocalImage(`${AGENT_BASE_GHCR_REPO}:9.9.9`, ref)).toBeNull();
+		it('returns null for an image that is neither the sentinel nor the published ref', () => {
+			expect(resolveLocalImage(`${AGENT_BASE_GHCR_REPO}:0.6.1`, ref)).toBeNull();
+		});
+	});
+
+	describe('refreshPublishedAgentBaseImage', () => {
+		it('pulls and returns the published ref when one exists', async () => {
+			const docker = {
+				pullImage: vi.fn().mockResolvedValue(undefined),
+			} as unknown as DockerClient;
+			const ref = `${AGENT_BASE_GHCR_REPO}:latest`;
+			const result = await refreshPublishedAgentBaseImage(docker, ref);
+			expect(docker.pullImage).toHaveBeenCalledWith(ref);
+			expect(result).toBe(ref);
+		});
+		it('is a no-op returning null when there is no published ref', async () => {
+			const docker = { pullImage: vi.fn() } as unknown as DockerClient;
+			const result = await refreshPublishedAgentBaseImage(docker, null);
+			expect(docker.pullImage).not.toHaveBeenCalled();
+			expect(result).toBeNull();
 		});
 	});
 


### PR DESCRIPTION
## What & why

Follow-up to #402. That PR had release binaries pull the **version-pinned**
`ghcr.io/hezo-ai/agent-base:<version>`. Per request, the runtime now fetches the floating
**`:latest`** tag instead, so a host always runs the newest published agent-base rather than
one frozen to its exact release.

**The wrinkle this handles:** Docker caches images by tag name, so once a host has pulled
`:latest` the existing `ensureImage` short-circuit would never re-pull it. So this also
**refreshes `:latest` once on server startup** (`refreshPublishedAgentBaseImage`, alongside
the existing stale-image prune) — a long-running install picks up a newer release's image on
the next restart, with no per-provision network cost.

`release-publish.yml` already pushes `:latest` alongside `:<version>` on each release, so
**no workflow change is needed** — we keep publishing `:<version>` for pinning/rollback and
just change what the runtime *fetches*.

## Changes

- **`image-registry.ts`**: `publishedAgentBaseRef()` returns `ghcr.io/hezo-ai/agent-base:latest`,
  gated only on `IS_PACKAGED_BUILD` (dropped the `version`/`isReleaseVersion` gating, removed
  the now-unused `isReleaseVersion`). Added `refreshPublishedAgentBaseImage(docker)` (pulls the
  published ref; no-op in dev/tests). `resolveAgentBaseImage` / `resolveLocalImage` /
  `ensureImage` (`preferPull`) / `provisionContainer` are **unchanged** — they already do the
  right thing with whatever ref is returned.
- **`startup.ts`**: best-effort `:latest` refresh after the bundled-image prune (no-op in
  dev/tests; skipped under the fake-Docker path).
- **`.dev/architecture.md`** §12 reworded; **tests** updated (`:latest` expectations, removed
  the `isReleaseVersion` block, added `refreshPublishedAgentBaseImage` cases).

## Behavior notes

- `:latest` tracks the latest **release**, not the latest commit — the per-commit
  `agent-base:<sha>` images from `ci.yml` are a separate concern (for CI's own test runners)
  and are never referenced by the runtime.
- The public-GHCR-package prerequisite from #402 still applies (already satisfied — the 0.6.2
  release published `:latest`).

## Test plan
- [x] `bun run check` (exit 0) · `bun run typecheck` green (5/5) · rebased onto current `main` (0.6.2).
- [x] `bun run test --package server --pattern image` → 55 passed (incl. new refresh cases; the fallback log line confirms pull→build still works with `:latest`).
- [x] `--pattern startup` → 4 passed · `--pattern container` → 56 passed.
- [ ] After merge: a release binary logs `refreshed published agent-base image ghcr.io/hezo-ai/agent-base:latest` at startup and provisions from `:latest`; blocking egress shows the local-build fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UNss4fsbpux1Y36GF83Dc9

---
_Generated by [Claude Code](https://claude.ai/code/session_01UNss4fsbpux1Y36GF83Dc9)_