### PR TITLE
fix(web): make mobile document panel its own layer above task sidebar

### DIFF
--- a/packages/web/src/components/task-detail/preview-panel.tsx
+++ b/packages/web/src/components/task-detail/preview-panel.tsx
@@ -31,7 +31,7 @@ export function PreviewPanel({ item, onClose }: PreviewPanelProps) {
 	return (
 		<aside
 			data-testid="preview-panel"
-			className="flex min-h-0 flex-col overflow-hidden rounded-lg border border-border bg-surface lg:sticky lg:top-4 lg:max-h-[calc(100vh-2rem)]"
+			className="fixed inset-0 z-[60] flex min-h-0 flex-col overflow-hidden bg-surface lg:inset-auto lg:z-auto lg:sticky lg:top-4 lg:max-h-[calc(100vh-2rem)] lg:rounded-lg lg:border lg:border-border"
 		>
 			<div className="flex items-center gap-2 border-b border-border bg-surface-2 px-3 py-2">
 				<span

--- a/packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx
@@ -60,17 +60,15 @@ function TaskDetailPage() {
 	// leave effort unset on submit and let the server resolve the agent default.
 	const [commentEffort, setCommentEffort] = useState<AgentEffort | null>(null);
 	const [replyTarget, setReplyTarget] = useState<Comment | null>(null);
-	// A doc/asset clicked in a comment opens in the right-rail preview panel
-	// (replacing the metadata sidebar until closed).
+	// A doc clicked in a comment opens in the preview panel: an in-grid column at
+	// lg+, and its own full-screen overlay (above the main content and the meta
+	// drawer) below lg. It is independent of the meta side rail.
 	const [preview, setPreview] = useState<PreviewItem | null>(null);
-	// On mobile the right rail is a collapsed-by-default drawer. Opening a preview
-	// (a doc/asset clicked in a comment) must also open the drawer, otherwise the
-	// preview would render off-screen behind the collapsed rail.
+	// The meta side rail is a collapsed-by-default drawer on mobile, toggled by
+	// the chevron. It is independent of the preview panel — opening/closing a
+	// preview must not affect it (otherwise closing a doc reveals the meta panel).
 	const [sidebarOpen, setSidebarOpen] = useState(false);
-	const openPreview = (item: PreviewItem | null) => {
-		setPreview(item);
-		if (item) setSidebarOpen(true);
-	};
+	const openPreview = (item: PreviewItem) => setPreview(item);
 	const commentFormRef = useRef<HTMLFormElement>(null);
 	const commentTextareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -185,31 +183,32 @@ function TaskDetailPage() {
 						className="lg:hidden fixed inset-0 z-40 bg-[var(--overlay)] cursor-default"
 					/>
 				)}
-				{/* Mobile: a fixed right-side drawer. Desktop: `lg:contents` makes this
-				    wrapper generate no box, so TaskSidebar/PreviewPanel become the direct
-				    grid child again — preserving the in-grid sticky column unchanged. */}
+				{/* Task meta side panel. Mobile: a fixed right-side drawer toggled by the
+				    chevron. Desktop: `lg:contents` makes this wrapper generate no box, so
+				    TaskSidebar becomes the direct grid child (in-grid sticky column). While
+				    a preview is open the sidebar column yields to the preview on desktop
+				    (`lg:hidden`); on mobile the preview is its own overlay above this. */}
 				<div
 					data-testid="task-rail"
 					className={`fixed top-0 right-0 z-40 h-full w-[280px] max-w-[85vw] overflow-y-auto bg-surface p-4 shadow-xl transition-transform duration-200 ${
 						sidebarOpen ? 'translate-x-0' : 'translate-x-full'
-					} lg:contents`}
+					} ${preview ? 'lg:hidden' : 'lg:contents'}`}
 				>
-					{preview ? (
-						<PreviewPanel item={preview} onClose={() => setPreview(null)} />
-					) : (
-						<TaskSidebar
-							task={task}
-							projectId={projectId}
-							agents={agents}
-							lock={lock}
-							comments={comments}
-							updateTask={updateTask}
-							commentEffort={commentEffort}
-							setCommentEffort={setCommentEffort}
-							scrollToBottom={scrollToBottom}
-						/>
-					)}
+					<TaskSidebar
+						task={task}
+						projectId={projectId}
+						agents={agents}
+						lock={lock}
+						comments={comments}
+						updateTask={updateTask}
+						commentEffort={commentEffort}
+						setCommentEffort={setCommentEffort}
+						scrollToBottom={scrollToBottom}
+					/>
 				</div>
+				{/* Document preview: its own layer. Mobile: a full-screen overlay above
+				    the main content and the meta drawer. Desktop: the in-grid column 2. */}
+				{preview && <PreviewPanel item={preview} onClose={() => setPreview(null)} />}
 			</div>
 
 			{/* Sits above the persistent CEO chat launcher (fixed bottom-right) so

--- a/test/browser/task-detail.mobile.spec.ts
+++ b/test/browser/task-detail.mobile.spec.ts
@@ -95,6 +95,76 @@ test.describe('Task detail — mobile layout (390px)', () => {
 	});
 });
 
+test.describe('Task detail — document preview panel (mobile, 390px)', () => {
+	// Seed a doc + a comment mentioning it, then assert the preview panel is its
+	// own full-screen overlay layered ABOVE the meta side rail — and that closing
+	// it does NOT reveal the meta sidebar (the drawer stays collapsed).
+	async function createProjectTaskWithDocMention(page: Page, token: string) {
+		const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+		const { project, task } = await createProjectAndTask(page, token, 'Mobile Doc Preview');
+
+		const docRes = await page.request.put(`/api/projects/${project.slug}/docs/prd.md`, {
+			headers,
+			data: { content: '# Product Requirements\n\nAn unmistakable document body.' },
+		});
+		if (!docRes.ok()) throw new Error(`seed prd.md failed: ${docRes.status()}`);
+
+		const commentRes = await page.request.post(
+			`/api/projects/${project.slug}/tasks/${task.id}/comments`,
+			{
+				headers,
+				data: { content_type: 'text', content: { text: 'Please review prd.md before we ship.' } },
+			},
+		);
+		if (!commentRes.ok()) throw new Error(`seed comment failed: ${commentRes.status()}`);
+
+		return { project, task };
+	}
+
+	test('doc preview is a full-screen overlay above the sidebar; closing it does not reveal the meta panel', async ({
+		page,
+		freshWorkspace,
+	}) => {
+		const { token } = freshWorkspace;
+		const { project, task } = await createProjectTaskWithDocMention(page, token);
+
+		await page.goto(`/projects/${project.slug}/tasks/${task.identifier.toLowerCase()}`);
+		await waitForPageLoad(page);
+		await expect(page.getByRole('heading', { name: 'Mobile Task' })).toBeVisible({
+			timeout: 20000,
+		});
+
+		// The meta rail starts collapsed off-screen.
+		const rail = page.getByTestId('task-rail');
+		const toggle = page.getByTestId('task-sidebar-toggle');
+		await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+		expect((await rail.boundingBox())?.x ?? 0).toBeGreaterThanOrEqual(360);
+
+		// Open the doc from its mention in the comment.
+		const mention = page.getByTestId('doc-mention-link').first();
+		await expect(mention).toBeVisible({ timeout: 15000 });
+		await mention.click();
+
+		// The preview is its own full-screen overlay covering the viewport, and the
+		// meta sidebar is not shown behind it.
+		const preview = page.getByTestId('preview-panel');
+		await expect(preview).toBeInViewport();
+		const previewBox = await preview.boundingBox();
+		expect(previewBox).not.toBeNull();
+		expect(previewBox!.x).toBeLessThan(8);
+		expect(previewBox!.width).toBeGreaterThan(360);
+		await expect(page.getByTestId('task-sidebar')).not.toBeInViewport();
+
+		// Close the preview — the bug was that this revealed the meta sidebar.
+		await page.getByTestId('preview-close').click();
+		await expect(preview).toHaveCount(0);
+		await expect(page.getByTestId('task-sidebar')).not.toBeInViewport();
+		// The meta drawer is still collapsed off-screen and the toggle untouched.
+		expect((await rail.boundingBox())?.x ?? 0).toBeGreaterThanOrEqual(360);
+		await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+	});
+});
+
 // Render a completed run comment cheaply by mocking the comments + heartbeat-run
 // responses — no real agent runtime needed (cribbed from agent-run-logs.spec.ts).
 async function mockRunComment(page: Page, token: string) {


### PR DESCRIPTION
## Problem

On mobile, closing the document preview panel unexpectedly revealed the task meta side panel (as seen in the attached screen recording).

The document preview panel and the task meta side panel (`TaskSidebar`) shared a single mobile drawer slot controlled by one `sidebarOpen` state. Opening a document (`openPreview`) force-set `sidebarOpen = true`. Closing the document (`setPreview(null)`) left `sidebarOpen` still `true`, so the drawer stayed open and fell back to rendering the meta sidebar — the metadata panel popped in when the user only meant to close the doc.

## Fix

The document panel is now its **own separate layer**, decoupled from the meta drawer:

- **Mobile:** the preview is a full-screen overlay (`fixed inset-0 z-[60]`) that sits **above** both the main task content and the meta side rail. Closing it just closes it and returns to the main content — the meta drawer stays collapsed.
- **Desktop (lg+):** unchanged — the preview is still the in-grid right column (360px) that the sidebar column yields to when a doc is open.
- `openPreview` no longer touches `sidebarOpen`; the `task-rail` drawer always holds `TaskSidebar` and is `lg:hidden` while a preview is open so the preview can take column 2 on desktop.

## Changes

- `packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx` — decouple `openPreview` from `sidebarOpen`; render `PreviewPanel` as its own grid child; `task-rail` always renders `TaskSidebar`.
- `packages/web/src/components/task-detail/preview-panel.tsx` — mobile full-screen overlay classes on the `<aside>`, reverting to the byte-for-byte original in-grid sticky column at `lg`.
- `test/browser/task-detail.mobile.spec.ts` — new mobile (390px) test: the preview opens as a full-screen overlay that hides the sidebar, and closing it does **not** reveal the meta panel (drawer stays off-screen, toggle stays `aria-expanded=false`).

## Testing

- `bunx vitest run test/task-comment-doc-preview.test.tsx` (packages/web) — passes (unchanged).
- `bunx playwright test test/browser/task-detail.mobile.spec.ts --project=mobile` — new test passes; existing mobile drawer test still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HGHgYCwBdpGfzSDaMip9xP)_