### PR TITLE
feat: add a --version argument to the CLI

### DIFF
--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -23,6 +23,7 @@ handy for baking defaults into a service definition while still overriding per r
 | `--no-open` | `HEZO_OPEN` | on | Auto-open the web app in your browser on startup. On by default; automatically skipped in environments without a browser (CI, containers, SSH, headless Linux). Pass `--no-open` or set `HEZO_OPEN=0` to disable. |
 | `--log-level <level>` | `HEZO_LOG_LEVEL` | `info` | Logging verbosity: `debug`, `info`, `warn`, or `error`. |
 | `--keep-old-containers` | `HEZO_KEEP_OLD_CONTAINERS` | off | Keep old project containers instead of removing them — for debugging a crashed container. |
+| `--version` | — | — | Print the Hezo version and exit (also `hezo version`). |
 | — | `HEZO_DISABLE_AUTO_UPDATE` | off | Disable the in-app auto-update (release check, the background download, and the "Install & restart" banner). When disabled the banner instead links to the GitHub release page. |
 | — | `HEZO_UPDATE_CHECK_CRON` | `0 0 4 * * *` | Cron schedule (seconds-precision) for the daily check that downloads and stages a newer release. A running instance also stages as soon as it detects an update, so the banner's "Install & restart" is instant. |
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -60,6 +60,7 @@ this is effectively the only path forward once the master key is lost.
 
 ```sh
 hezo --help          # show all commands and flags
+hezo --version       # print the Hezo version and exit
 ```
 
 ## See also

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -35,6 +35,7 @@ Starts the server on port 3100 with hot reload. In dev, PGlite data persists at 
 | `--no-open` | open on | Auto-open the web app in the browser on startup (on by default; skipped automatically in CI/containers/SSH/headless Linux). Disable with `--no-open` or `HEZO_OPEN=0` |
 | `--log-level <level>` | `info` | Logging verbosity: `debug`, `info`, `warn`, `error` (env: `HEZO_LOG_LEVEL`) |
 | `--keep-old-containers` | `false` | Keep old project containers instead of removing them, for debugging (env: `HEZO_KEEP_OLD_CONTAINERS`) |
+| `--version` | — | Print the Hezo version and exit (also `hezo version`) |
 
 ## Master Key
 

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -8,6 +8,7 @@ import {
 	validateMnemonic,
 } from '@hezo/shared';
 import { Command } from 'commander';
+import { HEZO_VERSION } from './version';
 
 export type LogLevelName = 'debug' | 'info' | 'warn' | 'error';
 
@@ -94,6 +95,24 @@ function parseMasterKey(raw: string): { unlockKeyHex: string; publicKeyHex: stri
 		unlockKeyHex: deriveUnlockKey(raw),
 		publicKeyHex: deriveAuthKeyPair(raw).publicKeyHex,
 	};
+}
+
+/**
+ * Handle a version request: `hezo --version`, `hezo -V`, or `hezo version`.
+ * Prints the running build's version string and returns `true` so the caller
+ * skips normal server startup (mirroring `runRestore`). Returns `false` when no
+ * version was requested. `out` is injectable for testing.
+ */
+export function runVersion(
+	argv: string[] = process.argv,
+	out: (line: string) => void = console.log,
+): boolean {
+	const tokens = argv.slice(2);
+	if (tokens.includes('--version') || tokens.includes('-V') || tokens[0] === 'version') {
+		out(HEZO_VERSION);
+		return true;
+	}
+	return false;
 }
 
 /**

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs';
 import type { PGlite } from '@electric-sql/pglite';
 import { AuthType } from '@hezo/shared';
 import { app } from './app';
-import { parseConfig, runRestore } from './cli';
+import { parseConfig, runRestore, runVersion } from './cli';
 import type { MasterKeyManager } from './crypto/master-key';
 import { PgDataCorruptError } from './db/client';
 import { DbNewerThanAppError, MigrationFailedError } from './db/migrate-errors';
@@ -80,6 +80,12 @@ process.on('uncaughtException', (err) => {
 
 interface WsConnectionData extends WsData {
 	_token?: string;
+}
+
+// `hezo --version` / `hezo version` prints the version and exits before any
+// server startup.
+if (runVersion()) {
+	process.exit(0);
 }
 
 // `hezo restore <backup>` runs and exits before any server startup.

--- a/packages/server/test/cli.test.ts
+++ b/packages/server/test/cli.test.ts
@@ -2,7 +2,8 @@ import { homedir } from 'node:os';
 import { resolve } from 'node:path';
 import { deriveAuthKeyPair, deriveUnlockKey } from '@hezo/shared';
 import { describe, expect, it } from 'vitest';
-import { parseConfig, resolveDevDataDir } from '../src/cli';
+import { parseConfig, resolveDevDataDir, runVersion } from '../src/cli';
+import { HEZO_VERSION } from '../src/version';
 
 // Canonical BIP39 vector — parseMasterKey only accepts a valid mnemonic.
 const PHRASE =
@@ -157,6 +158,32 @@ describe('parseConfig', () => {
 			const config = parseConfig(argv('--port', '8080'), { HEZO_PORT: '' });
 			expect(config.port).toBe(8080);
 		});
+	});
+});
+
+describe('runVersion', () => {
+	it('prints the version and returns true for --version', () => {
+		const lines: string[] = [];
+		expect(runVersion(argv('--version'), (l) => lines.push(l))).toBe(true);
+		expect(lines).toEqual([HEZO_VERSION]);
+	});
+
+	it('handles the -V short flag', () => {
+		const lines: string[] = [];
+		expect(runVersion(argv('-V'), (l) => lines.push(l))).toBe(true);
+		expect(lines).toEqual([HEZO_VERSION]);
+	});
+
+	it('handles the `version` subcommand', () => {
+		const lines: string[] = [];
+		expect(runVersion(argv('version'), (l) => lines.push(l))).toBe(true);
+		expect(lines).toEqual([HEZO_VERSION]);
+	});
+
+	it('returns false and prints nothing when no version is requested', () => {
+		const lines: string[] = [];
+		expect(runVersion(argv('--port', '8080'), (l) => lines.push(l))).toBe(false);
+		expect(lines).toEqual([]);
 	});
 });
 


### PR DESCRIPTION
## Summary

Adds a version flag to the `hezo` CLI that prints the running build's version and exits, without starting the server.

It recognizes three forms:

```sh
hezo --version    # 0.6.6
hezo -V           # 0.6.6
hezo version      # 0.6.6
```

## Implementation

- New `runVersion()` early-exit handler in `packages/server/src/cli.ts`, mirroring the existing `runRestore()` pattern. It sources the string from the existing `HEZO_VERSION` constant (`src/version.ts`), so it reports the injected literal in a packaged binary and the `package.json` version in dev.
- Wired into `src/index.ts` ahead of the restore check, so it runs before any server/Docker startup work.
- The print target is injectable, making it unit-testable without spying on `console`.

## Docs

Updated every surface that lists CLI flags, in the same change:
- `docs/reference/cli.md` (Info section)
- `docs/deployment/configuration.md` (options table)
- `packages/server/README.md` (CLI flags table)

## Tests

Added `runVersion` unit tests in `packages/server/test/cli.test.ts` covering all three invocation forms and the no-version case. Verified end-to-end that each form prints the version and exits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018CjVp9pNupvh5hargUHNQi)_