### PR TITLE
feat(concurrency): raise default max concurrent runs per project to 10

### DIFF
--- a/packages/server/migrations/023_raise_default_max_concurrent_runs.sql
+++ b/packages/server/migrations/023_raise_default_max_concurrent_runs.sql
@@ -1,0 +1,10 @@
+-- Raise the per-project concurrent agent-run ceiling default from 3 to 10.
+-- New projects (created via project-create.ts / teams.ts, which never set the
+-- column explicitly and rely on the DB default) now start at 10.
+--
+-- Existing projects still sitting on the old default (3) are bumped to the new
+-- default so the change reaches deployed instances too. Projects an operator
+-- deliberately customized to any other value are left untouched.
+ALTER TABLE projects ALTER COLUMN max_concurrent_runs SET DEFAULT 10;
+
+UPDATE projects SET max_concurrent_runs = 10 WHERE max_concurrent_runs = 3;

--- a/packages/server/test/migrate-023-raise-default-max-concurrent-runs.test.ts
+++ b/packages/server/test/migrate-023-raise-default-max-concurrent-runs.test.ts
@@ -1,0 +1,77 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createDataPreservationHarness, type DataPreservationHarness } from './helpers/migrate';
+
+const TARGET = '023_raise_default_max_concurrent_runs.sql';
+
+describe('023_raise_default_max_concurrent_runs migration', () => {
+	let h: DataPreservationHarness;
+	let defaultRowId: string;
+	let customRowId: string;
+
+	beforeAll(async () => {
+		h = await createDataPreservationHarness();
+		await h.applyUpToExclusive(TARGET);
+
+		// projects.team_id is UNIQUE (1:1 team↔project), so each project needs its own team.
+		const newTeam = async (slug: string): Promise<string> => {
+			const t = await h.db.query<{ id: string }>(
+				`INSERT INTO teams (name, slug) VALUES ($1, $1) RETURNING id`,
+				[slug],
+			);
+			return t.rows[0].id;
+		};
+
+		// A project on the old default (3) — inserted without specifying the column.
+		const onDefault = await h.db.query<{ id: string; max_concurrent_runs: number }>(
+			`INSERT INTO projects (team_id, name, slug, task_prefix)
+			 VALUES ($1, 'Default', 'default', 'DEF') RETURNING id, max_concurrent_runs`,
+			[await newTeam('team-default')],
+		);
+		defaultRowId = onDefault.rows[0].id;
+		// Guard the premise: the pre-migration default really is 3.
+		expect(onDefault.rows[0].max_concurrent_runs).toBe(3);
+
+		// A project an operator explicitly customized away from the default.
+		const custom = await h.db.query<{ id: string }>(
+			`INSERT INTO projects (team_id, name, slug, task_prefix, max_concurrent_runs)
+			 VALUES ($1, 'Custom', 'custom', 'CUS', 5) RETURNING id`,
+			[await newTeam('team-custom')],
+		);
+		customRowId = custom.rows[0].id;
+
+		await h.applyTarget(TARGET);
+	});
+	afterAll(() => h.close());
+
+	it('changes the column default to 10 for new projects', async () => {
+		const team = await h.db.query<{ id: string }>(
+			`INSERT INTO teams (name, slug) VALUES ('team-fresh', 'team-fresh') RETURNING id`,
+		);
+		const fresh = await h.db.query<{ max_concurrent_runs: number }>(
+			`INSERT INTO projects (team_id, name, slug, task_prefix)
+			 VALUES ($1, 'Fresh', 'fresh', 'FRE') RETURNING max_concurrent_runs`,
+			[team.rows[0].id],
+		);
+		expect(fresh.rows[0].max_concurrent_runs).toBe(10);
+	});
+
+	it('bumps pre-existing projects on the old default (3) to 10', async () => {
+		const row = await h.db.query<{ slug: string; max_concurrent_runs: number }>(
+			`SELECT slug, max_concurrent_runs FROM projects WHERE id = $1`,
+			[defaultRowId],
+		);
+		expect(row.rows).toHaveLength(1);
+		expect(row.rows[0].slug).toBe('default');
+		expect(row.rows[0].max_concurrent_runs).toBe(10);
+	});
+
+	it('preserves projects explicitly customized to another value', async () => {
+		const row = await h.db.query<{ slug: string; max_concurrent_runs: number }>(
+			`SELECT slug, max_concurrent_runs FROM projects WHERE id = $1`,
+			[customRowId],
+		);
+		expect(row.rows).toHaveLength(1);
+		expect(row.rows[0].slug).toBe('custom');
+		expect(row.rows[0].max_concurrent_runs).toBe(5);
+	});
+});

--- a/packages/web/test/project-settings.test.tsx
+++ b/packages/web/test/project-settings.test.tsx
@@ -130,9 +130,9 @@ test('edits the per-project concurrency cap and persists it', async () => {
 		params: { projectId: projectSlug },
 	});
 
-	// Read view shows the seeded default of 3.
+	// Read view shows the seeded default of 10.
 	const readValue = await findByTestId('max-concurrent-runs-value', undefined, { timeout: 8_000 });
-	expect(readValue.textContent).toContain('3');
+	expect(readValue.textContent).toContain('10');
 
 	await user.click(await findByRole('button', { name: 'Edit' }));
 	const input = (await findByTestId('max-concurrent-runs-input', undefined, {


### PR DESCRIPTION
## Summary

The per-project concurrent agent-run ceiling (`projects.max_concurrent_runs`) previously defaulted to **3**. This raises it to **10** so new projects allow more agents to work different tasks in parallel out of the box. The value stays fully configurable per project from the project Settings page (integer ≥ 1).

## Changes

- **Migration `021_raise_default_max_concurrent_runs.sql`** — sets the column `DEFAULT` to `10`, and backfills existing projects still sitting on the old default (`3`) to `10`. Projects an operator explicitly customized to any other value are left untouched.
- **Data-preservation test** (`migrate-021-raise-default-max-concurrent-runs.test.ts`) — asserts the new default applies to freshly-inserted projects, that old-default (`3`) rows are bumped to `10`, and that a customized value (`5`) is preserved.
- **Web test** (`project-settings.test.tsx`) — updated the settings read-view assertion from the old seeded default of `3` to `10`.

## Notes

- `project-create.ts` and `teams.ts` both `INSERT` projects without specifying the column, so they inherit the new DB default — no code change needed there.
- The enforcement path (`run-concurrency.ts` / `JobManager`) reads `max_concurrent_runs` directly and is unaffected by the default change.
- No user-facing docs pin the specific default value, so none required updating.

## Testing

- `migrate-021-…`, `migrate-data-preservation`, `migrate-runner`, `queued-wakeups`, `projects-routes-extended`, `projects-routes-cov-fill` — 100 passed
- `job-manager-progress`, `job-manager-scheduling`, `job-manager-extended` — 73 passed
- web `project-settings.test.tsx` — 7 passed
- `bun run typecheck` + full build — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011rND3qJ3sa9pPZJct6BKoL)_