### PR TITLE
feat(web): searchable folder dropdown in the asset move dialog

### DIFF
--- a/packages/web/src/lib/asset-folders.ts
+++ b/packages/web/src/lib/asset-folders.ts
@@ -66,3 +66,46 @@ export function folderCrumbs(folder: string): Array<{ name: string; path: string
 	const segments = folder.split('/');
 	return segments.map((name, i) => ({ name, path: segments.slice(0, i + 1).join('/') }));
 }
+
+/** Nesting depth: 0 at the library root, 1 for a top-level folder, 2 for a subfolder. */
+export function folderDepth(path: string): number {
+	return path === '' ? 0 : path.split('/').length;
+}
+
+/**
+ * Indentation level for the folder-picker tree: the library root and every
+ * top-level folder sit flush-left (0); each nested level steps in one more, so
+ * `launch/art` renders one indent under `launch`.
+ */
+export function folderIndentLevel(path: string): number {
+	const depth = folderDepth(path);
+	return depth === 0 ? 0 : depth - 1;
+}
+
+/** The folder's own trailing segment (its display name); '' is the library root. */
+export function folderLeafName(path: string): string {
+	if (path === '') return '';
+	const slash = path.lastIndexOf('/');
+	return slash < 0 ? path : path.slice(slash + 1);
+}
+
+/**
+ * Filter a sorted folder list to those matching `query` (case-insensitive
+ * substring on the full path), keeping each match's ancestors so the indented
+ * tree still reads coherently while searching (a matched subfolder never
+ * appears orphaned from its parent). An empty query returns the list intact.
+ */
+export function filterFolderTree(folders: string[], query: string): string[] {
+	const q = query.trim().toLowerCase();
+	if (!q) return folders;
+	const keep = new Set<string>();
+	for (const folder of folders) {
+		if (!folder.toLowerCase().includes(q)) continue;
+		keep.add(folder);
+		const segments = folder.split('/');
+		for (let i = 1; i < segments.length; i += 1) {
+			keep.add(segments.slice(0, i).join('/'));
+		}
+	}
+	return folders.filter((folder) => keep.has(folder));
+}

