### PR TITLE
Stop encouraging on-disk master key storage; enforce the rule in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -323,6 +323,12 @@ Wrap any multi-write sequence that must succeed/fail together in `BEGIN`/`COMMIT
 
 Never expose raw secrets, private keys, or signing keys via endpoints or logs. Use asymmetric crypto for cross-service verification, encrypt sensitive data at rest, and use `timingSafeEqual` for all hash/token/signature comparisons (never `===`).
 
+### Never encourage storing the master key on a system
+
+The **master key** is the one secret Hezo deliberately keeps **in memory only, never written to disk** — that in-memory-only invariant is what makes encryption-at-rest meaningful (anyone who can read the data directory *and* a persisted copy of the key can decrypt the entire vault). **Never encourage a user to store the master key anywhere on a system** — not in an env file, a `HEZO_MASTER_KEY=` line persisted to disk, a systemd/service definition, a config file, a shell profile, a same-host secrets file, or a code comment. This holds on every surface an agent produces: `docs/**`, `.dev/`, READMEs, CLI/`--help` text, deploy scripts (`deploy/**`), and agent replies. The secure default is to **unlock interactively** from the web gate — after any restart Hezo comes up **locked** by design, and that is the intended, secure behaviour, not a gap to paper over.
+
+`HEZO_MASTER_KEY` / `--master-key` are real and may be documented as the mechanism for a **single, non-interactive startup** (e.g. passed inline to one invocation) — but never as a place to *persist* the key. Whenever you touch a surface that mentions unattended unlock, frame it as "unlock from the browser" or "pass it for one startup without saving it," and warn against writing the phrase to disk. Treat "add your master key to the env file so reboots unlock unattended" as a security bug to fix, not a convenience to document.
+
 ### Credentials
 
 Agents reference secrets by **placeholder**, never by literal value. The pattern is `__HEZO_SECRET_<NAME>__` in any header or URL the agent emits; the egress proxy substitutes the real value at request time. Background and full lifecycle: `.dev/architecture.md` (§ Credentials, egress & secrets).

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -85,8 +85,9 @@ if [[ ! -f "${ENV_FILE}" ]]; then
 	cat >"${ENV_FILE}" <<EOF
 HEZO_DATA_DIR=${DATA_DIR}
 # HEZO_WEB_URL is written by hezo-firstboot on first boot (see /usr/local/sbin/hezo-firstboot.sh).
-# After first-run setup you may add your 12-word master key here so reboots unlock unattended:
-# HEZO_MASTER_KEY=word1 word2 ... word12
+# Do NOT put your master key in this file. Hezo keeps it in memory only and comes up locked
+# after each restart by design; unlock it from the browser gate. A copy of the key on disk
+# next to the encrypted data would let anyone who reads this box decrypt your vault.
 EOF
 fi
 

--- a/docs/deployment/cloud.md
+++ b/docs/deployment/cloud.md
@@ -26,8 +26,12 @@ DigitalOcean, Hetzner, Fly, Linode, or an EC2 instance.
    hezo --data-dir /var/lib/hezo
    ```
 
-3. **Bring it up unattended** by supplying the master key through the environment, so
-   the server unlocks on boot instead of waiting at the gate:
+3. **Unlock it from the browser.** After boot Hezo starts **locked** — open its gate
+   and enter your twelve-word master key to unlock the instance. This is by design:
+   the master key is kept in memory only and is never stored on the server, so a stolen
+   disk image can't decrypt your vault. If you need to unlock a single startup without
+   the browser, you can pass the key to that one invocation — but don't bake it into a
+   file or service definition:
 
    ```sh
    HEZO_MASTER_KEY="your twelve word master key phrase here" hezo --data-dir /var/lib/hezo

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -40,8 +40,8 @@ Run on a custom port with a dedicated data directory:
 hezo --port 8080 --data-dir /var/lib/hezo
 ```
 
-Bring an instance up unattended (for example under a service manager), unlocking it via
-the environment:
+Unlock a single startup non-interactively by passing the master key to that one
+invocation (Hezo normally starts **locked** and you unlock from the browser gate):
 
 ```sh
 HEZO_MASTER_KEY="your twelve word master key phrase here" \
@@ -49,6 +49,11 @@ HEZO_DATA_DIR=/var/lib/hezo \
 HEZO_WEB_URL=https://hezo.example.com \
   hezo
 ```
+
+Pass `HEZO_MASTER_KEY` inline like this only for a one-off launch — **never persist it**
+to an env file, a service definition, or anywhere on the host. The master key is kept in
+memory only so a copy of your disk can't decrypt your data; writing it to disk defeats
+that. See [Master key & encryption](/docs/security/master-key).
 
 ## Anonymous usage telemetry
 

--- a/docs/deployment/one-click.md
+++ b/docs/deployment/one-click.md
@@ -85,16 +85,12 @@ certificate for that name instead.
 ## After it's up
 
 - **The master key locks the *instance*.** After any restart, Hezo comes up **locked**
-  until you provide the twelve words again. To have it unlock unattended on reboot, add
-  your saved key to the environment file the deploy created:
-
-  ```sh
-  # /etc/hezo/hezo.env
-  HEZO_MASTER_KEY=word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12
-  ```
-
-  Then `sudo systemctl restart hezo`. See
-  [First-run setup](/docs/getting-started/first-run) and
+  until you provide the twelve words again on the browser gate — that locked-on-restart
+  behaviour is by design, and unlocking from the browser is the secure way to bring it
+  back up. **Don't save your master key to a file on the server** (an env file, the
+  systemd unit, anywhere on disk): it's the one secret Hezo keeps in memory only, and a
+  copy sitting next to the encrypted data lets anyone who can read the disk decrypt
+  everything. See [First-run setup](/docs/getting-started/first-run) and
   [Master key & encryption](/docs/security/master-key).
 - **Backups.** Everything lives in `/var/lib/hezo` — back that one directory up. See
   [Backup & recovery](/docs/deployment/backup-and-recovery).

--- a/docs/deployment/secure-remote-access.md
+++ b/docs/deployment/secure-remote-access.md
@@ -47,9 +47,10 @@ If you do want a public URL, terminate HTTPS with a reverse proxy (see
 directly.
 
 Hezo authenticates every session with your **admin password**, so a public deployment is
-no longer open by default. The practical setup is to supply the master key non-interactively
-(`HEZO_MASTER_KEY`) so the instance unlocks itself on each restart, while everyone still has
-to sign in with the password to reach the app:
+no longer open by default. Access is gated by that password on every request; the master
+key's job is separate — it unlocks the instance's encryption, and you provide it from the
+browser gate after each restart. **Don't store the master key on the server** to skip the
+unlock; keeping it in memory only is what protects the vault if the host is compromised.
 
 - **Set a strong admin password** and, if you upgraded an existing instance, change the
   default (`password`) before exposing it. See [Master key & encryption](/docs/security/master-key).

--- a/docs/deployment/self-hosting.md
+++ b/docs/deployment/self-hosting.md
@@ -38,16 +38,16 @@ hezo
 
 For an always-on instance, run it under your platform's service manager (for example a
 `systemd` unit on Linux) so it restarts on boot. Remember that Hezo starts **locked**
-after a restart — either unlock it from the web app or pass the master key via
-`HEZO_MASTER_KEY` so it can come up unattended (see
-[Deploying to the cloud](/docs/deployment/cloud)).
+after a restart — by design — so you unlock it from the web app's gate each time it comes
+back up. Don't store the master key on the server to skip that step; it's the one secret
+Hezo keeps in memory only (see [Master key & encryption](/docs/security/master-key)).
 
 ### Run as a systemd service (Linux)
 
 On a Linux host, a `systemd` unit gives you **auto-restart** (on crash and on
-boot) and **unattended unlock**. The unit below runs Hezo **as root** — the
-default when no `User=` is set — so the process reaches the Docker socket
-directly, with no need to add a user to the `docker` group.
+boot). The unit below runs Hezo **as root** — the default when no `User=` is set
+— so the process reaches the Docker socket directly, with no need to add a user
+to the `docker` group.
 
 **1. Install the prerequisites.** Make sure Docker is enabled and the `hezo`
 binary is on disk (see [Installation](/docs/getting-started/installation)):
@@ -58,24 +58,26 @@ command -v hezo                        # note the absolute path, e.g. /usr/local
 sudo mkdir -p /var/lib/hezo            # a stable data directory
 ```
 
-**2. Store the master key in a locked-down env file.** Pass the master key
-through the environment, never the `--master-key` flag — a flag is visible in
-`ps` and `systemctl cat`. Create a root-only env file:
+**2. Put non-secret settings in an env file.** Create an env file for the
+service — the data directory and, if the instance is reached via a public URL,
+its address:
 
 ```sh
 sudo install -d -m 700 /etc/hezo
 sudo install -m 600 /dev/null /etc/hezo/hezo.env
 ```
 
-Then add your settings to it (the twelve words come from
-[first-run setup](/docs/getting-started/first-run)):
-
 ```sh
 # /etc/hezo/hezo.env
-HEZO_MASTER_KEY=word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12
 HEZO_DATA_DIR=/var/lib/hezo
 # HEZO_WEB_URL=https://hezo.example.com   # only if reached via a public URL
 ```
+
+> **Never put your master key in this file** (or anywhere else on the server).
+> The master key is deliberately kept in memory only — a copy on disk next to the
+> encrypted data defeats encryption at rest, letting anyone who can read the disk
+> decrypt your vault. Hezo comes up **locked** after each restart on purpose; you
+> unlock it from the browser gate (step 5).
 
 **3. Create the unit** at `/etc/systemd/system/hezo.service`:
 
@@ -112,10 +114,10 @@ systemctl status hezo
 journalctl -u hezo -f          # follow the logs
 ```
 
-> **First run.** Until the master key is in `hezo.env`, Hezo comes up **locked** —
-> open it in the browser to create the key and finish setup, then add the twelve
-> words to the env file and `sudo systemctl restart hezo` so every future restart
-> unlocks unattended.
+**5. Unlock it in the browser.** Hezo comes up **locked** — open it in the browser
+to create your master key and finish setup on first run, and to unlock it again
+after each restart. Keep the twelve words somewhere safe **off** the server; Hezo
+never stores them, so unlocking from the gate is how the instance comes back up.
 
 In-app auto-update continues to work under systemd: Hezo swaps in the new binary
 and relaunches itself internally, so systemd sees one continuously running
@@ -276,11 +278,10 @@ run — for example inside a container — the bar instead links to the GitHub
 release page.)
 
 Because the restart re-locks the instance, **you'll need your 12-word master key
-to unlock Hezo again afterward** — unless you run Hezo with the master key set in
-the environment (`HEZO_MASTER_KEY`), in which case it unlocks itself on restart.
-The confirmation dialog tells you which case applies. In-flight agent runs are
-aborted and recovered automatically, and connected browsers reconnect on their
-own.
+to unlock Hezo again afterward** from the browser gate — that re-lock is by design,
+and unlocking interactively is the secure way back up (don't stash the key on the
+server to avoid it). In-flight agent runs are aborted and recovered automatically,
+and connected browsers reconnect on their own.
 
 Auto-update applies to the self-managed single binary. It is disabled when Hezo
 runs inside a container (update the image instead) and can be turned off with

--- a/docs/getting-started/first-run.md
+++ b/docs/getting-started/first-run.md
@@ -21,9 +21,11 @@ for you on first run.
   fresh. See [Master key & encryption](/docs/security/master-key).
 
 After every restart, Hezo starts **locked**: agents can't run and secrets can't be
-read until you provide the phrase again on the unlock screen. You can also supply it
-non-interactively with `--master-key` / the `HEZO_MASTER_KEY` environment variable —
-useful for servers (see [Deploying to the cloud](/docs/deployment/cloud)).
+read until you provide the phrase again on the unlock screen. This is by design — unlock
+it from the browser each time. You can pass it to a single startup non-interactively with
+`--master-key` / the `HEZO_MASTER_KEY` environment variable, but don't store the phrase on
+the server (see [Deploying to the cloud](/docs/deployment/cloud) and
+[Master key & encryption](/docs/security/master-key)).
 
 ## 2. Set an admin password
 

--- a/docs/security/master-key.md
+++ b/docs/security/master-key.md
@@ -34,9 +34,26 @@ Hezo has a simple gate around your secrets:
 - **Unlocked** — you've provided the correct phrase; Hezo can decrypt secrets and
   agents run normally.
 
-You unlock from the web app's gate screen, or non-interactively with the `--master-key`
-flag / `HEZO_MASTER_KEY` environment variable when running on a server (see
-[Deploying to the cloud](/docs/deployment/cloud)).
+You unlock from the web app's gate screen. On a server you can also unlock a **single
+startup** non-interactively by passing the `--master-key` flag / `HEZO_MASTER_KEY`
+environment variable to that one invocation (see
+[Deploying to the cloud](/docs/deployment/cloud)) — but don't persist the phrase to disk
+to do it (see [Keep it off the server](#keep-it-off-the-server) below).
+
+## Keep it off the server
+
+The master key's protection comes entirely from where it *isn't*: it lives in memory only
+and is **never written to disk**, so the encrypted data directory is useless to anyone who
+copies it without the phrase. **Don't undo that by storing the key on the server yourself** —
+not in an env file (`/etc/hezo/hezo.env`), the systemd unit, a shell profile, a same-host
+secrets file, or a note in the repo. A copy of the phrase sitting next to the encrypted
+vault means a stolen disk image, a leaked backup, or anyone who can read the box can decrypt
+everything — exactly what encryption at rest is meant to prevent.
+
+That Hezo comes up **locked** after every restart is the feature, not an inconvenience:
+unlock it from the browser gate each time. If you genuinely must automate one launch, you
+can pass `HEZO_MASTER_KEY` to that single invocation, but treat the phrase like a crypto
+wallet seed — keep the only durable copy somewhere safe **off** the server.
 
 ## Your password vs. the master key
 
@@ -49,9 +66,10 @@ The master key and your password do two different jobs:
   with it. Your password (like the master key) never leaves your browser — Hezo stores only
   a verifier it can check a login against, never the password itself.
 
-This split is what lets you run Hezo on a public network safely: set `HEZO_MASTER_KEY` on
-the server so it unlocks automatically on every restart, and everyone still has to sign in
-with the password to reach the app. See
+This split is what lets you run Hezo on a public network safely: access is gated by the
+admin password on every request, while the master key stays purely about unlocking
+encryption. You unlock the instance from the browser gate after each restart, and everyone
+still has to sign in with the password to reach the app. See
 [Secure remote access](/docs/deployment/secure-remote-access).
 
 **Forgot your password?** Reset it with your master key: on the sign-in screen choose


### PR DESCRIPTION
## Why

The master key is deliberately held **in memory only and never written to disk** — that invariant is the whole reason encryption at rest is meaningful. Yet several user-facing docs (and the deploy script) recommended persisting it — `HEZO_MASTER_KEY` in `/etc/hezo/hezo.env`, a systemd `EnvironmentFile`, etc. — so instances would "unlock unattended" on reboot. That guidance defeats the protection: a copy of the phrase sitting next to the encrypted vault lets anyone who can read the disk (a stolen image, a leaked backup, a compromised host) decrypt everything.

The screenshot that prompted this was the **One-click deploy** page telling users to add the twelve words to `/etc/hezo/hezo.env`.

## What changed

**Enforcement rule (`AGENTS.md`)**
- New Security subsection: *never* encourage a user to store the master key anywhere on a system — env files, persisted `HEZO_MASTER_KEY=` lines, service definitions, config, shell profiles, same-host secrets files, or comments — across every surface an agent produces (`docs/**`, `.dev/`, READMEs, CLI/`--help`, `deploy/**`, replies). `HEZO_MASTER_KEY` / `--master-key` may still be documented as a **single-startup** mechanism, never as a place to persist the key. "Add your master key to the env file so reboots unlock unattended" is called out as a security bug to fix.

**Docs reframed to interactive browser-gate unlock (the secure default)**
- `docs/deployment/one-click.md` — removed the `/etc/hezo/hezo.env` master-key recipe; locked-on-restart is by design, unlock from the browser, with a warning against saving the key to disk.
- `docs/deployment/self-hosting.md` — the systemd "Store the master key in a locked-down env file" step becomes "Put non-secret settings in an env file" (data dir / web URL only) with a blockquote forbidding the key; the flow ends at a new **step 5: unlock in the browser**; the auto-update re-lock note no longer offers the env-var escape hatch.
- `docs/deployment/cloud.md`, `docs/deployment/configuration.md` — keep the `HEZO_MASTER_KEY` inline example as a one-off launch, with an explicit "never persist it" warning.
- `docs/deployment/secure-remote-access.md` — access is gated by the admin password; the master key stays about unlocking encryption and shouldn't live on the server.
- `docs/getting-started/first-run.md` — unlock from the browser each time; don't store the phrase on the server.
- `docs/security/master-key.md` — new **"Keep it off the server"** section; reworded the "run on a public network safely" paragraph so it no longer says to set `HEZO_MASTER_KEY` for automatic unlock on every restart.

**Deploy script (`deploy/provision.sh`)**
- The generated `hezo.env` no longer hints at adding `HEZO_MASTER_KEY`; it now warns against it.

## Notes

- `HEZO_MASTER_KEY` / `--master-key` remain real, working flags — this only changes how they're *presented* (single-startup, not persisted). No code behavior changed.
- The docs bundle (`docs-bundle.json`, feeding the CEO chat) is a gitignored build artifact regenerated from `docs/` at build time, so these edits reach the CEO automatically; no manual rebuild needed.
- Internal `.dev/architecture.md` / `.dev/hosted-architecture.md` only *describe* the `HEZO_MASTER_KEY` mechanism (permitted by the rule), so they're left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7jrazadoas7uf4nMixEMq

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7jrazadoas7uf4nMixEMq)_