### PR TITLE
feat(goals): queue manual progress-update run when the Captain is busy

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -155,7 +155,16 @@ status flip, and code worktree. They fire on the Captain's heartbeat when goals 
 (`JobManager.tryDispatchProgressUpdate` → `getDueGoals`), and can also be triggered on demand from
 the Goals page's **Run now** button (`POST /projects/:projectId/goals/run-now` →
 `JobManager.dispatchProgressUpdateNow`, which resolves the project's Captain and reuses the same
-due-goal logic). Token usage is flushed to the
+due-goal logic). If **Run now** hits a *transient* conflict — the Captain is already running, the
+project is at its concurrency limit, the container is still coming up, or a launch race — the run is
+**queued** rather than erroring: a task-less `agent_wakeup_requests` row tagged
+`payload.trigger='progress_update_now'` (deduped per Captain by `createProgressUpdateWakeup`, so
+"Run now" is idempotent) that the 5s dispatcher retries until the Captain frees up. This trigger tag
+also makes such a wakeup guard against fall-through: when it is finally dispatched, `activateAgent`
+runs *only* the progress update — it never lets the Captain pick up ordinary task work — and completes
+the wakeup as a no-op if nothing is due by then. A queued run is listed/cancelled through
+`GET`/`POST /projects/:projectId/goals/queued-run[/:wakeupId/cancel]` (scheduled heartbeat checks
+carry no trigger tag, so they are never surfaced or cancellable here). Token usage is flushed to the
 row *during* the run (alongside the log), so a run the server kills mid-flight still
 reports the tokens/cost it burned instead of `0`; `usage_partial` flags such a snapshot
 until a clean completion supersedes it. `agent_task_sessions` persists

--- a/docs/concepts/goals.md
+++ b/docs/concepts/goals.md
@@ -80,6 +80,11 @@ You don't have to wait for the schedule: the **Run now** button next to **Progre
 the Progress page triggers a progress update immediately. It runs the same check the heartbeat would —
 assessing whichever goals are currently due — so if nothing is due yet it simply reports that.
 
+If the Captain is already busy when you press **Run now**, the progress update is **queued** instead
+of failing — it starts automatically as soon as the Captain is free. A queued run shows up as a
+"Queued — waiting for the Captain to finish" row in the **Progress update runs** section, and you can
+cancel it from there while it's still waiting.
+
 During the same run the Captain also refreshes the **project progress summary** shown at the top
 of the Progress page, so that headline stays in step with the goal estimates.
 

--- a/packages/server/src/routes/goals.ts
+++ b/packages/server/src/routes/goals.ts
@@ -1,4 +1,6 @@
+import { WakeupStatus, wsRoom } from '@hezo/shared';
 import { Hono } from 'hono';
+import { broadcastChange } from '../lib/broadcast';
 import { resolveActorMemberId } from '../lib/resolve';
 import { err, ok } from '../lib/response';
 import type { Env } from '../lib/types';
