### PR TITLE
feat(web): version display on General settings; base URL blurb → tooltip

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -971,7 +971,11 @@ master key) → run the previous binary.
 version from Conventional Commits and opens a `release/<version>` PR; merging fires
 `release-publish.yml`, which tags, cross-compiles, and publishes a GitHub Release (assets
 `hezo-{os}-{arch}[.exe]` + `SHA256SUMS`). The running instance polls
-`GET /api/updates/latest` (cached ~1 h, fails soft) and shows a bottom banner.
+`GET /api/updates/latest` (cached ~1 h, fails soft) and shows a bottom banner. The
+Settings → General page also renders a **Version** section (current version linked to its
+GitHub release, plus a **"Check for new version"** button that calls
+`POST /api/updates/check` — any authed user — to force a fresh GitHub check bypassing the
+1 h cache, the same upstream check the daily cron runs).
 
 **Self-update & supervisor.** A compiled binary with auto-update enabled
 (`isAutoUpdateEnabled()` — compiled, not `HEZO_DISABLE_AUTO_UPDATE`, not in a container)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   · <a href="./docs/introduction.md">Docs</a>
   · <a href="https://hezo.ai">Website</a>
   · <a href="https://github.com/hezo-ai/hezo">GitHub</a>
-  · <a href="https://x.com/taoofdev">X</a>
+  · <a href="https://x.com/hezo_ai">X</a>
 </p>
 
 <p align="center">
