### PR TITLE
fix(web): keep the version-update UI polling so it advances without a reload

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -1241,11 +1241,15 @@ GitHub release, plus a **"Check for new version"** button that calls
 1 h cache, the same upstream check the daily cron runs). When an update is available this
 section mirrors the banner's staged-update lifecycle **in place** — driven by
 `useUpdateStatus({ poll })`, which auto-refetches `GET /api/updates/status` every few seconds
-while the state is `checking`/`downloading`/`applying` so the section advances live without a
-reload: a self-applying instance shows **"Downloading new version…"** while staging, then an
-**"Install & restart"** button (same restart confirmation) once `Staged`, or a **"Retry
-download"** on `Error`; an instance that can't self-apply falls back to the **"Download"**
-release link.
+through the whole pre-terminal lifecycle (`updateStatusPollInterval`: while the server is
+`checking`/`downloading`/`applying`, **and** through the initial `idle` snapshot a self-applying
+instance returns before staging has started) so the section advances live without a reload, then
+stops once the state settles at `staged`/`error` (or there's nothing to stage): a self-applying
+instance shows **"Downloading new version…"** while staging, then an **"Install & restart"**
+button (same restart confirmation) once `Staged`, or a **"Retry download"** on `Error`; an
+instance that can't self-apply falls back to the **"Download"** release link. The top-of-shell
+banner polls the same way (`useUpdateStatus({ poll: true })`), so it surfaces "Install & restart"
+live on any page the moment the binary is staged — not only after a manual reload.
 
 **Self-update & supervisor.** A compiled binary with auto-update enabled
 (`isAutoUpdateEnabled()` — compiled, not `HEZO_DISABLE_AUTO_UPDATE`, not in a container)
@@ -1264,7 +1268,8 @@ re-attempts so a transient failure self-heals instead of sticking forever; likew
 `Downloading` state is respected only while **fresh** (`STAGE_DOWNLOAD_STALE_MS`), so a download
 abandoned by a worker crash/restart is re-attempted rather than wedging staging permanently. It
 runs from `GET /api/updates/status`
-(fire-and-forget on every banner poll, gated on `isSupervisedWorker()`) and the daily
+(fire-and-forget on every status poll from the banner or settings section, gated on
+`isSupervisedWorker()`) and the daily
 `update-check` cron (`HEZO_UPDATE_CHECK_CRON`), so a running instance usually stages a new
 release within seconds. `POST /api/updates/download` (superuser) is the same download path on
 demand; `POST /api/updates/apply` (superuser) gracefully shuts the worker down and exits with

--- a/packages/web/src/components/update-banner.tsx
+++ b/packages/web/src/components/update-banner.tsx
@@ -49,7 +49,12 @@ function readDismissed(): Dismissal | null {
  * release link. Dismissal lasts until the next calendar day (or a newer version ships).
  */
 export function UpdateBanner() {
-	const { data } = useUpdateStatus();
+	// Poll so the banner advances through the background download lifecycle live on any
+	// page (it's the only status observer off the settings page). The hook runs before
+	// the early `return null` below, so its poll keeps ticking while the banner is hidden
+	// mid-download and surfaces "Install & restart" the moment the binary is staged —
+	// without a manual reload.
+	const { data } = useUpdateStatus({ poll: true });
 	const { data: me } = useMe();
 	const apply = useApplyUpdate();
 	const download = useDownloadUpdate();

--- a/packages/web/src/hooks/use-update-check.ts
+++ b/packages/web/src/hooks/use-update-check.ts
@@ -56,15 +56,48 @@ export function useCheckForUpdate() {
 	});
 }
 
+/** Poll cadence (ms) while a staged-update download is advancing. */
+const POLL_INTERVAL_MS = 2500;
+
+/**
+ * Refetch cadence for the staged-update lifecycle while `useUpdateStatus({ poll })` is
+ * active — the interval in ms, or `false` to stop.
+ *
+ * The server stages the download in the background (kicked by `GET /api/updates/status`
+ * itself) and records only a coarse on-disk `state`, with no push when it changes, so the
+ * UI has to poll to observe `idle → downloading → staged`. Keep polling while the server is
+ * actively mid-flight (`checking`/`downloading`/`applying`) OR a self-applying instance has
+ * an available update that hasn't reached a terminal state yet — the latter covers the
+ * `idle` snapshot the first poll returns before the background stage has written
+ * `downloading`, the gap that otherwise stranded the "Downloading new version…" spinner
+ * until a manual reload. Terminal states (`staged`/`error`) stop the poll, and so does "no
+ * update / can't self-apply in place" — there's nothing to wait for.
+ */
+export function updateStatusPollInterval(data: UpdateStatusInfo | undefined): number | false {
+	if (!data) return false;
+	const { state } = data;
+	if (state === UpdateState.Staged || state === UpdateState.Error) return false;
+	if (
+		state === UpdateState.Checking ||
+		state === UpdateState.Downloading ||
+		state === UpdateState.Applying ||
+		(data.updateAvailable && data.canApply)
+	) {
+		return POLL_INTERVAL_MS;
+	}
+	return false;
+}
+
 /**
  * Latest-release info plus the staged-update lifecycle and whether this instance
  * can apply-and-restart. Drives the "Install & restart" affordance.
  *
- * Pass `{ poll: true }` (the settings Version section) to auto-refetch every few
- * seconds while the server is mid-flight (`checking`/`downloading`/`applying`), so
- * the section advances through the lifecycle live without a manual reload. Polling
- * stops on its own once the state settles (staged/idle/error). The banner leaves it
- * off — it only needs the terminal state.
+ * Pass `{ poll: true }` (the settings Version section and the top-of-shell banner) to
+ * auto-refetch every few seconds while an update is downloading/staging, so the UI advances
+ * through the lifecycle live without a manual reload. `updateStatusPollInterval` keeps
+ * polling through the whole pre-terminal lifecycle — including the `idle` snapshot before
+ * staging starts — and stops on its own once the state settles (`staged`/`error`) or there's
+ * nothing to stage.
  */
 export function useUpdateStatus(opts?: { poll?: boolean }) {
 	return useQuery({
@@ -73,16 +106,7 @@ export function useUpdateStatus(opts?: { poll?: boolean }) {
 		staleTime: 60 * 60 * 1000,
 		gcTime: 60 * 60 * 1000,
 		retry: false,
-		refetchInterval: opts?.poll
-			? (query) => {
-					const state = query.state.data?.state;
-					return state === UpdateState.Checking ||
-						state === UpdateState.Downloading ||
-						state === UpdateState.Applying
-						? 2500
-						: false;
-				}
-			: undefined,
+		refetchInterval: opts?.poll ? (query) => updateStatusPollInterval(query.state.data) : undefined,
 	});
 }
 

--- a/packages/web/test/settings-version.test.tsx
+++ b/packages/web/test/settings-version.test.tsx
@@ -187,3 +187,41 @@ test('a superuser-less caller on a self-applying instance still cannot apply (do
 	expect(queryByTestId('settings-version-install')).toBeNull();
 	expect(getByTestId('settings-version-download')).toBeTruthy();
 });
+
+test('advances from "Downloading new version…" to "Install & restart" via polling — no reload', async () => {
+	// Reproduces the reported bug: the server hands back the initial `idle` snapshot first
+	// (the background stage hasn't written `downloading` to disk yet), then `staged` once
+	// the download lands. The section must follow that transition live via its `poll: true`
+	// refetch instead of stranding the spinner until the user manually refreshes.
+	vi.spyOn(api, 'get')
+		.mockResolvedValueOnce({ ...AVAILABLE, state: UpdateState.Idle })
+		.mockResolvedValue({ ...AVAILABLE, state: UpdateState.Staged });
+	const qc = new QueryClient({
+		// refetchIntervalInBackground: the happy-dom document isn't "focused", so react-query
+		// would otherwise skip the interval poll a real (focused) browser runs.
+		defaultOptions: {
+			queries: {
+				retry: false,
+				staleTime: Number.POSITIVE_INFINITY,
+				refetchIntervalInBackground: true,
+			},
+		},
+	});
+	qc.setQueryData(queryKeys.me(), { type: 'admin', is_superuser: true });
+	const { findByTestId, queryByTestId } = render(
+		<QueryClientProvider client={qc}>
+			<VersionDisplay />
+		</QueryClientProvider>,
+	);
+
+	// Initial status fetch resolves to `idle` → the download spinner, no install button yet.
+	expect((await findByTestId('settings-version-downloading')).textContent).toContain(
+		'Downloading new version',
+	);
+	expect(queryByTestId('settings-version-install')).toBeNull();
+
+	// The interval poll (~2.5s) observes `staged` and the section flips in place, no reload.
+	const install = await findByTestId('settings-version-install', undefined, { timeout: 5000 });
+	expect(install.textContent).toContain('Install & restart');
+	expect(queryByTestId('settings-version-downloading')).toBeNull();
+});

--- a/packages/web/test/update-banner.test.tsx
+++ b/packages/web/test/update-banner.test.tsx
@@ -172,3 +172,38 @@ test('a legacy bare-version dismissal is ignored (banner shows)', () => {
 	const { getByTestId } = renderBanner();
 	expect(getByTestId('update-banner')).toBeTruthy();
 });
+
+test('surfaces "Install & restart" once a background download stages — via polling, no reload', async () => {
+	// Off the settings page the banner is the only status observer, so its own `poll: true`
+	// has to carry it through the background download. The server returns `idle` first (stage
+	// not yet written), then `staged`; the banner must advance from hidden to the instant-
+	// restart button live instead of staying hidden until the user reloads.
+	vi.spyOn(api, 'get')
+		.mockResolvedValueOnce({ ...BASE, state: UpdateState.Idle })
+		.mockResolvedValue({ ...BASE, state: UpdateState.Staged });
+	const qc = new QueryClient({
+		// refetchIntervalInBackground: the happy-dom document isn't "focused", so react-query
+		// would otherwise skip the interval poll a real (focused) browser runs.
+		defaultOptions: {
+			queries: {
+				retry: false,
+				staleTime: Number.POSITIVE_INFINITY,
+				refetchIntervalInBackground: true,
+			},
+		},
+	});
+	qc.setQueryData(['me'], { type: 'admin', is_superuser: true });
+	const { findByTestId, queryByTestId } = render(
+		<QueryClientProvider client={qc}>
+			<UpdateBanner />
+		</QueryClientProvider>,
+	);
+
+	// Mid-download the banner is hidden (no data yet / `idle`).
+	expect(queryByTestId('update-banner')).toBeNull();
+
+	// The interval poll advances idle → staged and the banner appears with the restart button.
+	const button = await findByTestId('update-restart-button', undefined, { timeout: 5000 });
+	expect(button.textContent).toContain('Install & restart');
+	expect(queryByTestId('update-banner')).toBeTruthy();
+});

--- a/packages/web/test/update-poll-interval.test.ts
+++ b/packages/web/test/update-poll-interval.test.ts
@@ -1,0 +1,65 @@
+import { UpdateState } from '@hezo/shared';
+import { expect, test } from 'vitest';
+import { type UpdateStatusInfo, updateStatusPollInterval } from '../src/hooks/use-update-check';
+
+const BASE: UpdateStatusInfo = {
+	current: '0.1.0',
+	latest: '0.2.0',
+	updateAvailable: true,
+	url: 'https://github.com/hezo-ai/hezo/releases/0.2.0',
+	state: UpdateState.Idle,
+	targetVersion: '0.2.0',
+	error: null,
+	autoUnlock: false,
+	canApply: true,
+};
+
+const status = (overrides: Partial<UpdateStatusInfo> = {}): UpdateStatusInfo => ({
+	...BASE,
+	...overrides,
+});
+
+// The regression this whole change fixes: a self-applying instance with an available
+// update sitting at the initial `idle` snapshot (the state the first status poll returns
+// before the background stage has written `downloading`) MUST keep polling — otherwise
+// the settings section's "Downloading new version…" spinner and the banner strand until a
+// manual reload.
+test('keeps polling on the idle snapshot while a self-applying update is available', () => {
+	expect(updateStatusPollInterval(status({ state: UpdateState.Idle }))).toBe(2500);
+});
+
+test('keeps polling while the server is actively mid-flight', () => {
+	for (const state of [
+		UpdateState.Checking,
+		UpdateState.Downloading,
+		UpdateState.Applying,
+	] as const) {
+		expect(updateStatusPollInterval(status({ state }))).toBe(2500);
+	}
+});
+
+test('stops polling once the lifecycle settles at a terminal state', () => {
+	// Staged → the UI shows "Install & restart"; Error → "Retry download". Nothing left to poll for.
+	expect(updateStatusPollInterval(status({ state: UpdateState.Staged }))).toBe(false);
+	expect(updateStatusPollInterval(status({ state: UpdateState.Error }))).toBe(false);
+});
+
+test('does not poll when there is no update to stage (already on the latest version)', () => {
+	expect(
+		updateStatusPollInterval(
+			status({ state: UpdateState.Idle, updateAvailable: false, latest: '0.1.0' }),
+		),
+	).toBe(false);
+});
+
+test('does not poll when the instance cannot self-apply in place', () => {
+	// e.g. an unsupervised / non-compiled instance: it only ever links to the GitHub
+	// release, so there's no background staging to await.
+	expect(updateStatusPollInterval(status({ state: UpdateState.Idle, canApply: false }))).toBe(
+		false,
+	);
+});
+
+test('does not poll before any status data has loaded', () => {
+	expect(updateStatusPollInterval(undefined)).toBe(false);
+});


### PR DESCRIPTION
## What & why

On **Settings → General**, after a new release starts downloading, the "Version" section (and the top-of-shell update banner) stayed stuck on **"Downloading new version…"** until the user manually refreshed the page — "Install & restart" only appeared after a reload.

The self-update flow is **poll-driven**: `GET /api/updates/status` reads a coarse on-disk lifecycle `state` (`idle → downloading → staged`) and fire-and-forget kicks the idempotent background stage; there is **no websocket push** when the state changes. The client is supposed to keep polling to observe the transition. Two frontend bugs broke that:

1. **The `idle` polling hole (settings section).** `VersionDisplay` renders the spinner whenever `downloading = canApply && !staged && !errored` — which is **true for `idle`** — but `useUpdateStatus`'s `refetchInterval` only polled while state was `checking | downloading | applying`, i.e. it **stopped on `idle`**, the exact snapshot the first status poll returns before staging has started. So the spinner stuck and never advanced.
2. **The banner never polled.** `UpdateBanner` called `useUpdateStatus()` with no `poll`, a 1 h `staleTime`, and no websocket invalidation — on any page other than settings it read status once and never reached the `staged` terminal state.

## What changed

- **`packages/web/src/hooks/use-update-check.ts`** — extract `updateStatusPollInterval(data)` and widen it: keep polling while the server is mid-flight (`checking`/`downloading`/`applying`) **or** a self-applying instance has an available update that hasn't reached a terminal state (this covers `idle`). Stop at `staged`/`error`, or when there's no update / the instance can't self-apply, so steady state never polls.
- **`packages/web/src/components/update-banner.tsx`** — `useUpdateStatus({ poll: true })` so the banner advances live on any page (its observer stays active while it's hidden mid-download).
- **`.dev/architecture.md`** — synced the poll-condition description.

Kept the existing poll design (the intended mechanism — the `poll` option already existed) rather than adding a websocket push, which would be a much larger change for a bug the polling was meant to handle.

## Tests

- New `packages/web/test/update-poll-interval.test.ts` — pure-unit test of the predicate across every state (idle+available → poll; terminal / no-update / can't-self-apply → stop).
- `settings-version.test.tsx` and `update-banner.test.tsx` — integration tests that the section and banner advance `idle → staged` via the real interval poll, with no reload.

All three files green; `bun run typecheck` and `bunx biome check` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGBFYk949bfZkQQvcQMv2n

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGBFYk949bfZkQQvcQMv2n)_