### PR TITLE
feat: add project icon upload

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -151,7 +151,14 @@ interrupted run still counts against budgets.
 unique scoping and full revision history in `document_revisions`. `skills` is the
 instance/team reference store (manifest-injected into runs, full-text-searchable) with
 `skill_revisions` history. `assets` + `task_attachments`/`comment_attachments` handle
-uploaded files (bytes on local disk, served over HMAC-signed URLs).
+uploaded files (bytes on local disk, served over HMAC-signed URLs). `project_icons`
+(1:1 with `projects`, `ON DELETE CASCADE`) holds an optional per-project icon image —
+unlike assets the **bytes live in the DB** (a `BYTEA` column) in a dedicated table so the
+hot `projects.*` list query never pulls the blob; it is rendered in the project rail and
+served from a public HMAC-signed read route (`GET /api/projects/:projectId/icon`, the `sig`
+query param is the credential since an `<img>` carries no bearer token). The serialized
+project carries a freshly-signed `icon_url` (null when unset); the client normalizes any
+picked image to a square PNG ≤512×512 before upload (`PUT`/`DELETE` on the same path).
 
 **Governance & misc.** `approvals` (polymorphic board decisions), `audit_log`
 (append-only, project + instance scopes — `project_id` set scopes a row to one project,

--- a/docs/concepts/projects-and-teams.md
+++ b/docs/concepts/projects-and-teams.md
@@ -15,6 +15,14 @@ project. You don't manage teams separately; you reach a team through its project
 This keeps things clean: a project's agents, tasks, budget, container, and connections
 all belong to that project and nothing leaks between them.
 
+## Project icon
+
+By default a project shows its initials in the project rail. To give it a distinct look,
+open the project's **Settings** and upload an image under **Project icon** — it then
+appears as the project's thumbnail in the rail. Pick any common image (PNG, JPEG, WebP,
+GIF, or SVG); Hezo crops it to a square and resizes it to 512×512. Use **Replace image**
+to swap it or **Remove** to go back to the initials.
+
 ## Team templates
 
 When you create a project you choose a **template**, which decides the starting roster.

