### PR TITLE
feat(goals): reintroduce project goals tracked by the Captain

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -115,6 +115,18 @@ on run completion), `preview`, `action`,
 `connect_required`, `credential_request`. Each comment carries a `public_id` slug for
 `#comment-<id>` deep-links. `comment_reactions` holds emoji reactions.
 
+**Goals.** `goals` are per-project objectives the Captain tracks (`project_id NOT NULL`;
+the `is_internal` HQ project has none, enforced in the service). Each carries a SMART
+`title`/`description`, a `target_date`, a `check_frequency` enum (`daily`/`weekly`/`monthly`,
+default daily), an admin-set `archived_at` (NULL = active; there is **no** achieved status),
+and the Captain-maintained snapshot — `progress_percent` (0–100), a `goal_health` enum
+(`pending`/`on_track`/`at_risk`/`off_track`), a `status_blurb`, and `last_checked_at`. The
+Captain refreshes these on its heartbeat via a **goal-check run** (below). `goal_run_updates`
+is the per-run progress history (one row per goal touched by a run, snapshotting
+percent/health/blurb) — the source of each goal's progress chart and the "this run updated
+goals X, Y" annotation on the Goals page. `tasks.goal_id` optionally links a ticket to the
+goal it advances (traceability only; it does **not** gate or alter how the task runs).
+
 **Secrets, OAuth, MCP connectors.** `secrets` stores AES-256-GCM ciphertext gated by
 `allowed_hosts` (§ 7). `oauth_connections` records connected GitHub/SaaS accounts; their
 tokens *ride the `secrets` table* (no token column). `mcp_connections` is the catalog of
@@ -128,7 +140,10 @@ single shared catalog keyed by a globally-unique name (`secrets.name` /
 **Runs, wakeups, sessions.** `agent_wakeup_requests` is the trigger queue, with
 idempotency keys and `coalesced_count` merging (§ 5). `heartbeat_runs` is one row per
 execution (status, timing, tokens, cost, captured logs, `wakeup_id` provenance, the
-success-gate flags `produced_output`/`reported_no_work`). Token usage is flushed to the
+success-gate flags `produced_output`/`reported_no_work`). A `kind` enum distinguishes a
+normal `task` run from a `goal_check` run (the Captain's task-less goal assessment —
+`task_id IS NULL`); goal-check runs reuse the full run lifecycle but skip the task comment,
+status flip, and code worktree. Token usage is flushed to the
 row *during* the run (alongside the log), so a run the server kills mid-flight still
 reports the tokens/cost it burned instead of `0`; `usage_partial` flags such a snapshot
 until a clean completion supersedes it. `agent_task_sessions` persists
@@ -890,8 +905,8 @@ shapes.
   `project-docs`.
 - **Agents & runs** — `agents` (hire/fire/pause/resume, system-prompt revisions),
   `execution-locks`, `queued-wakeups`, `ceo-chat` (live CEO session).
-- **Tasks & collaboration** — `tasks`, `comments`, `mentions`, `assets`, `inbox`,
-  `search` (full-text).
+- **Tasks & collaboration** — `tasks`, `goals` (CRUD + `/goals/runs` + `/goals/:id/history`),
+  `comments`, `mentions`, `assets`, `inbox`, `search` (full-text).
 - **Money & governance** — `costs` (project-scoped, `group_by=day` for charts),
   `model-pricing`, `approvals`, `audit-log`.
 - **Integrations & secrets** — `ai-providers`, `secrets`, `mcp-connections`, `oauth`

--- a/agents/blank/captain.md
+++ b/agents/blank/captain.md
@@ -16,6 +16,19 @@ Your role is to translate the team mission into actionable strategy, recommend t
 - Escalate unresolvable tasks, budget questions, or strategic pivots to the human admin
 - Monitor overall team progress across all projects
 - Coordinate cross-project priorities when work overlaps
