### PR TITLE
fix: prevent disabling the HQ instance agents (CEO/Coach)

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -305,10 +305,14 @@ project.
   tool both reject a re-point of these roles, and the settings UI disables the field. Each proposal is also mirrored as a `hire_proposal` action comment on the
   linked ticket (`services/hire-proposal-comment.ts`), which flips to hired/denied on
   resolution and re-wakes the requester; the approval no longer auto-closes the ticket —
-  the requester (the CEO) closes it once setup is complete. Retiring/reinstating an agent is the `set_agent_status` MCP tool (gated to
-  the team's Captain or an HQ coordinator), which runs the same `setAgentAdminStatus`
-  service as the REST disable/enable routes — it can't disable a Captain or an instance
-  agent. On a new team the CEO's initial coherence/setup pass **blocks** the Captain's
+  the requester (the CEO) closes it once setup is complete. Retiring/reinstating an agent runs through the `setAgentAdminStatus`
+  service, shared by the `set_agent_status` MCP tool (gated to the team's Captain or an HQ
+  coordinator) and the REST disable/enable routes (admin web UI). The **instance singletons
+  (CEO/Coach) cannot be disabled through any path** — the MCP tool rejects it and the REST
+  `POST .../agents/:agentId/disable` route returns `403` for their slugs (`INSTANCE_AGENT_SLUGS`),
+  since the whole instance depends on them for cross-project coordination and review. A
+  team's Captain is likewise protected from agent-initiated disabling, but an admin may
+  still retire one from the web UI. On a new team the CEO's initial coherence/setup pass **blocks** the Captain's
   planning task. It **auto-runs** on the direct (form) creation path; on the CEO-assisted
   path the CEO authors the concrete setup plan into it and then starts it with
   `start_team_setup` (see Creation flows).

--- a/docs/concepts/hiring-and-agents.md
+++ b/docs/concepts/hiring-and-agents.md
@@ -66,8 +66,10 @@ settings in the web app, or just by asking the CEO. Retiring stops the agent fro
 scheduled and unassigns it from any open tasks, but keeps all of its history, so it's
 fully reversible: reinstate (enable) it at any time and it picks work back up on its
 heartbeat. The CEO actions this directly once you confirm, which is handy after a
-project's direction changes and several roles no longer fit. (A team's Captain and the
-global CEO and Coach can't be retired this way.)
+project's direction changes and several roles no longer fit. (A team's Captain can't be
+retired by the CEO — only an admin can, from the web app. The global CEO and Coach run
+coordination and review across every project, so they're essential and can't be retired
+at all.)
 
 ## Other settings
 

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -3412,8 +3412,15 @@ export function registerTools(
 				COACH_AGENT_SLUG,
 			];
 			if (status === AgentAdminStatus.Disabled && protectedSlugs.includes(slug)) {
+				// The HQ instance singletons (CEO/Coach) are essential to the whole
+				// instance and cannot be disabled through any path — not even the admin
+				// web UI. The Captain is protected from agent-initiated disabling here,
+				// but the admin may still retire one from the web UI if truly needed.
+				const isInstance = (INSTANCE_AGENT_SLUGS as readonly string[]).includes(slug);
 				return {
-					error: `The ${slug} role is essential and cannot be retired with this tool; the admin can disable it from the web UI if truly needed.`,
+					error: isInstance
+						? `The ${slug} role is essential to the instance and cannot be disabled.`
+						: `The ${slug} role is essential and cannot be retired with this tool; the admin can disable it from the web UI if truly needed.`,
 				};
 			}
 

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -1006,6 +1006,23 @@ agentsRoutes.post('/projects/:projectId/agents/:agentId/disable', async (c) => {
 	const agentId = await resolveAgentId(db, teamId, c.req.param('agentId'));
 	if (!agentId) return err(c, 'NOT_FOUND', 'Agent not found', 404);
 
+	// The HQ instance singletons (CEO/Coach) run all cross-project coordination and
+	// review, so the instance can't function without them — they must never be
+	// disabled, even by the admin from the web UI. The MCP `set_agent_status` tool
+	// already blocks agents from disabling them; this closes the admin/REST path too.
+	const meta = await db.query<{ slug: string }>('SELECT slug FROM member_agents WHERE id = $1', [
+		agentId,
+	]);
+	const slug = meta.rows[0]?.slug;
+	if (slug && (INSTANCE_AGENT_SLUGS as readonly string[]).includes(slug)) {
+		return err(
+			c,
+			'FORBIDDEN',
+			`The ${slug} role is essential to the instance and cannot be disabled`,
+			403,
+		);
+	}
+
 	const actor = await resolveActor(db, c.get('auth'), teamId);
 	const result = await setAgentAdminStatus(
 		{ db, wsManager: c.get('wsManager'), events: c.get('events') },

--- a/packages/server/test/agent-status-tool.test.ts
+++ b/packages/server/test/agent-status-tool.test.ts
@@ -1,5 +1,5 @@
 import type { PGlite } from '@electric-sql/pglite';
-import { CAPTAIN_AGENT_SLUG, DEFAULT_TEAM_ID } from '@hezo/shared';
+import { CAPTAIN_AGENT_SLUG, DEFAULT_TEAM_ID, HQ_PROJECT_SLUG } from '@hezo/shared';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { MasterKeyManager } from '../src/crypto/master-key';
@@ -232,6 +232,24 @@ describe('MCP tool set_agent_status', () => {
 		});
 		expect(result.error).toContain('cannot be retired');
 		expect(await adminStatusOf(CAPTAIN_AGENT_SLUG)).toBe('enabled');
+	});
+
+	it.each([
+		'ceo',
+		'coach',
+	])('refuses to disable the HQ instance %s (essential singleton)', async (slug) => {
+		const result = await callTool(await ceoChatToken(), 'set_agent_status', {
+			project: HQ_PROJECT_SLUG,
+			agent: slug,
+			status: 'disabled',
+		});
+		expect(result.error).toContain('essential to the instance');
+		const r = await db.query<{ admin_status: string }>(
+			`SELECT ma.admin_status FROM member_agents ma JOIN members m ON m.id = ma.id
+				 WHERE m.team_id = $1 AND ma.slug = $2`,
+			[DEFAULT_TEAM_ID, slug],
+		);
+		expect(r.rows[0].admin_status).toBe('enabled');
 	});
 
 	it('errors when the agent is already in the requested state', async () => {

--- a/packages/server/test/agents.test.ts
+++ b/packages/server/test/agents.test.ts
@@ -1,4 +1,5 @@
 import type { PGlite } from '@electric-sql/pglite';
+import { HQ_PROJECT_SLUG } from '@hezo/shared';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Env } from '../src/lib/types';
@@ -349,6 +350,26 @@ describe('agents CRUD', () => {
 		expect(res.status).toBe(200);
 		const body = await res.json();
 		expect(body.data.admin_status).toBe('disabled');
+	});
+
+	it.each([
+		'ceo',
+		'coach',
+	])('refuses to disable the HQ instance %s, even for the admin', async (slug) => {
+		const res = await app.request(`/api/projects/${HQ_PROJECT_SLUG}/agents/${slug}/disable`, {
+			method: 'POST',
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(403);
+		const body = await res.json();
+		expect(body.error.code).toBe('FORBIDDEN');
+
+		// The instance agent stays enabled after the rejected attempt.
+		const listRes = await app.request(`/api/projects/${HQ_PROJECT_SLUG}/agents`, {
+			headers: authHeader(token),
+		});
+		const agent = (await listRes.json()).data.find((a: Record<string, unknown>) => a.slug === slug);
+		expect(agent.admin_status).toBe('enabled');
 	});
 
 	it('returns org chart with runtime_status and admin_status', async () => {

--- a/packages/web/src/routes/projects/$projectId/agents/$agentId/settings.tsx
+++ b/packages/web/src/routes/projects/$projectId/agents/$agentId/settings.tsx
@@ -5,6 +5,7 @@ import {
 	type BudgetWindowsCents,
 	CAPTAIN_AGENT_SLUG,
 	hasFixedReportsTo,
+	INSTANCE_AGENT_SLUGS,
 } from '@hezo/shared';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { Loader2, Power, PowerOff } from 'lucide-react';
@@ -98,6 +99,10 @@ function AgentSettingsPage() {
 	// Captain, CEO, and Coach have structurally-fixed reporting lines (Captain → CEO;
 	// CEO/Coach → admin) that must not be user-editable — mirrors the server guard.
 	const reportsToLocked = hasFixedReportsTo(agent.slug);
+
+	// The HQ instance singletons (CEO/Coach) are essential to the instance and can
+	// never be disabled — mirrors the server guard on the disable route.
+	const isInstanceAgent = (INSTANCE_AGENT_SLUGS as readonly string[]).includes(agent.slug);
 
 	async function handleSave(e: React.FormEvent) {
 		e.preventDefault();
@@ -295,11 +300,18 @@ function AgentSettingsPage() {
 			<div className="mt-8 pt-6 border-t border-border-subtle">
 				<div className="text-sm font-medium mb-1">Agent status</div>
 				<div className="text-xs text-text-2 mb-3">
-					{agent.admin_status === AgentAdminStatus.Enabled
-						? 'Disabling unassigns this agent from open tasks and stops it from being scheduled.'
-						: 'This agent is disabled and cannot be assigned new work. Enable to resume scheduling.'}
+					{isInstanceAgent
+						? agent.admin_status === AgentAdminStatus.Enabled
+							? 'This is an essential HQ role that runs coordination and review across every project. It is always active and cannot be disabled.'
+							: 'This essential HQ role is currently disabled. Re-enable it to restore cross-project coordination and review.'
+						: agent.admin_status === AgentAdminStatus.Enabled
+							? 'Disabling unassigns this agent from open tasks and stops it from being scheduled.'
+							: 'This agent is disabled and cannot be assigned new work. Enable to resume scheduling.'}
 				</div>
-				{agent.admin_status === AgentAdminStatus.Enabled && (
+				{/* The HQ instance singletons (CEO/Coach) can never be disabled — the disable
+				    button is hidden for them — but if one is somehow disabled, the admin can
+				    still re-enable it to recover. */}
+				{!isInstanceAgent && agent.admin_status === AgentAdminStatus.Enabled && (
 					<Button
 						variant="secondary"
 						size="sm"

--- a/packages/web/test/agent-detail.test.tsx
+++ b/packages/web/test/agent-detail.test.tsx
@@ -230,6 +230,28 @@ test('ordinary agent settings leaves the Reports To field editable', async () =>
 	expect(queryByTestId('reports-to-locked-hint')).toBeNull();
 });
 
+test('instance agent (CEO) settings shows an essential-role note and no disable button', async () => {
+	let teamSlug = '';
+	let ceoId = '';
+	const { findByText, queryByRole, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			teamSlug = ws.internalSlug;
+			// CEO/Coach surface as HQ virtual members of every project's roster.
+			ceoId = ws.agents.find((a) => a.slug === 'ceo')!.id;
+		},
+	});
+	await router.navigate({
+		to: '/projects/$projectId/agents/$agentId/settings',
+		params: { projectId: teamSlug, agentId: ceoId },
+	});
+
+	// The essential HQ role explains it's always active — and offers no disable button.
+	await findByText(/essential HQ role/i);
+	expect(queryByRole('button', { name: /Disable agent/i })).toBeNull();
+});
+
 test('agent header shows a live next-heartbeat countdown when the agent has work', async () => {
 	let projectSlug = '';
 	let agentId = '';


### PR DESCRIPTION
## Problem

It was possible to disable the HQ instance agents — the **CEO** and **Coach** — which the whole instance depends on for cross-project coordination and review. Disabling either would stop it from being scheduled and unassign it from its work, breaking core coordination.

The MCP `set_agent_status` tool already blocked *agents* from disabling the CEO/Coach/Captain, but it explicitly deferred to the admin: *"the admin can disable it from the web UI if truly needed."* The REST disable route behind that web UI (`POST /projects/:projectId/agents/:agentId/disable`) had **no** such guard, so an admin could disable the CEO or Coach from the HQ project's agent settings.

## Change

Close the gap so the instance singletons can't be disabled through **any** path, while leaving the Captain admin-disableable as before.

- **REST disable route** (`packages/server/src/routes/agents.ts`): returns `403 FORBIDDEN` when the target agent's slug is in `INSTANCE_AGENT_SLUGS` (`ceo`/`coach`). This is the admin/web-UI path.
- **MCP `set_agent_status`** (`packages/server/src/mcp/tools.ts`): the "essential role" error message is now accurate for instance agents — the web-UI escape hatch it used to mention only applies to the Captain now.
- **Agent settings UI** (`.../agents/$agentId/settings.tsx`): hides the **Disable** button for instance agents and shows an "essential HQ role, always active" note. The **Enable** button still appears if an instance agent is somehow already disabled, so a pre-existing disabled state can be recovered.
- **Docs**: updated the user-facing `docs/concepts/hiring-and-agents.md` retire/reinstate note and the `.dev/architecture.md` agent-lifecycle description to reflect the guard. The generated `docs/reference/mcp-api.md` is unchanged (the tool contract didn't change, only a runtime error string).

Keying on the **slug** (not the `is_instance` flag) is deliberate: `is_instance` is `false` when the CEO/Coach are viewed under HQ's own roster, whereas the slug is always `ceo`/`coach`. This also matches the existing slug-based guard in the MCP tool.

## Tests

- `packages/server/test/agents.test.ts` — the REST disable route returns `403` for `ceo` and `coach` in the HQ project, and they stay enabled.
- `packages/server/test/agent-status-tool.test.ts` — the MCP tool refuses to disable `ceo`/`coach` with the instance-specific message.
- `packages/web/test/agent-detail.test.tsx` — the CEO settings page shows the essential-role note and no Disable button.

Full `check`, `typecheck`, and `build` pass (via the pre-commit hook); the drift-guard tests (`mcp-reference`, `llms-txt`, `docs-bundle`) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FviEVq9KS6CoyXdJH5bv7S

---
_Generated by [Claude Code](https://claude.ai/code/session_01FviEVq9KS6CoyXdJH5bv7S)_