### PR TITLE
fix(web): size the app shell with dvh so the mobile top nav can't scroll off-screen

### DIFF
--- a/packages/web/src/routes/__root.tsx
+++ b/packages/web/src/routes/__root.tsx
@@ -201,7 +201,14 @@ function ShellChrome({ drawerOpen, setDrawerOpen }: ShellChromeProps) {
 	}, [pathname, hash]);
 
 	return (
-		<div className="h-screen flex flex-col overflow-hidden">
+		// dvh, not vh: on mobile, 100vh is the LARGE viewport (URL bar collapsed).
+		// With the URL bar expanded the shell then overflows the visual viewport,
+		// giving the root scroller ~56px of real scroll range — over-scrolling past
+		// the bottom of <main> chains to the root and pushes the app header
+		// off-screen, and it stays hidden until <main> is scrolled back to its very
+		// top. 100dvh tracks the URL bar, so the root never has overflow and the
+		// header can't leave the screen.
+		<div className="h-dvh flex flex-col overflow-hidden">
 			<AppHeader
 				onOpenDrawer={() => setDrawerOpen(true)}
 				onOpenSearch={() => setSearchOpen(true)}

--- a/packages/web/test/app-header.test.tsx
+++ b/packages/web/test/app-header.test.tsx
@@ -30,6 +30,29 @@ test('header keeps Home top-left and the rest in the top-right group', async () 
 	expect(header.querySelector('[data-testid="app-header-new"]') ?? null).toBeNull();
 });
 
+test('shell sizes itself with dvh so the header cannot scroll off-screen on mobile', async () => {
+	const { findByTestId } = await renderApp({
+		initialPath: '/home',
+		seed: async () => {
+			await seedWorkspace();
+		},
+	});
+
+	const header = await findByTestId('app-header');
+	const shell = header.parentElement;
+	if (!shell) throw new Error('app-header has no shell wrapper');
+
+	// The failure this pins is only observable under a real mobile browser's
+	// dynamic URL bar (no automated tier can emulate it): with `h-screen`
+	// (100vh = the LARGE viewport), the shell is taller than the visual viewport
+	// while the URL bar is expanded, the root scroller gains real overflow, and
+	// over-scrolling past the bottom of <main> chains to the root and pushes the
+	// header off-screen. `h-dvh` tracks the URL bar so the root never scrolls.
+	expect(shell.className).toContain('h-dvh');
+	expect(shell.className).not.toContain('h-screen');
+	expect(shell.className).toContain('overflow-hidden');
+});
+
 test('header drops the All Tasks and Skills shortcuts; those live elsewhere', async () => {
 	const { findByTestId, getByTestId, queryByTestId } = await renderApp({
 		initialPath: '/home',


### PR DESCRIPTION
## Problem

On mobile (reported on Brave/Android), the top nav bar disappears while reading a long task page and does **not** come back while scrolling up — it only reappears once the page is scrolled all the way back to the top.

## Root cause

The app shell was sized with `h-screen` (`100vh`). On mobile browsers `100vh` resolves against the **large** viewport (URL bar collapsed), so while the URL bar is expanded the shell is ~56px taller than the visual viewport. Even though the shell itself is `overflow-hidden`, the *root scroller* (html/body) then has real scrollable overflow:

1. The user scrolls to the bottom of the comments in `<main>` (the app's only scroller).
2. Continued swipes chain the gesture to the root scroller, which scrolls down its ~56px of overflow — pushing the 48px app header above the visual viewport.
3. Scrolling back up moves `<main>` first (it has the whole page of scroll range), so the root scroller stays pinned at its offset — the header stays hidden the entire way up and only returns once `<main>` hits `scrollTop === 0` and the gesture chains back to the root.

## Fix

Size the shell with `h-dvh` (`100dvh`), which tracks the dynamic URL bar. The document then never exceeds the visible viewport, the root scroller never has overflow, and the header physically cannot leave the screen. (This also stops `scrollIntoView` calls — comment deep-links, composer focus — from being able to offset the root scroller.)

## Testing

- Added a component test pinning the shell to `dvh` sizing. The failure itself is only observable under a real mobile browser's dynamic URL bar — neither happy-dom nor Playwright (fixed viewport, no browser chrome, so `vh` ≡ `dvh`) can emulate it — so the test guards the mechanism with a comment explaining why.
- Full web component tier: 155 files / 923 tests pass.
- `bun run check` and `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLa39RXnpWfExTs9TYhJEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01JLa39RXnpWfExTs9TYhJEs)_