### PR TITLE
fix: only log final connectivity outcome so a successful auto-rebind is silent

### DIFF
--- a/packages/server/src/services/container-connectivity-preflight.ts
+++ b/packages/server/src/services/container-connectivity-preflight.ts
@@ -306,6 +306,10 @@ export interface ConnectivityCheckDeps {
 	attempts?: number;
 	/** Gap between retries in ms (default 2000); 0 in tests. */
 	retryGapMs?: number;
+	/** Whether to log the outcome (default true). Set false for the silent
+	 * exploratory probe during auto-rebind, where only the *final* outcome should
+	 * be logged — otherwise the loopback probe warns even when the rebind fixes it. */
+	logOutcome?: boolean;
 }
 
 const PROBE_ATTEMPTS = 3;
@@ -313,6 +317,29 @@ const PROBE_RETRY_GAP_MS = 2000;
 
 function delay(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Log a connectivity outcome at the right level: `ok` at info, the bind-host
+ * degradations at `warn`, an unreachable MCP server at `error`, `skipped` not at
+ * all. Split out from the probe so the auto-rebind flow can probe silently and log
+ * only the final state (see `checkAndAutoRebindConnectivity`).
+ */
+export function logConnectivityOutcome(
+	outcome: ConnectivityOutcome | 'skipped',
+	opts: { serverPort: number; containerBindHost: string },
+): void {
+	if (outcome === 'skipped') return;
+	if (outcome === 'ok') {
+		log.info('container→host connectivity OK (MCP + egress bridge reachable from a container)');
+		return;
+	}
+	// Severity tracks impact: mcp-unreachable means no tools load (error); the
+	// bind-host cases are a degradation — MCP works and agents run, only proxied
+	// egress / git-over-SSH are affected (warn).
+	const message = `\n${formatContainerConnectivityMessage(outcome, opts)}\n`;
+	if (connectivitySeverity(outcome) === 'error') log.error(message);
+	else log.warn(message);
 }
 
 export interface ConnectivityCheckResult {
@@ -357,19 +384,12 @@ export async function checkContainerToHostConnectivity(
 		}
 
 		const outcome = classifyConnectivity(result, deps.containerBindHost);
-		if (outcome === 'ok') {
-			log.info('container→host connectivity OK (MCP + egress bridge reachable from a container)');
-			return { outcome, gatewayIp: result.gatewayIp };
+		if (deps.logOutcome !== false) {
+			logConnectivityOutcome(outcome, {
+				serverPort: deps.serverPort,
+				containerBindHost: deps.containerBindHost,
+			});
 		}
-		// Severity tracks impact: mcp-unreachable means no tools load (error); the
-		// bind-host cases are a degradation — MCP works and agents run, only proxied
-		// egress / git-over-SSH are affected (warn).
-		const message = `\n${formatContainerConnectivityMessage(outcome, {
-			serverPort: deps.serverPort,
-			containerBindHost: deps.containerBindHost,
-		})}\n`;
-		if (connectivitySeverity(outcome) === 'error') log.error(message);
-		else log.warn(message);
 		return { outcome, gatewayIp: result.gatewayIp };
 	} catch (err) {
 		// Diagnostics must never break startup. If the probe machinery itself
@@ -380,4 +400,54 @@ export async function checkContainerToHostConnectivity(
 		});
 		return { outcome: 'skipped' };
 	}
+}
+
+export interface AutoRebindDeps {
+	docker: DockerClient;
+	serverPort: number;
+	/** The shared, mutable bind host read per-run by the egress proxy / SSH bridge.
+	 * Rebound in place to the detected gateway IP when a loopback bind is unreachable. */
+	bindHost: { get(): string; set(host: string): void };
+	/** Injectable for tests; defaults to the real preflight. */
+	check?: (deps: ConnectivityCheckDeps) => Promise<ConnectivityCheckResult>;
+}
+
+/**
+ * Run the boot connectivity check and, when a loopback bind is unreachable from a
+ * container, auto-rebind the egress proxy / SSH bridge to the detected docker
+ * bridge gateway IP and re-probe. Both probes run **silently**; only the final
+ * outcome is logged — so a successful rebind logs `connectivity OK` and no warning,
+ * while a genuine failure (no gateway IP, or a still-blocked bind) warns exactly
+ * once with the right bind host. Returns the final outcome + the effective bind host.
+ */
+export async function checkAndAutoRebindConnectivity(
+	deps: AutoRebindDeps,
+): Promise<{ outcome: ConnectivityOutcome | 'skipped'; bindHost: string }> {
+	const check = deps.check ?? checkContainerToHostConnectivity;
+	const probe = (containerBindHost: string) =>
+		check({
+			docker: deps.docker,
+			serverPort: deps.serverPort,
+			containerBindHost,
+			logOutcome: false,
+		});
+
+	const first = await probe(deps.bindHost.get());
+	let outcome = first.outcome;
+	let bindHost = deps.bindHost.get();
+
+	const rebindTo = resolveAutoRebindTarget(first, bindHost);
+	if (rebindTo) {
+		log.info(
+			`Egress proxy / SSH bridge auto-bound to docker bridge gateway ${rebindTo} ` +
+				`(a container could not reach the loopback bind). Override with --container-bind-host.`,
+		);
+		deps.bindHost.set(rebindTo);
+		const second = await probe(rebindTo);
+		outcome = second.outcome;
+		bindHost = rebindTo;
+	}
+
+	logConnectivityOutcome(outcome, { serverPort: deps.serverPort, containerBindHost: bindHost });
+	return { outcome, bindHost };
 }

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -59,10 +59,7 @@ import { uiStateRoutes } from './routes/ui-state';
 import { buildUpdatesRoutes } from './routes/updates';
 import { AuthChallengeStore } from './services/auth-challenges';
 import { CeoSessionManager } from './services/ceo-session-manager';
