### PR TITLE
feat: standardize comment wakeups on active @-mentions

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -493,7 +493,8 @@ Work reaches an agent through the **wakeup → job-manager → agent-runner** pi
 
 **Wakeups.** Every trigger is an `agent_wakeup_requests` row. Sources: `heartbeat`
 (scheduled fallback tick), `timer` (recovery: orphan detector, retry), `assignment`,
-`mention`, `reply`, `comment` (opt-in assignee wake), `credential_provided` (a human
+`mention`, `reply`, `comment` (a system-posted comment wake; user comments wake agents
+only by actively `@`-mentioning them, never implicitly), `credential_provided` (a human
 supplied a requested credential), `on_demand`, `automation`.
 Event-based triggers wake agents immediately; scheduled heartbeats are the idle-agent
 fallback. A scheduled heartbeat that fires but finds no actionable task is a no-op that

--- a/packages/server/src/routes/comments.ts
+++ b/packages/server/src/routes/comments.ts
@@ -171,7 +171,6 @@ commentsRoutes.post('/projects/:projectId/tasks/:taskId/comments', async (c) => 
 		content_type?: string;
 		content: Record<string, unknown>;
 		effort?: string;
-		wake_assignee?: boolean;
 		parent_comment_id?: string | null;
 		attachment_ids?: string[];
 	}>();
@@ -234,11 +233,6 @@ commentsRoutes.post('/projects/:projectId/tasks/:taskId/comments', async (c) => 
 	// An API key authors as its first-class identity, not a member.
 	const authorApiKeyId = apiKeyIdFromAuth(auth);
 
-	// Only Admin (human) callers can opt into waking the assignee on a plain
-	// comment. Agent-authored comments (via the /mcp create_comment tool) keep
-	// mention-only behavior regardless of the body field.
-	const wakeAssignee = auth.type === AuthType.Admin && body.wake_assignee === true;
-
 	const result = await withTransaction(db, async () => {
 		const inserted = await db.query<{ id: string }>(
 			`INSERT INTO task_comments (task_id, author_member_id, author_api_key_id, parent_comment_id, content_type, content)
@@ -276,7 +270,6 @@ commentsRoutes.post('/projects/:projectId/tasks/:taskId/comments', async (c) => 
 		authorUserId: auth.type === AuthType.Admin ? auth.userId : null,
 		authorRunId: auth.type === AuthType.Agent ? auth.runId : null,
 		effort: commentEffort,
-		wakeAssignee,
 		parentCommentId,
 		wsManager: c.get('wsManager'),
 	});

--- a/packages/server/src/services/comment-wakeups.ts
+++ b/packages/server/src/services/comment-wakeups.ts
@@ -25,7 +25,6 @@ export interface FireCommentWakeupsParams {
 	authorUserId?: string | null;
 	authorRunId?: string | null;
 	effort?: string | null;
-	wakeAssignee?: boolean;
 	parentCommentId?: string | null;
 	wsManager?: WebSocketManager;
 }
@@ -41,7 +40,6 @@ export async function fireCommentWakeups(params: FireCommentWakeupsParams): Prom
 		authorMemberId,
 		authorUserId,
 		effort,
-		wakeAssignee,
 		parentCommentId,
 		wsManager,
 	} = params;
@@ -98,26 +96,6 @@ export async function fireCommentWakeups(params: FireCommentWakeupsParams): Prom
 				idempotencyKey,
 			).catch((e) => log.error('Failed to create mention wakeup:', e)),
 		);
-	}
-
-	if (wakeAssignee) {
-		const taskRow = await db.query<{ assignee_id: string | null }>(
-			'SELECT assignee_id FROM tasks WHERE id = $1 AND team_id = $2',
-			[taskId, teamId],
-		);
-		const assigneeId = taskRow.rows[0]?.assignee_id ?? null;
-		if (assigneeId && assigneeId !== authorMemberId && !mentionedAgentIds.has(assigneeId)) {
-			const isAgent = await db.query('SELECT id FROM member_agents WHERE id = $1', [assigneeId]);
-			if (isAgent.rows.length > 0) {
-				wakeupPromises.push(
-					createWakeup(db, assigneeId, teamId, WakeupSource.Comment, {
-						task_id: taskId,
-						comment_id: commentId,
-						...effortPayload,
-					}).catch((e) => log.error('Failed to create comment wakeup:', e)),
-				);
-			}
-		}
 	}
 
 	await Promise.all(wakeupPromises);

--- a/packages/server/test/comment-wakeups.test.ts
+++ b/packages/server/test/comment-wakeups.test.ts
@@ -312,7 +312,7 @@ describe('non-text comments skip mention wakeups', () => {
 	});
 });
 
-describe('admin POST comments honors wake_assignee opt-in', () => {
+describe('admin POST comments wake only via active @-mention', () => {
 	async function postAdminComment(taskId: string, body: Record<string, unknown>): Promise<string> {
 		const res = await app.request(`/api/projects/${projectSlug}/tasks/${taskId}/comments`, {
 			method: 'POST',
@@ -323,8 +323,19 @@ describe('admin POST comments honors wake_assignee opt-in', () => {
 		return (await res.json()).data.id;
 	}
 
-	it('wakes the assignee when wake_assignee is true', async () => {
-		const taskId = await insertTask(architectId, 'Admin wake true');
+	it('does not wake the assignee on a plain comment', async () => {
+		const taskId = await insertTask(architectId, 'Admin plain comment');
+		const commentId = await postAdminComment(taskId, {
+			content_type: CommentContentType.Text,
+			content: { text: 'Just a note — nobody is paged.' },
+		});
+
+		const wakeups = await wakeupsForComment(commentId);
+		expect(wakeups).toEqual([]);
+	});
+
+	it('ignores a legacy wake_assignee flag (wakeups are mention-only now)', async () => {
+		const taskId = await insertTask(architectId, 'Admin legacy flag');
 		const commentId = await postAdminComment(taskId, {
 			content_type: CommentContentType.Text,
 			content: { text: 'Take a look when you can.' },
@@ -332,48 +343,22 @@ describe('admin POST comments honors wake_assignee opt-in', () => {
 		});
 
 		const wakeups = await wakeupsForComment(commentId);
-		expect(wakeups).toHaveLength(1);
-		expect(wakeups[0].source).toBe(WakeupSource.Comment);
-		expect(wakeups[0].member_id).toBe(architectId);
-		expect(wakeups[0].payload.task_id).toBe(taskId);
-		expect(wakeups[0].payload.comment_id).toBe(commentId);
-	});
-
-	it('does not wake the assignee when wake_assignee is false', async () => {
-		const taskId = await insertTask(architectId, 'Admin wake false');
-		const commentId = await postAdminComment(taskId, {
-			content_type: CommentContentType.Text,
-			content: { text: 'Just a note.' },
-			wake_assignee: false,
-		});
-
-		const wakeups = await wakeupsForComment(commentId);
 		expect(wakeups).toEqual([]);
 	});
 
-	it('does not wake the assignee when wake_assignee is omitted', async () => {
-		const taskId = await insertTask(architectId, 'Admin wake omitted');
-		const commentId = await postAdminComment(taskId, {
-			content_type: CommentContentType.Text,
-			content: { text: 'No flag at all.' },
-		});
-
-		const wakeups = await wakeupsForComment(commentId);
-		expect(wakeups).toEqual([]);
-	});
-
-	it('does not double-fire when the assignee is also @-mentioned', async () => {
-		const taskId = await insertTask(architectId, 'Admin wake mention overlap');
+	it('wakes the assignee when it is actively @-mentioned', async () => {
+		const taskId = await insertTask(architectId, 'Admin mention assignee');
 		const commentId = await postAdminComment(taskId, {
 			content_type: CommentContentType.Text,
 			content: { text: '@architect please weigh in.' },
-			wake_assignee: true,
 		});
 
 		const wakeups = await wakeupsForComment(commentId);
 		expect(wakeups).toHaveLength(1);
 		expect(wakeups[0].source).toBe(WakeupSource.Mention);
 		expect(wakeups[0].member_id).toBe(architectId);
+		expect(wakeups[0].payload.task_id).toBe(taskId);
+		expect(wakeups[0].payload.comment_id).toBe(commentId);
 	});
 });
 

--- a/packages/server/test/comments-routes-uncovered.test.ts
+++ b/packages/server/test/comments-routes-uncovered.test.ts
@@ -18,7 +18,7 @@ import {
 // Line-coverage tests for packages/server/src/routes/comments.ts over real
 // HTTP: the comment list with reactions + attachments, reaction round-trips
 // (incl. the no-member-identity 403), comment creation (attachments,
-// wake_assignee, agent author, reply wakeups), the fulfill-credential flow
+// mention-only wakeups, agent author, reply wakeups), the fulfill-credential flow
 // across every secret-category kind (host overrides, body substitution,
 // requester wakeups) and resolve-asset-deletion approve/deny with all its
 // validation branches.
@@ -308,24 +308,19 @@ describe('POST comment — creation branches', () => {
 		expect(joins.rows).toHaveLength(1);
 	});
 
-	it('wake_assignee=true from an admin wakes the assignee agent', async () => {
-		await db.query(
-			`DELETE FROM agent_wakeup_requests WHERE member_id = $1 AND source = 'comment'`,
-			[agentId],
-		);
+	it('a plain admin comment does not wake the assignee (wakeups are mention-only)', async () => {
 		const res = await postComment({
 			content_type: 'text',
 			content: { text: 'please pick this up' },
-			wake_assignee: true,
 		});
 		expect(res.status).toBe(201);
 		const commentId = (await res.json()).data.id;
-		const wakeup = await db.query<{ source: string }>(
-			`SELECT source::text AS source FROM agent_wakeup_requests
+		const wakeup = await db.query(
+			`SELECT 1 FROM agent_wakeup_requests
 			 WHERE member_id = $1 AND payload->>'comment_id' = $2`,
 			[agentId, commentId],
 		);
-		expect(wakeup.rows.length).toBeGreaterThanOrEqual(1);
+		expect(wakeup.rows).toHaveLength(0);
 	});
 
 	it('an agent-authored comment carries the agent identity', async () => {

--- a/packages/shared/src/mentions/tokens.ts
+++ b/packages/shared/src/mentions/tokens.ts
@@ -137,6 +137,28 @@ export function extractMentionCandidates(value: string): MentionCandidates {
 }
 
 /**
+ * The active-agent slugs in `value` — the ones that page an agent. Unlike
+ * `extractMentionCandidates().agents` (which merges active `@slug` and passive
+ * `@@slug` into one list), this keeps only active `@slug` mentions, since a
+ * passive mention never wakes anyone. `@admin` is excluded (it fans out to the
+ * human inbox, not an agent). Code blocks and inline code are stripped, and
+ * results are lowercased and deduped. Mirrors the server's comment-wakeup rule
+ * so the composer's "Wake:" preview matches who actually gets woken.
+ */
+export function extractActiveAgentMentionSlugs(value: string): string[] {
+	const stripped = stripCode(value);
+	const slugs = new Set<string>();
+	const re = buildMentionRegex();
+	let m = re.exec(stripped);
+	while (m !== null) {
+		const token = parseMentionMatch(m);
+		if (token.kind === 'agent' && token.slug !== ADMIN_MENTION_SLUG) slugs.add(token.slug);
+		m = re.exec(stripped);
+	}
+	return Array.from(slugs);
+}
+
+/**
  * The inverse of {@link extractMentionCandidates}: pulls resolvable references
  * that are wrapped in *inline code* (and therefore render inert) instead of from
  * the surrounding prose. Fenced and indented code blocks are excluded — those

--- a/packages/shared/test/mentions-tokens.test.ts
+++ b/packages/shared/test/mentions-tokens.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
 	buildMentionRegex,
+	extractActiveAgentMentionSlugs,
 	extractBacktickedMentionCandidates,
 	extractDocCandidates,
 	extractMentionCandidates,
@@ -179,6 +180,25 @@ describe('extractMentionCandidates', () => {
 		expect(c.filenames).toEqual(['readme.md']);
 		expect(c.assets).toEqual(['diagram.png']);
 		expect(sorted(c.agents)).toEqual(['alice', 'bob']);
+	});
+});
+
+describe('extractActiveAgentMentionSlugs', () => {
+	it('keeps only active @slug mentions (drops passive, @admin, and code)', () => {
+		const input = [
+			'@alice pinged @@bob passively and cc @admin',
+			'again @Alice (dup, different case)',
+			'```',
+			'@charlie in a fenced block',
+			'```',
+			'inline `@dave` too',
+		].join('\n');
+		expect(sorted(extractActiveAgentMentionSlugs(input))).toEqual(['alice']);
+	});
+
+	it('returns [] when there is no active mention', () => {
+		expect(extractActiveAgentMentionSlugs('just @@passive and @admin here')).toEqual([]);
+		expect(extractActiveAgentMentionSlugs('')).toEqual([]);
 	});
 });
 

--- a/packages/web/src/components/project-intake-home-panel.tsx
+++ b/packages/web/src/components/project-intake-home-panel.tsx
@@ -32,6 +32,15 @@ export function ProjectIntakeHomePanel({ intake }: ProjectIntakeHomePanelProps) 
 		return textComments[textComments.length - 1];
 	}, [comments]);
 
+	// The CEO owns this intake and always greets first, so there is a CEO comment
+	// to reply to. Threading the admin's message to it wakes the CEO via the
+	// reply path (WakeupSource.Reply) — the standardized way a comment pages an
+	// agent now that plain comments no longer implicitly wake the assignee.
+	const lastCeoComment = useMemo(
+		() => [...(comments ?? [])].reverse().find((c) => c.author_type === 'agent'),
+		[comments],
+	);
+
 	useEffect(() => {
 		if (lastChatMessage?.author_type === 'agent') {
 			setAwaitingReply(false);
@@ -45,7 +54,10 @@ export function ProjectIntakeHomePanel({ intake }: ProjectIntakeHomePanelProps) 
 		setMessage('');
 		setAwaitingReply(true);
 		try {
-			await createComment.mutateAsync({ content: text, wake_assignee: true });
+			await createComment.mutateAsync({
+				content: text,
+				...(lastCeoComment ? { parent_comment_id: lastCeoComment.id } : {}),
+			});
 		} catch {
 			setAwaitingReply(false);
 		}

--- a/packages/web/src/components/task-detail/comment-composer.tsx
+++ b/packages/web/src/components/task-detail/comment-composer.tsx
@@ -1,11 +1,14 @@
-import type { AgentEffort } from '@hezo/shared';
+import { type AgentEffort, extractActiveAgentMentionSlugs } from '@hezo/shared';
 import { CornerDownRight, Loader2, Trash2 } from 'lucide-react';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
+import { useAgents } from '../../hooks/use-agents';
 import type { Comment, useCreateComment } from '../../hooks/use-comments';
 import type { Task } from '../../hooks/use-tasks';
 import { CommentAttachmentsDrop } from '../comment-attachments-drop';
 import { MentionTextarea } from '../mention-textarea';
+import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
+import { InfoTooltip } from '../ui/info-tooltip';
 
 type CreateCommentMutation = ReturnType<typeof useCreateComment>;
 
@@ -38,11 +41,12 @@ function previewCommentText(c: Comment): string {
 
 /**
  * The bottom-of-page comment-entry form: a MentionTextarea wrapped in a
- * drag-drop attachments target, a "wake assignee on submit" toggle (hidden when
- * replying to an agent's comment, since the reply already wakes that agent), and
- * the submit button. The "Effort" select
- * lives in the sidebar but writes into the same commentEffort state — owned
- * by the route component and passed in. `replyTarget` is similarly owned
+ * drag-drop attachments target, a "Wake:" preview row that pills every agent
+ * this comment will page, and the submit button. A comment wakes an agent only
+ * when it actively `@`-mentions it (replying to an agent's comment counts too,
+ * via WakeupSource.Reply) — there is no implicit assignee wake. The "Effort"
+ * select lives in the sidebar but writes into the same commentEffort state —
+ * owned by the route component and passed in. `replyTarget` is similarly owned
  * upstream so the comments list can `Reply →` into the composer.
  */
 export function CommentComposer({
@@ -59,12 +63,34 @@ export function CommentComposer({
 	commentTextareaRef,
 }: CommentComposerProps) {
 	const [commentText, setCommentText] = useState('');
-	const [wakeAssignee, setWakeAssignee] = useState(true);
 	const [pendingAttachmentIds, setPendingAttachmentIds] = useState<string[]>([]);
 
-	// Replying to an agent's comment already wakes that agent (WakeupSource.Reply),
-	// so the "wake assignee" toggle is redundant there — hide it and omit the flag.
+	// Replying to an agent's comment wakes that agent (WakeupSource.Reply) even
+	// without an explicit `@`-mention, so it joins the wake preview below.
 	const replyingToAgent = replyTarget?.author_type === 'agent';
+
+	const { data: agents } = useAgents(projectId);
+
+	// The agents this comment will wake when posted: every actively `@`-mentioned
+	// agent resolvable in the project roster (which includes the HQ CEO/Coach),
+	// plus the reply-target agent. Deduped by id, so an agent that is both
+	// mentioned and replied-to shows once. Mirrors the server's wakeup fan-out.
+	const wakeAgents = useMemo(() => {
+		const roster = agents ?? [];
+		const bySlug = new Map(roster.map((a) => [a.slug.toLowerCase(), a] as const));
+		const picked = new Map<string, { id: string; name: string }>();
+		for (const slug of extractActiveAgentMentionSlugs(commentText)) {
+			const a = bySlug.get(slug);
+			if (a) picked.set(a.id, { id: a.id, name: a.title });
+		}
+		if (replyingToAgent && replyTarget) {
+			const replyId = replyTarget.author_member_id;
+			const a = replyId ? roster.find((r) => r.id === replyId) : undefined;
+			const id = a?.id ?? replyId ?? `reply:${replyTarget.id}`;
+			picked.set(id, { id, name: a?.title ?? replyTarget.author_name });
+		}
+		return Array.from(picked.values());
+	}, [agents, commentText, replyingToAgent, replyTarget]);
 
 	async function handleComment(e: React.FormEvent) {
 		e.preventDefault();
@@ -72,13 +98,11 @@ export function CommentComposer({
 		await createComment.mutateAsync({
 			content: commentText,
 			...(commentEffort ? { effort: commentEffort } : {}),
-			...(task.assignee_id && !replyingToAgent ? { wake_assignee: wakeAssignee } : {}),
 			...(replyTarget ? { parent_comment_id: replyTarget.id } : {}),
 			...(pendingAttachmentIds.length > 0 ? { attachment_ids: pendingAttachmentIds } : {}),
 		});
 		setCommentText('');
 		setCommentEffort(null);
-		setWakeAssignee(true);
 		setReplyTarget(null);
 		setPendingAttachmentIds([]);
 	}
@@ -134,19 +158,31 @@ export function CommentComposer({
 						</button>
 					</div>
 				)}
-				<div className="flex items-center justify-end gap-2">
-					{task.assignee_id && !replyingToAgent && (
-						<label className="flex items-center gap-2 text-[13px] text-text-2 cursor-pointer select-none">
-							<input
-								type="checkbox"
-								checked={wakeAssignee}
-								onChange={(e) => setWakeAssignee(e.target.checked)}
-								className="rounded"
-								aria-label="Wake assignee on submit"
-							/>
-							<span>Wake assignee</span>
-						</label>
-					)}
+				<div className="flex flex-wrap items-center justify-between gap-2">
+					<div
+						className="flex flex-wrap items-center gap-1.5 min-w-0 text-[13px] text-text-2"
+						data-testid="wake-preview"
+					>
+						<span className="shrink-0">Wake:</span>
+						<InfoTooltip
+							label="Who this comment wakes"
+							data-testid="wake-preview-info"
+							content={
+								wakeAgents.length > 0
+									? 'These agents will be woken up when this comment is posted.'
+									: '@-mention an agent to wake it up when this comment is posted.'
+							}
+						/>
+						{wakeAgents.length === 0 ? (
+							<span className="text-text-3">(no one)</span>
+						) : (
+							wakeAgents.map((a) => (
+								<Badge key={a.id} color="info" testId="wake-pill">
+									{a.name}
+								</Badge>
+							))
+						)}
+					</div>
 					<Button
 						type="submit"
 						size="sm"

--- a/packages/web/src/hooks/use-comments.ts
+++ b/packages/web/src/hooks/use-comments.ts
@@ -61,7 +61,6 @@ export function useCreateComment(projectId: string, taskId: string) {
 			content: string;
 			content_type?: string;
 			effort?: string;
-			wake_assignee?: boolean;
 			parent_comment_id?: string;
 			attachment_ids?: string[];
 		}) => api.post<Comment>(`/api/projects/${projectId}/tasks/${taskId}/comments`, data),

--- a/packages/web/test/onboarding-home.test.tsx
+++ b/packages/web/test/onboarding-home.test.tsx
@@ -1,3 +1,4 @@
+import { waitFor } from '@testing-library/react';
 import { expect, test } from 'vitest';
 import { getTestContext, renderApp } from './helpers/render';
 
@@ -41,4 +42,51 @@ test('renders the CEO intake panel once an open intake exists', async () => {
 	await findByTestId('home-project-intake', undefined, { timeout: 20_000 });
 	// The conversation composer is present so the admin can reply (and approve) in-thread.
 	await findByTestId('home-project-intake-input', undefined, { timeout: 20_000 });
+});
+
+// The admin's intake reply must wake the CEO. Since plain comments no longer
+// wake the assignee, the panel threads the message to the CEO's greeting so the
+// reply path (WakeupSource.Reply) does it — carrying parent_comment_id, no
+// legacy wake_assignee flag.
+test('sending an intake reply threads to the CEO greeting to wake the CEO', async () => {
+	const { findByTestId, findByText, getByRole } = await renderApp({
+		initialPath: '/home',
+		seed: async () => {
+			await startIntake(`Home Intake Reply ${Date.now()}`);
+		},
+	});
+
+	const input = (await findByTestId('home-project-intake-input', undefined, {
+		timeout: 20_000,
+	})) as HTMLTextAreaElement;
+	// Wait for the CEO greeting to render, so its comment is in the client cache
+	// and available as the reply target when we send.
+	await findByText(/kicking off a new project/, undefined, { timeout: 20_000 });
+
+	const original = globalThis.fetch;
+	const posts: Array<Record<string, unknown>> = [];
+	globalThis.fetch = Object.assign(async (i: RequestInfo | URL, init?: RequestInit) => {
+		const url = typeof i === 'string' ? i : i.toString();
+		if (
+			init?.method === 'POST' &&
+			/\/tasks\/[^/]+\/comments$/.test(url) &&
+			typeof init.body === 'string'
+		) {
+			try {
+				posts.push(JSON.parse(init.body) as Record<string, unknown>);
+			} catch {}
+		}
+		return original(i, init);
+	}, original);
+	try {
+		const user = (await import('@testing-library/user-event')).default.setup({ delay: null });
+		await user.type(input, 'Here is what I want to build.');
+		await user.click(getByRole('button', { name: 'Send' }));
+		await waitFor(() => expect(posts.length).toBeGreaterThanOrEqual(1));
+	} finally {
+		globalThis.fetch = original;
+	}
+
+	expect(posts[0].parent_comment_id).toBeTruthy();
+	expect('wake_assignee' in posts[0]).toBe(false);
 });

--- a/packages/web/test/task-comments.test.tsx
+++ b/packages/web/test/task-comments.test.tsx
@@ -237,9 +237,9 @@ test('agent mentions render as bold anchor-colored links to agent page', async (
 	expect(fakeMatch).toBeUndefined();
 });
 
-test('wake-assignee checkbox is default-checked and reflected in submit body', async () => {
+test('wake preview shows "(no one)" by default, no checkbox, and submit omits wake_assignee', async () => {
 	const seeded = { projectSlug: '', taskId: '' };
-	const { findByPlaceholderText, findByText, getByRole, router } = await renderApp({
+	const { findByPlaceholderText, findByText, findByTestId, getByRole, router } = await renderApp({
 		initialPath: '/',
 		seed: async () => {
 			const ws = await seedWorkspace();
@@ -255,8 +255,11 @@ test('wake-assignee checkbox is default-checked and reflected in submit body', a
 	});
 
 	const composer = (await findByPlaceholderText('Add a comment...')) as HTMLTextAreaElement;
-	const checkbox = await findByRoleClosest(composer, 'checkbox', 'Wake assignee on submit');
-	expect(checkbox.checked).toBe(true);
+	// The legacy checkbox is gone; a "Wake:" preview stands in its place.
+	expect(composer.closest('form')?.querySelector('input[type="checkbox"]')).toBeNull();
+	const preview = await findByTestId('wake-preview');
+	expect(preview.textContent).toContain('Wake:');
+	expect(preview.textContent).toContain('(no one)');
 
 	const original = globalThis.fetch;
 	const posts: Array<Record<string, unknown>> = [];
@@ -276,41 +279,34 @@ test('wake-assignee checkbox is default-checked and reflected in submit body', a
 		const userMod = await import('@testing-library/user-event');
 		const user = userMod.default.setup({ delay: null });
 
-		await user.type(composer, 'wake-assignee on');
+		await user.type(composer, 'a plain comment');
 		await user.click(getByRole('button', { name: 'Comment' }));
-		await findByText('wake-assignee on');
+		await findByText('a plain comment');
 		expect(composer.value).toBe('');
-
-		expect(checkbox.checked).toBe(true);
-		await user.click(checkbox);
-		expect(checkbox.checked).toBe(false);
-
-		await user.type(composer, 'wake-assignee off');
-		await user.click(getByRole('button', { name: 'Comment' }));
-		await findByText('wake-assignee off');
 	} finally {
 		globalThis.fetch = original;
 	}
 
-	expect(posts.length).toBe(2);
-	expect(posts[0].wake_assignee).toBe(true);
-	expect(posts[1].wake_assignee).toBe(false);
+	expect(posts.length).toBe(1);
+	expect('wake_assignee' in posts[0]).toBe(false);
 });
 
-test('replying to an agent hides the wake-assignee toggle and omits the flag', async () => {
-	const seeded = { projectSlug: '', taskId: '' };
-	const { findByPlaceholderText, findByTestId, findByText, getByRole, router } = await renderApp({
-		initialPath: '/',
-		seed: async () => {
-			const ws = await seedWorkspace();
-			const project = await seedProject(ws, { name: 'Agent Reply Project' });
-			const task = await seedTask(ws, project, { title: 'Agent Reply Task' });
-			// Author the parent as the assignee agent so author_type is 'agent'.
-			await seedComment(ws, task, 'Agent original comment', { authorMemberId: ws.agents[0].id });
-			seeded.projectSlug = project.slug;
-			seeded.taskId = task.identifier.toLowerCase();
-		},
-	});
+test('replying to an agent surfaces it as a wake pill and threads the reply', async () => {
+	const seeded = { projectSlug: '', taskId: '', agentTitle: '' };
+	const { findByPlaceholderText, findByTestId, findAllByTestId, findByText, getByRole, router } =
+		await renderApp({
+			initialPath: '/',
+			seed: async () => {
+				const ws = await seedWorkspace();
+				const project = await seedProject(ws, { name: 'Agent Reply Project' });
+				const task = await seedTask(ws, project, { title: 'Agent Reply Task' });
+				// Author the parent as the assignee agent so author_type is 'agent'.
+				await seedComment(ws, task, 'Agent original comment', { authorMemberId: ws.agents[0].id });
+				seeded.projectSlug = project.slug;
+				seeded.taskId = task.identifier.toLowerCase();
+				seeded.agentTitle = ws.agents[0].title;
+			},
+		});
 	await router.navigate({
 		to: '/projects/$projectId/tasks/$taskId',
 		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
@@ -331,13 +327,10 @@ test('replying to an agent hides the wake-assignee toggle and omits the flag', a
 	expect(indicator.textContent).toContain('Agent original comment');
 
 	const composer = (await findByPlaceholderText('Add a comment...')) as HTMLTextAreaElement;
-	const form = composer.closest('form');
-	expect(form).not.toBeNull();
-	// The toggle is gone when the parent is an agent.
-	const wakeCheckbox = form?.querySelector(
-		'input[type="checkbox"][aria-label="Wake assignee on submit"]',
-	);
-	expect(wakeCheckbox).toBeNull();
+	expect(composer.closest('form')?.querySelector('input[type="checkbox"]')).toBeNull();
+	// Replying to an agent wakes it (reply-wake), so it shows up as a wake pill.
+	const pills = await findAllByTestId('wake-pill');
+	expect(pills.some((p) => p.textContent === seeded.agentTitle)).toBe(true);
 
 	const original = globalThis.fetch;
 	const posts: Array<Record<string, unknown>> = [];
@@ -367,7 +360,38 @@ test('replying to an agent hides the wake-assignee toggle and omits the flag', a
 	expect(posts[0].parent_comment_id).toBeTruthy();
 });
 
-test('replying to a human keeps the wake-assignee toggle and sends the flag', async () => {
+test('actively @-mentioning an agent shows it as a wake pill', async () => {
+	const seeded = { projectSlug: '', taskId: '', agentSlug: '', agentTitle: '' };
+	const { findByPlaceholderText, findByTestId, findAllByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Mention Wake Project' });
+			const task = await seedTask(ws, project, { title: 'Mention Wake Task' });
+			seeded.projectSlug = project.slug;
+			seeded.taskId = task.identifier.toLowerCase();
+			seeded.agentSlug = ws.agents[0].slug;
+			seeded.agentTitle = ws.agents[0].title;
+		},
+	});
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
+	});
+
+	const composer = (await findByPlaceholderText('Add a comment...')) as HTMLTextAreaElement;
+	expect((await findByTestId('wake-preview')).textContent).toContain('(no one)');
+
+	const userMod = await import('@testing-library/user-event');
+	const user = userMod.default.setup({ delay: null });
+	await user.type(composer, `@${seeded.agentSlug} please weigh in`);
+
+	const pills = await findAllByTestId('wake-pill');
+	expect(pills.some((p) => p.textContent === seeded.agentTitle)).toBe(true);
+	expect((await findByTestId('wake-preview')).textContent).not.toContain('(no one)');
+});
+
+test('replying to a human wakes no one (no pill, no wake_assignee)', async () => {
 	const seeded = { projectSlug: '', taskId: '' };
 	const { findByPlaceholderText, findByTestId, findByText, getByRole, router } = await renderApp({
 		initialPath: '/',
@@ -399,9 +423,10 @@ test('replying to a human keeps the wake-assignee toggle and sends the flag', as
 	expect(indicator.textContent).toContain('Human original comment');
 
 	const composer = (await findByPlaceholderText('Add a comment...')) as HTMLTextAreaElement;
-	// The toggle stays for a human-authored parent — nothing else wakes the assignee.
-	const checkbox = await findByRoleClosest(composer, 'checkbox', 'Wake assignee on submit');
-	expect(checkbox.checked).toBe(true);
+	// Replying to a human wakes nobody — no @-mention, no agent reply-target.
+	const preview = await findByTestId('wake-preview');
+	expect(preview.textContent).toContain('(no one)');
+	expect(preview.querySelector('[data-testid="wake-pill"]')).toBeNull();
 
 	const original = globalThis.fetch;
 	const posts: Array<Record<string, unknown>> = [];
@@ -426,7 +451,7 @@ test('replying to a human keeps the wake-assignee toggle and sends the flag', as
 	}
 
 	expect(posts.length).toBe(1);
-	expect(posts[0].wake_assignee).toBe(true);
+	expect('wake_assignee' in posts[0]).toBe(false);
 	expect(posts[0].parent_comment_id).toBeTruthy();
 });
 
@@ -555,17 +580,3 @@ test('a comment link to another comment renders as a clickable link to its hash'
 		`/projects/${seeded.projectSlug}/tasks/${seeded.taskId}#comment-${seeded.targetCommentId}`,
 	);
 });
-
-// Tiny helper for finding the checkbox by its aria-label within the same form
-// as the composer; happy-dom doesn't expose XPath axes the way Playwright does.
-async function findByRoleClosest(
-	composer: HTMLElement,
-	role: string,
-	name: string,
-): Promise<HTMLInputElement> {
-	const form = composer.closest('form');
-	if (!form) throw new Error('Composer is not inside a form');
-	const input = form.querySelector(`input[type="checkbox"][aria-label="${name}"]`);
-	if (!input) throw new Error(`No ${role} named "${name}" inside composer form`);
-	return input as HTMLInputElement;
-}

--- a/packages/web/test/task-detail.test.tsx
+++ b/packages/web/test/task-detail.test.tsx
@@ -202,7 +202,7 @@ test('bare ticket identifier renders as a tooltip-ed link and navigates to the t
 	expect(router.state.location.pathname).toBe(targetPath);
 });
 
-test('right sidebar houses the Effort control while wake-assignee lives in the comment form', async () => {
+test('right sidebar houses the Effort control while the wake preview lives in the comment form', async () => {
 	let teamSlug = '';
 	let projectSlug = '';
 	let taskIdentifier = '';
@@ -235,10 +235,10 @@ test('right sidebar houses the Effort control while wake-assignee lives in the c
 	);
 	expect(effort).toBeTruthy();
 
-	const wakeCheckboxInSidebar = sidebar.querySelector(
-		'input[type="checkbox"][aria-label="Wake assignee on submit"]',
-	);
-	expect(wakeCheckboxInSidebar).toBeNull();
+	// The wake preview belongs to the comment composer, not the sidebar.
+	expect(sidebar.querySelector('[data-testid="wake-preview"]')).toBeNull();
+	const preview = await findByTestId('wake-preview');
+	expect(preview.textContent).toContain('Wake:');
 });
 
 test('Progress Summary and Rules cards expose info icons with help text', async () => {

--- a/packages/web/test/task-preview-action-review.test.tsx
+++ b/packages/web/test/task-preview-action-review.test.tsx
@@ -123,7 +123,7 @@ test('Add to task pins the hosting task first; selecting it posts the handoff an
 		globalThis.fetch = original;
 	}
 
-	// Exactly `{ content: <handoff> }` — toEqual proves no wake_assignee or extras
+	// Exactly `{ content: <handoff> }` — toEqual proves no extra fields
 	// — POSTed to the hosting task's path.
 	expect(posts).toHaveLength(1);
 	expect(posts[0].url).toContain(`/tasks/${identifier.toLowerCase()}/comments`);

--- a/test/browser/task-comment-attachments.spec.ts
+++ b/test/browser/task-comment-attachments.spec.ts
@@ -155,12 +155,10 @@ test.describe('Task Comment Attachments', () => {
 		const chip = page.locator('[data-testid="comment-attachment-chip"]', { hasText: 'shot.png' });
 		await expect(chip).toBeVisible({ timeout: UPLOAD_WAIT_MS });
 
-		// Don't wake the Captain on submit: its synthetic run would post a run
-		// comment and re-render the thread while we're waiting on the attachment
-		// thumb below, adding avoidable load and re-render races. The thumb is what
-		// this test asserts, not the agent run.
-		await page.getByRole('checkbox', { name: 'Wake assignee on submit' }).uncheck();
-
+		// A plain comment (no @-mention) wakes no one, so submitting won't spawn a
+		// synthetic Captain run that would post a run comment and re-render the
+		// thread while we're waiting on the attachment thumb below. The thumb is
+		// what this test asserts, not the agent run.
 		const send = page.getByRole('button', { name: 'Comment', exact: true });
 		await expect(send).toBeEnabled();
 		await send.click();

--- a/test/browser/task-comments.spec.ts
+++ b/test/browser/task-comments.spec.ts
@@ -113,10 +113,9 @@ test.describe('Task Comments', () => {
 		await expect(page.getByTestId('reply-indicator')).toBeVisible();
 
 		await composer.fill('Mobile reply');
-		// Don't wake the Captain on submit: its synthetic run would post a run
-		// comment and re-render the thread while we wait for the reply below,
-		// adding avoidable load and re-render races. The reply is what we assert.
-		await page.getByRole('checkbox', { name: 'Wake assignee on submit' }).uncheck();
+		// Replying to a human-authored parent wakes no one, so submitting won't
+		// spawn a synthetic Captain run that would post a run comment and re-render
+		// the thread while we wait for the reply below. The reply is what we assert.
 		await page.getByRole('button', { name: 'Comment', exact: true }).click();
 
 		const followUp = page

--- a/test/browser/task-detail.spec.ts
+++ b/test/browser/task-detail.spec.ts
@@ -102,7 +102,9 @@ test.describe('Task detail — right sidebar sticky positioning', () => {
 		);
 		await expect(effort).toBeVisible();
 
-		await expect(sidebar.getByRole('checkbox', { name: 'Wake assignee on submit' })).toHaveCount(0);
+		// The wake preview lives in the comment composer, not the sidebar.
+		await expect(sidebar.getByTestId('wake-preview')).toHaveCount(0);
+		await expect(page.getByTestId('wake-preview')).toBeVisible();
 	});
 });
 


### PR DESCRIPTION
## What & why

Commenting on a task had **two** ways to wake an agent: the `@`-mention wake, and a separate **"Wake assignee"** checkbox (default *on*) that woke the task's assignee on any plain comment. That's inconsistent and means comments page someone by default.

This standardizes on **one rule: a comment wakes an agent only when it actively `@`-mentions it** (replying to an agent's comment still counts, via the reply path). By default a comment wakes no one. The checkbox is replaced by a **"Wake:" preview row** under the composer that pills exactly who will be paged when the comment is posted.

## Behavior

- **No implicit assignee wake.** Removed the `wake_assignee` request field and the assignee-wake fan-out.
- **Wake preview.** Under the composer: `Wake:` + an info-tooltip icon + a pill per agent in the wake set.
  - Wake set = agents **actively `@`-mentioned** (active `@slug` only — not passive `@@slug`, `@admin` excluded), resolved against the project roster (which includes the HQ CEO/Coach), **∪** the **reply-target agent** when replying to an agent's comment. Deduped by id.
  - No agents → shows `Wake: (no one)`; the tooltip prompts you to `@`-mention an agent.
  - Agents present → the tooltip confirms these agents will be woken when the comment is posted.
- **Project-intake chat** migrated off `wake_assignee`: the admin's message is threaded to the CEO's opening greeting, so the reply path wakes the CEO (the CEO always greets first, so there's always a comment to reply to).

## Changes

- `packages/shared/src/mentions/tokens.ts` — new `extractActiveAgentMentionSlugs` (active `@slug` only, strips code, drops passive/`@admin`), mirroring the server's wake rule; drives the composer preview.
- `packages/web/.../comment-composer.tsx` — remove checkbox/state/payload; add the `Wake:` preview (`InfoTooltip` + `Badge` pills) computed from mentions ∪ reply target.
- `packages/web/.../project-intake-home-panel.tsx` — thread intake replies to the CEO greeting instead of `wake_assignee`.
- `packages/web/src/hooks/use-comments.ts` — drop `wake_assignee` from the mutation type.
- `packages/server/src/routes/comments.ts` + `services/comment-wakeups.ts` — remove the `wake_assignee` body field and the assignee-wake block; mention + reply paths unchanged.
- `.dev/architecture.md` — update the `comment` wakeup-source description.

## Testing

- **Shared:** unit test for `extractActiveAgentMentionSlugs` (active only, drops passive/`@admin`/code, deduped).
- **Server:** `comment-wakeups` + `comments-routes-uncovered` updated — plain comment wakes no one, a legacy `wake_assignee` flag is ignored, `@`-mention still wakes.
- **Web (component):** default shows `Wake: (no one)` and no checkbox; `@`-mention shows a wake pill; replying to an agent surfaces it as a pill and threads; replying to a human wakes no one; intake reply threads to the CEO greeting.
- **Browser specs:** updated to drop the removed checkbox interactions and assert the wake preview lives in the composer.
- `bun run typecheck` and biome check pass. (Playwright can't launch Chromium in this sandbox — a version-mismatch limitation that fails all browser specs identically; the changes are covered by component tests and CI runs the browser tier.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tXxMjJdxTc4CVCYmiy8t5

---
_Generated by [Claude Code](https://claude.ai/code/session_012tXxMjJdxTc4CVCYmiy8t5)_