### PR TITLE
fix(runtime): force per-run config dirs traversable past a strict umask (fixes CEO EACCES)

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -361,7 +361,13 @@ write — the per-run config dir, `/workspace`, `/worktrees`, `/workspace/.previ
 container needs no host privilege, so it works identically on a root server, a non-root
 `User=hezo` server, and macOS (where Docker Desktop's bind-mount uid-remapping otherwise hides
 the mismatch — the reason this class of bug only surfaced on a native-Linux production host). It
-is a no-op when the run-user is root.
+is a no-op when the run-user is root. The chown fixes *ownership* of the leaf, but the run-user
+must also *traverse* the shared intermediate dirs (`.hezo/subscription/<provider>/`) that the
+chown never touches. Those are created world-traversable (`0o711`) via `mkdirTraversable`
+(`services/runtime-home.ts`), which `chmod`s each component **after** `mkdir` rather than relying
+on `mkdirSync`'s `mode` — that mode is masked by the **process umask**, so a hardened host (umask
+`0o027`/`0o077` under systemd `UMask=`) would silently strip the other-execute bit and the agent
+CLI would die with `EACCES` opening its `settings.json` (again only on native-Linux production).
 
 Before building a worktree the runner fetches each clone, then **fast-forwards the clone's
 local default branch** (the "main codebase") to `origin/<default>` (resolved via `origin/HEAD`

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -69,6 +69,7 @@ import {
 	ensureRuntimeHomeDir,
 	getContainerSubscriptionRoot as getContainerSubscriptionRootImpl,
 	getHostSubscriptionRoot as getHostSubscriptionRootImpl,
+	mkdirTraversable,
 	type RuntimeHomeMount,
 	SUBSCRIPTION_LAYOUTS,
 	type SubscriptionMount as SubscriptionMountImpl,
@@ -390,7 +391,9 @@ export async function buildRuntimeInvocation(
 	validateInjection(adapter, mcpInjection);
 
 	for (const file of mcpInjection.files) {
-		mkdirSync(dirname(file.hostPath), { recursive: true, mode: 0o711 });
+		// mkdirTraversable (not a bare mkdir mode) so a strict process umask can't strip
+		// the other-execute bit the non-root run-user needs to traverse to this leaf.
+		mkdirTraversable(dirname(file.hostPath));
 		writeFileSync(file.hostPath, file.contents, { mode: file.mode });
 	}
 

--- a/packages/server/src/services/runtime-home.ts
+++ b/packages/server/src/services/runtime-home.ts
@@ -1,10 +1,50 @@
-import { mkdirSync, writeFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { chmodSync, mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join, sep } from 'node:path';
 import { AiAuthMethod, AiProvider } from '@hezo/shared';
 import type { AiProviderCredential } from './ai-provider-keys';
 import { getWorkspacePath } from './workspace';
 
 export const CONTAINER_SUBSCRIPTION_DIR = '/workspace/.hezo/subscription';
+
+/** Host-path segment marking the subscription root. Everything at or below
+ *  `.../.hezo/subscription` is Hezo-created and must stay traversable by the
+ *  non-root container run-user. */
+const SUBSCRIPTION_PATH_MARKER = `${sep}.hezo${sep}subscription`;
+
+/**
+ * Create `dir` (recursively) and force every Hezo-created component from the
+ * subscription root down to `dir` to mode 0o711 (rwx--x--x).
+ *
+ * Why this exists instead of `mkdirSync(dir, { mode: 0o711 })`: `mkdirSync`'s mode is
+ * masked by the **process umask**. On a hardened production host (umask 0o027/0o077 —
+ * common under systemd `UMask=`), the intended world-traversable 0o711 is silently
+ * stripped to 0o710/0o700, dropping the *other-execute* bit. The non-root container
+ * run-user (`node`) then can't **traverse** the intermediate `subscription/<provider>/`
+ * dirs to reach its per-run config leaf, so the agent CLI fails with `EACCES` opening
+ * `<leaf>/settings.json` — even though the leaf and its files were chowned to that user
+ * (see `chownToRunUser`). `chmodSync` is not subject to umask and needs only ownership
+ * (the server created these dirs), so it restores the traversal bit uniformly across
+ * root-prod, non-root-server, and macOS-dev. Best-effort per component: a host where we
+ * can't chmod a dir must not abort the run over a permission tweak.
+ */
+export function mkdirTraversable(dir: string): void {
+	mkdirSync(dir, { recursive: true });
+	const idx = dir.indexOf(SUBSCRIPTION_PATH_MARKER);
+	if (idx === -1) return;
+	const stopAt = dir.slice(0, idx + SUBSCRIPTION_PATH_MARKER.length);
+	let cur = dir;
+	for (;;) {
+		try {
+			chmodSync(cur, 0o711);
+		} catch {
+			// Best-effort — see doc comment.
+		}
+		if (cur === stopAt) break;
+		const parent = dirname(cur);
+		if (parent === cur) break;
+		cur = parent;
+	}
+}
 
 export interface SubscriptionLayout {
 	dirName: string;
@@ -147,9 +187,10 @@ export function buildSubscriptionMount(
 
 	// 0o711 (not 0o700) so the non-root container run-user can *traverse* these
 	// intermediate dirs to reach the per-run leaf — which the runner chowns to that
-	// user (see chownToRunUser). The credential file itself stays 0o600 (and is
-	// chowned to the run-user), never world-readable.
-	mkdirSync(dirname(hostAuthFile), { recursive: true, mode: 0o711 });
+	// user (see chownToRunUser). mkdirTraversable (not a bare mkdir mode) so a strict
+	// process umask can't strip the traversal bit. The credential file itself stays
+	// 0o600 (and is chowned to the run-user), never world-readable.
+	mkdirTraversable(dirname(hostAuthFile));
 	writeFileSync(hostAuthFile, credential.value, { mode: 0o600 });
 
 	return {
@@ -203,8 +244,9 @@ export function ensureRuntimeHomeDir(
 	const containerDir = getContainerSubscriptionRoot(provider, heartbeatRunId) as string;
 
 	// 0o711 so the non-root container run-user can traverse the intermediate dirs to
-	// its per-run config dir (which the runner then chowns to that user).
-	mkdirSync(hostDir, { recursive: true, mode: 0o711 });
+	// its per-run config dir (which the runner then chowns to that user). Via
+	// mkdirTraversable so a strict process umask can't strip the traversal bit.
+	mkdirTraversable(hostDir);
 
 	return {
 		hostDir,

--- a/packages/server/test/runtime-home.test.ts
+++ b/packages/server/test/runtime-home.test.ts
@@ -1,0 +1,128 @@
+import { mkdirSync, mkdtempSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { AiAuthMethod, AiProvider } from '@hezo/shared';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+	buildSubscriptionMount,
+	ensureRuntimeHomeDir,
+	getHostSubscriptionRoot,
+	mkdirTraversable,
+} from '../src/services/runtime-home';
+
+/**
+ * Regression coverage for the EACCES-on-settings.json bug: the per-run subscription /
+ * runtime-home dirs are created with an intended-world-traversable 0o711 mode, but
+ * `mkdirSync`'s `mode` is masked by the process umask. On a hardened host (umask
+ * 0o027/0o077) that silently strips the other-execute bit, so the non-root container
+ * run-user can't traverse `subscription/<provider>/` to its per-run leaf and the agent
+ * CLI dies with `EACCES` opening `<leaf>/settings.json`. These tests run the real dir
+ * builders under a strict umask and assert the traversal bit survives.
+ */
+
+const TEAM = 'team-1';
+const PROJECT = 'project-1';
+const RUN = 'run-abc';
+const mode = (p: string): number => statSync(p).mode & 0o777;
+
+/** Run `fn` with the process umask forced to `value`, restoring it afterwards. */
+function withUmask<T>(value: number, fn: () => T): T {
+	const prev = process.umask(value);
+	try {
+		return fn();
+	} finally {
+		process.umask(prev);
+	}
+}
+
+describe('mkdirTraversable', () => {
+	let base: string;
+	afterEach(() => {
+		if (base) rmSync(base, { recursive: true, force: true });
+	});
+
+	it('forces 0o711 on every component from the subscription root down, past a strict umask', () => {
+		base = mkdtempSync(join(tmpdir(), 'hezo-rt-'));
+		const sub = join(base, 'workspace', '.hezo', 'subscription');
+		const leaf = join(sub, 'codex', RUN);
+
+		withUmask(0o077, () => {
+			// A bare mkdir would lose the traversal bit under this umask — assert the
+			// premise so this test fails loudly if Node's masking behaviour ever changes.
+			const control = join(base, 'control');
+			mkdirSync(control, { recursive: true, mode: 0o711 });
+			expect(mode(control) & 0o001).toBe(0);
+
+			mkdirTraversable(leaf);
+		});
+
+		expect(mode(sub)).toBe(0o711);
+		expect(mode(join(sub, 'codex'))).toBe(0o711);
+		expect(mode(leaf)).toBe(0o711);
+	});
+
+	it('leaves components above the subscription root untouched', () => {
+		base = mkdtempSync(join(tmpdir(), 'hezo-rt-'));
+		const hezo = join(base, 'workspace', '.hezo');
+		const leaf = join(hezo, 'subscription', 'gemini', RUN);
+
+		withUmask(0o077, () => mkdirTraversable(leaf));
+
+		// `.hezo` is above the marker — the walk stops at `subscription`, so `.hezo`
+		// keeps the umask-derived mode (here 0o700) rather than being widened.
+		expect(mode(hezo) & 0o001).toBe(0);
+	});
+});
+
+describe('ensureRuntimeHomeDir under a strict umask', () => {
+	let base: string;
+	afterEach(() => {
+		if (base) rmSync(base, { recursive: true, force: true });
+	});
+
+	it('keeps the intermediate dirs traversable by the non-root run-user', () => {
+		base = mkdtempSync(join(tmpdir(), 'hezo-rt-'));
+		const mount = withUmask(0o077, () =>
+			ensureRuntimeHomeDir(AiProvider.DeepSeek, base, TEAM, PROJECT, RUN, null),
+		);
+		expect(mount).not.toBeNull();
+
+		const leaf = getHostSubscriptionRoot(AiProvider.DeepSeek, base, TEAM, PROJECT, RUN);
+		expect(leaf).not.toBeNull();
+		const providerDir = dirname(leaf as string); // .../subscription/claude-code-deepseek
+		const subscriptionDir = dirname(providerDir); // .../subscription
+
+		// Other-execute must be set on every dir the run-user has to walk through.
+		expect(mode(subscriptionDir) & 0o001).toBe(0o001);
+		expect(mode(providerDir) & 0o001).toBe(0o001);
+		expect(mode(leaf as string) & 0o001).toBe(0o001);
+	});
+});
+
+describe('buildSubscriptionMount under a strict umask', () => {
+	let base: string;
+	afterEach(() => {
+		if (base) rmSync(base, { recursive: true, force: true });
+	});
+
+	it('makes the auth-file dir traversable while keeping the credential file 0o600', () => {
+		base = mkdtempSync(join(tmpdir(), 'hezo-rt-'));
+		const mount = withUmask(0o077, () =>
+			buildSubscriptionMount(base, TEAM, PROJECT, RUN, AiProvider.OpenAI, {
+				value: JSON.stringify({ tokens: { refresh_token: 'rt' } }),
+				authMethod: AiAuthMethod.Subscription,
+			}),
+		);
+		expect(mount).not.toBeNull();
+		const { hostAuthFile } = mount as { hostAuthFile: string };
+
+		// The credential stays owner-only; only the *directories* are widened to o+x.
+		expect(mode(hostAuthFile)).toBe(0o600);
+		expect(mode(dirname(hostAuthFile)) & 0o001).toBe(0o001);
+
+		// .../subscription/codex/<run> → .../subscription is two levels up from the leaf.
+		const leaf = getHostSubscriptionRoot(AiProvider.OpenAI, base, TEAM, PROJECT, RUN);
+		const subscriptionDir = dirname(dirname(leaf as string));
+		expect(mode(subscriptionDir) & 0o001).toBe(0o001);
+	});
+});


### PR DESCRIPTION
## Symptom

On production, the CEO chat reply renders **empty**, and CEO **task runs fail** with:

```
$ claude --settings /workspace/.hezo/subscription/claude-code-deepseek/<run>/settings.json
Error processing settings: EACCES: permission denied, open '.../settings.json'
```

Both surfaces share `buildRuntimeInvocation`, so one root cause produces both. In the live chat, `runTurn` forwards only **stdout** to the parser — the failing run's EACCES goes to stderr, so the assistant message accumulates no text and the chatbox shows an empty reply.

## Root cause

The per-run subscription / runtime-home directories (`/workspace/.hezo/subscription/<provider>/<run>/`) are created with an **intended world-traversable `0o711`**, but `mkdirSync`'s `mode` is **masked by the process umask**. On a hardened host (umask `0o027`/`0o077`, common under systemd `UMask=`) that silently strips the **other-execute** bit, leaving `0o710`/`0o700`. The non-root container run-user (`node`, uid 1000) then can't **traverse** the shared intermediate `subscription/<provider>/` dirs to reach its per-run leaf, so the agent CLI dies with `EACCES` opening `settings.json`.

The in-container chown from #409 fixes **ownership** of the leaf dir + files, but it never touches those intermediate dirs, so the traversal failure persisted — hence "still getting" the error. It only reproduces on a **native-Linux production host**; Docker Desktop's bind-mount uid-remapping masks it on macOS dev.

Reproduced the masking directly:

```
umask=0022: subscription=711  <provider>=711   ← ok, node can traverse
umask=0027: subscription=710  <provider>=710   ← other-x stripped → EACCES
umask=0077: subscription=700  <provider>=700   ← other-x stripped → EACCES
```

## Fix

Add `mkdirTraversable` (`services/runtime-home.ts`): after `mkdir`, `chmod` each component from the subscription root down to the leaf to `0o711`. `chmodSync` is **not subject to umask** and needs only ownership (the server created the dirs), so it restores the traversal bit uniformly across root-prod, non-root-`User=hezo`, and macOS. Routed the three creation sites — `ensureRuntimeHomeDir`, `buildSubscriptionMount`, and the injector file-write loop in `agent-runner.ts` — through it. The walk stops at `.hezo/subscription`, so dirs above it (e.g. the Docker-created `.hezo` mount-point parent) are left untouched.

Credential / `settings.json` files stay `0o600` — only **directories** are widened to `o+x` (traversal, not read). This is exactly the original `0o711` intent, just made umask-proof; it composes with (does not replace) the #409 ownership chown.

## Tests

`packages/server/test/runtime-home.test.ts` drives the real builders (`mkdirTraversable`, `ensureRuntimeHomeDir`, `buildSubscriptionMount`) under a forced `0o077` umask and asserts the intermediate dirs keep their other-execute bit, with an inline **control** proving a bare `mkdirSync(mode:0o711)` loses it under the same umask. Credential file is asserted to remain `0o600`.

- `runtime-home.test.ts` (4) + `agent-runner` (68) + `container-user` (10) + `mcp-injectors` (37) + `subscription-auth` (24): **143 passed**
- typecheck + biome + full build: clean (pre-commit hook)

Updated `.dev/architecture.md` (run-user / host-file-ownership section) to document the traversal-mode hardening alongside the existing ownership chown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A1ouZjRpeTNyuuoHuQSW2v

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1ouZjRpeTNyuuoHuQSW2v)_