### PR TITLE
fix(test): de-flake browser CI by serving the built web bundle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,7 +221,7 @@ test('<what changed>', async () => {
 
 ### Playwright environment
 
-Root `playwright.config.ts` auto-starts server (:3101) and web (:5174). Use `authenticate(page)` to bypass the master-key gate when not testing auth itself. The `sharedWorkspace` fixture in `test/browser/fixtures.ts` provisions a Startup-templated team once per worker; tests create their own per-test project under it via `createProjectAndClearPlanning`. Captain's coherence-review run is suppressed by `HEZO_E2E_SKIP_COHERENCE_REVIEW=1` in the test server env — without it, team setup blocks for ~30-60s.
+Root `playwright.config.ts` auto-starts server (:3101) and web (:5174). The web frontend is served two ways: `bun run test [--browser]` builds the bundle once and serves it via `vite preview` (the runner sets `HEZO_E2E_PREVIEW=1`), because two on-demand-transforming Vite dev servers saturate a 2-core CI runner and starve the backend until task fetches time out; a raw `bunx playwright test` (no runner, no prebuilt `dist`) falls back to the Vite dev server so one-off local debugging needs no build step. Use `authenticate(page)` to bypass the master-key gate when not testing auth itself. The `sharedWorkspace` fixture in `test/browser/fixtures.ts` provisions a Startup-templated team once per worker; tests create their own per-test project under it via `createProjectAndClearPlanning`. Captain's coherence-review run is suppressed by `HEZO_E2E_SKIP_COHERENCE_REVIEW=1` in the test server env — without it, team setup blocks for ~30-60s.
 
 ### No spurious `[error]`/`[warn]` in unit-test output
 

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -18,22 +18,36 @@ logger.error = (msg, options) => {
 	originalError(msg, options);
 };
 
+// The same backend proxy table is used by the dev server (`vite`) and the
+// preview server (`vite preview`, which serves the built bundle). The browser
+// E2E suite runs against `preview` rather than `dev`: a minified, pre-bundled
+// build is dramatically cheaper to serve than the dev server's per-request
+// module transform, which kept the CI runner's CPU saturated and starved the
+// backend until task fetches timed out. Keeping both tables identical means the
+// proxied surface (REST, OAuth, MCP, the WebSocket upgrade) behaves the same in
+// dev and in the E2E build.
+const proxy = {
+	'/api': serverUrl,
+	'/oauth': serverUrl,
+	'/health': serverUrl,
+	'/mcp': serverUrl,
+	'/SKILL.md': serverUrl,
+	'/llms.txt': serverUrl,
+	'/ws': {
+		target: serverUrl.replace('http', 'ws'),
+		ws: true,
+	},
+};
+
 export default defineConfig({
 	customLogger: logger,
 	plugins: [TanStackRouterVite({ quoteStyle: 'single' }), react(), tailwindcss()],
 	server: {
 		port: webPort,
-		proxy: {
-			'/api': serverUrl,
-			'/oauth': serverUrl,
-			'/health': serverUrl,
-			'/mcp': serverUrl,
-			'/SKILL.md': serverUrl,
-			'/llms.txt': serverUrl,
-			'/ws': {
-				target: serverUrl.replace('http', 'ws'),
-				ws: true,
-			},
-		},
+		proxy,
+	},
+	preview: {
+		port: webPort,
+		proxy,
 	},
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,6 +13,19 @@ const TEST_DATA_DIR = join(tmpdir(), 'hezo-e2e-test');
 const GATE_SERVER_PORT = 3102;
 const GATE_WEB_PORT = 5175;
 
+// Serve the web frontend from the *built* bundle (`vite preview`) when the test
+// runner sets HEZO_E2E_PREVIEW=1 (it builds the bundle first — see
+// scripts/test.ts), otherwise fall back to the Vite dev server. The dev server
+// transforms every module on demand; with two of them plus the backend, the 1Hz
+// crons and four Chromium workers on a 2-core CI runner, that sustained CPU cost
+// starved the backend until task fetches blew past the per-test timeouts and the
+// suite flaked. The minified preview build is far cheaper to serve, so CI runs
+// against it; a raw `bunx playwright test` (no runner, no prebuilt dist) still
+// gets the dev server so one-off local debugging needs no build step.
+const USE_PREVIEW = process.env.HEZO_E2E_PREVIEW === '1';
+const webCommand = (port: number) =>
+	USE_PREVIEW ? `bunx vite preview --port ${port} --strictPort` : 'bun run dev';
+
 export default defineConfig({
 	tsconfig: './tsconfig.json',
 	testDir: './test/browser',
@@ -106,7 +119,7 @@ export default defineConfig({
 			},
 		},
 		{
-			command: 'bun run dev',
+			command: webCommand(WEB_PORT),
 			cwd: './packages/web',
 			port: WEB_PORT,
 			reuseExistingServer: false,
@@ -116,7 +129,7 @@ export default defineConfig({
 			},
 		},
 		{
-			command: 'bun run dev',
+			command: webCommand(GATE_WEB_PORT),
 			cwd: './packages/web',
 			port: GATE_WEB_PORT,
 			reuseExistingServer: false,

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -153,15 +153,37 @@ async function runBunNativeForPackage(pkg: string): Promise<boolean> {
 	return passed;
 }
 
+// Build the web bundle the Playwright suite serves via `vite preview`. Running
+// the browser tests against the prebuilt bundle instead of two Vite dev servers
+// keeps the CI runner's CPU off the dev server's per-request module transform,
+// which otherwise starved the backend until task fetches timed out (see the
+// HEZO_E2E_PREVIEW note in playwright.config.ts). Done synchronously here, before
+// Playwright launches its webServers, because Playwright starts webServers ahead
+// of any globalSetup — there is no in-config hook that runs early enough.
+async function buildWebBundle(): Promise<boolean> {
+	console.log('Building web bundle for browser tests...');
+	const proc = Bun.spawn(['bunx', 'vite', 'build'], {
+		cwd: resolve(ROOT, 'packages/web'),
+		stdout: 'inherit',
+		stderr: 'inherit',
+	});
+	const exitCode = await proc.exited;
+	if (exitCode !== 0) console.error('Failed to build web bundle');
+	return exitCode === 0;
+}
+
 async function runBrowserTests(): Promise<boolean> {
 	console.log('\n── Browser Tests ──');
+	if (!(await buildWebBundle())) return false;
 	const playwrightArgs = ['playwright', 'test'];
 	if (pattern) playwrightArgs.push(pattern);
 	const proc = Bun.spawn(['bunx', ...playwrightArgs], {
 		cwd: ROOT,
 		stdout: 'inherit',
 		stderr: 'inherit',
-		env: { ...process.env, NODE_ENV: 'test' },
+		// HEZO_E2E_PREVIEW=1 switches playwright.config.ts's webServers from the
+		// Vite dev server to `vite preview`, serving the bundle built just above.
+		env: { ...process.env, NODE_ENV: 'test', HEZO_E2E_PREVIEW: '1' },
 	});
 	const passed = (await proc.exited) === 0;
 	console.log(`\nBrowser: ${passed ? 'passed' : 'FAILED'}`);

--- a/test/browser/helpers.ts
+++ b/test/browser/helpers.ts
@@ -459,7 +459,16 @@ export async function waitForPageLoad(page: Page, timeout = 15000) {
 	// the route has committed either its loader or its content, so the loader
 	// check below waits for data to land instead of racing the initial mount.
 	await expect(page.locator('main').first()).toBeVisible({ timeout });
-	await expect(page.getByText('Loading...')).toBeHidden({ timeout });
+	// A route renders its own "Loading..." placeholder while its data resolves —
+	// and some pages render more than one (the documents page has a loader in both
+	// its sidebar `complementary` and its main `section`). A bare
+	// `getByText('Loading...').toBeHidden()` is a *strict* locator and throws a
+	// "resolved to 2 elements" error the moment two loaders are on screen at once
+	// (which the fast preview build renders reliably). `toHaveCount(0)` waits for
+	// every loader to clear and is strict-mode safe; an absent loader is count 0,
+	// so the pre-mount fast-pass it guards against still can't happen (the <main>
+	// visibility gate above already ensures the route has committed).
+	await expect(page.getByText('Loading...')).toHaveCount(0, { timeout });
 }
 
 /**

--- a/test/browser/scroll-reset-on-navigate.spec.ts
+++ b/test/browser/scroll-reset-on-navigate.spec.ts
@@ -103,7 +103,13 @@ test('resets shell scroll to the top when navigating between pages', async ({
 	// later renders the tall list synchronously (no loading-state self-clamp).
 	await page.goto(`/projects/${project.slug}/tasks`);
 	await waitForPageLoad(page);
-	await expect(page.getByTestId('task-list-main')).toBeVisible({ timeout: 20000 });
+	// Wait on a seeded row rather than a section testid: the list now splits into
+	// "In progress" / "Backlog" / "Done" sections (each omitted when empty), and
+	// the 1Hz wakeup cron may have already moved these agent-assigned tasks out of
+	// Backlog into "In progress". A row is present whichever section owns it.
+	await expect(page.getByRole('row', { name: /Source task with comments/ })).toBeVisible({
+		timeout: 20000,
+	});
 
 	const main = page.locator('main').first();
 	await expect
@@ -135,7 +141,9 @@ test('resets shell scroll to the top when navigating between pages', async ({
 
 	// SPA-navigate back to the (cached, tall) task list via the sidebar link.
 	await page.getByTestId('project-sidebar-tasks').click();
-	await expect(page.getByTestId('task-list-main')).toBeVisible({ timeout: 20000 });
+	await expect(page.getByRole('row', { name: /Source task with comments/ })).toBeVisible({
+		timeout: 20000,
+	});
 
 	// The list still overflows, so without the reset the carried-over scrollTop
 	// would remain > 0. With the fix it lands back at the top.


### PR DESCRIPTION
## Problem

The `test-browser` CI job has been failing repeatedly on `main`. `run-termination` fails deterministically, while `scroll-reset-on-navigate`, `task-comment-attachments`, `task-comments`, and `master-key-gate` flake — and the *set* of hard failures shifts from run to run. That shifting pattern is the signature of capacity starvation, not individual UI bugs.

The Playwright trace snapshots (pulled from the failing run's artifact) confirm it: the failing pages hang on the route-level **"Loading..."** state. The un-mocked `GET /tasks/:id` (and sibling fetches) never return within the per-test timeout. In `run-termination` the terminate button renders correctly *once the data lands* — it just lands after the 20s deadline.

## Root cause

CPU starvation, not a UI bug. The browser job ran **two Vite *dev* servers** — which transform every module on demand — alongside the backend, the 1 Hz wakeup/heartbeat crons, and four Chromium workers on a 2-core runner. Near the end of the ~10-minute run the backend is starved of CPU and late-scheduled specs blow past their timeouts.

## Fix

**Serve the built bundle via `vite preview` instead of the dev server.** The test runner (`scripts/test.ts`) builds the web bundle once and launches Playwright with `HEZO_E2E_PREVIEW=1`, which switches both webServers from `bun run dev` to `vite preview`. A minified, pre-bundled build is dramatically cheaper to serve than the dev server's per-request transform, so the backend keeps its CPU. A raw `bunx playwright test` (no runner, no prebuilt `dist`) still falls back to the dev server, so one-off local debugging needs no build step.

- `vite.config.ts`: add a `preview` proxy block mirroring `server`.
- `playwright.config.ts`: webServers branch on `HEZO_E2E_PREVIEW`.
- `scripts/test.ts`: build the bundle before launching Playwright (Playwright starts webServers *before* `globalSetup`, so the build can't live in-config).

**Also fixes a real regression** surfaced by the same run: `scroll-reset-on-navigate` waited on `getByTestId('task-list-main')`, which the infinite-scroll change (#451) repurposed as the **Backlog** section's testid — and `TaskListSection` renders nothing when empty. The 1 Hz wakeup cron moves the seeded agent-assigned tasks out of Backlog into "In progress", so the testid vanished. It now waits on a seeded task row, which is present whichever status-section owns it.

## Validation (local)

- Full **`parallel` project — 35/35 pass** against the preview build.
- `master-key-gate` (auth-gate project) passes under preview.
- Dev-server fallback (raw `bunx playwright test`) still works.
- `bun run check` and `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019umoNHTBCvNQ75yVtCi631)_