### PR TITLE
docs: lead with the meta-harness concept

### DIFF
--- a/docs/concepts/meta-harness.md
+++ b/docs/concepts/meta-harness.md
@@ -1,15 +1,62 @@
 ---
-title: How Hezo works
+title: Meta-harness
 order: 6
 section: Concepts
 ---
 
-# How Hezo works
+# Meta-harness
 
-A quick tour of the moving parts. None of this is something you operate by hand —
-it's what the single `hezo` binary sets up for you.
+Every major model now ships its own agentic command-line tool — Anthropic has Claude
+Code, OpenAI has Codex, Google has the Gemini CLI, and there are more. Each *harness*
+wraps a model in a loop that reads and writes files, runs commands, and uses tools. They
+are genuinely good and genuinely different: each has its own strengths, guardrails, and
+rough edges. Picking one means inheriting all of its tradeoffs; juggling several by hand
+means re-learning each tool and getting inconsistent results depending on which one you
+happened to use.
 
-## The server
+> [!NOTE]
+> These are usually called *coding* harnesses because they grew up around software, but the
+> loop they provide — read, write, run a command, use a tool, repeat — is general-purpose.
+> **Hezo is for any task, not just code** — software, research, marketing, operations — and
+> runs each agent on one of these harnesses precisely because they are the most capable
+> general-purpose agents available.
+
+Hezo's answer is to sit one level up: it is a **meta-harness**, a harness around the
+harnesses. It runs each model inside its **own first-party harness** — Claude drives Claude
+Code, GPT drives Codex, Gemini drives the Gemini CLI — so you keep each model's native
+tooling instead of a lowest-common-denominator wrapper. Then it wraps a **single, uniform
+platform layer** around all of them, so the harness an agent happens to run on becomes an
+implementation detail rather than something you manage.
+
+That platform layer is what lets Hezo **even out the tradeoffs between harnesses**, so you
+get quality results across very different models. Three things do the levelling:
+
+- **A uniform completeness check on every run.** When an agent decides it's finished, Hezo
+  independently judges whether the work is *actually* done before letting the run end — it
+  won't let an agent stop on failing tests, quietly declare a problem "out of scope", or
+  punt with "I'll leave that for later". This discipline rides on top of every harness that
+  supports it, which matters most for models that wouldn't hold that line on their own. (One
+  harness, OpenCode, can't support the hook yet, so runs there rely on the model alone.)
+- **The same capabilities and the same safety, whichever model you choose.** The tools,
+  [skills](/docs/concepts/skills), memory, sandbox, and secret protection described below are
+  identical no matter which harness an agent runs on — switching a model, or running several
+  at once, never changes what an agent can do or how safely it runs.
+- **Rough edges smoothed over.** The per-tool differences — how a prompt is delivered, how a
+  run is configured, how results come back — are normalised by Hezo, so behaviour stays
+  consistent no matter which harness backs an agent.
+
+The practical payoff: put a cheaper model on routine work and a frontier model on the hard
+problems, and trust that the *floor* — the tooling, the guardrails, and the security —
+stays the same underneath all of them. You never have to choose between a model's native
+agentic tooling and a consistent, safe platform around it; you get both.
+
+## The moving parts
+
+The meta-harness is the idea; the rest of this page is the machinery that delivers it.
+None of it is something you operate by hand — it's what the single `hezo` binary sets up
+for you.
+
+### The server
 
 Everything runs from one self-contained server process:
 
