### PR TITLE
fix: re-openable tickets + agent approval before external-service writes

### DIFF
--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -70,13 +70,16 @@ async function wakeAgentIfAssigned(
 	assigneeId: string | null | undefined,
 	teamId: string,
 	taskId: string,
+	source: WakeupSource = WakeupSource.Assignment,
+	extraPayload: Record<string, unknown> = {},
 ): Promise<void> {
 	if (!assigneeId) return;
 	const isAgent = await db.query('SELECT id FROM member_agents WHERE id = $1', [assigneeId]);
 	if (isAgent.rows.length > 0) {
 		trackBackground(
-			createWakeup(db, assigneeId, teamId, WakeupSource.Assignment, {
+			createWakeup(db, assigneeId, teamId, source, {
 				task_id: taskId,
+				...extraPayload,
 			}).catch((e) => log.error('Failed to create wakeup for assignment:', e)),
 		);
 	}
@@ -590,6 +593,18 @@ tasksRoutes.patch('/projects/:projectId/tasks/:taskId', async (c) => {
 
 	if (body.assignee_id && body.assignee_id !== existing.rows[0].assignee_id) {
 		wakeAgentIfAssigned(db, body.assignee_id, teamId, taskId);
+	}
+
+	const wasTerminal = (TERMINAL_TASK_STATUSES as readonly string[]).includes(
+		existing.rows[0].status,
+	);
+	const nowTerminal =
+		body.status !== undefined &&
+		(TERMINAL_TASK_STATUSES as readonly string[]).includes(body.status);
+	if (body.status !== undefined && wasTerminal && !nowTerminal) {
+		wakeAgentIfAssigned(db, existing.rows[0].assignee_id, teamId, taskId, WakeupSource.Automation, {
+			trigger: 'task_reopened',
+		});
 	}
 
 	const actorMemberId = await resolveActorMemberId(c, teamId);

--- a/packages/server/src/services/template-resolver.ts
+++ b/packages/server/src/services/template-resolver.ts
@@ -180,6 +180,13 @@ const SHARED_INSTRUCTIONS = `
   - \`oauth_status = "failed"\` → an attempt errored (read \`auth_error\` for the AS's message). Surface this to the human; they may need to retry or fix something.
   - \`oauth_status = "revoked"\` → a human explicitly disconnected. Don't auto-reconnect; ask first.
 - If your tool list doesn't include the MCP's tools but \`oauth_status\` is \`"active"\`, it's NOT a "waiting on auth" situation. Call \`test_connector(connector_id)\` — it resolves the stored token server-side and pings the MCP URL directly, bypassing the container entirely. The result tells you (a) whether the token is still valid against the provider (and if not, surface to the user so they can reconnect), or (b) the token is valid and the issue is in the container/proxy chain (post a wrap-up comment explaining what \`test_connector\` returned so the human can file a bug).
+
+### Changes to External Services Require Admin Approval
+- Before you **create, configure, modify, or delete** anything on a third-party/external service — an analytics property, a CMS entry, a hosting site or deployment, a DNS record, a mailing list, a social post, an external repository or billing setting, a webhook, anything that lives outside Hezo — you must get explicit **admin approval first**. Never make the change unilaterally, even when the work clearly calls for it.
+- **Inspect before you write.** Read and list what already exists on the service first. The admin may have already set the resource up; a duplicate, misnamed, or unwanted entry is a real-world side effect that is awkward or impossible to undo. Discovering and reusing an existing resource is almost always the correct move over creating a new one.
+- **How to ask:** post a comment stating exactly what you intend to do — the service, the specific action, the target resource, and why — put \`@admin\` in that same comment, and end your turn with the ticket in a non-terminal status. That is a recognised "waiting on input" state; the admin's reply wakes you automatically. Proceed only after they approve.
+- **Read-only inspection needs no approval.** Listing, reading, and querying an external service to understand its current state is always fine — the gate is on state-changing writes, not on looking.
+- Having the service's endpoint or credentials is **not** approval for a specific change. Access lets you inspect and, once approved, act; it never licenses an unreviewed write on its own.
 `;
 
 export async function resolveSystemPrompt(

--- a/packages/server/test/tasks-reopen-wakeup.test.ts
+++ b/packages/server/test/tasks-reopen-wakeup.test.ts
@@ -1,0 +1,160 @@
+import type { PGlite } from '@electric-sql/pglite';
+import { WakeupSource } from '@hezo/shared';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { MasterKeyManager } from '../src/crypto/master-key';
+import type { Env } from '../src/lib/types';
+import { safeClose } from './helpers';
+import {
+	authHeader,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+	mintAgentToken,
+} from './helpers/app';
+
+let app: Hono<Env>;
+let db: PGlite;
+let token: string;
+let masterKeyManager: MasterKeyManager;
+let teamId: string;
+let projectId: string;
+let projectSlug: string;
+let agentId: string;
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+	masterKeyManager = ctx.masterKeyManager;
+
+	const teamRes = await createTestTeam(db, { name: 'Reopen Co' });
+	teamId = (await teamRes.json()).data.id;
+
+	const projectRes = await createTestProject(db, teamId, {
+		name: 'Reopen Project',
+		description: 'Test project.',
+	});
+	const projectBody = (await projectRes.json()).data;
+	projectId = projectBody.id;
+	projectSlug = projectBody.slug;
+
+	const agentRes = await app.request(`/api/projects/${projectSlug}/agents`, {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ title: 'Reopen Agent' }),
+	});
+	agentId = (await agentRes.json()).data.id;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+async function insertTaskDirect(status: string, title: string): Promise<{ id: string }> {
+	const meta = await db.query<{ task_prefix: string; number: number }>(
+		`SELECT p.task_prefix, next_project_task_number(p.id) AS number
+		 FROM projects p WHERE p.id = $1`,
+		[projectId],
+	);
+	const n = meta.rows[0].number;
+	const res = await db.query<{ id: string }>(
+		`INSERT INTO tasks (team_id, project_id, assignee_id, number, identifier, title, status, priority, labels)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7::task_status, 'medium'::task_priority, '[]'::jsonb)
+		 RETURNING id`,
+		[teamId, projectId, agentId, n, `${meta.rows[0].task_prefix}-${n}`, title, status],
+	);
+	return res.rows[0];
+}
+
+function flushAsyncWakeups(): Promise<void> {
+	return new Promise((resolve) => setImmediate(resolve));
+}
+
+async function reopenWakeups(taskId: string): Promise<{ source: string; trigger?: string }[]> {
+	const rows = await db.query<{ source: string; payload: { trigger?: string } }>(
+		`SELECT source::text AS source, payload FROM agent_wakeup_requests
+		 WHERE payload->>'task_id' = $1`,
+		[taskId],
+	);
+	return rows.rows.map((r) => ({ source: r.source, trigger: r.payload?.trigger }));
+}
+
+describe('re-opening a terminal task wakes the assignee', () => {
+	it('fires an automation wakeup with trigger=task_reopened when an admin re-opens a closed task', async () => {
+		const task = await insertTaskDirect('closed', 'Closed task to reopen');
+		await db.query('DELETE FROM agent_wakeup_requests');
+
+		const res = await app.request(`/api/projects/${projectSlug}/tasks/${task.id}`, {
+			method: 'PATCH',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ status: 'backlog' }),
+		});
+		expect(res.status).toBe(200);
+		await flushAsyncWakeups();
+
+		const wakeups = await reopenWakeups(task.id);
+		const reopen = wakeups.find(
+			(w) => w.source === WakeupSource.Automation && w.trigger === 'task_reopened',
+		);
+		expect(reopen).toBeDefined();
+	});
+
+	it('fires the re-open wakeup when an admin re-opens a done task', async () => {
+		const task = await insertTaskDirect('done', 'Done task to reopen');
+		await db.query('DELETE FROM agent_wakeup_requests');
+
+		const res = await app.request(`/api/projects/${projectSlug}/tasks/${task.id}`, {
+			method: 'PATCH',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ status: 'in_progress' }),
+		});
+		expect(res.status).toBe(200);
+		await flushAsyncWakeups();
+
+		const wakeups = await reopenWakeups(task.id);
+		expect(
+			wakeups.some((w) => w.source === WakeupSource.Automation && w.trigger === 'task_reopened'),
+		).toBe(true);
+	});
+
+	it('does NOT fire a re-open wakeup for a non-terminal status change', async () => {
+		const task = await insertTaskDirect('backlog', 'Active task being moved');
+		await db.query('DELETE FROM agent_wakeup_requests');
+
+		const res = await app.request(`/api/projects/${projectSlug}/tasks/${task.id}`, {
+			method: 'PATCH',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ status: 'in_progress' }),
+		});
+		expect(res.status).toBe(200);
+		await flushAsyncWakeups();
+
+		const wakeups = await reopenWakeups(task.id);
+		expect(wakeups.some((w) => w.trigger === 'task_reopened')).toBe(false);
+	});
+
+	it('still forbids an agent from re-opening a closed task', async () => {
+		const task = await insertTaskDirect('closed', 'Closed task agent cannot reopen');
+		const { token: agentToken } = await mintAgentToken(
+			db,
+			masterKeyManager,
+			agentId,
+			teamId,
+			task.id,
+		);
+
+		const res = await app.request(`/api/projects/${projectSlug}/tasks/${task.id}`, {
+			method: 'PATCH',
+			headers: { ...authHeader(agentToken), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ status: 'backlog' }),
+		});
+		expect(res.status).toBe(403);
+
+		const row = await db.query<{ status: string }>('SELECT status FROM tasks WHERE id = $1', [
+			task.id,
+		]);
+		expect(row.rows[0].status).toBe('closed');
+	});
+});

