### PR TITLE
feat(web): refine task filter bar and add floating/sidebar new-task buttons

### DIFF
--- a/packages/web/src/components/ceo-chat/ceo-chat-widget.tsx
+++ b/packages/web/src/components/ceo-chat/ceo-chat-widget.tsx
@@ -32,8 +32,15 @@ function fitTextareaToContent(el: HTMLTextAreaElement): void {
  * starts a fresh turn. The CEO is the instance-level singleton living in the HQ
  * team, so every reply is labelled `CEO · HQ`.
  */
-export function CeoChatWidget() {
-	const [open, setOpen] = useState(false);
+interface CeoChatWidgetProps {
+	/** Open state is lifted to the shell so sibling surfaces (the floating
+	 *  new-task button) can react to the chat being open. */
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}
+
+export function CeoChatWidget({ open, onOpenChange }: CeoChatWidgetProps) {
+	const setOpen = onOpenChange;
 	const [expanded, setExpanded] = useState(false);
 	const { messages, send, streaming, sending, loaded, unread } = useCeoChat(open);
 	const hq = useHqProject();
@@ -68,7 +75,7 @@ export function CeoChatWidget() {
 		};
 		window.addEventListener('keydown', onKey);
 		return () => window.removeEventListener('keydown', onKey);
-	}, [open]);
+	}, [open, setOpen]);
 
 	// Grow the composer with its content (capped by `max-h-32`, then it scrolls),
 	// and collapse it back to a single row when the draft is cleared on submit.

--- a/packages/web/src/components/floating-new-task-button.tsx
+++ b/packages/web/src/components/floating-new-task-button.tsx
@@ -1,0 +1,52 @@
+import { Plus } from 'lucide-react';
+import { useState } from 'react';
+import { useActiveProject } from '../hooks/use-active-project';
+import { CreateTaskDialog } from './create-task-dialog';
+import { Tooltip } from './ui/tooltip';
+
+interface FloatingNewTaskButtonProps {
+	/**
+	 * Hide the button while another full-screen surface owns the corner — the
+	 * mobile nav drawer (which contains both the project rail and the project
+	 * menu) or the open CEO chat. The dialog stays mounted so an in-flight create
+	 * can still close itself.
+	 */
+	hidden: boolean;
+}
+
+/**
+ * A round "+" button that creates a task in the active project. It mirrors the
+ * CEO chat launcher's floating treatment but uses the accent fill (vs. the
+ * chat's inverse fill) so the two are never confused, and it's pinned to the
+ * opposite (bottom-left) corner.
+ *
+ * Scope: mobile/tablet only (`lg:hidden`). On desktop the persistent project
+ * menu is always visible and carries its own "+" next to the Tasks link, so a
+ * floating duplicate there would be redundant. It only renders on project-scoped
+ * routes (where there's a project to create the task in).
+ */
+export function FloatingNewTaskButton({ hidden }: FloatingNewTaskButtonProps) {
+	const active = useActiveProject();
+	const [open, setOpen] = useState(false);
+
+	if (!active) return null;
+
+	return (
+		<>
+			{!hidden && (
+				<Tooltip content="New task" side="right">
+					<button
+						type="button"
+						onClick={() => setOpen(true)}
+						data-testid="floating-new-task"
+						aria-label="New task"
+						className="lg:hidden fixed bottom-4 left-4 z-40 flex h-12 w-12 items-center justify-center rounded-full bg-accent-solid text-accent-solid-fg shadow-lg transition-colors hover:bg-accent-hover"
+					>
+						<Plus className="h-6 w-6" />
+					</button>
+				</Tooltip>
+			)}
+			<CreateTaskDialog projectId={active.slug} open={open} onOpenChange={setOpen} />
+		</>
+	);
+}

--- a/packages/web/src/components/project-sidebar.tsx
+++ b/packages/web/src/components/project-sidebar.tsx
@@ -9,6 +9,7 @@ import { useInboxUnreadCount } from '../hooks/use-inbox-count';
 import { useProjectMeta } from '../hooks/use-projects';
 import { agentPageParams } from './agent-link';
 import { AgentStatusLabel } from './agent-status-label';
+import { CreateTaskDialog } from './create-task-dialog';
 import { SidebarNav, type SidebarNavSection } from './sidebar-nav';
 import { Tooltip } from './ui/tooltip';
 
