### PR TITLE
fix(web): use canonical terminate button for running agents in the agent queue

### DIFF
--- a/packages/web/src/components/task-detail/agent-queue-section.tsx
+++ b/packages/web/src/components/task-detail/agent-queue-section.tsx
@@ -5,8 +5,8 @@ import { useCancelQueuedWakeup } from '../../hooks/use-cancel-queued-wakeup';
 import type { ExecutionLock } from '../../hooks/use-execution-locks';
 import type { QueuedDispatchState, QueuedWakeup } from '../../hooks/use-queued-wakeups';
 import { useRunQueuedWakeup } from '../../hooks/use-run-queued-wakeup';
-import { useTerminateRun } from '../../hooks/use-terminate-run';
 import { AgentLink } from '../agent-link';
+import { TerminateRunButton } from '../terminate-run-button';
 import { ConfirmDialog } from '../ui/confirm-dialog';
 import { Tooltip } from '../ui/tooltip';
 
@@ -112,18 +112,11 @@ function RunningAgentRow({
 	agentSlug: string | undefined;
 	run: { runId: string; commentId: string } | undefined;
 }) {
-	const [open, setOpen] = useState(false);
-	// Reuse the run page's terminate flow verbatim. The active run id comes from
-	// the lock (populated the moment the run is `running`) and falls back to the
-	// run comment; the terminate control isn't rendered while it's empty, so the
-	// mutation can never fire without it.
+	// Reuse the run page's terminate control verbatim. The active run id comes
+	// from the lock (populated the moment the run is `running`) and falls back
+	// to the run comment; the terminate control isn't rendered while it's empty,
+	// so the mutation can never fire without it.
 	const runId = lock.run_id ?? run?.runId ?? '';
-	const terminateMutation = useTerminateRun({
-		projectId,
-		agentId: lock.member_id,
-		runId,
-		taskId,
-	});
 
 	return (
 		<div
@@ -169,35 +162,16 @@ function RunningAgentRow({
 					<Loader2 className="w-3.5 h-3.5 animate-spin text-info" aria-label="Running" />
 				)}
 				{runId && (
-					<Tooltip content="Terminate run">
-						<button
-							type="button"
-							onClick={() => setOpen(true)}
-							aria-label="Terminate run"
-							data-testid={`terminate-running-agent-${lock.member_id}`}
-							disabled={terminateMutation.isPending}
-							className="inline-flex items-center justify-center h-6 w-6 text-danger hover:bg-danger/10 rounded-md transition-colors"
-						>
-							<Trash2 className="w-3.5 h-3.5" />
-						</button>
-					</Tooltip>
+					<TerminateRunButton
+						projectId={projectId}
+						agentId={lock.member_id}
+						runId={runId}
+						status="running"
+						taskId={taskId}
+						testId={`terminate-running-agent-${lock.member_id}`}
+					/>
 				)}
 			</div>
-			{runId && (
-				<ConfirmDialog
-					open={open}
-					onOpenChange={setOpen}
-					title="Terminate this run?"
-					description="The agent will be aborted immediately. Any in-progress work in this run will be lost."
-					confirmLabel="Terminate"
-					cancelLabel="Cancel"
-					variant="danger"
-					loading={terminateMutation.isPending}
-					onConfirm={async () => {
-						await terminateMutation.mutateAsync();
-					}}
-				/>
-			)}
 		</div>
 	);
 }

