### PR TITLE
docs: note local models via OpenCode are on the roadmap

### DIFF
--- a/docs/ai-models.md
+++ b/docs/ai-models.md
@@ -26,6 +26,14 @@ Each provider is driven through its **native command-line runtime** inside the a
 container — so you get each model's first-party agentic tooling, not a lowest-common-
 denominator wrapper.
 
+## Local models (on the roadmap)
+
+The **OpenCode** runtime that powers OpenRouter can also drive **local, self-hosted
+models** (for example via Ollama or any OpenAI-compatible endpoint), so you could run
+agents entirely on your own hardware with no per-token cost. **This isn't available in
+Hezo yet** — today OpenCode is wired to OpenRouter only. First-class local-model support
+is planned; this page will be updated when it ships.
+
 ## API key or subscription
 
 Most providers accept either a plain **API key** or, where supported, a **subscription


### PR DESCRIPTION
## What

Adds a short **"Local models (on the roadmap)"** section to `docs/ai-models.md` noting that the OpenCode runtime (which powers OpenRouter) can also drive local, self-hosted models (Ollama / any OpenAI-compatible endpoint).

## Why

`opencode` supports local models, and we want users to know that's where we're headed.

## Accuracy note

Today Hezo wires OpenCode to **OpenRouter only** — there's no first-class local-model provider, no custom-endpoint field, and per-project containers route egress through the proxy, so a host-local model isn't reachable out of the box. Rather than overclaim a shipping feature, this is framed explicitly as **planned / coming-soon**. (Per maintainer direction.)

Content-only edit — no new page or frontmatter change, so the docs bundle (a build artifact) and `docs-bundle.test.ts` are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P9KQSa5AckZzXPsSe6A2Ek

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9KQSa5AckZzXPsSe6A2Ek)_