### PR TITLE
feat: anonymous daily usage telemetry (opt-out)

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -906,6 +906,21 @@ on Apple Silicon an unsigned replacement may still be Gatekeeper-blocked. Window
 relies on the rename-trick and is not exercised by CI (manual validation). The supervisor keeps
 running its own old code until a full process restart — only the worker is refreshed.
 
+**Anonymous usage telemetry.** `services/telemetry.ts` builds a daily aggregate snapshot of the
+whole install — counts of teams/projects/agents, tasks by status, tasks completed and agent-run
+input/output token sums over the last 24h, and the per-provider run mix — plus the version and
+`os`/`arch`. It carries a random per-install id persisted in `system_meta.instance_id`
+(generated lazily via `getOrCreateInstanceId`, `ON CONFLICT DO NOTHING` so it is stable). It
+deliberately excludes every name, prompt/content field, repo detail, user identity, and any
+`cost_cents`/monetary figure. The `JobManager` `telemetry` cron (`HEZO_TELEMETRY_CRON`, default
+`0 0 5 * * *`) is registered only when `config.telemetry.enabled` (opt-out — on by default,
+disabled by `--disable-telemetry` / `HEZO_TELEMETRY_ENABLED=0`). `reportTelemetry` POSTs the JSON
+to `config.telemetry.endpoint` (default `https://hezo.ai/api/telemetry`) with a direct `fetch` +
+5s timeout — like the update check, server-originated outbound calls do **not** route through the
+agent egress proxy — and fails soft (warn + swallow) so it never disrupts a run. The collector
+(a Cloudflare Pages Function backed by D1 in the website repo) stamps the receipt date and
+upserts one row per `(instance_id, UTC day)`; aggregates are shown at `hezo.ai/stats`.
+
 ---
 
 ## 13. API surface (summarized)

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -25,6 +25,9 @@ handy for baking defaults into a service definition while still overriding per r
 | `--keep-old-containers` | `HEZO_KEEP_OLD_CONTAINERS` | off | Keep old project containers instead of removing them — for debugging a crashed container. |
 | `--container-bind-host <host>` | `HEZO_CONTAINER_BIND_HOST` | `127.0.0.1` | Interface the egress proxy and SSH bridge bind to so agent containers can reach them. The default suits Docker Desktop; on native-Linux Docker the boot connectivity check auto-rebinds them to the detected bridge gateway IP (host-local, container-reachable), so this usually needs no change. Set it to pin a specific interface (an explicit non-loopback value is never auto-overridden); firewall-restrict the range (20000–29999) to the docker bridge. See [Self-hosting → Networking & firewall](/docs/deployment/self-hosting). |
 | `--version` | — | — | Print the Hezo version and exit (also `hezo version`). |
