### PR TITLE
fix(startup): serve web UI during boot; stop agent-base pull blocking readiness

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -658,10 +658,15 @@ way (`docker-bundle.json`, base64) so the image can always be built on the host 
 fallback. A release binary **pulls** the published image —
 `ghcr.io/hezo-ai/agent-base:latest` (multi-arch amd64/arm64), pushed per release by
 `.github/workflows/release-publish.yml` (alongside a `:<version>` tag) to a public GHCR
-package — and refreshes it once at startup (`refreshPublishedAgentBaseImage`, since Docker
+package — and refreshes it at startup (`refreshPublishedAgentBaseImage`, since Docker
 otherwise caches `:latest` by name), so a long-running install picks up a newer release on
-restart. It only **builds locally** when the pull fails (offline, package missing, private
-fork): at startup it also extracts the embedded context to `<dataDir>/agent-base-context`
+restart. That refresh (and the stale-bundled-image prune) runs **in the background**, off
+the readiness path: a cold first pull can take minutes, and it must never gate `serverReady`
+— the web UI, master-key unlock, and project creation are all usable without it, and
+provisioning pulls-then-builds on demand, so a missing/slow refresh self-heals on first use.
+It only **builds locally** when the pull fails (offline, package missing, private
+fork): at startup it also (synchronously, since it's fast and the local-build fallback needs
+it) extracts the embedded context to `<dataDir>/agent-base-context`
 and points the resolver (`setDockerBaseDir`) at it, so the fallback build needs no checkout.
 `resolveAgentBaseImage` (`image-registry.ts`) maps the stored `hezo/agent-base:latest`
 sentinel to `ghcr.io/hezo-ai/agent-base:latest` with `preferPull`, and `ensureImage` does
@@ -671,6 +676,17 @@ so in dev (`bun run`) and tests the bundles don't exist, loaders fall back to th
 (docker context → repo's `docker/` dir), and the image is always built from the
 working-tree Dockerfile so edits take effect immediately. The version is also surfaced at
 `/api/status`.
+
+**Pre-ready serving.** `startup()` is async and the Bun fetch entry (`index.ts`) binds the
+port immediately, so requests can arrive before the app exists. Until `serverReady` flips,
+the entry delegates to `serveStartupRequest` (`startup-serving.ts`): browser navigations and
+static assets are served from the embedded SPA bundle, and `/api/status` answers **200** with
+`{ starting: true, phase, message }` read from a boot-progress singleton (`startup-progress.ts`,
+advanced through `database → migrations → seed → pricing → workspace`). The web UI
+(`useStatus` → `StartingScreen`) renders a loading screen naming the current phase and keeps
+polling, flipping to the master-key gate the moment boot finishes — so a browser that connects
+mid-boot never sees a raw JSON error. Other API/MCP/WebSocket surfaces still get a JSON **503
+STARTING** so machine clients retry; `/health` always answers 200.
 
 **Migrations.** Real, tracked, **append-only** SQL under `packages/server/migrations/`
 (`001_initial_schema.sql` is the frozen baseline — never edit a shipped migration; each is

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -22,6 +22,9 @@ import { isAutoUpdateEnabled } from './services/updater';
 import type { WebSocketManager, WsData, WsSocket } from './services/ws';
 import { handleWsSubscribe, handleWsUnsubscribe } from './services/ws-subscribe-handler';
 import { type StartupResult, startup } from './startup';
+import { getStartupProgress, markStartupError, setStartupPhase } from './startup-progress';
+import { serveStartupRequest } from './startup-serving';
+import { loadStaticBundle } from './static-assets';
 import { runSupervisor } from './supervisor';
 
 const log = logger.child('server');
@@ -186,13 +189,6 @@ async function canAccessTeam(auth: WsData['auth'], teamId: string): Promise<bool
 	return canAuthAccessTeam(dbRef, auth as AuthInfo, teamId);
 }
 
-function startingResponse(): Response {
-	return Response.json(
-		{ error: { code: 'STARTING', message: 'Server is starting — retry in a moment' } },
-		{ status: 503 },
-	);
-}
-
 void (async () => {
 	await shutdownPreviousRuntime();
 
@@ -212,6 +208,7 @@ void (async () => {
 		logsRef = result.logs;
 		containerLogStreamerRef = result.containerLogStreamer;
 		serverReady = true;
+		setStartupPhase('ready');
 		const url = `http://localhost:${result.port}`;
 		log.info(`Hezo server running at ${url} [${result.masterKeyState}]`);
 		if (config.open) {
@@ -244,6 +241,7 @@ void (async () => {
 		} else {
 			log.error('Startup failed, serving minimal app:', err);
 		}
+		markStartupError(err instanceof Error ? err.message : 'Unexpected startup error');
 		log.info(`Hezo server (minimal) starting on port ${config.port}...`);
 	}
 })();
@@ -252,8 +250,11 @@ export default {
 	port: config.port,
 	fetch: (req: Request, server: Bun.Server<WsConnectionData>) => {
 		const url = new URL(req.url);
-		if (!serverReady && url.pathname !== '/health') {
-			return startingResponse();
+		if (!serverReady) {
+			return serveStartupRequest(req, {
+				progress: getStartupProgress(),
+				loadBundle: loadStaticBundle,
+			});
 		}
 		if (url.pathname === '/ws') {
 			const token =

--- a/packages/server/src/startup-progress.ts
+++ b/packages/server/src/startup-progress.ts
@@ -1,0 +1,55 @@
+/**
+ * Startup progress shared between the long-running `startup()` sequence and the
+ * pre-ready request handler (`startup-serving.ts`, wired into the Bun fetch entry
+ * in `index.ts`).
+ *
+ * While the server boots it can't serve the real app yet, so the entry handler
+ * serves the SPA shell and answers `/api/status` from this singleton. The web UI
+ * renders a loading screen that names the current phase instead of the browser
+ * showing a raw JSON 503. Messages here are user-facing — keep them generic and
+ * free of secrets/paths.
+ */
+
+export type StartupPhaseId =
+	| 'starting'
+	| 'database'
+	| 'migrations'
+	| 'seed'
+	| 'pricing'
+	| 'workspace'
+	| 'ready'
+	| 'error';
+
+export interface StartupProgress {
+	phase: StartupPhaseId;
+	/** Human-readable, safe to show in the browser. */
+	message: string;
+	/** Optional extra context for the loading screen (never secrets). */
+	detail?: string;
+}
+
+const PHASE_MESSAGES: Record<StartupPhaseId, string> = {
+	starting: 'Starting up…',
+	database: 'Opening the database…',
+	migrations: 'Running database migrations…',
+	seed: 'Preparing data…',
+	pricing: 'Loading model pricing…',
+	workspace: 'Setting up your workspace…',
+	ready: 'Ready',
+	error: 'Startup failed',
+};
+
+let current: StartupProgress = { phase: 'starting', message: PHASE_MESSAGES.starting };
+
+export function getStartupProgress(): StartupProgress {
+	return current;
+}
+
+export function setStartupPhase(phase: StartupPhaseId, detail?: string): void {
+	current = { phase, message: PHASE_MESSAGES[phase], detail };
+}
+
+/** Record a fatal startup failure so the loading screen can surface it. */
+export function markStartupError(detail: string): void {
+	current = { phase: 'error', message: PHASE_MESSAGES.error, detail };
+}

--- a/packages/server/src/startup-serving.ts
+++ b/packages/server/src/startup-serving.ts
@@ -1,0 +1,78 @@
+/**
+ * Pre-ready request handling.
+ *
+ * Until `startup()` finishes, the Bun fetch entry in `index.ts` can't serve the
+ * real Hono app. Rather than answer every request with a raw JSON 503 (which a
+ * browser renders as bare error text), we serve the SPA shell to browsers and a
+ * live `/api/status` so the web UI shows a loading screen naming the current
+ * boot phase. Machine surfaces (`/api/*`, `/mcp*`, `/ws`, agent manifests) still
+ * get a JSON 503 STARTING so they retry.
+ */
+
+import type { StartupProgress } from './startup-progress';
+import type { StaticAsset } from './static-assets';
+import { HEZO_VERSION } from './version';
+
+/** JSON 503 for machine clients — they should retry until the server is ready. */
+export function startingResponse(): Response {
+	return Response.json(
+		{ error: { code: 'STARTING', message: 'Server is starting — retry in a moment' } },
+		{ status: 503 },
+	);
+}
+
+export interface StartupServingDeps {
+	progress: StartupProgress;
+	/** Loads the embedded SPA bundle; `null` in dev where Vite serves the SPA. */
+	loadBundle: () => Promise<Map<string, StaticAsset> | null>;
+}
+
+/** Paths that must keep machine-readable JSON semantics while booting. */
+function isMachinePath(path: string): boolean {
+	return (
+		path.startsWith('/api/') ||
+		path === '/mcp' ||
+		path.startsWith('/mcp/') ||
+		path === '/ws' ||
+		path === '/SKILL.md' ||
+		path === '/llms.txt'
+	);
+}
+
+/**
+ * Build the response for a request that arrives before the server is ready.
+ * Pure and dependency-injected so it can be unit-tested without booting Bun.
+ */
+export async function serveStartupRequest(
+	req: Request,
+	deps: StartupServingDeps,
+): Promise<Response> {
+	const path = new URL(req.url).pathname;
+
+	// Always answer health so liveness probes don't flap during boot.
+	if (path === '/health') {
+		return Response.json({ ok: true });
+	}
+
+	// The web UI polls this while booting; answer 200 with the live phase so it
+	// renders a progress screen instead of treating it as an error.
+	if (path === '/api/status') {
+		const { phase, message, detail } = deps.progress;
+		return Response.json({ starting: true, phase, message, detail, version: HEZO_VERSION });
+	}
+
+	// Other API/MCP/WebSocket surfaces stay machine-readable so clients retry.
+	if (isMachinePath(path)) {
+		return startingResponse();
+	}
+
+	// Everything else is a browser navigation or static asset. Serve the SPA shell
+	// from the embedded bundle so the web UI loads (and then polls /api/status).
+	// In dev the bundle is absent — Vite serves the SPA on another port — so fall
+	// back to the JSON 503.
+	const bundle = await deps.loadBundle();
+	if (!bundle) return startingResponse();
+	const asset = bundle.get(path) ?? bundle.get('/index.html');
+	if (!asset) return startingResponse();
+	return new Response(asset.body, { headers: { 'Content-Type': asset.type } });
+}

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -75,6 +75,7 @@ import { LogStreamBroker } from './services/log-stream-broker';
 import { PricingService } from './services/pricing';
 import { SshAgentServer } from './services/ssh-agent';
 import { WebSocketManager } from './services/ws';
+import { setStartupPhase } from './startup-progress';
 import { loadStaticBundle } from './static-assets';
 import { HEZO_VERSION } from './version';
 
@@ -111,15 +112,19 @@ export async function startup(config: HezoConfig): Promise<StartupResult> {
 
 	// `db` may be replaced by a fresh handle if migrations run against a copy and
 	// swap it in, so it's a `let` — every consumer below uses the post-migration handle.
+	setStartupPhase('database');
 	let db = await openPersistentDb(config.dataDir, { reset: config.reset });
 
 	await db.exec(BASE_SCHEMA);
+	setStartupPhase('migrations');
 	db = await runAvailableMigrations(db, config.dataDir);
+	setStartupPhase('seed');
 	await runSeed(db);
 
 	// Runtime model pricing: seed the table from the bundled snapshot if empty,
 	// load it into memory, and (unless disabled) refresh from the live LiteLLM
 	// feed in the background. Drives per-run cost across every runtime.
+	setStartupPhase('pricing');
 	const pricing = new PricingService(db);
 	await pricing.init({ refresh: !process.env.HEZO_SKIP_PRICING_REFRESH });
 
@@ -133,36 +138,44 @@ export async function startup(config: HezoConfig): Promise<StartupResult> {
 	} else {
 		docker = new DockerClient();
 		// A compiled binary has no repo checkout, so extract the embedded agent-base
-		// build context to the data dir and point the image resolver at it. The
-		// published image is pulled first (refreshed below); this is the local-build
-		// fallback for when that pull fails. No-op in dev/source (returns null — the
-		// resolver falls back to the repo's docker/ dir).
+		// build context to the data dir and point the image resolver at it. This is
+		// the local-build fallback for when the published-image pull fails, and it's
+		// fast (writing files), so it stays on the critical path. No-op in dev/source
+		// (returns null — the resolver falls back to the repo's docker/ dir).
 		try {
 			const contextDir = await extractBundledDockerContext(config.dataDir);
 			if (contextDir) setDockerBaseDir(contextDir);
 		} catch (err) {
 			log.error('Failed to extract bundled agent-base build context (continuing):', err);
 		}
-		try {
-			const outcome = await pruneStaleBundledImages(docker);
-			if (outcome.removed.length > 0 || outcome.skipped.length > 0) {
-				log.info(
-					`bundled-image prune: kept=${outcome.kept.length} removed=${outcome.removed.length} skipped=${outcome.skipped.length}`,
-				);
-			}
-		} catch (err) {
-			log.error('bundled-image prune failed (continuing startup):', err);
-		}
-		// Refresh the published agent-base image so a long-running install picks up a
-		// newer release's :latest on restart (Docker caches :latest by name, so it is
-		// never refreshed on its own). Best-effort: provisioning falls back to the
-		// cached image or a local build if this fails. No-op in dev/tests.
-		try {
-			const refreshed = await refreshPublishedAgentBaseImage(docker);
-			if (refreshed) log.info(`refreshed published agent-base image ${refreshed}`);
-		} catch (err) {
-			log.warn('agent-base image refresh failed (continuing startup):', err);
-		}
+		// Prune stale bundled images and refresh the published agent-base image (so a
+		// long-running install picks up a newer release's :latest on restart — Docker
+		// caches :latest by name and never refreshes it on its own). The pull is
+		// network-bound and can take minutes on a cold cache, so run it in the
+		// BACKGROUND: it must not gate `serverReady` (the web UI, master-key unlock,
+		// and project creation are all usable without it). It's best-effort anyway —
+		// container provisioning pulls-then-builds on demand and falls back to a local
+		// build, so a missing/slow refresh self-heals on first use. No-op in dev/tests.
+		trackBackground(
+			(async () => {
+				try {
+					const outcome = await pruneStaleBundledImages(docker);
+					if (outcome.removed.length > 0 || outcome.skipped.length > 0) {
+						log.info(
+							`bundled-image prune: kept=${outcome.kept.length} removed=${outcome.removed.length} skipped=${outcome.skipped.length}`,
+						);
+					}
+				} catch (err) {
+					log.error('bundled-image prune failed (continuing startup):', err);
+				}
+				try {
+					const refreshed = await refreshPublishedAgentBaseImage(docker);
+					if (refreshed) log.info(`refreshed published agent-base image ${refreshed}`);
+				} catch (err) {
+					log.warn('agent-base image refresh failed (continuing startup):', err);
+				}
+			})(),
+		);
 	}
 	const wsManager = new WebSocketManager();
 	const logs = new LogStreamBroker();
@@ -209,6 +222,7 @@ export async function startup(config: HezoConfig): Promise<StartupResult> {
 		containerLogStreamer,
 	});
 
+	setStartupPhase('workspace');
 	const { seedDefaultTeam, ensureChatMemoryDoc } = await import('./services/teams.js');
 	try {
 		await seedDefaultTeam({

--- a/packages/server/test/startup-serving.test.ts
+++ b/packages/server/test/startup-serving.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import type { StartupProgress } from '../src/startup-progress';
+import { serveStartupRequest } from '../src/startup-serving';
+import type { StaticAsset } from '../src/static-assets';
+
+// The handler imports `StaticAsset` from static-assets; re-declare the shape here
+// for the fake bundle so the test doesn't depend on Blob internals beyond {type,body}.
+type FakeAsset = { type: string; body: Blob };
+
+const PROGRESS: StartupProgress = {
+	phase: 'migrations',
+	message: 'Running database migrations…',
+};
+
+function req(path: string): Request {
+	return new Request(`http://localhost:3100${path}`);
+}
+
+function bundle(entries: Record<string, FakeAsset>): Map<string, FakeAsset> {
+	return new Map(Object.entries(entries));
+}
+
+const html: FakeAsset = {
+	type: 'text/html; charset=utf-8',
+	body: new Blob(['<!doctype html><title>Hezo</title>'], { type: 'text/html; charset=utf-8' }),
+};
+const js: FakeAsset = {
+	type: 'application/javascript; charset=utf-8',
+	body: new Blob(['console.log(1)'], { type: 'application/javascript; charset=utf-8' }),
+};
+
+const withBundle = (b: Map<string, FakeAsset> | null) => ({
+	progress: PROGRESS,
+	loadBundle: async () => b as unknown as Map<string, StaticAsset> | null,
+});
+
+describe('serveStartupRequest (pre-ready handler)', () => {
+	it('answers /api/status with 200 and the live boot phase', async () => {
+		const res = await serveStartupRequest(req('/api/status'), withBundle(null));
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			starting: boolean;
+			phase: string;
+			message: string;
+			version: string;
+		};
+		expect(body.starting).toBe(true);
+		expect(body.phase).toBe('migrations');
+		expect(body.message).toBe('Running database migrations…');
+		expect(typeof body.version).toBe('string');
+	});
+
+	it('keeps /health answering 200 during boot', async () => {
+		const res = await serveStartupRequest(req('/health'), withBundle(null));
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ ok: true });
+	});
+
+	it('returns a JSON 503 STARTING for other API surfaces so clients retry', async () => {
+		for (const path of ['/api/projects', '/mcp', '/mcp/assets', '/ws', '/SKILL.md', '/llms.txt']) {
+			const res = await serveStartupRequest(req(path), withBundle(null));
+			expect(res.status, path).toBe(503);
+			const body = (await res.json()) as { error?: { code?: string } };
+			expect(body.error?.code, path).toBe('STARTING');
+		}
+	});
+
+	it('serves the SPA shell (index.html) for a browser navigation when the bundle exists', async () => {
+		const res = await serveStartupRequest(
+			req('/'),
+			withBundle(bundle({ '/index.html': html, '/assets/app.js': js })),
+		);
+		expect(res.status).toBe(200);
+		expect(res.headers.get('Content-Type')).toContain('text/html');
+		expect(await res.text()).toContain('<title>Hezo</title>');
+	});
+
+	it('serves a real static asset by path', async () => {
+		const res = await serveStartupRequest(
+			req('/assets/app.js'),
+			withBundle(bundle({ '/index.html': html, '/assets/app.js': js })),
+		);
+		expect(res.status).toBe(200);
+		expect(res.headers.get('Content-Type')).toContain('javascript');
+		expect(await res.text()).toBe('console.log(1)');
+	});
+
+	it('falls back to index.html for unknown SPA routes (client-side routing)', async () => {
+		const res = await serveStartupRequest(
+			req('/projects/demo/tasks'),
+			withBundle(bundle({ '/index.html': html })),
+		);
+		expect(res.status).toBe(200);
+		expect(res.headers.get('Content-Type')).toContain('text/html');
+	});
+
+	it('falls back to JSON 503 for navigations when no bundle is embedded (dev)', async () => {
+		const res = await serveStartupRequest(req('/'), withBundle(null));
+		expect(res.status).toBe(503);
+		const body = (await res.json()) as { error?: { code?: string } };
+		expect(body.error?.code).toBe('STARTING');
+	});
+});

--- a/packages/web/src/components/starting-screen.tsx
+++ b/packages/web/src/components/starting-screen.tsx
@@ -1,0 +1,45 @@
+import { Loader2 } from 'lucide-react';
+import { Logo } from './ui/logo';
+
+interface StartingScreenProps {
+	/** Coarse phase id; `error` switches to the failure layout. */
+	phase?: string;
+	/** Human-readable phase message from the server. */
+	message?: string;
+	/** Optional extra context (e.g. the failure reason). */
+	detail?: string;
+}
+
+/**
+ * Full-screen loading state shown while the server is still booting. The compiled
+ * binary serves the SPA shell during startup, so the web UI renders this instead
+ * of the browser showing a raw `STARTING` JSON 503. `useStatus` keeps polling
+ * `/api/status` and the app flips to the master-key gate the moment boot finishes.
+ */
+export function StartingScreen({ phase, message, detail }: StartingScreenProps) {
+	const isError = phase === 'error';
+
+	return (
+		<div
+			className="flex min-h-screen flex-col items-center justify-center gap-5 px-6 text-center"
+			data-testid="starting-screen"
+		>
+			<Logo size="lg" wordmark />
+			{isError ? (
+				<div className="flex flex-col items-center gap-2">
+					<p className="text-sm font-medium text-danger">{message ?? 'Startup failed'}</p>
+					{detail && <p className="max-w-md break-words text-[13px] text-text-2">{detail}</p>}
+					<p className="text-[13px] text-text-2">Check the server logs for details.</p>
+				</div>
+			) : (
+				<div className="flex flex-col items-center gap-3" role="status" aria-live="polite">
+					<Loader2 className="h-6 w-6 animate-spin text-text-2" aria-hidden />
+					<div className="flex flex-col items-center gap-1">
+						<p className="text-sm font-medium text-text-1">{message ?? 'Starting up…'}</p>
+						{detail && <p className="max-w-md break-words text-[13px] text-text-2">{detail}</p>}
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/packages/web/src/hooks/use-status.ts
+++ b/packages/web/src/hooks/use-status.ts
@@ -21,5 +21,8 @@ export function useStatus() {
 		refetchOnMount: 'always',
 		retry: (failureCount, error) => isRetryableStatusError(error) && failureCount < 40,
 		retryDelay: 500,
+		// While the server reports it's still booting, keep polling so the loading
+		// screen advances through phases and flips to the app the moment it's ready.
+		refetchInterval: (query) => (query.state.data?.starting ? 500 : false),
 	});
 }

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -10,9 +10,18 @@ import {
 } from '@hezo/shared';
 import { type ApiError, api } from './api';
 
-interface StatusResponse {
-	masterKeyState: MasterKeyState;
+export interface StatusResponse {
+	/** Absent while the server is still booting (`starting` is true). */
+	masterKeyState?: MasterKeyState;
 	version: string;
+	/** True when the server is still booting; the rest of the app should wait. */
+	starting?: boolean;
+	/** Coarse boot phase id (e.g. `migrations`, `workspace`) — for the loading screen. */
+	phase?: string;
+	/** Human-readable phase message, safe to show in the UI. */
+	message?: string;
+	/** Optional extra context for the loading screen. */
+	detail?: string;
 }
 
 export async function checkStatus(): Promise<StatusResponse> {
@@ -20,6 +29,17 @@ export async function checkStatus(): Promise<StatusResponse> {
 	const body = (await res.json()) as StatusResponse & {
 		error?: { code?: string; message?: string };
 	};
+	// While booting, the server answers 200 with `starting: true` and a live phase
+	// instead of `masterKeyState`. Surface it so the UI can render a loading screen.
+	if (body.starting) {
+		return {
+			starting: true,
+			phase: body.phase,
+			message: body.message,
+			detail: body.detail,
+			version: body.version,
+		};
+	}
 	if (!res.ok) {
 		const msg = body.error?.message ?? res.statusText;
 		throw new Error(msg || `Status request failed (${res.status})`);

--- a/packages/web/src/routes/__root.tsx
+++ b/packages/web/src/routes/__root.tsx
@@ -15,6 +15,7 @@ import { MasterKeyGate } from '../components/master-key-gate';
 import { ProjectRail } from '../components/project-rail';
 import { ProjectSidebar } from '../components/project-sidebar';
 import { MasterKeyStep, SetupGate } from '../components/setup/setup-wizard';
+import { StartingScreen } from '../components/starting-screen';
 import { UpdateBanner } from '../components/update-banner';
 import { SocketProvider } from '../contexts/socket-context';
 import { useActiveProject } from '../hooks/use-active-project';
@@ -50,9 +51,15 @@ function AppShell() {
 		}
 	}, [status?.masterKeyState, navigate]);
 
+	// The server is still booting (compiled binary serves the SPA shell during
+	// startup). Show the boot phase and keep polling rather than the bare spinner.
+	if (status?.starting) {
+		return <StartingScreen phase={status.phase} message={status.message} detail={status.detail} />;
+	}
+
 	if (isPending || isFetching) return <Spinner />;
 
-	if (isError || !status) {
+	if (isError || !status || !status.masterKeyState) {
 		const message =
 			(error as { message?: string } | null)?.message ??
 			'Could not reach the server. If you just reset the database, wait a few seconds and retry.';

--- a/packages/web/test/starting-screen.test.tsx
+++ b/packages/web/test/starting-screen.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { StartingScreen } from '../src/components/starting-screen';
+
+test('shows the live boot phase message with a spinner while starting', () => {
+	render(<StartingScreen phase="migrations" message="Running database migrations…" />);
+	expect(screen.getByText('Running database migrations…')).toBeTruthy();
+	// The polite status region is what screen readers announce as the phase advances.
+	expect(screen.getByRole('status')).toBeTruthy();
+});
+
+test('falls back to a generic message when none is provided', () => {
+	render(<StartingScreen />);
+	expect(screen.getByText('Starting up…')).toBeTruthy();
+});
+
+test('renders the failure layout with the reason when boot errors', () => {
+	render(<StartingScreen phase="error" message="Startup failed" detail="migration 017 failed" />);
+	expect(screen.getByText('Startup failed')).toBeTruthy();
+	expect(screen.getByText('migration 017 failed')).toBeTruthy();
+	expect(screen.getByText('Check the server logs for details.')).toBeTruthy();
+	// No spinner/status region on the error layout.
+	expect(screen.queryByRole('status')).toBeNull();
+});


### PR DESCRIPTION
## Problem

On a fresh install the compiled binary left the browser stuck on raw JSON for **minutes**:

```json
{"error":{"code":"STARTING","message":"Server is starting — retry in a moment"}}
```

Root cause: `startup()` **awaited** the agent-base image prune + `refreshPublishedAgentBaseImage` (a full `docker pull` from GHCR) *before* flipping `serverReady`. The Bun fetch entry returns the `STARTING` 503 for every path except `/health` while `!serverReady`, so during the (multi-minute, cold) pull the SPA shell itself returned JSON — the web app never loaded, so its `useStatus` retry logic never ran and the master-key gate never appeared. Confirmed in the field: ~6.5 min between *"Extracted … agent-base build context"* and *"refreshed published agent-base image … Hezo server running [locked]"*.

This was introduced by #405 (fetch `:latest`, refreshed at startup) — the refresh simply wasn't given the fire-and-forget treatment the HQ-container warm-up right below it already has.

## Fix

1. **Background the image work.** The prune + `refreshPublishedAgentBaseImage` now run via `trackBackground(...)` so they no longer gate `serverReady`. It's best-effort anyway — provisioning pulls-then-builds on demand (with `ImageBuildTracker` progress), so a slow/missing refresh self-heals on first use. The fast, local-only context extraction (`setDockerBaseDir`) stays synchronous on the critical path, so the local-build fallback still resolves.

2. **Never show raw JSON to a browser.** A new `serveStartupRequest` handler serves the embedded SPA shell during the (now brief) pre-ready window, and answers `/api/status` with `200 { starting: true, phase, message }` from a `startup-progress` singleton. The web UI renders a `StartingScreen` loading state naming the current phase and keeps polling (`useStatus` `refetchInterval`), flipping to the master-key gate the moment boot finishes. Other API/MCP/WS surfaces still get `503 STARTING` so machine clients retry; `/health` always answers 200.

3. **Show what's going on.** Boot advances through `database → migrations → seed → pricing → workspace`, surfaced live on the loading screen.

### Why both parts?
Backgrounding alone shortens the stall to ~1–3s, but a browser that *loads the page* during that window would still get raw JSON for the document itself (HTML navigations don't auto-retry — only the already-loaded SPA does). Serving the shell + phase status closes that gap, which is the *"should always show the web UI"* requirement.

## Dependency note (verified in code)
Creating a project + queueing tickets is pure DB work and does **not** need the HQ container (`createProjectWithTeam` provisions the per-project container fire-and-forget). Agents can only *run* once a container exists, and every container builds from the agent-base image — so deferring the image pull doesn't block setup/creation, only the eventual agent runs, which already wait on provisioning.

## Tests
- `packages/server/test/startup-serving.test.ts` — `/api/status` returns `starting + phase`; `/health` 200; other API/MCP/WS get 503 STARTING; SPA shell served for navigations when bundled; JSON-503 fallback in dev (no bundle).
- `packages/web/test/starting-screen.test.tsx` — phase message + spinner; generic fallback; error layout.
- Verified existing `startup`, `image-registry`, `prune-stale-bundled-images`, `docker-preflight`, `master-key-setup/unlock`, `project-sidebar`, `status-meta` suites still pass; `typecheck` + repo-wide `biome` clean.

## Docs
`.dev/architecture.md` (§12) updated: image refresh is now backgrounded, and a new **Pre-ready serving** note describes the `serveStartupRequest` / `startup-progress` behavior. No user-facing `docs/` change — the first-run *setup flow* is unchanged; the loading screen is a transient pre-setup nicety.

## Follow-up (deliberately not included)
A bounded `AbortSignal` timeout on the startup refresh pull. Now that the pull is fully off the readiness path it can't affect the user, and a too-tight bound would cancel a legitimate slow first-pull (closing the daemon stream aborts the pull). Left as an optional hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dp7Np8cFxyfvAZKHd8mCuX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dp7Np8cFxyfvAZKHd8mCuX)_