### PR TITLE
Merge model pricing into AI providers settings page

### DIFF
--- a/packages/web/src/components/model-pricing-section.tsx
+++ b/packages/web/src/components/model-pricing-section.tsx
@@ -1,13 +1,6 @@
-import { createFileRoute } from '@tanstack/react-router';
 import { Plus, RefreshCw, Trash2 } from 'lucide-react';
 import { useState } from 'react';
-import { Badge } from '../../components/ui/badge';
-import { Button } from '../../components/ui/button';
-import { type Column, DataTable } from '../../components/ui/data-table';
-import { InfoTooltip } from '../../components/ui/info-tooltip';
-import { Input } from '../../components/ui/input';
-import { Tooltip } from '../../components/ui/tooltip';
-import { useMe } from '../../hooks/use-me';
+import { useMe } from '../hooks/use-me';
 import {
 	type CreateOverridePayload,
 	type ModelPricingRow,
@@ -15,7 +8,13 @@ import {
 	useDeleteModelPricingOverride,
 	useModelPricing,
 	useRefreshModelPricing,
-} from '../../hooks/use-model-pricing';
+} from '../hooks/use-model-pricing';
+import { Badge } from './ui/badge';
+import { Button } from './ui/button';
+import { type Column, DataTable } from './ui/data-table';
+import { InfoTooltip } from './ui/info-tooltip';
+import { Input } from './ui/input';
+import { Tooltip } from './ui/tooltip';
 
 const PER_MILLION = 1_000_000;
 
@@ -34,7 +33,12 @@ function parsePerMillion(value: string): number | undefined {
 	return n / PER_MILLION;
 }
 
