### PR TITLE
feat(web): add Upload button to comment composer + reusable file-attachment kit

### DIFF
--- a/docs/concepts/assets.md
+++ b/docs/concepts/assets.md
@@ -35,8 +35,9 @@ reference — older comments citing the old path show it as plain text.
 Drag files onto the **Assets** page to add them to the library: mockups, screenshots,
 diagrams, images, PDFs, scripts, audio, or video, up to 10 MB each. Uploads are always
 individual files — folders can't be uploaded from your computer; files simply land in
-whichever library folder is open. You can also attach files directly to a task or a comment,
-so a screenshot or a reference document sits right next to the discussion it belongs to —
+whichever library folder is open. You can also attach files directly to a task or a comment —
+drag them onto the comment box or use its **Upload** button — so a screenshot or a
+reference document sits right next to the discussion it belongs to —
 those attachments are filed in the library under an **uploads** folder, in a subfolder named
 after the task, so each task's files stay grouped without any manual sorting.
 

--- a/packages/web/src/components/comment-attachments-drop.tsx
+++ b/packages/web/src/components/comment-attachments-drop.tsx
@@ -1,21 +1,8 @@
-import { ATTACHMENT_MAX_BYTES, assetBasename, isAllowedAttachmentExtension } from '@hezo/shared';
-import {
-	ExternalLink,
-	FileAudio,
-	File as FileIcon,
-	FileText,
-	FileVideo,
-	Image as ImageIcon,
-	Loader2,
-	Upload,
-	X,
-} from 'lucide-react';
-import { type ReactNode, useCallback, useMemo, useRef, useState } from 'react';
-import type { CommentAttachment } from '../hooks/use-comments';
+import type { ReactNode } from 'react';
+import { useFileAttachments } from '../hooks/use-file-attachments';
 import { useUploadAttachment } from '../hooks/use-upload-attachment';
-import type { ApiError } from '../lib/api';
+import { ATTACHMENT_ACCEPT, AttachmentChips, FileDropZone, UploadButton } from './file-attachments';
 import { InfoTooltip } from './ui/info-tooltip';
