### PR TITLE
docs: make HTTPS the baseline for all deployment and hosting instructions

### DIFF
--- a/docs/deployment/cloud.md
+++ b/docs/deployment/cloud.md
@@ -26,7 +26,9 @@ DigitalOcean, Hetzner, Fly, Linode, or an EC2 instance.
    hezo --data-dir /var/lib/hezo
    ```
 
-3. **Unlock it from the browser.** After boot Hezo starts **locked** — open its gate
+3. **Serve it over HTTPS** with a reverse proxy — required, not a nice-to-have; see
+   [below](#serve-it-over-https).
+4. **Unlock it from the browser.** After boot Hezo starts **locked** — open its gate
    and enter your twelve-word master key to unlock the instance. This is by design:
    the master key is kept in memory only and is never stored on the server, so a stolen
    disk image can't decrypt your vault. If you need to unlock a single startup without
@@ -37,7 +39,7 @@ DigitalOcean, Hetzner, Fly, Linode, or an EC2 instance.
    HEZO_MASTER_KEY="your twelve word master key phrase here" hezo --data-dir /var/lib/hezo
    ```
 
-4. **Set the public URL** so account sign-ins redirect back correctly:
+5. **Set the public URL** so account sign-ins redirect back correctly:
 
    ```sh
    hezo --web-url https://hezo.example.com
@@ -45,12 +47,53 @@ DigitalOcean, Hetzner, Fly, Linode, or an EC2 instance.
 
 See the [Configuration reference](/docs/deployment/configuration) for every option.
 
-## Terminate TLS with a reverse proxy
+## Serve it over HTTPS
 
-Hezo serves plain HTTP. For a public deployment, put a reverse proxy (Caddy, nginx, or
-Traefik) in front of it to handle HTTPS and your domain, forwarding to the Hezo port
-(3100 by default). Make sure the proxy is configured to **pass through WebSocket
-upgrades**, since the web app streams agent activity in real time.
+Hezo's own process serves plain HTTP, so every deployment puts a TLS-terminating
+reverse proxy (Caddy, nginx, or Traefik) in front, forwarding to the Hezo port (3100 by
+default). Treat HTTPS as **essential**, whether the address is public or on a private
+network:
+
+- **OAuth-connected MCP servers require it.** Connecting a SaaS MCP server runs an
+  OAuth flow whose callback lands on your instance's URL, and providers and browsers
+  only accept HTTPS (or `localhost`) callbacks — over plain HTTP the connect flow
+  fails. See [Connecting MCP servers](/docs/mcp/connecting-mcp-servers).
+- **The phone experience requires it.** Installing Hezo as a home-screen app needs a
+  secure context.
+- **Everything sensitive rides on every request** — your admin password, agent output,
+  task content. TLS is the baseline.
+
+Configure the proxy to do all three of:
+
+- **Pass through WebSocket upgrades** — the web app streams agent activity in real
+  time.
+- **Preserve the `Host` header** of the original request.
+- **Send `X-Forwarded-Proto`** — Hezo builds absolute URLs (such as the OAuth callback
+  an MCP connection registers with its provider) from the forwarded scheme and host;
+  without this header it falls back to `http://` and OAuth connects fail even though
+  you're browsing over HTTPS.
+
+With Caddy all three are the default — a complete Caddyfile is:
+
+```
+hezo.example.com {
+	reverse_proxy localhost:3100
+}
+```
+
+For nginx, set the headers explicitly on the proxied location:
+
+```nginx
+proxy_set_header Host $host;
+proxy_set_header X-Forwarded-Proto $scheme;
+proxy_set_header Upgrade $http_upgrade;
+proxy_set_header Connection "upgrade";
+```
+
+On a private network (a VPN or mesh) where a public certificate authority can't see
+your hostname, use a private CA or a DNS-01 certificate — see
+[Secure remote access](/docs/deployment/secure-remote-access) for the options per
+setup.
 
 ## Don't expose it to the open internet unguarded
 

