### PR TITLE
feat: add fullscreen toggle to create-task dialog

### DIFF
--- a/packages/web/src/components/create-task-dialog.tsx
+++ b/packages/web/src/components/create-task-dialog.tsx
@@ -1,14 +1,18 @@
 import { CAPTAIN_AGENT_SLUG } from '@hezo/shared';
 import * as Dialog from '@radix-ui/react-dialog';
 import { useNavigate } from '@tanstack/react-router';
-import { ChevronDown, Loader2, X } from 'lucide-react';
+import { ChevronDown, Loader2, Maximize2, Minimize2, X } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useAgents } from '../hooks/use-agents';
 import { useAllVisibleProjects, useProjectMeta } from '../hooks/use-projects';
 import { useCreateTask } from '../hooks/use-tasks';
 import { MarkdownEditor } from './markdown-editor';
 import { Button } from './ui/button';
-import { dialogContentClassName, dialogOverlayClassName } from './ui/dialog';
+import {
+	dialogContentClassName,
+	dialogOverlayClassName,
+	fullscreenContentClassName,
+} from './ui/dialog';
 import { Input } from './ui/input';
 
 interface CreateTaskDialogProps {
@@ -34,6 +38,10 @@ export function CreateTaskDialog({
 	const [priority, setPriority] = useState('medium');
 	const [moreOpen, setMoreOpen] = useState(false);
 	const [pickedProjectId, setPickedProjectId] = useState('');
+	// Fullscreen mode grows the panel to fill the viewport (desktop only — the
+	// dialog is already near-full-screen on mobile) and lets the description
+	// occupy most of the space, mirroring the CEO chat's expand affordance.
+	const [fullscreen, setFullscreen] = useState(false);
 
 	// With `selectProject` the picker drives the target; otherwise the fixed prop does.
 	const effectiveProjectId = selectProject ? pickedProjectId : (projectId ?? '');
@@ -93,21 +101,40 @@ export function CreateTaskDialog({
 		<Dialog.Root open={open} onOpenChange={onOpenChange}>
 			<Dialog.Portal>
 				<Dialog.Overlay className={dialogOverlayClassName} />
-				<Dialog.Content className={dialogContentClassName.lg}>
-					<div className="flex items-center justify-between mb-4">
+				<Dialog.Content
+					data-fullscreen={fullscreen}
+					className={fullscreen ? fullscreenContentClassName : dialogContentClassName.lg}
+				>
+					<div className="flex items-center justify-between mb-4 shrink-0">
 						<Dialog.Title className="text-lg font-semibold">Create Task</Dialog.Title>
-						<Dialog.Close asChild>
+						<div className="flex items-center gap-1">
+							{/* Fullscreen toggle is desktop-only — the dialog already fills the
+							    screen on mobile, where the toggle would be a no-op. */}
 							<button
 								type="button"
-								className="text-text-2 hover:text-text-1 p-2 -m-2"
-								aria-label="Close"
+								onClick={() => setFullscreen((v) => !v)}
+								aria-label={fullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
+								data-testid="create-task-fullscreen"
+								className="hidden text-text-2 hover:text-text-1 p-2 -m-2 sm:block"
 							>
-								<X className="w-4 h-4" />
+								{fullscreen ? <Minimize2 className="w-4 h-4" /> : <Maximize2 className="w-4 h-4" />}
 							</button>
-						</Dialog.Close>
+							<Dialog.Close asChild>
+								<button
+									type="button"
+									className="text-text-2 hover:text-text-1 p-2 -m-2"
+									aria-label="Close"
+								>
+									<X className="w-4 h-4" />
+								</button>
+							</Dialog.Close>
+						</div>
 					</div>
 
-					<form onSubmit={handleSubmit} className="flex flex-col gap-4">
+					<form
+						onSubmit={handleSubmit}
+						className={fullscreen ? 'flex min-h-0 flex-1 flex-col gap-4' : 'flex flex-col gap-4'}
+					>
 						{selectProject && (
 							<label className="flex flex-col gap-1.5">
 								<span className="text-sm text-text-2">Project *</span>
@@ -148,6 +175,7 @@ export function CreateTaskDialog({
 							placeholder="Optional"
 							previewClassName="min-h-[72px]"
 							emptyPreviewText="_(nothing to preview)_"
+							fill={fullscreen}
 						/>
 
 						<label className="flex flex-col gap-1.5">

--- a/packages/web/src/components/markdown-editor.tsx
+++ b/packages/web/src/components/markdown-editor.tsx
@@ -87,6 +87,13 @@ interface MarkdownEditorProps {
 	/** Markdown rendered when there is nothing to preview. */
 	emptyPreviewText?: string;
 	defaultMode?: MarkdownEditorMode;
+	/**
+	 * Grow to fill the available height of a flex column (both the edit textarea
+	 * and the preview). The caller must place this editor in a `flex flex-col`
+	 * parent with a bounded height. Used by the fullscreen create-task dialog so
+	 * the description occupies most of the space.
+	 */
+	fill?: boolean;
 }
 
 const TAB_BASE = 'px-2.5 py-1 rounded';
@@ -122,6 +129,7 @@ export function MarkdownEditor({
 	previewTestId,
 	emptyPreviewText = '',
 	defaultMode = 'edit',
+	fill = false,
 }: MarkdownEditorProps) {
 	const [mode, setMode] = useState<MarkdownEditorMode>(defaultMode);
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -154,7 +162,7 @@ export function MarkdownEditor({
 	const previewBody = previewContent ?? value;
 
 	return (
-		<div>
+		<div className={fill ? 'flex min-h-0 flex-1 flex-col' : undefined}>
 			<div className="flex items-center justify-between gap-2 mb-1.5">
 				{label ? <span className={labelClassName}>{label}</span> : <span />}
 				<div
@@ -184,7 +192,7 @@ export function MarkdownEditor({
 			</div>
 
 			{mode === 'edit' ? (
-				<>
+				<div className={fill ? 'flex min-h-0 flex-1 flex-col' : 'contents'}>
 					{chips && chips.length > 0 && (
 						<div className="flex flex-wrap gap-1.5 mb-2">
 							{chips.map((chip) => (
@@ -202,14 +210,16 @@ export function MarkdownEditor({
 						placeholder={placeholder}
 						required={required}
 						rows={rows}
-						className={className}
+						containerClassName={fill ? 'relative flex min-h-0 flex-1 flex-col' : 'relative'}
+						wrapperClassName={fill ? 'flex min-h-0 flex-1 flex-col' : undefined}
+						className={fill ? `min-h-0 flex-1 resize-none ${className ?? ''}` : className}
 					/>
 					{helpText && <p className="text-xs text-text-3 mt-1">{helpText}</p>}
-				</>
+				</div>
 			) : (
 				<div
 					data-testid={previewTestId}
-					className={`${previewClassName} rounded-md border border-border bg-surface-2 px-3 py-2 text-sm`}
+					className={`${fill ? 'min-h-0 flex-1 overflow-y-auto' : previewClassName} rounded-md border border-border bg-surface-2 px-3 py-2 text-sm`}
 				>
 					{isPreviewLoading ? (
 						<div className="text-text-2 text-xs">Resolving…</div>

--- a/packages/web/src/components/mention-textarea.tsx
+++ b/packages/web/src/components/mention-textarea.tsx
@@ -10,13 +10,25 @@ interface MentionTextareaProps extends TextareaProps {
 	projectSlug?: string;
 	value: string;
 	onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+	/** Class override for the relative wrapper (e.g. `flex-1` so the textarea can
+	 *  grow to fill a flex column). Defaults to `relative`. */
+	containerClassName?: string;
 }
 
 const TOKEN_RE = /@([a-z0-9][\w-]*)?$/i;
 
 export const MentionTextarea = forwardRef<HTMLTextAreaElement, MentionTextareaProps>(
 	function MentionTextarea(
-		{ projectId, projectSlug, value, onChange, onKeyDown, onBlur, ...rest },
+		{
+			projectId,
+			projectSlug,
+			value,
+			onChange,
+			onKeyDown,
+			onBlur,
+			containerClassName = 'relative',
+			...rest
+		},
 		forwardedRef,
 	) {
 		const textareaRef = useRef<HTMLTextAreaElement | null>(null);
@@ -181,7 +193,7 @@ export const MentionTextarea = forwardRef<HTMLTextAreaElement, MentionTextareaPr
 		);
 
 		return (
-			<div className="relative">
+			<div className={containerClassName}>
 				<Textarea
 					{...rest}
 					ref={setTextareaRef}

--- a/packages/web/src/components/ui/dialog.ts
+++ b/packages/web/src/components/ui/dialog.ts
@@ -8,4 +8,13 @@ export const dialogContentClassName = {
 	xl: `${base} sm:max-w-xl`,
 } as const;
 
+/**
+ * Fullscreen dialog content: fills the viewport (with a small inset on desktop)
+ * instead of centring at a fixed max-width. `overflow-hidden` so an inner
+ * `flex flex-col` body can own its own scrolling — used by dialogs that let a
+ * field grow to fill the space (e.g. the create-task description).
+ */
+export const fullscreenContentClassName =
+	'fixed inset-0 z-50 flex flex-col bg-surface p-4 overflow-hidden outline-none sm:inset-4 sm:rounded-lg sm:border sm:border-border sm:p-6 sm:shadow-lg';
+
 export const dialogOverlayClassName = 'fixed inset-0 bg-[var(--overlay)] backdrop-blur-sm z-40';

--- a/packages/web/src/components/ui/textarea.tsx
+++ b/packages/web/src/components/ui/textarea.tsx
@@ -2,15 +2,18 @@ import { forwardRef, type TextareaHTMLAttributes } from 'react';
 
 interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
 	label?: string;
+	/** Class override for the flex wrapper (e.g. `flex-1 min-h-0` so the textarea
+	 *  can grow to fill a flex column). Defaults to the standard stacked layout. */
+	wrapperClassName?: string;
 }
 
 export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
-	{ label, className = '', id, ...props },
+	{ label, className = '', wrapperClassName = 'flex flex-col gap-1.5', id, ...props },
 	ref,
 ) {
 	const inputId = id || label?.toLowerCase().replace(/\s+/g, '-');
 	return (
-		<div className="flex flex-col gap-1.5">
+		<div className={wrapperClassName}>
 			{label && (
 				<label htmlFor={inputId} className="text-eyebrow text-text-2">
 					{label}

--- a/packages/web/test/floating-new-task.test.tsx
+++ b/packages/web/test/floating-new-task.test.tsx
@@ -97,6 +97,37 @@ test('the sidebar "+" next to Tasks opens the create-task dialog', async () => {
 	);
 });
 
+test('the create-task dialog toggles between fullscreen and the default size', async () => {
+	const { findByTestId, user } = await renderOnProjectTasks();
+
+	await user.click(await findByTestId('floating-new-task'));
+
+	// Starts at the default (non-fullscreen) size.
+	const toggle = await findByTestId('create-task-fullscreen');
+	expect(toggle.getAttribute('aria-label')).toBe('Enter fullscreen');
+	const content = document.body.querySelector('[data-fullscreen]');
+	expect(content?.getAttribute('data-fullscreen')).toBe('false');
+
+	// Toggling expands it to fullscreen…
+	await user.click(toggle);
+	await waitFor(() => {
+		expect(document.body.querySelector('[data-fullscreen]')?.getAttribute('data-fullscreen')).toBe(
+			'true',
+		);
+	});
+	expect((await findByTestId('create-task-fullscreen')).getAttribute('aria-label')).toBe(
+		'Exit fullscreen',
+	);
+
+	// …and toggling again collapses it back.
+	await user.click(await findByTestId('create-task-fullscreen'));
+	await waitFor(() => {
+		expect(document.body.querySelector('[data-fullscreen]')?.getAttribute('data-fullscreen')).toBe(
+			'false',
+		);
+	});
+});
+
 test('the floating new-task button is available off a project route and offers a project picker', async () => {
 	const { findByTestId, user } = await renderApp({
 		initialPath: '/home',

--- a/test/browser/create-task-fullscreen.spec.ts
+++ b/test/browser/create-task-fullscreen.spec.ts
@@ -1,0 +1,55 @@
+// Decision-tree item 1: the fullscreen toggle grows the description textarea to
+// fill the panel via a flex chain (`flex-1` + `min-h-0`). Asserting the box
+// actually grows reads real `clientHeight` off a live layout pass, which
+// happy-dom can't resolve — the component tier only covers the toggle's state.
+import { expect, test } from './fixtures';
+import { createProjectAndClearPlanning, uniqueName, waitForPageLoad } from './helpers';
+
+test('the create-task dialog fullscreen toggle grows the description to fill the panel', async ({
+	sharedPage: page,
+	sharedWorkspace,
+}) => {
+	const { token } = sharedWorkspace;
+	const project = await createProjectAndClearPlanning(page, '', token, {
+		name: uniqueName('Fullscreen Task'),
+		description: 'E2E create-task fullscreen toggle.',
+	});
+
+	// Desktop viewport — the toggle is `sm:block`, hidden on mobile where the
+	// dialog is already near-full-screen.
+	await page.setViewportSize({ width: 1280, height: 900 });
+	await page.goto(`/projects/${project.slug}/tasks`);
+	await waitForPageLoad(page);
+
+	await page.getByTestId('project-sidebar-new-task').click();
+	await expect(page.getByRole('heading', { name: 'Create Task' })).toBeVisible();
+
+	const description = page.getByLabel('Description', { exact: true });
+	await expect(description).toBeVisible();
+	const beforeHeight = await description.evaluate((el) => el.clientHeight);
+
+	// Enter fullscreen: the panel fills the viewport and the description flexes
+	// to take the freed space.
+	const toggle = page.getByTestId('create-task-fullscreen');
+	await expect(toggle).toHaveAttribute('aria-label', 'Enter fullscreen');
+	await toggle.click();
+	await expect(toggle).toHaveAttribute('aria-label', 'Exit fullscreen');
+
+	await expect
+		.poll(async () => description.evaluate((el) => el.clientHeight))
+		.toBeGreaterThan(beforeHeight + 150);
+
+	// The textarea should now occupy the bulk of the dialog's height.
+	const content = page.locator('[data-fullscreen="true"]');
+	const descBox = await description.boundingBox();
+	const contentBox = await content.boundingBox();
+	if (!descBox || !contentBox) throw new Error('Missing layout box');
+	expect(descBox.height).toBeGreaterThan(contentBox.height * 0.4);
+
+	// Collapsing restores the compact size.
+	await toggle.click();
+	await expect(toggle).toHaveAttribute('aria-label', 'Enter fullscreen');
+	await expect
+		.poll(async () => description.evaluate((el) => el.clientHeight))
+		.toBeLessThan(beforeHeight + 100);
+});


### PR DESCRIPTION
## What & why

The Create Task dialog is a fixed-width centred modal, so the description field is a small box even when you're writing a substantial task brief. This adds a **fullscreen toggle** — mirroring the CEO chat's expand/collapse affordance — so you can grow the dialog to fill the viewport with the description editor taking up most of the space.

## Changes

- **`CreateTaskDialog`** — a desktop-only maximize/minimize button in the header toggles a `fullscreen` state. When on, the panel uses a full-viewport content class, the form becomes a bounded flex column, and the description editor gets `fill` so it flexes to occupy the freed space. The other fields keep their natural size and stay visible.
- **`MarkdownEditor`** — new `fill` prop that grows the edit textarea (and the preview) to fill the available flex height via a `flex-1` + `min-h-0` chain at every level.
- **`MentionTextarea` / `Textarea`** — new `containerClassName` / `wrapperClassName` overrides so the nested textarea can participate in that flex chain (default behaviour unchanged).
- **`ui/dialog.ts`** — shared `fullscreenContentClassName` constant.

The toggle is desktop-only (`sm:block`): the dialog is already near-full-screen on mobile, where the toggle would be a no-op — consistent with the CEO chat's expand button.

## Testing

- **Component** (`packages/web/test/floating-new-task.test.tsx`) — asserts the toggle flips the dialog's `data-fullscreen` state and the button's aria-label both ways.
- **Playwright** (`test/browser/create-task-fullscreen.spec.ts`) — real-layout assertion: opens the dialog on a desktop viewport, toggles fullscreen, and verifies the description textarea's `clientHeight` actually grows to occupy the bulk of the panel, then shrinks back on collapse. (Layout-dependent, so it can't be a component test.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JeXpFux4oPa79UyGmgpH5s