### PR TITLE
feat(connectors): OAuth connect popup for manually-added instance connectors

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -825,8 +825,28 @@ the same egress placeholder path as any secret; agents emit
 attempted) or a `provider_id` for a device-flow provider. The tool creates a pending
 `mcp_connections` row and posts a `connect_required` comment with a **Connect** button; a
 human completes the OAuth dance from the task chat or the Connectors page, and a
-`credential_provided` wakeup resumes the agent. Pending/revoked connectors are excluded
-from runs by `loadMcpConnectionsForRun`.
+`credential_provided` wakeup resumes the agent (scoped to the requesting task's own team,
+resolved from the task row — the connect can be completed from any surface).
+
+**Admin connector flow.** The superuser adds connectors manually on the global Settings →
+Connectors page (`POST /api/mcp-connections`, upsert-by-name; re-adding a name replaces
+`config` and clears `auth_error`). The page then auto-probes the new connector via
+`POST /api/mcp-connections/:id/auth-start` (superuser-gated) — the same PRM → DCR walk as
+the project-scoped auth-start, with two differences: there is no team context (the state
+envelope carries `teamId: null`, and the callback skips the team-room broadcasts and
+per-team provider hooks; the settings page refetches off the popup's
+`hezo-oauth-success` postMessage instead), and an MCP server that advertises **no** PRM
+resolves to `{ auth_url: null }` without marking the row failed
+(`PrmUnavailableError` → `no_oauth`) — missing PRM is the normal shape for the page's
+other use case, public / header-authenticated MCPs (`__HEZO_SECRET_*__` placeholders).
+When OAuth *is* advertised, the UI opens the authorize popup automatically on add, and
+every non-active SaaS row keeps a **Connect**/Retry button.
+
+**Run exclusion.** `loadMcpConnectionsForRun` skips revoked rows, plus SaaS rows that are
+known to want OAuth but haven't completed it — no `oauth_connection_id` and any of:
+agent-requested (`created_by_task_id`), discovery persisted `config.dcr`, or an attempt
+recorded `auth_error`. Injecting those would just 401 on every run. Operator rows that
+never attempted OAuth carry none of the markers and are always included.
 
 **MCP connections** (`mcp_connections`, see § 3 scoping). `kind='saas'` carries
 `{ url, headers }` (header values may contain `__HEZO_SECRET_*__`; OAuth-backed rows set
@@ -1128,7 +1148,8 @@ shapes.
 - **Money & governance** — `costs` (project-scoped, `group_by=day` for charts),
   `model-pricing`, `approvals`, `audit-log`.
 - **Integrations & secrets** — `ai-providers`, `secrets`, `mcp-connections`, `oauth`
-  (connectors: ensure / auth-start / device / callbacks), `skills`.
+  (connectors: ensure / auth-start — project-scoped and instance-admin
+  (`/mcp-connections/:id/auth-start`) / device / callbacks), `skills`.
 - **Ops** — `health`, `updates`, `preview` (HMAC-signed file URLs), public assets.
 
 One non-REST surface shares the port: the **MCP endpoint** (`POST /mcp`, Streamable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,15 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ env.PLAYWRIGHT_VERSION }}
+      # Both Playwright install paths below run `apt-get update`, which fails
+      # hard (exit 100) if any pre-configured apt source 403s. The runner image
+      # ships Microsoft's azure-cli/prod repos, which Playwright doesn't need and
+      # which intermittently return 403 — taking the whole browser shard down.
+      # Drop those sources first so an unrelated repo outage can't fail the job.
+      - name: Remove unneeded Microsoft apt sources (avoid 403 flakes)
+        run: |
+          sudo grep -rlZ 'packages\.microsoft\.com' /etc/apt/sources.list.d/ 2>/dev/null \
+            | sudo xargs -0 -r rm -f || true
       - if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: bunx playwright install --with-deps chromium
       - if: steps.playwright-cache.outputs.cache-hit == 'true'

