### PR TITLE
fix(updater): self-heal stuck self-update staging and lengthen download timeout

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -875,9 +875,13 @@ applies the staged binary and relaunches. The supervisor branch sits in `index.t
 after the `restore` subcommand and before preflights, so dev (`bun run`) and `hezo restore`
 never supervise. The `updater.ts` service handles the rest. Staging is **proactive**: the
 idempotent `ensureUpdateStaged()` downloads the platform asset + `SHA256SUMS`, verifies the
-hash, and stages to `<dataDir>/.update/staged[.exe]` (recording lifecycle in `state.json`),
-retrying once on failure (a second failure leaves `state.json` in `Error` for that version,
-honored as "retry exhausted" so polls don't re-download). It runs from `GET /api/updates/status`
+hash, and stages to `<dataDir>/.update/staged[.exe]` (recording lifecycle + an `updatedAt`
+timestamp in `state.json`), retrying once on failure. A second failure leaves `state.json` in
+`Error`, but that's honored only for a **cooldown** (`STAGE_ERROR_COOLDOWN_MS`) — a later poll
+re-attempts so a transient failure self-heals instead of sticking forever; likewise a
+`Downloading` state is respected only while **fresh** (`STAGE_DOWNLOAD_STALE_MS`), so a download
+abandoned by a worker crash/restart is re-attempted rather than wedging staging permanently. It
+runs from `GET /api/updates/status`
 (fire-and-forget on every banner poll, gated on `isSupervisedWorker()`) and the daily
 `update-check` cron (`HEZO_UPDATE_CHECK_CRON`), so a running instance usually stages a new
 release within seconds. `POST /api/updates/download` (superuser) is the same download path on
@@ -893,8 +897,9 @@ instance returns **locked** unless `HEZO_MASTER_KEY` is set (the web restart ove
 staged-update state plus an `autoUnlock` hint so the UI's confirmation can warn about the
 master-key re-unlock. The web banner shows an **"Install & restart"** button only once the
 binary is `Staged` (so the restart is instant); while the background download is in flight it
-stays hidden, and on a download `Error` (or for any instance that can't self-apply) it falls
-back to a **"Download"** link to the GitHub release page.
+stays hidden. On a download `Error`, a self-applying instance shows a **"Retry download"**
+button (which re-triggers `POST /api/updates/download`) with the GitHub release as a secondary
+link; an instance that can't self-apply falls back to the **"Download"** release link.
 
 **Known limits.** macOS binaries are unsigned (built on Linux; clear quarantine with `xattr -d`);
 on Apple Silicon an unsigned replacement may still be Gatekeeper-blocked. Windows self-update

--- a/biome.json
+++ b/biome.json
@@ -60,6 +60,8 @@
 			"!**/migrations-bundle.json",
 			"!**/agents-bundle.json",
 			"!**/docs-bundle.json",
+			"!**/docker-bundle.json",
+			"!**/static-bundle.json",
 			"!test/test-run-order.json",
 			"!test-results",
 			"!playwright-report",

--- a/docs/deployment/self-hosting.md
+++ b/docs/deployment/self-hosting.md
@@ -269,8 +269,11 @@ verifies the binary for your platform in the background. Once it's staged, a bar
 appears in the web UI; a superuser clicks **Install & restart** and confirms.
 Because the download already happened, the restart is instant — Hezo shuts down
 gracefully, swaps in the new binary, and restarts onto it, with no manual file
-replacement. (If the background download is disabled or can't run — for example
-inside a container — the bar instead links to the GitHub release page.)
+replacement. If a background download fails, the bar offers a **Retry download**
+button (with the GitHub release as a manual fallback), and it automatically
+re-attempts on a later check. (If the background download is disabled or can't
+run — for example inside a container — the bar instead links to the GitHub
+release page.)
 
 Because the restart re-locks the instance, **you'll need your 12-word master key
 to unlock Hezo again afterward** — unless you run Hezo with the master key set in

--- a/packages/server/src/services/updater.ts
+++ b/packages/server/src/services/updater.ts
@@ -39,7 +39,32 @@ export interface UpdateStateFile {
 	targetVersion?: string;
 	asset?: string;
 	error?: string;
+	/** Epoch ms of the last state write — drives staging retry/staleness decisions. */
+	updatedAt?: number;
 }
+
+/**
+ * How long to wait before re-attempting a download that previously errored for the
+ * same version, so a transient failure (network blip, rate limit) self-heals on a
+ * later status poll instead of sticking on the release-page link forever.
+ */
+export const STAGE_ERROR_COOLDOWN_MS = 30 * 60 * 1000;
+
+/**
+ * Total budget for fetching the release binary. The assets are large (~130 MB) and a
+ * flat short cap fails on slower links — the original production timeout was hit by a
+ * 129 MB asset that simply couldn't complete in time. Generous so a usable-but-slow
+ * connection still succeeds; a genuinely dead transfer is caught by the retry/cooldown.
+ */
+export const ASSET_DOWNLOAD_TIMEOUT_MS = 10 * 60 * 1000;
+
+/**
+ * How long a `Downloading` state may stand before it's treated as abandoned (the
+ * worker crashed or was restarted mid-download) and re-attempted. Must stay
+ * **comfortably above** `ASSET_DOWNLOAD_TIMEOUT_MS` so a genuinely in-flight (slow but
+ * live) download is never preempted by a concurrent poll.
+ */
+export const STAGE_DOWNLOAD_STALE_MS = 15 * 60 * 1000;
 
 /**
  * True only when this process is a `bun build --compile` standalone binary. In
@@ -128,7 +153,8 @@ export async function readUpdateState(dataDir: string): Promise<UpdateStateFile>
 
 async function writeState(dataDir: string, s: UpdateStateFile): Promise<void> {
 	await mkdir(updateDir(dataDir), { recursive: true });
-	await writeFile(stateFilePath(dataDir), `${JSON.stringify(s, null, 2)}\n`);
+	const stamped: UpdateStateFile = { ...s, updatedAt: Date.now() };
+	await writeFile(stateFilePath(dataDir), `${JSON.stringify(stamped, null, 2)}\n`);
 }
 
 /** Parse a `sha256sum`-style manifest, returning the lowercase hash for `asset`. */
@@ -176,7 +202,7 @@ export async function downloadAndStage(version: string, dataDir: string): Promis
 		const [binRes, sumsRes] = await Promise.all([
 			fetch(`${base}/${asset}`, {
 				headers: { 'User-Agent': 'hezo' },
-				signal: AbortSignal.timeout(120_000),
+				signal: AbortSignal.timeout(ASSET_DOWNLOAD_TIMEOUT_MS),
 			}),
 			fetch(`${base}/SHA256SUMS`, {
 				headers: { 'User-Agent': 'hezo' },
@@ -219,9 +245,11 @@ export async function downloadAndStage(version: string, dataDir: string): Promis
  * `isSupervisedWorker()` first; this helper assumes the feature is available.
  *
  * Retries the download once on failure; a second failure leaves `state.json` in
- * `Error` for that version, which is then honored as "retry exhausted" so we
- * don't re-download on every subsequent status poll. The web banner falls back
- * to a release-page link in that case.
+ * `Error` for that version. That error is honored only for a cooldown window, after
+ * which a later status poll re-attempts — a transient failure self-heals instead of
+ * sticking on the release-page link forever. Likewise a `Downloading` state is
+ * respected only while it's fresh; a stale one (worker crashed/restarted mid-download)
+ * is re-attempted.
  *
  * `latestInfo` is injectable so the route/cron can reuse their cached lookup and
  * tests can stub it without network.
@@ -235,9 +263,17 @@ export async function ensureUpdateStaged(
 	const version = latest.latest;
 
 	const state = await readUpdateState(dataDir);
-	if (state.state === UpdateState.Downloading) return;
-	if (state.state === UpdateState.Staged && state.targetVersion === version) return;
-	if (state.state === UpdateState.Error && state.targetVersion === version) return;
+	const sameVersion = state.targetVersion === version;
+	const age = state.updatedAt ? Date.now() - state.updatedAt : Number.POSITIVE_INFINITY;
+
+	// Already staged for this version — nothing to do.
+	if (state.state === UpdateState.Staged && sameVersion) return;
+	// A download for this version is still in flight (recent enough to be alive). A
+	// stale one was abandoned by a restart/crash, so fall through and re-attempt.
+	if (state.state === UpdateState.Downloading && sameVersion && age < STAGE_DOWNLOAD_STALE_MS)
+		return;
+	// A prior attempt errored for this version — back off for a cooldown, then re-attempt.
+	if (state.state === UpdateState.Error && sameVersion && age < STAGE_ERROR_COOLDOWN_MS) return;
 
 	try {
 		await downloadAndStage(version, dataDir);

--- a/packages/server/test/updater.test.ts
+++ b/packages/server/test/updater.test.ts
@@ -6,12 +6,21 @@ import { join } from 'node:path';
 import { UpdateState } from '@hezo/shared';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+	ASSET_DOWNLOAD_TIMEOUT_MS,
 	applyStagedUpdate,
 	currentAssetName,
 	downloadAndStage,
 	ensureUpdateStaged,
 	readUpdateState,
+	STAGE_DOWNLOAD_STALE_MS,
+	STAGE_ERROR_COOLDOWN_MS,
 } from '../src/services/updater';
+
+describe('staging timing invariants', () => {
+	it('keeps the staleness window above the download timeout so a slow live download is never preempted', () => {
+		expect(STAGE_DOWNLOAD_STALE_MS).toBeGreaterThan(ASSET_DOWNLOAD_TIMEOUT_MS);
+	});
+});
 
 async function tmp(prefix: string): Promise<string> {
 	return mkdtemp(join(tmpdir(), prefix));
@@ -145,10 +154,14 @@ describe('ensureUpdateStaged', () => {
 		}
 	});
 
-	it('no-ops while a download is in flight', async () => {
+	it('no-ops while a fresh download is in flight', async () => {
 		const dir = await tmp('hezo-ensure-downloading-');
 		try {
-			await seedState(dir, { state: UpdateState.Downloading, targetVersion: '9.9.9' });
+			await seedState(dir, {
+				state: UpdateState.Downloading,
+				targetVersion: '9.9.9',
+				updatedAt: Date.now(),
+			});
 			const fetchSpy = vi.spyOn(globalThis, 'fetch');
 			await ensureUpdateStaged(dir, latest());
 			expect(fetchSpy).not.toHaveBeenCalled();
@@ -157,13 +170,49 @@ describe('ensureUpdateStaged', () => {
 		}
 	});
 
-	it('does not re-download once it has errored for that version (retry exhausted)', async () => {
-		const dir = await tmp('hezo-ensure-errored-');
+	it('re-attempts a stale (abandoned) download', async () => {
+		const dir = await tmp('hezo-ensure-downloading-stale-');
 		try {
-			await seedState(dir, { state: UpdateState.Error, targetVersion: '9.9.9' });
+			await seedState(dir, {
+				state: UpdateState.Downloading,
+				targetVersion: '9.9.9',
+				updatedAt: Date.now() - STAGE_DOWNLOAD_STALE_MS - 1,
+			});
+			mockRelease(Buffer.from('new binary'));
+			await ensureUpdateStaged(dir, latest());
+			expect((await readUpdateState(dir)).state).toBe(UpdateState.Staged);
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	it('respects the error cooldown (does not re-download within the window)', async () => {
+		const dir = await tmp('hezo-ensure-errored-fresh-');
+		try {
+			await seedState(dir, {
+				state: UpdateState.Error,
+				targetVersion: '9.9.9',
+				updatedAt: Date.now(),
+			});
 			const fetchSpy = vi.spyOn(globalThis, 'fetch');
 			await ensureUpdateStaged(dir, latest());
 			expect(fetchSpy).not.toHaveBeenCalled();
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	it('re-attempts a download once the error cooldown has elapsed', async () => {
+		const dir = await tmp('hezo-ensure-errored-stale-');
+		try {
+			await seedState(dir, {
+				state: UpdateState.Error,
+				targetVersion: '9.9.9',
+				updatedAt: Date.now() - STAGE_ERROR_COOLDOWN_MS - 1,
+			});
+			mockRelease(Buffer.from('new binary'));
+			await ensureUpdateStaged(dir, latest());
+			expect((await readUpdateState(dir)).state).toBe(UpdateState.Staged);
 		} finally {
 			await rm(dir, { recursive: true, force: true });
 		}

--- a/packages/web/src/components/update-banner.tsx
+++ b/packages/web/src/components/update-banner.tsx
@@ -2,7 +2,7 @@ import { UpdateState } from '@hezo/shared';
 import { X } from 'lucide-react';
 import { useState } from 'react';
 import { useMe } from '../hooks/use-me';
-import { useApplyUpdate, useUpdateStatus } from '../hooks/use-update-check';
+import { useApplyUpdate, useDownloadUpdate, useUpdateStatus } from '../hooks/use-update-check';
 import { Button } from './ui/button';
 import { ConfirmDialog } from './ui/confirm-dialog';
 import { UpdateRestartOverlay } from './update-restart-overlay';
@@ -41,14 +41,16 @@ function readDismissed(): Dismissal | null {
  * binary), the caller is a superuser, and the binary is staged, an "Install &
  * restart" button — after a confirmation that warns about the master-key
  * re-unlock — restarts onto it instantly. While the background download is still
- * in flight the banner stays hidden; on a download error (and for any instance
- * that can't self-apply) it falls back to a link to the GitHub Release.
- * Dismissal lasts until the next calendar day (or until a newer version ships).
+ * in flight the banner stays hidden; if staging errored on a self-applying
+ * instance it offers a "Retry download" button (with the GitHub Release as a
+ * secondary link), and for any instance that can't self-apply it falls back to the
+ * release link. Dismissal lasts until the next calendar day (or a newer version ships).
  */
 export function UpdateBanner() {
 	const { data } = useUpdateStatus();
 	const { data: me } = useMe();
 	const apply = useApplyUpdate();
+	const download = useDownloadUpdate();
 	const [applying, setApplying] = useState(false);
 	const [confirmOpen, setConfirmOpen] = useState(false);
 	const [dismissed, setDismissed] = useState<Dismissal | null>(readDismissed);
@@ -81,9 +83,11 @@ export function UpdateBanner() {
 		setDismissed(record);
 	};
 
-	// Instant restart only once the binary is staged; otherwise (download errored,
-	// or this instance can't self-apply) fall back to the release-page download.
+	// Instant restart only once the binary is staged. A self-applying instance whose
+	// staging errored can re-trigger the background download; otherwise (can't
+	// self-apply) fall back to the release-page download.
 	const showInstall = canApply && staged;
+	const showRetry = canApply && !staged && errored;
 
 	const confirmDescription = (
 		<>
@@ -120,6 +124,30 @@ export function UpdateBanner() {
 					>
 						Install & restart
 					</Button>
+				) : showRetry ? (
+					<>
+						<Button
+							type="button"
+							variant="primary"
+							size="sm"
+							data-testid="update-retry-button"
+							disabled={download.isPending}
+							onClick={() => download.mutate()}
+						>
+							{download.isPending ? 'Downloading…' : 'Retry download'}
+						</Button>
+						{data.url && (
+							<a
+								href={data.url}
+								target="_blank"
+								rel="noreferrer"
+								data-testid="update-download-link"
+								className="underline underline-offset-2 hover:no-underline"
+							>
+								Download manually
+							</a>
+						)}
+					</>
 				) : (
 					data.url && (
 						<a

--- a/packages/web/src/hooks/use-update-check.ts
+++ b/packages/web/src/hooks/use-update-check.ts
@@ -1,5 +1,5 @@
 import type { UpdateState } from '@hezo/shared';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { api } from '../lib/api';
 import { queryKeys } from '../lib/query-keys';
 
@@ -58,5 +58,22 @@ export function useApplyUpdate() {
 	return useMutation({
 		mutationFn: () =>
 			api.post<{ state: UpdateState; targetVersion: string | null }>('/api/updates/apply'),
+	});
+}
+
+/**
+ * Kick a fresh background download+verify+stage of the latest release. Used by the
+ * banner to retry after a failed/abandoned auto-stage, since the server's poll-driven
+ * staging backs off on error. Invalidates the status query so the lifecycle
+ * (`downloading → staged`) is reflected as the server progresses.
+ */
+export function useDownloadUpdate() {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: () =>
+			api.post<{ data: { state: UpdateState; targetVersion: string | null } }>(
+				'/api/updates/download',
+			),
+		onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.updateStatus() }),
 	});
 }

--- a/packages/web/test/update-banner.test.tsx
+++ b/packages/web/test/update-banner.test.tsx
@@ -75,13 +75,28 @@ test('banner stays hidden while the background download is in flight', () => {
 	}
 });
 
-test('a download error falls back to the release-page download link', () => {
+test('a staging error on a self-applying instance offers a retry (with a manual link)', () => {
 	const { getByTestId, getByText, queryByTestId } = renderBanner({ state: UpdateState.Error });
 	expect(getByTestId('update-banner')).toBeTruthy();
 	// No instant-restart button — the staged binary never landed.
 	expect(queryByTestId('update-restart-button')).toBeNull();
-	const link = getByText('Download') as HTMLAnchorElement;
+	// The retry button re-triggers the background download; the release page stays
+	// available as a secondary fallback.
+	expect(getByTestId('update-retry-button').textContent).toContain('Retry download');
+	const link = getByText('Download manually') as HTMLAnchorElement;
 	expect(link.getAttribute('href')).toBe('https://github.com/hezo-ai/hezo/releases/0.2.0');
+});
+
+test('retry posts to the download route to re-stage', async () => {
+	const user = userEvent.setup();
+	const postSpy = vi
+		.spyOn(api, 'post')
+		.mockResolvedValue({ data: { state: UpdateState.Downloading, targetVersion: '0.2.0' } });
+	// onSuccess invalidates the status query; stub the refetch so it doesn't hit the network.
+	vi.spyOn(api, 'get').mockResolvedValue({ ...BASE, state: UpdateState.Downloading });
+	const { getByTestId } = renderBanner({ state: UpdateState.Error });
+	await user.click(getByTestId('update-retry-button'));
+	await waitFor(() => expect(postSpy).toHaveBeenCalledWith('/api/updates/download'));
 });
 
 test('Install & restart asks for confirmation (with master-key warning) before applying', async () => {


### PR DESCRIPTION
## Problem

On production, the in-app updater showed only a **Download** link to the GitHub release instead of the **Install & restart** button, even though the box is a fully capable supervised compiled binary.

Root cause confirmed from the live `state.json`:

```json
{ "state": "error", "targetVersion": "0.8.0", "asset": "hezo-linux-arm64", "error": "The operation timed out." }
```

Two compounding bugs:

1. **The download timed out.** The asset-fetch budget was a flat **120 s**, but the release binaries are ~130 MB — on a slower link to GitHub's CDN that simply can't complete in time.
2. **The failure became permanent.** `ensureUpdateStaged` returned early forever once `state.json` was `Error` (or `Downloading`) for the target version, so the poll-driven auto-stage never retried — and the banner has no retry affordance, only the release link. A single transient timeout wedged staging until manual intervention.

## Fix

- **Self-healing staging** — `ensureUpdateStaged` no longer treats `Error`/`Downloading` as terminal. An errored version re-attempts after a cooldown (`STAGE_ERROR_COOLDOWN_MS`, 30 min); a stale `Downloading` (worker crashed/restarted mid-download) is re-attempted once it exceeds `STAGE_DOWNLOAD_STALE_MS`. The state file gained an `updatedAt` stamp to drive this.
- **Generous download budget** — asset fetch raised **120 s → 10 min** (`ASSET_DOWNLOAD_TIMEOUT_MS`). The staleness window is kept safely **above** the download budget so a slow-but-live download is never preempted by a concurrent poll (guarded by a regression test).
- **Retry in the UI** — a self-applying instance whose staging errored now shows a **Retry download** button (`POST /api/updates/download`) with the GitHub release as a secondary manual link, instead of only the link.
- **Build hygiene** — exclude `docker-bundle.json` / `static-bundle.json` from biome formatting (matching the other generated bundles) so a built working tree commits cleanly.
- **Docs** — `.dev/architecture.md` and `docs/deployment/self-hosting.md` updated to the new behavior.

## Testing

- `packages/server` updater + update-route suites — 30 pass (incl. new cooldown / stale-download / timing-invariant cases).
- `packages/web` update-banner suite — 13 pass (incl. retry-button render + `POST /api/updates/download` on click).
- Typecheck, biome, and full build green (pre-commit hook).

## Production remediation

The stuck `/root/.hezo/.update` was already cleared on the box, so it re-stages on the next poll; with the larger timeout it now has 10 min to complete. Going forward the cooldown/retry makes this self-healing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159NAMbuBCMYB36MGBMR8SW