### PR TITLE
fix(test): scope container cleanup to test containers; harden worktree prep

### DIFF
--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -50,7 +50,12 @@ import {
 	type ProbeResult,
 	shouldAbortForConnectivity,
 } from './container-connectivity-status';
-import { type ContainerRunUser, chownToRunUser, resolveContainerRunUser } from './container-user';
+import {
+	type ContainerRunUser,
+	chownToRunUser,
+	mkdirInContainer,
+	resolveContainerRunUser,
+} from './container-user';
 import { syncContainerStatus } from './containers';
 import type { DockerClient, ExecLogChunk } from './docker';
 import { getAgentSystemPrompt } from './documents';
@@ -1357,13 +1362,17 @@ async function prepareWorktrees(
 		const workspaceRoot = getWorkspacePath(deps.dataDir, project.team_id, project.id);
 		const worktreesRoot = getWorktreesPath(deps.dataDir, project.team_id, project.id);
 		const taskWorktreeRoot = join(worktreesRoot, task.identifier);
+		const containerWorktreeRoot = `${CONTAINER_WORKTREES_ROOT}/${task.identifier}`;
 		mkdirSync(taskWorktreeRoot, { recursive: true });
-		// The host just created this task's worktree root (root-owned); give the
-		// run-user ownership so the in-container `git worktree add` (run as the
-		// run-user) can populate it. No-op when the run-user is root.
-		await chownToRunUser(deps.docker, project.container_id, runUser, [
-			`${CONTAINER_WORKTREES_ROOT}/${task.identifier}`,
-		]);
+		// Also create the root from inside the container. The host mkdir above may not
+		// be visible in the container yet (bind-mount propagation lag, most visibly
+		// right after a reprovision), and the chown below is skipped for a root
+		// run-user — so without this the in-container `git worktree add` can fail with
+		// ENOENT on the worktree path.
+		await mkdirInContainer(deps.docker, project.container_id, [containerWorktreeRoot]);
+		// Give the run-user ownership so the in-container `git worktree add` (run as
+		// the run-user) can populate it. No-op when the run-user is root.
+		await chownToRunUser(deps.docker, project.container_id, runUser, [containerWorktreeRoot]);
 
 		const branchName = `hezo/${task.identifier}`;
 		const repoLocOf = (name: string): RepoLoc => ({

--- a/packages/server/src/services/container-user.ts
+++ b/packages/server/src/services/container-user.ts
@@ -103,6 +103,37 @@ function shSingleQuote(s: string): string {
 }
 
 /**
+ * Create directories **inside the container** (as root, `mkdir -p`). A host-side
+ * `mkdirSync` in a bind mount is not always immediately visible in the container —
+ * bind-mount propagation lags on macOS Docker Desktop, most visibly right after a
+ * container reprovision — so an in-container `git worktree add` can fail with ENOENT
+ * on a path the host just created. Creating the directory from inside the container
+ * guarantees it exists in the container's namespace (and writes through the live bind
+ * to the host). Best-effort: a failure logs one warning and never throws; the git
+ * operation that follows surfaces the actionable error if the path truly can't be made.
+ */
+export async function mkdirInContainer(
+	docker: DockerClient,
+	containerId: string,
+	containerPaths: string[],
+): Promise<void> {
+	if (containerPaths.length === 0) return;
+	const targets = containerPaths.map(shSingleQuote).join(' ');
+	try {
+		const { exitCode, stderr } = await execCapture(docker, containerId, `mkdir -p ${targets}`);
+		if (exitCode !== 0) {
+			log.warn(`mkdir -p exited ${exitCode} for [${containerPaths.join(', ')}]: ${stderr.trim()}`);
+		}
+	} catch (e) {
+		log.warn(
+			`mkdir -p failed for [${containerPaths.join(', ')}]: ${
+				e instanceof Error ? e.message : String(e)
+			}`,
+		);
+	}
+}
+
+/**
  * Give the container's run-user ownership of paths the host created in a bind mount
  * that the run-user must read or write. The chown runs **inside the container as
  * root** (the base image's default user), so it needs no host privilege and works

--- a/packages/server/src/services/containers.ts
+++ b/packages/server/src/services/containers.ts
@@ -4,6 +4,9 @@ import type { PGlite } from '@electric-sql/pglite';
 import {
 	ContainerStatus,
 	HeartbeatRunStatus,
+	TEST_CONTAINER_LABEL_KEY,
+	TEST_CONTAINER_LABEL_VALUE,
+	TEST_CONTAINERS_ENV,
 	WakeupSource,
 	WsMessageType,
 	wsRoom,
@@ -278,7 +281,15 @@ export async function provisionContainer(
 		// down by stored `container_id`, never by name, so when it is retained
 		// (keep-old) the fresh name still avoids a create-time conflict.
 		const containerName = `hezo-${project.slug}-${project.id.slice(0, 8)}-${randomBytes(4).toString('hex')}`;
-		const containerLabels = { 'hezo.team': teamSlug, 'hezo.project': project.slug };
+		const containerLabels: Record<string, string> = {
+			'hezo.team': teamSlug,
+			'hezo.project': project.slug,
+		};
+		// Mark containers spawned by a test run so the test harness's cleanup can scope
+		// itself to them and never delete a developer's live dev-server containers.
+		if (process.env[TEST_CONTAINERS_ENV] === '1') {
+			containerLabels[TEST_CONTAINER_LABEL_KEY] = TEST_CONTAINER_LABEL_VALUE;
+		}
 		const extraHosts = ['host.docker.internal:host-gateway'];
 
 		const env: string[] = [];

--- a/packages/server/test/agent-runner.test.ts
+++ b/packages/server/test/agent-runner.test.ts
@@ -1044,13 +1044,15 @@ describe('runAgent', () => {
 			);
 			const repoId = repoRes.rows[0].id;
 
-			// Prep runs `git …` in the container; the agent CLI exec is anything else.
-			// The mock git execs "succeed" but produce no real checkout on disk, so the
-			// worktree can't be prepared and the run must fail before the agent runs.
+			// Prep runs `git …` and `sh -c …` helpers in the container (repo sync,
+			// worktree-root mkdir/chown, run-user probe); the agent CLI exec is the
+			// runtime binary — neither `git` nor `sh`. The mock git execs "succeed" but
+			// produce no real checkout on disk, so the worktree can't be prepared and the
+			// run must fail before the agent runs.
 			let agentExecCreated = false;
 			const docker = createMockDocker({
 				execCreate: async (_id: string, opts: { Cmd: string[] }) => {
-					if (opts.Cmd[0] !== 'git') agentExecCreated = true;
+					if (opts.Cmd[0] !== 'git' && opts.Cmd[0] !== 'sh') agentExecCreated = true;
 					return 'exec-wt-fail';
 				},
 			});

--- a/packages/server/test/container-sync.test.ts
+++ b/packages/server/test/container-sync.test.ts
@@ -809,6 +809,43 @@ describe('provisionContainer broadcasting', () => {
 		expect(hostConfig.MemorySwap).toBeUndefined();
 	});
 
+	it('labels containers as test containers only when HEZO_TEST_CONTAINERS is set', async () => {
+		const project = (
+			await db.query<ProjectRow>('SELECT * FROM projects WHERE id = $1', [projectId])
+		).rows[0];
+
+		const provisionWith = async (envValue: string | undefined) => {
+			const prev = process.env.HEZO_TEST_CONTAINERS;
+			if (envValue === undefined) delete process.env.HEZO_TEST_CONTAINERS;
+			else process.env.HEZO_TEST_CONTAINERS = envValue;
+			const dataDir = mkdtempSync(join(tmpdir(), 'hezo-test-'));
+			const docker = createStubDocker({
+				imageExists: vi.fn().mockResolvedValue(false),
+				pullImage: vi.fn().mockResolvedValue(undefined),
+				createContainer: vi.fn().mockResolvedValue({ Id: 'labelled-container' }),
+				startContainer: vi.fn().mockResolvedValue(undefined),
+			});
+			try {
+				await db.query(
+					'UPDATE projects SET container_id = NULL, container_status = NULL WHERE id = $1',
+					[projectId],
+				);
+				await provisionContainer({ db, docker, dataDir }, project, 'container-sync-co');
+				return docker.createContainer.mock.calls[0][1].Labels as Record<string, string>;
+			} finally {
+				if (prev === undefined) delete process.env.HEZO_TEST_CONTAINERS;
+				else process.env.HEZO_TEST_CONTAINERS = prev;
+			}
+		};
+
+		const labelled = await provisionWith('1');
+		expect(labelled['hezo.test']).toBe('1');
+		expect(labelled['hezo.project']).toBe(project.slug);
+
+		const unlabelled = await provisionWith(undefined);
+		expect(unlabelled['hezo.test']).toBeUndefined();
+	});
+
 	it('keeps bind mounts stable on rename; container name adopts the new slug', async () => {
 		const dataDir = mkdtempSync(join(tmpdir(), 'hezo-test-'));
 		const makeMockDocker = () =>

--- a/packages/server/test/container-user.test.ts
+++ b/packages/server/test/container-user.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
 	chownToRunUser,
 	clearContainerRunUserCache,
+	mkdirInContainer,
 	resolveContainerRunUser,
 } from '../src/services/container-user';
 import type { DockerClient } from '../src/services/docker';
@@ -148,5 +149,28 @@ describe('chownToRunUser', () => {
 		await expect(
 			chownToRunUser(docker, 'cid', { name: 'node', uid: 1000, gid: 1000 }, ['/workspace']),
 		).resolves.toBeUndefined();
+	});
+});
+
+describe('mkdirInContainer', () => {
+	it('runs `mkdir -p` in-container as root for the given paths', async () => {
+		const { docker, calls } = fakeDocker({});
+		await mkdirInContainer(docker, 'cid', ['/worktrees/TO-9', '/worktrees/TO-10']);
+		const mkdir = calls.find((c) => c.Cmd?.[2]?.startsWith('mkdir -p'));
+		expect(mkdir).toBeDefined();
+		expect(mkdir?.User).toBe('root');
+		expect(mkdir?.Cmd[2]).toContain("'/worktrees/TO-9'");
+		expect(mkdir?.Cmd[2]).toContain("'/worktrees/TO-10'");
+	});
+
+	it('is a no-op with no paths', async () => {
+		const { docker, calls } = fakeDocker({});
+		await mkdirInContainer(docker, 'cid', []);
+		expect(calls.filter((c) => c.Cmd?.[2]?.startsWith('mkdir'))).toHaveLength(0);
+	});
+
+	it('never throws when the mkdir exec fails', async () => {
+		const { docker } = fakeDocker({ throwOnExec: true });
+		await expect(mkdirInContainer(docker, 'cid', ['/worktrees/TO-9'])).resolves.toBeUndefined();
 	});
 });

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -192,6 +192,17 @@ export const UpdateState = {
 } as const;
 export type UpdateState = (typeof UpdateState)[keyof typeof UpdateState];
 
+/**
+ * Docker label stamped on agent containers provisioned during a test run. The test
+ * harness scopes its container cleanup to this label so it only ever removes
+ * test-spawned containers — never a developer's running dev-server containers, which
+ * share the same `hezo-<slug>-…` name prefix. The provisioner applies the label when
+ * TEST_CONTAINERS_ENV is set in its environment.
+ */
+export const TEST_CONTAINER_LABEL_KEY = 'hezo.test';
+export const TEST_CONTAINER_LABEL_VALUE = '1';
+export const TEST_CONTAINERS_ENV = 'HEZO_TEST_CONTAINERS';
+
 export const ATTACHMENT_MAX_BYTES = 10 * 1024 * 1024;
 export const ATTACHMENT_SIGNED_URL_TTL_SECONDS = 3600;
 

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -1,10 +1,20 @@
 #!/usr/bin/env bun
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import {
+	TEST_CONTAINER_LABEL_KEY,
+	TEST_CONTAINER_LABEL_VALUE,
+	TEST_CONTAINERS_ENV,
+} from '@hezo/shared';
 import { Command } from 'commander';
 import { ensureBundles } from './ensure-bundles';
 
 const ROOT = resolve(import.meta.dir, '..');
+
+// Any server this run spawns (e.g. the Playwright e2e server) must label the
+// containers it provisions as test containers so the cleanup below can scope to
+// them. Inherited by child processes.
+process.env[TEST_CONTAINERS_ENV] = '1';
 
 const defaultConcurrency = 10;
 
@@ -251,10 +261,22 @@ async function main() {
 
 async function cleanupDockerContainers() {
 	try {
-		const ps = Bun.spawn(['docker', 'ps', '-aq', '--filter', 'name=^hezo-'], {
-			stdout: 'pipe',
-			stderr: 'pipe',
-		});
+		// Scope strictly to containers this test run provisioned (labelled by the
+		// provisioner). A bare `name=^hezo-` filter also matches a developer's live
+		// dev-server containers and would delete them.
+		const ps = Bun.spawn(
+			[
+				'docker',
+				'ps',
+				'-aq',
+				'--filter',
+				`label=${TEST_CONTAINER_LABEL_KEY}=${TEST_CONTAINER_LABEL_VALUE}`,
+			],
+			{
+				stdout: 'pipe',
+				stderr: 'pipe',
+			},
+		);
 		const ids = (await new Response(ps.stdout).text()).trim();
 		await ps.exited;
 


### PR DESCRIPTION
## Problem

A dev-server task (`TO-9`) failed with:

> cannot prepare worktree for todoAA: could not open '/worktrees/TO-9/todoAA/.git' for writing: No such file or directory

Root-caused to a chain that starts in the **test harness**, not the server:

1. **`bun run test` force-deletes dev-server containers.** `scripts/test.ts`'s cleanup ran `docker rm -f` on every container matching `name=^hezo-`. Dev containers are named `hezo-<slug>-<id8>-<rand>` — same prefix — so a test run deleted the developer's running `hezo-todo-*` / `hezo-hq-*` containers. (Tests don't even create real containers — vitest uses a stub Docker, Playwright sets `HEZO_SKIP_DOCKER=1` — so that sweep only ever hit dev containers.)
2. On the next server restart the missing containers were **reprovisioned**. Right after a reprovision, a **bind-mount propagation lag** (macOS Docker Desktop / virtiofs) meant the host-created `/worktrees/<TASK>` dir was not yet visible inside the fresh container — and `chownToRunUser` is a no-op for a root run-user, so nothing created it container-side. `git worktree add` then failed with ENOENT on the worktree path, failing the run.

Filesystem/DB state is already fully isolated (vitest → `/tmp/hezo-test-*` + in-memory PGlite; Playwright → `$TMPDIR/hezo-e2e-test`); the only shared resource was the Docker daemon, and the cleanup filter was too broad.

## Fixes

- **Scope the test container cleanup.** Stamp a `hezo.test=1` label on containers a test run provisions (`TEST_CONTAINER_LABEL_*` / `TEST_CONTAINERS_ENV` in `@hezo/shared`, applied in `provisionContainer` when the env is set by `scripts/test.ts`), and change the harness cleanup to filter on that label. Dev-server containers carry no such label, so they can never be swept.
- **Harden worktree prep.** New `mkdirInContainer` (`container-user.ts`) creates the per-task worktree root **inside the container** (`mkdir -p`) before `git worktree add`, removing the dependency on host→container bind-mount propagation and on the root-skipped chown. `ensureTaskWorktree` already self-heals dangling worktrees; this covers the empty-root race.

## Tests

- `container-user.test.ts`: `mkdirInContainer` runs `mkdir -p` in-container as root, no-ops on empty, never throws.
- `container-sync.test.ts`: `provisionContainer` labels a container `hezo.test=1` only when `HEZO_TEST_CONTAINERS` is set.
- `agent-runner.test.ts`: refined the worktree-prep failure assertion to detect the agent CLI exec specifically (prep now also issues an `sh -c mkdir` exec).

**Verified end-to-end:** running the full suite with a live dev server no longer deletes its containers (cleanup matched zero containers; `hezo-todo`/`hezo-hq` stayed up). All tiers green — server 3736, Bun-native 20, web 822, shared 98; browser 66 (2 pre-existing scroll/WebSocket flakes confirmed green on isolated re-run).

## Recovery note

The stale mount has since caught up (container→host writes propagate; the container now sees the host dirs), so the affected tasks self-heal on their next run/retry — `ensureTaskWorktree` rebuilds dangling worktrees and recreates the empty `TO-9` root against the intact `hezo/TO-9` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HyzNumKeLWLWpQebopoBzR