### PR TITLE
fix: point agents at on-disk worktrees for connected repos

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -541,6 +541,11 @@ document, loaded from its **home** team) is resolved per run by
 `{{team_preferences_context}}`, `{{team_description}}`, `{{team_context}}`,
 `{{current_date}}`, and the CEO-only `{{projects_context}}`), then the resolver appends the
 Run Context / Repository / Project State / Teammates blocks and `SHARED_INSTRUCTIONS`.
+The **Repository** block names the designated repo *and every other linked repo*, giving each
+additional one its on-disk worktree path (`/worktrees/<task>/<repo>`, a sibling of the working
+directory), and directs agents to read connected repos from disk (`ls`/`Read`/`grep`) rather
+than fetch their files through the `github` MCP `get_file_contents` API — which is slower, costs
+tokens per file, and returns GitHub's default branch instead of the ref checked out for the run.
 Every surface that authors or edits a prompt — the hire proposal create/edit
 (`prepareHireProposal`, `PATCH /approvals`), direct agent create + `PATCH /agents`, and the
 `create_hire_proposal` / `update_agent_system_prompt` MCP tools — validates a supplied,

--- a/packages/server/src/services/template-resolver.ts
+++ b/packages/server/src/services/template-resolver.ts
@@ -1,7 +1,8 @@
-import { HEZO_DOCS_URL } from '@hezo/shared';
+import { HEZO_DOCS_URL, repoNameFromIdentifier } from '@hezo/shared';
 import type { Db } from '../db/database';
 import { terminalStatusParams } from '../lib/sql';
 import { buildHezoDocsBlock } from './docs-bundle';
+import { CONTAINER_WORKTREES_ROOT } from './workspace';
 
 /**
  * The marker in `agents/_instance/ceo.md` where the product/API documentation is
@@ -630,6 +631,14 @@ interface RepoContextRow {
  * brand-new repo to make their invented name work. Regenerated every run from
  * live DB state; omitted entirely when the project has no linked repo (a
  * code-touching run with no repo is gated upstream by the repo-setup approval).
+ *
+ * Every linked repo — not just the designated one — is cloned and checked out to
+ * its own per-task worktree (`agent-runner.ts` loops all of them), so the block
+ * names each additional repo's on-disk path and tells the agent to read it from
+ * disk. Without that, an agent asked to reference a second connected repo has no
+ * signal it is local and reaches for the `github` MCP `get_file_contents` API
+ * instead — slower, per-file token cost, and it reads GitHub's default branch
+ * rather than the ref checked out for this run.
  */
 async function buildRepositoryBlock(db: Db, ctx: ResolveContext): Promise<string> {
 	if (!ctx.projectId) return '';
@@ -645,14 +654,34 @@ async function buildRepositoryBlock(db: Db, ctx: ResolveContext): Promise<string
 	);
 	if (repos.rows.length === 0) return '';
 
+	let taskIdentifier = '';
+	if (ctx.taskId) {
+		const r = await db.query<{ identifier: string }>('SELECT identifier FROM tasks WHERE id = $1', [
+			ctx.taskId,
+		]);
+		taskIdentifier = r.rows[0]?.identifier ?? '';
+	}
+
 	const designated = repos.rows.find((r) => r.is_designated === true) ?? repos.rows[0];
 	const others = repos.rows.filter((r) => r !== designated);
 
+	// Each additional repo's worktree is a sibling of the working directory (the
+	// designated repo's worktree) — `/worktrees/<TICKET>/<name>`. Emit the concrete
+	// path when the ticket identifier resolves; otherwise describe it relative to
+	// the working directory so the guidance still holds.
+	const localPathOf = (name: string): string =>
+		taskIdentifier
+			? `\`${CONTAINER_WORKTREES_ROOT}/${taskIdentifier}/${name}\``
+			: `a sibling directory named \`${name}\` next to your working directory`;
+
 	const repoLines = [
-		`- Designated repository: \`${designated.repo_identifier}\` (${designated.host_type})`,
+		`- Designated repository: \`${designated.repo_identifier}\` (${designated.host_type}) — already cloned; your working directory is its worktree.`,
 	];
