### PR TITLE
fix(runs): stop a stalled git fetch from hanging a run forever

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -576,7 +576,16 @@ host (bind-mounted) path; git commands use the container path. SSH-transport ops
 fetch) are wrapped with the per-run SSH bridge (`hezo-run-with-bridge`) so `git@github.com:`
 authenticates through the host ssh-agent; the container's baked-in `/etc/ssh/ssh_known_hosts`
 verifies the host key. Cloning outside a run (container provision, repo link) uses a
-short-lived `withProvisionBridge`.
+short-lived `withProvisionBridge`. **Git-over-SSH fails fast.** Every git exec sets a
+`GIT_SSH_COMMAND` carrying `ConnectTimeout` + `ServerAliveInterval`/`ServerAliveCountMax` +
+`BatchMode`, so a stalled or black-holed `git@github.com` connection dies in ~45s rather than
+hanging on OS TCP defaults; each exec also carries a per-op timeout (fetch 60s, clone 120s)
+and, for prep, the run's own abort signal — both abort the `docker exec` stream, so a hung
+transport can no longer block the run (or the per-project git lock) until it is killed by
+hand. The abort actually tears the exec down because the streaming Docker transport removes
+its abort handler on the *response* stream's end, never on the `ClientRequest`'s `close`
+(which Bun emits prematurely, mid-body) — otherwise the timeout would fire against a handler
+that had already been detached.
 
 **Container run-user & host-file ownership.** The agent base image (`node:24-slim`) sets no
 `USER`, so the container runs as **root**; Hezo deprivileges individual `docker exec`s — the

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -73,7 +73,7 @@ import {
 	type WorktreeLoc,
 	worktreeHasChanges,
 } from './git';
-import { ContainerGitExecutor, type GitExecutor } from './git-executor';
+import { ContainerGitExecutor, GIT_SSH_COMMAND_VALUE, type GitExecutor } from './git-executor';
 import { buildGitIdentityEnv } from './git-identity';
 import type { LogStreamBroker } from './log-stream-broker';
 import { loadMcpConnectionDescriptors } from './mcp-connections';
@@ -454,6 +454,8 @@ export async function buildRuntimeInvocation(
 	];
 	if (sshSocketContainerPath) {
 		env.push(`SSH_AUTH_SOCK=${sshSocketContainerPath}`);
+		// Fail fast on a stalled git transport instead of hanging on OS TCP defaults.
+		env.push(`GIT_SSH_COMMAND=${GIT_SSH_COMMAND_VALUE}`);
 	}
 	// Configure git author/committer identity and SSH commit signing from the
 	// team's connected GitHub account + Ed25519 key, so in-container commits
@@ -1378,6 +1380,7 @@ async function prepareWorktrees(
 			bridge,
 			runUser,
 			gitIdentityEnv,
+			signal,
 		);
 
 		emitSystem('stdout', '(syncing repos...)');

--- a/packages/server/src/services/docker.ts
+++ b/packages/server/src/services/docker.ts
@@ -165,6 +165,7 @@ export class DockerClient {
 				return;
 			}
 			const payload = body === undefined ? undefined : JSON.stringify(body);
