### PR TITLE
feat(web): drag to resize the document preview panel

### DIFF
--- a/packages/web/src/components/ui/resizable-split.tsx
+++ b/packages/web/src/components/ui/resizable-split.tsx
@@ -1,0 +1,289 @@
+import {
+	type CSSProperties,
+	type KeyboardEvent as ReactKeyboardEvent,
+	type ReactNode,
+	type PointerEvent as ReactPointerEvent,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from 'react';
+import {
+	clampPanelWidth,
+	MAX_PANEL_WIDTH,
+	MIN_PANEL_WIDTH,
+	readStoredPanelWidth,
+	writeStoredPanelWidth,
+} from '../../lib/panel-width-storage';
+
+/** Keyboard resize step (px) per Arrow press on a focused handle. */
+const STEP = 24;
+
+type Side = 'left' | 'right';
+
+interface UseResizableSplitOptions {
+	side: Side;
+	/** Persist the dragged width under this localStorage key; omit → resets on reload. */
+	storageKey?: string;
+}
+
+interface UseResizableSplitResult {
+	/** The user-chosen width (px), or `null` before the first resize (responsive default in charge). */
+	width: number | null;
+	isResizing: boolean;
+	/** Ref for the grid container — measured for the container-based max clamp. */
+	gridRef: React.RefObject<HTMLDivElement | null>;
+	/** Ref for the panel's grid cell — measured at drag start for the width baseline. */
+	panelCellRef: React.RefObject<HTMLDivElement | null>;
+	handleProps: {
+		onPointerDown: (e: ReactPointerEvent<HTMLDivElement>) => void;
+		onKeyDown: (e: ReactKeyboardEvent<HTMLDivElement>) => void;
+	};
+}
+
+/**
+ * Drag-to-resize state for a two-column split. The pointer mechanics mirror
+ * {@link file://../../hooks/use-draggable-fab.ts}: pointer capture (with a
+ * happy-dom `try/catch`), document-level move/up listeners gated by a resizing
+ * flag, and a `ResizeObserver` re-clamp when the container shrinks. Reusable on
+ * its own for a bespoke grid; {@link ResizableSplit} wraps it with the layout.
+ */
+export function useResizableSplit({
+	side,
+	storageKey,
+}: UseResizableSplitOptions): UseResizableSplitResult {
+	const [width, setWidth] = useState<number | null>(() =>
+		storageKey ? readStoredPanelWidth(storageKey) : null,
+	);
+	const [isResizing, setIsResizing] = useState(false);
+	const gridRef = useRef<HTMLDivElement>(null);
+	const panelCellRef = useRef<HTMLDivElement>(null);
+	const dragRef = useRef<{ pointerId: number; startX: number; startWidth: number } | null>(null);
+	// Mirror width in a ref so the pointer-up handler persists the latest value.
+	const widthRef = useRef<number | null>(width);
+	widthRef.current = width;
+
+	const containerWidth = useCallback(() => gridRef.current?.getBoundingClientRect().width, []);
+
+	const persist = useCallback(
+		(w: number) => {
+			if (storageKey) writeStoredPanelWidth(storageKey, w);
+		},
+		[storageKey],
+	);
+
+	const onPointerDown = useCallback((e: ReactPointerEvent<HTMLDivElement>) => {
+		if (!e.isPrimary || e.button !== 0) return;
+		const cell = panelCellRef.current;
+		if (!cell) return;
+		e.preventDefault();
+		dragRef.current = {
+			pointerId: e.pointerId,
+			startX: e.clientX,
+			// Baseline off the rendered cell so a drag starting from a responsive
+			// default (width still null) picks up the real current width.
+			startWidth: cell.getBoundingClientRect().width,
+		};
+		try {
+			e.currentTarget.setPointerCapture(e.pointerId);
+		} catch {
+			// happy-dom lacks pointer capture; the document listeners still fire.
+		}
+		setIsResizing(true);
+	}, []);
+
+	useEffect(() => {
+		if (!isResizing) return;
+		// Keep the whole page in the resize cursor and suppress text selection
+		// while dragging; restore on gesture end.
+		const prevCursor = document.body.style.cursor;
+		const prevSelect = document.body.style.userSelect;
+		document.body.style.cursor = 'col-resize';
+		document.body.style.userSelect = 'none';
+
+		const onMove = (e: PointerEvent) => {
+			const d = dragRef.current;
+			if (!d || e.pointerId !== d.pointerId) return;
+			const dx = e.clientX - d.startX;
+			// Dragging the divider toward the main column widens the panel.
+			const delta = side === 'right' ? -dx : dx;
+			setWidth(clampPanelWidth(d.startWidth + delta, containerWidth()));
+		};
+		const onUp = (e: PointerEvent) => {
+			const d = dragRef.current;
+			if (!d || e.pointerId !== d.pointerId) return;
+			dragRef.current = null;
+			setIsResizing(false);
+			if (widthRef.current != null) persist(widthRef.current);
+		};
+		document.addEventListener('pointermove', onMove);
+		document.addEventListener('pointerup', onUp);
+		document.addEventListener('pointercancel', onUp);
+		return () => {
+			document.removeEventListener('pointermove', onMove);
+			document.removeEventListener('pointerup', onUp);
+			document.removeEventListener('pointercancel', onUp);
+			document.body.style.cursor = prevCursor;
+			document.body.style.userSelect = prevSelect;
+		};
+	}, [isResizing, side, containerWidth, persist]);
+
+	const onKeyDown = useCallback(
+		(e: ReactKeyboardEvent<HTMLDivElement>) => {
+			if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+			e.preventDefault();
+			const current =
+				widthRef.current ?? panelCellRef.current?.getBoundingClientRect().width ?? MIN_PANEL_WIDTH;
+			// The arrow pointing toward the main column widens the panel.
+			const towardMain = side === 'right' ? 'ArrowLeft' : 'ArrowRight';
+			const dir = e.key === towardMain ? 1 : -1;
+			const next = clampPanelWidth(current + dir * STEP, containerWidth());
+			setWidth(next);
+			persist(next);
+		},
+		[side, containerWidth, persist],
+	);
+
+	// Re-clamp a stored/dragged width when the container shrinks (e.g. viewport
+	// resize), so the panel can never leave the main column below its minimum.
+	useEffect(() => {
+		const grid = gridRef.current;
+		if (!grid || typeof ResizeObserver === 'undefined') return;
+		const ro = new ResizeObserver(() => {
+			if (widthRef.current == null) return;
+			const clamped = clampPanelWidth(widthRef.current, grid.getBoundingClientRect().width);
+			if (clamped !== widthRef.current) setWidth(clamped);
+		});
+		ro.observe(grid);
+		return () => ro.disconnect();
+	}, []);
+
+	return { width, isResizing, gridRef, panelCellRef, handleProps: { onPointerDown, onKeyDown } };
+}
+
+interface ResizableSplitProps {
+	/** Main content — the flexible `1fr` column. */
+	children: ReactNode;
+	/** The resizable side panel; `null` collapses the layout to `collapsedTrackClass`. */
+	panel: ReactNode | null;
+	/** Which side the resizable panel sits on. Default `'right'`. */
+	side?: Side;
+	/** Persist the dragged width in localStorage under this key; omit → resets on reload. */
+	storageKey?: string;
+	/**
+	 * Static `lg:grid-cols-[…]` utility used until the user first drags, so callers
+	 * keep their own responsive default. MUST be a literal for Tailwind's JIT.
+	 */
+	defaultTrackClass: string;
+	/** Static `lg:grid-cols-[…]` utility used when `panel` is `null`. */
+	collapsedTrackClass?: string;
+	/** Extra classes on the grid container (base breakpoints, etc.). */
+	className?: string;
+	/** App-specific extra grid siblings (e.g. a meta rail using `lg:contents`). */
+	aside?: ReactNode;
+}
+
+/**
+ * A two-column grid whose side panel can be resized by dragging the divider
+ * between the columns. Mobile-first: the grid is a single column at base and the
+ * resizable track only engages at `lg+` (the caller's track utilities are all
+ * `lg:`-prefixed), so a below-`lg` panel that renders as its own overlay is
+ * unaffected. The divider is keyboard-operable and the width optionally persists.
+ */
+export function ResizableSplit({
+	children,
+	panel,
+	side = 'right',
+	storageKey,
+	defaultTrackClass,
+	collapsedTrackClass = '',
+	className = '',
+	aside,
+}: ResizableSplitProps) {
+	const { width, isResizing, gridRef, panelCellRef, handleProps } = useResizableSplit({
+		side,
+		storageKey,
+	});
+
+	const hasPanel = panel != null;
+	const dragged = width != null;
+	// Static per-side literals so Tailwind's JIT emits both tracks.
+	const varTrack =
+		side === 'right' ? 'lg:grid-cols-[1fr_var(--panel-w)]' : 'lg:grid-cols-[var(--panel-w)_1fr]';
+	const trackClass = hasPanel ? (dragged ? varTrack : defaultTrackClass) : collapsedTrackClass;
+	const gridStyle: CSSProperties | undefined =
+		hasPanel && dragged ? ({ '--panel-w': `${width}px` } as CSSProperties) : undefined;
+
+	// `contents` below `lg` so the wrapper adds no grid box there — a panel that
+	// renders as its own overlay (e.g. `fixed`) then contributes no empty row/gap,
+	// and a panel that stacks flows directly. At `lg+` it becomes the positioned
+	// grid cell that hosts the divider and any sticky panel.
+	const panelCell = hasPanel ? (
+		<div ref={panelCellRef} className="contents min-w-0 lg:relative lg:block">
+			<ResizeHandle side={side} active={isResizing} valueNow={width} {...handleProps} />
+			{panel}
+		</div>
+	) : null;
+
+	return (
+		<div
+			ref={gridRef}
+			className={`grid grid-cols-1 gap-5 ${trackClass} ${className}`.trim()}
+			style={gridStyle}
+		>
+			{side === 'left' && panelCell}
+			{children}
+			{aside}
+			{side === 'right' && panelCell}
+		</div>
+	);
+}
+
+/**
+ * The draggable divider. A wide invisible hit-zone sits in the `gap-5` gutter on
+ * the main-content side of the panel, with a thin line that lights up on hover /
+ * while active. Desktop-only (`hidden lg:flex`) — below `lg` the panel is its own
+ * overlay, so there is nothing to resize.
+ */
+function ResizeHandle({
+	side,
+	active,
+	valueNow,
+	onPointerDown,
+	onKeyDown,
+}: {
+	side: Side;
+	active: boolean;
+	/** Current panel width (px) for `aria-valuenow`; `null` before the first resize. */
+	valueNow: number | null;
+	onPointerDown: (e: ReactPointerEvent<HTMLDivElement>) => void;
+	onKeyDown: (e: ReactKeyboardEvent<HTMLDivElement>) => void;
+}) {
+	// The gutter is the 20px (`gap-5`) immediately to the main-content side of the cell.
+	const gutter = side === 'right' ? '-left-5' : '-right-5';
+	return (
+		// The WAI-ARIA window-splitter pattern: a focusable `separator` with
+		// value semantics. An `<hr>` (useSemanticElements' suggestion) can't be
+		// focused or hold the visible line, so the role stays explicit.
+		// biome-ignore lint/a11y/useSemanticElements: focusable resize separator, not an <hr>
+		<div
+			role="separator"
+			aria-orientation="vertical"
+			aria-label="Resize panel"
+			aria-valuenow={valueNow ?? undefined}
+			aria-valuemin={MIN_PANEL_WIDTH}
+			aria-valuemax={MAX_PANEL_WIDTH}
+			tabIndex={0}
+			data-testid="resize-handle"
+			onPointerDown={onPointerDown}
+			onKeyDown={onKeyDown}
+			className={`group absolute inset-y-0 ${gutter} z-10 hidden w-5 cursor-col-resize touch-none select-none items-stretch justify-center rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring lg:flex`}
+		>
+			<span
+				className={`w-0.5 rounded-full transition-colors ${
+					active ? 'bg-accent' : 'bg-transparent group-hover:bg-border-strong'
+				}`}
+			/>
+		</div>
+	);
+}

--- a/packages/web/src/lib/panel-width-storage.ts
+++ b/packages/web/src/lib/panel-width-storage.ts
@@ -1,0 +1,48 @@
+// Generic, key-parameterised persistence for a resizable panel's width. The
+// user's dragged width is written to localStorage under a caller-supplied key so
+// it survives reloads. Modelled on `task-filter-storage.ts`: clamp/validate on
+// read so a tampered or stale entry can never feed a garbage width into the grid.
+
+import { readStored, writeStored } from './safe-storage';
+
+/** Narrowest a resizable panel may become (px) — below this a document is unreadable. */
+export const MIN_PANEL_WIDTH = 280;
+/** Absolute cap for a stored width (px), independent of the live container size. */
+export const MAX_PANEL_WIDTH = 1200;
+/** The flexible main column keeps at least this much room (px) when the panel widens. */
+export const MIN_MAIN_WIDTH = 380;
+
+/**
+ * Clamp a candidate panel width to `[MIN_PANEL_WIDTH, min(MAX_PANEL_WIDTH,
+ * containerWidth − MIN_MAIN_WIDTH)]`. `containerWidth` is omitted for the
+ * storage-only bound (no live layout to measure); pass it during a drag so the
+ * main column always keeps `MIN_MAIN_WIDTH`.
+ */
+export function clampPanelWidth(px: number, containerWidth?: number): number {
+	const containerMax =
+		containerWidth != null && Number.isFinite(containerWidth)
+			? containerWidth - MIN_MAIN_WIDTH
+			: Number.POSITIVE_INFINITY;
+	const upper = Math.min(MAX_PANEL_WIDTH, containerMax);
+	// Never return below the floor even if the container is too narrow to honour it.
+	return Math.max(MIN_PANEL_WIDTH, Math.min(px, Math.max(MIN_PANEL_WIDTH, upper)));
+}
+
+/**
+ * The persisted width for `key`, or `null` when nothing valid is stored (so the
+ * caller falls back to its responsive default). Tolerates malformed / non-numeric
+ * entries by returning `null`.
+ */
+export function readStoredPanelWidth(key: string): number | null {
+	if (typeof window === 'undefined' || !key) return null;
+	const raw = readStored(key);
+	if (raw == null || raw === '') return null;
+	const n = Number(raw);
+	if (!Number.isFinite(n)) return null;
+	return Math.round(clampPanelWidth(n));
+}
+
+export function writeStoredPanelWidth(key: string, px: number): void {
+	if (typeof window === 'undefined' || !key || !Number.isFinite(px)) return;
+	writeStored(key, String(Math.round(clampPanelWidth(px))));
+}

--- a/packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx
@@ -16,6 +16,7 @@ import { SubTasksSection } from '../../../../components/task-detail/sub-tasks-se
 import { TaskHeader } from '../../../../components/task-detail/task-header';
 import { TaskSidebar } from '../../../../components/task-detail/task-sidebar';
 import { TaskSummary } from '../../../../components/task-detail/task-summary';
+import { ResizableSplit } from '../../../../components/ui/resizable-split';
 import { useAgents } from '../../../../hooks/use-agents';
 import { type Comment, useComments, useCreateComment } from '../../../../hooks/use-comments';
 import { useExecutionLock } from '../../../../hooks/use-execution-locks';
@@ -61,10 +62,11 @@ function TaskDetailPage() {
 	const [commentEffort, setCommentEffort] = useState<AgentEffort | null>(null);
 	const [replyTarget, setReplyTarget] = useState<Comment | null>(null);
 	// A doc clicked in a comment opens in the preview panel: an in-grid column at
-	// lg+ that widens on the roomier xl/2xl breakpoints (up to 2× its base width)
-	// so wide screens get a more readable document view, and its own full-screen
-	// overlay (above the main content and the meta drawer) below lg. It is
-	// independent of the meta side rail.
+	// lg+ that defaults to widening on the roomier xl/2xl breakpoints (up to 2× its
+	// base width) and is user-resizable by dragging the divider between it and the
+	// task content (persisted in localStorage); and its own full-screen overlay
+	// (above the main content and the meta drawer) below lg. It is independent of
+	// the meta side rail.
 	const [preview, setPreview] = useState<PreviewItem | null>(null);
 	// The meta side rail is a collapsed-by-default drawer on mobile, toggled by
 	// the chevron. It is independent of the preview panel — opening/closing a
@@ -104,8 +106,71 @@ function TaskDetailPage() {
 	const taskProjectSlug = task.project_slug ?? projectId;
 
 	return (
-		<div
-			className={`grid grid-cols-1 gap-5 ${preview ? 'lg:grid-cols-[1fr_360px] xl:grid-cols-[1fr_520px] 2xl:grid-cols-[1fr_720px]' : 'lg:grid-cols-[1fr_190px]'}`}
+		<ResizableSplit
+			side="right"
+			storageKey="hezo:preview-panel-width"
+			defaultTrackClass="lg:grid-cols-[1fr_360px] xl:grid-cols-[1fr_520px] 2xl:grid-cols-[1fr_720px]"
+			collapsedTrackClass="lg:grid-cols-[1fr_190px]"
+			panel={
+				preview ? (
+					<PreviewPanel
+						item={preview}
+						onClose={() => setPreview(null)}
+						task={{ projectId, taskId, identifier: task.identifier, title: task.title }}
+					/>
+				) : null
+			}
+			aside={
+				<>
+					{/* Right rail: an in-grid sticky column at lg+, a slide-in floating
+					    drawer below lg (collapsed by default, toggled by the chevron). */}
+					<button
+						type="button"
+						onClick={() => setSidebarOpen((o) => !o)}
+						data-testid="task-sidebar-toggle"
+						aria-label={sidebarOpen ? 'Collapse task details' : 'Expand task details'}
+						aria-expanded={sidebarOpen}
+						className="lg:hidden fixed right-0 top-1/2 -translate-y-1/2 z-50 h-12 w-7 rounded-l-md border border-r-0 border-border bg-surface text-text-2 hover:text-text-1 shadow-md flex items-center justify-center"
+					>
+						{sidebarOpen ? (
+							<ChevronRight className="w-4 h-4" />
+						) : (
+							<ChevronLeft className="w-4 h-4" />
+						)}
+					</button>
+					{sidebarOpen && (
+						<button
+							type="button"
+							aria-label="Close task details"
+							onClick={() => setSidebarOpen(false)}
+							className="lg:hidden fixed inset-0 z-40 bg-[var(--overlay)] cursor-default"
+						/>
+					)}
+					{/* Task meta side panel. Mobile: a fixed right-side drawer toggled by the
+					    chevron. Desktop: `lg:contents` makes this wrapper generate no box, so
+					    TaskSidebar becomes the direct grid child (in-grid sticky column). While
+					    a preview is open the sidebar column yields to the preview on desktop
+					    (`lg:hidden`); on mobile the preview is its own overlay above this. */}
+					<div
+						data-testid="task-rail"
+						className={`fixed top-0 right-0 z-40 h-full w-[280px] max-w-[85vw] overflow-y-auto bg-surface p-4 shadow-xl transition-transform duration-200 ${
+							sidebarOpen ? 'translate-x-0' : 'translate-x-full'
+						} ${preview ? 'lg:hidden' : 'lg:contents'}`}
+					>
+						<TaskSidebar
+							task={task}
+							projectId={projectId}
+							agents={agents}
+							lock={lock}
+							comments={comments}
+							updateTask={updateTask}
+							commentEffort={commentEffort}
+							setCommentEffort={setCommentEffort}
+							scrollToBottom={scrollToBottom}
+						/>
+					</div>
+				</>
+			}
 		>
 			<PreviewProvider value={openPreview}>
 				<div className="min-w-0">
@@ -166,60 +231,7 @@ function TaskDetailPage() {
 					</div>
 				</div>
 			</PreviewProvider>
-
-			{/* Right rail: an in-grid sticky column at lg+, a slide-in floating
-				    drawer below lg (collapsed by default, toggled by the chevron). */}
-			<button
-				type="button"
-				onClick={() => setSidebarOpen((o) => !o)}
-				data-testid="task-sidebar-toggle"
-				aria-label={sidebarOpen ? 'Collapse task details' : 'Expand task details'}
-				aria-expanded={sidebarOpen}
-				className="lg:hidden fixed right-0 top-1/2 -translate-y-1/2 z-50 h-12 w-7 rounded-l-md border border-r-0 border-border bg-surface text-text-2 hover:text-text-1 shadow-md flex items-center justify-center"
-			>
-				{sidebarOpen ? <ChevronRight className="w-4 h-4" /> : <ChevronLeft className="w-4 h-4" />}
-			</button>
-			{sidebarOpen && (
-				<button
-					type="button"
-					aria-label="Close task details"
-					onClick={() => setSidebarOpen(false)}
-					className="lg:hidden fixed inset-0 z-40 bg-[var(--overlay)] cursor-default"
-				/>
-			)}
-			{/* Task meta side panel. Mobile: a fixed right-side drawer toggled by the
-				    chevron. Desktop: `lg:contents` makes this wrapper generate no box, so
-				    TaskSidebar becomes the direct grid child (in-grid sticky column). While
-				    a preview is open the sidebar column yields to the preview on desktop
-				    (`lg:hidden`); on mobile the preview is its own overlay above this. */}
-			<div
-				data-testid="task-rail"
-				className={`fixed top-0 right-0 z-40 h-full w-[280px] max-w-[85vw] overflow-y-auto bg-surface p-4 shadow-xl transition-transform duration-200 ${
-					sidebarOpen ? 'translate-x-0' : 'translate-x-full'
-				} ${preview ? 'lg:hidden' : 'lg:contents'}`}
-			>
-				<TaskSidebar
-					task={task}
-					projectId={projectId}
-					agents={agents}
-					lock={lock}
-					comments={comments}
-					updateTask={updateTask}
-					commentEffort={commentEffort}
-					setCommentEffort={setCommentEffort}
-					scrollToBottom={scrollToBottom}
-				/>
-			</div>
-			{/* Document preview: its own layer. Mobile: a full-screen overlay above
-				    the main content and the meta drawer. Desktop: the in-grid column 2. */}
-			{preview && (
-				<PreviewPanel
-					item={preview}
-					onClose={() => setPreview(null)}
-					task={{ projectId, taskId, identifier: task.identifier, title: task.title }}
-				/>
-			)}
-		</div>
+		</ResizableSplit>
 	);
 }
 

--- a/packages/web/test/panel-width-storage.test.ts
+++ b/packages/web/test/panel-width-storage.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, expect, test } from 'vitest';
+import {
+	clampPanelWidth,
+	MAX_PANEL_WIDTH,
+	MIN_MAIN_WIDTH,
+	MIN_PANEL_WIDTH,
+	readStoredPanelWidth,
+	writeStoredPanelWidth,
+} from '../src/lib/panel-width-storage';
+
+const KEY = 'hezo:test-panel-width';
+
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
+test('read returns null when nothing is stored', () => {
+	expect(readStoredPanelWidth(KEY)).toBeNull();
+});
+
+test('read returns null for non-numeric / malformed values', () => {
+	localStorage.setItem(KEY, 'not-a-number');
+	expect(readStoredPanelWidth(KEY)).toBeNull();
+	localStorage.setItem(KEY, '');
+	expect(readStoredPanelWidth(KEY)).toBeNull();
+});
+
+test('write then read round-trips a valid width', () => {
+	writeStoredPanelWidth(KEY, 480);
+	expect(readStoredPanelWidth(KEY)).toBe(480);
+});
+
+test('read clamps a stored value that is out of the absolute range', () => {
+	localStorage.setItem(KEY, '10'); // below MIN
+	expect(readStoredPanelWidth(KEY)).toBe(MIN_PANEL_WIDTH);
+	localStorage.setItem(KEY, '5000'); // above MAX
+	expect(readStoredPanelWidth(KEY)).toBe(MAX_PANEL_WIDTH);
+});
+
+test('write clamps before persisting', () => {
+	writeStoredPanelWidth(KEY, 5); // below MIN
+	expect(localStorage.getItem(KEY)).toBe(String(MIN_PANEL_WIDTH));
+});
+
+test('clampPanelWidth honours the container-based max (main column keeps MIN_MAIN_WIDTH)', () => {
+	const container = 1000;
+	// A width that would leave the main column below MIN_MAIN_WIDTH is capped.
+	expect(clampPanelWidth(900, container)).toBe(container - MIN_MAIN_WIDTH);
+	// A comfortable width passes through untouched.
+	expect(clampPanelWidth(400, container)).toBe(400);
+	// Never returns below the floor even on a very narrow container.
+	expect(clampPanelWidth(400, 500)).toBe(MIN_PANEL_WIDTH);
+});
+
+test('clampPanelWidth without a container uses only the absolute bounds', () => {
+	expect(clampPanelWidth(9999)).toBe(MAX_PANEL_WIDTH);
+	expect(clampPanelWidth(1)).toBe(MIN_PANEL_WIDTH);
+	expect(clampPanelWidth(600)).toBe(600);
+});

--- a/packages/web/test/resizable-split.test.tsx
+++ b/packages/web/test/resizable-split.test.tsx
@@ -1,0 +1,133 @@
+// Unit tests for ResizableSplit: the divider's a11y contract, the collapsed vs
+// default vs dragged track classes, and that dragging / arrow-keys drive the
+// width state, the `--panel-w` CSS variable, and persistence. happy-dom has no
+// layout, so getBoundingClientRect is stubbed to a fixed width to make the clamp
+// math deterministic; real pixel behavior is covered by
+// test/browser/task-doc-preview-resize.spec.ts.
+import { fireEvent, render } from '@testing-library/react';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { ResizableSplit } from '../src/components/ui/resizable-split';
+
+const KEY = 'hezo:test-resizable-split';
+const DEFAULT_TRACK = 'lg:grid-cols-[1fr_360px] xl:grid-cols-[1fr_520px] 2xl:grid-cols-[1fr_720px]';
+const COLLAPSED_TRACK = 'lg:grid-cols-[1fr_190px]';
+const VAR_TRACK = 'lg:grid-cols-[1fr_var(--panel-w)]';
+
+/** happy-dom returns zero-size boxes; pin a width so clamp math is predictable. */
+function stubLayout(width: number) {
+	vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+		width,
+		height: 0,
+		top: 0,
+		left: 0,
+		right: width,
+		bottom: 0,
+		x: 0,
+		y: 0,
+		toJSON: () => ({}),
+	} as DOMRect);
+}
+
+/** Synthesize a pointer event as a MouseEvent carrying the fields the hook reads. */
+function pointerEvent(type: string, init: { clientX: number; pointerId?: number }): MouseEvent {
+	const e = new MouseEvent(type, {
+		bubbles: true,
+		cancelable: true,
+		clientX: init.clientX,
+		clientY: 0,
+		button: 0,
+	});
+	Object.assign(e, { pointerId: init.pointerId ?? 1, isPrimary: true });
+	return e;
+}
+
+beforeEach(() => localStorage.clear());
+afterEach(() => {
+	vi.restoreAllMocks();
+	localStorage.clear();
+});
+
+test('renders an accessible resize handle and the default track when a panel is present', () => {
+	const { getByTestId, container } = render(
+		<ResizableSplit panel={<div>panel</div>} defaultTrackClass={DEFAULT_TRACK} storageKey={KEY}>
+			<div>main</div>
+		</ResizableSplit>,
+	);
+	const handle = getByTestId('resize-handle');
+	expect(handle.getAttribute('role')).toBe('separator');
+	expect(handle.getAttribute('aria-orientation')).toBe('vertical');
+	expect(handle.getAttribute('aria-label')).toBe('Resize panel');
+	expect(handle.tabIndex).toBe(0);
+
+	const grid = container.firstElementChild as HTMLElement;
+	expect(grid.className).toContain(DEFAULT_TRACK);
+	expect(grid.className).not.toContain('var(--panel-w)');
+	expect(grid.style.getPropertyValue('--panel-w')).toBe('');
+});
+
+test('omits the handle and uses the collapsed track when panel is null', () => {
+	const { queryByTestId, container } = render(
+		<ResizableSplit
+			panel={null}
+			defaultTrackClass={DEFAULT_TRACK}
+			collapsedTrackClass={COLLAPSED_TRACK}
+			storageKey={KEY}
+		>
+			<div>main</div>
+		</ResizableSplit>,
+	);
+	expect(queryByTestId('resize-handle')).toBeNull();
+	const grid = container.firstElementChild as HTMLElement;
+	expect(grid.className).toContain(COLLAPSED_TRACK);
+	expect(grid.className).not.toContain('360px');
+});
+
+test('dragging the divider updates the width, sets the CSS var, and persists', () => {
+	stubLayout(800); // cell + container both measure 800 (range → [280, 420])
+	const { getByTestId, container } = render(
+		<ResizableSplit
+			panel={<div>panel</div>}
+			side="right"
+			defaultTrackClass={DEFAULT_TRACK}
+			storageKey={KEY}
+		>
+			<div>main</div>
+		</ResizableSplit>,
+	);
+	const handle = getByTestId('resize-handle');
+	// Drag right by 400px → on the right side that narrows: 800 − 400 = 400 (in range).
+	fireEvent(handle, pointerEvent('pointerdown', { clientX: 500 }));
+	fireEvent(document, pointerEvent('pointermove', { clientX: 900 }));
+	fireEvent(document, pointerEvent('pointerup', { clientX: 900 }));
+
+	const grid = container.firstElementChild as HTMLElement;
+	expect(grid.style.getPropertyValue('--panel-w')).toBe('400px');
+	expect(grid.className).toContain(VAR_TRACK);
+	expect(localStorage.getItem(KEY)).toBe('400');
+});
+
+test('arrow keys resize the focused handle by a step and persist (right side: ← widens)', () => {
+	stubLayout(800); // range → [280, 420]
+	localStorage.setItem(KEY, '350'); // start inside the range
+	const { getByTestId, container } = render(
+		<ResizableSplit
+			panel={<div>panel</div>}
+			side="right"
+			defaultTrackClass={DEFAULT_TRACK}
+			storageKey={KEY}
+		>
+			<div>main</div>
+		</ResizableSplit>,
+	);
+	const grid = container.firstElementChild as HTMLElement;
+	expect(grid.style.getPropertyValue('--panel-w')).toBe('350px');
+
+	const handle = getByTestId('resize-handle');
+	fireEvent.keyDown(handle, { key: 'ArrowLeft' }); // toward main → widen by STEP(24)
+	expect(grid.style.getPropertyValue('--panel-w')).toBe('374px');
+	expect(localStorage.getItem(KEY)).toBe('374');
+
+	fireEvent.keyDown(handle, { key: 'ArrowRight' }); // away from main → narrow by STEP
+	expect(grid.style.getPropertyValue('--panel-w')).toBe('350px');
+	expect(localStorage.getItem(KEY)).toBe('350');
+});

