### PR TITLE
feat: auto-grow the CEO chat composer with multi-line input

### DIFF
--- a/packages/web/src/components/ceo-chat/ceo-chat-widget.tsx
+++ b/packages/web/src/components/ceo-chat/ceo-chat-widget.tsx
@@ -27,6 +27,7 @@ export function CeoChatWidget() {
 	const blockedHealth = hqHealth && hqHealth.kind !== 'healthy' ? hqHealth : null;
 	const [draft, setDraft] = useState('');
 	const scrollRef = useRef<HTMLDivElement>(null);
+	const inputRef = useRef<HTMLTextAreaElement>(null);
 
 	const lastId = messages.at(-1)?.id;
 	const lastLen = messages.at(-1)?.content.length ?? 0;
@@ -46,6 +47,19 @@ export function CeoChatWidget() {
 		window.addEventListener('keydown', onKey);
 		return () => window.removeEventListener('keydown', onKey);
 	}, [open]);
+
+	// Grow the composer with its content (capped by `max-h-32`, then it scrolls),
+	// and collapse it back to a single row when the draft is cleared on submit.
+	// Reset to `auto` first so the measured `scrollHeight` can shrink, not only grow.
+	// `open` re-runs it when the panel (re)mounts so a draft kept across a close/open
+	// is sized correctly rather than clipped to a single row.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: re-measure on draft/open change (body reads the DOM via a stable ref)
+	useEffect(() => {
+		const el = inputRef.current;
+		if (!el) return;
+		el.style.height = 'auto';
+		el.style.height = `${el.scrollHeight}px`;
+	}, [draft, open]);
 
 	const submit = () => {
 		const text = draft.trim();
@@ -167,6 +181,7 @@ export function CeoChatWidget() {
 						<div className="border-t border-border p-3">
 							<div className="flex items-end gap-2 rounded-2xl border border-border bg-surface px-2 py-1.5 transition-colors focus-within:border-border-strong">
 								<textarea
+									ref={inputRef}
 									value={draft}
 									onChange={(e) => setDraft(e.target.value)}
 									onKeyDown={(e) => {
@@ -178,7 +193,7 @@ export function CeoChatWidget() {
 									rows={1}
 									placeholder="Ask the CEO anything, across every project…"
 									data-testid="ceo-chat-input"
-									className="max-h-32 min-h-[2.25rem] flex-1 resize-none bg-transparent px-2 py-2 text-[13px] leading-5 text-text-1 outline-none placeholder:text-text-3"
+									className="max-h-32 min-h-[2.25rem] flex-1 resize-none overflow-y-auto bg-transparent px-2 py-2 text-[13px] leading-5 text-text-1 outline-none placeholder:text-text-3"
 								/>
 								<button
 									type="button"

--- a/test/browser/ceo-chat.spec.ts
+++ b/test/browser/ceo-chat.spec.ts
@@ -124,3 +124,41 @@ test.describe('CEO chat widget — responsive layout', () => {
 		await expect(page.getByTestId('ceo-chat-expand')).toBeHidden();
 	});
 });
+
+// Kept in Playwright by decision-tree item 1 (real CSS layout): the composer
+// auto-grows by measuring its own `scrollHeight` and writing back an inline
+// height. happy-dom reports `scrollHeight` as 0, so the grow/collapse can only
+// be observed against Chromium's real layout pass.
+test.describe('CEO chat widget — composer auto-grow', () => {
+	test('the composer grows with multi-line input and collapses after submit', async ({
+		sharedPage,
+		sharedWorkspace,
+	}) => {
+		const page = sharedPage;
+
+		await page.setViewportSize({ width: 1280, height: 800 });
+		await page.goto(`/projects/${sharedWorkspace.projectSlug}/tasks`);
+		await waitForPageLoad(page);
+
+		const launcher = page.getByTestId('ceo-chat-launcher');
+		await expect(launcher).toBeVisible({ timeout: 15000 });
+		await launcher.click();
+		await expect(page.getByTestId('ceo-chat-panel')).toBeVisible();
+
+		const input = page.getByTestId('ceo-chat-input');
+		const heightOf = async () => (await input.boundingBox())?.height ?? 0;
+
+		// Empty composer starts as a single row.
+		const initialHeight = await heightOf();
+		expect(initialHeight).toBeGreaterThan(0);
+
+		// Several lines of input expand the box well past its single-row height.
+		await input.fill(['one', 'two', 'three', 'four', 'five'].join('\n'));
+		await expect.poll(heightOf).toBeGreaterThan(initialHeight + 20);
+
+		// Submitting clears the draft, collapsing the composer back to one row.
+		await page.getByTestId('ceo-chat-send').click();
+		await expect(input).toHaveValue('');
+		await expect.poll(heightOf).toBeLessThan(initialHeight + 8);
+	});
+});


### PR DESCRIPTION
## What

The CEO chat composer ("Ask the CEO anything, across every project…") now grows with its content as the message wraps to multiple lines, and collapses back to its normal single-row height once the message is submitted.

## Why

The textarea was fixed at a single row (`rows={1}`), so a multi-line draft only produced an internal scrollbar — the input box never expanded to show what you were typing.

## How

In `packages/web/src/components/ceo-chat/ceo-chat-widget.tsx`:

- Added a ref to the textarea and an effect that, on every draft change, resets its height to `auto` and writes back `scrollHeight` as the inline height. This grows the box with its content up to the existing `max-h-32` cap (after which it scrolls).
- Resetting to `auto` first lets the height **shrink** as well as grow, so when `submit()` clears the draft the composer snaps straight back to a single row.
- The effect also re-runs on `open`, so a draft preserved across a close/reopen is sized correctly rather than clipped to one row.
- Added `overflow-y-auto` so the textarea scrolls cleanly once it hits the height cap.

The intentional `[draft, open]` dependencies (read indirectly via the DOM, not in the effect body) carry a `biome-ignore` for `useExhaustiveDependencies`, matching the existing scroll effect in the same component.

## Testing

- New Playwright test in `test/browser/ceo-chat.spec.ts` asserting the composer grows on multi-line input and collapses after submit. This lives in Playwright (not the component tier) because the behavior depends on real CSS layout — happy-dom reports `scrollHeight` as `0` (AGENTS.md decision-tree item 1). Verified passing against real Chromium.
- Existing CEO chat component suite (18 tests) still green.
- `biome check`, `typecheck`, and `build` all pass (pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014acwiD9SKXFc11qwpbTG8L

---
_Generated by [Claude Code](https://claude.ai/code/session_014acwiD9SKXFc11qwpbTG8L)_