### PR TITLE
feat(web): make the scroll-to-bottom button global to all long-form pages

### DIFF
--- a/packages/web/src/components/scroll-to-bottom-button.tsx
+++ b/packages/web/src/components/scroll-to-bottom-button.tsx
@@ -1,0 +1,39 @@
+import { ChevronDown } from 'lucide-react';
+import { Tooltip } from './ui/tooltip';
+
+/**
+ * A thin "jump to latest" pill: a downward chevron on the theme's inverse fill
+ * (black in light theme, the light inverse in dark theme, matching the CEO chat
+ * launcher). Rendered by the app shell over the <main> scroller on every page,
+ * and by full-viewport pages (e.g. the standalone document preview) over their
+ * own scroller — `positionClassName` supplies the positioning. Hides itself and
+ * leaves the tab order once the content is scrolled to the bottom (or never
+ * overflowed in the first place).
+ */
+export function ScrollToBottomButton({
+	onClick,
+	atBottom,
+	testId,
+	positionClassName,
+}: {
+	onClick: () => void;
+	atBottom: boolean;
+	testId: string;
+	positionClassName: string;
+}) {
+	return (
+		<Tooltip content="Scroll to bottom">
+			<button
+				type="button"
+				onClick={onClick}
+				data-testid={testId}
+				aria-label="Scroll to bottom"
+				aria-hidden={atBottom}
+				tabIndex={atBottom ? -1 : 0}
+				className={`flex h-6 items-center justify-center rounded-md bg-inverse px-5 text-inverse-fg shadow-lg transition-opacity hover:opacity-90 ${positionClassName} ${atBottom ? 'invisible pointer-events-none opacity-0' : ''}`}
+			>
+				<ChevronDown className="h-4 w-4" />
+			</button>
+		</Tooltip>
+	);
+}

