### PR TITLE
feat(web): add goal-form field tooltips and a reusable help dialog

### DIFF
--- a/packages/web/src/components/create-goal-dialog.tsx
+++ b/packages/web/src/components/create-goal-dialog.tsx
@@ -5,11 +5,13 @@ import {
 } from '@hezo/shared';
 import * as Dialog from '@radix-ui/react-dialog';
 import { Loader2, X } from 'lucide-react';
+import type { ReactNode } from 'react';
 import { useEffect, useState } from 'react';
 import { useCreateGoal, useUpdateGoal } from '../hooks/use-goals';
 import { GoalSmartGuidance } from './goal-smart-guidance';
 import { Button } from './ui/button';
 import { dialogContentClassName, dialogOverlayClassName } from './ui/dialog';
+import { InfoTooltip } from './ui/info-tooltip';
 import { Input } from './ui/input';
 
 interface CreateGoalDialogProps {
@@ -22,6 +24,38 @@ interface CreateGoalDialogProps {
 
 const textareaClass =
 	'rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-text-1 outline-none focus:border-border-strong';
+
+/**
+ * A field label row pairing the label text with an info tooltip suffix icon. Renders a `<span>` by
+ * default (for fields whose control is wrapped by an outer `<label>`); pass `htmlFor` to render an
+ * explicit `<label htmlFor>` instead (for controls that aren't a plain DOM element child).
+ */
+function FieldLabel({
+	children,
+	tooltip,
+	tooltipLabel,
+	htmlFor,
+}: {
+	children: ReactNode;
+	tooltip: ReactNode;
+	tooltipLabel: string;
+	htmlFor?: string;
+}) {
+	const className = 'flex items-center gap-1.5 text-sm text-text-2';
+	const inner = (
+		<>
+			{children}
+			<InfoTooltip label={tooltipLabel} content={tooltip} />
+		</>
+	);
+	return htmlFor ? (
+		<label htmlFor={htmlFor} className={className}>
+			{inner}
+		</label>
+	) : (
+		<span className={className}>{inner}</span>
+	);
+}
 
 export function CreateGoalDialog({ projectId, open, onOpenChange, goal }: CreateGoalDialogProps) {
 	const isEdit = !!goal;
@@ -94,16 +128,30 @@ export function CreateGoalDialog({ projectId, open, onOpenChange, goal }: Create
 					<form onSubmit={handleSubmit} className="flex flex-col gap-4">
 						<GoalSmartGuidance />
 
-						<Input
-							label="Goal name"
-							value={title}
-							onChange={(e) => setTitle(e.target.value)}
-							placeholder="e.g. Reach 100 paying customers"
-							required
-						/>
+						<div className="flex flex-col gap-1.5">
+							<FieldLabel
+								htmlFor="goal-name"
+								tooltipLabel="About goal name"
+								tooltip="A short, outcome-focused name for the goal — what success looks like, not the work to get there."
+							>
+								Goal name
+							</FieldLabel>
+							<Input
+								id="goal-name"
+								value={title}
+								onChange={(e) => setTitle(e.target.value)}
+								placeholder="e.g. Reach 100 paying customers"
+								required
+							/>
+						</div>
 
 						<label className="flex flex-col gap-1.5">
-							<span className="text-sm text-text-2">Measurement</span>
+							<FieldLabel
+								tooltipLabel="About measurement"
+								tooltip="How will you know this goal is achieved? Be precise — this is the bar the Captain measures progress against."
+							>
+								Measurement
+							</FieldLabel>
 							<textarea
 								value={measurement}
 								onChange={(e) => setMeasurement(e.target.value)}
@@ -114,9 +162,12 @@ export function CreateGoalDialog({ projectId, open, onOpenChange, goal }: Create
 						</label>
 
 						<label className="flex flex-col gap-1.5">
-							<span className="text-sm text-text-2">
+							<FieldLabel
+								tooltipLabel="About suggested actions"
+								tooltip="Optional — specific actions or checks the Captain should take toward this goal (e.g. run a weekly cron-style check of the signup funnel)."
+							>
 								Suggested actions <span className="text-text-3">(optional)</span>
-							</span>
+							</FieldLabel>
 							<textarea
 								value={actions}
 								onChange={(e) => setActions(e.target.value)}
@@ -128,7 +179,12 @@ export function CreateGoalDialog({ projectId, open, onOpenChange, goal }: Create
 
 						<div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
 							<label className="flex flex-col gap-1.5">
-								<span className="text-sm text-text-2">Check frequency</span>
+								<FieldLabel
+									tooltipLabel="About check frequency"
+									tooltip="How often the Captain re-checks progress on this goal and acts on it."
+								>
+									Check frequency
+								</FieldLabel>
 								<select
 									value={checkFrequency}
 									onChange={(e) => setCheckFrequency(e.target.value as GoalCheckFrequency)}
@@ -143,9 +199,12 @@ export function CreateGoalDialog({ projectId, open, onOpenChange, goal }: Create
 							</label>
 
 							<label className="flex flex-col gap-1.5">
-								<span className="text-sm text-text-2">
+								<FieldLabel
+									tooltipLabel="About deadline"
+									tooltip="Optional — a target date for reaching this goal. Leave blank for an open-ended goal."
+								>
 									Deadline <span className="text-text-3">(optional)</span>
-								</span>
+								</FieldLabel>
 								<input
 									type="date"
 									value={targetDate}

--- a/packages/web/src/components/goals-list.tsx
+++ b/packages/web/src/components/goals-list.tsx
@@ -15,6 +15,7 @@ import { GoalSmartGuidance } from './goal-smart-guidance';
 import { ProjectProgressSummary } from './project-progress-summary';
 import { Button } from './ui/button';
 import { EmptyState } from './ui/empty-state';
+import { HelpDialog } from './ui/help-dialog';
 
 interface GoalsListProps {
 	projectId: string;
@@ -243,8 +244,22 @@ export function GoalsList({ projectId }: GoalsListProps) {
 		<div>
 			<ProjectProgressSummary projectId={projectId} />
 			<div className="mb-4 flex flex-wrap items-center justify-between gap-2">
-				<div className="flex items-center gap-3">
+				<div className="flex items-center gap-1.5">
 					<h1 className="text-lg font-semibold text-text-1">Goals</h1>
+					<HelpDialog
+						title="What makes a good goal?"
+						triggerLabel="What makes a good goal?"
+						data-testid="goals-help"
+					>
+						<div className="flex flex-col gap-3">
+							<p className="text-sm text-text-2 leading-relaxed">
+								Goals are the outcomes the Captain steers the team toward. Write each one so
+								progress is unambiguous — strong goals follow the{' '}
+								<span className="font-semibold">SMART</span> framework:
+							</p>
+							<GoalSmartGuidance className="border-0 bg-transparent p-0" />
+						</div>
+					</HelpDialog>
 					<ViewFilter view={view} onChange={setView} />
 				</div>
 				<Button onClick={() => setCreateOpen(true)} data-testid="goals-new-goal">
@@ -252,16 +267,6 @@ export function GoalsList({ projectId }: GoalsListProps) {
 					New goal
 				</Button>
 			</div>
-
-			<details
-				className="mb-4 rounded-md border border-border bg-surface px-3 py-2"
-				data-testid="goals-smart-disclosure"
-			>
-				<summary className="cursor-pointer text-xs text-text-2 select-none">
-					What makes a good goal? (SMART)
-				</summary>
-				<GoalSmartGuidance className="mt-2 border-0 bg-transparent p-0" />
-			</details>
 
 			{goals.length === 0 ? (
 				<div className="py-12 text-center text-[13px] text-text-3" data-testid="goals-empty-view">

--- a/packages/web/src/components/ui/help-dialog.tsx
+++ b/packages/web/src/components/ui/help-dialog.tsx
@@ -1,0 +1,66 @@
+import * as Dialog from '@radix-ui/react-dialog';
+import { HelpCircle, X } from 'lucide-react';
+import { type ReactNode, useState } from 'react';
+import { dialogContentClassName, dialogOverlayClassName } from './dialog';
+
+interface HelpDialogProps {
+	/** Heading shown at the top of the modal. */
+	title: ReactNode;
+	/** Modal body content. */
+	children: ReactNode;
+	/** Accessible label for the question-mark trigger button. */
+	triggerLabel: string;
+	/** Trigger button size class for the icon. Defaults to a small (3.5) glyph. */
+	className?: string;
+	/** Width of the modal. Defaults to `md`. */
+	size?: keyof typeof dialogContentClassName;
+	'data-testid'?: string;
+}
+
+/**
+ * Reusable help affordance: a question-mark icon button that opens a modal popup with longer-form
+ * guidance. Use this (rather than {@link InfoTooltip}) when the explanation is too rich for a hover
+ * tooltip — the distinct `?` glyph signals to the user that clicking opens a dialog, not a tooltip.
+ */
+export function HelpDialog({
+	title,
+	children,
+	triggerLabel,
+	className,
+	size = 'md',
+	'data-testid': testId,
+}: HelpDialogProps) {
+	const [open, setOpen] = useState(false);
+	return (
+		<Dialog.Root open={open} onOpenChange={setOpen}>
+			<Dialog.Trigger asChild>
+				<button
+					type="button"
+					aria-label={triggerLabel}
+					data-testid={testId}
+					className={`shrink-0 text-text-3 hover:text-text-1 transition-colors ${className ?? ''}`}
+				>
+					<HelpCircle className="w-3.5 h-3.5" />
+				</button>
+			</Dialog.Trigger>
+			<Dialog.Portal>
+				<Dialog.Overlay className={dialogOverlayClassName} />
+				<Dialog.Content className={dialogContentClassName[size]}>
+					<div className="mb-4 flex items-center justify-between gap-2">
+						<Dialog.Title className="text-lg font-semibold">{title}</Dialog.Title>
+						<Dialog.Close asChild>
+							<button
+								type="button"
+								className="-m-2 p-2 text-text-2 hover:text-text-1"
+								aria-label="Close"
+							>
+								<X className="h-4 w-4" />
+							</button>
+						</Dialog.Close>
+					</div>
+					{children}
+				</Dialog.Content>
+			</Dialog.Portal>
+		</Dialog.Root>
+	);
+}

--- a/packages/web/test/goals.test.tsx
+++ b/packages/web/test/goals.test.tsx
@@ -53,6 +53,66 @@ test('Progress page renders the Captain progress summary above the goals', async
 	await findByText('Reach 100 customers');
 });
 
+test('the Goals header help button opens the SMART guidance modal', async () => {
+	let projectSlug = '';
+	const { findByTestId, findByText, queryByText, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Help Demo' });
+			projectSlug = project.slug;
+			await seedGoal(ws, project, { title: 'Ship it', measurement: 'shipped' });
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/goals',
+		params: { projectId: projectSlug },
+	});
+
+	// The guidance is not inline — it lives behind the help button.
+	const help = await findByTestId('goals-help', undefined, { timeout: 10_000 });
+	expect(queryByText(/Goals are the outcomes the Captain steers/)).toBeNull();
+
+	await user.click(help);
+
+	// The modal renders its title and the SMART guidance body.
+	await findByText('What makes a good goal?');
+	await findByText(/Goals are the outcomes the Captain steers/);
+});
+
+test('the goal create form renders an info tooltip for every field', async () => {
+	let projectSlug = '';
+	const { findByTestId, getByLabelText, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Tooltip Demo' });
+			projectSlug = project.slug;
+			await seedGoal(ws, project, { title: 'Ship it', measurement: 'shipped' });
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/goals',
+		params: { projectId: projectSlug },
+	});
+
+	const newGoal = await findByTestId('goals-new-goal', undefined, { timeout: 10_000 });
+	await user.click(newGoal);
+
+	// Every field in the form carries an info-tooltip suffix button (queried by its aria-label).
+	for (const label of [
+		'About goal name',
+		'About measurement',
+		'About suggested actions',
+		'About check frequency',
+		'About deadline',
+	]) {
+		expect(getByLabelText(label)).toBeTruthy();
+	}
+});
+
 test('clicking a goal opens its page with breadcrumbs, run feed, and edit modal', async () => {
 	let projectSlug = '';
 	const { findByText, findByTestId, getByTestId, user, router } = await renderApp({


### PR DESCRIPTION
## Summary

Adds inline help affordances to the goals UI, in two parts.

**Goal create/edit form** — every input field now carries an info-tooltip suffix icon (`InfoTooltip`) with a short explanatory blurb:
- Goal name, Measurement, Suggested actions, Check frequency, Deadline.
- A small `FieldLabel` helper pairs the label text with the tooltip; it renders a plain `<span>` for fields whose control is wrapped by an outer `<label>`, and an explicit `<label htmlFor>` for the goal-name field (whose control is the `Input` component, not a bare DOM element).

**Goals page header** — replaces the inline collapsible *"What makes a good goal? (SMART)"* disclosure with a question-mark **help button** next to the heading. Clicking it opens a modal popup with the goals/SMART guidance.
- The button + modal are a new **reusable `HelpDialog`** component (`ui/help-dialog.tsx`). It uses a distinct `?` (HelpCircle) glyph — rather than the `i` tooltip glyph — to signal that clicking opens a dialog, not a hover tooltip. Reuse it anywhere a piece of UI needs richer, click-to-open help than a tooltip can hold.

## Testing

`packages/web/test/goals.test.tsx`:
- New test: the Goals header help button opens the SMART guidance modal (and the guidance is not rendered inline).
- New test: the goal create form renders an info tooltip for every field.
- Existing goals tests still pass (5/5).

Pre-commit `turbo typecheck` + build passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Ddpw9DANHDvertMcsFVo2)_