### PR TITLE
feat(goals): skip by deadline as well as cadence in Captain heartbeat

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -264,6 +264,13 @@ Never commit `.js`/`.d.ts`/`.js.map`/`.d.ts.map` alongside source. Compiled outp
 - Use shared constants/enums from `@hezo/shared` (`packages/shared/src/types/common.ts`) — no raw status/type strings. Add new enum values to the shared package first.
 - `bunx`, not `npx`.
 
+### User-facing docs terminology
+
+These rules apply to **user-facing prose** — the `docs/` tree and anything a Hezo operator reads — because the audience is users, not engineers. They do **not** force renames of code identifiers, DB columns, route paths, or internal comments.
+
+- **Say "task", never "ticket".** The work item on the board is a **task** everywhere in `docs/`. "Ticket" is banned from user-facing prose — use "task" (plural "tasks"). The generated `docs/reference/mcp-api.md` is the one exception: it is built from the MCP tool registry and must not be hand-edited; when you author a tool's description or `TOOL_DOC_META` that will surface there, prefer "task" too so the generated page stays consistent.
+- **Say "global", never "instance-wide".** Describe HQ, the CEO, the Coach, skills, and MCP connections as **global** (e.g. "the global HQ project"). Users don't know what "instance-wide" means — don't use it in `docs/`.
+
 ### Web frontend mutations
 
 Three strategies, picked by mutation shape. Default to optimistic unless the mutation falls into the response-driven or invalidate carve-outs below.

--- a/docs/concepts/coach-and-self-improving-teams.md
+++ b/docs/concepts/coach-and-self-improving-teams.md
@@ -8,17 +8,17 @@ section: Concepts
 
 Most agent setups stay exactly as good as the day you wrote their prompts. Hezo teams
 don't: they get better the more they ship. That improvement loop is run by the **Coach** —
-an instance-wide agent whose only job is to turn finished work into durable lessons, so
+a global agent whose only job is to turn finished work into durable lessons, so
 the same mistake doesn't happen twice.
 
 ## What the Coach is
 
