### PR TITLE
feat(deploy): one-click / cloud-init deploy for VPS providers

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,62 @@
+# Hezo deploy artifacts
+
+One-click / near-one-click deployment of a self-hosted Hezo instance onto a VPS.
+
+Hezo runs as a host binary that needs the host Docker socket (it launches a
+container per project), so it deploys to a **real VPS/Droplet with Docker on the
+host** — not to a managed-container PaaS. These artifacts automate that host setup.
+
+## What's here
+
+| Path | Purpose |
+|---|---|
+| `provision.sh` | The canonical, self-contained installer. Installs Docker, downloads the `hezo` binary, sets up Caddy (automatic HTTPS + WebSocket passthrough), installs the systemd units, and locks the firewall down. Single source of truth — everything else runs it. |
+| `cloud-init/hezo.cloud-config.yaml` | Portable cloud-init user-data. Paste it into any VPS provider's "User data" field; it fetches and runs `provision.sh` on first boot. |
+
+## How it works
+
+`provision.sh` provisions the host, then a `hezo-firstboot` systemd unit derives
+the public HTTPS URL on first boot — `https://<public-ip>.sslip.io` by default (a
+real Let's Encrypt cert, no domain required), or a domain you supply via
+`HEZO_DOMAIN_OVERRIDE`. It never sets the master key: that is generated in the
+browser on first run and shown once, so the deploy lands you at the setup gate and
+you finish there (master key → admin password → connect a model). Password auth
+makes exposing that URL safe.
+
+Firewall posture: only **80/443** are public; **3100** (the Hezo server) and
+**20000–29999** (the per-run egress proxy) stay host-local, while the Docker
+bridge (`docker0`) can still reach the host so agent containers get their tools.
+See `docs/deployment/self-hosting.md` § Networking & firewall.
+
+## Using it
+
+The user-facing guide with per-provider steps is
+[`docs/deployment/one-click.md`](../docs/deployment/one-click.md). In short: create
+an Ubuntu server (≥2 GB RAM), paste `cloud-init/hezo.cloud-config.yaml` into its
+user-data field, wait ~2 minutes, open the `sslip.io` URL, finish setup.
+
+To run it by hand instead (e.g. an existing box):
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/hezo-ai/hezo/main/deploy/provision.sh | sudo bash
+```
+
+## Verifying a change
+
+`provision.sh` has no unit-test tier — it provisions a host, so verify it on a
+throwaway VM/droplet:
+
+1. **Local VM:** `multipass launch 24.04 --cloud-init cloud-init/hezo.cloud-config.yaml`,
+   then check `systemctl is-active hezo caddy` and
+   `curl -s http://127.0.0.1:3100/health` → `{"ok":true}`. (Multipass has no public
+   IP — set `HEZO_DOMAIN_OVERRIDE` to a local name to exercise Caddy.)
+2. **Throwaway droplet:** create a small droplet with the cloud-init, then from your
+   laptop hit `https://<ip>.sslip.io/health` (a valid cert proves the Let's Encrypt
+   path) and load the root URL to confirm you reach the master-key gate. Destroy it.
+
+## Roadmap — Phase 2 (not built yet)
+
+A `marketplace/digitalocean/` Packer template that bakes `provision.sh` into a
+DigitalOcean Marketplace image gives the literal one-click "Create Hezo Droplet"
+button. It's deferred because publishing requires an external DigitalOcean vendor
+account and image review that can't be done from this repo.