--- a/packages/web/src/routes/projects/$projectId/assets.tsx
+++ b/packages/web/src/routes/projects/$projectId/assets.tsx
@@ -9,6 +9,7 @@ import * as Dialog from '@radix-ui/react-dialog';
 import { createFileRoute } from '@tanstack/react-router';
 import {
 	Check,
+	ChevronDown,
 	Code,
 	Copy,
 	ExternalLink,
@@ -21,6 +22,7 @@ import {
 	FolderPlus,
 	Image as ImageIcon,
 	Loader2,
+	Search,
 	Trash2,
 	Upload,
 	X,
@@ -42,7 +44,14 @@ import {
 	useUploadProjectAsset,
 } from '../../../hooks/use-project-assets';
 import type { ApiError } from '../../../lib/api';
-import { allFolders, folderCrumbs, groupAssets } from '../../../lib/asset-folders';
+import {
+	allFolders,
+	filterFolderTree,
+	folderCrumbs,
+	folderIndentLevel,
+	folderLeafName,
+	groupAssets,
+} from '../../../lib/asset-folders';
 import { copyToClipboard } from '../../../lib/clipboard';
 
 interface AssetsSearch {
@@ -489,6 +498,184 @@ function NewFolderDialog({
 	);
 }
 
+/** Whether the library-root option ("Assets (root)") matches the search query. */
+function rootMatchesQuery(query: string): boolean {
+	const q = query.trim().toLowerCase();
+	return q === '' || 'assets (root)'.includes(q) || 'root'.includes(q);
+}
+
+/**
+ * Searchable folder picker for the move dialog: a text input that opens a
+ * dropdown of existing folders, filtered as you type, with subfolders indented
+ * one level under their parent so the nesting reads as a tree. The library root
+ * ("Assets (root)") is always the first option. `value` is the selected folder
+ * path ('' = root, `null` = nothing selected, e.g. while a new folder is typed).
+ */
+function FolderCombobox({
+	folders,
+	value,
+	currentFolder,
+	disabled,
+	onSelect,
+}: {
+	folders: string[];
+	value: string | null;
+	currentFolder: string;
+	disabled?: boolean;
+	onSelect: (path: string) => void;
+}) {
+	const [open, setOpen] = useState(false);
+	const [query, setQuery] = useState('');
+	const [activeIndex, setActiveIndex] = useState(0);
+	const containerRef = useRef<HTMLDivElement>(null);
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	const options: string[] = [
+		...(rootMatchesQuery(query) ? [''] : []),
+		...filterFolderTree(folders, query),
+	];
+
+	// Close when a pointer lands outside the combobox (option clicks stay inside).
+	useEffect(() => {
+		if (!open) return;
+		function onPointerDown(e: PointerEvent) {
+			if (!containerRef.current?.contains(e.target as Node)) setOpen(false);
+		}
+		document.addEventListener('pointerdown', onPointerDown);
+		return () => document.removeEventListener('pointerdown', onPointerDown);
+	}, [open]);
+
+	function choose(path: string) {
+		onSelect(path);
+		setQuery('');
+		setOpen(false);
+		inputRef.current?.blur();
+	}
+
+	function openDropdown() {
+		if (disabled) return;
+		setQuery('');
+		setActiveIndex(0);
+		setOpen(true);
+	}
+
+	function onKeyDown(e: React.KeyboardEvent) {
+		if (e.key === 'Escape') {
+			if (open) e.stopPropagation(); // keep Escape from also closing the dialog
+			setOpen(false);
+			return;
+		}
+		if (!open) {
+			if (e.key === 'ArrowDown' || e.key === 'Enter') {
+				e.preventDefault();
+				openDropdown();
+			}
+			return;
+		}
+		if (e.key === 'ArrowDown') {
+			e.preventDefault();
+			setActiveIndex((i) => Math.min(options.length - 1, i + 1));
+		} else if (e.key === 'ArrowUp') {
+			e.preventDefault();
+			setActiveIndex((i) => Math.max(0, i - 1));
+		} else if (e.key === 'Enter') {
+			e.preventDefault();
+			const path = options[activeIndex];
+			if (path !== undefined) choose(path);
+		}
+	}
+
+	const selectedLabel = value === null ? '' : value === '' ? 'Assets (root)' : value;
+
+	return (
+		<div className="flex flex-col gap-1.5">
+			<span id="asset-move-folder-label" className="text-eyebrow text-text-2">
+				Folder
+			</span>
+			<div ref={containerRef} className="relative">
+				<div className="flex h-8 w-full items-center gap-2 rounded-md border border-border-strong bg-surface px-2.5 text-[13px] transition-colors focus-within:border-accent focus-within:ring-[3px] focus-within:ring-ring">
+					<Search className="h-3.5 w-3.5 shrink-0 text-text-3" />
+					<input
+						ref={inputRef}
+						role="combobox"
+						aria-expanded={open}
+						aria-controls="asset-move-folder-list"
+						aria-autocomplete="list"
+						aria-labelledby="asset-move-folder-label"
+						aria-activedescendant={
+							open && options.length > 0 ? `asset-move-opt-${activeIndex}` : undefined
+						}
+						disabled={disabled}
+						value={open ? query : selectedLabel}
+						placeholder={open && selectedLabel ? selectedLabel : 'Search folders…'}
+						onFocus={openDropdown}
+						onChange={(e) => {
+							setQuery(e.target.value);
+							setActiveIndex(0);
+							setOpen(true);
+						}}
+						onKeyDown={onKeyDown}
+						className="min-w-0 flex-1 bg-transparent text-text-1 placeholder:text-text-3 outline-none"
+						data-testid="asset-move-folder-input"
+					/>
+					<ChevronDown className="h-3.5 w-3.5 shrink-0 text-text-3" />
+				</div>
+				{open && (
+					<div
+						id="asset-move-folder-list"
+						role="listbox"
+						aria-label="Existing folders"
+						className="absolute left-0 right-0 z-10 mt-1 max-h-48 overflow-y-auto rounded-md border border-border bg-surface p-1 shadow-md"
+					>
+						{options.length === 0 ? (
+							<div className="px-2.5 py-2 text-[13px] text-text-3" data-testid="asset-move-empty">
+								No folders match “{query.trim()}”.
+							</div>
+						) : (
+							options.map((path, i) => {
+								const indent = folderIndentLevel(path);
+								const label = path === '' ? 'Assets (root)' : folderLeafName(path);
+								const isSelected = value === path;
+								const isActive = i === activeIndex;
+								return (
+									<button
+										key={path === '' ? '(root)' : path}
+										id={`asset-move-opt-${i}`}
+										type="button"
+										role="option"
+										aria-selected={isSelected}
+										data-testid="asset-move-option"
+										data-folder={path}
+										data-indent={indent}
+										title={path === '' ? 'Assets (root)' : path}
+										onMouseEnter={() => setActiveIndex(i)}
+										onClick={() => choose(path)}
+										style={{ paddingLeft: `${0.625 + indent}rem` }}
+										className={`flex w-full items-center gap-2 rounded-md py-1.5 pr-2.5 text-left text-[13px] transition-colors ${
+											isActive
+												? 'bg-surface-3 text-text-1'
+												: isSelected
+													? 'bg-surface-2 text-text-1'
+													: 'text-text-2 hover:bg-surface-3 hover:text-text-1'
+										}`}
+									>
+										<Folder className="h-3.5 w-3.5 shrink-0 text-text-3" />
+										<span className="min-w-0 flex-1 truncate">{label}</span>
+										{path === currentFolder && (
+											<span className="shrink-0 text-[11px] text-text-3">current</span>
+										)}
+										{isSelected && <Check className="h-3.5 w-3.5 shrink-0 text-info" />}
+									</button>
+								);
+							})
+						)}
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}
+
 /** Admin "Move to folder" — PATCHes the asset's folder; 409 on collision. */
 function MoveAssetDialog({
 	projectId,
@@ -510,7 +697,6 @@ function MoveAssetDialog({
 	const [error, setError] = useState<string | null>(null);
 	const folders = allFolders(assets);
 
-	const options = ['', ...folders];
 	const targetFromNewName = newName.trim() !== '';
 
 	async function submit() {
@@ -557,36 +743,17 @@ function MoveAssetDialog({
 					<p className="mb-3 truncate text-[13px] text-text-2" title={asset.original_filename}>
 						{asset.original_filename}
 					</p>
-					<div className="flex max-h-48 flex-col gap-1 overflow-y-auto">
-						{options.map((path) => {
-							const active = !targetFromNewName && selected === path;
-							return (
-								<button
-									key={path === '' ? '(root)' : path}
-									type="button"
-									aria-pressed={active}
-									data-testid="asset-move-option"
-									data-folder={path}
-									onClick={() => {
-										setSelected(path);
-										setNewName('');
-										setError(null);
-									}}
-									className={`flex items-center gap-2 rounded-md border px-2.5 py-1.5 text-left text-[13px] transition-colors ${
-										active
-											? 'border-accent bg-surface-3 text-text-1'
-											: 'border-border bg-surface-2 text-text-2 hover:text-text-1 hover:bg-surface-3'
-									}`}
-								>
-									<Folder className="h-3.5 w-3.5 shrink-0 text-text-3" />
-									{path === '' ? 'Assets (root)' : path}
-									{path === from && (
-										<span className="ml-auto text-[11px] text-text-3">current</span>
-									)}
-								</button>
-							);
-						})}
-					</div>
+					<FolderCombobox
+						folders={folders}
+						value={targetFromNewName ? null : selected}
+						currentFolder={from}
+						disabled={move.isPending}
+						onSelect={(path) => {
+							setSelected(path);
+							setNewName('');
+							setError(null);
+						}}
+					/>
 					<div className="mt-3">
 						<Input
 							label="Or a new folder"

--- a/packages/web/test/asset-folders.test.ts
+++ b/packages/web/test/asset-folders.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'vitest';
+import {
+	filterFolderTree,
+	folderDepth,
+	folderIndentLevel,
+	folderLeafName,
+} from '../src/lib/asset-folders';
+
+describe('folderDepth', () => {
+	test('the root is 0; each path segment adds a level', () => {
+		expect(folderDepth('')).toBe(0);
+		expect(folderDepth('launch')).toBe(1);
+		expect(folderDepth('launch/art')).toBe(2);
+	});
+});
+
+describe('folderIndentLevel', () => {
+	test('root and top-level folders sit flush; subfolders step in one level', () => {
+		expect(folderIndentLevel('')).toBe(0);
+		expect(folderIndentLevel('launch')).toBe(0);
+		expect(folderIndentLevel('launch/art')).toBe(1);
+	});
+});
+
+describe('folderLeafName', () => {
+	test('returns the trailing segment; the root has none', () => {
+		expect(folderLeafName('')).toBe('');
+		expect(folderLeafName('launch')).toBe('launch');
+		expect(folderLeafName('launch/art')).toBe('art');
+	});
+});
+
+describe('filterFolderTree', () => {
+	const folders = ['docs', 'launch', 'launch/art', 'reports', 'reports/q3'];
+
+	test('an empty (or whitespace) query returns the list unchanged', () => {
+		expect(filterFolderTree(folders, '')).toEqual(folders);
+		expect(filterFolderTree(folders, '   ')).toEqual(folders);
+	});
+
+	test('matches a full path, case-insensitively, preserving order', () => {
+		expect(filterFolderTree(folders, 'REPORTS')).toEqual(['reports', 'reports/q3']);
+	});
+
+	test('keeps a matched subfolder together with its ancestor so the tree still reads', () => {
+		// "art" only matches launch/art, but its parent launch is retained.
+		expect(filterFolderTree(folders, 'art')).toEqual(['launch', 'launch/art']);
+	});
+
+	test('retains an ancestor whose child matches even if the ancestor itself does not', () => {
+		expect(filterFolderTree(folders, 'q3')).toEqual(['reports', 'reports/q3']);
+	});
+
+	test('drops folders that neither match nor parent a match', () => {
+		expect(filterFolderTree(folders, 'launch')).toEqual(['launch', 'launch/art']);
+	});
+});

--- a/packages/web/test/project-asset-folders.test.tsx
+++ b/packages/web/test/project-asset-folders.test.tsx
@@ -232,10 +232,14 @@ test('the move dialog re-homes an asset into another folder', async () => {
 		return el as HTMLElement;
 	});
 
-	// Pick the existing `homes` folder option and confirm.
-	const option = dialog.querySelector('[data-testid="asset-move-option"][data-folder="homes"]');
-	expect(option).not.toBeNull();
-	await user.click(option as HTMLElement);
+	// Open the folder search dropdown, then pick the existing `homes` folder.
+	await user.click(dialog.querySelector('[data-testid="asset-move-folder-input"]') as HTMLElement);
+	const option = await waitFor(() => {
+		const el = dialog.querySelector('[data-testid="asset-move-option"][data-folder="homes"]');
+		expect(el).not.toBeNull();
+		return el as HTMLElement;
+	});
+	await user.click(option);
 	await user.click(dialog.querySelector('[data-testid="asset-move-confirm"]') as HTMLElement);
 
 	// After the refetch the asset is gone from the root and lives under homes/.
@@ -250,6 +254,78 @@ test('the move dialog re-homes an asset into another folder', async () => {
 	await waitFor(() => {
 		expect(container.querySelector('[data-filename="homes/wanderer.png"]')).not.toBeNull();
 	});
+});
+
+test('the move dialog folder dropdown indents subfolders and filters by search', async () => {
+	let ctx!: { projectSlug: string };
+	const { findByText, findByTestId, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Nested' });
+			await seedAsset(ws, project, { filename: 'loose.png' });
+			await seedAsset(ws, project, { filename: 'hero.png', folder: 'launch' });
+			await seedAsset(ws, project, { filename: 'poster.png', folder: 'launch/art' });
+			await seedAsset(ws, project, { filename: 'brief.png', folder: 'reports' });
+			ctx = { projectSlug: project.slug };
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/assets',
+		params: { projectId: ctx.projectSlug },
+	});
+	await findByText('loose.png');
+
+	// Open the move dialog on the loose root asset.
+	await user.click(await findByTestId('asset-move'));
+	const dialog = await waitFor(() => {
+		const el = document.body.querySelector('[data-testid="asset-move-dialog"]');
+		expect(el).not.toBeNull();
+		return el as HTMLElement;
+	});
+
+	// Opening the search dropdown lists the root plus every folder.
+	const input = dialog.querySelector('[data-testid="asset-move-folder-input"]') as HTMLInputElement;
+	await user.click(input);
+	await waitFor(() => {
+		expect(
+			dialog.querySelector('[data-testid="asset-move-option"][data-folder=""]'),
+		).not.toBeNull();
+	});
+	const launch = dialog.querySelector(
+		'[data-testid="asset-move-option"][data-folder="launch"]',
+	) as HTMLElement;
+	const art = dialog.querySelector(
+		'[data-testid="asset-move-option"][data-folder="launch/art"]',
+	) as HTMLElement;
+	expect(launch).not.toBeNull();
+	expect(art).not.toBeNull();
+	expect(
+		dialog.querySelector('[data-testid="asset-move-option"][data-folder="reports"]'),
+	).not.toBeNull();
+
+	// Nesting: top-level folders sit flush (indent 0), the subfolder steps in one
+	// level and shows only its own segment as the label.
+	expect(launch.getAttribute('data-indent')).toBe('0');
+	expect(art.getAttribute('data-indent')).toBe('1');
+	expect(art.textContent).toContain('art');
+
+	// Searching narrows to matches, keeping a matched subfolder's parent for context
+	// and dropping unrelated folders and the root.
+	await user.type(input, 'art');
+	await waitFor(() => {
+		expect(
+			dialog.querySelector('[data-testid="asset-move-option"][data-folder="reports"]'),
+		).toBeNull();
+	});
+	expect(
+		dialog.querySelector('[data-testid="asset-move-option"][data-folder="launch/art"]'),
+	).not.toBeNull();
+	expect(
+		dialog.querySelector('[data-testid="asset-move-option"][data-folder="launch"]'),
+	).not.toBeNull();
+	expect(dialog.querySelector('[data-testid="asset-move-option"][data-folder=""]')).toBeNull();
 });
 
 test('asset cards label with the basename while keeping the full path for tooling', async () => {


### PR DESCRIPTION
## Summary

Replaces the flat folder button list in the assets **Move to folder** dialog with a **search input dropdown**, and indents subfolders one level under their parent so the nesting reads as a tree — as requested.

Before, picking a target folder meant scanning a flat list of every folder path (`launch`, `launch/art`, …). Now the picker is a combobox: type to filter existing folders, and the dropdown shows them as an indented tree.

## What changed

- **`MoveAssetDialog`** now renders a new `FolderCombobox` in place of the button list.
- **Search-to-filter** — typing matches the full folder path (case-insensitively). A matched subfolder keeps its parent visible so a filtered result never appears orphaned from its tree.
- **Indented nesting** — the library root and top-level folders sit flush-left; each nested level steps in one more (`launch/art` renders under `launch`), showing only its own segment as the label.
- **Library root** (`Assets (root)`) is always the first option; the asset's current folder is badged `current`; the selected row shows a check.
- **Keyboard + a11y** — `↑`/`↓` + `Enter` selection, `Escape` closes the dropdown (without closing the dialog), and proper `combobox`/`listbox`/`option` roles with `aria-activedescendant`.
- The separate **"Or a new folder"** field is unchanged; while a new folder name is being typed the combobox de-selects so the two inputs never disagree about the target.

The pure tree helpers — `folderDepth`, `folderIndentLevel`, `folderLeafName`, `filterFolderTree` — live in `packages/web/src/lib/asset-folders.ts`.

## Testing

- **New unit tests** (`packages/web/test/asset-folders.test.ts`) cover the tree helpers, including ancestor-preserving filtering and order preservation.
- **Component tests** (`packages/web/test/project-asset-folders.test.tsx`): the existing move test now drives the dropdown; a new test asserts subfolders carry `data-indent="1"` under their parent, that the root + every folder list, and that searching narrows to matches (keeping the matched subfolder's parent, dropping unrelated folders and the root).
- `bun run test --package web --pattern asset` — all asset suites green (unit + 3 component files, 35 tests). Full `turbo typecheck` and production `vite build` pass (run by the pre-commit hook).

No user-visible behaviour changed beyond the picker UI, so no docs/architecture updates were needed (the generic "Move to folder" reference in `docs/concepts/assets.md` still holds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MVr9ATdQ32gidFHZrhVKXx

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVr9ATdQ32gidFHZrhVKXx)_