@@ -24,7 +71,7 @@ Everything runs from one self-contained server process:
 - **MCP server** — a built-in [Model Context Protocol](/docs/mcp/hezo-mcp-server)
   endpoint, so agents (Hezo's own and external clients) can manage your work.
 
-## Where agents run
+### Where agents run
 
 Each project gets its own **Docker container** — a private workspace with the project's
 code and tools. Agents execute inside it, never on your host directly. All their
@@ -32,61 +79,15 @@ outbound traffic is forced through the egress proxy, and the keys used to sign c
 or reach your model never enter the container. See
 [Container isolation](/docs/security/container-isolation).
 
-## How a model becomes an agent
+### How a model becomes an agent
 
 You connect one or more **AI providers** (Claude, ChatGPT, Gemini, and more). Each
-provider is driven through its native command-line runtime inside the container. An
-**agent** is a role (its system prompt, reporting line, budget, and heartbeat) paired
-with a model — and you can give any agent its own model. See
+provider is driven through its native command-line runtime — its harness — inside the
+container. An **agent** is a role (its system prompt, reporting line, budget, and
+heartbeat) paired with a model — and you can give any agent its own model. See
 [AI model support](/docs/ai-models).
 
-## Hezo is a meta-harness
-
-Every major model now ships its own agentic command-line tool — Anthropic has Claude
-Code, OpenAI has Codex, Google has the Gemini CLI, and there are more. Each *harness* wraps
-a model in a loop that reads and writes files, runs commands, and uses tools. They are
-genuinely good and genuinely different: each has its own strengths, guardrails, and rough
-edges. Picking one means inheriting all of its tradeoffs; juggling several by hand means
-re-learning each tool and getting inconsistent results depending on which one you happened
-to use.
-
-> [!NOTE]
-> These are usually called *coding* harnesses because they grew up around software, but the
-> loop they provide — read, write, run a command, use a tool, repeat — is general-purpose.
-> **Hezo is for any task, not just code** — software, research, marketing, operations — and
-> runs each agent on one of these harnesses precisely because they are the most capable
-> general-purpose agents available.
-
-Hezo's answer is to sit one level up. It runs each model inside its **own first-party
-harness** — Claude drives Claude Code, GPT drives Codex, Gemini drives the Gemini CLI — so
-you keep each model's native tooling instead of a lowest-common-denominator wrapper. Then
-it wraps a **single, uniform platform layer** around all of them, so the harness an agent
-happens to run on becomes an implementation detail rather than something you manage.
-
-That platform layer is what lets Hezo **even out the tradeoffs between harnesses**, so you
-get quality results across very different models. Three things do the levelling:
-
-- **A uniform completeness check on every run.** When an agent decides it's finished, Hezo
-  independently judges whether the work is *actually* done before letting the run end — it
-  won't let an agent stop on failing tests, quietly declare a problem "out of scope", or
-  punt with "I'll leave that for later". This discipline rides on top of every harness that
-  supports it, which matters most for models that wouldn't hold that line on their own. (One
-  harness, OpenCode, can't support the hook yet, so runs there rely on the model alone.)
-- **The same capabilities and the same safety, whichever model you choose.** The tools,
-  [skills](/docs/concepts/skills), memory, sandbox, and secret protection described
-  elsewhere on this page are identical no matter which harness an agent runs on — switching
-  a model, or running several at once, never changes what an agent can do or how safely it
-  runs.
-- **Rough edges smoothed over.** The per-tool differences — how a prompt is delivered, how a
-  run is configured, how results come back — are normalised by Hezo, so behaviour stays
-  consistent no matter which harness backs an agent.
-
-The practical payoff: put a cheaper model on routine work and a frontier model on the hard
-problems, and trust that the *floor* — the tooling, the guardrails, and the security —
-stays the same underneath all of them. You never have to choose between a model's native
-agentic tooling and a consistent, safe platform around it; you get both.
-
-## How work is organised
+### How work is organised
 
 - A **project** owns exactly one **team** (its agent roster).
 - A team has a **Captain** plus worker roles; an instance-wide **CEO** and **Coach**
@@ -104,7 +105,7 @@ agentic tooling and a consistent, safe platform around it; you get both.
 See [Projects & teams](/docs/concepts/projects-and-teams) and
 [Roles & the CEO](/docs/concepts/roles-and-coordination).
 
-## The three security pillars
+### The three security pillars
 
 | Pillar | What it protects | Read more |
 |---|---|---|

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -74,18 +74,3 @@ agent can't hurt you. A few guarantees sit underneath everything:
 - **Own your data.** Hezo carries an embedded database — no external service to run — so
   your work lives on hardware you control, with safe, data-preserving upgrades. See
   [Your data & the database](/docs/concepts/your-data).
-
-## Meta-harness
-
-Every major model now ships its own agentic command-line tool — Claude Code, Codex, the
-Gemini CLI, and more. Each *harness* wraps a model in a loop that reads and writes files,
-runs commands, and uses tools. They are genuinely good and genuinely different, so picking
-one means inheriting all of its tradeoffs, and juggling several by hand means inconsistent
-results.
-
-**Hezo is a meta-harness — a harness around the harnesses.** It runs each model inside its
-own first-party harness, so you keep that model's native tooling, then wraps a single,
-uniform platform layer around all of them: the same tools, memory, completeness checks, and
-security on every run, whichever model an agent happens to use. That's what lets you put a
-cheaper model on routine work and a frontier model on the hard problems while trusting the
-floor underneath stays the same. See [Meta-harness](/docs/concepts/meta-harness).

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -74,3 +74,18 @@ agent can't hurt you. A few guarantees sit underneath everything:
 - **Own your data.** Hezo carries an embedded database — no external service to run — so
   your work lives on hardware you control, with safe, data-preserving upgrades. See
   [Your data & the database](/docs/concepts/your-data).
+
+## Meta-harness
+
+Every major model now ships its own agentic command-line tool — Claude Code, Codex, the
+Gemini CLI, and more. Each *harness* wraps a model in a loop that reads and writes files,
+runs commands, and uses tools. They are genuinely good and genuinely different, so picking
+one means inheriting all of its tradeoffs, and juggling several by hand means inconsistent
+results.
+
+**Hezo is a meta-harness — a harness around the harnesses.** It runs each model inside its
+own first-party harness, so you keep that model's native tooling, then wraps a single,
+uniform platform layer around all of them: the same tools, memory, completeness checks, and
+security on every run, whichever model an agent happens to use. That's what lets you put a
+cheaper model on routine work and a frontier model on the hard problems while trusting the
+floor underneath stays the same. See [Meta-harness](/docs/concepts/meta-harness).


### PR DESCRIPTION
## Summary

Leans into the **meta-harness** framing across the docs:

- **Introduction** — adds a new `## Meta-harness` section at the bottom of the page that introduces the concept ("a harness around the harnesses") and links to a dedicated page.
- **Concepts** — replaces the "How Hezo works" page with a new **Meta-harness** page in the same order slot (so it stays the first page under Concepts). It opens with the meta-harness pitch (what harnesses are, the tradeoffs, how Hezo levels them out) and then flows organically into the moving-parts tour the old page carried (the server, where agents run, how a model becomes an agent, how work is organised, the security pillars), now nested under a "The moving parts" heading.

No content was lost — the original "How Hezo works" material was reordered beneath the meta-harness lead and lightly rewired for the new flow.

## Notes

- `docs/concepts/how-hezo-works.md` → `docs/concepts/meta-harness.md` (rename + restructure). No code references the old filename; the docs bundle walks the tree by frontmatter, so the URL becomes `/docs/concepts/meta-harness`.
- `packages/server/test/docs-bundle.test.ts` passes (ordering/grouping intact); the docs bundle is a build artifact and regenerates from the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ASkrrKWRSULEePkPkyrwP3)_