### PR TITLE
feat(web): edit connector scope inline instead of a top filter

### DIFF
--- a/docs/mcp/connecting-mcp-servers.md
+++ b/docs/mcp/connecting-mcp-servers.md
@@ -60,9 +60,11 @@ and the global scope both define a connection of the same name, the project's ow
 Manage connections two ways:
 
 - **Project → Settings → Connectors** shows just that project's connectors.
-- The global **Settings → Connectors** page (admin) lists connectors across every project,
-  with a scope filter — **All projects** or a specific project — to narrow the view and
-  choose where a newly added connector lives.
+- The global **Settings → Connectors** page (admin) lists connectors across every project.
+  Each connector shows its scope — **All projects** or a specific project — as a badge you
+  can click to re-scope it: a searchable dropdown lets you move the connector to any
+  project or back to the global scope. New connectors pick their scope in the Add form the
+  same way.
 
 ## Adding a connection
 

--- a/packages/server/src/routes/mcp-connections.ts
+++ b/packages/server/src/routes/mcp-connections.ts
@@ -4,6 +4,7 @@ import { trackBackground } from '../lib/background';
 import { broadcastChange } from '../lib/broadcast';
 import { resolveActor } from '../lib/resolve';
 import { err, ok } from '../lib/response';
+import { isUniqueViolation } from '../lib/sql';
 import type { Env } from '../lib/types';
 import { logger } from '../logger';
 import { requireAdminEquivalent } from '../middleware/auth';
@@ -136,6 +137,68 @@ mcpConnectionsRoutes.post('/mcp-connections', async (c) => {
 		name: createdRow.name,
 	});
 	return ok(c, result.rows[0], 201);
+});
+
+// Admin surface: re-scope a connector to a different project (or to the global
+// "all projects" scope, project_id null). Only the scope is editable here — the
+// per-row inline scope picker on `/settings/connectors` posts to this.
+mcpConnectionsRoutes.patch('/mcp-connections/:id', async (c) => {
+	const denied = requireAdminEquivalent(c);
+	if (denied) return denied;
+	const db = c.get('db');
+	const id = c.req.param('id');
+
+	const body = await c.req
+		.json<{ project_id?: string | null }>()
+		.catch(() => ({}) as { project_id?: string | null });
+	if (!('project_id' in body)) {
+		return err(c, 'INVALID_REQUEST', 'project_id is required', 400);
+	}
+	// Empty/whitespace collapses to the global scope (project_id null).
+	const projectId = body.project_id?.trim() || null;
+	if (projectId) {
+		const proj = await db.query<{ id: string }>(`SELECT id FROM projects WHERE id = $1`, [
+			projectId,
+		]);
+		if (proj.rows.length === 0) return err(c, 'NOT_FOUND', 'project_id not found', 404);
+	}
+
+	let result: Awaited<ReturnType<typeof db.query>>;
+	try {
+		result = await db.query(
+			`UPDATE mcp_connections SET project_id = $2, updated_at = now()
+			 WHERE id = $1
+			 RETURNING ${CONNECTOR_COLUMNS},
+			   (SELECT name FROM projects WHERE id = project_id) AS project_name,
+			   (SELECT slug FROM projects WHERE id = project_id) AS project_slug`,
+			[id, projectId],
+		);
+	} catch (e) {
+		// Moving into a scope that already holds a connector of the same name trips
+		// one of the partial unique indexes (global name / per-project name).
+		if (isUniqueViolation(e)) {
+			return err(
+				c,
+				'CONFLICT',
+				'a connector with this name already exists in the target scope',
+				409,
+			);
+		}
+		throw e;
+	}
+	if (result.rows.length === 0) return err(c, 'NOT_FOUND', 'connector not found', 404);
+
+	const updated = result.rows[0] as { id: string; name: string };
+	c.get('events').emit({
+		type: 'mcp_connection.updated',
+		teamId: null,
+		actorType: 'admin',
+		actorMemberId: null,
+		connectionId: updated.id,
+		name: updated.name,
+		changeKind: 'scope',
+	});
+	return ok(c, result.rows[0]);
 });
 
 mcpConnectionsRoutes.delete('/mcp-connections/:id', async (c) => {

--- a/packages/server/test/mcp-connections-routes.test.ts
+++ b/packages/server/test/mcp-connections-routes.test.ts
@@ -160,6 +160,125 @@ describe('admin (instance-global) /mcp-connections routes', () => {
 	});
 });
 
