### PR TITLE
feat(web): collapsible document list on the Documents page

### DIFF
--- a/docs/concepts/documents-and-memory.md
+++ b/docs/concepts/documents-and-memory.md
@@ -111,6 +111,11 @@ can paste into a task comment or a new task's description when assigning the wor
 **clear review** (a trash button that deletes every comment after confirmation), alongside a
 **?** button that opens a short in-app guide to all of this.
 
+On a larger screen you can also **hide the document list** — the panel button just left of
+the document's title collapses it, giving the document the full width of the page; the same
+button brings the list back, and Hezo remembers your choice. (On a phone the list and the
+document already take turns filling the screen.)
+
 Agents read pending review comments directly: `read_project_doc` returns them alongside the
 document content, each one anchored to the exact text you highlighted. So the flow is —
 leave your comments, hand the review to an agent (paste the copied handoff into a task and

--- a/packages/web/src/components/docs-library.tsx
+++ b/packages/web/src/components/docs-library.tsx
@@ -4,12 +4,15 @@ import {
 	FileText,
 	History,
 	Loader2,
+	PanelLeftClose,
+	PanelLeftOpen,
 	Pencil,
 	Plus,
 	Search,
 	Trash2,
 } from 'lucide-react';
 import { type ReactNode, useEffect, useRef, useState } from 'react';
+import { readStored, writeStored } from '../lib/safe-storage';
 import { DocumentBody } from './document-review/document-body';
 import type { DocMetadata } from './document-review/document-metadata-banner';
 import { ReviewToolbarActions } from './document-review/review-toolbar-actions';
@@ -18,6 +21,10 @@ import { Button } from './ui/button';
 import { ConfirmDialog } from './ui/confirm-dialog';
 import { EmptyState } from './ui/empty-state';
 import { Input } from './ui/input';
+import { Tooltip } from './ui/tooltip';
+
+/** Remembers the doc-list collapse choice across documents and visits. */
+const LIST_COLLAPSED_KEY = 'hezo:doc-list-collapsed';
 
 export interface DocItem {
 	key: string;
@@ -108,6 +115,7 @@ export function DocsLibrary({
 	const [draft, setDraft] = useState('');
 	const [deleteOpen, setDeleteOpen] = useState(false);
 	const [search, setSearch] = useState('');
+	const [listCollapsed, setListCollapsed] = useState(() => readStored(LIST_COLLAPSED_KEY) === '1');
 	const prevModeRef = useRef<'view' | 'edit'>('view');
 
 	if (modeKey !== selectedKey) {
@@ -126,6 +134,18 @@ export function DocsLibrary({
 	const selectedItem = selectedKey ? items.find((it) => it.key === selectedKey) : undefined;
 	const showRightPane = showNewForm || selectedKey;
 	const popOutUrl = selectedKey && getPopOutUrl ? getPopOutUrl(selectedKey) : null;
+	// The collapse only applies while a document is open — its toolbar hosts the
+	// only expand control, so with nothing selected (empty state, new-doc form)
+	// the list must stay visible or there'd be no way to pick a document.
+	const collapsed = listCollapsed && !!selectedKey && !showNewForm;
+
+	function toggleList() {
+		setListCollapsed((prev) => {
+			const next = !prev;
+			writeStored(LIST_COLLAPSED_KEY, next ? '1' : '0');
+			return next;
+		});
+	}
 
 	// Filter on the visible label when it's a plain string; fall back to the key
 	// (typically the filename) for rich labels.
@@ -152,12 +172,27 @@ export function DocsLibrary({
 		/* minmax(0,1fr) — a bare 1fr track has an `auto` minimum, so wide doc
 		   content (tables, code) would push the column past the viewport and
 		   side-scroll the doc list out of view instead of scrolling inside the
-		   pane. */
-		<div className="grid grid-cols-1 md:grid-cols-[240px_minmax(0,1fr)] md:gap-6 md:min-h-[500px]">
+		   pane. Collapsing animates the list track (and the gap) to zero so the
+		   document takes the full content width. */
+		<div
+			data-testid="docs-library-grid"
+			className={`grid grid-cols-1 md:min-h-[500px] md:transition-[grid-template-columns,gap] md:duration-200 motion-reduce:md:transition-none ${
+				collapsed
+					? 'md:grid-cols-[0px_minmax(0,1fr)] md:gap-0'
+					: 'md:grid-cols-[240px_minmax(0,1fr)] md:gap-6'
+			}`}
+		>
+			{/* `inert` while collapsed keeps the visually-hidden list out of tab
+			    order and the accessibility tree. `overflow-hidden` clips the list
+			    during the track animation (it also disables the sticky child, which
+			    is moot while hidden); it must NOT apply when expanded or the sticky
+			    doc list stops sticking. */}
 			<aside
-				className={`md:border-r md:border-border md:pr-6 ${
-					showRightPane ? 'hidden md:block' : 'block'
-				}`}
+				inert={collapsed}
+				data-testid="doc-list-pane"
+				className={`min-w-0 md:transition-opacity md:duration-200 motion-reduce:md:transition-none ${
+					collapsed ? 'md:overflow-hidden md:opacity-0' : 'md:border-r md:border-border md:pr-6'
+				} ${showRightPane ? 'hidden md:block' : 'block'}`}
 			>
 				{/* Sticky on desktop so the doc list stays visible while a long
 				    document scrolls. The top offset mirrors the project layout's
@@ -263,9 +298,32 @@ export function DocsLibrary({
 						    z-index sits below the review overlays (selection pill z-20,
 						    editor z-30) so an open comment editor is never hidden. */}
 						<div className="sticky top-0 z-10 flex items-center justify-between gap-2 mb-4 pt-2 pb-3 bg-bg border-b border-border-subtle">
-							<h2 className="text-base font-semibold text-text-1 truncate">
-								{docTitle ?? selectedItem?.label ?? selectedKey}
-							</h2>
+							<div className="flex items-center gap-1.5 min-w-0">
+								{/* Mobile already swaps to a single pane with its own Back
+								    button, so the collapse control is desktop/tablet only. */}
+								<span className="hidden md:block shrink-0">
+									<Tooltip content={collapsed ? 'Show document list' : 'Hide document list'}>
+										<Button
+											variant="ghost"
+											size="sm"
+											className="px-1.5"
+											onClick={toggleList}
+											aria-expanded={!collapsed}
+											aria-label={collapsed ? 'Show document list' : 'Hide document list'}
+											data-testid="doc-list-toggle"
+										>
+											{collapsed ? (
+												<PanelLeftOpen className="w-3.5 h-3.5" />
+											) : (
+												<PanelLeftClose className="w-3.5 h-3.5" />
+											)}
+										</Button>
+									</Tooltip>
+								</span>
+								<h2 className="text-base font-semibold text-text-1 truncate">
+									{docTitle ?? selectedItem?.label ?? selectedKey}
+								</h2>
+							</div>
 							<div className="flex items-center gap-2 shrink-0">
 								{mode === 'view' ? (
 									<>

--- a/packages/web/test/docs-list-collapse.test.tsx
+++ b/packages/web/test/docs-list-collapse.test.tsx
@@ -1,0 +1,121 @@
+import { expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+import { seedProject, seedWorkspace } from './helpers/seed';
+
+const LIST_COLLAPSED_KEY = 'hezo:doc-list-collapsed';
+
+function uniqueName(base: string): string {
+	return `${base} ${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function seedDoc(
+	apiBase: (path: string, init: RequestInit) => Promise<Response>,
+	token: string,
+	projectSlug: string,
+	filename: string,
+	content: string,
+): Promise<void> {
+	const res = await apiBase(`/api/projects/${projectSlug}/docs/${filename}`, {
+		method: 'PUT',
+		headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+		body: JSON.stringify({ content }),
+	});
+	if (!res.ok) throw new Error(`doc write failed: ${res.status}`);
+}
+
+test('toggle collapses the doc list, persists the choice, and expands it again', async () => {
+	localStorage.removeItem(LIST_COLLAPSED_KEY);
+	let projectSlug = '';
+	const filename = `guide-${Math.random().toString(36).slice(2, 8)}.md`;
+
+	const { findByTestId, findByText, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async ({ apiBase, token }) => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, {
+				name: uniqueName('Collapse Project'),
+				description: 'Tests the doc-list collapse toggle.',
+			});
+			projectSlug = project.slug;
+			await seedDoc(apiBase, token, projectSlug, filename, 'Collapse me');
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/documents',
+		params: { projectId: projectSlug },
+		search: { file: filename } as never,
+	});
+	await findByText('Collapse me', undefined, { timeout: 15_000 });
+
+	const toggle = await findByTestId('doc-list-toggle');
+	const listPane = await findByTestId('doc-list-pane');
+
+	// Expanded by default: the list is interactive and the control offers to hide it.
+	expect(toggle.getAttribute('aria-expanded')).toBe('true');
+	expect(toggle.getAttribute('aria-label')).toBe('Hide document list');
+	expect(listPane.hasAttribute('inert')).toBe(false);
+
+	// Collapse: the list leaves the accessibility tree and the choice is stored.
+	await user.click(toggle);
+	expect(toggle.getAttribute('aria-expanded')).toBe('false');
+	expect(toggle.getAttribute('aria-label')).toBe('Show document list');
+	expect(listPane.hasAttribute('inert')).toBe(true);
+	expect(localStorage.getItem(LIST_COLLAPSED_KEY)).toBe('1');
+
+	// Expand again.
+	await user.click(toggle);
+	expect(toggle.getAttribute('aria-expanded')).toBe('true');
+	expect(listPane.hasAttribute('inert')).toBe(false);
+	expect(localStorage.getItem(LIST_COLLAPSED_KEY)).toBe('0');
+
+	localStorage.removeItem(LIST_COLLAPSED_KEY);
+});
+
+test('a stored collapse choice applies on load, but only while a document is open', async () => {
+	localStorage.setItem(LIST_COLLAPSED_KEY, '1');
+	let projectSlug = '';
+	const filename = `sticky-${Math.random().toString(36).slice(2, 8)}.md`;
+
+	try {
+		const { findByTestId, findByText, findByRole, queryByTestId, router } = await renderApp({
+			initialPath: '/',
+			seed: async ({ apiBase, token }) => {
+				const ws = await seedWorkspace();
+				const project = await seedProject(ws, {
+					name: uniqueName('Persisted Collapse'),
+					description: 'Tests the persisted doc-list collapse state.',
+				});
+				projectSlug = project.slug;
+				await seedDoc(apiBase, token, projectSlug, filename, 'Persisted body');
+			},
+		});
+
+		await router.navigate({
+			to: '/projects/$projectId/documents',
+			params: { projectId: projectSlug },
+			search: { file: filename } as never,
+		});
+		await findByText('Persisted body', undefined, { timeout: 15_000 });
+
+		// The remembered choice applies: collapsed from the first render.
+		const toggle = await findByTestId('doc-list-toggle');
+		expect(toggle.getAttribute('aria-expanded')).toBe('false');
+		expect((await findByTestId('doc-list-pane')).hasAttribute('inert')).toBe(true);
+
+		// With no document open there is no toggle, so the collapse must not
+		// apply — otherwise nothing could ever be selected.
+		await router.navigate({
+			to: '/projects/$projectId/documents',
+			params: { projectId: projectSlug },
+			search: {} as never,
+		});
+		await findByText('Select a document', undefined, { timeout: 15_000 });
+		expect(queryByTestId('doc-list-toggle')).toBeNull();
+		expect((await findByTestId('doc-list-pane')).hasAttribute('inert')).toBe(false);
+		// The list is genuinely usable: its entries are reachable.
+		await findByRole('button', { name: 'New document' });
+	} finally {
+		localStorage.removeItem(LIST_COLLAPSED_KEY);
+	}
+});

--- a/packages/web/test/project-documents.test.tsx
+++ b/packages/web/test/project-documents.test.tsx
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest';
-import { renderApp } from './helpers/render';
+import { getTestContext, renderApp } from './helpers/render';
 import { type SeededWorkspace, seedProject, seedWorkspace } from './helpers/seed';
 
 function uniqueName(base: string): string {

--- a/test/browser/docs-list-collapse.spec.ts
+++ b/test/browser/docs-list-collapse.spec.ts
@@ -1,0 +1,92 @@
+// Collapsing the doc list is a real-CSS-layout assertion (testing decision
+// tree, point 1): it animates the sidebar grid track to zero width and the
+// document pane reflows to the freed space — boundingBox() positions and
+// zero-size visibility that happy-dom can't compute. The mobile check is
+// viewport-conditional (point 2): the toggle only exists at md and up.
+
+import { expect, test } from './fixtures';
+import { waitForPageLoad } from './helpers';
+
+test('collapsing the doc list gives the document the full width, and the choice survives a reload', async ({
+	page,
+	lightWorkspace,
+}) => {
+	const { projectSlug, token } = lightWorkspace;
+	// Desktop: clears md (doc list beside the content pane) and lg (full rail).
+	await page.setViewportSize({ width: 1280, height: 800 });
+
+	const res = await page.request.put(`/api/projects/${projectSlug}/docs/collapse.md`, {
+		headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+		data: { content: '# Collapse target\n\nBody text for the collapse spec.' },
+	});
+	expect(res.ok()).toBe(true);
+
+	await page.goto(`/projects/${projectSlug}/documents?file=collapse.md`);
+	await waitForPageLoad(page);
+
+	const title = page.getByRole('heading', { name: 'collapse.md' });
+	await expect(title).toBeVisible({ timeout: 20000 });
+	const newDocButton = page.getByRole('button', { name: /New document/ });
+	await expect(newDocButton).toBeVisible();
+
+	// The list pane collapses to a zero-width grid track, which Playwright
+	// treats as hidden. (Its inner controls keep their own padding box even
+	// when clipped, so assert on the pane, not the buttons inside it.)
+	const listPane = page.getByTestId('doc-list-pane');
+	const toggle = page.getByTestId('doc-list-toggle');
+	await expect(toggle).toBeVisible();
+	await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+	const before = await title.boundingBox();
+	expect(before).not.toBeNull();
+
+	// Collapse: the list track animates to zero and the document toolbar
+	// shifts left into the freed space.
+	await toggle.click();
+	await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+	await expect(listPane).toBeHidden();
+	await expect
+		.poll(async () => (await title.boundingBox())?.x ?? Number.NaN, { timeout: 5000 })
+		// 240px track + 24px gap freed; allow slack for the toggle icon swap.
+		.toBeLessThan((before?.x ?? 0) - 200);
+
+	// The choice is remembered across a reload.
+	await page.reload();
+	await waitForPageLoad(page);
+	await expect(title).toBeVisible({ timeout: 20000 });
+	await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+	await expect(listPane).toBeHidden();
+
+	// Expand again: the list comes back where it was.
+	await toggle.click();
+	await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+	await expect(newDocButton).toBeVisible();
+	await expect
+		.poll(async () => (await title.boundingBox())?.x ?? Number.NaN, { timeout: 5000 })
+		.toBeGreaterThan((before?.x ?? 0) - 10);
+});
+
+test('mobile keeps the existing single-pane flow: no collapse toggle, Back still works', async ({
+	page,
+	lightWorkspace,
+}) => {
+	const { projectSlug, token } = lightWorkspace;
+	await page.setViewportSize({ width: 375, height: 800 });
+
+	const res = await page.request.put(`/api/projects/${projectSlug}/docs/mobile.md`, {
+		headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+		data: { content: '# Mobile doc\n\nMobile body.' },
+	});
+	expect(res.ok()).toBe(true);
+
+	await page.goto(`/projects/${projectSlug}/documents?file=mobile.md`);
+	await waitForPageLoad(page);
+
+	await expect(page.getByRole('heading', { name: 'mobile.md' })).toBeVisible({ timeout: 20000 });
+	// The doc fills the screen on mobile with the list already hidden, so the
+	// desktop collapse control would be redundant — it must not render.
+	await expect(page.getByTestId('doc-list-toggle')).toBeHidden();
+	// The existing mobile escape hatch back to the list is untouched.
+	await page.getByRole('button', { name: /Back/ }).click();
+	await expect(page.getByRole('button', { name: /New document/ })).toBeVisible();
+});


### PR DESCRIPTION
## What

When viewing a document, the left-hand document list can now be hidden so the open document takes the full content width. A panel-toggle button (lucide `PanelLeftClose` / `PanelLeftOpen`) sits leftmost in the sticky document toolbar, just before the title, so it stays reachable while a long document scrolls.

## How

- **`DocsLibrary`** (shared by the project Documents page): the sidebar grid track (and the grid gap) animate to zero width over 200ms (`motion-reduce` disables the transition). The collapsed list is marked `inert` so it leaves the tab order and the accessibility tree; the toggle carries `aria-expanded` and a swapping `aria-label`/tooltip ("Hide document list" / "Show document list").
- **Persistence**: the choice is remembered in `localStorage` (`hezo:doc-list-collapsed`, via the existing `safe-storage` helpers) across documents and visits.
- **Guard rail**: the collapse only applies while a document is open — the toolbar hosts the only expand control, so with nothing selected (empty state, new-doc form, after a delete) the list always shows and a document can always be picked.
- **Mobile unchanged**: below `md` the page already swaps to a single pane with its own Back button, so the toggle is desktop/tablet-only and doesn't render on mobile.
- **Docs**: `docs/concepts/documents-and-memory.md` gained a short paragraph describing the control (reaches the CEO chat via the docs bundle automatically).

## Tests

- **Component** (`packages/web/test/docs-list-collapse.test.tsx`): toggle collapses/expands (`aria-expanded`, `inert`, storage writes); a stored choice applies on load but is ignored while no document is open.
- **Playwright** (`test/browser/docs-list-collapse.spec.ts`) — real-CSS-layout slice (decision tree point 1) plus the viewport-conditional mobile check (point 2): the list track genuinely reaches zero width, the document toolbar shifts left by the freed ~264px, the choice survives a reload, and on a 375px viewport the toggle is absent while the existing Back flow still works.

`bun run test --skip-browser --package web` green (one unrelated `log-viewer-branches` clipboard flake under the loaded parallel run; passes in isolation), server `docs-bundle` drift test green, biome + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011imhQL4eBWpgiYbxYqiRbw

---
_Generated by [Claude Code](https://claude.ai/code/session_011imhQL4eBWpgiYbxYqiRbw)_