### PR TITLE
feat(auth): admin password authentication + master-key vault UI

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -815,16 +815,40 @@ keys), so the unlock key transits exactly twice per boot — at setup and at
 unlock-after-restart — always inside an Ed25519-signed payload.
 
 **Bootstrap (challenge-response).** `POST /auth/setup` enrolls the public key + unlock key
-+ canary in one transaction (self-certifying signature, `unset` state only). Routine login
-transmits **zero key material**: `POST /auth/challenge` issues a single-use nonce,
-`POST /auth/verify` returns a JWT after verifying the signature over a reconstructed,
-domain-separated message (`hezo-auth-v1:login:<nonce>`). After a restart the server starts
-**locked**; the first `verify` includes the `unlock_key`. Messages are versioned and
-domain-separated so signatures can't be replayed or cross-purposed; on unlock
-`MasterKeyManager` fires `onUnlock` callbacks that start the `JobManager`.
++ canary in one transaction (self-certifying signature, `unset` state only). The mnemonic
+transmits **zero key material** on routine use: `POST /auth/challenge` issues a single-use
+nonce, `POST /auth/verify` verifies the signature over a reconstructed, domain-separated
+message (`hezo-auth-v1:login:<nonce>`). After a restart the server starts **locked**; the
+first `verify` includes the `unlock_key`. Messages are versioned and domain-separated so
+signatures can't be replayed or cross-purposed; on unlock `MasterKeyManager` fires
+`onUnlock` callbacks that start the `JobManager`.
+
+**The master key only *unlocks*.** It is not a login. `setup` and `verify` return a
+short-lived **password-setup-scoped JWT** (`scope: password_setup`, ~10 min), never a
+session — `verifyToken` rejects that scope on every general route. Its sole power is
+`POST /auth/password`. So proving master-key ownership unlocks the instance and authorizes
+setting a password; a **session** is minted only by the password (below). This is the
+recovery path too: "forgot password" re-enters the master key to obtain the scoped token,
+then sets a new one.
+
+**Password authentication (no anonymous sessions).** Day-to-day access is a per-admin
+**password**, and every session is authenticated — there is **no anonymous access** on
+REST or the WebSocket. The password is low-entropy so it is **never sent to the server**:
+the browser derives an Ed25519 keypair from `scrypt(password, salt)` and the server stores
+only a **verifier** (`users.password_salt` + `users.password_public_key`), never a hash.
+Login mirrors the mnemonic's challenge-response: `POST /auth/password-challenge` returns a
+nonce + the salt; `POST /auth/password-verify` checks the signature over
+`hezo-auth-v1:password-login:<nonce>` and mints a **session JWT**. `POST /auth/password`
+(accepting either a session or the password-setup-scoped token) enrolls a new verifier and
+returns a fresh session. `password-verify` is throttled in memory (single admin → global
+backoff/lockout). `GET /api/status` exposes `passwordSet`, and the web gate uses a
+`GET /api/me` probe to distinguish "unlocked but no session → password login" from a valid
+session. **Existing installations** are migrated (013) with the default password `"password"`
+so operators can sign in immediately after upgrading, then change it.
 
 **Three principals.**
-- **User JWT** (HS256, secret derived from the unlock key) — `Authorization: Bearer <jwt>`.
+- **User JWT** (HS256, secret derived from the unlock key) — `Authorization: Bearer <jwt>`,
+  7-day, minted only by password login / set-password.
 - **API key** — `Authorization: Bearer hezo_<key>`, SHA-256-hashed, **instance-scoped**. The
   external on-ramp, confined to the **MCP endpoint (`POST /mcp`) only** — rejected on REST
   and the WebSocket. One `api_keys` table with a `status` (pending/approved) backs **two

