### PR TITLE
feat(web): head team chart with CEO, fix connector lines, add hover affordance

### DIFF
--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -1,17 +1,21 @@
 import type { PGlite } from '@electric-sql/pglite';
 import {
 	AgentAdminStatus,
+	AgentRuntimeStatus,
 	type AiProvider,
 	ALL_AI_PROVIDERS,
 	AuthType,
 	CAPTAIN_AGENT_SLUG,
+	CEO_AGENT_SLUG,
 	DEFAULT_EFFORT,
 	DEFAULT_HEARTBEAT_INTERVAL_MIN,
 	DEFAULT_TEAM_ID,
 	DocumentType,
+	HeartbeatRunStatus,
 	hasFixedReportsTo,
 	INSTANCE_AGENT_SLUGS,
 	isAgentEffort,
+	isBudgetPauseStatus,
 	isReservedAgentSlug,
 	MemberType,
 	requiredSystemPromptVarsError,
@@ -1046,15 +1050,16 @@ agentsRoutes.get('/projects/:projectId/org-chart', async (c) => {
 	const teamId = c.get('teamId') as string;
 	const db = c.get('db');
 
+	const ORG_COLUMNS = `m.id, ma.title, ma.slug, ma.role_description, ma.runtime_status, ma.admin_status, ma.reports_to`;
 	const result = await db.query(
-		`SELECT m.id, ma.title, ma.slug, ma.role_description, ma.runtime_status, ma.admin_status, ma.reports_to
+		`SELECT ${ORG_COLUMNS}
      FROM members m
      JOIN member_agents ma ON ma.id = m.id
      WHERE m.team_id = $1`,
 		[teamId],
 	);
 
-	const agents = result.rows as {
+	type OrgAgentRow = {
 		id: string;
 		title: string;
 		slug: string;
@@ -1062,9 +1067,46 @@ agentsRoutes.get('/projects/:projectId/org-chart', async (c) => {
 		runtime_status: string;
 		admin_status: string;
 		reports_to: string | null;
-	}[];
-	type AgentNode = (typeof agents)[number] & { children: AgentNode[] };
-	const byId = new Map(agents.map((a) => [a.id, { ...a, children: [] as AgentNode[] }]));
+	};
+	const agents = result.rows as OrgAgentRow[];
+	type AgentNode = OrgAgentRow & { children: AgentNode[] };
+	const byId = new Map<string, AgentNode>(
+		agents.map((a) => [a.id, { ...a, children: [] as AgentNode[] }]),
+	);
+
+	// The instance CEO manages every team's Captain but lives in HQ, so the
+	// team-scoped query above never returns it (except when this project *is* HQ,
+	// where it is already a member). Pull it in so the chart renders the real
+	// reporting line CEO → Captain → … instead of a headless Captain at the root.
+	const ceoResult = await db.query(
+		`SELECT ${ORG_COLUMNS}
+     FROM members m
+     JOIN member_agents ma ON ma.id = m.id
+     WHERE ma.slug = $1
+     LIMIT 1`,
+		[CEO_AGENT_SLUG],
+	);
+	const ceoRow = ceoResult.rows[0] as OrgAgentRow | undefined;
+	if (ceoRow && !byId.has(ceoRow.id)) {
+		byId.set(ceoRow.id, { ...ceoRow, children: [] });
+	}
+
+	// The CEO works across every project, so its global runtime_status may read
+	// 'active' because of a run in another team. Scope the "running" indicator to
+	// the current team: show active only when the CEO has an in-flight run *here*.
+	// Its global budget-pause / disabled states are left untouched.
+	const ceoNode = ceoRow ? byId.get(ceoRow.id) : undefined;
+	if (ceoNode && !isBudgetPauseStatus(ceoNode.runtime_status)) {
+		const runningHere = await db.query(
+			`SELECT 1 FROM heartbeat_runs
+       WHERE member_id = $1 AND team_id = $2
+         AND status IN ($3::heartbeat_run_status, $4::heartbeat_run_status)
+       LIMIT 1`,
+			[ceoNode.id, teamId, HeartbeatRunStatus.Running, HeartbeatRunStatus.Queued],
+		);
+		ceoNode.runtime_status =
+			runningHere.rows.length > 0 ? AgentRuntimeStatus.Active : AgentRuntimeStatus.Idle;
+	}
 
 	const roots: AgentNode[] = [];
 	for (const agent of byId.values()) {

--- a/packages/server/test/agents.test.ts
+++ b/packages/server/test/agents.test.ts
@@ -1,4 +1,5 @@
 import type { PGlite } from '@electric-sql/pglite';
+import { DEFAULT_TEAM_ID } from '@hezo/shared';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Env } from '../src/lib/types';
@@ -351,22 +352,68 @@ describe('agents CRUD', () => {
 		expect(body.data.admin_status).toBe('disabled');
 	});
 
-	it('returns org chart with runtime_status and admin_status', async () => {
+	it('returns the org chart with the CEO at the root and the Captain nested under it', async () => {
 		const res = await app.request(`/api/projects/${projectSlug}/org-chart`, {
 			headers: authHeader(token),
 		});
 		expect(res.status).toBe(200);
 		const body = await res.json();
 		expect(body.data.admin).toBeDefined();
-		expect(body.data.admin.children.length).toBeGreaterThan(0);
-		const captain = body.data.admin.children.find(
-			(c: Record<string, unknown>) => c.title === 'Captain',
+		// The instance CEO manages the Captain, so it heads the chart even though it
+		// lives in HQ rather than this team.
+		const ceo = body.data.admin.children.find((c: Record<string, unknown>) => c.slug === 'ceo');
+		expect(ceo).toBeDefined();
+		expect(ceo).toHaveProperty('runtime_status');
+		expect(ceo).toHaveProperty('admin_status');
+		const captain = (ceo.children as Array<Record<string, unknown>>).find(
+			(c) => c.title === 'Captain',
 		);
 		expect(captain).toBeDefined();
 		expect(captain).toHaveProperty('runtime_status');
 		expect(captain).toHaveProperty('admin_status');
 		expect(captain).toHaveProperty('role_description');
-		expect(captain.children.length).toBeGreaterThan(0);
+		expect((captain!.children as unknown[]).length).toBeGreaterThan(0);
+	});
+
+	it("scopes the CEO's running indicator to the current team", async () => {
+		const ceoRow = await db.query<{ id: string }>(
+			`SELECT id FROM member_agents WHERE slug = 'ceo' LIMIT 1`,
+		);
+		const ceoId = ceoRow.rows[0].id;
+
+		// The CEO is globally 'active' because of a run in another team (HQ) — not
+		// this one — so its node here must not read as active.
+		await db.query(
+			`UPDATE member_agents SET runtime_status = 'active'::agent_runtime_status WHERE id = $1`,
+			[ceoId],
+		);
+		await db.query(
+			`INSERT INTO heartbeat_runs (team_id, member_id, status)
+			 VALUES ($1, $2, 'running'::heartbeat_run_status)`,
+			[DEFAULT_TEAM_ID, ceoId],
+		);
+
+		let res = await app.request(`/api/projects/${projectSlug}/org-chart`, {
+			headers: authHeader(token),
+		});
+		let ceo = (await res.json()).data.admin.children.find(
+			(c: Record<string, unknown>) => c.slug === 'ceo',
+		);
+		expect(ceo.runtime_status).not.toBe('active');
+
+		// Now the CEO is running on a task in *this* team.
+		await db.query(
+			`INSERT INTO heartbeat_runs (team_id, member_id, status)
+			 VALUES ($1, $2, 'running'::heartbeat_run_status)`,
+			[teamId, ceoId],
+		);
+		res = await app.request(`/api/projects/${projectSlug}/org-chart`, {
+			headers: authHeader(token),
+		});
+		ceo = (await res.json()).data.admin.children.find(
+			(c: Record<string, unknown>) => c.slug === 'ceo',
+		);
+		expect(ceo.runtime_status).toBe('active');
 	});
 
 	it('rejects duplicate agent slug', async () => {

--- a/packages/web/src/components/org-chart-tree.tsx
+++ b/packages/web/src/components/org-chart-tree.tsx
@@ -2,6 +2,7 @@ import { isBudgetPauseStatus } from '@hezo/shared';
 import { Link } from '@tanstack/react-router';
 import { type ReactNode, useEffect, useRef, useState } from 'react';
 import type { OrgNode } from '../hooks/use-org-chart';
+import { agentPageParams } from './agent-link';
 import { StatusDot } from './ui/status-dot';
 import { Tooltip } from './ui/tooltip';
 
@@ -67,6 +68,23 @@ interface OrgChartTreeProps {
 	testId?: string;
 }
 
+/**
+ * A row of sibling nodes joined to their parent by three line segments: one
+ * vertical "trunk" dropping from the parent, a horizontal "bus" spanning the
+ * outermost siblings, and a vertical "riser" down to each sibling. The bus is
+ * assembled from each column's two half-width top borders — `::before` draws the
+ * left half, `::after` the right half — so it is width-agnostic; the first column
+ * drops its left half and the last drops its right half, ending the line exactly
+ * under the outermost siblings. Columns sit flush (no flex gap) so adjacent
+ * halves meet into one continuous line; spacing comes from the horizontal
+ * padding instead. This is what keeps every level's connectors joined.
+ */
+const CONNECTOR_COLUMN =
+	'relative flex flex-col items-center px-3 sm:px-4 ' +
+	"before:content-[''] before:absolute before:left-0 before:right-1/2 before:top-0 before:h-px before:bg-border " +
+	"after:content-[''] after:absolute after:left-1/2 after:right-0 after:top-0 after:h-px after:bg-border " +
+	'first:before:hidden last:after:hidden';
+
 export function OrgChartTree({ roots, projectId, mode, hint, testId }: OrgChartTreeProps) {
 	const { containerRef, contentRef, scale, height } = useOrgChartAutoFit();
 
@@ -83,8 +101,8 @@ export function OrgChartTree({ roots, projectId, mode, hint, testId }: OrgChartT
 			mode === 'interactive' && projectId ? (
 				<Link
 					to="/projects/$projectId/agents/$agentId"
-					params={{ projectId, agentId: node.slug }}
-					className="relative inline-flex items-center gap-2 rounded-md border border-border bg-surface px-3.5 py-2 text-[13px] font-medium transition-[border-color] duration-150 hover:border-border-strong"
+					params={agentPageParams(projectId, node.slug)}
+					className="relative inline-flex items-center gap-2 rounded-md border border-border bg-surface px-3.5 py-2 text-[13px] font-medium cursor-pointer transition-[border-color,background-color,box-shadow] duration-150 hover:border-border-strong hover:bg-surface-2 hover:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inverse/40"
 				>
 					{label}
 				</Link>
@@ -97,7 +115,7 @@ export function OrgChartTree({ roots, projectId, mode, hint, testId }: OrgChartT
 				>
 					<button
 						type="button"
-						className="inline-flex items-center gap-2 rounded-md border border-border bg-surface px-3.5 py-2 text-[13px] font-medium transition-[border-color,background-color] duration-150 hover:border-border-strong hover:bg-surface-elevated cursor-default focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inverse/40"
+						className="inline-flex items-center gap-2 rounded-md border border-border bg-surface px-3.5 py-2 text-[13px] font-medium transition-[border-color,background-color] duration-150 hover:border-border-strong hover:bg-surface-2 cursor-default focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inverse/40"
 						data-testid={`onboarding-org-node-${node.slug}`}
 						aria-label={`${node.title} — tap or hover for role description`}
 					>
@@ -109,22 +127,27 @@ export function OrgChartTree({ roots, projectId, mode, hint, testId }: OrgChartT
 		return (
 			<div className="flex flex-col items-center" key={node.id}>
 				{nodeBody}
-				{node.children.length > 0 && (
-					<>
-						<div className="w-px h-4 bg-border" />
-						<div className={`flex ${mode === 'onboarding' ? 'gap-4 sm:gap-6' : 'gap-6'}`}>
-							{node.children.map((child) => (
-								<div key={child.id} className="flex flex-col items-center">
-									<div className="w-px h-4 bg-border" />
-									{renderNode(child)}
-								</div>
-							))}
-						</div>
-					</>
-				)}
+				{node.children.length > 0 && renderBranch(node.children)}
 			</div>
 		);
 	};
+
+	// Trunk down from a parent, then the connected row of its children. Shared by
+	// the synthetic "You (Admin)" root and every interior node so connectors are
+	// drawn identically at every depth.
+	const renderBranch = (children: OrgNode[]): ReactNode => (
+		<>
+			<div className="w-px h-4 bg-border" />
+			<div className="flex">
+				{children.map((child) => (
+					<div key={child.id} className={CONNECTOR_COLUMN}>
+						<div className="w-px h-4 bg-border" />
+						{renderNode(child)}
+					</div>
+				))}
+			</div>
+		</>
+	);
 
 	if (roots.length === 0) return null;
 
@@ -136,18 +159,10 @@ export function OrgChartTree({ roots, projectId, mode, hint, testId }: OrgChartT
 					className="flex flex-col items-center"
 					style={{ transform: `scale(${scale})`, transformOrigin: 'top center' }}
 				>
-					<div className="inline-flex items-center gap-2 rounded-md border-2 border-inverse bg-info-soft px-4 py-2 text-[13px] font-medium text-info-soft-fg mb-2">
+					<div className="inline-flex items-center gap-2 rounded-md border-2 border-inverse bg-info-soft px-4 py-2 text-[13px] font-medium text-info-soft-fg">
 						You (Admin)
 					</div>
-					<div className="w-px h-4 bg-border" />
-					<div className={`flex ${mode === 'onboarding' ? 'gap-6 sm:gap-8' : 'gap-8'}`}>
-						{roots.map((node) => (
-							<div key={node.id} className="flex flex-col items-center">
-								<div className="w-px h-4 bg-border" />
-								{renderNode(node)}
-							</div>
-						))}
-					</div>
+					{renderBranch(roots)}
 				</div>
 			</div>
 			{hint && <p className="text-[11px] text-text-3 mt-3">{hint}</p>}

--- a/packages/web/test/agent-detail.test.tsx
+++ b/packages/web/test/agent-detail.test.tsx
@@ -5,9 +5,9 @@ import { queryClient } from '../src/lib/query-client';
 import { getTestContext, renderApp } from './helpers/render';
 import { seedProject, seedTask, seedWorkspace } from './helpers/seed';
 
-test('team org chart renders with status legend', async () => {
+test('team org chart renders the CEO at the head with a status legend', async () => {
 	let teamSlug = '';
-	const { findByText, router } = await renderApp({
+	const { findByText, findByTestId, router } = await renderApp({
 		initialPath: '/',
 		seed: async () => {
 			const ws = await seedWorkspace();
@@ -17,6 +17,11 @@ test('team org chart renders with status legend', async () => {
 	await router.navigate({ to: '/projects/$projectId/agents', params: { projectId: teamSlug } });
 	await findByText('You (Admin)', undefined, { timeout: 15_000 });
 	await findByText('Active', undefined, { timeout: 15_000 });
+	// The instance CEO heads the chart (the Captain reports to it) even though it
+	// lives in HQ. Scope to the chart itself — the CEO also shows in the global-
+	// agents rail.
+	const chart = await findByTestId('team-org-chart');
+	await within(chart).findByText('CEO', undefined, { timeout: 15_000 });
 });
 
 test('agent detail page defaults to Executions tab and exposes Settings tab', async () => {


### PR DESCRIPTION
## Summary

The team org chart drew the **Captain as a headless root**, rendered **disconnected connector stubs** at every branch (the horizontal connector between siblings was missing entirely), and gave **no hover cue** that agents are clickable. This fixes all three.

| Before | After |
|---|---|
| `You (Admin)` → `Captain` → … | `You (Admin)` → **`CEO`** → `Captain` → … |
| Floating vertical stubs, no horizontal join | One trunk → continuous horizontal bus → riser per child, at every level |
| Border-only hover | Stronger border + background + shadow + pointer cursor |

## Changes

**Show the CEO (`packages/server/src/routes/agents.ts`)**
- The instance CEO manages every team's Captain but lives in HQ, so the team-scoped `/org-chart` query never returned it and the Captain floated at the root. The endpoint now pulls the CEO in (deduped when the project *is* HQ, where it's already a member) so the real reporting line **CEO → Captain → …** renders.

**Scope the CEO's "running" indicator to the current project**
- The CEO works across every project, so its global `runtime_status` can read `active` because of a run in *another* team. The chart now shows the CEO active only when it has an in-flight (`queued`/`running`) `heartbeat_run` scoped to **this** team. Its global budget-pause / disabled states are left untouched.

**Fix the connector lines once and for all (`packages/web/src/components/org-chart-tree.tsx`)**
- Every sibling row now draws a single vertical *trunk* from the parent, a continuous horizontal *bus* spanning the outermost siblings, and a *riser* down to each child — shared across every depth by one `CONNECTOR_COLUMN` (half-width `::before`/`::after` top borders on flush columns, with the first/last column dropping its outer half). Width-agnostic, so it stays joined at any roster shape.

**Hover / clickable affordance**
- Interactive nodes get a clear hover state (border strengthens, background lifts to `surface-2`, soft shadow, `cursor-pointer`) plus a keyboard focus ring, and the CEO node routes to its canonical HQ agent page via `agentPageParams`.
- Also corrected a latent no-op class (`hover:bg-surface-elevated`, an undefined token) to the real `hover:bg-surface-2`.

## Testing
- `packages/server/test/agents.test.ts` — updated the org-chart assertion (CEO at root, Captain nested under it) and added a test that the CEO's running indicator is scoped to the current team.
- `packages/web/test/agent-detail.test.tsx` — asserts the CEO renders at the head of the chart.
- `bun run typecheck`, `bunx biome check` (0 errors), and full build all pass. Connector geometry and the hover state were verified by rendering the exact emitted CSS in Chromium.

## Notes
- No user-facing docs describe the endpoint's tree-building behaviour; `.dev/architecture.md` already documents the Captain → CEO reporting line this change now visualises, so no doc updates were required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019hszhkj6b3iaNNuWVLqkSF

---
_Generated by [Claude Code](https://claude.ai/code/session_019hszhkj6b3iaNNuWVLqkSF)_