### PR TITLE
chore: tell agents to edit project docs via write_project_doc, not Edit/Write

### DIFF
--- a/packages/server/src/services/template-resolver.ts
+++ b/packages/server/src/services/template-resolver.ts
@@ -301,7 +301,7 @@ export async function resolveSystemPrompt(
 					.join('\n');
 				docsText = [
 					'The project docs database holds high-level project context (PRDs, specs, architecture decisions, research). Entries are listed below by filename.',
-					"Call read_project_doc(filename) to load a doc's full contents when relevant to your task. These docs live in the database, not the filesystem — there is no /workspace/.hezo/project-docs path, so don't use the Read/cat file tools; load each one by its bare filename through read_project_doc.",
+					"Call read_project_doc(filename) to load a doc's full contents when relevant to your task. These docs live in the database, not the filesystem — there is no /workspace/.hezo/project-docs path, so don't use the Read/cat file tools; load each one by its bare filename through read_project_doc. To create or change a doc, call write_project_doc(filename, content) (it overwrites the whole doc) — the Edit/Write file tools target disk and will not touch these, so never reach for them to edit a doc.",
 					'',
 					lines,
 				].join('\n');

--- a/packages/server/test/template-resolver.test.ts
+++ b/packages/server/test/template-resolver.test.ts
@@ -143,6 +143,11 @@ describe('template resolver', () => {
 		expect(result).toContain('not the filesystem');
 		expect(result).toContain('/workspace/.hezo/project-docs');
 
+		// It also names the *write* path so agents don't reflexively reach for the
+		// Edit/Write file tools when they go to change a doc (they target disk).
+		expect(result).toContain('write_project_doc(filename, content)');
+		expect(result).toContain('will not touch these');
+
 		// Titled doc (architecture-guidelines.md is seeded by createTestProject with a non-empty title).
 		expect(result).toMatch(
 			/- architecture-guidelines\.md — Architecture Guidelines \(updated \d{4}-\d{2}-\d{2}\)/,


### PR DESCRIPTION
## Problem

Follow-up to #431. Even with the "docs live in the DB" guidance, agents were still slipping at **write** time. In a real transcript the agent:

1. Read a doc correctly via `read_project_doc` ✅
2. Then reflexively reached for the **`Edit`** file tool on an invented on-disk path (`/home/node/.claude/.../memory/umami-provisioning-edit.md`) ❌
3. Self-corrected a tool-call later: *"it's not a file on disk… I need to use `write_project_doc`"* ✅

The cost is a wasted tool call each time, and it keeps recurring.

## Root cause

The project-docs manifest header — the text sitting **right next to the doc list** the agent reads when deciding to act — only described the *read* path (`read_project_doc`) and "don't use the Read/cat file tools". It never named the **write** path, so at the moment the agent goes to *modify* a doc, nothing adjacent steers it off `Edit`/`Write`.

## Change

`packages/server/src/services/template-resolver.ts` — the populated manifest header now also says: to create or change a doc, call `write_project_doc(filename, content)` (overwrites the whole doc), and the `Edit`/`Write` file tools target disk and will not touch DB-backed docs. The empty-state already named `write_project_doc` (from #431).

Test in `template-resolver.test.ts` asserts the new write guidance is present.

## Testing

`bunx vitest run test/template-resolver.test.ts` — 76 passed. Typecheck + build green via pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012HDrV1hkLcDsrD5HoQMq2G)_