--- a/test/browser/task-doc-preview-resize.spec.ts
+++ b/test/browser/task-doc-preview-resize.spec.ts
@@ -1,0 +1,167 @@
+// Real-CSS-layout + native-pointer-drag assertion (testing decision tree, points
+// 1 & 3): the in-page document preview panel is grid column 2 whose width can be
+// changed by dragging the divider between it and the task content. happy-dom has
+// no layout and can't dispatch a real pointer drag, so the divider's pixel
+// behavior — widen/narrow, clamping, persistence — can only be observed in a real
+// browser. The reusable ResizableSplit wiring itself is unit-covered by
+// packages/web/test/resizable-split.test.tsx; the mention→panel flow by
+// packages/web/test/task-comment-doc-preview.test.tsx.
+
+import type { Locator, Page } from '@playwright/test';
+import { expect, test } from './fixtures';
+import { createProjectAndClearPlanning, uniqueName, waitForPageLoad } from './helpers';
+
+const DOC = 'spec.md';
+const DOC_CONTENT = ['# Spec', '', 'The document body that renders in the preview panel.'].join(
+	'\n',
+);
+const MIN_PANEL_WIDTH = 280;
+const MIN_MAIN_WIDTH = 380;
+const STEP = 24;
+
+async function seedTaskWithDocMention(
+	page: Page,
+	token: string,
+): Promise<{ projectSlug: string; taskId: string }> {
+	const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+
+	const project = await createProjectAndClearPlanning(page, '', token, {
+		name: uniqueName('Doc Preview Resize'),
+		description: 'Preview panel resize test.',
+	});
+
+	const agentsRes = await page.request.get(`/api/projects/${project.slug}/agents`, { headers });
+	const agents = ((await agentsRes.json()) as { data: Array<{ id: string; slug: string }> }).data;
+	const assigneeId = (agents.find((a) => a.slug === 'captain') ?? agents[0]).id;
+
+	const docRes = await page.request.put(`/api/projects/${project.slug}/docs/${DOC}`, {
+		headers,
+		data: { content: DOC_CONTENT },
+	});
+	expect(docRes.ok()).toBe(true);
+
+	const taskRes = await page.request.post(`/api/projects/${project.slug}/tasks`, {
+		headers,
+		data: { project_id: project.id, title: 'Review the spec', assignee_id: assigneeId },
+	});
+	const task = ((await taskRes.json()) as { data: { id: string; identifier: string } }).data;
+
+	const commentRes = await page.request.post(
+		`/api/projects/${project.slug}/tasks/${task.id}/comments`,
+		{
+			headers,
+			data: { content_type: 'text', content: { text: `Please review ${DOC} before we ship.` } },
+		},
+	);
+	expect(commentRes.ok()).toBe(true);
+
+	return { projectSlug: project.slug, taskId: task.identifier.toLowerCase() };
+}
+
+async function openPreview(page: Page): Promise<Locator> {
+	const mention = page.getByTestId('doc-mention-link').first();
+	await expect(mention).toBeVisible({ timeout: 20000 });
+	await mention.click();
+	const panel = page.getByTestId('preview-panel');
+	await expect(panel).toBeVisible();
+	return panel;
+}
+
+const panelWidth = async (panel: Locator): Promise<number> =>
+	(await panel.boundingBox())?.width ?? 0;
+
+/** Settle after a resize, then read the panel's border-box width. */
+async function widthAfterReflow(
+	panel: Locator,
+	predicate: (w: number) => boolean,
+): Promise<number> {
+	await expect.poll(async () => predicate(await panelWidth(panel)), { timeout: 5000 }).toBe(true);
+	return panelWidth(panel);
+}
+
+/** Press on the divider's center, returning that grab point (page coords). */
+async function grabDivider(page: Page): Promise<{ x: number; y: number }> {
+	const box = await page.getByTestId('resize-handle').boundingBox();
+	if (!box) throw new Error('resize-handle has no bounding box');
+	const x = box.x + box.width / 2;
+	const y = box.y + Math.min(box.height / 2, 80); // stay within the viewport
+	await page.mouse.move(x, y);
+	await page.mouse.down();
+	return { x, y };
+}
+
+/** Drag the divider by `dx` px (negative = left → widens the right-hand panel). */
+async function dragBy(page: Page, dx: number): Promise<void> {
+	const { x, y } = await grabDivider(page);
+	await page.mouse.move(x + dx, y, { steps: 12 });
+	await page.mouse.up();
+}
+
+/** Drag the divider to an absolute page X (used to over-drag against the clamps). */
+async function dragToX(page: Page, targetX: number): Promise<void> {
+	const { y } = await grabDivider(page);
+	await page.mouse.move(targetX, y, { steps: 12 });
+	await page.mouse.up();
+}
+
+test('the divider drags to resize the preview panel, clamps, and persists', async ({
+	sharedPage: page,
+	sharedWorkspace,
+}) => {
+	const { token } = sharedWorkspace;
+	const viewport = { width: 1440, height: 900 };
+	await page.setViewportSize(viewport);
+
+	const { projectSlug, taskId } = await seedTaskWithDocMention(page, token);
+	await page.goto(`/projects/${projectSlug}/tasks/${taskId}`);
+	await waitForPageLoad(page);
+
+	const panel = await openPreview(page);
+	const w0 = await panelWidth(panel);
+	expect(w0).toBeGreaterThan(MIN_PANEL_WIDTH);
+
+	// The grid container width bounds how wide the panel can get (main column keeps
+	// MIN_MAIN_WIDTH). Read it off the panel's grid ancestor.
+	const containerWidth = await panel.evaluate(
+		(el) => el.closest('.grid')?.getBoundingClientRect().width ?? 0,
+	);
+	expect(containerWidth).toBeGreaterThan(0);
+
+	// Drag left → the right-hand panel widens by ~120px.
+	await dragBy(page, -120);
+	const widened = await widthAfterReflow(panel, (w) => w > w0 + 100);
+	expect(widened).toBeLessThanOrEqual(w0 + 140);
+
+	// Drag right → it narrows back down below the original width.
+	await dragBy(page, 220);
+	const narrowed = await widthAfterReflow(panel, (w) => w < widened - 180);
+	expect(narrowed).toBeLessThan(w0);
+
+	// Over-drag to the right viewport edge → clamps at MIN_PANEL_WIDTH.
+	await dragToX(page, viewport.width - 4);
+	const min = await widthAfterReflow(panel, (w) => w <= MIN_PANEL_WIDTH + 6);
+	expect(min).toBeGreaterThanOrEqual(MIN_PANEL_WIDTH - 6);
+
+	// Over-drag to the left viewport edge → clamps so the main column keeps MIN_MAIN_WIDTH.
+	await dragToX(page, 4);
+	const expectedMax = containerWidth - MIN_MAIN_WIDTH;
+	const max = await widthAfterReflow(panel, (w) => w >= expectedMax - 8);
+	expect(max).toBeLessThanOrEqual(expectedMax + 8);
+
+	// Keyboard: back down to MIN for headroom, then step up by STEP with ArrowLeft.
+	await dragToX(page, viewport.width - 4);
+	const beforeKey = await widthAfterReflow(panel, (w) => w <= MIN_PANEL_WIDTH + 6);
+	await page.getByTestId('resize-handle').focus();
+	await page.keyboard.press('ArrowLeft'); // right side: ← widens
+	const afterKey = await widthAfterReflow(panel, (w) => w > beforeKey + 6);
+	expect(Math.abs(afterKey - (beforeKey + STEP))).toBeLessThanOrEqual(6);
+
+	// Persistence: settle on a distinct width, reload, reopen — it restores.
+	await dragBy(page, -160);
+	const settled = await widthAfterReflow(panel, (w) => w > afterKey + 100);
+	await page.reload();
+	await waitForPageLoad(page);
+	const reopened = await openPreview(page);
+	const restored = await widthAfterReflow(reopened, (w) => Math.abs(w - settled) <= 8);
+	expect(Math.abs(restored - settled)).toBeLessThanOrEqual(8);
+});


