### PR TITLE
feat(web): refine goals UI, run trigger labels, and sidebar add buttons

### DIFF
--- a/docs/concepts/goals.md
+++ b/docs/concepts/goals.md
@@ -22,14 +22,14 @@ Open **Progress** in the project menu (just under **Inbox**). Top to bottom it s
 - a **project progress summary** the Captain keeps current — a short blurb of what's done,
   what's in progress, and what's still to do. It opens collapsed (showing the Captain's
   headline points); expand it for the full narrative, which may link a few key tasks.
-- your **goals**, each as a panel with its progress, health, and a sparkline. Click a goal to
-  open its own page.
+- your **goals**, each as a panel showing its progress, health, and latest status. Click a
+  panel to open the goal's own page, where its full progress chart and history live.
 - the recent **goal heartbeat runs** for the project.
 
 ## Setting a goal
 
-From the **Progress** page choose **Create Goal** (or use **New goal** next to Progress in the
-menu). A goal has:
+From the **Progress** page choose **Create Goal** (or **New goal** in the page header). A goal
+has:
 
 - **Goal name** — the objective in a line (e.g. "Reach 100 active customers").
 - **Measurement** — the precise definition of *how you'll know the goal is achieved* (e.g.

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -83,7 +83,7 @@ const AGENT_BASE_COLUMNS = `m.id, m.team_id, m.display_name, m.created_at,
 	${NEXT_HEARTBEAT_AT_SQL} AS next_heartbeat_at,
 	${HAS_ACTIONABLE_WORK_SQL} AS has_actionable_work`;
 
-const HEARTBEAT_RUN_COLUMNS = `hr.id, hr.member_id, hr.team_id, hr.wakeup_id, hr.task_id,
+const HEARTBEAT_RUN_COLUMNS = `hr.id, hr.member_id, hr.team_id, hr.wakeup_id, hr.task_id, hr.kind,
 	hr.status, hr.queued_reason, hr.started_at, hr.finished_at, hr.exit_code, hr.error,
 	hr.input_tokens, hr.output_tokens, hr.cost_cents, hr.usage_partial,
 	hr.invocation_command, hr.log_text, hr.working_dir,

