### PR TITLE
docs: add "Meta-harness" Overview page; frame coding harnesses as general-purpose

### DIFF
--- a/docs/ai-models.md
+++ b/docs/ai-models.md
@@ -1,6 +1,6 @@
 ---
 title: AI model support
-order: 22
+order: 23
 section: AI models & MCP
 ---
 

--- a/docs/concepts/assets.md
+++ b/docs/concepts/assets.md
@@ -1,6 +1,6 @@
 ---
 title: Assets & previews
-order: 13
+order: 14
 section: Concepts
 ---
 

--- a/docs/concepts/budgets-and-costs.md
+++ b/docs/concepts/budgets-and-costs.md
@@ -1,6 +1,6 @@
 ---
 title: Budgets & cost control
-order: 14
+order: 15
 section: Concepts
 ---
 

--- a/docs/concepts/coach-and-self-improving-teams.md
+++ b/docs/concepts/coach-and-self-improving-teams.md
@@ -1,6 +1,6 @@
 ---
 title: The Coach & self-improving teams
-order: 10
+order: 11
 section: Concepts
 ---
 

--- a/docs/concepts/documents-and-memory.md
+++ b/docs/concepts/documents-and-memory.md
@@ -1,6 +1,6 @@
 ---
 title: Documents & long-term memory
-order: 11
+order: 12
 section: Concepts
 ---
 

--- a/docs/concepts/hiring-and-agents.md
+++ b/docs/concepts/hiring-and-agents.md
@@ -1,6 +1,6 @@
 ---
 title: Hiring & customizing agents
-order: 8
+order: 9
 section: Concepts
 ---
 

--- a/docs/concepts/how-hezo-works.md
+++ b/docs/concepts/how-hezo-works.md
@@ -1,6 +1,6 @@
 ---
 title: How Hezo works
-order: 5
+order: 6
 section: Concepts
 ---
 

--- a/docs/concepts/projects-and-teams.md
+++ b/docs/concepts/projects-and-teams.md
@@ -1,6 +1,6 @@
 ---
 title: Projects & teams
-order: 6
+order: 7
 section: Concepts
 ---
 

--- a/docs/concepts/roles-and-coordination.md
+++ b/docs/concepts/roles-and-coordination.md
@@ -1,6 +1,6 @@
 ---
 title: Roles & the CEO
-order: 7
+order: 8
 section: Concepts
 ---
 

--- a/docs/concepts/search.md
+++ b/docs/concepts/search.md
@@ -1,6 +1,6 @@
 ---
 title: Search
-order: 15
+order: 16
 section: Concepts
 ---
 

--- a/docs/concepts/skills.md
+++ b/docs/concepts/skills.md
@@ -1,6 +1,6 @@
 ---
 title: Skills
-order: 12
+order: 13
 section: Concepts
 ---
 

--- a/docs/concepts/tasks.md
+++ b/docs/concepts/tasks.md
@@ -1,6 +1,6 @@
 ---
 title: Tasks, rules & summaries
-order: 9
+order: 10
 section: Concepts
 ---
 

--- a/docs/concepts/your-data.md
+++ b/docs/concepts/your-data.md
@@ -1,6 +1,6 @@
 ---
 title: Your data & the database
-order: 16
+order: 17
 section: Concepts
 ---
 

--- a/docs/deployment/backup-and-recovery.md
+++ b/docs/deployment/backup-and-recovery.md
@@ -1,6 +1,6 @@
 ---
 title: Backup & recovery
-order: 29
+order: 30
 section: Deployment
 ---
 

--- a/docs/deployment/cloud.md
+++ b/docs/deployment/cloud.md
@@ -1,6 +1,6 @@
 ---
 title: Deploying to the cloud
-order: 26
+order: 27
 section: Deployment
 ---
 

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration reference
-order: 28
+order: 29
 section: Deployment
 ---
 

--- a/docs/deployment/secure-remote-access.md
+++ b/docs/deployment/secure-remote-access.md
@@ -1,6 +1,6 @@
 ---
 title: Secure remote access
-order: 27
+order: 28
 section: Deployment
 ---
 

--- a/docs/deployment/self-hosting.md
+++ b/docs/deployment/self-hosting.md
@@ -1,6 +1,6 @@
 ---
 title: Self-hosting
-order: 25
+order: 26
 section: Deployment
 ---
 

--- a/docs/getting-started/first-project.md
+++ b/docs/getting-started/first-project.md
@@ -1,6 +1,6 @@
 ---
 title: Your first project
