### PR TITLE
feat(git): seed an initial commit for empty connected repos at runtime

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -629,8 +629,18 @@ repointing origin (`remote set-url`) when it addresses a different repo/host
 answer (exec transport failure, stubbed executor) never triggers a repair — only git's own
 "No such remote" / "not a git repository" do. Relatedly, the per-run fetch names `origin`
 explicitly (`git fetch --prune origin`, not `--all`, which exits 0 having fetched nothing
-when no remote is configured), and a worktree add that can resolve neither `origin/<default>`
-nor a born HEAD fails with an actionable "clone has no commits" error instead of git's opaque
+when no remote is configured). A connected remote that has **no commits at all** is **seeded
+at the start of its worktree prep, before that fetch** (`seedInitialCommitIfEmpty`, `git.ts`):
+when `git ls-remote origin` shows no refs, Hezo writes a minimal `README.md` (`# <repo>`),
+commits it on `main`, and pushes — so a freshly-created empty repo becomes usable on its first
+run instead of dead-ending. A pre-populated directory (adopted in place) is preserved: the
+README is only written when absent and `git add -A` folds any existing files into the same
+initial commit. The seed commit is intentionally **unsigned** (`-c commit.gpgsign=false`) —
+SSH signing runs against a live `SSH_AUTH_SOCK`, absent for this bare local `git commit`, while
+the push still runs bridged (`needsSsh`) so it authenticates as the project; it is idempotent
+(a no-op once the remote has any commit). Should a commit still not exist afterward (the seed
+push failed, e.g. connectivity), a worktree add that can resolve neither `origin/<default>` nor
+a born HEAD fails with an actionable "clone has no commits" error instead of git's opaque
 `failed to resolve HEAD as a valid ref`.
 
 Before building a worktree the runner fetches each clone, then **fast-forwards the clone's

--- a/docs/security/git-and-verified-commits.md
+++ b/docs/security/git-and-verified-commits.md
@@ -33,6 +33,12 @@ repository can take a few minutes the first time. The repository shows **"Settin
 until it's ready; if setup fails (for example the workspace couldn't start), the error is
 shown on the repository with a **Retry** button.
 
+If you connect a repository that has **no commits yet**, Hezo seeds it with a minimal
+`README.md` on its first run and pushes that as the initial commit — an empty repository
+has no branch for a task to build on, so this makes it usable immediately. (Repositories
+you create through Hezo already start with an initial commit, so this only applies to
+pre-existing empty repositories you link.)
+
 ## Verified commits, signed on the host
 
 When an agent commits, the **signing happens host-side on its behalf** — the agent asks

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -70,6 +70,7 @@ import {
 	getWorktreeHead,
 	mergeDefaultIntoWorktree,
 	type RepoLoc,
+	seedInitialCommitIfEmpty,
 	type WorktreeLoc,
 	worktreeHasChanges,
 } from './git';