-The **Coach** is one of two instance-wide roles that live in
+The **Coach** is one of two global roles that live in
 [HQ](/docs/concepts/projects-and-teams#hq--the-home-team) (the other is the
 [CEO](/docs/concepts/roles-and-coordination#the-ceo)). There is exactly one Coach for the
 whole instance, it isn't a member of any single project team, and it reports to you — the
 admin. Unlike a worker, it doesn't pick up tasks, write features, or review code. Its sole
-purpose is **organisational learning**: reviewing how completed tickets actually went and
+purpose is **organisational learning**: reviewing how completed tasks actually went and
 improving the agents involved.
 
 The Coach's behaviour comes from its
@@ -26,14 +26,14 @@ The Coach's behaviour comes from its
 
 ## How the loop works
 
-Every ticket already carries a rich record of how the work went — the comment thread,
+Every task already carries a rich record of how the work went — the comment thread,
 the back-and-forth, any rejections or rework, and what each agent actually did (see
 [Tasks, rules & summaries](/docs/concepts/tasks)). The Coach reads that record after the
 fact and mines it for patterns.
 
-1. **A ticket is completed.** When a task is marked **Done** — in any project, in any
-   team — the Coach is woken automatically with that ticket's full history. It also runs
-   on its own heartbeat to catch any completed tickets that slipped through.
+1. **A task is completed.** When a task is marked **Done** — in any project, in any
+   team — the Coach is woken automatically with that task's full history. It also runs
+   on its own heartbeat to catch any completed tasks that slipped through.
 2. **It reviews the whole thread.** The Coach reads the comments and the agents' work
    end to end, looking for the moments that matter: work that got sent back, an agent that
    received corrective feedback or made a wrong assumption, an approach that was tried and
@@ -42,12 +42,12 @@ fact and mines it for patterns.
    out which agent (or agents) should learn from it and writes a concise, generalisable
    **learned rule** into their system prompt. It updates *everyone* involved in the
    feedback loop, not just the agent that got the direct pushback.
-4. **It closes the loop.** The Coach leaves a short summary comment on the ticket noting
-   what it changed (or that the ticket went smoothly and needed nothing). The ticket stays
+4. **It closes the loop.** The Coach leaves a short summary comment on the task noting
+   what it changed (or that the task went smoothly and needed nothing). The task stays
    in its final **Done** state — the Coach reviews it but does not change its status.
 
 This sits at the very end of the task lifecycle: **Done** is the final, completed state;
-the Coach's post-mortem runs against a done ticket without moving it anywhere. The review
+the Coach's post-mortem runs against a done task without moving it anywhere. The review
 happens in the background — you don't have to trigger it or wait on it.
 
 ## Learned rules
@@ -55,7 +55,7 @@ happens in the background — you don't have to trigger it or wait on it.
 A **learned rule** is a short, specific instruction the Coach appends to an agent's
 system prompt — collected together in a dedicated *Learned Rules* section so they're easy
 to find. A rule is a generalisable lesson ("always confirm the target environment before
-running a migration"), never a one-off fix for a single ticket.
+running a migration"), never a one-off fix for a single task.
 
 The Coach is deliberately conservative about what it writes:
 
@@ -64,7 +64,7 @@ The Coach is deliberately conservative about what it writes:
   existing instructions.
 - **No duplicates** — it reads an agent's current prompt first and skips anything already
   covered.
-- **When in doubt, it skips** — a false lesson is worse than a missed one, and a ticket
+- **When in doubt, it skips** — a false lesson is worse than a missed one, and a task
   that went cleanly gets no changes at all.
 
 Because learned rules are just additions to the system prompt, they behave exactly like
@@ -89,8 +89,8 @@ best. See [Documents & memory](/docs/concepts/documents-and-memory).
 
 ## Why this matters
 
-The result is a team that compounds. Each shipped ticket isn't just a finished piece of
-work — it's a data point that makes the next ticket go a little smoother. Agents stop
+The result is a team that compounds. Each shipped task isn't just a finished piece of
+work — it's a data point that makes the next task go a little smoother. Agents stop
 repeating the mistakes that earned them pushback, conventions that were learned the hard
 way get written down, and the whole roster sharpens over time **without you hand-tuning
 prompts after every misstep**. You keep the final say through approvals and rollbacks; the

--- a/docs/concepts/documents-and-memory.md
+++ b/docs/concepts/documents-and-memory.md
@@ -15,11 +15,11 @@ That memory lives at a few different scopes, and each one is kept current by you
 the agents as they work:
 
 - **Per task** — the [rules, description, and progress summary](/docs/concepts/tasks) that
-  say how a ticket should be worked and where it stands, plus the comment thread an agent
+  say how a task should be worked and where it stands, plus the comment thread an agent
   reads to catch up on what's happened.
 - **Per project** — the **Documents** library of PRDs, specs, and research the whole team
   keeps coming back to.
-- **Instance-wide** — [skills](/docs/concepts/skills), the reusable know-how every team can
+- **Global** — [skills](/docs/concepts/skills), the reusable know-how every team can
   reach for.
 - **Per team** — [preferences](#team-preferences): custom instructions applied to every
   agent on a team.
@@ -53,7 +53,7 @@ cached to go stale. Context reaches the agent in one of two ways:
 | Team preferences | One team | In full, every run | You |
 | Chatbox memory | The CEO | In full, every chat turn | You and the CEO |
 
-For how rules, the progress summary, and the thread work together on a single ticket — and
+For how rules, the progress summary, and the thread work together on a single task — and
 how an agent uses them to pick up where the last run left off — see
 [Tasks, rules & summaries](/docs/concepts/tasks).
 
@@ -128,10 +128,10 @@ prompts, every edit is **versioned and restorable**.
 All of the above is memory, but each piece has a natural home — putting knowledge in the
 right place is what keeps it findable and applied at the right moment:
 
-- **Where one ticket stands right now** → that task's **progress summary**.
-- **How a single ticket must be worked** (guardrails, required steps) → that task's
+- **Where one task stands right now** → that task's **progress summary**.
+- **How a single task must be worked** (guardrails, required steps) → that task's
   **rules**.
-- **What a ticket is and the domain context to do it** → that task's **description**.
+- **What a task is and the domain context to do it** → that task's **description**.
 - **Project-wide knowledge many tasks draw on** (the spec, the plan, the research) →
   a **project document**.
 - **Reusable, project-independent know-how** (how to use an MCP server, a release
@@ -140,5 +140,5 @@ right place is what keeps it findable and applied at the right moment:
 - **Your durable preferences for how the CEO works with you** → the CEO's **chatbox
   memory**.
 
-When in doubt, keep ticket-specific status in the summary, how-to-work constraints in the
+When in doubt, keep task-specific status in the summary, how-to-work constraints in the
 rules, and anything the wider team will need again in a document or a skill.

--- a/docs/concepts/goals.md
+++ b/docs/concepts/goals.md
@@ -21,7 +21,7 @@ Open **Progress** in the project menu (just under **Inbox**). Top to bottom it s
 
 - a **project progress summary** the Captain keeps current — a short blurb of what's done,
   what's in progress, and what's still to do. It opens collapsed (showing the Captain's
-  headline points); expand it for the full narrative, which may link a few key tickets.
+  headline points); expand it for the full narrative, which may link a few key tasks.
 - your **goals**, each as a panel with its progress, health, and a sparkline. Click a goal to
   open its own page.
 - the recent **goal heartbeat runs** for the project.
@@ -39,7 +39,8 @@ menu). A goal has:
   the goal: specific checks, or a standing instruction like "run a weekly cron-style review of
   the signup funnel". Leave it blank to let the Captain decide.
 - **Deadline** *(optional)* — when the goal should be met. The Captain weighs progress against
-  this date when it sets the goal's health.
+  this date when it sets the goal's health, and once the deadline has passed the goal is checked
+  on every heartbeat — regardless of its check frequency — until it's met or archived.
 - **Check frequency** — how often the Captain re-assesses the goal: **daily** (the default),
   **weekly**, or **monthly**.
 
@@ -51,11 +52,13 @@ same form.
 
 ## How the Captain tracks progress
 
-On the Captain's heartbeat, it looks at which goals are **due** for a check (based on each
-goal's frequency) and runs a single **goal check** covering all of them at once. Goals that
-aren't due yet are skipped. For each due goal the Captain assesses real progress toward the
-outcome — reading the relevant tickets, comments, and project state rather than just counting
-finished tasks — and records three things:
+On the Captain's heartbeat, it looks at which goals are **due** for a check and runs a single
+**goal check** covering all of them at once. A goal is due when its **check frequency** has come
+round (last checked longer ago than its cadence, or never checked) **or** once its **deadline**
+has passed — a goal past its deadline is always checked and never skipped while it stays active.
+Goals that aren't due on either count are skipped. For each due goal the Captain assesses real
+progress toward the outcome — reading the relevant tasks, comments, and project state rather than
+just counting finished tasks — and records three things:
 
 - a **progress percentage** (0–100) — its honest estimate of how far along the goal is,
 - a **health** — a coloured pill that reads at a glance: **on track** (green), **at risk**
@@ -69,7 +72,7 @@ has moved over time, so you can see momentum (or a stall) at a glance.
 These goal checks are **not** done inside a task — they're standalone Captain runs. The recent
 goal checks for the whole project appear at the bottom of the **Progress** page. Each goal's own
 page also has a **Goal heartbeat runs** section showing just the runs that did something for *that*
-goal — the progress it set, plus any tickets it created or commented on toward the goal.
+goal — the progress it set, plus any tasks it created or commented on toward the goal.
 
 During the same run the Captain also refreshes the **project progress summary** shown at the top
 of the Progress page, so that headline stays in step with the goal estimates.
@@ -84,15 +87,15 @@ files work for it. Unarchive it any time to bring it back into rotation.
 ## Goals and the board
 
 When the Captain decides a goal needs a push, it either **comments on an existing in-flight
-ticket** to steer or unblock it, or **files new tickets** through the normal delegation flow and
-links them to the goal. But it doesn't create work for its own sake: if tickets already in the
+task** to steer or unblock it, or **files new tasks** through the normal delegation flow and
+links them to the goal. But it doesn't create work for its own sake: if tasks already in the
 backlog or in flight will advance the goal, the Captain leaves the board alone. The point of a
 goal check is to judge whether the project is on course — not to manufacture busywork every time
-a goal comes due. The Captain never re-opens a closed ticket; if something needs redoing it files
-a fresh ticket that points back at the original.
+a goal comes due. The Captain never re-opens a closed task; if something needs redoing it files
+a fresh task that points back at the original.
 
 The estimate is exactly that — an estimate, made by the Captain. Treat the **blurb** as the
 primary signal and the **percentage** as a quick gauge of direction. Together they let you
-glance at a project and know where it's headed without reading every ticket.
+glance at a project and know where it's headed without reading every task.
 
-> Goals are a per-project concept. The instance-wide **HQ** project does not have goals.
+> Goals are a per-project concept. The global **HQ** project does not have goals.

--- a/docs/concepts/hiring-and-agents.md
+++ b/docs/concepts/hiring-and-agents.md
@@ -49,7 +49,7 @@ Every agent's system prompt is editable from its settings at any time. Changes t
 effect on the agent's next run, so you can correct course — tighten scope, add a
 convention, change tone — without rebuilding anything. The required substitution variables
 must remain in the prompt; an edit that drops one is rejected so an agent never loses its
-identity or live context. (The instance-wide CEO and Coach are exempt — they have no
+identity or live context. (The global CEO and Coach are exempt — they have no
 manager.)
 
 ## Per-agent model override
@@ -67,7 +67,7 @@ scheduled and unassigns it from any open tasks, but keeps all of its history, so
 fully reversible: reinstate (enable) it at any time and it picks work back up on its
 heartbeat. The CEO actions this directly once you confirm, which is handy after a
 project's direction changes and several roles no longer fit. (A team's Captain and the
-instance-wide CEO and Coach can't be retired this way.)
+global CEO and Coach can't be retired this way.)
 
 ## Other settings
 

--- a/docs/concepts/meta-harness.md
+++ b/docs/concepts/meta-harness.md
@@ -90,7 +90,7 @@ heartbeat) paired with a model — and you can give any agent its own model. See
 ### How work is organised
 
 - A **project** owns exactly one **team** (its agent roster).
-- A team has a **Captain** plus worker roles; an instance-wide **CEO** and **Coach**
+- A team has a **Captain** plus worker roles; a global **CEO** and **Coach**
   oversee everything from **HQ**.
 - Work flows as **tasks** on a board, each with a description, optional rules, and a
   living progress summary.

--- a/docs/concepts/projects-and-teams.md
+++ b/docs/concepts/projects-and-teams.md
@@ -26,7 +26,7 @@ to swap it or **Remove** to go back to the initials.
 ## Team templates
 
 When you create a project you choose a **template**, which decides the starting roster.
-Every template gives the team a **Captain** to lead it. The instance-wide CEO and Coach
+Every template gives the team a **Captain** to lead it. The global CEO and Coach
 are never part of a template — they live in HQ (below).
 
 Hezo ships with two built-in templates. Each agent's behaviour comes from a **system
@@ -50,7 +50,7 @@ Named **Startup** in the template picker, this is a **Captain** plus a full
 software-development roster:
 
 - [Captain](https://github.com/hezo-ai/hezo/blob/main/agents/software-development/captain.md) —
-  leads the team, breaks the goal into tickets, and coordinates delivery.
+  leads the team, breaks the goal into tasks, and coordinates delivery.
 - [Architect](https://github.com/hezo-ai/hezo/blob/main/agents/software-development/architect.md) —
   technical vision, specs, and architecture decisions; gates and schedules the deploy.
 - [Product Lead](https://github.com/hezo-ai/hezo/blob/main/agents/software-development/product-lead.md) —
@@ -103,7 +103,7 @@ the other.
 
 ## HQ — the home team
 
-**HQ** is the one special, instance-wide team. It's the permanent home of the two roles
+**HQ** is the one special, global team. It's the permanent home of the two roles
 that work across every project — the **CEO** and the **Coach** — and it's where
 instance-level settings live (model providers, shared connections, and the like). HQ is
 also where you [chat with the CEO](/docs/concepts/roles-and-coordination#chatting-with-the-ceo):

--- a/docs/concepts/roles-and-coordination.md
+++ b/docs/concepts/roles-and-coordination.md
@@ -10,7 +10,7 @@ Hezo organises agents like a company. A few roles coordinate; the rest do the wo
 
 ## The CEO
 
-The **CEO** is the instance-wide executive, and your main point of contact. There is
+The **CEO** is the global executive, and your main point of contact. There is
 exactly one CEO, and it lives in [HQ](/docs/concepts/projects-and-teams#hq--the-home-team) —
 so it can see and act across every project. You chat with the CEO to get things done
 across the whole instance:
@@ -19,7 +19,7 @@ across the whole instance:
   team once you've confirmed the plan (see
   [Your first project](/docs/getting-started/first-project)). It won't create anything
   until you give the go-ahead.
-- **Coordination** — ask about any project's status, tickets, or roster; the CEO
+- **Coordination** — ask about any project's status, tasks, or roster; the CEO
   works across every team.
 - **Setup review** — before a new team starts planning, the CEO aligns its roster with the
   goal. When the CEO creates a project with you, it sets the team up according to the plan
@@ -37,7 +37,7 @@ The CEO's behaviour comes from its
 
 ## The Coach
 
-The **Coach** is the second instance-wide role that lives in HQ. Whenever a ticket is
+The **Coach** is the second global role that lives in HQ. Whenever a task is
 completed — in any project — the Coach automatically reviews how it went: it reads the
 whole thread, notices where an agent struggled, got pushback, or needed several attempts,
 and captures what went well and what to improve. It then writes those lessons back as
@@ -50,7 +50,7 @@ this loop works, see
 The Coach's behaviour comes from its
 [system prompt](https://github.com/hezo-ai/hezo/blob/main/agents/_instance/coach.md).
 
-Both the CEO and the Coach are instance-wide singletons that live in
+Both the CEO and the Coach are global singletons that live in
 [HQ](/docs/concepts/projects-and-teams#hq--the-home-team) — the one special team — and
 act across every project's team. They are never part of a project template.
 
@@ -85,7 +85,7 @@ modal view. Collapse it back to the anchored panel when you're done, or press **
 Because the CEO works across the whole instance, you can ask about anything without
 opening a project first: "how's the marketing site coming along?", "what's the engineering
 team stuck on?", "spin up a team to research competitors". It answers with knowledge of
-every project, ticket, and roster.
+every project, task, and roster.
 
 The chat is also the control surface for the things that are awkward to click through:
 scoping work, reorganising a team, or changing how an agent behaves. State what you want

--- a/docs/concepts/search.md
+++ b/docs/concepts/search.md
@@ -33,7 +33,7 @@ The palette closes and you land where you needed to be.
 
 The palette searches **across all the teams you can access** at once — you don't pick a
 project first, and [HQ](/docs/concepts/projects-and-teams#hq--the-home-team) is included
-like any other team. Skills are instance-wide, so they turn up wherever you search.
+like any other team. Skills are global, so they turn up wherever you search.
 Scoping is enforced on the server: content from a team you can't see never appears in
 your results.
 

--- a/docs/concepts/tasks.md
+++ b/docs/concepts/tasks.md
@@ -6,7 +6,7 @@ section: Concepts
 
 # Tasks, rules & summaries
 
-Work in Hezo flows as **tasks** (tickets) on a board. Agents pick up tasks, do the
+Work in Hezo flows as **tasks** on a board. Agents pick up tasks, do the
 work, comment as they go, and move them through their statuses. Each task carries three
 distinct pieces of context, and keeping them separate is what lets work hand off
 cleanly between runs and between agents.
@@ -26,7 +26,7 @@ cleanly between runs and between agents.
 
 All three travel with the task as its **long-term memory**: at the start of every run the
 agent is handed the description, the rules, and the latest progress summary **in full**, so
-work carries cleanly from one run to the next even when a different agent picks the ticket
+work carries cleanly from one run to the next even when a different agent picks the task
 up. You can set the rules and edit the summary yourself from the task view at any time, and
 so can the agents. See [Documents & long-term memory](/docs/concepts/documents-and-memory)
 for how this fits the wider memory model.
@@ -46,19 +46,19 @@ The thread isn't just a chat log — it's part of the task's memory. When an age
 run on a task, it doesn't only rely on the injected description, rules, and progress
 summary: it **reads the comment thread to catch up on what's currently happening** — what
 other agents have already done, the decisions and feedback so far, open questions, and
-anything you've added since it last looked. That's how an agent stays current on a ticket
+anything you've added since it last looked. That's how an agent stays current on a task
 it shares with teammates and with you, rather than acting on a stale picture.
 
 When a run is triggered by an **@-mention**, or by a **reply** to one of the agent's own
 earlier comments, the triggering comment is put in front of the agent directly, so it acts
 on exactly the message that woke it.
 
-The practical upshot: keep discussion, decisions, and hand-offs on the ticket. Whatever
+The practical upshot: keep discussion, decisions, and hand-offs on the task. Whatever
 lands in the thread is inherited by the next agent that picks the task up — so the
 conversation compounds instead of evaporating between runs.
 
 ## Review on completion
 
-When work finishes, the **Coach** reviews completed tickets across your projects,
+When work finishes, the **Coach** reviews completed tasks across your projects,
 capturing lessons that feed back into how the teams improve. See
 [The Coach & self-improving teams](/docs/concepts/coach-and-self-improving-teams).

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -45,7 +45,7 @@ agent can't hurt you. A few guarantees sit underneath everything:
 - **Chat with the CEO in real time** to scope work, create projects, hire new agents, edit
   system prompts, and adjust settings — all from one conversation, with replies streaming
   back as it works. See [Roles & the CEO](/docs/concepts/roles-and-coordination).
-- **Get teams that improve themselves.** Whenever a ticket is finished, the Coach reviews
+- **Get teams that improve themselves.** Whenever a task is finished, the Coach reviews
   how it went and writes durable lessons back onto the agents, so they get better the more
   they ship — without you hand-tuning prompts. See
   [The Coach & self-improving teams](/docs/concepts/coach-and-self-improving-teams).
@@ -56,9 +56,9 @@ agent can't hurt you. A few guarantees sit underneath everything:
 - **Put a hard ceiling on spend.** Per-agent and per-project budgets with live cost
   tracking *pause* runs when a limit is hit and *auto-resume* when the window rolls over —
   control without babysitting. See [Budgets & cost control](/docs/concepts/budgets-and-costs).
-- **Steer by outcome, not just tickets.** Set high-level **goals** and let the Captain re-check
+- **Steer by outcome, not just tasks.** Set high-level **goals** and let the Captain re-check
   each one on a schedule — it writes a fresh progress estimate, health, and status — so you can see
-  where a project stands without reading every ticket. See [Goals & progress](/docs/concepts/goals).
+  where a project stands without reading every task. See [Goals & progress](/docs/concepts/goals).
 - **Set the rules per task** and let agents keep a running progress summary so work
   carries cleanly across runs. See [Tasks, rules & summaries](/docs/concepts/tasks).
 - **Give your agents long-term memory — versioned and reversible.** Keep durable project

--- a/docs/mcp/connecting-mcp-servers.md
+++ b/docs/mcp/connecting-mcp-servers.md
@@ -32,7 +32,7 @@ choice.
 
 ## Where a connection applies
 
-MCP connections are **instance-wide**: there's a single shared catalog and each
+MCP connections are **global**: there's a single shared catalog and each
 connection name is unique across the instance. Once you add a server it's available to
 every team's agent runs.
 

--- a/docs/mcp/hezo-mcp-server.md
+++ b/docs/mcp/hezo-mcp-server.md
@@ -29,7 +29,7 @@ tools into.
 
 Create an API key under **Settings → API keys** in the web app. Copy the key when it's
 shown — it isn't displayed again. It starts with `hezo_` and goes in the
-`Authorization: Bearer` header on every request. An API key has instance-wide access:
+`Authorization: Bearer` header on every request. An API key has global access:
 pass a `project` slug to project-scoped tools (use `list_projects` to discover them).
 
 Revoke a key at any time from the same page, which disables it immediately.
@@ -50,7 +50,7 @@ The flow:
    Until then the token is inert.
 4. **Poll** the `connection_status` tool (or `GET /api/api-keys/status` with the token)
    until it returns `{ "status": "approved" }`.
-5. **Use it.** The same token now authorizes `POST /mcp` with instance-wide access. Pass a
+5. **Use it.** The same token now authorizes `POST /mcp` with global access. Pass a
    `project` slug to project-scoped tools — use `list_projects` to discover them across the
    whole instance.
 

--- a/packages/server/src/services/goals.ts
+++ b/packages/server/src/services/goals.ts
@@ -235,8 +235,11 @@ export async function getGoalHistory(
 
 /**
  * Goals in a project that are due for a Captain check: active (not archived) and either
- * never checked or last checked longer ago than their cadence. Mirrors the interval-elapsed
- * test the heartbeat scheduler uses for agents.
+ * past their deadline or due on cadence. A goal whose **deadline** (`target_date`) has
+ * arrived is always checked — it is never skipped while it remains active. Otherwise the
+ * goal is skipped unless its **check frequency** is due: never checked, or last checked
+ * longer ago than its cadence. The cadence test mirrors the interval-elapsed check the
+ * heartbeat scheduler uses for agents.
  */
 export async function getDueGoals(db: PGlite, projectId: string): Promise<GoalRow[]> {
 	const r = await db.query<GoalRow>(
@@ -244,7 +247,8 @@ export async function getDueGoals(db: PGlite, projectId: string): Promise<GoalRo
 		 WHERE g.project_id = $1
 		   AND g.archived_at IS NULL
 		   AND (
-		     g.last_checked_at IS NULL
+		     (g.target_date IS NOT NULL AND g.target_date <= now())
+		     OR g.last_checked_at IS NULL
 		     OR g.last_checked_at + (CASE g.check_frequency
 		          WHEN 'daily'   THEN interval '1 day'
 		          WHEN 'weekly'  THEN interval '7 days'

--- a/packages/server/test/goals.test.ts
+++ b/packages/server/test/goals.test.ts
@@ -186,6 +186,29 @@ describe('goals service', () => {
 		expect(dueIds.has(weeklyRecent)).toBe(false);
 	});
 
+	it('checks a goal whose deadline is due even when its frequency is not', async () => {
+		// A goal is never skipped once its deadline (target_date) has arrived, regardless of
+		// cadence. A goal whose deadline is still in the future falls back to the frequency test.
+		const mk = async (title: string, checkedAgo: string, targetDate: string): Promise<string> => {
+			const r = await db.query<{ id: string }>(
+				`INSERT INTO goals (team_id, project_id, title, check_frequency, last_checked_at, target_date)
+				 VALUES ($1, $2, $3, 'weekly'::goal_check_frequency, now() - interval '${checkedAgo}', ${targetDate})
+				 RETURNING id`,
+				[teamId, projectId, title],
+			);
+			return r.rows[0].id;
+		};
+		// Checked an hour ago (frequency NOT due), but deadline passed yesterday -> due.
+		const deadlinePassed = await mk('deadline-passed', '1 hour', `now() - interval '1 day'`);
+		// Checked an hour ago (frequency NOT due), deadline a week out -> skipped.
+		const deadlineFuture = await mk('deadline-future', '1 hour', `now() + interval '7 days'`);
+
+		const due = await getDueGoals(db, projectId);
+		const dueIds = new Set(due.map((g) => g.id));
+		expect(dueIds.has(deadlinePassed)).toBe(true);
+		expect(dueIds.has(deadlineFuture)).toBe(false);
+	});
+
 	it('records progress: updates the goal, advances last_checked_at, writes history and run summary', async () => {
 		const goal = await db.query<{ id: string }>(
 			`INSERT INTO goals (team_id, project_id, title) VALUES ($1, $2, 'Track me') RETURNING id`,


### PR DESCRIPTION
## What & why

During a Captain heartbeat goal check, goals were selected for a check based **only** on their check frequency vs. `last_checked_at`. A goal's deadline (`target_date`) was purely informational — a goal could blow past its deadline yet sit unchecked until its cadence next came round.

This makes the skip logic deadline-aware, matching the intended behaviour:

- **Deadline is due** (`target_date <= now()`) → the goal is **never skipped**; it's checked on every heartbeat while it stays active.
- **Deadline not due** (future, or no deadline set) → unchanged: the goal is skipped unless its **check frequency** is due (never checked, or last checked longer ago than its cadence).

## Changes

**Code**
- `getDueGoals` (`packages/server/src/services/goals.ts`) gains an `OR (target_date IS NOT NULL AND target_date <= now())` to the due predicate, plus an updated doc comment.
- New test in `packages/server/test/goals.test.ts`: a goal whose deadline has passed but whose frequency has **not** is selected; a goal with a future deadline and a fresh check is **not**.

**Docs**
- `docs/concepts/goals.md` — describes deadline-aware skipping (the deadline bullet and the "How the Captain tracks progress" section).
- Replaced **"ticket(s)" → "task(s)"** across user-facing docs.
- Replaced **"instance-wide" → "global"** across user-facing docs (e.g. "the global HQ project").
- `AGENTS.md` — added a **User-facing docs terminology** rule under Conventions enforcing both: say "task" not "ticket", and "global" not "instance-wide" in `docs/` prose. The generated `docs/reference/mcp-api.md` is noted as the one exception (built from the MCP tool registry, not hand-edited).

## Scope notes

- The terminology sweep is intentionally limited to user-facing `docs/` prose. "ticket" is still pervasive in code identifiers, route messages, agent prompts, and internal comments — out of scope for a docs-readability change, and the new rule explicitly does not force code renames.
- The docs bundle (`docs-bundle.json`, injected into the CEO chat) and `mcp-api.md` were regenerated via `bun run build:docs`; `mcp-api.md` is unchanged since no tool descriptions were touched.

## Verification

- `bunx vitest run test/goals.test.ts` — 15 passing (incl. the new deadline case).
- `bunx vitest run test/docs-bundle.test.ts test/mcp-reference.test.ts test/llms-txt.test.ts` — green (drift guards).
- `turbo typecheck` + full build pass (run by the pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzjSVNdLZ5YunRmPKXbNCN)_