+| `--disable-telemetry` | `HEZO_TELEMETRY_ENABLED` | on | Turn off the anonymous daily usage report (see [Anonymous usage telemetry](#anonymous-usage-telemetry)). On by default; pass `--disable-telemetry` or set `HEZO_TELEMETRY_ENABLED=0`. |
+| `--telemetry-endpoint <url>` | `HEZO_TELEMETRY_ENDPOINT` | `https://hezo.ai/api/telemetry` | Where the daily report is sent. Point it at your own collector to keep the data in-house. |
+| — | `HEZO_TELEMETRY_CRON` | `0 0 5 * * *` | Cron schedule (seconds-precision) for the daily telemetry report. |
 | — | `HEZO_DISABLE_AUTO_UPDATE` | off | Disable the in-app auto-update (release check, the background download, and the "Install & restart" banner). When disabled the banner instead links to the GitHub release page. |
 | — | `HEZO_UPDATE_CHECK_CRON` | `0 0 4 * * *` | Cron schedule (seconds-precision) for the daily check that downloads and stages a newer release. A running instance also stages as soon as it detects an update, so the banner's "Install & restart" is instant. |
 
@@ -45,6 +48,35 @@ HEZO_DATA_DIR=/var/lib/hezo \
 HEZO_WEB_URL=https://hezo.example.com \
   hezo
 ```
+
+## Anonymous usage telemetry
+
+To help us understand how Hezo is used across self-hosted installs, each instance sends a
+small **anonymous** usage report once a day. It is **on by default** and easy to turn off.
+
+**What's sent** — aggregate counts only:
+
+- a random per-install id (a UUID generated on first report; not tied to you, your machine, or your data),
+- the Hezo version, operating system, and CPU architecture,
+- totals: number of teams, projects, and agents,
+- task counts by status, and how many tasks were completed in the last 24 hours,
+- agent-run count and total input/output **tokens** over the last 24 hours,
+- the mix of AI providers used (e.g. how many runs used Anthropic vs. OpenAI).
+
+**What's never sent** — project, team, or task names; prompts or any task content; repository
+details; user identities; secrets; or any monetary/cost figure. Aggregated numbers from all
+opted-in installs are shown publicly at [hezo.ai/stats](https://hezo.ai/stats).
+
+**Turn it off** with the flag or the environment variable:
+
+```sh
+hezo --disable-telemetry
+# or
+HEZO_TELEMETRY_ENABLED=0 hezo
+```
+
+You can also keep the data in-house by pointing `--telemetry-endpoint` (or
+`HEZO_TELEMETRY_ENDPOINT`) at your own collector.
 
 ## See also
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -30,6 +30,7 @@ hezo --master-key "<phrase>"     # set up or unlock without the web gate
 hezo --web-url https://hezo.example.com   # public base URL for sign-in redirects
 hezo --no-open                   # don't open the web app in your browser on start
 hezo --container-bind-host 0.0.0.0  # native-Linux Docker: let agent containers reach the egress proxy/SSH bridge
+hezo --disable-telemetry         # turn off the anonymous daily usage report (on by default)
 ```
 
 On **native-Linux Docker**, agent containers reach the host over the bridge gateway, so the

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -36,6 +36,8 @@ Starts the server on port 3100 with hot reload. In dev, PGlite data persists at 
 | `--log-level <level>` | `info` | Logging verbosity: `debug`, `info`, `warn`, `error` (env: `HEZO_LOG_LEVEL`) |
 | `--keep-old-containers` | `false` | Keep old project containers instead of removing them, for debugging (env: `HEZO_KEEP_OLD_CONTAINERS`) |
 | `--container-bind-host <host>` | `127.0.0.1` | Interface the egress proxy and SSH bridge bind to so agent containers can reach them. On native-Linux Docker the boot connectivity check auto-rebinds them to the detected bridge gateway IP; set this only to pin a specific interface (env: `HEZO_CONTAINER_BIND_HOST`) |
+| `--disable-telemetry` | telemetry on | Turn off the anonymous daily usage report (aggregate counts only — no names, content, or costs). On by default (env: `HEZO_TELEMETRY_ENABLED=0`) |
+| `--telemetry-endpoint <url>` | `https://hezo.ai/api/telemetry` | Where the daily usage report is sent; point at your own collector to keep data in-house (env: `HEZO_TELEMETRY_ENDPOINT`) |
 | `--version` | — | Print the Hezo version and exit (also `hezo version`) |
 
 ## Master Key

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -8,6 +8,7 @@ import {
 	validateMnemonic,
 } from '@hezo/shared';
 import { Command } from 'commander';
+import { DEFAULT_TELEMETRY_ENDPOINT } from './services/telemetry';
 import { HEZO_VERSION } from './version';
 
 export type LogLevelName = 'debug' | 'info' | 'warn' | 'error';
@@ -30,6 +31,16 @@ export interface HezoConfig {
 	 * and firewall-restrict the port range to the docker bridge.
 	 */
 	containerBindHost: string;
+	/**
+	 * Anonymous daily usage telemetry. On by default (opt-out): once a day the
+	 * server POSTs aggregate counts (projects, tasks, tokens, AI-provider mix,
+	 * version) — no names, content, or costs — to `endpoint`, keyed by a random
+	 * per-install id. Disabled with `--disable-telemetry` / `HEZO_TELEMETRY_ENABLED=0`.
+	 */
+	telemetry: {
+		enabled: boolean;
+		endpoint: string;
+	};
 }
 
 function resolveDataDir(raw: string): string {
@@ -185,6 +196,14 @@ export function parseConfig(
 			'--container-bind-host <host>',
 			'Interface the egress proxy and SSH bridge bind to so agent containers can reach them. Default 127.0.0.1 (works with Docker Desktop). On native-Linux Docker set 0.0.0.0 (or the bridge gateway IP) and firewall-restrict the egress port range to the docker bridge. (env: HEZO_CONTAINER_BIND_HOST)',
 		)
+		.option(
+			'--disable-telemetry',
+			'Disable anonymous daily usage telemetry (aggregate counts only — no names, content, or costs). On by default. (env: HEZO_TELEMETRY_ENABLED=0)',
+		)
+		.option(
+			'--telemetry-endpoint <url>',
+			`Override the telemetry collection endpoint (default ${DEFAULT_TELEMETRY_ENDPOINT}). (env: HEZO_TELEMETRY_ENDPOINT)`,
+		)
 		.parse(argv);
 
 	const cli = program.opts();
@@ -214,6 +233,14 @@ export function parseConfig(
 
 	const masterKeyRaw = pick('HEZO_MASTER_KEY', cli.masterKey);
 
+	// Telemetry defaults ON. The env var (when set) wins; otherwise the only way
+	// to disable via CLI is the explicit `--disable-telemetry` flag.
+	const telemetryEnabled = ((): boolean => {
+		const e = env.HEZO_TELEMETRY_ENABLED;
+		if (e !== undefined && e !== '') return parseBool(e);
+		return cli.disableTelemetry !== true;
+	})();
+
 	return {
 		port: parsePort(pick('HEZO_PORT', cli.port) ?? String(DEFAULT_PORT)),
 		dataDir: resolveDataDir(pick('HEZO_DATA_DIR', cli.dataDir) ?? DEFAULT_DATA_DIR),
@@ -227,5 +254,10 @@ export function parseConfig(
 		logLevel: parseLogLevel(pick('HEZO_LOG_LEVEL', cli.logLevel) ?? 'info'),
 		keepOldContainers: pickBool('HEZO_KEEP_OLD_CONTAINERS', cli.keepOldContainers),
 		containerBindHost: pick('HEZO_CONTAINER_BIND_HOST', cli.containerBindHost) ?? '127.0.0.1',
+		telemetry: {
+			enabled: telemetryEnabled,
+			endpoint:
+				pick('HEZO_TELEMETRY_ENDPOINT', cli.telemetryEndpoint) ?? DEFAULT_TELEMETRY_ENDPOINT,
+		},
 	};
 }

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -64,6 +64,7 @@ import type { PricingService } from './pricing';
 import { ensureRepoSetupAction } from './repo-setup';
 import { getProjectConcurrency, isTaskBusyInDb } from './run-concurrency';
 import type { SshAgentServer } from './ssh-agent';
+import { reportTelemetry } from './telemetry';
 import { ensureUpdateStaged, isSupervisedWorker } from './updater';
 import { absorbQueuedTaskWakeups, assignmentWakeupAlreadyServed, createWakeup } from './wakeup';
 import type { WebSocketManager } from './ws';
@@ -143,6 +144,8 @@ export interface JobManagerDeps {
 	connectivityStatus?: ContainerConnectivityStatus;
 	connectivityProbe?: () => Promise<ProbeResult>;
 	pricing?: PricingService;
+	/** Anonymous daily usage telemetry. Omitted/disabled → the cron is not registered. */
+	telemetry?: { enabled: boolean; endpoint: string };
 }
 
 const COALESCING_WINDOW_MS = Number(process.env.HEZO_WAKEUP_COALESCING_MS ?? 2_000);
@@ -152,6 +155,9 @@ const INBOX_ARCHIVE_CRON = process.env.HEZO_INBOX_ARCHIVE_CRON ?? '0 0 3 * * *';
 // Daily check for a newer release; when auto-update is enabled and one is found,
 // download+verify+stage it so an operator "Update & restart" is instant.
 const UPDATE_CHECK_CRON = process.env.HEZO_UPDATE_CHECK_CRON ?? '0 0 4 * * *';
+// Anonymous daily usage telemetry report — runs at 5am UTC, after the update
+// check, when telemetry is enabled (opt-out, default on).
+const TELEMETRY_CRON = process.env.HEZO_TELEMETRY_CRON ?? '0 0 5 * * *';
 // How often to re-evaluate budget-paused agents. Spend is summed over rolling
 // UTC windows, so a daily/weekly/monthly window rolling over silently frees an
 // agent's budget with no event — this sweep notices and lifts the reactive
@@ -417,6 +423,13 @@ export class JobManager {
 			log: cronLog,
 			onTick: () => this.guarded('update-check', () => this.checkForUpdate()),
 		});
+		if (this.deps.telemetry?.enabled) {
+			this.cron.createJob('telemetry', {
+				cron: TELEMETRY_CRON,
+				log: cronLog,
+				onTick: () => this.guarded('telemetry', () => this.runTelemetry()),
+			});
+		}
 		log.info('Job manager started.');
 	}
 
@@ -2270,5 +2283,11 @@ export class JobManager {
 	private async checkForUpdate(): Promise<void> {
 		if (!isSupervisedWorker()) return;
 		await ensureUpdateStaged(this.deps.dataDir, getLatestInfo);
+	}
+
+	private async runTelemetry(): Promise<void> {
+		const t = this.deps.telemetry;
+		if (!t?.enabled) return;
+		await reportTelemetry(this.deps.db, { endpoint: t.endpoint });
 	}
 }

--- a/packages/server/src/services/telemetry.ts
+++ b/packages/server/src/services/telemetry.ts
@@ -1,0 +1,156 @@
+import { randomUUID } from 'node:crypto';
+import { arch, platform } from 'node:os';
+import type { PGlite } from '@electric-sql/pglite';
+import { TaskStatus } from '@hezo/shared';
+import { getSystemMeta } from '../lib/system-meta';
+import { logger } from '../logger';
+import { HEZO_VERSION } from '../version';
+
+const log = logger.child('telemetry');
+
+/** `system_meta` key holding this instance's anonymous, randomly-generated id. */
+export const INSTANCE_ID_KEY = 'instance_id';
+
+/** Where daily reports are posted unless overridden via config. */
+export const DEFAULT_TELEMETRY_ENDPOINT = 'https://hezo.ai/api/telemetry';
+
+/**
+ * The anonymous daily usage snapshot sent to the central collector. Aggregate
+ * counts only — never names, prompts, repo/user identities, secrets, or any
+ * monetary figure. The collector stamps the receipt date itself (one row per
+ * instance per UTC day), so no timestamp is sent from here.
+ */
+export interface TelemetryPayload {
+	/** Stable random UUID for this install — lets the collector de-dupe and count distinct installs. */
+	instance_id: string;
+	version: string;
+	os: string;
+	arch: string;
+	teams: number;
+	projects: number;
+	agents: number;
+	tasks_total: number;
+	tasks_done: number;
+	/** Open tasks: everything not in a terminal (done / cancelled) status. */
+	tasks_active: number;
+	tasks_completed_24h: number;
+	runs_24h: number;
+	input_tokens_24h: number;
+	output_tokens_24h: number;
+	/** Agent-run count by AI provider over the last 24h, e.g. `{ anthropic: 12, openai: 3 }`. */
+	provider_mix: Record<string, number>;
+}
+
+/**
+ * Read this instance's anonymous id, generating and persisting one on first
+ * call. The insert is `ON CONFLICT DO NOTHING` and re-reads, so concurrent
+ * callers converge on the same id rather than clobbering it — the id is stable
+ * for the life of the data dir.
+ */
+export async function getOrCreateInstanceId(db: PGlite): Promise<string> {
+	const existing = await getSystemMeta(db, INSTANCE_ID_KEY);
+	if (existing) return existing;
+	const id = randomUUID();
+	await db.query(
+		`INSERT INTO system_meta (key, value) VALUES ($1, $2) ON CONFLICT (key) DO NOTHING`,
+		[INSTANCE_ID_KEY, id],
+	);
+	return (await getSystemMeta(db, INSTANCE_ID_KEY)) ?? id;
+}
+
+/**
+ * Assemble the anonymous aggregate payload from instance-wide tables. These are
+ * counts across every team — no per-team filter — since the snapshot describes
+ * the whole installation. Token sums are read as `float8` (exact for integers
+ * well past any daily volume) to avoid bigint-as-string surprises.
+ */
+export async function buildTelemetryPayload(db: PGlite): Promise<TelemetryPayload> {
+	const instanceId = await getOrCreateInstanceId(db);
+
+	const counts = await db.query<{ teams: number; projects: number; agents: number }>(
+		`SELECT
+		   (SELECT COUNT(*) FROM teams)::int          AS teams,
+		   (SELECT COUNT(*) FROM projects)::int       AS projects,
+		   (SELECT COUNT(*) FROM member_agents)::int  AS agents`,
+	);
+
+	const tasksByStatus = await db.query<{ status: string; count: number }>(
+		`SELECT status::text AS status, COUNT(*)::int AS count FROM tasks GROUP BY status`,
+	);
+	const statusCount = new Map(tasksByStatus.rows.map((r) => [r.status, Number(r.count)]));
+	const tasksTotal = [...statusCount.values()].reduce((a, b) => a + b, 0);
+	const tasksDone = statusCount.get(TaskStatus.Done) ?? 0;
+	const tasksCancelled = statusCount.get(TaskStatus.Cancelled) ?? 0;
+	const tasksActive = tasksTotal - tasksDone - tasksCancelled;
+
+	const completed = await db.query<{ count: number }>(
+		`SELECT COUNT(*)::int AS count FROM tasks
+		 WHERE status = $1 AND updated_at >= now() - INTERVAL '24 hours'`,
+		[TaskStatus.Done],
+	);
+
+	const runs = await db.query<{ count: number; input_tokens: number; output_tokens: number }>(
+		`SELECT COUNT(*)::int AS count,
+		        COALESCE(SUM(input_tokens), 0)::float8  AS input_tokens,
+		        COALESCE(SUM(output_tokens), 0)::float8 AS output_tokens
+		 FROM heartbeat_runs
+		 WHERE started_at >= now() - INTERVAL '24 hours'`,
+	);
+
+	const providers = await db.query<{ provider: string | null; count: number }>(
+		`SELECT provider::text AS provider, COUNT(*)::int AS count
+		 FROM heartbeat_runs
+		 WHERE started_at >= now() - INTERVAL '24 hours'
+		 GROUP BY provider`,
+	);
+	const providerMix: Record<string, number> = {};
+	for (const row of providers.rows) {
+		if (row.provider) providerMix[row.provider] = Number(row.count);
+	}
+
+	return {
+		instance_id: instanceId,
+		version: HEZO_VERSION,
+		os: platform(),
+		arch: arch(),
+		teams: Number(counts.rows[0]?.teams ?? 0),
+		projects: Number(counts.rows[0]?.projects ?? 0),
+		agents: Number(counts.rows[0]?.agents ?? 0),
+		tasks_total: tasksTotal,
+		tasks_done: tasksDone,
+		tasks_active: tasksActive,
+		tasks_completed_24h: Number(completed.rows[0]?.count ?? 0),
+		runs_24h: Number(runs.rows[0]?.count ?? 0),
+		input_tokens_24h: Number(runs.rows[0]?.input_tokens ?? 0),
+		output_tokens_24h: Number(runs.rows[0]?.output_tokens ?? 0),
+		provider_mix: providerMix,
+	};
+}
+
+/**
+ * Build and POST the daily snapshot. Fail-soft: a network/egress/rate-limit
+ * error or a non-2xx response is logged at warn and swallowed — telemetry must
+ * never disrupt the instance. Mirrors the update-check's direct `fetch` (server
+ * outbound calls do not route through the agent egress proxy).
+ */
+export async function reportTelemetry(db: PGlite, opts: { endpoint: string }): Promise<void> {
+	try {
+		const payload = await buildTelemetryPayload(db);
+		const res = await fetch(opts.endpoint, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'User-Agent': `hezo/${HEZO_VERSION}`,
+			},
+			body: JSON.stringify(payload),
+			signal: AbortSignal.timeout(5000),
+		});
+		if (!res.ok) {
+			log.warn(`Telemetry report rejected (status ${res.status})`);
+			return;
+		}
+		log.debug('Telemetry report sent');
+	} catch (err) {
+		log.warn('Telemetry report failed', err);
+	}
+}

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -116,6 +116,12 @@ export async function startup(config: HezoConfig): Promise<StartupResult> {
 	mkdirSync(config.dataDir, { recursive: true });
 	log.info(`Using data directory: ${config.dataDir}`);
 
+	if (config.telemetry?.enabled) {
+		log.info(
+			'Anonymous usage telemetry is enabled — aggregate counts only (no names, content, or costs). Disable with --disable-telemetry or HEZO_TELEMETRY_ENABLED=0.',
+		);
+	}
+
 	// `db` may be replaced by a fresh handle if migrations run against a copy and
 	// swap it in, so it's a `let` — every consumer below uses the post-migration handle.
 	setStartupPhase('database');
@@ -270,6 +276,7 @@ export async function startup(config: HezoConfig): Promise<StartupResult> {
 		connectivityStatus,
 		connectivityProbe,
 		pricing,
+		telemetry: config.telemetry,
 	});
 	const ceoSessionManager = new CeoSessionManager({
 		db,

--- a/packages/server/test/cli.test.ts
+++ b/packages/server/test/cli.test.ts
@@ -27,6 +27,32 @@ describe('parseConfig', () => {
 		expect(config.logLevel).toBe('info');
 		expect(config.keepOldContainers).toBe(false);
 		expect(config.containerBindHost).toBe('127.0.0.1');
+		expect(config.telemetry.enabled).toBe(true);
+		expect(config.telemetry.endpoint).toBe('https://hezo.ai/api/telemetry');
+	});
+
+	it('disables telemetry with --disable-telemetry', () => {
+		const config = parseConfig(argv('--disable-telemetry'), EMPTY_ENV);
+		expect(config.telemetry.enabled).toBe(false);
+	});
+
+	it('disables telemetry with HEZO_TELEMETRY_ENABLED=0', () => {
+		const config = parseConfig(argv(), { HEZO_TELEMETRY_ENABLED: '0' });
+		expect(config.telemetry.enabled).toBe(false);
+	});
+
+	it('lets HEZO_TELEMETRY_ENABLED override the --disable-telemetry flag', () => {
+		const config = parseConfig(argv('--disable-telemetry'), { HEZO_TELEMETRY_ENABLED: '1' });
+		expect(config.telemetry.enabled).toBe(true);
+	});
+
+	it('overrides the telemetry endpoint via flag and env', () => {
+		expect(
+			parseConfig(argv('--telemetry-endpoint', 'https://x.test/t'), EMPTY_ENV).telemetry.endpoint,
+		).toBe('https://x.test/t');
+		expect(
+			parseConfig(argv(), { HEZO_TELEMETRY_ENDPOINT: 'https://env.test/t' }).telemetry.endpoint,
+		).toBe('https://env.test/t');
 	});
 
 	it('parses --port', () => {

--- a/packages/server/test/telemetry.test.ts
+++ b/packages/server/test/telemetry.test.ts
@@ -1,0 +1,107 @@
+import { HeartbeatRunStatus } from '@hezo/shared';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { getSystemMeta } from '../src/lib/system-meta';
+import {
+	buildTelemetryPayload,
+	getOrCreateInstanceId,
+	INSTANCE_ID_KEY,
+	reportTelemetry,
+} from '../src/services/telemetry';
+import { createTestContext, destroyTestContext, type ServerTestContext } from './helpers/context';
+
+describe('telemetry', () => {
+	let ctx: ServerTestContext;
+	let teamId: string;
+	let projectId: string;
+	let memberId: string;
+
+	beforeAll(async () => {
+		ctx = await createTestContext();
+		// Reuse the seeded HQ team / project / a member for valid FKs.
+		teamId = (await ctx.db.query<{ id: string }>(`SELECT id FROM teams LIMIT 1`)).rows[0].id;
+		projectId = (
+			await ctx.db.query<{ id: string }>(`SELECT id FROM projects WHERE team_id = $1 LIMIT 1`, [
+				teamId,
+			])
+		).rows[0].id;
+		memberId = (
+			await ctx.db.query<{ id: string }>(`SELECT id FROM members WHERE team_id = $1 LIMIT 1`, [
+				teamId,
+			])
+		).rows[0].id;
+	});
+
+	afterAll(() => destroyTestContext(ctx));
+
+	it('aggregates new tasks and runs into the payload (counts + tokens, no money)', async () => {
+		const before = await buildTelemetryPayload(ctx.db);
+
+		await ctx.db.query(
+			`INSERT INTO tasks (team_id, project_id, number, identifier, title, status, updated_at)
+			 VALUES ($1, $2, 99001, 'TEL-99001', 'Telemetry done task', 'done', now())`,
+			[teamId, projectId],
+		);
+		await ctx.db.query(
+			`INSERT INTO heartbeat_runs
+			   (team_id, member_id, status, started_at, finished_at, input_tokens, output_tokens, provider)
+			 VALUES ($1, $2, $3::heartbeat_run_status, now(), now(), 1000, 500, 'anthropic')`,
+			[teamId, memberId, HeartbeatRunStatus.Succeeded],
+		);
+
+		const after = await buildTelemetryPayload(ctx.db);
+
+		expect(after.tasks_total).toBe(before.tasks_total + 1);
+		expect(after.tasks_done).toBe(before.tasks_done + 1);
+		expect(after.tasks_completed_24h).toBe(before.tasks_completed_24h + 1);
+		expect(after.runs_24h).toBe(before.runs_24h + 1);
+		expect(after.input_tokens_24h).toBe(before.input_tokens_24h + 1000);
+		expect(after.output_tokens_24h).toBe(before.output_tokens_24h + 500);
+		expect(after.provider_mix.anthropic).toBe((before.provider_mix.anthropic ?? 0) + 1);
+		expect(after.projects).toBeGreaterThanOrEqual(1);
+		expect(after.teams).toBeGreaterThanOrEqual(1);
+
+		// Never report monetary figures — the snapshot is usage-only.
+		const moneyKey = Object.keys(after).find((k) => /cost|cent|spend|usd|dollar|money/i.test(k));
+		expect(moneyKey).toBeUndefined();
+	});
+
+	it('generates a stable, persisted instance id (idempotent)', async () => {
+		const first = await getOrCreateInstanceId(ctx.db);
+		const second = await getOrCreateInstanceId(ctx.db);
+		expect(first).toBe(second);
+		expect(first).toMatch(/^[0-9a-f-]{36}$/);
+		expect(await getSystemMeta(ctx.db, INSTANCE_ID_KEY)).toBe(first);
+
+		const payload = await buildTelemetryPayload(ctx.db);
+		expect(payload.instance_id).toBe(first);
+	});
+
+	it('POSTs the payload to the endpoint as JSON', async () => {
+		const fetchSpy = vi
+			.spyOn(globalThis, 'fetch')
+			.mockResolvedValue(new Response(null, { status: 204 }));
+		try {
+			await reportTelemetry(ctx.db, { endpoint: 'https://collect.test/api/telemetry' });
+			expect(fetchSpy).toHaveBeenCalledOnce();
+			const [url, init] = fetchSpy.mock.calls[0];
+			expect(url).toBe('https://collect.test/api/telemetry');
+			expect(init?.method).toBe('POST');
+			const body = JSON.parse(String(init?.body));
+			expect(body.instance_id).toMatch(/^[0-9a-f-]{36}$/);
+			expect(typeof body.tasks_total).toBe('number');
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+
+	it('fails soft when the endpoint is unreachable (never throws)', async () => {
+		const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network down'));
+		try {
+			await expect(
+				reportTelemetry(ctx.db, { endpoint: 'https://collect.test/api/telemetry' }),
+			).resolves.toBeUndefined();
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Self-hosted Hezo instances now send an **anonymous** aggregate usage snapshot to a central collector once a day, so we can show adoption stats publicly. It's **on by default (opt-out)** with a clear first-run disclosure and an easy off switch.

The matching collector + public `/stats` page live in the website repo: **hezo-ai/website#34** (Cloudflare Pages Function + D1).

## What gets collected

Per install, once a day: a random `instance_id` (UUID in `system_meta`, generated lazily — not tied to you/your machine/your data), the Hezo `version`, `os`/`arch`, and **counts only** — teams, projects, agents, tasks by status, tasks completed in 24h, agent runs in 24h, total input/output **tokens** in 24h, and the AI-provider run mix.

**Never sent:** project/team/task names, prompts or any task content, repo details, user identities, secrets, or any monetary/cost figure.

## Changes

- **`services/telemetry.ts`** — `getOrCreateInstanceId` (stable id via `ON CONFLICT DO NOTHING`, so **no DB migration**), `buildTelemetryPayload` (instance-wide aggregate SQL, cribbing the windowed style from `routes/costs.ts`), and `reportTelemetry` (direct `fetch` + 5s timeout, fail-soft — like the update check, it does **not** route through the agent egress proxy).
- **`cli.ts`** — `HezoConfig.telemetry`; `--disable-telemetry` / `HEZO_TELEMETRY_ENABLED` (default on) and `--telemetry-endpoint` / `HEZO_TELEMETRY_ENDPOINT` (default `https://hezo.ai/api/telemetry`).
- **`job-manager.ts`** — daily `telemetry` cron (`HEZO_TELEMETRY_CRON`, default `0 0 5 * * *`), registered **only** when enabled.
- **`startup.ts`** — threads the config and logs a one-time disclosure when telemetry is on.
- **Docs** — `docs/deployment/configuration.md` (new flags + a "what's collected / how to opt out" section), `docs/reference/cli.md`, `packages/server/README.md`, `.dev/architecture.md`.

## Tests

`packages/server/test/telemetry.test.ts` — aggregation correctness against seeded tasks/runs, asserts the payload omits any money field, idempotent `instance_id`, and fail-soft POST (stubbed `fetch`). Opt-out + endpoint override assertions added to `cli.test.ts`. Typecheck + lint clean; job-manager/startup suites green.

## Notes / limitations

- The collection endpoint (website side) is public/unauthenticated → best-effort, spoofable data, mitigated by validation, sanity bounds, and per-install/day dedup. Acceptable for aggregate stats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)