--- a/docs/deployment/one-click.md
+++ b/docs/deployment/one-click.md
@@ -71,8 +71,10 @@ read them before you paste if you'd like to see exactly what runs.
 
 ## How the HTTPS URL works
 
-Your browser needs HTTPS (Hezo streams agent activity over a secure WebSocket), but a
-fresh server has a public IP and usually no domain. To bridge that, the deploy uses
+HTTPS is essential for a working instance — OAuth-connected MCP servers only complete
+their connect flow on an HTTPS address, installing Hezo on your phone needs a secure
+context, and the web app streams agent activity over a secure WebSocket. But a fresh
+server has a public IP and usually no domain. To bridge that, the deploy uses
 **[sslip.io](https://sslip.io)** — a DNS service where `<ip>.sslip.io` always resolves
 to `<ip>`. So `https://203.0.113.10.sslip.io` points straight at your server, and Caddy
 automatically obtains a real Let's Encrypt certificate for it. No domain to buy, no DNS

--- a/docs/deployment/secure-remote-access.md
+++ b/docs/deployment/secure-remote-access.md
@@ -7,25 +7,62 @@ section: Deployment
 # Secure remote access
 
 A cloud-hosted Hezo can run agents, spend money, and reach your connected accounts — so
-how you reach it matters as much as where you run it. Hezo serves plain HTTP and has no
-built-in VPN, so you put a secure channel **around** it. The goal is simple: **don't
-expose the Hezo port to the public internet.**
+how you reach it matters as much as where you run it. Two rules cover it:
 
-Here are the common ways to do that, roughly easiest first.
+1. **Don't expose the Hezo port to the public internet.** Keep it on a private network
+   or behind an authenticated tunnel.
+2. **Reach it over HTTPS — even on a private network.** The one address that's fine
+   over plain HTTP is `http://localhost` (loopback on your own machine, for example
+   through an SSH tunnel).
+
+Hezo's own process serves plain HTTP and has no built-in VPN, so both properties come
+from what you put around it: a private network or tunnel for reachability, and a
+TLS-terminating reverse proxy for HTTPS (see
+[Serve it over HTTPS](/docs/deployment/cloud#serve-it-over-https) for the proxy setup).
+
+## Why HTTPS is essential, even on a VPN
+
+- **OAuth-connected MCP servers won't finish connecting without it.** Connecting a SaaS
+  MCP server ([Connecting MCP servers](/docs/mcp/connecting-mcp-servers)) runs an OAuth
+  flow that redirects your browser back to your instance's callback URL. Providers and
+  browsers only accept **HTTPS** callbacks (plus `localhost`), so on a plain-HTTP
+  private address the consent popup's final **Allow** step is rejected or silently
+  blocked. The instance doesn't need to be publicly reachable — the redirect happens in
+  your browser — it just needs an HTTPS address.
+- **Your phone needs a secure context.** Installing Hezo as an app (below) and other
+  browser capabilities only work over HTTPS or `localhost`.
+- **Defense in depth.** Your admin password, agent output, and everything you paste
+  into a task ride on every request; TLS keeps them sealed even if another device on
+  the network is compromised.
+
+Here are the common ways to set up access, roughly easiest first.
 
 ## Private mesh VPN — Tailscale / WireGuard (recommended)
 
 Put the server and your devices on a private network and reach Hezo as if it were
 local. With **Tailscale** (or plain **WireGuard**), the Hezo port is never published to
 the internet — only devices on your mesh can connect. This is the simplest secure setup
-and the one we recommend for most people. You can browse to the server's private
-address, and your phone joins the same way for on-the-go oversight.
+and the one we recommend for most people, and your phone joins the same way for
+on-the-go oversight.
+
+Mesh hostnames aren't public, so add HTTPS one of these ways:
+
+- **Tailscale:** `tailscale cert` issues a real certificate for your machine's
+  `*.ts.net` name, or `tailscale serve` puts an HTTPS proxy in front of the Hezo port
+  in one command.
+- **Any other mesh (WireGuard, NordVPN Meshnet, …):** run a reverse proxy with a
+  private CA — Caddy's `tls internal` is the least-effort option — and trust its root
+  certificate on the devices you browse from. Or, if you own a domain, point a DNS
+  record at the private address and get a Let's Encrypt certificate via the **DNS-01**
+  challenge: a browser-trusted certificate with no public exposure and no CA-trust
+  step on any device.
 
 ## Cloudflare Tunnel
 
 A **Cloudflare Tunnel** connects your server out to Cloudflare, so you get an HTTPS
-hostname **without opening any inbound ports**. Pair it with an access policy
-(Cloudflare Access) to require sign-in before anyone reaches Hezo.
+hostname **without opening any inbound ports** — the certificate comes with the tunnel,
+nothing extra to set up. Pair it with an access policy (Cloudflare Access) to require
+sign-in before anyone reaches Hezo.
 
 ## SSH tunnel
 
@@ -38,7 +75,9 @@ ssh -L 3100:localhost:3100 user@your-server
 ```
 
 Then open `http://localhost:3100` locally. Nothing is exposed publicly; the tunnel
-lives only as long as the SSH session.
+lives only as long as the SSH session. This is the one setup where plain HTTP is fine:
+browsers and OAuth providers treat loopback as a secure context, so everything —
+including OAuth-connected MCP servers — works through the tunnel.
 
 ## Public domain + reverse proxy + auth
 
@@ -64,12 +103,13 @@ unlock; keeping it in memory only is what protects the vault if the host is comp
 Hezo is a Progressive Web App, so you can add it to your home screen and run it
 full-screen like a native app. Open Hezo in your mobile browser and it offers an
 **Install** prompt; on iPhone/iPad, use Safari's **Share → Add to Home Screen**. This
-needs a secure context — an **HTTPS** URL (a Cloudflare Tunnel or reverse proxy) or
-`localhost` (an SSH tunnel) — so the install option won't appear over a plain‑HTTP private
-address.
+needs a secure context — your instance's **HTTPS** URL, or `localhost` via an SSH
+tunnel — one more reason the HTTPS setup above isn't optional. If you used a private
+CA, trust its root certificate on the phone too.
 
 ## Rule of thumb
 
-Prefer a private network (Tailscale/WireGuard) or an authenticated tunnel. Treat a
-public, internet-facing Hezo as something that always needs both TLS and an auth layer
-in front of it.
+Prefer a private network (Tailscale/WireGuard) or an authenticated tunnel, and serve
+Hezo **over HTTPS either way** — OAuth-connected MCP servers and the phone app depend
+on it. Treat a public, internet-facing Hezo as something that always needs both TLS
+and an auth layer in front of it.

--- a/docs/deployment/self-hosting.md
+++ b/docs/deployment/self-hosting.md
@@ -59,8 +59,8 @@ sudo mkdir -p /var/lib/hezo            # a stable data directory
 ```
 
 **2. Put non-secret settings in an env file.** Create an env file for the
-service — the data directory and, if the instance is reached via a public URL,
-its address:
+service — the data directory and, if the instance is reached via a URL beyond
+`localhost`, its HTTPS address:
 
 ```sh
 sudo install -d -m 700 /etc/hezo
@@ -70,7 +70,7 @@ sudo install -m 600 /dev/null /etc/hezo/hezo.env
 ```sh
 # /etc/hezo/hezo.env
 HEZO_DATA_DIR=/var/lib/hezo
-# HEZO_WEB_URL=https://hezo.example.com   # only if reached via a public URL
+# HEZO_WEB_URL=https://hezo.example.com   # the HTTPS URL it's reached at (omit for localhost-only use)
 ```
 
 > **Never put your master key in this file** (or anywhere else on the server).
@@ -138,12 +138,29 @@ ownership of the bind-mounted workspace and per-run config. A custom
 user (root for most images), which also works; include a non-root user named `node`
 if you want agent-created files owned by a non-root uid on the host.
 
+## Serve it over HTTPS
+
+Hezo's process itself serves plain HTTP, so for anything beyond `localhost` use — on a
+private network or VPN just as much as on a public domain — put a TLS-terminating
+reverse proxy in front and browse the instance through it. HTTPS is what makes
+OAuth-connected MCP servers connectable (providers and browsers only accept HTTPS or
+`localhost` callback URLs), lets Hezo install as an app on your phone, and keeps your
+admin password and task content sealed in transit. The proxy must pass WebSocket
+upgrades and forward the `Host` and `X-Forwarded-Proto` headers — see
+[Serve it over HTTPS](/docs/deployment/cloud#serve-it-over-https) for a working
+config, and [Secure remote access](/docs/deployment/secure-remote-access) for
+certificate options on private networks.
+
 ## Networking & firewall
 
 - **3100** — the Hezo server and web app (configurable with `--port`).
 
-That is the only port **people** need to reach — Hezo serves the web app and brokers
-account sign-ins (such as GitHub) itself, so there is no separate gateway service or port.
+That is the only port the **reverse proxy** (and, through it, people) needs to reach —
+Hezo serves the web app and brokers account sign-ins (such as GitHub) itself, so there
+is no separate gateway service or port. With the proxy on the same host, 3100 doesn't
+need to be reachable from outside the host at all — browsers connect to the proxy's
+HTTPS port instead (agent containers still reach 3100 over the Docker bridge; see
+below).
 
 ### Container → host connectivity (native-Linux Docker)
 

--- a/docs/mcp/connecting-mcp-servers.md
+++ b/docs/mcp/connecting-mcp-servers.md
@@ -23,6 +23,24 @@ proxy](/docs/security/secret-protection) at request time and the real value neve
 in the connection config. For servers that authenticate with OAuth, connect the account
 once and Hezo attaches and refreshes the token for you.
 
+### OAuth connections need an HTTPS address
+
+For servers that authenticate with OAuth, completing the connection sends your browser
+from the provider's consent page back to your instance's callback URL. Providers and
+browsers only accept **HTTPS** callback URLs (with `http://localhost` as the one
+exception), so your instance must be reached over HTTPS for the final **Allow** step to
+work — on a private network or VPN too, where a plain-HTTP address makes the consent
+popup fail with a blocked or rejected redirect. Your instance does **not** need to be
+publicly reachable: the redirect happens in your browser, so a private HTTPS address
+works fine. See [Serve it over HTTPS](/docs/deployment/cloud#serve-it-over-https) and
+[Secure remote access](/docs/deployment/secure-remote-access) for setting that up.
+
+If your instance's address changes (for example you move from plain HTTP to HTTPS),
+remove the connector and add it again before reconnecting: the OAuth client Hezo
+registered with the provider is tied to the address it was created on, and a stale
+registration is rejected with a "redirect_uri does not match" error. Re-adding the
+connector registers a fresh client on the current address.
+
 ## Local (stdio) servers
 
 Hezo also supports **local, process-based** MCP servers that run inside the project

--- a/docs/mcp/hezo-mcp-server.md
+++ b/docs/mcp/hezo-mcp-server.md
@@ -17,9 +17,9 @@ tools into.
 ## Connection details
 
 - **Base URL:** your instance's address. Running locally with default settings that's
-  `http://localhost:3100`; a deployed instance is wherever it's hosted — its own domain
-  or `host:port`, not necessarily port 3100. (The port is set by `--port` / `HEZO_PORT`,
-  default `3100`.)
+  `http://localhost:3100`; a deployed instance is its **HTTPS** URL — its own domain
+  behind the TLS reverse proxy, not necessarily port 3100. (The port Hezo itself listens
+  on is set by `--port` / `HEZO_PORT`, default `3100`.)
 - **Endpoint:** `POST <base-url>/mcp`
 - **Transport:** Streamable HTTP
 - **Authentication:** an `Authorization: Bearer <token>` header, where the token is a
@@ -89,10 +89,11 @@ it at the `/mcp` endpoint and pass your key in the `Authorization` header:
 }
 ```
 
-If your Hezo runs on a remote server, replace `http://localhost:3100` with its base URL
-— a remote instance may be on a different host and port, or behind a domain on 443 — and
-make sure that address is reached over a secure channel, since the API key travels in
-the header. See [Secure remote access](/docs/deployment/secure-remote-access).
+If your Hezo runs on a remote server, replace `http://localhost:3100` with its **HTTPS**
+base URL — a remote instance sits behind a TLS reverse proxy on its own domain (see
+[Serve it over HTTPS](/docs/deployment/cloud#serve-it-over-https)). The API key travels
+in the header, so never call a remote instance over plain HTTP. See
+[Secure remote access](/docs/deployment/secure-remote-access).
 
 ## What you can do with it
 


### PR DESCRIPTION
## Why

Deployment docs framed TLS as a public-deployment nicety, and the recommended private-mesh setup implied browsing Hezo over plain HTTP. That silently breaks **OAuth-connected MCP servers**: the connect flow redirects the browser back to the instance's callback URL, and providers and browsers only accept HTTPS (or `localhost`) callbacks — so on a plain-HTTP private address the consent popup's **Allow** step is rejected or blocked (hit in the field with the Higgsfield connector on a mesh-VPN instance, blocked by the provider's `form-action` CSP). Plain HTTP also blocks the PWA install and sends the admin password and task content in the clear.

All deployment and hosting docs now treat HTTPS as essential — no http-only setup instructions remain; `http://localhost` (loopback/SSH tunnel) is documented as the one legitimate plain-HTTP address.

## What changed

- **`docs/deployment/secure-remote-access.md`** — leads with two rules (keep the port private *and* serve HTTPS); new "Why HTTPS is essential, even on a VPN" section; per-mesh certificate guidance (Tailscale `cert`/`serve`; private CA e.g. Caddy `tls internal`, or a real domain + DNS-01 Let's Encrypt for other meshes); SSH tunnel reframed as the loopback exception; phone-install and rule-of-thumb sections aligned.
- **`docs/deployment/cloud.md`** — "Terminate TLS with a reverse proxy" (public-only framing) replaced by a required **"Serve it over HTTPS"** section: the rationale, the three proxy requirements (WebSocket upgrades, preserve `Host`, send `X-Forwarded-Proto` — Hezo builds the OAuth callback URL from the forwarded scheme/host), working Caddy and nginx snippets, and a pointer for private-network certificates. Added as a numbered step in the deployment shape.
- **`docs/deployment/self-hosting.md`** — new "Serve it over HTTPS" section; networking section now has browsers reach the proxy's HTTPS port rather than the raw Hezo port (containers still reach it over the Docker bridge); env-file `HEZO_WEB_URL` comment updated.
- **`docs/deployment/one-click.md`** — broadened the "HTTPS is needed" rationale beyond the secure WebSocket (MCP connectors, phone install).
- **`docs/mcp/connecting-mcp-servers.md`** — new "OAuth connections need an HTTPS address" section: HTTPS-or-localhost callback requirement, explicit note that public reachability is *not* required (the redirect happens in the browser), and the remove-and-re-add step after changing the instance address (a stale OAuth client registration fails with a `redirect_uri` mismatch).
- **`docs/mcp/hezo-mcp-server.md`** — deployed base URLs are stated as HTTPS behind the TLS proxy.

## Notes

- Docs-only change; the docs bundle (`docs-bundle.json`) is gitignored and regenerates at build time, so the updated pages reach the CEO chat automatically.
- `bun run build:docs` run; `docs-bundle`, `mcp-reference`, and `llms-txt` drift tests pass (10/10). Pre-commit ran `check`, `typecheck`, and the full build, all green.
- Follow-up candidates (not in this PR): fail `auth-start` with a clear error on plain-HTTP non-localhost origins, and auto-refresh the cached OAuth client registration when the instance origin changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VFjqp1RKyyZN2Jcu2YuNk5

---
_Generated by [Claude Code](https://claude.ai/code/session_01VFjqp1RKyyZN2Jcu2YuNk5)_