### PR TITLE
fix(web): stop logo-less provider wordmark from overflowing the AI-provider picker header

### DIFF
--- a/packages/web/src/components/ai-provider-picker.tsx
+++ b/packages/web/src/components/ai-provider-picker.tsx
@@ -26,17 +26,17 @@ export function AiProviderPicker() {
 				<button
 					type="button"
 					onClick={() => setProvider(null)}
-					className="text-text-2 hover:text-text-1 p-2 -m-2"
+					className="shrink-0 text-text-2 hover:text-text-1 p-2 -m-2"
 					aria-label="Back"
 				>
 					<ArrowLeft className="w-4 h-4" />
 				</button>
-				<span className="flex h-6 w-6 items-center justify-center text-text-1">
+				<span className="flex h-6 w-6 shrink-0 items-center justify-center text-text-1">
 					<ProviderLogo provider={provider} className="h-5 w-5" />
 				</span>
-				<div className="flex flex-col">
-					<span className="text-sm font-medium text-text-1">Connect {info.name}</span>
-					<span className="text-xs text-text-3">{info.runtimeLabel}</span>
+				<div className="flex min-w-0 flex-col">
+					<span className="truncate text-sm font-medium text-text-1">Connect {info.name}</span>
+					<span className="truncate text-xs text-text-3">{info.runtimeLabel}</span>
 				</div>
 			</div>
 

--- a/packages/web/src/components/provider-logos.tsx
+++ b/packages/web/src/components/provider-logos.tsx
@@ -7,8 +7,9 @@ import type { FC } from 'react';
  * Each logo is a self-contained monochrome inline SVG using `currentColor`, so
  * it inherits the card's text colour and themes correctly in light/dark. Only
  * providers whose mark can be reproduced cleanly get an SVG here; everything
- * else falls back to a big-font wordmark via {@link ProviderLogo}. Drop a new
- * entry in this map to give another provider a real logo.
+ * else falls back to a compact monogram (the provider's initial) via
+ * {@link ProviderLogo}. Drop a new entry in this map to give another provider a
+ * real logo.
  */
 
 type LogoProps = { className?: string };
@@ -36,15 +37,23 @@ interface ProviderLogoProps {
 }
 
 /**
- * Render a provider's brand mark, or — when no SVG is registered — its name as
- * a big-font wordmark. Used on the provider-picker cards.
+ * Render a provider's brand mark, sized to fill the slot the caller sizes via
+ * `className` (e.g. `h-5 w-5`). Providers with a registered SVG show it; the
+ * rest fall back to a compact monogram of the provider's initial that fits the
+ * same box. The full provider name is shown as a large wordmark only on the
+ * card grid, which has room for it (see {@link ProviderCardGrid}) — squeezing a
+ * wordmark into a small slot (the picker header) overflows and overlaps its
+ * neighbours, so the fallback stays a single-letter badge here.
  */
 export function ProviderLogo({ provider, className }: ProviderLogoProps) {
 	const Logo = PROVIDER_LOGOS[provider];
 	if (Logo) return <Logo className={className} />;
 	return (
-		<span className="text-lg font-bold leading-none tracking-tight text-center sm:text-xl">
-			{AI_PROVIDER_INFO[provider].name}
+		<span
+			aria-hidden="true"
+			className={`flex items-center justify-center rounded-[5px] bg-surface-3 text-[13px] font-bold uppercase leading-none text-text-1 ${className ?? ''}`}
+		>
+			{AI_PROVIDER_INFO[provider].name.charAt(0)}
 		</span>
 	);
 }

--- a/packages/web/test/ai-providers.test.tsx
+++ b/packages/web/test/ai-providers.test.tsx
@@ -56,6 +56,32 @@ test('Add provider modal shows provider cards (no xAI/OpenRouter, no Moonshot, n
 	expect(queryAllByRole('button', { name: /OAuth/i }).length).toBe(0);
 });
 
+test('drilling into a logo-less provider shows a monogram, not an overflowing wordmark, and Back returns to the picker', async () => {
+	const { findByRole, getByRole, getByText, queryByText, user } = await renderApp({
+		initialPath: '/settings/ai-providers',
+		seed: async () => {
+			// Clear the default seeded provider so the gate renders the picker grid.
+			await clearAiProviders();
+		},
+	});
+
+	await findByRole('heading', { name: 'Set up an AI provider' }, { timeout: 15_000 });
+
+	// DeepSeek has no registered brand SVG, so its logo slot hits the fallback.
+	await user.click(getByRole('button', { name: 'DeepSeek' }));
+
+	// The header names the provider once, in the "Connect …" label. The logo slot
+	// renders a compact initial — not the full-name wordmark that used to overflow
+	// the small (24px) icon box, overlap the label, and cover the Back button.
+	getByText('Connect DeepSeek');
+	expect(queryByText('DeepSeek', { exact: true })).toBeNull();
+
+	// Back is reachable and returns to the card grid, so the provider that was
+	// only listed there (its own card) is selectable again.
+	await user.click(getByRole('button', { name: 'Back' }));
+	await findByRole('button', { name: 'DeepSeek' });
+});
+
 test('sidebar Settings link reaches Settings and the AI providers subpage', async () => {
 	const { findByRole, findByText, getAllByRole, router, user } = await renderApp({
 		initialPath: `/teams/${DEFAULT_TEAM_SLUG}/tasks`,


### PR DESCRIPTION
## Problem

When you drill into an AI provider that has no registered brand SVG — DeepSeek, OpenAI, Kimi, z.ai — the picker header rendered a broken, overlapping layout, and the **Back arrow was unclickable** so you couldn't return to the provider grid.

### Root cause

`ProviderLogo`'s fallback branch renders the provider *name* as a big-font wordmark (`text-lg … sm:text-xl`) and **ignores the caller's `className` sizing** (`h-5 w-5`). The picker header (`AiProviderPicker`) places that logo in a 24px slot, so a bold "DeepSeek" wordmark overflowed in every direction:

- it collided with the `Connect <name>` / runtime-label text on the right, and
- it sat **on top of the Back arrow** on the left, hiding it and intercepting the click.

The provider **card grid** never hit this branch — it checks `hasLogo` and renders its own large wordmark on a roomy tile — so the fallback was effectively only ever seen (broken) in the small header slot.

## Fix

- `ProviderLogo` fallback now renders a compact **monogram** (the provider's initial) that fits the sized slot, matching how the real SVG marks fill it. The full wordmark still shows on the card grid, which has room for it.
- Hardened the header row so it can't be squeezed on mobile: `shrink-0` on the Back button and logo slot, `min-w-0` + `truncate` on the label column.

### Before → After

- **Before:** oversized `DeepSeek` wordmark overlapping the label and covering the Back arrow.
- **After:** a `D` monogram badge in its slot, Back arrow (←) fully visible and clickable, `Connect DeepSeek` / `Claude Code` neatly beside it.

## Testing

- New regression test in `packages/web/test/ai-providers.test.tsx`: drilling into DeepSeek shows the monogram (asserts no standalone full-name wordmark) and Back returns to the picker grid. Verified it **fails** against the pre-fix code (it detected the `text-lg` wordmark) and passes after.
- Full `ai-providers.test.tsx` suite green (15/15); `turbo typecheck` and the production build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaGyDuMRAX1hg8VCuVpsSX

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaGyDuMRAX1hg8VCuVpsSX)_