### PR TITLE
fix(updates): unstick restart overlay and correct its master-key copy

### DIFF
--- a/packages/web/src/components/update-banner.tsx
+++ b/packages/web/src/components/update-banner.tsx
@@ -67,7 +67,13 @@ export function UpdateBanner() {
 	const errored = data?.state === UpdateState.Error;
 
 	if (applying) {
-		return <UpdateRestartOverlay targetVersion={data?.targetVersion ?? data?.latest ?? null} />;
+		return (
+			<UpdateRestartOverlay
+				targetVersion={data?.targetVersion ?? data?.latest ?? null}
+				fromVersion={data?.current ?? null}
+				autoUnlock={data?.autoUnlock ?? false}
+			/>
+		);
 	}
 
 	const isDismissed =

--- a/packages/web/src/components/update-restart-overlay.tsx
+++ b/packages/web/src/components/update-restart-overlay.tsx
@@ -1,46 +1,108 @@
 import { Loader2 } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
+/** Poll cadence (ms) while waiting for the relaunched worker to answer. */
+const POLL_INTERVAL_MS = 1500;
+/**
+ * Last-resort reload after this long, so a missed transition can never strand the
+ * overlay indefinitely. A slightly-early reload is safe — the app shell lands on
+ * the boot `StartingScreen` and polls `/api/status` until the new worker is ready.
+ */
+const FALLBACK_RELOAD_MS = 120_000;
+
+/**
+ * Decide, from one `/api/status` sample, whether the relaunched worker is up and
+ * we should reload. Pure so it can be unit-tested without DOM/fetch.
+ *
+ * The primary signal is a **version change**: `/api/status.version` is the running
+ * binary's `HEZO_VERSION`, so once it differs from the version we're restarting
+ * away from (`fromVersion`, also `HEZO_VERSION`), the new binary is up — this holds
+ * even if we never caught the brief unreachable window (polls are seconds apart) and
+ * even before the new worker is fully ready (its booting `starting: true` response
+ * already carries the new version). `wentDown → back-up` is a fallback for a
+ * same-version restart (reinstall, or a failed apply where the supervisor relaunches
+ * the previous binary) where the version never changes.
+ */
+export function evaluateRestartPoll(
+	state: { fromVersion: string | null; wentDown: boolean },
+	sample: { ok: boolean; starting: boolean; version: string | null },
+): { reload: boolean; wentDown: boolean } {
+	// Non-ok / network error → the worker is down mid-restart.
+	if (!sample.ok) return { reload: false, wentDown: true };
+	const swapped = !!sample.version && !!state.fromVersion && sample.version !== state.fromVersion;
+	// It went away and is back, finished booting, on the same version.
+	const backUp = state.wentDown && !sample.starting;
+	return { reload: swapped || backUp, wentDown: state.wentDown };
+}
+
 /**
  * Full-screen overlay shown while the server restarts onto a new binary. Polls
- * `/api/status` (the same public endpoint the app shell gates on); once the
- * server has gone down and come back, it reloads the page. A locked return lands
- * on the master-key gate via `AppShell`, which is why the copy reminds the
- * operator they'll need their master key.
+ * `/api/status` (the same public endpoint the app shell gates on) and reloads the
+ * page once the relaunched worker is up. A supervised update restart comes back
+ * already unlocked (the supervisor hands the in-memory unlock key to the new
+ * worker), so the copy only warns about re-entering the master key when the
+ * instance will actually come back locked (`autoUnlock` is false).
  */
-export function UpdateRestartOverlay({ targetVersion }: { targetVersion: string | null }) {
-	const [reachableAgain, setReachableAgain] = useState(false);
+export function UpdateRestartOverlay({
+	targetVersion,
+	fromVersion,
+	autoUnlock,
+}: {
+	targetVersion: string | null;
+	fromVersion: string | null;
+	autoUnlock: boolean;
+}) {
+	const [reloading, setReloading] = useState(false);
 	const wentDown = useRef(false);
 
 	useEffect(() => {
 		let cancelled = false;
 		let timer: ReturnType<typeof setTimeout>;
 
-		const poll = async () => {
-			try {
-				const res = await fetch('/api/status', { cache: 'no-store' });
-				if (res.ok && wentDown.current) {
-					// Server went away and is back — reload onto the new version.
-					if (!cancelled) {
-						setReachableAgain(true);
-						window.location.reload();
-					}
-					return;
-				}
-				if (!res.ok) wentDown.current = true;
-			} catch {
-				// Network error → the worker is down mid-restart.
-				wentDown.current = true;
-			}
-			if (!cancelled) timer = setTimeout(poll, 1500);
+		const reload = () => {
+			if (cancelled) return;
+			setReloading(true);
+			window.location.reload();
 		};
 
-		timer = setTimeout(poll, 1500);
+		const poll = async () => {
+			let sample: { ok: boolean; starting: boolean; version: string | null };
+			try {
+				const res = await fetch('/api/status', { cache: 'no-store' });
+				const body = res.ok
+					? ((await res.json().catch(() => null)) as {
+							starting?: boolean;
+							version?: string;
+						} | null)
+					: null;
+				sample = {
+					ok: res.ok,
+					starting: body?.starting === true,
+					version: body?.version ?? null,
+				};
+			} catch {
+				// Network error → the worker is down mid-restart.
+				sample = { ok: false, starting: false, version: null };
+			}
+			const result = evaluateRestartPoll({ fromVersion, wentDown: wentDown.current }, sample);
+			wentDown.current = result.wentDown;
+			if (result.reload) {
+				reload();
+				return;
+			}
+			if (!cancelled) timer = setTimeout(poll, POLL_INTERVAL_MS);
+		};
+
+		// Poll immediately (a brief restart window can fall between delayed polls),
+		// then on the interval, with a timeout fallback that reloads regardless.
+		void poll();
+		const fallback = setTimeout(reload, FALLBACK_RELOAD_MS);
 		return () => {
 			cancelled = true;
 			clearTimeout(timer);
+			clearTimeout(fallback);
 		};
-	}, []);
+	}, [fromVersion]);
 
 	// The scrim (`--overlay`) is a dark, semi-transparent dim in both themes, so
 	// text rendered directly on it washes out in light mode. Mirror every other
@@ -54,12 +116,14 @@ export function UpdateRestartOverlay({ targetVersion }: { targetVersion: string 
 			<div className="flex w-full max-w-sm flex-col items-center gap-4 rounded-lg border border-border bg-surface p-6 text-center shadow-lg sm:p-8">
 				<Loader2 className="w-8 h-8 animate-spin text-text-1" />
 				<div className="text-base font-semibold text-text-1">
-					{reachableAgain ? 'Reloading…' : 'Updating Hezo…'}
+					{reloading ? 'Reloading…' : 'Updating Hezo…'}
 				</div>
 				<p className="text-[13px] text-text-2 leading-relaxed">
 					{targetVersion ? `Restarting onto ${targetVersion}. ` : 'Restarting. '}
-					In-flight agent runs are paused and resume automatically. When Hezo comes back you'll need
-					your 12-word master key to unlock it again.
+					In-flight agent runs are paused and resume automatically.{' '}
+					{autoUnlock
+						? 'Hezo will come back unlocked — no master key needed.'
+						: "When Hezo comes back you'll need your 12-word master key to unlock it again."}
 				</p>
 			</div>
 		</div>

--- a/packages/web/src/components/version-display.tsx
+++ b/packages/web/src/components/version-display.tsx
@@ -41,7 +41,13 @@ export function VersionDisplay() {
 	const [confirmOpen, setConfirmOpen] = useState(false);
 
 	if (applying) {
-		return <UpdateRestartOverlay targetVersion={update?.targetVersion ?? update?.latest ?? null} />;
+		return (
+			<UpdateRestartOverlay
+				targetVersion={update?.targetVersion ?? update?.latest ?? null}
+				fromVersion={update?.current ?? null}
+				autoUnlock={update?.autoUnlock ?? false}
+			/>
+		);
 	}
 
 	if (!update?.current) return null;

--- a/packages/web/test/settings-version.test.tsx
+++ b/packages/web/test/settings-version.test.tsx
@@ -144,6 +144,9 @@ test('Install & restart asks for confirmation (with master-key warning) then app
 	const postSpy = vi
 		.spyOn(api, 'post')
 		.mockResolvedValue({ state: UpdateState.Applying, targetVersion: '0.2.0' });
+	// The mounted overlay polls `/api/status`; there's no server here, so stub fetch
+	// to a clean rejection (happy-dom's real fetch would log an ECONNREFUSED).
+	vi.spyOn(global, 'fetch').mockRejectedValue(new Error('down'));
 	const { getByTestId, findByTestId, queryByTestId } = renderVersion({ state: UpdateState.Staged });
 
 	await user.click(getByTestId('settings-version-install'));

--- a/packages/web/test/update-banner.test.tsx
+++ b/packages/web/test/update-banner.test.tsx
@@ -111,6 +111,9 @@ test('Install & restart asks for confirmation (with master-key warning) before a
 	const postSpy = vi
 		.spyOn(api, 'post')
 		.mockResolvedValue({ state: UpdateState.Applying, targetVersion: '0.2.0' });
+	// The mounted overlay polls `/api/status`; there's no server here, so stub fetch
+	// to a clean rejection (happy-dom's real fetch would log an ECONNREFUSED).
+	vi.spyOn(global, 'fetch').mockRejectedValue(new Error('down'));
 
 	const { getByTestId, findByTestId, queryByTestId } = renderBanner();
 

--- a/packages/web/test/update-restart-overlay.test.tsx
+++ b/packages/web/test/update-restart-overlay.test.tsx
@@ -1,0 +1,80 @@
+import { render } from '@testing-library/react';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import {
+	evaluateRestartPoll,
+	UpdateRestartOverlay,
+} from '../src/components/update-restart-overlay';
+
+describe('evaluateRestartPoll', () => {
+	test('reloads once the reported version differs from the one we left', () => {
+		// The booting new binary already carries the new version in its `starting`
+		// response, so we detect the swap even before it is fully ready.
+		expect(
+			evaluateRestartPoll(
+				{ fromVersion: '0.1.0', wentDown: false },
+				{ ok: true, starting: true, version: '0.2.0' },
+			),
+		).toEqual({ reload: true, wentDown: false });
+	});
+
+	test('a network error / non-ok marks the server as down (no reload yet)', () => {
+		expect(
+			evaluateRestartPoll(
+				{ fromVersion: '0.1.0', wentDown: false },
+				{ ok: false, starting: false, version: null },
+			),
+		).toEqual({ reload: false, wentDown: true });
+	});
+
+	test('a booting server on the same version is not treated as up', () => {
+		expect(
+			evaluateRestartPoll(
+				{ fromVersion: '0.1.0', wentDown: false },
+				{ ok: true, starting: true, version: '0.1.0' },
+			),
+		).toEqual({ reload: false, wentDown: false });
+	});
+
+	test('same-version restart recovers via the went-down → back-up fallback', () => {
+		expect(
+			evaluateRestartPoll(
+				{ fromVersion: '0.1.0', wentDown: true },
+				{ ok: true, starting: false, version: '0.1.0' },
+			),
+		).toEqual({ reload: true, wentDown: true });
+	});
+
+	test('a healthy server still on the old binary does not reload', () => {
+		expect(
+			evaluateRestartPoll(
+				{ fromVersion: '0.1.0', wentDown: false },
+				{ ok: true, starting: false, version: '0.1.0' },
+			),
+		).toEqual({ reload: false, wentDown: false });
+	});
+});
+
+describe('UpdateRestartOverlay copy', () => {
+	afterEach(() => vi.restoreAllMocks());
+
+	// The immediate poll would hit `/api/status`; reject it so the overlay just
+	// renders (never reaches `window.location.reload`).
+	function renderOverlay(props: { autoUnlock: boolean }) {
+		vi.spyOn(global, 'fetch').mockRejectedValue(new Error('down'));
+		return render(<UpdateRestartOverlay targetVersion="0.2.0" fromVersion="0.1.0" {...props} />);
+	}
+
+	test('warns about the master key when the instance comes back locked', () => {
+		const { getByTestId } = renderOverlay({ autoUnlock: false });
+		const text = getByTestId('update-restart-overlay').textContent ?? '';
+		expect(text).toContain("you'll need your 12-word master key");
+		expect(text).not.toContain('no master key needed');
+	});
+
+	test('reassures instead of warning when the instance auto-unlocks', () => {
+		const { getByTestId } = renderOverlay({ autoUnlock: true });
+		const text = getByTestId('update-restart-overlay').textContent ?? '';
+		expect(text).toContain('no master key needed');
+		expect(text).not.toContain("you'll need your 12-word master key");
+	});
+});


### PR DESCRIPTION
## Problem

Two issues with the full-screen `UpdateRestartOverlay` ("Updating Hezo…") shown during an **Install & restart** update:

1. **It gets stuck.** The spinner stays up forever and the page never reloads onto the new version.
2. **Wrong wording.** It says *"When Hezo comes back you'll need your 12-word master key to unlock it again"*, but on a supervised in-place update the instance now comes back **already unlocked** (the supervisor hands the in-memory unlock key to the relaunched worker — the handoff added in #596). The master-key line is stale.

## Root causes

**Stuck** — completion was detected *only* by catching the server transition from unreachable → reachable (`res.ok && wentDown.current`). Two ways that misses:
- Polls are 1.5s apart with **no immediate first poll**, so a brief restart window can fall *between* polls; `wentDown` never flips and it polls a healthy server forever.
- During boot the new worker answers `/api/status` with **HTTP 200** `{ starting: true, version }`, so a *booting* server counts as "up, never went down" and the reload never fires. There was no timeout fallback either.

**Wording** — the master-key sentence was printed unconditionally. The same warning in the two confirm dialogs is already gated on `!autoUnlock`, but the overlay was never handed `autoUnlock`.

## Fix

- **Version-change detection.** `/api/status.version` is the running binary's `HEZO_VERSION`, so once it differs from the version we're restarting away from (`fromVersion`, also `HEZO_VERSION` — identical plain `MAJOR.MINOR.PATCH` format), the new binary is up — even if the down-window was missed and even before the new worker is fully ready (its booting `starting: true` response already carries the new version). Factored into a pure, unit-tested `evaluateRestartPoll()`.
- **Poll immediately** (not only after 1.5s) and add a **120s timeout fallback** that reloads regardless, so a missed transition can never strand the overlay. A slightly-early reload is safe — the app shell lands on the boot `StartingScreen` and polls until ready. The went-down→back-up check stays as a fallback for same-version restarts (reinstall, or a failed apply where the supervisor relaunches the previous binary).
- **Correct copy** — gate the master-key sentence on `autoUnlock` (threaded in from both call sites), mirroring the confirm dialogs: warn only when the instance will actually come back locked, otherwise reassure that no master key is needed.

## Changes

- `packages/web/src/components/update-restart-overlay.tsx` — both fixes + `evaluateRestartPoll` helper.
- `packages/web/src/components/update-banner.tsx`, `version-display.tsx` — pass the new `fromVersion` / `autoUnlock` props.

## Tests

- New `packages/web/test/update-restart-overlay.test.tsx` — `evaluateRestartPoll` decision matrix (version change, network error, booting-same-version, went-down→back-up, healthy-old-version) and the conditional wording (locked warning vs. auto-unlock reassurance).
- Updated the two overlay-mounting tests (`update-banner`, `settings-version`) to stub `fetch` so the mounted overlay's poll doesn't emit `ECONNREFUSED` noise.
- Full web suite green (1060 tests), `typecheck` and `check` clean.

Docs already document the update-restart auto-unlock exception (`docs/security/master-key.md`), so no docs change was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ho3X3vVnWDVDanETUdo8g

---
_Generated by [Claude Code](https://claude.ai/code/session_019ho3X3vVnWDVDanETUdo8g)_