### PR TITLE
feat: link update banner version to its GitHub release page

### DIFF
--- a/packages/web/src/components/update-banner.tsx
+++ b/packages/web/src/components/update-banner.tsx
@@ -40,7 +40,9 @@ function readDismissed(): Dismissal | null {
  * background; when this instance can apply-and-restart (a supervised compiled
  * binary), the caller is a superuser, and the binary is staged, an "Install &
  * restart" button — after a confirmation that warns about the master-key
- * re-unlock — restarts onto it instantly. While the background download is still
+ * re-unlock — restarts onto it instantly. The new version number links to its
+ * GitHub release page so the user can read the release notes. While the
+ * background download is still
  * in flight the banner stays hidden; if staging errored on a self-applying
  * instance it offers a "Retry download" button (with the GitHub Release as a
  * secondary link), and for any instance that can't self-apply it falls back to the
@@ -110,8 +112,21 @@ export function UpdateBanner() {
 			className="shrink-0 flex flex-col sm:flex-row sm:items-center gap-2 px-4 py-2.5 text-[13px] bg-accent-soft text-accent-soft-fg border-b border-border"
 		>
 			<span className="flex-1">
-				Hezo <span className="font-semibold">{latest}</span> is available — you're on {data.current}
-				.
+				Hezo{' '}
+				{data.url ? (
+					<a
+						href={data.url}
+						target="_blank"
+						rel="noreferrer"
+						data-testid="update-version-link"
+						className="font-semibold underline underline-offset-2 hover:no-underline"
+					>
+						{latest}
+					</a>
+				) : (
+					<span className="font-semibold">{latest}</span>
+				)}{' '}
+				is available — you're on {data.current}.
 			</span>
 			<div className="flex items-center gap-2 sm:gap-3">
 				{showInstall ? (

--- a/packages/web/test/update-banner.test.tsx
+++ b/packages/web/test/update-banner.test.tsx
@@ -61,6 +61,13 @@ test('non-superuser / non-supervised falls back to a release download link', () 
 	expect(link.getAttribute('href')).toBe('https://github.com/hezo-ai/hezo/releases/0.2.0');
 });
 
+test('the version number links to its GitHub release page', () => {
+	const { getByTestId } = renderBanner();
+	const link = getByTestId('update-version-link') as HTMLAnchorElement;
+	expect(link.textContent).toBe('0.2.0');
+	expect(link.getAttribute('href')).toBe('https://github.com/hezo-ai/hezo/releases/0.2.0');
+});
+
 test('supervised + superuser shows an "Install & restart" button when staged', () => {
 	const { getByTestId } = renderBanner({ state: UpdateState.Staged });
 	const button = getByTestId('update-restart-button');


### PR DESCRIPTION
## Summary

The "Update Available" banner now renders the new version number as a clickable link to that release's GitHub page, so users can click through to read the release notes and see what's new.

## Changes

- `packages/web/src/components/update-banner.tsx` — the `{latest}` version text is now wrapped in an anchor pointing at `data.url` (the release `html_url` the server already returns from the GitHub Releases check — the same URL used by the manual "Download" link). Opens in a new tab with `rel="noreferrer"`, styled as an underlined link, and falls back to the plain bold span if no URL is available. Updated the component doc comment accordingly.
- `packages/web/test/update-banner.test.tsx` — added a test asserting the version link renders with the correct text and `href`.

## Testing

- `bunx vitest run test/update-banner.test.tsx` — 14 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CCBi4q6qPSt7ReG7A8rajd)_