-order: 4
+order: 5
 section: Getting started
 ---
 

--- a/docs/getting-started/first-run.md
+++ b/docs/getting-started/first-run.md
@@ -1,6 +1,6 @@
 ---
 title: First-run setup
-order: 3
+order: 4
 section: Getting started
 ---
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,6 +1,6 @@
 ---
 title: Installation
-order: 2
+order: 3
 section: Getting started
 ---
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -74,6 +74,8 @@ agent can't hurt you. A few guarantees sit underneath everything:
 
 ## Where to next
 
+- [Why Hezo](/docs/why-hezo) — the meta-harness approach and how it gets quality results
+  from any model.
 - [Installation](/docs/getting-started/installation) — get Hezo running.
 - [First-run setup](/docs/getting-started/first-run) — your master key and first model.
 - [Your first project](/docs/getting-started/first-project) — from idea to a working team.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -74,8 +74,8 @@ agent can't hurt you. A few guarantees sit underneath everything:
 
 ## Where to next
 
-- [Why Hezo](/docs/why-hezo) — the meta-harness approach and how it gets quality results
-  from any model.
+- [Meta-harness](/docs/meta-harness) — the meta-harness approach and how it gets quality
+  results from any model.
 - [Installation](/docs/getting-started/installation) — get Hezo running.
 - [First-run setup](/docs/getting-started/first-run) — your master key and first model.
 - [Your first project](/docs/getting-started/first-project) — from idea to a working team.

--- a/docs/mcp/connecting-mcp-servers.md
+++ b/docs/mcp/connecting-mcp-servers.md
@@ -1,6 +1,6 @@
 ---
 title: Connecting MCP servers
-order: 24
+order: 25
 section: AI models & MCP
 ---
 

--- a/docs/mcp/hezo-mcp-server.md
+++ b/docs/mcp/hezo-mcp-server.md
@@ -1,6 +1,6 @@
 ---
 title: Hezo's MCP server
-order: 23
+order: 24
 section: AI models & MCP
 ---
 

--- a/docs/meta-harness.md
+++ b/docs/meta-harness.md
@@ -1,18 +1,27 @@
 ---
-title: Why Hezo
+title: Meta-harness
 order: 2
 section: Overview
 ---
 
-# Why Hezo
+# Meta-harness
 
-Every serious coding model now ships its own agentic command-line tool — Anthropic has
+Every serious model now ships its own agentic command-line tool — Anthropic has
 Claude Code, OpenAI has Codex, Google has the Gemini CLI, and there are more. Each of
 these *harnesses* wraps a model in a loop that can read and write files, run commands,
 and use tools. They are genuinely good, and they are genuinely different: each has its
 own strengths, its own guardrails, and its own rough edges. Picking one means inheriting
 all of its tradeoffs; juggling several by hand means re-learning each tool and getting
 inconsistent results depending on which one you happened to use.
+
+> [!NOTE]
+> These tools are usually called *coding* harnesses because they grew up around
+> software, but the loop they provide — read, write, run a command, use a tool, repeat —
+> is general-purpose. Being able to run code turns out to be useful far beyond
+> programming, so a coding harness is really a general-purpose agent. **Hezo aims to be
+> for any task, not just code** — software, research, marketing, operations, whatever the
+> work is — and it runs each agent on one of these harnesses precisely because they are
+> the most capable general-purpose agents available.
 
 Hezo's answer is to sit one level up.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,6 +1,6 @@
 ---
 title: CLI reference
-order: 30
+order: 31
 section: Reference
 ---
 

--- a/docs/reference/mcp-api.md
+++ b/docs/reference/mcp-api.md
@@ -1,6 +1,6 @@
 ---
 title: MCP API reference
-order: 31
+order: 32
 section: Reference
 ---
 

--- a/docs/security/activity-log.md
+++ b/docs/security/activity-log.md
@@ -1,6 +1,6 @@
 ---
 title: Activity log & audit trail
-order: 21
+order: 22
 section: Security
 ---
 

--- a/docs/security/container-isolation.md
+++ b/docs/security/container-isolation.md
@@ -1,6 +1,6 @@
 ---
 title: Container isolation
-order: 19
+order: 20
 section: Security
 ---
 

--- a/docs/security/git-and-verified-commits.md
+++ b/docs/security/git-and-verified-commits.md
@@ -1,6 +1,6 @@
 ---
 title: Git & verified commits