-function ModelPricingPage() {
+/**
+ * Model pricing management, rendered below the AI providers table on the
+ * AI providers settings page. Superuser-only: returns null for board users so
+ * the page they *can* reach (for the provider list) doesn't show a dead panel.
+ */
+export function ModelPricingSection() {
 	const { data: me } = useMe();
 	const { data: rows = [] } = useModelPricing();
 	const createOverride = useCreateModelPricingOverride();
@@ -152,113 +156,105 @@ function ModelPricingPage() {
 		},
 	];
 
-	const content =
-		me && !me.is_superuser ? (
-			<p className="text-[13px] text-text-2">
-				Model pricing is managed by the Admin. You don't have access to this page.
-			</p>
-		) : (
-			<>
-				<div className="flex items-start justify-between gap-3 mb-4">
-					<div>
-						<div className="flex items-center gap-1.5">
-							<h1 className="text-[22px] font-medium">Model pricing</h1>
-							<InfoTooltip
-								label="About model pricing"
-								content="Per-model token rates used to compute the dollar cost of every agent run. Rows auto-refresh from the public LiteLLM feed; add a manual override for a model the feed lacks (or to correct one) — overrides win."
-								data-testid="model-pricing-info"
-							/>
-						</div>
-						<p className="text-[13px] text-text-2 mt-1 max-w-[680px]">
-							Per-token rates that turn a run's token counts into a dollar cost, across every
-							runtime. Feed rows refresh from <span className="font-mono">LiteLLM</span>; a manual
-							override wins for that model — use it for ids the feed doesn't carry (e.g.{' '}
-							<span className="font-mono">deepseek-v4-pro</span>
-							).
-						</p>
-					</div>
-					<div className="flex items-center gap-2 shrink-0">
-						<Button
-							variant="secondary"
-							size="sm"
-							onClick={() => refresh.mutate()}
-							disabled={refresh.isPending}
-						>
-							<RefreshCw className={`w-3 h-3 ${refresh.isPending ? 'animate-spin' : ''}`} /> Refresh
-						</Button>
-						<Button
-							variant="secondary"
-							size="sm"
-							onClick={() => (showForm ? resetForm() : setShowForm(true))}
-						>
-							<Plus className="w-3 h-3" /> Override
-						</Button>
-					</div>
-				</div>
+	// Board users can reach the AI providers page but don't manage pricing.
+	if (me && !me.is_superuser) return null;
 
-				{showForm && (
-					<form onSubmit={handleSubmit} className="flex flex-col gap-2 mb-4">
-						<Input
-							placeholder="Model id (e.g. deepseek-v4-pro)"
-							value={modelId}
-							onChange={(e) => setModelId(e.target.value)}
-							required
+	return (
+		<section className="mt-10 pt-8 border-t border-border">
+			<div className="flex items-start justify-between gap-3 mb-4">
+				<div>
+					<div className="flex items-center gap-1.5">
+						<h2 className="text-base font-medium">Model pricing</h2>
+						<InfoTooltip
+							label="About model pricing"
+							content="Per-model token rates used to compute the dollar cost of every agent run. Rows auto-refresh from the public LiteLLM feed; add a manual override for a model the feed lacks (or to correct one) — overrides win."
+							data-testid="model-pricing-info"
 						/>
-						<div className="flex flex-col sm:flex-row gap-2">
-							<Input
-								placeholder="Input $ / Mtok"
-								value={input}
-								onChange={(e) => setInput(e.target.value)}
-								required
-								className="flex-1"
-							/>
-							<Input
-								placeholder="Output $ / Mtok"
-								value={output}
-								onChange={(e) => setOutput(e.target.value)}
-								required
-								className="flex-1"
-							/>
-						</div>
-						<div className="flex flex-col sm:flex-row gap-2">
-							<Input
-								placeholder="Cache read $ / Mtok (optional)"
-								value={cacheRead}
-								onChange={(e) => setCacheRead(e.target.value)}
-								className="flex-1"
-							/>
-							<Input
-								placeholder="Cache write $ / Mtok (optional)"
-								value={cacheCreation}
-								onChange={(e) => setCacheCreation(e.target.value)}
-								className="flex-1"
-							/>
-						</div>
-						{error && <p className="text-[13px] text-danger">{error}</p>}
-						<div className="flex gap-2">
-							<Button type="submit" size="sm" disabled={createOverride.isPending}>
-								Save override
-							</Button>
-							<Button type="button" variant="secondary" size="sm" onClick={resetForm}>
-								Cancel
-							</Button>
-						</div>
-					</form>
-				)}
-
-				{!rows.length ? (
-					<p className="text-[13px] text-text-2">
-						No pricing rows yet. Refresh from the feed, or add a manual override above.
+					</div>
+					<p className="text-[13px] text-text-2 mt-1 max-w-[680px]">
+						Per-token rates that turn a run's token counts into a dollar cost, across every runtime.
+						Feed rows refresh from <span className="font-mono">LiteLLM</span>; a manual override
+						wins for that model — use it for ids the feed doesn't carry (e.g.{' '}
+						<span className="font-mono">deepseek-v4-pro</span>
+						).
 					</p>
-				) : (
-					<DataTable columns={columns} data={rows} rowKey={(row) => row.id} />
-				)}
-			</>
-		);
+				</div>
+				<div className="flex items-center gap-2 shrink-0">
+					<Button
+						variant="secondary"
+						size="sm"
+						onClick={() => refresh.mutate()}
+						disabled={refresh.isPending}
+					>
+						<RefreshCw className={`w-3 h-3 ${refresh.isPending ? 'animate-spin' : ''}`} /> Refresh
+					</Button>
+					<Button
+						variant="secondary"
+						size="sm"
+						onClick={() => (showForm ? resetForm() : setShowForm(true))}
+					>
+						<Plus className="w-3 h-3" /> Override
+					</Button>
+				</div>
+			</div>
 
