### PR TITLE
feat(web): improve task detail mobile layout

### DIFF
--- a/packages/web/src/components/comment-renderers/run-comment.tsx
+++ b/packages/web/src/components/comment-renderers/run-comment.tsx
@@ -192,7 +192,7 @@ function RunCommentBody({
 			</Link>
 			{actorName && (
 				<span
-					className="inline-flex items-center text-xs text-text-3 shrink-0 whitespace-nowrap"
+					className="hidden sm:inline-flex items-center text-xs text-text-3 shrink-0 whitespace-nowrap"
 					data-testid="run-comment-actor"
 				>
 					<span aria-hidden="true">·</span>
@@ -209,8 +209,10 @@ function RunCommentBody({
 						className={`inline-block w-2 h-2 rounded-full ${runStatusDotClass(status)}`}
 					/>
 					<span>{runStatusLabel(status)}</span>
-					<span aria-hidden="true">·</span>
-					<span data-testid="run-comment-line-count">
+					<span aria-hidden="true" className="hidden sm:inline">
+						·
+					</span>
+					<span className="hidden sm:inline" data-testid="run-comment-line-count">
 						{lines.length} {lines.length === 1 ? 'line' : 'lines'}
 					</span>
 					{durationMs != null && (
@@ -221,8 +223,12 @@ function RunCommentBody({
 					)}
 					{run?.cost_cents != null && run.cost_cents > 0 && (
 						<>
-							<span aria-hidden="true">·</span>
-							<span data-testid="run-comment-cost">${(run.cost_cents / 100).toFixed(2)}</span>
+							<span aria-hidden="true" className="hidden sm:inline">
+								·
+							</span>
+							<span className="hidden sm:inline" data-testid="run-comment-cost">
+								${(run.cost_cents / 100).toFixed(2)}
+							</span>
 						</>
 					)}
 				</span>

--- a/packages/web/src/components/log-viewer.tsx
+++ b/packages/web/src/components/log-viewer.tsx
@@ -117,9 +117,9 @@ export function LogViewer({
 		<>
 			<div className="flex items-center justify-between bg-surface-2 px-3 py-1.5 border-b border-border-subtle">
 				<div className="flex items-center gap-2 text-xs text-text-2 font-medium">
-					<span>Logs</span>
+					<span className="hidden sm:inline">Logs</span>
 					{liveLabel}
-					<span className="text-text-3 font-normal">{lines.length} lines</span>
+					<span className="hidden sm:inline text-text-3 font-normal">{lines.length} lines</span>
 					{formattable && (
 						<div className="flex items-center gap-0.5">
 							<Tooltip content="Formatted view">

--- a/packages/web/src/components/task-detail/comment-composer.tsx
+++ b/packages/web/src/components/task-detail/comment-composer.tsx
@@ -85,7 +85,7 @@ export function CommentComposer({
 
 	return (
 		<form ref={commentFormRef} onSubmit={handleComment} className="flex gap-2.5 scroll-mt-20">
-			<div className="w-[26px] shrink-0" aria-hidden />
+			<div className="hidden md:block w-[26px] shrink-0" aria-hidden />
 			<div className="flex-1 min-w-0 flex flex-col gap-2">
 				<CommentAttachmentsDrop
 					projectId={projectId}

--- a/packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx
@@ -1,6 +1,6 @@
 import type { AgentEffort } from '@hezo/shared';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
-import { ArrowDown } from 'lucide-react';
+import { ArrowDown, ChevronLeft, ChevronRight } from 'lucide-react';
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { jumpToComment } from '../../../../components/comment-renderers';
 import { CommentComposer } from '../../../../components/task-detail/comment-composer';
@@ -63,6 +63,14 @@ function TaskDetailPage() {
 	// A doc/asset clicked in a comment opens in the right-rail preview panel
 	// (replacing the metadata sidebar until closed).
 	const [preview, setPreview] = useState<PreviewItem | null>(null);
+	// On mobile the right rail is a collapsed-by-default drawer. Opening a preview
+	// (a doc/asset clicked in a comment) must also open the drawer, otherwise the
+	// preview would render off-screen behind the collapsed rail.
+	const [sidebarOpen, setSidebarOpen] = useState(false);
+	const openPreview = (item: PreviewItem | null) => {
+		setPreview(item);
+		if (item) setSidebarOpen(true);
+	};
 	const commentFormRef = useRef<HTMLFormElement>(null);
 	const commentTextareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -97,7 +105,7 @@ function TaskDetailPage() {
 			<div
 				className={`grid grid-cols-1 gap-5 ${preview ? 'lg:grid-cols-[1fr_360px]' : 'lg:grid-cols-[1fr_190px]'}`}
 			>
-				<PreviewProvider value={setPreview}>
+				<PreviewProvider value={openPreview}>
 					<div className="min-w-0">
 						<LastRunFailedBanner task={task} />
 						<TaskHeader
@@ -157,21 +165,51 @@ function TaskDetailPage() {
 					</div>
 				</PreviewProvider>
 
-				{preview ? (
-					<PreviewPanel item={preview} onClose={() => setPreview(null)} />
-				) : (
-					<TaskSidebar
-						task={task}
-						projectId={projectId}
-						agents={agents}
-						lock={lock}
-						comments={comments}
-						updateTask={updateTask}
-						commentEffort={commentEffort}
-						setCommentEffort={setCommentEffort}
-						scrollToBottom={scrollToBottom}
+				{/* Right rail: an in-grid sticky column at lg+, a slide-in floating
+				    drawer below lg (collapsed by default, toggled by the chevron). */}
+				<button
+					type="button"
+					onClick={() => setSidebarOpen((o) => !o)}
+					data-testid="task-sidebar-toggle"
+					aria-label={sidebarOpen ? 'Collapse task details' : 'Expand task details'}
+					aria-expanded={sidebarOpen}
+					className="lg:hidden fixed right-0 top-1/2 -translate-y-1/2 z-50 h-12 w-7 rounded-l-md border border-r-0 border-border bg-surface text-text-2 hover:text-text-1 shadow-md flex items-center justify-center"
+				>
+					{sidebarOpen ? <ChevronRight className="w-4 h-4" /> : <ChevronLeft className="w-4 h-4" />}
+				</button>
+				{sidebarOpen && (
+					<button
+						type="button"
+						aria-label="Close task details"
+						onClick={() => setSidebarOpen(false)}
+						className="lg:hidden fixed inset-0 z-40 bg-[var(--overlay)] cursor-default"
 					/>
 				)}
+				{/* Mobile: a fixed right-side drawer. Desktop: `lg:contents` makes this
+				    wrapper generate no box, so TaskSidebar/PreviewPanel become the direct
+				    grid child again — preserving the in-grid sticky column unchanged. */}
+				<div
+					data-testid="task-rail"
+					className={`fixed top-0 right-0 z-40 h-full w-[280px] max-w-[85vw] overflow-y-auto bg-surface p-4 shadow-xl transition-transform duration-200 ${
+						sidebarOpen ? 'translate-x-0' : 'translate-x-full'
+					} lg:contents`}
+				>
+					{preview ? (
+						<PreviewPanel item={preview} onClose={() => setPreview(null)} />
+					) : (
+						<TaskSidebar
+							task={task}
+							projectId={projectId}
+							agents={agents}
+							lock={lock}
+							comments={comments}
+							updateTask={updateTask}
+							commentEffort={commentEffort}
+							setCommentEffort={setCommentEffort}
+							scrollToBottom={scrollToBottom}
+						/>
+					)}
+				</div>
 			</div>
 
 			{/* Sits above the persistent CEO chat launcher (fixed bottom-right) so

--- a/test/browser/task-detail.mobile.spec.ts
+++ b/test/browser/task-detail.mobile.spec.ts
@@ -1,0 +1,219 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from './fixtures';
+import { createProjectAndClearPlanning, waitForPageLoad } from './helpers';
+
+// The `mobile` Playwright project runs every *.mobile.spec.ts at a 390px
+// viewport (see playwright.config.ts), so these assertions exercise the
+// `<lg`/`<sm` responsive branches a desktop run never hits and happy-dom can't
+// lay out (#1/#2 in the test-tier decision tree).
+
+type CreatedProject = { id: string; slug: string; team_id: string };
+
+async function createProjectAndTask(page: Page, token: string, name: string) {
+	const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+	const projectRes = await createProjectAndClearPlanning(page, '', token, {
+		name,
+		description: 'Mobile layout test.',
+	});
+	const project = ((await projectRes.json()) as { data: CreatedProject }).data;
+
+	const agentsRes = await page.request.get(`/api/projects/${project.slug}/agents`, { headers });
+	const agents = ((await agentsRes.json()) as { data: Array<{ id: string; slug: string }> }).data;
+	const captain = agents.find((a) => a.slug === 'captain') ?? agents[0];
+
+	const taskRes = await page.request.post(`/api/projects/${project.slug}/tasks`, {
+		headers,
+		data: {
+			project_id: project.id,
+			title: 'Mobile Task',
+			description: 'Mobile description',
+			assignee_id: captain.id,
+		},
+	});
+	const task = ((await taskRes.json()) as { data: { id: string; identifier: string } }).data;
+	return { project, task, captainId: captain.id };
+}
+
+test.describe('Task detail — mobile layout (390px)', () => {
+	test('comment input spans the full container width (avatar spacer hidden)', async ({
+		page,
+		freshWorkspace,
+	}) => {
+		const { token } = freshWorkspace;
+		const { project, task } = await createProjectAndTask(page, token, 'Mobile Composer');
+
+		await page.goto(`/projects/${project.slug}/tasks/${task.identifier.toLowerCase()}`);
+		await waitForPageLoad(page);
+
+		const heading = page.getByRole('heading', { name: 'Mobile Task' });
+		await expect(heading).toBeVisible({ timeout: 20000 });
+		const composer = page.getByPlaceholder('Add a comment...');
+		await expect(composer).toBeVisible();
+
+		// With the 26px avatar spacer hidden on mobile, the textarea is flush with
+		// the content column's left edge (same x as the task heading). With the
+		// spacer it would sit ~36px (26px + gap) to the right.
+		const headingBox = await heading.boundingBox();
+		const composerBox = await composer.boundingBox();
+		expect(headingBox).not.toBeNull();
+		expect(composerBox).not.toBeNull();
+		expect(Math.abs(composerBox!.x - headingBox!.x)).toBeLessThan(8);
+	});
+
+	test('right sidebar is a collapsed floating drawer the chevron opens', async ({
+		page,
+		freshWorkspace,
+	}) => {
+		const { token } = freshWorkspace;
+		const { project, task } = await createProjectAndTask(page, token, 'Mobile Sidebar');
+
+		await page.goto(`/projects/${project.slug}/tasks/${task.identifier.toLowerCase()}`);
+		await waitForPageLoad(page);
+
+		await expect(page.getByRole('heading', { name: 'Mobile Task' })).toBeVisible({
+			timeout: 20000,
+		});
+
+		const toggle = page.getByTestId('task-sidebar-toggle');
+		await expect(toggle).toBeVisible();
+		await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+		// Collapsed by default: the drawer is translated off the right edge, so its
+		// left edge sits at (or beyond) the 390px viewport width.
+		const rail = page.getByTestId('task-rail');
+		const closedBox = await rail.boundingBox();
+		expect(closedBox).not.toBeNull();
+		expect(closedBox!.x).toBeGreaterThanOrEqual(360);
+
+		// Tapping the chevron slides the drawer into view.
+		await toggle.click();
+		await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+		await expect
+			.poll(async () => (await rail.boundingBox())?.x ?? 999, { timeout: 5000 })
+			.toBeLessThan(200);
+		await expect(page.getByTestId('task-sidebar')).toBeInViewport();
+	});
+});
+
+// Render a completed run comment cheaply by mocking the comments + heartbeat-run
+// responses — no real agent runtime needed (cribbed from agent-run-logs.spec.ts).
+async function mockRunComment(page: Page, token: string) {
+	const { project, task, captainId } = await createProjectAndTask(page, token, 'Mobile Run Meta');
+
+	const runId = '99999999-9999-9999-9999-999999999999';
+	const startedAt = '2026-05-15T18:11:00Z';
+	const finishedAt = '2026-05-15T18:12:17Z';
+	const logText = Array.from({ length: 27 }, (_, i) => `[synthetic] line ${i + 1}`).join('\n');
+
+	const runComment = {
+		id: 'dddd0000-0000-0000-0000-000000000001',
+		task_id: task.id,
+		content_type: 'run',
+		content: {
+			run_id: runId,
+			agent_id: captainId,
+			agent_title: 'Product Lead',
+			actor_name: 'Admin',
+		},
+		chosen_option: null,
+		created_at: startedAt,
+		author_type: 'agent',
+		author_name: 'Product Lead',
+		author_member_id: captainId,
+	};
+
+	await page.route('**/api/projects/*/tasks/*/comments**', async (route) => {
+		if (route.request().method() !== 'GET') return route.continue();
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({ data: [runComment] }),
+		});
+	});
+
+	await page.route(
+		`**/api/projects/*/agents/${captainId}/heartbeat-runs/${runId}`,
+		async (route) => {
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify({
+					data: {
+						id: runId,
+						member_id: captainId,
+						team_id: project.team_id,
+						task_id: task.id,
+						task_identifier: null,
+						task_title: null,
+						project_id: project.id,
+						status: 'succeeded',
+						started_at: startedAt,
+						finished_at: finishedAt,
+						exit_code: 0,
+						error: null,
+						input_tokens: 0,
+						output_tokens: 0,
+						cost_cents: 215,
+						invocation_command: null,
+						log_text: logText,
+						working_dir: null,
+						created_tasks: [],
+					},
+				}),
+			});
+		},
+	);
+
+	return { project, task };
+}
+
+test.describe('Agent-run meta — mobile (390px)', () => {
+	test('post-run summary hides line count, cost, and actor; keeps status + duration', async ({
+		page,
+		freshWorkspace,
+	}) => {
+		const { token } = freshWorkspace;
+		const { project, task } = await mockRunComment(page, token);
+
+		await page.goto(`/projects/${project.slug}/tasks/${task.id}`);
+
+		const runCommentEl = page.getByTestId('run-comment').first();
+		await expect(runCommentEl).toBeVisible({ timeout: 20_000 });
+
+		const summary = runCommentEl.getByTestId('run-comment-summary');
+		await expect(summary).toBeVisible({ timeout: 20_000 });
+		await expect(summary).toContainText('succeeded');
+		await expect(summary.getByTestId('run-comment-duration')).toBeVisible();
+
+		// Freed up on mobile.
+		await expect(summary.getByTestId('run-comment-line-count')).toBeHidden();
+		await expect(summary.getByTestId('run-comment-cost')).toBeHidden();
+		await expect(runCommentEl.getByTestId('run-comment-actor')).toBeHidden();
+	});
+
+	test('expanded log top bar hides the "Logs" label and line count', async ({
+		page,
+		freshWorkspace,
+	}) => {
+		const { token } = freshWorkspace;
+		const { project, task } = await mockRunComment(page, token);
+
+		await page.goto(`/projects/${project.slug}/tasks/${task.id}`);
+
+		const runCommentEl = page.getByTestId('run-comment').first();
+		await expect(runCommentEl).toBeVisible({ timeout: 20_000 });
+
+		await runCommentEl.getByTestId('run-comment-header').click();
+		const log = runCommentEl.getByTestId('run-comment-log');
+		await expect(log).toBeVisible();
+
+		// Scope to the log region so we read the toolbar's own label/count, not the
+		// (also-hidden) summary line count that lives in the header above it.
+		const logRegion = runCommentEl.locator('[id^="run-comment-log-"]');
+		// The agent status label still anchors the toolbar; the redundant "Logs"
+		// word and line count are hidden on mobile.
+		await expect(logRegion.getByText(/Product Lead.*succeeded/)).toBeVisible();
+		await expect(logRegion.getByText('Logs', { exact: true })).toBeHidden();
+		await expect(logRegion.getByText('27 lines', { exact: true })).toBeHidden();
+	});
+});

--- a/test/browser/task-detail.spec.ts
+++ b/test/browser/task-detail.spec.ts
@@ -71,6 +71,10 @@ test.describe('Task detail — right sidebar sticky positioning', () => {
 		const sidebar = page.getByTestId('task-sidebar');
 		await expect(sidebar).toBeVisible({ timeout: 20000 });
 
+		// On desktop the rail is an in-grid sticky column — the mobile floating
+		// toggle (`lg:hidden`) must not be present.
+		await expect(page.getByTestId('task-sidebar-toggle')).toBeHidden();
+
 		const position = await sidebar.evaluate((el) => getComputedStyle(el).position);
 		expect(position).toBe('sticky');
 


### PR DESCRIPTION
## Summary

On narrow screens the task detail page wasted horizontal space and buried the metadata sidebar. This makes four **mobile-only** changes — desktop (`lg`+) layout is unchanged everywhere.

1. **Full-width comment input** — the 26px avatar spacer is hidden below `md`, so the textarea spans the full container width on mobile.
2. **Floating right sidebar** — the right rail (priority / assignee / project / created / effort / close) no longer stacks below the content on `<lg`. It's now a slide-in drawer from the right edge, **collapsed by default**, opened by a floating **chevron** pinned mid-right. `lg:contents` on the wrapper means the rail becomes the direct grid child again at `lg`+, preserving the in-grid sticky column exactly as before.
3. **Agent-run log top bar** — hides the redundant "Logs" label and line count below `sm`, so the agent status label (e.g. "Captain — running") stops wrapping.
4. **Post-run summary meta** — hides line count, the "started by" actor chip, and cost below `sm` so the row no longer overflows; status, duration, and timestamp remain.

The fields hidden on the agent-run surfaces (line count / "Logs" / actor / cost) were chosen in consultation with the requester.

## Screenshots context

Addresses the cramped mobile comment box + below-the-fold sidebar, and the overflowing agent-run top bar / post-run meta lines.

## Tests

New `test/browser/task-detail.mobile.spec.ts` (runs at 390px in the `mobile` Playwright project) covers all four behaviours: full-width composer, collapsed-drawer + chevron toggle, post-run meta field hiding, and log-toolbar field hiding. A desktop assertion was added to the existing sticky-sidebar spec to confirm the floating toggle is absent and the in-grid sticky column is preserved. All five ran green locally; the existing happy-dom run-comment component tests stay green (they assert DOM presence, not CSS visibility).

Frontend-only, visual changes — no API / CLI / data-model / docs impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZRRCDDEEbxw9SqimmMPF5

---
_Generated by [Claude Code](https://claude.ai/code/session_015ZRRCDDEEbxw9SqimmMPF5)_