### PR TITLE
feat(web): default inbox to unread and reorder tab pills

### DIFF
--- a/packages/web/src/components/inbox-view.tsx
+++ b/packages/web/src/components/inbox-view.tsx
@@ -35,9 +35,9 @@ type InboxRow =
 	  };
 
 const READ_OPTIONS: { value: ReadFilter; label: string }[] = [
-	{ value: 'all', label: 'All' },
 	{ value: 'unread', label: 'Unread' },
 	{ value: 'read', label: 'Read' },
+	{ value: 'all', label: 'All' },
 	{ value: 'archived', label: 'Archived' },
 ];
 
@@ -62,7 +62,7 @@ function approvalSearch(a: Approval): string {
 }
 
 export function InboxView({ projectSlugs, scope }: InboxViewProps) {
-	const [readFilter, setReadFilter] = useState<ReadFilter>('all');
+	const [readFilter, setReadFilter] = useState<ReadFilter>('unread');
 	const archivedView = readFilter === 'archived';
 	const { data: approvals, isLoading: approvalsLoading } = useAllApprovals(projectSlugs, {
 		archived: archivedView,

--- a/packages/web/test/approval-card.test.tsx
+++ b/packages/web/test/approval-card.test.tsx
@@ -112,7 +112,7 @@ test('a deploy-production approval names the target environment', async () => {
 });
 
 test('a resolved (approved) approval is read-only history: status badge, resolution note, no buttons', async () => {
-	const { findByText, queryByRole } = await renderTeamInbox(async ({ ws }) => {
+	const { findByText, queryByRole, user } = await renderTeamInbox(async ({ ws }) => {
 		await insertApproval(ws, {
 			type: 'strategy',
 			payload: { plan: 'Old launch plan' },
@@ -121,6 +121,9 @@ test('a resolved (approved) approval is read-only history: status badge, resolut
 		});
 	});
 
+	// Resolved approvals are read, so they live under the All filter (the inbox
+	// defaults to Unread).
+	await user.click(await findByText('All'));
 	await findByText('Old launch plan', undefined, { timeout: 15_000 });
 	// Resolved approvals show the status badge + resolution note.
 	await findByText('approved');
@@ -131,7 +134,7 @@ test('a resolved (approved) approval is read-only history: status badge, resolut
 });
 
 test('a denied approval shows a red denied badge', async () => {
-	const { findByText } = await renderTeamInbox(async ({ ws }) => {
+	const { findByText, user } = await renderTeamInbox(async ({ ws }) => {
 		await insertApproval(ws, {
 			type: 'strategy',
 			payload: { plan: 'Rejected plan' },
@@ -140,6 +143,9 @@ test('a denied approval shows a red denied badge', async () => {
 		});
 	});
 
+	// Denied approvals are read, so they live under the All filter (the inbox
+	// defaults to Unread).
+	await user.click(await findByText('All'));
 	await findByText('Rejected plan', undefined, { timeout: 15_000 });
 	await findByText('denied');
 	await findByText(/Not now\./);

--- a/packages/web/test/inbox-approvals.test.tsx
+++ b/packages/web/test/inbox-approvals.test.tsx
@@ -84,7 +84,9 @@ test('can approve a pending approval', async () => {
 
 	await findByText('Proposing strategy', undefined, { timeout: 10_000 });
 	await user.click(await findByRole('button', { name: 'Approve' }));
-	// Resolved approvals stay in the inbox as read history with a status badge.
+	// Resolving moves the approval out of the default Unread view; it stays in the
+	// inbox as read history with a status badge under the All filter.
+	await user.click(await findByText('All'));
 	await findByText('approved', undefined, { timeout: 15_000 });
 	await findByText('Proposing strategy');
 });
@@ -110,7 +112,9 @@ test('can deny a pending approval', async () => {
 
 	await findByText('Proposing strategy', undefined, { timeout: 10_000 });
 	await user.click(await findByRole('button', { name: 'Deny' }));
-	// Resolved approvals stay in the inbox as read history with a status badge.
+	// Resolving moves the approval out of the default Unread view; it stays in the
+	// inbox as read history with a status badge under the All filter.
+	await user.click(await findByText('All'));
 	await findByText('denied', undefined, { timeout: 15_000 });
 	await findByText('Proposing strategy');
 });

--- a/packages/web/test/inbox-mentions.test.tsx
+++ b/packages/web/test/inbox-mentions.test.tsx
@@ -204,7 +204,7 @@ test('clicking a mention deep-links to and highlights the source comment', async
 
 test('inbox shows read mentions as history and highlights unread ones', async () => {
 	let ctx: { projectSlug: string };
-	const { findAllByTestId, router } = await renderApp({
+	const { findAllByTestId, findByText, user, router } = await renderApp({
 		initialPath: '/',
 		seed: async () => {
 			const ws = await seedWorkspace();
@@ -223,6 +223,8 @@ test('inbox shows read mentions as history and highlights unread ones', async ()
 		params: { projectId: ctx!.projectSlug },
 	});
 
+	// The inbox defaults to the Unread filter; switch to All to see read + unread together.
+	await user.click(await findByText('All'));
 	await waitFor(async () => expect((await findAllByTestId('mention-card')).length).toBe(2), {
 		timeout: 10_000,
 	});
@@ -252,6 +254,8 @@ test('read/unread filter and keyword search narrow the inbox', async () => {
 		params: { projectId: ctx!.projectSlug },
 	});
 
+	// The inbox defaults to Unread; switch to All to establish the 2-card baseline.
+	await user.click(await findByText('All'));
 	await waitFor(async () => expect((await findAllByTestId('mention-card')).length).toBe(2), {
 		timeout: 10_000,
 	});
@@ -306,7 +310,8 @@ test('archived mentions are hidden by default and shown under the Archived filte
 		params: { projectId: ctx!.projectSlug },
 	});
 
-	// Default view shows only the active (non-archived) mention.
+	// The All filter shows only the active (non-archived) mention; the archived one is hidden.
+	await user.click(await findByText('All'));
 	await findByText(/active decision/, undefined, { timeout: 10_000 });
 	await waitFor(async () => expect((await findAllByTestId('mention-card')).length).toBe(1));
 


### PR DESCRIPTION
## Summary

Makes the inbox open on the **Unread** filter by default (previously **All**) and reorders the tab pills so the most actionable view leads:

- **Unread**
- **Read**
- **All**
- **Archived**

## Changes

- `packages/web/src/components/inbox-view.tsx` — reorder `READ_OPTIONS` (Unread → Read → All → Archived) and change the default `readFilter` state from `'all'` to `'unread'`.
- `packages/web/test/inbox-mentions.test.tsx` / `packages/web/test/inbox-approvals.test.tsx` — update tests that relied on the old "All" default. Where a test needs read/resolved items visible (read-mention history, keyword-search baseline, post-resolve approval status badges), it now switches to the **All** filter first, which mirrors real user behavior with the new default.

## Testing

- `bunx vitest run test/inbox-mentions.test.tsx test/inbox-approvals.test.tsx test/inbox-global.test.tsx` — 14 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013qZYJM8h2kPbtDqD4kDFWb)_