### PR TITLE
feat(deploy): add digitalocean marketplace packer image

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -54,9 +54,11 @@ throwaway VM/droplet:
    laptop hit `https://<ip>.sslip.io/health` (a valid cert proves the Let's Encrypt
    path) and load the root URL to confirm you reach the master-key gate. Destroy it.
 
-## Roadmap — Phase 2 (not built yet)
+## DigitalOcean Marketplace image (Phase 2)
 
-A `marketplace/digitalocean/` Packer template that bakes `provision.sh` into a
-DigitalOcean Marketplace image gives the literal one-click "Create Hezo Droplet"
-button. It's deferred because publishing requires an external DigitalOcean vendor
-account and image review that can't be done from this repo.
+[`marketplace/digitalocean/`](marketplace/digitalocean/README.md) holds a Packer
+template that bakes `provision.sh` into a DigitalOcean snapshot — the literal
+one-click "Create Hezo Droplet" button. The template and build/validation runbook
+are in-repo and buildable today; **publishing** the listing still requires an
+external DigitalOcean vendor account and DO's image review, which can't be done
+from this repo. See that directory's README for the build + submission steps.

--- a/deploy/marketplace/digitalocean/README.md
+++ b/deploy/marketplace/digitalocean/README.md
@@ -1,0 +1,94 @@
+# Hezo — DigitalOcean Marketplace 1-Click image
+
+This builds the DigitalOcean Marketplace **Droplet 1-Click** image — the literal
+"Create Hezo Droplet" button. It bakes Hezo into an Ubuntu snapshot using the same
+[`deploy/provision.sh`](../../provision.sh) the cloud-init path runs, so there is one
+source of truth for how a host is set up.
+
+The end-user experience: click **Create Hezo Droplet** → wait for first boot → open
+`https://<droplet-ip>.sslip.io` → finish the short setup (master key, admin password,
+model). Identical to the [cloud-init path](../../../docs/deployment/one-click.md), just
+with the software pre-baked so first boot is fast.
+
+## What's code (here) vs. external ops
+
+| Step | Where |
+|---|---|
+| Packer template + build-time provisioning (`hezo.pkr.hcl`, reusing `provision.sh`) | **This repo** |
+| DigitalOcean vendor account + Vendor Portal access | **External** — request at <https://marketplace.digitalocean.com/vendors> |
+| Running the build (needs a real `DIGITALOCEAN_TOKEN`; creates a snapshot in your DO account) | **External** — you run `packer build` |
+| Listing metadata, screenshots, category, pricing, first-boot instructions | **External** — Vendor Portal |
+| DO's automated `img-check` + manual review + publication | **External** — DO-side, on their timeline |
+
+You cannot complete the submission from this repo — it requires a DO vendor account and
+DO's review. Everything needed to *produce a valid, submittable image* is here.
+
+## How it works
+
+`provision.sh` runs with `HEZO_IMAGE_BUILD=1` (see its header). In that mode it installs
+Docker, the `hezo` binary, Caddy, the systemd units, and the firewall, and **enables** the
+services — but does **not** start them or derive a URL. That is deliberate: the build VM's
+IP must not be baked in. On the end user's first boot, `hezo-firstboot` (its sentinel is
+absent) derives `https://<their-ip>.sslip.io`, then Caddy and Hezo start.
+
+After provisioning, the template fetches and runs DigitalOcean's own
+[`90-cleanup.sh`](https://github.com/digitalocean/marketplace-partners/blob/master/scripts/90-cleanup.sh)
+(removes SSH host keys, `authorized_keys`, logs, bash history; zero-fills free space) and
+[`99-img-check.sh`](https://github.com/digitalocean/marketplace-partners/blob/master/scripts/99-img-check.sh)
+(validates the image against Marketplace requirements). They are fetched at build time so
+you always run DO's current, unmodified checks — pin `do_marketplace_ref` to a commit SHA
+for a reproducible build.
+
+## Prerequisites
+
+- [Packer](https://developer.hashicorp.com/packer/install) ≥ 1.9.
+- A DigitalOcean API token with **write** scope:
+  ```sh
+  export DIGITALOCEAN_TOKEN=dop_v1_...
+  ```
+
+## Build
+
+```sh
+cd deploy/marketplace/digitalocean
+packer init hezo.pkr.hcl        # installs the digitalocean plugin
+packer build hezo.pkr.hcl       # builds + validates; produces a snapshot in your account
+```
+
+Useful overrides (`-var`):
+
+- `hezo_release_tag=1.2.3` — bake a specific release instead of `latest`.
+- `do_marketplace_ref=<sha>` — pin DO's validators for reproducibility (recommended).
+- `region=`, `base_image=`, `size=` — build droplet location / base / size.
+
+A green build means `img-check` passed and a snapshot named `hezo-<timestamp>` now exists
+in your DO account. A failing `img-check` fails the build on purpose — fix the reported
+item and rebuild before submitting.
+
+## Test the snapshot before submitting
+
+1. Create a small droplet **from the snapshot** (Create → Snapshots → `hezo-<timestamp>`).
+2. From your laptop, hit `https://<droplet-ip>.sslip.io/health` — a valid (non-self-signed)
+   certificate proves the Let's Encrypt path provisioned against sslip.io on first boot.
+3. Load the root URL and confirm you reach the master-key gate; complete the three setup
+   steps. The CEO chat's live log stream proves the WebSocket passthrough works.
+4. Confirm the container→host path (agents' tools) is open:
+   ```sh
+   docker run --rm --add-host=host.docker.internal:host-gateway curlimages/curl \
+     curl -sv --max-time 5 http://host.docker.internal:3100/mcp
+   ```
+   Any HTTP status (even 401/404) is success; a timeout means the `docker0` firewall rule
+   is wrong. See [`docs/deployment/self-hosting.md`](../../../docs/deployment/self-hosting.md)
+   § Networking & firewall.
+5. Destroy the test droplet.
+
+## Submit
+
+In the [Vendor Portal](https://cloud.digitalocean.com/vendorportal): create the 1-Click
+app, attach the snapshot, and fill the listing (description, logo, category, pricing).
+For the **first-boot instructions**, tell users to open `https://<droplet-ip>.sslip.io`
+and complete setup. DO then runs its own validation and manual review before publishing.
+
+DO may ask for standard Marketplace niceties not needed for a working image — e.g. a
+first-login MOTD describing the app. Add those iteratively during review; keep
+`provision.sh` as the single source of truth for the actual host setup.

--- a/deploy/marketplace/digitalocean/hezo.pkr.hcl
+++ b/deploy/marketplace/digitalocean/hezo.pkr.hcl
@@ -1,0 +1,117 @@
+# Packer template for the Hezo DigitalOcean Marketplace 1-Click image.
+#
+# It bakes Hezo into an Ubuntu snapshot by running the SAME installer the
+# cloud-init path uses (deploy/provision.sh) in image-build mode, then runs
+# DigitalOcean's canonical Marketplace cleanup + validation scripts.
+#
+# In image-build mode provision.sh installs and enables everything but does NOT
+# start the services or derive the public URL — that happens on the END USER's
+# first boot (hezo-firstboot derives <ip>.sslip.io, then Caddy + Hezo start).
+#
+# Build (external — needs a DigitalOcean account + API token):
+#   export DIGITALOCEAN_TOKEN=dop_v1_...
+#   packer init hezo.pkr.hcl
+#   packer build hezo.pkr.hcl
+#
+# See README.md for the full build + Vendor Portal submission runbook.
+
+packer {
+  required_plugins {
+    digitalocean = {
+      version = ">= 1.4.0"
+      source  = "github.com/digitalocean/digitalocean"
+    }
+  }
+}
+
+variable "do_token" {
+  type      = string
+  sensitive = true
+  default   = env("DIGITALOCEAN_TOKEN")
+}
+
+variable "region" {
+  type    = string
+  default = "nyc3"
+}
+
+variable "base_image" {
+  type    = string
+  default = "ubuntu-24-04-x64"
+}
+
+variable "size" {
+  type        = string
+  description = "Build droplet size. A 2 GB box comfortably runs the install; the image works on any size the end user picks."
+  default     = "s-2vcpu-2gb"
+}
+
+variable "hezo_release_tag" {
+  type        = string
+  description = "Hezo release to bake in (default: latest). Auto-update upgrades it after boot."
+  default     = "latest"
+}
+
+variable "do_marketplace_ref" {
+  type        = string
+  description = "digitalocean/marketplace-partners git ref for the cleanup + img-check validators. Pin to a commit SHA for reproducible builds."
+  default     = "master"
+}
+
+locals {
+  timestamp = formatdate("YYYYMMDDhhmmss", timestamp())
+}
+
+source "digitalocean" "hezo" {
+  api_token     = var.do_token
+  image         = var.base_image
+  region        = var.region
+  size          = var.size
+  ssh_username  = "root"
+  snapshot_name = "hezo-${local.timestamp}"
+  tags          = ["hezo", "marketplace"]
+}
+
+build {
+  sources = ["source.digitalocean.hezo"]
+
+  # Let the base image's own cloud-init finish before we touch it.
+  provisioner "shell" {
+    inline = ["cloud-init status --wait"]
+  }
+
+  # Upload the single-source installer shared with the cloud-init path.
+  provisioner "file" {
+    source      = "${path.root}/../../provision.sh"
+    destination = "/opt/hezo-provision.sh"
+  }
+
+  # Bake Hezo in: install + enable, but don't start or derive the URL.
+  provisioner "shell" {
+    environment_vars = [
+      "HEZO_IMAGE_BUILD=1",
+      "HEZO_RELEASE_TAG=${var.hezo_release_tag}",
+      "DEBIAN_FRONTEND=noninteractive",
+    ]
+    inline = [
+      "chmod +x /opt/hezo-provision.sh",
+      "bash /opt/hezo-provision.sh",
+    ]
+  }
+
+  # DigitalOcean's canonical Marketplace cleanup + validation, fetched at build
+  # time so we always run their current, unmodified checks. Pin do_marketplace_ref
+  # to a commit SHA for a reproducible build. img-check exits non-zero on any
+  # failed requirement, which correctly fails the build before submission.
+  provisioner "shell" {
+    environment_vars = ["DEBIAN_FRONTEND=noninteractive"]
+    inline = [
+      "set -e",
+      "BASE=https://raw.githubusercontent.com/digitalocean/marketplace-partners/${var.do_marketplace_ref}/scripts",
+      "curl -fsSL \"$BASE/90-cleanup.sh\" -o /tmp/90-cleanup.sh",
+      "curl -fsSL \"$BASE/99-img-check.sh\" -o /tmp/99-img-check.sh",
+      "bash /tmp/90-cleanup.sh",
+      "bash /tmp/99-img-check.sh",
+    ]
+  }
+}

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -23,6 +23,11 @@
 #   HEZO_DOMAIN_OVERRIDE   use this domain instead of <public-ip>.sslip.io
 #                          (point an A record at the host first; Caddy gets a cert for it)
 #   HEZO_RELEASE_TAG       pin a release tag (default: latest)
+#   HEZO_IMAGE_BUILD       set to 1 when baking a machine image (e.g. the DigitalOcean
+#                          Marketplace Packer build). Installs and enables everything but
+#                          does NOT start the services or derive the public URL — that is
+#                          deferred to the end user's first boot, so no build-VM URL or
+#                          first-boot sentinel is baked into the snapshot.
 
 set -euo pipefail
 
@@ -223,14 +228,24 @@ if command -v ufw >/dev/null 2>&1; then
 fi
 
 # ---------------------------------------------------------------------------
-# 8. Start everything
+# 8. Enable (and, outside image builds, start) everything
 # ---------------------------------------------------------------------------
 systemctl daemon-reload
-systemctl enable --now hezo-firstboot.service
-systemctl enable --now caddy
-# Re-run Caddy now that the real site address exists.
-systemctl restart caddy
-systemctl enable --now hezo
 
-log "Done. Once DNS + certificate settle (a few seconds), open the URL from:"
-log "  cat /etc/hezo/hezo.env    # HEZO_WEB_URL=https://<host>.sslip.io"
+if [[ "${HEZO_IMAGE_BUILD:-}" == "1" ]]; then
+	# Machine-image build: enable units for boot but do not start them, and do not
+	# derive a URL. The end user's first boot runs hezo-firstboot (its sentinel is
+	# absent, so it fires) which sets the real <ip>.sslip.io address, then Caddy and
+	# Hezo start. Guard against a baked sentinel/URL just in case.
+	rm -f /var/lib/hezo/.firstboot-done
+	systemctl enable hezo-firstboot.service caddy hezo
+	log "Image build: services enabled for first boot (not started). URL is derived on the user's first boot."
+else
+	systemctl enable --now hezo-firstboot.service
+	systemctl enable --now caddy
+	# Re-run Caddy now that the real site address exists.
+	systemctl restart caddy
+	systemctl enable --now hezo
+	log "Done. Once DNS + certificate settle (a few seconds), open the URL from:"
+	log "  cat /etc/hezo/hezo.env    # HEZO_WEB_URL=https://<host>.sslip.io"
+fi


### PR DESCRIPTION
## Why

Phase 2 of one-click deploy, following up #547. That PR shipped the portable cloud-init path; this adds the literal **"Create Hezo Droplet"** DigitalOcean Marketplace 1-Click image.

Hezo needs the host Docker socket, so DO's App Platform button doesn't fit — the Marketplace mechanism is a **Droplet image** (a Packer-built snapshot). This PR is the in-repo half: a buildable, self-validating Packer template. Publishing the listing still needs an external DO vendor account + DO's review, which can't be done from the repo.

## What's in it

- **`deploy/provision.sh`** — new `HEZO_IMAGE_BUILD` mode. It installs and *enables* Docker, the binary, Caddy, the systemd units, and the firewall, but does **not** start the services or derive the public URL. That's deliberate: the build VM's IP must not be baked into the snapshot. On the **end user's** first boot, `hezo-firstboot` (sentinel absent) derives `https://<their-ip>.sslip.io` and Caddy + Hezo start. Same single source of truth as the cloud-init path — no duplicated setup logic.
- **`deploy/marketplace/digitalocean/hezo.pkr.hcl`** — `digitalocean` builder. Uploads `../../provision.sh`, runs it with `HEZO_IMAGE_BUILD=1`, then fetches and runs DigitalOcean's canonical `90-cleanup.sh` and `99-img-check.sh` (pinned via `do_marketplace_ref`) so the image is validated by DO's own, unmodified checks. A failing `img-check` fails the build on purpose.
- **`deploy/marketplace/digitalocean/README.md`** — build + Vendor-Portal submission runbook, with an explicit table of what's in-repo vs. external DO ops.
- **`deploy/README.md`** — roadmap note now points at the in-repo marketplace path.

## Design notes

- **DO validators are fetched at build time, not vendored** — always runs DO's current checks; pin `do_marketplace_ref` to a commit SHA for reproducibility.
- **`HEZO_IMAGE_BUILD` is a provisioner flag, not a `hezo` binary env var** — so it's intentionally not in `docs/deployment/configuration.md`.
- **Not a `packages/*` workspace** — this is bash/HCL/markdown ops tooling, so it lives under the root `deploy/` tree alongside `docker/`, `scripts/`, `agents/`, consistent with #547.

## Testing

- `bash -n deploy/provision.sh` — passes; the non-image path is unchanged (image mode only branches the final start step).
- Pre-commit hook ran full typecheck + release build — green.
- Packer wasn't available in this environment to `packer validate`; the template is standard HCL2 for the official `digitalocean` plugin. End-to-end image build + boot verification is external (needs a `DIGITALOCEAN_TOKEN`) and is documented step-by-step in the marketplace README (build → create droplet from snapshot → `https://<ip>.sslip.io/health` → complete setup → destroy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBMdyzCx6h7hk7UmuTw8uK

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBMdyzCx6h7hk7UmuTw8uK)_