### PR TITLE
refactor(web): folder-style tab bars via a reusable Tabs component

### DIFF
--- a/packages/web/src/components/repo-picker-modal.tsx
+++ b/packages/web/src/components/repo-picker-modal.tsx
@@ -11,6 +11,7 @@ import type { ApiError } from '../lib/api';
 import { Button } from './ui/button';
 import { DialogContent } from './ui/dialog';
 import { Input } from './ui/input';
+import { Tabs } from './ui/tabs';
 
 interface RepoPickerModalProps {
 	open: boolean;
@@ -129,32 +130,16 @@ export function RepoPickerModal({
 					Create a new repository for this project in one of your orgs, or pick an existing one.
 				</Dialog.Description>
 
-				<div className="flex gap-1 border-b border-border mb-4">
-					<button
-						type="button"
-						className={`px-3 py-1.5 text-sm border-b-2 transition-colors ${
-							mode === 'create'
-								? 'text-text-1 font-medium border-text-1'
-								: 'text-text-2 border-transparent hover:text-text-1'
-						}`}
-						onClick={() => setMode('create')}
-						data-testid="repo-picker-tab-create"
-					>
-						Create new
-					</button>
-					<button
-						type="button"
-						className={`px-3 py-1.5 text-sm border-b-2 transition-colors ${
-							mode === 'link'
-								? 'text-text-1 font-medium border-text-1'
-								: 'text-text-2 border-transparent hover:text-text-1'
-						}`}
-						onClick={() => setMode('link')}
-						data-testid="repo-picker-tab-link"
-					>
-						Link existing
-					</button>
-				</div>
+				<Tabs
+					items={[
+						{ key: 'create', label: 'Create new', testId: 'repo-picker-tab-create' },
+						{ key: 'link', label: 'Link existing', testId: 'repo-picker-tab-link' },
+					]}
+					value={mode}
+					onValueChange={(k) => setMode(k as PickerMode)}
+					activeSurface="bg-surface"
+					className="mb-4"
+				/>
 
 				<form onSubmit={handleSubmit} className="space-y-3">
 					<div className="flex flex-col gap-1.5">

--- a/packages/web/src/components/search-results.tsx
+++ b/packages/web/src/components/search-results.tsx
@@ -2,6 +2,7 @@ import { HIGHLIGHT_SENTINEL, type SearchResult, type SearchResultType } from '@h
 import { Link } from '@tanstack/react-router';
 import { BookOpen, CheckSquare, FileText, type LucideIcon, MessageSquare } from 'lucide-react';
 import { Fragment, type ReactNode, useMemo, useState } from 'react';
+import { Tabs } from './ui/tabs';
 
 const TYPE_META: Record<SearchResultType, { label: string; Icon: LucideIcon }> = {
 	task: { label: 'Tasks', Icon: CheckSquare },
@@ -47,34 +48,21 @@ export function SearchResults({
 
 	return (
 		<div className="flex min-h-0 flex-col">
-			<div
-				role="tablist"
-				className="flex items-center gap-1 overflow-x-auto border-b border-border px-1"
-			>
-				{tabs.map((t) => {
+			<Tabs
+				items={tabs.map((t) => {
 					const { label, Icon } = TYPE_META[t];
-					const isActive = t === active;
-					return (
-						<button
-							key={t}
-							type="button"
-							role="tab"
-							aria-selected={isActive}
-							data-testid={`search-tab-${t}`}
-							onClick={() => setActiveType(t)}
-							className={`-mb-px flex shrink-0 items-center gap-1.5 border-b-2 px-2.5 py-2 text-[13px] transition-colors ${
-								isActive
-									? 'border-accent font-medium text-text-1'
-									: 'border-transparent text-text-2 hover:text-text-1'
-							}`}
-						>
-							<Icon className="h-3.5 w-3.5" />
-							{label}
-							<span className="text-text-3">({grouped[t].length})</span>
-						</button>
-					);
+					return {
+						key: t,
+						label,
+						icon: <Icon className="h-3.5 w-3.5" />,
+						count: grouped[t].length,
+						testId: `search-tab-${t}`,
+					};
 				})}
-			</div>
+				value={active}
+				onValueChange={(k) => setActiveType(k as SearchResultType)}
+				activeSurface="bg-surface"
+			/>
 			<ul className="flex flex-col overflow-y-auto py-1" data-testid="search-results-list">
 				{grouped[active].map((r) => (
 					<li key={`${r.type}-${r.id}`}>

--- a/packages/web/src/components/ui/tabs.tsx
+++ b/packages/web/src/components/ui/tabs.tsx
@@ -1,46 +1,132 @@
 import { Link, useMatchRoute } from '@tanstack/react-router';
 import type { ReactNode } from 'react';
 
-interface TabItem {
-	to: string;
+export interface TabItem {
+	/** Stable identity + controlled-mode value. Defaults to `to` when omitted. */
+	key?: string;
+	label: ReactNode;
+	/** Route-mode target. Used when the component is not in controlled mode. */
+	to?: string;
 	params?: Record<string, string>;
-	label: string;
+	/** Optional leading icon. */
+	icon?: ReactNode;
+	/** Optional trailing count, rendered as "(n)". */
 	count?: number;
 	badge?: ReactNode;
+	testId?: string;
 }
 
 interface TabsProps {
 	items: TabItem[];
+	/** Controlled mode: when `onValueChange` is provided, tabs render as buttons driven by `value`. */
+	value?: string;
+	onValueChange?: (key: string) => void;
+	/**
+	 * Background utility for the active ("in front") tab. It must match the panel
+	 * directly below the tab strip so the selected tab visually merges into it —
+	 * the browser/folder-tab look. Defaults to the page background `bg-bg`; pass
+	 * `bg-surface` when the tabs sit above a surface panel (e.g. inside a modal).
+	 */
+	activeSurface?: string;
+	'aria-label'?: string;
+	/** Extra classes for the tab-strip container (e.g. margins). */
+	className?: string;
 }
 
-// Wire's `.hz-tab`: underline tabs, neutral active (text-1 + bottom border),
-// counts rendered in Geist Mono.
-export function Tabs({ items }: TabsProps) {
-	const matchRoute = useMatchRoute();
+// Folder ("browser tab") styling, defined once. The active tab gets top + side
+// borders and a rounded top, then pulls itself down 1px (`-mb-px` +
+// `border-b-transparent` + a fill matching the panel below) so it covers the
+// strip's baseline border and reads as raised in front of the others. Inactive
+// tabs stay recessed on the baseline.
+const BASE_TAB =
+	'relative flex items-center gap-1.5 rounded-t-md border px-3 py-2 text-[13px] font-medium transition-colors';
 
+function tabClass(isActive: boolean, activeSurface: string): string {
+	return isActive
+		? `${BASE_TAB} z-10 -mb-px border-border border-b-transparent ${activeSurface} text-text-1`
+		: `${BASE_TAB} border-transparent bg-surface-2 text-text-2 hover:bg-surface-3 hover:text-text-1`;
+}
+
+function TabInner({ item }: { item: TabItem }) {
 	return (
-		<nav className="mb-5 flex gap-5 border-b border-border">
+		<>
+			{item.icon}
+			{item.label}
+			{item.count != null && <span className="ml-0.5 text-text-3">({item.count})</span>}
+			{item.badge}
+		</>
+	);
+}
+
+function tabStripClass(className?: string): string {
+	return `flex items-end gap-1 border-b border-border${className ? ` ${className}` : ''}`;
+}
+
+/**
+ * Route-mode tab strip: active state is derived from the current URL, tabs are
+ * `<Link>`s. Isolated in its own component so the router hook is only called
+ * when actually in route mode.
+ */
+function RouteTabs({
+	items,
+	activeSurface = 'bg-bg',
+	className,
+	'aria-label': ariaLabel,
+}: TabsProps) {
+	const matchRoute = useMatchRoute();
+	return (
+		<nav aria-label={ariaLabel} className={tabStripClass(className)}>
 			{items.map((item) => {
-				const isActive = matchRoute({ to: item.to, params: item.params, fuzzy: true });
+				if (!item.to) return null;
+				const isActive = !!matchRoute({ to: item.to, params: item.params, fuzzy: true });
 				return (
 					<Link
-						key={item.to}
+						key={item.key ?? item.to}
 						to={item.to}
 						params={item.params ?? {}}
-						className={`-mb-px border-b-2 py-2 text-[13.5px] font-medium transition-colors ${
-							isActive
-								? 'border-text-1 text-text-1'
-								: 'border-transparent text-text-2 hover:text-text-1'
-						}`}
+						data-testid={item.testId}
+						className={tabClass(isActive, activeSurface)}
 					>
-						{item.label}
-						{item.count != null && (
-							<span className="ml-1.5 font-mono text-[11px] text-text-3">{item.count}</span>
-						)}
-						{item.badge}
+						<TabInner item={item} />
 					</Link>
 				);
 			})}
 		</nav>
 	);
+}
+
+/** Controlled-mode tab strip: active state is driven by `value`, tabs are buttons. */
+function ControlledTabs({
+	items,
+	value,
+	onValueChange,
+	activeSurface = 'bg-bg',
+	className,
+	'aria-label': ariaLabel,
+}: TabsProps) {
+	return (
+		<div role="tablist" aria-label={ariaLabel} className={tabStripClass(className)}>
+			{items.map((item) => {
+				const key = item.key ?? item.to ?? '';
+				const isActive = key === value;
+				return (
+					<button
+						key={key}
+						type="button"
+						role="tab"
+						aria-selected={isActive}
+						data-testid={item.testId}
+						onClick={() => onValueChange?.(key)}
+						className={tabClass(isActive, activeSurface)}
+					>
+						<TabInner item={item} />
+					</button>
+				);
+			})}
+		</div>
+	);
+}
+
+export function Tabs(props: TabsProps) {
+	return props.onValueChange != null ? <ControlledTabs {...props} /> : <RouteTabs {...props} />;
 }

--- a/packages/web/src/routes/projects/$projectId/agents/$agentId/route.tsx
+++ b/packages/web/src/routes/projects/$projectId/agents/$agentId/route.tsx
@@ -1,9 +1,10 @@
 import { AgentAdminStatus } from '@hezo/shared';
-import { createFileRoute, Link, Outlet, useMatchRoute } from '@tanstack/react-router';
+import { createFileRoute, Link, Outlet } from '@tanstack/react-router';
 import { ArrowLeft } from 'lucide-react';
 import { NextHeartbeatIndicator } from '../../../../../components/next-heartbeat-indicator';
 import { Badge } from '../../../../../components/ui/badge';
 import { ExpandableText } from '../../../../../components/ui/expandable-text';
+import { Tabs } from '../../../../../components/ui/tabs';
 import { useAgent } from '../../../../../hooks/use-agents';
 import { agentRuntimeStatusMeta } from '../../../../../lib/status-meta';
 
@@ -23,7 +24,6 @@ const settingsTab = {
 function AgentLayout() {
 	const { projectId, agentId } = Route.useParams();
 	const { data: agent, isLoading } = useAgent(projectId, agentId);
-	const matchRoute = useMatchRoute();
 	const params = { projectId, agentId };
 
 	if (isLoading || !agent) return <div className="text-text-2">Loading...</div>;
@@ -71,25 +71,7 @@ function AgentLayout() {
 				/>
 			</div>
 
-			<div className="flex gap-1 border-b border-border mb-6 mt-6">
-				{tabs.map((tab) => {
-					const isActive = matchRoute({ to: tab.to, params, fuzzy: true });
-					return (
-						<Link
-							key={tab.to}
-							to={tab.to}
-							params={params}
-							className={`px-3 py-2 text-[13px] font-medium border-b-2 transition-colors -mb-px ${
-								isActive
-									? 'border-inverse text-text-1'
-									: 'border-transparent text-text-2 hover:text-text-1 hover:border-border-strong'
-							}`}
-						>
-							{tab.label}
-						</Link>
-					);
-				})}
-			</div>
+			<Tabs items={tabs.map((tab) => ({ ...tab, params }))} className="mt-6 mb-6" />
 
 			<Outlet />
 		</div>

--- a/packages/web/src/routes/projects/$projectId/audit-log.tsx
+++ b/packages/web/src/routes/projects/$projectId/audit-log.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { AuditLogTable } from '../../../components/audit-log-table';
 import { Badge } from '../../../components/ui/badge';
 import { type Column, DataTable } from '../../../components/ui/data-table';
+import { Tabs } from '../../../components/ui/tabs';
 import { type AuditEntry, useProjectAuditLog } from '../../../hooks/use-audit-log';
 
 type TabKey = 'all' | 'egress';
@@ -104,22 +105,12 @@ function ProjectAuditLogPage() {
 				<h2 className="text-base font-medium">Activity</h2>
 				<p className="text-[13px] text-text-2 mt-1">{activeTab.description}</p>
 			</div>
-			<div className="flex gap-1 mb-4 border-b border-border-subtle">
-				{tabs.map((t) => (
-					<button
-						key={t.key}
-						type="button"
-						onClick={() => setTab(t.key)}
-						className={`px-3 py-1.5 text-[13px] -mb-px border-b-2 cursor-pointer transition-colors ${
-							tab === t.key
-								? 'border-info text-text-1 font-medium'
-								: 'border-transparent text-text-2 hover:text-text-1'
-						}`}
-					>
-						{t.label}
-					</button>
-				))}
-			</div>
+			<Tabs
+				items={tabs.map((t) => ({ key: t.key, label: t.label }))}
+				value={tab}
+				onValueChange={(k) => setTab(k as TabKey)}
+				className="mb-4"
+			/>
 			{tab === 'egress' ? (
 				!entries?.length ? (
 					<p className="text-[13px] text-text-2">No outbound traffic recorded yet.</p>

--- a/packages/web/test/agent-detail.test.tsx
+++ b/packages/web/test/agent-detail.test.tsx
@@ -42,12 +42,17 @@ test('agent detail page defaults to Executions tab and exposes Settings tab', as
 
 	const main = await findByRole('main');
 	await waitFor(() => {
+		// The active tab renders as a folder tab raised in front: its fill matches
+		// the panel below (bg-bg) and its bottom border is removed so it merges in.
 		const executionsLink = within(main).getByRole('link', { name: 'Executions' });
-		expect(executionsLink.className).toMatch(/border-inverse/);
+		expect(executionsLink.className).toMatch(/bg-bg/);
+		expect(executionsLink.className).toMatch(/border-b-transparent/);
 	});
 
 	const settingsLink = within(getByRole('main')).getByRole('link', { name: 'Settings' });
 	expect(settingsLink).toBeTruthy();
+	// The inactive tab is recessed on the baseline (surface-2 fill, no merge).
+	expect(settingsLink.className).toMatch(/bg-surface-2/);
 });
 
 test('agent settings tab shows budget, heartbeat, title, and save controls', async () => {

--- a/packages/web/test/audit-log.test.tsx
+++ b/packages/web/test/audit-log.test.tsx
@@ -20,7 +20,7 @@ test('project Activity page exposes the Outbound traffic (egress) tab', async ()
 	await findByRole('heading', { name: 'Activity' }, { timeout: 10_000 });
 
 	// Switching to the egress tab swaps in its description and empty state.
-	await user.click(await findByRole('button', { name: 'Outbound traffic' }));
+	await user.click(await findByRole('tab', { name: 'Outbound traffic' }));
 	await findByText(/Every outbound HTTPS request/, undefined, { timeout: 10_000 });
 	expect(await findByText(/No outbound traffic recorded yet/)).toBeTruthy();
 });

--- a/packages/web/test/tabs.test.tsx
+++ b/packages/web/test/tabs.test.tsx
@@ -1,0 +1,90 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { expect, test, vi } from 'vitest';
+import { Tabs } from '../src/components/ui/tabs';
+
+const items = [
+	{ key: 'all', label: 'All' },
+	{ key: 'egress', label: 'Outbound', count: 3, testId: 'tab-egress' },
+];
+
+test('controlled Tabs marks the active tab with folder-tab styling and recesses the rest', () => {
+	const { getByRole } = render(<Tabs items={items} value="all" onValueChange={() => {}} />);
+
+	// Container is a tablist; tabs carry role="tab" + aria-selected.
+	expect(getByRole('tablist')).toBeTruthy();
+	const active = getByRole('tab', { name: 'All' });
+	const inactive = getByRole('tab', { name: /Outbound/ });
+
+	expect(active.getAttribute('aria-selected')).toBe('true');
+	expect(inactive.getAttribute('aria-selected')).toBe('false');
+
+	// Active tab is raised "in front": its fill matches the panel below (default
+	// bg-bg) and its bottom border is removed so it merges into that panel.
+	expect(active.className).toMatch(/bg-bg/);
+	expect(active.className).toMatch(/border-b-transparent/);
+	expect(active.className).toMatch(/text-text-1/);
+
+	// Inactive tab stays recessed on the baseline.
+	expect(inactive.className).toMatch(/bg-surface-2/);
+	expect(inactive.className).toMatch(/text-text-2/);
+	expect(inactive.className).not.toMatch(/border-b-transparent/);
+});
+
+test('controlled Tabs renders icon + count and fires onValueChange on click', async () => {
+	const user = userEvent.setup({ delay: null });
+	const onValueChange = vi.fn();
+	const { getByTestId, getByRole } = render(
+		<Tabs
+			items={[
+				{ key: 'all', label: 'All' },
+				{
+					key: 'egress',
+					label: 'Outbound',
+					count: 3,
+					icon: <svg data-testid="egress-icon" />,
+					testId: 'tab-egress',
+				},
+			]}
+			value="all"
+			onValueChange={onValueChange}
+		/>,
+	);
+
+	// Count is rendered as "(n)" and the leading icon is present.
+	expect(getByTestId('tab-egress').textContent).toContain('(3)');
+	expect(getByTestId('egress-icon')).toBeTruthy();
+
+	await user.click(getByRole('tab', { name: /Outbound/ }));
+	expect(onValueChange).toHaveBeenCalledWith('egress');
+});
+
+test('controlled Tabs tracks the selected value as it changes', async () => {
+	const user = userEvent.setup({ delay: null });
+
+	function Harness() {
+		const [value, setValue] = useState('all');
+		return <Tabs items={items} value={value} onValueChange={setValue} />;
+	}
+	const { getByRole } = render(<Harness />);
+
+	expect(getByRole('tab', { name: 'All' }).getAttribute('aria-selected')).toBe('true');
+
+	await user.click(getByRole('tab', { name: /Outbound/ }));
+
+	// Selection moves: the clicked tab becomes the raised folder tab.
+	const egress = getByRole('tab', { name: /Outbound/ });
+	expect(egress.getAttribute('aria-selected')).toBe('true');
+	expect(egress.className).toMatch(/border-b-transparent/);
+	expect(getByRole('tab', { name: 'All' }).getAttribute('aria-selected')).toBe('false');
+});
+
+test('activeSurface controls the fill the active tab merges into', () => {
+	const { getByRole } = render(
+		<Tabs items={items} value="all" onValueChange={() => {}} activeSurface="bg-surface" />,
+	);
+	const active = getByRole('tab', { name: 'All' });
+	expect(active.className).toMatch(/bg-surface\b/);
+	expect(active.className).not.toMatch(/bg-bg/);
+});


### PR DESCRIPTION
## What & why

The agent page's **Executions / Settings** tabs (and the app's other tab bars) were **underline tabs** — the active tab was marked only by a colored 2px bottom border. This restyles them to look and behave like OS/browser tabs: the selected tab reads as **raised in front of the others**, a rounded-top "folder" shape whose bottom edge merges into the panel directly below it (the classic notch).

Per the request, this is applied **app-wide** and consolidated into a **single reusable `Tabs` component** so the folder styling is defined once instead of copy-pasted across five hand-rolled tab rows.

## How

`packages/web/src/components/ui/tabs.tsx` is now a **dual-mode** component:

- **Route mode** — `<Link>` tabs whose active state comes from the URL (`useMatchRoute`, `fuzzy`). Used by the agent detail page.
- **Controlled mode** — `<button role="tab">` tabs driven by a `value` / `onValueChange` pair (container is a `role="tablist"`). Used by the stateful bars.

The folder recipe lives in one place: the active tab gets top + side borders and a rounded top, then pulls itself down 1px (`-mb-px` + `border-b-transparent` + a fill that matches the panel below) so it covers the strip's baseline and merges into the content. Inactive tabs stay recessed on the baseline (`bg-surface-2`). The active fill is parameterized via `activeSurface` so it matches its context — `bg-bg` on page-level bars, `bg-surface` inside modals.

### Call sites migrated to `<Tabs>`
- Agent detail page — Executions / Chat history / Settings (`routes/.../agents/$agentId/route.tsx`)
- Project Activity / audit-log page (`routes/.../audit-log.tsx`)
- Repo-picker modal — Create new / Link existing (`components/repo-picker-modal.tsx`)
- Global search palette — one tab per result type, with leading icon + `(count)` (`components/search-results.tsx`)

All existing `data-testid`s and the `role="tab"` / `aria-selected` semantics are preserved.

## Testing

- **New** `packages/web/test/tabs.test.tsx` — controlled-mode coverage: active vs inactive folder classes, `role="tablist"`/`role="tab"`/`aria-selected`, click fires `onValueChange`, `value` tracking, icon + `(count)` rendering, and `activeSurface`.
- Updated `agent-detail.test.tsx` (asserts the new active `bg-bg` + `border-b-transparent` and inactive `bg-surface-2`) and `audit-log.test.tsx` (queries the tab by `role="tab"`).
- Full web component tier green: **177 files / 1057 tests**. `turbo typecheck` and `biome check` clean (only pre-existing warnings).

## Notes on responsiveness
Route-based mode covered by the real-app agent-detail spec; the bars carry 2–4 short tabs and fit at mobile widths, so the strip is not made horizontally scrollable (scrolling would clip the 1px merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q59NQbXBLV45mwJqG8VNQq)_