-import { Tooltip } from './ui/tooltip';
 
 interface Props {
 	projectId: string;
@@ -25,238 +12,92 @@ interface Props {
 	children: ReactNode;
 }
 
-interface UploadingFile {
-	tempId: string;
-	filename: string;
-}
-
-interface ErrorChip {
-	id: string;
-	filename: string;
-	message: string;
-}
-
-function iconFor(contentType: string, className = 'h-3.5 w-3.5') {
-	if (contentType.startsWith('image/')) return <ImageIcon className={className} />;
-	if (contentType.startsWith('audio/')) return <FileAudio className={className} />;
-	if (contentType.startsWith('video/')) return <FileVideo className={className} />;
-	if (contentType === 'application/pdf' || contentType === 'text/plain') {
-		return <FileText className={className} />;
-	}
-	return <FileIcon className={className} />;
-}
-
+/**
+ * Task-comment binding of the reusable file-attachment kit: wires the composer's
+ * `pendingAttachmentIds` to `useFileAttachments` (uploading via the task assets
+ * endpoint), wraps the comment textarea in a `FileDropZone`, and offers both an
+ * **Upload** button and drag-and-drop. The drag hint is hidden on mobile, where
+ * you can't drag — the Upload button is the affordance there. The generic parts
+ * (`useFileAttachments`, `FileDropZone`, `UploadButton`, `AttachmentChips`) are
+ * reused as-is by the realtime chat input.
+ */
 export function CommentAttachmentsDrop({ projectId, taskId, value, onChange, children }: Props) {
-	const [isDragActive, setIsDragActive] = useState(false);
-	const dragDepth = useRef(0);
-	const [metaById, setMetaById] = useState<Map<string, CommentAttachment>>(new Map());
-	const [uploading, setUploading] = useState<UploadingFile[]>([]);
-	const [errors, setErrors] = useState<ErrorChip[]>([]);
 	const upload = useUploadAttachment(projectId, taskId);
-
-	const visibleAttachments = useMemo(
-		() => value.map((id) => metaById.get(id)).filter((a): a is CommentAttachment => Boolean(a)),
-		[value, metaById],
-	);
-
-	const pushError = useCallback((filename: string, message: string) => {
-		const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
-		setErrors((prev) => [...prev, { id, filename, message }]);
-		setTimeout(() => setErrors((prev) => prev.filter((e) => e.id !== id)), 5000);
-	}, []);
-
-	const handleFiles = useCallback(
-		async (files: File[]) => {
-			const accepted: File[] = [];
-			for (const file of files) {
-				if (!isAllowedAttachmentExtension(file.name)) {
-					pushError(file.name, 'Unsupported file type');
-					continue;
-				}
-				if (file.size > ATTACHMENT_MAX_BYTES) {
-					pushError(file.name, 'File exceeds 10 MB');
-					continue;
-				}
-				accepted.push(file);
-			}
-			if (accepted.length === 0) return;
-
-			const pending: UploadingFile[] = accepted.map((f) => ({
-				tempId: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
-				filename: f.name,
-			}));
-			setUploading((prev) => [...prev, ...pending]);
-
-			const results = await Promise.allSettled(accepted.map((file) => upload.mutateAsync(file)));
-
-			const newOnes: CommentAttachment[] = [];
-			results.forEach((res, idx) => {
-				if (res.status === 'fulfilled') {
-					newOnes.push(res.value);
-				} else {
-					const reason = res.reason as ApiError;
-					pushError(accepted[idx].name, reason?.message ?? 'Upload failed');
-				}
-			});
-
-			setUploading((prev) => prev.filter((u) => !pending.some((p) => p.tempId === u.tempId)));
-
-			if (newOnes.length > 0) {
-				setMetaById((prev) => {
-					const next = new Map(prev);
-					for (const a of newOnes) next.set(a.id, a);
-					return next;
-				});
-				onChange([...value, ...newOnes.map((a) => a.id)]);
-			}
-		},
-		[onChange, pushError, upload, value],
-	);
-
-	const onDragEnter = useCallback((e: React.DragEvent) => {
-		if (!Array.from(e.dataTransfer.types).includes('Files')) return;
-		e.preventDefault();
-		dragDepth.current += 1;
-		setIsDragActive(true);
-	}, []);
-
-	const onDragLeave = useCallback((e: React.DragEvent) => {
-		if (!Array.from(e.dataTransfer.types).includes('Files')) return;
-		e.preventDefault();
-		dragDepth.current = Math.max(0, dragDepth.current - 1);
-		if (dragDepth.current === 0) setIsDragActive(false);
-	}, []);
-
-	const onDragOver = useCallback((e: React.DragEvent) => {
-		if (!Array.from(e.dataTransfer.types).includes('Files')) return;
-		e.preventDefault();
-	}, []);
-
-	const onDrop = useCallback(
-		(e: React.DragEvent) => {
-			if (!Array.from(e.dataTransfer.types).includes('Files')) return;
-			e.preventDefault();
-			dragDepth.current = 0;
-			setIsDragActive(false);
-			const files = Array.from(e.dataTransfer.files);
-			if (files.length > 0) handleFiles(files);
-		},
-		[handleFiles],
-	);
-
-	const removeAttachment = useCallback(
-		(id: string) => {
-			onChange(value.filter((v) => v !== id));
-		},
-		[onChange, value],
-	);
-
-	const hasAnyChip = visibleAttachments.length > 0 || uploading.length > 0 || errors.length > 0;
+	const {
+		isDragActive,
+		visibleAttachments,
+		uploading,
+		errors,
+		hasAnyChip,
+		handleFiles,
+		removeAttachment,
+		dropZoneProps,
+	} = useFileAttachments({
+		value,
+		onChange,
+		uploadFile: (file) => upload.mutateAsync(file),
+	});
 
 	return (
-		// biome-ignore lint/a11y/noStaticElementInteractions: drag-and-drop wrapper; the inner textarea owns keyboard interaction
-		<div
-			className="relative"
+		<FileDropZone
+			isDragActive={isDragActive}
+			dropZoneProps={dropZoneProps}
 			data-testid="comment-attachments-drop"
-			onDragEnter={onDragEnter}
-			onDragLeave={onDragLeave}
-			onDragOver={onDragOver}
-			onDrop={onDrop}
+			overlayTestId="comment-attachment-drop-overlay"
 		>
-			{!hasAnyChip && (
-				<div
-					className="mb-2 flex items-center gap-1.5 text-xs text-text-3"
-					data-testid="comment-attachment-hint"
-				>
-					<span>Drag and drop files to attach</span>
-					<InfoTooltip
-						label="Supported attachment types"
-						data-testid="comment-attachment-hint-info"
-						content={
-							<div className="space-y-1">
-								<div>
-									<strong>Images:</strong> PNG, JPG, GIF
+			<div className="mb-2 flex flex-wrap items-center gap-1.5">
+				<UploadButton
+					onFiles={handleFiles}
+					accept={ATTACHMENT_ACCEPT}
+					data-testid="comment-attachment-upload-button"
+				/>
+				{!hasAnyChip && (
+					<div
+						className="flex items-center gap-1.5 text-xs text-text-3"
+						data-testid="comment-attachment-hint"
+					>
+						{/* Touch devices can't drag files, so the hint is desktop-only; the
+						    Upload button carries attachment on mobile. */}
+						<span className="hidden sm:inline" data-testid="comment-attachment-hint-text">
+							Drag and drop files to attach
+						</span>
+						<InfoTooltip
+							label="Supported attachment types"
+							data-testid="comment-attachment-hint-info"
+							content={
+								<div className="space-y-1">
+									<div>
+										<strong>Images:</strong> PNG, JPG, GIF
+									</div>
+									<div>
+										<strong>Documents:</strong> PDF, TXT
+									</div>
+									<div>
+										<strong>Audio:</strong> MP3, WAV, AAC, OPUS
+									</div>
+									<div>
+										<strong>Video:</strong> MP4, WEBM, MOV
+									</div>
+									<div className="pt-1 text-text-3">Max 10&nbsp;MB per file</div>
 								</div>
-								<div>
-									<strong>Documents:</strong> PDF, TXT
-								</div>
-								<div>
-									<strong>Audio:</strong> MP3, WAV, AAC, OPUS
-								</div>
-								<div>
-									<strong>Video:</strong> MP4, WEBM, MOV
-								</div>
-								<div className="pt-1 text-text-3">Max 10&nbsp;MB per file</div>
-							</div>
-						}
-					/>
-				</div>
-			)}
+							}
+						/>
+					</div>
+				)}
+			</div>
 			{hasAnyChip && (
-				<div className="mb-2 flex flex-wrap gap-1.5" data-testid="comment-attachment-pending-row">
-					{visibleAttachments.map((a) => (
-						<span
-							key={a.id}
-							className="flex items-center gap-1.5 rounded-sm border border-border bg-surface-3 px-2 py-1 text-[12px] text-text-1"
-							data-testid="comment-attachment-chip"
-						>
-							{iconFor(a.content_type)}
-							<Tooltip content={a.original_filename}>
-								<a
-									href={a.url}
-									target="_blank"
-									rel="noopener noreferrer"
-									className="flex items-center gap-1 text-text-1 hover:underline"
-									data-testid="comment-attachment-preview"
-								>
-									<span className="max-w-[140px] truncate">
-										{assetBasename(a.original_filename)}
-									</span>
-									<ExternalLink className="h-3 w-3 shrink-0" />
-								</a>
-							</Tooltip>
-							<button
-								type="button"
-								aria-label="Remove attachment"
-								className="text-text-3 hover:text-text-1"
-								onClick={() => removeAttachment(a.id)}
-							>
-								<X className="h-3 w-3" />
-							</button>
-						</span>
-					))}
-					{uploading.map((u) => (
-						<span
-							key={u.tempId}
-							className="flex items-center gap-1.5 rounded-sm border border-dashed border-border bg-surface-3/50 px-2 py-1 text-[12px] text-text-3"
-						>
-							<Loader2 className="h-3 w-3 animate-spin" />
-							<span className="max-w-[140px] truncate">{u.filename}</span>
-						</span>
-					))}
-					{errors.map((e) => (
-						<span
-							key={e.id}
-							className="flex items-center gap-1.5 rounded-sm border border-danger/40 bg-danger/10 px-2 py-1 text-[12px] text-danger"
-							data-testid="comment-attachment-error"
-						>
-							<span className="max-w-[200px] truncate">
-								{e.filename}: {e.message}
-							</span>
-						</span>
-					))}
-				</div>
+				<AttachmentChips
+					attachments={visibleAttachments}
+					uploading={uploading}
+					errors={errors}
+					onRemove={removeAttachment}
+					rowTestId="comment-attachment-pending-row"
+					chipTestId="comment-attachment-chip"
+					previewTestId="comment-attachment-preview"
+					errorTestId="comment-attachment-error"
+				/>
 			)}
 			{children}
-			{isDragActive && (
-				<div
-					className="pointer-events-none absolute inset-0 z-10 flex flex-col items-center justify-center gap-2 rounded-md border border-dashed border-border-strong bg-surface/95"
-					data-testid="comment-attachment-drop-overlay"
-				>
-					<Upload className="h-5 w-5 text-text-3" />
-					<p className="text-[13px] text-text-3">Drop to attach</p>
-				</div>
-			)}
-		</div>
+		</FileDropZone>
 	);
 }

--- a/packages/web/src/components/file-attachments/attachment-chips.tsx
+++ b/packages/web/src/components/file-attachments/attachment-chips.tsx
@@ -1,0 +1,108 @@
+import { assetBasename } from '@hezo/shared';
+import {
+	ExternalLink,
+	FileAudio,
+	File as FileIcon,
+	FileText,
+	FileVideo,
+	Image as ImageIcon,
+	Loader2,
+	X,
+} from 'lucide-react';
+import type {
+	ErrorChip,
+	UploadedAttachment,
+	UploadingFile,
+} from '../../hooks/use-file-attachments';
+import { Tooltip } from '../ui/tooltip';
+
+function iconFor(contentType: string, className = 'h-3.5 w-3.5') {
+	if (contentType.startsWith('image/')) return <ImageIcon className={className} />;
+	if (contentType.startsWith('audio/')) return <FileAudio className={className} />;
+	if (contentType.startsWith('video/')) return <FileVideo className={className} />;
+	if (contentType === 'application/pdf' || contentType === 'text/plain') {
+		return <FileText className={className} />;
+	}
+	return <FileIcon className={className} />;
+}
+
+interface AttachmentChipsProps {
+	attachments: UploadedAttachment[];
+	uploading: UploadingFile[];
+	errors: ErrorChip[];
+	onRemove: (id: string) => void;
+	rowTestId?: string;
+	chipTestId?: string;
+	previewTestId?: string;
+	errorTestId?: string;
+}
+
+/**
+ * The pending-attachments row: a linked chip per uploaded file, a spinner chip
+ * per in-flight upload, and a transient error chip per rejection. Presentational
+ * only — the data comes from `useFileAttachments`.
+ */
+export function AttachmentChips({
+	attachments,
+	uploading,
+	errors,
+	onRemove,
+	rowTestId,
+	chipTestId,
+	previewTestId,
+	errorTestId,
+}: AttachmentChipsProps) {
+	return (
+		<div className="mb-2 flex flex-wrap gap-1.5" data-testid={rowTestId}>
+			{attachments.map((a) => (
+				<span
+					key={a.id}
+					className="flex items-center gap-1.5 rounded-sm border border-border bg-surface-3 px-2 py-1 text-[12px] text-text-1"
+					data-testid={chipTestId}
+				>
+					{iconFor(a.content_type)}
+					<Tooltip content={a.original_filename}>
+						<a
+							href={a.url}
+							target="_blank"
+							rel="noopener noreferrer"
+							className="flex items-center gap-1 text-text-1 hover:underline"
+							data-testid={previewTestId}
+						>
+							<span className="max-w-[140px] truncate">{assetBasename(a.original_filename)}</span>
+							<ExternalLink className="h-3 w-3 shrink-0" />
+						</a>
+					</Tooltip>
+					<button
+						type="button"
+						aria-label="Remove attachment"
+						className="text-text-3 hover:text-text-1"
+						onClick={() => onRemove(a.id)}
+					>
+						<X className="h-3 w-3" />
+					</button>
+				</span>
+			))}
+			{uploading.map((u) => (
+				<span
+					key={u.tempId}
+					className="flex items-center gap-1.5 rounded-sm border border-dashed border-border bg-surface-3/50 px-2 py-1 text-[12px] text-text-3"
+				>
+					<Loader2 className="h-3 w-3 animate-spin" />
+					<span className="max-w-[140px] truncate">{u.filename}</span>
+				</span>
+			))}
+			{errors.map((e) => (
+				<span
+					key={e.id}
+					className="flex items-center gap-1.5 rounded-sm border border-danger/40 bg-danger/10 px-2 py-1 text-[12px] text-danger"
+					data-testid={errorTestId}
+				>
+					<span className="max-w-[200px] truncate">
+						{e.filename}: {e.message}
+					</span>
+				</span>
+			))}
+		</div>
+	);
+}

--- a/packages/web/src/components/file-attachments/file-drop-zone.tsx
+++ b/packages/web/src/components/file-attachments/file-drop-zone.tsx
@@ -1,0 +1,55 @@
+import { Upload } from 'lucide-react';
+import type { ReactNode } from 'react';
+import type { DropZoneHandlers } from '../../hooks/use-file-attachments';
+
+interface FileDropZoneProps {
+	/** From `useFileAttachments` — whether a file drag is currently over the zone. */
+	isDragActive: boolean;
+	/** From `useFileAttachments` — the four drag/drop handlers to spread on the zone. */
+	dropZoneProps: DropZoneHandlers;
+	overlayLabel?: string;
+	overlayTestId?: string;
+	className?: string;
+	'data-testid'?: string;
+	children: ReactNode;
+}
+
+/**
+ * Reusable drag-and-drop surface: a relatively-positioned wrapper that wires the
+ * drag handlers and paints a "drop to attach" overlay while a file is dragged
+ * over it. Owns no state — feed it `isDragActive`/`dropZoneProps` from
+ * `useFileAttachments`. The content it wraps (a textarea, a chat input, …) owns
+ * keyboard interaction.
+ */
+export function FileDropZone({
+	isDragActive,
+	dropZoneProps,
+	overlayLabel = 'Drop to attach',
+	overlayTestId,
+	className,
+	'data-testid': testId,
+	children,
+}: FileDropZoneProps) {
+	return (
+		// biome-ignore lint/a11y/noStaticElementInteractions: drag-and-drop wrapper; the wrapped input owns keyboard interaction
+		<div
+			className={`relative ${className ?? ''}`}
+			data-testid={testId}
+			onDragEnter={dropZoneProps.onDragEnter}
+			onDragLeave={dropZoneProps.onDragLeave}
+			onDragOver={dropZoneProps.onDragOver}
+			onDrop={dropZoneProps.onDrop}
+		>
+			{children}
+			{isDragActive && (
+				<div
+					className="pointer-events-none absolute inset-0 z-10 flex flex-col items-center justify-center gap-2 rounded-md border border-dashed border-border-strong bg-surface/95"
+					data-testid={overlayTestId}
+				>
+					<Upload className="h-5 w-5 text-text-3" />
+					<p className="text-[13px] text-text-3">{overlayLabel}</p>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/packages/web/src/components/file-attachments/index.ts
+++ b/packages/web/src/components/file-attachments/index.ts
@@ -1,0 +1,14 @@
+import { ATTACHMENT_EXTENSIONS } from '@hezo/shared';
+
+export { AttachmentChips } from './attachment-chips';
+export { FileDropZone } from './file-drop-zone';
+export { UploadButton } from './upload-button';
+
+/**
+ * Comma-separated `accept` value for a file picker, derived from the shared
+ * attachment allowlist so the OS dialog pre-filters to supported extensions.
+ * (The real gate is still `handleFiles` — `accept` is only a UX hint.)
+ */
+export const ATTACHMENT_ACCEPT = Object.keys(ATTACHMENT_EXTENSIONS)
+	.map((ext) => `.${ext}`)
+	.join(',');

--- a/packages/web/src/components/file-attachments/upload-button.tsx
+++ b/packages/web/src/components/file-attachments/upload-button.tsx
@@ -1,0 +1,62 @@
+import { Plus } from 'lucide-react';
+import { useRef } from 'react';
+import { Button } from '../ui/button';
+
+interface UploadButtonProps {
+	/** Called with the picked files — route it to `useFileAttachments`' `handleFiles`. */
+	onFiles: (files: File[]) => void;
+	/** `accept` attribute for the picker (e.g. `ATTACHMENT_ACCEPT`). */
+	accept?: string;
+	label?: string;
+	disabled?: boolean;
+	'data-testid'?: string;
+}
+
+/**
+ * A "+ Upload" button that opens the native file picker — the click-to-attach
+ * alternative to drag-and-drop (and the primary affordance on touch devices,
+ * which can't drag). Renders a hidden multi-select `<input type="file">` and
+ * hands the chosen files back through `onFiles`. `type="button"` so it never
+ * submits a surrounding form.
+ */
+export function UploadButton({
+	onFiles,
+	accept,
+	label = 'Upload',
+	disabled,
+	'data-testid': testId,
+}: UploadButtonProps) {
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	return (
+		<>
+			<Button
+				type="button"
+				variant="secondary"
+				size="sm"
+				onClick={() => inputRef.current?.click()}
+				disabled={disabled}
+				data-testid={testId}
+			>
+				<Plus className="h-3.5 w-3.5" />
+				{label}
+			</Button>
+			<input
+				ref={inputRef}
+				type="file"
+				multiple
+				accept={accept}
+				className="hidden"
+				aria-hidden="true"
+				tabIndex={-1}
+				data-testid={testId ? `${testId}-input` : undefined}
+				onChange={(e) => {
+					const files = Array.from(e.target.files ?? []);
+					if (files.length > 0) onFiles(files);
+					// Reset so picking the same file again still fires `change`.
+					e.target.value = '';
+				}}
+			/>
+		</>
+	);
+}

--- a/packages/web/src/hooks/use-file-attachments.ts
+++ b/packages/web/src/hooks/use-file-attachments.ts
@@ -1,0 +1,172 @@
+import { ATTACHMENT_MAX_BYTES, isAllowedAttachmentExtension } from '@hezo/shared';
+import { type DragEventHandler, useCallback, useMemo, useRef, useState } from 'react';
+
+/**
+ * Minimal shape the attachments UI needs from an uploaded file. Any upload
+ * mutation whose result carries these fields (the task `CommentAttachment`, and
+ * the realtime-chat attachment to come) satisfies it.
+ */
+export interface UploadedAttachment {
+	id: string;
+	content_type: string;
+	original_filename: string;
+	url: string;
+}
+
+export interface UploadingFile {
+	tempId: string;
+	filename: string;
+}
+
+export interface ErrorChip {
+	id: string;
+	filename: string;
+	message: string;
+}
+
+export interface DropZoneHandlers {
+	onDragEnter: DragEventHandler;
+	onDragLeave: DragEventHandler;
+	onDragOver: DragEventHandler;
+	onDrop: DragEventHandler;
+}
+
+interface UseFileAttachmentsOptions<T extends UploadedAttachment> {
+	/** Selected attachment ids (controlled by the consumer). */
+	value: string[];
+	onChange: (ids: string[]) => void;
+	/** Uploads one file and resolves to its stored metadata. Injected so this hook
+	 *  stays decoupled from any one endpoint (comments today, chat later). */
+	uploadFile: (file: File) => Promise<T>;
+}
+
+/**
+ * Headless state machine behind the file-attachment UI: client-side validation
+ * (extension + 10 MB cap), concurrent uploads with per-file progress, transient
+ * error chips, a depth-tracked drag overlay, and add/remove of the selected ids.
+ * It renders nothing — pair it with `FileDropZone`, `UploadButton`, and
+ * `AttachmentChips`, or drive `handleFiles`/`dropZoneProps` from any surface.
+ */
+export function useFileAttachments<T extends UploadedAttachment>({
+	value,
+	onChange,
+	uploadFile,
+}: UseFileAttachmentsOptions<T>) {
+	const [isDragActive, setIsDragActive] = useState(false);
+	const dragDepth = useRef(0);
+	const [metaById, setMetaById] = useState<Map<string, T>>(new Map());
+	const [uploading, setUploading] = useState<UploadingFile[]>([]);
+	const [errors, setErrors] = useState<ErrorChip[]>([]);
+
+	const visibleAttachments = useMemo(
+		() => value.map((id) => metaById.get(id)).filter((a): a is T => Boolean(a)),
+		[value, metaById],
+	);
+
+	const pushError = useCallback((filename: string, message: string) => {
+		const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+		setErrors((prev) => [...prev, { id, filename, message }]);
+		setTimeout(() => setErrors((prev) => prev.filter((e) => e.id !== id)), 5000);
+	}, []);
+
+	const handleFiles = useCallback(
+		async (files: File[]) => {
+			const accepted: File[] = [];
+			for (const file of files) {
+				if (!isAllowedAttachmentExtension(file.name)) {
+					pushError(file.name, 'Unsupported file type');
+					continue;
+				}
+				if (file.size > ATTACHMENT_MAX_BYTES) {
+					pushError(file.name, 'File exceeds 10 MB');
+					continue;
+				}
+				accepted.push(file);
+			}
+			if (accepted.length === 0) return;
+
+			const pending: UploadingFile[] = accepted.map((f) => ({
+				tempId: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+				filename: f.name,
+			}));
+			setUploading((prev) => [...prev, ...pending]);
+
+			const results = await Promise.allSettled(accepted.map((file) => uploadFile(file)));
+
+			const newOnes: T[] = [];
+			results.forEach((res, idx) => {
+				if (res.status === 'fulfilled') {
+					newOnes.push(res.value);
+				} else {
+					const message = res.reason instanceof Error ? res.reason.message : 'Upload failed';
+					pushError(accepted[idx].name, message);
+				}
+			});
+
+			setUploading((prev) => prev.filter((u) => !pending.some((p) => p.tempId === u.tempId)));
+
+			if (newOnes.length > 0) {
+				setMetaById((prev) => {
+					const next = new Map(prev);
+					for (const a of newOnes) next.set(a.id, a);
+					return next;
+				});
+				onChange([...value, ...newOnes.map((a) => a.id)]);
+			}
+		},
+		[onChange, pushError, uploadFile, value],
+	);
+
+	const onDragEnter = useCallback((e: React.DragEvent) => {
+		if (!Array.from(e.dataTransfer.types).includes('Files')) return;
+		e.preventDefault();
+		dragDepth.current += 1;
+		setIsDragActive(true);
+	}, []);
+
+	const onDragLeave = useCallback((e: React.DragEvent) => {
+		if (!Array.from(e.dataTransfer.types).includes('Files')) return;
+		e.preventDefault();
+		dragDepth.current = Math.max(0, dragDepth.current - 1);
+		if (dragDepth.current === 0) setIsDragActive(false);
+	}, []);
+
+	const onDragOver = useCallback((e: React.DragEvent) => {
+		if (!Array.from(e.dataTransfer.types).includes('Files')) return;
+		e.preventDefault();
+	}, []);
+
+	const onDrop = useCallback(
+		(e: React.DragEvent) => {
+			if (!Array.from(e.dataTransfer.types).includes('Files')) return;
+			e.preventDefault();
+			dragDepth.current = 0;
+			setIsDragActive(false);
+			const files = Array.from(e.dataTransfer.files);
+			if (files.length > 0) handleFiles(files);
+		},
+		[handleFiles],
+	);
+
+	const removeAttachment = useCallback(
+		(id: string) => {
+			onChange(value.filter((v) => v !== id));
+		},
+		[onChange, value],
+	);
+
+	const hasAnyChip = visibleAttachments.length > 0 || uploading.length > 0 || errors.length > 0;
+
+	const dropZoneProps: DropZoneHandlers = { onDragEnter, onDragLeave, onDragOver, onDrop };
+
+	return {
+		isDragActive,
+		visibleAttachments,
+		uploading,
+		errors,
+		hasAnyChip,
+		handleFiles,
+		removeAttachment,
+		dropZoneProps,
+	};
+}

--- a/packages/web/test/comment-attachments-dropzone.test.tsx
+++ b/packages/web/test/comment-attachments-dropzone.test.tsx
@@ -100,6 +100,35 @@ test('dropping allowed files uploads them and renders linked chips; the X remove
 	expect(await findByTestId('comment-attachment-hint')).toBeTruthy();
 });
 
+test('the Upload button picks files via the hidden input and uploads them', async () => {
+	const { findByTestId, queryByTestId } = await renderTaskPage();
+
+	// The idle hint and the Upload button both show before any chip.
+	expect(await findByTestId('comment-attachment-hint')).toBeTruthy();
+	await findByTestId('comment-attachment-upload-button');
+
+	// The picker is a native multi-select input pre-filtered to allowed extensions.
+	const input = (await findByTestId('comment-attachment-upload-button-input')) as HTMLInputElement;
+	expect(input.getAttribute('type')).toBe('file');
+	expect(input.multiple).toBe(true);
+	expect(input.getAttribute('accept')).toContain('.png');
+
+	const png = new File([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], 'picked.png', {
+		type: 'image/png',
+	});
+	// Choosing a file in the OS dialog fires `change` on the hidden input.
+	Object.defineProperty(input, 'files', { value: [png], configurable: true });
+	fireEvent.change(input);
+
+	const chip = await findByTestId('comment-attachment-chip', undefined, { timeout: 15_000 });
+	expect(chip.textContent).toContain('picked.png');
+
+	// The hint is replaced by the chip row, but the Upload button persists so more
+	// files can be added — the only way to attach on touch devices.
+	expect(queryByTestId('comment-attachment-hint')).toBeNull();
+	expect(queryByTestId('comment-attachment-upload-button')).toBeTruthy();
+});
+
 test('each content type gets its own chip icon (image/audio/video/document/fallback)', async () => {
 	const { zone, container } = await renderTaskPage();
 

--- a/test/browser/task-comment-attachments.spec.ts
+++ b/test/browser/task-comment-attachments.spec.ts
@@ -186,6 +186,9 @@ test.describe('Task Comment Attachments', () => {
 		await expect(hint).toBeVisible();
 		await expect(hint).toContainText('Drag and drop files to attach');
 
+		// The Upload button sits beside the hint as the click-to-attach alternative.
+		await expect(page.locator('[data-testid="comment-attachment-upload-button"]')).toBeVisible();
+
 		const info = page.locator('[data-testid="comment-attachment-hint-info"]');
 		const tooltip = page.getByRole('tooltip');
 		// Radix opens this tooltip in its trigger's `onFocus` handler, which fires
@@ -276,7 +279,7 @@ test.describe('Task Comment Attachments', () => {
 		await expect(errorChip).toContainText('virus.exe');
 	});
 
-	test('mobile viewport — hint visible, chips wrap and overlay still triggers', async ({
+	test('mobile viewport — Upload button drives attach, drag hint text is hidden', async ({
 		sharedPage: page,
 		sharedWorkspace,
 	}) => {
@@ -285,10 +288,13 @@ test.describe('Task Comment Attachments', () => {
 
 		await openTaskDetail(page, project.slug, task);
 
-		const hint = page.locator('[data-testid="comment-attachment-hint"]');
-		await expect(hint).toBeVisible();
-		await expect(hint).toContainText('Drag and drop files to attach');
+		// Touch devices can't drag files, so the "Drag and drop…" text is hidden on
+		// mobile; the Upload button is the affordance instead.
+		const uploadButton = page.locator('[data-testid="comment-attachment-upload-button"]');
+		await expect(uploadButton).toBeVisible();
+		await expect(page.locator('[data-testid="comment-attachment-hint-text"]')).toBeHidden();
 
+		// A drop still uploads (the whole zone remains a drop target) and chips wrap.
 		await dropFileAndAwaitUpload(
 			page,
 			task.id,
@@ -302,7 +308,8 @@ test.describe('Task Comment Attachments', () => {
 			hasText: 'mobile.png',
 		});
 		await expect(chip).toBeVisible({ timeout: UPLOAD_WAIT_MS });
-		await expect(hint).toBeHidden();
+		// The Upload button persists alongside the chips so more files can be added.
+		await expect(uploadButton).toBeVisible();
 		await expect(chip.locator('[data-testid="comment-attachment-preview"]')).toBeVisible();
 	});
 });


### PR DESCRIPTION
## What & why

Adds a **+ Upload** button beside the "Drag and drop files to attach" hint in the task comment composer, as a click-to-attach alternative to drag-and-drop. It opens the native multi-select file picker and routes chosen files through the **same** validation/upload path as a drop (identical extension + 10 MB checks, progress chips, error chips).

On **mobile the drag hint text is hidden** — touch devices can't drag files, so the Upload button is the attach affordance there. The button also **persists alongside chips** so more files can always be added (previously, once you attached one file the hint row disappeared, leaving mobile users no way to add a second).

The change was reviewed as a visual mockup (desktop + mobile, light + dark) before implementation.

## Reusable refactor

Per the plan to add file upload / drag-and-drop to the realtime chat input later, the attachment logic is extracted into a reusable kit so the chat input can reuse it wholesale:

- **`useFileAttachments`** (`packages/web/src/hooks/`) — headless state machine: client-side validation, concurrent uploads with per-file progress, transient error chips, a depth-tracked drag overlay, add/remove of selected ids. Decoupled from any endpoint via an injected `uploadFile(file)`.
- **`FileDropZone` / `UploadButton` / `AttachmentChips`** (`packages/web/src/components/file-attachments/`) — presentational primitives a consumer composes.
- **`ATTACHMENT_ACCEPT`** — picker `accept` string derived from the shared attachment allowlist.

`CommentAttachmentsDrop` becomes a thin task-comment binding of the kit (wires `useUploadAttachment`); its public props are unchanged, so `CommentComposer` needs no change.

## Design decisions

- Button uses the shared **secondary / sm** style (neutral outline, `Plus` icon + "Upload") so the red **Comment** CTA stays dominant.
- `type="button"` so it never submits the surrounding comment form.
- Hidden `<input type="file" multiple>` with `accept` pre-filtered to supported types; the real gate remains `handleFiles`.

## Testing

- **Component** (`comment-attachments-dropzone.test.tsx`): new test drives the hidden picker → upload → chip, asserts `multiple`/`accept`, and that the button persists after a chip appears. Existing drag/drop, error-chip, and icon tests still pass (6/6).
- **Browser** (`task-comment-attachments.spec.ts`): desktop test now also asserts the Upload button; the mobile test asserts the drag hint text is hidden at 375px and attach is button/drop-driven (5/5).
- Composer-adjacent web tests (task-comments, mention-autocomplete/handoff): 29/29.
- Typecheck + Biome clean; pre-commit build green.

## Docs

`docs/concepts/assets.md` now notes you can drag onto the comment box **or use its Upload button**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVXXiB5ohFrw4x3hjBYYZj

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVXXiB5ohFrw4x3hjBYYZj)_