### PR TITLE
feat: scope OAuth accounts and MCP connectors per project

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -162,12 +162,18 @@ MCP tool) is the markdown blurb shown at the top of the Progress page.
 **Secrets, OAuth, MCP connectors.** `secrets` stores AES-256-GCM ciphertext gated by
 `allowed_hosts` (§ 7). `oauth_connections` records connected GitHub/SaaS accounts; their
 tokens *ride the `secrets` table* (no token column). `mcp_connections` is the catalog of
-SaaS/local MCP servers injected into runs (§ 9). All three are **instance-global** — a
-single shared catalog keyed by a globally-unique name (`secrets.name` /
-`mcp_connections.name` / `oauth_connections (provider, provider_account_id)`), with no
-`team_id` column, so every team's runs see the same set. `team_ssh_keys` is the exception
-— one Ed25519 key **per team** (`UNIQUE(team_id)`, and therefore per project given the
-1:1), encrypted on the team row, never in the vault (§ 8).
+SaaS/local MCP servers injected into runs (§ 9). `secrets` is **instance-global**
+(`secrets.name` globally unique). `oauth_connections` and `mcp_connections` are
+**scoped by project** via a nullable `project_id` (FK → `projects`, `ON DELETE CASCADE`):
+a non-NULL value makes the row private to that project (so two projects can connect
+*separate* GitHub/SaaS accounts), while `project_id NULL` is the global "all projects"
+scope (the instance-admin surface and pre-existing rows). Uniqueness is per-scope via
+partial indexes — `(provider, provider_account_id)` / `(name)` where `project_id IS NULL`,
+and `(project_id, …)` where non-NULL. A run resolves the connectors/identity for **its
+task's project**: the project's own rows plus global ones, a project row shadowing a global
+of the same name. `team_ssh_keys` is separate — one Ed25519 key **per team**
+(`UNIQUE(team_id)`, and therefore per project given the 1:1), encrypted on the team row,
+never in the vault (§ 8).
 
 **Runs, wakeups, sessions.** `agent_wakeup_requests` is the trigger queue, with
 idempotency keys and `coalesced_count` merging (§ 5). `heartbeat_runs` is one row per
@@ -880,8 +886,9 @@ cloning outside a run (provision, repo link) allocates a short-lived bridge via
 public key is auto-registered on the connecting user's account as **both** a signing key
 (`POST /user/ssh_signing_keys` — drives `Verified` badges) and an authentication key
 (`POST /user/keys` — so SSH git works). Registration is idempotent (GitHub 422 "already
-in use" → no-op). Commit *authorship* comes from the instance-global GitHub connection;
-*signing* uses the project's own key.
+in use" → no-op). Commit *authorship* comes from the project's own GitHub connection (its
+`project_id`-scoped `oauth_connections` row, or a global one as fallback); *signing* uses
+the project's (team's) own key.
 
 ---
 
@@ -903,14 +910,18 @@ impossible) and a redirect flow would need a per-host registered callback. The s
 is data-driven via `packages/shared/src/types/connector-capabilities.ts`; generic OAuth
 machinery is in `services/oauth/*`, GitHub REST helpers in `services/github.ts`.
 
