### PR TITLE
fix(repos): run repo checkout setup in the background instead of inside POST /repos

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -103,7 +103,18 @@ container config, dev ports, the designated repo, and `is_internal` (only HQ).
 **Repos.** `repos` stores a GitHub `owner/repo` identifier; the segment after the owner
 is the display label, worktree directory name, and `@mention` handle. The **first** repo
 linked to a project becomes its immutable `designated_repo_id` (`ON DELETE RESTRICT` +
-a 409 `DESIGNATED_REPO_IMMUTABLE` guard).
+a 409 `DESIGNATED_REPO_IMMUTABLE` guard). Adding a repo is **asynchronous**: `POST
+/repos` validates GitHub-side access (or creates the repo upstream), inserts the row
+with `setup_status = 'pending'`, and returns immediately; the slow half — container up,
+in-container clone, first-repo designation + approval finalize — runs in a tracked
+background task (`services/repo-provisioning.ts`) and settles the row to
+`ready`/`failed` (`setup_error` records why), broadcast to the team room as a `repos`
+UPDATE. Failures never delete the row: designation is still deferred until a checkout
+exists (the gate never half-opens), and POSTing the same repo again reclaims a
+`failed` row back to `pending` and re-runs setup (a live `pending` duplicate 409s
+`REPO_SETUP_IN_PROGRESS`; a `ready` duplicate 409s `REPO_NAME_TAKEN`). Rows still
+`pending` at boot were lost with the previous process — `JobManager.reconcileOnStartup`
+parks them `failed` so they surface as retryable instead of spinning forever.
 
 **Tasks & threads.** `tasks` are Linear-style tickets with a frozen `identifier`
 (`<task_prefix>-<n>`, e.g. `IN-42`), a required `assignee_id → members.id`, `rules`, and

--- a/docs/security/git-and-verified-commits.md
+++ b/docs/security/git-and-verified-commits.md
@@ -27,6 +27,12 @@ your GitHub account as both a *signing* key (so commits show the Verified badge)
 *authentication* key (so SSH git operations work). Subsequent repositories reuse that
 connection.
 
+When you link or create a repository, Hezo records it right away and prepares the
+checkout **in the background** — starting the project's workspace and cloning the
+repository can take a few minutes the first time. The repository shows **"Setting up…"**
+until it's ready; if setup fails (for example the workspace couldn't start), the error is
+shown on the repository with a **Retry** button.
+
 ## Verified commits, signed on the host
 
 When an agent commits, the **signing happens host-side on its behalf** — the agent asks

