### PR TITLE
fix(agents): wait for deployment readiness before verifying a deployed URL

### DIFF
--- a/agents/software-development/devops-engineer.md
+++ b/agents/software-development/devops-engineer.md
@@ -38,6 +38,7 @@ Escalation: infrastructure outages → @-mention the Architect and Captain immed
 - **Do not edit application source code or tests.** Only the Engineer modifies those. You own deployment configs, CI/CD workflows, Dockerfiles, and infrastructure-as-code — those remain yours to edit. If an infrastructure change requires an application-code change, file it on the ticket and route it to `@engineer`.
 - Never deploy to production without admin approval.
 - Always test in staging first.
+- **Wait for a deployment to go live before verifying its URL — don't probe it the instant the platform API returns.** A freshly published deployment, and especially a newly created hostname, is not reachable immediately: the provider still has to finish publishing the build and provision routing, DNS, and TLS for the host, which can take anywhere from a few seconds to a few minutes. First confirm the deployment has reached the provider's ready/succeeded state (poll its deployment status), then fetch the URL with a short retry and backoff. Treat a connection-refused, DNS-resolution, or TLS error in that window as "not live yet" and keep retrying — not as a failed deploy. Only conclude the deployment failed once the provider reports a failed build or the URL is still unreachable after a reasonable retry window.
 - Keep deployment configs in version control, not manual.
 - Database migrations must be reversible when possible.
 - Monitor costs — flag unexpected cloud spending to the Captain.


### PR DESCRIPTION
## What & why

A DevOps Engineer run set up a Pages project and, immediately after wiring the deploy, probed the freshly-published site (`HEAD /`, the JS/CSS assets, `/manifest.webmanifest`, `/sw.js`). Those probes fired **before the deployment was live**, producing a burst of egress warnings:

```
<egress-proxy> egress upstream request failed {"host":"todoaa.pages.dev","port":443,"method":"HEAD","path":"/","code":"ECONNREFUSED"}
<egress-proxy> egress upstream request failed {"host":"todoaa.pages.dev","port":443,"method":"HEAD","path":"/manifest.webmanifest","code":"FailedToOpenSocket","errno":0}
```

**This was not a bug in the egress proxy.** The proxy accepted each request, terminated TLS, dialed the real upstream (`proxy.ts` `onForwardError`/`pipeUpstream`), and faithfully reported that the upstream refused the connection — then returned `502` to the agent. The hostname resolves fine to Cloudflare's anycast IPs; it simply wasn't serving yet. A newly-created deployment (and especially a newly-created hostname) isn't reachable the instant the platform API returns — the provider still has to publish the build and provision routing, DNS, and TLS for the host. The same URL now returns `HTTP/2 200`, so the deployment actually succeeded; the agent just checked too early and risked misreading a not-yet-live deploy as a failed one.

## Change

Adds one **provider-neutral** rule to the DevOps Engineer role prompt (`agents/software-development/devops-engineer.md`):

- Confirm the deployment has reached the provider's ready/succeeded state (poll deployment status) **before** fetching the URL.
- Fetch with a short retry and backoff.
- Treat a connection-refused / DNS-resolution / TLS error in that window as "not live yet" and keep retrying — not as a failed deploy.
- Only conclude failure once the provider reports a failed build or the URL is still unreachable after a reasonable retry window.

The guidance is deliberately platform-agnostic (no hosting-provider names) so it applies to any deploy target.

## Testing

- `bunx vitest run test/template-resolver.test.ts` — 79 passed (devops-engineer prompt still resolves).
- Pre-commit `turbo typecheck` + full build pass; `bun run build:agents` re-bundles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWZmoaey6LawiU5Wy8vufo

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWZmoaey6LawiU5Wy8vufo)_