### PR TITLE
docs: expand the long-term memory model for agents

### DIFF
--- a/docs/concepts/documents-and-memory.md
+++ b/docs/concepts/documents-and-memory.md
@@ -6,10 +6,56 @@ section: Concepts
 
 # Documents & long-term memory
 
-Agents are at their best when they don't start cold. Hezo gives every project a set of
-**documents** — durable, markdown knowledge that lives with the project and outlasts any
-single run. This is the team's long-term memory: context, decisions, and plans are written
-down once and read back whenever they're needed, instead of being re-derived on every run.
+Agents are at their best when they don't start cold. Hezo gives every project a
+**long-term memory**: the durable context a team accumulates — decisions, plans,
+conventions, and where each task stands — is written down once and read back into every
+run, instead of being re-derived (or lost) each time an agent wakes.
+
+That memory lives at a few different scopes, and each one is kept current by you *and* by
+the agents as they work:
+
+- **Per task** — the [rules, description, and progress summary](/docs/concepts/tasks) that
+  say how a ticket should be worked and where it stands, plus the comment thread an agent
+  reads to catch up on what's happened.
+- **Per project** — the **Documents** library of PRDs, specs, and research the whole team
+  keeps coming back to.
+- **Instance-wide** — [skills](/docs/concepts/skills), the reusable know-how every team can
+  reach for.
+- **Per team** — [preferences](#team-preferences): custom instructions applied to every
+  agent on a team.
+- **The CEO's** — its [chatbox memory](#chatbox-memory) of your standing preferences and
+  guidelines.
+
+## What an agent carries into every run
+
+Hezo assembles an agent's context **fresh on every run**, from the latest state in the
+database — so an edit you or another agent made lands on the very next run, with nothing
+cached to go stale. Context reaches the agent in one of two ways:
+
+- **In full** — short, always-relevant text is injected verbatim: the current task's
+  **rules**, **description**, and **progress summary**; the team's **preferences**; and, for
+  the CEO, its **chatbox memory**. These are small and central, so the agent always has them
+  in view.
+- **As a manifest** — larger libraries are surfaced as a *table of contents* rather than
+  pasted in whole. The agent sees an index of what exists and pulls the full item only when
+  it's relevant: **project documents** are listed by filename, title, and last-updated date
+  (the agent opens one with `read_project_doc`), and **skills** are listed by name and
+  description (the agent loads one with `get_skill`). This keeps prompts lean while still
+  putting the entire library within reach.
+
+| Memory | Scope | How it reaches the agent | Kept current by |
+|---|---|---|---|
+| Rules | One task | In full, every run | You and agents |
+| Progress summary | One task | In full, every run | You and agents |
+| Comment thread | One task | Read by the agent at the start of a run | You and agents |
+| Project documents | One project | Manifest, full text on demand | You and agents |
+| Skills | Whole instance | Manifest, full text on demand | You and agents |
+| Team preferences | One team | In full, every run | You |
+| Chatbox memory | The CEO | In full, every chat turn | You and the CEO |
+
+For how rules, the progress summary, and the thread work together on a single ticket — and
+how an agent uses them to pick up where the last run left off — see
+[Tasks, rules & summaries](/docs/concepts/tasks).
 
 ## Project documents
 
@@ -27,6 +73,12 @@ work (`list_project_docs`, `read_project_doc`, and `write_project_doc` over Hezo
 [MCP server](/docs/mcp/hezo-mcp-server)). A document is referenced by its plain filename —
 for example `spec.md` — so links stay stable as the work evolves.
 
+Agents don't carry every document's full text on every run. Instead each run includes a
+**manifest** — a table of contents listing each document's filename, title, and when it
+last changed — and the agent opens the ones it needs with `read_project_doc`. So adding or
+updating a document immediately makes it discoverable to the whole team, without bloating
+anyone's prompt.
+
 ## Version history
 
 Every change to a document is versioned. The Documents page shows the full **revision
@@ -37,23 +89,56 @@ a spec evolved and roll back a bad edit without losing the thread.
 This **versioned-and-reversible** guarantee isn't limited to project documents. The same
 applies to **agent system prompts** — every edit, including the
 [learned rules the Coach adds](/docs/concepts/coach-and-self-improving-teams#every-change-is-reversible),
-is snapshotted and restorable from the agent's settings — and to
+is snapshotted and restorable from the agent's settings — to a team's
+[preferences](#team-preferences), and to
 [**skills**](/docs/concepts/skills#version-history--restore), your reusable cross-team
 know-how. Whatever your agents change, you can see what changed and put it back.
 
 ## Chatbox memory
 
-The CEO keeps a special, permanent document — its **chatbox memory** — so your standing
-preferences and guidelines carry across every conversation. Tell the CEO once how you like
-things done and it records the durable facts there, then reads them back on every turn. Live
-data such as project lists and rosters is deliberately *not* memorised — that's always read
-fresh from Hezo. See [Roles & the CEO](/docs/concepts/roles-and-coordination).
+The CEO keeps a single, permanent memory document — its **chatbox memory**, the file
+`chat-memory.md` — so your standing preferences and guidelines carry across every
+conversation. Its full contents are injected into **every** chat turn, so anything recorded
+there survives even after older messages scroll out of the conversation window.
 
-## Documents vs. the task summary
+Tell the CEO once how you like things done — "always run a plan past me before provisioning a
+team", "we deploy on Fridays", "default new services to TypeScript" — and it records the
+durable facts there, then reads them back on every turn. Live data such as project lists and
+rosters is deliberately *not* memorised — that's always read fresh from Hezo, so it can never
+go stale.
 
-Both are memory, at different scopes:
+You're not limited to dictating to the CEO. The chatbox memory is a document you can **read
+and edit yourself**: it lives in the
+[HQ](/docs/concepts/projects-and-teams#hq--the-home-team) project's documents (and is
+explained under **Settings → Chatbox**), so you can seed it with preferences up front or
+prune stale entries later. It's permanent — it can't be deleted. See
+[Roles & the CEO](/docs/concepts/roles-and-coordination).
 
-- A task's **progress summary** is the living checkpoint for *one task* — where that ticket
-  stands right now. See [Tasks, rules & summaries](/docs/concepts/tasks).
-- **Documents** are *project-wide* knowledge that many tasks and agents draw on — the spec,
-  the plan, the research.
+## Team preferences
+
+Where the chatbox memory steers the CEO, a team's **preferences** steer that team's workers.
+Preferences are free-form **custom instructions applied to every agent on the team** —
+house conventions, tone, standing do's and don'ts — set from the team's settings and injected
+in full into each agent's prompt on every run. They're the lighter-weight choice when the
+guidance applies to the whole roster rather than one role, and, like documents and system
+prompts, every edit is **versioned and restorable**.
+
+## Where each kind of knowledge goes
+
+All of the above is memory, but each piece has a natural home — putting knowledge in the
+right place is what keeps it findable and applied at the right moment:
+
+- **Where one ticket stands right now** → that task's **progress summary**.
+- **How a single ticket must be worked** (guardrails, required steps) → that task's
+  **rules**.
+- **What a ticket is and the domain context to do it** → that task's **description**.
+- **Project-wide knowledge many tasks draw on** (the spec, the plan, the research) →
+  a **project document**.
+- **Reusable, project-independent know-how** (how to use an MCP server, a release
+  checklist, a house style) → a **[skill](/docs/concepts/skills)**.
+- **A standing instruction for every agent on a team** → that team's **preferences**.
+- **Your durable preferences for how the CEO works with you** → the CEO's **chatbox
+  memory**.
+
+When in doubt, keep ticket-specific status in the summary, how-to-work constraints in the
+rules, and anything the wider team will need again in a document or a skill.

--- a/docs/concepts/roles-and-coordination.md
+++ b/docs/concepts/roles-and-coordination.md
@@ -90,6 +90,7 @@ every project, ticket, and roster.
 The chat is also the control surface for the things that are awkward to click through:
 scoping work, reorganising a team, or changing how an agent behaves. State what you want
 in plain language; the CEO proposes the change and asks you to approve anything that
-matters. Standing preferences you ask it to remember persist in the CEO's
-[chatbox memory](/docs/concepts/documents-and-memory#chatbox-memory), so you don't repeat
-yourself.
+matters. Standing preferences and guidelines you ask it to remember persist in the CEO's
+[chatbox memory](/docs/concepts/documents-and-memory#chatbox-memory) — a `chat-memory.md`
+document injected into every turn — so you don't repeat yourself. Just tell the CEO what to
+remember and it records it there; you can also read and edit that memory yourself.

--- a/docs/concepts/skills.md
+++ b/docs/concepts/skills.md
@@ -17,8 +17,12 @@ research write-ups.
 
 There is **one skills catalog for the whole instance**. A skill you add is available to
 every team's agents — you don't re-create it per project. Each skill is a markdown
-document with a name, a short description, and optional tags, and agents see a manifest of
-the available skills on every run so they know what they can reach for.
+document with a name, a short description, and optional tags. On every run agents are given
+a **manifest** of the available skills — each one's name and description, not its full body
+— so they know what they can reach for; an agent then loads a skill's full instructions
+on demand when it's relevant to the task. That manifest-plus-load-on-demand pattern is part
+of how Hezo gives agents [long-term memory](/docs/concepts/documents-and-memory#what-an-agent-carries-into-every-run)
+without bloating every prompt.
 
 ## Where skills come from
 

--- a/docs/concepts/tasks.md
+++ b/docs/concepts/tasks.md
@@ -17,16 +17,19 @@ cleanly between runs and between agents.
   agent needs to understand the work.
 - **Rules** — *how* the task should be worked: approach constraints, guardrails, or
   required workflows. For example: "run the full test suite before pushing", "consult
-  the architect before touching auth", or "don't edit database migrations". Rules are
-  put in front of the agent on every run, so they're the right place for
-  non-negotiables.
+  the architect before touching auth", or "don't edit database migrations". Set rules
+  when you want agents to follow specific guidelines on a task — they're the right place
+  for non-negotiables.
 - **Progress summary** — *where things stand*: a living checkpoint of what's been done
-  and what's left. Agents keep it up to date as they work, and you can edit it too.
-  When an agent returns to a task later, the summary lets it continue without re-reading
-  the whole thread.
+  and what's left. Agents keep it up to date as they work, and you can edit it too. It
+  lets an agent returning to a task continue without re-reading the whole thread.
 
-You can set rules and edit the summary yourself from the task view at any time, and so
-can the agents.
+All three travel with the task as its **long-term memory**: at the start of every run the
+agent is handed the description, the rules, and the latest progress summary **in full**, so
+work carries cleanly from one run to the next even when a different agent picks the ticket
+up. You can set the rules and edit the summary yourself from the task view at any time, and
+so can the agents. See [Documents & long-term memory](/docs/concepts/documents-and-memory)
+for how this fits the wider memory model.
 
 ## Comments and mentions
 
@@ -36,6 +39,23 @@ reasoning and results to the thread as they go, and significant changes (status,
 assignee, and the like) are recorded there automatically. You can attach files —
 screenshots, PDFs, or other references — to a task or a comment; see
 [Assets & previews](/docs/concepts/assets).
+
+## Catching up at the start of a run
+
+The thread isn't just a chat log — it's part of the task's memory. When an agent starts a
+run on a task, it doesn't only rely on the injected description, rules, and progress
+summary: it **reads the comment thread to catch up on what's currently happening** — what
+other agents have already done, the decisions and feedback so far, open questions, and
+anything you've added since it last looked. That's how an agent stays current on a ticket
+it shares with teammates and with you, rather than acting on a stale picture.
+
+When a run is triggered by an **@-mention**, or by a **reply** to one of the agent's own
+earlier comments, the triggering comment is put in front of the agent directly, so it acts
+on exactly the message that woke it.
+
+The practical upshot: keep discussion, decisions, and hand-offs on the ticket. Whatever
+lands in the thread is inherited by the next agent that picks the task up — so the
+conversation compounds instead of evaporating between runs.
 
 ## Review on completion
 


### PR DESCRIPTION
## What & why

The docs already touched on the individual pieces of agent memory (rules, progress summaries, skills, chatbox memory), but never tied them together or explained the key mechanic: **most of this context is assembled fresh and injected into the agent's prompt on every run**, so agents don't start cold. This PR updates the existing concept pages (no new page) to make that long-term-memory model explicit, with the right level of detail in each section.

The framing now distinguishes the two ways context reaches an agent — injected **in full** (rules, description, progress summary, team preferences, the CEO's chatbox memory) vs. surfaced **as a manifest** with the body loaded on demand (project documents, skills). All claims were verified against the implementation (`template-resolver.ts`, `agent-runner.ts`/`buildTaskPrompt`, `ceo-session-manager.ts`, the role templates, and the web settings surfaces).

## Changes

- **`concepts/documents-and-memory.md`** (the hub):
  - New **"What an agent carries into every run"** section — full vs. manifest injection, plus a summary table of every memory by scope and how it reaches the agent.
  - Documented the **project-docs manifest** (filename + title + last-updated date; full text via `read_project_doc`).
  - Expanded **Chatbox memory**: it's the file `chat-memory.md`, injected in full every turn; you save to it by telling the CEO *or* by editing it yourself (it lives in HQ's documents / **Settings → Chatbox**) and it's permanent.
  - New **Team preferences** section (custom instructions applied to every agent on a team, injected in full, versioned).
  - New **"Where each kind of knowledge goes"** decision guide.
- **`concepts/tasks.md`**: clarified that rules, description, and progress summary are injected **in full at the start of every run**, and added **"Catching up at the start of a run"** — agents read the comment thread (and, on a mention/reply wake, the triggering comment) to stay current on shared tickets.
- **`concepts/skills.md`**: made the manifest-plus-load-on-demand mechanism explicit and linked it to the memory model.
- **`concepts/roles-and-coordination.md`**: noted the CEO chatbox memory is `chat-memory.md`, injected every turn, and editable by the user directly.

## Verification

- Real `docs/` tree bundles cleanly (`bundle-docs.ts`: 31 docs) and the new content/headings are present in the CEO docs bundle.
- `docs-bundle.test.ts` + `docs-bundle-fs.test.ts` green (8/8).
- All added internal anchors resolve to real headings; the inbound `#version-history` and `#chatbox-memory` anchors are preserved.
- No MCP-tool/CLI/route changes, so generated reference surfaces are untouched (the pre-commit `build:docs` regenerated `mcp-api.md` byte-identically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nLJ7WRY6W6qZzNVcNRkPn

---
_Generated by [Claude Code](https://claude.ai/code/session_015nLJ7WRY6W6qZzNVcNRkPn)_