### PR TITLE
fix: log egress/SSH bind degradation at warn, not error

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -491,8 +491,11 @@ overrides the bind interface for both the egress proxy and the ssh-agent TCP bri
 Linux sets `0.0.0.0` and firewall-restricts the egress range (20000–29999) to the docker
 bridge. A boot-time preflight (`container-connectivity-preflight.ts`) starts a throwaway
 container, probes the MCP port and a bind-host listener in the egress range, and logs the
-exact firewall / `--container-bind-host` remedy when the path is blocked — non-fatal, so the
-web UI stays up to act on it.
+exact firewall / `--container-bind-host` remedy when the path is blocked. Severity tracks
+impact: `error` when the MCP server is unreachable (no tools load, runs hang), a non-fatal
+`warn` for the egress/SSH bind-host degradation (MCP works and agents still run — only
+proxied egress and git-over-SSH are affected). Either way it never gates startup, so the web
+UI stays up to act on it.
 
 For each request the proxy terminates TLS, matches placeholders **in the URL and headers
 only** (bodies are forwarded byte-for-byte — body substitution is intentionally absent),

--- a/docs/deployment/self-hosting.md
+++ b/docs/deployment/self-hosting.md
@@ -195,8 +195,10 @@ CEO chat reports its tools "aren't available"**:
 
 Hezo runs a **boot-time connectivity check** — it starts a throwaway container, has it call
 back to the host, and logs the exact firewall / `--container-bind-host` fix if the path is