@@ -1449,6 +1450,19 @@ async function prepareWorktrees(
 			// survives an aborted or timed-out run instead of dying with the ephemeral
 			// worktree. Idempotent and best-effort (never throws).
 			ensurePushHook(repoLoc);
+
+			// Bootstrap a connected repo that has no commits yet: `git worktree add`
+			// can't branch off an unborn HEAD, so an empty remote would otherwise fail
+			// worktree prep below with "clone is empty (no commits fetched)". Seed a
+			// minimal README initial commit and push it so the repo has a default branch;
+			// the fetch just below then materializes its `origin/*` tracking refs. No-op
+			// when the remote already has commits.
+			const seed = await seedInitialCommitIfEmpty(executor, repo.repo_identifier, repoLoc, true);
+			if (seed.seeded) {
+				emitSystem('stdout', `seeded initial commit for ${repoName} (remote was empty)`);
+			} else if (seed.error) {
+				emitSystem('stderr', `could not seed initial commit for ${repoName}: ${seed.error}`);
+			}
 
 			emitSystem('stdout', `git fetch ${repoName}...`);
 			const fetchRes = await fetchRepo(executor, repoLoc);

--- a/packages/server/src/services/git.ts
+++ b/packages/server/src/services/git.ts
@@ -208,6 +208,85 @@ export async function initRepoInPlace(
 	return connectExistingRepo(executor, buildGitSshUrl(hostType, repoIdentifier), target, true);
 }
 
+/** The minimal README seeded as an empty repo's initial commit — just the repo name. */
+export function initialReadmeContent(repoIdentifier: string): string {
+	const name = repoIdentifier.includes('/') ? repoIdentifier.split('/')[1] : repoIdentifier;
+	return `# ${name}\n`;
+}
+
+/**
+ * Bootstraps a connected repo that has no commits yet. `git worktree add` can't
+ * base a branch on an unborn HEAD, so an empty remote otherwise fails run prep
+ * with the "clone is empty (no commits fetched)" error from {@link addTaskWorktree}.
+ * When — and only when — the remote advertises no refs, this writes a minimal
+ * README, commits it on `main`, and pushes so the repo gains a default branch and
+ * worktrees can be built. Idempotent: a no-op returning `{ seeded: false }` once the
+ * remote has any commit.
+ *
+ * The commit is deliberately unsigned (`-c commit.gpgsign=false`): SSH commit
+ * signing runs `ssh-keygen -Y sign` against `SSH_AUTH_SOCK`, which is only live for
+ * bridged (`needsSsh`) ops — a signed local `git commit` here would fail. The push
+ * still runs bridged, so it authenticates as the project over the run's SSH bridge.
+ * The caller must supply a git identity on the executor env (the prep executor does).
+ *
+ * A pre-populated working tree (a directory adopted in place) is preserved: the
+ * README is only written when absent, and `add -A` folds any existing files into the
+ * same initial commit — matching {@link connectExistingRepo}'s "existing files become
+ * the initial content" contract. `needsSsh` gates the network ops (false for the
+ * `file://` remotes used in tests).
+ */
+export async function seedInitialCommitIfEmpty(
+	executor: GitExecutor,
+	repoIdentifier: string,
+	repo: RepoLoc,
+	needsSsh: boolean,
+): Promise<{ seeded: boolean; error?: string }> {
+	const cwd = repo.containerPath;
+
+	// Emptiness is judged by the full remote ref listing: `ls-remote --symref HEAD`
+	// can print a symref line even for an unborn HEAD (see connectExistingRepo), so a
+	// bare `ls-remote` is the authoritative "has any commit" probe.
+	const refs = await executor.exec(['ls-remote', 'origin'], { cwd, needsSsh, timeout: 60_000 });
+	if (refs.exitCode !== 0) return { seeded: false, error: formatGitError(refs.stderr) };
+	if (refs.stdout.trim().length > 0) return { seeded: false };
+
+	// Commit on `main` so the pushed default matches GitHub's default for a fresh repo.
+	// `symbolic-ref` works on an unborn HEAD and is a no-op when HEAD is already `main`.
+	const sym = await executor.exec(['symbolic-ref', 'HEAD', 'refs/heads/main'], {
+		cwd,
+		timeout: 30_000,
+	});
+	if (sym.exitCode !== 0) return { seeded: false, error: formatGitError(sym.stderr) };
+
+	const readmePath = join(repo.hostPath, 'README.md');
+	try {
+		if (!existsSync(readmePath)) {
+			writeFileSync(readmePath, initialReadmeContent(repoIdentifier));
+		}
+	} catch (e) {
+		return { seeded: false, error: e instanceof Error ? e.message : String(e) };
+	}
+
+	const add = await executor.exec(['add', '-A'], { cwd, timeout: 30_000 });
+	if (add.exitCode !== 0) return { seeded: false, error: formatGitError(add.stderr) };
+
+	// Unsigned bootstrap commit — see the docstring.
+	const commit = await executor.exec(
+		['-c', 'commit.gpgsign=false', 'commit', '-m', 'Initial commit'],
+		{ cwd, timeout: 30_000 },
+	);
+	if (commit.exitCode !== 0) return { seeded: false, error: formatGitError(commit.stderr) };
+
+	const push = await executor.exec(['push', '-u', 'origin', 'HEAD:main'], {
+		cwd,
+		needsSsh,
+		timeout: 120_000,
+	});
+	if (push.exitCode !== 0) return { seeded: false, error: formatGitError(push.stderr) };
+
+	return { seeded: true };
+}
+
 export async function fetchRepo(
 	executor: GitExecutor,
 	repo: RepoLoc,

--- a/packages/server/test/git-seed-initial-commit.test.ts
+++ b/packages/server/test/git-seed-initial-commit.test.ts
@@ -1,0 +1,142 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { initialReadmeContent, seedInitialCommitIfEmpty } from '../src/services/git';
+import { HostGitExecutor } from '../src/services/git-executor';
+
+let root: string;
+
+// Git runs against host temp dirs here, so host and container paths coincide.
+// The executor carries a git identity so the seed's `git commit` has an author
+// (the prep executor supplies this in production via buildGitIdentityEnv).
+const exec = new HostGitExecutor({
+	GIT_AUTHOR_NAME: 'Hezo',
+	GIT_AUTHOR_EMAIL: 'agent@hezo.local',
+	GIT_COMMITTER_NAME: 'Hezo',
+	GIT_COMMITTER_EMAIL: 'agent@hezo.local',
+});
+const loc = (p: string) => ({ hostPath: p, containerPath: p });
+
+function git(cwd: string, ...args: string[]): string {
+	return execFileSync('git', args, {
+		cwd,
+		env: {
+			...process.env,
+			GIT_AUTHOR_NAME: 'Test',
+			GIT_AUTHOR_EMAIL: 'test@example.com',
+			GIT_COMMITTER_NAME: 'Test',
+			GIT_COMMITTER_EMAIL: 'test@example.com',
+		},
+	})
+		.toString()
+		.trim();
+}
+
+/** A bare repo with no commits, default branch `main`. */
+function makeEmptyRemote(): string {
+	const bare = join(root, 'empty.git');
+	git(root, 'init', '--bare', '-b', 'main', bare);
+	return bare;
+}
+
+/** A bare repo carrying one commit with the given files, default branch `main`. */
+function makeRemoteWithCommit(files: Record<string, string>): string {
+	const seed = join(root, 'seed');
+	mkdirSync(seed, { recursive: true });
+	git(seed, 'init', '-b', 'main');
+	for (const [name, content] of Object.entries(files)) {
+		writeFileSync(join(seed, name), content);
+	}
+	git(seed, 'add', '-A');
+	git(seed, 'commit', '-m', 'initial');
+	const bare = join(root, 'remote.git');
+	git(root, 'clone', '--bare', seed, bare);
+	return bare;
+}
+
+/** Clone `remote` into a fresh work dir and return its path. */
+function cloneInto(remote: string, name = 'work'): string {
+	const target = join(root, name);
+	git(root, 'clone', `file://${remote}`, target);
+	return target;
+}
+
+beforeEach(() => {
+	root = mkdtempSync(join(tmpdir(), 'seed-initial-'));
+});
+
+afterEach(() => {
+	rmSync(root, { recursive: true, force: true });
+});
+
+describe('initialReadmeContent', () => {
+	it('is the repo name as a markdown heading', () => {
+		expect(initialReadmeContent('acme/widgets')).toBe('# widgets\n');
+		// A bare name (no owner) is used as-is.
+		expect(initialReadmeContent('widgets')).toBe('# widgets\n');
+	});
+});
+
+describe('seedInitialCommitIfEmpty', () => {
+	it('seeds a minimal README initial commit and pushes it to main when the remote is empty', async () => {
+		const remote = makeEmptyRemote();
+		const work = cloneInto(remote);
+
+		const res = await seedInitialCommitIfEmpty(exec, 'acme/widgets', loc(work), false);
+
+		expect(res.seeded).toBe(true);
+		expect(res.error).toBeUndefined();
+
+		// The local working tree gained the minimal README...
+		expect(existsSync(join(work, 'README.md'))).toBe(true);
+		// ...and it was pushed to the remote's `main` as an "Initial commit".
+		expect(git(remote, 'rev-parse', '--verify', 'main')).toMatch(/^[0-9a-f]{40}$/);
+		expect(git(remote, 'log', '-1', '--format=%s', 'main')).toBe('Initial commit');
+		expect(git(remote, 'show', 'main:README.md')).toBe('# widgets');
+	});
+
+	it('is an idempotent no-op when the remote already has commits', async () => {
+		const remote = makeRemoteWithCommit({ 'app.js': 'console.log(1)\n' });
+		const work = cloneInto(remote);
+		const tipBefore = git(remote, 'rev-parse', 'main');
+
+		const res = await seedInitialCommitIfEmpty(exec, 'acme/widgets', loc(work), false);
+
+		expect(res.seeded).toBe(false);
+		expect(res.error).toBeUndefined();
+		// No README was written and the remote tip is untouched (no extra commit).
+		expect(existsSync(join(work, 'README.md'))).toBe(false);
+		expect(git(remote, 'rev-parse', 'main')).toBe(tipBefore);
+	});
+
+	it('folds a pre-populated working tree into the same initial commit, keeping its files', async () => {
+		// The adopt-in-place case: an agent populated the directory (connected to an
+		// empty remote) before the first commit exists. Its files must survive.
+		const remote = makeEmptyRemote();
+		const work = join(root, 'work');
+		git(root, 'clone', `file://${remote}`, work);
+		writeFileSync(join(work, 'index.html'), '<html></html>');
+
+		const res = await seedInitialCommitIfEmpty(exec, 'acme/site', loc(work), false);
+
+		expect(res.seeded).toBe(true);
+		// Both the agent's file and the seeded README are in the pushed initial commit.
+		expect(git(remote, 'show', 'main:index.html')).toBe('<html></html>');
+		expect(git(remote, 'show', 'main:README.md')).toBe('# site');
+	});
+
+	it('does not overwrite an existing README when folding the working tree', async () => {
+		const remote = makeEmptyRemote();
+		const work = join(root, 'work');
+		git(root, 'clone', `file://${remote}`, work);
+		writeFileSync(join(work, 'README.md'), 'hand-written\n');
+
+		const res = await seedInitialCommitIfEmpty(exec, 'acme/site', loc(work), false);
+
+		expect(res.seeded).toBe(true);
+		// The pre-existing README is preserved verbatim, not clobbered by the default.
+		expect(git(remote, 'show', 'main:README.md')).toBe('hand-written');
+	});
+});


### PR DESCRIPTION
## Summary

When a connected GitHub repository has **no commits yet**, `git worktree add` can't base a task branch on its unborn HEAD, so run prep dead-ended with the actionable error `clone is empty (no commits fetched) — … push an initial commit, then retry`. A brand-new empty repo could therefore never have its first run.

This makes Hezo **handle that case at runtime**: it detects an empty remote during worktree prep and seeds it with a minimal `README.md` initial commit, so the repo becomes usable on its first run instead of failing.

## What changed

- **`packages/server/src/services/git.ts`** — new `seedInitialCommitIfEmpty(executor, repoIdentifier, repo, needsSsh)` (plus a small `initialReadmeContent` helper). When — and only when — `git ls-remote origin` shows no refs, it writes a minimal `README.md` (`# <repo>`), commits it on `main`, and pushes.
  - The commit is deliberately **unsigned** (`-c commit.gpgsign=false`): SSH commit signing runs `ssh-keygen -Y sign` against `SSH_AUTH_SOCK`, which is only live for bridged (`needsSsh`) ops — a signed local `git commit` during prep would fail. The **push** still runs bridged, so it authenticates as the project over the run's SSH bridge.
  - **Idempotent** — a no-op once the remote has any commit.
  - **Preserves a pre-populated working tree** (the adopt-in-place case): the README is only written when absent, and `git add -A` folds any existing files into the same initial commit, matching `connectExistingRepo`'s "existing files become the initial content" contract.
- **`packages/server/src/services/agent-runner.ts`** — `prepareWorktrees` now calls `seedInitialCommitIfEmpty` per repo, after `ensurePushHook` and before `fetchRepo`, so the existing per-run fetch then materializes the freshly-pushed `origin/*` tracking refs. Emits a `[system]` log line on seed / on error.

## Why

`prepareWorktrees` throws for the designated repo when its worktree can't be prepared (`agent-runner.ts`), which fails the run. Seeding the initial commit removes the empty-repo dead-end for the common case (a freshly-created/linked empty repo) while leaving the actionable error in place as the last-resort guard if a commit still can't be established (e.g. the seed push failed on connectivity).

## Docs

- **`.dev/architecture.md`** — updated the repo-sync / worktree section to describe the seeding step, the unsigned-bootstrap rationale, and the retained fallback error.
- **`docs/security/git-and-verified-commits.md`** — added a short, user-facing note that linking an empty repository is seeded with an initial `README.md` on its first run.

## Testing

- New `packages/server/test/git-seed-initial-commit.test.ts` (5 tests, real bare remotes + `HostGitExecutor`): seeds + pushes an `Initial commit` to `main` when empty; idempotent no-op when the remote already has commits; folds a pre-populated tree into the initial commit; does not overwrite an existing README.
- Existing git suite (86), prep/runner integration (168 across `agent-runner*`, `run-timeout`, `job-manager-extended`, `repo-sync`, `containers*`), and generated-surface drift tests (`docs-bundle`, `mcp-reference`, `llms-txt`) all pass; `typecheck` and `biome check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193Ep6UcyHBXdE8SNNGXyBr

---
_Generated by [Claude Code](https://claude.ai/code/session_0193Ep6UcyHBXdE8SNNGXyBr)_