### PR TITLE
feat(web): status pill + terminal strikethrough in task-mention tooltip

### DIFF
--- a/packages/web/src/components/markdown-prose.tsx
+++ b/packages/web/src/components/markdown-prose.tsx
@@ -1,3 +1,4 @@
+import { TERMINAL_TASK_STATUSES } from '@hezo/shared';
 import { Link } from '@tanstack/react-router';
 import { ExternalLink } from 'lucide-react';
 import { type ReactNode, useMemo } from 'react';
@@ -22,6 +23,7 @@ import {
 } from '../lib/remark-mentions';
 import { CommentRefLink, MENTION_CLASSES } from './comment-ref-link';
 import { useOpenPreview } from './task-detail/preview-context';
+import { TaskStatusBadge } from './task-status-badge';
 import { Tooltip } from './ui/tooltip';
 
 type RemarkPlugin = Parameters<typeof Markdown>[0]['remarkPlugins'];
@@ -112,7 +114,11 @@ export function MarkdownProse({
 		const source = instanceResolved?.tasks ?? resolvedTasks;
 		if (!source) return m;
 		for (const i of source) {
-			m.set(i.identifier.toLowerCase(), { title: i.title, projectSlug: i.project_slug });
+			m.set(i.identifier.toLowerCase(), {
+				title: i.title,
+				projectSlug: i.project_slug,
+				status: i.status,
+			});
 		}
 		return m;
 	}, [resolvedTasks, instanceResolved]);