-	return <div className="max-w-[900px]">{content}</div>;
+			{showForm && (
+				<form onSubmit={handleSubmit} className="flex flex-col gap-2 mb-4">
+					<Input
+						placeholder="Model id (e.g. deepseek-v4-pro)"
+						value={modelId}
+						onChange={(e) => setModelId(e.target.value)}
+						required
+					/>
+					<div className="flex flex-col sm:flex-row gap-2">
+						<Input
+							placeholder="Input $ / Mtok"
+							value={input}
+							onChange={(e) => setInput(e.target.value)}
+							required
+							className="flex-1"
+						/>
+						<Input
+							placeholder="Output $ / Mtok"
+							value={output}
+							onChange={(e) => setOutput(e.target.value)}
+							required
+							className="flex-1"
+						/>
+					</div>
+					<div className="flex flex-col sm:flex-row gap-2">
+						<Input
+							placeholder="Cache read $ / Mtok (optional)"
+							value={cacheRead}
+							onChange={(e) => setCacheRead(e.target.value)}
+							className="flex-1"
+						/>
+						<Input
+							placeholder="Cache write $ / Mtok (optional)"
+							value={cacheCreation}
+							onChange={(e) => setCacheCreation(e.target.value)}
+							className="flex-1"
+						/>
+					</div>
+					{error && <p className="text-[13px] text-danger">{error}</p>}
+					<div className="flex gap-2">
+						<Button type="submit" size="sm" disabled={createOverride.isPending}>
+							Save override
+						</Button>
+						<Button type="button" variant="secondary" size="sm" onClick={resetForm}>
+							Cancel
+						</Button>
+					</div>
+				</form>
+			)}
+
+			{!rows.length ? (
+				<p className="text-[13px] text-text-2">
+					No pricing rows yet. Refresh from the feed, or add a manual override above.
+				</p>
+			) : (
+				<DataTable columns={columns} data={rows} rowKey={(row) => row.id} />
+			)}
+		</section>
+	);
 }
-
-export const Route = createFileRoute('/settings/model-pricing')({
-	component: ModelPricingPage,
-});

--- a/packages/web/src/components/settings-sidebar.tsx
+++ b/packages/web/src/components/settings-sidebar.tsx
@@ -25,7 +25,6 @@ const ADMIN_ITEMS: NavItem[] = [
 	{ to: '/settings/connectors', label: 'Connectors' },
 	{ to: '/settings/credentials', label: 'Credentials' },
 	{ to: '/settings/api-keys', label: 'API keys' },
-	{ to: '/settings/model-pricing', label: 'Model pricing' },
 	{ to: '/settings/audit-log', label: 'Activity' },
 ];
 

--- a/packages/web/src/routeTree.gen.ts
+++ b/packages/web/src/routeTree.gen.ts
@@ -14,7 +14,6 @@ import { Route as IndexRouteImport } from './routes/index'
 import { Route as SettingsIndexRouteImport } from './routes/settings/index'
 import { Route as HomeIndexRouteImport } from './routes/home/index'
 import { Route as SettingsSkillsRouteImport } from './routes/settings/skills'
-import { Route as SettingsModelPricingRouteImport } from './routes/settings/model-pricing'
 import { Route as SettingsCredentialsRouteImport } from './routes/settings/credentials'
 import { Route as SettingsConnectorsRouteImport } from './routes/settings/connectors'
 import { Route as SettingsChatboxRouteImport } from './routes/settings/chatbox'