@@ -37,6 +38,7 @@ export function ProjectSidebar() {
 	const { data: inboxCount } = useInboxUnreadCount(projectId);
 	const { data: agents } = useAgents(projectId);
 	const [teamCollapsed, setTeamCollapsed] = useState(readTeamCollapsed);
+	const [createTaskOpen, setCreateTaskOpen] = useState(false);
 
 	if (!active) return null;
 
@@ -107,6 +109,11 @@ export function ProjectSidebar() {
 			label: 'Tasks',
 			count: project?.open_task_count,
 			testId: 'project-sidebar-tasks',
+			action: {
+				onClick: () => setCreateTaskOpen(true),
+				label: 'New task',
+				testId: 'project-sidebar-new-task',
+			},
 		},
 		// HQ (internal) exposes Documents (the chatbox memory doc) and Assets (where
 		// the CEO saves files it produces for the operator in chat); Budget and
@@ -236,6 +243,11 @@ export function ProjectSidebar() {
 			<div className="flex-1">
 				<SidebarNav sections={sections} />
 			</div>
+			<CreateTaskDialog
+				projectId={projectId}
+				open={createTaskOpen}
+				onOpenChange={setCreateTaskOpen}
+			/>
 		</div>
 	);
 }

--- a/packages/web/src/components/sidebar-nav.tsx
+++ b/packages/web/src/components/sidebar-nav.tsx
@@ -3,6 +3,12 @@ import { Plus } from 'lucide-react';
 import { Fragment } from 'react';
 import { Tooltip } from './ui/tooltip';
 
