### PR TITLE
feat(web): draggable floating buttons on portrait mobile screens

### DIFF
--- a/docs/concepts/roles-and-coordination.md
+++ b/docs/concepts/roles-and-coordination.md
@@ -77,7 +77,9 @@ follow its thinking instead of waiting for a finished block of text.
 
 Keep working alongside it: **minimize** the chat to the corner button and a badge appears
 there when a CEO reply lands while you're away — the same unread indicator the inbox uses
-— clearing the moment you reopen it. When you want more room, **expand** the chat to fill
+— clearing the moment you reopen it. On a phone, the corner button (like the floating "+"
+new-task button) can be **dragged** anywhere on screen to move it off content it covers;
+it stays where you drop it until the page reloads. When you want more room, **expand** the chat to fill
 the screen below the top navigation bar; expanding dims the rest of the page into a focused,
 modal view. Collapse it back to the anchored panel when you're done, or press **Escape**
 (or click the dimmed area) to close the chat.

--- a/packages/web/src/components/ceo-chat/ceo-chat-widget.tsx
+++ b/packages/web/src/components/ceo-chat/ceo-chat-widget.tsx
@@ -13,6 +13,7 @@ import {
 import { type ReactNode, useEffect, useRef, useState } from 'react';
 import { type CeoMessage, useCeoChat } from '../../hooks/use-ceo-chat';
 import { useContainerHealth } from '../../hooks/use-container-health';
+import { useDraggableFab } from '../../hooks/use-draggable-fab';
 import { useHqProject } from '../../hooks/use-projects';
 import { copyToClipboard } from '../../lib/clipboard';
 import { HqContainerNotice } from '../hq-container-notice';
@@ -27,7 +28,8 @@ function fitTextareaToContent(el: HTMLTextAreaElement): void {
 }
 
 /**
- * Floating chat with the CEO, pinned bottom-right. Talks to the single global CEO
+ * Floating chat with the CEO, pinned bottom-right (on portrait mobile screens
+ * the launcher can be dragged elsewhere). Talks to the single global CEO
  * conversation; messages stream in over the `ceo:global` WebSocket room. Sending a
  * new message while a reply is in flight interrupts it (handled server-side) and
  * starts a fresh turn. The CEO is the instance-level singleton living in the HQ
@@ -43,6 +45,9 @@ interface CeoChatWidgetProps {
 export function CeoChatWidget({ open, onOpenChange }: CeoChatWidgetProps) {
 	const setOpen = onOpenChange;
 	const [expanded, setExpanded] = useState(false);
+	// Draggable launcher on portrait mobile screens (the panel itself never
+	// moves). Must be called before the `if (!open)` early return below.
+	const fab = useDraggableFab('ceo-chat');
 	const { messages, send, streaming, sending, loaded, unread, compactedCount } = useCeoChat(open);
 	const hq = useHqProject();
 	const hqHealth = useContainerHealth(hq);
@@ -143,11 +148,14 @@ export function CeoChatWidget({ open, onOpenChange }: CeoChatWidgetProps) {
 		return (
 			<Tooltip content="Chat with CEO" side="left">
 				<button
+					ref={fab.ref}
 					type="button"
 					onClick={() => setOpen(true)}
+					{...fab.handlers}
+					style={fab.style}
 					data-testid="ceo-chat-launcher"
 					aria-label={unread > 0 ? `Chat with the CEO (${unread} unread)` : 'Chat with the CEO'}
-					className="fixed bottom-4 right-4 z-50 flex h-12 w-12 items-center justify-center rounded-full bg-inverse text-inverse-fg shadow-lg hover:opacity-90"
+					className="fixed bottom-4 right-4 z-50 flex h-12 w-12 touch-none items-center justify-center rounded-full bg-inverse text-inverse-fg shadow-lg hover:opacity-90"
 				>
 					<MessageSquare className="h-5 w-5" />
 					{/* Unread CEO replies overlay the launcher, mirroring the inbox icon. */}

--- a/packages/web/src/components/document-review/reviewable-document.tsx
+++ b/packages/web/src/components/document-review/reviewable-document.tsx
@@ -7,6 +7,7 @@ import {
 	useDocReviewComments,
 	useUpdateDocReviewComment,
 } from '../../hooks/use-doc-review';
+import { useMediaQuery } from '../../hooks/use-media-query';
 import { toast } from '../../hooks/use-toast';
 import {
 	computeBlockAnchor,
@@ -371,22 +372,6 @@ function selectionIntersectsMark(contentEl: HTMLElement, range: Range): boolean 
 		}
 	}
 	return false;
