### PR TITLE
fix(assets): equal-size cards, folder reads as a labelled stack

### DIFF
--- a/packages/web/src/routes/projects/$projectId/assets.tsx
+++ b/packages/web/src/routes/projects/$projectId/assets.tsx
@@ -276,31 +276,44 @@ function ProjectAssetsPage() {
 					<ul className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
 						{grouped.folders.map((folder) => (
 							<li key={folder.path}>
-								{/* Folder cards mirror the file card's shape (h-28 media region +
-								    p-2 footer) so both read as one grid of equal-sized cards.
-								    Folders keep the grey surface-2 fill; file cards use the
-								    lighter surface so the two are never the same colour. */}
+								{/* A folder reads as a small stack of cards: two lips peek above
+								    the top card so it's unmistakable next to the flat, white file
+								    cards. The top card keeps the file card's exact footprint (h-28
+								    media + p-2 footer) so folders and files stay the same size;
+								    the lips are absolutely positioned in the grid gap and add no
+								    layout height. Folders keep the grey surface-2 fill (and its
+								    dark-mode counterpart); file cards use the lighter surface. */}
 								<button
 									type="button"
 									data-testid="asset-folder-card"
 									data-folder={folder.path}
 									onClick={() => openFolder(folder.path)}
-									className="flex w-full flex-col overflow-hidden rounded-md border border-border bg-surface-2 text-left transition-colors hover:border-border-strong hover:bg-surface-3"
+									className="group relative block w-full text-left"
 								>
-									<div className="flex h-28 items-center justify-center">
-										<Folder className="h-8 w-8 text-text-3" />
-									</div>
-									<div className="p-2">
-										<div
-											className="truncate text-[12px] font-medium text-text-1"
-											title={folder.path}
-										>
-											{folder.name}
-										</div>
-										<div className="text-[11px] text-text-3">
-											{folder.count} file{folder.count === 1 ? '' : 's'}
-										</div>
-									</div>
+									<span
+										aria-hidden="true"
+										className="absolute inset-x-4 -top-2 h-6 rounded-t-md border border-border bg-surface-2 transition-colors group-hover:border-border-strong group-hover:bg-surface-3"
+									/>
+									<span
+										aria-hidden="true"
+										className="absolute inset-x-2 -top-1 h-6 rounded-t-md border border-border bg-surface-2 transition-colors group-hover:border-border-strong group-hover:bg-surface-3"
+									/>
+									<span className="relative flex flex-col overflow-hidden rounded-md border border-border bg-surface-2 transition-colors group-hover:border-border-strong group-hover:bg-surface-3">
+										<span className="flex h-28 items-center justify-center">
+											<Folder className="h-16 w-16 text-text-3" />
+										</span>
+										<span className="block p-2">
+											<span
+												className="block truncate text-[12px] font-medium text-text-1"
+												title={folder.path}
+											>
+												{folder.name}
+											</span>
+											<span className="block text-[11px] text-text-3">
+												{folder.count} file{folder.count === 1 ? '' : 's'}
+											</span>
+										</span>
+									</span>
 								</button>
 							</li>
 						))}

--- a/packages/web/src/routes/projects/$projectId/assets.tsx
+++ b/packages/web/src/routes/projects/$projectId/assets.tsx
@@ -276,13 +276,14 @@ function ProjectAssetsPage() {
 					<ul className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
 						{grouped.folders.map((folder) => (
 							<li key={folder.path}>
-								{/* A folder reads as a small stack of cards: two lips peek above
-								    the top card so it's unmistakable next to the flat, white file
-								    cards. The top card keeps the file card's exact footprint (h-28
-								    media + p-2 footer) so folders and files stay the same size;
-								    the lips are absolutely positioned in the grid gap and add no
-								    layout height. Folders keep the grey surface-2 fill (and its
-								    dark-mode counterpart); file cards use the lighter surface. */}
+								{/* A folder reads as a small stack of cards: two darker lips
+								    (surface-3, strong border, elevated) peek above the raised top
+								    card so it's unmistakable next to the flat, white file cards.
+								    The top card keeps the file card's exact footprint (h-28 media
+								    + p-2 footer) so folders and files stay the same size; the lips
+								    are absolutely positioned in the grid gap and add no layout
+								    height. Folders keep the grey surface-2 fill (and its dark-mode
+								    counterpart); file cards use the lighter surface. */}
 								<button
 									type="button"
 									data-testid="asset-folder-card"
@@ -292,13 +293,13 @@ function ProjectAssetsPage() {
 								>
 									<span
 										aria-hidden="true"
-										className="absolute inset-x-4 -top-2 h-6 rounded-t-md border border-border bg-surface-2 transition-colors group-hover:border-border-strong group-hover:bg-surface-3"
+										className="absolute inset-x-5 -top-2 h-5 rounded-t-md border border-border-strong bg-surface-3 shadow-sm"
 									/>
 									<span
 										aria-hidden="true"
-										className="absolute inset-x-2 -top-1 h-6 rounded-t-md border border-border bg-surface-2 transition-colors group-hover:border-border-strong group-hover:bg-surface-3"
+										className="absolute inset-x-2.5 -top-1 h-5 rounded-t-md border border-border-strong bg-surface-3 shadow-sm"
 									/>
-									<span className="relative flex flex-col overflow-hidden rounded-md border border-border bg-surface-2 transition-colors group-hover:border-border-strong group-hover:bg-surface-3">
+									<span className="relative flex flex-col overflow-hidden rounded-md border border-border bg-surface-2 shadow-md transition group-hover:border-border-strong group-hover:shadow-lg">
 										<span className="flex h-28 items-center justify-center">
 											<Folder className="h-16 w-16 text-text-3" />
 										</span>

--- a/packages/web/src/routes/projects/$projectId/assets.tsx
+++ b/packages/web/src/routes/projects/$projectId/assets.tsx
@@ -276,23 +276,31 @@ function ProjectAssetsPage() {
 					<ul className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
 						{grouped.folders.map((folder) => (
 							<li key={folder.path}>
+								{/* Folder cards mirror the file card's shape (h-28 media region +
+								    p-2 footer) so both read as one grid of equal-sized cards.
+								    Folders keep the grey surface-2 fill; file cards use the
+								    lighter surface so the two are never the same colour. */}
 								<button
 									type="button"
 									data-testid="asset-folder-card"
 									data-folder={folder.path}
 									onClick={() => openFolder(folder.path)}
-									className="flex w-full flex-col items-center justify-center gap-1.5 rounded-md border border-border bg-surface-2 px-2 py-6 transition-colors hover:border-border-strong hover:bg-surface-3"
+									className="flex w-full flex-col overflow-hidden rounded-md border border-border bg-surface-2 text-left transition-colors hover:border-border-strong hover:bg-surface-3"
 								>
-									<Folder className="h-8 w-8 text-text-3" />
-									<span
-										className="w-full truncate text-center text-[12px] font-medium text-text-1"
-										title={folder.path}
-									>
-										{folder.name}
-									</span>
-									<span className="text-[11px] text-text-3">
-										{folder.count} file{folder.count === 1 ? '' : 's'}
-									</span>
+									<div className="flex h-28 items-center justify-center">
+										<Folder className="h-8 w-8 text-text-3" />
+									</div>
+									<div className="p-2">
+										<div
+											className="truncate text-[12px] font-medium text-text-1"
+											title={folder.path}
+										>
+											{folder.name}
+										</div>
+										<div className="text-[11px] text-text-3">
+											{folder.count} file{folder.count === 1 ? '' : 's'}
+										</div>
+									</div>
 								</button>
 							</li>
 						))}
@@ -702,7 +710,7 @@ function AssetCard({
 			ref={ref}
 			data-testid="asset-card"
 			data-filename={asset.original_filename}
-			className={`flex flex-col overflow-hidden rounded-md border bg-surface-2 ${
+			className={`flex flex-col overflow-hidden rounded-md border bg-surface ${
 				highlighted ? 'border-info' : 'border-border'
 			}`}
 		>


### PR DESCRIPTION
## What & why

On the project Assets page, folder cards and file cards didn't line up as a cohesive grid, and a folder wasn't clearly distinct from a file:

- **Different dimensions** — folder cards were a short, vertically-centered tile (`px-2 py-6`) while file cards were taller (`h-28` preview + footer), so a mixed grid looked ragged.
- **Same background + weak affordance** — both used `bg-surface-2`, and a file card's grey preview well sat right next to the grey folder cards, so a file card could read as a folder.

This change makes folders and files render as one grid of equal-sized cards, and makes a folder unmistakable.

## Changes

`packages/web/src/routes/projects/$projectId/assets.tsx`

- **Equal size** — the folder card's *top card* mirrors the file card's exact footprint (`h-28` media region + `p-2` footer), so every card is the same size and aligns top and bottom. Verified at 165px across both types.
- **Folder reads as a stack of cards** — two card "lips" peek above the top card. They're absolutely positioned into the grid gap, so they add **no** layout height and don't disturb the equal sizing.
- **Distinct background** — file cards move from `bg-surface-2` → `bg-surface`. Folders keep the grey `surface-2` fill (and its dark-mode counterpart); files read as the lighter `surface`, so a file card is never the same colour as a folder card.
- **Large folder glyph** — the folder icon is enlarged (`h-8` → `h-16`) so it reads as the container of the stack, while file icons stay at their smaller size.

## Verification

- Measured both card types against the exact Wire design tokens + Tailwind Preflight (light + dark): every card renders at **165px** — dimensional parity confirmed, folder top card aligns with file cards.
- Visual check: folders (grey stack, large icon) vs files (white/lighter, small icon) are clearly distinguishable in light and dark mode.
- `bun run test --skip-browser --package web --pattern asset` — all 28 asset component tests pass.
- `turbo typecheck` and the production build (run by the pre-commit hook) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wLSVKJP7ubMBXVwP6BgRd