### PR TITLE
fix(web): stop mobile shell from remounting on background status refetch

### DIFF
--- a/packages/web/src/routes/__root.tsx
+++ b/packages/web/src/routes/__root.tsx
@@ -43,7 +43,7 @@ function Spinner() {
 }
 
 function AppShell() {
-	const { data: status, isPending, isFetching, isError, error, refetch } = useStatus();
+	const { data: status, isPending, isError, error, refetch } = useStatus();
 	const navigate = useNavigate();
 
 	useEffect(() => {
@@ -58,7 +58,13 @@ function AppShell() {
 		return <StartingScreen phase={status.phase} message={status.message} detail={status.detail} />;
 	}
 
-	if (isPending || isFetching) return <Spinner />;
+	// Only the FIRST load (no status yet) shows the full-screen spinner. Background
+	// refetches — notably React Query's refetch-on-reconnect, which fires on every
+	// mobile network blip (radio waking on app-switch, cell↔wifi handoffs, signal
+	// dips) — must NOT unmount the shell, or the whole app blanks to a spinner and
+	// remounts, which reads as a spontaneous full-page refresh. `isPending` already
+	// covers the initial load and the retry-while-no-data window.
+	if (isPending) return <Spinner />;
 
 	if (isError || !status || !status.masterKeyState) {
 		const message =

--- a/test/browser/status-refetch-no-remount.spec.ts
+++ b/test/browser/status-refetch-no-remount.spec.ts
@@ -1,0 +1,58 @@
+// Testing decision tree, point 5 (real network/WebSocket reconnect behaviour):
+// this reproduces a mobile-only symptom that needs genuine `offline`→`online`
+// transitions (which flip `navigator.onLine` and fire the browser events React
+// Query's onlineManager listens to) plus observation of the app tree
+// mounting/unmounting across an in-flight fetch window. happy-dom can neither
+// fire those transitions nor model the reconnect refetch, so it lives here.
+//
+// The bug: AppShell (`packages/web/src/routes/__root.tsx`) gated its full-screen
+// spinner on `isFetching`, which is true during ANY `useStatus()` fetch — not
+// just the first load. `useStatus` has `staleTime: 0` and inherits React Query's
+// default `refetchOnReconnect: true`, so every network blip (constant on mobile:
+// radio sleep on app-switch, cell↔wifi handoffs, signal dips) refetched status,
+// flipped `isFetching`, and unmounted the whole `<SocketProvider>/<ShellLayout>`
+// tree behind the spinner — which reads as a spontaneous full-page refresh. The
+// fix gates the spinner on `isPending` (initial load only); background refetches
+// must keep the shell mounted.
+
+import { expect, test } from './fixtures';
+
+test('does not blank the shell to a spinner when status refetches on reconnect', async ({
+	sharedPage,
+	sharedWorkspace,
+}) => {
+	const page = sharedPage;
+	const context = page.context();
+
+	// Load the shell fully first so the initial status fetch is already resolved —
+	// only a *background* refetch should be under test.
+	await page.goto(`/projects/${sharedWorkspace.projectSlug}/tasks`);
+	const contentWell = page.getByTestId('content-well');
+	await expect(contentWell).toBeVisible({ timeout: 20000 });
+
+	// Hold the reconnect-triggered status refetch in flight long enough to observe
+	// whether the shell stays mounted. Only added now, so the initial load above
+	// wasn't delayed.
+	await page.route('**/api/status', async (route) => {
+		await new Promise((r) => setTimeout(r, 2500));
+		await route.continue();
+	});
+
+	// A real offline→online transition: `navigator.onLine` flips and the browser
+	// fires `offline` then `online`, exactly the mobile network blip. React Query's
+	// onlineManager reacts to `online` and, because the status query is stale and
+	// refetch-on-reconnect is on, refetches it — the request our route now delays.
+	const statusRefetch = page.waitForRequest(
+		(req) => req.url().includes('/api/status') && req.method() === 'GET',
+		{ timeout: 15000 },
+	);
+	await context.setOffline(true);
+	await context.setOffline(false);
+	await statusRefetch;
+
+	// The status refetch is now in flight and stays so for ~2.5s. Before the fix
+	// the shell had already been replaced by the full-screen spinner for that whole
+	// window (content-well detached); after the fix it stays mounted. A short
+	// timeout keeps this assertion inside the in-flight window.
+	await expect(contentWell).toBeVisible({ timeout: 1500 });
+});


### PR DESCRIPTION
## Problem

On mobile, users reported the whole page spontaneously "refreshing" every now and then while doing nothing — scroll position lost, everything reloading. It only happened on production accessed from a phone, never on desktop dev.

## Root cause

It wasn't a true `window.location.reload()` (the only one, in `update-restart-overlay.tsx`, requires an explicit "Install & restart" click). It was a **full remount of the app tree** that *looks* like a reload.

`AppShell` (`packages/web/src/routes/__root.tsx`) gated its full-screen spinner on `isFetching`:

```tsx
if (isPending || isFetching) return <Spinner />;
```

`isFetching` is true during **any** `useStatus()` fetch, not just the first load. And `useStatus` (`packages/web/src/hooks/use-status.ts`) sets `staleTime: 0` while inheriting React Query's default `refetchOnReconnect: true` (the global client in `lib/query-client.ts` only disables `refetchOnWindowFocus`). So:

1. A mobile network blip fires the browser `online` event.
2. React Query refetches the (always-stale) status query → `isFetching` flips true.
3. `AppShell` returns `<Spinner />`, unmounting the entire `<SocketProvider>/<ShellLayout>` subtree.
4. The refetch resolves → everything remounts: WebSocket reconnects, every query re-fetches, scroll resets.

Mobile fires `online`/reconnect constantly (radio sleeping on app-switch and waking on return, cell↔wifi handoffs, signal dips); desktop-on-localhost essentially never does — which is exactly why it was mobile-only.

## Fix

Gate the spinner on `isPending` (initial load / retry-while-no-data window) instead of `isFetching`. Background status refetches now keep the already-rendered shell mounted. A refetch that resolves to a locked/unset master-key state (e.g. after a server restart) still renders the gate via the existing downstream branches — just without the intermediate full-tree flash.

## Testing

- New Playwright spec `test/browser/status-refetch-no-remount.spec.ts` drives a real `offline`→`online` transition with a delayed `/api/status` response and asserts the shell content stays mounted through the in-flight reconnect refetch. Verified it **fails** against the old `isFetching` code and **passes** with the fix.
- Full browser suite (serial + parallel projects) green; representative web component test green; typecheck and biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wn6AANe6jQRLZdTFTnEbN4)_