--- a/packages/server/migrations/017_repo_setup_status.sql
+++ b/packages/server/migrations/017_repo_setup_status.sql
@@ -1,0 +1,13 @@
+-- Repo checkout setup (container up + in-container clone + first-repo
+-- designation) now runs in the background after POST /repos returns, instead
+-- of holding the HTTP request open for minutes. Track its lifecycle on the
+-- row so the UI can render progress/failure and a failed or interrupted
+-- setup can be retried instead of dead-ending on the unique index.
+--
+-- Existing rows predate the state machine and only ever persisted after a
+-- successful (or explicitly tolerated) setup, so they backfill to 'ready'.
+CREATE TYPE repo_setup_status AS ENUM ('pending', 'ready', 'failed');
+
+ALTER TABLE repos
+    ADD COLUMN setup_status repo_setup_status NOT NULL DEFAULT 'ready',
+    ADD COLUMN setup_error TEXT;

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -264,6 +264,14 @@ void (async () => {
 
 export default {
 	port: config.port,
+	// Bun's default idleTimeout is 10s, measured between writes on the socket.
+	// Handlers that legitimately work for a while before producing their first
+	// byte (GitHub API round-trips, container queries, big uploads) get their
+	// connection severed mid-request at the default — the client sees a bare
+	// "Failed to fetch" while the server keeps working. 120s is deliberate
+	// headroom, not a license for slow routes: anything that can outlive it
+	// (cloning, provisioning) must run in the background, not in the handler.
+	idleTimeout: 120,
 	fetch: (req: Request, server: Bun.Server<WsConnectionData>) => {
 		const url = new URL(req.url);
 		if (!serverReady) {

--- a/packages/server/src/routes/repos.ts
+++ b/packages/server/src/routes/repos.ts
@@ -1,23 +1,17 @@
-import { repoNameFromIdentifier, wsRoom } from '@hezo/shared';
-import { type Context, Hono } from 'hono';
+import { RepoSetupStatus, repoNameFromIdentifier, wsRoom } from '@hezo/shared';
+import { Hono } from 'hono';
+import { trackBackground } from '../lib/background';
 import { broadcastChange } from '../lib/broadcast';
 import { getProjectLocator, resolveProjectId } from '../lib/resolve';
 import { err, ok } from '../lib/response';
-import { isUniqueViolation, withTransaction } from '../lib/sql';
+import { isUniqueViolation } from '../lib/sql';
 import type { Env } from '../lib/types';
 import { logger } from '../logger';
-import { resolveContainerRunUser } from '../services/container-user';
-import { ensureProjectContainerRunning } from '../services/containers';
-import { ContainerGitExecutor } from '../services/git-executor';
+import type { ContainerDeps } from '../services/containers';
 import { createGitHubRepo, parseGitHubUrl, validateRepoAccess } from '../services/github';
 import { getConnection } from '../services/oauth/connection-store';
-import {
-	enqueueRepoSetupResumeWakeups,
-	finalizePendingRepoSetup,
-	markRepoSetupFailed,
-} from '../services/repo-setup';
-import { ensureProjectRepos, removeRepoFromWorkspace } from '../services/repo-sync';
-import { type BridgeRunnerArgs, withProvisionBridge } from '../services/ssh-agent';
+import { performRepoSetup } from '../services/repo-provisioning';
+import { removeRepoFromWorkspace } from '../services/repo-sync';
 
 const log = logger.child('routes');
 
@@ -31,7 +25,7 @@ reposRoutes.get('/projects/:projectId/repos', async (c) => {
 
 	const result = await db.query(
 		`SELECT r.id, r.project_id, r.repo_identifier, r.host_type,
-		        r.oauth_connection_id, r.created_at,
+		        r.oauth_connection_id, r.created_at, r.setup_status, r.setup_error,
 		        (p.designated_repo_id = r.id) AS is_designated,
 		        oc.provider_account_label AS oauth_account_label
 		 FROM repos r
@@ -48,9 +42,11 @@ reposRoutes.get('/projects/:projectId/repos', async (c) => {
 /**
  * Add a GitHub repository to the project. The user must already have an
  * active GitHub OAuth connection for this team; the request supplies its
- * id, and the server validates access via the corresponding token before
- * recording the repo. Clones run over HTTPS, with the proxy substituting
- * the access-token placeholder at request time.
+ * id, and the server validates access (mode=link) or creates the repo on
+ * GitHub (mode=create) via the corresponding token before recording the row.
+ * The row is returned `pending`; the checkout itself (container up +
+ * in-container clone + first-repo designation) settles in the background —
+ * see `performRepoSetup`.
  */
 reposRoutes.post('/projects/:projectId/repos', async (c) => {
 	const teamId = c.get('teamId') as string;
@@ -143,45 +139,48 @@ reposRoutes.post('/projects/:projectId/repos', async (c) => {
 		host_type: string;
 		oauth_connection_id: string | null;
 		created_at: string;
+		setup_status: string;
+		setup_error: string | null;
 	};
-	const emptyFinalize: Awaited<ReturnType<typeof finalizePendingRepoSetup>> = {
-		resolvedApprovalId: null,
-		affectedTaskIds: [],
-		deferredWakeups: [],
-		approvalRow: null,
-		updatedCommentRows: [],
-		systemCommentRows: [],
-	};
+	const REPO_COLUMNS = `id, project_id, repo_identifier, host_type, oauth_connection_id,
+	                      created_at, setup_status, setup_error`;
 
+	// The row is inserted `pending` and the response returns immediately; the
+	// slow half (container up + in-container clone + first-repo designation)
+	// runs in the background and settles the row to ready/failed, broadcast to
+	// the team room. Holding the request open for that work is not an option —
+	// it can take minutes (image pull, provisioning), which outlives HTTP
+	// timeouts, and a connection or server death mid-flight used to strand a
+	// half-set-up row that 409'd every retry.
 	let insertedRepo: InsertedRepo;
-	let becameDesignated = false;
-	let finalizeResult = emptyFinalize;
-	// Whether this repo would become the project's designated repo once its
-	// checkout is in place. Designation is deferred until the clone/init
-	// succeeds so a setup failure never leaves the gate half-open.
-	let wouldDesignate = false;
-
 	try {
-		const txResult = await withTransaction(db, async () => {
-			const lockRes = await db.query<{ id: string; designated_repo_id: string | null }>(
-				'SELECT id, designated_repo_id FROM projects WHERE id = $1 FOR UPDATE',
-				[projectId],
-			);
-			if (lockRes.rows.length === 0) throw new Error('project disappeared during insert');
-			const projectRow = lockRes.rows[0];
-
-			const insertRes = await db.query<InsertedRepo>(
-				`INSERT INTO repos (project_id, repo_identifier, host_type, oauth_connection_id)
-				 VALUES ($1, $2, 'github'::repo_host_type, $3)
-				 RETURNING id, project_id, repo_identifier, host_type, oauth_connection_id, created_at`,
-				[projectId, repoIdentifier, conn.id],
-			);
-			return { inserted: insertRes.rows[0], wouldDesignate: !projectRow.designated_repo_id };
-		});
-		insertedRepo = txResult.inserted;
-		wouldDesignate = txResult.wouldDesignate;
+		const insertRes = await db.query<InsertedRepo>(
+			`INSERT INTO repos (project_id, repo_identifier, host_type, oauth_connection_id, setup_status)
+			 VALUES ($1, $2, 'github'::repo_host_type, $3, $4::repo_setup_status)
+			 RETURNING ${REPO_COLUMNS}`,
+			[projectId, repoIdentifier, conn.id, RepoSetupStatus.Pending],
+		);
+		insertedRepo = insertRes.rows[0];
 	} catch (e) {
-		if (isUniqueViolation(e)) {
+		if (!isUniqueViolation(e)) {
+			const msg = e instanceof Error ? e.message : 'Failed to insert repo';
+			return err(c, 'REPO_INSERT_FAILED', msg, 500);
+		}
+		// A repo with this name is already on the project. A `failed` row for the
+		// same repo is a retry: reclaim it to pending and run setup again (rows
+		// stranded pending by a restart are marked failed at startup, so a live
+		// `pending` row really is in flight).
+		const existing = await db.query<InsertedRepo>(
+			`SELECT ${REPO_COLUMNS} FROM repos
+			 WHERE project_id = $1 AND split_part(repo_identifier, '/', 2) = $2`,
+			[projectId, repoName],
+		);
+		const row = existing.rows[0];
+		if (
+			!row ||
+			row.repo_identifier !== repoIdentifier ||
+			row.setup_status === RepoSetupStatus.Ready
+		) {
 			return err(
 				c,
 				'REPO_NAME_TAKEN',
@@ -189,143 +188,43 @@ reposRoutes.post('/projects/:projectId/repos', async (c) => {
 				409,
 			);
 		}
-		const msg = e instanceof Error ? e.message : 'Failed to insert repo';
-		return err(c, 'REPO_INSERT_FAILED', msg, 500);
+		const reclaimed = await db.query<InsertedRepo>(
+			`UPDATE repos
+			 SET setup_status = $1::repo_setup_status, setup_error = NULL, oauth_connection_id = $2
+			 WHERE id = $3 AND setup_status = $4::repo_setup_status
+			 RETURNING ${REPO_COLUMNS}`,
+			[RepoSetupStatus.Pending, conn.id, row.id, RepoSetupStatus.Failed],
+		);
+		if (reclaimed.rows.length === 0) {
+			return err(c, 'REPO_SETUP_IN_PROGRESS', `${repoIdentifier} is already being set up`, 409);
+		}
+		insertedRepo = reclaimed.rows[0];
 	}
 
 	const dataDir = c.get('dataDir');
 	const docker = c.get('docker');
-	let cloneStatus: 'skipped' | 'cloned' | 'failed' = 'skipped';
-	let cloneError: string | undefined;
-
-	if (dataDir && docker) {
-		const locator = await getProjectLocator(db, projectId);
-		if (locator) {
-			// Git runs inside the project container, so bring it up first (provisioning
-			// clones if it had to provision), then clone in-container. The host runs no git.
-			await ensureProjectContainerUp(c, projectId);
-			const containerRow = await db.query<{
-				container_id: string | null;
-				container_status: string | null;
-			}>('SELECT container_id, container_status FROM projects WHERE id = $1', [projectId]);
-			const containerId = containerRow.rows[0]?.container_id ?? null;
-			const running = containerRow.rows[0]?.container_status === 'running';
-			const sshAgentServer = c.get('sshAgentServer');
-
-			if (containerId && running) {
-				const runUser = await resolveContainerRunUser(docker, containerId);
-				const syncRepos = (bridge: BridgeRunnerArgs | null) =>
-					ensureProjectRepos(
-						db,
-						{ id: projectId, team_id: teamId },
-						dataDir,
-						ContainerGitExecutor.forPrep(docker, containerId, bridge, runUser),
-					);
-				const syncRes = sshAgentServer
-					? await withProvisionBridge(sshAgentServer, teamId, dataDir, runUser.name, ({ bridge }) =>
-							syncRepos(bridge),
-						)
-					: await syncRepos(null);
-				const failed = syncRes.failed.find((f) => f.name === repoName);
-				if (failed) {
-					cloneStatus = 'failed';
-					cloneError = failed.error;
-					log.error(`Failed to clone ${repoIdentifier}:`, cloneError);
-				} else if (
-					syncRes.cloned.includes(repoName) ||
-					// A pre-existing dir whose broken git state was healed (origin
-					// added/repointed) — setup produced a usable checkout, same as a clone.
-					syncRes.repaired.includes(repoName)
-				) {
-					cloneStatus = 'cloned';
-				}
-			} else {
-				cloneStatus = 'failed';
-				cloneError = 'project container is not running';
-				log.error(`Cannot clone ${repoIdentifier}: container not running`);
-			}
-		}
-	}
-
-	if (wouldDesignate) {
-		if (cloneStatus === 'failed') {
-			// Setup never produced a usable checkout. Don't designate or persist the
-			// repo; tell the operator on the gated task(s) and leave the approval
-			// pending so a fixed retry resolves it. Agents stay correctly parked.
-			const failure = await markRepoSetupFailed(db, {
-				teamId,
-				projectId,
-				repoIdentifier,
-				error: cloneError ?? 'unknown error',
-			});
-			await db.query('DELETE FROM repos WHERE id = $1', [insertedRepo.id]);
-			for (const row of failure.systemCommentRows) {
-				broadcastChange(c, wsRoom.team(teamId), 'task_comments', 'INSERT', row);
-			}
-			return err(
-				c,
-				'REPO_SETUP_FAILED',
-				`Failed to set up ${repoIdentifier}: ${cloneError ?? 'unknown error'}`,
-				500,
-			);
-		}
-
-		finalizeResult = await withTransaction(db, async () => {
-			await db.query('UPDATE projects SET designated_repo_id = $1 WHERE id = $2', [
-				insertedRepo.id,
-				projectId,
-			]);
-			return finalizePendingRepoSetup(db, {
-				teamId,
-				projectId,
-				repoId: insertedRepo.id,
-				repoIdentifier,
-			});
-		});
-		becameDesignated = true;
-
-		if (finalizeResult.resolvedApprovalId) {
-			await enqueueRepoSetupResumeWakeups(
-				db,
-				teamId,
-				insertedRepo.id,
-				finalizeResult.resolvedApprovalId,
-				finalizeResult.deferredWakeups,
-			);
-		}
-	}
+	const setupDeps: Omit<ContainerDeps, 'docker' | 'dataDir'> = {
+		db,
+		wsManager: c.get('wsManager'),
+		masterKeyManager: c.get('masterKeyManager'),
+		logs: c.get('logs'),
+		containerLogStreamer: c.get('containerLogStreamer'),
+		sshAgentServer: c.get('sshAgentServer'),
+		egressCAPath: c.get('egressProxy')?.caCertPath ?? null,
+	};
+	trackBackground(
+		performRepoSetup(
+			{ ...setupDeps, docker, dataDir },
+			{ teamId, projectId, repoId: insertedRepo.id, repoIdentifier },
+		).catch((e) => log.error(`Background repo setup for ${repoIdentifier} failed:`, e)),
+	);
 
 	broadcastChange(c, wsRoom.team(teamId), 'repos', 'INSERT', {
 		...insertedRepo,
-		is_designated: becameDesignated,
+		is_designated: false,
 	} as Record<string, unknown>);
 
-	if (becameDesignated) {
-		broadcastChange(c, wsRoom.team(teamId), 'projects', 'UPDATE', {
-			id: projectId,
-			designated_repo_id: insertedRepo.id,
-		});
-		if (finalizeResult.approvalRow) {
-			broadcastChange(c, wsRoom.team(teamId), 'approvals', 'UPDATE', finalizeResult.approvalRow);
-		}
-		for (const row of finalizeResult.updatedCommentRows) {
-			broadcastChange(c, wsRoom.team(teamId), 'task_comments', 'UPDATE', row);
-		}
-		for (const row of finalizeResult.systemCommentRows) {
-			broadcastChange(c, wsRoom.team(teamId), 'task_comments', 'INSERT', row);
-		}
-	}
-
-	return ok(
-		c,
-		{
-			...insertedRepo,
-			is_designated: becameDesignated,
-			clone_status: cloneStatus,
-			clone_error: cloneError ?? null,
-		},
-		201,
-	);
+	return ok(c, { ...insertedRepo, is_designated: false }, 201);
 });
 
 reposRoutes.delete('/projects/:projectId/repos/:repoId', async (c) => {
@@ -421,31 +320,4 @@ async function loadOAuthAccessToken(
 	if (result.rows.length === 0) return null;
 	const { decrypt } = await import('../crypto/encryption');
 	return decrypt(result.rows[0].encrypted_value, key);
-}
-
-async function ensureProjectContainerUp(c: Context<Env>, projectId: string): Promise<void> {
-	const docker = c.get('docker');
-	const dataDir = c.get('dataDir');
-	const egressProxy = c.get('egressProxy');
-
-	if (!docker || !dataDir) return;
-
-	try {
-		await ensureProjectContainerRunning(
-			{
-				db: c.get('db'),
-				docker,
-				dataDir,
-				wsManager: c.get('wsManager'),
-				masterKeyManager: c.get('masterKeyManager'),
-				logs: c.get('logs'),
-				containerLogStreamer: c.get('containerLogStreamer'),
-				sshAgentServer: c.get('sshAgentServer'),
-				egressCAPath: egressProxy?.caCertPath ?? null,
-			},
-			projectId,
-		);
-	} catch (e) {
-		log.error('Failed to auto-start container after repo add:', e);
-	}
 }

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -10,6 +10,7 @@ import {
 	DEFAULT_TEAM_ID,
 	HeartbeatRunStatus,
 	INSTANCE_AGENT_SLUGS,
+	RepoSetupStatus,
 	TaskPriority,
 	TERMINAL_TASK_STATUSES,
 	WakeupSkipReason,
@@ -673,9 +674,28 @@ export class JobManager {
 			);
 		}
 
-		if (stranded.rows.length > 0 || resetAgents.rows.length > 0) {
+		// Repo rows whose background setup (clone + designation) was in flight when
+		// the previous process died. Their setup can't resume — the work was lost
+		// with the process — so park them `failed`; POSTing the same repo again
+		// reclaims a failed row and re-runs setup.
+		const strandedRepos = await db.query<Record<string, unknown> & { team_id: string }>(
+			`UPDATE repos r
+			 SET setup_status = $1::repo_setup_status,
+			     setup_error = 'Server restarted while repository setup was in flight'
+			 FROM projects p
+			 WHERE p.id = r.project_id AND r.setup_status = $2::repo_setup_status
+			 RETURNING r.id, r.project_id, r.repo_identifier, r.host_type, r.oauth_connection_id,
+			           r.created_at, r.setup_status, r.setup_error, p.team_id,
+			           (p.designated_repo_id = r.id) AS is_designated`,
+			[RepoSetupStatus.Failed, RepoSetupStatus.Pending],
+		);
+		for (const { team_id, ...repo } of strandedRepos.rows) {
+			broadcastRowChange(wsManager, wsRoom.team(team_id), 'repos', 'UPDATE', repo);
+		}
+
+		if (stranded.rows.length > 0 || resetAgents.rows.length > 0 || strandedRepos.rows.length > 0) {
 			log.info(
-				`Startup reconciliation: failed ${stranded.rows.length} stranded run(s), reset ${resetAgents.rows.length} agent(s) to idle`,
+				`Startup reconciliation: failed ${stranded.rows.length} stranded run(s), reset ${resetAgents.rows.length} agent(s) to idle, failed ${strandedRepos.rows.length} interrupted repo setup(s)`,
 			);
 		}
 

--- a/packages/server/src/services/repo-provisioning.ts
+++ b/packages/server/src/services/repo-provisioning.ts
@@ -1,0 +1,247 @@
+import { RepoSetupStatus, repoNameFromIdentifier, wsRoom } from '@hezo/shared';
+import type { Db } from '../db/database';
+import { broadcastRowChange } from '../lib/broadcast';
+import { withTransaction } from '../lib/sql';
+import { logger } from '../logger';
+import { resolveContainerRunUser } from './container-user';
+import { type ContainerDeps, ensureProjectContainerRunning } from './containers';
+import { ContainerGitExecutor } from './git-executor';
+import {
+	enqueueRepoSetupResumeWakeups,
+	finalizePendingRepoSetup,
+	markRepoSetupFailed,
+} from './repo-setup';
+import { ensureProjectRepos } from './repo-sync';
+import { type BridgeRunnerArgs, withProvisionBridge } from './ssh-agent';
+
+const log = logger.child('repo-provisioning');
+
+/**
+ * `ContainerDeps` minus the hard docker/data-dir requirement: a deployment
+ * shape without Docker or a data dir has nothing to clone, and setup settles
+ * straight to ready.
+ */
+export type RepoSetupDeps = Omit<ContainerDeps, 'docker' | 'dataDir'> & {
+	docker?: ContainerDeps['docker'] | null;
+	dataDir?: ContainerDeps['dataDir'] | null;
+};
+
+export interface RepoSetupInput {
+	teamId: string;
+	projectId: string;
+	repoId: string;
+	repoIdentifier: string;
+}
+
+export interface RepoSetupOutcome {
+	status: RepoSetupStatus;
+	designated: boolean;
+	error: string | null;
+}
+
+interface RepoRowForBroadcast {
+	id: string;
+	project_id: string;
+	repo_identifier: string;
+	host_type: string;
+	oauth_connection_id: string | null;
+	created_at: string;
+	setup_status: string;
+	setup_error: string | null;
+}
+
+/**
+ * Runs the slow half of adding a repo — container up, in-container clone,
+ * first-repo designation — for a `repos` row already inserted in `pending`
+ * state. POST /repos returns before this runs (wrap the call in
+ * `trackBackground`), so every state change here is pushed to clients over
+ * the team room: `repos` UPDATE when the row settles, plus the designation
+ * family (`projects`, `approvals`, `task_comments`) when the gate resolves.
+ *
+ * Failures never delete the row: the row parks in `failed` with the error on
+ * it, the designated-repo approval stays pending (agents stay parked), and a
+ * retry POST for the same repo re-enters `pending` and runs this again.
+ */
+export async function performRepoSetup(
+	deps: RepoSetupDeps,
+	input: RepoSetupInput,
+): Promise<RepoSetupOutcome> {
+	const { db, docker, dataDir } = deps;
+	const repoName = repoNameFromIdentifier(input.repoIdentifier);
+
+	let setupError: string | null = null;
+	if (docker && dataDir) {
+		const containerDeps: ContainerDeps = { ...deps, docker, dataDir };
+		try {
+			try {
+				await ensureProjectContainerRunning(containerDeps, input.projectId);
+			} catch (e) {
+				log.error('Failed to auto-start container during repo setup:', e);
+			}
+
+			const containerRow = await db.query<{
+				container_id: string | null;
+				container_status: string | null;
+			}>('SELECT container_id, container_status FROM projects WHERE id = $1', [input.projectId]);
+			const containerId = containerRow.rows[0]?.container_id ?? null;
+			const running = containerRow.rows[0]?.container_status === 'running';
+
+			if (containerId && running) {
+				// Git runs inside the project container; the host runs no git. The
+				// provisioning bridge carries the project SSH key into the exec.
+				const runUser = await resolveContainerRunUser(docker, containerId);
+				const syncRepos = (bridge: BridgeRunnerArgs | null) =>
+					ensureProjectRepos(
+						db,
+						{ id: input.projectId, team_id: input.teamId },
+						dataDir,
+						ContainerGitExecutor.forPrep(docker, containerId, bridge, runUser),
+					);
+				const syncRes = deps.sshAgentServer
+					? await withProvisionBridge(
+							deps.sshAgentServer,
+							input.teamId,
+							dataDir,
+							runUser.name,
+							({ bridge }) => syncRepos(bridge),
+						)
+					: await syncRepos(null);
+				const failed = syncRes.failed.find((f) => f.name === repoName);
+				if (failed) {
+					setupError = failed.error;
+					log.error(`Failed to clone ${input.repoIdentifier}:`, failed.error);
+				}
+			} else {
+				setupError = 'project container is not running';
+				log.error(`Cannot clone ${input.repoIdentifier}: container not running`);
+			}
+		} catch (e) {
+			setupError = e instanceof Error ? e.message : 'unknown error';
+			log.error(`Repo setup for ${input.repoIdentifier} threw:`, e);
+		}
+	}
+
+	if (setupError) {
+		return finishFailed(deps, input, setupError);
+	}
+	return finishReady(deps, input);
+}
+
+async function finishReady(deps: RepoSetupDeps, input: RepoSetupInput): Promise<RepoSetupOutcome> {
+	const { db, wsManager } = deps;
+
+	const { repoRow, designated, finalizeResult } = await withTransaction(db, async () => {
+		const updated = await db.query<RepoRowForBroadcast>(
+			`UPDATE repos SET setup_status = $1::repo_setup_status, setup_error = NULL
+			 WHERE id = $2
+			 RETURNING id, project_id, repo_identifier, host_type, oauth_connection_id, created_at,
+			           setup_status, setup_error`,
+			[RepoSetupStatus.Ready, input.repoId],
+		);
+		// The repo was deleted while its setup ran — nothing to settle.
+		if (updated.rows.length === 0)
+			return { repoRow: null, designated: false, finalizeResult: null };
+
+		const projectRow = await db.query<{ designated_repo_id: string | null }>(
+			'SELECT designated_repo_id FROM projects WHERE id = $1 FOR UPDATE',
+			[input.projectId],
+		);
+		if (projectRow.rows.length === 0 || projectRow.rows[0].designated_repo_id) {
+			return { repoRow: updated.rows[0], designated: false, finalizeResult: null };
+		}
+
+		await db.query('UPDATE projects SET designated_repo_id = $1 WHERE id = $2', [
+			input.repoId,
+			input.projectId,
+		]);
+		const finalizeResult = await finalizePendingRepoSetup(db, {
+			teamId: input.teamId,
+			projectId: input.projectId,
+			repoId: input.repoId,
+			repoIdentifier: input.repoIdentifier,
+		});
+		return { repoRow: updated.rows[0], designated: true, finalizeResult };
+	});
+
+	if (!repoRow) return { status: RepoSetupStatus.Ready, designated: false, error: null };
+
+	if (finalizeResult?.resolvedApprovalId) {
+		await enqueueRepoSetupResumeWakeups(
+			db,
+			input.teamId,
+			input.repoId,
+			finalizeResult.resolvedApprovalId,
+			finalizeResult.deferredWakeups,
+		);
+	}
+
+	const room = wsRoom.team(input.teamId);
+	broadcastRowChange(wsManager, room, 'repos', 'UPDATE', {
+		...repoRow,
+		is_designated: designated,
+	});
+	if (designated) {
+		broadcastRowChange(wsManager, room, 'projects', 'UPDATE', {
+			id: input.projectId,
+			designated_repo_id: input.repoId,
+		});
+		if (finalizeResult?.approvalRow) {
+			broadcastRowChange(wsManager, room, 'approvals', 'UPDATE', finalizeResult.approvalRow);
+		}
+		for (const row of finalizeResult?.updatedCommentRows ?? []) {
+			broadcastRowChange(wsManager, room, 'task_comments', 'UPDATE', row);
+		}
+		for (const row of finalizeResult?.systemCommentRows ?? []) {
+			broadcastRowChange(wsManager, room, 'task_comments', 'INSERT', row);
+		}
+	}
+
+	return { status: RepoSetupStatus.Ready, designated, error: null };
+}
+
+async function finishFailed(
+	deps: RepoSetupDeps,
+	input: RepoSetupInput,
+	error: string,
+): Promise<RepoSetupOutcome> {
+	const { db, wsManager } = deps;
+
+	const updated = await db.query<RepoRowForBroadcast>(
+		`UPDATE repos SET setup_status = $1::repo_setup_status, setup_error = $2
+		 WHERE id = $3
+		 RETURNING id, project_id, repo_identifier, host_type, oauth_connection_id, created_at,
+		           setup_status, setup_error`,
+		[RepoSetupStatus.Failed, error, input.repoId],
+	);
+	if (updated.rows.length === 0) {
+		// Deleted while its setup ran — nothing to report.
+		return { status: RepoSetupStatus.Failed, designated: false, error };
+	}
+
+	// If the designated-repo gate is still open this failure blocks it; tell the
+	// gated task(s) so the operator can fix the cause and retry. The approval
+	// stays pending, so agents stay correctly parked.
+	const project = await db.query<{ designated_repo_id: string | null }>(
+		'SELECT designated_repo_id FROM projects WHERE id = $1',
+		[input.projectId],
+	);
+	const room = wsRoom.team(input.teamId);
+	if (project.rows.length > 0 && !project.rows[0].designated_repo_id) {
+		const failure = await markRepoSetupFailed(db, {
+			teamId: input.teamId,
+			projectId: input.projectId,
+			repoIdentifier: input.repoIdentifier,
+			error,
+		});
+		for (const row of failure.systemCommentRows) {
+			broadcastRowChange(wsManager, room, 'task_comments', 'INSERT', row);
+		}
+	}
+
+	broadcastRowChange(wsManager, room, 'repos', 'UPDATE', {
+		...updated.rows[0],
+		is_designated: false,
+	});
+
+	return { status: RepoSetupStatus.Failed, designated: false, error };
+}

--- a/packages/server/test/job-manager-workflows.test.ts
+++ b/packages/server/test/job-manager-workflows.test.ts
@@ -1861,6 +1861,45 @@ describe('JobManager workflow methods', () => {
 			manager.shutdown();
 		});
 
+		it('fails repos stranded pending by a restart and broadcasts the update', async () => {
+			// A repo whose background setup (clone + designation) was in flight when
+			// the previous process died: the work is lost, so the row must park
+			// `failed` (retriable via POST) rather than stay `pending` forever.
+			const inserted = await db.query<{ id: string }>(
+				`INSERT INTO repos (project_id, repo_identifier, host_type, setup_status)
+				 VALUES ($1, 'acme/stranded-setup', 'github', 'pending'::repo_setup_status)
+				 RETURNING id`,
+				[projectId],
+			);
+
+			const broadcasts: Array<{ table: string; row: Record<string, unknown> }> = [];
+			const manager = createJobManager({
+				wsManager: {
+					broadcast: (_room: string, msg: { table: string; row: Record<string, unknown> }) => {
+						broadcasts.push({ table: msg.table, row: msg.row });
+					},
+				} as any,
+			});
+
+			await manager.reconcileOnStartup();
+
+			const row = await db.query<{ setup_status: string; setup_error: string | null }>(
+				`SELECT setup_status::text AS setup_status, setup_error FROM repos WHERE id = $1`,
+				[inserted.rows[0].id],
+			);
+			expect(row.rows[0].setup_status).toBe('failed');
+			expect(row.rows[0].setup_error).toContain('Server restarted');
+
+			const repoBroadcast = broadcasts.find(
+				(b) => b.table === 'repos' && b.row.id === inserted.rows[0].id,
+			);
+			expect(repoBroadcast).toBeTruthy();
+			expect(repoBroadcast?.row.setup_status).toBe('failed');
+
+			manager.shutdown();
+			await db.query('DELETE FROM repos WHERE id = $1', [inserted.rows[0].id]);
+		});
+
 		describe('container restart', () => {
 			// Other projects (notably HQ) get provisioned in the background during
 			// file-level setup and end up with container_status='running'. Clear all

--- a/packages/server/test/migrate-017-repo-setup-status.test.ts
+++ b/packages/server/test/migrate-017-repo-setup-status.test.ts
@@ -1,0 +1,65 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createDataPreservationHarness, type DataPreservationHarness } from './helpers/migrate';
+
+const TARGET = '017_repo_setup_status.sql';
+
+describe('017_repo_setup_status migration', () => {
+	let h: DataPreservationHarness;
+	let seededRepoId: string;
+
+	beforeAll(async () => {
+		h = await createDataPreservationHarness();
+		await h.applyUpToExclusive(TARGET);
+
+		const team = await h.db.query<{ id: string }>(
+			`INSERT INTO teams (name, slug) VALUES ('Acme', 'acme') RETURNING id`,
+		);
+		const project = await h.db.query<{ id: string }>(
+			`INSERT INTO projects (team_id, name, slug, task_prefix)
+			 VALUES ($1, 'Site', 'site', 'SITE') RETURNING id`,
+			[team.rows[0].id],
+		);
+		const repo = await h.db.query<{ id: string }>(
+			`INSERT INTO repos (project_id, repo_identifier, host_type)
+			 VALUES ($1, 'acme/site', 'github') RETURNING id`,
+			[project.rows[0].id],
+		);
+		seededRepoId = repo.rows[0].id;
+
+		await h.applyTarget(TARGET);
+	});
+	afterAll(() => h.close());
+
+	it('adds the setup_status and setup_error columns', async () => {
+		const cols = await h.db.query<{ column_name: string }>(
+			`SELECT column_name FROM information_schema.columns
+			 WHERE table_name = 'repos' AND column_name IN ('setup_status', 'setup_error')`,
+		);
+		expect(cols.rows.map((r) => r.column_name).sort()).toEqual(['setup_error', 'setup_status']);
+	});
+
+	it('backfills pre-existing rows as ready with no error', async () => {
+		const kept = await h.db.query<{
+			repo_identifier: string;
+			setup_status: string;
+			setup_error: string | null;
+		}>(`SELECT repo_identifier, setup_status, setup_error FROM repos WHERE id = $1`, [
+			seededRepoId,
+		]);
+		expect(kept.rows).toHaveLength(1);
+		expect(kept.rows[0].repo_identifier).toBe('acme/site');
+		expect(kept.rows[0].setup_status).toBe('ready');
+		expect(kept.rows[0].setup_error).toBeNull();
+	});
+
+	it('accepts the new lifecycle states on insert', async () => {
+		const project = await h.db.query<{ id: string }>(`SELECT project_id AS id FROM repos LIMIT 1`);
+		const inserted = await h.db.query<{ setup_status: string }>(
+			`INSERT INTO repos (project_id, repo_identifier, host_type, setup_status, setup_error)
+			 VALUES ($1, 'acme/pending-repo', 'github', 'pending', NULL)
+			 RETURNING setup_status`,
+			[project.rows[0].id],
+		);
+		expect(inserted.rows[0].setup_status).toBe('pending');
+	});
+});

--- a/packages/server/test/repos-branches.test.ts
+++ b/packages/server/test/repos-branches.test.ts
@@ -4,6 +4,7 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { MasterKeyManager } from '../src/crypto/master-key';
 import type { Db } from '../src/db/database';
+import { waitForBackground } from '../src/lib/background';
 import type { Env } from '../src/lib/types';
 import { createConnection } from '../src/services/oauth/connection-store';
 import { ensureRepoSetupAction } from '../src/services/repo-setup';
@@ -152,8 +153,20 @@ describe('POST repos — first-repo designation resolves a pending repo-setup ap
 		});
 		expect(res.status).toBe(201);
 		const body = await res.json();
-		expect(body.data.is_designated).toBe(true);
-		expect(body.data.clone_status).toBe('skipped');
+		// The response returns before the checkout/designation settles.
+		expect(body.data.setup_status).toBe('pending');
+		expect(body.data.is_designated).toBe(false);
+
+		// Drain the background setup (clone skipped via the pre-seeded .git dir,
+		// then designation + approval finalize).
+		await waitForBackground();
+
+		const repoRow = await db.query<{ setup_status: string; setup_error: string | null }>(
+			`SELECT setup_status::text AS setup_status, setup_error FROM repos WHERE id = $1`,
+			[body.data.id],
+		);
+		expect(repoRow.rows[0].setup_status).toBe('ready');
+		expect(repoRow.rows[0].setup_error).toBeNull();
 
 		// The approval was auto-resolved.
 		const approval = await db.query<{ status: string }>(

--- a/packages/server/test/repos-coverage.test.ts
+++ b/packages/server/test/repos-coverage.test.ts
@@ -2,6 +2,7 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { MasterKeyManager } from '../src/crypto/master-key';
 import type { Db } from '../src/db/database';
+import { waitForBackground } from '../src/lib/background';
 import type { Env } from '../src/lib/types';
 import { createConnection } from '../src/services/oauth/connection-store';
 import { safeClose } from './helpers';
@@ -175,40 +176,13 @@ describe('POST repos — mode=link access branches', () => {
 
 	// The first repo on a project would become its designated repo. Designation is
 	// deferred until the checkout exists, so under the test harness (stub docker,
-	// no real in-container clone) the clone fails → the route runs
-	// markRepoSetupFailed, deletes the row, and returns REPO_SETUP_FAILED. The
-	// [error] lines this logs are this test asserting on that failure path.
-	it('returns REPO_SETUP_FAILED for the first (would-be-designated) repo when the clone fails', async () => {
-		const res = await postRepo({
-			mode: 'link',
-			url: 'sim-user/existing-repo',
-			oauth_connection_id: connId,
-		});
-		expect(res.status).toBe(500);
-		expect((await res.json()).error.code).toBe('REPO_SETUP_FAILED');
-		// The row was rolled back so a fixed retry can re-create it.
-		const row = await db.query(
-			`SELECT 1 FROM repos WHERE project_id = $1 AND repo_identifier = 'sim-user/existing-repo'`,
-			[projectId],
-		);
-		expect(row.rows.length).toBe(0);
-	});
+	// no real in-container clone) the background setup fails → the row parks
+	// `failed` with the error recorded (never deleted), the project stays
+	// undesignated, and a retry can reclaim the row. The [error] lines this logs
+	// are this suite asserting on that failure path.
+	let failedRepoId: string;
 
-	// With a designated repo already in place, a newly-linked repo no longer
-	// "would designate", so a failed clone is reported as clone_status:'failed' on
-	// a 201 and the row persists (the non-designating insert branch).
-	it('persists a non-designating repo with clone_status=failed when the clone fails', async () => {
-		// Seed + designate a placeholder so the next link does not designate.
-		const placeholder = await db.query<{ id: string }>(
-			`INSERT INTO repos (project_id, repo_identifier, host_type)
-			 VALUES ($1, 'acme/placeholder-designated', 'github') RETURNING id`,
-			[projectId],
-		);
-		await db.query('UPDATE projects SET designated_repo_id = $1 WHERE id = $2', [
-			placeholder.rows[0].id,
-			projectId,
-		]);
-
+	it('201s pending, then parks the row failed when the clone fails', async () => {
 		const res = await postRepo({
 			mode: 'link',
 			url: 'sim-user/existing-repo',
@@ -216,20 +190,69 @@ describe('POST repos — mode=link access branches', () => {
 		});
 		expect(res.status).toBe(201);
 		const body = await res.json();
-		expect(body.data.repo_identifier).toBe('sim-user/existing-repo');
+		expect(body.data.setup_status).toBe('pending');
 		expect(body.data.is_designated).toBe(false);
-		expect(body.data.clone_status).toBe('failed');
 
-		const row = await db.query(
-			`SELECT 1 FROM repos WHERE project_id = $1 AND repo_identifier = 'sim-user/existing-repo'`,
+		await waitForBackground();
+
+		const row = await db.query<{ id: string; setup_status: string; setup_error: string | null }>(
+			`SELECT id, setup_status::text AS setup_status, setup_error FROM repos
+			 WHERE project_id = $1 AND repo_identifier = 'sim-user/existing-repo'`,
 			[projectId],
 		);
-		expect(row.rows.length).toBe(1);
+		expect(row.rows).toHaveLength(1);
+		expect(row.rows[0].setup_status).toBe('failed');
+		expect(row.rows[0].setup_error).toBeTruthy();
+		failedRepoId = row.rows[0].id;
+
+		// A repo whose checkout never materialized must not become designated.
+		const project = await db.query<{ designated_repo_id: string | null }>(
+			'SELECT designated_repo_id FROM projects WHERE id = $1',
+			[projectId],
+		);
+		expect(project.rows[0].designated_repo_id).toBeNull();
 	});
 
-	it('409s (REPO_NAME_TAKEN) when re-linking the same accessible repo', async () => {
-		// sim-user/existing-repo now persists from the previous test → unique
-		// violation fires on insert, before any clone.
+	it('409s (REPO_SETUP_IN_PROGRESS) while a setup for the same repo is still pending', async () => {
+		await db.query(`UPDATE repos SET setup_status = 'pending' WHERE id = $1`, [failedRepoId]);
+		const res = await postRepo({
+			mode: 'link',
+			url: 'sim-user/existing-repo',
+			oauth_connection_id: connId,
+		});
+		expect(res.status).toBe(409);
+		expect((await res.json()).error.code).toBe('REPO_SETUP_IN_PROGRESS');
+		await db.query(`UPDATE repos SET setup_status = 'failed' WHERE id = $1`, [failedRepoId]);
+	});
+
+	it('retrying a failed repo reclaims the same row and re-runs setup', async () => {
+		const res = await postRepo({
+			mode: 'link',
+			url: 'sim-user/existing-repo',
+			oauth_connection_id: connId,
+		});
+		expect(res.status).toBe(201);
+		const body = await res.json();
+		expect(body.data.id).toBe(failedRepoId);
+		expect(body.data.setup_status).toBe('pending');
+
+		await waitForBackground();
+
+		const rows = await db.query<{ setup_status: string }>(
+			`SELECT setup_status::text AS setup_status FROM repos
+			 WHERE project_id = $1 AND repo_identifier = 'sim-user/existing-repo'`,
+			[projectId],
+		);
+		// Still exactly one row — the retry reused it (and failed again under the
+		// harness, which is fine: the point is the lifecycle, not the clone).
+		expect(rows.rows).toHaveLength(1);
+		expect(rows.rows[0].setup_status).toBe('failed');
+	});
+
+	it('409s (REPO_NAME_TAKEN) when re-linking a repo that is already set up', async () => {
+		await db.query(`UPDATE repos SET setup_status = 'ready', setup_error = NULL WHERE id = $1`, [
+			failedRepoId,
+		]);
 		const res = await postRepo({
 			mode: 'link',
 			url: 'sim-user/existing-repo',
@@ -241,10 +264,10 @@ describe('POST repos — mode=link access branches', () => {
 });
 
 describe('POST repos — mode=create branches', () => {
-	it('creates a new repo on GitHub then reports clone_status=failed under the harness', async () => {
-		// A designated repo is already in place from the link tests, so this create
-		// does not designate; the GitHub-side create succeeds (sim) and the row
-		// persists with a failed in-container clone.
+	it('creates a new repo on GitHub then parks the row failed under the harness', async () => {
+		// The GitHub-side create succeeds (sim); the in-container clone fails under
+		// the harness, so the background setup settles the row to failed and it
+		// persists for a retry.
 		const res = await postRepo({
 			mode: 'create',
 			owner: 'sim-user',
@@ -255,9 +278,18 @@ describe('POST repos — mode=create branches', () => {
 		expect(res.status).toBe(201);
 		const body = await res.json();
 		expect(body.data.repo_identifier).toBe('sim-user/brand-new-repo');
-		expect(body.data.clone_status).toBe('failed');
+		expect(body.data.setup_status).toBe('pending');
 		// The repo was actually created on GitHub (the sim).
 		expect(sim.state.repos.some((r) => r.full_name === 'sim-user/brand-new-repo')).toBe(true);
+
+		await waitForBackground();
+
+		const row = await db.query<{ setup_status: string }>(
+			`SELECT setup_status::text AS setup_status FROM repos
+			 WHERE project_id = $1 AND repo_identifier = 'sim-user/brand-new-repo'`,
+			[projectId],
+		);
+		expect(row.rows[0].setup_status).toBe('failed');
 	});
 
 	it('409s when the repo already exists on GitHub', async () => {

--- a/packages/server/test/repos-create-github.test.ts
+++ b/packages/server/test/repos-create-github.test.ts
@@ -4,6 +4,7 @@ import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { MasterKeyManager } from '../src/crypto/master-key';
 import type { Db } from '../src/db/database';
+import { waitForBackground } from '../src/lib/background';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
 import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
@@ -162,12 +163,21 @@ describe('repo creation, first-repo designation, and designated immutability', (
 		expect(res.status).toBe(201);
 		const body = await res.json();
 		expect(body.data.repo_identifier).toBe('octo-repo/fresh-service');
-		expect(body.data.is_designated).toBe(true);
-		expect(body.data.clone_status).toBe('skipped');
+		// Checkout + designation settle in the background after the response.
+		expect(body.data.setup_status).toBe('pending');
+		expect(body.data.is_designated).toBe(false);
 		designatedRepoId = body.data.id;
 
 		// Created upstream, not just recorded locally.
 		expect(sim.state.repos.some((r) => r.full_name === 'octo-repo/fresh-service')).toBe(true);
+
+		await waitForBackground();
+
+		const repoRow = await db.query<{ setup_status: string }>(
+			`SELECT setup_status::text AS setup_status FROM repos WHERE id = $1`,
+			[designatedRepoId],
+		);
+		expect(repoRow.rows[0].setup_status).toBe('ready');
 
 		const project = await db.query<{ designated_repo_id: string | null }>(
 			'SELECT designated_repo_id FROM projects WHERE id = $1',
@@ -192,6 +202,8 @@ describe('repo creation, first-repo designation, and designated immutability', (
 		const body = await res.json();
 		expect(body.data.is_designated).toBe(false);
 		secondRepoId = body.data.id;
+
+		await waitForBackground();
 
 		const project = await db.query<{ designated_repo_id: string | null }>(
 			'SELECT designated_repo_id FROM projects WHERE id = $1',

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -983,6 +983,20 @@ export type AuditActorType = (typeof AuditActorType)[keyof typeof AuditActorType
 export const RepoHostType = { GitHub: 'github' } as const;
 export type RepoHostType = (typeof RepoHostType)[keyof typeof RepoHostType];
 
+/**
+ * Lifecycle of a linked repo's checkout setup (container up + in-container
+ * clone + first-repo designation), which runs in the background after the
+ * POST /repos insert returns. `pending` rows found at startup were interrupted
+ * by a restart and are marked `failed`; a `failed` repo is retried by POSTing
+ * the same repo again.
+ */
+export const RepoSetupStatus = {
+	Pending: 'pending',
+	Ready: 'ready',
+	Failed: 'failed',
+} as const;
+export type RepoSetupStatus = (typeof RepoSetupStatus)[keyof typeof RepoSetupStatus];
+
 export const AuthType = {
 	Admin: 'admin',
 	ApiKey: 'api_key',

--- a/packages/web/src/components/github-section.tsx
+++ b/packages/web/src/components/github-section.tsx
@@ -1,6 +1,6 @@
 import { repoNameFromIdentifier } from '@hezo/shared';
 import { useQueryClient } from '@tanstack/react-query';
-import { AlertTriangle, GitBranch, Github, Loader2, Lock, Trash2 } from 'lucide-react';
+import { AlertTriangle, GitBranch, Github, Loader2, Lock, RotateCw, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { useMcpConnections } from '../hooks/use-mcp-connections';
 import {
@@ -8,7 +8,7 @@ import {
 	useEnsureConnector,
 	useOAuthConnections,
 } from '../hooks/use-oauth-connections';
-import { useDeleteRepo, useRepos } from '../hooks/use-repos';
+import { useCreateRepo, useDeleteRepo, useRepos } from '../hooks/use-repos';
 import { repoWebUrl } from '../lib/github';
 import { queryKeys } from '../lib/query-keys';
 import { ConnectorDeviceFlowDialog } from './connector-device-flow-dialog';
@@ -26,6 +26,7 @@ export function GitHubSection({ projectId }: GitHubSectionProps) {
 	const { data: connectors = [] } = useMcpConnections(projectId);
 	const { data: repos } = useRepos(projectId);
 	const deleteRepo = useDeleteRepo(projectId);
+	const retryRepo = useCreateRepo(projectId);
 	const queryClient = useQueryClient();
 
 	const githubConnection = connections.find((c) => c.provider === 'github') ?? null;
@@ -175,50 +176,88 @@ export function GitHubSection({ projectId }: GitHubSectionProps) {
 							return (
 								<div
 									key={r.id}
-									className="flex items-center justify-between rounded-md border border-border-subtle bg-surface px-3 py-2 text-sm"
+									className="flex flex-col gap-1 rounded-md border border-border-subtle bg-surface px-3 py-2 text-sm"
 								>
-									<div className="flex items-center gap-2">
-										<Badge color="gray">{r.host_type}</Badge>
-										<span className="font-medium">{repoName}</span>
-										{(() => {
-											const url = repoWebUrl(r.repo_identifier, r.host_type);
-											return url ? (
-												<a
-													href={url}
-													target="_blank"
-													rel="noopener noreferrer"
-													className="text-info-soft-fg hover:underline"
-													data-testid={`repo-link-${repoName}`}
+									<div className="flex items-center justify-between">
+										<div className="flex flex-wrap items-center gap-2">
+											<Badge color="gray">{r.host_type}</Badge>
+											<span className="font-medium">{repoName}</span>
+											{(() => {
+												const url = repoWebUrl(r.repo_identifier, r.host_type);
+												return url ? (
+													<a
+														href={url}
+														target="_blank"
+														rel="noopener noreferrer"
+														className="text-info-soft-fg hover:underline"
+														data-testid={`repo-link-${repoName}`}
+													>
+														{r.repo_identifier}
+													</a>
+												) : (
+													<span className="text-text-2">{r.repo_identifier}</span>
+												);
+											})()}
+											{r.is_designated && <Badge color="blue">Designated</Badge>}
+											{r.setup_status === 'pending' && (
+												<span
+													className="flex items-center gap-1 text-xs text-text-2"
+													data-testid={`repo-setup-pending-${repoName}`}
 												>
-													{r.repo_identifier}
-												</a>
+													<Loader2 className="size-3 animate-spin" /> Setting up…
+												</span>
+											)}
+										</div>
+										<div className="flex items-center gap-2">
+											{r.setup_status === 'failed' && githubConnection && (
+												<Button
+													variant="secondary"
+													size="sm"
+													disabled={retryRepo.isPending}
+													onClick={() =>
+														retryRepo.mutate({
+															mode: 'link',
+															url: `https://github.com/${r.repo_identifier}`,
+															oauth_connection_id: githubConnection.id,
+														})
+													}
+													data-testid={`repo-setup-retry-${repoName}`}
+												>
+													<RotateCw className="size-3 mr-1" /> Retry
+												</Button>
+											)}
+											{r.is_designated ? (
+												<Tooltip content="Designated repository cannot be removed">
+													<span
+														role="img"
+														aria-label="Designated repository cannot be removed"
+														className="text-text-3"
+														data-testid={`repo-locked-${repoName}`}
+													>
+														<Lock className="w-3.5 h-3.5" />
+													</span>
+												</Tooltip>
 											) : (
-												<span className="text-text-2">{r.repo_identifier}</span>
-											);
-										})()}
-										{r.is_designated && <Badge color="blue">Designated</Badge>}
+												<button
+													type="button"
+													onClick={() => deleteRepo.mutate(r.id)}
+													className="text-text-3 hover:text-danger"
+													aria-label={`Remove repo ${repoName}`}
+													data-testid={`repo-delete-${repoName}`}
+												>
+													<Trash2 className="w-3.5 h-3.5" />
+												</button>
+											)}
+										</div>
 									</div>
