### PR TITLE
feat: admin git repository state panel with recovery actions

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -663,6 +663,24 @@ clone whose `core.hooksPath` is redirected (e.g. husky) simply doesn't fire it. 
 changes are still not covered — the agent commits to preserve, and the role prompts frame frequent
 committing (not a manual end-of-run push) as the durability action.
 
+**Admin git-state & recovery (superuser).** Because a clone's live state lives only in the
+container, the project Git settings page exposes a per-repo, **superuser-only** panel to inspect
+and repair it. `GET /api/projects/:projectId/repos/:repoId/git-state` reads it — the clone's
+default branch, HEAD, dirty flag, and ahead/behind vs. the last-fetched `origin/<default>` (all
+computed locally, no network fetch), plus the active `/worktrees/<task>/<repo>` worktrees joined
+to their tasks — and returns `{ container_running: false }` when the container is stopped rather
+than auto-starting one, since a passive inspect must not trigger a provision. `POST .../reset`
+runs one of three recovery actions: `discard_local` (`git reset --hard` + `clean -fd` — no `-x`,
+so gitignored build artifacts survive — after a best-effort fetch; the escape hatch for the
+"local changes would be overwritten" fast-forward failure that otherwise silently stalls sync),
+`prune_worktrees` (`git worktree prune`), and `reclone` (wipe the clone via `removeRepoFromWorkspace`
+then re-run `performRepoSetup`, reusing its `pending`→`ready`/`failed` lifecycle). Reset is
+**blocked (409) while any agent run is active on the project** (`getProjectConcurrency`) — it
+mutates the shared `.git` a live worktree prep also touches, and reclone deletes worktrees a run
+may hold — and `discard_local`/`prune_worktrees` additionally require a running container. Every
+read and reset runs under the same per-project git lock (`withProjectGitLock`, extracted to
+`lib/git-lock.ts`) as run-time worktree prep, so they never interleave on the shared `.git`.
+
 **Timeout handling (graceful cut).** The `run_timeout_min` timer aborts the run's signal with a
 tagged `'run_timeout'` reason (`JobManager.launchTask`), so the runner finalizes it as `timed_out`
 — distinct from a bare abort (user cancel / shutdown → `cancelled`) and container death

--- a/docs/security/git-and-verified-commits.md
+++ b/docs/security/git-and-verified-commits.md
@@ -62,6 +62,29 @@ often. One thing to know: because Hezo pushes on every commit, a branch that run
 push will build more often than it would with a single end-of-run push — scope CI to pull
 requests if that becomes noisy.
 
+## Recovering a stuck repository
+
+Occasionally a project's working copy of a repository gets into a state where Hezo's automatic
+syncing can't move it forward on its own — most often when the local copy of the main branch has
+uncommitted changes that stop it from fast-forwarding to the latest commit on GitHub. When that
+happens the repository quietly stops keeping up with the remote.
+
+For these cases, an **admin** can open the project's **Git** settings page and expand any
+repository to see its live state: the current branch, whether the working copy has uncommitted
+changes, how far ahead or behind GitHub it is, and which tasks currently have work in progress
+against it. From there, three recovery actions are available:
+
+- **Discard local changes** — throws away uncommitted changes in the project's copy and resets it
+  to match GitHub. This is the fix for the stuck-sync case above. Work already committed and pushed
+  to GitHub is never affected.
+- **Prune worktrees** — clears out leftover per-task working copies from runs that were interrupted.
+  Committed work on their branches is preserved.
+- **Re-clone** — the last resort: deletes the project's copy entirely and clones it fresh from GitHub.
+
+These actions only ever affect the local working copy on your instance, never the repository on
+GitHub, and they're deliberately **blocked while any agent is actively working** in the project so a
+reset can't pull the rug out from under a running task.
+
 This is the same posture described in [Container isolation](/docs/security/container-isolation):
 the keys that matter most stay on the host, and a compromised agent can use them only
 indirectly, for the operations Hezo performs on its behalf.

--- a/packages/server/src/lib/git-lock.ts
+++ b/packages/server/src/lib/git-lock.ts
@@ -1,0 +1,18 @@
+// Serializes git operations that mutate a repo's shared .git store (clone,
+// fetch, worktree add, reset) per project. Concurrent runs on the same project
+// work in separate per-task worktrees but share one .git per repo, so these
+// brief setup/recovery steps must not overlap or they race on git's index/ref
+// locks. Keyed by project id, so different projects never block one another.
+// In-process only (single-server assumption), same as the rest of the runtime.
+const projectGitLocks = new Map<string, Promise<unknown>>();
+
+export function withProjectGitLock<T>(projectId: string, fn: () => Promise<T>): Promise<T> {
+	const prev = projectGitLocks.get(projectId) ?? Promise.resolve();
+	const run = prev.then(() => fn());
+	const tail = run.catch(() => {});
+	projectGitLocks.set(projectId, tail);
+	void tail.then(() => {
+		if (projectGitLocks.get(projectId) === tail) projectGitLocks.delete(projectId);
+	});
+	return run;
+}

--- a/packages/server/src/routes/repos.ts
+++ b/packages/server/src/routes/repos.ts
@@ -1,17 +1,39 @@
-import { RepoSetupStatus, repoNameFromIdentifier, wsRoom } from '@hezo/shared';
+import { join } from 'node:path';
+import { ContainerStatus, RepoSetupStatus, repoNameFromIdentifier, wsRoom } from '@hezo/shared';
 import { Hono } from 'hono';
 import { trackBackground } from '../lib/background';
 import { broadcastChange } from '../lib/broadcast';
+import { withProjectGitLock } from '../lib/git-lock';
 import { getProjectLocator, resolveProjectId } from '../lib/resolve';
 import { err, ok } from '../lib/response';
 import { isUniqueViolation } from '../lib/sql';
 import type { Env } from '../lib/types';
 import { logger } from '../logger';
+import { requireSuperuser } from '../middleware/auth';
+import { resolveContainerRunUser } from '../services/container-user';
 import type { ContainerDeps } from '../services/containers';
+import {
+	getCloneState,
+	getWorktreeState,
+	listWorktrees,
+	pruneWorktrees,
+	type RepoLoc,
+	resetCloneToOrigin,
+	type WorktreeLoc,
+} from '../services/git';
+import { ContainerGitExecutor } from '../services/git-executor';
 import { createGitHubRepo, parseGitHubUrl, validateRepoAccess } from '../services/github';
 import { getConnection } from '../services/oauth/connection-store';
 import { performRepoSetup } from '../services/repo-provisioning';
 import { removeRepoFromWorkspace } from '../services/repo-sync';
+import { getProjectConcurrency } from '../services/run-concurrency';
+import { type BridgeRunnerArgs, withProvisionBridge } from '../services/ssh-agent';
+import {
+	CONTAINER_WORKSPACE_ROOT,
+	CONTAINER_WORKTREES_ROOT,
+	getWorkspacePath,
+	getWorktreesPath,
+} from '../services/workspace';
 
 const log = logger.child('routes');
 
@@ -271,6 +293,218 @@ reposRoutes.delete('/projects/:projectId/repos/:repoId', async (c) => {
 	return ok(c, { deleted: true });
 });
 
