### PR TITLE
docs: add Team shapes concept page

### DIFF
--- a/docs/concepts/projects-and-teams.md
+++ b/docs/concepts/projects-and-teams.md
@@ -27,7 +27,9 @@ to swap it or **Remove** to go back to the initials.
 
 When you create a project you choose a **template**, which decides the starting roster.
 Every template gives the team a **Captain** to lead it. The global CEO and Coach
-are never part of a template — they live in HQ (below).
+are never part of a template — they live in HQ (below). A template is only the starting
+point — you reshape the team freely from there; see
+[Team shapes](/docs/concepts/team-shapes) for the bigger picture.
 
 Hezo ships with two built-in templates. Each agent's behaviour comes from a **system
 prompt** that you can read (and, once hired, customise — see

--- a/docs/concepts/projects-and-teams.md
+++ b/docs/concepts/projects-and-teams.md
@@ -28,8 +28,8 @@ to swap it or **Remove** to go back to the initials.
 When you create a project you choose a **template**, which decides the starting roster.
 Every template gives the team a **Captain** to lead it. The global CEO and Coach
 are never part of a template — they live in HQ (below). A template is only the starting
-point — you reshape the team freely from there; see
-[Team shapes](/docs/concepts/team-shapes) for the bigger picture.
+point — you change the team's structure freely from there; see
+[Team structure](/docs/concepts/team-structure) for the bigger picture.
 
 Hezo ships with two built-in templates. Each agent's behaviour comes from a **system
 prompt** that you can read (and, once hired, customise — see

--- a/docs/concepts/team-shapes.md
+++ b/docs/concepts/team-shapes.md
@@ -1,0 +1,98 @@
+---
+title: Team shapes
+order: 7.5
+section: Concepts
+---
+
+# Team shapes
+
+As models converge and features get copied, the part of an AI system that's hard to
+reproduce isn't the code — it's how the work is organised: which roles exist, how they
+report to each other, what each one is good at, and the tools, knowledge, and judgement
+they share. That arrangement is a team's **shape**, and in Hezo it's a first-class thing
+you compose, reshape, and reuse — not a fixed structure you're stuck with.
+
+A team's shape is the same idea as a *dynamic agent workflow*: instead of one fixed
+pipeline of model calls, the structure of the agents is chosen to fit the work in front
+of it, and changes as the work does. In Hezo that structure is an org chart of agents
+that you can pick a starting point for, evolve while a project runs, and carry forward to
+the next project.
+
+## What makes up a shape
+
+A team's shape is more than a list of agents. It's:
+
+- **The roster** — which roles exist on the team (a Captain plus whatever specialists the
+  work needs). See [Roles & the CEO](/docs/concepts/roles-and-coordination).
+- **The reporting lines** — who reports to whom. This org chart is what lets work be
+  delegated up and down the team, so it shapes how the team actually operates, not just
+  how it looks.
+- **What each role is** — every agent's [system prompt](/docs/concepts/hiring-and-agents#editing-system-prompts),
+  which defines its responsibilities, conventions, and how it works, plus the model it
+  runs on.
+- **What the team shares** — its [skills](/docs/concepts/skills),
+  [project documents and memory](/docs/concepts/documents-and-memory),
+  connected [MCP tools](/docs/mcp/connecting-mcp-servers), budgets, and the project
+  container they all work in.
+
+Change any of these and you've reshaped the team.
+
+## Choosing a starting shape
+
+Every project starts from a **template**, which decides the team's initial shape. Hezo
+ships with a minimal **Blank** team (just a Captain) and a full software-development
+**Startup** team, and you can add your own. For the built-in rosters and a link to every
+role's prompt, see
+[Team templates](/docs/concepts/projects-and-teams#team-templates).
+
+A template is just a convenient starting point — it's not a cage. The Blank team is
+designed to be grown into whatever the work needs; the Startup team is a fully-staffed
+shape for building software. Pick whichever is closest and adjust from there.
+
+## Reshaping a team while it runs
+
+A team's shape is meant to change as a project does. Nothing about it is locked in once
+the project is created:
+
+- **Hire** new roles when the work calls for a specialist the team doesn't have, and
+  **retire** roles it has outgrown — both are reversible, and a retired agent keeps its
+  history. See [Hiring & customizing agents](/docs/concepts/hiring-and-agents).
+- **Rewire reporting lines** to change how work flows through the team.
+- **Edit any agent's system prompt** to refine what a role does, or
+  [give a single agent its own model](/docs/concepts/hiring-and-agents#per-agent-model-override).
+
+You drive this in plain language through the
+[CEO chat](/docs/concepts/roles-and-coordination#chatting-with-the-ceo) — "this project
+needs a data analyst", "have QA report to the Architect" — and the CEO proposes the
+change and asks you to approve anything consequential. When a team's roster changes, the
+Captain runs a **coherence review** to re-align the reporting lines and role descriptions
+so the new shape hangs together.
+
+## Reusing a shape
+
+A shape you've tuned — its roles, prompts, reporting lines, skills, and connections — is
+worth keeping. Rather than rebuild it for the next project, you can:
+
+- **Save a team as a template** so its shape becomes a reusable option in the template
+  picker, or
+- **Start a new project directly from an existing team**, which snapshots that team's
+  shape as the new project's starting point.
+
+Either way the new project gets its own independent team — the two never affect each
+other. See
+[Reusing a team setup](/docs/concepts/projects-and-teams#reusing-a-team-setup).
+
+## Shapes that improve themselves
+
+Team shapes don't just change on demand — they get better as the team ships. Every time a
+task is completed, the [Coach](/docs/concepts/coach-and-self-improving-teams) reviews how
+it went and writes durable **learned rules** back onto the agents that need them, and
+sometimes updates a project document or skill. Over many projects, the lessons baked into
+a shape compound: a team you reuse carries forward not just its roster but everything it
+has learned.
+
+> [!TIP]
+> The durable thing in Hezo isn't any single task or even any single project — it's the
+> shape you build: a roster, reporting structure, prompts, skills, and learned rules that
+> you tune once and carry forward. That accumulated structure is what makes the next
+> project faster than the last.

--- a/docs/concepts/team-structure.md
+++ b/docs/concepts/team-structure.md
@@ -1,32 +1,32 @@
 ---
-title: Team shapes
+title: Team structure
 order: 7.5
 section: Concepts
 ---
 
-# Team shapes
+# Team structure
 
 As models converge and features get copied, the part of an AI system that's hard to
 reproduce isn't the code — it's how the work is organised: which roles exist, how they
 report to each other, what each one is good at, and the tools, knowledge, and judgement
-they share. That arrangement is a team's **shape**, and in Hezo it's a first-class thing
-you compose, reshape, and reuse — not a fixed structure you're stuck with.
+they share. That arrangement is a team's **structure**, and in Hezo it's a first-class
+thing you compose, change, and reuse — not something fixed that you're stuck with.
 
-A team's shape is the same idea as a *dynamic agent workflow*: instead of one fixed
-pipeline of model calls, the structure of the agents is chosen to fit the work in front
-of it, and changes as the work does. In Hezo that structure is an org chart of agents
+A team's structure is the same idea as a *dynamic agent workflow*: instead of one fixed
+pipeline of model calls, the arrangement of the agents is chosen to fit the work in front
+of it, and changes as the work does. In Hezo that arrangement is an org chart of agents
 that you can pick a starting point for, evolve while a project runs, and carry forward to
 the next project.
 
-## What makes up a shape
+## What makes up a team's structure
 
-A team's shape is more than a list of agents. It's:
+A team's structure is more than a list of agents. It's:
 
 - **The roster** — which roles exist on the team (a Captain plus whatever specialists the
   work needs). See [Roles & the CEO](/docs/concepts/roles-and-coordination).
 - **The reporting lines** — who reports to whom. This org chart is what lets work be
-  delegated up and down the team, so it shapes how the team actually operates, not just
-  how it looks.
+  delegated up and down the team, so it determines how the team actually operates, not
+  just how it looks.
 - **What each role is** — every agent's [system prompt](/docs/concepts/hiring-and-agents#editing-system-prompts),
   which defines its responsibilities, conventions, and how it works, plus the model it
   runs on.
@@ -35,11 +35,11 @@ A team's shape is more than a list of agents. It's:
   connected [MCP tools](/docs/mcp/connecting-mcp-servers), budgets, and the project
   container they all work in.
 
-Change any of these and you've reshaped the team.
+Change any of these and you've changed the team's structure.
 
-## Choosing a starting shape
+## Choosing a starting structure
 
-Every project starts from a **template**, which decides the team's initial shape. Hezo
+Every project starts from a **template**, which decides the team's initial structure. Hezo
 ships with a minimal **Blank** team (just a Captain) and a full software-development
 **Startup** team, and you can add your own. For the built-in rosters and a link to every
 role's prompt, see
@@ -47,12 +47,12 @@ role's prompt, see
 
 A template is just a convenient starting point — it's not a cage. The Blank team is
 designed to be grown into whatever the work needs; the Startup team is a fully-staffed
-shape for building software. Pick whichever is closest and adjust from there.
+structure for building software. Pick whichever is closest and adjust from there.
 
-## Reshaping a team while it runs
+## Changing a team's structure while it runs
 
-A team's shape is meant to change as a project does. Nothing about it is locked in once
-the project is created:
+A team's structure is meant to change as a project does. Nothing about it is locked in
+once the project is created:
 
 - **Hire** new roles when the work calls for a specialist the team doesn't have, and
   **retire** roles it has outgrown — both are reversible, and a retired agent keeps its
@@ -66,33 +66,39 @@ You drive this in plain language through the
 needs a data analyst", "have QA report to the Architect" — and the CEO proposes the
 change and asks you to approve anything consequential. When a team's roster changes, the
 Captain runs a **coherence review** to re-align the reporting lines and role descriptions
-so the new shape hangs together.
+so the new structure hangs together.
 
-## Reusing a shape
+## Reusing a structure
 
-A shape you've tuned — its roles, prompts, reporting lines, skills, and connections — is
-worth keeping. Rather than rebuild it for the next project, you can:
+A structure you've tuned — its roles, prompts, reporting lines, skills, and connections —
+is worth keeping. Rather than rebuild it for the next project, you can:
 
-- **Save a team as a template** so its shape becomes a reusable option in the template
+- **Save a team as a template** so its structure becomes a reusable option in the template
   picker, or
 - **Start a new project directly from an existing team**, which snapshots that team's
-  shape as the new project's starting point.
+  structure as the new project's starting point.
 
 Either way the new project gets its own independent team — the two never affect each
 other. See
 [Reusing a team setup](/docs/concepts/projects-and-teams#reusing-a-team-setup).
 
-## Shapes that improve themselves
+## Improving the team within its structure
 
-Team shapes don't just change on demand — they get better as the team ships. Every time a
-task is completed, the [Coach](/docs/concepts/coach-and-self-improving-teams) reviews how
-it went and writes durable **learned rules** back onto the agents that need them, and
-sometimes updates a project document or skill. Over many projects, the lessons baked into
-a shape compound: a team you reuse carries forward not just its roster but everything it
-has learned.
+Changing the structure isn't the only way a team gets better. Within whatever structure a
+team has, the [Coach](/docs/concepts/coach-and-self-improving-teams) makes the team's
+*existing* agents work better — without changing the roster or the reporting lines. Every
+time a task is completed, the Coach reviews how it went and writes durable **learned
+rules** back onto the agents that need them, and sometimes updates a project document or
+skill — so the same mistake doesn't happen twice and the existing agents coordinate more
+smoothly over time.
+
+Restructuring a team and coaching it are separate things: one changes *who's on the team
+and how they report*; the other sharpens *how the existing agents work*. Because the
+coaching improvements live in the agents' own prompts, a structure you save and reuse
+carries them forward too.
 
 > [!TIP]
 > The durable thing in Hezo isn't any single task or even any single project — it's the
-> shape you build: a roster, reporting structure, prompts, skills, and learned rules that
+> structure you build: a roster, reporting lines, prompts, skills, and learned rules that
 > you tune once and carry forward. That accumulated structure is what makes the next
 > project faster than the last.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -42,10 +42,10 @@ agent can't hurt you. A few guarantees sit underneath everything:
 
 - **Spin up a team per project** from a template, or reuse an existing team's setup
   for a new project. See [Projects & teams](/docs/concepts/projects-and-teams).
-- **Shape the team to the work — and reshape it as the work changes.** Compose a team's
-  roster, reporting lines, and roles, evolve them while a project runs, and carry a
-  shape you've tuned forward to the next project. See
-  [Team shapes](/docs/concepts/team-shapes).
+- **Structure the team to the work — and restructure it as the work changes.** Compose a
+  team's roster, reporting lines, and roles, evolve them while a project runs, and carry a
+  structure you've tuned forward to the next project. See
+  [Team structure](/docs/concepts/team-structure).
 - **Chat with the CEO in real time** to scope work, create projects, hire new agents, edit
   system prompts, and adjust settings — all from one conversation, with replies streaming
   back as it works. See [Roles & the CEO](/docs/concepts/roles-and-coordination).

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -42,6 +42,10 @@ agent can't hurt you. A few guarantees sit underneath everything:
 
 - **Spin up a team per project** from a template, or reuse an existing team's setup
   for a new project. See [Projects & teams](/docs/concepts/projects-and-teams).
+- **Shape the team to the work — and reshape it as the work changes.** Compose a team's
+  roster, reporting lines, and roles, evolve them while a project runs, and carry a
+  shape you've tuned forward to the next project. See
+  [Team shapes](/docs/concepts/team-shapes).
 - **Chat with the CEO in real time** to scope work, create projects, hire new agents, edit
   system prompts, and adjust settings — all from one conversation, with replies streaming
   back as it works. See [Roles & the CEO](/docs/concepts/roles-and-coordination).


### PR DESCRIPTION
## What & why

A widely-shared essay ("the shape of the company itself is becoming the moat") argues that as AI models and features converge, the durable, hard-to-copy advantage is *how the work is organised* — the org structure. Hezo's reusable project-teams architecture is exactly a mechanism for this: you can compose, reshape, and reuse a team's **shape**. The mechanics were already documented page-by-page, but no page tied them into a single narrative or connected them to the idea of dynamic agent workflows.

This PR adds that narrative as a new user-facing concept page and links to it from the relevant existing pages.

## Changes

- **New page** `docs/concepts/team-shapes.md` (Concepts, `order: 7.5`, slotting right after Projects & teams). It explains:
  - what makes up a team's shape (roster, reporting lines, role prompts/models, shared skills/memory/tools);
  - choosing a starting shape via templates;
  - reshaping a team while it runs (hire/retire, rewire reporting lines, edit prompts) via the CEO chat and coherence review;
  - reusing a shape (save as template / start from an existing team);
  - how shapes improve themselves over time via the Coach loop.
  - It frames team shape as the same idea as a *dynamic agent workflow* and **links out** to the existing mechanics pages rather than duplicating their detail.
- **Cross-links** added in `docs/introduction.md` (new "What you can do" bullet) and `docs/concepts/projects-and-teams.md` (a pointer noting a template is only a starting point).

## Conventions followed

- User-facing terminology: "task" not "ticket", "global" not "instance-wide".
- Neutral, capability-focused voice matching the rest of `docs/`.
- Internal links use the `/docs/...` form used elsewhere.

## Verification

- `bunx vitest run test/docs-bundle.test.ts` (server) — passes; the new `order: 7.5` page slots in cleanly via the filesystem walk.
- `bun run build:docs` — bundles 33 docs (was 32) with no MCP-reference drift; `docs-bundle.json` is a build artifact and not committed.
- Pre-push hook ran full `typecheck` + production build — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5GsYiTqVjuqaAksdQctro)_