@@ -251,6 +257,7 @@ export function MarkdownProse({
 					'data-mention-passive'?: string;
 					'data-mention-task-identifier'?: string;
 					'data-mention-task-title'?: string;
+					'data-mention-task-status'?: string;
 					'data-mention-project-slug'?: string;
 					'data-mention-comment-task-identifier'?: string;
 					'data-mention-comment-id'?: string;
@@ -382,16 +389,34 @@ export function MarkdownProse({
 				const taskIdentifier = attrs['data-mention-task-identifier'];
 				const taskTitle = attrs['data-mention-task-title'];
 				const taskProjectSlug = attrs['data-mention-project-slug'];
+				const taskStatus = attrs['data-mention-task-status'];
 				if (taskIdentifier && taskTitle && taskProjectSlug && mentionsEnabled) {
+					const closed = taskStatus
+						? (TERMINAL_TASK_STATUSES as readonly string[]).includes(taskStatus)
+						: false;
 					return (
-						<Tooltip content={taskTitle}>
+						<Tooltip
+							content={
+								<span className="flex flex-col gap-1">
+									<span>{taskTitle}</span>
+									{taskStatus ? (
+										<TaskStatusBadge
+											status={taskStatus}
+											className="self-start"
+											testId="task-mention-status-pill"
+										/>
+									) : null}
+								</span>
+							}
+						>
 							<Link
 								to="/projects/$projectId/tasks/$taskId"
 								params={{
 									projectId: taskProjectSlug,
 									taskId: taskIdentifier.toLowerCase(),
 								}}
-								className={MENTION_CLASSES}
+								className={closed ? `${MENTION_CLASSES} line-through` : MENTION_CLASSES}
+								data-mention-task-status={taskStatus}
 								data-testid="task-mention-link"
 							>
 								{props.children}

--- a/packages/web/src/lib/remark-mentions.ts
+++ b/packages/web/src/lib/remark-mentions.ts
@@ -47,6 +47,7 @@ export interface AgentMentionData {
 export interface TaskMentionData {
 	title: string;
 	projectSlug: string;
+	status: string;
 }
 
 export interface KbDocMentionData {
@@ -306,6 +307,7 @@ function buildLink(token: MentionToken, opts: Options): LinkNode | null {
 				hProperties: {
 					'data-mention-task-identifier': token.identifier,
 					'data-mention-task-title': data.title,
+					'data-mention-task-status': data.status,
 					'data-mention-project-slug': data.projectSlug,
 				},
 			},

--- a/packages/web/test/markdown-prose-mentions.test.tsx
+++ b/packages/web/test/markdown-prose-mentions.test.tsx
@@ -10,6 +10,52 @@ import { expect, test } from 'vitest';
 import { getTestContext, renderApp } from './helpers/render';
 import { seedComment, seedProject, seedTask, seedWorkspace } from './helpers/seed';
 
+/**
+ * Seed a "source" task whose description references a "target" task by identifier,
+ * put the target at `targetStatus`, render the source's task page, and return the
+ * resolved `task-mention-link` element for the target. The description field runs
+ * through markdown-prose, so the reference linkifies once `/tasks/resolve` returns.
+ */
+async function renderTaskMention(targetStatus: string): Promise<HTMLAnchorElement> {
+	let projSlug = '';
+	let sourceIdentifier = '';
+	let targetIdentifier = '';
+
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Status Mention Project' });
+			const target = await seedTask(ws, project, { title: 'Target task title' });
+			const source = await seedTask(ws, project, {
+				title: 'Source task',
+				description: `See also ${target.identifier} for related work.`,
+			});
+			// Set status directly: the closing automations (approval gates, child
+			// checks) are irrelevant here and would make the terminal cases flaky.
+			const { db } = getTestContext();
+			await db.query('UPDATE tasks SET status = $1::task_status WHERE id = $2', [
+				targetStatus,
+				target.id,
+			]);
+			projSlug = project.slug;
+			targetIdentifier = target.identifier;
+			sourceIdentifier = source.identifier;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: projSlug, taskId: sourceIdentifier.toLowerCase() },
+	});
+
+	const link = (await findByTestId('task-mention-link', undefined, {
+		timeout: 20_000,
+	})) as HTMLAnchorElement;
+	expect(link.textContent).toContain(targetIdentifier);
+	return link;
+}
+
 async function seedSkill(name: string, slug: string): Promise<void> {
 	const { apiBase, token } = getTestContext();
 	const res = await apiBase('/api/skills', {
@@ -180,3 +226,28 @@ test('a passive @@agent mention renders the bare slug as a passive-flagged link'
 	// Passive form drops the leading "@" in the visible label.
 	expect(passiveLink.textContent).toBe(seeded.agentSlug);
 });
+
+test('a mention of a done task strikes through the link and carries its status', async () => {
+	const link = await renderTaskMention('done');
+	// The threaded status drives both the strikethrough and the tooltip pill.
+	expect(link.getAttribute('data-mention-task-status')).toBe('done');
+	expect(link.className).toContain('line-through');
+});
+
+test('a mention of a cancelled task strikes through the link', async () => {
+	const link = await renderTaskMention('cancelled');
+	expect(link.getAttribute('data-mention-task-status')).toBe('cancelled');
+	expect(link.className).toContain('line-through');
+});
+
+test('a mention of an open (in-progress) task is not struck through', async () => {
+	const link = await renderTaskMention('in_progress');
+	expect(link.getAttribute('data-mention-task-status')).toBe('in_progress');
+	expect(link.className).not.toContain('line-through');
+});
+
+// The status pill itself lives inside a Radix tooltip that only mounts its portal
+// content on a real pointer hover — a path happy-dom can't drive — so the
+// hover→pill assertion lives in test/browser/task-mention-status.spec.ts. The
+// `data-mention-task-status` assertions above prove the exact value that feeds the
+// pill reaches the DOM.

--- a/test/browser/task-mention-status.spec.ts
+++ b/test/browser/task-mention-status.spec.ts
@@ -1,0 +1,84 @@
+// Real Chromium (decision tree #1 + #5-adjacent): the status pill lives inside a
+// Radix tooltip that only mounts its content (a portal on document.body) on a real
+// pointer hover, and the "struck through" assertion reads the computed
+// text-decoration off the laid-out link — neither the hover-driven portal nor
+// getComputedStyle works under happy-dom, so this slice stays in the browser tier.
+// (The status→DOM threading and the strikethrough class toggle are covered cheaply
+// by packages/web/test/markdown-prose-mentions.test.tsx.)
+
+import { expect, test } from './fixtures';
+import { createProjectAndClearPlanning, uniqueName, waitForPageLoad } from './helpers';
+
+type Page = import('@playwright/test').Page;
+
+async function createTaskViaApi(
+	page: Page,
+	projectSlug: string,
+	token: string,
+	data: { project_id: string; title: string; assignee_slug?: string; description?: string },
+): Promise<{ id: string; identifier: string }> {
+	const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+	// A task requires an assignee; the Blank-templated project has a Captain.
+	const res = await page.request.post(`/api/projects/${projectSlug}/tasks`, {
+		headers,
+		data: { assignee_slug: 'captain', ...data },
+	});
+	if (!res.ok()) throw new Error(`createTaskViaApi failed — ${res.status()} ${await res.text()}`);
+	return ((await res.json()) as { data: { id: string; identifier: string } }).data;
+}
+
+test.describe('Task mention — status pill tooltip & terminal strikethrough', () => {
+	test('a mention of a cancelled task shows a status pill on hover and strikes through the link', async ({
+		page,
+		sharedWorkspace,
+	}) => {
+		const { token } = sharedWorkspace;
+		await page.setViewportSize({ width: 1280, height: 720 });
+
+		const proj = await createProjectAndClearPlanning(page, '', token, {
+			name: uniqueName('Mention Status'),
+			description: 'Mention status pill spec.',
+		});
+
+		// Target is set terminal (cancelled is unguarded, so closing is deterministic
+		// with no run-race), then referenced from the source task's description, which
+		// renders through markdown-prose and linkifies the identifier.
+		const target = await createTaskViaApi(page, proj.slug, token, {
+			project_id: proj.id,
+			title: 'Cancelled target task',
+		});
+		const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+		const patchRes = await page.request.patch(
+			`/api/projects/${proj.slug}/tasks/${target.identifier.toLowerCase()}`,
+			{ headers, data: { status: 'cancelled' } },
+		);
+		expect(patchRes.ok()).toBeTruthy();
+
+		const source = await createTaskViaApi(page, proj.slug, token, {
+			project_id: proj.id,
+			title: 'Source task',
+			description: `Superseded by ${target.identifier}, see there.`,
+		});
+
+		await page.goto(`/projects/${proj.slug}/tasks/${source.identifier.toLowerCase()}`);
+		await waitForPageLoad(page);
+
+		const mention = page.getByTestId('task-mention-link');
+		await expect(mention).toBeVisible({ timeout: 20_000 });
+		await expect(mention).toContainText(target.identifier);
+
+		// Terminal → the link text is struck through. toHaveCSS auto-retries so it
+		// can't race the dev server's async stylesheet injection. Assert before
+		// hovering: MENTION_CLASSES' hover:underline flips text-decoration-line to
+		// underline while the pointer is over the link.
+		await expect(mention).toHaveCSS('text-decoration-line', 'line-through');
+
+		// Hover opens the Radix tooltip; the status pill lives inside its portal
+		// content. Scope to the role="tooltip" panel — Radix also renders a hidden
+		// aria duplicate of the content that carries the same testId.
+		await mention.hover();
+		const pill = page.getByRole('tooltip').getByTestId('task-mention-status-pill');
+		await expect(pill).toBeVisible({ timeout: 20_000 });
+		await expect(pill).toHaveText('Cancelled');
+	});
+});


### PR DESCRIPTION
## What & why

Inline task mentions (e.g. `HM-94`, `HM-102`) render as links with a hover tooltip, but the tooltip only showed the task **title** — so a done or cancelled task looked identical to an open one, both in the tooltip and as inline link text.

This adds the two requested improvements:

1. **The mention tooltip now shows a status pill** (Backlog / In Progress / Review / Blocked / Done / Cancelled) below the title.
2. **Done/cancelled task mentions render their link text with a strikethrough**, so a closed task reads as closed at a glance.

The task-resolve endpoints already returned `status` and it was carried all the way to the web hook types, then discarded before the tooltip. This is a pure frontend threading + rendering change — **no server, SQL, or API change**.

## Changes

- **`packages/web/src/lib/remark-mentions.ts`** — add `status` to the plugin's `TaskMentionData`; emit it as the `data-mention-task-status` hProperty on the task link node.
- **`packages/web/src/components/markdown-prose.tsx`** — thread `status` through `tasksMap`; build the tooltip content with a reused `TaskStatusBadge` pill; append `line-through` to the link className when the status is terminal (`TERMINAL_TASK_STATUSES` from `@hezo/shared`). The pill and strikethrough reuse existing components/constants — no new styling primitives.

## Testing

- **Component (`packages/web/test/markdown-prose-mentions.test.tsx`)** — new cases assert done/cancelled links get `line-through` and carry the correct `data-mention-task-status`, and an open (in-progress) link does not. These robustly cover the status→DOM threading (the exact input to the pill) and the strikethrough toggle.
- **Browser (`test/browser/task-mention-status.spec.ts`)** — a Playwright spec drives a real hover, asserting the status pill appears inside the tooltip portal and the link's computed `text-decoration-line` is `line-through`. The pill lives in a Radix tooltip that only mounts its portal content on real pointer hover and the strike assertion reads real computed layout — neither works under happy-dom, so this slice belongs in the browser tier.

All new component tests pass, the broader mention/prose suite (30 tests) is green, the browser spec is stable across repeated runs, and `typecheck` + `biome check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wr4dBTGAhymtKjDp6eVKk

---
_Generated by [Claude Code](https://claude.ai/code/session_016wr4dBTGAhymtKjDp6eVKk)_