+/**
+ * Admin-only live git state for one repository's clone: the default branch, HEAD,
+ * clean/dirty, ahead/behind origin (all read locally — no network fetch), plus the
+ * active per-task worktrees. Git runs inside the project container, so this
+ * requires the container running; a stopped container returns
+ * `{ container_running: false }` rather than auto-starting one (a passive inspect
+ * must never trigger a minutes-long provision). Reads run under the project git
+ * lock so they never interleave with a run's worktree prep on the shared `.git`.
+ */
+reposRoutes.get('/projects/:projectId/repos/:repoId/git-state', async (c) => {
+	const denied = requireSuperuser(c);
+	if (denied) return denied;
+
+	const teamId = c.get('teamId') as string;
+	const db = c.get('db');
+	const projectId = await resolveProjectId(db, teamId, c.req.param('projectId'));
+	if (!projectId) return err(c, 'NOT_FOUND', 'Project not found', 404);
+	const dataDir = c.get('dataDir');
+	if (!dataDir)
+		return err(c, 'GIT_STATE_UNSUPPORTED', 'git state unavailable in this deployment', 400);
+
+	const repo = await loadRepoForGit(db, dataDir, teamId, projectId, c.req.param('repoId'));
+	if (!repo) return err(c, 'NOT_FOUND', 'Repo not found', 404);
+
+	if (!repo.containerId || !repo.containerRunning) {
+		return ok(c, { container_running: false });
+	}
+	const containerId = repo.containerId;
+
+	const docker = c.get('docker');
+	const runUser = await resolveContainerRunUser(docker, containerId);
+	const executor = ContainerGitExecutor.forPrep(docker, containerId, null, runUser);
+	const worktreesPath = getWorktreesPath(dataDir, teamId, projectId);
+	const wtPrefix = `${CONTAINER_WORKTREES_ROOT}/`;
+
+	const state = await withProjectGitLock(projectId, async () => {
+		const clone = await getCloneState(executor, repo.repoLoc);
+		const entries = await listWorktrees(executor, repo.repoLoc);
+		const worktrees: {
+			taskIdentifier: string;
+			branch: string | null;
+			head: string | null;
+			dirty: boolean;
+		}[] = [];
+		for (const entry of entries) {
+			// Skip the main worktree (the clone itself, under /workspace/<repo>); only
+			// list the per-task worktrees under /worktrees/<taskId>/<repo>.
+			if (!entry.path.startsWith(wtPrefix)) continue;
+			const taskIdentifier = entry.path.slice(wtPrefix.length).split('/')[0];
+			if (!taskIdentifier) continue;
+			const wtLoc: WorktreeLoc = {
+				hostPath: join(worktreesPath, taskIdentifier, repo.repoName),
+				containerPath: entry.path,
+			};
+			const wt = await getWorktreeState(executor, wtLoc);
+			worktrees.push({
+				taskIdentifier,
+				branch: entry.branch ? entry.branch.replace(/^refs\/heads\//, '') : null,
+				head: wt.head,
+				dirty: wt.dirty,
+			});
+		}
+		return { clone, worktrees };
+	});
+
+	// Attach each worktree's task title/status in one query.
+	const identifiers = [...new Set(state.worktrees.map((w) => w.taskIdentifier))];
+	const taskMap = new Map<string, { title: string; status: string }>();
+	if (identifiers.length > 0) {
+		const tasks = await db.query<{ identifier: string; title: string; status: string }>(
+			'SELECT identifier, title, status FROM tasks WHERE project_id = $1 AND identifier = ANY($2)',
+			[projectId, identifiers],
+		);
+		for (const t of tasks.rows) taskMap.set(t.identifier, { title: t.title, status: t.status });
+	}
+
+	return ok(c, {
+		container_running: true,
+		clone: state.clone,
+		worktrees: state.worktrees.map((w) => ({ ...w, task: taskMap.get(w.taskIdentifier) ?? null })),
+	});
+});
+
+const RESET_ACTIONS = ['discard_local', 'prune_worktrees', 'reclone'] as const;
+type ResetAction = (typeof RESET_ACTIONS)[number];
+
+/**
+ * Admin-only recovery for a wedged repository. Actions:
+ * - `discard_local`: `git reset --hard` + `clean -fd` on the clone (best-effort
+ *   fetch first) — unsticks the "local changes would be overwritten" sync failure.
+ * - `prune_worktrees`: `git worktree prune` — clears stale worktrees from crashed runs.
+ * - `reclone`: wipe the on-disk clone and re-run the standard provisioning path.
+ *
+ * All are blocked (409) while any agent run is active on the project — reset
+ * mutates the shared `.git` a live run's worktree prep also touches, and reclone
+ * deletes worktrees a run may hold. `discard_local`/`prune_worktrees` additionally
+ * require a running container; `reclone` starts one as part of provisioning.
+ */
+reposRoutes.post('/projects/:projectId/repos/:repoId/reset', async (c) => {
+	const denied = requireSuperuser(c);
+	if (denied) return denied;
+
+	const teamId = c.get('teamId') as string;
+	const db = c.get('db');
+	const projectId = await resolveProjectId(db, teamId, c.req.param('projectId'));
+	if (!projectId) return err(c, 'NOT_FOUND', 'Project not found', 404);
+	const dataDir = c.get('dataDir');
+	if (!dataDir)
+		return err(c, 'GIT_RESET_UNSUPPORTED', 'git reset unavailable in this deployment', 400);
+
+	const body = await c.req.json<{ action?: string }>().catch(() => ({}) as { action?: string });
+	if (!body.action || !RESET_ACTIONS.includes(body.action as ResetAction)) {
+		return err(c, 'INVALID_REQUEST', `action must be one of: ${RESET_ACTIONS.join(', ')}`, 400);
+	}
+	const action = body.action as ResetAction;
+
+	const repo = await loadRepoForGit(db, dataDir, teamId, projectId, c.req.param('repoId'));
+	if (!repo) return err(c, 'NOT_FOUND', 'Repo not found', 404);
+
+	// Never reset while a run may hold a worktree in this project's shared .git.
+	const { active } = await getProjectConcurrency(db, projectId);
+	if (active > 0) {
+		return err(
+			c,
+			'RUN_IN_PROGRESS',
+			`Cannot reset while ${active} agent run(s) are active on this project; stop or wait for them to finish first`,
+			409,
+		);
+	}
+
+	const docker = c.get('docker');
+
+	if (action === 'reclone') {
+		// Wipe the clone (+ this repo's worktrees) and re-run the standard repo-setup
+		// path, which re-clones and settles the row to ready/failed. The frontend
+		// already renders `setup_status === 'pending'` as "Setting up…".
+		try {
+			removeRepoFromWorkspace(dataDir, teamId, projectId, repo.repoName);
+		} catch (e) {
+			log.error(`Failed to wipe workspace for reclone of ${repo.repoName}:`, e);
+			return err(c, 'RECLONE_FAILED', 'failed to remove existing clone', 500);
+		}
+		const updated = await db.query<Record<string, unknown>>(
+			`UPDATE repos r SET setup_status = $1::repo_setup_status, setup_error = NULL
+			 WHERE r.id = $2 AND r.project_id = $3
+			 RETURNING r.id, r.project_id, r.repo_identifier, r.host_type, r.oauth_connection_id,
+			           r.created_at, r.setup_status, r.setup_error,
+			           (SELECT p.designated_repo_id = r.id FROM projects p WHERE p.id = r.project_id)
+			             AS is_designated`,
+			[RepoSetupStatus.Pending, repo.repoId, projectId],
+		);
+		if (updated.rows[0]) {
+			broadcastChange(c, wsRoom.team(teamId), 'repos', 'UPDATE', updated.rows[0]);
+		}
+		const setupDeps: Omit<ContainerDeps, 'docker' | 'dataDir'> = {
+			db,
+			wsManager: c.get('wsManager'),
+			masterKeyManager: c.get('masterKeyManager'),
+			logs: c.get('logs'),
+			containerLogStreamer: c.get('containerLogStreamer'),
+			sshAgentServer: c.get('sshAgentServer'),
+			egressCAPath: c.get('egressProxy')?.caCertPath ?? null,
+		};
+		trackBackground(
+			performRepoSetup(
+				{ ...setupDeps, docker, dataDir },
+				{ teamId, projectId, repoId: repo.repoId, repoIdentifier: repo.repoIdentifier },
+			).catch((e) => log.error(`Background reclone for ${repo.repoIdentifier} failed:`, e)),
+		);
+		return ok(c, { reset: true, action });
+	}
+
+	// discard_local / prune_worktrees run git in the container → require it running.
+	if (!repo.containerId || !repo.containerRunning) {
+		return err(c, 'CONTAINER_NOT_RUNNING', 'Start the project container before resetting', 409);
+	}
+	const containerId = repo.containerId;
+	const runUser = await resolveContainerRunUser(docker, containerId);
+
+	const result = await withProjectGitLock(
+		projectId,
+		async (): Promise<{
+			success: boolean;
+			error?: string;
+			warning?: string;
+		}> => {
+			if (action === 'prune_worktrees') {
+				const executor = ContainerGitExecutor.forPrep(docker, containerId, null, runUser);
+				await pruneWorktrees(executor, repo.repoLoc);
+				return { success: true };
+			}
+			// discard_local: the best-effort fetch needs the SSH bridge.
+			const sshAgentServer = c.get('sshAgentServer');
+			const runReset = (bridge: BridgeRunnerArgs | null) =>
+				resetCloneToOrigin(
+					ContainerGitExecutor.forPrep(docker, containerId, bridge, runUser),
+					repo.repoLoc,
+				);
+			return sshAgentServer
+				? withProvisionBridge(sshAgentServer, teamId, dataDir, runUser.name, ({ bridge }) =>
+						runReset(bridge),
+					)
+				: runReset(null);
+		},
+	);
+
+	if (!result.success) {
+		return err(c, 'RESET_FAILED', result.error ?? 'git reset failed', 500);
+	}
+	return ok(c, { reset: true, action, warning: result.warning ?? null });
+});
+
 reposRoutes.get('/projects/:projectId/oauth-connections/:id/orgs', async (c) => {
 	const db = c.get('db');
 	const projectId = c.get('projectId') as string;
@@ -330,4 +564,51 @@ async function loadOAuthAccessToken(
 	if (result.rows.length === 0) return null;
 	const { decrypt } = await import('../crypto/encryption');
 	return decrypt(result.rows[0].encrypted_value, key);
+}
+
+interface RepoGitTarget {
+	repoId: string;
+	repoIdentifier: string;
+	repoName: string;
+	repoLoc: RepoLoc;
+	containerId: string | null;
+	containerRunning: boolean;
+}
+
+/**
+ * Resolve a repo row scoped to its project plus the addressing the container git
+ * executor needs: the clone's host/container paths and the project container's
+ * id + running state. Returns null when the repo isn't on the project.
+ */
+async function loadRepoForGit(
+	db: import('../db/database').Db,
+	dataDir: string,
+	teamId: string,
+	projectId: string,
+	repoId: string,
+): Promise<RepoGitTarget | null> {
+	const repoRes = await db.query<{ repo_identifier: string }>(
+		'SELECT repo_identifier FROM repos WHERE id = $1 AND project_id = $2',
+		[repoId, projectId],
+	);
+	if (repoRes.rows.length === 0) return null;
+	const repoIdentifier = repoRes.rows[0].repo_identifier;
+	const repoName = repoNameFromIdentifier(repoIdentifier);
+
+	const containerRes = await db.query<{
+		container_id: string | null;
+		container_status: string | null;
+	}>('SELECT container_id, container_status FROM projects WHERE id = $1', [projectId]);
+
+	return {
+		repoId,
+		repoIdentifier,
+		repoName,
+		repoLoc: {
+			hostPath: join(getWorkspacePath(dataDir, teamId, projectId), repoName),
+			containerPath: `${CONTAINER_WORKSPACE_ROOT}/${repoName}`,
+		},
+		containerId: containerRes.rows[0]?.container_id ?? null,
+		containerRunning: containerRes.rows[0]?.container_status === ContainerStatus.Running,
+	};
 }

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -33,6 +33,7 @@ import type { Db } from '../db/database';
 import type { DomainEventBus } from '../events/bus';
 import { signAgentAssetUrl } from '../lib/asset-urls';
 import { broadcastProjectUpdate, broadcastRowChange } from '../lib/broadcast';
+import { withProjectGitLock } from '../lib/git-lock';
 import { withTransaction } from '../lib/sql';
 import { logger } from '../logger';
 import { signAgentJwt } from '../middleware/auth';
@@ -1305,23 +1306,6 @@ export function shellQuoteArg(arg: string): string {
 	if (arg === '') return "''";
 	if (/^[A-Za-z0-9_\-./=:@%+,]+$/.test(arg)) return arg;
 	return `'${arg.replace(/'/g, `'\\''`)}'`;
-}
-
-// Serializes git operations that mutate a repo's shared .git store (clone,
-// fetch, worktree add) per project. Concurrent runs on the same project work in
-// separate per-task worktrees but share one .git per repo, so these brief setup
-// steps must not overlap or they race on git's index/ref locks. Keyed by
-// project id, so different projects never block one another.
-const projectGitLocks = new Map<string, Promise<unknown>>();
-function withProjectGitLock<T>(projectId: string, fn: () => Promise<T>): Promise<T> {
-	const prev = projectGitLocks.get(projectId) ?? Promise.resolve();
-	const run = prev.then(() => fn());
-	const tail = run.catch(() => {});
-	projectGitLocks.set(projectId, tail);
-	void tail.then(() => {
-		if (projectGitLocks.get(projectId) === tail) projectGitLocks.delete(projectId);
-	});
-	return run;
 }
 
 interface WorktreeRef {

--- a/packages/server/src/services/git.ts
+++ b/packages/server/src/services/git.ts
@@ -412,12 +412,21 @@ export async function createWorktree(
 	return { success: true };
 }
 
-interface WorktreeListEntry {
+export interface WorktreeListEntry {
 	path: string;
 	branch?: string;
 }
 
-async function listWorktrees(executor: GitExecutor, repo: RepoLoc): Promise<WorktreeListEntry[]> {
+/**
+ * Parses `git worktree list --porcelain` into `{ path, branch? }` entries. The
+ * main worktree (the clone itself) is always index 0; linked task worktrees
+ * follow. `branch` is the full ref (`refs/heads/<name>`) or absent when the
+ * worktree is detached.
+ */
+export async function listWorktrees(
+	executor: GitExecutor,
+	repo: RepoLoc,
+): Promise<WorktreeListEntry[]> {
 	const res = await executor.exec(['worktree', 'list', '--porcelain'], {
 		cwd: repo.containerPath,
 		timeout: 30_000,
@@ -668,6 +677,153 @@ export async function worktreeHasChanges(
 	if (status.exitCode === 0 && status.stdout.trim().length > 0) return true;
 	const headAfter = await getWorktreeHead(executor, wt);
 	return headAfter !== null && headBefore !== null && headAfter !== headBefore;
+}
+
+/**
+ * A clone's local git state for the admin git-state panel. Read **without
+ * touching the network**: `ahead`/`behind` compare HEAD against the last-fetched
+ * `origin/<default>` tracking ref, so they reflect the most recent `git fetch`,
+ * not live origin. `cloned:false` means the on-disk clone has no `.git` yet (repo
+ * setup still pending or failed).
+ */
+export interface CloneState {
+	cloned: boolean;
+	defaultBranch: string | null;
+	headBranch: string | null;
+	head: string | null;
+	dirty: boolean;
+	ahead: number | null;
+	behind: number | null;
+}
+
+export async function getCloneState(executor: GitExecutor, repo: RepoLoc): Promise<CloneState> {
+	if (!existsSync(join(repo.hostPath, '.git'))) {
+		return {
+			cloned: false,
+			defaultBranch: null,
+			headBranch: null,
+			head: null,
+			dirty: false,
+			ahead: null,
+			behind: null,
+		};
+	}
+	const cwd = repo.containerPath;
+	const defaultBranch = await getRemoteDefaultBranch(executor, repo);
+
+	const headBranchRes = await executor.exec(['symbolic-ref', '--quiet', '--short', 'HEAD'], {
+		cwd,
+		timeout: 10_000,
+	});
+	const headBranch = headBranchRes.exitCode === 0 ? headBranchRes.stdout.trim() || null : null;
+
+	const headRes = await executor.exec(['rev-parse', '--verify', '--quiet', 'HEAD'], {
+		cwd,
+		timeout: 10_000,
+	});
+	const head = headRes.exitCode === 0 ? headRes.stdout.trim() || null : null;
+
+	const statusRes = await executor.exec(['status', '--porcelain'], { cwd, timeout: 10_000 });
+	const dirty = statusRes.exitCode === 0 && statusRes.stdout.trim().length > 0;
+
+	let ahead: number | null = null;
+	let behind: number | null = null;
+	if (defaultBranch && head) {
+		const remoteRef = `refs/remotes/origin/${defaultBranch}`;
+		const remoteExists = await executor.exec(['rev-parse', '--verify', '--quiet', remoteRef], {
+			cwd,
+			timeout: 10_000,
+		});
+		if (remoteExists.exitCode === 0) {
+			// left = commits only on origin/<def> (behind), right = only on HEAD (ahead).
+			const counts = await executor.exec(
+				['rev-list', '--left-right', '--count', `${remoteRef}...HEAD`],
+				{ cwd, timeout: 10_000 },
+			);
+			if (counts.exitCode === 0) {
+				const [left, right] = counts.stdout.trim().split(/\s+/);
+				const b = Number.parseInt(left ?? '', 10);
+				const a = Number.parseInt(right ?? '', 10);
+				behind = Number.isNaN(b) ? null : b;
+				ahead = Number.isNaN(a) ? null : a;
+			}
+		}
+	}
+
+	return { cloned: true, defaultBranch, headBranch, head, dirty, ahead, behind };
+}
+
+/**
+ * A task worktree's live state for the git-state panel: its current commit and
+ * whether it has uncommitted/untracked changes. `worktreeHasChanges(…, null)`
+ * reduces to "`git status --porcelain` non-empty".
+ */
+export async function getWorktreeState(
+	executor: GitExecutor,
+	wt: WorktreeLoc,
+): Promise<{ head: string | null; dirty: boolean }> {
+	const head = await getWorktreeHead(executor, wt);
+	const dirty = await worktreeHasChanges(executor, wt, null);
+	return { head, dirty };
+}
+
+/**
+ * Recovers a wedged clone to a syncable state: discards all uncommitted and
+ * untracked changes and puts the local default branch back on the (last-fetched)
+ * remote tip. This is the escape hatch for the "could not fast-forward <default>:
+ * your local changes would be overwritten" state that silently stops periodic
+ * sync. A best-effort `git fetch` runs first so the reset lands on the latest
+ * origin; a fetch failure is non-fatal (returned as `warning`) so a transient
+ * network fault never blocks local recovery. Untracked files are removed with
+ * `clean -fd` — no `-x`, so gitignored build artifacts (e.g. `node_modules`) are
+ * kept and the next run needn't rebuild them. Committed work already pushed to
+ * the remote is unaffected.
+ */
+export async function resetCloneToOrigin(
+	executor: GitExecutor,
+	repo: RepoLoc,
+): Promise<{ success: boolean; error?: string; warning?: string }> {
+	const cwd = repo.containerPath;
+
+	let warning: string | undefined;
+	const fetched = await fetchRepo(executor, repo);
+	if (!fetched.success) {
+		warning = `fetch failed, reset to last-known origin: ${fetched.error ?? 'unknown error'}`;
+	}
+
+	const def = await getRemoteDefaultBranch(executor, repo);
+	if (!def) {
+		return { success: false, error: 'no default branch resolved (empty remote?)', warning };
+	}
+
+	// getRemoteDefaultBranch only returns a name whose origin tracking ref exists,
+	// so this normally resolves; fall back to the local branch defensively.
+	const remoteRef = `refs/remotes/origin/${def}`;
+	const remoteExists = await executor.exec(['rev-parse', '--verify', '--quiet', remoteRef], {
+		cwd,
+		timeout: 10_000,
+	});
+	const target = remoteExists.exitCode === 0 ? remoteRef : def;
+
+	// Force onto the default branch: reattaches a detached HEAD and abandons any
+	// unrelated branch a human may have left checked out in the clone. `-f`
+	// discards conflicting working-tree changes so the switch can't be blocked.
+	const checkout = await executor.exec(['checkout', '-f', def], { cwd, timeout: 30_000 });
+	if (checkout.exitCode !== 0) {
+		return { success: false, error: formatGitError(checkout.stderr), warning };
+	}
+
+	const reset = await executor.exec(['reset', '--hard', target], { cwd, timeout: 30_000 });
+	if (reset.exitCode !== 0) {
+		return { success: false, error: formatGitError(reset.stderr), warning };
+	}
+
+	const clean = await executor.exec(['clean', '-fd'], { cwd, timeout: 30_000 });
+	if (clean.exitCode !== 0) {
+		return { success: false, error: formatGitError(clean.stderr), warning };
+	}
+
+	return { success: true, warning };
 }
 
 /**

--- a/packages/server/test/git-clone-state.test.ts
+++ b/packages/server/test/git-clone-state.test.ts
@@ -1,0 +1,210 @@
+import { execSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+	createWorktree,
+	getCloneState,
+	getWorktreeState,
+	listWorktrees,
+	type RepoLoc,
+	resetCloneToOrigin,
+	type WorktreeLoc,
+} from '../src/services/git';
+import { HostGitExecutor } from '../src/services/git-executor';
+
+const root = mkdtempSync(join(tmpdir(), 'git-clone-state-'));
+const exec = new HostGitExecutor();
+const repoLoc = (p: string): RepoLoc => ({ hostPath: p, containerPath: p });
+const wtLoc = (p: string): WorktreeLoc => ({ hostPath: p, containerPath: p });
+
+function run(cmd: string, cwd?: string) {
+	execSync(cmd, { cwd, stdio: 'pipe' });
+}
+
+function configure(dir: string) {
+	run('git config user.name Test', dir);
+	run('git config user.email test@test.com', dir);
+	run('git config commit.gpgsign false', dir);
+}
+
+let bare: string;
+let clone: string;
+
+beforeAll(() => {
+	bare = join(root, 'bare.git');
+	clone = join(root, 'clone');
+	run(`git init --bare -b main ${bare}`);
+	run(`git clone ${bare} ${clone}`);
+	configure(clone);
+	writeFileSync(join(clone, 'README.md'), '# hi');
+	run('git add .', clone);
+	run('git commit -m init', clone);
+	run('git push', clone);
+});
+
+afterAll(() => {
+	rmSync(root, { recursive: true, force: true });
+});
+
+describe('getCloneState', () => {
+	it('reports a clean, up-to-date clone', async () => {
+		const state = await getCloneState(exec, repoLoc(clone));
+		expect(state.cloned).toBe(true);
+		expect(state.defaultBranch).toBe('main');
+		expect(state.headBranch).toBe('main');
+		expect(state.head).toMatch(/^[0-9a-f]{40}$/);
+		expect(state.head).toBe(execSync('git rev-parse HEAD', { cwd: clone }).toString().trim());
+		expect(state.dirty).toBe(false);
+		expect(state.ahead).toBe(0);
+		expect(state.behind).toBe(0);
+	});
+
+	it('reports cloned:false when the directory has no .git', async () => {
+		const state = await getCloneState(exec, repoLoc(join(root, 'does-not-exist')));
+		expect(state).toEqual({
+			cloned: false,
+			defaultBranch: null,
+			headBranch: null,
+			head: null,
+			dirty: false,
+			ahead: null,
+			behind: null,
+		});
+	});
+
+	it('detects an untracked change as dirty', async () => {
+		const dir = join(root, 'dirty');
+		run(`git clone ${bare} ${dir}`);
+		writeFileSync(join(dir, 'scratch.txt'), 'wip');
+		const state = await getCloneState(exec, repoLoc(dir));
+		expect(state.dirty).toBe(true);
+	});
+
+	it('counts a local unpushed commit as ahead', async () => {
+		const dir = join(root, 'ahead');
+		run(`git clone ${bare} ${dir}`);
+		configure(dir);
+		writeFileSync(join(dir, 'a.txt'), 'a');
+		run('git add .', dir);
+		run('git commit -m local', dir);
+		const state = await getCloneState(exec, repoLoc(dir));
+		expect(state.ahead).toBe(1);
+		expect(state.behind).toBe(0);
+	});
+
+	it('counts fetched-but-unmerged origin commits as behind', async () => {
+		// Clone the "behind" repo at the current tip FIRST, then advance the remote
+		// from a second clone, then fetch (no merge) so local main lags origin/main.
+		const dir = join(root, 'behind');
+		run(`git clone ${bare} ${dir}`);
+
+		const pusher = join(root, 'pusher');
+		run(`git clone ${bare} ${pusher}`);
+		configure(pusher);
+		writeFileSync(join(pusher, 'b.txt'), 'b');
+		run('git add .', pusher);
+		run('git commit -m remote-advance', pusher);
+		run('git push', pusher);
+
+		run('git fetch origin', dir);
+		const state = await getCloneState(exec, repoLoc(dir));
+		expect(state.behind).toBe(1);
+		expect(state.ahead).toBe(0);
+	});
+
+	it('handles a repository with no commits (unborn HEAD, empty remote)', async () => {
+		const emptyBare = join(root, 'empty.git');
+		const emptyClone = join(root, 'empty-clone');
+		run(`git init --bare ${emptyBare}`);
+		run(`git clone ${emptyBare} ${emptyClone}`);
+		const state = await getCloneState(exec, repoLoc(emptyClone));
+		expect(state.cloned).toBe(true);
+		expect(state.head).toBeNull();
+		expect(state.defaultBranch).toBeNull();
+		expect(state.ahead).toBeNull();
+		expect(state.behind).toBeNull();
+	});
+});
+
+describe('resetCloneToOrigin', () => {
+	it('discards tracked edits and untracked files, realigning to origin', async () => {
+		const dir = join(root, 'reset');
+		run(`git clone ${bare} ${dir}`);
+		configure(dir);
+		writeFileSync(join(dir, 'README.md'), '# tampered'); // tracked edit
+		writeFileSync(join(dir, 'junk.txt'), 'junk'); // untracked file
+		const before = await getCloneState(exec, repoLoc(dir));
+		expect(before.dirty).toBe(true);
+
+		const result = await resetCloneToOrigin(exec, repoLoc(dir));
+		expect(result.success).toBe(true);
+
+		const status = execSync('git status --porcelain', { cwd: dir }).toString().trim();
+		expect(status).toBe('');
+		expect(execSync('cat README.md', { cwd: dir }).toString()).toBe('# hi');
+		const head = execSync('git rev-parse HEAD', { cwd: dir }).toString().trim();
+		const originMain = execSync('git rev-parse origin/main', { cwd: dir }).toString().trim();
+		expect(head).toBe(originMain);
+	});
+
+	it('resets a local divergent commit back to the origin tip', async () => {
+		const dir = join(root, 'reset-diverged');
+		run(`git clone ${bare} ${dir}`);
+		configure(dir);
+		writeFileSync(join(dir, 'c.txt'), 'c');
+		run('git add .', dir);
+		run('git commit -m diverge', dir);
+		const originMain = execSync('git rev-parse origin/main', { cwd: dir }).toString().trim();
+
+		const result = await resetCloneToOrigin(exec, repoLoc(dir));
+		expect(result.success).toBe(true);
+		expect(execSync('git rev-parse HEAD', { cwd: dir }).toString().trim()).toBe(originMain);
+	});
+
+	it('fails gracefully on a repository with no commits', async () => {
+		const emptyBare = join(root, 'empty-reset.git');
+		const emptyClone = join(root, 'empty-reset-clone');
+		run(`git init --bare ${emptyBare}`);
+		run(`git clone ${emptyBare} ${emptyClone}`);
+		const result = await resetCloneToOrigin(exec, repoLoc(emptyClone));
+		expect(result.success).toBe(false);
+		expect(result.error).toBeTruthy();
+	});
+});
+
+describe('listWorktrees (exported)', () => {
+	it('lists the main worktree plus a linked task worktree', async () => {
+		const dir = join(root, 'wt-clone');
+		const worktree = join(root, 'wt-linked');
+		run(`git clone ${bare} ${dir}`);
+		configure(dir);
+		const created = await createWorktree(exec, repoLoc(dir), wtLoc(worktree), 'hezo/HM-1');
+		expect(created.success).toBe(true);
+
+		const entries = await listWorktrees(exec, repoLoc(dir));
+		expect(entries.length).toBe(2);
+		expect(entries[0].path).toBe(dir); // main worktree first
+		const linked = entries.find((e) => e.path === worktree);
+		expect(linked?.branch).toBe('refs/heads/hezo/HM-1');
+	});
+});
+
+describe('getWorktreeState', () => {
+	it('reports clean then dirty for a worktree', async () => {
+		const dir = join(root, 'wt-state-clone');
+		const worktree = join(root, 'wt-state-linked');
+		run(`git clone ${bare} ${dir}`);
+		configure(dir);
+		await createWorktree(exec, repoLoc(dir), wtLoc(worktree), 'hezo/HM-2');
+
+		const clean = await getWorktreeState(exec, wtLoc(worktree));
+		expect(clean.dirty).toBe(false);
+		expect(clean.head).toMatch(/^[0-9a-f]{40}$/);
+
+		writeFileSync(join(worktree, 'wip.txt'), 'wip');
+		const dirty = await getWorktreeState(exec, wtLoc(worktree));
+		expect(dirty.dirty).toBe(true);
+	});
+});

--- a/packages/server/test/repos-git-state.test.ts
+++ b/packages/server/test/repos-git-state.test.ts
@@ -1,0 +1,139 @@
+import { CAPTAIN_AGENT_SLUG } from '@hezo/shared';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+	authHeader,
+	createAgentRun,
+	createTestProject,
+	createTestTeam,
+	finalizeAgentRun,
+	mintAgentToken,
+} from './helpers/app';
+import { createTestContext, destroyTestContext, type ServerTestContext } from './helpers/context';
+
+// Route control-flow tests for the admin git-state + reset endpoints. Real git
+// output requires a running container (Docker), which the test harness fakes, so
+// these assert auth/validation/guards — not git behaviour (see
+// git-clone-state.test.ts for the git helpers exercised against real git).
+
+let ctx: ServerTestContext;
+let teamId: string;
+let projectSlug: string;
+let projectId: string;
+let planningTaskId: string;
+let captainId: string;
+let repoId: string;
+
+beforeAll(async () => {
+	ctx = await createTestContext();
+	const team = (await (await createTestTeam(ctx.db, { name: 'Repo QA' })).json()).data;
+	teamId = team.id;
+	const project = (await (await createTestProject(ctx.db, teamId, { name: 'Website' })).json())
+		.data;
+	projectSlug = project.slug;
+	projectId = project.id;
+	planningTaskId = project.planning_task_id;
+
+	const captain = await ctx.db.query<{ id: string }>(
+		`SELECT ma.id FROM member_agents ma JOIN members m ON m.id = ma.id
+		 WHERE m.team_id = $1 AND ma.slug = $2 LIMIT 1`,
+		[teamId, CAPTAIN_AGENT_SLUG],
+	);
+	captainId = captain.rows[0].id;
+
+	const repo = await ctx.db.query<{ id: string }>(
+		`INSERT INTO repos (project_id, repo_identifier, host_type, setup_status)
+		 VALUES ($1, 'acme/website', 'github'::repo_host_type, 'ready'::repo_setup_status)
+		 RETURNING id`,
+		[projectId],
+	);
+	repoId = repo.rows[0].id;
+});
+
+afterAll(() => destroyTestContext(ctx));
+
+const gitStateUrl = () => `${ctx.baseUrl}/api/projects/${projectSlug}/repos/${repoId}/git-state`;
+const resetUrl = () => `${ctx.baseUrl}/api/projects/${projectSlug}/repos/${repoId}/reset`;
+
+describe('GET /repos/:repoId/git-state', () => {
+	it('rejects a non-superuser (team-member agent) with 403', async () => {
+		// A team-member agent passes project-access middleware and reaches the
+		// in-handler requireSuperuser gate — so a 403 here proves that gate, not membership.
+		const { token, runId } = await mintAgentToken(
+			ctx.db,
+			ctx.masterKeyManager,
+			captainId,
+			teamId,
+			planningTaskId,
+		);
+		const res = await fetch(gitStateUrl(), { headers: authHeader(token) });
+		expect(res.status).toBe(403);
+		await finalizeAgentRun(ctx.db, runId);
+	});
+
+	it('reports container_running:false when the project has no running container', async () => {
+		const res = await fetch(gitStateUrl(), { headers: authHeader(ctx.token) });
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { data: { container_running: boolean } };
+		expect(body.data.container_running).toBe(false);
+	});
+
+	it('404s for a repo that is not on the project', async () => {
+		const url = `${ctx.baseUrl}/api/projects/${projectSlug}/repos/00000000-0000-0000-0000-000000000000/git-state`;
+		const res = await fetch(url, { headers: authHeader(ctx.token) });
+		expect(res.status).toBe(404);
+	});
+});
+
+describe('POST /repos/:repoId/reset', () => {
+	it('rejects a non-superuser (team-member agent) with 403', async () => {
+		const { token, runId } = await mintAgentToken(
+			ctx.db,
+			ctx.masterKeyManager,
+			captainId,
+			teamId,
+			planningTaskId,
+		);
+		const res = await fetch(resetUrl(), {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ action: 'discard_local' }),
+		});
+		expect(res.status).toBe(403);
+		await finalizeAgentRun(ctx.db, runId);
+	});
+
+	it('rejects an unknown action with 400', async () => {
+		const res = await fetch(resetUrl(), {
+			method: 'POST',
+			headers: { ...authHeader(ctx.token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ action: 'nuke_everything' }),
+		});
+		expect(res.status).toBe(400);
+		const body = (await res.json()) as { error: { code: string } };
+		expect(body.error.code).toBe('INVALID_REQUEST');
+	});
+
+	it('blocks reset with 409 while an agent run is active on the project', async () => {
+		const runId = await createAgentRun(ctx.db, captainId, teamId, planningTaskId);
+		const res = await fetch(resetUrl(), {
+			method: 'POST',
+			headers: { ...authHeader(ctx.token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ action: 'discard_local' }),
+		});
+		expect(res.status).toBe(409);
+		const body = (await res.json()) as { error: { code: string } };
+		expect(body.error.code).toBe('RUN_IN_PROGRESS');
+		await finalizeAgentRun(ctx.db, runId);
+	});
+
+	it('blocks discard_local with 409 when the container is not running', async () => {
+		const res = await fetch(resetUrl(), {
+			method: 'POST',
+			headers: { ...authHeader(ctx.token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ action: 'discard_local' }),
+		});
+		expect(res.status).toBe(409);
+		const body = (await res.json()) as { error: { code: string } };
+		expect(body.error.code).toBe('CONTAINER_NOT_RUNNING');
+	});
+});

--- a/packages/web/src/components/github-section.tsx
+++ b/packages/web/src/components/github-section.tsx
@@ -1,8 +1,19 @@
 import { repoNameFromIdentifier } from '@hezo/shared';
 import { useQueryClient } from '@tanstack/react-query';
-import { AlertTriangle, GitBranch, Github, Loader2, Lock, RotateCw, Trash2 } from 'lucide-react';
+import {
+	AlertTriangle,
+	ChevronDown,
+	ChevronRight,
+	GitBranch,
+	Github,
+	Loader2,
+	Lock,
+	RotateCw,
+	Trash2,
+} from 'lucide-react';
 import { useState } from 'react';
 import { useMcpConnections } from '../hooks/use-mcp-connections';
+import { useMe } from '../hooks/use-me';
 import {
 	useConnectionScopeStatus,
 	useDeleteOAuthConnection,
@@ -13,6 +24,7 @@ import { useCreateRepo, useDeleteRepo, useRepos } from '../hooks/use-repos';
 import { repoWebUrl } from '../lib/github';
 import { queryKeys } from '../lib/query-keys';
 import { ConnectorDeviceFlowDialog } from './connector-device-flow-dialog';
+import { RepoGitStatePanel } from './repo-git-state-panel';
 import { RepoPickerModal } from './repo-picker-modal';
 import { Badge } from './ui/badge';
 import { Button } from './ui/button';
@@ -36,9 +48,20 @@ export function GitHubSection({ projectId }: GitHubSectionProps) {
 	const scopeStatusQuery = useConnectionScopeStatus(projectId, githubConnection?.id);
 
 	const ensure = useEnsureConnector(projectId);
+	const { data: me } = useMe();
+	const isSuperuser = me?.is_superuser === true;
 	const [pickerOpen, setPickerOpen] = useState(false);
 	const [deviceConnectorId, setDeviceConnectorId] = useState<string | null>(null);
 	const [error, setError] = useState<string | null>(null);
+	const [expandedRepos, setExpandedRepos] = useState<Set<string>>(new Set());
+
+	const toggleRepoExpanded = (repoId: string) =>
+		setExpandedRepos((prev) => {
+			const next = new Set(prev);
+			if (next.has(repoId)) next.delete(repoId);
+			else next.add(repoId);
+			return next;
+		});
 
 	const isReady = !!githubConnection && scopeStatusQuery.data?.sufficient === true;
 	const needsReauth =
@@ -196,6 +219,7 @@ export function GitHubSection({ projectId }: GitHubSectionProps) {
 					<div className="flex flex-col gap-2">
 						{repos?.map((r) => {
 							const repoName = repoNameFromIdentifier(r.repo_identifier);
+							const isExpanded = expandedRepos.has(r.id);
 							return (
 								<div
 									key={r.id}
@@ -203,6 +227,22 @@ export function GitHubSection({ projectId }: GitHubSectionProps) {
 								>
 									<div className="flex items-center justify-between">
 										<div className="flex flex-wrap items-center gap-2">
+											{isSuperuser && (
+												<button
+													type="button"
+													onClick={() => toggleRepoExpanded(r.id)}
+													className="-ml-1 text-text-3 hover:text-text-1"
+													aria-label={`${isExpanded ? 'Hide' : 'Show'} git state for ${repoName}`}
+													aria-expanded={isExpanded}
+													data-testid={`repo-git-toggle-${repoName}`}
+												>
+													{isExpanded ? (
+														<ChevronDown className="size-3.5" />
+													) : (
+														<ChevronRight className="size-3.5" />
+													)}
+												</button>
+											)}
 											<Badge color="gray">{r.host_type}</Badge>
 											<span className="font-medium">{repoName}</span>
 											{(() => {
@@ -281,6 +321,9 @@ export function GitHubSection({ projectId }: GitHubSectionProps) {
 											Setup failed{r.setup_error ? `: ${r.setup_error}` : ''}. Retry to run it
 											again.
 										</p>
+									)}
+									{isExpanded && (
+										<RepoGitStatePanel projectId={projectId} repoId={r.id} repoName={repoName} />
 									)}
 								</div>
 							);

--- a/packages/web/src/components/repo-git-state-panel.tsx
+++ b/packages/web/src/components/repo-git-state-panel.tsx
@@ -1,0 +1,278 @@
+import { Link } from '@tanstack/react-router';
+import { AlertTriangle, ArrowDown, ArrowUp, GitBranch, Loader2, RefreshCw } from 'lucide-react';
+import { useState } from 'react';
+import { useMe } from '../hooks/use-me';
+import {
+	type CloneState,
+	type GitWorktree,
+	type ResetAction,
+	useRepoGitState,
+	useResetRepo,
+} from '../hooks/use-repo-git-state';
+import { toast } from '../hooks/use-toast';
+import { Badge } from './ui/badge';
+import { Button } from './ui/button';
+import { ConfirmDialog } from './ui/confirm-dialog';
+import { Tooltip } from './ui/tooltip';
+
+interface RepoGitStatePanelProps {
+	projectId: string;
+	repoId: string;
+	repoName: string;
+}
+
+const RESET_DIALOGS: Record<
+	ResetAction,
+	{ title: string; description: string; confirmLabel: string }
+> = {
+	discard_local: {
+		title: 'Discard local changes?',
+		description:
+			'Discards all uncommitted and untracked changes in the repository clone and resets its default branch to origin. Committed work already pushed to GitHub is unaffected.',
+		confirmLabel: 'Discard changes',
+	},
+	prune_worktrees: {
+		title: 'Prune stale worktrees?',
+		description:
+			'Removes leftover per-task worktrees from crashed or interrupted runs and prunes worktree references. Committed work on their branches is preserved.',
+		confirmLabel: 'Prune worktrees',
+	},
+	reclone: {
+		title: 'Re-clone this repository?',
+		description:
+			'Deletes the on-disk clone entirely and re-clones it fresh from GitHub. All local-only state is discarded. Use this only to recover from deep corruption.',
+		confirmLabel: 'Re-clone',
+	},
+};
+
+/**
+ * Superuser-only live git state for one repository: the clone's branch / HEAD /
+ * dirty / ahead-behind, its active task worktrees, and the recovery actions
+ * (discard local changes, prune worktrees, re-clone). Rendered when a repo row is
+ * expanded; the state query runs lazily on mount.
+ */
+export function RepoGitStatePanel({ projectId, repoId, repoName }: RepoGitStatePanelProps) {
+	const { data, isLoading, isError, refetch, isFetching } = useRepoGitState(
+		projectId,
+		repoId,
+		true,
+	);
+	const resetRepo = useResetRepo(projectId, repoId);
+	const { data: me } = useMe();
+	const isSuperuser = me?.is_superuser === true;
+	const [dialog, setDialog] = useState<ResetAction | null>(null);
+
+	const runReset = async (action: ResetAction) => {
+		try {
+			await resetRepo.mutateAsync(action);
+		} catch (e) {
+			toast.error(e instanceof Error ? e.message : 'Reset failed');
+		}
+	};
+
+	return (
+		<div
+			className="mt-2 flex flex-col gap-3 border-t border-border-subtle pt-2"
+			data-testid={`repo-git-state-${repoName}`}
+		>
+			<div className="flex items-center justify-between">
+				<span className="text-xs font-medium text-text-2">Git state</span>
+				<Button
+					variant="ghost"
+					size="sm"
+					onClick={() => refetch()}
+					disabled={isFetching}
+					data-testid={`repo-git-refresh-${repoName}`}
+				>
+					{isFetching ? (
+						<Loader2 className="size-3 animate-spin" />
+					) : (
+						<RefreshCw className="size-3" />
+					)}
+					Refresh
+				</Button>
+			</div>
+
+			{isLoading ? (
+				<div className="flex items-center gap-2 text-xs text-text-2">
+					<Loader2 className="size-3.5 animate-spin" /> Loading git state…
+				</div>
+			) : isError ? (
+				<p className="text-xs text-danger-soft-fg">Failed to load git state.</p>
+			) : data?.container_running === false ? (
+				<div
+					className="rounded-md border border-border bg-surface-2 p-3 text-xs text-text-2"
+					data-testid={`repo-git-container-stopped-${repoName}`}
+				>
+					Container is stopped —{' '}
+					<Link
+						to="/projects/$projectId/container"
+						params={{ projectId }}
+						className="text-info-soft-fg hover:underline"
+					>
+						start it
+					</Link>{' '}
+					to inspect git state.
+				</div>
+			) : data?.container_running === true ? (
+				<>
+					<CloneSummary clone={data.clone} />
+					<Worktrees projectId={projectId} worktrees={data.worktrees} />
+					{isSuperuser && (
+						<div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap">
+							<ResetActionButton
+								action="discard_local"
+								label="Discard local changes"
+								repoName={repoName}
+								disabled={resetRepo.isPending || !data.clone.cloned || !data.clone.defaultBranch}
+								disabledReason={
+									!data.clone.cloned
+										? 'Repository is not cloned yet'
+										: !data.clone.defaultBranch
+											? 'No default branch to reset to (empty repository)'
+											: undefined
+								}
+								onClick={() => setDialog('discard_local')}
+							/>
+							<ResetActionButton
+								action="prune_worktrees"
+								label="Prune worktrees"
+								repoName={repoName}
+								disabled={resetRepo.isPending}
+								onClick={() => setDialog('prune_worktrees')}
+							/>
+							<ResetActionButton
+								action="reclone"
+								label="Re-clone"
+								repoName={repoName}
+								disabled={resetRepo.isPending}
+								onClick={() => setDialog('reclone')}
+							/>
+						</div>
+					)}
+				</>
+			) : null}
+
+			{dialog && (
+				<ConfirmDialog
+					open={true}
+					onOpenChange={(o) => {
+						if (!o) setDialog(null);
+					}}
+					title={RESET_DIALOGS[dialog].title}
+					description={RESET_DIALOGS[dialog].description}
+					confirmLabel={RESET_DIALOGS[dialog].confirmLabel}
+					variant="danger"
+					loading={resetRepo.isPending}
+					onConfirm={async () => {
+						await runReset(dialog);
+					}}
+				/>
+			)}
+		</div>
+	);
+}
+
+function CloneSummary({ clone }: { clone: CloneState }) {
+	if (!clone.cloned) {
+		return <p className="text-xs text-text-3">Repository is not cloned yet.</p>;
+	}
+	const showDivergence = (clone.ahead ?? 0) > 0 || (clone.behind ?? 0) > 0;
+	return (
+		<div
+			className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs"
+			data-testid="repo-clone-summary"
+		>
+			<span className="text-text-3">Clone</span>
+			<Badge color="neutral" mono>
+				<GitBranch className="size-3" />
+				{clone.headBranch ?? clone.defaultBranch ?? 'detached'}
+			</Badge>
+			{clone.head === null ? (
+				<Badge color="warning">No commits yet</Badge>
+			) : (
+				<>
+					<span className="font-mono text-text-2">{clone.head.slice(0, 7)}</span>
+					{clone.dirty ? (
+						<Badge color="warning">
+							<AlertTriangle className="size-3" /> Uncommitted changes
+						</Badge>
+					) : (
+						<Badge color="success">Clean</Badge>
+					)}
+					{showDivergence && (
+						<Tooltip content="Relative to the last fetch from origin">
+							<span className="inline-flex items-center gap-1.5 font-mono tabular-nums text-text-2">
+								<span className="inline-flex items-center gap-0.5">
+									<ArrowUp className="size-3" />
+									{clone.ahead ?? 0}
+								</span>
+								<span className="inline-flex items-center gap-0.5">
+									<ArrowDown className="size-3" />
+									{clone.behind ?? 0}
+								</span>
+							</span>
+						</Tooltip>
+					)}
+				</>
+			)}
+		</div>
+	);
+}
+
+function Worktrees({ projectId, worktrees }: { projectId: string; worktrees: GitWorktree[] }) {
+	if (worktrees.length === 0) {
+		return <p className="text-xs text-text-3">No active task worktrees.</p>;
+	}
+	return (
+		<div className="flex flex-col gap-1" data-testid="repo-worktrees">
+			<span className="text-xs text-text-3">Worktrees ({worktrees.length})</span>
+			{worktrees.map((w) => (
+				<div key={w.taskIdentifier} className="flex flex-wrap items-center gap-2 text-xs">
+					<Link
+						to="/projects/$projectId/tasks/$taskId"
+						params={{ projectId, taskId: w.taskIdentifier.toLowerCase() }}
+						className="font-mono text-info-soft-fg hover:underline"
+					>
+						{w.taskIdentifier}
+					</Link>
+					{w.branch && <span className="font-mono text-text-3">{w.branch}</span>}
+					<Badge color={w.dirty ? 'warning' : 'success'}>{w.dirty ? 'dirty' : 'clean'}</Badge>
+					{w.task && <span className="max-w-[12rem] truncate text-text-2">{w.task.title}</span>}
+				</div>
+			))}
+		</div>
+	);
+}
+
+function ResetActionButton({
+	action,
+	label,
+	repoName,
+	disabled,
+	disabledReason,
+	onClick,
+}: {
+	action: ResetAction;
+	label: string;
+	repoName: string;
+	disabled: boolean;
+	disabledReason?: string;
+	onClick: () => void;
+}) {
+	const button = (
+		<Button
+			variant="secondary"
+			size="sm"
+			disabled={disabled}
+			onClick={onClick}
+			data-testid={`repo-reset-${action}-${repoName}`}
+		>
+			{label}
+		</Button>
+	);
+	if (disabled && disabledReason) {
+		return <Tooltip content={disabledReason}>{button}</Tooltip>;
+	}
+	return button;
+}

--- a/packages/web/src/hooks/use-repo-git-state.ts
+++ b/packages/web/src/hooks/use-repo-git-state.ts
@@ -1,0 +1,61 @@
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { api } from '../lib/api';
+import { queryClient } from '../lib/query-client';
+import { queryKeys } from '../lib/query-keys';
+
+/** Local git state of a repository clone (read live from the project container). */
+export interface CloneState {
+	cloned: boolean;
+	/** Remote default branch (origin/HEAD → main/master), the branch sync fast-forwards. */
+	defaultBranch: string | null;
+	/** Currently checked-out branch in the clone (null if detached). */
+	headBranch: string | null;
+	/** HEAD commit sha, or null for an unborn HEAD (repo with no commits). */
+	head: string | null;
+	dirty: boolean;
+	/** Commits on HEAD not on origin/<default>; null when it can't be computed. */
+	ahead: number | null;
+	/** Commits on origin/<default> not on HEAD (reflects the last fetch). */
+	behind: number | null;
+}
+
+export interface GitWorktree {
+	taskIdentifier: string;
+	branch: string | null;
+	head: string | null;
+	dirty: boolean;
+	task: { title: string; status: string } | null;
+}
+
+export type RepoGitState =
+	| { container_running: false }
+	| { container_running: true; clone: CloneState; worktrees: GitWorktree[] };
+
+export type ResetAction = 'discard_local' | 'prune_worktrees' | 'reclone';
+
+/**
+ * Live git state for one repository. Lazy: pass `enabled` so the query (which does
+ * live docker execs in the container) fires only when the panel is expanded.
+ */
+export function useRepoGitState(projectId: string, repoId: string, enabled: boolean) {
+	return useQuery({
+		queryKey: queryKeys.projects.gitState(projectId, repoId),
+		queryFn: () => api.get<RepoGitState>(`/api/projects/${projectId}/repos/${repoId}/git-state`),
+		enabled,
+	});
+}
+
+export function useResetRepo(projectId: string, repoId: string) {
+	return useMutation({
+		mutationFn: (action: ResetAction) =>
+			api.post<{ reset: true; action: ResetAction; warning?: string | null }>(
+				`/api/projects/${projectId}/repos/${repoId}/reset`,
+				{ action },
+			),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: queryKeys.projects.gitState(projectId, repoId) });
+			queryClient.invalidateQueries({ queryKey: queryKeys.projects.repos(projectId) });
+			queryClient.invalidateQueries({ queryKey: queryKeys.projects.detail(projectId) });
+		},
+	});
+}

--- a/packages/web/src/lib/query-keys.ts
+++ b/packages/web/src/lib/query-keys.ts
@@ -197,6 +197,7 @@ export const queryKeys = {
 		secrets: (slug: string) => ['projects', slug, 'secrets'],
 		credentials: (slug: string) => ['projects', slug, 'credentials'],
 		repos: (slug: string) => ['projects', slug, 'repos'],
+		gitState: (slug: string, repoId: string) => ['projects', slug, 'repos', repoId, 'git-state'],
 		mcpConnections: (slug: string) => ['projects', slug, 'mcp-connections'],
 		mcpConnectionsFiltered: (slug: string, filterProjectId: string | null) => [
 			'projects',

--- a/packages/web/test/repo-git-state.test.tsx
+++ b/packages/web/test/repo-git-state.test.tsx
@@ -1,0 +1,74 @@
+import { expect, test } from 'vitest';
+import { getTestContext, renderApp } from './helpers/render';
+import { seedProject, seedWorkspace } from './helpers/seed';
+
+// Component-tier coverage for the admin git-state panel on the Git settings page.
+// Per the test decision tree this needs no real layout engine or WebSocket, so it
+// runs here rather than as a Playwright spec. The in-process backend has no
+// container for the seeded project, so the panel resolves to the container-stopped
+// state — enough to prove the toggle gating and the lazy fetch wiring.
+
+async function seedRepo(projectId: string, identifier = 'acme/website'): Promise<void> {
+	const { db } = getTestContext();
+	await db.query(
+		`INSERT INTO repos (project_id, repo_identifier, host_type, setup_status)
+		 VALUES ($1, $2, 'github'::repo_host_type, 'ready'::repo_setup_status)`,
+		[projectId, identifier],
+	);
+}
+
+test('superuser can expand a repo to inspect its git state', async () => {
+	let slug = '';
+	const { findByTestId, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Website' });
+			await seedRepo(project.id);
+			slug = project.slug;
+		},
+	});
+	await router.navigate({ to: '/projects/$projectId/git', params: { projectId: slug } });
+
+	// The superuser-only disclosure is present; expanding it lazily loads git state.
+	const toggle = await findByTestId('repo-git-toggle-website');
+	await user.click(toggle);
+
+	// No container is provisioned for the seeded project, so the panel reports the
+	// stopped-container state rather than spinning forever.
+	await findByTestId('repo-git-container-stopped-website');
+});
+
+test('a non-superuser does not see the git-state disclosure', async () => {
+	// Report the caller as a non-superuser to the UI (via /api/me) while the DB user
+	// stays superuser, so project access — and the repo row — still resolve.
+	const appFetch = globalThis.fetch;
+	globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+		const url =
+			input instanceof Request ? input.url : typeof input === 'string' ? input : input.toString();
+		if (new URL(url, 'http://localhost').pathname === '/api/me') {
+			return new Response(JSON.stringify({ data: { type: 'admin', is_superuser: false } }), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			});
+		}
+		return appFetch(input, init);
+	}) as typeof globalThis.fetch;
+
+	let slug = '';
+	const { findByText, queryByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Website' });
+			await seedRepo(project.id);
+			slug = project.slug;
+		},
+	});
+	await router.navigate({ to: '/projects/$projectId/git', params: { projectId: slug } });
+
+	// The repo row renders (the section loaded)…
+	await findByText('website');
+	// …but the superuser-only git-state disclosure is absent.
+	expect(queryByTestId('repo-git-toggle-website')).toBeNull();
+});


### PR DESCRIPTION
## Why

A project's git clone lives **inside its Docker container** (`/workspace/<repo>`), with per-task worktrees under `/worktrees/<taskId>/<repo>`. The host runs no git, and there's **no DB record of branch/worktree/HEAD state** — it only exists live in the container. Today an admin has zero visibility into that state and no way to recover a wedged clone.

The concrete failure this addresses: the clone's local default branch accumulates uncommitted changes, so the periodic sync can't fast-forward — `could not fast-forward main: error: Your local changes to the following files would be overwritten by merge … Aborting` — and the repo silently stops syncing with no UI to see why or fix it.

## What

On the project **Git** settings page, a superuser can expand each repository to see its live clone state and its active worktrees, and run recovery actions to unstick sync.

**Backend**
- `services/git.ts`: export `listWorktrees`; add `getCloneState` (default branch / HEAD / dirty / ahead-behind, all computed **locally, no network fetch**), `getWorktreeState`, and `resetCloneToOrigin` (`git reset --hard` + `clean -fd` — no `-x`, so gitignored artifacts survive — after a best-effort fetch). All handle an **unborn HEAD** (a repository with no commits).
- Extract `withProjectGitLock` into `lib/git-lock.ts` (verbatim) so git-state reads and resets serialize with run-time worktree prep on the shared `.git`.
- `routes/repos.ts`: superuser-gated `GET /api/projects/:projectId/repos/:repoId/git-state` and `POST .../reset`. Reset actions: `discard_local`, `prune_worktrees`, `reclone`. Reset is **blocked (409) while any agent run is active** on the project (`getProjectConcurrency`) and, for the local ops, while the container is stopped. A stopped container makes the read return `{ container_running: false }` rather than auto-starting one. `reclone` reuses `performRepoSetup`'s `pending`→`ready`/`failed` lifecycle.

**Frontend**
- `use-repo-git-state.ts`: lazy state query + reset mutation (invalidate-and-refetch).
- `repo-git-state-panel.tsx`: inline expandable panel per repo row — clone summary (branch, short HEAD, clean/dirty badge, ↑ahead ↓behind), active worktrees linked to their tasks, the container-stopped state, and danger-confirmed recovery actions. Renders **"No commits yet"** for an empty repo. Mounted behind a superuser-only chevron in `github-section.tsx`.

## Design decisions (confirmed with the requester)
- **Actions:** state display + discard-to-origin + prune worktrees + full re-clone (no per-worktree discard).
- **Auth:** superuser only.
- **Load:** on-demand — the panel fetches only when a row is expanded, and never auto-starts a container just from viewing the page.
- **Display:** inline expandable panel per repo row.

## Testing
- `packages/server/test/git-clone-state.test.ts` — git helpers against real git via `HostGitExecutor`, including clean/dirty/ahead/behind, reset semantics, and the **no-commits** case.
- `packages/server/test/repos-git-state.test.ts` — route auth (403 for a team-member agent), validation (400), and the `RUN_IN_PROGRESS` / `CONTAINER_NOT_RUNNING` guards (409).
- `packages/web/test/repo-git-state.test.tsx` — superuser sees the disclosure + container-stopped panel; a non-superuser does not.
- Existing git suite (55 tests) + `docs-bundle` green; `turbo typecheck` green across all three packages.

## Docs
- `.dev/architecture.md` — the git-state/reset endpoints, reset semantics, the git lock, and the active-run block.
- `docs/security/git-and-verified-commits.md` — a user-facing "Recovering a stuck repository" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SeoSShtJp9itPDSS8hLy3u

---
_Generated by [Claude Code](https://claude.ai/code/session_01SeoSShtJp9itPDSS8hLy3u)_