### PR TITLE
feat(web): surface staged-update lifecycle in Settings Version section

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -1041,7 +1041,14 @@ version from Conventional Commits and opens a `release/<version>` PR; merging fi
 Settings → General page also renders a **Version** section (current version linked to its
 GitHub release, plus a **"Check for new version"** button that calls
 `POST /api/updates/check` — any authed user — to force a fresh GitHub check bypassing the
-1 h cache, the same upstream check the daily cron runs).
+1 h cache, the same upstream check the daily cron runs). When an update is available this
+section mirrors the banner's staged-update lifecycle **in place** — driven by
+`useUpdateStatus({ poll })`, which auto-refetches `GET /api/updates/status` every few seconds
+while the state is `checking`/`downloading`/`applying` so the section advances live without a
+reload: a self-applying instance shows **"Downloading new version…"** while staging, then an
+**"Install & update"** button (same restart confirmation) once `Staged`, or a **"Retry
+download"** on `Error`; an instance that can't self-apply falls back to the **"Download"**
+release link.
 
 **Self-update & supervisor.** A compiled binary with auto-update enabled
 (`isAutoUpdateEnabled()` — compiled, not `HEZO_DISABLE_AUTO_UPDATE`, not in a container)

--- a/packages/web/src/components/version-display.tsx
+++ b/packages/web/src/components/version-display.tsx
@@ -1,6 +1,16 @@
+import { UpdateState } from '@hezo/shared';
 import { Loader2 } from 'lucide-react';
-import { useCheckForUpdate, useUpdateCheck } from '../hooks/use-update-check';
+import { useState } from 'react';
+import { useMe } from '../hooks/use-me';
+import {
+	useApplyUpdate,
+	useCheckForUpdate,
+	useDownloadUpdate,
+	useUpdateStatus,
+} from '../hooks/use-update-check';
 import { Button } from './ui/button';
+import { ConfirmDialog } from './ui/confirm-dialog';
+import { UpdateRestartOverlay } from './update-restart-overlay';
 
 /** Release tags are plain `MAJOR.MINOR.PATCH` (no `v` prefix) — only those have a GitHub tag page. */
 const RELEASE_TAG = /^\d+\.\d+\.\d+$/;
@@ -11,16 +21,59 @@ const RELEASES_URL = 'https://github.com/hezo-ai/hezo/releases';
  * Version section at the bottom of the General settings page: the running version
  * (linked to its GitHub release page) plus a "Check for new version" button that
  * forces the same GitHub update check the daily cron runs.
