### PR TITLE
fix(git): repair a clone stuck at git clone's .invalid HEAD sentinel

### DIFF
--- a/packages/server/src/services/git.ts
+++ b/packages/server/src/services/git.ts
@@ -310,9 +310,26 @@ export async function fastForwardLocalDefault(
 		}
 	}
 	const upd = await executor.exec(['update-ref', local, remote], { cwd, timeout: 30_000 });
-	return upd.exitCode === 0
-		? undefined
-		: `could not fast-forward ${def}: ${formatGitError(upd.stderr)}`;
+	if (upd.exitCode !== 0) {
+		return `could not fast-forward ${def}: ${formatGitError(upd.stderr)}`;
+	}
+
+	// A clone populated by fetch alone (adopted in place, or one whose initial
+	// checkout never completed) has an unborn HEAD: the local default ref now
+	// exists, but HEAD still points at a branch with no commit, and `git worktree
+	// add` reads HEAD and dies with "Failed to resolve HEAD as a valid ref" — even
+	// when handed an explicit commit-ish. Point HEAD at the freshly-materialised
+	// default branch (ref only, working tree left untouched) so worktree prep can
+	// proceed and the stale clone self-heals.
+	const headBorn = await executor.exec(['rev-parse', '--verify', '--quiet', 'HEAD'], {
+		cwd,
+		timeout: 30_000,
+	});
+	if (headBorn.exitCode !== 0) {
+		const sym = await executor.exec(['symbolic-ref', 'HEAD', local], { cwd, timeout: 30_000 });
+		if (sym.exitCode !== 0) return `could not set HEAD to ${def}: ${formatGitError(sym.stderr)}`;
+	}
+	return undefined;
 }
 
 /**

--- a/packages/server/test/git.test.ts
+++ b/packages/server/test/git.test.ts
@@ -651,6 +651,43 @@ describe('origin remote inspection and repair', () => {
 		expect(res.error).toContain('push an initial commit');
 		expect(res.error).toContain('the fetch above failed');
 	});
+
+	it("fastForwardLocalDefault repairs a clone stuck at git clone's .invalid HEAD sentinel", async () => {
+		// The production failure: a `git clone` that dies mid-fetch (a dropped network,
+		// the MTU black-hole) leaves .git/HEAD at the `refs/heads/.invalid` sentinel that
+		// clone sets before it resolves the real default. Once a later fetch succeeds,
+		// origin/<default> exists but HEAD is still the invalid ref — and `git worktree
+		// add`, even with an explicit commit-ish, dies with "failed to resolve HEAD as a
+		// valid ref" (an unborn *valid* branch would be fine; an invalid ref is not).
+		const def = branchOf(cloneDir); // the branch that exists on the bare "remote"
+		const initDir = join(testDir, 'invalid-head-clone');
+		mkdirSync(initDir, { recursive: true });
+		run('git init', initDir);
+		configure(initDir, 'Test');
+		run(`git remote add origin ${bareRepoDir}`, initDir);
+		const fetched = await fetchRepo(exec, repoLoc(initDir));
+		expect(fetched.success).toBe(true);
+		// Stick HEAD at the sentinel, exactly as an interrupted clone leaves it.
+		writeFileSync(join(initDir, '.git', 'HEAD'), 'ref: refs/heads/.invalid\n');
+		const before = await exec.exec(['rev-parse', '--verify', '--quiet', 'HEAD'], { cwd: initDir });
+		expect(before.exitCode).not.toBe(0); // HEAD does not resolve
+
+		const warn = await fastForwardLocalDefault(exec, repoLoc(initDir));
+		expect(warn).toBeUndefined();
+
+		// HEAD now resolves to the remote default tip.
+		const remoteTip = execSync(`git rev-parse refs/remotes/origin/${def}`, { cwd: initDir })
+			.toString()
+			.trim();
+		expect(sha(initDir)).toBe(remoteTip);
+		expect(branchOf(initDir)).toBe(def);
+
+		// The worktree add that previously failed with "failed to resolve HEAD" now works.
+		const wtDir = join(testDir, 'wt-invalid-head', 'repo');
+		const wt = await ensureTaskWorktree(exec, repoLoc(initDir), wtLoc(wtDir), 'hezo/IH-1');
+		expect(wt.success).toBe(true);
+		expect(existsSync(join(wtDir, 'README.md'))).toBe(true);
+	});
 });
 
 describe('isTransientMountError', () => {


### PR DESCRIPTION
A `git clone` that dies mid-fetch (e.g. the original MTU black-hole) leaves .git/HEAD at the `refs/heads/.invalid` sentinel that clone sets before it resolves the remote's default branch. Once a later fetch succeeds, origin/<default> is populated but HEAD is still the invalid ref — and `git worktree add`, even with an explicit commit-ish, dies with "failed to resolve HEAD as a valid ref", so repo prep can never complete. Observed on production for the `website` clone (its original clone was interrupted by the MTU black-hole; the fetch now succeeds but HEAD stayed at the sentinel). A valid-but-unborn HEAD is fine for worktree add; an invalid ref is not, which is why fresh-clone reproductions all passed.

fastForwardLocalDefault already materialises refs/heads/<default> from the fetched tip via update-ref; now, when HEAD doesn't resolve (the .invalid sentinel, an unborn branch, or any broken ref), it points HEAD at that branch so the clone self-heals on the next run — no re-clone, keeping the fetched objects. Born-HEAD clones are untouched, and the sentinel never matches the default so the merge fast-path is not taken.

Adds a regression test reproducing the exact prod state (.git/HEAD = ref: refs/heads/.invalid): the worktree add that previously failed with "failed to resolve HEAD" now succeeds.