### PR TITLE
Add per-provider "how to get an API key" instructions to the provider connect form

### DIFF
--- a/docs/ai-models.md
+++ b/docs/ai-models.md
@@ -40,6 +40,24 @@ sign-in** (for example Claude Pro/Max, ChatGPT, or Gemini) — so you can put an
 existing plan to work instead of paying per token. You choose the method when you
 connect the provider.
 
+## Where to get an API key
+
+Each provider issues API keys from its own console. When you connect a provider, the
+form in Hezo walks you through these same steps inline.
+
+| Provider | Create your key at | Billing |
+|---|---|---|
+| **Anthropic** | [Claude Console → API keys](https://platform.claude.com/settings/keys) | Prepaid credits, billed per token |
+| **OpenAI** | [OpenAI Platform → API keys](https://platform.openai.com/api-keys) | Billed per token; add a payment method first (separate from ChatGPT) |
+| **Google** | [Google AI Studio → API keys](https://aistudio.google.com/apikey) | Free tier with strict rate limits; enable billing on the key's Google Cloud project for sustained use |
+| **Kimi** (Moonshot) | [Kimi Open Platform → API keys](https://platform.kimi.ai/console/api-keys) | Prepaid balance |
+| **DeepSeek** | [DeepSeek Platform → API keys](https://platform.deepseek.com/api_keys) | Prepaid balance |
+| **Z.ai** | [Z.ai platform → API keys](https://z.ai/manage-apikey/apikey-list) | Prepaid balance ([billing page](https://z.ai/manage-apikey/billing)) |
+
+Most consoles show a newly created key **only once** — copy it right away and paste it
+into Hezo, which stores it encrypted. Providers billed per token generally need a
+positive balance before agents can run.
+
 ## Use more than one
 
 You can connect **several providers at once** and keep them all available. That's

--- a/docs/getting-started/first-run.md
+++ b/docs/getting-started/first-run.md
@@ -38,7 +38,9 @@ If you ever forget it, reset it with your master key from the sign-in screen. Se
 
 Agents need a model to run. Add at least one **AI provider** — paste an API key (or
 connect a subscription where supported) for Anthropic (Claude), OpenAI (ChatGPT),
-Google (Gemini), DeepSeek, Z.ai, or Kimi.
+Google (Gemini), DeepSeek, Z.ai, or Kimi. Don't have a key yet? The connect form walks
+you through creating one, with links to each provider's key console (also listed in
+[AI model support](/docs/ai-models)).
 
 You can add more than one provider and switch between them later, including giving an
 individual agent its own model. See [AI model support](/docs/ai-models).

--- a/packages/web/src/components/api-key-instructions.tsx
+++ b/packages/web/src/components/api-key-instructions.tsx
@@ -1,0 +1,186 @@
+import { AiProvider } from '@hezo/shared';
+import {
+	InstructionsBox,
+	InstructionsLink,
+	type ProviderInstructionContent,
+} from './provider-instructions';
+
+/**
+ * Per-provider "how to get an API key" walkthroughs, each linking to the
+ * provider's own key console. Deliberately a full record (not Partial): adding
+ * a provider without its key instructions should fail the typecheck.
+ */
+export const API_KEY_INSTRUCTIONS: Record<AiProvider, ProviderInstructionContent> = {
+	[AiProvider.Anthropic]: {
+		title: 'How to get your Anthropic API key',
+		steps: [
+			<>
+				Sign in to the{' '}
+				<InstructionsLink href="https://platform.claude.com/">Claude Console</InstructionsLink> (or
+				create an account).
+			</>,
+			<>
+				Open{' '}
+				<InstructionsLink href="https://platform.claude.com/settings/keys">
+					Settings → API keys
+				</InstructionsLink>{' '}
+				and click <strong>Create key</strong>.
+			</>,
+			<>
+				Copy the key (starts with <code>sk-ant-</code>) and paste it below — it's only shown once.
+			</>,
+		],
+		footer: (
+			<>
+				API usage is billed per token from prepaid credits — add credits under the Console's Billing
+				settings. Have a Claude Pro or Max plan? Use the <strong>Claude Code subscription</strong>{' '}
+				option above instead.
+			</>
+		),
+	},
+	[AiProvider.OpenAI]: {
+		title: 'How to get your OpenAI API key',
+		steps: [
+			<>
+				Sign in to the{' '}
+				<InstructionsLink href="https://platform.openai.com/">OpenAI Platform</InstructionsLink> (or
+				create an account).
+			</>,
+			<>
+				Open the{' '}
+				<InstructionsLink href="https://platform.openai.com/api-keys">API keys</InstructionsLink>{' '}
+				page and click <strong>Create new secret key</strong>.
+			</>,
+			<>
+				Copy the key (starts with <code>sk-</code>) and paste it below — it's only shown once.
+			</>,
+		],
+		footer: (
+			<>
+				API usage is billed separately from ChatGPT — add a payment method under the platform's
+				Billing settings. Have a ChatGPT Plus or Pro plan? Use the{' '}
+				<strong>Codex subscription</strong> option above instead.
+			</>
+		),
+	},
+	[AiProvider.Google]: {
+		title: 'How to get your Gemini API key',
+		steps: [
+			<>
+				Open{' '}
+				<InstructionsLink href="https://aistudio.google.com/apikey">
+					Google AI Studio → API keys
+				</InstructionsLink>{' '}
+				and sign in with your Google account.
+			</>,
+			<>
+				Click <strong>Create API key</strong> and pick (or create) the Google Cloud project the key
+				should live in.
+			</>,
+			<>
+				Copy the key (starts with <code>AIza</code>) and paste it below.
+			</>,
+		],
+		footer: (
+			<>
+				AI Studio keys start on a free tier with strict rate limits — enable billing on the key's
+				Google Cloud project for sustained agent use. Have a Google AI Pro/Ultra plan? Use the{' '}
+				<strong>Gemini subscription</strong> option above instead.
+			</>
+		),
+	},
+	[AiProvider.DeepSeek]: {
+		title: 'How to get your DeepSeek API key',
+		steps: [
+			<>
+				Sign in to the{' '}
+				<InstructionsLink href="https://platform.deepseek.com/">DeepSeek Platform</InstructionsLink>{' '}
+				(or create an account).
+			</>,
+			<>
+				Open{' '}
+				<InstructionsLink href="https://platform.deepseek.com/api_keys">API keys</InstructionsLink>{' '}
+				and click <strong>Create new API key</strong>.
+			</>,
+			<>Copy the key and paste it below — it's only shown once.</>,
+		],
+		footer: (
+			<>The DeepSeek API is prepaid — top up your balance on the platform before agents run.</>
+		),
+	},
+	[AiProvider.ZAi]: {
+		title: 'How to get your Z.ai API key',
+		steps: [
+			<>
+				Register or sign in on the{' '}
+				<InstructionsLink href="https://z.ai/model-api">Z.ai API platform</InstructionsLink>.
+			</>,
+			<>
+				Open the{' '}
+				<InstructionsLink href="https://z.ai/manage-apikey/apikey-list">API keys</InstructionsLink>{' '}
+				page and click <strong>Create a new API key</strong>.
+			</>,
+			<>Copy the key and paste it below.</>,
+		],
+		footer: (
+			<>
+				Usage is billed from your prepaid balance — top up on the{' '}
+				<InstructionsLink href="https://z.ai/manage-apikey/billing">Billing</InstructionsLink> page
+				if needed.
+			</>
+		),
+	},
+	[AiProvider.OpenRouter]: {
+		title: 'How to get your OpenRouter API key',
+		steps: [
+			<>
+				Sign in at <InstructionsLink href="https://openrouter.ai/">OpenRouter</InstructionsLink> (or
+				create an account).
+			</>,
+			<>
+				Open{' '}
+				<InstructionsLink href="https://openrouter.ai/settings/keys">
+					Settings → API keys
+				</InstructionsLink>{' '}
+				and click <strong>Create key</strong>.
+			</>,
+			<>
+				Copy the key (starts with <code>sk-or-</code>) and paste it below — it's only shown once.
+			</>,
+		],
+		footer: (
+			<>
+				One OpenRouter key routes to models from many labs. Usage is prepaid — buy credits in your
+				OpenRouter account before agents run.
+			</>
+		),
+	},
+	[AiProvider.Kimi]: {
+		title: 'How to get your Kimi API key',
+		steps: [
+			<>
+				Sign in to the{' '}
+				<InstructionsLink href="https://platform.kimi.ai/">Kimi Open Platform</InstructionsLink>{' '}
+				(Moonshot AI's developer console).
+			</>,
+			<>
+				Open{' '}
+				<InstructionsLink href="https://platform.kimi.ai/console/api-keys">
+					API keys
+				</InstructionsLink>{' '}
+				and click <strong>Create API key</strong>.
+			</>,
+			<>
+				Copy the key (starts with <code>sk-</code>) and paste it below.
+			</>,
+		],
+		footer: (
+			<>The Kimi API is prepaid — top up a small balance on the platform before agents run.</>
+		),
+	},
+};
+
+/** The gray, provider-specific "how to get your API key" box. */
+export function ApiKeyInstructions({ provider }: { provider: AiProvider }) {
+	return <InstructionsBox content={API_KEY_INSTRUCTIONS[provider]} />;
+}

--- a/packages/web/src/components/provider-config-form.tsx
+++ b/packages/web/src/components/provider-config-form.tsx
@@ -6,6 +6,7 @@ import {
 	useAiProviders,
 	useCreateAiProvider,
 } from '../hooks/use-ai-providers';
+import { ApiKeyInstructions } from './api-key-instructions';
 import { SUBSCRIPTION_INSTRUCTIONS, SubscriptionInstructions } from './subscription-paste-form';
 import { Button } from './ui/button';
 import { Input } from './ui/input';
@@ -164,13 +165,16 @@ export function ProviderConfigForm({
 					/>
 				</div>
 			) : (
-				<Input
-					label="API key"
-					type="password"
-					placeholder={info.keyPlaceholder}
-					value={apiKey}
-					onChange={(e) => setApiKey(e.target.value)}
-				/>
+				<div className="flex flex-col gap-2">
+					<ApiKeyInstructions provider={provider} />
+					<Input
+						label="API key"
+						type="password"
+						placeholder={info.keyPlaceholder}
+						value={apiKey}
+						onChange={(e) => setApiKey(e.target.value)}
+					/>
+				</div>
 			)}
 
 			{error && <p className="text-[13px] text-danger">{error}</p>}

--- a/packages/web/src/components/provider-instructions.tsx
+++ b/packages/web/src/components/provider-instructions.tsx
@@ -1,0 +1,42 @@
+import type { ReactNode } from 'react';
+
+/** One provider's "how to get your credential" walkthrough. */
+export interface ProviderInstructionContent {
+	title: string;
+	steps: ReactNode[];
+	footer: ReactNode;
+}
+
+/** External link used inside instruction steps (opens the provider console in a new tab). */
+export function InstructionsLink({ href, children }: { href: string; children: ReactNode }) {
+	return (
+		<a
+			href={href}
+			target="_blank"
+			rel="noopener noreferrer"
+			className="text-info-soft-fg hover:underline"
+		>
+			{children}
+		</a>
+	);
+}
+
+/**
+ * The gray, provider-specific instructions box rendered above a credential
+ * input. Shared by the API-key and subscription flavours of the provider
+ * connect form.
+ */
+export function InstructionsBox({ content }: { content: ProviderInstructionContent }) {
+	return (
+		<div className="rounded-md border border-border bg-surface-2 p-3 text-[13px] text-text-2">
+			<p className="font-medium text-text-1 mb-2">{content.title}</p>
+			<ol className="list-decimal pl-5 space-y-1">
+				{content.steps.map((step, i) => (
+					// biome-ignore lint/suspicious/noArrayIndexKey: instruction list is static
+					<li key={i}>{step}</li>
+				))}
+			</ol>
+			<p className="mt-2">{content.footer}</p>
+		</div>
+	);
+}

--- a/packages/web/src/components/subscription-paste-form.tsx
+++ b/packages/web/src/components/subscription-paste-form.tsx
@@ -1,10 +1,7 @@
 import { AiProvider } from '@hezo/shared';
-import type { ReactNode } from 'react';
+import { InstructionsBox, type ProviderInstructionContent } from './provider-instructions';
 
-interface ProviderInstructions {
-	title: string;
-	steps: ReactNode[];
-	footer: ReactNode;
+interface ProviderInstructions extends ProviderInstructionContent {
 	placeholder: string;
 }
 
@@ -93,16 +90,5 @@ export const SUBSCRIPTION_INSTRUCTIONS: Partial<Record<AiProvider, ProviderInstr
 export function SubscriptionInstructions({ provider }: { provider: AiProvider }) {
 	const instructions = SUBSCRIPTION_INSTRUCTIONS[provider];
 	if (!instructions) return null;
-	return (
-		<div className="rounded-md border border-border bg-surface-2 p-3 text-[13px] text-text-2">
-			<p className="font-medium text-text-1 mb-2">{instructions.title}</p>
-			<ol className="list-decimal pl-5 space-y-1">
-				{instructions.steps.map((step, i) => (
-					// biome-ignore lint/suspicious/noArrayIndexKey: instruction list is static
-					<li key={i}>{step}</li>
-				))}
-			</ol>
-			<p className="mt-2">{instructions.footer}</p>
-		</div>
-	);
+	return <InstructionsBox content={instructions} />;
 }

--- a/packages/web/test/ai-provider-key-instructions.test.tsx
+++ b/packages/web/test/ai-provider-key-instructions.test.tsx
@@ -1,0 +1,91 @@
+import { waitFor, within } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+
+// Every provider offered by the Add-provider picker, with the key-console URL
+// its instructions box must link to. Mirrors ADD_PROVIDER_ORDER; the URLs are
+// each provider's own documented key-management page.
+const EXPECTED_KEY_LINKS: ReadonlyArray<{ card: string; title: RegExp; href: string }> = [
+	{
+		card: 'DeepSeek',
+		title: /How to get your DeepSeek API key/i,
+		href: 'https://platform.deepseek.com/api_keys',
+	},
+	{
+		card: 'z.ai',
+		title: /How to get your Z\.ai API key/i,
+		href: 'https://z.ai/manage-apikey/apikey-list',
+	},
+	{
+		card: 'Anthropic',
+		title: /How to get your Anthropic API key/i,
+		href: 'https://platform.claude.com/settings/keys',
+	},
+	{
+		card: 'OpenAI',
+		title: /How to get your OpenAI API key/i,
+		href: 'https://platform.openai.com/api-keys',
+	},
+	{
+		card: 'Google',
+		title: /How to get your Gemini API key/i,
+		href: 'https://aistudio.google.com/apikey',
+	},
+	{
+		card: 'Kimi',
+		title: /How to get your Kimi API key/i,
+		href: 'https://platform.kimi.ai/console/api-keys',
+	},
+];
+
+test('every pickable provider shows how-to-get-a-key instructions linking its key console', async () => {
+	const { findByRole, getByRole, user } = await renderApp({
+		initialPath: '/settings/ai-providers',
+	});
+
+	await findByRole('heading', { name: 'AI providers' });
+	await user.click(getByRole('button', { name: 'Add provider' }));
+	const dialog = await findByRole('dialog');
+
+	for (const { card, title, href } of EXPECTED_KEY_LINKS) {
+		await user.click(within(dialog).getByRole('button', { name: card }));
+
+		// The API-key mode is the default, so the instructions box renders
+		// immediately with a link to the provider's own key console.
+		await within(dialog).findByText(title);
+		await waitFor(() => {
+			const link = Array.from(dialog.querySelectorAll('a')).find(
+				(a) => a.getAttribute('href') === href,
+			);
+			if (!link) throw new Error(`No link to ${href} for ${card}`);
+			// Console links open in a new tab so the in-progress form isn't lost.
+			expect(link.getAttribute('target')).toBe('_blank');
+		});
+
+		// Back to the picker grid for the next provider.
+		await user.click(within(dialog).getByRole('button', { name: 'Back' }));
+		await within(dialog).findByRole('button', { name: card });
+	}
+});
+
+test('switching Anthropic to subscription swaps the API-key instructions for the setup-token ones', async () => {
+	const { findByRole, getByRole, user } = await renderApp({
+		initialPath: '/settings/ai-providers',
+	});
+
+	await findByRole('heading', { name: 'AI providers' });
+	await user.click(getByRole('button', { name: 'Add provider' }));
+	const dialog = await findByRole('dialog');
+
+	await user.click(within(dialog).getByRole('button', { name: 'Anthropic' }));
+	await within(dialog).findByText(/How to get your Anthropic API key/i);
+
+	await user.click(within(dialog).getByRole('button', { name: /Claude Code subscription/i }));
+	await within(dialog).findByText(/How to get your Claude subscription token/i);
+	expect(within(dialog).queryByText(/How to get your Anthropic API key/i)).toBeNull();
+
+	// And back: API-key mode restores the key instructions.
+	await user.click(within(dialog).getByRole('button', { name: 'API key' }));
+	await within(dialog).findByText(/How to get your Anthropic API key/i);
+	expect(within(dialog).queryByText(/How to get your Claude subscription token/i)).toBeNull();
+});


### PR DESCRIPTION
## What

The connect-provider form's API-key mode gave no hint where a key comes from, while subscription mode already had a step-by-step instructions box. This adds the same gray box for **API-key mode, for every provider**: three steps with links straight to the provider's own key console, plus a one-line billing note (prepaid/billing gotchas), and — for Anthropic/OpenAI/Google — a pointer to the subscription option for users who already have a plan.

All console URLs were verified against each provider's own documentation:

| Provider | Key console |
|---|---|
| Anthropic | `platform.claude.com/settings/keys` (the current Console domain — `console.anthropic.com` 301s here) |
| OpenAI | `platform.openai.com/api-keys` |
| Google | `aistudio.google.com/apikey` |
| DeepSeek | `platform.deepseek.com/api_keys` |
| Z.ai | `z.ai/manage-apikey/apikey-list` (+ billing page) |
| OpenRouter | `openrouter.ai/settings/keys` (hidden from the picker, but instructions ship for when it returns) |
| Kimi | `platform.kimi.ai/console/api-keys` (Moonshot's current console domain, per their own quickstart) |

## How

- New `API_KEY_INSTRUCTIONS` map + `ApiKeyInstructions` component (`packages/web/src/components/api-key-instructions.tsx`). It's a **full `Record<AiProvider, …>`** (not `Partial`), so adding a provider without key instructions fails the typecheck.
- The box markup is extracted from `SubscriptionInstructions` into a shared `InstructionsBox` (`provider-instructions.tsx`); both credential flavours now render through it. Links open in a new tab so the in-progress form isn't lost.
- `ProviderConfigForm` renders the box above the API-key input, mirroring the subscription branch's layout.
- Docs: `docs/ai-models.md` gains a matching "Where to get an API key" table (this reaches the CEO chat automatically via the docs bundle), and `first-run.md` mentions the inline guidance.

## Tests

- New component spec `ai-provider-key-instructions.test.tsx`: every pickable provider shows its box with the exact console href (and `target="_blank"`), and toggling Anthropic to subscription swaps the API-key box for the setup-token one (and back).
- Existing `ai-providers.test.tsx` (15 tests) passes; typecheck + biome green.
- Verified visually in the real app (desktop 1280px and mobile 375px): box renders cleanly in both auth modes for all six pickable providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SsJAkgRjhEv6AAHVyziCTA

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsJAkgRjhEv6AAHVyziCTA)_