-blocked, so you see the problem at startup instead of as a stalled agent run. To verify by
-hand:
+blocked, so you see the problem at startup instead of as a stalled agent run. An unreachable
+MCP server is logged as an error (no tools load); the egress/SSH bind-host case is a non-fatal
+**warning** — your agents still run, only proxied egress and git-over-SSH are affected. To
+verify by hand:
 
 ```sh
 docker run --rm --add-host=host.docker.internal:host-gateway curlimages/curl \

--- a/packages/server/src/services/container-connectivity-preflight.ts
+++ b/packages/server/src/services/container-connectivity-preflight.ts
@@ -77,11 +77,25 @@ const FAILURE_HEADER = [
 ];
 
 /**
- * Operator-actionable guidance for a failed connectivity check, logged at boot.
- * Mirrors the Docker/port preflights: a one-line diagnosis, then the exact
- * remedy (the firewall rule, or the `--container-bind-host` flag), plus a docs
- * pointer. Never surfaces `HEZO_SKIP_DOCKER` / the opt-out env (those hide the
- * symptom rather than fix it).
+ * Log severity for a non-ok outcome. `mcp-unreachable` is fatal to agent work —
+ * no Hezo tools load, so runs and the CEO chat hang — so it is logged at `error`.
+ * The bind-host cases are a degradation: the MCP server is reachable and agents
+ * run; only proxied egress, credentialed calls, and git-over-SSH are affected, so
+ * they are logged at `warn`.
+ */
+export function connectivitySeverity(
+	outcome: Exclude<ConnectivityOutcome, 'ok'>,
+): 'error' | 'warn' {
+	return outcome === 'mcp-unreachable' ? 'error' : 'warn';
+}
+
+/**
+ * Operator-actionable guidance for a non-ok connectivity check, logged at boot.
+ * `mcp-unreachable` is a fatal failure (no tools load); the bind-host cases are a
+ * degradation (MCP works, agents run — only proxied egress / git-over-SSH break),
+ * worded accordingly. A one-line diagnosis, then the exact remedy (the firewall
+ * rule, or the `--container-bind-host` flag), plus a docs pointer. Never surfaces
+ * `HEZO_SKIP_DOCKER` / the opt-out env (those hide the symptom rather than fix it).
  */
 export function formatContainerConnectivityMessage(
 	outcome: Exclude<ConnectivityOutcome, 'ok'>,
@@ -113,17 +127,18 @@ export function formatContainerConnectivityMessage(
 
 	if (outcome === 'bind-loopback') {
 		return [
-			...FAILURE_HEADER,
-			'The MCP server is reachable, but the egress proxy and SSH bridge bind to',
-			`${containerBindHost} (loopback), which a container on native-Linux Docker cannot`,
-			'reach via host.docker.internal. Outbound API calls, credentialed requests, and',
-			'git-over-SSH will fail even though the MCP tools load.',
+			'Egress proxy / SSH bridge unreachable from agent containers (degraded, not fatal).',
 			'',
-			'Bind them to all interfaces, then firewall-restrict the range to the bridge:',
+			'The MCP server is reachable and agents run, but the egress proxy and SSH bridge',
+			`bind to ${containerBindHost} (loopback), which a container on native-Linux Docker`,
+			'cannot reach via host.docker.internal. Proxied API calls, credentialed requests,',
+			'and git-over-SSH will fail; direct LLM providers (no proxy) are unaffected — safe',
+			'to ignore if that is all you use.',
+			'',
+			'To enable them, bind a container-reachable interface (then firewall-restrict it):',
 			'',
 			'  HEZO_CONTAINER_BIND_HOST=0.0.0.0 hezo      # or --container-bind-host 0.0.0.0',
 			'  sudo ufw allow in on docker0 to any port 20000:29999 proto tcp',
-			'  sudo ufw reload',
 			'',
 			`More detail: ${NETWORKING_DOCS_URL}`,
 		].join('\n');
@@ -131,10 +146,12 @@ export function formatContainerConnectivityMessage(
 
 	// bind-firewalled: the bind host is non-loopback but the range is still blocked.
 	return [
-		...FAILURE_HEADER,
-		'The MCP server is reachable, but a container could not reach the egress proxy /',
-		`SSH bridge port range on the host (bound to ${containerBindHost}). Outbound API`,
-		'calls, credentialed requests, and git-over-SSH will fail.',
+		'Egress proxy / SSH bridge unreachable from agent containers (degraded, not fatal).',
+		'',
+		'The MCP server is reachable and agents run, but a container could not reach the egress',
+		`proxy / SSH bridge port range on the host (bound to ${containerBindHost}). Proxied API`,
+		'calls, credentialed requests, and git-over-SSH will fail; direct LLM providers (no',
+		'proxy) are unaffected — safe to ignore if that is all you use.',
 		'',
 		'Open the Docker bridge to the host for the egress range:',
 		'',
@@ -309,12 +326,15 @@ export async function checkContainerToHostConnectivity(
 			log.info('container→host connectivity OK (MCP + egress bridge reachable from a container)');
 			return outcome;
 		}
-		log.error(
-			`\n${formatContainerConnectivityMessage(outcome, {
-				serverPort: deps.serverPort,
-				containerBindHost: deps.containerBindHost,
-			})}\n`,
-		);
+		// Severity tracks impact: mcp-unreachable means no tools load (error); the
+		// bind-host cases are a degradation — MCP works and agents run, only proxied
+		// egress / git-over-SSH are affected (warn).
+		const message = `\n${formatContainerConnectivityMessage(outcome, {
+			serverPort: deps.serverPort,
+			containerBindHost: deps.containerBindHost,
+		})}\n`;
+		if (connectivitySeverity(outcome) === 'error') log.error(message);
+		else log.warn(message);
 		return outcome;
 	} catch (err) {
 		// Diagnostics must never break startup. If the probe machinery itself

--- a/packages/server/test/container-connectivity-preflight.test.ts
+++ b/packages/server/test/container-connectivity-preflight.test.ts
@@ -5,6 +5,7 @@ import {
 	type ConnectivityProbeResult,
 	checkContainerToHostConnectivity,
 	classifyConnectivity,
+	connectivitySeverity,
 	formatContainerConnectivityMessage,
 	isLoopbackHost,
 	NETWORKING_DOCS_URL,
@@ -46,6 +47,16 @@ describe('classifyConnectivity', () => {
 	});
 	it('blames the firewall when the bind host is non-loopback but still unreachable', () => {
 		expect(classifyConnectivity(BIND_DOWN, '0.0.0.0')).toBe('bind-firewalled');
+	});
+});
+
+describe('connectivitySeverity', () => {
+	it('is error only for the fully-broken mcp-unreachable case', () => {
+		expect(connectivitySeverity('mcp-unreachable')).toBe('error');
+	});
+	it('is warn for the bind-host degradations (MCP works, agents still run)', () => {
+		expect(connectivitySeverity('bind-loopback')).toBe('warn');
+		expect(connectivitySeverity('bind-firewalled')).toBe('warn');
 	});
 });
 
@@ -100,6 +111,10 @@ describe('formatContainerConnectivityMessage', () => {
 		const msg = formatContainerConnectivityMessage('bind-loopback', opts);
 		expect(msg).toContain('--container-bind-host 0.0.0.0');
 		expect(msg).toContain('20000:29999');
+		// Degradation framing, not the fatal "produce nothing" of mcp-unreachable.
+		expect(msg).toContain('direct LLM providers');
+		expect(msg).toContain('safe');
+		expect(msg).not.toContain('produce nothing');
 	});
 
 	it('points at the firewall (egress range) when the bind host is already non-loopback', () => {
@@ -109,6 +124,20 @@ describe('formatContainerConnectivityMessage', () => {
 		});
 		expect(msg).toContain('20000:29999');
 		expect(msg).not.toContain('--container-bind-host');
+		expect(msg).toContain('direct LLM providers');
+		expect(msg).not.toContain('produce nothing');
+	});
+
+	it('frames mcp-unreachable as fatal and the bind cases as non-fatal degradations', () => {
+		expect(formatContainerConnectivityMessage('mcp-unreachable', opts)).toContain(
+			'hang with no tools',
+		);
+		for (const outcome of ['bind-loopback', 'bind-firewalled'] as const) {
+			const msg = formatContainerConnectivityMessage(outcome, opts);
+			expect(msg).toContain('degraded');
+			expect(msg).toContain('agents run');
+			expect(msg).not.toContain('produce nothing');
+		}
 	});
 
 	it('honours a custom --port in the firewall rule', () => {
@@ -138,11 +167,14 @@ describe('checkContainerToHostConnectivity', () => {
 		env: {} as NodeJS.ProcessEnv,
 	};
 
-	// The orchestrator logs its (multi-line) guidance on the failure path. Spy on
-	// the logger so a green run stays quiet and so we can assert it actually fired.
+	// The orchestrator logs its (multi-line) guidance on the non-ok path. Spy on the
+	// logger so a green run stays quiet and so we can assert which level fired:
+	// error for the fatal mcp-unreachable case, warn for the bind-host degradations.
 	let errorSpy: ReturnType<typeof vi.spyOn>;
+	let warnSpy: ReturnType<typeof vi.spyOn>;
 	beforeEach(() => {
 		errorSpy = vi.spyOn(Logger.prototype, 'error').mockImplementation(() => {});
+		warnSpy = vi.spyOn(Logger.prototype, 'warn').mockImplementation(() => {});
 		vi.spyOn(Logger.prototype, 'info').mockImplementation(() => {});
 	});
 	afterEach(() => {
@@ -178,32 +210,38 @@ describe('checkContainerToHostConnectivity', () => {
 		});
 		expect(outcome).toBe('ok');
 		expect(errorSpy).not.toHaveBeenCalled();
+		expect(warnSpy).not.toHaveBeenCalled();
 	});
 
-	it('classifies a blocked MCP port as mcp-unreachable and logs guidance', async () => {
+	it('logs mcp-unreachable at error (fatal — no tools load)', async () => {
 		const outcome = await checkContainerToHostConnectivity({
 			...base,
 			probe: async () => MCP_DOWN,
 		});
 		expect(outcome).toBe('mcp-unreachable');
 		expect(errorSpy).toHaveBeenCalled();
+		expect(warnSpy).not.toHaveBeenCalled();
 	});
 
-	it('classifies a loopback bind (default host) as bind-loopback', async () => {
+	it('logs a loopback bind at warn (degraded — MCP works, agents run)', async () => {
 		const outcome = await checkContainerToHostConnectivity({
 			...base,
 			probe: async () => BIND_DOWN,
 		});
 		expect(outcome).toBe('bind-loopback');
+		expect(warnSpy).toHaveBeenCalled();
+		expect(errorSpy).not.toHaveBeenCalled();
 	});
 
-	it('classifies an unreachable non-loopback bind as bind-firewalled', async () => {
+	it('logs an unreachable non-loopback bind at warn (degraded)', async () => {
 		const outcome = await checkContainerToHostConnectivity({
 			...base,
 			containerBindHost: '0.0.0.0',
 			probe: async () => BIND_DOWN,
 		});
 		expect(outcome).toBe('bind-firewalled');
+		expect(warnSpy).toHaveBeenCalled();
+		expect(errorSpy).not.toHaveBeenCalled();
 	});
 
 	it('retries a transient failure before settling on the result', async () => {


### PR DESCRIPTION
## Problem

The container→host connectivity preflight added in #426 logs **every** non-ok outcome at `[error]`, behind a shared header that says agents *"hang with no tools and produce nothing."* That's only true for `mcp-unreachable`.

When the **MCP server is reachable** but the egress proxy / SSH bridge are loopback-bound (operator hasn't set `HEZO_CONTAINER_BIND_HOST=0.0.0.0` yet), agents run fine — direct providers like DeepSeek work, the CEO chat loads its tools — and only **proxied egress, credentialed calls, and git-over-SSH** are affected. Yet the operator gets a 20-line red `[error]` block on every boot, whose own body even admits *"even though the MCP tools load."* Disproportionate, and easy to mistake for a hard failure.

(Surfaced in production: a native-Linux deploy that picked up the #426 build logged this `[error]` while runs were working.)

## Change

Severity now tracks impact:

| Outcome | Before | After |
|---|---|---|
| `mcp-unreachable` (no tools load, runs hang) | `error` | **`error`** (unchanged, full block) |
| `bind-loopback` / `bind-firewalled` (MCP works, only egress/SSH degraded) | `error` | **`warn`** (concise, degradation-framed) |

- New `connectivitySeverity(outcome)` → `'error' | 'warn'`; the orchestrator routes its log call through it.
- The two bind-case messages are reworded: dropped the "produce nothing" framing, added that **direct LLM providers (no proxy) are unaffected — safe to ignore if that's all you use**, kept the exact `--container-bind-host` / `ufw` fix + docs link.
- Detection/classification (`classifyConnectivity`, the probe) is untouched.

## Tests

- `connectivitySeverity` unit test (error for `mcp-unreachable`; warn for both bind cases).
- Orchestrator tests now spy on `warn` *and* `error` and assert the right level fires per outcome (and neither on `ok`); the message tests assert the degradation framing and that the bind cases no longer say "produce nothing".
- `cd packages/server && bunx vitest run test/container-connectivity-preflight.test.ts` → 24 passing; typecheck + biome clean; `docs-bundle` green.

Docs updated to match (`.dev/architecture.md`, `docs/deployment/self-hosting.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mzi3RcgoHFWBz4Kvu3VLUh

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mzi3RcgoHFWBz4Kvu3VLUh)_