### PR TITLE
feat(web): filterable Add-to-task picker in the action review dialog

### DIFF
--- a/docs/concepts/documents-and-memory.md
+++ b/docs/concepts/documents-and-memory.md
@@ -131,8 +131,9 @@ delete actions **stay pinned to the top while you scroll**, so they're always in
 document. The toolbar shows a comment count — **click the count to jump to the first comment** —
 plus two actions: **action this review** (a clipboard button that opens a ready-made handoff you
 can copy and paste into a task comment or a new task's description when assigning the work to an
-agent — and, when you're reviewing a document from a task's preview panel, an **Add to \<task\>**
-button posts the handoff straight onto that task as a comment) and
+agent — or post directly with the **Add to task** button, which opens a filterable list of the
+project's tasks and adds the handoff to the one you pick as a comment; when you're reviewing a
+document from a task's preview panel, that task is suggested first) and
 **clear review** (a trash button that deletes every comment after confirmation), alongside a
 **?** button that opens a short in-app guide to all of this.
 
@@ -143,8 +144,9 @@ document already take turns filling the screen.)
 
 Agents read pending review comments directly: `read_project_doc` returns them alongside the
 document content, each one anchored to the exact text you highlighted. So the flow is —
-leave your comments, hand the review to an agent (add the handoff to the task with one click
-from a task's document preview, or paste the copied handoff into any task and assign it), and
+leave your comments, hand the review to an agent (pick the task from the **Add to task** list —
+the task you're viewing comes first when you review from a task's document preview — or paste
+the copied handoff into any task and assign it), and
 the agent actions each comment against the document.
 
 **A review applies to the current version of the document only.** Any update to the

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -150,7 +150,9 @@ tasksRoutes.get('/projects/:projectId/tasks', async (c) => {
 
 	const search = c.req.query('search');
 	if (search) {
-		conditions.push(`(i.title ILIKE $${idx} OR i.description ILIKE $${idx})`);
+		conditions.push(
+			`(i.title ILIKE $${idx} OR i.description ILIKE $${idx} OR i.identifier ILIKE $${idx})`,
+		);
 		params.push(`%${search}%`);
 		idx++;
 	}

--- a/packages/server/test/tasks-coverage.test.ts
+++ b/packages/server/test/tasks-coverage.test.ts
@@ -146,6 +146,17 @@ describe('GET /tasks list filters', () => {
 		expect(data[0].title).toContain('Zxyzzy');
 	});
 
+	it('filters by search on the task identifier', async () => {
+		const task = await createTask('Identifier-search target');
+		const res = await app.request(
+			`/api/projects/${projectSlug}/tasks?search=${task.identifier.toLowerCase()}`,
+			{ headers: authHeader(token) },
+		);
+		expect(res.status).toBe(200);
+		const data = (await res.json()).data;
+		expect(data.map((t: { id: string }) => t.id)).toContain(task.id);
+	});
+
 	it('ignores an assignee_id filter that is only whitespace/commas', async () => {
 		// The split/trim/filter leaves no ids, so no IN clause is added (the
 		// `ids.length > 0` branch is skipped) and all tasks come back.

--- a/packages/web/src/components/document-review/action-review-dialog.tsx
+++ b/packages/web/src/components/document-review/action-review-dialog.tsx
@@ -1,49 +1,61 @@
 import * as Dialog from '@radix-ui/react-dialog';
-import { Copy, Loader2 } from 'lucide-react';
-import { useCreateComment } from '../../hooks/use-comments';
+import { Copy } from 'lucide-react';
+import { useState } from 'react';
+import { useCreateCommentOnTask } from '../../hooks/use-comments';
 import { toast } from '../../hooks/use-toast';
 import { copyToClipboard } from '../../lib/clipboard';
 import { Button } from '../ui/button';
 import { DialogContent } from '../ui/dialog';
+import { AddToTaskPicker } from './add-to-task-picker';
 import { buildReviewHandoff } from './review-handoff';
 
-/** Task context for the "Add to <ID>" action — present only when the dialog is opened from a task view. */
+/** Task context when the dialog is opened from a task view — pins that task first in the picker. */
 export interface ReviewTaskContext {
 	/** Route-param project slug (API path + query keys). */
 	projectId: string;
 	/** Route-param task id (lowercase identifier) — API path + query keys. */
 	taskId: string;
-	/** Uppercase display identifier, e.g. "HM-31" — the button label. */
+	/** Uppercase display identifier, e.g. "HM-31". */
 	identifier: string;
+	/** Task title for the picker's pinned row. */
+	title?: string;
 }
 
 interface ActionReviewDialogProps {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
+	/** Route-param project slug — scopes the "Add to task" picker's task list. */
+	projectId: string;
 	filename: string;
 	commentCount: number;
-	/** When set, renders "Add to <identifier>" which posts the handoff as a comment on that task. */
+	/** When set, the picker pins this task as its first entry. */
 	task?: ReviewTaskContext;
 }
 
 /**
  * "Action this review": hands the pending review to an agent. Shows the
- * admin-facing instructions and the handoff blurb — copyable everywhere, and
- * postable straight onto the hosting task as a comment when opened from a task
- * view. The review comments themselves stay in the database (agents read them
- * via read_project_doc). Either action closes the dialog on success.
+ * admin-facing instructions and the handoff blurb — copyable, or postable as a
+ * comment onto any of the project's tasks via the "Add to task" picker (the
+ * hosting task leads the list when opened from a task view). The review
+ * comments themselves stay in the database (agents read them via
+ * read_project_doc). Either action closes the dialog on success.
  */
 export function ActionReviewDialog({
 	open,
 	onOpenChange,
+	projectId,
 	filename,
 	commentCount,
 	task,
 }: ActionReviewDialogProps) {
 	const handoff = buildReviewHandoff(filename);
-	// Inert until fired — the Add button only renders (and handleAdd only runs)
-	// when `task` is set, so the empty-string fallback never reaches the API.
-	const createComment = useCreateComment(task?.projectId ?? '', task?.taskId ?? '');
+	const createComment = useCreateCommentOnTask(projectId);
+	const [pickerOpen, setPickerOpen] = useState(false);
+
+	function handleOpenChange(next: boolean) {
+		if (!next) setPickerOpen(false);
+		onOpenChange(next);
+	}
 
 	async function handleCopy() {
 		const ok = await copyToClipboard(handoff);
@@ -51,29 +63,40 @@ export function ActionReviewDialog({
 			toast.error('Failed to copy to clipboard');
 			return;
 		}
-		onOpenChange(false);
+		handleOpenChange(false);
 	}
 
-	async function handleAdd() {
-		if (!task) return;
+	async function handleAdd(target: { taskId: string; identifier: string }) {
 		try {
-			await createComment.mutateAsync({ content: handoff });
-			onOpenChange(false);
+			await createComment.mutateAsync({ taskId: target.taskId, content: handoff });
+			handleOpenChange(false);
 		} catch (e) {
+			// Close only the picker — the dialog stays so the handoff isn't lost.
+			setPickerOpen(false);
 			toast.error((e as Error).message || 'Failed to add comment');
 		}
 	}
 
 	return (
-		<Dialog.Root open={open} onOpenChange={onOpenChange}>
-			<DialogContent size="md" data-testid="action-review-dialog">
+		<Dialog.Root open={open} onOpenChange={handleOpenChange}>
+			<DialogContent
+				size="md"
+				data-testid="action-review-dialog"
+				onEscapeKeyDown={(e) => {
+					// Escape with the picker open closes just the picker.
+					if (pickerOpen) {
+						e.preventDefault();
+						setPickerOpen(false);
+					}
+				}}
+			>
 				<Dialog.Title className="mb-3 pr-8 text-base font-semibold">
 					Action this review
 				</Dialog.Title>
 				<Dialog.Description className="mb-3 text-[12.5px] leading-relaxed text-text-2">
-					{task
-						? `Add this handoff as a comment on ${task.identifier} — or copy it for another task — and assign it to the agent who should action the feedback. The agent reads the review comments directly from the document.`
-						: "Paste this handoff into a task comment — or a new task's description — and assign it to the agent who should action the feedback. The agent reads the review comments directly from the document."}
+					Add this handoff as a comment on a task — pick one from Add to task, or copy it — and
+					assign it to the agent who should action the feedback. The agent reads the review comments
+					directly from the document.
 				</Dialog.Description>
 				<div
 					className="whitespace-pre-wrap rounded-md border border-border bg-surface-2 p-3 text-[12.5px] leading-relaxed text-text-1"
@@ -85,12 +108,12 @@ export function ActionReviewDialog({
 					{commentCount} comment{commentCount === 1 ? '' : 's'} · {filename}
 				</div>
 				<div
-					className={`mt-3 flex items-center gap-2 ${task ? 'justify-between' : 'justify-center'}`}
+					className="mt-3 flex items-center justify-between gap-2"
 					data-testid="action-review-footer"
 				>
 					<Button
 						size="sm"
-						variant={task ? 'secondary' : 'primary'}
+						variant="secondary"
 						onClick={handleCopy}
 						aria-label="Copy handoff"
 						data-testid="action-review-copy"
@@ -98,18 +121,17 @@ export function ActionReviewDialog({
 						<Copy className="h-3 w-3" />
 						Copy
 					</Button>
-					{task && (
-						<Button
-							size="sm"
-							onClick={handleAdd}
-							disabled={createComment.isPending}
-							aria-label={`Add to ${task.identifier}`}
-							data-testid="action-review-add"
-						>
-							{createComment.isPending && <Loader2 className="h-3 w-3 animate-spin" />}
-							Add to {task.identifier}
-						</Button>
-					)}
+					<AddToTaskPicker
+						projectId={projectId}
+						currentTask={task}
+						open={pickerOpen}
+						onOpenChange={setPickerOpen}
+						pending={createComment.isPending}
+						pendingTaskId={
+							createComment.isPending ? (createComment.variables?.taskId ?? null) : null
+						}
+						onSelect={handleAdd}
+					/>
 				</div>
 			</DialogContent>
 		</Dialog.Root>

--- a/packages/web/src/components/document-review/add-to-task-picker.tsx
+++ b/packages/web/src/components/document-review/add-to-task-picker.tsx
@@ -1,0 +1,240 @@
+import { Hash, Loader2 } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useTasks } from '../../hooks/use-tasks';
+import { Button } from '../ui/button';
+import type { ReviewTaskContext } from './action-review-dialog';
+
+interface TaskRow {
+	/** Lowercase identifier — the `:taskId` API path segment. */
+	taskId: string;
+	identifier: string;
+	title: string;
+	status: string | null;
+	isCurrent: boolean;
+}
+
+interface AddToTaskPickerProps {
+	/** Route-param project slug (query keys + API paths). */
+	projectId: string;
+	/** The hosting task when the dialog was opened from a task view — pinned first in the list. */
+	currentTask?: ReviewTaskContext;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	/** Disables the trigger and rows while a post is in flight. */
+	pending: boolean;
+	/** Lowercase id of the in-flight target — puts the spinner on that row. */
+	pendingTaskId: string | null;
+	onSelect: (target: { taskId: string; identifier: string }) => void;
+}
+
+/**
+ * "Add to task": a filterable dropdown of the project's tasks, opened from the
+ * action-review dialog's footer. Hand-rolled absolute panel (MentionPicker
+ * style) rather than a body-portaled popover — the trigger already sits inside
+ * a modal dialog, and the panel opens upward so it never crosses the dialog's
+ * scroll edge. Selecting a row posts the handoff to that task immediately.
+ */
+export function AddToTaskPicker({
+	projectId,
+	currentTask,
+	open,
+	onOpenChange,
+	pending,
+	pendingTaskId,
+	onSelect,
+}: AddToTaskPickerProps) {
+	const [query, setQuery] = useState('');
+	const [debouncedQuery, setDebouncedQuery] = useState('');
+	const [highlightedIndex, setHighlightedIndex] = useState(0);
+	const listRef = useRef<HTMLDivElement>(null);
+
+	// Fresh filter on every open.
+	useEffect(() => {
+		if (!open) return;
+		setQuery('');
+		setDebouncedQuery('');
+		setHighlightedIndex(0);
+	}, [open]);
+
+	useEffect(() => {
+		if (!open) return;
+		const id = setTimeout(() => setDebouncedQuery(query), 150);
+		return () => clearTimeout(id);
+	}, [query, open]);
+
+	const { data, isFetching } = useTasks(
+		projectId,
+		{ search: debouncedQuery || undefined, per_page: '20', sort: 'updated_at:desc' },
+		{ enabled: open },
+	);
+
+	const rows = useMemo<TaskRow[]>(() => {
+		const fetched = data?.data ?? [];
+		const isCurrent = (identifier: string) => identifier.toLowerCase() === currentTask?.taskId;
+		const rest: TaskRow[] = fetched
+			.filter((t) => !isCurrent(t.identifier))
+			.map((t) => ({
+				taskId: t.identifier.toLowerCase(),
+				identifier: t.identifier,
+				title: t.title,
+				status: t.status,
+				isCurrent: false,
+			}));
+		if (!currentTask) return rest;
+		const fetchedCurrent = fetched.find((t) => isCurrent(t.identifier));
+		// Pinned first row: with no filter it's synthesized from the context (so
+		// it leads even when outside the server page); with a filter it appears
+		// only if the search matched it.
+		if (!debouncedQuery || fetchedCurrent) {
+			return [
+				{
+					taskId: currentTask.taskId,
+					identifier: currentTask.identifier,
+					title: fetchedCurrent?.title ?? currentTask.title ?? currentTask.identifier,
+					status: fetchedCurrent?.status ?? null,
+					isCurrent: true,
+				},
+				...rest,
+			];
+		}
+		return rest;
+	}, [data, currentTask, debouncedQuery]);
+
+	useEffect(() => {
+		if (highlightedIndex >= rows.length) setHighlightedIndex(0);
+	}, [rows, highlightedIndex]);
+
+	useEffect(() => {
+		const el = listRef.current?.querySelector<HTMLElement>(`[data-task-idx="${highlightedIndex}"]`);
+		if (el) el.scrollIntoView({ block: 'nearest' });
+	}, [highlightedIndex]);
+
+	// Tracks the blur-close timer so we can cancel it on unmount. Without this
+	// the timer fires after the component is gone — in happy-dom teardown that
+	// throws "window is not defined" and breaks the test scheduled right after.
+	const blurTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	useEffect(() => {
+		return () => {
+			if (blurTimerRef.current !== null) {
+				clearTimeout(blurTimerRef.current);
+				blurTimerRef.current = null;
+			}
+		};
+	}, []);
+
+	function handleBlur() {
+		if (blurTimerRef.current !== null) clearTimeout(blurTimerRef.current);
+		blurTimerRef.current = setTimeout(() => {
+			blurTimerRef.current = null;
+			onOpenChange(false);
+		}, 100);
+	}
+
+	function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+		if (e.key === 'Escape') {
+			e.preventDefault();
+			e.stopPropagation();
+			onOpenChange(false);
+			return;
+		}
+		if (rows.length === 0) return;
+		if (e.key === 'ArrowDown') {
+			e.preventDefault();
+			setHighlightedIndex((i) => (i + 1) % rows.length);
+		} else if (e.key === 'ArrowUp') {
+			e.preventDefault();
+			setHighlightedIndex((i) => (i - 1 + rows.length) % rows.length);
+		} else if (e.key === 'Enter') {
+			e.preventDefault();
+			const row = rows[highlightedIndex] ?? rows[0];
+			if (!pending) onSelect({ taskId: row.taskId, identifier: row.identifier });
+		}
+	}
+
+	return (
+		<div className="relative">
+			<Button
+				size="sm"
+				onClick={() => onOpenChange(!open)}
+				disabled={pending}
+				aria-label="Add to task"
+				aria-haspopup="listbox"
+				aria-expanded={open}
+				data-testid="action-review-add"
+			>
+				{pending && <Loader2 className="h-3 w-3 animate-spin" />}
+				Add to task…
+			</Button>
+			{open && (
+				<div
+					className="absolute bottom-full right-0 z-10 mb-1 w-72 max-w-[calc(100vw-3rem)] rounded-md border border-border bg-surface shadow-md"
+					data-testid="add-to-task-picker"
+				>
+					<input
+						// biome-ignore lint/a11y/noAutofocus: the picker is an on-demand filter popup — focus lands in the filter by design
+						autoFocus
+						value={query}
+						onChange={(e) => setQuery(e.target.value)}
+						onKeyDown={handleKeyDown}
+						onBlur={handleBlur}
+						placeholder="Filter tasks…"
+						aria-label="Filter tasks"
+						data-testid="add-to-task-filter"
+						className="w-full border-b border-border bg-transparent px-3 py-2 text-[13px] text-text-1 outline-none placeholder:text-text-3"
+					/>
+					<div ref={listRef} role="listbox" className="max-h-56 overflow-y-auto p-1">
+						{isFetching && rows.length === 0 && (
+							<div className="px-3 py-2 text-xs text-text-2">Searching…</div>
+						)}
+						{!isFetching && rows.length === 0 && (
+							<div className="px-3 py-2 text-xs text-text-2">
+								{debouncedQuery
+									? `No tasks matching "${debouncedQuery}"`
+									: 'No tasks in this project'}
+							</div>
+						)}
+						{rows.map((row, idx) => (
+							<button
+								key={row.taskId}
+								type="button"
+								role="option"
+								aria-selected={idx === highlightedIndex}
+								disabled={pending}
+								data-task-idx={idx}
+								data-task-id={row.taskId}
+								data-testid={row.isCurrent ? 'add-to-task-current' : 'add-to-task-option'}
+								onMouseDown={(e) => {
+									// Keep focus in the filter input so blur doesn't close first.
+									e.preventDefault();
+									if (!pending) onSelect({ taskId: row.taskId, identifier: row.identifier });
+								}}
+								onMouseEnter={() => setHighlightedIndex(idx)}
+								className={`flex w-full items-center gap-2 rounded px-3 py-1.5 text-left text-[13px] disabled:opacity-60 ${
+									idx === highlightedIndex ? 'bg-surface-2' : ''
+								}`}
+							>
+								{pendingTaskId === row.taskId ? (
+									<Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-text-2" />
+								) : (
+									<Hash className="h-3.5 w-3.5 shrink-0 text-text-2" />
+								)}
+								<div className="flex min-w-0 flex-1 flex-col">
+									<span className="truncate text-text-1">{row.title}</span>
+									<span className="truncate text-[11px] text-text-3">
+										{row.identifier}
+										{row.status ? ` · ${row.status.replace(/_/g, ' ')}` : ''}
+									</span>
+								</div>
+								{row.isCurrent && (
+									<span className="ml-2 shrink-0 text-[10px] uppercase tracking-wider text-text-3">
+										Current task
+									</span>
+								)}
+							</button>
+						))}
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/packages/web/src/components/document-review/review-help.tsx
+++ b/packages/web/src/components/document-review/review-help.tsx
@@ -28,8 +28,9 @@ export function ReviewHelp({ className }: { className?: string }) {
 					<strong>Click a highlight</strong> (or its margin icon) to edit or delete that comment.
 				</li>
 				<li>
-					The <strong>clipboard button</strong> copies a handoff you can paste into a task — agents
-					read the comments directly from the document.
+					The <strong>clipboard button</strong> opens a handoff you can copy — or post straight onto
+					a task you pick from the <strong>Add to task</strong> list — agents read the comments
+					directly from the document.
 				</li>
 				<li>
 					The <strong>trash button</strong> clears the entire review.

--- a/packages/web/src/components/document-review/review-toolbar-actions.tsx
+++ b/packages/web/src/components/document-review/review-toolbar-actions.tsx
@@ -10,7 +10,7 @@ interface ReviewToolbarActionsProps {
 	/** Route-param project slug (query keys + API paths). */
 	projectId: string;
 	filename: string;
-	/** Task context when this toolbar renders inside a task view — enables "Add to <ID>" in the action dialog. */
+	/** Task context when this toolbar renders inside a task view — pins that task first in the action dialog's "Add to task" picker. */
 	task?: ReviewTaskContext;
 	/**
 	 * `'grouped'` (default) wraps the controls in a tinted, rounded container so
@@ -103,6 +103,7 @@ export function ReviewToolbarActions({
 			<ActionReviewDialog
 				open={actionOpen}
 				onOpenChange={setActionOpen}
+				projectId={projectId}
 				filename={filename}
 				commentCount={count}
 				task={task}

--- a/packages/web/src/components/task-detail/preview-panel.tsx
+++ b/packages/web/src/components/task-detail/preview-panel.tsx
@@ -17,7 +17,7 @@ function formatBytes(bytes?: number): string {
 interface PreviewPanelProps {
 	item: PreviewItem;
 	onClose: () => void;
-	/** The hosting task (task-detail surface only) — threads through to the review dialog's "Add to <ID>". */
+	/** The hosting task (task-detail surface only) — pinned first in the review dialog's "Add to task" picker. */
 	task?: ReviewTaskContext;
 }
 

--- a/packages/web/src/hooks/use-comments.ts
+++ b/packages/web/src/hooks/use-comments.ts
@@ -81,6 +81,31 @@ export function useCreateComment(projectId: string, taskId: string) {
 	});
 }
 
+/**
+ * Create a comment on a task chosen at call time (e.g. the action-review
+ * "Add to task" picker). Same cache handling as `useCreateComment`, but the
+ * target task travels in the mutation variables instead of the hook args.
+ */
+export function useCreateCommentOnTask(projectId: string) {
+	return useMutation({
+		mutationFn: ({ taskId, content }: { taskId: string; content: string }) =>
+			api.post<Comment>(`/api/projects/${projectId}/tasks/${taskId}/comments`, { content }),
+		onSuccess: (created, { taskId }) => {
+			queryClient.setQueryData<Comment[]>(
+				queryKeys.projects.taskComments(projectId, taskId),
+				(old) => {
+					if (!old) return [created];
+					if (old.some((c) => c.id === created.id)) return old;
+					return [...old, created];
+				},
+			);
+			queryClient.invalidateQueries({
+				queryKey: queryKeys.projects.taskComments(projectId, taskId),
+			});
+		},
+	});
+}
+
 export interface ReactionMutationResponse {
 	comment_id: string;
 	kind: string;

--- a/packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx
@@ -216,7 +216,7 @@ function TaskDetailPage() {
 				<PreviewPanel
 					item={preview}
 					onClose={() => setPreview(null)}
-					task={{ projectId, taskId, identifier: task.identifier }}
+					task={{ projectId, taskId, identifier: task.identifier, title: task.title }}
 				/>
 			)}
 		</div>

--- a/packages/web/test/action-review-add-to-task.test.tsx
+++ b/packages/web/test/action-review-add-to-task.test.tsx
@@ -1,0 +1,293 @@
+import { waitFor } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { buildReviewHandoff } from '../src/components/document-review/review-handoff';
+import { renderApp } from './helpers/render';
+import {
+	seedComment,
+	seedDocument,
+	seedProject,
+	seedReviewComment,
+	seedTask,
+	seedWorkspace,
+} from './helpers/seed';
+
+// The action-review dialog's "Add to task…" picker: available on task-less
+// surfaces (here the standalone /preview route), filterable via its text
+// input, keyboard-navigable, and — when opened from a task view — pinning the
+// hosting task as the first entry exactly once.
+
+const DOC_CONTENT = ['# Product Requirements', '', 'An unmistakable document body.'].join('\n');
+
+interface SeedRef {
+	projectSlug: string;
+	tasks: Array<{ taskId: string; identifier: string; title: string }>;
+}
+
+/** Seed a reviewed doc + `titles.length` tasks, then open the action dialog on the standalone preview route. */
+async function openActionDialogFromPreview(titles: string[]) {
+	const ref: SeedRef = { projectSlug: '', tasks: [] };
+	const utils = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Picker Project' });
+			await seedDocument(ws, project, { filename: 'prd.md', content: DOC_CONTENT });
+			await seedReviewComment(ws, project, 'prd.md', {
+				quote: 'unmistakable document body',
+				comment: 'Tighten this sentence',
+			});
+			for (const title of titles) {
+				const task = await seedTask(ws, project, { title });
+				ref.tasks.push({
+					taskId: task.identifier.toLowerCase(),
+					identifier: task.identifier,
+					title,
+				});
+			}
+			ref.projectSlug = project.slug;
+		},
+	});
+
+	await utils.router.navigate({
+		to: '/preview/$projectId/$filename',
+		params: { projectId: ref.projectSlug, filename: 'prd.md' },
+	});
+
+	await utils.findByTestId('review-count-chip', undefined, { timeout: 15_000 });
+	await utils.user.click(await utils.findByTestId('review-action-open'));
+	const add = await waitFor(() => {
+		const el = document.body.querySelector('[data-testid="action-review-add"]');
+		expect(el).toBeTruthy();
+		return el as HTMLElement;
+	});
+	return { ...utils, ...ref, add };
+}
+
+function filterInput(): HTMLInputElement {
+	return document.body.querySelector('[data-testid="add-to-task-filter"]') as HTMLInputElement;
+}
+
+function optionRows(): HTMLElement[] {
+	return Array.from(
+		document.body.querySelectorAll<HTMLElement>(
+			'[data-testid="add-to-task-option"], [data-testid="add-to-task-current"]',
+		),
+	);
+}
+
+/** Wrap fetch to capture POST .../comments payloads without blocking them. */
+function spyOnCommentPosts() {
+	const original = globalThis.fetch;
+	const posts: Array<{ url: string; body: Record<string, unknown> }> = [];
+	globalThis.fetch = Object.assign(async (input: RequestInfo | URL, init?: RequestInit) => {
+		const url = typeof input === 'string' ? input : input.toString();
+		if (
+			init?.method === 'POST' &&
+			/\/tasks\/[^/]+\/comments$/.test(url) &&
+			typeof init.body === 'string'
+		) {
+			try {
+				posts.push({ url, body: JSON.parse(init.body) as Record<string, unknown> });
+			} catch {}
+		}
+		return original(input, init);
+	}, original);
+	return {
+		posts,
+		restore: () => {
+			globalThis.fetch = original;
+		},
+	};
+}
+
+test('task-less surface: picker lists tasks with no pinned entry, filters, and posts to the chosen task', async () => {
+	const { add, user, tasks } = await openActionDialogFromPreview([
+		'Fix onboarding flow',
+		'Polish dashboard',
+	]);
+
+	await user.click(add);
+	await waitFor(() => {
+		expect(document.body.querySelector('[data-testid="add-to-task-picker"]')).toBeTruthy();
+	});
+
+	// Both seeded tasks listed (alongside the project's auto-provisioned
+	// planning task), none tagged as current.
+	await waitFor(() => {
+		const text = optionRows()
+			.map((r) => r.textContent)
+			.join('\n');
+		expect(text).toContain('Fix onboarding flow');
+		expect(text).toContain('Polish dashboard');
+	});
+	expect(document.body.querySelector('[data-testid="add-to-task-current"]')).toBeNull();
+
+	// Typing filters the list down (150 ms debounce + server round-trip).
+	await user.type(filterInput(), 'onboarding');
+	await waitFor(
+		() => {
+			const rows = optionRows();
+			expect(rows.length).toBe(1);
+			expect(rows[0].textContent).toContain('Fix onboarding flow');
+		},
+		{ timeout: 5_000 },
+	);
+
+	const target = tasks.find((t) => t.title === 'Fix onboarding flow');
+	if (!target) throw new Error('missing seeded task');
+	const spy = spyOnCommentPosts();
+	try {
+		await user.click(optionRows()[0]);
+		await waitFor(() => {
+			expect(spy.posts).toHaveLength(1);
+		});
+	} finally {
+		spy.restore();
+	}
+	expect(spy.posts[0].url).toContain(`/tasks/${target.taskId}/comments`);
+	expect(spy.posts[0].body).toEqual({ content: buildReviewHandoff('prd.md') });
+
+	// Success closes the whole dialog.
+	await waitFor(() => {
+		expect(document.body.querySelector('[data-testid="action-review-dialog"]')).toBeNull();
+	});
+});
+
+test('keyboard: arrows move the highlight, Enter posts to the highlighted task, Escape closes only the picker', async () => {
+	const { add, user } = await openActionDialogFromPreview([
+		'Fix onboarding flow',
+		'Polish dashboard',
+	]);
+
+	await user.click(add);
+	await waitFor(() => {
+		expect(optionRows().length).toBeGreaterThanOrEqual(2);
+	});
+
+	// Escape closes the picker but leaves the dialog up.
+	await user.keyboard('{Escape}');
+	await waitFor(() => {
+		expect(document.body.querySelector('[data-testid="add-to-task-picker"]')).toBeNull();
+	});
+	expect(document.body.querySelector('[data-testid="action-review-dialog"]')).toBeTruthy();
+
+	// Reopen, arrow to the second row, Enter posts to it.
+	await user.click(document.body.querySelector('[data-testid="action-review-add"]') as HTMLElement);
+	await waitFor(() => {
+		expect(optionRows().length).toBeGreaterThanOrEqual(2);
+	});
+	const secondTaskId = optionRows()[1].getAttribute('data-task-id');
+	expect(secondTaskId).toBeTruthy();
+
+	const spy = spyOnCommentPosts();
+	try {
+		await user.keyboard('{ArrowDown}');
+		await waitFor(() => {
+			expect(optionRows()[1].getAttribute('aria-selected')).toBe('true');
+		});
+		await user.keyboard('{Enter}');
+		await waitFor(() => {
+			expect(spy.posts).toHaveLength(1);
+		});
+	} finally {
+		spy.restore();
+	}
+	expect(spy.posts[0].url).toContain(`/tasks/${secondTaskId}/comments`);
+	await waitFor(() => {
+		expect(document.body.querySelector('[data-testid="action-review-dialog"]')).toBeNull();
+	});
+});
+
+test('empty states: no tasks in the project, and no matches for a filter', async () => {
+	const { add, user, ctx } = await openActionDialogFromPreview([]);
+	// The project is provisioned with a planning task; remove it so the
+	// zero-task empty state is reachable.
+	await ctx.db.query('DELETE FROM tasks');
+
+	await user.click(add);
+	await waitFor(() => {
+		const picker = document.body.querySelector('[data-testid="add-to-task-picker"]');
+		expect(picker?.textContent).toContain('No tasks in this project');
+	});
+	expect(optionRows().length).toBe(0);
+
+	await user.type(filterInput(), 'zzz-no-such-task');
+	await waitFor(
+		() => {
+			const picker = document.body.querySelector('[data-testid="add-to-task-picker"]');
+			expect(picker?.textContent).toContain('No tasks matching "zzz-no-such-task"');
+		},
+		{ timeout: 5_000 },
+	);
+});
+
+test('task context: current task pinned first exactly once; a filter excluding it drops it', async () => {
+	const ref = { projectSlug: '', taskId: '', identifier: '', otherTitle: 'Polish dashboard' };
+	const utils = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Pinning Project' });
+			await seedDocument(ws, project, { filename: 'prd.md', content: DOC_CONTENT });
+			await seedReviewComment(ws, project, 'prd.md', {
+				quote: 'unmistakable document body',
+				comment: 'Tighten this sentence',
+			});
+			const task = await seedTask(ws, project, { title: 'Review the spec' });
+			await seedComment(ws, task, 'Please review prd.md before we ship.');
+			await seedTask(ws, project, { title: ref.otherTitle });
+			ref.projectSlug = project.slug;
+			ref.taskId = task.identifier.toLowerCase();
+			ref.identifier = task.identifier;
+		},
+	});
+	await utils.router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: ref.projectSlug, taskId: ref.taskId },
+	});
+	const mention = await utils.findByTestId('doc-mention-link', undefined, { timeout: 15_000 });
+	await utils.user.click(mention);
+	await utils.findByTestId('preview-panel');
+	await utils.findByTestId('review-count-chip');
+	await utils.user.click(await utils.findByTestId('review-action-open'));
+	const add = await waitFor(() => {
+		const el = document.body.querySelector('[data-testid="action-review-add"]');
+		expect(el).toBeTruthy();
+		return el as HTMLElement;
+	});
+
+	await utils.user.click(add);
+
+	// Empty filter: current task first (tagged), both tasks present, and the
+	// current task's identifier appears exactly once (the fetched duplicate is
+	// deduped against the synthesized pinned row).
+	await waitFor(() => {
+		expect(optionRows().length).toBeGreaterThanOrEqual(2);
+	});
+	const rows = optionRows();
+	expect(rows[0].getAttribute('data-testid')).toBe('add-to-task-current');
+	expect(rows[0].textContent).toContain('Review the spec');
+	expect(rows[0].textContent).toContain('Current task');
+	expect(rows.filter((r) => r.getAttribute('data-task-id') === ref.taskId).length).toBe(1);
+
+	// A filter matching only the other task drops the pinned entry.
+	await utils.user.type(filterInput(), 'dashboard');
+	await waitFor(
+		() => {
+			const filtered = optionRows();
+			expect(filtered.length).toBe(1);
+			expect(filtered[0].textContent).toContain(ref.otherTitle);
+		},
+		{ timeout: 5_000 },
+	);
+	expect(document.body.querySelector('[data-testid="add-to-task-current"]')).toBeNull();
+
+	// Clearing the filter brings the pinned entry back.
+	await utils.user.clear(filterInput());
+	await waitFor(
+		() => {
+			expect(optionRows()[0]?.getAttribute('data-testid')).toBe('add-to-task-current');
+		},
+		{ timeout: 5_000 },
+	);
+});

--- a/packages/web/test/document-review.test.tsx
+++ b/packages/web/test/document-review.test.tsx
@@ -253,7 +253,7 @@ test('clear review deletes every comment after confirmation', async () => {
 	expect(container.querySelector('[data-testid="review-count-chip"]')).toBeNull();
 });
 
-test('action dialog copies the handoff, closes, and shows no Add button outside a task view', async () => {
+test('action dialog copies the handoff, closes, and offers Add to task outside a task view', async () => {
 	const { findByTestId, filename, user } = await setupDocumentsPage({
 		comments: [{ quote: 'target text', comment: 'Expand this' }],
 	});
@@ -283,13 +283,14 @@ test('action dialog copies the handoff, closes, and shows no Add button outside 
 		expect(handoff.textContent).toContain(filename);
 		expect(handoff.textContent).toContain('automatically deletes every review comment');
 
-		// Task-less surface: no "Add to <task>" button, the lone copy button is
-		// centred, and the meta line carries the count + filename.
-		expect(document.body.querySelector('[data-testid="action-review-add"]')).toBeNull();
+		// The "Add to task…" picker trigger renders even on a task-less surface,
+		// with Copy on the left; the meta line carries the count + filename.
+		expect(document.body.querySelector('[data-testid="action-review-add"]')).toBeTruthy();
 		const footer = document.body.querySelector(
 			'[data-testid="action-review-footer"]',
 		) as HTMLElement;
-		expect(footer.className).toContain('justify-center');
+		expect(footer.className).toContain('justify-between');
+		expect(footer.firstElementChild?.getAttribute('data-testid')).toBe('action-review-copy');
 		const meta = document.body.querySelector('[data-testid="action-review-meta"]') as HTMLElement;
 		expect(meta.textContent).toContain('1 comment');
 		expect(meta.textContent).toContain(filename);

--- a/packages/web/test/task-preview-action-review.test.tsx
+++ b/packages/web/test/task-preview-action-review.test.tsx
@@ -12,10 +12,11 @@ import {
 	seedWorkspace,
 } from './helpers/seed';
 
-// The action-review dialog, opened from a task's document preview panel, gains
-// an "Add to <TASK-ID>" button that posts the handoff as a comment on that task
-// (payload is exactly `{ content }` — no wake) and closes the dialog; the copy
-// button sits on the left. Failure keeps the dialog open and toasts.
+// The action-review dialog, opened from a task's document preview panel, offers
+// an "Add to task…" picker whose first entry is the hosting task; selecting it
+// posts the handoff as a comment on that task (payload is exactly `{ content }`
+// — no wake) and closes the dialog; the copy button sits on the left. Failure
+// keeps the dialog open and toasts.
 
 const DOC_CONTENT = ['# Product Requirements', '', 'An unmistakable document body.'].join('\n');
 
@@ -62,27 +63,27 @@ async function openActionDialogFromTask() {
 	return { ...utils, ...ref };
 }
 
-test('Add to <id> posts the handoff as a comment on the task and closes the dialog', async () => {
+test('Add to task pins the hosting task first; selecting it posts the handoff and closes the dialog', async () => {
 	const { container, identifier, user } = await openActionDialogFromTask();
 
-	// Task context: Copy sits left, "Add to <ID>" right, footer spread apart.
+	// Copy sits left, the "Add to task…" trigger right, footer spread apart.
 	const footer = document.body.querySelector('[data-testid="action-review-footer"]') as HTMLElement;
 	expect(footer.className).toContain('justify-between');
 	const add = document.body.querySelector('[data-testid="action-review-add"]') as HTMLElement;
-	expect(add.textContent).toBe(`Add to ${identifier}`);
+	expect(add.textContent).toBe('Add to task…');
 	expect(footer.firstElementChild?.getAttribute('data-testid')).toBe('action-review-copy');
-	expect(footer.lastElementChild?.getAttribute('data-testid')).toBe('action-review-add');
+	expect(footer.lastElementChild?.querySelector('[data-testid="action-review-add"]')).toBeTruthy();
 
 	// Spy on POST /api/.../comments to pin the exact payload.
 	const original = globalThis.fetch;
-	const posts: Array<Record<string, unknown>> = [];
+	const posts: Array<{ url: string; body: Record<string, unknown> }> = [];
 	globalThis.fetch = Object.assign(async (input: RequestInfo | URL, init?: RequestInit) => {
 		const url = typeof input === 'string' ? input : input.toString();
 		if (init?.method === 'POST' && /\/tasks\/[^/]+\/comments$/.test(url)) {
 			const body = init.body;
 			if (typeof body === 'string') {
 				try {
-					posts.push(JSON.parse(body) as Record<string, unknown>);
+					posts.push({ url, body: JSON.parse(body) as Record<string, unknown> });
 				} catch {}
 			}
 		}
@@ -90,6 +91,23 @@ test('Add to <id> posts the handoff as a comment on the task and closes the dial
 	}, original);
 	try {
 		await user.click(add);
+
+		// The picker opens with the hosting task pinned as the FIRST row.
+		const picker = await waitFor(() => {
+			const el = document.body.querySelector('[data-testid="add-to-task-picker"]');
+			expect(el).toBeTruthy();
+			return el as HTMLElement;
+		});
+		const current = picker.querySelector('[data-testid="add-to-task-current"]') as HTMLElement;
+		expect(current).toBeTruthy();
+		expect(current.textContent).toContain('Review the spec');
+		expect(current.textContent).toContain('Current task');
+		const listbox = picker.querySelector('[role="listbox"]') as HTMLElement;
+		expect(listbox.querySelector('button')?.getAttribute('data-testid')).toBe(
+			'add-to-task-current',
+		);
+
+		await user.click(current);
 
 		// The handoff lands in the task thread (the prd.md mention splits the text
 		// across nodes, so assert on the comment bodies rather than findByText).
@@ -105,9 +123,11 @@ test('Add to <id> posts the handoff as a comment on the task and closes the dial
 		globalThis.fetch = original;
 	}
 
-	// Exactly `{ content: <handoff> }` — toEqual proves no wake_assignee or extras.
+	// Exactly `{ content: <handoff> }` — toEqual proves no wake_assignee or extras
+	// — POSTed to the hosting task's path.
 	expect(posts).toHaveLength(1);
-	expect(posts[0]).toEqual({ content: buildReviewHandoff('prd.md') });
+	expect(posts[0].url).toContain(`/tasks/${identifier.toLowerCase()}/comments`);
+	expect(posts[0].body).toEqual({ content: buildReviewHandoff('prd.md') });
 
 	await waitFor(() => {
 		expect(document.body.querySelector('[data-testid="action-review-dialog"]')).toBeNull();
@@ -133,11 +153,18 @@ test('a failed Add keeps the dialog open and toasts the error', async () => {
 		await user.click(
 			document.body.querySelector('[data-testid="action-review-add"]') as HTMLElement,
 		);
+		const current = await waitFor(() => {
+			const el = document.body.querySelector('[data-testid="add-to-task-current"]');
+			expect(el).toBeTruthy();
+			return el as HTMLElement;
+		});
+		await user.click(current);
 		await waitFor(() => {
 			expect(errorSpy).toHaveBeenCalledWith('boom');
 		});
-		// The dialog stays open so the handoff isn't lost.
+		// The dialog stays open so the handoff isn't lost; the picker closes.
 		expect(document.body.querySelector('[data-testid="action-review-dialog"]')).toBeTruthy();
+		expect(document.body.querySelector('[data-testid="add-to-task-picker"]')).toBeNull();
 	} finally {
 		globalThis.fetch = original;
 		errorSpy.mockRestore();


### PR DESCRIPTION
## What

The action-review dialog's add button is now **always available** — including on the task-less surfaces (standalone doc preview route, docs library) — as an **"Add to task…"** picker instead of the previous conditional "Add to \<ID\>" button.

Clicking it opens a dropdown anchored above the button with:

- a **filter input** (auto-focused, 150 ms debounce) that narrows the project's task list via server-side search
- the project's tasks (all statuses, `updated_at` desc, status shown in each row's sublabel)
- when the dialog is opened from a task's document preview, the **current task pinned as the first entry** with a "Current task" tag (deduped against the fetched results; a filter that excludes it drops it like any other task)
- keyboard navigation: Arrow keys move the highlight, Enter selects, Escape closes just the picker (the dialog stays)

Selecting a task posts the review handoff onto it as a comment immediately (spinner on the row); success closes the dialog, failure toasts and keeps the dialog open so the handoff isn't lost.

## How

- **`add-to-task-picker.tsx`** (new): hand-rolled absolute dropdown in the existing MentionPicker style (no portal — the trigger already sits inside a modal dialog), data via `useTasks(projectId, { search, per_page: '20', sort: 'updated_at:desc' })`
- **`useCreateCommentOnTask(projectId)`** (new hook): same cache handling as `useCreateComment`, but the target task travels in the mutation variables — needed because the picker chooses the target at runtime
- **`GET /tasks` search now also matches `identifier`** (`title ILIKE … OR description ILIKE … OR identifier ILIKE …`), so typing an id like `HM-31` finds the task
- `ActionReviewDialog` gains a required `projectId` prop (threaded from `ReviewToolbarActions`, which already had it on all three surfaces); `ReviewTaskContext` gains optional `title` for the pinned row
- Docs (`docs/concepts/documents-and-memory.md`) and the in-app review help updated to describe the picker

## Tests

- New `packages/web/test/action-review-add-to-task.test.tsx`: task-less flow (list, filter, post to chosen task), keyboard nav + Escape scoping, empty states, current-task pinning/dedupe/drop-out
- Updated `task-preview-action-review.test.tsx` (picker flow from a task view; exact `{ content }` payload + error path preserved) and `document-review.test.tsx` (trigger now present on task-less surfaces)
- New server test case: identifier search on `GET /tasks`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014hJQCW9R4znQd79xpuk9M7

---
_Generated by [Claude Code](https://claude.ai/code/session_014hJQCW9R4znQd79xpuk9M7)_