### PR TITLE
fix(web): flow the rail create button after the project list until it overflows

### DIFF
--- a/packages/web/src/components/project-rail.tsx
+++ b/packages/web/src/components/project-rail.tsx
@@ -1,6 +1,6 @@
 import { Link } from '@tanstack/react-router';
 import { Building2, Home, Plus } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import { useActiveProject } from '../hooks/use-active-project';
 import { useInboxUnreadCount, useInboxUnreadCountsBySlug } from '../hooks/use-inbox-count';
 import { useMe } from '../hooks/use-me';
@@ -19,9 +19,10 @@ import { Tooltip } from './ui/tooltip';
  * The create-project action is the last item *inside* the scrolling avatar
  * list, with `sticky bottom-0`: while the avatars fit the rail it simply flows
  * right after the last one, and once they overflow it pins to the bottom of
- * the visible area (the avatars scroll beneath it) with an elevation shadow
- * marking the pinned state. Only the HQ entry stays pinned below the scroll
- * area, behind a border.
+ * the visible area (the avatars scroll beneath it). Its elevation shadow is
+ * always on — it is the button's affordance in both states; there is no
+ * separator border in either. Only the HQ entry stays pinned below the
+ * scroll area, behind a border.
  *
  * `showHome` pins a Home button above the avatar list (separated by a border).
  * It's used in the mobile side drawer, where the header logo opens the drawer
