### PR TITLE
chore: update tagline to "Self-hosted and secure"

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 </div>
 
 <p align="center">
-  <strong>A whole AI workforce. And you're the boss.</strong>
+  <strong>A whole AI workforce. Self-hosted and secure.</strong>
 </p>
 
 <p align="center">

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "hezo",
+	"description": "A whole AI workforce. Self-hosted and secure.",
 	"private": true,
 	"license": "AGPL-3.0-or-later",
 	"packageManager": "bun@1.3.9",

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -3,19 +3,19 @@
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<title>Hezo — A whole AI workforce. And you're the boss.</title>
+		<title>Hezo — A whole AI workforce. Self-hosted and secure.</title>
 		<meta
 			name="description"
 			content="Run a whole team of AI agents like a company — you set the goals, they ship the work, and you own everything they produce."
 		/>
 		<meta property="og:type" content="website" />
-		<meta property="og:title" content="Hezo — A whole AI workforce. And you're the boss." />
+		<meta property="og:title" content="Hezo — A whole AI workforce. Self-hosted and secure." />
 		<meta
 			property="og:description"
 			content="Run a whole team of AI agents like a company — you set the goals, they ship the work, and you own everything they produce."
 		/>
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="Hezo — A whole AI workforce. And you're the boss." />
+		<meta name="twitter:title" content="Hezo — A whole AI workforce. Self-hosted and secure." />
 		<meta
 			name="twitter:description"
 			content="Run a whole team of AI agents like a company — you set the goals, they ship the work, and you own everything they produce."


### PR DESCRIPTION
Updates the product tagline from **"A whole AI workforce. And you're the boss."** to **"A whole AI workforce. Self-hosted and secure."**

## Changes
- `packages/web/index.html` — updated the tagline in the page `<title>`, `og:title`, and `twitter:title` (the title shown in browser tabs and social share cards for the app).
- `README.md` — updated the headline tagline.
- `package.json` — added a `description` field set to the new tagline (none existed before).

## Notes
- The historical tagline entry in `CHANGELOG.md` is intentionally left unchanged — it's a frozen record of a past release.
- No occurrence of the tagline exists under `docs/` (those pages use descriptive prose like "Hezo is a self-hosted platform…"), so nothing there needed updating.
- The branch was first fast-forwarded to latest `main` (picks up the `--version` CLI commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KUeepc6iBeYzDeYdFpkDqW

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUeepc6iBeYzDeYdFpkDqW)_