-**Storage.** `oauth_connections` is instance-global (one row per provider + account,
-usable by every team's runs). Tokens have no column of their own — they ride the `secrets`
-table under name pattern `OAUTH_<PROVIDER>_<8 hex>` (`_REFRESH` suffix for refresh
-tokens), `allowed_hosts` auto-locked to the provider's hosts. So OAuth tokens flow through
-the same egress placeholder path as any secret; agents emit
+**Storage.** `oauth_connections` is **project-scoped** via `project_id` (non-NULL = private
+to that project so two projects hold separate accounts; NULL = the global "all projects"
+scope), keyed per-scope on `(project_id, provider, provider_account_id)`. Tokens have no
+column of their own — they ride the `secrets` table under name pattern
+`OAUTH_<PROVIDER>_<8 hex>` (`_REFRESH` suffix for refresh tokens), `allowed_hosts`
+auto-locked to the provider's hosts. So OAuth tokens flow through the same egress
+placeholder path as any secret; agents emit
 `Authorization: Bearer __HEZO_SECRET_OAUTH_GITHUB_AB12CD34__`. `refreshExpiringTokens`
 (called by the egress substitution path on every outbound request) refreshes tokens within
-60 s of expiry, coalescing concurrent refreshes per connection.
+60 s of expiry, coalescing concurrent refreshes per connection. Deleting a project (or its
+team) purges the project's connections and their token secrets before the cascade, so no
+encrypted token orphans in the vault.
 
 **Agent connector flow.** An agent calls `register_connector` with an MCP URL (DCR is
 attempted) or a `provider_id` for a device-flow provider. The tool creates a pending
@@ -919,9 +930,13 @@ human completes the OAuth dance from the task chat or the Connectors page, and a
 `credential_provided` wakeup resumes the agent (scoped to the requesting task's own team,
 resolved from the task row — the connect can be completed from any surface).
 
-**Admin connector flow.** The superuser adds connectors manually on the global Settings →
-Connectors page (`POST /api/mcp-connections`, upsert-by-name; re-adding a name replaces
-`config` and clears `auth_error`). The page then auto-probes the new connector via
+**Admin connector flow.** The global Settings → Connectors page lists **every project's**
+connectors plus global ones (each row carries its `project_id` + project name), with a
+**scope-filter dropdown** — `(All projects)` / a specific project — that filters the view
+and sets the create scope. The superuser adds a connector in the selected scope
+(`POST /api/mcp-connections` with an optional `project_id`; upsert-by-`(project_id, name)`;
+re-adding a name in the same scope replaces `config` and clears `auth_error`). The page then
+auto-probes the new connector via
 `POST /api/mcp-connections/:id/auth-start` (superuser-gated) — the same PRM → DCR walk as
 the project-scoped auth-start, with two differences: there is no team context (the state
 envelope carries `teamId: null`, and the callback skips the team-room broadcasts and
@@ -933,11 +948,13 @@ other use case, public / header-authenticated MCPs (`__HEZO_SECRET_*__` placehol
 When OAuth *is* advertised, the UI opens the authorize popup automatically on add, and
 every non-active SaaS row keeps a **Connect**/Retry button.
 
-**Run exclusion.** `loadMcpConnectionsForRun` skips revoked rows, plus SaaS rows that are
-known to want OAuth but haven't completed it — no `oauth_connection_id` and any of:
-agent-requested (`created_by_task_id`), discovery persisted `config.dcr`, or an attempt
-recorded `auth_error`. Injecting those would just 401 on every run. Operator rows that
-never attempted OAuth carry none of the markers and are always included.
+**Run exclusion.** `loadMcpConnectionsForRun(db, projectId)` returns the run's project's own
+connectors plus global ones (a project connector shadows a global of the same name). It
+skips revoked rows, plus SaaS rows that are known to want OAuth but haven't completed it —
+no `oauth_connection_id` and any of: agent-requested (`created_by_task_id`), discovery
+persisted `config.dcr`, or an attempt recorded `auth_error`. Injecting those would just 401
+on every run. Operator rows that never attempted OAuth carry none of the markers and are
+always included.
 
 **MCP connections** (`mcp_connections`, see § 3 scoping). `kind='saas'` carries
 `{ url, headers }` (header values may contain `__HEZO_SECRET_*__`; OAuth-backed rows set

--- a/docs/mcp/connecting-mcp-servers.md
+++ b/docs/mcp/connecting-mcp-servers.md
@@ -50,9 +50,19 @@ choice.
 
 ## Where a connection applies
 
-MCP connections are **global**: there's a single shared catalog and each
-connection name is unique across the instance. Once you add a server it's available to
-every team's agent runs.
+MCP connections are **scoped by project**. A connection you add to a project is private to
+that project's agent runs, so two projects can each connect a *different* account for the
+same provider (for example, a separate GitHub account per project) without one bleeding
+into the other. Each project's runs see its own connections plus any connection scoped to
+**All projects** — the global scope for servers you want shared everywhere. When a project
+and the global scope both define a connection of the same name, the project's own wins.
+
+Manage connections two ways:
+
+- **Project → Settings → Connectors** shows just that project's connectors.
+- The global **Settings → Connectors** page (admin) lists connectors across every project,
+  with a scope filter — **All projects** or a specific project — to narrow the view and
+  choose where a newly added connector lives.
 
 ## Adding a connection
 

--- a/docs/reference/mcp-api.md
+++ b/docs/reference/mcp-api.md
@@ -882,7 +882,7 @@ Fetch a remote agent skill file (Markdown describing how to use a third-party MC
 
 _Read-only._
 
-List the MCP server connections available to agent runs (instance-global — the same catalog for every team). Each row includes a derived `oauth_status` so you can tell whether a connector is usable: "active" means OAuth completed and the MCP tools should appear in your tool list on your next run; "pending" means waiting on the human to click Connect; "failed" means the OAuth flow errored (see auth_error); "revoked" means a human disconnected it; "none" means no OAuth needed (e.g., an env-var-token MCP or a public one). Do NOT confuse `install_status` (which tracks local-package install state and is meaningless for SaaS MCPs) with `oauth_status`. An active OAuth-backed connector also carries `rest_auth` = `{ placeholder, allowed_hosts, scopes }`: put `placeholder` (e.g. in an `Authorization: Bearer <placeholder>` header) on a raw HTTP request to authenticate the provider's REST API directly when no MCP tool covers what you need — the egress proxy substitutes the real token, but ONLY for requests to `allowed_hosts`; you never see the value. Use this instead of requesting a PAT (e.g. for GitHub repo-settings edits that the `github` MCP does not expose).
+List the MCP server connections available to agent runs in your project (its own connectors plus global "all projects" ones; a project connector shadows a global one of the same name). Each row includes a derived `oauth_status` so you can tell whether a connector is usable: "active" means OAuth completed and the MCP tools should appear in your tool list on your next run; "pending" means waiting on the human to click Connect; "failed" means the OAuth flow errored (see auth_error); "revoked" means a human disconnected it; "none" means no OAuth needed (e.g., an env-var-token MCP or a public one). Do NOT confuse `install_status` (which tracks local-package install state and is meaningless for SaaS MCPs) with `oauth_status`. An active OAuth-backed connector also carries `rest_auth` = `{ placeholder, allowed_hosts, scopes }`: put `placeholder` (e.g. in an `Authorization: Bearer <placeholder>` header) on a raw HTTP request to authenticate the provider's REST API directly when no MCP tool covers what you need — the egress proxy substitutes the real token, but ONLY for requests to `allowed_hosts`; you never see the value. Use this instead of requesting a PAT (e.g. for GitHub repo-settings edits that the `github` MCP does not expose).
 
 **Parameters:**
 
@@ -890,7 +890,7 @@ List the MCP server connections available to agent runs (instance-global — the
 | --- | --- | --- | --- |
 | `project` | `string` | No | Project slug or ID. Omit to use the project your run is already in; instance agents (CEO/Coach) must name the project to act in. |
 
-**Returns:** An array of connector rows with a derived `oauth_status` (`active` | `pending` | `failed` | `revoked` | `none`) and, for an active OAuth-backed connector, `rest_auth` = `{ placeholder, allowed_hosts, scopes }` (else `null`). Other fields include `id`, `name`, `display_name`, `kind`, `config`, `install_status`, `install_error`, `skill_id`, `created_by_task_id`, `activated_at`, `revoked_at`, `auth_error`. Instance-global.
+**Returns:** An array of connector rows with a derived `oauth_status` (`active` | `pending` | `failed` | `revoked` | `none`) and, for an active OAuth-backed connector, `rest_auth` = `{ placeholder, allowed_hosts, scopes }` (else `null`). Other fields include `id`, `name`, `display_name`, `kind`, `config`, `project_id`, `oauth_account_label`, `install_status`, `install_error`, `skill_id`, `created_by_task_id`, `activated_at`, `revoked_at`, `auth_error`. Scoped to your project: its own connectors plus global ("all projects") ones, with a project connector shadowing a global one of the same name.
 
 ### `test_connector`
 
@@ -911,7 +911,7 @@ Test an MCP connector end-to-end from the server side. Resolves the stored OAuth
 
 _Write tool._
 
-Register an MCP server (SaaS HTTP or local stdio). Connections are instance-global — available to every team's agent runs. SaaS servers go into the agent's descriptor list immediately. Header values may include __HEZO_SECRET_<NAME>__ placeholders that the egress proxy substitutes at request time. Local servers must be installed before they take effect.
+Register an MCP server (SaaS HTTP or local stdio) for your project. The connection is scoped to your project — available to this project's agent runs, alongside any global "all projects" connectors. SaaS servers go into the agent's descriptor list immediately. Header values may include __HEZO_SECRET_<NAME>__ placeholders that the egress proxy substitutes at request time. Local servers must be installed before they take effect.
 
 **Parameters:**
 
@@ -922,13 +922,13 @@ Register an MCP server (SaaS HTTP or local stdio). Connections are instance-glob
 | `kind` | `saas` \| `local` | Yes | saas = HTTP MCP, local = stdio MCP |
 | `config` | `object` | Yes | For saas: { url, headers? }. For local: { command, args?, env?, package? }. |
 
-**Returns:** `{ id, install_status, note }`, or `{ error }` if `config.url` (saas) / `config.command` (local) is missing. Upserts by `name`; instance-global.
+**Returns:** `{ id, install_status, note }`, or `{ error }` if `config.url` (saas) / `config.command` (local) is missing. Upserts by `name` within your project.
 
 ### `remove_mcp_connection`
 
 _Write tool._
 
-Remove a registered MCP connection (instance-global — removing it affects every team). The next agent run will not see it.
+Remove one of your project's registered MCP connections. Only connectors owned by your project can be removed — global "all projects" connectors and other projects' are managed elsewhere. The next agent run will not see it.
 
 **Parameters:**
 
@@ -937,7 +937,7 @@ Remove a registered MCP connection (instance-global — removing it affects ever
 | `project` | `string` | No | Project slug or ID. Omit to use the project your run is already in; instance agents (CEO/Coach) must name the project to act in. |
 | `id` | `string` | Yes | mcp_connections.id (returned by add_mcp_connection or list_mcp_connections) |
 
-**Returns:** `{ removed: true, id }`, or `{ error }` if the connection is not found. Instance-global.
+**Returns:** `{ removed: true, id }`, or `{ error }` if the connection is not found. Removes only your project's own connector (never a global or another project's).
 
 ## Project docs & assets
 

--- a/packages/server/migrations/018_scope_connections_per_project.sql
+++ b/packages/server/migrations/018_scope_connections_per_project.sql
@@ -1,0 +1,60 @@
+-- OAuth account connections and MCP connectors were instance-global: connect a
+-- GitHub (or SaaS) account once, shared by every project's runs. Real deployments
+-- run multiple projects that each need a *separate* upstream account (e.g. two
+-- projects, two different GitHub logins whose repos and commit identities must not
+-- cross). Scope both catalogs by project: a non-NULL project_id makes the row
+-- private to that project; NULL keeps the historical global ("all projects")
+-- semantics — the instance-admin /settings/connectors surface and every
+-- pre-existing row. (A project owns exactly one team, 1:1, and a run is scoped to
+-- the task's project, so project_id is the natural, more-correct key.)
+
+ALTER TABLE oauth_connections
+    ADD COLUMN project_id UUID REFERENCES projects(id) ON DELETE CASCADE;
+ALTER TABLE mcp_connections
+    ADD COLUMN project_id UUID REFERENCES projects(id) ON DELETE CASCADE;
+
+-- Backfill: a GitHub oauth connection whose linked repos all live in a single
+-- project is unambiguously that project's — claim it so existing single-project
+-- setups keep working without a reconnect. A connection whose repos span more
+-- than one project (the shared-account case being fixed) stays global, as does a
+-- repo-less SaaS connection; those are separated by reconnecting per project.
+UPDATE oauth_connections oc
+SET project_id = t.project_id
+FROM (
+    SELECT r.oauth_connection_id, MIN(r.project_id::text)::uuid AS project_id
+    FROM repos r
+    WHERE r.oauth_connection_id IS NOT NULL
+    GROUP BY r.oauth_connection_id
+    HAVING COUNT(DISTINCT r.project_id) = 1
+) t
+WHERE oc.id = t.oauth_connection_id;
+
+-- A connector follows its linked oauth connection's (now-resolved) project, so a
+-- GitHub connector lands in the same project as its token. Connectors with no
+-- oauth link, or whose oauth stayed global, remain global.
+UPDATE mcp_connections mc
+SET project_id = oc.project_id
+FROM oauth_connections oc
+WHERE mc.oauth_connection_id = oc.id AND oc.project_id IS NOT NULL;
+
+-- Replace the global unique keys with project-partitioned ones. NULL project_id
+-- keeps a single global namespace; non-NULL gets a per-project namespace, so the
+-- same upstream account (or connector name) can exist independently in two
+-- projects. The old global uniques are still in force during the backfill above,
+-- so no duplicate can pre-exist to violate the new partial indexes.
+ALTER TABLE oauth_connections
+    DROP CONSTRAINT IF EXISTS oauth_connections_provider_provider_account_id_key;
+CREATE UNIQUE INDEX idx_oauth_conn_global_account
+    ON oauth_connections (provider, provider_account_id) WHERE project_id IS NULL;
+CREATE UNIQUE INDEX idx_oauth_conn_project_account
+    ON oauth_connections (project_id, provider, provider_account_id) WHERE project_id IS NOT NULL;
+
+ALTER TABLE mcp_connections
+    DROP CONSTRAINT IF EXISTS mcp_connections_name_key;
+CREATE UNIQUE INDEX idx_mcp_conn_global_name
+    ON mcp_connections (name) WHERE project_id IS NULL;
+CREATE UNIQUE INDEX idx_mcp_conn_project_name
+    ON mcp_connections (project_id, name) WHERE project_id IS NOT NULL;
+
+CREATE INDEX idx_oauth_connections_project ON oauth_connections(project_id) WHERE project_id IS NOT NULL;
+CREATE INDEX idx_mcp_connections_project ON mcp_connections(project_id) WHERE project_id IS NOT NULL;

--- a/packages/server/src/mcp/mcp-reference.ts
+++ b/packages/server/src/mcp/mcp-reference.ts
@@ -330,7 +330,7 @@ export const TOOL_DOC_META: Record<string, ToolDocMeta> = {
 	list_mcp_connections: {
 		category: 'MCP connections',
 		returns:
-			'An array of connector rows with a derived `oauth_status` (`active` | `pending` | `failed` | `revoked` | `none`) and, for an active OAuth-backed connector, `rest_auth` = `{ placeholder, allowed_hosts, scopes }` (else `null`). Other fields include `id`, `name`, `display_name`, `kind`, `config`, `install_status`, `install_error`, `skill_id`, `created_by_task_id`, `activated_at`, `revoked_at`, `auth_error`. Instance-global.',
+			'An array of connector rows with a derived `oauth_status` (`active` | `pending` | `failed` | `revoked` | `none`) and, for an active OAuth-backed connector, `rest_auth` = `{ placeholder, allowed_hosts, scopes }` (else `null`). Other fields include `id`, `name`, `display_name`, `kind`, `config`, `project_id`, `oauth_account_label`, `install_status`, `install_error`, `skill_id`, `created_by_task_id`, `activated_at`, `revoked_at`, `auth_error`. Scoped to your project: its own connectors plus global ("all projects") ones, with a project connector shadowing a global one of the same name.',
 	},
 	test_connector: {
 		category: 'MCP connections',
@@ -340,12 +340,12 @@ export const TOOL_DOC_META: Record<string, ToolDocMeta> = {
 	add_mcp_connection: {
 		category: 'MCP connections',
 		returns:
-			'`{ id, install_status, note }`, or `{ error }` if `config.url` (saas) / `config.command` (local) is missing. Upserts by `name`; instance-global.',
+			'`{ id, install_status, note }`, or `{ error }` if `config.url` (saas) / `config.command` (local) is missing. Upserts by `name` within your project.',
 	},
 	remove_mcp_connection: {
 		category: 'MCP connections',
 		returns:
-			'`{ removed: true, id }`, or `{ error }` if the connection is not found. Instance-global.',
+			"`{ removed: true, id }`, or `{ error }` if the connection is not found. Removes only your project's own connector (never a global or another project's).",
 	},
 
 	// Project docs & assets

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -2590,7 +2590,7 @@ export function registerTools(
 			const skillId = (args.skill_id as string | undefined) ?? null;
 
 			// Slug from providerId if available, else from display_name. Connectors
-			// are global, so `name` (UNIQUE) is the idempotency key.
+			// are scoped by project, so `(project_id, name)` is the idempotency key.
 			const slugSource = providerId ?? displayName;
 			const name = slugSource
 				.toLowerCase()
@@ -2612,6 +2612,7 @@ export function registerTools(
 				skillId,
 				createdByTaskId: taskId,
 				providerId,
+				projectId: scope.projectId,
 			});
 
 			if (!alreadyExisted) {
@@ -4363,7 +4364,7 @@ export function registerTools(
 	tool(
 		server,
 		'list_mcp_connections',
-		'List the MCP server connections available to agent runs (instance-global — the same catalog for every team). Each row includes a derived `oauth_status` so you can tell whether a connector is usable: "active" means OAuth completed and the MCP tools should appear in your tool list on your next run; "pending" means waiting on the human to click Connect; "failed" means the OAuth flow errored (see auth_error); "revoked" means a human disconnected it; "none" means no OAuth needed (e.g., an env-var-token MCP or a public one). Do NOT confuse `install_status` (which tracks local-package install state and is meaningless for SaaS MCPs) with `oauth_status`. An active OAuth-backed connector also carries `rest_auth` = `{ placeholder, allowed_hosts, scopes }`: put `placeholder` (e.g. in an `Authorization: Bearer <placeholder>` header) on a raw HTTP request to authenticate the provider\'s REST API directly when no MCP tool covers what you need — the egress proxy substitutes the real token, but ONLY for requests to `allowed_hosts`; you never see the value. Use this instead of requesting a PAT (e.g. for GitHub repo-settings edits that the `github` MCP does not expose).',
+		'List the MCP server connections available to agent runs in your project (its own connectors plus global "all projects" ones; a project connector shadows a global one of the same name). Each row includes a derived `oauth_status` so you can tell whether a connector is usable: "active" means OAuth completed and the MCP tools should appear in your tool list on your next run; "pending" means waiting on the human to click Connect; "failed" means the OAuth flow errored (see auth_error); "revoked" means a human disconnected it; "none" means no OAuth needed (e.g., an env-var-token MCP or a public one). Do NOT confuse `install_status` (which tracks local-package install state and is meaningless for SaaS MCPs) with `oauth_status`. An active OAuth-backed connector also carries `rest_auth` = `{ placeholder, allowed_hosts, scopes }`: put `placeholder` (e.g. in an `Authorization: Bearer <placeholder>` header) on a raw HTTP request to authenticate the provider\'s REST API directly when no MCP tool covers what you need — the egress proxy substitutes the real token, but ONLY for requests to `allowed_hosts`; you never see the value. Use this instead of requesting a PAT (e.g. for GitHub repo-settings edits that the `github` MCP does not expose).',
 		{
 			project: projectArg(),
 		},
@@ -4389,17 +4390,21 @@ export function registerTools(
 				oauth_secret_name: string | null;
 				oauth_allowed_hosts: string[] | null;
 				oauth_scopes: string[] | null;
+				oauth_account_label: string | null;
 			}>(
 				`SELECT mc.id, mc.name, mc.display_name, mc.kind::text AS kind,
 				        mc.config, mc.oauth_connection_id, mc.install_status::text AS install_status, mc.install_error,
 				        mc.skill_id, mc.created_by_task_id,
 				        mc.activated_at::text AS activated_at, mc.revoked_at::text AS revoked_at, mc.auth_error,
 				        mc.created_at::text, mc.updated_at::text,
-				        s.name AS oauth_secret_name, s.allowed_hosts AS oauth_allowed_hosts, oc.scopes AS oauth_scopes
+				        s.name AS oauth_secret_name, s.allowed_hosts AS oauth_allowed_hosts, oc.scopes AS oauth_scopes,
+				        oc.provider_account_label AS oauth_account_label
 				 FROM mcp_connections mc
 				 LEFT JOIN oauth_connections oc ON oc.id = mc.oauth_connection_id
 				 LEFT JOIN secrets s ON s.id = oc.access_token_secret_id
-				 ORDER BY mc.name ASC`,
+				 WHERE mc.project_id = $1 OR mc.project_id IS NULL
+				 ORDER BY mc.name ASC, (mc.project_id IS NULL) ASC`,
+				[scope.projectId],
 			);
 			// Derive a single oauth_status field that's the load-bearing signal
 			// for whether the connector is usable by agents on subsequent runs.
@@ -4407,7 +4412,12 @@ export function registerTools(
 				const c = row.config as { dcr?: unknown };
 				return !!c?.dcr;
 			};
-			return r.rows.map((row) => {
+			// A project connector shadows a global one of the same name (the run sees
+			// the same set — see loadMcpConnectionsForRun). Rows are ordered project
+			// first, so keep the first occurrence per name.
+			const byName = new Map<string, (typeof r.rows)[number]>();
+			for (const row of r.rows) if (!byName.has(row.name)) byName.set(row.name, row);
+			return [...byName.values()].map((row) => {
 				let oauth_status: 'active' | 'pending' | 'failed' | 'revoked' | 'none';
 				if (row.kind !== 'saas') oauth_status = 'none';
 				else if (row.revoked_at) oauth_status = 'revoked';
@@ -4458,8 +4468,9 @@ export function registerTools(
 				oauth_connection_id: string | null;
 			}>(
 				`SELECT id, name, kind::text AS kind, config, oauth_connection_id
-				 FROM mcp_connections WHERE id = $1`,
-				[connectorId],
+				 FROM mcp_connections
+				 WHERE id = $1 AND (project_id = $2 OR project_id IS NULL)`,
+				[connectorId, scope.projectId],
 			);
 			if (row.rows.length === 0) return { error: 'connector not found' };
 			const connector = row.rows[0];
@@ -4544,7 +4555,7 @@ export function registerTools(
 	tool(
 		server,
 		'add_mcp_connection',
-		"Register an MCP server (SaaS HTTP or local stdio). Connections are instance-global — available to every team's agent runs. SaaS servers go into the agent's descriptor list immediately. Header values may include __HEZO_SECRET_<NAME>__ placeholders that the egress proxy substitutes at request time. Local servers must be installed before they take effect.",
+		'Register an MCP server (SaaS HTTP or local stdio) for your project. The connection is scoped to your project — available to this project\'s agent runs, alongside any global "all projects" connectors. SaaS servers go into the agent\'s descriptor list immediately. Header values may include __HEZO_SECRET_<NAME>__ placeholders that the egress proxy substitutes at request time. Local servers must be installed before they take effect.',
 		{
 			project: projectArg(),
 			name: z
@@ -4580,16 +4591,16 @@ export function registerTools(
 				id: string;
 				install_status: string;
 			}>(
-				`INSERT INTO mcp_connections (name, kind, config, install_status)
-				 VALUES ($1, $2::mcp_connection_kind, $3::jsonb, $4::mcp_install_status)
-				 ON CONFLICT (name) DO UPDATE
+				`INSERT INTO mcp_connections (name, kind, config, install_status, project_id)
+				 VALUES ($1, $2::mcp_connection_kind, $3::jsonb, $4::mcp_install_status, $5)
+				 ON CONFLICT (project_id, name) WHERE project_id IS NOT NULL DO UPDATE
 				 SET kind = EXCLUDED.kind,
 				     config = EXCLUDED.config,
 				     install_status = EXCLUDED.install_status,
 				     install_error = NULL,
 				     updated_at = now()
 				 RETURNING id, install_status::text AS install_status`,
-				[name, kind, JSON.stringify(config), initialStatus],
+				[name, kind, JSON.stringify(config), initialStatus, scope.projectId],
 			);
 			return {
 				id: r.rows[0].id,
@@ -4606,7 +4617,7 @@ export function registerTools(
 	tool(
 		server,
 		'remove_mcp_connection',
-		'Remove a registered MCP connection (instance-global — removing it affects every team). The next agent run will not see it.',
+		'Remove one of your project\'s registered MCP connections. Only connectors owned by your project can be removed — global "all projects" connectors and other projects\' are managed elsewhere. The next agent run will not see it.',
 		{
 			project: projectArg(),
 			id: z
@@ -4617,8 +4628,8 @@ export function registerTools(
 			const scope = await resolveScope(db, auth, args);
 			if ('error' in scope) return scope;
 			const r = await db.query<{ id: string }>(
-				'DELETE FROM mcp_connections WHERE id = $1 RETURNING id',
-				[args.id as string],
+				'DELETE FROM mcp_connections WHERE id = $1 AND project_id = $2 RETURNING id',
+				[args.id as string, scope.projectId],
 			);
 			if (r.rows.length === 0) return { error: 'MCP connection not found' };
 			return { removed: true, id: r.rows[0].id };

--- a/packages/server/src/routes/mcp-connections.ts
+++ b/packages/server/src/routes/mcp-connections.ts
@@ -12,31 +12,52 @@ import { installLocalMcpById } from '../services/mcp-installer';
 
 const log = logger.child('mcp-connections-route');
 
-// Connectors are instance-global — one catalog shared with every team's runs.
-// The project-scoped routes below keep their paths (so the in-project connectors
-// page works) but read/write the global catalog; the un-prefixed routes are the
-// Admin (superuser) surface for `/settings/connectors`.
+// Connectors are scoped by project_id (NULL = global "all projects" scope). The
+// project-scoped routes below read/write that project's own connectors plus
+// global ones; the un-prefixed routes are the Admin (superuser) surface for
+// `/settings/connectors`, which spans every project.
 const CONNECTOR_COLUMNS = `id, name, display_name, kind::text AS kind,
-        config, oauth_connection_id, install_status::text AS install_status, install_error,
+        config, oauth_connection_id, project_id, install_status::text AS install_status, install_error,
         skill_id, created_by_task_id, activated_at, revoked_at, auth_error,
         created_at, updated_at`;
+
+// Same columns, `mc.`-qualified for queries that JOIN `projects` (whose id/name/
+// slug would otherwise collide with the connector's).
+const CONNECTOR_COLUMNS_MC = `mc.id, mc.name, mc.display_name, mc.kind::text AS kind,
+        mc.config, mc.oauth_connection_id, mc.project_id, mc.install_status::text AS install_status,
+        mc.install_error, mc.skill_id, mc.created_by_task_id, mc.activated_at, mc.revoked_at,
+        mc.auth_error, mc.created_at, mc.updated_at`;
 
 export const mcpConnectionsRoutes = new Hono<Env>();
 
 mcpConnectionsRoutes.get('/projects/:projectId/mcp-connections', async (c) => {
 	const db = c.get('db');
+	const projectId = c.get('projectId') as string;
 	const result = await db.query(
-		`SELECT ${CONNECTOR_COLUMNS} FROM mcp_connections ORDER BY name ASC`,
+		`SELECT ${CONNECTOR_COLUMNS_MC}, oc.provider_account_label AS oauth_account_label
+		 FROM mcp_connections mc
+		 LEFT JOIN oauth_connections oc ON oc.id = mc.oauth_connection_id
+		 WHERE mc.project_id = $1 OR mc.project_id IS NULL
+		 ORDER BY mc.name ASC`,
+		[projectId],
 	);
 	return ok(c, result.rows);
 });
 
+// Admin surface: every connector across all projects, each annotated with its
+// owning project (null = global) so `/settings/connectors` can render + filter
+// by project.
 mcpConnectionsRoutes.get('/mcp-connections', async (c) => {
 	const denied = requireAdminEquivalent(c);
 	if (denied) return denied;
 	const db = c.get('db');
 	const result = await db.query(
-		`SELECT ${CONNECTOR_COLUMNS} FROM mcp_connections ORDER BY name ASC`,
+		`SELECT ${CONNECTOR_COLUMNS_MC}, p.name AS project_name, p.slug AS project_slug,
+		        oc.provider_account_label AS oauth_account_label
+		 FROM mcp_connections mc
+		 LEFT JOIN projects p ON p.id = mc.project_id
+		 LEFT JOIN oauth_connections oc ON oc.id = mc.oauth_connection_id
+		 ORDER BY mc.name ASC`,
 	);
 	return ok(c, result.rows);
 });
@@ -51,6 +72,7 @@ mcpConnectionsRoutes.post('/mcp-connections', async (c) => {
 		display_name?: string;
 		kind: 'saas' | 'local';
 		config: Record<string, unknown>;
+		project_id?: string | null;
 	}>();
 
 	if (!body.name?.trim()) {
@@ -64,14 +86,29 @@ mcpConnectionsRoutes.post('/mcp-connections', async (c) => {
 		return err(c, 'INVALID_REQUEST', 'saas connections require config.url (string)', 400);
 	}
 
-	// Re-adding an existing name is a reconfiguration: config is replaced
-	// wholesale (dropping any stale config.dcr for a changed URL) and a
+	// The admin surface may target a specific project (from the scope dropdown) or
+	// create a global "all projects" connector (project_id null). Validate a named
+	// project exists; the superuser may act on any.
+	const projectId = body.project_id?.trim() || null;
+	if (projectId) {
+		const proj = await db.query<{ id: string }>(`SELECT id FROM projects WHERE id = $1`, [
+			projectId,
+		]);
+		if (proj.rows.length === 0) return err(c, 'NOT_FOUND', 'project_id not found', 404);
+	}
+
+	// Re-adding an existing name in the same scope is a reconfiguration: config is
+	// replaced wholesale (dropping any stale config.dcr for a changed URL) and a
 	// previous OAuth attempt's auth_error is cleared, so the row starts from a
-	// clean slate. An active row keeps oauth_connection_id/activated_at.
+	// clean slate. An active row keeps oauth_connection_id/activated_at. The
+	// conflict target names the partial unique index matching the row's scope.
+	const conflictTarget = projectId
+		? '(project_id, name) WHERE project_id IS NOT NULL'
+		: '(name) WHERE project_id IS NULL';
 	const result = await db.query(
-		`INSERT INTO mcp_connections (name, display_name, kind, config, install_status)
-		 VALUES ($1, $2, $3::mcp_connection_kind, $4::jsonb, 'installed'::mcp_install_status)
-		 ON CONFLICT (name) DO UPDATE
+		`INSERT INTO mcp_connections (name, display_name, kind, config, install_status, project_id)
+		 VALUES ($1, $2, $3::mcp_connection_kind, $4::jsonb, 'installed'::mcp_install_status, $5)
+		 ON CONFLICT ${conflictTarget} DO UPDATE
 		 SET display_name = EXCLUDED.display_name,
 		     kind = EXCLUDED.kind,
 		     config = EXCLUDED.config,
@@ -80,7 +117,13 @@ mcpConnectionsRoutes.post('/mcp-connections', async (c) => {
 		     auth_error = NULL,
 		     updated_at = now()
 		 RETURNING ${CONNECTOR_COLUMNS}`,
-		[body.name.trim(), body.display_name?.trim() ?? null, body.kind, JSON.stringify(body.config)],
+		[
+			body.name.trim(),
+			body.display_name?.trim() ?? null,
+			body.kind,
+			JSON.stringify(body.config),
+			projectId,
+		],
 	);
 
 	const createdRow = result.rows[0] as { id: string; name: string };
@@ -120,23 +163,31 @@ mcpConnectionsRoutes.delete('/mcp-connections/:id', async (c) => {
 
 mcpConnectionsRoutes.get('/projects/:projectId/mcp-connections/:id', async (c) => {
 	const db = c.get('db');
+	const projectId = c.get('projectId') as string;
 	const id = c.req.param('id');
-	const result = await db.query(`SELECT ${CONNECTOR_COLUMNS} FROM mcp_connections WHERE id = $1`, [
-		id,
-	]);
+	const result = await db.query(
+		`SELECT ${CONNECTOR_COLUMNS} FROM mcp_connections
+		 WHERE id = $1 AND (project_id = $2 OR project_id IS NULL)`,
+		[id, projectId],
+	);
 	if (result.rows.length === 0) return err(c, 'NOT_FOUND', 'connector not found', 404);
 	return ok(c, result.rows[0]);
 });
 
 mcpConnectionsRoutes.post('/projects/:projectId/mcp-connections/:id/revoke', async (c) => {
 	const teamId = c.get('teamId') as string;
+	const projectId = c.get('projectId') as string;
 	const db = c.get('db');
 	const id = c.req.param('id');
 	const { markRevoked } = await import('../services/connectors/lifecycle');
 	const existing = await db.query<{
 		name: string;
 		oauth_connection_id: string | null;
-	}>(`SELECT name, oauth_connection_id FROM mcp_connections WHERE id = $1`, [id]);
+	}>(
+		`SELECT name, oauth_connection_id FROM mcp_connections
+		 WHERE id = $1 AND (project_id = $2 OR project_id IS NULL)`,
+		[id, projectId],
+	);
 	if (existing.rows.length === 0) return err(c, 'NOT_FOUND', 'connector not found', 404);
 	const row = await markRevoked(db, id);
 	if (existing.rows[0].oauth_connection_id) {
@@ -180,6 +231,7 @@ mcpConnectionsRoutes.post('/projects/:projectId/mcp-connections/:id/revoke', asy
 
 mcpConnectionsRoutes.post('/projects/:projectId/mcp-connections', async (c) => {
 	const teamId = c.get('teamId') as string;
+	const projectId = c.get('projectId') as string;
 	const db = c.get('db');
 
 	const body = await c.req.json<{
@@ -205,9 +257,12 @@ mcpConnectionsRoutes.post('/projects/:projectId/mcp-connections', async (c) => {
 	}
 
 	if (body.oauth_connection_id) {
+		// Only an oauth connection visible to this project (its own or global) may
+		// be linked — never another project's.
 		const ownership = await db.query<{ id: string }>(
-			`SELECT id FROM oauth_connections WHERE id = $1`,
-			[body.oauth_connection_id],
+			`SELECT id FROM oauth_connections
+			 WHERE id = $1 AND (project_id = $2 OR project_id IS NULL)`,
+			[body.oauth_connection_id, projectId],
 		);
 		if (ownership.rows.length === 0) {
 			return err(c, 'NOT_FOUND', 'oauth_connection_id not found', 404);
@@ -216,9 +271,9 @@ mcpConnectionsRoutes.post('/projects/:projectId/mcp-connections', async (c) => {
 
 	const initialStatus = body.kind === McpConnectionKind.Saas ? 'installed' : 'pending';
 	const result = await db.query(
-		`INSERT INTO mcp_connections (name, kind, config, oauth_connection_id, install_status)
-		 VALUES ($1, $2::mcp_connection_kind, $3::jsonb, $4, $5::mcp_install_status)
-		 ON CONFLICT (name) DO UPDATE
+		`INSERT INTO mcp_connections (name, kind, config, oauth_connection_id, install_status, project_id)
+		 VALUES ($1, $2::mcp_connection_kind, $3::jsonb, $4, $5::mcp_install_status, $6)
+		 ON CONFLICT (project_id, name) WHERE project_id IS NOT NULL DO UPDATE
 		 SET kind = EXCLUDED.kind,
 		     config = EXCLUDED.config,
 		     oauth_connection_id = EXCLUDED.oauth_connection_id,
@@ -232,6 +287,7 @@ mcpConnectionsRoutes.post('/projects/:projectId/mcp-connections', async (c) => {
 			JSON.stringify(body.config),
 			body.oauth_connection_id ?? null,
 			initialStatus,
+			projectId,
 		],
 	);
 
@@ -307,6 +363,7 @@ async function kickoffLocalInstall(
  */
 mcpConnectionsRoutes.post('/projects/:projectId/connectors/ensure', async (c) => {
 	const teamId = c.get('teamId') as string;
+	const projectId = c.get('projectId') as string;
 	const db = c.get('db');
 	const body = (await c.req.json().catch(() => ({}))) as { provider_id?: string };
 	const providerId = body.provider_id?.trim();
@@ -324,6 +381,7 @@ mcpConnectionsRoutes.post('/projects/:projectId/connectors/ensure', async (c) =>
 		mcpTransport: capability.mcpServer.transport,
 		mcpHeaders: capability.mcpServer.headers,
 		providerId: capability.id,
+		projectId,
 	});
 	if (!alreadyExisted) {
 		broadcastChange(c, wsRoom.team(teamId), 'mcp_connections', 'INSERT', { id: row.id });
@@ -342,12 +400,15 @@ mcpConnectionsRoutes.post('/projects/:projectId/connectors/ensure', async (c) =>
 
 mcpConnectionsRoutes.delete('/projects/:projectId/mcp-connections/:id', async (c) => {
 	const teamId = c.get('teamId') as string;
+	const projectId = c.get('projectId') as string;
 	const db = c.get('db');
 	const id = c.req.param('id');
 
+	// A project may only delete its own connectors, never a global or another
+	// project's.
 	const result = await db.query<{ id: string; name: string }>(
-		'DELETE FROM mcp_connections WHERE id = $1 RETURNING id, name',
-		[id],
+		'DELETE FROM mcp_connections WHERE id = $1 AND project_id = $2 RETURNING id, name',
+		[id, projectId],
 	);
 	if (result.rows.length === 0) {
 		return err(c, 'NOT_FOUND', 'MCP connection not found', 404);

--- a/packages/server/src/routes/oauth.ts
+++ b/packages/server/src/routes/oauth.ts
@@ -48,6 +48,14 @@ const log = logger.child('oauth-route');
 
 export const oauthRoutes = new Hono<Env>();
 
+/** A project may see its own connections and global ("all projects") ones. */
+function connectionVisibleToProject(
+	conn: { projectId: string | null },
+	projectId: string,
+): boolean {
+	return conn.projectId === null || conn.projectId === projectId;
+}
+
 /**
  * In-flight GitHub device-flow handshakes, keyed by an opaque flow id handed
  * to the client. The device code never leaves the server. Entries are pruned
@@ -56,6 +64,7 @@ export const oauthRoutes = new Hono<Env>();
 interface DeviceFlowEntry {
 	deviceCode: string;
 	teamId: string;
+	projectId: string;
 	connectorId: string;
 	scopes: string[];
 	expiresAt: number;
@@ -122,6 +131,7 @@ oauthRoutes.get('/oauth/callback', async (c) => {
 				: payload.manualConfig.scopes,
 			expiresAt: token.expiresAt ?? null,
 			allowedHosts,
+			projectId: payload.projectId,
 			metadata: {
 				resource_url: payload.resourceUrl,
 				token_url: payload.manualConfig.token_url,
@@ -231,6 +241,7 @@ oauthRoutes.post('/projects/:projectId/oauth/auth-code/start', async (c) => {
 
 	const { state, codeChallenge } = await signState(masterKeyManager, {
 		teamId: teamId,
+		projectId: c.get('projectId') as string,
 		provider: body.provider,
 		redirectUri,
 		returnTo: body.return_to ?? '/',
@@ -267,6 +278,8 @@ type StartConnectorAuthCodeOutcome =
 interface StartConnectorAuthCodeOpts {
 	/** Team that initiated the connect; null for the instance-admin surface. */
 	teamId: string | null;
+	/** Project that initiated the connect; null for the instance-admin surface. */
+	projectId: string | null;
 	/** Path the callback page navigates to when opened without a popup opener. */
 	returnTo: string;
 	/**
@@ -418,6 +431,7 @@ async function startConnectorAuthCode(
 
 	const { state, codeChallenge } = await signState(masterKeyManager, {
 		teamId: opts.teamId,
+		projectId: opts.projectId,
 		provider: `mcp:${connector.id}`,
 		redirectUri,
 		returnTo: opts.returnTo,
@@ -458,6 +472,7 @@ oauthRoutes.post('/projects/:projectId/auth-start', async (c) => {
 
 	const result = await startConnectorAuthCode(c, body.connector_id, {
 		teamId,
+		projectId: c.get('projectId') as string,
 		returnTo: `/projects/${c.req.param('projectId')}/connectors?focus=${body.connector_id}`,
 	});
 	if (result.kind === 'error') return err(c, result.code, result.message, result.status);
@@ -482,6 +497,7 @@ oauthRoutes.post('/mcp-connections/:id/auth-start', async (c) => {
 
 	const result = await startConnectorAuthCode(c, connectorId, {
 		teamId: null,
+		projectId: null,
 		returnTo: `/settings/connectors?focus=${connectorId}`,
 		missingPrmMeansNoOAuth: true,
 	});
@@ -550,6 +566,7 @@ oauthRoutes.get('/oauth/mcp-callback', async (c) => {
 	try {
 		await finalizeConnectorConnection(c, {
 			teamId: payload.teamId,
+			projectId: payload.projectId,
 			connector,
 			capability: getConnectorCapability(connector.name),
 			provider: payload.provider,
@@ -577,8 +594,9 @@ oauthRoutes.get('/oauth/mcp-callback', async (c) => {
 oauthRoutes.get('/projects/:projectId/oauth-connections', async (c) => {
 	const db = c.get('db');
 	const masterKeyManager = c.get('masterKeyManager');
-	// OAuth connections are instance-global; the in-project page lists them all.
-	const list = await listConnections({ db, masterKeyManager });
+	const projectId = c.get('projectId') as string;
+	// This project's own connections plus global ("all projects") ones.
+	const list = await listConnections({ db, masterKeyManager }, projectId);
 
 	return ok(
 		c,
@@ -590,6 +608,7 @@ oauthRoutes.get('/projects/:projectId/oauth-connections', async (c) => {
 			scopes: conn.scopes,
 			expires_at: conn.expiresAt,
 			metadata: conn.metadata,
+			project_id: conn.projectId,
 			created_at: conn.createdAt,
 			updated_at: conn.updatedAt,
 		})),
@@ -601,8 +620,11 @@ oauthRoutes.get('/projects/:projectId/oauth-connections/:id/scope-status', async
 	const masterKeyManager = c.get('masterKeyManager');
 	const id = c.req.param('id');
 
+	const projectId = c.get('projectId') as string;
 	const conn = await getConnection({ db, masterKeyManager }, id);
-	if (!conn) return err(c, 'NOT_FOUND', 'oauth connection not found', 404);
+	if (!conn || !connectionVisibleToProject(conn, projectId)) {
+		return err(c, 'NOT_FOUND', 'oauth connection not found', 404);
+	}
 	if (conn.provider !== 'github') {
 		return err(c, 'INVALID_REQUEST', 'scope-status is only supported for github connections', 400);
 	}
@@ -612,12 +634,15 @@ oauthRoutes.get('/projects/:projectId/oauth-connections/:id/scope-status', async
 
 oauthRoutes.delete('/projects/:projectId/oauth-connections/:id', async (c) => {
 	const teamId = c.get('teamId') as string;
+	const projectId = c.get('projectId') as string;
 	const db = c.get('db');
 	const masterKeyManager = c.get('masterKeyManager');
 	const id = c.req.param('id');
 
 	const conn = await getConnection({ db, masterKeyManager }, id);
-	if (!conn) return err(c, 'NOT_FOUND', 'oauth connection not found', 404);
+	if (!conn || !connectionVisibleToProject(conn, projectId)) {
+		return err(c, 'NOT_FOUND', 'oauth connection not found', 404);
+	}
 
 	const ok2 = await deleteConnection({ db, masterKeyManager }, id);
 	if (!ok2) return err(c, 'NOT_FOUND', 'oauth connection not found', 404);
@@ -667,6 +692,7 @@ oauthRoutes.post('/projects/:projectId/connectors/:connectorId/device/start', as
 	deviceFlows.set(flowId, {
 		deviceCode: started.deviceCode,
 		teamId,
+		projectId: c.get('projectId') as string,
 		connectorId,
 		scopes,
 		expiresAt: Date.now() + DEVICE_FLOW_TTL_MS,
@@ -728,6 +754,7 @@ oauthRoutes.post('/projects/:projectId/connectors/:connectorId/device/poll', asy
 	try {
 		finalized = await finalizeConnectorConnection(c, {
 			teamId,
+			projectId: entry.projectId,
 			connector,
 			capability,
 			provider: capability.id,
@@ -888,10 +915,13 @@ async function finalizeConnectorConnection(
 	opts: {
 		// teamId is the team that initiated the connect (from the OAuth state /
 		// request context); null when the connect started from the instance-admin
-		// surface. Connectors are global, but the GitHub key registration,
-		// container push, and WS broadcasts are still per-team and are skipped
-		// without one. The wakeup resolves its own team from the requesting task.
+		// surface. The GitHub key registration, container push, and WS broadcasts
+		// are per-team and are skipped without one. The wakeup resolves its own
+		// team from the requesting task.
 		teamId: string | null;
+		// projectId scopes the resulting oauth connection to the initiating project
+		// (matching its connector's scope); null for the instance-admin surface.
+		projectId: string | null;
 		connector: ConnectorRow;
 		capability: ConnectorCapability | undefined;
 		provider: string;
@@ -929,6 +959,7 @@ async function finalizeConnectorConnection(
 			scopes: opts.scopes,
 			expiresAt: opts.expiresAt ?? null,
 			allowedHosts: opts.allowedHosts,
+			projectId: opts.projectId,
 			metadata: { connector_id: connector.id, ...opts.baseMetadata, ...identity.metadata },
 		},
 	);

--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -584,6 +584,12 @@ projectsRoutes.delete('/projects/:projectId', async (c) => {
 			}),
 	);
 
+	// Purge the project's OAuth connections + their vault secrets before the row
+	// delete: the project_id cascade drops the connection rows but would orphan
+	// their encrypted token secrets otherwise.
+	const { deleteProjectConnections } = await import('../services/oauth/connection-store');
+	await deleteProjectConnections({ db, masterKeyManager: c.get('masterKeyManager') }, projectId);
+
 	await db.query('DELETE FROM projects WHERE id = $1', [projectId]);
 	broadcastChange(c, wsRoom.team(teamId), 'projects', 'DELETE', { id: projectId });
 	return c.json({ data: null }, 200);

--- a/packages/server/src/routes/repos.ts
+++ b/packages/server/src/routes/repos.ts
@@ -86,7 +86,9 @@ reposRoutes.post('/projects/:projectId/repos', async (c) => {
 	}
 
 	const conn = await getConnection({ db, masterKeyManager }, body.oauth_connection_id);
-	if (!conn) return err(c, 'NOT_FOUND', 'oauth connection not found', 404);
+	if (!conn || (conn.projectId !== null && conn.projectId !== projectId)) {
+		return err(c, 'NOT_FOUND', 'oauth connection not found', 404);
+	}
 	if (conn.provider !== 'github') {
 		return err(c, 'INVALID_REQUEST', 'oauth connection is not for GitHub', 400);
 	}
@@ -270,11 +272,15 @@ reposRoutes.delete('/projects/:projectId/repos/:repoId', async (c) => {
 });
 
 reposRoutes.get('/projects/:projectId/oauth-connections/:id/orgs', async (c) => {
-	const teamId = c.get('teamId') as string;
 	const db = c.get('db');
+	const projectId = c.get('projectId') as string;
 	const masterKeyManager = c.get('masterKeyManager');
 	const conn = await getConnection({ db, masterKeyManager }, c.req.param('id'));
-	if (!conn || conn.provider !== 'github')
+	if (
+		!conn ||
+		conn.provider !== 'github' ||
+		(conn.projectId !== null && conn.projectId !== projectId)
+	)
 		return err(c, 'NOT_FOUND', 'github connection not found', 404);
 
 	const token = await loadOAuthAccessToken(db, masterKeyManager, conn.id);
@@ -286,14 +292,18 @@ reposRoutes.get('/projects/:projectId/oauth-connections/:id/orgs', async (c) => 
 });
 
 reposRoutes.get('/projects/:projectId/oauth-connections/:id/repos', async (c) => {
-	const teamId = c.get('teamId') as string;
 	const owner = c.req.query('owner');
 	const query = c.req.query('q') ?? undefined;
 	if (!owner) return err(c, 'INVALID_REQUEST', 'owner query parameter is required', 400);
 	const db = c.get('db');
+	const projectId = c.get('projectId') as string;
 	const masterKeyManager = c.get('masterKeyManager');
 	const conn = await getConnection({ db, masterKeyManager }, c.req.param('id'));
-	if (!conn || conn.provider !== 'github')
+	if (
+		!conn ||
+		conn.provider !== 'github' ||
+		(conn.projectId !== null && conn.projectId !== projectId)
+	)
 		return err(c, 'NOT_FOUND', 'github connection not found', 404);
 	const token = await loadOAuthAccessToken(db, masterKeyManager, conn.id);
 	if (!token) return err(c, 'OAUTH_TOKEN_UNAVAILABLE', 'token unavailable', 503);

--- a/packages/server/src/routes/teams.ts
+++ b/packages/server/src/routes/teams.ts
@@ -146,6 +146,18 @@ teamsRoutes.delete('/projects/:projectId/team', async (c) => {
 		return err(c, 'NOT_FOUND', 'Team not found', 404);
 	}
 
+	// Purge the OAuth connections + vault secrets of every project the team backs
+	// before the cascade delete, so their encrypted tokens don't orphan (the
+	// project_id cascade drops the connection rows but not their `secrets`).
+	const { deleteProjectConnections } = await import('../services/oauth/connection-store');
+	const masterKeyManager = c.get('masterKeyManager');
+	const projects = await db.query<{ id: string }>(`SELECT id FROM projects WHERE team_id = $1`, [
+		teamId,
+	]);
+	for (const project of projects.rows) {
+		await deleteProjectConnections({ db, masterKeyManager }, project.id);
+	}
+
 	await db.query('DELETE FROM teams WHERE id = $1', [teamId]);
 	return c.json({ data: null }, 200);
 });

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -407,7 +407,7 @@ export async function buildRuntimeInvocation(
 			url: `http://host.docker.internal:${deps.serverPort}/mcp`,
 			bearerToken: agentJwt,
 		},
-		...(await loadMcpConnectionDescriptors(deps.db, deps.masterKeyManager)),
+		...(await loadMcpConnectionDescriptors(deps.db, deps.masterKeyManager, projectId)),
 	];
 
 	const mcpInjection = adapter.build(mcpDescriptors, {
@@ -460,7 +460,12 @@ export async function buildRuntimeInvocation(
 	// Configure git author/committer identity and SSH commit signing from the
 	// team's connected GitHub account + Ed25519 key, so in-container commits
 	// don't fail for lack of an author and land Verified via the agent socket.
-	env.push(...(await buildGitIdentityEnv(deps.db, deps.masterKeyManager, runTeamId)));
+	env.push(
+		...(await buildGitIdentityEnv(deps.db, deps.masterKeyManager, {
+			projectId,
+			teamId: runTeamId,
+		})),
+	);
 	if (egress) {
 		const proxyUrl = `http://${egress.host}:${egress.port}`;
 		const noProxyHosts = [
@@ -1369,11 +1374,10 @@ async function prepareWorktrees(
 		// The team's git identity (+ signing) is passed so the worktree catch-up merge
 		// can record a (verified) merge commit; the run team owns this, matching the
 		// agent's own in-container commits.
-		const gitIdentityEnv = await buildGitIdentityEnv(
-			deps.db,
-			deps.masterKeyManager,
-			project.team_id,
-		);
+		const gitIdentityEnv = await buildGitIdentityEnv(deps.db, deps.masterKeyManager, {
+			projectId: project.id,
+			teamId: project.team_id,
+		});
 		const executor = ContainerGitExecutor.forPrep(
 			deps.docker,
 			project.container_id,

--- a/packages/server/src/services/connectors/lifecycle.ts
+++ b/packages/server/src/services/connectors/lifecycle.ts
@@ -4,9 +4,9 @@ import { logger } from '../../logger';
 
 const log = logger.child('connector-lifecycle');
 
-// Connectors are instance-global; rows carry no team/project scope.
+// Connectors are scoped by project_id (NULL = global "all projects" scope).
 const CONNECTOR_COLS = `id, name, display_name, kind::text AS kind,
-        config, oauth_connection_id, install_status::text AS install_status,
+        config, oauth_connection_id, project_id, install_status::text AS install_status,
         install_error, skill_id, created_by_task_id,
         activated_at::text AS activated_at, revoked_at::text AS revoked_at, auth_error,
         created_at::text AS created_at, updated_at::text AS updated_at`;
@@ -23,6 +23,8 @@ export interface CreateConnectorInput {
 	skillId?: string | null;
 	createdByTaskId?: string | null;
 	providerId?: string | null;
+	/** Owning project, or null for a global ("all projects") connector. */
+	projectId?: string | null;
 }
 
 export interface ConnectorRow {
@@ -32,6 +34,7 @@ export interface ConnectorRow {
 	kind: string;
 	config: Record<string, unknown>;
 	oauth_connection_id: string | null;
+	project_id: string | null;
 	install_status: string;
 	install_error: string | null;
 	skill_id: string | null;
@@ -55,17 +58,23 @@ export function statusOf(
 }
 
 /**
- * Idempotently create or fetch a connector. Connectors are global, so the
- * idempotency key is `name`. If one already exists, returns it without
- * modification (restoring a previously-revoked row for re-authorization).
+ * Idempotently create or fetch a connector. Connectors are scoped by project, so
+ * the idempotency key is `(project_id, name)`. The lookup is *strictly* scoped —
+ * it must NOT fall back to a global row of the same name, or a project's "connect"
+ * would return another project's (or the shared global) connector and its token,
+ * reintroducing the cross-project bleed. If one already exists in this scope,
+ * returns it without modification (restoring a previously-revoked row for
+ * re-authorization).
  */
 export async function createOrFetchConnector(
 	db: Db,
 	input: CreateConnectorInput,
 ): Promise<{ row: ConnectorRow; alreadyExisted: boolean }> {
+	const projectId = input.projectId ?? null;
 	const existing = await db.query<ConnectorRow>(
-		`SELECT ${CONNECTOR_COLS} FROM mcp_connections WHERE name = $1`,
-		[input.name],
+		`SELECT ${CONNECTOR_COLS} FROM mcp_connections
+		 WHERE name = $1 AND project_id IS NOT DISTINCT FROM $2`,
+		[input.name, projectId],
 	);
 	const existingRow = existing.rows[0];
 	if (existingRow) {
@@ -104,11 +113,11 @@ export async function createOrFetchConnector(
 	const inserted = await db.query<ConnectorRow>(
 		`INSERT INTO mcp_connections (
 		    name, display_name, kind, config,
-		    install_status, skill_id, created_by_task_id
+		    install_status, skill_id, created_by_task_id, project_id
 		 )
 		 VALUES (
 		    $1, $2, $3::mcp_connection_kind, $4::jsonb,
-		    'pending'::mcp_install_status, $5, $6
+		    'pending'::mcp_install_status, $5, $6, $7
 		 )
 		 RETURNING ${CONNECTOR_COLS}`,
 		[
@@ -118,6 +127,7 @@ export async function createOrFetchConnector(
 			JSON.stringify(config),
 			input.skillId ?? null,
 			input.createdByTaskId ?? null,
+			projectId,
 		],
 	);
 	log.info('connector created', {
@@ -181,7 +191,20 @@ export async function getConnector(db: Db, connectorId: string): Promise<Connect
 	return result.rows[0] ?? null;
 }
 
-export async function listConnectors(db: Db): Promise<ConnectorRow[]> {
+/**
+ * List connectors. With `projectId`, returns that project's own connectors plus
+ * global ("all projects") ones; omit for the instance-admin view (all rows).
+ */
+export async function listConnectors(db: Db, projectId?: string | null): Promise<ConnectorRow[]> {
+	if (projectId != null) {
+		const result = await db.query<ConnectorRow>(
+			`SELECT ${CONNECTOR_COLS} FROM mcp_connections
+			 WHERE project_id = $1 OR project_id IS NULL
+			 ORDER BY created_at ASC`,
+			[projectId],
+		);
+		return result.rows;
+	}
 	const result = await db.query<ConnectorRow>(
 		`SELECT ${CONNECTOR_COLS} FROM mcp_connections ORDER BY created_at ASC`,
 	);

--- a/packages/server/src/services/git-identity.ts
+++ b/packages/server/src/services/git-identity.ts
@@ -60,17 +60,20 @@ export function gitConfigEnv(identity: GitIdentity): string[] {
 }
 
 /**
- * Resolve the Git identity: author/committer from the instance-global GitHub
- * connection (most recent wins), and the commit-signing key from the team's own
- * Ed25519 key (the signing identity stays per-team). Falls back to a generic
- * identity so `git commit` never fails for lack of a configured author.
+ * Resolve the Git identity: author/committer from the project's own GitHub
+ * connection (a global "all projects" connection is the fallback; the project's
+ * own always wins), and the commit-signing key from the team's own Ed25519 key
+ * (the signing identity stays per-team). Falls back to a generic identity so
+ * `git commit` never fails for lack of a configured author. `listConnections`
+ * already orders the project's own connections ahead of global ones, so the
+ * first github row is the correct one for this project.
  */
 export async function resolveGitIdentity(
 	db: Db,
 	masterKeyManager: MasterKeyManager,
-	teamId: string,
+	scope: { projectId: string; teamId: string },
 ): Promise<GitIdentity> {
-	const connections = await listConnections({ db, masterKeyManager });
+	const connections = await listConnections({ db, masterKeyManager }, scope.projectId);
 	const github = connections.find((c) => c.provider === 'github');
 	const derived = github
 		? deriveGitHubIdentity(github.metadata, github.providerAccountLabel)
@@ -78,7 +81,7 @@ export async function resolveGitIdentity(
 
 	const keyRow = await db.query<{ public_key: string }>(
 		`SELECT public_key FROM team_ssh_keys WHERE team_id = $1`,
-		[teamId],
+		[scope.teamId],
 	);
 
 	return {
@@ -91,7 +94,7 @@ export async function resolveGitIdentity(
 export async function buildGitIdentityEnv(
 	db: Db,
 	masterKeyManager: MasterKeyManager,
-	teamId: string,
+	scope: { projectId: string; teamId: string },
 ): Promise<string[]> {
-	return gitConfigEnv(await resolveGitIdentity(db, masterKeyManager, teamId));
+	return gitConfigEnv(await resolveGitIdentity(db, masterKeyManager, scope));
 }

--- a/packages/server/src/services/mcp-connections.ts
+++ b/packages/server/src/services/mcp-connections.ts
@@ -45,10 +45,16 @@ export interface McpConnectionRow {
 }
 
 /**
- * Load MCP connections exposed to an agent run. Connectors are instance-global,
- * so every run sees the same set (no team/project scope).
+ * Load MCP connections exposed to an agent run. Scoped to the run's project: its
+ * own connectors plus global ("all projects") ones. When a project and a global
+ * connector share a name, the project's own wins (it shadows the global) — the
+ * `ORDER BY … (project_id IS NULL) DESC` emits globals first so the last-write
+ * Map keeps the project row.
  */
-export async function loadMcpConnectionsForRun(db: Db): Promise<McpConnectionRow[]> {
+export async function loadMcpConnectionsForRun(
+	db: Db,
+	projectId?: string | null,
+): Promise<McpConnectionRow[]> {
 	// Filters: skip revoked (user disconnected); skip saas rows that are known
 	// to want OAuth but haven't completed it (no oauth_connection_id and any of:
 	// agent-requested via the connector flow, discovery already persisted
@@ -56,6 +62,8 @@ export async function loadMcpConnectionsForRun(db: Db): Promise<McpConnectionRow
 	// would just 401 on every run. Operator-created rows that never attempted
 	// OAuth carry none of these markers and continue to be included regardless
 	// (existing behavior for public / header-authenticated MCPs).
+	const scopeClause = projectId != null ? `AND (project_id = $1 OR project_id IS NULL)` : '';
+	const params = projectId != null ? [projectId] : [];
 	const result = await db.query<McpConnectionRow>(
 		`SELECT id, name, kind::text AS kind,
 		        config, oauth_connection_id, install_status::text AS install_status, install_error,
@@ -66,7 +74,9 @@ export async function loadMcpConnectionsForRun(db: Db): Promise<McpConnectionRow
 		            AND (created_by_task_id IS NOT NULL
 		                 OR config ? 'dcr'
 		                 OR auth_error IS NOT NULL))
-		 ORDER BY name ASC`,
+		   ${scopeClause}
+		 ORDER BY name ASC, (project_id IS NULL) DESC`,
+		params,
 	);
 
 	const out = new Map<string, McpConnectionRow>();
@@ -135,8 +145,9 @@ async function loadAllOAuthSecrets(
 export async function loadMcpConnectionDescriptors(
 	db: Db,
 	masterKeyManager: MasterKeyManager,
+	projectId?: string | null,
 ): Promise<McpDescriptor[]> {
-	const rows = await loadMcpConnectionsForRun(db);
+	const rows = await loadMcpConnectionsForRun(db, projectId);
 	const oauthSecrets = await loadAllOAuthSecrets(db, masterKeyManager);
 	const descriptors: McpDescriptor[] = [];
 	for (const row of rows) {

--- a/packages/server/src/services/mcp-installer.ts
+++ b/packages/server/src/services/mcp-installer.ts
@@ -72,15 +72,16 @@ export async function installLocalMcpById(
 }
 
 async function loadPending(deps: InstallerDeps): Promise<PendingRow[]> {
-	// Connectors are global; the installer provisions every pending local MCP
-	// into this run's container (deps.teamId/projectId pick the container, not
-	// the connector rows).
+	// Provision the pending local MCPs this project's runs can see: its own plus
+	// global ("all projects") rows. deps.projectId scopes both the connector rows
+	// and (via deps.containerId) the target container.
 	const result = await deps.db.query<PendingRow>(
 		`SELECT id, name, config
 		 FROM mcp_connections
 		 WHERE kind = $1::mcp_connection_kind
-		   AND install_status <> $2::mcp_install_status`,
-		[McpConnectionKind.Local, McpInstallStatus.Installed],
+		   AND install_status <> $2::mcp_install_status
+		   AND (project_id = $3 OR project_id IS NULL)`,
+		[McpConnectionKind.Local, McpInstallStatus.Installed, deps.projectId],
 	);
 	return result.rows;
 }

--- a/packages/server/src/services/oauth/connection-store.ts
+++ b/packages/server/src/services/oauth/connection-store.ts
@@ -18,6 +18,8 @@ export interface OAuthConnectionRow {
 	scopes: string[];
 	expiresAt: Date | null;
 	metadata: Record<string, unknown>;
+	/** Owning project, or null for a global ("all projects") connection. */
+	projectId: string | null;
 	createdAt: Date;
 	updatedAt: Date;
 }
@@ -38,6 +40,12 @@ export interface CreateConnectionInput {
 	metadata?: Record<string, unknown>;
 	/** Hosts the access token is allowed to be substituted on. Required. */
 	allowedHosts: string[];
+	/**
+	 * Owning project. A non-null value scopes the connection to that project so
+	 * two projects can connect separate upstream accounts; null keeps the
+	 * historical global ("all projects") scope (the instance-admin surface).
+	 */
+	projectId?: string | null;
 }
 
 export interface UpdateTokensInput {
@@ -96,12 +104,20 @@ export async function createConnection(
 			refreshSecretId = refreshSecret.rows[0].id;
 		}
 
+		// Reconnecting the same account within the same scope updates the existing
+		// row. Two partial unique indexes back the scoping (one for project_id
+		// NULL, one for non-NULL), so the conflict target must name the matching
+		// index for the row being written — a single ON CONFLICT can't infer both.
+		const projectId = input.projectId ?? null;
+		const conflictTarget = projectId
+			? '(project_id, provider, provider_account_id) WHERE project_id IS NOT NULL'
+			: '(provider, provider_account_id) WHERE project_id IS NULL';
 		const conn = await deps.db.query<RawConnRow>(
 			`INSERT INTO oauth_connections
 				(id, provider, provider_account_id, provider_account_label,
-				 access_token_secret_id, refresh_token_secret_id, scopes, expires_at, metadata)
-			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-			 ON CONFLICT (provider, provider_account_id)
+				 access_token_secret_id, refresh_token_secret_id, scopes, expires_at, metadata, project_id)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+			 ON CONFLICT ${conflictTarget}
 			 DO UPDATE SET
 				provider_account_label = EXCLUDED.provider_account_label,
 				access_token_secret_id = EXCLUDED.access_token_secret_id,
@@ -120,6 +136,7 @@ export async function createConnection(
 				input.scopes,
 				input.expiresAt ?? null,
 				JSON.stringify(input.metadata ?? {}),
+				projectId,
 			],
 		);
 
@@ -149,14 +166,32 @@ export async function getConnection(
 	return mapRow(result.rows[0], result.rows[0].access_token_secret_name);
 }
 
-// OAuth connections are instance-global. Listing/lookup are team-agnostic.
-export async function listConnections(deps: ConnectionStoreDeps): Promise<OAuthConnectionRow[]> {
-	const result = await deps.db.query<RawConnRow>(
-		`SELECT oc.*, s.name AS access_token_secret_name
-		 FROM oauth_connections oc
-		 JOIN secrets s ON s.id = oc.access_token_secret_id
-		 ORDER BY oc.created_at DESC`,
-	);
+/**
+ * List OAuth connections. When `projectId` is given, returns that project's own
+ * connections plus global ("all projects") ones, with the project's own first so
+ * a caller taking "the first github" resolves the project-scoped account over a
+ * global fallback. Omit `projectId` for the instance-admin view (all rows).
+ */
+export async function listConnections(
+	deps: ConnectionStoreDeps,
+	projectId?: string | null,
+): Promise<OAuthConnectionRow[]> {
+	const result =
+		projectId != null
+			? await deps.db.query<RawConnRow>(
+					`SELECT oc.*, s.name AS access_token_secret_name
+					 FROM oauth_connections oc
+					 JOIN secrets s ON s.id = oc.access_token_secret_id
+					 WHERE oc.project_id = $1 OR oc.project_id IS NULL
+					 ORDER BY (oc.project_id IS NULL) ASC, oc.created_at DESC`,
+					[projectId],
+				)
+			: await deps.db.query<RawConnRow>(
+					`SELECT oc.*, s.name AS access_token_secret_name
+					 FROM oauth_connections oc
+					 JOIN secrets s ON s.id = oc.access_token_secret_id
+					 ORDER BY oc.created_at DESC`,
+				);
 	return result.rows.map((r) => mapRow(r, r.access_token_secret_name));
 }
 
@@ -164,13 +199,15 @@ export async function findConnectionByAccount(
 	deps: ConnectionStoreDeps,
 	provider: string,
 	providerAccountId: string,
+	projectId?: string | null,
 ): Promise<OAuthConnectionRow | null> {
 	const result = await deps.db.query<RawConnRow>(
 		`SELECT oc.*, s.name AS access_token_secret_name
 		 FROM oauth_connections oc
 		 JOIN secrets s ON s.id = oc.access_token_secret_id
-		 WHERE oc.provider = $1 AND oc.provider_account_id = $2`,
-		[provider, providerAccountId],
+		 WHERE oc.provider = $1 AND oc.provider_account_id = $2
+		   AND oc.project_id IS NOT DISTINCT FROM $3`,
+		[provider, providerAccountId, projectId ?? null],
 	);
 	if (result.rows.length === 0) return null;
 	return mapRow(result.rows[0], result.rows[0].access_token_secret_name);
@@ -212,6 +249,27 @@ export async function deleteConnection(
 
 	if (deleted) log.info('oauth connection deleted', { id: connectionId });
 	return deleted;
+}
+
+/**
+ * Delete every OAuth connection owned by a project, along with its encrypted
+ * token secrets. Must run BEFORE the project (or its team) is deleted: the
+ * `project_id` FK cascade would drop the `oauth_connections` / `mcp_connections`
+ * rows but leave their `secrets` orphaned in the global vault (still
+ * egress-substitutable within their allowed_hosts). Returns the count purged.
+ */
+export async function deleteProjectConnections(
+	deps: ConnectionStoreDeps,
+	projectId: string,
+): Promise<number> {
+	const rows = await deps.db.query<{ id: string }>(
+		`SELECT id FROM oauth_connections WHERE project_id = $1`,
+		[projectId],
+	);
+	for (const row of rows.rows) {
+		await deleteConnection(deps, row.id);
+	}
+	return rows.rows.length;
 }
 
 export async function updateTokens(
@@ -268,6 +326,7 @@ interface RawConnRow {
 	scopes: string[];
 	expires_at: Date | null;
 	metadata: Record<string, unknown>;
+	project_id: string | null;
 	created_at: Date;
 	updated_at: Date;
 }
@@ -284,6 +343,7 @@ function mapRow(row: RawConnRow, accessName: string): OAuthConnectionRow {
 		scopes: row.scopes ?? [],
 		expiresAt: row.expires_at,
 		metadata: row.metadata ?? {},
+		projectId: row.project_id ?? null,
 		createdAt: row.created_at,
 		updatedAt: row.updated_at,
 	};

--- a/packages/server/src/services/oauth/state.ts
+++ b/packages/server/src/services/oauth/state.ts
@@ -16,6 +16,11 @@ export interface ManualOAuthConfig {
 export interface StatePayload {
 	/** Team that initiated the flow; null for instance-admin-initiated connects. */
 	teamId: string | null;
+	/**
+	 * Project that initiated the flow, so the resulting connection is scoped to it;
+	 * null for instance-admin-initiated (global) connects.
+	 */
+	projectId: string | null;
 	provider: string;
 	nonce: string;
 	codeVerifier: string;
@@ -30,6 +35,7 @@ export interface StatePayload {
 
 export interface NewStateInput {
 	teamId: string | null;
+	projectId: string | null;
 	provider: string;
 	redirectUri: string;
 	returnTo: string;
@@ -51,6 +57,7 @@ export async function signState(
 
 	const payload: StatePayload = {
 		teamId: input.teamId,
+		projectId: input.projectId,
 		provider: input.provider,
 		nonce: randomBytes(16).toString('hex'),
 		codeVerifier,

--- a/packages/server/test/connectors.test.ts
+++ b/packages/server/test/connectors.test.ts
@@ -602,6 +602,46 @@ describe('loadMcpConnectionsForRun excludes pending/revoked', () => {
 		expect(rows.find((r) => r.name === 'dcr-pending')).toBeUndefined();
 		expect(rows.find((r) => r.name === 'oauth-failed')).toBeUndefined();
 	});
+
+	it('scopes to the run project (own + global) and a project connector shadows a global one', async () => {
+		const { loadMcpConnectionsForRun } = await import('../src/services/mcp-connections');
+		// A second project (its own team — one project per team) whose connector
+		// must never appear for our project.
+		const otherTeam = await db.query<{ id: string }>(
+			`INSERT INTO teams (name, slug) VALUES ('Other Run Team', 'other-run-team') RETURNING id`,
+		);
+		const otherProject = await db.query<{ id: string }>(
+			`INSERT INTO projects (team_id, name, slug, task_prefix) VALUES ($1, 'Other', 'other-run', 'OTHR') RETURNING id`,
+			[otherTeam.rows[0].id],
+		);
+		await db.query(
+			`INSERT INTO mcp_connections (name, kind, config, install_status, project_id)
+			 VALUES ('other-only', 'saas', '{"url":"https://other/mcp"}'::jsonb, 'installed', $1)`,
+			[otherProject.rows[0].id],
+		);
+		// A global 'shared' and this project's own 'shared' — the project one wins.
+		await db.query(
+			`INSERT INTO mcp_connections (name, kind, config, install_status, project_id)
+			 VALUES ('shared', 'saas', '{"url":"https://global/mcp"}'::jsonb, 'installed', NULL)`,
+		);
+		await db.query(
+			`INSERT INTO mcp_connections (name, kind, config, install_status, project_id)
+			 VALUES ('shared', 'saas', '{"url":"https://project/mcp"}'::jsonb, 'installed', $1)`,
+			[projectId],
+		);
+		// A plain global connector remains visible to every project.
+		await db.query(
+			`INSERT INTO mcp_connections (name, kind, config, install_status, project_id)
+			 VALUES ('global-visible', 'saas', '{"url":"https://gv/mcp"}'::jsonb, 'installed', NULL)`,
+		);
+
+		const rows = await loadMcpConnectionsForRun(db, projectId);
+		expect(rows.find((r) => r.name === 'other-only')).toBeUndefined();
+		expect(rows.find((r) => r.name === 'global-visible')).toBeTruthy();
+		const shared = rows.filter((r) => r.name === 'shared');
+		expect(shared).toHaveLength(1);
+		expect((shared[0].config as { url: string }).url).toBe('https://project/mcp');
+	});
 });
 
 // Importing CommentContentType keeps the symbol used so test isolation imports

--- a/packages/server/test/git-identity.test.ts
+++ b/packages/server/test/git-identity.test.ts
@@ -48,6 +48,22 @@ async function makeTeam(slug: string): Promise<string> {
 	return team.rows[0].id;
 }
 
+async function makeTeamAndProject(slug: string): Promise<{ teamId: string; projectId: string }> {
+	const teamId = await makeTeam(slug);
+	const project = await db.query<{ id: string }>(
+		`INSERT INTO projects (team_id, name, slug, task_prefix) VALUES ($1, $2, $2, $3) RETURNING id`,
+		[
+			teamId,
+			slug,
+			slug
+				.toUpperCase()
+				.replace(/[^A-Z0-9]/g, '')
+				.slice(0, 6) || 'PRJ',
+		],
+	);
+	return { teamId, projectId: project.rows[0].id };
+}
+
 describe('deriveGitHubIdentity', () => {
 	it('builds name + privacy-form noreply email from metadata', () => {
 		expect(deriveGitHubIdentity({ login: 'octocat', github_user_id: 12345 }, 'octocat')).toEqual({
@@ -87,8 +103,8 @@ describe('gitConfigEnv', () => {
 });
 
 describe('buildGitIdentityEnv', () => {
-	it('derives identity from the GitHub connection and signs with the team key', async () => {
-		const teamId = await makeTeam('gh-team');
+	it("derives identity from the project's GitHub connection and signs with the team key", async () => {
+		const { teamId, projectId } = await makeTeamAndProject('gh-team');
 		const key = await generateTeamSSHKey(db, teamId, masterKeyManager);
 		await createConnection(
 			{ db, masterKeyManager },
@@ -99,11 +115,14 @@ describe('buildGitIdentityEnv', () => {
 				accessToken: 'gho_x',
 				scopes: ['repo'],
 				allowedHosts: ['github.com'],
+				projectId,
 				metadata: { login: 'octocat', github_user_id: 12345, email: null },
 			},
 		);
 
-		const cfg = parseGitConfig(await buildGitIdentityEnv(db, masterKeyManager, teamId));
+		const cfg = parseGitConfig(
+			await buildGitIdentityEnv(db, masterKeyManager, { projectId, teamId }),
+		);
 		expect(cfg['user.name']).toBe('octocat');
 		expect(cfg['user.email']).toBe('12345+octocat@users.noreply.github.com');
 		expect(cfg['gpg.format']).toBe('ssh');
@@ -112,17 +131,92 @@ describe('buildGitIdentityEnv', () => {
 	});
 
 	it('falls back to a generic identity with no signing when nothing is connected', async () => {
-		const teamId = await makeTeam('bare-team');
-		const cfg = parseGitConfig(await buildGitIdentityEnv(db, masterKeyManager, teamId));
+		const { teamId, projectId } = await makeTeamAndProject('bare-team');
+		const cfg = parseGitConfig(
+			await buildGitIdentityEnv(db, masterKeyManager, { projectId, teamId }),
+		);
 		expect(cfg).toEqual({ 'user.name': 'Hezo Agent', 'user.email': 'agent@hezo.local' });
 	});
 
 	it('signs with the team key even when no GitHub account is connected', async () => {
-		const teamId = await makeTeam('key-only-team');
+		const { teamId, projectId } = await makeTeamAndProject('key-only-team');
 		const key = await generateTeamSSHKey(db, teamId, masterKeyManager);
-		const cfg = parseGitConfig(await buildGitIdentityEnv(db, masterKeyManager, teamId));
+		const cfg = parseGitConfig(
+			await buildGitIdentityEnv(db, masterKeyManager, { projectId, teamId }),
+		);
 		expect(cfg['user.name']).toBe('Hezo Agent');
 		expect(cfg['user.signingkey']).toBe(key.publicKey);
 		expect(cfg['commit.gpgsign']).toBe('true');
+	});
+
+	it('resolves each project to its OWN github account (no cross-project bleed)', async () => {
+		const a = await makeTeamAndProject('proj-a');
+		const b = await makeTeamAndProject('proj-b');
+		await createConnection(
+			{ db, masterKeyManager },
+			{
+				provider: 'github',
+				providerAccountId: '111',
+				providerAccountLabel: 'account-a',
+				accessToken: 'gho_a',
+				scopes: ['repo'],
+				allowedHosts: ['github.com'],
+				projectId: a.projectId,
+				metadata: { login: 'account-a', github_user_id: 111 },
+			},
+		);
+		await createConnection(
+			{ db, masterKeyManager },
+			{
+				provider: 'github',
+				providerAccountId: '222',
+				providerAccountLabel: 'account-b',
+				accessToken: 'gho_b',
+				scopes: ['repo'],
+				allowedHosts: ['github.com'],
+				projectId: b.projectId,
+				metadata: { login: 'account-b', github_user_id: 222 },
+			},
+		);
+
+		const cfgA = parseGitConfig(await buildGitIdentityEnv(db, masterKeyManager, a));
+		const cfgB = parseGitConfig(await buildGitIdentityEnv(db, masterKeyManager, b));
+		expect(cfgA['user.name']).toBe('account-a');
+		expect(cfgB['user.name']).toBe('account-b');
+	});
+
+	it('prefers the project connection over a global one', async () => {
+		const { teamId, projectId } = await makeTeamAndProject('proj-pref');
+		// Global ("all projects") connection, created most-recently…
+		await createConnection(
+			{ db, masterKeyManager },
+			{
+				provider: 'github',
+				providerAccountId: '999',
+				providerAccountLabel: 'global-acct',
+				accessToken: 'gho_g',
+				scopes: ['repo'],
+				allowedHosts: ['github.com'],
+				metadata: { login: 'global-acct', github_user_id: 999 },
+			},
+		);
+		// …plus the project's own — which must win despite being older.
+		await createConnection(
+			{ db, masterKeyManager },
+			{
+				provider: 'github',
+				providerAccountId: '333',
+				providerAccountLabel: 'project-acct',
+				accessToken: 'gho_p',
+				scopes: ['repo'],
+				allowedHosts: ['github.com'],
+				projectId,
+				metadata: { login: 'project-acct', github_user_id: 333 },
+			},
+		);
+		const cfg = parseGitConfig(
+			await buildGitIdentityEnv(db, masterKeyManager, { projectId, teamId }),
+		);
+		expect(cfg['user.name']).toBe('project-acct');
 	});
 });

--- a/packages/server/test/mcp-connections-routes.test.ts
+++ b/packages/server/test/mcp-connections-routes.test.ts
@@ -162,11 +162,14 @@ describe('admin (instance-global) /mcp-connections routes', () => {
 
 describe('project-scoped /projects/:projectId/mcp-connections/:id', () => {
 	async function seedSaasConnector(name: string): Promise<string> {
+		const project = await ctx.db.query<{ id: string }>(`SELECT id FROM projects WHERE slug = $1`, [
+			projectSlug,
+		]);
 		const r = await ctx.db.query<{ id: string }>(
-			`INSERT INTO mcp_connections (name, kind, config, install_status)
-			 VALUES ($1, $2::mcp_connection_kind, '{"url": "https://svc/mcp"}'::jsonb, 'installed')
+			`INSERT INTO mcp_connections (name, kind, config, install_status, project_id)
+			 VALUES ($1, $2::mcp_connection_kind, '{"url": "https://svc/mcp"}'::jsonb, 'installed', $3)
 			 RETURNING id`,
-			[name, McpConnectionKind.Saas],
+			[name, McpConnectionKind.Saas, project.rows[0].id],
 		);
 		return r.rows[0].id;
 	}
@@ -286,5 +289,93 @@ describe('project-scoped POST /mcp-connections branches', () => {
 		});
 		expect(res.status).toBe(400);
 		expect((await res.json()).error.message).toContain('provider_id is required');
+	});
+});
+
+describe('cross-project connector isolation', () => {
+	it("a project's list shows its own + global connectors, never another project's", async () => {
+		// Two separate projects, plus a global ("all projects") connector.
+		const teamA = (await (await createTestTeam(ctx.db, { name: 'Iso A' })).json()).data.id;
+		const teamB = (await (await createTestTeam(ctx.db, { name: 'Iso B' })).json()).data.id;
+		const slugA = await projectSlugFor(ctx.db, teamA);
+		const slugB = await projectSlugFor(ctx.db, teamB);
+		const projA = await ctx.db.query<{ id: string }>('SELECT id FROM projects WHERE slug = $1', [
+			slugA,
+		]);
+		const projB = await ctx.db.query<{ id: string }>('SELECT id FROM projects WHERE slug = $1', [
+			slugB,
+		]);
+
+		await ctx.db.query(
+			`INSERT INTO mcp_connections (name, kind, config, install_status, project_id)
+			 VALUES ('iso-a-only', 'saas', '{"url":"https://a/mcp"}'::jsonb, 'installed', $1)`,
+			[projA.rows[0].id],
+		);
+		await ctx.db.query(
+			`INSERT INTO mcp_connections (name, kind, config, install_status, project_id)
+			 VALUES ('iso-b-only', 'saas', '{"url":"https://b/mcp"}'::jsonb, 'installed', $1)`,
+			[projB.rows[0].id],
+		);
+		await ctx.db.query(
+			`INSERT INTO mcp_connections (name, kind, config, install_status, project_id)
+			 VALUES ('iso-global', 'saas', '{"url":"https://g/mcp"}'::jsonb, 'installed', NULL)`,
+		);
+
+		const listOf = async (slug: string) => {
+			const res = await ctx.app.request(`/api/projects/${slug}/mcp-connections`, {
+				headers: authHeader(token),
+			});
+			expect(res.status).toBe(200);
+			return ((await res.json()).data as Array<{ name: string }>).map((r) => r.name);
+		};
+
+		const aNames = await listOf(slugA);
+		expect(aNames).toContain('iso-a-only');
+		expect(aNames).toContain('iso-global');
+		expect(aNames).not.toContain('iso-b-only');
+
+		const bNames = await listOf(slugB);
+		expect(bNames).toContain('iso-b-only');
+		expect(bNames).toContain('iso-global');
+		expect(bNames).not.toContain('iso-a-only');
+
+		// The admin cross-project list spans everything and annotates each row's
+		// owning project (null for the global one).
+		const adminRes = await ctx.app.request('/api/mcp-connections', { headers: authHeader(token) });
+		const adminRows = (await adminRes.json()).data as Array<{
+			name: string;
+			project_id: string | null;
+			project_name: string | null;
+		}>;
+		const byName = new Map(adminRows.map((r) => [r.name, r]));
+		expect(byName.get('iso-a-only')?.project_id).toBe(projA.rows[0].id);
+		expect(byName.get('iso-b-only')?.project_id).toBe(projB.rows[0].id);
+		expect(byName.get('iso-global')?.project_id).toBeNull();
+		expect(byName.get('iso-a-only')?.project_name).toBeTruthy();
+	});
+
+	it("a project cannot delete another project's connector", async () => {
+		const teamA = (await (await createTestTeam(ctx.db, { name: 'Iso Del A' })).json()).data.id;
+		const teamB = (await (await createTestTeam(ctx.db, { name: 'Iso Del B' })).json()).data.id;
+		const slugA = await projectSlugFor(ctx.db, teamA);
+		const slugB = await projectSlugFor(ctx.db, teamB);
+		const projA = await ctx.db.query<{ id: string }>('SELECT id FROM projects WHERE slug = $1', [
+			slugA,
+		]);
+		const inserted = await ctx.db.query<{ id: string }>(
+			`INSERT INTO mcp_connections (name, kind, config, install_status, project_id)
+			 VALUES ('iso-del', 'saas', '{"url":"https://a/mcp"}'::jsonb, 'installed', $1) RETURNING id`,
+			[projA.rows[0].id],
+		);
+		// Project B tries to delete project A's connector → 404, row still present.
+		const res = await ctx.app.request(
+			`/api/projects/${slugB}/mcp-connections/${inserted.rows[0].id}`,
+			{ method: 'DELETE', headers: authHeader(token) },
+		);
+		expect(res.status).toBe(404);
+		const still = await ctx.db.query('SELECT 1 FROM mcp_connections WHERE id = $1', [
+			inserted.rows[0].id,
+		]);
+		expect(still.rows.length).toBe(1);
 	});
 });

--- a/packages/server/test/mcp-tools-extended.test.ts
+++ b/packages/server/test/mcp-tools-extended.test.ts
@@ -627,9 +627,9 @@ describe('MCP register_connector', () => {
 			[secret.rows[0].id],
 		);
 		await db.query(
-			`INSERT INTO mcp_connections (name, display_name, kind, config, install_status, oauth_connection_id, activated_at)
-			 VALUES ('already-active', 'Already Active', 'saas'::mcp_connection_kind, $1::jsonb, 'installed'::mcp_install_status, $2, now())`,
-			[JSON.stringify({ url: 'https://mcp.active.com/' }), oauth.rows[0].id],
+			`INSERT INTO mcp_connections (name, display_name, kind, config, install_status, oauth_connection_id, activated_at, project_id)
+			 VALUES ('already-active', 'Already Active', 'saas'::mcp_connection_kind, $1::jsonb, 'installed'::mcp_install_status, $2, now(), $3)`,
+			[JSON.stringify({ url: 'https://mcp.active.com/' }), oauth.rows[0].id, projectId],
 		);
 
 		const result = (await callToolAs(await captainToken(), 'register_connector', {

--- a/packages/server/test/migrate-018-scope-connections-per-project.test.ts
+++ b/packages/server/test/migrate-018-scope-connections-per-project.test.ts
@@ -1,0 +1,204 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createDataPreservationHarness, type DataPreservationHarness } from './helpers/migrate';
+
+const TARGET = '018_scope_connections_per_project.sql';
+
+/**
+ * 018 scopes oauth_connections + mcp_connections by project. Seed at 017 (both
+ * tables still instance-global) with a mix that exercises every backfill branch,
+ * then assert the migration preserves the rows AND applies the scoping.
+ */
+describe('018_scope_connections_per_project migration', () => {
+	let h: DataPreservationHarness;
+	let projectAId: string;
+	let projectBId: string;
+	let connAId: string; // github, repos only in project A  -> backfills to A
+	let connSharedId: string; // github, repos in A and B     -> stays global
+	let connSaasId: string; // saas, no repos                 -> stays global
+	let connectorGithubAId: string; // linked to connA        -> backfills to A
+	let connectorSharedId: string; // linked to connSaas      -> stays global
+
+	async function seedSecret(name: string): Promise<string> {
+		const r = await h.db.query<{ id: string }>(
+			`INSERT INTO secrets (name, encrypted_value) VALUES ($1, 'enc') RETURNING id`,
+			[name],
+		);
+		return r.rows[0].id;
+	}
+
+	async function seedConnection(
+		provider: string,
+		accountId: string,
+		label: string,
+	): Promise<string> {
+		const secretId = await seedSecret(`OAUTH_${accountId}`);
+		const r = await h.db.query<{ id: string }>(
+			`INSERT INTO oauth_connections
+			   (provider, provider_account_id, provider_account_label, access_token_secret_id)
+			 VALUES ($1, $2, $3, $4) RETURNING id`,
+			[provider, accountId, label, secretId],
+		);
+		return r.rows[0].id;
+	}
+
+	beforeAll(async () => {
+		h = await createDataPreservationHarness();
+		await h.applyUpToExclusive(TARGET);
+
+		const teamA = await h.db.query<{ id: string }>(
+			`INSERT INTO teams (name, slug) VALUES ('Acme', 'acme') RETURNING id`,
+		);
+		const teamB = await h.db.query<{ id: string }>(
+			`INSERT INTO teams (name, slug) VALUES ('Globex', 'globex') RETURNING id`,
+		);
+		const projectA = await h.db.query<{ id: string }>(
+			`INSERT INTO projects (team_id, name, slug, task_prefix) VALUES ($1, 'Site', 'site', 'SITE') RETURNING id`,
+			[teamA.rows[0].id],
+		);
+		const projectB = await h.db.query<{ id: string }>(
+			`INSERT INTO projects (team_id, name, slug, task_prefix) VALUES ($1, 'App', 'app', 'APP') RETURNING id`,
+			[teamB.rows[0].id],
+		);
+		projectAId = projectA.rows[0].id;
+		projectBId = projectB.rows[0].id;
+
+		connAId = await seedConnection('github', 'gh-acme', 'acme-agent');
+		connSharedId = await seedConnection('github', 'gh-shared', 'shared-agent');
+		connSaasId = await seedConnection('datocms', 'dato-1', 'DatoCMS');
+
+		// connA: one repo in project A only.
+		await h.db.query(
+			`INSERT INTO repos (project_id, repo_identifier, host_type, oauth_connection_id)
+			 VALUES ($1, 'acme/site', 'github', $2)`,
+			[projectAId, connAId],
+		);
+		// connShared: repos in BOTH projects → ambiguous, stays global.
+		await h.db.query(
+			`INSERT INTO repos (project_id, repo_identifier, host_type, oauth_connection_id)
+			 VALUES ($1, 'shared/one', 'github', $2)`,
+			[projectAId, connSharedId],
+		);
+		await h.db.query(
+			`INSERT INTO repos (project_id, repo_identifier, host_type, oauth_connection_id)
+			 VALUES ($1, 'shared/two', 'github', $2)`,
+			[projectBId, connSharedId],
+		);
+
+		const connectorGithubA = await h.db.query<{ id: string }>(
+			`INSERT INTO mcp_connections (name, kind, oauth_connection_id)
+			 VALUES ('github', 'saas', $1) RETURNING id`,
+			[connAId],
+		);
+		connectorGithubAId = connectorGithubA.rows[0].id;
+		const connectorShared = await h.db.query<{ id: string }>(
+			`INSERT INTO mcp_connections (name, kind, oauth_connection_id)
+			 VALUES ('shared-docs', 'saas', $1) RETURNING id`,
+			[connSaasId],
+		);
+		connectorSharedId = connectorShared.rows[0].id;
+
+		await h.applyTarget(TARGET);
+	});
+	afterAll(() => h.close());
+
+	it('adds project_id to both tables', async () => {
+		const cols = await h.db.query<{ table_name: string }>(
+			`SELECT table_name FROM information_schema.columns
+			 WHERE column_name = 'project_id' AND table_name IN ('oauth_connections', 'mcp_connections')`,
+		);
+		expect(cols.rows.map((r) => r.table_name).sort()).toEqual([
+			'mcp_connections',
+			'oauth_connections',
+		]);
+	});
+
+	it('backfills a single-project oauth connection to that project', async () => {
+		const r = await h.db.query<{ project_id: string | null }>(
+			`SELECT project_id FROM oauth_connections WHERE id = $1`,
+			[connAId],
+		);
+		expect(r.rows[0].project_id).toBe(projectAId);
+	});
+
+	it('leaves a multi-project oauth connection global', async () => {
+		const r = await h.db.query<{ project_id: string | null }>(
+			`SELECT project_id FROM oauth_connections WHERE id = $1`,
+			[connSharedId],
+		);
+		expect(r.rows[0].project_id).toBeNull();
+	});
+
+	it('leaves a repo-less saas oauth connection global', async () => {
+		const r = await h.db.query<{ project_id: string | null }>(
+			`SELECT project_id FROM oauth_connections WHERE id = $1`,
+			[connSaasId],
+		);
+		expect(r.rows[0].project_id).toBeNull();
+	});
+
+	it('backfills a connector from its linked oauth connection', async () => {
+		const github = await h.db.query<{ project_id: string | null }>(
+			`SELECT project_id FROM mcp_connections WHERE id = $1`,
+			[connectorGithubAId],
+		);
+		expect(github.rows[0].project_id).toBe(projectAId);
+		const shared = await h.db.query<{ project_id: string | null }>(
+			`SELECT project_id FROM mcp_connections WHERE id = $1`,
+			[connectorSharedId],
+		);
+		expect(shared.rows[0].project_id).toBeNull();
+	});
+
+	it('preserves every seeded row', async () => {
+		const oauth = await h.db.query<{ c: number }>(
+			`SELECT COUNT(*)::int AS c FROM oauth_connections`,
+		);
+		expect(oauth.rows[0].c).toBe(3);
+		const mcp = await h.db.query<{ c: number }>(`SELECT COUNT(*)::int AS c FROM mcp_connections`);
+		expect(mcp.rows[0].c).toBe(2);
+		const repos = await h.db.query<{ c: number }>(`SELECT COUNT(*)::int AS c FROM repos`);
+		expect(repos.rows[0].c).toBe(3);
+	});
+
+	it('allows the same upstream account in two different projects', async () => {
+		const s1 = await seedSecret('OAUTH_dup_a');
+		const s2 = await seedSecret('OAUTH_dup_b');
+		await h.db.query(
+			`INSERT INTO oauth_connections (provider, provider_account_id, provider_account_label, access_token_secret_id, project_id)
+			 VALUES ('github', 'gh-dup', 'dup-a', $1, $2)`,
+			[s1, projectAId],
+		);
+		await expect(
+			h.db.query(
+				`INSERT INTO oauth_connections (provider, provider_account_id, provider_account_label, access_token_secret_id, project_id)
+				 VALUES ('github', 'gh-dup', 'dup-b', $1, $2)`,
+				[s2, projectBId],
+			),
+		).resolves.toBeDefined();
+	});
+
+	it('rejects a duplicate upstream account within one project', async () => {
+		const s = await seedSecret('OAUTH_dup_conflict');
+		await expect(
+			h.db.query(
+				`INSERT INTO oauth_connections (provider, provider_account_id, provider_account_label, access_token_secret_id, project_id)
+				 VALUES ('github', 'gh-dup', 'dup-again', $1, $2)`,
+				[s, projectAId],
+			),
+		).rejects.toThrow();
+	});
+
+	it('allows the same connector name in two projects but rejects two globals', async () => {
+		await h.db.query(
+			`INSERT INTO mcp_connections (name, kind, project_id) VALUES ('github', 'saas', $1)`,
+			[projectBId],
+		);
+		// A second global connector named 'github' collides with the pre-existing
+		// backfilled row only if that stayed global — it moved to project A, so a
+		// fresh global 'github' is allowed once, but a second global is not.
+		await h.db.query(`INSERT INTO mcp_connections (name, kind) VALUES ('linear', 'saas')`);
+		await expect(
+			h.db.query(`INSERT INTO mcp_connections (name, kind) VALUES ('linear', 'saas')`),
+		).rejects.toThrow();
+	});
+});

--- a/packages/server/test/oauth-github-routes.test.ts
+++ b/packages/server/test/oauth-github-routes.test.ts
@@ -178,7 +178,7 @@ describe('GitHub device-flow connector', () => {
 		const otherConnector = await db.query<{ id: string }>(
 			`INSERT INTO mcp_connections (name, display_name, kind, config, install_status)
 			 VALUES ('github', 'GitHub', 'saas'::mcp_connection_kind, '{}'::jsonb, 'installed')
-			 ON CONFLICT (name) DO UPDATE SET display_name = EXCLUDED.display_name
+			 ON CONFLICT (name) WHERE project_id IS NULL DO UPDATE SET display_name = EXCLUDED.display_name
 			 RETURNING id`,
 		);
 		const start = await app.request(

--- a/packages/web/src/components/github-section.tsx
+++ b/packages/web/src/components/github-section.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import { useMcpConnections } from '../hooks/use-mcp-connections';
 import {
 	useConnectionScopeStatus,
+	useDeleteOAuthConnection,
 	useEnsureConnector,
 	useOAuthConnections,
 } from '../hooks/use-oauth-connections';
@@ -27,6 +28,7 @@ export function GitHubSection({ projectId }: GitHubSectionProps) {
 	const { data: repos } = useRepos(projectId);
 	const deleteRepo = useDeleteRepo(projectId);
 	const retryRepo = useCreateRepo(projectId);
+	const deleteConnection = useDeleteOAuthConnection(projectId);
 	const queryClient = useQueryClient();
 
 	const githubConnection = connections.find((c) => c.provider === 'github') ?? null;
@@ -136,8 +138,29 @@ export function GitHubSection({ projectId }: GitHubSectionProps) {
 					</div>
 				</div>
 			) : (
-				<div className="text-xs text-text-3 mb-3">
-					Connected as <span className="font-mono">{githubConnection.provider_account_label}</span>.
+				<div className="flex items-center justify-between gap-2 mb-3">
+					<div className="text-xs text-text-3">
+						Connected as{' '}
+						<span className="font-mono">{githubConnection.provider_account_label}</span>.
+					</div>
+					<Button
+						variant="ghost"
+						size="sm"
+						disabled={deleteConnection.isPending}
+						onClick={() => {
+							if (
+								window.confirm(
+									`Disconnect GitHub account ${githubConnection.provider_account_label}?`,
+								)
+							) {
+								deleteConnection.mutate(githubConnection.id);
+							}
+						}}
+						data-testid="github-disconnect"
+					>
+						<Trash2 className="size-3.5 mr-1" />
+						{deleteConnection.isPending ? 'Disconnecting…' : 'Disconnect'}
+					</Button>
 				</div>
 			)}
 

--- a/packages/web/src/components/project-sidebar.tsx
+++ b/packages/web/src/components/project-sidebar.tsx
@@ -94,6 +94,13 @@ export function ProjectSidebar() {
 		label: 'Git',
 		testId: 'project-sidebar-git',
 	};
+	// Connectors (this project's MCP servers + GitHub) also disclose under Settings.
+	const connectorsPage = {
+		to: '/projects/$projectId/connectors',
+		params: projectParams,
+		label: 'Connectors',
+		testId: 'project-sidebar-connectors',
+	};
 
 	// Progress (the project's goals + Captain-maintained summary) leads under Inbox; it's a
 	// normal-project concept, so HQ (internal) has none.
@@ -159,9 +166,9 @@ export function ProjectSidebar() {
 						params: projectParams,
 						label: 'Settings',
 						testId: 'project-sidebar-settings',
-						// Git, Container and Activity disclose under Settings when it (or one
-						// of them) is the active route.
-						subItems: [gitPage, containerPage, activityPage],
+						// Git, Connectors, Container and Activity disclose under Settings when
+						// it (or one of them) is the active route.
+						subItems: [gitPage, connectorsPage, containerPage, activityPage],
 					},
 				]),
 	];

--- a/packages/web/src/hooks/use-instance-connectors.ts
+++ b/packages/web/src/hooks/use-instance-connectors.ts
@@ -3,10 +3,12 @@ import { api } from '../lib/api';
 import { queryClient } from '../lib/query-client';
 import type { McpConnection } from './use-mcp-connections';
 
-// Instance-level connectors (mcp_connections with team_id NULL) are shared with
-// every team. Only the Admin (superuser) manages them, via the un-prefixed
-// /api/mcp-connections routes. SaaS (remote URL) only — local MCPs carry
-// per-container install state and stay per-team.
+// The admin (superuser) connectors surface. Its list spans EVERY project's
+// connectors plus global ("all projects") ones (project_id NULL), via the
+// un-prefixed /api/mcp-connections routes, so it can render a per-project scope
+// filter. Create targets the selected scope: a project_id, or none for a global
+// connector. SaaS (remote URL) only — local MCPs carry per-container install
+// state and are managed on the project.
 export const INSTANCE_CONNECTORS_KEY = ['instance', 'mcp-connections'] as const;
 
 export interface CreateInstanceConnectorPayload {
@@ -14,6 +16,8 @@ export interface CreateInstanceConnectorPayload {
 	display_name?: string;
 	kind: 'saas';
 	config: { url: string; headers?: Record<string, string> };
+	/** Target project, or omitted/null for a global ("all projects") connector. */
+	project_id?: string | null;
 }
 
 export function useInstanceConnectors() {

--- a/packages/web/src/hooks/use-mcp-connections.ts
+++ b/packages/web/src/hooks/use-mcp-connections.ts
@@ -10,6 +10,8 @@ export interface McpConnection {
 	kind: 'saas' | 'local';
 	config: Record<string, unknown>;
 	oauth_connection_id: string | null;
+	/** Owning project, or null for a global ("all projects") connector. */
+	project_id: string | null;
 	install_status: 'pending' | 'installed' | 'failed';
 	install_error: string | null;
 	skill_id: string | null;
@@ -19,6 +21,11 @@ export interface McpConnection {
 	auth_error: string | null;
 	created_at: string;
 	updated_at: string;
+	/** Linked OAuth account's username/label (e.g. GitHub login), when connected. */
+	oauth_account_label?: string | null;
+	/** Owning project's name/slug — populated only by the admin cross-project list. */
+	project_name?: string | null;
+	project_slug?: string | null;
 }
 
 export type ConnectorStatus = 'pending' | 'active' | 'failed' | 'revoked';

--- a/packages/web/src/routes/projects/$projectId/connectors.tsx
+++ b/packages/web/src/routes/projects/$projectId/connectors.tsx
@@ -273,6 +273,11 @@ function ConnectorRow({ connector, projectId, focused, focusRef }: ConnectorRowP
 						<StatusBadge status={status} />
 					</div>
 					{url && <p className="text-xs text-text-2 mt-1 truncate font-mono">{url}</p>}
+					{connector.oauth_account_label && (
+						<p className="text-xs text-text-2 mt-1">
+							Connected as <span className="font-mono">{connector.oauth_account_label}</span>
+						</p>
+					)}
 					{connector.skill_id && (
 						<p className="text-xs text-text-2 mt-1 flex items-center gap-1">
 							<ExternalLink className="size-3" />

--- a/packages/web/src/routes/settings/connectors.tsx
+++ b/packages/web/src/routes/settings/connectors.tsx
@@ -1,7 +1,7 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
 import { Plus, Trash2 } from 'lucide-react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Badge } from '../../components/ui/badge';
 import { Button } from '../../components/ui/button';
 import { InPlaceForm } from '../../components/ui/in-place-form';
@@ -16,6 +16,14 @@ import {
 } from '../../hooks/use-instance-connectors';
 import { connectorStatus, type McpConnection } from '../../hooks/use-mcp-connections';
 import { useMe } from '../../hooks/use-me';
+import { useAllVisibleProjects } from '../../hooks/use-projects';
+
+// Scope filter sentinel: show/create against "all projects" (a global connector,
+// project_id null). Any other value is a concrete project id.
+const ALL_PROJECTS = 'all';
+
+const SELECT_CLASS =
+	'rounded-md border border-border bg-surface-2 px-3 py-1.5 text-[13px] text-text-1 outline-none focus:border-border-strong';
 
 function openAuthPopup(authUrl: string): string | null {
 	const popup = window.open(authUrl, 'hezo-connect', 'width=600,height=720');
@@ -26,6 +34,7 @@ function InstanceConnectorsPage() {
 	const { data: me } = useMe();
 	const { focus } = Route.useSearch();
 	const { data: connectors = [] } = useInstanceConnectors();
+	const { projects } = useAllVisibleProjects();
 	const createConnector = useCreateInstanceConnector();
 	const authStart = useInstanceAuthStart();
 	const queryClient = useQueryClient();
@@ -36,10 +45,20 @@ function InstanceConnectorsPage() {
 		if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
 	}, []);
 
+	// The scope filter doubles as the create scope: `all` shows every connector
+	// and adds a global one; a project id filters to that project and adds there.
+	const [scope, setScope] = useState<string>(ALL_PROJECTS);
 	const [showForm, setShowForm] = useState(false);
 	const [name, setName] = useState('');
 	const [url, setUrl] = useState('');
 	const [error, setError] = useState<string | null>(null);
+
+	const visibleConnectors = useMemo(
+		() => (scope === ALL_PROJECTS ? connectors : connectors.filter((c) => c.project_id === scope)),
+		[connectors, scope],
+	);
+	const scopeName =
+		scope === ALL_PROJECTS ? null : (projects.find((p) => p.id === scope)?.name ?? 'this project');
 
 	function closeForm() {
 		setShowForm(false);
@@ -75,6 +94,7 @@ function InstanceConnectorsPage() {
 				name: name.trim(),
 				kind: 'saas',
 				config: { url: url.trim() },
+				project_id: scope === ALL_PROJECTS ? null : scope,
 			});
 		} catch (err) {
 			setError(err instanceof Error ? err.message : 'Failed to create connector');
@@ -117,7 +137,8 @@ function InstanceConnectorsPage() {
 							/>
 						</div>
 						<p className="text-[13px] text-text-2 mt-1 max-w-[680px]">
-							Remote (SaaS) MCP servers shared with every team's agent runs.
+							Remote (SaaS) MCP servers across every project. Each project's runs see its own
+							connectors plus any scoped to "All projects".
 						</p>
 					</div>
 					<Button variant="secondary" size="sm" onClick={() => setShowForm((s) => !s)}>
@@ -125,8 +146,37 @@ function InstanceConnectorsPage() {
 					</Button>
 				</div>
 
+				<div className="flex items-center gap-2 mb-4">
+					<label htmlFor="connector-scope" className="text-[13px] text-text-2">
+						Scope
+					</label>
+					<select
+						id="connector-scope"
+						aria-label="Filter connectors by project"
+						data-testid="connector-scope-filter"
+						value={scope}
+						onChange={(e) => setScope(e.target.value)}
+						className={SELECT_CLASS}
+					>
+						<option value={ALL_PROJECTS}>All projects</option>
+						{projects.map((p) => (
+							<option key={p.id} value={p.id}>
+								{p.name}
+							</option>
+						))}
+					</select>
+				</div>
+
 				{showForm && (
-					<InPlaceForm title="Add connector" onClose={closeForm} onSubmit={handleCreate}>
+					<InPlaceForm
+						title={
+							scope === ALL_PROJECTS
+								? 'Add connector (All projects)'
+								: `Add connector — ${scopeName}`
+						}
+						onClose={closeForm}
+						onSubmit={handleCreate}
+					>
 						<Input
 							placeholder="Name (e.g. shared-docs)"
 							value={name}
@@ -154,13 +204,15 @@ function InstanceConnectorsPage() {
 				    closes, so popup-blocked / auth-start errors need a home too. */}
 				{error && <p className="text-[13px] text-danger mb-4">{error}</p>}
 
-				{!connectors.length ? (
+				{!visibleConnectors.length ? (
 					<p className="text-[13px] text-text-2">
-						No instance connectors yet. Add one above to share it across every team.
+						{scope === ALL_PROJECTS
+							? 'No connectors yet. Add one above to share it across every project.'
+							: `No connectors scoped to ${scopeName} yet.`}
 					</p>
 				) : (
 					<div className="flex flex-col gap-1">
-						{connectors.map((c) => (
+						{visibleConnectors.map((c) => (
 							<InstanceConnectorRow
 								key={c.id}
 								connector={c}
@@ -190,6 +242,7 @@ function InstanceConnectorRow({ connector, focused, focusRef }: InstanceConnecto
 	const status = connectorStatus(connector);
 
 	const url = typeof connector.config?.url === 'string' ? connector.config.url : '';
+	const scopeLabel = connector.project_id ? (connector.project_name ?? 'Project') : 'All projects';
 
 	const openConnect = () => {
 		setRowError(null);
@@ -224,9 +277,15 @@ function InstanceConnectorRow({ connector, focused, focusRef }: InstanceConnecto
 			<div className="flex flex-wrap items-center gap-2">
 				<span className="font-medium">{connector.display_name || connector.name}</span>
 				<Badge color="neutral">{connector.kind}</Badge>
+				<Badge color={connector.project_id ? 'blue' : 'gray'}>{scopeLabel}</Badge>
 				{status === 'active' && <Badge color="success">Connected</Badge>}
 				{status === 'failed' && <Badge color="danger">Failed</Badge>}
 				{status === 'revoked' && <Badge>Revoked</Badge>}
+				{connector.oauth_account_label && (
+					<span className="text-xs text-text-2 font-mono" data-testid="connector-account">
+						{connector.oauth_account_label}
+					</span>
+				)}
 				<span className="text-xs text-text-3 font-mono truncate flex-1 min-w-0 basis-24">
 					{url}
 				</span>
@@ -245,9 +304,7 @@ function InstanceConnectorRow({ connector, focused, focusRef }: InstanceConnecto
 					<button
 						type="button"
 						onClick={() => {
-							if (
-								confirm(`Remove instance connector "${connector.display_name || connector.name}"?`)
-							) {
+							if (confirm(`Remove connector "${connector.display_name || connector.name}"?`)) {
 								deleteConnector.mutate(connector.id);
 							}
 						}}

--- a/packages/web/test/instance-connectors.test.tsx
+++ b/packages/web/test/instance-connectors.test.tsx
@@ -59,7 +59,7 @@ test('the blurb is a single sentence and the add form is a dismissible standout 
 	await findByText('Connectors', { selector: 'h1' });
 	// The blurb is just the first sentence; the OAuth/placeholder detail moved
 	// into the info tooltip (unmounted until hover).
-	await findByText("Remote (SaaS) MCP servers shared with every team's agent runs.");
+	await findByText(/Remote \(SaaS\) MCP servers across every project\./);
 	expect(queryByText(/Servers that advertise OAuth/)).toBeNull();
 
 	// The form opens inside the titled panel, without a display-name field —


### PR DESCRIPTION
## Problem

`oauth_connections` and `mcp_connections` were **instance-global**, so a deployment running two projects that each need a **different** GitHub (or SaaS) account couldn't keep them separate — one project's account bled into the other. Two independent global assumptions caused it:

1. **Reads ignored the project** — `resolveGitIdentity` / `listConnections` picked "most-recent GitHub wins", and the project connection list returned *all* connections.
2. **`mcp_connections.name` was globally unique** — only one `github` connector could exist, so a second project's "Connect GitHub" silently returned the first project's connector (and its token).

## What changed

Connections are now **scoped by project** via a nullable `project_id` (`NULL` = the global "all projects" scope, which preserves existing rows and the admin surface). A project owns exactly one team (1:1) and a run is scoped to its task's project, so `project_id` is the natural key.

### Data model
- **Migration `018_scope_connections_per_project.sql`** — adds `project_id` to both tables, backfills from `repos.project_id` where a connection's repos all live in one project, and replaces the global unique constraints with project-partitioned partial unique indexes. Ships a `createDataPreservationHarness` test covering every backfill branch and both partial uniques.

### Server
- Connection store, connector lifecycle, run-time descriptor loading (`loadMcpConnectionsForRun`), git identity, and the local-MCP installer now resolve the run's project: its own connectors/account **plus** global ones, with a project row **shadowing** a global of the same name. `createOrFetchConnector` keys strictly on `(project_id, name)` (no fall-back to a global row).
- OAuth + MCP-connection routes and the four agent MCP tools (`list_mcp_connections`, `test_connector`, `add_mcp_connection`, `remove_mcp_connection`) are project-scoped; `register_connector` passes the project. This closes a **cross-project token-placeholder leak** where `list_mcp_connections` exposed another project's `rest_auth` placeholder.
- The admin `GET /api/mcp-connections` now spans every project (each row annotated with its `project_id`/name) and `POST` accepts an optional `project_id`.
- Deleting a project (or its team) purges the project's connection token secrets **before** the cascade so none orphan in the vault.

### Web
- **Project → Settings → Connectors** — surfaces the existing project connectors page in the nav.
- **Global Settings → Connectors** — gains a scope-filter dropdown (`All projects` / a specific project) that filters the list and sets the create scope; rows show a project badge and the linked account username.
- The **GitHub** card gains a **Disconnect** button next to "Connected as …".
- Connector rows show the connected account's username when available.

### Docs
- `.dev/architecture.md`, `docs/mcp/connecting-mcp-servers.md`, and the generated MCP reference (`docs/reference/mcp-api.md` via `TOOL_DOC_META`) updated to describe per-project scoping.

## Migration / data notes

- Existing single-project GitHub connections auto-assign to their project (no reconnect). A connection whose repos span multiple projects, or a repo-less SaaS connection, stays global — reconnect per project to separate those.

## Testing

- Full server vitest suite green; new isolation tests: `git-identity` (each project resolves its own account; project shadows global), `mcp-connections-routes` (cross-project list isolation + a project can't delete another's connector + admin list spans projects), `connectors` (`loadMcpConnectionsForRun` project scoping + shadow), and the migration-018 data-preservation test.
- `bun run typecheck` and the full `bun run build` pass (run by the pre-commit hook); web component tests for the connectors pages and GitHub section pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxuU6BRmCGgsdT8FU6Q1hy

---
_Generated by [Claude Code](https://claude.ai/code/session_01JxuU6BRmCGgsdT8FU6Q1hy)_