### PR TITLE
feat(web): label icon-only add-item buttons on desktop

### DIFF
--- a/packages/web/src/components/docs-library.tsx
+++ b/packages/web/src/components/docs-library.tsx
@@ -273,12 +273,15 @@ export function DocsLibrary({
 								<Button
 									variant="accent"
 									size="sm"
-									className="h-8 w-8 shrink-0 px-0 rounded-md"
+									// Icon-only below desktop to keep the narrow doc-list column
+									// clear for the filter; the "New document" label appears at lg+.
+									className="h-8 w-8 shrink-0 px-0 rounded-md lg:w-auto lg:px-2.5"
 									onClick={onNewDoc}
 									aria-label="New document"
 									title="New document"
 								>
 									<Plus className="w-4 h-4" />
+									<span className="hidden lg:inline">New document</span>
 								</Button>
 							)}
 						</div>

--- a/packages/web/src/components/goals-list.tsx
+++ b/packages/web/src/components/goals-list.tsx
@@ -345,6 +345,8 @@ export function GoalsList({ projectId }: GoalsListProps) {
 						title="New goal"
 					>
 						<Plus className="w-4 h-4" />
+						{/* Label appears at the desktop breakpoint; icon-only below it. */}
+						<span className="hidden lg:inline">New goal</span>
 					</Button>
 				)}
 			</div>

--- a/packages/web/src/components/task-list.tsx
+++ b/packages/web/src/components/task-list.tsx
@@ -552,17 +552,22 @@ export function TaskList({ projectId }: TaskListProps) {
 
 			<div className="mb-4 flex flex-row items-stretch gap-2">
 				{filterBar}
-				{/* Icon-only create button pinned to the filter bar's row, matching its
-				    height. The accessible name keeps it discoverable without the label. */}
+				{/* Create button pinned to the filter bar's row, matching its height.
+				    Icon-only on mobile/tablet to save space; the "New task" label
+				    appears at the desktop breakpoint (lg+). The accessible name keeps
+				    it discoverable at every width. */}
 				<button
 					type="button"
 					onClick={() => setCreateOpen(true)}
 					data-testid="task-list-new-task"
 					aria-label="New task"
 					title="New task"
-					className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-inverse text-inverse-fg transition-colors hover:opacity-90 outline-none focus-visible:ring-[3px] focus-visible:ring-ring focus-visible:border-accent"
+					className="flex h-10 w-10 shrink-0 items-center justify-center gap-1.5 rounded-md bg-inverse text-inverse-fg transition-colors hover:opacity-90 outline-none focus-visible:ring-[3px] focus-visible:ring-ring focus-visible:border-accent lg:w-auto lg:px-3"
 				>
 					<Plus className="w-4 h-4" />
+					<span className="hidden text-[13px] font-medium whitespace-nowrap lg:inline">
+						New task
+					</span>
 				</button>
 			</div>
 

--- a/test/browser/new-task-button.mobile.spec.ts
+++ b/test/browser/new-task-button.mobile.spec.ts
@@ -111,4 +111,34 @@ test.describe('Header new-task button responsiveness', () => {
 		expect(btnBox.x).toBeGreaterThan(barBox.x + barBox.width - 4);
 		expect(Math.abs(btnBox.y - barBox.y)).toBeLessThan(barBox.height);
 	});
+
+	// The create button's "New task" label is `hidden lg:inline` — a real
+	// media-query/layout assertion (decision-tree items 1–2), so it needs
+	// Chromium + setViewportSize; happy-dom can't resolve the breakpoint.
+	test('the create button is icon-only on mobile and shows its label on desktop', async ({
+		page,
+		sharedWorkspace,
+	}) => {
+		const { token } = sharedWorkspace;
+		const project = await createProjectAndClearPlanning(page, '', token, {
+			name: uniqueName('Task Label'),
+			description: 'E2E new-task label responsiveness.',
+		});
+
+		const newTask = page.getByTestId('task-list-new-task');
+		// The label lives in a span; the button also carries it as aria-label/title,
+		// but getByText only matches the rendered text node, so it targets the span.
+		const label = newTask.getByText('New task', { exact: true });
+
+		// Mobile: icon-only — the label span is display:none.
+		await page.setViewportSize({ width: 375, height: 800 });
+		await page.goto(`/projects/${project.slug}/tasks`);
+		await waitForPageLoad(page);
+		await expect(newTask).toBeVisible({ timeout: 15000 });
+		await expect(label).toBeHidden();
+
+		// Desktop (≥lg): the "New task" label renders beside the icon.
+		await page.setViewportSize({ width: 1280, height: 900 });
+		await expect(label).toBeVisible();
+	});
 });


### PR DESCRIPTION
The task list "New task", goals "New goal", and docs "New document"
create buttons were icon-only "+" affordances at every width, leaving
their purpose unclear on desktop where there's room for a label.

Keep them icon-only on mobile/tablet (to save space next to the filter
bars they sit beside) and reveal the label at the desktop breakpoint
(lg+), with the icon as a prefix. The accessible name (aria-label/title)
is unchanged, so the buttons stay discoverable at every width and all
existing role/testid-based tests keep matching.

Other add-item buttons already carry desktop labels (home "New project",
assets "New folder", settings Add/Create, "Hire agent", "Add provider").
The app-header "New task" (lg:hidden mobile-only, its desktop counterpart
is the sidebar "+"), the vertical project rail "New project", and the
inline sidebar "+" chips stay icon-only by design and keep their tooltips.

Add a Playwright assertion that the "New task" label is hidden on mobile
and shown on desktop (a real media-query/layout check).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Nv8xgznLCELHnuhFFudPVf