### PR TITLE
ci(release): grant actions:write so agent-base cache export can't fail the release

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -42,6 +42,16 @@ jobs:
     permissions:
       contents: read
       packages: write
+      # Writing the type=gha build cache (cache-to below) requires the actions
+      # scope. This job runs on pull_request (the release PR merging into main),
+      # where the cache-service runtime token is NOT granted cache-write scope by
+      # default — unlike ci.yml's build-agent-image, which runs on push and works
+      # without it. Without this the cache export fails ("failed to reserve cache:
+      # token has no writable scopes"), and because buildkit exports the image and
+      # the cache concurrently and treats a cache-export error as fatal, that
+      # cancels the in-flight GHCR push and fails the whole release (see the failed
+      # run 28863819276 on release/0.16.0).
+      actions: write
     steps:
       - uses: actions/checkout@v5
         with:
@@ -67,7 +77,10 @@ jobs:
             ghcr.io/hezo-ai/agent-base:${{ steps.meta.outputs.version }}
             ghcr.io/hezo-ai/agent-base:latest
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # ignore-error keeps an optional cache-export problem from cancelling the
+          # GHCR push this release gates on — the downstream publish job needs this
+          # image live before it tags and cuts the Release.
+          cache-to: type=gha,mode=max,ignore-error=true
 
   # Cross-compile the release binaries, tag the merge commit, and publish the
   # GitHub Release. `needs: publish-agent-image` is the gate the whole change is


### PR DESCRIPTION
## What & why

The `Release Publish` run for **release/0.16.0** failed ([run 28863819276](https://github.com/hezo-ai/hezo/actions/runs/28863819276/job/85609728444)). This blocks the whole release: the `publish` job (tag the merge commit + cut the GitHub Release) `needs: publish-agent-image`, so a failed image job means no release lands.

### Diagnosis

The multi-arch `agent-base` image built and started pushing fine — the job died at the **build-cache export** step:

```
#32 exporting to GitHub Actions Cache
#32 ERROR: error writing layer blob: failed to reserve cache
...
Cache reservation failed: cache write denied: token has no writable scopes
```

Root cause: `publish-agent-image`'s `permissions` block granted only `contents: read` + `packages: write`, so the `actions` scope was `none`. Writing the `type=gha` build cache (`cache-to`) requires the `actions` scope. Because BuildKit exports the image and the cache **concurrently** and treats a cache-export error as fatal, the denied reservation **cancelled the in-flight GHCR push** (`#30 … CANCELED`) and failed the job.

Why it's specific to this job:
- `ci.yml`'s `build-agent-image` has the *identical* `permissions` block and `cache-to: type=gha`, and it **succeeded at the very same second** — it runs on `push`, where the cache runtime token gets write scope implicitly.
- This job runs on `pull_request: closed` (the release PR merging into main; this was also a manual re-run, `run_attempt: 2`), where that token is **not** granted cache-write scope.
- `0.15.3` published fine yesterday; `0.16.0` hit this on the release path today.

### Fix

- Add `actions: write` to the job's `permissions` so the `type=gha` cache export is authorized regardless of the trigger event — GitHub's documented remedy for *"token has no writable scopes."*
- Add `ignore-error=true` to `cache-to` so an optional cache-export problem can never again cancel the release-critical GHCR push. Cache is a build optimization; the pushed image is the deliverable the downstream `publish` job gates on.

## Scope

Only `.github/workflows/release-publish.yml` is touched. `ci.yml`'s `build-agent-image` is left as-is (it works on `push`); if GitHub later tightens cache-write scope for `push` tokens too, the same two-line change would apply there.

## Testing

Workflow-only change; `python -c "import yaml; yaml.safe_load(...)"` confirms the file still parses. It genuinely verifies only on the next release merge — re-running the failed job on a merged/closed PR won't reflect the new permissions until this lands on `main`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NGX9oDp9XmbFParwH8YXMN)_