### PR TITLE
Lock structurally-fixed reporting lines (CEO, Captain, Coach)

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -272,7 +272,12 @@ project.
   agent via the hire approval handler (resolving the manager slug → member id). An
   existing agent's manager is set/changed with the **`set_agent_reports_to`** MCP tool
   (Captain or HQ coordinator; rejects self-reports and cycles) — the structural analogue
-  of the descriptive `team_context` blob. Each proposal is also mirrored as a `hire_proposal` action comment on the
+  of the descriptive `team_context` blob. Three roles have **structurally-fixed reporting
+  lines that cannot be changed** (`hasFixedReportsTo` / `FIXED_REPORTS_TO_SLUGS` in
+  `@hezo/shared`): the Captain always reports to the CEO, and the CEO and Coach report to
+  the admin (no agent). The lock is enforced on every write path — the REST
+  `PATCH /projects/:projectId/agents/:agentId` handler and the `set_agent_reports_to`
+  tool both reject a re-point of these roles, and the settings UI disables the field. Each proposal is also mirrored as a `hire_proposal` action comment on the
   linked ticket (`services/hire-proposal-comment.ts`), which flips to hired/denied on
   resolution and re-wakes the requester; the approval no longer auto-closes the ticket —
   the requester (the CEO) closes it once setup is complete. Retiring/reinstating an agent is the `set_agent_status` MCP tool (gated to

--- a/docs/reference/mcp-api.md
+++ b/docs/reference/mcp-api.md
@@ -521,7 +521,7 @@ Declare that, after evaluating the current task this run, there is genuinely not
 
 _Write tool._
 
-Set or change the manager an agent reports to — the structural reporting line in the org chart that gates delegation. Work can only be assigned to/from an agent along this line, so an agent whose manager is unset can't be delegated to or hand work down. Use this to wire up reporting structure (e.g. after hiring specialists, point them at their lead) or fix it during a coherence review. Pass the target agent and its new manager (both by slug or member ID); pass an empty reports_to to clear the line. Callable by the team's Captain or an HQ instance agent (CEO/Coach) acting in the team.
+Set or change the manager an agent reports to — the structural reporting line in the org chart that gates delegation. Work can only be assigned to/from an agent along this line, so an agent whose manager is unset can't be delegated to or hand work down. Use this to wire up reporting structure (e.g. after hiring specialists, point them at their lead) or fix it during a coherence review. Pass the target agent and its new manager (both by slug or member ID); pass an empty reports_to to clear the line. Callable by the team's Captain or an HQ instance agent (CEO/Coach) acting in the team. The Captain, CEO, and Coach have fixed reporting lines (Captain → CEO; CEO/Coach → admin) that cannot be changed.
 
 **Parameters:**
 
@@ -531,7 +531,7 @@ Set or change the manager an agent reports to — the structural reporting line 
 | `agent_id` | `string` | Yes | Target agent — its slug (e.g. "engineer") or member ID |
 | `reports_to` | `string` | Yes | The new manager — an existing agent's slug (or member ID) on this team. Pass an empty string to clear the reporting line. |
 
-**Returns:** `{ applied: true, agent, reports_to }` (`reports_to` is null when cleared), or `{ error }` if the agent/manager is not in the team, the manager is the agent itself, or the link would create a reporting cycle.
+**Returns:** `{ applied: true, agent, reports_to }` (`reports_to` is null when cleared), or `{ error }` if the agent/manager is not in the team, the target is the Captain/CEO/Coach (whose reporting lines are fixed), the manager is the agent itself, or the link would create a reporting cycle.
 
 **Authorization:** The team's Captain, or an HQ instance agent (CEO/Coach) acting in the team.
 

--- a/packages/server/src/mcp/mcp-reference.ts
+++ b/packages/server/src/mcp/mcp-reference.ts
@@ -267,7 +267,7 @@ export const TOOL_DOC_META: Record<string, ToolDocMeta> = {
 	set_agent_reports_to: {
 		category: 'Agents & hiring',
 		returns:
-			'`{ applied: true, agent, reports_to }` (`reports_to` is null when cleared), or `{ error }` if the agent/manager is not in the team, the manager is the agent itself, or the link would create a reporting cycle.',
+			'`{ applied: true, agent, reports_to }` (`reports_to` is null when cleared), or `{ error }` if the agent/manager is not in the team, the target is the Captain/CEO/Coach (whose reporting lines are fixed), the manager is the agent itself, or the link would create a reporting cycle.',
 		auth: "The team's Captain, or an HQ instance agent (CEO/Coach) acting in the team.",
 	},
 

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -24,6 +24,7 @@ import {
 	extractBacktickedMentionCandidates,
 	type GoalHealth,
 	getConnectorCapability,
+	hasFixedReportsTo,
 	INSTANCE_AGENT_SLUGS,
 	isAgentAuthorableAssetMime,
 	isMarkdownDocSlug,
@@ -3222,7 +3223,7 @@ export function registerTools(
 	tool(
 		server,
 		'set_agent_reports_to',
-		"Set or change the manager an agent reports to — the structural reporting line in the org chart that gates delegation. Work can only be assigned to/from an agent along this line, so an agent whose manager is unset can't be delegated to or hand work down. Use this to wire up reporting structure (e.g. after hiring specialists, point them at their lead) or fix it during a coherence review. Pass the target agent and its new manager (both by slug or member ID); pass an empty reports_to to clear the line. Callable by the team's Captain or an HQ instance agent (CEO/Coach) acting in the team.",
+		"Set or change the manager an agent reports to — the structural reporting line in the org chart that gates delegation. Work can only be assigned to/from an agent along this line, so an agent whose manager is unset can't be delegated to or hand work down. Use this to wire up reporting structure (e.g. after hiring specialists, point them at their lead) or fix it during a coherence review. Pass the target agent and its new manager (both by slug or member ID); pass an empty reports_to to clear the line. Callable by the team's Captain or an HQ instance agent (CEO/Coach) acting in the team. The Captain, CEO, and Coach have fixed reporting lines (Captain → CEO; CEO/Coach → admin) that cannot be changed.",
 		{
 			project: projectArg(),
 			agent_id: z.string().describe('Target agent — its slug (e.g. "engineer") or member ID'),
@@ -3250,6 +3251,14 @@ export function registerTools(
 				[agentId, teamId],
 			);
 			if (target.rows.length === 0) return { error: 'Agent not found in this team' };
+
+			// Structurally-fixed lines are immutable: the Captain always reports to the
+			// CEO; the CEO and Coach report to the admin. These cannot be re-pointed.
+			if (hasFixedReportsTo(target.rows[0].slug)) {
+				return {
+					error: `The ${target.rows[0].slug} reporting line is fixed and cannot be changed`,
+				};
+			}
 
 			const raw = String(args.reports_to ?? '').trim();
 			let managerId: string | null = null;

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -4,10 +4,12 @@ import {
 	type AiProvider,
 	ALL_AI_PROVIDERS,
 	AuthType,
+	CAPTAIN_AGENT_SLUG,
 	DEFAULT_EFFORT,
 	DEFAULT_HEARTBEAT_INTERVAL_MIN,
 	DEFAULT_TEAM_ID,
 	DocumentType,
+	hasFixedReportsTo,
 	INSTANCE_AGENT_SLUGS,
 	isAgentEffort,
 	isReservedAgentSlug,
@@ -778,6 +780,30 @@ agentsRoutes.patch('/projects/:projectId/agents/:agentId', async (c) => {
 		return err(c, 'INVALID_REQUEST', `Invalid default_effort: ${body.default_effort}`, 400);
 	}
 
+	// Structurally-fixed reporting lines (Captain → CEO, CEO/Coach → admin) are
+	// immutable. Reject any PATCH that moves one off its stored value; a no-op
+	// resubmission of the current value (as the settings form always sends) passes.
+	// The fetched current value is reused below as priorReportsTo.
+	let priorReportsTo: string | null | undefined;
+	if (body.reports_to !== undefined) {
+		const cur = await db.query<{ slug: string; reports_to: string | null }>(
+			'SELECT slug, reports_to FROM member_agents WHERE id = $1',
+			[agentId],
+		);
+		priorReportsTo = cur.rows[0]?.reports_to ?? null;
+		const slug = cur.rows[0]?.slug;
+		if (slug && hasFixedReportsTo(slug) && (body.reports_to ?? null) !== priorReportsTo) {
+			return err(
+				c,
+				'INVALID_REQUEST',
+				slug === CAPTAIN_AGENT_SLUG
+					? 'The Captain always reports to the CEO; its reporting line cannot be changed'
+					: 'This role reports to the admin; its reporting line cannot be changed',
+				400,
+			);
+		}
+	}
+
 	// A supplied system prompt must keep the required substitution variables.
 	// Instance singletons (CEO/Coach) are exempt — they have no in-team manager,
 	// so the {{reports_to}} requirement does not apply to them.
@@ -898,15 +924,6 @@ agentsRoutes.patch('/projects/:projectId/agents/:agentId', async (c) => {
 			[agentId],
 		);
 		return ok(c, result.rows[0]);
-	}
-
-	let priorReportsTo: string | null | undefined;
-	if (body.reports_to !== undefined) {
-		const prior = await db.query<{ reports_to: string | null }>(
-			'SELECT reports_to FROM member_agents WHERE id = $1',
-			[agentId],
-		);
-		priorReportsTo = prior.rows[0]?.reports_to ?? null;
 	}
 
 	if (body.title?.trim()) {

--- a/packages/server/test/reports-to-hire-flow.test.ts
+++ b/packages/server/test/reports-to-hire-flow.test.ts
@@ -174,13 +174,30 @@ describe('set_agent_reports_to', () => {
 		});
 		expect(self.error).toContain('cannot report to itself');
 
-		// engineer→captain now; making the captain report to the engineer closes a loop.
+		// engineer→captain now. Point the architect at the engineer, then closing the
+		// loop by pointing the engineer back at the architect is rejected as a cycle.
+		// (Uses two ordinary roles — the Captain's own line is fixed, see below.)
+		const link = await callTool(await captainToken(), 'set_agent_reports_to', {
+			project: projectSlug,
+			agent_id: 'architect',
+			reports_to: 'engineer',
+		});
+		expect(link.error).toBeUndefined();
 		const cycle = await callTool(await captainToken(), 'set_agent_reports_to', {
+			project: projectSlug,
+			agent_id: 'engineer',
+			reports_to: 'architect',
+		});
+		expect(cycle.error).toContain('cycle');
+	});
+
+	it('refuses to re-point a structurally-fixed reporting line (Captain)', async () => {
+		const result = await callTool(await captainToken(), 'set_agent_reports_to', {
 			project: projectSlug,
 			agent_id: 'captain',
 			reports_to: 'engineer',
 		});
-		expect(cycle.error).toContain('cycle');
+		expect(result.error).toContain('fixed');
 	});
 
 	it('an empty reports_to clears the reporting line', async () => {
@@ -215,5 +232,41 @@ describe('set_agent_reports_to', () => {
 			reports_to: 'captain',
 		});
 		expect(result.error).toContain('Access denied');
+	});
+});
+
+describe('REST PATCH locks fixed reporting lines', () => {
+	async function patchReportsTo(agentId: string, reportsTo: string | null) {
+		return app.request(`/api/projects/${projectSlug}/agents/${agentId}`, {
+			method: 'PATCH',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ reports_to: reportsTo }),
+		});
+	}
+
+	it("rejects changing the Captain's reports_to to another agent", async () => {
+		const res = await patchReportsTo(captainId, engineerId);
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.error.message).toContain('Captain');
+	});
+
+	it("allows a no-op resubmission of the Captain's current reports_to", async () => {
+		const cur = await db.query<{ reports_to: string | null }>(
+			'SELECT reports_to FROM member_agents WHERE id = $1',
+			[captainId],
+		);
+		const res = await patchReportsTo(captainId, cur.rows[0].reports_to);
+		expect(res.status).toBe(200);
+	});
+
+	it('still allows re-pointing an ordinary worker agent', async () => {
+		const res = await patchReportsTo(engineerId, captainId);
+		expect(res.status).toBe(200);
+		const row = await db.query<{ reports_to: string | null }>(
+			'SELECT reports_to FROM member_agents WHERE id = $1',
+			[engineerId],
+		);
+		expect(row.rows[0].reports_to).toBe(captainId);
 	});
 });

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -17,6 +17,21 @@ export const RESERVED_AGENT_SLUGS = [ADMIN_MENTION_SLUG] as const;
 export function isReservedAgentSlug(slug: string): boolean {
 	return (RESERVED_AGENT_SLUGS as readonly string[]).includes(slug);
 }
+
+/**
+ * Roles whose reporting line is structurally fixed and must never be user-editable:
+ * the Captain always reports to the CEO; the CEO and Coach report to the admin (no
+ * agent). Enforced across every write path (REST PATCH, MCP `set_agent_reports_to`)
+ * and disabled in the settings UI.
+ */
+export const FIXED_REPORTS_TO_SLUGS = [
+	CAPTAIN_AGENT_SLUG,
+	CEO_AGENT_SLUG,
+	COACH_AGENT_SLUG,
+] as const;
+export function hasFixedReportsTo(slug: string): boolean {
+	return (FIXED_REPORTS_TO_SLUGS as readonly string[]).includes(slug);
+}
 /**
  * The single instance-level coordination project, living in the HQ (default)
  * team. There is exactly one across the instance — it hosts the CEO + Coach and

--- a/packages/shared/test/reports-to.test.ts
+++ b/packages/shared/test/reports-to.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import {
+	CAPTAIN_AGENT_SLUG,
+	CEO_AGENT_SLUG,
+	COACH_AGENT_SLUG,
+	FIXED_REPORTS_TO_SLUGS,
+	hasFixedReportsTo,
+} from '../src/constants';
+
+describe('hasFixedReportsTo', () => {
+	it('is true for the structurally-fixed roles (captain, ceo, coach)', () => {
+		expect(hasFixedReportsTo(CAPTAIN_AGENT_SLUG)).toBe(true);
+		expect(hasFixedReportsTo(CEO_AGENT_SLUG)).toBe(true);
+		expect(hasFixedReportsTo(COACH_AGENT_SLUG)).toBe(true);
+	});
+
+	it('is false for ordinary worker roles', () => {
+		for (const slug of ['engineer', 'architect', 'product-lead', 'qa', 'devops', '']) {
+			expect(hasFixedReportsTo(slug)).toBe(false);
+		}
+	});
+
+	it('FIXED_REPORTS_TO_SLUGS lists exactly captain, ceo, coach', () => {
+		expect([...FIXED_REPORTS_TO_SLUGS].sort()).toEqual(
+			[CAPTAIN_AGENT_SLUG, CEO_AGENT_SLUG, COACH_AGENT_SLUG].sort(),
+		);
+	});
+});

--- a/packages/web/src/routes/projects/$projectId/agents/$agentId/settings.tsx
+++ b/packages/web/src/routes/projects/$projectId/agents/$agentId/settings.tsx
@@ -3,6 +3,8 @@ import {
 	AI_PROVIDER_INFO,
 	type AiProvider,
 	type BudgetWindowsCents,
+	CAPTAIN_AGENT_SLUG,
+	hasFixedReportsTo,
 } from '@hezo/shared';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { Loader2, Power, PowerOff } from 'lucide-react';
@@ -92,6 +94,10 @@ function AgentSettingsPage() {
 
 	const otherAgents =
 		agents?.filter((a) => a.id !== agentId && a.admin_status !== AgentAdminStatus.Disabled) ?? [];
+
+	// Captain, CEO, and Coach have structurally-fixed reporting lines (Captain → CEO;
+	// CEO/Coach → admin) that must not be user-editable — mirrors the server guard.
+	const reportsToLocked = hasFixedReportsTo(agent.slug);
 
 	async function handleSave(e: React.FormEvent) {
 		e.preventDefault();
@@ -192,7 +198,8 @@ function AgentSettingsPage() {
 					<select
 						value={reportsTo}
 						onChange={(e) => setReportsTo(e.target.value)}
-						className="rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-text-1 outline-none focus:border-border-strong"
+						disabled={reportsToLocked}
+						className="rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-text-1 outline-none focus:border-border-strong disabled:opacity-60 disabled:cursor-not-allowed"
 					>
 						<option value="">None (Admin)</option>
 						{otherAgents.map((a) => (
@@ -201,6 +208,13 @@ function AgentSettingsPage() {
 							</option>
 						))}
 					</select>
+					{reportsToLocked && (
+						<span data-testid="reports-to-locked-hint" className="text-xs text-text-2 italic">
+							{agent.slug === CAPTAIN_AGENT_SLUG
+								? 'The Captain always reports to the CEO; this reporting line is fixed.'
+								: 'This role reports to the admin; its reporting line is fixed.'}
+						</span>
+					)}
 				</label>
 
 				<div className="flex flex-col gap-1.5">

--- a/packages/web/test/agent-detail.test.tsx
+++ b/packages/web/test/agent-detail.test.tsx
@@ -184,6 +184,52 @@ test('agent settings tab edits the title and persists across reload', async () =
 	);
 });
 
+test('Captain settings disables the Reports To field with a fixed-line hint', async () => {
+	let teamSlug = '';
+	let captainId = '';
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			teamSlug = ws.internalSlug;
+			captainId = ws.agents.find((a) => a.slug === 'captain')!.id;
+		},
+	});
+	await router.navigate({
+		to: '/projects/$projectId/agents/$agentId/settings',
+		params: { projectId: teamSlug, agentId: captainId },
+	});
+
+	const hint = await findByTestId('reports-to-locked-hint');
+	expect(hint.textContent).toMatch(/Captain always reports to the CEO/);
+	const select = hint.closest('label')!.querySelector('select') as HTMLSelectElement;
+	expect(select.disabled).toBe(true);
+});
+
+test('ordinary agent settings leaves the Reports To field editable', async () => {
+	let teamSlug = '';
+	let engineerId = '';
+	const { findByText, queryByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			teamSlug = ws.internalSlug;
+			engineerId = ws.agents.find((a) => a.slug === 'engineer')!.id;
+		},
+	});
+	await router.navigate({
+		to: '/projects/$projectId/agents/$agentId/settings',
+		params: { projectId: teamSlug, agentId: engineerId },
+	});
+
+	// Wait for the settings form to render, then assert the select is enabled and
+	// carries no fixed-line hint.
+	const label = await findByText('Reports To');
+	const select = label.closest('label')!.querySelector('select') as HTMLSelectElement;
+	expect(select.disabled).toBe(false);
+	expect(queryByTestId('reports-to-locked-hint')).toBeNull();
+});
+
 test('agent header shows a live next-heartbeat countdown when the agent has work', async () => {
 	let projectSlug = '';
 	let agentId = '';


### PR DESCRIPTION
## Summary

Three roles have **structurally-fixed reporting lines** that must never change:

- **CEO** → reports to the admin (no agent / `reports_to = null`)
- **Coach** → reports to the admin (`reports_to = null`)
- **Captain** → reports to the CEO (mandatory in every team, wired at provisioning by `linkTeamCaptainToInstanceCeo`)

Previously nothing enforced this: the agent settings **Reports To** `<select>` was editable for every agent, the REST `PATCH /projects/:projectId/agents/:agentId` handler wrote `reports_to` with no role check, and the MCP `set_agent_reports_to` tool let the Captain/CEO re-point these roles. Re-pointing a Captain or CEO breaks delegation gating (`assertSubordinateAssignee`) and the org chart.

This makes those reporting lines immutable across **every** write path and disables the field in the UI with an explanation.

## Changes

- **`@hezo/shared`** — new `FIXED_REPORTS_TO_SLUGS` + `hasFixedReportsTo(slug)` predicate (captain / ceo / coach).
- **REST PATCH handler** (`packages/server/src/routes/agents.ts`) — rejects a `reports_to` change for a fixed role with a 400. A no-op resubmission of the current value (as the settings form always sends) still passes. Reuses the fetched current value as `priorReportsTo` to avoid a duplicate query.
- **MCP `set_agent_reports_to`** (`packages/server/src/mcp/tools.ts`) — rejects re-pointing a fixed role; tool description + generated `docs/reference/mcp-api.md` and `TOOL_DOC_META` note updated.
- **Web UI** (`agents/$agentId/settings.tsx`) — disables the Reports To select for these roles and shows a fixed-line hint ("The Captain always reports to the CEO" / "This role reports to the admin").
- **`.dev/architecture.md`** — documents the fixed reporting lines and where they're enforced.

Enforcement rule kept simple/robust: for a fixed-slug agent, reject any request that moves `reports_to` off its stored value. Provisioning already sets the correct values, so only an actual re-point is blocked. No DB migration — this is an application-layer invariant on existing columns.

## Tests

- **Shared unit** (`packages/shared/test/reports-to.test.ts`) — `hasFixedReportsTo` true for captain/ceo/coach, false for ordinary roles.
- **Server integration** (`packages/server/test/reports-to-hire-flow.test.ts`) — REST PATCH of the Captain's `reports_to` → 400; no-op resubmission → 200; ordinary worker still re-pointable; MCP `set_agent_reports_to` targeting the Captain → error contains "fixed". Existing cycle test reworked to use two ordinary roles.
- **Web component** (`packages/web/test/agent-detail.test.tsx`) — Captain settings renders the Reports To select disabled with the hint; ordinary agent leaves it editable.
- Docs drift (`mcp-reference.test.ts`, `docs-bundle*.test.ts`) stay green.

All server agents suites, shared, and web component tiers pass; `typecheck` and the full build are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018qE7Mt9yAwjw9k8j6ny8s8)_