-import {
-	checkContainerToHostConnectivity,
-	resolveAutoRebindTarget,
-} from './services/container-connectivity-preflight';
+import { checkAndAutoRebindConnectivity } from './services/container-connectivity-preflight';
 import {
 	ContainerConnectivityStatus,
 	EffectiveBindHost,
@@ -228,34 +225,14 @@ export async function startup(config: HezoConfig): Promise<StartupResult> {
 	// so the operator can act on any residual guidance. No-ops under HEZO_SKIP_DOCKER
 	// (fake docker / tests) and the documented opt-out.
 	trackBackground(
-		(async () => {
-			const first = await checkContainerToHostConnectivity({
-				docker,
-				serverPort: config.port,
-				containerBindHost: bindHost.get(),
-			});
-			const rebindTo = resolveAutoRebindTarget(first, bindHost.get());
-			if (rebindTo) {
-				log.info(
-					`Egress proxy / SSH bridge auto-bound to docker bridge gateway ${rebindTo} ` +
-						`(a container could not reach the loopback bind). Override with --container-bind-host.`,
-				);
-				bindHost.set(rebindTo);
-				const second = await checkContainerToHostConnectivity({
-					docker,
-					serverPort: config.port,
-					containerBindHost: rebindTo,
+		checkAndAutoRebindConnectivity({ docker, serverPort: config.port, bindHost })
+			.then((r) => connectivityStatus.set(r.outcome, r.bindHost))
+			.catch((err) => {
+				log.info('container→host connectivity check failed', {
+					error: err instanceof Error ? err.message : String(err),
 				});
-				connectivityStatus.set(second.outcome, rebindTo);
-				return;
-			}
-			connectivityStatus.set(first.outcome, bindHost.get());
-		})().catch((err) => {
-			log.info('container→host connectivity check failed', {
-				error: err instanceof Error ? err.message : String(err),
-			});
-			connectivityStatus.set('skipped', bindHost.get());
-		}),
+				connectivityStatus.set('skipped', bindHost.get());
+			}),
 	);
 	const events = new DomainEventBus();
 	const jobManager = new JobManager({

--- a/packages/server/test/container-connectivity-preflight.test.ts
+++ b/packages/server/test/container-connectivity-preflight.test.ts
@@ -2,12 +2,15 @@ import { Logger } from '@hiddentao/logger';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
 	buildProbeScript,
+	type ConnectivityCheckResult,
 	type ConnectivityProbeResult,
+	checkAndAutoRebindConnectivity,
 	checkContainerToHostConnectivity,
 	classifyConnectivity,
 	connectivitySeverity,
 	formatContainerConnectivityMessage,
 	isLoopbackHost,
+	logConnectivityOutcome,
 	NETWORKING_DOCS_URL,
 	parseProbeOutput,
 	resolveAutoRebindTarget,
@@ -300,5 +303,152 @@ describe('checkContainerToHostConnectivity', () => {
 			},
 		});
 		expect(outcome.outcome).toBe('skipped');
+	});
+
+	it('returns the outcome but logs nothing when logOutcome is false', async () => {
+		const outcome = await checkContainerToHostConnectivity({
+			...base,
+			logOutcome: false,
+			probe: async () => BIND_DOWN,
+		});
+		expect(outcome.outcome).toBe('bind-loopback');
+		expect(warnSpy).not.toHaveBeenCalled();
+		expect(errorSpy).not.toHaveBeenCalled();
+	});
+});
+
+describe('logConnectivityOutcome', () => {
+	const opts = { serverPort: 3100, containerBindHost: '127.0.0.1' };
+	let errorSpy: ReturnType<typeof vi.spyOn>;
+	let warnSpy: ReturnType<typeof vi.spyOn>;
+	let infoSpy: ReturnType<typeof vi.spyOn>;
+	beforeEach(() => {
+		errorSpy = vi.spyOn(Logger.prototype, 'error').mockImplementation(() => {});
+		warnSpy = vi.spyOn(Logger.prototype, 'warn').mockImplementation(() => {});
+		infoSpy = vi.spyOn(Logger.prototype, 'info').mockImplementation(() => {});
+	});
+	afterEach(() => vi.restoreAllMocks());
+
+	it('logs ok at info only', () => {
+		logConnectivityOutcome('ok', opts);
+		expect(infoSpy).toHaveBeenCalled();
+		expect(warnSpy).not.toHaveBeenCalled();
+		expect(errorSpy).not.toHaveBeenCalled();
+	});
+	it('logs the bind-host degradations at warn', () => {
+		logConnectivityOutcome('bind-loopback', opts);
+		logConnectivityOutcome('bind-firewalled', opts);
+		expect(warnSpy).toHaveBeenCalledTimes(2);
+		expect(errorSpy).not.toHaveBeenCalled();
+	});
+	it('logs the fatal mcp-unreachable case at error', () => {
+		logConnectivityOutcome('mcp-unreachable', opts);
+		expect(errorSpy).toHaveBeenCalled();
+		expect(warnSpy).not.toHaveBeenCalled();
+	});
+	it('says nothing for skipped', () => {
+		logConnectivityOutcome('skipped', opts);
+		expect(infoSpy).not.toHaveBeenCalled();
+		expect(warnSpy).not.toHaveBeenCalled();
+		expect(errorSpy).not.toHaveBeenCalled();
+	});
+});
+
+describe('checkAndAutoRebindConnectivity', () => {
+	const docker = createStubDocker({ imageExists: async () => true });
+	let errorSpy: ReturnType<typeof vi.spyOn>;
+	let warnSpy: ReturnType<typeof vi.spyOn>;
+	let infoSpy: ReturnType<typeof vi.spyOn>;
+	beforeEach(() => {
+		errorSpy = vi.spyOn(Logger.prototype, 'error').mockImplementation(() => {});
+		warnSpy = vi.spyOn(Logger.prototype, 'warn').mockImplementation(() => {});
+		infoSpy = vi.spyOn(Logger.prototype, 'info').mockImplementation(() => {});
+	});
+	afterEach(() => vi.restoreAllMocks());
+
+	// A mutable bind-host ref like the production EffectiveBindHost.
+	function bindRef(initial: string) {
+		let host = initial;
+		return { get: () => host, set: (h: string) => (host = h) };
+	}
+
+	it('rebinds a loopback bind to the gateway IP and logs no warning (the success path)', async () => {
+		const ref = bindRef('127.0.0.1');
+		const check = vi
+			.fn<() => Promise<ConnectivityCheckResult>>()
+			.mockResolvedValueOnce({ outcome: 'bind-loopback', gatewayIp: '172.17.0.1' })
+			.mockResolvedValueOnce({ outcome: 'ok' });
+
+		const result = await checkAndAutoRebindConnectivity({
+			docker,
+			serverPort: 3100,
+			bindHost: ref,
+			check,
+		});
+
+		expect(result).toEqual({ outcome: 'ok', bindHost: '172.17.0.1' });
+		expect(ref.get()).toBe('172.17.0.1');
+		expect(check).toHaveBeenCalledTimes(2);
+		// No warning at all; the final OK + the auto-bound notice are info.
+		expect(warnSpy).not.toHaveBeenCalled();
+		expect(errorSpy).not.toHaveBeenCalled();
+		expect(infoSpy).toHaveBeenCalled();
+	});
+
+	it('warns once and leaves the bind host unchanged when no gateway IP was resolved', async () => {
+		const ref = bindRef('127.0.0.1');
+		const check = vi
+			.fn<() => Promise<ConnectivityCheckResult>>()
+			.mockResolvedValue({ outcome: 'bind-loopback' });
+
+		const result = await checkAndAutoRebindConnectivity({
+			docker,
+			serverPort: 3100,
+			bindHost: ref,
+			check,
+		});
+
+		expect(result).toEqual({ outcome: 'bind-loopback', bindHost: '127.0.0.1' });
+		expect(ref.get()).toBe('127.0.0.1');
+		expect(check).toHaveBeenCalledTimes(1);
+		expect(warnSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not rebind an explicit non-loopback bind, warns once on firewalled', async () => {
+		const ref = bindRef('0.0.0.0');
+		const check = vi
+			.fn<() => Promise<ConnectivityCheckResult>>()
+			.mockResolvedValue({ outcome: 'bind-firewalled', gatewayIp: '172.17.0.1' });
+
+		const result = await checkAndAutoRebindConnectivity({
+			docker,
+			serverPort: 3100,
+			bindHost: ref,
+			check,
+		});
+
+		expect(result).toEqual({ outcome: 'bind-firewalled', bindHost: '0.0.0.0' });
+		expect(ref.get()).toBe('0.0.0.0');
+		expect(check).toHaveBeenCalledTimes(1);
+		expect(warnSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it('logs OK and does not rebind when the first probe already passes', async () => {
+		const ref = bindRef('127.0.0.1');
+		const check = vi
+			.fn<() => Promise<ConnectivityCheckResult>>()
+			.mockResolvedValue({ outcome: 'ok' });
+
+		const result = await checkAndAutoRebindConnectivity({
+			docker,
+			serverPort: 3100,
+			bindHost: ref,
+			check,
+		});
+
+		expect(result).toEqual({ outcome: 'ok', bindHost: '127.0.0.1' });
+		expect(check).toHaveBeenCalledTimes(1);
+		expect(warnSpy).not.toHaveBeenCalled();
+		expect(infoSpy).toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## Why

Follow-up to #441. On native-Linux Docker the egress-proxy auto-rebind works, but the server still logs an alarming `bind-loopback` **warning** at startup even though everything is fine.

**Cause:** the boot check probes connectivity **twice** — first at the loopback default (classifies `bind-loopback`), then again after auto-rebinding to the bridge gateway IP. The warning was emitted *inside* the **first** probe, before the rebind happened — so a successful auto-rebind printed the loopback warning immediately followed by the `auto-bound …` and `connectivity OK` info lines. Contradictory and misleading.

## What

Probe **silently** during the rebind dance and log **only the final outcome**:
- successful auto-rebind → `connectivity OK`, **no warning**;
- genuine failure (no gateway IP, or a still-firewalled bind) → still warns/errors **exactly once**, with the correct bind host.

Changes (all in `container-connectivity-preflight.ts` + `startup.ts`):
- Extract `logConnectivityOutcome(outcome, opts)` — `ok` → info, bind-host degradations → warn, `mcp-unreachable` → error, `skipped` → nothing.
- Add `logOutcome?: boolean` (default `true`) to `ConnectivityCheckDeps`; default keeps the run-time re-probes (agent-runner / CEO `ensureFresh`) logging a degraded state.
- Add `checkAndAutoRebindConnectivity(...)` owning the probe→rebind→re-probe→**log-once** flow that was inlined in `startup.ts`; `startup.ts` now just calls it and stores the result.

## Tests

`container-connectivity-preflight.test.ts`:
- `logConnectivityOutcome` severity mapping (ok→info, bind cases→warn, mcp→error, skipped→silent).
- `checkContainerToHostConnectivity` with `logOutcome: false` returns the outcome but logs nothing.
- `checkAndAutoRebindConnectivity`: **rebind success → no warning**, bind host updated to the gateway IP, returns `{ ok, <gw> }`; no-gateway and explicit-non-loopback-firewalled paths warn once without rebinding; first-probe-ok logs info and doesn't re-probe.

No API/docs surface changes (internal logging refactor). Typecheck, lint, and the connectivity/agent-runner/startup suites are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015bYNE2AxYhEMz8jvQjCmSF

---
_Generated by [Claude Code](https://claude.ai/code/session_015bYNE2AxYhEMz8jvQjCmSF)_