### PR TITLE
fix(web): align comment-card action rows and fix the connect-required Connectors link

### DIFF
--- a/packages/web/src/components/comment-renderers/action-comment.tsx
+++ b/packages/web/src/components/comment-renderers/action-comment.tsx
@@ -50,7 +50,7 @@ export function ActionComment({ comment, projectId }: Props) {
 					this ticket will resume.
 				</span>
 			</div>
-			<div>
+			<div className="pl-6">
 				<Link to="/projects/$projectId/git" params={{ projectId }}>
 					<Button size="sm">Open Git settings</Button>
 				</Link>

--- a/packages/web/src/components/comment-renderers/asset-deletion-request-comment.tsx
+++ b/packages/web/src/components/comment-renderers/asset-deletion-request-comment.tsx
@@ -108,8 +108,8 @@ export function AssetDeletionRequestComment({ comment, projectId, taskId }: Prop
 					)}
 				</div>
 			</div>
-			{error && <p className="text-xs text-danger-soft-fg">{error}</p>}
-			<div className="flex items-center gap-2">
+			{error && <p className="pl-6 text-xs text-danger-soft-fg">{error}</p>}
+			<div className="flex items-center gap-2 pl-6">
 				<Button
 					size="sm"
 					variant="destructive"

--- a/packages/web/src/components/comment-renderers/connect-required-comment.tsx
+++ b/packages/web/src/components/comment-renderers/connect-required-comment.tsx
@@ -128,7 +128,7 @@ export function ConnectRequiredComment({ comment, projectId }: Props) {
 					)}
 				</div>
 			</div>
-			{error && <p className="text-xs text-danger-soft-fg">{error}</p>}
+			{error && <p className="pl-6 text-xs text-danger-soft-fg">{error}</p>}
 			{usesDeviceFlow && deviceOpen && (
 				<ConnectorDeviceFlowDialog
 					open={deviceOpen}
@@ -141,7 +141,7 @@ export function ConnectRequiredComment({ comment, projectId }: Props) {
 					}
 				/>
 			)}
-			<div className="flex items-center gap-2">
+			<div className="flex items-center gap-2 pl-6">
 				<Button
 					size="sm"
 					onClick={openConnect}

