### PR TITLE
fix(web): wrap container controls on mobile and add confirm-dialog close button

### DIFF
--- a/packages/web/src/components/ui/confirm-dialog.tsx
+++ b/packages/web/src/components/ui/confirm-dialog.tsx
@@ -1,5 +1,5 @@
 import * as AlertDialog from '@radix-ui/react-alert-dialog';
-import { Loader2 } from 'lucide-react';
+import { Loader2, X } from 'lucide-react';
 import { useState } from 'react';
 import { dialogContentClassName, dialogOverlayClassName } from './dialog';
 
@@ -50,6 +50,17 @@ export function ConfirmDialog({
 			<AlertDialog.Portal>
 				<AlertDialog.Overlay className={dialogOverlayClassName} />
 				<AlertDialog.Content data-testid="confirm-dialog" className={dialogContentClassName.sm}>
+					<AlertDialog.Cancel asChild>
+						<button
+							type="button"
+							disabled={loading}
+							className="absolute right-3 top-3 z-10 -m-1 p-2 text-text-2 hover:text-text-1 disabled:opacity-50 disabled:pointer-events-none sm:right-4 sm:top-4"
+							aria-label="Close"
+							data-testid="confirm-dialog-close"
+						>
+							<X className="h-4 w-4" />
+						</button>
+					</AlertDialog.Cancel>
 					<AlertDialog.Title className="text-base font-semibold mb-2">{title}</AlertDialog.Title>
 					{description && (
 						<AlertDialog.Description className="text-[13px] text-text-2 mb-5 leading-relaxed">

--- a/packages/web/src/routes/projects/$projectId/container.tsx
+++ b/packages/web/src/routes/projects/$projectId/container.tsx
@@ -90,18 +90,22 @@ function ContainerPage() {
 	return (
 		<div className="flex flex-col gap-5">
 			{/* Controls */}
-			<div className="flex items-center gap-3 rounded-lg border border-border-subtle bg-surface px-4 py-3">
-				{isBuilding ? (
-					<Badge color="info" testId="container-status-badge-building">
-						Rebuilding{imageBuild ? ` ${imageBuild.percent}%` : ''}
-					</Badge>
-				) : (
-					<ContainerStatusBadge status={project.container_status} />
-				)}
-				{project.container_id && (
-					<span className="font-mono text-xs text-text-2">{project.container_id.slice(0, 12)}</span>
-				)}
-				<div className="ml-auto flex items-center gap-2">
+			<div className="flex flex-col gap-3 rounded-lg border border-border-subtle bg-surface px-4 py-3 sm:flex-row sm:items-center">
+				<div className="flex items-center gap-3">
+					{isBuilding ? (
+						<Badge color="info" testId="container-status-badge-building">
+							Rebuilding{imageBuild ? ` ${imageBuild.percent}%` : ''}
+						</Badge>
+					) : (
+						<ContainerStatusBadge status={project.container_status} />
+					)}
+					{project.container_id && (
+						<span className="font-mono text-xs text-text-2">
+							{project.container_id.slice(0, 12)}
+						</span>
+					)}
+				</div>
+				<div className="flex flex-wrap items-center gap-2 sm:ml-auto">
 					<Tooltip content="Start container">
 						<Button
 							variant="ghost"

--- a/packages/web/test/container-states.test.tsx
+++ b/packages/web/test/container-states.test.tsx
@@ -214,3 +214,28 @@ test('the Restart control opens a confirm dialog whose confirm posts to the rebu
 	await r.user.click(await r.findByRole('button', { name: 'Restart' }));
 	await waitFor(() => expect(rebuilt).toBe(true), { timeout: 15_000 });
 });
+
+test('the confirm dialog has a top-right close button that dismisses it without running the action', async () => {
+	let rebuilt = false;
+	const r = await renderContainer(
+		(teamId) =>
+			fakeProject(teamId, {
+				slug: 'close-flow',
+				container_status: 'running',
+				container_id: '111122223333',
+				docker_base_image: 'hezo/agent-base:latest',
+			}),
+		{ onRebuild: () => (rebuilt = true) },
+	);
+
+	const restartBtn = await r.findByRole('button', { name: /Restart/ }, { timeout: 20_000 });
+	await r.user.click(restartBtn);
+	await r.findByText('Restart container?');
+
+	// The X in the top-right corner dismisses the dialog like Cancel does.
+	const closeBtn = await r.findByTestId('confirm-dialog-close');
+	await r.user.click(closeBtn);
+
+	await waitFor(() => expect(r.queryByText('Restart container?')).toBeNull(), { timeout: 15_000 });
+	expect(rebuilt).toBe(false);
+});


### PR DESCRIPTION
## Summary

Two mobile-layout fixes on the container page and shared confirm dialog.

**Container controls wrapping.** On a narrow mobile viewport the container page's `Start` / `Stop` / `Restart` buttons overflowed off the right edge — the controls bar was a single horizontal flex row with the buttons pushed right via `ml-auto`, so they ran past the screen edge behind the status badge. The bar now stacks vertically on mobile (status badge + container id on top, buttons wrapping below) and keeps the inline row at `sm+`.

**Confirm-dialog close button.** `ConfirmDialog` (Radix `AlertDialog`) was the only modal without a top-right close (X) button — every `DialogContent`-based modal already renders one. On touch there's no Escape key and the AlertDialog overlay isn't click-to-close, so there was no obvious way to dismiss it other than the inline Cancel button. Added an X in the top-right corner that wires through `AlertDialog.Cancel`, so it dismisses the dialog without running the (potentially destructive) action, and is disabled while the action is in flight.

## Changes

- `packages/web/src/routes/projects/$projectId/container.tsx` — stack the controls bar on mobile (`flex-col` → `sm:flex-row`), group status + id, allow the button cluster to `flex-wrap`.
- `packages/web/src/components/ui/confirm-dialog.tsx` — add a top-right close button backed by `AlertDialog.Cancel`.

## Testing

- Added a component test asserting the confirm dialog's close button dismisses it without invoking the action.
- `bunx vitest run test/container-states.test.tsx test/container-management.test.tsx` — 8 + existing tests pass.
- `turbo typecheck` and `biome check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0129v9vz7yqht6DfFTWDkxKc)_