### PR TITLE
fix(web): relabel repo button to "Add repo" above the repo list

### DIFF
--- a/packages/web/src/components/github-section.tsx
+++ b/packages/web/src/components/github-section.tsx
@@ -82,20 +82,10 @@ export function GitHubSection({ projectId }: GitHubSectionProps) {
 
 	return (
 		<section data-testid="github-section">
-			<div className="flex items-center justify-between mb-3">
+			<div className="flex items-center mb-3">
 				<h2 className="text-sm font-medium text-text-2 flex items-center gap-1.5">
 					<Github className="w-4 h-4" /> GitHub
 				</h2>
-				{isReady && hasRepos && (
-					<Button
-						variant="ghost"
-						size="sm"
-						onClick={() => setPickerOpen(true)}
-						data-testid="repo-setup-add"
-					>
-						Set up repo
-					</Button>
-				)}
 			</div>
 			<p className="text-xs text-text-3 mb-3">
 				Connects this team to GitHub for both git operations (clone, push, signed commits) and the
@@ -217,6 +207,19 @@ export function GitHubSection({ projectId }: GitHubSectionProps) {
 			<div className="mt-4">
 				{hasRepos ? (
 					<div className="flex flex-col gap-2">
+						{isReady && (
+							<div className="flex justify-end">
+								<Button
+									variant="ghost"
+									size="sm"
+									onClick={() => setPickerOpen(true)}
+									data-testid="repo-setup-add"
+								>
+									<GitBranch className="size-4 mr-2" />
+									Add repo
+								</Button>
+							</div>
+						)}
 						{repos?.map((r) => {
 							const repoName = repoNameFromIdentifier(r.repo_identifier);
 							const isExpanded = expandedRepos.has(r.id);
@@ -346,7 +349,7 @@ export function GitHubSection({ projectId }: GitHubSectionProps) {
 								</div>
 								<Button size="sm" onClick={() => setPickerOpen(true)} data-testid="repo-setup-add">
 									<GitBranch className="size-4 mr-2" />
-									Set up repo
+									Add repo
 								</Button>
 							</div>
 						</div>

--- a/packages/web/test/github-section-states.test.tsx
+++ b/packages/web/test/github-section-states.test.tsx
@@ -152,9 +152,9 @@ test('connected with repos lists each repo with a web link; designated is locked
 		],
 	});
 
-	// "Set up repo" header affordance appears once ready + has repos. The repos
-	// query can resolve before scope-status, so await this isReady-gated element
-	// before asserting on the rest of the rendered state.
+	// "Add repo" affordance (above the repo list) appears once ready + has repos.
+	// The repos query can resolve before scope-status, so await this isReady-gated
+	// element before asserting on the rest of the rendered state.
 	const setupButtons = await r.findAllByTestId('repo-setup-add', undefined, { timeout: 20_000 });
 	expect(setupButtons.length).toBeGreaterThan(0);
 


### PR DESCRIPTION
## Summary

The GitHub section's repo-picker affordance previously lived in the section **header** and read **"Set up repo"**. This moves it to sit **directly above the repo list** and renames it to **"Add repo"** for clarity.

- Removed the ghost "Set up repo" button from the `GitHub` header row.
- Added an "Add repo" ghost button directly above the repo list (shown when the connection is ready and repos exist).
- Renamed the empty-state ("No repositories yet") button from "Set up repo" to "Add repo" so the label is consistent everywhere.

The button keeps its existing `data-testid="repo-setup-add"` and behaviour (opens the repo picker modal).

## Testing

- `bunx vitest run test/github-section-states.test.tsx` — all 7 tests pass (updated the stale "header affordance" comment; the `repo-setup-add` testid assertion is unchanged).
- `bunx tsc --noEmit` (web) — clean.
- `bunx biome check` on the changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015bPTLTEQqm3T5Ncy5TjcXZ)_