--- a/packages/server/test/template-resolver.test.ts
+++ b/packages/server/test/template-resolver.test.ts
@@ -247,6 +247,10 @@ describe('template resolver', () => {
 		expect(result).toContain('write_project_doc');
 		expect(result).toContain('create_skill');
 		expect(result).toContain('create_task');
+		// Every agent must seek admin approval before mutating an external service, and
+		// must inspect for an existing resource before creating a duplicate.
+		expect(result).toContain('### Changes to External Services Require Admin Approval');
+		expect(result).toContain('Inspect before you write');
 	});
 
 	it('tells every agent the run is headless and not to point the user at terminal/adapter commands', async () => {

--- a/packages/web/src/components/task-detail/task-sidebar.tsx
+++ b/packages/web/src/components/task-detail/task-sidebar.tsx
@@ -5,6 +5,7 @@ import {
 	DEFAULT_EFFORT,
 	HQ_PROJECT_SLUG,
 	TaskStatus,
+	TERMINAL_TASK_STATUSES,
 } from '@hezo/shared';
 import { Link } from '@tanstack/react-router';
 import { ChevronDown } from 'lucide-react';
@@ -252,8 +253,8 @@ export function TaskSidebar({
 					</select>
 				</div>
 
-				<div className="mt-auto pt-4 border-t border-border">
-					{task.status === TaskStatus.Closed ? (
+				<div className="mt-auto pt-4 border-t border-border space-y-2">
+					{(TERMINAL_TASK_STATUSES as readonly string[]).includes(task.status) && (
 						<Button
 							variant="secondary"
 							size="sm"
@@ -263,7 +264,8 @@ export function TaskSidebar({
 						>
 							Re-open task
 						</Button>
-					) : (
+					)}
+					{task.status !== TaskStatus.Closed && task.status !== TaskStatus.Cancelled && (
 						<Button
 							variant="danger-text"
 							size="sm"

--- a/packages/web/test/task-close-reopen.test.tsx
+++ b/packages/web/test/task-close-reopen.test.tsx
@@ -1,6 +1,20 @@
 import { expect, test } from 'vitest';
-import { renderApp } from './helpers/render';
-import { seedProject, seedTask, seedWorkspace } from './helpers/seed';
+import { getTestContext, renderApp } from './helpers/render';
+import { type SeededWorkspace, seedProject, seedTask, seedWorkspace } from './helpers/seed';
+
+async function patchStatus(
+	ws: SeededWorkspace,
+	projectSlug: string,
+	taskId: string,
+	status: string,
+) {
+	const { apiBase } = getTestContext();
+	await apiBase(`/api/projects/${projectSlug}/tasks/${taskId}`, {
+		method: 'PATCH',
+		headers: ws.headers,
+		body: JSON.stringify({ status }),
+	});
+}
 
 test('the admin can close and re-open a task via themed modal', async () => {
 	const seeded = { projectSlug: '', taskId: '', identifier: '' };
@@ -70,4 +84,50 @@ test('task detail no longer shows a delete button or status pill row', async () 
 	expect(queryByRole('button', { name: /Delete Task/i })).toBeNull();
 	expect(queryByRole('button', { name: 'in progress' })).toBeNull();
 	expect(queryByRole('button', { name: 'review' })).toBeNull();
+});
+
+test('a done task offers both re-open and close', async () => {
+	const seeded = { projectSlug: '', taskId: '' };
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Done Project' });
+			const task = await seedTask(ws, project, { title: 'Done Task' });
+			await patchStatus(ws, project.slug, task.id, 'done');
+			seeded.projectSlug = project.slug;
+			seeded.taskId = task.identifier.toLowerCase();
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
+	});
+
+	await findByTestId('task-reopen-button', undefined, { timeout: 10_000 });
+	await findByTestId('task-close-button');
+});
+
+test('a cancelled task offers re-open and hides close', async () => {
+	const seeded = { projectSlug: '', taskId: '' };
+	const { findByTestId, queryByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Cancelled Project' });
+			const task = await seedTask(ws, project, { title: 'Cancelled Task' });
+			await patchStatus(ws, project.slug, task.id, 'cancelled');
+			seeded.projectSlug = project.slug;
+			seeded.taskId = task.identifier.toLowerCase();
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
+	});
+
+	await findByTestId('task-reopen-button', undefined, { timeout: 10_000 });
+	expect(queryByTestId('task-close-button')).toBeNull();
 });


### PR DESCRIPTION
## Context

Prompted by task `hm-12` (hezo-marketing): an agent created a **new** Umami website property even though one already existed under the team, registered an MCP connector, and marked the work shipped — all unilateral writes to an external service. By the time the admin commented "there is already a website property," the run had ended and the ticket was closed, so the agent never responded and there was no way to re-engage it.

Three fixes, one per gap.

## Changes

### 1. Admins can re-open `done`/`closed`/`cancelled` tickets
`packages/web/src/components/task-detail/task-sidebar.tsx` — the **Re-open task** button previously appeared only for `closed`. It now shows for any terminal status. A `done` task shows **both** Re-open and Close (preserving the admin "force-close, skip coach review" shortcut); `closed`/`cancelled` show Re-open only. The server already permitted admins to re-open any task — only agents remain barred from re-opening a `closed` one.

### 2. Re-opening wakes the assigned agent
`packages/server/src/routes/tasks.ts` — a **terminal → non-terminal** status transition now fires an `automation` wakeup (`trigger: task_reopened`) to the assignee, so the agent resumes and responds to the comment that was stranded on the closed ticket. `wakeAgentIfAssigned` was generalized to accept a source + payload rather than duplicating the lookup.

### 3. All agents must get admin approval before external-service writes
`packages/server/src/services/template-resolver.ts` — new **"Changes to External Services Require Admin Approval"** section in `SHARED_INSTRUCTIONS`, which reaches every agent (current and future runtime hires, all team types): inspect-before-you-write (would have caught the existing Umami property), explicit `@admin` approval before any create/configure/modify/delete on a third-party service, read-only inspection stays free, and "having credentials ≠ approval." Reuses the documented `@admin`-and-wait pattern; no new MCP tool required.

## Tests
- `packages/server/test/tasks-reopen-wakeup.test.ts` (new) — closed→backlog and done→in_progress fire the reopen wakeup; non-terminal moves don't; an agent re-opening a closed task still 403s.
- `packages/web/test/task-close-reopen.test.tsx` — added `done` (both buttons) and `cancelled` (reopen only) cases.
- `packages/server/test/template-resolver.test.ts` — asserts the new section appears in every prompt.

All affected suites green; typecheck clean. No MCP/route/CLI surface changed, so no generated-doc regen needed (the `mcp-api.md` "only the admin can re-open a closed task" note remains accurate — agents are still barred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159NAMbuBCMYB36MGBMR8SW