### PR TITLE
fix(web): render review-comment highlights on markdown tables

### DIFF
--- a/packages/web/src/lib/rehype-review-highlights.ts
+++ b/packages/web/src/lib/rehype-review-highlights.ts
@@ -13,6 +13,15 @@
  * across rare hast/DOM divergences (e.g. a quote spanning a mention rewritten
  * by remark-mentions) — an unmatched quote simply renders no highlight.
  *
+ * Tables are the one structural exception: `mdast-util-to-hast` interleaves
+ * whitespace-only "\n" text nodes between a table's structural elements
+ * (`table`/`thead`/`tbody`/`tfoot`/`tr`), but the browser (and React) never
+ * render whitespace-only text as a direct child of those elements — the DOM
+ * text walk therefore never sees them. We skip exactly those nodes here so the
+ * hast stream stays byte-identical to the DOM stream; without it, any selection
+ * spanning a cell or row boundary produces a quote the plugin can never match
+ * (e.g. DOM "AB" vs hast "A\nB"), and the comment renders no highlight.
+ *
  * There is no `rehype-raw` in this app: these element nodes are injected into
  * the tree directly, never parsed from HTML strings, so no raw-HTML surface is
  * opened.
@@ -54,10 +63,28 @@ function isText(node: HastChild): node is HastText & HastChild {
 	return node.type === 'text' && typeof (node as HastText).value === 'string';
 }
 
