### PR TITLE
fix(containers): chown bind-mounted files to the detected container run-user

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -345,6 +345,24 @@ authenticates through the host ssh-agent; the container's baked-in `/etc/ssh/ssh
 verifies the host key. Cloning outside a run (container provision, repo link) uses a
 short-lived `withProvisionBridge`.
 
+**Container run-user & host-file ownership.** The agent base image (`node:24-slim`) sets no
+`USER`, so the container runs as **root**; Hezo deprivileges individual `docker exec`s — the
+agent CLI and every git op — to a non-root **run-user** (the stock image's `node`, which has
+passwordless sudo, so this is for file-ownership hygiene, not a security boundary) so files
+those execs create in the bind-mounted workspace stay non-root-owned. The run-user is
+**detected, not assumed** (`resolveContainerRunUser`, `services/container-user.ts`): it prefers
+a `node` user and falls back to the container's default user (root, for a custom
+`docker_base_image` with no `node`), cached per container, and is used for the `--user` of every
+exec and the socat socket owner. Because the server writes the per-run runtime config dir +
+credentials and creates the workspace/worktree dirs on the host (as root in production), Hezo
+gives the run-user ownership of every bind-mounted path those deprivileged execs must read or
+write — the per-run config dir, `/workspace`, `/worktrees`, `/workspace/.previews`, `/run/hezo`
+— via an **in-container `chown` run as root** (`chownToRunUser`). Doing the chown inside the
+container needs no host privilege, so it works identically on a root server, a non-root
+`User=hezo` server, and macOS (where Docker Desktop's bind-mount uid-remapping otherwise hides
+the mismatch — the reason this class of bug only surfaced on a native-Linux production host). It
+is a no-op when the run-user is root.
+
 Before building a worktree the runner fetches each clone, then **fast-forwards the clone's
 local default branch** (the "main codebase") to `origin/<default>` (resolved via `origin/HEAD`
 → fallback `main`/`master`) — a clean fast-forward when it's checked out, else an `update-ref`,
