### PR TITLE
refactor: safe code-review cleanups (enums, defensive wakeup, dependency toasts)

### DIFF
--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -57,24 +57,29 @@ async function buildCreateTaskCaller(c: Context<Env>, teamId: string): Promise<C
 	return caller;
 }
 
-async function wakeAgentIfAssigned(
+// Fire-and-forget: the agent's run is inherently async, so callers don't await
+// this. The whole body — including the member-agent lookup — is wrapped in
+// trackBackground + catch so a rejection from either query can't surface as an
+// unhandled rejection or race test teardown (the tracker is drained on close).
+function wakeAgentIfAssigned(
 	db: PGlite,
 	assigneeId: string | null | undefined,
 	teamId: string,
 	taskId: string,
 	source: WakeupSource = WakeupSource.Assignment,
 	extraPayload: Record<string, unknown> = {},
-): Promise<void> {
+): void {
 	if (!assigneeId) return;
-	const isAgent = await db.query('SELECT id FROM member_agents WHERE id = $1', [assigneeId]);
-	if (isAgent.rows.length > 0) {
-		trackBackground(
-			createWakeup(db, assigneeId, teamId, source, {
+	trackBackground(
+		(async () => {
+			const isAgent = await db.query('SELECT id FROM member_agents WHERE id = $1', [assigneeId]);
+			if (isAgent.rows.length === 0) return;
+			await createWakeup(db, assigneeId, teamId, source, {
 				task_id: taskId,
 				...extraPayload,
-			}).catch((e) => log.error('Failed to create wakeup for assignment:', e)),
-		);
-	}
+			});
+		})().catch((e) => log.error('Failed to create wakeup for assignment:', e)),
+	);
 }
 
 async function resolveActorMemberId(c: Context<Env>, teamId: string): Promise<string | null> {

--- a/packages/shared/src/task-progress.ts
+++ b/packages/shared/src/task-progress.ts
@@ -1,4 +1,4 @@
-import { TaskStatus, TERMINAL_TASK_STATUSES } from './types/common.js';
+import { HeartbeatRunStatus, TaskStatus, TERMINAL_TASK_STATUSES } from './types/common.js';
 
 export type TaskProgressBucket = 'complete' | 'in_progress' | 'not_done';
 
@@ -108,7 +108,10 @@ export interface TaskProgressStatusRow extends TaskProgressRow {
 }
 
 export function isLastRunFailed(hasActiveRun: boolean, lastRunStatus: string | null): boolean {
-	return !hasActiveRun && (lastRunStatus === 'failed' || lastRunStatus === 'timed_out');
+	return (
+		!hasActiveRun &&
+		(lastRunStatus === HeartbeatRunStatus.Failed || lastRunStatus === HeartbeatRunStatus.TimedOut)
+	);
 }
 
 /**

--- a/packages/web/src/components/ceo-chat/ceo-chat-widget.tsx
+++ b/packages/web/src/components/ceo-chat/ceo-chat-widget.tsx
@@ -1,4 +1,4 @@
-import { HQ_PROJECT_NAME } from '@hezo/shared';
+import { CeoMessageStatus, HQ_PROJECT_NAME } from '@hezo/shared';
 import {
 	ArrowRight,
 	Check,
@@ -313,9 +313,9 @@ function RoleLabel({ children }: { children: ReactNode }) {
 
 function MessageBubble({ message }: { message: CeoMessage }) {
 	const isCeo = message.role === 'assistant';
-	const interrupted = message.status === 'interrupted';
-	const failed = message.status === 'failed';
-	const streaming = message.status === 'streaming';
+	const interrupted = message.status === CeoMessageStatus.Interrupted;
+	const failed = message.status === CeoMessageStatus.Failed;
+	const streaming = message.status === CeoMessageStatus.Streaming;
 
 	if (isCeo) {
 		// Still composing with no text yet → the typing indicator stands in for

--- a/packages/web/src/components/comment-renderers/helpers.ts
+++ b/packages/web/src/components/comment-renderers/helpers.ts
@@ -1,3 +1,4 @@
+import { HeartbeatRunStatus } from '@hezo/shared';
 import {
 	AlertTriangle,
 	ArrowRightLeft,
@@ -43,14 +44,16 @@ export const REACTION_LABEL: Record<string, string> = { ack: 'Acknowledged' };
 export const AVAILABLE_REACTION_KINDS = ['ack'] as const;
 
 export function runStatusLabel(status: string): string {
-	if (status === 'timed_out') return 'timed out';
+	if (status === HeartbeatRunStatus.TimedOut) return 'timed out';
 	return status;
 }
 
 export function runStatusDotClass(status: string): string {
-	if (status === 'running' || status === 'queued') return 'bg-warning animate-pulse';
-	if (status === 'succeeded') return 'bg-success';
-	if (status === 'failed' || status === 'timed_out') return 'bg-danger';
+	if (status === HeartbeatRunStatus.Running || status === HeartbeatRunStatus.Queued)
+		return 'bg-warning animate-pulse';
+	if (status === HeartbeatRunStatus.Succeeded) return 'bg-success';
+	if (status === HeartbeatRunStatus.Failed || status === HeartbeatRunStatus.TimedOut)
+		return 'bg-danger';
 	return 'bg-text-3';
 }
 

--- a/packages/web/src/components/comment-renderers/run-comment.tsx
+++ b/packages/web/src/components/comment-renderers/run-comment.tsx
@@ -1,3 +1,4 @@
+import { HeartbeatRunStatus } from '@hezo/shared';
 import { Link } from '@tanstack/react-router';
 import { DoorOpen, Loader2, RotateCw } from 'lucide-react';
 import { useState } from 'react';
@@ -154,7 +155,9 @@ function RunCommentBody({
 	// and only when nothing is already running or queued for this task — that's
 	// exactly what `retryableRunId` resolves to (null otherwise).
 	const canRetry =
-		Boolean(taskId) && runId === retryableRunId && (status === 'failed' || status === 'timed_out');
+		Boolean(taskId) &&
+		runId === retryableRunId &&
+		(status === HeartbeatRunStatus.Failed || status === HeartbeatRunStatus.TimedOut);
 	const { lines } = useRunLogs(run?.project_id, runId, run?.log_text, isActive);
 	const createdTasks = run?.created_tasks ?? [];
 	const createdDocs = run?.created_docs ?? [];

--- a/packages/web/src/components/task-detail/task-sidebar.tsx
+++ b/packages/web/src/components/task-detail/task-sidebar.tsx
@@ -4,6 +4,7 @@ import {
 	CAPTAIN_AGENT_SLUG,
 	DEFAULT_EFFORT,
 	HQ_PROJECT_SLUG,
+	TaskPriority,
 	TaskStatus,
 	TERMINAL_TASK_STATUSES,
 } from '@hezo/shared';
@@ -110,11 +111,13 @@ export function TaskSidebar({
 						onChange={(e) => updateTask.mutate({ priority: e.target.value })}
 						className="w-full rounded-md border border-border bg-surface px-2.5 py-1.5 text-xs text-text-1 outline-none"
 					>
-						{['low', 'medium', 'high', 'urgent'].map((p) => (
-							<option key={p} value={p}>
-								{p}
-							</option>
-						))}
+						{[TaskPriority.Low, TaskPriority.Medium, TaskPriority.High, TaskPriority.Urgent].map(
+							(p) => (
+								<option key={p} value={p}>
+									{p}
+								</option>
+							),
+						)}
 					</select>
 				</div>
 

--- a/packages/web/src/components/task-list.tsx
+++ b/packages/web/src/components/task-list.tsx
@@ -1,4 +1,9 @@
-import { formatTaskStatus, TaskStatus, TERMINAL_TASK_STATUSES } from '@hezo/shared';
+import {
+	formatTaskStatus,
+	isLastRunFailed,
+	TaskStatus,
+	TERMINAL_TASK_STATUSES,
+} from '@hezo/shared';
 import { useNavigate } from '@tanstack/react-router';
 import { AlertTriangle, AtSign, ChevronDown, ListPlus, Plus, Search } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -330,9 +335,7 @@ export function TaskList({ projectId }: TaskListProps) {
 			width: '88px',
 			className: 'font-mono text-text-2',
 			render: (row) => {
-				const lastRunFailed =
-					!row.has_active_run &&
-					(row.last_run_status === 'failed' || row.last_run_status === 'timed_out');
+				const lastRunFailed = isLastRunFailed(row.has_active_run, row.last_run_status);
 				return (
 					<span className="inline-flex items-center gap-1.5">
 						<TaskRunDot hasActiveRun={row.has_active_run} queuedWakeup={row.queued_wakeup} />

--- a/packages/web/src/hooks/use-tasks.ts
+++ b/packages/web/src/hooks/use-tasks.ts
@@ -4,6 +4,7 @@ import { api } from '../lib/api';
 import { queryClient } from '../lib/query-client';
 import { queryKeys } from '../lib/query-keys';
 import { useSimpleOptimisticUpdate } from './use-optimistic-mutation';
+import { toast } from './use-toast';
 
 export interface QueuedWakeup {
 	reason: 'task_busy' | 'project_at_capacity' | 'agent_running';
@@ -270,6 +271,7 @@ export function useAddDependency(projectId: string, taskId: string) {
 			queryClient.invalidateQueries({
 				queryKey: queryKeys.projects.taskDependencies(projectId, taskId),
 			}),
+		onError: () => toast.error('Failed to add dependency'),
 	});
 }
 
@@ -281,5 +283,6 @@ export function useRemoveDependency(projectId: string, taskId: string) {
 			queryClient.invalidateQueries({
 				queryKey: queryKeys.projects.taskDependencies(projectId, taskId),
 			}),
+		onError: () => toast.error('Failed to remove dependency'),
 	});
 }


### PR DESCRIPTION
## Context

This PR is the result of a **full code-review pass** across the server, web, and shared packages aimed at eliminating dead code/duplication and improving maintainability, defensive logic, security, performance, and usability.

The honest headline: **the codebase is healthy.** Most of the high-severity findings from the review turned out to be **false positives** after verifying each one against the actual code, and were discarded:

- **Security (timing-safe comparisons): clean.** All three call sites (`safeCompareHex` in `middleware/auth.ts`, `asset-urls.ts`, `project-icon-urls.ts`) already length-check before `timingSafeEqual` and wrap it in `try/catch`.
- **Type safety: clean.** Zero real `any` in source (grep hits were the generated `routeTree.gen.ts` and the word "any" in comments).
- **Authorization / SQL: clean.** Nested resources are team/project-scoped; queries are parameterized.
- **`waitForBackground` is not dead** — it's a test-drain utility used by the test suite, so it was left in place.

What remains is the bounded set of **genuine, low-risk, no-behavior-change** cleanups below. Each is independently revertible.

## Changes

**Maintainability — replace raw status/priority strings with `@hezo/shared` enums**
- `shared/task-progress.ts`, `web/task-list.tsx`, `web/comment-renderers/run-comment.tsx`, `web/comment-renderers/helpers.ts`, `web/ceo-chat/ceo-chat-widget.tsx`, `web/task-detail/task-sidebar.tsx` — swap raw `'failed'`/`'timed_out'`/`'running'`/etc. and the hardcoded priority array for `HeartbeatRunStatus`, `CeoMessageStatus`, and `TaskPriority`.
- `task-list.tsx` now reuses the shared `isLastRunFailed()` helper instead of re-implementing its logic inline.

**Defensive logic — harden `wakeAgentIfAssigned` (`server/routes/tasks.ts`)**
- The function is called fire-and-forget. Its `createWakeup` was already tracked + caught, but the leading member-agent lookup query sat outside that guard, so a rejection there could surface as an unhandled rejection / race test teardown. The whole body is now wrapped in `trackBackground` + `.catch`.

**Usability — surface dependency-mutation failures (`web/hooks/use-tasks.ts`)**
- `useAddDependency` / `useRemoveDependency` were plain `useMutation` + invalidate with no `onError`, so failures were silent. Added `onError` toasts (matching the errors-only toast convention).

## Out of scope (deliberately)

Large structural refactors — splitting `mcp/tools.ts` / `agent-runner.ts` / `job-manager.ts` and modularizing the 1359-line `shared/types/common.ts` — were intentionally **not** done: high churn and regression risk for readability-only benefit.

## Verification

- `bun run typecheck` — passes across all three packages.
- `bunx biome check` on the changed files — clean (pre-existing warnings/errors elsewhere are untouched test helpers).
- `packages/shared` `task-progress.test.ts` — 14/14 pass.
- `packages/server` `tasks.test.ts` + `tasks-last-run.test.ts` — 53/53 pass.
- `packages/web` full vitest suite — 582/582 pass.
- Pre-commit hook (typecheck + full build) — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PAmR9dECRTtBh71T1uW9Hn)_