### PR TITLE
fix(server): strip NUL bytes from container output before persisting

### DIFF
--- a/packages/server/src/lib/sql.ts
+++ b/packages/server/src/lib/sql.ts
@@ -59,6 +59,16 @@ export function buildUpdateSet(fields: UpdateFieldSpec[], startIdx = 1): UpdateS
 	return { clauses, params, nextIdx: idx };
 }
 
+/**
+ * Remove NUL (0x00) bytes from decoded text. Postgres `text`/`jsonb` columns reject NUL
+ * on write, and NUL is valid UTF-8 so `TextDecoder` passes it through unchanged —
+ * container output carrying binary noise must be scrubbed before it can be persisted.
+ */
+export function stripNulBytes(text: string): string {
+	const NUL = String.fromCharCode(0);
+	return text.includes(NUL) ? text.split(NUL).join('') : text;
+}
+
 const PG_FK_VIOLATION = '23503';
 const PG_UNIQUE_VIOLATION = '23505';
 

--- a/packages/server/src/services/container-logs.ts
+++ b/packages/server/src/services/container-logs.ts
@@ -1,4 +1,5 @@
 import { WsMessageType } from '@hezo/shared';
+import { stripNulBytes } from '../lib/sql';
 import type { DockerClient } from './docker';
 import type { LogStreamBroker } from './log-stream-broker';
 
@@ -134,7 +135,7 @@ export class ContainerLogStreamer {
 					buffer = buffer.slice(8 + frameSize);
 
 					const stream: 'stdout' | 'stderr' = streamType === 2 ? 'stderr' : 'stdout';
-					const text = decoder.decode(payload);
+					const text = stripNulBytes(decoder.decode(payload));
 
 					batchLines.push({ stream, text });
 					scheduleBatch();

--- a/packages/server/src/services/containers.ts
+++ b/packages/server/src/services/containers.ts
@@ -12,7 +12,7 @@ import type { MasterKeyManager } from '../crypto/master-key';
 import { trackBackground } from '../lib/background';
 import { broadcastProjectUpdate, broadcastRowChange } from '../lib/broadcast';
 import { ref } from '../lib/log-ref';
-import { terminalStatusParams } from '../lib/sql';
+import { stripNulBytes, terminalStatusParams } from '../lib/sql';
 import { logger } from '../logger';
 import { setAgentIdleIfNoActiveRuns } from './agent-runtime-status';
 import type { ContainerLogStreamer } from './container-logs';
@@ -200,7 +200,7 @@ export async function captureContainerLogs(
 			chunks.push(decoder.decode(raw.slice(offset, offset + frameSize)));
 			offset += frameSize;
 		}
-		let combined = chunks.join('');
+		let combined = stripNulBytes(chunks.join(''));
 		if (combined.length > LAST_LOGS_CAP_BYTES) {
 			combined = combined.slice(-LAST_LOGS_CAP_BYTES);
 		}

--- a/packages/server/src/services/docker.ts
+++ b/packages/server/src/services/docker.ts
@@ -1,3 +1,5 @@
+import { stripNulBytes } from '../lib/sql';
+
 const SOCKET_PATH = '/var/run/docker.sock';
 const API_VERSION = 'v1.44';
 
@@ -421,8 +423,8 @@ function demuxDockerStream(raw: Uint8Array): { stdout: string; stderr: string } 
 
 	const decoder = new TextDecoder();
 	return {
-		stdout: decoder.decode(concatUint8Arrays(stdout)),
-		stderr: decoder.decode(concatUint8Arrays(stderr)),
+		stdout: stripNulBytes(decoder.decode(concatUint8Arrays(stdout))),
+		stderr: stripNulBytes(decoder.decode(concatUint8Arrays(stderr))),
 	};
 }
 
