### PR TITLE
feat(web): global mobile create-task button with project selector

### DIFF
--- a/packages/web/src/components/create-task-dialog.tsx
+++ b/packages/web/src/components/create-task-dialog.tsx
@@ -2,9 +2,9 @@ import { CAPTAIN_AGENT_SLUG } from '@hezo/shared';
 import * as Dialog from '@radix-ui/react-dialog';
 import { useNavigate } from '@tanstack/react-router';
 import { ChevronDown, Loader2, X } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useAgents } from '../hooks/use-agents';
-import { useProjectMeta } from '../hooks/use-projects';
+import { useAllVisibleProjects, useProjectMeta } from '../hooks/use-projects';
 import { useCreateTask } from '../hooks/use-tasks';
 import { MarkdownEditor } from './markdown-editor';
 import { Button } from './ui/button';
@@ -12,21 +12,49 @@ import { dialogContentClassName, dialogOverlayClassName } from './ui/dialog';
 import { Input } from './ui/input';
 
 interface CreateTaskDialogProps {
-	projectId: string;
+	/** Fixed target project (slug). Pass this OR `selectProject`, not both. */
+	projectId?: string;
+	/** Show a project picker as the first field instead of targeting a fixed
+	 *  `projectId` — used by the global mobile "+" so a task can be filed into any
+	 *  project. The picked project then drives the assignee list. */
+	selectProject?: boolean;
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 }
 