-order: 20
+order: 21
 section: Security
 ---
 

--- a/docs/security/master-key.md
+++ b/docs/security/master-key.md
@@ -1,6 +1,6 @@
 ---
 title: Master key & encryption
-order: 18
+order: 19
 section: Security
 ---
 

--- a/docs/security/secret-protection.md
+++ b/docs/security/secret-protection.md
@@ -1,6 +1,6 @@
 ---
 title: Secret protection & egress
-order: 17
+order: 18
 section: Security
 ---
 

--- a/docs/why-hezo.md
+++ b/docs/why-hezo.md
@@ -1,0 +1,79 @@
+---
+title: Why Hezo
+order: 2
+section: Overview
+---
+
+# Why Hezo
+
+Every serious coding model now ships its own agentic command-line tool — Anthropic has
+Claude Code, OpenAI has Codex, Google has the Gemini CLI, and there are more. Each of
+these *harnesses* wraps a model in a loop that can read and write files, run commands,
+and use tools. They are genuinely good, and they are genuinely different: each has its
+own strengths, its own guardrails, and its own rough edges. Picking one means inheriting
+all of its tradeoffs; juggling several by hand means re-learning each tool and getting
+inconsistent results depending on which one you happened to use.
+
+Hezo's answer is to sit one level up.
+
+## Hezo is a meta-harness
+
+Hezo runs each model inside its **own first-party harness** — Claude drives Claude Code,
+GPT drives Codex, Gemini drives the Gemini CLI, and so on (see
+[AI model support](/docs/ai-models) for the full list). You keep each model's native
+agentic tooling instead of settling for a lowest-common-denominator wrapper. Then Hezo
+wraps a **single, uniform platform layer** around all of them, so the harness an agent
+happens to run on becomes an implementation detail rather than something you manage.
+
+Working as a meta-harness around the individual coding harnesses is what lets Hezo
+**even out the tradeoffs between them** — so you can get quality results across very
+different models. Three things do the levelling:
+
+- **A uniform completeness check on every run.** When an agent decides it's finished,
+  Hezo independently judges whether the work is *actually* done before letting the run
+  end — it won't let an agent stop on failing tests, quietly declare a problem "out of
+  scope", or punt with "I'll leave that for later". This same discipline is applied on
+  top of every harness that supports it, which matters most for models or tools that
+  wouldn't hold that line on their own. (One harness, OpenCode, can't support this hook
+  yet, so runs there rely on the model alone.)
+- **The same capabilities and the same safety, whichever model you choose.** Every
+  agent — regardless of its harness — gets the same built-in tools, the same
+  [skills](/docs/concepts/skills), the same project memory and
+  [documents](/docs/concepts/documents-and-memory), the same task board, the same
+  [sandbox](/docs/security/container-isolation), and the same
+  [secret protection](/docs/security/secret-protection). Switching a model, or running
+  several at once, never changes what an agent can do or how safely it runs.
+- **Rough edges smoothed over.** The per-tool differences — how a prompt is delivered,
+  how a run is configured, how results come back — are normalised by Hezo, so behaviour
+  stays consistent no matter which harness backs a given agent.
+
+The practical payoff: you can put a cheaper model on routine work and a frontier model
+on the hard problems (you can even [give each agent its own model](/docs/ai-models)) and
+trust that the *floor* — the tooling, the guardrails, and the security — stays the same
+underneath all of them.
+
+## A modern agent platform, by design
+
+There's broad agreement now on the patterns that make agents actually work in practice.
+Hezo is built around them — and because it provides them at the platform layer, every
+agent gets them no matter which underlying model or harness it runs on:
+
+| Pattern | How Hezo provides it |
+|---|---|
+| **Planning & goals** | Work lives as [tasks](/docs/concepts/tasks) on a board, each with a description, optional rules, and a living progress summary; the Captain plans and breaks work down. |
+| **Sub-agents** | A whole [team of agents](/docs/concepts/roles-and-coordination) — a CEO, a Captain, and worker roles — delegates focused work to one another, and each native harness can also spin up its own child agents. |
+| **File-system access** | Every agent works inside its project's [container workspace](/docs/security/container-isolation), with durable [documents](/docs/concepts/documents-and-memory) and an [assets library](/docs/concepts/assets) alongside it. |
+| **Good prompts** | Each role carries a tuned system prompt, layered on top of the first-party agent prompt its harness already brings — so agents stay aligned to your intent. |
+| **Code interpreter / bash** | Each native CLI harness can run code and shell commands directly inside the sandbox. |
+| **Skills** | A shared [skills](/docs/concepts/skills) catalog gives agents reusable know-how they read on demand, instead of bloating every prompt. |
+| **Sandboxes, code execution & CLIs** | Each model runs through its own first-party CLI, and every one of them runs inside an isolated [Docker sandbox](/docs/security/container-isolation) with all outbound traffic forced through Hezo's egress proxy. |
+
+In other words, Hezo doesn't ask you to choose between a model's native agentic tooling
+and a consistent, safe, well-structured platform around it — you get both.
+
+## Where to next
+
+- [How Hezo works](/docs/concepts/how-hezo-works) — the architecture at a glance.
+- [AI model support](/docs/ai-models) — the providers, their runtimes, and per-agent models.
+- [Container isolation](/docs/security/container-isolation) — the per-project sandbox.
+- [Secret protection & egress](/docs/security/secret-protection) — how your keys stay yours.

