### PR TITLE
fix: restore clipped bottom border on org-chart bottom-row agent cards

### DIFF
--- a/packages/web/src/components/org-chart-tree.tsx
+++ b/packages/web/src/components/org-chart-tree.tsx
@@ -24,7 +24,14 @@ export function useOrgChartAutoFit() {
 			if (!containerWidth || !contentWidth) return;
 			const next = Math.min(1, containerWidth / contentWidth);
 			setScale(next);
-			setHeight(contentHeight * next);
+			// The container is border-box with vertical padding and clips via
+			// overflow-hidden, so the height must cover the scaled content *plus*
+			// that padding — otherwise the padding eats into the box and the last
+			// row's bottom border falls outside the clip. Round the scaled height
+			// up and add 1px to absorb the sub-pixel rounding of the scaled border.
+			const style = getComputedStyle(container);
+			const paddingY = parseFloat(style.paddingTop) + parseFloat(style.paddingBottom);
+			setHeight(Math.ceil(contentHeight * next) + paddingY + 1);
 		};
 
 		recompute();
@@ -153,7 +160,12 @@ export function OrgChartTree({ roots, projectId, mode, hint, testId }: OrgChartT
 
 	return (
 		<div data-testid={testId}>
-			<div ref={containerRef} className="w-full overflow-hidden pt-1" style={{ height }}>
+			<div
+				ref={containerRef}
+				data-testid={testId ? `${testId}-viewport` : undefined}
+				className="w-full overflow-hidden py-1"
+				style={{ height }}
+			>
 				<div
 					ref={contentRef}
 					className="flex flex-col items-center"

--- a/test/browser/org-chart-card-border-clip.spec.ts
+++ b/test/browser/org-chart-card-border-clip.spec.ts
@@ -1,0 +1,47 @@
+// Playwright (decision tree #1: real CSS layout / overflow clipping). The org
+// chart auto-fits by scaling its content and clipping the wrapper to a computed
+// height via `overflow-hidden`. If that height doesn't account for the wrapper's
+// vertical padding, the padding eats into the border box and the bottom row's
+// cards have their 1px bottom border sheared off. Asserting "not clipped" means
+// comparing each bottom-row card's real layout box against the clip container's
+// bottom edge — only a browser engine resolves this. happy-dom reports 0 for
+// boundingBox, so this cannot be a component test.
+
+import { expect, test } from './fixtures';
+import { waitForPageLoad } from './helpers';
+
+test('bottom-row agent cards are not clipped by the org-chart viewport', async ({
+	sharedPage: page,
+	sharedWorkspace,
+}) => {
+	const { projectSlug } = sharedWorkspace;
+
+	await page.goto(`/projects/${projectSlug}/agents`);
+	await waitForPageLoad(page);
+
+	const viewport = page.getByTestId('team-org-chart-viewport');
+	await expect(viewport).toBeVisible({ timeout: 15_000 });
+
+	// Every card except the synthetic "You (Admin)" root is a Link (an <a>). The
+	// bottom row is whichever cards have the greatest bottom edge.
+	const cards = viewport.getByRole('link');
+	await expect(cards.first()).toBeVisible({ timeout: 15_000 });
+
+	const viewportBox = await viewport.boundingBox();
+	if (!viewportBox) throw new Error('org-chart viewport has no layout box');
+	const viewportBottom = viewportBox.y + viewportBox.height;
+
+	const count = await cards.count();
+	let lowestCardBottom = Number.NEGATIVE_INFINITY;
+	for (let i = 0; i < count; i++) {
+		const box = await cards.nth(i).boundingBox();
+		if (!box) continue;
+		lowestCardBottom = Math.max(lowestCardBottom, box.y + box.height);
+	}
+	expect(lowestCardBottom).toBeGreaterThan(Number.NEGATIVE_INFINITY);
+
+	// The lowest card's bottom edge (border included) must sit at or above the
+	// viewport's clipped bottom edge; anything below is sheared off. The 1px
+	// tolerance absorbs sub-pixel rounding — the regression clipped a full ~4px.
+	expect(lowestCardBottom).toBeLessThanOrEqual(viewportBottom + 1);
+});


### PR DESCRIPTION
## Problem

On the team org-chart page, the **bottom border of the bottom-row agent cards is sheared off** — the last row of role cards (e.g. Content Writer, Visual Designer, …) renders with no visible bottom border.

## Root cause

`OrgChartTree` auto-fits by scaling its content (`transform: scale(...)`) and clipping the wrapper to a computed height with `overflow-hidden`. The wrapper is `box-sizing: border-box` (Tailwind default) and carried `pt-1` (4px) top padding, but its height was set to exactly `contentHeight * scale`. Because border-box height *includes* padding, that 4px was subtracted from the usable content area, pushing the scaled content's bottom ~4px past the clip boundary — so the last row's 1px bottom border fell outside the clipped box. Sub-pixel rounding of the scaled border made it worse.

Verified in a real browser: before the fix the lowest card's bottom edge landed at `501.9px` while the viewport's clipped bottom was `497.9px` — a ~4px shear, exactly the `pt-1`.

## Fix

`packages/web/src/components/org-chart-tree.tsx`:
- Height now covers the scaled content **plus** the wrapper's vertical padding (read from computed style so it tracks the class), rounds the scaled height up, and adds a 1px buffer for the sub-pixel rounding of the scaled border.
- `pt-1` → `py-1` so the bottom row gets the same breathing room as the top and the interactive cards' `hover:shadow-sm` isn't clipped.
- Added a `${testId}-viewport` data-testid on the clip container so the behaviour is testable.

## Testing

- New Playwright spec `test/browser/org-chart-card-border-clip.spec.ts` (real CSS layout / overflow clipping — browser-tier per the decision tree) asserts the lowest card's bottom edge stays within the viewport's clipped bottom.
- Confirmed the spec **fails against the pre-fix code** (the ~4px shear) and **passes with the fix**.
- `biome check` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011t6XzaMPMPnY3HxjTFUnfH

---
_Generated by [Claude Code](https://claude.ai/code/session_011t6XzaMPMPnY3HxjTFUnfH)_