--- a/packages/server/src/services/goals.ts
+++ b/packages/server/src/services/goals.ts
@@ -327,6 +327,7 @@ export async function listGoalCheckRuns(
 	// fan-out, no GROUP BY.
 	const r = await db.query<GoalCheckRunSummary>(
 		`SELECT hr.id, hr.status, hr.created_at, hr.started_at, hr.finished_at,
+		        hr.member_id, ma.title AS agent_title, ma.slug AS agent_slug,
 		        COALESCE((
 		          SELECT json_agg(g.title ORDER BY g.title)
 		          FROM goal_run_updates gru
@@ -334,6 +335,7 @@ export async function listGoalCheckRuns(
 		          WHERE gru.run_id = hr.id
 		        ), '[]'::json) AS updated_goal_titles
 		 FROM heartbeat_runs hr
+		 JOIN member_agents ma ON ma.id = hr.member_id
 		 WHERE hr.kind = $1
 		   AND hr.task_id IS NULL
 		   AND hr.team_id = (SELECT team_id FROM projects WHERE id = $2)
@@ -358,6 +360,7 @@ export async function listGoalRunActivity(
 ): Promise<GoalRunActivity[]> {
 	const r = await db.query<GoalRunActivity>(
 		`SELECT hr.id, hr.status, hr.created_at, hr.started_at, hr.finished_at,
+		        hr.member_id, ma.slug AS agent_slug,
 		        (
 		          SELECT json_build_object(
 		                   'progress_percent', gru.progress_percent,
@@ -385,6 +388,7 @@ export async function listGoalRunActivity(
 		          ) ct
 		        ), '[]'::json) AS commented_tasks
 		 FROM heartbeat_runs hr
+		 JOIN member_agents ma ON ma.id = hr.member_id
 		 WHERE hr.kind = $1
 		   AND hr.task_id IS NULL
 		   AND hr.team_id = (SELECT team_id FROM projects WHERE id = $3)

--- a/packages/server/test/goals.test.ts
+++ b/packages/server/test/goals.test.ts
@@ -250,6 +250,9 @@ describe('goals service', () => {
 		const summary = runs.find((r) => r.id === runId);
 		expect(summary).toBeTruthy();
 		expect(summary?.updated_goal_titles).toContain('Track me');
+		// The run carries its Captain so the UI can link to the run in the agent's run list.
+		expect(summary?.member_id).toBe(captainMemberId);
+		expect(summary?.agent_slug).toBe('captain');
 	});
 
 	it('rejects a pending health on recordGoalProgress', async () => {

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -687,6 +687,10 @@ export interface GoalCheckRunSummary {
 	created_at: string;
 	started_at: string | null;
 	finished_at: string | null;
+	/** The Captain member that ran this goal-check, for linking to its run in the agent's run list. */
+	member_id: string;
+	agent_title: string;
+	agent_slug: string;
 	/** Titles of the goals this run updated (empty = ran but changed nothing). */
 	updated_goal_titles: string[];
 }
@@ -710,6 +714,9 @@ export interface GoalRunActivity {
 	created_at: string;
 	started_at: string | null;
 	finished_at: string | null;
+	/** The Captain member that ran this goal-check, for linking to its run in the agent's run list. */
+	member_id: string;
+	agent_slug: string;
 	/** The progress snapshot this run recorded for the goal, or null if it only created/commented. */
 	progress: { progress_percent: number; health: GoalHealth; status_blurb: string } | null;
 	/** Tasks this run created that are linked to the goal. */

--- a/packages/web/src/components/comment-renderers/run-comment.tsx
+++ b/packages/web/src/components/comment-renderers/run-comment.tsx
@@ -122,7 +122,7 @@ function RunRetryButton({
 	);
 }
 
-function RunCommentBody({
+export function RunCommentBody({
 	projectId,
 	runId,
 	agentId,
@@ -142,7 +142,9 @@ function RunCommentBody({
 	agentSlug: string;
 	actorName: string | null;
 	createdAt: string;
-	publicId: string;
+	/** Comment public id for the timestamp permalink. Absent for runs with no anchoring
+	 * comment (e.g. goal-check runs), which render a plain timestamp instead. */
+	publicId?: string;
 	taskId?: string;
 	retryableRunId?: string | null;
 	inline?: boolean;
@@ -236,11 +238,17 @@ function RunCommentBody({
 					)}
 				</span>
 			)}
-			<CommentTimestampLink
-				publicId={publicId}
-				createdAt={createdAt}
-				className="truncate min-w-0"
-			/>
+			{publicId ? (
+				<CommentTimestampLink
+					publicId={publicId}
+					createdAt={createdAt}
+					className="truncate min-w-0"
+				/>
+			) : (
+				<span className="text-[11px] text-text-3 truncate min-w-0">
+					{new Date(createdAt).toLocaleString()}
+				</span>
+			)}
 		</span>
 	);
 

--- a/packages/web/src/components/goal-detail/goal-detail-page.tsx
+++ b/packages/web/src/components/goal-detail/goal-detail-page.tsx
@@ -7,6 +7,7 @@ import { Link } from '@tanstack/react-router';
 import { Archive, ArchiveRestore, ChevronRight, Pencil } from 'lucide-react';
 import { useState } from 'react';
 import { useGoal, useGoalHistory, useGoalRunActivity, useUpdateGoal } from '../../hooks/use-goals';
+import { agentPageParams } from '../agent-link';
 import { CreateGoalDialog } from '../create-goal-dialog';
 import { GoalHealthPill } from '../goal-health-pill';
 import { GoalProgressChart } from '../goal-progress-chart';
@@ -57,16 +58,31 @@ function TaskChip({ projectId, identifier }: { projectId: string; identifier: st
 }
 
 function GoalRunRow({ projectId, run }: { projectId: string; run: GoalRunActivity }) {
+	// The whole row is a stretched link to this run in the Captain's run list. Task chips
+	// sit above the overlay (`relative z-10`) so they remain independently clickable.
+	const runLinkParams = { ...agentPageParams(projectId, run.agent_slug), runId: run.id };
 	return (
-		<li data-testid="goal-run" className="flex flex-col gap-1.5 px-3 py-2.5">
+		<li
+			data-testid="goal-run"
+			className="relative flex flex-col gap-1.5 px-3 py-2.5 transition-colors hover:bg-surface-2"
+		>
 			<div className="flex flex-wrap items-center gap-2">
-				<span className="text-[13px] text-text-2">{formatRunTime(run)}</span>
+				<Link
+					to="/projects/$projectId/agents/$agentId/executions/$runId"
+					params={runLinkParams}
+					data-testid="goal-run-open"
+					aria-label="Open run"
+					className="text-[13px] text-text-2 hover:underline before:absolute before:inset-0"
+				>
+					{formatRunTime(run)}
+				</Link>
 				{run.status !== HeartbeatRunStatus.Succeeded && (
 					<Badge color={RUN_STATUS_COLOR[run.status] ?? 'neutral'}>{run.status}</Badge>
 				)}
 				{run.progress && (
-					<span className="text-xs text-text-3">
-						{run.progress.progress_percent}% · {run.progress.health}
+					<span className="flex items-center gap-1.5 text-xs text-text-3">
+						<span>{run.progress.progress_percent}%</span>
+						<GoalHealthPill health={run.progress.health} />
 					</span>
 				)}
 			</div>
@@ -76,7 +92,7 @@ function GoalRunRow({ projectId, run }: { projectId: string; run: GoalRunActivit
 				</p>
 			)}
 			{run.created_tasks.length > 0 && (
-				<p className="text-xs text-text-3">
+				<p className="relative z-10 self-start text-xs text-text-3">
 					Created{' '}
 					{run.created_tasks.map((t, i) => (
 						<span key={t.id}>
@@ -87,7 +103,7 @@ function GoalRunRow({ projectId, run }: { projectId: string; run: GoalRunActivit
 				</p>
 			)}
 			{run.commented_tasks.length > 0 && (
-				<p className="text-xs text-text-3">
+				<p className="relative z-10 self-start text-xs text-text-3">
 					Commented on{' '}
 					{run.commented_tasks.map((t, i) => (
 						<span key={t.id}>

--- a/packages/web/src/components/goals-list.tsx
+++ b/packages/web/src/components/goals-list.tsx
@@ -1,17 +1,13 @@
-import {
-	GOAL_CHECK_FREQUENCY_LABELS,
-	type GoalCheckRunSummary,
-	type GoalWithProject,
-	HeartbeatRunStatus,
-} from '@hezo/shared';
+import { GOAL_CHECK_FREQUENCY_LABELS, type GoalWithProject } from '@hezo/shared';
 import { Link } from '@tanstack/react-router';
 import { Archive, ArchiveRestore, Pencil, Plus, Target } from 'lucide-react';
 import { useState } from 'react';
 import { useGoalRuns, useGoals, useUpdateGoal } from '../hooks/use-goals';
+import { RunCommentBody } from './comment-renderers/run-comment';
 import { CreateGoalDialog } from './create-goal-dialog';
 import { GoalHealthPill } from './goal-health-pill';
-import { GoalProgressChart } from './goal-progress-chart';
 import { GoalSmartGuidance } from './goal-smart-guidance';
+import { LazyMount } from './lazy-mount';
 import { ProjectProgressSummary } from './project-progress-summary';
 import { Button } from './ui/button';
 import { EmptyState } from './ui/empty-state';
@@ -29,18 +25,6 @@ function formatTargetDate(iso: string): string {
 	return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
 }
 
-function formatRunTime(run: GoalCheckRunSummary): string {
-	const iso = run.finished_at ?? run.started_at ?? run.created_at;
-	const d = new Date(iso);
-	if (Number.isNaN(d.getTime())) return iso;
-	return d.toLocaleString(undefined, {
-		month: 'short',
-		day: 'numeric',
-		hour: 'numeric',
-		minute: '2-digit',
-	});
-}
-
 function GoalPanel({
 	projectId,
 	goal,
@@ -54,10 +38,13 @@ function GoalPanel({
 	const isArchived = !!goal.archived_at;
 	const percent = Math.max(0, Math.min(100, Math.round(goal.progress_percent)));
 
+	// The whole card is a stretched link to the goal's detail page (its expanded view).
+	// `before:absolute before:inset-0` makes the card surface clickable; the edit/archive
+	// buttons sit above it (`relative z-10`) so they stay independently clickable.
 	return (
 		<div
 			data-testid="goal-panel"
-			className={`flex flex-col gap-3 rounded-md border border-border bg-surface p-4 ${
+			className={`relative flex flex-col gap-3 rounded-md border border-border bg-surface p-4 transition-colors hover:border-border-strong ${
 				isArchived ? 'opacity-70' : ''
 			}`}
 		>
@@ -66,14 +53,15 @@ function GoalPanel({
 					to="/projects/$projectId/goals/$goalId"
 					params={{ projectId, goalId: goal.id }}
 					data-testid="goal-open"
-					className="flex min-w-0 flex-col gap-1.5 group"
+					aria-label={`Open goal ${goal.title}`}
+					className="flex min-w-0 flex-col gap-1.5 before:absolute before:inset-0 before:rounded-md"
 				>
-					<h3 className="text-sm font-semibold text-text-1 break-words group-hover:underline">
+					<h3 className="text-sm font-semibold text-text-1 break-words hover:underline">
 						{goal.title}
 					</h3>
 					<GoalHealthPill health={goal.health} testId="goal-health-pill" />
 				</Link>
-				<div className="flex shrink-0 items-center gap-0.5">
+				<div className="relative z-10 flex shrink-0 items-center gap-0.5">
 					<button
 						type="button"
 						onClick={() => onEdit(goal)}
@@ -111,25 +99,14 @@ function GoalPanel({
 				</div>
 			</div>
 
-			<GoalProgressChart history={goal.history} size="compact" />
-
 			{goal.status_blurb && (
-				<p className="text-[13px] text-text-2 leading-relaxed break-words">{goal.status_blurb}</p>
-			)}
-
-			{goal.measurement && (
-				<p className="text-xs text-text-3 leading-relaxed break-words">
-					<span className="font-medium text-text-2">Achieved when:</span> {goal.measurement}
-				</p>
-			)}
-			{goal.actions && (
-				<p className="text-xs text-text-3 leading-relaxed break-words">
-					<span className="font-medium text-text-2">Actions:</span> {goal.actions}
+				<p className="text-[13px] text-text-2 leading-relaxed break-words line-clamp-3">
+					{goal.status_blurb}
 				</p>
 			)}
 
 			<div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-text-3">
-				<span>{GOAL_CHECK_FREQUENCY_LABELS[goal.check_frequency]}</span>
+				<span>Checked {GOAL_CHECK_FREQUENCY_LABELS[goal.check_frequency]}</span>
 				{goal.target_date && <span>Deadline: {formatTargetDate(goal.target_date)}</span>}
 				{isArchived && <span className="text-text-2">Archived</span>}
 			</div>
@@ -154,17 +131,26 @@ function GoalChecksFooter({ projectId }: { projectId: string }) {
 						<li
 							key={run.id}
 							data-testid="goal-check-run"
-							className="flex flex-col gap-0.5 px-3 py-2 sm:flex-row sm:items-center sm:justify-between sm:gap-3"
+							className="flex flex-col gap-1.5 px-3 py-2.5"
 						>
-							<span className="text-[13px] text-text-2">
-								{formatRunTime(run)}
-								{run.status !== HeartbeatRunStatus.Succeeded && (
-									<span className="ml-2 text-text-3">({run.status})</span>
-								)}
-							</span>
-							<span className="text-xs text-text-3 break-words">
-								{updated ? `Updated goals: ${run.updated_goal_titles.join(', ')}` : 'No changes'}
-							</span>
+							{/* Collapsible run card — the same summary/expand/log UI as an agent run on a task. */}
+							<LazyMount minHeight={32} testId="goal-check-run-lazy">
+								<RunCommentBody
+									projectId={projectId}
+									runId={run.id}
+									agentId={run.member_id}
+									agentTitle={run.agent_title}
+									agentSlug={run.agent_slug}
+									actorName={null}
+									createdAt={run.created_at}
+									inline
+								/>
+							</LazyMount>
+							{updated && (
+								<p className="text-xs text-text-3 break-words" data-testid="goal-check-run-goals">
+									Updated goals: {run.updated_goal_titles.join(', ')}
+								</p>
+							)}
 						</li>
 					);
 				})}

--- a/packages/web/src/components/project-sidebar.tsx
+++ b/packages/web/src/components/project-sidebar.tsx
@@ -9,7 +9,6 @@ import { useInboxUnreadCount } from '../hooks/use-inbox-count';
 import { useProjectMeta } from '../hooks/use-projects';
 import { agentPageParams } from './agent-link';
 import { AgentStatusLabel } from './agent-status-label';
-import { CreateGoalDialog } from './create-goal-dialog';
 import { CreateTaskDialog } from './create-task-dialog';
 import { SidebarNav, type SidebarNavSection } from './sidebar-nav';
 import { Tooltip } from './ui/tooltip';
@@ -40,7 +39,6 @@ export function ProjectSidebar() {
 	const { data: agents } = useAgents(projectId);
 	const [teamCollapsed, setTeamCollapsed] = useState(readTeamCollapsed);
 	const [createTaskOpen, setCreateTaskOpen] = useState(false);
-	const [createGoalOpen, setCreateGoalOpen] = useState(false);
 	// Goals are a project concept only (HQ has none). Use the open_goal_count carried on the
 	// project-detail payload rather than a separate per-page goals fetch — the dot shows only
 	// once the project has loaded and reports zero active goals.
@@ -130,11 +128,6 @@ export function ProjectSidebar() {
 			</span>
 		),
 		testId: 'project-sidebar-progress',
-		action: {
-			onClick: () => setCreateGoalOpen(true),
-			label: 'New goal',
-			testId: 'project-sidebar-new-goal',
-		},
 	};
 
 	const projectPages = [
@@ -284,11 +277,6 @@ export function ProjectSidebar() {
 				projectId={projectId}
 				open={createTaskOpen}
 				onOpenChange={setCreateTaskOpen}
-			/>
-			<CreateGoalDialog
-				projectId={projectId}
-				open={createGoalOpen}
-				onOpenChange={setCreateGoalOpen}
 			/>
 		</div>
 	);

--- a/packages/web/src/components/sidebar-nav.tsx
+++ b/packages/web/src/components/sidebar-nav.tsx
@@ -21,6 +21,11 @@ interface SidebarNavItem {
 	action?: SidebarNavItemAction;
 }
 
+// A small bordered "+" chip, used both as an inline suffix to a row label (Tasks)
+// and a section title (Team). Round border with padding so it reads as a button.
+const ADD_CHIP_CLASSES =
+	'inline-flex shrink-0 items-center rounded-md border border-border p-0.5 text-text-3 transition-colors hover:border-border-strong hover:bg-surface-2 hover:text-text-1 cursor-pointer';
+
 function ItemAction({ action }: { action: SidebarNavItemAction }) {
 	return (
 		<Tooltip content={action.label} side="right">
@@ -33,9 +38,9 @@ function ItemAction({ action }: { action: SidebarNavItemAction }) {
 				}}
 				data-testid={action.testId}
 				aria-label={action.label}
-				className="mr-1 shrink-0 rounded-sm p-0.5 text-text-3 transition-colors hover:bg-surface-2 hover:text-text-1 cursor-pointer"
+				className={`ml-2 ${ADD_CHIP_CLASSES}`}
 			>
-				<Plus className="w-3.5 h-3.5" />
+				<Plus className="w-3 h-3" />
 			</button>
 		</Tooltip>
 	);
@@ -127,8 +132,6 @@ export function SidebarNav({ sections }: SidebarNavProps) {
 									params={item.params ?? {}}
 									data-testid={item.testId}
 									className={`flex items-center text-left text-[12px] ${paddingClass} rounded-md transition-colors ${
-										item.action ? 'flex-1 min-w-0' : ''
-									} ${
 										isActive
 											? 'text-text-1 font-medium bg-surface-2'
 											: 'text-text-2 hover:text-text-1 hover:bg-surface-2'
@@ -139,14 +142,32 @@ export function SidebarNav({ sections }: SidebarNavProps) {
 								</Link>
 							);
 							// Plain items render exactly as before (no wrapper). An item with an
-							// inline action sits beside its "+" on one row; items with sub-items
-							// wrap so the disclosure can sit beneath the parent.
+							// inline action puts its bordered "+" right after the label (the count,
+							// if any, stays pinned to the far right); items with sub-items wrap so
+							// the disclosure can sit beneath the parent.
 							if (!item.subItems?.length) {
 								if (item.action) {
 									return (
-										<div key={key} className="flex items-center">
-											{link}
+										<div
+											key={key}
+											className={`group flex items-center text-[12px] ${paddingClass} rounded-md transition-colors ${
+												isActive ? 'bg-surface-2' : 'hover:bg-surface-2'
+											}`}
+										>
+											<Link
+												to={item.to}
+												params={item.params ?? {}}
+												data-testid={item.testId}
+												className={`text-left transition-colors ${
+													isActive
+														? 'text-text-1 font-medium'
+														: 'text-text-2 group-hover:text-text-1'
+												}`}
+											>
+												{item.label}
+											</Link>
 											<ItemAction action={item.action} />
+											<CountBadge value={item.count} />
 										</div>
 									);
 								}
@@ -211,19 +232,21 @@ function SectionHeader({ section }: { section: SidebarNavSection }) {
 			<button
 				type="button"
 				onClick={section.onAdd}
-				className="text-text-3 hover:text-text-1 transition-colors p-0.5 -m-0.5 cursor-pointer shrink-0"
+				className={`ml-2 ${ADD_CHIP_CLASSES}`}
 				aria-label={section.addLabel ?? 'Add'}
 			>
-				<Plus className="w-3.5 h-3.5" />
+				<Plus className="w-3 h-3" />
 			</button>
 		</Tooltip>
 	);
 
+	// Title hugs its text so the "+" can sit right after it as a suffix; the
+	// collapse chevron is pinned to the far right.
 	const titleNode = section.titleTo ? (
 		<Link
 			to={section.titleTo}
 			params={section.titleParams ?? {}}
-			className={`${TITLE_TEXT_CLASSES} flex-1 text-left hover:text-text-1 transition-colors`}
+			className={`${TITLE_TEXT_CLASSES} text-left hover:text-text-1 transition-colors`}
 		>
 			{section.title}
 		</Link>
@@ -231,13 +254,13 @@ function SectionHeader({ section }: { section: SidebarNavSection }) {
 		<button
 			type="button"
 			onClick={section.onToggle}
-			className={`${TITLE_TEXT_CLASSES} flex items-center justify-between flex-1 text-left hover:text-text-1 transition-colors cursor-pointer gap-2`}
+			className={`${TITLE_TEXT_CLASSES} flex items-center text-left hover:text-text-1 transition-colors cursor-pointer gap-2`}
 		>
 			<span>{section.title}</span>
 			{chevron}
 		</button>
 	) : (
-		<span className={`${TITLE_TEXT_CLASSES} flex-1`}>{section.title}</span>
+		<span className={TITLE_TEXT_CLASSES}>{section.title}</span>
 	);
 
 	const trailingChevron = section.titleTo && section.collapsible && (
@@ -252,14 +275,10 @@ function SectionHeader({ section }: { section: SidebarNavSection }) {
 	);
 
 	return (
-		<div className="flex items-center justify-between px-2.5 pt-2.5 pb-0.5 gap-2">
+		<div className="flex items-center px-2.5 pt-2.5 pb-0.5">
 			{titleNode}
-			{(addButton || trailingChevron) && (
-				<div className="flex items-center gap-1.5">
-					{addButton}
-					{trailingChevron}
-				</div>
-			)}
+			{addButton}
+			{trailingChevron && <div className="ml-auto flex items-center">{trailingChevron}</div>}
 		</div>
 	);
 }

--- a/packages/web/src/hooks/use-heartbeat-runs.ts
+++ b/packages/web/src/hooks/use-heartbeat-runs.ts
@@ -1,4 +1,4 @@
-import type { WakeupSource } from '@hezo/shared';
+import type { HeartbeatRunKind, WakeupSource } from '@hezo/shared';
 import { useQuery } from '@tanstack/react-query';
 import { api } from '../lib/api';
 import { queryKeys } from '../lib/query-keys';
@@ -9,6 +9,7 @@ export interface HeartbeatRun {
 	team_id: string;
 	wakeup_id: string | null;
 	task_id: string | null;
+	kind: HeartbeatRunKind;
 	task_identifier: string | null;
 	task_title: string | null;
 	project_id: string | null;

--- a/packages/web/src/lib/run-trigger.ts
+++ b/packages/web/src/lib/run-trigger.ts
@@ -1,4 +1,4 @@
-import { WakeupSource } from '@hezo/shared';
+import { HeartbeatRunKind, WakeupSource } from '@hezo/shared';
 import type { HeartbeatRun } from '../hooks/use-heartbeat-runs';
 
 export interface TriggerLabel {
@@ -32,6 +32,12 @@ export function formatTriggerReason(run: HeartbeatRun, teamSlug: string): Trigge
 	const source = run.trigger_source;
 	const taskId = run.trigger_comment_task_identifier ?? run.task_identifier;
 	const actor = run.trigger_actor_slug;
+
+	// Goal-check runs are the Captain's periodic progress assessment. They have no task and
+	// reuse the heartbeat wakeup, so describe them by what the run does, not the raw source.
+	if (run.kind === HeartbeatRunKind.GoalCheck) {
+		return { source, text: 'Automation: goals and progress report' };
+	}
 
 	switch (source) {
 		case WakeupSource.Mention: {

--- a/packages/web/test/agent-executions-list.test.tsx
+++ b/packages/web/test/agent-executions-list.test.tsx
@@ -27,6 +27,7 @@ function makeRun(overrides: Partial<HeartbeatRun>): HeartbeatRun {
 		team_id: 't-1',
 		wakeup_id: null,
 		task_id: 'task-1',
+		kind: 'task',
 		task_identifier: 'DEMO-1',
 		task_title: 'Do the thing',
 		project_id: 'p-1',

--- a/packages/web/test/goals.test.tsx
+++ b/packages/web/test/goals.test.tsx
@@ -1,6 +1,12 @@
 import { expect, test } from 'vitest';
 import { renderApp } from './helpers/render';
-import { seedGoal, seedProject, seedProjectProgress, seedWorkspace } from './helpers/seed';
+import {
+	seedGoal,
+	seedGoalCheckRun,
+	seedProject,
+	seedProjectProgress,
+	seedWorkspace,
+} from './helpers/seed';
 
 // Component-tier proof for the Progress (goals) page: seed a team + project (no goals),
 // navigate to the goals route, and assert the empty-state hero renders with its
@@ -51,6 +57,67 @@ test('Progress page renders the Captain progress summary above the goals', async
 	// The bold lead key point renders from markdown, and the goal panel shows below.
 	await findByText('Auth shipped.');
 	await findByText('Reach 100 customers');
+});
+
+test('the goal detail run feed renders the health as a coloured pill and links to the run', async () => {
+	let projectSlug = '';
+	let goalId = '';
+	const { findByTestId, getByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Run Feed Demo' });
+			projectSlug = project.slug;
+			const goal = await seedGoal(ws, project, {
+				title: 'Reach launch',
+				measurement: 'launched',
+			});
+			goalId = goal.id;
+			await seedGoalCheckRun(ws, {
+				goal,
+				progressPercent: 40,
+				health: 'on_track',
+				statusBlurb: 'Tracking nicely',
+			});
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/goals/$goalId',
+		params: { projectId: projectSlug, goalId },
+	});
+
+	// The run row renders the health as the same pill used in goal meta ("On track"),
+	// not the raw enum, and links to the run in the Captain's run list.
+	await findByTestId('goal-run', undefined, { timeout: 10_000 });
+	const open = getByTestId('goal-run-open') as HTMLAnchorElement;
+	expect(open.getAttribute('href')).toMatch(/\/agents\/captain\/executions\//);
+	expect(getByTestId('goal-run').textContent).toContain('On track');
+	expect(getByTestId('goal-run').textContent).not.toContain('on_track');
+});
+
+test('the Progress page goal-check footer renders runs as collapsible run cards', async () => {
+	let projectSlug = '';
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Footer Demo' });
+			projectSlug = project.slug;
+			const goal = await seedGoal(ws, project, { title: 'Ship beta', measurement: 'beta live' });
+			await seedGoalCheckRun(ws, { goal, statusBlurb: 'Going well' });
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/goals',
+		params: { projectId: projectSlug },
+	});
+
+	// Each goal-check run renders the same collapsible run card used for agent runs on a
+	// task — its summary header (with the expand toggle) is the tell.
+	await findByTestId('goal-check-run', undefined, { timeout: 10_000 });
+	await findByTestId('run-comment-header', undefined, { timeout: 10_000 });
 });
 
 test('the Goals header help button opens the SMART guidance modal', async () => {

--- a/packages/web/test/helpers/seed.ts
+++ b/packages/web/test/helpers/seed.ts
@@ -256,3 +256,47 @@ export async function seedRunningAgent(
 
 	return { runId, lockId, commentId };
 }
+
+/**
+ * Seed a completed Captain goal-check run (the heartbeat run with no task, kind
+ * 'goal_check') and, when a goal is given, the progress snapshot it recorded. Mirrors
+ * what `tryDispatchGoalCheck` + `recordGoalProgress` produce, so the Progress page and
+ * goal detail run feed render against real rows.
+ */
+export async function seedGoalCheckRun(
+	workspace: SeededWorkspace,
+	opts: {
+		goal?: SeededGoal;
+		progressPercent?: number;
+		health?: string;
+		statusBlurb?: string;
+	} = {},
+): Promise<{ runId: string }> {
+	const { db } = getTestContext();
+	const captain = workspace.agents.find((a) => a.slug === 'captain');
+	if (!captain) throw new Error('seedGoalCheckRun: captain agent missing');
+
+	const runRes = await db.query<{ id: string }>(
+		`INSERT INTO heartbeat_runs (member_id, team_id, status, kind, started_at, finished_at)
+		 VALUES ($1, $2, 'succeeded'::heartbeat_run_status, 'goal_check'::heartbeat_run_kind, now(), now())
+		 RETURNING id`,
+		[captain.id, workspace.team.id],
+	);
+	const runId = runRes.rows[0].id;
+
+	if (opts.goal) {
+		await db.query(
+			`INSERT INTO goal_run_updates (run_id, goal_id, progress_percent, health, status_blurb)
+			 VALUES ($1, $2, $3, $4::goal_health, $5)`,
+			[
+				runId,
+				opts.goal.id,
+				opts.progressPercent ?? 25,
+				opts.health ?? 'on_track',
+				opts.statusBlurb ?? '',
+			],
+		);
+	}
+
+	return { runId };
+}

--- a/packages/web/test/run-trigger.test.ts
+++ b/packages/web/test/run-trigger.test.ts
@@ -1,4 +1,4 @@
-import { WakeupSource } from '@hezo/shared';
+import { HeartbeatRunKind, WakeupSource } from '@hezo/shared';
 import { expect, test } from 'vitest';
 import type { HeartbeatRun } from '../src/hooks/use-heartbeat-runs';
 import { formatTriggerReason } from '../src/lib/run-trigger';
@@ -14,6 +14,7 @@ function run(overrides: Partial<HeartbeatRun>): HeartbeatRun {
 		team_id: 't-1',
 		wakeup_id: null,
 		task_id: 'task-1',
+		kind: HeartbeatRunKind.Task,
 		task_identifier: 'ACME-7',
 		task_title: 'Do the thing',
 		project_id: 'p-1',
@@ -173,6 +174,14 @@ test('automation falls back to the reason field, then to bare label', () => {
 		TEAM,
 	);
 	expect(nonString.text).toBe('Automation');
+});
+
+test('a goal-check run is labelled as the goals-and-progress automation regardless of source', () => {
+	const label = formatTriggerReason(
+		run({ kind: HeartbeatRunKind.GoalCheck, trigger_source: WakeupSource.Automation }),
+		TEAM,
+	);
+	expect(label.text).toBe('Automation: goals and progress report');
 });
 
 test('heartbeat is a fixed label', () => {


### PR DESCRIPTION
## Summary

A batch of Progress/Goals UI refinements plus a clearer run trigger label and tidier sidebar add buttons.

### Run trigger reason
- Goal-check runs now read **"Triggered by: Automation: goals and progress report"** in the run detail, instead of a bare "Automation". This is driven by the run's `goal_check` kind (exposed via `hr.kind` on the heartbeat-run query and `HeartbeatRun.kind`), so it's accurate regardless of which wakeup drove the run.

### Progress page (goals list)
- The **Goal heartbeat runs** footer now renders each run as the same collapsible run card used for agent runs on a task — collapsed with a result summary once done, expandable to live logs (reuses `RunCommentBody`, made reusable with an optional `publicId`). `GoalCheckRunSummary` now carries `member_id`/`agent_title`/`agent_slug`.
- **Goal cards**: removed the lone-dot sparkline and excess space, dropped the "Achieved when"/"Actions" lines, clamp the progress blurb to 3 lines, and made the whole card a stretched link to the goal page (its expanded view). Cards now show `Checked <frequency>` and a `Deadline: …` when set.

### Goal detail page
- Each run in the per-goal **Goal heartbeat runs** feed links to that run in the Captain's run list, and renders health as the coloured `GoalHealthPill` ("On track") instead of the raw `on_track` enum. `GoalRunActivity` now carries `member_id`/`agent_slug`.

### Sidebar
- Removed the `+` next to **Progress** (create a goal from the Progress page header instead).
- The **Tasks** and **Team** `+` buttons are now a bordered chip rendered as a suffix to the label (with spacing), with the count/collapse chevron pinned to the far right.

### Docs & tests
- Updated `docs/concepts/goals.md` to match the new goal-card layout and the removed sidebar `+`.
- Added a `seedGoalCheckRun` web test helper and component tests for the goal-detail run feed (health pill + run link) and the Progress-page run-card footer; updated `run-trigger` and heartbeat-run fixtures for the new `kind` field; extended the server `listGoalCheckRuns` test.

## Test plan
- `bunx turbo typecheck` — green
- `packages/web`: `run-trigger`, `goals`, `agent-executions-list`, `agent-executions-project`, `run-usage-partial`, `run-created-tasks`, `task-comments`, `project-sidebar`, `sidebar-nav-branches` — all pass
- `packages/server`: `goals`, `mcp-goals`, `goal-check-run` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XorbbcdEVZ9a8ujiysdubx)_