### PR TITLE
fix(web): hide project-menu "+" chips on mobile

### DIFF
--- a/packages/web/src/components/sidebar-nav.tsx
+++ b/packages/web/src/components/sidebar-nav.tsx
@@ -23,8 +23,11 @@ interface SidebarNavItem {
 
 // A small bordered "+" chip, used both as an inline suffix to a row label (Tasks)
 // and a section title (Team). Round border with padding so it reads as a button.
+// Hidden on mobile (`<md`): the drawer's tap targets are too easy to hit by
+// accident, so the "+" only appears from tablet up. Mobile users create tasks via
+// the floating new-task button and hire from the Team page's "Hire agent" button.
 const ADD_CHIP_CLASSES =
-	'inline-flex shrink-0 items-center rounded-md border border-border p-0.5 text-text-3 transition-colors hover:border-border-strong hover:bg-surface-2 hover:text-text-1 cursor-pointer';
+	'hidden md:inline-flex shrink-0 items-center rounded-md border border-border p-0.5 text-text-3 transition-colors hover:border-border-strong hover:bg-surface-2 hover:text-text-1 cursor-pointer';
 
 function ItemAction({ action }: { action: SidebarNavItemAction }) {
 	return (

--- a/test/browser/floating-new-task.mobile.spec.ts
+++ b/test/browser/floating-new-task.mobile.spec.ts
@@ -88,10 +88,13 @@ test.describe('Floating new-task button responsiveness', () => {
 		await expect(drawer.getByTestId('project-sidebar-new-task')).toBeHidden();
 		await expect(drawer.getByRole('button', { name: 'Hire a new agent' })).toBeHidden();
 
-		// --- Desktop: the persistent menu shows both chips. ---
+		// --- Desktop: the persistent menu shows both chips. Scope to the persistent
+		// sidebar (content-well): the drawer opened above stays mounted (just
+		// `lg:hidden`), so the project menu — and its chips' testids — exist twice. ---
 		await page.setViewportSize({ width: 1280, height: 900 });
-		await expect(page.getByTestId('project-sidebar-new-task')).toBeVisible();
-		await expect(page.getByRole('button', { name: 'Hire a new agent' })).toBeVisible();
+		const persistentMenu = page.getByTestId('content-well');
+		await expect(persistentMenu.getByTestId('project-sidebar-new-task')).toBeVisible();
+		await expect(persistentMenu.getByRole('button', { name: 'Hire a new agent' })).toBeVisible();
 	});
 
 	test('the filter bar and its icon create button share one row on mobile', async ({

--- a/test/browser/floating-new-task.mobile.spec.ts
+++ b/test/browser/floating-new-task.mobile.spec.ts
@@ -66,6 +66,34 @@ test.describe('Floating new-task button responsiveness', () => {
 		await expect(page.getByRole('heading', { name: 'Create Task' })).toBeVisible();
 	});
 
+	test('project-menu "+" chips (Tasks, Team) are hidden on mobile, shown on desktop', async ({
+		page,
+		sharedWorkspace,
+	}) => {
+		const { token } = sharedWorkspace;
+		const project = await createProjectAndClearPlanning(page, '', token, {
+			name: uniqueName('Menu Plus'),
+			description: 'E2E project-menu plus chips.',
+		});
+
+		// --- Mobile: open the nav drawer; the "+" chips are too easy to fat-finger,
+		// so they're `hidden md:inline-flex` — present in the DOM but not visible. ---
+		await page.setViewportSize({ width: 375, height: 800 });
+		await page.goto(`/projects/${project.slug}/tasks`);
+		await waitForPageLoad(page);
+
+		await page.getByTestId('mobile-nav-toggle').click();
+		const drawer = page.getByTestId('mobile-nav-drawer');
+		await expect(drawer).toBeVisible();
+		await expect(drawer.getByTestId('project-sidebar-new-task')).toBeHidden();
+		await expect(drawer.getByRole('button', { name: 'Hire a new agent' })).toBeHidden();
+
+		// --- Desktop: the persistent menu shows both chips. ---
+		await page.setViewportSize({ width: 1280, height: 900 });
+		await expect(page.getByTestId('project-sidebar-new-task')).toBeVisible();
+		await expect(page.getByRole('button', { name: 'Hire a new agent' })).toBeVisible();
+	});
+
 	test('the filter bar and its icon create button share one row on mobile', async ({
 		page,
 		sharedWorkspace,


### PR DESCRIPTION
## Summary

On mobile the project menu's two inline "+" chips — **New task** (next to Tasks) and **Hire a new agent** (next to Team) — sit right on top of the Tasks/Team tap targets in the nav drawer, making them easy to hit by accident.

This makes the shared add-chip class `hidden md:inline-flex`, so both chips only render from tablet (`md`, ≥768px) up. Since both project-menu plus buttons are the only consumers of that class, the change is centralized in `sidebar-nav.tsx`.

Mobile users lose nothing:
- **Task creation** stays on the floating bottom-left "+" (`FloatingNewTaskButton`, mobile/tablet only).
- **Hiring** is reachable from the Team page's always-on **Hire agent** button (`agents/index.tsx`), which is shown for all screen types and drives the existing hire flow (`/projects/$projectId/agents/hire`).

## Changes

- `packages/web/src/components/sidebar-nav.tsx` — `ADD_CHIP_CLASSES` is now `hidden md:inline-flex` (was `inline-flex`), with a comment explaining the mobile rationale.
- `test/browser/floating-new-task.mobile.spec.ts` — new Playwright test asserting the two chips are hidden in the mobile drawer (375px) and visible in the desktop sidebar (1280px).

## Testing

- `packages/web` component tests: `sidebar-nav-branches.test.tsx` (12) and `floating-new-task.test.tsx` (5) pass.
- Typecheck + biome clean on changed files.
- The visibility change is viewport-conditional CSS, so it's covered by the new Playwright test (happy-dom can't run media queries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MhfVXCMAKBMbgA7wKQKzhX

---
_Generated by [Claude Code](https://claude.ai/code/session_01MhfVXCMAKBMbgA7wKQKzhX)_