### PR TITLE
fix: fast egress preflight + CEO chat reliability (pending UI, no duplicate/stuck turns)

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -241,7 +241,12 @@ after the container-restart reconcile pass and brings HQ up via
 provision if missing) — fire-and-forget so a slow image pull doesn't delay startup. This is
 unconditional because the standard restart pass deliberately leaves `stopped` projects
 alone, whereas HQ — home of the always-on CEO/Coach — should run whenever the instance does.
-The live CEO chat (`ceo-session-manager.ts`) also provisions it on demand as a fallback.
+The live CEO chat (`ceo-session-manager.ts`) also provisions it on demand as a fallback. Turns
+are **serialized** (a `turnLock` chain) so concurrent sends can't each spawn a turn — a newer
+message interrupts the in-flight reply (kept as `interrupted`) and only the latest streams. No
+turn survives a process restart, so `reconcileOnStartup` clears orphaned non-terminal
+`ceo_messages` (deletes empty `streaming`/`pending` placeholders, marks partial ones
+`interrupted`) — an abandoned turn never lingers as a stuck "thinking" bubble.
 
 HQ also exposes the standard **assets library** — the one internal-project surface that
 isn't hidden in the UI (Budget/Settings still are). Files the CEO produces for the operator
@@ -528,13 +533,17 @@ ssh-agent TCP bridge is read **per-run** from a shared mutable holder (`Effectiv
 seeded from `HEZO_CONTAINER_BIND_HOST` / `--container-bind-host` (default `127.0.0.1`).
 
 A boot-time preflight (`container-connectivity-preflight.ts`) starts a throwaway container,
-probes the MCP port and a bind-host listener in the egress range (20000–29999), and also
-resolves the bridge gateway IP the container sees for `host.docker.internal`. **Auto-rebind:**
+probes the MCP port and a bind-host listener in the egress range (20000–29999), and resolves
+the bridge gateway IP both host-side (`DockerClient.inspectNetwork('bridge')` → `IPAM.Config[]
+.Gateway`, no container needed) and in-container (for images that expose it). **Auto-rebind:**
 when the bind is loopback-only and a container can't reach it (`bind-loopback`), the proxy +
 SSH bridge are rebound to that detected gateway IP and re-probed — so native-Linux works out
 of the box without exposing them on all interfaces (the gateway IP is host-local, container-
 reachable; binding `0.0.0.0` would expose the proxy and the SSH key bridge on every
-interface). An explicit non-loopback `--container-bind-host` is never overridden. The preflight
+interface). An explicit non-loopback `--container-bind-host` is never overridden. The
+exploratory loopback probe runs **once** (it's deterministic — loopback is reachable on Docker
+Desktop, structurally not on native-Linux) with a short curl timeout, so the whole check is a
+couple of container round-trips (~10s), not a retry loop. The preflight
 logs the exact firewall / `--container-bind-host` remedy when a path is still blocked; severity
 tracks impact: `error` when the MCP server is unreachable (no tools load, runs hang), a
 non-fatal `warn` for a residual egress/SSH bind-host degradation. It never gates startup, so

--- a/packages/server/src/services/ceo-session-manager.ts
+++ b/packages/server/src/services/ceo-session-manager.ts
@@ -141,6 +141,11 @@ export class CeoSessionManager {
 	private current: CurrentTurn | null = null;
 	private ensuring: Promise<LiveSession> | null = null;
 	private healthTimer: ReturnType<typeof setInterval> | null = null;
+	// Serializes `sendTurn` so concurrent sends (e.g. an impatient double-click while
+	// the boot egress check is still warming up) can't each clear the gate together
+	// and spawn their own session/turn. With sends serialized, the interrupt guard in
+	// `sendTurn` correctly aborts the prior turn and only the latest one streams.
+	private turnLock: Promise<unknown> = Promise.resolve();
 
 	constructor(private readonly deps: CeoSessionDeps) {}
 
@@ -170,6 +175,19 @@ export class CeoSessionManager {
 			 WHERE status IN ($2, $3)`,
 			[CeoSessionStatus.Crashed, CeoSessionStatus.Starting, CeoSessionStatus.Running],
 		);
