### PR TITLE
feat(web): documents sidebar search with fixed header

### DIFF
--- a/docs/concepts/documents-and-memory.md
+++ b/docs/concepts/documents-and-memory.md
@@ -71,7 +71,10 @@ every agent can reach them without cluttering the codebase. You read and edit an
 from the **Documents** page in the web app, and agents read and write the same files as they
 work (`list_project_docs`, `read_project_doc`, and `write_project_doc` over Hezo's
 [MCP server](/docs/mcp/hezo-mcp-server)). A document is referenced by its plain filename —
-for example `spec.md` — so links stay stable as the work evolves.
+for example `spec.md` — so links stay stable as the work evolves. The document list sits
+beside the reader, with a **search box** at the top that filters the list as you type and a
+**+** button next to it for creating a new document — both stay in view while you scroll
+the list.
 
 Agents don't carry every document's full text on every run. Instead each run includes a
 **manifest** — a table of contents listing each document's filename, title, and when it

--- a/packages/web/src/components/docs-library.tsx
+++ b/packages/web/src/components/docs-library.tsx
@@ -6,6 +6,7 @@ import {
 	Loader2,
 	Pencil,
 	Plus,
+	Search,
 	Trash2,
 } from 'lucide-react';
 import { type ReactNode, useEffect, useRef, useState } from 'react';
@@ -16,6 +17,7 @@ import { MentionTextarea } from './mention-textarea';
 import { Button } from './ui/button';
 import { ConfirmDialog } from './ui/confirm-dialog';
 import { EmptyState } from './ui/empty-state';
