### PR TITLE
fix(web): hide run status text on mobile in run comment top bar

### DIFF
--- a/packages/web/src/components/comment-renderers/run-comment.tsx
+++ b/packages/web/src/components/comment-renderers/run-comment.tsx
@@ -319,7 +319,7 @@ export function RunCommentBody({
 								<span
 									className={`inline-block w-2 h-2 rounded-full ${runStatusDotClass(status)}`}
 								/>
-								<span>
+								<span className="hidden sm:inline">
 									{agentTitle} — {runStatusLabel(status)}
 								</span>
 							</span>

--- a/test/browser/task-detail.mobile.spec.ts
+++ b/test/browser/task-detail.mobile.spec.ts
@@ -261,7 +261,7 @@ test.describe('Agent-run meta — mobile (390px)', () => {
 		await expect(runCommentEl.getByTestId('run-comment-actor')).toBeHidden();
 	});
 
-	test('expanded log top bar hides the "Logs" label and line count', async ({
+	test('expanded log top bar hides the status label, "Logs" word, and line count', async ({
 		page,
 		freshWorkspace,
 	}) => {
@@ -280,9 +280,10 @@ test.describe('Agent-run meta — mobile (390px)', () => {
 		// Scope to the log region so we read the toolbar's own label/count, not the
 		// (also-hidden) summary line count that lives in the header above it.
 		const logRegion = runCommentEl.locator('[id^="run-comment-log-"]');
-		// The agent status label still anchors the toolbar; the redundant "Logs"
-		// word and line count are hidden on mobile.
-		await expect(logRegion.getByText(/Product Lead.*succeeded/)).toBeVisible();
+		// On mobile the toolbar is anchored by the status dot alone; the agent
+		// status label, the redundant "Logs" word, and the line count are all
+		// hidden to free up horizontal room for the toolbar buttons.
+		await expect(logRegion.getByText(/Product Lead.*succeeded/)).toBeHidden();
 		await expect(logRegion.getByText('Logs', { exact: true })).toBeHidden();
 		await expect(logRegion.getByText('27 lines', { exact: true })).toBeHidden();
 	});


### PR DESCRIPTION
## Summary

On narrow (mobile) screens, the execution run log header showed the `<agent> — <status>` live label (e.g. "Captain — running") on the left, which crowded the toolbar buttons in the top bar.

This hides that text on mobile while keeping the colored status dot as a compact indicator. The full label returns at the `sm` breakpoint (≥640px), so desktop/tablet are unchanged.

## Changes

- `packages/web/src/components/comment-renderers/run-comment.tsx`: add `hidden sm:inline` to the `liveLabel` text span passed to `LogViewer`. The status dot beside it stays visible at all widths.

## Testing

- `bunx vitest run test/log-viewer-branches.test.tsx` — passes (9 tests)
- `turbo typecheck` + full build — pass

## Before / after (mobile)

Before: `● Captain — running` + toolbar buttons wrapped/crowded.
After: `●` + toolbar buttons only. Desktop still shows the full label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4mpoB4xguKH9GeyRKTvy4

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4mpoB4xguKH9GeyRKTvy4)_