--- a/deploy/cloud-init/hezo.cloud-config.yaml
+++ b/deploy/cloud-init/hezo.cloud-config.yaml
@@ -1,0 +1,25 @@
+#cloud-config
+# ---------------------------------------------------------------------------
+# Hezo — portable one-click deploy (cloud-init user-data)
+#
+# Paste this whole file into your VPS provider's "User data" / "Cloud config" /
+# "Startup script" field when creating an Ubuntu server (2 GB RAM+ recommended).
+# Works as-is on DigitalOcean, Hetzner, Vultr, Linode, and AWS Lightsail.
+#
+# On first boot it installs Docker, downloads Hezo, sets up automatic HTTPS via
+# Caddy, and starts Hezo under systemd. After ~2 minutes, open the URL it derives
+# (https://<public-ip>.sslip.io) and finish the short in-browser setup: create
+# your master key, set an admin password, and connect a model.
+#
+# OPTIONAL — use your own domain instead of sslip.io: point an A record at the
+# server, then uncomment and edit the HEZO_DOMAIN_OVERRIDE line under runcmd.
+# ---------------------------------------------------------------------------
+package_update: true
+packages:
+  - curl
+
+runcmd:
+  # To use your own domain, set this before the curl line (A record must point here first):
+  # - [ sh, -c, "echo 'HEZO_DOMAIN_OVERRIDE=hezo.example.com' >> /etc/environment" ]
+  - [ sh, -c, "curl -fsSL https://raw.githubusercontent.com/hezo-ai/hezo/main/deploy/provision.sh -o /root/hezo-provision.sh" ]
+  - [ sh, -c, "set -a; [ -f /etc/environment ] && . /etc/environment; set +a; bash /root/hezo-provision.sh" ]

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+#
+# provision.sh — one-shot installer that turns a fresh Ubuntu host into a
+# running, HTTPS-reachable Hezo instance.
+#
+# It is the single source of truth for the one-click / cloud-init deploy:
+#   • the portable cloud-config (deploy/cloud-init/hezo.cloud-config.yaml) runs it
+#   • the DigitalOcean Marketplace image (deploy/marketplace/digitalocean) bakes it in
+#   • you can also just SSH into a box and run it by hand
+#
+# What it does, idempotently:
+#   1. installs Docker Engine and starts it (Hezo needs the host Docker socket)
+#   2. downloads the arch-matched `hezo` binary from GitHub Releases
+#   3. installs Caddy as a reverse proxy with automatic HTTPS + WebSocket passthrough
+#   4. installs systemd units (a first-boot unit that derives the public URL, then Hezo)
+#   5. locks the firewall down (only 80/443 public; 3100 + egress ports stay host-local)
+#
+# It never sets the master key: that is generated in the browser on first run and
+# shown once, so it cannot be pre-seeded. After boot, open the printed URL and
+# finish the short setup (create master key, set admin password, connect a model).
+#
+# Optional environment variables:
+#   HEZO_DOMAIN_OVERRIDE   use this domain instead of <public-ip>.sslip.io
+#                          (point an A record at the host first; Caddy gets a cert for it)
+#   HEZO_RELEASE_TAG       pin a release tag (default: latest)
+
+set -euo pipefail
+
+if [[ "${EUID}" -ne 0 ]]; then
+	echo "provision.sh must run as root (it installs packages and system services)." >&2
+	exit 1
+fi
+
+DATA_DIR="/var/lib/hezo"
+ENV_FILE="/etc/hezo/hezo.env"
+DEPLOY_ENV="/etc/hezo/deploy.env"
+RELEASE_TAG="${HEZO_RELEASE_TAG:-latest}"
+
+log() { echo "[hezo-provision] $*"; }
+
+# ---------------------------------------------------------------------------
+# 1. Docker Engine
+# ---------------------------------------------------------------------------
+if ! command -v docker >/dev/null 2>&1; then
+	log "Installing Docker Engine…"
+	curl -fsSL https://get.docker.com | sh
+fi
+systemctl enable --now docker
+log "Docker is running."
+
+# ---------------------------------------------------------------------------
+# 2. Hezo binary
+# ---------------------------------------------------------------------------
+case "$(uname -m)" in
+	x86_64) ARCH="x64" ;;
+	aarch64 | arm64) ARCH="arm64" ;;
+	*)
+		echo "Unsupported architecture: $(uname -m). Hezo ships linux-x64 and linux-arm64." >&2
+		exit 1
+		;;
+esac
+
+if [[ "${RELEASE_TAG}" == "latest" ]]; then
+	BINARY_URL="https://github.com/hezo-ai/hezo/releases/latest/download/hezo-linux-${ARCH}"
+else
+	BINARY_URL="https://github.com/hezo-ai/hezo/releases/download/${RELEASE_TAG}/hezo-linux-${ARCH}"
+fi
+
+log "Downloading hezo (${ARCH}) from ${BINARY_URL}"
+curl -fsSL -o /usr/local/bin/hezo "${BINARY_URL}"
+chmod +x /usr/local/bin/hezo
+
+# ---------------------------------------------------------------------------
+# 3. Data dir + environment file (never overwrite an operator-edited env file)
+# ---------------------------------------------------------------------------
+install -d -m 700 /etc/hezo
+install -d -m 755 "${DATA_DIR}"
+if [[ ! -f "${ENV_FILE}" ]]; then
+	install -m 600 /dev/null "${ENV_FILE}"
+	cat >"${ENV_FILE}" <<EOF
+HEZO_DATA_DIR=${DATA_DIR}
+# HEZO_WEB_URL is written by hezo-firstboot on first boot (see /usr/local/sbin/hezo-firstboot.sh).
+# After first-run setup you may add your 12-word master key here so reboots unlock unattended:
+# HEZO_MASTER_KEY=word1 word2 ... word12
+EOF
+fi
+
+# Persist the optional domain override so the first-boot unit can read it.
+if [[ -n "${HEZO_DOMAIN_OVERRIDE:-}" ]]; then
+	install -m 600 /dev/null "${DEPLOY_ENV}"
+	echo "HEZO_DOMAIN_OVERRIDE=${HEZO_DOMAIN_OVERRIDE}" >"${DEPLOY_ENV}"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Caddy (reverse proxy, automatic HTTPS, WebSocket passthrough)
+# ---------------------------------------------------------------------------
+if ! command -v caddy >/dev/null 2>&1; then
+	log "Installing Caddy…"
+	apt-get update -y
+	apt-get install -y debian-keyring debian-archive-keyring apt-transport-https curl
+	curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' |
+		gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+	curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' |
+		tee /etc/apt/sources.list.d/caddy-stable.list >/dev/null
+	apt-get update -y
+	apt-get install -y caddy
+fi
+
+# The site address is provided at runtime by hezo-firstboot via /etc/caddy/hezo.env.
+cat >/etc/caddy/Caddyfile <<'EOF'
+# Managed by Hezo provision.sh — the site address comes from HEZO_SITE_ADDRESS
+# (written to /etc/caddy/hezo.env by hezo-firstboot). Caddy provisions a
+# Let's Encrypt certificate for it automatically and passes WebSocket upgrades
+# (Hezo's /ws stream) straight through.
+{$HEZO_SITE_ADDRESS} {
+	reverse_proxy 127.0.0.1:3100
+}
+EOF
+
+# Feed HEZO_SITE_ADDRESS into Caddy's process and order it after first-boot.
+install -d /etc/systemd/system/caddy.service.d
+cat >/etc/systemd/system/caddy.service.d/hezo.conf <<'EOF'
+[Unit]
+After=hezo-firstboot.service
+Wants=hezo-firstboot.service
+
+[Service]
+EnvironmentFile=/etc/caddy/hezo.env
+EOF
+# Placeholder so caddy's EnvironmentFile exists before first-boot writes the real value.
+[[ -f /etc/caddy/hezo.env ]] || echo 'HEZO_SITE_ADDRESS=:80' >/etc/caddy/hezo.env
+
+# ---------------------------------------------------------------------------
+# 5. First-boot unit: derive the public URL, wire it into Caddy + Hezo
+# ---------------------------------------------------------------------------
+cat >/usr/local/sbin/hezo-firstboot.sh <<'EOF'
+#!/usr/bin/env bash
+# Runs once, before Caddy and Hezo start. Derives the public HTTPS URL from the
+# host's public IP (via <ip>.sslip.io) unless HEZO_DOMAIN_OVERRIDE is set, then
+# writes it where Caddy and Hezo read it.
+set -euo pipefail
+
+SENTINEL="/var/lib/hezo/.firstboot-done"
+[[ -f "${SENTINEL}" ]] && exit 0
+
+[[ -f /etc/hezo/deploy.env ]] && . /etc/hezo/deploy.env
+
+if [[ -n "${HEZO_DOMAIN_OVERRIDE:-}" ]]; then
+	DOMAIN="${HEZO_DOMAIN_OVERRIDE}"
+else
+	# DigitalOcean metadata first (exact public IP), then a provider-agnostic fallback.
+	IP="$(curl -fsS --max-time 5 http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address 2>/dev/null || true)"
+	[[ -z "${IP}" ]] && IP="$(curl -fsS --max-time 5 https://api.ipify.org 2>/dev/null || true)"
+	if [[ -z "${IP}" ]]; then
+		echo "hezo-firstboot: could not determine public IP; leaving Caddy on :80" >&2
+		exit 0
+	fi
+	DOMAIN="${IP}.sslip.io"
+fi
+
+echo "HEZO_SITE_ADDRESS=${DOMAIN}" >/etc/caddy/hezo.env
+grep -q '^HEZO_WEB_URL=' /etc/hezo/hezo.env || echo "HEZO_WEB_URL=https://${DOMAIN}" >>/etc/hezo/hezo.env
+
+install -d /var/lib/hezo
+touch "${SENTINEL}"
+echo "hezo-firstboot: public URL is https://${DOMAIN}"
+EOF
+chmod +x /usr/local/sbin/hezo-firstboot.sh
+
+cat >/etc/systemd/system/hezo-firstboot.service <<'EOF'
+[Unit]
+Description=Hezo first-boot URL setup
+After=network-online.target
+Wants=network-online.target
+Before=caddy.service hezo.service
+ConditionPathExists=!/var/lib/hezo/.firstboot-done
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/sbin/hezo-firstboot.sh
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# ---------------------------------------------------------------------------
+# 6. Hezo systemd unit (mirrors docs/deployment/self-hosting.md)
+# ---------------------------------------------------------------------------
+cat >/etc/systemd/system/hezo.service <<'EOF'
+[Unit]
+Description=Hezo
+Requires=docker.service
+After=docker.service network-online.target hezo-firstboot.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/hezo
+EnvironmentFile=/etc/hezo/hezo.env
+Restart=always
+RestartSec=5
+TimeoutStopSec=30
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# ---------------------------------------------------------------------------
+# 7. Firewall — only 80/443 public; keep 3100 and the egress range host-local,
+#    but let the Docker bridge reach the host (agents call back over docker0).
+#    See docs/deployment/self-hosting.md § Networking & firewall.
+# ---------------------------------------------------------------------------
+if command -v ufw >/dev/null 2>&1; then
+	ufw --force reset >/dev/null 2>&1 || true
+	ufw default deny incoming
+	ufw default allow outgoing
+	ufw allow OpenSSH
+	ufw allow 80/tcp
+	ufw allow 443/tcp
+	ufw allow in on docker0
+	ufw --force enable
+fi
+
+# ---------------------------------------------------------------------------
+# 8. Start everything
+# ---------------------------------------------------------------------------
+systemctl daemon-reload
+systemctl enable --now hezo-firstboot.service
+systemctl enable --now caddy
+# Re-run Caddy now that the real site address exists.
+systemctl restart caddy
+systemctl enable --now hezo
+
+log "Done. Once DNS + certificate settle (a few seconds), open the URL from:"
+log "  cat /etc/hezo/hezo.env    # HEZO_WEB_URL=https://<host>.sslip.io"

