### PR TITLE
fix(web): clear the Progress "no goals yet" dot once a project has a goal

### DIFF
--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -109,6 +109,7 @@ projectsRoutes.get('/projects', async (c) => {
        (SELECT count(*) FROM members m WHERE m.team_id = p.team_id AND m.member_type = $${agentTypeIdx})::int AS agent_count,
        (SELECT count(*) FROM repos r WHERE r.project_id = p.id)::int AS repo_count,
        (SELECT count(*) FROM tasks i WHERE i.project_id = p.id AND i.status NOT IN (${ts.placeholders}))::int AS open_task_count,
+       (SELECT count(*) FROM goals g WHERE g.project_id = p.id AND g.archived_at IS NULL)::int AS open_goal_count,
        (SELECT count(*) FROM member_agents ma JOIN members mm ON mm.id = ma.id
           WHERE mm.team_id = p.team_id AND ma.runtime_status = 'active'::agent_runtime_status)::int
           AS running_agents_count,

--- a/packages/server/test/goals.test.ts
+++ b/packages/server/test/goals.test.ts
@@ -121,6 +121,13 @@ describe('goals REST CRUD', () => {
 		expect((await res.json()).data.open_goal_count).toBe(1);
 	});
 
+	it('exposes the active goal count on the project index (drives the sidebar dot)', async () => {
+		const res = await app.request('/api/projects', { headers: authHeader(token) });
+		expect(res.status).toBe(200);
+		const project = (await res.json()).data.find((p: { slug: string }) => p.slug === projectSlug);
+		expect(project.open_goal_count).toBe(1);
+	});
+
 	it('archives a goal and hides it from the default list', async () => {
 		const del = await app.request(`/api/projects/${projectSlug}/goals/${goalId}`, {
 			method: 'DELETE',

--- a/packages/web/src/components/project-sidebar.tsx
+++ b/packages/web/src/components/project-sidebar.tsx
@@ -42,8 +42,8 @@ export function ProjectSidebar() {
 	const [createTaskOpen, setCreateTaskOpen] = useState(false);
 	const [createGoalOpen, setCreateGoalOpen] = useState(false);
 	// Goals are a project concept only (HQ has none). Use the open_goal_count carried on the
-	// project-detail payload rather than a separate per-page goals fetch — the dot shows only
-	// once the project has loaded and reports zero active goals.
+	// project index payload (the same source as open_task_count) rather than a separate per-page
+	// goals fetch — the dot shows only once the project has loaded and reports zero active goals.
 	const isInternalProject = project?.is_internal ?? false;
 	const hasNoGoals = !isInternalProject && project != null && (project.open_goal_count ?? 0) === 0;
 

--- a/packages/web/src/hooks/use-goals.ts
+++ b/packages/web/src/hooks/use-goals.ts
@@ -81,6 +81,10 @@ export function useCreateGoal(projectId: string) {
 			api.post<GoalWithProject>(`/api/projects/${projectId}/goals`, data),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: queryKeys.projects.goals(projectId) });
+			// open_goal_count (which drives the sidebar "no goals yet" dot) is carried on both the
+			// project index and the detail payload — refresh both so the dot clears at once.
+			queryClient.invalidateQueries({ queryKey: queryKeys.projects.detail(projectId) });
+			queryClient.invalidateQueries({ queryKey: queryKeys.projects.all() });
 		},
 	});
 }
@@ -118,6 +122,10 @@ export function useArchiveGoal(projectId: string) {
 			api.delete<GoalWithProject>(`/api/projects/${projectId}/goals/${goalId}`),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: queryKeys.projects.goals(projectId) });
+			// Archiving the last goal must bring the sidebar "no goals yet" dot back — refresh the
+			// project index and detail, which both carry open_goal_count.
+			queryClient.invalidateQueries({ queryKey: queryKeys.projects.detail(projectId) });
+			queryClient.invalidateQueries({ queryKey: queryKeys.projects.all() });
 		},
 	});
 }

