### PR TITLE
fix: link a doc/asset mention that ends a sentence

### DIFF
--- a/packages/shared/src/mentions/tokens.ts
+++ b/packages/shared/src/mentions/tokens.ts
@@ -20,11 +20,17 @@ export const TASK_RE_SRC = String.raw`(?<![\w-])([A-Z][A-Z0-9]{1,3}-\d+)(?![\w-]
 // matching branch at a position, so otherwise TASK_RE_SRC consumes the bare
 // `IN-42` prefix and the `#comment-...` suffix is left dangling.
 export const COMMENT_LINK_RE_SRC = String.raw`(?<![\w-])([A-Z][A-Z0-9]{1,3}-\d+)#comment-(\d{14}(?:-\d+)?)(?![\w-])`;
-export const FILENAME_RE_SRC = String.raw`(?<![\w/.-])([a-z0-9][\w-]*\.[a-z0-9]+)(?![\w/.-])`;
+// The trailing boundary rejects a filename that continues into another path or
+// name segment (`foo.md/bar`, `foo.md.bak`) but NOT one followed by a bare `.`
+// that ends a sentence (`Remove architecture-guidelines.md.`) — a dot only
+// blocks the match when it leads into a further alphanumeric segment, so
+// ordinary sentence punctuation after a filename still links.
+export const FILENAME_RE_SRC = String.raw`(?<![\w/.-])([a-z0-9][\w-]*\.[a-z0-9]+)(?![\w/-]|\.[a-z0-9])`;
 // Asset references are path-prefixed (`assets/<name>.<ext>`) and may contain
 // uppercase (e.g. a task identifier embedded in the name). The leading `assets/`
