### PR TITLE
feat(ai-providers): "verified" status and a single global default

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -753,9 +753,17 @@ Google → `gemini`, OpenRouter → `opencode`.
 row per `(provider, label)`, each inlining an encrypted credential. `auth_method`
 distinguishes an **API key** (injected as env at run start) from a **subscription** blob
 (materialized to a per-run mount in the container). Subscription auth is supported by
-Anthropic, OpenAI, and Google. `resolveRuntimeForTask` filters by
-`PROVIDERS_BY_RUNTIME[runtime]`, then orders `is_default DESC, created_at ASC`; an
-agent's `model_override_*` (or the config's `default_model`) sets the CLI `--model`.
+Anthropic, OpenAI, and Google. A config's `status` is `verified` (the healthy default —
+the add flow live-verifies the key, and the Verify action persists the result, restoring
+`verified` on a key that had gone `invalid`), `invalid` (a verify was rejected), or
+`revoked` (a retired provider). Exactly **one** config instance-wide carries the
+`is_default` flag — a single global default enforced by a partial-unique index
+(`ai_provider_configs_single_default`); the first config added to the instance auto-takes
+it, and `setDefaultAiProvider` moves it atomically. `resolveRuntimeForTask` filters by
+`status = 'verified'` and `PROVIDERS_BY_RUNTIME[runtime]`, then orders
+`is_default DESC, created_at ASC`, so the global default wins whenever it's a candidate
+for the chosen runtime, else the oldest verified config; an agent's `model_override_*`
+(or the config's `default_model`) sets the CLI `--model`.
 
 **Reasoning effort.** Each run resolves an `agent_effort` level
 (`minimal|low|medium|high|max`) from the wakeup payload → `member_agents.default_effort` →

--- a/docs/ai-models.md
+++ b/docs/ai-models.md
@@ -64,6 +64,11 @@ You can connect **several providers at once** and keep them all available. That'
 useful for spreading work across accounts, keeping a cheaper model on hand for routine
 tasks and a frontier model for the hard ones, or simply having a fallback.
 
+When a key is stored it's checked against the provider and shown as **verified** (the
+Verify action re-checks it any time). Mark one provider as the **default** with the star:
+that's the single global default every agent uses unless it has its own model override.
+Change the default and agents on the default pick up the new provider on their next run.
+
 ## Give an agent its own model
 
 By default the agents on a team share the team's model, but you can **override the model

--- a/packages/server/migrations/020_ai_provider_verified_status_and_global_default.sql
+++ b/packages/server/migrations/020_ai_provider_verified_status_and_global_default.sql
@@ -1,0 +1,34 @@
+-- AI provider configs carried a `status` of 'active' for any healthy key, and a
+-- per-provider `is_default` flag (one default per provider type). This migration
+-- makes two aligned changes:
+--
+--   1. Rename the healthy status to 'verified' — a stored key has been checked
+--      against the provider (the add flow live-verifies, and the Verify action now
+--      persists the result), so 'verified' is the truthful label. 'invalid' and
+--      'revoked' are unchanged.
+--   2. Make the default a single instance-wide flag rather than one-per-provider,
+--      so an operator can pick exactly one provider config as THE default used by
+--      agent runs. The runtime resolver already orders `is_default DESC,
+--      created_at ASC`, so a single global default is honoured without further code.
+--
+-- Existing rows are preserved throughout — only the `status` string and the
+-- `is_default` flag move.
+
+-- 1. Rename the healthy status 'active' -> 'verified'.
+ALTER TABLE ai_provider_configs ALTER COLUMN status SET DEFAULT 'verified';
+UPDATE ai_provider_configs SET status = 'verified', updated_at = now() WHERE status = 'active';
+
+-- 2. Collapse per-provider defaults to ONE instance-wide default: keep the oldest
+-- currently-default config, clear the rest (rows are preserved, only the flag moves).
+UPDATE ai_provider_configs SET is_default = false, updated_at = now()
+WHERE is_default = true
+  AND id <> (
+    SELECT id FROM ai_provider_configs WHERE is_default = true ORDER BY created_at ASC LIMIT 1
+  );
+
+-- Replace the per-provider partial-unique index with a global one. In the partial
+-- (WHERE is_default) the indexed expression is always true, so at most one row can
+-- carry the default flag instance-wide.
+DROP INDEX IF EXISTS ai_provider_configs_default_per_provider;
+CREATE UNIQUE INDEX ai_provider_configs_single_default
+    ON ai_provider_configs ((is_default)) WHERE is_default;

