### PR TITLE
docs: surface goals as a first-class concept in overview pages

### DIFF
--- a/docs/concepts/how-hezo-works.md
+++ b/docs/concepts/how-hezo-works.md
@@ -93,6 +93,9 @@ agentic tooling and a consistent, safe platform around it; you get both.
   oversee everything from **HQ**.
 - Work flows as **tasks** on a board, each with a description, optional rules, and a
   living progress summary.
+- A project also sets **goals** — the outcomes those tasks add up to — and the Captain re-checks each
+  on a schedule, recording progress and health so you can see where things stand. See
+  [Goals & progress](/docs/concepts/goals).
 - Knowledge lives alongside the work: **documents** (markdown PRDs, specs, and research,
   with version history) and an **assets** library (uploads and agent-generated files, with
   HTML previews). See [Documents & long-term memory](/docs/concepts/documents-and-memory)

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -56,6 +56,9 @@ agent can't hurt you. A few guarantees sit underneath everything:
 - **Put a hard ceiling on spend.** Per-agent and per-project budgets with live cost
   tracking *pause* runs when a limit is hit and *auto-resume* when the window rolls over —
   control without babysitting. See [Budgets & cost control](/docs/concepts/budgets-and-costs).
+- **Steer by outcome, not just tickets.** Set high-level **goals** and let the Captain re-check
+  each one on a schedule — it writes a fresh progress estimate, health, and status — so you can see
+  where a project stands without reading every ticket. See [Goals & progress](/docs/concepts/goals).
 - **Set the rules per task** and let agents keep a running progress summary so work
   carries cleanly across runs. See [Tasks, rules & summaries](/docs/concepts/tasks).
 - **Give your agents long-term memory — versioned and reversible.** Keep durable project


### PR DESCRIPTION
## What

Goals already ship as a first-class product feature (project-scoped SMART objectives the Captain re-checks on a heartbeat, with a dedicated concept page at `docs/concepts/goals.md`), but they weren't mentioned anywhere in the two top-of-funnel overview pages. A reader scanning the product's capabilities wouldn't know goals exist.

This adds goals to:

- **`docs/introduction.md`** — a new bullet in "What you can do with it", framing goals as steering by outcome rather than just tickets, linking to the goals page.
- **`docs/concepts/how-hezo-works.md`** — a goals bullet in "How work is organised", right after tasks, framing goals as the outcomes tasks add up to.

Both link to `/docs/concepts/goals`. The dedicated goals page itself is unchanged.

## Notes

- The docs bundle (`packages/server/src/services/docs-bundle.json`) is a gitignored build artifact; it's regenerated by `bun run build:docs` and now carries the new prose, so the CEO chat reflects it.
- `docs-bundle.test.ts` / `docs-bundle-fs.test.ts` pass (no page added/removed, no frontmatter changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FsR5Em4tc9DW2jWmgLs7Qb)_