### PR TITLE
fix(web): remove gap after AI providers in settings nav

### DIFF
--- a/packages/web/src/components/settings-sidebar.tsx
+++ b/packages/web/src/components/settings-sidebar.tsx
@@ -110,13 +110,11 @@ export function SettingsSidebar() {
 				className="hidden md:flex flex-col gap-0.5 sticky top-0 self-start"
 				data-testid="settings-nav-desktop"
 			>
-				{items.map((item, idx) => (
+				{items.map((item) => (
 					<Link
 						key={item.to}
 						to={item.to}
-						className={`${itemClass(isActive(item.to, pathname))} ${
-							idx === PUBLIC_ITEMS.length ? 'mt-3' : ''
-						}`}
+						className={itemClass(isActive(item.to, pathname))}
 					>
 						{item.label}
 					</Link>

--- a/packages/web/src/components/settings-sidebar.tsx
+++ b/packages/web/src/components/settings-sidebar.tsx
@@ -111,11 +111,7 @@ export function SettingsSidebar() {
 				data-testid="settings-nav-desktop"
 			>
 				{items.map((item) => (
-					<Link
-						key={item.to}
-						to={item.to}
-						className={itemClass(isActive(item.to, pathname))}
-					>
+					<Link key={item.to} to={item.to} className={itemClass(isActive(item.to, pathname))}>
 						{item.label}
 					</Link>
 				))}


### PR DESCRIPTION
## What

Removes the visual gap in the desktop Settings navigation between **AI providers** and **Chatbox**.

## Why

The desktop sidebar (`packages/web/src/components/settings-sidebar.tsx`) applied an `mt-3` (12px) top margin to the first admin-only item ("Chatbox") to separate the public items (General, AI providers) from the superuser-only items below:

```tsx
idx === PUBLIC_ITEMS.length ? 'mt-3' : ''
```

That extra margin is the gap seen after "AI providers". The mobile dropdown never had this separator — it uses uniform `gap-0.5` — so the desktop and mobile layouts were inconsistent.

## Change

Drop the `idx`-based margin so the desktop list uses the same uniform `gap-0.5` spacing as the mobile dropdown. The public/admin split still governs which items render (superuser-only items are still hidden from non-admins); only the visual gap is removed.

## Testing

- `bunx biome check` passes on the changed file.
- No test asserted the gap (`test/browser/settings-nav.mobile.spec.ts` only checks desktop/mobile nav visibility and the mobile sticky/dropdown behavior), so no test changes were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YC3cLvEMJjxG6EX1YXv3iA

---
_Generated by [Claude Code](https://claude.ai/code/session_01YC3cLvEMJjxG6EX1YXv3iA)_