### PR TITLE
fix: self-heal the egress connectivity gate (unblock CEO/agents) + surface CEO send errors as a toast

### DIFF
--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -41,13 +41,11 @@ import {
 	updateAiProviderCredential,
 } from './ai-provider-keys';
 import { checkOverBudget, recordRunCost } from './budget';
-import {
-	checkContainerToHostConnectivity,
-	formatContainerConnectivityMessage,
-} from './container-connectivity-preflight';
+import { formatContainerConnectivityMessage } from './container-connectivity-preflight';
 import {
 	CONNECTIVITY_STALE_MS,
 	type ContainerConnectivityStatus,
+	type ProbeResult,
 	shouldAbortForConnectivity,
 } from './container-connectivity-status';
 import { type ContainerRunUser, chownToRunUser, resolveContainerRunUser } from './container-user';
@@ -162,6 +160,10 @@ export interface RunnerDeps {
 	 * proxy is unreachable from containers, the run aborts instead of silently
 	 * falling through to direct egress. Absent → fail open (back-compat). */
 	connectivityStatus?: ContainerConnectivityStatus;
+	/** Probe used to (re)confirm connectivity at run time. Auto-rebinds against the
+	 * live bind host, so a stale loopback result self-heals. Required alongside
+	 * `connectivityStatus` for the gate to run; absent → fail open. */
+	connectivityProbe?: () => Promise<ProbeResult>;
 	/** Runtime model pricing; when present, the parser computes run cost from it. */
 	pricing?: PricingService;
 }