-export function CreateTaskDialog({ projectId, open, onOpenChange }: CreateTaskDialogProps) {
+export function CreateTaskDialog({
+	projectId,
+	selectProject,
+	open,
+	onOpenChange,
+}: CreateTaskDialogProps) {
 	const [title, setTitle] = useState('');
 	const [description, setDescription] = useState('');
 	const [assigneeId, setAssigneeId] = useState('');
 	const [priority, setPriority] = useState('medium');
 	const [moreOpen, setMoreOpen] = useState(false);
-	const project = useProjectMeta(projectId);
-	const { data: agents } = useAgents(projectId);
-	const createTask = useCreateTask(projectId);
+	const [pickedProjectId, setPickedProjectId] = useState('');
+
+	// With `selectProject` the picker drives the target; otherwise the fixed prop does.
+	const effectiveProjectId = selectProject ? pickedProjectId : (projectId ?? '');
+
+	const { projects } = useAllVisibleProjects();
+	const project = useProjectMeta(effectiveProjectId);
+	const { data: agents } = useAgents(effectiveProjectId);
+	const createTask = useCreateTask(effectiveProjectId);
 	const navigate = useNavigate();
+
+	// On open, seed the picker with the passed/active project (only when it's a
+	// user-visible project) and clear any stale assignee. Rising-edge only, so a
+	// pick already in progress is never reset while the dialog stays open.
+	const prevOpenRef = useRef(false);
+	useEffect(() => {
+		if (selectProject && open && !prevOpenRef.current) {
+			setPickedProjectId(projectId && projects.some((p) => p.slug === projectId) ? projectId : '');
+			setAssigneeId('');
+		}
+		prevOpenRef.current = open;
+	}, [open, selectProject, projectId, projects]);
 
 	const isInternalProject = project?.is_internal ?? false;
 	const captainAgent = useMemo(() => agents?.find((a) => a.slug === CAPTAIN_AGENT_SLUG), [agents]);
@@ -39,7 +67,7 @@ export function CreateTaskDialog({ projectId, open, onOpenChange }: CreateTaskDi
 	}, [agents, captainAgent, isInternalProject]);
 
 	const priorityLabel = priority.charAt(0).toUpperCase() + priority.slice(1);
-	const summaryLabel = `${priorityLabel} priority · ${project?.name ?? projectId}`;
+	const summaryLabel = `${priorityLabel} priority · ${project?.name ?? 'No project'}`;
 
 	async function handleSubmit(e: React.FormEvent) {
 		e.preventDefault();
@@ -55,7 +83,7 @@ export function CreateTaskDialog({ projectId, open, onOpenChange }: CreateTaskDi
 		navigate({
 			to: '/projects/$projectId/tasks/$taskId',
 			params: {
-				projectId: result.project_slug ?? projectId,
+				projectId: result.project_slug ?? effectiveProjectId,
 				taskId: result.identifier.toLowerCase(),
 			},
 		});
@@ -80,6 +108,30 @@ export function CreateTaskDialog({ projectId, open, onOpenChange }: CreateTaskDi
 					</div>
 
 					<form onSubmit={handleSubmit} className="flex flex-col gap-4">
+						{selectProject && (
+							<label className="flex flex-col gap-1.5">
+								<span className="text-sm text-text-2">Project *</span>
+								<select
+									value={pickedProjectId}
+									onChange={(e) => {
+										// Switching projects invalidates the chosen assignee (a
+										// different roster), so clear it in the same update.
+										setPickedProjectId(e.target.value);
+										setAssigneeId('');
+									}}
+									required
+									data-testid="create-task-project"
+									className="rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-text-1 outline-none focus:border-border-strong"
+								>
+									<option value="">Select project</option>
+									{projects.map((p) => (
+										<option key={p.id} value={p.slug}>
+											{p.name}
+										</option>
+									))}
+								</select>
+							</label>
+						)}
 						<Input
 							label="Title"
 							value={title}
@@ -87,7 +139,7 @@ export function CreateTaskDialog({ projectId, open, onOpenChange }: CreateTaskDi
 							required
 						/>
 						<MarkdownEditor
-							projectId={projectId}
+							projectId={effectiveProjectId}
 							projectSlug={project?.slug}
 							label="Description"
 							ariaLabel="Description"
@@ -104,6 +156,7 @@ export function CreateTaskDialog({ projectId, open, onOpenChange }: CreateTaskDi
 								value={assigneeId}
 								onChange={(e) => setAssigneeId(e.target.value)}
 								required
+								data-testid="create-task-assignee"
 								className="rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-text-1 outline-none focus:border-border-strong"
 							>
 								<option value="">Select assignee</option>
@@ -159,7 +212,12 @@ export function CreateTaskDialog({ projectId, open, onOpenChange }: CreateTaskDi
 							<Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
 								Cancel
 							</Button>
-							<Button type="submit" disabled={!title.trim() || !assigneeId || createTask.isPending}>
+							<Button
+								type="submit"
+								disabled={
+									!effectiveProjectId || !title.trim() || !assigneeId || createTask.isPending
+								}
+							>
 								{createTask.isPending && <Loader2 className="w-4 h-4 animate-spin" />}
 								Create
 							</Button>

--- a/packages/web/src/components/floating-new-task-button.tsx
+++ b/packages/web/src/components/floating-new-task-button.tsx
@@ -15,21 +15,21 @@ interface FloatingNewTaskButtonProps {
 }
 
 /**
- * A round "+" button that creates a task in the active project. It mirrors the
- * CEO chat launcher's floating treatment but uses the accent fill (vs. the
- * chat's inverse fill) so the two are never confused, and it's pinned to the
- * opposite (bottom-left) corner.
+ * A round "+" button that opens a create-task dialog with a project picker, so a
+ * task can be filed into any project from anywhere. It mirrors the CEO chat
+ * launcher's floating treatment but uses the accent fill (vs. the chat's inverse
+ * fill) so the two are never confused, and it's pinned to the opposite
+ * (bottom-left) corner. The current route's project, if any, is the picker's
+ * default.
  *
  * Scope: mobile/tablet only (`lg:hidden`). On desktop the persistent project
  * menu is always visible and carries its own "+" next to the Tasks link, so a
- * floating duplicate there would be redundant. It only renders on project-scoped
- * routes (where there's a project to create the task in).
+ * floating duplicate there would be redundant. It renders on every mobile route
+ * (project-scoped or not) — the dialog's picker supplies the target project.
  */
 export function FloatingNewTaskButton({ hidden }: FloatingNewTaskButtonProps) {
 	const active = useActiveProject();
 	const [open, setOpen] = useState(false);
-
-	if (!active) return null;
 
 	return (
 		<>
@@ -46,7 +46,7 @@ export function FloatingNewTaskButton({ hidden }: FloatingNewTaskButtonProps) {
 					</button>
 				</Tooltip>
 			)}
-			<CreateTaskDialog projectId={active.slug} open={open} onOpenChange={setOpen} />
+			<CreateTaskDialog selectProject projectId={active?.slug} open={open} onOpenChange={setOpen} />
 		</>
 	);
 }

--- a/packages/web/test/floating-new-task.test.tsx
+++ b/packages/web/test/floating-new-task.test.tsx
@@ -1,4 +1,4 @@
-import { waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import { expect, test } from 'vitest';
 import { renderApp } from './helpers/render';
 import { seedProject, seedWorkspace } from './helpers/seed';
@@ -67,8 +67,66 @@ test('the sidebar "+" next to Tasks opens the create-task dialog', async () => {
 	);
 });
 
-test('no floating new-task button off a project route', async () => {
-	const { queryByTestId } = await renderApp({ initialPath: '/home' });
-	await waitFor(() => expect(queryByTestId('ceo-chat-launcher')).not.toBeNull());
-	expect(queryByTestId('floating-new-task')).toBeNull();
+test('the floating new-task button is available off a project route and offers a project picker', async () => {
+	const { findByTestId, user } = await renderApp({
+		initialPath: '/home',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			await seedProject(ws, { name: 'Off-route Project' });
+		},
+	});
+
+	// Global now: the button shows even with no project in the route.
+	const floating = await findByTestId('floating-new-task');
+	await user.click(floating);
+
+	// The dialog renders into a Radix portal on document.body.
+	await waitFor(() =>
+		expect(
+			Array.from(document.body.querySelectorAll('h2,[role="dialog"] *')).some(
+				(el) => el.textContent === 'Create Task',
+			),
+		).toBe(true),
+	);
+	// …and the form leads with a project selector (the fixed-project call sites don't).
+	await screen.findByTestId('create-task-project');
+});
+
+test('the floating dialog scopes the assignee list to the chosen project', async () => {
+	let alpha = { slug: '', captain: '' };
+	let beta = { slug: '', captain: '' };
+	const { findByTestId, user } = await renderApp({
+		initialPath: '/home',
+		seed: async () => {
+			const a = await seedWorkspace();
+			const ap = await seedProject(a, { name: 'Alpha' });
+			const b = await seedWorkspace();
+			const bp = await seedProject(b, { name: 'Beta' });
+			// Captain is team-local (a distinct row per team), so its id is the
+			// cleanest fingerprint that the assignee list followed the project.
+			alpha = { slug: ap.slug, captain: a.agents.find((x) => x.slug === 'captain')?.id ?? '' };
+			beta = { slug: bp.slug, captain: b.agents.find((x) => x.slug === 'captain')?.id ?? '' };
+		},
+	});
+
+	await user.click(await findByTestId('floating-new-task'));
+	const projectSelect = (await screen.findByTestId('create-task-project')) as HTMLSelectElement;
+	const assignee = (await screen.findByTestId('create-task-assignee')) as HTMLSelectElement;
+
+	// Pick Alpha → its roster (incl. Alpha's Captain) fills the assignee select.
+	await user.selectOptions(projectSelect, alpha.slug);
+	await waitFor(() => {
+		const values = Array.from(assignee.options).map((o) => o.value);
+		expect(values).toContain(alpha.captain);
+		expect(values).not.toContain(beta.captain);
+	});
+
+	// Switch to Beta → the assignee options swap and the prior choice is cleared.
+	await user.selectOptions(projectSelect, beta.slug);
+	await waitFor(() => {
+		const values = Array.from(assignee.options).map((o) => o.value);
+		expect(values).toContain(beta.captain);
+		expect(values).not.toContain(alpha.captain);
+	});
+	expect(assignee.value).toBe('');
 });


### PR DESCRIPTION
## What & why

On mobile/tablet the floating "+" button (bottom-left) previously only appeared on **project-scoped** routes and could only create a task in *that* project. There was no way to file a task into an arbitrary project from the global button.

This makes it a **truly global** create-task action:

- The button now renders on **every** mobile route (project-scoped or not).
- Its dialog leads with a **project picker**. Choosing a project then drives the **assignee** list — agents are team-scoped and resolved from the selected project, so a task can be filed into any project from anywhere.
- The current route's project (when there is one) is the picker's default.

## How

- **`CreateTaskDialog`** gains an opt-in `selectProject` mode (`projectId` is now optional). An `effectiveProjectId` (picked project when `selectProject`, else the fixed prop) feeds `useProjectMeta` / `useAgents` / `useCreateTask` / the description editor. Switching projects clears the now-stale assignee, and Create is disabled until a project, title, and assignee are all set. The two fixed-project call sites (task list, project sidebar) pass no `selectProject` and are behaviourally unchanged.
- **`FloatingNewTaskButton`** drops its `if (!active) return null` project-route guard and passes `selectProject`, defaulting the picker to the current route's project.

**No server change.** A task's team and project are derived from the request URL (`POST /api/projects/:projectId/tasks` — `teamId` comes from `requireProjectAccessMiddleware`, and the body carries no `project_id`), so pointing the existing per-project hooks at the picked slug is sufficient and correct.

## Testing

Component tests in `packages/web/test/floating-new-task.test.tsx`:

- Flipped the old "no button off a project route" test → the button now **appears** off-project (`/home`) and the dialog offers a project picker.
- New cross-project test: seeds two projects with distinct rosters, opens the global dialog, and asserts the assignee options follow the selected project (and reset when switching).
- Existing fixed-project usages re-verified via `task-list.test.tsx` and `task-crud.test.tsx`.

`tsc --noEmit` (turbo typecheck), `biome check`, and the affected vitest files all pass locally.

No docs/architecture changes — this is a frontend UX affordance with no API, route, data-model, or user-facing-doc surface affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8LCzSMen4u9WMDrwez6XK

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8LCzSMen4u9WMDrwez6XK)_