### PR TITLE
feat(web): icon-only open-in-new-tab button in preview panel header

### DIFF
--- a/packages/web/src/components/task-detail/preview-panel.tsx
+++ b/packages/web/src/components/task-detail/preview-panel.tsx
@@ -3,6 +3,7 @@ import { type ProjectDoc, useProjectDoc } from '../../hooks/use-project-docs';
 import { docPreviewPath } from '../../lib/doc-preview';
 import { DocumentBody } from '../document-review/document-body';
 import { ReviewToolbarActions } from '../document-review/review-toolbar-actions';
+import { Tooltip } from '../ui/tooltip';
 import type { PreviewItem } from './preview-context';
 
 function formatBytes(bytes?: number): string {
@@ -42,17 +43,19 @@ export function PreviewPanel({ item, onClose }: PreviewPanelProps) {
 				>
 					{item.filename}
 				</span>
-				<a
-					href={openUrl}
-					target="_blank"
-					rel="noopener noreferrer"
-					className="inline-flex shrink-0 items-center gap-1 text-[11px] text-info-soft-fg hover:underline"
-					data-testid="preview-open-tab"
-				>
-					open in new tab
-					<ExternalLink className="h-3 w-3" />
-				</a>
 				<ReviewToolbarActions projectId={item.projectId} filename={item.filename} />
+				<Tooltip content="Open in new tab">
+					<a
+						href={openUrl}
+						target="_blank"
+						rel="noopener noreferrer"
+						aria-label="Open in new tab"
+						className="shrink-0 rounded-md p-1 text-text-3 transition-colors hover:bg-surface-3 hover:text-text-1"
+						data-testid="preview-open-tab"
+					>
+						<ExternalLink className="h-4 w-4" />
+					</a>
+				</Tooltip>
 				<button
 					type="button"
 					onClick={onClose}

--- a/packages/web/test/task-comment-doc-preview.test.tsx
+++ b/packages/web/test/task-comment-doc-preview.test.tsx
@@ -40,11 +40,16 @@ test('doc mention in a task comment opens the preview panel, not a new tab', asy
 
 	await user.click(mention);
 
-	// The panel opens with the document, its rendered body, and an open-in-new-tab link.
+	// The panel opens with the document, its rendered body, and an icon-only
+	// open-in-new-tab link sitting immediately before the close button.
 	await findByTestId('preview-panel');
 	expect((await findByTestId('preview-panel-filename')).textContent).toBe('prd.md');
 	await findByText(/unmistakable document body/i);
 	const openTab = (await findByTestId('preview-open-tab')) as HTMLAnchorElement;
 	expect(openTab.getAttribute('target')).toBe('_blank');
 	expect(openTab.getAttribute('href')).toContain('/preview/');
+	expect(openTab.getAttribute('aria-label')).toBe('Open in new tab');
+	expect(openTab.textContent).toBe('');
+	const close = await findByTestId('preview-close');
+	expect(openTab.nextElementSibling).toBe(close);
 });


### PR DESCRIPTION
## Summary

The document preview panel's header previously showed a text link ("open in new tab" with a small external-link icon) between the filename and the review toolbar actions. This PR turns it into an icon-only button and moves it to the right, immediately before the close (✕) button.

- The link is now just the `ExternalLink` icon, styled to match the close button, with a "Open in new tab" tooltip and `aria-label` for accessibility.
- Header order is now: filename → review toolbar actions → open-in-new-tab icon → close.
- `href`/`target="_blank"`/`rel` behavior is unchanged.

## Tests

- Extended `packages/web/test/task-comment-doc-preview.test.tsx` to assert the affordance is icon-only (no text content, `aria-label` present) and sits immediately before the close button.
- `task-comment-doc-preview.test.tsx` and `project-doc-preview.test.tsx` both pass; typecheck and biome are clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PimbKabGjLrNoiVbucqDnj

---
_Generated by [Claude Code](https://claude.ai/code/session_01PimbKabGjLrNoiVbucqDnj)_