--- a/packages/web/src/components/comment-renderers/connect-required-comment.tsx
+++ b/packages/web/src/components/comment-renderers/connect-required-comment.tsx
@@ -49,8 +49,9 @@ export function ConnectRequiredComment({ comment, projectId }: Props) {
 
 	const connector = connectorQuery.data;
 	const status = connector ? connectorStatus(connector) : 'pending';
-	const connectorsUrl = `/teams/${projectId}/connectors`;
-	const focusedConnectorUrl = `${connectorsUrl}?focus=${connector_id}#${connector_id}`;
+	// Connectors are global resources (register_connector creates instance-level
+	// rows), so the manage link goes to the global settings page.
+	const focusedConnectorUrl = `/settings/connectors?focus=${connector_id}#${connector_id}`;
 
 	// Providers whose AS can't do DCR (declared via `deviceAuth`) authorize
 	// through the device flow; everything else uses the redirect popup.

--- a/packages/web/src/components/comment-renderers/hire-proposal-comment.tsx
+++ b/packages/web/src/components/comment-renderers/hire-proposal-comment.tsx
@@ -84,7 +84,7 @@ export function HireProposalComment({ comment, projectId }: Props) {
 				</div>
 			</div>
 			{projectId && approvalId && (
-				<div>
+				<div className="pl-6">
 					<Link
 						to="/projects/$projectId/agents/hire"
 						params={{ projectId }}

--- a/packages/web/src/routes/settings/connectors.tsx
+++ b/packages/web/src/routes/settings/connectors.tsx
@@ -1,7 +1,7 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
 import { Plus, Trash2 } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Badge } from '../../components/ui/badge';
 import { Button } from '../../components/ui/button';
 import { InfoTooltip } from '../../components/ui/info-tooltip';
@@ -23,10 +23,17 @@ function openAuthPopup(authUrl: string): string | null {
 
 function InstanceConnectorsPage() {
 	const { data: me } = useMe();
+	const { focus } = Route.useSearch();
 	const { data: connectors = [] } = useInstanceConnectors();
 	const createConnector = useCreateInstanceConnector();
 	const authStart = useInstanceAuthStart();
 	const queryClient = useQueryClient();
+
+	// Ref callback fires when the focused row mounts (which can happen after the
+	// initial render once the connectors query resolves). Scrolls into view then.
+	const focusRef = useCallback((el: HTMLDivElement | null) => {
+		if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+	}, []);
 
 	const [showForm, setShowForm] = useState(false);
 	const [name, setName] = useState('');
@@ -170,7 +177,12 @@ function InstanceConnectorsPage() {
 				) : (
 					<div className="flex flex-col gap-1">
 						{connectors.map((c) => (
-							<InstanceConnectorRow key={c.id} connector={c} />
+							<InstanceConnectorRow
+								key={c.id}
+								connector={c}
+								focused={c.id === focus}
+								focusRef={c.id === focus ? focusRef : undefined}
+							/>
 						))}
 					</div>
 				)}
@@ -180,7 +192,13 @@ function InstanceConnectorsPage() {
 	return <div className="max-w-[900px]">{content}</div>;
 }
 
-function InstanceConnectorRow({ connector }: { connector: McpConnection }) {
+interface InstanceConnectorRowProps {
+	connector: McpConnection;
+	focused: boolean;
+	focusRef?: (el: HTMLDivElement | null) => void;
+}
+
+function InstanceConnectorRow({ connector, focused, focusRef }: InstanceConnectorRowProps) {
 	const deleteConnector = useDeleteInstanceConnector();
 	const authStart = useInstanceAuthStart();
 	const [rowError, setRowError] = useState<string | null>(null);
@@ -210,7 +228,11 @@ function InstanceConnectorRow({ connector }: { connector: McpConnection }) {
 
 	return (
 		<div
-			className="rounded-md border border-border bg-surface px-3 py-2 text-[13px]"
+			ref={focusRef}
+			id={connector.id}
+			className={`rounded-md border px-3 py-2 text-[13px] transition-colors ${
+				focused ? 'border-info bg-info-soft' : 'border-border bg-surface'
+			}`}
 			data-testid="instance-connector-row"
 			data-connector-id={connector.id}
 			data-status={status}
@@ -261,6 +283,13 @@ function InstanceConnectorRow({ connector }: { connector: McpConnection }) {
 	);
 }
 
+interface ConnectorsSearch {
+	focus?: string;
+}
+
 export const Route = createFileRoute('/settings/connectors')({
+	validateSearch: (search: Record<string, unknown>): ConnectorsSearch => ({
+		focus: typeof search.focus === 'string' ? search.focus : undefined,
+	}),
 	component: InstanceConnectorsPage,
 });

--- a/packages/web/test/connect-required-comment.test.tsx
+++ b/packages/web/test/connect-required-comment.test.tsx
@@ -131,8 +131,9 @@ test('pending connector renders the connect prompt with provider code and links'
 	expect(connectBtn.textContent).toContain('Connect');
 	expect((connectBtn as HTMLButtonElement).disabled).toBe(false);
 
+	// Connectors are global, so the manage link targets the global settings page.
 	const link = await findByTestId('connect-required-link');
-	expect(link.getAttribute('href')).toContain('/connectors?focus=');
+	expect(link.getAttribute('href')).toContain('/settings/connectors?focus=');
 });
 
 test('failed connector shows the failure label plus the auth_error detail', async () => {
@@ -195,7 +196,7 @@ test('active connector renders the success state as a manage link', async () => 
 	const active = await findByTestId('connect-required-active');
 	expect(active.textContent).toContain('DatoCMS connected');
 	expect(active.textContent).toContain('Available to every agent run');
-	expect(active.getAttribute('href')).toContain('/connectors?focus=');
+	expect(active.getAttribute('href')).toContain('/settings/connectors?focus=');
 });
 
 test('clicking Connect on a redirect (non-device) connector opens an OAuth popup with the auth_url', async () => {

--- a/packages/web/test/instance-connectors.test.tsx
+++ b/packages/web/test/instance-connectors.test.tsx
@@ -211,6 +211,57 @@ test('refetches the list when the OAuth popup reports success', async () => {
 	await findByText('Connected');
 });
 
+test('?focus=<id> highlights the connector row and scrolls it into view', async () => {
+	// happy-dom's scrollIntoView is a no-op with no layout, so assert the wiring:
+	// the focused row is the element the scroll fires on.
+	const scrolled: Element[] = [];
+	const spy = vi.spyOn(Element.prototype, 'scrollIntoView').mockImplementation(function (
+		this: Element,
+	) {
+		scrolled.push(this);
+	});
+	try {
+		const { findByText, ctx, router } = await renderApp({
+			initialPath: '/settings/connectors',
+			seed: async (c) => {
+				await seedInstanceConnector(c, {
+					name: 'other-conn',
+					kind: 'saas',
+					config: { url: 'https://other.example/mcp' },
+				});
+				await seedInstanceConnector(c, {
+					name: 'focus-conn',
+					kind: 'saas',
+					config: { url: 'https://focus.example/mcp' },
+				});
+			},
+		});
+		await findByText('focus-conn');
+		const r = await ctx.db.query<{ id: string }>(
+			`SELECT id FROM mcp_connections WHERE name = 'focus-conn'`,
+		);
+		const focusId = r.rows[0].id;
+
+		// The connect_required comment card links here with ?focus=<connector_id>.
+		await router.navigate({ to: '/settings/connectors', search: { focus: focusId } });
+
+		await waitFor(() => {
+			const row = document.querySelector(`[data-connector-id="${focusId}"]`);
+			expect(row).toBeTruthy();
+			expect(row?.className).toContain('border-info');
+		});
+		expect(scrolled.some((el) => el.getAttribute('data-connector-id') === focusId)).toBe(true);
+		// The sibling row is not highlighted.
+		const other = Array.from(
+			document.querySelectorAll('[data-testid="instance-connector-row"]'),
+		).find((el) => el.getAttribute('data-connector-id') !== focusId);
+		expect(other).toBeTruthy();
+		expect(other?.className).not.toContain('border-info');
+	} finally {
+		spy.mockRestore();
+	}
+});
+
 test('settings page sidebar links to connectors', async () => {
 	const { findByRole, getAllByRole, user, router } = await renderApp({ initialPath: '/settings' });
 


### PR DESCRIPTION
## What

Two fixes to the task-thread comment cards, prompted by the `connect_required` card:

### 1. Action rows now left-align with the text above

The icon-led cards render a `w-4` icon + `gap-2` header, so their text starts 24px in — but the action buttons below sat flush with the card edge. The action rows (and the transient error line, where one exists) are now indented `pl-6` (24px = 16px icon + 8px gap) so they line up with the text column:

- **connect-required** — Connect button + "Open in Connectors" link (the reported card)
- **asset-deletion-request** — Approve/Deny buttons
- **hire-proposal** — Edit & review button
- **repo-setup action** — Open Git settings button

The credential-request card is untouched: its full-width form already sits flush-left, so its buttons align with their own preceding content.

### 2. "Open in Connectors" now points at the global Connectors page

The card built `/teams/<project>/connectors?focus=…` — a route that doesn't exist, so both the pending card's "Open in Connectors" link and the connected card's manage link were dead. Connectors registered via `register_connector` are **global** (instance-level) resources, so the links now target `/settings/connectors?focus=<connector_id>` — the same URL shape the instance auth-start flow already emits as `returnTo` (`routes/oauth.ts`).

To make that deep link land properly, the global Connectors page (`/settings/connectors`) now honours `?focus=`: it validates the search param, highlights the focused row (`border-info bg-info-soft`), and scrolls it into view — mirroring the project connectors page's existing behaviour.

## Tests

- Tightened `connect-required-comment.test.tsx` href assertions to pin `/settings/connectors?focus=` (pending link + connected-state link).
- New test in `instance-connectors.test.tsx`: navigating with `?focus=<id>` highlights that row, leaves siblings unhighlighted, and fires `scrollIntoView` on the focused row.
- Component tests for all touched renderers pass; typecheck and lint clean. Alignment math verified against the compiled Tailwind output (`--spacing: .25rem`, so `pl-6` = `w-4` + `gap-2` exactly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHuiBk8vCjirgcFzEYo4Lh

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHuiBk8vCjirgcFzEYo4Lh)_