### PR TITLE
feat(web): "Add to <TASK-ID>" button in the action-review dialog

### DIFF
--- a/docs/concepts/documents-and-memory.md
+++ b/docs/concepts/documents-and-memory.md
@@ -106,8 +106,10 @@ together into their own **review toolbar** above the document — set apart from
 own edit and delete actions so the two don't get mixed up. Both the toolbar and those edit and
 delete actions **stay pinned to the top while you scroll**, so they're always in reach in a long
 document. The toolbar shows a comment count — **click the count to jump to the first comment** —
-plus two actions: **action this review** (a clipboard button that copies a ready-made handoff you
-can paste into a task comment or a new task's description when assigning the work to an agent) and
+plus two actions: **action this review** (a clipboard button that opens a ready-made handoff you
+can copy and paste into a task comment or a new task's description when assigning the work to an
+agent — and, when you're reviewing a document from a task's preview panel, an **Add to \<task\>**
+button posts the handoff straight onto that task as a comment) and
 **clear review** (a trash button that deletes every comment after confirmation), alongside a
 **?** button that opens a short in-app guide to all of this.
 
@@ -118,8 +120,9 @@ document already take turns filling the screen.)
 
 Agents read pending review comments directly: `read_project_doc` returns them alongside the
 document content, each one anchored to the exact text you highlighted. So the flow is —
