### PR TITLE
feat: live CEO processing dots in header + project rail updates on create

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -672,7 +672,13 @@ server state. Tailwind + Radix UI primitives (shadcn-style) under `components/ui
 events over WebSocket (UUID-keyed rooms), and the client **invalidates the matching query
 keys** to refetch. There is no client-side local query engine. The hard rule (`AGENTS.md`
 › Slugs vs UUIDs): **query keys use the route-param slug**, WebSocket rooms use UUIDs, and
-`useWebSocket` takes both — mixing them silently breaks realtime updates.
+`useWebSocket` takes both — mixing them silently breaks realtime updates. Project
+**creation** is the exception to the per-team room model: a brand-new project lands in a
+team whose `team:<uuid>` room no client has joined yet, so creation also emits a
+payload-free `ProjectsChanged` signal on the global `projects:global` room (which every
+shell watches). Clients react by refetching the per-caller-authorized project index, so the
+left project rail updates live — for the dialog, the CEO's `create_project`, and other
+sessions alike — without a row on the shared room leaking a project a user can't see.
 
 **Mutations** (three strategies, by shape — see `AGENTS.md` › Web frontend mutations):
 **optimistic + rollback** (default for field edits/toggles/reactions, via

--- a/packages/server/src/lib/broadcast.ts
+++ b/packages/server/src/lib/broadcast.ts
@@ -62,6 +62,21 @@ export function broadcastEvent(
 	wsManager.broadcast(room, { type, ...data });
 }
 
+/**
+ * Signal the global project index changed (a project was created) so every
+ * connected shell refetches `/api/projects` and the project rail updates live.
+ *
+ * A new project lands in a brand-new team whose `team:<id>` room no client has
+ * joined yet, so the per-team `projects`-INSERT broadcast never reaches the
+ * rail. This fires on the global `projects:global` room — which every shell
+ * watches — carrying no row data (the index is authorized per caller, so a row
+ * here would leak projects a user can't see; clients refetch instead).
+ */
+export function broadcastProjectsChanged(wsManager: WebSocketManager | undefined): void {
+	if (!wsManager) return;
+	wsManager.broadcast(wsRoom.projects(), { type: WsMessageType.ProjectsChanged });
+}
+
 export async function broadcastProjectUpdate(
 	db: PGlite,
 	wsManager: WebSocketManager | undefined,

--- a/packages/server/src/services/project-create.ts
+++ b/packages/server/src/services/project-create.ts
@@ -10,7 +10,7 @@ import {
 } from '@hezo/shared';
 import type { DomainEventBus } from '../events/bus';
 import { trackBackground } from '../lib/background';
-import { broadcastRowChange } from '../lib/broadcast';
+import { broadcastProjectsChanged, broadcastRowChange } from '../lib/broadcast';
 import { toProjectTaskPrefix, toSlug, uniqueSlug } from '../lib/slug';
 import { withTransaction } from '../lib/sql';
 import { allocateTaskIdentifier } from '../lib/task-identifier';
@@ -559,6 +559,11 @@ export async function createProjectWithTeam(
 		if (coherenceRow) {
 			broadcastRowChange(deps.wsManager, wsRoom.team(team.id), 'tasks', 'INSERT', coherenceRow);
 		}
+		// The new team's room above is one no shell has joined yet, so the rail
+		// can't learn of the project from it. Signal the global project index so
+		// every connected shell refetches and the project appears in the rail at
+		// once — covers the dialog, the CEO's create_project, and other sessions.
+		broadcastProjectsChanged(deps.wsManager);
 	}
 
 	if (coherenceTaskId) {

--- a/packages/server/src/services/ws-subscribe-handler.ts
+++ b/packages/server/src/services/ws-subscribe-handler.ts
@@ -39,6 +39,15 @@ export async function handleWsSubscribe(
 		return;
 	}
 
+	// The single global project-index room. Its messages carry only an "index
+	// changed" signal (no row data), and the refetch they trigger
+	// (`GET /api/projects`) is itself authorized per team, so any authenticated
+	// socket may watch it without leaking a project it can't see.
+	if (room === wsRoom.projects()) {
+		deps.wsManager.subscribe(ws, room);
+		return;
+	}
+
 	const teamMatch = room.match(/^team:(.+)$/);
 	if (teamMatch) {
 		const allowed = await deps.canAccessTeam(ws.data.auth, teamMatch[1]);

--- a/packages/server/test/project-create-broadcast.test.ts
+++ b/packages/server/test/project-create-broadcast.test.ts
@@ -1,0 +1,81 @@
+import { WsMessageType, wsRoom } from '@hezo/shared';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { WebSocketManager, type WsEvent } from '../src/services/ws';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp } from './helpers/app';
+
+interface CapturedBroadcast {
+	room: string;
+	event: WsEvent;
+}
+
+// A project is created in a brand-new team whose `team:<id>` room no shell has
+// joined yet, so the per-team `projects`-INSERT broadcast can't reach the rail.
+// Creation must additionally signal the global project-index room so every
+// connected shell refetches `/api/projects` and the project appears at once.
+describe('project creation signals the global project-index room', () => {
+	let ctx: Awaited<ReturnType<typeof createTestApp>>;
+	let blankTemplateId: string;
+	let captured: CapturedBroadcast[];
+	let broadcastSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeAll(async () => {
+		ctx = await createTestApp();
+		const typesRes = await ctx.app.request('/api/team-templates', {
+			headers: authHeader(ctx.token),
+		});
+		blankTemplateId = (await typesRes.json()).data.find(
+			(t: { name: string }) => t.name === 'Blank',
+		).id;
+
+		captured = [];
+		broadcastSpy = vi.spyOn(WebSocketManager.prototype, 'broadcast').mockImplementation(function (
+			this: WebSocketManager,
+			room: string,
+			event: WsEvent,
+		) {
+			captured.push({ room, event });
+		});
+	});
+
+	afterAll(async () => {
+		broadcastSpy.mockRestore();
+		await safeClose(ctx.db);
+	});
+
+	it('broadcasts a no-payload ProjectsChanged signal to projects:global on create', async () => {
+		captured.length = 0;
+
+		const res = await ctx.app.request('/api/projects', {
+			method: 'POST',
+			headers: { ...authHeader(ctx.token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				name: 'Rail Signal Co',
+				description: 'verifies the global rail signal',
+				template_id: blankTemplateId,
+			}),
+		});
+		expect(res.status).toBe(201);
+		const project = (await res.json()).data;
+
+		const signals = captured.filter(
+			(c) => c.room === wsRoom.projects() && c.event.type === WsMessageType.ProjectsChanged,
+		);
+		expect(signals).toHaveLength(1);
+		// No row data on the global room — the index is authorized per caller, so a
+		// row here would leak a project a user can't see. Just the type.
+		expect(Object.keys(signals[0].event)).toEqual(['type']);
+
+		// The team-scoped INSERT still fires (regression guard) — it drives the
+		// already-subscribed team members' other views; the global signal is what
+		// reaches a shell that hasn't joined the new team's room.
+		const teamInsert = captured.filter(
+			(c) =>
+				c.room === wsRoom.team(project.team_id) &&
+				c.event.type === WsMessageType.RowChange &&
+				c.event.table === 'projects' &&
+				c.event.action === 'INSERT',
+		);
+		expect(teamInsert).toHaveLength(1);
+	});
+});

--- a/packages/server/test/ws-subscribe-handler.test.ts
+++ b/packages/server/test/ws-subscribe-handler.test.ts
@@ -226,6 +226,25 @@ describe('handleWsSubscribe', () => {
 		});
 	});
 
+	it('subscribes any authenticated socket to the global projects room', async () => {
+		// A board user who is a member of no team must still watch the project
+		// index: the signal carries no row data and the refetch it triggers is
+		// authorized per team, so this can't leak a project they can't see.
+		const user = await db.query<{ id: string }>(
+			"INSERT INTO users (display_name) VALUES ('U') RETURNING id",
+		);
+		const ws = createMockWs({ type: AuthType.Admin, userId: user.rows[0].id });
+
+		await handleWsSubscribe(ws, wsRoom.projects(), deps());
+
+		expect(wsManager.getRoomSize(wsRoom.projects())).toBe(1);
+
+		// A live signal reaches the now-subscribed socket.
+		wsManager.broadcast(wsRoom.projects(), { type: WsMessageType.ProjectsChanged });
+		expect(ws._sent).toHaveLength(1);
+		expect(JSON.parse(ws._sent[0]).type).toBe(WsMessageType.ProjectsChanged);
+	});
+
 	it('subscribes to container-logs and replays buffered logs for that room', async () => {
 		const { userId, projectId } = await seedTeamWithProject(db);
 		const ws = createMockWs({ type: AuthType.Admin, userId });

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -79,6 +79,15 @@ export const wsRoom = {
 	 * progress is broadcast here once and every project page filters by image.
 	 */
 	imageBuilds: () => 'image-builds',
+	/**
+	 * The single global project-index room. A project is created in a brand-new
+	 * team whose `team:<id>` room no client has joined yet (and whose row isn't in
+	 * the cached index to resolve a slug from), so a project-INSERT on the team
+	 * room can't reach the rail live. The "the index changed" signal is broadcast
+	 * here instead; every shell subscribes so the project rail stays current the
+	 * moment any project is created — by the dialog, the CEO, or another session.
+	 */
+	projects: () => 'projects:global',
 } as const;
 
 /**

--- a/packages/shared/src/types/websocket.ts
+++ b/packages/shared/src/types/websocket.ts
@@ -10,6 +10,7 @@ export enum WsMessageType {
 	CeoMessageStart = 'ceo_message_start',
 	CeoMessageDelta = 'ceo_message_delta',
 	CeoMessageComplete = 'ceo_message_complete',
+	ProjectsChanged = 'projects_changed',
 	Error = 'error',
 }
 
@@ -79,6 +80,18 @@ export interface WsErrorMessage {
 }
 
 /**
+ * The instance-wide project index changed (a project was created). Broadcast to
+ * the global `projects:global` room with no row payload: the project list is
+ * authorized per-caller (`GET /api/projects` filters by team membership), so a
+ * full row on a room every client watches would leak projects a user can't see.
+ * Clients react by refetching the index, which returns only their visible
+ * projects — keeping the project rail live without exposing anything.
+ */
+export interface WsProjectsChangedMessage {
+	type: WsMessageType.ProjectsChanged;
+}
+
+/**
  * A new CEO chat message row was created. Sent for assistant replies as they
  * begin streaming AND for user messages from any channel, so every mirrored
  * surface (web, future Telegram/WhatsApp) renders the full thread live.
@@ -119,6 +132,7 @@ export type WsServerMessage =
 	| WsCeoMessageStartMessage
 	| WsCeoMessageDeltaMessage
 	| WsCeoMessageCompleteMessage
+	| WsProjectsChangedMessage
 	| WsConnectedMessage
 	| WsErrorMessage;
 

--- a/packages/web/src/components/ceo-chat/ceo-chat-widget.tsx
+++ b/packages/web/src/components/ceo-chat/ceo-chat-widget.tsx
@@ -155,6 +155,16 @@ export function CeoChatWidget() {
 						<span className="rounded-sm border border-border px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-text-2">
 							{HQ_PROJECT_NAME}
 						</span>
+						{/* Mirror the in-thread typing dots up here so the "CEO is working"
+						    signal stays visible even when the latest reply is scrolled out of
+						    view. Decorative only — the in-thread indicator carries the aria
+						    live-region announcement, so this stays aria-hidden to avoid a
+						    duplicate read. */}
+						{streaming && (
+							<span data-testid="ceo-chat-header-dots" className="pl-0.5">
+								<Dots />
+							</span>
+						)}
 					</div>
 					<div className="flex items-center gap-1">
 						{/* Copy the full transcript to the clipboard. Disabled until there's

--- a/packages/web/src/hooks/use-websocket.ts
+++ b/packages/web/src/hooks/use-websocket.ts
@@ -208,4 +208,23 @@ export function useShellWebSockets(teams: TeamRoom[] | undefined): void {
 			}
 		};
 	}, [teamsKey, queryClient, joinRoom, leaveRoom, subscribe]);
+
+	// The global project-index room is independent of team membership: a freshly
+	// created project lands in a team whose room this client hasn't joined (and
+	// whose row isn't in the cached index yet to resolve a slug from), so the
+	// team-scoped path above can't surface it. Subscribe here unconditionally so
+	// the index — and with it the project rail — refetches the instant any
+	// project is created, whether by the dialog, the CEO, or another session.
+	useEffect(() => {
+		const room = wsRoom.projects();
+		joinRoom(room);
+		const unsubscribe = subscribe(WsMessageType.ProjectsChanged, () => {
+			queryClient.invalidateQueries({ queryKey: queryKeys.projects.all() });
+			queryClient.invalidateQueries({ queryKey: queryKeys.projectIntakes() });
+		});
+		return () => {
+			unsubscribe();
+			leaveRoom(room);
+		};
+	}, [queryClient, joinRoom, leaveRoom, subscribe]);
 }

--- a/packages/web/test/ceo-chat.test.tsx
+++ b/packages/web/test/ceo-chat.test.tsx
@@ -204,6 +204,70 @@ test('a completed reply shows no typing dots', async () => {
 	expect(queryByTestId('ceo-chat-typing')).toBeNull();
 });
 
+// The header mirrors the in-thread "still working" dots up next to the CEO
+// label, so the processing signal stays visible even when the latest reply has
+// scrolled out of view. It tracks the same streaming state as the in-thread
+// indicators, whether or not any text has landed yet.
+test('the header shows processing dots while the CEO is composing with no text yet', async () => {
+	const { findByTestId } = await renderApp({ initialPath: '/home' });
+	(await findByTestId('ceo-chat-launcher')).click();
+	await findByTestId('ceo-chat-panel');
+
+	seedConversation([
+		{
+			id: 'a1',
+			role: 'assistant',
+			channel: 'web',
+			status: 'streaming',
+			content: '',
+			created_at: now(),
+		},
+	]);
+
+	expect(await findByTestId('ceo-chat-header-dots')).toBeTruthy();
+});
+
+test('the header keeps the processing dots while a reply is still streaming text', async () => {
+	const { findByTestId, findByText } = await renderApp({ initialPath: '/home' });
+	(await findByTestId('ceo-chat-launcher')).click();
+	await findByTestId('ceo-chat-panel');
+
+	seedConversation([
+		{
+			id: 'a1',
+			role: 'assistant',
+			channel: 'web',
+			status: 'streaming',
+			content: 'Working on it',
+			created_at: now(),
+		},
+	]);
+
+	// Both the in-thread trailing dots and the header dots are present mid-stream.
+	expect(await findByText('Working on it')).toBeTruthy();
+	expect(await findByTestId('ceo-chat-header-dots')).toBeTruthy();
+});
+
+test('the header drops the processing dots once the reply settles', async () => {
+	const { findByTestId, findByText, queryByTestId } = await renderApp({ initialPath: '/home' });
+	(await findByTestId('ceo-chat-launcher')).click();
+	await findByTestId('ceo-chat-panel');
+
+	seedConversation([
+		{
+			id: 'a1',
+			role: 'assistant',
+			channel: 'web',
+			status: 'complete',
+			content: 'All done',
+			created_at: now(),
+		},
+	]);
+
+	await findByText('All done');
+	expect(queryByTestId('ceo-chat-header-dots')).toBeNull();
+});
+
 test('a CEO reply renders its markdown as formatted HTML, not raw text', async () => {
 	const { findByTestId } = await renderApp({ initialPath: '/home' });
 	(await findByTestId('ceo-chat-launcher')).click();


### PR DESCRIPTION
## Summary

Two realtime-visibility fixes to the app shell, both from the same screenshots:

### 1. CEO chat — processing dots in the header

While the CEO is composing a reply, the three pulsing "still working" dots now also appear at the top of the chat panel, right next to the **CEO / HQ** header label — not just in the message thread. This keeps the processing signal visible even when the latest reply has scrolled out of view.

- Tracks the same `streaming` state the in-thread indicators already use.
- Decorative only: the in-thread `TypingIndicator` / `StreamingDots` carry the aria live-region announcement, so the header dots stay `aria-hidden` to avoid a duplicate screen-reader read.

### 2. Project rail — new project appears immediately

A newly created project now shows up in the left project rail at once, with no manual refresh.

**The bug:** project creation broadcasts a `projects` INSERT on the backing team's `team:<id>` WebSocket room. But a brand-new team's room is one **no shell has joined yet** (rooms are derived from the cached project index, which doesn't contain the new project), and even if the event arrived, the row can't be resolved to a known project slug — so the invalidation is skipped. The rail therefore never learned about projects created by **the CEO's `create_project`**, an agent, or **another browser session**. (The local create-project dialog appeared to work only because its own mutation `onSuccess` invalidates the list client-side.)

**The fix:** a global `projects:global` signal room, mirroring the existing `ceo:global` / `image-builds` pattern.
- On creation, the server also emits a **payload-free** `ProjectsChanged` message on `projects:global`. No row data — the project index is authorized per caller (`GET /api/projects` filters by team membership), so a row on a room every client watches would leak projects a user can't see.
- Any authenticated socket may join the room (`ws-subscribe-handler`); the refetch it triggers is itself per-team authorized.
- Every shell subscribes via `useShellWebSockets` and, on `ProjectsChanged`, refetches the project index — so the rail updates live.

Both creation paths are covered, since `POST /api/projects` and the CEO's `create_project` MCP tool both go through `createProjectWithTeam`.

## Tests

- **Server** — `project-create-broadcast.test.ts`: creating a project emits exactly one no-payload `ProjectsChanged` on `projects:global` (and still fires the team-room INSERT). `ws-subscribe-handler.test.ts`: any authenticated socket can join the global projects room and receives the signal.
- **Web** — `ceo-chat.test.tsx`: header dots render while streaming (with and without text) and disappear once the reply settles.

All affected suites pass; typecheck and lint clean. `.dev/architecture.md` updated to describe the new realtime path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011CiYrAyUKUZqTCxzyn68nM)_