@@ -928,16 +930,14 @@ export async function runAgent(
 			// connectivity outcome and abort with operator guidance when the proxy is
 			// known-unreachable. Fail OPEN on ok/skipped/unknown (and when no status
 			// holder is wired) so Docker Desktop and tests are unaffected.
-			if (deps.connectivityStatus) {
-				const probeBindHost = deps.connectivityStatus.get().bindHost;
-				const status = await deps.connectivityStatus.ensureFresh(async () => {
-					const { outcome } = await checkContainerToHostConnectivity({
-						docker: deps.docker,
-						serverPort: deps.serverPort,
-						containerBindHost: probeBindHost,
-					});
-					return { status: outcome, bindHost: probeBindHost };
-				}, CONNECTIVITY_STALE_MS);
+			if (deps.connectivityStatus && deps.connectivityProbe) {
+				// Re-confirm a BAD cached outcome before blocking (maxAge 0): the probe
+				// auto-rebinds against the live bind host, so a stale/race-poisoned
+				// loopback result self-heals instead of blocking for the whole staleness
+				// window. A good cached outcome short-circuits on the normal staleness.
+				const cached = deps.connectivityStatus.get().status;
+				const maxAge = shouldAbortForConnectivity(cached) ? 0 : CONNECTIVITY_STALE_MS;
+				const status = await deps.connectivityStatus.ensureFresh(deps.connectivityProbe, maxAge);
 				if (shouldAbortForConnectivity(status)) {
 					// Release the ssh socket allocated just above; the credential lock is
 					// freed by the outer finally.

--- a/packages/server/src/services/ceo-session-manager.ts
+++ b/packages/server/src/services/ceo-session-manager.ts
@@ -33,10 +33,7 @@ import {
 	createAgentChatParser,
 } from './agent-stream-parser';
 import { getProviderCredentialAndModel } from './ai-provider-keys';
-import {
-	checkContainerToHostConnectivity,
-	formatContainerConnectivityMessage,
-} from './container-connectivity-preflight';
+import { formatContainerConnectivityMessage } from './container-connectivity-preflight';
 import { CONNECTIVITY_STALE_MS, shouldAbortForConnectivity } from './container-connectivity-status';
 import type { ContainerLogStreamer } from './container-logs';
 import { type ContainerRunUser, resolveContainerRunUser } from './container-user';
@@ -385,16 +382,14 @@ export class CeoSessionManager {
 				// which releases the ssh bridge and records the session error. Fail open on
 				// ok/skipped/unknown (and when no status holder is wired).
 				const connectivityStatus = this.deps.connectivityStatus;
-				if (connectivityStatus) {
-					const probeBindHost = connectivityStatus.get().bindHost;
-					const status = await connectivityStatus.ensureFresh(async () => {
-						const { outcome } = await checkContainerToHostConnectivity({
-							docker: this.deps.docker,
-							serverPort: this.deps.serverPort,
-							containerBindHost: probeBindHost,
-						});
-						return { status: outcome, bindHost: probeBindHost };
-					}, CONNECTIVITY_STALE_MS);
+				const connectivityProbe = this.deps.connectivityProbe;
+				if (connectivityStatus && connectivityProbe) {
+					// Re-confirm a BAD cached outcome before blocking (maxAge 0): the probe
+					// auto-rebinds against the live bind host, so a stale/race-poisoned
+					// loopback result self-heals instead of blocking until restart.
+					const cached = connectivityStatus.get().status;
+					const maxAge = shouldAbortForConnectivity(cached) ? 0 : CONNECTIVITY_STALE_MS;
+					const status = await connectivityStatus.ensureFresh(connectivityProbe, maxAge);
 					if (shouldAbortForConnectivity(status)) {
 						const guidance = formatContainerConnectivityMessage(status, {
 							serverPort: this.deps.serverPort,

--- a/packages/server/src/services/container-connectivity-preflight.ts
+++ b/packages/server/src/services/container-connectivity-preflight.ts
@@ -410,6 +410,10 @@ export interface AutoRebindDeps {
 	bindHost: { get(): string; set(host: string): void };
 	/** Injectable for tests; defaults to the real preflight. */
 	check?: (deps: ConnectivityCheckDeps) => Promise<ConnectivityCheckResult>;
+	/** Whether to log the final outcome / auto-bind notice (default true). Set false
+	 * for per-run gate re-probes, which call this on every CEO/agent start and would
+	 * otherwise spam the log; the gate surfaces a bad outcome via its abort message. */
+	logResult?: boolean;
 }
 
 /**
@@ -436,18 +440,23 @@ export async function checkAndAutoRebindConnectivity(
 	let outcome = first.outcome;
 	let bindHost = deps.bindHost.get();
 
+	const logResult = deps.logResult !== false;
 	const rebindTo = resolveAutoRebindTarget(first, bindHost);
 	if (rebindTo) {
-		log.info(
-			`Egress proxy / SSH bridge auto-bound to docker bridge gateway ${rebindTo} ` +
-				`(a container could not reach the loopback bind). Override with --container-bind-host.`,
-		);
+		if (logResult) {
+			log.info(
+				`Egress proxy / SSH bridge auto-bound to docker bridge gateway ${rebindTo} ` +
+					`(a container could not reach the loopback bind). Override with --container-bind-host.`,
+			);
+		}
 		deps.bindHost.set(rebindTo);
 		const second = await probe(rebindTo);
 		outcome = second.outcome;
 		bindHost = rebindTo;
 	}
 
-	logConnectivityOutcome(outcome, { serverPort: deps.serverPort, containerBindHost: bindHost });
+	if (logResult) {
+		logConnectivityOutcome(outcome, { serverPort: deps.serverPort, containerBindHost: bindHost });
+	}
 	return { outcome, bindHost };
 }

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -36,7 +36,7 @@ import {
 	setAgentIdleIfNoActiveRuns,
 } from './agent-runtime-status';
 import { checkOverBudget } from './budget';
-import type { ContainerConnectivityStatus } from './container-connectivity-status';
+import type { ContainerConnectivityStatus, ProbeResult } from './container-connectivity-status';
 import type { ContainerLogStreamer } from './container-logs';
 import {
 	type ContainerDeps,
@@ -136,6 +136,7 @@ export interface JobManagerDeps {
 	egressProxy?: EgressProxy | null;
 	egressCAPath?: string;
 	connectivityStatus?: ContainerConnectivityStatus;
+	connectivityProbe?: () => Promise<ProbeResult>;
 	pricing?: PricingService;
 }
 

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -224,15 +224,33 @@ export async function startup(config: HezoConfig): Promise<StartupResult> {
 	// Backgrounded + non-fatal: it must not gate readiness, and the web UI stays up
 	// so the operator can act on any residual guidance. No-ops under HEZO_SKIP_DOCKER
 	// (fake docker / tests) and the documented opt-out.
+	//
+	// One probe over the LIVE bind host, used by both the boot check and the per-run
+	// gate (agent-runner / CEO). Routing every probe through checkAndAutoRebindConnectivity
+	// means the gate always re-probes the current EffectiveBindHost (and rebinds if still
+	// on loopback), so a stale/race-poisoned loopback result self-heals on the next run
+	// instead of blocking until restart. The boot probe logs the auto-bind / outcome; the
+	// per-run gate stays quiet (logResult:false) — it surfaces failures via its abort message.
+	const makeConnectivityProbe = (logResult: boolean) => async () => {
+		const r = await checkAndAutoRebindConnectivity({
+			docker,
+			serverPort: config.port,
+			bindHost,
+			logResult,
+		});
+		return { status: r.outcome, bindHost: r.bindHost };
+	};
+	const connectivityProbe = makeConnectivityProbe(false);
+	// Boot via ensureFresh so an early run-time probe shares this single-flight (no race,
+	// no duplicate probe container). maxAge 0 forces the initial probe; the boot closure
+	// logs. Whichever ensureFresh starts first wins — boot starts here, before any request.
 	trackBackground(
-		checkAndAutoRebindConnectivity({ docker, serverPort: config.port, bindHost })
-			.then((r) => connectivityStatus.set(r.outcome, r.bindHost))
-			.catch((err) => {
-				log.info('container→host connectivity check failed', {
-					error: err instanceof Error ? err.message : String(err),
-				});
-				connectivityStatus.set('skipped', bindHost.get());
-			}),
+		connectivityStatus.ensureFresh(makeConnectivityProbe(true), 0).catch((err) => {
+			log.info('container→host connectivity check failed', {
+				error: err instanceof Error ? err.message : String(err),
+			});
+			connectivityStatus.set('skipped', bindHost.get());
+		}),
 	);
 	const events = new DomainEventBus();
 	const jobManager = new JobManager({
@@ -249,6 +267,7 @@ export async function startup(config: HezoConfig): Promise<StartupResult> {
 		egressProxy,
 		egressCAPath: egressCA.certPath,
 		connectivityStatus,
+		connectivityProbe,
 		pricing,
 	});
 	const ceoSessionManager = new CeoSessionManager({
@@ -264,6 +283,7 @@ export async function startup(config: HezoConfig): Promise<StartupResult> {
 		egressProxy,
 		egressCAPath: egressCA.certPath,
 		connectivityStatus,
+		connectivityProbe,
 		containerLogStreamer,
 	});
 

--- a/packages/server/test/agent-runner-extended.test.ts
+++ b/packages/server/test/agent-runner-extended.test.ts
@@ -27,6 +27,7 @@ import { NETWORKING_DOCS_URL } from '../src/services/container-connectivity-pref
 import {
 	type ConnectivityStatus,
 	ContainerConnectivityStatus,
+	type ProbeResult,
 } from '../src/services/container-connectivity-status';
 import type { DockerClient } from '../src/services/docker';
 import { LogStreamBroker } from '../src/services/log-stream-broker';
@@ -354,12 +355,23 @@ describe('runAgent — egress proxy + ssh agent env injection', () => {
 });
 
 describe('runAgent — egress connectivity gate', () => {
-	// A fresh status holder preset to `s` (so ensureFresh hits the cache and never
-	// boots a probe container). `unknown` is left unset.
+	// A status holder preset to `s` (fresh). `unknown` is left unset.
 	function presetStatus(s: ConnectivityStatus): ContainerConnectivityStatus {
 		const status = new ContainerConnectivityStatus('127.0.0.1');
 		if (s !== 'unknown') status.set(s, '127.0.0.1');
 		return status;
+	}
+
+	// A fake run-time probe (stands in for the auto-rebind closure from startup).
+	function fakeProbe(result: ProbeResult) {
+		const calls = { count: 0 };
+		return {
+			calls,
+			fn: async () => {
+				calls.count++;
+				return result;
+			},
+		};
 	}
 
 	const okDocker = () =>
@@ -369,18 +381,42 @@ describe('runAgent — egress connectivity gate', () => {
 			execInspect: async () => ({ ExitCode: 0, Running: false, Pid: 0 }),
 		});
 
-	it.each([
-		'bind-loopback',
-		'bind-firewalled',
-		'mcp-unreachable',
-	] as const)('aborts (without allocating egress) when the proxy is unreachable: %s', async (badStatus) => {
+	it('self-heals a stale/race-poisoned bind-loopback cache by re-probing the live bind host', async () => {
+		// The production bug: connectivityStatus stuck at bind-loopback@127.0.0.1 while
+		// the proxy is actually bound+reachable at the gateway. A bad cache must re-probe,
+		// and the auto-rebind probe reports ok@172.17.0.1 → the run proceeds.
 		const egress = fakeEgressProxy();
 		const ssh = fakeSshAgentServer();
+		const probe = fakeProbe({ status: 'ok', bindHost: '172.17.0.1' });
 		const deps = baseDeps(okDocker(), {
 			egressProxy: egress.proxy,
 			egressCAPath: '/tmp/test-data/egress-ca.crt',
 			sshAgentServer: ssh.server,
-			connectivityStatus: presetStatus(badStatus),
+			connectivityStatus: presetStatus('bind-loopback'),
+			connectivityProbe: probe.fn,
+		});
+
+		const result = await runAgent(deps, makeAgent(), makeTask(), makeProject());
+
+		expect(result.success).toBe(true);
+		expect(probe.calls.count).toBe(1); // bad cache forced a re-probe
+		expect(egress.calls.allocated).toContain(result.heartbeatRunId);
+	});
+
+	it.each([
+		'bind-loopback',
+		'bind-firewalled',
+		'mcp-unreachable',
+	] as const)('aborts (without allocating egress) when the proxy is genuinely unreachable: %s', async (bad) => {
+		const egress = fakeEgressProxy();
+		const ssh = fakeSshAgentServer();
+		const probe = fakeProbe({ status: bad, bindHost: '127.0.0.1' });
+		const deps = baseDeps(okDocker(), {
+			egressProxy: egress.proxy,
+			egressCAPath: '/tmp/test-data/egress-ca.crt',
+			sshAgentServer: ssh.server,
+			connectivityStatus: presetStatus(bad),
+			connectivityProbe: probe.fn,
 		});
 
 		const result = await runAgent(deps, makeAgent(), makeTask(), makeProject());
@@ -393,17 +429,35 @@ describe('runAgent — egress connectivity gate', () => {
 		expect(ssh.calls.released).toContain(result.heartbeatRunId);
 	});
 
-	it.each([
-		'ok',
-		'skipped',
-	] as const)('proceeds and allocates egress when connectivity is fine: %s', async (goodStatus) => {
+	it('short-circuits a fresh good cache without re-probing', async () => {
+		const egress = fakeEgressProxy();
+		const ssh = fakeSshAgentServer();
+		const status = new ContainerConnectivityStatus('172.17.0.1');
+		status.set('ok', '172.17.0.1'); // fresh ok
+		const probe = fakeProbe({ status: 'mcp-unreachable', bindHost: '127.0.0.1' }); // would abort if called
+		const deps = baseDeps(okDocker(), {
+			egressProxy: egress.proxy,
+			egressCAPath: '/tmp/test-data/egress-ca.crt',
+			sshAgentServer: ssh.server,
+			connectivityStatus: status,
+			connectivityProbe: probe.fn,
+		});
+
+		const result = await runAgent(deps, makeAgent(), makeTask(), makeProject());
+
+		expect(result.success).toBe(true);
+		expect(probe.calls.count).toBe(0); // fresh ok → no probe
+		expect(egress.calls.allocated).toContain(result.heartbeatRunId);
+	});
+
+	it('fails open (allocates egress) when the probe is not wired (back-compat)', async () => {
 		const egress = fakeEgressProxy();
 		const ssh = fakeSshAgentServer();
 		const deps = baseDeps(okDocker(), {
 			egressProxy: egress.proxy,
 			egressCAPath: '/tmp/test-data/egress-ca.crt',
 			sshAgentServer: ssh.server,
-			connectivityStatus: presetStatus(goodStatus),
+			connectivityStatus: presetStatus('bind-loopback'), // present, but no probe → gate skipped
 		});
 
 		const result = await runAgent(deps, makeAgent(), makeTask(), makeProject());
@@ -412,7 +466,7 @@ describe('runAgent — egress connectivity gate', () => {
 		expect(egress.calls.allocated).toContain(result.heartbeatRunId);
 	});
 
-	it('fails open (allocates egress) when no connectivity status holder is wired', async () => {
+	it('fails open when no connectivity status holder is wired', async () => {
 		const egress = fakeEgressProxy();
 		const ssh = fakeSshAgentServer();
 		const deps = baseDeps(okDocker(), {

--- a/packages/server/test/container-connectivity-preflight.test.ts
+++ b/packages/server/test/container-connectivity-preflight.test.ts
@@ -395,6 +395,27 @@ describe('checkAndAutoRebindConnectivity', () => {
 		expect(infoSpy).toHaveBeenCalled();
 	});
 
+	it('logs nothing when logResult is false (per-run gate re-probes stay quiet)', async () => {
+		const ref = bindRef('127.0.0.1');
+		// A genuinely-degraded outcome that would otherwise warn.
+		const check = vi
+			.fn<() => Promise<ConnectivityCheckResult>>()
+			.mockResolvedValue({ outcome: 'bind-loopback' });
+
+		const result = await checkAndAutoRebindConnectivity({
+			docker,
+			serverPort: 3100,
+			bindHost: ref,
+			check,
+			logResult: false,
+		});
+
+		expect(result).toEqual({ outcome: 'bind-loopback', bindHost: '127.0.0.1' });
+		expect(infoSpy).not.toHaveBeenCalled();
+		expect(warnSpy).not.toHaveBeenCalled();
+		expect(errorSpy).not.toHaveBeenCalled();
+	});
+
 	it('warns once and leaves the bind host unchanged when no gateway IP was resolved', async () => {
 		const ref = bindRef('127.0.0.1');
 		const check = vi

--- a/packages/web/src/hooks/use-ceo-chat.ts
+++ b/packages/web/src/hooks/use-ceo-chat.ts
@@ -13,6 +13,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useSocket } from '../contexts/socket-context';
 import { api } from '../lib/api';
 import { queryKeys } from '../lib/query-keys';
+import { toast } from './use-toast';
 
 export interface CeoMessage {
 	id: string;
@@ -156,6 +157,9 @@ export function useCeoChat(active: boolean) {
 
 	const sendMutation = useMutation({
 		mutationFn: (text: string) => api.post('/api/ceo/messages', { text }),
+		onError: (error: { message?: string }) => {
+			toast.error(error?.message ?? 'Failed to send message to the CEO');
+		},
 	});
 
 	const messages = query.data?.messages ?? [];

--- a/packages/web/test/ceo-chat.test.tsx
+++ b/packages/web/test/ceo-chat.test.tsx
@@ -1,8 +1,9 @@
 import type { CeoMessage } from '@hezo/web/hooks/use-ceo-chat';
+import { toast } from '@hezo/web/hooks/use-toast';
 import { queryClient } from '@hezo/web/lib/query-client';
 import { queryKeys } from '@hezo/web/lib/query-keys';
 import { waitFor } from '@testing-library/react';
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 import { renderApp } from './helpers/render';
 
 // The component harness builds the backend without a CeoSessionManager (the chat
@@ -50,6 +51,22 @@ test('composer enables send when text is entered and clears on submit', async ()
 	await user.click(send);
 	// The draft clears immediately on submit regardless of the server result.
 	expect(input.value).toBe('');
+});
+
+test('surfaces a failed CEO send as an error toast', async () => {
+	// The harness backend has no CeoSessionManager, so POST /api/ceo/messages
+	// returns 503 — the send mutation's onError must surface the server message.
+	const errorSpy = vi.spyOn(toast, 'error');
+	try {
+		const { findByTestId, getByTestId, user } = await renderApp({ initialPath: '/home' });
+		(await findByTestId('ceo-chat-launcher')).click();
+		const input = (await findByTestId('ceo-chat-input')) as HTMLTextAreaElement;
+		await user.type(input, 'why is everything stuck?');
+		await user.click(getByTestId('ceo-chat-send') as HTMLButtonElement);
+		await waitFor(() => expect(errorSpy).toHaveBeenCalledWith('CEO chat is not available'));
+	} finally {
+		errorSpy.mockRestore();
+	}
 });
 
 test('shows the empty state once history loads', async () => {


### PR DESCRIPTION
## Why

After #441, a production native-Linux Docker host hit `CEO_UNAVAILABLE` (`bind-loopback @ 127.0.0.1`) **even though the egress proxy was bound to and reachable at the bridge gateway**. Diagnosed live on the affected server: a container can't reach a host listener on `127.0.0.1` (`000`) but **can** reach one on the bridge gateway `172.17.0.1` (`200`) — so the network is fine; the bug is in the gate logic.

**Root cause.** Two bind-host values exist: `EffectiveBindHost` (what the proxy/SSH actually bind — correctly auto-rebound to `172.17.0.1`) and a **frozen copy stored in `ContainerConnectivityStatus`**. The run-time gate re-probed at `connectivityStatus.get().bindHost`, **not** the live `EffectiveBindHost`, and never rebinds. With the boot probe backgrounded, a CEO/agent run firing *before* the rebind finished probed the seeded `127.0.0.1`, recorded `bind-loopback @ 127.0.0.1`, and every later re-probe stayed hardwired to that stale `127.0.0.1` → blocked forever, until restart, while the proxy worked at `172.17.0.1`.

## What

1. **Self-healing gate.** Route every probe (boot **and** per-run gate) through one `checkAndAutoRebindConnectivity` closure over the **live** `EffectiveBindHost`, and **always re-confirm a bad cached outcome before blocking** (`maxAge 0`). The gate now re-probes the live bind host, rebinds if still on loopback, and recovers a stale/race-poisoned result on the next run — no restart. The boot probe runs via the same `ensureFresh` single-flight, so an early run shares it (no race, no duplicate probe). Boot still logs the auto-bind/outcome; the per-run gate stays quiet (`logResult: false`).

2. **CEO send errors → error toast.** The web composer swallowed send errors (`use-ceo-chat.ts` had no `onError`), so `CEO_UNAVAILABLE` was invisible. Added `onError` → `toast.error(server message)`.

### Key files
- `startup.ts` — one shared `connectivityProbe` over the live bind host; boot via `ensureFresh(probe, 0)`; inject into both managers.
- `agent-runner.ts` / `ceo-session-manager.ts` — gate uses the injected probe + re-confirm-bad logic.
- `job-manager.ts` — `connectivityProbe?` dep.
- `container-connectivity-preflight.ts` — `logResult?` on `AutoRebindDeps`.
- `packages/web/src/hooks/use-ceo-chat.ts` — toast on send error.

## Tests
- **Self-heal (the bug):** poisoned `bind-loopback @ 127.0.0.1` cache + probe reporting `ok @ 172.17.0.1` → run **proceeds**, egress allocated, re-probe fired.
- Aborts on a genuinely-unreachable probe outcome (no egress, ssh released, guidance + docs link); fresh-good cache short-circuits without probing; fail-open when probe/status not wired.
- Preflight: `checkAndAutoRebindConnectivity` with `logResult: false` logs nothing.
- Web: a failed CEO send fires `toast.error('CEO chat is not available')`.

## Note on stacking
This stacks on **#441 → #443**. It targets the #443 branch so the diff is just this fix; GitHub will retarget it to `main` once #443 merges. (Equivalent to merging #441, #443, then this in order.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015bYNE2AxYhEMz8jvQjCmSF

---
_Generated by [Claude Code](https://claude.ai/code/session_015bYNE2AxYhEMz8jvQjCmSF)_