### PR TITLE
fix(containers): pin container MTU to the host egress MTU on VPN/mesh…

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -776,6 +776,17 @@ name maps to the bridge gateway IP. The bind interface for both the egress proxy
 ssh-agent TCP bridge is read **per-run** from a shared mutable holder (`EffectiveBindHost`),
 seeded from `HEZO_CONTAINER_BIND_HOST` / `--container-bind-host` (default `127.0.0.1`).
 
+**Egress MTU.** Containers reach the internet through the host's default-route interface via
+NAT but otherwise inherit Docker's 1500-byte bridge MTU. On a host whose egress is a VPN/mesh
+tunnel (WireGuard, NordVPN, Tailscale — commonly 1420) a full-size packet then black-holes at
+the tunnel: the TLS/SSH handshake (small packets) completes, but a bulk transfer — a
+`git fetch` pack — stalls mid-stream. Provisioning detects the egress-interface MTU
+(`detectHostEgressMtu`, via `ip route get` so a policy-routed VPN table is honoured, not just
+`/proc/net/route`) and, when it is below 1500, pins the container link MTU to it — adding
+`CAP_NET_ADMIN` and running `ip link set dev eth0 mtu <n>` right after start (the base image
+ships `iproute2`; `/sys` is read-only in a container so netlink, not a `/sys` write, is
+required). Normal (≥1500) hosts are untouched — no capability, no MTU change.
+
 A boot-time preflight (`container-connectivity-preflight.ts`) starts a throwaway container,
 probes the MCP port and a bind-host listener in the egress range (20000–29999), and resolves
 the bridge gateway IP both host-side (`DockerClient.inspectNetwork('bridge')` → `IPAM.Config[]

--- a/docker/Dockerfile.agent-base
+++ b/docker/Dockerfile.agent-base
@@ -11,7 +11,7 @@ FROM node:24-slim
 # building git from source is no longer needed; the distro package keeps the
 # image build fast and cache-friendly.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git curl jq unzip openssh-client ca-certificates python3 socat sudo \
+    git curl jq unzip openssh-client ca-certificates python3 socat sudo iproute2 \
     && rm -rf /var/lib/apt/lists/*
 
 # The container runs as the unprivileged `node` user (so bind-mounted worktree

--- a/packages/server/src/services/containers.ts
+++ b/packages/server/src/services/containers.ts
@@ -1,4 +1,6 @@
+import { execFile } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import {
 	ContainerStatus,
@@ -72,12 +74,42 @@ export interface ContainerDeps {
 	containerLogStreamer?: ContainerLogStreamer;
 	sshAgentServer?: SshAgentServer | null;
 	egressCAPath?: string | null;
+	/** Test seam: override host egress-MTU detection. Defaults to the real probe. */
+	detectEgressMtu?: () => Promise<number | null>;
 }
 
 /** In-container path the egress CA is bind-mounted to. */
 export const CONTAINER_CA_PATH = '/usr/local/share/ca-certificates/hezo-egress.crt';
 
 const PROVISION_CAP_BYTES = 64 * 1024;
+
+/** Docker's default bridge MTU; below this the container link MTU is pinned to match. */
+const DEFAULT_BRIDGE_MTU = 1500;
+
+/**
+ * The MTU of the host's default-route egress interface, or null when it can't be
+ * determined (non-Linux, `ip` absent, or a parse failure). Uses `ip route get` so
+ * it honours policy routing — a VPN/mesh (WireGuard, NordVPN, Tailscale) installs
+ * its default route in a separate table that `/proc/net/route` alone wouldn't
+ * reflect. Containers reach the internet through this interface via NAT, so an
+ * egress MTU below the docker bridge MTU means a bulk transfer (a `git fetch`)
+ * black-holes at the tunnel boundary unless the container link MTU is pinned to it.
+ */
+export async function detectHostEgressMtu(): Promise<number | null> {
+	try {
+		const dev = await new Promise<string | null>((resolve) => {
+			execFile('ip', ['-o', 'route', 'get', '1.1.1.1'], { timeout: 3000 }, (err, stdout) => {
+				if (err) return resolve(null);
+				resolve(stdout.match(/\bdev\s+(\S+)/)?.[1] ?? null);
+			});
+		});
+		if (!dev) return null;
+		const mtu = Number.parseInt((await readFile(`/sys/class/net/${dev}/mtu`, 'utf8')).trim(), 10);
+		return Number.isFinite(mtu) && mtu > 0 ? mtu : null;
+	} catch {
+		return null;
+	}
+}
 
 function provisionStreamId(projectId: string): string {
 	return `provision:${projectId}`;
@@ -293,6 +325,15 @@ export async function provisionContainer(
 		}
 		const extraHosts = ['host.docker.internal:host-gateway'];
 
+		// A host whose internet egress is a VPN/mesh tunnel (WireGuard, NordVPN,
+		// Tailscale) has a sub-1500 MTU. Containers reach the internet through it via
+		// NAT but otherwise inherit the 1500 docker-bridge MTU, so a bulk transfer
+		// (a git fetch) black-holes at the tunnel boundary. Pin the container link
+		// MTU to the egress MTU; this needs NET_ADMIN, added only when a lower egress
+		// MTU is actually detected so default (non-tunnelled) hosts are unaffected.
+		const egressMtu = await (deps.detectEgressMtu ?? detectHostEgressMtu)();
+		const pinMtu = egressMtu !== null && egressMtu < DEFAULT_BRIDGE_MTU ? egressMtu : null;
+
 		const env: string[] = [];
 
 		// The stored image is the managed sentinel/default for most projects; in a
@@ -320,12 +361,31 @@ export async function provisionContainer(
 				Binds: binds,
 				PortBindings: portBindings,
 				ExtraHosts: extraHosts,
+				...(pinMtu !== null ? { CapAdd: ['NET_ADMIN'] } : {}),
 			},
 			ExposedPorts: exposedPorts,
 		});
 
 		emit('stdout', '→ Starting container');
 		await docker.startContainer(Id);
+		if (pinMtu !== null) {
+			emit(
+				'stdout',
+				`→ Host egress MTU is ${egressMtu} (< ${DEFAULT_BRIDGE_MTU}); pinning container MTU to ${pinMtu}`,
+			);
+			try {
+				const execId = await docker.execCreate(Id, {
+					Cmd: ['ip', 'link', 'set', 'dev', 'eth0', 'mtu', String(pinMtu)],
+					AttachStdout: true,
+					AttachStderr: true,
+				});
+				const out = await docker.execStart(execId);
+				if (out.stderr.trim())
+					emit('stderr', `⚠ could not pin container MTU: ${out.stderr.trim()}`);
+			} catch (e) {
+				emit('stderr', `⚠ could not pin container MTU: ${(e as Error).message}`);
+			}
+		}
 		log.info(
 			`project ${ref(project.slug, project.id)} container ${ref(project.slug, Id.slice(0, 12))} provisioned and started`,
 		);

--- a/packages/server/src/services/docker.ts
+++ b/packages/server/src/services/docker.ts
@@ -28,6 +28,7 @@ interface ContainerConfig {
 		Binds?: string[];
 		PortBindings?: Record<string, Array<{ HostPort: string }>>;
 		ExtraHosts?: string[];
+		CapAdd?: string[];
 	};
 	ExposedPorts?: Record<string, object>;
 }

--- a/packages/server/src/services/git.ts
+++ b/packages/server/src/services/git.ts
@@ -512,7 +512,7 @@ async function addTaskWorktree(
 					success: false,
 					created: false,
 					error:
-						'clone has no commits and no remote default branch — push an initial commit to the remote and retry (it is fetched on the next run)',
+						'clone is empty (no commits fetched) — the fetch above failed, or the remote genuinely has no commits; fix connectivity or push an initial commit, then retry',
 				};
 			}
 			args = ['worktree', 'add', '-b', branchName, wt.containerPath];

--- a/packages/server/test/containers-provision-branches.test.ts
+++ b/packages/server/test/containers-provision-branches.test.ts
@@ -37,6 +37,7 @@ interface CreateContainerCall {
 			Binds?: string[];
 			PortBindings?: Record<string, Array<{ HostPort: string }>>;
 			ExtraHosts?: string[];
+			CapAdd?: string[];
 		};
 		ExposedPorts?: Record<string, object>;
 	};
@@ -328,6 +329,48 @@ describe('provisionContainer', () => {
 		const text = logs.getLogText(`provision:${projectId}`);
 		expect(text).toContain('→ Trusting Hezo egress CA');
 		expect(text).toContain('ca-store warning line');
+	});
+
+	it('pins the container MTU (with NET_ADMIN) when the host egress MTU is below the bridge', async () => {
+		await resetContainerRow();
+		const { docker, created } = recordingDocker();
+		const logs = new LogStreamBroker();
+
+		await provisionContainer(
+			baseDeps(docker, { logs, detectEgressMtu: async () => 1420 }),
+			await projectRow(),
+			teamSlug,
+		);
+
+		expect(created[0].config.HostConfig.CapAdd).toEqual(['NET_ADMIN']);
+		const execCreate = docker.execCreate as ReturnType<typeof vi.fn>;
+		const mtuExec = execCreate.mock.calls.find((c) => (c[1] as { Cmd: string[] }).Cmd[0] === 'ip');
+		expect((mtuExec?.[1] as { Cmd: string[] }).Cmd).toEqual([
+			'ip',
+			'link',
+			'set',
+			'dev',
+			'eth0',
+			'mtu',
+			'1420',
+		]);
+		expect(logs.getLogText(`provision:${projectId}`)).toContain('pinning container MTU to 1420');
+	});
+
+	it('leaves MTU and capabilities untouched on a normal (>=1500) egress host', async () => {
+		await resetContainerRow();
+		const { docker, created } = recordingDocker();
+
+		await provisionContainer(
+			baseDeps(docker, { detectEgressMtu: async () => null }),
+			await projectRow(),
+			teamSlug,
+		);
+
+		expect(created[0].config.HostConfig.CapAdd).toBeUndefined();
+		const execCreate = docker.execCreate as ReturnType<typeof vi.fn>;
+		const mtuExec = execCreate.mock.calls.find((c) => (c[1] as { Cmd: string[] }).Cmd[0] === 'ip');
+		expect(mtuExec).toBeUndefined();
 	});
 
 	it('reports a failed update-ca-certificates without failing the provision', async () => {

--- a/packages/server/test/git.test.ts
+++ b/packages/server/test/git.test.ts
@@ -649,6 +649,7 @@ describe('origin remote inspection and repair', () => {
 		expect(res.success).toBe(false);
 		expect(res.error).toContain('no commits');
 		expect(res.error).toContain('push an initial commit');
+		expect(res.error).toContain('the fetch above failed');
 	});
 });
 


### PR DESCRIPTION
… hosts

When the host's internet egress is a VPN/mesh tunnel (WireGuard, NordVPN, Tailscale — commonly MTU 1420), containers inherit Docker's 1500-byte bridge MTU and their full-size packets black-hole at the tunnel: the TLS/SSH handshake (small packets) completes, but a bulk `git fetch` pack stalls mid-stream. On a production NordVPN host this surfaced as a run whose fetch failed with "server github.com not responding" / "unexpected disconnect while reading sideband packet" — the host itself clones fine (it uses the 1420 MTU); only containers, which think their MTU is 1500, fail.

Provisioning now detects the host egress-interface MTU (`detectHostEgressMtu` via `ip route get`, so a policy-routed VPN table is honoured, not just /proc/net/route) and, when it is below 1500, pins the container link MTU to match — adding CAP_NET_ADMIN and running `ip link set dev eth0 mtu <n>` after start. Normal (>=1500) hosts are untouched: no capability, no MTU change. The agent base image now ships iproute2 (netlink is required — /sys is read-only in a container so the MTU can't be set via a /sys write).

Also reword the empty-clone worktree error, which wrongly told the operator to "push an initial commit" when the usual cause is a failed fetch, not an empty remote.