### PR TITLE
fix(web): strip @@ prefix from unresolved passive mentions

### DIFF
--- a/packages/server/src/services/ceo-message-render.ts
+++ b/packages/server/src/services/ceo-message-render.ts
@@ -90,7 +90,11 @@ export async function renderCeoMessageForChannel(
 					return `[${display}](${baseUrl}${GLOBAL_INBOX_PATH})`;
 				}
 				const a = agents.get(token.slug);
-				return a ? `[${display}](${baseUrl}${agentPath(a.project_slug, token.slug)})` : null;
+				if (a) return `[${display}](${baseUrl}${agentPath(a.project_slug, token.slug)})`;
+				// An unresolved passive `@@slug` still sheds its `@@` authoring prefix and
+				// renders as the bare slug — the double-@ is internal syntax that must
+				// never surface. Active `@slug` keeps its (readable) prefix as plain text.
+				return token.kind === 'passive_agent' ? display : null;
 			}
 		}
 	});

--- a/packages/server/test/ceo-message-render.test.ts
+++ b/packages/server/test/ceo-message-render.test.ts
@@ -120,6 +120,15 @@ describe('renderCeoMessageForChannel', () => {
 			);
 		});
 
+		it('strips the @@ prefix from an unresolved passive mention, keeping the bare slug', async () => {
+			// A passive @@slug that resolves to no agent (unknown, or ambiguous across
+			// teams) still sheds its internal `@@` syntax; an unresolved active @slug
+			// keeps its (readable) prefix as plain text.
+			expect(
+				await renderCeoMessageForChannel(db, 'Handed to @@nobody, cc @ghost', CeoChannel.Telegram),
+			).toBe('Handed to nobody, cc @ghost');
+		});
+
 		it('keeps unknown references and code spans bare in a mixed message', async () => {
 			const mixed = 'RD-901 is real but ZZ-99 is not, and `RD-901` stays code:\n```\nRD-901\n```';
 			expect(await renderCeoMessageForChannel(db, mixed, CeoChannel.Telegram)).toBe(

--- a/packages/web/src/components/markdown-prose.tsx
+++ b/packages/web/src/components/markdown-prose.tsx
@@ -159,9 +159,15 @@ export function MarkdownProse({
 
 	const remarkPlugins = useMemo<RemarkPlugin>(() => {
 		const plugins: NonNullable<RemarkPlugin> = [remarkGfm];
+		// The plugin also runs when the text carries a passive `@@` mention even if
+		// nothing resolved: an unresolved passive mention still needs its internal
+		// `@@` prefix stripped to a bare slug (see remark-mentions splitTextNode), so
+		// gating purely on resolved-map sizes would leak `@@slug` to the reader.
+		const hasPassiveMention = children.includes('@@');
 		if (
 			(projectId || instance) &&
-			(agentsMap.size > 0 ||
+			(hasPassiveMention ||
+				agentsMap.size > 0 ||
 				tasksMap.size > 0 ||
 				kbDocsMap.size > 0 ||
 				projectDocsMap.size > 0 ||
@@ -186,6 +192,7 @@ export function MarkdownProse({
 		if (commentRefTask) plugins.push([remarkCommentRefs, commentRefTask]);
 		return plugins;
 	}, [
+		children,
 		projectId,
 		projectSlug,
 		instance,

--- a/packages/web/src/lib/remark-mentions.ts
+++ b/packages/web/src/lib/remark-mentions.ts
@@ -135,8 +135,16 @@ function splitTextNode(node: TextNode, opts: Options): MdNode[] {
 	MENTION_RE.lastIndex = 0;
 	let match = MENTION_RE.exec(value);
 	while (match !== null) {
-		const link = buildLink(parseMentionMatch(match), opts);
-		if (!link) {
+		const token = parseMentionMatch(match);
+		const link = buildLink(token, opts);
+		// A passive `@@slug` that can't resolve to a link (unknown agent, or an agent
+		// slug that's ambiguous instance-wide — every Startup team has a `captain`)
+		// still strips its `@@` authoring prefix and degrades to the bare slug as
+		// plain text. The double-@ is internal mention syntax and must never surface
+		// to a reader, matching how the resolved passive form already drops it.
+		const replacement: MdNode | null =
+			link ?? (token.kind === 'passive_agent' ? { type: 'text', value: token.raw.slice(2) } : null);
+		if (!replacement) {
 			match = MENTION_RE.exec(value);
 			continue;
 		}
@@ -145,7 +153,7 @@ function splitTextNode(node: TextNode, opts: Options): MdNode[] {
 		if (start > lastIndex) {
 			parts.push({ type: 'text', value: value.slice(lastIndex, start) });
 		}
-		parts.push(link);
+		parts.push(replacement);
 		lastIndex = end;
 		match = MENTION_RE.exec(value);
 	}

--- a/packages/web/test/ceo-chat-mentions.test.tsx
+++ b/packages/web/test/ceo-chat-mentions.test.tsx
@@ -186,3 +186,32 @@ test('agent mentions link to the agent home project; HQ singletons resolve to hq
 	expect(agentLink.getAttribute('href')).toBe('/projects/hq/agents/ceo');
 	expect(agentLink.textContent).toBe('ceo');
 });
+
+test('an unresolved passive @@mention sheds its @@ prefix and renders as the bare slug', async () => {
+	// Instance-wide resolution drops references that aren't unique across every team
+	// (an agent slug like `captain` collides — every Startup team has one), so the
+	// passive mention never links. It must still degrade to the bare slug, not leak
+	// the internal `@@` authoring syntax to the reader.
+	const { findByTestId, getByTestId } = await renderApp({
+		initialPath: '/home',
+		seed: async () => {
+			await seedWorkspace();
+		},
+	});
+
+	(await findByTestId('ceo-chat-launcher')).click();
+	await findByTestId('ceo-chat-panel');
+
+	seedCeoReply('HM-70 is with @@nonexistentrole — two focused amendments.');
+
+	const body = await findByTestId('ceo-chat-markdown');
+	await waitFor(() => {
+		if (!getByTestId('ceo-chat-markdown').textContent?.includes('nonexistentrole')) {
+			throw new Error('reply not rendered yet');
+		}
+	});
+	// The `@@` prefix is stripped; the bare slug remains as plain text, not a link.
+	expect(body.textContent).toContain('is with nonexistentrole');
+	expect(body.textContent).not.toContain('@@');
+	expect(body.querySelector('[data-testid="agent-mention-link"]')).toBeNull();
+});


### PR DESCRIPTION
## What & why

In the global CEO chat a passive `@@captain` mention rendered as literal `@@captain` text next to properly-linked task references (`HM-69`, `HM-70`), which reads as broken passive-mention rendering.

**Root cause.** A passive `@@slug` links only when its agent resolves. In the CEO chat (instance scope), `resolveInstanceMentions` links a reference only when it's **unique across the whole instance** (`WHERE n = 1`). An agent slug like `captain` collides — every Startup-template team has one — so it's dropped as ambiguous. The web renderer's `buildLink` then returns `null` and `splitTextNode` left the **raw matched text** `@@captain` in place, leaking the internal `@@` authoring syntax to the reader. (The resolved passive form already strips `@@` and shows the bare slug.)

## Changes

- **`packages/web/src/lib/remark-mentions.ts`** — when a passive `@@slug` doesn't resolve to a link, degrade to the **bare slug** as plain text instead of leaving raw `@@slug`. Unresolved active `@slug` is unchanged (readable plain text).
- **`packages/web/src/components/markdown-prose.tsx`** — the mention plugin gate now also fires when the text carries a `@@` mention, so a message that resolves nothing else still gets its passive prefix cleaned up.
- **`packages/server/src/services/ceo-message-render.ts`** — same fallback for the server-side channel (Telegram) renderer, keeping every surface consistent.

## Tests

- `packages/web/test/ceo-chat-mentions.test.tsx` — an unresolved passive `@@mention` sheds its `@@` prefix and renders as the bare slug (no link).
- `packages/server/test/ceo-message-render.test.ts` — an unresolved passive `@@slug` strips to the bare slug for Telegram while an unresolved active `@slug` keeps its prefix.

All mention suites (server, web, shared), typecheck, and the production build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ogyhcHKuPTUfbMownY9gK

---
_Generated by [Claude Code](https://claude.ai/code/session_013ogyhcHKuPTUfbMownY9gK)_