### PR TITLE
ci(release): gate GitHub Release on agent-base image publish

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -1211,8 +1211,12 @@ via `hezo restore` (embedded only).
 
 **Releases & updates.** A PR flow (`.github/workflows/`): `release.yml` computes the next
 version from Conventional Commits and opens a `release/<version>` PR; merging fires
-`release-publish.yml`, which tags, cross-compiles, and publishes a GitHub Release (assets
-`hezo-{os}-{arch}[.exe]` + `SHA256SUMS`). The running instance polls
+`release-publish.yml`, which first builds and publishes the agent-base image to GHCR
+(`ghcr.io/hezo-ai/agent-base:<version>` + `:latest`) and then — **only once that push
+succeeds** — tags the merge commit, cross-compiles, and publishes a GitHub Release (assets
+`hezo-{os}-{arch}[.exe]` + `SHA256SUMS`). Gating the Release on the image (the `publish`
+job `needs` `publish-agent-image`) means a published version never advertises binaries whose
+provisioning pull (`agent-base:<version>`) would 404. The running instance polls
 `GET /api/updates/latest` (cached ~1 h, fails soft) and shows a bottom banner. The
 Settings → General page also renders a **Version** section (current version linked to its
 GitHub release, plus a **"Check for new version"** button that calls

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,8 +1,9 @@
 name: Release Publish
 
 # Fires when a release PR (head branch release/<version>, opened by release.yml)
-# is merged into main. Tags the merge commit (no v-prefix) and publishes a
-# GitHub Release whose body is the just-merged CHANGELOG.md section.
+# is merged into main. First builds + publishes the agent-base image to GHCR, then
+# — only once that push has succeeded — tags the merge commit (no v-prefix) and
+# publishes a GitHub Release whose body is the just-merged CHANGELOG.md section.
 
 on:
   pull_request:
@@ -19,8 +20,63 @@ env:
   BUN_VERSION: "1.3.11"
 
 jobs:
+  # Build the agent-base image and publish it to GHCR tagged with this release's
+  # version (+ :latest). Release binaries of this version pull
+  # ghcr.io/hezo-ai/agent-base:<version> at provision time instead of building it
+  # locally (packages/server/src/services/image-registry.ts) — so the GHCR package
+  # must be public for the server's anonymous pull. Multi-arch so amd64 and arm64
+  # hosts both pull rather than fall back to a local build; arm64 compiles git from
+  # source under QEMU emulation, hence the long timeout.
+  #
+  # This runs BEFORE the GitHub Release is published (the `publish` job `needs` it):
+  # a released version advertises binaries that pull agent-base:<version> at
+  # provision time, so cutting the Release before the image is pushed would hand
+  # users a version that can't provision if this build fails. cache-from reuses the
+  # amd64 layers ci.yml warms on main; arm64 builds cold.
+  publish-agent-image:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    if: >-
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/')
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: main # post-merge main, matching the published binaries
+      - id: meta
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: echo "version=${HEAD_REF#release/}" >> "$GITHUB_OUTPUT"
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: docker
+          file: docker/Dockerfile.agent-base
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/hezo-ai/agent-base:${{ steps.meta.outputs.version }}
+            ghcr.io/hezo-ai/agent-base:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # Cross-compile the release binaries, tag the merge commit, and publish the
+  # GitHub Release. `needs: publish-agent-image` is the gate the whole change is
+  # about: nothing here (tag, Release, or advertised assets) lands until the
+  # agent-base image for this version is live in GHCR, so a published version can
+  # never point users at binaries whose provisioning pull would 404.
   publish:
     runs-on: ubuntu-latest
+    needs: publish-agent-image
     if: >-
       github.event.pull_request.merged == true &&
       startsWith(github.event.pull_request.head.ref, 'release/')
@@ -64,48 +120,3 @@ jobs:
           bun run release --notes "$version" > /tmp/release-notes.md
           gh release create "$version" --title "$version" --notes-file /tmp/release-notes.md \
             dist/binaries/*
-
-  # Build the agent-base image and publish it to GHCR tagged with this release's
-  # version (+ :latest). Release binaries of this version pull
-  # ghcr.io/hezo-ai/agent-base:<version> at provision time instead of building it
-  # locally (packages/server/src/services/image-registry.ts) — so the GHCR package
-  # must be public for the server's anonymous pull. Multi-arch so amd64 and arm64
-  # hosts both pull rather than fall back to a local build; arm64 compiles git from
-  # source under QEMU emulation, hence the long timeout. Runs in parallel with the
-  # binary publish job above — neither depends on the other.
-  publish-agent-image:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    if: >-
-      github.event.pull_request.merged == true &&
-      startsWith(github.event.pull_request.head.ref, 'release/')
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          ref: main # post-merge main, matching the published binaries
-      - id: meta
-        env:
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
-        run: echo "version=${HEAD_REF#release/}" >> "$GITHUB_OUTPUT"
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      # cache-from reuses the amd64 layers ci.yml warms on main; arm64 builds cold.
-      - uses: docker/build-push-action@v6
-        with:
-          context: docker
-          file: docker/Dockerfile.agent-base
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ghcr.io/hezo-ai/agent-base:${{ steps.meta.outputs.version }}
-            ghcr.io/hezo-ai/agent-base:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max


### PR DESCRIPTION
## What & why

Publishing a release (the final step, triggered when a `release/<version>` PR merges) previously created the GitHub Release and built the agent-base Docker image **in parallel** — neither depended on the other.

That ordering is unsafe: a release binary of `<version>` pulls `ghcr.io/hezo-ai/agent-base:<version>` at provision time (`packages/server/src/services/image-registry.ts`). If the image build failed or lagged, the GitHub Release could already be live, advertising a version whose provisioning pull would **404**.

This makes the release-publishing job wait for the image: the GitHub Release is not created until the agent-base image has been built and pushed to GHCR successfully.

## Changes

- **`.github/workflows/release-publish.yml`**: the `publish` job (build binaries → tag merge commit → `gh release create`) now `needs: publish-agent-image`. If the image build fails, `publish` is skipped — no tag, no Release. Reordered the image job ahead of `publish` and rewrote the comments to explain the gate. Re-running the failed image job (then `publish`) is the recovery path.
- **`.dev/architecture.md`**: updated the *Releases & updates* section to describe the new ordering (image publish first, then — only on success — tag + cross-compile + GitHub Release).

## Behavior

| Outcome | Result |
|---|---|
| Image build succeeds | Tag pushed + GitHub Release published, as before |
| Image build fails | `publish` skipped — no tag, no Release advertising a broken version |

## Testing

The release workflows are CI YAML with no unit-test tier. Verified the YAML parses and the dependency edge is present (`jobs.publish.needs == publish-agent-image`). No `.test.ts` references these workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PvvUU7AhcCZxkx5gbWmka

---
_Generated by [Claude Code](https://claude.ai/code/session_011PvvUU7AhcCZxkx5gbWmka)_