+/**
+ * Table-section elements whose whitespace-only text children the browser drops
+ * (a `<table>` may not hold rendered text between its rows/sections). Cells
+ * (`td`/`th`) and `caption` keep their text, so they are deliberately absent.
+ */
+const TABLE_STRUCTURAL_TAGS = new Set(['table', 'thead', 'tbody', 'tfoot', 'tr', 'colgroup']);
+
+function isDroppedTableWhitespace(parent: HastParent, node: HastText): boolean {
+	return (
+		parent.tagName !== undefined &&
+		TABLE_STRUCTURAL_TAGS.has(parent.tagName) &&
+		node.value.trim() === ''
+	);
+}
+
 function collectTextRefs(parent: HastParent, refs: TextRef[], offset: { value: number }): void {
 	if (!parent.children) return;
 	for (const child of parent.children) {
 		if (isText(child)) {
+			// The DOM never renders this node (see the table note above), so leave it
+			// out of the stream to keep hast and DOM offsets aligned.
+			if (isDroppedTableWhitespace(parent, child)) continue;
 			refs.push({ parent, node: child, start: offset.value });
 			offset.value += child.value.length;
 			continue;

--- a/packages/web/test/document-review.test.tsx
+++ b/packages/web/test/document-review.test.tsx
@@ -70,7 +70,9 @@ async function setupDocumentsPage(opts?: {
 		params: { projectId: setup.project.slug },
 		search: { file: setup.filename },
 	});
-	await utils.findByText(opts?.ready ?? 'Alpha paragraph with target text inside.', { exact: false });
+	await utils.findByText(opts?.ready ?? 'Alpha paragraph with target text inside.', {
+		exact: false,
+	});
 	return { ...utils, ...setup };
 }
 

--- a/packages/web/test/document-review.test.tsx
+++ b/packages/web/test/document-review.test.tsx
@@ -27,6 +27,18 @@ const DOC_CONTENT = [
 	'Beta paragraph repeats token foo bar foo here.',
 ].join('\n');
 
+// A doc whose reviewable content is a GFM table — the structural case where the
+// hast text stream (with "\n" nodes between rows/cells) diverges from the DOM
+// text stream a selection walks, unless the highlight plugin skips them.
+const TABLE_DOC_CONTENT = [
+	'# Security Rules',
+	'',
+	'| Rule | Scope |',
+	'| --- | --- |',
+	'| Never use raw HTML | All components |',
+	'| Export is static | utils/export.ts |',
+].join('\n');
+
 interface Setup {
 	ws: SeededWorkspace;
 	project: SeededProject;
@@ -34,16 +46,19 @@ interface Setup {
 }
 
 async function setupDocumentsPage(opts?: {
+	content?: string;
+	ready?: string;
 	comments?: Array<{ quote: string; occurrence?: number; comment: string }>;
 }) {
 	let setup!: Setup;
+	const content = opts?.content ?? DOC_CONTENT;
 	const utils = await renderApp({
 		initialPath: '/',
 		seed: async () => {
 			const ws = await seedWorkspace();
 			const project = await seedProject(ws, { name: uniqueName('Review Project') });
 			const filename = `spec-${Math.random().toString(36).slice(2, 8)}.md`;
-			await seedDocument(ws, project, { filename, content: DOC_CONTENT });
+			await seedDocument(ws, project, { filename, content });
 			for (const c of opts?.comments ?? []) {
 				await seedReviewComment(ws, project, filename, c);
 			}
@@ -55,7 +70,7 @@ async function setupDocumentsPage(opts?: {
 		params: { projectId: setup.project.slug },
 		search: { file: setup.filename },
 	});
-	await utils.findByText('Alpha paragraph with target text inside.', { exact: false });
+	await utils.findByText(opts?.ready ?? 'Alpha paragraph with target text inside.', { exact: false });
 	return { ...utils, ...setup };
 }
 
@@ -294,6 +309,57 @@ test('selecting text raises the comment pill and saving creates an anchored comm
 	await waitFor(() => {
 		const mark = container.querySelector('mark[data-review-id]');
 		expect(mark?.textContent).toBe('target text');
+	});
+});
+
+test('selecting across table cells anchors a comment that renders as a highlight', async () => {
+	// Regression: a review comment left on a markdown table showed neither the
+	// highlight nor the margin icon. The browser drops the whitespace-only "\n"
+	// nodes between a table's rows/cells, so a cross-cell selection captured
+	// "RuleScope" while the highlight plugin saw "Rule\nScope" and never matched.
+	const { container, findByTestId, user } = await setupDocumentsPage({
+		content: TABLE_DOC_CONTENT,
+		ready: 'Never use raw HTML',
+	});
+
+	// Select from the start of the "Rule" header cell across into the "Scope" one.
+	const headers = Array.from(container.querySelectorAll('th'));
+	const ruleText = headers.find((th) => th.textContent === 'Rule')?.firstChild as Text;
+	const scopeText = headers.find((th) => th.textContent === 'Scope')?.firstChild as Text;
+	expect(ruleText).toBeTruthy();
+	expect(scopeText).toBeTruthy();
+
+	const range = document.createRange();
+	range.setStart(ruleText, 0);
+	range.setEnd(scopeText, 'Scope'.length);
+	const selection = window.getSelection();
+	selection?.removeAllRanges();
+	selection?.addRange(range);
+	document.dispatchEvent(new Event('selectionchange'));
+
+	const pill = await findByTestId('review-selection-pill');
+	fireEvent.mouseDown(pill);
+
+	await user.type(
+		(await findByTestId('review-editor-textarea')) as HTMLTextAreaElement,
+		'These headers need clarifying',
+	);
+	await user.click(await findByTestId('review-editor-save'));
+
+	// The DOM stream concatenates the two cells with no separator.
+	await waitFor(async () => {
+		const rows = await reviewCommentRows();
+		expect(rows.length).toBe(1);
+		expect(rows[0].quote).toBe('RuleScope');
+		expect(rows[0].occurrence).toBe(0);
+	});
+
+	// The anchor resolves back to a highlight (one mark per spanned cell) AND a
+	// margin icon — the two things the bug suppressed.
+	await waitFor(() => {
+		const marks = Array.from(container.querySelectorAll('mark[data-review-id]'));
+		expect(marks.map((m) => m.textContent)).toEqual(['Rule', 'Scope']);
+		expect(container.querySelectorAll('[data-testid="review-margin-icon"]').length).toBe(1);
 	});
 });
 

--- a/packages/web/test/rehype-review-highlights.test.ts
+++ b/packages/web/test/rehype-review-highlights.test.ts
@@ -146,4 +146,99 @@ describe('applyReviewHighlights', () => {
 		applyReviewHighlights(tree, [ann('li1', 'second item')]);
 		expect(marks(tree).map(textContent)).toEqual(['second item']);
 	});
+
+	// A GFM table's hast interleaves whitespace-only "\n" text nodes between its
+	// structural elements (table/thead/tbody/tr). The browser never renders those
+	// as text, so the DOM selection stream concatenates cells with no separator
+	// ("RuleScope"); the highlight walk must skip them or a cross-cell quote can
+	// never match its hast counterpart ("Rule\nScope"). These build a table shaped
+	// like `mdast-util-to-hast` output to lock that in.
+	const gfmTable = (rows: string[][], head: string[]) =>
+		el(
+			'table',
+			text('\n'),
+			el(
+				'thead',
+				text('\n'),
+				el('tr', text('\n'), ...head.flatMap((h) => [el('th', text(h)), text('\n')])),
+			),
+			text('\n'),
+			el(
+				'tbody',
+				text('\n'),
+				...rows.flatMap((cells) => [
+					el('tr', text('\n'), ...cells.flatMap((v) => [el('td', text(v)), text('\n')])),
+					text('\n'),
+				]),
+			),
+		);
+
+	it('matches a quote spanning a table cell boundary, skipping the inter-cell whitespace', () => {
+		// DOM renders the two header cells as adjacent text "RuleScope"; the quote
+		// captured from such a selection must resolve despite the "\n" nodes in hast.
+		const tree = root(gfmTable([['Never use X', 'All components']], ['Rule', 'Scope']));
+		const matched = applyReviewHighlights(tree, [ann('t1', 'RuleScope')]);
+
+		expect(matched).toEqual(new Set(['t1']));
+		// One mark per cell, sharing the id (the boundary splits the run in two).
+		expect(marks(tree).map(textContent)).toEqual(['Rule', 'Scope']);
+	});
+
+	it('matches a quote spanning a table row boundary', () => {
+		// Selection dragged from the last cell of one row into the first of the next.
+		const tree = root(
+			gfmTable(
+				[
+					['Never use X', 'All components'],
+					['Export static', 'utils/export.ts'],
+				],
+				['Rule', 'Scope'],
+			),
+		);
+		const matched = applyReviewHighlights(tree, [ann('t2', 'All componentsExport static')]);
+
+		expect(matched).toEqual(new Set(['t2']));
+		expect(marks(tree).map(textContent)).toEqual(['All components', 'Export static']);
+	});
+
+	it('leaves the table whitespace nodes intact (matching only, no reflow)', () => {
+		// Skipping the "\n" nodes from the match STREAM must not remove them from the
+		// tree — the rendered table is unchanged, only anchoring is fixed.
+		const tree = root(gfmTable([['a', 'b']], ['H1', 'H2']));
+		const before = textContent(tree);
+		applyReviewHighlights(tree, [ann('t3', 'H1H2')]);
+		expect(textContent(tree)).toBe(before);
+	});
+
+	it('counts occurrences correctly across cells despite the whitespace nodes', () => {
+		// "dup" appears in two separate cells; the phantom "\n" nodes must not shift
+		// the occurrence count, so occurrence:1 still targets the SECOND cell.
+		const tree = root(
+			gfmTable(
+				[
+					['alpha dup', 'x'],
+					['beta dup', 'y'],
+				],
+				['Key', 'Val'],
+			),
+		);
+		applyReviewHighlights(tree, [ann('t4', 'dup', 1)]);
+
+		const m = marks(tree);
+		expect(m.length).toBe(1);
+		expect(textContent(m[0])).toBe('dup');
+
+		// The wrapped "dup" is the second one: the "beta dup" cell now holds the
+		// mark, while the first cell ("alpha dup") is untouched.
+		const cells: Node[] = [];
+		const walkCells = (n: Node) => {
+			if (n.tagName === 'td') cells.push(n);
+			for (const c of n.children ?? []) walkCells(c);
+		};
+		walkCells(tree);
+		const alpha = cells.find((c) => textContent(c) === 'alpha dup');
+		const beta = cells.find((c) => textContent(c) === 'beta dup');
+		expect(alpha?.children?.some((c) => c.tagName === 'mark')).toBe(false);
+		expect(beta?.children?.some((c) => c.tagName === 'mark')).toBe(true);
+	});
 });


### PR DESCRIPTION
## Problem

Leaving a review comment on a markdown **table** (Documents tab / task-sidebar preview / new-tab preview) showed neither the highlight nor the margin comment icon afterward. The comment was saved to the DB, but on render it silently vanished — and its margin icon detached to the top of the document.

## Root cause

The highlight plugin (`rehype-review-highlights.ts`) anchors each comment by `(quote, occurrence)` over the document's rendered text stream, and depends on that stream being **byte-identical** on both sides:

- the **DOM walk** that captures a selection (`doc-review-selection.ts` → `collectDomText`), and
- the **hast walk** that places the highlight (`collectTextRefs`).

Tables break that invariant. `mdast-util-to-hast` interleaves whitespace-only `"\n"` text nodes between a table's structural elements (`table`/`thead`/`tbody`/`tr`), but the browser (and React) never render whitespace as a direct child of those elements — so the DOM walk never sees them.

A selection crossing a cell or row boundary therefore captured e.g. `"RuleScope"` (cells concatenated with no separator), while the plugin's hast stream had `"Rule\nScope"`. `findQuoteRange` never matched → no `<mark>` was emitted → no highlight, and `querySelector('mark[data-review-id=…]')` returned null so the margin icon fell back to `top: 0`.

## Fix

Skip exactly those dropped whitespace nodes in the hast walk (`collectTextRefs`), mirroring what the browser drops, so the two streams realign. The set is scoped to table-section containers (`table`, `thead`, `tbody`, `tfoot`, `tr`, `colgroup`); cells (`td`/`th`) and `caption` keep their text. This is match-time only — the whitespace nodes stay in the tree, so the rendered table is unchanged.

```
DOM  stream:  …RuleScope…       (browser drops the inter-cell "\n")
hast stream:  …Rule\nScope…     → after fix: …RuleScope…  (aligned)
```

## Testing

- **Unit** (`rehype-review-highlights.test.ts`): quotes spanning a cell boundary and a row boundary now resolve; occurrence-counting stays correct across cells; whitespace nodes are left intact (no reflow).
- **End-to-end** (`document-review.test.tsx`): a select-across-cells → pill → save → highlight flow on the Documents tab now produces the anchored highlight **and** its margin icon.
- Both new suites were confirmed to **fail without the source change** and pass with it.
- Full web component suite green (150 files / 871 tests); `tsc --noEmit` and Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q2cxwVgPTEnSwxhWzaVZjo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2cxwVgPTEnSwxhWzaVZjo)_