### PR TITLE
fix(web): brighten raw agent-run log text

### DIFF
--- a/packages/web/src/components/log-viewer.tsx
+++ b/packages/web/src/components/log-viewer.tsx
@@ -111,7 +111,7 @@ export function LogViewer({
 	const sizing = isExpanded ? 'flex-1 min-h-0' : heightClassName;
 	const bodyClassName = isFormatted
 		? `bg-[#0d1117] log-surface-dark text-text-1 ${sizing} overflow-y-auto p-3 text-sm leading-relaxed`
-		: `bg-[#0d1117] ${sizing} overflow-y-auto p-3 font-mono text-xs leading-relaxed`;
+		: `bg-[#0d1117] log-surface-dark ${sizing} overflow-y-auto p-3 font-mono text-xs leading-relaxed`;
 
 	const content = (
 		<>
@@ -203,7 +203,7 @@ export function LogViewer({
 					lines.map((line) => (
 						<div
 							key={line.id}
-							className={`whitespace-pre-wrap ${line.stream === 'stderr' ? 'text-danger' : 'text-text-2'}`}
+							className={`whitespace-pre-wrap ${line.stream === 'stderr' ? 'text-danger' : 'text-text-1'}`}
 						>
 							{line.text}
 						</div>

--- a/packages/web/test/formatted-log-view.test.tsx
+++ b/packages/web/test/formatted-log-view.test.tsx
@@ -65,9 +65,14 @@ test('run log defaults to the formatted view and toggles to raw via the icon but
 
 	// Switching to Raw shows the literal prefixed line.
 	await user.click(getByLabelText('Raw logs'));
-	expect((await findByTestId('run-log')).textContent).toContain(
-		'[tool] Bash(command=ls -la /tmp, description=list files)',
-	);
+	const rawBody = await findByTestId('run-log');
+	expect(rawBody.textContent).toContain('[tool] Bash(command=ls -la /tmp, description=list files)');
+	// Raw lines render bright (text-text-1) on the forced-dark terminal surface,
+	// not the dim text-text-2 that low-contrasts against #0d1117 in light mode.
+	expect(rawBody.className).toContain('log-surface-dark');
+	const rawLine = await findByText('[tool] Bash(command=ls -la /tmp, description=list files)');
+	expect(rawLine.className).toContain('text-text-1');
+	expect(rawLine.className).not.toContain('text-text-2');
 
 	// Switching back to Formatted hides the prefixes again.
 	await user.click(getByLabelText('Formatted view'));


### PR DESCRIPTION
## What

Raw agent-run log lines (the `[tool]` / `[tool-result]` prefixed view) rendered dim and low-contrast. This brightens them to a near-white on the dark terminal surface.

## Why

The raw log body sits on the always-dark `#0d1117` terminal background but, unlike the **formatted** view, never opted into the dark log palette (`log-surface-dark`). Its `text-text-*` tokens therefore resolved against the *active theme*:

- **Light mode:** stdout lines used `--text-2` = `oklch(0.46 …)` — a dark gray — on near-black → dim, muddy, hard to read (this is what the report screenshot showed).
- **Dark mode:** `text-text-2` is still a muted gray, not bright.

## Change

- Force the dark log palette on the raw surface (`log-surface-dark`), matching what the formatted view already does for the same `#0d1117` background — so colors resolve identically in light and dark mode.
- Render stdout lines with the palette's bright near-white `text-text-1` (`#e8e8e4`) instead of `text-text-2`.

As a bonus this also fixes latent light-mode contrast for `stderr` lines (`text-danger` → soft red `#f09595`) and the empty state on the dark surface. The fix is centralized in `LogViewer`, so it applies to every raw-log consumer (run comments, the execution page, and container logs).

## Test

Extended `formatted-log-view.test.tsx` (which already toggles into the raw view) to assert the raw surface carries `log-surface-dark` and stdout lines render with `text-text-1`, not the dim `text-text-2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114XctF1Qjb9X9C1e1MRok9

---
_Generated by [Claude Code](https://claude.ai/code/session_0114XctF1Qjb9X9C1e1MRok9)_