### PR TITLE
Assets: breadcrumb-only header in subfolders, per-asset copy-link + button tooltips

### DIFF
--- a/docs/concepts/assets.md
+++ b/docs/concepts/assets.md
@@ -54,8 +54,10 @@ ongoing context) live in their own store via `write_project_doc` instead.
 
 Anywhere you write text in Hezo — a task, a comment, a document — you can point at an asset
 by writing `assets/<path>` (for example `assets/login-mockup.png`, or
-`assets/launch/images/hero.png` for one inside folders). Opening a link to a foldered asset
-takes you straight to its folder with the file highlighted.
+`assets/launch/images/hero.png` for one inside folders). You don't have to type it out: each
+asset card has a **Copy link** action that copies its exact `assets/<path>` reference to your
+clipboard, ready to paste. Opening a link to a foldered asset takes you straight to its folder
+with the file highlighted.
 
 This is also how the **CEO** hands you files from the chat. When you ask the CEO to whip
 something up — a quick mockup, a diagram, a one-off HTML page — it saves the result to an

--- a/packages/web/src/routes/projects/$projectId/assets.tsx
+++ b/packages/web/src/routes/projects/$projectId/assets.tsx
@@ -8,7 +8,9 @@ import {
 import * as Dialog from '@radix-ui/react-dialog';
 import { createFileRoute } from '@tanstack/react-router';
 import {
+	Check,
 	Code,
+	Copy,
 	ExternalLink,
 	FileAudio,
 	File as FileIcon,
@@ -31,6 +33,7 @@ import { ConfirmDialog } from '../../../components/ui/confirm-dialog';
 import { dialogContentClassName, dialogOverlayClassName } from '../../../components/ui/dialog';
 import { EmptyState } from '../../../components/ui/empty-state';
 import { Input } from '../../../components/ui/input';
+import { Tooltip } from '../../../components/ui/tooltip';
 import {
 	type ProjectAsset,
 	useDeleteProjectAsset,
@@ -40,6 +43,7 @@ import {
 } from '../../../hooks/use-project-assets';
 import type { ApiError } from '../../../lib/api';
 import { allFolders, folderCrumbs, groupAssets } from '../../../lib/asset-folders';
+import { copyToClipboard } from '../../../lib/clipboard';
 
 interface AssetsSearch {
 	file?: string;
@@ -175,12 +179,21 @@ function ProjectAssetsPage() {
 	return (
 		<div>
 			<div className="flex flex-wrap items-start justify-between gap-2 mb-4">
+				{/* Root shows the page title + blurb; inside a folder the breadcrumb
+				    takes its place so the header stays a single orienting row. */}
 				<div className="min-w-0">
-					<h1 className="text-base font-semibold text-text-1">Assets</h1>
-					<p className="text-[13px] text-text-2">
-						Mockups, wireframes, and other uploads, organized in folders. Reference one in a comment
-						or doc as <code className="text-info-soft-fg">assets/&lt;path&gt;</code>.
-					</p>
+					{currentFolder === '' ? (
+						<>
+							<h1 className="text-base font-semibold text-text-1">Assets</h1>
+							<p className="text-[13px] text-text-2">
+								Mockups, wireframes, and other uploads, organized in folders.
+							</p>
+						</>
+					) : (
+						<div className="flex min-h-[26px] items-center">
+							<Breadcrumb segments={crumbs} data-testid="assets-breadcrumb" />
+						</div>
+					)}
 				</div>
 				<div className="flex items-center gap-2">
 					{folderDepth < ASSET_MAX_FOLDER_DEPTH && (
@@ -221,12 +234,6 @@ function ProjectAssetsPage() {
 					}}
 				/>
 			</div>
-
-			{currentFolder !== '' && (
-				<div className="mb-3">
-					<Breadcrumb segments={crumbs} data-testid="assets-breadcrumb" />
-				</div>
-			)}
 
 			{errors.length > 0 && (
 				<div className="mb-3 flex flex-wrap gap-1.5">
@@ -618,6 +625,44 @@ function MoveAssetDialog({
 	);
 }
 
+/**
+ * Copies an asset's canonical `assets/<path>` reference — the exact string that
+ * linkifies in comments and docs — to the clipboard, swapping its icon to a
+ * check for 1.5s as confirmation (mirrors the comment/log copy affordances).
+ */
+function CopyReferenceButton({ reference }: { reference: string }) {
+	const [copied, setCopied] = useState(false);
+	const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	useEffect(() => {
+		return () => {
+			if (timeoutRef.current) clearTimeout(timeoutRef.current);
+		};
+	}, []);
+
+	const handleCopy = async () => {
+		if (await copyToClipboard(reference)) {
+			setCopied(true);
+			if (timeoutRef.current) clearTimeout(timeoutRef.current);
+			timeoutRef.current = setTimeout(() => setCopied(false), 1500);
+		}
+	};
+
+	return (
+		<Tooltip content={copied ? 'Copied!' : 'Copy link'}>
+			<button
+				type="button"
+				className="p-1 text-text-3 hover:text-text-1"
+				onClick={handleCopy}
+				aria-label={copied ? 'Reference copied' : 'Copy reference link'}
+				data-testid="asset-copy-link"
+			>
+				{copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+			</button>
+		</Tooltip>
+	);
+}
+
 function AssetCard({
 	asset,
 	highlighted,
@@ -696,34 +741,41 @@ function AssetCard({
 					<div className="text-[11px] text-text-3">{formatBytes(asset.byte_size)}</div>
 				</div>
 				<div className="flex shrink-0 items-center gap-0.5">
-					<a
-						href={asset.url}
-						target="_blank"
-						rel="noopener noreferrer"
-						className="p-1 text-text-3 hover:text-text-1"
-						aria-label="Open in new tab"
-						data-testid="asset-popout"
-					>
-						<ExternalLink className="h-3.5 w-3.5" />
-					</a>
-					<button
-						type="button"
-						className="p-1 text-text-3 hover:text-text-1"
-						onClick={onMove}
-						aria-label="Move to folder"
-						data-testid="asset-move"
-					>
-						<FolderInput className="h-3.5 w-3.5" />
-					</button>
-					<button
-						type="button"
-						className="p-1 text-text-3 hover:text-danger"
-						onClick={onDelete}
-						aria-label="Delete asset"
-						data-testid="asset-delete"
-					>
-						<Trash2 className="h-3.5 w-3.5" />
-					</button>
+					<Tooltip content="Open in new tab">
+						<a
+							href={asset.url}
+							target="_blank"
+							rel="noopener noreferrer"
+							className="p-1 text-text-3 hover:text-text-1"
+							aria-label="Open in new tab"
+							data-testid="asset-popout"
+						>
+							<ExternalLink className="h-3.5 w-3.5" />
+						</a>
+					</Tooltip>
+					<CopyReferenceButton reference={`assets/${asset.original_filename}`} />
+					<Tooltip content="Move to folder">
+						<button
+							type="button"
+							className="p-1 text-text-3 hover:text-text-1"
+							onClick={onMove}
+							aria-label="Move to folder"
+							data-testid="asset-move"
+						>
+							<FolderInput className="h-3.5 w-3.5" />
+						</button>
+					</Tooltip>
+					<Tooltip content="Delete asset">
+						<button
+							type="button"
+							className="p-1 text-text-3 hover:text-danger"
+							onClick={onDelete}
+							aria-label="Delete asset"
+							data-testid="asset-delete"
+						>
+							<Trash2 className="h-3.5 w-3.5" />
+						</button>
+					</Tooltip>
 				</div>
 			</div>
 		</li>

--- a/packages/web/test/project-asset-folders.test.tsx
+++ b/packages/web/test/project-asset-folders.test.tsx
@@ -278,6 +278,46 @@ test('asset cards label with the basename while keeping the full path for toolin
 	expect(card?.querySelector('[title="reports/q3/chart.png"]')).not.toBeNull();
 });
 
+test('inside a folder the page title and blurb give way to the breadcrumb', async () => {
+	let ctx!: { projectSlug: string };
+	const {
+		findByText,
+		findByTestId,
+		getByRole,
+		queryByRole,
+		queryByText,
+		queryByTestId,
+		user,
+		router,
+	} = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Chrome' });
+			await seedAsset(ws, project, { filename: 'inside.png', folder: 'launch' });
+			ctx = { projectSlug: project.slug };
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/assets',
+		params: { projectId: ctx.projectSlug },
+	});
+
+	// Root: the page heading + blurb are visible and there is no breadcrumb yet.
+	await findByText(/Mockups, wireframes, and other uploads/);
+	expect(getByRole('heading', { level: 1, name: 'Assets' })).not.toBeNull();
+	expect(queryByTestId('assets-breadcrumb')).toBeNull();
+
+	// Drill into the folder: the heading + blurb are replaced by the breadcrumb.
+	await user.click(await findByTestId('asset-folder-card'));
+	await findByTestId('assets-breadcrumb');
+	await waitFor(() => {
+		expect(queryByText(/Mockups, wireframes, and other uploads/)).toBeNull();
+	});
+	expect(queryByRole('heading', { level: 1, name: 'Assets' })).toBeNull();
+});
+
 test('a script upload through the picker succeeds and stores text/plain', async () => {
 	let ctx!: { projectSlug: string };
 	const { findByText, findByTestId, user, router, container } = await renderApp({

--- a/packages/web/test/project-assets.test.tsx
+++ b/packages/web/test/project-assets.test.tsx
@@ -162,6 +162,50 @@ test('a foldered assets/<folder>/<name> reference links; an over-deep path stays
 	expect(anchors.some((a) => a.textContent?.includes('a/b/c/d.png'))).toBe(false);
 });
 
+test('the copy-link button copies the asset reference (assets/<path>) to the clipboard', async () => {
+	let ctx!: { projectSlug: string };
+	const { findByText, findByTestId, router, user } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Refs' });
+			await seedAsset(ws, project, { filename: 'hero.png', folder: 'blog/images' });
+			ctx = { projectSlug: project.slug };
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/assets',
+		params: { projectId: ctx.projectSlug },
+		search: { folder: 'blog/images' },
+	});
+	await findByText('hero.png');
+
+	const writes: string[] = [];
+	const originalDesc = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+	Object.defineProperty(navigator, 'clipboard', {
+		configurable: true,
+		value: {
+			writeText: async (t: string) => {
+				writes.push(t);
+			},
+		},
+	});
+	try {
+		const copyBtn = await findByTestId('asset-copy-link');
+		expect(copyBtn.getAttribute('aria-label')).toBe('Copy reference link');
+		await user.click(copyBtn);
+		// The full foldered path is included so the copied string linkifies verbatim
+		// in a comment or doc.
+		expect(writes).toEqual(['assets/blog/images/hero.png']);
+		// The icon swaps to a check — the aria-label flips to "Reference copied".
+		await waitFor(() => expect(copyBtn.getAttribute('aria-label')).toBe('Reference copied'));
+	} finally {
+		if (originalDesc) Object.defineProperty(navigator, 'clipboard', originalDesc);
+		else delete (navigator as { clipboard?: unknown }).clipboard;
+	}
+});
+
 test('uploading a file through the picker adds it to the library', async () => {
 	let ctx!: { projectSlug: string };
 	const { findByText, findByTestId, user, router } = await renderApp({


### PR DESCRIPTION
## Summary

Refines the project **Assets** page based on three requests:

1. **Breadcrumb-only header in subfolders.** The page title (`Assets`) and blurb now render only at the library root. Once you drill into a folder, the header collapses to just the breadcrumb nav, which takes the title's place so the header stays a single orienting row (the standalone breadcrumb block below the header is removed).
2. **Per-asset "Copy link" button.** The blurb no longer explains how to reference an asset (`Reference one … as assets/<path>`). Instead, every asset card has a **Copy link** action that copies that asset's exact `assets/<path>` reference — the same string that linkifies in comments and docs — to the clipboard, with a check-icon confirmation for 1.5s. The reference includes the full foldered path (e.g. `assets/blog/images/hero.png`).
3. **Tooltips on all asset-card action buttons.** Open in new tab, Copy link, Move to folder, and Delete asset each get a tooltip (the Copy link tooltip also reflects the copied state: `Copy link` → `Copied!`).

## Changes

- `packages/web/src/routes/projects/$projectId/assets.tsx`
  - Conditionally render the title + blurb at root vs. the breadcrumb in the header when inside a folder; drop the separate breadcrumb block.
  - Trim the reference instruction out of the root blurb.
  - New `CopyReferenceButton` component (copies `assets/${original_filename}`, mirrors the existing comment/log copy affordances).
  - Wrap each action button in the shared `Tooltip`.
- `docs/concepts/assets.md` — document the new **Copy link** card action in the referencing section.

## Testing

- `packages/web/test/project-asset-folders.test.tsx` — new test: the page title + blurb give way to the breadcrumb inside a folder (present at root, absent in subfolder).
- `packages/web/test/project-assets.test.tsx` — new test: the Copy link button writes the full `assets/blog/images/hero.png` reference to the clipboard and flips its icon/aria-label to the copied state.
- All 24 asset component tests pass; `docs-bundle.test.ts` stays green; typecheck + full build pass via the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012FKopMDup2o3kGzZZJUkrM

---
_Generated by [Claude Code](https://claude.ai/code/session_012FKopMDup2o3kGzZZJUkrM)_