### PR TITLE
feat(web): rename AI provider configs in place

### DIFF
--- a/packages/server/src/routes/ai-providers.ts
+++ b/packages/server/src/routes/ai-providers.ts
@@ -7,6 +7,7 @@ import {
 } from '@hezo/shared';
 import { Hono } from 'hono';
 import { err, ok } from '../lib/response';
+import { isUniqueViolation } from '../lib/sql';
 import type { Env } from '../lib/types';
 import { logger } from '../logger';
 import { requireAdminEquivalent } from '../middleware/auth';
@@ -16,8 +17,8 @@ import {
 	getProviderConfigCredential,
 	listAiProviders,
 	setDefaultAiProvider,
-	setProviderDefaultModel,
 	storeAiProviderKey,
+	updateAiProviderConfig,
 } from '../services/ai-provider-keys';
 import { validateSubscriptionBlob } from '../services/subscription-auth';
 
@@ -213,7 +214,7 @@ aiProvidersRoutes.post('/ai-providers/:configId/verify', async (c) => {
 	}
 });
 
-// Update a provider config — currently only `default_model`
+// Update a provider config — `label` (rename) and/or `default_model`
 aiProvidersRoutes.patch('/ai-providers/:configId', async (c) => {
 	const denied = requireAdminEquivalent(c);
 	if (denied) return denied;
@@ -221,9 +222,16 @@ aiProvidersRoutes.patch('/ai-providers/:configId', async (c) => {
 	const db = c.get('db');
 	const configId = c.req.param('configId');
 
-	const body = await c.req.json<{ default_model?: string | null }>();
-	if (!('default_model' in body)) {
+	const body = await c.req.json<{ default_model?: string | null; label?: string }>();
+	const hasLabel = 'label' in body;
+	const hasModel = 'default_model' in body;
+	if (!hasLabel && !hasModel) {
 		return err(c, 'INVALID_REQUEST', 'Nothing to update', 400);
+	}
+
+	const label = hasLabel && typeof body.label === 'string' ? body.label.trim() : '';
+	if (hasLabel && !label) {
+		return err(c, 'INVALID_REQUEST', 'label must be a non-empty string', 400);
 	}
 
 	const model =
@@ -233,12 +241,26 @@ aiProvidersRoutes.patch('/ai-providers/:configId', async (c) => {
 				? body.default_model.trim() || null
 				: null;
 
-	const updated = await setProviderDefaultModel(db, configId, model);
-	if (!updated) {
-		return err(c, 'NOT_FOUND', 'AI provider config not found', 404);
+	try {
+		const updated = await updateAiProviderConfig(db, configId, {
+			...(hasLabel ? { label } : {}),
+			...(hasModel ? { defaultModel: model } : {}),
+		});
+		if (!updated) {
+			return err(c, 'NOT_FOUND', 'AI provider config not found', 404);
+		}
+	} catch (e) {
+		if (isUniqueViolation(e)) {
+			return err(c, 'DUPLICATE', 'A config with this provider and label already exists', 409);
+		}
+		throw e;
 	}
 
-	return ok(c, { updated: true, default_model: model });
+	return ok(c, {
+		updated: true,
+		...(hasLabel ? { label } : {}),
+		...(hasModel ? { default_model: model } : {}),
+	});
 });
 
 // List models available for this provider config, fetched live from the provider

--- a/packages/server/src/services/ai-provider-keys.ts
+++ b/packages/server/src/services/ai-provider-keys.ts
@@ -2,7 +2,7 @@ import type { PGlite } from '@electric-sql/pglite';
 import { type AiAuthMethod, type AiProvider, AiProviderStatus } from '@hezo/shared';
 import { decrypt, encrypt } from '../crypto/encryption';
 import type { MasterKeyManager } from '../crypto/master-key';
-import { withTransaction } from '../lib/sql';
+import { buildUpdateSet, withTransaction } from '../lib/sql';
 
 export interface AiProviderCredential {
 	value: string;
@@ -138,17 +138,28 @@ export async function listAiProviders(db: PGlite): Promise<AiProviderConfig[]> {
 	return result.rows;
 }
 
-export async function setProviderDefaultModel(
+export interface AiProviderConfigUpdate {
+	label?: string;
+	defaultModel?: string | null;
+}
+
+export async function updateAiProviderConfig(
 	db: PGlite,
 	configId: string,
-	model: string | null,
+	fields: AiProviderConfigUpdate,
 ): Promise<boolean> {
+	const { clauses, params, nextIdx } = buildUpdateSet([
+		{ column: 'label', value: fields.label },
+		{ column: 'default_model', value: fields.defaultModel },
+	]);
+	if (clauses.length === 0) return false;
+
 	const result = await db.query<{ id: string }>(
 		`UPDATE ai_provider_configs
-		 SET default_model = $1, updated_at = now()
-		 WHERE id = $2
+		 SET ${clauses.join(', ')}, updated_at = now()
+		 WHERE id = $${nextIdx}
 		 RETURNING id`,
-		[model, configId],
+		[...params, configId],
 	);
 	return result.rows.length > 0;
 }

--- a/packages/server/test/ai-providers.test.ts
+++ b/packages/server/test/ai-providers.test.ts
@@ -535,6 +535,151 @@ describe('AI providers default model', () => {
 	});
 });
 
+describe('AI providers rename', () => {
+	let firstId: string;
+	let secondId: string;
+
+	beforeAll(async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue({ ok: true }) as unknown as typeof fetch;
+		await db.query('DELETE FROM ai_provider_configs');
+
+		const first = await app.request('/api/ai-providers', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				provider: 'anthropic',
+				api_key: 'sk-ant-rename-a',
+				label: 'anthropic-a',
+			}),
+		});
+		firstId = (await first.json()).data.id;
+
+		const second = await app.request('/api/ai-providers', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				provider: 'anthropic',
+				api_key: 'sk-ant-rename-b',
+				label: 'anthropic-b',
+			}),
+		});
+		secondId = (await second.json()).data.id;
+	});
+
+	it('PATCH renames a config (trimmed) and the list reflects it', async () => {
+		const res = await app.request(`/api/ai-providers/${firstId}`, {
+			method: 'PATCH',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ label: '  anthropic-renamed  ' }),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data.updated).toBe(true);
+		expect(body.data.label).toBe('anthropic-renamed');
+
+		const list = await app.request('/api/ai-providers', { headers: authHeader(token) });
+		const row = ((await list.json()).data as Array<{ id: string; label: string }>).find(
+			(r) => r.id === firstId,
+		);
+		expect(row?.label).toBe('anthropic-renamed');
+	});
+
+	it('rejects an empty or whitespace-only label', async () => {
+		for (const label of ['', '   ']) {
+			const res = await app.request(`/api/ai-providers/${firstId}`, {
+				method: 'PATCH',
+				headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+				body: JSON.stringify({ label }),
+			});
+			expect(res.status).toBe(400);
+			expect((await res.json()).error.code).toBe('INVALID_REQUEST');
+		}
+	});
+
+	it('rejects a label already used by another config of the same provider', async () => {
+		const res = await app.request(`/api/ai-providers/${firstId}`, {
+			method: 'PATCH',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ label: 'anthropic-b' }),
+		});
+		expect(res.status).toBe(409);
+		expect((await res.json()).error.code).toBe('DUPLICATE');
+	});
+
+	it('allows the same label across different providers', async () => {
+		const created = await app.request('/api/ai-providers', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				provider: 'openai',
+				api_key: 'sk-openai-rename',
+				label: 'openai-rename-me',
+			}),
+		});
+		const openaiId = (await created.json()).data.id;
+
+		const res = await app.request(`/api/ai-providers/${openaiId}`, {
+			method: 'PATCH',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ label: 'anthropic-b' }),
+		});
+		expect(res.status).toBe(200);
+	});
+
+	it('renames and sets default_model in one PATCH', async () => {
+		const res = await app.request(`/api/ai-providers/${secondId}`, {
+			method: 'PATCH',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ label: 'anthropic-b2', default_model: 'claude-opus-4-7' }),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data.label).toBe('anthropic-b2');
+		expect(body.data.default_model).toBe('claude-opus-4-7');
+
+		const list = await app.request('/api/ai-providers', { headers: authHeader(token) });
+		const row = (
+			(await list.json()).data as Array<{ id: string; label: string; default_model: string }>
+		).find((r) => r.id === secondId);
+		expect(row?.label).toBe('anthropic-b2');
+		expect(row?.default_model).toBe('claude-opus-4-7');
+	});
+
+	it('a label-only rename preserves default_model', async () => {
+		const res = await app.request(`/api/ai-providers/${secondId}`, {
+			method: 'PATCH',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ label: 'anthropic-b3' }),
+		});
+		expect(res.status).toBe(200);
+
+		const list = await app.request('/api/ai-providers', { headers: authHeader(token) });
+		const row = (
+			(await list.json()).data as Array<{ id: string; label: string; default_model: string }>
+		).find((r) => r.id === secondId);
+		expect(row?.label).toBe('anthropic-b3');
+		expect(row?.default_model).toBe('claude-opus-4-7');
+	});
+
+	it('returns 404 when renaming an unknown config', async () => {
+		const res = await app.request('/api/ai-providers/00000000-0000-0000-0000-000000000000', {
+			method: 'PATCH',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ label: 'ghost' }),
+		});
+		expect(res.status).toBe(404);
+	});
+
+	it('rejects non-superusers', async () => {
+		const res = await app.request(`/api/ai-providers/${firstId}`, {
+			method: 'PATCH',
+			headers: { ...authHeader(nonSuperuserToken), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ label: 'sneaky' }),
+		});
+		expect(res.status).toBe(403);
+	});
+});
+
 describe('AI providers models endpoint', () => {
 	let configId: string;
 

--- a/packages/web/src/components/ai-providers-section.tsx
+++ b/packages/web/src/components/ai-providers-section.tsx
@@ -1,5 +1,5 @@
 import { AI_PROVIDER_INFO, AiAuthMethod, type AiProvider } from '@hezo/shared';
-import { Loader2, Plus, ShieldCheck, Star, Trash2 } from 'lucide-react';
+import { Check, Loader2, Pencil, Plus, ShieldCheck, Star, Trash2, X } from 'lucide-react';
 import { useState } from 'react';
 import {
 	type AiProviderConfig,
@@ -55,7 +55,7 @@ export function AiProvidersSection() {
 			header: 'Name',
 			render: (c) => (
 				<span className="flex items-center gap-2">
-					<span className="font-mono text-[13px]">{c.label}</span>
+					<ProviderNameCell config={c} />
 					{c.is_default && providerCount(c.provider) > 1 && <Badge color="accent">Default</Badge>}
 				</span>
 			),
@@ -180,6 +180,102 @@ export function AiProvidersSection() {
 
 			<AddAiProviderDialog open={addOpen} onOpenChange={setAddOpen} />
 		</section>
+	);
+}
+
+function ProviderNameCell({ config }: { config: AiProviderConfig }) {
+	const [editing, setEditing] = useState(false);
+	const [value, setValue] = useState(config.label);
+	const update = useUpdateAiProviderConfig(config.id);
+
+	function startEditing() {
+		setValue(config.label);
+		setEditing(true);
+	}
+
+	function cancel() {
+		setEditing(false);
+		setValue(config.label);
+	}
+
+	async function submit() {
+		const trimmed = value.trim();
+		if (!trimmed || trimmed === config.label) {
+			cancel();
+			return;
+		}
+		try {
+			await update.mutateAsync({ label: trimmed });
+			setEditing(false);
+		} catch (e) {
+			// Keep the editor open so the user can fix the name (e.g. a duplicate).
+			toast.error(e instanceof Error ? e.message : 'Could not rename provider');
+		}
+	}
+
+	if (!editing) {
+		return (
+			<span className="flex items-center gap-1.5">
+				<span className="font-mono text-[13px]">{config.label}</span>
+				<Tooltip content="Rename">
+					<button
+						type="button"
+						onClick={startEditing}
+						aria-label={`Rename ${config.label}`}
+						className="text-text-3 hover:text-text-1"
+					>
+						<Pencil className="w-3 h-3" />
+					</button>
+				</Tooltip>
+			</span>
+		);
+	}
+
+	return (
+		<span className="flex items-center gap-1.5">
+			<input
+				value={value}
+				onChange={(e) => setValue(e.target.value)}
+				onKeyDown={(e) => {
+					if (e.key === 'Enter') {
+						e.preventDefault();
+						submit();
+					}
+					if (e.key === 'Escape') cancel();
+				}}
+				aria-label={`New name for ${config.label}`}
+				// biome-ignore lint/a11y/noAutofocus: user just clicked the edit icon — focus follows their action
+				autoFocus
+				disabled={update.isPending}
+				className="w-28 sm:w-36 rounded-md border border-border bg-surface-2 px-2 py-1 font-mono text-xs text-text-1 outline-none focus:border-border-strong disabled:opacity-50"
+			/>
+			<Tooltip content="Save">
+				<button
+					type="button"
+					onClick={submit}
+					aria-label={`Save name for ${config.label}`}
+					disabled={update.isPending}
+					className="text-text-3 hover:text-text-1 disabled:opacity-50"
+				>
+					{update.isPending ? (
+						<Loader2 className="w-3.5 h-3.5 animate-spin" />
+					) : (
+						<Check className="w-3.5 h-3.5" />
+					)}
+				</button>
+			</Tooltip>
+			<Tooltip content="Cancel">
+				<button
+					type="button"
+					onClick={cancel}
+					aria-label={`Cancel renaming ${config.label}`}
+					disabled={update.isPending}
+					className="text-text-3 hover:text-text-1 disabled:opacity-50"
+				>
+					<X className="w-3.5 h-3.5" />
+				</button>
+			</Tooltip>
+		</span>
 	);
 }
 

--- a/packages/web/src/hooks/use-ai-providers.ts
+++ b/packages/web/src/hooks/use-ai-providers.ts
@@ -94,8 +94,8 @@ export function useAiProviderModels(configId: string, options: { enabled?: boole
 
 export function useUpdateAiProviderConfig(configId: string) {
 	return useMutation({
-		mutationFn: (data: { default_model: string | null }) =>
-			api.patch<{ updated: boolean; default_model: string | null }>(
+		mutationFn: (data: { default_model?: string | null; label?: string }) =>
+			api.patch<{ updated: boolean; default_model?: string | null; label?: string }>(
 				`/api/ai-providers/${configId}`,
 				data,
 			),

--- a/packages/web/test/ai-providers.test.tsx
+++ b/packages/web/test/ai-providers.test.tsx
@@ -293,6 +293,66 @@ test('lists API key + Subscription rows for a provider and flips the default', a
 	);
 });
 
+test('renames a provider config in place from the table', async () => {
+	const { findByRole, findByText, getByRole, queryByText, user } = await renderApp({
+		initialPath: '/settings/ai-providers',
+		seed: async () => {
+			await clearAiProviders();
+			const res = await postProvider({
+				provider: 'anthropic',
+				api_key: 'sk-ant-rename-component',
+				label: 'anthropic-old-name',
+			});
+			expect(res.status).toBe(201);
+		},
+	});
+
+	await findByRole('heading', { name: 'AI providers' });
+	await findByText('anthropic-old-name');
+
+	await user.click(getByRole('button', { name: 'Rename anthropic-old-name' }));
+	const input = getByRole('textbox', {
+		name: 'New name for anthropic-old-name',
+	}) as HTMLInputElement;
+	// The editor opens pre-filled with the current name.
+	expect(input.value).toBe('anthropic-old-name');
+	fireEvent.change(input, { target: { value: 'anthropic-shiny' } });
+	await user.click(getByRole('button', { name: 'Save name for anthropic-old-name' }));
+
+	// The row re-renders under the new name once the refetch lands.
+	await findByText('anthropic-shiny', undefined, { timeout: 15_000 });
+	await waitFor(() => expect(queryByText('anthropic-old-name')).toBeNull());
+});
+
+test('cancelling a rename restores the read-only label unchanged', async () => {
+	const { findByRole, findByText, getByRole, queryByRole, user } = await renderApp({
+		initialPath: '/settings/ai-providers',
+		seed: async () => {
+			await clearAiProviders();
+			const res = await postProvider({
+				provider: 'anthropic',
+				api_key: 'sk-ant-rename-cancel',
+				label: 'anthropic-keep-name',
+			});
+			expect(res.status).toBe(201);
+		},
+	});
+
+	await findByRole('heading', { name: 'AI providers' });
+	await findByText('anthropic-keep-name');
+
+	await user.click(getByRole('button', { name: 'Rename anthropic-keep-name' }));
+	const input = getByRole('textbox', {
+		name: 'New name for anthropic-keep-name',
+	}) as HTMLInputElement;
+	fireEvent.change(input, { target: { value: 'discarded-edit' } });
+	await user.click(getByRole('button', { name: 'Cancel renaming anthropic-keep-name' }));
+
+	// Editor closes without saving; the original label still renders.
+	expect(queryByRole('textbox', { name: 'New name for anthropic-keep-name' })).toBeNull();
+	await findByText('anthropic-keep-name');
+});
+
 test('Add provider modal pre-fills a default name from the selected provider', async () => {
 	const { findByRole, getByRole, user } = await renderApp({
 		initialPath: '/settings/ai-providers',


### PR DESCRIPTION
## Summary

The AI providers settings table showed each config's name but offered no way to change it after creation. This adds a small pencil icon next to the name that swaps it for an in-place edit field with save/cancel buttons — Enter submits, Escape cancels.

**Web**
- `ProviderNameCell` in `ai-providers-section.tsx`: read-only label + pencil icon → inline input pre-filled with the current name, check (save) and X (cancel) buttons. Submitting an unchanged or empty value just closes the editor; a server rejection (e.g. duplicate name) surfaces as a toast and keeps the editor open.
- `useUpdateAiProviderConfig` now accepts `label` alongside `default_model` and invalidates/refetches on success (same strategy the default-model selector already uses, since the server validates uniqueness).

**Server**
- `PATCH /api/ai-providers/:configId` accepts `label` and/or `default_model` in one request, applied as a single atomic UPDATE (`updateAiProviderConfig` built on the existing `buildUpdateSet` helper, replacing the single-purpose `setProviderDefaultModel`).
- Label is trimmed and must be non-empty (400 `INVALID_REQUEST`); a name already used by another config of the same provider returns 409 `DUPLICATE` (backed by the existing `UNIQUE(provider, label)` constraint — same label across different providers stays allowed). Route remains admin-only.

No schema change; renames don't affect provider resolution (configs are resolved by provider/`is_default`, never by label).

## Tests

- **Server** (`test/ai-providers.test.ts`, 8 new): rename + trim reflected in the list, empty/whitespace label → 400, duplicate within provider → 409, same label across providers → 200, combined `label` + `default_model` patch, label-only rename preserves `default_model`, unknown config → 404, non-superuser → 403.
- **Web component** (`test/ai-providers.test.tsx`, 2 new): full rename flow through the real in-process backend (pencil → pre-filled input → save → row re-renders under the new name), and cancel restores the original label unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016UJmhjHjZ2Zg96C6kLcYYY