### PR TITLE
feat(docs): document status (planning/approved) in the metadata banner

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -217,9 +217,15 @@ task-sidebar panel, Documents tab view mode) via a rehype plugin
 `write_project_doc` tool takes an optional `changelog`, both stored on the revision recorded for
 the *prior* content; `restoreRevision` writes `Restored content from revision N`. The single-doc
 GET returns `created_at` + a resolved `last_updated_by_name`/`last_updated_by_type`, feeding a
-structured **metadata banner** on the Documents page (created/updated + last editor — no more
-run-on metadata paragraph; a conservative display-only strip hides any legacy leading metadata
-block from the rendered body). A **revision-history dialog** shows each version's changelog
+structured **metadata banner** on the Documents page (status + created/updated + last editor — no
+more run-on metadata paragraph; a conservative display-only strip hides any legacy leading metadata
+block from the rendered body). Documents also carry a **`status`** enum column
+(`document_status`: `planning` | `approved`, default `planning`) — lifecycle metadata surfaced
+only for `project_doc` (list + single GET, `list_project_docs`/`read_project_doc`). Humans set it
+from a dropdown in the banner (`PATCH /projects/:projectId/docs/:filename`), agents via the
+`set_project_doc_status` MCP tool; both call `setDocumentStatus` (`services/documents.ts`), which
+records no revision and leaves `last_updated_by_member_id` untouched — a status flip is not a
+content edit (the row trigger still bumps `updated_at`). A **revision-history dialog** shows each version's changelog
 rendered like a task comment; `buildDocVersionHistory`
 (`packages/web/src/lib/doc-version-history.ts`) pairs each version's content with the changelog
 that *produced* it (a one-step shift, since revisions snapshot prior content), so the current

--- a/docs/concepts/documents-and-memory.md
+++ b/docs/concepts/documents-and-memory.md
@@ -79,6 +79,13 @@ last changed — and the agent opens the ones it needs with `read_project_doc`. 
 updating a document immediately makes it discoverable to the whole team, without bloating
 anyone's prompt.
 
+Every project document also carries a **status** — **Planning** (still being drafted and
+iterated) or **Approved** (signed off as the current source of truth) — shown in the
+details banner at the top of the document and next to each entry in the Documents list.
+New documents start in Planning. You change the status from the dropdown in the banner;
+agents set it with `set_project_doc_status`. The status is metadata only: changing it
+doesn't touch the document's content and records no version.
+
 ## Reviewing documents
 
 When you're reading a document — on the Documents page, in the task-sidebar preview, or in
@@ -116,8 +123,9 @@ the Documents page.
 
 ## Version history
 
-At the top of every document a compact **details** banner shows, at a glance, when it was
-created, when it last changed, and who last edited it — a person or a named agent.
+At the top of every document a compact **details** banner shows, at a glance, its status
+(Planning or Approved), when it was created, when it last changed, and who last edited
+it — a person or a named agent.
 
 Every change to a document is versioned, and each version carries a **changelog** — a short note
 describing what changed and why. When an agent updates a document it writes that note as part of

--- a/docs/reference/mcp-api.md
+++ b/docs/reference/mcp-api.md
@@ -953,7 +953,7 @@ List project documentation files (PRD, spec, implementation plan, etc.)
 | --- | --- | --- | --- |
 | `project` | `string` | No | Project slug or ID. Omit to use the project your run is already in; instance agents (CEO/Coach) must name the project to act in. |
 
-**Returns:** `{ files: [{ id, filename, title, updated_at }] }` — the markdown project docs.
+**Returns:** `{ files: [{ id, filename, title, status, updated_at }] }` — the markdown project docs. `status` is the doc's lifecycle status (`planning` or `approved`).
 
 ### `list_project_assets`
 
@@ -1064,7 +1064,7 @@ Read a markdown project doc by filename (e.g. "spec.md") — the high-level proj
 | `project` | `string` | No | Project slug or ID. Omit to use the project your run is already in; instance agents (CEO/Coach) must name the project to act in. |
 | `filename` | `string` | Yes | Filename to read (e.g. "spec.md") |
 