--- a/packages/server/src/routes/mcp-connections.ts
+++ b/packages/server/src/routes/mcp-connections.ts
@@ -64,6 +64,10 @@ mcpConnectionsRoutes.post('/mcp-connections', async (c) => {
 		return err(c, 'INVALID_REQUEST', 'saas connections require config.url (string)', 400);
 	}
 
+	// Re-adding an existing name is a reconfiguration: config is replaced
+	// wholesale (dropping any stale config.dcr for a changed URL) and a
+	// previous OAuth attempt's auth_error is cleared, so the row starts from a
+	// clean slate. An active row keeps oauth_connection_id/activated_at.
 	const result = await db.query(
 		`INSERT INTO mcp_connections (name, display_name, kind, config, install_status)
 		 VALUES ($1, $2, $3::mcp_connection_kind, $4::jsonb, 'installed'::mcp_install_status)
@@ -73,6 +77,7 @@ mcpConnectionsRoutes.post('/mcp-connections', async (c) => {
 		     config = EXCLUDED.config,
 		     install_status = EXCLUDED.install_status,
 		     install_error = NULL,
+		     auth_error = NULL,
 		     updated_at = now()
 		 RETURNING ${CONNECTOR_COLUMNS}`,
 		[body.name.trim(), body.display_name?.trim() ?? null, body.kind, JSON.stringify(body.config)],

--- a/packages/server/src/routes/oauth.ts
+++ b/packages/server/src/routes/oauth.ts
@@ -12,6 +12,7 @@ import { requestOrigin } from '../lib/request-origin';
 import { err, ok } from '../lib/response';
 import type { Env } from '../lib/types';
 import { logger } from '../logger';
+import { requireAdminEquivalent } from '../middleware/auth';
 import {
 	type ConnectorRow,
 	getConnector,
@@ -33,7 +34,7 @@ import {
 } from '../services/oauth/connection-store';
 import { registerClient } from '../services/oauth/dcr';
 import { pollDeviceFlow, resolveDeviceAuth, startDeviceFlow } from '../services/oauth/device-flow';
-import { discoverMcpAuthorization } from '../services/oauth/prm-discovery';
+import { discoverMcpAuthorization, PrmUnavailableError } from '../services/oauth/prm-discovery';
 import {
 	buildAuthorizationUrl,
 	discoverMetadata,
@@ -134,17 +135,23 @@ oauthRoutes.get('/oauth/callback', async (c) => {
 			conn.id,
 			payload.mcpConnectionId,
 		]);
-		broadcastChange(c, wsRoom.team(payload.teamId), 'mcp_connections', 'UPDATE', {
-			id: payload.mcpConnectionId,
-			oauth_connection_id: conn.id,
-		});
+		// This flow only starts from the project-scoped auth-code route, so a
+		// team is always present; the guard narrows the now-nullable state type.
+		if (payload.teamId) {
+			broadcastChange(c, wsRoom.team(payload.teamId), 'mcp_connections', 'UPDATE', {
+				id: payload.mcpConnectionId,
+				oauth_connection_id: conn.id,
+			});
+		}
 	}
 
-	broadcastChange(c, wsRoom.team(payload.teamId), 'oauth_connections', 'INSERT', {
-		id: conn.id,
-		provider: conn.provider,
-		provider_account_label: conn.providerAccountLabel,
-	});
+	if (payload.teamId) {
+		broadcastChange(c, wsRoom.team(payload.teamId), 'oauth_connections', 'INSERT', {
+			id: conn.id,
+			provider: conn.provider,
+			provider_account_label: conn.providerAccountLabel,
+		});
+	}
 
 	// The callback is an unauthenticated browser redirect (state is signed), so
 	// the acting member can't be resolved here — attribute to the admin actor.
@@ -254,7 +261,24 @@ oauthRoutes.post('/projects/:projectId/oauth/auth-code/start', async (c) => {
 
 type StartConnectorAuthCodeOutcome =
 	| { kind: 'auth_url'; authUrl: string }
+	| { kind: 'no_oauth'; reason: string }
 	| { kind: 'error'; code: string; message: string; status: 400 | 403 | 404 | 503 };
+
+interface StartConnectorAuthCodeOpts {
+	/** Team that initiated the connect; null for the instance-admin surface. */
+	teamId: string | null;
+	/** Path the callback page navigates to when opened without a popup opener. */
+	returnTo: string;
+	/**
+	 * Resolve an MCP server that advertises no Protected Resource Metadata to
+	 * the `no_oauth` outcome (connector left untouched) instead of a failure.
+	 * The admin connectors page probes every manually-added connector
+	 * speculatively, and public / header-authenticated MCPs legitimately have
+	 * no PRM. Errors past discovery (broken AS metadata, DCR unsupported or
+	 * rejected) still mark the connector failed — there OAuth *is* advertised.
+	 */
+	missingPrmMeansNoOAuth?: boolean;
+}
 
 /**
  * Connector-driven MCP OAuth helper: discovers the MCP server's Authorization
@@ -264,8 +288,8 @@ type StartConnectorAuthCodeOutcome =
  */
 async function startConnectorAuthCode(
 	c: import('hono').Context<Env>,
-	teamId: string,
 	connectorId: string,
+	opts: StartConnectorAuthCodeOpts,
 ): Promise<StartConnectorAuthCodeOutcome> {
 	const db = c.get('db');
 	const masterKeyManager = c.get('masterKeyManager');
@@ -329,6 +353,9 @@ async function startConnectorAuthCode(
 		try {
 			discovery = await discoverMcpAuthorization(config.url);
 		} catch (e) {
+			if (opts.missingPrmMeansNoOAuth && e instanceof PrmUnavailableError) {
+				return { kind: 'no_oauth', reason: (e as Error).message };
+			}
 			await markFailed(db, connector.id, `discovery: ${(e as Error).message}`);
 			return {
 				kind: 'error',
@@ -390,10 +417,10 @@ async function startConnectorAuthCode(
 	const requestedScopes = capability?.scopes ?? scopesSupported;
 
 	const { state, codeChallenge } = await signState(masterKeyManager, {
-		teamId,
+		teamId: opts.teamId,
 		provider: `mcp:${connector.id}`,
 		redirectUri,
-		returnTo: `/projects/${c.req.param('projectId')}/connectors?focus=${connector.id}`,
+		returnTo: opts.returnTo,
 		mcpConnectionId: connector.id,
 		mcpConnectionName: connector.display_name ?? connector.name,
 		manualConfig: {
@@ -429,8 +456,37 @@ oauthRoutes.post('/projects/:projectId/auth-start', async (c) => {
 
 	if (!body.connector_id) return err(c, 'INVALID_REQUEST', 'connector_id is required', 400);
 
-	const result = await startConnectorAuthCode(c, teamId, body.connector_id);
+	const result = await startConnectorAuthCode(c, body.connector_id, {
+		teamId,
+		returnTo: `/projects/${c.req.param('projectId')}/connectors?focus=${body.connector_id}`,
+	});
 	if (result.kind === 'error') return err(c, result.code, result.message, result.status);
+	// Unreachable without `missingPrmMeansNoOAuth`; kept for exhaustiveness.
+	if (result.kind === 'no_oauth') return err(c, 'OAUTH_DISCOVERY_FAILED', result.reason, 503);
+	return ok(c, { auth_url: result.authUrl });
+});
+
+/**
+ * OAuth kickoff for a connector from the instance-admin surface
+ * (`/settings/connectors`). Same DCR walk as the project-scoped auth-start,
+ * with two differences: there is no team context (the state envelope carries
+ * `teamId: null` and the callback skips team-scoped side effects), and an MCP
+ * server that advertises no OAuth resolves to `{ auth_url: null }` instead of
+ * a failure — the admin page probes every manually-added connector, and
+ * header-authenticated / public MCPs legitimately have no PRM.
+ */
+oauthRoutes.post('/mcp-connections/:id/auth-start', async (c) => {
+	const denied = requireAdminEquivalent(c);
+	if (denied) return denied;
+	const connectorId = c.req.param('id');
+
+	const result = await startConnectorAuthCode(c, connectorId, {
+		teamId: null,
+		returnTo: `/settings/connectors?focus=${connectorId}`,
+		missingPrmMeansNoOAuth: true,
+	});
+	if (result.kind === 'error') return err(c, result.code, result.message, result.status);
+	if (result.kind === 'no_oauth') return ok(c, { auth_url: null, reason: result.reason });
 	return ok(c, { auth_url: result.authUrl });
 });
 
@@ -445,7 +501,6 @@ oauthRoutes.post('/projects/:projectId/auth-start', async (c) => {
 oauthRoutes.get('/oauth/mcp-callback', async (c) => {
 	const masterKeyManager = c.get('masterKeyManager');
 	const db = c.get('db');
-	const docker = c.get('docker');
 
 	const code = c.req.query('code');
 	const stateParam = c.req.query('state');
@@ -832,9 +887,11 @@ async function finalizeConnectorConnection(
 	c: import('hono').Context<Env>,
 	opts: {
 		// teamId is the team that initiated the connect (from the OAuth state /
-		// request context). Connectors are global, but the GitHub key
-		// registration, container push, and wakeup are still per-team.
-		teamId: string;
+		// request context); null when the connect started from the instance-admin
+		// surface. Connectors are global, but the GitHub key registration,
+		// container push, and WS broadcasts are still per-team and are skipped
+		// without one. The wakeup resolves its own team from the requesting task.
+		teamId: string | null;
 		connector: ConnectorRow;
 		capability: ConnectorCapability | undefined;
 		provider: string;
@@ -881,7 +938,10 @@ async function finalizeConnectorConnection(
 	// Provider side effects (e.g. GitHub SSH-key registration) are non-fatal —
 	// the connection itself is already usable; a failed key registration just
 	// degrades git ops and is logged, not surfaced as a connect failure.
-	if (hooks.afterConnect) {
+	// They are per-team, so an instance-admin connect (no team) skips them —
+	// today that's unreachable anyway (GitHub, the only hooked provider, is
+	// device-flow and the device routes are project-scoped).
+	if (hooks.afterConnect && teamId) {
 		await hooks.afterConnect({ db, masterKeyManager, teamId }, accessToken).catch((e) =>
 			log.warn('post-connect side effect failed (non-fatal)', {
 				connector: capability?.id,
@@ -892,27 +952,33 @@ async function finalizeConnectorConnection(
 
 	// Sync push to the parent task's container so the calling agent sees the
 	// MCP on its next tool call; other team containers updated best-effort.
-	try {
-		await pushConnectorToTeamContainers(
-			{ db, docker },
-			{ teamId, connectorId: connector.id, syncTaskId: connector.created_by_task_id },
-		);
-	} catch (e) {
-		log.warn('live-push failed (non-fatal)', { error: (e as Error).message });
+	if (teamId) {
+		try {
+			await pushConnectorToTeamContainers(
+				{ db, docker },
+				{ teamId, connectorId: connector.id, syncTaskId: connector.created_by_task_id },
+			);
+		} catch (e) {
+			log.warn('live-push failed (non-fatal)', { error: (e as Error).message });
+		}
 	}
 
-	await fireCredentialProvidedWakeup(db, connector, teamId);
+	await fireCredentialProvidedWakeup(db, connector);
 
-	broadcastChange(c, wsRoom.team(teamId), 'mcp_connections', 'UPDATE', {
-		id: connector.id,
-		oauth_connection_id: conn.id,
-		status: 'active',
-	});
-	broadcastChange(c, wsRoom.team(teamId), 'oauth_connections', 'INSERT', {
-		id: conn.id,
-		provider: conn.provider,
-		provider_account_label: conn.providerAccountLabel,
-	});
+	// The instance-admin flow has no team room to target; the settings page
+	// refetches off the popup's hezo-oauth-success postMessage instead.
+	if (teamId) {
+		broadcastChange(c, wsRoom.team(teamId), 'mcp_connections', 'UPDATE', {
+			id: connector.id,
+			oauth_connection_id: conn.id,
+			status: 'active',
+		});
+		broadcastChange(c, wsRoom.team(teamId), 'oauth_connections', 'INSERT', {
+			id: conn.id,
+			provider: conn.provider,
+			provider_account_label: conn.providerAccountLabel,
+		});
+	}
 
 	return { connectionId: conn.id, label: conn.providerAccountLabel };
 }
@@ -920,24 +986,30 @@ async function finalizeConnectorConnection(
 /**
  * Fire a CredentialProvided wakeup on the assignee of the task that requested
  * the connector, if any. Fire-and-forget — the agent's run is inherently async.
+ *
+ * The wakeup's team is resolved from the requesting task itself, not from
+ * whoever completed the connect: connectors are global, so the OAuth dance can
+ * finish from another project's Connectors page or from the instance settings
+ * page (which has no team context at all), while the waiting agent lives in
+ * the task's team.
  */
 async function fireCredentialProvidedWakeup(
 	db: import('@electric-sql/pglite').PGlite,
 	connector: ConnectorRow,
-	teamId: string,
 ): Promise<void> {
 	if (!connector.created_by_task_id) return;
-	const row = await db.query<{ assignee_id: string | null }>(
-		`SELECT assignee_id FROM tasks WHERE id = $1`,
+	const row = await db.query<{ assignee_id: string | null; team_id: string }>(
+		`SELECT assignee_id, team_id FROM tasks WHERE id = $1`,
 		[connector.created_by_task_id],
 	);
 	const assigneeId = row.rows[0]?.assignee_id;
-	if (!assigneeId) return;
+	const taskTeamId = row.rows[0]?.team_id;
+	if (!assigneeId || !taskTeamId) return;
 	trackBackground(
 		createWakeup(
 			db,
 			assigneeId,
-			teamId,
+			taskTeamId,
 			WakeupSource.CredentialProvided,
 			{ connector_id: connector.id, task_id: connector.created_by_task_id },
 			`connector:${connector.id}`,

--- a/packages/server/src/services/mcp-connections.ts
+++ b/packages/server/src/services/mcp-connections.ts
@@ -49,18 +49,23 @@ export interface McpConnectionRow {
  * so every run sees the same set (no team/project scope).
  */
 export async function loadMcpConnectionsForRun(db: PGlite): Promise<McpConnectionRow[]> {
-	// Filters: skip revoked (user disconnected); skip our connector-flow rows
-	// that haven't completed OAuth yet (saas + created_by_task_id IS NOT NULL
-	// + oauth_connection_id IS NULL). Operator-created saas rows without
-	// created_by_task_id continue to be included regardless of OAuth state
-	// (existing behavior for public MCPs).
+	// Filters: skip revoked (user disconnected); skip saas rows that are known
+	// to want OAuth but haven't completed it (no oauth_connection_id and any of:
+	// agent-requested via the connector flow, discovery already persisted
+	// config.dcr, or an OAuth attempt recorded auth_error) — injecting those
+	// would just 401 on every run. Operator-created rows that never attempted
+	// OAuth carry none of these markers and continue to be included regardless
+	// (existing behavior for public / header-authenticated MCPs).
 	const result = await db.query<McpConnectionRow>(
 		`SELECT id, name, kind::text AS kind,
 		        config, oauth_connection_id, install_status::text AS install_status, install_error,
 		        created_at::text, updated_at::text
 		 FROM mcp_connections
 		 WHERE revoked_at IS NULL
-		   AND NOT (kind = 'saas' AND created_by_task_id IS NOT NULL AND oauth_connection_id IS NULL)
+		   AND NOT (kind = 'saas' AND oauth_connection_id IS NULL
+		            AND (created_by_task_id IS NOT NULL
+		                 OR config ? 'dcr'
+		                 OR auth_error IS NOT NULL))
 		 ORDER BY name ASC`,
 	);
 

--- a/packages/server/src/services/oauth/prm-discovery.ts
+++ b/packages/server/src/services/oauth/prm-discovery.ts
@@ -98,6 +98,17 @@ export async function fetchProtectedResourceMetadata(
 }
 
 /**
+ * The MCP server advertises no usable Protected Resource Metadata — neither a
+ * WWW-Authenticate hint nor the well-known document. Per MCP 2025-06-18 an
+ * OAuth-protected server MUST publish PRM, so this most likely means the
+ * server doesn't use OAuth at all (public, or header-authenticated). Callers
+ * that probe speculatively (the admin connectors page) treat this as "no
+ * OAuth", not as a failure; downstream errors (broken AS metadata, DCR
+ * rejection) stay plain Errors because there OAuth *is* advertised but broken.
+ */
+export class PrmUnavailableError extends Error {}
+
+/**
  * Full discovery walk: probe the MCP server, fetch its PRM, then fetch the
  * advertised Authorization Server's metadata. The single entry point used by
  * the auth-start route for a connector.
@@ -111,7 +122,7 @@ export async function discoverMcpAuthorization(
 	try {
 		prm = await fetchProtectedResourceMetadata(prmUrl, fetchFn);
 	} catch (e) {
-		throw new Error(
+		throw new PrmUnavailableError(
 			`Could not discover OAuth endpoints for ${mcpUrl}: WWW-Authenticate had no resource_metadata pointer, and ${prmUrl} failed (${(e as Error).message})`,
 		);
 	}

--- a/packages/server/src/services/oauth/state.ts
+++ b/packages/server/src/services/oauth/state.ts
@@ -14,7 +14,8 @@ export interface ManualOAuthConfig {
 }
 
 export interface StatePayload {
-	teamId: string;
+	/** Team that initiated the flow; null for instance-admin-initiated connects. */
+	teamId: string | null;
 	provider: string;
 	nonce: string;
 	codeVerifier: string;
@@ -28,7 +29,7 @@ export interface StatePayload {
 }
 
 export interface NewStateInput {
-	teamId: string;
+	teamId: string | null;
 	provider: string;
 	redirectUri: string;
 	returnTo: string;

--- a/packages/server/test/connectors.test.ts
+++ b/packages/server/test/connectors.test.ts
@@ -580,10 +580,27 @@ describe('loadMcpConnectionsForRun excludes pending/revoked', () => {
 			 VALUES ('operator', $1::mcp_connection_kind, '{"url": "https://public.example/mcp"}'::jsonb, 'installed')`,
 			[McpConnectionKind.Saas],
 		);
+		// Operator rows that are *known* to want OAuth but haven't completed it
+		// are excluded: discovery persisted config.dcr, or an attempt recorded
+		// auth_error. Injecting either would just 401 on every run.
+		await db.query(
+			`INSERT INTO mcp_connections (name, kind, config, install_status)
+			 VALUES ('dcr-pending', $1::mcp_connection_kind,
+			         '{"url": "https://oauth.example/mcp", "dcr": {"client_id": "c1"}}'::jsonb, 'installed')`,
+			[McpConnectionKind.Saas],
+		);
+		await db.query(
+			`INSERT INTO mcp_connections (name, kind, config, install_status, auth_error)
+			 VALUES ('oauth-failed', $1::mcp_connection_kind,
+			         '{"url": "https://broken.example/mcp"}'::jsonb, 'installed', 'discovery: boom')`,
+			[McpConnectionKind.Saas],
+		);
 		const { loadMcpConnectionsForRun } = await import('../src/services/mcp-connections');
 		const rows = await loadMcpConnectionsForRun(db);
 		expect(rows.find((r) => r.name === 'operator')).toBeTruthy();
 		expect(rows.find((r) => r.name === 'pending')).toBeUndefined();
+		expect(rows.find((r) => r.name === 'dcr-pending')).toBeUndefined();
+		expect(rows.find((r) => r.name === 'oauth-failed')).toBeUndefined();
 	});
 });
 

--- a/packages/server/test/instance-connectors.test.ts
+++ b/packages/server/test/instance-connectors.test.ts
@@ -1,12 +1,19 @@
+import { createServer } from 'node:http';
 import type { PGlite } from '@electric-sql/pglite';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { MasterKeyManager } from '../src/crypto/master-key';
 import type { Env } from '../src/lib/types';
 import { signAdminJwt } from '../src/middleware/auth';
+import {
+	createOrFetchConnector,
+	getConnector,
+	statusOf,
+} from '../src/services/connectors/lifecycle';
 import { loadMcpConnectionsForRun } from '../src/services/mcp-connections';
 import { safeClose } from './helpers';
-import { authHeader, createTestApp, createTestTeam } from './helpers/app';
+import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
+import { type FakeMcpServer, startFakeMcpServer } from './helpers/fake-mcp-server';
 
 let app: Hono<Env>;
 let db: PGlite;
@@ -151,5 +158,256 @@ describe('global connectors', () => {
 			}),
 		});
 		expect(postRes.status).toBe(403);
+	});
+});
+
+describe('instance connector OAuth (admin auth-start)', () => {
+	let fake: FakeMcpServer;
+
+	beforeAll(async () => {
+		fake = await startFakeMcpServer();
+	});
+
+	afterAll(async () => {
+		await fake.close();
+	});
+
+	async function createSaasConnector(name: string, url: string): Promise<{ id: string }> {
+		const res = await app.request('/api/mcp-connections', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name, kind: 'saas', config: { url } }),
+		});
+		expect(res.status).toBe(201);
+		return (await res.json()).data as { id: string };
+	}
+
+	async function driveCallback(authUrl: string): Promise<Response> {
+		// The fake AS auto-approves and 302s to our redirect_uri with code+state;
+		// capture those and drive the callback handler directly.
+		const authorizeRes = await fetch(authUrl, { redirect: 'manual' });
+		expect(authorizeRes.status).toBe(302);
+		const loc = new URL(authorizeRes.headers.get('location')!);
+		const code = loc.searchParams.get('code')!;
+		const state = loc.searchParams.get('state')!;
+		return app.request(
+			`/api/oauth/mcp-callback?code=${encodeURIComponent(code)}&state=${encodeURIComponent(state)}`,
+		);
+	}
+
+	it('performs DCR and completes the callback with no team context', async () => {
+		const conn = await createSaasConnector('higgsfield', `${fake.url}/mcp`);
+
+		const startRes = await app.request(`/api/mcp-connections/${conn.id}/auth-start`, {
+			method: 'POST',
+			headers: authHeader(token),
+		});
+		expect(startRes.status).toBe(200);
+		const { data } = (await startRes.json()) as { data: { auth_url: string | null } };
+		expect(data.auth_url).toContain(`${fake.url}/authorize`);
+		expect(data.auth_url).toContain('client_id=fake_');
+		expect(data.auth_url).toContain('code_challenge=');
+
+		// DCR registration persisted on the row…
+		const withDcr = await getConnector(db, conn.id);
+		const config = withDcr!.config as { dcr?: { client_id: string } };
+		expect(config.dcr?.client_id).toBe(fake.lastClientId());
+
+		// …which marks the row known-OAuth: excluded from runs until authorized.
+		expect((await loadMcpConnectionsForRun(db)).find((r) => r.name === 'higgsfield')).toBe(
+			undefined,
+		);
+
+		const cbRes = await driveCallback(data.auth_url!);
+		expect(cbRes.status).toBe(200);
+		expect(await cbRes.text()).toContain('OAuth connection complete');
+
+		const after = await getConnector(db, conn.id);
+		expect(after?.oauth_connection_id).toBeTruthy();
+		expect(after?.activated_at).toBeTruthy();
+		expect(statusOf(after!)).toBe('active');
+
+		// Token secret landed in the vault.
+		const secretRow = await db.query<{ name: string }>(
+			`SELECT s.name FROM oauth_connections oc
+			 JOIN secrets s ON s.id = oc.access_token_secret_id
+			 WHERE oc.id = $1`,
+			[after!.oauth_connection_id],
+		);
+		expect(secretRow.rows[0].name).toMatch(/^OAUTH_MCP_/);
+
+		// Authorized → injected into runs again.
+		const forRun = await loadMcpConnectionsForRun(db);
+		expect(forRun.find((r) => r.name === 'higgsfield')?.oauth_connection_id).toBeTruthy();
+	});
+
+	it('resolves to auth_url null when the server advertises no PRM, without failing the connector', async () => {
+		// A plain HTTP server with no OAuth surface at all: everything 404s —
+		// the shape of a public or header-authenticated MCP.
+		const plain = createServer((_req, res) => {
+			res.statusCode = 404;
+			res.end('not found');
+		});
+		await new Promise<void>((resolve) => plain.listen(0, '127.0.0.1', resolve));
+		const port = (plain.address() as { port: number }).port;
+		try {
+			const conn = await createSaasConnector('header-auth-mcp', `http://127.0.0.1:${port}/mcp`);
+			const res = await app.request(`/api/mcp-connections/${conn.id}/auth-start`, {
+				method: 'POST',
+				headers: authHeader(token),
+			});
+			expect(res.status).toBe(200);
+			const { data } = (await res.json()) as {
+				data: { auth_url: string | null; reason?: string };
+			};
+			expect(data.auth_url).toBeNull();
+			expect(data.reason).toMatch(/Could not discover OAuth endpoints/);
+
+			// Not marked failed — and still available to agent runs.
+			const row = await getConnector(db, conn.id);
+			expect(row?.auth_error).toBeNull();
+			expect(statusOf(row!)).toBe('pending');
+			expect(
+				(await loadMcpConnectionsForRun(db)).find((r) => r.name === 'header-auth-mcp'),
+			).toBeTruthy();
+		} finally {
+			await new Promise<void>((resolve, reject) => plain.close((e) => (e ? reject(e) : resolve())));
+		}
+	});
+
+	it('marks the connector failed and keeps it out of runs when OAuth is advertised but DCR unsupported', async () => {
+		const noDcr = await startFakeMcpServer({ noRegistrationEndpoint: true });
+		try {
+			const conn = await createSaasConnector('no-dcr', `${noDcr.url}/mcp`);
+			const res = await app.request(`/api/mcp-connections/${conn.id}/auth-start`, {
+				method: 'POST',
+				headers: authHeader(token),
+			});
+			expect(res.status).toBe(400);
+			expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
+				'OAUTH_DCR_UNSUPPORTED',
+			);
+
+			const row = await getConnector(db, conn.id);
+			expect(statusOf(row!)).toBe('failed');
+			expect(row?.auth_error).toContain('registration_endpoint');
+			expect((await loadMcpConnectionsForRun(db)).find((r) => r.name === 'no-dcr')).toBe(undefined);
+		} finally {
+			await noDcr.close();
+		}
+	});
+
+	it('re-adding the same name clears a previous OAuth failure', async () => {
+		const noDcr = await startFakeMcpServer({ noRegistrationEndpoint: true });
+		try {
+			const conn = await createSaasConnector('readd-me', `${noDcr.url}/mcp`);
+			await app.request(`/api/mcp-connections/${conn.id}/auth-start`, {
+				method: 'POST',
+				headers: authHeader(token),
+			});
+			expect((await getConnector(db, conn.id))?.auth_error).toBeTruthy();
+
+			const readd = await createSaasConnector('readd-me', 'https://corrected.example.com/mcp');
+			expect(readd.id).toBe(conn.id);
+			const row = await getConnector(db, conn.id);
+			expect(row?.auth_error).toBeNull();
+			expect(statusOf(row!)).toBe('pending');
+		} finally {
+			await noDcr.close();
+		}
+	});
+
+	it('rejects auth-start for non-superusers, unknown, local, and revoked connectors', async () => {
+		const conn = await createSaasConnector('authz-check', `${fake.url}/mcp`);
+
+		const nonSuper = await db.query<{ id: string }>(
+			"INSERT INTO users (display_name, is_superuser) VALUES ('Member2', false) RETURNING id",
+		);
+		const memberToken = await signAdminJwt(masterKeyManager, nonSuper.rows[0].id);
+		const forbidden = await app.request(`/api/mcp-connections/${conn.id}/auth-start`, {
+			method: 'POST',
+			headers: authHeader(memberToken),
+		});
+		expect(forbidden.status).toBe(403);
+
+		const missing = await app.request(
+			'/api/mcp-connections/00000000-0000-0000-0000-000000000000/auth-start',
+			{ method: 'POST', headers: authHeader(token) },
+		);
+		expect(missing.status).toBe(404);
+
+		// Local kind (inserted directly — the admin POST rejects local creation).
+		const local = await db.query<{ id: string }>(
+			`INSERT INTO mcp_connections (name, kind, config, install_status)
+			 VALUES ('local-authz', 'local'::mcp_connection_kind, '{"command": "npx"}'::jsonb, 'installed'::mcp_install_status)
+			 RETURNING id`,
+		);
+		const localRes = await app.request(`/api/mcp-connections/${local.rows[0].id}/auth-start`, {
+			method: 'POST',
+			headers: authHeader(token),
+		});
+		expect(localRes.status).toBe(400);
+
+		const revoked = await createSaasConnector('revoked-authz', `${fake.url}/mcp`);
+		await db.query(`UPDATE mcp_connections SET revoked_at = now() WHERE id = $1`, [revoked.id]);
+		const revokedRes = await app.request(`/api/mcp-connections/${revoked.id}/auth-start`, {
+			method: 'POST',
+			headers: authHeader(token),
+		});
+		expect(revokedRes.status).toBe(400);
+	});
+
+	it("fires the credential_provided wakeup under the requesting task's team when connected from the admin surface", async () => {
+		const teamRes = await createTestTeam(db, { name: 'Wakeup Team' });
+		const wTeamId = (await teamRes.json()).data.id;
+		const projectRes = await createTestProject(db, wTeamId, { name: 'Wakeup Project' });
+		const wProjectId = (await projectRes.json()).data.id;
+		const agent = await db.query<{ id: string }>(
+			`SELECT ma.id FROM member_agents ma JOIN members m ON m.id = ma.id
+			 WHERE m.team_id = $1 LIMIT 1`,
+			[wTeamId],
+		);
+		const agentId = agent.rows[0].id;
+		const taskRes = await db.query<{ id: string }>(
+			`INSERT INTO tasks (team_id, project_id, assignee_id, number, identifier, title)
+			 SELECT $1, $2, $3, COALESCE(MAX(number), 0) + 1, 'WKP-' || (COALESCE(MAX(number), 0) + 1)::text, 'needs connector'
+			 FROM tasks WHERE project_id = $2
+			 RETURNING id`,
+			[wTeamId, wProjectId, agentId],
+		);
+		const taskId = taskRes.rows[0].id;
+
+		const { row } = await createOrFetchConnector(db, {
+			name: 'agent-requested',
+			displayName: 'Agent Requested',
+			mcpUrl: `${fake.url}/mcp`,
+			mcpTransport: 'http',
+			createdByTaskId: taskId,
+		});
+
+		const startRes = await app.request(`/api/mcp-connections/${row.id}/auth-start`, {
+			method: 'POST',
+			headers: authHeader(token),
+		});
+		expect(startRes.status).toBe(200);
+		const { data } = (await startRes.json()) as { data: { auth_url: string | null } };
+		const cbRes = await driveCallback(data.auth_url!);
+		expect(cbRes.status).toBe(200);
+		expect(await cbRes.text()).toContain('OAuth connection complete');
+
+		// The wakeup insert is fire-and-forget (trackBackground); drain it before
+		// asserting.
+		const { waitForBackground } = await import('../src/lib/background');
+		await waitForBackground();
+
+		// The wakeup scope comes from the task's own team, even though the
+		// connect was completed with no team context at all.
+		const wakeup = await db.query<{ team_id: string }>(
+			`SELECT team_id FROM agent_wakeup_requests
+			 WHERE member_id = $1 AND source = 'credential_provided'::wakeup_source`,
+			[agentId],
+		);
+		expect(wakeup.rows.length).toBeGreaterThan(0);
+		expect(wakeup.rows[0].team_id).toBe(wTeamId);
 	});
 });

--- a/packages/server/test/ssh-agent-server.test.ts
+++ b/packages/server/test/ssh-agent-server.test.ts
@@ -255,6 +255,12 @@ async function runCommand(
 		if (stdin) {
 			child.stdin?.end(stdin);
 		}
+		// A missing binary emits 'error' (ENOENT) and never 'close' — without
+		// this handler the promise never settles, hasCommand() can't return
+		// false, and the guard-skipped tests time out instead of skipping.
+		child.on('error', () => {
+			resolve({ code: -1, stdout: '', stderr: '' });
+		});
 		child.on('close', (code) => {
 			resolve({
 				code: code ?? -1,

--- a/packages/web/src/hooks/use-instance-connectors.ts
+++ b/packages/web/src/hooks/use-instance-connectors.ts
@@ -41,3 +41,29 @@ export function useDeleteInstanceConnector() {
 		},
 	});
 }
+
+export interface InstanceAuthStartResult {
+	/**
+	 * Authorize URL to open in a popup, or null when the MCP server advertises
+	 * no OAuth (public / header-authenticated) — a normal outcome, not an error.
+	 */
+	auth_url: string | null;
+	reason?: string;
+}
+
+/**
+ * Kick off the DCR OAuth flow for an instance connector. Mirrors the
+ * project-scoped useAuthStart but against the admin surface, and its
+ * `auth_url` is nullable (see InstanceAuthStartResult).
+ */
+export function useInstanceAuthStart() {
+	return useMutation({
+		mutationFn: (id: string) =>
+			api.post<InstanceAuthStartResult>(`/api/mcp-connections/${id}/auth-start`, {}),
+		onSettled: () => {
+			// auth-start mutates the row on both paths (persists config.dcr on
+			// success, auth_error on failure) — refresh statuses either way.
+			queryClient.invalidateQueries({ queryKey: INSTANCE_CONNECTORS_KEY });
+		},
+	});
+}

--- a/packages/web/src/routes/settings/connectors.tsx
+++ b/packages/web/src/routes/settings/connectors.tsx
@@ -1,28 +1,54 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
 import { Plus, Trash2 } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Badge } from '../../components/ui/badge';
 import { Button } from '../../components/ui/button';
 import { InfoTooltip } from '../../components/ui/info-tooltip';
 import { Input } from '../../components/ui/input';
 import {
+	INSTANCE_CONNECTORS_KEY,
 	useCreateInstanceConnector,
 	useDeleteInstanceConnector,
+	useInstanceAuthStart,
 	useInstanceConnectors,
 } from '../../hooks/use-instance-connectors';
+import { connectorStatus, type McpConnection } from '../../hooks/use-mcp-connections';
 import { useMe } from '../../hooks/use-me';
+
+function openAuthPopup(authUrl: string): string | null {
+	const popup = window.open(authUrl, 'hezo-connect', 'width=600,height=720');
+	return popup ? null : 'Pop-up blocked. Allow pop-ups for Hezo and try again.';
+}
 
 function InstanceConnectorsPage() {
 	const { data: me } = useMe();
 	const { data: connectors = [] } = useInstanceConnectors();
 	const createConnector = useCreateInstanceConnector();
-	const deleteConnector = useDeleteInstanceConnector();
+	const authStart = useInstanceAuthStart();
+	const queryClient = useQueryClient();
 
 	const [showForm, setShowForm] = useState(false);
 	const [name, setName] = useState('');
 	const [displayName, setDisplayName] = useState('');
 	const [url, setUrl] = useState('');
 	const [error, setError] = useState<string | null>(null);
+
+	// Refetch the list when the OAuth popup signals success. The popup posts
+	// {type: 'hezo-oauth-success'} via window.opener.postMessage from the
+	// callback page (routes/oauth.ts:buildCallbackPage), which lives on the
+	// server origin while we're on the web origin — so we can't require
+	// e.origin === window.location.origin and gate on message type instead.
+	// The payload is just a type tag, not credentials.
+	useEffect(() => {
+		const onMessage = (e: MessageEvent) => {
+			if (!e.data || typeof e.data !== 'object') return;
+			if ((e.data as { type?: string }).type !== 'hezo-oauth-success') return;
+			queryClient.invalidateQueries({ queryKey: INSTANCE_CONNECTORS_KEY });
+		};
+		window.addEventListener('message', onMessage);
+		return () => window.removeEventListener('message', onMessage);
+	}, [queryClient]);
 
 	async function handleCreate(e: React.FormEvent) {
 		e.preventDefault();
@@ -31,19 +57,35 @@ function InstanceConnectorsPage() {
 			setError('Name and MCP server URL are required.');
 			return;
 		}
+		let created: McpConnection;
 		try {
-			await createConnector.mutateAsync({
+			created = await createConnector.mutateAsync({
 				name: name.trim(),
 				display_name: displayName.trim() || undefined,
 				kind: 'saas',
 				config: { url: url.trim() },
 			});
-			setName('');
-			setDisplayName('');
-			setUrl('');
-			setShowForm(false);
 		} catch (err) {
 			setError(err instanceof Error ? err.message : 'Failed to create connector');
+			return;
+		}
+		setName('');
+		setDisplayName('');
+		setUrl('');
+		setShowForm(false);
+		// Probe the new connector for OAuth support and pop the authorize window
+		// when it advertises any; header-auth/public MCPs resolve to
+		// auth_url null and need nothing further.
+		try {
+			const started = await authStart.mutateAsync(created.id);
+			if (started.auth_url) {
+				const popupError = openAuthPopup(started.auth_url);
+				if (popupError) setError(popupError);
+			}
+		} catch (err) {
+			// The row exists either way; the failure is also recorded on it as
+			// auth_error (Failed badge + Retry), so this is just immediate feedback.
+			setError(err instanceof Error ? err.message : 'Failed to start OAuth');
 		}
 	}
 
@@ -65,9 +107,9 @@ function InstanceConnectorsPage() {
 							/>
 						</div>
 						<p className="text-[13px] text-text-2 mt-1 max-w-[680px]">
-							Remote (SaaS) MCP servers shared with every team's agent runs. Authenticate headers
-							with a shared credential placeholder (
-							<span className="font-mono">__HEZO_SECRET_NAME__</span>).
+							Remote (SaaS) MCP servers shared with every team's agent runs. Servers that advertise
+							OAuth get a connect popup when added; for the rest, authenticate headers with a shared
+							credential placeholder (<span className="font-mono">__HEZO_SECRET_NAME__</span>).
 						</p>
 					</div>
 					<Button variant="secondary" size="sm" onClick={() => setShowForm((s) => !s)}>
@@ -98,7 +140,6 @@ function InstanceConnectorsPage() {
 							onChange={(e) => setUrl(e.target.value)}
 							required
 						/>
-						{error && <p className="text-[13px] text-danger">{error}</p>}
 						<div className="flex gap-2">
 							<Button type="submit" size="sm" disabled={createConnector.isPending}>
 								Add connector
@@ -118,6 +159,10 @@ function InstanceConnectorsPage() {
 					</form>
 				)}
 
+				{/* Rendered outside the form: the OAuth kickoff runs after the form
+				    closes, so popup-blocked / auth-start errors need a home too. */}
+				{error && <p className="text-[13px] text-danger mb-4">{error}</p>}
+
 				{!connectors.length ? (
 					<p className="text-[13px] text-text-2">
 						No instance connectors yet. Add one above to share it across every team.
@@ -125,30 +170,7 @@ function InstanceConnectorsPage() {
 				) : (
 					<div className="flex flex-col gap-1">
 						{connectors.map((c) => (
-							<div
-								key={c.id}
-								className="flex items-center justify-between rounded-md border border-border bg-surface px-3 py-2 text-[13px]"
-							>
-								<div className="flex items-center gap-2 min-w-0 flex-1">
-									<span className="font-medium">{c.display_name || c.name}</span>
-									<Badge color="neutral">{c.kind}</Badge>
-									<span className="text-xs text-text-3 font-mono truncate">
-										{typeof c.config?.url === 'string' ? c.config.url : ''}
-									</span>
-								</div>
-								<button
-									type="button"
-									onClick={() => {
-										if (confirm(`Remove instance connector "${c.display_name || c.name}"?`)) {
-											deleteConnector.mutate(c.id);
-										}
-									}}
-									aria-label="Remove"
-									className="text-text-3 hover:text-danger"
-								>
-									<Trash2 className="w-3.5 h-3.5" />
-								</button>
-							</div>
+							<InstanceConnectorRow key={c.id} connector={c} />
 						))}
 					</div>
 				)}
@@ -156,6 +178,87 @@ function InstanceConnectorsPage() {
 		);
 
 	return <div className="max-w-[900px]">{content}</div>;
+}
+
+function InstanceConnectorRow({ connector }: { connector: McpConnection }) {
+	const deleteConnector = useDeleteInstanceConnector();
+	const authStart = useInstanceAuthStart();
+	const [rowError, setRowError] = useState<string | null>(null);
+	const [rowInfo, setRowInfo] = useState<string | null>(null);
+	const status = connectorStatus(connector);
+
+	const url = typeof connector.config?.url === 'string' ? connector.config.url : '';
+
+	const openConnect = () => {
+		setRowError(null);
+		setRowInfo(null);
+		authStart.mutate(connector.id, {
+			onSuccess: ({ auth_url }) => {
+				if (!auth_url) {
+					setRowInfo(
+						"This MCP server doesn't advertise OAuth — authenticate with a header placeholder if needed.",
+					);
+					return;
+				}
+				const popupError = openAuthPopup(auth_url);
+				if (popupError) setRowError(popupError);
+			},
+			onError: (e: unknown) =>
+				setRowError(e instanceof Error ? e.message : 'Failed to start OAuth'),
+		});
+	};
+
+	return (
+		<div
+			className="rounded-md border border-border bg-surface px-3 py-2 text-[13px]"
+			data-testid="instance-connector-row"
+			data-connector-id={connector.id}
+			data-status={status}
+		>
+			<div className="flex flex-wrap items-center gap-2">
+				<span className="font-medium">{connector.display_name || connector.name}</span>
+				<Badge color="neutral">{connector.kind}</Badge>
+				{status === 'active' && <Badge color="success">Connected</Badge>}
+				{status === 'failed' && <Badge color="danger">Failed</Badge>}
+				{status === 'revoked' && <Badge>Revoked</Badge>}
+				<span className="text-xs text-text-3 font-mono truncate flex-1 min-w-0 basis-24">
+					{url}
+				</span>
+				<div className="flex items-center gap-2 ml-auto shrink-0">
+					{connector.kind === 'saas' && status !== 'active' && (
+						<Button
+							size="sm"
+							variant="secondary"
+							onClick={openConnect}
+							disabled={authStart.isPending}
+							data-testid="instance-connector-connect"
+						>
+							{authStart.isPending ? 'Starting…' : status === 'failed' ? 'Retry' : 'Connect'}
+						</Button>
+					)}
+					<button
+						type="button"
+						onClick={() => {
+							if (
+								confirm(`Remove instance connector "${connector.display_name || connector.name}"?`)
+							) {
+								deleteConnector.mutate(connector.id);
+							}
+						}}
+						aria-label="Remove"
+						className="text-text-3 hover:text-danger"
+					>
+						<Trash2 className="w-3.5 h-3.5" />
+					</button>
+				</div>
+			</div>
+			{connector.auth_error && status === 'failed' && (
+				<p className="text-xs text-danger mt-1">{connector.auth_error}</p>
+			)}
+			{rowError && <p className="text-xs text-danger mt-1">{rowError}</p>}
+			{rowInfo && <p className="text-xs text-text-3 mt-1">{rowInfo}</p>}
+		</div>
+	);
 }
 
 export const Route = createFileRoute('/settings/connectors')({

--- a/packages/web/test/instance-connectors.test.tsx
+++ b/packages/web/test/instance-connectors.test.tsx
@@ -1,5 +1,5 @@
 import { waitFor } from '@testing-library/react';
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 import { renderApp } from './helpers/render';
 
 async function seedInstanceConnector(
@@ -15,27 +15,200 @@ async function seedInstanceConnector(
 }
 
 test('lists seeded instance connectors and creates a new one via the form', async () => {
-	const { findByText, getByRole, getByPlaceholderText, user } = await renderApp({
+	// The create flow now auto-probes the new connector for OAuth; stub that
+	// call so this test doesn't reach for the (nonexistent) example host.
+	const intercept = interceptAuthStart({ auth_url: null, reason: 'no PRM' });
+	try {
+		const { findByText, getByRole, getByPlaceholderText, user } = await renderApp({
+			initialPath: '/settings/connectors',
+			seed: async (ctx) => {
+				await seedInstanceConnector(ctx, {
+					name: 'seeded-docs',
+					display_name: 'Seeded Docs',
+					kind: 'saas',
+					config: { url: 'https://mcp.seeded.example/mcp' },
+				});
+			},
+		});
+
+		await findByText('Connectors', { selector: 'h1' });
+		await findByText('Seeded Docs');
+
+		await user.click(getByRole('button', { name: 'Add' }));
+		await user.type(getByPlaceholderText('Name (e.g. shared-docs)'), 'new-conn');
+		await user.type(getByPlaceholderText(/MCP server URL/), 'https://mcp.new.example/mcp');
+		await user.click(getByRole('button', { name: 'Add connector' }));
+
+		await findByText('new-conn');
+	} finally {
+		intercept.restore();
+	}
+});
+
+/**
+ * Intercept the admin auth-start REST call with a canned response. A live fake
+ * MCP server is unreliable under this harness — the patched fetch routes by
+ * pathname and `/mcp` collides with the in-process Hezo app — so the web tier
+ * asserts the UI wiring and the server suite (instance-connectors.test.ts)
+ * covers real discovery/DCR.
+ */
+function interceptAuthStart(body: { auth_url: string | null; reason?: string }): {
+	calls: () => number;
+	restore: () => void;
+} {
+	const patched = globalThis.fetch;
+	let calls = 0;
+	globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+		const urlStr =
+			input instanceof Request ? input.url : typeof input === 'string' ? input : input.toString();
+		const path = new URL(urlStr, 'http://localhost').pathname;
+		if (/^\/api\/mcp-connections\/[^/]+\/auth-start$/.test(path)) {
+			calls += 1;
+			return new Response(JSON.stringify({ data: body }), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			});
+		}
+		return patched(input as RequestInfo, init);
+	}) as typeof globalThis.fetch;
+	return {
+		calls: () => calls,
+		restore: () => {
+			globalThis.fetch = patched;
+		},
+	};
+}
+
+test('adding a connector that advertises OAuth opens the authorize popup', async () => {
+	const authUrl = 'https://as.example/authorize?client_id=abc&state=xyz';
+	const openSpy = vi.spyOn(window, 'open').mockReturnValue({} as Window);
+	const intercept = interceptAuthStart({ auth_url: authUrl });
+	try {
+		const { findByText, getByRole, getByPlaceholderText, user } = await renderApp({
+			initialPath: '/settings/connectors',
+		});
+		await findByText('Connectors', { selector: 'h1' });
+
+		await user.click(getByRole('button', { name: 'Add' }));
+		await user.type(getByPlaceholderText('Name (e.g. shared-docs)'), 'oauth-conn');
+		await user.type(getByPlaceholderText(/MCP server URL/), 'https://mcp.oauth.example/mcp');
+		await user.click(getByRole('button', { name: 'Add connector' }));
+
+		await findByText('oauth-conn');
+		await waitFor(() => {
+			expect(openSpy).toHaveBeenCalledWith(authUrl, 'hezo-connect', 'width=600,height=720');
+		});
+	} finally {
+		intercept.restore();
+		openSpy.mockRestore();
+	}
+});
+
+test('adding a connector without OAuth opens no popup and shows no error', async () => {
+	const openSpy = vi.spyOn(window, 'open').mockReturnValue({} as Window);
+	const intercept = interceptAuthStart({ auth_url: null, reason: 'no PRM' });
+	try {
+		const { findByText, getByRole, getByPlaceholderText, queryByText, user } = await renderApp({
+			initialPath: '/settings/connectors',
+		});
+		await findByText('Connectors', { selector: 'h1' });
+
+		await user.click(getByRole('button', { name: 'Add' }));
+		await user.type(getByPlaceholderText('Name (e.g. shared-docs)'), 'plain-conn');
+		await user.type(getByPlaceholderText(/MCP server URL/), 'https://mcp.plain.example/mcp');
+		await user.click(getByRole('button', { name: 'Add connector' }));
+
+		await findByText('plain-conn');
+		await waitFor(() => expect(intercept.calls()).toBe(1));
+		expect(openSpy).not.toHaveBeenCalled();
+		expect(queryByText(/Pop-up blocked/)).toBeNull();
+		expect(queryByText(/Failed to start OAuth/)).toBeNull();
+	} finally {
+		intercept.restore();
+		openSpy.mockRestore();
+	}
+});
+
+test('rows surface Connected / Failed states and a Connect button', async () => {
+	const { findByText, findByRole, getByRole } = await renderApp({
 		initialPath: '/settings/connectors',
 		seed: async (ctx) => {
-			await seedInstanceConnector(ctx, {
-				name: 'seeded-docs',
-				display_name: 'Seeded Docs',
-				kind: 'saas',
-				config: { url: 'https://mcp.seeded.example/mcp' },
-			});
+			for (const name of ['active-conn', 'failed-conn', 'plain-conn']) {
+				await seedInstanceConnector(ctx, {
+					name,
+					kind: 'saas',
+					config: { url: `https://${name}.example/mcp` },
+				});
+			}
+			// active-conn completed OAuth: vault-backed oauth_connections row +
+			// activated_at. failed-conn recorded a failed attempt.
+			const secret = await ctx.db.query<{ id: string }>(
+				`INSERT INTO secrets (name, encrypted_value) VALUES ('T_ACTIVE', 'enc') RETURNING id`,
+			);
+			const oc = await ctx.db.query<{ id: string }>(
+				`INSERT INTO oauth_connections
+				 (provider, provider_account_id, provider_account_label, access_token_secret_id)
+				 VALUES ('mcp:test', 'acct', 'Test', $1) RETURNING id`,
+				[secret.rows[0].id],
+			);
+			await ctx.db.query(
+				`UPDATE mcp_connections SET oauth_connection_id = $1, activated_at = now()
+				 WHERE name = 'active-conn'`,
+				[oc.rows[0].id],
+			);
+			await ctx.db.query(
+				`UPDATE mcp_connections SET auth_error = 'discovery: boom' WHERE name = 'failed-conn'`,
+			);
 		},
 	});
 
-	await findByText('Connectors', { selector: 'h1' });
-	await findByText('Seeded Docs');
+	await findByText('Connected');
+	await findByText('Failed');
+	await findByText('discovery: boom');
+	// The failed row offers a retry; the never-attempted row a plain Connect;
+	// the active row offers neither.
+	await findByRole('button', { name: 'Retry' });
+	await findByRole('button', { name: 'Connect' });
+	const activeRow = document.querySelector('[data-status="active"]');
+	expect(activeRow).toBeTruthy();
+	expect(activeRow!.querySelector('[data-testid="instance-connector-connect"]')).toBeNull();
+	// Sanity: the page-level Add button still renders alongside row buttons.
+	getByRole('button', { name: 'Add' });
+});
 
-	await user.click(getByRole('button', { name: 'Add' }));
-	await user.type(getByPlaceholderText('Name (e.g. shared-docs)'), 'new-conn');
-	await user.type(getByPlaceholderText(/MCP server URL/), 'https://mcp.new.example/mcp');
-	await user.click(getByRole('button', { name: 'Add connector' }));
+test('refetches the list when the OAuth popup reports success', async () => {
+	const { findByText, queryByText, ctx } = await renderApp({
+		initialPath: '/settings/connectors',
+		seed: async (c) => {
+			await seedInstanceConnector(c, {
+				name: 'msg-conn',
+				kind: 'saas',
+				config: { url: 'https://msg.example/mcp' },
+			});
+		},
+	});
+	await findByText('msg-conn');
+	expect(queryByText('Connected')).toBeNull();
 
-	await findByText('new-conn');
+	// The popup completed the flow server-side (simulated directly in the DB)…
+	const secret = await ctx.db.query<{ id: string }>(
+		`INSERT INTO secrets (name, encrypted_value) VALUES ('T_MSG', 'enc') RETURNING id`,
+	);
+	const oc = await ctx.db.query<{ id: string }>(
+		`INSERT INTO oauth_connections
+		 (provider, provider_account_id, provider_account_label, access_token_secret_id)
+		 VALUES ('mcp:msg', 'acct', 'Msg', $1) RETURNING id`,
+		[secret.rows[0].id],
+	);
+	await ctx.db.query(
+		`UPDATE mcp_connections SET oauth_connection_id = $1, activated_at = now()
+		 WHERE name = 'msg-conn'`,
+		[oc.rows[0].id],
+	);
+
+	// …and posts hezo-oauth-success to the opener, which refetches the list.
+	window.dispatchEvent(new MessageEvent('message', { data: { type: 'hezo-oauth-success' } }));
+	await findByText('Connected');
 });
 
 test('settings page sidebar links to connectors', async () => {


### PR DESCRIPTION
## Problem

Adding a SaaS connector manually on the global **Settings → Connectors** page never offered OAuth (reported with the Higgsfield MCP: "it didn't popup oauth flow for me"). The page just inserted the `mcp_connections` row — the whole PRM discovery (RFC 9728) → DCR (RFC 7591) → authorize-popup flow was only reachable from the **project-scoped** `POST /api/projects/:projectId/auth-start` route and its Connect buttons. Worse, an OAuth-requiring connector added this way was still injected into every agent run (`loadMcpConnectionsForRun` only excluded *agent-requested* unauthorized rows), so agents 401'd on it every run.

## Changes

**Server**
- New `POST /api/mcp-connections/:id/auth-start` (superuser-gated, like the other instance connector routes). Same DCR walk as the project route, refactored into `startConnectorAuthCode(c, connectorId, opts)` with two differences:
  - **No team context**: the OAuth state envelope carries `teamId: null`; the callback skips team-room broadcasts and per-team provider hooks (the settings page refetches off the popup's `hezo-oauth-success` postMessage instead).
  - **Missing PRM is not a failure**: a server that advertises no Protected Resource Metadata resolves to `200 { auth_url: null }` via the new `PrmUnavailableError`, leaving the row untouched — that's the normal shape for the page's other use case (public / header-authenticated MCPs with `__HEZO_SECRET_*__` placeholders). Downstream errors (broken AS metadata, DCR unsupported/rejected) still mark the connector failed, since there OAuth *is* advertised.
- `loadMcpConnectionsForRun` now also excludes SaaS rows **known to want OAuth but not authorized** — no `oauth_connection_id` and any of: agent-requested, `config.dcr` persisted by discovery, or `auth_error` recorded. Never-attempted operator rows keep today's behavior exactly.
- `fireCredentialProvidedWakeup` resolves the wakeup's team from the **requesting task row** instead of the connecting surface — required for the team-less admin flow, and fixes a latent bug where completing a connect from project X for a connector requested by a task in project Y filed the wakeup under the wrong team.
- Re-adding a connector name via the admin upsert clears `auth_error` (clean slate for a corrected URL); an active row keeps its OAuth link.

**Web**
- `/settings/connectors`: after adding a connector, the page auto-probes it and opens the authorize popup when OAuth is advertised (popup-blocked fallback message included). Rows get **Connected/Failed** badges (no badge for pending — normal for header-auth MCPs), a **Connect/Retry** button on non-active SaaS rows, inline `auth_error`, and a `hezo-oauth-success` postMessage listener that refetches the list. Rows wrap at mobile widths.
- New `useInstanceAuthStart()` hook (`packages/web/src/hooks/use-instance-connectors.ts`).

**Also**
- `packages/server/test/ssh-agent-server.test.ts`: `runCommand` now resolves on spawn `error` (ENOENT), so the `hasCommand('ssh-keygen')` guard skips instead of hanging to the 15s timeout on machines without openssh-client (separate commit).
- `.dev/architecture.md` § 9 documents the admin connector flow and the run-exclusion rule.

## Failure semantics (what happens to the row when OAuth setup fails)

The row is never rolled back. No-PRM → plain row, still injected into runs. DCR unsupported/rejected or exchange failure → `auth_error` + Failed badge + Retry, excluded from runs. Popup closed/blocked → pending with Connect available, excluded from runs once `config.dcr` was persisted. Completing OAuth activates the row and re-includes it with the Bearer header.

## Tests

- `packages/server/test/instance-connectors.test.ts`: full DCR + callback e2e against the fake MCP/AS server with no team context (secret in vault, row active, run-loader inclusion flips across the flow); no-PRM → `auth_url: null` without `markFailed`; DCR-unsupported → 400 + failed + run-excluded; re-add clears `auth_error`; authz (403/404/400 local/400 revoked); wakeup lands under the requesting task's team.
- `packages/server/test/connectors.test.ts`: run-loader exclusion markers (`config.dcr`, `auth_error`).
- `packages/web/test/instance-connectors.test.tsx`: popup opened on add when `auth_url` returned; no popup/no error when `auth_url: null`; Connected/Failed badges + Connect/Retry buttons; postMessage-triggered refetch.
- Full `bun run test --skip-browser`: server 3874 passed (the one failure was the pre-existing ssh-keygen ENOENT hang, fixed here), Bun-native tier passed, web 918 passed, shared 112 passed. `bun run typecheck` and `bun run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PBbF8nP1uJ1HLpPV5LyKK8

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBbF8nP1uJ1HLpPV5LyKK8)_