### PR TITLE
Password show/hide toggle + Admin password settings page

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -912,11 +912,19 @@ Login mirrors the mnemonic's challenge-response: `POST /auth/password-challenge`
 nonce + the salt; `POST /auth/password-verify` checks the signature over
 `hezo-auth-v1:password-login:<nonce>` and mints a **session JWT**. `POST /auth/password`
 (accepting either a session or the password-setup-scoped token) enrolls a new verifier and
-returns a fresh session. `password-verify` is throttled in memory (single admin → global
-backoff/lockout). `GET /api/status` exposes `passwordSet`, and the web gate uses a
+returns a fresh session. A **session-authenticated change** while a verifier is already
+enrolled must additionally prove the *current* password: the body carries
+`current_challenge_id` + `current_signature` — a `password-challenge` nonce signed with the
+keypair derived from the current password — verified against the stored verifier before it
+is replaced (a stolen session alone can't rotate the password). Setup-scoped bearers
+(master-key recovery) and first enrollment are exempt. `password-verify` and the
+current-password proof share one in-memory throttle (single admin → global
+backoff/lockout), so the change endpoint can't be used to brute-force around the login
+lockout. `GET /api/status` exposes `passwordSet`, and the web gate uses a
 `GET /api/me` probe to distinguish "unlocked but no session → password login" from a valid
 session. **Existing installations** are migrated (013) with the default password `"password"`
-so operators can sign in immediately after upgrading, then change it.
+so operators can sign in immediately after upgrading, then change it (**Settings → Admin
+password** while signed in).
 
 **Three principals.**
 - **User JWT** (HS256, secret derived from the unlock key) — `Authorization: Bearer <jwt>`,

--- a/docs/deployment/secure-remote-access.md
+++ b/docs/deployment/secure-remote-access.md
@@ -53,7 +53,8 @@ browser gate after each restart. **Don't store the master key on the server** to
 unlock; keeping it in memory only is what protects the vault if the host is compromised.
 
 - **Set a strong admin password** and, if you upgraded an existing instance, change the
-  default (`password`) before exposing it. See [Master key & encryption](/docs/security/master-key).
+  default (`password`) in **Settings → Admin password** before exposing it. See
+  [Master key & encryption](/docs/security/master-key).
 - For defense in depth you can still add a second authentication layer in front (your
   proxy's auth, an identity-aware proxy, or an SSO gateway) — recommended for
   internet-facing deployments.

--- a/docs/getting-started/first-run.md
+++ b/docs/getting-started/first-run.md
@@ -33,7 +33,8 @@ After the master key unlocks, you create an **admin password**. This is how you 
 from here on — the master key unlocks the *instance*, your password signs *you* in. Your
 password never leaves your browser.
 
-If you ever forget it, reset it with your master key from the sign-in screen. See
+You can change it later in **Settings → Admin password**. If you ever forget it, reset it
+with your master key from the sign-in screen. See
 [Master key & encryption](/docs/security/master-key).
 
 ## 3. Connect a model

--- a/docs/security/master-key.md
+++ b/docs/security/master-key.md
@@ -72,13 +72,16 @@ encryption. You unlock the instance from the browser gate after each restart, an
 still has to sign in with the password to reach the app. See
 [Secure remote access](/docs/deployment/secure-remote-access).
 
+**Changing your password?** While signed in, go to **Settings → Admin password**, enter
+your current password and the new one twice, and save. Your session stays signed in.
+
 **Forgot your password?** Reset it with your master key: on the sign-in screen choose
 **Forgot password? Use your master key**, enter the twelve words, and set a new one. The
 master key is the ultimate authority, so it's also your password-recovery path.
 
 > **Upgrading an existing instance?** Your admin account is given the default password
-> `password` so you can sign in right away — **change it immediately**, especially before
-> exposing the instance to a network.
+> `password` so you can sign in right away — **change it immediately** in
+> **Settings → Admin password**, especially before exposing the instance to a network.
 
 ## What's encrypted
 
@@ -91,7 +94,8 @@ The master key protects all confidential data at rest, including:
 
 ## Recovery
 
-A forgotten **password** is easy to recover — reset it with your master key (above).
+A forgotten **password** is easy to recover — reset it with your master key (above). A
+password you still know can be changed any time in **Settings → Admin password**.
 
 A lost **master key** is different: there is intentionally **no backdoor.** If you lose it,
 the encrypted data can't be recovered — your only path forward is to reset the instance and

--- a/packages/server/src/middleware/auth.ts
+++ b/packages/server/src/middleware/auth.ts
@@ -252,14 +252,16 @@ export async function signPasswordSetupToken(
  * Authorize a password mutation (`POST /api/auth/password`). Accepts a bearer
  * that is EITHER a full admin session JWT (logged-in change) OR a
  * password-setup-scoped JWT (initial-set / recovery), and returns the superuser
- * id it authorizes — or `null` if the token is anything else. Kept separate from
- * `verifyToken` precisely because that path rejects the scoped token.
+ * id it authorizes plus which of the two it was — or `null` if the token is
+ * anything else. Kept separate from `verifyToken` precisely because that path
+ * rejects the scoped token. `isSetupScoped` lets the route exempt master-key
+ * recovery from the current-password proof a session-authenticated change needs.
  */
 export async function resolvePasswordMutationUserId(
 	token: string,
 	db: PGlite,
 	masterKeyManager: MasterKeyManager,
-): Promise<string | null> {
+): Promise<{ userId: string; isSetupScoped: boolean } | null> {
 	if (masterKeyManager.getState() !== 'unlocked') return null;
 	try {
 		const jwtKey = await masterKeyManager.getJwtKey();
@@ -275,7 +277,7 @@ export async function resolvePasswordMutationUserId(
 			[userId],
 		);
 		if (!result.rows[0]?.is_superuser) return null;
-		return userId;
+		return { userId, isSetupScoped: payload.scope === PASSWORD_SETUP_SCOPE };
 	} catch {
 		return null;
 	}

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -274,8 +274,13 @@ authRoutes.post('/auth/password-verify', async (c) => {
 // bearer must be a full session JWT (logged-in change) or a password-setup-scoped
 // JWT (initial-set / recovery). The password never arrives — only the client-
 // derived { salt, public_key } verifier plus a self-signature proving the client
-// holds the matching private key. Returns a fresh session so the caller is logged
-// in with the password they just set.
+// holds the matching private key. A session-authenticated change while a verifier
+// is already enrolled must additionally prove the CURRENT password: a
+// `/auth/password-challenge` nonce signed with the current-password keypair
+// (`current_challenge_id` + `current_signature`), throttled like login so this
+// endpoint can't be used as a password oracle. Setup-scoped bearers (master-key
+// recovery) and first enrollment are exempt. Returns a fresh session so the
+// caller is logged in with the password they just set.
 authRoutes.post('/auth/password', async (c) => {
 	const masterKeyManager = c.get('masterKeyManager');
 	const db = c.get('db');
@@ -287,18 +292,25 @@ authRoutes.post('/auth/password', async (c) => {
 	if (!header?.startsWith('Bearer ')) {
 		return err(c, 'UNAUTHORIZED', 'Missing authorization header', 401);
 	}
-	const userId = await resolvePasswordMutationUserId(header.slice(7), db, masterKeyManager);
-	if (!userId) {
+	const auth = await resolvePasswordMutationUserId(header.slice(7), db, masterKeyManager);
+	if (!auth) {
 		return err(c, 'UNAUTHORIZED', 'Invalid or expired token', 401);
 	}
+	const { userId, isSetupScoped } = auth;
 
-	let body: { salt?: string; public_key?: string; signature?: string };
+	let body: {
+		salt?: string;
+		public_key?: string;
+		signature?: string;
+		current_challenge_id?: string;
+		current_signature?: string;
+	};
 	try {
 		body = await c.req.json();
 	} catch {
 		return err(c, 'INVALID_REQUEST', 'JSON body required', 400);
 	}
-	const { salt, public_key, signature } = body;
+	const { salt, public_key, signature, current_challenge_id, current_signature } = body;
 	if (
 		typeof salt !== 'string' ||
 		!SALT_HEX.test(salt) ||
@@ -308,6 +320,49 @@ authRoutes.post('/auth/password', async (c) => {
 		!SIGNATURE_HEX.test(signature)
 	) {
 		return err(c, 'INVALID_REQUEST', 'salt, public_key, and signature are required', 400);
+	}
+
+	// A logged-in change (session bearer, verifier already enrolled) must prove
+	// the current password before the verifier is replaced. Verified against the
+	// OLD stored verifier, so this must run before setAdminPasswordVerifier.
+	if (!isSetupScoped && (await getAdminPasswordVerifier(db))) {
+		const now = Date.now();
+		const lockMs = loginLockRemainingMs(now);
+		if (lockMs > 0) {
+			return err(
+				c,
+				'TOO_MANY_ATTEMPTS',
+				`Too many attempts. Try again in ${Math.ceil(lockMs / 1000)}s.`,
+				429,
+			);
+		}
+		if (
+			typeof current_challenge_id !== 'string' ||
+			current_challenge_id.length === 0 ||
+			typeof current_signature !== 'string' ||
+			!SIGNATURE_HEX.test(current_signature)
+		) {
+			return err(
+				c,
+				'CURRENT_PASSWORD_REQUIRED',
+				'Changing the password requires proof of the current password',
+				400,
+			);
+		}
+		// Consume before verifying: one nonce absorbs a single guess.
+		const challenge = c.get('authChallenges').consume(current_challenge_id);
+		if (!challenge) {
+			return err(c, 'INVALID_CHALLENGE', 'Unknown, expired, or already used challenge', 401);
+		}
+		const currentOk = await verifyPasswordSignature(
+			db,
+			buildPasswordLoginMessage(challenge.nonce),
+			current_signature,
+		);
+		if (!currentOk) {
+			recordLoginFailure(now);
+			return err(c, 'INVALID_CREDENTIALS', 'Incorrect password', 401);
+		}
 	}
 
 	// TOFU self-signature: proves the client holds the private key for the verifier

--- a/packages/server/test/auth-password.test.ts
+++ b/packages/server/test/auth-password.test.ts
@@ -42,6 +42,22 @@ async function enrollmentBody(password: string) {
 	return { salt, public_key: publicKeyHex, signature };
 }
 
+/**
+ * Build the current-password proof a session-authenticated change must carry:
+ * a fresh challenge nonce signed with the keypair derived from `password`.
+ */
+async function currentProof(password: string) {
+	const challengeRes = await ctx.app.request('/api/auth/password-challenge', { method: 'POST' });
+	const { data } = (await challengeRes.json()) as {
+		data: { challenge_id: string; nonce: string; salt: string };
+	};
+	const { privateKey } = await derivePasswordKeyPair(password, data.salt);
+	return {
+		current_challenge_id: data.challenge_id,
+		current_signature: signAuthMessage(privateKey, buildPasswordLoginMessage(data.nonce)),
+	};
+}
+
 describe('password login (challenge-response)', () => {
 	it('logs in with the correct password and mints a working session', async () => {
 		const res = await passwordLogin(ctx.password);
@@ -111,7 +127,7 @@ describe('password enrollment / change (POST /api/auth/password)', () => {
 		expect(res.status).toBe(401);
 	});
 
-	it('changes the password when authenticated with a session, and rotates login', async () => {
+	it('changes the password when authenticated with a session + current-password proof, and rotates login', async () => {
 		// Snapshot the seeded verifier so we can restore it by DB write afterward —
 		// re-enrolling would cost another slow scrypt derivation.
 		const orig = (
@@ -124,7 +140,10 @@ describe('password enrollment / change (POST /api/auth/password)', () => {
 		const res = await ctx.app.request('/api/auth/password', {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json', ...authHeader(ctx.token) },
-			body: JSON.stringify(await enrollmentBody(newPassword)),
+			body: JSON.stringify({
+				...(await enrollmentBody(newPassword)),
+				...(await currentProof(ctx.password)),
+			}),
 		});
 		expect(res.status).toBe(200);
 		const { data } = (await res.json()) as { data: { token: string } };
@@ -140,6 +159,99 @@ describe('password enrollment / change (POST /api/auth/password)', () => {
 			`UPDATE users SET password_salt = $1, password_public_key = $2 WHERE is_superuser = true`,
 			[orig.password_salt, orig.password_public_key],
 		);
+	});
+
+	it('rejects a session-authenticated change that carries no current-password proof', async () => {
+		const res = await ctx.app.request('/api/auth/password', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json', ...authHeader(ctx.token) },
+			body: JSON.stringify(await enrollmentBody('sneaky-new-password')),
+		});
+		expect(res.status).toBe(400);
+		const body = (await res.json()) as { error: { code: string } };
+		expect(body.error.code).toBe('CURRENT_PASSWORD_REQUIRED');
+
+		// The verifier is untouched: the seeded password still logs in.
+		expect((await passwordLogin(ctx.password)).status).toBe(200);
+	});
+
+	it('rejects a wrong current password, counts it toward the shared login throttle', async () => {
+		// A well-formed but wrong current_signature fails verification without
+		// deriving a key (same no-scrypt trick as the login throttle test above).
+		const badSig = '00'.repeat(64);
+		const enrollment = await enrollmentBody('another-new-password');
+		async function badChange(): Promise<Response> {
+			const ch = await ctx.app.request('/api/auth/password-challenge', { method: 'POST' });
+			const { data } = (await ch.json()) as { data: { challenge_id: string } };
+			return ctx.app.request('/api/auth/password', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json', ...authHeader(ctx.token) },
+				body: JSON.stringify({
+					...enrollment,
+					current_challenge_id: data.challenge_id,
+					current_signature: badSig,
+				}),
+			});
+		}
+
+		for (let i = 0; i < 5; i++) {
+			const res = await badChange();
+			expect(res.status).toBe(401);
+			const body = (await res.json()) as { error: { code: string } };
+			expect(body.error.code).toBe('INVALID_CREDENTIALS');
+		}
+		// Locked now — and the lock is shared with password-verify, so the change
+		// endpoint can't be used to brute-force around the login throttle.
+		expect((await badChange()).status).toBe(429);
+		expect((await passwordLogin(ctx.password)).status).toBe(429);
+
+		// The verifier never changed.
+		resetLoginThrottle();
+		expect((await passwordLogin(ctx.password)).status).toBe(200);
+	});
+
+	it('rejects an unknown or already-used current challenge', async () => {
+		const enrollment = await enrollmentBody('yet-another-password');
+		const unknown = await ctx.app.request('/api/auth/password', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json', ...authHeader(ctx.token) },
+			body: JSON.stringify({
+				...enrollment,
+				current_challenge_id: 'no-such-challenge',
+				current_signature: '00'.repeat(64),
+			}),
+		});
+		expect(unknown.status).toBe(401);
+		const unknownBody = (await unknown.json()) as { error: { code: string } };
+		expect(unknownBody.error.code).toBe('INVALID_CHALLENGE');
+
+		// A challenge is consumed on first use: replaying the proof is rejected.
+		const proof = await currentProof(ctx.password);
+		const first = await ctx.app.request('/api/auth/password', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json', ...authHeader(ctx.token) },
+			body: JSON.stringify({ ...enrollment, ...proof }),
+		});
+		expect(first.status).toBe(200);
+		const replay = await ctx.app.request('/api/auth/password', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json', ...authHeader(ctx.token) },
+			body: JSON.stringify({ ...enrollment, ...proof }),
+		});
+		expect(replay.status).toBe(401);
+		const replayBody = (await replay.json()) as { error: { code: string } };
+		expect(replayBody.error.code).toBe('INVALID_CHALLENGE');
+
+		// Restore the seeded password for later tests (the first change succeeded).
+		const restore = await ctx.app.request('/api/auth/password', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json', ...authHeader(ctx.token) },
+			body: JSON.stringify({
+				...(await enrollmentBody(ctx.password)),
+				...(await currentProof('yet-another-password')),
+			}),
+		});
+		expect(restore.status).toBe(200);
 	});
 
 	it('lets the master key (mnemonic) reset a forgotten password without a session', async () => {

--- a/packages/web/src/components/password-login.tsx
+++ b/packages/web/src/components/password-login.tsx
@@ -8,6 +8,7 @@ import { MasterKeyForm, VaultShell } from './master-key-gate';
 import { PasswordSetForm } from './password-set-form';
 import { Button } from './ui/button';
 import { Logo } from './ui/logo';
+import { PasswordInput } from './ui/password-input';
 
 type Mode = 'login' | 'master-key' | 'reset';
 
@@ -100,13 +101,11 @@ export function PasswordLogin() {
 						<label htmlFor="login-password" className="text-sm font-medium text-text-1">
 							Password
 						</label>
-						<input
+						<PasswordInput
 							id="login-password"
-							type="password"
 							value={password}
 							onChange={(e) => setPassword(e.target.value)}
 							autoComplete="current-password"
-							className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-1 focus:outline-none focus:ring-2 focus:ring-accent"
 						/>
 					</div>
 					{error && <p className="text-sm text-danger">{error}</p>}

--- a/packages/web/src/components/password-set-form.tsx
+++ b/packages/web/src/components/password-set-form.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import type { ApiError } from '../lib/api';
 import { MIN_PASSWORD_LENGTH, setPassword as setPasswordApi } from '../lib/auth';
 import { Button } from './ui/button';
+import { PasswordInput } from './ui/password-input';
 
 interface PasswordSetFormProps {
 	submitLabel: string;
@@ -45,13 +46,11 @@ export function PasswordSetForm({ submitLabel, onSuccess }: PasswordSetFormProps
 				<label htmlFor="new-password" className="text-sm font-medium text-text-1">
 					Password
 				</label>
-				<input
+				<PasswordInput
 					id="new-password"
-					type="password"
 					value={password}
 					onChange={(e) => setPassword(e.target.value)}
 					autoComplete="new-password"
-					className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-1 focus:outline-none focus:ring-2 focus:ring-accent"
 				/>
 				{tooShort && (
 					<p className="text-xs text-text-2">At least {MIN_PASSWORD_LENGTH} characters.</p>
@@ -61,13 +60,11 @@ export function PasswordSetForm({ submitLabel, onSuccess }: PasswordSetFormProps
 				<label htmlFor="confirm-password" className="text-sm font-medium text-text-1">
 					Confirm password
 				</label>
-				<input
+				<PasswordInput
 					id="confirm-password"
-					type="password"
 					value={confirm}
 					onChange={(e) => setConfirm(e.target.value)}
 					autoComplete="new-password"
-					className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-1 focus:outline-none focus:ring-2 focus:ring-accent"
 				/>
 				{mismatch && <p className="text-xs text-danger">Passwords don't match.</p>}
 			</div>

--- a/packages/web/src/components/settings-sidebar.tsx
+++ b/packages/web/src/components/settings-sidebar.tsx
@@ -16,6 +16,7 @@ const PUBLIC_ITEMS: NavItem[] = [
 ];
 
 const ADMIN_ITEMS: NavItem[] = [
+	{ to: '/settings/admin-password', label: 'Admin password' },
 	{ to: '/settings/chatbox', label: 'Chatbox' },
 	{ to: '/settings/skills', label: 'Skills' },
 	{ to: '/settings/connectors', label: 'Connectors' },

--- a/packages/web/src/components/ui/password-input.tsx
+++ b/packages/web/src/components/ui/password-input.tsx
@@ -1,0 +1,30 @@
+import { Eye, EyeOff } from 'lucide-react';
+import { type InputHTMLAttributes, useState } from 'react';
+
+type PasswordInputProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'type'>;
+
+/**
+ * Password field with a trailing show/hide toggle. Renders only the input (plus
+ * the eye button) — labels stay external so existing `getByLabelText` queries
+ * and form layouts keep working. Styled to match the auth-form inputs.
+ */
+export function PasswordInput({ className = '', ...props }: PasswordInputProps) {
+	const [visible, setVisible] = useState(false);
+	return (
+		<div className="relative">
+			<input
+				type={visible ? 'text' : 'password'}
+				className={`w-full rounded-md border border-border bg-surface px-3 py-2 pr-10 text-sm text-text-1 focus:outline-none focus:ring-2 focus:ring-accent ${className}`}
+				{...props}
+			/>
+			<button
+				type="button"
+				onClick={() => setVisible((v) => !v)}
+				aria-label={visible ? 'Hide password' : 'Show password'}
+				className="absolute inset-y-0 right-0 flex items-center px-3 text-text-3 hover:text-text-1"
+			>
+				{visible ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+			</button>
+		</div>
+	);
+}

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -181,6 +181,37 @@ export async function setPassword(password: string): Promise<void> {
 	clearPendingSetupToken();
 }
 
+/**
+ * Change the admin password while signed in. Proves the CURRENT password by
+ * signing a fresh server challenge with the keypair derived from it (the server
+ * verifies against the stored verifier and throttles like login), then enrolls
+ * a fresh verifier for the new password. Neither password leaves the browser.
+ * The server returns a rotated session, so the user stays signed in.
+ */
+export async function changePassword(currentPassword: string, newPassword: string): Promise<void> {
+	const challenge = await api.post<{ challenge_id: string; nonce: string; salt: string }>(
+		'/api/auth/password-challenge',
+	);
+	const current = await derivePasswordKeyPair(currentPassword, challenge.salt);
+	const currentSignature = signAuthMessage(
+		current.privateKey,
+		buildPasswordLoginMessage(challenge.nonce),
+	);
+
+	const salt = generatePasswordSalt();
+	const { publicKeyHex, privateKey } = await derivePasswordKeyPair(newPassword, salt);
+	const signature = signAuthMessage(privateKey, buildPasswordSetupMessage(publicKeyHex, salt));
+
+	const data = await api.post<{ token: string }>('/api/auth/password', {
+		salt,
+		public_key: publicKeyHex,
+		signature,
+		current_challenge_id: challenge.challenge_id,
+		current_signature: currentSignature,
+	});
+	api.setToken(data.token);
+}
+
 export function logout() {
 	api.clearToken();
 	clearPendingSetupToken();

--- a/packages/web/src/routeTree.gen.ts
+++ b/packages/web/src/routeTree.gen.ts
@@ -20,6 +20,7 @@ import { Route as SettingsChatboxRouteImport } from './routes/settings/chatbox'
 import { Route as SettingsAuditLogRouteImport } from './routes/settings/audit-log'
 import { Route as SettingsApiKeysRouteImport } from './routes/settings/api-keys'
 import { Route as SettingsAiProvidersRouteImport } from './routes/settings/ai-providers'
+import { Route as SettingsAdminPasswordRouteImport } from './routes/settings/admin-password'
 import { Route as ProjectsProjectIdRouteRouteImport } from './routes/projects/$projectId/route'
 import { Route as ProjectsProjectIdIndexRouteImport } from './routes/projects/$projectId/index'
 import { Route as HomeInboxIndexRouteImport } from './routes/home/inbox/index'
@@ -100,6 +101,11 @@ const SettingsApiKeysRoute = SettingsApiKeysRouteImport.update({
 const SettingsAiProvidersRoute = SettingsAiProvidersRouteImport.update({
   id: '/ai-providers',
   path: '/ai-providers',
+  getParentRoute: () => SettingsRouteRoute,
+} as any)
+const SettingsAdminPasswordRoute = SettingsAdminPasswordRouteImport.update({
+  id: '/admin-password',
+  path: '/admin-password',
   getParentRoute: () => SettingsRouteRoute,
 } as any)
 const ProjectsProjectIdRouteRoute = ProjectsProjectIdRouteRouteImport.update({
@@ -257,6 +263,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/settings': typeof SettingsRouteRouteWithChildren
   '/projects/$projectId': typeof ProjectsProjectIdRouteRouteWithChildren
+  '/settings/admin-password': typeof SettingsAdminPasswordRoute
   '/settings/ai-providers': typeof SettingsAiProvidersRoute
   '/settings/api-keys': typeof SettingsApiKeysRoute
   '/settings/audit-log': typeof SettingsAuditLogRoute
@@ -294,6 +301,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/settings/admin-password': typeof SettingsAdminPasswordRoute
   '/settings/ai-providers': typeof SettingsAiProvidersRoute
   '/settings/api-keys': typeof SettingsApiKeysRoute
   '/settings/audit-log': typeof SettingsAuditLogRoute
@@ -333,6 +341,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/settings': typeof SettingsRouteRouteWithChildren
   '/projects/$projectId': typeof ProjectsProjectIdRouteRouteWithChildren
+  '/settings/admin-password': typeof SettingsAdminPasswordRoute
   '/settings/ai-providers': typeof SettingsAiProvidersRoute
   '/settings/api-keys': typeof SettingsApiKeysRoute
   '/settings/audit-log': typeof SettingsAuditLogRoute
@@ -374,6 +383,7 @@ export interface FileRouteTypes {
     | '/'
     | '/settings'
     | '/projects/$projectId'
+    | '/settings/admin-password'
     | '/settings/ai-providers'
     | '/settings/api-keys'
     | '/settings/audit-log'
@@ -411,6 +421,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/settings/admin-password'
     | '/settings/ai-providers'
     | '/settings/api-keys'
     | '/settings/audit-log'
@@ -449,6 +460,7 @@ export interface FileRouteTypes {
     | '/'
     | '/settings'
     | '/projects/$projectId'
+    | '/settings/admin-password'
     | '/settings/ai-providers'
     | '/settings/api-keys'
     | '/settings/audit-log'
@@ -571,6 +583,13 @@ declare module '@tanstack/react-router' {
       path: '/ai-providers'
       fullPath: '/settings/ai-providers'
       preLoaderRoute: typeof SettingsAiProvidersRouteImport
+      parentRoute: typeof SettingsRouteRoute
+    }
+    '/settings/admin-password': {
+      id: '/settings/admin-password'
+      path: '/admin-password'
+      fullPath: '/settings/admin-password'
+      preLoaderRoute: typeof SettingsAdminPasswordRouteImport
       parentRoute: typeof SettingsRouteRoute
     }
     '/projects/$projectId': {
@@ -759,6 +778,7 @@ declare module '@tanstack/react-router' {
 }
 
 interface SettingsRouteRouteChildren {
+  SettingsAdminPasswordRoute: typeof SettingsAdminPasswordRoute
   SettingsAiProvidersRoute: typeof SettingsAiProvidersRoute
   SettingsApiKeysRoute: typeof SettingsApiKeysRoute
   SettingsAuditLogRoute: typeof SettingsAuditLogRoute
@@ -770,6 +790,7 @@ interface SettingsRouteRouteChildren {
 }
 
 const SettingsRouteRouteChildren: SettingsRouteRouteChildren = {
+  SettingsAdminPasswordRoute: SettingsAdminPasswordRoute,
   SettingsAiProvidersRoute: SettingsAiProvidersRoute,
   SettingsApiKeysRoute: SettingsApiKeysRoute,
   SettingsAuditLogRoute: SettingsAuditLogRoute,

--- a/packages/web/src/routes/settings/admin-password.tsx
+++ b/packages/web/src/routes/settings/admin-password.tsx
@@ -1,0 +1,121 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { Loader2 } from 'lucide-react';
+import { useState } from 'react';
+import { Button } from '../../components/ui/button';
+import { PasswordInput } from '../../components/ui/password-input';
+import { useMe } from '../../hooks/use-me';
+import type { ApiError } from '../../lib/api';
+import { changePassword, MIN_PASSWORD_LENGTH } from '../../lib/auth';
+
+function ChangePasswordForm() {
+	const [current, setCurrent] = useState('');
+	const [next, setNext] = useState('');
+	const [confirm, setConfirm] = useState('');
+	const [error, setError] = useState('');
+	const [saved, setSaved] = useState(false);
+	const [loading, setLoading] = useState(false);
+
+	const tooShort = next.length > 0 && next.length < MIN_PASSWORD_LENGTH;
+	const mismatch = confirm.length > 0 && confirm !== next;
+	const canSubmit =
+		current.length > 0 && next.length >= MIN_PASSWORD_LENGTH && confirm === next && !loading;
+
+	async function handleSubmit(e: React.FormEvent) {
+		e.preventDefault();
+		if (!canSubmit) return;
+		setError('');
+		setSaved(false);
+		setLoading(true);
+		try {
+			await changePassword(current, next);
+			setCurrent('');
+			setNext('');
+			setConfirm('');
+			setSaved(true);
+		} catch (err) {
+			setError((err as ApiError).message || 'Could not change the password');
+		} finally {
+			setLoading(false);
+		}
+	}
+
+	return (
+		<div className="border border-border rounded-md p-4 bg-surface max-w-[480px]">
+			<form onSubmit={handleSubmit} className="flex flex-col gap-4">
+				<div className="flex flex-col gap-1.5">
+					<label htmlFor="current-password" className="text-sm font-medium text-text-1">
+						Current password
+					</label>
+					<PasswordInput
+						id="current-password"
+						value={current}
+						onChange={(e) => setCurrent(e.target.value)}
+						autoComplete="current-password"
+					/>
+				</div>
+				<div className="flex flex-col gap-1.5">
+					<label htmlFor="new-password" className="text-sm font-medium text-text-1">
+						New password
+					</label>
+					<PasswordInput
+						id="new-password"
+						value={next}
+						onChange={(e) => setNext(e.target.value)}
+						autoComplete="new-password"
+					/>
+					{tooShort && (
+						<p className="text-xs text-text-2">At least {MIN_PASSWORD_LENGTH} characters.</p>
+					)}
+				</div>
+				<div className="flex flex-col gap-1.5">
+					<label htmlFor="confirm-password" className="text-sm font-medium text-text-1">
+						Confirm new password
+					</label>
+					<PasswordInput
+						id="confirm-password"
+						value={confirm}
+						onChange={(e) => setConfirm(e.target.value)}
+						autoComplete="new-password"
+					/>
+					{mismatch && <p className="text-xs text-danger">Passwords don't match.</p>}
+				</div>
+				{error && <p className="text-sm text-danger">{error}</p>}
+				{saved && <p className="text-sm text-success">Password updated.</p>}
+				<div>
+					<Button type="submit" disabled={!canSubmit}>
+						{loading && <Loader2 className="w-4 h-4 animate-spin" />}
+						Save
+					</Button>
+				</div>
+			</form>
+		</div>
+	);
+}
+
+function AdminPasswordPage() {
+	const { data: me } = useMe();
+
+	const content =
+		me && !me.is_superuser ? (
+			<p className="text-[13px] text-text-2">
+				The admin password is managed by the Admin. You don't have access to this page.
+			</p>
+		) : (
+			<>
+				<div className="mb-5">
+					<h1 className="text-[22px] font-medium">Admin password</h1>
+					<p className="text-[13px] text-text-2 mt-1 max-w-[680px]">
+						Change the password you use to sign in. Your password never leaves the browser. If
+						you've forgotten it, sign out and reset it with your master key instead.
+					</p>
+				</div>
+				<ChangePasswordForm />
+			</>
+		);
+
+	return <div className="max-w-[900px]">{content}</div>;
+}
+
+export const Route = createFileRoute('/settings/admin-password')({
+	component: AdminPasswordPage,
+});

--- a/packages/web/test/admin-password-settings.test.tsx
+++ b/packages/web/test/admin-password-settings.test.tsx
@@ -1,0 +1,93 @@
+import { buildPasswordLoginMessage, derivePasswordKeyPair, signAuthMessage } from '@hezo/shared';
+import { expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+
+async function renderPage() {
+	const utils = await renderApp({ initialPath: '/settings/admin-password' });
+	await utils.findByRole('heading', { name: 'Admin password' });
+	return utils;
+}
+
+test('eye toggle reveals and re-hides the password text', async () => {
+	const { getByLabelText, getAllByRole, user } = await renderPage();
+
+	const current = getByLabelText('Current password') as HTMLInputElement;
+	expect(current.type).toBe('password');
+
+	// Three fields → three toggles; the first belongs to Current password.
+	const [toggle] = getAllByRole('button', { name: 'Show password' });
+	await user.click(toggle);
+	expect(current.type).toBe('text');
+	expect(toggle.getAttribute('aria-label')).toBe('Hide password');
+
+	await user.click(toggle);
+	expect(current.type).toBe('password');
+});
+
+test('changing the password with the correct current password succeeds', async () => {
+	const { ctx, getByLabelText, getByRole, findByText, user } = await renderPage();
+
+	await user.type(getByLabelText('Current password'), ctx.password);
+	await user.type(getByLabelText('New password'), 'a-new-strong-password');
+	await user.type(getByLabelText('Confirm new password'), 'a-new-strong-password');
+	await user.click(getByRole('button', { name: 'Save' }));
+
+	await findByText('Password updated.');
+
+	// The change landed server-side: a real challenge/verify login with the new
+	// password succeeds against the in-process backend.
+	const challengeRes = await ctx.apiBase('/api/auth/password-challenge', { method: 'POST' });
+	expect(challengeRes.status).toBe(200);
+	const { data } = (await challengeRes.json()) as {
+		data: { challenge_id: string; nonce: string; salt: string };
+	};
+	const { privateKey } = await derivePasswordKeyPair('a-new-strong-password', data.salt);
+	const verifyRes = await ctx.apiBase('/api/auth/password-verify', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			challenge_id: data.challenge_id,
+			signature: signAuthMessage(privateKey, buildPasswordLoginMessage(data.nonce)),
+		}),
+	});
+	expect(verifyRes.status).toBe(200);
+});
+
+test('a wrong current password shows the server error and changes nothing', async () => {
+	const { getByLabelText, getByRole, findByText, user } = await renderPage();
+
+	await user.type(getByLabelText('Current password'), 'not-the-password');
+	await user.type(getByLabelText('New password'), 'a-new-strong-password');
+	await user.type(getByLabelText('Confirm new password'), 'a-new-strong-password');
+	await user.click(getByRole('button', { name: 'Save' }));
+
+	await findByText('Incorrect password');
+});
+
+test('too-short and mismatched passwords disable Save with inline hints', async () => {
+	const { getByLabelText, getByRole, findByText, user } = await renderPage();
+
+	const save = getByRole('button', { name: 'Save' }) as HTMLButtonElement;
+	await user.type(getByLabelText('Current password'), 'whatever');
+
+	await user.type(getByLabelText('New password'), 'short');
+	await findByText('At least 8 characters.');
+	expect(save.disabled).toBe(true);
+
+	await user.type(getByLabelText('New password'), '-but-now-long-enough');
+	await user.type(getByLabelText('Confirm new password'), 'something-else');
+	await findByText("Passwords don't match.");
+	expect(save.disabled).toBe(true);
+});
+
+test('non-superuser sees the managed message instead of the form', async () => {
+	const { findByText, queryByLabelText } = await renderApp({
+		initialPath: '/settings/admin-password',
+		seed: async (ctx) => {
+			await ctx.db.query('UPDATE users SET is_superuser = false');
+		},
+	});
+
+	await findByText(/managed by the Admin/i);
+	expect(queryByLabelText('Current password')).toBeNull();
+});

--- a/packages/web/test/password-auth.test.tsx
+++ b/packages/web/test/password-auth.test.tsx
@@ -32,6 +32,26 @@ test('shows the password login with no session and signs in with the password', 
 	await expect.poll(() => queryByTestId('password-login')).toBeNull();
 });
 
+test('the login password field has a show/hide toggle', async () => {
+	const { findByTestId, getByLabelText, getByRole, user } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			api.clearToken();
+			localStorage.removeItem('hezo_token');
+		},
+	});
+
+	await findByTestId('password-login');
+	const input = getByLabelText('Password') as HTMLInputElement;
+	expect(input.type).toBe('password');
+
+	await user.click(getByRole('button', { name: 'Show password' }));
+	expect(input.type).toBe('text');
+
+	await user.click(getByRole('button', { name: 'Hide password' }));
+	expect(input.type).toBe('password');
+});
+
 test('offers master-key recovery from the login screen', async () => {
 	const { findByTestId, findByText } = await renderApp({
 		initialPath: '/',


### PR DESCRIPTION
## What

**1. Show/hide toggle on password inputs.** New shared `PasswordInput` component (`packages/web/src/components/ui/password-input.tsx`) with a trailing eye button (lucide `Eye`/`EyeOff`) that flips the input between `password` and `text`. Used on the sign-in screen (`password-login.tsx`), the set/reset-password form (`password-set-form.tsx`), and the new change-password form.

**2. Change-password settings page.** New global-settings subpage **Settings → Admin password** (`/settings/admin-password`, superuser-only, with a non-superuser fallback like the API-keys page): enter the current password, the new password twice, and Save. On success the session rotates and the user stays signed in. Mobile-first stacked layout.

**3. Server-side current-password enforcement.** `POST /api/auth/password` now requires proof of the current password when the caller is a full session JWT and a verifier is already enrolled: the body carries `current_challenge_id` + `current_signature` — a `/api/auth/password-challenge` nonce signed with the keypair derived from the current password — verified against the stored verifier *before* it is replaced, and counted toward the same in-memory brute-force throttle as `password-verify` (so the change endpoint can't be used as an unthrottled password oracle). Master-key recovery (password-setup-scoped token) and first enrollment are exempt, so the existing reset and onboarding flows are unchanged. Neither password ever leaves the browser.

## Tests

- `packages/server/test/auth-password.test.ts`: change with correct proof succeeds and rotates login; session change without proof → `400 CURRENT_PASSWORD_REQUIRED`; wrong current password → `401 INVALID_CREDENTIALS` with shared throttle locking both endpoints at `429`; unknown/replayed challenge → `401 INVALID_CHALLENGE`; master-key recovery and initial-set paths unchanged.
- `packages/web/test/admin-password-settings.test.tsx` (new): eye toggle flips input type; happy-path change verified by a real challenge-response login with the new password against the in-process backend; wrong current password shows the server error; too-short/mismatch validation disables Save; non-superuser fallback.
- `packages/web/test/password-auth.test.tsx`: login-screen toggle coverage.

Full `bun run test --skip-browser` sweep green (server 66/66 auth tests targeted + full tier, web 158 files / 945 tests, shared 113).

## Docs

- `.dev/architecture.md` § auth: documents the current-password proof and shared throttle.
- `docs/security/master-key.md`, `docs/deployment/secure-remote-access.md`, `docs/getting-started/first-run.md`: point password changes at **Settings → Admin password** (master key remains the forgot-password path). Docs bundle rebuilt (`bun run build:docs`); drift tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRqZqhP1iqs5BRpsdCgc7U

---
_Generated by [Claude Code](https://claude.ai/code/session_01WRqZqhP1iqs5BRpsdCgc7U)_