--- a/packages/server/migrations/002_project_icons.sql
+++ b/packages/server/migrations/002_project_icons.sql
@@ -1,0 +1,14 @@
+-- Project icons: an optional user-uploaded image that represents a project in
+-- the rail (in place of the initials fallback). Stored as bytes in the database
+-- per product requirement, in a dedicated 1:1 table so the hot `projects.*`
+-- SELECT that powers the rail and the project list never pulls the image blob.
+
+CREATE TABLE project_icons (
+    project_id   UUID PRIMARY KEY REFERENCES projects(id) ON DELETE CASCADE,
+    content_type TEXT NOT NULL,
+    data         BYTEA NOT NULL,
+    byte_size    INTEGER NOT NULL,
+    width        INTEGER NOT NULL,
+    height       INTEGER NOT NULL,
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/packages/server/src/lib/image-dimensions.ts
+++ b/packages/server/src/lib/image-dimensions.ts
@@ -1,0 +1,87 @@
+/**
+ * Read the pixel dimensions of a raster image from its header bytes — no image
+ * library. Used to defensively enforce the project-icon size cap server-side
+ * (the client already downscales, but the server must not trust the client).
+ *
+ * Supports the formats the client can emit after normalization: PNG, JPEG,
+ * GIF, and WebP (VP8/VP8L/VP8X). Returns `null` when the bytes aren't a
+ * recognized/parseable image of those types.
+ */
+export interface ImageDimensions {
+	width: number;
+	height: number;
+}
+
+export function readImageDimensions(buf: Buffer): ImageDimensions | null {
+	return readPng(buf) ?? readGif(buf) ?? readWebp(buf) ?? readJpeg(buf);
+}
+
+function readPng(buf: Buffer): ImageDimensions | null {
+	// 8-byte signature, then an IHDR chunk whose data starts at offset 16:
+	// width (4 bytes BE) and height (4 bytes BE).
+	if (buf.length < 24) return null;
+	const sig = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+	for (let i = 0; i < sig.length; i++) {
+		if (buf[i] !== sig[i]) return null;
+	}
+	if (buf.toString('ascii', 12, 16) !== 'IHDR') return null;
+	return { width: buf.readUInt32BE(16), height: buf.readUInt32BE(20) };
+}
+
+function readGif(buf: Buffer): ImageDimensions | null {
+	// "GIF87a"/"GIF89a", then logical screen width/height as LE uint16.
+	if (buf.length < 10) return null;
+	const header = buf.toString('ascii', 0, 6);
+	if (header !== 'GIF87a' && header !== 'GIF89a') return null;
+	return { width: buf.readUInt16LE(6), height: buf.readUInt16LE(8) };
+}
+
+function readWebp(buf: Buffer): ImageDimensions | null {
+	// RIFF container: "RIFF" .... "WEBP" then a VP8/VP8L/VP8X chunk.
+	if (buf.length < 30) return null;
+	if (buf.toString('ascii', 0, 4) !== 'RIFF' || buf.toString('ascii', 8, 12) !== 'WEBP') {
+		return null;
+	}
+	const format = buf.toString('ascii', 12, 16);
+	if (format === 'VP8 ') {
+		// Lossy: dimensions live after the 3-byte start code at offset 23/25.
+		return { width: buf.readUInt16LE(26) & 0x3fff, height: buf.readUInt16LE(28) & 0x3fff };
+	}
+	if (format === 'VP8L') {
+		// Lossless: 14-bit width/height packed after a 1-byte signature at 21.
+		const bits = buf.readUInt32LE(21);
+		return { width: (bits & 0x3fff) + 1, height: ((bits >> 14) & 0x3fff) + 1 };
+	}
+	if (format === 'VP8X') {
+		// Extended: 24-bit (width-1)/(height-1) at offsets 24 and 27.
+		const width = 1 + (buf[24] | (buf[25] << 8) | (buf[26] << 16));
+		const height = 1 + (buf[27] | (buf[28] << 8) | (buf[29] << 16));
+		return { width, height };
+	}
+	return null;
+}
+
+function readJpeg(buf: Buffer): ImageDimensions | null {
+	// SOI marker, then a sequence of marker segments; the SOFn frame header
+	// carries height/width as BE uint16 at segment offsets 5 and 7.
+	if (buf.length < 4 || buf[0] !== 0xff || buf[1] !== 0xd8) return null;
+	let offset = 2;
+	while (offset + 9 < buf.length) {
+		if (buf[offset] !== 0xff) {
+			offset++;
+			continue;
+		}
+		const marker = buf[offset + 1];
+		// SOF0..SOF15 (excluding DHT=0xc4, DAC=0xcc, RSTn) carry the frame size.
+		const isSof =
+			marker >= 0xc0 && marker <= 0xcf && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc;
+		if (isSof) {
+			return { width: buf.readUInt16BE(offset + 7), height: buf.readUInt16BE(offset + 5) };
+		}
+		// Skip this segment using its length field (BE uint16, includes itself).
+		const segLen = buf.readUInt16BE(offset + 2);
+		if (segLen < 2) return null;
+		offset += 2 + segLen;
+	}
+	return null;
+}

--- a/packages/server/src/lib/project-icon-urls.ts
+++ b/packages/server/src/lib/project-icon-urls.ts
@@ -1,0 +1,50 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { ATTACHMENT_SIGNED_URL_TTL_SECONDS } from '@hezo/shared';
+import { deriveKey } from '../crypto/encryption';
+import type { MasterKeyManager } from '../crypto/master-key';
+
+// A project icon is rendered in an `<img>` tag, which cannot carry a bearer
+// token, so it is served from a public endpoint guarded by an HMAC-signed URL —
+// the same pattern as asset reads (`lib/asset-urls.ts`), keyed separately.
+const KEY_PURPOSE = 'project-icon-url';
+
+async function getSigningKey(masterKeyManager: MasterKeyManager): Promise<Buffer> {
+	const unlockKeyHex = masterKeyManager.getUnlockKeyHex();
+	if (!unlockKeyHex) throw new Error('Master key not available');
+	return deriveKey(unlockKeyHex, KEY_PURPOSE);
+}
+
+/**
+ * Sign a time-limited URL for a project's icon. `version` (the icon's
+ * `updated_at` epoch) is appended as an unsigned `v` query param so the `<img>`
+ * cache busts when the icon changes, while the signature only covers the
+ * project id + expiry.
+ */
+export async function signProjectIconUrl(
+	projectId: string,
+	masterKeyManager: MasterKeyManager,
+	version: number,
+	ttlSeconds: number = ATTACHMENT_SIGNED_URL_TTL_SECONDS,
+): Promise<string> {
+	const exp = Math.floor(Date.now() / 1000) + ttlSeconds;
+	const key = await getSigningKey(masterKeyManager);
+	const sig = createHmac('sha256', key).update(`${projectId}|${exp}`).digest('base64url');
+	return `/api/projects/${projectId}/icon?exp=${exp}&sig=${sig}&v=${version}`;
+}
+
+export async function verifyProjectIconUrl(
+	projectId: string,
+	exp: number,
+	sig: string,
+	masterKeyManager: MasterKeyManager,
+): Promise<boolean> {
+	if (!Number.isFinite(exp) || Math.floor(Date.now() / 1000) > exp) return false;
+	const key = await getSigningKey(masterKeyManager);
+	const expected = createHmac('sha256', key).update(`${projectId}|${exp}`).digest('base64url');
+	if (sig.length !== expected.length) return false;
+	try {
+		return timingSafeEqual(Buffer.from(sig), Buffer.from(expected));
+	} catch {
+		return false;
+	}
+}

--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -1,10 +1,21 @@
 import type { PGlite } from '@electric-sql/pglite';
-import { AuthType, ContainerStatus, MemberType, wsRoom } from '@hezo/shared';
+import {
+	AuthType,
+	ContainerStatus,
+	isAllowedProjectIconStoredMime,
+	MemberType,
+	PROJECT_ICON_MAX_BYTES,
+	PROJECT_ICON_MAX_DIMENSION,
+	wsRoom,
+} from '@hezo/shared';
 import { type Context, Hono } from 'hono';
+import { bodyLimit } from 'hono/body-limit';
 import { trackBackground } from '../lib/background';
 import { broadcastChange, broadcastProjectUpdate } from '../lib/broadcast';
 import { budgetWindowsError } from '../lib/budget-validation';
+import { readImageDimensions } from '../lib/image-dimensions';
 import { ref } from '../lib/log-ref';
+import { signProjectIconUrl, verifyProjectIconUrl } from '../lib/project-icon-urls';
 import { err, ok } from '../lib/response';
 import { toSlug, uniqueSlug } from '../lib/slug';
 import { terminalStatusParams } from '../lib/sql';
@@ -39,6 +50,26 @@ function buildContainerDeps(c: Context<Env>): ContainerDeps {
 }
 
 const log = logger.child('routes');
+
+/**
+ * Attach a freshly-signed `icon_url` to a serialized project row when it has an
+ * icon (`icon_updated_at` is present from a LEFT-correlated subselect against
+ * `project_icons`). The icon bytes themselves are never selected onto the row.
+ */
+async function withIconUrl(
+	c: Context<Env>,
+	row: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+	const updatedAt = row.icon_updated_at;
+	if (typeof updatedAt === 'string' || updatedAt instanceof Date) {
+		const version = Math.floor(new Date(updatedAt).getTime() / 1000);
+		row.icon_url = await signProjectIconUrl(row.id as string, c.get('masterKeyManager'), version);
+	} else {
+		row.icon_url = null;
+		row.icon_updated_at = null;
+	}
+	return row;
+}
 
 async function cancelRunningAgentTasks(
 	db: PGlite,
@@ -84,7 +115,8 @@ projectsRoutes.get('/projects', async (c) => {
           WHERE ce.project_id = p.id AND ce.created_at >= date_trunc('day', now()))::int
           AS today_spend_cents,
        COALESCE((SELECT max(i3.updated_at) FROM tasks i3 WHERE i3.project_id = p.id), p.created_at)
-          AS last_activity_at
+          AS last_activity_at,
+       (SELECT pi.updated_at FROM project_icons pi WHERE pi.project_id = p.id) AS icon_updated_at
      FROM projects p
      JOIN teams t ON t.id = p.team_id`;
 
@@ -101,7 +133,10 @@ projectsRoutes.get('/projects', async (c) => {
 	}
 
 	const result = await db.query(query, params);
-	return ok(c, result.rows);
+	const rows = await Promise.all(
+		result.rows.map((r) => withIconUrl(c, r as Record<string, unknown>)),
+	);
+	return ok(c, rows);
 });
 
 // Projects-primary creation: a project owns its own team (1:1). "Create a
@@ -263,7 +298,8 @@ projectsRoutes.get('/projects/:projectId', async (c) => {
 	const result = await db.query(
 		`SELECT p.*,
        (SELECT count(*) FROM repos r WHERE r.project_id = p.id)::int AS repo_count,
-       (SELECT count(*) FROM tasks i WHERE i.project_id = p.id AND i.status NOT IN (${ts2.placeholders}))::int AS open_task_count
+       (SELECT count(*) FROM tasks i WHERE i.project_id = p.id AND i.status NOT IN (${ts2.placeholders}))::int AS open_task_count,
+       (SELECT pi.updated_at FROM project_icons pi WHERE pi.project_id = p.id) AS icon_updated_at
      FROM projects p
      WHERE p.id = $1 AND p.team_id = $2`,
 		[projectId, teamId, ...ts2.values],
@@ -278,7 +314,8 @@ projectsRoutes.get('/projects/:projectId', async (c) => {
 		[projectId],
 	);
 
-	return ok(c, { ...(result.rows[0] as Record<string, unknown>), repos: repos.rows });
+	const row = await withIconUrl(c, result.rows[0] as Record<string, unknown>);
+	return ok(c, { ...row, repos: repos.rows });
 });
 
 projectsRoutes.patch('/projects/:projectId', async (c) => {
@@ -396,6 +433,91 @@ projectsRoutes.patch('/projects/:projectId', async (c) => {
 		result.rows[0] as Record<string, unknown>,
 	);
 	return ok(c, result.rows[0]);
+});
+
+// --- Project icon -------------------------------------------------------------
+// An optional user-uploaded image shown in the rail in place of the initials.
+// Stored as bytes in the DB (project_icons, 1:1). The client normalizes any
+// picked image to a square PNG ≤ PROJECT_ICON_MAX_DIMENSION before upload; the
+// server re-validates content-type, byte size, and pixel dimensions defensively.
+
+projectsRoutes.put(
+	'/projects/:projectId/icon',
+	bodyLimit({
+		maxSize: PROJECT_ICON_MAX_BYTES,
+		onError: (c) => err(c, 'TOO_LARGE', 'Icon exceeds the size limit', 400),
+	}),
+	async (c) => {
+		const teamId = c.get('teamId') as string;
+		const db = c.get('db');
+		const projectId = c.get('projectId') as string;
+		if (!projectId) return err(c, 'NOT_FOUND', 'Project not found', 404);
+
+		let form: Awaited<ReturnType<typeof c.req.parseBody>>;
+		try {
+			form = await c.req.parseBody({ all: false });
+		} catch (e) {
+			log.error('project icon parseBody failed:', e);
+			return err(c, 'INVALID_REQUEST', 'Malformed upload', 400);
+		}
+		const file = form.file;
+		if (!(file instanceof Blob)) {
+			return err(c, 'INVALID_REQUEST', 'Missing file field', 400);
+		}
+
+		const contentType = file.type || 'application/octet-stream';
+		if (!isAllowedProjectIconStoredMime(contentType)) {
+			return err(c, 'INVALID_ATTACHMENT', `Unsupported content type: ${contentType}`, 400);
+		}
+		if (file.size > PROJECT_ICON_MAX_BYTES) {
+			return err(c, 'TOO_LARGE', 'Icon exceeds the size limit', 400);
+		}
+
+		const buf = Buffer.from(await file.arrayBuffer());
+		const dims = readImageDimensions(buf);
+		if (!dims) {
+			return err(c, 'INVALID_ATTACHMENT', 'Could not read image dimensions', 400);
+		}
+		if (dims.width > PROJECT_ICON_MAX_DIMENSION || dims.height > PROJECT_ICON_MAX_DIMENSION) {
+			return err(
+				c,
+				'INVALID_ATTACHMENT',
+				`Icon exceeds ${PROJECT_ICON_MAX_DIMENSION}×${PROJECT_ICON_MAX_DIMENSION} pixels`,
+				400,
+			);
+		}
+
+		const updated = await db.query<{ updated_at: string }>(
+			`INSERT INTO project_icons (project_id, content_type, data, byte_size, width, height, updated_at)
+			 VALUES ($1, $2, $3, $4, $5, $6, now())
+			 ON CONFLICT (project_id) DO UPDATE SET
+			   content_type = EXCLUDED.content_type,
+			   data         = EXCLUDED.data,
+			   byte_size    = EXCLUDED.byte_size,
+			   width        = EXCLUDED.width,
+			   height       = EXCLUDED.height,
+			   updated_at   = now()
+			 RETURNING updated_at`,
+			[projectId, contentType, buf, buf.byteLength, dims.width, dims.height],
+		);
+
+		await broadcastProjectUpdate(db, c.get('wsManager'), teamId, projectId);
+
+		const version = Math.floor(new Date(updated.rows[0].updated_at).getTime() / 1000);
+		const iconUrl = await signProjectIconUrl(projectId, c.get('masterKeyManager'), version);
+		return ok(c, { icon_url: iconUrl, icon_updated_at: updated.rows[0].updated_at });
+	},
+);
+
+projectsRoutes.delete('/projects/:projectId/icon', async (c) => {
+	const teamId = c.get('teamId') as string;
+	const db = c.get('db');
+	const projectId = c.get('projectId') as string;
+	if (!projectId) return err(c, 'NOT_FOUND', 'Project not found', 404);
+
+	await db.query('DELETE FROM project_icons WHERE project_id = $1', [projectId]);
+	await broadcastProjectUpdate(db, c.get('wsManager'), teamId, projectId);
+	return ok(c, { icon_url: null, icon_updated_at: null });
 });
 
 projectsRoutes.delete('/projects/:projectId', async (c) => {
@@ -591,4 +713,46 @@ projectsRoutes.post('/projects/:projectId/container/rebuild', async (c) => {
 	);
 
 	return ok(c, { container_status: ContainerStatus.Creating });
+});
+
+// Public signed-URL read endpoint for a project icon. Rendered in an `<img>`
+// tag, which can't carry a bearer token, so the HMAC `sig` query param is the
+// credential. Must be mounted before the `/api/*` auth middleware.
+export const publicProjectsRoutes = new Hono<Env>();
+
+publicProjectsRoutes.get('/api/projects/:projectId/icon', async (c) => {
+	const projectId = c.req.param('projectId');
+	const expRaw = c.req.query('exp');
+	const sig = c.req.query('sig');
+	if (!expRaw || !sig) {
+		return err(c, 'UNAUTHORIZED', 'Missing signature', 401);
+	}
+	const exp = Number.parseInt(expRaw, 10);
+	const masterKeyManager = c.get('masterKeyManager');
+	const valid = await verifyProjectIconUrl(projectId, exp, sig, masterKeyManager);
+	if (!valid) {
+		return err(c, 'UNAUTHORIZED', 'Invalid or expired signature', 401);
+	}
+
+	const row = await c.get('db').query<{
+		content_type: string;
+		data: Uint8Array;
+		updated_at: string;
+	}>('SELECT content_type, data, updated_at FROM project_icons WHERE project_id = $1', [projectId]);
+	if (row.rows.length === 0) {
+		return err(c, 'NOT_FOUND', 'Icon not found', 404);
+	}
+	const { content_type, data, updated_at } = row.rows[0];
+	const src = data instanceof Uint8Array ? data : new Uint8Array(data);
+	// Copy into a fresh ArrayBuffer so the body type is Uint8Array<ArrayBuffer>
+	// (PGlite hands back a Uint8Array<ArrayBufferLike>).
+	const ab = new ArrayBuffer(src.byteLength);
+	new Uint8Array(ab).set(src);
+
+	return c.body(new Uint8Array(ab), 200, {
+		'Content-Type': content_type,
+		'Content-Length': String(src.byteLength),
+		'Cache-Control': 'private, max-age=3600',
+		ETag: `"${new Date(updated_at).getTime()}"`,
+	});
 });

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -46,7 +46,7 @@ import { oauthRoutes } from './routes/oauth';
 import { preferencesRoutes } from './routes/preferences';
 import { previewRoutes } from './routes/preview';
 import { projectDocsRoutes } from './routes/project-docs';
-import { projectsRoutes } from './routes/projects';
+import { projectsRoutes, publicProjectsRoutes } from './routes/projects';
 import { queuedWakeupsRoutes } from './routes/queued-wakeups';
 import { reposRoutes } from './routes/repos';
 import { searchRoutes } from './routes/search';
@@ -437,6 +437,11 @@ export function buildApp(
 	// Public signed-URL asset read endpoint (sig query is the credential, so it
 	// must be reachable without a bearer token).
 	app.route('/', publicAssetsRoutes);
+
+	// Public signed-URL project-icon read endpoint — same rationale (rendered in
+	// an <img>, so the sig query param is the credential). Mounted before the
+	// /api/* auth + project-access middleware so it bypasses the bearer check.
+	app.route('/', publicProjectsRoutes);
 
 	// Auth middleware for all /api/* routes
 	app.use('/api/*', authMiddleware);

--- a/packages/server/test/image-dimensions.test.ts
+++ b/packages/server/test/image-dimensions.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { readImageDimensions } from '../src/lib/image-dimensions';
+
+function png(width: number, height: number): Buffer {
+	const sig = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+	const ihdr = Buffer.alloc(25);
+	ihdr.writeUInt32BE(13, 0);
+	ihdr.write('IHDR', 4, 'ascii');
+	ihdr.writeUInt32BE(width, 8);
+	ihdr.writeUInt32BE(height, 12);
+	return Buffer.concat([sig, ihdr]);
+}
+
+function gif(width: number, height: number): Buffer {
+	const buf = Buffer.alloc(10);
+	buf.write('GIF89a', 0, 'ascii');
+	buf.writeUInt16LE(width, 6);
+	buf.writeUInt16LE(height, 8);
+	return buf;
+}
+
+function jpeg(width: number, height: number): Buffer {
+	// SOI + an SOF0 segment carrying height/width.
+	const soi = Buffer.from([0xff, 0xd8]);
+	const sof = Buffer.alloc(11);
+	sof[0] = 0xff;
+	sof[1] = 0xc0; // SOF0
+	sof.writeUInt16BE(11 - 2, 2); // segment length
+	sof[4] = 8; // precision
+	sof.writeUInt16BE(height, 5);
+	sof.writeUInt16BE(width, 7);
+	return Buffer.concat([soi, sof]);
+}
+
+describe('readImageDimensions', () => {
+	it('reads PNG dimensions', () => {
+		expect(readImageDimensions(png(512, 256))).toEqual({ width: 512, height: 256 });
+	});
+
+	it('reads GIF dimensions', () => {
+		expect(readImageDimensions(gif(48, 64))).toEqual({ width: 48, height: 64 });
+	});
+
+	it('reads JPEG dimensions', () => {
+		expect(readImageDimensions(jpeg(100, 200))).toEqual({ width: 100, height: 200 });
+	});
+
+	it('returns null for non-image bytes', () => {
+		expect(readImageDimensions(Buffer.from('not an image'))).toBeNull();
+	});
+});

--- a/packages/server/test/migrate-002-project-icons.test.ts
+++ b/packages/server/test/migrate-002-project-icons.test.ts
@@ -1,0 +1,63 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createDataPreservationHarness, type DataPreservationHarness } from './helpers/migrate';
+
+const TARGET = '002_project_icons.sql';
+
+describe('002_project_icons migration', () => {
+	let h: DataPreservationHarness;
+	let projectId: string;
+
+	beforeAll(async () => {
+		h = await createDataPreservationHarness();
+		await h.applyUpToExclusive(TARGET);
+
+		const team = await h.db.query<{ id: string }>(
+			`INSERT INTO teams (name, slug) VALUES ('Acme', 'acme') RETURNING id`,
+		);
+		const project = await h.db.query<{ id: string }>(
+			`INSERT INTO projects (team_id, name, slug, task_prefix)
+			 VALUES ($1, 'Acme Project', 'acme-project', 'AP') RETURNING id`,
+			[team.rows[0].id],
+		);
+		projectId = project.rows[0].id;
+
+		await h.applyTarget(TARGET);
+	});
+	afterAll(() => h.close());
+
+	it('creates the project_icons table with the icon columns', async () => {
+		const cols = await h.db.query<{ column_name: string }>(
+			`SELECT column_name FROM information_schema.columns WHERE table_name = 'project_icons'`,
+		);
+		const names = cols.rows.map((r) => r.column_name).sort();
+		expect(names).toEqual(
+			['byte_size', 'content_type', 'data', 'height', 'project_id', 'updated_at', 'width'].sort(),
+		);
+	});
+
+	it('preserves pre-existing project rows', async () => {
+		const kept = await h.db.query(`SELECT 1 FROM projects WHERE id = $1`, [projectId]);
+		expect(kept.rows.length).toBe(1);
+	});
+
+	it('stores and reads back icon bytes 1:1 with a project', async () => {
+		const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x01, 0x02, 0x03]);
+		await h.db.query(
+			`INSERT INTO project_icons (project_id, content_type, data, byte_size, width, height)
+			 VALUES ($1, 'image/png', $2, $3, 512, 512)`,
+			[projectId, bytes, bytes.byteLength],
+		);
+		const r = await h.db.query<{ data: Uint8Array; content_type: string }>(
+			`SELECT data, content_type FROM project_icons WHERE project_id = $1`,
+			[projectId],
+		);
+		expect(r.rows[0].content_type).toBe('image/png');
+		expect(Buffer.from(r.rows[0].data).equals(bytes)).toBe(true);
+	});
+
+	it('cascades icon deletion when the project is removed', async () => {
+		await h.db.query(`DELETE FROM projects WHERE id = $1`, [projectId]);
+		const r = await h.db.query(`SELECT 1 FROM project_icons WHERE project_id = $1`, [projectId]);
+		expect(r.rows.length).toBe(0);
+	});
+});

--- a/packages/server/test/project-icon.test.ts
+++ b/packages/server/test/project-icon.test.ts
@@ -1,0 +1,116 @@
+import type { PGlite } from '@electric-sql/pglite';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Env } from '../src/lib/types';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp } from './helpers/app';
+
+let app: Hono<Env>;
+let db: PGlite;
+let token: string;
+let projectSlug: string;
+
+const DESCRIPTION = 'A backend API that serves authenticated requests for the main app.';
+
+/**
+ * Build a minimal but structurally-valid PNG: the 8-byte signature plus an IHDR
+ * chunk carrying the given dimensions. `readImageDimensions` only parses the
+ * header, so the rest of the file body is omitted.
+ */
+function pngWithDimensions(width: number, height: number): Buffer {
+	const sig = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+	const ihdr = Buffer.alloc(25);
+	ihdr.writeUInt32BE(13, 0); // chunk length
+	ihdr.write('IHDR', 4, 'ascii');
+	ihdr.writeUInt32BE(width, 8);
+	ihdr.writeUInt32BE(height, 12);
+	return Buffer.concat([sig, ihdr]);
+}
+
+function iconForm(bytes: Buffer, type = 'image/png'): FormData {
+	const fd = new FormData();
+	fd.set('file', new Blob([bytes], { type }), 'icon.png');
+	return fd;
+}
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+
+	const res = await app.request('/api/projects', {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ name: 'Icon Project', description: DESCRIPTION }),
+	});
+	projectSlug = (await res.json()).data.slug;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+describe('project icon upload/serve', () => {
+	it('uploads an icon and returns a signed url', async () => {
+		const res = await app.request(`/api/projects/${projectSlug}/icon`, {
+			method: 'PUT',
+			headers: authHeader(token),
+			body: iconForm(pngWithDimensions(512, 512)),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data.icon_url).toMatch(/\/api\/projects\/[\w-]+\/icon\?exp=\d+&sig=[^&]+&v=\d+/);
+		expect(body.data.icon_updated_at).toBeTruthy();
+	});
+
+	it('serves the stored bytes from the signed url', async () => {
+		const list = await app.request('/api/projects', { headers: authHeader(token) });
+		const project = (await list.json()).data.find((p: { slug: string }) => p.slug === projectSlug);
+		expect(project.icon_url).toBeTruthy();
+
+		const res = await app.request(project.icon_url);
+		expect(res.status).toBe(200);
+		expect(res.headers.get('Content-Type')).toBe('image/png');
+		const buf = Buffer.from(await res.arrayBuffer());
+		expect(buf.equals(pngWithDimensions(512, 512))).toBe(true);
+	});
+
+	it('rejects an unsigned request to the serve endpoint', async () => {
+		const res = await app.request(`/api/projects/${projectSlug}/icon`);
+		expect(res.status).toBe(401);
+	});
+
+	it('rejects an image exceeding 512px', async () => {
+		const res = await app.request(`/api/projects/${projectSlug}/icon`, {
+			method: 'PUT',
+			headers: authHeader(token),
+			body: iconForm(pngWithDimensions(513, 512)),
+		});
+		expect(res.status).toBe(400);
+	});
+
+	it('rejects an unsupported content type', async () => {
+		const res = await app.request(`/api/projects/${projectSlug}/icon`, {
+			method: 'PUT',
+			headers: authHeader(token),
+			body: iconForm(Buffer.from('<svg/>'), 'image/svg+xml'),
+		});
+		expect(res.status).toBe(400);
+	});
+
+	it('removes the icon', async () => {
+		const del = await app.request(`/api/projects/${projectSlug}/icon`, {
+			method: 'DELETE',
+			headers: authHeader(token),
+		});
+		expect(del.status).toBe(200);
+
+		const list = await app.request('/api/projects', { headers: authHeader(token) });
+		const project = (await list.json()).data.find((p: { slug: string }) => p.slug === projectSlug);
+		expect(project.icon_url).toBeNull();
+
+		const rows = await db.query('SELECT 1 FROM project_icons WHERE project_id IS NOT NULL');
+		expect(rows.rows.length).toBe(0);
+	});
+});

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -198,6 +198,41 @@ export type UpdateState = (typeof UpdateState)[keyof typeof UpdateState];
 export const ATTACHMENT_MAX_BYTES = 10 * 1024 * 1024;
 export const ATTACHMENT_SIGNED_URL_TTL_SECONDS = 3600;
 
+// Project icons are normalized client-side to a square PNG no larger than
+// PROJECT_ICON_MAX_DIMENSION on each side before upload; the server enforces
+// both caps defensively. The byte cap is generous for a 512×512 PNG (~1 MB).
+export const PROJECT_ICON_MAX_DIMENSION = 512;
+export const PROJECT_ICON_MAX_BYTES = 1024 * 1024;
+
+// Formats accepted from the file picker. Everything is rasterized to a PNG on
+// the client (animated GIFs flatten to a still frame; SVG is rasterized), so the
+// bytes the server stores are always one of the raster types below.
+export const PROJECT_ICON_INPUT_MIME: ReadonlySet<string> = new Set([
+	'image/png',
+	'image/jpeg',
+	'image/webp',
+	'image/gif',
+	'image/svg+xml',
+]);
+
+// Raster content types the server will store for an icon (post client-side
+// normalization). SVG is intentionally excluded — its pixel dimensions can't be
+// bounded, and the client always sends a rasterized PNG.
+export const PROJECT_ICON_STORED_MIME: ReadonlySet<string> = new Set([
+	'image/png',
+	'image/jpeg',
+	'image/webp',
+	'image/gif',
+]);
+
+export function isAllowedProjectIconInputMime(mime: string): boolean {
+	return PROJECT_ICON_INPUT_MIME.has(mime);
+}
+
+export function isAllowedProjectIconStoredMime(mime: string): boolean {
+	return PROJECT_ICON_STORED_MIME.has(mime);
+}
+
 export const ATTACHMENT_EXTENSIONS = {
 	txt: 'text/plain',
 	html: 'text/html',

--- a/packages/web/src/components/project-icon-section.tsx
+++ b/packages/web/src/components/project-icon-section.tsx
@@ -1,0 +1,150 @@
+import { isAllowedProjectIconInputMime } from '@hezo/shared';
+import { ImagePlus, Loader2 } from 'lucide-react';
+import { useRef, useState } from 'react';
+import { type Project, useRemoveProjectIcon, useUploadProjectIcon } from '../hooks/use-projects';
+import { toast } from '../hooks/use-toast';
+import { normalizeProjectIcon } from '../lib/normalize-image';
+import { Avatar, getInitials } from './ui/avatar';
+import { Button } from './ui/button';
+
+interface Preview {
+	blob: Blob;
+	url: string;
+}
+
+/**
+ * GitHub-style project-icon control: shows the current icon (or the initials
+ * fallback), lets the user pick an image, previews the center-cropped square
+ * before saving, and removes an existing icon. The picked image is normalized to
+ * a ≤512×512 PNG client-side (`normalizeProjectIcon`) before upload.
+ */
+export function ProjectIconSection({ project }: { project: Project }) {
+	const upload = useUploadProjectIcon(project.slug);
+	const remove = useRemoveProjectIcon(project.slug);
+	const inputRef = useRef<HTMLInputElement>(null);
+	const [preview, setPreview] = useState<Preview | null>(null);
+	const [processing, setProcessing] = useState(false);
+
+	const busy = processing || upload.isPending || remove.isPending;
+
+	function clearPreview() {
+		setPreview((prev) => {
+			if (prev) URL.revokeObjectURL(prev.url);
+			return null;
+		});
+	}
+
+	async function handleFile(file: File) {
+		if (!isAllowedProjectIconInputMime(file.type)) {
+			toast.error('Unsupported image type. Use PNG, JPEG, WebP, GIF, or SVG.');
+			return;
+		}
+		setProcessing(true);
+		try {
+			const blob = await normalizeProjectIcon(file);
+			clearPreview();
+			setPreview({ blob, url: URL.createObjectURL(blob) });
+		} catch {
+			toast.error('Could not read that image. Try a different file.');
+		} finally {
+			setProcessing(false);
+		}
+	}
+
+	async function handleSave() {
+		if (!preview) return;
+		try {
+			await upload.mutateAsync(preview.blob);
+			clearPreview();
+		} catch {
+			toast.error('Failed to upload icon');
+		}
+	}
+
+	async function handleRemove() {
+		try {
+			await remove.mutateAsync();
+		} catch {
+			toast.error('Failed to remove icon');
+		}
+	}
+
+	const shownUrl = preview?.url ?? project.icon_url ?? undefined;
+
+	return (
+		<section>
+			<h2 className="text-sm font-medium text-text-2 mb-3">Project icon</h2>
+			<div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+				<div data-testid="project-icon-preview">
+					<Avatar initials={getInitials(project.name)} imageUrl={shownUrl} size="lg" />
+				</div>
+				<div className="flex flex-col gap-2">
+					<div className="flex flex-wrap gap-2">
+						<input
+							ref={inputRef}
+							type="file"
+							accept="image/png,image/jpeg,image/webp,image/gif,image/svg+xml"
+							className="hidden"
+							data-testid="project-icon-input"
+							onChange={(e) => {
+								const file = e.target.files?.[0];
+								// Reset so re-picking the same file fires change again.
+								e.target.value = '';
+								if (file) void handleFile(file);
+							}}
+						/>
+						{preview ? (
+							<>
+								<Button
+									size="sm"
+									onClick={handleSave}
+									disabled={busy}
+									data-testid="project-icon-save"
+								>
+									{upload.isPending ? <Loader2 className="w-3 h-3 animate-spin" /> : 'Save icon'}
+								</Button>
+								<Button size="sm" variant="ghost" onClick={clearPreview} disabled={busy}>
+									Cancel
+								</Button>
+							</>
+						) : (
+							<>
+								<Button
+									size="sm"
+									variant="outline"
+									onClick={() => inputRef.current?.click()}
+									disabled={busy}
+									data-testid="project-icon-upload"
+								>
+									{processing ? (
+										<Loader2 className="w-3 h-3 animate-spin" />
+									) : (
+										<>
+											<ImagePlus className="w-3.5 h-3.5 mr-1.5" />
+											{project.icon_url ? 'Replace image' : 'Upload image'}
+										</>
+									)}
+								</Button>
+								{project.icon_url && (
+									<Button
+										size="sm"
+										variant="destructive"
+										onClick={handleRemove}
+										disabled={busy}
+										data-testid="project-icon-remove"
+									>
+										{remove.isPending ? <Loader2 className="w-3 h-3 animate-spin" /> : 'Remove'}
+									</Button>
+								)}
+							</>
+						)}
+					</div>
+					<p className="text-xs text-text-3">
+						Shown in the project rail. Square images work best; we crop to a square and resize to{' '}
+						512×512. Leave unset to show the project initials.
+					</p>
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/packages/web/src/components/project-rail.tsx
+++ b/packages/web/src/components/project-rail.tsx
@@ -60,7 +60,11 @@ export function ProjectRail() {
 										isActive ? 'ring-2 ring-inverse ring-offset-1 ring-offset-surface-2' : ''
 									}`}
 								>
-									<Avatar initials={getInitials(p.name)} color={avatarColorFromString(p.name)} />
+									<Avatar
+										initials={getInitials(p.name)}
+										color={avatarColorFromString(p.name)}
+										imageUrl={p.icon_url}
+									/>
 									<CountOverlayBadge
 										count={inboxCounts[p.slug] ?? 0}
 										testId={`project-rail-inbox-badge-${p.slug}`}

--- a/packages/web/src/components/ui/avatar.tsx
+++ b/packages/web/src/components/ui/avatar.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 // Avatars are monochrome (the spec: "monochrome, color = state"). Identity is
 // the initials; state (a running agent) is shown by a cyan `--live` ring.
 const sizeMap = {
@@ -17,6 +19,8 @@ interface AvatarProps {
 	color?: AvatarColor;
 	/** Running agents get a cyan live ring. */
 	running?: boolean;
+	/** Optional image (e.g. a project icon). Falls back to initials on load error. */
+	imageUrl?: string | null;
 	className?: string;
 }
 
@@ -35,14 +39,32 @@ export function avatarColorFromString(str: string): AvatarColor {
 	return AVATAR_COLORS[Math.abs(hash) % AVATAR_COLORS.length];
 }
 
-export function Avatar({ initials, size = 'md', running = false, className = '' }: AvatarProps) {
+export function Avatar({
+	initials,
+	size = 'md',
+	running = false,
+	imageUrl,
+	className = '',
+}: AvatarProps) {
+	// Track the specific URL that failed so a later icon change re-attempts the image.
+	const [failedUrl, setFailedUrl] = useState<string | null>(null);
+	const showImage = !!imageUrl && failedUrl !== imageUrl;
 	return (
 		<div
-			className={`inline-flex shrink-0 items-center justify-center rounded-full border border-border bg-surface-3 font-semibold text-text-2 ${
+			className={`inline-flex shrink-0 items-center justify-center overflow-hidden rounded-full border border-border bg-surface-3 font-semibold text-text-2 ${
 				sizeMap[size]
 			} ${running ? 'ring-2 ring-live ring-offset-2 ring-offset-bg' : ''} ${className}`}
 		>
-			{initials.slice(0, 2).toUpperCase()}
+			{showImage ? (
+				<img
+					src={imageUrl}
+					alt=""
+					className="h-full w-full object-cover"
+					onError={() => setFailedUrl(imageUrl)}
+				/>
+			) : (
+				initials.slice(0, 2).toUpperCase()
+			)}
 		</div>
 	);
 }

--- a/packages/web/src/hooks/use-projects.ts
+++ b/packages/web/src/hooks/use-projects.ts
@@ -194,9 +194,31 @@ export interface ProjectIconResponse {
 }
 
 /**
+ * Seed the icon fields into the cached project detail + index from a server
+ * response, so the rail and settings reflect the change immediately rather than
+ * waiting for the invalidated queries to refetch (which races under load). The
+ * server returns the signed `icon_url`, so this is response-driven, not optimistic.
+ */
+function applyIconToCaches(projectId: string, icon: ProjectIconResponse) {
+	queryClient.setQueryData<Project>(queryKeys.projects.detail(projectId), (old) =>
+		old ? { ...old, icon_url: icon.icon_url, icon_updated_at: icon.icon_updated_at } : old,
+	);
+	queryClient.setQueryData<Project[]>(queryKeys.projects.all(), (old) =>
+		old?.map((p) =>
+			p.slug === projectId || p.id === projectId
+				? { ...p, icon_url: icon.icon_url, icon_updated_at: icon.icon_updated_at }
+				: p,
+		),
+	);
+	// Reconcile against the server (e.g. exact timestamps) without blocking the UI.
+	queryClient.invalidateQueries({ queryKey: queryKeys.projects.all() });
+	queryClient.invalidateQueries({ queryKey: queryKeys.projects.detail(projectId) });
+}
+
+/**
  * Upload (or replace) a project's icon. `blob` is the already-normalized square
- * PNG produced client-side. Invalidates the project index + detail so the rail
- * and settings page re-render with the new signed `icon_url`.
+ * PNG produced client-side. The response carries the signed `icon_url`, which we
+ * write straight into the project caches so the rail and settings update at once.
  */
 export function useUploadProjectIcon(projectId: string) {
 	return useMutation<ProjectIconResponse, ApiError, Blob>({
@@ -205,19 +227,13 @@ export function useUploadProjectIcon(projectId: string) {
 			fd.set('file', blob, 'icon.png');
 			return api.putForm<ProjectIconResponse>(`/api/projects/${projectId}/icon`, fd);
 		},
-		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: queryKeys.projects.all() });
-			queryClient.invalidateQueries({ queryKey: queryKeys.projects.detail(projectId) });
-		},
+		onSuccess: (data) => applyIconToCaches(projectId, data),
 	});
 }
 
 export function useRemoveProjectIcon(projectId: string) {
 	return useMutation<ProjectIconResponse, ApiError, void>({
 		mutationFn: () => api.delete<ProjectIconResponse>(`/api/projects/${projectId}/icon`),
-		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: queryKeys.projects.all() });
-			queryClient.invalidateQueries({ queryKey: queryKeys.projects.detail(projectId) });
-		},
+		onSuccess: () => applyIconToCaches(projectId, { icon_url: null, icon_updated_at: null }),
 	});
 }