@@ -448,6 +466,11 @@ substitution — there is **no fall-through**; if it can't bind, the run aborts
 (`<dataDir>/ca/`, cert world-readable, key host-owner-only) that both signs per-host leaf
 certs and is bind-mounted into every container's trust store
 (`update-ca-certificates`, `NODE_EXTRA_CA_CERTS`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`).
+Unlike the CA cert (deliberately world-readable so any in-container uid can read it), the
+per-run runtime config and subscription-credential files the server writes into the
+`/workspace` bind mount stay `0o600`/`0o700` and are instead **chowned to the container
+run-user** (see § Containers & worktrees) so the deprivileged agent CLI can read them
+without exposing secrets to other host users.
 Per run, the agent's container gets `HTTP(S)_PROXY=http://host.docker.internal:<port>`
 with `NO_PROXY` carving out the Hezo backend and the LLM provider host (LLM traffic goes
 direct — credentials are env-injected, and MITM breaks some Anthropic-compatible APIs).

--- a/docs/deployment/self-hosting.md
+++ b/docs/deployment/self-hosting.md
@@ -124,7 +124,17 @@ service.
 **Running as a non-root user instead.** Add `User=hezo` (and `Group=hezo`) to the
 `[Service]` section, make that user a member of the `docker` group
 (`sudo usermod -aG docker hezo`), and give it ownership of the data directory
-(`sudo chown -R hezo:hezo /var/lib/hezo`).
+(`sudo chown -R hezo:hezo /var/lib/hezo`). This is fully supported: Hezo fixes
+container file ownership from *inside* each container, so it needs no host
+privilege either way.
+
+**Custom agent images.** Inside each project container Hezo runs the agent (and its
+git operations) as a non-root **run-user** — the stock agent image's `node` — so the
+files the agent writes stay non-root-owned, and it automatically gives that user
+ownership of the bind-mounted workspace and per-run config. A custom
+`docker_base_image` with no `node` user simply runs the agent as the image's default
+user (root for most images), which also works; include a non-root user named `node`
+if you want agent-created files owned by a non-root uid on the host.
 
 ## Ports
 

--- a/packages/server/src/routes/repos.ts
+++ b/packages/server/src/routes/repos.ts
@@ -6,6 +6,7 @@ import { err, ok } from '../lib/response';
 import { isUniqueViolation, withTransaction } from '../lib/sql';
 import type { Env } from '../lib/types';
 import { logger } from '../logger';
+import { resolveContainerRunUser } from '../services/container-user';
 import { ensureProjectContainerRunning } from '../services/containers';
 import { ContainerGitExecutor } from '../services/git-executor';
 import { createGitHubRepo, parseGitHubUrl, validateRepoAccess } from '../services/github';
@@ -212,15 +213,16 @@ reposRoutes.post('/projects/:projectId/repos', async (c) => {
 			const sshAgentServer = c.get('sshAgentServer');
 
 			if (containerId && running) {
+				const runUser = await resolveContainerRunUser(docker, containerId);
 				const syncRepos = (bridge: BridgeRunnerArgs | null) =>
 					ensureProjectRepos(
 						db,
 						{ id: projectId, team_id: teamId },
 						dataDir,
-						ContainerGitExecutor.forPrep(docker, containerId, bridge),
+						ContainerGitExecutor.forPrep(docker, containerId, bridge, runUser),
 					);
 				const syncRes = sshAgentServer
-					? await withProvisionBridge(sshAgentServer, teamId, dataDir, ({ bridge }) =>
+					? await withProvisionBridge(sshAgentServer, teamId, dataDir, runUser.name, ({ bridge }) =>
 							syncRepos(bridge),
 						)
 					: await syncRepos(null);

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -41,6 +41,7 @@ import {
 	updateAiProviderCredential,
 } from './ai-provider-keys';
 import { checkOverBudget, recordRunCost } from './budget';
+import { type ContainerRunUser, chownToRunUser, resolveContainerRunUser } from './container-user';
 import type { DockerClient, ExecLogChunk } from './docker';
 import { getAgentSystemPrompt } from './documents';
 import { applyEffortToRuntime, type EffortRuntimeApplication, resolveEffort } from './effort';
@@ -295,6 +296,11 @@ export interface RuntimeInvocationInput {
 	agentId: string;
 	/** Keys the per-resource home/subscription/config dirs — heartbeatRunId or sessionId. */
 	resourceId: string;
+	/** The project container the run executes in (target of the run-user chown). */
+	containerId: string;
+	/** Detected container run-user; the per-run config dir is chowned to it so the
+	 *  non-root agent CLI can read the host-written settings/credentials. */
+	runUser: ContainerRunUser;
 	/** Container path the prompt is read from on stdin. */
 	promptContainerPath: string;
 	effort: string;
@@ -328,6 +334,8 @@ export async function buildRuntimeInvocation(
 		agentJwt,
 		agentId,
 		resourceId,
+		containerId,
+		runUser,
 		promptContainerPath,
 		effort,
 		effortApplication,
@@ -382,8 +390,19 @@ export async function buildRuntimeInvocation(
 	validateInjection(adapter, mcpInjection);
 
 	for (const file of mcpInjection.files) {
-		mkdirSync(dirname(file.hostPath), { recursive: true, mode: 0o700 });
+		mkdirSync(dirname(file.hostPath), { recursive: true, mode: 0o711 });
 		writeFileSync(file.hostPath, file.contents, { mode: file.mode });
+	}
+
+	// The host (root in production) just wrote the per-run config dir + files at
+	// restrictive modes; give the container's non-root run-user ownership so the
+	// agent CLI can read them (settings/MCP config, judge script) and rewrite any
+	// rotating subscription credential. Runs in-container as root (needs no host
+	// privilege); a no-op when the run-user is root.
+	if (homeMount) {
+		await chownToRunUser(deps.docker, containerId, runUser, [homeMount.containerDir], {
+			recursive: true,
+		});
 	}
 
 	const env: string[] = [
@@ -478,6 +497,7 @@ async function buildRunContext(
 	sshSocketContainerPath: string | null,
 	bridge: BridgeRunnerArgs | null,
 	egress: EgressEnvDescriptor | null,
+	runUser: ContainerRunUser,
 ): Promise<RunContext> {
 	// The run is scoped to the project's team (the "run team"). For normal agents
 	// this equals the agent's home team; for instance agents (CEO/Coach) that
@@ -560,6 +580,8 @@ async function buildRunContext(
 		agentJwt,
 		agentId: agent.id,
 		resourceId: heartbeatRunId,
+		containerId: project.container_id,
+		runUser,
 		promptContainerPath: promptFilePath,
 		effort,
 		effortApplication,
@@ -827,6 +849,12 @@ export async function runAgent(
 		// since a run has no friendly identifier of its own.
 		const runLabel = `${agent.slug}/${task.identifier}`;
 
+		// Detect the container's run-user once (cached). Drives every --user exec, the
+		// ssh socket owner, and the chowns that give the run-user ownership of the
+		// host-written config/worktree dirs. Defaults to root for an image with no
+		// `node` user, which makes those chowns a harmless no-op.
+		const runUser = await resolveContainerRunUser(deps.docker, project.container_id);
+
 		let sshSocketContainerPath: string | null = null;
 		let sshSocketHostPath: string | null = null;
 		let bridge: BridgeRunnerArgs | null = null;
@@ -840,7 +868,7 @@ export async function runAgent(
 			sshSocketContainerPath = `/run/hezo/${heartbeatRunId}.sock`;
 			bridge = {
 				socketPath: sshSocketContainerPath,
-				socketUser: 'node',
+				socketUser: runUser.name,
 				tokenHex: allocated.tokenHex,
 				hostName: 'host.docker.internal',
 				hostPort: allocated.tcpHostPort,
@@ -881,6 +909,7 @@ export async function runAgent(
 			sshSocketContainerPath,
 			bridge,
 			egressEnv,
+			runUser,
 		);
 
 		const hostPromptPath = getHostPromptPath(
@@ -970,7 +999,7 @@ export async function runAgent(
 		try {
 			if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
 
-			const prep = await prepareWorktrees(deps, project, task, bridge, emit, signal);
+			const prep = await prepareWorktrees(deps, project, task, bridge, runUser, emit, signal);
 
 			if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
 
@@ -994,7 +1023,7 @@ export async function runAgent(
 				Cmd: context.execCmd,
 				Env: context.env,
 				WorkingDir: prep.workingDir,
-				User: 'node',
+				User: runUser.name,
 				AttachStdout: true,
 				AttachStderr: true,
 			});
@@ -1174,6 +1203,7 @@ async function prepareWorktrees(
 	project: ProjectInfo,
 	task: TaskInfo,
 	bridge: BridgeRunnerArgs | null,
+	runUser: ContainerRunUser,
 	emit: (stream: 'stdout' | 'stderr', text: string) => void,
 	signal?: AbortSignal,
 ): Promise<{
@@ -1211,6 +1241,7 @@ async function prepareWorktrees(
 			deps.docker,
 			project.container_id,
 			bridge,
+			runUser,
 			gitIdentityEnv,
 		);
 
@@ -1234,6 +1265,12 @@ async function prepareWorktrees(
 		const worktreesRoot = getWorktreesPath(deps.dataDir, project.team_id, project.id);
 		const taskWorktreeRoot = join(worktreesRoot, task.identifier);
 		mkdirSync(taskWorktreeRoot, { recursive: true });
+		// The host just created this task's worktree root (root-owned); give the
+		// run-user ownership so the in-container `git worktree add` (run as the
+		// run-user) can populate it. No-op when the run-user is root.
+		await chownToRunUser(deps.docker, project.container_id, runUser, [
+			`${CONTAINER_WORKTREES_ROOT}/${task.identifier}`,
+		]);
 
 		const branchName = `hezo/${task.identifier}`;
 		const repoLocOf = (name: string): RepoLoc => ({

--- a/packages/server/src/services/ceo-session-manager.ts
+++ b/packages/server/src/services/ceo-session-manager.ts
@@ -34,6 +34,7 @@ import {
 } from './agent-stream-parser';
 import { getProviderCredentialAndModel } from './ai-provider-keys';
 import type { ContainerLogStreamer } from './container-logs';
+import { type ContainerRunUser, resolveContainerRunUser } from './container-user';
 import { type ContainerDeps, ensureProjectContainerRunning } from './containers';
 import { getAgentSystemPrompt, getDocument } from './documents';
 import { applyEffortToRuntime, type EffortRuntimeApplication } from './effort';
@@ -100,6 +101,7 @@ interface LiveSession {
 	ceoMemberId: string;
 	projectId: string;
 	containerId: string;
+	runUser: ContainerRunUser;
 	runtimeType: AgentRuntime;
 	env: string[];
 	execCmd: string[];
@@ -288,6 +290,10 @@ export class CeoSessionManager {
 				? project.container_id
 				: await ensureProjectContainerRunning(this.buildContainerDeps(), project.id);
 
+		// Detect the HQ container's run-user once for this session; reused on every
+		// turn's exec, the ssh socket owner, and the per-turn config-dir chown.
+		const runUser = await resolveContainerRunUser(this.deps.docker, containerId);
+
 		const override = await db.query<{ provider: AiProvider | null; model: string | null }>(
 			`SELECT model_override_provider AS provider, model_override_model AS model
 			 FROM member_agents WHERE id = $1`,
@@ -356,7 +362,7 @@ export class CeoSessionManager {
 				sshSocketContainerPath = `/run/hezo/${sessionId}.sock`;
 				bridge = {
 					socketPath: sshSocketContainerPath,
-					socketUser: 'node',
+					socketUser: runUser.name,
 					tokenHex: allocated.tokenHex,
 					hostName: 'host.docker.internal',
 					hostPort: allocated.tcpHostPort,
@@ -406,6 +412,8 @@ export class CeoSessionManager {
 				agentJwt,
 				agentId: ceoMemberId,
 				resourceId: sessionId,
+				containerId,
+				runUser,
 				promptContainerPath: getContainerPromptPath(sessionId),
 				effort: AgentEffort.Max,
 				effortApplication,
@@ -426,6 +434,7 @@ export class CeoSessionManager {
 				ceoMemberId,
 				projectId: project.id,
 				containerId,
+				runUser,
 				runtimeType,
 				env: invocation.env,
 				execCmd: invocation.execCmd,
@@ -490,7 +499,7 @@ export class CeoSessionManager {
 				Cmd: session.execCmd,
 				Env: session.env,
 				WorkingDir: CHAT_WORKING_DIR,
-				User: 'node',
+				User: session.runUser.name,
 				AttachStdout: true,
 				AttachStderr: true,
 			});

--- a/packages/server/src/services/container-user.ts
+++ b/packages/server/src/services/container-user.ts
@@ -1,0 +1,144 @@
+import { logger } from '../logger';
+import type { DockerClient } from './docker';
+
+const log = logger.child('container-user');
+
+/**
+ * The user a project container's agent/git execs run as. The agent base image runs
+ * as **root** (no `USER` directive); Hezo deprivileges individual execs to a
+ * non-root user (the stock image's `node`) purely so bind-mounted files stay
+ * non-root-owned — `node` has passwordless sudo, so it is not a security boundary.
+ * Custom `docker_base_image`s may have no `node` user, so the user is **detected**,
+ * never assumed.
+ */
+export interface ContainerRunUser {
+	/** Username for `docker exec --user` and the socat `user=` socket owner. */
+	name: string;
+	uid: number;
+	gid: number;
+}
+
+const ROOT: ContainerRunUser = { name: 'root', uid: 0, gid: 0 };
+
+// Resolved once per container (immutable for the container's lifetime) — the same
+// value is needed at provision, at run time, and on every CEO chat turn.
+const cache = new Map<string, ContainerRunUser>();
+
+/** Drop a container's cached run-user (call on teardown / rebuild / reprovision). */
+export function clearContainerRunUserCache(containerId?: string): void {
+	if (containerId) cache.delete(containerId);
+	else cache.clear();
+}
+
+async function execCapture(
+	docker: DockerClient,
+	containerId: string,
+	script: string,
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+	const execId = await docker.execCreate(containerId, {
+		Cmd: ['sh', '-c', script],
+		User: 'root',
+		AttachStdout: true,
+		AttachStderr: true,
+	});
+	const { stdout, stderr } = await docker.execStart(execId);
+	const { ExitCode } = await docker.execInspect(execId);
+	return { exitCode: ExitCode, stdout, stderr };
+}
+
+async function probe(
+	docker: DockerClient,
+	containerId: string,
+	user: 'node' | null,
+): Promise<ContainerRunUser | null> {
+	// `&&`-chained so a missing user yields a non-zero exit (not a partial reading).
+	// `user` is only ever the literal 'node' — there is no shell-injection surface.
+	const t = user ? ` ${user}` : '';
+	const { exitCode, stdout } = await execCapture(
+		docker,
+		containerId,
+		`id -u${t} && id -g${t} && id -un${t}`,
+	);
+	if (exitCode !== 0) return null;
+	const [uidStr, gidStr, name] = stdout.split('\n').map((l) => l.trim());
+	const uid = Number(uidStr);
+	const gid = Number(gidStr);
+	if (!Number.isInteger(uid) || !Number.isInteger(gid) || !name) return null;
+	return { name, uid, gid };
+}
+
+/**
+ * Resolve the user a project container's agent/git execs should run as. Prefers a
+ * `node` user (the stock agent-base) and falls back to the container's default user
+ * (root, for an image with no `USER`). Never throws — on any docker failure it
+ * defaults to root, which makes the run-user chowns a harmless no-op and lets the
+ * (root) container read everything the host wrote. Cached per container.
+ */
+export async function resolveContainerRunUser(
+	docker: DockerClient,
+	containerId: string,
+): Promise<ContainerRunUser> {
+	const cached = cache.get(containerId);
+	if (cached) return cached;
+	let resolved: ContainerRunUser;
+	try {
+		resolved =
+			(await probe(docker, containerId, 'node')) ??
+			(await probe(docker, containerId, null)) ??
+			ROOT;
+	} catch (e) {
+		log.debug(
+			`run-user detection failed for ${containerId.slice(0, 12)}, defaulting to root: ${
+				e instanceof Error ? e.message : String(e)
+			}`,
+		);
+		resolved = ROOT;
+	}
+	cache.set(containerId, resolved);
+	return resolved;
+}
+
+function shSingleQuote(s: string): string {
+	return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * Give the container's run-user ownership of paths the host created in a bind mount
+ * that the run-user must read or write. The chown runs **inside the container as
+ * root** (the base image's default user), so it needs no host privilege and works
+ * uniformly across root-host, non-root-host, and macOS deployments — unlike a
+ * host-side chown, which would need `CAP_CHOWN` and fail on macOS dev / a non-root
+ * `User=hezo` server. A no-op when the run-user is root (the container already
+ * accesses everything). Best-effort: a non-zero/failed chown logs one warning and
+ * never throws — a permission fix must never abort the run/provision around it.
+ */
+export async function chownToRunUser(
+	docker: DockerClient,
+	containerId: string,
+	runUser: ContainerRunUser,
+	containerPaths: string[],
+	opts: { recursive?: boolean } = {},
+): Promise<void> {
+	if (runUser.uid === 0 || containerPaths.length === 0) return;
+	const flag = opts.recursive ? '-R ' : '';
+	const owner = `${shSingleQuote(runUser.name)}:${shSingleQuote(runUser.name)}`;
+	const targets = containerPaths.map(shSingleQuote).join(' ');
+	try {
+		const { exitCode, stderr } = await execCapture(
+			docker,
+			containerId,
+			`chown ${flag}${owner} ${targets}`,
+		);
+		if (exitCode !== 0) {
+			log.warn(
+				`chown to ${runUser.name} exited ${exitCode} for [${containerPaths.join(', ')}]: ${stderr.trim()}`,
+			);
+		}
+	} catch (e) {
+		log.warn(
+			`chown to ${runUser.name} failed for [${containerPaths.join(', ')}]: ${
+				e instanceof Error ? e.message : String(e)
+			}`,
+		);
+	}
+}

--- a/packages/server/src/services/containers.ts
+++ b/packages/server/src/services/containers.ts
@@ -16,6 +16,11 @@ import { terminalStatusParams } from '../lib/sql';
 import { logger } from '../logger';
 import { setAgentIdleIfNoActiveRuns } from './agent-runtime-status';
 import type { ContainerLogStreamer } from './container-logs';
+import {
+	chownToRunUser,
+	clearContainerRunUserCache,
+	resolveContainerRunUser,
+} from './container-user';
 import type { DockerClient } from './docker';
 import { ensureImage } from './ensure-image';
 import { ContainerGitExecutor } from './git-executor';
@@ -24,7 +29,12 @@ import type { LogStreamBroker } from './log-stream-broker';
 import { ensureProjectRepos } from './repo-sync';
 import { type BridgeRunnerArgs, type SshAgentServer, withProvisionBridge } from './ssh-agent';
 import { createWakeup } from './wakeup';
-import { ensureProjectWorkspace, removeProjectWorkspace } from './workspace';
+import {
+	CONTAINER_WORKSPACE_ROOT,
+	CONTAINER_WORKTREES_ROOT,
+	ensureProjectWorkspace,
+	removeProjectWorkspace,
+} from './workspace';
 import type { WebSocketManager } from './ws';
 
 export type ContainerExitReason = 'container_error' | 'container_stopped';
@@ -332,6 +342,22 @@ export async function provisionContainer(
 			}
 		}
 
+		// Detect the container's run-user (the stock agent-base's `node`, or root for a
+		// custom image without it). The host created the bind-mounted dirs as root;
+		// give the run-user ownership of those the deprivileged git/agent execs must
+		// write into — repo clones (/workspace), worktrees, previews — plus the per-run
+		// ssh socket dir. Chowning in-container (as root) needs no host privilege; a
+		// no-op when the run-user is root. Cleared on rebuild so a fresh container
+		// re-detects.
+		clearContainerRunUserCache(Id);
+		const runUser = await resolveContainerRunUser(docker, Id);
+		await chownToRunUser(docker, Id, runUser, [
+			CONTAINER_WORKSPACE_ROOT,
+			CONTAINER_WORKTREES_ROOT,
+			`${CONTAINER_WORKSPACE_ROOT}/.previews`,
+			'/run/hezo',
+		]);
+
 		if (masterKeyManager) {
 			emit('stdout', '→ Syncing project repos');
 			// Clone in-container (the host has no git). Repos clone over SSH, which
@@ -343,12 +369,16 @@ export async function provisionContainer(
 					db,
 					{ id: project.id, team_id: teamId },
 					dataDir,
-					ContainerGitExecutor.forPrep(docker, Id, bridge),
+					ContainerGitExecutor.forPrep(docker, Id, bridge, runUser),
 					(stream, text) => emit(stream, text),
 				);
 			const syncRes = deps.sshAgentServer
-				? await withProvisionBridge(deps.sshAgentServer, teamId, dataDir, ({ bridge }) =>
-						syncRepos(bridge),
+				? await withProvisionBridge(
+						deps.sshAgentServer,
+						teamId,
+						dataDir,
+						runUser.name,
+						({ bridge }) => syncRepos(bridge),
 					)
 				: await syncRepos(null);
 			if (syncRes.failed.length > 0) {

--- a/packages/server/src/services/git-executor.ts
+++ b/packages/server/src/services/git-executor.ts
@@ -1,4 +1,5 @@
 import { execFile } from 'node:child_process';
+import type { ContainerRunUser } from './container-user';
 import type { DockerClient } from './docker';
 import { type BridgeRunnerArgs, buildBridgeRunnerArgv } from './ssh-agent';
 
@@ -62,6 +63,8 @@ export interface ContainerGitExecutorOptions {
 	baseEnv: string[];
 	/** The run's SSH bridge; required for `needsSsh` ops. Null disables SSH wrapping. */
 	bridge?: BridgeRunnerArgs | null;
+	/** The container user every git exec runs as (detected, not assumed `node`). */
+	runUser: ContainerRunUser;
 }
 
 /**
@@ -77,6 +80,7 @@ export interface ContainerGitExecutorOptions {
 export class ContainerGitExecutor implements GitExecutor {
 	private readonly bridge: BridgeRunnerArgs | null;
 	private readonly baseEnv: string[];
+	private readonly runUser: ContainerRunUser;
 
 	constructor(
 		private readonly docker: DockerClient,
@@ -84,6 +88,7 @@ export class ContainerGitExecutor implements GitExecutor {
 		opts: ContainerGitExecutorOptions,
 	) {
 		this.bridge = opts.bridge ?? null;
+		this.runUser = opts.runUser;
 		// The bridge wrapper appends/redirects HEZO_PROMPT_FILE into the command it
 		// runs; it must never leak into a git invocation. Strip it defensively.
 		this.baseEnv = opts.baseEnv.filter((e) => !e.startsWith('HEZO_PROMPT_FILE='));
@@ -102,11 +107,12 @@ export class ContainerGitExecutor implements GitExecutor {
 		docker: DockerClient,
 		containerId: string,
 		bridge: BridgeRunnerArgs | null,
+		runUser: ContainerRunUser,
 		extraEnv: string[] = [],
 	): ContainerGitExecutor {
 		const baseEnv = ['GIT_TERMINAL_PROMPT=0', ...extraEnv];
 		if (bridge) baseEnv.push(`SSH_AUTH_SOCK=${bridge.socketPath}`);
-		return new ContainerGitExecutor(docker, containerId, { baseEnv, bridge });
+		return new ContainerGitExecutor(docker, containerId, { baseEnv, bridge, runUser });
 	}
 
 	async exec(args: string[], opts: GitExecOpts): Promise<GitExecResult> {
@@ -120,7 +126,7 @@ export class ContainerGitExecutor implements GitExecutor {
 				Cmd: cmd,
 				Env: this.baseEnv,
 				WorkingDir: opts.cwd,
-				User: 'node',
+				User: this.runUser.name,
 				AttachStdout: true,
 				AttachStderr: true,
 			});

--- a/packages/server/src/services/runtime-home.ts
+++ b/packages/server/src/services/runtime-home.ts
@@ -145,7 +145,11 @@ export function buildSubscriptionMount(
 	const containerDir = getContainerSubscriptionRoot(provider, heartbeatRunId) as string;
 	const hostAuthFile = join(hostDir, authFileRelative);
 
-	mkdirSync(dirname(hostAuthFile), { recursive: true, mode: 0o700 });
+	// 0o711 (not 0o700) so the non-root container run-user can *traverse* these
+	// intermediate dirs to reach the per-run leaf — which the runner chowns to that
+	// user (see chownToRunUser). The credential file itself stays 0o600 (and is
+	// chowned to the run-user), never world-readable.
+	mkdirSync(dirname(hostAuthFile), { recursive: true, mode: 0o711 });
 	writeFileSync(hostAuthFile, credential.value, { mode: 0o600 });
 
 	return {
@@ -198,7 +202,9 @@ export function ensureRuntimeHomeDir(
 	) as string;
 	const containerDir = getContainerSubscriptionRoot(provider, heartbeatRunId) as string;
 
-	mkdirSync(hostDir, { recursive: true, mode: 0o700 });
+	// 0o711 so the non-root container run-user can traverse the intermediate dirs to
+	// its per-run config dir (which the runner then chowns to that user).
+	mkdirSync(hostDir, { recursive: true, mode: 0o711 });
 
 	return {
 		hostDir,

--- a/packages/server/src/services/ssh-agent/host.ts
+++ b/packages/server/src/services/ssh-agent/host.ts
@@ -15,6 +15,7 @@ export async function withProvisionBridge<T>(
 	sshAgentServer: SshAgentServer,
 	teamId: string,
 	dataDir: string,
+	socketUser: string,
 	fn: (ctx: { bridge: BridgeRunnerArgs }) => Promise<T>,
 ): Promise<T> {
 	const runId = `provision-${randomBytes(8).toString('hex')}`;
@@ -27,7 +28,7 @@ export async function withProvisionBridge<T>(
 	try {
 		const bridge: BridgeRunnerArgs = {
 			socketPath: `/run/hezo/${runId}.sock`,
-			socketUser: 'node',
+			socketUser,
 			tokenHex: allocated.tokenHex,
 			hostName: 'host.docker.internal',
 			hostPort: allocated.tcpHostPort,

--- a/packages/server/test/agent-runner.test.ts
+++ b/packages/server/test/agent-runner.test.ts
@@ -26,6 +26,7 @@ import { LogStreamBroker } from '../src/services/log-stream-broker';
 import { PricingService, upsertManualRate } from '../src/services/pricing';
 import { safeClose } from './helpers';
 import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
+import { withRunUserStub } from './helpers/run-user-docker';
 
 function readPromptFromExec(
 	opts: { Env: string[] },
@@ -129,7 +130,7 @@ function createMockDocker(overrides: Record<string, any> = {}): DockerClient {
 		...rest
 	} = overrides;
 	const innerExecStart = execStartOverride ?? (async () => ({ stdout: 'done', stderr: '' }));
-	return {
+	const base = {
 		ping: async () => true,
 		imageExists: async () => true,
 		pullImage: async () => {},
@@ -162,6 +163,10 @@ function createMockDocker(overrides: Record<string, any> = {}): DockerClient {
 			return (innerExecStart as (...a: unknown[]) => unknown)(...args);
 		},
 	} as unknown as DockerClient;
+	// Transparently answer the run-user probe (`id -u node`) + ownership chowns so the
+	// runner resolves a `node` run-user without those infra execs reaching the test's
+	// own execCreate/execStart handlers above.
+	return withRunUserStub(base);
 }
 
 async function setAgentPrompt(content: string) {

--- a/packages/server/test/container-sync.test.ts
+++ b/packages/server/test/container-sync.test.ts
@@ -904,6 +904,81 @@ describe('provisionContainer broadcasting', () => {
 		expect(mockDocker.execCreate).toHaveBeenCalled();
 	});
 
+	// A recording docker that answers the run-user probe from `users` and records
+	// every exec, so a test can assert the in-container ownership chowns.
+	function provisionRecordingDocker(users: Record<string, { uid: number; gid: number }>) {
+		const execs: { Cmd: string[]; User?: string }[] = [];
+		const byId = new Map<string, string[]>();
+		let seq = 0;
+		const docker = createStubDocker({
+			imageExists: vi.fn().mockResolvedValue(true),
+			createContainer: vi.fn().mockResolvedValue({ Id: 'runuser-cid' }),
+			startContainer: vi.fn().mockResolvedValue(undefined),
+			execCreate: vi.fn(async (_id: string, config: { Cmd: string[]; User?: string }) => {
+				execs.push(config);
+				const id = `e-${seq++}`;
+				byId.set(id, config.Cmd);
+				return id;
+			}),
+			execStart: vi.fn(async (id: string) => {
+				const m = byId.get(id)?.[2]?.match(/^id -u (\S+) &&/);
+				const u = m ? users[m[1]] : users.__default;
+				if (byId.get(id)?.[2]?.startsWith('id -u')) {
+					return u
+						? { stdout: `${u.uid}\n${u.gid}\n${m ? m[1] : '__default'}\n`, stderr: '' }
+						: { stdout: '', stderr: 'no such user' };
+				}
+				return { stdout: '', stderr: '' };
+			}),
+			execInspect: vi.fn(async (id: string) => {
+				const script = byId.get(id)?.[2] ?? '';
+				const m = script.match(/^id -u (\S+) &&/);
+				const known = script.startsWith('id -u') ? (m ? !!users[m[1]] : !!users.__default) : true;
+				return { ExitCode: known ? 0 : 1, Running: false, Pid: 0 };
+			}),
+		});
+		return { docker, execs };
+	}
+
+	it('chowns the bind-mount dirs + /run/hezo to the detected run-user', async () => {
+		await db.query(
+			'UPDATE projects SET container_id = NULL, container_status = NULL WHERE id = $1',
+			[projectId],
+		);
+		const dataDir = mkdtempSync(join(tmpdir(), 'hezo-test-'));
+		const { docker, execs } = provisionRecordingDocker({ node: { uid: 1000, gid: 1000 } });
+		const project = (
+			await db.query<ProjectRow>('SELECT * FROM projects WHERE id = $1', [projectId])
+		).rows[0];
+
+		await provisionContainer({ db, docker, dataDir }, project, 'container-sync-co');
+
+		const chown = execs.find((e) => e.Cmd?.[2]?.startsWith('chown'));
+		expect(chown).toBeDefined();
+		expect(chown?.User).toBe('root'); // chown runs in-container as root
+		expect(chown?.Cmd[2]).toContain("'node':'node'");
+		expect(chown?.Cmd[2]).toContain('/workspace');
+		expect(chown?.Cmd[2]).toContain('/worktrees');
+		expect(chown?.Cmd[2]).toContain('/run/hezo');
+	});
+
+	it('runs as root with no chown for a custom image without a node user', async () => {
+		await db.query(
+			'UPDATE projects SET container_id = NULL, container_status = NULL WHERE id = $1',
+			[projectId],
+		);
+		const dataDir = mkdtempSync(join(tmpdir(), 'hezo-test-'));
+		// No `node`; the container default user is root.
+		const { docker, execs } = provisionRecordingDocker({ __default: { uid: 0, gid: 0 } });
+		const project = (
+			await db.query<ProjectRow>('SELECT * FROM projects WHERE id = $1', [projectId])
+		).rows[0];
+
+		await provisionContainer({ db, docker, dataDir }, project, 'container-sync-co');
+
+		expect(execs.some((e) => e.Cmd?.[2]?.startsWith('chown'))).toBe(false);
+	});
+
 	it('broadcasts row_change on provisioning error', async () => {
 		// Reset status
 		await db.query(

--- a/packages/server/test/container-user.test.ts
+++ b/packages/server/test/container-user.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+	chownToRunUser,
+	clearContainerRunUserCache,
+	resolveContainerRunUser,
+} from '../src/services/container-user';
+import type { DockerClient } from '../src/services/docker';
+
+interface ExecRec {
+	Cmd: string[];
+	User?: string;
+}
+
+/**
+ * A docker mock that answers `id` probes from a small fake passwd and records every
+ * exec. `users` maps username → {uid,gid}; a probe for an absent user exits 1.
+ * `defaultUser` is what a bare `id -u` (no username) resolves to.
+ */
+function fakeDocker(opts: {
+	users?: Record<string, { uid: number; gid: number }>;
+	defaultUser?: string;
+	throwOnExec?: boolean;
+}) {
+	const users = opts.users ?? { node: { uid: 1000, gid: 1000 }, root: { uid: 0, gid: 0 } };
+	const defaultUser = opts.defaultUser ?? 'root';
+	const calls: ExecRec[] = [];
+	const byId = new Map<string, ExecRec>();
+	let seq = 0;
+
+	const resolveProbe = (script: string): { code: number; out: string } => {
+		// `id -u <name> && …` (named probe) or `id -u && …` (default-user probe).
+		const m = script.match(/^id -u (\S+) &&/);
+		const name = m ? m[1] : defaultUser;
+		const u = users[name];
+		if (!u) return { code: 1, out: `id: '${name}': no such user\n` };
+		return { code: 0, out: `${u.uid}\n${u.gid}\n${name}\n` };
+	};
+
+	const docker = {
+		execCreate: async (_id: string, config: ExecRec) => {
+			if (opts.throwOnExec) throw new Error('docker unreachable');
+			const execId = `exec-${seq++}`;
+			calls.push(config);
+			byId.set(execId, config);
+			return execId;
+		},
+		execStart: async (execId: string) => {
+			const rec = byId.get(execId);
+			const script = rec?.Cmd?.[2] ?? '';
+			if (script.startsWith('id -u')) return { stdout: resolveProbe(script).out, stderr: '' };
+			return { stdout: '', stderr: '' };
+		},
+		execInspect: async (execId: string) => {
+			const rec = byId.get(execId);
+			const script = rec?.Cmd?.[2] ?? '';
+			const code = script.startsWith('id -u') ? resolveProbe(script).code : 0;
+			return { ExitCode: code, Running: false, Pid: 0 };
+		},
+	} as unknown as DockerClient;
+
+	return { docker, calls };
+}
+
+describe('resolveContainerRunUser', () => {
+	afterEach(() => clearContainerRunUserCache());
+
+	it('detects the `node` user on the stock image', async () => {
+		const { docker } = fakeDocker({});
+		const runUser = await resolveContainerRunUser(docker, 'c-node');
+		expect(runUser).toEqual({ name: 'node', uid: 1000, gid: 1000 });
+	});
+
+	it('detects a non-1000 node uid (does not assume 1000)', async () => {
+		const { docker } = fakeDocker({ users: { node: { uid: 2002, gid: 2002 } } });
+		const runUser = await resolveContainerRunUser(docker, 'c-node-2002');
+		expect(runUser).toEqual({ name: 'node', uid: 2002, gid: 2002 });
+	});
+
+	it('falls back to the container default user when there is no `node` user', async () => {
+		// Custom image: no node user, default user is root.
+		const { docker } = fakeDocker({ users: { root: { uid: 0, gid: 0 } }, defaultUser: 'root' });
+		const runUser = await resolveContainerRunUser(docker, 'c-custom');
+		expect(runUser).toEqual({ name: 'root', uid: 0, gid: 0 });
+	});
+
+	it('falls back to a non-root default user (custom image with its own user)', async () => {
+		const { docker } = fakeDocker({
+			users: { appuser: { uid: 1500, gid: 1500 } },
+			defaultUser: 'appuser',
+		});
+		const runUser = await resolveContainerRunUser(docker, 'c-appuser');
+		expect(runUser).toEqual({ name: 'appuser', uid: 1500, gid: 1500 });
+	});
+
+	it('defaults to root (never throws) when docker exec fails', async () => {
+		const { docker } = fakeDocker({ throwOnExec: true });
+		const runUser = await resolveContainerRunUser(docker, 'c-broken');
+		expect(runUser).toEqual({ name: 'root', uid: 0, gid: 0 });
+	});
+
+	it('caches the result and re-detects after clearContainerRunUserCache', async () => {
+		const { docker, calls } = fakeDocker({});
+		await resolveContainerRunUser(docker, 'c-cache');
+		const probesAfterFirst = calls.length;
+		await resolveContainerRunUser(docker, 'c-cache');
+		expect(calls.length).toBe(probesAfterFirst); // cached — no new exec
+
+		clearContainerRunUserCache('c-cache');
+		await resolveContainerRunUser(docker, 'c-cache');
+		expect(calls.length).toBeGreaterThan(probesAfterFirst); // re-detected
+	});
+});
+
+describe('chownToRunUser', () => {
+	it('chowns the given container paths to the run-user, in-container as root', async () => {
+		const { docker, calls } = fakeDocker({});
+		await chownToRunUser(
+			docker,
+			'cid',
+			{ name: 'node', uid: 1000, gid: 1000 },
+			['/workspace/.hezo/subscription/run-1'],
+			{ recursive: true },
+		);
+		const chown = calls.find((c) => c.Cmd?.[2]?.startsWith('chown'));
+		expect(chown).toBeDefined();
+		expect(chown?.User).toBe('root');
+		expect(chown?.Cmd[2]).toContain('-R');
+		expect(chown?.Cmd[2]).toContain("'node':'node'");
+		expect(chown?.Cmd[2]).toContain("'/workspace/.hezo/subscription/run-1'");
+	});
+
+	it('issues a non-recursive chown without -R', async () => {
+		const { docker, calls } = fakeDocker({});
+		await chownToRunUser(docker, 'cid', { name: 'node', uid: 1000, gid: 1000 }, ['/workspace']);
+		const chown = calls.find((c) => c.Cmd?.[2]?.startsWith('chown'));
+		expect(chown?.Cmd[2]).not.toContain('-R');
+		expect(chown?.Cmd[2]).toContain("'/workspace'");
+	});
+
+	it('is a no-op when the run-user is root', async () => {
+		const { docker, calls } = fakeDocker({});
+		await chownToRunUser(docker, 'cid', { name: 'root', uid: 0, gid: 0 }, ['/workspace']);
+		expect(calls.filter((c) => c.Cmd?.[2]?.startsWith('chown'))).toHaveLength(0);
+	});
+
+	it('never throws when the chown exec fails', async () => {
+		const { docker } = fakeDocker({ throwOnExec: true });
+		await expect(
+			chownToRunUser(docker, 'cid', { name: 'node', uid: 1000, gid: 1000 }, ['/workspace']),
+		).resolves.toBeUndefined();
+	});
+});

--- a/packages/server/test/git-executor.test.ts
+++ b/packages/server/test/git-executor.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import type { ContainerRunUser } from '../src/services/container-user';
 import { ContainerGitExecutor } from '../src/services/git-executor';
 import {
 	BRIDGE_RUNNER_BINARY,
@@ -6,6 +7,8 @@ import {
 	buildBridgeRunnerArgv,
 } from '../src/services/ssh-agent';
 import { createStubDocker } from './helpers/app';
+
+const runUser: ContainerRunUser = { name: 'node', uid: 1000, gid: 1000 };
 
 const bridge: BridgeRunnerArgs = {
 	socketPath: '/run/hezo/test.sock',
@@ -39,9 +42,12 @@ function recordingDocker(opts: { exitCode?: number; throwOnStart?: boolean } = {
 }
 
 describe('ContainerGitExecutor', () => {
-	it('runs a plain git command in the container as the node user', async () => {
+	it('runs a plain git command in the container as the run-user', async () => {
 		const { docker, calls } = recordingDocker();
-		const exec = new ContainerGitExecutor(docker, 'cid', { baseEnv: ['GIT_CONFIG_COUNT=0'] });
+		const exec = new ContainerGitExecutor(docker, 'cid', {
+			baseEnv: ['GIT_CONFIG_COUNT=0'],
+			runUser,
+		});
 
 		const res = await exec.exec(['status', '--porcelain'], { cwd: '/worktrees/T-1/repo' });
 
@@ -52,9 +58,21 @@ describe('ContainerGitExecutor', () => {
 		expect(calls[0].User).toBe('node');
 	});
 
+	it('runs as the detected run-user, not a hardcoded node (custom image)', async () => {
+		const { docker, calls } = recordingDocker();
+		const exec = new ContainerGitExecutor(docker, 'cid', {
+			baseEnv: [],
+			runUser: { name: 'appuser', uid: 1001, gid: 1001 },
+		});
+
+		await exec.exec(['status'], { cwd: '/w' });
+
+		expect(calls[0].User).toBe('appuser');
+	});
+
 	it('wraps SSH-transport ops with the bridge runner', async () => {
 		const { docker, calls } = recordingDocker();
-		const exec = new ContainerGitExecutor(docker, 'cid', { baseEnv: [], bridge });
+		const exec = new ContainerGitExecutor(docker, 'cid', { baseEnv: [], bridge, runUser });
 
 		await exec.exec(['fetch', '--all', '--prune'], { cwd: '/workspace/repo', needsSsh: true });
 
@@ -70,7 +88,7 @@ describe('ContainerGitExecutor', () => {
 
 	it('does not wrap when needsSsh but no bridge is available', async () => {
 		const { docker, calls } = recordingDocker();
-		const exec = new ContainerGitExecutor(docker, 'cid', { baseEnv: [], bridge: null });
+		const exec = new ContainerGitExecutor(docker, 'cid', { baseEnv: [], bridge: null, runUser });
 
 		await exec.exec(['fetch'], { cwd: '/workspace/repo', needsSsh: true });
 
@@ -85,6 +103,7 @@ describe('ContainerGitExecutor', () => {
 				'SSH_AUTH_SOCK=/run/hezo/run.sock',
 				'HEZO_PROMPT_FILE=/tmp/prompt.txt',
 			],
+			runUser,
 		});
 
 		await exec.exec(['status'], { cwd: '/w' });
@@ -94,9 +113,9 @@ describe('ContainerGitExecutor', () => {
 		expect(calls[0].Env?.some((e) => e.startsWith('HEZO_PROMPT_FILE='))).toBe(false);
 	});
 
-	it('forPrep threads extraEnv (git identity) alongside the prep defaults', async () => {
+	it('forPrep threads the run-user + extraEnv (git identity) alongside the prep defaults', async () => {
 		const { docker, calls } = recordingDocker();
-		const exec = ContainerGitExecutor.forPrep(docker, 'cid', bridge, [
+		const exec = ContainerGitExecutor.forPrep(docker, 'cid', bridge, runUser, [
 			'GIT_CONFIG_COUNT=2',
 			'GIT_CONFIG_KEY_0=user.name',
 			'GIT_CONFIG_VALUE_0=octocat',
@@ -106,6 +125,7 @@ describe('ContainerGitExecutor', () => {
 		// inherits the executor's baseEnv: prep defaults + the git identity.
 		await exec.exec(['merge', '--no-edit', 'origin/main'], { cwd: '/worktrees/T-1/repo' });
 
+		expect(calls[0].User).toBe('node');
 		expect(calls[0].Env).toContain('GIT_TERMINAL_PROMPT=0');
 		expect(calls[0].Env).toContain(`SSH_AUTH_SOCK=${bridge.socketPath}`);
 		expect(calls[0].Env).toContain('GIT_CONFIG_COUNT=2');
@@ -115,7 +135,7 @@ describe('ContainerGitExecutor', () => {
 
 	it('surfaces a non-zero exit code from execInspect', async () => {
 		const { docker } = recordingDocker({ exitCode: 128 });
-		const exec = new ContainerGitExecutor(docker, 'cid', { baseEnv: [] });
+		const exec = new ContainerGitExecutor(docker, 'cid', { baseEnv: [], runUser });
 
 		const res = await exec.exec(['rev-parse', '--git-dir'], { cwd: '/w' });
 
@@ -124,7 +144,7 @@ describe('ContainerGitExecutor', () => {
 
 	it('returns exitCode 1 instead of throwing when docker fails', async () => {
 		const { docker } = recordingDocker({ throwOnStart: true });
-		const exec = new ContainerGitExecutor(docker, 'cid', { baseEnv: [] });
+		const exec = new ContainerGitExecutor(docker, 'cid', { baseEnv: [], runUser });
 
 		const res = await exec.exec(['status'], { cwd: '/w' });
 

--- a/packages/server/test/helpers/run-user-docker.ts
+++ b/packages/server/test/helpers/run-user-docker.ts
@@ -1,0 +1,55 @@
+import type { DockerClient } from '../../src/services/docker';
+
+/** The run-user the stub answers `id -u node …` with (matches the stock agent-base). */
+export const STUB_RUN_USER = { name: 'node', uid: 1000, gid: 1000 };
+
+type ExecCreateConfig = Parameters<DockerClient['execCreate']>[1];
+type ExecStartOpts = Parameters<DockerClient['execStart']>[1];
+
+function classify(cmd?: string[]): 'probe' | 'chown' | null {
+	if (!cmd || cmd[0] !== 'sh' || cmd[1] !== '-c') return null;
+	const s = cmd[2] ?? '';
+	if (s.startsWith('id -u')) return 'probe';
+	if (s.startsWith('chown ')) return 'chown';
+	return null;
+}
+
+/**
+ * Wrap a mock {@link DockerClient} so the container run-user probe (`id -u node …`)
+ * and the ownership chowns Hezo issues are answered transparently — yielding a
+ * `node` run-user and a clean exit — and are NEVER forwarded to the wrapped
+ * client's exec handlers. Lets run-user detection work in unit tests (which fake
+ * Docker) without polluting tests that record or inspect the agent's own exec.
+ * Pass a custom `user` to simulate a different / no-node image.
+ */
+export function withRunUserStub(
+	docker: DockerClient,
+	user: { name: string; uid: number; gid: number } = STUB_RUN_USER,
+): DockerClient {
+	const infra = new Map<string, 'probe' | 'chown'>();
+	let seq = 0;
+	return {
+		...docker,
+		execCreate: async (containerId: string, config: ExecCreateConfig) => {
+			const kind = classify(config?.Cmd);
+			if (kind) {
+				const id = `__runuser-${kind}-${seq++}`;
+				infra.set(id, kind);
+				return id;
+			}
+			return docker.execCreate(containerId, config);
+		},
+		execStart: async (execId: string, opts: ExecStartOpts) => {
+			const kind = infra.get(execId);
+			if (kind === 'probe') {
+				return { stdout: `${user.uid}\n${user.gid}\n${user.name}\n`, stderr: '' };
+			}
+			if (kind === 'chown') return { stdout: '', stderr: '' };
+			return docker.execStart(execId, opts);
+		},
+		execInspect: async (execId: string) => {
+			if (infra.has(execId)) return { ExitCode: 0, Running: false, Pid: 0 };
+			return docker.execInspect(execId);
+		},
+	} as DockerClient;
+}

--- a/packages/server/test/ssh-agent-host.test.ts
+++ b/packages/server/test/ssh-agent-host.test.ts
@@ -85,11 +85,12 @@ afterAll(async () => {
 describe('withProvisionBridge', () => {
 	it('allocates a bridge advertising the team key, then releases on exit', async () => {
 		let port = 0;
-		await withProvisionBridge(server, teamId, dataDir, async ({ bridge }) => {
+		await withProvisionBridge(server, teamId, dataDir, 'node', async ({ bridge }) => {
 			port = bridge.hostPort;
 			expect(bridge.tokenHex).toMatch(/^[0-9a-f]{32}$/);
 			expect(bridge.hostPort).toBeGreaterThan(0);
 			expect(bridge.socketPath.startsWith('/run/hezo/')).toBe(true);
+			expect(bridge.socketUser).toBe('node');
 			expect(bridge.hostName).toBe('host.docker.internal');
 
 			const reply = await tcpRequestIdentities(bridge.hostPort, bridge.tokenHex);
@@ -105,7 +106,7 @@ describe('withProvisionBridge', () => {
 	it('releases the bridge even if fn throws', async () => {
 		let port = 0;
 		await expect(
-			withProvisionBridge(server, teamId, dataDir, async ({ bridge }) => {
+			withProvisionBridge(server, teamId, dataDir, 'node', async ({ bridge }) => {
 				port = bridge.hostPort;
 				throw new Error('boom');
 			}),


### PR DESCRIPTION
## Problem

A production (native-Linux) CEO run failed with:

```
$ claude --settings /workspace/.hezo/subscription/claude-code-deepseek/<runId>/settings.json
Error processing settings: EACCES: permission denied, open '.../settings.json'
```

**Root cause.** The agent base image (`node:24-slim`) sets no `USER`, so each project container runs as **root**; Hezo deprivileges the agent CLI and every git op to a non-root `node` user (purely for file-ownership hygiene — `node` has passwordless sudo, so it isn't a security boundary). The server runs as **root** in production and writes the per-run config dir + subscription credentials at `0o600`/`0o700` and creates the `/workspace`, `/worktrees`, `/workspace/.previews` dirs root-owned — so the deprivileged execs can neither **read** the config (the reported `EACCES`) nor **write** the workspace (a latent failure that surfaces once a project has repos: in-container `git clone` / `git worktree add` run as `node`). macOS Docker Desktop masks all of this via bind-mount uid-remapping, so it only breaks on a real Linux host.

This was found via a codebase-wide audit of the whole class (host-root writes a path a `--user node` exec must touch).

## Fix

Detect the run-user and give it ownership of the bind-mounted paths, **inside the container as root** (needs no host privilege):

- **`resolveContainerRunUser`** (`services/container-user.ts`) — detect the run-user instead of assuming `node`: prefer a `node` user, fall back to the container's default user (root for a custom `docker_base_image` without `node`). Cached per container; used for every `--user` exec and the socat socket owner.
- **`chownToRunUser`** — give the run-user ownership of the per-run config dir, `/workspace`, `/worktrees`, `/workspace/.previews`, and `/run/hezo` via an in-container `chown` run as root. Works identically on a root server, a non-root `User=hezo` server, and macOS; a no-op when the run-user is root.
- Per-run config **intermediate dirs are now `0o711`** (traversable) so the run-user can reach its chowned leaf; secret files stay `0o600` (chowned, never world-readable — matching how the egress CA cert is already handled).
- **De-hardcodes** the six `User:'node'` / `socketUser:'node'` sites across the run, provision, repo-link, and CEO-chat paths, so custom base images without a `node` user run (as root) instead of failing.

## Tests

- New `container-user.test.ts` — resolution, non-1000 uid, no-node/custom-user fallback, never-throws, caching; chown command shape + root no-op + best-effort.
- `container-sync.test.ts` — provision chowns the bind-mount dirs + `/run/hezo` to the run-user; a no-node image runs as root with no chown.
- `git-executor.test.ts` — the exec user comes from the detected run-user (incl. a non-node image).
- `agent-runner.test.ts` — wired a transparent run-user stub so the run path resolves `node` without polluting recorded execs.
- Full server vitest suite green.

## Docs

- `.dev/architecture.md` §§ Containers & worktrees and Credentials/egress.
- `docs/deployment/self-hosting.md` — non-root server + custom-image run-user notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FT4bd46dFPgawHuHXAv1Ka

---
_Generated by [Claude Code](https://claude.ai/code/session_01FT4bd46dFPgawHuHXAv1Ka)_