### PR TITLE
feat(web): standardize in-place add/edit forms behind a shared InPlaceForm panel

### DIFF
--- a/packages/web/src/components/model-pricing-section.tsx
+++ b/packages/web/src/components/model-pricing-section.tsx
@@ -13,6 +13,7 @@ import { Badge } from './ui/badge';
 import { Button } from './ui/button';
 import { type Column, DataTable } from './ui/data-table';
 import { HelpDialog } from './ui/help-dialog';
+import { InPlaceForm } from './ui/in-place-form';
 import { Input } from './ui/input';
 import { Tooltip } from './ui/tooltip';
 
@@ -229,7 +230,7 @@ export function ModelPricingSection() {
 			</div>
 
 			{showForm && (
-				<form onSubmit={handleSubmit} className="flex flex-col gap-2 mb-4">
+				<InPlaceForm title="Add price override" onClose={resetForm} onSubmit={handleSubmit}>
 					<Input
 						placeholder="Model id (e.g. my-custom-model)"
 						value={modelId}
@@ -275,7 +276,7 @@ export function ModelPricingSection() {
 							Cancel
 						</Button>
 					</div>
-				</form>
+				</InPlaceForm>
 			)}
 
 			{!rows.length ? (

--- a/packages/web/src/components/ui/in-place-form.tsx
+++ b/packages/web/src/components/ui/in-place-form.tsx
@@ -1,0 +1,64 @@
+import { X } from 'lucide-react';
+import type { FormEvent, ReactNode } from 'react';
+
+interface InPlaceFormProps {
+	/** Panel heading, e.g. "Add connector" or "Edit credential". */
+	title: string;
+	/** Fired by the top-right close button — hide the panel and reset its state. */
+	onClose: () => void;
+	/** When set, children render inside a <form> wired to this handler. */
+	onSubmit?: (e: FormEvent<HTMLFormElement>) => void;
+	children: ReactNode;
+	/**
+	 * Rendered inside the panel but outside the <form>, for widgets whose own
+	 * buttons must not submit it (e.g. the skill editor's revisions panel).
+	 */
+	footer?: ReactNode;
+	className?: string;
+	'data-testid'?: string;
+}
+
+/**
+ * In-place add/edit panel toggled by a page-header action (the "+ Add" button
+ * pattern on the settings list pages). A filled, rounded card makes the form
+ * stand out from the list it edits, and the always-present top-right close
+ * button gives every one of these forms the same dismissal affordance.
+ * Children are the form fields plus their submit/cancel row.
+ */
+export function InPlaceForm({
+	title,
+	onClose,
+	onSubmit,
+	children,
+	footer,
+	className = '',
+	'data-testid': testId = 'in-place-form',
+}: InPlaceFormProps) {
+	return (
+		<section
+			className={`mb-4 rounded-lg border border-border bg-surface-2 p-3 sm:p-4 ${className}`}
+			data-testid={testId}
+		>
+			<div className="mb-3 flex items-center justify-between gap-2">
+				<h2 className="text-[13px] font-medium text-text-1">{title}</h2>
+				<button
+					type="button"
+					onClick={onClose}
+					aria-label="Close"
+					data-testid="in-place-form-close"
+					className="-m-1 p-1 text-text-3 hover:text-text-1 transition-colors"
+				>
+					<X className="w-4 h-4" />
+				</button>
+			</div>
+			{onSubmit ? (
+				<form onSubmit={onSubmit} className="flex flex-col gap-2">
+					{children}
+				</form>
+			) : (
+				<div className="flex flex-col gap-2">{children}</div>
+			)}
+			{footer}
+		</section>
+	);
+}

--- a/packages/web/src/routes/settings/api-keys.tsx
+++ b/packages/web/src/routes/settings/api-keys.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import { Badge } from '../../components/ui/badge';
 import { Button } from '../../components/ui/button';
 import { type Column, DataTable } from '../../components/ui/data-table';
+import { InPlaceForm } from '../../components/ui/in-place-form';
 import { InfoTooltip } from '../../components/ui/info-tooltip';
 import { Input } from '../../components/ui/input';
 import { Tooltip } from '../../components/ui/tooltip';
@@ -209,18 +210,24 @@ function ApiKeysPage() {
 				)}
 
 				{showForm && (
-					<form onSubmit={handleCreate} className="flex flex-col sm:flex-row gap-2 mb-5">
-						<Input
-							placeholder="Key name"
-							value={name}
-							onChange={(e) => setName(e.target.value)}
-							required
-							className="flex-1"
-						/>
-						<Button type="submit" size="sm" disabled={create.isPending}>
-							Create
-						</Button>
-					</form>
+					<InPlaceForm
+						title="Create API key"
+						onClose={() => setShowForm(false)}
+						onSubmit={handleCreate}
+					>
+						<div className="flex flex-col sm:flex-row gap-2">
+							<Input
+								placeholder="Key name"
+								value={name}
+								onChange={(e) => setName(e.target.value)}
+								required
+								className="flex-1"
+							/>
+							<Button type="submit" size="sm" disabled={create.isPending}>
+								Create
+							</Button>
+						</div>
+					</InPlaceForm>
 				)}
 
 				{pending.length > 0 && (

--- a/packages/web/src/routes/settings/connectors.tsx
+++ b/packages/web/src/routes/settings/connectors.tsx
@@ -4,6 +4,7 @@ import { Plus, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { Badge } from '../../components/ui/badge';
 import { Button } from '../../components/ui/button';
+import { InPlaceForm } from '../../components/ui/in-place-form';
 import { InfoTooltip } from '../../components/ui/info-tooltip';
 import { Input } from '../../components/ui/input';
 import {
@@ -37,9 +38,13 @@ function InstanceConnectorsPage() {
 
 	const [showForm, setShowForm] = useState(false);
 	const [name, setName] = useState('');
-	const [displayName, setDisplayName] = useState('');
 	const [url, setUrl] = useState('');
 	const [error, setError] = useState<string | null>(null);
+
+	function closeForm() {
+		setShowForm(false);
+		setError(null);
+	}
 
 	// Refetch the list when the OAuth popup signals success. The popup posts
 	// {type: 'hezo-oauth-success'} via window.opener.postMessage from the
@@ -68,7 +73,6 @@ function InstanceConnectorsPage() {
 		try {
 			created = await createConnector.mutateAsync({
 				name: name.trim(),
-				display_name: displayName.trim() || undefined,
 				kind: 'saas',
 				config: { url: url.trim() },
 			});
@@ -77,7 +81,6 @@ function InstanceConnectorsPage() {
 			return;
 		}
 		setName('');
-		setDisplayName('');
 		setUrl('');
 		setShowForm(false);
 		// Probe the new connector for OAuth support and pop the authorize window
@@ -109,14 +112,12 @@ function InstanceConnectorsPage() {
 							<h1 className="text-[22px] font-medium">Connectors</h1>
 							<InfoTooltip
 								label="About connectors"
-								content="Remote MCP servers shared with every team's agent runs."
+								content="Servers that advertise OAuth get a connect popup when added; for the rest, authenticate headers with a shared credential placeholder (__HEZO_SECRET_NAME__)."
 								data-testid="connectors-info"
 							/>
 						</div>
 						<p className="text-[13px] text-text-2 mt-1 max-w-[680px]">
-							Remote (SaaS) MCP servers shared with every team's agent runs. Servers that advertise
-							OAuth get a connect popup when added; for the rest, authenticate headers with a shared
-							credential placeholder (<span className="font-mono">__HEZO_SECRET_NAME__</span>).
+							Remote (SaaS) MCP servers shared with every team's agent runs.
 						</p>
 					</div>
 					<Button variant="secondary" size="sm" onClick={() => setShowForm((s) => !s)}>
@@ -125,22 +126,13 @@ function InstanceConnectorsPage() {
 				</div>
 
 				{showForm && (
-					<form onSubmit={handleCreate} className="flex flex-col gap-2 mb-4">
-						<div className="flex flex-col sm:flex-row gap-2">
-							<Input
-								placeholder="Name (e.g. shared-docs)"
-								value={name}
-								onChange={(e) => setName(e.target.value)}
-								required
-								className="flex-1"
-							/>
-							<Input
-								placeholder="Display name (optional)"
-								value={displayName}
-								onChange={(e) => setDisplayName(e.target.value)}
-								className="flex-1"
-							/>
-						</div>
+					<InPlaceForm title="Add connector" onClose={closeForm} onSubmit={handleCreate}>
+						<Input
+							placeholder="Name (e.g. shared-docs)"
+							value={name}
+							onChange={(e) => setName(e.target.value)}
+							required
+						/>
 						<Input
 							placeholder="MCP server URL (e.g. https://mcp.example.com/mcp)"
 							value={url}
@@ -151,19 +143,11 @@ function InstanceConnectorsPage() {
 							<Button type="submit" size="sm" disabled={createConnector.isPending}>
 								Add connector
 							</Button>
-							<Button
-								type="button"
-								variant="secondary"
-								size="sm"
-								onClick={() => {
-									setShowForm(false);
-									setError(null);
-								}}
-							>
+							<Button type="button" variant="secondary" size="sm" onClick={closeForm}>
 								Cancel
 							</Button>
 						</div>
-					</form>
+					</InPlaceForm>
 				)}
 
 				{/* Rendered outside the form: the OAuth kickoff runs after the form

--- a/packages/web/src/routes/settings/credentials.tsx
+++ b/packages/web/src/routes/settings/credentials.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { Badge } from '../../components/ui/badge';
 import { Button } from '../../components/ui/button';
 import { type Column, DataTable } from '../../components/ui/data-table';
+import { InPlaceForm } from '../../components/ui/in-place-form';
 import { InfoTooltip } from '../../components/ui/info-tooltip';
 import { Input } from '../../components/ui/input';
 import { Tooltip } from '../../components/ui/tooltip';
@@ -229,7 +230,11 @@ function InstanceCredentialsPage() {
 				</div>
 
 				{showForm && (
-					<form onSubmit={handleSubmit} className="flex flex-col gap-2 mb-4">
+					<InPlaceForm
+						title={editing ? 'Edit credential' : 'Add credential'}
+						onClose={resetForm}
+						onSubmit={handleSubmit}
+					>
 						<div className="flex flex-col sm:flex-row gap-2">
 							<Input
 								placeholder="Name (e.g. SHARED_API_KEY)"
@@ -288,7 +293,7 @@ function InstanceCredentialsPage() {
 								Cancel
 							</Button>
 						</div>
-					</form>
+					</InPlaceForm>
 				)}
 
 				{!rows.length ? (

--- a/packages/web/src/routes/settings/skills.tsx
+++ b/packages/web/src/routes/settings/skills.tsx
@@ -5,6 +5,7 @@ import { MarkdownEditor } from '../../components/markdown-editor';
 import { RevisionsPanel } from '../../components/revisions-panel';
 import { Badge } from '../../components/ui/badge';
 import { Button } from '../../components/ui/button';
+import { InPlaceForm } from '../../components/ui/in-place-form';
 import { InfoTooltip } from '../../components/ui/info-tooltip';
 import { Input } from '../../components/ui/input';
 import {
@@ -149,10 +150,24 @@ function InstanceSkillsPage() {
 					</div>
 				</div>
 
-				{showSearch && <RegistrySearch />}
+				{showSearch && <RegistrySearch onClose={() => setShowSearch(false)} />}
 
 				{showForm && (
-					<form onSubmit={handleSubmit} className="flex flex-col gap-2 mb-4">
+					<InPlaceForm
+						title={editingSlug ? 'Edit skill' : 'Add skill'}
+						onClose={resetForm}
+						onSubmit={handleSubmit}
+						footer={
+							/* Outside the <form> so the panel's buttons never submit the editor. */
+							editingSlug ? (
+								<RevisionsPanel
+									revisions={revisions}
+									onRestore={(revisionNumber) => restoreSkill.mutateAsync(revisionNumber)}
+									isRestoring={restoreSkill.isPending}
+								/>
+							) : undefined
+						}
+					>
 						<div className="flex flex-col sm:flex-row gap-2">
 							<Input
 								placeholder="Name (e.g. Commit conventions)"
@@ -200,16 +215,7 @@ function InstanceSkillsPage() {
 								Cancel
 							</Button>
 						</div>
-					</form>
-				)}
-
-				{/* Outside the <form> so the panel's buttons never submit the editor. */}
-				{showForm && editingSlug && (
-					<RevisionsPanel
-						revisions={revisions}
-						onRestore={(revisionNumber) => restoreSkill.mutateAsync(revisionNumber)}
-						isRestoring={restoreSkill.isPending}
-					/>
+					</InPlaceForm>
 				)}
 
 				{!skills.length ? (
@@ -271,7 +277,7 @@ function InstanceSkillsPage() {
  * registry API needs a bearer token, so this panel is gated on a configured
  * token (agents don't need it — they use the `npx skills` CLI in the container).
  */
-function RegistrySearch() {
+function RegistrySearch({ onClose }: { onClose: () => void }) {
 	const { data: tokenStatus } = useRegistryTokenStatus();
 	const setToken = useSetRegistryToken();
 	const installSkill = useInstallRegistrySkill();
@@ -294,7 +300,7 @@ function RegistrySearch() {
 	}
 
 	return (
-		<div className="mb-4 rounded-md border border-border bg-surface-2 p-3">
+		<InPlaceForm title="Search skills.sh" onClose={onClose} data-testid="registry-search-panel">
 			{!configured ? (
 				<div className="flex flex-col gap-2">
 					<p className="text-[13px] text-text-2">
@@ -410,7 +416,7 @@ function RegistrySearch() {
 					)}
 				</div>
 			)}
-		</div>
+		</InPlaceForm>
 	);
 }
 

--- a/packages/web/test/api-keys-settings.test.tsx
+++ b/packages/web/test/api-keys-settings.test.tsx
@@ -80,6 +80,19 @@ test('an admin can mint a new key and see it once', async () => {
 	await findByText('minted-key');
 });
 
+test('the create-key form opens in a titled panel and closes via its close button', async () => {
+	const { findByText, getByRole, getByTestId, queryByTestId, user } = await renderApp({
+		initialPath: '/settings/api-keys',
+	});
+
+	await findByText(/full access/i);
+	await user.click(getByRole('button', { name: 'Create' }));
+	expect(getByTestId('in-place-form').textContent).toContain('Create API key');
+
+	await user.click(getByTestId('in-place-form-close'));
+	expect(queryByTestId('in-place-form')).toBeNull();
+});
+
 test('non-superuser sees the managed message instead of the list', async () => {
 	const { findByText } = await renderApp({
 		initialPath: '/settings/api-keys',

--- a/packages/web/test/instance-connectors.test.tsx
+++ b/packages/web/test/instance-connectors.test.tsx
@@ -45,6 +45,35 @@ test('lists seeded instance connectors and creates a new one via the form', asyn
 	}
 });
 
+test('the blurb is a single sentence and the add form is a dismissible standout panel', async () => {
+	const {
+		findByText,
+		getByRole,
+		getByTestId,
+		queryByTestId,
+		queryByText,
+		queryByPlaceholderText,
+		user,
+	} = await renderApp({ initialPath: '/settings/connectors' });
+
+	await findByText('Connectors', { selector: 'h1' });
+	// The blurb is just the first sentence; the OAuth/placeholder detail moved
+	// into the info tooltip (unmounted until hover).
+	await findByText("Remote (SaaS) MCP servers shared with every team's agent runs.");
+	expect(queryByText(/Servers that advertise OAuth/)).toBeNull();
+
+	// The form opens inside the titled panel, without a display-name field —
+	// the connector name doubles as its display label.
+	await user.click(getByRole('button', { name: 'Add' }));
+	const panel = getByTestId('in-place-form');
+	expect(panel.textContent).toContain('Add connector');
+	expect(queryByPlaceholderText('Display name (optional)')).toBeNull();
+
+	// The top-right close button hides the form.
+	await user.click(getByTestId('in-place-form-close'));
+	expect(queryByTestId('in-place-form')).toBeNull();
+});
+
 /**
  * Intercept the admin auth-start REST call with a canned response. A live fake
  * MCP server is unreliable under this harness — the patched fetch routes by

--- a/packages/web/test/instance-credentials.test.tsx
+++ b/packages/web/test/instance-credentials.test.tsx
@@ -97,6 +97,33 @@ test('toggles body substitution on an existing credential via the edit form', as
 	});
 });
 
+test('the add/edit form is a dismissible panel titled for its mode', async () => {
+	const { findByText, getByRole, getByTestId, queryByTestId, user } = await renderApp({
+		initialPath: '/settings/credentials',
+		seed: async (ctx) => {
+			await seedInstanceSecret(ctx, {
+				name: 'PANEL_KEY',
+				value: 'v1',
+				allowed_hosts: ['api.panel.example'],
+			});
+		},
+	});
+
+	await findByText('PANEL_KEY');
+
+	// Create mode opens the standout panel; its close button dismisses it.
+	await user.click(getByRole('button', { name: 'Add' }));
+	expect(getByTestId('in-place-form').textContent).toContain('Add credential');
+	await user.click(getByTestId('in-place-form-close'));
+	expect(queryByTestId('in-place-form')).toBeNull();
+
+	// Edit mode reuses the same panel with an edit title.
+	await user.click(getByRole('button', { name: 'Edit PANEL_KEY' }));
+	expect(getByTestId('in-place-form').textContent).toContain('Edit credential');
+	await user.click(getByTestId('in-place-form-close'));
+	expect(queryByTestId('in-place-form')).toBeNull();
+});
+
 test('settings page shows the superuser Credentials link and navigates to it', async () => {
 	const { findByRole, getAllByRole, user, router } = await renderApp({ initialPath: '/settings' });
 

--- a/packages/web/test/model-pricing.test.tsx
+++ b/packages/web/test/model-pricing.test.tsx
@@ -49,6 +49,19 @@ test('model pricing lists the baked catalog plus overrides and creates an overri
 	await findByText('my-fine-tune');
 });
 
+test('the override form opens in a titled panel and closes via its close button', async () => {
+	const { findByRole, getByRole, getByTestId, queryByTestId, user } = await renderApp({
+		initialPath: '/settings/ai-providers',
+	});
+
+	await findByRole('heading', { name: 'Model pricing' });
+	await user.click(getByRole('button', { name: 'Override' }));
+	expect(getByTestId('in-place-form').textContent).toContain('Add price override');
+
+	await user.click(getByTestId('in-place-form-close'));
+	expect(queryByTestId('in-place-form')).toBeNull();
+});
+
 test('the Model pricing help dialog explains table-only pricing and the conservative estimate', async () => {
 	const { findByTestId, findByText, queryByText, user } = await renderApp({
 		initialPath: '/settings/ai-providers',

--- a/packages/web/test/settings-skills.test.tsx
+++ b/packages/web/test/settings-skills.test.tsx
@@ -1,3 +1,4 @@
+import { within } from '@testing-library/react';
 import { expect, test } from 'vitest';
 import { renderApp } from './helpers/render';
 
@@ -35,4 +36,26 @@ test('the skills.sh search panel is gated on a configured token', async () => {
 	await r.user.click(await r.findByTestId('toggle-search'));
 	// No token configured for a fresh instance → prompts for one instead of searching.
 	expect(await r.findByLabelText('skills.sh API token')).toBeTruthy();
+});
+
+test('the add form and the registry search panel each close via their own close button', async () => {
+	const r = await renderApp({ initialPath: '/settings/skills' });
+
+	// Open both panels: registry search first, then the add form below it.
+	await r.user.click(await r.findByTestId('toggle-search'));
+	await r.user.click(await r.findByRole('button', { name: 'Add' }));
+
+	const searchPanel = await r.findByTestId('registry-search-panel');
+	const addPanel = await r.findByTestId('in-place-form');
+	expect(addPanel.textContent).toContain('Add skill');
+	expect(searchPanel.textContent).toContain('Search skills.sh');
+
+	// Closing the search panel leaves the add form open…
+	await r.user.click(within(searchPanel).getByTestId('in-place-form-close'));
+	expect(r.queryByTestId('registry-search-panel')).toBeNull();
+	expect(r.queryByTestId('in-place-form')).not.toBeNull();
+
+	// …and the add form closes independently.
+	await r.user.click(within(addPanel).getByTestId('in-place-form-close'));
+	expect(r.queryByTestId('in-place-form')).toBeNull();
 });


### PR DESCRIPTION
## Summary

Standardizes the toggled in-place add/edit forms on the settings list pages behind a new shared `InPlaceForm` component (`packages/web/src/components/ui/in-place-form.tsx`):

- **Standout panel** — filled (`bg-surface-2`), rounded, bordered card so the form separates visually from the list it edits
- **Title** — names the action (`Add connector`, `Edit credential`, …)
- **Top-right close button** — every one of these forms now dismisses the same way
- Optional `onSubmit` (renders a plain container for non-form panels) and a `footer` slot rendered inside the panel but outside the `<form>` (used by the skill editor's revisions panel so its buttons never submit the editor)

Adopted on: settings **Connectors**, **Credentials**, **Skills** (both the add/edit form and the skills.sh registry search panel), **API keys**, and the **Model pricing** override form.

The Connectors page additionally:

- Blurb trimmed to just its first sentence; the OAuth-popup/placeholder-auth detail moved into the "About connectors" info tooltip so it stays discoverable
- **Display name field removed** — the connector name doubles as its display label (`display_name` stays in the API for agent-registered connectors; rows still render it when present)

## Testing

- New component-tier coverage in each affected page spec: panel title per mode (add vs edit), close-button dismissal, trimmed blurb, absent display-name field, and independent closing of the two skills panels
- Full web component tier green: 159 files / 958 tests
- Verified live in Chromium against a real server + Vite: created a connector end-to-end through the new panel, exercised every close button, and checked the 375px mobile layout and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mvp1NTAscGe37GqBWQ9KT7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mvp1NTAscGe37GqBWQ9KT7)_