### PR TITLE
fix: prevent spurious failed run on dev-server restart from worktree mount race

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -423,6 +423,21 @@ subdirectory per linked repo. For each task the runner creates a `git worktree` 
 across runs and torn down on terminal status. The working dir resolves to the designated
 repo's worktree (falling back to `/workspace`).
 
+Because Docker Desktop bind-mount propagation can lag right after a container reprovision (a
+path the host just `mkdirSync`'d briefly stats as missing inside the container), the runner
+hardens worktree prep against a transient `ENOENT`: it (i) confirms the `/worktrees/<task>`
+root is visible in-container with a bounded `mkdir -p && test -d` readiness check
+(`ensureContainerDirReady`, `services/container-user.ts`) before building any worktree, and
+(ii) retries `git worktree add` a few times when it fails with a transient mount-propagation
+signature — "could not open … for writing: No such file or directory"
+(`ensureTaskWorktreeWithRetry` + `isTransientMountError`, `git.ts`); genuine git failures
+(`not a git repository`, merge/auth errors, the `not cloned` marker) fall through and fail
+fast. Relatedly, the startup stale-mount repair (`repairStaleContainerMounts`, which rebuilds a
+container whose bind mounts went stale across a server restart) probes **both** `/workspace`
+reachability and `/worktrees` writability (a create+remove probe) in `verifyContainerWorkspace`,
+so a stale `/worktrees` is caught too — without this, a run could dispatch into a container whose
+`/worktrees` mount was not yet usable and fail worktree prep on the first attempt.
+
 **All git runs in the container — the host runs none.** Hezo's only prerequisite is Docker;
 there is no host `git`. Every repo/worktree operation (clone, fetch, `worktree add`, …) runs
 via `docker exec` in the project container (which ships git 2.51), driven from TypeScript on

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -53,7 +53,7 @@ import {
 import {
 	type ContainerRunUser,
 	chownToRunUser,
-	mkdirInContainer,
+	ensureContainerDirReady,
 	resolveContainerRunUser,
 } from './container-user';
 import { syncContainerStatus } from './containers';
@@ -62,7 +62,7 @@ import { getAgentSystemPrompt } from './documents';
 import { applyEffortToRuntime, type EffortRuntimeApplication, resolveEffort } from './effort';
 import type { EgressProxy } from './egress';
 import {
-	ensureTaskWorktree,
+	ensureTaskWorktreeWithRetry,
 	fastForwardLocalDefault,
 	fetchRepo,
 	getWorktreeHead,
@@ -1364,12 +1364,13 @@ async function prepareWorktrees(
 		const taskWorktreeRoot = join(worktreesRoot, task.identifier);
 		const containerWorktreeRoot = `${CONTAINER_WORKTREES_ROOT}/${task.identifier}`;
 		mkdirSync(taskWorktreeRoot, { recursive: true });
-		// Also create the root from inside the container. The host mkdir above may not
-		// be visible in the container yet (bind-mount propagation lag, most visibly
-		// right after a reprovision), and the chown below is skipped for a root
-		// run-user — so without this the in-container `git worktree add` can fail with
-		// ENOENT on the worktree path.
-		await mkdirInContainer(deps.docker, project.container_id, [containerWorktreeRoot]);
+		// Also create the root from inside the container and confirm it is visible
+		// there. The host mkdir above may not have propagated into the container yet
+		// (bind-mount propagation lag, most visibly right after a reprovision), and the
+		// chown below is skipped for a root run-user — so without this the in-container
+		// `git worktree add` can fail with ENOENT on the worktree path. The readiness
+		// check retries until the dir stats as present in the container's namespace.
+		await ensureContainerDirReady(deps.docker, project.container_id, containerWorktreeRoot);
 		// Give the run-user ownership so the in-container `git worktree add` (run as
 		// the run-user) can populate it. No-op when the run-user is root.
 		await chownToRunUser(deps.docker, project.container_id, runUser, [containerWorktreeRoot]);
@@ -1411,7 +1412,18 @@ async function prepareWorktrees(
 			if (ffWarn) emitSystem('stderr', `${repoName}: ${ffWarn}`);
 
 			emitSystem('stdout', `git worktree ${repoName}...`);
-			const wt = await ensureTaskWorktree(executor, repoLoc, wtLocOf(repoName), branchName);
+			const wt = await ensureTaskWorktreeWithRetry(
+				executor,
+				repoLoc,
+				wtLocOf(repoName),
+				branchName,
+				async () => {
+					// A transient bind-mount ENOENT right after a reprovision — re-assert the
+					// worktree root is visible in-container before git retries the add.
+					await ensureContainerDirReady(deps.docker, project.container_id, containerWorktreeRoot);
+					emitSystem('stderr', `git worktree ${repoName}: mount not ready, retrying`);
+				},
+			);
 			if (!wt.success) {
 				worktreeErrors.set(repo.id, wt.error ?? 'unknown');
 				emitSystem('stderr', `git worktree for ${repoName} failed: ${wt.error ?? 'unknown'}`);

--- a/packages/server/src/services/container-user.ts
+++ b/packages/server/src/services/container-user.ts
@@ -46,6 +46,10 @@ async function execCapture(
 	return { exitCode: ExitCode, stdout, stderr };
 }
 
+function delay(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 async function probe(
 	docker: DockerClient,
 	containerId: string,
@@ -131,6 +135,47 @@ export async function mkdirInContainer(
 			}`,
 		);
 	}
+}
+
+const DIR_READY_RETRIES = 5;
+const DIR_READY_DELAY_MS = 100;
+
+/**
+ * Ensure a directory exists **and is visible** inside the container, retrying to
+ * absorb bind-mount propagation lag. Right after a container (re)provision on
+ * macOS Docker Desktop, a path the host just `mkdirSync`'d — or even one a prior
+ * in-container `mkdir -p` created — can briefly stat as missing in the container's
+ * mount namespace, so a follow-on `git worktree add` fails with ENOENT. Each
+ * attempt runs `mkdir -p <path> && test -d <path>` as root: the `test -d`
+ * re-stats through the live bind, so a `mkdir` that returns 0 before the entry is
+ * visible on a later stat still loops. Best-effort: returns `false` (never
+ * throws) if the path is never confirmed, logging one warning — the git op that
+ * follows surfaces the actionable error if the path truly can't be made.
+ */
+export async function ensureContainerDirReady(
+	docker: DockerClient,
+	containerId: string,
+	containerPath: string,
+	opts: { retries?: number; delayMs?: number } = {},
+): Promise<boolean> {
+	const retries = opts.retries ?? DIR_READY_RETRIES;
+	const delayMs = opts.delayMs ?? DIR_READY_DELAY_MS;
+	const target = shSingleQuote(containerPath);
+	for (let attempt = 0; attempt < retries; attempt++) {
+		try {
+			const { exitCode } = await execCapture(
+				docker,
+				containerId,
+				`mkdir -p ${target} && test -d ${target}`,
+			);
+			if (exitCode === 0) return true;
+		} catch {
+			// A docker exec error is itself transient right after (re)provision; retry.
+		}
+		if (attempt < retries - 1) await delay(delayMs);
+	}
+	log.warn(`mkdir/verify did not confirm ${containerPath} in container after ${retries} attempts`);
+	return false;
 }
 
 /**

--- a/packages/server/src/services/containers.ts
+++ b/packages/server/src/services/containers.ts
@@ -587,11 +587,15 @@ export async function stopContainerGracefully(
 }
 
 /**
- * Verify that the container's `/workspace` bind mount is reachable from inside.
- * Docker Desktop on macOS can leave a container in a state where it inspects as
- * Running but its bind mounts have gone stale — `docker exec` then fails with
- * "current working directory is outside of container mount namespace root". Doing
- * a cheap exec catches that case where `inspectContainer` cannot.
+ * Verify that the container's `/workspace` and `/worktrees` bind mounts are
+ * reachable — and that `/worktrees` is writable — from inside. Docker Desktop on
+ * macOS can leave a container in a state where it inspects as Running but its bind
+ * mounts have gone stale: `docker exec` then fails with "current working directory
+ * is outside of container mount namespace root", or a freshly-provisioned mount is
+ * present-but-not-yet-writable. A cheap in-container probe catches both, where
+ * `inspectContainer` cannot. `/worktrees` is exercised with a create+remove
+ * because it is the mount an agent run writes first (its per-task worktree) and
+ * the one whose lag surfaces as a spurious worktree-prep failure.
  */
 export async function verifyContainerWorkspace(
 	docker: DockerClient,
@@ -599,7 +603,11 @@ export async function verifyContainerWorkspace(
 ): Promise<boolean> {
 	try {
 		const execId = await docker.execCreate(containerId, {
-			Cmd: ['ls', '/workspace'],
+			Cmd: [
+				'sh',
+				'-c',
+				'ls /workspace && d=/worktrees/.hezo-mount-probe && mkdir -p "$d" && rmdir "$d"',
+			],
 			AttachStdout: true,
 			AttachStderr: true,
 		});

--- a/packages/server/src/services/git.ts
+++ b/packages/server/src/services/git.ts
@@ -446,6 +446,64 @@ export async function ensureTaskWorktree(
 	return addTaskWorktree(executor, repo, wt, branchName);
 }
 
+const WORKTREE_PREP_RETRIES = 3;
+const WORKTREE_PREP_DELAY_MS = 250;
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * A worktree-prep git failure that looks like transient bind-mount propagation
+ * lag — the freshly-created worktree parent not yet visible in the container's
+ * mount namespace — rather than a genuine git error. Right after a container
+ * reprovision on macOS Docker Desktop the first `git worktree add` can fail with
+ * `could not open '.../.git' for writing: No such file or directory`; a retry a
+ * beat later succeeds. Deliberately narrow: real failures (`not a git
+ * repository`, merge/auth errors, and Hezo's own `not cloned` marker) fall
+ * through so they still fail fast and are never masked.
+ */
+export function isTransientMountError(error: string | undefined): boolean {
+	if (!error) return false;
+	const e = error.toLowerCase();
+	return (
+		e.includes('no such file or directory') ||
+		(e.includes('could not open') && e.includes('for writing')) ||
+		e.includes('enoent')
+	);
+}
+
+/**
+ * {@link ensureTaskWorktree} wrapped in a bounded retry for the transient
+ * mount-propagation ENOENT above. On a transient failure it waits, invokes
+ * `onRetry` (the caller re-asserts the worktree parent is visible in-container
+ * and emits a run-log breadcrumb), then retries. A non-transient failure returns
+ * immediately (fail fast); a transient that never clears returns the original
+ * error after the cap (surfaced, not swallowed).
+ */
+export async function ensureTaskWorktreeWithRetry(
+	executor: GitExecutor,
+	repo: RepoLoc,
+	wt: WorktreeLoc,
+	branchName: string,
+	onRetry: () => Promise<void>,
+	opts: { retries?: number; delayMs?: number } = {},
+): Promise<{ success: boolean; created: boolean; error?: string }> {
+	const retries = opts.retries ?? WORKTREE_PREP_RETRIES;
+	const gap = opts.delayMs ?? WORKTREE_PREP_DELAY_MS;
+	let result = await ensureTaskWorktree(executor, repo, wt, branchName);
+	for (
+		let attempt = 1;
+		attempt < retries && !result.success && isTransientMountError(result.error);
+		attempt++
+	) {
+		await sleep(gap);
+		await onRetry();
+		result = await ensureTaskWorktree(executor, repo, wt, branchName);
+	}
+	return result;
+}
+
 export async function pruneWorktrees(executor: GitExecutor, repo: RepoLoc): Promise<void> {
 	await executor.exec(['worktree', 'prune', '--expire', 'now'], {
 		cwd: repo.containerPath,

--- a/packages/server/test/container-dir-ready.test.ts
+++ b/packages/server/test/container-dir-ready.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { ensureContainerDirReady } from '../src/services/container-user';
+import type { DockerClient } from '../src/services/docker';
+
+/**
+ * A docker mock that scripts a sequence of exit codes for the readiness probe
+ * (`mkdir -p <p> && test -d <p>`): `exitCodes[i]` is returned for the i-th exec,
+ * and once exhausted the last code repeats. Records every exec script so a test
+ * can assert the probe shape and the exact attempt count. `throwOnExec` makes
+ * `execCreate` throw, exercising the swallow-and-retry path.
+ */
+function scriptedDocker(opts: { exitCodes?: number[]; throwOnExec?: boolean }) {
+	const exitCodes = opts.exitCodes ?? [0];
+	const scripts: string[] = [];
+	const byId = new Map<string, string>();
+	let seq = 0;
+
+	const docker = {
+		execCreate: async (_id: string, config: { Cmd: string[] }) => {
+			if (opts.throwOnExec) throw new Error('docker unreachable');
+			const execId = `exec-${seq++}`;
+			scripts.push(config.Cmd[2] ?? '');
+			byId.set(execId, config.Cmd[2] ?? '');
+			return execId;
+		},
+		execStart: async () => ({ stdout: '', stderr: '' }),
+		execInspect: async (execId: string) => {
+			const idx = Number(execId.split('-')[1]);
+			const code = idx < exitCodes.length ? exitCodes[idx] : exitCodes[exitCodes.length - 1];
+			return { ExitCode: code, Running: false, Pid: 0 };
+		},
+	} as unknown as DockerClient;
+
+	return { docker, scripts };
+}
+
+describe('ensureContainerDirReady', () => {
+	it('confirms on the first attempt when the dir is already visible (no wasted retries)', async () => {
+		const { docker, scripts } = scriptedDocker({ exitCodes: [0] });
+		const ok = await ensureContainerDirReady(docker, 'cid', '/worktrees/TO-1', {
+			retries: 3,
+			delayMs: 0,
+		});
+		expect(ok).toBe(true);
+		expect(scripts).toHaveLength(1); // one exec on the happy path — zero added latency
+		// The probe creates AND re-stats the path so a not-yet-visible mkdir still loops.
+		expect(scripts[0]).toContain('mkdir -p');
+		expect(scripts[0]).toContain('test -d');
+		expect(scripts[0]).toContain("'/worktrees/TO-1'");
+	});
+
+	it('retries a transient miss and returns true as soon as the dir appears', async () => {
+		// exit 1, 1, 0 — the mount settles on the third probe.
+		const { docker, scripts } = scriptedDocker({ exitCodes: [1, 1, 0] });
+		const ok = await ensureContainerDirReady(docker, 'cid', '/worktrees/TO-2', {
+			retries: 5,
+			delayMs: 0,
+		});
+		expect(ok).toBe(true);
+		expect(scripts).toHaveLength(3); // stopped the instant it was confirmed
+	});
+
+	it('returns false (never throws) after exactly `retries` attempts when never confirmed', async () => {
+		const { docker, scripts } = scriptedDocker({ exitCodes: [1] });
+		const ok = await ensureContainerDirReady(docker, 'cid', '/worktrees/TO-3', {
+			retries: 3,
+			delayMs: 0,
+		});
+		expect(ok).toBe(false);
+		expect(scripts).toHaveLength(3); // bounded — never loops past the cap
+	});
+
+	it('returns false (never throws) when the docker exec itself fails every time', async () => {
+		const { docker } = scriptedDocker({ throwOnExec: true });
+		await expect(
+			ensureContainerDirReady(docker, 'cid', '/worktrees/TO-4', { retries: 3, delayMs: 0 }),
+		).resolves.toBe(false);
+	});
+});

--- a/packages/server/test/containers-recovery.test.ts
+++ b/packages/server/test/containers-recovery.test.ts
@@ -8,6 +8,7 @@ import {
 	type ContainerDeps,
 	failProjectRuns,
 	requeueContainerKilledRuns,
+	verifyContainerWorkspace,
 	wakeAgentsWithPendingWork,
 } from '../src/services/containers';
 import { LogStreamBroker } from '../src/services/log-stream-broker';
@@ -284,5 +285,44 @@ describe('wakeAgentsWithPendingWork', () => {
 			orig.rows[0].status,
 			taskId,
 		]);
+	});
+});
+
+describe('verifyContainerWorkspace', () => {
+	// A docker whose single exec captures the probe Cmd and returns a scripted exit
+	// code — extends createStubDocker per the inline-mock rule.
+	function probeDocker(exitCode: number) {
+		let captured: string[] = [];
+		const docker = createStubDocker({
+			execCreate: async (_id: string, config: { Cmd: string[] }) => {
+				captured = config.Cmd;
+				return 'exec-1';
+			},
+			execInspect: async () => ({ ExitCode: exitCode, Running: false, Pid: 0 }),
+		});
+		return { docker, cmd: () => captured };
+	}
+
+	it('probes both /workspace and /worktrees writability and passes on exit 0', async () => {
+		const { docker, cmd } = probeDocker(0);
+		expect(await verifyContainerWorkspace(docker, 'cid')).toBe(true);
+		const script = cmd()[2] ?? '';
+		expect(script).toContain('/workspace');
+		// A stale /worktrees is now caught too — not just /workspace.
+		expect(script).toContain('/worktrees');
+	});
+
+	it('fails (→ triggers a rebuild) when the probe exits non-zero', async () => {
+		const { docker } = probeDocker(1);
+		expect(await verifyContainerWorkspace(docker, 'cid')).toBe(false);
+	});
+
+	it('returns false (never throws) when the exec itself fails', async () => {
+		const docker = createStubDocker({
+			execCreate: async () => {
+				throw new Error('current working directory is outside of container mount namespace root');
+			},
+		});
+		await expect(verifyContainerWorkspace(docker, 'cid')).resolves.toBe(false);
 	});
 });

--- a/packages/server/test/git.test.ts
+++ b/packages/server/test/git.test.ts
@@ -7,9 +7,11 @@ import {
 	cloneRepo,
 	createWorktree,
 	ensureTaskWorktree,
+	ensureTaskWorktreeWithRetry,
 	fastForwardLocalDefault,
 	fetchRepo,
 	getRemoteDefaultBranch,
+	isTransientMountError,
 	mergeDefaultIntoWorktree,
 	pruneWorktrees,
 	type RepoLoc,
@@ -448,5 +450,126 @@ describe('mergeDefaultIntoWorktree catches a resumed worktree up to trunk', () =
 		expect(sha(worktreePath)).toBe(agentTip);
 		expect(execSync('git status --porcelain', { cwd: worktreePath }).toString().trim()).toBe('');
 		expect(readFileSync(join(worktreePath, 'conflict.txt'), 'utf-8')).not.toContain('<<<<<<<');
+	});
+});
+
+// The first `git worktree add` right after a container reprovision can fail with a
+// transient bind-mount ENOENT — the freshly-created worktree parent not yet visible
+// in the container's mount namespace. ensureTaskWorktreeWithRetry re-asserts the dir
+// (via onRetry) and retries, turning what today surfaces as a whole failed run into
+// an in-run retry — while a genuine git failure still fails fast and is never masked.
+describe('ensureTaskWorktreeWithRetry retries transient mount ENOENT', () => {
+	// Wraps a real HostGitExecutor, failing the first `failFirst` `worktree add`
+	// calls with a scripted stderr and delegating everything else to real git.
+	class FlakyWorktreeAdd implements GitExecutor {
+		addCalls = 0;
+		constructor(
+			private readonly inner: GitExecutor,
+			private readonly failFirst: number,
+			private readonly stderr: string,
+		) {}
+		async exec(args: string[], opts: GitExecOpts): Promise<GitExecResult> {
+			if (args[0] === 'worktree' && args[1] === 'add') {
+				this.addCalls++;
+				if (this.addCalls <= this.failFirst) {
+					return { exitCode: 128, stdout: '', stderr: this.stderr };
+				}
+			}
+			return this.inner.exec(args, opts);
+		}
+	}
+
+	const ENOENT_STDERR =
+		"fatal: could not open '/worktrees/TO-10/todos/.git' for writing: No such file or directory";
+
+	function freshClone(name: string): { repoDir: string; worktreePath: string } {
+		const projectDir = join(testDir, name);
+		const repoDir = join(projectDir, 'workspace', 'todos');
+		const worktreePath = join(projectDir, 'worktrees', 'TO-10', 'todos');
+		mkdirSync(join(projectDir, 'workspace'), { recursive: true });
+		run(`git clone ${bareRepoDir} ${repoDir}`);
+		configure(repoDir, 'Test');
+		return { repoDir, worktreePath };
+	}
+
+	it('recovers when the first worktree add fails transiently, then succeeds', async () => {
+		const { repoDir, worktreePath } = freshClone('retry-transient');
+		const flaky = new FlakyWorktreeAdd(exec, 1, ENOENT_STDERR);
+		let retries = 0;
+		const res = await ensureTaskWorktreeWithRetry(
+			flaky,
+			repoLoc(repoDir),
+			wtLoc(worktreePath),
+			'hezo/TO-10',
+			async () => {
+				retries++;
+			},
+			{ retries: 3, delayMs: 0 },
+		);
+		expect(res.success).toBe(true);
+		expect(res.created).toBe(true);
+		expect(retries).toBe(1); // one onRetry (re-assert dir) before the successful add
+		expect(flaky.addCalls).toBe(2); // failed once, then a real add succeeded
+		expect(existsSync(join(worktreePath, '.git'))).toBe(true);
+	});
+
+	it('does not retry a genuine (non-transient) failure — fails fast, not masked', async () => {
+		const { repoDir, worktreePath } = freshClone('retry-genuine');
+		const flaky = new FlakyWorktreeAdd(exec, 99, 'fatal: not a git repository');
+		let retries = 0;
+		const res = await ensureTaskWorktreeWithRetry(
+			flaky,
+			repoLoc(repoDir),
+			wtLoc(worktreePath),
+			'hezo/TO-10',
+			async () => {
+				retries++;
+			},
+			{ retries: 3, delayMs: 0 },
+		);
+		expect(res.success).toBe(false);
+		expect(res.error).toContain('not a git repository');
+		expect(retries).toBe(0); // predicate rejected it — no retries
+		expect(flaky.addCalls).toBe(1); // exactly one attempt, no wasted work
+	});
+
+	it('surfaces the original ENOENT after the bounded cap when the mount never settles', async () => {
+		const { repoDir, worktreePath } = freshClone('retry-stuck');
+		const flaky = new FlakyWorktreeAdd(exec, 99, ENOENT_STDERR);
+		let retries = 0;
+		const res = await ensureTaskWorktreeWithRetry(
+			flaky,
+			repoLoc(repoDir),
+			wtLoc(worktreePath),
+			'hezo/TO-10',
+			async () => {
+				retries++;
+			},
+			{ retries: 3, delayMs: 0 },
+		);
+		expect(res.success).toBe(false);
+		expect(res.error).toContain('No such file or directory'); // surfaced, not swallowed
+		expect(retries).toBe(2); // retries - 1 onRetry invocations
+		expect(flaky.addCalls).toBe(3); // exactly `retries` attempts, bounded
+	});
+});
+
+describe('isTransientMountError', () => {
+	it('matches the bind-mount ENOENT signatures', () => {
+		expect(
+			isTransientMountError(
+				"fatal: could not open '/worktrees/TO-1/r/.git' for writing: No such file or directory",
+			),
+		).toBe(true);
+		expect(isTransientMountError('fatal: No such file or directory')).toBe(true);
+		expect(isTransientMountError('open /worktrees/x: ENOENT')).toBe(true);
+	});
+
+	it('rejects genuine git failures and Hezo markers so they fail fast', () => {
+		expect(isTransientMountError('fatal: not a git repository')).toBe(false);
+		expect(isTransientMountError('CONFLICT (add/add): Merge conflict in conflict.txt')).toBe(false);
+		expect(isTransientMountError('repo is not cloned')).toBe(false);
+		expect(isTransientMountError(undefined)).toBe(false);
+		expect(isTransientMountError('')).toBe(false);
 	});
 });


### PR DESCRIPTION
## Problem

Every time the dev server restarts, there is **one failed agent run immediately followed by a run that succeeds**. The failed run's log is always the same:

```
(syncing repos...)
git fetch todoAA done
git worktree todoAA...
git worktree for todoAA failed: Preparing worktree (new branch 'hezo/TO-11')
fatal: could not open '/worktrees/TO-11/todoAA/.git' for writing: No such file or directory
[runner] cannot prepare worktree for todoAA: ...
```

This is noise on every restart and erodes trust in the run history.

## Root cause

On startup, `repairStaleContainerMounts` probes each running container's `/workspace` (`verifyContainerWorkspace`); macOS Docker Desktop can leave a container inspecting as `Running` while its bind mounts are stale, so the probe fails and the container is rebuilt (`rebuildContainer` → `provisionContainer`). Provisioning marks the container `Running` and, at the end, calls `wakeAgentsWithPendingWork`, so a run dispatches **within seconds** of the rebuild.

But the freshly-reprovisioned `/worktrees` bind mount can still be settling (Docker Desktop gRPC-FUSE/virtiofs consistency lag between the host `mkdirSync` and a separate in-container `docker exec`). The first `git worktree add` then hits `ENOENT` — the worktree parent isn't yet visible in the container's mount namespace — and the run fails. The next scheduled wakeup (~5s later) succeeds once the mount settles. Net effect: a spurious failed run on every restart.

The existing mitigation (a fire-and-forget in-container `mkdir`) is at the right spot but swallows failures and never verifies visibility, so it doesn't cover the lag; and `verifyContainerWorkspace` never checked `/worktrees`.

## Fix

Make worktree preparation resilient to the transient mount-propagation `ENOENT` so the run never spuriously fails, while keeping genuine failures fast and visible.

- **`ensureContainerDirReady`** (`container-user.ts`) — a bounded `mkdir -p && test -d` readiness check that retries until the worktree root is confirmed visible in-container. Replaces the fire-and-forget `mkdirInContainer` call in `prepareWorktrees`.
- **`ensureTaskWorktreeWithRetry` + `isTransientMountError`** (`git.ts`) — retries `git worktree add` a few times, but **only** on the transient mount-`ENOENT` signature (`could not open … for writing: No such file or directory` / `ENOENT`). Genuine failures (`not a git repository`, merge/auth errors, Hezo's own `not cloned` marker) fall through and fail fast — they are never masked. On each retry the runner re-asserts the worktree root and emits a `mount not ready, retrying` breadcrumb to the run log.
- **`verifyContainerWorkspace`** (`containers.ts`) — now probes `/worktrees` writability (a create+remove probe) in addition to `ls /workspace`, so the startup stale-mount repair also catches a stale `/worktrees`.

Latency: **zero on the happy path** (both checks succeed on the first attempt); worst case ~1s, bounded, far under the 5s heartbeat interval.

## Testing

- `packages/server/test/container-dir-ready.test.ts` (new) — readiness gate: confirms on first attempt (no wasted retries), retries a transient miss and stops the instant it settles, returns `false` (never throws) after the bounded cap, and survives a throwing exec.
- `packages/server/test/git.test.ts` — retry regression against a real `HostGitExecutor` wrapped to fail the first `worktree add`: recovers and creates the worktree; a genuine failure is **not** retried (exactly one attempt); an unclearing transient surfaces the original error after exactly `retries` attempts. Plus `isTransientMountError` predicate cases.
- `packages/server/test/containers-recovery.test.ts` — `verifyContainerWorkspace` now probes both `/workspace` and `/worktrees`, fails closed on a non-zero probe, and never throws.
- Full server suite green (3743 passed; the one failing case is an unrelated environment gap — `ssh-keygen` not installed in the sandbox). `typecheck` and `check` clean.

## Docs

- `.dev/architecture.md` "Containers & worktrees" — documents the readiness gate, the transient-`ENOENT` retry, and the extended `/worktrees` probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CSBLHdvLv86CWmQwW31cME

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSBLHdvLv86CWmQwW31cME)_