### PR TITLE
fix(server): self-heal broken cached repo clones during repo sync

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -590,6 +590,22 @@ on `mkdirSync`'s `mode` — that mode is masked by the **process umask**, so a h
 `0o027`/`0o077` under systemd `UMask=`) would silently strip the other-execute bit and the agent
 CLI would die with `EACCES` opening its `settings.json` (again only on native-Linux production).
 
+Repo sync (`ensureProjectRepos`, `services/repo-sync.ts`) does **not trust a bare `.git`
+marker** in a repo's reserved workspace directory: an agent may have run `git init` there
+before the repo was connected, leaving a repo with no origin (every fetch then silently
+no-ops and worktree prep dies on an unborn HEAD) or with origin pointed at the wrong repo.
+The sync reads `origin` (`getOriginRemote`, `git.ts`) and **self-heals** a positively-wrong
+state — adopting the directory in place (`connectExistingRepo`) when origin is missing,
+repointing origin (`remote set-url`) when it addresses a different repo/host
+(`remoteUrlMatchesRepo` accepts the SSH form Hezo writes plus hand-configured `ssh://`/
+`https://` forms). Healing never discards local files or commits, and an **indeterminate**
+answer (exec transport failure, stubbed executor) never triggers a repair — only git's own
+"No such remote" / "not a git repository" do. Relatedly, the per-run fetch names `origin`
+explicitly (`git fetch --prune origin`, not `--all`, which exits 0 having fetched nothing
+when no remote is configured), and a worktree add that can resolve neither `origin/<default>`
+nor a born HEAD fails with an actionable "clone has no commits" error instead of git's opaque
+`failed to resolve HEAD as a valid ref`.
+
 Before building a worktree the runner fetches each clone, then **fast-forwards the clone's
 local default branch** (the "main codebase") to `origin/<default>` (resolved via `origin/HEAD`
 → fallback `main`/`master`) — a clean fast-forward when it's checked out, else an `update-ref`,