-									{r.is_designated ? (
-										<Tooltip content="Designated repository cannot be removed">
-											<span
-												role="img"
-												aria-label="Designated repository cannot be removed"
-												className="text-text-3"
-												data-testid={`repo-locked-${repoName}`}
-											>
-												<Lock className="w-3.5 h-3.5" />
-											</span>
-										</Tooltip>
-									) : (
-										<button
-											type="button"
-											onClick={() => deleteRepo.mutate(r.id)}
-											className="text-text-3 hover:text-danger"
-											aria-label={`Remove repo ${repoName}`}
-											data-testid={`repo-delete-${repoName}`}
+									{r.setup_status === 'failed' && (
+										<p
+											className="text-xs text-danger-soft-fg"
+											data-testid={`repo-setup-failed-${repoName}`}
 										>
-											<Trash2 className="w-3.5 h-3.5" />
-										</button>
+											Setup failed{r.setup_error ? `: ${r.setup_error}` : ''}. Retry to run it
+											again.
+										</p>
 									)}
 								</div>
 							);

--- a/packages/web/src/hooks/use-projects.ts
+++ b/packages/web/src/hooks/use-projects.ts
@@ -61,6 +61,9 @@ export interface Repo {
 	host_type: string;
 	created_at: string;
 	is_designated?: boolean;
+	/** Background checkout setup lifecycle; the row settles via WebSocket UPDATE. */
+	setup_status?: 'pending' | 'ready' | 'failed';
+	setup_error?: string | null;
 }
 
 export type ProjectWithTeam = Project & { teamSlug: string; teamName: string };

--- a/packages/web/test/github-section-states.test.tsx
+++ b/packages/web/test/github-section-states.test.tsx
@@ -22,6 +22,8 @@ interface MockRepo {
 	repo_identifier: string;
 	host_type: string;
 	is_designated: boolean;
+	setup_status?: 'pending' | 'ready' | 'failed';
+	setup_error?: string | null;
 }
 
 /**
@@ -36,6 +38,7 @@ function installGitHubMock(opts: {
 	scopeMissing?: string[];
 	repos?: MockRepo[];
 	ensureFails?: boolean;
+	onRepoPost?: (body: Record<string, unknown>) => void;
 }) {
 	const original = globalThis.fetch;
 	restoreFetch = () => {
@@ -91,6 +94,11 @@ function installGitHubMock(opts: {
 		}
 		if (method === 'DELETE' && /\/api\/projects\/[^/]+\/repos\/[^/]+$/.test(url)) {
 			return jsonRes({ ok: true });
+		}
+		if (method === 'POST' && /\/api\/projects\/[^/]+\/repos$/.test(url)) {
+			const body = init?.body ? JSON.parse(init.body as string) : {};
+			opts.onRepoPost?.(body);
+			return jsonRes({ id: 'r-new', setup_status: 'pending' }, 201);
 		}
 		return original(input as RequestInfo, init);
 	}) as typeof globalThis.fetch;
@@ -191,6 +199,64 @@ test('insufficient scopes show the needs-permissions reauth banner with the miss
 	expect(banner.textContent).toContain('read:org, write:public_key');
 	// The re-authorize button is present.
 	await r.findByTestId('github-reauth');
+});
+
+test('a pending repo shows the setting-up indicator instead of settling silently', async () => {
+	const r = await renderSettings({
+		connection: { id: 'conn-1', provider_account_label: 'octocat' },
+		scopeSufficient: true,
+		repos: [
+			{
+				id: 'r1',
+				repo_identifier: 'octocat/cloning-now',
+				host_type: 'github',
+				is_designated: false,
+				setup_status: 'pending',
+			},
+		],
+	});
+
+	const indicator = await r.findByTestId('repo-setup-pending-cloning-now', undefined, {
+		timeout: 20_000,
+	});
+	expect(indicator.textContent).toContain('Setting up');
+	// A pending repo is neither failed nor retryable yet.
+	expect(r.queryByTestId('repo-setup-retry-cloning-now')).toBeNull();
+	expect(r.queryByTestId('repo-setup-failed-cloning-now')).toBeNull();
+});
+
+test('a failed repo shows the setup error and Retry re-POSTs the same repo link', async () => {
+	const posts: Record<string, unknown>[] = [];
+	const r = await renderSettings({
+		connection: { id: 'conn-1', provider_account_label: 'octocat' },
+		scopeSufficient: true,
+		repos: [
+			{
+				id: 'r1',
+				repo_identifier: 'octocat/broken-clone',
+				host_type: 'github',
+				is_designated: false,
+				setup_status: 'failed',
+				setup_error: 'project container is not running',
+			},
+		],
+		onRepoPost: (body) => posts.push(body),
+	});
+
+	const failedNote = await r.findByTestId('repo-setup-failed-broken-clone', undefined, {
+		timeout: 20_000,
+	});
+	expect(failedNote.textContent).toContain('project container is not running');
+
+	const retry = await r.findByTestId('repo-setup-retry-broken-clone');
+	await r.user.click(retry);
+
+	// Retry re-POSTs the same repo through the normal link flow, so the server
+	// reclaims the failed row and re-runs setup.
+	expect(posts).toHaveLength(1);
+	expect(posts[0].mode).toBe('link');
+	expect(posts[0].url).toBe('https://github.com/octocat/broken-clone');
+	expect(posts[0].oauth_connection_id).toBe('conn-1');
 });
 
 test('a failing connector-ensure surfaces an inline error under the GitHub heading', async () => {


### PR DESCRIPTION
## Problem

Linking or creating a GitHub repo from the "Set up GitHub repo" modal on a production deployment:

1. **The modal never closed** — the request eventually died with `Failed to fetch`.
2. Refreshing showed the repo as connected, but **after a container/instance restart it was "no longer connected"**.
3. Retrying then failed with `a repository named "…" is already linked to this project` — a dead end with no way out from the UI.

## Root cause

`POST /api/projects/:id/repos` did the entire setup **inside the HTTP request**: insert the `repos` row → start the project container (minutes on first provision: image pull etc.) → clone inside the container → designate the repo. Two defects compounded:

- Bun's default `idleTimeout` is **10 seconds**, so the socket was severed long before the handler finished. The browser saw `Failed to fetch` while the server kept working — hence "connected" after refresh (row already inserted).
- A restart (or crash) mid-setup killed the handler **between the row insert and designation**, stranding a half-set-up row: never designated (the setup gate stays blocked, so the project behaves as if no repo is connected), yet blocking every retry with a unique-violation 409.

## Fix

- **Async setup with a real lifecycle.** The POST validates GitHub-side access (or creates the repo upstream), inserts the row as `setup_status='pending'`, and returns immediately — the modal closes right away. The slow half (container up + in-container clone + first-repo designation + approval finalize) runs in a tracked background task (`services/repo-provisioning.ts`) and settles the row to `ready`/`failed`, broadcast to the team room so the UI updates live.
- **Failures are retryable, never stranded.** A failed setup parks the row `failed` with `setup_error` recorded (instead of deleting it); POSTing the same repo reclaims the row back to `pending` and re-runs setup. A live `pending` duplicate 409s `REPO_SETUP_IN_PROGRESS`; a `ready` duplicate keeps 409ing `REPO_NAME_TAKEN`. Designation is still deferred until a checkout exists, so the gate never half-opens.
- **Restart recovery.** `JobManager.reconcileOnStartup` marks rows stranded `pending` by a restart as `failed` ("Server restarted while repository setup was in flight") and broadcasts the update, so they surface as retryable instead of spinning forever.
- **UI.** Repo rows show a "Setting up…" spinner while pending, and the setup error with a **Retry** button when failed.
- **Timeout hardening.** The Bun server now sets `idleTimeout: 120` so legitimately slow handlers (GitHub API round-trips, uploads) aren't severed at 10s; anything longer must run in the background.
- **Migration `017_repo_setup_status.sql`** adds the `repo_setup_status` enum + `setup_status`/`setup_error` columns; existing rows backfill to `ready`. Ships with a data-preservation test.

## Tests

- `migrate-017-repo-setup-status.test.ts` — schema change + pre-existing rows preserved/backfilled.
- `repos-coverage.test.ts` — full lifecycle: 201-pending → background failure parks the row `failed` and undesignated; `REPO_SETUP_IN_PROGRESS` on pending duplicate; retry reclaims the same row; `REPO_NAME_TAKEN` once ready.
- `repos-create-github.test.ts` / `repos-branches.test.ts` — successful background settle: designation, approval auto-resolve, gate comments.
- `job-manager-workflows.test.ts` — startup reconcile fails stranded pending repos and broadcasts.
- `github-section-states.test.tsx` — pending indicator, failed error + Retry re-POSTs the same repo link.

Docs updated in the same PR: `.dev/architecture.md` (§ Repos) and `docs/security/git-and-verified-commits.md` (background setup + Retry). No MCP tool or CLI surface changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GpyhZ3nXaA9Fcjro5G3ms4

---
_Generated by [Claude Code](https://claude.ai/code/session_01GpyhZ3nXaA9Fcjro5G3ms4)_