-	if (others.length > 0) {
-		repoLines.push(`- Also linked: ${others.map((r) => `\`${r.repo_identifier}\``).join(', ')}`);
+	for (const o of others) {
+		const name = repoNameFromIdentifier(o.repo_identifier);
+		repoLines.push(
+			`- Also linked: \`${o.repo_identifier}\` (${o.host_type}) — also cloned and checked out locally at ${localPathOf(name)}.`,
+		);
 	}
 
 	return `
@@ -665,6 +694,7 @@ This project has a **designated repository** — the one and only place your cod
 
 ${repoLines.join('\n')}
 
+- **Read connected repositories from disk, never through an API.** Every linked repo above is cloned and checked out locally for this run — your working directory is the designated repo's worktree, and any additional repos sit in sibling worktree directories (paths above). Inspect them with \`ls\`/\`Read\`/\`grep\`/\`cat\` directly. Do **not** pull a repo's file contents through the \`github\` MCP (\`get_file_contents\`) or any other remote fetch just to read code — that is slower, spends tokens per file, and returns GitHub's default branch instead of the exact ref checked out here. The \`github\` MCP is for GitHub *operations* (pull requests, CI logs, issues), not for reading files that are already on disk.
 - **Commits auto-push to \`origin\`; you don't need a manual push to preserve work.** Every commit you make is pushed to \`origin/<branch>\` (e.g. \`origin/hezo/<TICKET>\`) automatically the moment it lands — git authenticates over **SSH** with the project's key — so committed work survives even if the run ends early. An explicit \`git push -u origin <branch>\` still works out of the box if you want one. You do **not** need a GitHub Personal Access Token for git, so never call \`request_credential\` for a PAT to push or to create a repo.
 - **Open and manage pull requests against this repository** with the \`github\` MCP tools (e.g. \`create_pull_request\`), targeting this repo. Use the \`github\` MCP for any other GitHub API need rather than raw \`curl\` to \`api.github.com\`.
 - **When CI checks fail, read the logs through the \`github\` MCP, never by hand.** Use \`get_job_logs\` with \`failed_only: true\` + the \`run_id\` (or a specific \`job_id\`), \`return_content: true\`, and a \`tail_lines\` bound (e.g. 200) so output stays scoped to the failure. Find the run and its jobs with \`list_workflow_runs\` / \`list_workflow_jobs\`, or \`pull_request_read\` (\`method: "get_check_runs"\`) for a PR's checks. Do **not** \`curl\` \`api.github.com/.../actions/jobs/<id>/logs\` or wrestle with zip downloads — the MCP returns ready-to-read text.

--- a/packages/server/test/template-resolver.test.ts
+++ b/packages/server/test/template-resolver.test.ts
@@ -1257,7 +1257,7 @@ describe('repository block', () => {
 		expect(result).not.toContain(repoIns.rows[0].id);
 	});
 
-	it('lists additional linked repos under the designated one', async () => {
+	it('lists additional linked repos under the designated one and marks them cloned locally', async () => {
 		await db.query(
 			`INSERT INTO repos (project_id, repo_identifier, host_type)
 			 VALUES ($1, 'acme/docs', 'github'::repo_host_type)`,
@@ -1269,6 +1269,34 @@ describe('repository block', () => {
 		});
 		expect(result).toContain('Designated repository: `acme/widgets`');
 		expect(result).toContain('Also linked: `acme/docs`');
+		// The additional repo is flagged as cloned/checked out locally, and — with no
+		// resolved ticket here — described relative to the working directory.
+		expect(result).toContain('also cloned and checked out locally at');
+		expect(result).toContain('a sibling directory named `docs` next to your working directory');
+		// Steer reading to disk, not the github MCP file API.
+		expect(result).toContain('Read connected repositories from disk, never through an API');
+		expect(result).toContain('get_file_contents');
+	});
+
+	it('names the concrete worktree path of a linked repo when the ticket resolves', async () => {
+		await db.query(
+			`INSERT INTO repos (project_id, repo_identifier, host_type)
+			 VALUES ($1, 'acme/api', 'github'::repo_host_type)`,
+			[repoProjectId],
+		);
+		const task = await db.query<{ id: string; identifier: string }>(
+			`INSERT INTO tasks (team_id, project_id, number, identifier, title, status, priority, labels)
+			 VALUES ($1, $2, next_project_task_number($2), 'REPO-1', 'Repo worktree ticket', 'backlog'::task_status, 'medium'::task_priority, '[]'::jsonb)
+			 RETURNING id, identifier`,
+			[repoTeamId, repoProjectId],
+		);
+		const result = await resolveSystemPrompt(db, 'Simple prompt', {
+			teamId: repoTeamId,
+			projectId: repoProjectId,
+			taskId: task.rows[0].id,
+		});
+		// The additional repo is addressed by its absolute per-task worktree path.
+		expect(result).toContain(`/worktrees/${task.rows[0].identifier}/api`);
 	});
 
 	it('omits the Repository block for a cross-team (roaming) resolve', async () => {


### PR DESCRIPTION
## Problem

For a project with multiple connected repos, the runtime clones and checks out a `git worktree` for **every** linked repo (`agent-runner.ts` loops all of them into `/worktrees/<task>/<repo>`), not just the designated one. But the **Repository** prompt block only promised the *designated* repo was on disk — additional repos were merely named on the `Also linked:` line with no path and no signal they were checked out locally.

The result, observed in a real run on a two-repo project: asked to reference the second connected repo, the agent had no reason to believe it was on disk and reached for the `github` MCP `get_file_contents` API to read it file-by-file. That's slower, spends tokens per file, and reads GitHub's default branch rather than the exact ref checked out for the run — all while a complete local checkout sat unused in a sibling worktree directory.

## Change

`buildRepositoryBlock` (`packages/server/src/services/template-resolver.ts`) now:

- Emits each **additional** linked repo's on-disk worktree path — `/worktrees/<ticket>/<repo>` when the ticket identifier resolves, or a working-directory-relative description (`a sibling directory named \`<repo>\``) otherwise.
- Adds an explicit bullet: **read connected repositories from disk** (`ls`/`Read`/`grep`/`cat`), do **not** pull their files through the `github` MCP `get_file_contents` API — that API is reserved for GitHub *operations* (pull requests, CI logs, issues).

The designated-repo guidance (never invent/create a repo, never repoint `origin`, no PAT, no TLS bypass, PRs/CI via the `github` MCP) is unchanged.

## Notes

- The `Also linked:` and `Designated repository:` substrings are preserved, so this is additive prompt guidance rather than a format break.
- `.dev/architecture.md`'s system-prompt-composition section is updated to describe the block's multi-repo behavior in the same change.

## Tests

- `packages/server/test/template-resolver.test.ts`: extended the "additional linked repos" test to assert the cloned-locally marker and the read-from-disk guidance, and added a test that a resolved ticket yields the concrete `/worktrees/<ticket>/<repo>` path. Full file green (86/86).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyGMn4V6Uu2P5yMydoAAuQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PyGMn4V6Uu2P5yMydoAAuQ)_