+		// No CEO turn survives a process restart, so any message left in a non-terminal
+		// state (streaming/pending) is orphaned — its run is gone. Empty ones are pure
+		// "thinking" placeholders with nothing to show: delete them so they don't reload
+		// as perpetual dots. Non-empty ones kept a partial reply: mark them interrupted.
+		await this.deps.db.query(`DELETE FROM ceo_messages WHERE status IN ($1, $2) AND content = ''`, [
+			CeoMessageStatus.Streaming,
+			CeoMessageStatus.Pending,
+		]);
+		await this.deps.db.query(`UPDATE ceo_messages SET status = $1 WHERE status IN ($2, $3)`, [
+			CeoMessageStatus.Interrupted,
+			CeoMessageStatus.Streaming,
+			CeoMessageStatus.Pending,
+		]);
 	}
 
 	/**
@@ -178,6 +196,22 @@ export class CeoSessionManager {
 	 * Returns the two message ids so the client can correlate streamed deltas.
 	 */
 	async sendTurn(input: {
+		text: string;
+		channel?: CeoChannel;
+		authorUserId?: string | null;
+	}): Promise<{ userMessageId: string; assistantMessageId: string }> {
+		// Serialize turns: chain on the prior send so two overlapping requests run the
+		// body sequentially (the second only after the first has set `this.current`),
+		// letting the interrupt guard below abort the prior turn instead of racing it.
+		const run = this.turnLock.then(
+			() => this.runSendTurn(input),
+			() => this.runSendTurn(input),
+		);
+		this.turnLock = run.catch(() => undefined);
+		return run;
+	}
+
+	private async runSendTurn(input: {
 		text: string;
 		channel?: CeoChannel;
 		authorUserId?: string | null;

--- a/packages/server/src/services/container-connectivity-preflight.ts
+++ b/packages/server/src/services/container-connectivity-preflight.ts
@@ -196,7 +196,7 @@ export function formatContainerConnectivityMessage(
  */
 export function buildProbeScript(serverPort: number, bindPort: number): string {
 	const probe = (name: string, url: string) =>
-		`${name}=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 ${url} 2>/dev/null) || true; ` +
+		`${name}=$(curl -s -o /dev/null -w '%{http_code}' --max-time 2 ${url} 2>/dev/null) || true; ` +
 		`[ -z "$${name}" ] && ${name}=DOWN`;
 	return (
 		`${probe('mcp', `http://host.docker.internal:${serverPort}/mcp`)}; ` +
@@ -402,6 +402,21 @@ export async function checkContainerToHostConnectivity(
 	}
 }
 
+/**
+ * The docker bridge gateway IP host-side (`IPAM.Config[].Gateway`, e.g.
+ * `172.17.0.1`) — the IP a container reaches the host through on the default
+ * bridge, and the auto-rebind target. Read directly from the Docker API so it
+ * doesn't depend on in-container tooling. Returns null if it can't be determined.
+ */
+async function resolveBridgeGateway(docker: DockerClient): Promise<string | null> {
+	try {
+		const net = await docker.inspectNetwork('bridge');
+		return net?.IPAM?.Config?.find((c) => c.Gateway)?.Gateway ?? null;
+	} catch {
+		return null;
+	}
+}
+
 export interface AutoRebindDeps {
 	docker: DockerClient;
 	serverPort: number;
@@ -428,20 +443,32 @@ export async function checkAndAutoRebindConnectivity(
 	deps: AutoRebindDeps,
 ): Promise<{ outcome: ConnectivityOutcome | 'skipped'; bindHost: string }> {
 	const check = deps.check ?? checkContainerToHostConnectivity;
-	const probe = (containerBindHost: string) =>
+	const probe = (containerBindHost: string, attempts?: number) =>
 		check({
 			docker: deps.docker,
 			serverPort: deps.serverPort,
 			containerBindHost,
 			logOutcome: false,
+			attempts,
 		});
 
-	const first = await probe(deps.bindHost.get());
+	// The exploratory loopback probe is deterministic — loopback is either reachable
+	// (Docker Desktop → ok) or structurally unreachable from a bridge container
+	// (native Linux → bind-loopback). Retrying it just wastes ~3 container boots and
+	// 5s curl timeouts, so probe ONCE here; the gateway re-probe below keeps retries.
+	const first = await probe(deps.bindHost.get(), 1);
 	let outcome = first.outcome;
 	let bindHost = deps.bindHost.get();
 
+	// Resolve the bridge gateway host-side too (a single Docker API call, no
+	// container) and use it when the in-container probe couldn't — so auto-rebind
+	// still works on agent images that lack `getent`/`awk`.
+	const hostGateway = await resolveBridgeGateway(deps.docker);
 	const logResult = deps.logResult !== false;
-	const rebindTo = resolveAutoRebindTarget(first, bindHost);
+	const rebindTo = resolveAutoRebindTarget(
+		{ outcome: first.outcome, gatewayIp: first.gatewayIp ?? hostGateway ?? undefined },
+		bindHost,
+	);
 	if (rebindTo) {
 		if (logResult) {
 			log.info(

--- a/packages/server/src/services/docker.ts
+++ b/packages/server/src/services/docker.ts
@@ -83,6 +83,12 @@ export interface ImageInfo {
 	};
 }
 
+export interface NetworkInfo {
+	IPAM: {
+		Config: Array<{ Gateway?: string; Subnet?: string }> | null;
+	} | null;
+}
+
 async function parseJsonOrThrow<T>(res: Response, op: string): Promise<T> {
 	const text = await res.text();
 	if (text.trim() === '') {
@@ -160,6 +166,24 @@ export class DockerClient {
 			throw new Error(`Docker inspectImage failed (${res.status}): ${text}`);
 		}
 		return parseJsonOrThrow(res, 'inspectImage');
+	}
+
+	/**
+	 * Read a Docker network's config — used to resolve the bridge gateway IP host-side
+	 * (`IPAM.Config[].Gateway`, e.g. `172.17.0.1`) for the connectivity preflight,
+	 * avoiding a throwaway container just to detect it. Returns null on 404.
+	 */
+	async inspectNetwork(name: string): Promise<NetworkInfo | null> {
+		const res = await this.request('GET', `/networks/${encodeURIComponent(name)}`);
+		if (res.status === 404) {
+			await res.text();
+			return null;
+		}
+		if (!res.ok) {
+			const text = await res.text();
+			throw new Error(`Docker inspectNetwork failed (${res.status}): ${text}`);
+		}
+		return parseJsonOrThrow(res, 'inspectNetwork');
 	}
 
 	async removeImage(image: string, force = false): Promise<void> {

--- a/packages/server/src/services/fake-docker.ts
+++ b/packages/server/src/services/fake-docker.ts
@@ -65,6 +65,7 @@ export function createFakeDockerClient(db?: PGlite): DockerClient {
 		removeContainer: async (id: string) => {
 			containers.delete(id);
 		},
+		inspectNetwork: async () => ({ IPAM: { Config: [{ Gateway: '172.17.0.1' }] } }),
 		inspectContainer: async (id: string) => {
 			const c = containers.get(id);
 			const running = c?.running ?? true;

--- a/packages/server/test/ceo-session.test.ts
+++ b/packages/server/test/ceo-session.test.ts
@@ -363,6 +363,73 @@ describe('CeoSessionManager', () => {
 		const r = await ctx.db.query<{ status: string }>('SELECT status FROM ceo_sessions LIMIT 1');
 		expect(r.rows[0].status).toBe(CeoSessionStatus.Crashed);
 	});
+
+	test('reconcileOnStartup clears orphaned streaming messages (deletes empty, interrupts partial)', async () => {
+		const { manager } = makeManager(ctx, makeChatDocker(ctx.dataDir, projectId).docker);
+		const conversationId = await manager.getConversationId();
+		const insert = async (status: string, content: string, role = 'assistant') => {
+			const r = await ctx.db.query<{ id: string }>(
+				`INSERT INTO ceo_messages (conversation_id, role, channel, status, content)
+				 VALUES ($1, $2::ceo_message_role, 'web'::ceo_channel, $3::ceo_message_status, $4)
+				 RETURNING id`,
+				[conversationId, role, status, content],
+			);
+			return r.rows[0].id;
+		};
+		const emptyStreaming = await insert('streaming', '');
+		const partialStreaming = await insert('streaming', 'half a thought');
+		const emptyPending = await insert('pending', '');
+		const done = await insert('complete', 'all good');
+		const userMsg = await insert('complete', 'hello', 'user');
+
+		await manager.reconcileOnStartup();
+
+		const rows = await ctx.db.query<{ id: string; status: string }>(
+			'SELECT id, status FROM ceo_messages',
+		);
+		const byId = new Map(rows.rows.map((r) => [r.id, r.status]));
+		// Empty orphaned placeholders (the stuck "thinking" dots) are deleted.
+		expect(byId.has(emptyStreaming)).toBe(false);
+		expect(byId.has(emptyPending)).toBe(false);
+		// A partial reply is preserved, marked interrupted; terminal rows untouched.
+		expect(byId.get(partialStreaming)).toBe(CeoMessageStatus.Interrupted);
+		expect(byId.get(done)).toBe(CeoMessageStatus.Complete);
+		expect(byId.get(userMsg)).toBe(CeoMessageStatus.Complete);
+	});
+
+	test('serializes concurrent sends — no overlapping turns or orphaned streaming rows', async () => {
+		const { manager } = makeManager(ctx, makeChatDocker(ctx.dataDir, projectId).docker);
+
+		// Two sends fired together (the impatient double-send during a slow gate).
+		const [a, b] = await Promise.all([
+			manager.sendTurn({ text: 'first' }),
+			manager.sendTurn({ text: 'second' }),
+		]);
+		expect(a.assistantMessageId).not.toBe(b.assistantMessageId);
+
+		// Every turn finalizes to a terminal state — none left streaming (the earlier is
+		// interrupted by the later, which the mutex makes deterministic).
+		await poll(async () => {
+			const r = await ctx.db.query<{ n: number }>(
+				`SELECT COUNT(*)::int AS n FROM ceo_messages WHERE role = 'assistant' AND status = $1`,
+				[CeoMessageStatus.Streaming],
+			);
+			return r.rows[0].n === 0;
+		});
+
+		// Exactly one assistant row per send (not duplicated) and a single live session.
+		const assistants = await ctx.db.query<{ n: number }>(
+			`SELECT COUNT(*)::int AS n FROM ceo_messages WHERE role = 'assistant'`,
+		);
+		expect(assistants.rows[0].n).toBe(2);
+		const sessions = await ctx.db.query<{ n: number }>(
+			`SELECT COUNT(*)::int AS n FROM ceo_sessions WHERE status IN ($1, $2)`,
+			[CeoSessionStatus.Starting, CeoSessionStatus.Running],
+		);
+		expect(sessions.rows[0].n).toBe(1);
+
+		await manager.stop();
+	});
 });
 
 describe('CEO session auth', () => {

--- a/packages/server/test/container-connectivity-preflight.test.ts
+++ b/packages/server/test/container-connectivity-preflight.test.ts
@@ -2,6 +2,7 @@ import { Logger } from '@hiddentao/logger';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
 	buildProbeScript,
+	type ConnectivityCheckDeps,
 	type ConnectivityCheckResult,
 	type ConnectivityProbeResult,
 	checkAndAutoRebindConnectivity,
@@ -355,7 +356,13 @@ describe('logConnectivityOutcome', () => {
 });
 
 describe('checkAndAutoRebindConnectivity', () => {
+	// Default stub resolves the bridge gateway host-side (172.17.0.1).
 	const docker = createStubDocker({ imageExists: async () => true });
+	// A host with no resolvable bridge gateway (host-side inspect returns null).
+	const noGwDocker = createStubDocker({
+		imageExists: async () => true,
+		inspectNetwork: async () => null,
+	});
 	let errorSpy: ReturnType<typeof vi.spyOn>;
 	let warnSpy: ReturnType<typeof vi.spyOn>;
 	let infoSpy: ReturnType<typeof vi.spyOn>;
@@ -403,7 +410,7 @@ describe('checkAndAutoRebindConnectivity', () => {
 			.mockResolvedValue({ outcome: 'bind-loopback' });
 
 		const result = await checkAndAutoRebindConnectivity({
-			docker,
+			docker: noGwDocker,
 			serverPort: 3100,
 			bindHost: ref,
 			check,
@@ -423,7 +430,7 @@ describe('checkAndAutoRebindConnectivity', () => {
 			.mockResolvedValue({ outcome: 'bind-loopback' });
 
 		const result = await checkAndAutoRebindConnectivity({
-			docker,
+			docker: noGwDocker,
 			serverPort: 3100,
 			bindHost: ref,
 			check,
@@ -433,6 +440,47 @@ describe('checkAndAutoRebindConnectivity', () => {
 		expect(ref.get()).toBe('127.0.0.1');
 		expect(check).toHaveBeenCalledTimes(1);
 		expect(warnSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it('uses the host-side bridge gateway to rebind when the in-container probe found none', async () => {
+		const ref = bindRef('127.0.0.1');
+		// In-container probe never resolves a gatewayIp (e.g. image lacks getent/awk);
+		// the host-side inspectNetwork (172.17.0.1 from the stub) supplies the target.
+		const check = vi
+			.fn<() => Promise<ConnectivityCheckResult>>()
+			.mockResolvedValueOnce({ outcome: 'bind-loopback' })
+			.mockResolvedValueOnce({ outcome: 'ok' });
+
+		const result = await checkAndAutoRebindConnectivity({
+			docker,
+			serverPort: 3100,
+			bindHost: ref,
+			check,
+		});
+
+		expect(result).toEqual({ outcome: 'ok', bindHost: '172.17.0.1' });
+		expect(ref.get()).toBe('172.17.0.1');
+		expect(check).toHaveBeenCalledTimes(2);
+	});
+
+	it('probes the exploratory loopback bind only once (no retry loop)', async () => {
+		const ref = bindRef('127.0.0.1');
+		const calls: Array<number | undefined> = [];
+		const check = vi.fn<(d: ConnectivityCheckDeps) => Promise<ConnectivityCheckResult>>(
+			async (d) => {
+				calls.push(d.attempts);
+				return { outcome: 'ok' };
+			},
+		);
+
+		await checkAndAutoRebindConnectivity({
+			docker: noGwDocker,
+			serverPort: 3100,
+			bindHost: ref,
+			check,
+		});
+
+		expect(calls[0]).toBe(1); // loopback probe forced to a single attempt
 	});
 
 	it('does not rebind an explicit non-loopback bind, warns once on firewalled', async () => {

--- a/packages/server/test/helpers/app.ts
+++ b/packages/server/test/helpers/app.ts
@@ -48,6 +48,7 @@ const STUB_DOCKER_METHODS = {
 		Config: { Image: 'stub' },
 	}),
 	findContainerByNamePrefix: async () => null,
+	inspectNetwork: async () => ({ IPAM: { Config: [{ Gateway: '172.17.0.1' }] } }),
 	containerStats: async () => null,
 	containerLogs: async () => ({ arrayBuffer: async () => new ArrayBuffer(0) }),
 	execCreate: async () => {

--- a/packages/web/src/components/ceo-chat/ceo-chat-widget.tsx
+++ b/packages/web/src/components/ceo-chat/ceo-chat-widget.tsx
@@ -35,7 +35,7 @@ function fitTextareaToContent(el: HTMLTextAreaElement): void {
 export function CeoChatWidget() {
 	const [open, setOpen] = useState(false);
 	const [expanded, setExpanded] = useState(false);
-	const { messages, send, streaming, loaded, unread } = useCeoChat(open);
+	const { messages, send, streaming, sending, loaded, unread } = useCeoChat(open);
 	const hq = useHqProject();
 	const hqHealth = useContainerHealth(hq);
 	// The CEO can only act while the HQ container is up. When it isn't, the chat
@@ -109,7 +109,10 @@ export function CeoChatWidget() {
 
 	const submit = () => {
 		const text = draft.trim();
-		if (!text) return;
+		// Block while a send is in flight or a reply is streaming — prevents the
+		// impatient double-click (seeing the optimistic bubble "stuck" during the
+		// egress check) that used to spawn duplicate CEO turns.
+		if (!text || sending || streaming) return;
 		setDraft('');
 		send(text).catch(() => undefined);
 	};
@@ -280,7 +283,7 @@ export function CeoChatWidget() {
 								<button
 									type="button"
 									onClick={submit}
-									disabled={!draft.trim()}
+									disabled={!draft.trim() || sending || streaming}
 									aria-label="Send message"
 									data-testid="ceo-chat-send"
 									className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-accent-solid text-accent-solid-fg transition-colors hover:bg-accent-hover disabled:opacity-40"

--- a/packages/web/src/hooks/use-ceo-chat.ts
+++ b/packages/web/src/hooks/use-ceo-chat.ts
@@ -70,6 +70,11 @@ export function useCeoChat(active: boolean) {
 	const { subscribe, joinRoom, leaveRoom } = useSocket();
 	const queryClient = useQueryClient();
 	const [unread, setUnread] = useState<number>(readStoredUnread);
+	// In-flight send: the user's text is shown optimistically (with a pending
+	// assistant placeholder) while the server warms the session / egress check, so
+	// the operator gets immediate feedback instead of a ~10s blank. Cleared when the
+	// real user message arrives over WS, or when the send settles (incl. failure).
+	const [pending, setPending] = useState<{ text: string; at: string } | null>(null);
 	// The socket handler is wired once; this ref lets it read the live open state
 	// (whether the chat is currently visible) without re-subscribing every toggle.
 	const activeRef = useRef(active);
@@ -109,6 +114,9 @@ export function useCeoChat(active: boolean) {
 		};
 		const offStart = subscribe(WsMessageType.CeoMessageStart, (raw) => {
 			const m = raw as WsCeoMessageStartMessage;
+			// The real user message landed — drop the optimistic placeholder so the
+			// server rows (user + streaming assistant) take over without duplicating.
+			if (m.role === 'user') setPending(null);
 			patch((messages) =>
 				messages.some((x) => x.id === m.messageId)
 					? messages
@@ -160,15 +168,52 @@ export function useCeoChat(active: boolean) {
 		onError: (error: { message?: string }) => {
 			toast.error(error?.message ?? 'Failed to send message to the CEO');
 		},
+		// Clear the optimistic placeholder once the request settles — on success the
+		// WS user-message event has already cleared it; on failure (e.g. egress gate
+		// reject, toasted above) this drops the unsent bubble.
+		onSettled: () => setPending(null),
 	});
 
-	const messages = query.data?.messages ?? [];
+	const serverMessages = query.data?.messages ?? [];
+	// Append the optimistic user bubble + a pending assistant "thinking" placeholder
+	// while a send is in flight (an assistant row with empty streaming content renders
+	// the existing typing indicator). They're dropped the moment the real rows arrive.
+	const messages: CeoMessage[] =
+		pending !== null
+			? [
+					...serverMessages,
+					{
+						id: 'optimistic-user',
+						role: 'user' as CeoMessageRole,
+						channel: 'web' as CeoChannel,
+						status: 'complete' as CeoMessageStatus,
+						content: pending.text,
+						created_at: pending.at,
+					},
+					{
+						id: 'optimistic-assistant',
+						role: 'assistant' as CeoMessageRole,
+						channel: 'web' as CeoChannel,
+						status: 'streaming' as CeoMessageStatus,
+						content: '',
+						created_at: pending.at,
+					},
+				]
+			: serverMessages;
 	const streaming = messages.some((m) => m.role === 'assistant' && m.status === 'streaming');
+
+	const send = (text: string) => {
+		const trimmed = text.trim();
+		if (!trimmed) return Promise.resolve();
+		setPending({ text: trimmed, at: new Date().toISOString() });
+		return sendMutation.mutateAsync(trimmed);
+	};
 
 	return {
 		messages,
-		send: (text: string) => sendMutation.mutateAsync(text.trim()),
+		send,
 		streaming,
+		sending: pending !== null,
 		loaded: !query.isPending,
 		unread,
 	};

--- a/packages/web/test/ceo-chat.test.tsx
+++ b/packages/web/test/ceo-chat.test.tsx
@@ -2,7 +2,7 @@ import type { CeoMessage } from '@hezo/web/hooks/use-ceo-chat';
 import { toast } from '@hezo/web/hooks/use-toast';
 import { queryClient } from '@hezo/web/lib/query-client';
 import { queryKeys } from '@hezo/web/lib/query-keys';
-import { waitFor } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 import { expect, test, vi } from 'vitest';
 import { renderApp } from './helpers/render';
 
@@ -51,6 +51,30 @@ test('composer enables send when text is entered and clears on submit', async ()
 	await user.click(send);
 	// The draft clears immediately on submit regardless of the server result.
 	expect(input.value).toBe('');
+});
+
+test('shows the user message optimistically and disables send while in flight', async () => {
+	const { findByTestId, getByTestId, getByText, queryByText, user } = await renderApp({
+		initialPath: '/home',
+	});
+	(await findByTestId('ceo-chat-launcher')).click();
+	const input = (await findByTestId('ceo-chat-input')) as HTMLTextAreaElement;
+	const sendBtn = getByTestId('ceo-chat-send') as HTMLButtonElement;
+
+	await user.type(input, 'i just enabled markdown assets');
+	// fireEvent (synchronous) so we can observe the optimistic state before the
+	// harness's 503 lands and clears it.
+	fireEvent.click(sendBtn);
+
+	// The user's message renders immediately (optimistic), before any WS round-trip…
+	expect(getByText('i just enabled markdown assets')).toBeTruthy();
+	// …a pending assistant "thinking" indicator shows…
+	expect(getByTestId('ceo-chat-typing')).toBeTruthy();
+	// …and the send button is disabled so an impatient re-click can't spawn duplicates.
+	expect(sendBtn.disabled).toBe(true);
+
+	// Once the (failed) send settles, the optimistic placeholder is dropped.
+	await waitFor(() => expect(queryByText('i just enabled markdown assets')).toBeNull());
 });
 
 test('surfaces a failed CEO send as an error toast', async () => {


### PR DESCRIPTION
## Why

Four issues surfaced when messaging the CEO **while the boot egress preflight is still running** (and from orphaned chat rows), seen on a production native-Linux Docker host:

1. **Egress preflight ~50s.** It booted **4 throwaway containers** — 3 doomed loopback retries (each a 5s curl timeout + 2s gap) then a gateway probe.
2. **No pending feedback.** The send blocked ~50s with nothing on screen.
3. **Duplicate CEOs.** Impatient double-clicks each cleared the gate and spawned their own turn (multiple `●●●` + multiple replies).
4. **Stuck "thinking" after restart.** Abandoned turns left `ceo_messages` rows `streaming` forever, reloaded as perpetual dots ("old chat state cached").

## What

**A — Fast preflight (~50s → ~10s).** New `DockerClient.inspectNetwork('bridge')` resolves the gateway IP **host-side** (no container); the deterministic loopback bind is probed **once** (no retry loop); curl timeout lowered to 2s. Host-side detection also makes auto-rebind robust on images lacking `getent`/`awk`.

**B — Serialize CEO turns.** `sendTurn` now runs under a `turnLock` chain, so concurrent sends can't each spawn a turn — a newer message interrupts the prior reply (kept `interrupted`) and only the latest streams.

**C — Reconcile orphaned messages on startup.** `reconcileOnStartup` now deletes empty `streaming`/`pending` placeholders and marks partial ones `interrupted`. Idempotent and runs on every boot — **existing stuck rows on production are cleared on the next restart**, no manual surgery.

**D — Pending UI + double-submit guard.** The web composer shows the user's message **optimistically** + a pending "thinking" indicator the moment you send (dropped when the real rows arrive or on failure), and the send button is **disabled while a send is in flight / streaming** — killing the double-click that triggered the duplicates.

### Key files
- `docker.ts` — `inspectNetwork`; `container-connectivity-preflight.ts` — host-side gateway + single-attempt loopback + 2s timeout
- `ceo-session-manager.ts` — `turnLock` serialization + orphaned-message reconcile
- `use-ceo-chat.ts` / `ceo-chat-widget.tsx` — optimistic message, pending indicator, disabled send
- `.dev/architecture.md` — preflight speed + CEO turn/reconcile notes

## Tests
- Preflight: host-side gateway fallback used when in-container probe finds none; loopback probed once (no retry); existing pure-helper tests green.
- CEO (server): `reconcileOnStartup` deletes empty / interrupts partial / leaves terminal rows; two concurrent sends → exactly one assistant per send, none left streaming, single session.
- Web: the user message renders optimistically with the send button disabled, and clears after the send settles.

Typecheck, lint, and the connectivity/ceo-session/agent-runner/startup + web ceo-chat suites are green; the pre-commit build passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015bYNE2AxYhEMz8jvQjCmSF

---
_Generated by [Claude Code](https://claude.ai/code/session_015bYNE2AxYhEMz8jvQjCmSF)_