### PR TITLE
fix: keep document preview panel top pinned on scroll

### DIFF
--- a/packages/web/src/components/task-detail/preview-panel.tsx
+++ b/packages/web/src/components/task-detail/preview-panel.tsx
@@ -33,10 +33,19 @@ export function PreviewPanel({ item, onClose, task }: PreviewPanelProps) {
 	const openUrl = docPreviewPath(item.projectSlug, item.filename);
 	const meta = formatBytes(item.size);
 
+	// Below lg the panel is a full-screen overlay (fixed inset-0). At lg+ it's an
+	// in-grid sticky column: pinned `top-4` below the shell scroller so its top never
+	// scrolls out of view. The max-height must keep the panel inside the scroller's
+	// visible area — the shell scroller (<main>) sits below the h-12 (3rem) app
+	// header, so `100vh` overshoots it. Subtracting the header (3rem) plus the
+	// `top-4` offset (1rem) = 4rem sizes the panel to fit exactly: a sticky box
+	// taller than its scrollport has too little room in its grid cell and its top
+	// rides up on scroll, which is precisely what an oversized (100vh − 2rem) panel
+	// did.
 	return (
 		<aside
 			data-testid="preview-panel"
-			className="fixed inset-0 z-[60] flex min-h-0 flex-col overflow-hidden bg-surface lg:inset-auto lg:z-auto lg:sticky lg:top-4 lg:max-h-[calc(100vh-2rem)] lg:rounded-lg lg:border lg:border-border"
+			className="fixed inset-0 z-[60] flex min-h-0 flex-col overflow-hidden bg-surface lg:inset-auto lg:z-auto lg:sticky lg:top-4 lg:max-h-[calc(100vh-4rem)] lg:rounded-lg lg:border lg:border-border"
 		>
 			<div className="flex items-center gap-2 border-b border-border bg-surface-2 px-3 py-2">
 				<span

--- a/test/browser/task-doc-preview-sticky.spec.ts
+++ b/test/browser/task-doc-preview-sticky.spec.ts
@@ -1,0 +1,141 @@
+// Real-CSS-layout assertion (testing decision tree, point 1): the in-page
+// document preview panel is a `position: sticky` grid column pinned below the
+// shell scroller. Whether its top stays pinned on scroll — and whether the panel
+// fits within the scroller's visible area rather than overflowing below the fold —
+// depends on the sticky box's height resolving against the real viewport and its
+// grid cell, values happy-dom can't compute. So this lives in Playwright. The
+// mention→panel flow itself is covered by
+// packages/web/test/task-comment-doc-preview.test.tsx, and the resize/width
+// behaviour by task-doc-preview-{resize,width}.spec.ts.
+
+import type { Page } from '@playwright/test';
+import { expect, test } from './fixtures';
+import { createProjectAndClearPlanning, uniqueName, waitForPageLoad } from './helpers';
+
+const DOC = 'guidelines.md';
+// A doc long enough that the preview body overflows and the panel is driven to its
+// max-height cap — the height whose (mis)sizing this spec guards.
+const DOC_CONTENT = `# Guidelines\n\n${Array.from(
+	{ length: 120 },
+	(_, i) => `## Section ${i}\n\nParagraph body for section ${i}.`,
+).join('\n\n')}`;
+
+async function seedTaskWithLongThread(
+	page: Page,
+	token: string,
+): Promise<{ projectSlug: string; taskId: string }> {
+	const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+
+	const project = await createProjectAndClearPlanning(page, '', token, {
+		name: uniqueName('Doc Preview Sticky'),
+		description: 'Preview panel sticky-height test.',
+	});
+
+	const agentsRes = await page.request.get(`/api/projects/${project.slug}/agents`, { headers });
+	const agents = ((await agentsRes.json()) as { data: Array<{ id: string; slug: string }> }).data;
+	const assigneeId = (agents.find((a) => a.slug === 'captain') ?? agents[0]).id;
+
+	const docRes = await page.request.put(`/api/projects/${project.slug}/docs/${DOC}`, {
+		headers,
+		data: { content: DOC_CONTENT },
+	});
+	expect(docRes.ok()).toBe(true);
+
+	const taskRes = await page.request.post(`/api/projects/${project.slug}/tasks`, {
+		headers,
+		data: { project_id: project.id, title: 'Review the guidelines', assignee_id: assigneeId },
+	});
+	const task = ((await taskRes.json()) as { data: { id: string; identifier: string } }).data;
+
+	// The first comment carries the bare-filename mention that opens the in-page
+	// preview panel. The rest pad the thread so the main content column overflows
+	// the viewport, giving the shell <main> a real scroll range to test pinning.
+	const bodies = [
+		`Please review ${DOC} before we ship.`,
+		...Array.from({ length: 24 }, (_, i) => `Follow-up note ${i} adding thread height to scroll.`),
+	];
+	for (const text of bodies) {
+		const res = await page.request.post(`/api/projects/${project.slug}/tasks/${task.id}/comments`, {
+			headers,
+			data: { content_type: 'text', content: { text } },
+		});
+		expect(res.ok()).toBe(true);
+	}
+
+	return { projectSlug: project.slug, taskId: task.identifier.toLowerCase() };
+}
+
+test('the document preview panel fits the viewport and its top stays pinned on scroll', async ({
+	sharedPage: page,
+	sharedWorkspace,
+}) => {
+	const { token } = sharedWorkspace;
+	const viewport = { width: 1280, height: 800 };
+	await page.setViewportSize(viewport);
+
+	const { projectSlug, taskId } = await seedTaskWithLongThread(page, token);
+	await page.goto(`/projects/${projectSlug}/tasks/${taskId}`);
+	await waitForPageLoad(page);
+
+	// Open the doc in the in-grid preview panel (lg+ sticky column).
+	const mention = page.getByTestId('doc-mention-link').first();
+	await expect(mention).toBeVisible({ timeout: 20000 });
+	await mention.click();
+
+	const panel = page.getByTestId('preview-panel');
+	await expect(panel).toBeVisible();
+	const header = page.getByTestId('preview-panel-filename');
+	await expect(header).toBeVisible();
+
+	const scroller = page.locator('main').first();
+	const mainBox = await scroller.boundingBox();
+	expect(mainBox).not.toBeNull();
+	if (!mainBox) return;
+
+	// The long doc drives the panel to its max-height cap — confirm the cap actually
+	// engaged (the panel is nearly as tall as the scroller's visible area), otherwise
+	// a trivially short panel would pass the fit check below without exercising the
+	// sizing at all.
+	const box0 = await panel.boundingBox();
+	expect(box0).not.toBeNull();
+	if (!box0) return;
+	expect(box0.height).toBeGreaterThan(mainBox.height - 48);
+
+	// The padded thread gives the scroller a real, meaningful range to scroll.
+	const range = await scroller.evaluate((el) => el.scrollHeight - el.clientHeight);
+	expect(range).toBeGreaterThan(300);
+
+	// Scroll to a mid position (well past the layout's top padding so the sticky
+	// panel is docked at its `top-4` offset, and well clear of the bottom where a
+	// sticky box legitimately releases with its containing block).
+	const midA = Math.round(range * 0.35);
+	await scroller.evaluate((el, top) => el.scrollTo({ top }), midA);
+	await expect.poll(() => scroller.evaluate((el) => el.scrollTop)).toBeGreaterThan(midA - 4);
+
+	// Pinned, the panel sits entirely within the scroller's visible area: its top
+	// docked just below the app header and its bottom above the fold. The old
+	// max-height (100vh − 2rem) ignored the h-12 (3rem) app header the scroller sits
+	// below, so the pinned panel overran the scroller's bottom by ~2rem — this bound
+	// fails on that sizing (bottom ≈ mainBottom + 32) and holds on the corrected one.
+	const pinned = await panel.boundingBox();
+	const headerTop1 = (await header.boundingBox())?.y ?? -1;
+	expect(pinned).not.toBeNull();
+	if (!pinned) return;
+	expect(pinned.y).toBeGreaterThanOrEqual(mainBox.y - 1);
+	expect(pinned.y + pinned.height).toBeLessThanOrEqual(mainBox.y + mainBox.height + 2);
+	// Docked near the top of the scroller (below the header, at the sticky offset),
+	// not risen out of view.
+	expect(headerTop1).toBeGreaterThanOrEqual(mainBox.y - 1);
+	expect(headerTop1).toBeLessThan(mainBox.y + 40);
+
+	// Scroll further (still clear of the bottom): the panel top does not scroll out
+	// of view — its header stays pinned at the same y. A panel taller than the
+	// scrollport has too little stick room in its grid cell and its top rides up on
+	// scroll — the symptom the height fix removes.
+	const midB = Math.round(range * 0.65);
+	await scroller.evaluate((el, top) => el.scrollTo({ top }), midB);
+	await expect.poll(() => scroller.evaluate((el) => el.scrollTop)).toBeGreaterThan(midB - 4);
+	const headerTop2 = (await header.boundingBox())?.y ?? -1;
+	expect(headerTop2).toBeGreaterThanOrEqual(mainBox.y - 1);
+	expect(Math.abs(headerTop2 - headerTop1)).toBeLessThanOrEqual(2);
+});


### PR DESCRIPTION
## Summary

The in-grid document preview panel on the task-detail surface (opened by clicking a doc mention in a comment) is a `position: sticky` column pinned `top-4` below the shell scroller. Its top was scrolling out of view as the page scrolled.

**Root cause:** the panel's `max-height` was `calc(100vh - 2rem)`, which treats the browser viewport as the scroll container. But the actual scroller (`<main>`) sits *below* the `h-12` (3rem) app header, so `100vh` overshoots the visible scroll area by ~2rem. That made the panel taller than its scrollport, leaving too little "stick room" in its grid cell — a sticky box with no room rides its top up and out of view on scroll, and its bottom was also cut off below the fold.

**Fix:** size the panel to fit exactly within the scroller by subtracting the header (3rem) plus the `top-4` sticky offset (1rem): `calc(100vh - 4rem)`. The panel now fits within `<main>`'s visible area, always has enough stick room, and its top stays pinned while the page scrolls. This mirrors the sizing convention already used by the documents-library sidebar.

## Changes

- `packages/web/src/components/task-detail/preview-panel.tsx`: `lg:max-h-[calc(100vh-2rem)]` → `lg:max-h-[calc(100vh-4rem)]`, with a comment explaining the header/offset math.
- `test/browser/task-doc-preview-sticky.spec.ts`: new Playwright spec (real CSS layout, per the testing decision tree) that opens the preview panel over a long doc + padded thread and asserts the pinned panel fits within the `<main>` scroller and its header does not rise on scroll.

## Testing

- `bunx playwright test test/browser/task-doc-preview-sticky.spec.ts` — passes on the fix.
- Verified the new spec **fails** on the pre-fix `calc(100vh - 2rem)` sizing (genuine regression guard) and passes on `calc(100vh - 4rem)`.
- Sibling specs `task-doc-preview-width` and `task-doc-preview-resize` still pass (height change doesn't affect width/resize).
- `bun run typecheck` and biome check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ewhsav3NtQkPcArsjSggoo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ewhsav3NtQkPcArsjSggoo)_