### PR TITLE
fix(web): keep documents page within the viewport for wide doc content

### DIFF
--- a/packages/web/src/components/docs-library.tsx
+++ b/packages/web/src/components/docs-library.tsx
@@ -104,7 +104,11 @@ export function DocsLibrary({
 	}
 
 	return (
-		<div className="grid grid-cols-1 md:grid-cols-[240px_1fr] md:gap-6 md:min-h-[500px]">
+		/* minmax(0,1fr) — a bare 1fr track has an `auto` minimum, so wide doc
+		   content (tables, code) would push the column past the viewport and
+		   side-scroll the doc list out of view instead of scrolling inside the
+		   pane. */
+		<div className="grid grid-cols-1 md:grid-cols-[240px_minmax(0,1fr)] md:gap-6 md:min-h-[500px]">
 			<aside
 				className={`md:border-r md:border-border md:pr-6 ${
 					showRightPane ? 'hidden md:block' : 'block'

--- a/packages/web/src/components/markdown-prose.tsx
+++ b/packages/web/src/components/markdown-prose.tsx
@@ -25,8 +25,11 @@ import { Tooltip } from './ui/tooltip';
 
 type RemarkPlugin = Parameters<typeof Markdown>[0]['remarkPlugins'];
 
+// break-words wraps long unbreakable strings (URLs, paths) inside the prose
+// column instead of widening it; tables opt back out so cell tokens stay whole
+// and the table scrolls in its overflow wrapper (see the `table` component).
 const PROSE_CLASSES =
-	'prose prose-sm max-w-none text-sm text-text-1 [&_a]:text-info-soft-fg [&_h1]:text-text-1 [&_h2]:text-text-1 [&_h3]:text-text-1 [&_h4]:text-text-1 [&_strong]:text-text-1 [&_code]:text-info-soft-fg [&_code]:bg-surface-3 [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded [&_pre]:bg-surface-3 [&_pre]:border [&_pre]:border-border [&_blockquote]:text-text-1 [&_blockquote]:border-l-border-strong [&_blockquote_p]:text-text-1 [&_p:last-child]:mb-0 [&_p:first-child]:mt-0 [&_hr]:my-6';
+	'prose prose-sm max-w-none break-words [&_table]:[overflow-wrap:normal] text-sm text-text-1 [&_a]:text-info-soft-fg [&_h1]:text-text-1 [&_h2]:text-text-1 [&_h3]:text-text-1 [&_h4]:text-text-1 [&_strong]:text-text-1 [&_code]:text-info-soft-fg [&_code]:bg-surface-3 [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded [&_pre]:bg-surface-3 [&_pre]:border [&_pre]:border-border [&_blockquote]:text-text-1 [&_blockquote]:border-l-border-strong [&_blockquote_p]:text-text-1 [&_p:last-child]:mb-0 [&_p:first-child]:mt-0 [&_hr]:my-6';
 
 interface MarkdownProseProps {
 	children: string;
@@ -382,6 +385,15 @@ export function MarkdownProse({
 					</a>
 				);
 			},
+			// A wide table would otherwise widen the prose container itself (tables
+			// have no intrinsic overflow handling, unlike `pre`), pushing the whole
+			// page into horizontal scroll; the wrapper keeps the scrollbar on the
+			// table alone.
+			table: (props) => (
+				<div className="overflow-x-auto">
+					<table>{props.children}</table>
+				</div>
+			),
 		};
 	}, [projectId, instance, openPreview]);
 

--- a/test/browser/docs-content-fit.spec.ts
+++ b/test/browser/docs-content-fit.spec.ts
@@ -1,0 +1,76 @@
+// Viewport fit is a real-CSS-layout assertion (testing decision tree, point 1):
+// it compares the shell scroller's scrollWidth/clientWidth and the table
+// wrapper's internal overflow after a real layout pass — happy-dom computes
+// neither.
+
+import { expect, test } from './fixtures';
+import { waitForPageLoad } from './helpers';
+
+// The three content shapes that can widen a doc past the pane: a table whose
+// unbreakable code cells far exceed the column width, a single-line code
+// fence, and a long unbreakable word in a paragraph.
+const WIDE_DOC = [
+	'# Wide document',
+	'',
+	'Reference sheet: https://example.com/a-very-long-unbreakable-url-segment/that-would-otherwise-widen-the-prose-column-past-the-viewport-if-it-could-not-wrap',
+	'',
+	'| Metric | Endpoint | Frequency |',
+	'| --- | --- | --- |',
+	'| Release downloads (per release, per platform) | `GET /repos/hezo-ai/hezo/releases/assets/deeply/nested/unbreakable/path` → `.assets[].download_count_with_a_long_property_name` | Per-release + weekly rollup |',
+	// Underscore-only token: unlike slashes/hyphens, underscores offer no
+	// line-break opportunity, so this cell's min-content width (~1000px)
+	// genuinely exceeds the doc pane at every viewport under test.
+	'| Star → download conversion | `total_downloads_divided_by_stargazers_count_as_one_underscored_token_that_offers_no_line_break_opportunity_at_all_and_therefore_exceeds_any_reasonable_pane_width` | Weekly |',
+	'',
+	'```sh',
+	'curl -sS https://api.github.com/repos/hezo-ai/hezo/releases | jq ".[] | {tag_name, assets: [.assets[] | {name, download_count}]}" # one long line that must scroll inside the pre block, not widen the page',
+	'```',
+].join('\n');
+
+test('documents page fits the viewport with wide doc content (desktop + mobile)', async ({
+	page,
+	lightWorkspace,
+}) => {
+	const { projectSlug, token } = lightWorkspace;
+	// Desktop: clears md (doc list beside the content pane) and lg (full rail +
+	// project sidebar), so the pane gets its narrowest desktop width.
+	await page.setViewportSize({ width: 1280, height: 800 });
+
+	const res = await page.request.put(`/api/projects/${projectSlug}/docs/wide.md`, {
+		headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+		data: { content: WIDE_DOC },
+	});
+	expect(res.ok()).toBe(true);
+
+	await page.goto(`/projects/${projectSlug}/documents?file=wide.md`);
+	await waitForPageLoad(page);
+	await expect(page.getByRole('heading', { name: 'wide.md' })).toBeVisible({ timeout: 20000 });
+
+	// The shell <main> is the only scroller; wide doc content must not give it
+	// horizontal overflow (±1px for sub-pixel rounding)…
+	const scroller = page.locator('main').first();
+	expect(await scroller.evaluate((el) => el.scrollWidth - el.clientWidth)).toBeLessThanOrEqual(1);
+
+	// …so trying to side-scroll is a no-op and the doc list stays in view.
+	await scroller.evaluate((el) => el.scrollTo({ left: el.scrollWidth }));
+	expect(await scroller.evaluate((el) => el.scrollLeft)).toBeLessThanOrEqual(1);
+	const newDocButton = page.getByRole('button', { name: /New document/ });
+	await expect(newDocButton).toBeVisible();
+	const listBox = await newDocButton.boundingBox();
+	expect(listBox).not.toBeNull();
+	if (listBox) {
+		expect(listBox.x).toBeGreaterThanOrEqual(0);
+	}
+
+	// The wide table is preserved, not clipped: it scrolls inside its own
+	// wrapper instead of widening the page.
+	const tableWrapper = page.locator('main div.overflow-x-auto:has(> table)').first();
+	await expect(tableWrapper).toBeVisible();
+	expect(await tableWrapper.evaluate((el) => el.scrollWidth - el.clientWidth)).toBeGreaterThan(50);
+
+	// Mobile: the doc pane replaces the list at <md; the same wide content must
+	// not widen the page there either.
+	await page.setViewportSize({ width: 375, height: 800 });
+	await expect(page.getByRole('heading', { name: 'wide.md' })).toBeVisible();
+	expect(await scroller.evaluate((el) => el.scrollWidth - el.clientWidth)).toBeLessThanOrEqual(1);
+});


### PR DESCRIPTION
## Problem

On desktop, opening a document with wide content (tables of endpoint paths, long code lines, long URLs) made the whole page scroll horizontally, so the docs menu could be side-scrolled out of view.

Two compounding causes:

1. `DocsLibrary`'s grid used `md:grid-cols-[240px_1fr]`. A bare `1fr` track has an implicit `auto` minimum, so the content column grew to the widest table/code block instead of being capped at the free space, giving the shell `<main>` scroller horizontal overflow.
2. `MarkdownProse` rendered GFM tables with no overflow handling, so even a width-constrained pane had nowhere for a wide table to scroll.

## Fix

- **`DocsLibrary`**: content column is now `minmax(0,1fr)`, capping it at the available space (with a comment so it doesn't get "simplified" back to `1fr`).
- **`MarkdownProse`** (benefits every markdown surface — comments, CEO chat, previews):
  - GFM tables render inside an `overflow-x-auto` wrapper, so a wide table scrolls by itself (typography's `pre` already does this once the column is constrained).
  - `break-words` on the prose container wraps long unbreakable strings (URLs, paths) in paragraphs; tables opt back out via `[overflow-wrap:normal]` so cell tokens stay whole and the table scrolls GitHub-style instead of breaking mid-token.

## Tests

- New Playwright spec `test/browser/docs-content-fit.spec.ts` (real-CSS-layout assertion, decision-tree point 1): seeds a doc with a wide table, a long single-line code fence, and a long URL, then asserts the shell scroller gains no horizontal overflow, a side-scroll attempt is a no-op with the doc list still in view, the table overflows *inside* its wrapper (content preserved, not clipped), and the same holds at the 375px mobile viewport.
- Existing `docs-sidebar-sticky.spec.ts` and `content-width.spec.ts` pass with the grid change.
- Web component tier: 147 files / 830 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FkAmhg3ggMFdhqxG74qYNz

---
_Generated by [Claude Code](https://claude.ai/code/session_01FkAmhg3ggMFdhqxG74qYNz)_