-// keeps them from colliding with the bare project-doc filenames above.
-export const ASSET_RE_SRC = String.raw`(?<![\w/.-])assets/([A-Za-z0-9][\w.-]*\.[A-Za-z0-9]+)(?![\w/.-])`;
+// keeps them from colliding with the bare project-doc filenames above. Same
+// trailing-boundary rule as filenames: a sentence-ending `.` still links.
+export const ASSET_RE_SRC = String.raw`(?<![\w/.-])assets/([A-Za-z0-9][\w.-]*\.[A-Za-z0-9]+)(?![\w/-]|\.[A-Za-z0-9])`;
 
 /**
  * Combined mention regex. Capture-group layout (consumed by

--- a/packages/shared/test/mentions-tokens.test.ts
+++ b/packages/shared/test/mentions-tokens.test.ts
@@ -36,6 +36,49 @@ describe('parseMentionMatch via buildMentionRegex', () => {
 		expect(byKind.asset).toMatchObject({ kind: 'asset', filename: 'diagram.png' });
 	});
 
+	it('matches a filename ending a sentence (trailing period)', () => {
+		const kinds = (input: string): MentionToken[] => {
+			const out: MentionToken[] = [];
+			const re = buildMentionRegex();
+			let m = re.exec(input);
+			while (m !== null) {
+				out.push(parseMentionMatch(m));
+				m = re.exec(input);
+			}
+			return out;
+		};
+		expect(kinds('Remove architecture-guidelines.md.')).toEqual([
+			{
+				kind: 'filename',
+				raw: 'architecture-guidelines.md',
+				filename: 'architecture-guidelines.md',
+			},
+		]);
+		// Two filenames, the second sentence-final.
+		expect(kinds('See prd.md, and readme.md.').map((t) => t.raw)).toEqual(['prd.md', 'readme.md']);
+		// Sentence-final asset reference.
+		expect(kinds('See assets/diagram.png.')).toEqual([
+			{ kind: 'asset', raw: 'assets/diagram.png', filename: 'diagram.png' },
+		]);
+	});
+
+	it('does not match a filename that continues into another path or name segment', () => {
+		const raws = (input: string): string[] => {
+			const out: string[] = [];
+			const re = buildMentionRegex();
+			let m = re.exec(input);
+			while (m !== null) {
+				out.push(m[0]);
+				m = re.exec(input);
+			}
+			return out;
+		};
+		// A path continuation (`foo.md/bar`) and a further extension segment
+		// (`foo.md.bak`) both stay plain text — the trailing dot leads into more.
+		expect(raws('path foo.md/bar')).toEqual([]);
+		expect(raws('archive foo.md.bak here')).toEqual([]);
+	});
+
 	it('returns a fresh regex instance each call', () => {
 		const a = buildMentionRegex();
 		const b = buildMentionRegex();

--- a/packages/web/test/markdown-prose-mentions.test.tsx
+++ b/packages/web/test/markdown-prose-mentions.test.tsx
@@ -52,6 +52,42 @@ test('a bare doc-style reference resolving to a skill renders a KB-doc link to t
 	expect(link.textContent).toContain('runbook.md');
 });
 
+test('a project-doc reference ending a sentence (trailing period) still renders a doc link', async () => {
+	// Regression: a doc filename immediately followed by a sentence-ending period
+	// (`Remove architecture-guidelines.md.`) used to fall out of the mention regex
+	// because its trailing boundary rejected any following `.`, leaving the
+	// filename as plain text instead of a clickable doc link.
+	const seeded = { projectSlug: '', taskId: '' };
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Doc Mention Project' });
+			const task = await seedTask(ws, project, { title: 'Doc Mention Task' });
+			const { apiBase } = getTestContext();
+			await apiBase(`/api/projects/${project.slug}/docs/architecture-guidelines.md`, {
+				method: 'PUT',
+				headers: ws.headers,
+				body: JSON.stringify({ content: '# Architecture Guidelines' }),
+			});
+			await seedComment(ws, task, 'Remove architecture-guidelines.md.');
+			seeded.projectSlug = project.slug;
+			seeded.taskId = task.identifier.toLowerCase();
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
+	});
+
+	// In a comment thread the doc mention opens in the preview panel, so it renders
+	// as a preview button (not an href anchor) — the presence of the mention
+	// element is what proves the filename linkified instead of staying plain text.
+	const link = await findByTestId('doc-mention-link', undefined, { timeout: 20_000 });
+	expect(link.textContent).toContain('architecture-guidelines.md');
+});
+
 test('@admin in a comment renders an inbox mention link scoped to the project', async () => {
 	const seeded = { projectSlug: '', taskId: '' };
 	const { findByTestId, router } = await renderApp({


### PR DESCRIPTION
## Problem

Inserting a document reference via the @-mention picker (e.g. the "Architecture Guidelines" doc → `architecture-guidelines.md`) and then ending the sentence with a period rendered the filename as **plain text instead of a clickable link**:

> Remove architecture-guidelines.md.

The filename mention regex (`FILENAME_RE_SRC`) and the asset mention regex (`ASSET_RE_SRC`) both ended with the trailing boundary `(?[\w/.-])`, which rejected **any** following character in `[\w/.-]` — including a bare `.`. That trailing `.` in the boundary was intended to keep the regex from matching part of a longer dotted name (e.g. `foo.md.bak`), but it also rejected an ordinary sentence-ending period right after a filename, so the whole reference failed to match and never linkified.

## Fix

Tighten the trailing boundary from `(?[\w/.-])` to `(?[\w/-]|\.[a-z0-9])` (and the case-insensitive equivalent for assets). A following dot now blocks the match **only when it leads into another alphanumeric segment** (`foo.md.bak`, `foo.md/bar` stay plain text), while a dot that ends a sentence still links the filename.

## Tests

- `packages/shared/test/mentions-tokens.test.ts` — new cases: a filename/asset ending a sentence linkifies (`Remove architecture-guidelines.md.`, `See assets/diagram.png.`, two filenames where the second is sentence-final); path/extension continuations (`foo.md/bar`, `foo.md.bak`) still stay plain text.
- `packages/web/test/markdown-prose-mentions.test.tsx` — end-to-end regression reproducing the exact reported scenario: a seeded project doc referenced as `Remove architecture-guidelines.md.` in a comment now renders a `doc-mention-link`.

All three affected tiers (shared, web, server mention tests) pass; typecheck and the production build are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015TR2xjgQQxHkEuoAvYXxad)_