@@ -446,7 +448,7 @@ async function streamDockerExec(
 			if (buffer.length < 8 + size) break;
 			const payload = buffer.slice(8, 8 + size);
 			buffer = buffer.slice(8 + size);
-			const text = decoder.decode(payload);
+			const text = stripNulBytes(decoder.decode(payload));
 			const stream: 'stdout' | 'stderr' = streamType === 2 ? 'stderr' : 'stdout';
 			if (stream === 'stdout') stdoutParts.push(text);
 			else stderrParts.push(text);

--- a/packages/server/test/capture-container-logs.test.ts
+++ b/packages/server/test/capture-container-logs.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { captureContainerLogs } from '../src/services/containers';
+import type { DockerClient } from '../src/services/docker';
+
+const NUL = String.fromCharCode(0);
+
+// Wrap a payload in a single Docker multiplexed-stream frame: a 1-byte stream
+// type, three padding bytes, and a big-endian 4-byte length, followed by the
+// payload. This mirrors the framing `captureContainerLogs` demultiplexes.
+function frame(streamType: 1 | 2, payload: Uint8Array): Uint8Array {
+	const out = new Uint8Array(8 + payload.length);
+	out[0] = streamType;
+	out[4] = (payload.length >>> 24) & 0xff;
+	out[5] = (payload.length >>> 16) & 0xff;
+	out[6] = (payload.length >>> 8) & 0xff;
+	out[7] = payload.length & 0xff;
+	out.set(payload, 8);
+	return out;
+}
+
+function dockerReturning(bytes: Uint8Array): DockerClient {
+	return {
+		containerLogs: async () => new Response(bytes),
+	} as unknown as DockerClient;
+}
+
+describe('captureContainerLogs NUL handling', () => {
+	it('strips NUL bytes so the tail can be persisted to a Postgres text column', async () => {
+		// Container output carrying a raw 0x00 (binary noise) — Postgres would reject
+		// this on the container_last_logs write if it survived the decode.
+		const payload = new TextEncoder().encode(`hello${NUL}world`);
+		const docker = dockerReturning(frame(1, payload));
+
+		const result = await captureContainerLogs(docker, 'ctr-1', 'proj');
+
+		expect(result).toBe('helloworld');
+		expect(result?.includes(NUL)).toBe(false);
+	});
+
+	it('leaves NUL-free output untouched across stdout and stderr frames', async () => {
+		const stdout = frame(1, new TextEncoder().encode('out line\n'));
+		const stderr = frame(2, new TextEncoder().encode('err line\n'));
+		const combined = new Uint8Array(stdout.length + stderr.length);
+		combined.set(stdout, 0);
+		combined.set(stderr, stdout.length);
+
+		const result = await captureContainerLogs(dockerReturning(combined), 'ctr-2');
+
+		expect(result).toBe('out line\nerr line\n');
+	});
+});

--- a/packages/server/test/sql-helpers.test.ts
+++ b/packages/server/test/sql-helpers.test.ts
@@ -4,9 +4,12 @@ import {
 	buildUpdateSet,
 	isFkViolation,
 	isUniqueViolation,
+	stripNulBytes,
 	terminalStatusParams,
 	withTransaction,
 } from '../src/lib/sql';
+
+const NUL = String.fromCharCode(0);
 
 // withTransaction only depends on db.query for BEGIN/COMMIT/ROLLBACK, so a tiny
 // fake suffices to exercise both the commit and rollback branches without a DB.
@@ -87,6 +90,23 @@ describe('buildUpdateSet', () => {
 			params: [],
 			nextIdx: 1,
 		});
+	});
+});
+
+describe('stripNulBytes', () => {
+	it('removes embedded NUL bytes that Postgres text/jsonb columns reject', () => {
+		expect(stripNulBytes(`a${NUL}b${NUL}c`)).toBe('abc');
+		expect(stripNulBytes(`${NUL}lead and trail${NUL}`)).toBe('lead and trail');
+	});
+
+	it('preserves surrounding text and other control characters', () => {
+		expect(stripNulBytes(`line1\n\tline2${NUL} end`)).toBe('line1\n\tline2 end');
+	});
+
+	it('returns the input unchanged when there is no NUL', () => {
+		const clean = 'plain log output\nwith newlines';
+		expect(stripNulBytes(clean)).toBe(clean);
+		expect(stripNulBytes('')).toBe('');
 	});
 });
 


### PR DESCRIPTION
## Problem

A live dev-server run failed with:

> Run for @qa-engineer failed: invalid byte sequence for encoding "UTF8": 0x00

This is Postgres/PGlite rejecting a string containing a raw NUL byte (`0x00`) — `text`/`jsonb` columns cannot store NUL.

## Root cause

Container stdout/stderr is turned into JS strings via `TextDecoder.decode()`. A NUL byte is *valid* UTF-8 (a single `0x00`), so the decoder passes it through unchanged. That unsanitized string then flows into a Postgres text column and the write throws.

Failure flow:
1. The qa-engineer container emitted output containing a `0x00` (binary/garbled tool output).
2. `streamDockerExec` decoded it and fed it through `emit` → `LogStreamBroker` → `CappedLogBuffer`.
3. On flush, `UPDATE heartbeat_runs SET log_text = $1` threw `invalid byte sequence … 0x00`.
4. The throw became the run's `error`, which `postFailurePing()` wrote as the visible `run_failed` comment.

Every affected write is downstream of a `TextDecoder.decode()` of raw Docker bytes: `heartbeat_runs.log_text`, `heartbeat_runs.error`, `projects.container_last_logs`, and the `task_comments.content` failure-ping. There was no NUL sanitization anywhere.

## Fix

Strip NUL at the decode boundary — where raw Docker bytes first become strings — so no NUL can reach any downstream string or DB write. This keeps the live WebSocket broadcast and the persisted snapshot identical, and needs no per-column patching.

- **`lib/sql.ts`** — new `stripNulBytes()` helper (Postgres-safety concern, alongside `isFkViolation`).
- **`docker.ts`** — applied at both decode sites: `demuxDockerStream` and `streamDockerExec`.
- **`container-logs.ts`** — applied at the live container-log stream decode.
- **`containers.ts`** — applied to the `captureContainerLogs` tail feeding `container_last_logs`.

`ceo_sessions.error` and the run's `catch`-path `error` derive from JS `Error.message`, not raw container bytes, so they never carry an actual NUL and need no change.

## Tests

- **Unit** (`sql-helpers.test.ts`): `stripNulBytes` removes embedded NUL, preserves other control chars (`\n`/`\t`), and no-ops on clean input.
- **Integration** (`capture-container-logs.test.ts`): builds real Docker-framed bytes with a `0x00` payload, runs them through `captureContainerLogs`, asserts the result is NUL-free with surrounding text intact — exercising the real decode+strip the exec path shares.

The fake Docker client emits already-decoded strings, so it bypasses the real `TextDecoder` boundary; the helper unit test plus the `captureContainerLogs` integration test (symmetric decode logic) are the faithful coverage.

## Verification

- `typecheck` + `biome check` clean on all touched files.
- Green: sql-helpers (16), capture-container-logs (2), container tier (137), log-stream/log-format/container-logs-streaming/agent-runner (94).

No schema/route/MCP-tool/user-visible change — no docs, architecture, or migration updates required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HyzNumKeLWLWpQebopoBzR