### PR TITLE
fix: accept user-facing IDs (task identifier / agent slug) in ID-accepting MCP tools

### DIFF
--- a/docs/reference/mcp-api.md
+++ b/docs/reference/mcp-api.md
@@ -472,7 +472,7 @@ Read an agent's system prompt. Accessible by any agent or the admin in the same 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
 | `project` | `string` | No | Project slug or ID. Omit to use the project your run is already in; instance agents (CEO/Coach) must name the project to act in. |
-| `agent_id` | `string` | Yes | Target agent member ID |
+| `agent_id` | `string` | Yes | Target agent — its slug (e.g. "engineer") or member ID |
 | `placeholders` | `boolean` | No | When true (default) substitutes `{{…}}` placeholders with real team/team values. When false returns the raw stored template — needed when reading before update_agent_system_prompt so placeholders survive the round-trip. |
 
 **Returns:** `{ title, slug, system_prompt }`, or `{ error }` if the agent is not in the team. By default `{{…}}` placeholders are resolved; pass `placeholders: false` for the raw stored template.
@@ -507,7 +507,7 @@ Apply a system prompt change for an agent. Callable by the Coach agent (for afte
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
 | `project` | `string` | No | Project slug or ID. Omit to use the project your run is already in; instance agents (CEO/Coach) must name the project to act in. |
-| `agent_id` | `string` | Yes | Target agent member ID |
+| `agent_id` | `string` | Yes | Target agent — its slug (e.g. "engineer") or member ID |
 | `new_system_prompt` | `string` | Yes | The full updated system prompt |
 | `change_summary` | `string` | Yes | Summary of what changed and why |
 
@@ -526,7 +526,7 @@ Save a short human-readable summary for an agent (≤1000 chars, single paragrap
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
 | `project` | `string` | No | Project slug or ID. Omit to use the project your run is already in; instance agents (CEO/Coach) must name the project to act in. |
-| `agent_id` | `string` | Yes | Target agent member ID |
+| `agent_id` | `string` | Yes | Target agent — its slug (e.g. "engineer") or member ID |
 | `summary` | `string` | Yes | The new summary, ≤1000 chars |
 
 **Returns:** `{ updated: true }`, or `{ error }` (summary empty, over 1000 chars, or agent not in team).
@@ -561,7 +561,7 @@ Save the team-relationships context for an agent (≤6000 chars, plain prose, se
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
 | `project` | `string` | No | Project slug or ID. Omit to use the project your run is already in; instance agents (CEO/Coach) must name the project to act in. |
-| `agent_id` | `string` | Yes | Target agent member ID |
+| `agent_id` | `string` | Yes | Target agent — its slug (e.g. "engineer") or member ID |
 | `content` | `string` | Yes | The new team_context, ≤6000 chars |
 
 **Returns:** `{ updated: true }`, or `{ error }` (content empty, over 6000 chars, or agent not in team).
@@ -579,7 +579,7 @@ Read an agent's stored team-relationships context. Useful for the Captain when r
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
 | `project` | `string` | No | Project slug or ID. Omit to use the project your run is already in; instance agents (CEO/Coach) must name the project to act in. |
-| `agent_id` | `string` | Yes | Target agent member ID |
+| `agent_id` | `string` | Yes | Target agent — its slug (e.g. "engineer") or member ID |
 
 **Returns:** `{ title, slug, team_context }`, or `{ error }` if the agent is not in the team.
 

--- a/docs/reference/mcp-api.md
+++ b/docs/reference/mcp-api.md
@@ -419,7 +419,7 @@ File a new hire proposal. Callable by a team Captain (for its own team) or the C
 | `weekly_budget_cents` | `number` | No | Weekly budget in cents |
 | `monthly_budget_cents` | `number` | No | Monthly budget in cents |
 | `touches_code` | `boolean` | No | Whether this agent reads/writes repo code |
-| `task_id` | `string` | No | Optional originating ticket id to link the proposal to |
+| `task_id` | `string` | No | Optional originating ticket to link the proposal to — a task identifier (e.g. "HM-1") or UUID |
 
 **Returns:** `{ approval_id, status, payload }` for the new pending hire approval, or `{ error }` if the spec is rejected (missing title, invalid effort/budget, reserved or duplicate slug, or an unknown `task_id`).
 

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -1354,7 +1354,9 @@ export function registerTools(
 			task_id: z
 				.string()
 				.optional()
-				.describe('Optional originating ticket id to link the proposal to'),
+				.describe(
+					'Optional originating ticket to link the proposal to — a task identifier (e.g. "HM-1") or UUID',
+				),
 		},
 		async (args, db, auth) => {
 			if (auth.type !== AuthType.Agent) {
@@ -1377,14 +1379,21 @@ export function registerTools(
 
 			let taskId: string | null = null;
 			if (args.task_id !== undefined) {
-				const taskCheck = await db.query<{ id: string }>(
-					'SELECT id FROM tasks WHERE id = $1 AND team_id = $2',
-					[args.task_id, teamId],
-				);
-				if (taskCheck.rows.length === 0) {
+				// Agents naturally hold the human-readable identifier (e.g. "HM-1"),
+				// not the UUID — resolve either form before linking.
+				const resolved = await resolveTaskId(db, teamId, args.task_id as string);
+				// resolveTaskId trusts a well-formed UUID without a team check, so
+				// re-verify the resolved task actually belongs to this team.
+				const taskCheck = resolved
+					? await db.query<{ id: string }>('SELECT id FROM tasks WHERE id = $1 AND team_id = $2', [
+							resolved,
+							teamId,
+						])
+					: null;
+				if (!resolved || !taskCheck || taskCheck.rows.length === 0) {
 					return { error: 'task_id not found on this team' };
 				}
-				taskId = args.task_id as string;
+				taskId = resolved;
 			}
 
 			const prepared = await prepareHireProposal(db, teamId, args as unknown as HireProposalInput);

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -54,6 +54,7 @@ import {
 	actorTypeFromAuth,
 	apiKeyIdFromAuth,
 	resolveActorMemberId,
+	resolveAgentId,
 	resolveProject,
 	resolveTaskId,
 } from '../lib/resolve';
@@ -2532,7 +2533,7 @@ export function registerTools(
 		"Read an agent's system prompt. Accessible by any agent or the admin in the same team. Returns the resolved role doc by default — `{{…}}` placeholders substituted with the real team name, mission, manager, KB, project docs, and team context — so you can see what the agent actually says about itself with real values. Pass placeholders=false to get the raw stored template with `{{…}}` placeholders intact; only do this when you intend to edit the prompt and need a safe round-trip back through update_agent_system_prompt.",
 		{
 			project: projectArg(),
-			agent_id: z.string().describe('Target agent member ID'),
+			agent_id: z.string().describe('Target agent — its slug (e.g. "engineer") or member ID'),
 			placeholders: z
 				.boolean()
 				.optional()
@@ -2550,19 +2551,25 @@ export function registerTools(
 				return { error: 'Access denied' };
 			}
 
+			// Agents reference teammates by slug; accept either form. The team-scoped
+			// query below is the authorization check — resolveAgentId can fall back to
+			// an HQ agent, which must not be readable through a project team.
+			const agentId = await resolveAgentId(db, teamId, args.agent_id as string);
+			if (!agentId) return { error: 'Agent not found in this team' };
+
 			const agent = await db.query<{ title: string; slug: string }>(
 				`SELECT ma.title, ma.slug
 				 FROM member_agents ma JOIN members m ON m.id = ma.id
 				 WHERE ma.id = $1 AND m.team_id = $2`,
-				[args.agent_id, teamId],
+				[agentId, teamId],
 			);
 			if (agent.rows.length === 0) return { error: 'Agent not found in this team' };
 
-			const raw = await getAgentSystemPrompt(db, teamId, args.agent_id as string);
+			const raw = await getAgentSystemPrompt(db, teamId, agentId);
 			const system_prompt = args.placeholders
 				? await resolveSystemPrompt(db, raw, {
 						teamId,
-						agentId: args.agent_id as string,
+						agentId,
 						mode: 'placeholders',
 					})
 				: raw;
@@ -2638,7 +2645,7 @@ export function registerTools(
 		'Apply a system prompt change for an agent. Callable by the Coach agent (for after-task learned-rules updates) or by the Captain of the same team (during team-coherence reviews). The change is applied immediately and a revision snapshot is stored so the admin can restore previous versions.',
 		{
 			project: projectArg(),
-			agent_id: z.string().describe('Target agent member ID'),
+			agent_id: z.string().describe('Target agent — its slug (e.g. "engineer") or member ID'),
 			new_system_prompt: z.string().describe('The full updated system prompt'),
 			change_summary: z.string().describe('Summary of what changed and why'),
 		},
@@ -2654,10 +2661,14 @@ export function registerTools(
 				};
 			}
 
+			// Accept a slug or member ID; the team-scoped check keeps an HQ agent
+			// (resolveAgentId's fallback) from being editable through a project team.
+			const agentId = await resolveAgentId(db, teamId, args.agent_id as string);
+			if (!agentId) return { error: 'Agent not found in this team' };
 			const agentCheck = await db.query<{ id: string }>(
 				`SELECT ma.id FROM member_agents ma JOIN members m ON m.id = ma.id
 				 WHERE ma.id = $1 AND m.team_id = $2`,
-				[args.agent_id, teamId],
+				[agentId, teamId],
 			);
 			if (agentCheck.rows.length === 0) return { error: 'Agent not found in this team' };
 
@@ -2667,7 +2678,7 @@ export function registerTools(
 				scope: {
 					type: DocumentType.AgentSystemPrompt,
 					teamId,
-					memberAgentId: args.agent_id as string,
+					memberAgentId: agentId,
 				},
 				content: args.new_system_prompt as string,
 				changeSummary: args.change_summary as string,
@@ -2693,7 +2704,7 @@ export function registerTools(
 		'Save a short human-readable summary for an agent (≤1000 chars, single paragraph, plain prose). Callable by any agent in the same team or any the admin; the Captain is the expected caller, but agents may also self-summarise.',
 		{
 			project: projectArg(),
-			agent_id: z.string().describe('Target agent member ID'),
+			agent_id: z.string().describe('Target agent — its slug (e.g. "engineer") or member ID'),
 			summary: z.string().describe('The new summary, ≤1000 chars'),
 		},
 		async (args, db, auth) => {
@@ -2711,13 +2722,17 @@ export function registerTools(
 				return { error: `summary too long (${summary.length} chars; max 1000)` };
 			}
 
+			// Accept a slug or member ID; the team_id filter scopes the write so an HQ
+			// agent (resolveAgentId's fallback) can't be summarised through this team.
+			const agentId = await resolveAgentId(db, teamId, args.agent_id as string);
+			if (!agentId) return { error: 'Agent not found in this team' };
 			const r = await db.query<{ id: string }>(
 				`UPDATE member_agents SET summary = $1, updated_at = now()
 				 WHERE id = $2 AND id IN (
 				   SELECT m.id FROM members m WHERE m.id = $2 AND m.team_id = $3
 				 )
 				 RETURNING id`,
-				[summary, args.agent_id, teamId],
+				[summary, agentId, teamId],
 			);
 			if (r.rows.length === 0) return { error: 'Agent not found in this team' };
 
@@ -2793,7 +2808,7 @@ export function registerTools(
 		"Save the team-relationships context for an agent (≤6000 chars, plain prose, second-person 'you', describes how this agent relates to its manager, direct reports, peers, indirect reports, and humans). This blob is injected into the agent's system prompt at the start of every run. Only callable by the Captain of the same team.",
 		{
 			project: projectArg(),
-			agent_id: z.string().describe('Target agent member ID'),
+			agent_id: z.string().describe('Target agent — its slug (e.g. "engineer") or member ID'),
 			content: z.string().describe('The new team_context, ≤6000 chars'),
 		},
 		async (args, db, auth) => {
@@ -2811,13 +2826,17 @@ export function registerTools(
 				return { error: `content too long (${content.length} chars; max 6000)` };
 			}
 
+			// Accept a slug or member ID; the team_id filter scopes the write so an HQ
+			// agent (resolveAgentId's fallback) can't be written through this team.
+			const agentId = await resolveAgentId(db, teamId, args.agent_id as string);
+			if (!agentId) return { error: 'Agent not found in this team' };
 			const r = await db.query<{ id: string }>(
 				`UPDATE member_agents SET team_context = $1, updated_at = now()
 				 WHERE id = $2 AND id IN (
 				   SELECT m.id FROM members m WHERE m.id = $2 AND m.team_id = $3
 				 )
 				 RETURNING id`,
-				[content, args.agent_id, teamId],
+				[content, agentId, teamId],
 			);
 			if (r.rows.length === 0) return { error: 'Agent not found in this team' };
 
@@ -2832,7 +2851,7 @@ export function registerTools(
 		"Read an agent's stored team-relationships context. Useful for the Captain when regenerating siblings' contexts. Accessible by any agent or the admin in the same team.",
 		{
 			project: projectArg(),
-			agent_id: z.string().describe('Target agent member ID'),
+			agent_id: z.string().describe('Target agent — its slug (e.g. "engineer") or member ID'),
 		},
 		async (args, db, auth) => {
 			const scope = await resolveScope(db, auth, args);
@@ -2843,11 +2862,15 @@ export function registerTools(
 				return { error: 'Access denied' };
 			}
 
+			// Accept a slug or member ID; the team-scoped query is the authorization
+			// check, keeping an HQ agent (resolveAgentId's fallback) out of this team.
+			const agentId = await resolveAgentId(db, teamId, args.agent_id as string);
+			if (!agentId) return { error: 'Agent not found in this team' };
 			const r = await db.query<{ title: string; slug: string; team_context: string }>(
 				`SELECT ma.title, ma.slug, ma.team_context
 				 FROM member_agents ma JOIN members m ON m.id = ma.id
 				 WHERE ma.id = $1 AND m.team_id = $2`,
-				[args.agent_id, teamId],
+				[agentId, teamId],
 			);
 			if (r.rows.length === 0) return { error: 'Agent not found in this team' };
 

--- a/packages/server/test/create-hire-proposal.test.ts
+++ b/packages/server/test/create-hire-proposal.test.ts
@@ -132,6 +132,25 @@ describe('MCP tool create_hire_proposal', () => {
 		expect((result.payload as Record<string, unknown>).task_id).toBe(taskId);
 	});
 
+	it('links the proposal to an originating ticket by human-readable identifier', async () => {
+		const taskRow = await db.query<{ id: string; identifier: string }>(
+			'SELECT id, identifier FROM tasks WHERE team_id = $1 LIMIT 1',
+			[teamId],
+		);
+		const { id: taskId, identifier } = taskRow.rows[0];
+		// Sanity: the identifier is the human-readable form, not the UUID.
+		expect(identifier).not.toBe(taskId);
+
+		const result = await callTool(await captainToken(), 'create_hire_proposal', {
+			title: 'Field Engineer',
+			system_prompt: 'You handle on-site work.',
+			task_id: identifier,
+		});
+		expect(result.error).toBeUndefined();
+		// The proposal stores the resolved UUID, not the identifier it was given.
+		expect((result.payload as Record<string, unknown>).task_id).toBe(taskId);
+	});
+
 	it('rejects a task_id that is not on the team', async () => {
 		const result = await callTool(await captainToken(), 'create_hire_proposal', {
 			title: 'Stray Role',

--- a/packages/server/test/mcp-tools-extended.test.ts
+++ b/packages/server/test/mcp-tools-extended.test.ts
@@ -1,5 +1,5 @@
 import type { PGlite } from '@electric-sql/pglite';
-import { CredentialKind, DEFAULT_TEAM_ID, ReactionKind } from '@hezo/shared';
+import { CEO_AGENT_SLUG, CredentialKind, DEFAULT_TEAM_ID, ReactionKind } from '@hezo/shared';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { MasterKeyManager } from '../src/crypto/master-key';
@@ -961,6 +961,72 @@ describe('MCP set_agent_team_context / get_agent_team_context', () => {
 		const result = (await callToolAs(await captainToken(), 'get_agent_team_context', {
 			project: projectId,
 			agent_id: '00000000-0000-0000-0000-000000000000',
+		})) as ToolResult;
+		expect(result.error).toContain('Agent not found');
+	});
+});
+
+describe('MCP agent tools accept a slug or a member ID', () => {
+	// Regression: these tools previously did a UUID-only `WHERE ma.id = $1` lookup,
+	// so a caller (the CEO/Captain) that referenced a teammate by its natural slug
+	// — e.g. "engineer" — got "Agent not found". They now resolve the slug too,
+	// matching set_agent_status and the REST agent routes.
+	it('get_agent_system_prompt resolves an agent slug', async () => {
+		const result = (await callToolAs(await captainToken(), 'get_agent_system_prompt', {
+			project: projectId,
+			agent_id: 'engineer',
+		})) as { slug?: string; system_prompt?: string; error?: string };
+		expect(result.error).toBeUndefined();
+		expect(result.slug).toBe('engineer');
+		expect(typeof result.system_prompt).toBe('string');
+	});
+
+	it('update_agent_system_prompt resolves an agent slug', async () => {
+		const result = (await callToolAs(await captainToken(), 'update_agent_system_prompt', {
+			project: projectId,
+			agent_id: 'engineer',
+			new_system_prompt: 'You are the engineer. Updated by slug.',
+			change_summary: 'slug round-trip',
+		})) as { applied?: boolean; error?: string };
+		expect(result.error).toBeUndefined();
+		expect(result.applied).toBe(true);
+	});
+
+	it('set_agent_summary resolves an agent slug', async () => {
+		const result = (await callToolAs(await captainToken(), 'set_agent_summary', {
+			project: projectId,
+			agent_id: 'engineer',
+			summary: 'Resolved by slug.',
+		})) as { updated?: boolean; error?: string };
+		expect(result.error).toBeUndefined();
+		expect(result.updated).toBe(true);
+	});
+
+	it('set_agent_team_context then get_agent_team_context resolve an agent slug', async () => {
+		const captain = await captainToken();
+		const written = (await callToolAs(captain, 'set_agent_team_context', {
+			project: projectId,
+			agent_id: 'engineer',
+			content: 'You pair with QA. Written by slug.',
+		})) as { updated?: boolean; error?: string };
+		expect(written.error).toBeUndefined();
+		expect(written.updated).toBe(true);
+
+		const read = (await callToolAs(captain, 'get_agent_team_context', {
+			project: projectId,
+			agent_id: 'engineer',
+		})) as { slug?: string; team_context?: string; error?: string };
+		expect(read.error).toBeUndefined();
+		expect(read.slug).toBe('engineer');
+		expect(read.team_context).toContain('Written by slug.');
+	});
+
+	it('does not resolve an HQ agent slug through a project team', async () => {
+		// resolveAgentId can fall back to an HQ agent (CEO/Coach); the team-scoped
+		// check must still reject it so a project Captain can't read HQ prompts.
+		const result = (await callToolAs(await captainToken(), 'get_agent_team_context', {
+			project: projectId,
+			agent_id: CEO_AGENT_SLUG,
 		})) as ToolResult;
 		expect(result.error).toContain('Agent not found');
 	});


### PR DESCRIPTION
## Problem

A CEO run filing hire proposals hit `task_id not found on this team` and had to discover the underlying UUID and refile — the screenshot showed it reasoning *"The `task_id` needs a UUID, not the identifier. Let me fix that and refile."*

`create_hire_proposal` resolved its optional `task_id` with a raw UUID-only lookup (`WHERE id = $1`), unlike every other task-taking MCP tool which uses the shared `resolveTaskId` helper that accepts the human-readable identifier (e.g. `HM-1`) too. Agents naturally hold the identifier from the ticket they're working, so the first attempt always failed.

## Audit

Per the follow-up request, I audited **every ID-accepting MCP tool and REST route** to ensure each accepts both the UUID and the user-facing form (task → identifier, project → slug, team → slug, agent → slug). Findings:

- **`create_hire_proposal.task_id`** — UUID-only. **Fixed.**
- **Five agent-targeting MCP tools** looked up `agent_id` with a UUID-only `WHERE ma.id = $1`, while the parallel REST routes, `set_agent_status`, and the batch prompt tool all accept slug-or-UUID via `resolveAgentId`. The CEO/Captain reference teammates by slug (`engineer`), so these failed with "Agent not found". **Fixed:**
  - `get_agent_system_prompt`
  - `update_agent_system_prompt`
  - `set_agent_summary`
  - `set_agent_team_context`
  - `get_agent_team_context`
- **Everything else verified correct.** Tasks / projects / teams / agents go through resolvers everywhere else. `approvals`, `secrets`, `mcp_connections`, comments (`parent_comment_id`), `assignee_id`, `member_id`, and `reports_to` are UUID-only internal references set from data the client already holds (UI pickers) — not values a human types or an agent emits from memory — so UUID-only is correct there.

## Approach

Both fixes route through the existing shared resolvers (`resolveTaskId`, `resolveAgentId`). For the agent tools, the existing **team-scoped query is retained as the authorization check** — `resolveAgentId` can fall back to an HQ agent (CEO/Coach), which must not be readable/writable through a project team. No security posture change.

## Tests

- `create-hire-proposal.test.ts`: links a proposal by human-readable identifier; the stored payload still holds the resolved UUID; the existing "not on this team" rejection still holds.
- `mcp-tools-extended.test.ts`: the slug path for all five agent tools, plus a guard proving an **HQ agent slug does not resolve through a project team**.
- Generated MCP reference (`docs/reference/mcp-api.md`) regenerated via `bun run build:docs`; drift tests green.
- Full server suite: 2759 passed. The single failure is `ssh-agent-server.test.ts` (`spawn ssh-keygen ENOENT`) — `ssh-keygen` isn't installed in this container; environmental and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018nztAsJkGTXFvGQm8psFsN

---
_Generated by [Claude Code](https://claude.ai/code/session_018nztAsJkGTXFvGQm8psFsN)_