### PR TITLE
fix(web): refresh budget-status after agent cap edits; drop the hero sparkline

### DIFF
--- a/packages/web/src/components/budget/project-budget-panel.tsx
+++ b/packages/web/src/components/budget/project-budget-panel.tsx
@@ -2,12 +2,7 @@ import { type BudgetWindowsCents, centsToDollars } from '@hezo/shared';
 import { Link } from '@tanstack/react-router';
 import { Clock, Loader2, Pencil, TriangleAlert } from 'lucide-react';
 import { type Ref, useState } from 'react';
-import {
-	type EntityBudgetStatus,
-	useBudgetStatus,
-	useDailyCostSeries,
-	type WindowStatus,
-} from '../../hooks/use-costs';
+import { type EntityBudgetStatus, useBudgetStatus, type WindowStatus } from '../../hooks/use-costs';
 import { useProject, useUpdateProject } from '../../hooks/use-projects';
 import { Button } from '../ui/button';
 import { SectionHeader } from '../ui/section-header';
@@ -93,42 +88,7 @@ function WindowColumn({ status, windowKey }: { status: WindowStatus; windowKey: 
 	);
 }
 
-/** Month-to-date sparkline of daily project spend; days over the daily cap go red. */
-function Sparkline({ projectId, dailyCap }: { projectId: string; dailyCap: number }) {
-	const { data } = useDailyCostSeries(projectId);
-	const month = new Date().toISOString().slice(0, 7);
-	const points = (data?.summary ?? []).filter((d) => d.day.startsWith(month));
-	if (points.length === 0) return <div className="h-10" aria-hidden />;
-	const max = Math.max(...points.map((p) => p.total_cents), 1);
-	return (
-		<div className="flex h-10 items-end gap-[3px]" aria-hidden>
-			{points.map((p) => {
-				const over = dailyCap > 0 && p.total_cents >= dailyCap;
-				const h = Math.max(Math.round((p.total_cents / max) * 100), 5);
-				return (
-					<div
-						key={p.day}
-						className={`flex-1 rounded-sm ${over ? 'bg-danger' : 'bg-surface-3'}`}
-						style={{ height: `${h}%` }}
-						title={`${p.day}: ${dollars(p.total_cents)}`}
-					/>
-				);
-			})}
-		</div>
-	);
-}
-
-function Hero({
-	projectId,
-	monthly,
-	runsThisMonth,
-	dailyCap,
-}: {
-	projectId: string;
-	monthly: WindowStatus;
-	runsThisMonth: number;
-	dailyCap: number;
-}) {
+function Hero({ monthly, runsThisMonth }: { monthly: WindowStatus; runsThisMonth: number }) {
 	const now = new Date();
 	const monthLong = now.toLocaleString('en-US', { month: 'long', timeZone: 'UTC' });
 	const monthShort = now.toLocaleString('en-US', { month: 'short', timeZone: 'UTC' });
@@ -154,7 +114,6 @@ function Hero({
 			<span className="text-[12px] text-text-3">
 				{runsThisMonth} {runsThisMonth === 1 ? 'run' : 'runs'} · ≈ {dollars(Math.round(avg))} / run
 			</span>
-			<Sparkline projectId={projectId} dailyCap={dailyCap} />
 			<span className="inline-flex w-fit items-center gap-1.5 rounded-md border border-border bg-surface-2 px-2 py-1 text-[11px] text-text-2">
 				<span className="h-1.5 w-1.5 rounded-full bg-info" />
 				projected ≈ {dollars(projected)} by {monthShort} {daysInMonth}
@@ -326,12 +285,7 @@ export function ProjectBudgetPanel({
 				status ? (
 					<>
 						<div className="flex flex-col divide-y divide-border rounded-lg border border-border bg-surface shadow-xs lg:flex-row lg:divide-x lg:divide-y-0">
-							<Hero
-								projectId={projectId}
-								monthly={status.project.monthly}
-								runsThisMonth={status.runsThisMonth}
-								dailyCap={project.daily_budget_cents}
-							/>
+							<Hero monthly={status.project.monthly} runsThisMonth={status.runsThisMonth} />
 							<div className="flex flex-1 flex-col divide-y divide-border sm:flex-row sm:divide-x sm:divide-y-0">
 								<WindowColumn windowKey="daily" status={status.project.daily} />
 								<WindowColumn windowKey="weekly" status={status.project.weekly} />

--- a/packages/web/src/hooks/use-agents.ts
+++ b/packages/web/src/hooks/use-agents.ts
@@ -105,9 +105,13 @@ export function useUpdateAgent(projectId: string, agentId: string) {
 		queryKeys.projects.agent(projectId, agentId),
 		{
 			omitOptimistic: ['system_prompt', 'system_prompt_change_summary'],
+			// budgetStatus carries the per-agent window limits the Budget page reads,
+			// so a cap edit here must refetch it (staleTime would otherwise serve the
+			// old caps for up to a minute).
 			invalidateOnSettled: [
 				queryKeys.projects.agents(projectId),
 				queryKeys.projects.agentSystemPrompt(projectId, agentId),
+				queryKeys.projects.budgetStatus(projectId),
 			],
 			errorMessage: 'Failed to update agent',
 		},

--- a/packages/web/src/hooks/use-websocket.ts
+++ b/packages/web/src/hooks/use-websocket.ts
@@ -62,7 +62,9 @@ const TABLE_TO_QUERY_KEY: Record<
 	task_comments: (cid) => [queryKeys.projects.tasks(cid)],
 	comment_reactions: (cid) => [queryKeys.projects.tasks(cid)],
 	comment_attachments: (cid) => [queryKeys.projects.tasks(cid)],
-	member_agents: (cid) => [queryKeys.projects.agents(cid)],
+	// Agent rows carry the per-agent budget caps, so an update (e.g. a cap edit
+	// or a budget pause) must also refresh the Budget page's status query.
+	member_agents: (cid) => [queryKeys.projects.agents(cid), queryKeys.projects.budgetStatus(cid)],
 	projects: (cid) => [
 		queryKeys.projects.all(),
 		queryKeys.projectIntakes(),
@@ -107,7 +109,8 @@ const TABLE_TO_QUERY_KEY: Record<
 		}
 		return keys;
 	},
-	cost_entries: (cid) => [['projects', cid, 'costs']],
+	// New spend moves both the cost charts and the spend-vs-cap status.
+	cost_entries: (cid) => [['projects', cid, 'costs'], queryKeys.projects.budgetStatus(cid)],
 	execution_locks: (cid) => [['projects', cid, 'execution-locks']],
 	repos: (cid) => [queryKeys.projects.repos(cid), queryKeys.projects.all()],
 	// `goals(cid)` = ['projects', slug, 'goals'] is a prefix of goalsFiltered /

--- a/packages/web/test/budget-page.test.tsx
+++ b/packages/web/test/budget-page.test.tsx
@@ -1,4 +1,4 @@
-import { waitFor } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 import { expect, test } from 'vitest';
 import { getTestContext, renderApp } from './helpers/render';
 import { seedProject, seedWorkspace } from './helpers/seed';
@@ -215,4 +215,65 @@ test('Budget page: project window columns render caps and the binding-window ban
 	// The binding-window banner surfaces the daily window and links to raise its cap.
 	const banner = await findByTestId('binding-window-banner');
 	expect(banner.textContent ?? '').toContain('Raise daily cap');
+});
+
+test('Budget page: saving an agent cap edit refreshes the status (no stale cache)', async () => {
+	let teamSlug = '';
+	let agentSlug = '';
+	let headers: Record<string, string> = {};
+
+	const { findByTestId, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const { apiBase } = getTestContext();
+			const agent = ws.agents.find((a) => a.slug === 'engineer') ?? ws.agents[0];
+			agentSlug = agent.slug;
+			teamSlug = ws.internalSlug;
+			headers = ws.headers;
+			await apiBase(`/api/projects/${ws.internalSlug}/agents/${agent.id}`, {
+				method: 'PATCH',
+				headers: ws.headers,
+				body: JSON.stringify({ monthly_budget_cents: 3000 }),
+			});
+		},
+	});
+
+	// Populate the budget-status cache with the old $30 monthly cap.
+	await router.navigate({ to: '/projects/$projectId/budget', params: { projectId: teamSlug } });
+	const row = await findByTestId(`agent-budget-row-${agentSlug}`, undefined, { timeout: 15_000 });
+	await waitFor(() => expect(row.textContent ?? '').toContain('$30.00'));
+
+	// Raise the monthly cap to $50 through the agent settings form.
+	await router.navigate({
+		to: '/projects/$projectId/agents/$agentId/settings',
+		params: { projectId: teamSlug, agentId: agentSlug },
+	});
+	const monthlyInput = await findByTestId('budget-monthly', undefined, { timeout: 15_000 });
+	await user.clear(monthlyInput);
+	await user.type(monthlyInput, '50');
+	// happy-dom does not implicit-submit a form on click of a submit button;
+	// dispatch the submit event directly.
+	fireEvent.submit(monthlyInput.closest('form')!);
+
+	// Wait for the save to land server-side before navigating back, so the only
+	// question left is whether the client cache refetches.
+	await waitFor(
+		async () => {
+			const { apiBase } = getTestContext();
+			const res = await apiBase(`/api/projects/${teamSlug}/agents/${agentSlug}`, { headers });
+			const body = (await res.json()) as { data?: { monthly_budget_cents?: number } };
+			expect(body.data?.monthly_budget_cents).toBe(5000);
+		},
+		{ timeout: 10_000 },
+	);
+
+	// Back on the Budget page the card must show the new cap right away — the
+	// mutation invalidates budget-status; without that, the 60s staleTime would
+	// keep serving the old $30 cap from cache.
+	await router.navigate({ to: '/projects/$projectId/budget', params: { projectId: teamSlug } });
+	const updated = await findByTestId(`agent-budget-row-${agentSlug}`, undefined, {
+		timeout: 15_000,
+	});
+	await waitFor(() => expect(updated.textContent ?? '').toContain('$50.00'));
 });

--- a/packages/web/test/query-keys-websocket.test.ts
+++ b/packages/web/test/query-keys-websocket.test.ts
@@ -80,6 +80,23 @@ describe('invalidateQueriesForRowChange uses the queryKeys factory', () => {
 		expect(keys).toContainEqual(queryKeys.projects.tasks(SLUG));
 	});
 
+	test('member_agents row change invalidates agents AND budget status', () => {
+		// Agent rows carry the per-agent budget caps; the Budget page's status
+		// query must refetch when one changes (e.g. a cap edit or budget pause).
+		const { client, keys } = recordingClient();
+		invalidateQueriesForRowChange(client, SLUG, 'member_agents', {});
+		expect(keys).toContainEqual(queryKeys.projects.agents(SLUG));
+		expect(keys).toContainEqual(queryKeys.projects.budgetStatus(SLUG));
+	});
+
+	test('cost_entries row change invalidates costs AND budget status', () => {
+		// New spend moves both the cost charts and the spend-vs-cap status.
+		const { client, keys } = recordingClient();
+		invalidateQueriesForRowChange(client, SLUG, 'cost_entries', {});
+		expect(keys).toContainEqual(['projects', SLUG, 'costs']);
+		expect(keys).toContainEqual(queryKeys.projects.budgetStatus(SLUG));
+	});
+
 	test('unknown table is a no-op', () => {
 		const { client, keys } = recordingClient();
 		invalidateQueriesForRowChange(client, SLUG, 'nonexistent', {});


### PR DESCRIPTION
## Problem

1. **Stale data on the Budget page after editing an agent's budget.** The page's `budget-status` query has a 60s `staleTime`, and saving an agent's caps (`useUpdateAgent`, used by the agent settings form) never invalidated it. `useUpdateProject` already did — only the agent path was missing. So after raising a cap, the Budget page (and the "over budget — run paused" banner) kept showing the old caps/status.
2. The month-to-date bar blocks under the "This month · to date" hero were unlabeled and unclear.

## Changes

- `useUpdateAgent` now invalidates `projects.budgetStatus` on settle, matching what `useUpdateProject` already does.
- The realtime invalidation map also refreshes `budget-status` on `member_agents` broadcasts (cap edits, budget pauses) and `cost_entries` broadcasts (new spend moves spend-vs-cap), so an open Budget page tracks changes live.
- Removed the `Sparkline` bars from the Budget hero; the projected-spend pill stays. The hero column was the tallest in the row, so the dead vertical space under the window columns shrinks too.

## Tests

- New component regression test: seed an agent with a $30 monthly cap, load the Budget page (populating the cache), raise the cap to $50 through the agent settings form, and assert the Budget page shows the new cap. Fails without the invalidation fix (verified), passes with it.
- New `query-keys-websocket` cases pinning the `member_agents` and `cost_entries` mappers to include `budgetStatus`.
- Full web suite green: 158 files, 948 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018gfBrQZFtKqdXqnW13yUoQ

---
_Generated by [Claude Code](https://claude.ai/code/session_018gfBrQZFtKqdXqnW13yUoQ)_