### PR TITLE
feat: add copy buttons to the CEO chat

### DIFF
--- a/packages/web/src/components/ceo-chat/ceo-chat-widget.tsx
+++ b/packages/web/src/components/ceo-chat/ceo-chat-widget.tsx
@@ -1,9 +1,19 @@
 import { HQ_PROJECT_NAME } from '@hezo/shared';
-import { ArrowRight, Loader2, Maximize2, MessageSquare, Minimize2, X } from 'lucide-react';
+import {
+	ArrowRight,
+	Check,
+	Copy,
+	Loader2,
+	Maximize2,
+	MessageSquare,
+	Minimize2,
+	X,
+} from 'lucide-react';
 import { type ReactNode, useEffect, useRef, useState } from 'react';
 import { type CeoMessage, useCeoChat } from '../../hooks/use-ceo-chat';
 import { useContainerHealth } from '../../hooks/use-container-health';
 import { useHqProject } from '../../hooks/use-projects';
+import { copyToClipboard } from '../../lib/clipboard';
 import { HqContainerNotice } from '../hq-container-notice';
 import { MarkdownProse } from '../markdown-prose';
 import { CountOverlayBadge } from '../ui/count-overlay-badge';
@@ -26,8 +36,10 @@ export function CeoChatWidget() {
 	// stays openable but swaps its body for the container state + a link to fix it.
 	const blockedHealth = hqHealth && hqHealth.kind !== 'healthy' ? hqHealth : null;
 	const [draft, setDraft] = useState('');
+	const [copied, setCopied] = useState(false);
 	const scrollRef = useRef<HTMLDivElement>(null);
 	const inputRef = useRef<HTMLTextAreaElement>(null);
+	const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
 	const lastId = messages.at(-1)?.id;
 	const lastLen = messages.at(-1)?.content.length ?? 0;
@@ -61,11 +73,32 @@ export function CeoChatWidget() {
 		el.style.height = `${el.scrollHeight}px`;
 	}, [draft, open]);
 