@@ -194,4 +194,4 @@ Copyright (C) 2026 [Ramesh Nair](https://hiddentao.com).
 
 Hezo is licensed under the [MIT License](./LICENSE.md).
 
-X: [@taoofdev](https://x.com/taoofdev)
+X: [@hezo_ai](https://x.com/hezo_ai)

--- a/packages/server/src/routes/updates.ts
+++ b/packages/server/src/routes/updates.ts
@@ -75,9 +75,13 @@ async function fetchLatest(): Promise<UpdateInfo> {
 	}
 }
 
-/** Cached latest-release info (1h TTL), shared by the route and the update-check cron. */
-export async function getLatestInfo(): Promise<UpdateInfo> {
-	if (!cache || Date.now() - cache.at >= TTL_MS) {
+/**
+ * Cached latest-release info (1h TTL), shared by the route and the update-check cron.
+ * Pass `force` to bypass the cache and hit GitHub now (the manual "Check for new
+ * version" button) — the fresh result is then cached like any other.
+ */
+export async function getLatestInfo(opts?: { force?: boolean }): Promise<UpdateInfo> {
+	if (opts?.force || !cache || Date.now() - cache.at >= TTL_MS) {
 		cache = { at: Date.now(), data: await fetchLatest() };
 	}
 	return cache.data;
@@ -93,6 +97,11 @@ export function buildUpdatesRoutes(opts: { autoUnlock: boolean }): Hono<Env> {
 
 	// Any authed user: passive "is an update available" check (banner + settings).
 	routes.get('/updates/latest', async (c) => c.json(await getLatestInfo()));
+
+	// Any authed user: force a fresh GitHub check now, bypassing the 1h cache. This
+	// is the same upstream check the daily update-check cron runs; the settings
+	// "Check for new version" button calls it on demand.
+	routes.post('/updates/check', async (c) => c.json(await getLatestInfo({ force: true })));
 
 	// Any authed user: latest info + staged-update lifecycle + auto-unlock hint.
 	routes.get('/updates/status', async (c) => {

--- a/packages/server/test/updates-routes.test.ts
+++ b/packages/server/test/updates-routes.test.ts
@@ -51,6 +51,30 @@ describe('update routes (status / download / apply)', () => {
 		expect(body.canApply).toBe(false);
 	});
 
+	it('POST /updates/check forces a fresh check for any authed user, bypassing the cache', async () => {
+		// Warm the cache with an older release, then flip the upstream to a newer one.
+		await app.request('/api/updates/latest', { headers: authHeader(userToken) });
+		vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					tag_name: '10.0.0',
+					html_url: 'https://github.com/hezo-ai/hezo/releases/10.0.0',
+				}),
+				{ status: 200, headers: { 'Content-Type': 'application/json' } },
+			),
+		);
+
+		const res = await app.request('/api/updates/check', {
+			method: 'POST',
+			headers: authHeader(userToken),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		// The forced check bypassed the 1h cache and picked up the newer release.
+		expect(body.latest).toBe('10.0.0');
+		expect(body.updateAvailable).toBe(true);
+	});
+
 	it('POST /updates/download requires superuser', async () => {
 		const res = await app.request('/api/updates/download', {
 			method: 'POST',

--- a/packages/web/src/components/instance-settings-section.tsx
+++ b/packages/web/src/components/instance-settings-section.tsx
@@ -8,7 +8,11 @@ import {
 import { useMe } from '../hooks/use-me';
 import type { ApiError } from '../lib/api';
 import { Button } from './ui/button';
+import { InfoTooltip } from './ui/info-tooltip';
 import { Input } from './ui/input';
+
+const BASE_URL_BLURB =
+	'Public base URL of this Hezo instance, used to build absolute links to tasks and documents in external channels (e.g. Telegram). Captured automatically the first time the instance is unlocked.';
 
 export function InstanceSettingsSection() {
 	const { data: me } = useMe();
@@ -18,16 +22,18 @@ export function InstanceSettingsSection() {
 		<section>
 			<div className="mb-4">
 				<h2 className="text-base font-medium">General</h2>
-				<p className="text-[13px] text-text-2 mt-1">
-					Public base URL of this Hezo instance, used to build absolute links to tasks and documents
-					in external channels (e.g. Telegram). Captured automatically the first time the instance
-					is unlocked.
-				</p>
 			</div>
 			<div className="border border-border rounded-md p-3 bg-surface">
-				<label className="block text-[13px] font-medium mb-1.5" htmlFor="instance-base-url-input">
-					Base URL
-				</label>
+				<div className="flex items-center gap-1.5 mb-1.5">
+					<label className="block text-[13px] font-medium" htmlFor="instance-base-url-input">
+						Base URL
+					</label>
+					<InfoTooltip
+						label="About the base URL"
+						content={BASE_URL_BLURB}
+						data-testid="instance-base-url-info"
+					/>
+				</div>
 				{settings === undefined ? null : me?.is_superuser ? (
 					<BaseUrlForm settings={settings} />
 				) : (

--- a/packages/web/src/components/settings-sidebar.tsx
+++ b/packages/web/src/components/settings-sidebar.tsx
@@ -2,10 +2,6 @@ import { Link, useLocation } from '@tanstack/react-router';
 import { ChevronDown } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useMe } from '../hooks/use-me';
-import { useUpdateCheck } from '../hooks/use-update-check';
-
-/** Release tags are plain `MAJOR.MINOR.PATCH` (no `v` prefix) — only those have a GitHub tag page. */
-const RELEASE_TAG = /^\d+\.\d+\.\d+$/;
 
 interface NavItem {
 	to: string;
@@ -39,44 +35,6 @@ function itemClass(active: boolean): string {
 			? 'text-text-1 font-medium bg-surface-2'
 			: 'text-text-2 hover:text-text-1 hover:bg-surface-2'
 	}`;
-}
-
-function VersionFooter() {
-	const { data: update } = useUpdateCheck();
-	if (!update?.current) return null;
-	return (
-		<div
-			data-testid="settings-version"
-			className="mt-3 pt-3 px-3 border-t border-border text-[12px] text-text-2"
-		>
-			<div className="italic">
-				version:{' '}
-				{RELEASE_TAG.test(update.current) ? (
-					<a
-						href={`https://github.com/hezo-ai/hezo/releases/tag/${update.current}`}
-						target="_blank"
-						rel="noreferrer"
-						className="hover:underline hover:text-text-1 transition-colors"
-					>
-						{update.current}
-					</a>
-				) : (
-					<span>{update.current}</span>
-				)}
-			</div>
-			<div className="mt-1.5">
-				Got feedback?{' '}
-				<a
-					href="https://x.com/taoofdev"
-					target="_blank"
-					rel="noreferrer"
-					className="hover:underline hover:text-text-1 transition-colors"
-				>
-					@taoofdev
-				</a>
-			</div>
-		</div>
-	);
 }
 
 /**
@@ -163,7 +121,6 @@ export function SettingsSidebar() {
 						{item.label}
 					</Link>
 				))}
-				<VersionFooter />
 			</nav>
 		</>
 	);

--- a/packages/web/src/components/version-display.tsx
+++ b/packages/web/src/components/version-display.tsx
@@ -1,0 +1,101 @@
+import { Loader2 } from 'lucide-react';
+import { useCheckForUpdate, useUpdateCheck } from '../hooks/use-update-check';
+import { Button } from './ui/button';
+
+/** Release tags are plain `MAJOR.MINOR.PATCH` (no `v` prefix) — only those have a GitHub tag page. */
+const RELEASE_TAG = /^\d+\.\d+\.\d+$/;
+
+const RELEASES_URL = 'https://github.com/hezo-ai/hezo/releases';
+
+/**
+ * Version section at the bottom of the General settings page: the running version
+ * (linked to its GitHub release page) plus a "Check for new version" button that
+ * forces the same GitHub update check the daily cron runs.
+ */
+export function VersionDisplay() {
+	const { data: update } = useUpdateCheck();
+	const check = useCheckForUpdate();
+
+	if (!update?.current) return null;
+
+	const current = update.current;
+	const isReleaseTag = RELEASE_TAG.test(current);
+	const releaseUrl = isReleaseTag ? `${RELEASES_URL}/tag/${current}` : RELEASES_URL;
+
+	return (
+		<section className="mt-8" data-testid="settings-version">
+			<div className="mb-4">
+				<h2 className="text-base font-medium">Version</h2>
+				<p className="text-[13px] text-text-2 mt-1">
+					The version of Hezo this instance is running. Check for new releases on GitHub.
+				</p>
+			</div>
+			<div className="border border-border rounded-md p-3 bg-surface">
+				<div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+					<div className="text-[13px]">
+						<span className="text-text-2">Current version:</span>{' '}
+						<a
+							href={releaseUrl}
+							target="_blank"
+							rel="noreferrer"
+							className="font-medium text-text-1 hover:underline"
+							data-testid="settings-version-current"
+						>
+							{current}
+						</a>
+					</div>
+					<Button
+						size="sm"
+						variant="secondary"
+						onClick={() => check.mutate()}
+						disabled={check.isPending}
+						data-testid="settings-version-check"
+						className="self-start sm:self-auto"
+					>
+						{check.isPending && <Loader2 className="w-3 h-3 animate-spin" />} Check for new version
+					</Button>
+				</div>
+				{!check.isPending && check.isSuccess && (
+					<p
+						className="text-[13px] mt-2.5"
+						data-testid="settings-version-result"
+						aria-live="polite"
+					>
+						{update.updateAvailable && update.latest ? (
+							<span className="text-text-1">
+								Version{' '}
+								<a
+									href={update.url ?? RELEASES_URL}
+									target="_blank"
+									rel="noreferrer"
+									className="font-medium hover:underline"
+								>
+									{update.latest}
+								</a>{' '}
+								is available.
+							</span>
+						) : (
+							<span className="text-text-2">You're on the latest version.</span>
+						)}
+					</p>
+				)}
+				{check.isError && (
+					<p className="text-[13px] text-danger mt-2.5" data-testid="settings-version-error">
+						Couldn't check for updates. Please try again.
+					</p>
+				)}
+			</div>
+			<p className="text-[13px] text-text-2 mt-3">
+				Got feedback?{' '}
+				<a
+					href="https://x.com/hezo_ai"
+					target="_blank"
+					rel="noreferrer"
+					className="hover:underline hover:text-text-1 transition-colors"
+				>
+					@hezo_ai
+				</a>
+			</p>
+		</section>
+	);
+}

--- a/packages/web/src/hooks/use-update-check.ts
+++ b/packages/web/src/hooks/use-update-check.ts
@@ -36,6 +36,23 @@ export function useUpdateCheck() {
 }
 
 /**
+ * Force a fresh GitHub release check now (bypassing the server's 1h cache) — the
+ * same upstream check the daily cron runs. Drives the settings "Check for new
+ * version" button; seeds the `updateCheck` query with the result so the version
+ * display reflects it immediately.
+ */
+export function useCheckForUpdate() {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: () => api.post<UpdateInfo>('/api/updates/check'),
+		onSuccess: (data) => {
+			queryClient.setQueryData(queryKeys.updateCheck(), data);
+			queryClient.invalidateQueries({ queryKey: queryKeys.updateStatus() });
+		},
+	});
+}
+
+/**
  * Latest-release info plus the staged-update lifecycle and whether this instance
  * can apply-and-restart. Drives the "Install & restart" affordance.
  */

--- a/packages/web/src/routes/settings/index.tsx
+++ b/packages/web/src/routes/settings/index.tsx
@@ -1,11 +1,13 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { InstanceSettingsSection } from '../../components/instance-settings-section';
+import { VersionDisplay } from '../../components/version-display';
 
 /** The default Settings page (visiting /settings with no subpage) — general instance settings. */
 function GeneralSettingsPage() {
 	return (
 		<div className="max-w-[900px]">
 			<InstanceSettingsSection />
+			<VersionDisplay />
 		</div>
 	);
 }

--- a/packages/web/test/helpers/render.tsx
+++ b/packages/web/test/helpers/render.tsx
@@ -134,7 +134,11 @@ beforeEach(async () => {
 		// through), so a static "no update available" body keeps the banner inert.
 		// Tests that need a specific version/update seed the query cache directly
 		// (see settings-version.test.tsx), so `current` here is cosmetic.
-		if (path === '/api/updates/latest' || path === '/api/updates/status') {
+		if (
+			path === '/api/updates/latest' ||
+			path === '/api/updates/status' ||
+			path === '/api/updates/check'
+		) {
 			const base = { current: '0.0.0-test', latest: null, updateAvailable: false, url: null };
 			const body =
 				path === '/api/updates/status'

--- a/packages/web/test/settings-version.test.tsx
+++ b/packages/web/test/settings-version.test.tsx
@@ -3,52 +3,72 @@ import { queryClient } from '../src/lib/query-client';
 import { queryKeys } from '../src/lib/query-keys';
 import { renderApp } from './helpers/render';
 
-// The settings page reads the running version via useUpdateCheck(); the app tree
-// pulls from the singleton query client (__root re-wraps with it), so seed that
-// cache to render the footer deterministically without an upstream GitHub call.
-function seedVersion(current: string) {
+// The General settings page reads the running version via useUpdateCheck(); the app
+// tree pulls from the singleton query client (__root re-wraps with it), so seed that
+// cache to render the version display deterministically without an upstream GitHub call.
+function seedVersion(update: {
+	current: string;
+	latest?: string | null;
+	updateAvailable?: boolean;
+	url?: string | null;
+}) {
 	queryClient.setQueryData(queryKeys.updateCheck(), {
-		current,
-		latest: null,
-		updateAvailable: false,
-		url: null,
+		current: update.current,
+		latest: update.latest ?? null,
+		updateAvailable: update.updateAvailable ?? false,
+		url: update.url ?? null,
 	});
 }
 
-test('settings footer shows the version and links to its GitHub release tag', async () => {
-	seedVersion('0.2.0');
+test('general settings page shows the version and links to its GitHub release tag', async () => {
+	seedVersion({ current: '0.2.0' });
 	const { findByTestId } = await renderApp({ initialPath: '/settings' });
 
-	const footer = await findByTestId('settings-version');
-	expect(footer.textContent).toContain('version: 0.2.0');
+	const section = await findByTestId('settings-version');
+	expect(section.textContent).toContain('Current version:');
+	expect(section.textContent).toContain('0.2.0');
 
-	const releaseLink = footer.querySelector(
+	const releaseLink = section.querySelector(
 		'a[href="https://github.com/hezo-ai/hezo/releases/tag/0.2.0"]',
 	) as HTMLAnchorElement | null;
 	expect(releaseLink).toBeTruthy();
 	expect(releaseLink?.textContent).toContain('0.2.0');
 });
 
-test('settings footer shows a non-release version as plain text (no broken tag link)', async () => {
-	seedVersion('0.0.0-dev');
+test('general settings page links a non-release version to the releases index (no broken tag link)', async () => {
+	seedVersion({ current: '0.0.0-dev' });
 	const { findByTestId } = await renderApp({ initialPath: '/settings' });
 
-	const footer = await findByTestId('settings-version');
-	expect(footer.textContent).toContain('version: 0.0.0-dev');
-	// No release-tag link for a non-release version (the feedback link still renders).
-	expect(footer.querySelector('a[href*="/releases/tag/"]')).toBeNull();
+	const section = await findByTestId('settings-version');
+	expect(section.textContent).toContain('0.0.0-dev');
+	// No release-tag link for a non-release version; it points at the releases index instead.
+	expect(section.querySelector('a[href*="/releases/tag/"]')).toBeNull();
+	expect(section.querySelector('a[href="https://github.com/hezo-ai/hezo/releases"]')).toBeTruthy();
 });
 
-test('settings footer links the feedback handle to the taoofdev X account', async () => {
-	seedVersion('0.2.0');
+test('check-for-new-version button posts a fresh check and reports the result', async () => {
+	seedVersion({ current: '0.2.0' });
+	const { findByTestId, user } = await renderApp({ initialPath: '/settings' });
+
+	// The server's /api/updates/check returns the same release the test backend has;
+	// clicking the button seeds the cache with that response and renders the result.
+	const button = await findByTestId('settings-version-check');
+	await user.click(button);
+
+	const result = await findByTestId('settings-version-result');
+	expect(result.textContent).toMatch(/latest version|is available/);
+});
+
+test('feedback handle links to the hezo_ai X account', async () => {
+	seedVersion({ current: '0.2.0' });
 	const { findByTestId } = await renderApp({ initialPath: '/settings' });
 
-	const footer = await findByTestId('settings-version');
-	expect(footer.textContent).toContain('Got feedback? @taoofdev');
+	const section = await findByTestId('settings-version');
+	expect(section.textContent).toContain('Got feedback? @hezo_ai');
 
-	const feedbackLink = footer.querySelector(
-		'a[href="https://x.com/taoofdev"]',
+	const feedbackLink = section.querySelector(
+		'a[href="https://x.com/hezo_ai"]',
 	) as HTMLAnchorElement | null;
 	expect(feedbackLink).toBeTruthy();
-	expect(feedbackLink?.textContent).toContain('@taoofdev');
+	expect(feedbackLink?.textContent).toContain('@hezo_ai');
 });


### PR DESCRIPTION
## Summary

Reworks the **Settings → General** page per the request:

- **Base URL blurb → tooltip.** The "Public base URL of this Hezo instance…" description moved out from under the *General* heading into an ⓘ info tooltip beside the **Base URL** label.
- **New Version section** at the bottom of the General page:
  - **Current version**, linked to its GitHub release page (`…/releases/tag/<version>`; falls back to the releases index for non-release/dev versions).
  - **Check for new version** button — forces the GitHub update check on demand (the same upstream check the daily cron runs), bypassing the server's 1 h cache, and reports whether an update is available or you're up to date.
- **Removed the old `version:` footer** from the desktop settings menu — the version now lives on the General page. The "Got feedback?" link moved along with it.
- Updated the feedback X handle to **@hezo_ai** across the codebase (README + settings page).

## Changes

**Server**
- `routes/updates.ts` — `getLatestInfo({ force })` can bypass the cache; new `POST /api/updates/check` (any authed user) forces a fresh GitHub check.

**Web**
- `components/version-display.tsx` (new) — the Version section, rendered at the bottom of `/settings`.
- `hooks/use-update-check.ts` — `useCheckForUpdate()` mutation that seeds the `updateCheck` cache from the forced check.
- `components/instance-settings-section.tsx` — blurb moved into an `InfoTooltip` next to the Base URL label.
- `components/settings-sidebar.tsx` — removed `VersionFooter`.
- `routes/settings/index.tsx` — renders `<VersionDisplay />`.

**Docs**
- `.dev/architecture.md` — documents the new manual force-check endpoint and the settings Version section.

## Testing

- `packages/server/test/updates-routes.test.ts` — `POST /updates/check` forces a fresh check for any authed user, bypassing the cache.
- `packages/web/test/settings-version.test.tsx` — rewritten to target the General-page Version section: release-tag link, non-release fallback, the check button's result state, and the feedback handle.
- `packages/web/test/helpers/render.tsx` — short-circuits `POST /api/updates/check` so component tests stay off the real GitHub API.
- Full `turbo typecheck` + build pass (via the pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UGyEd195rLsN8PFoaA6HFt)_