### PR TITLE
feat(web): move new-goal affordance to a right-aligned + button in the header

### DIFF
--- a/packages/web/src/components/goals-list.tsx
+++ b/packages/web/src/components/goals-list.tsx
@@ -273,6 +273,17 @@ export function GoalsList({ projectId }: GoalsListProps) {
 					</HelpDialog>
 					<ViewFilter view={view} onChange={setView} />
 				</div>
+				{view === 'active' && (
+					<Button
+						size="sm"
+						onClick={() => setCreateOpen(true)}
+						data-testid="goals-new-goal"
+						aria-label="New goal"
+						title="New goal"
+					>
+						<Plus className="w-4 h-4" />
+					</Button>
+				)}
 			</div>
 
 			{goals.length === 0 ? (
@@ -281,19 +292,6 @@ export function GoalsList({ projectId }: GoalsListProps) {
 				</div>
 			) : (
 				<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-					{/* An add-goal card sits inline with the goals so the affordance is hard to miss. */}
-					{view === 'active' && (
-						<button
-							type="button"
-							onClick={() => setCreateOpen(true)}
-							data-testid="goals-new-goal"
-							aria-label="New goal"
-							className="flex min-h-[132px] flex-col items-center justify-center gap-2 rounded-md border border-dashed border-border bg-surface p-4 text-text-3 transition-colors hover:border-border-strong hover:bg-surface-2 hover:text-text-1"
-						>
-							<Plus className="h-5 w-5" />
-							<span className="text-sm font-medium">New goal</span>
-						</button>
-					)}
 					{goals.map((goal) => (
 						<GoalPanel key={goal.id} projectId={projectId} goal={goal} onEdit={setEditingGoal} />
 					))}

--- a/packages/web/test/goals.test.tsx
+++ b/packages/web/test/goals.test.tsx
@@ -316,7 +316,7 @@ test('the goal run feed hides the status summary until expanded, keeping task ch
 	await findByText(createdIdentifier);
 });
 
-test('the New goal card sits in the goals grid and opens the create dialog', async () => {
+test('the New goal button sits on the Goals header line and opens the create dialog', async () => {
 	let projectSlug = '';
 	const { findByTestId, findByText, user, router } = await renderApp({
 		initialPath: '/',
@@ -324,7 +324,7 @@ test('the New goal card sits in the goals grid and opens the create dialog', asy
 			const ws = await seedWorkspace();
 			const project = await seedProject(ws, { name: 'Add Card Demo' });
 			projectSlug = project.slug;
-			// A goal already exists, so the grid (with the inline add-card) renders, not the hero.
+			// A goal already exists, so the list header (with the add button) renders, not the hero.
 			await seedGoal(ws, project, { title: 'Ship it', measurement: 'shipped' });
 		},
 	});
@@ -334,10 +334,10 @@ test('the New goal card sits in the goals grid and opens the create dialog', asy
 		params: { projectId: projectSlug },
 	});
 
-	// The add affordance is a card in the list (same testid the header button used to carry).
-	const addCard = await findByTestId('goals-new-goal', undefined, { timeout: 10_000 });
-	expect(addCard.textContent).toContain('New goal');
-	await user.click(addCard);
+	// The add affordance is a small "+" button right-aligned on the Goals header line.
+	const addButton = await findByTestId('goals-new-goal', undefined, { timeout: 10_000 });
+	expect(addButton.getAttribute('aria-label')).toBe('New goal');
+	await user.click(addButton);
 	await findByText('Create Goal');
 });
 


### PR DESCRIPTION
## Summary

Replaces the inline dashed "New goal" card in the goals grid with a small `+` icon button placed on the **Goals** header line, right-aligned. This restores the header add-button affordance that the goals list originally carried, so it now shows consistently on both mobile and desktop.

## Changes

- `packages/web/src/components/goals-list.tsx`
  - Removed the dashed "New goal" card that sat inline in the goals grid.
  - Added a small `+` icon button (`size="sm"`, `aria-label`/`title` "New goal") to the existing `justify-between` header row so it sits on the same line as the **Goals** label, right-aligned. Shown only on the active view.
- `packages/web/test/goals.test.tsx`
  - Updated the corresponding test to assert on the header `+` button (via its `aria-label`) instead of the removed inline card. It still verifies the button opens the create-goal dialog.

The first-run hero empty state (with its own "Create Goal" CTA) and the `goals-new-goal` test id are unchanged, so existing coverage keeps working.

## Testing

- `bunx vitest run test/goals.test.tsx` — 12/12 pass
- `bunx biome check` — clean
- Pre-push hook ran `turbo typecheck` + full build — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TVdhewpqzY74Kz6qXj2cw4)_