### PR TITLE
feat(web): redesign AI provider setup as a logo card grid

### DIFF
--- a/packages/web/src/components/add-ai-provider-dialog.tsx
+++ b/packages/web/src/components/add-ai-provider-dialog.tsx
@@ -1,138 +1,42 @@
-import { AI_PROVIDER_INFO, AiAuthMethod, AiProvider } from '@hezo/shared';
+import { AI_PROVIDER_INFO, type AiProvider } from '@hezo/shared';
 import * as Dialog from '@radix-ui/react-dialog';
-import { ArrowLeft, Loader2, X } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
-import {
-	type AiProviderConfig,
-	useAiProviders,
-	useCreateAiProvider,
-} from '../hooks/use-ai-providers';
+import { ArrowLeft, X } from 'lucide-react';
+import { useEffect, useState } from 'react';
 import { ProviderCardGrid } from './provider-card-grid';
-import { SUBSCRIPTION_INSTRUCTIONS, SubscriptionInstructions } from './subscription-paste-form';
-import { Button } from './ui/button';
+import { ADD_PROVIDER_ORDER, ProviderConfigForm } from './provider-config-form';
 import { dialogContentClassName, dialogOverlayClassName } from './ui/dialog';
-import { Input } from './ui/input';
-
-// Display order mirrors the catalogue order used elsewhere in the app.
-const ADD_PROVIDER_ORDER: AiProvider[] = [
-	AiProvider.DeepSeek,
-	AiProvider.ZAi,
-	AiProvider.Anthropic,
-	AiProvider.OpenAI,
-	AiProvider.Google,
-	AiProvider.OpenRouter,
-	AiProvider.Kimi,
-	AiProvider.XAi,
-];
-
-/**
- * Generate a friendly default name for a new config based on the selected
- * provider, skipping labels already used for that provider so the
- * `UNIQUE(provider, label)` constraint never trips on the suggested default.
- */
-function defaultLabel(provider: AiProvider, configs: AiProviderConfig[] | undefined): string {
-	const info = AI_PROVIDER_INFO[provider];
-	const used = new Set((configs ?? []).filter((c) => c.provider === provider).map((c) => c.label));
-	if (!used.has(info.name)) return info.name;
-	let n = 2;
-	while (used.has(`${info.name} ${n}`)) n++;
-	return `${info.name} ${n}`;
-}
 
 interface AddAiProviderDialogProps {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 }
 
