### PR TITLE
build(docker): use Debian-packaged git in agent-base image

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -557,7 +557,7 @@ so a stale `/worktrees` is caught too — without this, a run could dispatch int
 
 **All git runs in the container — the host runs none.** Hezo's only prerequisite is Docker;
 there is no host `git`. Every repo/worktree operation (clone, fetch, `worktree add`, …) runs
-via `docker exec` in the project container (which ships git 2.51), driven from TypeScript on
+via `docker exec` in the project container (which ships Debian's packaged git), driven from TypeScript on
 the server through a `GitExecutor` seam (`services/git-executor.ts`): `ContainerGitExecutor`
 in production, `HostGitExecutor` (host `execFile`) in unit tests. `git.ts` functions take the
 executor plus a `{ hostPath, containerPath }` pair per location — `node:fs` checks use the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,9 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      # The Dockerfile builds git 2.51.0 from source (~5–10 min cold); the gha
-      # layer cache keeps unchanged-Dockerfile runs cheap.
+      # The agent-base image installs everything (incl. git) from Debian
+      # packages, so a cold build is quick; the gha layer cache keeps
+      # unchanged-Dockerfile runs cheaper still.
       - uses: docker/build-push-action@v6
         with:
           context: docker

--- a/docker/Dockerfile.agent-base
+++ b/docker/Dockerfile.agent-base
@@ -2,31 +2,17 @@ FROM node:24-slim
 
 # Install common development tools. `unzip` is required by the upstream bun.sh
 # installer and other `curl | bash` installers agents may run at runtime.
+#
+# Debian's packaged `git` is sufficient: every git operation (worktree add,
+# status, commit, push) runs inside this container via `docker exec`, and the
+# per-task worktrees are created and consumed entirely with in-container paths,
+# so nothing depends on the relative-path worktree extension (`extensions.
+# relativeWorktrees`, git 2.48+) — no code passes `--relative-paths`. That is why
+# building git from source is no longer needed; the distro package keeps the
+# image build fast and cache-friendly.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl jq unzip openssh-client ca-certificates python3 socat sudo \
+    git curl jq unzip openssh-client ca-certificates python3 socat sudo \
     && rm -rf /var/lib/apt/lists/*
-
-# Build git from source. The host creates per-task worktrees with
-# `git worktree add --relative-paths`, which records `extensions.relativeworktrees`
-# in the repo config. Debian's packaged git (<2.48) refuses to read that
-# extension — "fatal: unknown repository extension found: relativeworktrees" —
-# which breaks every in-container git operation (status/commit/push), so agents
-# can never persist their work. Build a git new enough to understand it, then
-# drop the heavy build toolchain in the same layer (the small -dev packages stay
-# so git keeps its runtime shared libs). The final `git --version` fails the
-# build if anything is wrong.
-ENV GIT_VERSION=2.51.0
-RUN apt-get update && apt-get install -y --no-install-recommends \
-      build-essential gettext libcurl4-openssl-dev libexpat1-dev zlib1g-dev libssl-dev \
-    && curl -fsSL "https://www.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz" -o /tmp/git.tar.gz \
-    && tar -xzf /tmp/git.tar.gz -C /tmp \
-    && make -C "/tmp/git-${GIT_VERSION}" prefix=/usr/local NO_TCLTK=1 NO_GITWEB=1 NO_PERL=1 NO_PYTHON=1 -j"$(nproc)" all \
-    && make -C "/tmp/git-${GIT_VERSION}" prefix=/usr/local NO_TCLTK=1 NO_GITWEB=1 NO_PERL=1 NO_PYTHON=1 install \
-    && rm -rf /tmp/git.tar.gz "/tmp/git-${GIT_VERSION}" \
-    && apt-get purge -y build-essential \
-    && apt-get autoremove -y \
-    && rm -rf /var/lib/apt/lists/* \
-    && git --version
 
 # The container runs as the unprivileged `node` user (so bind-mounted worktree
 # files stay node-owned), but agents need to install system packages at runtime


### PR DESCRIPTION
## Summary

The agent-base image built **git 2.51.0 from source** to work around a constraint that no longer exists. This replaces the from-source build with `apt-get install git`, dropping the build toolchain, tarball download, and full compile (~5–10 min cold) from every image build.

## Why it's safe to drop the from-source build

The original justification (preserved in the old Dockerfile comment): the host created per-task worktrees with `git worktree add --relative-paths`, which records the `extensions.relativeWorktrees` extension (git 2.48+); Debian's packaged git (<2.48) refuses to read it, breaking every in-container git op.

That is obsolete:

- **All git now runs inside the container** via `docker exec` (`ContainerGitExecutor`) — `git-executor.ts:24-25`: *"The host process itself never runs git in production."*
- **No code passes `--relative-paths`.** A repo-wide grep finds the string only in the old Dockerfile comment. Every `worktree add` in `packages/server/src/services/git.ts` uses plain absolute paths.
- **The `relativeWorktrees` extension is never written** to any repo config.
- The host↔container path mismatch that relative-paths solved is gone: worktrees are created and consumed entirely with in-container paths, so absolute paths in `.git` resolve fine. Nothing in `git.ts` needs 2.48+ (the newest version it reasons about is a `<2.42` workaround).

Debian trixie (base of `node:24-slim`) packages git 2.47.3 — plenty for the plain worktree add/list/prune/remove operations the orchestration performs.

## Changes

- `docker/Dockerfile.agent-base` — add `git` to the base `apt-get install`; remove the `GIT_VERSION` env + from-source build `RUN` block; rewrite the explanatory comment.
- `.github/workflows/ci.yml` — refresh the stale comment that described the 2.51 from-source build.
- `.dev/architecture.md` — update the "ships git 2.51" reference to "Debian's packaged git".

## Testing

No TypeScript changes, so no unit test exercises this. Docker is unavailable in the authoring environment; the image build is validated by CI's `build-agent-image` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYmUKMRF2ofXp54mUJPkWy

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYmUKMRF2ofXp54mUJPkWy)_