+- Track progress toward the project's goals (see **Goals** below)
+
+## Goals
+
+The admin sets the project's **goals** — the high-level objectives the team works toward, and you are the only role responsible for tracking them. On your heartbeat, when a goal is due for a check (each goal has a daily/weekly/monthly cadence), you are given a **goal-check run** listing the due goals, with no task attached.
+
+For each due goal:
+
+1. Assess **real** progress toward the objective — read the relevant tickets, comments, and any repo/state, and judge outcomes rather than counting tasks.
+2. Call `update_goal_progress` with a fresh `progress_percent` (0–100), a `health` (`on_track` / `at_risk` / `off_track`, weighing progress against the goal's target date), and a one-paragraph `status_blurb` on where the goal stands and the next step. Don't lower a percentage without saying why in the blurb — the admin tracks this over time.
+3. Decide whether new work is actually needed. If existing tickets already advance the goal, file nothing. Only when a concrete next step is missing, open the ticket(s) and set `goal_id` on each to link the work to the goal.
+
+The heartbeat brings due goals to you; use `list_goals` if you need the full picture mid-task.
 
 ## Growing the team
 

--- a/agents/blank/captain.md
+++ b/agents/blank/captain.md
@@ -24,8 +24,8 @@ The admin sets the project's **goals** — the high-level objectives the team wo
 
 For each due goal:
 
-1. Assess **real** progress toward the objective — read the relevant tickets, comments, and any repo/state, and judge outcomes rather than counting tasks.
-2. Call `update_goal_progress` with a fresh `progress_percent` (0–100), a `health` (`on_track` / `at_risk` / `off_track`, weighing progress against the goal's target date), and a one-paragraph `status_blurb` on where the goal stands and the next step. Don't lower a percentage without saying why in the blurb — the admin tracks this over time.
+1. Assess **real** progress toward the objective, judged against the goal's **measurement** (the precise, admin-written definition of "achieved" — that is the bar). Read the relevant tickets, comments, and any repo/state, and judge outcomes rather than counting tasks. If the goal lists **suggested actions**, follow that guidance for what to check or do.
+2. Call `update_goal_progress` with a fresh `progress_percent` (0–100), a `health` (`on_track` / `at_risk` / `off_track`, weighing progress against the goal's deadline), and a one-paragraph `status_blurb` on where the goal stands against its measurement and the next step. Don't lower a percentage without saying why in the blurb — the admin tracks this over time.
 3. Decide whether new work is actually needed. If existing tickets already advance the goal, file nothing. Only when a concrete next step is missing, open the ticket(s) and set `goal_id` on each to link the work to the goal.
 
 The heartbeat brings due goals to you; use `list_goals` if you need the full picture mid-task.

--- a/agents/software-development/captain.md
+++ b/agents/software-development/captain.md
@@ -47,8 +47,8 @@ The admin sets the project's **goals** — the high-level objectives the team wo
 
 For each due goal:
 
-1. Assess **real** progress toward the objective. Read the relevant tickets, comments, and repo/state — judge outcomes, not task counts. A goal can be 100% of its tickets closed and still only partway to the outcome, or vice versa.
-2. Call `update_goal_progress` with a fresh `progress_percent` (0–100), a `health` (`on_track` / `at_risk` / `off_track`, weighing progress against the goal's target date), and a one-paragraph `status_blurb` describing where the goal stands and what is needed next. Do not lower a percentage without explaining why in the blurb — the admin watches this number over time, so keep it honest and steady.
+1. Assess **real** progress toward the objective, judged against the goal's **measurement** (the precise, admin-written definition of "achieved" — that is the bar, not your own interpretation). Read the relevant tickets, comments, and repo/state — judge outcomes, not task counts. A goal can be 100% of its tickets closed and still only partway to the measurement, or vice versa. If the goal lists **suggested actions**, follow that guidance for what to check or do.
+2. Call `update_goal_progress` with a fresh `progress_percent` (0–100), a `health` (`on_track` / `at_risk` / `off_track`, weighing progress against the goal's deadline), and a one-paragraph `status_blurb` describing where the goal stands against its measurement and what is needed next. Do not lower a percentage without explaining why in the blurb — the admin watches this number over time, so keep it honest and steady.
 3. Decide whether new work is actually needed. Often the existing backlog or in-flight tickets already advance the goal — in that case file nothing. Only when a concrete next step is missing, create the ticket(s) through the normal delegation chain and set `goal_id` on each so the work is linked to the goal.
 
 You don't need to act on goals outside a goal-check run; the heartbeat brings the due ones to you. Use `list_goals` if you need the full picture mid-task.

--- a/agents/software-development/captain.md
+++ b/agents/software-development/captain.md
@@ -18,6 +18,7 @@ Your role is to translate the team mission into actionable strategy, delegate wo
 - Refine admin hire requests (see the Hire workflow section). You are the only role that can expand draft hire prompts before admin approval.
 - Coordinate cross-project priorities when work overlaps
 - Provide context and direction when agents are blocked or confused
+- Track progress toward the project's goals (see **Goals** below)
 
 Concrete pattern for the research → PRD → spec chain:
 1. Create the research ticket assigned to the Researcher (no blockers).
@@ -39,6 +40,18 @@ When a project is created you are woken on its **planning ticket** (labelled `pl
 3. **Close it out — this is the final, required step.** Once every planning sub-task has reached a terminal status (`done` or `cancelled`) and the top-level execution tickets exist, set the planning ticket to `done` with `update_task`; the Coach reviews it for the post-mortem but it stays `done`. Do not leave it parked in `in_progress` once it is eligible — the execution tickets ship independently and do not block it from being marked done.
 
 If a heartbeat returns you to the planning ticket and its sub-tasks are not all terminal (`done`/`cancelled`) yet, there is nothing to do: leave it `in_progress`, call `report_no_work` with a one-line reason, and end your turn. You will be woken again when the last sub-task lands.
+
+## Goals
+
+The admin sets the project's **goals** — the high-level objectives the team works toward. You are the only role responsible for tracking them. On your heartbeat, when a goal is due for a check (each goal has a daily/weekly/monthly cadence), you are given a **goal-check run** that lists the due goals — there is no task attached.
+
+For each due goal:
+
+1. Assess **real** progress toward the objective. Read the relevant tickets, comments, and repo/state — judge outcomes, not task counts. A goal can be 100% of its tickets closed and still only partway to the outcome, or vice versa.
+2. Call `update_goal_progress` with a fresh `progress_percent` (0–100), a `health` (`on_track` / `at_risk` / `off_track`, weighing progress against the goal's target date), and a one-paragraph `status_blurb` describing where the goal stands and what is needed next. Do not lower a percentage without explaining why in the blurb — the admin watches this number over time, so keep it honest and steady.
+3. Decide whether new work is actually needed. Often the existing backlog or in-flight tickets already advance the goal — in that case file nothing. Only when a concrete next step is missing, create the ticket(s) through the normal delegation chain and set `goal_id` on each so the work is linked to the goal.
+
+You don't need to act on goals outside a goal-check run; the heartbeat brings the due ones to you. Use `list_goals` if you need the full picture mid-task.
 
 ## Dispute resolution
 

--- a/docs/concepts/goals.md
+++ b/docs/concepts/goals.md
@@ -19,17 +19,22 @@ a fresh estimate, so the Goals page is always a current read on the project.
 
 Open **Goals** in the project menu (above Tasks) and choose **Create Goal**. A goal has:
 
-- **Title** — the objective in a line (e.g. "Reach 100 active customers").
-- **Description** — the guidelines for what the goal means and how to judge it. Write these
-  to be **SMART**: Specific, Measurable, Achievable, Relevant, and Time-bound. The clearer
-  the definition, the more honest the Captain's progress estimates.
-- **Target date** *(optional)* — when the goal should be met. The Captain weighs progress
-  against this date when it sets the goal's health.
+- **Goal name** — the objective in a line (e.g. "Reach 100 active customers").
+- **Measurement** — the precise definition of *how you'll know the goal is achieved* (e.g.
+  "100 active paid subscriptions in Stripe"). This is the bar the Captain measures against, so
+  the more concrete it is, the more honest its progress estimates.
+- **Suggested actions** *(optional)* — guidance on what the Captain should do or check toward
+  the goal: specific checks, or a standing instruction like "run a weekly cron-style review of
+  the signup funnel". Leave it blank to let the Captain decide.
+- **Deadline** *(optional)* — when the goal should be met. The Captain weighs progress against
+  this date when it sets the goal's health.
 - **Check frequency** — how often the Captain re-assesses the goal: **daily** (the default),
   **weekly**, or **monthly**.
 
-A project can have any number of goals. Until you've set one, a gentle dot pulses next to
-**Goals** in the menu as a nudge to create your first.
+The create and edit forms keep the **SMART** framework (Specific, Measurable, Achievable,
+Relevant, Time-bound) in front of you as a reminder. A project can have any number of goals;
+until you've set one, a gentle dot pulses next to **Goals** in the menu as a nudge to create
+your first.
 
 ## How the Captain tracks progress
 
@@ -51,6 +56,13 @@ has moved over time, so you can see momentum (or a stall) at a glance.
 These goal checks are **not** done inside a task — they're standalone Captain runs. The list
 of recent goal checks appears at the bottom of the Goals page, each noting which goals it
 updated (or that nothing changed).
+
+## Archiving
+
+The Goals page defaults to an **Active** view and has an **Archived** filter to see the rest.
+Archiving a goal (from its edit/archive control) sets it aside without deleting it: an archived
+goal is **no longer checked** — the Captain skips it entirely and never updates its status or
+files work for it. Unarchive it any time to bring it back into rotation.
 
 ## Goals and the board
 

--- a/docs/concepts/goals.md
+++ b/docs/concepts/goals.md
@@ -1,0 +1,67 @@
+---
+title: Goals & progress
+order: 10.5
+section: Concepts
+---
+
+# Goals & progress
+
+**Goals** are the high-level objectives a project is working toward. Where tasks are the
+individual pieces of work on the board, goals are the outcomes those tasks add up to — and
+they give you, the admin, a way to see how far along a project is and where things stand
+**without micromanaging the board.**
+
+You set the goals; the **Captain** keeps them up to date. You don't have to remember to
+update a status or move a slider — the Captain re-checks each goal on a schedule and writes
+a fresh estimate, so the Goals page is always a current read on the project.
+
+## Setting a goal
+
+Open **Goals** in the project menu (above Tasks) and choose **Create Goal**. A goal has:
+
+- **Title** — the objective in a line (e.g. "Reach 100 active customers").
+- **Description** — the guidelines for what the goal means and how to judge it. Write these
+  to be **SMART**: Specific, Measurable, Achievable, Relevant, and Time-bound. The clearer
+  the definition, the more honest the Captain's progress estimates.
+- **Target date** *(optional)* — when the goal should be met. The Captain weighs progress
+  against this date when it sets the goal's health.
+- **Check frequency** — how often the Captain re-assesses the goal: **daily** (the default),
+  **weekly**, or **monthly**.
+
+A project can have any number of goals. Until you've set one, a gentle dot pulses next to
+**Goals** in the menu as a nudge to create your first.
+
+## How the Captain tracks progress
+
+On the Captain's heartbeat, it looks at which goals are **due** for a check (based on each
+goal's frequency) and runs a single **goal check** covering all of them at once. Goals that
+aren't due yet are skipped. For each due goal the Captain assesses real progress toward the
+outcome — reading the relevant tickets, comments, and project state rather than just counting
+finished tasks — and records three things:
+
+- a **progress percentage** (0–100) — its honest estimate of how far along the goal is,
+- a **health** — a coloured pill that reads at a glance: **on track** (green), **at risk**
+  (amber), or **off track** (red); a brand-new goal shows **not assessed** (grey) until its
+  first check,
+- a **status blurb** — a short paragraph on where the goal stands and what's needed next.
+
+Because each check is recorded, every goal shows a **progress chart** of how its percentage
+has moved over time, so you can see momentum (or a stall) at a glance.
+
+These goal checks are **not** done inside a task — they're standalone Captain runs. The list
+of recent goal checks appears at the bottom of the Goals page, each noting which goals it
+updated (or that nothing changed).
+
+## Goals and the board
+
+When the Captain decides a goal needs work to move forward, it files the tickets through the
+normal delegation flow and links them to the goal. But it doesn't create work for its own
+sake: if tickets already in the backlog or in flight will advance the goal, the Captain
+leaves the board alone. The point of a goal check is to judge whether the project is on
+course — not to manufacture busywork every time a goal comes due.
+
+The estimate is exactly that — an estimate, made by the Captain. Treat the **blurb** as the
+primary signal and the **percentage** as a quick gauge of direction. Together they let you
+glance at a project and know where it's headed without reading every ticket.
+
+> Goals are a per-project concept. The instance-wide **HQ** project does not have goals.

--- a/docs/reference/mcp-api.md
+++ b/docs/reference/mcp-api.md
@@ -297,7 +297,7 @@ Remove a blocker between two tasks. Call this when a dependency that was previou
 
 _Read-only._
 
-List a project's goals (the objectives the Captain tracks). Each goal has a title, a SMART description, the Captain's current progress_percent (0-100), a health (pending/on_track/at_risk/off_track), a status_blurb, a check_frequency (daily/weekly/monthly), an optional target_date, and last_checked_at. As the Captain, call this during your heartbeat to see which goals are due for a fresh assessment, then call update_goal_progress for each. Archived goals are excluded unless include_archived is true.
+List a project's goals (the objectives the Captain tracks). Each goal has a title, a `measurement` (the precise definition of when the goal is achieved — the bar to judge against), optional `actions` (admin guidance on what to do/check toward it), the Captain's current progress_percent (0-100), a health (pending/on_track/at_risk/off_track), a status_blurb, a check_frequency (daily/weekly/monthly), an optional target_date (deadline), and last_checked_at. As the Captain, call this during your heartbeat to see which goals are due for a fresh assessment, then call update_goal_progress for each. Archived goals are excluded unless include_archived is true.
 
 **Parameters:**
 

--- a/docs/reference/mcp-api.md
+++ b/docs/reference/mcp-api.md
@@ -210,6 +210,7 @@ Create a new task. Use parent_task_id for sub-tasks — prefer this over a top-l
 | `parent_task_id` | `string` | No | Parent task to nest this under as a sub-task — a task identifier (e.g. "BE-2") or UUID. Sub-tasks can themselves have sub-tasks, but no deeper — depth is capped at 2. |
 | `runtime_type` | `string` | No | Pin this task to a specific AI runtime (claude_code, codex, gemini). Leave unset to use the instance default. |
 | `blocked_by_task_ids` | `string[]` | No | Task identifiers (e.g. ["BE-2", "BE-3"]) or UUIDs that must reach a terminal status before this ticket is started. The assignee will not be woken on this ticket until every blocker is satisfied. |
+| `goal_id` | `string` | No | UUID of the project goal this task advances. Links the task to the goal for traceability; it does not gate or change how the task runs. (Captain) set this when filing work to move a goal forward. |
 
 **Returns:** The created task row (it may carry an advisory `warning` string when the description backticked a real entity). Returns `{ error }` on a validation failure.
 
@@ -289,6 +290,43 @@ Remove a blocker between two tasks. Call this when a dependency that was previou
 | `blocked_by_task_id` | `string` | Yes | Task identifier or UUID of the blocker to remove |
 
 **Returns:** `{ removed: true }`, or `{ error }` if the dependency or blocker is not found. Clearing the last open blocker wakes the downstream assignee.
+
+## Goals
+
+### `list_goals`
+
+_Read-only._
+
+List a project's goals (the objectives the Captain tracks). Each goal has a title, a SMART description, the Captain's current progress_percent (0-100), a health (pending/on_track/at_risk/off_track), a status_blurb, a check_frequency (daily/weekly/monthly), an optional target_date, and last_checked_at. As the Captain, call this during your heartbeat to see which goals are due for a fresh assessment, then call update_goal_progress for each. Archived goals are excluded unless include_archived is true.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `project` | `string` | No | Project slug or ID. Omit to use the project your run is already in; instance agents (CEO/Coach) must name the project to act in. |
+| `include_archived` | `boolean` | No | Include archived goals (default false). |
+
+**Returns:** An array of the project's goal rows, each with `project_name`/`project_slug` and an embedded `history[]` of recent progress snapshots (`{ t, percent, health }`). Archived goals are excluded unless `include_archived` is true.
+
+### `update_goal_progress`
+
+_Write tool._
+
+Record your current assessment of a goal's progress. Only the Captain does this, and only from within a goal-check run. Pass progress_percent (0-100, your honest estimate — do not lower it without a reason in the blurb), health (on_track / at_risk / off_track, weighing progress against the target_date), and a one-paragraph status_blurb explaining where the goal stands and what is needed next. This updates the goal's live status and appends a point to its progress history; the goal then won't be re-surfaced for checking until its cadence elapses again.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `project` | `string` | No | Project slug or ID. Omit to use the project your run is already in; instance agents (CEO/Coach) must name the project to act in. |
+| `goal_id` | `string` | Yes | UUID of the goal to update. |
+| `progress_percent` | `integer` | Yes | Estimated progress toward the goal, 0-100. |
+| `health` | `on_track` \| `at_risk` \| `off_track` | Yes | on_track, at_risk, or off_track. |
+| `status_blurb` | `string` | Yes | One-paragraph summary of where the goal stands and the next step. |
+
+**Returns:** The updated goal row (with the new `progress_percent`, `health`, `status_blurb`, and a refreshed `last_checked_at`). Appends a point to the goal’s progress history keyed to the calling run. Returns `{ error }` if the goal is not in the project or the inputs are invalid.
+
+**Authorization:** Captain only, and only from within a goal-check agent run (the run records the history point).
 
 ## Comments & reactions
 

--- a/packages/server/migrations/005_goals.sql
+++ b/packages/server/migrations/005_goals.sql
@@ -2,8 +2,9 @@
 --
 -- A goal is a project-level objective the Captain tracks. The Captain estimates each
 -- goal's progress on a cadence (during its heartbeat), updating a percentage, a coloured
--- health, and a one-paragraph status blurb. Goals are SMART: the title/description are the
--- guidelines, target_date carries the time-bound aspect.
+-- health, and a one-paragraph status blurb. Goals are SMART: the title names it, the
+-- measurement defines precisely how we know it's achieved, optional actions hint at what to
+-- do toward it, and target_date carries the time-bound aspect.
 --
 -- Additive only; preserves all existing data. heartbeat_runs.kind defaults to 'task' so every
 -- existing run row stays correct with no backfill, and tasks.goal_id is nullable.
@@ -19,7 +20,11 @@ CREATE TABLE goals (
     team_id               UUID NOT NULL REFERENCES teams(id)    ON DELETE CASCADE,
     project_id            UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
     title                 TEXT NOT NULL,
-    description           TEXT NOT NULL DEFAULT '',          -- SMART guidelines
+    -- Precise, free-text definition of how we know the goal is achieved (the "Measurable" in SMART).
+    measurement           TEXT NOT NULL DEFAULT '',
+    -- Optional free-text guidance on what actions/checks the Captain could take toward the goal
+    -- (e.g. "run a weekly cron-style check", "verify the signup funnel each Monday").
+    actions               TEXT NOT NULL DEFAULT '',
     progress_percent      INTEGER NOT NULL DEFAULT 0 CHECK (progress_percent BETWEEN 0 AND 100),
     health                goal_health NOT NULL DEFAULT 'pending',   -- coloured pill, Captain-set
     status_blurb          TEXT NOT NULL DEFAULT '',          -- Captain's "where it stands"

--- a/packages/server/migrations/005_goals.sql
+++ b/packages/server/migrations/005_goals.sql
@@ -1,0 +1,62 @@
+-- Reintroduce Goals as a first-class, project-scoped concept.
+--
+-- A goal is a project-level objective the Captain tracks. The Captain estimates each
+-- goal's progress on a cadence (during its heartbeat), updating a percentage, a coloured
+-- health, and a one-paragraph status blurb. Goals are SMART: the title/description are the
+-- guidelines, target_date carries the time-bound aspect.
+--
+-- Additive only; preserves all existing data. heartbeat_runs.kind defaults to 'task' so every
+-- existing run row stays correct with no backfill, and tasks.goal_id is nullable.
+
+-- Cadence at which the Captain re-checks a goal.
+CREATE TYPE goal_check_frequency AS ENUM ('daily', 'weekly', 'monthly');
+
+-- Captain-set health pill. 'pending' = not yet assessed (grey) so a brand-new goal is honest.
+CREATE TYPE goal_health AS ENUM ('pending', 'on_track', 'at_risk', 'off_track');
+
+CREATE TABLE goals (
+    id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    team_id               UUID NOT NULL REFERENCES teams(id)    ON DELETE CASCADE,
+    project_id            UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    title                 TEXT NOT NULL,
+    description           TEXT NOT NULL DEFAULT '',          -- SMART guidelines
+    progress_percent      INTEGER NOT NULL DEFAULT 0 CHECK (progress_percent BETWEEN 0 AND 100),
+    health                goal_health NOT NULL DEFAULT 'pending',   -- coloured pill, Captain-set
+    status_blurb          TEXT NOT NULL DEFAULT '',          -- Captain's "where it stands"
+    check_frequency       goal_check_frequency NOT NULL DEFAULT 'daily',
+    target_date           DATE,                              -- optional, SMART "Timed"
+    last_checked_at       TIMESTAMPTZ,                       -- NULL = due now
+    archived_at           TIMESTAMPTZ,                       -- NULL = active; admin-set
+    created_by_member_id  UUID REFERENCES members(id) ON DELETE SET NULL,
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at            TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_goals_project ON goals(project_id);
+CREATE INDEX idx_goals_team    ON goals(team_id);
+CREATE INDEX idx_goals_active  ON goals(project_id) WHERE archived_at IS NULL;
+
+-- Classify a heartbeat run; default 'task' keeps every existing/legacy row correct with no
+-- backfill. Goal-check runs are Captain runs with task_id IS NULL and kind = 'goal_check'.
+CREATE TYPE heartbeat_run_kind AS ENUM ('task', 'goal_check');
+ALTER TABLE heartbeat_runs ADD COLUMN kind heartbeat_run_kind NOT NULL DEFAULT 'task';
+
+-- Which goals a goal-check run updated, snapshotting the percent/health/blurb at that moment.
+-- This is the single source of a goal's progress history (line charts) and powers the Goals
+-- page's "this run updated goals A, B" annotation. Snapshotting keeps both stable after later
+-- edits to the live goal.
+CREATE TABLE goal_run_updates (
+    id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    run_id            UUID NOT NULL REFERENCES heartbeat_runs(id) ON DELETE CASCADE,
+    goal_id           UUID NOT NULL REFERENCES goals(id)          ON DELETE CASCADE,
+    progress_percent  INTEGER NOT NULL CHECK (progress_percent BETWEEN 0 AND 100),
+    health            goal_health NOT NULL DEFAULT 'pending',
+    status_blurb      TEXT NOT NULL DEFAULT '',
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (run_id, goal_id)
+);
+CREATE INDEX idx_goal_run_updates_run  ON goal_run_updates(run_id);
+CREATE INDEX idx_goal_run_updates_goal ON goal_run_updates(goal_id);
+
+-- Optional, non-gating traceability link from a task to the goal it advances.
+ALTER TABLE tasks ADD COLUMN goal_id UUID REFERENCES goals(id) ON DELETE SET NULL;
+CREATE INDEX idx_tasks_goal ON tasks(goal_id) WHERE goal_id IS NOT NULL;

--- a/packages/server/src/mcp/mcp-reference.ts
+++ b/packages/server/src/mcp/mcp-reference.ts
@@ -38,6 +38,7 @@ export const MCP_REFERENCE_CATEGORY_ORDER: readonly string[] = [
 	'Teams',
 	'Projects',
 	'Tasks',
+	'Goals',
 	'Comments & reactions',
 	'Agents & hiring',
 	'Agent prompts & context',
@@ -137,6 +138,19 @@ export const TOOL_DOC_META: Record<string, ToolDocMeta> = {
 		category: 'Tasks',
 		returns:
 			'`{ removed: true }`, or `{ error }` if the dependency or blocker is not found. Clearing the last open blocker wakes the downstream assignee.',
+	},
+
+	// Goals
+	list_goals: {
+		category: 'Goals',
+		returns:
+			"An array of the project's goal rows, each with `project_name`/`project_slug` and an embedded `history[]` of recent progress snapshots (`{ t, percent, health }`). Archived goals are excluded unless `include_archived` is true.",
+	},
+	update_goal_progress: {
+		category: 'Goals',
+		returns:
+			'The updated goal row (with the new `progress_percent`, `health`, `status_blurb`, and a refreshed `last_checked_at`). Appends a point to the goal’s progress history keyed to the calling run. Returns `{ error }` if the goal is not in the project or the inputs are invalid.',
+		auth: 'Captain only, and only from within a goal-check agent run (the run records the history point).',
 	},
 
 	// Comments & reactions

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -11,6 +11,7 @@ import {
 	AuditActorType,
 	AuthType,
 	CAPTAIN_AGENT_SLUG,
+	CAPTAIN_SETTABLE_GOAL_HEALTH,
 	CEO_AGENT_SLUG,
 	COACH_AGENT_SLUG,
 	CommentContentType,
@@ -21,6 +22,7 @@ import {
 	DocumentType,
 	extensionOf,
 	extractBacktickedMentionCandidates,
+	type GoalHealth,
 	getConnectorCapability,
 	INSTANCE_AGENT_SLUGS,
 	isAgentAuthorableAssetMime,
@@ -85,6 +87,7 @@ import {
 	listDocuments,
 	upsertDocument,
 } from '../services/documents';
+import { listGoals, recordGoalProgress } from '../services/goals';
 import {
 	buildHirePayloadPatch,
 	type HirePayloadPatchInput,
@@ -173,6 +176,7 @@ const MCP_WRITE_TOOLS: ReadonlySet<string> = new Set([
 	'create_skill',
 	'add_mcp_connection',
 	'remove_mcp_connection',
+	'update_goal_progress',
 ]);
 
 /** A handler result that signals failure rather than a persisted write. */
@@ -512,6 +516,7 @@ function mcpArgsToCreateTaskInput(
 		priority: args.priority as string | undefined,
 		runtime_type: args.runtime_type as string | undefined,
 		blocked_by_task_ids: args.blocked_by_task_ids as string[] | undefined,
+		goal_id: args.goal_id as string | undefined,
 	};
 }
 
@@ -882,6 +887,12 @@ export function registerTools(
 				.describe(
 					'Task identifiers (e.g. ["BE-2", "BE-3"]) or UUIDs that must reach a terminal status before this ticket is started. The assignee will not be woken on this ticket until every blocker is satisfied.',
 				),
+			goal_id: z
+				.string()
+				.optional()
+				.describe(
+					'UUID of the project goal this task advances. Links the task to the goal for traceability; it does not gate or change how the task runs. (Captain) set this when filing work to move a goal forward.',
+				),
 		},
 		async (args, db, auth) => {
 			const scope = await resolveScope(db, auth, args);
@@ -909,6 +920,76 @@ export function registerTools(
 				args.description as string | undefined,
 				created,
 			);
+		},
+		db,
+	);
+
+	tool(
+		server,
+		'list_goals',
+		"List a project's goals (the objectives the Captain tracks). Each goal has a title, a SMART description, the Captain's current progress_percent (0-100), a health (pending/on_track/at_risk/off_track), a status_blurb, a check_frequency (daily/weekly/monthly), an optional target_date, and last_checked_at. As the Captain, call this during your heartbeat to see which goals are due for a fresh assessment, then call update_goal_progress for each. Archived goals are excluded unless include_archived is true.",
+		{
+			project: projectArg(),
+			include_archived: z.boolean().optional().describe('Include archived goals (default false).'),
+		},
+		async (args, db, auth) => {
+			const scope = await resolveScope(db, auth, args);
+			if ('error' in scope) return scope;
+			return listGoals(db, scope.projectId, {
+				includeArchived: args.include_archived === true,
+			});
+		},
+		db,
+	);
+
+	tool(
+		server,
+		'update_goal_progress',
+		"Record your current assessment of a goal's progress. Only the Captain does this, and only from within a goal-check run. Pass progress_percent (0-100, your honest estimate — do not lower it without a reason in the blurb), health (on_track / at_risk / off_track, weighing progress against the target_date), and a one-paragraph status_blurb explaining where the goal stands and what is needed next. This updates the goal's live status and appends a point to its progress history; the goal then won't be re-surfaced for checking until its cadence elapses again.",
+		{
+			project: projectArg(),
+			goal_id: z.string().describe('UUID of the goal to update.'),
+			progress_percent: z
+				.number()
+				.int()
+				.min(0)
+				.max(100)
+				.describe('Estimated progress toward the goal, 0-100.'),
+			health: z.enum(CAPTAIN_SETTABLE_GOAL_HEALTH).describe('on_track, at_risk, or off_track.'),
+			status_blurb: z
+				.string()
+				.describe('One-paragraph summary of where the goal stands and the next step.'),
+		},
+		async (args, db, auth) => {
+			const scope = await resolveScope(db, auth, args);
+			if ('error' in scope) return scope;
+			if (auth.type !== AuthType.Agent || !auth.runId) {
+				return { error: 'update_goal_progress can only be called from within an agent run' };
+			}
+			const goalId = args.goal_id as string;
+			const found = await db.query<{ id: string }>(
+				`SELECT id FROM goals WHERE id = $1 AND project_id = $2 AND archived_at IS NULL`,
+				[goalId, scope.projectId],
+			);
+			if (found.rows.length === 0) {
+				return { error: `Goal not found in project: ${goalId}` };
+			}
+			try {
+				return await recordGoalProgress(
+					db,
+					{
+						goalId,
+						runId: auth.runId,
+						progressPercent: args.progress_percent as number,
+						health: args.health as GoalHealth,
+						statusBlurb: args.status_blurb as string,
+					},
+					wsManager,
+				);
+			} catch (e) {
+				if (e instanceof Error && 'code' in e) return { error: e.message };
+				throw e;
+			}
 		},
 		db,
 	);

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -927,7 +927,7 @@ export function registerTools(
 	tool(
 		server,
 		'list_goals',
-		"List a project's goals (the objectives the Captain tracks). Each goal has a title, a SMART description, the Captain's current progress_percent (0-100), a health (pending/on_track/at_risk/off_track), a status_blurb, a check_frequency (daily/weekly/monthly), an optional target_date, and last_checked_at. As the Captain, call this during your heartbeat to see which goals are due for a fresh assessment, then call update_goal_progress for each. Archived goals are excluded unless include_archived is true.",
+		"List a project's goals (the objectives the Captain tracks). Each goal has a title, a `measurement` (the precise definition of when the goal is achieved — the bar to judge against), optional `actions` (admin guidance on what to do/check toward it), the Captain's current progress_percent (0-100), a health (pending/on_track/at_risk/off_track), a status_blurb, a check_frequency (daily/weekly/monthly), an optional target_date (deadline), and last_checked_at. As the Captain, call this during your heartbeat to see which goals are due for a fresh assessment, then call update_goal_progress for each. Archived goals are excluded unless include_archived is true.",
 		{
 			project: projectArg(),
 			include_archived: z.boolean().optional().describe('Include archived goals (default false).'),

--- a/packages/server/src/routes/goals.ts
+++ b/packages/server/src/routes/goals.ts
@@ -1,0 +1,104 @@
+import { Hono } from 'hono';
+import { resolveActorMemberId } from '../lib/resolve';
+import { err, ok } from '../lib/response';
+import type { Env } from '../lib/types';
+import {
+	type CreateGoalInput,
+	createGoal,
+	GoalError,
+	getGoal,
+	getGoalHistory,
+	listGoalCheckRuns,
+	listGoals,
+	type UpdateGoalInput,
+	updateGoal,
+} from '../services/goals';
+
+export const goalsRoutes = new Hono<Env>();
+
+function statusForGoalError(code: GoalError['code']): 400 | 403 | 404 {
+	return code === 'NOT_FOUND' ? 404 : code === 'FORBIDDEN' ? 403 : 400;
+}
+
+goalsRoutes.get('/projects/:projectId/goals', async (c) => {
+	const projectId = c.get('projectId') as string;
+	const includeArchived = c.req.query('include_archived') === 'true';
+	const goals = await listGoals(c.get('db'), projectId, { includeArchived });
+	return ok(c, goals);
+});
+
+// Registered before /goals/:goalId so "runs" isn't captured as a goal id.
+goalsRoutes.get('/projects/:projectId/goals/runs', async (c) => {
+	const projectId = c.get('projectId') as string;
+	const runs = await listGoalCheckRuns(c.get('db'), projectId);
+	return ok(c, runs);
+});
+
+goalsRoutes.post('/projects/:projectId/goals', async (c) => {
+	const teamId = c.get('teamId') as string;
+	const projectId = c.get('projectId') as string;
+	const db = c.get('db');
+
+	const body = await c.req.json<CreateGoalInput>();
+	body.project_id = projectId;
+	const actorMemberId = await resolveActorMemberId(db, c.get('auth'), teamId);
+
+	try {
+		const goal = await createGoal(db, teamId, body, { actorMemberId }, c.get('wsManager'));
+		return ok(c, goal, 201);
+	} catch (e) {
+		if (e instanceof GoalError) return err(c, e.code, e.message, statusForGoalError(e.code));
+		throw e;
+	}
+});
+
+goalsRoutes.get('/projects/:projectId/goals/:goalId', async (c) => {
+	const projectId = c.get('projectId') as string;
+	const goal = await getGoal(c.get('db'), projectId, c.req.param('goalId'));
+	if (!goal) return err(c, 'NOT_FOUND', 'Goal not found', 404);
+	return ok(c, goal);
+});
+
+goalsRoutes.get('/projects/:projectId/goals/:goalId/history', async (c) => {
+	const projectId = c.get('projectId') as string;
+	const history = await getGoalHistory(c.get('db'), projectId, c.req.param('goalId'));
+	if (history === null) return err(c, 'NOT_FOUND', 'Goal not found', 404);
+	return ok(c, history);
+});
+
+goalsRoutes.patch('/projects/:projectId/goals/:goalId', async (c) => {
+	const teamId = c.get('teamId') as string;
+	const projectId = c.get('projectId') as string;
+	const db = c.get('db');
+
+	// Ensure the goal belongs to this project before mutating by team id.
+	const existing = await getGoal(db, projectId, c.req.param('goalId'));
+	if (!existing) return err(c, 'NOT_FOUND', 'Goal not found', 404);
+
+	const body = await c.req.json<UpdateGoalInput>();
+	try {
+		const goal = await updateGoal(db, teamId, existing.id, body, c.get('wsManager'));
+		return ok(c, goal);
+	} catch (e) {
+		if (e instanceof GoalError) return err(c, e.code, e.message, statusForGoalError(e.code));
+		throw e;
+	}
+});
+
+// Archive (soft delete) — goals are never hard-deleted.
+goalsRoutes.delete('/projects/:projectId/goals/:goalId', async (c) => {
+	const teamId = c.get('teamId') as string;
+	const projectId = c.get('projectId') as string;
+	const db = c.get('db');
+
+	const existing = await getGoal(db, projectId, c.req.param('goalId'));
+	if (!existing) return err(c, 'NOT_FOUND', 'Goal not found', 404);
+
+	try {
+		const goal = await updateGoal(db, teamId, existing.id, { archived: true }, c.get('wsManager'));
+		return ok(c, goal);
+	} catch (e) {
+		if (e instanceof GoalError) return err(c, e.code, e.message, statusForGoalError(e.code));
+		throw e;
+	}
+});

--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -299,6 +299,7 @@ projectsRoutes.get('/projects/:projectId', async (c) => {
 		`SELECT p.*,
        (SELECT count(*) FROM repos r WHERE r.project_id = p.id)::int AS repo_count,
        (SELECT count(*) FROM tasks i WHERE i.project_id = p.id AND i.status NOT IN (${ts2.placeholders}))::int AS open_task_count,
+       (SELECT count(*) FROM goals g WHERE g.project_id = p.id AND g.archived_at IS NULL)::int AS open_goal_count,
        (SELECT pi.updated_at FROM project_icons pi WHERE pi.project_id = p.id) AS icon_updated_at
      FROM projects p
      WHERE p.id = $1 AND p.team_id = $2`,

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -9,6 +9,7 @@ import {
 	CommentContentType,
 	ContainerStatus,
 	claudeCodeModelArg,
+	HeartbeatRunKind,
 	HeartbeatRunStatus,
 	opencodeModelArg,
 	PROVIDER_RUNTIME_ADAPTERS,
@@ -505,7 +506,7 @@ export async function buildRuntimeInvocation(
 async function buildRunContext(
 	deps: RunnerDeps,
 	agent: AgentInfo,
-	task: TaskInfo,
+	task: TaskInfo | null,
 	project: ProjectInfo,
 	wakeupPayload: Record<string, unknown> | undefined,
 	credential: AiProviderCredential,
@@ -517,6 +518,7 @@ async function buildRunContext(
 	bridge: BridgeRunnerArgs | null,
 	egress: EgressEnvDescriptor | null,
 	runUser: ContainerRunUser,
+	goalCheck: GoalCheckContext | null,
 ): Promise<RunContext> {
 	// The run is scoped to the project's team (the "run team"). For normal agents
 	// this equals the agent's home team; for instance agents (CEO/Coach) that
@@ -536,22 +538,23 @@ async function buildRunContext(
 	let resolvedPrompt = await resolveSystemPrompt(deps.db, storedPrompt, {
 		teamId: runTeamId,
 		projectId: project.id,
-		taskId: task.id,
+		taskId: task?.id,
 		agentId: agent.id,
 		dataDir: deps.dataDir,
 	});
 
 	if (resolvedPrompt.includes('{{requester_context}}')) {
-		const creator = await deps.db.query<{ display_name: string; member_type: string }>(
-			`SELECT m.display_name, m.member_type FROM tasks i
-			 JOIN members m ON m.id = i.created_by_member_id
-			 WHERE i.id = $1`,
-			[task.id],
-		);
-		const row = creator.rows[0];
-		const requesterText = row
-			? `This task was created by ${row.display_name} (${row.member_type}).`
-			: '';
+		let requesterText = '';
+		if (task) {
+			const creator = await deps.db.query<{ display_name: string; member_type: string }>(
+				`SELECT m.display_name, m.member_type FROM tasks i
+				 JOIN members m ON m.id = i.created_by_member_id
+				 WHERE i.id = $1`,
+				[task.id],
+			);
+			const row = creator.rows[0];
+			if (row) requesterText = `This task was created by ${row.display_name} (${row.member_type}).`;
+		}
 		resolvedPrompt = resolvedPrompt.replace(/\{\{requester_context\}\}/g, requesterText);
 	}
 
@@ -575,14 +578,20 @@ async function buildRunContext(
 		wakeupPayload?.source === WakeupSource.Reply
 			? await loadReplyContext(deps.db, wakeupPayload)
 			: null;
-	const spawnedFrom = await loadSpawnedFromTask(deps.db, task);
-	const basePrompt = isCoachReview
-		? await buildCoachReviewPrompt(deps.db, resolvedPrompt, task, runTeamId)
-		: buildTaskPrompt(resolvedPrompt, task, wakeupPayload, {
-				mentionContext,
-				replyContext,
-				spawnedFrom,
-			});
+	const spawnedFrom = task ? await loadSpawnedFromTask(deps.db, task) : null;
+	let basePrompt: string;
+	if (goalCheck) {
+		basePrompt = buildGoalCheckPrompt(resolvedPrompt, goalCheck);
+	} else if (isCoachReview) {
+		// task is non-null on every non-goal-check path (enforced by runAgent).
+		basePrompt = await buildCoachReviewPrompt(deps.db, resolvedPrompt, task as TaskInfo, runTeamId);
+	} else {
+		basePrompt = buildTaskPrompt(resolvedPrompt, task as TaskInfo, wakeupPayload, {
+			mentionContext,
+			replyContext,
+			spawnedFrom,
+		});
+	}
 	const taskPrompt = effortApplication.promptDirective
 		? `${basePrompt}\n\n${effortApplication.promptDirective}`
 		: basePrompt;
@@ -608,7 +617,9 @@ async function buildRunContext(
 		sshSocketContainerPath,
 		bridge,
 		egress,
-		extraEnv: [`HEZO_TASK_ID=${task.id}`, `HEZO_TASK_IDENTIFIER=${task.identifier}`],
+		extraEnv: task
+			? [`HEZO_TASK_ID=${task.id}`, `HEZO_TASK_IDENTIFIER=${task.identifier}`]
+			: ['HEZO_GOAL_CHECK=1'],
 	});
 
 	return {
@@ -662,12 +673,13 @@ async function createSyntheticOnDemandWakeup(
 export async function runAgent(
 	deps: RunnerDeps,
 	agent: AgentInfo,
-	task: TaskInfo,
+	task: TaskInfo | null,
 	project: ProjectInfo,
 	wakeupPayload?: Record<string, unknown>,
 	signal?: AbortSignal,
 	onRunRegistered?: (heartbeatRunId: string) => void,
 	wakeupId?: string,
+	goalCheck?: GoalCheckContext | null,
 ): Promise<RunResult> {
 	const startTime = Date.now();
 
@@ -681,7 +693,7 @@ export async function runAgent(
 		events: deps.events,
 		teamId: runTeamId,
 		projectId: project.id,
-		taskId: task.id,
+		taskId: task?.id ?? null,
 		memberId: agent.id,
 	};
 	const effectiveWakeupId =
@@ -694,6 +706,7 @@ export async function runAgent(
 		runBroadcast,
 		effectiveWakeupId,
 		extractTriggeredBy(wakeupPayload),
+		goalCheck ? HeartbeatRunKind.GoalCheck : HeartbeatRunKind.Task,
 	);
 	onRunRegistered?.(heartbeatRunId);
 	await emitRunStarted(deps, heartbeatRunId, agent, task, project, effectiveWakeupId);
@@ -712,7 +725,7 @@ export async function runAgent(
 			type: WsMessageType.RunLog,
 			projectId: project.id,
 			runId: heartbeatRunId,
-			taskId: task.id,
+			taskId: task?.id ?? null,
 			stream: line.stream,
 			text: line.text,
 		}),
@@ -720,7 +733,7 @@ export async function runAgent(
 			type: WsMessageType.RunLog,
 			projectId: project.id,
 			runId: heartbeatRunId,
-			taskId: task.id,
+			taskId: task?.id ?? null,
 			stream: 'stdout',
 			text,
 			replace: true,
@@ -841,7 +854,7 @@ export async function runAgent(
 		provider = agent.model_override_provider;
 		runtimeType = PROVIDER_RUNTIME_ADAPTERS[provider].runtime;
 	} else {
-		const resolved = await resolveRuntimeForTask(deps.db, task.runtime_type ?? null);
+		const resolved = await resolveRuntimeForTask(deps.db, task?.runtime_type ?? null);
 		if (!resolved) {
 			return finalizeFailure(
 				'No AI provider credentials configured at the instance level. Add one in Settings > AI Providers.',
@@ -887,7 +900,7 @@ export async function runAgent(
 
 		// Human-friendly label for run-scoped logs (egress proxy, ssh-agent),
 		// since a run has no friendly identifier of its own.
-		const runLabel = `${agent.slug}/${task.identifier}`;
+		const runLabel = task ? `${agent.slug}/${task.identifier}` : `${agent.slug}/goal-check`;
 
 		// Detect the container's run-user once (cached). Drives every --user exec, the
 		// ssh socket owner, and the chowns that give the run-user ownership of the
@@ -982,6 +995,7 @@ export async function runAgent(
 			bridge,
 			egressEnv,
 			runUser,
+			goalCheck ?? null,
 		);
 
 		const hostPromptPath = getHostPromptPath(
@@ -1071,7 +1085,15 @@ export async function runAgent(
 		try {
 			if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
 
-			const prep = await prepareWorktrees(deps, project, task, bridge, runUser, emit, signal);
+			// Goal-check runs only call MCP tools; they need no code worktree.
+			const prep = task
+				? await prepareWorktrees(deps, project, task, bridge, runUser, emit, signal)
+				: {
+						workingDir: '/workspace',
+						designatedRepo: null as RepoRow | null,
+						worktrees: [] as WorktreeRef[],
+						executor: null as GitExecutor | null,
+					};
 
 			if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
 
@@ -1575,6 +1597,53 @@ export interface BuildTaskPromptContext {
 	spawnedFrom?: SpawnedFromTask | null;
 }
 
+/** One due goal handed to the Captain in a goal-check run. */
+export interface GoalCheckGoal {
+	id: string;
+	title: string;
+	description: string;
+	progress_percent: number;
+	health: string;
+	status_blurb: string;
+	check_frequency: string;
+	target_date: string | null;
+}
+
+export interface GoalCheckContext {
+	goals: GoalCheckGoal[];
+}
+
+/**
+ * The user-message body for a Captain goal-check run. Lists every due goal with its current
+ * estimate and instructs the Captain to assess each and call `update_goal_progress`. No task is
+ * attached — the run exists only to refresh goal status.
+ */
+export function buildGoalCheckPrompt(systemPrompt: string, ctx: GoalCheckContext): string {
+	const parts = [systemPrompt, '', '---', '', '## Goal Check', ''];
+	parts.push(
+		`${ctx.goals.length} goal${ctx.goals.length === 1 ? ' is' : 's are'} due for a progress check. ` +
+			'For each goal below, assess real progress toward the objective — read the relevant tickets, ' +
+			'comments, and repo state; do not just count tasks. Then call `update_goal_progress` once per ' +
+			'goal with a fresh `progress_percent` (0-100), a `health` (on_track / at_risk / off_track, ' +
+			'weighing progress against any target date), and a one-paragraph `status_blurb` describing where ' +
+			'the goal stands and the next step needed. Do not lower a percentage without explaining why in ' +
+			'the blurb. Only file new tasks (with `goal_id` set) when a concrete next step is actually ' +
+			'missing — existing backlog or in-flight work often already covers the goal.',
+	);
+	parts.push('');
+	for (const g of ctx.goals) {
+		parts.push(`### ${g.title}  \`${g.id}\``);
+		parts.push(
+			`- Current: ${g.progress_percent}% · health ${g.health} · checked ${g.check_frequency}` +
+				(g.target_date ? ` · target ${g.target_date}` : ''),
+		);
+		if (g.status_blurb) parts.push(`- Last status: ${g.status_blurb}`);
+		parts.push(`- Definition: ${g.description || 'No description provided.'}`);
+		parts.push('');
+	}
+	return parts.join('\n');
+}
+
 export function buildTaskPrompt(
 	systemPrompt: string,
 	task: TaskInfo,
@@ -1923,7 +1992,8 @@ export interface HeartbeatRunBroadcast {
 	events?: DomainEventBus;
 	teamId: string;
 	projectId?: string;
-	taskId: string;
+	/** Null for goal-check runs, which are not tied to a task. */
+	taskId: string | null;
 	memberId: string;
 }
 
@@ -1952,19 +2022,23 @@ export async function createHeartbeatRun(
 	db: PGlite,
 	agent: AgentInfo,
 	runTeamId: string,
-	task: TaskInfo,
+	task: TaskInfo | null,
 	broadcast: HeartbeatRunBroadcast,
 	wakeupId: string,
 	triggeredBy: TriggeredBy | null = null,
+	kind: HeartbeatRunKind = HeartbeatRunKind.Task,
 ): Promise<string> {
 	const { runId, statusFlippedToInProgress } = await withTransaction(db, async () => {
 		const runResult = await db.query<{ id: string }>(
-			`INSERT INTO heartbeat_runs (member_id, team_id, task_id, wakeup_id, status)
-			 VALUES ($1, $2, $3, $4, $5::heartbeat_run_status)
+			`INSERT INTO heartbeat_runs (member_id, team_id, task_id, wakeup_id, status, kind)
+			 VALUES ($1, $2, $3, $4, $5::heartbeat_run_status, $6::heartbeat_run_kind)
 			 RETURNING id`,
-			[agent.id, runTeamId, task.id, wakeupId, HeartbeatRunStatus.Queued],
+			[agent.id, runTeamId, task?.id ?? null, wakeupId, HeartbeatRunStatus.Queued, kind],
 		);
 		const runId = runResult.rows[0].id;
+
+		// Goal-check runs have no task — no Run comment to anchor and no status to flip.
+		if (!task) return { runId, statusFlippedToInProgress: false };
 
 		await db.query(
 			`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
@@ -2002,7 +2076,7 @@ export async function createHeartbeatRun(
 	});
 
 	broadcastHeartbeatRunChange(broadcast, runId, HeartbeatRunStatus.Queued, 'INSERT');
-	if (broadcast.wsManager) {
+	if (broadcast.wsManager && task) {
 		broadcastRowChange(
 			broadcast.wsManager,
 			wsRoom.team(broadcast.teamId),
@@ -2020,7 +2094,7 @@ export async function createHeartbeatRun(
 			});
 		}
 	}
-	if (statusFlippedToInProgress) {
+	if (statusFlippedToInProgress && task) {
 		await recordStatusChange(
 			db,
 			broadcast.teamId,
@@ -2188,7 +2262,7 @@ async function emitRunStarted(
 	deps: RunnerDeps,
 	runId: string,
 	agent: AgentInfo,
-	task: TaskInfo,
+	task: TaskInfo | null,
 	project: ProjectInfo,
 	wakeupId: string,
 ): Promise<void> {
@@ -2212,7 +2286,7 @@ async function emitRunStarted(
 		teamId: agent.team_id,
 		projectId: project.id,
 		runId,
-		taskId: task.id,
+		taskId: task?.id ?? null,
 		agentMemberId: agent.id,
 		triggerSource,
 		triggeredBy,

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -1601,7 +1601,8 @@ export interface BuildTaskPromptContext {
 export interface GoalCheckGoal {
 	id: string;
 	title: string;
-	description: string;
+	measurement: string;
+	actions: string;
 	progress_percent: number;
 	health: string;
 	status_blurb: string;
@@ -1635,10 +1636,11 @@ export function buildGoalCheckPrompt(systemPrompt: string, ctx: GoalCheckContext
 		parts.push(`### ${g.title}  \`${g.id}\``);
 		parts.push(
 			`- Current: ${g.progress_percent}% · health ${g.health} · checked ${g.check_frequency}` +
-				(g.target_date ? ` · target ${g.target_date}` : ''),
+				(g.target_date ? ` · deadline ${g.target_date}` : ''),
 		);
 		if (g.status_blurb) parts.push(`- Last status: ${g.status_blurb}`);
-		parts.push(`- Definition: ${g.description || 'No description provided.'}`);
+		parts.push(`- Achieved when: ${g.measurement || 'Not specified.'}`);
+		if (g.actions) parts.push(`- Suggested actions: ${g.actions}`);
 		parts.push('');
 	}
 	return parts.join('\n');

--- a/packages/server/src/services/goals.ts
+++ b/packages/server/src/services/goals.ts
@@ -1,0 +1,333 @@
+import type { PGlite } from '@electric-sql/pglite';
+import {
+	GoalCheckFrequency as Freq,
+	type GoalCheckFrequency,
+	type GoalCheckRunSummary,
+	type GoalHealth,
+	type GoalWithProject,
+	GoalHealth as Health,
+	HeartbeatRunKind,
+	wsRoom,
+} from '@hezo/shared';
+import { broadcastRowChange } from '../lib/broadcast';
+import { withTransaction } from '../lib/sql';
+import type { WebSocketManager } from './ws';
+
+// Bare projection of the goals table — every column, shared by REST handlers, the MCP
+// tools, and this service.
+export const GOAL_COLUMNS_BARE = `id, team_id, project_id, title, description, progress_percent,
+	health, status_blurb, check_frequency, target_date, last_checked_at, archived_at,
+	created_by_member_id, created_at, updated_at`;
+
+export type GoalErrorCode = 'INVALID_REQUEST' | 'NOT_FOUND' | 'FORBIDDEN';
+
+export class GoalError extends Error {
+	readonly code: GoalErrorCode;
+	constructor(code: GoalErrorCode, message: string) {
+		super(message);
+		this.code = code;
+		this.name = 'GoalError';
+	}
+}
+
+export interface CreateGoalInput {
+	project_id: string;
+	title: string;
+	description?: string;
+	check_frequency?: string;
+	target_date?: string | null;
+}
+
+export interface CreateGoalCaller {
+	actorMemberId: string | null;
+}
+
+export interface UpdateGoalInput {
+	title?: string;
+	description?: string;
+	check_frequency?: string;
+	target_date?: string | null;
+	/** Admin-only: ISO timestamp to archive, or null to un-archive. */
+	archived?: boolean;
+}
+
+export type GoalRow = Record<string, unknown> & { id: string; project_id: string };
+
+const VALID_FREQUENCIES = new Set<string>(Object.values(Freq));
+
+function assertFrequency(freq: string | undefined): GoalCheckFrequency {
+	if (freq === undefined) return Freq.Daily;
+	if (!VALID_FREQUENCIES.has(freq)) {
+		throw new GoalError('INVALID_REQUEST', `Invalid check_frequency '${freq}'`);
+	}
+	return freq as GoalCheckFrequency;
+}
+
+/** The recent progress-history points embedded on each goal in list/detail responses. */
+const HISTORY_AGG_SQL = `COALESCE((
+	SELECT json_agg(h ORDER BY h.t ASC)
+	FROM (
+		SELECT gru.created_at AS t, gru.progress_percent AS percent, gru.health
+		FROM goal_run_updates gru
+		WHERE gru.goal_id = g.id
+		ORDER BY gru.created_at DESC
+		LIMIT 30
+	) h
+), '[]'::json)`;
+
+export async function createGoal(
+	db: PGlite,
+	teamId: string,
+	input: CreateGoalInput,
+	caller: CreateGoalCaller,
+	wsManager: WebSocketManager | undefined,
+): Promise<GoalRow> {
+	const title = input.title?.trim();
+	if (!input.project_id || !title) {
+		throw new GoalError('INVALID_REQUEST', 'project_id and title are required');
+	}
+	const frequency = assertFrequency(input.check_frequency);
+
+	// HQ / internal projects don't have goals.
+	const proj = await db.query<{ is_internal: boolean }>(
+		`SELECT is_internal FROM projects WHERE id = $1 AND team_id = $2`,
+		[input.project_id, teamId],
+	);
+	if (proj.rows.length === 0) {
+		throw new GoalError('NOT_FOUND', 'Project not found');
+	}
+	if (proj.rows[0].is_internal) {
+		throw new GoalError('FORBIDDEN', 'The HQ project does not support goals');
+	}
+
+	const r = await db.query<GoalRow>(
+		`INSERT INTO goals (team_id, project_id, title, description, check_frequency, target_date, created_by_member_id)
+		 VALUES ($1, $2, $3, $4, $5::goal_check_frequency, $6, $7)
+		 RETURNING ${GOAL_COLUMNS_BARE}`,
+		[
+			teamId,
+			input.project_id,
+			title,
+			input.description ?? '',
+			frequency,
+			input.target_date ?? null,
+			caller.actorMemberId,
+		],
+	);
+	const goal = r.rows[0];
+	broadcastRowChange(wsManager, wsRoom.team(teamId), 'goals', 'INSERT', goal);
+	return goal;
+}
+
+export async function updateGoal(
+	db: PGlite,
+	teamId: string,
+	goalId: string,
+	input: UpdateGoalInput,
+	wsManager: WebSocketManager | undefined,
+): Promise<GoalRow> {
+	const sets: string[] = [];
+	const params: unknown[] = [];
+	let idx = 1;
+
+	if (input.title !== undefined) {
+		const title = input.title.trim();
+		if (!title) throw new GoalError('INVALID_REQUEST', 'title cannot be empty');
+		sets.push(`title = $${idx++}`);
+		params.push(title);
+	}
+	if (input.description !== undefined) {
+		sets.push(`description = $${idx++}`);
+		params.push(input.description);
+	}
+	if (input.check_frequency !== undefined) {
+		sets.push(`check_frequency = $${idx++}::goal_check_frequency`);
+		params.push(assertFrequency(input.check_frequency));
+	}
+	if (input.target_date !== undefined) {
+		sets.push(`target_date = $${idx++}`);
+		params.push(input.target_date);
+	}
+	if (input.archived !== undefined) {
+		sets.push(`archived_at = ${input.archived ? 'now()' : 'NULL'}`);
+	}
+
+	if (sets.length === 0) {
+		throw new GoalError('INVALID_REQUEST', 'No updatable fields provided');
+	}
+	sets.push('updated_at = now()');
+
+	params.push(goalId, teamId);
+	const r = await db.query<GoalRow>(
+		`UPDATE goals SET ${sets.join(', ')}
+		 WHERE id = $${idx++} AND team_id = $${idx}
+		 RETURNING ${GOAL_COLUMNS_BARE}`,
+		params,
+	);
+	if (r.rows.length === 0) {
+		throw new GoalError('NOT_FOUND', 'Goal not found');
+	}
+	const goal = r.rows[0];
+	broadcastRowChange(wsManager, wsRoom.team(teamId), 'goals', 'UPDATE', goal);
+	return goal;
+}
+
+export async function listGoals(
+	db: PGlite,
+	projectId: string,
+	opts: { includeArchived?: boolean } = {},
+): Promise<GoalWithProject[]> {
+	const where = opts.includeArchived ? '' : 'AND g.archived_at IS NULL';
+	const r = await db.query<GoalWithProject>(
+		`SELECT g.*, p.name AS project_name, p.slug AS project_slug,
+		        ${HISTORY_AGG_SQL} AS history
+		 FROM goals g
+		 JOIN projects p ON p.id = g.project_id
+		 WHERE g.project_id = $1 ${where}
+		 ORDER BY g.archived_at IS NOT NULL, g.created_at ASC`,
+		[projectId],
+	);
+	return r.rows;
+}
+
+export async function getGoal(
+	db: PGlite,
+	projectId: string,
+	goalId: string,
+): Promise<GoalWithProject | null> {
+	const r = await db.query<GoalWithProject>(
+		`SELECT g.*, p.name AS project_name, p.slug AS project_slug,
+		        ${HISTORY_AGG_SQL} AS history
+		 FROM goals g
+		 JOIN projects p ON p.id = g.project_id
+		 WHERE g.id = $1 AND g.project_id = $2`,
+		[goalId, projectId],
+	);
+	return r.rows[0] ?? null;
+}
+
+/** Full, un-capped progress series for a goal — for the larger detail/page chart. */
+export async function getGoalHistory(
+	db: PGlite,
+	projectId: string,
+	goalId: string,
+): Promise<{ t: string; percent: number; health: GoalHealth }[] | null> {
+	const exists = await db.query(`SELECT 1 FROM goals WHERE id = $1 AND project_id = $2`, [
+		goalId,
+		projectId,
+	]);
+	if (exists.rows.length === 0) return null;
+	const r = await db.query<{ t: string; percent: number; health: GoalHealth }>(
+		`SELECT created_at AS t, progress_percent AS percent, health
+		 FROM goal_run_updates WHERE goal_id = $1 ORDER BY created_at ASC`,
+		[goalId],
+	);
+	return r.rows;
+}
+
+/**
+ * Goals in a project that are due for a Captain check: active (not archived) and either
+ * never checked or last checked longer ago than their cadence. Mirrors the interval-elapsed
+ * test the heartbeat scheduler uses for agents.
+ */
+export async function getDueGoals(db: PGlite, projectId: string): Promise<GoalRow[]> {
+	const r = await db.query<GoalRow>(
+		`SELECT ${GOAL_COLUMNS_BARE} FROM goals g
+		 WHERE g.project_id = $1
+		   AND g.archived_at IS NULL
+		   AND (
+		     g.last_checked_at IS NULL
+		     OR g.last_checked_at + (CASE g.check_frequency
+		          WHEN 'daily'   THEN interval '1 day'
+		          WHEN 'weekly'  THEN interval '7 days'
+		          WHEN 'monthly' THEN interval '1 month'
+		        END) < now()
+		   )
+		 ORDER BY g.created_at ASC`,
+		[projectId],
+	);
+	return r.rows;
+}
+
+/**
+ * Record one goal's progress snapshot from a goal-check run: update the live goal and append a
+ * history row keyed to the run. `runId` is the goal-check run; the (run_id, goal_id) link is
+ * what the Goals page reads to annotate "this run updated goals X, Y".
+ */
+export async function recordGoalProgress(
+	db: PGlite,
+	input: {
+		goalId: string;
+		runId: string;
+		progressPercent: number;
+		health: GoalHealth;
+		statusBlurb: string;
+	},
+	wsManager: WebSocketManager | undefined,
+): Promise<GoalRow> {
+	const pct = Math.round(input.progressPercent);
+	if (!Number.isFinite(pct) || pct < 0 || pct > 100) {
+		throw new GoalError('INVALID_REQUEST', 'progress_percent must be between 0 and 100');
+	}
+	if (input.health === Health.Pending) {
+		throw new GoalError('INVALID_REQUEST', 'health must be on_track, at_risk, or off_track');
+	}
+
+	const goal = await withTransaction(db, async () => {
+		const upd = await db.query<GoalRow>(
+			`UPDATE goals
+			 SET progress_percent = $1, health = $2::goal_health, status_blurb = $3,
+			     last_checked_at = now(), updated_at = now()
+			 WHERE id = $4
+			 RETURNING ${GOAL_COLUMNS_BARE}`,
+			[pct, input.health, input.statusBlurb, input.goalId],
+		);
+		if (upd.rows.length === 0) {
+			throw new GoalError('NOT_FOUND', 'Goal not found');
+		}
+		await db.query(
+			`INSERT INTO goal_run_updates (run_id, goal_id, progress_percent, health, status_blurb)
+			 VALUES ($1, $2, $3, $4::goal_health, $5)
+			 ON CONFLICT (run_id, goal_id) DO UPDATE
+			   SET progress_percent = EXCLUDED.progress_percent,
+			       health = EXCLUDED.health,
+			       status_blurb = EXCLUDED.status_blurb`,
+			[input.runId, input.goalId, pct, input.health, input.statusBlurb],
+		);
+		return upd.rows[0];
+	});
+
+	broadcastRowChange(wsManager, wsRoom.team(goal.team_id as string), 'goals', 'UPDATE', goal);
+	return goal;
+}
+
+/**
+ * The goal-check runs for a project, newest first, each annotated with the titles of the goals
+ * it updated. Shown at the bottom of the Goals page.
+ */
+export async function listGoalCheckRuns(
+	db: PGlite,
+	projectId: string,
+	limit = 50,
+): Promise<GoalCheckRunSummary[]> {
+	// Goal-check runs are team-scoped (Captain runs with no task); a project maps 1:1 to its
+	// team, so filter by the project's team. The title list is a correlated subquery — no join
+	// fan-out, no GROUP BY.
+	const r = await db.query<GoalCheckRunSummary>(
+		`SELECT hr.id, hr.status, hr.created_at, hr.started_at, hr.finished_at,
+		        COALESCE((
+		          SELECT json_agg(g.title ORDER BY g.title)
+		          FROM goal_run_updates gru
+		          JOIN goals g ON g.id = gru.goal_id
+		          WHERE gru.run_id = hr.id
+		        ), '[]'::json) AS updated_goal_titles
+		 FROM heartbeat_runs hr
+		 WHERE hr.kind = $1
+		   AND hr.task_id IS NULL
+		   AND hr.team_id = (SELECT team_id FROM projects WHERE id = $2)
+		 ORDER BY hr.created_at DESC
+		 LIMIT $3`,
+		[HeartbeatRunKind.GoalCheck, projectId, limit],
+	);
+	return r.rows;
+}

--- a/packages/server/src/services/goals.ts
+++ b/packages/server/src/services/goals.ts
@@ -15,7 +15,7 @@ import type { WebSocketManager } from './ws';
 
 // Bare projection of the goals table — every column, shared by REST handlers, the MCP
 // tools, and this service.
-export const GOAL_COLUMNS_BARE = `id, team_id, project_id, title, description, progress_percent,
+export const GOAL_COLUMNS_BARE = `id, team_id, project_id, title, measurement, actions, progress_percent,
 	health, status_blurb, check_frequency, target_date, last_checked_at, archived_at,
 	created_by_member_id, created_at, updated_at`;
 
@@ -33,7 +33,8 @@ export class GoalError extends Error {
 export interface CreateGoalInput {
 	project_id: string;
 	title: string;
-	description?: string;
+	measurement?: string;
+	actions?: string;
 	check_frequency?: string;
 	target_date?: string | null;
 }
@@ -44,7 +45,8 @@ export interface CreateGoalCaller {
 
 export interface UpdateGoalInput {
 	title?: string;
-	description?: string;
+	measurement?: string;
+	actions?: string;
 	check_frequency?: string;
 	target_date?: string | null;
 	/** Admin-only: ISO timestamp to archive, or null to un-archive. */
@@ -101,14 +103,15 @@ export async function createGoal(
 	}
 
 	const r = await db.query<GoalRow>(
-		`INSERT INTO goals (team_id, project_id, title, description, check_frequency, target_date, created_by_member_id)
-		 VALUES ($1, $2, $3, $4, $5::goal_check_frequency, $6, $7)
+		`INSERT INTO goals (team_id, project_id, title, measurement, actions, check_frequency, target_date, created_by_member_id)
+		 VALUES ($1, $2, $3, $4, $5, $6::goal_check_frequency, $7, $8)
 		 RETURNING ${GOAL_COLUMNS_BARE}`,
 		[
 			teamId,
 			input.project_id,
 			title,
-			input.description ?? '',
+			input.measurement ?? '',
+			input.actions ?? '',
 			frequency,
 			input.target_date ?? null,
 			caller.actorMemberId,
@@ -136,9 +139,13 @@ export async function updateGoal(
 		sets.push(`title = $${idx++}`);
 		params.push(title);
 	}
-	if (input.description !== undefined) {
-		sets.push(`description = $${idx++}`);
-		params.push(input.description);
+	if (input.measurement !== undefined) {
+		sets.push(`measurement = $${idx++}`);
+		params.push(input.measurement);
+	}
+	if (input.actions !== undefined) {
+		sets.push(`actions = $${idx++}`);
+		params.push(input.actions);
 	}
 	if (input.check_frequency !== undefined) {
 		sets.push(`check_frequency = $${idx++}::goal_check_frequency`);

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -5,6 +5,7 @@ import {
 	AgentRuntimeStatus,
 	type AiProvider,
 	BUDGET_PAUSE_STATUSES,
+	CAPTAIN_AGENT_SLUG,
 	CommentContentType,
 	ContainerStatus,
 	DEFAULT_TEAM_ID,
@@ -26,7 +27,13 @@ import { shouldDeferWakeupForBlockers } from '../lib/dependencies';
 import { ref } from '../lib/log-ref';
 import { logger } from '../logger';
 import { getLatestInfo } from '../routes/updates';
-import { type RunnerDeps, type RunResult, recordRunCostAndEnforce, runAgent } from './agent-runner';
+import {
+	type GoalCheckContext,
+	type RunnerDeps,
+	type RunResult,
+	recordRunCostAndEnforce,
+	runAgent,
+} from './agent-runner';
 import {
 	pauseAgentForBudget,
 	reconcileBudgetPause,
@@ -49,6 +56,7 @@ import {
 } from './containers';
 import type { DockerClient } from './docker';
 import type { EgressProxy } from './egress';
+import { getDueGoals } from './goals';
 import { HEARTBEAT_INTERVAL_FLOOR_MIN } from './heartbeat-schedule';
 import type { LogStreamBroker } from './log-stream-broker';
 import { detectOrphans, healStaleRunState, STALE_STATE_GRACE_SECONDS } from './orphan-detector';
@@ -99,7 +107,8 @@ interface RunningTask {
 export interface LiveRun {
 	runId: string;
 	memberId: string;
-	taskId: string;
+	/** Null for goal-check runs, which are not tied to a task. */
+	taskId: string | null;
 	projectId: string;
 	teamId: string;
 	taskKey: string;
@@ -1304,6 +1313,29 @@ export class JobManager {
 			}
 			task = payloadTask.rows[0];
 		} else {
+			// The Captain's periodic heartbeat first checks whether any of the project's
+			// goals are due for a progress assessment. If so, it runs one goal-check run
+			// (no task, kind=goal_check) and yields this activation; ordinary task work
+			// resumes on the next heartbeat. Goals not yet due are skipped entirely.
+			if (agent.rows[0].slug === CAPTAIN_AGENT_SLUG) {
+				const dispatched = await this.tryDispatchGoalCheck(
+					memberId,
+					teamId,
+					{
+						id: memberId,
+						title: agent.rows[0].title,
+						slug: agent.rows[0].slug,
+						default_effort: agent.rows[0].default_effort,
+						model_override_provider: agent.rows[0].model_override_provider,
+						model_override_model: agent.rows[0].model_override_model,
+						run_timeout_min: agent.rows[0].run_timeout_min,
+					},
+					wakeupId,
+					wakeupPayload,
+				);
+				if (dispatched) return;
+			}
+
 			// Instance agents (CEO/Coach) select across every team; everyone else is
 			// scoped to their own team. Build the params positionally so the team
 			// filter is only present when its placeholder is.
@@ -1769,6 +1801,198 @@ export class JobManager {
 		// no `closed`), so the task stays `done` after the Coach run.
 
 		await this.chainNextTaskWakeup(memberId, agentSlug, taskId, teamId);
+	}
+
+	/**
+	 * If the Captain has goals due for a check, launch one goal-check run (no task) covering
+	 * all of them and return true so the caller yields this activation. Returns false when there
+	 * are no due goals or the run can't start right now (in which case the caller falls through
+	 * to normal task selection; the goals stay due and re-surface next heartbeat).
+	 */
+	private async tryDispatchGoalCheck(
+		memberId: string,
+		teamId: string,
+		agentRow: {
+			id: string;
+			title: string;
+			slug: string;
+			default_effort: string;
+			model_override_provider: AiProvider | null;
+			model_override_model: string | null;
+			run_timeout_min: number;
+		},
+		wakeupId: string | undefined,
+		wakeupPayload: Record<string, unknown>,
+	): Promise<boolean> {
+		const { db, docker, masterKeyManager, serverPort } = this.deps;
+
+		// The Captain's project is its team's single non-internal project.
+		const project = await db.query<{
+			id: string;
+			slug: string;
+			team_id: string;
+			team_slug: string;
+			container_id: string | null;
+			container_status: string;
+			designated_repo_id: string | null;
+			is_internal: boolean;
+		}>(
+			`SELECT p.id, p.slug, p.team_id, c.slug AS team_slug,
+			        p.container_id, p.container_status, p.designated_repo_id, p.is_internal
+			 FROM projects p JOIN teams c ON c.id = p.team_id
+			 WHERE p.team_id = $1 AND p.is_internal = false
+			 LIMIT 1`,
+			[teamId],
+		);
+		const projectRow = project.rows[0];
+		if (!projectRow) return false;
+
+		const dueGoals = await getDueGoals(db, projectRow.id);
+		if (dueGoals.length === 0) return false;
+
+		// Don't start a goal check while the Captain is already running in this project, the
+		// project is at capacity, the container isn't up, or the Captain/project is over budget.
+		// Fall through (return false) — the goals remain due for the next heartbeat.
+		if (await this.isAgentBusyInProject(memberId, projectRow.id)) return false;
+		if (await this.isProjectAtCapacity(projectRow.id)) return false;
+		if (!projectRow.container_id || projectRow.container_status !== ContainerStatus.Running) {
+			return false;
+		}
+		if (await checkOverBudget(db, memberId, projectRow.id)) return false;
+
+		const goalCheck: GoalCheckContext = {
+			goals: dueGoals.map((g) => ({
+				id: g.id as string,
+				title: g.title as string,
+				description: (g.description as string) ?? '',
+				progress_percent: (g.progress_percent as number) ?? 0,
+				health: (g.health as string) ?? 'pending',
+				status_blurb: (g.status_blurb as string) ?? '',
+				check_frequency: (g.check_frequency as string) ?? 'daily',
+				target_date: (g.target_date as string | null) ?? null,
+			})),
+		};
+
+		const runProject = { ...projectRow, container_id: projectRow.container_id };
+
+		await db.query(
+			'UPDATE member_agents SET runtime_status = $1::agent_runtime_status WHERE id = $2',
+			[AgentRuntimeStatus.Active, memberId],
+		);
+		broadcastRowChange(this.deps.wsManager, wsRoom.team(teamId), 'member_agents', 'UPDATE', {
+			id: memberId,
+			runtime_status: AgentRuntimeStatus.Active,
+		});
+
+		const deps: RunnerDeps = {
+			db,
+			docker,
+			masterKeyManager,
+			serverPort,
+			dataDir: this.deps.dataDir,
+			wsManager: this.deps.wsManager,
+			events: this.deps.events,
+			logs: this.deps.logs,
+			sshAgentServer: this.deps.sshAgentServer,
+			egressProxy: this.deps.egressProxy ?? null,
+			egressCAPath: this.deps.egressCAPath ?? null,
+			pricing: this.deps.pricing,
+		};
+		const timeoutMs = agentRow.run_timeout_min * 60 * 1000;
+		const key = `goalcheck:${memberId}:${projectRow.id}`;
+		this.acquireProjectRun(projectRow.id);
+
+		const launched = this.launchTask(
+			key,
+			async (signal) => {
+				let registeredRunId: string | undefined;
+				try {
+					const result = await runAgent(
+						deps,
+						{
+							id: memberId,
+							title: agentRow.title,
+							slug: agentRow.slug,
+							team_id: teamId,
+							default_effort: agentRow.default_effort,
+							model_override_provider: agentRow.model_override_provider,
+							model_override_model: agentRow.model_override_model,
+						},
+						null,
+						runProject,
+						wakeupPayload,
+						signal,
+						(runId) => {
+							registeredRunId = runId;
+							this.registerLiveRun({
+								runId,
+								memberId,
+								taskId: null,
+								projectId: projectRow.id,
+								teamId,
+								taskKey: key,
+							});
+						},
+						wakeupId,
+						goalCheck,
+					);
+					if (registeredRunId) this.unregisterLiveRun(registeredRunId);
+					await this.onGoalCheckComplete(memberId, teamId, wakeupId, result);
+					return result;
+				} catch (err) {
+					log.error(
+						`Background goal-check run for Captain ${ref('captain', memberId)} failed:`,
+						err,
+					);
+					if (registeredRunId) this.unregisterLiveRun(registeredRunId);
+					await this.onGoalCheckComplete(memberId, teamId, wakeupId, {
+						success: false,
+						exitCode: -1,
+						stdout: '',
+						stderr: err instanceof Error ? err.message : String(err),
+						durationMs: 0,
+						heartbeatRunId: registeredRunId,
+					}).catch((e) => log.error('Goal-check completion bookkeeping failed:', e));
+					return null;
+				} finally {
+					this.releaseProjectRun(projectRow.id);
+					void trackBackground(this.guarded('wakeups', () => this.processWakeups()));
+				}
+			},
+			timeoutMs,
+		);
+
+		if (!launched) {
+			// A concurrent dispatch holds this key; undo the status flip and re-queue.
+			this.releaseProjectRun(projectRow.id);
+			await setAgentIdleIfNoActiveRuns(db, memberId, teamId, undefined, this.deps.wsManager);
+			await this.requeueWakeup(wakeupId);
+			return true;
+		}
+		return true;
+	}
+
+	/** Trimmed completion bookkeeping for a goal-check run: no task lock, badge, or chain. */
+	private async onGoalCheckComplete(
+		memberId: string,
+		teamId: string,
+		wakeupId: string | undefined,
+		result: RunResult,
+	): Promise<void> {
+		const { db } = this.deps;
+		await setAgentIdleIfNoActiveRuns(
+			db,
+			memberId,
+			teamId,
+			result.heartbeatRunId,
+			this.deps.wsManager,
+		);
+		if (wakeupId) {
+			await db.query(
+				`UPDATE agent_wakeup_requests SET status = $1::wakeup_status, completed_at = now() WHERE id = $2`,
+				[result.success ? WakeupStatus.Completed : WakeupStatus.Failed, wakeupId],
+			);
+		}
 	}
 
 	private async postFailurePing(

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -1864,7 +1864,8 @@ export class JobManager {
 			goals: dueGoals.map((g) => ({
 				id: g.id as string,
 				title: g.title as string,
-				description: (g.description as string) ?? '',
+				measurement: (g.measurement as string) ?? '',
+				actions: (g.actions as string) ?? '',
 				progress_percent: (g.progress_percent as number) ?? 0,
 				health: (g.health as string) ?? 'pending',
 				status_blurb: (g.status_blurb as string) ?? '',

--- a/packages/server/src/services/tasks.ts
+++ b/packages/server/src/services/tasks.ts
@@ -24,7 +24,7 @@ export const TASK_COLUMNS_BARE = `id, team_id, project_id, assignee_id, parent_t
 	number, identifier, title, description, rules,
 	status, priority, labels,
 	progress_summary, progress_summary_updated_at, progress_summary_updated_by,
-	branch_name, runtime_type,
+	branch_name, runtime_type, goal_id,
 	created_at, updated_at`;
 
 export interface CreateTaskInput {
@@ -38,6 +38,8 @@ export interface CreateTaskInput {
 	labels?: string[];
 	runtime_type?: string;
 	blocked_by_task_ids?: string[];
+	/** Optional, non-gating link to the goal this task advances (set by the Captain). */
+	goal_id?: string;
 }
 
 export interface CreateTaskCaller {
@@ -117,6 +119,20 @@ export async function createTask(
 		}
 	}
 
+	// Optional goal link — the goal must live in the same project. Purely for
+	// traceability; it does not gate or alter how the task runs.
+	let goalId: string | null = null;
+	if (input.goal_id) {
+		const g = await db.query<{ id: string }>(
+			`SELECT id FROM goals WHERE id = $1 AND project_id = $2`,
+			[input.goal_id, input.project_id],
+		);
+		if (g.rows.length === 0) {
+			throw new CreateTaskError('NOT_FOUND', `Goal '${input.goal_id}' not found in this project`);
+		}
+		goalId = g.rows[0].id;
+	}
+
 	// Identifier allocation, the insert, and blocker attachment must land
 	// atomically — a rejected blocker reference would otherwise leave an
 	// orphan task row behind.
@@ -127,9 +143,9 @@ export async function createTask(
 			`INSERT INTO tasks (team_id, project_id, assignee_id, parent_task_id,
 			                     created_by_member_id, created_by_run_id,
 			                     number, identifier, title, description,
-			                     status, priority, labels, runtime_type)
+			                     status, priority, labels, runtime_type, goal_id)
 			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
-			         $11::task_status, $12::task_priority, $13::jsonb, $14::agent_runtime)
+			         $11::task_status, $12::task_priority, $13::jsonb, $14::agent_runtime, $15)
 			 RETURNING ${TASK_COLUMNS_BARE}`,
 			[
 				teamId,
@@ -146,6 +162,7 @@ export async function createTask(
 				input.priority ?? TaskPriority.Medium,
 				JSON.stringify(input.labels ?? []),
 				input.runtime_type ?? null,
+				goalId,
 			],
 		);
 		let created = r.rows[0];

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -35,6 +35,7 @@ import { ceoChatRoutes } from './routes/ceo-chat';
 import { commentsRoutes } from './routes/comments';
 import { costsRoutes } from './routes/costs';
 import { executionLocksRoutes } from './routes/execution-locks';
+import { goalsRoutes } from './routes/goals';
 import { healthRoutes } from './routes/health';
 import { inboxRoutes } from './routes/inbox';
 import { instanceSettingsRoutes } from './routes/instance-settings';
@@ -502,6 +503,7 @@ export function buildApp(
 	app.route('/api', agentsRoutes);
 	app.route('/api', projectsRoutes);
 	app.route('/api', tasksRoutes);
+	app.route('/api', goalsRoutes);
 	app.route('/api', commentsRoutes);
 	app.route('/api', assetsRoutes);
 	app.route('/api', secretsRoutes);

--- a/packages/server/test/goal-check-run.test.ts
+++ b/packages/server/test/goal-check-run.test.ts
@@ -1,0 +1,79 @@
+import type { PGlite } from '@electric-sql/pglite';
+import { HeartbeatRunKind, WakeupSource } from '@hezo/shared';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createHeartbeatRun, type HeartbeatRunBroadcast } from '../src/services/agent-runner';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
+
+let db: PGlite;
+let teamId: string;
+let captainMemberId: string;
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	db = ctx.db;
+	const token = ctx.token;
+
+	const typesRes = await ctx.app.request('/api/team-templates', { headers: authHeader(token) });
+	const typeId = (await typesRes.json()).data.find(
+		(t: { name: string }) => t.name === 'Startup',
+	).id;
+	const teamRes = await createTestTeam(db, { name: 'Goal Check Co', template_id: typeId });
+	teamId = (await teamRes.json()).data.id;
+	await createTestProject(db, teamId, { name: 'Goal Check Project' });
+
+	const captain = await db.query<{ id: string }>(
+		`SELECT ma.id FROM member_agents ma JOIN members m ON m.id = ma.id
+		 WHERE m.team_id = $1 AND ma.slug = 'captain' LIMIT 1`,
+		[teamId],
+	);
+	captainMemberId = captain.rows[0].id;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+describe('createHeartbeatRun for goal-check (null task)', () => {
+	it('creates a kind=goal_check run with no task and no Run comment', async () => {
+		const wakeup = await db.query<{ id: string }>(
+			`INSERT INTO agent_wakeup_requests (member_id, team_id, source, status, payload)
+			 VALUES ($1, $2, $3::wakeup_source, 'claimed'::wakeup_status, '{}'::jsonb)
+			 RETURNING id`,
+			[captainMemberId, teamId, WakeupSource.Heartbeat],
+		);
+		const broadcast: HeartbeatRunBroadcast = {
+			teamId,
+			taskId: null,
+			memberId: captainMemberId,
+		};
+
+		const commentsBefore = await db.query<{ c: number }>(
+			`SELECT count(*)::int AS c FROM task_comments`,
+		);
+
+		const runId = await createHeartbeatRun(
+			db,
+			{ id: captainMemberId, title: 'Captain', team_id: teamId },
+			teamId,
+			null,
+			broadcast,
+			wakeup.rows[0].id,
+			null,
+			HeartbeatRunKind.GoalCheck,
+		);
+
+		const run = await db.query<{ task_id: string | null; kind: string }>(
+			`SELECT task_id, kind::text AS kind FROM heartbeat_runs WHERE id = $1`,
+			[runId],
+		);
+		expect(run.rows[0].task_id).toBeNull();
+		expect(run.rows[0].kind).toBe('goal_check');
+
+		// No task comment was written (a goal-check run has no task to anchor one).
+		const commentsAfter = await db.query<{ c: number }>(
+			`SELECT count(*)::int AS c FROM task_comments`,
+		);
+		expect(commentsAfter.rows[0].c).toBe(commentsBefore.rows[0].c);
+	});
+});

--- a/packages/server/test/goals.test.ts
+++ b/packages/server/test/goals.test.ts
@@ -113,6 +113,12 @@ describe('goals REST CRUD', () => {
 		expect(goal.title).toBe('Reach 200 paying customers');
 	});
 
+	it('exposes the active goal count on the project detail payload', async () => {
+		const res = await app.request(`/api/projects/${projectSlug}`, { headers: authHeader(token) });
+		expect(res.status).toBe(200);
+		expect((await res.json()).data.open_goal_count).toBe(1);
+	});
+
 	it('archives a goal and hides it from the default list', async () => {
 		const del = await app.request(`/api/projects/${projectSlug}/goals/${goalId}`, {
 			method: 'DELETE',
@@ -120,6 +126,10 @@ describe('goals REST CRUD', () => {
 		});
 		expect(del.status).toBe(200);
 		expect((await del.json()).data.archived_at).not.toBeNull();
+
+		// Archiving drops it out of the active count.
+		const proj = await app.request(`/api/projects/${projectSlug}`, { headers: authHeader(token) });
+		expect((await proj.json()).data.open_goal_count).toBe(0);
 
 		const active = await app.request(`/api/projects/${projectSlug}/goals`, {
 			headers: authHeader(token),

--- a/packages/server/test/goals.test.ts
+++ b/packages/server/test/goals.test.ts
@@ -1,0 +1,242 @@
+import type { PGlite } from '@electric-sql/pglite';
+import { GoalHealth } from '@hezo/shared';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Env } from '../src/lib/types';
+import {
+	createGoal,
+	type GoalError,
+	getDueGoals,
+	listGoalCheckRuns,
+	listGoals,
+	recordGoalProgress,
+} from '../src/services/goals';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
+
+let db: PGlite;
+let app: Hono<Env>;
+let token: string;
+let teamId: string;
+let projectId: string;
+let projectSlug: string;
+let captainMemberId: string;
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	db = ctx.db;
+	app = ctx.app;
+	token = ctx.token;
+
+	const typesRes = await app.request('/api/team-templates', { headers: authHeader(token) });
+	const teamTemplateId = (await typesRes.json()).data.find(
+		(t: { name: string }) => t.name === 'Startup',
+	).id;
+	const teamRes = await createTestTeam(db, { name: 'Goals Co', template_id: teamTemplateId });
+	teamId = (await teamRes.json()).data.id;
+
+	const projectRes = await createTestProject(db, teamId, { name: 'Goals Project' });
+	const project = (await projectRes.json()).data;
+	projectId = project.id;
+	projectSlug = project.slug;
+
+	const captain = await db.query<{ id: string }>(
+		`SELECT ma.id FROM member_agents ma JOIN members m ON m.id = ma.id
+		 WHERE m.team_id = $1 AND ma.slug = 'captain' LIMIT 1`,
+		[teamId],
+	);
+	captainMemberId = captain.rows[0].id;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+function jsonHeaders() {
+	return { ...authHeader(token), 'content-type': 'application/json' };
+}
+
+describe('goals REST CRUD', () => {
+	let goalId: string;
+
+	it('creates a goal', async () => {
+		const res = await app.request(`/api/projects/${projectSlug}/goals`, {
+			method: 'POST',
+			headers: jsonHeaders(),
+			body: JSON.stringify({
+				title: 'Reach 100 paying customers',
+				description: 'Measured by active subscriptions; by end of Q3.',
+				check_frequency: 'weekly',
+				target_date: '2026-09-30',
+			}),
+		});
+		expect(res.status).toBe(201);
+		const goal = (await res.json()).data;
+		goalId = goal.id;
+		expect(goal.title).toBe('Reach 100 paying customers');
+		expect(goal.check_frequency).toBe('weekly');
+		expect(goal.health).toBe('pending');
+		expect(goal.progress_percent).toBe(0);
+	});
+
+	it('lists goals with embedded (empty) history', async () => {
+		const res = await app.request(`/api/projects/${projectSlug}/goals`, {
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		const goals = (await res.json()).data;
+		expect(goals).toHaveLength(1);
+		expect(goals[0].history).toEqual([]);
+		expect(goals[0].project_slug).toBe(projectSlug);
+	});
+
+	it('fetches a single goal', async () => {
+		const res = await app.request(`/api/projects/${projectSlug}/goals/${goalId}`, {
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		expect((await res.json()).data.id).toBe(goalId);
+	});
+
+	it('patches a goal', async () => {
+		const res = await app.request(`/api/projects/${projectSlug}/goals/${goalId}`, {
+			method: 'PATCH',
+			headers: jsonHeaders(),
+			body: JSON.stringify({ check_frequency: 'monthly', title: 'Reach 200 paying customers' }),
+		});
+		expect(res.status).toBe(200);
+		const goal = (await res.json()).data;
+		expect(goal.check_frequency).toBe('monthly');
+		expect(goal.title).toBe('Reach 200 paying customers');
+	});
+
+	it('archives a goal and hides it from the default list', async () => {
+		const del = await app.request(`/api/projects/${projectSlug}/goals/${goalId}`, {
+			method: 'DELETE',
+			headers: authHeader(token),
+		});
+		expect(del.status).toBe(200);
+		expect((await del.json()).data.archived_at).not.toBeNull();
+
+		const active = await app.request(`/api/projects/${projectSlug}/goals`, {
+			headers: authHeader(token),
+		});
+		expect((await active.json()).data).toHaveLength(0);
+
+		const all = await app.request(`/api/projects/${projectSlug}/goals?include_archived=true`, {
+			headers: authHeader(token),
+		});
+		expect((await all.json()).data).toHaveLength(1);
+	});
+});
+
+describe('goals service', () => {
+	it('rejects goal creation on the internal HQ project', async () => {
+		const hq = await db.query<{ id: string; team_id: string }>(
+			`SELECT id, team_id FROM projects WHERE is_internal = true LIMIT 1`,
+		);
+		await expect(
+			createGoal(
+				db,
+				hq.rows[0].team_id,
+				{ project_id: hq.rows[0].id, title: 'No goals here' },
+				{ actorMemberId: null },
+				undefined,
+			),
+		).rejects.toMatchObject({ code: 'FORBIDDEN' } satisfies Partial<GoalError>);
+	});
+
+	it('selects only due goals based on frequency and last_checked_at', async () => {
+		// daily goal never checked -> due; daily goal checked 2h ago -> not due;
+		// daily goal checked 2 days ago -> due; weekly checked 2 days ago -> not due.
+		const mk = async (title: string, freq: string, checkedAgo: string | null): Promise<string> => {
+			const r = await db.query<{ id: string }>(
+				`INSERT INTO goals (team_id, project_id, title, check_frequency, last_checked_at)
+				 VALUES ($1, $2, $3, $4::goal_check_frequency, ${checkedAgo ? `now() - interval '${checkedAgo}'` : 'NULL'})
+				 RETURNING id`,
+				[teamId, projectId, title, freq],
+			);
+			return r.rows[0].id;
+		};
+		const neverChecked = await mk('daily-never', 'daily', null);
+		const checkedRecently = await mk('daily-2h', 'daily', '2 hours');
+		const checkedStale = await mk('daily-2d', 'daily', '2 days');
+		const weeklyRecent = await mk('weekly-2d', 'weekly', '2 days');
+
+		const due = await getDueGoals(db, projectId);
+		const dueIds = new Set(due.map((g) => g.id));
+		expect(dueIds.has(neverChecked)).toBe(true);
+		expect(dueIds.has(checkedStale)).toBe(true);
+		expect(dueIds.has(checkedRecently)).toBe(false);
+		expect(dueIds.has(weeklyRecent)).toBe(false);
+	});
+
+	it('records progress: updates the goal, advances last_checked_at, writes history and run summary', async () => {
+		const goal = await db.query<{ id: string }>(
+			`INSERT INTO goals (team_id, project_id, title) VALUES ($1, $2, 'Track me') RETURNING id`,
+			[teamId, projectId],
+		);
+		const goalRowId = goal.rows[0].id;
+		// A Captain goal-check run with no task.
+		const run = await db.query<{ id: string }>(
+			`INSERT INTO heartbeat_runs (team_id, member_id, status, kind)
+			 VALUES ($1, $2, 'succeeded'::heartbeat_run_status, 'goal_check'::heartbeat_run_kind)
+			 RETURNING id`,
+			[teamId, captainMemberId],
+		);
+		const runId = run.rows[0].id;
+
+		const updated = await recordGoalProgress(
+			db,
+			{
+				goalId: goalRowId,
+				runId,
+				progressPercent: 35,
+				health: GoalHealth.AtRisk,
+				statusBlurb: 'Behind on hiring',
+			},
+			undefined,
+		);
+		expect(updated.progress_percent).toBe(35);
+		expect(updated.health).toBe('at_risk');
+		expect(updated.last_checked_at).not.toBeNull();
+
+		// History is embedded in the list payload.
+		const goals = await listGoals(db, projectId);
+		const tracked = goals.find((g) => g.id === goalRowId);
+		expect(tracked?.history).toHaveLength(1);
+		expect(tracked?.history[0].percent).toBe(35);
+
+		// The goal-check run shows up annotated with the goal title.
+		const runs = await listGoalCheckRuns(db, projectId);
+		const summary = runs.find((r) => r.id === runId);
+		expect(summary).toBeTruthy();
+		expect(summary?.updated_goal_titles).toContain('Track me');
+	});
+
+	it('rejects a pending health on recordGoalProgress', async () => {
+		const goal = await db.query<{ id: string }>(
+			`INSERT INTO goals (team_id, project_id, title) VALUES ($1, $2, 'Pending check') RETURNING id`,
+			[teamId, projectId],
+		);
+		const run = await db.query<{ id: string }>(
+			`INSERT INTO heartbeat_runs (team_id, member_id, status, kind)
+			 VALUES ($1, $2, 'succeeded'::heartbeat_run_status, 'goal_check'::heartbeat_run_kind)
+			 RETURNING id`,
+			[teamId, captainMemberId],
+		);
+		await expect(
+			recordGoalProgress(
+				db,
+				{
+					goalId: goal.rows[0].id,
+					runId: run.rows[0].id,
+					progressPercent: 50,
+					health: GoalHealth.Pending,
+					statusBlurb: '',
+				},
+				undefined,
+			),
+		).rejects.toMatchObject({ code: 'INVALID_REQUEST' });
+	});
+});

--- a/packages/server/test/goals.test.ts
+++ b/packages/server/test/goals.test.ts
@@ -65,7 +65,8 @@ describe('goals REST CRUD', () => {
 			headers: jsonHeaders(),
 			body: JSON.stringify({
 				title: 'Reach 100 paying customers',
-				description: 'Measured by active subscriptions; by end of Q3.',
+				measurement: '100 active paid subscriptions in Stripe',
+				actions: 'Check the signup funnel weekly',
 				check_frequency: 'weekly',
 				target_date: '2026-09-30',
 			}),
@@ -74,6 +75,8 @@ describe('goals REST CRUD', () => {
 		const goal = (await res.json()).data;
 		goalId = goal.id;
 		expect(goal.title).toBe('Reach 100 paying customers');
+		expect(goal.measurement).toBe('100 active paid subscriptions in Stripe');
+		expect(goal.actions).toBe('Check the signup funnel weekly');
 		expect(goal.check_frequency).toBe('weekly');
 		expect(goal.health).toBe('pending');
 		expect(goal.progress_percent).toBe(0);

--- a/packages/server/test/mcp-goals.test.ts
+++ b/packages/server/test/mcp-goals.test.ts
@@ -1,0 +1,135 @@
+import type { PGlite } from '@electric-sql/pglite';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { MasterKeyManager } from '../src/crypto/master-key';
+import type { Env } from '../src/lib/types';
+import { safeClose } from './helpers';
+import {
+	authHeader,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+	mintAgentToken,
+} from './helpers/app';
+
+let app: Hono<Env>;
+let db: PGlite;
+let token: string;
+let masterKeyManager: MasterKeyManager;
+let teamId: string;
+let projectId: string;
+let projectSlug: string;
+let captainAgentId: string;
+let goalId: string;
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+	masterKeyManager = ctx.masterKeyManager;
+
+	const typesRes = await app.request('/api/team-templates', { headers: authHeader(token) });
+	const typeId = (await typesRes.json()).data.find(
+		(t: { name: string }) => t.name === 'Startup',
+	).id;
+	const teamRes = await createTestTeam(db, { name: 'MCP Goals Co', template_id: typeId });
+	teamId = (await teamRes.json()).data.id;
+
+	const projectRes = await createTestProject(db, teamId, { name: 'MCP Goals Project' });
+	const project = (await projectRes.json()).data;
+	projectId = project.id;
+	projectSlug = project.slug;
+
+	const captain = await db.query<{ id: string }>(
+		`SELECT ma.id FROM member_agents ma JOIN members m ON m.id = ma.id
+		 WHERE m.team_id = $1 AND ma.slug = 'captain' LIMIT 1`,
+		[teamId],
+	);
+	captainAgentId = captain.rows[0].id;
+
+	const goalRes = await app.request(`/api/projects/${projectSlug}/goals`, {
+		method: 'POST',
+		headers: { ...authHeader(token), 'content-type': 'application/json' },
+		body: JSON.stringify({ title: 'Grow MRR to $10k', check_frequency: 'daily' }),
+	});
+	goalId = (await goalRes.json()).data.id;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+async function callTool(
+	bearer: string,
+	toolName: string,
+	args: Record<string, unknown>,
+): Promise<unknown> {
+	const res = await app.request('/mcp', {
+		method: 'POST',
+		headers: { Authorization: `Bearer ${bearer}`, 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			jsonrpc: '2.0',
+			method: 'tools/call',
+			params: { name: toolName, arguments: args },
+			id: 1,
+		}),
+	});
+	const body = (await res.json()) as { result: { content: Array<{ text: string }> } };
+	return JSON.parse(body.result.content[0].text);
+}
+
+describe('MCP goals tools', () => {
+	it('registers list_goals and update_goal_progress', async () => {
+		const res = await app.request('/mcp', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ jsonrpc: '2.0', method: 'tools/list', id: 1 }),
+		});
+		const names = (await res.json()).result.tools.map((t: { name: string }) => t.name);
+		expect(names).toContain('list_goals');
+		expect(names).toContain('update_goal_progress');
+	});
+
+	it('list_goals returns the project goals', async () => {
+		const goals = (await callTool(token, 'list_goals', { project: projectSlug })) as Array<{
+			id: string;
+		}>;
+		expect(goals.map((g) => g.id)).toContain(goalId);
+	});
+
+	it('update_goal_progress is rejected for a non-run caller', async () => {
+		const result = (await callTool(token, 'update_goal_progress', {
+			project: projectSlug,
+			goal_id: goalId,
+			progress_percent: 20,
+			health: 'on_track',
+			status_blurb: 'Early days',
+		})) as { error?: string };
+		expect(result.error).toMatch(/within an agent run/);
+	});
+
+	it('update_goal_progress records progress from a Captain run', async () => {
+		const agent = await mintAgentToken(db, masterKeyManager, captainAgentId, teamId, null, {
+			projectId,
+		});
+		const updated = (await callTool(agent.token, 'update_goal_progress', {
+			project: projectSlug,
+			goal_id: goalId,
+			progress_percent: 45,
+			health: 'at_risk',
+			status_blurb: 'Churn is up; need a retention push.',
+		})) as { progress_percent: number; health: string; last_checked_at: string | null };
+		expect(updated.progress_percent).toBe(45);
+		expect(updated.health).toBe('at_risk');
+		expect(updated.last_checked_at).not.toBeNull();
+
+		// The snapshot is linked to the run, so it shows in the goal's history.
+		const goals = (await callTool(token, 'list_goals', { project: projectSlug })) as Array<{
+			id: string;
+			history: Array<{ percent: number }>;
+		}>;
+		const goal = goals.find((g) => g.id === goalId);
+		expect(goal?.history.at(-1)?.percent).toBe(45);
+	});
+});

--- a/packages/server/test/migrate-005-goals.test.ts
+++ b/packages/server/test/migrate-005-goals.test.ts
@@ -108,8 +108,8 @@ describe('005_goals migration', () => {
 
 	it('round-trips a goal and a goal_run_update snapshot', async () => {
 		const goal = await h.db.query<{ id: string; health: string; check_frequency: string }>(
-			`INSERT INTO goals (team_id, project_id, title, description, progress_percent, health, status_blurb, check_frequency)
-			 VALUES ($1, $2, 'Ship v1', 'Launch the product', 40, 'on_track'::goal_health, 'Coming along', 'weekly'::goal_check_frequency)
+			`INSERT INTO goals (team_id, project_id, title, measurement, actions, progress_percent, health, status_blurb, check_frequency)
+			 VALUES ($1, $2, 'Ship v1', '50 paying customers', 'weekly funnel check', 40, 'on_track'::goal_health, 'Coming along', 'weekly'::goal_check_frequency)
 			 RETURNING id, health::text AS health, check_frequency::text AS check_frequency`,
 			[teamId, projectId],
 		);

--- a/packages/server/test/migrate-005-goals.test.ts
+++ b/packages/server/test/migrate-005-goals.test.ts
@@ -1,0 +1,135 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createDataPreservationHarness, type DataPreservationHarness } from './helpers/migrate';
+
+const TARGET = '005_goals.sql';
+
+describe('005_goals migration', () => {
+	let h: DataPreservationHarness;
+	let teamId: string;
+	let projectId: string;
+	let taskId: string;
+	let runId: string;
+
+	beforeAll(async () => {
+		h = await createDataPreservationHarness();
+		await h.applyUpToExclusive(TARGET);
+
+		const team = await h.db.query<{ id: string }>(
+			`INSERT INTO teams (name, slug) VALUES ('Acme', 'acme') RETURNING id`,
+		);
+		teamId = team.rows[0].id;
+		const project = await h.db.query<{ id: string }>(
+			`INSERT INTO projects (team_id, name, slug, task_prefix)
+			 VALUES ($1, 'Acme Project', 'acme-project', 'AP') RETURNING id`,
+			[teamId],
+		);
+		projectId = project.rows[0].id;
+		const member = await h.db.query<{ id: string }>(
+			`INSERT INTO members (team_id, member_type, display_name)
+			 VALUES ($1, 'agent', 'Captain') RETURNING id`,
+			[teamId],
+		);
+		const memberId = member.rows[0].id;
+		// A pre-existing task and heartbeat_run that must survive and pick up the new columns.
+		const task = await h.db.query<{ id: string }>(
+			`INSERT INTO tasks (team_id, project_id, number, identifier, title, status, priority, labels)
+			 VALUES ($1, $2, 1, 'AP-1', 'Existing task', 'backlog'::task_status, 'medium'::task_priority, '[]'::jsonb)
+			 RETURNING id`,
+			[teamId, projectId],
+		);
+		taskId = task.rows[0].id;
+		const run = await h.db.query<{ id: string }>(
+			`INSERT INTO heartbeat_runs (team_id, member_id, task_id, status)
+			 VALUES ($1, $2, $3, 'succeeded'::heartbeat_run_status) RETURNING id`,
+			[teamId, memberId, taskId],
+		);
+		runId = run.rows[0].id;
+
+		await h.applyTarget(TARGET);
+	});
+	afterAll(() => h.close());
+
+	it('creates the goals and goal_run_updates tables and new enums', async () => {
+		const tables = await h.db.query<{ table_name: string }>(
+			`SELECT table_name FROM information_schema.tables
+			 WHERE table_name IN ('goals', 'goal_run_updates')`,
+		);
+		expect(tables.rows.map((r) => r.table_name).sort()).toEqual(['goal_run_updates', 'goals']);
+
+		const enums = await h.db.query<{ typname: string }>(
+			`SELECT typname FROM pg_type
+			 WHERE typname IN ('goal_check_frequency', 'goal_health', 'heartbeat_run_kind')`,
+		);
+		expect(enums.rows.map((r) => r.typname).sort()).toEqual([
+			'goal_check_frequency',
+			'goal_health',
+			'heartbeat_run_kind',
+		]);
+	});
+
+	it('defaults existing heartbeat_runs to kind=task and tasks to goal_id NULL', async () => {
+		const run = await h.db.query<{ kind: string }>(
+			`SELECT kind::text AS kind FROM heartbeat_runs WHERE id = $1`,
+			[runId],
+		);
+		expect(run.rows[0].kind).toBe('task');
+		const task = await h.db.query<{ goal_id: string | null }>(
+			`SELECT goal_id FROM tasks WHERE id = $1`,
+			[taskId],
+		);
+		expect(task.rows[0].goal_id).toBeNull();
+	});
+
+	it('preserves the pre-existing team, project, task, and run rows', async () => {
+		const kept = await h.db.query(
+			`SELECT
+			   (SELECT count(*) FROM teams WHERE id = $1) AS teams,
+			   (SELECT count(*) FROM projects WHERE id = $2) AS projects,
+			   (SELECT count(*) FROM tasks WHERE id = $3) AS tasks,
+			   (SELECT count(*) FROM heartbeat_runs WHERE id = $4) AS runs`,
+			[teamId, projectId, taskId, runId],
+		);
+		const r = kept.rows[0] as Record<string, string>;
+		expect(Number(r.teams)).toBe(1);
+		expect(Number(r.projects)).toBe(1);
+		expect(Number(r.tasks)).toBe(1);
+		expect(Number(r.runs)).toBe(1);
+	});
+
+	it('enforces the progress_percent CHECK on goals', async () => {
+		await expect(
+			h.db.query(
+				`INSERT INTO goals (team_id, project_id, title, progress_percent)
+				 VALUES ($1, $2, 'Bad', 101)`,
+				[teamId, projectId],
+			),
+		).rejects.toThrow();
+	});
+
+	it('round-trips a goal and a goal_run_update snapshot', async () => {
+		const goal = await h.db.query<{ id: string; health: string; check_frequency: string }>(
+			`INSERT INTO goals (team_id, project_id, title, description, progress_percent, health, status_blurb, check_frequency)
+			 VALUES ($1, $2, 'Ship v1', 'Launch the product', 40, 'on_track'::goal_health, 'Coming along', 'weekly'::goal_check_frequency)
+			 RETURNING id, health::text AS health, check_frequency::text AS check_frequency`,
+			[teamId, projectId],
+		);
+		expect(goal.rows[0].health).toBe('on_track');
+		expect(goal.rows[0].check_frequency).toBe('weekly');
+
+		const upd = await h.db.query<{ progress_percent: number }>(
+			`INSERT INTO goal_run_updates (run_id, goal_id, progress_percent, health, status_blurb)
+			 VALUES ($1, $2, 40, 'on_track'::goal_health, 'Coming along')
+			 RETURNING progress_percent`,
+			[runId, goal.rows[0].id],
+		);
+		expect(upd.rows[0].progress_percent).toBe(40);
+
+		// A task can now be linked to the goal.
+		await h.db.query(`UPDATE tasks SET goal_id = $1 WHERE id = $2`, [goal.rows[0].id, taskId]);
+		const linked = await h.db.query<{ goal_id: string }>(
+			`SELECT goal_id FROM tasks WHERE id = $1`,
+			[taskId],
+		);
+		expect(linked.rows[0].goal_id).toBe(goal.rows[0].id);
+	});
+});

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -618,6 +618,18 @@ export function formatGoalHealth(health: string): string {
 	return GOAL_HEALTH_LABELS[health as GoalHealth] ?? health;
 }
 
+/**
+ * SMART-goal guidance shown on the goal create/edit surfaces so the admin keeps the framework
+ * in mind. Single source of truth so every surface renders the same explanation.
+ */
+export const GOAL_SMART_GUIDANCE: ReadonlyArray<{ letter: string; label: string; hint: string }> = [
+	{ letter: 'S', label: 'Specific', hint: 'Target one clear outcome, not a vague theme.' },
+	{ letter: 'M', label: 'Measurable', hint: 'Define exactly how you will know it is achieved.' },
+	{ letter: 'A', label: 'Achievable', hint: 'Realistic for the team given its resources.' },
+	{ letter: 'R', label: 'Relevant', hint: "Matters to the project's mission right now." },
+	{ letter: 'T', label: 'Time-bound', hint: 'Give it a deadline to work toward.' },
+];
+
 /** One point in a goal's progress history — a snapshot recorded by a goal-check run. */
 export interface GoalHistoryPoint {
 	/** ISO timestamp of the recording goal-check run. */
@@ -631,7 +643,10 @@ export interface Goal {
 	team_id: string;
 	project_id: string;
 	title: string;
-	description: string;
+	/** Precise free-text definition of how we know the goal is achieved (SMART "Measurable"). */
+	measurement: string;
+	/** Optional free-text guidance on actions/checks the Captain could take toward the goal. */
+	actions: string;
 	progress_percent: number;
 	health: GoalHealth;
 	status_blurb: string;

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -565,6 +565,116 @@ export const HeartbeatRunStatus = {
 } as const;
 export type HeartbeatRunStatus = (typeof HeartbeatRunStatus)[keyof typeof HeartbeatRunStatus];
 
+/** Classifies a heartbeat run. 'task' is the normal task-scoped run; 'goal_check' is a
+ * Captain run with no task that estimates progress across the project's due goals. */
+export const HeartbeatRunKind = {
+	Task: 'task',
+	GoalCheck: 'goal_check',
+} as const;
+export type HeartbeatRunKind = (typeof HeartbeatRunKind)[keyof typeof HeartbeatRunKind];
+
+// --- Goals ---
+
+/** How often the Captain re-checks a goal's progress during its heartbeat. */
+export const GoalCheckFrequency = {
+	Daily: 'daily',
+	Weekly: 'weekly',
+	Monthly: 'monthly',
+} as const;
+export type GoalCheckFrequency = (typeof GoalCheckFrequency)[keyof typeof GoalCheckFrequency];
+
+export const GOAL_CHECK_FREQUENCY_LABELS: Record<GoalCheckFrequency, string> = {
+	[GoalCheckFrequency.Daily]: 'Daily',
+	[GoalCheckFrequency.Weekly]: 'Weekly',
+	[GoalCheckFrequency.Monthly]: 'Monthly',
+};
+
+/** The Captain's at-a-glance read on a goal. 'pending' = not yet assessed (a brand-new
+ * goal the Captain hasn't checked). The Captain sets the other three on each check. */
+export const GoalHealth = {
+	Pending: 'pending',
+	OnTrack: 'on_track',
+	AtRisk: 'at_risk',
+	OffTrack: 'off_track',
+} as const;
+export type GoalHealth = (typeof GoalHealth)[keyof typeof GoalHealth];
+
+export const GOAL_HEALTH_LABELS: Record<GoalHealth, string> = {
+	[GoalHealth.Pending]: 'Not assessed',
+	[GoalHealth.OnTrack]: 'On track',
+	[GoalHealth.AtRisk]: 'At risk',
+	[GoalHealth.OffTrack]: 'Off track',
+};
+
+/** The health values the Captain may set via update_goal_progress (excludes 'pending', the
+ * pre-assessment default). */
+export const CAPTAIN_SETTABLE_GOAL_HEALTH = [
+	GoalHealth.OnTrack,
+	GoalHealth.AtRisk,
+	GoalHealth.OffTrack,
+] as const;
+
+export function formatGoalHealth(health: string): string {
+	return GOAL_HEALTH_LABELS[health as GoalHealth] ?? health;
+}
+
+/** One point in a goal's progress history — a snapshot recorded by a goal-check run. */
+export interface GoalHistoryPoint {
+	/** ISO timestamp of the recording goal-check run. */
+	t: string;
+	percent: number;
+	health: GoalHealth;
+}
+
+export interface Goal {
+	id: string;
+	team_id: string;
+	project_id: string;
+	title: string;
+	description: string;
+	progress_percent: number;
+	health: GoalHealth;
+	status_blurb: string;
+	check_frequency: GoalCheckFrequency;
+	target_date: string | null;
+	last_checked_at: string | null;
+	/** NULL = active; non-null = archived by an admin at this time. */
+	archived_at: string | null;
+	created_by_member_id: string | null;
+	created_at: string;
+	updated_at: string;
+}
+
+/** The list/detail DTO: a goal plus its project handle and embedded recent history (so the
+ * goal panels can draw their line charts without an extra round-trip). */
+export interface GoalWithProject extends Goal {
+	project_name: string | null;
+	project_slug: string | null;
+	history: GoalHistoryPoint[];
+}
+
+/** A single goal's progress snapshot taken during one goal-check run. */
+export interface GoalRunUpdate {
+	id: string;
+	run_id: string;
+	goal_id: string;
+	progress_percent: number;
+	health: GoalHealth;
+	status_blurb: string;
+	created_at: string;
+}
+
+/** A goal-check run as shown in the Goals page footer, annotated with which goals it touched. */
+export interface GoalCheckRunSummary {
+	id: string;
+	status: HeartbeatRunStatus;
+	created_at: string;
+	started_at: string | null;
+	finished_at: string | null;
+	/** Titles of the goals this run updated (empty = ran but changed nothing). */
+	updated_goal_titles: string[];
+}
+
 // --- CEO chat ---
 
 /**

--- a/packages/web/src/components/create-goal-dialog.tsx
+++ b/packages/web/src/components/create-goal-dialog.tsx
@@ -1,0 +1,131 @@
+import { GOAL_CHECK_FREQUENCY_LABELS, GoalCheckFrequency } from '@hezo/shared';
+import * as Dialog from '@radix-ui/react-dialog';
+import { Loader2, X } from 'lucide-react';
+import { useState } from 'react';
+import { useCreateGoal } from '../hooks/use-goals';
+import { Button } from './ui/button';
+import { dialogContentClassName, dialogOverlayClassName } from './ui/dialog';
+import { Input } from './ui/input';
+
+interface CreateGoalDialogProps {
+	projectId: string;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}
+
+export function CreateGoalDialog({ projectId, open, onOpenChange }: CreateGoalDialogProps) {
+	const [title, setTitle] = useState('');
+	const [description, setDescription] = useState('');
+	const [checkFrequency, setCheckFrequency] = useState<GoalCheckFrequency>(
+		GoalCheckFrequency.Daily,
+	);
+	const [targetDate, setTargetDate] = useState('');
+	const createGoal = useCreateGoal(projectId);
+
+	function reset() {
+		setTitle('');
+		setDescription('');
+		setCheckFrequency(GoalCheckFrequency.Daily);
+		setTargetDate('');
+	}
+
+	async function handleSubmit(e: React.FormEvent) {
+		e.preventDefault();
+		await createGoal.mutateAsync({
+			title,
+			description: description || undefined,
+			check_frequency: checkFrequency,
+			target_date: targetDate || undefined,
+		});
+		onOpenChange(false);
+		reset();
+	}
+
+	return (
+		<Dialog.Root open={open} onOpenChange={onOpenChange}>
+			<Dialog.Portal>
+				<Dialog.Overlay className={dialogOverlayClassName} />
+				<Dialog.Content className={dialogContentClassName.lg}>
+					<div className="flex items-center justify-between mb-4">
+						<Dialog.Title className="text-lg font-semibold">Create Goal</Dialog.Title>
+						<Dialog.Close asChild>
+							<button
+								type="button"
+								className="text-text-2 hover:text-text-1 p-2 -m-2"
+								aria-label="Close"
+							>
+								<X className="w-4 h-4" />
+							</button>
+						</Dialog.Close>
+					</div>
+
+					<form onSubmit={handleSubmit} className="flex flex-col gap-4">
+						<Input
+							label="Title"
+							value={title}
+							onChange={(e) => setTitle(e.target.value)}
+							required
+						/>
+
+						<label className="flex flex-col gap-1.5">
+							<span className="text-sm text-text-2">Description</span>
+							<textarea
+								value={description}
+								onChange={(e) => setDescription(e.target.value)}
+								placeholder="Optional"
+								rows={4}
+								className="rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-text-1 outline-none focus:border-border-strong"
+							/>
+							<span className="text-xs text-text-3">
+								Make it Specific, Measurable, Achievable, Relevant, and Time-bound.
+							</span>
+						</label>
+
+						<div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+							<label className="flex flex-col gap-1.5">
+								<span className="text-sm text-text-2">Check frequency</span>
+								<select
+									value={checkFrequency}
+									onChange={(e) => setCheckFrequency(e.target.value as GoalCheckFrequency)}
+									className="rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-text-1 outline-none focus:border-border-strong"
+								>
+									{Object.entries(GOAL_CHECK_FREQUENCY_LABELS).map(([value, label]) => (
+										<option key={value} value={value}>
+											{label}
+										</option>
+									))}
+								</select>
+							</label>
+
+							<label className="flex flex-col gap-1.5">
+								<span className="text-sm text-text-2">Target date</span>
+								<input
+									type="date"
+									value={targetDate}
+									onChange={(e) => setTargetDate(e.target.value)}
+									className="rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-text-1 outline-none focus:border-border-strong"
+								/>
+							</label>
+						</div>
+
+						{createGoal.error && (
+							<p className="text-sm text-danger">
+								{(createGoal.error as { message: string }).message}
+							</p>
+						)}
+
+						<div className="flex justify-end gap-2 mt-2">
+							<Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
+								Cancel
+							</Button>
+							<Button type="submit" disabled={!title.trim() || createGoal.isPending}>
+								{createGoal.isPending && <Loader2 className="w-4 h-4 animate-spin" />}
+								Create
+							</Button>
+						</div>
+					</form>
+				</Dialog.Content>
+			</Dialog.Portal>
+		</Dialog.Root>
+	);
+}

--- a/packages/web/src/components/create-goal-dialog.tsx
+++ b/packages/web/src/components/create-goal-dialog.tsx
@@ -1,8 +1,13 @@
-import { GOAL_CHECK_FREQUENCY_LABELS, GoalCheckFrequency } from '@hezo/shared';
+import {
+	GOAL_CHECK_FREQUENCY_LABELS,
+	GoalCheckFrequency,
+	type GoalWithProject,
+} from '@hezo/shared';
 import * as Dialog from '@radix-ui/react-dialog';
 import { Loader2, X } from 'lucide-react';
-import { useState } from 'react';
-import { useCreateGoal } from '../hooks/use-goals';
+import { useEffect, useState } from 'react';
+import { useCreateGoal, useUpdateGoal } from '../hooks/use-goals';
+import { GoalSmartGuidance } from './goal-smart-guidance';
 import { Button } from './ui/button';
 import { dialogContentClassName, dialogOverlayClassName } from './ui/dialog';
 import { Input } from './ui/input';
@@ -11,34 +16,59 @@ interface CreateGoalDialogProps {
 	projectId: string;
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
+	/** When set, the dialog edits this goal instead of creating a new one. */
+	goal?: GoalWithProject | null;
 }
 
-export function CreateGoalDialog({ projectId, open, onOpenChange }: CreateGoalDialogProps) {
+const textareaClass =
+	'rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-text-1 outline-none focus:border-border-strong';
+
+export function CreateGoalDialog({ projectId, open, onOpenChange, goal }: CreateGoalDialogProps) {
+	const isEdit = !!goal;
 	const [title, setTitle] = useState('');
-	const [description, setDescription] = useState('');
+	const [measurement, setMeasurement] = useState('');
+	const [actions, setActions] = useState('');
 	const [checkFrequency, setCheckFrequency] = useState<GoalCheckFrequency>(
 		GoalCheckFrequency.Daily,
 	);
 	const [targetDate, setTargetDate] = useState('');
-	const createGoal = useCreateGoal(projectId);
 
-	function reset() {
-		setTitle('');
-		setDescription('');
-		setCheckFrequency(GoalCheckFrequency.Daily);
-		setTargetDate('');
-	}
+	const createGoal = useCreateGoal(projectId);
+	const updateGoal = useUpdateGoal(projectId, goal?.id ?? '');
+	const pending = createGoal.isPending || updateGoal.isPending;
+	const error = (createGoal.error ?? updateGoal.error) as { message: string } | null;
+
+	// Seed the form from the goal being edited (or clear it for a fresh create) whenever the
+	// dialog opens or the target goal changes.
+	useEffect(() => {
+		if (!open) return;
+		setTitle(goal?.title ?? '');
+		setMeasurement(goal?.measurement ?? '');
+		setActions(goal?.actions ?? '');
+		setCheckFrequency((goal?.check_frequency as GoalCheckFrequency) ?? GoalCheckFrequency.Daily);
+		setTargetDate(goal?.target_date ?? '');
+	}, [open, goal]);
 
 	async function handleSubmit(e: React.FormEvent) {
 		e.preventDefault();
-		await createGoal.mutateAsync({
-			title,
-			description: description || undefined,
-			check_frequency: checkFrequency,
-			target_date: targetDate || undefined,
-		});
+		if (isEdit) {
+			await updateGoal.mutateAsync({
+				title,
+				measurement,
+				actions,
+				check_frequency: checkFrequency,
+				target_date: targetDate || null,
+			});
+		} else {
+			await createGoal.mutateAsync({
+				title,
+				measurement: measurement || undefined,
+				actions: actions || undefined,
+				check_frequency: checkFrequency,
+				target_date: targetDate || undefined,
+			});
+		}
 		onOpenChange(false);
-		reset();
 	}
 
 	return (
@@ -47,7 +77,9 @@ export function CreateGoalDialog({ projectId, open, onOpenChange }: CreateGoalDi
 				<Dialog.Overlay className={dialogOverlayClassName} />
 				<Dialog.Content className={dialogContentClassName.lg}>
 					<div className="flex items-center justify-between mb-4">
-						<Dialog.Title className="text-lg font-semibold">Create Goal</Dialog.Title>
+						<Dialog.Title className="text-lg font-semibold">
+							{isEdit ? 'Edit Goal' : 'Create Goal'}
+						</Dialog.Title>
 						<Dialog.Close asChild>
 							<button
 								type="button"
@@ -60,25 +92,38 @@ export function CreateGoalDialog({ projectId, open, onOpenChange }: CreateGoalDi
 					</div>
 
 					<form onSubmit={handleSubmit} className="flex flex-col gap-4">
+						<GoalSmartGuidance />
+
 						<Input
-							label="Title"
+							label="Goal name"
 							value={title}
 							onChange={(e) => setTitle(e.target.value)}
+							placeholder="e.g. Reach 100 paying customers"
 							required
 						/>
 
 						<label className="flex flex-col gap-1.5">
-							<span className="text-sm text-text-2">Description</span>
+							<span className="text-sm text-text-2">Measurement</span>
 							<textarea
-								value={description}
-								onChange={(e) => setDescription(e.target.value)}
-								placeholder="Optional"
-								rows={4}
-								className="rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-text-1 outline-none focus:border-border-strong"
+								value={measurement}
+								onChange={(e) => setMeasurement(e.target.value)}
+								placeholder="How will you know this goal is achieved? Be precise — this is the bar the Captain measures against."
+								rows={3}
+								className={textareaClass}
 							/>
-							<span className="text-xs text-text-3">
-								Make it Specific, Measurable, Achievable, Relevant, and Time-bound.
+						</label>
+
+						<label className="flex flex-col gap-1.5">
+							<span className="text-sm text-text-2">
+								Suggested actions <span className="text-text-3">(optional)</span>
 							</span>
+							<textarea
+								value={actions}
+								onChange={(e) => setActions(e.target.value)}
+								placeholder="Optional — specific actions or checks the Captain should take toward this goal (e.g. run a weekly cron-style check of the signup funnel)."
+								rows={3}
+								className={textareaClass}
+							/>
 						</label>
 
 						<div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -98,7 +143,9 @@ export function CreateGoalDialog({ projectId, open, onOpenChange }: CreateGoalDi
 							</label>
 
 							<label className="flex flex-col gap-1.5">
-								<span className="text-sm text-text-2">Target date</span>
+								<span className="text-sm text-text-2">
+									Deadline <span className="text-text-3">(optional)</span>
+								</span>
 								<input
 									type="date"
 									value={targetDate}
@@ -108,19 +155,15 @@ export function CreateGoalDialog({ projectId, open, onOpenChange }: CreateGoalDi
 							</label>
 						</div>
 
-						{createGoal.error && (
-							<p className="text-sm text-danger">
-								{(createGoal.error as { message: string }).message}
-							</p>
-						)}
+						{error && <p className="text-sm text-danger">{error.message}</p>}
 
 						<div className="flex justify-end gap-2 mt-2">
 							<Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
 								Cancel
 							</Button>
-							<Button type="submit" disabled={!title.trim() || createGoal.isPending}>
-								{createGoal.isPending && <Loader2 className="w-4 h-4 animate-spin" />}
-								Create
+							<Button type="submit" disabled={!title.trim() || pending}>
+								{pending && <Loader2 className="w-4 h-4 animate-spin" />}
+								{isEdit ? 'Save' : 'Create'}
 							</Button>
 						</div>
 					</form>

--- a/packages/web/src/components/goal-health-pill.tsx
+++ b/packages/web/src/components/goal-health-pill.tsx
@@ -1,0 +1,27 @@
+import { formatGoalHealth, GoalHealth } from '@hezo/shared';
+import { Badge, type BadgeColor } from './ui/badge';
+
+interface GoalHealthPillProps {
+	health: string;
+	testId?: string;
+}
+
+const HEALTH_COLOR: Record<string, BadgeColor> = {
+	[GoalHealth.Pending]: 'neutral',
+	[GoalHealth.OnTrack]: 'success',
+	[GoalHealth.AtRisk]: 'warning',
+	[GoalHealth.OffTrack]: 'danger',
+};
+
+/**
+ * Small pill summarising a goal's health. Colour follows the design tokens:
+ * pending → neutral, on_track → green, at_risk → amber, off_track → red.
+ */
+export function GoalHealthPill({ health, testId }: GoalHealthPillProps) {
+	const color = HEALTH_COLOR[health] ?? 'neutral';
+	return (
+		<Badge color={color} testId={testId}>
+			{formatGoalHealth(health)}
+		</Badge>
+	);
+}

--- a/packages/web/src/components/goal-progress-chart.tsx
+++ b/packages/web/src/components/goal-progress-chart.tsx
@@ -1,0 +1,118 @@
+import { type GoalHealth, GoalHealth as GoalHealthEnum, type GoalHistoryPoint } from '@hezo/shared';
+import { useMemo } from 'react';
+import {
+	CartesianGrid,
+	Line,
+	LineChart,
+	ResponsiveContainer,
+	Tooltip,
+	XAxis,
+	YAxis,
+} from 'recharts';
+
+interface GoalProgressChartProps {
+	history: GoalHistoryPoint[];
+	/** 'compact' = small inline line (no axes); 'full' = axes + grid + tooltip. */
+	size?: 'compact' | 'full';
+}
+
+/** Line colour reflecting the latest health snapshot. */
+const HEALTH_STROKE: Record<GoalHealth, string> = {
+	[GoalHealthEnum.Pending]: 'var(--color-text-3)',
+	[GoalHealthEnum.OnTrack]: 'var(--color-success)',
+	[GoalHealthEnum.AtRisk]: 'var(--color-warning)',
+	[GoalHealthEnum.OffTrack]: 'var(--color-danger)',
+};
+
+interface ChartDatum {
+	t: string;
+	label: string;
+	percent: number;
+}
+
+function formatTime(iso: string): string {
+	const d = new Date(iso);
+	if (Number.isNaN(d.getTime())) return iso;
+	return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+/**
+ * A line chart of a goal's progress over time. Degrades gracefully: 0 points
+ * renders a muted placeholder, 1 point renders a single dot. The line colour
+ * follows the latest health snapshot.
+ */
+export function GoalProgressChart({ history, size = 'compact' }: GoalProgressChartProps) {
+	const data = useMemo<ChartDatum[]>(
+		() =>
+			[...history]
+				.sort((a, b) => a.t.localeCompare(b.t))
+				.map((p) => ({ t: p.t, label: formatTime(p.t), percent: p.percent })),
+		[history],
+	);
+
+	const stroke = useMemo(() => {
+		const latest = data.length > 0 ? history[history.length - 1]?.health : undefined;
+		return (latest && HEALTH_STROKE[latest]) || 'var(--color-accent)';
+	}, [data.length, history]);
+
+	const compact = size === 'compact';
+	const heightClass = compact ? 'h-16' : 'h-[200px]';
+
+	if (data.length === 0) {
+		return (
+			<div
+				className={`${heightClass} w-full flex items-center justify-center rounded-md border border-border-subtle bg-surface-2 text-[11px] text-text-3`}
+				data-testid="goal-progress-empty"
+			>
+				No history yet
+			</div>
+		);
+	}
+
+	// A single point can't draw a line; render it as a dot so the panel still
+	// communicates "one snapshot so far".
+	const singlePoint = data.length === 1;
+
+	return (
+		<div className={`${heightClass} w-full`} data-testid="goal-progress-chart">
+			<ResponsiveContainer width="100%" height="100%">
+				<LineChart
+					data={data}
+					margin={
+						compact
+							? { top: 4, right: 4, bottom: 4, left: 4 }
+							: { top: 8, right: 8, bottom: 0, left: -16 }
+					}
+				>
+					{!compact && <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />}
+					{!compact && (
+						<XAxis dataKey="label" tick={{ fontSize: 11 }} stroke="var(--color-text-3)" />
+					)}
+					{!compact && (
+						<YAxis
+							domain={[0, 100]}
+							tick={{ fontSize: 11 }}
+							stroke="var(--color-text-3)"
+							unit="%"
+						/>
+					)}
+					{compact && <YAxis domain={[0, 100]} hide />}
+					{!compact && (
+						<Tooltip
+							formatter={(value) => `${Math.round(Number(value))}%`}
+							contentStyle={{ fontSize: 12 }}
+						/>
+					)}
+					<Line
+						type="monotone"
+						dataKey="percent"
+						stroke={stroke}
+						strokeWidth={2}
+						dot={singlePoint ? { r: 3, fill: stroke } : false}
+						isAnimationActive={false}
+					/>
+				</LineChart>
+			</ResponsiveContainer>
+		</div>
+	);
+}

--- a/packages/web/src/components/goal-smart-guidance.tsx
+++ b/packages/web/src/components/goal-smart-guidance.tsx
@@ -1,0 +1,29 @@
+import { GOAL_SMART_GUIDANCE } from '@hezo/shared';
+
+/**
+ * Compact SMART-goal reminder shown on the goal create/edit surfaces and the Goals page, so the
+ * admin keeps the framework in mind while writing or editing a goal. Content comes from the
+ * shared `GOAL_SMART_GUIDANCE` so every surface stays in sync.
+ */
+export function GoalSmartGuidance({ className = '' }: { className?: string }) {
+	return (
+		<div
+			data-testid="goal-smart-guidance"
+			className={`rounded-md border border-border bg-surface-2 p-3 ${className}`}
+		>
+			<p className="text-xs font-medium text-text-2 mb-2">
+				Good goals are <span className="font-semibold text-text-1">SMART</span>:
+			</p>
+			<ul className="flex flex-col gap-1">
+				{GOAL_SMART_GUIDANCE.map((item) => (
+					<li key={item.letter} className="text-xs text-text-3 leading-relaxed">
+						<span className="font-semibold text-text-2">
+							{item.letter} — {item.label}:
+						</span>{' '}
+						{item.hint}
+					</li>
+				))}
+			</ul>
+		</div>
+	);
+}

--- a/packages/web/src/components/goals-list.tsx
+++ b/packages/web/src/components/goals-list.tsx
@@ -1,0 +1,181 @@
+import {
+	GOAL_CHECK_FREQUENCY_LABELS,
+	type GoalCheckRunSummary,
+	type GoalWithProject,
+	HeartbeatRunStatus,
+} from '@hezo/shared';
+import { Archive, Plus, Target } from 'lucide-react';
+import { useState } from 'react';
+import { useArchiveGoal, useGoalRuns, useGoals } from '../hooks/use-goals';
+import { CreateGoalDialog } from './create-goal-dialog';
+import { GoalHealthPill } from './goal-health-pill';
+import { GoalProgressChart } from './goal-progress-chart';
+import { Button } from './ui/button';
+import { EmptyState } from './ui/empty-state';
+
+interface GoalsListProps {
+	projectId: string;
+}
+
+function formatTargetDate(iso: string): string {
+	const d = new Date(iso);
+	if (Number.isNaN(d.getTime())) return iso;
+	return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+function formatRunTime(run: GoalCheckRunSummary): string {
+	const iso = run.finished_at ?? run.started_at ?? run.created_at;
+	const d = new Date(iso);
+	if (Number.isNaN(d.getTime())) return iso;
+	return d.toLocaleString(undefined, {
+		month: 'short',
+		day: 'numeric',
+		hour: 'numeric',
+		minute: '2-digit',
+	});
+}
+
+function GoalPanel({ projectId, goal }: { projectId: string; goal: GoalWithProject }) {
+	const archiveGoal = useArchiveGoal(projectId);
+	const percent = Math.max(0, Math.min(100, Math.round(goal.progress_percent)));
+
+	return (
+		<div
+			data-testid="goal-panel"
+			className="flex flex-col gap-3 rounded-md border border-border bg-surface p-4"
+		>
+			<div className="flex items-start justify-between gap-2">
+				<div className="flex flex-col gap-1.5 min-w-0">
+					<h3 className="text-sm font-semibold text-text-1 break-words">{goal.title}</h3>
+					<GoalHealthPill health={goal.health} testId="goal-health-pill" />
+				</div>
+				<button
+					type="button"
+					onClick={() => archiveGoal.mutate(goal.id)}
+					disabled={archiveGoal.isPending}
+					aria-label="Archive goal"
+					title="Archive goal"
+					data-testid="goal-archive"
+					className="shrink-0 text-text-3 hover:text-text-1 transition-colors p-1 -m-1 disabled:opacity-50"
+				>
+					<Archive className="w-4 h-4" />
+				</button>
+			</div>
+
+			<div className="flex flex-col gap-1.5">
+				<div className="flex items-baseline justify-between">
+					<span className="text-2xl font-semibold text-text-1">{percent}%</span>
+				</div>
+				<div className="h-2 w-full overflow-hidden rounded-full bg-surface-3">
+					<div
+						className="h-full rounded-full bg-accent-solid transition-all"
+						style={{ width: `${percent}%` }}
+						data-testid="goal-progress-bar"
+					/>
+				</div>
+			</div>
+
+			<GoalProgressChart history={goal.history} size="compact" />
+
+			{goal.status_blurb && (
+				<p className="text-[13px] text-text-2 leading-relaxed break-words">{goal.status_blurb}</p>
+			)}
+
+			<div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-text-3">
+				<span>{GOAL_CHECK_FREQUENCY_LABELS[goal.check_frequency]}</span>
+				{goal.target_date && <span>Target: {formatTargetDate(goal.target_date)}</span>}
+			</div>
+		</div>
+	);
+}
+
+function GoalChecksFooter({ projectId }: { projectId: string }) {
+	const { data: runs, isLoading } = useGoalRuns(projectId);
+
+	if (isLoading || !runs || runs.length === 0) return null;
+
+	return (
+		<section data-testid="goal-checks" className="mt-8">
+			<h2 className="text-[11px] font-medium uppercase tracking-wider text-text-3 mb-2 px-0.5">
+				Goal checks
+			</h2>
+			<ul className="flex flex-col divide-y divide-border rounded-md border border-border bg-surface">
+				{runs.map((run) => {
+					const updated = run.updated_goal_titles.length > 0;
+					return (
+						<li
+							key={run.id}
+							data-testid="goal-check-run"
+							className="flex flex-col gap-0.5 px-3 py-2 sm:flex-row sm:items-center sm:justify-between sm:gap-3"
+						>
+							<span className="text-[13px] text-text-2">
+								{formatRunTime(run)}
+								{run.status !== HeartbeatRunStatus.Succeeded && (
+									<span className="ml-2 text-text-3">({run.status})</span>
+								)}
+							</span>
+							<span className="text-xs text-text-3 break-words">
+								{updated ? `Updated goals: ${run.updated_goal_titles.join(', ')}` : 'No changes'}
+							</span>
+						</li>
+					);
+				})}
+			</ul>
+		</section>
+	);
+}
+
+export function GoalsList({ projectId }: GoalsListProps) {
+	const { data: goals, isLoading } = useGoals(projectId);
+	const [createOpen, setCreateOpen] = useState(false);
+
+	if (isLoading) {
+		return (
+			<div data-testid="goals-list-loading" className="text-text-2 text-[13px] py-8 text-center">
+				Loading...
+			</div>
+		);
+	}
+
+	if (!goals || goals.length === 0) {
+		return (
+			<div>
+				<EmptyState
+					variant="hero"
+					icon={<Target className="w-8 h-8" />}
+					title="No goals yet"
+					description="Create the first goal for the team to work towards"
+					action={
+						<Button size="lg" onClick={() => setCreateOpen(true)} data-testid="goals-empty-create">
+							<Plus className="w-4 h-4" />
+							Create Goal
+						</Button>
+					}
+				/>
+				<CreateGoalDialog projectId={projectId} open={createOpen} onOpenChange={setCreateOpen} />
+			</div>
+		);
+	}
+
+	return (
+		<div>
+			<div className="mb-4 flex items-center justify-between gap-2">
+				<h1 className="text-lg font-semibold text-text-1">Goals</h1>
+				<Button onClick={() => setCreateOpen(true)} data-testid="goals-new-goal">
+					<Plus className="w-4 h-4" />
+					New goal
+				</Button>
+			</div>
+
+			<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+				{goals.map((goal) => (
+					<GoalPanel key={goal.id} projectId={projectId} goal={goal} />
+				))}
+			</div>
+
+			<GoalChecksFooter projectId={projectId} />
+
+			<CreateGoalDialog projectId={projectId} open={createOpen} onOpenChange={setCreateOpen} />
+		</div>
+	);
+}

--- a/packages/web/src/components/goals-list.tsx
+++ b/packages/web/src/components/goals-list.tsx
@@ -4,18 +4,21 @@ import {
 	type GoalWithProject,
 	HeartbeatRunStatus,
 } from '@hezo/shared';
-import { Archive, Plus, Target } from 'lucide-react';
+import { Archive, ArchiveRestore, Pencil, Plus, Target } from 'lucide-react';
 import { useState } from 'react';
-import { useArchiveGoal, useGoalRuns, useGoals } from '../hooks/use-goals';
+import { useGoalRuns, useGoals, useUpdateGoal } from '../hooks/use-goals';
 import { CreateGoalDialog } from './create-goal-dialog';
 import { GoalHealthPill } from './goal-health-pill';
 import { GoalProgressChart } from './goal-progress-chart';
+import { GoalSmartGuidance } from './goal-smart-guidance';
 import { Button } from './ui/button';
 import { EmptyState } from './ui/empty-state';
 
 interface GoalsListProps {
 	projectId: string;
 }
+
+type GoalView = 'active' | 'archived';
 
 function formatTargetDate(iso: string): string {
 	const d = new Date(iso);
@@ -35,31 +38,54 @@ function formatRunTime(run: GoalCheckRunSummary): string {
 	});
 }
 
-function GoalPanel({ projectId, goal }: { projectId: string; goal: GoalWithProject }) {
-	const archiveGoal = useArchiveGoal(projectId);
+function GoalPanel({
+	projectId,
+	goal,
+	onEdit,
+}: {
+	projectId: string;
+	goal: GoalWithProject;
+	onEdit: (goal: GoalWithProject) => void;
+}) {
+	const updateGoal = useUpdateGoal(projectId, goal.id);
+	const isArchived = !!goal.archived_at;
 	const percent = Math.max(0, Math.min(100, Math.round(goal.progress_percent)));
 
 	return (
 		<div
 			data-testid="goal-panel"
-			className="flex flex-col gap-3 rounded-md border border-border bg-surface p-4"
+			className={`flex flex-col gap-3 rounded-md border border-border bg-surface p-4 ${
+				isArchived ? 'opacity-70' : ''
+			}`}
 		>
 			<div className="flex items-start justify-between gap-2">
 				<div className="flex flex-col gap-1.5 min-w-0">
 					<h3 className="text-sm font-semibold text-text-1 break-words">{goal.title}</h3>
 					<GoalHealthPill health={goal.health} testId="goal-health-pill" />
 				</div>
-				<button
-					type="button"
-					onClick={() => archiveGoal.mutate(goal.id)}
-					disabled={archiveGoal.isPending}
-					aria-label="Archive goal"
-					title="Archive goal"
-					data-testid="goal-archive"
-					className="shrink-0 text-text-3 hover:text-text-1 transition-colors p-1 -m-1 disabled:opacity-50"
-				>
-					<Archive className="w-4 h-4" />
-				</button>
+				<div className="flex shrink-0 items-center gap-0.5">
+					<button
+						type="button"
+						onClick={() => onEdit(goal)}
+						aria-label="Edit goal"
+						title="Edit goal"
+						data-testid="goal-edit"
+						className="text-text-3 hover:text-text-1 transition-colors p-1"
+					>
+						<Pencil className="w-4 h-4" />
+					</button>
+					<button
+						type="button"
+						onClick={() => updateGoal.mutate({ archived: !isArchived })}
+						disabled={updateGoal.isPending}
+						aria-label={isArchived ? 'Unarchive goal' : 'Archive goal'}
+						title={isArchived ? 'Unarchive goal' : 'Archive goal'}
+						data-testid="goal-archive"
+						className="text-text-3 hover:text-text-1 transition-colors p-1 disabled:opacity-50"
+					>
+						{isArchived ? <ArchiveRestore className="w-4 h-4" /> : <Archive className="w-4 h-4" />}
+					</button>
+				</div>
 			</div>
 
 			<div className="flex flex-col gap-1.5">
@@ -81,9 +107,21 @@ function GoalPanel({ projectId, goal }: { projectId: string; goal: GoalWithProje
 				<p className="text-[13px] text-text-2 leading-relaxed break-words">{goal.status_blurb}</p>
 			)}
 
+			{goal.measurement && (
+				<p className="text-xs text-text-3 leading-relaxed break-words">
+					<span className="font-medium text-text-2">Achieved when:</span> {goal.measurement}
+				</p>
+			)}
+			{goal.actions && (
+				<p className="text-xs text-text-3 leading-relaxed break-words">
+					<span className="font-medium text-text-2">Actions:</span> {goal.actions}
+				</p>
+			)}
+
 			<div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-text-3">
 				<span>{GOAL_CHECK_FREQUENCY_LABELS[goal.check_frequency]}</span>
-				{goal.target_date && <span>Target: {formatTargetDate(goal.target_date)}</span>}
+				{goal.target_date && <span>Deadline: {formatTargetDate(goal.target_date)}</span>}
+				{isArchived && <span className="text-text-2">Archived</span>}
 			</div>
 		</div>
 	);
@@ -125,9 +163,42 @@ function GoalChecksFooter({ projectId }: { projectId: string }) {
 	);
 }
 
+function ViewFilter({ view, onChange }: { view: GoalView; onChange: (v: GoalView) => void }) {
+	return (
+		<div
+			data-testid="goals-view-filter"
+			className="inline-flex rounded-md border border-border bg-surface p-0.5 text-xs"
+		>
+			{(['active', 'archived'] as const).map((v) => (
+				<button
+					key={v}
+					type="button"
+					onClick={() => onChange(v)}
+					data-testid={`goals-view-${v}`}
+					className={`rounded px-2.5 py-1 capitalize transition-colors ${
+						view === v ? 'bg-surface-3 text-text-1' : 'text-text-3 hover:text-text-1'
+					}`}
+				>
+					{v}
+				</button>
+			))}
+		</div>
+	);
+}
+
 export function GoalsList({ projectId }: GoalsListProps) {
-	const { data: goals, isLoading } = useGoals(projectId);
+	const [view, setView] = useState<GoalView>('active');
 	const [createOpen, setCreateOpen] = useState(false);
+	const [editingGoal, setEditingGoal] = useState<GoalWithProject | null>(null);
+
+	// Active view fetches only live goals; archived view fetches everything and filters to the
+	// archived ones, so the same query cache backs both tabs.
+	const { data: allGoals, isLoading } = useGoals(projectId, {
+		includeArchived: view === 'archived',
+	});
+	const goals = (allGoals ?? []).filter((g) =>
+		view === 'archived' ? !!g.archived_at : !g.archived_at,
+	);
 
 	if (isLoading) {
 		return (
@@ -137,7 +208,8 @@ export function GoalsList({ projectId }: GoalsListProps) {
 		);
 	}
 
-	if (!goals || goals.length === 0) {
+	// First-run empty state (no goals at all): the hero CTA. Shown only on the active tab.
+	if (view === 'active' && goals.length === 0) {
 		return (
 			<div>
 				<EmptyState
@@ -159,23 +231,48 @@ export function GoalsList({ projectId }: GoalsListProps) {
 
 	return (
 		<div>
-			<div className="mb-4 flex items-center justify-between gap-2">
-				<h1 className="text-lg font-semibold text-text-1">Goals</h1>
+			<div className="mb-4 flex flex-wrap items-center justify-between gap-2">
+				<div className="flex items-center gap-3">
+					<h1 className="text-lg font-semibold text-text-1">Goals</h1>
+					<ViewFilter view={view} onChange={setView} />
+				</div>
 				<Button onClick={() => setCreateOpen(true)} data-testid="goals-new-goal">
 					<Plus className="w-4 h-4" />
 					New goal
 				</Button>
 			</div>
 
-			<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-				{goals.map((goal) => (
-					<GoalPanel key={goal.id} projectId={projectId} goal={goal} />
-				))}
-			</div>
+			<details
+				className="mb-4 rounded-md border border-border bg-surface px-3 py-2"
+				data-testid="goals-smart-disclosure"
+			>
+				<summary className="cursor-pointer text-xs text-text-2 select-none">
+					What makes a good goal? (SMART)
+				</summary>
+				<GoalSmartGuidance className="mt-2 border-0 bg-transparent p-0" />
+			</details>
+
+			{goals.length === 0 ? (
+				<div className="py-12 text-center text-[13px] text-text-3" data-testid="goals-empty-view">
+					{view === 'archived' ? 'No archived goals.' : 'No active goals.'}
+				</div>
+			) : (
+				<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+					{goals.map((goal) => (
+						<GoalPanel key={goal.id} projectId={projectId} goal={goal} onEdit={setEditingGoal} />
+					))}
+				</div>
+			)}
 
 			<GoalChecksFooter projectId={projectId} />
 
 			<CreateGoalDialog projectId={projectId} open={createOpen} onOpenChange={setCreateOpen} />
+			<CreateGoalDialog
+				projectId={projectId}
+				goal={editingGoal}
+				open={!!editingGoal}
+				onOpenChange={(o) => !o && setEditingGoal(null)}
+			/>
 		</div>
 	);
 }

--- a/packages/web/src/components/project-sidebar.tsx
+++ b/packages/web/src/components/project-sidebar.tsx
@@ -5,10 +5,12 @@ import { useState } from 'react';
 import { useActiveProject } from '../hooks/use-active-project';
 import { useAgents } from '../hooks/use-agents';
 import { useContainerHealth } from '../hooks/use-container-health';
+import { useGoals } from '../hooks/use-goals';
 import { useInboxUnreadCount } from '../hooks/use-inbox-count';
 import { useProjectMeta } from '../hooks/use-projects';
 import { agentPageParams } from './agent-link';
 import { AgentStatusLabel } from './agent-status-label';
+import { CreateGoalDialog } from './create-goal-dialog';
 import { CreateTaskDialog } from './create-task-dialog';
 import { SidebarNav, type SidebarNavSection } from './sidebar-nav';
 import { Tooltip } from './ui/tooltip';
@@ -39,6 +41,13 @@ export function ProjectSidebar() {
 	const { data: agents } = useAgents(projectId);
 	const [teamCollapsed, setTeamCollapsed] = useState(readTeamCollapsed);
 	const [createTaskOpen, setCreateTaskOpen] = useState(false);
+	const [createGoalOpen, setCreateGoalOpen] = useState(false);
+	// Goals are a project concept only (HQ has none); fetch only for normal projects.
+	const isInternalProject = project?.is_internal ?? false;
+	const { data: goals, isLoading: goalsLoading } = useGoals(projectId, {
+		enabled: !!projectId && !isInternalProject,
+	});
+	const hasNoGoals = !isInternalProject && !goalsLoading && (goals?.length ?? 0) === 0;
 
 	if (!active) return null;
 
@@ -115,6 +124,36 @@ export function ProjectSidebar() {
 				testId: 'project-sidebar-new-task',
 			},
 		},
+		// Goals are a normal-project concept; HQ (internal) has none.
+		...(isInternal
+			? []
+			: [
+					{
+						to: '/projects/$projectId/goals',
+						params: projectParams,
+						label: (
+							<span className="inline-flex items-center gap-1.5">
+								<span>Goals</span>
+								{hasNoGoals && (
+									<Tooltip content="No goals yet — create one to focus the team" side="right">
+										<span
+											role="img"
+											aria-label="No goals yet"
+											data-testid="project-sidebar-goals-empty-dot"
+											className="inline-block w-2 h-2 rounded-full bg-info animate-pulse shrink-0"
+										/>
+									</Tooltip>
+								)}
+							</span>
+						),
+						testId: 'project-sidebar-goals',
+						action: {
+							onClick: () => setCreateGoalOpen(true),
+							label: 'New goal',
+							testId: 'project-sidebar-new-goal',
+						},
+					},
+				]),
 		// HQ (internal) exposes Documents (the chatbox memory doc) and Assets (where
 		// the CEO saves files it produces for the operator in chat); Budget and
 		// Settings stay hidden below.
@@ -247,6 +286,11 @@ export function ProjectSidebar() {
 				projectId={projectId}
 				open={createTaskOpen}
 				onOpenChange={setCreateTaskOpen}
+			/>
+			<CreateGoalDialog
+				projectId={projectId}
+				open={createGoalOpen}
+				onOpenChange={setCreateGoalOpen}
 			/>
 		</div>
 	);

--- a/packages/web/src/components/project-sidebar.tsx
+++ b/packages/web/src/components/project-sidebar.tsx
@@ -5,7 +5,6 @@ import { useState } from 'react';
 import { useActiveProject } from '../hooks/use-active-project';
 import { useAgents } from '../hooks/use-agents';
 import { useContainerHealth } from '../hooks/use-container-health';
-import { useGoals } from '../hooks/use-goals';
 import { useInboxUnreadCount } from '../hooks/use-inbox-count';
 import { useProjectMeta } from '../hooks/use-projects';
 import { agentPageParams } from './agent-link';
@@ -42,12 +41,11 @@ export function ProjectSidebar() {
 	const [teamCollapsed, setTeamCollapsed] = useState(readTeamCollapsed);
 	const [createTaskOpen, setCreateTaskOpen] = useState(false);
 	const [createGoalOpen, setCreateGoalOpen] = useState(false);
-	// Goals are a project concept only (HQ has none); fetch only for normal projects.
+	// Goals are a project concept only (HQ has none). Use the open_goal_count carried on the
+	// project-detail payload rather than a separate per-page goals fetch — the dot shows only
+	// once the project has loaded and reports zero active goals.
 	const isInternalProject = project?.is_internal ?? false;
-	const { data: goals, isLoading: goalsLoading } = useGoals(projectId, {
-		enabled: !!projectId && !isInternalProject,
-	});
-	const hasNoGoals = !isInternalProject && !goalsLoading && (goals?.length ?? 0) === 0;
+	const hasNoGoals = !isInternalProject && project != null && (project.open_goal_count ?? 0) === 0;
 
 	if (!active) return null;
 

--- a/packages/web/src/hooks/use-goals.ts
+++ b/packages/web/src/hooks/use-goals.ts
@@ -37,7 +37,8 @@ export function useGoalRuns(projectId: string) {
 
 interface CreateGoalVars {
 	title: string;
-	description?: string;
+	measurement?: string;
+	actions?: string;
 	check_frequency?: GoalCheckFrequency;
 	target_date?: string;
 }
@@ -55,7 +56,8 @@ export function useCreateGoal(projectId: string) {
 
 interface UpdateGoalVars {
 	title?: string;
-	description?: string;
+	measurement?: string;
+	actions?: string;
 	check_frequency?: GoalCheckFrequency;
 	target_date?: string | null;
 	archived?: boolean;

--- a/packages/web/src/hooks/use-goals.ts
+++ b/packages/web/src/hooks/use-goals.ts
@@ -1,0 +1,90 @@
+import type { GoalCheckFrequency, GoalCheckRunSummary, GoalWithProject } from '@hezo/shared';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { api } from '../lib/api';
+import { queryClient } from '../lib/query-client';
+import { queryKeys } from '../lib/query-keys';
+import { useOptimisticMutation } from './use-optimistic-mutation';
+
+export type { GoalCheckRunSummary, GoalWithProject };
+
+interface UseGoalsOptions {
+	includeArchived?: boolean;
+	enabled?: boolean;
+}
+
+/** The active project's goals (optionally including archived ones), with embedded history. */
+export function useGoals(projectId: string, options?: UseGoalsOptions) {
+	const includeArchived = options?.includeArchived ?? false;
+	const filters = { include_archived: includeArchived };
+	return useQuery({
+		queryKey: queryKeys.projects.goalsFiltered(projectId, filters),
+		queryFn: () =>
+			api.get<GoalWithProject[]>(
+				`/api/projects/${projectId}/goals`,
+				includeArchived ? { include_archived: 'true' } : undefined,
+			),
+		enabled: options?.enabled ?? true,
+	});
+}
+
+/** The goal-check runs for this project (newest-first as returned by the server). */
+export function useGoalRuns(projectId: string) {
+	return useQuery({
+		queryKey: queryKeys.projects.goalRuns(projectId),
+		queryFn: () => api.get<GoalCheckRunSummary[]>(`/api/projects/${projectId}/goals/runs`),
+	});
+}
+
+interface CreateGoalVars {
+	title: string;
+	description?: string;
+	check_frequency?: GoalCheckFrequency;
+	target_date?: string;
+}
+
+/** Response-driven create: the server assigns id/health/etc, so seed from the response. */
+export function useCreateGoal(projectId: string) {
+	return useMutation({
+		mutationFn: (data: CreateGoalVars) =>
+			api.post<GoalWithProject>(`/api/projects/${projectId}/goals`, data),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: queryKeys.projects.goals(projectId) });
+		},
+	});
+}
+
+interface UpdateGoalVars {
+	title?: string;
+	description?: string;
+	check_frequency?: GoalCheckFrequency;
+	target_date?: string | null;
+	archived?: boolean;
+}
+
+/** Optimistic field edits against a goal's detail cache, re-flowing the list on settle. */
+export function useUpdateGoal(projectId: string, goalId: string) {
+	return useOptimisticMutation<UpdateGoalVars, GoalWithProject, GoalWithProject>({
+		mutationFn: (vars) =>
+			api.patch<GoalWithProject>(`/api/projects/${projectId}/goals/${goalId}`, vars),
+		queryKey: queryKeys.projects.goal(projectId, goalId),
+		applyOptimistic: (current, vars) => {
+			if (!current) return current;
+			const { archived: _archived, ...rest } = vars;
+			return { ...current, ...rest };
+		},
+		mergeResponse: (current, updated) => (current ? { ...current, ...updated } : current),
+		invalidateOnSettled: [queryKeys.projects.goalsFiltered(projectId, undefined)],
+		errorMessage: 'Failed to update goal',
+	});
+}
+
+/** Archive a goal (DELETE), then re-flow the goal lists. */
+export function useArchiveGoal(projectId: string) {
+	return useMutation({
+		mutationFn: (goalId: string) =>
+			api.delete<GoalWithProject>(`/api/projects/${projectId}/goals/${goalId}`),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: queryKeys.projects.goals(projectId) });
+		},
+	});
+}

--- a/packages/web/src/hooks/use-projects.ts
+++ b/packages/web/src/hooks/use-projects.ts
@@ -28,6 +28,9 @@ export interface Project {
 	dev_ports: Array<{ container: number; host: number }>;
 	repo_count: number;
 	open_task_count: number;
+	/** Active (non-archived) goals on this project; drives the sidebar "no goals yet" dot. Only
+	 * present on the single-project detail payload, so optional. */
+	open_goal_count?: number;
 	/** Total Agent members on this project's team (the hired roster size). */
 	agent_count: number;
 	/** Agents currently running on this project's team (runtime_status = active). */

--- a/packages/web/src/hooks/use-websocket.ts
+++ b/packages/web/src/hooks/use-websocket.ts
@@ -43,6 +43,11 @@ const TABLE_TO_QUERY_KEY: Record<
 				);
 			}
 		}
+		// A goal-check run (a heartbeat run with no task) updates the Goals page's
+		// runs footer; refresh it live.
+		if (!row.task_id) {
+			keys.push(queryKeys.projects.goalRuns(cid));
+		}
 		return keys;
 	},
 	agent_wakeup_requests: (cid, row) => {
@@ -91,6 +96,9 @@ const TABLE_TO_QUERY_KEY: Record<
 	cost_entries: (cid) => [['projects', cid, 'costs']],
 	execution_locks: (cid) => [['projects', cid, 'execution-locks']],
 	repos: (cid) => [queryKeys.projects.repos(cid), queryKeys.projects.all()],
+	// `goals(cid)` = ['projects', slug, 'goals'] is a prefix of goalsFiltered /
+	// goal / goalHistory / goalRuns, so it invalidates every goal query at once.
+	goals: (cid) => [queryKeys.projects.goals(cid), queryKeys.projects.all()],
 };
 
 /** Invalidate TanStack Query caches for a realtime row_change event. */

--- a/packages/web/src/lib/query-keys.ts
+++ b/packages/web/src/lib/query-keys.ts
@@ -95,6 +95,13 @@ export const queryKeys = {
 			'queued-wakeups',
 		],
 
+		// goals
+		goals: (slug: string) => ['projects', slug, 'goals'],
+		goalsFiltered: (slug: string, filters: KeyParam) => ['projects', slug, 'goals', filters],
+		goal: (slug: string, goalId: string) => ['projects', slug, 'goals', goalId],
+		goalHistory: (slug: string, goalId: string) => ['projects', slug, 'goals', goalId, 'history'],
+		goalRuns: (slug: string) => ['projects', slug, 'goals', 'runs'],
+
 		// agents
 		agents: (slug: string) => ['projects', slug, 'agents'],
 		agentsFiltered: (slug: string, filters: KeyParam) => ['projects', slug, 'agents', filters],

--- a/packages/web/src/routeTree.gen.ts
+++ b/packages/web/src/routeTree.gen.ts
@@ -34,6 +34,7 @@ import { Route as PreviewProjectIdFilenameRouteImport } from './routes/preview/$
 import { Route as ProjectsProjectIdTasksIndexRouteImport } from './routes/projects/$projectId/tasks/index'
 import { Route as ProjectsProjectIdSettingsIndexRouteImport } from './routes/projects/$projectId/settings/index'
 import { Route as ProjectsProjectIdInboxIndexRouteImport } from './routes/projects/$projectId/inbox/index'
+import { Route as ProjectsProjectIdGoalsIndexRouteImport } from './routes/projects/$projectId/goals/index'
 import { Route as ProjectsProjectIdAgentsIndexRouteImport } from './routes/projects/$projectId/agents/index'
 import { Route as ProjectsProjectIdTeamSettingsGeneralRouteImport } from './routes/projects/$projectId/team-settings/general'
 import { Route as ProjectsProjectIdTasksTaskIdRouteImport } from './routes/projects/$projectId/tasks/$taskId'
@@ -177,6 +178,12 @@ const ProjectsProjectIdInboxIndexRoute =
     path: '/inbox/',
     getParentRoute: () => ProjectsProjectIdRouteRoute,
   } as any)
+const ProjectsProjectIdGoalsIndexRoute =
+  ProjectsProjectIdGoalsIndexRouteImport.update({
+    id: '/goals/',
+    path: '/goals/',
+    getParentRoute: () => ProjectsProjectIdRouteRoute,
+  } as any)
 const ProjectsProjectIdAgentsIndexRoute =
   ProjectsProjectIdAgentsIndexRouteImport.update({
     id: '/agents/',
@@ -260,6 +267,7 @@ export interface FileRoutesByFullPath {
   '/projects/$projectId/tasks/$taskId': typeof ProjectsProjectIdTasksTaskIdRoute
   '/projects/$projectId/team-settings/general': typeof ProjectsProjectIdTeamSettingsGeneralRoute
   '/projects/$projectId/agents/': typeof ProjectsProjectIdAgentsIndexRoute
+  '/projects/$projectId/goals/': typeof ProjectsProjectIdGoalsIndexRoute
   '/projects/$projectId/inbox/': typeof ProjectsProjectIdInboxIndexRoute
   '/projects/$projectId/settings/': typeof ProjectsProjectIdSettingsIndexRoute
   '/projects/$projectId/tasks/': typeof ProjectsProjectIdTasksIndexRoute
@@ -294,6 +302,7 @@ export interface FileRoutesByTo {
   '/projects/$projectId/tasks/$taskId': typeof ProjectsProjectIdTasksTaskIdRoute
   '/projects/$projectId/team-settings/general': typeof ProjectsProjectIdTeamSettingsGeneralRoute
   '/projects/$projectId/agents': typeof ProjectsProjectIdAgentsIndexRoute
+  '/projects/$projectId/goals': typeof ProjectsProjectIdGoalsIndexRoute
   '/projects/$projectId/inbox': typeof ProjectsProjectIdInboxIndexRoute
   '/projects/$projectId/settings': typeof ProjectsProjectIdSettingsIndexRoute
   '/projects/$projectId/tasks': typeof ProjectsProjectIdTasksIndexRoute
@@ -331,6 +340,7 @@ export interface FileRoutesById {
   '/projects/$projectId/tasks/$taskId': typeof ProjectsProjectIdTasksTaskIdRoute
   '/projects/$projectId/team-settings/general': typeof ProjectsProjectIdTeamSettingsGeneralRoute
   '/projects/$projectId/agents/': typeof ProjectsProjectIdAgentsIndexRoute
+  '/projects/$projectId/goals/': typeof ProjectsProjectIdGoalsIndexRoute
   '/projects/$projectId/inbox/': typeof ProjectsProjectIdInboxIndexRoute
   '/projects/$projectId/settings/': typeof ProjectsProjectIdSettingsIndexRoute
   '/projects/$projectId/tasks/': typeof ProjectsProjectIdTasksIndexRoute
@@ -369,6 +379,7 @@ export interface FileRouteTypes {
     | '/projects/$projectId/tasks/$taskId'
     | '/projects/$projectId/team-settings/general'
     | '/projects/$projectId/agents/'
+    | '/projects/$projectId/goals/'
     | '/projects/$projectId/inbox/'
     | '/projects/$projectId/settings/'
     | '/projects/$projectId/tasks/'
@@ -403,6 +414,7 @@ export interface FileRouteTypes {
     | '/projects/$projectId/tasks/$taskId'
     | '/projects/$projectId/team-settings/general'
     | '/projects/$projectId/agents'
+    | '/projects/$projectId/goals'
     | '/projects/$projectId/inbox'
     | '/projects/$projectId/settings'
     | '/projects/$projectId/tasks'
@@ -439,6 +451,7 @@ export interface FileRouteTypes {
     | '/projects/$projectId/tasks/$taskId'
     | '/projects/$projectId/team-settings/general'
     | '/projects/$projectId/agents/'
+    | '/projects/$projectId/goals/'
     | '/projects/$projectId/inbox/'
     | '/projects/$projectId/settings/'
     | '/projects/$projectId/tasks/'
@@ -643,6 +656,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProjectsProjectIdInboxIndexRouteImport
       parentRoute: typeof ProjectsProjectIdRouteRoute
     }
+    '/projects/$projectId/goals/': {
+      id: '/projects/$projectId/goals/'
+      path: '/goals'
+      fullPath: '/projects/$projectId/goals/'
+      preLoaderRoute: typeof ProjectsProjectIdGoalsIndexRouteImport
+      parentRoute: typeof ProjectsProjectIdRouteRoute
+    }
     '/projects/$projectId/agents/': {
       id: '/projects/$projectId/agents/'
       path: '/agents'
@@ -746,6 +766,7 @@ interface ProjectsProjectIdRouteRouteChildren {
   ProjectsProjectIdTasksTaskIdRoute: typeof ProjectsProjectIdTasksTaskIdRoute
   ProjectsProjectIdTeamSettingsGeneralRoute: typeof ProjectsProjectIdTeamSettingsGeneralRoute
   ProjectsProjectIdAgentsIndexRoute: typeof ProjectsProjectIdAgentsIndexRoute
+  ProjectsProjectIdGoalsIndexRoute: typeof ProjectsProjectIdGoalsIndexRoute
   ProjectsProjectIdInboxIndexRoute: typeof ProjectsProjectIdInboxIndexRoute
   ProjectsProjectIdSettingsIndexRoute: typeof ProjectsProjectIdSettingsIndexRoute
   ProjectsProjectIdTasksIndexRoute: typeof ProjectsProjectIdTasksIndexRoute
@@ -767,6 +788,7 @@ const ProjectsProjectIdRouteRouteChildren: ProjectsProjectIdRouteRouteChildren =
     ProjectsProjectIdTeamSettingsGeneralRoute:
       ProjectsProjectIdTeamSettingsGeneralRoute,
     ProjectsProjectIdAgentsIndexRoute: ProjectsProjectIdAgentsIndexRoute,
+    ProjectsProjectIdGoalsIndexRoute: ProjectsProjectIdGoalsIndexRoute,
     ProjectsProjectIdInboxIndexRoute: ProjectsProjectIdInboxIndexRoute,
     ProjectsProjectIdSettingsIndexRoute: ProjectsProjectIdSettingsIndexRoute,
     ProjectsProjectIdTasksIndexRoute: ProjectsProjectIdTasksIndexRoute,

--- a/packages/web/src/routes/projects/$projectId/goals/index.tsx
+++ b/packages/web/src/routes/projects/$projectId/goals/index.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { GoalsList } from '../../../../components/goals-list';
+
+function ProjectGoalsListPage() {
+	const { projectId } = Route.useParams();
+	return <GoalsList projectId={projectId} />;
+}
+
+export const Route = createFileRoute('/projects/$projectId/goals/')({
+	component: ProjectGoalsListPage,
+});

--- a/packages/web/test/goals.test.tsx
+++ b/packages/web/test/goals.test.tsx
@@ -1,0 +1,27 @@
+import { expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+import { seedProject, seedWorkspace } from './helpers/seed';
+
+// Component-tier proof for the Goals page: seed a team + project (no goals),
+// navigate to the goals route, and assert the empty-state hero renders with its
+// exact tagline. No goal seeder exists, so the empty path is what we assert.
+test('renders the goals empty state when a project has no goals', async () => {
+	let projectSlug = '';
+	const { findByText, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Goals Demo' });
+			projectSlug = project.slug;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/goals',
+		params: { projectId: projectSlug },
+	});
+
+	await findByText('Create the first goal for the team to work towards', undefined, {
+		timeout: 10_000,
+	});
+});


### PR DESCRIPTION
## What & why

Reintroduces **Goals** as a first-class, per-project concept. Goals are the high-level objectives the admin sets; the **Captain** keeps them current so the admin can see where a project stands without micromanaging the board.

Unlike the two mainstream approaches — task-completion rollup (measures activity, not outcome) or human-owned OKRs (rot because someone has to remember to update them) — Hezo uses a third model: the Captain **estimates** each goal's progress on a cadence, so the read is always fresh and outcome-flavored. The status blurb is the primary signal; the percentage is the glanceable secondary.

## How it works

- The admin sets goals (title, SMART description, optional **target date**, and a **daily/weekly/monthly** check cadence) from a new **Goals** entry in the project menu (above Tasks). A gentle flashing dot nudges goal creation when none exist.
- On the Captain's heartbeat, goals that are **due** (per their cadence) are assessed in a single **goal-check run** — a task-less Captain run. Goals not yet due are skipped.
- For each due goal the Captain records a **progress %** (0–100), a coloured **health** (on-track / at-risk / off-track; new goals show *not assessed*), and a **status blurb**, via the `update_goal_progress` MCP tool. Each snapshot feeds the goal's **progress-history chart**.
- The Goals page shows each goal as a panel (title, health pill, percent + bar, history line chart, blurb, cadence, target date) and lists recent goal-check runs underneath, annotated with which goals each updated.
- The Captain only files new tickets toward a goal when a concrete next step is actually missing; such tickets carry a non-gating `goal_id` link. The HQ/internal project has no goals.

## Changes

**Server**
- `005_goals.sql` (+ data-preservation test): `goals`, `goal_run_updates`, `goal_health` / `goal_check_frequency` enums, `heartbeat_runs.kind`, `tasks.goal_id`
- goals service + project-scoped REST routes (CRUD, `/goals/runs`, `/goals/:id/history`); HQ rejected
- MCP tools `list_goals` + `update_goal_progress` (Captain, run-scoped), optional `goal_id` on `create_task`
- null-task goal-check runs threaded through the runner; `JobManager` dispatches them from the Captain's heartbeat when goals are due; trimmed completion bookkeeping
- Captain role docs (software-development + blank) gain a Goals responsibility

**Web**
- Goals nav entry + flashing dot, goals list of panels, create dialog, recharts progress-history chart, health pill, goal-checks footer, realtime invalidation

**Docs**
- new Goals concept page (bundled into the CEO chat), `.dev/architecture.md` + regenerated MCP reference

## Tests
- Migration preservation, goals service (due-cadence boundaries, `recordGoalProgress` writes goal + history + advances `last_checked_at`, HQ rejection), REST CRUD incl. archive/`include_archived`, MCP tools (read + run-scoped write path), null-task goal-check run creates no task comment, plus a web component test. Full `typecheck` + `build` pass via the pre-commit hook.

> Note: two pre-existing `ssh-agent` tests fail locally only because the `ssh-keygen` binary isn't installed in this environment — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013u6dCYWuW8KbwQ2KdYfcXx)_