### PR TITLE
feat(credentials): auto-fill suggested allowed hosts on credential requests

### DIFF
--- a/packages/shared/src/credentials/suggest-allowed-hosts.ts
+++ b/packages/shared/src/credentials/suggest-allowed-hosts.ts
@@ -1,0 +1,152 @@
+/**
+ * Best-effort inference of the `allowed_hosts` allowlist for a credential
+ * request, so the human fulfilling it doesn't have to hand-type the API
+ * host(s) the egress proxy should scope the secret to.
+ *
+ * Two complementary signals are combined:
+ *
+ *  1. **The request text** — any `https://host/…` URL the requesting agent put
+ *     in its instructions is a concrete, request-specific hint (e.g. a
+ *     self-hosted instance URL like `https://umami.acme.io`, which no static
+ *     table could know). URL hosts win, since they describe *this* request.
+ *  2. **Web knowledge of well-known services** — a curated map (plus the
+ *     connector registry) of common SaaS API hosts, keyed by a token that
+ *     typically appears in the credential's name or instructions
+ *     (`NETLIFY_AUTH_TOKEN` → `api.netlify.com`).
+ *
+ * The result is only a *suggestion*: the human always reviews and can edit or
+ * clear it before the secret is stored. It is therefore intentionally generous
+ * (a wrong suggestion costs one edit) rather than conservative.
+ */
+
+import { CONNECTOR_CAPABILITIES } from '../types/connector-capabilities.js';
+
+export interface SuggestAllowedHostsInput {
+	/** The credential name, e.g. `NETLIFY_AUTH_TOKEN`. */
+	name?: string;
+	/** The human-facing instructions the agent attached to the request. */
+	instructions?: string;
+}
+
+/**
+ * Curated API hosts for well-known services, keyed by a lowercase token that
+ * commonly shows up in a credential name or its instructions. This is the
+ * "web knowledge of the service" layer. Kept intentionally focused on common
+ * providers — the URL-extraction signal covers the long tail (anything whose
+ * endpoint the agent names explicitly), and the human reviews the result.
+ */
+const KNOWN_SERVICE_HOSTS: Record<string, string[]> = {
+	netlify: ['api.netlify.com'],
+	vercel: ['api.vercel.com'],
+	stripe: ['api.stripe.com'],
+	openai: ['api.openai.com'],
+	anthropic: ['api.anthropic.com'],
+	openrouter: ['openrouter.ai'],
+	deepseek: ['api.deepseek.com'],
+	groq: ['api.groq.com'],
+	cohere: ['api.cohere.com'],
+	huggingface: ['huggingface.co', 'api-inference.huggingface.co'],
+	sendgrid: ['api.sendgrid.com'],
+	mailgun: ['api.mailgun.net'],
+	postmark: ['api.postmarkapp.com'],
+	resend: ['api.resend.com'],
+	twilio: ['api.twilio.com'],
+	slack: ['slack.com'],
+	discord: ['discord.com'],
+	github: ['api.github.com'],
+	gitlab: ['gitlab.com'],
+	linear: ['api.linear.app'],
+	notion: ['api.notion.com'],
+	airtable: ['api.airtable.com'],
+	hubspot: ['api.hubapi.com'],
+	shopify: ['*.myshopify.com'],
+	supabase: ['*.supabase.co'],
+	cloudflare: ['api.cloudflare.com'],
+	digitalocean: ['api.digitalocean.com'],
+	datadog: ['api.datadoghq.com'],
+	sentry: ['sentry.io'],
+	pagerduty: ['api.pagerduty.com'],
+	mixpanel: ['api.mixpanel.com'],
+	amplitude: ['api.amplitude.com'],
+	posthog: ['app.posthog.com'],
+	algolia: ['*.algolia.net'],
+	pinecone: ['*.pinecone.io'],
+	contentful: ['api.contentful.com'],
+	datocms: ['site-api.datocms.com'],
+	sanity: ['api.sanity.io'],
+};
+
+/**
+ * Hosts that are never a useful API allowlist entry — placeholders and
+ * loopback addresses an agent might paste as an example.
+ */
+const GENERIC_HOSTS = new Set([
+	'example.com',
+	'example.org',
+	'example.net',
+	'localhost',
+	'127.0.0.1',
+	'0.0.0.0',
+]);
+
+const MAX_SUGGESTIONS = 6;
+
+/** Pull the host portion out of every `http(s)://…` URL in a block of text. */
+function extractUrlHosts(text: string): string[] {
+	const hosts: string[] = [];
+	const re = /https?:\/\/([^\s/:?#"'`)]+)/gi;
+	let match: RegExpExecArray | null = re.exec(text);
+	while (match !== null) {
+		const host = match[1].toLowerCase();
+		if (host.includes('.')) hosts.push(host);
+		match = re.exec(text);
+	}
+	return hosts;
+}
+
+/** Lowercase alphanumeric tokens of a string (split on every non-alphanumeric run). */
+function tokenize(text: string): string[] {
+	return text
+		.toLowerCase()
+		.split(/[^a-z0-9]+/)
+		.filter((t) => t.length > 0);
+}
+
+/**
+ * Suggest an `allowed_hosts` allowlist for a credential request from its name
+ * and instructions. Returns a de-duplicated, ordered list (URL-derived hosts
+ * first, then known-service hosts), or an empty array when nothing matches.
+ */
+export function suggestAllowedHosts(input: SuggestAllowedHostsInput): string[] {
+	const name = input.name ?? '';
+	const instructions = input.instructions ?? '';
+
+	const ordered: string[] = [];
+	const seen = new Set<string>();
+	const add = (host: string) => {
+		const h = host.trim().toLowerCase();
+		if (h.length === 0 || GENERIC_HOSTS.has(h) || seen.has(h)) return;
+		seen.add(h);
+		ordered.push(h);
+	};
+
+	// 1. Concrete hosts named in the instructions — most request-specific.
+	for (const host of extractUrlHosts(instructions)) add(host);
+
+	// 2. Known-service hosts: match name tokens first (the strongest signal),
+	//    then instruction tokens.
+	const nameTokens = new Set(tokenize(name));
+	const instructionTokens = new Set(tokenize(instructions));
+	for (const tokens of [nameTokens, instructionTokens]) {
+		for (const [service, hosts] of Object.entries(KNOWN_SERVICE_HOSTS)) {
+			if (tokens.has(service)) hosts.forEach(add);
+		}
+		// The connector registry is a second source of known hosts (its ids
+		// match the same service tokens, e.g. `github`, `linear`, `vercel`).
+		for (const [id, capability] of Object.entries(CONNECTOR_CAPABILITIES)) {
+			if (tokens.has(id)) capability.allowedHosts.forEach(add);
+		}
+	}
+
+	return ordered.slice(0, MAX_SUGGESTIONS);
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,6 @@
 export * from './budget.js';
 export * from './constants.js';
+export * from './credentials/suggest-allowed-hosts.js';
 export * from './crypto/auth.js';
 export * from './crypto/mnemonic.js';
 export * from './mentions/index.js';

--- a/packages/shared/test/suggest-allowed-hosts.test.ts
+++ b/packages/shared/test/suggest-allowed-hosts.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { suggestAllowedHosts } from '../src/credentials/suggest-allowed-hosts.js';
+
+describe('suggestAllowedHosts', () => {
+	it('extracts the host from a URL named in the instructions', () => {
+		const hosts = suggestAllowedHosts({
+			name: 'UMAMI_INSTANCE_URL',
+			instructions: 'Use the self-hosted instance at https://umami.hezo.ai or similar.',
+		});
+		expect(hosts).toContain('umami.hezo.ai');
+	});
+
+	it('strips the path, query, and port from an instruction URL', () => {
+		const hosts = suggestAllowedHosts({
+			name: 'API_BASE',
+			instructions: 'Base URL: https://app.acme.io:8443/v2/path?token=x#frag',
+		});
+		expect(hosts).toContain('app.acme.io');
+		expect(hosts).not.toContain('app.acme.io:8443');
+	});
+
+	it('maps a well-known service from the credential name', () => {
+		expect(suggestAllowedHosts({ name: 'NETLIFY_AUTH_TOKEN' })).toEqual(['api.netlify.com']);
+		expect(suggestAllowedHosts({ name: 'STRIPE_SECRET_KEY' })).toEqual(['api.stripe.com']);
+	});
+
+	it('maps a well-known service mentioned only in the instructions', () => {
+		const hosts = suggestAllowedHosts({
+			name: 'DEPLOY_TOKEN',
+			instructions: 'Create a personal token from the Vercel dashboard.',
+		});
+		expect(hosts).toContain('api.vercel.com');
+	});
+
+	it('falls back to the connector registry for its service ids', () => {
+		const hosts = suggestAllowedHosts({ name: 'LINEAR_API_KEY' });
+		expect(hosts).toContain('api.linear.app');
+	});
+
+	it('puts URL-derived hosts before known-service hosts and de-dupes', () => {
+		const hosts = suggestAllowedHosts({
+			name: 'NETLIFY_TOKEN',
+			instructions: 'See https://app.netlify.com/account and https://app.netlify.com/teams',
+		});
+		expect(hosts[0]).toBe('app.netlify.com'); // URL host first
+		expect(hosts).toContain('api.netlify.com'); // known-service host after
+		// de-duped: app.netlify.com appears once despite two URLs
+		expect(hosts.filter((h) => h === 'app.netlify.com')).toHaveLength(1);
+	});
+
+	it('drops generic placeholder and loopback hosts', () => {
+		const hosts = suggestAllowedHosts({
+			name: 'SOME_KEY',
+			instructions: 'e.g. https://example.com or http://localhost:3000 or http://127.0.0.1:8080',
+		});
+		expect(hosts).toEqual([]);
+	});
+
+	it('lowercases hosts', () => {
+		const hosts = suggestAllowedHosts({
+			name: 'X',
+			instructions: 'Endpoint: https://API.Example.IO/health',
+		});
+		expect(hosts).toContain('api.example.io');
+	});
+
+	it('returns an empty array when nothing matches', () => {
+		expect(suggestAllowedHosts({ name: 'GENERIC_SECRET', instructions: 'paste it here' })).toEqual(
+			[],
+		);
+	});
+
+	it('handles missing name and instructions', () => {
+		expect(suggestAllowedHosts({})).toEqual([]);
+	});
+
+	it('caps the number of suggestions', () => {
+		const instructions = Array.from({ length: 12 }, (_, i) => `https://h${i}.example.io/x`).join(
+			' ',
+		);
+		expect(suggestAllowedHosts({ name: 'X', instructions }).length).toBeLessThanOrEqual(6);
+	});
+});

--- a/packages/web/src/components/comment-renderers/credential-request-comment.tsx
+++ b/packages/web/src/components/comment-renderers/credential-request-comment.tsx
@@ -1,3 +1,4 @@
+import { suggestAllowedHosts } from '@hezo/shared';
 import { Check, KeyRound } from 'lucide-react';
 import { useState } from 'react';
 import { useFulfillCredential } from '../../hooks/use-comments';
@@ -23,9 +24,20 @@ export function CredentialRequestComment({ comment, projectId, taskId }: Props) 
 	const allowedHosts = Array.isArray(content.allowed_hosts) ? content.allowed_hosts : [];
 	const fulfilled = typeof comment.chosen_option?.secret_id === 'string';
 
+	// When the agent didn't scope the request, pre-fill the field with a
+	// best-guess allowlist inferred from the credential name and instructions
+	// (curated service hosts + any URL the agent named). It's only a suggestion —
+	// the human reviews and can edit or clear it before the secret is stored.
+	const suggestedHosts =
+		allowedHosts.length === 0 ? suggestAllowedHosts({ name, instructions }) : [];
+
 	const [value, setValue] = useState('');
-	const [hostsInput, setHostsInput] = useState(allowedHosts.join(', '));
+	const [hostsInput, setHostsInput] = useState(
+		allowedHosts.length > 0 ? allowedHosts.join(', ') : suggestedHosts.join(', '),
+	);
+	const [hostsEdited, setHostsEdited] = useState(false);
 	const [error, setError] = useState<string | null>(null);
+	const showSuggestionHint = !hostsEdited && suggestedHosts.length > 0 && hostsInput.length > 0;
 	const fulfill = useFulfillCredential(projectId ?? '', taskId ?? '');
 
 	const parseHosts = (raw: string): string[] =>
@@ -164,12 +176,20 @@ export function CredentialRequestComment({ comment, projectId, taskId }: Props) 
 							id={`hosts-${comment.id}`}
 							type="text"
 							value={hostsInput}
-							onChange={(e) => setHostsInput(e.target.value)}
+							onChange={(e) => {
+								setHostsInput(e.target.value);
+								setHostsEdited(true);
+							}}
 							placeholder="e.g. api.netlify.com, *.netlify.com"
 							autoComplete="off"
 							className="w-full text-sm p-2 rounded border border-border bg-surface focus:outline-none focus:border-info"
 							data-testid="credential-hosts-input"
 						/>
+						{showSuggestionHint && (
+							<p className="text-xs text-text-3" data-testid="credential-hosts-suggested">
+								Suggested from the request — review and edit if these aren't right.
+							</p>
+						)}
 					</div>
 					{error && <p className="text-xs text-danger-soft-fg">{error}</p>}
 					<div>

--- a/packages/web/test/credential-request-comment.test.tsx
+++ b/packages/web/test/credential-request-comment.test.tsx
@@ -72,7 +72,11 @@ test('human can set allowed_hosts when fulfilling an unscoped request', async ()
 	await findByTestId('credential-request', undefined, { timeout: 15_000 });
 
 	await user.type(await findByTestId('credential-input'), 'tok-123');
-	await user.type(await findByTestId('credential-hosts-input'), 'api.netlify.com, *.netlify.com');
+	// The field prefills with an inferred suggestion (NETLIFY_* → api.netlify.com);
+	// clear it before typing the exact allowlist this test asserts on.
+	const hostsField = await findByTestId('credential-hosts-input');
+	await user.clear(hostsField);
+	await user.type(hostsField, 'api.netlify.com, *.netlify.com');
 	await user.click(await findByTestId('credential-submit'));
 
 	// Fulfillment swaps the form for the confirmation block.
@@ -257,6 +261,69 @@ test('an already-fulfilled request renders the fulfilled state directly', async 
 	const fulfilled = await findByTestId('credential-fulfilled', undefined, { timeout: 15_000 });
 	expect(fulfilled.textContent).toContain('PREFILLED_TOKEN provided');
 	expect(fulfilled.textContent).toContain('__HEZO_SECRET_PREFILLED_TOKEN__');
+});
+
+test('prefills allowed_hosts from a known service in the name when the agent left it unscoped', async () => {
+	const { findByTestId } = await renderTaskWithCredentialContent({
+		name: 'NETLIFY_AUTH_TOKEN',
+		kind: 'other',
+		input_type: 'text',
+		instructions: 'Create a personal access token from the dashboard.',
+		// no allowed_hosts — the agent did not scope the request
+	});
+
+	const hosts = (await findByTestId('credential-hosts-input', undefined, {
+		timeout: 15_000,
+	})) as HTMLInputElement;
+	await waitFor(() => expect(hosts.value).toBe('api.netlify.com'));
+	// The suggestion hint is shown until the human edits the field.
+	await findByTestId('credential-hosts-suggested');
+});
+
+test('prefills allowed_hosts from a URL named in the instructions (self-hosted service)', async () => {
+	const { findByTestId } = await renderTaskWithCredentialContent({
+		name: 'UMAMI_INSTANCE_URL',
+		kind: 'other',
+		input_type: 'text',
+		instructions: 'Use the self-hosted instance at https://umami.hezo.ai or similar.',
+	});
+
+	const hosts = (await findByTestId('credential-hosts-input', undefined, {
+		timeout: 15_000,
+	})) as HTMLInputElement;
+	await waitFor(() => expect(hosts.value).toBe('umami.hezo.ai'));
+});
+
+test('editing the prefilled hosts clears the suggestion hint', async () => {
+	const { findByTestId, queryByTestId, user } = await renderTaskWithCredentialContent({
+		name: 'STRIPE_SECRET_KEY',
+		kind: 'other',
+		input_type: 'text',
+	});
+
+	const hosts = (await findByTestId('credential-hosts-input', undefined, {
+		timeout: 15_000,
+	})) as HTMLInputElement;
+	await waitFor(() => expect(hosts.value).toBe('api.stripe.com'));
+	await findByTestId('credential-hosts-suggested');
+
+	await user.type(hosts, ', api.override.com');
+	expect(queryByTestId('credential-hosts-suggested')).toBeNull();
+});
+
+test('does not prefill or hint when the credential name is generic and no URL is given', async () => {
+	const { findByTestId, queryByTestId } = await renderTaskWithCredentialContent({
+		name: 'GENERIC_SECRET',
+		kind: 'other',
+		input_type: 'text',
+		instructions: 'Paste the value here.',
+	});
+
+	const hosts = (await findByTestId('credential-hosts-input', undefined, {
+		timeout: 15_000,
+	})) as HTMLInputElement;
+	expect(hosts.value).toBe('');
+	expect(queryByTestId('credential-hosts-suggested')).toBeNull();
 });
 
 test('textarea input_type renders a multi-line value field; host override seeds from the request', async () => {


### PR DESCRIPTION
## What

When an agent asks a human for a credential (`request_credential` → the "Agent needs credential" card), the **Allowed hosts** field rendered empty and warned _"Not scoped to any host."_ The human had to know and hand-type the API host(s) the egress proxy should scope the secret to — friction, and a common source of an under-scoped (undeliverable) secret.

This pre-fills that field with a best-guess suggestion the human reviews, edits, or clears before submitting. Nothing is stored until they confirm.

## How

- **New shared pure helper** `suggestAllowedHosts({ name, instructions })` (`packages/shared/src/credentials/suggest-allowed-hosts.ts`). Two signals, combined / de-duped / capped, URL-derived hosts first:
  - **URL extraction** — pulls the host out of any `http(s)://…` URL the agent named in its instructions (covers self-hosted / long-tail services like `https://umami.hezo.ai`). Drops placeholders/loopback (`example.com`, `localhost`, …).
  - **Built-in service knowledge** — a curated `token → host[]` map of common SaaS API hosts (`NETLIFY_AUTH_TOKEN` → `api.netlify.com`), matched against the credential name first then the instructions, plus the existing `CONNECTOR_CAPABILITIES` registry (reused — its ids already carry `allowedHosts`).
- **Credential card** (`credential-request-comment.tsx`) seeds its hosts input from the suggestion **only when the agent left the request unscoped**, with a small hint marking it as a suggestion (cleared once the human edits). When the agent did declare hosts, behaviour is unchanged.

No MCP tool / REST / stored-data-shape changes — this is a UI-side prefill of an existing field plus a pure helper.

## Tests

- `packages/shared/test/suggest-allowed-hosts.test.ts` (11 cases): URL extraction, port/path stripping, known-service-by-name, service-in-instructions, connector-registry hit, ordering + de-dup, generic-host filtering, lowercasing, empty/no-match, cap.
- `packages/web/test/credential-request-comment.test.tsx`: prefill from a known service, prefill from an instruction URL, hint clears on edit, no prefill for a generic name; existing "human sets hosts" test updated to clear the now-prefilled field first.

Verification: `bunx vitest run` (shared + web credential suites) green; `bun run typecheck` and biome clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SxjfV3RgNUBdhSz1BD2DKu)_