### PR TITLE
fix(web): render reaction picker above adjacent comments

### DIFF
--- a/packages/web/src/components/comment-renderers/comment-reactions.tsx
+++ b/packages/web/src/components/comment-renderers/comment-reactions.tsx
@@ -1,3 +1,4 @@
+import * as Popover from '@radix-ui/react-popover';
 import { Smile } from 'lucide-react';
 import { useState } from 'react';
 import { type ReactionGroup, useAddReaction, useRemoveReaction } from '../../hooks/use-comments';
@@ -66,21 +67,29 @@ export function CommentReactions({ comment, projectId, taskId }: Props) {
 				</Tooltip>
 			))}
 			{availableToAdd.length > 0 && (
-				<div className="relative">
-					<button
-						type="button"
-						onClick={() => setPickerOpen((open) => !open)}
-						disabled={busy}
-						aria-label="Add reaction"
-						data-testid="add-reaction-button"
-						className="inline-flex items-center justify-center min-w-[28px] min-h-[28px] px-1.5 rounded-full border border-border text-text-2 hover:text-text-1 hover:border-border-strong disabled:opacity-60"
-					>
-						<Smile className="w-3.5 h-3.5" />
-					</button>
-					{pickerOpen && (
-						<div
-							className="absolute z-10 mt-1 flex gap-1 rounded-md border border-border bg-surface p-1 shadow-md"
-							role="menu"
+				<Popover.Root open={pickerOpen} onOpenChange={setPickerOpen}>
+					<Popover.Trigger asChild>
+						<button
+							type="button"
+							disabled={busy}
+							aria-label="Add reaction"
+							data-testid="add-reaction-button"
+							className="inline-flex items-center justify-center min-w-[28px] min-h-[28px] px-1.5 rounded-full border border-border text-text-2 hover:text-text-1 hover:border-border-strong disabled:opacity-60"
+						>
+							<Smile className="w-3.5 h-3.5" />
+						</button>
+					</Popover.Trigger>
+					{/* Portal + z-50 so the picker escapes the comment card's
+					    `overflow-hidden` and the Virtuoso row's stacking context —
+					    an in-flow `absolute` popup was clipped and painted under the
+					    next comment. Radix flips it above the trigger near the
+					    viewport's bottom edge. */}
+					<Popover.Portal>
+						<Popover.Content
+							align="start"
+							side="bottom"
+							sideOffset={4}
+							className="z-50 flex gap-1 rounded-md border border-border bg-surface p-1 shadow-md"
 							data-testid="reaction-picker"
 						>
 							{availableToAdd.map((kind) => (
@@ -99,9 +108,9 @@ export function CommentReactions({ comment, projectId, taskId }: Props) {
 									</button>
 								</Tooltip>
 							))}
-						</div>
-					)}
-				</div>
+						</Popover.Content>
+					</Popover.Portal>
+				</Popover.Root>
 			)}
 		</div>
 	);

--- a/packages/web/test/reactions.test.tsx
+++ b/packages/web/test/reactions.test.tsx
@@ -31,6 +31,11 @@ test('add and remove a reaction toggles the chip', async () => {
 	await user.click(addButton);
 
 	const picker = await findByTestId('reaction-picker', undefined, { timeout: 5_000 });
+	// Regression: the picker must be portaled out of the comment card. The card
+	// clips its children with `overflow-hidden` and sits in a Virtuoso row's
+	// stacking context, so an in-flow popup was drawn under the next comment.
+	// A portaled popup has no comment-item ancestor.
+	expect(picker.closest('[data-testid="comment-item"]')).toBeNull();
 	const ackBtn = picker.querySelector('[data-reaction-kind="ack"]') as HTMLButtonElement;
 	expect(ackBtn).not.toBeNull();
 	await user.click(ackBtn);


### PR DESCRIPTION
## Problem

The comment reaction picker (the emoji popup opened by the "Add reaction" button) rendered **under** adjacent content instead of on top of it.

Two overlapping causes:

1. **Clipping** — the picker was an in-flow `absolute z-10` popup nested inside the comment card, and the card clips its children with `overflow-hidden` (needed to round the header). A popup opening downward from the bottom-of-card reaction row overflowed the card boundary and was cut off.
2. **Stacking context** — each comment renders inside its own Virtuoso row, so a low `z-10` inside one row can't rise above a *following* row. The picker was painted under the next comment.

## Fix

Render the picker through a **Radix `Popover` portal at `z-50`** — the same pattern already used for tooltips (`ui/tooltip.tsx`), the multi-select (`ui/multi-select.tsx`), and the task-list filters. Portaling to `document.body`:

- escapes the card's `overflow-hidden` clip and every Virtuoso row stacking context, and
- lets Radix's collision handling flip the picker above the trigger when it's near the viewport's bottom edge.

All test-facing hooks are preserved unchanged: `data-testid="add-reaction-button"`, `data-testid="reaction-picker"`, `data-reaction-kind`, and the `aria-label`s. The picker still closes after a selection (controlled `open` state) and additionally on outside-click / Escape (Radix behavior).

## Testing

- `packages/web/test/reactions.test.tsx` — added a regression assertion that the open picker has **no `comment-item` ancestor** (i.e. it is portaled out of the clipping card); this fails against the old in-flow popup. All 3 reaction tests pass.
- Broader comment suite (`task-comments.test.tsx`, 14 tests) passes.
- `tsc --noEmit` and `biome check` clean.

The mobile browser spec (`test/browser/reactions.mobile.spec.ts`) asserts open → select → chip and tap-target sizes; those selectors and the trigger's classes are unchanged, and the Radix portal pattern is already exercised under the same test infra by the task-list filters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKZZDvUwEMKSfs1ioMDPJK

---
_Generated by [Claude Code](https://claude.ai/code/session_01WKZZDvUwEMKSfs1ioMDPJK)_