+import { Input } from './ui/input';
 
 export interface DocItem {
 	key: string;
@@ -105,6 +107,7 @@ export function DocsLibrary({
 	const [modeKey, setModeKey] = useState<string | null>(selectedKey);
 	const [draft, setDraft] = useState('');
 	const [deleteOpen, setDeleteOpen] = useState(false);
+	const [search, setSearch] = useState('');
 	const prevModeRef = useRef<'view' | 'edit'>('view');
 
 	if (modeKey !== selectedKey) {
@@ -123,6 +126,16 @@ export function DocsLibrary({
 	const selectedItem = selectedKey ? items.find((it) => it.key === selectedKey) : undefined;
 	const showRightPane = showNewForm || selectedKey;
 	const popOutUrl = selectedKey && getPopOutUrl ? getPopOutUrl(selectedKey) : null;
+
+	// Filter on the visible label when it's a plain string; fall back to the key
+	// (typically the filename) for rich labels.
+	const query = search.trim().toLowerCase();
+	const visibleItems = query
+		? items.filter((item) => {
+				const text = typeof item.label === 'string' ? item.label : item.key;
+				return text.toLowerCase().includes(query);
+			})
+		: items;
 
 	async function handleSave() {
 		await onSave(draft);
@@ -151,48 +164,71 @@ export function DocsLibrary({
 				    vertical padding (md:py-5 lg:py-6) so the pinned position
 				    preserves the breathing room visible when unscrolled. max-h
 				    subtracts the h-10 app header (2.5rem) plus the top offset so
-				    the list never overflows the bottom of <main>. */}
-				<div className="md:sticky md:top-5 lg:top-6 md:max-h-[calc(100vh-3.75rem)] lg:max-h-[calc(100vh-4rem)] md:overflow-y-auto">
-					{onNewDoc && (
-						<Button
-							variant="outline"
-							size="sm"
-							className="w-full mb-3 justify-start"
-							onClick={onNewDoc}
-						>
-							<Plus className="w-3.5 h-3.5" /> New document
-						</Button>
-					)}
+				    the list never overflows the bottom of <main>. The column is a
+				    flex stack: the search header stays fixed while only the list
+				    below it scrolls. */}
+				<div className="md:sticky md:top-5 lg:top-6 md:max-h-[calc(100vh-3.75rem)] lg:max-h-[calc(100vh-4rem)] md:flex md:flex-col">
+					{/* On mobile the whole page scrolls, so the header pins itself to
+					    the shell scroller; on md+ it's a non-scrolling flex row above
+					    the list's own scroller. bg-bg so list rows pass cleanly
+					    underneath on mobile. */}
+					<div className="sticky top-0 z-10 md:static flex items-center gap-2 bg-bg pb-3 md:shrink-0">
+						<Input
+							type="search"
+							aria-label="Search documents"
+							placeholder="Search documents"
+							icon={<Search className="w-3.5 h-3.5" />}
+							className="flex-1 min-w-0"
+							value={search}
+							onChange={(e) => setSearch(e.target.value)}
+						/>
+						{onNewDoc && (
+							<Button
+								variant="outline"
+								size="sm"
+								className="h-8 w-8 shrink-0 px-0 rounded-md"
+								onClick={onNewDoc}
+								aria-label="New document"
+								title="New document"
+							>
+								<Plus className="w-4 h-4" />
+							</Button>
+						)}
+					</div>
 
-					{isLoadingList ? (
-						<div className="text-text-2 text-[13px] py-4">Loading...</div>
-					) : items.length === 0 ? (
-						<div className="text-text-2 text-[13px] py-4">No documents</div>
-					) : (
-						<ul className="flex flex-col gap-0.5">
-							{items.map((item) => {
-								const isActive = item.key === selectedKey;
-								return (
-									<li key={item.key}>
-										<button
-											type="button"
-											onClick={() => onSelect(item.key)}
-											className={`w-full text-left px-2 py-1.5 rounded-md transition-colors ${
-												isActive
-													? 'bg-surface-2 text-text-1'
-													: 'text-text-2 hover:bg-surface-2 hover:text-text-1'
-											}`}
-										>
-											<div className="text-[13px] font-medium truncate">{item.label}</div>
-											{item.meta && (
-												<div className="text-[11px] text-text-3 mt-0.5 truncate">{item.meta}</div>
-											)}
-										</button>
-									</li>
-								);
-							})}
-						</ul>
-					)}
+					<div className="md:overflow-y-auto md:min-h-0">
+						{isLoadingList ? (
+							<div className="text-text-2 text-[13px] py-4">Loading...</div>
+						) : items.length === 0 ? (
+							<div className="text-text-2 text-[13px] py-4">No documents</div>
+						) : visibleItems.length === 0 ? (
+							<div className="text-text-2 text-[13px] py-4">No matching documents</div>
+						) : (
+							<ul className="flex flex-col gap-0.5">
+								{visibleItems.map((item) => {
+									const isActive = item.key === selectedKey;
+									return (
+										<li key={item.key}>
+											<button
+												type="button"
+												onClick={() => onSelect(item.key)}
+												className={`w-full text-left px-2 py-1.5 rounded-md transition-colors ${
+													isActive
+														? 'bg-surface-2 text-text-1'
+														: 'text-text-2 hover:bg-surface-2 hover:text-text-1'
+												}`}
+											>
+												<div className="text-[13px] font-medium truncate">{item.label}</div>
+												{item.meta && (
+													<div className="text-[11px] text-text-3 mt-0.5 truncate">{item.meta}</div>
+												)}
+											</button>
+										</li>
+									);
+								})}
+							</ul>
+						)}
+					</div>
 				</div>
 			</aside>
 

--- a/packages/web/test/project-docs-md-only.test.tsx
+++ b/packages/web/test/project-docs-md-only.test.tsx
@@ -23,21 +23,22 @@ async function seedDoc(
 
 test('the New Document form rejects non-markdown filenames', async () => {
 	let ctx!: { projectSlug: string };
-	const { findByText, findByPlaceholderText, getByRole, user, router } = await renderApp({
-		initialPath: '/',
-		seed: async () => {
-			const ws = await seedWorkspace();
-			const project = await seedProject(ws, { name: 'MD Only' });
-			ctx = { projectSlug: project.slug };
-		},
-	});
+	const { findByText, findByRole, findByPlaceholderText, getByRole, user, router } =
+		await renderApp({
+			initialPath: '/',
+			seed: async () => {
+				const ws = await seedWorkspace();
+				const project = await seedProject(ws, { name: 'MD Only' });
+				ctx = { projectSlug: project.slug };
+			},
+		});
 
 	await router.navigate({
 		to: '/projects/$projectId/documents',
 		params: { projectId: ctx.projectSlug },
 	});
 
-	await user.click(await findByText('New document'));
+	await user.click(await findByRole('button', { name: 'New document' }));
 	await user.type(await findByPlaceholderText('notes.md'), 'mockup.html');
 	await user.click(getByRole('button', { name: 'Create' }));
 

--- a/packages/web/test/project-documents.test.tsx
+++ b/packages/web/test/project-documents.test.tsx
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest';
-import { getTestContext, renderApp } from './helpers/render';
+import { renderApp } from './helpers/render';
 import { type SeededWorkspace, seedProject, seedWorkspace } from './helpers/seed';
 
 function uniqueName(base: string): string {
@@ -207,6 +207,56 @@ test('viewing an older revision shows the banner, hides Edit, and can return to 
 	await user.click(await findByTestId('view-latest'));
 	await findByText('Second draft', undefined, { timeout: 15_000 });
 	await findByRole('button', { name: 'Edit' });
+});
+
+test('search input filters the document list as you type', async () => {
+	let ws!: SeededWorkspace;
+	let projectSlug = '';
+
+	const { findByText, findByLabelText, queryByText, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async ({ apiBase, token }) => {
+			ws = await seedWorkspace();
+			const project = await seedProject(ws, {
+				name: uniqueName('Search Project'),
+				description: 'Tests filtering the doc list from the sidebar search input.',
+			});
+			projectSlug = project.slug;
+			await seedDoc(apiBase, token, projectSlug, 'analytics-workflow.md', [
+				{ content: 'Analytics' },
+			]);
+			await seedDoc(apiBase, token, projectSlug, 'brand-style-guide.md', [{ content: 'Brand' }]);
+			await seedDoc(apiBase, token, projectSlug, 'content-calendar.md', [{ content: 'Calendar' }]);
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/documents',
+		params: { projectId: projectSlug },
+	});
+
+	// All three docs are listed before any filtering.
+	await findByText('analytics-workflow.md', undefined, { timeout: 15_000 });
+	await findByText('brand-style-guide.md');
+	await findByText('content-calendar.md');
+
+	const search = await findByLabelText('Search documents');
+	await user.type(search, 'brand');
+
+	await findByText('brand-style-guide.md');
+	expect(queryByText('analytics-workflow.md')).toBeNull();
+	expect(queryByText('content-calendar.md')).toBeNull();
+
+	// A query matching nothing shows the empty-filter message…
+	await user.clear(search);
+	await user.type(search, 'zzz-no-match');
+	await findByText('No matching documents');
+
+	// …and clearing the query restores the full list.
+	await user.clear(search);
+	await findByText('analytics-workflow.md');
+	await findByText('brand-style-guide.md');
+	await findByText('content-calendar.md');
 });
 
 test('rejects invalid filename when creating a document', async () => {

--- a/test/browser/docs-sidebar-sticky.spec.ts
+++ b/test/browser/docs-sidebar-sticky.spec.ts
@@ -32,7 +32,7 @@ test('documents sidebar stays pinned while the page scrolls on desktop', async (
 	// The filename heading confirms the doc loaded and its content is rendered.
 	await expect(page.getByRole('heading', { name: 'longdoc.md' })).toBeVisible({ timeout: 20000 });
 
-	const newDocButton = page.getByRole('button', { name: /New document/ });
+	const newDocButton = page.getByRole('button', { name: 'New document' });
 	await expect(newDocButton).toBeVisible();
 	const before = await newDocButton.boundingBox();
 	expect(before).not.toBeNull();
@@ -59,5 +59,50 @@ test('documents sidebar stays pinned while the page scrolls on desktop', async (
 		expect(after.y).toBeGreaterThanOrEqual(before.y - 1);
 		// And it sits within the app header + a small offset of the top.
 		expect(after.y).toBeLessThan(120);
+	}
+});
+
+test('sidebar search header stays fixed while the doc list itself scrolls', async ({
+	page,
+	freshWorkspace,
+}) => {
+	const { projectSlug, token } = freshWorkspace;
+	await page.setViewportSize({ width: 1280, height: 800 });
+
+	// Seed enough docs that the sidebar list overflows its own md scroller
+	// (max-h ≈ viewport minus header), so scrolling to the last entry scrolls
+	// the list — not the page.
+	const count = 40;
+	for (let i = 0; i < count; i++) {
+		const res = await page.request.put(
+			`/api/projects/${projectSlug}/docs/doc-${String(i).padStart(2, '0')}.md`,
+			{
+				headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+				data: { content: `Doc ${i}` },
+			},
+		);
+		expect(res.ok()).toBe(true);
+	}
+
+	await page.goto(`/projects/${projectSlug}/documents`);
+	await waitForPageLoad(page);
+
+	const searchInput = page.getByRole('searchbox', { name: 'Search documents' });
+	await expect(searchInput).toBeVisible();
+	await expect(page.getByText('doc-00.md')).toBeVisible();
+
+	const before = await searchInput.boundingBox();
+	expect(before).not.toBeNull();
+
+	// Scroll the last doc into view — with 40 rows this must scroll the list's
+	// own overflow-y-auto container.
+	await page.getByText(`doc-${count - 1}.md`).scrollIntoViewIfNeeded();
+	await expect(page.getByText(`doc-${count - 1}.md`)).toBeVisible();
+
+	// The search header did not move: it lives above the list's scroller.
+	const after = await searchInput.boundingBox();
+	expect(after).not.toBeNull();
+	if (before && after) {
+		expect(Math.abs(after.y - before.y)).toBeLessThanOrEqual(1);
 	}
 });


### PR DESCRIPTION
## What

Reworks the top of the documents side menu:

- The full-width **New document** button is replaced by a **search input** that filters the document list by filename as you type (with a "No matching documents" empty state), plus an icon-only **+** button to its right that opens the new-document form (same `aria-label="New document"` accessible name as before).
- The header row is now **fixed in place while the menu scrolls**: on desktop the sticky sidebar column becomes a flex stack where only the list below the header gets its own scroller; on mobile the header sticks to the top of the page scroller with a matching background so rows pass cleanly underneath.

## Tests

- New component test: typing in the search box narrows the list, a non-matching query shows the empty-filter message, and clearing restores all documents (`packages/web/test/project-documents.test.tsx`).
- New Playwright test (real-CSS-layout assertion): with 40 seeded docs the list overflows its own scroller, and scrolling the last entry into view leaves the search header's bounding box unmoved (`test/browser/docs-sidebar-sticky.spec.ts`).
- Existing sidebar-sticky, content-fit, and actions-sticky browser specs plus the full web component suite (946 tests) pass.

## Docs

- `docs/concepts/documents-and-memory.md` now mentions the search box and + button in the Project documents section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHQ6W58MBoXWhYUWXCuC1C

---
_Generated by [Claude Code](https://claude.ai/code/session_01SHQ6W58MBoXWhYUWXCuC1C)_