+/**
+ * Settings "Add provider" modal. Two-step: pick a provider from the card grid,
+ * then configure its credential. Unlike the onboarding wizard this surface
+ * carries no welcome blurb or step indicator — just the dialog title, a back
+ * affordance, and the shared {@link ProviderConfigForm}.
+ */
 export function AddAiProviderDialog({ open, onOpenChange }: AddAiProviderDialogProps) {
-	const { data: configs } = useAiProviders();
-	const createProvider = useCreateAiProvider();
-
-	// The dialog is a two-step flow: pick a provider from the card grid, then
-	// configure its credential. `provider` is null until a card is chosen.
-	const [step, setStep] = useState<'pick' | 'configure'>('pick');
 	const [provider, setProvider] = useState<AiProvider | null>(null);
-	const [authMethod, setAuthMethod] = useState<AiAuthMethod>(AiAuthMethod.ApiKey);
-	const [name, setName] = useState('');
-	const [nameEdited, setNameEdited] = useState(false);
-	const [apiKey, setApiKey] = useState('');
-	const [authJson, setAuthJson] = useState('');
-	const [error, setError] = useState<string | null>(null);
-
 	const info = provider ? AI_PROVIDER_INFO[provider] : null;
-	const generatedName = useMemo(
-		() => (provider ? defaultLabel(provider, configs) : ''),
-		[provider, configs],
-	);
 
-	// Reset the whole flow back to the card grid each time the dialog opens.
+	// Reset back to the card grid each time the dialog opens.
 	useEffect(() => {
-		if (!open) return;
-		setStep('pick');
-		setProvider(null);
-		setAuthMethod(AiAuthMethod.ApiKey);
-		setNameEdited(false);
-		setApiKey('');
-		setAuthJson('');
-		setError(null);
+		if (open) setProvider(null);
 	}, [open]);
-
-	// Keep the name pinned to the generated default until the user edits it
-	// (also re-syncs once the async configs query resolves).
-	useEffect(() => {
-		if (!nameEdited && provider) setName(generatedName);
-	}, [generatedName, nameEdited, provider]);
-
-	// A card was clicked: select the provider and advance to the form.
-	function handleSelectProvider(next: AiProvider) {
-		setProvider(next);
-		setNameEdited(false);
-		setApiKey('');
-		setAuthJson('');
-		setError(null);
-		setAuthMethod(AiAuthMethod.ApiKey);
-		setStep('configure');
-	}
-
-	// Back from the form to the card grid; clear the in-progress credential.
-	function handleBack() {
-		setStep('pick');
-		setProvider(null);
-		setApiKey('');
-		setAuthJson('');
-		setError(null);
-	}
-
-	const credential = authMethod === AiAuthMethod.Subscription ? authJson : apiKey;
-
-	async function handleSubmit(e: React.FormEvent) {
-		e.preventDefault();
-		setError(null);
-		if (!provider || !credential.trim()) return;
-		try {
-			await createProvider.mutateAsync({
-				provider,
-				api_key: credential,
-				label: name.trim() || undefined,
-				auth_method: authMethod,
-			});
-			onOpenChange(false);
-		} catch (err) {
-			setError(err instanceof Error ? err.message : 'Failed to add provider');
-		}
-	}
 
 	return (
 		<Dialog.Root open={open} onOpenChange={onOpenChange}>
 			<Dialog.Portal>
 				<Dialog.Overlay className={dialogOverlayClassName} />
-				<Dialog.Content className={dialogContentClassName.md}>
-					<div className="flex items-center justify-between mb-1">
+				<Dialog.Content className={dialogContentClassName.md} aria-describedby={undefined}>
+					<div className="flex items-center justify-between mb-4">
 						<div className="flex items-center gap-2">
-							{step === 'configure' && (
+							{provider && info && (
 								<button
 									type="button"
-									onClick={handleBack}
+									onClick={() => setProvider(null)}
 									className="text-text-2 hover:text-text-1 p-2 -m-2"
 									aria-label="Back"
 								>
@@ -140,7 +44,7 @@ export function AddAiProviderDialog({ open, onOpenChange }: AddAiProviderDialogP
 								</button>
 							)}
 							<Dialog.Title className="text-lg font-semibold">
-								{step === 'configure' && info ? `Connect ${info.name}` : 'Add AI provider'}
+								{provider && info ? `Connect ${info.name}` : 'Add AI provider'}
 							</Dialog.Title>
 						</div>
 						<Dialog.Close asChild>
@@ -153,90 +57,18 @@ export function AddAiProviderDialog({ open, onOpenChange }: AddAiProviderDialogP
 							</button>
 						</Dialog.Close>
 					</div>
-					<Dialog.Description className="text-[13px] text-text-2 mb-4">
-						API keys for AI coding agents. Shared across every team in this Hezo instance.
-					</Dialog.Description>
 
-					{step === 'pick' || !provider || !info ? (
-						<ProviderCardGrid providers={ADD_PROVIDER_ORDER} onSelect={handleSelectProvider} />
+					{!provider || !info ? (
+						<ProviderCardGrid providers={ADD_PROVIDER_ORDER} onSelect={setProvider} />
 					) : (
-						<form onSubmit={handleSubmit} className="flex flex-col gap-4">
-							{info.supportsSubscription && (
-								<div className="flex flex-col gap-1.5">
-									<span className="text-eyebrow text-text-2">Authentication</span>
-									<div className="flex gap-2">
-										<Button
-											type="button"
-											size="sm"
-											variant={authMethod === AiAuthMethod.ApiKey ? 'primary' : 'secondary'}
-											onClick={() => {
-												setAuthMethod(AiAuthMethod.ApiKey);
-												setError(null);
-											}}
-										>
-											API key
-										</Button>
-										<Button
-											type="button"
-											size="sm"
-											variant={authMethod === AiAuthMethod.Subscription ? 'primary' : 'secondary'}
-											onClick={() => {
-												setAuthMethod(AiAuthMethod.Subscription);
-												setError(null);
-											}}
-										>
-											{info.runtimeLabel} subscription
-										</Button>
-									</div>
-								</div>
-							)}
-
-							<Input
-								label="Name"
-								value={name}
-								placeholder={info.name}
-								onChange={(e) => {
-									setName(e.target.value);
-									setNameEdited(true);
-								}}
-							/>
-
-							{authMethod === AiAuthMethod.Subscription ? (
-								<div className="flex flex-col gap-2">
-									<SubscriptionInstructions provider={provider} />
-									<textarea
-										required
-										aria-label="Subscription credential"
-										value={authJson}
-										onChange={(e) => setAuthJson(e.target.value)}
-										placeholder={SUBSCRIPTION_INSTRUCTIONS[provider]?.placeholder}
-										rows={6}
-										spellCheck={false}
-										className="w-full rounded-md border border-border bg-surface-2 px-2 py-1.5 text-xs font-mono text-text-1 outline-none focus:border-border-strong"
-									/>
-								</div>
-							) : (
-								<Input
-									label="API key"
-									type="password"
-									placeholder={info.keyPlaceholder}
-									value={apiKey}
-									onChange={(e) => setApiKey(e.target.value)}
-								/>
-							)}
-
-							{error && <p className="text-[13px] text-danger">{error}</p>}
-
-							<div className="flex justify-end gap-2">
-								<Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
-									Cancel
-								</Button>
-								<Button type="submit" disabled={!credential.trim() || createProvider.isPending}>
-									{createProvider.isPending && <Loader2 className="w-4 h-4 animate-spin" />}
-									Add provider
-								</Button>
-							</div>
-						</form>
+						<ProviderConfigForm
+							key={provider}
+							provider={provider}
+							showName
+							submitLabel="Add provider"
+							onCancel={() => onOpenChange(false)}
+							onDone={() => onOpenChange(false)}
+						/>
 					)}
 				</Dialog.Content>
 			</Dialog.Portal>

--- a/packages/web/src/components/ai-provider-picker.tsx
+++ b/packages/web/src/components/ai-provider-picker.tsx
@@ -1,14 +1,15 @@
 import { AI_PROVIDER_INFO, AiAuthMethod, AiProvider } from '@hezo/shared';
-import { ClipboardPaste, Key, Loader2 } from 'lucide-react';
+import { ArrowLeft, Loader2 } from 'lucide-react';
 import { useState } from 'react';
 import { useCreateAiProvider } from '../hooks/use-ai-providers';
-import { PROVIDER_LOGOS, ProviderLogo } from './provider-logos';
-import { SubscriptionPasteForm } from './subscription-paste-form';
-import { Badge } from './ui/badge';
+import { ProviderCardGrid } from './provider-card-grid';
+import { ProviderLogo } from './provider-logos';
+import { SUBSCRIPTION_INSTRUCTIONS, SubscriptionInstructions } from './subscription-paste-form';
 import { Button } from './ui/button';
 import { Input } from './ui/input';
 
-const PROVIDERS = [
+// Display order mirrors the catalogue order used elsewhere in the app.
+const PROVIDERS: readonly AiProvider[] = [
 	AiProvider.DeepSeek,
 	AiProvider.ZAi,
 	AiProvider.Anthropic,
@@ -17,102 +18,138 @@ const PROVIDERS = [
 	AiProvider.OpenRouter,
 	AiProvider.Kimi,
 	AiProvider.XAi,
-] as const;
+];
 
+/**
+ * Onboarding AI-provider setup: a grid of provider cards. Picking one drills
+ * into a form showing only the credential inputs that provider supports (an API
+ * key, or — where available — a runtime-subscription paste). "Back" returns to
+ * the full card view. Submitting fires the create mutation; the rest of the work
+ * (verification, encryption, persistence) happens server-side from there.
+ */
 export function AiProviderPicker() {
-	return (
-		<div className="space-y-3">
-			{PROVIDERS.map((provider) => (
-				<ProviderCard key={provider} provider={provider} />
-			))}
-		</div>
-	);
+	const [provider, setProvider] = useState<AiProvider | null>(null);
+
+	if (!provider) {
+		return <ProviderCardGrid providers={PROVIDERS} onSelect={setProvider} />;
+	}
+
+	return <ProviderConfigForm provider={provider} onBack={() => setProvider(null)} />;
 }
 
-function ProviderCard({ provider }: { provider: AiProvider }) {
+function ProviderConfigForm({ provider, onBack }: { provider: AiProvider; onBack: () => void }) {
 	const info = AI_PROVIDER_INFO[provider];
-	const [showKeyForm, setShowKeyForm] = useState(false);
-	const [showPasteForm, setShowPasteForm] = useState(false);
-	const [apiKey, setApiKey] = useState('');
 	const createProvider = useCreateAiProvider();
+	const [authMethod, setAuthMethod] = useState<AiAuthMethod>(AiAuthMethod.ApiKey);
+	const [apiKey, setApiKey] = useState('');
+	const [authJson, setAuthJson] = useState('');
+	const [error, setError] = useState<string | null>(null);
 
-	async function handleSubmitKey(e: React.FormEvent) {
+	const credential = authMethod === AiAuthMethod.Subscription ? authJson : apiKey;
+
+	async function handleSubmit(e: React.FormEvent) {
 		e.preventDefault();
-		await createProvider.mutateAsync({ provider, api_key: apiKey });
-		setApiKey('');
-		setShowKeyForm(false);
-	}
-
-	async function handleSubmitPaste(authJson: string) {
-		await createProvider.mutateAsync({
-			provider,
-			api_key: authJson,
-			auth_method: AiAuthMethod.Subscription,
-		});
-		setShowPasteForm(false);
+		setError(null);
+		if (!credential.trim()) return;
+		try {
+			await createProvider.mutateAsync({
+				provider,
+				api_key: credential,
+				auth_method: authMethod,
+			});
+			// Success: the wizard advances once a provider is configured. Returning
+			// to the grid keeps the surface coherent if it re-renders first.
+			onBack();
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Failed to add provider');
+		}
 	}
 
 	return (
-		<div className="border border-border rounded-md p-4">
-			<div className="flex items-center justify-between mb-2">
-				<div className="flex items-center gap-2">
-					{PROVIDER_LOGOS[provider] && (
-						<span className="flex h-6 w-6 items-center justify-center text-text-1">
-							<ProviderLogo provider={provider} className="h-5 w-5" />
-						</span>
-					)}
-					<span className="text-[13px] font-medium">{info.name}</span>
-					<Badge color="neutral" className="ml-1">
-						{info.runtimeLabel}
-					</Badge>
+		<form onSubmit={handleSubmit} className="flex flex-col gap-4">
+			<div className="flex items-center gap-2">
+				<button
+					type="button"
+					onClick={onBack}
+					className="text-text-2 hover:text-text-1 p-2 -m-2"
+					aria-label="Back"
+				>
+					<ArrowLeft className="w-4 h-4" />
+				</button>
+				<span className="flex h-6 w-6 items-center justify-center text-text-1">
+					<ProviderLogo provider={provider} className="h-5 w-5" />
+				</span>
+				<div className="flex flex-col">
+					<span className="text-sm font-medium text-text-1">Connect {info.name}</span>
+					<span className="text-xs text-text-3">{info.runtimeLabel}</span>
 				</div>
 			</div>
 
-			{showKeyForm ? (
-				<form onSubmit={handleSubmitKey} className="flex flex-col sm:flex-row gap-2 mt-2">
-					<Input
-						type="password"
-						placeholder={info.keyPlaceholder}
-						value={apiKey}
-						onChange={(e) => setApiKey(e.target.value)}
-						required
-						className="flex-1"
-					/>
-					<Button type="submit" size="sm" disabled={createProvider.isPending}>
-						{createProvider.isPending && <Loader2 className="w-3 h-3 animate-spin" />}
-						Save
-					</Button>
-					<Button type="button" variant="secondary" size="sm" onClick={() => setShowKeyForm(false)}>
-						Cancel
-					</Button>
-				</form>
-			) : showPasteForm ? (
-				<SubscriptionPasteForm
-					provider={provider}
-					onSubmit={handleSubmitPaste}
-					onCancel={() => setShowPasteForm(false)}
-					pending={createProvider.isPending}
-				/>
-			) : (
-				<div className="flex gap-2 mt-2">
-					{info.supportsSubscription && (
-						<Button variant="secondary" size="sm" onClick={() => setShowPasteForm(true)}>
-							<ClipboardPaste className="w-3 h-3" />
-							Use {info.runtimeLabel} subscription
+			{info.supportsSubscription && (
+				<div className="flex flex-col gap-1.5">
+					<span className="text-eyebrow text-text-2">Authentication</span>
+					<div className="flex gap-2">
+						<Button
+							type="button"
+							size="sm"
+							variant={authMethod === AiAuthMethod.ApiKey ? 'primary' : 'secondary'}
+							onClick={() => {
+								setAuthMethod(AiAuthMethod.ApiKey);
+								setError(null);
+							}}
+						>
+							API key
 						</Button>
-					)}
-					<Button variant="secondary" size="sm" onClick={() => setShowKeyForm(true)}>
-						<Key className="w-3 h-3" />
-						Enter API key
-					</Button>
+						<Button
+							type="button"
+							size="sm"
+							variant={authMethod === AiAuthMethod.Subscription ? 'primary' : 'secondary'}
+							onClick={() => {
+								setAuthMethod(AiAuthMethod.Subscription);
+								setError(null);
+							}}
+						>
+							{info.runtimeLabel} subscription
+						</Button>
+					</div>
 				</div>
 			)}
 
-			{createProvider.error && (
-				<p className="text-[13px] text-danger mt-2">
-					{(createProvider.error as { message?: string }).message || 'Failed to save'}
-				</p>
+			{authMethod === AiAuthMethod.Subscription ? (
+				<div className="flex flex-col gap-2">
+					<SubscriptionInstructions provider={provider} />
+					<textarea
+						required
+						aria-label="Subscription credential"
+						value={authJson}
+						onChange={(e) => setAuthJson(e.target.value)}
+						placeholder={SUBSCRIPTION_INSTRUCTIONS[provider]?.placeholder}
+						rows={6}
+						spellCheck={false}
+						className="w-full rounded-md border border-border bg-surface-2 px-2 py-1.5 text-xs font-mono text-text-1 outline-none focus:border-border-strong"
+					/>
+				</div>
+			) : (
+				<Input
+					label="API key"
+					type="password"
+					placeholder={info.keyPlaceholder}
+					value={apiKey}
+					onChange={(e) => setApiKey(e.target.value)}
+				/>
 			)}
-		</div>
+
+			{error && <p className="text-[13px] text-danger">{error}</p>}
+
+			<div className="flex justify-end gap-2">
+				<Button type="button" variant="ghost" onClick={onBack}>
+					Cancel
+				</Button>
+				<Button type="submit" disabled={!credential.trim() || createProvider.isPending}>
+					{createProvider.isPending && <Loader2 className="w-4 h-4 animate-spin" />}
+					Save
+				</Button>
+			</div>
+		</form>
 	);
 }

--- a/packages/web/src/components/ai-provider-picker.tsx
+++ b/packages/web/src/components/ai-provider-picker.tsx
@@ -1,76 +1,31 @@
-import { AI_PROVIDER_INFO, AiAuthMethod, AiProvider } from '@hezo/shared';
-import { ArrowLeft, Loader2 } from 'lucide-react';
+import { AI_PROVIDER_INFO, type AiProvider } from '@hezo/shared';
+import { ArrowLeft } from 'lucide-react';
 import { useState } from 'react';
-import { useCreateAiProvider } from '../hooks/use-ai-providers';
 import { ProviderCardGrid } from './provider-card-grid';
+import { ADD_PROVIDER_ORDER, ProviderConfigForm } from './provider-config-form';
 import { ProviderLogo } from './provider-logos';
-import { SUBSCRIPTION_INSTRUCTIONS, SubscriptionInstructions } from './subscription-paste-form';
-import { Button } from './ui/button';
-import { Input } from './ui/input';
-
-// Display order mirrors the catalogue order used elsewhere in the app.
-const PROVIDERS: readonly AiProvider[] = [
-	AiProvider.DeepSeek,
-	AiProvider.ZAi,
-	AiProvider.Anthropic,
-	AiProvider.OpenAI,
-	AiProvider.Google,
-	AiProvider.OpenRouter,
-	AiProvider.Kimi,
-	AiProvider.XAi,
-];
 
 /**
  * Onboarding AI-provider setup: a grid of provider cards. Picking one drills
- * into a form showing only the credential inputs that provider supports (an API
- * key, or — where available — a runtime-subscription paste). "Back" returns to
- * the full card view. Submitting fires the create mutation; the rest of the work
- * (verification, encryption, persistence) happens server-side from there.
+ * into the shared {@link ProviderConfigForm}; "Back" returns to the full card
+ * view. The surrounding welcome heading + step indicator are supplied by the
+ * setup wizard, so this component renders only the grid and the form — the same
+ * picker the settings modal reuses without that onboarding chrome.
  */
 export function AiProviderPicker() {
 	const [provider, setProvider] = useState<AiProvider | null>(null);
 
 	if (!provider) {
-		return <ProviderCardGrid providers={PROVIDERS} onSelect={setProvider} />;
+		return <ProviderCardGrid providers={ADD_PROVIDER_ORDER} onSelect={setProvider} />;
 	}
 
-	return <ProviderConfigForm provider={provider} onBack={() => setProvider(null)} />;
-}
-
-function ProviderConfigForm({ provider, onBack }: { provider: AiProvider; onBack: () => void }) {
 	const info = AI_PROVIDER_INFO[provider];
-	const createProvider = useCreateAiProvider();
-	const [authMethod, setAuthMethod] = useState<AiAuthMethod>(AiAuthMethod.ApiKey);
-	const [apiKey, setApiKey] = useState('');
-	const [authJson, setAuthJson] = useState('');
-	const [error, setError] = useState<string | null>(null);
-
-	const credential = authMethod === AiAuthMethod.Subscription ? authJson : apiKey;
-
-	async function handleSubmit(e: React.FormEvent) {
-		e.preventDefault();
-		setError(null);
-		if (!credential.trim()) return;
-		try {
-			await createProvider.mutateAsync({
-				provider,
-				api_key: credential,
-				auth_method: authMethod,
-			});
-			// Success: the wizard advances once a provider is configured. Returning
-			// to the grid keeps the surface coherent if it re-renders first.
-			onBack();
-		} catch (err) {
-			setError(err instanceof Error ? err.message : 'Failed to add provider');
-		}
-	}
-
 	return (
-		<form onSubmit={handleSubmit} className="flex flex-col gap-4">
+		<div className="flex flex-col gap-4">
 			<div className="flex items-center gap-2">
 				<button
 					type="button"
-					onClick={onBack}
+					onClick={() => setProvider(null)}
 					className="text-text-2 hover:text-text-1 p-2 -m-2"
 					aria-label="Back"
 				>
@@ -85,71 +40,13 @@ function ProviderConfigForm({ provider, onBack }: { provider: AiProvider; onBack
 				</div>
 			</div>
 
-			{info.supportsSubscription && (
-				<div className="flex flex-col gap-1.5">
-					<span className="text-eyebrow text-text-2">Authentication</span>
-					<div className="flex gap-2">
-						<Button
-							type="button"
-							size="sm"
-							variant={authMethod === AiAuthMethod.ApiKey ? 'primary' : 'secondary'}
-							onClick={() => {
-								setAuthMethod(AiAuthMethod.ApiKey);
-								setError(null);
-							}}
-						>
-							API key
-						</Button>
-						<Button
-							type="button"
-							size="sm"
-							variant={authMethod === AiAuthMethod.Subscription ? 'primary' : 'secondary'}
-							onClick={() => {
-								setAuthMethod(AiAuthMethod.Subscription);
-								setError(null);
-							}}
-						>
-							{info.runtimeLabel} subscription
-						</Button>
-					</div>
-				</div>
-			)}
-
-			{authMethod === AiAuthMethod.Subscription ? (
-				<div className="flex flex-col gap-2">
-					<SubscriptionInstructions provider={provider} />
-					<textarea
-						required
-						aria-label="Subscription credential"
-						value={authJson}
-						onChange={(e) => setAuthJson(e.target.value)}
-						placeholder={SUBSCRIPTION_INSTRUCTIONS[provider]?.placeholder}
-						rows={6}
-						spellCheck={false}
-						className="w-full rounded-md border border-border bg-surface-2 px-2 py-1.5 text-xs font-mono text-text-1 outline-none focus:border-border-strong"
-					/>
-				</div>
-			) : (
-				<Input
-					label="API key"
-					type="password"
-					placeholder={info.keyPlaceholder}
-					value={apiKey}
-					onChange={(e) => setApiKey(e.target.value)}
-				/>
-			)}
-
-			{error && <p className="text-[13px] text-danger">{error}</p>}
-
-			<div className="flex justify-end gap-2">
-				<Button type="button" variant="ghost" onClick={onBack}>
-					Cancel
-				</Button>
-				<Button type="submit" disabled={!credential.trim() || createProvider.isPending}>
-					{createProvider.isPending && <Loader2 className="w-4 h-4 animate-spin" />}
-					Save
-				</Button>
-			</div>
-		</form>
+			<ProviderConfigForm
+				key={provider}
+				provider={provider}
+				submitLabel="Save"
+				onCancel={() => setProvider(null)}
+				onDone={() => setProvider(null)}
+			/>
+		</div>
 	);
 }

--- a/packages/web/src/components/provider-card-grid.tsx
+++ b/packages/web/src/components/provider-card-grid.tsx
@@ -1,6 +1,5 @@
 import { AI_PROVIDER_INFO, type AiProvider } from '@hezo/shared';
-import { ProviderLogo } from './provider-logos';
-import { Badge } from './ui/badge';
+import { PROVIDER_LOGOS, ProviderLogo } from './provider-logos';
 
 interface ProviderCardGridProps {
 	/** Providers to show, in display order. */
@@ -9,29 +8,39 @@ interface ProviderCardGridProps {
 }
 
 /**
- * Responsive grid of selectable AI-provider cards, each showing the provider's
- * brand logo (or a big-font wordmark fallback) plus its name and runtime label.
- * Mobile-first: two columns on phones, three from the `sm` breakpoint up. Cards
- * are real buttons so they're keyboard-focusable and screen-reader friendly.
+ * Responsive grid of selectable AI-provider cards. Each card shows the
+ * provider's brand logo with its name underneath; providers without a
+ * registered logo render their name on its own as a big-font wordmark (no
+ * duplicate label). Mobile-first: two columns on phones, three from the `sm`
+ * breakpoint up. Cards are real buttons so they're keyboard-focusable and
+ * screen-reader friendly.
  */
 export function ProviderCardGrid({ providers, onSelect }: ProviderCardGridProps) {
 	return (
 		<div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
 			{providers.map((provider) => {
 				const info = AI_PROVIDER_INFO[provider];
+				const hasLogo = Boolean(PROVIDER_LOGOS[provider]);
 				return (
 					<button
 						key={provider}
 						type="button"
 						onClick={() => onSelect(provider)}
-						aria-label={`${info.name} · ${info.runtimeLabel}`}
-						className="flex flex-col items-center gap-2 rounded-lg border border-border bg-surface p-4 text-center shadow-xs transition-[border-color] duration-150 hover:border-border-strong focus:border-accent focus:outline-none"
+						aria-label={info.name}
+						className="flex min-h-[6.5rem] flex-col items-center justify-center gap-2 rounded-lg border border-border bg-surface p-4 text-center shadow-xs transition-[border-color] duration-150 hover:border-border-strong focus:border-accent focus:outline-none"
 					>
-						<span className="flex h-10 w-full items-center justify-center text-text-1">
-							<ProviderLogo provider={provider} className="h-8 w-8" />
-						</span>
-						<span className="text-[13px] font-medium text-text-1">{info.name}</span>
-						<Badge color="neutral">{info.runtimeLabel}</Badge>
+						{hasLogo ? (
+							<>
+								<span className="flex h-9 w-full items-center justify-center text-text-1">
+									<ProviderLogo provider={provider} className="h-8 w-8" />
+								</span>
+								<span className="text-[13px] font-medium text-text-1">{info.name}</span>
+							</>
+						) : (
+							<span className="text-base font-bold leading-tight tracking-tight text-text-1 sm:text-lg">
+								{info.name}
+							</span>
+						)}
 					</button>
 				);
 			})}

--- a/packages/web/src/components/provider-config-form.tsx
+++ b/packages/web/src/components/provider-config-form.tsx
@@ -1,0 +1,188 @@
+import { AI_PROVIDER_INFO, AiAuthMethod, AiProvider } from '@hezo/shared';
+import { Loader2 } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import {
+	type AiProviderConfig,
+	useAiProviders,
+	useCreateAiProvider,
+} from '../hooks/use-ai-providers';
+import { SUBSCRIPTION_INSTRUCTIONS, SubscriptionInstructions } from './subscription-paste-form';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+
+// Display order mirrors the catalogue order used elsewhere in the app. Shared by
+// every surface that renders the provider card grid (onboarding + settings).
+export const ADD_PROVIDER_ORDER: readonly AiProvider[] = [
+	AiProvider.DeepSeek,
+	AiProvider.ZAi,
+	AiProvider.Anthropic,
+	AiProvider.OpenAI,
+	AiProvider.Google,
+	AiProvider.OpenRouter,
+	AiProvider.Kimi,
+	AiProvider.XAi,
+];
+
+/**
+ * Friendly default name for a new config, skipping labels already used for that
+ * provider so the `UNIQUE(provider, label)` constraint never trips on the
+ * suggested default.
+ */
+export function defaultLabel(
+	provider: AiProvider,
+	configs: AiProviderConfig[] | undefined,
+): string {
+	const info = AI_PROVIDER_INFO[provider];
+	const used = new Set((configs ?? []).filter((c) => c.provider === provider).map((c) => c.label));
+	if (!used.has(info.name)) return info.name;
+	let n = 2;
+	while (used.has(`${info.name} ${n}`)) n++;
+	return `${info.name} ${n}`;
+}
+
+interface ProviderConfigFormProps {
+	provider: AiProvider;
+	/** Called after the credential is successfully created. */
+	onDone: () => void;
+	/** Called when the user cancels out of the form. */
+	onCancel: () => void;
+	/** Show an editable, auto-prefilled name field (settings flow). */
+	showName?: boolean;
+	/** Submit-button label. */
+	submitLabel?: string;
+}
+
+/**
+ * The provider credential form, shared by the onboarding picker and the
+ * settings "Add provider" modal. Renders only the inputs the selected provider
+ * supports — an API key, or (where available) a runtime-subscription paste —
+ * plus an optional name field. Owns no surrounding chrome (heading, stepper,
+ * back affordance); the caller supplies that so the same form works in both an
+ * onboarding page and a modal. Mount with a `key={provider}` so switching
+ * providers resets the in-progress credential.
+ */
+export function ProviderConfigForm({
+	provider,
+	onDone,
+	onCancel,
+	showName = false,
+	submitLabel = 'Add provider',
+}: ProviderConfigFormProps) {
+	const { data: configs } = useAiProviders();
+	const createProvider = useCreateAiProvider();
+	const info = AI_PROVIDER_INFO[provider];
+
+	const [authMethod, setAuthMethod] = useState<AiAuthMethod>(AiAuthMethod.ApiKey);
+	const [name, setName] = useState(() => defaultLabel(provider, configs));
+	const [nameEdited, setNameEdited] = useState(false);
+	const [apiKey, setApiKey] = useState('');
+	const [authJson, setAuthJson] = useState('');
+	const [error, setError] = useState<string | null>(null);
+
+	// Keep the name pinned to the generated default until the user edits it
+	// (also re-syncs once the async configs query resolves).
+	useEffect(() => {
+		if (!nameEdited) setName(defaultLabel(provider, configs));
+	}, [configs, nameEdited, provider]);
+
+	const credential = authMethod === AiAuthMethod.Subscription ? authJson : apiKey;
+
+	async function handleSubmit(e: React.FormEvent) {
+		e.preventDefault();
+		setError(null);
+		if (!credential.trim()) return;
+		try {
+			await createProvider.mutateAsync({
+				provider,
+				api_key: credential,
+				label: showName ? name.trim() || undefined : undefined,
+				auth_method: authMethod,
+			});
+			onDone();
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Failed to add provider');
+		}
+	}
+
+	return (
+		<form onSubmit={handleSubmit} className="flex flex-col gap-4">
+			{info.supportsSubscription && (
+				<div className="flex flex-col gap-1.5">
+					<span className="text-eyebrow text-text-2">Authentication</span>
+					<div className="flex gap-2">
+						<Button
+							type="button"
+							size="sm"
+							variant={authMethod === AiAuthMethod.ApiKey ? 'primary' : 'secondary'}
+							onClick={() => {
+								setAuthMethod(AiAuthMethod.ApiKey);
+								setError(null);
+							}}
+						>
+							API key
+						</Button>
+						<Button
+							type="button"
+							size="sm"
+							variant={authMethod === AiAuthMethod.Subscription ? 'primary' : 'secondary'}
+							onClick={() => {
+								setAuthMethod(AiAuthMethod.Subscription);
+								setError(null);
+							}}
+						>
+							{info.runtimeLabel} subscription
+						</Button>
+					</div>
+				</div>
+			)}
+
+			{showName && (
+				<Input
+					label="Name"
+					value={name}
+					placeholder={info.name}
+					onChange={(e) => {
+						setName(e.target.value);
+						setNameEdited(true);
+					}}
+				/>
+			)}
+
+			{authMethod === AiAuthMethod.Subscription ? (
+				<div className="flex flex-col gap-2">
+					<SubscriptionInstructions provider={provider} />
+					<textarea
+						required
+						aria-label="Subscription credential"
+						value={authJson}
+						onChange={(e) => setAuthJson(e.target.value)}
+						placeholder={SUBSCRIPTION_INSTRUCTIONS[provider]?.placeholder}
+						rows={6}
+						spellCheck={false}
+						className="w-full rounded-md border border-border bg-surface-2 px-2 py-1.5 text-xs font-mono text-text-1 outline-none focus:border-border-strong"
+					/>
+				</div>
+			) : (
+				<Input
+					label="API key"
+					type="password"
+					placeholder={info.keyPlaceholder}
+					value={apiKey}
+					onChange={(e) => setApiKey(e.target.value)}
+				/>
+			)}
+
+			{error && <p className="text-[13px] text-danger">{error}</p>}
+
+			<div className="flex justify-end gap-2">
+				<Button type="button" variant="ghost" onClick={onCancel}>
+					Cancel
+				</Button>
+				<Button type="submit" disabled={!credential.trim() || createProvider.isPending}>
+					{createProvider.isPending && <Loader2 className="w-4 h-4 animate-spin" />}
+					{submitLabel}
+				</Button>
+			</div>
+		</form>
+	);
+}

--- a/packages/web/src/components/subscription-paste-form.tsx
+++ b/packages/web/src/components/subscription-paste-form.tsx
@@ -1,14 +1,5 @@
 import { AiProvider } from '@hezo/shared';
-import { Loader2 } from 'lucide-react';
-import { type ReactNode, useState } from 'react';
-import { Button } from './ui/button';
-
-export interface SubscriptionPasteFormProps {
-	provider: AiProvider;
-	onSubmit: (authJson: string) => Promise<void> | void;
-	onCancel: () => void;
-	pending: boolean;
-}
+import type { ReactNode } from 'react';
 
 interface ProviderInstructions {
 	title: string;
@@ -139,54 +130,5 @@ export function SubscriptionInstructions({ provider }: { provider: AiProvider })
 			</ol>
 			<p className="mt-2">{instructions.footer}</p>
 		</div>
-	);
-}
-
-export function SubscriptionPasteForm({
-	provider,
-	onSubmit,
-	onCancel,
-	pending,
-}: SubscriptionPasteFormProps) {
-	const [authJson, setAuthJson] = useState('');
-	const instructions = SUBSCRIPTION_INSTRUCTIONS[provider];
-
-	if (!instructions) {
-		return (
-			<p className="text-[13px] text-danger mt-2">
-				Subscription paste flow is not available for this provider.
-			</p>
-		);
-	}
-
-	async function handleSubmit(e: React.FormEvent) {
-		e.preventDefault();
-		await onSubmit(authJson);
-	}
-
-	return (
-		<form onSubmit={handleSubmit} className="mt-2 flex flex-col gap-3">
-			<SubscriptionInstructions provider={provider} />
-
-			<textarea
-				required
-				value={authJson}
-				onChange={(e) => setAuthJson(e.target.value)}
-				placeholder={instructions.placeholder}
-				rows={6}
-				spellCheck={false}
-				className="w-full rounded-md border border-border bg-surface-2 px-2 py-1.5 text-xs font-mono text-text-1 outline-none focus:border-border-strong"
-			/>
-
-			<div className="flex gap-2">
-				<Button type="submit" size="sm" disabled={!authJson.trim() || pending}>
-					{pending && <Loader2 className="w-3 h-3 animate-spin" />}
-					Save
-				</Button>
-				<Button type="button" variant="secondary" size="sm" onClick={onCancel}>
-					Cancel
-				</Button>
-			</div>
-		</form>
 	);
 }

--- a/packages/web/test/ai-providers.test.tsx
+++ b/packages/web/test/ai-providers.test.tsx
@@ -42,12 +42,13 @@ test('Add provider modal shows provider cards incl. xAI (no Moonshot, no OAuth)'
 	await user.click(getByRole('button', { name: 'Add provider' }));
 
 	const dialog = await findByRole('dialog');
-	// The picker step renders one selectable card per provider (aria-label is
-	// "<name> · <runtime>"), including the new xAI / Grok Build entry.
+	// The picker step renders one selectable card per provider (each card's
+	// accessible name is just the provider name), including the xAI entry.
 	for (const name of ['Anthropic', 'OpenAI', 'Google', 'OpenRouter', 'Kimi', 'xAI']) {
 		expect(within(dialog).getByRole('button', { name: new RegExp(name) })).toBeTruthy();
 	}
-	expect(within(dialog).getByRole('button', { name: /xAI · Grok Build/ })).toBeTruthy();
+	// Cards show only the logo + name now — the runtime label is no longer on them.
+	expect(queryAllByText('Grok Build').length).toBe(0);
 	expect(queryAllByText('Moonshot').length).toBe(0);
 	expect(queryAllByRole('button', { name: /OAuth/i }).length).toBe(0);
 });
@@ -61,7 +62,7 @@ test('Add provider modal: pick xAI card → API-key form → Back returns to the
 	await user.click(getByRole('button', { name: 'Add provider' }));
 
 	const dialog = await findByRole('dialog');
-	await user.click(within(dialog).getByRole('button', { name: /xAI · Grok Build/ }));
+	await user.click(within(dialog).getByRole('button', { name: /xAI/ }));
 
 	// Configure step: title flips and an API-key field appears (xAI is key-only,
 	// so there's no subscription toggle).
@@ -84,7 +85,7 @@ test('adds an xAI API key via the card flow', async () => {
 	await user.click(getByRole('button', { name: 'Add provider' }));
 
 	const dialog = await findByRole('dialog');
-	await user.click(within(dialog).getByRole('button', { name: /xAI · Grok Build/ }));
+	await user.click(within(dialog).getByRole('button', { name: /xAI/ }));
 
 	const nameInput = within(dialog).getByLabelText('Name') as HTMLInputElement;
 	fireEvent.change(nameInput, { target: { value: 'My Grok' } });
@@ -121,35 +122,28 @@ test('sidebar Settings link navigates to /settings and renders the AI providers 
 });
 
 test('can add an Anthropic API key via the settings UI', async () => {
-	const { container, findByRole, findByText, user } = await renderApp({
+	const { container, findByRole, findByText, getByRole, user } = await renderApp({
 		initialPath: '/settings/ai-providers',
 		seed: async () => {
-			// Clear the default seeded provider so the gate modal renders and the
-			// "Enter API key" affordance is reachable.
+			// Clear the default seeded provider so the gate (card grid) renders.
 			await clearAiProviders();
 		},
 	});
 
 	await findByRole('heading', { name: 'Set up an AI provider' }, { timeout: 15_000 });
 
-	// Find the Anthropic card inside the gate modal (p-4 padding).
-	const modalCards = Array.from(
-		container.querySelectorAll<HTMLElement>('div.border.border-border.rounded-md.p-4'),
-	);
-	const anthropicCard = modalCards.find((el) => el.textContent?.includes('Anthropic'));
-	expect(anthropicCard).toBeTruthy();
-
-	await user.click(within(anthropicCard!).getByRole('button', { name: 'Enter API key' }));
-	const keyInput = anthropicCard!.querySelector('input[type="password"]') as HTMLInputElement;
+	// Pick the Anthropic card from the grid, then fill its API-key form.
+	await user.click(getByRole('button', { name: 'Anthropic' }));
+	const keyInput = container.querySelector('input[type="password"]') as HTMLInputElement;
 	fireEvent.change(keyInput, { target: { value: 'sk-ant-component-test-1234567890' } });
-	await user.click(within(anthropicCard!).getByRole('button', { name: 'Save' }));
+	await user.click(getByRole('button', { name: 'Save' }));
 
 	// Once a provider is configured the gate drops and the settings page renders.
 	await findByText('active', undefined, { timeout: 15_000 });
 });
 
 test('offers Claude Code subscription (setup-token) paste flow for Anthropic', async () => {
-	const { container, findByRole, findByText, user } = await renderApp({
+	const { container, findAllByText, findByRole, findByText, getByRole, user } = await renderApp({
 		initialPath: '/settings/ai-providers',
 		seed: async () => {
 			await clearAiProviders();
@@ -158,26 +152,19 @@ test('offers Claude Code subscription (setup-token) paste flow for Anthropic', a
 
 	await findByRole('heading', { name: 'Set up an AI provider' }, { timeout: 15_000 });
 
-	const modalCards = Array.from(
-		container.querySelectorAll<HTMLElement>('div.border.border-border.rounded-md.p-4'),
-	);
-	const anthropicCard = modalCards.find((el) => el.textContent?.includes('Anthropic'));
-	expect(anthropicCard).toBeTruthy();
-
-	await user.click(
-		within(anthropicCard!).getByRole('button', { name: /Use Claude Code subscription/i }),
-	);
-	const setupHits = await within(anthropicCard!).findAllByText(/setup-token/i);
+	await user.click(getByRole('button', { name: 'Anthropic' }));
+	await user.click(getByRole('button', { name: /Claude Code subscription/i }));
+	const setupHits = await findAllByText(/setup-token/i);
 	expect(setupHits.length).toBeGreaterThan(0);
-	const textarea = anthropicCard!.querySelector('textarea') as HTMLTextAreaElement;
+	const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
 	fireEvent.change(textarea, { target: { value: 'sk-ant-oat01-component-test-token' } });
-	await user.click(within(anthropicCard!).getByRole('button', { name: 'Save' }));
+	await user.click(getByRole('button', { name: 'Save' }));
 
 	await findByText('Subscription', undefined, { timeout: 15_000 });
 });
 
 test('offers Kimi Code subscription paste flow for Kimi', async () => {
-	const { container, findByRole, findByText, user } = await renderApp({
+	const { container, findAllByText, findByRole, findByText, getByRole, user } = await renderApp({
 		initialPath: '/settings/ai-providers',
 		seed: async () => {
 			await clearAiProviders();
@@ -186,16 +173,11 @@ test('offers Kimi Code subscription paste flow for Kimi', async () => {
 
 	await findByRole('heading', { name: 'Set up an AI provider' }, { timeout: 15_000 });
 
-	const modalCards = Array.from(
-		container.querySelectorAll<HTMLElement>('div.border.border-border.rounded-md.p-4'),
-	);
-	const kimiCard = modalCards.find((el) => el.textContent?.includes('Kimi'));
-	expect(kimiCard).toBeTruthy();
-
-	await user.click(within(kimiCard!).getByRole('button', { name: /Use Kimi Code subscription/i }));
-	const loginHits = await within(kimiCard!).findAllByText(/kimi login/i);
+	await user.click(getByRole('button', { name: 'Kimi' }));
+	await user.click(getByRole('button', { name: /Kimi Code subscription/i }));
+	const loginHits = await findAllByText(/kimi login/i);
 	expect(loginHits.length).toBeGreaterThan(0);
-	const textarea = kimiCard!.querySelector('textarea') as HTMLTextAreaElement;
+	const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
 	fireEvent.change(textarea, {
 		target: {
 			value: JSON.stringify({
@@ -206,13 +188,13 @@ test('offers Kimi Code subscription paste flow for Kimi', async () => {
 			}),
 		},
 	});
-	await user.click(within(kimiCard!).getByRole('button', { name: 'Save' }));
+	await user.click(getByRole('button', { name: 'Save' }));
 
 	await findByText('Subscription', undefined, { timeout: 15_000 });
 });
 
 test('offers Codex subscription paste flow for OpenAI', async () => {
-	const { container, findByRole, findByText, user } = await renderApp({
+	const { container, findAllByText, findByRole, findByText, getByRole, user } = await renderApp({
 		initialPath: '/settings/ai-providers',
 		seed: async () => {
 			await clearAiProviders();
@@ -221,26 +203,21 @@ test('offers Codex subscription paste flow for OpenAI', async () => {
 
 	await findByRole('heading', { name: 'Set up an AI provider' }, { timeout: 15_000 });
 
-	const modalCards = Array.from(
-		container.querySelectorAll<HTMLElement>('div.border.border-border.rounded-md.p-4'),
-	);
-	const openaiCard = modalCards.find((el) => el.textContent?.includes('OpenAI'));
-	expect(openaiCard).toBeTruthy();
-
-	await user.click(within(openaiCard!).getByRole('button', { name: /Use Codex subscription/i }));
-	const codexHits = await within(openaiCard!).findAllByText(/codex login/i);
+	await user.click(getByRole('button', { name: 'OpenAI' }));
+	await user.click(getByRole('button', { name: /Codex subscription/i }));
+	const codexHits = await findAllByText(/codex login/i);
 	expect(codexHits.length).toBeGreaterThan(0);
-	const textarea = openaiCard!.querySelector('textarea') as HTMLTextAreaElement;
+	const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
 	fireEvent.change(textarea, {
 		target: { value: JSON.stringify({ tokens: { refresh_token: 'rt-component-paste' } }) },
 	});
-	await user.click(within(openaiCard!).getByRole('button', { name: 'Save' }));
+	await user.click(getByRole('button', { name: 'Save' }));
 
 	await findByText('Subscription', undefined, { timeout: 15_000 });
 });
 
 test('offers Gemini subscription paste flow for Google', async () => {
-	const { container, findByRole, findByText, user } = await renderApp({
+	const { container, findAllByText, findByRole, findByText, getByRole, user } = await renderApp({
 		initialPath: '/settings/ai-providers',
 		seed: async () => {
 			await clearAiProviders();
@@ -249,16 +226,11 @@ test('offers Gemini subscription paste flow for Google', async () => {
 
 	await findByRole('heading', { name: 'Set up an AI provider' }, { timeout: 15_000 });
 
-	const modalCards = Array.from(
-		container.querySelectorAll<HTMLElement>('div.border.border-border.rounded-md.p-4'),
-	);
-	const googleCard = modalCards.find((el) => el.textContent?.includes('Google'));
-	expect(googleCard).toBeTruthy();
-
-	await user.click(within(googleCard!).getByRole('button', { name: /Use Gemini subscription/i }));
-	const oauthHits = await within(googleCard!).findAllByText(/oauth_creds\.json/i);
+	await user.click(getByRole('button', { name: 'Google' }));
+	await user.click(getByRole('button', { name: /Gemini subscription/i }));
+	const oauthHits = await findAllByText(/oauth_creds\.json/i);
 	expect(oauthHits.length).toBeGreaterThan(0);
-	const textarea = googleCard!.querySelector('textarea') as HTMLTextAreaElement;
+	const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
 	fireEvent.change(textarea, {
 		target: {
 			value: JSON.stringify({
@@ -270,7 +242,7 @@ test('offers Gemini subscription paste flow for Google', async () => {
 			}),
 		},
 	});
-	await user.click(within(googleCard!).getByRole('button', { name: 'Save' }));
+	await user.click(getByRole('button', { name: 'Save' }));
 
 	await findByText('Subscription', undefined, { timeout: 15_000 });
 });
@@ -411,7 +383,7 @@ test('adds a subscription credential via the Add modal', async () => {
 	await user.click(getByRole('button', { name: 'Add provider' }));
 
 	const dialog = await findByRole('dialog');
-	await user.click(within(dialog).getByRole('button', { name: /OpenAI · Codex/ }));
+	await user.click(within(dialog).getByRole('button', { name: /OpenAI/ }));
 	await user.click(within(dialog).getByRole('button', { name: /Codex subscription/i }));
 
 	// "codex login" appears in both a step and the footer, so match all.
@@ -427,7 +399,7 @@ test('adds a subscription credential via the Add modal', async () => {
 });
 
 test('blocks the app when no provider is configured and drops once one is added', async () => {
-	const { container, findByRole, queryAllByRole, user } = await renderApp({
+	const { container, findByRole, getByRole, queryAllByRole, user } = await renderApp({
 		initialPath: '/',
 		seed: async () => {
 			await clearAiProviders();
@@ -437,16 +409,11 @@ test('blocks the app when no provider is configured and drops once one is added'
 	await findByRole('heading', { name: 'Set up an AI provider' }, { timeout: 15_000 });
 	expect(queryAllByRole('heading', { name: 'AI providers' }).length).toBe(0);
 
-	const modalCards = Array.from(
-		container.querySelectorAll<HTMLElement>('div.border.border-border.rounded-md.p-4'),
-	);
-	const anthropicCard = modalCards.find((el) => el.textContent?.includes('Anthropic'));
-	expect(anthropicCard).toBeTruthy();
-
-	await user.click(within(anthropicCard!).getByRole('button', { name: 'Enter API key' }));
-	const keyInput = anthropicCard!.querySelector('input[type="password"]') as HTMLInputElement;
+	// Pick the Anthropic card from the grid, then fill its API-key form.
+	await user.click(getByRole('button', { name: 'Anthropic' }));
+	const keyInput = container.querySelector('input[type="password"]') as HTMLInputElement;
 	fireEvent.change(keyInput, { target: { value: 'sk-ant-gate-component-12345' } });
-	await user.click(within(anthropicCard!).getByRole('button', { name: 'Save' }));
+	await user.click(getByRole('button', { name: 'Save' }));
 
 	// Gate drops once the provider lands and the app shell renders.
 	await waitFor(

--- a/test/browser/helpers.ts
+++ b/test/browser/helpers.ts
@@ -442,7 +442,8 @@ export async function dismissAiProviderModal(page: Page) {
 		return;
 	}
 
-	await page.getByRole('button', { name: 'Enter API key' }).first().click();
+	// Pick the Anthropic card from the grid, then fill its API-key form.
+	await page.getByRole('button', { name: 'Anthropic' }).first().click();
 	await page.locator('input[type="password"]').first().fill('sk-ant-e2e-test-key');
 	await page.getByRole('button', { name: 'Save' }).first().click();
 


### PR DESCRIPTION
## What & why

Reworks the onboarding **AI-provider step** (`AiProviderPicker`) from a vertical stack of cards with inline expand-to-form into a clean **grid → form → back** flow, matching the requested layout.

## Changes

- **Grid of cards** — providers render in a responsive grid (2 cols on mobile, 3 from `sm` up), each card showing **just the brand logo with the provider name underneath**. Providers without a registered logo show their name on its own as a **large wordmark** (no more duplicate label).
- **Drill-in form** — selecting a card opens a form with only the credential inputs that provider supports: an **API key**, or a **runtime-subscription paste** where available (Anthropic / OpenAI / Google / Kimi). A **Back** arrow returns to the full card grid.
- **Submit = done** — submitting fires the existing `useCreateAiProvider` mutation; verification, encryption and persistence stay server-side. On success the setup gate drops automatically once a provider is configured.
- **Shared card cleanup** — simplified `ProviderCardGrid` (logo + name only, dropped the runtime-label badge) so the settings *Add provider* dialog and the onboarding picker look identical. Removed the now-unused `SubscriptionPasteForm`.

## Tests

- Updated `packages/web/test/ai-providers.test.tsx` to drive the new grid→form→back flow for both the dialog and the onboarding gate (API-key and all four subscription-paste providers). **16/16 passing.**
- Updated the Playwright helper `dismissAiProviderModal` to pick the Anthropic card before filling its key form.
- Full `typecheck` + production `build` pass via the pre-commit hook.

No docs changes needed — the underlying behavior (configure a provider by API key or subscription) is unchanged; only the UI layout differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAkv1fiBiVFoyfkQiot4G9)_