@@ -38,29 +39,6 @@ export function ProjectRail({ showHome = false }: { showHome?: boolean } = {}) {
 	const { data: hqInbox } = useInboxUnreadCount(hq?.slug ?? '', !!hq);
 	const [createOpen, setCreateOpen] = useState(false);
 	const hqActive = !!hq && active?.slug === hq.slug;
-
-	// Whether the avatar list overflows its viewport. Drives only the shadow on
-	// the sticky create button — its position is pure CSS, so toggling the class
-	// never changes layout and there is no measure→move feedback loop.
-	const scrollRef = useRef<HTMLDivElement | null>(null);
-	const [overflowing, setOverflowing] = useState(false);
-	useEffect(() => {
-		const el = scrollRef.current;
-		if (!el) return;
-		const measure = () => setOverflowing(el.scrollHeight - el.clientHeight > 1);
-		measure();
-		// The container box changes on window resize or when the pinned HQ block
-		// (de)mounts; content growth (projects loading in) changes scrollHeight
-		// without a box change, which only the childList observer sees.
-		const ro = new ResizeObserver(measure);
-		ro.observe(el);
-		const mo = new MutationObserver(measure);
-		mo.observe(el, { childList: true });
-		return () => {
-			ro.disconnect();
-			mo.disconnect();
-		};
-	}, []);
 
 	return (
 		<>
@@ -90,7 +68,6 @@ export function ProjectRail({ showHome = false }: { showHome?: boolean } = {}) {
 				  overhang plus the active ring.
 				*/}
 				<div
-					ref={scrollRef}
 					className="flex-1 min-h-0 w-full overflow-y-auto flex flex-col items-center gap-2 pt-2.5 pb-1"
 					data-testid="project-rail-scroll"
 				>
@@ -125,8 +102,9 @@ export function ProjectRail({ showHome = false }: { showHome?: boolean } = {}) {
 						  Sticky, not a pinned sibling: in flow it sits right after the
 						  last avatar; once the list overflows it stops at the viewport
 						  bottom while the avatars scroll beneath. The full-width opaque
-						  wrapper masks avatars sliding under; the shadow (elevation, no
-						  separator border) only appears while the list overflows.
+						  wrapper masks avatars sliding under. The shadow is always on
+						  (upward, so the overflow box can't clip it away in the stuck
+						  position) — there is no separator border in either state.
 						*/
 						<div className="sticky bottom-0 z-10 shrink-0 w-full flex justify-center py-1 bg-surface-2">
 							<Tooltip content="New project" side="right">
@@ -135,9 +113,7 @@ export function ProjectRail({ showHome = false }: { showHome?: boolean } = {}) {
 									onClick={() => setCreateOpen(true)}
 									aria-label="New project"
 									data-testid="project-rail-new"
-									className={`w-9 h-9 rounded-md flex items-center justify-center text-text-2 hover:text-text-1 hover:bg-surface border border-dashed border-border transition ${
-										overflowing ? 'shadow-up' : ''
-									}`}
+									className="w-9 h-9 rounded-md flex items-center justify-center text-text-2 hover:text-text-1 hover:bg-surface border border-dashed border-border transition-colors shadow-up"
 								>
 									<Plus className="w-4 h-4" />
 								</button>

--- a/packages/web/src/components/project-rail.tsx
+++ b/packages/web/src/components/project-rail.tsx
@@ -1,6 +1,6 @@
 import { Link } from '@tanstack/react-router';
 import { Building2, Home, Plus } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useActiveProject } from '../hooks/use-active-project';
 import { useInboxUnreadCount, useInboxUnreadCountsBySlug } from '../hooks/use-inbox-count';
 import { useMe } from '../hooks/use-me';
@@ -14,9 +14,14 @@ import { Tooltip } from './ui/tooltip';
  * The thin left rail of project avatars. Projects are the primary navigation
  * axis: every visible project across every team appears here. Selecting one
  * opens its menu in the panel to the right. There is no team-level grouping —
- * each project is presented as a standalone entity. The create-project action
- * and the HQ entry are pinned below the scrolling avatar list (create-project
- * above HQ) so they stay in place as the avatar list scrolls.
+ * each project is presented as a standalone entity.
+ *
+ * The create-project action is the last item *inside* the scrolling avatar
+ * list, with `sticky bottom-0`: while the avatars fit the rail it simply flows
+ * right after the last one, and once they overflow it pins to the bottom of
+ * the visible area (the avatars scroll beneath it) with an elevation shadow
+ * marking the pinned state. Only the HQ entry stays pinned below the scroll
+ * area, behind a border.
  *
  * `showHome` pins a Home button above the avatar list (separated by a border).
  * It's used in the mobile side drawer, where the header logo opens the drawer
@@ -33,6 +38,29 @@ export function ProjectRail({ showHome = false }: { showHome?: boolean } = {}) {
 	const { data: hqInbox } = useInboxUnreadCount(hq?.slug ?? '', !!hq);
 	const [createOpen, setCreateOpen] = useState(false);
 	const hqActive = !!hq && active?.slug === hq.slug;
+
+	// Whether the avatar list overflows its viewport. Drives only the shadow on
+	// the sticky create button — its position is pure CSS, so toggling the class
+	// never changes layout and there is no measure→move feedback loop.
+	const scrollRef = useRef<HTMLDivElement | null>(null);
+	const [overflowing, setOverflowing] = useState(false);
+	useEffect(() => {
+		const el = scrollRef.current;
+		if (!el) return;
+		const measure = () => setOverflowing(el.scrollHeight - el.clientHeight > 1);
+		measure();
+		// The container box changes on window resize or when the pinned HQ block
+		// (de)mounts; content growth (projects loading in) changes scrollHeight
+		// without a box change, which only the childList observer sees.
+		const ro = new ResizeObserver(measure);
+		ro.observe(el);
+		const mo = new MutationObserver(measure);
+		mo.observe(el, { childList: true });
+		return () => {
+			ro.disconnect();
+			mo.disconnect();
+		};
+	}, []);
 
 	return (
 		<>
@@ -62,6 +90,7 @@ export function ProjectRail({ showHome = false }: { showHome?: boolean } = {}) {
 				  overhang plus the active ring.
 				*/}
 				<div
+					ref={scrollRef}
 					className="flex-1 min-h-0 w-full overflow-y-auto flex flex-col items-center gap-2 pt-2.5 pb-1"
 					data-testid="project-rail-scroll"
 				>
@@ -91,22 +120,31 @@ export function ProjectRail({ showHome = false }: { showHome?: boolean } = {}) {
 							</Tooltip>
 						);
 					})}
+					{me?.is_superuser && (
+						/*
+						  Sticky, not a pinned sibling: in flow it sits right after the
+						  last avatar; once the list overflows it stops at the viewport
+						  bottom while the avatars scroll beneath. The full-width opaque
+						  wrapper masks avatars sliding under; the shadow (elevation, no
+						  separator border) only appears while the list overflows.
+						*/
+						<div className="sticky bottom-0 z-10 shrink-0 w-full flex justify-center py-1 bg-surface-2">
+							<Tooltip content="New project" side="right">
+								<button
+									type="button"
+									onClick={() => setCreateOpen(true)}
+									aria-label="New project"
+									data-testid="project-rail-new"
+									className={`w-9 h-9 rounded-md flex items-center justify-center text-text-2 hover:text-text-1 hover:bg-surface border border-dashed border-border transition ${
+										overflowing ? 'shadow-up' : ''
+									}`}
+								>
+									<Plus className="w-4 h-4" />
+								</button>
+							</Tooltip>
+						</div>
+					)}
 				</div>
-				{me?.is_superuser && (
-					<div className="shrink-0 pt-2 mt-2 w-full flex justify-center border-t border-border">
-						<Tooltip content="New project" side="right">
-							<button
-								type="button"
-								onClick={() => setCreateOpen(true)}
-								aria-label="New project"
-								data-testid="project-rail-new"
-								className="w-9 h-9 rounded-md flex items-center justify-center text-text-2 hover:text-text-1 hover:bg-surface border border-dashed border-border transition-colors"
-							>
-								<Plus className="w-4 h-4" />
-							</button>
-						</Tooltip>
-					</div>
-				)}
 				{hq && (
 					<div className="shrink-0 pt-2 mt-2 w-full flex justify-center border-t border-border">
 						<Tooltip content={hq.name} side="right">

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -74,6 +74,11 @@
 	--elev-sm: 0 1px 3px oklch(0.2 0.02 262 / 0.07), 0 1px 2px oklch(0.2 0.02 262 / 0.05);
 	--elev-md: 0 4px 12px oklch(0.2 0.02 262 / 0.08), 0 1px 3px oklch(0.2 0.02 262 / 0.06);
 	--elev-lg: 0 12px 32px oklch(0.2 0.02 262 / 0.14), 0 2px 8px oklch(0.2 0.02 262 / 0.08);
+	/* Upward elevation for bottom-stuck elements inside a scroll container — an
+	   overflow box clips a downward shadow at its bottom edge, so the ink has to
+	   spread up onto the content scrolling beneath (e.g. the project rail's
+	   sticky create button). */
+	--elev-up: 0 -2px 10px oklch(0.2 0.02 262 / 0.14), 0 -1px 3px oklch(0.2 0.02 262 / 0.1);
 }
 
 /* `.log-surface-dark` opts a subtree into the dark palette regardless of the
@@ -143,6 +148,7 @@ html.dark,
 	--elev-sm: 0 1px 3px oklch(0 0 0 / 0.35);
 	--elev-md: 0 4px 14px oklch(0 0 0 / 0.4);
 	--elev-lg: 0 16px 40px oklch(0 0 0 / 0.5);
+	--elev-up: 0 -2px 12px oklch(0 0 0 / 0.5), 0 -1px 3px oklch(0 0 0 / 0.4);
 }
 
 /* Agent run logs keep their pre-Wire palette. The formatted run-log view is the
@@ -327,6 +333,7 @@ html.dark,
 	--shadow-sm: var(--elev-sm);
 	--shadow-md: var(--elev-md);
 	--shadow-lg: var(--elev-lg);
+	--shadow-up: var(--elev-up);
 
 	--radius-sm: 6px;
 	--radius-md: 8px;

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -74,10 +74,10 @@
 	--elev-sm: 0 1px 3px oklch(0.2 0.02 262 / 0.07), 0 1px 2px oklch(0.2 0.02 262 / 0.05);
 	--elev-md: 0 4px 12px oklch(0.2 0.02 262 / 0.08), 0 1px 3px oklch(0.2 0.02 262 / 0.06);
 	--elev-lg: 0 12px 32px oklch(0.2 0.02 262 / 0.14), 0 2px 8px oklch(0.2 0.02 262 / 0.08);
-	/* Upward elevation for bottom-stuck elements inside a scroll container — an
-	   overflow box clips a downward shadow at its bottom edge, so the ink has to
-	   spread up onto the content scrolling beneath (e.g. the project rail's
-	   sticky create button). */
+	/* Upward elevation for elements that can stick to the bottom of a scroll
+	   container (the project rail's create button, which carries it in both its
+	   in-flow and stuck states) — an overflow box clips a downward shadow at its
+	   bottom edge, so the ink has to spread up instead. */
 	--elev-up: 0 -2px 10px oklch(0.2 0.02 262 / 0.14), 0 -1px 3px oklch(0.2 0.02 262 / 0.1);
 }
 

--- a/packages/web/test/project-rail.test.tsx
+++ b/packages/web/test/project-rail.test.tsx
@@ -91,7 +91,7 @@ test('the HQ project is pinned at the bottom of the rail and opens on click', as
 	await waitFor(() => expect(router.state.location.pathname).toMatch(/^\/projects\/hq(\/|$)/));
 });
 
-test('the create-project button is pinned above the HQ button', async () => {
+test('the create-project button follows the avatar list, with HQ pinned below it', async () => {
 	const { findByTestId } = await renderApp({
 		initialPath: '/home',
 		seed: async () => {
@@ -100,16 +100,32 @@ test('the create-project button is pinned above the HQ button', async () => {
 		},
 	});
 
-	// Wait for both pinned controls to render before asserting their order.
-	await findByTestId('project-rail-new', undefined, { timeout: 15_000 });
-	await findByTestId('project-rail-hq', undefined, { timeout: 15_000 });
+	// Wait for both controls to render before asserting structure.
+	const newBtn = await findByTestId('project-rail-new', undefined, { timeout: 15_000 });
+	const hq = await findByTestId('project-rail-hq', undefined, { timeout: 15_000 });
 
+	// The create button lives INSIDE the scroll container as its last item, so
+	// it flows directly after the last avatar while the list fits the rail (and
+	// sticks to the visible bottom once the list overflows — a real-layout
+	// behaviour covered by the project-rail-create-button browser specs).
+	const scroll = await findByTestId('project-rail-scroll');
+	expect(scroll.contains(newBtn)).toBe(true);
+	const scrollItems = Array.from(
+		scroll.querySelectorAll(
+			'[data-testid^="project-rail-avatar-"], [data-testid="project-rail-new"]',
+		),
+	).map((el) => el.getAttribute('data-testid'));
+	expect(scrollItems.length).toBeGreaterThan(1);
+	expect(scrollItems[scrollItems.length - 1]).toBe('project-rail-new');
+
+	// HQ stays pinned outside (below) the scroll area, after the create button.
+	expect(scroll.contains(hq)).toBe(false);
 	const rail = await findByTestId('project-rail');
 	// querySelectorAll yields document order, so create-project must come first.
-	const pinned = Array.from(
+	const order = Array.from(
 		rail.querySelectorAll('[data-testid="project-rail-new"], [data-testid="project-rail-hq"]'),
 	).map((el) => el.getAttribute('data-testid'));
-	expect(pinned).toEqual(['project-rail-new', 'project-rail-hq']);
+	expect(order).toEqual(['project-rail-new', 'project-rail-hq']);
 });
 
 test('clicking a project avatar opens that project menu', async () => {
@@ -131,7 +147,7 @@ test('clicking a project avatar opens that project menu', async () => {
 	await findByTestId('project-sidebar-name', undefined, { timeout: 15_000 });
 });
 
-test('superuser creates a new project from the rail-pinned create button', async () => {
+test('superuser creates a new project from the rail create button', async () => {
 	const { findByTestId, user, router } = await renderApp({
 		initialPath: '/home',
 		seed: async () => {

--- a/test/browser/helpers.ts
+++ b/test/browser/helpers.ts
@@ -650,3 +650,46 @@ export async function clickAndWaitForResponse(
 	]);
 	return response;
 }
+
+/**
+ * Serve a deterministic `/api/projects` index for project-rail layout specs.
+ *
+ * The e2e server is shared across parallel workers, each creating teams and
+ * projects of its own, so the real index length is unpredictable. This keeps
+ * only the internal (HQ) entries plus `keepSlug`'s project, then appends
+ * `clones` synthetic copies of it — enough to force (or rule out) rail
+ * overflow regardless of what the other workers are doing. The clone slugs
+ * don't exist server-side, so their per-avatar inbox-count queries are
+ * answered with zero instead of 404ing against the backend.
+ */
+export async function mockRailProjects(
+	page: Page,
+	options: { keepSlug: string; clones: number },
+): Promise<void> {
+	await page.route('**/api/projects', async (route) => {
+		const res = await route.fetch();
+		const json = (await res.json()) as { data: Array<Record<string, unknown>> };
+		const kept = json.data.filter((p) => p.is_internal === true || p.slug === options.keepSlug);
+		const base = kept.find((p) => p.slug === options.keepSlug);
+		if (!base) {
+			throw new Error(`mockRailProjects: project "${options.keepSlug}" not in the live index`);
+		}
+		const clones = Array.from({ length: options.clones }, (_, i) => ({
+			...base,
+			id: `00000000-0000-4000-8000-${String(i + 1).padStart(12, '0')}`,
+			slug: `rail-fill-${i + 1}`,
+			name: `Rail Fill ${i + 1}`,
+		}));
+		await route.fulfill({
+			response: res,
+			body: JSON.stringify({ ...json, data: [...kept, ...clones] }),
+		});
+	});
+	await page.route('**/api/projects/rail-fill-*/inbox/count', (route) =>
+		route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({ data: { unread: 0 } }),
+		}),
+	);
+}

--- a/test/browser/project-rail-create-button.mobile.spec.ts
+++ b/test/browser/project-rail-create-button.mobile.spec.ts
@@ -36,7 +36,8 @@ test('mobile drawer: the create button follows the avatar list while it fits', a
 	expect(scrollerBox.y + scrollerBox.height - (buttonBox.y + buttonBox.height)).toBeGreaterThan(
 		100,
 	);
-	expect(await button.evaluate((el) => getComputedStyle(el).boxShadow)).toBe('none');
+	// The elevation shadow is always on, in the inline state too.
+	expect(await button.evaluate((el) => getComputedStyle(el).boxShadow)).not.toBe('none');
 });
 
 test('mobile drawer: the create button pins to the bottom with a shadow when the list overflows', async ({
@@ -59,9 +60,7 @@ test('mobile drawer: the create button pins to the bottom with a shadow when the
 
 	const button = drawer.getByTestId('project-rail-new');
 	await expect(button).toBeVisible();
-	await expect
-		.poll(async () => button.evaluate((el) => getComputedStyle(el).boxShadow))
-		.not.toBe('none');
+	expect(await button.evaluate((el) => getComputedStyle(el).boxShadow)).not.toBe('none');
 
 	const scrollerBox = await scroller.boundingBox();
 	const buttonBox = await button.boundingBox();

--- a/test/browser/project-rail-create-button.mobile.spec.ts
+++ b/test/browser/project-rail-create-button.mobile.spec.ts
@@ -1,0 +1,76 @@
+// Decision-tree points 1–2: on mobile the rail only exists inside the
+// hamburger drawer (viewport-conditional), and the create button's placement
+// is real sticky/scroll layout. happy-dom runs neither media queries nor
+// layout, so this needs Chromium at the mobile viewport.
+
+import { expect, test } from './fixtures';
+import { mockRailProjects, waitForPageLoad } from './helpers';
+
+test('mobile drawer: the create button follows the avatar list while it fits', async ({
+	sharedPage: page,
+	sharedWorkspace,
+}) => {
+	await mockRailProjects(page, { keepSlug: sharedWorkspace.projectSlug, clones: 0 });
+	await page.goto('/home');
+	await waitForPageLoad(page);
+
+	await page.getByTestId('mobile-nav-toggle').click();
+	// The hidden desktop rail stays in the DOM at mobile widths, so scope every
+	// query to the drawer.
+	const drawer = page.getByTestId('mobile-nav-drawer');
+	await expect(drawer).toBeVisible();
+
+	const scroller = drawer.getByTestId('project-rail-scroll');
+	const avatar = scroller.locator('[data-testid^="project-rail-avatar-"]').last();
+	await expect(avatar).toBeVisible({ timeout: 15_000 });
+	const button = drawer.getByTestId('project-rail-new');
+	await expect(button).toBeVisible();
+
+	const avatarBox = await avatar.boundingBox();
+	const buttonBox = await button.boundingBox();
+	const scrollerBox = await scroller.boundingBox();
+	if (!avatarBox || !buttonBox || !scrollerBox) throw new Error('missing layout boxes');
+
+	// Directly below the last avatar, not pinned to the drawer bottom.
+	expect(buttonBox.y - (avatarBox.y + avatarBox.height)).toBeLessThan(24);
+	expect(scrollerBox.y + scrollerBox.height - (buttonBox.y + buttonBox.height)).toBeGreaterThan(
+		100,
+	);
+	expect(await button.evaluate((el) => getComputedStyle(el).boxShadow)).toBe('none');
+});
+
+test('mobile drawer: the create button pins to the bottom with a shadow when the list overflows', async ({
+	sharedPage: page,
+	sharedWorkspace,
+}) => {
+	await mockRailProjects(page, { keepSlug: sharedWorkspace.projectSlug, clones: 40 });
+	await page.goto('/home');
+	await waitForPageLoad(page);
+
+	await page.getByTestId('mobile-nav-toggle').click();
+	const drawer = page.getByTestId('mobile-nav-drawer');
+	await expect(drawer).toBeVisible();
+
+	const scroller = drawer.getByTestId('project-rail-scroll');
+	await expect(scroller.locator('[data-testid^="project-rail-avatar-"]').first()).toBeVisible({
+		timeout: 15_000,
+	});
+	expect(await scroller.evaluate((el) => el.scrollHeight > el.clientHeight + 1)).toBe(true);
+
+	const button = drawer.getByTestId('project-rail-new');
+	await expect(button).toBeVisible();
+	await expect
+		.poll(async () => button.evaluate((el) => getComputedStyle(el).boxShadow))
+		.not.toBe('none');
+
+	const scrollerBox = await scroller.boundingBox();
+	const buttonBox = await button.boundingBox();
+	if (!scrollerBox || !buttonBox) throw new Error('missing layout boxes');
+	// Pinned at the visible bottom edge of the drawer's scroll area, no border.
+	expect(
+		Math.abs(scrollerBox.y + scrollerBox.height - (buttonBox.y + buttonBox.height)),
+	).toBeLessThan(10);
+	expect(
+		await button.evaluate((el) => getComputedStyle(el.parentElement as Element).borderTopWidth),
+	).toBe('0px');
+});

--- a/test/browser/project-rail-create-button.spec.ts
+++ b/test/browser/project-rail-create-button.spec.ts
@@ -33,8 +33,9 @@ test('the create button flows right after the avatar list while it fits the rail
 	expect(scrollerBox.y + scrollerBox.height - (buttonBox.y + buttonBox.height)).toBeGreaterThan(
 		100,
 	);
-	// Inline state: no elevation shadow, and no separator border above it.
-	expect(await button.evaluate((el) => getComputedStyle(el).boxShadow)).toBe('none');
+	// The elevation shadow is always on — inline too — and there is no
+	// separator border above the button.
+	expect(await button.evaluate((el) => getComputedStyle(el).boxShadow)).not.toBe('none');
 	expect(
 		await button.evaluate((el) => getComputedStyle(el.parentElement as Element).borderTopWidth),
 	).toBe('0px');
@@ -58,11 +59,8 @@ test('the create button pins to the bottom with a shadow once the avatar list ov
 	const button = page.getByTestId('project-rail-new');
 	await expect(button).toBeVisible();
 
-	// The overflow measurement lands a paint after the avatars mount — poll for
-	// the shadow rather than asserting the very first frame.
-	await expect
-		.poll(async () => button.evaluate((el) => getComputedStyle(el).boxShadow))
-		.not.toBe('none');
+	// The always-on elevation shadow is the only separation cue while pinned.
+	expect(await button.evaluate((el) => getComputedStyle(el).boxShadow)).not.toBe('none');
 
 	const scrollerBox = await scroller.boundingBox();
 	const buttonBox = await button.boundingBox();

--- a/test/browser/project-rail-create-button.spec.ts
+++ b/test/browser/project-rail-create-button.spec.ts
@@ -1,0 +1,90 @@
+// Decision-tree point 1: the create button's placement is real CSS layout —
+// `position: sticky` inside the rail's overflow-y scroll container — and the
+// assertions compare boundingBox positions and computed box-shadow before and
+// after scrolling. happy-dom has no layout engine (scrollHeight/clientHeight
+// are 0 and sticky never engages), so this cannot be a component test.
+
+import { expect, test } from './fixtures';
+import { mockRailProjects, waitForPageLoad } from './helpers';
+
+test('the create button flows right after the avatar list while it fits the rail', async ({
+	sharedPage: page,
+	sharedWorkspace,
+}) => {
+	await mockRailProjects(page, { keepSlug: sharedWorkspace.projectSlug, clones: 0 });
+	await page.goto('/home');
+	await waitForPageLoad(page);
+
+	const scroller = page.getByTestId('project-rail-scroll');
+	const avatar = scroller.locator('[data-testid^="project-rail-avatar-"]').last();
+	await expect(avatar).toBeVisible({ timeout: 15_000 });
+	const button = page.getByTestId('project-rail-new');
+	await expect(button).toBeVisible();
+
+	const avatarBox = await avatar.boundingBox();
+	const buttonBox = await button.boundingBox();
+	const scrollerBox = await scroller.boundingBox();
+	if (!avatarBox || !buttonBox || !scrollerBox) throw new Error('missing layout boxes');
+
+	// Directly below the last avatar (the list gap plus the wrapper padding)…
+	expect(buttonBox.y - (avatarBox.y + avatarBox.height)).toBeGreaterThan(0);
+	expect(buttonBox.y - (avatarBox.y + avatarBox.height)).toBeLessThan(24);
+	// …and far above the bottom of the mostly-empty scroll area, i.e. not pinned.
+	expect(scrollerBox.y + scrollerBox.height - (buttonBox.y + buttonBox.height)).toBeGreaterThan(
+		100,
+	);
+	// Inline state: no elevation shadow, and no separator border above it.
+	expect(await button.evaluate((el) => getComputedStyle(el).boxShadow)).toBe('none');
+	expect(
+		await button.evaluate((el) => getComputedStyle(el.parentElement as Element).borderTopWidth),
+	).toBe('0px');
+});
+
+test('the create button pins to the bottom with a shadow once the avatar list overflows', async ({
+	sharedPage: page,
+	sharedWorkspace,
+}) => {
+	await mockRailProjects(page, { keepSlug: sharedWorkspace.projectSlug, clones: 40 });
+	await page.goto('/home');
+	await waitForPageLoad(page);
+
+	const scroller = page.getByTestId('project-rail-scroll');
+	await expect(scroller.locator('[data-testid^="project-rail-avatar-"]').first()).toBeVisible({
+		timeout: 15_000,
+	});
+	// The mocked index must actually overflow the rail for this test to mean anything.
+	expect(await scroller.evaluate((el) => el.scrollHeight > el.clientHeight + 1)).toBe(true);
+
+	const button = page.getByTestId('project-rail-new');
+	await expect(button).toBeVisible();
+
+	// The overflow measurement lands a paint after the avatars mount — poll for
+	// the shadow rather than asserting the very first frame.
+	await expect
+		.poll(async () => button.evaluate((el) => getComputedStyle(el).boxShadow))
+		.not.toBe('none');
+
+	const scrollerBox = await scroller.boundingBox();
+	const buttonBox = await button.boundingBox();
+	if (!scrollerBox || !buttonBox) throw new Error('missing layout boxes');
+	// Pinned at the visible bottom edge of the scroll area (± the wrapper padding).
+	expect(
+		Math.abs(scrollerBox.y + scrollerBox.height - (buttonBox.y + buttonBox.height)),
+	).toBeLessThan(10);
+	// The old border-t separator is gone — the shadow is the only elevation cue.
+	expect(
+		await button.evaluate((el) => getComputedStyle(el.parentElement as Element).borderTopWidth),
+	).toBe('0px');
+
+	// It stays put while the avatars scroll beneath it.
+	const firstAvatar = scroller.locator('[data-testid^="project-rail-avatar-"]').first();
+	const avatarBefore = await firstAvatar.boundingBox();
+	if (!avatarBefore) throw new Error('missing avatar box');
+	await scroller.evaluate((el) => {
+		el.scrollTop = 300;
+	});
+	await expect.poll(async () => (await firstAvatar.boundingBox())?.y).not.toBe(avatarBefore.y);
+	const buttonAfter = await button.boundingBox();
+	if (!buttonAfter) throw new Error('missing layout boxes');
+	expect(Math.abs(buttonAfter.y - buttonBox.y)).toBeLessThan(2);
+});


### PR DESCRIPTION
## What

The create-project "+" in the project rail was always pinned below the avatar list behind a `border-t` separator, even when the list was only a few avatars tall. Now:

- **While the avatar list fits the rail height**, the button flows directly after the last avatar.
- **Once the list overflows (must scroll)**, the button stays at the bottom of the visible area while the avatars scroll beneath it.
- The `border-t` separator is gone; the button carries an **elevation shadow in both states** as its affordance.

The HQ entry is unchanged: still pinned below the scroll area behind its border.

## How

- The button is now the **last item inside the scroll container** with `sticky bottom-0`, so both placements are the same pure-CSS element — inline when in flow, pinned when the list overflows. A full-width `bg-surface-2` wrapper masks avatars sliding underneath. No JS measurement involved.
- New themed elevation token `--elev-up` / `shadow-up` (light + dark): an upward shadow, since the scroll container clips downward ink at its bottom edge when the button is stuck there.

## Tests

- `test/browser/project-rail-create-button.spec.ts` (desktop) and `.mobile.spec.ts` (drawer at mobile viewport): real-layout assertions — inline position after the last avatar, pinned position at the scroll viewport bottom, computed `box-shadow` present in both states, `border-top-width: 0px`, and the button holding still while the list scrolls beneath it. Both run against a deterministic mocked `/api/projects` index (`mockRailProjects` helper) so parallel workers can't skew the rail length.
- `packages/web/test/project-rail.test.tsx`: updated to assert the button now renders inside the scroll container as its last item, with HQ still pinned below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G9RfH16WYV9usVz6qM1C7U