### PR TITLE
fix: group document review controls into a distinct toolbar cluster

### DIFF
--- a/docs/concepts/documents-and-memory.md
+++ b/docs/concepts/documents-and-memory.md
@@ -91,12 +91,13 @@ ways to comment:
   clicking it highlights the entire line and attaches your comment to it.
 
 Each comment shows as an icon in the right margin, level with its highlighted text. Click a
-highlight or its icon to **edit or delete** that comment. The toolbar above the document
-shows a comment count plus two actions — **action this review** (a clipboard button that
-copies a ready-made handoff you can paste into a task comment or a new task's description
-when assigning the work to an agent) and **clear review** (a trash button that deletes every
-comment after confirmation). The **?** button next to the toolbar opens a short in-app guide
-to all of this.
+highlight or its icon to **edit or delete** that comment. The review controls are grouped
+together into their own **review toolbar** above the document — set apart from the document's
+own edit and delete actions so the two don't get mixed up. It shows a comment count plus two
+actions — **action this review** (a clipboard button that copies a ready-made handoff you can
+paste into a task comment or a new task's description when assigning the work to an agent) and
+**clear review** (a trash button that deletes every comment after confirmation) — alongside a
+**?** button that opens a short in-app guide to all of this.
 
 Agents read pending review comments directly: `read_project_doc` returns them alongside the
 document content, each one anchored to the exact text you highlighted. So the flow is —

--- a/packages/web/src/components/docs-library.tsx
+++ b/packages/web/src/components/docs-library.tsx
@@ -1,6 +1,5 @@
 import { ArrowLeft, ExternalLink, FileText, Loader2, Plus, Trash2 } from 'lucide-react';
 import { type ReactNode, useEffect, useRef, useState } from 'react';
-import { ReviewHelp } from './document-review/review-help';
 import { ReviewToolbarActions } from './document-review/review-toolbar-actions';
 import { ReviewableDocument } from './document-review/reviewable-document';
 import { MarkdownProse } from './markdown-prose';
@@ -207,10 +206,7 @@ export function DocsLibrary({
 								{mode === 'view' ? (
 									<>
 										{review && projectId && (
-											<>
-												<ReviewToolbarActions projectId={projectId} filename={review.filename} />
-												<ReviewHelp />
-											</>
+											<ReviewToolbarActions projectId={projectId} filename={review.filename} />
 										)}
 										{popOutUrl && (
 											<Button

--- a/packages/web/src/components/document-review/review-toolbar-actions.tsx
+++ b/packages/web/src/components/document-review/review-toolbar-actions.tsx
@@ -4,11 +4,20 @@ import { useClearDocReviewComments, useDocReviewComments } from '../../hooks/use
 import { ConfirmDialog } from '../ui/confirm-dialog';
 import { Tooltip } from '../ui/tooltip';
 import { ActionReviewDialog } from './action-review-dialog';
+import { ReviewHelp } from './review-help';
 
 interface ReviewToolbarActionsProps {
 	/** Route-param project slug (query keys + API paths). */
 	projectId: string;
 	filename: string;
+	/**
+	 * `'grouped'` (default) wraps the controls in a tinted, rounded container so
+	 * the review-comment tools read as one self-contained cluster, clearly set
+	 * apart from the document-level actions (edit / delete / open-in-new-tab)
+	 * sitting beside them in the same header. `'inline'` drops the container for
+	 * surfaces that already supply their own (the standalone preview toolbar).
+	 */
+	variant?: 'grouped' | 'inline';
 }
 
 const ICON_BUTTON_CLASSES =
@@ -16,18 +25,29 @@ const ICON_BUTTON_CLASSES =
 
 /**
  * The review actions for a document view surface: comment count, "Action this
- * review" (agent handoff dialog) and "Clear review" (confirm-gated delete of
- * every comment). Dropped into each surface's header/toolbar.
+ * review" (agent handoff dialog), "Clear review" (confirm-gated delete of every
+ * comment) and the "?" help affordance. These belong together as the document's
+ * review-comment toolbar, kept visually distinct from the document's own
+ * meta-level actions. Dropped into each surface's header/toolbar.
  */
-export function ReviewToolbarActions({ projectId, filename }: ReviewToolbarActionsProps) {
+export function ReviewToolbarActions({
+	projectId,
+	filename,
+	variant = 'grouped',
+}: ReviewToolbarActionsProps) {
 	const { data: comments } = useDocReviewComments(projectId, filename);
 	const clearMutation = useClearDocReviewComments(projectId, filename);
 	const [actionOpen, setActionOpen] = useState(false);
 	const [confirmClearOpen, setConfirmClearOpen] = useState(false);
 	const count = comments?.length ?? 0;
 
+	const containerClasses =
+		variant === 'grouped'
+			? 'flex shrink-0 items-center gap-1 rounded-lg border border-border bg-surface-2 px-1.5 py-0.5'
+			: 'flex shrink-0 items-center gap-1';
+
 	return (
-		<div className="flex shrink-0 items-center gap-1">
+		<div className={containerClasses} data-testid="review-toolbar">
 			{count > 0 && (
 				<span
 					className="inline-flex items-center gap-1 rounded-full bg-neutral-soft px-2 py-0.5 text-[11px] font-medium text-neutral-soft-fg"
@@ -62,6 +82,7 @@ export function ReviewToolbarActions({ projectId, filename }: ReviewToolbarActio
 					<Trash2 className="h-4 w-4" />
 				</button>
 			</Tooltip>
+			<ReviewHelp className="rounded-md p-1 leading-none hover:bg-surface-3" />
 			<ActionReviewDialog
 				open={actionOpen}
 				onOpenChange={setActionOpen}

--- a/packages/web/src/components/task-detail/preview-panel.tsx
+++ b/packages/web/src/components/task-detail/preview-panel.tsx
@@ -1,7 +1,6 @@
 import { ExternalLink, X } from 'lucide-react';
 import { useProjectDoc } from '../../hooks/use-project-docs';
 import { docPreviewPath } from '../../lib/doc-preview';
-import { ReviewHelp } from '../document-review/review-help';
 import { ReviewToolbarActions } from '../document-review/review-toolbar-actions';
 import { ReviewableDocument } from '../document-review/reviewable-document';
 import type { PreviewItem } from './preview-context';
@@ -54,7 +53,6 @@ export function PreviewPanel({ item, onClose }: PreviewPanelProps) {
 					<ExternalLink className="h-3 w-3" />
 				</a>
 				<ReviewToolbarActions projectId={item.projectId} filename={item.filename} />
-				<ReviewHelp />
 				<button
 					type="button"
 					onClick={onClose}

--- a/packages/web/src/routes/preview/$projectId/$filename.tsx
+++ b/packages/web/src/routes/preview/$projectId/$filename.tsx
@@ -1,5 +1,4 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { ReviewHelp } from '../../../components/document-review/review-help';
 import { ReviewToolbarActions } from '../../../components/document-review/review-toolbar-actions';
 import { ReviewableDocument } from '../../../components/document-review/reviewable-document';
 import { useProjectDoc } from '../../../hooks/use-project-docs';
@@ -30,9 +29,8 @@ function DocPreviewPage() {
 						{filename}
 					</span>
 					<span className="h-4 w-px shrink-0 bg-border" aria-hidden />
-					<ReviewToolbarActions projectId={projectId} filename={filename} />
+					<ReviewToolbarActions projectId={projectId} filename={filename} variant="inline" />
 				</div>
-				<ReviewHelp />
 			</div>
 			<div className="max-w-3xl mx-auto px-4 py-8 sm:px-6 lg:px-8">
 				<ReviewableDocument

--- a/packages/web/test/document-review.test.tsx
+++ b/packages/web/test/document-review.test.tsx
@@ -95,6 +95,42 @@ test('renders seeded review comments as highlights with margin icons and a count
 	expect((await findByTestId('review-count-chip')).textContent).toContain('2');
 });
 
+test('groups the review-comment controls in a bordered cluster, apart from the document actions', async () => {
+	const { findByTestId, getByTestId, getByRole } = await setupDocumentsPage({
+		comments: [{ quote: 'target text', comment: 'Group me' }],
+	});
+
+	// Wait for the comments query to resolve (count chip appears) so every review
+	// control is mounted before we assert on the grouping.
+	const chip = await findByTestId('review-count-chip');
+	const toolbar = getByTestId('review-toolbar');
+
+	// The review-comment controls — count, action-this-review, clear-review and
+	// the "?" help — all live inside the one grouped cluster.
+	expect(toolbar.contains(chip)).toBe(true);
+	for (const testid of ['review-action-open', 'review-clear', 'review-help']) {
+		expect(toolbar.querySelector(`[data-testid="${testid}"]`)).toBeTruthy();
+	}
+
+	// The cluster is visually contained (rounded, bordered, tinted background) so
+	// it reads as one group distinct from the actions beside it.
+	expect(toolbar.className).toContain('rounded-lg');
+	expect(toolbar.className).toContain('border');
+	expect(toolbar.className).toContain('bg-surface-2');
+
+	// The document-level meta actions sit OUTSIDE the review cluster — that
+	// separation is the whole point. In particular the two trash icons (clear the
+	// review vs. delete the document) now live in different groups.
+	const popout = getByTestId('doc-popout');
+	const editButton = getByRole('button', { name: 'Edit' });
+	const deleteDoc = getByRole('button', { name: 'Delete document' });
+	expect(toolbar.contains(popout)).toBe(false);
+	expect(toolbar.contains(editButton)).toBe(false);
+	expect(toolbar.contains(deleteDoc)).toBe(false);
+	// The clear-review trash, by contrast, is inside the cluster.
+	expect(toolbar.contains(getByTestId('review-clear'))).toBe(true);
+});
+
 test('clicking a margin icon opens the editor and saving updates the comment', async () => {
 	const { container, findByTestId, user } = await setupDocumentsPage({
 		comments: [{ quote: 'target text', comment: 'Original comment' }],


### PR DESCRIPTION
## Problem

The document header packed the **review-comment controls** and the document's **own meta actions** into one flat, undivided row:

`💬1  ·  📋 action review  ·  🗑 clear review  ·  ?  ·  ↗ open  ·  Edit  ·  🗑 delete`

Two identical trash icons — *clear the review* vs. *delete the document* — sat side by side reading exactly the same, and nothing signalled that the first four controls are one feature and the rest are another. It was easy to misread.

## Change

Wrap the review-comment controls in a tinted, rounded, bordered **cluster** so they read as one self-contained group, clearly set apart from the document actions beside them (matching the container pattern already used by the standalone preview toolbar). The `?` help affordance moves inside the cluster too, since it explains the review system.

`ReviewToolbarActions` gains a `variant` prop:
- `grouped` (default) — the bordered cluster.
- `inline` — no container, for the standalone preview route which already supplies its own pill.

Applied across all three surfaces that render it: the **Documents page**, the **task-sidebar preview panel**, and the **standalone document preview route**.

**Visual before/after** (rendered in the app's real light/dark tokens): https://claude.ai/code/artifact/21b008bc-9c64-4b32-86d7-5014820406a7

## Testing

- New component test in `document-review.test.tsx` asserts the review controls (count, action, clear, help) live inside the grouped cluster while the doc actions (open, edit, delete) sit outside it.
- Full `document-review` + `project-doc-preview` suites pass (13 tests).
- `typecheck`, `biome check`, and the production `build` all pass (via the pre-commit hook).

## Docs

Updated `docs/concepts/documents-and-memory.md` to describe the review toolbar as a grouped set of controls, separate from the document's own actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UyJMrgqzZX2PFfqcHjJmwJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UyJMrgqzZX2PFfqcHjJmwJ)_