--- a/packages/server/src/routes/ai-providers.ts
+++ b/packages/server/src/routes/ai-providers.ts
@@ -2,6 +2,7 @@ import {
 	AI_PROVIDER_INFO,
 	AiAuthMethod,
 	type AiProvider,
+	AiProviderStatus,
 	ALL_AI_PROVIDERS,
 	parseProviderModels,
 } from '@hezo/shared';
@@ -202,12 +203,18 @@ aiProvidersRoutes.post('/ai-providers/:configId/verify', async (c) => {
 	try {
 		const valid = await verifyProviderKey(cred.provider as AiProvider, cred.value, cred.authMethod);
 		if (valid) {
+			// Persist the healthy state so the badge is truthful and a key that was
+			// previously marked `invalid` recovers on a successful re-verify.
+			await db.query(
+				`UPDATE ai_provider_configs SET status = $1, updated_at = now() WHERE id = $2`,
+				[AiProviderStatus.Verified, configId],
+			);
 			return ok(c, { valid: true });
 		}
-		await db.query(
-			`UPDATE ai_provider_configs SET status = 'invalid', updated_at = now() WHERE id = $1`,
-			[configId],
-		);
+		await db.query(`UPDATE ai_provider_configs SET status = $1, updated_at = now() WHERE id = $2`, [
+			AiProviderStatus.Invalid,
+			configId,
+		]);
 		return ok(c, { valid: false, message: 'API key is invalid or expired' });
 	} catch {
 		return ok(c, { valid: false, message: 'Could not reach provider to verify key' });

--- a/packages/server/src/services/ai-provider-keys.ts
+++ b/packages/server/src/services/ai-provider-keys.ts
@@ -39,12 +39,17 @@ export async function storeAiProviderKey(
 
 	const encryptedValue = encrypt(credential, encryptionKey);
 
-	const existing = await db.query<{ id: string }>(
+	const existingForProvider = await db.query<{ id: string }>(
 		`SELECT id FROM ai_provider_configs WHERE provider = $1::ai_provider`,
 		[provider],
 	);
-	const isDefault = existing.rows.length === 0;
-	const resolvedLabel = label?.trim() || deriveLabel(provider, existing.rows.length);
+	// The default is a single instance-wide flag: only the first config added to
+	// the instance (across all providers) becomes the default.
+	const anyConfig = await db.query<{ exists: number }>(
+		`SELECT 1 AS exists FROM ai_provider_configs LIMIT 1`,
+	);
+	const isDefault = anyConfig.rows.length === 0;
+	const resolvedLabel = label?.trim() || deriveLabel(provider, existingForProvider.rows.length);
 
 	const configResult = await db.query<{ id: string }>(
 		`INSERT INTO ai_provider_configs (provider, auth_method, label, encrypted_credential, is_default, metadata)
@@ -115,7 +120,7 @@ export async function getProviderCredentialAndModel(
 		 WHERE provider = $1::ai_provider AND status = $2
 		 ORDER BY is_default DESC, created_at ASC
 		 LIMIT 1`,
-		[provider, AiProviderStatus.Active],
+		[provider, AiProviderStatus.Verified],
 	);
 
 	if (result.rows.length === 0) return null;
@@ -173,19 +178,18 @@ export async function deleteAiProviderConfig(db: Db, configId: string): Promise<
 }
 
 export async function setDefaultAiProvider(db: Db, configId: string): Promise<boolean> {
-	const config = await db.query<{ provider: string }>(
-		`SELECT provider FROM ai_provider_configs WHERE id = $1`,
+	const config = await db.query<{ id: string }>(
+		`SELECT id FROM ai_provider_configs WHERE id = $1`,
 		[configId],
 	);
 
 	if (config.rows.length === 0) return false;
 
-	const provider = config.rows[0].provider;
-
+	// A single instance-wide default: demote every other config, then promote this one.
 	await withTransaction(db, async () => {
 		await db.query(
-			`UPDATE ai_provider_configs SET is_default = false WHERE provider = $1::ai_provider AND id <> $2`,
-			[provider, configId],
+			`UPDATE ai_provider_configs SET is_default = false, updated_at = now() WHERE id <> $1 AND is_default = true`,
+			[configId],
 		);
 		await db.query(
 			`UPDATE ai_provider_configs SET is_default = true, updated_at = now() WHERE id = $1`,
@@ -201,7 +205,7 @@ export async function getAiProviderStatus(
 ): Promise<{ configured: boolean; providers: string[] }> {
 	const result = await db.query<{ provider: string }>(
 		`SELECT DISTINCT provider FROM ai_provider_configs WHERE status = $1`,
-		[AiProviderStatus.Active],
+		[AiProviderStatus.Verified],
 	);
 
 	return {

--- a/packages/server/src/services/runtime-resolver.ts
+++ b/packages/server/src/services/runtime-resolver.ts
@@ -35,7 +35,7 @@ export async function resolveRuntimeForTask(
 			 WHERE status = $1 AND provider IN (${placeholders})
 			 ORDER BY is_default DESC, created_at ASC
 			 LIMIT 1`,
-			[AiProviderStatus.Active, ...candidates],
+			[AiProviderStatus.Verified, ...candidates],
 		);
 		const row = result.rows[0];
 		if (!row) return null;
@@ -51,7 +51,7 @@ export async function resolveRuntimeForTask(
 		 WHERE status = $1 AND provider IN (${placeholders})
 		 ORDER BY is_default DESC, created_at ASC
 		 LIMIT 1`,
-		[AiProviderStatus.Active, ...known],
+		[AiProviderStatus.Verified, ...known],
 	);
 	const first = providers.rows[0];
 	if (!first) return null;

--- a/packages/server/test/agent-runner-extended.test.ts
+++ b/packages/server/test/agent-runner-extended.test.ts
@@ -1201,7 +1201,7 @@ describe('runAgent — rotated subscription auth tombstone', () => {
 			'SELECT encrypted_credential, status FROM ai_provider_configs WHERE id = $1',
 			[configId],
 		);
-		expect(cfg.rows[0].status).toBe('active');
+		expect(cfg.rows[0].status).toBe('verified');
 		expect(decrypt(cfg.rows[0].encrypted_credential, masterKeyManager.getKey())).toBe(
 			validAuthJson,
 		);

--- a/packages/server/test/ai-providers-verify.test.ts
+++ b/packages/server/test/ai-providers-verify.test.ts
@@ -101,6 +101,23 @@ describe('POST /ai-providers/:configId/verify', () => {
 		expect(status.rows[0].status).toBe('invalid');
 	});
 
+	it('restores the config to verified when a previously-invalid key checks out again', async () => {
+		// The prior test left this config marked `invalid`; a successful re-verify heals it.
+		globalThis.fetch = vi.fn().mockResolvedValue({ ok: true }) as unknown as typeof fetch;
+		const res = await app.request(`/api/ai-providers/${configId}/verify`, {
+			method: 'POST',
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		expect((await res.json()).data.valid).toBe(true);
+
+		const status = await db.query<{ status: string }>(
+			'SELECT status FROM ai_provider_configs WHERE id = $1',
+			[configId],
+		);
+		expect(status.rows[0].status).toBe('verified');
+	});
+
 	it('returns valid:false when the provider is unreachable', async () => {
 		globalThis.fetch = vi.fn().mockRejectedValue(new Error('net')) as unknown as typeof fetch;
 		const res = await app.request(`/api/ai-providers/${configId}/verify`, {

--- a/packages/server/test/ai-providers.test.ts
+++ b/packages/server/test/ai-providers.test.ts
@@ -759,49 +759,53 @@ describe('AI providers models endpoint', () => {
 	});
 });
 
-describe('AI providers default-per-provider invariant', () => {
-	it('enforces exactly one default per provider after setting a new default', async () => {
+describe('AI providers single global default invariant', () => {
+	async function addProvider(provider: string, apiKey: string, label: string): Promise<string> {
+		const res = await app.request('/api/ai-providers', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ provider, api_key: apiKey, label }),
+		});
+		expect(res.status).toBe(201);
+		return (await res.json()).data.id;
+	}
+
+	async function listConfigs(): Promise<Array<{ id: string; is_default: boolean }>> {
+		const list = await app.request('/api/ai-providers', { headers: authHeader(token) });
+		return (await list.json()).data;
+	}
+
+	it('auto-defaults only the first config added to the instance', async () => {
 		await db.query('DELETE FROM ai_provider_configs');
 
-		const first = await app.request('/api/ai-providers', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({
-				provider: 'anthropic',
-				api_key: 'sk-ant-first',
-				label: 'anthropic-a',
-			}),
-		});
-		const firstId = (await first.json()).data.id;
+		const firstId = await addProvider('anthropic', 'sk-ant-first', 'anthropic-a');
+		// A second config for a DIFFERENT provider does not become a second default.
+		const secondId = await addProvider('deepseek', 'sk-deepseek-second', 'deepseek-a');
 
-		const second = await app.request('/api/ai-providers', {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({
-				provider: 'anthropic',
-				api_key: 'sk-ant-second',
-				label: 'anthropic-b',
-			}),
-		});
-		const secondId = (await second.json()).data.id;
+		const configs = await listConfigs();
+		const defaults = configs.filter((c) => c.is_default);
+		expect(defaults.length).toBe(1);
+		expect(defaults[0].id).toBe(firstId);
+		expect(configs.find((c) => c.id === secondId)?.is_default).toBe(false);
+	});
 
-		const promote = await app.request(`/api/ai-providers/${secondId}/default`, {
+	it('enforces exactly one default instance-wide after promoting across providers', async () => {
+		await db.query('DELETE FROM ai_provider_configs');
+
+		const anthropicId = await addProvider('anthropic', 'sk-ant-a', 'anthropic-a');
+		const googleId = await addProvider('google', 'gm-b', 'google-b');
+
+		const promote = await app.request(`/api/ai-providers/${googleId}/default`, {
 			method: 'PATCH',
 			headers: authHeader(token),
 		});
 		expect(promote.status).toBe(200);
 
-		const list = await app.request('/api/ai-providers', { headers: authHeader(token) });
-		const configs = (await list.json()).data as Array<{
-			id: string;
-			provider: string;
-			is_default: boolean;
-		}>;
-		const anthropicConfigs = configs.filter((c) => c.provider === 'anthropic');
-		const defaults = anthropicConfigs.filter((c) => c.is_default);
+		const configs = await listConfigs();
+		const defaults = configs.filter((c) => c.is_default);
 		expect(defaults.length).toBe(1);
-		expect(defaults[0].id).toBe(secondId);
-		expect(anthropicConfigs.find((c) => c.id === firstId)?.is_default).toBe(false);
+		expect(defaults[0].id).toBe(googleId);
+		expect(configs.find((c) => c.id === anthropicId)?.is_default).toBe(false);
 	});
 });
 

--- a/packages/server/test/ceo-chat-http-routes.test.ts
+++ b/packages/server/test/ceo-chat-http-routes.test.ts
@@ -57,7 +57,7 @@ async function seedProviderAndContainer(ctx: ServerTestContext): Promise<string>
 	if (!key) throw new Error('master key unavailable');
 	await ctx.db.query(
 		`INSERT INTO ai_provider_configs (provider, auth_method, label, encrypted_credential, is_default, status, default_model)
-		 VALUES ('anthropic', 'api_key', 'test', $1, true, 'active', 'claude-sonnet-4-6')`,
+		 VALUES ('anthropic', 'api_key', 'test', $1, true, 'verified', 'claude-sonnet-4-6')`,
 		[encrypt('sk-ant-test', key)],
 	);
 	const proj = await ctx.db.query<{ id: string }>(

--- a/packages/server/test/ceo-session-branches.test.ts
+++ b/packages/server/test/ceo-session-branches.test.ts
@@ -71,7 +71,7 @@ async function seedProvider(ctx: ServerTestContext): Promise<void> {
 	if (!key) throw new Error('master key unavailable');
 	await ctx.db.query(
 		`INSERT INTO ai_provider_configs (provider, auth_method, label, encrypted_credential, is_default, status, default_model)
-		 VALUES ('anthropic', 'api_key', 'test', $1, true, 'active', 'claude-sonnet-4-6')`,
+		 VALUES ('anthropic', 'api_key', 'test', $1, true, 'verified', 'claude-sonnet-4-6')`,
 		[encrypt('sk-ant-test', key)],
 	);
 }

--- a/packages/server/test/ceo-session-compaction-lifecycle.test.ts
+++ b/packages/server/test/ceo-session-compaction-lifecycle.test.ts
@@ -138,7 +138,7 @@ async function seedProviderAndContainer(ctx: ServerTestContext): Promise<string>
 	if (!key) throw new Error('master key unavailable');
 	await ctx.db.query(
 		`INSERT INTO ai_provider_configs (provider, auth_method, label, encrypted_credential, is_default, status, default_model)
-		 VALUES ('anthropic', 'api_key', 'test', $1, true, 'active', 'claude-sonnet-4-6')`,
+		 VALUES ('anthropic', 'api_key', 'test', $1, true, 'verified', 'claude-sonnet-4-6')`,
 		[encrypt('sk-ant-test', key)],
 	);
 	const proj = await ctx.db.query<{ id: string }>(

--- a/packages/server/test/ceo-session.test.ts
+++ b/packages/server/test/ceo-session.test.ts
@@ -110,7 +110,7 @@ async function seedProviderAndContainer(ctx: ServerTestContext): Promise<string>
 	if (!key) throw new Error('master key unavailable');
 	await ctx.db.query(
 		`INSERT INTO ai_provider_configs (provider, auth_method, label, encrypted_credential, is_default, status, default_model)
-		 VALUES ('anthropic', 'api_key', 'test', $1, true, 'active', 'claude-sonnet-4-6')`,
+		 VALUES ('anthropic', 'api_key', 'test', $1, true, 'verified', 'claude-sonnet-4-6')`,
 		[encrypt('sk-ant-test', key)],
 	);
 	const proj = await ctx.db.query<{ id: string }>(

--- a/packages/server/test/migrate-020-ai-provider-verified-status-and-global-default.test.ts
+++ b/packages/server/test/migrate-020-ai-provider-verified-status-and-global-default.test.ts
@@ -1,0 +1,111 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createDataPreservationHarness, type DataPreservationHarness } from './helpers/migrate';
+
+const TARGET = '020_ai_provider_verified_status_and_global_default.sql';
+
+/**
+ * 020 renames the healthy provider status 'active' -> 'verified' and collapses the
+ * per-provider `is_default` flag into a single instance-wide default. Seed at 019
+ * (status 'active', one default per provider) with two providers each marked default
+ * plus an 'invalid' row, then assert the migration preserves every row AND applies
+ * both changes.
+ */
+describe('020_ai_provider_verified_status_and_global_default migration', () => {
+	let h: DataPreservationHarness;
+	let anthropicId: string; // active + default, older -> stays the single default
+	let googleId: string; // active + default, newer -> demoted
+	let deepseekId: string; // invalid, not default -> status untouched
+
+	async function seedConfig(opts: {
+		provider: string;
+		label: string;
+		status: string;
+		isDefault: boolean;
+		createdAt: string;
+	}): Promise<string> {
+		const r = await h.db.query<{ id: string }>(
+			`INSERT INTO ai_provider_configs
+			   (provider, label, encrypted_credential, is_default, status, created_at)
+			 VALUES ($1::ai_provider, $2, 'enc', $3, $4, $5)
+			 RETURNING id`,
+			[opts.provider, opts.label, opts.isDefault, opts.status, opts.createdAt],
+		);
+		return r.rows[0].id;
+	}
+
+	beforeAll(async () => {
+		h = await createDataPreservationHarness();
+		await h.applyUpToExclusive(TARGET);
+
+		// The old per-provider unique index allows one default per provider, so two
+		// providers can each carry is_default = true at the prior schema.
+		anthropicId = await seedConfig({
+			provider: 'anthropic',
+			label: 'anthropic-a',
+			status: 'active',
+			isDefault: true,
+			createdAt: '2024-01-01T00:00:00Z',
+		});
+		googleId = await seedConfig({
+			provider: 'google',
+			label: 'google-a',
+			status: 'active',
+			isDefault: true,
+			createdAt: '2024-02-01T00:00:00Z',
+		});
+		deepseekId = await seedConfig({
+			provider: 'deepseek',
+			label: 'deepseek-a',
+			status: 'invalid',
+			isDefault: false,
+			createdAt: '2024-03-01T00:00:00Z',
+		});
+
+		await h.applyTarget(TARGET);
+	});
+	afterAll(() => h.close());
+
+	it('preserves every seeded row', async () => {
+		const c = await h.db.query<{ c: number }>(`SELECT COUNT(*)::int AS c FROM ai_provider_configs`);
+		expect(c.rows[0].c).toBe(3);
+		const ids = await h.db.query<{ id: string }>(
+			`SELECT id FROM ai_provider_configs WHERE id = ANY($1::uuid[])`,
+			[[anthropicId, googleId, deepseekId]],
+		);
+		expect(ids.rows.length).toBe(3);
+	});
+
+	it("renames 'active' rows to 'verified' and leaves 'invalid' untouched", async () => {
+		const rows = await h.db.query<{ id: string; status: string }>(
+			`SELECT id, status FROM ai_provider_configs`,
+		);
+		const byId = new Map(rows.rows.map((r) => [r.id, r.status]));
+		expect(byId.get(anthropicId)).toBe('verified');
+		expect(byId.get(googleId)).toBe('verified');
+		expect(byId.get(deepseekId)).toBe('invalid');
+	});
+
+	it('keeps exactly one instance-wide default (the oldest previously-default row)', async () => {
+		const defaults = await h.db.query<{ id: string }>(
+			`SELECT id FROM ai_provider_configs WHERE is_default = true`,
+		);
+		expect(defaults.rows.length).toBe(1);
+		expect(defaults.rows[0].id).toBe(anthropicId);
+	});
+
+	it("defaults the status column to 'verified' for new rows", async () => {
+		const r = await h.db.query<{ status: string }>(
+			`INSERT INTO ai_provider_configs (provider, label, encrypted_credential)
+			 VALUES ('kimi'::ai_provider, 'kimi-new', 'enc')
+			 RETURNING status`,
+		);
+		expect(r.rows[0].status).toBe('verified');
+	});
+
+	it('enforces a single global default via the unique index', async () => {
+		// anthropic is already the default; promoting a second row must collide.
+		await expect(
+			h.db.query(`UPDATE ai_provider_configs SET is_default = true WHERE id = $1`, [googleId]),
+		).rejects.toThrow();
+	});
+});

--- a/packages/server/test/runtime-resolver.test.ts
+++ b/packages/server/test/runtime-resolver.test.ts
@@ -106,7 +106,7 @@ describe('resolveRuntimeForTask', () => {
 			AiAuthMethod.ApiKey,
 			'anthropic-primary',
 		);
-		await storeAiProviderKey(
+		const deepseekId = await storeAiProviderKey(
 			db,
 			masterKeyManager,
 			AiProvider.DeepSeek,
@@ -115,17 +115,15 @@ describe('resolveRuntimeForTask', () => {
 			'deepseek-primary',
 		);
 
-		// Both providers ship a default row of their own; tiebreak goes to whichever
-		// was added first under the same runtime.
+		// Anthropic was added first, so it holds the single instance-wide default and
+		// wins the shared ClaudeCode runtime on is_default DESC.
 		expect(await resolveRuntimeForTask(db, AgentRuntime.ClaudeCode)).toEqual({
 			runtime: AgentRuntime.ClaudeCode,
 			provider: AiProvider.Anthropic,
 		});
 
-		// Demote anthropic so deepseek wins on is_default DESC.
-		await db.query(
-			`UPDATE ai_provider_configs SET is_default = false WHERE provider = 'anthropic'`,
-		);
+		// Make deepseek the global default so it wins on is_default DESC.
+		await setDefaultAiProvider(db, deepseekId);
 
 		expect(await resolveRuntimeForTask(db, AgentRuntime.ClaudeCode)).toEqual({
 			runtime: AgentRuntime.ClaudeCode,

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -1136,7 +1136,7 @@ export const AiAuthMethod = {
 export type AiAuthMethod = (typeof AiAuthMethod)[keyof typeof AiAuthMethod];
 
 export const AiProviderStatus = {
-	Active: 'active',
+	Verified: 'verified',
 	Invalid: 'invalid',
 	Revoked: 'revoked',
 } as const;

--- a/packages/web/src/components/ai-providers-section.tsx
+++ b/packages/web/src/components/ai-providers-section.tsx
@@ -1,4 +1,4 @@
-import { AI_PROVIDER_INFO, AiAuthMethod, type AiProvider } from '@hezo/shared';
+import { AI_PROVIDER_INFO, AiAuthMethod, type AiProvider, AiProviderStatus } from '@hezo/shared';
 import { Check, Loader2, Pencil, Plus, ShieldCheck, Star, Trash2, X } from 'lucide-react';
 import { useState } from 'react';
 import {
@@ -30,10 +30,6 @@ export function AiProvidersSection() {
 
 	const rows = configs ?? [];
 
-	function providerCount(provider: string) {
-		return rows.filter((c) => c.provider === provider).length;
-	}
-
 	async function handleVerify(configId: string) {
 		setVerifyingId(configId);
 		try {
@@ -56,7 +52,7 @@ export function AiProvidersSection() {
 			render: (c) => (
 				<span className="flex items-center gap-2">
 					<ProviderNameCell config={c} />
-					{c.is_default && providerCount(c.provider) > 1 && <Badge color="accent">Default</Badge>}
+					{c.is_default && <Badge color="accent">Default</Badge>}
 				</span>
 			),
 		},
@@ -88,7 +84,13 @@ export function AiProvidersSection() {
 			header: 'Status',
 			render: (c) => (
 				<Badge
-					color={c.status === 'active' ? 'success' : c.status === 'invalid' ? 'danger' : 'neutral'}
+					color={
+						c.status === AiProviderStatus.Verified
+							? 'success'
+							: c.status === AiProviderStatus.Invalid
+								? 'danger'
+								: 'neutral'
+					}
 				>
 					{c.status}
 				</Badge>
@@ -104,7 +106,6 @@ export function AiProvidersSection() {
 			key: 'actions',
 			header: '',
 			render: (c) => {
-				const multiple = providerCount(c.provider) > 1;
 				return (
 					<span className="flex items-center gap-2 justify-end">
 						{verifiedOk[c.id] && (
@@ -112,7 +113,7 @@ export function AiProvidersSection() {
 								<ShieldCheck className="w-3.5 h-3.5 text-success-soft-fg" />
 							</Tooltip>
 						)}
-						{multiple && !c.is_default && (
+						{!c.is_default && (
 							<Tooltip content="Set as default">
 								<button
 									type="button"

--- a/packages/web/src/routes/projects/$projectId/agents/$agentId/settings.tsx
+++ b/packages/web/src/routes/projects/$projectId/agents/$agentId/settings.tsx
@@ -2,6 +2,7 @@ import {
 	AgentAdminStatus,
 	AI_PROVIDER_INFO,
 	type AiProvider,
+	AiProviderStatus,
 	type BudgetWindowsCents,
 	CAPTAIN_AGENT_SLUG,
 	hasFixedReportsTo,
@@ -352,7 +353,7 @@ function ModelOverride({ provider, model, onProviderChange, onModelChange }: Mod
 	const configByProvider = useMemo(() => {
 		const map = new Map<string, { id: string; default_model: string | null }>();
 		for (const c of configs ?? []) {
-			if (c.status !== 'active') continue;
+			if (c.status !== AiProviderStatus.Verified) continue;
 			if (!map.has(c.provider)) {
 				map.set(c.provider, { id: c.id, default_model: c.default_model });
 			}

--- a/packages/web/test/ai-providers.test.tsx
+++ b/packages/web/test/ai-providers.test.tsx
@@ -134,7 +134,7 @@ test('can add an Anthropic API key via the settings UI', async () => {
 	await user.click(getByRole('button', { name: 'Save' }));
 
 	// Once a provider is configured the gate drops and the settings page renders.
-	await findByText('active', undefined, { timeout: 15_000 });
+	await findByText('verified', undefined, { timeout: 15_000 });
 });
 
 test('offers Claude Code subscription (setup-token) paste flow for Anthropic', async () => {
@@ -176,7 +176,7 @@ test('Kimi offers only an API-key form (no subscription, runs on Claude Code/Moo
 	fireEvent.change(keyInput, { target: { value: 'sk-kimi-component-test' } });
 	await user.click(getByRole('button', { name: 'Save' }));
 
-	await findByText('active', undefined, { timeout: 15_000 });
+	await findByText('verified', undefined, { timeout: 15_000 });
 });
 
 test('offers Codex subscription paste flow for OpenAI', async () => {
@@ -234,7 +234,7 @@ test('offers Gemini subscription paste flow for Google', async () => {
 });
 
 test('lists API key + Subscription rows for a provider and flips the default', async () => {
-	const { findByRole, findByText, getByRole, queryAllByText, user, ctx } = await renderApp({
+	const { findByRole, findByText, getByRole, queryAllByText, ctx } = await renderApp({
 		initialPath: '/settings/ai-providers',
 		seed: async () => {
 			await clearAiProviders();
@@ -267,8 +267,8 @@ test('lists API key + Subscription rows for a provider and flips the default', a
 		},
 		{ timeout: 15_000 },
 	);
-	// The first-created config is the default; the badge only shows when >1 exist.
-	expect(queryAllByText('Default').length).toBeGreaterThan(0);
+	// The first-created config is the (single, instance-wide) default and shows the badge.
+	expect(queryAllByText('Default').length).toBe(1);
 
 	const setDefaultBtn = getByRole('button', { name: 'Set openai-mix-subscription as default' });
 	fireEvent.click(setDefaultBtn);
@@ -288,6 +288,53 @@ test('lists API key + Subscription rows for a provider and flips the default', a
 			};
 			const defaultConfig = body.data.find((c) => c.is_default && c.provider === 'openai');
 			expect(defaultConfig?.auth_method).toBe('subscription');
+		},
+		{ timeout: 15_000 },
+	);
+});
+
+test('flips the single instance-wide default across two different providers', async () => {
+	const { findByRole, findByText, getByRole, queryAllByText, ctx } = await renderApp({
+		initialPath: '/settings/ai-providers',
+		seed: async () => {
+			await clearAiProviders();
+			// First config added anywhere becomes the single global default.
+			const anthropic = await postProvider({
+				provider: 'anthropic',
+				api_key: 'sk-ant-default-x',
+				label: 'anthropic-x',
+			});
+			expect(anthropic.status).toBe(201);
+			const google = await postProvider({
+				provider: 'google',
+				api_key: 'gm-default-x',
+				label: 'google-x',
+			});
+			expect(google.status).toBe(201);
+		},
+	});
+
+	await findByRole('heading', { name: 'AI providers' });
+	await findByText('anthropic-x');
+	await findByText('google-x');
+
+	// Exactly one config across all providers is the default, always badged.
+	await waitFor(() => expect(queryAllByText('Default').length).toBe(1), { timeout: 15_000 });
+
+	// Promote the other provider's config — the default moves globally.
+	fireEvent.click(getByRole('button', { name: 'Set google-x as default' }));
+
+	await waitFor(
+		async () => {
+			const res = await ctx.apiBase('/api/ai-providers', {
+				headers: { Authorization: `Bearer ${ctx.token}` },
+			});
+			const body = (await res.json()) as {
+				data: Array<{ provider: string; is_default: boolean }>;
+			};
+			const defaults = body.data.filter((c) => c.is_default);
+			expect(defaults.length).toBe(1);
+			expect(defaults[0].provider).toBe('google');
 		},
 		{ timeout: 15_000 },
 	);


### PR DESCRIPTION
## What & why

On **Settings → AI providers** the Status column showed every configured provider as `active`, and the "default" flag was scoped **per provider** with its control hidden unless a provider had 2+ keys — so with one key each for two different providers (e.g. DeepSeek and z.ai) there was no way to pick which provider is primary. This PR:

1. **Renames the healthy status `active` → `verified`** across the stack, and makes verification *mean* something: a successful **Verify** now persists `verified`, so a key that had gone `invalid` recovers (previously nothing ever restored it — only failures wrote `invalid`).
2. **Replaces the per-provider default with one instance-wide default** an operator picks from the settings table with the star (always visible now).

Agent runs resolve the provider through the existing `is_default DESC, created_at ASC` ordering in `resolveRuntimeForTask`, so **changing the global default switches which provider default-configured agents use on their next run** — agents with an explicit `model_override_provider` are unaffected, and a task that pins a `runtime_type` still narrows to that runtime.

## Changes

- **shared** (`packages/shared/src/types/common.ts`): `AiProviderStatus.Active` → `Verified` (`'verified'`); all reads follow.
- **server**:
  - `services/ai-provider-keys.ts`: reads filter `verified`; `storeAiProviderKey` auto-defaults only the *first config added to the instance*; `setDefaultAiProvider` clears the flag across **all** providers before promoting.
  - `routes/ai-providers.ts`: Verify persists `verified` on success / `invalid` on rejection.
  - `services/runtime-resolver.ts`: filters `verified`.
- **migration `020`**: backfills `status active → verified`, collapses per-provider defaults to the oldest single default, and swaps the per-provider unique index for a global `ai_provider_configs_single_default`. **Data-preserving**, with a `createDataPreservationHarness` test.
- **web**:
  - `ai-providers-section.tsx`: status badge reads `verified`; the **Default** badge and **Set as default** star are always shown (no longer gated on 2+ configs per provider).
  - agent `settings.tsx` model-override picker filters on `verified`.
- **docs**: `.dev/architecture.md` §6 and `docs/ai-models.md` describe the status vocabulary and the single global default.

## Testing

- `bun run typecheck` — green (enum rename surfaces any missed reference at compile time).
- New migration test + updated provider suites: `migrate-020`, `ai-providers`, `ai-provider-keys`, `runtime-resolver`, `ai-providers-verify` (incl. a new invalid→verified recovery test), CEO-session + agent-runner suites — all green.
- Web `ai-providers.test.tsx` (18 tests, incl. a new "flips the single instance-wide default across two different providers") — green.
- Full non-browser sweep green apart from one unrelated `document-review.test.tsx` `findByText` timeout that passes in isolation (pre-existing flake under the loaded parallel run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QeR52Jna9aDDZZXdqU6w2g)_