+			let cleanupAbort: (() => void) | undefined;
 			const req = httpRequest(
 				{
 					socketPath: this.socketPath,
@@ -179,6 +180,13 @@ export class DockerClient {
 								},
 				},
 				(res) => {
+					// Detach the abort handler when the RESPONSE stream ends — never on the
+					// ClientRequest's 'close', which Bun emits prematurely (while the body
+					// is still streaming). Removing the handler on that premature event
+					// leaves a stalled read with nothing left to tear it down, so a hung
+					// exec (e.g. a black-holed git fetch) ignores its timeout and blocks
+					// until the connection dies at OS level.
+					res.on('close', () => cleanupAbort?.());
 					const headers = new Headers();
 					for (const [key, value] of Object.entries(res.headers)) {
 						if (typeof value === 'string') headers.set(key, value);
@@ -198,7 +206,7 @@ export class DockerClient {
 			if (signal) {
 				const onAbort = () => req.destroy(abortError());
 				signal.addEventListener('abort', onAbort, { once: true });
-				req.on('close', () => signal.removeEventListener('abort', onAbort));
+				cleanupAbort = () => signal.removeEventListener('abort', onAbort);
 			}
 			if (payload !== undefined) req.write(payload);
 			req.end();

--- a/packages/server/src/services/git-executor.ts
+++ b/packages/server/src/services/git-executor.ts
@@ -3,6 +3,25 @@ import type { ContainerRunUser } from './container-user';
 import type { DockerClient } from './docker';
 import { type BridgeRunnerArgs, buildBridgeRunnerArgv } from './ssh-agent';
 
+/**
+ * SSH options applied to every in-container git transport op so a stalled
+ * connection fails fast instead of hanging on OS TCP defaults. `ConnectTimeout`
+ * bounds the initial connect; `ServerAliveInterval`/`ServerAliveCountMax` detect
+ * an established-then-silent connection (~30s) without tripping a slow-but-alive
+ * transfer; `BatchMode` guarantees git never blocks on an interactive prompt.
+ * Worst case (~45s) stays under the fetch (60s) and clone (120s) op caps.
+ */
+export const GIT_SSH_COMMAND_VALUE =
+	'ssh -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=10 -o ServerAliveCountMax=3';
+
+/** Merge a run's abort signal with a per-op timeout signal (either may be absent). */
+function combineAbortSignals(...signals: Array<AbortSignal | undefined>): AbortSignal | undefined {
+	const present = signals.filter((s): s is AbortSignal => s !== undefined);
+	if (present.length === 0) return undefined;
+	if (present.length === 1) return present[0];
+	return AbortSignal.any(present);
+}
+
 export interface GitExecResult {
 	exitCode: number;
 	stdout: string;
@@ -65,6 +84,8 @@ export interface ContainerGitExecutorOptions {
 	bridge?: BridgeRunnerArgs | null;
 	/** The container user every git exec runs as (detected, not assumed `node`). */
 	runUser: ContainerRunUser;
+	/** The run's abort signal, so a cancel / run-timeout interrupts an in-flight exec. */
+	signal?: AbortSignal;
 }
 
 /**
@@ -81,6 +102,7 @@ export class ContainerGitExecutor implements GitExecutor {
 	private readonly bridge: BridgeRunnerArgs | null;
 	private readonly baseEnv: string[];
 	private readonly runUser: ContainerRunUser;
+	private readonly runSignal?: AbortSignal;
 
 	constructor(
 		private readonly docker: DockerClient,
@@ -89,6 +111,7 @@ export class ContainerGitExecutor implements GitExecutor {
 	) {
 		this.bridge = opts.bridge ?? null;
 		this.runUser = opts.runUser;
+		this.runSignal = opts.signal;
 		// The bridge wrapper appends/redirects HEZO_PROMPT_FILE into the command it
 		// runs; it must never leak into a git invocation. Strip it defensively.
 		this.baseEnv = opts.baseEnv.filter((e) => !e.startsWith('HEZO_PROMPT_FILE='));
@@ -109,10 +132,15 @@ export class ContainerGitExecutor implements GitExecutor {
 		bridge: BridgeRunnerArgs | null,
 		runUser: ContainerRunUser,
 		extraEnv: string[] = [],
+		signal?: AbortSignal,
 	): ContainerGitExecutor {
-		const baseEnv = ['GIT_TERMINAL_PROMPT=0', ...extraEnv];
+		const baseEnv = [
+			'GIT_TERMINAL_PROMPT=0',
+			`GIT_SSH_COMMAND=${GIT_SSH_COMMAND_VALUE}`,
+			...extraEnv,
+		];
 		if (bridge) baseEnv.push(`SSH_AUTH_SOCK=${bridge.socketPath}`);
-		return new ContainerGitExecutor(docker, containerId, { baseEnv, bridge, runUser });
+		return new ContainerGitExecutor(docker, containerId, { baseEnv, bridge, runUser, signal });
 	}
 
 	async exec(args: string[], opts: GitExecOpts): Promise<GitExecResult> {
@@ -120,7 +148,10 @@ export class ContainerGitExecutor implements GitExecutor {
 			opts.needsSsh && this.bridge
 				? [...buildBridgeRunnerArgv(this.bridge), 'git', ...args]
 				: ['git', ...args];
-		const signal = opts.timeout ? AbortSignal.timeout(opts.timeout) : undefined;
+		// The per-op deadline and the run's own abort (cancel / run-timeout) both
+		// interrupt an in-flight exec; whichever fires tears down the docker stream.
+		const timeoutSignal = opts.timeout ? AbortSignal.timeout(opts.timeout) : undefined;
+		const signal = combineAbortSignals(this.runSignal, timeoutSignal);
 		try {
 			const execId = await this.docker.execCreate(this.containerId, {
 				Cmd: cmd,
@@ -134,12 +165,15 @@ export class ContainerGitExecutor implements GitExecutor {
 			const info = await this.docker.execInspect(execId);
 			return { exitCode: info.ExitCode, stdout, stderr };
 		} catch (e) {
-			if (signal?.aborted) {
+			if (timeoutSignal?.aborted) {
 				return {
 					exitCode: 1,
 					stdout: '',
 					stderr: `timed out after ${Math.round((opts.timeout ?? 0) / 1000)}s`,
 				};
+			}
+			if (this.runSignal?.aborted) {
+				return { exitCode: 1, stdout: '', stderr: 'run aborted' };
 			}
 			return { exitCode: 1, stdout: '', stderr: e instanceof Error ? e.message : String(e) };
 		}

--- a/packages/server/test/bun/docker-stream.bun.test.ts
+++ b/packages/server/test/bun/docker-stream.bun.test.ts
@@ -108,6 +108,30 @@ describe('execStart over node:http (Bun runtime)', () => {
 		}
 		expect((caught as Error)?.name).toBe('AbortError');
 	});
+
+	test('buffered read (no onChunk) aborts a hung exec at the deadline instead of hanging', async () => {
+		// No onChunk → the buffered branch (await res.arrayBuffer()). This is the
+		// git-fetch prep path that hung indefinitely in production: the exec stream
+		// stays open-but-silent, and under Bun destroying the node:http request does
+		// not reject the pending web-body read, so the declared timeout was silently
+		// ineffective. The read must now settle at the deadline, not run forever.
+		sim.onExecStart('exec-hang-buffered', {
+			frames: [{ stream: 'stdout', text: 'partial' }],
+			hangAfterFrames: true,
+		});
+
+		const started = Date.now();
+		let caught: unknown;
+		try {
+			await docker.execStart('exec-hang-buffered', { signal: AbortSignal.timeout(150) });
+		} catch (e) {
+			caught = e;
+		}
+		const elapsed = Date.now() - started;
+
+		expect(caught).toBeDefined();
+		expect(elapsed).toBeLessThan(2000);
+	});
 });
 
 describe('containerLogs over node:http (Bun runtime)', () => {

--- a/packages/server/test/git-executor.test.ts
+++ b/packages/server/test/git-executor.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { ContainerRunUser } from '../src/services/container-user';
-import { ContainerGitExecutor } from '../src/services/git-executor';
+import { ContainerGitExecutor, GIT_SSH_COMMAND_VALUE } from '../src/services/git-executor';
 import {
 	BRIDGE_RUNNER_BINARY,
 	type BridgeRunnerArgs,
@@ -39,6 +39,28 @@ function recordingDocker(opts: { exitCode?: number; throwOnStart?: boolean } = {
 		execInspect: async () => ({ ExitCode: opts.exitCode ?? 0, Running: false, Pid: 1 }),
 	});
 	return { docker, calls };
+}
+
+const abortErrorOf = (s: AbortSignal): Error =>
+	s.reason instanceof Error
+		? s.reason
+		: new DOMException('This operation was aborted', 'AbortError');
+
+// A docker whose execStart never settles until the exec's abort signal fires —
+// modelling a black-holed in-container command (e.g. a stalled `git fetch`), the
+// production failure this executor's timeout/run-signal handling must survive.
+function hangingDocker() {
+	return createStubDocker({
+		execCreate: async () => 'exec-1',
+		execStart: (_id: string, opts?: { signal?: AbortSignal }) =>
+			new Promise<{ stdout: string; stderr: string }>((_resolve, reject) => {
+				const signal = opts?.signal;
+				if (!signal) return;
+				if (signal.aborted) return reject(abortErrorOf(signal));
+				signal.addEventListener('abort', () => reject(abortErrorOf(signal)), { once: true });
+			}),
+		execInspect: async () => ({ ExitCode: 0, Running: false, Pid: 1 }),
+	});
 }
 
 describe('ContainerGitExecutor', () => {
@@ -128,9 +150,17 @@ describe('ContainerGitExecutor', () => {
 		expect(calls[0].User).toBe('node');
 		expect(calls[0].Env).toContain('GIT_TERMINAL_PROMPT=0');
 		expect(calls[0].Env).toContain(`SSH_AUTH_SOCK=${bridge.socketPath}`);
+		expect(calls[0].Env).toContain(`GIT_SSH_COMMAND=${GIT_SSH_COMMAND_VALUE}`);
 		expect(calls[0].Env).toContain('GIT_CONFIG_COUNT=2');
 		expect(calls[0].Env).toContain('GIT_CONFIG_KEY_0=user.name');
 		expect(calls[0].Env).toContain('GIT_CONFIG_VALUE_0=octocat');
+	});
+
+	it('forPrep sets fail-fast SSH options so a stalled transport cannot hang forever', () => {
+		expect(GIT_SSH_COMMAND_VALUE).toContain('BatchMode=yes');
+		expect(GIT_SSH_COMMAND_VALUE).toContain('ConnectTimeout=15');
+		expect(GIT_SSH_COMMAND_VALUE).toContain('ServerAliveInterval=10');
+		expect(GIT_SSH_COMMAND_VALUE).toContain('ServerAliveCountMax=3');
 	});
 
 	it('surfaces a non-zero exit code from execInspect', async () => {
@@ -150,5 +180,41 @@ describe('ContainerGitExecutor', () => {
 
 		expect(res.exitCode).toBe(1);
 		expect(res.stderr).toContain('docker daemon unreachable');
+	});
+
+	it('times out a hung exec at the per-op deadline instead of hanging', async () => {
+		const exec = ContainerGitExecutor.forPrep(hangingDocker(), 'cid', bridge, runUser);
+
+		const res = await exec.exec(['fetch', '--prune', 'origin'], {
+			cwd: '/workspace/repo',
+			needsSsh: true,
+			timeout: 50,
+		});
+
+		expect(res.exitCode).toBe(1);
+		expect(res.stderr).toContain('timed out');
+	});
+
+	it('interrupts an in-flight exec when the run signal aborts', async () => {
+		const ac = new AbortController();
+		const exec = ContainerGitExecutor.forPrep(
+			hangingDocker(),
+			'cid',
+			bridge,
+			runUser,
+			[],
+			ac.signal,
+		);
+
+		const p = exec.exec(['fetch', '--prune', 'origin'], {
+			cwd: '/workspace/repo',
+			needsSsh: true,
+			timeout: 60_000,
+		});
+		ac.abort();
+		const res = await p;
+
+		expect(res.exitCode).toBe(1);
+		expect(res.stderr).toBe('run aborted');
 	});
 });


### PR DESCRIPTION
A run could hang indefinitely during repo sync when a `git fetch` over SSH stalled — it sat blocked (holding the per-project git lock) until killed by hand. Three compounding defects, each fixed:

- SSH had no fail-fast options, so a black-holed github.com connection waited on OS TCP defaults. Every in-container git exec now sets GIT_SSH_COMMAND with ConnectTimeout + ServerAliveInterval/CountMax + BatchMode, failing a stall in ~45s (under the fetch/clone op caps).

- The per-op docker-exec timeout never actually fired: the streaming Docker transport removed its abort handler on the ClientRequest's `close`, which Bun emits prematurely (mid-body). When the timeout aborted, no handler was left to destroy the request, so the buffered `arrayBuffer()` read hung forever. Cleanup is now keyed off the response stream's end, so the abort reliably tears the exec down.

- The run's abort signal was never plumbed into the git executor, so a cancel / run-timeout could not interrupt an in-flight fetch. It is now combined with the per-op timeout; a cancel aborts the exec and frees the git lock promptly.

Adds a Bun-native regression test (a hung buffered exec must abort at its deadline — hangs forever without the fix) plus git-executor unit tests for the SSH options, timeout mapping, and run-abort handling.