### PR TITLE
feat(web): add Tasks root breadcrumb on task detail page

### DIFF
--- a/packages/web/src/components/task-detail/task-header.tsx
+++ b/packages/web/src/components/task-detail/task-header.tsx
@@ -33,10 +33,11 @@ interface TaskHeaderProps {
  */
 export function TaskHeader({ task, projectId, taskId, taskProjectSlug }: TaskHeaderProps) {
 	// Ancestors come back root-first, excluding the current task, so the
-	// breadcrumb reads `root → … → parent → current`. Sub-tasks are capped at two
-	// levels deep, so at most two links precede the current identifier. They share
-	// the current task's project (sub-tasks inherit the parent's project), so the
-	// current task's slug is the right link target.
+	// breadcrumb reads `Tasks → root → … → parent → current`. Sub-tasks are
+	// capped at two levels deep, so at most two ancestor links precede the
+	// current identifier. They share the current task's project (sub-tasks
+	// inherit the parent's project), so the current task's slug is the right
+	// link target — for the task-list crumb too.
 	const { data: ancestors } = useTaskAncestors(projectId, taskId);
 	return (
 		<>
@@ -45,6 +46,17 @@ export function TaskHeader({ task, projectId, taskId, taskProjectSlug }: TaskHea
 				className="mb-1 flex flex-wrap items-center gap-x-1 text-[13px] font-mono text-text-2"
 				data-testid="task-breadcrumb"
 			>
+				<span className="flex items-center gap-x-1">
+					<Link
+						to="/projects/$projectId/tasks"
+						params={{ projectId: taskProjectSlug }}
+						className="hover:text-text-1 hover:underline transition-colors"
+						data-testid="task-breadcrumb-tasks"
+					>
+						Tasks
+					</Link>
+					<ChevronRight className="w-3 h-3 shrink-0 text-text-3" />
+				</span>
 				{ancestors?.map((ancestor) => (
 					<span key={ancestor.id} className="flex items-center gap-x-1">
 						<Link

--- a/packages/web/test/project-documents.test.tsx
+++ b/packages/web/test/project-documents.test.tsx
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest';
-import { renderApp } from './helpers/render';
+import { getTestContext, renderApp } from './helpers/render';
 import { type SeededWorkspace, seedProject, seedWorkspace } from './helpers/seed';
 
 function uniqueName(base: string): string {

--- a/packages/web/test/task-breadcrumb.test.tsx
+++ b/packages/web/test/task-breadcrumb.test.tsx
@@ -43,6 +43,11 @@ test('sub-task header shows a breadcrumb link to its parent and navigates there'
 	const breadcrumb = await findByTestId('task-breadcrumb');
 	expect(breadcrumb.textContent).toContain(seeded.childIdentifier);
 
+	// ...starts with a "Tasks" link back to the project's task list...
+	const tasksLink = await findByTestId('task-breadcrumb-tasks');
+	expect(tasksLink.textContent).toBe('Tasks');
+	expect(tasksLink.getAttribute('href')).toContain(`/projects/${seeded.projectSlug}/tasks`);
+
 	// ...and is preceded by a link to the parent.
 	const parentLink = await findByTestId('task-breadcrumb-ancestor');
 	expect(parentLink.textContent).toBe(seeded.parentIdentifier);
@@ -55,9 +60,9 @@ test('sub-task header shows a breadcrumb link to its parent and navigates there'
 	);
 });
 
-test('top-level task header shows only its identifier with no ancestor links', async () => {
+test('top-level task header shows a Tasks crumb and its identifier with no ancestor links', async () => {
 	const seeded = { projectSlug: '', taskPath: '', identifier: '' };
-	const { findByTestId, queryByTestId, router } = await renderApp({
+	const { findByTestId, queryByTestId, router, user } = await renderApp({
 		initialPath: '/',
 		seed: async () => {
 			const ws = await seedWorkspace();
@@ -76,6 +81,14 @@ test('top-level task header shows only its identifier with no ancestor links', a
 
 	const breadcrumb = await findByTestId('task-breadcrumb');
 	expect(breadcrumb.textContent).toContain(seeded.identifier);
-	// No parent → the breadcrumb is just the current identifier, no ancestor crumb.
+	// No parent → no ancestor crumb, but the Tasks list crumb is always there.
 	expect(queryByTestId('task-breadcrumb-ancestor')).toBeNull();
+	const tasksLink = await findByTestId('task-breadcrumb-tasks');
+	expect(tasksLink.getAttribute('href')).toContain(`/projects/${seeded.projectSlug}/tasks`);
+
+	// Clicking it navigates back to the task list.
+	await user.click(tasksLink);
+	await waitFor(() =>
+		expect(router.state.location.pathname).toBe(`/projects/${seeded.projectSlug}/tasks`),
+	);
 });


### PR DESCRIPTION
## Summary

The task-detail breadcrumb started at the root ancestor task (`HM-51 > HM-80`), so on mobile — where the sidebar is hidden behind the hamburger drawer — there was no one-tap way back to the project's task list. This prepends a **Tasks** crumb linking to `/projects/:projectId/tasks` as the first breadcrumb item, mirroring the goal detail page's existing "Progress" root crumb pattern. The crumb renders at all breakpoints, using the same styling and chevron separator as the ancestor crumbs.

Also fixes a pre-existing typecheck error in `packages/web/test/project-documents.test.tsx` (missing `getTestContext` import), which was failing `bun run typecheck` for the whole web package.

## Changes

- `packages/web/src/components/task-detail/task-header.tsx` — prepend a "Tasks" link (targeting the task's own project slug, consistent with the ancestor links) followed by a chevron, before the ancestor crumbs.
- `packages/web/test/task-breadcrumb.test.tsx` — both existing breadcrumb tests now also assert the Tasks crumb's presence and href; the top-level-task test clicks it and verifies navigation back to the task list.
- `packages/web/test/project-documents.test.tsx` — add the missing `getTestContext` import.

## Testing

- `bun run test --package web` — all 158 files / 950 tests pass.
- `tsc --noEmit` in `packages/web` — clean (was failing before the import fix).
- `bunx biome check` on the changed files — clean.
- Component tier is the right level per the repo's decision tree: the breadcrumb isn't viewport-conditional or layout-dependent, so no new Playwright spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXyPmm9Ekh5MdwJscSEj3w

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXyPmm9Ekh5MdwJscSEj3w)_