-}
-
-function useMediaQuery(query: string): boolean {
-	const [matches, setMatches] = useState(() => {
-		if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false;
-		return window.matchMedia(query).matches;
-	});
-	useEffect(() => {
-		if (typeof window.matchMedia !== 'function') return;
-		const mql = window.matchMedia(query);
-		const onChange = () => setMatches(mql.matches);
-		mql.addEventListener?.('change', onChange);
-		setMatches(mql.matches);
-		return () => mql.removeEventListener?.('change', onChange);
-	}, [query]);
-	return matches;
 }
 
 interface ReviewEditorProps {

--- a/packages/web/src/components/floating-new-task-button.tsx
+++ b/packages/web/src/components/floating-new-task-button.tsx
@@ -1,6 +1,7 @@
 import { Plus } from 'lucide-react';
 import { useState } from 'react';
 import { useActiveProject } from '../hooks/use-active-project';
+import { useDraggableFab } from '../hooks/use-draggable-fab';
 import { CreateTaskDialog } from './create-task-dialog';
 import { Tooltip } from './ui/tooltip';
 
@@ -26,21 +27,28 @@ interface FloatingNewTaskButtonProps {
  * menu is always visible and carries its own "+" next to the Tasks link, so a
  * floating duplicate there would be redundant. It renders on every mobile route
  * (project-scoped or not) — the dialog's picker supplies the target project.
+ *
+ * On portrait mobile screens the button is draggable (via `useDraggableFab`)
+ * so it can be moved off content it would otherwise cover.
  */
 export function FloatingNewTaskButton({ hidden }: FloatingNewTaskButtonProps) {
 	const active = useActiveProject();
 	const [open, setOpen] = useState(false);
+	const fab = useDraggableFab('new-task');
 
 	return (
 		<>
 			{!hidden && (
 				<Tooltip content="New task" side="right">
 					<button
+						ref={fab.ref}
 						type="button"
 						onClick={() => setOpen(true)}
+						{...fab.handlers}
+						style={fab.style}
 						data-testid="floating-new-task"
 						aria-label="New task"
-						className="lg:hidden fixed bottom-4 left-4 z-40 flex h-12 w-12 items-center justify-center rounded-full bg-accent-solid text-accent-solid-fg shadow-lg transition-colors hover:bg-accent-hover"
+						className="lg:hidden fixed bottom-4 left-4 z-40 flex h-12 w-12 touch-none items-center justify-center rounded-full bg-accent-solid text-accent-solid-fg shadow-lg transition-colors hover:bg-accent-hover"
 					>
 						<Plus className="h-6 w-6" />
 					</button>

--- a/packages/web/src/hooks/use-draggable-fab.ts
+++ b/packages/web/src/hooks/use-draggable-fab.ts
@@ -1,0 +1,198 @@
+import {
+	type CSSProperties,
+	type MouseEvent as ReactMouseEvent,
+	type PointerEvent as ReactPointerEvent,
+	type RefObject,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from 'react';
+import {
+	type FabId,
+	type FabPosition,
+	fabPixelPosition,
+	getFabPosition,
+	pixelsToFabPosition,
+	setFabPosition,
+} from '../lib/fab-position';
+import { useMediaQuery } from './use-media-query';
+
+/**
+ * Below this pointer travel (px) a press is a tap and the button never moves;
+ * beyond it the gesture becomes a drag and the resulting click is swallowed.
+ */
+const DRAG_THRESHOLD_PX = 8;
+
+/** Matches the buttons' `h-12 w-12` before the ref has a measured element. */
+const FALLBACK_BUTTON_SIZE = 48;
+
+/**
+ * Drag is only offered where the floating buttons overlay content and can
+ * occlude it: portrait phone/tablet layouts. Landscape and `lg`+ keep the
+ * default fixed corners. Mirrors Tailwind's `lg` boundary (1024px).
+ */
+const DRAG_MEDIA_QUERY = '(max-width: 1023px) and (orientation: portrait)';
+
+interface DragGesture {
+	pointerId: number;
+	startX: number;
+	startY: number;
+	originLeft: number;
+	originTop: number;
+	/** Set once travel passes the threshold — from then on it's a drag. */
+	moved: boolean;
+}
+
+export interface DraggableFab {
+	ref: RefObject<HTMLButtonElement | null>;
+	/**
+	 * Inline position when the button has been dragged on a portrait mobile
+	 * screen; `undefined` leaves the default corner classes in charge. The
+	 * `auto`s neutralize the class-based `bottom-*`/`left-*`/`right-*` anchors.
+	 */
+	style: CSSProperties | undefined;
+	handlers: {
+		onPointerDown: (e: ReactPointerEvent<HTMLButtonElement>) => void;
+		onClickCapture: (e: ReactMouseEvent<HTMLButtonElement>) => void;
+	};
+}
+
+/**
+ * Makes a floating action button draggable anywhere in the viewport on
+ * portrait mobile screens (camera-app style), so it can be moved off content
+ * it would otherwise occlude. Free placement — the button stays exactly where
+ * it's dropped, clamped fully on-screen. The position is in-memory only
+ * (module-level, per {@link FabId}): it survives the button unmounting and
+ * remounting within the page's lifetime but resets on refresh.
+ */
+export function useDraggableFab(id: FabId): DraggableFab {
+	const draggable = useMediaQuery(DRAG_MEDIA_QUERY);
+	const ref = useRef<HTMLButtonElement | null>(null);
+	const [pos, setPos] = useState<FabPosition | null>(() => getFabPosition(id));
+	const [viewport, setViewport] = useState(() =>
+		typeof window === 'undefined'
+			? { w: 0, h: 0 }
+			: { w: window.innerWidth, h: window.innerHeight },
+	);
+	const posRef = useRef(pos);
+	posRef.current = pos;
+	const gestureRef = useRef<DragGesture | null>(null);
+	const suppressClickRef = useRef(false);
+	// Gates the document-level move/up listeners to the lifetime of a gesture.
+	const [gestureActive, setGestureActive] = useState(false);
+
+	// Re-clamp on rotation/resize. `window.inner*` is the layout viewport, which
+	// is what `position: fixed` elements are laid out against (correct even with
+	// the soft keyboard up).
+	useEffect(() => {
+		if (!draggable) return;
+		const update = () => setViewport({ w: window.innerWidth, h: window.innerHeight });
+		update();
+		window.addEventListener('resize', update);
+		window.addEventListener('orientationchange', update);
+		return () => {
+			window.removeEventListener('resize', update);
+			window.removeEventListener('orientationchange', update);
+		};
+	}, [draggable]);
+
+	useEffect(() => {
+		if (!gestureActive) return;
+		const buttonSize = () => ({
+			w: ref.current?.offsetWidth || FALLBACK_BUTTON_SIZE,
+			h: ref.current?.offsetHeight || FALLBACK_BUTTON_SIZE,
+		});
+		const endGesture = () => {
+			gestureRef.current = null;
+			setGestureActive(false);
+		};
+		const onMove = (e: PointerEvent) => {
+			const g = gestureRef.current;
+			if (!g || e.pointerId !== g.pointerId) return;
+			const dx = e.clientX - g.startX;
+			const dy = e.clientY - g.startY;
+			if (!g.moved && Math.hypot(dx, dy) < DRAG_THRESHOLD_PX) return;
+			g.moved = true;
+			const { w, h } = buttonSize();
+			setPos(
+				pixelsToFabPosition(
+					g.originLeft + dx,
+					g.originTop + dy,
+					w,
+					h,
+					window.innerWidth,
+					window.innerHeight,
+				),
+			);
+		};
+		const onUp = (e: PointerEvent) => {
+			const g = gestureRef.current;
+			if (!g || e.pointerId !== g.pointerId) return;
+			const dropped = g.moved;
+			endGesture();
+			if (dropped) {
+				// A real drag: remember the drop point and swallow the click the
+				// browser is about to synthesize on this button.
+				suppressClickRef.current = true;
+				if (posRef.current) setFabPosition(id, posRef.current);
+			}
+		};
+		const onCancel = (e: PointerEvent) => {
+			const g = gestureRef.current;
+			if (!g || e.pointerId !== g.pointerId) return;
+			endGesture();
+			// Revert to the last committed spot (or the default corner).
+			setPos(getFabPosition(id));
+		};
+		document.addEventListener('pointermove', onMove);
+		document.addEventListener('pointerup', onUp);
+		document.addEventListener('pointercancel', onCancel);
+		return () => {
+			document.removeEventListener('pointermove', onMove);
+			document.removeEventListener('pointerup', onUp);
+			document.removeEventListener('pointercancel', onCancel);
+		};
+	}, [gestureActive, id]);
+
+	const onPointerDown = useCallback(
+		(e: ReactPointerEvent<HTMLButtonElement>) => {
+			if (!draggable || !e.isPrimary || e.button !== 0) return;
+			const el = ref.current;
+			if (!el) return;
+			const rect = el.getBoundingClientRect();
+			gestureRef.current = {
+				pointerId: e.pointerId,
+				startX: e.clientX,
+				startY: e.clientY,
+				originLeft: rect.left,
+				originTop: rect.top,
+				moved: false,
+			};
+			try {
+				el.setPointerCapture(e.pointerId);
+			} catch {
+				// happy-dom lacks pointer capture; document listeners still work.
+			}
+			setGestureActive(true);
+		},
+		[draggable],
+	);
+
+	const onClickCapture = useCallback((e: ReactMouseEvent<HTMLButtonElement>) => {
+		if (!suppressClickRef.current) return;
+		suppressClickRef.current = false;
+		e.preventDefault();
+		e.stopPropagation();
+	}, []);
+
+	let style: CSSProperties | undefined;
+	if (draggable && pos) {
+		const w = ref.current?.offsetWidth || FALLBACK_BUTTON_SIZE;
+		const h = ref.current?.offsetHeight || FALLBACK_BUTTON_SIZE;
+		const { left, top } = fabPixelPosition(pos, w, h, viewport.w, viewport.h);
+		style = { left, top, right: 'auto', bottom: 'auto' };
+	}
+
+	return { ref, style, handlers: { onPointerDown, onClickCapture } };
+}

--- a/packages/web/src/hooks/use-media-query.ts
+++ b/packages/web/src/hooks/use-media-query.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Reactive `window.matchMedia` — re-renders when the query flips. Guards for
+ * environments without `matchMedia` (happy-dom in component tests), where it
+ * always reports `false`.
+ */
+export function useMediaQuery(query: string): boolean {
+	const [matches, setMatches] = useState(() => {
+		if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false;
+		return window.matchMedia(query).matches;
+	});
+	useEffect(() => {
+		if (typeof window.matchMedia !== 'function') return;
+		const mql = window.matchMedia(query);
+		const onChange = () => setMatches(mql.matches);
+		mql.addEventListener?.('change', onChange);
+		setMatches(mql.matches);
+		return () => mql.removeEventListener?.('change', onChange);
+	}, [query]);
+	return matches;
+}

--- a/packages/web/src/lib/fab-position.ts
+++ b/packages/web/src/lib/fab-position.ts
@@ -1,0 +1,82 @@
+/**
+ * In-memory positions for the draggable floating action buttons (the "+"
+ * create-task button and the CEO chat launcher) on portrait mobile screens.
+ *
+ * Deliberately not persisted: a dragged position is a temporary "get out of my
+ * way" adjustment, so it lives in a module-level map — surviving the buttons'
+ * unmount/remount cycles (the `hidden` prop, the launcher unmounting while the
+ * chat panel is open) but resetting to the default corner on page refresh.
+ *
+ * Positions are stored as fractions of the *free range* (viewport minus button
+ * size) rather than pixels, so a rotation or resize keeps the button at the
+ * same relative spot and can never strand it off-screen: pixels are recomputed
+ * from the fractions against the current viewport on every render.
+ */
+
+export type FabId = 'new-task' | 'ceo-chat';
+
+export interface FabPosition {
+	/** 0 = flush left, 1 = flush right, of `viewportWidth - buttonWidth`. */
+	xFrac: number;
+	/** 0 = flush top, 1 = flush bottom, of `viewportHeight - buttonHeight`. */
+	yFrac: number;
+}
+
+const positions = new Map<FabId, FabPosition>();
+
+export function getFabPosition(id: FabId): FabPosition | null {
+	return positions.get(id) ?? null;
+}
+
+export function setFabPosition(id: FabId, pos: FabPosition): void {
+	positions.set(id, { xFrac: clamp01(pos.xFrac), yFrac: clamp01(pos.yFrac) });
+}
+
+/** Test-only isolation helper — clears all remembered positions. */
+export function resetFabPositions(): void {
+	positions.clear();
+}
+
+function clamp01(n: number): number {
+	if (!Number.isFinite(n)) return 0;
+	return Math.min(1, Math.max(0, n));
+}
+
+/**
+ * Resolve a fractional position to concrete `left`/`top` pixels for the
+ * current viewport. The free range clamps at 0 so a viewport smaller than the
+ * button degrades to the top-left corner instead of negative offsets.
+ */
+export function fabPixelPosition(
+	pos: FabPosition,
+	buttonWidth: number,
+	buttonHeight: number,
+	viewportWidth: number,
+	viewportHeight: number,
+): { left: number; top: number } {
+	return {
+		left: clamp01(pos.xFrac) * Math.max(0, viewportWidth - buttonWidth),
+		top: clamp01(pos.yFrac) * Math.max(0, viewportHeight - buttonHeight),
+	};
+}
+
+/**
+ * Inverse of {@link fabPixelPosition}: convert a dragged `left`/`top` back to
+ * clamped fractions. A degenerate free range (viewport no bigger than the
+ * button) maps to 0 on that axis.
+ */
+export function pixelsToFabPosition(
+	left: number,
+	top: number,
+	buttonWidth: number,
+	buttonHeight: number,
+	viewportWidth: number,
+	viewportHeight: number,
+): FabPosition {
+	const freeX = Math.max(0, viewportWidth - buttonWidth);
+	const freeY = Math.max(0, viewportHeight - buttonHeight);
+	return {
+		xFrac: freeX > 0 ? clamp01(left / freeX) : 0,
+		yFrac: freeY > 0 ? clamp01(top / freeY) : 0,
+	};
+}

--- a/packages/web/test/fab-position.test.ts
+++ b/packages/web/test/fab-position.test.ts
@@ -1,0 +1,94 @@
+// Unit tests for the draggable-FAB position store and its geometry helpers:
+// the in-memory per-button map, frac clamping on write, and the px<->frac
+// conversions staying fully on-screen including degenerate viewports.
+import { beforeEach, describe, expect, test } from 'vitest';
+import {
+	fabPixelPosition,
+	getFabPosition,
+	pixelsToFabPosition,
+	resetFabPositions,
+	setFabPosition,
+} from '../src/lib/fab-position';
+
+beforeEach(() => {
+	resetFabPositions();
+});
+
+describe('in-memory store', () => {
+	test('returns null before any position is set', () => {
+		expect(getFabPosition('new-task')).toBeNull();
+		expect(getFabPosition('ceo-chat')).toBeNull();
+	});
+
+	test('stores positions per button id', () => {
+		setFabPosition('new-task', { xFrac: 0.25, yFrac: 0.5 });
+		setFabPosition('ceo-chat', { xFrac: 0.9, yFrac: 0.1 });
+		expect(getFabPosition('new-task')).toEqual({ xFrac: 0.25, yFrac: 0.5 });
+		expect(getFabPosition('ceo-chat')).toEqual({ xFrac: 0.9, yFrac: 0.1 });
+	});
+
+	test('clamps fractions to [0,1] on write and rejects non-finite values', () => {
+		setFabPosition('new-task', { xFrac: -3, yFrac: 42 });
+		expect(getFabPosition('new-task')).toEqual({ xFrac: 0, yFrac: 1 });
+		// Non-finite values are garbage, not "very far right" — they zero out.
+		setFabPosition('new-task', { xFrac: Number.NaN, yFrac: Number.POSITIVE_INFINITY });
+		expect(getFabPosition('new-task')).toEqual({ xFrac: 0, yFrac: 0 });
+	});
+
+	test('reset clears every stored position', () => {
+		setFabPosition('new-task', { xFrac: 0.5, yFrac: 0.5 });
+		resetFabPositions();
+		expect(getFabPosition('new-task')).toBeNull();
+	});
+});
+
+describe('fabPixelPosition', () => {
+	test('maps fractions over the free range (viewport minus button)', () => {
+		// 375x800 viewport, 48px button: free range is 327x752.
+		expect(fabPixelPosition({ xFrac: 0, yFrac: 0 }, 48, 48, 375, 800)).toEqual({
+			left: 0,
+			top: 0,
+		});
+		expect(fabPixelPosition({ xFrac: 1, yFrac: 1 }, 48, 48, 375, 800)).toEqual({
+			left: 327,
+			top: 752,
+		});
+		expect(fabPixelPosition({ xFrac: 0.5, yFrac: 0.5 }, 48, 48, 375, 800)).toEqual({
+			left: 163.5,
+			top: 376,
+		});
+	});
+
+	test('degenerate viewport smaller than the button pins to the origin', () => {
+		expect(fabPixelPosition({ xFrac: 1, yFrac: 1 }, 48, 48, 30, 30)).toEqual({ left: 0, top: 0 });
+	});
+});
+
+describe('pixelsToFabPosition', () => {
+	test('inverts fabPixelPosition inside the viewport', () => {
+		const pos = pixelsToFabPosition(163.5, 376, 48, 48, 375, 800);
+		expect(pos.xFrac).toBeCloseTo(0.5);
+		expect(pos.yFrac).toBeCloseTo(0.5);
+	});
+
+	test('clamps drops beyond the viewport edges', () => {
+		expect(pixelsToFabPosition(-100, 9999, 48, 48, 375, 800)).toEqual({ xFrac: 0, yFrac: 1 });
+	});
+
+	test('degenerate free range maps to 0', () => {
+		expect(pixelsToFabPosition(10, 10, 48, 48, 40, 40)).toEqual({ xFrac: 0, yFrac: 0 });
+	});
+});
+
+describe('round trip', () => {
+	test('a dragged spot re-resolves to the same relative position after rotation', () => {
+		// Drop at bottom-right-ish in portrait…
+		const pos = pixelsToFabPosition(300, 700, 48, 48, 375, 800);
+		// …then rotate to landscape: still bottom-right-ish, fully on-screen.
+		const { left, top } = fabPixelPosition(pos, 48, 48, 800, 375);
+		expect(left).toBeGreaterThan(0);
+		expect(left).toBeLessThanOrEqual(800 - 48);
+		expect(top).toBeLessThanOrEqual(375 - 48);
+		expect(left / (800 - 48)).toBeCloseTo(300 / (375 - 48));
+	});
+});

--- a/packages/web/test/use-draggable-fab.test.tsx
+++ b/packages/web/test/use-draggable-fab.test.tsx
@@ -1,0 +1,164 @@
+// Unit tests for useDraggableFab: the portrait-mobile media-query gate, the
+// inline style derived from the in-memory position, and the tap-vs-drag
+// threshold (a real drag commits the position and swallows the next click; a
+// sub-threshold press stays a click). Rendered with a bare button — real
+// layout/boundingBox behavior is covered by test/browser/draggable-fabs.mobile.spec.ts.
+import { fireEvent, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { useDraggableFab } from '../src/hooks/use-draggable-fab';
+import { getFabPosition, resetFabPositions, setFabPosition } from '../src/lib/fab-position';
+
+/** A controllable matchMedia capturing change listeners (theme test pattern). */
+function installMatchMedia(matches: boolean) {
+	const listeners = new Set<() => void>();
+	const mql = {
+		matches,
+		media: '(max-width: 1023px) and (orientation: portrait)',
+		onchange: null,
+		addEventListener: (_type: string, cb: () => void) => listeners.add(cb),
+		removeEventListener: (_type: string, cb: () => void) => listeners.delete(cb),
+		addListener: (cb: () => void) => listeners.add(cb),
+		removeListener: (cb: () => void) => listeners.delete(cb),
+		dispatchEvent: () => true,
+	};
+	vi.spyOn(window, 'matchMedia').mockReturnValue(mql as unknown as MediaQueryList);
+}
+
+/**
+ * happy-dom's PointerEvent support is spotty, so synthesize pointer events as
+ * MouseEvents carrying the pointer fields the hook reads (pointerId, isPrimary).
+ */
+function pointerEvent(
+	type: string,
+	init: { clientX: number; clientY: number; pointerId?: number },
+): MouseEvent {
+	const e = new MouseEvent(type, {
+		bubbles: true,
+		cancelable: true,
+		clientX: init.clientX,
+		clientY: init.clientY,
+		button: 0,
+	});
+	Object.assign(e, { pointerId: init.pointerId ?? 1, isPrimary: true });
+	return e;
+}
+
+function TestFab({ onActivate }: { onActivate: () => void }) {
+	const fab = useDraggableFab('new-task');
+	return (
+		<button
+			ref={fab.ref}
+			type="button"
+			data-testid="fab"
+			onClick={onActivate}
+			{...fab.handlers}
+			style={fab.style}
+		>
+			fab
+		</button>
+	);
+}
+
+beforeEach(() => {
+	resetFabPositions();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe('style gate', () => {
+	test('no stored position → no inline position, default classes stay in charge', () => {
+		installMatchMedia(true);
+		const { getByTestId } = render(<TestFab onActivate={() => {}} />);
+		const btn = getByTestId('fab');
+		expect(btn.style.left).toBe('');
+		expect(btn.style.top).toBe('');
+	});
+
+	test('stored position on portrait mobile → inline px position with anchors neutralized', () => {
+		installMatchMedia(true);
+		setFabPosition('new-task', { xFrac: 0.5, yFrac: 0.25 });
+		const { getByTestId } = render(<TestFab onActivate={() => {}} />);
+		const btn = getByTestId('fab');
+		// happy-dom has no layout, so the button measures via the 48px fallback.
+		const expectedLeft = 0.5 * Math.max(0, window.innerWidth - 48);
+		const expectedTop = 0.25 * Math.max(0, window.innerHeight - 48);
+		expect(btn.style.left).toBe(`${expectedLeft}px`);
+		expect(btn.style.top).toBe(`${expectedTop}px`);
+		expect(btn.style.right).toBe('auto');
+		expect(btn.style.bottom).toBe('auto');
+	});
+
+	test('gate off (desktop/landscape) → stored position is ignored, not cleared', () => {
+		installMatchMedia(false);
+		setFabPosition('new-task', { xFrac: 0.5, yFrac: 0.25 });
+		const { getByTestId } = render(<TestFab onActivate={() => {}} />);
+		const btn = getByTestId('fab');
+		expect(btn.style.left).toBe('');
+		expect(btn.style.top).toBe('');
+		expect(getFabPosition('new-task')).toEqual({ xFrac: 0.5, yFrac: 0.25 });
+	});
+});
+
+describe('tap vs drag', () => {
+	test('a sub-threshold press stays a click and never moves the button', () => {
+		installMatchMedia(true);
+		const onActivate = vi.fn();
+		const { getByTestId } = render(<TestFab onActivate={onActivate} />);
+		const btn = getByTestId('fab');
+		fireEvent(btn, pointerEvent('pointerdown', { clientX: 10, clientY: 10 }));
+		fireEvent(document, pointerEvent('pointermove', { clientX: 13, clientY: 13 }));
+		fireEvent(document, pointerEvent('pointerup', { clientX: 13, clientY: 13 }));
+		fireEvent.click(btn);
+		expect(onActivate).toHaveBeenCalledTimes(1);
+		expect(getFabPosition('new-task')).toBeNull();
+		expect(btn.style.left).toBe('');
+	});
+
+	test('a real drag commits the position and swallows exactly the next click', () => {
+		installMatchMedia(true);
+		const onActivate = vi.fn();
+		const { getByTestId } = render(<TestFab onActivate={onActivate} />);
+		const btn = getByTestId('fab');
+		fireEvent(btn, pointerEvent('pointerdown', { clientX: 10, clientY: 10 }));
+		fireEvent(document, pointerEvent('pointermove', { clientX: 60, clientY: 90 }));
+		fireEvent(document, pointerEvent('pointerup', { clientX: 60, clientY: 90 }));
+		// The drag committed a position…
+		const committed = getFabPosition('new-task');
+		expect(committed).not.toBeNull();
+		expect(btn.style.left).not.toBe('');
+		// …and the click the browser synthesizes after pointerup is swallowed.
+		fireEvent.click(btn);
+		expect(onActivate).not.toHaveBeenCalled();
+		// A later plain click works again.
+		fireEvent.click(btn);
+		expect(onActivate).toHaveBeenCalledTimes(1);
+	});
+
+	test('pointercancel reverts to the last committed position', () => {
+		installMatchMedia(true);
+		setFabPosition('new-task', { xFrac: 0, yFrac: 0 });
+		const { getByTestId } = render(<TestFab onActivate={() => {}} />);
+		const btn = getByTestId('fab');
+		fireEvent(btn, pointerEvent('pointerdown', { clientX: 10, clientY: 10 }));
+		fireEvent(document, pointerEvent('pointermove', { clientX: 200, clientY: 200 }));
+		fireEvent(document, pointerEvent('pointercancel', { clientX: 200, clientY: 200 }));
+		expect(getFabPosition('new-task')).toEqual({ xFrac: 0, yFrac: 0 });
+		expect(btn.style.left).toBe('0px');
+		expect(btn.style.top).toBe('0px');
+	});
+
+	test('drag is inert when the gate is off', () => {
+		installMatchMedia(false);
+		const onActivate = vi.fn();
+		const { getByTestId } = render(<TestFab onActivate={onActivate} />);
+		const btn = getByTestId('fab');
+		fireEvent(btn, pointerEvent('pointerdown', { clientX: 10, clientY: 10 }));
+		fireEvent(document, pointerEvent('pointermove', { clientX: 200, clientY: 200 }));
+		fireEvent(document, pointerEvent('pointerup', { clientX: 200, clientY: 200 }));
+		expect(getFabPosition('new-task')).toBeNull();
+		fireEvent.click(btn);
+		expect(onActivate).toHaveBeenCalledTimes(1);
+	});
+});

--- a/test/browser/draggable-fabs.mobile.spec.ts
+++ b/test/browser/draggable-fabs.mobile.spec.ts
@@ -1,0 +1,131 @@
+// Decision-tree item 1: dragging is asserted via boundingBox() against real
+// fixed-position layout, and the portrait-mobile gate is a media query — both
+// need real Chromium + setViewportSize. happy-dom covers the position math and
+// tap/drag threshold in packages/web/test/{fab-position,use-draggable-fab}.
+import { expect, test } from './fixtures';
+import { createProjectAndClearPlanning, uniqueName, waitForPageLoad } from './helpers';
+
+/** Drag a locator's center to (toX, toY) with enough steps to cross the 8px threshold. */
+async function dragTo(
+	page: import('@playwright/test').Page,
+	locator: import('@playwright/test').Locator,
+	toX: number,
+	toY: number,
+) {
+	const box = await locator.boundingBox();
+	if (!box) throw new Error('Missing layout box');
+	await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+	await page.mouse.down();
+	await page.mouse.move(toX, toY, { steps: 12 });
+	await page.mouse.up();
+}
+
+test.describe('Draggable floating buttons (portrait mobile)', () => {
+	test('the "+" button drags anywhere, clamps on-screen, and resets on reload', async ({
+		page,
+		sharedWorkspace,
+	}) => {
+		const { token } = sharedWorkspace;
+		const project = await createProjectAndClearPlanning(page, '', token, {
+			name: uniqueName('Drag Fab'),
+			description: 'E2E draggable new-task button.',
+		});
+
+		await page.setViewportSize({ width: 375, height: 800 });
+		await page.goto(`/projects/${project.slug}/tasks`);
+		await waitForPageLoad(page);
+
+		const floating = page.getByTestId('floating-new-task');
+		await expect(floating).toBeVisible({ timeout: 15000 });
+		const home = await floating.boundingBox();
+		if (!home) throw new Error('Missing layout box');
+
+		// Drag far past the top-right corner: the button must clamp fully inside
+		// the viewport instead of leaving it.
+		await dragTo(page, floating, 900, -100);
+		const dragged = await floating.boundingBox();
+		if (!dragged) throw new Error('Missing layout box');
+		expect(dragged.x).toBeGreaterThanOrEqual(0);
+		expect(dragged.y).toBeGreaterThanOrEqual(0);
+		expect(dragged.x + dragged.width).toBeLessThanOrEqual(375);
+		expect(dragged.y + dragged.height).toBeLessThanOrEqual(800);
+		// …and it actually left the default bottom-left corner.
+		expect(dragged.x).toBeGreaterThan(home.x + 50);
+		expect(dragged.y).toBeLessThan(home.y - 50);
+
+		// The drop must not count as a click — no Create Task dialog.
+		await expect(page.getByRole('heading', { name: 'Create Task' })).toBeHidden();
+
+		// A plain tap afterwards still opens it.
+		await floating.click();
+		await expect(page.getByRole('heading', { name: 'Create Task' })).toBeVisible();
+		await page.keyboard.press('Escape');
+		await expect(page.getByRole('heading', { name: 'Create Task' })).toBeHidden();
+
+		// Position is memory-only: a reload puts the button back in its corner.
+		await page.reload();
+		await waitForPageLoad(page);
+		await expect(floating).toBeVisible({ timeout: 15000 });
+		const reloaded = await floating.boundingBox();
+		if (!reloaded) throw new Error('Missing layout box');
+		expect(Math.abs(reloaded.x - home.x)).toBeLessThan(2);
+		expect(Math.abs(reloaded.y - home.y)).toBeLessThan(2);
+	});
+
+	test('the chat launcher drags, keeps its spot across open/close, and snaps back on desktop', async ({
+		page,
+		sharedWorkspace,
+	}) => {
+		const { token } = sharedWorkspace;
+		const project = await createProjectAndClearPlanning(page, '', token, {
+			name: uniqueName('Drag Chat'),
+			description: 'E2E draggable chat launcher.',
+		});
+
+		await page.setViewportSize({ width: 375, height: 800 });
+		await page.goto(`/projects/${project.slug}/tasks`);
+		await waitForPageLoad(page);
+
+		const launcher = page.getByTestId('ceo-chat-launcher');
+		await expect(launcher).toBeVisible({ timeout: 15000 });
+		const home = await launcher.boundingBox();
+		if (!home) throw new Error('Missing layout box');
+
+		// Drag it to the mid-left of the screen.
+		await dragTo(page, launcher, 40, 400);
+		const dragged = await launcher.boundingBox();
+		if (!dragged) throw new Error('Missing layout box');
+		expect(dragged.x).toBeLessThan(home.x - 50);
+		expect(Math.abs(dragged.y + dragged.height / 2 - 400)).toBeLessThan(30);
+
+		// A tap still opens the chat panel in its normal mobile layout (the panel
+		// is unaffected by the launcher's position — near-fullscreen sheet).
+		await launcher.click();
+		const panel = page.getByTestId('ceo-chat-panel');
+		await expect(panel).toBeVisible();
+		const panelBox = await panel.boundingBox();
+		if (!panelBox) throw new Error('Missing layout box');
+		expect(panelBox.width).toBeGreaterThan(300); // spans the viewport width
+		await page.getByTestId('ceo-chat-close').click();
+
+		// The launcher remounts where it was dragged (in-memory position).
+		await expect(launcher).toBeVisible();
+		const remounted = await launcher.boundingBox();
+		if (!remounted) throw new Error('Missing layout box');
+		expect(Math.abs(remounted.x - dragged.x)).toBeLessThan(2);
+		expect(Math.abs(remounted.y - dragged.y)).toBeLessThan(2);
+
+		// On desktop (gate off) the launcher is back at its fixed bottom-right
+		// corner, and dragging does nothing.
+		await page.setViewportSize({ width: 1280, height: 900 });
+		const desktop = await launcher.boundingBox();
+		if (!desktop) throw new Error('Missing layout box');
+		expect(desktop.x).toBeGreaterThan(1280 / 2);
+		expect(desktop.y).toBeGreaterThan(900 / 2);
+		await dragTo(page, launcher, 200, 200);
+		const afterDesktopDrag = await launcher.boundingBox();
+		if (!afterDesktopDrag) throw new Error('Missing layout box');
+		expect(Math.abs(afterDesktopDrag.x - desktop.x)).toBeLessThan(2);
+		expect(Math.abs(afterDesktopDrag.y - desktop.y)).toBeLessThan(2);
+	});
+});


### PR DESCRIPTION
## What

On phones, the floating "+" create-task button and the CEO chat launcher sit on top of page content — e.g. covering the comment box's "Wake assignee" checkbox and "Comment" button at the bottom of a task thread. Both buttons are now **draggable anywhere in the viewport** (camera-app style) so they can be moved off content they occlude.

Scope, per the request:
- **Portrait mobile only** — drag is gated to `(max-width: 1023px) and (orientation: portrait)` (width < height, below Tailwind's `lg`). Desktop and landscape keep the fixed corners; the chat launcher snaps back to bottom-right the moment the gate turns off.
- **Free placement** — the button stays exactly where dropped, clamped fully on-screen (no edge snapping).
- **In-memory only** — the position survives the buttons' unmount/remount cycles (nav drawer/chat hiding the "+", the launcher unmounting while the panel is open) but resets to the default corner on page reload. No localStorage.

## How

- `packages/web/src/hooks/use-draggable-fab.ts` — shared hook: raw pointer-event drag machine (`setPointerCapture` + document-level move/up/cancel listeners), an 8px travel threshold so normal taps still click, click suppression for exactly the click synthesized after a real drag, `pointercancel` revert, and re-clamping on resize/orientation change. Returns `style: undefined` when the gate is off so the default corner classes stay in charge — with no drag, rendering is identical to before.
- `packages/web/src/lib/fab-position.ts` — per-button in-memory position store plus pure frac↔px geometry. Positions are stored as fractions of the free range (viewport minus button), so rotation/resize can never strand the button off-screen.
- `packages/web/src/hooks/use-media-query.ts` — extracted verbatim from `reviewable-document.tsx` (previously a private hook there) for reuse.
- Both buttons get `touch-none` so touch-drag doesn't pan the page (the browser decides panning at touchstart, so this can't be applied mid-drag).
- The CEO chat **panel** is untouched — only the launcher moves; the hook is called before the widget's `!open` early return per the rules of hooks.

## Tests

- `packages/web/test/fab-position.test.ts` — store semantics, frac clamping, px↔frac round-trip incl. degenerate viewports and rotation.
- `packages/web/test/use-draggable-fab.test.tsx` — media-query gate on/off, inline-style derivation, tap-vs-drag threshold, click suppression, `pointercancel` revert.
- `test/browser/draggable-fabs.mobile.spec.ts` — Playwright at 375×800 (decision-tree item 1: real `boundingBox()` layout): drag past the viewport edge clamps on-screen; the drop doesn't count as a click but a following tap does; reload resets to the default corner; the launcher keeps its dragged spot across chat open/close; at desktop size it returns to bottom-right and drags are inert.
- Existing `floating-new-task` (component + mobile Playwright) and `ceo-chat` suites pass unchanged.

## Docs

- `docs/concepts/roles-and-coordination.md` — one sentence on dragging the corner button (and the floating "+") on phones.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DzmavDwGapZBWK6t2RgjUm)_