-**Returns:** `{ filename, content }` (the full markdown body), plus `review_comments: [{ id, quote, occurrence, comment, created_at }]` when the admin has left pending review feedback on the doc (each comment anchors to an exact `quote` snippet; `occurrence` disambiguates repeats). Any write to the doc deletes all of its review comments, so capture them before writing. Returns `{ error }` if the file is not found.
+**Returns:** `{ filename, content, status }` (the full markdown body plus the doc's lifecycle status, `planning` or `approved`), plus `review_comments: [{ id, quote, occurrence, comment, created_at }]` when the admin has left pending review feedback on the doc (each comment anchors to an exact `quote` snippet; `occurrence` disambiguates repeats). Any write to the doc deletes all of its review comments, so capture them before writing. Returns `{ error }` if the file is not found.
 
 ### `write_project_doc`
 
@@ -1082,6 +1082,22 @@ Write a project documentation file. Project docs are markdown only — the filen
 | `changelog` | `string` | No | Markdown summary of what changed in THIS update and why — recorded as the revision's changelog and shown in the document's revision history. Put update/status notes here, never in the document body. Reference tickets/docs/agents by bare identifier as in content. |
 
 **Returns:** `{ written: true, id, filename }`, or `{ error }` if the filename is not `.md`. Make all edits in one consolidated write: a content-changing write deletes ALL pending review comments on the doc (read them first) and records a document revision, so many partial writes lose review context and bury the revision history. The optional `changelog` is stored as that revision's changelog and shown in the document's history — put update/status notes there, not in the document body.
+
+### `set_project_doc_status`
+
+_Write tool._
+
+Set the lifecycle status of a project doc: "planning" (still being drafted/iterated) or "approved" (signed off as the current source of truth). Status is metadata shown in the doc header — changing it does not touch the content and records no revision. New docs start in planning.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `project` | `string` | No | Project slug or ID. Omit to use the project your run is already in; instance agents (CEO/Coach) must name the project to act in. |
+| `filename` | `string` | Yes | Doc filename (e.g. "spec.md") |
+| `status` | `planning` \| `approved` | Yes | New status: "planning" or "approved" |
+
+**Returns:** `{ updated: true, filename, status }`, or `{ error }` if the file is not found. Status is metadata only — no content change, no revision recorded.
 
 ## Costs
 

--- a/packages/server/migrations/015_document_status.sql
+++ b/packages/server/migrations/015_document_status.sql
@@ -1,0 +1,9 @@
+-- Document status: a lightweight lifecycle flag on documents, settable by
+-- humans (web UI) and agents (PATCH /docs/:filename, set_project_doc_status).
+-- Surfaced only for project docs; team_preferences and agent_system_prompt
+-- rows carry the default and never expose it. Existing rows backfill to
+-- 'planning' via the column default — no data transform needed.
+CREATE TYPE document_status AS ENUM ('planning', 'approved');
+
+ALTER TABLE documents
+    ADD COLUMN status document_status NOT NULL DEFAULT 'planning';

--- a/packages/server/src/mcp/mcp-reference.ts
+++ b/packages/server/src/mcp/mcp-reference.ts
@@ -351,17 +351,23 @@ export const TOOL_DOC_META: Record<string, ToolDocMeta> = {
 	// Project docs & assets
 	list_project_docs: {
 		category: 'Project docs & assets',
-		returns: '`{ files: [{ id, filename, title, updated_at }] }` — the markdown project docs.',
+		returns:
+			"`{ files: [{ id, filename, title, status, updated_at }] }` — the markdown project docs. `status` is the doc's lifecycle status (`planning` or `approved`).",
 	},
 	read_project_doc: {
 		category: 'Project docs & assets',
 		returns:
-			'`{ filename, content }` (the full markdown body), plus `review_comments: [{ id, quote, occurrence, comment, created_at }]` when the admin has left pending review feedback on the doc (each comment anchors to an exact `quote` snippet; `occurrence` disambiguates repeats). Any write to the doc deletes all of its review comments, so capture them before writing. Returns `{ error }` if the file is not found.',
+			"`{ filename, content, status }` (the full markdown body plus the doc's lifecycle status, `planning` or `approved`), plus `review_comments: [{ id, quote, occurrence, comment, created_at }]` when the admin has left pending review feedback on the doc (each comment anchors to an exact `quote` snippet; `occurrence` disambiguates repeats). Any write to the doc deletes all of its review comments, so capture them before writing. Returns `{ error }` if the file is not found.",
 	},
 	write_project_doc: {
 		category: 'Project docs & assets',
 		returns:
 			"`{ written: true, id, filename }`, or `{ error }` if the filename is not `.md`. Make all edits in one consolidated write: a content-changing write deletes ALL pending review comments on the doc (read them first) and records a document revision, so many partial writes lose review context and bury the revision history. The optional `changelog` is stored as that revision's changelog and shown in the document's history — put update/status notes there, not in the document body.",
+	},
+	set_project_doc_status: {
+		category: 'Project docs & assets',
+		returns:
+			'`{ updated: true, filename, status }`, or `{ error }` if the file is not found. Status is metadata only — no content change, no revision recorded.',
 	},
 	list_project_assets: {
 		category: 'Project docs & assets',

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -21,6 +21,7 @@ import {
 	CredentialKind,
 	credentialKindRequiresAllowedHosts,
 	DEFAULT_TEAM_ID,
+	DocumentStatus,
 	DocumentType,
 	extensionOf,
 	extractBacktickedMentionCandidates,
@@ -95,6 +96,7 @@ import {
 	getAgentSystemPrompt,
 	getDocument,
 	listDocuments,
+	setDocumentStatus,
 	upsertDocument,
 } from '../services/documents';
 import { listGoals, recordGoalProgress } from '../services/goals';
@@ -187,6 +189,7 @@ const MCP_WRITE_TOOLS: ReadonlySet<string> = new Set([
 	'move_project_asset',
 	'copy_project_asset',
 	'write_project_doc',
+	'set_project_doc_status',
 	'update_chat_memory',
 	'propose_skill',
 	'create_skill',
@@ -3466,6 +3469,7 @@ export function registerTools(
 					id: d.id,
 					filename: d.slug,
 					title: d.title,
+					status: d.status,
 					updated_at: d.updated_at,
 				})),
 			};
@@ -3920,10 +3924,12 @@ export function registerTools(
 			});
 			if (!doc) return { error: `File '${args.filename}' not found` };
 			const reviewComments = await listReviewComments(db, doc.id);
-			if (reviewComments.length === 0) return { filename: doc.slug, content: doc.content };
+			if (reviewComments.length === 0)
+				return { filename: doc.slug, content: doc.content, status: doc.status };
 			return {
 				filename: doc.slug,
 				content: doc.content,
+				status: doc.status,
 				review_comments: reviewComments.map((r) => ({
 					id: r.id,
 					quote: r.quote,
@@ -3980,6 +3986,44 @@ export function registerTools(
 				},
 			});
 			return { written: true, id: doc.id, filename: doc.slug };
+		},
+		db,
+	);
+
+	tool(
+		server,
+		'set_project_doc_status',
+		'Set the lifecycle status of a project doc: "planning" (still being drafted/iterated) or "approved" (signed off as the current source of truth). Status is metadata shown in the doc header — changing it does not touch the content and records no revision. New docs start in planning.',
+		{
+			project: projectArg(),
+			filename: z.string().describe('Doc filename (e.g. "spec.md")'),
+			status: z
+				.enum(Object.values(DocumentStatus) as [string, ...string[]])
+				.describe('New status: "planning" or "approved"'),
+		},
+		async (args, db, auth) => {
+			const scope = await resolveScope(db, auth, args);
+			if ('error' in scope) return scope;
+			const callerMemberId = auth.type === AuthType.Agent ? auth.memberId : null;
+			const row = await setDocumentStatus(
+				db,
+				wsManager,
+				{
+					type: DocumentType.ProjectDoc,
+					teamId: scope.teamId,
+					projectId: scope.projectId,
+					slug: args.filename as string,
+				},
+				args.status as DocumentStatus,
+				callerMemberId,
+				{
+					events,
+					actorType: actorTypeFromAuth(auth),
+					actorApiKeyId: apiKeyIdFromAuth(auth),
+				},
+			);
+			if (!row) return { error: `File '${args.filename}' not found` };
+			return { updated: true, filename: row.slug, status: row.status };
 		},
 		db,
 	);

--- a/packages/server/src/routes/project-docs.ts
+++ b/packages/server/src/routes/project-docs.ts
@@ -1,6 +1,7 @@
 import {
 	ApprovalType,
 	AuthType,
+	DocumentStatus,
 	DocumentType,
 	isMarkdownDocSlug,
 	repoNameFromIdentifier,
@@ -23,6 +24,7 @@ import {
 	listDocuments,
 	listRevisions,
 	restoreRevision,
+	setDocumentStatus,
 	upsertDocument,
 } from '../services/documents';
 
@@ -34,6 +36,7 @@ function toDocResponse(d: DocumentRowWithAuthor) {
 		id: d.id,
 		filename: d.slug,
 		content: d.content,
+		status: d.status,
 		created_at: d.created_at,
 		updated_at: d.updated_at,
 		last_updated_by_name: d.last_updated_by_name,
@@ -55,7 +58,7 @@ projectDocsRoutes.get('/projects/:projectId/docs', async (c) => {
 
 	return ok(
 		c,
-		docs.map((d) => ({ id: d.id, filename: d.slug, updated_at: d.updated_at })),
+		docs.map((d) => ({ id: d.id, filename: d.slug, status: d.status, updated_at: d.updated_at })),
 	);
 });
 
@@ -148,6 +151,52 @@ projectDocsRoutes.put('/projects/:projectId/docs/:filename', async (c) => {
 	return ok(
 		c,
 		toDocResponse(saved ?? { ...doc, last_updated_by_name: null, last_updated_by_type: 'admin' }),
+	);
+});
+
+projectDocsRoutes.patch('/projects/:projectId/docs/:filename', async (c) => {
+	const teamId = c.get('teamId') as string;
+	const db = c.get('db');
+	const filename = c.req.param('filename');
+	const auth = c.get('auth');
+	const projectId = await resolveProjectId(db, teamId, c.req.param('projectId'));
+	if (!projectId) return err(c, 'NOT_FOUND', 'Project not found', 404);
+
+	const body = await c.req.json<{ status?: string }>();
+	if (!Object.values(DocumentStatus).includes(body.status as DocumentStatus)) {
+		return err(
+			c,
+			'INVALID_REQUEST',
+			`status must be one of: ${Object.values(DocumentStatus).join(', ')}`,
+			400,
+		);
+	}
+
+	const actorMemberId = await resolveActorMemberId(db, auth, teamId);
+	const row = await setDocumentStatus(
+		db,
+		c.get('wsManager'),
+		{ type: DocumentType.ProjectDoc, teamId, projectId, slug: filename },
+		body.status as DocumentStatus,
+		actorMemberId,
+		{
+			events: c.get('events'),
+			actorType: actorTypeFromAuth(auth),
+			actorApiKeyId: apiKeyIdFromAuth(auth),
+		},
+	);
+	if (!row) return err(c, 'NOT_FOUND', `Document '${filename}' not found`, 404);
+
+	// Re-read WITH_AUTHOR so the response carries the resolved last editor.
+	const saved = await getDocument(db, {
+		type: DocumentType.ProjectDoc,
+		teamId,
+		projectId,
+		slug: filename,
+	});
+	return ok(
+		c,
+		toDocResponse(saved ?? { ...row, last_updated_by_name: null, last_updated_by_type: 'admin' }),
 	);
 });
 

--- a/packages/server/src/services/documents.ts
+++ b/packages/server/src/services/documents.ts
@@ -1,5 +1,5 @@
 import type { PGlite } from '@electric-sql/pglite';
-import { type AuditActorType, DocumentType, wsRoom } from '@hezo/shared';
+import { type AuditActorType, type DocumentStatus, DocumentType, wsRoom } from '@hezo/shared';
 import type { DomainEventBus } from '../events/bus';
 import { broadcastCommentFamilyChange, broadcastRowChange } from '../lib/broadcast';
 import { withTransaction } from '../lib/sql';
@@ -44,6 +44,7 @@ export interface DocumentRow {
 	slug: string;
 	title: string;
 	content: string;
+	status: DocumentStatus;
 	last_updated_by_member_id: string | null;
 	created_at: string;
 	updated_at: string;
@@ -118,7 +119,7 @@ function scopeWhere(scope: DocumentScope, alias = ''): { sql: string; params: un
 // Explicit column list — the generated search_tsv column (full-text index) is
 // server-internal and never serialized to API responses.
 const SELECT_WITH_AUTHOR = `SELECT d.id, d.team_id, d.project_id, d.member_agent_id,
-	        d.type, d.slug, d.title, d.content,
+	        d.type, d.slug, d.title, d.content, d.status,
 	        d.last_updated_by_member_id, d.created_at, d.updated_at,
 	        COALESCE(ma.title, m.display_name) AS last_updated_by_name,
 	        CASE WHEN ma.id IS NOT NULL THEN 'agent' ELSE 'admin' END AS last_updated_by_type
@@ -229,6 +230,37 @@ export async function upsertDocument(
 		row,
 		input.authorMemberId,
 	);
+	return row;
+}
+
+/**
+ * Sets the lifecycle status of a document. A status flip is metadata, not a
+ * content edit — it records no revision and leaves last_updated_by_member_id
+ * untouched so the "Last edited by" attribution stays honest.
+ */
+export async function setDocumentStatus(
+	db: PGlite,
+	wsManager: WebSocketManager | undefined,
+	scope: DocumentScope,
+	status: DocumentStatus,
+	actorMemberId: string | null,
+	audit?: DocumentAuditContext,
+): Promise<DocumentRow | null> {
+	const where = scopeWhere(scope, '');
+	const result = await db.query<DocumentRow>(
+		`UPDATE documents SET status = $${where.params.length + 1} WHERE ${where.sql} RETURNING *`,
+		[...where.params, status],
+	);
+	if (result.rows.length === 0) return null;
+	const row = result.rows[0];
+	broadcastRowChange(
+		wsManager,
+		wsRoom.team(row.team_id),
+		'documents',
+		'UPDATE',
+		row as unknown as Record<string, unknown>,
+	);
+	emitDocumentEvent(audit, 'document.updated', row, actorMemberId);
 	return row;
 }
 

--- a/packages/server/test/mcp-tools-extended.test.ts
+++ b/packages/server/test/mcp-tools-extended.test.ts
@@ -1173,6 +1173,49 @@ describe('MCP project docs & assets', () => {
 		expect(result.error).toContain('not found');
 	});
 
+	it('docs carry a lifecycle status, set via set_project_doc_status', async () => {
+		await callTool('write_project_doc', {
+			project: projectId,
+			filename: 'status-doc.md',
+			content: '# Status',
+		});
+
+		// New docs start in planning; read + list both surface it.
+		const read = (await callTool('read_project_doc', {
+			project: projectId,
+			filename: 'status-doc.md',
+		})) as { status?: string };
+		expect(read.status).toBe('planning');
+		const listed = (await callTool('list_project_docs', { project: projectId })) as {
+			files: Array<{ filename: string; status: string }>;
+		};
+		expect(listed.files.find((f) => f.filename === 'status-doc.md')?.status).toBe('planning');
+
+		const updated = (await callTool('set_project_doc_status', {
+			project: projectId,
+			filename: 'status-doc.md',
+			status: 'approved',
+		})) as { updated?: boolean; status?: string; error?: string };
+		expect(updated.error).toBeUndefined();
+		expect(updated.updated).toBe(true);
+		expect(updated.status).toBe('approved');
+
+		const reread = (await callTool('read_project_doc', {
+			project: projectId,
+			filename: 'status-doc.md',
+		})) as { status?: string };
+		expect(reread.status).toBe('approved');
+	});
+
+	it('set_project_doc_status errors for an unknown file', async () => {
+		const result = (await callTool('set_project_doc_status', {
+			project: projectId,
+			filename: 'missing.md',
+			status: 'approved',
+		})) as ToolResult;
+		expect(result.error).toContain('not found');
+	});
+
 	it('list_project_assets returns the assets written via write_project_asset', async () => {
 		await callTool('write_project_asset', {
 			project: projectId,

--- a/packages/server/test/migrate-015-document-status.test.ts
+++ b/packages/server/test/migrate-015-document-status.test.ts
@@ -1,0 +1,91 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createDataPreservationHarness, type DataPreservationHarness } from './helpers/migrate';
+
+const TARGET = '015_document_status.sql';
+
+describe('015_document_status migration', () => {
+	let h: DataPreservationHarness;
+	let teamId: string;
+	let projectId: string;
+	let projectDocId: string;
+	let preferencesDocId: string;
+
+	beforeAll(async () => {
+		h = await createDataPreservationHarness();
+		await h.applyUpToExclusive(TARGET); // schema at 014
+
+		const team = await h.db.query<{ id: string }>(
+			`INSERT INTO teams (name, slug) VALUES ('Acme', 'acme') RETURNING id`,
+		);
+		teamId = team.rows[0].id;
+		const project = await h.db.query<{ id: string }>(
+			`INSERT INTO projects (team_id, name, slug, task_prefix)
+			 VALUES ($1, 'Demo', 'demo', 'DM') RETURNING id`,
+			[teamId],
+		);
+		projectId = project.rows[0].id;
+		const projectDoc = await h.db.query<{ id: string }>(
+			`INSERT INTO documents (team_id, project_id, type, slug, content)
+			 VALUES ($1, $2, 'project_doc', 'spec.md', '# Spec') RETURNING id`,
+			[teamId, projectId],
+		);
+		projectDocId = projectDoc.rows[0].id;
+		const preferencesDoc = await h.db.query<{ id: string }>(
+			`INSERT INTO documents (team_id, type, slug, content)
+			 VALUES ($1, 'team_preferences', 'preferences', 'Prefer TypeScript') RETURNING id`,
+			[teamId],
+		);
+		preferencesDocId = preferencesDoc.rows[0].id;
+
+		await h.applyTarget(TARGET);
+	});
+	afterAll(() => h.close());
+
+	it('adds the status column with the planning default', async () => {
+		const col = await h.db.query<{ column_default: string; is_nullable: string }>(
+			`SELECT column_default, is_nullable FROM information_schema.columns
+			 WHERE table_name = 'documents' AND column_name = 'status'`,
+		);
+		expect(col.rows.length).toBe(1);
+		expect(col.rows[0].is_nullable).toBe('NO');
+		expect(col.rows[0].column_default).toContain('planning');
+
+		const inserted = await h.db.query<{ status: string }>(
+			`INSERT INTO documents (team_id, project_id, type, slug, content)
+			 VALUES ($1, $2, 'project_doc', 'fresh.md', 'x') RETURNING status`,
+			[teamId, projectId],
+		);
+		expect(inserted.rows[0].status).toBe('planning');
+
+		const approved = await h.db.query<{ status: string }>(
+			`INSERT INTO documents (team_id, project_id, type, slug, content, status)
+			 VALUES ($1, $2, 'project_doc', 'approved.md', 'x', 'approved') RETURNING status`,
+			[teamId, projectId],
+		);
+		expect(approved.rows[0].status).toBe('approved');
+
+		await expect(
+			h.db.query(
+				`INSERT INTO documents (team_id, project_id, type, slug, content, status)
+				 VALUES ($1, $2, 'project_doc', 'bogus.md', 'x', 'shipped')`,
+				[teamId, projectId],
+			),
+		).rejects.toThrow(/invalid input value for enum document_status/);
+	});
+
+	it('preserves pre-existing rows and backfills them to planning', async () => {
+		const projectDoc = await h.db.query<{ content: string; status: string }>(
+			`SELECT content, status FROM documents WHERE id = $1`,
+			[projectDocId],
+		);
+		expect(projectDoc.rows[0].content).toBe('# Spec');
+		expect(projectDoc.rows[0].status).toBe('planning');
+
+		const preferencesDoc = await h.db.query<{ content: string; status: string }>(
+			`SELECT content, status FROM documents WHERE id = $1`,
+			[preferencesDocId],
+		);
+		expect(preferencesDoc.rows[0].content).toBe('Prefer TypeScript');
+		expect(preferencesDoc.rows[0].status).toBe('planning');
+	});
+});

--- a/packages/server/test/project-docs.test.ts
+++ b/packages/server/test/project-docs.test.ts
@@ -185,6 +185,74 @@ describe('Project docs (DB-backed)', () => {
 	});
 });
 
+describe('Project doc status', () => {
+	const filename = 'status-doc.md';
+
+	it('new docs start in planning', async () => {
+		const res = await app.request(`/api/projects/${projectId}/docs/${filename}`, {
+			method: 'PUT',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ content: '# Status doc' }),
+		});
+		expect(res.status).toBe(200);
+		expect((await res.json()).data.status).toBe('planning');
+	});
+
+	it('list items include the status', async () => {
+		const res = await app.request(`/api/projects/${projectId}/docs`, {
+			headers: authHeader(token),
+		});
+		const body = await res.json();
+		const item = body.data.find((d: any) => d.filename === filename);
+		expect(item.status).toBe('planning');
+	});
+
+	it('PATCH sets the status without touching content or the last editor', async () => {
+		const before = await (
+			await app.request(`/api/projects/${projectId}/docs/${filename}`, {
+				headers: authHeader(token),
+			})
+		).json();
+
+		const res = await app.request(`/api/projects/${projectId}/docs/${filename}`, {
+			method: 'PATCH',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ status: 'approved' }),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data.status).toBe('approved');
+		expect(body.data.content).toBe(before.data.content);
+		expect(body.data.last_updated_by_name).toBe(before.data.last_updated_by_name);
+		expect(body.data.last_updated_by_type).toBe(before.data.last_updated_by_type);
+
+		// A status flip is metadata, not a content edit — no revision recorded.
+		const revRes = await app.request(`/api/projects/${projectId}/docs/${filename}/revisions`, {
+			headers: authHeader(token),
+		});
+		expect((await revRes.json()).data.length).toBe(0);
+	});
+
+	it('rejects an unknown status with 400', async () => {
+		const res = await app.request(`/api/projects/${projectId}/docs/${filename}`, {
+			method: 'PATCH',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ status: 'shipped' }),
+		});
+		expect(res.status).toBe(400);
+		expect((await res.json()).error.code).toBe('INVALID_REQUEST');
+	});
+
+	it('returns 404 when the doc does not exist', async () => {
+		const res = await app.request(`/api/projects/${projectId}/docs/missing.md`, {
+			method: 'PATCH',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ status: 'approved' }),
+		});
+		expect(res.status).toBe(404);
+	});
+});
+
 describe('Project doc revisions and restore', () => {
 	const filename = 'revisioned.md';
 

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -930,6 +930,21 @@ export const DocumentType = {
 } as const;
 export type DocumentType = (typeof DocumentType)[keyof typeof DocumentType];
 
+export const DocumentStatus = {
+	Planning: 'planning',
+	Approved: 'approved',
+} as const;
+export type DocumentStatus = (typeof DocumentStatus)[keyof typeof DocumentStatus];
+
+export const DOCUMENT_STATUS_LABELS: Record<DocumentStatus, string> = {
+	[DocumentStatus.Planning]: 'Planning',
+	[DocumentStatus.Approved]: 'Approved',
+};
+
+export function formatDocumentStatus(status: string): string {
+	return DOCUMENT_STATUS_LABELS[status as DocumentStatus] ?? status;
+}
+
 export const AuditActorType = {
 	Admin: 'admin',
 	Agent: 'agent',

--- a/packages/web/src/components/document-review/document-metadata-banner.tsx
+++ b/packages/web/src/components/document-review/document-metadata-banner.tsx
@@ -1,12 +1,19 @@
+import { DOCUMENT_STATUS_LABELS, type DocumentStatus } from '@hezo/shared';
 import type { ReactNode } from 'react';
+import { documentStatusMeta } from '../../lib/status-meta';
 import { ActorBadge } from '../ui/actor-badge';
 import { getInitials } from '../ui/avatar';
+import { Badge } from '../ui/badge';
 
 export interface DocMetadata {
 	createdAt?: string;
 	updatedAt?: string;
 	editorName?: string | null;
 	editorType?: string;
+	/** Lifecycle status: 'planning' | 'approved'. */
+	status?: string;
+	/** When set, the status renders as an editable dropdown instead of a static badge. */
+	onStatusChange?: (status: DocumentStatus) => void;
 }
 
 function shortDate(iso: string): string {
@@ -40,10 +47,35 @@ export function DocumentMetadataBanner({
 	updatedAt,
 	editorName,
 	editorType,
+	status,
+	onStatusChange,
 }: DocMetadata) {
-	if (!createdAt && !updatedAt && !editorName) return null;
+	if (!createdAt && !updatedAt && !editorName && !status) return null;
 	const sep = <span className="text-border-strong">·</span>;
 	const items: ReactNode[] = [];
+	if (status) {
+		items.push(
+			<span key="status" className="inline-flex items-center gap-1.5">
+				<span className={K}>Status</span>
+				{onStatusChange ? (
+					<select
+						aria-label="Document status"
+						value={status}
+						onChange={(e) => onStatusChange(e.target.value as DocumentStatus)}
+						className="rounded-md border border-border bg-surface px-1.5 py-0.5 text-[11px] text-text-1 outline-none"
+					>
+						{Object.entries(DOCUMENT_STATUS_LABELS).map(([value, label]) => (
+							<option key={value} value={value}>
+								{label}
+							</option>
+						))}
+					</select>
+				) : (
+					<Badge color={documentStatusMeta(status).color}>{documentStatusMeta(status).label}</Badge>
+				)}
+			</span>,
+		);
+	}
 	if (createdAt) {
 		items.push(
 			<span key="created" className="inline-flex items-center gap-1.5 tabular-nums">

--- a/packages/web/src/hooks/use-project-docs.ts
+++ b/packages/web/src/hooks/use-project-docs.ts
@@ -3,10 +3,13 @@ import type { DocumentRevision } from '../components/revisions-panel';
 import { type ApiError, api } from '../lib/api';
 import { queryClient } from '../lib/query-client';
 import { queryKeys } from '../lib/query-keys';
+import { useSimpleOptimisticUpdate } from './use-optimistic-mutation';
 
 export interface ProjectDoc {
 	id: string;
 	filename: string;
+	/** Lifecycle status: 'planning' | 'approved'. */
+	status?: string;
 	updated_at: string;
 	content?: string;
 	/** Present on the single-doc GET (and after a save/restore); absent in the list. */
@@ -71,6 +74,17 @@ export function useUpdateProjectDoc(projectId: string) {
 			});
 		},
 	});
+}
+
+export function useUpdateProjectDocStatus(projectId: string, filename: string | null) {
+	return useSimpleOptimisticUpdate<ProjectDoc>(
+		`/api/projects/${projectId}/docs/${filename}`,
+		queryKeys.projects.doc(projectId, filename),
+		{
+			invalidateOnSettled: [queryKeys.projects.docs(projectId)],
+			errorMessage: 'Failed to update document status',
+		},
+	);
 }
 
 export function useDeleteProjectDoc(projectId: string) {

--- a/packages/web/src/lib/status-meta.ts
+++ b/packages/web/src/lib/status-meta.ts
@@ -1,6 +1,8 @@
 import {
 	AgentRuntimeStatus,
 	ApprovalType,
+	DocumentStatus,
+	formatDocumentStatus,
 	formatTaskStatus,
 	TaskPriority,
 	TaskStatus,
@@ -41,6 +43,21 @@ export function taskStatusColor(status: string): BadgeColor {
 /** Color + label for a task status (label sourced from the shared label map). */
 export function taskStatusMeta(status: string): BadgeMeta {
 	return { color: taskStatusColor(status), label: formatTaskStatus(status) };
+}
+
+const DOCUMENT_STATUS_COLORS: Record<DocumentStatus, BadgeColor> = {
+	[DocumentStatus.Planning]: 'warning',
+	[DocumentStatus.Approved]: 'success',
+};
+
+/** Badge color for a document status, defaulting to neutral for unknown values. */
+export function documentStatusColor(status: string): BadgeColor {
+	return DOCUMENT_STATUS_COLORS[status as DocumentStatus] ?? 'neutral';
+}
+
+/** Color + label for a document status (label sourced from the shared label map). */
+export function documentStatusMeta(status: string): BadgeMeta {
+	return { color: documentStatusColor(status), label: formatDocumentStatus(status) };
 }
 
 // Priority maps to the spec's semantic tints: urgent = danger, high = warning,

--- a/packages/web/src/routes/projects/$projectId/documents.tsx
+++ b/packages/web/src/routes/projects/$projectId/documents.tsx
@@ -1,4 +1,4 @@
-import { isMarkdownDocSlug } from '@hezo/shared';
+import { type DocumentStatus, formatDocumentStatus, isMarkdownDocSlug } from '@hezo/shared';
 import { createFileRoute } from '@tanstack/react-router';
 import { Loader2 } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
@@ -17,6 +17,7 @@ import {
 	useRestoreProjectDocRevision,
 	useUpdateProjectAgentsMd,
 	useUpdateProjectDoc,
+	useUpdateProjectDocStatus,
 } from '../../../hooks/use-project-docs';
 import { docPreviewPath } from '../../../lib/doc-preview';
 import { buildDocVersionHistory, type DocVersionEntry } from '../../../lib/doc-version-history';
@@ -46,6 +47,7 @@ function ProjectDocumentsPage() {
 	const { data: doc, isLoading: isLoadingDoc } = useProjectDoc(projectId, filenameForFetch);
 	const { data: revisions } = useProjectDocRevisions(projectId, filenameForFetch);
 	const restore = useRestoreProjectDocRevision(projectId, file ?? '');
+	const updateStatus = useUpdateProjectDocStatus(projectId, filenameForFetch);
 
 	// Which past version (if any) is being viewed, and whether the history dialog is open.
 	const [viewingRevision, setViewingRevision] = useState<DocVersionEntry | null>(null);
@@ -77,7 +79,9 @@ function ProjectDocumentsPage() {
 			list.push({
 				key: d.filename,
 				label: d.filename,
-				meta: `Updated ${new Date(d.updated_at).toLocaleDateString()}`,
+				meta: d.status
+					? `${formatDocumentStatus(d.status)} · Updated ${new Date(d.updated_at).toLocaleDateString()}`
+					: `Updated ${new Date(d.updated_at).toLocaleDateString()}`,
 			});
 		}
 		return list;
@@ -93,12 +97,17 @@ function ProjectDocumentsPage() {
 					updatedAt: viewingRevision.timestamp,
 					editorName: viewingRevision.authorName,
 					editorType: viewingRevision.authorType,
+					status: doc?.status,
 				}
 			: {
 					createdAt: doc?.created_at,
 					updatedAt: doc?.updated_at,
 					editorName: doc?.last_updated_by_name,
 					editorType: doc?.last_updated_by_type,
+					status: doc?.status,
+					onStatusChange: file
+						? (status: DocumentStatus) => updateStatus.mutate({ status })
+						: undefined,
 				};
 
 	function selectFile(key: string | null) {

--- a/packages/web/test/project-documents.test.tsx
+++ b/packages/web/test/project-documents.test.tsx
@@ -163,6 +163,53 @@ test('shows the metadata banner and hides a legacy metadata header from the rend
 	expect(queryByText(/experiment-zzz/)).toBeNull();
 });
 
+test('shows the document status in the banner and updates it via the dropdown', async () => {
+	let ws!: SeededWorkspace;
+	let projectSlug = '';
+	const filename = `status-${Math.random().toString(36).slice(2, 8)}.md`;
+
+	const { findByText, findByLabelText, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async ({ apiBase, token }) => {
+			ws = await seedWorkspace();
+			const project = await seedProject(ws, {
+				name: uniqueName('Status Project'),
+				description: 'Tests the document status dropdown.',
+			});
+			projectSlug = project.slug;
+			await seedDoc(apiBase, token, projectSlug, filename, [{ content: 'Doc body' }]);
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/documents',
+		params: { projectId: projectSlug },
+		search: { file: filename } as never,
+	});
+
+	await findByText('Doc body', undefined, { timeout: 15_000 });
+
+	// New docs start in Planning; the banner renders an editable dropdown.
+	const statusSelect = (await findByLabelText('Document status')) as HTMLSelectElement;
+	expect(statusSelect.value).toBe('planning');
+
+	await user.selectOptions(statusSelect, 'approved');
+	// Optimistic update — the select reflects the new value immediately.
+	expect(statusSelect.value).toBe('approved');
+
+	// The server processed the mutation: the DB row carries the new status.
+	const { db } = getTestContext();
+	await new Promise((r) => setTimeout(r, 300));
+	const row = await db.query<{ status: string }>(
+		`SELECT status FROM documents WHERE slug = $1 AND type = 'project_doc'`,
+		[filename],
+	);
+	expect(row.rows[0].status).toBe('approved');
+
+	// The doc list entry surfaces the status label.
+	await findByText(/Approved · Updated/, undefined, { timeout: 15_000 });
+});
+
 test('viewing an older revision shows the banner, hides Edit, and can return to latest', async () => {
 	let ws!: SeededWorkspace;
 	let projectSlug = '';


### PR DESCRIPTION
## Summary

Documents previously carried **no status anywhere** — the metadata banner showed only created/updated/last-edited-by. This adds a lifecycle status (`planning` | `approved`) to documents end-to-end:

- **DB**: migration `015_document_status.sql` — new `document_status` Postgres enum + `documents.status` column (`NOT NULL DEFAULT 'planning'`, so existing rows backfill automatically). Ships with a data-preservation test (`migrate-015-document-status.test.ts`).
- **Shared**: `DocumentStatus` enum + `DOCUMENT_STATUS_LABELS` / `formatDocumentStatus` in `@hezo/shared`.
- **REST**: `status` on the doc list + single-doc responses; new `PATCH /api/projects/:projectId/docs/:filename` accepting `{ status }` (400 on unknown value, 404 on missing doc). Kept separate from PUT so a status flip never resends content or trips the `prd.md` agent-approval path.
- **MCP**: `list_project_docs` / `read_project_doc` now return `status`; new `set_project_doc_status` write tool. `docs/reference/mcp-api.md` regenerated via `bun run build:docs`; `TOOL_DOC_META` authored.
- **Web**: the doc metadata banner shows a Status item — an editable dropdown on the latest version, a static badge in read-only revision views. The Documents list shows the status label per doc. Optimistic mutation via `useSimpleOptimisticUpdate`.
- **Docs**: `docs/concepts/documents-and-memory.md` + `.dev/architecture.md` updated.

## Design notes

- A status flip is **metadata, not a content edit**: no revision is recorded and `last_updated_by_member_id` is untouched, so "Last edited by" stays honest. The row trigger still bumps `updated_at`; the post-mutation invalidation refreshes the review-comment staleness check, so this is self-healing.
- The `prd.md` agent PUT → Strategy approval path is unchanged; status is independent of the approvals system.
- The column exists for all document types but is surfaced only for project docs.

## Tests

- New: migration data-preservation test; "Project doc status" REST describe block (default planning, list includes status, PATCH happy/400/404, no revision recorded); MCP round-trip for `set_project_doc_status`; web component test driving the dropdown and asserting the DB row.
- Drift tests (`mcp-reference`, `llms-txt`, `docs-bundle`) green after `bun run build:docs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C3DvHFVjEHWurSpq6zkcx1

---
_Generated by [Claude Code](https://claude.ai/code/session_01C3DvHFVjEHWurSpq6zkcx1)_