### PR TITLE
test: de-flake task-comment-attachments browser specs

### DIFF
--- a/test/browser/task-comment-attachments.spec.ts
+++ b/test/browser/task-comment-attachments.spec.ts
@@ -15,12 +15,15 @@ const PNG_BYTES = Uint8Array.from([
 ]);
 
 // Attachment chips/previews only render after the dropped file's upload
-// round-trips to the server (handleFiles → upload.mutateAsync). The e2e server
-// runs on a single-connection PGlite, so every query from all four parallel
-// workers serialises through it; under a burst the upload's handful of queries
-// can queue for many seconds behind other workers' requests. That is genuine
-// saturation latency, not a stuck render, so wait generously rather than letting
-// a transient spike fail the run.
+// round-trips to the server (handleFiles → upload.mutateAsync) and the composer
+// commits its local state. The historical first-attempt failures here were not
+// upload latency: they were the route's UUID→identifier canonicalization redirect
+// remounting CommentComposer mid-upload and wiping its pending-attachment state
+// (see openTaskDetail below), which no timeout could rescue. With canonical
+// navigation that race is gone; this generous budget is just headroom for genuine
+// PGlite saturation — the e2e server runs on a single-connection PGlite, so every
+// query from all four parallel workers serialises through it and a burst can queue
+// the upload's handful of queries behind other workers' requests.
 const UPLOAD_WAIT_MS = 30_000;
 
 test.describe('Task Comment Attachments', () => {
@@ -47,11 +50,34 @@ test.describe('Task Comment Attachments', () => {
 			headers,
 			data: { project_id: project.id, title: 'Attach me', assignee_id: assigneeId },
 		});
-		const task = ((await taskRes.json()) as { data: { id: string } }).data;
+		const task = ((await taskRes.json()) as { data: { id: string; identifier: string } }).data;
 
 		await waitForAgentIdle(page, project.team_slug, assigneeId, token);
 
 		return { token, task, project, headers };
+	}
+
+	// Open a task's detail page ready for composer interaction. Navigate by the
+	// canonical friendly identifier, NOT task.id (UUID): a UUID URL triggers the
+	// route's canonicalization redirect (routes/.../$taskId.tsx), which changes the
+	// useTask query key, drops the page to its `isLoading` branch, and remounts
+	// CommentComposer — wiping the composer-local pendingAttachmentIds/metaById. If
+	// that remount races an in-flight upload, the chip/thumb/preview never renders
+	// and no UPLOAD_WAIT_MS can save it. Friendly-id navigation is already canonical,
+	// so the redirect never fires and the composer stays mounted across the upload.
+	async function openTaskDetail(
+		page: import('@playwright/test').Page,
+		projectSlug: string,
+		task: { identifier: string },
+	) {
+		const friendlyId = task.identifier.toLowerCase();
+		await page.goto(`/projects/${projectSlug}/tasks/${friendlyId}`);
+		await waitForPageLoad(page);
+		// Cheap regression guard: passes instantly when already canonical; if anyone
+		// reverts to UUID navigation it forces the redirect to settle before we touch
+		// the composer (the agent-run-logs.spec.ts safety pattern).
+		await expect(page).toHaveURL(new RegExp(`/tasks/${friendlyId}$`));
+		await expect(page.getByPlaceholder('Add a comment...')).toBeVisible({ timeout: 20000 });
 	}
 
 	async function dropFile(
@@ -115,9 +141,7 @@ test.describe('Task Comment Attachments', () => {
 	}) => {
 		const { task, project } = await createTask(page, sharedWorkspace.token);
 
-		await page.goto(`/projects/${project.slug}/tasks/${task.id}`);
-		await waitForPageLoad(page);
-		await expect(page.getByPlaceholder('Add a comment...')).toBeVisible({ timeout: 20000 });
+		await openTaskDetail(page, project.slug, task);
 
 		await dropFileAndAwaitUpload(
 			page,
@@ -158,9 +182,7 @@ test.describe('Task Comment Attachments', () => {
 	}) => {
 		const { task, project } = await createTask(page, sharedWorkspace.token);
 
-		await page.goto(`/projects/${project.slug}/tasks/${task.id}`);
-		await waitForPageLoad(page);
-		await expect(page.getByPlaceholder('Add a comment...')).toBeVisible({ timeout: 20000 });
+		await openTaskDetail(page, project.slug, task);
 
 		const hint = page.locator('[data-testid="comment-attachment-hint"]');
 		await expect(hint).toBeVisible();
@@ -213,9 +235,7 @@ test.describe('Task Comment Attachments', () => {
 	}) => {
 		const { task, project } = await createTask(page, sharedWorkspace.token);
 
-		await page.goto(`/projects/${project.slug}/tasks/${task.id}`);
-		await waitForPageLoad(page);
-		await expect(page.getByPlaceholder('Add a comment...')).toBeVisible({ timeout: 20000 });
+		await openTaskDetail(page, project.slug, task);
 
 		await dropFileAndAwaitUpload(
 			page,
@@ -243,9 +263,7 @@ test.describe('Task Comment Attachments', () => {
 	}) => {
 		const { task, project } = await createTask(page, sharedWorkspace.token);
 
-		await page.goto(`/projects/${project.slug}/tasks/${task.id}`);
-		await waitForPageLoad(page);
-		await expect(page.getByPlaceholder('Add a comment...')).toBeVisible({ timeout: 20000 });
+		await openTaskDetail(page, project.slug, task);
 
 		await dropFile(
 			page,
@@ -267,9 +285,7 @@ test.describe('Task Comment Attachments', () => {
 		await page.setViewportSize({ width: 375, height: 812 });
 		const { task, project } = await createTask(page, sharedWorkspace.token);
 
-		await page.goto(`/projects/${project.slug}/tasks/${task.id}`);
-		await waitForPageLoad(page);
-		await expect(page.getByPlaceholder('Add a comment...')).toBeVisible({ timeout: 20000 });
+		await openTaskDetail(page, project.slug, task);
 
 		const hint = page.locator('[data-testid="comment-attachment-hint"]');
 		await expect(hint).toBeVisible();


### PR DESCRIPTION
## Problem

CI run [28178004906](https://github.com/hezo-ai/hezo/actions/runs/28178004906/job/83461004330)
reported **"Browser: passed"** even though three tests in
`test/browser/task-comment-attachments.spec.ts` failed on their first attempt
and only went green on retry:

- `drag-drop adds a chip, sends, renders an icon thumb, opens in new tab`
- `hint with tooltip shows when empty, hides once a chip appears, returns after removal`
- `pending chip exposes a preview link with the signed asset URL`

Playwright records a retried-then-passing test as **flaky** (not failed), so the
job stays green and masks the race. All three timed out with `element(s) not
found` after the 30s `UPLOAD_WAIT_MS`, even though the upload POST had already
fired.

## Root cause — lost component state, not upload latency

The tests navigated to the task page by **UUID**
(`page.goto(.../tasks/${task.id})`). The task-detail route canonicalizes a UUID
URL to the friendly identifier (`task-N`) via a `useEffect` redirect once the
task loads. That redirect changes the `useTask` query key → a key with no cached
data → the route's `if (isLoading || !task) return <Loading/>` branch → the whole
page, **including `CommentComposer`, unmounts and remounts**, resetting its
composer-local `pendingAttachmentIds` / `metaById`.

When the redirect raced an in-flight upload, the resolved upload wrote
`onChange`/`setMetaById` to the dead composer and the chip/thumb/preview never
rendered — so no `UPLOAD_WAIT_MS` could rescue it. The existing 30s timeout was
treating this as PGlite saturation latency, but the state was simply gone.

The tell: `agent-run-logs.spec.ts` navigates by UUID too but **explicitly waits
out the redirect** (`await expect(page).toHaveURL(/\/tasks\/<identifier>$/)`)
before interacting; the attachment tests never did. Tests that navigate by the
friendly identifier never hit this, and UUID-navigating tests that assert on
server-backed React-Query data don't flake because that data survives the
remount — only the attachment composer's purely-local state gets wiped.

## Fix (test-only, scoped to this one spec)

Navigate by the **canonical friendly identifier** so the URL is already canonical
and the redirect never fires — addressing the lost state at its source rather than
bumping a timeout.

- Type `createTask`'s returned task to expose `identifier` (the POST `/tasks`
  response already returns it).
- Factor the repeated navigate → load → composer-ready block into a local
  `openTaskDetail()` helper shared by all five tests, with a `toHaveURL`
  regression guard (the `agent-run-logs.spec.ts` safety pattern) so a future
  revert to UUID navigation can't silently reintroduce the race.
- Correct the `UPLOAD_WAIT_MS` comment to reflect the real cause; the 30s budget
  stays as headroom for genuine PGlite saturation.

No product code changed. The underlying behavior (a UUID deep-link briefly
unmounting the page during canonicalization) is noted as a possible follow-up but
is out of scope for de-flaking.

## Verification

- `bunx biome check` — clean; full pre-commit hook (biome + typecheck + build) green.
- Spec run: **5/5 passed, zero retries**.
- Stress: **25/25 passed** (5 tests × `--repeat-each=5`) under 4-worker
  parallelism, zero retries — including the three previously-flaky tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXLuDp6EksGuFudssVzES1

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXLuDp6EksGuFudssVzES1)_