@@ -69,11 +68,6 @@ const HomeIndexRoute = HomeIndexRouteImport.update({
 const SettingsSkillsRoute = SettingsSkillsRouteImport.update({
   id: '/skills',
   path: '/skills',
-  getParentRoute: () => SettingsRouteRoute,
-} as any)
-const SettingsModelPricingRoute = SettingsModelPricingRouteImport.update({
-  id: '/model-pricing',
-  path: '/model-pricing',
   getParentRoute: () => SettingsRouteRoute,
 } as any)
 const SettingsCredentialsRoute = SettingsCredentialsRouteImport.update({
@@ -256,7 +250,6 @@ export interface FileRoutesByFullPath {
   '/settings/chatbox': typeof SettingsChatboxRoute
   '/settings/connectors': typeof SettingsConnectorsRoute
   '/settings/credentials': typeof SettingsCredentialsRoute
-  '/settings/model-pricing': typeof SettingsModelPricingRoute
   '/settings/skills': typeof SettingsSkillsRoute
   '/home/': typeof HomeIndexRoute
   '/settings/': typeof SettingsIndexRoute
@@ -292,7 +285,6 @@ export interface FileRoutesByTo {
   '/settings/chatbox': typeof SettingsChatboxRoute
   '/settings/connectors': typeof SettingsConnectorsRoute
   '/settings/credentials': typeof SettingsCredentialsRoute
-  '/settings/model-pricing': typeof SettingsModelPricingRoute
   '/settings/skills': typeof SettingsSkillsRoute
   '/home': typeof HomeIndexRoute
   '/settings': typeof SettingsIndexRoute
@@ -330,7 +322,6 @@ export interface FileRoutesById {
   '/settings/chatbox': typeof SettingsChatboxRoute
   '/settings/connectors': typeof SettingsConnectorsRoute
   '/settings/credentials': typeof SettingsCredentialsRoute
-  '/settings/model-pricing': typeof SettingsModelPricingRoute
   '/settings/skills': typeof SettingsSkillsRoute
   '/home/': typeof HomeIndexRoute
   '/settings/': typeof SettingsIndexRoute
@@ -370,7 +361,6 @@ export interface FileRouteTypes {
     | '/settings/chatbox'
     | '/settings/connectors'
     | '/settings/credentials'
-    | '/settings/model-pricing'
     | '/settings/skills'
     | '/home/'
     | '/settings/'
@@ -406,7 +396,6 @@ export interface FileRouteTypes {
     | '/settings/chatbox'
     | '/settings/connectors'
     | '/settings/credentials'
-    | '/settings/model-pricing'
     | '/settings/skills'
     | '/home'
     | '/settings'
@@ -443,7 +432,6 @@ export interface FileRouteTypes {
     | '/settings/chatbox'
     | '/settings/connectors'
     | '/settings/credentials'
-    | '/settings/model-pricing'
     | '/settings/skills'
     | '/home/'
     | '/settings/'
@@ -516,13 +504,6 @@ declare module '@tanstack/react-router' {
       path: '/skills'
       fullPath: '/settings/skills'
       preLoaderRoute: typeof SettingsSkillsRouteImport
-      parentRoute: typeof SettingsRouteRoute
-    }
-    '/settings/model-pricing': {
-      id: '/settings/model-pricing'
-      path: '/model-pricing'
-      fullPath: '/settings/model-pricing'
-      preLoaderRoute: typeof SettingsModelPricingRouteImport
       parentRoute: typeof SettingsRouteRoute
     }
     '/settings/credentials': {
@@ -745,7 +726,6 @@ interface SettingsRouteRouteChildren {
   SettingsChatboxRoute: typeof SettingsChatboxRoute
   SettingsConnectorsRoute: typeof SettingsConnectorsRoute
   SettingsCredentialsRoute: typeof SettingsCredentialsRoute
-  SettingsModelPricingRoute: typeof SettingsModelPricingRoute
   SettingsSkillsRoute: typeof SettingsSkillsRoute
   SettingsIndexRoute: typeof SettingsIndexRoute
 }
@@ -757,7 +737,6 @@ const SettingsRouteRouteChildren: SettingsRouteRouteChildren = {
   SettingsChatboxRoute: SettingsChatboxRoute,
   SettingsConnectorsRoute: SettingsConnectorsRoute,
   SettingsCredentialsRoute: SettingsCredentialsRoute,
-  SettingsModelPricingRoute: SettingsModelPricingRoute,
   SettingsSkillsRoute: SettingsSkillsRoute,
   SettingsIndexRoute: SettingsIndexRoute,
 }

--- a/packages/web/src/routes/settings/ai-providers.tsx
+++ b/packages/web/src/routes/settings/ai-providers.tsx
@@ -1,10 +1,12 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { AiProvidersSection } from '../../components/ai-providers-section';
+import { ModelPricingSection } from '../../components/model-pricing-section';
 
 function AiProvidersPage() {
 	return (
 		<div className="max-w-[900px]">
 			<AiProvidersSection />
+			<ModelPricingSection />
 		</div>
 	);
 }

--- a/packages/web/test/model-pricing.test.tsx
+++ b/packages/web/test/model-pricing.test.tsx
@@ -1,5 +1,4 @@
-import { waitFor } from '@testing-library/react';
-import { expect, test } from 'vitest';
+import { test } from 'vitest';
 import { renderApp } from './helpers/render';
 
 async function seedOverride(
@@ -14,9 +13,9 @@ async function seedOverride(
 	if (res.status !== 201) throw new Error(`seed override failed: ${res.status}`);
 }
 
-test('lists a seeded override and creates a new one via the form', async () => {
-	const { findByText, getByRole, getByPlaceholderText, user } = await renderApp({
-		initialPath: '/settings/model-pricing',
+test('model pricing renders below the AI providers table and creates an override', async () => {
+	const { findByText, findByRole, getByRole, getByPlaceholderText, user } = await renderApp({
+		initialPath: '/settings/ai-providers',
 		seed: async (ctx) => {
 			await seedOverride(ctx, {
 				model_id: 'seeded-model',
@@ -26,8 +25,10 @@ test('lists a seeded override and creates a new one via the form', async () => {
 		},
 	});
 
-	// Heading + the seeded override (and its $/Mtok rendering) show.
-	await findByText('Model pricing', { selector: 'h1' });
+	// The merged page leads with the AI providers section, then the model
+	// pricing section below it.
+	await findByRole('heading', { name: 'AI providers' });
+	await findByRole('heading', { name: 'Model pricing' });
 	await findByText('seeded-model');
 	await findByText('$3.00');
 
@@ -40,21 +41,4 @@ test('lists a seeded override and creates a new one via the form', async () => {
 
 	// The new override appears after the invalidate + refetch.
 	await findByText('deepseek-v4-pro');
-});
-
-test('settings page shows the superuser Model pricing link and navigates to it', async () => {
-	const { findByRole, getAllByRole, user, router } = await renderApp({ initialPath: '/settings' });
-
-	await findByRole('heading', { name: 'Settings' });
-	const link = await waitFor(() => {
-		const found = getAllByRole('link', { name: 'Model pricing' }).find(
-			(l) => l.getAttribute('href') === '/settings/model-pricing',
-		);
-		expect(found).toBeTruthy();
-		return found as HTMLElement;
-	});
-	await user.click(link);
-
-	expect(router.state.location.pathname).toBe('/settings/model-pricing');
-	await findByRole('heading', { name: 'Model pricing' });
 });


### PR DESCRIPTION
## Summary

Merges the standalone **Model pricing** settings page into the **AI providers** settings page, rendered as a section directly below the providers table.

## Changes

- **New `ModelPricingSection` component** (`packages/web/src/components/model-pricing-section.tsx`) — extracts the model pricing UI (LiteLLM feed table, manual override form, refresh) from the old route into a reusable section. It's superuser-only: returns `null` for board users so the AI providers page (which board users can reach) doesn't show a dead panel. The heading is now an `<h2>` to match the section style, sitting under a top border with spacing.
- **AI providers page** (`routes/settings/ai-providers.tsx`) now renders `<AiProvidersSection />` followed by `<ModelPricingSection />`.
- **Removed** the standalone `/settings/model-pricing` route file and its **Model pricing** entry from the settings sidebar nav.
- **Regenerated** `routeTree.gen.ts` to drop the removed route.

## Notes

The REST API (`/api/model-pricing`) is unchanged — this is purely a UI relocation. No `docs/` changes were needed (no doc page links to the old settings location; the pricing behaviour described in `budgets-and-costs.md` is unchanged).

## Testing

- Rewrote `packages/web/test/model-pricing.test.tsx` to navigate to `/settings/ai-providers` and assert the Model pricing section renders below the AI providers table, plus the create-override flow. ✅
- `ai-providers.test.tsx` (16 tests) still green. ✅
- `tsc --noEmit` and Biome clean across the touched files. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmP6KzEgQDvZt6dmGHwSDs)_