--- a/packages/web/src/hooks/use-projects.ts
+++ b/packages/web/src/hooks/use-projects.ts
@@ -29,8 +29,9 @@ export interface Project {
 	dev_ports: Array<{ container: number; host: number }>;
 	repo_count: number;
 	open_task_count: number;
-	/** Active (non-archived) goals on this project; drives the sidebar "no goals yet" dot. Only
-	 * present on the single-project detail payload, so optional. */
+	/** Active (non-archived) goals on this project; drives the sidebar "no goals yet" dot.
+	 * Carried on both the project index and the single-project detail payload. Optional because
+	 * older/partial payloads may omit it. */
 	open_goal_count?: number;
 	/** Total Agent members on this project's team (the hired roster size). */
 	agent_count: number;

--- a/packages/web/test/project-sidebar.test.tsx
+++ b/packages/web/test/project-sidebar.test.tsx
@@ -1,7 +1,7 @@
 import { waitFor, within } from '@testing-library/react';
 import { expect, test } from 'vitest';
 import { getTestContext, renderApp } from './helpers/render';
-import { type SeededWorkspace, seedProject, seedWorkspace } from './helpers/seed';
+import { type SeededWorkspace, seedGoal, seedProject, seedWorkspace } from './helpers/seed';
 
 function getNav(container: HTMLElement): HTMLElement {
 	const nav = container.querySelector('nav[aria-label="Sidebar"]');
@@ -230,6 +230,79 @@ test("the project menu persists across the project's team pages and disappears o
 	await waitFor(() =>
 		expect(container.querySelector('[data-testid="project-sidebar-name"]')).toBeNull(),
 	);
+});
+
+test('the Progress nav item shows the "no goals yet" dot only until the project has a goal', async () => {
+	// Two projects need two workspaces — a team backs exactly one project (1:1).
+	let emptySlug = '';
+	let withGoalSlug = '';
+	const { findByTestId, queryByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const emptyWs = await seedWorkspace();
+			const empty = await seedProject(emptyWs, { name: 'No Goals Yet' });
+			emptySlug = empty.slug;
+
+			const goalWs = await seedWorkspace();
+			const withGoal = await seedProject(goalWs, { name: 'Has A Goal' });
+			withGoalSlug = withGoal.slug;
+			await seedGoal(goalWs, withGoal, { title: 'Ship the beta', measurement: 'beta is live' });
+		},
+	});
+
+	// A project with no goals surfaces the prompting dot.
+	await router.navigate({
+		to: '/projects/$projectId/tasks',
+		params: { projectId: emptySlug },
+	});
+	await findByTestId('project-sidebar-goals-empty-dot', undefined, { timeout: 15_000 });
+
+	// A project that already has a goal must NOT show it — open_goal_count flows from the
+	// project index, so the dot clears for projects with goals (regression: it always showed).
+	await router.navigate({
+		to: '/projects/$projectId/tasks',
+		params: { projectId: withGoalSlug },
+	});
+	await findByTestId('project-sidebar-name', undefined, { timeout: 15_000 });
+	await waitFor(() => expect(queryByTestId('project-sidebar-goals-empty-dot')).toBeNull(), {
+		timeout: 15_000,
+	});
+});
+
+test('creating a goal from the sidebar clears the "no goals yet" dot', async () => {
+	let ws!: SeededWorkspace;
+	let projectSlug = '';
+	const { findByTestId, queryByTestId, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Goal Creation' });
+			projectSlug = project.slug;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks',
+		params: { projectId: projectSlug },
+	});
+	// The dot is present while the project has no goals.
+	await findByTestId('project-sidebar-goals-empty-dot', undefined, { timeout: 15_000 });
+
+	// Open the sidebar "New goal" action and create a goal.
+	await user.click(await findByTestId('project-sidebar-new-goal', undefined, { timeout: 15_000 }));
+	// The dialog renders into a portal on document.body; the name field has an explicit id.
+	const nameInput = await waitFor(() => {
+		const el = document.body.querySelector<HTMLInputElement>('#goal-name');
+		if (!el) throw new Error('goal-name input not mounted');
+		return el;
+	});
+	await user.type(nameInput, 'Reach 100 customers');
+	await user.click(within(document.body).getByRole('button', { name: 'Create' }));
+
+	// Creating a goal invalidates the project index, so the dot clears without a manual refresh.
+	await waitFor(() => expect(queryByTestId('project-sidebar-goals-empty-dot')).toBeNull(), {
+		timeout: 15_000,
+	});
 });
 
 test('the Container nav item shows a provisioning spinner while the container is creating', async () => {


### PR DESCRIPTION
## Problem

The **Progress** sidebar item kept showing its blue "no goals yet" notification dot even after the user had viewed the Progress page and created a goal.

## Root cause

The dot is driven by `hasNoGoals = !isInternal && project != null && (project.open_goal_count ?? 0) === 0` in `project-sidebar.tsx`. The sidebar reads `project` from `useProjectMeta` — which is sourced from the **project index** (`GET /api/projects`), the same place it reads `open_task_count` for the Tasks count.

But `open_goal_count` was only computed on the single-project **detail** route (`GET /api/projects/:id`), *not* on the index. So in the sidebar `project.open_goal_count` was always `undefined`, making `(undefined ?? 0) === 0` perpetually true. The dot showed for every non-internal project and never cleared — regardless of how many goals existed.

A secondary gap: creating/archiving a goal only invalidated the goals query, never the project index/detail, so even a correct count wouldn't have refreshed without a manual reload.

## Changes

- **`packages/server/src/routes/projects.ts`** — add `open_goal_count` to the project index query, parallel to the existing `open_task_count` subquery, so the index payload the sidebar reads actually carries it.
- **`packages/web/src/hooks/use-goals.ts`** — invalidate the project index (`projects.all()`) and detail on goal create/archive, so the dot clears the instant a goal is added and returns when the last one is archived.
- **`packages/web/src/hooks/use-projects.ts` / `project-sidebar.tsx`** — update the now-stale comments noting `open_goal_count` is carried on the index too.

## Tests

- **Server** (`packages/server/test/goals.test.ts`): the `/api/projects` index exposes `open_goal_count`.
- **Web** (`packages/web/test/project-sidebar.test.tsx`):
  - the dot shows for a project with no goals and is absent for a project that has one (the reported regression);
  - creating a goal from the sidebar "New goal" action clears the dot live, exercising the invalidation path.

All affected tiers pass (`goals.test.ts`, `project-sidebar.test.tsx`, `goals.test.tsx`), plus repo-wide `typecheck` and lint on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GcV6Bko9ev3v4tjt3D7nen)_