--- a/packages/server/src/routes/repos.ts
+++ b/packages/server/src/routes/repos.ts
@@ -231,7 +231,12 @@ reposRoutes.post('/projects/:projectId/repos', async (c) => {
 					cloneStatus = 'failed';
 					cloneError = failed.error;
 					log.error(`Failed to clone ${repoIdentifier}:`, cloneError);
-				} else if (syncRes.cloned.includes(repoName)) {
+				} else if (
+					syncRes.cloned.includes(repoName) ||
+					// A pre-existing dir whose broken git state was healed (origin
+					// added/repointed) — setup produced a usable checkout, same as a clone.
+					syncRes.repaired.includes(repoName)
+				) {
 					cloneStatus = 'cloned';
 				}
 			} else {

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -1383,6 +1383,9 @@ async function prepareWorktrees(
 		if (syncRes.cloned.length > 0) {
 			emitSystem('stdout', `(cloned ${syncRes.cloned.length} repo(s) on demand)`);
 		}
+		if (syncRes.repaired.length > 0) {
+			emitSystem('stdout', `(repaired ${syncRes.repaired.length} repo(s) with a broken origin)`);
+		}
 
 		if (signal?.aborted) {
 			return { workingDir: '/workspace', designatedRepo: null, worktrees: [], executor };

--- a/packages/server/src/services/git.ts
+++ b/packages/server/src/services/git.ts
@@ -33,6 +33,81 @@ export function buildGitSshUrl(hostType: RepoHostType, repoIdentifier: string): 
 	return `git@${host}:${repoIdentifier}.git`;
 }
 
+function escapeRegExp(s: string): string {
+	return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Whether a configured remote URL points at the given repo (`owner/repo`) on the
+ * given host. Accepts the scp-style SSH form Hezo writes plus the `ssh://` and
+ * `http(s)://` forms a human may have configured by hand — a different repo or a
+ * different host is a mismatch.
+ */
+export function remoteUrlMatchesRepo(
+	url: string,
+	repoIdentifier: string,
+	hostType: RepoHostType = RepoHostType.GitHub,
+): boolean {
+	const host = SSH_HOSTS[hostType];
+	if (!host) return false;
+	const h = escapeRegExp(host);
+	const id = escapeRegExp(repoIdentifier);
+	const forms = new RegExp(
+		`^(?:git@${h}:|ssh://git@${h}(?::\\d+)?/|https?://(?:[^/@]+@)?${h}/)${id}(?:\\.git)?/?$`,
+		'i',
+	);
+	return forms.test(url.trim());
+}
+
+export type OriginRemote =
+	/** `origin` is configured and its URL was read. */
+	| { status: 'configured'; url: string }
+	/** Git positively reported no `origin` (or that the dir is not a git repo). */
+	| { status: 'missing' }
+	/** No definitive answer — exec transport failure, or zero-exit with no URL. */
+	| { status: 'indeterminate' };
+
+/**
+ * Reads a clone's `origin` remote URL. `missing` is reserved for git's own
+ * definitive answers — "No such remote" (an agent's bare `git init` in the
+ * reserved workspace directory) or "not a git repository" (a corrupt `.git`) —
+ * both healed by the same adopt-in-place path. Anything else that isn't a
+ * readable URL is `indeterminate`: a docker-exec transport failure or a stubbed
+ * executor's empty zero-exit is no evidence of misconfiguration, and must never
+ * license "repairing" a possibly-healthy clone.
+ */
+export async function getOriginRemote(executor: GitExecutor, repo: RepoLoc): Promise<OriginRemote> {
+	const res = await executor.exec(['remote', 'get-url', 'origin'], {
+		cwd: repo.containerPath,
+		timeout: 30_000,
+	});
+	if (res.exitCode !== 0) {
+		return /no such remote|not a git repository/i.test(res.stderr)
+			? { status: 'missing' }
+			: { status: 'indeterminate' };
+	}
+	const url = res.stdout.trim();
+	return url.length > 0 ? { status: 'configured', url } : { status: 'indeterminate' };
+}
+
+/**
+ * Repoints a clone's `origin` at the repo it is supposed to track. Purely a
+ * config change — branches, commits, and the working tree are untouched; the
+ * next `git fetch --prune` replaces the stale `origin/*` tracking refs.
+ */
+export async function setOriginUrl(
+	executor: GitExecutor,
+	url: string,
+	repo: RepoLoc,
+): Promise<{ success: boolean; error?: string }> {
+	const res = await executor.exec(['remote', 'set-url', 'origin', url], {
+		cwd: repo.containerPath,
+		timeout: 30_000,
+	});
+	if (res.exitCode !== 0) return { success: false, error: formatGitError(res.stderr) };
+	return { success: true };
+}
+
 export async function cloneRepo(
 	executor: GitExecutor,
 	repoIdentifier: string,
@@ -77,7 +152,13 @@ export async function connectExistingRepo(
 	const init = await executor.exec(['init', '-b', 'main'], { cwd, timeout: 30_000 });
 	if (init.exitCode !== 0) return fail(formatGitError(init.stderr));
 
-	const remote = await executor.exec(['remote', 'add', 'origin', url], { cwd, timeout: 30_000 });
+	// A repaired repo can already carry an `origin` (e.g. one recorded in
+	// `.git/config` before the repo broke) — fall back to set-url so the connect
+	// is idempotent instead of dying on "remote origin already exists".
+	let remote = await executor.exec(['remote', 'add', 'origin', url], { cwd, timeout: 30_000 });
+	if (remote.exitCode !== 0) {
+		remote = await executor.exec(['remote', 'set-url', 'origin', url], { cwd, timeout: 30_000 });
+	}
 	if (remote.exitCode !== 0) return fail(formatGitError(remote.stderr));
 
 	// A remote with no refs has no commits yet — keep the existing files as the
@@ -131,7 +212,11 @@ export async function fetchRepo(
 	executor: GitExecutor,
 	repo: RepoLoc,
 ): Promise<{ success: boolean; error?: string }> {
-	const { exitCode, stderr } = await executor.exec(['fetch', '--all', '--prune'], {
+	// Fetch `origin` by name, not `--all`: with no remotes configured (a stray
+	// `git init` in the reserved directory) `--all` exits 0 having fetched
+	// nothing, and the broken clone reads as "up to date". Naming origin makes
+	// that state fail loudly instead.
+	const { exitCode, stderr } = await executor.exec(['fetch', '--prune', 'origin'], {
 		cwd: repo.containerPath,
 		needsSsh: true,
 		timeout: 60_000,
@@ -374,7 +459,8 @@ async function releaseBranchFromWorktrees(
  * existing remote branch is tracked, otherwise a **new** branch is created off the
  * latest fetched remote default branch (`origin/<default>`) so every task starts
  * from current trunk. Only when no default branch resolves (an empty remote) does
- * it fall back to HEAD.
+ * it fall back to HEAD — and when HEAD is unborn too (nothing to base a worktree
+ * on) it fails with an actionable error rather than git's opaque one.
  */
 async function addTaskWorktree(
 	executor: GitExecutor,
@@ -409,9 +495,28 @@ async function addTaskWorktree(
 		];
 	} else {
 		const def = await getRemoteDefaultBranch(executor, repo);
-		args = def
-			? ['worktree', 'add', '-b', branchName, wt.containerPath, `origin/${def}`]
-			: ['worktree', 'add', '-b', branchName, wt.containerPath];
+		if (def) {
+			args = ['worktree', 'add', '-b', branchName, wt.containerPath, `origin/${def}`];
+		} else {
+			// No remote default branch resolves (an empty remote). Basing the new
+			// branch on HEAD only works when HEAD points at a commit — an unborn HEAD
+			// (a clone of an empty repo, or a stray `git init`) makes git (< 2.42) die
+			// with the opaque "failed to resolve HEAD as a valid ref", so surface the
+			// actionable story instead.
+			const head = await executor.exec(['rev-parse', '--verify', '--quiet', 'HEAD'], {
+				cwd,
+				timeout: 30_000,
+			});
+			if (head.exitCode !== 0) {
+				return {
+					success: false,
+					created: false,
+					error:
+						'clone has no commits and no remote default branch — push an initial commit to the remote and retry (it is fetched on the next run)',
+				};
+			}
+			args = ['worktree', 'add', '-b', branchName, wt.containerPath];
+		}
 	}
 
 	const result = await executor.exec(args, { cwd, timeout: 30_000 });

--- a/packages/server/src/services/repo-sync.ts
+++ b/packages/server/src/services/repo-sync.ts
@@ -1,9 +1,17 @@
 import { existsSync, mkdirSync, readdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
-import { repoNameFromIdentifier } from '@hezo/shared';
+import { RepoHostType, repoNameFromIdentifier } from '@hezo/shared';
 import type { Db } from '../db/database';
 import { logger } from '../logger';
-import { cloneRepo, initRepoInPlace, type RepoLoc } from './git';
+import {
+	buildGitSshUrl,
+	cloneRepo,
+	getOriginRemote,
+	initRepoInPlace,
+	type RepoLoc,
+	remoteUrlMatchesRepo,
+	setOriginUrl,
+} from './git';
 import type { GitExecutor } from './git-executor';
 import { CONTAINER_WORKSPACE_ROOT, getWorkspacePath, getWorktreesPath } from './workspace';
 
@@ -14,6 +22,8 @@ export type LogEmitter = (stream: 'stdout' | 'stderr', text: string) => void;
 /** Repos keyed by name — the workspace directory each clone lives in. */
 export interface RepoSyncResult {
 	cloned: string[];
+	/** Existing dirs whose broken git state was healed (origin added/repointed). */
+	repaired: string[];
 	skipped: string[];
 	failed: Array<{ name: string; error: string }>;
 }
@@ -30,6 +40,15 @@ export interface ProjectIdentity {
  * checks against the bind-mounted workspace. The container must be running and the
  * executor's bridge must carry the project SSH key, or clone-over-SSH fails and is
  * reported in `failed` (same outcome as a missing key today).
+ *
+ * A directory that already carries `.git` is not trusted blindly: an agent may
+ * have run `git init` in the reserved directory before the repo was connected,
+ * leaving a repo with no origin (every fetch then silently no-ops and worktree
+ * prep dies on an unborn HEAD) or with origin pointed somewhere else entirely.
+ * The sync verifies `origin` actually tracks the linked repo and self-heals when
+ * it doesn't — adopting the directory in place when origin is missing, repointing
+ * origin when it's wrong — reported in `repaired`. Healing never discards local
+ * files or commits; a heal that would clobber untracked work fails instead.
  */
 export async function ensureProjectRepos(
 	db: Db,
@@ -39,7 +58,7 @@ export async function ensureProjectRepos(
 	logEmit?: LogEmitter,
 	containerWorkspaceRoot: string = CONTAINER_WORKSPACE_ROOT,
 ): Promise<RepoSyncResult> {
-	const result: RepoSyncResult = { cloned: [], skipped: [], failed: [] };
+	const result: RepoSyncResult = { cloned: [], repaired: [], skipped: [], failed: [] };
 
 	const repos = await db.query<RepoRow>(
 		`SELECT repo_identifier FROM repos
@@ -52,7 +71,8 @@ export async function ensureProjectRepos(
 	const workspacePath = getWorkspacePath(dataDir, project.team_id, project.id);
 	mkdirSync(workspacePath, { recursive: true });
 
-	const pending: Array<{ repo: RepoRow; mode: 'clone' | 'init'; loc: RepoLoc }> = [];
+	type SyncMode = 'clone' | 'init' | 'adopt' | 'repoint';
+	const pending: Array<{ repo: RepoRow; mode: SyncMode; loc: RepoLoc; badOrigin?: string }> = [];
 	for (const r of repos.rows) {
 		const name = repoNameFromIdentifier(r.repo_identifier);
 		const targetDir = join(workspacePath, name);
@@ -61,7 +81,20 @@ export async function ensureProjectRepos(
 			containerPath: `${containerWorkspaceRoot}/${name}`,
 		};
 		if (existsSync(join(targetDir, '.git'))) {
-			result.skipped.push(name);
+			// Verify — don't trust — the existing `.git` (see the docstring). Only a
+			// positively-wrong state is healed; an indeterminate answer leaves the
+			// clone alone.
+			const origin = await getOriginRemote(executor, loc);
+			if (origin.status === 'missing') {
+				pending.push({ repo: r, mode: 'adopt', loc });
+			} else if (
+				origin.status === 'configured' &&
+				!remoteUrlMatchesRepo(origin.url, r.repo_identifier)
+			) {
+				pending.push({ repo: r, mode: 'repoint', loc, badOrigin: origin.url });
+			} else {
+				result.skipped.push(name);
+			}
 		} else if (existsSync(targetDir) && readdirSync(targetDir).length > 0) {
 			// An agent populated this directory before the repo was connected — a
 			// plain clone would refuse the non-empty target, so adopt it in place.
@@ -73,17 +106,42 @@ export async function ensureProjectRepos(
 
 	if (pending.length === 0) return result;
 
-	for (const { repo: r, mode, loc } of pending) {
+	const VERBS: Record<SyncMode, [progressive: string, past: string]> = {
+		clone: ['Cloning', 'Cloned'],
+		init: ['Initializing', 'Initialized'],
+		adopt: ['Repairing', 'Repaired'],
+		repoint: ['Repairing', 'Repaired'],
+	};
+	for (const { repo: r, mode, loc, badOrigin } of pending) {
 		const name = repoNameFromIdentifier(r.repo_identifier);
-		const verb = mode === 'init' ? 'Initializing' : 'Cloning';
-		logEmit?.('stdout', `→ ${verb} ${r.repo_identifier} → ${name}/`);
-		const res =
-			mode === 'init'
-				? await initRepoInPlace(executor, r.repo_identifier, loc)
-				: await cloneRepo(executor, r.repo_identifier, loc);
+		const [verb, done] = VERBS[mode];
+		const detail =
+			mode === 'adopt'
+				? ' (existing directory has no usable origin remote; connecting it in place)'
+				: mode === 'repoint'
+					? ` (origin pointed at ${badOrigin})`
+					: '';
+		logEmit?.('stdout', `→ ${verb} ${r.repo_identifier} → ${name}/${detail}`);
+		let res: { success: boolean; error?: string };
+		switch (mode) {
+			case 'clone':
+				res = await cloneRepo(executor, r.repo_identifier, loc);
+				break;
+			case 'init':
+			case 'adopt':
+				res = await initRepoInPlace(executor, r.repo_identifier, loc);
+				break;
+			case 'repoint':
+				res = await setOriginUrl(
+					executor,
+					buildGitSshUrl(RepoHostType.GitHub, r.repo_identifier),
+					loc,
+				);
+				break;
+		}
 		if (res.success) {
-			logEmit?.('stdout', `✓ ${mode === 'init' ? 'Initialized' : 'Cloned'} ${name}`);
-			result.cloned.push(name);
+			logEmit?.('stdout', `✓ ${done} ${name}`);
+			(mode === 'adopt' || mode === 'repoint' ? result.repaired : result.cloned).push(name);
 		} else {
 			const errMsg = res.error ?? 'unknown error';
 			logEmit?.('stderr', `✗ ${verb} failed for ${name}: ${errMsg}`);

--- a/packages/server/test/git-init-in-place.test.ts
+++ b/packages/server/test/git-init-in-place.test.ts
@@ -81,6 +81,25 @@ describe('connectExistingRepo', () => {
 		expect(readFileSync(join(target, 'local-only.txt'), 'utf8')).toBe('scaffold\n');
 	});
 
+	it('repoints an already-configured origin instead of failing on remote add', async () => {
+		// A directory healed after a previous partial failure (or a stray agent
+		// setup) can already carry an origin; connect must be idempotent.
+		const remote = makeEmptyRemote();
+		const target = join(root, 'work');
+		mkdirSync(target, { recursive: true });
+		git(target, 'init', '-b', 'main');
+		git(target, 'remote', 'add', 'origin', 'git@github.com:someone/else.git');
+		writeFileSync(join(target, 'index.html'), '<html></html>');
+
+		const res = await connectExistingRepo(exec, `file://${remote}`, loc(target), false);
+
+		expect(res.success).toBe(true);
+		expect(
+			execFileSync('git', ['remote', 'get-url', 'origin'], { cwd: target }).toString().trim(),
+		).toBe(`file://${remote}`);
+		expect(readFileSync(join(target, 'index.html'), 'utf8')).toBe('<html></html>');
+	});
+
 	it('fails and rolls back its .git when a local file conflicts with the remote', async () => {
 		const remote = makeRemoteWithCommit({ 'README.md': 'from remote\n' });
 		const target = join(root, 'work');

--- a/packages/server/test/git.test.ts
+++ b/packages/server/test/git.test.ts
@@ -10,11 +10,14 @@ import {
 	ensureTaskWorktreeWithRetry,
 	fastForwardLocalDefault,
 	fetchRepo,
+	getOriginRemote,
 	getRemoteDefaultBranch,
 	isTransientMountError,
 	mergeDefaultIntoWorktree,
 	pruneWorktrees,
 	type RepoLoc,
+	remoteUrlMatchesRepo,
+	setOriginUrl,
 	type WorktreeLoc,
 } from '../src/services/git';
 import {
@@ -551,6 +554,101 @@ describe('ensureTaskWorktreeWithRetry retries transient mount ENOENT', () => {
 		expect(res.error).toContain('No such file or directory'); // surfaced, not swallowed
 		expect(retries).toBe(2); // retries - 1 onRetry invocations
 		expect(flaky.addCalls).toBe(3); // exactly `retries` attempts, bounded
+	});
+});
+
+// A workspace directory can carry a `.git` that is not a clone of the linked
+// repo — an agent's stray `git init` (no origin, unborn HEAD) or an origin
+// pointed elsewhere. These primitives let repo-sync detect and heal that state
+// instead of every run dying in worktree prep.
+describe('origin remote inspection and repair', () => {
+	// Neutralize ambient URL rewrites (CI proxies inject `url.*.insteadOf` via
+	// GIT_CONFIG_* env and global/system config) so origin URLs read back exactly
+	// as stored — like production's clean container git.
+	const cleanExec = new HostGitExecutor({
+		GIT_CONFIG_COUNT: '0',
+		GIT_CONFIG_GLOBAL: '/dev/null',
+		GIT_CONFIG_SYSTEM: '/dev/null',
+	});
+
+	it('remoteUrlMatchesRepo accepts the URL forms that address the repo', () => {
+		const id = 'hezo-ai/website';
+		expect(remoteUrlMatchesRepo('git@github.com:hezo-ai/website.git', id)).toBe(true);
+		expect(remoteUrlMatchesRepo('git@github.com:hezo-ai/website', id)).toBe(true);
+		expect(remoteUrlMatchesRepo('ssh://git@github.com/hezo-ai/website.git', id)).toBe(true);
+		expect(remoteUrlMatchesRepo('https://github.com/hezo-ai/website.git', id)).toBe(true);
+		expect(remoteUrlMatchesRepo('https://github.com/hezo-ai/website', id)).toBe(true);
+		expect(remoteUrlMatchesRepo('https://user@github.com/hezo-ai/website.git', id)).toBe(true);
+		expect(remoteUrlMatchesRepo('HTTPS://GitHub.com/Hezo-AI/Website.git', id)).toBe(true);
+	});
+
+	it('remoteUrlMatchesRepo rejects other repos and other hosts', () => {
+		const id = 'hezo-ai/website';
+		expect(remoteUrlMatchesRepo('git@github.com:hezo-ai/hezo.git', id)).toBe(false);
+		expect(remoteUrlMatchesRepo('git@github.com:other/website.git', id)).toBe(false);
+		expect(remoteUrlMatchesRepo('git@github.com:prefix-hezo-ai/website.git', id)).toBe(false);
+		expect(remoteUrlMatchesRepo('git@gitlab.com:hezo-ai/website.git', id)).toBe(false);
+		expect(remoteUrlMatchesRepo('https://github.com/hezo-ai/website/extra', id)).toBe(false);
+		expect(remoteUrlMatchesRepo('', id)).toBe(false);
+	});
+
+	it('getOriginRemote reads a configured origin and repairs via setOriginUrl', async () => {
+		const dir = join(testDir, 'origin-inspect');
+		mkdirSync(dir, { recursive: true });
+		run('git init -b main', dir);
+		run('git remote add origin git@github.com:someone/else.git', dir);
+
+		const before = await getOriginRemote(cleanExec, repoLoc(dir));
+		expect(before).toEqual({ status: 'configured', url: 'git@github.com:someone/else.git' });
+
+		const fixed = await setOriginUrl(cleanExec, 'git@github.com:owner/right.git', repoLoc(dir));
+		expect(fixed.success).toBe(true);
+		const after = await getOriginRemote(cleanExec, repoLoc(dir));
+		expect(after).toEqual({ status: 'configured', url: 'git@github.com:owner/right.git' });
+	});
+
+	it('getOriginRemote reports missing only on a definitive git answer', async () => {
+		// A repo with no remotes — git's "No such remote 'origin'".
+		const noOrigin = join(testDir, 'origin-none');
+		mkdirSync(noOrigin, { recursive: true });
+		run('git init -b main', noOrigin);
+		expect(await getOriginRemote(cleanExec, repoLoc(noOrigin))).toEqual({ status: 'missing' });
+
+		// A transport-style failure gives no evidence either way.
+		const flaky: GitExecutor = {
+			exec: async () => ({ exitCode: 1, stdout: '', stderr: 'docker exec transport died' }),
+		};
+		expect(await getOriginRemote(flaky, repoLoc(noOrigin))).toEqual({ status: 'indeterminate' });
+
+		// A zero-exit with no URL (a stubbed executor) is indeterminate too.
+		const silent: GitExecutor = {
+			exec: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
+		};
+		expect(await getOriginRemote(silent, repoLoc(noOrigin))).toEqual({ status: 'indeterminate' });
+	});
+
+	it('fetchRepo fails loudly when no origin remote is configured', async () => {
+		const dir = join(testDir, 'fetch-no-origin');
+		mkdirSync(dir, { recursive: true });
+		run('git init -b main', dir);
+
+		const res = await fetchRepo(exec, repoLoc(dir));
+		expect(res.success).toBe(false);
+		expect(res.error).toBeTruthy();
+	});
+
+	it('ensureTaskWorktree fails with an actionable error on an unborn HEAD', async () => {
+		// A stray `git init` with no commits and no origin — git itself would die
+		// with the opaque "failed to resolve HEAD as a valid ref" (git < 2.42).
+		const dir = join(testDir, 'unborn');
+		mkdirSync(dir, { recursive: true });
+		run('git init -b main', dir);
+
+		const wt = join(testDir, 'worktrees', 'UB-1', 'unborn');
+		const res = await ensureTaskWorktree(exec, repoLoc(dir), wtLoc(wt), 'hezo/UB-1');
+		expect(res.success).toBe(false);
+		expect(res.error).toContain('no commits');
+		expect(res.error).toContain('push an initial commit');
 	});
 });
 

--- a/packages/server/test/repo-sync.test.ts
+++ b/packages/server/test/repo-sync.test.ts
@@ -1,12 +1,20 @@
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Db } from '../src/db/database';
 import type { Env } from '../src/lib/types';
-import { HostGitExecutor } from '../src/services/git-executor';
+import {
+	type GitExecOpts,
+	type GitExecResult,
+	type GitExecutor,
+	HostGitExecutor,
+} from '../src/services/git-executor';
 import {
 	ensureProjectRepos,
+	type LogEmitter,
+	type RepoSyncResult,
 	removeRepoFromWorkspace,
 	removeTaskWorktrees,
 } from '../src/services/repo-sync';
@@ -43,41 +51,179 @@ afterAll(async () => {
 	await safeClose(db);
 });
 
-// The clone path runs in-container; these cases (no repos, already-cloned) never
-// reach the executor, so a host executor suffices and no Docker is needed.
-const exec = new HostGitExecutor();
+// Neutralize ambient URL rewrites (CI proxies inject `url.*.insteadOf` via
+// GIT_CONFIG_* env and global/system config) so origin URLs read back exactly
+// as stored — the executor sees what production's clean container git would.
+const HERMETIC_GIT_ENV = {
+	GIT_CONFIG_COUNT: '0',
+	GIT_CONFIG_GLOBAL: '/dev/null',
+	GIT_CONFIG_SYSTEM: '/dev/null',
+};
+
+// Git runs against host temp dirs here (host and container paths coincide via
+// the containerWorkspaceRoot override), so the clone-over-SSH path is never
+// exercised — tests cover the skip and self-heal classification of
+// already-on-disk directories.
+const exec = new HostGitExecutor(HERMETIC_GIT_ENV);
+
+function git(cwd: string, ...args: string[]): string {
+	return execFileSync('git', args, {
+		cwd,
+		stdio: 'pipe',
+		env: { ...process.env, ...HERMETIC_GIT_ENV },
+	}).toString();
+}
+
+/** A real git repo at `dir`, optionally with an `origin` remote configured. */
+function makeRepo(dir: string, originUrl?: string): void {
+	mkdirSync(dir, { recursive: true });
+	git(dir, 'init', '-b', 'main');
+	if (originUrl) git(dir, 'remote', 'add', 'origin', originUrl);
+}
+
+/** The raw stored origin URL — unaffected by any insteadOf display rewriting. */
+function rawOriginUrl(dir: string): string {
+	return git(dir, 'config', '--get', 'remote.origin.url').trim();
+}
+
+/**
+ * Delegates to real host git but answers `ls-remote` with an empty ref listing —
+ * the empty-remote shape — so the adopt-in-place heal path completes without any
+ * network. Everything the heal does besides `ls-remote` is a local operation.
+ */
+class EmptyRemoteExecutor implements GitExecutor {
+	private readonly inner = new HostGitExecutor(HERMETIC_GIT_ENV);
+	exec(args: string[], opts: GitExecOpts): Promise<GitExecResult> {
+		if (args[0] === 'ls-remote') {
+			return Promise.resolve({ exitCode: 0, stdout: '', stderr: '' });
+		}
+		return this.inner.exec(args, opts);
+	}
+}
+
+/** Answers every git call with a zero-exit and no output — the stubbed-docker shape. */
+class SilentExecutor implements GitExecutor {
+	calls: string[][] = [];
+	exec(args: string[]): Promise<GitExecResult> {
+		this.calls.push(args);
+		return Promise.resolve({ exitCode: 0, stdout: '', stderr: '' });
+	}
+}
+
+async function withRepo(
+	identifier: string,
+	fn: (
+		targetDir: string,
+		sync: (executor: GitExecutor, logEmit?: LogEmitter) => Promise<RepoSyncResult>,
+	) => Promise<void>,
+): Promise<void> {
+	await db.query(
+		`INSERT INTO repos (project_id, repo_identifier, host_type)
+		 VALUES ($1, $2, 'github'::repo_host_type)`,
+		[projectId, identifier],
+	);
+	const workspacePath = join(dataDir, 'teams', teamId, 'projects', projectId, 'workspace');
+	try {
+		await fn(join(workspacePath, identifier.split('/')[1]), (executor, logEmit) =>
+			// Host and "container" paths coincide: the executor runs host git, so the
+			// workspace path doubles as the container workspace root.
+			ensureProjectRepos(
+				db,
+				{ id: projectId, team_id: teamId },
+				dataDir,
+				executor,
+				logEmit,
+				workspacePath,
+			),
+		);
+	} finally {
+		await db.query('DELETE FROM repos WHERE project_id = $1 AND repo_identifier = $2', [
+			projectId,
+			identifier,
+		]);
+	}
+}
 
 describe('ensureProjectRepos', () => {
 	it('returns empty result when no repos are linked', async () => {
 		const result = await ensureProjectRepos(db, { id: projectId, team_id: teamId }, dataDir, exec);
 		expect(result.cloned).toEqual([]);
+		expect(result.repaired).toEqual([]);
 		expect(result.skipped).toEqual([]);
 		expect(result.failed).toEqual([]);
 	});
 
-	it('skips repos whose target dir already contains .git', async () => {
-		// Insert a repo record directly; emulate an existing clone by creating .git.
-		await db.query(
-			`INSERT INTO repos (project_id, repo_identifier, host_type)
-			 VALUES ($1, 'owner/preexisting', 'github'::repo_host_type)`,
-			[projectId],
-		);
+	it('skips a clone whose origin already points at the linked repo', async () => {
+		await withRepo('owner/preexisting', async (targetDir, sync) => {
+			makeRepo(targetDir, 'git@github.com:owner/preexisting.git');
 
-		const workspacePath = join(dataDir, 'teams', teamId, 'projects', projectId, 'workspace');
-		const targetDir = join(workspacePath, 'preexisting');
-		mkdirSync(join(targetDir, '.git'), { recursive: true });
-		writeFileSync(join(targetDir, '.git', 'HEAD'), 'ref: refs/heads/main\n');
+			const result = await sync(exec);
+			expect(result.skipped).toContain('preexisting');
+			expect(result.repaired).toEqual([]);
+			expect(result.cloned).toEqual([]);
+		});
+	});
 
-		const logs: Array<{ stream: string; text: string }> = [];
-		const result = await ensureProjectRepos(
-			db,
-			{ id: projectId, team_id: teamId },
-			dataDir,
-			exec,
-			(stream, text) => logs.push({ stream, text }),
-		);
-		expect(result.skipped).toContain('preexisting');
-		expect(result.cloned).not.toContain('preexisting');
+	it('skips a clone whose origin is the https form of the linked repo', async () => {
+		await withRepo('owner/https-form', async (targetDir, sync) => {
+			makeRepo(targetDir, 'https://github.com/owner/https-form.git');
+
+			const result = await sync(exec);
+			expect(result.skipped).toContain('https-form');
+			expect(result.repaired).toEqual([]);
+		});
+	});
+
+	// The production incident: an agent ran `git init` in the reserved directory
+	// before the repo was connected, leaving a repo with no origin and an unborn
+	// HEAD. Every fetch then silently no-oped and worktree prep died on
+	// "failed to resolve HEAD as a valid ref". The sync must detect and heal it.
+	it('heals a stray git init (no origin) by adopting the directory in place', async () => {
+		await withRepo('owner/stray', async (targetDir, sync) => {
+			makeRepo(targetDir); // no origin, no commits — an agent's bare `git init`
+			writeFileSync(join(targetDir, 'draft.md'), 'agent draft\n');
+
+			const logs: Array<{ stream: string; text: string }> = [];
+			const result = await sync(new EmptyRemoteExecutor(), (stream, text) =>
+				logs.push({ stream, text }),
+			);
+
+			expect(result.repaired).toContain('stray');
+			expect(result.skipped).not.toContain('stray');
+			expect(result.failed).toEqual([]);
+			// Origin now tracks the linked repo, and the agent's draft survived.
+			expect(rawOriginUrl(targetDir)).toBe('git@github.com:owner/stray.git');
+			expect(readFileSync(join(targetDir, 'draft.md'), 'utf8')).toBe('agent draft\n');
+			expect(logs.some((l) => l.text.includes('Repairing owner/stray'))).toBe(true);
+		});
+	});
+
+	it('repoints an origin configured at the wrong repo', async () => {
+		await withRepo('owner/repointed', async (targetDir, sync) => {
+			makeRepo(targetDir, 'git@github.com:someone/else.git');
+
+			const result = await sync(exec);
+			expect(result.repaired).toContain('repointed');
+			expect(result.failed).toEqual([]);
+			expect(rawOriginUrl(targetDir)).toBe('git@github.com:owner/repointed.git');
+		});
+	});
+
+	// An executor that can't produce a definitive answer (a stubbed docker, a
+	// transport failure) must never trigger a "repair" of a possibly-healthy
+	// clone — the dir is left untouched and reported as skipped.
+	it('leaves the clone alone when the origin check is indeterminate', async () => {
+		await withRepo('owner/indeterminate', async (targetDir, sync) => {
+			makeRepo(targetDir); // no origin — but the executor can't see that
+			const silent = new SilentExecutor();
+
+			const result = await sync(silent);
+			expect(result.skipped).toContain('indeterminate');
+			expect(result.repaired).toEqual([]);
+			expect(result.failed).toEqual([]);
+			// Only the read happened; no mutating git call was issued.
+			expect(silent.calls).toEqual([['remote', 'get-url', 'origin']]);
+		});
 	});
 });
 


### PR DESCRIPTION
## Problem

A repo's reserved workspace directory can carry a `.git` that is not a usable clone of the linked repo — typically an agent ran `git init` in the directory before the repo was connected, leaving a repo with **no origin remote and an unborn HEAD**. Every run for the project then failed permanently in worktree prep:

1. `ensureProjectRepos` trusted any existing `.git` and skipped cloning.
2. `git fetch --all --prune` exits 0 with no remotes configured, so the "fetch" silently did nothing.
3. No `origin/HEAD` / `origin/main` / `origin/master` resolved, so the task worktree fell back to HEAD.
4. HEAD was unborn, and git (< 2.42, i.e. the `node:24-slim` container's 2.39) dies with the opaque `fatal: failed to resolve HEAD as a valid ref`.

The only recovery was manually deleting the directory on the Hezo host. This PR makes a version update recover existing broken production state automatically on the next run.

## Changes

- **Repo sync self-heals** (`repo-sync.ts`): an existing `.git` is verified, not trusted — `getOriginRemote` reads `origin` and a positively-wrong state is healed: missing origin → adopt the directory in place (`connectExistingRepo`: repair init, set origin, fetch + checkout the real default branch), wrong origin → repoint via `remote set-url`. Healing never discards local files or commits (a checkout that would clobber untracked work aborts, and the run still proceeds off the fetched `origin/<default>` on retry). Healed repos are reported in a new `RepoSyncResult.repaired` bucket and logged in the run output.
- **Only definitive answers trigger repair**: `missing` is reserved for git's own "No such remote" / "not a git repository"; a docker-exec transport failure or a stubbed executor's empty zero-exit is `indeterminate` and leaves the clone untouched.
- **Fetch fails loudly** (`git.ts`): `fetchRepo` runs `git fetch --prune origin` instead of `--all`, so a remoteless repo errors instead of pretending to be current.
- **Actionable worktree error**: when neither `origin/<default>` nor a born HEAD can seed the worktree, `addTaskWorktree` now fails with `clone has no commits and no remote default branch — push an initial commit to the remote and retry` instead of git's opaque message.
- **Idempotent adopt**: `connectExistingRepo` falls back to `remote set-url` when `origin` already exists, so re-healing a previously half-healed directory works.
- `.dev/architecture.md` updated (§ Containers & worktrees).

## Testing

- New `repo-sync.test.ts` coverage drives the real heal paths with host git: reproduces the incident state (stray `git init`, no origin, agent draft file) and asserts it is adopted with the draft preserved; asserts wrong-origin repoint; asserts an indeterminate executor answer performs no mutating git call.
- New `git.test.ts` coverage for `remoteUrlMatchesRepo` (SSH/`ssh://`/https forms, other-repo/other-host rejection), `getOriginRemote` classification, `fetchRepo` failing without origin, and the unborn-HEAD actionable error.
- New `git-init-in-place.test.ts` case for the set-url fallback.
- Ran the affected server suites (git*, repo*, agent-runner*, containers*: 300+ tests), web repo flows, typecheck, lint, and the full `bun run test --skip-browser` suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDsqMe2aPT7qmWVPx2qeHr

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDsqMe2aPT7qmWVPx2qeHr)_