### PR TITLE
fix: verify container liveness before agent exec; gate Retry on container health

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -322,9 +322,13 @@ Instance agents (CEO/Coach) select work across *all* teams here.
 
 **Run.** `agent-runner.ts` builds the run context (provider/runtime resolution, MCP
 descriptors, egress proxy, ssh-agent socket, container env), starts a `heartbeat_runs`
-row, and drives a streaming `docker exec` of the runtime CLI. It captures interleaved
-stdout/stderr into `log_text` (capped at 1 MB, `[stderr]`-prefixed) and broadcasts the
-same stream live over the `project-runs:<projectId>` WebSocket room.
+row, and drives a streaming `docker exec` of the runtime CLI. Before that exec it
+**live-verifies the container against Docker** (`syncContainerStatus`) instead of trusting
+the cached `container_status`: a container pruned externally or lost to a Docker restart is
+reconciled (status flipped, `container_id` nulled, project update broadcast) and the run
+fails fast with a clear message rather than tripping over a raw 404 mid-exec. It captures
+interleaved stdout/stderr into `log_text` (capped at 1 MB, `[stderr]`-prefixed) and
+broadcasts the same stream live over the `project-runs:<projectId>` WebSocket room.
 
 **Containers & worktrees.** One container per project; the project's
 `<dataDir>/teams/<slug>/projects/<slug>/workspace/` bind-mounts to `/workspace`, with one

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -29,7 +29,7 @@ import {
 } from '@hezo/shared';
 import type { MasterKeyManager } from '../crypto/master-key';
 import type { DomainEventBus } from '../events/bus';
-import { broadcastRowChange } from '../lib/broadcast';
+import { broadcastProjectUpdate, broadcastRowChange } from '../lib/broadcast';
 import { withTransaction } from '../lib/sql';
 import { logger } from '../logger';
 import { signAgentJwt } from '../middleware/auth';
@@ -42,6 +42,7 @@ import {
 } from './ai-provider-keys';
 import { checkOverBudget, recordRunCost } from './budget';
 import { type ContainerRunUser, chownToRunUser, resolveContainerRunUser } from './container-user';
+import { syncContainerStatus } from './containers';
 import type { DockerClient, ExecLogChunk } from './docker';
 import { getAgentSystemPrompt } from './documents';
 import { applyEffortToRuntime, type EffortRuntimeApplication, resolveEffort } from './effort';
