### PR TITLE
feat(web): widen the task doc preview panel on xl/2xl screens

### DIFF
--- a/packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx
@@ -62,8 +62,10 @@ function TaskDetailPage() {
 	const [commentEffort, setCommentEffort] = useState<AgentEffort | null>(null);
 	const [replyTarget, setReplyTarget] = useState<Comment | null>(null);
 	// A doc clicked in a comment opens in the preview panel: an in-grid column at
-	// lg+, and its own full-screen overlay (above the main content and the meta
-	// drawer) below lg. It is independent of the meta side rail.
+	// lg+ that widens on the roomier xl/2xl breakpoints (up to 2× its base width)
+	// so wide screens get a more readable document view, and its own full-screen
+	// overlay (above the main content and the meta drawer) below lg. It is
+	// independent of the meta side rail.
 	const [preview, setPreview] = useState<PreviewItem | null>(null);
 	// The meta side rail is a collapsed-by-default drawer on mobile, toggled by
 	// the chevron. It is independent of the preview panel — opening/closing a
@@ -102,7 +104,7 @@ function TaskDetailPage() {
 	return (
 		<>
 			<div
-				className={`grid grid-cols-1 gap-5 ${preview ? 'lg:grid-cols-[1fr_360px]' : 'lg:grid-cols-[1fr_190px]'}`}
+				className={`grid grid-cols-1 gap-5 ${preview ? 'lg:grid-cols-[1fr_360px] xl:grid-cols-[1fr_520px] 2xl:grid-cols-[1fr_720px]' : 'lg:grid-cols-[1fr_190px]'}`}
 			>
 				<PreviewProvider value={openPreview}>
 					<div className="min-w-0">
@@ -218,7 +220,7 @@ function TaskDetailPage() {
 			    the sidebar (whichever width the preview panel is using). */}
 			<div
 				aria-hidden={atBottom}
-				className={`hidden lg:grid sticky bottom-4 z-30 gap-5 pointer-events-none ${preview ? 'lg:grid-cols-[1fr_360px]' : 'lg:grid-cols-[1fr_190px]'}`}
+				className={`hidden lg:grid sticky bottom-4 z-30 gap-5 pointer-events-none ${preview ? 'lg:grid-cols-[1fr_360px] xl:grid-cols-[1fr_520px] 2xl:grid-cols-[1fr_720px]' : 'lg:grid-cols-[1fr_190px]'}`}
 			>
 				<div className="flex justify-center">
 					<ScrollToBottomButton

--- a/test/browser/task-doc-preview-width.spec.ts
+++ b/test/browser/task-doc-preview-width.spec.ts
@@ -1,0 +1,107 @@
+// Viewport-conditional real-CSS-layout assertion (testing decision tree, points
+// 1 & 2): the in-page document preview panel is grid column 2 whose track width
+// is set by responsive `grid-cols-[1fr_Npx]` utilities that only diverge once a
+// real layout pass evaluates the lg/xl/2xl media queries. happy-dom runs no media
+// queries and returns zero-width boxes, so the widening can only be observed in a
+// real browser at real viewport sizes. The mention→panel data flow itself is
+// covered by packages/web/test/task-comment-doc-preview.test.tsx.
+
+import type { Page } from '@playwright/test';
+import { expect, test } from './fixtures';
+import { createProjectAndClearPlanning, uniqueName, waitForPageLoad } from './helpers';
+
+const DOC = 'spec.md';
+const DOC_CONTENT = ['# Spec', '', 'The document body that renders in the preview panel.'].join(
+	'\n',
+);
+
+async function seedTaskWithDocMention(
+	page: Page,
+	token: string,
+): Promise<{ projectSlug: string; taskId: string }> {
+	const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+
+	// Its own team+project (Blank template → Captain only), planning task cleared.
+	const project = await createProjectAndClearPlanning(page, '', token, {
+		name: uniqueName('Doc Preview Width'),
+		description: 'Preview panel width test.',
+	});
+
+	const agentsRes = await page.request.get(`/api/projects/${project.slug}/agents`, { headers });
+	const agents = ((await agentsRes.json()) as { data: Array<{ id: string; slug: string }> }).data;
+	const assigneeId = (agents.find((a) => a.slug === 'captain') ?? agents[0]).id;
+
+	const docRes = await page.request.put(`/api/projects/${project.slug}/docs/${DOC}`, {
+		headers,
+		data: { content: DOC_CONTENT },
+	});
+	expect(docRes.ok()).toBe(true);
+
+	const taskRes = await page.request.post(`/api/projects/${project.slug}/tasks`, {
+		headers,
+		data: { project_id: project.id, title: 'Review the spec', assignee_id: assigneeId },
+	});
+	const task = ((await taskRes.json()) as { data: { id: string; identifier: string } }).data;
+
+	// A bare filename in a comment resolves to a doc mention that opens the in-page
+	// preview panel (not a new tab) on the task-detail surface.
+	const commentRes = await page.request.post(
+		`/api/projects/${project.slug}/tasks/${task.id}/comments`,
+		{
+			headers,
+			data: { content_type: 'text', content: { text: `Please review ${DOC} before we ship.` } },
+		},
+	);
+	expect(commentRes.ok()).toBe(true);
+
+	return { projectSlug: project.slug, taskId: task.identifier.toLowerCase() };
+}
+
+test('document preview panel widens on xl/2xl screens (up to 2× its base width)', async ({
+	sharedPage: page,
+	sharedWorkspace,
+}) => {
+	const { token } = sharedWorkspace;
+	await page.setViewportSize({ width: 1100, height: 900 });
+
+	const { projectSlug, taskId } = await seedTaskWithDocMention(page, token);
+
+	await page.goto(`/projects/${projectSlug}/tasks/${taskId}`);
+	await waitForPageLoad(page);
+
+	// Open the doc in the in-grid preview panel.
+	const mention = page.getByTestId('doc-mention-link').first();
+	await expect(mention).toBeVisible({ timeout: 20000 });
+	await mention.click();
+
+	const panel = page.getByTestId('preview-panel');
+	await expect(panel).toBeVisible();
+
+	// The preview track is a fixed px width independent of the (scrollbar-sensitive)
+	// 1fr content column, so the measured border-box lands on the track value ±a
+	// couple px. Poll past the reflow after each resize, then read the settled box.
+	const widthOnceAtLeast = async (floor: number): Promise<number> => {
+		await expect
+			.poll(async () => (await panel.boundingBox())?.width ?? 0, { timeout: 5000 })
+			.toBeGreaterThanOrEqual(floor);
+		return (await panel.boundingBox())?.width ?? 0;
+	};
+
+	// lg (1024–1279px): base track ≈ 360px.
+	const lgWidth = await widthOnceAtLeast(352);
+	expect(lgWidth).toBeLessThanOrEqual(368);
+
+	// xl (1280–1535px): wider track ≈ 520px.
+	await page.setViewportSize({ width: 1400, height: 900 });
+	const xlWidth = await widthOnceAtLeast(512);
+	expect(xlWidth).toBeLessThanOrEqual(528);
+	expect(xlWidth).toBeGreaterThan(lgWidth);
+
+	// 2xl (≥1536px): widest track ≈ 720px — twice the lg base.
+	await page.setViewportSize({ width: 1600, height: 900 });
+	const xxlWidth = await widthOnceAtLeast(712);
+	expect(xxlWidth).toBeLessThanOrEqual(728);
+	expect(xxlWidth).toBeGreaterThan(xlWidth);
+	// Honors "can be twice as wide": the 2xl track is ≈2× the lg base.
+	expect(xxlWidth).toBeGreaterThanOrEqual(lgWidth * 2 - 8);
+});


### PR DESCRIPTION
## What & why

The in-page **document preview panel** — opened by clicking a doc mention in a task comment — was a fixed **360px** column at *every* desktop width. On wide screens that left the rendered document cramped while a lot of horizontal space went unused.

This grows the preview column at the roomier breakpoints so wide screens get a more readable document view, honoring the request that it can be "twice as wide."

## Change

Both grid definitions in `packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx` — the main content grid **and** the mirror grid that keeps the scroll-to-bottom pill aligned with the content column — get responsive preview-column widths (only when a preview is open; the `190px` meta-sidebar column is untouched):

| Breakpoint | Preview column | Content (`1fr`) column at the low end |
|---|---|---|
| `lg` (1024–1279px) | `360px` (unchanged) | ~312px |
| `xl` (1280–1535px) | `520px` | ~408px |
| `2xl` (≥1536px) | `720px` (2× the base) | ~464px |

Widening only kicks in at `xl`/`2xl`, so the content column stays **at least as wide as today's `lg` minimum** (~312px) at every step — no regression at 1024px, and the mobile full-screen overlay (below `lg`) is unaffected.

## Testing

- New Playwright spec `test/browser/task-doc-preview-width.spec.ts` opens the panel and asserts the measured column width grows 360 → 520 → 720 across the `lg`/`xl`/`2xl` viewports (a real-CSS-layout, viewport-conditional assertion happy-dom can't make). Passes locally.
- `bun run typecheck` and Biome check pass; existing preview component specs (`task-comment-doc-preview`, `project-doc-preview`) stay green.

No user-facing docs or API surfaces describe the panel width, so nothing else needed updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYKNmzpgKxNeEN7rmRrdQY

---
_Generated by [Claude Code](https://claude.ai/code/session_01FYKNmzpgKxNeEN7rmRrdQY)_