+	// Clear the "copied" reset timer on unmount so it can't fire into a gone component.
+	useEffect(() => {
+		return () => {
+			if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+		};
+	}, []);
+
 	const submit = () => {
 		const text = draft.trim();
 		if (!text) return;
 		setDraft('');
 		send(text).catch(() => undefined);
+	};
+
+	// Copy the whole conversation as plain text, each turn labelled by speaker.
+	const copyConversation = async () => {
+		const transcript = messages
+			.filter((m) => m.content.trim().length > 0)
+			.map((m) => `${m.role === 'assistant' ? `CEO · ${HQ_PROJECT_NAME}` : 'You'}: ${m.content}`)
+			.join('\n\n');
+		if (!transcript) return;
+		if (await copyToClipboard(transcript)) {
+			setCopied(true);
+			if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+			copyTimeoutRef.current = setTimeout(() => setCopied(false), 2000);
+		}
 	};
 
 	if (!open) {
@@ -120,6 +153,18 @@ export function CeoChatWidget() {
 						</span>
 					</div>
 					<div className="flex items-center gap-1">
+						{/* Copy the full transcript to the clipboard. Disabled until there's
+					    something to copy; the icon flips to a check for 2s on success. */}
+						<button
+							type="button"
+							onClick={copyConversation}
+							disabled={messages.length === 0}
+							aria-label={copied ? 'Conversation copied' : 'Copy conversation'}
+							data-testid="ceo-chat-copy"
+							className="flex h-9 w-9 items-center justify-center rounded-md text-text-2 hover:bg-surface-2 hover:text-text-1 disabled:pointer-events-none disabled:opacity-40"
+						>
+							{copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+						</button>
 						{/* Expand/collapse is desktop-only; the panel is already near-full-screen
 					    on mobile, where the toggle would be a no-op. */}
 						<button
@@ -233,7 +278,7 @@ function MessageBubble({ message }: { message: CeoMessage }) {
 		}
 		return (
 			<div
-				className="flex max-w-[90%] flex-col gap-1"
+				className="group flex max-w-[90%] flex-col gap-1"
 				data-testid="ceo-chat-message"
 				data-role="ceo"
 			>
@@ -256,13 +301,18 @@ function MessageBubble({ message }: { message: CeoMessage }) {
 				{/* Reply has begun but the CEO is still working → dots sit just below
 				    the same bubble. */}
 				{streaming && <StreamingDots />}
+				{/* Once the reply has settled, a hover-revealed copy affordance for this
+				    single message sits just under the bubble. */}
+				{!streaming && message.content.length > 0 && (
+					<MessageCopyButton text={message.content} align="start" />
+				)}
 			</div>
 		);
 	}
 
 	return (
 		<div
-			className="flex max-w-[90%] flex-col items-end gap-1 self-end"
+			className="group flex max-w-[90%] flex-col items-end gap-1 self-end"
 			data-testid="ceo-chat-message"
 			data-role="user"
 		>
@@ -270,7 +320,47 @@ function MessageBubble({ message }: { message: CeoMessage }) {
 			<div className="rounded-2xl rounded-br-sm bg-inverse px-3.5 py-2.5 text-sm leading-relaxed text-inverse-fg whitespace-pre-wrap">
 				{message.content}
 			</div>
+			{message.content.length > 0 && <MessageCopyButton text={message.content} align="end" />}
 		</div>
+	);
+}
+
+/**
+ * A mini copy affordance for a single message, fading in when its bubble is
+ * hovered (or the button is focused). Each instance tracks its own copied state
+ * so the check only flips on the message you actually copied. Keyed on hover
+ * *capability*, not screen size: pointer devices hide it until the bubble is
+ * hovered; touch devices (no hover, any size) keep it visible so it stays
+ * reachable. `group-hover` is itself auto-scoped to `(hover: hover)` by Tailwind.
+ */
+function MessageCopyButton({ text, align }: { text: string; align: 'start' | 'end' }) {
+	const [copied, setCopied] = useState(false);
+	const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	useEffect(() => {
+		return () => {
+			if (timeoutRef.current) clearTimeout(timeoutRef.current);
+		};
+	}, []);
+
+	const handleCopy = async () => {
+		if (await copyToClipboard(text)) {
+			setCopied(true);
+			if (timeoutRef.current) clearTimeout(timeoutRef.current);
+			timeoutRef.current = setTimeout(() => setCopied(false), 1500);
+		}
+	};
+
+	return (
+		<button
+			type="button"
+			onClick={handleCopy}
+			aria-label={copied ? 'Message copied' : 'Copy message'}
+			data-testid="ceo-chat-message-copy"
+			className={`${align === 'end' ? 'self-end' : 'self-start'} flex h-6 w-6 items-center justify-center rounded-md text-text-3 opacity-100 transition-opacity hover:bg-surface-2 hover:text-text-1 focus-visible:opacity-100 [@media(hover:hover)]:opacity-0 group-hover:opacity-100`}
+		>
+			{copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+		</button>
 	);
 }
 

--- a/packages/web/test/ceo-chat.test.tsx
+++ b/packages/web/test/ceo-chat.test.tsx
@@ -372,3 +372,152 @@ test('a user message is shown as typed, not parsed as markdown', async () => {
 	expect(bubble.querySelector('strong')).toBeNull();
 	expect(bubble.querySelector('code')).toBeNull();
 });
+
+test('the copy button writes the whole conversation to the clipboard, labelled by speaker', async () => {
+	const { findByTestId, user } = await renderApp({ initialPath: '/home' });
+	(await findByTestId('ceo-chat-launcher')).click();
+	await findByTestId('ceo-chat-panel');
+
+	seedConversation([
+		{
+			id: 'u1',
+			role: 'user',
+			channel: 'web',
+			status: 'complete',
+			content: 'What is blocked?',
+			created_at: now(),
+		},
+		{
+			id: 'a1',
+			role: 'assistant',
+			channel: 'web',
+			status: 'complete',
+			content: 'Nothing is blocked right now.',
+			created_at: now(),
+		},
+	]);
+
+	const copyBtn = (await findByTestId('ceo-chat-copy')) as HTMLButtonElement;
+	expect(copyBtn.getAttribute('aria-label')).toBe('Copy conversation');
+
+	const writes: string[] = [];
+	const originalDesc = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+	Object.defineProperty(navigator, 'clipboard', {
+		configurable: true,
+		value: {
+			writeText: async (t: string) => {
+				writes.push(t);
+			},
+		},
+	});
+	try {
+		await user.click(copyBtn);
+		// Each turn is prefixed with its speaker and separated by a blank line.
+		expect(writes).toEqual(['You: What is blocked?\n\nCEO · HQ: Nothing is blocked right now.']);
+		// The icon swaps to a check — the aria-label flips to "Conversation copied".
+		await waitFor(() => expect(copyBtn.getAttribute('aria-label')).toBe('Conversation copied'));
+	} finally {
+		if (originalDesc) Object.defineProperty(navigator, 'clipboard', originalDesc);
+		else delete (navigator as { clipboard?: unknown }).clipboard;
+	}
+});
+
+test('the copy button is disabled until the conversation has a message', async () => {
+	const { findByTestId, getByTestId } = await renderApp({ initialPath: '/home' });
+	(await findByTestId('ceo-chat-launcher')).click();
+	await findByTestId('ceo-chat-panel');
+
+	// Empty conversation → nothing to copy yet.
+	expect(((await findByTestId('ceo-chat-copy')) as HTMLButtonElement).disabled).toBe(true);
+
+	// Once a message lands, the affordance enables.
+	seedConversation([
+		{
+			id: 'u1',
+			role: 'user',
+			channel: 'web',
+			status: 'complete',
+			content: 'Hi',
+			created_at: now(),
+		},
+	]);
+	await waitFor(() =>
+		expect((getByTestId('ceo-chat-copy') as HTMLButtonElement).disabled).toBe(false),
+	);
+});
+
+test('each message has its own copy button that copies only that message', async () => {
+	const { findByTestId, findAllByTestId, user } = await renderApp({ initialPath: '/home' });
+	(await findByTestId('ceo-chat-launcher')).click();
+	await findByTestId('ceo-chat-panel');
+
+	seedConversation([
+		{
+			id: 'u1',
+			role: 'user',
+			channel: 'web',
+			status: 'complete',
+			content: 'First, the question',
+			created_at: now(),
+		},
+		{
+			id: 'a1',
+			role: 'assistant',
+			channel: 'web',
+			status: 'complete',
+			content: 'Then, the answer',
+			created_at: now(),
+		},
+	]);
+
+	// One copy affordance per message — for the operator's turn and the CEO's alike.
+	const copyButtons = await findAllByTestId('ceo-chat-message-copy');
+	expect(copyButtons).toHaveLength(2);
+	expect(copyButtons[0].getAttribute('aria-label')).toBe('Copy message');
+
+	const writes: string[] = [];
+	const originalDesc = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+	Object.defineProperty(navigator, 'clipboard', {
+		configurable: true,
+		value: {
+			writeText: async (t: string) => {
+				writes.push(t);
+			},
+		},
+	});
+	try {
+		// Copying the CEO reply writes only that message's text — no speaker label
+		// and none of the other turns.
+		await user.click(copyButtons[1]);
+		expect(writes).toEqual(['Then, the answer']);
+		// The check confirms on the button that was clicked…
+		await waitFor(() => expect(copyButtons[1].getAttribute('aria-label')).toBe('Message copied'));
+		// …and only that one — the sibling stays idle.
+		expect(copyButtons[0].getAttribute('aria-label')).toBe('Copy message');
+	} finally {
+		if (originalDesc) Object.defineProperty(navigator, 'clipboard', originalDesc);
+		else delete (navigator as { clipboard?: unknown }).clipboard;
+	}
+});
+
+test('a streaming reply shows no per-message copy button until it settles', async () => {
+	const { findByTestId, findByText, queryAllByTestId } = await renderApp({ initialPath: '/home' });
+	(await findByTestId('ceo-chat-launcher')).click();
+	await findByTestId('ceo-chat-panel');
+
+	seedConversation([
+		{
+			id: 'a1',
+			role: 'assistant',
+			channel: 'web',
+			status: 'streaming',
+			content: 'Working on it',
+			created_at: now(),
+		},
+	]);
+
+	await findByText('Working on it');
+	// Mid-stream the trailing dots stand in; the copy affordance only appears once
+	// the reply is complete.
+	expect(queryAllByTestId('ceo-chat-message-copy')).toHaveLength(0);
+});


### PR DESCRIPTION
## Summary

Adds two copy-to-clipboard affordances to the CEO chat widget (`packages/web/src/components/ceo-chat/ceo-chat-widget.tsx`):

1. **Copy whole conversation** — a button in the chat header, placed **to the left of the expand/collapse toggle**. It copies the full transcript to the clipboard with each turn labelled by speaker (`You:` / `CEO · HQ:`), separated by blank lines. It's disabled until there's something to copy, and its icon flips to a check for 2s on success.

2. **Copy a single message** — a mini copy button that **reveals on hover** of each bubble (yours or the CEO's) and sits just below the message body, aligned to the message's side. It copies only that message's text.

Both reuse the shared `copyToClipboard` helper (secure + insecure-context fallback) and the established `Copy`/`Check` icon pattern used elsewhere (log viewer, comment copy).

## Hover behaviour & mobile

The per-message button is keyed on hover **capability** (`[@media(hover:hover)]`), not screen size:

- **Pointer devices** — hidden by default, fades in on bubble hover (and on keyboard focus via `focus-visible`).
- **Touch devices (any size)** — always visible, so it stays reachable where there's no hover.

This was verified against the compiled CSS with computed-opacity probes: desktop default `0` → desktop hover `1` → touch `1`.

## Header layout

| State | Result |
|---|---|
| Header | `[copy] [expand] [✕]` — copy is left of expand/collapse, as requested |
| Desktop, no hover | per-message buttons hidden |
| Desktop, hovering a bubble | that bubble's copy button appears below it |
| Touch | per-message buttons always visible |

## Tests

Four new component tests in `packages/web/test/ceo-chat.test.tsx` (all 22 in the file pass):

- header copy writes the full transcript labelled by speaker, with the icon flipping to a check
- header copy is disabled until the conversation has a message
- each message has its own copy button that copies **only** that message (sibling stays idle)
- a streaming reply shows no per-message copy button until it settles

`bun run typecheck`, `biome check`, and the production build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQinrwjmn8tfLVAfca5rnJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NQinrwjmn8tfLVAfca5rnJ)_