### PR TITLE
feat: remove mobile sidemenu close button and homepage time display

### DIFF
--- a/packages/web/src/routes/__root.tsx
+++ b/packages/web/src/routes/__root.tsx
@@ -6,7 +6,6 @@ import {
 	useMatches,
 	useNavigate,
 } from '@tanstack/react-router';
-import { X } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { AppHeader } from '../components/app-header';
 import { CeoChatWidget } from '../components/ceo-chat/ceo-chat-widget';
@@ -216,15 +215,6 @@ function ShellChrome({ drawerOpen, setDrawerOpen }: ShellChromeProps) {
 								<ProjectSidebar />
 							</div>
 						)}
-						<button
-							type="button"
-							aria-label="Close navigation"
-							onClick={() => setDrawerOpen(false)}
-							data-testid="mobile-nav-close"
-							className="absolute top-2 right-2 z-10 w-9 h-9 rounded-md flex items-center justify-center text-text-2 hover:text-text-1 hover:bg-surface-2 transition-colors"
-						>
-							<X className="w-4 h-4" />
-						</button>
 					</div>
 				</div>
 			)}

--- a/packages/web/src/routes/home/index.tsx
+++ b/packages/web/src/routes/home/index.tsx
@@ -420,24 +420,11 @@ function HomePage() {
 	const hasProject = projects.length > 0;
 	const hasIntake = !!intake;
 	const showWelcome = !hasProject && !hasIntake;
-	const now = new Date();
-	const dateLabel = now
-		.toLocaleString(undefined, {
-			weekday: 'short',
-			day: 'numeric',
-			month: 'short',
-			hour: '2-digit',
-			minute: '2-digit',
-		})
-		.toLowerCase();
 
 	return (
 		<div className="max-w-7xl mx-auto w-full px-4 py-4 md:px-6 md:py-5 lg:px-8 lg:py-6">
 			<div className="mb-5 flex items-baseline justify-between gap-3">
 				<h1 className="text-[22px] md:text-[28px] font-semibold tracking-[-0.02em]">Home</h1>
-				<span className="font-mono text-[12px] text-text-3" data-testid="home-date">
-					{dateLabel}
-				</span>
 			</div>
 
 			{showWelcome && <WelcomeCard onCreate={() => setCreateOpen(true)} />}

--- a/packages/web/test/home-dashboard.test.tsx
+++ b/packages/web/test/home-dashboard.test.tsx
@@ -28,8 +28,7 @@ test('home shows the dashboard with an active project card carrying live stats',
 
 	await router.navigate({ to: '/home' });
 
-	// Date header + Active section render.
-	await findByTestId('home-date', undefined, { timeout: 15_000 });
+	// Active section renders.
 	const active = await findByTestId('home-active', undefined, { timeout: 15_000 });
 	expect(active.textContent).toContain(ref.name);
 

--- a/test/browser/app-header.mobile.spec.ts
+++ b/test/browser/app-header.mobile.spec.ts
@@ -45,7 +45,10 @@ test.describe('app header + project rail responsiveness', () => {
 		await expect(drawer).toBeVisible();
 		await expect(drawer.getByTestId('project-rail')).toBeVisible();
 
-		await page.getByTestId('mobile-nav-close').click();
+		// No close button — clicking the background overlay (right of the panel) dismisses it.
+		await drawer.getByRole('button', { name: 'Close navigation' }).click({
+			position: { x: 350, y: 400 },
+		});
 		await expect(drawer).toBeHidden();
 	});
 });

--- a/test/browser/floating-new-task.mobile.spec.ts
+++ b/test/browser/floating-new-task.mobile.spec.ts
@@ -41,7 +41,13 @@ test.describe('Floating new-task button responsiveness', () => {
 		await page.getByTestId('mobile-nav-toggle').click();
 		await expect(page.getByTestId('mobile-nav-drawer')).toBeVisible();
 		await expect(floating).toBeHidden();
-		await page.getByTestId('mobile-nav-close').click();
+		// No close button — clicking the background overlay (right of the panel) dismisses it.
+		await page
+			.getByTestId('mobile-nav-drawer')
+			.getByRole('button', { name: 'Close navigation' })
+			.click({
+				position: { x: 350, y: 400 },
+			});
 		await expect(floating).toBeVisible();
 
 		// …and it hides while the CEO chat is open.


### PR DESCRIPTION
## Summary

- **Removed the close (X) button from the mobile nav drawer.** The drawer can already be dismissed by tapping the background overlay (the `Close navigation` backdrop behind the panel), so the dedicated button was redundant. Also dropped the now-unused `X` lucide import.
- **Removed the date/time display from the Home header** (the `mon 29 jun, 15:26` chip). Dropped the `dateLabel`/`now` computation and the `home-date` span.

## Changes

- `packages/web/src/routes/__root.tsx` — drop the `mobile-nav-close` button and the `X` import from the drawer.
- `packages/web/src/routes/home/index.tsx` — drop the date/time chip from the Home header.

## Tests

- `test/browser/app-header.mobile.spec.ts` & `test/browser/floating-new-task.mobile.spec.ts` — updated to dismiss the drawer by clicking the background overlay (right of the panel) instead of the removed close button.
- `packages/web/test/home-dashboard.test.tsx` — dropped the `home-date` assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UV9jz88UC6uV6c4gktAe5

---
_Generated by [Claude Code](https://claude.ai/code/session_011UV9jz88UC6uV6c4gktAe5)_