### PR TITLE
feat(web): reusable markdown edit/preview component

### DIFF
--- a/packages/web/src/components/create-task-dialog.tsx
+++ b/packages/web/src/components/create-task-dialog.tsx
@@ -6,7 +6,7 @@ import { useMemo, useState } from 'react';
 import { useAgents } from '../hooks/use-agents';
 import { useProjectMeta } from '../hooks/use-projects';
 import { useCreateTask } from '../hooks/use-tasks';
-import { MentionTextarea } from './mention-textarea';
+import { MarkdownEditor } from './markdown-editor';
 import { Button } from './ui/button';
 import { dialogContentClassName, dialogOverlayClassName } from './ui/dialog';
 import { Input } from './ui/input';
@@ -86,13 +86,16 @@ export function CreateTaskDialog({ projectId, open, onOpenChange }: CreateTaskDi
 							onChange={(e) => setTitle(e.target.value)}
 							required
 						/>
-						<MentionTextarea
+						<MarkdownEditor
 							projectId={projectId}
 							projectSlug={project?.slug}
 							label="Description"
+							ariaLabel="Description"
 							value={description}
-							onChange={(e) => setDescription(e.target.value)}
+							onChange={setDescription}
 							placeholder="Optional"
+							previewClassName="min-h-[72px]"
+							emptyPreviewText="_(nothing to preview)_"
 						/>
 
 						<label className="flex flex-col gap-1.5">

--- a/packages/web/src/components/hire-agent-form.tsx
+++ b/packages/web/src/components/hire-agent-form.tsx
@@ -1,5 +1,6 @@
 import type { BudgetWindowsCents } from '@hezo/shared';
 import { BudgetWindowsEditor } from './budget/budget-windows-editor';
+import { MarkdownEditor } from './markdown-editor';
 import { Input } from './ui/input';
 
 export interface HireFormValues {
@@ -30,11 +31,6 @@ interface HireAgentFormProps {
 export function HireAgentForm({ values, onChange, slug }: HireAgentFormProps) {
 	function set<K extends keyof HireFormValues>(key: K, value: HireFormValues[K]) {
 		onChange({ ...values, [key]: value });
-	}
-
-	function insertVar(v: string) {
-		const prev = values.systemPrompt;
-		set('systemPrompt', `${prev}${prev && !prev.endsWith(' ') ? ' ' : ''}${v}`);
 	}
 
 	return (
@@ -101,32 +97,19 @@ export function HireAgentForm({ values, onChange, slug }: HireAgentFormProps) {
 				</span>
 			</label>
 
-			<div>
-				<span className="text-xs font-medium uppercase tracking-wider text-text-2 block mb-1.5">
-					System prompt
-				</span>
-				<div className="flex flex-wrap gap-1.5 mb-2">
-					{templateVars.map((v) => (
-						<button
-							key={v}
-							type="button"
-							onClick={() => insertVar(v)}
-							className="text-[11px] px-2 py-0.5 rounded-md bg-info-soft text-info-soft-fg cursor-pointer hover:opacity-80"
-						>
-							{v}
-						</button>
-					))}
-				</div>
-				<textarea
-					value={values.systemPrompt}
-					onChange={(e) => set('systemPrompt', e.target.value)}
-					className="w-full rounded-md border border-border bg-surface px-3 py-2 text-[13px] text-text-1 outline-none focus:border-border-strong min-h-[160px] resize-y font-mono leading-relaxed"
-					placeholder="You are the {{agent_role}} at {{team_name}}..."
-				/>
-				<p className="text-xs text-text-3 mt-1">
-					Insert variables using the chips above. Markdown supported.
-				</p>
-			</div>
+			<MarkdownEditor
+				label="System prompt"
+				labelClassName="text-xs font-medium uppercase tracking-wider text-text-2"
+				ariaLabel="System prompt"
+				value={values.systemPrompt}
+				onChange={(v) => set('systemPrompt', v)}
+				chips={templateVars}
+				placeholder="You are the {{agent_role}} at {{team_name}}..."
+				helpText="Insert variables using the chips above. Markdown supported."
+				className="min-h-[160px] font-mono"
+				previewClassName="min-h-[160px]"
+				emptyPreviewText="_(nothing to preview)_"
+			/>
 		</div>
 	);
 }

--- a/packages/web/src/components/markdown-editor.tsx
+++ b/packages/web/src/components/markdown-editor.tsx
@@ -1,0 +1,189 @@
+import { type ReactNode, useRef, useState } from 'react';
+import { MarkdownProse } from './markdown-prose';
+import { MentionTextarea } from './mention-textarea';
+
+export type MarkdownEditorMode = 'edit' | 'preview';
+
+interface MarkdownEditorProps {
+	value: string;
+	onChange: (value: string) => void;
+
+	/** Field label rendered to the left of the Edit/Preview tabs. */
+	label?: ReactNode;
+	/** Class override for the label span (callers use different idioms). */
+	labelClassName?: string;
+	/** Helper text shown beneath the editor (edit mode only). */
+	helpText?: ReactNode;
+	/** Clickable chips that insert a token at the cursor — e.g. template variables. */
+	chips?: string[];
+
+	placeholder?: string;
+	/** Accessible name for the textarea; also how tests query it (findByLabelText). */
+	ariaLabel?: string;
+	required?: boolean;
+	rows?: number;
+	/** Extra classes for the textarea (sizing / font). */
+	className?: string;
+
+	/** Enables @mentions in the editor and mention links in the preview. */
+	projectId?: string;
+	projectSlug?: string;
+
+	/**
+	 * Server-resolved preview body. When provided the preview renders this instead
+	 * of `value` (e.g. an agent prompt with its placeholders filled in).
+	 */
+	previewContent?: string;
+	/** Shows a "Resolving…" placeholder while `previewContent` loads. */
+	isPreviewLoading?: boolean;
+	/** Fires on every mode flip so a parent can lazily fetch `previewContent`. */
+	onModeChange?: (mode: MarkdownEditorMode) => void;
+	/** Preview container classes (mainly min-height). */
+	previewClassName?: string;
+	previewTestId?: string;
+	/** Markdown rendered when there is nothing to preview. */
+	emptyPreviewText?: string;
+	defaultMode?: MarkdownEditorMode;
+}
+
+const TAB_BASE = 'px-2.5 py-1 rounded';
+const TAB_ACTIVE = 'bg-surface text-text-1 shadow-sm';
+const TAB_INACTIVE = 'text-text-2 hover:text-text-1';
+
+/**
+ * Reusable markdown editor with an Edit/Preview toggle. Edits go through
+ * {@link MentionTextarea} (which degrades to a plain textarea when no
+ * `projectId` is set) and the preview renders through {@link MarkdownProse}.
+ * Optionally shows template-variable chips that insert at the cursor, and
+ * accepts a server-resolved `previewContent` override for prompts whose preview
+ * is computed on the backend.
+ */
+export function MarkdownEditor({
+	value,
+	onChange,
+	label,
+	labelClassName = 'text-sm text-text-2',
+	helpText,
+	chips,
+	placeholder,
+	ariaLabel,
+	required,
+	rows,
+	className,
+	projectId,
+	projectSlug,
+	previewContent,
+	isPreviewLoading,
+	onModeChange,
+	previewClassName = 'min-h-[160px]',
+	previewTestId,
+	emptyPreviewText = '',
+	defaultMode = 'edit',
+}: MarkdownEditorProps) {
+	const [mode, setMode] = useState<MarkdownEditorMode>(defaultMode);
+	const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+	function switchMode(next: MarkdownEditorMode) {
+		if (next === mode) return;
+		setMode(next);
+		onModeChange?.(next);
+	}
+
+	function insertChip(token: string) {
+		const el = textareaRef.current;
+		if (!el) {
+			// No live textarea (e.g. while previewing): append with a separating space.
+			const sep = value && !/\s$/.test(value) ? ' ' : '';
+			onChange(`${value}${sep}${token}`);
+			return;
+		}
+		const start = el.selectionStart ?? value.length;
+		const end = el.selectionEnd ?? start;
+		const next = `${value.slice(0, start)}${token}${value.slice(end)}`;
+		onChange(next);
+		const caret = start + token.length;
+		requestAnimationFrame(() => {
+			el.focus();
+			el.setSelectionRange(caret, caret);
+		});
+	}
+
+	const previewBody = previewContent ?? value;
+
+	return (
+		<div>
+			<div className="flex items-center justify-between gap-2 mb-1.5">
+				{label ? <span className={labelClassName}>{label}</span> : <span />}
+				<div
+					role="tablist"
+					aria-label="Editor view mode"
+					className="inline-flex rounded-md border border-border-subtle bg-surface-2 p-0.5 text-xs"
+				>
+					<button
+						type="button"
+						role="tab"
+						aria-selected={mode === 'edit'}
+						onClick={() => switchMode('edit')}
+						className={`${TAB_BASE} ${mode === 'edit' ? TAB_ACTIVE : TAB_INACTIVE}`}
+					>
+						Edit
+					</button>
+					<button
+						type="button"
+						role="tab"
+						aria-selected={mode === 'preview'}
+						onClick={() => switchMode('preview')}
+						className={`${TAB_BASE} ${mode === 'preview' ? TAB_ACTIVE : TAB_INACTIVE}`}
+					>
+						Preview
+					</button>
+				</div>
+			</div>
+
+			{mode === 'edit' ? (
+				<>
+					{chips && chips.length > 0 && (
+						<div className="flex flex-wrap gap-1.5 mb-2">
+							{chips.map((token) => (
+								<button
+									key={token}
+									type="button"
+									onClick={() => insertChip(token)}
+									className="text-[11px] px-2 py-0.5 rounded-md bg-info-soft text-info-soft-fg cursor-pointer hover:opacity-80"
+								>
+									{token}
+								</button>
+							))}
+						</div>
+					)}
+					<MentionTextarea
+						ref={textareaRef}
+						projectId={projectId}
+						projectSlug={projectSlug}
+						value={value}
+						onChange={(e) => onChange(e.target.value)}
+						aria-label={ariaLabel}
+						placeholder={placeholder}
+						required={required}
+						rows={rows}
+						className={className}
+					/>
+					{helpText && <p className="text-xs text-text-3 mt-1">{helpText}</p>}
+				</>
+			) : (
+				<div
+					data-testid={previewTestId}
+					className={`${previewClassName} rounded-md border border-border bg-surface-2 px-3 py-2 text-sm`}
+				>
+					{isPreviewLoading ? (
+						<div className="text-text-2 text-xs">Resolving…</div>
+					) : (
+						<MarkdownProse projectId={projectId} projectSlug={projectSlug}>
+							{previewBody || emptyPreviewText}
+						</MarkdownProse>
+					)}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/packages/web/src/components/task-detail/task-summary.tsx
+++ b/packages/web/src/components/task-detail/task-summary.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import type { Task, useUpdateTask } from '../../hooks/use-tasks';
+import { MarkdownEditor } from '../markdown-editor';
 import { MarkdownProse } from '../markdown-prose';
-import { MentionTextarea } from '../mention-textarea';
 import { Button } from '../ui/button';
 import { InfoTooltip } from '../ui/info-tooltip';
 
@@ -57,12 +57,15 @@ export function TaskSummary({ task, projectId, taskProjectSlug, updateTask }: Ta
 				</div>
 				{editingSummary ? (
 					<div className="flex flex-col gap-2">
-						<MentionTextarea
+						<MarkdownEditor
+							ariaLabel="Progress Summary"
 							projectId={projectId}
 							projectSlug={taskProjectSlug}
 							value={summaryText}
-							onChange={(e) => setSummaryText(e.target.value)}
+							onChange={setSummaryText}
 							className="min-h-[60px]"
+							previewClassName="min-h-[60px]"
+							emptyPreviewText="_(nothing to preview)_"
 						/>
 						<div className="flex gap-2 justify-end">
 							<Button size="sm" variant="secondary" onClick={() => setEditingSummary(false)}>
@@ -120,13 +123,16 @@ export function TaskSummary({ task, projectId, taskProjectSlug, updateTask }: Ta
 				</div>
 				{editingRules ? (
 					<div className="flex flex-col gap-2">
-						<MentionTextarea
+						<MarkdownEditor
+							ariaLabel="Rules"
 							projectId={projectId}
 							projectSlug={taskProjectSlug}
 							value={rulesText}
-							onChange={(e) => setRulesText(e.target.value)}
+							onChange={setRulesText}
 							placeholder="e.g., Consult the architect before making changes..."
 							className="min-h-[60px]"
+							previewClassName="min-h-[60px]"
+							emptyPreviewText="_(nothing to preview)_"
 						/>
 						<div className="flex gap-2 justify-end">
 							<Button size="sm" variant="secondary" onClick={() => setEditingRules(false)}>

--- a/packages/web/src/routes/projects/$projectId/agents/$agentId/settings.tsx
+++ b/packages/web/src/routes/projects/$projectId/agents/$agentId/settings.tsx
@@ -8,7 +8,7 @@ import { createFileRoute, Link } from '@tanstack/react-router';
 import { Loader2, Power, PowerOff } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { BudgetWindowsEditor } from '../../../../../components/budget/budget-windows-editor';
-import { MarkdownProse } from '../../../../../components/markdown-prose';
+import { MarkdownEditor } from '../../../../../components/markdown-editor';
 import { RevisionsPanel } from '../../../../../components/revisions-panel';
 import { Button } from '../../../../../components/ui/button';
 import { ExpandableText } from '../../../../../components/ui/expandable-text';
@@ -167,60 +167,19 @@ function AgentSettingsPage() {
 					onChange={(e) => setRoleDesc(e.target.value)}
 				/>
 				<div>
-					<div className="flex items-center justify-between mb-1.5">
-						<span className="text-sm text-text-2">System Prompt</span>
-						<div
-							role="tablist"
-							aria-label="Prompt view mode"
-							className="inline-flex rounded-md border border-border-subtle bg-surface-2 p-0.5 text-xs"
-						>
-							<button
-								type="button"
-								role="tab"
-								aria-selected={promptMode === 'edit'}
-								onClick={() => setPromptMode('edit')}
-								className={`px-2.5 py-1 rounded ${
-									promptMode === 'edit'
-										? 'bg-surface text-text-1 shadow-sm'
-										: 'text-text-2 hover:text-text-1'
-								}`}
-							>
-								Edit
-							</button>
-							<button
-								type="button"
-								role="tab"
-								aria-selected={promptMode === 'preview'}
-								onClick={() => setPromptMode('preview')}
-								className={`px-2.5 py-1 rounded ${
-									promptMode === 'preview'
-										? 'bg-surface text-text-1 shadow-sm'
-										: 'text-text-2 hover:text-text-1'
-								}`}
-							>
-								Preview
-							</button>
-						</div>
-					</div>
-					{promptMode === 'edit' ? (
-						<Textarea
-							aria-label="System Prompt"
-							value={systemPrompt}
-							onChange={(e) => setSystemPrompt(e.target.value)}
-							className="min-h-[160px] font-mono text-xs"
-						/>
-					) : (
-						<div
-							data-testid="system-prompt-preview"
-							className="min-h-[160px] rounded-md border border-border bg-surface-2 px-3 py-2 text-sm"
-						>
-							{isPreviewLoading ? (
-								<div className="text-text-2 text-xs">Resolving…</div>
-							) : (
-								<MarkdownProse>{previewData?.content ?? ''}</MarkdownProse>
-							)}
-						</div>
-					)}
+					<MarkdownEditor
+						label="System Prompt"
+						ariaLabel="System Prompt"
+						value={systemPrompt}
+						onChange={setSystemPrompt}
+						defaultMode={promptMode}
+						onModeChange={setPromptMode}
+						className="min-h-[160px] font-mono text-xs"
+						previewClassName="min-h-[160px]"
+						previewTestId="system-prompt-preview"
+						previewContent={previewData?.content ?? ''}
+						isPreviewLoading={isPreviewLoading}
+					/>
 					<RevisionsPanel
 						revisions={revisions}
 						onRestore={(rev) => restorePrompt.mutateAsync(rev)}

--- a/packages/web/src/routes/projects/$projectId/documents.tsx
+++ b/packages/web/src/routes/projects/$projectId/documents.tsx
@@ -3,7 +3,7 @@ import { createFileRoute } from '@tanstack/react-router';
 import { Info, Loader2 } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { type DocItem, DocsLibrary } from '../../../components/docs-library';
-import { MentionTextarea } from '../../../components/mention-textarea';
+import { MarkdownEditor } from '../../../components/markdown-editor';
 import { RevisionsPanel } from '../../../components/revisions-panel';
 import { Button } from '../../../components/ui/button';
 import { Input } from '../../../components/ui/input';
@@ -218,13 +218,16 @@ function NewProjectDocForm({
 				onChange={(e) => setFilename(e.target.value)}
 				required
 			/>
-			<MentionTextarea
+			<MarkdownEditor
 				projectId={projectId}
 				projectSlug={projectSlug}
 				label="Content (Markdown)"
+				ariaLabel="Content (Markdown)"
 				value={content}
-				onChange={(e) => setContent(e.target.value)}
+				onChange={setContent}
 				className="min-h-[300px] font-mono text-xs"
+				previewClassName="min-h-[300px]"
+				emptyPreviewText="_(empty)_"
 			/>
 			{error && <p className="text-sm text-danger">{error}</p>}
 			<div className="flex justify-end gap-2">

--- a/packages/web/src/routes/settings/skills.tsx
+++ b/packages/web/src/routes/settings/skills.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { ExternalLink, Loader2, Pencil, Plus, Search, Trash2 } from 'lucide-react';
 import { useEffect, useState } from 'react';
-import { MarkdownProse } from '../../components/markdown-prose';
+import { MarkdownEditor } from '../../components/markdown-editor';
 import { RevisionsPanel } from '../../components/revisions-panel';
 import { SettingsBreadcrumb } from '../../components/settings-breadcrumb';
 import { Badge } from '../../components/ui/badge';
@@ -37,7 +37,6 @@ function InstanceSkillsPage() {
 	const [name, setName] = useState('');
 	const [description, setDescription] = useState('');
 	const [content, setContent] = useState('');
-	const [contentMode, setContentMode] = useState<'edit' | 'preview'>('edit');
 	const [tags, setTags] = useState('');
 	const [error, setError] = useState<string | null>(null);
 
@@ -61,7 +60,6 @@ function InstanceSkillsPage() {
 		setName('');
 		setDescription('');
 		setContent('');
-		setContentMode('edit');
 		setTags('');
 		setError(null);
 	}
@@ -176,59 +174,20 @@ function InstanceSkillsPage() {
 							value={description}
 							onChange={(e) => setDescription(e.target.value)}
 						/>
-						<div className="flex items-center justify-between">
-							<span className="text-[13px] text-text-2">Content (markdown)</span>
-							<div
-								role="tablist"
-								aria-label="Content view mode"
-								className="inline-flex rounded-md border border-border-subtle bg-surface-2 p-0.5 text-xs"
-							>
-								<button
-									type="button"
-									role="tab"
-									aria-selected={contentMode === 'edit'}
-									onClick={() => setContentMode('edit')}
-									className={`px-2.5 py-1 rounded ${
-										contentMode === 'edit'
-											? 'bg-surface text-text-1 shadow-sm'
-											: 'text-text-2 hover:text-text-1'
-									}`}
-								>
-									Edit
-								</button>
-								<button
-									type="button"
-									role="tab"
-									aria-selected={contentMode === 'preview'}
-									onClick={() => setContentMode('preview')}
-									className={`px-2.5 py-1 rounded ${
-										contentMode === 'preview'
-											? 'bg-surface text-text-1 shadow-sm'
-											: 'text-text-2 hover:text-text-1'
-									}`}
-								>
-									Preview
-								</button>
-							</div>
-						</div>
-						{contentMode === 'edit' ? (
-							<textarea
-								aria-label="Skill content"
-								placeholder="Skill content (markdown)"
-								value={content}
-								onChange={(e) => setContent(e.target.value)}
-								required
-								rows={10}
-								className="w-full rounded-md border border-border bg-surface px-3 py-2 text-[13px] font-mono focus:outline-none focus:ring-1 focus:ring-accent"
-							/>
-						) : (
-							<div
-								data-testid="skill-content-preview"
-								className="min-h-[200px] rounded-md border border-border bg-surface-2 px-3 py-2 text-sm"
-							>
-								<MarkdownProse>{content || '_(nothing to preview)_'}</MarkdownProse>
-							</div>
-						)}
+						<MarkdownEditor
+							label="Content (markdown)"
+							labelClassName="text-[13px] text-text-2"
+							ariaLabel="Skill content"
+							placeholder="Skill content (markdown)"
+							value={content}
+							onChange={setContent}
+							required
+							rows={10}
+							className="font-mono"
+							previewClassName="min-h-[200px]"
+							previewTestId="skill-content-preview"
+							emptyPreviewText="_(nothing to preview)_"
+						/>
 						{error && <p className="text-[13px] text-danger">{error}</p>}
 						<div className="flex gap-2">
 							<Button

--- a/packages/web/test/markdown-editor.test.tsx
+++ b/packages/web/test/markdown-editor.test.tsx
@@ -1,0 +1,142 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { type ReactElement, useState } from 'react';
+import { expect, test, vi } from 'vitest';
+import { MarkdownEditor } from '../src/components/markdown-editor';
+
+/** The preview pane mounts <MarkdownProse>, whose mention hooks call useQuery. */
+function renderWithClient(ui: ReactElement) {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false, staleTime: 0 } },
+	});
+	return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+}
+
+/** Controlled wrapper mirroring how the real forms drive the editor. */
+function Harness({
+	initial = '',
+	onChange,
+	...rest
+}: {
+	initial?: string;
+	onChange?: (next: string) => void;
+} & Omit<React.ComponentProps<typeof MarkdownEditor>, 'value' | 'onChange'>) {
+	const [value, setValue] = useState(initial);
+	return (
+		<MarkdownEditor
+			value={value}
+			onChange={(next) => {
+				setValue(next);
+				onChange?.(next);
+			}}
+			{...rest}
+		/>
+	);
+}
+
+test('typing updates the value via onChange', async () => {
+	const user = userEvent.setup({ delay: null });
+	const onChange = vi.fn();
+	const { getByLabelText } = renderWithClient(<Harness ariaLabel="Body" onChange={onChange} />);
+
+	const textarea = getByLabelText('Body') as HTMLTextAreaElement;
+	await user.type(textarea, 'hello');
+
+	expect(textarea.value).toBe('hello');
+	expect(onChange).toHaveBeenLastCalledWith('hello');
+});
+
+test('toggling Edit/Preview swaps panes, fires onModeChange, and round-trips the value', async () => {
+	const user = userEvent.setup({ delay: null });
+	const onModeChange = vi.fn();
+	const { getByRole, getByTestId, queryByLabelText, getByLabelText } = renderWithClient(
+		<Harness
+			initial="# Heading"
+			ariaLabel="Body"
+			previewTestId="md-preview"
+			onModeChange={onModeChange}
+		/>,
+	);
+
+	await user.click(getByRole('tab', { name: 'Preview' }));
+	expect(onModeChange).toHaveBeenLastCalledWith('preview');
+	// Edit textarea is replaced by the rendered preview.
+	expect(queryByLabelText('Body')).toBeNull();
+	expect(getByTestId('md-preview').querySelector('h1')?.textContent).toContain('Heading');
+
+	await user.click(getByRole('tab', { name: 'Edit' }));
+	expect(onModeChange).toHaveBeenLastCalledWith('edit');
+	// The raw markdown survives the round-trip.
+	expect((getByLabelText('Body') as HTMLTextAreaElement).value).toBe('# Heading');
+});
+
+test('empty content renders the emptyPreviewText placeholder', async () => {
+	const user = userEvent.setup({ delay: null });
+	const { getByRole, getByTestId } = renderWithClient(
+		<Harness
+			ariaLabel="Body"
+			previewTestId="md-preview"
+			emptyPreviewText="_(nothing to preview)_"
+		/>,
+	);
+
+	await user.click(getByRole('tab', { name: 'Preview' }));
+	expect(getByTestId('md-preview').textContent).toContain('nothing to preview');
+});
+
+test('previewContent overrides the editor value in the preview pane', async () => {
+	const user = userEvent.setup({ delay: null });
+	const { getByRole, getByTestId } = renderWithClient(
+		<Harness
+			initial="# Raw template"
+			ariaLabel="Body"
+			previewTestId="md-preview"
+			previewContent="# Resolved output"
+		/>,
+	);
+
+	await user.click(getByRole('tab', { name: 'Preview' }));
+	const preview = getByTestId('md-preview');
+	expect(preview.querySelector('h1')?.textContent).toContain('Resolved output');
+	expect(preview.textContent).not.toContain('Raw template');
+});
+
+test('isPreviewLoading shows a resolving placeholder instead of the body', async () => {
+	const user = userEvent.setup({ delay: null });
+	const { getByRole, getByTestId } = renderWithClient(
+		<Harness
+			initial="# Body heading"
+			ariaLabel="Body"
+			previewTestId="md-preview"
+			isPreviewLoading
+		/>,
+	);
+
+	await user.click(getByRole('tab', { name: 'Preview' }));
+	const preview = getByTestId('md-preview');
+	expect(preview.textContent).toContain('Resolving');
+	expect(preview.querySelector('h1')).toBeNull();
+});
+
+test('chips insert their token into the value', async () => {
+	const user = userEvent.setup({ delay: null });
+	const { getByRole, getByLabelText } = renderWithClient(
+		<Harness ariaLabel="Body" chips={['{{team_name}}', '{{agent_role}}']} />,
+	);
+
+	await user.click(getByRole('button', { name: '{{team_name}}' }));
+	await user.click(getByRole('button', { name: '{{agent_role}}' }));
+
+	const textarea = getByLabelText('Body') as HTMLTextAreaElement;
+	expect(textarea.value).toContain('{{team_name}}');
+	expect(textarea.value).toContain('{{agent_role}}');
+});
+
+test('without a projectId, typing @ opens no mention picker', async () => {
+	const user = userEvent.setup({ delay: null });
+	const { getByLabelText, queryByTestId } = renderWithClient(<Harness ariaLabel="Body" />);
+
+	await user.type(getByLabelText('Body'), '@eng');
+	expect(queryByTestId('mention-picker')).toBeNull();
+});


### PR DESCRIPTION
## What & why

The Edit/Preview toggle for markdown was **hand-rolled and duplicated** in three places (agent **System Prompt** in settings, instance **Skills** content, and a separate view→edit model in the docs library), and several genuine markdown bodies were plain textareas with **no preview at all** — most visibly the **system-prompt editor in the hire form** (the screenshot that prompted this).

This extracts a single reusable `MarkdownEditor` and adopts it across every markdown-body editor, so authoring markdown looks and behaves the same everywhere.

## The component

`packages/web/src/components/markdown-editor.tsx` composes the existing primitives — `MentionTextarea` for editing (it already degrades to a plain textarea with no project) and `MarkdownProse` for the preview. It adds:

- an **Edit/Preview** tab toggle (same markup/classes as the old inline toggles, so visuals are unchanged);
- optional **template-variable chips** that insert at the **cursor** (the hire form previously only appended);
- a **server-resolved preview override** (`previewContent` + `isPreviewLoading` + `onModeChange`) for the agent system prompt, whose preview is computed on the backend;
- label / help-text / placeholder / `ariaLabel` / sizing passthrough.

## Surfaces converted

| Surface | File |
|---|---|
| Agent **System Prompt** (settings) — keeps the server-resolved preview + revisions | `routes/projects/$projectId/agents/$agentId/settings.tsx` |
| **Hire-form** system prompt (the screenshot) — chips now insert at the cursor + live preview | `components/hire-agent-form.tsx` |
| Instance **Skills** content | `routes/settings/skills.tsx` |
| **New project document** form | `routes/projects/$projectId/documents.tsx` |
| **Create-task** description | `components/create-task-dialog.tsx` |
| Task **Progress Summary** + **Rules** | `components/task-detail/task-summary.tsx` |

## Design notes

- **Behavior preserved per surface, not changed.** Editors that were plain textareas (agent/hire system prompt, skills) get the preview but stay mention-free; editors that already used `MentionTextarea` (new-doc, create-task, task-summary) keep `@mentions`.
- **Intentionally left as-is** (and not in scope): the realtime **comment composer** (a fast send-box with attachments + Cmd/Enter — the thread itself is the preview) and short non-prose **metadata fields** (project/role/team-type descriptions, CEO intake input). Happy to fold either in if you'd prefer maximal uniformity.
- The docs library already has its own page-level view→edit, so it's untouched (its separate *new-doc* form is converted).

## Tests

- New `packages/web/test/markdown-editor.test.tsx` (7 cases): typing → `onChange`, Edit/Preview toggle + `onModeChange` + value round-trip, default markdown preview, empty-preview placeholder, `previewContent` override, `isPreviewLoading`, cursor chip insertion, and "no project → no mention picker".
- All existing contract tests stay green: `agent-system-prompts`, `settings-skills`, `agent-hire` (chips by name, single textarea), `project-documents`, `task-crud` (edit rules/summary, markdown render).
- Full web vitest tier: **554 passed**. `typecheck` and `biome check` clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013q3iWUZDSVGVrDngkVHxrp

---
_Generated by [Claude Code](https://claude.ai/code/session_013q3iWUZDSVGVrDngkVHxrp)_