+describe('admin PATCH /mcp-connections/:id (re-scope)', () => {
+	async function createGlobalConnector(name: string): Promise<string> {
+		const res = await ctx.app.request('/api/mcp-connections', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name, kind: 'saas', config: { url: `https://${name}/mcp` } }),
+		});
+		expect(res.status).toBe(201);
+		return (await res.json()).data.id as string;
+	}
+
+	async function projectIdForSlug(slug: string): Promise<string> {
+		const p = await ctx.db.query<{ id: string }>('SELECT id FROM projects WHERE slug = $1', [slug]);
+		return p.rows[0].id;
+	}
+
+	it('rejects a non-superuser', async () => {
+		const id = await createGlobalConnector('rescope-forbidden');
+		const res = await ctx.app.request(`/api/mcp-connections/${id}`, {
+			method: 'PATCH',
+			headers: { ...authHeader(nonAdminToken), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ project_id: null }),
+		});
+		expect(res.status).toBe(403);
+	});
+
+	it('rejects a body without project_id', async () => {
+		const id = await createGlobalConnector('rescope-nobody');
+		const res = await ctx.app.request(`/api/mcp-connections/${id}`, {
+			method: 'PATCH',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({}),
+		});
+		expect(res.status).toBe(400);
+		expect((await res.json()).error.message).toContain('project_id is required');
+	});
+
+	it('returns 404 for an unknown connector', async () => {
+		const res = await ctx.app.request('/api/mcp-connections/00000000-0000-0000-0000-000000000000', {
+			method: 'PATCH',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ project_id: null }),
+		});
+		expect(res.status).toBe(404);
+		expect((await res.json()).error.message).toContain('connector not found');
+	});
+
+	it('returns 404 for an unknown target project_id', async () => {
+		const id = await createGlobalConnector('rescope-badproj');
+		const res = await ctx.app.request(`/api/mcp-connections/${id}`, {
+			method: 'PATCH',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ project_id: '00000000-0000-0000-0000-000000000000' }),
+		});
+		expect(res.status).toBe(404);
+		expect((await res.json()).error.message).toContain('project_id not found');
+	});
+
+	it('moves a global connector into a project, then back to global', async () => {
+		const id = await createGlobalConnector('rescope-move');
+		const projId = await projectIdForSlug(projectSlug);
+
+		const toProject = await ctx.app.request(`/api/mcp-connections/${id}`, {
+			method: 'PATCH',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ project_id: projId }),
+		});
+		expect(toProject.status).toBe(200);
+		const scoped = (await toProject.json()).data as {
+			project_id: string | null;
+			project_name: string | null;
+			name: string;
+		};
+		expect(scoped.project_id).toBe(projId);
+		expect(scoped.project_name).toBeTruthy();
+		// The rest of the row is untouched by a scope change.
+		expect(scoped.name).toBe('rescope-move');
+
+		const toGlobal = await ctx.app.request(`/api/mcp-connections/${id}`, {
+			method: 'PATCH',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ project_id: '  ' }), // whitespace collapses to global
+		});
+		expect(toGlobal.status).toBe(200);
+		const global = (await toGlobal.json()).data as {
+			project_id: string | null;
+			project_name: string | null;
+		};
+		expect(global.project_id).toBeNull();
+		expect(global.project_name).toBeNull();
+	});
+
+	it('409s when the target scope already holds a same-named connector', async () => {
+		const projId = await projectIdForSlug(projectSlug);
+		// A global connector and a project-scoped one that share a name coexist
+		// (different partial unique indexes) — until you try to merge their scopes.
+		const globalId = await createGlobalConnector('rescope-dup');
+		await ctx.db.query(
+			`INSERT INTO mcp_connections (name, kind, config, install_status, project_id)
+			 VALUES ('rescope-dup', 'saas', '{"url":"https://p/mcp"}'::jsonb, 'installed', $1)`,
+			[projId],
+		);
+
+		const res = await ctx.app.request(`/api/mcp-connections/${globalId}`, {
+			method: 'PATCH',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ project_id: projId }),
+		});
+		expect(res.status).toBe(409);
+		expect((await res.json()).error.code).toBe('CONFLICT');
+		// The global connector kept its original scope (the write rolled back).
+		const still = await ctx.db.query<{ project_id: string | null }>(
+			'SELECT project_id FROM mcp_connections WHERE id = $1',
+			[globalId],
+		);
+		expect(still.rows[0].project_id).toBeNull();
+	});
+});
+
 describe('project-scoped /projects/:projectId/mcp-connections/:id', () => {
 	async function seedSaasConnector(name: string): Promise<string> {
 		const project = await ctx.db.query<{ id: string }>(`SELECT id FROM projects WHERE slug = $1`, [

--- a/packages/web/src/components/ui/searchable-select.tsx
+++ b/packages/web/src/components/ui/searchable-select.tsx
@@ -1,0 +1,151 @@
+import * as Popover from '@radix-ui/react-popover';
+import { Check, ChevronDown, Search } from 'lucide-react';
+import { type ReactNode, useMemo, useState } from 'react';
+
+export interface SearchableSelectOption {
+	value: string;
+	label: string;
+	/** Optional secondary line rendered under the label (also searchable). */
+	description?: string;
+}
+
+interface SearchableSelectProps {
+	options: SearchableSelectOption[];
+	value: string | null;
+	onChange: (value: string) => void;
+	/**
+	 * Custom trigger element (rendered via Radix `asChild`). Must be a single
+	 * focusable element that forwards props/ref (e.g. a `<button>`). Falls back to
+	 * a labelled button showing the current selection.
+	 */
+	trigger?: ReactNode;
+	placeholder?: string;
+	searchPlaceholder?: string;
+	emptyLabel?: string;
+	align?: 'start' | 'center' | 'end';
+	className?: string;
+	contentClassName?: string;
+	testId?: string;
+	disabled?: boolean;
+}
+
+/**
+ * A single-select dropdown with a type-to-filter search box. Reusable anywhere a
+ * plain `<select>` gets unwieldy with many options. Renders in a Radix portal, so
+ * query the option buttons against `document.body` in tests.
+ */
+export function SearchableSelect({
+	options,
+	value,
+	onChange,
+	trigger,
+	placeholder = 'Select…',
+	searchPlaceholder = 'Search…',
+	emptyLabel = 'No matches',
+	align = 'start',
+	className = '',
+	contentClassName = '',
+	testId,
+	disabled = false,
+}: SearchableSelectProps) {
+	const [open, setOpen] = useState(false);
+	const [query, setQuery] = useState('');
+
+	const selected = options.find((o) => o.value === value) ?? null;
+	const filtered = useMemo(() => {
+		const q = query.trim().toLowerCase();
+		if (!q) return options;
+		return options.filter(
+			(o) =>
+				o.label.toLowerCase().includes(q) ||
+				(o.description ? o.description.toLowerCase().includes(q) : false),
+		);
+	}, [options, query]);
+
+	function handleSelect(next: string) {
+		onChange(next);
+		setOpen(false);
+		setQuery('');
+	}
+
+	return (
+		<Popover.Root
+			open={open}
+			onOpenChange={(next) => {
+				setOpen(next);
+				if (!next) setQuery('');
+			}}
+		>
+			<Popover.Trigger asChild disabled={disabled}>
+				{trigger ?? (
+					<button
+						type="button"
+						data-testid={testId}
+						className={`flex items-center justify-between gap-2 min-w-[160px] rounded-md border border-border bg-surface px-2.5 py-1.5 text-[13px] text-text-1 outline-none hover:border-border-strong focus:border-border-strong disabled:opacity-50 cursor-pointer ${className}`}
+					>
+						<span className={`truncate ${selected ? '' : 'text-text-2'}`}>
+							{selected ? selected.label : placeholder}
+						</span>
+						<ChevronDown className="w-3.5 h-3.5 text-text-3 shrink-0" />
+					</button>
+				)}
+			</Popover.Trigger>
+			<Popover.Portal>
+				<Popover.Content
+					align={align}
+					sideOffset={4}
+					data-testid={testId ? `${testId}-content` : undefined}
+					className={`z-50 min-w-[220px] rounded-md border border-border bg-surface p-1 shadow-md ${contentClassName}`}
+				>
+					<div className="flex items-center gap-1.5 border-b border-border px-2 pb-1.5 mb-1">
+						<Search className="w-3.5 h-3.5 text-text-3 shrink-0" />
+						<input
+							// biome-ignore lint/a11y/noAutofocus: focusing the search box on open is the point
+							autoFocus
+							value={query}
+							onChange={(e) => setQuery(e.target.value)}
+							placeholder={searchPlaceholder}
+							aria-label={searchPlaceholder}
+							data-testid={testId ? `${testId}-search` : undefined}
+							className="w-full bg-transparent text-[13px] text-text-1 outline-none placeholder:text-text-3"
+						/>
+					</div>
+					<div className="max-h-64 overflow-y-auto">
+						{filtered.length === 0 ? (
+							<div className="px-2.5 py-2 text-[13px] text-text-2">{emptyLabel}</div>
+						) : (
+							filtered.map((opt) => {
+								const active = opt.value === value;
+								return (
+									<button
+										key={opt.value}
+										type="button"
+										onClick={() => handleSelect(opt.value)}
+										data-testid={testId ? `${testId}-option-${opt.value}` : undefined}
+										className={`flex w-full items-start gap-2 rounded-md px-2.5 py-1.5 text-left text-[13px] transition-colors cursor-pointer ${
+											active
+												? 'text-text-1 bg-surface-2'
+												: 'text-text-2 hover:text-text-1 hover:bg-surface-3'
+										}`}
+									>
+										<Check
+											className={`w-3.5 h-3.5 mt-0.5 shrink-0 ${active ? 'text-info' : 'text-transparent'}`}
+										/>
+										<span className="min-w-0 flex-1">
+											<span className="block truncate">{opt.label}</span>
+											{opt.description && (
+												<span className="block truncate text-[11px] text-text-3">
+													{opt.description}
+												</span>
+											)}
+										</span>
+									</button>
+								);
+							})
+						)}
+					</div>
+				</Popover.Content>
+			</Popover.Portal>
+		</Popover.Root>
+	);
+}

--- a/packages/web/src/hooks/use-instance-connectors.ts
+++ b/packages/web/src/hooks/use-instance-connectors.ts
@@ -46,6 +46,22 @@ export function useDeleteInstanceConnector() {
 	});
 }
 
+/**
+ * Re-scope a connector: move it to another project, or to the global "all
+ * projects" scope (`project_id: null`). Validation-heavy (the target scope may
+ * already hold a connector of the same name → 409), so it's invalidate+refetch
+ * rather than optimistic — the refreshed list carries the new project_name.
+ */
+export function useUpdateInstanceConnectorScope() {
+	return useMutation({
+		mutationFn: ({ id, project_id }: { id: string; project_id: string | null }) =>
+			api.patch<McpConnection>(`/api/mcp-connections/${id}`, { project_id }),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: INSTANCE_CONNECTORS_KEY });
+		},
+	});
+}
+
 export interface InstanceAuthStartResult {
 	/**
 	 * Authorize URL to open in a popup, or null when the MCP server advertises

--- a/packages/web/src/routes/settings/connectors.tsx
+++ b/packages/web/src/routes/settings/connectors.tsx
@@ -1,6 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
-import { Plus, Trash2 } from 'lucide-react';
+import { ChevronDown, Plus, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Badge } from '../../components/ui/badge';
 import { Button } from '../../components/ui/button';
@@ -8,22 +8,24 @@ import { InPlaceForm } from '../../components/ui/in-place-form';
 import { InfoTooltip } from '../../components/ui/info-tooltip';
 import { Input } from '../../components/ui/input';
 import {
+	SearchableSelect,
+	type SearchableSelectOption,
+} from '../../components/ui/searchable-select';
+import {
 	INSTANCE_CONNECTORS_KEY,
 	useCreateInstanceConnector,
 	useDeleteInstanceConnector,
 	useInstanceAuthStart,
 	useInstanceConnectors,
+	useUpdateInstanceConnectorScope,
 } from '../../hooks/use-instance-connectors';
 import { connectorStatus, type McpConnection } from '../../hooks/use-mcp-connections';
 import { useMe } from '../../hooks/use-me';
 import { useAllVisibleProjects } from '../../hooks/use-projects';
 
-// Scope filter sentinel: show/create against "all projects" (a global connector,
-// project_id null). Any other value is a concrete project id.
+// Scope sentinel: create against / re-scope to "all projects" (a global
+// connector, project_id null). Any other option value is a concrete project id.
 const ALL_PROJECTS = 'all';
-
-const SELECT_CLASS =
-	'rounded-md border border-border bg-surface-2 px-3 py-1.5 text-[13px] text-text-1 outline-none focus:border-border-strong';
 
 function openAuthPopup(authUrl: string): string | null {
 	const popup = window.open(authUrl, 'hezo-connect', 'width=600,height=720');
@@ -45,20 +47,26 @@ function InstanceConnectorsPage() {
 		if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
 	}, []);
 
-	// The scope filter doubles as the create scope: `all` shows every connector
-	// and adds a global one; a project id filters to that project and adds there.
-	const [scope, setScope] = useState<string>(ALL_PROJECTS);
+	// Scope picked in the Add form for the new connector (`all` = global).
+	const [createScope, setCreateScope] = useState<string>(ALL_PROJECTS);
 	const [showForm, setShowForm] = useState(false);
 	const [name, setName] = useState('');
 	const [url, setUrl] = useState('');
 	const [error, setError] = useState<string | null>(null);
 
-	const visibleConnectors = useMemo(
-		() => (scope === ALL_PROJECTS ? connectors : connectors.filter((c) => c.project_id === scope)),
-		[connectors, scope],
+	// Shared "All projects" + every project — drives both the create-form scope
+	// picker and each row's inline re-scope dropdown.
+	const scopeOptions = useMemo<SearchableSelectOption[]>(
+		() => [
+			{ value: ALL_PROJECTS, label: 'All projects' },
+			...projects.map((p) => ({ value: p.id, label: p.name, description: p.teamName })),
+		],
+		[projects],
 	);
-	const scopeName =
-		scope === ALL_PROJECTS ? null : (projects.find((p) => p.id === scope)?.name ?? 'this project');
+	const createScopeName =
+		createScope === ALL_PROJECTS
+			? null
+			: (projects.find((p) => p.id === createScope)?.name ?? 'this project');
 
 	function closeForm() {
 		setShowForm(false);
@@ -94,7 +102,7 @@ function InstanceConnectorsPage() {
 				name: name.trim(),
 				kind: 'saas',
 				config: { url: url.trim() },
-				project_id: scope === ALL_PROJECTS ? null : scope,
+				project_id: createScope === ALL_PROJECTS ? null : createScope,
 			});
 		} catch (err) {
 			setError(err instanceof Error ? err.message : 'Failed to create connector');
@@ -146,33 +154,12 @@ function InstanceConnectorsPage() {
 					</Button>
 				</div>
 
-				<div className="flex items-center gap-2 mb-4">
-					<label htmlFor="connector-scope" className="text-[13px] text-text-2">
-						Scope
-					</label>
-					<select
-						id="connector-scope"
-						aria-label="Filter connectors by project"
-						data-testid="connector-scope-filter"
-						value={scope}
-						onChange={(e) => setScope(e.target.value)}
-						className={SELECT_CLASS}
-					>
-						<option value={ALL_PROJECTS}>All projects</option>
-						{projects.map((p) => (
-							<option key={p.id} value={p.id}>
-								{p.name}
-							</option>
-						))}
-					</select>
-				</div>
-
 				{showForm && (
 					<InPlaceForm
 						title={
-							scope === ALL_PROJECTS
+							createScope === ALL_PROJECTS
 								? 'Add connector (All projects)'
-								: `Add connector — ${scopeName}`
+								: `Add connector — ${createScopeName}`
 						}
 						onClose={closeForm}
 						onSubmit={handleCreate}
@@ -189,6 +176,17 @@ function InstanceConnectorsPage() {
 							onChange={(e) => setUrl(e.target.value)}
 							required
 						/>
+						<div className="flex flex-wrap items-center gap-2">
+							<span className="text-[13px] text-text-2">Scope</span>
+							<SearchableSelect
+								options={scopeOptions}
+								value={createScope}
+								onChange={setCreateScope}
+								searchPlaceholder="Search projects…"
+								emptyLabel="No projects"
+								testId="create-scope-select"
+							/>
+						</div>
 						<div className="flex gap-2">
 							<Button type="submit" size="sm" disabled={createConnector.isPending}>
 								Add connector
@@ -204,18 +202,17 @@ function InstanceConnectorsPage() {
 				    closes, so popup-blocked / auth-start errors need a home too. */}
 				{error && <p className="text-[13px] text-danger mb-4">{error}</p>}
 
