### PR TITLE
fix(web): pre-fill the goal editor Deadline field from target_date

### DIFF
--- a/packages/web/src/components/create-goal-dialog.tsx
+++ b/packages/web/src/components/create-goal-dialog.tsx
@@ -26,6 +26,21 @@ const textareaClass =
 	'rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-text-1 outline-none focus:border-border-strong';
 
 /**
+ * Normalize a goal's `target_date` into the `YYYY-MM-DD` value an `<input type="date">`
+ * requires. `target_date` is a SQL `DATE` that serializes over the API as a UTC-midnight
+ * ISO timestamp (e.g. "2026-09-30T00:00:00.000Z"); feeding that straight into a date input
+ * leaves the field blank because the control only parses a bare calendar date. Take the UTC
+ * calendar day, which is exactly the stored date. Returns '' for a missing/unparseable value.
+ */
+function toDateInputValue(value: string | null | undefined): string {
+	if (!value) return '';
+	if (/^\d{4}-\d{2}-\d{2}$/.test(value)) return value;
+	const d = new Date(value);
+	if (Number.isNaN(d.getTime())) return '';
+	return d.toISOString().slice(0, 10);
+}
+
+/**
  * A field label row pairing the label text with an info tooltip suffix icon. Renders a `<span>` by
  * default (for fields whose control is wrapped by an outer `<label>`); pass `htmlFor` to render an
  * explicit `<label htmlFor>` instead (for controls that aren't a plain DOM element child).
@@ -80,7 +95,7 @@ export function CreateGoalDialog({ projectId, open, onOpenChange, goal }: Create
 		setMeasurement(goal?.measurement ?? '');
 		setActions(goal?.actions ?? '');
 		setCheckFrequency((goal?.check_frequency as GoalCheckFrequency) ?? GoalCheckFrequency.Daily);
-		setTargetDate(goal?.target_date ?? '');
+		setTargetDate(toDateInputValue(goal?.target_date));
 	}, [open, goal]);
 
 	async function handleSubmit(e: React.FormEvent) {

--- a/packages/web/test/goals.test.tsx
+++ b/packages/web/test/goals.test.tsx
@@ -217,6 +217,40 @@ test('clicking a goal opens its page with breadcrumbs, run feed, and edit modal'
 	await findByText('Edit Goal');
 });
 
+test('the edit dialog pre-fills the Deadline field from a goal saved with a target date', async () => {
+	let projectSlug = '';
+	const { findByTestId, findByText, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Deadline Demo' });
+			projectSlug = project.slug;
+			await seedGoal(ws, project, {
+				title: 'Reach 10k stars on GitHub',
+				measurement: '10k GitHub stars',
+				target_date: '2026-09-30',
+			});
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/goals',
+		params: { projectId: projectSlug },
+	});
+
+	// Open the edit dialog from the goal card's pencil button.
+	await user.click(await findByTestId('goal-edit', undefined, { timeout: 10_000 }));
+	await findByText('Edit Goal');
+
+	// The Deadline <input type="date"> must be seeded with the goal's bare calendar date. A SQL
+	// DATE serializes over the API as a UTC-midnight ISO timestamp ("2026-09-30T00:00:00.000Z"),
+	// which a date input can't parse — feeding it raw left the field blank on edit.
+	await waitFor(() => {
+		const dateInput = document.body.querySelector<HTMLInputElement>('input[type="date"]');
+		expect(dateInput?.value).toBe('2026-09-30');
+	});
+});
+
 test('the goal detail blurb linkifies task identifiers and markdown PR links', async () => {
 	let projectSlug = '';
 	let goalId = '';


### PR DESCRIPTION
## Summary

The goal card shows a deadline (e.g. **"Deadline: 30 Sept 2026"**), but opening the **Edit Goal** dialog left the **Deadline** field blank (`dd/mm/yyyy`). This fixes the pre-fill so the editor shows the goal's existing deadline.

## Root cause

A goal's `target_date` is a SQL `DATE`. PGlite returns a `DATE` column as a JS `Date`, so the API serializes it as a **UTC-midnight ISO timestamp** — `"2026-09-30T00:00:00.000Z"`.

- The **card** formats that fine via `toLocaleDateString(...)`, so the deadline displays correctly.
- The **edit dialog** seeds it straight into an `<input type="date">`, whose `value` only accepts a bare `YYYY-MM-DD`. Given a full timestamp the control renders **blank** — so editing a goal wiped the visible deadline.

Verified empirically that PGlite serializes a `DATE` as `2026-09-30T00:00:00.000Z`, and that an `<input type="date">` blanks a non-`YYYY-MM-DD` value.

## Fix

`packages/web/src/components/create-goal-dialog.tsx` — a small `toDateInputValue()` helper normalizes `target_date` to its **UTC calendar day** before seeding the date input. That's exactly the stored date, so it round-trips unchanged on save (the input already emits `YYYY-MM-DD` on change; the write path is untouched). The helper passes through an already-bare `YYYY-MM-DD` and returns `''` for a missing/unparseable value.

This is the only `<input type="date">` in the web app, so no other surface has the same latent bug.

## Testing

- Added a component-tier regression test in `packages/web/test/goals.test.tsx`: seed a goal with `target_date: '2026-09-30'`, open the edit dialog, and assert the Deadline input is pre-filled with `2026-09-30`. Confirmed it **fails without the fix** (value `''`, matching the reported blank field) and **passes with it**.
- Full `goals.test.tsx` (15 tests) green; `bunx biome check` and `turbo typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MmbdJjycrmQzzJQWpqtLPk

---
_Generated by [Claude Code](https://claude.ai/code/session_01MmbdJjycrmQzzJQWpqtLPk)_