### PR TITLE
feat(web): move GitHub to a dedicated Git settings subpage

### DIFF
--- a/packages/web/src/components/comment-renderers/action-comment.tsx
+++ b/packages/web/src/components/comment-renderers/action-comment.tsx
@@ -46,13 +46,13 @@ export function ActionComment({ comment, projectId }: Props) {
 			<div className="flex items-center gap-2 text-sm">
 				<GitBranch className="w-4 h-4 text-info-soft-fg" />
 				<span>
-					This project has no designated repository yet. Add a repo URL in project settings, then
+					This project has no designated repository yet. Add a repo on the Git settings page, then
 					this ticket will resume.
 				</span>
 			</div>
 			<div>
-				<Link to="/projects/$projectId/settings" params={{ projectId }}>
-					<Button size="sm">Open project settings</Button>
+				<Link to="/projects/$projectId/git" params={{ projectId }}>
+					<Button size="sm">Open Git settings</Button>
 				</Link>
 			</div>
 		</div>

--- a/packages/web/src/components/project-sidebar.tsx
+++ b/packages/web/src/components/project-sidebar.tsx
@@ -108,6 +108,14 @@ export function ProjectSidebar() {
 		label: 'Activity',
 		testId: 'project-sidebar-activity',
 	};
+	// Git (GitHub today; GitLab/others later) discloses under Settings on a
+	// normal project, like Container and Activity. HQ has no Git page.
+	const gitPage = {
+		to: '/projects/$projectId/git',
+		params: projectParams,
+		label: 'Git',
+		testId: 'project-sidebar-git',
+	};
 
 	// Progress (the project's goals + Captain-maintained summary) leads under Inbox; it's a
 	// normal-project concept, so HQ (internal) has none.
@@ -178,9 +186,9 @@ export function ProjectSidebar() {
 						params: projectParams,
 						label: 'Settings',
 						testId: 'project-sidebar-settings',
-						// Container and Activity disclose under Settings when it (or one of
-						// them) is the active route.
-						subItems: [containerPage, activityPage],
+						// Git, Container and Activity disclose under Settings when it (or one
+						// of them) is the active route.
+						subItems: [gitPage, containerPage, activityPage],
 					},
 				]),
 	];

--- a/packages/web/src/components/repo-setup-approval-modal.tsx
+++ b/packages/web/src/components/repo-setup-approval-modal.tsx
@@ -39,11 +39,11 @@ export function RepoSetupApprovalModal({
 		});
 	}
 