@@ -790,6 +791,27 @@ export async function runAgent(
 	};
 
 	if (!project.container_id || project.container_status !== ContainerStatus.Running) {
+		return finalizeFailure(
+			'Project container is not running. Start the container from the Project page and retry.',
+		);
+	}
+
+	// The cached container_status can lag reality — Docker may have been restarted
+	// or the container pruned externally, leaving the row marked "running" while
+	// execCreate would 404 mid-run. Verify liveness against Docker and reconcile the
+	// DB (syncContainerStatus nulls the id + flips status on a 404 or exit) before we
+	// commit to the run, then broadcast so the banner / sidebar / Container page
+	// correct at once.
+	const liveStatus = await syncContainerStatus(
+		deps.db,
+		deps.docker,
+		project.id,
+		project.slug,
+		project.container_id,
+		project.container_status,
+	);
+	if (liveStatus !== ContainerStatus.Running) {
+		await broadcastProjectUpdate(deps.db, deps.wsManager, project.team_id, project.id);
 		return finalizeFailure(
 			'Project container is not running. Start the container from the Project page and retry.',
 		);

--- a/packages/server/test/agent-runner.test.ts
+++ b/packages/server/test/agent-runner.test.ts
@@ -6,6 +6,7 @@ import {
 	AiProvider,
 	ContainerStatus,
 	HeartbeatRunStatus,
+	WsMessageType,
 } from '@hezo/shared';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
@@ -264,6 +265,74 @@ describe('runAgent', () => {
 
 		const logBroadcasts = broadcasts.filter((b) => b.event.type === 'run_log');
 		expect(logBroadcasts.some((b) => b.event.text.includes('not running'))).toBe(true);
+	});
+
+	it('reconciles and fails the run when a cached-running container has vanished from Docker', async () => {
+		// The DB still says running, but Docker 404s on inspect — the exact stale
+		// state after an external `docker rm` or a Docker daemon restart. The runner
+		// must catch this before execCreate, flip the row to error, null the id, and
+		// broadcast so the UI corrects — rather than trip over a raw 404 mid-run.
+		const broadcasts: Array<{ room: string; event: any }> = [];
+		const wsManager = {
+			broadcast: (room: string, event: any) => {
+				broadcasts.push({ room, event });
+			},
+			subscribe: () => {},
+			unsubscribe: () => {},
+			unsubscribeAll: () => {},
+			getRoomSize: () => 0,
+			getTotalConnections: () => 0,
+		} as any;
+
+		// The cached state the runner reads: running, with a container id Docker no
+		// longer knows about.
+		await db.query(
+			`UPDATE projects SET container_status = $1::container_status, container_id = $2,
+			     container_error = NULL WHERE id = $3`,
+			[ContainerStatus.Running, 'gone-1', projectId],
+		);
+
+		const deps: RunnerDeps = {
+			db,
+			docker: createMockDocker({ inspectContainer: async () => null }),
+			masterKeyManager,
+			serverPort: 3000,
+			dataDir: '/tmp/test-data',
+			wsManager,
+			logs: new LogStreamBroker(),
+		};
+
+		const result = await runAgent(
+			deps,
+			makeAgent(),
+			makeTask(),
+			makeProject({ container_status: ContainerStatus.Running, container_id: 'gone-1' }),
+		);
+
+		expect(result.success).toBe(false);
+		expect(result.stderr).toContain('not running');
+
+		const run = await db.query<{ status: string; log_text: string }>(
+			'SELECT status, log_text FROM heartbeat_runs WHERE id = $1',
+			[result.heartbeatRunId],
+		);
+		expect(run.rows[0].status).toBe(HeartbeatRunStatus.Failed);
+		expect(run.rows[0].log_text).toContain('not running');
+
+		// The stale row was reconciled against Docker reality.
+		const proj = await db.query<{ container_status: string; container_id: string | null }>(
+			'SELECT container_status, container_id FROM projects WHERE id = $1',
+			[projectId],
+		);
+		expect(proj.rows[0].container_status).toBe(ContainerStatus.Error);
+		expect(proj.rows[0].container_id).toBeNull();
+
+		// And the correction was broadcast so the banner/sidebar/Container page update.
+		expect(
+			broadcasts.some(
+				(b) => b.event.type === WsMessageType.RowChange && b.event.table === 'projects',
+			),
+		).toBe(true);
 	});
 
 	it('returns failure when container_id is null and records it in the run log', async () => {

--- a/packages/web/src/components/comment-renderers/run-comment.tsx
+++ b/packages/web/src/components/comment-renderers/run-comment.tsx
@@ -1,12 +1,14 @@
 import { Link } from '@tanstack/react-router';
 import { DoorOpen, Loader2, RotateCw } from 'lucide-react';
 import { useState } from 'react';
+import { type ContainerHealth, useContainerHealth } from '../../hooks/use-container-health';
 import { formatElapsed } from '../../hooks/use-elapsed-duration';
 import {
 	getRunWaitingMessage,
 	isActiveRunStatus,
 	useHeartbeatRun,
 } from '../../hooks/use-heartbeat-runs';
+import { useProjectMeta } from '../../hooks/use-projects';
 import { useRetryFailedRun } from '../../hooks/use-retry-failed-run';
 import { useRunLogs } from '../../hooks/use-run-logs';
 import { agentPageParams } from '../agent-link';
@@ -69,6 +71,19 @@ function skillSourceLabel(url: string): string {
 	}
 }
 
+/** Why a retry is currently blocked — keyed off the same health the banner reads. */
+function containerNotReadyReason(health: ContainerHealth | null): string {
+	switch (health?.kind) {
+		case 'rebuilding':
+			return 'Container is rebuilding — retry will be available once it finishes';
+		case 'provisioning':
+			return 'Container is starting up — retry will be available once it is running';
+		default:
+			// stopped, error, or the project index has not loaded yet.
+			return 'Container is not running — start it from the Container page to retry';
+	}
+}
+
 function RunRetryButton({
 	projectId,
 	taskId,
@@ -79,12 +94,18 @@ function RunRetryButton({
 	runId: string;
 }) {
 	const retry = useRetryFailedRun({ projectId, taskId });
+	const project = useProjectMeta(projectId);
+	const health = useContainerHealth(project);
+	// A run can only be dispatched into a healthy container (running, and not mid
+	// base-image rebuild). Mirror the runtime gate so a click can't queue a retry
+	// that would immediately fail on a missing/stopped container.
+	const containerReady = health?.kind === 'healthy';
 	return (
-		<Tooltip content="Retry this run">
+		<Tooltip content={containerReady ? 'Retry this run' : containerNotReadyReason(health)}>
 			<button
 				type="button"
 				onClick={() => retry.mutate(runId)}
-				disabled={retry.isPending}
+				disabled={retry.isPending || !containerReady}
 				aria-label="Retry failed run"
 				data-testid="retry-failed-run"
 				className="inline-flex h-6 shrink-0 items-center gap-1 rounded-md border border-border px-2 text-[11px] font-medium text-text-2 hover:bg-surface-2 hover:text-text-1 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"

--- a/packages/web/src/components/project-sidebar.tsx
+++ b/packages/web/src/components/project-sidebar.tsx
@@ -1,9 +1,10 @@
-import { AgentAdminStatus, ContainerStatus } from '@hezo/shared';
+import { AgentAdminStatus } from '@hezo/shared';
 import { Link, useNavigate } from '@tanstack/react-router';
-import { AlertTriangle, Globe, Info } from 'lucide-react';
+import { AlertTriangle, Globe, Info, Loader2 } from 'lucide-react';
 import { useState } from 'react';
 import { useActiveProject } from '../hooks/use-active-project';
 import { useAgents } from '../hooks/use-agents';
+import { useContainerHealth } from '../hooks/use-container-health';
 import { useInboxUnreadCount } from '../hooks/use-inbox-count';
 import { useProjectMeta } from '../hooks/use-projects';
 import { agentPageParams } from './agent-link';
@@ -32,6 +33,7 @@ export function ProjectSidebar() {
 	const navigate = useNavigate();
 	const projectId = active?.slug ?? '';
 	const project = useProjectMeta(projectId);
+	const health = useContainerHealth(project);
 	const { data: inboxCount } = useInboxUnreadCount(projectId);
 	const { data: agents } = useAgents(projectId);
 	const [teamCollapsed, setTeamCollapsed] = useState(readTeamCollapsed);
@@ -49,9 +51,8 @@ export function ProjectSidebar() {
 
 	const isInternal = project?.is_internal ?? false;
 	const projectParams = { projectId };
-	const containerFailed =
-		project?.container_status === ContainerStatus.Stopped ||
-		project?.container_status === ContainerStatus.Error;
+	const containerFailed = health?.kind === 'stopped' || health?.kind === 'error';
+	const containerProvisioning = health?.kind === 'provisioning' || health?.kind === 'rebuilding';
 
 	const enabledAgents = (agents ?? []).filter((a) => a.admin_status !== AgentAdminStatus.Disabled);
 	const byCreatedAt = (a: { created_at: string }, b: { created_at: string }) =>
@@ -70,6 +71,13 @@ export function ProjectSidebar() {
 		label: (
 			<span className="inline-flex items-center gap-1.5">
 				<span>Container</span>
+				{containerProvisioning && (
+					<Loader2
+						data-testid="project-sidebar-container-spinner"
+						aria-hidden="true"
+						className="w-3 h-3 shrink-0 animate-spin text-info"
+					/>
+				)}
 				{containerFailed && (
 					<Tooltip content="Container failed — click for details" side="right">
 						<span

--- a/packages/web/test/project-sidebar.test.tsx
+++ b/packages/web/test/project-sidebar.test.tsx
@@ -231,3 +231,68 @@ test("the project menu persists across the project's team pages and disappears o
 		expect(container.querySelector('[data-testid="project-sidebar-name"]')).toBeNull(),
 	);
 });
+
+test('the Container nav item shows a provisioning spinner while the container is creating', async () => {
+	let ws!: SeededWorkspace;
+	let projectSlug = '';
+	const { findByTestId, queryByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Operations' });
+			projectSlug = project.slug;
+			// A container mid-provision: the sidebar should surface a live spinner.
+			await getTestContext().db.query(
+				`UPDATE projects SET container_status = 'creating'::container_status WHERE id = $1`,
+				[project.id],
+			);
+		},
+	});
+
+	// The Container item discloses on its own route; its label carries the spinner.
+	await router.navigate({
+		to: '/projects/$projectId/container',
+		params: { projectId: projectSlug },
+	});
+	await findByTestId('project-sidebar-name', undefined, { timeout: 15_000 });
+
+	const spinner = await findByTestId('project-sidebar-container-spinner', undefined, {
+		timeout: 15_000,
+	});
+	expect(spinner.className).toContain('animate-spin');
+	expect(spinner.className).toContain('text-info');
+	// Provisioning is not a failure — no error indicator alongside it.
+	expect(queryByTestId('project-sidebar-container-error')).toBeNull();
+});
+
+test('the Container nav item shows no spinner once the container is running', async () => {
+	let ws!: SeededWorkspace;
+	let projectSlug = '';
+	const { container, findByTestId, queryByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Operations' });
+			projectSlug = project.slug;
+			await getTestContext().db.query(
+				`UPDATE projects SET container_status = 'running'::container_status,
+				        container_id = COALESCE(container_id, 'c1') WHERE id = $1`,
+				[project.id],
+			);
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/container',
+		params: { projectId: projectSlug },
+	});
+	await findByTestId('project-sidebar-name', undefined, { timeout: 15_000 });
+
+	// Once the Container item is disclosed (and healthy), no spinner or error icon.
+	const nav = getNav(container);
+	await waitFor(() => expect(within(nav).getByRole('link', { name: 'Container' })).toBeTruthy(), {
+		timeout: 15_000,
+	});
+	expect(queryByTestId('project-sidebar-container-spinner')).toBeNull();
+	expect(queryByTestId('project-sidebar-container-error')).toBeNull();
+});

--- a/packages/web/test/run-comment-retry.test.tsx
+++ b/packages/web/test/run-comment-retry.test.tsx
@@ -1,6 +1,6 @@
 import { waitFor } from '@testing-library/react';
 import { expect, test } from 'vitest';
-import { renderApp } from './helpers/render';
+import { getTestContext, renderApp } from './helpers/render';
 import { seedProject, seedTask, seedWorkspace } from './helpers/seed';
 
 // The Retry button on a failed run-entry comment. It must appear only for the
@@ -98,8 +98,10 @@ async function setup(opts: {
 		teamId: string;
 	}) => Record<string, Record<string, unknown>>;
 	taskOverride?: Record<string, unknown>;
+	/** Container state the project index should report; Retry is gated on health. */
+	containerStatus?: string;
 }) {
-	const { seeded, retryCalls, comments, runs, taskOverride } = opts;
+	const { seeded, retryCalls, comments, runs, taskOverride, containerStatus = 'running' } = opts;
 	return renderApp({
 		initialPath: '/',
 		seed: async () => {
@@ -110,6 +112,14 @@ async function setup(opts: {
 				title: 'Run Retry Task',
 				assignee_id: captain.id,
 			});
+
+			// Retry is gated on container health; default the project to running so
+			// the button is clickable, and let specs override to exercise the gate.
+			await getTestContext().db.query(
+				`UPDATE projects SET container_status = $1::container_status,
+				        container_id = COALESCE(container_id, 'retry-test-container') WHERE id = $2`,
+				[containerStatus, project.id],
+			);
 
 			seeded.projectSlug = project.slug;
 			seeded.taskId = task.identifier.toLowerCase();
@@ -192,6 +202,8 @@ test('failed run-entry comment shows Retry and retries that run on click', async
 		timeout: 20_000,
 	})) as HTMLButtonElement;
 	expect(retryButton.textContent ?? '').toContain('Retry');
+	// Enabled once the project index confirms the container is running.
+	await waitFor(() => expect(retryButton.disabled).toBe(false), { timeout: 20_000 });
 
 	await user.click(retryButton);
 
@@ -275,4 +287,38 @@ test('succeeded run-entry comment shows no Retry button', async () => {
 
 	await findByTestId('run-comment-summary', undefined, { timeout: 20_000 });
 	expect(queryByTestId('retry-failed-run')).toBeNull();
+});
+
+test('failed run-entry comment disables Retry while the container is not running', async () => {
+	const seeded: Seeded = { projectSlug: '', taskId: '', agentSlug: '' };
+	const retryCalls: string[] = [];
+
+	const { findByTestId, user, router } = await setup({
+		seeded,
+		retryCalls,
+		// The exact stale state from the incident: the run failed and the container
+		// is gone, so a retry would only fail again.
+		containerStatus: 'stopped',
+		comments: ({ task, agent }) => [
+			runComment('c1', task.id, FAILED_RUN_ID, agent, '2026-05-20T11:30:00Z'),
+		],
+		runs: ({ task, agent, teamId }) => ({
+			[FAILED_RUN_ID]: runResponse(FAILED_RUN_ID, agent, teamId, task.id, 'failed'),
+		}),
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
+	});
+
+	// The button still renders (this is the latest failed run), but the not-running
+	// container makes it inert so a click can't dispatch a doomed retry.
+	const retryButton = (await findByTestId('retry-failed-run', undefined, {
+		timeout: 20_000,
+	})) as HTMLButtonElement;
+	await waitFor(() => expect(retryButton.disabled).toBe(true), { timeout: 20_000 });
+
+	await user.click(retryButton).catch(() => {});
+	expect(retryCalls).toEqual([]);
 });


### PR DESCRIPTION
## Problem

In production, killing all Docker containers/images and restarting hezo left the app in a broken state: retrying an agent run failed with a raw

```
[runner] Docker execCreate failed (404): {"message":"No such container: 5ce42dbc8d0a…"}
```

…and the Container page still showed the dead container as **Running**.

**Root cause:** the run path trusted the cached `projects.container_status` and never checked that the container was actually alive before `execCreate`. The gate in `runAgent` was DB-only, so a stale `running` (after an external `docker rm` or a Docker daemon restart) passed the check and tripped over a 404 mid-run. The ~1 Hz sync and the startup reconcile are supposed to flip a vanished container to `error`, but they can lag or miss.

## Changes

**1. Robust container detection (backend).** `runAgent` now live-verifies the container against Docker via the existing `syncContainerStatus` primitive before exec. If the container is gone/stopped, the DB row is reconciled (status → `error`, `container_id` nulled), the change is broadcast so the banner/sidebar/Container page correct immediately, and the run fails fast with a clear message instead of a raw 404. The cheap cached fast-path check is kept ahead of it (no Docker round-trip when the row already says not-running).

**2. Retry button gated on container health (frontend).** The Retry button on a failed run is disabled unless the container is healthy — running *and* not mid base-image rebuild (`useContainerHealth(...).kind === 'healthy'`), mirroring the runtime gate. A tooltip explains why when it's blocked (not running / starting up / rebuilding).

**3. Provisioning spinner in the project sidebar (frontend).** The sidebar's **Container** nav item shows a blue spinner while the container is creating/stopping/rebuilding, derived from the same `useContainerHealth` the top banner uses (so the two never disagree). The existing error indicator is unchanged. The spinner is decorative (`aria-hidden`) so it doesn't alter the nav link's accessible name; the top banner already provides the accessible provisioning announcement.

## Scope decisions

- **Detect-and-correct, not auto-reprovision.** A vanished container makes the run fail with a clear message and flips the UI to not-running; the operator restarts via the Container page (or the banner's Restart) and retries. Auto-reprovision stays the startup reconcile's job.
- Did **not** add a separate cached-status guard on the retry REST endpoint: it would read the same stale `container_status` that causes the bug, so it wouldn't catch the real scenario — the authoritative `runAgent` live-check plus the frontend gate cover all paths with a single source of truth.

## Tests

- **Server** (`agent-runner.test.ts`): new case — cached `running` but the container 404s on inspect → run fails, the `projects` row is reconciled to `error` with `container_id` nulled, and a `projects` update is broadcast. Existing cached fast-path and happy-path cases still pass.
- **Web** (`project-sidebar.test.tsx`): the Container item shows the spinner while `creating` and none when `running`.
- **Web** (`run-comment-retry.test.tsx`): Retry is disabled while the container isn't running; the existing click test now waits for the enabled state.

`.dev/architecture.md` documents the pre-exec liveness check. Typecheck, biome, and all affected server/web suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015NUczPxpYLfUiRAW4tZtWh)_