### PR TITLE
fix(git): recover a stranded initial commit when the empty-repo seed push fails

### DIFF
--- a/packages/server/src/services/git.ts
+++ b/packages/server/src/services/git.ts
@@ -221,7 +221,9 @@ export function initialReadmeContent(repoIdentifier: string): string {
  * When — and only when — the remote advertises no refs, this writes a minimal
  * README, commits it on `main`, and pushes so the repo gains a default branch and
  * worktrees can be built. Idempotent: a no-op returning `{ seeded: false }` once the
- * remote has any commit.
+ * remote has any commit, and recoverable — if an earlier call committed locally but
+ * its push failed (a transient network error), a later call re-pushes the existing
+ * commit instead of re-committing (which would die with "nothing to commit").
  *
  * The commit is deliberately unsigned (`-c commit.gpgsign=false`): SSH commit
  * signing runs `ssh-keygen -Y sign` against `SSH_AUTH_SOCK`, which is only live for
@@ -250,32 +252,43 @@ export async function seedInitialCommitIfEmpty(
 	if (refs.exitCode !== 0) return { seeded: false, error: formatGitError(refs.stderr) };
 	if (refs.stdout.trim().length > 0) return { seeded: false };
 
-	// Commit on `main` so the pushed default matches GitHub's default for a fresh repo.
-	// `symbolic-ref` works on an unborn HEAD and is a no-op when HEAD is already `main`.
-	const sym = await executor.exec(['symbolic-ref', 'HEAD', 'refs/heads/main'], {
+	// A prior attempt may have committed locally but failed to push (e.g. a transient
+	// network error): the remote is still empty while HEAD is already born. Only build
+	// the commit when HEAD is genuinely unborn — otherwise re-running `git commit` here
+	// dies with "nothing to commit" and strands the local commit unpushed forever. When
+	// HEAD already has a commit, fall straight through to (re)pushing it.
+	const born = await executor.exec(['rev-parse', '--verify', '--quiet', 'HEAD'], {
 		cwd,
 		timeout: 30_000,
 	});
-	if (sym.exitCode !== 0) return { seeded: false, error: formatGitError(sym.stderr) };
+	if (born.exitCode !== 0) {
+		// Commit on `main` so the pushed default matches GitHub's default for a fresh repo.
+		// `symbolic-ref` works on an unborn HEAD and is a no-op when HEAD is already `main`.
+		const sym = await executor.exec(['symbolic-ref', 'HEAD', 'refs/heads/main'], {
+			cwd,
+			timeout: 30_000,
+		});
+		if (sym.exitCode !== 0) return { seeded: false, error: formatGitError(sym.stderr) };
 
-	const readmePath = join(repo.hostPath, 'README.md');
-	try {
-		if (!existsSync(readmePath)) {
-			writeFileSync(readmePath, initialReadmeContent(repoIdentifier));
+		const readmePath = join(repo.hostPath, 'README.md');
+		try {
+			if (!existsSync(readmePath)) {
+				writeFileSync(readmePath, initialReadmeContent(repoIdentifier));
+			}
+		} catch (e) {
+			return { seeded: false, error: e instanceof Error ? e.message : String(e) };
 		}
-	} catch (e) {
-		return { seeded: false, error: e instanceof Error ? e.message : String(e) };
+
+		const add = await executor.exec(['add', '-A'], { cwd, timeout: 30_000 });
+		if (add.exitCode !== 0) return { seeded: false, error: formatGitError(add.stderr) };
+
+		// Unsigned bootstrap commit — see the docstring.
+		const commit = await executor.exec(
+			['-c', 'commit.gpgsign=false', 'commit', '-m', 'Initial commit'],
+			{ cwd, timeout: 30_000 },
+		);
+		if (commit.exitCode !== 0) return { seeded: false, error: formatGitError(commit.stderr) };
 	}
-
-	const add = await executor.exec(['add', '-A'], { cwd, timeout: 30_000 });
-	if (add.exitCode !== 0) return { seeded: false, error: formatGitError(add.stderr) };
-
-	// Unsigned bootstrap commit — see the docstring.
-	const commit = await executor.exec(
-		['-c', 'commit.gpgsign=false', 'commit', '-m', 'Initial commit'],
-		{ cwd, timeout: 30_000 },
-	);
-	if (commit.exitCode !== 0) return { seeded: false, error: formatGitError(commit.stderr) };
 
 	const push = await executor.exec(['push', '-u', 'origin', 'HEAD:main'], {
 		cwd,

--- a/packages/server/test/git-seed-initial-commit.test.ts
+++ b/packages/server/test/git-seed-initial-commit.test.ts
@@ -139,4 +139,25 @@ describe('seedInitialCommitIfEmpty', () => {
 		// The pre-existing README is preserved verbatim, not clobbered by the default.
 		expect(git(remote, 'show', 'main:README.md')).toBe('hand-written');
 	});
+
+	it('re-pushes a stranded local commit when a prior push failed, without re-committing', async () => {
+		// A prior attempt committed locally but its push failed (transient network),
+		// leaving the remote empty and HEAD born. The retry must push that same commit,
+		// not re-run `git commit` (which would die with "nothing to commit").
+		const remote = makeEmptyRemote();
+		const work = cloneInto(remote);
+		writeFileSync(join(work, 'README.md'), '# widgets\n');
+		git(work, 'add', '-A');
+		git(work, 'commit', '-m', 'Initial commit');
+		const strandedSha = git(work, 'rev-parse', 'HEAD');
+		// Remote is still empty — nothing has been pushed yet (no `main` branch).
+		expect(git(remote, 'branch', '--list', 'main')).toBe('');
+
+		const res = await seedInitialCommitIfEmpty(exec, 'acme/widgets', loc(work), false);
+
+		expect(res.seeded).toBe(true);
+		expect(res.error).toBeUndefined();
+		// The *existing* local commit reached the remote (same SHA — no new commit).
+		expect(git(remote, 'rev-parse', 'main')).toBe(strandedSha);
+	});
 });


### PR DESCRIPTION
## Summary

Follow-up to the empty-repo seeding merged in #613. That code committed a minimal README locally and then pushed. If the **push failed** — e.g. a transient `git@github.com:22` connect timeout — the local commit was left on `main` while the remote stayed empty, and the **next run could never recover**: the seed re-ran, found the remote still empty, and died at `git commit` with `nothing to commit, working tree clean`, stranding that commit unpushed forever.

This was observed in the wild: `could not seed initial commit for <repo>: ssh: connect to host github.com port 22: Connection timed out` — the SSH transport hit a transient connect timeout (a `git fetch` over the same transport succeeded moments later), and the seed had no way back.

## What changed

- **`packages/server/src/services/git.ts`** — `seedInitialCommitIfEmpty` now guards the commit build behind an **unborn-HEAD check** (`git rev-parse --verify --quiet HEAD`):
  - HEAD unborn → do the full sequence (set `main`, write README, `add -A`, unsigned commit), as before.
  - HEAD already born (a prior attempt committed but its push failed) → **skip re-committing and fall straight through to (re)pushing** the existing commit.
  - The push runs unchanged. The seed is now **recoverable across a partial failure**, not merely idempotent once the remote has a commit.

## Why

The original `git commit` is fatal when there's nothing to stage, so a commit-then-failed-push left the repo permanently wedged on retry. Detecting the born HEAD and re-pushing the existing commit is the standard recovery for a partial network failure — the local commit reaches the remote on the next run instead of being stranded.

## Testing

- New regression test in `packages/server/test/git-seed-initial-commit.test.ts`: commits a README locally **without** pushing (simulating a prior failed push), then asserts the seed re-pushes **that same commit (same SHA)** rather than re-committing. Fails against the old code (`nothing to commit`), passes now.
- Full seed spec (6 tests) + `typecheck` + `biome check` green.

## Note on scope

This hardens **recovery** from a transient push failure; it does not change the transport. If an environment can *read* over one path (proxy/SSH) but genuinely cannot *push* over SSH to GitHub at all, that's an egress/config issue to fix separately — this change ensures Hezo self-heals across runs once the push can land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193Ep6UcyHBXdE8SNNGXyBr

---
_Generated by [Claude Code](https://claude.ai/code/session_0193Ep6UcyHBXdE8SNNGXyBr)_