+interface SidebarNavItemAction {
+	onClick: () => void;
+	label: string;
+	testId?: string;
+}
+
 interface SidebarNavItem {
 	to: string;
 	params?: Record<string, string>;
@@ -10,6 +16,29 @@ interface SidebarNavItem {
 	count?: number;
 	subItems?: SidebarNavItem[];
 	testId?: string;
+	/** An inline "+" affordance rendered to the right of the row (e.g. create a
+	 *  task next to the Tasks link). Clicking it never follows the row's link. */
+	action?: SidebarNavItemAction;
+}
+
+function ItemAction({ action }: { action: SidebarNavItemAction }) {
+	return (
+		<Tooltip content={action.label} side="right">
+			<button
+				type="button"
+				onClick={(e) => {
+					e.preventDefault();
+					e.stopPropagation();
+					action.onClick();
+				}}
+				data-testid={action.testId}
+				aria-label={action.label}
+				className="mr-1 shrink-0 rounded-sm p-0.5 text-text-3 transition-colors hover:bg-surface-2 hover:text-text-1 cursor-pointer"
+			>
+				<Plus className="w-3.5 h-3.5" />
+			</button>
+		</Tooltip>
+	);
 }
 
 function CountBadge({ value }: { value: number | undefined }) {
@@ -98,6 +127,8 @@ export function SidebarNav({ sections }: SidebarNavProps) {
 									params={item.params ?? {}}
 									data-testid={item.testId}
 									className={`flex items-center text-left text-[12px] ${paddingClass} rounded-md transition-colors ${
+										item.action ? 'flex-1 min-w-0' : ''
+									} ${
 										isActive
 											? 'text-text-1 font-medium bg-surface-2'
 											: 'text-text-2 hover:text-text-1 hover:bg-surface-2'
@@ -107,9 +138,20 @@ export function SidebarNav({ sections }: SidebarNavProps) {
 									<CountBadge value={item.count} />
 								</Link>
 							);
-							// Plain items render exactly as before (no wrapper). Items with
-							// sub-items wrap so the disclosure can sit beneath the parent.
-							if (!item.subItems?.length) return <Fragment key={key}>{link}</Fragment>;
+							// Plain items render exactly as before (no wrapper). An item with an
+							// inline action sits beside its "+" on one row; items with sub-items
+							// wrap so the disclosure can sit beneath the parent.
+							if (!item.subItems?.length) {
+								if (item.action) {
+									return (
+										<div key={key} className="flex items-center">
+											{link}
+											<ItemAction action={item.action} />
+										</div>
+									);
+								}
+								return <Fragment key={key}>{link}</Fragment>;
+							}
 							return (
 								<div key={key}>
 									{link}

--- a/packages/web/src/components/task-list.tsx
+++ b/packages/web/src/components/task-list.tsx
@@ -4,7 +4,7 @@ import { AlertTriangle, AtSign, ChevronDown, ListPlus, Plus, Search } from 'luci
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAgents } from '../hooks/use-agents';
 import { useProjectMeta } from '../hooks/use-projects';
-import { type Task, type TaskFilters, useTasks } from '../hooks/use-tasks';
+import { type Task, useTasks } from '../hooks/use-tasks';
 import { nestTasksForDisplay } from '../lib/nest-tasks-for-display';
 import {
 	clearStoredTaskFilters,
@@ -412,7 +412,7 @@ export function TaskList({ projectId }: TaskListProps) {
 	);
 
 	const filterBar = (
-		<div className="relative flex-1 min-w-0 h-9" data-testid="task-filter-bar">
+		<div className="relative flex-1 min-w-0 h-10" data-testid="task-filter-bar">
 			<div className="h-full rounded-md border border-border bg-surface">
 				<button
 					type="button"
@@ -511,17 +511,20 @@ export function TaskList({ projectId }: TaskListProps) {
 			<AdminApprovalsBanner projectId={projectId} />
 			{showProjectProgress && <ProjectTaskListHeader projectId={projectId} />}
 
-			<div className="mb-4 flex flex-col sm:flex-row items-stretch gap-2">
+			<div className="mb-4 flex flex-row items-stretch gap-2">
 				{filterBar}
-				<Button
-					size="sm"
+				{/* Icon-only create button pinned to the filter bar's row, matching its
+				    height. The accessible name keeps it discoverable without the label. */}
+				<button
+					type="button"
 					onClick={() => setCreateOpen(true)}
 					data-testid="task-list-new-task"
-					className="h-9 sm:shrink-0"
+					aria-label="New task"
+					title="New task"
+					className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-inverse text-inverse-fg transition-colors hover:opacity-90 outline-none focus-visible:ring-[3px] focus-visible:ring-ring focus-visible:border-accent"
 				>
-					<Plus className="w-3.5 h-3.5" />
-					New task
-				</Button>
+					<Plus className="w-4 h-4" />
+				</button>
 			</div>
 
 			{inProgressLoading ? (

--- a/packages/web/src/routes/__root.tsx
+++ b/packages/web/src/routes/__root.tsx
@@ -10,6 +10,7 @@ import { X } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { AppHeader } from '../components/app-header';
 import { CeoChatWidget } from '../components/ceo-chat/ceo-chat-widget';
+import { FloatingNewTaskButton } from '../components/floating-new-task-button';
 import { GlobalSearchDialog } from '../components/global-search-dialog';
 import { MasterKeyGate } from '../components/master-key-gate';
 import { ProjectRail } from '../components/project-rail';
@@ -109,20 +110,30 @@ function ShellLayout() {
 	const matches = useMatches();
 	const bare = matches.some((m) => m.staticData?.bare);
 
+	// Drawer + chat open state live here so the floating new-task button can hide
+	// itself whenever either of those full-screen surfaces takes over the corner.
+	const [drawerOpen, setDrawerOpen] = useState(false);
+	const [chatOpen, setChatOpen] = useState(false);
+
 	// Bare routes (e.g. the standalone document preview) render full-viewport
 	// without the header, project rail, or mobile drawer.
 	if (bare) return <Outlet />;
 
 	return (
 		<>
-			<ShellChrome />
-			<CeoChatWidget />
+			<ShellChrome drawerOpen={drawerOpen} setDrawerOpen={setDrawerOpen} />
+			<FloatingNewTaskButton hidden={drawerOpen || chatOpen} />
+			<CeoChatWidget open={chatOpen} onOpenChange={setChatOpen} />
 		</>
 	);
 }
 
-function ShellChrome() {
-	const [drawerOpen, setDrawerOpen] = useState(false);
+interface ShellChromeProps {
+	drawerOpen: boolean;
+	setDrawerOpen: (open: boolean) => void;
+}
+
+function ShellChrome({ drawerOpen, setDrawerOpen }: ShellChromeProps) {
 	const [searchOpen, setSearchOpen] = useState(false);
 	const active = useActiveProject();
 	const mainRef = useRef<HTMLElement>(null);

--- a/packages/web/test/floating-new-task.test.tsx
+++ b/packages/web/test/floating-new-task.test.tsx
@@ -1,0 +1,74 @@
+import { waitFor } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+import { seedProject, seedWorkspace } from './helpers/seed';
+
+async function renderOnProjectTasks() {
+	let projectSlug = '';
+	const app = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Float Project' });
+			projectSlug = project.slug;
+		},
+	});
+	await app.router.navigate({
+		to: '/projects/$projectId/tasks',
+		params: { projectId: projectSlug },
+	});
+	return app;
+}
+
+test('the floating new-task button opens the create-task dialog on a project route', async () => {
+	const { findByTestId, user } = await renderOnProjectTasks();
+
+	const floating = await findByTestId('floating-new-task');
+	await user.click(floating);
+
+	// The dialog renders into a Radix portal on document.body.
+	await waitFor(() =>
+		expect(
+			Array.from(document.body.querySelectorAll('h2,[role="dialog"] *')).some(
+				(el) => el.textContent === 'Create Task',
+			),
+		).toBe(true),
+	);
+});
+
+test('the floating new-task button is hidden while the CEO chat is open', async () => {
+	const { findByTestId, queryByTestId, user } = await renderOnProjectTasks();
+
+	// Present on a project route to start with.
+	await findByTestId('floating-new-task');
+
+	// Opening the chat takes over the corner — the floating button hides.
+	await user.click(await findByTestId('ceo-chat-launcher'));
+	await findByTestId('ceo-chat-panel');
+	await waitFor(() => expect(queryByTestId('floating-new-task')).toBeNull());
+
+	// Closing the chat brings it back.
+	await user.click(await findByTestId('ceo-chat-close'));
+	await findByTestId('floating-new-task');
+});
+
+test('the sidebar "+" next to Tasks opens the create-task dialog', async () => {
+	const { findByTestId, user } = await renderOnProjectTasks();
+
+	const plus = await findByTestId('project-sidebar-new-task');
+	await user.click(plus);
+
+	await waitFor(() =>
+		expect(
+			Array.from(document.body.querySelectorAll('h2,[role="dialog"] *')).some(
+				(el) => el.textContent === 'Create Task',
+			),
+		).toBe(true),
+	);
+});
+
+test('no floating new-task button off a project route', async () => {
+	const { queryByTestId } = await renderApp({ initialPath: '/home' });
+	await waitFor(() => expect(queryByTestId('ceo-chat-launcher')).not.toBeNull());
+	expect(queryByTestId('floating-new-task')).toBeNull();
+});

--- a/packages/web/test/task-crud.test.tsx
+++ b/packages/web/test/task-crud.test.tsx
@@ -20,7 +20,7 @@ async function lockTask(
 
 test('can create a task with required assignee', async () => {
 	const seeded = { projectSlug: '' };
-	const { findByRole, findByLabelText, router, user, container } = await renderApp({
+	const { findByRole, findByTestId, findByLabelText, router, user, container } = await renderApp({
 		initialPath: '/',
 		seed: async () => {
 			const ws = await seedWorkspace();
@@ -34,7 +34,9 @@ test('can create a task with required assignee', async () => {
 		params: { projectId: seeded.projectSlug },
 	});
 
-	const newTaskBtn = await findByRole('button', { name: /New task/i });
+	// The filter-bar create button is now icon-only; target it by testid (several
+	// "New task" affordances — sidebar "+", floating button — share the label).
+	const newTaskBtn = await findByTestId('task-list-new-task');
 	await user.click(newTaskBtn);
 
 	const titleInput = await findByLabelText('Title');

--- a/test/browser/floating-new-task.mobile.spec.ts
+++ b/test/browser/floating-new-task.mobile.spec.ts
@@ -1,0 +1,89 @@
+// Decision-tree items 1–2: the floating new-task button is viewport-conditional
+// (`lg:hidden`, pinned bottom-left via `fixed`) and the desktop equivalent is the
+// sidebar "+", which only shows once the persistent menu renders at ≥1024.
+// happy-dom can't run the media queries or report fixed-position layout, so this
+// needs real Chromium + setViewportSize.
+import { expect, test } from './fixtures';
+import { createProjectAndClearPlanning, uniqueName, waitForPageLoad } from './helpers';
+
+test.describe('Floating new-task button responsiveness', () => {
+	test('mobile shows the floating "+" bottom-left; desktop hides it for the sidebar "+"', async ({
+		page,
+		sharedWorkspace,
+	}) => {
+		const { token } = sharedWorkspace;
+		const project = await createProjectAndClearPlanning(page, '', token, {
+			name: uniqueName('Floating Task'),
+			description: 'E2E floating new-task button.',
+		});
+
+		// --- Mobile: floating button visible and pinned to the bottom-left corner. ---
+		await page.setViewportSize({ width: 375, height: 800 });
+		await page.goto(`/projects/${project.slug}/tasks`);
+		await waitForPageLoad(page);
+
+		const floating = page.getByTestId('floating-new-task');
+		await expect(floating).toBeVisible({ timeout: 15000 });
+		const box = await floating.boundingBox();
+		const viewport = page.viewportSize();
+		if (!box || !viewport) throw new Error('Missing layout box');
+		// Anchored to the left half and near the bottom of the viewport.
+		expect(box.x).toBeLessThan(viewport.width / 2);
+		expect(box.y).toBeGreaterThan(viewport.height / 2);
+
+		// Opening it pops the create-task dialog…
+		await floating.click();
+		await expect(page.getByRole('heading', { name: 'Create Task' })).toBeVisible();
+		await page.keyboard.press('Escape');
+		await expect(page.getByRole('heading', { name: 'Create Task' })).toBeHidden();
+
+		// …and it hides while the mobile nav drawer is open.
+		await page.getByTestId('mobile-nav-toggle').click();
+		await expect(page.getByTestId('mobile-nav-drawer')).toBeVisible();
+		await expect(floating).toBeHidden();
+		await page.getByTestId('mobile-nav-close').click();
+		await expect(floating).toBeVisible();
+
+		// …and it hides while the CEO chat is open.
+		await page.getByTestId('ceo-chat-launcher').click();
+		await expect(page.getByTestId('ceo-chat-panel')).toBeVisible();
+		await expect(floating).toBeHidden();
+		await page.getByTestId('ceo-chat-close').click();
+		await expect(floating).toBeVisible();
+
+		// --- Desktop: floating button is gone; the sidebar carries the "+". ---
+		await page.setViewportSize({ width: 1280, height: 900 });
+		await expect(floating).toBeHidden();
+		const sidebarPlus = page.getByTestId('project-sidebar-new-task');
+		await expect(sidebarPlus).toBeVisible();
+		await sidebarPlus.click();
+		await expect(page.getByRole('heading', { name: 'Create Task' })).toBeVisible();
+	});
+
+	test('the filter bar and its icon create button share one row on mobile', async ({
+		page,
+		sharedWorkspace,
+	}) => {
+		const { token } = sharedWorkspace;
+		const project = await createProjectAndClearPlanning(page, '', token, {
+			name: uniqueName('Filter Row'),
+			description: 'E2E filter bar row.',
+		});
+
+		await page.setViewportSize({ width: 375, height: 800 });
+		await page.goto(`/projects/${project.slug}/tasks`);
+		await waitForPageLoad(page);
+
+		const bar = page.getByTestId('task-filter-bar');
+		const newTask = page.getByTestId('task-list-new-task');
+		await expect(bar).toBeVisible({ timeout: 15000 });
+		await expect(newTask).toBeVisible();
+
+		const barBox = await bar.boundingBox();
+		const btnBox = await newTask.boundingBox();
+		if (!barBox || !btnBox) throw new Error('Missing layout box');
+		// Same row: vertically overlapping, with the button to the right of the bar.
+		expect(btnBox.x).toBeGreaterThan(barBox.x + barBox.width - 4);
+		expect(Math.abs(btnBox.y - barBox.y)).toBeLessThan(barBox.height);
+	});
+});


### PR DESCRIPTION
## Summary

Reworks the task list's filter row and adds complementary create-task affordances scaled to viewport, addressing the screenshot feedback.

### Filter bar row
- The filter bar is a bit taller (`h-9` → `h-10`).
- The full-width "New task" button becomes an **icon-only "+"** pinned to the **same row** as the filter bar, matching its height. It keeps an `aria-label`/`title` of "New task" so it stays discoverable and keyboard/screen-reader friendly.

### Floating new-task button (mobile/tablet)
- New round "+" button pinned **bottom-left** (`fixed bottom-4 left-4`), mirroring the CEO chat launcher's floating treatment but using the **accent fill** (vs. the chat's inverse fill) so the two are never confused.
- It **hides** while the mobile nav drawer (rail + project menu) is open, and while the **CEO chat is open**.
- Scoped to `lg:hidden` and to project routes (so there's a project to create the task in).

### Desktop sidebar "+"
- On desktop the persistent project menu is always visible, so the floating duplicate would be redundant. Instead, a small **"+" sits next to the Tasks link** in the project menu (new optional `action` field on `SidebarNav` items; the action button never follows the row's link).

### Plumbing
- The CEO chat widget's open state is **lifted to the shell** (`ShellLayout`) so the floating button can react to it; the drawer state is lifted alongside it.

## Testing
- **Component tests** (`packages/web/test/floating-new-task.test.tsx`): floating button opens the create dialog, hides while chat is open (and returns on close), sidebar "+" opens the dialog, and the button is absent off-project routes.
- Updated `task-crud.test.tsx` to target the now-icon-only filter-bar button by test id (several affordances share the "New task" label).
- **Playwright** (`test/browser/floating-new-task.mobile.spec.ts`): verifies the viewport-conditional placement — mobile shows the floating "+" bottom-left (and hides it for drawer/chat), desktop hides it in favor of the sidebar "+", and the filter bar + icon button share one row. (Decision-tree items 1–2: `fixed`/`lg:hidden` need real Chromium.)
- `bun run typecheck` and Biome both clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019qiGViPeJd3UR5cf8mRtvK)_