### PR TITLE
fix(web): use "Install & restart" label and readable overlay copy

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -1117,7 +1117,7 @@ section mirrors the banner's staged-update lifecycle **in place** — driven by
 `useUpdateStatus({ poll })`, which auto-refetches `GET /api/updates/status` every few seconds
 while the state is `checking`/`downloading`/`applying` so the section advances live without a
 reload: a self-applying instance shows **"Downloading new version…"** while staging, then an
-**"Install & update"** button (same restart confirmation) once `Staged`, or a **"Retry
+**"Install & restart"** button (same restart confirmation) once `Staged`, or a **"Retry
 download"** on `Error`; an instance that can't self-apply falls back to the **"Download"**
 release link.
 

--- a/packages/web/src/components/update-restart-overlay.tsx
+++ b/packages/web/src/components/update-restart-overlay.tsx
@@ -42,20 +42,26 @@ export function UpdateRestartOverlay({ targetVersion }: { targetVersion: string 
 		};
 	}, []);
 
+	// The scrim (`--overlay`) is a dark, semi-transparent dim in both themes, so
+	// text rendered directly on it washes out in light mode. Mirror every other
+	// overlay consumer (dialogs/drawers) and float the copy in a `bg-surface` card
+	// so `text-1`/`text-2` keep their intended contrast in both themes.
 	return (
 		<div
 			data-testid="update-restart-overlay"
-			className="fixed inset-0 z-[100] flex flex-col items-center justify-center gap-4 bg-[var(--overlay)] backdrop-blur-sm p-6 text-center"
+			className="fixed inset-0 z-[100] flex items-center justify-center bg-[var(--overlay)] backdrop-blur-sm p-4 sm:p-6"
 		>
-			<Loader2 className="w-8 h-8 animate-spin text-text-1" />
-			<div className="text-base font-semibold text-text-1">
-				{reachableAgain ? 'Reloading…' : 'Updating Hezo…'}
+			<div className="flex w-full max-w-sm flex-col items-center gap-4 rounded-lg border border-border bg-surface p-6 text-center shadow-lg sm:p-8">
+				<Loader2 className="w-8 h-8 animate-spin text-text-1" />
+				<div className="text-base font-semibold text-text-1">
+					{reachableAgain ? 'Reloading…' : 'Updating Hezo…'}
+				</div>
+				<p className="text-[13px] text-text-2 leading-relaxed">
+					{targetVersion ? `Restarting onto ${targetVersion}. ` : 'Restarting. '}
+					In-flight agent runs are paused and resume automatically. When Hezo comes back you'll need
+					your 12-word master key to unlock it again.
+				</p>
 			</div>
-			<p className="max-w-sm text-[13px] text-text-2 leading-relaxed">
-				{targetVersion ? `Restarting onto ${targetVersion}. ` : 'Restarting. '}
-				In-flight agent runs are paused and resume automatically. When Hezo comes back you'll need
-				your 12-word master key to unlock it again.
-			</p>
 		</div>
 	);
 }

--- a/packages/web/src/components/version-display.tsx
+++ b/packages/web/src/components/version-display.tsx
@@ -26,7 +26,7 @@ const RELEASES_URL = 'https://github.com/hezo-ai/hezo/releases';
  * in place — surfacing the live staged-update lifecycle. On a self-applying
  * instance (supervised compiled binary) for a superuser it shows "Downloading new
  * version…" while the background download/verify/stage runs, then flips to an
- * "Install & update" button (with the same restart confirmation) once staged, or a
+ * "Install & restart" button (with the same restart confirmation) once staged, or a
  * "Retry download" if staging errored. Any instance that can't update in place
  * falls back to a "Download" link to the GitHub release. `useUpdateStatus({ poll })`
  * refetches while a download is in flight so the transition is live, no reload.
@@ -147,7 +147,7 @@ export function VersionDisplay() {
 									data-testid="settings-version-install"
 									onClick={() => setConfirmOpen(true)}
 								>
-									Install &amp; update
+									Install &amp; restart
 								</Button>
 							) : canApply && errored ? (
 								<>

--- a/packages/web/test/settings-version.test.tsx
+++ b/packages/web/test/settings-version.test.tsx
@@ -133,13 +133,13 @@ test('an available update on a self-applying instance shows "Downloading new ver
 	}
 });
 
-test('a staged update on a self-applying instance shows an "Install & update" button', () => {
+test('a staged update on a self-applying instance shows an "Install & restart" button', () => {
 	const { getByTestId } = renderVersion({ state: UpdateState.Staged });
-	expect(getByTestId('settings-version-install').textContent).toContain('Install');
+	expect(getByTestId('settings-version-install').textContent).toContain('Install & restart');
 	expect(getByTestId('settings-version-result').textContent).toContain('0.2.0');
 });
 
-test('Install & update asks for confirmation (with master-key warning) then applies', async () => {
+test('Install & restart asks for confirmation (with master-key warning) then applies', async () => {
 	const user = userEvent.setup();
 	const postSpy = vi
 		.spyOn(api, 'post')


### PR DESCRIPTION
## What & why

Two small update-flow UI fixes reported from the update screens.

### 1. Inconsistent button label
The Settings → **Version** section labelled its staged-update action **"Install & update"**, while the top-of-shell update banner and the confirmation dialog both say **"Install & restart"**. The action does the same thing everywhere (shut down and restart onto the new binary), so the odd label out is now **"Install & restart"** for consistency.

### 2. Washed-out text on the restart overlay
The full-screen "Updating Hezo…" overlay rendered its copy **directly on the `--overlay` scrim**. Every *other* overlay consumer (dialogs, drawers) floats its content in a `bg-surface` card above the scrim — this one didn't. In light mode the scrim is a medium tone, so the mid-gray `text-2` body copy had almost no contrast against it and was barely legible (the darker `text-1` title survived, which is why only the body looked broken).

Fix: float the spinner + copy in a `bg-surface` card (mirroring the dialog pattern) so `text-1`/`text-2` keep their intended contrast in **both** themes.

## Changes
- `packages/web/src/components/version-display.tsx` — button label + doc comment → "Install & restart".
- `packages/web/src/components/update-restart-overlay.tsx` — wrap spinner + copy in a responsive `bg-surface` card.
- `packages/web/test/settings-version.test.tsx` — update the two test titles and tighten the assertion to check the exact new label.
- `.dev/architecture.md` — sync the button name.

## Testing
- `packages/web` — `settings-version.test.tsx` (10) and `update-banner.test.tsx` (14) pass.
- `tsc --noEmit` on `packages/web` is clean; Biome is clean on the changed files.
- Verified the contrast fix visually by rendering a before/after mockup with the real light-mode `oklch` tokens: the old bare-on-scrim copy washes out; the new surface card renders it at full contrast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kx8v5taJNztxbvo9Vf64NL