### PR TITLE
feat: surface Edit and History on all document views

### DIFF
--- a/docs/concepts/documents-and-memory.md
+++ b/docs/concepts/documents-and-memory.md
@@ -137,6 +137,12 @@ document from a task's preview panel, that task is suggested first) and
 **clear review** (a trash button that deletes every comment after confirmation), alongside a
 **?** button that opens a short in-app guide to all of this.
 
+Wherever you read a document — the Documents page, the task-sidebar preview, or its own tab —
+its header carries **Edit** and **History** buttons. On the two preview views these take you
+to the document on the Documents page, ready to edit or with its version history open, so you
+can move from a quick look straight into changing the document or seeing how it changed.
+(Edit is hidden while a document is archived, since archived documents are read-only.)
+
 On a larger screen you can also **hide the document list** — the panel button just left of
 the document's title collapses it, giving the document the full width of the page; the same
 button brings the list back, and Hezo remembers your choice. (On a phone the list and the

--- a/packages/web/src/components/docs-library.tsx
+++ b/packages/web/src/components/docs-library.tsx
@@ -93,6 +93,13 @@ interface DocsLibraryProps {
 	bodyBanner?: ReactNode;
 	/** Opens the revision-history dialog; when set, a History button shows in the toolbar. */
 	onShowHistory?: () => void;
+	/**
+	 * Open the selected doc directly in edit mode once its content has loaded — set
+	 * by the Edit affordance on the read-only preview surfaces, which deep-link here
+	 * with `?edit=1`. Honoured a single time per mount (cancelling back to view
+	 * won't re-trigger); a no-op for read-only/archived docs.
+	 */
+	autoEdit?: boolean;
 	/** View-only (an older revision is shown): hides Edit/Delete. */
 	readOnly?: boolean;
 
@@ -129,6 +136,7 @@ export function DocsLibrary({
 	docMeta,
 	bodyBanner,
 	onShowHistory,
+	autoEdit,
 	readOnly,
 	emptyTitle = 'No documents yet',
 	emptyDescription,
@@ -142,6 +150,7 @@ export function DocsLibrary({
 	const [search, setSearch] = useState('');
 	const [listCollapsed, setListCollapsed] = useState(() => readStored(LIST_COLLAPSED_KEY) === '1');
 	const prevModeRef = useRef<'view' | 'edit'>('view');
+	const autoEditHonoredRef = useRef(false);
 
 	if (modeKey !== selectedKey) {
 		setModeKey(selectedKey);
@@ -154,6 +163,23 @@ export function DocsLibrary({
 		}
 		prevModeRef.current = mode;
 	}, [mode, docContent]);
+
+	// Honour a deep-linked `?edit=1` once the doc content has loaded: flip into
+	// edit mode a single time. Waiting for content (rather than starting in edit)
+	// lets the draft-init effect above seed the editor from the loaded text.
+	useEffect(() => {
+		if (
+			autoEdit &&
+			!autoEditHonoredRef.current &&
+			selectedKey &&
+			docContent != null &&
+			!readOnly &&
+			!archivedInfo
+		) {
+			autoEditHonoredRef.current = true;
+			setMode('edit');
+		}
+	}, [autoEdit, selectedKey, docContent, readOnly, archivedInfo]);
 
 	const showNewForm = isCreating && !!newForm;
 	const selectedItem = selectedKey ? items.find((it) => it.key === selectedKey) : undefined;

--- a/packages/web/src/components/task-detail/preview-panel.tsx
+++ b/packages/web/src/components/task-detail/preview-panel.tsx
@@ -1,4 +1,5 @@
-import { ExternalLink, X } from 'lucide-react';
+import { Link } from '@tanstack/react-router';
+import { ExternalLink, History, Pencil, X } from 'lucide-react';
 import { type ProjectDoc, useProjectDoc } from '../../hooks/use-project-docs';
 import { docPreviewPath } from '../../lib/doc-preview';
 import type { ReviewTaskContext } from '../document-review/action-review-dialog';
@@ -6,6 +7,11 @@ import { DocumentBody } from '../document-review/document-body';
 import { ReviewToolbarActions } from '../document-review/review-toolbar-actions';
 import { Tooltip } from '../ui/tooltip';
 import type { PreviewItem } from './preview-context';
+
+// Icon-button styling shared by the panel's document-level actions (edit,
+// history, open-in-new-tab), so the whole header row reads as one cluster.
+const ICON_ACTION_CLASSES =
+	'shrink-0 rounded-md p-1 text-text-3 transition-colors hover:bg-surface-3 hover:text-text-1';
 
 function formatBytes(bytes?: number): string {
 	if (!bytes || bytes < 0) return '';
@@ -32,6 +38,9 @@ export function PreviewPanel({ item, onClose, task }: PreviewPanelProps) {
 	const docQuery = useProjectDoc(item.projectId, item.filename);
 	const openUrl = docPreviewPath(item.projectSlug, item.filename);
 	const meta = formatBytes(item.size);
+	// Archived docs are read-only — mirror the Documents toolbar and drop Edit
+	// (History stays: past revisions are still viewable/restorable there).
+	const isArchived = !!docQuery.data?.archived_at;
 
 	return (
 		<aside
@@ -47,13 +56,39 @@ export function PreviewPanel({ item, onClose, task }: PreviewPanelProps) {
 					{item.filename}
 				</span>
 				<ReviewToolbarActions projectId={item.projectId} filename={item.filename} task={task} />
+				{!isArchived && (
+					<Tooltip content="Edit document">
+						<Link
+							to="/projects/$projectId/documents"
+							params={{ projectId: item.projectSlug }}
+							search={{ file: item.filename, edit: true }}
+							aria-label="Edit document"
+							className={ICON_ACTION_CLASSES}
+							data-testid="preview-edit"
+						>
+							<Pencil className="h-4 w-4" />
+						</Link>
+					</Tooltip>
+				)}
+				<Tooltip content="Revision history">
+					<Link
+						to="/projects/$projectId/documents"
+						params={{ projectId: item.projectSlug }}
+						search={{ file: item.filename, history: true }}
+						aria-label="Revision history"
+						className={ICON_ACTION_CLASSES}
+						data-testid="preview-history"
+					>
+						<History className="h-4 w-4" />
+					</Link>
+				</Tooltip>
 				<Tooltip content="Open in new tab">
 					<a
 						href={openUrl}
 						target="_blank"
 						rel="noopener noreferrer"
 						aria-label="Open in new tab"
-						className="shrink-0 rounded-md p-1 text-text-3 transition-colors hover:bg-surface-3 hover:text-text-1"
+						className={ICON_ACTION_CLASSES}
 						data-testid="preview-open-tab"
 					>
 						<ExternalLink className="h-4 w-4" />

--- a/packages/web/src/routes/preview/$projectId/$filename.tsx
+++ b/packages/web/src/routes/preview/$projectId/$filename.tsx
@@ -1,10 +1,17 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, Link } from '@tanstack/react-router';
+import { History, Pencil } from 'lucide-react';
 import { useState } from 'react';
 import { DocumentBody } from '../../../components/document-review/document-body';
 import { ReviewToolbarActions } from '../../../components/document-review/review-toolbar-actions';
 import { ScrollToBottomButton } from '../../../components/scroll-to-bottom-button';
+import { Tooltip } from '../../../components/ui/tooltip';
 import { useProjectDoc } from '../../../hooks/use-project-docs';
 import { useScrollToBottom } from '../../../hooks/use-scroll-to-bottom';
+
+// Matches the icon-button styling on the task-detail preview panel so the
+// document-level actions read consistently across both preview surfaces.
+const ICON_ACTION_CLASSES =
+	'shrink-0 rounded-md p-1 text-text-3 transition-colors hover:bg-surface-3 hover:text-text-1';
 
 function DocPreviewPage() {
 	const { projectId, filename } = Route.useParams();
@@ -24,22 +31,55 @@ function DocPreviewPage() {
 
 	return (
 		<div ref={setScroller} className="h-screen overflow-auto bg-surface">
-			<div className="sticky top-0 z-10 flex items-center justify-center gap-2 px-4 pt-3">
+			{/* Full-width sticky bar spanning the content column: filename left,
+			    actions right. `border-b` + translucent blur lets the doc scroll
+			    cleanly underneath. */}
+			<div className="sticky top-0 z-10 border-b border-border bg-surface/85 backdrop-blur-md">
 				<div
-					className="flex items-center gap-2 rounded-[10px] border border-border bg-surface/85 px-2.5 py-1 shadow-sm backdrop-blur-md"
+					className="mx-auto flex max-w-3xl items-center justify-between gap-3 px-4 py-2.5 sm:px-6 lg:px-8"
 					data-testid="preview-review-toolbar"
 				>
 					<span
-						className="max-w-[45vw] truncate font-mono text-[13px] text-text-1"
+						className="min-w-0 flex-1 truncate font-mono text-[13px] text-text-1"
 						title={filename}
 					>
 						{filename}
 					</span>
-					<span className="h-4 w-px shrink-0 bg-border" aria-hidden />
-					<ReviewToolbarActions projectId={projectId} filename={filename} variant="inline" />
+					<div className="flex shrink-0 items-center gap-1">
+						<ReviewToolbarActions projectId={projectId} filename={filename} variant="inline" />
+						{/* Archived docs are read-only — mirror the Documents toolbar and drop
+						    Edit while keeping History. */}
+						{!doc.archived_at && (
+							<Tooltip content="Edit document">
+								<Link
+									to="/projects/$projectId/documents"
+									params={{ projectId }}
+									search={{ file: filename, edit: true }}
+									aria-label="Edit document"
+									className={ICON_ACTION_CLASSES}
+									data-testid="preview-edit"
+								>
+									<Pencil className="h-4 w-4" />
+								</Link>
+							</Tooltip>
+						)}
+						<Tooltip content="Revision history">
+							<Link
+								to="/projects/$projectId/documents"
+								params={{ projectId }}
+								search={{ file: filename, history: true }}
+								aria-label="Revision history"
+								className={ICON_ACTION_CLASSES}
+								data-testid="preview-history"
+							>
+								<History className="h-4 w-4" />
+							</Link>
+						</Tooltip>
+					</div>
 				</div>
 			</div>
-			<div className="max-w-3xl mx-auto px-4 py-8 sm:px-6 lg:px-8">
+			{/* pt-4 (was py-8) tightens the gap between the top bar and the metadata banner. */}
+			<div className="max-w-3xl mx-auto px-4 pt-4 pb-8 sm:px-6 lg:px-8">
 				<DocumentBody
 					projectId={projectId}
 					projectSlug={projectId}

--- a/packages/web/src/routes/projects/$projectId/documents.tsx
+++ b/packages/web/src/routes/projects/$projectId/documents.tsx
@@ -8,7 +8,7 @@ import {
 } from '@hezo/shared';
 import { createFileRoute } from '@tanstack/react-router';
 import { Loader2 } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { type DocItem, DocsLibrary } from '../../../components/docs-library';
 import { RevisionHistoryDialog } from '../../../components/document-review/revision-history-dialog';
 import { ViewingRevisionBanner } from '../../../components/document-review/viewing-revision-banner';
@@ -37,11 +37,15 @@ interface DocumentsSearch {
 	file?: string;
 	/** Archive filter — absent means the default Active view. */
 	filter?: ArchiveFilter;
+	/** Deep-link from a preview surface's Edit button: open `file` in edit mode. */
+	edit?: boolean;
+	/** Deep-link from a preview surface's History button: open the revision dialog. */
+	history?: boolean;
 }
 
 function ProjectDocumentsPage() {
 	const { projectId } = Route.useParams();
-	const { file, filter = ArchiveFilter.Active } = Route.useSearch();
+	const { file, filter = ArchiveFilter.Active, edit, history } = Route.useSearch();
 	const navigate = Route.useNavigate();
 
 	const { data: docs, isLoading: isLoadingList } = useProjectDocs(projectId);
@@ -64,12 +68,23 @@ function ProjectDocumentsPage() {
 	// Which past version (if any) is being viewed, and whether the history dialog is open.
 	const [viewingRevision, setViewingRevision] = useState<DocVersionEntry | null>(null);
 	const [historyOpen, setHistoryOpen] = useState(false);
+	const historyAutoOpenedRef = useRef(false);
 	// Return to the latest version whenever the selected file changes.
 	// biome-ignore lint/correctness/useExhaustiveDependencies: reset only on file switch
 	useEffect(() => {
 		setViewingRevision(null);
 		setHistoryOpen(false);
 	}, [file]);
+
+	// Honour a deep-linked `?history=1` from a preview surface once: open the
+	// revision dialog for the selected doc. Declared after the file-reset effect so
+	// it wins on the initial mount, and latched so closing the dialog is final.
+	useEffect(() => {
+		if (history && !historyAutoOpenedRef.current && file && !isAgentsMd) {
+			historyAutoOpenedRef.current = true;
+			setHistoryOpen(true);
+		}
+	}, [history, file, isAgentsMd]);
 
 	const versionEntries = useMemo(
 		() => (doc && !isAgentsMd ? buildDocVersionHistory(doc, revisions) : []),
@@ -263,6 +278,7 @@ function ProjectDocumentsPage() {
 					) : undefined
 				}
 				onShowHistory={file && !isAgentsMd ? () => setHistoryOpen(true) : undefined}
+				autoEdit={!!edit}
 				readOnly={!!viewingRevision}
 				emptyTitle="Select a document"
 				emptyDescription="Choose a project document from the list to view or edit it."
@@ -357,6 +373,12 @@ export const Route = createFileRoute('/projects/$projectId/documents')({
 		filter:
 			isArchiveFilter(search.filter) && search.filter !== ArchiveFilter.Active
 				? search.filter
+				: undefined,
+		// Drop when falsy so the deep-link flags never linger in the URL.
+		edit: search.edit === true || search.edit === '1' || search.edit === 'true' ? true : undefined,
+		history:
+			search.history === true || search.history === '1' || search.history === 'true'
+				? true
 				: undefined,
 	}),
 	component: ProjectDocumentsPage,

--- a/packages/web/test/project-doc-preview.test.tsx
+++ b/packages/web/test/project-doc-preview.test.tsx
@@ -178,6 +178,88 @@ test('the task-detail preview panel flags an archived doc in the metadata banner
 	expect(banner.textContent).toContain('Archived');
 });
 
+test('standalone preview route exposes Edit and History deep-links into the documents editor', async () => {
+	let ctx!: { projectSlug: string };
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Preview Actions' });
+			await seedDoc(ws, project, 'notes.md', '# Hello standalone');
+			ctx = { projectSlug: project.slug };
+		},
+	});
+
+	await router.navigate({
+		to: '/preview/$projectId/$filename',
+		params: { projectId: ctx.projectSlug, filename: 'notes.md' },
+	});
+
+	const editLink = (await findByTestId('preview-edit')) as HTMLAnchorElement;
+	const historyLink = (await findByTestId('preview-history')) as HTMLAnchorElement;
+	// Both point back at the authoritative Documents surface for this file — Edit
+	// opens it in edit mode, History opens the revision dialog.
+	expect(editLink.getAttribute('href')).toContain(`/projects/${ctx.projectSlug}/documents`);
+	expect(editLink.getAttribute('href')).toContain('file=notes.md');
+	expect(editLink.getAttribute('href')).toContain('edit');
+	expect(historyLink.getAttribute('href')).toContain('file=notes.md');
+	expect(historyLink.getAttribute('href')).toContain('history');
+});
+
+test('standalone preview hides Edit for an archived doc but keeps History', async () => {
+	let ctx!: { projectSlug: string };
+	const { findByTestId, queryByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Archived Actions' });
+			await seedDoc(ws, project, 'retired.md', '# Retired');
+			await archiveSeededDocument(ws, project, 'retired.md');
+			ctx = { projectSlug: project.slug };
+		},
+	});
+
+	await router.navigate({
+		to: '/preview/$projectId/$filename',
+		params: { projectId: ctx.projectSlug, filename: 'retired.md' },
+	});
+
+	// History stays reachable on an archived doc (revisions remain viewable); the
+	// Edit affordance is suppressed since an archived doc is read-only.
+	await findByTestId('preview-history');
+	expect(queryByTestId('preview-edit')).toBeNull();
+});
+
+test('the task-detail preview panel exposes Edit and History deep-links into the documents editor', async () => {
+	let ctx!: { projectSlug: string; taskId: string };
+	const { findByTestId, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Panel Actions Demo' });
+			await seedDoc(ws, project, 'ui-mockups.md', '# Mockups');
+			const task = await seedTask(ws, project, { title: 'Review the mockup' });
+			await seedComment(ws, task, 'Please review ui-mockups.md before the demo.');
+			ctx = { projectSlug: project.slug, taskId: task.id };
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: ctx.projectSlug, taskId: ctx.taskId },
+	});
+
+	const mention = await findByTestId('doc-mention-link', undefined, { timeout: 15_000 });
+	await user.click(mention);
+
+	const editLink = (await findByTestId('preview-edit')) as HTMLAnchorElement;
+	const historyLink = (await findByTestId('preview-history')) as HTMLAnchorElement;
+	expect(editLink.getAttribute('href')).toContain(`/projects/${ctx.projectSlug}/documents`);
+	expect(editLink.getAttribute('href')).toContain('file=ui-mockups.md');
+	expect(editLink.getAttribute('href')).toContain('edit');
+	expect(historyLink.getAttribute('href')).toContain('history');
+});
+
 test('a doc mention in a task comment opens the preview panel instead of a new tab', async () => {
 	let ctx!: { projectSlug: string; taskId: string };
 	const { container, findByTestId, user, router } = await renderApp({

--- a/packages/web/test/project-documents.test.tsx
+++ b/packages/web/test/project-documents.test.tsx
@@ -130,6 +130,69 @@ test('shows revision history via the History dialog and restores a previous vers
 	await findByText('Original plan', undefined, { timeout: 15_000 });
 });
 
+test('a deep-linked ?edit=1 opens the selected doc directly in edit mode', async () => {
+	let ws!: SeededWorkspace;
+	let projectSlug = '';
+	const filename = `edit-link-${Math.random().toString(36).slice(2, 8)}.md`;
+
+	const { findByRole, container, router } = await renderApp({
+		initialPath: '/',
+		seed: async ({ apiBase, token }) => {
+			ws = await seedWorkspace();
+			const project = await seedProject(ws, {
+				name: uniqueName('Edit Deep Link'),
+				description: 'Tests the ?edit=1 deep-link from a preview surface.',
+			});
+			projectSlug = project.slug;
+			await seedDoc(apiBase, token, projectSlug, filename, [{ content: 'Deep link body' }]);
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/documents',
+		params: { projectId: projectSlug },
+		search: { file: filename, edit: true } as never,
+	});
+
+	// Lands in edit mode: the Save action and the editor textarea are present
+	// (rather than the read-only Edit button), seeded with the loaded content.
+	await findByRole('button', { name: 'Save' }, { timeout: 15_000 });
+	const editArea = container.querySelector('textarea') as HTMLTextAreaElement;
+	expect(editArea).toBeTruthy();
+	expect(editArea.value).toContain('Deep link body');
+});
+
+test('a deep-linked ?history=1 opens the revision-history dialog', async () => {
+	let ws!: SeededWorkspace;
+	let projectSlug = '';
+	const filename = `history-link-${Math.random().toString(36).slice(2, 8)}.md`;
+
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async ({ apiBase, token }) => {
+			ws = await seedWorkspace();
+			const project = await seedProject(ws, {
+				name: uniqueName('History Deep Link'),
+				description: 'Tests the ?history=1 deep-link from a preview surface.',
+			});
+			projectSlug = project.slug;
+			await seedDoc(apiBase, token, projectSlug, filename, [
+				{ content: 'First' },
+				{ content: 'Second', change_summary: 'revise' },
+			]);
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/documents',
+		params: { projectId: projectSlug },
+		search: { file: filename, history: true } as never,
+	});
+
+	// The revision dialog opens on load without clicking the History button.
+	await findByTestId('revision-history-dialog', undefined, { timeout: 15_000 });
+});
+
 test('shows the metadata banner and hides a legacy metadata header from the rendered body', async () => {
 	let ws!: SeededWorkspace;
 	let projectSlug = '';


### PR DESCRIPTION
## What & why

The document **preview** surfaces — the task-sidebar preview panel and the standalone new-tab preview route — were read-only viewers with no way to edit the document or reach its version history. Only the Documents page toolbar carried **Edit** and **History**. This makes those two actions available on *all* views of a document, and cleans up the new-tab view's layout.

## Changes

**Edit & History on every doc view**
- Both preview surfaces now show **Edit** (pencil) and **History** (clock) buttons alongside the existing review toolbar, styled to match the surrounding icon buttons.
- They deep-link into the authoritative Documents editor rather than duplicating the editor/history machinery:
  - `?edit=1` → `DocsLibrary` gains an `autoEdit` prop, honoured **once** after the doc content has loaded (so the editor seeds from the loaded text, not an empty draft); it's a no-op for read-only/archived docs.
  - `?history=1` → the Documents page opens the revision-history dialog on load.
- **Edit is hidden while a document is archived** (archived docs are read-only), mirroring the Documents toolbar; **History stays reachable**.

**New-tab preview top bar (layout)**
- Replaced the centered floating pill with a **full content-width** sticky bar: filename **left-aligned**, action buttons **right-aligned** (`justify-between`, `border-b` + translucent blur so the doc scrolls cleanly underneath).
- **Tightened the gap** between the top bar and the metadata banner (content padding `py-8` → `pt-4 pb-8`).

**Docs**
- Updated `docs/concepts/documents-and-memory.md` to describe the new Edit/History affordances on the preview views.

## Testing

- `bunx vitest run` (full web suite): **1050 passed / 176 files**.
- New component tests:
  - Edit/History deep-links present with correct `?file=…&edit`/`&history` hrefs on both the standalone preview and the task-sidebar panel.
  - Archived doc → Edit hidden, History kept (standalone preview).
  - `?edit=1` lands the Documents page directly in edit mode with the loaded content in the editor.
  - `?history=1` opens the revision-history dialog on load.
- `typecheck` and `biome check` clean on the changed files; `docs-bundle` test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYRpdji7XNsMhCPT8QTUGv

---
_Generated by [Claude Code](https://claude.ai/code/session_01GYRpdji7XNsMhCPT8QTUGv)_