--- a/docs/deployment/cloud.md
+++ b/docs/deployment/cloud.md
@@ -10,6 +10,11 @@ Running Hezo on an always-on cloud server lets your teams keep working around th
 without your laptop being on. Any VPS that can run Docker works — for example
 DigitalOcean, Hetzner, Fly, Linode, or an EC2 instance.
 
+> **Want the fast path?** [One-click deploy](/docs/deployment/one-click) provisions all
+> of the below for you from a single cloud-init snippet — Docker, the binary, automatic
+> HTTPS, systemd, and the firewall — on DigitalOcean, Hetzner, Vultr, Linode, or
+> Lightsail. This page covers the manual shape if you'd rather set it up yourself.
+
 ## The shape of a cloud deployment
 
 1. **Provision a host with Docker** and install the `hezo` binary

--- a/docs/deployment/one-click.md
+++ b/docs/deployment/one-click.md
@@ -1,0 +1,115 @@
+---
+title: One-click deploy
+order: 25
+section: Deployment
+---
+
+# One-click deploy
+
+The fastest way to get a public, always-on Hezo running is to let your VPS
+provider provision it for you. You paste one snippet when you create the server,
+wait a couple of minutes, and open a working HTTPS URL — then finish the short
+[first-run setup](/docs/getting-started/first-run) in your browser.
+
+This works on any provider that runs Ubuntu and accepts **cloud-init user data**,
+which is all of the common ones: DigitalOcean, Hetzner, Vultr, Linode, and AWS
+Lightsail.
+
+## What it sets up
+
+On first boot the snippet:
+
+- installs **Docker** and starts it (Hezo runs each project's agents in a container),
+- downloads the latest **`hezo`** binary for the server's CPU architecture,
+- puts **Caddy** in front for **automatic HTTPS** with a real certificate — no domain
+  required (see [How the HTTPS URL works](#how-the-https-url-works)),
+- runs Hezo under **systemd** so it restarts on boot and after a crash, and
+- locks the **firewall** down so only the web ports (80/443) are public.
+
+It deliberately does **not** set your master key — that's generated in your browser
+on first run and shown once, so it can't be pre-filled. The deploy gets you to the
+setup screen; you take it from there.
+
+## Deploy it
+
+1. **Create an Ubuntu server** on your provider — 2 GB RAM or more is a good start.
+2. **Paste the snippet below** into the provider's user-data field (each provider
+   calls it something slightly different — see [Where to paste it](#where-to-paste-it)).
+3. **Create the server and wait ~2 minutes** for first boot to finish.
+4. **Open `https://<your-server-ip>.sslip.io`** and complete
+   [first-run setup](/docs/getting-started/first-run): create your master key, set an
+   admin password, and connect a model.
+
+```yaml
+#cloud-config
+package_update: true
+packages:
+  - curl
+runcmd:
+  # To use your own domain instead of sslip.io, point an A record at this server, then
+  # uncomment the next line and set your domain (do it before the curl line runs):
+  # - [ sh, -c, "echo 'HEZO_DOMAIN_OVERRIDE=hezo.example.com' >> /etc/environment" ]
+  - [ sh, -c, "curl -fsSL https://raw.githubusercontent.com/hezo-ai/hezo/main/deploy/provision.sh -o /root/hezo-provision.sh" ]
+  - [ sh, -c, "set -a; [ -f /etc/environment ] && . /etc/environment; set +a; bash /root/hezo-provision.sh" ]
+```
+
+The same file lives in the repo at
+[`deploy/cloud-init/hezo.cloud-config.yaml`](https://github.com/hezo-ai/hezo/blob/main/deploy/cloud-init/hezo.cloud-config.yaml),
+and the installer it runs is
+[`deploy/provision.sh`](https://github.com/hezo-ai/hezo/blob/main/deploy/provision.sh) —
+read them before you paste if you'd like to see exactly what runs.
+
+### Where to paste it
+
+| Provider | Field, on the create-server page |
+|---|---|
+| DigitalOcean | **Advanced options → Add Initialization scripts (user data)** |
+| Hetzner Cloud | **Cloud config** |
+| Vultr | **Additional Features → Enable Cloud-Init User-Data** |
+| Linode | **Add User Data** |
+| AWS Lightsail | **Add launch script** — and also open ports **80** and **443** in the Lightsail firewall (its console firewall is separate from the server's) |
+
+## How the HTTPS URL works
+
+Your browser needs HTTPS (Hezo streams agent activity over a secure WebSocket), but a
+fresh server has a public IP and usually no domain. To bridge that, the deploy uses
+**[sslip.io](https://sslip.io)** — a DNS service where `<ip>.sslip.io` always resolves
+to `<ip>`. So `https://203.0.113.10.sslip.io` points straight at your server, and Caddy
+automatically obtains a real Let's Encrypt certificate for it. No domain to buy, no DNS
+to configure, and no browser warnings.
+
+**Prefer your own domain?** Point an A record at the server's IP, then set
+`HEZO_DOMAIN_OVERRIDE` (uncomment the line in the snippet above). Caddy provisions a
+certificate for that name instead.
+
+## After it's up
+
+- **The master key locks the *instance*.** After any restart, Hezo comes up **locked**
+  until you provide the twelve words again. To have it unlock unattended on reboot, add
+  your saved key to the environment file the deploy created:
+
+  ```sh
+  # /etc/hezo/hezo.env
+  HEZO_MASTER_KEY=word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12
+  ```
+
+  Then `sudo systemctl restart hezo`. See
+  [First-run setup](/docs/getting-started/first-run) and
+  [Master key & encryption](/docs/security/master-key).
+- **Backups.** Everything lives in `/var/lib/hezo` — back that one directory up. See
+  [Backup & recovery](/docs/deployment/backup-and-recovery).
+- **Updates** work as usual: a superuser clicks **Install & restart** in the web app.
+  See [Self-hosting → Updating](/docs/deployment/self-hosting#updating).
+
+## Doing it by hand instead
+
+If you'd rather provision an existing server yourself, the same installer runs
+standalone:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/hezo-ai/hezo/main/deploy/provision.sh | sudo bash
+```
+
+For the fully manual path — your own systemd unit, reverse proxy, and firewall rules,
+step by step — see [Self-hosting](/docs/deployment/self-hosting) and
+[Deploying to the cloud](/docs/deployment/cloud).


### PR DESCRIPTION
## Why

Now that Hezo has password-based authentication, an instance can safely sit on a public URL — the first thing a visitor hits is the master-key gate + admin-password sign-in. That unblocks a **self-serve deploy** story: a user spins up a VPS and gets a running, HTTPS-reachable Hezo in ~2 minutes, then finishes the short browser setup.

Hezo runs as a **host binary that needs the host Docker socket** (it launches a container per project), so it targets a **real VPS/Droplet with Docker on the host** — not a managed-container PaaS. This is why DigitalOcean's own "Deploy to DO" button (App Platform), Render, Railway, and Fly's managed tier don't fit; the right mechanism is cloud-init/user-data on a Droplet.

This is **Phase 1: the portable cloud-init path**, which works today on every common provider with no external approvals. (Phase 2 — a DigitalOcean Marketplace image for the literal 1-click button — is noted as a roadmap item; it's blocked on an external DO vendor account + image review.)

## What's in it

- **`deploy/provision.sh`** — single-source installer. Installs Docker, downloads the arch-matched `hezo` binary from GitHub Releases, sets up **Caddy** (automatic HTTPS + WebSocket passthrough), installs the systemd units, and locks the firewall down (only 80/443 public; 3100 + the 20000–29999 egress range stay host-local, while `docker0` can still reach the host so agents get their tools). Idempotent; never overwrites an operator-edited env file.
- **`deploy/cloud-init/hezo.cloud-config.yaml`** — portable `#cloud-config` user-data that fetches and runs `provision.sh` on first boot. Works as-is on DigitalOcean, Hetzner, Vultr, Linode, and AWS Lightsail.
- **`deploy/README.md`** — overview, verification steps, and the Phase-2 note.
- **`docs/deployment/one-click.md`** — user-facing guide: per-provider "where to paste user-data" table, the sslip.io auto-HTTPS explainer, bring-your-own-domain, and post-deploy notes (unattended unlock, backups, updates). Ordered first in the Deployment section (`order: 25`).
- **`docs/deployment/cloud.md`** — links the fast path from the manual cloud guide.

## HTTPS with no domain

A fresh server has a public IP but usually no domain, yet browsers need HTTPS (Hezo streams over a secure WebSocket). A `hezo-firstboot` systemd unit derives `https://<public-ip>.sslip.io` and Caddy provisions a **real Let's Encrypt certificate** for it — zero config, no domain, no browser warnings. `HEZO_DOMAIN_OVERRIDE` switches to a user-supplied domain (point an A record, Caddy provisions for that name instead).

## First-run is intentionally in-browser

The 12-word master key is generated on first run and shown once, so it can't be pre-seeded. The deploy lands the user at the setup gate; they create the master key, set an admin password, and connect a model there. This is what makes exposing the URL safe.

## No server code change

The existing public `GET /health` readiness probe and env-driven config (`HEZO_PORT`, `HEZO_DATA_DIR`, `HEZO_MASTER_KEY`, `HEZO_WEB_URL`) already cover everything the artifact needs. This is pure packaging + docs.

## Testing

- `bash -n` on `provision.sh` and its embedded first-boot script — pass.
- Strict YAML parse of the cloud-config — valid (`#cloud-config`, `runcmd` well-formed).
- `docs-bundle.test.ts` — passes; the new page bundles into the CEO chat (34 docs).
- Pre-commit hook ran full typecheck + release build — green.
- End-to-end provisioning is integration/manual (no unit tier for host provisioning): `multipass launch --cloud-init …` for a local smoke test, or a throwaway droplet to confirm the real Let's Encrypt cert on `https://<ip>.sslip.io` and reaching the master-key gate. Steps are documented in `deploy/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBMdyzCx6h7hk7UmuTw8uK

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBMdyzCx6h7hk7UmuTw8uK)_