### PR TITLE
fix(web): open a tailored dialog for sub-task creation

### DIFF
--- a/packages/web/src/components/create-task-dialog.tsx
+++ b/packages/web/src/components/create-task-dialog.tsx
@@ -5,7 +5,7 @@ import { ChevronDown, Loader2, Maximize2, Minimize2 } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useAgents } from '../hooks/use-agents';
 import { useAllVisibleProjects, useProjectMeta } from '../hooks/use-projects';
-import { useCreateTask } from '../hooks/use-tasks';
+import { useCreateSubTask, useCreateTask } from '../hooks/use-tasks';
 import { MarkdownEditor } from './markdown-editor';
 import { Button } from './ui/button';
 import { DialogContent } from './ui/dialog';
@@ -18,6 +18,12 @@ interface CreateTaskDialogProps {
 	 *  `projectId` — used by the global mobile "+" so a task can be filed into any
 	 *  project. The picked project then drives the assignee list. */
 	selectProject?: boolean;
+	/** When set, the dialog creates a *sub-task* of this parent (identifier or
+	 *  UUID — both resolve server-side) instead of a top-level task. The project
+	 *  is fixed to the parent's, so `selectProject` doesn't apply. */
+	parentTaskId?: string;
+	/** Parent's display identifier (e.g. "OPS-12"), shown in the dialog title. */
+	parentIdentifier?: string;
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 }
@@ -25,6 +31,8 @@ interface CreateTaskDialogProps {
 export function CreateTaskDialog({
 	projectId,
 	selectProject,
+	parentTaskId,
+	parentIdentifier,
 	open,
 	onOpenChange,
 }: CreateTaskDialogProps) {
@@ -46,6 +54,11 @@ export function CreateTaskDialog({
 	const project = useProjectMeta(effectiveProjectId);
 	const { data: agents } = useAgents(effectiveProjectId);
 	const createTask = useCreateTask(effectiveProjectId);
+	// Both hooks are called unconditionally (rules of hooks). `useCreateSubTask`
+	// only builds a URL; it never fires unless `mutateAsync` is invoked below.
+	const createSubTask = useCreateSubTask(effectiveProjectId, parentTaskId ?? '');
+	const isSubTask = !!parentTaskId;
+	const activeMutation = isSubTask ? createSubTask : createTask;
 	const navigate = useNavigate();
 
 	// On open, seed the picker with the passed/active project (only when it's a
@@ -75,22 +88,33 @@ export function CreateTaskDialog({
 
 	async function handleSubmit(e: React.FormEvent) {
 		e.preventDefault();
-		const result = await createTask.mutateAsync({
+		const payload = {
 			title,
 			description: description || undefined,
 			assignee_id: assigneeId || undefined,
 			priority,
-		});
-		onOpenChange(false);
-		setTitle('');
-		setDescription('');
-		navigate({
-			to: '/projects/$projectId/tasks/$taskId',
-			params: {
-				projectId: result.project_slug ?? effectiveProjectId,
-				taskId: result.identifier.toLowerCase(),
-			},
-		});
+		};
+		try {
+			// Branch the call (not the mutation object) so each `mutateAsync` stays
+			// monomorphic — the two hooks have structurally different variables.
+			const result = isSubTask
+				? await createSubTask.mutateAsync(payload)
+				: await createTask.mutateAsync(payload);
+			onOpenChange(false);
+			setTitle('');
+			setDescription('');
+			setAssigneeId('');
+			navigate({
+				to: '/projects/$projectId/tasks/$taskId',
+				params: {
+					projectId: result.project_slug ?? effectiveProjectId,
+					taskId: result.identifier.toLowerCase(),
+				},
+			});
+		} catch {
+			// Surfaced inline via `activeMutation.error` — keep the dialog open so
+			// the user can correct and retry (e.g. the sub-task depth-cap error).
+		}
 	}
 
 	return (
@@ -114,14 +138,16 @@ export function CreateTaskDialog({
 				}
 			>
 				<Dialog.Title className="text-lg font-semibold mb-4 pr-16 shrink-0">
-					Create Task
+					{isSubTask
+						? `Create sub-task${parentIdentifier ? ` · ${parentIdentifier}` : ''}`
+						: 'Create Task'}
 				</Dialog.Title>
 
 				<form
 					onSubmit={handleSubmit}
 					className={fullscreen ? 'flex min-h-0 flex-1 flex-col gap-4' : 'flex flex-col gap-4'}
 				>
-					{selectProject && (
+					{selectProject && !isSubTask && (
 						<label className="flex flex-col gap-1.5">
 							<span className="text-sm text-text-2">Project *</span>
 							<select
@@ -211,9 +237,9 @@ export function CreateTaskDialog({
 						)}
 					</div>
 
-					{createTask.error && (
-						<p className="text-sm text-danger">
-							{(createTask.error as { message: string }).message}
+					{activeMutation.error && (
+						<p className="text-sm text-danger" data-testid="create-task-error">
+							{(activeMutation.error as { message: string }).message}
 						</p>
 					)}
 
@@ -223,9 +249,11 @@ export function CreateTaskDialog({
 						</Button>
 						<Button
 							type="submit"
-							disabled={!effectiveProjectId || !title.trim() || !assigneeId || createTask.isPending}
+							disabled={
+								!effectiveProjectId || !title.trim() || !assigneeId || activeMutation.isPending
+							}
 						>
-							{createTask.isPending && <Loader2 className="w-4 h-4 animate-spin" />}
+							{activeMutation.isPending && <Loader2 className="w-4 h-4 animate-spin" />}
 							Create
 						</Button>
 					</div>

--- a/packages/web/src/components/task-detail/sub-tasks-section.tsx
+++ b/packages/web/src/components/task-detail/sub-tasks-section.tsx
@@ -1,29 +1,30 @@
 import { Link } from '@tanstack/react-router';
 import { ChevronDown, Plus } from 'lucide-react';
 import { useState } from 'react';
-import { useCreateSubTask, useTasks } from '../../hooks/use-tasks';
+import { useTasks } from '../../hooks/use-tasks';
 import { DEFAULT_SUBTASK_PAGE_SIZE, useTeam } from '../../hooks/use-teams';
+import { CreateTaskDialog } from '../create-task-dialog';
 import { TaskRunDot } from '../task-run-dot';
 import { TaskStatusBadge } from '../task-status-badge';
-import { Button } from '../ui/button';
 
 interface SubTasksSectionProps {
 	projectId: string;
-	taskId: string;
 	parentTaskId: string;
+	/** Parent's display identifier (e.g. "OPS-12"), shown in the create dialog title. */
+	parentIdentifier: string;
 	taskProjectSlug: string;
 }
 
 /**
  * Collapsible "Sub-tasks" card: a list of direct children with status
- * badges plus an inline form to create new ones. Paginated client-side
- * by the team's `subtask_page_size` setting so very busy parents don't
- * blow up the layout.
+ * badges plus an "Add" button that opens the tailored create-task dialog
+ * (parent fixed, assignee required). Paginated client-side by the team's
+ * `subtask_page_size` setting so very busy parents don't blow up the layout.
  */
 export function SubTasksSection({
 	projectId,
-	taskId,
 	parentTaskId,
+	parentIdentifier,
 	taskProjectSlug,
 }: SubTasksSectionProps) {
 	const { data: team } = useTeam(projectId);
@@ -36,10 +37,7 @@ export function SubTasksSection({
 		parentTaskId ? { parent_task_id: parentTaskId, per_page: '200' } : undefined,
 		{ enabled: !!parentTaskId },
 	);
-	const createSubTask = useCreateSubTask(projectId, taskId);
-
-	const [subTaskTitle, setSubTaskTitle] = useState('');
-	const [showSubForm, setShowSubForm] = useState(false);
+	const [createOpen, setCreateOpen] = useState(false);
 	const [subTasksOpen, setSubTasksOpen] = useState(true);
 	const [subTasksShownState, setSubTasksShownState] = useState<{
 		taskId: string;
@@ -49,18 +47,6 @@ export function SubTasksSection({
 		subTasksShownState && subTasksShownState.taskId === parentTaskId
 			? subTasksShownState.count
 			: subTaskPageSize;
-
-	async function handleSubTask(e: React.FormEvent) {
-		e.preventDefault();
-		if (!subTaskTitle.trim()) return;
-		try {
-			await createSubTask.mutateAsync({ title: subTaskTitle });
-			setSubTaskTitle('');
-			setShowSubForm(false);
-		} catch {
-			// error rendered below the form via createSubTask.error
-		}
-	}
 
 	return (
 		<div
@@ -89,7 +75,7 @@ export function SubTasksSection({
 					type="button"
 					onClick={() => {
 						setSubTasksOpen(true);
-						setShowSubForm((s) => !s);
+						setCreateOpen(true);
 					}}
 					className="text-[11px] text-text-3 hover:text-text-1 flex items-center gap-1 cursor-pointer"
 					data-testid="sub-tasks-add"
@@ -102,29 +88,7 @@ export function SubTasksSection({
 					className="px-3 py-2.5 flex flex-col gap-1.5 border-t border-border"
 					data-testid="sub-tasks-list"
 				>
-					{showSubForm && (
-						<>
-							<form onSubmit={handleSubTask} className="flex gap-2 mb-1">
-								<input
-									value={subTaskTitle}
-									onChange={(e) => setSubTaskTitle(e.target.value)}
-									placeholder="Sub-task title"
-									className="flex-1 rounded-md border border-border bg-surface px-3 py-1.5 text-[13px] text-text-1 outline-none focus:border-border-strong"
-									data-testid="sub-task-title-input"
-								/>
-								<Button type="submit" size="sm" disabled={!subTaskTitle.trim()}>
-									Create
-								</Button>
-							</form>
-							{createSubTask.error && (
-								<div className="text-[12px] text-danger mb-1" data-testid="sub-task-error">
-									{(createSubTask.error as { message?: string }).message ??
-										'Failed to create sub-task'}
-								</div>
-							)}
-						</>
-					)}
-					{(subTasks?.data.length ?? 0) === 0 && !showSubForm && (
+					{(subTasks?.data.length ?? 0) === 0 && (
 						<span className="text-[13px] text-text-2">No sub-tasks.</span>
 					)}
 					{subTasks?.data.slice(0, subTasksShown).map((s) => (
@@ -167,6 +131,13 @@ export function SubTasksSection({
 					)}
 				</div>
 			)}
+			<CreateTaskDialog
+				projectId={projectId}
+				parentTaskId={parentTaskId}
+				parentIdentifier={parentIdentifier}
+				open={createOpen}
+				onOpenChange={setCreateOpen}
+			/>
 		</div>
 	);
 }

--- a/packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx
@@ -126,8 +126,8 @@ function TaskDetailPage() {
 
 					<SubTasksSection
 						projectId={projectId}
-						taskId={taskId}
 						parentTaskId={task.id}
+						parentIdentifier={task.identifier}
 						taskProjectSlug={taskProjectSlug}
 					/>
 

--- a/packages/web/test/task-detail.test.tsx
+++ b/packages/web/test/task-detail.test.tsx
@@ -26,11 +26,10 @@ async function createSubTask(
 }
 
 test('UI surfaces the depth-cap error when creating a sub-task under a depth-2 ticket', async () => {
-	let teamSlug = '';
 	let projectSlug = '';
 	let subSubIdentifier = '';
 
-	const { findByRole, findByTestId, user, router } = await renderApp({
+	const { findByRole, findByTestId, findByLabelText, findByText, user, router } = await renderApp({
 		initialPath: '/',
 		seed: async () => {
 			const ws = await seedWorkspace();
@@ -48,7 +47,6 @@ test('UI surfaces the depth-cap error when creating a sub-task under a depth-2 t
 				title: 'Depth Sub-Sub',
 				assignee_id: engineer.id,
 			});
-			teamSlug = ws.team.slug;
 			projectSlug = project.slug;
 			subSubIdentifier = subSub.identifier;
 		},
@@ -64,17 +62,36 @@ test('UI surfaces the depth-cap error when creating a sub-task under a depth-2 t
 
 	await findByRole('heading', { name: 'Depth Sub-Sub' });
 
-	const addButton = await findByTestId('sub-tasks-add');
-	await user.click(addButton);
+	// The inline quick-add is gone — "+ Add" now opens the tailored create-task
+	// dialog, which requires an assignee, so we must pick one to enable submit.
+	await user.click(await findByTestId('sub-tasks-add'));
 
-	const titleInput = await findByTestId('sub-task-title-input');
+	const titleInput = await findByLabelText('Title');
 	await user.type(titleInput, 'Should be rejected');
 
-	const createBtn = await findByRole('button', { name: 'Create' });
-	await user.click(createBtn);
+	// The dialog renders into a Radix portal on document.body; find the assignee
+	// select and pick its first real option (mirrors task-crud.test.tsx).
+	await waitFor(() => {
+		const optionsText = Array.from(document.body.querySelectorAll('option')).map(
+			(o) => o.textContent,
+		);
+		expect(optionsText).toContain('Select assignee');
+	});
+	const assigneeSel = Array.from(document.body.querySelectorAll('select')).find((s) =>
+		Array.from(s.options).some((o) => o.text === 'Select assignee'),
+	) as HTMLSelectElement;
+	await waitFor(() => {
+		expect(Array.from(assigneeSel.options).some((o) => o.value !== '')).toBe(true);
+	});
+	const firstAgent = Array.from(assigneeSel.options).find((o) => o.value !== '');
+	if (!firstAgent) throw new Error('expected an assignable agent option');
+	await user.selectOptions(assigneeSel, firstAgent.value);
 
-	const errorEl = await findByTestId('sub-task-error');
-	expect(errorEl.textContent).toMatch(/2 levels deep/);
+	await user.click(await findByRole('button', { name: 'Create' }));
+
+	// The server checks sub-task depth (services/tasks.ts) before the assignee,
+	// so it rejects with the depth-cap error and the dialog stays open to show it.
+	expect(await findByText(/2 levels deep/)).toBeTruthy();
 });
 
 test('canonical task URL is project-scoped; UUID and wrong-project forms redirect', async () => {

--- a/packages/web/test/task-sub-tasks.test.tsx
+++ b/packages/web/test/task-sub-tasks.test.tsx
@@ -225,3 +225,61 @@ test('sub-tasks card sits between the description card and the comments heading'
 		subTasksCard.compareDocumentPosition(commentsHeading) & Node.DOCUMENT_POSITION_FOLLOWING,
 	).toBeTruthy();
 });
+
+test('Add opens the tailored sub-task dialog; creating one (with assignee) navigates to it', async () => {
+	let projectSlug = '';
+	let parentIdentifier = '';
+
+	const { findByRole, findByTestId, findByLabelText, findByText, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const engineer = ws.agents.find((a) => a.slug === 'engineer') ?? ws.agents[0];
+			const project = await seedProject(ws, { name: 'Sub-Task Dialog Project' });
+			projectSlug = project.slug;
+			const parent = await seedTask(ws, project, {
+				title: 'Dialog Parent',
+				assignee_id: engineer.id,
+			});
+			parentIdentifier = parent.identifier;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: projectSlug, taskId: parentIdentifier.toLowerCase() },
+	});
+
+	await findByTestId('sub-tasks-toggle');
+
+	// "+ Add" opens the tailored create dialog — titled for the sub-task and
+	// carrying the parent's identifier, rather than the old inline title input.
+	await user.click(await findByTestId('sub-tasks-add'));
+	expect(await findByText(`Create sub-task · ${parentIdentifier}`)).toBeTruthy();
+
+	const titleInput = await findByLabelText('Title');
+	await user.type(titleInput, 'Dialog Child');
+
+	// Assignee is required now — collecting it is the fix for the title-only bug.
+	// The dialog is in a Radix portal on document.body; pick the first real option.
+	await waitFor(() => {
+		const optionsText = Array.from(document.body.querySelectorAll('option')).map(
+			(o) => o.textContent,
+		);
+		expect(optionsText).toContain('Select assignee');
+	});
+	const assigneeSel = Array.from(document.body.querySelectorAll('select')).find((s) =>
+		Array.from(s.options).some((o) => o.text === 'Select assignee'),
+	) as HTMLSelectElement;
+	await waitFor(() => {
+		expect(Array.from(assigneeSel.options).some((o) => o.value !== '')).toBe(true);
+	});
+	const firstAgent = Array.from(assigneeSel.options).find((o) => o.value !== '');
+	if (!firstAgent) throw new Error('expected an assignable agent option');
+	await user.selectOptions(assigneeSel, firstAgent.value);
+
+	await user.click(await findByRole('button', { name: 'Create' }));
+
+	// The server accepts it (assignee present) and we land on the new sub-task.
+	expect(await findByRole('heading', { name: 'Dialog Child' })).toBeTruthy();
+});


### PR DESCRIPTION
## Summary

Creating a sub-task from the **Sub-tasks** card was broken: the inline quick-add form sent only a title, but the server requires an assignee, so every attempt failed with **"Either assignee_id or assignee_slug is required"**.

This replaces the inline form with the existing **Create Task** dialog, parameterized for sub-tasks — so it collects an assignee and the failure goes away — while tailoring the UI to signal it's a sub-task.

## What changed

- **`create-task-dialog.tsx`** — `CreateTaskDialog` gains optional `parentTaskId` / `parentIdentifier` props. When `parentTaskId` is set (sub-task mode):
  - Posts through `useCreateSubTask` (project inherited from the parent) instead of `useCreateTask`; both hooks are instantiated unconditionally per rules-of-hooks, and only the `mutateAsync` call is branched so each stays type-monomorphic.
  - Title reads **`Create sub-task · <PARENT-ID>`**; the project picker is hidden.
  - `handleSubmit` is wrapped in `try/catch` so server rejections (e.g. the sub-task depth cap) surface inline and keep the dialog open, instead of becoming an unhandled rejection.
  - After success it navigates to the new sub-task, matching the top-level create flow.
- **`sub-tasks-section.tsx`** — "+ Add" now opens the dialog instead of the inline title-only form; the inline form, its title-only mutation, and the bespoke error row are removed. List, count badge, pagination, and collapse behavior are unchanged. The now-unused `taskId` prop was dropped in favor of the canonical `parentTaskId` (UUID).
- **`$taskId.tsx`** — threads the parent's real `task.identifier` down so the dialog title label is always clean (no cold-load UUID flash).

The other three `CreateTaskDialog` callers (app header, project sidebar, task list) are unaffected — with no `parentTaskId` the component behaves exactly as before.

## Testing

- Reworked the depth-cap test in `task-detail.test.tsx` to drive the new dialog (select assignee → submit → assert the "2 levels deep" error renders in-dialog).
- Added a create-flow test in `task-sub-tasks.test.tsx`: "+ Add" opens the tailored dialog, and creating a sub-task with an assignee now succeeds and navigates to the child.
- `bun run test --package web` — **959 tests across 159 files pass**. Full monorepo `typecheck` + build run green via the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019LdRsokG42hdDKwnTVdoqP