### PR DESCRIPTION
## What & why

On the task-detail page, clicking a document mention in a comment opens a **preview panel** as the right-hand grid column beside the task content. That column was a **fixed width** (`360 / 520 / 720px` at `lg / xl / 2xl`) with no way to adjust it. This PR lets the user **widen or narrow the preview by dragging the divider between it and the task content**.

Per the request, the resize is implemented as a **reusable layout/component**, not logic hard-wired into the route.

## Approach

- **`ResizableSplit`** (new, `packages/web/src/components/ui/resizable-split.tsx`) — a generic, drop-in two-column grid whose side panel resizes by dragging the divider. Exposes a slots API (`children` / `panel` / `aside`) and is built on an exported **`useResizableSplit`** hook, so the resize behaviour alone is reusable in a bespoke grid. The task-detail route is its first consumer.
- **`panel-width-storage.ts`** (new) — the generic, key-parameterised width persistence (clamp/validate on read), modelled on the existing `task-filter-storage.ts` and using the `safe-storage` helpers.
- Pointer mechanics mirror `use-draggable-fab.ts` (pointer capture with a happy-dom `try/catch`, document `pointermove`/`pointerup` listeners gated by a resizing flag, `ResizeObserver` re-clamp on container shrink).

## Behaviour

- **Desktop-only** (`lg+`): below `lg` the panel stays a full-screen overlay, so there is nothing to resize — mobile-first is preserved.
- Width is **clamped** to a readable range (panel ≥ 280px; the main column keeps a minimum) and **persists** in `localStorage` across reloads.
- **Keyboard-operable**: the divider is a focusable `role="separator"` (WAI-ARIA window-splitter pattern) — Arrow keys step the width.
- Until the user first drags, the responsive default track is unchanged, so existing behaviour is preserved.

## Testing

- `packages/web/test/panel-width-storage.test.ts` — storage clamp / round-trip / container-based max.
- `packages/web/test/resizable-split.test.tsx` — the divider's a11y contract, collapsed vs default vs dragged track classes, and drag/keyboard wiring drives width + `--panel-w` + persistence.
- `test/browser/task-doc-preview-resize.spec.ts` — a real Chromium pointer drag verifies widen/narrow, both clamps, the keyboard step, and persistence across reload.
- Existing `test/browser/task-doc-preview-width.spec.ts` (responsive default widths) and the task-detail component tests still pass — the refactor is backward-compatible.
- `typecheck` and Biome `check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QpkVhANP67qbVHbV1YAxJu)_