--- a/packages/server/src/mcp/mcp-reference.ts
+++ b/packages/server/src/mcp/mcp-reference.ts
@@ -447,7 +447,7 @@ export function generateMcpReference(
 	const lines: string[] = [
 		'---',
 		'title: MCP API reference',
-		'order: 31',
+		'order: 32',
 		'section: Reference',
 		'---',
 		'',

--- a/packages/server/test/mcp-reference.test.ts
+++ b/packages/server/test/mcp-reference.test.ts
@@ -79,6 +79,6 @@ describe('MCP API reference (docs/reference/mcp-api.md)', () => {
 		const doc = parseDoc(readFileSync(REFERENCE_PATH, 'utf-8'));
 		expect(doc.title).toBe('MCP API reference');
 		expect(doc.section).toBe('Reference');
-		expect(doc.order).toBe(31);
+		expect(doc.order).toBe(32);
 	});
 });


### PR DESCRIPTION
## What & why

Adds a user-facing **"Meta-harness"** page to `docs/` (Overview section) that makes the
case for Hezo's approach, with a dedicated **technical section** on the meta-harness
idea: by working as a meta-harness *around* the individual coding harnesses (Claude
Code, Codex, Gemini CLI, Kimi Code, OpenCode), Hezo **evens out the tradeoffs between
them** so you get quality results across different AI models. It also shows how Hezo
**fulfils the modern-agent patterns** (planning & goals, sub-agents, file-system access,
good prompts, code/bash execution, skills, and sandboxes/code-execution/CLIs).

The page also frames these tools as **general-purpose**: they're called *coding*
harnesses because they grew up around software, but the read/write/run-a-command loop is
useful far beyond programming — so **Hezo aims to be for any task, not just code**
(software, research, marketing, operations, …), and runs each agent on one of these
harnesses precisely because they're the most capable general-purpose agents available.

Previously `docs/` had no "why Hezo" / value-proposition page — the harness story was
only lightly touched in `ai-models.md` and `concepts/how-hezo-works.md`, with no
explanation of *why* the per-harness approach matters or how Hezo normalizes across
harnesses.

## Page contents

- **Lead** — every serious model now ships its own agentic CLI, each with different
  strengths and rough edges; picking or juggling them by hand means inconsistent results.
  A note reframes them as general-purpose agents and states Hezo's any-task ambition.
- **"Hezo is a meta-harness"** — runs each model in its own first-party harness, then
  wraps a uniform platform layer around all of them. The three levellers that compensate
  for per-harness tradeoffs: a uniform completeness check on every run (with the honest
  OpenCode caveat), identical tools/skills/memory/sandbox/secret-protection per model,
  and normalized per-CLI quirks.
- **"A modern agent platform, by design"** — a mapping table tying each modern-agent
  pattern to the concrete Hezo mechanism that provides it.
- Cross-links to How Hezo works, AI model support, container isolation, and secret
  protection; discoverable via a new link in the Introduction's "Where to next".

## Mechanics

- Page is `docs/meta-harness.md` (title **Meta-harness**) in the **Overview** section
  right after Introduction (`order: 2`); the rest of the docs keep the gapless global
  `order` sequence (1–32).
- Docs-only change — no MCP tool/route/CLI surface changes. `docs-bundle.json` is a
  gitignored build artifact, regenerated by `build:docs`; the drift test
  `docs-bundle.test.ts` passes, and the full pre-commit build (typecheck + bundle) is
  green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KwXLkhbics3MGWxgpqo41X