@@ -81,7 +83,10 @@ goalsRoutes.post('/projects/:projectId/goals/run-now', async (c) => {
 		: null;
 
 	const result = await c.get('jobManager').dispatchProgressUpdateNow(projectId, triggeredBy);
-	if (result.dispatched) return ok(c, { dispatched: true });
+	if ('dispatched' in result && result.dispatched) return ok(c, { dispatched: true });
+	// A transient conflict (Captain busy, project at capacity, container down, launch
+	// race) was queued instead of erroring — it runs when the Captain frees up.
+	if ('queued' in result) return ok(c, { queued: true, wakeup_id: result.wakeupId });
 
 	if (result.reason === 'no_due_goals') {
 		return ok(c, { dispatched: false, reason: result.reason });
@@ -91,6 +96,81 @@ goalsRoutes.post('/projects/:projectId/goals/run-now', async (c) => {
 		return err(c, 'NOT_FOUND', message, 404);
 	}
 	return err(c, 'CONFLICT', message, 409);
+});
+
+// The single queued manual progress-update run for this project ("Run now" while the Captain was
+// busy), if any. At most one exists (deduped by `createProgressUpdateWakeup`). Scheduled heartbeat
+// progress checks have no `progress_update_now` trigger, so they are never surfaced here.
+goalsRoutes.get('/projects/:projectId/goals/queued-run', async (c) => {
+	const teamId = c.get('teamId') as string;
+	const projectId = c.get('projectId') as string;
+	const db = c.get('db');
+
+	const r = await db.query<{
+		id: string;
+		created_at: string;
+		triggered_by: { member_id: string; name: string } | null;
+	}>(
+		`SELECT id, created_at, payload->'triggered_by' AS triggered_by
+		 FROM agent_wakeup_requests
+		 WHERE team_id = $1
+		   AND status = $2::wakeup_status
+		   AND payload->>'trigger' = 'progress_update_now'
+		   AND payload->>'project_id' = $3::text
+		 ORDER BY created_at ASC
+		 LIMIT 1`,
+		[teamId, WakeupStatus.Queued, projectId],
+	);
+	return ok(c, { queued: r.rows[0] ?? null });
+});
+
+// Cancel the queued manual progress-update run. Only manually-initiated ("Run now") runs carry the
+// `progress_update_now` trigger, so scheduled heartbeat checks can't be cancelled through here.
+goalsRoutes.post('/projects/:projectId/goals/queued-run/:wakeupId/cancel', async (c) => {
+	const teamId = c.get('teamId') as string;
+	const projectId = c.get('projectId') as string;
+	const db = c.get('db');
+	const wakeupId = c.req.param('wakeupId');
+
+	const lookup = await db.query<{ status: string; member_id: string }>(
+		`SELECT status, member_id FROM agent_wakeup_requests
+		 WHERE id = $1 AND team_id = $2
+		   AND payload->>'trigger' = 'progress_update_now'
+		   AND payload->>'project_id' = $3::text`,
+		[wakeupId, teamId, projectId],
+	);
+	const row = lookup.rows[0];
+	// 404 (not 403) for unknown / wrong-team / wrong-project to avoid leaking existence.
+	if (!row) return err(c, 'NOT_FOUND', 'Queued progress update not found', 404);
+	if (row.status !== WakeupStatus.Queued) {
+		return err(c, 'CONFLICT', `Queued run is already ${row.status} and cannot be cancelled`, 409);
+	}
+
+	// Race-safe: the 5s dispatcher (processWakeups) may flip queued->claimed between the
+	// lookup and here. The conditional WHERE guards against it.
+	const updated = await db.query<{ id: string }>(
+		`UPDATE agent_wakeup_requests
+		    SET status = $1::wakeup_status, completed_at = now()
+		  WHERE id = $2 AND status = $3::wakeup_status
+		 RETURNING id`,
+		[WakeupStatus.Cancelled, wakeupId, WakeupStatus.Queued],
+	);
+	if (updated.rows.length === 0) {
+		return err(c, 'CONFLICT', 'Queued run is no longer queued and cannot be cancelled', 409);
+	}
+
+	// A progress-update wakeup is task-less, so there's no task thread to record a
+	// cancellation system comment on (unlike task queued-wakeups). The queued row
+	// disappearing from the Goals page is the feedback.
+	broadcastChange(c, wsRoom.team(teamId), 'agent_wakeup_requests', 'UPDATE', {
+		id: wakeupId,
+		team_id: teamId,
+		project_id: projectId,
+		member_id: row.member_id,
+		status: WakeupStatus.Cancelled,
+	});
+
+	return ok(c, { cancelled: true });
 });
 
 goalsRoutes.get('/projects/:projectId/goals/:goalId', async (c) => {

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -66,7 +66,12 @@ import { getProjectConcurrency, isTaskBusyInDb } from './run-concurrency';
 import type { SshAgentServer } from './ssh-agent';
 import { reportTelemetry } from './telemetry';
 import { ensureUpdateStaged, isSupervisedWorker } from './updater';
-import { absorbQueuedTaskWakeups, assignmentWakeupAlreadyServed, createWakeup } from './wakeup';
+import {
+	absorbQueuedTaskWakeups,
+	assignmentWakeupAlreadyServed,
+	createProgressUpdateWakeup,
+	createWakeup,
+} from './wakeup';
 import type { WebSocketManager } from './ws';
 
 const log = logger.child('job-manager');
@@ -142,9 +147,17 @@ export type ProgressUpdateDispatchReason =
 	| 'over_budget'
 	| 'launch_conflict';
 
-export type ProgressUpdateDispatchResult =
+/** Outcome of a single dispatch attempt (`tryDispatchProgressUpdate`). Never queues. */
+export type TryProgressUpdateResult =
 	| { dispatched: true }
 	| { dispatched: false; reason: ProgressUpdateDispatchReason };
+
+/** What the manual `dispatchProgressUpdateNow` path returns to the route: a single
+ * attempt outcome, or — for a transient conflict — a queued wakeup that runs when
+ * the Captain frees up. */
+export type ProgressUpdateDispatchResult =
+	| TryProgressUpdateResult
+	| { queued: true; wakeupId: string };
 
 export interface JobManagerDeps {
 	db: PGlite;
@@ -1380,6 +1393,44 @@ export class JobManager {
 				// one already holds the key (the wakeup was requeued to retry). Any other reason
 				// (no due goals, over budget, …) falls through to normal task selection.
 				if (result.dispatched || result.reason === 'launch_conflict') return;
+
+				// A manually-queued progress-update wakeup ("Run now" while the Captain was
+				// busy) must NEVER fall through to task selection — the user asked for a
+				// progress assessment, not for the Captain to start unrelated task work.
+				// Handle every non-launched outcome here and always return. (The wakeup was
+				// already claimed by the dispatcher, so the transient branch must re-queue it,
+				// not just stamp a skip reason — otherwise it would stick in `claimed`.)
+				if (wakeupPayload?.trigger === 'progress_update_now' && wakeupId) {
+					if (
+						result.reason === 'agent_busy' ||
+						result.reason === 'project_at_capacity' ||
+						result.reason === 'container_down'
+					) {
+						// Still transient — re-queue so a later cron tick retries once the
+						// Captain frees / the container comes up / capacity clears.
+						const skipReason =
+							result.reason === 'project_at_capacity'
+								? WakeupSkipReason.ProjectAtCapacity
+								: result.reason === 'container_down'
+									? WakeupSkipReason.ContainerDown
+									: WakeupSkipReason.AgentRunning;
+						await db.query(
+							`UPDATE agent_wakeup_requests
+							 SET status = $1::wakeup_status, claimed_at = NULL,
+							     last_skipped_at = now(), last_skipped_reason = $2
+							 WHERE id = $3`,
+							[WakeupStatus.Queued, skipReason, wakeupId],
+						);
+					} else {
+						// Terminal by dispatch time (goals no longer due, or over budget): the
+						// queued run is a no-op. Complete it so it doesn't spin forever.
+						await db.query(
+							`UPDATE agent_wakeup_requests SET status = $1::wakeup_status, completed_at = now() WHERE id = $2`,
+							[WakeupStatus.Completed, wakeupId],
+						);
+					}
+					return;
+				}
 			}
 
 			// Instance agents (CEO/Coach) select across every team; everyone else is
@@ -1871,7 +1922,7 @@ export class JobManager {
 		},
 		wakeupId: string | undefined,
 		wakeupPayload: Record<string, unknown>,
-	): Promise<ProgressUpdateDispatchResult> {
+	): Promise<TryProgressUpdateResult> {
 		const { db, docker, masterKeyManager, serverPort } = this.deps;
 
 		// The Captain's project is its team's single non-internal project.
@@ -2096,7 +2147,9 @@ export class JobManager {
 			return { dispatched: false, reason: 'captain_disabled' };
 		}
 
-		return this.tryDispatchProgressUpdate(
+		// First attempt is synchronous: when the Captain is free this launches
+		// immediately (run card appears at once), exactly as before.
+		const result = await this.tryDispatchProgressUpdate(
 			captainRow.id,
 			teamId,
 			{
@@ -2115,6 +2168,53 @@ export class JobManager {
 				...(triggeredBy ? { triggered_by: triggeredBy } : {}),
 			},
 		);
+
+		// A transient conflict (Captain already running, project at capacity,
+		// container still coming up, or a launch race) is queued rather than
+		// surfaced as an error: the 5s dispatcher retries the wakeup and the run
+		// fires once the Captain frees up. Terminal reasons (no project/captain,
+		// disabled, over budget, nothing due) fall through unchanged.
+		if (
+			!result.dispatched &&
+			(result.reason === 'agent_busy' ||
+				result.reason === 'project_at_capacity' ||
+				result.reason === 'container_down' ||
+				result.reason === 'launch_conflict')
+		) {
+			const projRow = await db.query<{ id: string }>(
+				'SELECT id FROM projects WHERE team_id = $1 AND is_internal = false LIMIT 1',
+				[teamId],
+			);
+			const projectRowId = projRow.rows[0]?.id;
+			// Guarded by tryDispatchProgressUpdate already resolving the project, but
+			// stay defensive: without a project id we can't queue, so surface the reason.
+			if (projectRowId) {
+				const wakeupId = await createProgressUpdateWakeup(
+					db,
+					captainRow.id,
+					teamId,
+					projectRowId,
+					WakeupSource.OnDemand,
+					triggeredBy,
+				);
+				broadcastRowChange(
+					this.deps.wsManager,
+					wsRoom.team(teamId),
+					'agent_wakeup_requests',
+					'INSERT',
+					{
+						id: wakeupId,
+						team_id: teamId,
+						project_id: projectRowId,
+						member_id: captainRow.id,
+						status: WakeupStatus.Queued,
+					},
+				);
+				return { queued: true, wakeupId };
+			}
+		}
+
+		return result;
 	}
 
 	private async postFailurePing(

--- a/packages/server/src/services/wakeup.ts
+++ b/packages/server/src/services/wakeup.ts
@@ -66,6 +66,52 @@ export async function createWakeup(
 }
 
 /**
+ * Idempotently create the Captain's manual ("Run now") progress-update wakeup.
+ *
+ * Unlike a task wakeup, a progress-update wakeup is task-less, so `createWakeup`
+ * would coalesce it onto the Captain's *scheduled* task-less heartbeat wakeup
+ * (same member, `task_id IS NULL`) — merging the two and blurring the
+ * `progress_update_now` marker. This helper never coalesces: it returns any
+ * existing still-queued progress wakeup for the Captain (so clicking "Run now"
+ * twice yields one row) or inserts a fresh, uniquely-keyed one. The
+ * `progress_update_now:<captain>` idempotency key both dedups and lets the
+ * list/cancel routes target the row precisely.
+ */
+export async function createProgressUpdateWakeup(
+	db: PGlite,
+	captainMemberId: string,
+	teamId: string,
+	projectId: string,
+	source: WakeupSource,
+	triggeredBy?: { member_id: string; name: string } | null,
+): Promise<string> {
+	const idempotencyKey = `progress_update_now:${captainMemberId}`;
+
+	const existing = await db.query<{ id: string }>(
+		`SELECT id FROM agent_wakeup_requests
+		 WHERE member_id = $1 AND status = $2::wakeup_status
+		   AND payload->>'trigger' = 'progress_update_now'
+		 LIMIT 1`,
+		[captainMemberId, WakeupStatus.Queued],
+	);
+	if (existing.rows.length > 0) return existing.rows[0].id;
+
+	const payload = {
+		source,
+		trigger: 'progress_update_now',
+		project_id: projectId,
+		...(triggeredBy ? { triggered_by: triggeredBy } : {}),
+	};
+	const result = await db.query<{ id: string }>(
+		`INSERT INTO agent_wakeup_requests (member_id, team_id, source, payload, idempotency_key)
+		 VALUES ($1, $2, $3::wakeup_source, $4::jsonb, $5)
+		 RETURNING id`,
+		[captainMemberId, teamId, source, JSON.stringify(payload), idempotencyKey],
+	);
+	return result.rows[0].id;
+}
+
+/**
  * Retire every still-queued wakeup for one agent + task except the one that is
  * driving the run that is about to start. A run reads the full task context at
  * boot, so any trigger already queued when it starts is served by that run;

--- a/packages/server/test/goals-queued-run.test.ts
+++ b/packages/server/test/goals-queued-run.test.ts
@@ -1,0 +1,217 @@
+import type { PGlite } from '@electric-sql/pglite';
+import { WakeupSkipReason, WakeupSource, WakeupStatus } from '@hezo/shared';
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { MasterKeyManager } from '../src/crypto/master-key';
+import type { Env } from '../src/lib/types';
+import { ContainerLogStreamer } from '../src/services/container-logs';
+import { JobManager, type JobManagerDeps } from '../src/services/job-manager';
+import { LogStreamBroker } from '../src/services/log-stream-broker';
+import { safeClose } from './helpers';
+import {
+	authHeader,
+	createStubDocker,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+} from './helpers/app';
+
+// The queued manual progress-update run ("Run now" while the Captain is busy). Covers the queue
+// dedup that must NOT cross-coalesce with the Captain's scheduled task-less heartbeat wakeup, the
+// project-scoped list/cancel routes, and the activateAgent guard that keeps a queued progress
+// wakeup from falling through to ordinary task selection.
+let db: PGlite;
+let app: Hono<Env>;
+let token: string;
+let masterKeyManager: MasterKeyManager;
+let dataDir: string;
+let teamId: string;
+let projectId: string;
+let projectSlug: string;
+let captainId: string;
+
+const json = { 'content-type': 'application/json' };
+
+function createJobManager(): JobManager {
+	return new JobManager({
+		db,
+		docker: createStubDocker(),
+		masterKeyManager,
+		serverPort: 3100,
+		dataDir,
+		wsManager: { broadcast: () => {} } as unknown as JobManagerDeps['wsManager'],
+		logs: new LogStreamBroker(),
+		containerLogStreamer: new ContainerLogStreamer(),
+	});
+}
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	db = ctx.db;
+	app = ctx.app;
+	token = ctx.token;
+	masterKeyManager = ctx.masterKeyManager;
+	dataDir = ctx.dataDir;
+
+	const typesRes = await app.request('/api/team-templates', { headers: authHeader(token) });
+	const typeId = (await typesRes.json()).data.find(
+		(t: { name: string }) => t.name === 'Startup',
+	).id;
+	const teamRes = await createTestTeam(db, { name: 'Queued Run Co', template_id: typeId });
+	teamId = (await teamRes.json()).data.id;
+	const projectRes = await createTestProject(db, teamId, { name: 'Queued Run Project' });
+	const project = (await projectRes.json()).data;
+	projectId = project.id;
+	projectSlug = project.slug;
+
+	const captain = await db.query<{ id: string }>(
+		`SELECT ma.id FROM member_agents ma JOIN members m ON m.id = ma.id
+		 WHERE m.team_id = $1 AND ma.slug = 'captain' LIMIT 1`,
+		[teamId],
+	);
+	captainId = captain.rows[0].id;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+function jsonHeaders() {
+	return { ...authHeader(token), ...json };
+}
+
+async function createDueGoal(title: string): Promise<void> {
+	const res = await app.request(`/api/projects/${projectSlug}/goals`, {
+		method: 'POST',
+		headers: jsonHeaders(),
+		body: JSON.stringify({ title, measurement: 'm', check_frequency: 'daily' }),
+	});
+	expect(res.status).toBe(201);
+}
+
+async function insertProgressWakeup(): Promise<string> {
+	const r = await db.query<{ id: string }>(
+		`INSERT INTO agent_wakeup_requests (member_id, team_id, source, status, payload, idempotency_key)
+		 VALUES ($1, $2, $3::wakeup_source, 'queued'::wakeup_status, $4::jsonb, $5)
+		 RETURNING id`,
+		[
+			captainId,
+			teamId,
+			WakeupSource.OnDemand,
+			JSON.stringify({ trigger: 'progress_update_now', project_id: projectId }),
+			`progress_update_now:${captainId}`,
+		],
+	);
+	return r.rows[0].id;
+}
+
+async function wakeupRow(id: string) {
+	const r = await db.query<{ status: string; last_skipped_reason: string | null }>(
+		`SELECT status::text AS status, last_skipped_reason FROM agent_wakeup_requests WHERE id = $1`,
+		[id],
+	);
+	return r.rows[0];
+}
+
+describe('queued manual progress-update run', () => {
+	it('does not cross-coalesce with the Captain scheduled heartbeat wakeup', async () => {
+		await createDueGoal('Coalesce guard goal');
+
+		// A pre-existing task-less scheduled heartbeat wakeup for the same Captain.
+		const heartbeat = await db.query<{ id: string }>(
+			`INSERT INTO agent_wakeup_requests (member_id, team_id, source, status, payload)
+			 VALUES ($1, $2, $3::wakeup_source, 'queued'::wakeup_status, '{}'::jsonb)
+			 RETURNING id`,
+			[captainId, teamId, WakeupSource.Heartbeat],
+		);
+		const heartbeatId = heartbeat.rows[0].id;
+
+		const res = await app.request(`/api/projects/${projectSlug}/goals/run-now`, {
+			method: 'POST',
+			headers: jsonHeaders(),
+			body: '{}',
+		});
+		expect(res.status).toBe(200);
+		const body = (await res.json()).data;
+		expect(body.queued).toBe(true);
+		expect(body.wakeup_id).not.toBe(heartbeatId);
+
+		// The heartbeat wakeup is untouched (still no trigger) — it was NOT merged with the
+		// progress wakeup, and a distinct progress wakeup row exists.
+		const hb = await db.query<{ payload: Record<string, unknown> }>(
+			`SELECT payload FROM agent_wakeup_requests WHERE id = $1`,
+			[heartbeatId],
+		);
+		expect(hb.rows[0].payload.trigger).toBeUndefined();
+
+		const progress = await db.query<{ payload: Record<string, unknown> }>(
+			`SELECT payload FROM agent_wakeup_requests WHERE id = $1`,
+			[body.wakeup_id],
+		);
+		expect(progress.rows[0].payload.trigger).toBe('progress_update_now');
+
+		// The list surfaces only the manual progress wakeup, never the heartbeat.
+		const list = await app.request(`/api/projects/${projectSlug}/goals/queued-run`, {
+			headers: authHeader(token),
+		});
+		expect((await list.json()).data.queued.id).toBe(body.wakeup_id);
+
+		// Cleanup so later tests start clean.
+		await db.query(`DELETE FROM agent_wakeup_requests WHERE id = ANY($1)`, [
+			[heartbeatId, body.wakeup_id],
+		]);
+	});
+
+	it('cancel returns 404 for an unknown wakeup id', async () => {
+		const res = await app.request(
+			`/api/projects/${projectSlug}/goals/queued-run/00000000-0000-0000-0000-000000000000/cancel`,
+			{ method: 'POST', headers: jsonHeaders(), body: '{}' },
+		);
+		expect(res.status).toBe(404);
+	});
+
+	it('re-queues (not falls through to task work) when the container is down at dispatch', async () => {
+		// Due goal + no running container ⇒ tryDispatchProgressUpdate returns container_down.
+		const wakeupId = await insertProgressWakeup();
+		const manager = createJobManager();
+
+		// Drive activateAgent through the public run-now dispatch (task-less path).
+		await manager.dispatchWakeupNow(wakeupId);
+
+		// The guard re-queued the wakeup with a container_down skip reason instead of letting
+		// the Captain fall through to picking up a task.
+		const ws = await wakeupRow(wakeupId);
+		expect(ws.status).toBe(WakeupStatus.Queued);
+		expect(ws.last_skipped_reason).toBe(WakeupSkipReason.ContainerDown);
+
+		// No progress-update run was started (still no container).
+		const runs = await db.query<{ c: number }>(
+			`SELECT COUNT(*)::int AS c FROM heartbeat_runs WHERE member_id = $1`,
+			[captainId],
+		);
+		expect(runs.rows[0].c).toBe(0);
+
+		manager.shutdown();
+		await db.query(`DELETE FROM agent_wakeup_requests WHERE id = $1`, [wakeupId]);
+	});
+
+	it('completes the queued run as a no-op when no goals are due at dispatch', async () => {
+		// Archive the due goals so nothing is due, then dispatch the queued progress wakeup.
+		await db.query(`UPDATE goals SET archived_at = now() WHERE project_id = $1`, [projectId]);
+		const wakeupId = await insertProgressWakeup();
+		const manager = createJobManager();
+
+		await manager.dispatchWakeupNow(wakeupId);
+
+		// Nothing due ⇒ the queued run is a no-op: completed, not left queued, and no task run.
+		const ws = await wakeupRow(wakeupId);
+		expect(ws.status).toBe(WakeupStatus.Completed);
+		const runs = await db.query<{ c: number }>(
+			`SELECT COUNT(*)::int AS c FROM heartbeat_runs WHERE member_id = $1`,
+			[captainId],
+		);
+		expect(runs.rows[0].c).toBe(0);
+
+		manager.shutdown();
+	});
+});

--- a/packages/server/test/goals-run-now.test.ts
+++ b/packages/server/test/goals-run-now.test.ts
@@ -51,7 +51,7 @@ describe('POST /projects/:projectId/goals/run-now', () => {
 		expect(body.reason).toBe('no_due_goals');
 	});
 
-	it('resolves the Captain and reaches run-gating (409) when a goal is due but the container is down', async () => {
+	it('queues the run (200, queued) when a goal is due but the container is down', async () => {
 		// A freshly created goal has never been checked, so it is immediately due.
 		const create = await app.request(`/api/projects/${projectSlug}/goals`, {
 			method: 'POST',
@@ -70,9 +70,61 @@ describe('POST /projects/:projectId/goals/run-now', () => {
 			body: '{}',
 		});
 		// Past the "nothing due" check it hits run-gating — the test project has no running
-		// container — so it is a 409 (not a 200 no-op and not a 404), proving the Captain and the
-		// due goal were both resolved.
-		expect(res.status).toBe(409);
-		expect((await res.json()).error.message).toBeTruthy();
+		// container (a transient conflict) — so instead of a 409 the run is queued to fire once
+		// the Captain is free. Proves the Captain and the due goal were both resolved.
+		expect(res.status).toBe(200);
+		const body = (await res.json()).data;
+		expect(body.queued).toBe(true);
+		expect(body.wakeup_id).toBeTruthy();
+
+		// A single queued progress-update wakeup was created for the Captain.
+		const queued = await db.query<{ payload: Record<string, unknown> }>(
+			`SELECT payload FROM agent_wakeup_requests
+			 WHERE id = $1 AND status = 'queued'::wakeup_status`,
+			[body.wakeup_id],
+		);
+		expect(queued.rows.length).toBe(1);
+		expect(queued.rows[0].payload.trigger).toBe('progress_update_now');
+		expect(queued.rows[0].payload.project_id).toBeTruthy();
+
+		// It surfaces via the project-scoped queued-run endpoint.
+		const list = await app.request(`/api/projects/${projectSlug}/goals/queued-run`, {
+			headers: authHeader(token),
+		});
+		expect(list.status).toBe(200);
+		expect((await list.json()).data.queued.id).toBe(body.wakeup_id);
+
+		// "Run now" again is idempotent — same wakeup, no second row.
+		const again = await app.request(`/api/projects/${projectSlug}/goals/run-now`, {
+			method: 'POST',
+			headers: jsonHeaders(),
+			body: '{}',
+		});
+		expect((await again.json()).data.wakeup_id).toBe(body.wakeup_id);
+		const count = await db.query<{ c: number }>(
+			`SELECT COUNT(*)::int AS c FROM agent_wakeup_requests
+			 WHERE status = 'queued'::wakeup_status AND payload->>'trigger' = 'progress_update_now'`,
+		);
+		expect(count.rows[0].c).toBe(1);
+
+		// Cancelling removes it from the queue.
+		const cancel = await app.request(
+			`/api/projects/${projectSlug}/goals/queued-run/${body.wakeup_id}/cancel`,
+			{ method: 'POST', headers: jsonHeaders(), body: '{}' },
+		);
+		expect(cancel.status).toBe(200);
+		expect((await cancel.json()).data.cancelled).toBe(true);
+
+		const afterCancel = await app.request(`/api/projects/${projectSlug}/goals/queued-run`, {
+			headers: authHeader(token),
+		});
+		expect((await afterCancel.json()).data.queued).toBe(null);
+
+		// Cancelling an already-cancelled run is a 409.
+		const recancel = await app.request(
+			`/api/projects/${projectSlug}/goals/queued-run/${body.wakeup_id}/cancel`,
+			{ method: 'POST', headers: jsonHeaders(), body: '{}' },
+		);
+		expect(recancel.status).toBe(409);
 	});
 });

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -553,6 +553,7 @@ export const WakeupSkipReason = {
 	ProjectAtCapacity: 'project_at_capacity',
 	AgentRunning: 'agent_running',
 	OverBudget: 'over_budget',
+	ContainerDown: 'container_down',
 } as const;
 export type WakeupSkipReason = (typeof WakeupSkipReason)[keyof typeof WakeupSkipReason];
 

--- a/packages/web/src/components/goals-list.tsx
+++ b/packages/web/src/components/goals-list.tsx
@@ -1,8 +1,24 @@
 import { GOAL_CHECK_FREQUENCY_LABELS, type GoalWithProject } from '@hezo/shared';
 import { Link } from '@tanstack/react-router';
-import { Archive, ArchiveRestore, Pencil, Plus, RotateCw, Target } from 'lucide-react';
+import {
+	Archive,
+	ArchiveRestore,
+	Clock,
+	Pencil,
+	Plus,
+	RotateCw,
+	Target,
+	Trash2,
+} from 'lucide-react';
 import { useState } from 'react';
-import { useGoalRuns, useGoals, useRunProgressUpdateNow, useUpdateGoal } from '../hooks/use-goals';
+import {
+	useCancelQueuedProgressRun,
+	useGoalQueuedRun,
+	useGoalRuns,
+	useGoals,
+	useRunProgressUpdateNow,
+	useUpdateGoal,
+} from '../hooks/use-goals';
 import { RunCommentBody } from './comment-renderers/run-comment';
 import { CreateGoalDialog } from './create-goal-dialog';
 import { GoalHealthPill } from './goal-health-pill';
@@ -10,8 +26,10 @@ import { GoalSmartGuidance } from './goal-smart-guidance';
 import { LazyMount } from './lazy-mount';
 import { ProjectProgressSummary } from './project-progress-summary';
 import { Button } from './ui/button';
+import { ConfirmDialog } from './ui/confirm-dialog';
 import { EmptyState } from './ui/empty-state';
 import { HelpDialog } from './ui/help-dialog';
+import { Tooltip } from './ui/tooltip';
 
 interface GoalsListProps {
 	projectId: string;
@@ -114,10 +132,54 @@ function GoalPanel({
 	);
 }
 
+function QueuedProgressRunRow({ projectId, wakeupId }: { projectId: string; wakeupId: string }) {
+	const [open, setOpen] = useState(false);
+	const cancel = useCancelQueuedProgressRun(projectId);
+
+	return (
+		<div
+			data-testid="progress-update-queued-row"
+			className="mb-2 flex items-center justify-between gap-2 rounded-md border border-border bg-surface px-3 py-2.5"
+		>
+			<div className="flex min-w-0 items-center gap-2 text-[13px] text-text-2">
+				<Clock className="h-3.5 w-3.5 shrink-0 text-text-3" />
+				<span className="truncate">Queued — waiting for the Captain to finish</span>
+			</div>
+			<Tooltip content="Cancel queued progress update">
+				<button
+					type="button"
+					onClick={() => setOpen(true)}
+					aria-label="Cancel queued progress update"
+					data-testid="cancel-queued-progress-run"
+					disabled={cancel.isPending}
+					className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-danger transition-colors hover:bg-danger/10"
+				>
+					<Trash2 className="h-3.5 w-3.5" />
+				</button>
+			</Tooltip>
+			<ConfirmDialog
+				open={open}
+				onOpenChange={setOpen}
+				title="Cancel queued progress update?"
+				description="The queued progress update will be removed and won't run."
+				confirmLabel="Cancel run"
+				cancelLabel="Keep queued"
+				variant="danger"
+				loading={cancel.isPending}
+				onConfirm={async () => {
+					await cancel.mutateAsync(wakeupId);
+				}}
+			/>
+		</div>
+	);
+}
+
 function ProgressUpdatesFooter({ projectId }: { projectId: string }) {
 	const { data: runs } = useGoalRuns(projectId);
+	const { data: queued } = useGoalQueuedRun(projectId);
 	const runNow = useRunProgressUpdateNow(projectId);
 	const hasRuns = !!runs && runs.length > 0;
+	const queuedRun = queued?.queued ?? null;
 
 	return (
 		<section data-testid="progress-updates" className="mt-8">
@@ -137,6 +199,7 @@ function ProgressUpdatesFooter({ projectId }: { projectId: string }) {
 					{runNow.isPending ? 'Running…' : 'Run now'}
 				</Button>
 			</div>
+			{queuedRun && <QueuedProgressRunRow projectId={projectId} wakeupId={queuedRun.id} />}
 			{!hasRuns ? (
 				<div
 					data-testid="progress-updates-empty"

--- a/packages/web/src/hooks/use-goals.ts
+++ b/packages/web/src/hooks/use-goals.ts
@@ -59,6 +59,24 @@ export function useGoalRuns(projectId: string) {
 	});
 }
 
+export interface QueuedProgressRun {
+	id: string;
+	created_at: string;
+	triggered_by: { member_id: string; name: string } | null;
+}
+
+/**
+ * The single queued manual progress-update run for this project, if any — created when "Run now" is
+ * clicked while the Captain is already busy. `queued` is null when nothing is waiting.
+ */
+export function useGoalQueuedRun(projectId: string) {
+	return useQuery({
+		queryKey: queryKeys.projects.goalQueuedRun(projectId),
+		queryFn: () =>
+			api.get<{ queued: QueuedProgressRun | null }>(`/api/projects/${projectId}/goals/queued-run`),
+	});
+}
+
 /** The progress-update runs that did something for one goal — shown at the bottom of its detail page. */
 export function useGoalRunActivity(projectId: string, goalId: string) {
 	return useQuery({
@@ -139,11 +157,18 @@ export function useArchiveGoal(projectId: string) {
 export function useRunProgressUpdateNow(projectId: string) {
 	return useMutation({
 		mutationFn: () =>
-			api.post<{ dispatched: boolean; reason?: string }>(
+			api.post<{ dispatched?: boolean; queued?: boolean; reason?: string }>(
 				`/api/projects/${projectId}/goals/run-now`,
 				{},
 			),
 		onSuccess: (data) => {
+			// The Captain was busy, so the run was queued instead of erroring — it fires
+			// automatically once the Captain frees up. Surface the queued row live.
+			if (data.queued) {
+				toast.info('Progress update queued — it will run when the Captain is free.');
+				queryClient.invalidateQueries({ queryKey: queryKeys.projects.goalQueuedRun(projectId) });
+				return;
+			}
 			if (!data.dispatched) {
 				toast.info(
 					data.reason === 'no_due_goals'
@@ -158,6 +183,24 @@ export function useRunProgressUpdateNow(projectId: string) {
 		},
 		onError: (error: { message?: string }) => {
 			toast.error(error?.message ?? 'Failed to start progress update');
+		},
+	});
+}
+
+/** Cancel the queued manual progress-update run (the "Run now"-while-busy row on the Goals page). */
+export function useCancelQueuedProgressRun(projectId: string) {
+	return useMutation({
+		mutationFn: (wakeupId: string) =>
+			api.post<{ cancelled: boolean }>(
+				`/api/projects/${projectId}/goals/queued-run/${wakeupId}/cancel`,
+				{},
+			),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: queryKeys.projects.goalQueuedRun(projectId) });
+			queryClient.invalidateQueries({ queryKey: queryKeys.projects.goalRuns(projectId) });
+		},
+		onError: (error: { message?: string }) => {
+			toast.error(error?.message ?? 'Failed to cancel queued progress update');
 		},
 	});
 }

--- a/packages/web/src/hooks/use-websocket.ts
+++ b/packages/web/src/hooks/use-websocket.ts
@@ -52,6 +52,10 @@ const TABLE_TO_QUERY_KEY: Record<
 		const keys: QueryKey[] = [queryKeys.projects.tasks(cid)];
 		if (row.task_id) {
 			keys.push(queryKeys.projects.taskQueuedWakeups(cid, row.task_id as string));
+		} else {
+			// A task-less wakeup is the Captain's queued progress-update run — refresh
+			// the Goals page's queued row so it appears/clears live.
+			keys.push(queryKeys.projects.goalQueuedRun(cid));
 		}
 		return keys;
 	},

--- a/packages/web/src/lib/query-keys.ts
+++ b/packages/web/src/lib/query-keys.ts
@@ -98,6 +98,7 @@ export const queryKeys = {
 		goal: (slug: string, goalId: string) => ['projects', slug, 'goals', goalId],
 		goalHistory: (slug: string, goalId: string) => ['projects', slug, 'goals', goalId, 'history'],
 		goalRuns: (slug: string) => ['projects', slug, 'goals', 'runs'],
+		goalQueuedRun: (slug: string) => ['projects', slug, 'goals', 'queued-run'],
 		goalRunsForGoal: (slug: string, goalId: string) => ['projects', slug, 'goals', goalId, 'runs'],
 		progress: (slug: string) => ['projects', slug, 'progress'],
 

--- a/packages/web/test/goals.test.tsx
+++ b/packages/web/test/goals.test.tsx
@@ -1,3 +1,4 @@
+import { waitFor } from '@testing-library/react';
 import { expect, test } from 'vitest';
 import { renderApp } from './helpers/render';
 import {
@@ -361,8 +362,46 @@ test('the Progress page shows a Run now button beside the progress update runs l
 	await findByText('Progress update runs');
 	const runNow = await findByTestId('progress-update-run-now', undefined, { timeout: 10_000 });
 	expect(runNow.textContent).toContain('Run now');
-	// Clicking fires the run-now mutation against the in-process backend (no running container in
-	// tests → a handled 409); it must not throw and the button stays in the DOM.
+	// Clicking fires the run-now mutation against the in-process backend. The goal is due but there
+	// is no running container in tests (a transient conflict), so the run is queued rather than
+	// erroring — the queued row appears.
 	await user.click(runNow);
 	await findByTestId('progress-update-run-now');
+});
+
+test('Run now queues when the Captain is busy, and the queued run can be cancelled', async () => {
+	let projectSlug = '';
+	const { findByTestId, findByText, queryByTestId, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Queue Demo' });
+			projectSlug = project.slug;
+			// A freshly-seeded goal is immediately due; no running container in tests means the run
+			// is queued instead of started.
+			await seedGoal(ws, project, { title: 'Ship it', measurement: 'shipped' });
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/goals',
+		params: { projectId: projectSlug },
+	});
+
+	const runNow = await findByTestId('progress-update-run-now', undefined, { timeout: 10_000 });
+	await user.click(runNow);
+
+	// The queued row appears (driven by the real backend queuing the wakeup).
+	const queuedRow = await findByTestId('progress-update-queued-row', undefined, {
+		timeout: 10_000,
+	});
+	expect(queuedRow.textContent).toContain('Queued');
+
+	// Cancelling opens the confirm dialog, then removes the queued row.
+	await user.click(await findByTestId('cancel-queued-progress-run'));
+	await user.click(await findByText('Cancel run'));
+
+	await waitFor(() => expect(queryByTestId('progress-update-queued-row')).toBeNull(), {
+		timeout: 10_000,
+	});
 });


### PR DESCRIPTION
## Problem

Clicking **Run now** in the Progress Update Runs section of the Goals page while the Captain was already running returned a 409 error toast — *"The Captain is already running in this project."* — forcing the user to keep retrying manually.

## What changed

Instead of erroring on a **transient** conflict, the progress-update run is now **queued** and fires automatically once the Captain frees up. The user can **cancel** a queued run while it waits.

This reuses the existing `agent_wakeup_requests` queue and the 5s dispatcher rather than adding new infrastructure. **No DB migration** (`cancelled` is already a valid `wakeup_status`; project scope lives in the wakeup payload).

### Behaviour

| `Run now` outcome | Before | After |
|---|---|---|
| Captain busy / project at capacity / container coming up / launch race | 409 error | **queued** → `200 { queued, wakeup_id }`, runs when free |
| Nothing due | 200 no-op | unchanged |
| No project / no Captain | 404 | unchanged |
| Captain disabled / over budget | 409 | unchanged |

### Backend
- `dispatchProgressUpdateNow` queues a task-less wakeup tagged `payload.trigger='progress_update_now'` on transient conflict and returns `{ queued, wakeup_id }`.
- New `createProgressUpdateWakeup` (`services/wakeup.ts`) dedups per Captain (idempotent "Run now") and — unlike `createWakeup` — never cross-coalesces onto the Captain's scheduled task-less heartbeat wakeup.
- `activateAgent` guards the trigger tag: a queued progress wakeup only ever runs the progress update — it **never falls through to ordinary task selection** — re-queuing on a still-transient conflict and completing as a no-op if nothing is due by dispatch time.
- New project-scoped `GET /goals/queued-run` and `POST /goals/queued-run/:wakeupId/cancel` routes (race-safe; no task comment, since a progress run has no task thread). Only manually-initiated runs carry the trigger tag, so scheduled heartbeat checks are never surfaced or cancellable here.

### Frontend
- A "Queued — waiting for the Captain to finish" row with a cancel (X) button + confirm dialog in `ProgressUpdatesFooter`.
- `useRunProgressUpdateNow` handles the `queued` response (info toast + invalidate); new `useGoalQueuedRun` / `useCancelQueuedProgressRun` hooks.
- Live WS invalidation of the queued row for task-less `agent_wakeup_requests` changes.

## Tests
- `goals-run-now.test.ts`: the container-down case now asserts `200 { queued }` (was 409), plus dedup, list, cancel, and re-cancel-409.
- New `goals-queued-run.test.ts`: no cross-coalesce with a heartbeat wakeup, list scoping, cancel 404, and the **no-fallthrough** regression (a queued progress wakeup re-queues on container-down and completes as a no-op when nothing is due — never starts a task run).
- `goals.test.tsx`: Run now → queued row appears → cancel removes it, driven by the real in-process backend.

Full non-browser suite green (`bun run test --skip-browser`); typecheck + build pass via the pre-commit hook.

## Docs
- `.dev/architecture.md` — describes the queue/cancel path and the trigger-tag fallthrough guard.
- `docs/concepts/goals.md` — user-facing note that Run now queues when the Captain is busy and can be cancelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013UDRf4V6tU7V4bYDp87186