### PR TITLE
feat(web): single Edit button for project and per-agent budgets

### DIFF
--- a/packages/web/src/components/budget/project-budget-panel.tsx
+++ b/packages/web/src/components/budget/project-budget-panel.tsx
@@ -1,6 +1,7 @@
 import { type BudgetWindowsCents, centsToDollars } from '@hezo/shared';
+import { Link } from '@tanstack/react-router';
 import { Clock, Loader2, Pencil, TriangleAlert } from 'lucide-react';
-import { useState } from 'react';
+import { type Ref, useState } from 'react';
 import {
 	type EntityBudgetStatus,
 	useBudgetStatus,
@@ -57,15 +58,7 @@ function resetCaption(w: WindowKey): string {
 	return `resets ${nm.toLocaleString('en-US', { month: 'short', timeZone: 'UTC' })} 1`;
 }
 
-function WindowColumn({
-	status,
-	windowKey,
-	onEdit,
-}: {
-	status: WindowStatus;
-	windowKey: WindowKey;
-	onEdit: () => void;
-}) {
+function WindowColumn({ status, windowKey }: { status: WindowStatus; windowKey: WindowKey }) {
 	const unlimited = status.limitCents <= 0;
 	const tone = toneFor(status);
 	const p = pctUsed(status);
@@ -84,14 +77,6 @@ function WindowColumn({
 				<span className="font-mono text-[13px] text-text-3">
 					/ {unlimited ? 'no cap' : dollars(status.limitCents)}
 				</span>
-				<button
-					type="button"
-					onClick={onEdit}
-					aria-label={`Edit ${WINDOW_LABELS[windowKey]} cap`}
-					className="ml-0.5 text-text-3 transition-colors hover:text-text-1"
-				>
-					<Pencil className="h-3 w-3" />
-				</button>
 			</div>
 			{!unlimited && (
 				<div className="h-1.5 overflow-hidden rounded-full bg-surface-3">
@@ -178,7 +163,7 @@ function Hero({
 	);
 }
 
-function BindingBanner({ project, onRaise }: { project: EntityBudgetStatus; onRaise: () => void }) {
+function BindingBanner({ project, projectId }: { project: EntityBudgetStatus; projectId: string }) {
 	const windows = (
 		[
 			{ key: 'daily', s: project.daily },
@@ -212,9 +197,16 @@ function BindingBanner({ project, onRaise }: { project: EntityBudgetStatus; onRa
 					about {dollars(remaining)} left {scope}.
 				</p>
 			</div>
-			<Button variant="secondary" size="sm" onClick={onRaise} className="shrink-0">
-				Raise {binding.key} cap
-			</Button>
+			<Link
+				to="/projects/$projectId/settings"
+				params={{ projectId }}
+				hash="budget"
+				className="shrink-0"
+			>
+				<Button variant="secondary" size="sm" className="w-full sm:w-auto">
+					Raise {binding.key} cap
+				</Button>
+			</Link>
 		</div>
 	);
 }
@@ -240,9 +232,14 @@ function LimitCell({ label, cents }: { label: string; cents: number }) {
 export function ProjectBudgetPanel({
 	projectId,
 	variant = 'spend',
+	sectionRef,
+	sectionId,
 }: {
 	projectId: string;
 	variant?: 'spend' | 'limits';
+	/** Anchor hooks so a deep link (`…/settings#budget`) can scroll to this section. */
+	sectionRef?: Ref<HTMLElement>;
+	sectionId?: string;
 }) {
 	const { data: project } = useProject(projectId);
 	const { data: status } = useBudgetStatus(projectId, { enabled: variant === 'spend' });
@@ -272,22 +269,32 @@ export function ProjectBudgetPanel({
 	}
 
 	return (
-		<section>
+		<section ref={sectionRef} id={sectionId} className={sectionId ? 'scroll-mt-20' : undefined}>
 			<SectionHeader
 				icon={Clock}
 				title="Project budget"
 				action={
-					variant === 'limits' &&
-					!editing && (
-						<Button
-							variant="ghost"
-							size="sm"
-							onClick={startEditing}
-							data-testid="edit-project-budget"
-						>
-							<Pencil className="h-3.5 w-3.5" aria-hidden />
-							Edit caps
-						</Button>
+					variant === 'spend' ? (
+						// The Budget page is read-only for caps; editing lives in project
+						// settings. This single header button takes you straight there.
+						<Link to="/projects/$projectId/settings" params={{ projectId }} hash="budget">
+							<Button variant="ghost" size="sm" data-testid="edit-project-budget-link">
+								<Pencil className="h-3.5 w-3.5" aria-hidden />
+								Edit
+							</Button>
+						</Link>
+					) : (
+						!editing && (
+							<Button
+								variant="ghost"
+								size="sm"
+								onClick={startEditing}
+								data-testid="edit-project-budget"
+							>
+								<Pencil className="h-3.5 w-3.5" aria-hidden />
+								Edit caps
+							</Button>
+						)
 					)
 				}
 			/>
@@ -326,24 +333,12 @@ export function ProjectBudgetPanel({
 								dailyCap={project.daily_budget_cents}
 							/>
 							<div className="flex flex-1 flex-col divide-y divide-border sm:flex-row sm:divide-x sm:divide-y-0">
-								<WindowColumn
-									windowKey="daily"
-									status={status.project.daily}
-									onEdit={startEditing}
-								/>
-								<WindowColumn
-									windowKey="weekly"
-									status={status.project.weekly}
-									onEdit={startEditing}
-								/>
-								<WindowColumn
-									windowKey="monthly"
-									status={status.project.monthly}
-									onEdit={startEditing}
-								/>
+								<WindowColumn windowKey="daily" status={status.project.daily} />
+								<WindowColumn windowKey="weekly" status={status.project.weekly} />
+								<WindowColumn windowKey="monthly" status={status.project.monthly} />
 							</div>
 						</div>
-						<BindingBanner project={status.project} onRaise={startEditing} />
+						<BindingBanner project={status.project} projectId={projectId} />
 					</>
 				) : (
 					<div className="h-[180px] animate-pulse rounded-lg border border-border bg-surface-2" />

--- a/packages/web/src/hooks/use-scroll-to-hash.ts
+++ b/packages/web/src/hooks/use-scroll-to-hash.ts
@@ -1,0 +1,24 @@
+import { useLocation } from '@tanstack/react-router';
+import { useCallback, useRef } from 'react';
+
+/**
+ * Returns a ref callback that scrolls its element into view when the current
+ * router hash matches `id`. Because the callback fires when the element mounts —
+ * which, on a page whose content loads from an async query, happens after the
+ * initial render — a cross-page deep link (e.g. `…/settings#budget`) still lands
+ * on the section even though it isn't in the DOM at navigation time. Guarded to
+ * fire once per hash so a later re-render never yanks the viewport back.
+ */
+export function useScrollToHash(id: string) {
+	const hash = useLocation({ select: (l) => l.hash });
+	const scrolledFor = useRef<string | null>(null);
+	return useCallback(
+		(el: HTMLElement | null) => {
+			// `location.hash` has no leading '#'.
+			if (!el || hash !== id || scrolledFor.current === id) return;
+			scrolledFor.current = id;
+			el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+		},
+		[hash, id],
+	);
+}

--- a/packages/web/src/routes/projects/$projectId/agents/$agentId/settings.tsx
+++ b/packages/web/src/routes/projects/$projectId/agents/$agentId/settings.tsx
@@ -30,6 +30,7 @@ import {
 } from '../../../../../hooks/use-agents';
 import { useAiProviderModels, useAiProviders } from '../../../../../hooks/use-ai-providers';
 import { useBudgetStatus } from '../../../../../hooks/use-costs';
+import { useScrollToHash } from '../../../../../hooks/use-scroll-to-hash';
 
 function AgentSettingsPage() {
 	const { projectId, agentId } = Route.useParams();
@@ -42,6 +43,8 @@ function AgentSettingsPage() {
 	const disableAgent = useDisableAgent(projectId);
 	const enableAgent = useEnableAgent(projectId);
 	const { data: budgetStatus } = useBudgetStatus(projectId);
+	// Deep link from the Budget page's per-agent "Edit" button lands on Budget limits.
+	const budgetSectionRef = useScrollToHash('budget');
 
 	const [title, setTitle] = useState('');
 	const [roleDesc, setRoleDesc] = useState('');
@@ -241,7 +244,7 @@ function AgentSettingsPage() {
 					</p>
 				</div>
 
-				<div className="flex flex-col gap-1.5">
+				<div ref={budgetSectionRef} id="budget" className="flex scroll-mt-20 flex-col gap-1.5">
 					<span className="text-sm text-text-2">Budget limits</span>
 					<BudgetWindowsEditor value={budget} onChange={setBudget} />
 				</div>

--- a/packages/web/src/routes/projects/$projectId/budget.tsx
+++ b/packages/web/src/routes/projects/$projectId/budget.tsx
@@ -1,6 +1,7 @@
 import { centsToDollars, HQ_PROJECT_SLUG } from '@hezo/shared';
-import { createFileRoute, redirect } from '@tanstack/react-router';
-import { BarChart3, Users } from 'lucide-react';
+import { createFileRoute, Link, redirect } from '@tanstack/react-router';
+import { BarChart3, Pencil, Users } from 'lucide-react';
+import { agentPageParams } from '../../../components/agent-link';
 import { BudgetCharts } from '../../../components/budget/budget-charts';
 import { ProjectBudgetPanel } from '../../../components/budget/project-budget-panel';
 import { type SpendCell, StackedSpendChart } from '../../../components/budget/stacked-spend-chart';
@@ -150,7 +151,20 @@ function BudgetPage() {
 												{agent.agent_title}
 											</span>
 										</div>
-										{agent.agent_over_budget && <Badge color="danger">Over budget</Badge>}
+										<div className="flex shrink-0 items-center gap-2">
+											{agent.agent_over_budget && <Badge color="danger">Over budget</Badge>}
+											<Link
+												to="/projects/$projectId/agents/$agentId/settings"
+												params={agentPageParams(projectId, agent.agent_slug)}
+												hash="budget"
+												aria-label={`Edit ${agent.agent_title} budget`}
+												title="Edit budget"
+												data-testid={`edit-agent-budget-${agent.agent_slug}`}
+												className="rounded-sm p-1 text-text-3 transition-colors hover:bg-surface-3 hover:text-text-1"
+											>
+												<Pencil className="h-3.5 w-3.5" aria-hidden />
+											</Link>
+										</div>
 									</div>
 									<WindowGrid status={agent} />
 								</div>

--- a/packages/web/src/routes/projects/$projectId/settings/index.tsx
+++ b/packages/web/src/routes/projects/$projectId/settings/index.tsx
@@ -8,11 +8,14 @@ import { Button } from '../../../../components/ui/button';
 import { Input } from '../../../../components/ui/input';
 import { Textarea } from '../../../../components/ui/textarea';
 import { useProject, useUpdateProject } from '../../../../hooks/use-projects';
+import { useScrollToHash } from '../../../../hooks/use-scroll-to-hash';
 
 function ProjectSettingsPage() {
 	const { projectId } = Route.useParams();
 	const { data: project } = useProject(projectId);
 	const updateProject = useUpdateProject(projectId);
+	// Deep link from the Budget page's "Edit" button lands on the budget section.
+	const budgetSectionRef = useScrollToHash('budget');
 
 	const [name, setName] = useState('');
 	const [description, setDescription] = useState('');
@@ -123,7 +126,12 @@ function ProjectSettingsPage() {
 				)}
 			</section>
 
-			<ProjectBudgetPanel projectId={projectId} variant="limits" />
+			<ProjectBudgetPanel
+				projectId={projectId}
+				variant="limits"
+				sectionRef={budgetSectionRef}
+				sectionId="budget"
+			/>
 
 			{project.container_status === 'running' && project.dev_ports?.length > 0 && (
 				<section>

--- a/packages/web/test/budget-page.test.tsx
+++ b/packages/web/test/budget-page.test.tsx
@@ -159,3 +159,60 @@ test('Budget page: each agent card links to that agent’s settings budget secti
 	await findByRole('heading', { name: agentTitle }, { timeout: 15_000 });
 	await findByText('Budget limits');
 });
+
+test('Budget page: project window columns render caps and the binding-window banner appears', async () => {
+	let teamSlug = '';
+
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const { apiBase } = getTestContext();
+			teamSlug = ws.internalSlug;
+			const agent = ws.agents[0];
+
+			// Cap all three project windows so every WindowColumn renders a bar + % (not "no cap").
+			// Caps must satisfy the cross-window floors (weekly ≥ daily×7, monthly ≥ weekly×52/12).
+			const patchRes = await apiBase(`/api/projects/${ws.internalSlug}`, {
+				method: 'PATCH',
+				headers: ws.headers,
+				body: JSON.stringify({
+					daily_budget_cents: 1000,
+					weekly_budget_cents: 10000,
+					monthly_budget_cents: 50000,
+				}),
+			});
+			if (!patchRes.ok) throw new Error(`seed: setting project caps failed (${patchRes.status})`);
+
+			const projects = (await (await apiBase('/api/projects', { headers: ws.headers })).json()) as {
+				data: Array<{ id: string; slug: string }>;
+			};
+			const projectId = projects.data.find((p) => p.slug === ws.internalSlug)?.id;
+
+			// $9 of project spend → daily 90% (the binding window), weekly 45%, monthly 18%.
+			await apiBase(`/api/projects/${ws.internalSlug}/costs`, {
+				method: 'POST',
+				headers: ws.headers,
+				body: JSON.stringify({
+					member_id: agent.id,
+					amount_cents: 900,
+					project_id: projectId,
+					description: 'project spend',
+				}),
+			});
+		},
+	});
+
+	await router.navigate({ to: '/projects/$projectId/budget', params: { projectId: teamSlug } });
+
+	// The daily window renders its $10 cap and 90% usage against the progress bar.
+	const daily = await findByTestId('budget-window-daily', undefined, { timeout: 15_000 });
+	await waitFor(() => {
+		expect(daily.textContent ?? '').toContain('$10.00');
+		expect(daily.textContent ?? '').toContain('90%');
+	});
+
+	// The binding-window banner surfaces the daily window and links to raise its cap.
+	const banner = await findByTestId('binding-window-banner');
+	expect(banner.textContent ?? '').toContain('Raise daily cap');
+});

--- a/packages/web/test/budget-page.test.tsx
+++ b/packages/web/test/budget-page.test.tsx
@@ -94,45 +94,68 @@ test('Budgets page renders per-day breakdown panels by agent and adapter', async
 	});
 });
 
-test('Budget page: editing limits inline updates the spend progress cards', async () => {
+test('Budget page: Project budget header has a single Edit link to the settings budget section', async () => {
 	let teamSlug = '';
-	let projectId = '';
 
-	const { findByTestId, findByRole, user, ctx, router } = await renderApp({
+	const { findByTestId, findByRole, queryByRole, user, router } = await renderApp({
 		initialPath: '/',
+		strictMode: true,
 		seed: async () => {
 			const ws = await seedWorkspace();
-			const project = await seedProject(ws, { name: 'Budget Inline' });
+			await seedProject(ws, { name: 'Budget Link' });
 			teamSlug = ws.internalSlug;
-			projectId = project.id;
 		},
 	});
 
 	await router.navigate({ to: '/projects/$projectId/budget', params: { projectId: teamSlug } });
 
-	// The progress display and the editor are one section: edit limits in place
-	// via the inline per-window pencil.
-	await user.click(await findByRole('button', { name: 'Edit Today cap' }));
-	await user.click(await findByTestId('budget-daily-toggle'));
-	const daily = (await findByTestId('budget-daily')) as HTMLInputElement;
-	await user.clear(daily);
-	await user.type(daily, '20');
-	await user.click(await findByRole('button', { name: 'Save' }));
+	// The per-window pencils are gone — caps are edited from settings now, not here.
+	const editLink = await findByTestId('edit-project-budget-link');
+	expect(queryByRole('button', { name: 'Edit Today cap' })).toBeNull();
+	expect(queryByRole('button', { name: 'Edit This week cap' })).toBeNull();
+	expect(queryByRole('button', { name: 'Edit This month cap' })).toBeNull();
 
-	// The window column (driven by budget-status) reflects the new $20 daily cap — i.e.
-	// editing the cap refreshes the same progress display it lives in.
-	await waitFor(
-		() => {
-			const col = document.querySelector('[data-testid="budget-window-daily"]');
-			expect(col?.textContent ?? '').toContain('$20.00');
+	// The single header Edit affordance points at the project settings budget anchor.
+	const href = editLink.closest('a')?.getAttribute('href') ?? '';
+	expect(href).toContain(`/projects/${teamSlug}/settings`);
+	expect(href).toContain('#budget');
+
+	// Following it lands on the settings page, where the budget caps editor lives.
+	await user.click(editLink);
+	await findByTestId('edit-project-budget', undefined, { timeout: 15_000 });
+	await findByRole('button', { name: 'Edit caps' });
+});
+
+test('Budget page: each agent card links to that agent’s settings budget section', async () => {
+	let teamSlug = '';
+	let agentSlug = '';
+	let agentTitle = '';
+
+	const { findByTestId, findByRole, findByText, user, router } = await renderApp({
+		initialPath: '/',
+		strictMode: true,
+		seed: async () => {
+			const ws = await seedWorkspace();
+			// Every team agent surfaces in the per-agent budget list (spend or not).
+			const agent = ws.agents.find((a) => a.slug === 'engineer') ?? ws.agents[0];
+			agentSlug = agent.slug;
+			agentTitle = agent.title;
+			teamSlug = ws.internalSlug;
 		},
-		{ timeout: 15_000 },
-	);
-	await waitFor(async () => {
-		const row = await ctx.db.query<{ daily_budget_cents: number }>(
-			'SELECT daily_budget_cents FROM projects WHERE id = $1',
-			[projectId],
-		);
-		expect(row.rows[0]?.daily_budget_cents).toBe(2000);
 	});
+
+	await router.navigate({ to: '/projects/$projectId/budget', params: { projectId: teamSlug } });
+
+	// The card carries a single Edit button pointing at the agent's settings budget anchor.
+	const editLink = await findByTestId(`edit-agent-budget-${agentSlug}`, undefined, {
+		timeout: 15_000,
+	});
+	const href = editLink.getAttribute('href') ?? '';
+	expect(href).toContain(`/agents/${agentSlug}/settings`);
+	expect(href).toContain('#budget');
+
+	// Following it lands on that agent's settings page with its budget editor.
+	await user.click(editLink);
+	await findByRole('heading', { name: agentTitle }, { timeout: 15_000 });
+	await findByText('Budget limits');
 });


### PR DESCRIPTION
## Summary

Consolidates budget-cap editing on the Budget page behind a single, discoverable **Edit** affordance per surface, and routes it to the pages where caps are actually edited.

**Project budget** — the three per-window pencil icons on the "Project budget" panel are replaced by one **Edit** button (icon + text) that sits as a suffix to the "Project budget" header. It links to the **project settings → budget section**, which is where caps are edited. The binding-window banner's "Raise cap" button now links there too, so the Budget page is read-only for caps and all editing lives in one place.

**Per-agent budgets** — each agent budget card gains a single edit button in its **top-right corner** that deep-links to that agent's **settings page → Budget limits** section.

## What changed

- `components/budget/project-budget-panel.tsx`
  - Removed the per-window pencil buttons from `WindowColumn`.
  - The `spend` variant's header now renders a single **Edit** link → `…/settings#budget`; the `limits` variant keeps its inline "Edit caps" editor unchanged.
  - The binding-window banner's "Raise cap" button links to `…/settings#budget` instead of opening an inline editor.
  - Added optional `sectionRef`/`sectionId` props so the settings page can anchor and scroll to the budget section.
- `routes/projects/$projectId/budget.tsx` — added a top-right Edit link to each per-agent card → that agent's `…/settings#budget` (via `agentPageParams`, so HQ agents resolve correctly).
- `routes/projects/$projectId/settings/index.tsx` and `routes/projects/$projectId/agents/$agentId/settings.tsx` — anchor their budget sections (`id="budget"`, `scroll-mt-20`) and wire up scroll-on-arrival.
- `hooks/use-scroll-to-hash.ts` (new) — a ref-callback hook that scrolls its element into view when the router hash matches; fires when the (async-loaded) section mounts, so a cross-page deep link lands on the budget editor even though it isn't in the DOM at navigation time. Guarded to fire once per hash.

No behavioural change to how caps are stored or enforced — only where the edit affordances live. Docs describe budgets conceptually and don't pin the edit affordance to a page, so no docs update was needed.

## Testing

- `packages/web/test/budget-page.test.tsx` — rewrote the obsolete inline-edit test; added coverage that the Project budget header exposes a single Edit link (and the per-window pencils are gone) that lands on the settings budget editor, and that each agent card links to its agent-settings budget section.
- Green: budget-page (4/4), project-settings (7/7), all agent-named web tests (78), typecheck, biome, and the full build (pre-commit hook).

Responsive: the header/card buttons and the banner's stacked → row layout were checked at all three breakpoints; the banner's "Raise cap" button keeps its full-width mobile tap target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFudGXWNSTHum1HDMxsmsN

---
_Generated by [Claude Code](https://claude.ai/code/session_01GFudGXWNSTHum1HDMxsmsN)_