+ *
+ * When an update is available this section mirrors the top-of-shell update banner
+ * in place — surfacing the live staged-update lifecycle. On a self-applying
+ * instance (supervised compiled binary) for a superuser it shows "Downloading new
+ * version…" while the background download/verify/stage runs, then flips to an
+ * "Install & update" button (with the same restart confirmation) once staged, or a
+ * "Retry download" if staging errored. Any instance that can't update in place
+ * falls back to a "Download" link to the GitHub release. `useUpdateStatus({ poll })`
+ * refetches while a download is in flight so the transition is live, no reload.
  */
 export function VersionDisplay() {
-	const { data: update } = useUpdateCheck();
+	const { data: update } = useUpdateStatus({ poll: true });
+	const { data: me } = useMe();
 	const check = useCheckForUpdate();
+	const apply = useApplyUpdate();
+	const download = useDownloadUpdate();
+	const [applying, setApplying] = useState(false);
+	const [confirmOpen, setConfirmOpen] = useState(false);
+
+	if (applying) {
+		return <UpdateRestartOverlay targetVersion={update?.targetVersion ?? update?.latest ?? null} />;
+	}
 
 	if (!update?.current) return null;
 
 	const current = update.current;
 	const isReleaseTag = RELEASE_TAG.test(current);
 	const releaseUrl = isReleaseTag ? `${RELEASES_URL}/tag/${current}` : RELEASES_URL;
+
+	const updateAvailable = update.updateAvailable && !!update.latest;
+	const latest = update.latest;
+	const downloadUrl = update.url ?? RELEASES_URL;
+	// A self-applying instance (supervised compiled binary) whose caller is a superuser.
+	const canApply = update.canApply && me?.is_superuser === true;
+	const staged = update.state === UpdateState.Staged;
+	const errored = update.state === UpdateState.Error;
+	// canApply and not yet staged (and not errored) → the background download is in flight.
+	const downloading = canApply && !staged && !errored;
+
+	const confirmDescription = (
+		<>
+			Hezo will shut down and restart on <span className="font-medium">{latest}</span>. In-flight
+			agent runs are paused and resume automatically.
+			{!update.autoUnlock && (
+				<>
+					{' '}
+					<span className="font-medium text-text-1">
+						You'll need your 12-word master key to unlock Hezo again once it restarts.
+					</span>
+				</>
+			)}
+		</>
+	);
 
 	return (
 		<section className="mt-8" data-testid="settings-version">
@@ -55,33 +108,89 @@ export function VersionDisplay() {
 						{check.isPending && <Loader2 className="w-3 h-3 animate-spin" />} Check for new version
 					</Button>
 				</div>
-				{!check.isPending && check.isSuccess && (
+
+				{check.isError ? (
+					<p className="text-[13px] text-danger mt-2.5" data-testid="settings-version-error">
+						Couldn't check for updates. Please try again.
+					</p>
+				) : updateAvailable ? (
+					<div
+						className="mt-2.5 flex flex-col gap-2.5 sm:flex-row sm:items-center sm:justify-between"
+						data-testid="settings-version-result"
+						aria-live="polite"
+					>
+						<p className="text-[13px] text-text-1">
+							Version{' '}
+							<a
+								href={downloadUrl}
+								target="_blank"
+								rel="noreferrer"
+								className="font-medium hover:underline"
+							>
+								{latest}
+							</a>{' '}
+							is available.
+						</p>
+						<div className="flex items-center gap-2 sm:gap-3 self-start sm:self-auto">
+							{downloading ? (
+								<span
+									className="inline-flex items-center gap-1.5 text-[13px] text-text-2"
+									data-testid="settings-version-downloading"
+								>
+									<Loader2 className="w-3 h-3 animate-spin" /> Downloading new version…
+								</span>
+							) : canApply && staged ? (
+								<Button
+									type="button"
+									variant="primary"
+									size="sm"
+									data-testid="settings-version-install"
+									onClick={() => setConfirmOpen(true)}
+								>
+									Install &amp; update
+								</Button>
+							) : canApply && errored ? (
+								<>
+									<Button
+										type="button"
+										variant="primary"
+										size="sm"
+										data-testid="settings-version-retry"
+										disabled={download.isPending}
+										onClick={() => download.mutate()}
+									>
+										{download.isPending ? 'Downloading…' : 'Retry download'}
+									</Button>
+									<a
+										href={downloadUrl}
+										target="_blank"
+										rel="noreferrer"
+										data-testid="settings-version-download"
+										className="text-[13px] underline underline-offset-2 hover:no-underline"
+									>
+										Download manually
+									</a>
+								</>
+							) : (
+								<a
+									href={downloadUrl}
+									target="_blank"
+									rel="noreferrer"
+									data-testid="settings-version-download"
+									className="inline-flex items-center justify-center whitespace-nowrap border border-transparent font-medium transition-colors h-[26px] px-2.5 text-[12.5px] rounded-sm bg-inverse text-inverse-fg hover:opacity-90 focus-visible:ring-[3px] focus-visible:ring-ring outline-none"
+								>
+									Download
+								</a>
+							)}
+						</div>
+					</div>
+				) : (
 					<p
 						className="text-[13px] mt-2.5"
 						data-testid="settings-version-result"
 						aria-live="polite"
 					>
-						{update.updateAvailable && update.latest ? (
-							<span className="text-text-1">
-								Version{' '}
-								<a
-									href={update.url ?? RELEASES_URL}
-									target="_blank"
-									rel="noreferrer"
-									className="font-medium hover:underline"
-								>
-									{update.latest}
-								</a>{' '}
-								is available.
-							</span>
-						) : (
-							<span className="text-text-2">You're on the latest version.</span>
-						)}
-					</p>
-				)}
-				{check.isError && (
-					<p className="text-[13px] text-danger mt-2.5" data-testid="settings-version-error">
-						Couldn't check for updates. Please try again.
+						<span className="text-text-2">You're on the latest version.</span>
 					</p>
 				)}
 			</div>
@@ -96,6 +205,18 @@ export function VersionDisplay() {
 					@hezo_ai
 				</a>
 			</p>
+
+			<ConfirmDialog
+				open={confirmOpen}
+				onOpenChange={setConfirmOpen}
+				title="Install & restart Hezo?"
+				description={confirmDescription}
+				confirmLabel="Install & restart"
+				onConfirm={async () => {
+					await apply.mutateAsync();
+					setApplying(true);
+				}}
+			/>
 		</section>
 	);
 }

--- a/packages/web/src/hooks/use-update-check.ts
+++ b/packages/web/src/hooks/use-update-check.ts
@@ -1,4 +1,4 @@
-import type { UpdateState } from '@hezo/shared';
+import { UpdateState } from '@hezo/shared';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { api } from '../lib/api';
 import { queryKeys } from '../lib/query-keys';
@@ -55,14 +55,30 @@ export function useCheckForUpdate() {
 /**
  * Latest-release info plus the staged-update lifecycle and whether this instance
  * can apply-and-restart. Drives the "Install & restart" affordance.
+ *
+ * Pass `{ poll: true }` (the settings Version section) to auto-refetch every few
+ * seconds while the server is mid-flight (`checking`/`downloading`/`applying`), so
+ * the section advances through the lifecycle live without a manual reload. Polling
+ * stops on its own once the state settles (staged/idle/error). The banner leaves it
+ * off — it only needs the terminal state.
  */
-export function useUpdateStatus() {
+export function useUpdateStatus(opts?: { poll?: boolean }) {
 	return useQuery({
 		queryKey: queryKeys.updateStatus(),
 		queryFn: () => api.get<UpdateStatusInfo>('/api/updates/status'),
 		staleTime: 60 * 60 * 1000,
 		gcTime: 60 * 60 * 1000,
 		retry: false,
+		refetchInterval: opts?.poll
+			? (query) => {
+					const state = query.state.data?.state;
+					return state === UpdateState.Checking ||
+						state === UpdateState.Downloading ||
+						state === UpdateState.Applying
+						? 2500
+						: false;
+				}
+			: undefined,
 	});
 }
 

--- a/packages/web/test/settings-version.test.tsx
+++ b/packages/web/test/settings-version.test.tsx
@@ -1,23 +1,36 @@
-import { expect, test } from 'vitest';
+import { UpdateState } from '@hezo/shared';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, expect, test, vi } from 'vitest';
+import { VersionDisplay } from '../src/components/version-display';
+import type { UpdateStatusInfo } from '../src/hooks/use-update-check';
+import { api } from '../src/lib/api';
 import { queryClient } from '../src/lib/query-client';
 import { queryKeys } from '../src/lib/query-keys';
 import { renderApp } from './helpers/render';
 
-// The General settings page reads the running version via useUpdateCheck(); the app
-// tree pulls from the singleton query client (__root re-wraps with it), so seed that
-// cache to render the version display deterministically without an upstream GitHub call.
+// The General settings page reads version + staged-update lifecycle via
+// useUpdateStatus(); the app tree pulls from the singleton query client (__root
+// re-wraps with it), so seed that cache to render the version display
+// deterministically without an upstream GitHub call.
 function seedVersion(update: {
 	current: string;
 	latest?: string | null;
 	updateAvailable?: boolean;
 	url?: string | null;
 }) {
-	queryClient.setQueryData(queryKeys.updateCheck(), {
+	queryClient.setQueryData(queryKeys.updateStatus(), {
 		current: update.current,
 		latest: update.latest ?? null,
 		updateAvailable: update.updateAvailable ?? false,
 		url: update.url ?? null,
-	});
+		state: UpdateState.Idle,
+		targetVersion: null,
+		error: null,
+		autoUnlock: true,
+		canApply: false,
+	} satisfies UpdateStatusInfo);
 }
 
 test('general settings page shows the version and links to its GitHub release tag', async () => {
@@ -71,4 +84,106 @@ test('feedback handle links to the hezo_ai X account', async () => {
 	) as HTMLAnchorElement | null;
 	expect(feedbackLink).toBeTruthy();
 	expect(feedbackLink?.textContent).toContain('@hezo_ai');
+});
+
+// ---- staged-update lifecycle rendered in place (mirrors the top-of-shell banner) ----
+
+const AVAILABLE: UpdateStatusInfo = {
+	current: '0.1.0',
+	latest: '0.2.0',
+	updateAvailable: true,
+	url: 'https://github.com/hezo-ai/hezo/releases/0.2.0',
+	state: UpdateState.Staged,
+	targetVersion: '0.2.0',
+	error: null,
+	autoUnlock: false,
+	canApply: true,
+};
+
+/**
+ * Render just the Version section against a fresh query client so we can drive the
+ * staged-update lifecycle (state + canApply + superuser) deterministically without
+ * the real backend. No router needed — the component only reads instance-level hooks.
+ */
+function renderVersion(status: Partial<UpdateStatusInfo> = {}, isSuperuser = true) {
+	const qc = new QueryClient({
+		defaultOptions: { queries: { retry: false, staleTime: Number.POSITIVE_INFINITY } },
+	});
+	qc.setQueryData(queryKeys.updateStatus(), { ...AVAILABLE, ...status });
+	qc.setQueryData(queryKeys.me(), { type: 'admin', is_superuser: isSuperuser });
+	return render(
+		<QueryClientProvider client={qc}>
+			<VersionDisplay />
+		</QueryClientProvider>,
+	);
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+test('an available update on a self-applying instance shows "Downloading new version…" while staging', () => {
+	for (const state of [UpdateState.Idle, UpdateState.Checking, UpdateState.Downloading] as const) {
+		const { getByTestId, queryByTestId, unmount } = renderVersion({ state });
+		expect(getByTestId('settings-version-downloading').textContent).toContain(
+			'Downloading new version',
+		);
+		expect(queryByTestId('settings-version-install')).toBeNull();
+		unmount();
+	}
+});
+
+test('a staged update on a self-applying instance shows an "Install & update" button', () => {
+	const { getByTestId } = renderVersion({ state: UpdateState.Staged });
+	expect(getByTestId('settings-version-install').textContent).toContain('Install');
+	expect(getByTestId('settings-version-result').textContent).toContain('0.2.0');
+});
+
+test('Install & update asks for confirmation (with master-key warning) then applies', async () => {
+	const user = userEvent.setup();
+	const postSpy = vi
+		.spyOn(api, 'post')
+		.mockResolvedValue({ state: UpdateState.Applying, targetVersion: '0.2.0' });
+	const { getByTestId, findByTestId, queryByTestId } = renderVersion({ state: UpdateState.Staged });
+
+	await user.click(getByTestId('settings-version-install'));
+	const dialog = await findByTestId('confirm-dialog');
+	expect(dialog.textContent).toContain('master key');
+	expect(postSpy).not.toHaveBeenCalled();
+	expect(queryByTestId('update-restart-overlay')).toBeNull();
+
+	await user.click(getByTestId('confirm-dialog-confirm'));
+	expect(await findByTestId('update-restart-overlay')).toBeTruthy();
+	expect(postSpy).toHaveBeenCalledWith('/api/updates/apply');
+});
+
+test('a staging error offers a retry (with a manual download link)', async () => {
+	const user = userEvent.setup();
+	const postSpy = vi
+		.spyOn(api, 'post')
+		.mockResolvedValue({ data: { state: UpdateState.Downloading, targetVersion: '0.2.0' } });
+	vi.spyOn(api, 'get').mockResolvedValue({ ...AVAILABLE, state: UpdateState.Downloading });
+	const { getByTestId } = renderVersion({ state: UpdateState.Error });
+
+	expect(getByTestId('settings-version-retry').textContent).toContain('Retry download');
+	const link = getByTestId('settings-version-download') as HTMLAnchorElement;
+	expect(link.getAttribute('href')).toBe('https://github.com/hezo-ai/hezo/releases/0.2.0');
+
+	await user.click(getByTestId('settings-version-retry'));
+	expect(postSpy).toHaveBeenCalledWith('/api/updates/download');
+});
+
+test('an instance that cannot self-apply falls back to a release download link', () => {
+	const { getByTestId, queryByTestId } = renderVersion({ canApply: false });
+	expect(queryByTestId('settings-version-install')).toBeNull();
+	expect(queryByTestId('settings-version-downloading')).toBeNull();
+	const link = getByTestId('settings-version-download') as HTMLAnchorElement;
+	expect(link.textContent).toContain('Download');
+	expect(link.getAttribute('href')).toBe('https://github.com/hezo-ai/hezo/releases/0.2.0');
+});
+
+test('a superuser-less caller on a self-applying instance still cannot apply (download link)', () => {
+	const { getByTestId, queryByTestId } = renderVersion({ state: UpdateState.Staged }, false);
+	expect(queryByTestId('settings-version-install')).toBeNull();
+	expect(getByTestId('settings-version-download')).toBeTruthy();
 });


### PR DESCRIPTION
## Summary

The **Version** section on Settings → General now shows the realtime status of the version check + daily background download, instead of only reporting "up to date / update available" text. It mirrors the top-of-shell update banner **in place**, so a superuser never has to scroll to the banner to act on an update.

When an update is available the section renders the live staged-update lifecycle:

- **"Downloading new version…"** while the background download/verify/stage runs (self-applying instance).
- **"Install & update"** button once the binary is `Staged` — opens the same restart confirmation (with the master-key re-unlock warning) the banner uses, then applies and shows the restart overlay.
- **"Retry download"** (+ a manual release link) if staging errored.
- **"Download"** link to the GitHub release for any instance that can't self-apply.

"Check for new version" still forces a fresh GitHub check; "You're on the latest version" is shown when no update is available.

## How it works

- `useUpdateStatus({ poll })` is a new opt-in on the existing status hook: it auto-refetches `GET /api/updates/status` every ~2.5s **only while** the state is `checking`/`downloading`/`applying`, so the section advances through the lifecycle live without a reload, then stops polling once the state settles. The banner keeps `poll` off (unchanged behavior).
- `VersionDisplay` now reads `useUpdateStatus` (current version + lifecycle + `canApply`) plus `useMe` for the superuser gate, and reuses `useApplyUpdate` / `useDownloadUpdate`, `ConfirmDialog`, and `UpdateRestartOverlay` — the same building blocks as the banner. No backend changes.

## Tests

- Reworked `packages/web/test/settings-version.test.tsx` to seed `updateStatus` and added coverage for every new state: downloading, staged → install (confirm → apply → restart overlay), staging error → retry + manual link, and the non-self-applying / non-superuser download-link fallbacks.
- Full web component tier green (155 files / 913 tests); typecheck and biome clean.

## Docs

- Updated `.dev/architecture.md` to describe the in-place lifecycle and the `poll` behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYatzS8eTjYGuP8YK9fb7B

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYatzS8eTjYGuP8YK9fb7B)_