### PR TITLE
fix(web): make the running-agent trash a terminate button

### DIFF
--- a/packages/server/src/routes/execution-locks.ts
+++ b/packages/server/src/routes/execution-locks.ts
@@ -15,7 +15,15 @@ executionLocksRoutes.get('/projects/:projectId/tasks/:taskId/lock', async (c) =>
 
 	const result = await db.query(
 		`SELECT el.id, el.task_id, el.member_id, el.lock_type, el.locked_at,
-		        COALESCE(ma.title, m.display_name) AS member_name
+		        COALESCE(ma.title, m.display_name) AS member_name,
+		        (
+		          SELECT hr.id FROM heartbeat_runs hr
+		          WHERE hr.task_id = el.task_id
+		            AND hr.member_id = el.member_id
+		            AND hr.status = 'running'
+		          ORDER BY hr.started_at DESC NULLS LAST, hr.created_at DESC
+		          LIMIT 1
+		        ) AS run_id
 		 FROM execution_locks el
 		 JOIN members m ON m.id = el.member_id
 		 LEFT JOIN member_agents ma ON ma.id = el.member_id

--- a/packages/server/test/execution-locks.test.ts
+++ b/packages/server/test/execution-locks.test.ts
@@ -138,4 +138,56 @@ describe('execution locks', () => {
 			headers: authHeader(token),
 		});
 	});
+
+	it("surfaces the agent's active run id on the lock (and null without one)", async () => {
+		// Acquire a lock with no running run — run_id is null.
+		await app.request(`/api/projects/${projectSlug}/tasks/${taskId}/lock`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ member_id: agentId }),
+		});
+
+		let res = await app.request(`/api/projects/${projectSlug}/tasks/${taskId}/lock`, {
+			headers: authHeader(token),
+		});
+		let lock = (await res.json()).data.locks.find(
+			(l: { member_id: string }) => l.member_id === agentId,
+		);
+		expect(lock.run_id).toBeNull();
+
+		// A running heartbeat run for this member+task now surfaces on the lock.
+		const runRes = await db.query<{ id: string }>(
+			`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at)
+			 VALUES ($1, $2, $3, 'running'::heartbeat_run_status, now())
+			 RETURNING id`,
+			[agentId, teamId, taskId],
+		);
+		const runId = runRes.rows[0].id;
+
+		res = await app.request(`/api/projects/${projectSlug}/tasks/${taskId}/lock`, {
+			headers: authHeader(token),
+		});
+		lock = (await res.json()).data.locks.find(
+			(l: { member_id: string }) => l.member_id === agentId,
+		);
+		expect(lock.run_id).toBe(runId);
+
+		// A finished run no longer counts as the active run.
+		await db.query(
+			`UPDATE heartbeat_runs SET status = 'cancelled'::heartbeat_run_status WHERE id = $1`,
+			[runId],
+		);
+		res = await app.request(`/api/projects/${projectSlug}/tasks/${taskId}/lock`, {
+			headers: authHeader(token),
+		});
+		lock = (await res.json()).data.locks.find(
+			(l: { member_id: string }) => l.member_id === agentId,
+		);
+		expect(lock.run_id).toBeNull();
+
+		await app.request(`/api/projects/${projectSlug}/tasks/${taskId}/lock`, {
+			method: 'DELETE',
+			headers: authHeader(token),
+		});
+	});
 });

--- a/packages/web/src/components/task-detail/agent-queue-section.tsx
+++ b/packages/web/src/components/task-detail/agent-queue-section.tsx
@@ -113,13 +113,15 @@ function RunningAgentRow({
 	run: { runId: string; commentId: string } | undefined;
 }) {
 	const [open, setOpen] = useState(false);
-	// Reuse the run page's terminate flow verbatim. runId is empty when no run
-	// comment has landed yet — the terminate control isn't rendered in that case,
-	// so the mutation can never fire with it.
+	// Reuse the run page's terminate flow verbatim. The active run id comes from
+	// the lock (populated the moment the run is `running`) and falls back to the
+	// run comment; the terminate control isn't rendered while it's empty, so the
+	// mutation can never fire without it.
+	const runId = lock.run_id ?? run?.runId ?? '';
 	const terminateMutation = useTerminateRun({
 		projectId,
 		agentId: lock.member_id,
-		runId: run?.runId ?? '',
+		runId,
 		taskId,
 	});
 
@@ -166,7 +168,7 @@ function RunningAgentRow({
 				) : (
 					<Loader2 className="w-3.5 h-3.5 animate-spin text-info" aria-label="Running" />
 				)}
-				{run && (
+				{runId && (
 					<Tooltip content="Terminate run">
 						<button
 							type="button"
@@ -181,7 +183,7 @@ function RunningAgentRow({
 					</Tooltip>
 				)}
 			</div>
-			{run && (
+			{runId && (
 				<ConfirmDialog
 					open={open}
 					onOpenChange={setOpen}

--- a/packages/web/src/hooks/use-execution-locks.ts
+++ b/packages/web/src/hooks/use-execution-locks.ts
@@ -8,6 +8,11 @@ export interface ExecutionLock {
 	member_id: string;
 	member_name: string;
 	locked_at: string;
+	/** Id of the agent's active (`running`) heartbeat run on this task, when one
+	 * exists. Lets the UI offer "terminate" the moment the agent is running,
+	 * before its run comment has landed. Null between lock acquisition and the
+	 * run flipping to `running`. */
+	run_id?: string | null;
 }
 
 export interface ExecutionLockState {

--- a/packages/web/test/agent-queue.test.tsx
+++ b/packages/web/test/agent-queue.test.tsx
@@ -89,6 +89,64 @@ test('terminates the running run via the confirm dialog', async () => {
 	);
 });
 
+test('terminates a running agent even before its run comment lands', async () => {
+	// The lock surfaces the active run id, so the terminate control is available
+	// the moment the agent is `running` — without waiting for the run comment.
+	const seeded = { projectSlug: '', taskId: '', agentId: '', runId: '' };
+	const { findByTestId, findByText, getByTestId, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async (ctx) => {
+			const ws = await seedWorkspace();
+			const captain = ws.agents.find((a) => a.slug === 'captain') ?? ws.agents[0];
+			const agent = ws.agents.find((a) => a.id !== captain.id) ?? ws.agents[0];
+			const project = await seedProject(ws, { name: 'No Comment Demo' });
+			const task = await seedTask(ws, project, {
+				title: 'No Comment Task',
+				assignee_id: captain.id,
+			});
+			// Seed a running heartbeat run + lock, but deliberately NO run comment.
+			const runRes = await ctx.db.query<{ id: string }>(
+				`INSERT INTO heartbeat_runs (member_id, team_id, task_id, status, started_at)
+				 VALUES ($1, $2, $3, 'running'::heartbeat_run_status, now())
+				 RETURNING id`,
+				[agent.id, ws.team.id, task.id],
+			);
+			await ctx.db.query(
+				`INSERT INTO execution_locks (task_id, member_id, lock_type) VALUES ($1, $2, 'read')`,
+				[task.id, agent.id],
+			);
+			seeded.projectSlug = project.slug;
+			seeded.taskId = task.identifier.toLowerCase();
+			seeded.agentId = agent.id;
+			seeded.runId = runRes.rows[0].id;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
+	});
+
+	const terminate = await findByTestId(`terminate-running-agent-${seeded.agentId}`, undefined, {
+		timeout: 15_000,
+	});
+	await user.click(terminate);
+
+	await findByText('Terminate this run?');
+	await user.click(getByTestId('confirm-dialog-confirm'));
+
+	await waitFor(
+		async () => {
+			const r = await getTestContext().db.query<{ status: string }>(
+				'SELECT status FROM heartbeat_runs WHERE id = $1',
+				[seeded.runId],
+			);
+			expect(r.rows[0]?.status).toBe('cancelled');
+		},
+		{ timeout: 15_000 },
+	);
+});
+
 test('lists running agents above queued agents', async () => {
 	const seeded = { projectSlug: '', taskId: '', runningAgentId: '', wakeupId: '' };
 	const { findByTestId, router } = await renderApp({


### PR DESCRIPTION
## What & why

In the task sidebar's **Agent Queue**, when an agent is actively running on the task the row's trash icon should terminate that active run — confirmation box, then termination — using the same flow as the run page's Terminate button.

The terminate control existed but was gated on the agent's **run comment** having landed. In the window between a run flipping to `running` and that comment arriving, the row showed only a spinner with no way to terminate the active run.

## Changes

- **Server** (`execution-locks.ts`): the `GET .../tasks/:taskId/lock` response now includes `run_id` — the id of the agent's active (`running`) heartbeat run for that task+member, or `null` when there isn't one.
- **Web type** (`use-execution-locks.ts`): `ExecutionLock` gains `run_id?: string | null`.
- **Web component** (`agent-queue-section.tsx`): `RunningAgentRow` sources the run id from the lock (falling back to the run comment) and gates the terminate button + confirm dialog on it, so the trash → confirm → terminate flow is available the moment the agent is running.

The change is additive and backward compatible — no schema migration, no doc-surface changes (the lock endpoint shape isn't referenced in `docs/` or `.dev/architecture.md`).

## Testing

- `packages/server/test/execution-locks.test.ts`: lock endpoint surfaces the active `run_id`, returns `null` with no running run, and clears it once the run finishes.
- `packages/web/test/agent-queue.test.tsx`: a running agent with a lock + `running` run but **no** run comment still shows a working terminate button and cancels the run through the confirm dialog.
- Existing running/terminate/ordering tests stay green. Typecheck + build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YbrCVzEEpH7F1b9Px7Rxrd)_