--- a/packages/web/src/components/terminate-run-button.tsx
+++ b/packages/web/src/components/terminate-run-button.tsx
@@ -11,6 +11,7 @@ interface TerminateRunButtonProps {
 	runId: string;
 	status: RunStatus;
 	taskId?: string | null;
+	testId?: string;
 }
 
 export function TerminateRunButton({
@@ -19,6 +20,7 @@ export function TerminateRunButton({
 	runId,
 	status,
 	taskId,
+	testId = 'terminate-run-button',
 }: TerminateRunButtonProps) {
 	const [open, setOpen] = useState(false);
 	const mutation = useTerminateRun({ projectId, agentId, runId, taskId });
@@ -32,7 +34,7 @@ export function TerminateRunButton({
 					type="button"
 					onClick={() => setOpen(true)}
 					aria-label="Terminate run"
-					data-testid="terminate-run-button"
+					data-testid={testId}
 					disabled={mutation.isPending}
 					className="inline-flex items-center justify-center h-6 px-2 text-xs text-danger hover:bg-danger/10 rounded-md transition-colors"
 				>

--- a/packages/web/test/agent-queue.test.tsx
+++ b/packages/web/test/agent-queue.test.tsx
@@ -36,9 +36,12 @@ test('shows the running agent with a loader and a terminate button', async () =>
 	expect(row.textContent).toContain(seeded.agentTitle);
 	// The loader animation replaces the queued row's run-now button.
 	expect(row.querySelector('.animate-spin')).not.toBeNull();
-	// The delete button terminates the run.
+	// A running agent gets the canonical terminate control (the run viewer's
+	// filled stop square), not the queued row's trashcan.
 	const terminate = await findByTestId(`terminate-running-agent-${seeded.agentId}`);
-	expect(terminate).toBeTruthy();
+	const icon = terminate.querySelector('svg');
+	expect(icon?.classList.contains('lucide-square')).toBe(true);
+	expect(icon?.getAttribute('fill')).toBe('currentColor');
 });
 
 test('terminates the running run via the confirm dialog', async () => {
@@ -186,6 +189,12 @@ test('lists running agents above queued agents', async () => {
 	expect(
 		runningRow.compareDocumentPosition(queuedRow) & Node.DOCUMENT_POSITION_FOLLOWING,
 	).toBeTruthy();
+	// The running agent shows the canonical stop-square terminate button, while
+	// the not-yet-running queued agent keeps the trashcan cancel button.
+	const terminate = await findByTestId(`terminate-running-agent-${seeded.runningAgentId}`);
+	expect(terminate.querySelector('svg')?.classList.contains('lucide-square')).toBe(true);
+	const cancel = await findByTestId(`cancel-queued-wakeup-${seeded.wakeupId}`);
+	expect(cancel.querySelector('svg')?.classList.contains('lucide-trash-2')).toBe(true);
 });
 
 test('renders nothing when the task is fully idle (no running and no queued agents)', () => {


### PR DESCRIPTION
## Summary

The task sidebar's **Agent Queue** rendered a trashcan icon for terminating a *running* agent, while the run viewer and inline run comments use the canonical red filled stop square. This PR makes the running-agent row reuse the shared `TerminateRunButton` component, so the terminate control looks identical everywhere a live run can be stopped.

Queued agents that haven't started yet are unchanged: cancelling a queued (not-yet-running) agent is a removal, not a termination, so that row keeps its trashcan.

## Changes

- `TerminateRunButton` accepts an optional `testId` prop (default unchanged: `terminate-run-button`), so call sites that need distinct test ids can reuse it.
- `AgentQueueSection`'s `RunningAgentRow` drops its hand-rolled trashcan button + duplicated confirm dialog and renders `TerminateRunButton` instead — same `useTerminateRun` flow, same confirm dialog copy, same test id (`terminate-running-agent-<memberId>`), now with the canonical stop-square styling.
- `QueuedAgentRow`'s cancel button is untouched (still `Trash2`).

## Tests

- Strengthened `agent-queue.test.tsx`: the running row's terminate button must render the filled `lucide-square` icon (`fill="currentColor"`), and the mixed running+queued test now asserts the running agent gets the stop square while the queued agent keeps the trashcan.
- Existing terminate-flow tests (confirm dialog → run cancelled server-side) pass unchanged, since the test ids and mutation flow are preserved.
- `bunx vitest run test/agent-queue.test.tsx test/queued-agents.test.tsx test/run-termination.test.tsx test/task-crud.test.tsx test/agent-links.test.tsx` — 28 tests passed; typecheck and biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AgSJ6xH9yUnFSvcywrihqG

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgSJ6xH9yUnFSvcywrihqG)_