-	function openSettings() {
+	function openGitSettings() {
 		if (!projectSlug) return;
 		onOpenChange(false);
 		navigate({
-			to: '/projects/$projectId/settings',
+			to: '/projects/$projectId/git',
 			params: { projectId: projectSlug },
 		});
 	}
@@ -104,7 +104,7 @@ export function RepoSetupApprovalModal({
 						</Button>
 						<Button
 							size="sm"
-							onClick={openSettings}
+							onClick={openGitSettings}
 							disabled={!projectSlug}
 							data-testid="repo-setup-approval-cta"
 						>

--- a/packages/web/src/routeTree.gen.ts
+++ b/packages/web/src/routeTree.gen.ts
@@ -23,6 +23,7 @@ import { Route as SettingsAiProvidersRouteImport } from './routes/settings/ai-pr
 import { Route as ProjectsProjectIdRouteRouteImport } from './routes/projects/$projectId/route'
 import { Route as ProjectsProjectIdIndexRouteImport } from './routes/projects/$projectId/index'
 import { Route as HomeInboxIndexRouteImport } from './routes/home/inbox/index'
+import { Route as ProjectsProjectIdGitRouteImport } from './routes/projects/$projectId/git'
 import { Route as ProjectsProjectIdDocumentsRouteImport } from './routes/projects/$projectId/documents'
 import { Route as ProjectsProjectIdContainerRouteImport } from './routes/projects/$projectId/container'
 import { Route as ProjectsProjectIdConnectorsRouteImport } from './routes/projects/$projectId/connectors'
@@ -114,6 +115,11 @@ const HomeInboxIndexRoute = HomeInboxIndexRouteImport.update({
   id: '/home/inbox/',
   path: '/home/inbox/',
   getParentRoute: () => rootRouteImport,
+} as any)
+const ProjectsProjectIdGitRoute = ProjectsProjectIdGitRouteImport.update({
+  id: '/git',
+  path: '/git',
+  getParentRoute: () => ProjectsProjectIdRouteRoute,
 } as any)
 const ProjectsProjectIdDocumentsRoute =
   ProjectsProjectIdDocumentsRouteImport.update({
@@ -260,6 +266,7 @@ export interface FileRoutesByFullPath {
   '/projects/$projectId/connectors': typeof ProjectsProjectIdConnectorsRoute
   '/projects/$projectId/container': typeof ProjectsProjectIdContainerRoute
   '/projects/$projectId/documents': typeof ProjectsProjectIdDocumentsRoute
+  '/projects/$projectId/git': typeof ProjectsProjectIdGitRoute
   '/home/inbox/': typeof HomeInboxIndexRoute
   '/projects/$projectId/': typeof ProjectsProjectIdIndexRoute
   '/projects/$projectId/agents/$agentId': typeof ProjectsProjectIdAgentsAgentIdRouteRouteWithChildren
@@ -295,6 +302,7 @@ export interface FileRoutesByTo {
   '/projects/$projectId/connectors': typeof ProjectsProjectIdConnectorsRoute
   '/projects/$projectId/container': typeof ProjectsProjectIdContainerRoute
   '/projects/$projectId/documents': typeof ProjectsProjectIdDocumentsRoute
+  '/projects/$projectId/git': typeof ProjectsProjectIdGitRoute
   '/home/inbox': typeof HomeInboxIndexRoute
   '/projects/$projectId': typeof ProjectsProjectIdIndexRoute
   '/projects/$projectId/agents/hire': typeof ProjectsProjectIdAgentsHireRoute
@@ -332,6 +340,7 @@ export interface FileRoutesById {
   '/projects/$projectId/connectors': typeof ProjectsProjectIdConnectorsRoute
   '/projects/$projectId/container': typeof ProjectsProjectIdContainerRoute
   '/projects/$projectId/documents': typeof ProjectsProjectIdDocumentsRoute
+  '/projects/$projectId/git': typeof ProjectsProjectIdGitRoute
   '/home/inbox/': typeof HomeInboxIndexRoute
   '/projects/$projectId/': typeof ProjectsProjectIdIndexRoute
   '/projects/$projectId/agents/$agentId': typeof ProjectsProjectIdAgentsAgentIdRouteRouteWithChildren
@@ -371,6 +380,7 @@ export interface FileRouteTypes {
     | '/projects/$projectId/connectors'
     | '/projects/$projectId/container'
     | '/projects/$projectId/documents'
+    | '/projects/$projectId/git'
     | '/home/inbox/'
     | '/projects/$projectId/'
     | '/projects/$projectId/agents/$agentId'
@@ -406,6 +416,7 @@ export interface FileRouteTypes {
     | '/projects/$projectId/connectors'
     | '/projects/$projectId/container'
     | '/projects/$projectId/documents'
+    | '/projects/$projectId/git'
     | '/home/inbox'
     | '/projects/$projectId'
     | '/projects/$projectId/agents/hire'
@@ -442,6 +453,7 @@ export interface FileRouteTypes {
     | '/projects/$projectId/connectors'
     | '/projects/$projectId/container'
     | '/projects/$projectId/documents'
+    | '/projects/$projectId/git'
     | '/home/inbox/'
     | '/projects/$projectId/'
     | '/projects/$projectId/agents/$agentId'
@@ -568,6 +580,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/home/inbox/'
       preLoaderRoute: typeof HomeInboxIndexRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/projects/$projectId/git': {
+      id: '/projects/$projectId/git'
+      path: '/git'
+      fullPath: '/projects/$projectId/git'
+      preLoaderRoute: typeof ProjectsProjectIdGitRouteImport
+      parentRoute: typeof ProjectsProjectIdRouteRoute
     }
     '/projects/$projectId/documents': {
       id: '/projects/$projectId/documents'
@@ -776,6 +795,7 @@ interface ProjectsProjectIdRouteRouteChildren {
   ProjectsProjectIdConnectorsRoute: typeof ProjectsProjectIdConnectorsRoute
   ProjectsProjectIdContainerRoute: typeof ProjectsProjectIdContainerRoute
   ProjectsProjectIdDocumentsRoute: typeof ProjectsProjectIdDocumentsRoute
+  ProjectsProjectIdGitRoute: typeof ProjectsProjectIdGitRoute
   ProjectsProjectIdIndexRoute: typeof ProjectsProjectIdIndexRoute
   ProjectsProjectIdAgentsAgentIdRouteRoute: typeof ProjectsProjectIdAgentsAgentIdRouteRouteWithChildren
   ProjectsProjectIdAgentsHireRoute: typeof ProjectsProjectIdAgentsHireRoute
@@ -797,6 +817,7 @@ const ProjectsProjectIdRouteRouteChildren: ProjectsProjectIdRouteRouteChildren =
     ProjectsProjectIdConnectorsRoute: ProjectsProjectIdConnectorsRoute,
     ProjectsProjectIdContainerRoute: ProjectsProjectIdContainerRoute,
     ProjectsProjectIdDocumentsRoute: ProjectsProjectIdDocumentsRoute,
+    ProjectsProjectIdGitRoute: ProjectsProjectIdGitRoute,
     ProjectsProjectIdIndexRoute: ProjectsProjectIdIndexRoute,
     ProjectsProjectIdAgentsAgentIdRouteRoute:
       ProjectsProjectIdAgentsAgentIdRouteRouteWithChildren,

--- a/packages/web/src/routes/projects/$projectId/git.tsx
+++ b/packages/web/src/routes/projects/$projectId/git.tsx
@@ -1,0 +1,26 @@
+import { HQ_PROJECT_SLUG } from '@hezo/shared';
+import { createFileRoute, redirect } from '@tanstack/react-router';
+import { GitHubSection } from '../../../components/github-section';
+
+function GitSettingsPage() {
+	const { projectId } = Route.useParams();
+	return (
+		<div className="space-y-8">
+			<GitHubSection projectId={projectId} />
+		</div>
+	);
+}
+
+export const Route = createFileRoute('/projects/$projectId/git')({
+	beforeLoad: ({ params }) => {
+		// Internal projects (slug `internal-<teamSlug>`) have no Git settings page.
+		if (params.projectId === HQ_PROJECT_SLUG) {
+			throw redirect({
+				to: '/projects/$projectId/tasks',
+				params,
+				replace: true,
+			});
+		}
+	},
+	component: GitSettingsPage,
+});

--- a/packages/web/src/routes/projects/$projectId/settings/index.tsx
+++ b/packages/web/src/routes/projects/$projectId/settings/index.tsx
@@ -3,7 +3,6 @@ import { createFileRoute, redirect } from '@tanstack/react-router';
 import { ExternalLink, Loader2 } from 'lucide-react';
 import { useState } from 'react';
 import { ProjectBudgetPanel } from '../../../../components/budget/project-budget-panel';
-import { GitHubSection } from '../../../../components/github-section';
 import { ProjectIconSection } from '../../../../components/project-icon-section';
 import { Button } from '../../../../components/ui/button';
 import { Input } from '../../../../components/ui/input';
@@ -144,8 +143,6 @@ function ProjectSettingsPage() {
 					</div>
 				</section>
 			)}
-
-			<GitHubSection projectId={projectId} />
 		</div>
 	);
 }

--- a/packages/web/test/action-comment-branches.test.tsx
+++ b/packages/web/test/action-comment-branches.test.tsx
@@ -93,14 +93,14 @@ test('setup_repo resolved without a result identifier shows "(unknown)"', async 
 	expect((await findByTestId('action-complete')).textContent).toContain('(unknown)');
 });
 
-test('setup_repo unresolved with projectId renders the setup-repo prompt and settings link', async () => {
+test('setup_repo unresolved with projectId renders the setup-repo prompt and Git settings link', async () => {
 	const { findByTestId } = renderNode(
 		<ActionComment comment={actionComment({ kind: 'setup_repo' })} projectId="proj" />,
 	);
 	const prompt = await findByTestId('action-setup-repo');
 	expect(prompt.textContent).toContain('no designated repository');
 	const link = prompt.querySelector('a') as HTMLAnchorElement;
-	expect(link.getAttribute('href')).toContain('/projects/proj/settings');
+	expect(link.getAttribute('href')).toContain('/projects/proj/git');
 });
 
 test('setup_repo unresolved without projectId renders the unavailable fallback', async () => {

--- a/packages/web/test/github-section-states.test.tsx
+++ b/packages/web/test/github-section-states.test.tsx
@@ -1,8 +1,8 @@
 // Coverage for components/github-section.tsx beyond the disconnected CTA that
 // project-settings.test.tsx already hits: the connected state, the repo list
 // (web link + designated lock + deletable rows), the reauth/needs-permissions
-// banner, and the startConnect error path. Rendered through the project settings
-// page. The OAuth-connection / scope-status / repos / mcp-connections endpoints
+// banner, and the startConnect error path. Rendered through the project's Git
+// settings page. The OAuth-connection / scope-status / repos / mcp-connections endpoints
 // are fetch-mocked (matching agent-executions-project.test.tsx) because seeding a
 // realistic GitHub OAuth connection + repos against the real backend is heavy and
 // orthogonal to what this component renders. Component tier — no real layout/WS.
@@ -115,7 +115,7 @@ async function renderSettings(mock: Parameters<typeof installGitHubMock>[0]) {
 		},
 	});
 	await helpers.router.navigate({
-		to: '/projects/$projectId/settings',
+		to: '/projects/$projectId/git',
 		params: { projectId: seeded.projectSlug },
 	});
 	return { ...helpers, seeded };

--- a/packages/web/test/project-settings.test.tsx
+++ b/packages/web/test/project-settings.test.tsx
@@ -269,7 +269,7 @@ test('State A — no GitHub connection: shows Connect GitHub CTA', async () => {
 	});
 
 	await router.navigate({
-		to: '/projects/$projectId/settings',
+		to: '/projects/$projectId/git',
 		params: { projectId: projectSlug },
 	});
 

--- a/packages/web/test/project-sidebar.test.tsx
+++ b/packages/web/test/project-sidebar.test.tsx
@@ -34,8 +34,9 @@ test('the project menu leads with Inbox, lists the project pages, and has a Team
 	expect(within(nav).getByRole('link', { name: 'Documents' })).toBeTruthy();
 	expect(within(nav).getByRole('link', { name: 'Assets' })).toBeTruthy();
 	expect(within(nav).getByRole('link', { name: 'Settings' })).toBeTruthy();
-	// Container and Activity now nest under Settings — hidden until it (or one of
-	// them) is the active route.
+	// Git, Container and Activity now nest under Settings — hidden until it (or
+	// one of them) is the active route.
+	expect(within(nav).queryByRole('link', { name: 'Git' })).toBeNull();
 	expect(within(nav).queryByRole('link', { name: 'Container' })).toBeNull();
 	expect(within(nav).queryByRole('link', { name: 'Activity' })).toBeNull();
 
@@ -50,7 +51,7 @@ test('the project menu leads with Inbox, lists the project pages, and has a Team
 	expect(queryByTestId('project-sidebar-back')).toBeNull();
 });
 
-test('Container and Activity nest under Settings, disclosed when Settings is the active route', async () => {
+test('Git, Container and Activity nest under Settings, disclosed when Settings is the active route', async () => {
 	let ws!: SeededWorkspace;
 	let projectSlug = '';
 	const { container, findByTestId, router } = await renderApp({
@@ -68,17 +69,19 @@ test('Container and Activity nest under Settings, disclosed when Settings is the
 		params: { projectId: projectSlug },
 	});
 	await findByTestId('project-sidebar-name', undefined, { timeout: 15_000 });
+	expect(within(getNav(container)).queryByRole('link', { name: 'Git' })).toBeNull();
 	expect(within(getNav(container)).queryByRole('link', { name: 'Container' })).toBeNull();
 	expect(within(getNav(container)).queryByRole('link', { name: 'Activity' })).toBeNull();
 
-	// Selecting Settings discloses Container and Activity beneath it.
+	// Selecting Settings discloses Git, Container and Activity beneath it.
 	await router.navigate({
 		to: '/projects/$projectId/settings',
 		params: { projectId: projectSlug },
 	});
 	await waitFor(() =>
-		expect(within(getNav(container)).getByRole('link', { name: 'Container' })).toBeTruthy(),
+		expect(within(getNav(container)).getByRole('link', { name: 'Git' })).toBeTruthy(),
 	);
+	expect(within(getNav(container)).getByRole('link', { name: 'Container' })).toBeTruthy();
 	expect(within(getNav(container)).getByRole('link', { name: 'Activity' })).toBeTruthy();
 	expect(within(getNav(container)).getByRole('link', { name: 'Settings' })).toBeTruthy();
 

--- a/packages/web/test/repo-picker-exists.test.tsx
+++ b/packages/web/test/repo-picker-exists.test.tsx
@@ -73,7 +73,7 @@ test('GITHUB_REPO_EXISTS surfaces a link-existing affordance that flips the moda
 	});
 
 	await router.navigate({
-		to: '/projects/$projectId/settings',
+		to: '/projects/$projectId/git',
 		params: { projectId: projectSlug },
 	});
 

--- a/packages/web/test/repo-picker-flows.test.tsx
+++ b/packages/web/test/repo-picker-flows.test.tsx
@@ -1,7 +1,7 @@
 // Wizard-flow coverage for the Phase 13 repo-setup picker: the successful
 // "Link existing" and "Create new" paths against the GitHub simulator, plus
-// the designated-repo lock (no delete affordance) on the project settings
-// page. Component tier per the decision tree — pure form/dialog/mutation
+// the designated-repo lock (no delete affordance) on the project's Git
+// settings page. Component tier per the decision tree — pure form/dialog/mutation
 // behavior, no real layout, viewport, or WebSocket dependency.
 
 import { mkdirSync, writeFileSync } from 'node:fs';
@@ -117,7 +117,7 @@ test('link-existing flow links the repo and auto-designates the first repo', asy
 	});
 
 	await router.navigate({
-		to: '/projects/$projectId/settings',
+		to: '/projects/$projectId/git',
 		params: { projectId: projectSlug },
 	});
 
@@ -159,7 +159,7 @@ test('create-new flow creates the repo on GitHub and auto-designates it', async 
 	});
 
 	await router.navigate({
-		to: '/projects/$projectId/settings',
+		to: '/projects/$projectId/git',
 		params: { projectId: projectSlug },
 	});
 
@@ -215,7 +215,7 @@ test('designated repo shows a lock with no delete affordance; extras stay deleta
 	});
 
 	await router.navigate({
-		to: '/projects/$projectId/settings',
+		to: '/projects/$projectId/git',
 		params: { projectId: projectSlug },
 	});
 

--- a/packages/web/test/repo-setup-approval.test.tsx
+++ b/packages/web/test/repo-setup-approval.test.tsx
@@ -134,7 +134,7 @@ test('clicking a ticket row navigates to the comment with a brief highlight', as
 	expect(router.state.location.pathname).toBe(expectedPrefix);
 });
 
-test('CTA navigates to the project settings page', async () => {
+test('CTA navigates to the project Git settings page', async () => {
 	let seed!: SeededBlocked;
 
 	const { findAllByTestId, findByRole, user, router } = await renderApp({
@@ -159,7 +159,7 @@ test('CTA navigates to the project settings page', async () => {
 	await screen.findByTestId('repo-setup-approval-modal', undefined, { timeout: 10_000 });
 	await user.click(await screen.findByTestId('repo-setup-approval-cta'));
 
-	const expected = `/projects/${seed.projectSlug}/settings`;
+	const expected = `/projects/${seed.projectSlug}/git`;
 	await new Promise((r) => setTimeout(r, 500));
 	expect(router.state.location.pathname).toBe(expected);
 	await findByRole('heading', { name: 'GitHub' }, { timeout: 15_000 });


### PR DESCRIPTION
## What & why

GitHub setup previously rendered as an inline section at the bottom of the project **Settings** page. This promotes it into its own subpage at `/projects/$projectId/git`, with a dedicated **Git** entry in the project sidebar (disclosed under Settings alongside Container and Activity).

The menu item is named **Git** rather than "GitHub" deliberately — so GitLab and other hosts can live under the same page in the future.

This also closes the loop on the inbox "set up GitHub repo" prompt: clicking **Set up GitHub** in the approval modal (and the setup-repo action comment in a task thread) now takes the user straight to the Git page where they actually configure the repo, instead of dropping them on the general Settings page.

## Changes

- **New route** `routes/projects/$projectId/git.tsx` rendering `GitHubSection` (with the same HQ/internal-project redirect guard as Settings). Removed the inline `GitHubSection` from the project Settings page.
- **Project sidebar** (`project-sidebar.tsx`): added a `gitPage` and disclose it under Settings, before Container and Activity.
- **Navigation targets** updated to the Git page:
  - `repo-setup-approval-modal.tsx` CTA (`openGitSettings`).
  - `action-comment.tsx` setup-repo link + copy ("Add a repo on the Git settings page" / "Open Git settings").
- Regenerated `routeTree.gen.ts`.

## Testing

- Updated component tests to render/assert against the Git page: `project-sidebar`, `project-settings`, `github-section-states`, `repo-picker-exists`, `repo-picker-flows`, `repo-setup-approval`. Added Git to the sidebar disclosure assertions.
- `bunx vitest run` over the affected files: **27 passed**.
- Web `tsc --noEmit` clean; Biome clean on changed source files; pre-commit typecheck + full build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vg7dju37Uo5CrZNDW5YxQT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vg7dju37Uo5CrZNDW5YxQT)_