### PR TITLE
fix(web): relabel misleading "Open tasks" task filter summary

### DIFF
--- a/packages/web/src/components/task-list.tsx
+++ b/packages/web/src/components/task-list.tsx
@@ -275,7 +275,7 @@ export function TaskList({ projectId }: TaskListProps) {
 	const statusLabel: string | null = (() => {
 		if (statusValues.length === 0) return 'No statuses';
 		if (statusValues.length === ALL_STATUSES.length) return 'All statuses';
-		if (isDefaultTodoSelection(statusValues)) return 'Open tasks';
+		if (isDefaultTodoSelection(statusValues)) return 'Open & done';
 		if (statusValues.length === 1) return `Status: ${formatTaskStatus(statusValues[0])}`;
 		return `${statusValues.length} statuses`;
 	})();

--- a/packages/web/test/task-list-filter-persistence.test.tsx
+++ b/packages/web/test/task-list-filter-persistence.test.tsx
@@ -148,6 +148,6 @@ test('one project does not inherit another project filters', async () => {
 
 	// The collapsed summary reflects the default selection, not Alpha's.
 	const summary = await findByTestId('task-filter-toggle');
-	await waitFor(() => expect(summary.textContent).toContain('Open tasks'));
+	await waitFor(() => expect(summary.textContent).toContain('Open & done'));
 	expect(summary.textContent).not.toContain('Status: Done');
 });


### PR DESCRIPTION
## Problem

The task-list filter bar's collapsed summary showed **"Open tasks"** for the default status selection — but that default view visibly includes completed (`done`) tasks in the bottom "Done" section. The label was misleading: the filter said "Open tasks" while done tasks were right there on screen.

## Cause

`DEFAULT_TODO_STATUSES` in `packages/web/src/components/task-list.tsx` deliberately includes `TaskStatus.Done` so finished work surfaces in its own "Done" section (this is intended behavior). The `statusLabel` helper, however, labeled that exact selection `'Open tasks'`, which doesn't reflect the included done tasks.

## Fix

Relabel the default selection from **"Open tasks"** to **"Open & done"**, accurately describing what the default view shows (open work + completed tasks; `cancelled` remains hidden unless explicitly filtered in). No behavioral change to which tasks are displayed — only the summary text.

## Tests

- Updated `task-list-filter-persistence.test.tsx` assertion to expect the new label.
- `bunx vitest run test/task-list-filter-persistence.test.tsx` — 2 passed.
- `bunx vitest run test/task-list.test.tsx` — 11 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqTZKivY4XxxiH4kjnUceB)_