--- a/packages/web/src/hooks/use-scroll-to-bottom.ts
+++ b/packages/web/src/hooks/use-scroll-to-bottom.ts
@@ -4,7 +4,9 @@ export function useScrollToBottom(scrollParent: HTMLElement | null): {
 	atBottom: boolean;
 	scrollToBottom: () => void;
 } {
-	const [atBottom, setAtBottom] = useState(false);
+	// Start hidden (`atBottom: true`) so short pages never flash the button
+	// before the first measurement runs.
+	const [atBottom, setAtBottom] = useState(true);
 	useEffect(() => {
 		if (!scrollParent) return;
 		const check = () => {
@@ -16,9 +18,24 @@ export function useScrollToBottom(scrollParent: HTMLElement | null): {
 		scrollParent.addEventListener('scroll', check, { passive: true });
 		const ro = new ResizeObserver(check);
 		ro.observe(scrollParent);
-		for (const child of Array.from(scrollParent.children)) ro.observe(child);
+		const observeChildren = () => {
+			for (const child of Array.from(scrollParent.children)) ro.observe(child);
+		};
+		observeChildren();
+		// The scroll parent can outlive its content: the shell <main> never
+		// unmounts across navigations — the route swap replaces its children. The
+		// ResizeObserver only tracks the elements it was handed, so re-observe (a
+		// no-op for already-observed nodes) and re-measure whenever the child list
+		// changes; otherwise the new page's async content growth goes unseen and
+		// the button state is stale until the next scroll.
+		const mo = new MutationObserver(() => {
+			observeChildren();
+			check();
+		});
+		mo.observe(scrollParent, { childList: true });
 		return () => {
 			scrollParent.removeEventListener('scroll', check);
+			mo.disconnect();
 			ro.disconnect();
 		};
 	}, [scrollParent]);

--- a/packages/web/src/routes/__root.tsx
+++ b/packages/web/src/routes/__root.tsx
@@ -6,7 +6,7 @@ import {
 	useMatches,
 	useNavigate,
 } from '@tanstack/react-router';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AppHeader } from '../components/app-header';
 import { CeoChatWidget } from '../components/ceo-chat/ceo-chat-widget';
 import { GlobalSearchDialog } from '../components/global-search-dialog';
@@ -15,6 +15,7 @@ import { PasswordLogin } from '../components/password-login';
 import { ProjectRail } from '../components/project-rail';
 import { ProjectSidebar } from '../components/project-sidebar';
 import { PwaInstallPrompt } from '../components/pwa-install-prompt';
+import { ScrollToBottomButton } from '../components/scroll-to-bottom-button';
 import { CreatePasswordFlow, SetupGate } from '../components/setup/setup-wizard';
 import { StartingScreen } from '../components/starting-screen';
 import { UpdateBanner } from '../components/update-banner';
@@ -22,6 +23,7 @@ import { SocketProvider } from '../contexts/socket-context';
 import { useActiveProject } from '../hooks/use-active-project';
 import { useMe } from '../hooks/use-me';
 import { useProjectsIndex } from '../hooks/use-projects';
+import { useScrollToBottom } from '../hooks/use-scroll-to-bottom';
 import { useStatus } from '../hooks/use-status';
 import { useShellWebSockets } from '../hooks/use-websocket';
 import { api } from '../lib/api';
@@ -157,6 +159,16 @@ function ShellChrome({ drawerOpen, setDrawerOpen }: ShellChromeProps) {
 	const [searchOpen, setSearchOpen] = useState(false);
 	const active = useActiveProject();
 	const mainRef = useRef<HTMLElement>(null);
+	// The scroll-to-bottom hook needs the <main> element as state (a ref never
+	// re-runs its effect), so a stable callback ref feeds both. Stable identity
+	// matters: an inline ref would be re-invoked (null, then el) on every render
+	// and thrash the state.
+	const [mainEl, setMainEl] = useState<HTMLElement | null>(null);
+	const attachMain = useCallback((el: HTMLElement | null) => {
+		mainRef.current = el;
+		setMainEl(el);
+	}, []);
+	const { atBottom, scrollToBottom } = useScrollToBottom(mainEl);
 	const pathname = useLocation({ select: (l) => l.pathname });
 	const hash = useLocation({ select: (l) => l.hash });
 	const lastPathnameRef = useRef(pathname);
@@ -223,9 +235,23 @@ function ShellChrome({ drawerOpen, setDrawerOpen }: ShellChromeProps) {
 							<ProjectSidebar />
 						</div>
 					)}
-					<main ref={mainRef} className="flex-1 min-w-0 overflow-auto relative">
-						<Outlet />
-					</main>
+					{/* The relative wrapper hosts the scroll-to-bottom pill as a sibling
+					    of the scroller, so the pill stays pinned over the content area
+					    (never scrolling with it) on ANY page whose long-form content
+					    overflows <main> — task threads, documents, settings, etc. */}
+					<div className="relative flex flex-col flex-1 min-w-0 overflow-hidden">
+						<main ref={attachMain} className="flex-1 min-w-0 overflow-auto relative">
+							<Outlet />
+						</main>
+						{/* Bottom-centre of the content area: clear of the CEO chat
+						    launcher (bottom-right) at every breakpoint. */}
+						<ScrollToBottomButton
+							onClick={scrollToBottom}
+							atBottom={atBottom}
+							testId="scroll-to-bottom"
+							positionClassName="absolute bottom-4 left-1/2 -translate-x-1/2 z-30"
+						/>
+					</div>
 				</div>
 			</div>
 			{drawerOpen && (

--- a/packages/web/src/routes/preview/$projectId/$filename.tsx
+++ b/packages/web/src/routes/preview/$projectId/$filename.tsx
@@ -1,11 +1,18 @@
 import { createFileRoute } from '@tanstack/react-router';
+import { useState } from 'react';
 import { DocumentBody } from '../../../components/document-review/document-body';
 import { ReviewToolbarActions } from '../../../components/document-review/review-toolbar-actions';
+import { ScrollToBottomButton } from '../../../components/scroll-to-bottom-button';
 import { useProjectDoc } from '../../../hooks/use-project-docs';
+import { useScrollToBottom } from '../../../hooks/use-scroll-to-bottom';
 
 function DocPreviewPage() {
 	const { projectId, filename } = Route.useParams();
 	const { data: doc, isLoading, isError } = useProjectDoc(projectId, filename);
+	// This bare route renders outside the app shell, so it carries its own
+	// scroll-to-bottom pill wired to its own full-viewport scroller.
+	const [scroller, setScroller] = useState<HTMLDivElement | null>(null);
+	const { atBottom, scrollToBottom } = useScrollToBottom(scroller);
 
 	if (isLoading) {
 		return <CenteredMessage>Loading…</CenteredMessage>;
@@ -16,7 +23,7 @@ function DocPreviewPage() {
 	}
 
 	return (
-		<div className="h-screen overflow-auto bg-surface">
+		<div ref={setScroller} className="h-screen overflow-auto bg-surface">
 			<div className="sticky top-0 z-10 flex items-center justify-center gap-2 px-4 pt-3">
 				<div
 					className="flex items-center gap-2 rounded-[10px] border border-border bg-surface/85 px-2.5 py-1 shadow-sm backdrop-blur-md"
@@ -46,6 +53,12 @@ function DocPreviewPage() {
 					review={{ filename, docUpdatedAt: doc.updated_at }}
 				/>
 			</div>
+			<ScrollToBottomButton
+				onClick={scrollToBottom}
+				atBottom={atBottom}
+				testId="scroll-to-bottom"
+				positionClassName="fixed bottom-4 left-1/2 -translate-x-1/2 z-30"
+			/>
 		</div>
 	);
 }

--- a/packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx
@@ -1,6 +1,6 @@
 import type { AgentEffort } from '@hezo/shared';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
-import { ChevronDown, ChevronLeft, ChevronRight } from 'lucide-react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { jumpToComment } from '../../../../components/comment-renderers';
 import { CommentComposer } from '../../../../components/task-detail/comment-composer';
@@ -16,7 +16,6 @@ import { SubTasksSection } from '../../../../components/task-detail/sub-tasks-se
 import { TaskHeader } from '../../../../components/task-detail/task-header';
 import { TaskSidebar } from '../../../../components/task-detail/task-sidebar';
 import { TaskSummary } from '../../../../components/task-detail/task-summary';
-import { Tooltip } from '../../../../components/ui/tooltip';
 import { useAgents } from '../../../../hooks/use-agents';
 import { type Comment, useComments, useCreateComment } from '../../../../hooks/use-comments';
 import { useExecutionLock } from '../../../../hooks/use-execution-locks';
@@ -86,7 +85,10 @@ function TaskDetailPage() {
 		setScrollParent(document.querySelector('main'));
 	}, []);
 
-	const { atBottom, scrollToBottom } = useScrollToBottom(scrollParent);
+	// The jump-to-bottom button itself is global (rendered by the shell over
+	// <main> — see __root.tsx); this hook instance only provides scrollToBottom
+	// for the sidebar's close/re-open actions.
+	const { scrollToBottom } = useScrollToBottom(scrollParent);
 
 	if (isLoading || !task)
 		return <div className="text-text-2 text-[13px] py-8 text-center">Loading...</div>;
@@ -102,180 +104,116 @@ function TaskDetailPage() {
 	const taskProjectSlug = task.project_slug ?? projectId;
 
 	return (
-		<>
-			<div
-				className={`grid grid-cols-1 gap-5 ${preview ? 'lg:grid-cols-[1fr_360px] xl:grid-cols-[1fr_520px] 2xl:grid-cols-[1fr_720px]' : 'lg:grid-cols-[1fr_190px]'}`}
-			>
-				<PreviewProvider value={openPreview}>
-					<div className="min-w-0">
-						<LastRunFailedBanner task={task} />
-						<TaskHeader
-							task={task}
-							projectId={projectId}
-							taskId={taskId}
-							taskProjectSlug={taskProjectSlug}
-						/>
+		<div
+			className={`grid grid-cols-1 gap-5 ${preview ? 'lg:grid-cols-[1fr_360px] xl:grid-cols-[1fr_520px] 2xl:grid-cols-[1fr_720px]' : 'lg:grid-cols-[1fr_190px]'}`}
+		>
+			<PreviewProvider value={openPreview}>
+				<div className="min-w-0">
+					<LastRunFailedBanner task={task} />
+					<TaskHeader
+						task={task}
+						projectId={projectId}
+						taskId={taskId}
+						taskProjectSlug={taskProjectSlug}
+					/>
 
-						<TaskSummary
-							task={task}
-							projectId={projectId}
-							taskProjectSlug={taskProjectSlug}
-							updateTask={updateTask}
-						/>
+					<TaskSummary
+						task={task}
+						projectId={projectId}
+						taskProjectSlug={taskProjectSlug}
+						updateTask={updateTask}
+					/>
 
-						<SubTasksSection
-							projectId={projectId}
-							taskId={taskId}
-							parentTaskId={task.id}
-							taskProjectSlug={taskProjectSlug}
-						/>
+					<SubTasksSection
+						projectId={projectId}
+						taskId={taskId}
+						parentTaskId={task.id}
+						taskProjectSlug={taskProjectSlug}
+					/>
 
-						<DependenciesSection projectId={projectId} taskId={taskId} />
+					<DependenciesSection projectId={projectId} taskId={taskId} />
 
-						<div className="border-t border-border pt-4">
-							<div className="flex items-center gap-1.5 mb-4">
-								<h3 className="text-[13px] text-text-1 font-medium">Comments</h3>
-								<span className="bg-surface-2 px-[7px] py-px rounded-full text-[11px] text-text-2">
-									{comments?.length ?? 0}
-								</span>
-							</div>
-
-							<CommentsSection
-								task={task}
-								projectId={projectId}
-								taskId={taskId}
-								taskProjectSlug={taskProjectSlug}
-								scrollParent={scrollParent}
-								onStartReply={startReply}
-							/>
-
-							<CommentComposer
-								task={task}
-								projectId={projectId}
-								taskProjectSlug={taskProjectSlug}
-								createComment={createComment}
-								commentEffort={commentEffort}
-								setCommentEffort={setCommentEffort}
-								replyTarget={replyTarget}
-								setReplyTarget={setReplyTarget}
-								jumpToComment={jumpToComment}
-								commentFormRef={commentFormRef}
-								commentTextareaRef={commentTextareaRef}
-							/>
+					<div className="border-t border-border pt-4">
+						<div className="flex items-center gap-1.5 mb-4">
+							<h3 className="text-[13px] text-text-1 font-medium">Comments</h3>
+							<span className="bg-surface-2 px-[7px] py-px rounded-full text-[11px] text-text-2">
+								{comments?.length ?? 0}
+							</span>
 						</div>
-					</div>
-				</PreviewProvider>
 
-				{/* Right rail: an in-grid sticky column at lg+, a slide-in floating
+						<CommentsSection
+							task={task}
+							projectId={projectId}
+							taskId={taskId}
+							taskProjectSlug={taskProjectSlug}
+							scrollParent={scrollParent}
+							onStartReply={startReply}
+						/>
+
+						<CommentComposer
+							task={task}
+							projectId={projectId}
+							taskProjectSlug={taskProjectSlug}
+							createComment={createComment}
+							commentEffort={commentEffort}
+							setCommentEffort={setCommentEffort}
+							replyTarget={replyTarget}
+							setReplyTarget={setReplyTarget}
+							jumpToComment={jumpToComment}
+							commentFormRef={commentFormRef}
+							commentTextareaRef={commentTextareaRef}
+						/>
+					</div>
+				</div>
+			</PreviewProvider>
+
+			{/* Right rail: an in-grid sticky column at lg+, a slide-in floating
 				    drawer below lg (collapsed by default, toggled by the chevron). */}
+			<button
+				type="button"
+				onClick={() => setSidebarOpen((o) => !o)}
+				data-testid="task-sidebar-toggle"
+				aria-label={sidebarOpen ? 'Collapse task details' : 'Expand task details'}
+				aria-expanded={sidebarOpen}
+				className="lg:hidden fixed right-0 top-1/2 -translate-y-1/2 z-50 h-12 w-7 rounded-l-md border border-r-0 border-border bg-surface text-text-2 hover:text-text-1 shadow-md flex items-center justify-center"
+			>
+				{sidebarOpen ? <ChevronRight className="w-4 h-4" /> : <ChevronLeft className="w-4 h-4" />}
+			</button>
+			{sidebarOpen && (
 				<button
 					type="button"
-					onClick={() => setSidebarOpen((o) => !o)}
-					data-testid="task-sidebar-toggle"
-					aria-label={sidebarOpen ? 'Collapse task details' : 'Expand task details'}
-					aria-expanded={sidebarOpen}
-					className="lg:hidden fixed right-0 top-1/2 -translate-y-1/2 z-50 h-12 w-7 rounded-l-md border border-r-0 border-border bg-surface text-text-2 hover:text-text-1 shadow-md flex items-center justify-center"
-				>
-					{sidebarOpen ? <ChevronRight className="w-4 h-4" /> : <ChevronLeft className="w-4 h-4" />}
-				</button>
-				{sidebarOpen && (
-					<button
-						type="button"
-						aria-label="Close task details"
-						onClick={() => setSidebarOpen(false)}
-						className="lg:hidden fixed inset-0 z-40 bg-[var(--overlay)] cursor-default"
-					/>
-				)}
-				{/* Task meta side panel. Mobile: a fixed right-side drawer toggled by the
+					aria-label="Close task details"
+					onClick={() => setSidebarOpen(false)}
+					className="lg:hidden fixed inset-0 z-40 bg-[var(--overlay)] cursor-default"
+				/>
+			)}
+			{/* Task meta side panel. Mobile: a fixed right-side drawer toggled by the
 				    chevron. Desktop: `lg:contents` makes this wrapper generate no box, so
 				    TaskSidebar becomes the direct grid child (in-grid sticky column). While
 				    a preview is open the sidebar column yields to the preview on desktop
 				    (`lg:hidden`); on mobile the preview is its own overlay above this. */}
-				<div
-					data-testid="task-rail"
-					className={`fixed top-0 right-0 z-40 h-full w-[280px] max-w-[85vw] overflow-y-auto bg-surface p-4 shadow-xl transition-transform duration-200 ${
-						sidebarOpen ? 'translate-x-0' : 'translate-x-full'
-					} ${preview ? 'lg:hidden' : 'lg:contents'}`}
-				>
-					<TaskSidebar
-						task={task}
-						projectId={projectId}
-						agents={agents}
-						lock={lock}
-						comments={comments}
-						updateTask={updateTask}
-						commentEffort={commentEffort}
-						setCommentEffort={setCommentEffort}
-						scrollToBottom={scrollToBottom}
-					/>
-				</div>
-				{/* Document preview: its own layer. Mobile: a full-screen overlay above
-				    the main content and the meta drawer. Desktop: the in-grid column 2. */}
-				{preview && <PreviewPanel item={preview} onClose={() => setPreview(null)} />}
-			</div>
-
-			{/* Desktop/tablet: the same thin pill, centred over the content column and
-			    pinned to the bottom of the viewport. The mirror grid matches the main
-			    content grid above so the pill lines up with the content column, never
-			    the sidebar (whichever width the preview panel is using). */}
 			<div
-				aria-hidden={atBottom}
-				className={`hidden lg:grid sticky bottom-4 z-30 gap-5 pointer-events-none ${preview ? 'lg:grid-cols-[1fr_360px] xl:grid-cols-[1fr_520px] 2xl:grid-cols-[1fr_720px]' : 'lg:grid-cols-[1fr_190px]'}`}
+				data-testid="task-rail"
+				className={`fixed top-0 right-0 z-40 h-full w-[280px] max-w-[85vw] overflow-y-auto bg-surface p-4 shadow-xl transition-transform duration-200 ${
+					sidebarOpen ? 'translate-x-0' : 'translate-x-full'
+				} ${preview ? 'lg:hidden' : 'lg:contents'}`}
 			>
-				<div className="flex justify-center">
-					<ScrollToBottomButton
-						onClick={scrollToBottom}
-						atBottom={atBottom}
-						testId="task-scroll-to-bottom"
-						positionClassName="pointer-events-auto"
-					/>
-				</div>
+				<TaskSidebar
+					task={task}
+					projectId={projectId}
+					agents={agents}
+					lock={lock}
+					comments={comments}
+					updateTask={updateTask}
+					commentEffort={commentEffort}
+					setCommentEffort={setCommentEffort}
+					scrollToBottom={scrollToBottom}
+				/>
 			</div>
-
-			{/* Mobile: the same pill pinned bottom-centre, clear of the CEO chat
-			    launcher in the bottom-right corner. */}
-			<ScrollToBottomButton
-				onClick={scrollToBottom}
-				atBottom={atBottom}
-				testId="task-scroll-to-bottom-mobile"
-				positionClassName="lg:hidden fixed bottom-4 left-1/2 -translate-x-1/2 z-40"
-			/>
-		</>
-	);
-}
-
-/**
- * A thin "jump to latest" pill: a downward chevron on the theme's inverse fill
- * (black in light theme, the light inverse in dark theme, matching the CEO chat
- * launcher). Shared by the desktop (content-centred) and mobile (bottom-centre)
- * placements — `positionClassName` supplies the positioning. Hides itself and
- * leaves the tab order once the thread is scrolled to the bottom.
- */
-function ScrollToBottomButton({
-	onClick,
-	atBottom,
-	testId,
-	positionClassName,
-}: {
-	onClick: () => void;
-	atBottom: boolean;
-	testId: string;
-	positionClassName: string;
-}) {
-	return (
-		<Tooltip content="Scroll to bottom">
-			<button
-				type="button"
-				onClick={onClick}
-				data-testid={testId}
-				aria-label="Scroll to bottom"
-				aria-hidden={atBottom}
-				tabIndex={atBottom ? -1 : 0}
-				className={`flex h-6 items-center justify-center rounded-md bg-inverse px-5 text-inverse-fg shadow-lg transition-opacity hover:opacity-90 ${positionClassName} ${atBottom ? 'invisible pointer-events-none opacity-0' : ''}`}
-			>
-				<ChevronDown className="h-4 w-4" />
-			</button>
-		</Tooltip>
+			{/* Document preview: its own layer. Mobile: a full-screen overlay above
+				    the main content and the meta drawer. Desktop: the in-grid column 2. */}
+			{preview && <PreviewPanel item={preview} onClose={() => setPreview(null)} />}
+		</div>
 	);
 }
 

--- a/test/browser/scroll-to-bottom-global.spec.ts
+++ b/test/browser/scroll-to-bottom-global.spec.ts
@@ -1,0 +1,107 @@
+// Real clientHeight/scrollHeight/scrollTop comparisons (testing decision tree,
+// point 1): the global scroll-to-bottom pill only shows when the shell <main>
+// (or the bare preview page's own scroller) genuinely overflows, and clicking
+// it must move the real scroll position — values happy-dom can't compute. The
+// task-page variant of this behaviour is covered in task-detail.spec.ts; this
+// spec proves the pill is global by exercising it on a documents page and on
+// the standalone document preview.
+
+import { expect, test } from './fixtures';
+import { waitForPageLoad } from './helpers';
+
+const DOC = 'long-doc.md';
+
+// Long enough that the content column overflows the viewport at both
+// breakpoints, so reaching the bottom requires scrolling.
+const LONG_CONTENT = `# Long document\n\n${Array.from(
+	{ length: 150 },
+	(_, i) => `## Section ${i}\n\nParagraph body for section ${i}.`,
+).join('\n\n')}\n\nTHE-VERY-END`;
+
+const SHORT_CONTENT = '# Short document\n\nJust one paragraph.';
+
+async function seedDoc(
+	page: import('@playwright/test').Page,
+	projectSlug: string,
+	token: string,
+	content: string,
+): Promise<void> {
+	const res = await page.request.put(`/api/projects/${projectSlug}/docs/${DOC}`, {
+		headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+		data: { content },
+	});
+	expect(res.ok()).toBe(true);
+}
+
+for (const { name, width, height } of [
+	{ name: 'desktop', width: 1280, height: 800 },
+	{ name: 'mobile', width: 375, height: 800 },
+]) {
+	test(`${name}: pill appears on a long document page and scrolls to the bottom`, async ({
+		page,
+		lightWorkspace,
+	}) => {
+		const { projectSlug, token } = lightWorkspace;
+		await page.setViewportSize({ width, height });
+		await seedDoc(page, projectSlug, token, LONG_CONTENT);
+
+		await page.goto(`/projects/${projectSlug}/documents?file=${DOC}`);
+		await waitForPageLoad(page);
+		await expect(page.getByRole('heading', { name: DOC })).toBeVisible({ timeout: 20000 });
+
+		const button = page.getByTestId('scroll-to-bottom');
+		await expect(button).toBeVisible();
+		await button.click();
+
+		// The pill hides once the scroller reaches the bottom, and the real scroll
+		// position confirms the content genuinely moved.
+		await expect(button).toBeHidden({ timeout: 10000 });
+		const main = page.locator('main').first();
+		await expect
+			.poll(() => main.evaluate((el) => el.scrollHeight - el.scrollTop - el.clientHeight), {
+				timeout: 10000,
+			})
+			.toBeLessThan(200);
+		await expect(page.getByText('THE-VERY-END')).toBeInViewport();
+	});
+}
+
+test('pill stays hidden when the page content does not overflow', async ({
+	page,
+	lightWorkspace,
+}) => {
+	const { projectSlug, token } = lightWorkspace;
+	await page.setViewportSize({ width: 1280, height: 800 });
+	await seedDoc(page, projectSlug, token, SHORT_CONTENT);
+
+	await page.goto(`/projects/${projectSlug}/documents?file=${DOC}`);
+	await waitForPageLoad(page);
+	await expect(page.getByRole('heading', { name: DOC })).toBeVisible({ timeout: 20000 });
+
+	// The document fits the viewport, so <main> has nothing to scroll and the
+	// pill must not offer a jump.
+	const main = page.locator('main').first();
+	const overflow = await main.evaluate((el) => el.scrollHeight - el.clientHeight);
+	expect(overflow).toBeLessThanOrEqual(200);
+	await expect(page.getByTestId('scroll-to-bottom')).toBeHidden();
+});
+
+test('pill works on the standalone (bare) document preview page', async ({
+	page,
+	lightWorkspace,
+}) => {
+	const { projectSlug, token } = lightWorkspace;
+	await page.setViewportSize({ width: 1280, height: 800 });
+	await seedDoc(page, projectSlug, token, LONG_CONTENT);
+
+	await page.goto(`/preview/${projectSlug}/${DOC}`);
+	await waitForPageLoad(page);
+	await expect(page.getByTestId('preview-review-toolbar')).toBeVisible({ timeout: 20000 });
+
+	const button = page.getByTestId('scroll-to-bottom');
+	await expect(button).toBeVisible();
+	await button.click();
+
+	await expect(button).toBeHidden({ timeout: 10000 });
+	await expect(page.getByText('THE-VERY-END')).toBeInViewport();
+});

--- a/test/browser/scroll-to-bottom-global.spec.ts
+++ b/test/browser/scroll-to-bottom-global.spec.ts
@@ -95,7 +95,8 @@ test('pill works on the standalone (bare) document preview page', async ({
 	await seedDoc(page, projectSlug, token, LONG_CONTENT);
 
 	await page.goto(`/preview/${projectSlug}/${DOC}`);
-	await waitForPageLoad(page);
+	// No waitForPageLoad here: the bare route renders without the shell's <main>,
+	// which that helper gates on. The toolbar is the page's own mounted signal.
 	await expect(page.getByTestId('preview-review-toolbar')).toBeVisible({ timeout: 20000 });
 
 	const button = page.getByTestId('scroll-to-bottom');

--- a/test/browser/task-detail.spec.ts
+++ b/test/browser/task-detail.spec.ts
@@ -145,7 +145,7 @@ test.describe('Task detail — initial scroll and scroll-to-bottom button', () =
 		const main = page.locator('main').first();
 		await expect.poll(() => main.evaluate((el) => el.scrollTop), { timeout: 10000 }).toBe(0);
 
-		const button = page.getByTestId('task-scroll-to-bottom');
+		const button = page.getByTestId('scroll-to-bottom');
 		await expect(button).toBeVisible();
 
 		await button.click();
@@ -191,9 +191,9 @@ test.describe('Task detail — initial scroll and scroll-to-bottom button', () =
 		const main = page.locator('main').first();
 		await expect.poll(() => main.evaluate((el) => el.scrollTop), { timeout: 10000 }).toBe(0);
 
-		// The mobile layout swaps the floating round button for a rectangular
-		// button pinned bottom-centre between the new-task and CEO chat launchers.
-		const button = page.getByTestId('task-scroll-to-bottom-mobile');
+		// The same global pill pinned bottom-centre of the content area, clear of
+		// the CEO chat launcher in the corner.
+		const button = page.getByTestId('scroll-to-bottom');
 		await expect(button).toBeVisible();
 		await button.click();
 


### PR DESCRIPTION
## What

The jump-to-bottom pill previously existed only on the task detail page. It now appears on **any** page whose long-form content overflows the scroller — document pages (the reported case), task threads, settings, audit logs, everything rendered inside the app shell — and on the standalone (bare) document preview page.

## How

- **`ScrollToBottomButton` extracted** to `packages/web/src/components/scroll-to-bottom-button.tsx` (same pill: inverse-fill chevron, hides itself and leaves the tab order at the bottom).
- **Rendered globally by the app shell** (`__root.tsx`): the `<main>` scroller is wrapped in a relative container and the pill sits as a non-scrolling sibling, pinned bottom-centre of the content area (`data-testid="scroll-to-bottom"`), clear of the CEO chat launcher at every breakpoint. Since `<main>` is the single scroller for all routes, every page gets the behaviour for free; pages with their own inner scrollers (or short content) never show it because `<main>` doesn't overflow.
- **Bare preview route** (`/preview/$projectId/$filename`) renders outside the shell with its own full-viewport scroller, so it carries its own instance of the same component.
- **`useScrollToBottom` hardened for a long-lived scroll parent**: the shell `<main>` never unmounts across navigations — route swaps replace its children — so the hook now re-observes children (and re-measures) via a `MutationObserver` on `childList` changes. It also starts in the hidden state so short pages never flash the button before the first measurement.
- **Task page cleanup**: its two bespoke pill placements (desktop mirror-grid + mobile fixed) are removed in favour of the global one; the page keeps a hook instance only to feed `scrollToBottom` to the sidebar's close/re-open actions.

## Tests

- `test/browser/scroll-to-bottom-global.spec.ts` (new, Playwright — real `scrollHeight`/`clientHeight`/`scrollTop` assertions per the testing decision tree): pill appears on a long document page and scrolls to the bottom at desktop **and** mobile viewports; stays hidden when the document doesn't overflow; works on the bare `/preview/...` page.
- `test/browser/task-detail.spec.ts` updated to the global `scroll-to-bottom` testid (desktop + mobile scenarios retained).
- Full web component tier (939 tests) and typecheck pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0161xNSKmMy2BkP37NA9R1st

---
_Generated by [Claude Code](https://claude.ai/code/session_0161xNSKmMy2BkP37NA9R1st)_