### PR TITLE
fix(connectors): show local (credential-auth) connectors as Connected

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -1013,7 +1013,12 @@ always included.
 **MCP connections** (`mcp_connections`, see § 3 scoping). `kind='saas'` carries
 `{ url, headers }` (header values may contain `__HEZO_SECRET_*__`; OAuth-backed rows set
 `oauth_connection_id` and the loader emits the `Bearer` placeholder). `kind='local'`
-carries a stdio `{ command, args, env }` (the on-demand installer is a deferred phase).
+carries a stdio `{ command, args, env }` (the on-demand installer is a deferred phase);
+local servers authenticate via credential placeholders in their `env` (e.g. a
+username/password login that fetches a token), never OAuth, so the connectors UI treats a
+non-revoked, non-failed local row as **connected the moment it exists** (`statusOf`/
+`connectorStatus` short-circuit `kind='local'` to `active`) rather than showing it a
+meaningless "Pending connect" OAuth affordance.
 At run build, `loadMcpConnectionDescriptors` merges connectors after the built-in `hezo`
 MCP, and each of the five runtime adapters translates the descriptors into the spawn
 artifacts its CLI expects (Claude Code `--mcp-config`, Codex `config.toml`, Gemini

--- a/packages/server/src/services/connectors/lifecycle.ts
+++ b/packages/server/src/services/connectors/lifecycle.ts
@@ -49,11 +49,19 @@ export interface ConnectorRow {
 export type ConnectorStatus = 'pending' | 'active' | 'failed' | 'revoked';
 
 export function statusOf(
-	row: Pick<ConnectorRow, 'oauth_connection_id' | 'activated_at' | 'revoked_at' | 'auth_error'>,
+	row: Pick<
+		ConnectorRow,
+		'kind' | 'oauth_connection_id' | 'activated_at' | 'revoked_at' | 'auth_error'
+	>,
 ): ConnectorStatus {
 	if (row.revoked_at) return 'revoked';
 	if (row.auth_error && !row.activated_at) return 'failed';
 	if (row.oauth_connection_id && row.activated_at) return 'active';
+	// Local (stdio) connectors authenticate via credential placeholders
+	// (__HEZO_SECRET_*__ — e.g. a username/password login that fetches a token),
+	// not OAuth, so there is no oauth_connection_id/activated_at handshake. A
+	// non-revoked, non-failed local row is connected the moment it exists.
+	if (row.kind === McpConnectionKind.Local) return 'active';
 	return 'pending';
 }
 

--- a/packages/server/test/connectors-lifecycle-branches.test.ts
+++ b/packages/server/test/connectors-lifecycle-branches.test.ts
@@ -53,6 +53,7 @@ afterAll(async () => {
 
 describe('statusOf precedence', () => {
 	const base = {
+		kind: McpConnectionKind.Saas,
 		oauth_connection_id: null,
 		activated_at: null,
 		revoked_at: null,
@@ -87,6 +88,20 @@ describe('statusOf precedence', () => {
 
 	it('pending when activated but missing the oauth connection id', () => {
 		expect(statusOf({ ...base, activated_at: 'now' })).toBe('pending');
+	});
+
+	it('active for a local connector with no oauth (credential-placeholder auth)', () => {
+		// Local (stdio) connectors log in via __HEZO_SECRET_*__ placeholders, not
+		// OAuth, so they are connected as soon as the row exists.
+		expect(statusOf({ ...base, kind: McpConnectionKind.Local })).toBe('active');
+	});
+
+	it('revoked still wins over a local connector', () => {
+		expect(statusOf({ ...base, kind: McpConnectionKind.Local, revoked_at: 'now' })).toBe('revoked');
+	});
+
+	it('failed still wins over a local connector', () => {
+		expect(statusOf({ ...base, kind: McpConnectionKind.Local, auth_error: 'boom' })).toBe('failed');
 	});
 });
 

--- a/packages/web/src/hooks/use-mcp-connections.ts
+++ b/packages/web/src/hooks/use-mcp-connections.ts
@@ -34,6 +34,12 @@ export function connectorStatus(c: McpConnection): ConnectorStatus {
 	if (c.revoked_at) return 'revoked';
 	if (c.auth_error && !c.activated_at) return 'failed';
 	if (c.oauth_connection_id && c.activated_at) return 'active';
+	// Local (stdio) connectors authenticate via credential placeholders
+	// (__HEZO_SECRET_*__ — e.g. a username/password login that fetches a token),
+	// not OAuth. There is no oauth_connection_id/activated_at handshake to
+	// complete, so a non-revoked, non-failed local row is connected the moment it
+	// exists — never leave it stuck on "Pending connect" offering an OAuth flow.
+	if (c.kind === 'local') return 'active';
 	return 'pending';
 }
 

--- a/packages/web/test/connectors-page.test.tsx
+++ b/packages/web/test/connectors-page.test.tsx
@@ -31,6 +31,27 @@ async function seedSaasConnector(
 	return (await res.json()).data;
 }
 
+// Seed a local (stdio) MCP connector — e.g. a self-hosted umami server that logs
+// in with a username/password credential placeholder rather than OAuth. Local
+// connectors carry a `config.command`, never a url, and never an oauth handshake.
+async function seedLocalConnector(
+	ws: SeededWorkspace,
+	input: { name: string; command: string },
+): Promise<{ id: string; name: string }> {
+	const { apiBase } = getTestContext();
+	const res = await apiBase(`/api/projects/${ws.internalSlug}/mcp-connections`, {
+		method: 'POST',
+		headers: ws.headers,
+		body: JSON.stringify({
+			name: input.name,
+			kind: 'local',
+			config: { command: input.command, args: [], env: {} },
+		}),
+	});
+	if (res.status !== 201) throw new Error(`seedLocalConnector failed: ${res.status}`);
+	return (await res.json()).data;
+}
+
 // Seed an "active" GitHub OAuth connection straight into the DB (the same shape
 // finalizeConnectorConnection produces) so the GitHub row renders its connected
 // state without driving the full device flow.
@@ -220,6 +241,32 @@ test('an active non-GitHub connector renders Disconnect and revokes', async () =
 		expect(row?.getAttribute('data-status')).toBe('revoked');
 	});
 	await findByTestId('connector-connect');
+});
+
+test('a local (credential-auth) connector renders Connected, not a Connect button', async () => {
+	let slug = '';
+	const { findByText, getByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			slug = ws.internalSlug;
+			await seedLocalConnector(ws, { name: 'umami', command: 'umami-mcp' });
+		},
+	});
+	await router.navigate({ to: CONNECTORS_ROUTE, params: { projectId: slug } });
+
+	await findByText('umami');
+	// Local connectors have no OAuth handshake — they're connected as soon as the
+	// row exists, so the row shows the Connected badge, not "Pending connect".
+	const umamiRow = within(getByTestId('connectors-list'))
+		.getAllByTestId('connector-row')
+		.find((li) => li.getAttribute('data-connector-id'));
+	if (!umamiRow) throw new Error('umami connector row not found');
+	expect(umamiRow.getAttribute('data-status')).toBe('active');
+	// A local connector never offers the (OAuth) Connect button — only Disconnect.
+	expect(within(umamiRow).queryByTestId('connector-connect')).toBeNull();
+	within(umamiRow).getByTestId('connector-revoke');
+	await findByText('Connected');
 });
 
 test('GitHub Connect drives the device flow to a connected OAuth connection', async () => {


### PR DESCRIPTION
## What & why

Local (stdio) MCP connectors — e.g. a self-hosted **umami** server that logs in with a username/password credential placeholder to fetch a token — authenticate via `__HEZO_SECRET_*__` substitution at egress, **never OAuth**. They therefore never carry an `oauth_connection_id` / `activated_at` handshake.

Both status derivations classified such a row as `pending` forever:

- **Project Connectors page** (`/projects/:id/connectors`): showed a **"Pending connect"** badge and a meaningless OAuth **"Connect"** button.
- **Admin Settings → Connectors** (`/settings/connectors`): showed **no status badge at all** (the "Connected" badge is gated on `status === 'active'`).

So a fully-working umami connector read as unconnected on both surfaces.

## Change

Short-circuit `kind='local'` to `active` (unless the row is revoked or failed) in both the server-side `statusOf` (`services/connectors/lifecycle.ts`) and the client-side `connectorStatus` (`hooks/use-mcp-connections.ts`), keeping the two in lockstep.

Result:
- Project page now renders the **Connected** badge and a **Disconnect** action for a local connector instead of the OAuth Connect flow.
- Admin page renders the **Connected** badge.
- `revoked` / `failed` still take precedence over `local`.

The `register_connector` MCP tool always creates SaaS connectors (`mcp_url` is required), so its use of `statusOf` is unaffected.

## Tests

- `packages/server/test/connectors-lifecycle-branches.test.ts` — added `statusOf` cases: local → `active`, plus `revoked`/`failed` still winning over local (and threaded `kind` through the existing precedence `base`).
- `packages/web/test/connectors-page.test.tsx` — new component test: a seeded local connector renders `data-status="active"`, shows the **Connected** badge and a **Disconnect** button, and offers **no** Connect button.

## Docs

- `.dev/architecture.md` (§ 9, MCP connections) — noted that local rows authenticate via credential placeholders and are treated as connected on existence.

## Verification

- `bunx vitest run` for both changed suites — green (server 18 tests, web 7 tests).
- Related suites green: `connectors.test.ts`, `instance-connectors.test.ts`, `mcp-connections-routes.test.ts`, `mcp-tools-extended.test.ts`.
- `tsc --noEmit` clean for server + web; `biome check` introduces no new findings (2 pre-existing warnings in untouched code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNJuzHjBf62sqogTtU89YW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNJuzHjBf62sqogTtU89YW)_