--- a/docs/deployment/secure-remote-access.md
+++ b/docs/deployment/secure-remote-access.md
@@ -43,9 +43,19 @@ lives only as long as the SSH session.
 ## Public domain + reverse proxy + auth
 
 If you do want a public URL, terminate HTTPS with a reverse proxy (see
-[Deploying to the cloud](/docs/deployment/cloud)) **and** put an authentication layer in
-front (your proxy's auth, an identity-aware proxy, or an SSO gateway). Never publish the
-raw Hezo port directly.
+[Deploying to the cloud](/docs/deployment/cloud)). Never publish the raw Hezo port
+directly.
+
+Hezo authenticates every session with your **admin password**, so a public deployment is
+no longer open by default. The practical setup is to supply the master key non-interactively
+(`HEZO_MASTER_KEY`) so the instance unlocks itself on each restart, while everyone still has
+to sign in with the password to reach the app:
+
+- **Set a strong admin password** and, if you upgraded an existing instance, change the
+  default (`password`) before exposing it. See [Master key & encryption](/docs/security/master-key).
+- For defense in depth you can still add a second authentication layer in front (your
+  proxy's auth, an identity-aware proxy, or an SSO gateway) — recommended for
+  internet-facing deployments.
 
 ## Install Hezo on your phone
 

--- a/docs/getting-started/first-run.md
+++ b/docs/getting-started/first-run.md
@@ -7,7 +7,7 @@ section: Getting started
 # First-run setup
 
 The first time you open Hezo at **http://localhost:3100**, a short setup flow gets you
-to a working instance: create your master key and connect a model.
+to a working instance: create your master key, set an admin password, and connect a model.
 
 ## 1. Create your master key
 
@@ -25,11 +25,16 @@ read until you provide the phrase again on the unlock screen. You can also suppl
 non-interactively with `--master-key` / the `HEZO_MASTER_KEY` environment variable —
 useful for servers (see [Deploying to the cloud](/docs/deployment/cloud)).
 
-Setting the master key also signs you in as the instance operator — the board account
-you'll use to oversee teams, approve work, and chat with the CEO. There's no separate
-account sign-up step.
+## 2. Set an admin password
 
-## 2. Connect a model
+After the master key unlocks, you create an **admin password**. This is how you sign in
+from here on — the master key unlocks the *instance*, your password signs *you* in. Your
+password never leaves your browser.
+
+If you ever forget it, reset it with your master key from the sign-in screen. See
+[Master key & encryption](/docs/security/master-key).
+
+## 3. Connect a model
 
 Agents need a model to run. Add at least one **AI provider** — paste an API key (or
 connect a subscription where supported) for Anthropic (Claude), OpenAI (ChatGPT),

--- a/docs/security/master-key.md
+++ b/docs/security/master-key.md
@@ -38,6 +38,30 @@ You unlock from the web app's gate screen, or non-interactively with the `--mast
 flag / `HEZO_MASTER_KEY` environment variable when running on a server (see
 [Deploying to the cloud](/docs/deployment/cloud)).
 
+## Your password vs. the master key
+
+The master key and your password do two different jobs:
+
+- The **master key** *unlocks the instance* — it turns encryption on and, once entered (or
+  supplied via `HEZO_MASTER_KEY`), it's done for that run. It is **not** how you sign in.
+- Your **admin password** is how you *sign in* to the web app. On first run, right after
+  the master key, you set a password; from then on each browser session is authenticated
+  with it. Your password (like the master key) never leaves your browser — Hezo stores only
+  a verifier it can check a login against, never the password itself.
+
+This split is what lets you run Hezo on a public network safely: set `HEZO_MASTER_KEY` on
+the server so it unlocks automatically on every restart, and everyone still has to sign in
+with the password to reach the app. See
+[Secure remote access](/docs/deployment/secure-remote-access).
+
+**Forgot your password?** Reset it with your master key: on the sign-in screen choose
+**Forgot password? Use your master key**, enter the twelve words, and set a new one. The
+master key is the ultimate authority, so it's also your password-recovery path.
+
+> **Upgrading an existing instance?** Your admin account is given the default password
+> `password` so you can sign in right away — **change it immediately**, especially before
+> exposing the instance to a network.
+
 ## What's encrypted
 
 The master key protects all confidential data at rest, including:
@@ -49,7 +73,9 @@ The master key protects all confidential data at rest, including:
 
 ## Recovery
 
-There is intentionally **no backdoor.** If you lose the master key, the encrypted data
-can't be recovered — your only path forward is to reset the instance and start over
-(`hezo --reset`, see [Backup & recovery](/docs/deployment/backup-and-recovery)). Keep
-the phrase somewhere you trust.
+A forgotten **password** is easy to recover — reset it with your master key (above).
+
+A lost **master key** is different: there is intentionally **no backdoor.** If you lose it,
+the encrypted data can't be recovered — your only path forward is to reset the instance and
+start over (`hezo --reset`, see [Backup & recovery](/docs/deployment/backup-and-recovery)).
+Keep the phrase somewhere you trust.

--- a/packages/server/src/db/migrations/code/013_user_password.ts
+++ b/packages/server/src/db/migrations/code/013_user_password.ts
@@ -1,0 +1,44 @@
+import type { PGlite } from '@electric-sql/pglite';
+import { derivePasswordKeyPair, generatePasswordSalt } from '@hezo/shared';
+import type { CodeMigration } from '../../migrate';
+
+/**
+ * Adds password authentication to the single admin user.
+ *
+ * A password is never stored — only a *verifier*: a per-admin salt plus the
+ * Ed25519 public key derived from `scrypt(password, salt)` (see
+ * `derivePasswordKeyPair` in `@hezo/shared`). Login is challenge-response, so the
+ * password never leaves the browser. This is a code migration (not plain SQL)
+ * because the backfill has to run the same scrypt+Ed25519 derivation the browser
+ * uses, which SQL can't express.
+ *
+ * Existing installations: every superuser without a verifier is backfilled with
+ * the default password `"password"` so the operator can sign in immediately after
+ * upgrading (and is prompted to change it). A brand-new instance has no users row
+ * at migration time — the admin is created lazily on first `/auth/setup` and
+ * enrolls its own verifier through onboarding — so the backfill is a no-op there.
+ */
+const DEFAULT_PASSWORD = 'password';
+
+export const migration013UserPassword: CodeMigration = {
+	// Explicit, stable — a minifier rewriting run.toString() must not shift it.
+	checksum: '013_user_password_v1',
+	run: async (db: PGlite) => {
+		await db.exec(`
+			ALTER TABLE users ADD COLUMN password_salt TEXT;
+			ALTER TABLE users ADD COLUMN password_public_key TEXT;
+		`);
+
+		const existingAdmins = await db.query<{ id: string }>(
+			`SELECT id FROM users WHERE is_superuser = true AND password_public_key IS NULL`,
+		);
+		for (const { id } of existingAdmins.rows) {
+			const salt = generatePasswordSalt();
+			const { publicKeyHex } = await derivePasswordKeyPair(DEFAULT_PASSWORD, salt);
+			await db.query(
+				`UPDATE users SET password_salt = $1, password_public_key = $2, updated_at = now() WHERE id = $3`,
+				[salt, publicKeyHex, id],
+			);
+		}
+	},
+};

--- a/packages/server/src/db/migrations/code/index.ts
+++ b/packages/server/src/db/migrations/code/index.ts
@@ -1,4 +1,5 @@
 import type { CodeMigration } from '../../migrate';
+import { migration013UserPassword } from './013_user_password';
 
 /**
  * Registry of **code migrations** — schema/data migrations whose data transform
@@ -28,4 +29,6 @@ import type { CodeMigration } from '../../migrate';
  * `loadMigrations()` in `startup.ts` merges this with the SQL migrations into a
  * single ordered `Record<string, Migration>` the runner applies.
  */
-export const codeMigrations: Record<string, CodeMigration> = {};
+export const codeMigrations: Record<string, CodeMigration> = {
+	'013_user_password': migration013UserPassword,
+};

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -9,7 +9,7 @@ import { DbNewerThanAppError, MigrationFailedError } from './db/migrate-errors';
 import { browserAvailable, openBrowser } from './lib/open-browser';
 import type { AuthInfo } from './lib/types';
 import { logger, setLogLevel } from './logger';
-import { canAuthAccessTeam, loadAdminAuth, verifyToken } from './middleware/auth';
+import { canAuthAccessTeam, verifyToken } from './middleware/auth';
 import { getActiveRuntime, setActiveRuntime, shutdownRuntime } from './runtime-control';
 import type { ContainerLogStreamer } from './services/container-logs';
 import { setKeepOldContainers } from './services/containers';
@@ -180,12 +180,6 @@ async function validateToken(token: string): Promise<WsData['auth'] | null> {
 	return auth;
 }
 
-async function validateAnonymous(): Promise<WsData['auth'] | null> {
-	if (!mkmRef || !dbRef) return null;
-	if (mkmRef.getState() !== 'unlocked') return null;
-	return loadAdminAuth(dbRef);
-}
-
 async function canAccessTeam(auth: WsData['auth'], teamId: string): Promise<boolean> {
 	if (!dbRef) return false;
 	// By the time a socket subscribes, `open` has replaced the placeholder with a
@@ -281,7 +275,8 @@ export default {
 			const token = ws.data._token;
 			delete ws.data._token;
 
-			const auth = token ? await validateToken(token) : await validateAnonymous();
+			// No anonymous sockets: a valid session token is required, same as REST.
+			const auth = token ? await validateToken(token) : null;
 			if (!auth) {
 				ws.close(1008, 'Invalid auth');
 				return;

--- a/packages/server/src/lib/response.ts
+++ b/packages/server/src/lib/response.ts
@@ -8,7 +8,7 @@ export function err(
 	c: Context,
 	code: string,
 	message: string,
-	status: 400 | 401 | 402 | 403 | 404 | 409 | 422 | 500 | 503,
+	status: 400 | 401 | 402 | 403 | 404 | 409 | 422 | 429 | 500 | 503,
 ) {
 	return c.json({ error: { code, message } }, status);
 }

--- a/packages/server/src/middleware/auth.ts
+++ b/packages/server/src/middleware/auth.ts
@@ -19,13 +19,34 @@ const PUBLIC_PATHS = [
 	'/api/auth/setup',
 	'/api/auth/challenge',
 	'/api/auth/verify',
+	// Password login is challenge-response: fetch a nonce+salt, then verify a
+	// signature. Both are token-keyed and self-authenticating.
+	'/api/auth/password-challenge',
+	'/api/auth/password-verify',
+	// Set/change the password verifier. Public path but self-authenticating: it
+	// accepts either a full session JWT or a password-setup-scoped JWT and checks
+	// the bearer itself (the scoped token is rejected everywhere else).
+	'/api/auth/password',
 	'/',
+	// OAuth provider redirect targets: the browser arrives here from the provider
+	// with no session token; security comes from the signed `state` param, verified
+	// server-side. (Both the generic and the DCR/MCP callback.)
 	'/api/oauth/callback',
+	'/api/oauth/mcp-callback',
 	// API-key self-registration + status polling are token-keyed and do their own
 	// lookup, so they bypass the bearer-token auth middleware.
 	'/api/api-keys/register',
 	'/api/api-keys/status',
 ];
+
+/**
+ * JWT scope for the short-lived token minted by the mnemonic flows (setup /
+ * unlock / recovery). Its ONLY accepted use is `POST /api/auth/password`; it is
+ * rejected as a session everywhere else (see `verifyToken`). This is what keeps
+ * the master key an *unlock* credential, never a general login — a session is
+ * only ever minted by the password.
+ */
+export const PASSWORD_SETUP_SCOPE = 'password_setup';
 
 /**
  * Shared token verification used by HTTP middleware, MCP, and WebSocket auth.
@@ -128,6 +149,10 @@ export async function verifyToken(
 			};
 		}
 		if (payload.user_id) {
+			// A password-setup-scoped token proves master-key ownership but is NOT a
+			// session — it can only reach `/api/auth/password` (which validates it
+			// directly, bypassing this path). Reject it as a general credential.
+			if (payload.scope === PASSWORD_SETUP_SCOPE) return null;
 			const userResult = await db.query<{ is_superuser: boolean }>(
 				'SELECT is_superuser FROM users WHERE id = $1',
 				[payload.user_id],
@@ -151,15 +176,10 @@ export const authMiddleware = createMiddleware<Env>(async (c, next) => {
 	const header = c.req.header('Authorization');
 
 	if (!header?.startsWith('Bearer ')) {
-		// While the server is unlocked, requests without a token are accepted as
-		// the bootstrap admin so the instance is publicly viewable.
-		if (masterKeyManager.getState() === 'unlocked') {
-			const adminAuth = await loadAdminAuth(db);
-			if (adminAuth) {
-				c.set('auth', adminAuth);
-				return next();
-			}
-		}
+		// No anonymous access. Every session is authenticated by the admin
+		// password (JWT); a tokenless request is rejected so the instance is safe
+		// to expose on a public network. (Public, token-keyed endpoints are handled
+		// above via PUBLIC_PATHS.)
 		return c.json(
 			{ error: { code: 'UNAUTHORIZED', message: 'Missing authorization header' } },
 			401,
@@ -198,15 +218,6 @@ export const authMiddleware = createMiddleware<Env>(async (c, next) => {
 	return next();
 });
 
-export async function loadAdminAuth(db: PGlite): Promise<AuthInfo | null> {
-	const result = await db.query<{ id: string }>(
-		'SELECT id FROM users WHERE is_superuser = true LIMIT 1',
-	);
-	const userId = result.rows[0]?.id;
-	if (!userId) return null;
-	return { type: AuthType.Admin, userId, isSuperuser: true };
-}
-
 export async function signAdminJwt(
 	masterKeyManager: { getJwtKey: () => Promise<Buffer> },
 	userId: string,
@@ -215,6 +226,59 @@ export async function signAdminJwt(
 	const secret = jwtKey.toString('base64');
 	const now = Math.floor(Date.now() / 1000);
 	return sign({ user_id: userId, iat: now, exp: now + 86400 * 7 }, secret, 'HS256');
+}
+
+/**
+ * Short-lived, single-purpose token minted by the mnemonic flows (setup / unlock
+ * / recovery). It carries `scope: PASSWORD_SETUP_SCOPE` and is accepted ONLY by
+ * `POST /api/auth/password`; `verifyToken` rejects it as a session everywhere
+ * else, so the master key can never stand in for the password.
+ */
+export async function signPasswordSetupToken(
+	masterKeyManager: { getJwtKey: () => Promise<Buffer> },
+	userId: string,
+): Promise<string> {
+	const jwtKey = await masterKeyManager.getJwtKey();
+	const secret = jwtKey.toString('base64');
+	const now = Math.floor(Date.now() / 1000);
+	return sign(
+		{ user_id: userId, scope: PASSWORD_SETUP_SCOPE, iat: now, exp: now + 600 },
+		secret,
+		'HS256',
+	);
+}
+
+/**
+ * Authorize a password mutation (`POST /api/auth/password`). Accepts a bearer
+ * that is EITHER a full admin session JWT (logged-in change) OR a
+ * password-setup-scoped JWT (initial-set / recovery), and returns the superuser
+ * id it authorizes — or `null` if the token is anything else. Kept separate from
+ * `verifyToken` precisely because that path rejects the scoped token.
+ */
+export async function resolvePasswordMutationUserId(
+	token: string,
+	db: PGlite,
+	masterKeyManager: MasterKeyManager,
+): Promise<string | null> {
+	if (masterKeyManager.getState() !== 'unlocked') return null;
+	try {
+		const jwtKey = await masterKeyManager.getJwtKey();
+		const payload = await verify(token, jwtKey.toString('base64'), 'HS256');
+		const userId = payload.user_id as string | undefined;
+		if (!userId) return null;
+		// Only a full session or the password-setup scope may set a password. Agent
+		// / CEO tokens (member_id/session_id) never can.
+		if (payload.member_id || payload.session_id) return null;
+		if (payload.scope !== undefined && payload.scope !== PASSWORD_SETUP_SCOPE) return null;
+		const result = await db.query<{ is_superuser: boolean }>(
+			'SELECT is_superuser FROM users WHERE id = $1',
+			[userId],
+		);
+		if (!result.rows[0]?.is_superuser) return null;
+		return userId;
+	} catch {
+		return null;
+	}
 }
 
 export async function signAgentJwt(

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -1,5 +1,7 @@
 import {
 	buildLoginMessage,
+	buildPasswordLoginMessage,
+	buildPasswordSetupMessage,
 	buildSetupMessage,
 	buildUnlockMessage,
 	DEFAULT_TEAM_ID,
@@ -18,12 +20,49 @@ import {
 } from '../lib/system-meta';
 import type { Env } from '../lib/types';
 import { logger } from '../logger';
-import { signAdminJwt } from '../middleware/auth';
+import {
+	resolvePasswordMutationUserId,
+	signAdminJwt,
+	signPasswordSetupToken,
+} from '../middleware/auth';
+import {
+	getAdminPasswordVerifier,
+	setAdminPasswordVerifier,
+	verifyPasswordSignature,
+} from '../services/password';
 
 const log = logger.child('routes');
 
 const KEY_HEX = /^[0-9a-f]{64}$/;
 const SIGNATURE_HEX = /^[0-9a-f]{128}$/;
+const SALT_HEX = /^[0-9a-f]{32}$/;
+
+// In-memory brute-force throttle for password login. Single admin, so one global
+// counter suffices. Not persisted — a restart clears it, which is fine (a
+// restart re-locks the instance behind the master key anyway).
+const LOGIN_MAX_ATTEMPTS = 5;
+const LOGIN_LOCKOUT_MS = 60_000;
+const loginThrottle = { failures: 0, lockedUntil: 0 };
+
+function loginLockRemainingMs(now: number): number {
+	return loginThrottle.lockedUntil > now ? loginThrottle.lockedUntil - now : 0;
+}
+
+function recordLoginFailure(now: number): void {
+	loginThrottle.failures += 1;
+	if (loginThrottle.failures >= LOGIN_MAX_ATTEMPTS) {
+		// Exponential backoff past the threshold: 1m, 2m, 4m, … (capped at 1h).
+		const overage = loginThrottle.failures - LOGIN_MAX_ATTEMPTS;
+		const backoff = Math.min(LOGIN_LOCKOUT_MS * 2 ** overage, 60 * 60_000);
+		loginThrottle.lockedUntil = now + backoff;
+	}
+}
+
+/** Exported for tests: the throttle is module-global, so specs reset it to stay deterministic. */
+export function resetLoginThrottle(): void {
+	loginThrottle.failures = 0;
+	loginThrottle.lockedUntil = 0;
+}
 
 export const authRoutes = new Hono<Env>();
 
@@ -69,7 +108,7 @@ authRoutes.post('/auth/setup', async (c) => {
 		return err(c, 'ALREADY_SET', 'Master key is already set', 409);
 	}
 
-	return issueAdminSession(c);
+	return issuePasswordSetupToken(c);
 });
 
 // Step 1 of login/unlock: a single-use nonce for the client to sign.
@@ -81,11 +120,13 @@ authRoutes.post('/auth/challenge', (c) => {
 	return ok(c, { challenge_id: challengeId, nonce, expires_in: expiresInSeconds });
 });
 
-// Step 2: verify the Ed25519 signature over the stored nonce and issue a JWT.
-// The client signs buildUnlockMessage(nonce, unlock_key) when it includes the
-// unlock key (server locked), buildLoginMessage(nonce) otherwise. The nonce is
-// never echoed back — the message is reconstructed from the stored copy, so
-// the signature is the sole authenticator.
+// Step 2: verify the Ed25519 signature over the stored nonce and issue a
+// short-lived password-setup token (the mnemonic unlocks + authorizes setting a
+// password, but is not itself a session). The client signs
+// buildUnlockMessage(nonce, unlock_key) when it includes the unlock key (server
+// locked), buildLoginMessage(nonce) otherwise. The nonce is never echoed back —
+// the message is reconstructed from the stored copy, so the signature is the
+// sole authenticator.
 authRoutes.post('/auth/verify', async (c) => {
 	let body: { challenge_id?: string; signature?: string; unlock_key?: string };
 	try {
@@ -141,11 +182,154 @@ authRoutes.post('/auth/verify', async (c) => {
 		}
 	}
 
-	return issueAdminSession(c);
+	return issuePasswordSetupToken(c);
 });
 
-/** Shared tail of setup/verify: capture base URL, ensure superuser, mint JWT. */
-async function issueAdminSession(c: Context<Env>) {
+// --- Password auth (challenge-response; password never leaves the browser) ----
+
+// Login step 1: hand back a nonce to sign + the admin's salt so the client can
+// re-derive its password keypair. 409 until a password verifier is enrolled.
+authRoutes.post('/auth/password-challenge', async (c) => {
+	const masterKeyManager = c.get('masterKeyManager');
+	if (masterKeyManager.getState() !== 'unlocked') {
+		return err(c, 'LOCKED', 'Server is locked. Provide master key to unlock.', 401);
+	}
+	const verifier = await getAdminPasswordVerifier(c.get('db'));
+	if (!verifier) {
+		return err(c, 'PASSWORD_NOT_SET', 'No password set. Set one via the master key.', 409);
+	}
+	const { challengeId, nonce, expiresInSeconds } = c.get('authChallenges').issue();
+	return ok(c, {
+		challenge_id: challengeId,
+		nonce,
+		salt: verifier.salt,
+		expires_in: expiresInSeconds,
+	});
+});
+
+// Login step 2: verify the signature over buildPasswordLoginMessage(nonce)
+// against the stored verifier and mint a session JWT. Throttled globally.
+authRoutes.post('/auth/password-verify', async (c) => {
+	const masterKeyManager = c.get('masterKeyManager');
+	const db = c.get('db');
+	if (masterKeyManager.getState() !== 'unlocked') {
+		return err(c, 'LOCKED', 'Server is locked. Provide master key to unlock.', 401);
+	}
+
+	const now = Date.now();
+	const lockMs = loginLockRemainingMs(now);
+	if (lockMs > 0) {
+		return err(
+			c,
+			'TOO_MANY_ATTEMPTS',
+			`Too many attempts. Try again in ${Math.ceil(lockMs / 1000)}s.`,
+			429,
+		);
+	}
+
+	let body: { challenge_id?: string; signature?: string };
+	try {
+		body = await c.req.json();
+	} catch {
+		return err(c, 'INVALID_REQUEST', 'JSON body required', 400);
+	}
+	const { challenge_id, signature } = body;
+	if (
+		typeof challenge_id !== 'string' ||
+		challenge_id.length === 0 ||
+		typeof signature !== 'string' ||
+		!SIGNATURE_HEX.test(signature)
+	) {
+		return err(c, 'INVALID_REQUEST', 'challenge_id and signature are required', 400);
+	}
+
+	// Consume before verifying: one nonce absorbs a single guess.
+	const challenge = c.get('authChallenges').consume(challenge_id);
+	if (!challenge) {
+		return err(c, 'INVALID_CHALLENGE', 'Unknown, expired, or already used challenge', 401);
+	}
+
+	const verifier = await getAdminPasswordVerifier(db);
+	if (!verifier) {
+		return err(c, 'PASSWORD_NOT_SET', 'No password set. Set one via the master key.', 409);
+	}
+
+	const ok_ = await verifyPasswordSignature(
+		db,
+		buildPasswordLoginMessage(challenge.nonce),
+		signature,
+	);
+	if (!ok_) {
+		recordLoginFailure(now);
+		// Generic message: never reveal whether it was the user or the password.
+		return err(c, 'INVALID_CREDENTIALS', 'Incorrect password', 401);
+	}
+
+	resetLoginThrottle();
+	const token = await signAdminJwt(masterKeyManager, verifier.userId);
+	return ok(c, { token }, 200);
+});
+
+// Set or change the password verifier. Public path but self-authenticating: the
+// bearer must be a full session JWT (logged-in change) or a password-setup-scoped
+// JWT (initial-set / recovery). The password never arrives — only the client-
+// derived { salt, public_key } verifier plus a self-signature proving the client
+// holds the matching private key. Returns a fresh session so the caller is logged
+// in with the password they just set.
+authRoutes.post('/auth/password', async (c) => {
+	const masterKeyManager = c.get('masterKeyManager');
+	const db = c.get('db');
+	if (masterKeyManager.getState() !== 'unlocked') {
+		return err(c, 'LOCKED', 'Server is locked. Provide master key to unlock.', 401);
+	}
+
+	const header = c.req.header('Authorization');
+	if (!header?.startsWith('Bearer ')) {
+		return err(c, 'UNAUTHORIZED', 'Missing authorization header', 401);
+	}
+	const userId = await resolvePasswordMutationUserId(header.slice(7), db, masterKeyManager);
+	if (!userId) {
+		return err(c, 'UNAUTHORIZED', 'Invalid or expired token', 401);
+	}
+
+	let body: { salt?: string; public_key?: string; signature?: string };
+	try {
+		body = await c.req.json();
+	} catch {
+		return err(c, 'INVALID_REQUEST', 'JSON body required', 400);
+	}
+	const { salt, public_key, signature } = body;
+	if (
+		typeof salt !== 'string' ||
+		!SALT_HEX.test(salt) ||
+		typeof public_key !== 'string' ||
+		!KEY_HEX.test(public_key) ||
+		typeof signature !== 'string' ||
+		!SIGNATURE_HEX.test(signature)
+	) {
+		return err(c, 'INVALID_REQUEST', 'salt, public_key, and signature are required', 400);
+	}
+
+	// TOFU self-signature: proves the client holds the private key for the verifier
+	// it's enrolling. Password length/complexity is enforced client-side (the
+	// server never sees the password).
+	if (!verifyAuthSignature(public_key, buildPasswordSetupMessage(public_key, salt), signature)) {
+		return err(c, 'INVALID_SIGNATURE', 'Signature verification failed', 401);
+	}
+
+	await setAdminPasswordVerifier(db, userId, { salt, publicKeyHex: public_key });
+	resetLoginThrottle();
+	const token = await signAdminJwt(masterKeyManager, userId);
+	return ok(c, { token }, 200);
+});
+
+/**
+ * Shared tail of setup/verify: capture base URL, ensure the superuser exists,
+ * and mint a short-lived **password-setup token** (NOT a session). The mnemonic
+ * only unlocks — proving master-key ownership lets the client set a password via
+ * `POST /api/auth/password`, which is the only path that then mints a session.
+ */
+async function issuePasswordSetupToken(c: Context<Env>) {
 	const db = c.get('db');
 	const masterKeyManager = c.get('masterKeyManager');
 
@@ -176,7 +360,7 @@ async function issueAdminSession(c: Context<Env>) {
 		await addUserToDefaultTeam(db, userId);
 	}
 
-	const token = await signAdminJwt(masterKeyManager, userId);
+	const token = await signPasswordSetupToken(masterKeyManager, userId);
 	return ok(c, { token }, 200);
 }
 

--- a/packages/server/src/services/password.ts
+++ b/packages/server/src/services/password.ts
@@ -1,0 +1,71 @@
+import type { PGlite } from '@electric-sql/pglite';
+import { verifyAuthSignature } from '@hezo/shared';
+
+/**
+ * Admin password auth — verifier storage + signature checks.
+ *
+ * The password is never sent to the server and never stored. What the browser
+ * derives from `scrypt(password, salt)` is an Ed25519 keypair; the server keeps
+ * only the **verifier** (`password_salt` + `password_public_key`) and proves the
+ * caller by verifying a signature over a one-time challenge nonce. The crypto
+ * primitives live in `@hezo/shared` so browser enrollment and the server-side
+ * backfill derive an identical verifier.
+ */
+
+export interface PasswordVerifier {
+	userId: string;
+	salt: string;
+	publicKeyHex: string;
+}
+
+/** The superuser's password verifier, or `null` if none is enrolled yet. */
+export async function getAdminPasswordVerifier(db: PGlite): Promise<PasswordVerifier | null> {
+	const result = await db.query<{
+		id: string;
+		password_salt: string | null;
+		password_public_key: string | null;
+	}>(
+		`SELECT id, password_salt, password_public_key
+		 FROM users WHERE is_superuser = true ORDER BY created_at LIMIT 1`,
+	);
+	const row = result.rows[0];
+	if (!row || !row.password_salt || !row.password_public_key) return null;
+	return { userId: row.id, salt: row.password_salt, publicKeyHex: row.password_public_key };
+}
+
+/** True once the admin has enrolled a password verifier. */
+export async function adminPasswordIsSet(db: PGlite): Promise<boolean> {
+	const result = await db.query<{ count: number }>(
+		`SELECT COUNT(*)::int AS count FROM users
+		 WHERE is_superuser = true AND password_public_key IS NOT NULL`,
+	);
+	return (result.rows[0]?.count ?? 0) > 0;
+}
+
+/** Store (or replace) the admin's password verifier. */
+export async function setAdminPasswordVerifier(
+	db: PGlite,
+	userId: string,
+	verifier: { salt: string; publicKeyHex: string },
+): Promise<void> {
+	await db.query(
+		`UPDATE users SET password_salt = $1, password_public_key = $2, updated_at = now()
+		 WHERE id = $3`,
+		[verifier.salt, verifier.publicKeyHex, userId],
+	);
+}
+
+/**
+ * Verify an Ed25519 signature over `message` against the admin's stored password
+ * public key. Returns false (never throws) when no verifier is enrolled or the
+ * signature doesn't check out.
+ */
+export async function verifyPasswordSignature(
+	db: PGlite,
+	message: string,
+	signatureHex: string,
+): Promise<boolean> {
+	const verifier = await getAdminPasswordVerifier(db);
+	if (!verifier) return false;
+	return verifyAuthSignature(verifier.publicKeyHex, message, signatureHex);
+}

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -79,6 +79,7 @@ import {
 } from './services/image-registry';
 import { JobManager } from './services/job-manager';
 import { LogStreamBroker } from './services/log-stream-broker';
+import { adminPasswordIsSet } from './services/password';
 import { PricingService } from './services/pricing';
 import { SshAgentServer } from './services/ssh-agent';
 import { WebSocketManager } from './services/ws';
@@ -437,8 +438,18 @@ export function buildApp(
 
 	// `/api/status` carries master-key state + version. `/` is left to the SPA
 	// catch-all below (the compiled binary serves index.html there).
-	const statusHandler = (c: Context<Env>) =>
-		c.json({ masterKeyState: masterKeyManager.getState(), version: HEZO_VERSION });
+	const statusHandler = async (c: Context<Env>) => {
+		// passwordSet tells the gate whether to show the login screen (true) or the
+		// create-password flow (false). Only meaningful once unlocked; cheap enough
+		// to always compute.
+		const passwordSet =
+			masterKeyManager.getState() === 'unlocked' ? await adminPasswordIsSet(c.get('db')) : false;
+		return c.json({
+			masterKeyState: masterKeyManager.getState(),
+			passwordSet,
+			version: HEZO_VERSION,
+		});
+	};
 	app.get('/api/status', statusHandler);
 
 	// Agent manifest (public). Lists the onboarding tools first, then every MCP

--- a/packages/server/test/auth-middleware.test.ts
+++ b/packages/server/test/auth-middleware.test.ts
@@ -7,7 +7,6 @@ import type { MasterKeyManager } from '../src/crypto/master-key';
 import type { AuthInfo, Env } from '../src/lib/types';
 import {
 	canAuthAccessTeam,
-	loadAdminAuth,
 	safeCompareHex,
 	signAdminJwt,
 	signAgentJwt,
@@ -327,16 +326,28 @@ describe('authMiddleware (via HTTP)', () => {
 		expect(verify.status).not.toBe(401);
 	});
 
-	it('allows API requests without auth header (anonymous admin while unlocked)', async () => {
+	it('rejects API requests without an auth header (no anonymous access)', async () => {
 		const res = await app.request('/api/projects');
-		expect(res.status).toBe(200);
+		expect(res.status).toBe(401);
+		const body = await res.json();
+		expect(body.error.code).toBe('UNAUTHORIZED');
 	});
 
-	it('allows API requests with non-Bearer auth header (treated as anonymous)', async () => {
+	it('rejects API requests with a non-Bearer auth header', async () => {
 		const res = await app.request('/api/projects', {
 			headers: { Authorization: 'Basic abc123' },
 		});
-		expect(res.status).toBe(200);
+		expect(res.status).toBe(401);
+	});
+
+	it('rejects a password-setup-scoped token as a session', async () => {
+		const { signPasswordSetupToken } = await import('../src/middleware/auth');
+		const admin = await db.query<{ id: string }>(
+			'SELECT id FROM users WHERE is_superuser = true LIMIT 1',
+		);
+		const scoped = await signPasswordSetupToken(masterKeyManager, admin.rows[0].id);
+		const res = await app.request('/api/projects', { headers: authHeader(scoped) });
+		expect(res.status).toBe(401);
 	});
 
 	it('rejects API requests with invalid token', async () => {
@@ -379,28 +390,6 @@ describe('authMiddleware (via HTTP)', () => {
 		const res = await app.request('/');
 		expect(res.status).not.toBe(401);
 		expect(res.status).not.toBe(403);
-	});
-});
-
-describe('loadAdminAuth', () => {
-	it('returns Admin/superuser auth for the bootstrap admin', async () => {
-		const auth = await loadAdminAuth(db);
-		expect(auth).not.toBeNull();
-		expect(auth!.type).toBe(AuthType.Admin);
-		if (auth!.type === AuthType.Admin) {
-			expect(auth!.isSuperuser).toBe(true);
-			expect(typeof auth!.userId).toBe('string');
-		}
-	});
-
-	it('returns null when no superuser exists', async () => {
-		const { createTestDbWithMigrations } = await import('./helpers/db');
-		const freshDb = await createTestDbWithMigrations();
-		try {
-			expect(await loadAdminAuth(freshDb)).toBeNull();
-		} finally {
-			await safeClose(freshDb);
-		}
 	});
 });
 

--- a/packages/server/test/auth-password.test.ts
+++ b/packages/server/test/auth-password.test.ts
@@ -1,0 +1,168 @@
+import {
+	buildPasswordLoginMessage,
+	buildPasswordSetupMessage,
+	derivePasswordKeyPair,
+	generatePasswordSalt,
+	signAuthMessage,
+} from '@hezo/shared';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { resetLoginThrottle } from '../src/routes/auth';
+import { authHeader, loginViaAuthApi } from './helpers/app';
+import { createTestContext, destroyTestContext, type ServerTestContext } from './helpers/context';
+
+let ctx: ServerTestContext;
+
+beforeAll(async () => {
+	ctx = await createTestContext();
+});
+afterAll(() => destroyTestContext(ctx));
+beforeEach(() => resetLoginThrottle());
+
+/** Drive the real challenge-response password login; returns the raw Response. */
+async function passwordLogin(password: string): Promise<Response> {
+	const challengeRes = await ctx.app.request('/api/auth/password-challenge', { method: 'POST' });
+	if (challengeRes.status !== 200) return challengeRes;
+	const { data } = (await challengeRes.json()) as {
+		data: { challenge_id: string; nonce: string; salt: string };
+	};
+	const { privateKey } = await derivePasswordKeyPair(password, data.salt);
+	const signature = signAuthMessage(privateKey, buildPasswordLoginMessage(data.nonce));
+	return ctx.app.request('/api/auth/password-verify', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ challenge_id: data.challenge_id, signature }),
+	});
+}
+
+/** Build the { salt, public_key, signature } enrollment body for a new password. */
+async function enrollmentBody(password: string) {
+	const salt = generatePasswordSalt();
+	const { publicKeyHex, privateKey } = await derivePasswordKeyPair(password, salt);
+	const signature = signAuthMessage(privateKey, buildPasswordSetupMessage(publicKeyHex, salt));
+	return { salt, public_key: publicKeyHex, signature };
+}
+
+describe('password login (challenge-response)', () => {
+	it('logs in with the correct password and mints a working session', async () => {
+		const res = await passwordLogin(ctx.password);
+		expect(res.status).toBe(200);
+		const { data } = (await res.json()) as { data: { token: string } };
+		expect(typeof data.token).toBe('string');
+
+		// The minted session works on a real /api route.
+		const projects = await ctx.app.request('/api/projects', { headers: authHeader(data.token) });
+		expect(projects.status).toBe(200);
+	});
+
+	it('rejects a wrong password with a generic 401', async () => {
+		const res = await passwordLogin('not-the-password');
+		expect(res.status).toBe(401);
+		const body = (await res.json()) as { error: { code: string } };
+		expect(body.error.code).toBe('INVALID_CREDENTIALS');
+	});
+
+	it('never receives the password in the request body', async () => {
+		// The verify body carries only challenge_id + signature — no password field.
+		const challengeRes = await ctx.app.request('/api/auth/password-challenge', { method: 'POST' });
+		const { data } = (await challengeRes.json()) as {
+			data: { challenge_id: string; nonce: string; salt: string };
+		};
+		const { privateKey } = await derivePasswordKeyPair(ctx.password, data.salt);
+		const body = {
+			challenge_id: data.challenge_id,
+			signature: signAuthMessage(privateKey, buildPasswordLoginMessage(data.nonce)),
+		};
+		expect(JSON.stringify(body)).not.toContain(ctx.password);
+	});
+
+	it('throttles after repeated failures, then locks with 429', async () => {
+		for (let i = 0; i < 5; i++) {
+			const res = await passwordLogin('wrong-guess');
+			expect(res.status).toBe(401);
+		}
+		const locked = await passwordLogin(ctx.password); // correct, but locked out now
+		expect(locked.status).toBe(429);
+		const body = (await locked.json()) as { error: { code: string } };
+		expect(body.error.code).toBe('TOO_MANY_ATTEMPTS');
+	});
+});
+
+describe('password enrollment / change (POST /api/auth/password)', () => {
+	it('requires a session or password-setup token', async () => {
+		const res = await ctx.app.request('/api/auth/password', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(await enrollmentBody('whatever')),
+		});
+		expect(res.status).toBe(401);
+	});
+
+	it('changes the password when authenticated with a session, and rotates login', async () => {
+		const newPassword = 'a-brand-new-password';
+		const res = await ctx.app.request('/api/auth/password', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json', ...authHeader(ctx.token) },
+			body: JSON.stringify(await enrollmentBody(newPassword)),
+		});
+		expect(res.status).toBe(200);
+		const { data } = (await res.json()) as { data: { token: string } };
+		expect(typeof data.token).toBe('string');
+
+		// New password now logs in; the seeded one no longer does.
+		expect((await passwordLogin(newPassword)).status).toBe(200);
+		resetLoginThrottle();
+		expect((await passwordLogin(ctx.password)).status).toBe(401);
+
+		// Restore the seeded password so later tests/order are unaffected.
+		await ctx.app.request('/api/auth/password', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json', ...authHeader(ctx.token) },
+			body: JSON.stringify({
+				salt: ctx.passwordSalt,
+				public_key: (await derivePasswordKeyPair(ctx.password, ctx.passwordSalt)).publicKeyHex,
+				signature: await (async () => {
+					const { publicKeyHex, privateKey } = await derivePasswordKeyPair(
+						ctx.password,
+						ctx.passwordSalt,
+					);
+					return signAuthMessage(
+						privateKey,
+						buildPasswordSetupMessage(publicKeyHex, ctx.passwordSalt),
+					);
+				})(),
+			}),
+		});
+	});
+
+	it('lets the master key (mnemonic) reset a forgotten password without a session', async () => {
+		// The mnemonic flow returns a password-setup-scoped token (not a session)...
+		const verifyRes = await loginViaAuthApi(ctx.app, ctx.mnemonic);
+		expect(verifyRes.status).toBe(200);
+		const { data: verifyData } = (await verifyRes.json()) as { data: { token: string } };
+		const scopedToken = verifyData.token;
+
+		// ...which cannot act as a session on a general route...
+		const blocked = await ctx.app.request('/api/projects', { headers: authHeader(scopedToken) });
+		expect(blocked.status).toBe(401);
+
+		// ...but CAN set a new password, which then logs in.
+		const recovered = 'recovered-via-master-key';
+		const setRes = await ctx.app.request('/api/auth/password', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json', ...authHeader(scopedToken) },
+			body: JSON.stringify(await enrollmentBody(recovered)),
+		});
+		expect(setRes.status).toBe(200);
+		resetLoginThrottle();
+		expect((await passwordLogin(recovered)).status).toBe(200);
+	});
+});
+
+describe('GET /api/status passwordSet', () => {
+	it('reports passwordSet true once a verifier is enrolled', async () => {
+		const res = await ctx.app.request('/api/status');
+		const body = (await res.json()) as { masterKeyState: string; passwordSet: boolean };
+		expect(body.masterKeyState).toBe('unlocked');
+		expect(body.passwordSet).toBe(true);
+	});
+});

--- a/packages/server/test/auth-password.test.ts
+++ b/packages/server/test/auth-password.test.ts
@@ -76,11 +76,25 @@ describe('password login (challenge-response)', () => {
 	});
 
 	it('throttles after repeated failures, then locks with 429', async () => {
-		for (let i = 0; i < 5; i++) {
-			const res = await passwordLogin('wrong-guess');
-			expect(res.status).toBe(401);
+		// A well-formed but wrong signature fails verification without deriving a
+		// key — the throttle counts failed verifies, so we avoid scrypt here (which
+		// is intentionally slow and, under CI coverage instrumentation, would blow
+		// the test timeout across six logins).
+		const badSig = '00'.repeat(64);
+		async function badVerify(): Promise<Response> {
+			const ch = await ctx.app.request('/api/auth/password-challenge', { method: 'POST' });
+			const { data } = (await ch.json()) as { data: { challenge_id: string } };
+			return ctx.app.request('/api/auth/password-verify', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ challenge_id: data.challenge_id, signature: badSig }),
+			});
 		}
-		const locked = await passwordLogin(ctx.password); // correct, but locked out now
+		for (let i = 0; i < 5; i++) {
+			expect((await badVerify()).status).toBe(401);
+		}
+		// The throttle short-circuits before verifying, so the next attempt is 429.
+		const locked = await badVerify();
 		expect(locked.status).toBe(429);
 		const body = (await locked.json()) as { error: { code: string } };
 		expect(body.error.code).toBe('TOO_MANY_ATTEMPTS');
@@ -98,6 +112,14 @@ describe('password enrollment / change (POST /api/auth/password)', () => {
 	});
 
 	it('changes the password when authenticated with a session, and rotates login', async () => {
+		// Snapshot the seeded verifier so we can restore it by DB write afterward —
+		// re-enrolling would cost another slow scrypt derivation.
+		const orig = (
+			await ctx.db.query<{ password_salt: string; password_public_key: string }>(
+				`SELECT password_salt, password_public_key FROM users WHERE is_superuser = true LIMIT 1`,
+			)
+		).rows[0];
+
 		const newPassword = 'a-brand-new-password';
 		const res = await ctx.app.request('/api/auth/password', {
 			method: 'POST',
@@ -113,25 +135,11 @@ describe('password enrollment / change (POST /api/auth/password)', () => {
 		resetLoginThrottle();
 		expect((await passwordLogin(ctx.password)).status).toBe(401);
 
-		// Restore the seeded password so later tests/order are unaffected.
-		await ctx.app.request('/api/auth/password', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json', ...authHeader(ctx.token) },
-			body: JSON.stringify({
-				salt: ctx.passwordSalt,
-				public_key: (await derivePasswordKeyPair(ctx.password, ctx.passwordSalt)).publicKeyHex,
-				signature: await (async () => {
-					const { publicKeyHex, privateKey } = await derivePasswordKeyPair(
-						ctx.password,
-						ctx.passwordSalt,
-					);
-					return signAuthMessage(
-						privateKey,
-						buildPasswordSetupMessage(publicKeyHex, ctx.passwordSalt),
-					);
-				})(),
-			}),
-		});
+		// Restore the seeded verifier so later tests are unaffected (no scrypt).
+		await ctx.db.query(
+			`UPDATE users SET password_salt = $1, password_public_key = $2 WHERE is_superuser = true`,
+			[orig.password_salt, orig.password_public_key],
+		);
 	});
 
 	it('lets the master key (mnemonic) reset a forgotten password without a session', async () => {

--- a/packages/server/test/auth-routes.test.ts
+++ b/packages/server/test/auth-routes.test.ts
@@ -117,14 +117,14 @@ describe('setup, unlock, and restart flows', () => {
 		expect(rows.rows).toHaveLength(0);
 	});
 
-	it('enrolls, unlocks, and returns a working token', async () => {
+	it('enrolls, unlocks, and returns a password-setup token (not a session)', async () => {
 		const res = await postJson(app, '/api/auth/setup', setupBody());
 		expect(res.status).toBe(200);
 		const { token } = (await res.json()).data;
 
-		const auth = await verifyToken(token, db, masterKeyManager);
-		expect(auth).not.toBeNull();
-		expect(auth?.type).toBe('admin');
+		// The mnemonic only unlocks — setup mints a password-setup-scoped token, not
+		// a session, so verifyToken rejects it as a general credential.
+		expect(await verifyToken(token, db, masterKeyManager)).toBeNull();
 
 		const status = await app.request('/api/status');
 		expect((await status.json()).masterKeyState).toBe('unlocked');
@@ -230,29 +230,24 @@ describe('login flow on an enrolled, unlocked server', () => {
 		expect(await errorCode(res)).toBe('ALREADY_SET');
 	});
 
-	it('logs in via challenge + signature, twice, as the same user', async () => {
+	it('mnemonic verify returns a password-setup token (not a session), repeatably', async () => {
 		const res1 = await loginViaAuthApi(app, mnemonic);
 		expect(res1.status).toBe(200);
 		const token1 = (await res1.json()).data.token;
 
 		const res2 = await loginViaAuthApi(app, mnemonic);
 		expect(res2.status).toBe(200);
-		const token2 = (await res2.json()).data.token;
 
-		const auth1 = await verifyToken(token1, db, masterKeyManager);
-		const auth2 = await verifyToken(token2, db, masterKeyManager);
-		expect(auth1?.type).toBe('admin');
-		expect(auth2?.type).toBe('admin');
-		if (auth1?.type === 'admin' && auth2?.type === 'admin') {
-			expect(auth1.userId).toBe(auth2.userId);
-		}
+		// The mnemonic only unlocks: its token is password-setup-scoped, not a
+		// session, so verifyToken rejects it on general routes.
+		expect(await verifyToken(token1, db, masterKeyManager)).toBeNull();
 	});
 
-	it('the token grants access to protected endpoints', async () => {
+	it('the mnemonic token cannot access protected endpoints (only password setup)', async () => {
 		const res = await loginViaAuthApi(app, mnemonic);
 		const { token } = (await res.json()).data;
 		const projectsRes = await app.request('/api/projects', { headers: authHeader(token) });
-		expect(projectsRes.status).toBe(200);
+		expect(projectsRes.status).toBe(401);
 	});
 
 	it('rejects a replayed challenge', async () => {

--- a/packages/server/test/helpers/app.ts
+++ b/packages/server/test/helpers/app.ts
@@ -8,8 +8,10 @@ import {
 	buildUnlockMessage,
 	CAPTAIN_AGENT_SLUG,
 	deriveAuthKeyPair,
+	derivePasswordKeyPair,
 	deriveUnlockKey,
 	generateMnemonic,
+	generatePasswordSalt,
 	signAuthMessage,
 } from '@hezo/shared';
 import type { Hono } from 'hono';
@@ -119,6 +121,17 @@ export async function createTestApp(opts: { webUrl?: string } = {}) {
 	const userResult = await db.query<{ id: string }>(
 		"INSERT INTO users (display_name, is_superuser) VALUES ('Test Admin', true) RETURNING id",
 	);
+	// Enroll a password verifier so `/api/status` reports passwordSet:true (the web
+	// gate lands on the app rather than the create-password step). The plaintext is
+	// exposed for auth-flow tests that drive the real challenge/verify login.
+	const password = 'test-password';
+	const passwordSalt = generatePasswordSalt();
+	const passwordKeys = await derivePasswordKeyPair(password, passwordSalt);
+	await db.query('UPDATE users SET password_salt = $1, password_public_key = $2 WHERE id = $3', [
+		passwordSalt,
+		passwordKeys.publicKeyHex,
+		userResult.rows[0].id,
+	]);
 	const token = await signAdminJwt(masterKeyManager, userResult.rows[0].id);
 
 	// Seed the HQ team (CEO + Coach + HQ project). Coordination flows (intake,
@@ -133,7 +146,18 @@ export async function createTestApp(opts: { webUrl?: string } = {}) {
 		containerLogStreamer,
 	});
 
-	return { app, db, token, mnemonic, unlockKeyHex, authKeys, masterKeyManager, dataDir };
+	return {
+		app,
+		db,
+		token,
+		mnemonic,
+		unlockKeyHex,
+		authKeys,
+		masterKeyManager,
+		dataDir,
+		password,
+		passwordSalt,
+	};
 }
 
 /**

--- a/packages/server/test/helpers/context.ts
+++ b/packages/server/test/helpers/context.ts
@@ -18,11 +18,24 @@ export interface ServerTestContext {
 	unlockKeyHex: string;
 	masterKeyManager: MasterKeyManager;
 	dataDir: string;
+	/** The seeded admin's plaintext password (verifier enrolled in createTestApp). */
+	password: string;
+	/** Salt for the seeded admin's password verifier. */
+	passwordSalt: string;
 }
 
 export async function createTestContext(): Promise<ServerTestContext> {
-	const { app, db, token, mnemonic, unlockKeyHex, masterKeyManager, dataDir } =
-		await createTestApp();
+	const {
+		app,
+		db,
+		token,
+		mnemonic,
+		unlockKeyHex,
+		masterKeyManager,
+		dataDir,
+		password,
+		passwordSalt,
+	} = await createTestApp();
 
 	const server = createServer(async (req, res) => {
 		const url = `http://localhost${req.url}`;
@@ -64,6 +77,8 @@ export async function createTestContext(): Promise<ServerTestContext> {
 		unlockKeyHex,
 		masterKeyManager,
 		dataDir,
+		password,
+		passwordSalt,
 	};
 }
 

--- a/packages/server/test/helpers/db.ts
+++ b/packages/server/test/helpers/db.ts
@@ -2,6 +2,8 @@ import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { PGlite } from '@electric-sql/pglite';
+import { type Migration, runMigrations } from '../../src/db/migrate';
+import { codeMigrations } from '../../src/db/migrations/code';
 import { BASE_SCHEMA } from '../../src/db/schema';
 
 /** Creates a fresh in-memory PGlite instance with base tables for testing. */
@@ -11,19 +13,9 @@ export async function createTestDb(): Promise<PGlite> {
 	return db;
 }
 
-/** Creates a test DB with full migrations applied. */
+/** Creates a test DB with full migrations applied (SQL + code, in one ordered sequence). */
 export async function createTestDbWithMigrations(): Promise<PGlite> {
 	const db = new PGlite();
-
-	// Ensure _migrations table exists (uses IF NOT EXISTS, safe to run before migration)
-	await db.exec(`
-    CREATE TABLE IF NOT EXISTS _migrations (
-      id          SERIAL PRIMARY KEY,
-      filename    TEXT NOT NULL UNIQUE,
-      applied_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
-      checksum    TEXT NOT NULL
-    );
-  `);
 
 	// Load migration SQL directly from filesystem. fileURLToPath() (not
 	// .pathname) is required because Vite rewrites import.meta.url to a
@@ -48,26 +40,26 @@ export async function createTestDbWithMigrations(): Promise<PGlite> {
 		? process.env.HEZO_MIGRATIONS_DIR
 		: join(currentDir, '..', '..', 'migrations');
 
+	// Merge SQL files with code migrations into one ordered set, then apply through
+	// the real runMigrations so SQL + code steps run in the same sorted sequence
+	// (code migrations like 013 add columns SQL alone won't) with proper tracking.
+	const migrations: Record<string, Migration> = {};
 	try {
-		const files = readdirSync(migrationsDir)
+		for (const file of readdirSync(migrationsDir)
 			.filter((f: string) => f.endsWith('.sql'))
-			.sort();
-
-		for (const file of files) {
-			let sql = readFileSync(join(migrationsDir, file), 'utf-8');
+			.sort()) {
 			// PGlite loads pgcrypto built-in; strip only that.
-			sql = sql.replace(/CREATE EXTENSION IF NOT EXISTS "pgcrypto";/g, '');
-			try {
-				await db.exec(sql);
-			} catch (e) {
-				console.error(`Migration ${file} failed:`, e);
-				throw e;
-			}
+			migrations[file] = readFileSync(join(migrationsDir, file), 'utf-8').replace(
+				/CREATE EXTENSION IF NOT EXISTS "pgcrypto";/g,
+				'',
+			);
 		}
 	} catch (e) {
 		console.error('Migration loading failed:', e);
 		throw e;
 	}
+	Object.assign(migrations, codeMigrations);
 
+	await runMigrations(db, migrations);
 	return db;
 }

--- a/packages/server/test/migrate-013-user-password.test.ts
+++ b/packages/server/test/migrate-013-user-password.test.ts
@@ -1,0 +1,88 @@
+import {
+	buildPasswordLoginMessage,
+	derivePasswordKeyPair,
+	signAuthMessage,
+	verifyAuthSignature,
+} from '@hezo/shared';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createDataPreservationHarness, type DataPreservationHarness } from './helpers/migrate';
+
+// Code migration — keyed by its registry name (no .sql extension).
+const TARGET = '013_user_password';
+
+describe('013_user_password migration', () => {
+	let h: DataPreservationHarness;
+	let adminId: string;
+	let plainUserId: string;
+
+	beforeAll(async () => {
+		h = await createDataPreservationHarness();
+		await h.applyUpToExclusive(TARGET); // schema before 013
+
+		const admin = await h.db.query<{ id: string }>(
+			`INSERT INTO users (display_name, is_superuser) VALUES ('Admin', true) RETURNING id`,
+		);
+		adminId = admin.rows[0].id;
+		const plain = await h.db.query<{ id: string }>(
+			`INSERT INTO users (display_name, is_superuser) VALUES ('Board User', false) RETURNING id`,
+		);
+		plainUserId = plain.rows[0].id;
+
+		await h.applyTarget(TARGET);
+	});
+	afterAll(() => h.close());
+
+	it('adds the verifier columns', async () => {
+		const cols = await h.db.query<{ column_name: string }>(
+			`SELECT column_name FROM information_schema.columns
+			 WHERE table_name = 'users' AND column_name IN ('password_salt', 'password_public_key')`,
+		);
+		expect(cols.rows.map((r) => r.column_name).sort()).toEqual([
+			'password_public_key',
+			'password_salt',
+		]);
+	});
+
+	it('preserves the pre-existing admin row', async () => {
+		const kept = await h.db.query<{ display_name: string }>(
+			`SELECT display_name FROM users WHERE id = $1`,
+			[adminId],
+		);
+		expect(kept.rows).toHaveLength(1);
+		expect(kept.rows[0].display_name).toBe('Admin');
+	});
+
+	it('backfills the admin with the default password "password"', async () => {
+		const row = await h.db.query<{ password_salt: string; password_public_key: string }>(
+			`SELECT password_salt, password_public_key FROM users WHERE id = $1`,
+			[adminId],
+		);
+		const { password_salt, password_public_key } = row.rows[0];
+		expect(password_salt).toMatch(/^[0-9a-f]{32}$/);
+		expect(password_public_key).toMatch(/^[0-9a-f]{64}$/);
+
+		// The stored verifier must validate a login signature produced from the
+		// default password + backfilled salt — exactly what the browser would send.
+		const { publicKeyHex, privateKey } = await derivePasswordKeyPair('password', password_salt);
+		expect(publicKeyHex).toBe(password_public_key);
+		const sig = signAuthMessage(privateKey, buildPasswordLoginMessage('cafef00d'));
+		expect(
+			verifyAuthSignature(password_public_key, buildPasswordLoginMessage('cafef00d'), sig),
+		).toBe(true);
+
+		// A wrong password would NOT validate against the stored verifier.
+		const wrong = await derivePasswordKeyPair('hunter2', password_salt);
+		const wrongSig = signAuthMessage(wrong.privateKey, buildPasswordLoginMessage('cafef00d'));
+		expect(
+			verifyAuthSignature(password_public_key, buildPasswordLoginMessage('cafef00d'), wrongSig),
+		).toBe(false);
+	});
+
+	it('leaves a non-superuser without a verifier', async () => {
+		const row = await h.db.query<{ password_public_key: string | null }>(
+			`SELECT password_public_key FROM users WHERE id = $1`,
+			[plainUserId],
+		);
+		expect(row.rows[0].password_public_key).toBeNull();
+	});
+});

--- a/packages/server/test/startup-spa-serving.test.ts
+++ b/packages/server/test/startup-spa-serving.test.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { authHeader } from './helpers/app';
 import { createTestContext, destroyTestContext, type ServerTestContext } from './helpers/context';
 
 // Exercises the SPA-serving catch-all in buildApp() (startup.ts). The compiled
@@ -27,7 +28,11 @@ describe('buildApp SPA serving (filesystem fallback)', () => {
 	afterAll(() => destroyTestContext(ctx));
 
 	it('returns 404 for an unknown /api/ path (not SPA fallback)', async () => {
-		const res = await ctx.app.request('/api/this-route-does-not-exist');
+		// Authenticated: an unknown /api route must 404 (not fall through to the SPA
+		// index.html). Without a token it would 401 at the auth middleware first.
+		const res = await ctx.app.request('/api/this-route-does-not-exist', {
+			headers: authHeader(ctx.token),
+		});
 		expect(res.status).toBe(404);
 		expect(await res.text()).toBe('Not found');
 	});

--- a/packages/shared/src/crypto/auth.ts
+++ b/packages/shared/src/crypto/auth.ts
@@ -1,13 +1,18 @@
 import { ed25519 } from '@noble/curves/ed25519';
 import { hkdf } from '@noble/hashes/hkdf';
+import { scryptAsync } from '@noble/hashes/scrypt';
 import { sha256 } from '@noble/hashes/sha2';
-import { bytesToHex, hexToBytes, utf8ToBytes } from '@noble/hashes/utils';
+import { bytesToHex, hexToBytes, randomBytes, utf8ToBytes } from '@noble/hashes/utils';
 import { mnemonicToSeedSync } from '@scure/bip39';
 import { normalizeMnemonic } from './mnemonic.js';
 
 const HKDF_INFO = utf8ToBytes('hezo');
 const UNLOCK_KEY_SALT = utf8ToBytes('hezo-unlock-key-v1');
 const AUTH_KEY_SALT = utf8ToBytes('hezo-auth-key-v1');
+
+// scrypt cost for password-derived keys. Memory-hard so a leaked verifier is
+// expensive to brute-force offline; tuned to stay ~sub-second in the browser.
+const PASSWORD_SCRYPT = { N: 2 ** 15, r: 8, p: 1, dkLen: 32 } as const;
 
 export interface AuthKeyPair {
 	/** 32-byte Ed25519 public key, lowercase hex (64 chars). Safe to share. */
@@ -72,4 +77,40 @@ export function buildLoginMessage(nonceHex: string): string {
 
 export function buildUnlockMessage(nonceHex: string, unlockKeyHex: string): string {
 	return `hezo-auth-v1:unlock:${nonceHex}:${unlockKeyHex}`;
+}
+
+// --- Password auth ------------------------------------------------------------
+//
+// A password is a low-entropy secret, so it is NEVER sent to the server. It is
+// treated exactly like the mnemonic: a seed for an Ed25519 keypair derived via a
+// memory-hard KDF (scrypt) with a per-admin salt. The server stores only the
+// public key + salt (the "verifier") and authenticates by verifying a signature
+// over a one-time server nonce. Only public keys, salts, and one-time signatures
+// ever cross the wire — never the password or its derived private key.
+
+/** Random 16-byte salt, lowercase hex (32 chars). Not secret; sent to the client. */
+export function generatePasswordSalt(): string {
+	return bytesToHex(randomBytes(16));
+}
+
+/**
+ * Deterministic password + salt -> Ed25519 keypair via scrypt. Runs identically
+ * in the browser and in Node/Bun (pure JS), so the verifier the client enrolls
+ * matches what the server-side backfill computes. Async because scrypt is
+ * intentionally slow — never block a UI thread or Bun's event loop on it.
+ */
+export async function derivePasswordKeyPair(
+	password: string,
+	saltHex: string,
+): Promise<AuthKeyPair> {
+	const seed = await scryptAsync(utf8ToBytes(password), hexToBytes(saltHex), PASSWORD_SCRYPT);
+	return { publicKeyHex: bytesToHex(ed25519.getPublicKey(seed)), privateKey: seed };
+}
+
+export function buildPasswordLoginMessage(nonceHex: string): string {
+	return `hezo-auth-v1:password-login:${nonceHex}`;
+}
+
+export function buildPasswordSetupMessage(publicKeyHex: string, saltHex: string): string {
+	return `hezo-auth-v1:password-setup:${publicKeyHex}:${saltHex}`;
 }

--- a/packages/shared/test/crypto-auth.test.ts
+++ b/packages/shared/test/crypto-auth.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import {
 	buildLoginMessage,
+	buildPasswordLoginMessage,
+	buildPasswordSetupMessage,
 	buildSetupMessage,
 	buildUnlockMessage,
 	deriveAuthKeyPair,
+	derivePasswordKeyPair,
 	deriveUnlockKey,
+	generatePasswordSalt,
 	signAuthMessage,
 	verifyAuthSignature,
 } from '../src/crypto/auth';
@@ -78,5 +82,57 @@ describe('canonical signed payloads', () => {
 		expect(buildSetupMessage('PUB', 'UNLOCK')).toBe('hezo-auth-v1:setup:PUB:UNLOCK');
 		expect(buildLoginMessage('NONCE')).toBe('hezo-auth-v1:login:NONCE');
 		expect(buildUnlockMessage('NONCE', 'UNLOCK')).toBe('hezo-auth-v1:unlock:NONCE:UNLOCK');
+		expect(buildPasswordLoginMessage('NONCE')).toBe('hezo-auth-v1:password-login:NONCE');
+		expect(buildPasswordSetupMessage('PUB', 'SALT')).toBe('hezo-auth-v1:password-setup:PUB:SALT');
+	});
+});
+
+describe('generatePasswordSalt', () => {
+	it('returns 32-char lowercase hex', () => {
+		expect(generatePasswordSalt()).toMatch(/^[0-9a-f]{32}$/);
+	});
+
+	it('is random (distinct across calls)', () => {
+		expect(generatePasswordSalt()).not.toBe(generatePasswordSalt());
+	});
+});
+
+describe('derivePasswordKeyPair', () => {
+	const SALT = '00112233445566778899aabbccddeeff';
+
+	it('is deterministic for the same password + salt', async () => {
+		const a = await derivePasswordKeyPair('correct horse battery staple', SALT);
+		const b = await derivePasswordKeyPair('correct horse battery staple', SALT);
+		expect(a.privateKey).toEqual(b.privateKey);
+		expect(a.privateKey).toHaveLength(32);
+		expect(a.publicKeyHex).toBe(b.publicKeyHex);
+		expect(a.publicKeyHex).toMatch(/^[0-9a-f]{64}$/);
+	});
+
+	it('differs for a different password', async () => {
+		const a = await derivePasswordKeyPair('password', SALT);
+		const b = await derivePasswordKeyPair('Password', SALT);
+		expect(a.publicKeyHex).not.toBe(b.publicKeyHex);
+	});
+
+	it('differs for a different salt (per-admin separation)', async () => {
+		const a = await derivePasswordKeyPair('password', SALT);
+		const b = await derivePasswordKeyPair('password', 'ffffffffffffffffffffffffffffffff');
+		expect(a.publicKeyHex).not.toBe(b.publicKeyHex);
+	});
+
+	it('produces a keypair whose signatures verify (login round-trip)', async () => {
+		const salt = generatePasswordSalt();
+		const { privateKey, publicKeyHex } = await derivePasswordKeyPair('hunter2!!', salt);
+		const sig = signAuthMessage(privateKey, buildPasswordLoginMessage('deadbeef'));
+		expect(verifyAuthSignature(publicKeyHex, buildPasswordLoginMessage('deadbeef'), sig)).toBe(
+			true,
+		);
+		// A wrong password derives a different key, so its signature fails.
+		const wrong = await derivePasswordKeyPair('hunter3!!', salt);
+		const wrongSig = signAuthMessage(wrong.privateKey, buildPasswordLoginMessage('deadbeef'));
+		expect(verifyAuthSignature(publicKeyHex, buildPasswordLoginMessage('deadbeef'), wrongSig)).toBe(
+			false,
+		);
 	});
 });

--- a/packages/web/src/components/master-key-gate.tsx
+++ b/packages/web/src/components/master-key-gate.tsx
@@ -4,34 +4,79 @@ import {
 	normalizeMnemonic,
 	validateMnemonic,
 } from '@hezo/shared';
-import * as Dialog from '@radix-ui/react-dialog';
-import { KeyRound, Loader2, ShieldCheck } from 'lucide-react';
+import { KeyRound, Loader2, Lock, ShieldCheck } from 'lucide-react';
+import type { ReactNode } from 'react';
 import { useState } from 'react';
 import { authenticateWithMnemonic } from '../lib/auth';
 import { copyToClipboard } from '../lib/clipboard';
 import { queryClient } from '../lib/query-client';
 import { queryKeys } from '../lib/query-keys';
 import { Button } from './ui/button';
-import { dialogContentClassName } from './ui/dialog';
 import { Logo } from './ui/logo';
+
+const REVEAL_STRIPS = 11;
+
+/**
+ * Full-viewport "pre-active vault" chrome. Always dark (via `.vault-surface`),
+ * visually distinct from the running app so it reads as "the instance is not
+ * live yet". Used by the master-key setup + unlock + recovery screens.
+ */
+export function VaultShell({ children }: { children: ReactNode }) {
+	return (
+		<div className="vault-surface min-h-screen flex flex-col items-center justify-center bg-bg px-4 py-10">
+			<div className="w-full max-w-md">{children}</div>
+		</div>
+	);
+}
+
+/** The vertical-blind reveal overlay; calls `onDone` after the last strip collapses. */
+function UnlockReveal({ onDone }: { onDone: () => void }) {
+	return (
+		<div className="vault-reveal" aria-hidden="true">
+			{Array.from({ length: REVEAL_STRIPS }, (_, i) => (
+				<div
+					// biome-ignore lint/suspicious/noArrayIndexKey: fixed-length decorative strip list
+					key={i}
+					className="vault-reveal-strip"
+					style={{ '--i': i } as React.CSSProperties}
+					onAnimationEnd={i === REVEAL_STRIPS - 1 ? onDone : undefined}
+				/>
+			))}
+		</div>
+	);
+}
 
 interface MasterKeyFormProps {
 	state: MasterKeyState;
 	/** When true, omit the dialog header (caller renders its own page-level heading). */
 	embedded?: boolean;
+	/**
+	 * When provided, called after the master key is accepted instead of the default
+	 * unlock reveal + status refetch. Used by the password-recovery flow, where the
+	 * mnemonic only fetches a password-setup token and the caller advances to the
+	 * create-password step itself.
+	 */
+	onAuthenticated?: () => void;
 }
 
-export function MasterKeyForm({ state, embedded }: MasterKeyFormProps) {
+export function MasterKeyForm({ state, embedded, onAuthenticated }: MasterKeyFormProps) {
 	const [key, setKey] = useState('');
 	const [generatedKey, setGeneratedKey] = useState<string | null>(null);
 	const [error, setError] = useState('');
 	const [loading, setLoading] = useState(false);
 	const [copied, setCopied] = useState(false);
+	const [revealing, setRevealing] = useState(false);
 
 	const isUnset = state === 'unset';
 
 	function handleGenerate() {
 		setGeneratedKey(generateMnemonic());
+	}
+
+	function finishTransition() {
+		// Refetch status (now unlocked) + the session probe so the gate advances.
+		queryClient.invalidateQueries({ queryKey: queryKeys.status() });
+		queryClient.invalidateQueries({ queryKey: queryKeys.me() });
 	}
 
 	async function handleSubmit(e: React.FormEvent) {
@@ -46,11 +91,19 @@ export function MasterKeyForm({ state, embedded }: MasterKeyFormProps) {
 		setLoading(true);
 		try {
 			await authenticateWithMnemonic(phrase, state);
-			queryClient.invalidateQueries({ queryKey: queryKeys.status() });
+			if (onAuthenticated) {
+				onAuthenticated();
+				return;
+			}
+			// Play the unlock reveal; the last strip triggers the gate transition.
+			if (matchMedia('(prefers-reduced-motion: reduce)').matches) {
+				finishTransition();
+			} else {
+				setRevealing(true);
+			}
 		} catch (err: unknown) {
 			const apiErr = err as { message?: string };
 			setError(apiErr.message || 'Invalid master key');
-		} finally {
 			setLoading(false);
 		}
 	}
@@ -64,24 +117,21 @@ export function MasterKeyForm({ state, embedded }: MasterKeyFormProps) {
 
 	return (
 		<>
+			{revealing && <UnlockReveal onDone={finishTransition} />}
 			{!embedded && (
 				<div className="flex flex-col items-center gap-2 mb-6">
 					<Logo size="lg" wordmark className="mb-1" />
-					<div className="p-3 rounded-full bg-surface-2 border border-border">
-						{isUnset ? (
-							<KeyRound className="w-6 h-6 text-text-2" />
-						) : (
-							<ShieldCheck className="w-6 h-6 text-text-2" />
-						)}
+					<div className="p-3 rounded-full bg-surface-2 border border-border-strong text-accent-soft-fg">
+						{isUnset ? <KeyRound className="w-6 h-6" /> : <ShieldCheck className="w-6 h-6" />}
 					</div>
-					<Dialog.Title className="text-lg font-semibold text-text-1">
-						{isUnset ? 'Set Master Key' : 'Unlock Hezo'}
-					</Dialog.Title>
-					<Dialog.Description className="text-sm text-text-2 text-center">
+					<h2 className="text-lg font-semibold text-text-1">
+						{isUnset ? 'Create your master key' : 'Unlock Hezo'}
+					</h2>
+					<p className="text-sm text-text-2 text-center">
 						{isUnset
-							? "Your master key is these 12 words. Save them somewhere safe — you'll need them to unlock Hezo on restart."
-							: 'Enter your 12-word master key to unlock the server.'}
-					</Dialog.Description>
+							? 'This 12-word key unlocks the instance and encrypts everything in it.'
+							: 'The instance is locked. Enter your 12-word master key to bring it back online.'}
+					</p>
 				</div>
 			)}
 
@@ -89,7 +139,7 @@ export function MasterKeyForm({ state, embedded }: MasterKeyFormProps) {
 				{isUnset && !generatedKey && (
 					<Button type="button" variant="secondary" onClick={handleGenerate}>
 						<KeyRound className="w-4 h-4" />
-						Generate Key
+						Generate master key
 					</Button>
 				)}
 
@@ -104,9 +154,9 @@ export function MasterKeyForm({ state, embedded }: MasterKeyFormProps) {
 									// biome-ignore lint/suspicious/noArrayIndexKey: fixed-length, never-reordered list with possibly-repeating words; position is the stable identity
 									key={index}
 									data-testid="mnemonic-word"
-									className="flex items-center gap-1.5 rounded-md border border-border bg-surface px-2 py-1.5"
+									className="flex items-center gap-1.5 rounded-md border border-border bg-surface-2 px-2 py-1.5"
 								>
-									<span className="w-4 text-right text-[10px] tabular-nums text-text-2 select-none">
+									<span className="w-4 text-right text-[10px] tabular-nums text-text-3 select-none">
 										{index + 1}
 									</span>
 									<span className="font-mono text-xs text-text-1">{word}</span>
@@ -116,6 +166,16 @@ export function MasterKeyForm({ state, embedded }: MasterKeyFormProps) {
 						<Button type="button" variant="ghost" size="sm" onClick={handleCopy}>
 							{copied ? 'Copied!' : 'Copy to clipboard'}
 						</Button>
+						<div className="flex gap-2.5 items-start rounded-md border border-warning-soft-fg/25 bg-warning-soft px-3 py-2.5 text-[12.5px] leading-relaxed text-warning-soft-fg">
+							<Lock className="w-4 h-4 shrink-0 mt-0.5" />
+							<span>
+								<span className="font-semibold text-text-1">
+									Store these words somewhere safe now.
+								</span>{' '}
+								They're the only way to unlock the instance after a restart and to reset a forgotten
+								password. Hezo can't recover them for you.
+							</span>
+						</div>
 					</div>
 				)}
 
@@ -133,7 +193,7 @@ export function MasterKeyForm({ state, embedded }: MasterKeyFormProps) {
 							autoComplete="off"
 							autoCapitalize="none"
 							spellCheck={false}
-							className="w-full resize-none rounded-md border border-border bg-surface p-2.5 font-mono text-xs text-text-1 placeholder:text-text-2 focus:outline-none focus:ring-2 focus:ring-info-soft-fg"
+							className="w-full resize-none rounded-md border border-border-strong bg-surface-2 p-2.5 font-mono text-xs text-text-1 placeholder:text-text-3 focus:outline-none focus:ring-2 focus:ring-accent"
 						/>
 					</div>
 				)}
@@ -142,7 +202,7 @@ export function MasterKeyForm({ state, embedded }: MasterKeyFormProps) {
 
 				<Button type="submit" disabled={loading || (isUnset ? !generatedKey : !key.trim())}>
 					{loading && <Loader2 className="w-4 h-4 animate-spin" />}
-					{isUnset ? 'Set Key & Continue' : 'Unlock'}
+					{isUnset ? 'Set key & continue' : 'Unlock'}
 				</Button>
 			</form>
 		</>
@@ -153,16 +213,16 @@ interface MasterKeyGateProps {
 	state: MasterKeyState;
 }
 
-/** Modal wrapper kept for callers that still want the centered overlay variant. */
+/** Full-page vault screen: master-key setup (unset) or unlock-on-restart (locked). */
 export function MasterKeyGate({ state }: MasterKeyGateProps) {
 	return (
-		<Dialog.Root open>
-			<Dialog.Portal>
-				<Dialog.Overlay className="fixed inset-0 bg-[var(--overlay)] backdrop-blur-sm" />
-				<Dialog.Content className={dialogContentClassName.md}>
-					<MasterKeyForm state={state} />
-				</Dialog.Content>
-			</Dialog.Portal>
-		</Dialog.Root>
+		<VaultShell>
+			<div
+				data-testid={state === 'unset' ? 'master-key-setup' : 'master-key-unlock'}
+				className="rounded-2xl border border-border-strong bg-surface p-6 sm:p-8 shadow-[var(--elev-lg)]"
+			>
+				<MasterKeyForm state={state} />
+			</div>
+		</VaultShell>
 	);
 }

--- a/packages/web/src/components/password-login.tsx
+++ b/packages/web/src/components/password-login.tsx
@@ -1,0 +1,128 @@
+import { Loader2, LogIn } from 'lucide-react';
+import { useState } from 'react';
+import type { ApiError } from '../lib/api';
+import { loginWithPassword } from '../lib/auth';
+import { queryClient } from '../lib/query-client';
+import { queryKeys } from '../lib/query-keys';
+import { MasterKeyForm, VaultShell } from './master-key-gate';
+import { PasswordSetForm } from './password-set-form';
+import { Button } from './ui/button';
+import { Logo } from './ui/logo';
+
+type Mode = 'login' | 'master-key' | 'reset';
+
+function advance() {
+	queryClient.invalidateQueries({ queryKey: queryKeys.status() });
+	queryClient.invalidateQueries({ queryKey: queryKeys.me() });
+}
+
+/**
+ * Password sign-in for an already-active instance (normal app styling). A
+ * "Forgot password?" path swaps to master-key entry (the recovery credential),
+ * then a set-new-password step. The password never leaves the browser.
+ */
+export function PasswordLogin() {
+	const [mode, setMode] = useState<Mode>('login');
+	const [password, setPassword] = useState('');
+	const [error, setError] = useState('');
+	const [loading, setLoading] = useState(false);
+
+	async function handleLogin(e: React.FormEvent) {
+		e.preventDefault();
+		if (!password || loading) return;
+		setError('');
+		setLoading(true);
+		try {
+			await loginWithPassword(password);
+			advance();
+		} catch (err) {
+			setError((err as ApiError).message || 'Incorrect password');
+			setLoading(false);
+		}
+	}
+
+	if (mode === 'master-key') {
+		return (
+			<VaultShell>
+				<div
+					data-testid="forgot-password-master-key"
+					className="rounded-2xl border border-border-strong bg-surface p-6 sm:p-8 shadow-[var(--elev-lg)]"
+				>
+					<div className="mb-5 text-center">
+						<h2 className="text-lg font-semibold text-text-1">Reset with your master key</h2>
+						<p className="mt-1 text-sm text-text-2">
+							Enter your 12-word master key to set a new admin password.
+						</p>
+					</div>
+					<MasterKeyForm state="unlocked" embedded onAuthenticated={() => setMode('reset')} />
+					<button
+						type="button"
+						onClick={() => setMode('login')}
+						className="mt-4 w-full text-center text-[13px] text-text-2 hover:text-text-1"
+					>
+						Back to sign in
+					</button>
+				</div>
+			</VaultShell>
+		);
+	}
+
+	if (mode === 'reset') {
+		return (
+			<div className="min-h-screen flex items-center justify-center bg-surface px-4">
+				<div
+					data-testid="reset-password"
+					className="w-full max-w-sm rounded-lg border border-border bg-surface p-6 sm:p-8 shadow-sm"
+				>
+					<div className="mb-5 text-center">
+						<h2 className="text-lg font-semibold text-text-1">Set a new password</h2>
+						<p className="mt-1 text-sm text-text-2">You'll use this to sign in from now on.</p>
+					</div>
+					<PasswordSetForm submitLabel="Set password & sign in" onSuccess={advance} />
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="min-h-screen flex items-center justify-center bg-surface px-4">
+			<div
+				data-testid="password-login"
+				className="w-full max-w-sm rounded-lg border border-border bg-surface p-6 sm:p-8 shadow-sm"
+			>
+				<div className="mb-6 flex flex-col items-center gap-2 text-center">
+					<Logo size="lg" wordmark className="mb-1" />
+					<h2 className="text-lg font-semibold text-text-1">Sign in</h2>
+					<p className="text-sm text-text-2">Enter your admin password to continue.</p>
+				</div>
+				<form onSubmit={handleLogin} className="flex flex-col gap-4">
+					<div className="flex flex-col gap-1.5">
+						<label htmlFor="login-password" className="text-sm font-medium text-text-1">
+							Password
+						</label>
+						<input
+							id="login-password"
+							type="password"
+							value={password}
+							onChange={(e) => setPassword(e.target.value)}
+							autoComplete="current-password"
+							className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-1 focus:outline-none focus:ring-2 focus:ring-accent"
+						/>
+					</div>
+					{error && <p className="text-sm text-danger">{error}</p>}
+					<Button type="submit" disabled={loading || !password}>
+						{loading ? <Loader2 className="w-4 h-4 animate-spin" /> : <LogIn className="w-4 h-4" />}
+						Sign in
+					</Button>
+				</form>
+				<button
+					type="button"
+					onClick={() => setMode('master-key')}
+					className="mt-4 w-full text-center text-[13px] text-text-2 hover:text-text-1"
+				>
+					Forgot password? Use your master key
+				</button>
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/components/password-set-form.tsx
+++ b/packages/web/src/components/password-set-form.tsx
@@ -1,0 +1,81 @@
+import { Loader2 } from 'lucide-react';
+import { useState } from 'react';
+import type { ApiError } from '../lib/api';
+import { MIN_PASSWORD_LENGTH, setPassword as setPasswordApi } from '../lib/auth';
+import { Button } from './ui/button';
+
+interface PasswordSetFormProps {
+	submitLabel: string;
+	/** Called after the password is enrolled and a session is stored. */
+	onSuccess: () => void;
+}
+
+/**
+ * Enter + confirm a new password and enroll it. The password never leaves the
+ * browser — `setPassword` derives a verifier and signs a challenge. Shared by the
+ * onboarding create-password step and the forgot-password reset flow.
+ */
+export function PasswordSetForm({ submitLabel, onSuccess }: PasswordSetFormProps) {
+	const [password, setPassword] = useState('');
+	const [confirm, setConfirm] = useState('');
+	const [error, setError] = useState('');
+	const [loading, setLoading] = useState(false);
+
+	const tooShort = password.length > 0 && password.length < MIN_PASSWORD_LENGTH;
+	const mismatch = confirm.length > 0 && confirm !== password;
+	const canSubmit = password.length >= MIN_PASSWORD_LENGTH && confirm === password && !loading;
+
+	async function handleSubmit(e: React.FormEvent) {
+		e.preventDefault();
+		if (!canSubmit) return;
+		setError('');
+		setLoading(true);
+		try {
+			await setPasswordApi(password);
+			onSuccess();
+		} catch (err) {
+			setError((err as ApiError).message || 'Could not set the password');
+			setLoading(false);
+		}
+	}
+
+	return (
+		<form onSubmit={handleSubmit} className="flex flex-col gap-4">
+			<div className="flex flex-col gap-1.5">
+				<label htmlFor="new-password" className="text-sm font-medium text-text-1">
+					Password
+				</label>
+				<input
+					id="new-password"
+					type="password"
+					value={password}
+					onChange={(e) => setPassword(e.target.value)}
+					autoComplete="new-password"
+					className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-1 focus:outline-none focus:ring-2 focus:ring-accent"
+				/>
+				{tooShort && (
+					<p className="text-xs text-text-2">At least {MIN_PASSWORD_LENGTH} characters.</p>
+				)}
+			</div>
+			<div className="flex flex-col gap-1.5">
+				<label htmlFor="confirm-password" className="text-sm font-medium text-text-1">
+					Confirm password
+				</label>
+				<input
+					id="confirm-password"
+					type="password"
+					value={confirm}
+					onChange={(e) => setConfirm(e.target.value)}
+					autoComplete="new-password"
+					className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-1 focus:outline-none focus:ring-2 focus:ring-accent"
+				/>
+				{mismatch && <p className="text-xs text-danger">Passwords don't match.</p>}
+			</div>
+			{error && <p className="text-sm text-danger">{error}</p>}
+			<Button type="submit" disabled={!canSubmit}>
+				{loading && <Loader2 className="w-4 h-4 animate-spin" />}
+				{submitLabel}
+			</Button>
+		</form>
+	);
+}

--- a/packages/web/src/components/setup/setup-wizard.tsx
+++ b/packages/web/src/components/setup/setup-wizard.tsx
@@ -1,20 +1,30 @@
-import type { MasterKeyState } from '@hezo/shared';
 import { Loader2 } from 'lucide-react';
 import type { ReactNode } from 'react';
+import { useState } from 'react';
 import { useAiProviderStatus } from '../../hooks/use-ai-providers';
+import { api } from '../../lib/api';
+import { getPendingSetupToken } from '../../lib/auth';
+import { queryClient } from '../../lib/query-client';
+import { queryKeys } from '../../lib/query-keys';
 import { AiProviderPicker } from '../ai-provider-picker';
-import { MasterKeyForm } from '../master-key-gate';
+import { MasterKeyForm, VaultShell } from '../master-key-gate';
+import { PasswordSetForm } from '../password-set-form';
 import { Stepper, type StepStatus } from './stepper';
 
-export type WizardStep = 'master-key' | 'ai-provider' | 'done';
+export type WizardStep = 'password' | 'ai-provider' | 'done';
 
 interface WizardShellProps {
-	currentStep: 'master-key' | 'ai-provider';
+	currentStep: 'password' | 'ai-provider';
 	children: ReactNode;
 }
 
+/**
+ * Onboarding chrome shown AFTER the vault master-key screen. The master key is a
+ * separate pre-active gate, so it's always a completed step here; the two live
+ * steps are creating a password and configuring an AI provider.
+ */
 function WizardShell({ currentStep, children }: WizardShellProps) {
-	const masterKeyStatus: StepStatus = currentStep === 'master-key' ? 'current' : 'complete';
+	const passwordStatus: StepStatus = currentStep === 'password' ? 'current' : 'complete';
 	const aiProviderStatus: StepStatus = currentStep === 'ai-provider' ? 'current' : 'pending';
 	return (
 		<div className="min-h-screen flex flex-col items-center px-4 py-8 sm:py-16 bg-surface">
@@ -25,7 +35,8 @@ function WizardShell({ currentStep, children }: WizardShellProps) {
 				</div>
 				<Stepper
 					steps={[
-						{ label: 'Master key', status: masterKeyStatus },
+						{ label: 'Master key', status: 'complete' },
+						{ label: 'Password', status: passwordStatus },
 						{ label: 'AI provider', status: aiProviderStatus },
 					]}
 				/>
@@ -37,17 +48,60 @@ function WizardShell({ currentStep, children }: WizardShellProps) {
 	);
 }
 
-export function MasterKeyStep({ state }: { state: MasterKeyState }) {
+/** Create/confirm the admin password. On success the session is stored and the gate advances. */
+function PasswordStep() {
 	return (
-		<WizardShell currentStep="master-key">
-			<div data-testid="setup-step-master-key">
-				<h2 className="text-base sm:text-lg font-semibold mb-1">Set Master Key</h2>
-				<p className="text-[13px] text-text-2 mb-5">
-					Your master key is 12 words that encrypt your data. Save them somewhere safe — you'll need
-					them to unlock Hezo on restart.
-				</p>
-				<MasterKeyForm state={state} embedded />
-			</div>
+		<div data-testid="setup-step-password">
+			<h2 className="text-base sm:text-lg font-semibold mb-1">Create an admin password</h2>
+			<p className="text-[13px] text-text-2 mb-5">
+				You'll sign in with this password from now on. If you forget it, you can reset it with your
+				master key.
+			</p>
+			<PasswordSetForm
+				submitLabel="Set password & continue"
+				onSuccess={() => {
+					// Now logged in (session stored) and passwordSet flips true.
+					queryClient.invalidateQueries({ queryKey: queryKeys.status() });
+					queryClient.invalidateQueries({ queryKey: queryKeys.me() });
+				}}
+			/>
+		</div>
+	);
+}
+
+/**
+ * The create-password phase. Needs a credential to enroll the verifier — either
+ * the in-memory password-setup token from the just-completed master-key flow, or
+ * (if that was lost, e.g. a page refresh mid-onboarding) a fresh one obtained by
+ * re-entering the master key.
+ */
+export function CreatePasswordFlow() {
+	const [reentered, setReentered] = useState(0);
+	const hasCredential = getPendingSetupToken() !== null || api.getToken() !== null;
+
+	if (!hasCredential) {
+		return (
+			<VaultShell>
+				<div className="rounded-2xl border border-border-strong bg-surface p-6 sm:p-8 shadow-[var(--elev-lg)]">
+					<div className="mb-5 text-center">
+						<h2 className="text-lg font-semibold text-text-1">Confirm your master key</h2>
+						<p className="mt-1 text-sm text-text-2">
+							Enter your master key to set an admin password for this instance.
+						</p>
+					</div>
+					<MasterKeyForm
+						state="unlocked"
+						embedded
+						onAuthenticated={() => setReentered((n) => n + 1)}
+					/>
+				</div>
+			</VaultShell>
+		);
+	}
+
+	return (
+		<WizardShell currentStep="password" key={reentered}>
+			<PasswordStep />
 		</WizardShell>
 	);
 }
@@ -84,7 +138,7 @@ interface SetupGateProps {
 	children: React.ReactNode;
 }
 
-/** Wraps the app shell: shows the wizard until an AI provider is configured. */
+/** Wraps the app shell: shows the AI-provider wizard until a provider is configured. */
 export function SetupGate({ children }: SetupGateProps) {
 	const step = useWizardStep();
 	if (step === 'loading') {

--- a/packages/web/src/hooks/use-me.ts
+++ b/packages/web/src/hooks/use-me.ts
@@ -7,9 +7,18 @@ export interface Me {
 	is_superuser: boolean;
 }
 
-export function useMe() {
+/**
+ * The authenticated caller's identity. Also serves as the session probe for the
+ * top-level gate: a 401 means "unlocked but no valid session → show login". The
+ * gate passes `retry: false` so that 401 surfaces immediately (a missing/expired
+ * token won't fix itself), and `enabled: false` to hold the probe until unlock.
+ * Both default to the plain useQuery behavior so existing callers are unchanged.
+ */
+export function useMe(options?: { enabled?: boolean; retry?: boolean }) {
 	return useQuery({
 		queryKey: queryKeys.me(),
 		queryFn: () => api.get<Me>('/api/me'),
+		enabled: options?.enabled ?? true,
+		...(options?.retry !== undefined ? { retry: options.retry } : {}),
 	});
 }

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -194,6 +194,76 @@ html.dark,
 	--color-neutral-soft-fg: #9a9a96;
 }
 
+/* `.vault-surface` opts a subtree into the "pre-active vault" palette — a deep,
+   cool indigo world used by the master-key screens (setup / unlock) to signal the
+   instance is NOT live yet, distinct from both the normal app and the password
+   login. Always dark regardless of the active theme. Like `.log-surface-dark` it
+   overrides the resolved `--color-*` vars directly (the `@theme` indirection is
+   resolved once at :root/html.dark) plus `--border` for the `*` fallback. The one
+   warm accent (Hezo vermilion) is reserved for the primary action. */
+.vault-surface {
+	--color-bg: oklch(0.108 0.022 264);
+	--color-surface: oklch(0.178 0.027 264);
+	--color-surface-2: oklch(0.22 0.029 264);
+	--color-surface-3: oklch(0.262 0.03 264);
+	--color-border: oklch(0.3 0.028 264);
+	--color-border-strong: oklch(0.39 0.03 264);
+	--border: oklch(0.3 0.028 264);
+
+	--color-text-1: oklch(0.955 0.006 260);
+	--color-text-2: oklch(0.7 0.018 262);
+	--color-text-3: oklch(0.54 0.018 262);
+	--color-inverse: oklch(0.955 0.006 260);
+	--color-inverse-fg: oklch(0.108 0.022 264);
+
+	--color-accent: oklch(0.635 0.205 31);
+	--color-accent-hover: oklch(0.685 0.19 31);
+	--color-accent-soft: oklch(0.3 0.085 28);
+	--color-accent-soft-fg: oklch(0.82 0.13 33);
+
+	--color-warning-soft: oklch(0.28 0.06 82);
+	--color-warning-soft-fg: oklch(0.84 0.12 82);
+	--color-danger: oklch(0.74 0.18 18);
+
+	/* Cool "secured" cyan — a hairline/eyebrow detail only, not the accent. */
+	--vault-seal: oklch(0.72 0.11 205);
+}
+
+/* Vertical-blind unlock reveal: an overlay of vertical strips that collapse
+   upward once the master key is accepted, uncovering the app behind them. The
+   strips are laid out flex-1 (width-agnostic → works at every breakpoint); the
+   stagger comes from a per-strip inline `--i`. The last strip's `animationend`
+   drives the status refetch that swaps the gate out (see master-key-gate.tsx). */
+@keyframes vault-blind {
+	from {
+		transform: scaleY(1);
+	}
+	to {
+		transform: scaleY(0);
+	}
+}
+.vault-reveal {
+	position: fixed;
+	inset: 0;
+	z-index: 60;
+	display: flex;
+	pointer-events: none;
+}
+.vault-reveal-strip {
+	flex: 1 1 0;
+	transform-origin: top;
+	background: linear-gradient(180deg, oklch(0.178 0.027 264), oklch(0.108 0.022 264));
+	border-right: 1px solid oklch(1 0 0 / 0.03);
+	animation: vault-blind 0.5s cubic-bezier(0.7, 0, 0.3, 1) both;
+	animation-delay: calc(var(--i) * 34ms);
+}
+@media (prefers-reduced-motion: reduce) {
+	.vault-reveal-strip {
+		animation-duration: 0.01ms;
+		animation-delay: 0ms;
+	}
+}
+
 @theme {
 	--color-bg: var(--bg);
 	--color-surface: var(--surface);

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -1,10 +1,14 @@
 import {
 	type AuthKeyPair,
 	buildLoginMessage,
+	buildPasswordLoginMessage,
+	buildPasswordSetupMessage,
 	buildSetupMessage,
 	buildUnlockMessage,
 	deriveAuthKeyPair,
+	derivePasswordKeyPair,
 	deriveUnlockKey,
+	generatePasswordSalt,
 	type MasterKeyState,
 	signAuthMessage,
 } from '@hezo/shared';
@@ -13,6 +17,8 @@ import { type ApiError, api } from './api';
 export interface StatusResponse {
 	/** Absent while the server is still booting (`starting` is true). */
 	masterKeyState?: MasterKeyState;
+	/** True once the admin has enrolled a password verifier (gate: login vs create-password). */
+	passwordSet?: boolean;
 	version: string;
 	/** True when the server is still booting; the rest of the app should wait. */
 	starting?: boolean;
@@ -22,6 +28,20 @@ export interface StatusResponse {
 	message?: string;
 	/** Optional extra context for the loading screen. */
 	detail?: string;
+}
+
+/** The password below is the minimum the UI will accept before deriving a verifier. */
+export const MIN_PASSWORD_LENGTH = 8;
+
+// The mnemonic flows return a short-lived, password-setup-scoped token — NOT a
+// session. It's held in memory (never persisted) until the create-password step
+// exchanges it for a real session via `setPassword`.
+let pendingSetupToken: string | null = null;
+export function getPendingSetupToken(): string | null {
+	return pendingSetupToken;
+}
+export function clearPendingSetupToken(): void {
+	pendingSetupToken = null;
 }
 
 export async function checkStatus(): Promise<StatusResponse> {
@@ -51,16 +71,20 @@ export async function checkStatus(): Promise<StatusResponse> {
 }
 
 /**
- * Authenticate with the 12-word master key phrase. The phrase never leaves
- * the browser: it derives an Ed25519 keypair (whose signature over a server
- * challenge is the login credential) and an unlock key (transmitted only at
- * setup and unlock-after-restart, inside the signed payload, to root the
- * server's at-rest encryption).
+ * Authenticate with the 12-word master key phrase. The phrase never leaves the
+ * browser: it derives an Ed25519 keypair (whose signature over a server
+ * challenge proves ownership) and an unlock key (transmitted only at setup and
+ * unlock-after-restart, inside the signed payload, to root the server's at-rest
+ * encryption).
+ *
+ * The master key only *unlocks* — it does not mint a session. The server returns
+ * a short-lived, password-setup-scoped token, held in memory here; the caller
+ * then routes to the create-password step, which exchanges it for a session.
  */
 export async function authenticateWithMnemonic(
 	phrase: string,
 	state: MasterKeyState,
-): Promise<string> {
+): Promise<void> {
 	const keys = deriveAuthKeyPair(phrase);
 	const unlockKey = deriveUnlockKey(phrase);
 
@@ -70,23 +94,24 @@ export async function authenticateWithMnemonic(
 			unlock_key: unlockKey,
 			signature: signAuthMessage(keys.privateKey, buildSetupMessage(keys.publicKeyHex, unlockKey)),
 		});
-		api.setToken(data.token);
-		return data.token;
+		pendingSetupToken = data.token;
+		return;
 	}
 
 	try {
-		return await challengeLogin(keys, state === 'locked' ? unlockKey : null);
+		await challengeLogin(keys, state === 'locked' ? unlockKey : null);
 	} catch (err) {
 		// The server restarted (and locked) between the status fetch and this
 		// attempt — retry once with the unlock key included.
 		if ((err as ApiError).code === 'UNLOCK_KEY_REQUIRED') {
-			return await challengeLogin(keys, unlockKey);
+			await challengeLogin(keys, unlockKey);
+			return;
 		}
 		throw err;
 	}
 }
 
-async function challengeLogin(keys: AuthKeyPair, unlockKey: string | null): Promise<string> {
+async function challengeLogin(keys: AuthKeyPair, unlockKey: string | null): Promise<void> {
 	const challenge = await api.post<{ challenge_id: string; nonce: string }>('/api/auth/challenge');
 	const body: Record<string, string> = { challenge_id: challenge.challenge_id };
 	if (unlockKey !== null) {
@@ -99,12 +124,66 @@ async function challengeLogin(keys: AuthKeyPair, unlockKey: string | null): Prom
 		body.signature = signAuthMessage(keys.privateKey, buildLoginMessage(challenge.nonce));
 	}
 	const data = await api.post<{ token: string }>('/api/auth/verify', body);
+	pendingSetupToken = data.token;
+}
+
+/**
+ * Log in with the admin password via challenge-response. The password never
+ * leaves the browser: it derives an Ed25519 keypair from `scrypt(password, salt)`
+ * and signs a one-time server nonce. On success a session JWT is stored.
+ */
+export async function loginWithPassword(password: string): Promise<void> {
+	const challenge = await api.post<{ challenge_id: string; nonce: string; salt: string }>(
+		'/api/auth/password-challenge',
+	);
+	const { privateKey } = await derivePasswordKeyPair(password, challenge.salt);
+	const data = await api.post<{ token: string }>('/api/auth/password-verify', {
+		challenge_id: challenge.challenge_id,
+		signature: signAuthMessage(privateKey, buildPasswordLoginMessage(challenge.nonce)),
+	});
 	api.setToken(data.token);
-	return data.token;
+	clearPendingSetupToken();
+}
+
+/**
+ * Set or change the admin password. Derives a fresh verifier `{ salt, public_key }`
+ * plus a self-signature (the password itself is never sent) and enrolls it,
+ * authenticating with the current session if logged in, otherwise the in-memory
+ * password-setup token from the mnemonic flow. Returns having stored the session.
+ */
+export async function setPassword(password: string): Promise<void> {
+	const salt = generatePasswordSalt();
+	const { publicKeyHex, privateKey } = await derivePasswordKeyPair(password, salt);
+	const signature = signAuthMessage(privateKey, buildPasswordSetupMessage(publicKeyHex, salt));
+
+	const bearer = api.getToken() ?? pendingSetupToken;
+	const res = await fetch('/api/auth/password', {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			...(bearer ? { Authorization: `Bearer ${bearer}` } : {}),
+		},
+		body: JSON.stringify({ salt, public_key: publicKeyHex, signature }),
+	});
+	const json = (await res.json().catch(() => null)) as {
+		data?: { token: string };
+		error?: { code?: string; message?: string };
+	} | null;
+	if (!res.ok) {
+		const e: ApiError = {
+			code: json?.error?.code ?? 'UNKNOWN',
+			message: json?.error?.message ?? res.statusText,
+			status: res.status,
+		};
+		throw e;
+	}
+	if (json?.data?.token) api.setToken(json.data.token);
+	clearPendingSetupToken();
 }
 
 export function logout() {
 	api.clearToken();
+	clearPendingSetupToken();
 }
 
 export function isAuthenticated(): boolean {

--- a/packages/web/src/routes/__root.tsx
+++ b/packages/web/src/routes/__root.tsx
@@ -12,14 +12,16 @@ import { CeoChatWidget } from '../components/ceo-chat/ceo-chat-widget';
 import { FloatingNewTaskButton } from '../components/floating-new-task-button';
 import { GlobalSearchDialog } from '../components/global-search-dialog';
 import { MasterKeyGate } from '../components/master-key-gate';
+import { PasswordLogin } from '../components/password-login';
 import { ProjectRail } from '../components/project-rail';
 import { ProjectSidebar } from '../components/project-sidebar';
 import { PwaInstallPrompt } from '../components/pwa-install-prompt';
-import { MasterKeyStep, SetupGate } from '../components/setup/setup-wizard';
+import { CreatePasswordFlow, SetupGate } from '../components/setup/setup-wizard';
 import { StartingScreen } from '../components/starting-screen';
 import { UpdateBanner } from '../components/update-banner';
 import { SocketProvider } from '../contexts/socket-context';
 import { useActiveProject } from '../hooks/use-active-project';
+import { useMe } from '../hooks/use-me';
 import { useProjectsIndex } from '../hooks/use-projects';
 import { useStatus } from '../hooks/use-status';
 import { useShellWebSockets } from '../hooks/use-websocket';
@@ -45,6 +47,9 @@ function Spinner() {
 function AppShell() {
 	const { data: status, isPending, isError, error, refetch } = useStatus();
 	const navigate = useNavigate();
+	// Session probe: only meaningful (and only fired) once the instance is unlocked.
+	// A 401 here means "unlocked but no valid session → show the password login".
+	const me = useMe({ enabled: status?.masterKeyState === 'unlocked', retry: false });
 
 	useEffect(() => {
 		if (status?.masterKeyState === 'unset' && window.location.pathname !== '/') {
@@ -86,22 +91,34 @@ function AppShell() {
 
 	if (status.masterKeyState !== 'unlocked') {
 		api.clearToken();
-		// Initial setup: render the master-key step inside the wizard chrome so the
-		// stepper makes the two-step flow obvious. On server restart (locked state),
-		// the modal unlock dialog is the right primitive — there's no setup to flow into.
-		if (status.masterKeyState === 'unset') {
-			return <MasterKeyStep state={status.masterKeyState} />;
-		}
+		// Pre-active vault gate. Both first-run setup (unset) and post-restart unlock
+		// (locked) share the same full-screen "vault" treatment to signal the
+		// instance isn't live yet; the master key only unlocks — it never grants a
+		// session. After the unlock reveal, the gate re-evaluates below.
 		return <MasterKeyGate state={status.masterKeyState} />;
 	}
 
-	return (
-		<SocketProvider token={api.getToken()}>
-			<SetupGate>
-				<ShellLayout />
-			</SetupGate>
-		</SocketProvider>
-	);
+	// Unlocked. A session is now required (no anonymous access). A valid session is
+	// only ever minted by the password, so it's proof enough to enter the app.
+	if (me.isPending) return <Spinner />;
+	if (!me.isError) {
+		return (
+			<SocketProvider token={api.getToken()}>
+				<SetupGate>
+					<ShellLayout />
+				</SetupGate>
+			</SocketProvider>
+		);
+	}
+
+	// No valid session. `passwordSet` decides how to get one:
+	if (!status.passwordSet) {
+		// Brand-new instance (or recovery): create the first password, which mints
+		// the first session.
+		return <CreatePasswordFlow />;
+	}
+	// A password exists but this browser has no session → sign in.
+	return <PasswordLogin />;
 }
 
 function ShellLayout() {

--- a/packages/web/test/auth.test.ts
+++ b/packages/web/test/auth.test.ts
@@ -1,10 +1,13 @@
 import {
 	buildLoginMessage,
+	buildPasswordLoginMessage,
 	buildSetupMessage,
 	buildUnlockMessage,
 	deriveAuthKeyPair,
+	derivePasswordKeyPair,
 	deriveUnlockKey,
 	generateMnemonic,
+	generatePasswordSalt,
 	verifyAuthSignature,
 } from '@hezo/shared';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
@@ -24,7 +27,15 @@ vi.mock('../src/lib/api', () => ({
 	},
 }));
 
-import { authenticateWithMnemonic, checkStatus, isAuthenticated, logout } from '../src/lib/auth';
+import {
+	authenticateWithMnemonic,
+	checkStatus,
+	clearPendingSetupToken,
+	getPendingSetupToken,
+	isAuthenticated,
+	loginWithPassword,
+	logout,
+} from '../src/lib/auth';
 
 const PHRASE = generateMnemonic();
 
@@ -33,6 +44,7 @@ beforeEach(() => {
 	setToken.mockReset();
 	getToken.mockReset();
 	clearToken.mockReset();
+	clearPendingSetupToken();
 });
 afterEach(() => {
 	vi.restoreAllMocks();
@@ -105,12 +117,14 @@ describe('checkStatus', () => {
 });
 
 describe('authenticateWithMnemonic — setup (unset)', () => {
-	test('posts a valid setup payload and stores the returned token', async () => {
+	test('posts a valid setup payload and holds the scoped token (not a session)', async () => {
 		post.mockResolvedValueOnce({ token: 'tok-setup' });
-		const token = await authenticateWithMnemonic(PHRASE, 'unset');
+		await authenticateWithMnemonic(PHRASE, 'unset');
 
-		expect(token).toBe('tok-setup');
-		expect(setToken).toHaveBeenCalledWith('tok-setup');
+		// The mnemonic only unlocks: the token is held in memory for the
+		// create-password step, never stored as a session.
+		expect(getPendingSetupToken()).toBe('tok-setup');
+		expect(setToken).not.toHaveBeenCalled();
 		expect(post).toHaveBeenCalledTimes(1);
 		const [path, payload] = post.mock.calls[0] as [string, Record<string, string>];
 		expect(path).toBe('/api/auth/setup');
@@ -137,9 +151,9 @@ describe('authenticateWithMnemonic — login (unlocked)', () => {
 			.mockResolvedValueOnce({ challenge_id: 'c1', nonce: 'abcd' }) // /api/auth/challenge
 			.mockResolvedValueOnce({ token: 'tok-login' }); // /api/auth/verify
 
-		const token = await authenticateWithMnemonic(PHRASE, 'unlocked');
-		expect(token).toBe('tok-login');
-		expect(setToken).toHaveBeenCalledWith('tok-login');
+		await authenticateWithMnemonic(PHRASE, 'unlocked');
+		expect(getPendingSetupToken()).toBe('tok-login');
+		expect(setToken).not.toHaveBeenCalled();
 
 		expect(post.mock.calls[0][0]).toBe('/api/auth/challenge');
 		const [verifyPath, body] = post.mock.calls[1] as [string, Record<string, string>];
@@ -160,8 +174,8 @@ describe('authenticateWithMnemonic — unlock (locked)', () => {
 			.mockResolvedValueOnce({ challenge_id: 'c2', nonce: 'beef' })
 			.mockResolvedValueOnce({ token: 'tok-unlock' });
 
-		const token = await authenticateWithMnemonic(PHRASE, 'locked');
-		expect(token).toBe('tok-unlock');
+		await authenticateWithMnemonic(PHRASE, 'locked');
+		expect(getPendingSetupToken()).toBe('tok-unlock');
 
 		const body = post.mock.calls[1][1] as Record<string, string>;
 		const unlockKey = deriveUnlockKey(PHRASE);
@@ -182,8 +196,8 @@ describe('authenticateWithMnemonic — unlock-required retry', () => {
 			.mockResolvedValueOnce({ challenge_id: 'c4', nonce: '2222' }) // retry challenge
 			.mockResolvedValueOnce({ token: 'tok-retry' }); // retry verify
 
-		const token = await authenticateWithMnemonic(PHRASE, 'unlocked');
-		expect(token).toBe('tok-retry');
+		await authenticateWithMnemonic(PHRASE, 'unlocked');
+		expect(getPendingSetupToken()).toBe('tok-retry');
 
 		// Second attempt carries the unlock key + unlock-message signature.
 		const retryBody = post.mock.calls[3][1] as Record<string, string>;
@@ -209,6 +223,29 @@ describe('authenticateWithMnemonic — unlock-required retry', () => {
 		});
 		// challenge + failed verify only; no retry challenge.
 		expect(post).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe('loginWithPassword', () => {
+	test('signs the nonce with a password-derived key and stores the session', async () => {
+		const salt = generatePasswordSalt();
+		post
+			.mockResolvedValueOnce({ challenge_id: 'pc1', nonce: 'facef00d', salt }) // password-challenge
+			.mockResolvedValueOnce({ token: 'sess-tok' }); // password-verify
+
+		await loginWithPassword('correct horse battery staple');
+
+		expect(setToken).toHaveBeenCalledWith('sess-tok');
+		expect(post.mock.calls[0][0]).toBe('/api/auth/password-challenge');
+		const [verifyPath, body] = post.mock.calls[1] as [string, Record<string, string>];
+		expect(verifyPath).toBe('/api/auth/password-verify');
+		expect(body.challenge_id).toBe('pc1');
+		// The password is never in the body — only a signature over the nonce.
+		expect(JSON.stringify(body)).not.toContain('correct horse battery staple');
+		const { publicKeyHex } = await derivePasswordKeyPair('correct horse battery staple', salt);
+		expect(
+			verifyAuthSignature(publicKeyHex, buildPasswordLoginMessage('facef00d'), body.signature),
+		).toBe(true);
 	});
 });
 

--- a/packages/web/test/helpers/render.tsx
+++ b/packages/web/test/helpers/render.tsx
@@ -37,6 +37,8 @@ interface RenderOptions {
 interface TestAppContext {
 	app: Hono;
 	token: string;
+	/** The seeded admin's plaintext password (verifier enrolled in createTestApp). */
+	password: string;
 	/** The 12-word master key phrase the test app was enrolled with. */
 	mnemonic: string;
 	apiBase: (path: string, init?: RequestInit) => Promise<Response>;
@@ -69,6 +71,7 @@ beforeEach(async () => {
 	activeContext = {
 		app: test.app,
 		token: test.token,
+		password: test.password,
 		mnemonic: test.mnemonic,
 		apiBase,
 		db: test.db,

--- a/packages/web/test/master-key-setup.test.tsx
+++ b/packages/web/test/master-key-setup.test.tsx
@@ -11,7 +11,7 @@ afterEach(() => {
 test('setup generates a 12-word master key in a numbered grid', async () => {
 	render(<MasterKeyForm state="unset" embedded />);
 
-	fireEvent.click(screen.getByRole('button', { name: /generate key/i }));
+	fireEvent.click(screen.getByRole('button', { name: /generate master key/i }));
 
 	const words = await screen.findAllByTestId('mnemonic-word');
 	expect(words).toHaveLength(12);
@@ -36,7 +36,7 @@ test('copy writes the space-joined phrase and toggles the label', async () => {
 	});
 
 	render(<MasterKeyForm state="unset" embedded />);
-	fireEvent.click(screen.getByRole('button', { name: /generate key/i }));
+	fireEvent.click(screen.getByRole('button', { name: /generate master key/i }));
 	await screen.findAllByTestId('mnemonic-word');
 	fireEvent.click(screen.getByRole('button', { name: /copy to clipboard/i }));
 

--- a/packages/web/test/master-key-unlock.test.tsx
+++ b/packages/web/test/master-key-unlock.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, expect, test } from 'vitest';
 import { MasterKeyForm } from '../src/components/master-key-gate';
 import { api } from '../src/lib/api';
+import { clearPendingSetupToken, getPendingSetupToken } from '../src/lib/auth';
 // Importing the harness registers its beforeEach: an in-process Hono + PGlite
 // backend (enrolled and unlocked) with fetch rerouted to it. The form is
 // rendered with state="locked", so the client runs the unlock flow — derive
@@ -15,6 +16,7 @@ afterEach(cleanup);
 test('unlock derives keys client-side and completes the challenge dance', async () => {
 	const ctx = getTestContext();
 	api.clearToken();
+	clearPendingSetupToken();
 
 	render(<MasterKeyForm state="locked" embedded />);
 	fireEvent.change(screen.getByLabelText(/master key/i), {
@@ -22,9 +24,12 @@ test('unlock derives keys client-side and completes the challenge dance', async 
 	});
 	fireEvent.click(screen.getByRole('button', { name: /unlock/i }));
 
+	// The mnemonic only unlocks: it yields a password-setup token held in memory,
+	// not a session — so no api token is set, but the scoped token is present.
 	await waitFor(() => {
-		expect(api.getToken()).toBeTruthy();
+		expect(getPendingSetupToken()).toBeTruthy();
 	});
+	expect(api.getToken()).toBeNull();
 	expect(screen.queryByText(/failed|invalid/i)).toBeNull();
 });
 

--- a/packages/web/test/password-auth.test.tsx
+++ b/packages/web/test/password-auth.test.tsx
@@ -1,0 +1,80 @@
+import { api } from '@hezo/web/lib/api';
+import { expect, test } from 'vitest';
+import { getTestContext, renderApp } from './helpers/render';
+
+// The gate reads `/api/status.passwordSet` + a `/api/me` session probe:
+//  - unlocked + passwordSet + no session → password login
+//  - unlocked + !passwordSet + a credential → create-password wizard step
+// The harness seeds a verifier + session, so we mutate one of those per test.
+
+test('shows the password login with no session and signs in with the password', async () => {
+	const { findByTestId, getByLabelText, user, queryByTestId } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			// Fresh browser: a password exists on the server, but this client has no
+			// session token.
+			api.clearToken();
+			localStorage.removeItem('hezo_token');
+		},
+	});
+
+	await findByTestId('password-login');
+
+	const ctx = getTestContext();
+	await user.type(getByLabelText('Password'), ctx.password);
+	await user.click(
+		await findByTestId('password-login').then(
+			(el) => el.querySelector('button[type="submit"]') as HTMLButtonElement,
+		),
+	);
+
+	// A correct password mints a session; the gate advances off the login screen.
+	await expect.poll(() => queryByTestId('password-login')).toBeNull();
+});
+
+test('offers master-key recovery from the login screen', async () => {
+	const { findByTestId, findByText } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			api.clearToken();
+			localStorage.removeItem('hezo_token');
+		},
+	});
+
+	const login = await findByTestId('password-login');
+	// The forgot-password affordance points at the master key.
+	const forgot = await findByText(/forgot password\?/i);
+	forgot.click();
+	await findByTestId('forgot-password-master-key');
+	expect(login).toBeDefined();
+});
+
+test('with no session and no password, master-key re-entry leads to create-password', async () => {
+	const { findByTestId, findByText, getByLabelText, user, queryByTestId } = await renderApp({
+		initialPath: '/',
+		seed: async (ctx) => {
+			// No session, and no password verifier yet (e.g. a page refresh mid-onboarding
+			// lost the in-memory setup token). The gate asks for the master key first.
+			api.clearToken();
+			localStorage.removeItem('hezo_token');
+			await ctx.db.query(
+				`UPDATE users SET password_salt = NULL, password_public_key = NULL WHERE is_superuser = true`,
+			);
+		},
+	});
+
+	// Re-enter the master key to obtain a password-setup token.
+	await findByText(/confirm your master key/i);
+	const ctx = getTestContext();
+	await user.type(getByLabelText('Master Key'), ctx.mnemonic);
+	await user.click(await findByText('Unlock'));
+
+	// Then the create-password step, which mints the first session.
+	await findByTestId('setup-step-password');
+	await user.type(getByLabelText('Password'), 'a-new-strong-password');
+	await user.type(getByLabelText('Confirm password'), 'a-new-strong-password');
+	const step = await findByTestId('setup-step-password');
+	await user.click(step.querySelector('button[type="submit"]') as HTMLButtonElement);
+
+	await expect.poll(() => queryByTestId('setup-step-password')).toBeNull();
+});

--- a/test/browser/constants.ts
+++ b/test/browser/constants.ts
@@ -6,3 +6,10 @@
  */
 export const TEST_MNEMONIC =
 	'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+/**
+ * The e2e admin password. The mnemonic only unlocks the instance now — a session
+ * is minted only by the password — so helpers exchange the master-key setup token
+ * for a session by enrolling this password's verifier.
+ */
+export const TEST_PASSWORD = 'e2e-admin-password';

--- a/test/browser/fixtures.ts
+++ b/test/browser/fixtures.ts
@@ -86,6 +86,20 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 		{ scope: 'worker' },
 	],
 
+	// Every page from the shared fixtures is authenticated by default with the
+	// worker's admin session. The app no longer allows anonymous access, so a bare
+	// page.goto would otherwise land on the password login and never render the
+	// shell. Fixtures that need a specific token (sharedPage) or a fresh auth flow
+	// (freshWorkspace/lightWorkspace) inject their own token on top afterward — the
+	// later addInitScript wins on the next navigation. (The master-key-gate spec
+	// drives its own server via the raw @playwright/test `test`, so it is unaffected.)
+	page: async ({ page, apiToken }, use) => {
+		await page.addInitScript((t: string) => {
+			localStorage.setItem('hezo_token', t);
+		}, apiToken);
+		await use(page);
+	},
+
 	authedPage: async ({ page, apiToken }, use) => {
 		await page.addInitScript((t: string) => {
 			localStorage.setItem('hezo_token', t);

--- a/test/browser/helpers.ts
+++ b/test/browser/helpers.ts
@@ -1,13 +1,16 @@
 import {
 	buildLoginMessage,
+	buildPasswordSetupMessage,
 	buildSetupMessage,
 	buildUnlockMessage,
 	deriveAuthKeyPair,
+	derivePasswordKeyPair,
 	deriveUnlockKey,
+	generatePasswordSalt,
 	signAuthMessage,
 } from '@hezo/shared';
 import { expect, type Locator, type Page, type Response } from '@playwright/test';
-import { TEST_MNEMONIC } from './constants';
+import { TEST_MNEMONIC, TEST_PASSWORD } from './constants';
 
 // The phrase never goes over the wire: the Node test process derives the same
 // keys the browser would and runs the challenge-response dance over HTTP.
@@ -17,7 +20,8 @@ const TEST_UNLOCK_KEY = deriveUnlockKey(TEST_MNEMONIC);
 // Bun's webserver starts listening before Hono routes are mounted, so the very
 // first request during cold start can hit the default 404 ("404 Not Found"
 // plain text) and crash res.json(). Retry until we get a real JSON body.
-async function requestToken(page: Page): Promise<string> {
+// Returns the master-key *setup* token (password-setup-scoped, not a session).
+async function requestSetupToken(page: Page): Promise<string> {
 	const deadline = Date.now() + 30_000;
 	let lastError: unknown = null;
 	while (Date.now() < deadline) {
@@ -41,6 +45,29 @@ async function requestToken(page: Page): Promise<string> {
 		await new Promise((resolve) => setTimeout(resolve, 250));
 	}
 	throw lastError ?? new Error('Timed out authenticating via /api/auth');
+}
+
+// Exchange the master-key setup token for a real session by enrolling the test
+// password's verifier — the mnemonic only unlocks; a session is minted only by
+// the password. The password never goes over the wire (only salt + public key +
+// signature). Enrolling is last-write-wins on the verifier but each call returns
+// its own signed session, so parallel workers don't race for a usable token.
+async function requestToken(page: Page): Promise<string> {
+	const setupToken = await requestSetupToken(page);
+	const salt = generatePasswordSalt();
+	const { publicKeyHex, privateKey } = await derivePasswordKeyPair(TEST_PASSWORD, salt);
+	const res = await page.request.post('/api/auth/password', {
+		headers: { Authorization: `Bearer ${setupToken}` },
+		data: {
+			salt,
+			public_key: publicKeyHex,
+			signature: signAuthMessage(privateKey, buildPasswordSetupMessage(publicKeyHex, salt)),
+		},
+	});
+	if (!res.ok()) throw new Error(`Unexpected ${res.status()} from /api/auth/password`);
+	const json = (await res.json()) as { data?: { token: string } };
+	if (!json.data?.token) throw new Error('No session token from /api/auth/password');
+	return json.data.token;
 }
 
 async function setupViaApi(page: Page): Promise<string | null> {

--- a/test/browser/master-key-gate.spec.ts
+++ b/test/browser/master-key-gate.spec.ts
@@ -81,13 +81,15 @@ test.afterAll(async () => {
 	rmSync(dataDir, { recursive: true, force: true });
 });
 
-test('first-boot setup wizard, then the locked gate after a restart', async ({ page }) => {
+const PASSWORD = 'e2e-admin-password';
+
+test('setup → password → provider, then restart → unlock → password login', async ({ page }) => {
 	await startGateServer({ reset: true });
 	await page.goto('/');
 
-	// Phase A — unset: the setup wizard's master-key step at mobile viewport.
-	await expect(page.getByTestId('setup-step-master-key')).toBeVisible();
-	await page.getByRole('button', { name: /generate key/i }).click();
+	// Phase A — unset: the pre-active vault setup screen at mobile viewport.
+	await expect(page.getByTestId('master-key-setup')).toBeVisible();
+	await page.getByRole('button', { name: /generate master key/i }).click();
 	const words = page.getByTestId('mnemonic-word');
 	await expect(words).toHaveCount(12);
 	// Each item renders "<n> <word>" — strip the leading position number.
@@ -96,30 +98,42 @@ test('first-boot setup wizard, then the locked gate after a restart', async ({ p
 		.join(' ');
 	await page.getByRole('button', { name: /set key & continue/i }).click();
 
-	// Setup enrolled + unlocked the server; the wizard advances to the
-	// AI-provider step (none configured on this fresh instance).
+	// The unlock reveal plays, then the wizard advances to the dedicated
+	// create-password step (the mnemonic only unlocked — no session yet).
+	await expect(page.getByTestId('setup-step-password')).toBeVisible();
+	await page.getByLabel('Password', { exact: true }).fill(PASSWORD);
+	await page.getByLabel('Confirm password').fill(PASSWORD);
+	await page.getByRole('button', { name: /set password & continue/i }).click();
+
+	// Setting the password mints a session; with no AI provider configured the
+	// wizard resumes at the provider step.
 	await expect(page.getByTestId('setup-step-ai-provider')).toBeVisible();
 	const status = await page.request.get(`http://localhost:${GATE_SERVER_PORT}/api/status`);
-	expect(((await status.json()) as { masterKeyState: string }).masterKeyState).toBe('unlocked');
+	const statusBody = (await status.json()) as { masterKeyState: string; passwordSet: boolean };
+	expect(statusBody.masterKeyState).toBe('unlocked');
+	expect(statusBody.passwordSet).toBe(true);
 
-	// Phase B — restart on the same data dir without a boot key: locked gate.
+	// Phase B — restart on the same data dir without a boot key: locked vault.
 	await stopGateServer();
 	await startGateServer({ reset: false });
 	await page.reload();
 
 	const entry = page.getByLabel(/master key/i);
-	await expect(entry).toBeVisible();
+	await expect(page.getByTestId('master-key-unlock')).toBeVisible();
 
 	// A valid-but-wrong phrase signs with the wrong keypair — server rejects.
 	await entry.fill('legal winner thank year wave sausage worth useful legal winner thank yellow');
 	await page.getByRole('button', { name: /unlock/i }).click();
 	await expect(page.getByText(/signature verification failed/i)).toBeVisible();
 
-	// The phrase captured during setup unlocks; with no AI provider configured
-	// the wizard resumes at the provider step — the post-gate surface.
+	// The captured phrase unlocks. The instance is active but this browser has no
+	// session, so the password login is next — the mnemonic never grants a session.
 	await entry.fill(phrase);
 	await page.getByRole('button', { name: /unlock/i }).click();
+	await expect(page.getByTestId('password-login')).toBeVisible();
+
+	// Sign in with the password set in Phase A → the app (provider step) returns.
+	await page.getByLabel('Password', { exact: true }).fill(PASSWORD);
+	await page.getByRole('button', { name: /sign in/i }).click();
 	await expect(page.getByTestId('setup-step-ai-provider')).toBeVisible();
-	const after = await page.request.get(`http://localhost:${GATE_SERVER_PORT}/api/status`);
-	expect(((await after.json()) as { masterKeyState: string }).masterKeyState).toBe('unlocked');
 });


### PR DESCRIPTION
## What & why

Hezo currently proves admin identity solely with the 12-word master key, and while the instance is unlocked **any tokenless request is accepted as the bootstrap admin** — so it can't safely sit on a public network without re-entering the master key constantly.

This PR adds a **per-admin password**. The master key now only *unlocks the instance*; a **password authenticates each session**, and **anonymous access is removed** (HTTP *and* WebSocket). The intended deployment is: set `HEZO_MASTER_KEY` so the instance auto-unlocks on restart, while users still sign in with a password.

## Auth model

- **The password never touches the network.** The browser derives an Ed25519 keypair from `scrypt(password, salt)`; the server stores only a **verifier** (`users.password_salt` + `users.password_public_key`) and authenticates challenge-response, mirroring the mnemonic. New shared crypto: `derivePasswordKeyPair`, `generatePasswordSalt`, and domain-separated password messages.
- **The master key only unlocks.** `/auth/setup` and `/auth/verify` return a short-lived **password-setup-scoped** JWT — never a session; `verifyToken` rejects that scope on every general route. A **session** is minted only by the password.
- **New routes:** `POST /auth/password-challenge`, `POST /auth/password-verify` (in-memory brute-force throttle), and `POST /auth/password` (accepts a session *or* the scoped token → enrolls a verifier → returns a session). This is also the **forgot-password** path: re-enter the master key → scoped token → set a new password.
- Removed the anonymous-admin branch in `authMiddleware` and the anonymous WebSocket path in `index.ts`. `/api/status` now exposes `passwordSet`; the web gate uses a `/api/me` session probe.

## Migration 013 (code migration)

Adds the verifier columns and **backfills existing installations** with the default admin password `"password"` so operators can sign in immediately after upgrading — with a prominent prompt to change it. A fresh DB has no users at migration time, so the backfill is a no-op there.

## Web

- **Pre-active "vault" master-key screens** (setup + unlock): a distinct always-dark palette (`.vault-surface`) that reads as "instance not live yet", improved copy, and a **vertical-blind unlock reveal** animation (honors `prefers-reduced-motion`).
- **Session-first gate:** a valid session → app; otherwise `passwordSet` chooses the password login vs. the create-password flow.
- **3-step onboarding:** master key → create password → AI provider.
- Password login screen with a "Forgot password? Use your master key" recovery path.

## Docs

Updated `.dev/architecture.md` (§ Auth), `docs/security/master-key.md`, `docs/getting-started/first-run.md`, and `docs/deployment/secure-remote-access.md` — including the default-password-on-upgrade behavior and the public-deploy story.

## Testing

- **Shared:** unit tests for the new crypto (deterministic derivation, per-salt separation, signature round-trip).
- **Server:** new `auth-password.test.ts` (challenge/verify login, wrong-password rejection, throttle, enroll/change, scoped-token can't hit general routes, mnemonic recovery, `passwordSet`) and `migrate-013-user-password.test.ts` (columns added, rows preserved, default verifier validates). Updated `auth-routes` / `auth-middleware` for the new model. Full server suite green (the only failure is a pre-existing `ssh-keygen`-missing environment test).
- **Web:** new `password-auth.test.tsx` (login, recovery, create-password) plus updated `auth` / master-key specs.
- **Browser:** the `master-key-gate` Playwright spec passes end-to-end: setup → password → provider, then restart → unlock → password login → sign in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DhVoigmKr7eGmWxUEeLj7

---
_Generated by [Claude Code](https://claude.ai/code/session_013DhVoigmKr7eGmWxUEeLj7)_