### PR TITLE
feat(assets): allow markdown as a project asset with rendered viewer

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -151,7 +151,10 @@ interrupted run still counts against budgets.
 unique scoping and full revision history in `document_revisions`. `skills` is the
 instance/team reference store (manifest-injected into runs, full-text-searchable) with
 `skill_revisions` history. `assets` + `task_attachments`/`comment_attachments` handle
-uploaded files (bytes on local disk, served over HMAC-signed URLs). `project_icons`
+uploaded files (bytes on local disk, served over HMAC-signed URLs); agents can also author
+text-based assets directly (`write_project_asset` — HTML, SVG, plain text, and markdown such
+as a blog post), and the web app renders markdown assets with a rich preview plus a
+view-source toggle. `project_icons`
 (1:1 with `projects`, `ON DELETE CASCADE`) holds an optional per-project icon image —
 unlike assets the **bytes live in the DB** (a `BYTEA` column) in a dedicated table so the
 hot `projects.*` list query never pulls the blob; it is rendered in the project rail and

--- a/docs/concepts/assets.md
+++ b/docs/concepts/assets.md
@@ -19,11 +19,15 @@ the discussion it belongs to.
 ## Agent-generated assets
 
 Agents don't just consume assets — they create them. An agent can write an interactive
-**HTML** mockup, an **SVG** diagram, or a plain-text export straight into the library
-(`write_project_asset` over Hezo's [MCP server](/docs/mcp/hezo-mcp-server)) and read any
-asset back later. Generated deliverables live here rather than being committed to the source
-repository, so they're easy to find and review, and re-saving the same filename updates it in
-place so references stay stable.
+**HTML** mockup, an **SVG** diagram, a plain-text export, or a **markdown** deliverable such
+as a blog post or report straight into the library (`write_project_asset` over Hezo's
+[MCP server](/docs/mcp/hezo-mcp-server)) and read any asset back later. Generated deliverables
+live here rather than being committed to the source repository, so they're easy to find and
+review, and re-saving the same filename updates it in place so references stay stable.
+
+Markdown belongs in the assets library when it's a standalone deliverable you want to open and
+read — a blog post, a one-off report. Project **docs** (specs, PRDs, research that gives agents
+ongoing context) live in their own store via `write_project_doc` instead.
 
 Anywhere you write text in Hezo — a task, a comment, a document — you can point at an asset
 by writing `assets/<filename>` (for example `assets/login-mockup.png`).
@@ -35,10 +39,13 @@ conversation rather than hunting for a file on a server you can't reach. The CEO
 deliverable with whichever **project** the conversation is about, falling back to HQ only when
 the work isn't tied to a project at all.
 
-## HTML previews
+## Previews
 
 Assets aren't just stored — they're **previewable**. When an agent produces an HTML
 deliverable — a mockup, a dashboard, a report — you can open it and click through it right in
 Hezo, rendered live, without checking anything out or running it yourself. HTML previews run
 in a **sandbox**, isolated from your instance and your data, so viewing an agent's output is
 safe by default.
+
+Markdown assets open the same way: click one and it renders as formatted prose right in Hezo,
+with a **view-source** toggle to flip to the raw markdown whenever you want it.

--- a/docs/reference/mcp-api.md
+++ b/docs/reference/mcp-api.md
@@ -868,7 +868,7 @@ List project documentation files (PRD, spec, implementation plan, etc.)
 
 _Read-only._
 
-List the project's assets — non-markdown files (UI mockups, wireframes, diagrams, PDFs). Reference one in a comment or doc as `assets/<filename>` (e.g. assets/login-mockup.png), no backticks. You can author text-based assets (.html, .svg, .txt) with write_project_asset; binary assets (images, PDFs) are human-uploaded.
+List the project's assets — files in the assets library (UI mockups, wireframes, diagrams, PDFs, and generated markdown such as blog posts or reports). Reference one in a comment or doc as `assets/<filename>` (e.g. assets/login-mockup.png), no backticks. You can author text-based assets (.html, .svg, .txt, .md) with write_project_asset; binary assets (images, PDFs) are human-uploaded.
 
 **Parameters:**
 
@@ -876,13 +876,13 @@ List the project's assets — non-markdown files (UI mockups, wireframes, diagra
 | --- | --- | --- | --- |
 | `project` | `string` | No | Project slug or ID. Omit to use the project your run is already in; instance agents (CEO/Coach) must name the project to act in. |
 
-**Returns:** `{ files: [{ id, filename, content_type, created_at }] }` — the non-markdown assets.
+**Returns:** `{ files: [{ id, filename, content_type, created_at }] }` — the project asset files.
 
 ### `write_project_asset`
 
 _Write tool._
 
-Save a text-based file to the project assets library so a human can open it (an interactive HTML mockup, an SVG diagram, a plain-text export). Allowed extensions: .html, .svg, .txt. Re-saving the same filename overwrites it, so the reference stays stable. Returns the reference string to drop into a comment as `assets/<filename>` (no backticks). HTML opens interactively in a new tab. Mockups and other deliverables belong here, never committed to the source repo.
+Save a text-based file to the project assets library so a human can open it (an interactive HTML mockup, an SVG diagram, a plain-text export, or a markdown deliverable such as a blog post or report). Allowed extensions: .html, .svg, .txt, .md. Re-saving the same filename overwrites it, so the reference stays stable. Returns the reference string to drop into a comment as `assets/<filename>` (no backticks). HTML opens interactively in a new tab; markdown renders with a rich preview and a view-source toggle. Use a markdown asset for a standalone deliverable opened from the assets library; use write_project_doc for project context docs (specs, PRDs, research). Mockups and other deliverables belong here, never committed to the source repo.
 
 **Parameters:**
 
@@ -892,13 +892,13 @@ Save a text-based file to the project assets library so a human can open it (an 
 | `filename` | `string` | Yes | Filename to write (e.g. "ui-mockups.html") |
 | `content` | `string` | Yes | File content |
 
-**Returns:** `{ written: true, id, reference: "assets/<filename>" }`, or `{ error }` if the type is not text-based (`.html`, `.svg`, `.txt`) or exceeds 10 MB. Re-saving the same filename overwrites it.
+**Returns:** `{ written: true, id, reference: "assets/<filename>" }`, or `{ error }` if the type is not text-based (`.html`, `.svg`, `.txt`, `.md`) or exceeds 10 MB. Re-saving the same filename overwrites it.
 
 ### `read_project_asset`
 
 _Read-only._
 
-Read a project asset's contents by filename (e.g. "ui-mockups.html") — the non-markdown files that list_project_assets returns (UI mockups, wireframes, SVG diagrams, text exports). Text-based assets (HTML, SVG, plain text) come back inline as `content`. Binary assets (images, PDFs, media) are not inlined; the response gives a read-only container path under /workspace/.hezo/assets/ to open directly. For markdown project docs use read_project_doc instead.
+Read a project asset's contents by filename (e.g. "ui-mockups.html") — the files that list_project_assets returns (UI mockups, wireframes, SVG diagrams, text exports, markdown deliverables). Text-based assets (HTML, SVG, plain text, markdown) come back inline as `content`. Binary assets (images, PDFs, media) are not inlined; the response gives a read-only container path under /workspace/.hezo/assets/ to open directly. For markdown project docs use read_project_doc instead.
 
 **Parameters:**
 

--- a/packages/server/src/mcp/mcp-reference.ts
+++ b/packages/server/src/mcp/mcp-reference.ts
@@ -332,7 +332,7 @@ export const TOOL_DOC_META: Record<string, ToolDocMeta> = {
 	},
 	list_project_assets: {
 		category: 'Project docs & assets',
-		returns: '`{ files: [{ id, filename, content_type, created_at }] }` — the non-markdown assets.',
+		returns: '`{ files: [{ id, filename, content_type, created_at }] }` — the project asset files.',
 	},
 	read_project_asset: {
 		category: 'Project docs & assets',
@@ -342,7 +342,7 @@ export const TOOL_DOC_META: Record<string, ToolDocMeta> = {
 	write_project_asset: {
 		category: 'Project docs & assets',
 		returns:
-			'`{ written: true, id, reference: "assets/<filename>" }`, or `{ error }` if the type is not text-based (`.html`, `.svg`, `.txt`) or exceeds 10 MB. Re-saving the same filename overwrites it.',
+			'`{ written: true, id, reference: "assets/<filename>" }`, or `{ error }` if the type is not text-based (`.html`, `.svg`, `.txt`, `.md`) or exceeds 10 MB. Re-saving the same filename overwrites it.',
 	},
 
 	// Costs

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -3149,7 +3149,7 @@ export function registerTools(
 	tool(
 		server,
 		'list_project_assets',
-		"List the project's assets — non-markdown files (UI mockups, wireframes, diagrams, PDFs). Reference one in a comment or doc as `assets/<filename>` (e.g. assets/login-mockup.png), no backticks. You can author text-based assets (.html, .svg, .txt) with write_project_asset; binary assets (images, PDFs) are human-uploaded.",
+		"List the project's assets — files in the assets library (UI mockups, wireframes, diagrams, PDFs, and generated markdown such as blog posts or reports). Reference one in a comment or doc as `assets/<filename>` (e.g. assets/login-mockup.png), no backticks. You can author text-based assets (.html, .svg, .txt, .md) with write_project_asset; binary assets (images, PDFs) are human-uploaded.",
 		{
 			project: projectArg(),
 		},
@@ -3181,7 +3181,7 @@ export function registerTools(
 	tool(
 		server,
 		'write_project_asset',
-		'Save a text-based file to the project assets library so a human can open it (an interactive HTML mockup, an SVG diagram, a plain-text export). Allowed extensions: .html, .svg, .txt. Re-saving the same filename overwrites it, so the reference stays stable. Returns the reference string to drop into a comment as `assets/<filename>` (no backticks). HTML opens interactively in a new tab. Mockups and other deliverables belong here, never committed to the source repo.',
+		'Save a text-based file to the project assets library so a human can open it (an interactive HTML mockup, an SVG diagram, a plain-text export, or a markdown deliverable such as a blog post or report). Allowed extensions: .html, .svg, .txt, .md. Re-saving the same filename overwrites it, so the reference stays stable. Returns the reference string to drop into a comment as `assets/<filename>` (no backticks). HTML opens interactively in a new tab; markdown renders with a rich preview and a view-source toggle. Use a markdown asset for a standalone deliverable opened from the assets library; use write_project_doc for project context docs (specs, PRDs, research). Mockups and other deliverables belong here, never committed to the source repo.',
 		{
 			project: projectArg(),
 			filename: z.string().describe('Filename to write (e.g. "ui-mockups.html")'),
@@ -3239,7 +3239,7 @@ export function registerTools(
 	tool(
 		server,
 		'read_project_asset',
-		'Read a project asset\'s contents by filename (e.g. "ui-mockups.html") — the non-markdown files that list_project_assets returns (UI mockups, wireframes, SVG diagrams, text exports). Text-based assets (HTML, SVG, plain text) come back inline as `content`. Binary assets (images, PDFs, media) are not inlined; the response gives a read-only container path under /workspace/.hezo/assets/ to open directly. For markdown project docs use read_project_doc instead.',
+		'Read a project asset\'s contents by filename (e.g. "ui-mockups.html") — the files that list_project_assets returns (UI mockups, wireframes, SVG diagrams, text exports, markdown deliverables). Text-based assets (HTML, SVG, plain text, markdown) come back inline as `content`. Binary assets (images, PDFs, media) are not inlined; the response gives a read-only container path under /workspace/.hezo/assets/ to open directly. For markdown project docs use read_project_doc instead.',
 		{
 			project: projectArg(),
 			filename: z.string().describe('Asset filename to read (e.g. "ui-mockups.html")'),

--- a/packages/server/src/routes/assets.ts
+++ b/packages/server/src/routes/assets.ts
@@ -49,17 +49,21 @@ export async function storeUploadedAsset(
 	if (!isAllowedAttachmentExtension(file.name)) {
 		return err(c, 'INVALID_ATTACHMENT', 'Unsupported file extension', 400);
 	}
-	// Trust the browser's MIME only when it's one we allow; otherwise fall back to
-	// the canonical type for the (already validated) extension. Browsers often send
-	// an empty type or `application/octet-stream` for files they don't recognise —
-	// notably `.md` — which would otherwise be rejected despite a valid extension.
+	// Derive the canonical type from the (already validated) extension when the
+	// browser declares no real type — an empty string or the generic
+	// `application/octet-stream` it falls back to for files it doesn't recognise
+	// (common for `.md`), which would otherwise be rejected despite a valid
+	// extension. A *specific* present-but-disallowed MIME is still rejected: a type
+	// that contradicts the extension (e.g. a `.png` claiming
+	// `application/x-msdownload`) is suspicious.
 	const ext = extensionOf(file.name);
 	const extMime = ext
 		? ATTACHMENT_EXTENSIONS[ext as keyof typeof ATTACHMENT_EXTENSIONS]
 		: undefined;
-	const contentType = file.type && isAllowedAttachmentMime(file.type) ? file.type : (extMime ?? '');
+	const declared = file.type === 'application/octet-stream' ? '' : file.type;
+	const contentType = declared || extMime || '';
 	if (!isAllowedAttachmentMime(contentType)) {
-		return err(c, 'INVALID_ATTACHMENT', `Unsupported content type: ${file.type}`, 400);
+		return err(c, 'INVALID_ATTACHMENT', `Unsupported content type: ${contentType}`, 400);
 	}
 	if (file.size > ATTACHMENT_MAX_BYTES) {
 		return err(c, 'TOO_LARGE', 'Attachment exceeds 10 MB', 400);

--- a/packages/server/src/routes/assets.ts
+++ b/packages/server/src/routes/assets.ts
@@ -6,6 +6,7 @@ import {
 	AuthType,
 	assetContentDisposition,
 	assetServeCsp,
+	extensionOf,
 	isAllowedAttachmentExtension,
 	isAllowedAttachmentMime,
 	normalizeAssetFilename,
@@ -48,9 +49,17 @@ export async function storeUploadedAsset(
 	if (!isAllowedAttachmentExtension(file.name)) {
 		return err(c, 'INVALID_ATTACHMENT', 'Unsupported file extension', 400);
 	}
-	const contentType = file.type || 'application/octet-stream';
+	// Trust the browser's MIME only when it's one we allow; otherwise fall back to
+	// the canonical type for the (already validated) extension. Browsers often send
+	// an empty type or `application/octet-stream` for files they don't recognise —
+	// notably `.md` — which would otherwise be rejected despite a valid extension.
+	const ext = extensionOf(file.name);
+	const extMime = ext
+		? ATTACHMENT_EXTENSIONS[ext as keyof typeof ATTACHMENT_EXTENSIONS]
+		: undefined;
+	const contentType = file.type && isAllowedAttachmentMime(file.type) ? file.type : (extMime ?? '');
 	if (!isAllowedAttachmentMime(contentType)) {
-		return err(c, 'INVALID_ATTACHMENT', `Unsupported content type: ${contentType}`, 400);
+		return err(c, 'INVALID_ATTACHMENT', `Unsupported content type: ${file.type}`, 400);
 	}
 	if (file.size > ATTACHMENT_MAX_BYTES) {
 		return err(c, 'TOO_LARGE', 'Attachment exceeds 10 MB', 400);

--- a/packages/server/test/project-assets.test.ts
+++ b/packages/server/test/project-assets.test.ts
@@ -178,6 +178,20 @@ describe('project asset upload', () => {
 		expect(webp.status).toBe(201);
 		expect(svg.status).toBe(201);
 	});
+
+	it('accepts a markdown upload, deriving text/markdown when the browser sends no MIME', async () => {
+		// Browsers commonly leave `.md` files with an empty type; the canonical
+		// type is filled in from the (allowlisted) extension.
+		const res = await uploadProjectAsset('notes.md', '', new TextEncoder().encode('# Hello'));
+		expect(res.status).toBe(201);
+		const body = await res.json();
+		expect(body.data.content_type).toBe('text/markdown');
+
+		// And it serves inline (markdown is inert text — no forced download).
+		const served = await app.request(body.data.url);
+		expect(served.headers.get('content-disposition')).toContain('inline');
+		expect(await served.text()).toBe('# Hello');
+	});
 });
 
 describe('asset serving disposition', () => {
@@ -230,6 +244,40 @@ describe('agent-authored assets (write_project_asset)', () => {
 		expect(row.rows[0].content_type).toBe('text/html');
 		const onDisk = join(dataDir, 'teams', teamId, 'projects', projectId, 'assets', row.rows[0].id);
 		expect(existsSync(onDisk)).toBe(true);
+	});
+
+	it('writes a markdown asset (e.g. a blog post) stored as text/markdown', async () => {
+		const { token: agentToken } = await mintAgentToken(
+			db,
+			masterKeyManager,
+			agentId,
+			teamId,
+			taskId,
+		);
+		const body = '# Launch announcement\n\nWe shipped **markdown assets**.';
+		const result = await callToolViaMcp(agentToken, 'write_project_asset', {
+			project: projectId,
+			filename: 'launch-post.md',
+			content: body,
+		});
+		expect(result.written).toBe(true);
+		expect(result.reference).toBe('assets/launch-post.md');
+
+		const row = await db.query<{ id: string; content_type: string }>(
+			'SELECT id, content_type FROM assets WHERE project_id = $1 AND original_filename = $2',
+			[projectId, 'launch-post.md'],
+		);
+		expect(row.rows).toHaveLength(1);
+		expect(row.rows[0].content_type).toBe('text/markdown');
+
+		// It reads back inline (so the agent and the in-app viewer get the raw text).
+		const read = await callToolViaMcp(agentToken, 'read_project_asset', {
+			project: projectId,
+			filename: 'launch-post.md',
+		});
+		expect(read.content_type).toBe('text/markdown');
+		expect(read.content).toBe(body);
+		expect(read.binary).toBeUndefined();
 	});
 
 	it('overwrites the same filename on re-save, keeping a single stable reference', async () => {

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -235,6 +235,7 @@ export function isAllowedProjectIconStoredMime(mime: string): boolean {
 
 export const ATTACHMENT_EXTENSIONS = {
 	txt: 'text/plain',
+	md: 'text/markdown',
 	html: 'text/html',
 	pdf: 'application/pdf',
 	png: 'image/png',
@@ -286,7 +287,18 @@ export const AGENT_AUTHORABLE_ASSET_MIME: ReadonlySet<string> = new Set([
 	'text/html',
 	'image/svg+xml',
 	'text/plain',
+	'text/markdown',
 ]);
+
+// Asset content types that the app renders as markdown (rich preview + a raw
+// "source" toggle) rather than downloading or framing. Project docs are a
+// separate store; this is for markdown that lives in the assets library, e.g. a
+// generated blog post or report.
+export const ASSET_MARKDOWN_MIME: ReadonlySet<string> = new Set(['text/markdown']);
+
+export function isMarkdownAssetMime(mime: string): boolean {
+	return ASSET_MARKDOWN_MIME.has(mime);
+}
 
 export function isAgentAuthorableAssetMime(mime: string): boolean {
 	return AGENT_AUTHORABLE_ASSET_MIME.has(mime);

--- a/packages/web/src/components/markdown-asset-dialog.tsx
+++ b/packages/web/src/components/markdown-asset-dialog.tsx
@@ -1,0 +1,148 @@
+import * as Dialog from '@radix-ui/react-dialog';
+import { ExternalLink, Loader2, X } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import type { ProjectAsset } from '../hooks/use-project-assets';
+import { MarkdownProse } from './markdown-prose';
+import { dialogOverlayClassName } from './ui/dialog';
+
+type ViewMode = 'preview' | 'source';
+
+const TAB_BASE = 'px-2.5 py-1 rounded';
+const TAB_ACTIVE = 'bg-surface text-text-1 shadow-sm';
+const TAB_INACTIVE = 'text-text-2 hover:text-text-1';
+
+/**
+ * Renders a markdown asset (e.g. a generated blog post) with a rich Preview and
+ * a raw Source toggle. The body is fetched from the asset's signed URL (the
+ * public asset route serves the stored markdown text). `projectId` is the
+ * route-param slug so @mentions/`assets/<file>` references resolve.
+ */
+export function MarkdownAssetDialog({
+	asset,
+	projectId,
+	open,
+	onOpenChange,
+}: {
+	asset: ProjectAsset;
+	projectId: string;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}) {
+	const [mode, setMode] = useState<ViewMode>('preview');
+	const [content, setContent] = useState<string | null>(null);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		if (!open) return;
+		let cancelled = false;
+		setContent(null);
+		setError(null);
+		setMode('preview');
+		(async () => {
+			try {
+				const res = await fetch(asset.url);
+				if (!res.ok) throw new Error(`Failed to load asset (${res.status})`);
+				const text = await res.text();
+				if (!cancelled) setContent(text);
+			} catch (e) {
+				if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load asset');
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, [open, asset.url]);
+
+	return (
+		<Dialog.Root open={open} onOpenChange={onOpenChange}>
+			<Dialog.Portal>
+				<Dialog.Overlay className={dialogOverlayClassName} />
+				<Dialog.Content
+					data-testid="markdown-asset-dialog"
+					className="fixed inset-0 z-50 flex flex-col bg-surface outline-none sm:inset-auto sm:top-1/2 sm:left-1/2 sm:-translate-x-1/2 sm:-translate-y-1/2 sm:w-full sm:max-w-3xl sm:max-h-[90vh] sm:rounded-lg sm:border sm:border-border sm:shadow-lg"
+				>
+					<div className="flex items-center justify-between gap-2 border-b border-border px-4 py-3">
+						<Dialog.Title
+							className="min-w-0 truncate text-sm font-semibold text-text-1"
+							title={asset.original_filename}
+						>
+							{asset.original_filename}
+						</Dialog.Title>
+						<Dialog.Description className="sr-only">
+							Markdown asset {asset.original_filename}, shown as a rendered preview with a
+							view-source toggle.
+						</Dialog.Description>
+						<div className="flex shrink-0 items-center gap-2">
+							<div
+								role="tablist"
+								aria-label="Asset view mode"
+								className="inline-flex rounded-md border border-border-subtle bg-surface-2 p-0.5 text-xs"
+							>
+								<button
+									type="button"
+									role="tab"
+									aria-selected={mode === 'preview'}
+									onClick={() => setMode('preview')}
+									className={`${TAB_BASE} ${mode === 'preview' ? TAB_ACTIVE : TAB_INACTIVE}`}
+									data-testid="markdown-asset-preview-tab"
+								>
+									Preview
+								</button>
+								<button
+									type="button"
+									role="tab"
+									aria-selected={mode === 'source'}
+									onClick={() => setMode('source')}
+									className={`${TAB_BASE} ${mode === 'source' ? TAB_ACTIVE : TAB_INACTIVE}`}
+									data-testid="markdown-asset-source-tab"
+								>
+									Source
+								</button>
+							</div>
+							<a
+								href={asset.url}
+								target="_blank"
+								rel="noopener noreferrer"
+								className="p-1 text-text-3 hover:text-text-1"
+								aria-label="Open raw markdown in a new tab"
+							>
+								<ExternalLink className="h-4 w-4" />
+							</a>
+							<Dialog.Close
+								className="p-1 text-text-3 hover:text-text-1"
+								aria-label="Close"
+								data-testid="markdown-asset-close"
+							>
+								<X className="h-4 w-4" />
+							</Dialog.Close>
+						</div>
+					</div>
+
+					<div className="min-h-0 flex-1 overflow-y-auto px-4 py-4 sm:px-6">
+						{error ? (
+							<div className="text-[13px] text-danger" data-testid="markdown-asset-error">
+								{error}
+							</div>
+						) : content === null ? (
+							<div className="flex items-center gap-2 text-[13px] text-text-2">
+								<Loader2 className="h-3.5 w-3.5 animate-spin" />
+								Loading…
+							</div>
+						) : mode === 'preview' ? (
+							<MarkdownProse projectId={projectId} testId="markdown-asset-rendered">
+								{content}
+							</MarkdownProse>
+						) : (
+							<pre
+								className="whitespace-pre-wrap break-words font-mono text-[12px] text-text-1"
+								data-testid="markdown-asset-source"
+							>
+								{content}
+							</pre>
+						)}
+					</div>
+				</Dialog.Content>
+			</Dialog.Portal>
+		</Dialog.Root>
+	);
+}

--- a/packages/web/src/routes/projects/$projectId/assets.tsx
+++ b/packages/web/src/routes/projects/$projectId/assets.tsx
@@ -1,3 +1,4 @@
+import { isMarkdownAssetMime } from '@hezo/shared';
 import { createFileRoute } from '@tanstack/react-router';
 import {
 	Code,
@@ -12,6 +13,7 @@ import {
 	Upload,
 } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { MarkdownAssetDialog } from '../../../components/markdown-asset-dialog';
 import { Button } from '../../../components/ui/button';
 import { ConfirmDialog } from '../../../components/ui/confirm-dialog';
 import { EmptyState } from '../../../components/ui/empty-state';
@@ -38,7 +40,11 @@ function AssetIcon({ contentType }: { contentType: string }) {
 	if (contentType.startsWith('audio/')) return <FileAudio className={cls} />;
 	if (contentType.startsWith('video/')) return <FileVideo className={cls} />;
 	if (contentType === 'text/html') return <Code className={cls} />;
-	if (contentType === 'application/pdf' || contentType === 'text/plain') {
+	if (
+		contentType === 'application/pdf' ||
+		contentType === 'text/plain' ||
+		isMarkdownAssetMime(contentType)
+	) {
 		return <FileText className={cls} />;
 	}
 	if (contentType.startsWith('image/')) return <ImageIcon className={cls} />;
@@ -64,6 +70,7 @@ function ProjectAssetsPage() {
 	const dragDepth = useRef(0);
 	const [errors, setErrors] = useState<ErrorChip[]>([]);
 	const [pendingDelete, setPendingDelete] = useState<ProjectAsset | null>(null);
+	const [viewMarkdown, setViewMarkdown] = useState<ProjectAsset | null>(null);
 
 	const pushError = useCallback((filename: string, message: string) => {
 		const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
@@ -190,6 +197,7 @@ function ProjectAssetsPage() {
 								asset={asset}
 								highlighted={focusFile === asset.original_filename}
 								onDelete={() => setPendingDelete(asset)}
+								onView={() => setViewMarkdown(asset)}
 							/>
 						))}
 					</ul>
@@ -233,6 +241,17 @@ function ProjectAssetsPage() {
 					setPendingDelete(null);
 				}}
 			/>
+
+			{viewMarkdown && (
+				<MarkdownAssetDialog
+					asset={viewMarkdown}
+					projectId={projectId}
+					open={viewMarkdown !== null}
+					onOpenChange={(open) => {
+						if (!open) setViewMarkdown(null);
+					}}
+				/>
+			)}
 		</div>
 	);
 }
@@ -241,10 +260,12 @@ function AssetCard({
 	asset,
 	highlighted,
 	onDelete,
+	onView,
 }: {
 	asset: ProjectAsset;
 	highlighted: boolean;
 	onDelete: () => void;
+	onView: () => void;
 }) {
 	const ref = useRef<HTMLLIElement>(null);
 	useEffect(() => {
@@ -253,6 +274,19 @@ function AssetCard({
 
 	const isImage = asset.content_type.startsWith('image/');
 	const isHtml = asset.content_type === 'text/html';
+	const isMarkdown = isMarkdownAssetMime(asset.content_type);
+	const thumbnail = isImage ? (
+		<img src={asset.url} alt={asset.original_filename} className="h-full w-full object-cover" />
+	) : isHtml ? (
+		<iframe
+			src={asset.url}
+			title={asset.original_filename}
+			sandbox=""
+			className="pointer-events-none h-full w-full bg-surface"
+		/>
+	) : (
+		<AssetIcon contentType={asset.content_type} />
+	);
 	return (
 		<li
 			ref={ref}
@@ -262,31 +296,30 @@ function AssetCard({
 				highlighted ? 'border-info' : 'border-border'
 			}`}
 		>
-			<a
-				href={asset.url}
-				target="_blank"
-				rel="noopener noreferrer"
-				className="flex h-28 items-center justify-center bg-surface-3"
-				data-testid="asset-open-link"
-				aria-label={`Open ${asset.original_filename} in a new tab`}
-			>
-				{isImage ? (
-					<img
-						src={asset.url}
-						alt={asset.original_filename}
-						className="h-full w-full object-cover"
-					/>
-				) : isHtml ? (
-					<iframe
-						src={asset.url}
-						title={asset.original_filename}
-						sandbox=""
-						className="pointer-events-none h-full w-full bg-surface"
-					/>
-				) : (
-					<AssetIcon contentType={asset.content_type} />
-				)}
-			</a>
+			{/* Markdown renders in-app (rich preview + view-source); everything else
+			    opens its raw signed URL in a new tab. */}
+			{isMarkdown ? (
+				<button
+					type="button"
+					onClick={onView}
+					className="flex h-28 items-center justify-center bg-surface-3"
+					data-testid="asset-open-markdown"
+					aria-label={`View ${asset.original_filename}`}
+				>
+					{thumbnail}
+				</button>
+			) : (
+				<a
+					href={asset.url}
+					target="_blank"
+					rel="noopener noreferrer"
+					className="flex h-28 items-center justify-center bg-surface-3"
+					data-testid="asset-open-link"
+					aria-label={`Open ${asset.original_filename} in a new tab`}
+				>
+					{thumbnail}
+				</a>
+			)}
 			<div className="flex items-start justify-between gap-1 p-2">
 				<div className="min-w-0">
 					<div

--- a/packages/web/test/project-assets.test.tsx
+++ b/packages/web/test/project-assets.test.tsx
@@ -26,6 +26,41 @@ test('the assets library lists uploads with an open-in-new-tab link to a signed 
 	expect(openLink.getAttribute('target')).toBe('_blank');
 });
 
+test('a markdown asset renders in-app with a view-source toggle', async () => {
+	let ctx!: { projectSlug: string };
+	const md = '# Launch Post\n\nWe shipped **markdown assets**.';
+	const { findByTestId, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Blog' });
+			await seedAsset(ws, project, {
+				filename: 'post.md',
+				contentType: 'text/markdown',
+				bytes: new TextEncoder().encode(md),
+			});
+			ctx = { projectSlug: project.slug };
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/assets',
+		params: { projectId: ctx.projectSlug },
+	});
+
+	// Markdown opens the in-app viewer (a button), not an external new-tab link.
+	await user.click(await findByTestId('asset-open-markdown'));
+
+	// Preview renders the markdown — the heading becomes an <h1>, not a literal `#`.
+	const rendered = await findByTestId('markdown-asset-rendered');
+	await waitFor(() => expect(rendered.querySelector('h1')?.textContent).toBe('Launch Post'));
+
+	// Flipping to Source shows the raw markdown verbatim (the `#`, the `**`).
+	await user.click(await findByTestId('markdown-asset-source-tab'));
+	const source = await findByTestId('markdown-asset-source');
+	expect(source.textContent).toBe(md);
+});
+
 test('an asset can be deleted from the library', async () => {
 	let ctx!: { projectSlug: string };
 	const { findByText, findByTestId, getByRole, queryByText, user, router } = await renderApp({


### PR DESCRIPTION
## What & why

Markdown can now be generated/stored as a **project asset** (not just a project doc) — so agents can produce standalone deliverables like blog posts or reports straight into the assets library. Viewing a markdown asset renders it with the markdown renderer **plus a view-source toggle**, instead of downloading as raw text.

This addresses two asks:
1. Allow markdown to be generated as a project asset (e.g. blog posts).
2. Viewing a markdown asset should render via the markdown renderer, with the ability to view source as well.

### Asset vs. doc
Project **docs** (specs, PRDs, research → `write_project_doc`) remain the store for ongoing agent context. Markdown **assets** (`write_project_asset`) are standalone deliverables you open and read. Both are `.md`; the tool descriptions now spell out when to use which.

## Changes

**Backend**
- `@hezo/shared`: add `md → text/markdown` to `ATTACHMENT_EXTENSIONS`, add `text/markdown` to `AGENT_AUTHORABLE_ASSET_MIME`, and a new `ASSET_MARKDOWN_MIME` / `isMarkdownAssetMime()` helper.
- Upload route: derive the canonical MIME from the (allow-listed) extension when the browser sends an empty/generic type — browsers commonly leave `.md` untyped, which would otherwise be rejected. Markdown serves **inline** (inert text, no forced download).
- MCP tools: `write_project_asset` now accepts `.md`; `read_project_asset` returns markdown inline (it already did for `text/*`). Tool descriptions + `TOOL_DOC_META` updated.

**Frontend**
- New `MarkdownAssetDialog`: fetches the asset's signed URL and renders it through the existing `MarkdownProse` (react-markdown + GFM + mentions), with a **Preview / Source** toggle (raw markdown in a `<pre>`).
- Assets page: markdown cards open the in-app viewer instead of a new tab; markdown icon added.

**Docs**
- Regenerated `docs/reference/mcp-api.md` (`build:docs`), updated `docs/concepts/assets.md` and `.dev/architecture.md`.

## Tests
- Server: `write_project_asset` stores `.md` as `text/markdown` and reads back inline; `.md` upload with empty browser MIME is accepted and served inline.
- Web component: a markdown asset opens in the dialog, renders the heading as `<h1>` (Preview), and shows the raw markdown verbatim after toggling to Source.
- Drift tests (`mcp-reference`, `llms-txt`, `docs-bundle`) green; typecheck, lint, and full build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FD7dHSZ4Eehf8tBW3GZR95)_