-				{!visibleConnectors.length ? (
+				{!connectors.length ? (
 					<p className="text-[13px] text-text-2">
-						{scope === ALL_PROJECTS
-							? 'No connectors yet. Add one above to share it across every project.'
-							: `No connectors scoped to ${scopeName} yet.`}
+						No connectors yet. Add one above to share it across every project.
 					</p>
 				) : (
 					<div className="flex flex-col gap-1">
-						{visibleConnectors.map((c) => (
+						{connectors.map((c) => (
 							<InstanceConnectorRow
 								key={c.id}
 								connector={c}
+								scopeOptions={scopeOptions}
 								focused={c.id === focus}
 								focusRef={c.id === focus ? focusRef : undefined}
 							/>
@@ -230,19 +227,65 @@ function InstanceConnectorsPage() {
 
 interface InstanceConnectorRowProps {
 	connector: McpConnection;
+	scopeOptions: SearchableSelectOption[];
 	focused: boolean;
 	focusRef?: (el: HTMLDivElement | null) => void;
 }
 
-function InstanceConnectorRow({ connector, focused, focusRef }: InstanceConnectorRowProps) {
+/** Pull a human message off either a thrown Error or the API client's ApiError. */
+function errMessage(e: unknown, fallback: string): string {
+	if (e instanceof Error) return e.message;
+	if (e && typeof e === 'object' && 'message' in e) {
+		const m = (e as { message: unknown }).message;
+		if (typeof m === 'string' && m) return m;
+	}
+	return fallback;
+}
+
+function InstanceConnectorRow({
+	connector,
+	scopeOptions,
+	focused,
+	focusRef,
+}: InstanceConnectorRowProps) {
 	const deleteConnector = useDeleteInstanceConnector();
 	const authStart = useInstanceAuthStart();
+	const updateScope = useUpdateInstanceConnectorScope();
 	const [rowError, setRowError] = useState<string | null>(null);
 	const [rowInfo, setRowInfo] = useState<string | null>(null);
 	const status = connectorStatus(connector);
 
 	const url = typeof connector.config?.url === 'string' ? connector.config.url : '';
 	const scopeLabel = connector.project_id ? (connector.project_name ?? 'Project') : 'All projects';
+	const scopeValue = connector.project_id ?? ALL_PROJECTS;
+	const scopeTone = connector.project_id
+		? 'bg-info-soft text-info-soft-fg'
+		: 'bg-neutral-soft text-neutral-soft-fg';
+
+	const changeScope = (next: string) => {
+		setRowError(null);
+		const nextProjectId = next === ALL_PROJECTS ? null : next;
+		// No-op when the picked scope already matches (avoids a needless 409-prone write).
+		if (nextProjectId === (connector.project_id ?? null)) return;
+		updateScope.mutate(
+			{ id: connector.id, project_id: nextProjectId },
+			{ onError: (e: unknown) => setRowError(errMessage(e, 'Failed to change scope')) },
+		);
+	};
+
+	// Badge-styled trigger: clicking it opens the searchable scope picker.
+	const scopeTrigger = (
+		<button
+			type="button"
+			data-testid="instance-connector-scope"
+			aria-label={`Scope: ${scopeLabel}. Change scope`}
+			disabled={updateScope.isPending}
+			className={`inline-flex items-center gap-1 whitespace-nowrap rounded-full h-5 pl-2 pr-1.5 text-[11.5px] font-medium outline-none cursor-pointer transition-opacity hover:opacity-80 focus:ring-1 focus:ring-border-strong disabled:opacity-50 ${scopeTone}`}
+		>
+			{updateScope.isPending ? 'Saving…' : scopeLabel}
+			<ChevronDown className="w-3 h-3 opacity-70" />
+		</button>
+	);
 
 	const openConnect = () => {
 		setRowError(null);
@@ -277,7 +320,15 @@ function InstanceConnectorRow({ connector, focused, focusRef }: InstanceConnecto
 			<div className="flex flex-wrap items-center gap-2">
 				<span className="font-medium">{connector.display_name || connector.name}</span>
 				<Badge color="neutral">{connector.kind}</Badge>
-				<Badge color={connector.project_id ? 'blue' : 'gray'}>{scopeLabel}</Badge>
+				<SearchableSelect
+					options={scopeOptions}
+					value={scopeValue}
+					onChange={changeScope}
+					trigger={scopeTrigger}
+					searchPlaceholder="Search projects…"
+					emptyLabel="No projects"
+					testId="instance-connector-scope-select"
+				/>
 				{status === 'active' && <Badge color="success">Connected</Badge>}
 				{status === 'failed' && <Badge color="danger">Failed</Badge>}
 				{status === 'revoked' && <Badge>Revoked</Badge>}

--- a/packages/web/test/instance-connectors.test.tsx
+++ b/packages/web/test/instance-connectors.test.tsx
@@ -1,6 +1,7 @@
 import { waitFor } from '@testing-library/react';
 import { expect, test, vi } from 'vitest';
 import { renderApp } from './helpers/render';
+import { seedProject, seedWorkspace } from './helpers/seed';
 
 async function seedInstanceConnector(
 	ctx: { token: string; apiBase: (p: string, i?: RequestInit) => Promise<Response> },
@@ -289,6 +290,41 @@ test('?focus=<id> highlights the connector row and scrolls it into view', async 
 	} finally {
 		spy.mockRestore();
 	}
+});
+
+test('re-scopes a connector via the inline searchable scope dropdown', async () => {
+	let project: { id: string; name: string } | undefined;
+	const { findByText, getByTestId, findByTestId, user } = await renderApp({
+		initialPath: '/settings/connectors',
+		seed: async (ctx) => {
+			await seedInstanceConnector(ctx, {
+				name: 'movable',
+				kind: 'saas',
+				config: { url: 'https://movable.example/mcp' },
+			});
+			// A visible project to move the connector under (shows in the picker).
+			const ws = await seedWorkspace();
+			project = await seedProject(ws, { name: 'Scope Target' });
+		},
+	});
+
+	if (!project) throw new Error('seed did not create the target project');
+
+	await findByText('movable');
+	// The connector starts global — its inline scope trigger reads "All projects".
+	const trigger = await findByTestId('instance-connector-scope');
+	expect(trigger.textContent).toContain('All projects');
+
+	// Click the scope badge → the searchable dropdown opens; filter to the project.
+	await user.click(trigger);
+	const search = await findByTestId('instance-connector-scope-select-search');
+	await user.type(search, 'Scope');
+	await user.click(await findByTestId(`instance-connector-scope-select-option-${project.id}`));
+
+	// The PATCH + refetch re-scopes the row; the badge now shows the project name.
+	await waitFor(() =>
+		expect(getByTestId('instance-connector-scope').textContent).toContain('Scope Target'),
+	);
 });
 
 test('settings page sidebar links to connectors', async () => {


### PR DESCRIPTION
## Summary

The admin **Settings → Connectors** page had a single **Scope** dropdown at the top that did double duty as a list filter and the create-scope selector. This replaces it with **per-connector scope editing**.

- Each connector row's scope badge is now a **clickable trigger** that opens a searchable dropdown to move the connector to any project — or back to the global **All projects** scope.
- The **Add** form gets its own scope picker (same searchable dropdown), so the top filter is no longer needed and is removed. The list now always shows every connector.

### Before → After

| Before | After |
|---|---|
| A top `Scope` `<select>` filtered the list and set the create-scope. | No top filter. The list shows all connectors; each row's scope badge is editable, and the Add form picks its own scope. |

## Changes

**Frontend**
- New reusable `SearchableSelect` UI component (`packages/web/src/components/ui/searchable-select.tsx`) — Radix Popover + type-to-filter search, with an optional custom trigger. Renders into a portal.
- `packages/web/src/routes/settings/connectors.tsx` — removed the top scope filter; the row scope badge is now a `SearchableSelect` trigger; the Add form gained a scope picker.
- `useUpdateInstanceConnectorScope` hook (`use-instance-connectors.ts`) — `PATCH`es the connector scope (invalidate + refetch; validation-heavy, can 409).

**Backend**
- New admin route `PATCH /api/mcp-connections/:id` re-scopes a connector (`project_id`, or null for global). Validates the target project (404), and returns **409** when the destination scope already holds a same-named connector (the partial unique indexes). Emits `mcp_connection.updated` (`changeKind: 'scope'`).

**Docs**
- `docs/mcp/connecting-mcp-servers.md` — updated the admin-page description to reflect inline re-scoping instead of the removed filter.

## Testing

- **Server** (`mcp-connections-routes.test.ts`, +6 tests): re-scope moves a connector into a project and back to global; 403 non-admin; 400 missing `project_id`; 404 unknown connector / unknown project; 409 on same-name scope collision (with rollback assertion). All 65 connector server tests pass.
- **Web** (`instance-connectors.test.tsx`, +1 test): opens a row's scope dropdown, filters, picks a project, and asserts the badge re-scopes after the `PATCH` + refetch. All existing connector web tests still pass.
- Typecheck and biome clean; full build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WsyT5Evn8Ztj3aXM7gFs5V

---
_Generated by [Claude Code](https://claude.ai/code/session_01WsyT5Evn8Ztj3aXM7gFs5V)_