### PR TITLE
feat(web): float document action buttons and jump to first review comment

### DIFF
--- a/docs/concepts/documents-and-memory.md
+++ b/docs/concepts/documents-and-memory.md
@@ -93,10 +93,12 @@ ways to comment:
 Each comment shows as an icon in the right margin, level with its highlighted text. Click a
 highlight or its icon to **edit or delete** that comment. The review controls are grouped
 together into their own **review toolbar** above the document — set apart from the document's
-own edit and delete actions so the two don't get mixed up. It shows a comment count plus two
-actions — **action this review** (a clipboard button that copies a ready-made handoff you can
-paste into a task comment or a new task's description when assigning the work to an agent) and
-**clear review** (a trash button that deletes every comment after confirmation) — alongside a
+own edit and delete actions so the two don't get mixed up. Both the toolbar and those edit and
+delete actions **stay pinned to the top while you scroll**, so they're always in reach in a long
+document. The toolbar shows a comment count — **click the count to jump to the first comment** —
+plus two actions: **action this review** (a clipboard button that copies a ready-made handoff you
+can paste into a task comment or a new task's description when assigning the work to an agent) and
+**clear review** (a trash button that deletes every comment after confirmation), alongside a
 **?** button that opens a short in-app guide to all of this.
 
 Agents read pending review comments directly: `read_project_doc` returns them alongside the

--- a/packages/web/src/components/docs-library.tsx
+++ b/packages/web/src/components/docs-library.tsx
@@ -220,7 +220,13 @@ export function DocsLibrary({
 				) : (
 					<div className="flex flex-col">
 						{viewerBanner}
-						<div className="flex items-center justify-between gap-2 mb-4 pb-3 border-b border-border-subtle">
+						{/* Sticky so the document actions (edit / delete / review toolbar)
+						    stay reachable while a long document scrolls. It docks to the top
+						    of the shell <main> scroller; `bg-bg` matches the content
+						    background so scrolled text passes cleanly underneath, and the
+						    z-index sits below the review overlays (selection pill z-20,
+						    editor z-30) so an open comment editor is never hidden. */}
+						<div className="sticky top-0 z-10 flex items-center justify-between gap-2 mb-4 pt-2 pb-3 bg-bg border-b border-border-subtle">
 							<h2 className="text-base font-semibold text-text-1 truncate">
 								{docTitle ?? selectedItem?.label ?? selectedKey}
 							</h2>

--- a/packages/web/src/components/document-review/review-toolbar-actions.tsx
+++ b/packages/web/src/components/document-review/review-toolbar-actions.tsx
@@ -41,6 +41,16 @@ export function ReviewToolbarActions({
 	const [confirmClearOpen, setConfirmClearOpen] = useState(false);
 	const count = comments?.length ?? 0;
 
+	// Jump to the first review comment in the document. The highlights live in the
+	// rendered body — a sibling surface, not a child of this toolbar — so reach
+	// them through the document. `querySelector` returns the first match in
+	// document order — the topmost comment; `block: 'center'` keeps it clear of the
+	// sticky document-action header docked at the top of the scroller.
+	function scrollToFirstComment() {
+		const first = document.querySelector('mark[data-review-id]');
+		first?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+	}
+
 	const containerClasses =
 		variant === 'grouped'
 			? 'flex shrink-0 items-center gap-1 rounded-lg border border-border bg-surface-2 px-1.5 py-0.5'
@@ -49,14 +59,18 @@ export function ReviewToolbarActions({
 	return (
 		<div className={containerClasses} data-testid="review-toolbar">
 			{count > 0 && (
-				<span
-					className="inline-flex items-center gap-1 rounded-full bg-neutral-soft px-2 py-0.5 text-[11px] font-medium text-neutral-soft-fg"
-					data-testid="review-count-chip"
-					title={`${count} review comment${count === 1 ? '' : 's'}`}
-				>
-					<MessageSquare className="h-3 w-3" />
-					{count}
-				</span>
+				<Tooltip content="Jump to the first review comment">
+					<button
+						type="button"
+						aria-label={`Jump to the first of ${count} review comment${count === 1 ? '' : 's'}`}
+						data-testid="review-count-chip"
+						onClick={scrollToFirstComment}
+						className="inline-flex cursor-pointer items-center gap-1 rounded-full bg-neutral-soft px-2 py-0.5 text-[11px] font-medium text-neutral-soft-fg transition-colors hover:bg-surface-3 hover:text-text-1"
+					>
+						<MessageSquare className="h-3 w-3" />
+						{count}
+					</button>
+				</Tooltip>
 			)}
 			<Tooltip content="Action this review — copy a handoff for an agent">
 				<button

--- a/packages/web/test/document-review.test.tsx
+++ b/packages/web/test/document-review.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, waitFor } from '@testing-library/react';
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 import { getTestContext, renderApp } from './helpers/render';
 import {
 	type SeededProject,
@@ -110,6 +110,40 @@ test('renders seeded review comments as highlights with margin icons and a count
 	// Margin icons (one per comment) and the count chip.
 	expect(container.querySelectorAll('[data-testid="review-margin-icon"]').length).toBe(2);
 	expect((await findByTestId('review-count-chip')).textContent).toContain('2');
+});
+
+test('clicking the count chip scrolls to the first review comment in the document', async () => {
+	const { container, findByTestId, user } = await setupDocumentsPage({
+		comments: [
+			// 'Spec Title' anchors into the H1 (topmost); 'target text' is lower in
+			// the first paragraph. The chip must jump to the FIRST — the topmost.
+			{ quote: 'target text', comment: 'lower comment' },
+			{ quote: 'Spec Title', comment: 'top comment' },
+		],
+	});
+
+	await waitFor(() => {
+		expect(container.querySelectorAll('mark[data-review-id]').length).toBe(2);
+	});
+	const firstMark = container.querySelector('mark[data-review-id]');
+	expect(firstMark?.textContent).toBe('Spec Title');
+
+	// happy-dom's scrollIntoView is a no-op with no layout, so assert the wiring:
+	// the chip scrolls the topmost highlight into view. Real scroll movement +
+	// the sticky-header clearance are covered in test/browser/docs-actions-sticky.spec.ts.
+	const scrolled: Element[] = [];
+	const spy = vi.spyOn(Element.prototype, 'scrollIntoView').mockImplementation(function (
+		this: Element,
+	) {
+		scrolled.push(this);
+	});
+	try {
+		await user.click(await findByTestId('review-count-chip'));
+		expect(scrolled).toHaveLength(1);
+		expect(scrolled[0]).toBe(firstMark);
+	} finally {
+		spy.mockRestore();
+	}
 });
 
 test('groups the review-comment controls in a bordered cluster, apart from the document actions', async () => {

--- a/test/browser/docs-actions-sticky.spec.ts
+++ b/test/browser/docs-actions-sticky.spec.ts
@@ -1,0 +1,135 @@
+// Real-CSS-layout + scroll-position assertions (testing decision tree, point 1):
+// the floating document-action header depends on `position: sticky` resolving
+// against the shell <main> scroller and its box staying put on scroll, and the
+// count-chip jump depends on `scrollIntoView` actually moving the viewport onto
+// the highlight — values happy-dom can't compute. So this lives in Playwright.
+// The chip-click wiring itself is covered in packages/web/test/document-review.test.tsx.
+
+import { expect, test } from './fixtures';
+import { waitForPageLoad } from './helpers';
+
+const DOC = 'sticky-actions.md';
+
+// A document long enough that its content column overflows the viewport, so
+// reaching the bottom requires scrolling the shell <main>.
+const LONG_CONTENT = `# Long document\n\n${Array.from(
+	{ length: 150 },
+	(_, i) => `## Section ${i}\n\nParagraph body for section ${i}.`,
+).join('\n\n')}`;
+
+async function seedDoc(
+	page: import('@playwright/test').Page,
+	projectSlug: string,
+	token: string,
+	content: string,
+): Promise<void> {
+	const res = await page.request.put(`/api/projects/${projectSlug}/docs/${DOC}`, {
+		headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+		data: { content },
+	});
+	expect(res.ok()).toBe(true);
+}
+
+async function seedComment(
+	page: import('@playwright/test').Page,
+	projectSlug: string,
+	token: string,
+	quote: string,
+): Promise<void> {
+	const res = await page.request.post(`/api/projects/${projectSlug}/docs/${DOC}/review-comments`, {
+		headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+		data: { quote, occurrence: 0, comment: `Comment on ${quote}` },
+	});
+	expect(res.ok()).toBe(true);
+}
+
+for (const { name, width, height } of [
+	{ name: 'desktop', width: 1280, height: 800 },
+	{ name: 'mobile', width: 375, height: 800 },
+]) {
+	test(`${name}: the document actions stay pinned while the page scrolls`, async ({
+		page,
+		lightWorkspace,
+	}) => {
+		const { projectSlug, token } = lightWorkspace;
+		await page.setViewportSize({ width, height });
+		await seedDoc(page, projectSlug, token, LONG_CONTENT);
+		// A review comment so the whole action cluster — the review toolbar plus the
+		// edit/delete controls — is present in the header we expect to stay pinned.
+		await seedComment(page, projectSlug, token, 'Long document');
+
+		await page.goto(`/projects/${projectSlug}/documents?file=${DOC}`);
+		await waitForPageLoad(page);
+		await expect(page.getByRole('heading', { name: DOC })).toBeVisible({ timeout: 20000 });
+
+		const editButton = page.getByRole('button', { name: 'Edit' });
+		const reviewToolbar = page.getByTestId('review-toolbar');
+		await expect(editButton).toBeVisible();
+		await expect(reviewToolbar).toBeVisible();
+
+		// Scroll the shell scroller to the bottom.
+		const scroller = page.locator('main').first();
+		await scroller.evaluate((el) => el.scrollTo({ top: el.scrollHeight }));
+		const scrollTop = await scroller.evaluate((el) => el.scrollTop);
+		// Proves the content genuinely overflowed and we scrolled a meaningful amount.
+		expect(scrollTop).toBeGreaterThan(300);
+
+		// The actions are still visible near the top of the viewport (pinned). Without
+		// sticky they would be thousands of px above the fold (y << 0) after scrolling.
+		await expect(editButton).toBeVisible();
+		await expect(reviewToolbar).toBeVisible();
+		const editBox = await editButton.boundingBox();
+		const toolbarBox = await reviewToolbar.boundingBox();
+		expect(editBox).not.toBeNull();
+		expect(toolbarBox).not.toBeNull();
+		if (editBox) {
+			expect(editBox.y).toBeGreaterThanOrEqual(0);
+			// Docked within the app header + a small offset of the top.
+			expect(editBox.y).toBeLessThan(150);
+		}
+		if (toolbarBox) {
+			expect(toolbarBox.y).toBeGreaterThanOrEqual(0);
+			expect(toolbarBox.y).toBeLessThan(150);
+		}
+	});
+}
+
+test('clicking the review count chip scrolls the first comment into view', async ({
+	page,
+	lightWorkspace,
+}) => {
+	const { projectSlug, token } = lightWorkspace;
+	await page.setViewportSize({ width: 1280, height: 800 });
+
+	// A unique target buried below a tall block of filler, so it starts well below
+	// the fold and only a real scroll can bring it into view.
+	const target = 'Zulu-Jump-Target-Marker';
+	const content = [
+		'# Jump document',
+		'',
+		...Array.from({ length: 60 }, (_, i) => `Filler paragraph number ${i} to push things down.`),
+		'',
+		`Paragraph containing the ${target} to jump to.`,
+		'',
+		...Array.from({ length: 30 }, (_, i) => `Trailing filler paragraph number ${i}.`),
+	].join('\n\n');
+	await seedDoc(page, projectSlug, token, content);
+	await seedComment(page, projectSlug, token, target);
+
+	await page.goto(`/projects/${projectSlug}/documents?file=${DOC}`);
+	await waitForPageLoad(page);
+	await expect(page.getByRole('heading', { name: DOC })).toBeVisible({ timeout: 20000 });
+
+	const mark = page.locator('mark[data-review-id]');
+	await expect(mark).toHaveText(target, { timeout: 15000 });
+
+	// The chip lives in the always-visible sticky header; the target starts off-screen.
+	const chip = page.getByTestId('review-count-chip');
+	await expect(chip).toBeVisible();
+	await expect(mark).not.toBeInViewport();
+
+	await chip.click();
+
+	// Clicking the chip brings the first (here: only) comment into view.
+	await expect(mark).toBeInViewport({ timeout: 10000 });
+});


### PR DESCRIPTION
## What & why

On the project **Documents** page, the document-action header (the title plus the edit / delete controls and the review toolbar) scrolled away with the content, so on a long document the actions were out of reach unless you scrolled back to the top. This pins that header so the actions stay visible.

It also makes the review **comment-count chip** actionable: clicking it jumps to the first review comment in the document — a quick way to reach the review from the top of a long doc.

## Changes

- **Sticky action header** (`docs-library.tsx`): the header docks to the top of the shell `<main>` scroller with `sticky top-0`. It uses `bg-bg` to match the content background so scrolled text passes cleanly underneath, and a `z-10` that sits below the review overlays (selection pill `z-20`, comment editor `z-30`) so an open comment editor is never hidden. Works in both view and edit mode (Save/Cancel stay reachable too).
- **Clickable count chip** (`review-toolbar-actions.tsx`): the count is now a `<button>` that scrolls the first review comment (the topmost `mark[data-review-id]`) into view with `block: 'center'`, so it clears the now-sticky header. It carries a tooltip + `aria-label` and a hover affordance. This applies on every surface that renders the review toolbar (Documents page and the pop-out preview).
- **Docs**: updated `docs/concepts/documents-and-memory.md` to describe the pinned toolbar and the click-to-jump count.

## Testing

- **Component** (`packages/web/test/document-review.test.tsx`): new test asserts clicking the count chip invokes `scrollIntoView` on the topmost highlight (the wiring; happy-dom has no layout). All 11 tests in the file pass.
- **Browser** (`test/browser/docs-actions-sticky.spec.ts`, new): the action header stays pinned after scrolling to the bottom — verified at **desktop (1280px)** and **mobile (375px)** — and clicking the count chip scrolls an off-screen comment into view (real `position: sticky` + scroll behaviour → Playwright per the testing decision tree). All 3 pass, and the existing `document-review` / `docs-sidebar-sticky` / `docs-content-fit` specs still pass.
- Typecheck + biome clean; pre-commit build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGuVZEszPMjZuZ4JyrhMpG

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGuVZEszPMjZuZ4JyrhMpG)_