### PR TITLE
Update tagline to "Your own AI workforce. Self-hosted and secure."

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </div>
 
 <p align="center">
-  <strong>A whole AI workforce. Self-hosted and secure.</strong>
+  <strong>Your own AI workforce. Self-hosted and secure.</strong>
 </p>
 
 <p align="center">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "hezo",
-	"description": "A whole AI workforce. Self-hosted and secure.",
+	"description": "Your own AI workforce. Self-hosted and secure.",
 	"private": true,
 	"license": "MIT",
 	"packageManager": "bun@1.3.9",

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -3,19 +3,19 @@
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<title>Hezo — A whole AI workforce. Self-hosted and secure.</title>
+		<title>Hezo — Your own AI workforce. Self-hosted and secure.</title>
 		<meta
 			name="description"
 			content="Run a whole team of AI agents like a company — you set the goals, they ship the work, and you own everything they produce."
 		/>
 		<meta property="og:type" content="website" />
-		<meta property="og:title" content="Hezo — A whole AI workforce. Self-hosted and secure." />
+		<meta property="og:title" content="Hezo — Your own AI workforce. Self-hosted and secure." />
 		<meta
 			property="og:description"
 			content="Run a whole team of AI agents like a company — you set the goals, they ship the work, and you own everything they produce."
 		/>
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="Hezo — A whole AI workforce. Self-hosted and secure." />
+		<meta name="twitter:title" content="Hezo — Your own AI workforce. Self-hosted and secure." />
 		<meta
 			name="twitter:description"
 			content="Run a whole team of AI agents like a company — you set the goals, they ship the work, and you own everything they produce."


### PR DESCRIPTION
## Summary

Changes the product tagline from "A whole AI workforce. Self-hosted and secure." to "Your own AI workforce. Self-hosted and secure." everywhere it appears in this repo:

- `README.md` — the header strapline
- `package.json` — the root package description
- `packages/web/index.html` — the page `<title>`, `og:title`, and `twitter:title`

The longer sub-description ("Run a whole team of AI agents like a company…") in the meta descriptions and web manifest is unchanged — only the tagline itself was updated. The historical CHANGELOG entry mentioning an older tagline is left as-is. A matching change to the marketing site is in hezo-ai/website.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01REqyJx9CCs5uTfUx4j1aJr

---
_Generated by [Claude Code](https://claude.ai/code/session_01REqyJx9CCs5uTfUx4j1aJr)_