### PR TITLE
feat(web): collapse goal-run + project-progress summaries, add progress help

### DIFF
--- a/docs/concepts/goals.md
+++ b/docs/concepts/goals.md
@@ -72,7 +72,8 @@ has moved over time, so you can see momentum (or a stall) at a glance.
 These goal checks are **not** done inside a task — they're standalone Captain runs. The recent
 goal checks for the whole project appear at the bottom of the **Progress** page. Each goal's own
 page also has a **Goal heartbeat runs** section showing just the runs that did something for *that*
-goal — the progress it set, plus any tasks it created or commented on toward the goal.
+goal — the progress it set and any tasks it created or commented on toward the goal show inline,
+and each run expands to reveal the status summary it recorded.
 
 During the same run the Captain also refreshes the **project progress summary** shown at the top
 of the Progress page, so that headline stays in step with the goal estimates.

--- a/packages/web/src/components/goal-detail/goal-detail-page.tsx
+++ b/packages/web/src/components/goal-detail/goal-detail-page.tsx
@@ -58,9 +58,12 @@ function TaskChip({ projectId, identifier }: { projectId: string; identifier: st
 }
 
 function GoalRunRow({ projectId, run }: { projectId: string; run: GoalRunActivity }) {
-	// The whole row is a stretched link to this run in the Captain's run list. Task chips
-	// sit above the overlay (`relative z-10`) so they remain independently clickable.
+	// The whole row is a stretched link to this run in the Captain's run list. The expand
+	// toggle and task chips sit above the overlay (`relative z-10`) so they stay clickable.
 	const runLinkParams = { ...agentPageParams(projectId, run.agent_slug), runId: run.id };
+	const [expanded, setExpanded] = useState(false);
+	const blurb = run.progress?.status_blurb;
+	const blurbId = `goal-run-blurb-${run.id}`;
 	return (
 		<li
 			data-testid="goal-run"
@@ -85,10 +88,32 @@ function GoalRunRow({ projectId, run }: { projectId: string; run: GoalRunActivit
 						<GoalHealthPill health={run.progress.health} />
 					</span>
 				)}
+				{/* The status summary is hidden by default; the chevron reveals it inline. Task
+				    chips below stay visible in both states. */}
+				{blurb && (
+					<button
+						type="button"
+						onClick={() => setExpanded((v) => !v)}
+						aria-expanded={expanded}
+						aria-controls={blurbId}
+						aria-label={expanded ? 'Hide progress summary' : 'Show progress summary'}
+						data-testid="goal-run-expand"
+						className="relative z-10 ml-auto flex shrink-0 items-center text-text-3 transition-colors hover:text-text-1"
+					>
+						<svg
+							aria-hidden="true"
+							className={`h-3 w-3 transition-transform ${expanded ? 'rotate-90' : ''}`}
+							viewBox="0 0 16 16"
+							fill="currentColor"
+						>
+							<path d="M6 3l5 5-5 5V3z" />
+						</svg>
+					</button>
+				)}
 			</div>
-			{run.progress?.status_blurb && (
-				<p className="text-[13px] text-text-2 leading-relaxed break-words">
-					{run.progress.status_blurb}
+			{blurb && expanded && (
+				<p id={blurbId} className="text-[13px] text-text-2 leading-relaxed break-words">
+					{blurb}
 				</p>
 			)}
 			{run.created_tasks.length > 0 && (

--- a/packages/web/src/components/project-progress-summary.tsx
+++ b/packages/web/src/components/project-progress-summary.tsx
@@ -1,10 +1,8 @@
 import { ChevronDown } from 'lucide-react';
-import { useEffect, useId, useLayoutEffect, useRef, useState } from 'react';
+import { useEffect, useId, useState } from 'react';
 import { useProjectProgress } from '../hooks/use-projects';
 import { MarkdownProse } from './markdown-prose';
-
-/** Collapsed height for the summary — just the bold lead line plus the first line of narrative. */
-const COLLAPSED_MAX_HEIGHT = 64; // px
+import { HelpDialog } from './ui/help-dialog';
 
 function formatUpdated(iso: string): string {
 	const d = new Date(iso);
@@ -18,36 +16,65 @@ function formatUpdated(iso: string): string {
 }
 
 /**
+ * Split the summary into its bold lead line (the key points the Captain leads with) and the rest
+ * of the narrative. The lead is the first markdown paragraph — everything up to the first blank
+ * line; the body is whatever follows. A summary with no blank line is all lead and has no body.
+ */
+function splitLead(summary: string): { lead: string; body: string } {
+	const match = summary.match(/\n[ \t]*\n/);
+	if (!match || match.index === undefined) return { lead: summary, body: '' };
+	return {
+		lead: summary.slice(0, match.index).trimEnd(),
+		body: summary.slice(match.index + match[0].length).trim(),
+	};
+}
+
+/** The explanation behind the question-mark help affordance on the Project progress header. */
+function ProjectProgressHelp() {
+	return (
+		<HelpDialog
+			title="About project progress"
+			triggerLabel="About project progress"
+			tooltip="What is project progress, and how does it update?"
+			data-testid="project-progress-help"
+		>
+			<div className="flex flex-col gap-3 text-sm leading-relaxed text-text-2">
+				<p>
+					Project progress is the Captain's running summary of where this project stands. It leads
+					with the key points in <span className="font-semibold">bold</span>, then a short narrative
+					of what's done, in progress, and still to do. Collapsed, it shows just the bold lead line;
+					use <span className="font-medium text-text-1">Show more</span> to read the full narrative.
+				</p>
+				<p>
+					It updates on its own — there's nothing to edit by hand. Each time the Captain runs a
+					goal-check heartbeat, it reviews progress across the project's goals and tasks and
+					rewrites this summary. The <span className="font-medium text-text-1">Updated</span> time
+					shows when it last changed.
+				</p>
+			</div>
+		</HelpDialog>
+	);
+}
+
+/**
  * The Captain-maintained project progress summary shown at the top of the Progress page. Collapsed
- * by default (showing the lead key points the Captain writes in bold), expandable to the full
- * narrative — mirroring how agent descriptions are shown. Renders null until a summary exists.
+ * by default to just the bold lead line the Captain leads with, expandable to the full narrative —
+ * mirroring how agent descriptions are shown. Renders null until a summary exists.
  */
 export function ProjectProgressSummary({ projectId }: { projectId: string }) {
 	const { data } = useProjectProgress(projectId);
 	const [expanded, setExpanded] = useState(false);
-	const [overflows, setOverflows] = useState(false);
-	const contentRef = useRef<HTMLDivElement>(null);
 	const contentId = useId();
 
 	const summary = data?.summary?.trim() ?? '';
 	const hasSummary = summary.length > 0;
+	const { lead, body } = splitLead(summary);
+	const hasBody = body.length > 0;
 
-	useLayoutEffect(() => {
-		const el = contentRef.current;
-		if (!el || !hasSummary) {
-			setOverflows(false);
-			return;
-		}
-		const measure = () => setOverflows(el.scrollHeight > COLLAPSED_MAX_HEIGHT + 1);
-		measure();
-		const observer = new ResizeObserver(measure);
-		observer.observe(el);
-		return () => observer.disconnect();
-	}, [hasSummary]);
-
+	// Collapse back down if the summary shrinks to a lead-only blurb while expanded.
 	useEffect(() => {
-		if (!overflows && expanded) setExpanded(false);
-	}, [overflows, expanded]);
+		if (!hasBody && expanded) setExpanded(false);
+	}, [hasBody, expanded]);
 
 	if (!hasSummary) return null;
 
@@ -57,29 +84,22 @@ export function ProjectProgressSummary({ projectId }: { projectId: string }) {
 			className="mb-6 rounded-md border border-border bg-surface p-4"
 		>
 			<div className="mb-2 flex items-center justify-between gap-2">
-				<h2 className="text-[11px] font-medium uppercase tracking-wider text-text-3">
-					Project progress
-				</h2>
+				<div className="flex items-center gap-1.5">
+					<h2 className="text-[11px] font-medium uppercase tracking-wider text-text-3">
+						Project progress
+					</h2>
+					<ProjectProgressHelp />
+				</div>
 				{data?.updated_at && (
 					<span className="text-[11px] text-text-3">Updated {formatUpdated(data.updated_at)}</span>
 				)}
 			</div>
-			<div className="relative">
-				<div
-					ref={contentRef}
-					id={contentId}
-					className="overflow-hidden"
-					style={expanded ? undefined : { maxHeight: COLLAPSED_MAX_HEIGHT }}
-				>
-					<MarkdownProse projectId={projectId} projectSlug={projectId}>
-						{summary}
-					</MarkdownProse>
-				</div>
-				{overflows && !expanded && (
-					<div className="pointer-events-none absolute inset-x-0 bottom-0 h-8 bg-gradient-to-t from-surface to-transparent" />
-				)}
+			<div id={contentId}>
+				<MarkdownProse projectId={projectId} projectSlug={projectId}>
+					{expanded ? summary : lead}
+				</MarkdownProse>
 			</div>
-			{overflows && (
+			{hasBody && (
 				<button
 					type="button"
 					onClick={() => setExpanded((v) => !v)}

--- a/packages/web/src/components/ui/help-dialog.tsx
+++ b/packages/web/src/components/ui/help-dialog.tsx
@@ -2,6 +2,7 @@ import * as Dialog from '@radix-ui/react-dialog';
 import { HelpCircle, X } from 'lucide-react';
 import { type ReactNode, useState } from 'react';
 import { dialogContentClassName, dialogOverlayClassName } from './dialog';
+import { Tooltip } from './tooltip';
 
 interface HelpDialogProps {
 	/** Heading shown at the top of the modal. */
@@ -10,6 +11,11 @@ interface HelpDialogProps {
 	children: ReactNode;
 	/** Accessible label for the question-mark trigger button. */
 	triggerLabel: string;
+	/**
+	 * Optional hover/focus tooltip on the question-mark trigger — a one-line teaser
+	 * shown before the user commits to opening the dialog. Omit for a bare trigger.
+	 */
+	tooltip?: ReactNode;
 	/** Trigger button size class for the icon. Defaults to a small (3.5) glyph. */
 	className?: string;
 	/** Width of the modal. Defaults to `md`. */
@@ -21,28 +27,33 @@ interface HelpDialogProps {
  * Reusable help affordance: a question-mark icon button that opens a modal popup with longer-form
  * guidance. Use this (rather than {@link InfoTooltip}) when the explanation is too rich for a hover
  * tooltip — the distinct `?` glyph signals to the user that clicking opens a dialog, not a tooltip.
+ * Pass `tooltip` to also show a short hover teaser on the trigger.
  */
 export function HelpDialog({
 	title,
 	children,
 	triggerLabel,
+	tooltip,
 	className,
 	size = 'md',
 	'data-testid': testId,
 }: HelpDialogProps) {
 	const [open, setOpen] = useState(false);
+	const trigger = (
+		<Dialog.Trigger asChild>
+			<button
+				type="button"
+				aria-label={triggerLabel}
+				data-testid={testId}
+				className={`shrink-0 text-text-3 hover:text-text-1 transition-colors ${className ?? ''}`}
+			>
+				<HelpCircle className="w-3.5 h-3.5" />
+			</button>
+		</Dialog.Trigger>
+	);
 	return (
 		<Dialog.Root open={open} onOpenChange={setOpen}>
-			<Dialog.Trigger asChild>
-				<button
-					type="button"
-					aria-label={triggerLabel}
-					data-testid={testId}
-					className={`shrink-0 text-text-3 hover:text-text-1 transition-colors ${className ?? ''}`}
-				>
-					<HelpCircle className="w-3.5 h-3.5" />
-				</button>
-			</Dialog.Trigger>
+			{tooltip ? <Tooltip content={tooltip}>{trigger}</Tooltip> : trigger}
 			<Dialog.Portal>
 				<Dialog.Overlay className={dialogOverlayClassName} />
 				<Dialog.Content className={dialogContentClassName[size]}>

--- a/packages/web/test/goals.test.tsx
+++ b/packages/web/test/goals.test.tsx
@@ -5,6 +5,7 @@ import {
 	seedGoalCheckRun,
 	seedProject,
 	seedProjectProgress,
+	seedTask,
 	seedWorkspace,
 } from './helpers/seed';
 
@@ -213,4 +214,104 @@ test('clicking a goal opens its page with breadcrumbs, run feed, and edit modal'
 	// Editing reuses the create/edit modal.
 	await user.click(getByTestId('goal-edit'));
 	await findByText('Edit Goal');
+});
+
+test('Project progress shows only the bold lead line until expanded', async () => {
+	let projectSlug = '';
+	const { findByText, findByTestId, queryByText, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Collapse Demo' });
+			projectSlug = project.slug;
+			await seedGoal(ws, project, { title: 'Ship v1', measurement: 'v1 live' });
+			// A representative two-paragraph summary: bold lead line, then a narrative body.
+			await seedProjectProgress(
+				project,
+				'**Auth shipped, payments next.**\n\nThe login flow is live and analytics land later this week.',
+			);
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/goals',
+		params: { projectId: projectSlug },
+	});
+
+	await findByTestId('project-progress-summary', undefined, { timeout: 10_000 });
+	// Collapsed: the bold lead renders, the narrative body does not.
+	await findByText('Auth shipped, payments next.');
+	expect(queryByText(/analytics land later this week/)).toBeNull();
+
+	// Show more reveals the body; the lead stays put.
+	await user.click(await findByTestId('project-progress-toggle'));
+	await findByText(/analytics land later this week/);
+	await findByText('Auth shipped, payments next.');
+});
+
+test('Project progress header opens a help dialog explaining how it updates', async () => {
+	let projectSlug = '';
+	const { findByText, findByTestId, queryByText, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Help Demo' });
+			projectSlug = project.slug;
+			await seedGoal(ws, project, { title: 'Ship v1', measurement: 'v1 live' });
+			await seedProjectProgress(project, '**On track.**\n\nMost of the work is done.');
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/goals',
+		params: { projectId: projectSlug },
+	});
+
+	// The explanation lives behind the question-mark help button, not inline.
+	const help = await findByTestId('project-progress-help', undefined, { timeout: 10_000 });
+	expect(queryByText(/reviews progress across the project/)).toBeNull();
+
+	await user.click(help);
+
+	// The dialog explains what it is and that the Captain refreshes it during goal-check runs.
+	await findByText('About project progress');
+	await findByText(/reviews progress across the project/);
+});
+
+test('the goal run feed hides the status summary until expanded, keeping task chips visible', async () => {
+	let projectSlug = '';
+	let goalId = '';
+	let createdIdentifier = '';
+	const { findByText, findByTestId, queryByText, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Blurb Demo' });
+			projectSlug = project.slug;
+			const goal = await seedGoal(ws, project, { title: 'Ship beta', measurement: 'beta live' });
+			goalId = goal.id;
+			const task = await seedTask(ws, project, { title: 'Wire up auth' });
+			createdIdentifier = task.identifier;
+			await seedGoalCheckRun(ws, {
+				goal,
+				statusBlurb: 'Auth is the last blocker before beta.',
+				createdTasks: [task],
+			});
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/goals/$goalId',
+		params: { projectId: projectSlug, goalId },
+	});
+
+	await findByTestId('goal-run', undefined, { timeout: 10_000 });
+	// Collapsed: the created-task chip shows, but the status summary stays hidden.
+	await findByText(createdIdentifier);
+	expect(queryByText(/Auth is the last blocker/)).toBeNull();
+
+	// Expanding the run reveals the summary; the task chip is still there.
+	await user.click(await findByTestId('goal-run-expand'));
+	await findByText(/Auth is the last blocker/);
+	await findByText(createdIdentifier);
 });

--- a/packages/web/test/helpers/seed.ts
+++ b/packages/web/test/helpers/seed.ts
@@ -270,6 +270,11 @@ export async function seedGoalCheckRun(
 		progressPercent?: number;
 		health?: string;
 		statusBlurb?: string;
+		/**
+		 * Attribute these existing tasks to the run as goal-linked "created" tasks, so the run's
+		 * `created_tasks` activity is populated the way `tryDispatchGoalCheck` + `create_task` produce.
+		 */
+		createdTasks?: SeededTask[];
 	} = {},
 ): Promise<{ runId: string }> {
 	const { db } = getTestContext();
@@ -296,6 +301,16 @@ export async function seedGoalCheckRun(
 				opts.statusBlurb ?? '',
 			],
 		);
+	}
+
+	if (opts.goal && opts.createdTasks?.length) {
+		for (const t of opts.createdTasks) {
+			await db.query(`UPDATE tasks SET goal_id = $1, created_by_run_id = $2 WHERE id = $3`, [
+				opts.goal.id,
+				runId,
+				t.id,
+			]);
+		}
 	}
 
 	return { runId };


### PR DESCRIPTION
## What & why

Three Progress-page refinements so the long Captain-written summaries don't dominate the collapsed views, plus an in-app explanation of what "Project progress" is.

### 1. Goal heartbeat runs — status summary is expand-on-demand
On a goal's detail page, each run row used to render its full `status_blurb` paragraph inline. Now the paragraph is hidden behind a disclosure chevron. The **progress % / health pill** and the **tasks the run created or commented on** stay visible in *both* collapsed and expanded states — only the prose summary is gated behind the toggle.

### 2. Project progress card — collapse to just the bold lead line
Previously the card clipped the summary to a fixed 64px height, which leaked the first line of the narrative body under the bold lead. It now splits the summary at the first blank line and shows **only the bold lead paragraph** when collapsed; the narrative body appears only after **Show more**. This drops the `ResizeObserver`/`scrollHeight` measurement and the gradient fade in favour of a simple, layout-independent split.

### 3. "Project progress" help affordance
A question-mark icon next to the **Project progress** header now shows a hover tooltip and opens a help dialog explaining what the summary is and that the Captain refreshes it automatically during goal-check heartbeat runs (with the *Updated* time as the last-changed marker). This mirrors the existing "What makes a good goal?" help button on the same page.

`HelpDialog` gained an optional `tooltip` prop (wraps the trigger in a `Tooltip`); existing callers render identically.

## Changes
- `goal-detail/goal-detail-page.tsx` — `GoalRunRow` disclosure toggle; blurb hidden unless expanded; task chips unchanged.
- `project-progress-summary.tsx` — `splitLead()` lead/body split; collapsed renders the lead, expanded renders the full summary; added `ProjectProgressHelp`.
- `ui/help-dialog.tsx` — optional `tooltip` prop.
- `test/helpers/seed.ts` — `seedGoalCheckRun` can attribute goal-linked "created" tasks to a run.
- `docs/concepts/goals.md` — note that run rows expand to reveal the status summary.

## Testing
- `packages/web/test/goals.test.tsx` — 3 new component tests (project-progress collapses to lead until **Show more**; the header help dialog opens and explains how it updates; the goal-run status summary is hidden until expanded while task chips stay visible). All 10 tests in the file pass.
- Full web component suite green except one pre-existing, unrelated flake (`task-comment-doc-preview` — passes in isolation; touches a doc-mention/preview path not changed here).
- `bun run typecheck` (all 3 packages) and biome check pass; `docs-bundle` test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xr1apG7fiBpD8LEf6FJqSZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xr1apG7fiBpD8LEf6FJqSZ)_