--- a/packages/web/src/hooks/use-projects.ts
+++ b/packages/web/src/hooks/use-projects.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { api } from '../lib/api';
+import { type ApiError, api } from '../lib/api';
 import { queryClient } from '../lib/query-client';
 import { queryKeys } from '../lib/query-keys';
 import { useSimpleOptimisticUpdate } from './use-optimistic-mutation';
@@ -37,6 +37,10 @@ export interface Project {
 	/** Most recent task update, falling back to the project's creation time. */
 	last_activity_at: string;
 	created_at: string;
+	/** Signed URL for the project's icon image, or null when none is set. */
+	icon_url?: string | null;
+	/** When the icon was last set (drives the `<img>` cache version), or null. */
+	icon_updated_at?: string | null;
 	repos?: Repo[];
 	planning_task_id?: string;
 	planning_task_identifier?: string;
@@ -181,5 +185,39 @@ export function useDeleteProject() {
 	return useMutation({
 		mutationFn: (projectId: string) => api.delete(`/api/projects/${projectId}`),
 		onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.projects.all() }),
+	});
+}
+
+export interface ProjectIconResponse {
+	icon_url: string | null;
+	icon_updated_at: string | null;
+}
+
+/**
+ * Upload (or replace) a project's icon. `blob` is the already-normalized square
+ * PNG produced client-side. Invalidates the project index + detail so the rail
+ * and settings page re-render with the new signed `icon_url`.
+ */
+export function useUploadProjectIcon(projectId: string) {
+	return useMutation<ProjectIconResponse, ApiError, Blob>({
+		mutationFn: (blob) => {
+			const fd = new FormData();
+			fd.set('file', blob, 'icon.png');
+			return api.putForm<ProjectIconResponse>(`/api/projects/${projectId}/icon`, fd);
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: queryKeys.projects.all() });
+			queryClient.invalidateQueries({ queryKey: queryKeys.projects.detail(projectId) });
+		},
+	});
+}
+
+export function useRemoveProjectIcon(projectId: string) {
+	return useMutation<ProjectIconResponse, ApiError, void>({
+		mutationFn: () => api.delete<ProjectIconResponse>(`/api/projects/${projectId}/icon`),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: queryKeys.projects.all() });
+			queryClient.invalidateQueries({ queryKey: queryKeys.projects.detail(projectId) });
+		},
 	});
 }

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -109,11 +109,19 @@ class ApiClient {
 	}
 
 	async postForm<T>(path: string, formData: FormData): Promise<T> {
+		return this.sendForm<T>('POST', path, formData);
+	}
+
+	async putForm<T>(path: string, formData: FormData): Promise<T> {
+		return this.sendForm<T>('PUT', path, formData);
+	}
+
+	private async sendForm<T>(method: string, path: string, formData: FormData): Promise<T> {
 		const headers: Record<string, string> = {};
 		if (this.token) headers.Authorization = `Bearer ${this.token}`;
 
 		const res = await fetch(path, {
-			method: 'POST',
+			method,
 			headers,
 			body: formData,
 		});

--- a/packages/web/src/lib/normalize-image.ts
+++ b/packages/web/src/lib/normalize-image.ts
@@ -1,0 +1,63 @@
+import { PROJECT_ICON_MAX_DIMENSION } from '@hezo/shared';
+
+/**
+ * Normalize a user-picked image file into a square PNG no larger than
+ * `PROJECT_ICON_MAX_DIMENSION` per side, center-cropped to a square. Handles
+ * raster formats and SVG (rasterized via the browser); animated GIFs collapse
+ * to their first frame. Returns a PNG `Blob` ready to upload.
+ *
+ * Throws if the file can't be decoded as an image.
+ */
+export async function normalizeProjectIcon(file: File): Promise<Blob> {
+	const bitmap = await loadImage(file);
+	try {
+		const srcSize = Math.min(bitmap.width, bitmap.height);
+		if (srcSize <= 0) throw new Error('Image has no pixels');
+		const sx = (bitmap.width - srcSize) / 2;
+		const sy = (bitmap.height - srcSize) / 2;
+		const outSize = Math.min(srcSize, PROJECT_ICON_MAX_DIMENSION);
+
+		const canvas = document.createElement('canvas');
+		canvas.width = outSize;
+		canvas.height = outSize;
+		const ctx = canvas.getContext('2d');
+		if (!ctx) throw new Error('Canvas 2D context unavailable');
+		ctx.imageSmoothingQuality = 'high';
+		ctx.drawImage(bitmap, sx, sy, srcSize, srcSize, 0, 0, outSize, outSize);
+
+		return await new Promise<Blob>((resolve, reject) => {
+			canvas.toBlob(
+				(blob) => (blob ? resolve(blob) : reject(new Error('Failed to encode image'))),
+				'image/png',
+			);
+		});
+	} finally {
+		if ('close' in bitmap && typeof bitmap.close === 'function') bitmap.close();
+	}
+}
+
+/** Decode a file into a drawable bitmap, falling back to an <img> for SVG. */
+async function loadImage(file: File): Promise<ImageBitmap | HTMLImageElement> {
+	// SVG must go through an <img> element so the browser rasterizes it; some
+	// browsers reject SVG in createImageBitmap.
+	if (file.type !== 'image/svg+xml' && 'createImageBitmap' in window) {
+		try {
+			return await createImageBitmap(file);
+		} catch {
+			// Fall through to the <img> path for formats createImageBitmap can't decode.
+		}
+	}
+	const url = URL.createObjectURL(file);
+	try {
+		const img = new Image();
+		img.decoding = 'async';
+		await new Promise<void>((resolve, reject) => {
+			img.onload = () => resolve();
+			img.onerror = () => reject(new Error('Could not decode image'));
+			img.src = url;
+		});
+		return img;
+	} finally {
+		URL.revokeObjectURL(url);
+	}
+}

--- a/packages/web/src/routes/projects/$projectId/settings/index.tsx
+++ b/packages/web/src/routes/projects/$projectId/settings/index.tsx
@@ -4,6 +4,7 @@ import { ExternalLink, Loader2 } from 'lucide-react';
 import { useState } from 'react';
 import { ProjectBudgetPanel } from '../../../../components/budget/project-budget-panel';
 import { GitHubSection } from '../../../../components/github-section';
+import { ProjectIconSection } from '../../../../components/project-icon-section';
 import { Button } from '../../../../components/ui/button';
 import { Input } from '../../../../components/ui/input';
 import { Textarea } from '../../../../components/ui/textarea';
@@ -50,6 +51,8 @@ function ProjectSettingsPage() {
 
 	return (
 		<div className="space-y-8">
+			<ProjectIconSection project={project} />
+
 			<section>
 				<h2 className="text-sm font-medium text-text-2 mb-3">General</h2>
 				{editing ? (

--- a/packages/web/test/project-icon.test.tsx
+++ b/packages/web/test/project-icon.test.tsx
@@ -1,0 +1,91 @@
+import { expect, test } from 'vitest';
+import { getTestContext, renderApp } from './helpers/render';
+import { type SeededProject, seedProject, seedWorkspace } from './helpers/seed';
+
+/** A structurally-valid 512×512 PNG header — enough for the server's dimension check. */
+function pngHeader(): Uint8Array {
+	const sig = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+	const ihdr = new Uint8Array(25);
+	const view = new DataView(ihdr.buffer);
+	view.setUint32(0, 13);
+	ihdr.set([0x49, 0x48, 0x44, 0x52], 4); // "IHDR"
+	view.setUint32(8, 512);
+	view.setUint32(12, 512);
+	return new Uint8Array([...sig, ...ihdr]);
+}
+
+/** Upload a project icon through the real API (bypassing the client canvas crop). */
+async function seedProjectIcon(project: SeededProject): Promise<void> {
+	const { apiBase, token } = getTestContext();
+	const fd = new FormData();
+	fd.set('file', new Blob([pngHeader() as BlobPart], { type: 'image/png' }), 'icon.png');
+	const res = await apiBase(`/api/projects/${project.slug}/icon`, {
+		method: 'PUT',
+		headers: { Authorization: `Bearer ${token}` },
+		body: fd,
+	});
+	if (res.status !== 200) throw new Error(`seedProjectIcon failed: ${res.status}`);
+}
+
+test('the rail renders the icon image when a project has one', async () => {
+	let slug = '';
+	const { findByTestId } = await renderApp({
+		initialPath: '/home',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Pictured' });
+			await seedProjectIcon(project);
+			slug = project.slug;
+		},
+	});
+
+	const avatar = await findByTestId(`project-rail-avatar-${slug}`, undefined, { timeout: 15_000 });
+	await expect.poll(() => avatar.querySelector('img'), { timeout: 15_000 }).toBeTruthy();
+	const img = avatar.querySelector('img');
+	expect(img?.getAttribute('src')).toContain(`/icon?exp=`);
+});
+
+test('settings shows Upload image with no icon, and Replace/Remove once set', async () => {
+	let withIcon: SeededProject;
+	const { findByTestId, queryByTestId, router } = await renderApp({
+		initialPath: '/home',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			withIcon = await seedProject(ws, { name: 'Branded' });
+			await seedProjectIcon(withIcon);
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/settings',
+		params: { projectId: withIcon!.slug },
+	});
+
+	// An existing icon shows Replace + Remove, never the first-run Upload label.
+	await findByTestId('project-icon-remove', undefined, { timeout: 15_000 });
+	const upload = await findByTestId('project-icon-upload');
+	expect(upload.textContent).toContain('Replace image');
+	expect(queryByTestId('project-icon-preview')?.querySelector('img')).toBeTruthy();
+});
+
+test('settings shows the initials fallback and Upload image when no icon is set', async () => {
+	let plain: SeededProject;
+	const { findByTestId, queryByTestId, router } = await renderApp({
+		initialPath: '/home',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			plain = await seedProject(ws, { name: 'Plain' });
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/settings',
+		params: { projectId: plain!.slug },
+	});
+
+	const upload = await findByTestId('project-icon-upload', undefined, { timeout: 15_000 });
+	expect(upload.textContent).toContain('Upload image');
+	expect(queryByTestId('project-icon-remove')).toBeNull();
+	// No icon → the preview shows initials, not an <img>.
+	expect(queryByTestId('project-icon-preview')?.querySelector('img')).toBeFalsy();
+});

--- a/test/browser/project-icon.spec.ts
+++ b/test/browser/project-icon.spec.ts
@@ -1,0 +1,63 @@
+// Playwright (not component): the upload flow normalizes the picked image with a
+// real canvas — createImageBitmap + canvas.toBlob('image/png') — which happy-dom
+// can't execute (reason #3: native input/canvas work the component runner can't
+// synthesize). Only a real browser engine produces the cropped PNG that gets
+// uploaded, so the end-to-end "pick → crop → save → renders in rail" path lives here.
+
+import { expect, test } from './fixtures';
+import { createProjectAndClearPlanning, uniqueName, waitForPageLoad } from './helpers';
+
+// A small but fully-valid 1×1 PNG the browser can decode and re-encode.
+const PNG_BYTES = [
+	0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+	0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+	0x89, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00,
+	0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae,
+	0x42, 0x60, 0x82,
+];
+
+test.describe('Project icon', () => {
+	test('upload an image in settings, then it renders in the rail', async ({
+		sharedPage: page,
+		sharedWorkspace,
+	}) => {
+		const project = await createProjectAndClearPlanning(page, '', sharedWorkspace.token, {
+			name: uniqueName('Iconic'),
+			description: 'Project icon e2e.',
+		});
+
+		await page.goto(`/projects/${project.slug}/settings`);
+		await waitForPageLoad(page);
+
+		// First-run state: Upload image, no Remove.
+		await expect(page.getByTestId('project-icon-upload')).toContainText('Upload image');
+		await expect(page.getByTestId('project-icon-remove')).toHaveCount(0);
+
+		// Pick a file — the hidden input drives handleFile → canvas normalize → preview.
+		await page.getByTestId('project-icon-input').setInputFiles({
+			name: 'logo.png',
+			mimeType: 'image/png',
+			buffer: Buffer.from(PNG_BYTES),
+		});
+
+		// Save the cropped preview; wait for the PUT to land.
+		const saveBtn = page.getByTestId('project-icon-save');
+		await expect(saveBtn).toBeVisible({ timeout: 15_000 });
+		const putResponse = page.waitForResponse(
+			(r) =>
+				r.url().includes(`/api/projects/${project.slug}/icon`) &&
+				r.request().method() === 'PUT' &&
+				r.status() === 200,
+		);
+		await saveBtn.click();
+		await putResponse;
+
+		// Settings now reflects the icon: Remove appears, preview holds an <img>.
+		await expect(page.getByTestId('project-icon-remove')).toBeVisible({ timeout: 15_000 });
+		await expect(page.getByTestId('project-icon-preview').locator('img')).toBeVisible();
+
+		// The rail avatar for this project renders the icon image, not initials.
+		const railAvatar = page.getByTestId(`project-rail-avatar-${project.slug}`);
+		await expect(railAvatar.locator('img')).toBeVisible({ timeout: 15_000 });
+	});
+});


### PR DESCRIPTION
## What & why

Projects in the rail were represented only by monochrome initials, with no way to give a project a distinct visual identity. This lets users upload an image to represent a project. The icon renders as the thumbnail in the project rail in place of the initials; when no icon is set, the initials remain the fallback (the default — users opt in from Settings).

## UX (GitHub-style)

In a project's **Settings → Project icon**:
- Pick any common image (PNG / JPEG / WebP / GIF / SVG).
- It's cropped to a square and resized to **512×512** client-side, with a preview before saving.
- **Replace image** to swap, **Remove** to revert to initials.

Mobile-first responsive layout.

## How it works

- **Stored in the database** as bytes (`BYTEA`) in a dedicated 1:1 `project_icons` table (`ON DELETE CASCADE`), kept off the hot `projects.*` list query so the rail/list never pulls the blob.
- Served from a **public HMAC-signed read route** `GET /api/projects/:projectId/icon` — an `<img>` tag carries no bearer token, so the `sig` query param is the credential (same pattern as asset reads). The serialized project carries a freshly-signed `icon_url` (null when unset).
- Upload/remove via `PUT`/`DELETE` on the same path (auth + project-access gated, body-limited).
- The client normalizes any picked image to a square PNG ≤512×512 via canvas; the server **re-validates** content type, byte size, and pixel dimensions defensively with a pure-JS image-header parser — **no image library added**.

## Tests

- Migration data-preservation (`migrate-002-project-icons`)
- Server route: upload → signed-URL serve → unsigned 401 → oversized/bad-type/dimension rejects → delete
- `image-dimensions` unit (PNG/JPEG/GIF parsing)
- Web component: rail renders `<img>` when set / initials when not; settings Upload vs Replace/Remove states
- Playwright: real-canvas pick → crop → save → renders in rail

## Docs

Updated `.dev/architecture.md` (data model + serve route) and the user-facing `docs/concepts/projects-and-teams.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWjSHD3fWgs5qDwyFwHVbW

---
_Generated by [Claude Code](https://claude.ai/code/session_01QWjSHD3fWgs5qDwyFwHVbW)_