-leave your comments, hand the review to an agent (paste the copied handoff into a task and
-assign it), and the agent actions each comment against the document.
+leave your comments, hand the review to an agent (add the handoff to the task with one click
+from a task's document preview, or paste the copied handoff into any task and assign it), and
+the agent actions each comment against the document.
 
 **A review applies to the current version of the document only.** Any update to the
 document — whether you edit it or an agent does — automatically deletes all of its review

--- a/packages/web/src/components/document-review/action-review-dialog.tsx
+++ b/packages/web/src/components/document-review/action-review-dialog.tsx
@@ -1,38 +1,67 @@
 import * as Dialog from '@radix-ui/react-dialog';
-import { Check, Copy } from 'lucide-react';
-import { useRef, useState } from 'react';
+import { Copy, Loader2 } from 'lucide-react';
+import { useCreateComment } from '../../hooks/use-comments';
+import { toast } from '../../hooks/use-toast';
 import { copyToClipboard } from '../../lib/clipboard';
+import { Button } from '../ui/button';
 import { DialogContent } from '../ui/dialog';
 import { buildReviewHandoff } from './review-handoff';
+
+/** Task context for the "Add to <ID>" action — present only when the dialog is opened from a task view. */
+export interface ReviewTaskContext {
+	/** Route-param project slug (API path + query keys). */
+	projectId: string;
+	/** Route-param task id (lowercase identifier) — API path + query keys. */
+	taskId: string;
+	/** Uppercase display identifier, e.g. "HM-31" — the button label. */
+	identifier: string;
+}
 
 interface ActionReviewDialogProps {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	filename: string;
 	commentCount: number;
+	/** When set, renders "Add to <identifier>" which posts the handoff as a comment on that task. */
+	task?: ReviewTaskContext;
 }
 
 /**
  * "Action this review": hands the pending review to an agent. Shows the
- * admin-facing instructions and the copyable handoff blurb — the comments
- * themselves stay in the database (agents read them via read_project_doc).
+ * admin-facing instructions and the handoff blurb — copyable everywhere, and
+ * postable straight onto the hosting task as a comment when opened from a task
+ * view. The review comments themselves stay in the database (agents read them
+ * via read_project_doc). Either action closes the dialog on success.
  */
 export function ActionReviewDialog({
 	open,
 	onOpenChange,
 	filename,
 	commentCount,
+	task,
 }: ActionReviewDialogProps) {
-	const [copied, setCopied] = useState(false);
-	const copiedTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
 	const handoff = buildReviewHandoff(filename);
+	// Inert until fired — the Add button only renders (and handleAdd only runs)
+	// when `task` is set, so the empty-string fallback never reaches the API.
+	const createComment = useCreateComment(task?.projectId ?? '', task?.taskId ?? '');
 
 	async function handleCopy() {
 		const ok = await copyToClipboard(handoff);
-		if (!ok) return;
-		setCopied(true);
-		clearTimeout(copiedTimer.current);
-		copiedTimer.current = setTimeout(() => setCopied(false), 1500);
+		if (!ok) {
+			toast.error('Failed to copy to clipboard');
+			return;
+		}
+		onOpenChange(false);
+	}
+
+	async function handleAdd() {
+		if (!task) return;
+		try {
+			await createComment.mutateAsync({ content: handoff });
+			onOpenChange(false);
+		} catch (e) {
+			toast.error((e as Error).message || 'Failed to add comment');
+		}
 	}
 
 	return (
@@ -42,9 +71,9 @@ export function ActionReviewDialog({
 					Action this review
 				</Dialog.Title>
 				<Dialog.Description className="mb-3 text-[12.5px] leading-relaxed text-text-2">
-					Paste this handoff into a task comment — or a new task's description — and assign it to
-					the agent who should action the feedback. The agent reads the review comments directly
-					from the document.
+					{task
+						? `Add this handoff as a comment on ${task.identifier} — or copy it for another task — and assign it to the agent who should action the feedback. The agent reads the review comments directly from the document.`
+						: "Paste this handoff into a task comment — or a new task's description — and assign it to the agent who should action the feedback. The agent reads the review comments directly from the document."}
 				</Dialog.Description>
 				<div
 					className="whitespace-pre-wrap rounded-md border border-border bg-surface-2 p-3 text-[12.5px] leading-relaxed text-text-1"
@@ -52,20 +81,35 @@ export function ActionReviewDialog({
 				>
 					{handoff}
 				</div>
-				<div className="mt-4 flex items-center justify-between gap-2">
-					<span className="text-xs text-text-3">
-						{commentCount} comment{commentCount === 1 ? '' : 's'} · {filename}
-					</span>
-					<button
-						type="button"
+				<div className="mt-4 min-w-0 truncate text-xs text-text-3" data-testid="action-review-meta">
+					{commentCount} comment{commentCount === 1 ? '' : 's'} · {filename}
+				</div>
+				<div
+					className={`mt-3 flex items-center gap-2 ${task ? 'justify-between' : 'justify-center'}`}
+					data-testid="action-review-footer"
+				>
+					<Button
+						size="sm"
+						variant={task ? 'secondary' : 'primary'}
 						onClick={handleCopy}
-						aria-label={copied ? 'Copied' : 'Copy handoff'}
+						aria-label="Copy handoff"
 						data-testid="action-review-copy"
-						className="inline-flex h-[26px] cursor-pointer items-center gap-1.5 rounded-sm border border-transparent bg-inverse px-2.5 text-[12.5px] font-medium text-inverse-fg hover:opacity-90"
 					>
-						{copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
-						{copied ? 'Copied' : 'Copy'}
-					</button>
+						<Copy className="h-3 w-3" />
+						Copy
+					</Button>
+					{task && (
+						<Button
+							size="sm"
+							onClick={handleAdd}
+							disabled={createComment.isPending}
+							aria-label={`Add to ${task.identifier}`}
+							data-testid="action-review-add"
+						>
+							{createComment.isPending && <Loader2 className="h-3 w-3 animate-spin" />}
+							Add to {task.identifier}
+						</Button>
+					)}
 				</div>
 			</DialogContent>
 		</Dialog.Root>

--- a/packages/web/src/components/document-review/review-toolbar-actions.tsx
+++ b/packages/web/src/components/document-review/review-toolbar-actions.tsx
@@ -3,13 +3,15 @@ import { useState } from 'react';
 import { useClearDocReviewComments, useDocReviewComments } from '../../hooks/use-doc-review';
 import { ConfirmDialog } from '../ui/confirm-dialog';
 import { Tooltip } from '../ui/tooltip';
-import { ActionReviewDialog } from './action-review-dialog';
+import { ActionReviewDialog, type ReviewTaskContext } from './action-review-dialog';
 import { ReviewHelp } from './review-help';
 
 interface ReviewToolbarActionsProps {
 	/** Route-param project slug (query keys + API paths). */
 	projectId: string;
 	filename: string;
+	/** Task context when this toolbar renders inside a task view — enables "Add to <ID>" in the action dialog. */
+	task?: ReviewTaskContext;
 	/**
 	 * `'grouped'` (default) wraps the controls in a tinted, rounded container so
 	 * the review-comment tools read as one self-contained cluster, clearly set
@@ -33,6 +35,7 @@ const ICON_BUTTON_CLASSES =
 export function ReviewToolbarActions({
 	projectId,
 	filename,
+	task,
 	variant = 'grouped',
 }: ReviewToolbarActionsProps) {
 	const { data: comments } = useDocReviewComments(projectId, filename);
@@ -102,6 +105,7 @@ export function ReviewToolbarActions({
 				onOpenChange={setActionOpen}
 				filename={filename}
 				commentCount={count}
+				task={task}
 			/>
 			<ConfirmDialog
 				open={confirmClearOpen}

--- a/packages/web/src/components/task-detail/preview-panel.tsx
+++ b/packages/web/src/components/task-detail/preview-panel.tsx
@@ -1,6 +1,7 @@
 import { ExternalLink, X } from 'lucide-react';
 import { type ProjectDoc, useProjectDoc } from '../../hooks/use-project-docs';
 import { docPreviewPath } from '../../lib/doc-preview';
+import type { ReviewTaskContext } from '../document-review/action-review-dialog';
 import { DocumentBody } from '../document-review/document-body';
 import { ReviewToolbarActions } from '../document-review/review-toolbar-actions';
 import { Tooltip } from '../ui/tooltip';
@@ -16,6 +17,8 @@ function formatBytes(bytes?: number): string {
 interface PreviewPanelProps {
 	item: PreviewItem;
 	onClose: () => void;
+	/** The hosting task (task-detail surface only) — threads through to the review dialog's "Add to <ID>". */
+	task?: ReviewTaskContext;
 }
 
 /**
@@ -25,7 +28,7 @@ interface PreviewPanelProps {
  * moves here. (Asset mentions no longer open here — they link straight to a new
  * tab.)
  */
-export function PreviewPanel({ item, onClose }: PreviewPanelProps) {
+export function PreviewPanel({ item, onClose, task }: PreviewPanelProps) {
 	const docQuery = useProjectDoc(item.projectId, item.filename);
 	const openUrl = docPreviewPath(item.projectSlug, item.filename);
 	const meta = formatBytes(item.size);
@@ -43,7 +46,7 @@ export function PreviewPanel({ item, onClose }: PreviewPanelProps) {
 				>
 					{item.filename}
 				</span>
-				<ReviewToolbarActions projectId={item.projectId} filename={item.filename} />
+				<ReviewToolbarActions projectId={item.projectId} filename={item.filename} task={task} />
 				<Tooltip content="Open in new tab">
 					<a
 						href={openUrl}

--- a/packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx
@@ -212,7 +212,13 @@ function TaskDetailPage() {
 			</div>
 			{/* Document preview: its own layer. Mobile: a full-screen overlay above
 				    the main content and the meta drawer. Desktop: the in-grid column 2. */}
-			{preview && <PreviewPanel item={preview} onClose={() => setPreview(null)} />}
+			{preview && (
+				<PreviewPanel
+					item={preview}
+					onClose={() => setPreview(null)}
+					task={{ projectId, taskId, identifier: task.identifier }}
+				/>
+			)}
 		</div>
 	);
 }

--- a/packages/web/test/document-review.test.tsx
+++ b/packages/web/test/document-review.test.tsx
@@ -251,7 +251,7 @@ test('clear review deletes every comment after confirmation', async () => {
 	expect(container.querySelector('[data-testid="review-count-chip"]')).toBeNull();
 });
 
-test('action dialog shows the agent handoff and copies it to the clipboard', async () => {
+test('action dialog copies the handoff, closes, and shows no Add button outside a task view', async () => {
 	const { findByTestId, filename, user } = await setupDocumentsPage({
 		comments: [{ quote: 'target text', comment: 'Expand this' }],
 	});
@@ -281,12 +281,24 @@ test('action dialog shows the agent handoff and copies it to the clipboard', asy
 		expect(handoff.textContent).toContain(filename);
 		expect(handoff.textContent).toContain('automatically deletes every review comment');
 
+		// Task-less surface: no "Add to <task>" button, the lone copy button is
+		// centred, and the meta line carries the count + filename.
+		expect(document.body.querySelector('[data-testid="action-review-add"]')).toBeNull();
+		const footer = document.body.querySelector(
+			'[data-testid="action-review-footer"]',
+		) as HTMLElement;
+		expect(footer.className).toContain('justify-center');
+		const meta = document.body.querySelector('[data-testid="action-review-meta"]') as HTMLElement;
+		expect(meta.textContent).toContain('1 comment');
+		expect(meta.textContent).toContain(filename);
+
 		const copy = document.body.querySelector('[data-testid="action-review-copy"]') as HTMLElement;
 		await user.click(copy);
 		await waitFor(() => {
 			expect(written.length).toBe(1);
 			expect(written[0]).toContain(filename);
-			expect(copy.getAttribute('aria-label')).toBe('Copied');
+			// A successful copy closes the dialog.
+			expect(document.body.querySelector('[data-testid="action-review-dialog"]')).toBeNull();
 		});
 	} finally {
 		if (originalDesc) Object.defineProperty(navigator, 'clipboard', originalDesc);

--- a/packages/web/test/task-preview-action-review.test.tsx
+++ b/packages/web/test/task-preview-action-review.test.tsx
@@ -1,0 +1,145 @@
+import { waitFor } from '@testing-library/react';
+import { expect, test, vi } from 'vitest';
+import { buildReviewHandoff } from '../src/components/document-review/review-handoff';
+import { toast } from '../src/hooks/use-toast';
+import { renderApp } from './helpers/render';
+import {
+	seedComment,
+	seedDocument,
+	seedProject,
+	seedReviewComment,
+	seedTask,
+	seedWorkspace,
+} from './helpers/seed';
+
+// The action-review dialog, opened from a task's document preview panel, gains
+// an "Add to <TASK-ID>" button that posts the handoff as a comment on that task
+// (payload is exactly `{ content }` — no wake) and closes the dialog; the copy
+// button sits on the left. Failure keeps the dialog open and toasts.
+
+const DOC_CONTENT = ['# Product Requirements', '', 'An unmistakable document body.'].join('\n');
+
+/** Seed a task whose thread mentions a reviewed doc, open its preview panel, and open the action dialog. */
+async function openActionDialogFromTask() {
+	const ref = { projectSlug: '', taskId: '', identifier: '' };
+	const utils = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Review Handoff Project' });
+			await seedDocument(ws, project, { filename: 'prd.md', content: DOC_CONTENT });
+			// The action button is disabled until the doc has review comments.
+			await seedReviewComment(ws, project, 'prd.md', {
+				quote: 'unmistakable document body',
+				comment: 'Tighten this sentence',
+			});
+			const task = await seedTask(ws, project, { title: 'Review the spec' });
+			await seedComment(ws, task, 'Please review prd.md before we ship.');
+			ref.projectSlug = project.slug;
+			ref.taskId = task.identifier.toLowerCase();
+			ref.identifier = task.identifier;
+		},
+	});
+
+	await utils.router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: ref.projectSlug, taskId: ref.taskId },
+	});
+
+	const mention = await utils.findByTestId('doc-mention-link', undefined, { timeout: 15_000 });
+	await utils.user.click(mention);
+	await utils.findByTestId('preview-panel');
+
+	// Count chip appearing means the review-comments query resolved with count > 0,
+	// so the action button is enabled.
+	await utils.findByTestId('review-count-chip');
+	await utils.user.click(await utils.findByTestId('review-action-open'));
+
+	// Dialog portals onto document.body; the portal mounts asynchronously.
+	await waitFor(() => {
+		expect(document.body.querySelector('[data-testid="action-review-dialog"]')).toBeTruthy();
+	});
+	return { ...utils, ...ref };
+}
+
+test('Add to <id> posts the handoff as a comment on the task and closes the dialog', async () => {
+	const { container, identifier, user } = await openActionDialogFromTask();
+
+	// Task context: Copy sits left, "Add to <ID>" right, footer spread apart.
+	const footer = document.body.querySelector('[data-testid="action-review-footer"]') as HTMLElement;
+	expect(footer.className).toContain('justify-between');
+	const add = document.body.querySelector('[data-testid="action-review-add"]') as HTMLElement;
+	expect(add.textContent).toBe(`Add to ${identifier}`);
+	expect(footer.firstElementChild?.getAttribute('data-testid')).toBe('action-review-copy');
+	expect(footer.lastElementChild?.getAttribute('data-testid')).toBe('action-review-add');
+
+	// Spy on POST /api/.../comments to pin the exact payload.
+	const original = globalThis.fetch;
+	const posts: Array<Record<string, unknown>> = [];
+	globalThis.fetch = Object.assign(async (input: RequestInfo | URL, init?: RequestInit) => {
+		const url = typeof input === 'string' ? input : input.toString();
+		if (init?.method === 'POST' && /\/tasks\/[^/]+\/comments$/.test(url)) {
+			const body = init.body;
+			if (typeof body === 'string') {
+				try {
+					posts.push(JSON.parse(body) as Record<string, unknown>);
+				} catch {}
+			}
+		}
+		return original(input, init);
+	}, original);
+	try {
+		await user.click(add);
+
+		// The handoff lands in the task thread (the prd.md mention splits the text
+		// across nodes, so assert on the comment bodies rather than findByText).
+		await waitFor(() => {
+			const bodies = Array.from(container.querySelectorAll('[data-testid="text-comment-body"]'));
+			expect(
+				bodies.some((b) =>
+					b.textContent?.includes('Review comments have been left on the document'),
+				),
+			).toBe(true);
+		});
+	} finally {
+		globalThis.fetch = original;
+	}
+
+	// Exactly `{ content: <handoff> }` — toEqual proves no wake_assignee or extras.
+	expect(posts).toHaveLength(1);
+	expect(posts[0]).toEqual({ content: buildReviewHandoff('prd.md') });
+
+	await waitFor(() => {
+		expect(document.body.querySelector('[data-testid="action-review-dialog"]')).toBeNull();
+	});
+});
+
+test('a failed Add keeps the dialog open and toasts the error', async () => {
+	const { user } = await openActionDialogFromTask();
+
+	const original = globalThis.fetch;
+	const errorSpy = vi.spyOn(toast, 'error');
+	globalThis.fetch = Object.assign(async (input: RequestInfo | URL, init?: RequestInit) => {
+		const url = typeof input === 'string' ? input : input.toString();
+		if (init?.method === 'POST' && /\/tasks\/[^/]+\/comments$/.test(url)) {
+			return new Response(JSON.stringify({ error: { message: 'boom' } }), {
+				status: 500,
+				headers: { 'Content-Type': 'application/json' },
+			});
+		}
+		return original(input, init);
+	}, original);
+	try {
+		await user.click(
+			document.body.querySelector('[data-testid="action-review-add"]') as HTMLElement,
+		);
+		await waitFor(() => {
+			expect(errorSpy).toHaveBeenCalledWith('boom');
+		});
+		// The dialog stays open so the handoff isn't lost.
+		expect(document.body.querySelector('[data-testid="action-review-dialog"]')).toBeTruthy();
+	} finally {
+		globalThis.fetch = original;
+		errorSpy.mockRestore();
+	}
+});


### PR DESCRIPTION
## What

When the "Action this review" dialog is opened from a **task's document preview panel**, it now shows an **"Add to \<TASK-ID\>"** button (e.g. *Add to HM-31*) that posts the agent handoff straight onto that task as a comment — no more copy → scroll → paste. Both footer actions now close the dialog on success.

- **Task context** (preview panel on a task page): Copy button (icon + "Copy") on the left, primary "Add to \<ID\>" on the right.
- **Task-less surfaces** (Documents tab, standalone `/preview` route): only the Copy button, centre-aligned.
- The posted comment payload is exactly `{ content: <handoff> }` — comment only, no `wake_assignee` (explicit product decision).
- On failure: `toast.error` and the dialog stays open (copy failure now also toasts). The transient "Copied" state was removed — the dialog closes immediately instead.
- The meta line (comment count · filename) moved to its own truncating line above the buttons.

## How

- `ActionReviewDialog` gains an optional `task?: ReviewTaskContext` (`{ projectId, taskId, identifier }`) and instantiates `useCreateComment` itself; its existing `onSuccess` cache update makes the comment appear in the task thread immediately.
- The context threads task route → `PreviewPanel` → `ReviewToolbarActions` → `ActionReviewDialog` as a sibling prop (`PreviewItem` stays document-centric). Route params are used so the mutation's query key matches the thread's `useComments(projectId, taskId)`.
- Footer buttons now use the shared `Button` component (`size="sm"`).

## Tests

- Updated `packages/web/test/document-review.test.tsx`: Documents-tab dialog shows no Add button, lone Copy is centred, meta line renders, and a successful copy closes the dialog.
- New `packages/web/test/task-preview-action-review.test.tsx`:
  - Happy path: opens the preview from a doc mention on a task, clicks *Add to \<ID\>*, pins the POST body to `{ content: buildReviewHandoff('prd.md') }` via fetch-spy (proves no extra fields), asserts the comment lands in the thread and the dialog closes.
  - Failure path: comments POST stubbed to 500 → `toast.error('boom')`, dialog stays open.
- Full `bun run test --skip-browser` (server + web + shared) green; `bun run typecheck` and `bun run check` clean.

## Docs

- `docs/concepts/documents-and-memory.md` updated to describe the one-click add from a task's document preview alongside the copy-and-paste path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T1b5g31J7HTyBhBLwMQAc8

---
_Generated by [Claude Code](https://claude.ai/code/session_01T1b5g31J7HTyBhBLwMQAc8)_