### PR TITLE
feat: show connector↔credential relationships with project-aware naming

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -823,9 +823,22 @@ assumes the agent itself may misbehave; the egress proxy is the choke point.
 
 **Secrets.** `secrets` rows are AES-256-GCM ciphertext plus `allowed_hosts` (e.g.
 `['api.stripe.com']`, `*.googleapis.com` wildcards) or the `allow_all_hosts` escape hatch.
-They are **instance-global** by default (`team_id NULL`), bounded per-secret by
-`allowed_hosts`; project/team-scoped rows are possible and win on name dedup
-(project > team > instance). The master key (§ 10) decrypts at request time.
+They are **instance-global** — `name` is globally unique and the egress proxy resolves the
+placeholder by name with no project context — bounded per-secret by `allowed_hosts`. The
+master key (§ 10) decrypts at request time. Connectors, by contrast, are project-scoped
+(`mcp_connections.project_id`, NULL = global); a credential does **not** follow its
+connector's scope (moving a connector between scopes leaves its credential untouched).
+Instead the credential *name* carries the project signal (see the API-key row below), so a
+global credential list stays legible.
+
+**Connector ↔ credential relationships.** The admin credentials list (`GET /api/credentials`)
+returns, per credential, the `connectors` that use it (matched via `api_key_secret_id` or the
+connector's OAuth access token); the connector lists return the reverse `credentials` array.
+The web surfaces render each as an indented, deep-linked sub-list under the other (credentials
+page ↔ `/settings/connectors`, connector pages ↔ `/settings/credentials`, both via a
+`?focus=<id>#<id>` anchor). A credential in use by ≥1 connector cannot be deleted — `DELETE
+/api/secrets/:id` returns `409 IN_USE` and the UI disables the revoke control with a tooltip;
+remove the connector(s) first.
 
 **Acquisition.** An agent calls the `request_credential` MCP tool (`name`, `kind`,
 `allowed_hosts`, human `instructions`, `confirmation_text`). `CredentialKind` =
@@ -975,7 +988,7 @@ supports; once a token exists, both strategies finalize through one shared path.
 |---|---|---|---|
 | **DCR auth-code + PKCE** | PRM discovery (RFC 9728) → Dynamic Client Registration (RFC 7591) → redirect popup → `/api/oauth/mcp-callback`. Zero config — the AS mints a `client_id`. | the AS advertises a `registration_endpoint` | DatoCMS, Linear, Notion, Vercel, … |
 | **Device flow (RFC 8628)** | `connectors/:id/device/start` → user types a code → `…/device/poll`. Needs a pre-registered public `client_id`; no redirect, no secret. | the capability registry declares a `deviceAuth` descriptor | **GitHub** |
-| **API key** | human pastes a key on the connect_required card or the Connectors page → `POST /api/projects/:projectId/mcp-connections/:id/api-key` encrypts it into the vault (`allowed_hosts` = the MCP host) and links it via `mcp_connections.api_key_secret_id`. | the MCP server exposes no OAuth (no PRM) and authenticates with a bearer/API key | **Typefully**, header-auth MCPs |
+| **API key** | human pastes a key on the connect_required card or the Connectors page → `POST /api/projects/:projectId/mcp-connections/:id/api-key` encrypts it into the vault (`allowed_hosts` = the MCP host) and links it via `mcp_connections.api_key_secret_id`. The generated secret name is `MCP_<CONNECTOR>_<PROJFRAG>` for a project-scoped connector (`PROJFRAG` = first 5 hex of the project UUID, uppercased) and `MCP_<CONNECTOR>` for a global one, so two same-type connectors in different projects get distinctly-named credentials. | the MCP server exposes no OAuth (no PRM) and authenticates with a bearer/API key | **Typefully**, header-auth MCPs |
 | **Paste / `request_credential`** | raw key pasted into the vault, referenced by placeholder from a tool call | an agent needs an arbitrary secret (not a whole connector) | `request_credential` |
 
 GitHub uses the device flow because its AS advertises no `registration_endpoint` (DCR

--- a/docs/mcp/connecting-mcp-servers.md
+++ b/docs/mcp/connecting-mcp-servers.md
@@ -77,6 +77,25 @@ Manage connections two ways:
   project or back to the global scope. New connectors pick their scope in the Add form the
   same way.
 
+## Connectors and their credentials
+
+[Credentials](/docs/security/secret-protection) stay **global** — one shared vault, not
+scoped per project. But because a connector *is* scoped, the credential a connector creates
+is **named after that connector's project** (a project-scoped connector's API key gets a
+short project tag in its name; a global connector's does not), so when two projects connect
+the same kind of server you can still tell their credentials apart at a glance.
+
+Both pages show the link between the two:
+
+- Under each connector, the **credential** it uses — click it to jump to that credential on
+  the Credentials page.
+- Under each credential (**Settings → Credentials**), the **connectors** that use it — click
+  one to jump to it on the Connectors page.
+
+Because a connector depends on its credential, a credential that's still in use **can't be
+deleted**: its revoke button is disabled with a note explaining why. Remove the connector
+first, then the credential can be revoked.
+
 ## Adding a connection
 
 Register connections from the web app, or let an agent add one itself when it needs a

--- a/packages/server/src/routes/mcp-connections.ts
+++ b/packages/server/src/routes/mcp-connections.ts
@@ -35,13 +35,27 @@ const CONNECTOR_COLUMNS_MC = `mc.id, mc.name, mc.display_name, mc.kind::text AS 
         mc.install_error, mc.skill_id, mc.created_by_task_id, mc.activated_at, mc.revoked_at,
         mc.auth_error, mc.created_at, mc.updated_at`;
 
+// The credential(s) a connector uses, as a JSON array — its pasted API-key secret
+// or the access token of its linked OAuth connection (relation R, symmetric with
+// the `connectors` array on GET /credentials). Correlated on the connector row
+// aliased `<alias>`; returns `[]` for a connector with no connector-managed auth.
+const connectorCredentialsJson = (alias: string): string =>
+	`COALESCE((
+		SELECT json_agg(json_build_object('id', cs.id, 'name', cs.name) ORDER BY cs.name)
+		FROM secrets cs
+		WHERE cs.id = ${alias}.api_key_secret_id
+		   OR cs.id = (SELECT oc2.access_token_secret_id FROM oauth_connections oc2
+		               WHERE oc2.id = ${alias}.oauth_connection_id)
+	), '[]'::json) AS credentials`;
+
 export const mcpConnectionsRoutes = new Hono<Env>();
 
 mcpConnectionsRoutes.get('/projects/:projectId/mcp-connections', async (c) => {
 	const db = c.get('db');
 	const projectId = c.get('projectId') as string;
 	const result = await db.query(
-		`SELECT ${CONNECTOR_COLUMNS_MC}, oc.provider_account_label AS oauth_account_label
+		`SELECT ${CONNECTOR_COLUMNS_MC}, oc.provider_account_label AS oauth_account_label,
+		        ${connectorCredentialsJson('mc')}
 		 FROM mcp_connections mc
 		 LEFT JOIN oauth_connections oc ON oc.id = mc.oauth_connection_id
 		 WHERE mc.project_id = $1 OR mc.project_id IS NULL
@@ -60,7 +74,8 @@ mcpConnectionsRoutes.get('/mcp-connections', async (c) => {
 	const db = c.get('db');
 	const result = await db.query(
 		`SELECT ${CONNECTOR_COLUMNS_MC}, p.name AS project_name, p.slug AS project_slug,
-		        oc.provider_account_label AS oauth_account_label
+		        oc.provider_account_label AS oauth_account_label,
+		        ${connectorCredentialsJson('mc')}
 		 FROM mcp_connections mc
 		 LEFT JOIN projects p ON p.id = mc.project_id
 		 LEFT JOIN oauth_connections oc ON oc.id = mc.oauth_connection_id
@@ -235,8 +250,8 @@ mcpConnectionsRoutes.get('/projects/:projectId/mcp-connections/:id', async (c) =
 	const projectId = c.get('projectId') as string;
 	const id = c.req.param('id');
 	const result = await db.query(
-		`SELECT ${CONNECTOR_COLUMNS} FROM mcp_connections
-		 WHERE id = $1 AND (project_id = $2 OR project_id IS NULL)`,
+		`SELECT ${CONNECTOR_COLUMNS_MC}, ${connectorCredentialsJson('mc')} FROM mcp_connections mc
+		 WHERE mc.id = $1 AND (mc.project_id = $2 OR mc.project_id IS NULL)`,
 		[id, projectId],
 	);
 	if (result.rows.length === 0) return err(c, 'NOT_FOUND', 'connector not found', 404);
@@ -310,19 +325,25 @@ mcpConnectionsRoutes.post('/projects/:projectId/mcp-connections/:id/revoke', asy
 
 /**
  * Derive a stable, grammar-valid vault secret name for a connector's pasted API
- * key. Keyed on the connector id (first 8 hex) so re-pasting upserts the same
- * secret and two like-named connectors in different projects never collide.
+ * key. A project-scoped connector's key is qualified with the first 5 hex chars
+ * of its project UUID (`MCP_<base>_<PROJFRAG>`) so two connectors of the same
+ * type in different projects get distinctly-named credentials — the name is the
+ * only project signal, since credentials themselves stay global. A global
+ * ("all projects") connector's key is unqualified (`MCP_<base>`). Deriving from
+ * (connector name, project) keeps re-pastes upserting the same secret; connector
+ * names are unique within a scope, so the base never collides in-scope.
  */
-function apiKeySecretName(connectorName: string, connectorId: string): string {
-	const suffix = connectorId.replace(/-/g, '').slice(0, 8).toUpperCase();
+function apiKeySecretName(connectorName: string, projectId: string | null): string {
+	const frag = projectId ? projectId.replace(/-/g, '').slice(0, 5).toUpperCase() : '';
 	let base = connectorName
 		.toUpperCase()
 		.replace(/[^A-Z0-9_]/g, '_')
 		.replace(/^[^A-Z]+/, '');
 	if (base.length === 0) base = 'KEY';
-	// Cap so total `MCP_<base>_<suffix>` stays within the 64-char grammar limit.
-	base = base.slice(0, 64 - 'MCP_'.length - 1 - suffix.length);
-	return `MCP_${base}_${suffix}`;
+	// Cap so total `MCP_<base>[_<frag>]` stays within the 64-char grammar limit.
+	const tail = frag ? 1 + frag.length : 0;
+	base = base.slice(0, 64 - 'MCP_'.length - tail);
+	return frag ? `MCP_${base}_${frag}` : `MCP_${base}`;
 }
 
 /**
@@ -355,8 +376,9 @@ mcpConnectionsRoutes.post('/projects/:projectId/mcp-connections/:id/api-key', as
 		config: Record<string, unknown>;
 		revoked_at: string | null;
 		created_by_task_id: string | null;
+		project_id: string | null;
 	}>(
-		`SELECT id, name, kind::text AS kind, config, revoked_at::text AS revoked_at, created_by_task_id
+		`SELECT id, name, kind::text AS kind, config, revoked_at::text AS revoked_at, created_by_task_id, project_id
 		 FROM mcp_connections
 		 WHERE id = $1 AND (project_id = $2 OR project_id IS NULL)`,
 		[id, projectId],
@@ -393,7 +415,7 @@ mcpConnectionsRoutes.post('/projects/:projectId/mcp-connections/:id/api-key', as
 			? { ...(header !== undefined ? { header } : {}), ...(scheme !== undefined ? { scheme } : {}) }
 			: null;
 
-	const secretName = apiKeySecretName(conn.name, conn.id);
+	const secretName = apiKeySecretName(conn.name, conn.project_id);
 	const nameCheck = validateSecretName(secretName);
 	if (!nameCheck.valid) {
 		return err(c, 'INVALID_REQUEST', `derived secret name invalid: ${nameCheck.error}`, 500);

--- a/packages/server/src/routes/secrets.ts
+++ b/packages/server/src/routes/secrets.ts
@@ -34,7 +34,19 @@ secretsRoutes.get('/credentials', async (c) => {
 		        s.allowed_hosts, s.allow_all_hosts, s.allow_body_substitution, s.created_at, s.updated_at,
 		        usage.last_used_at,
 		        usage.use_count,
-		        usage.last_host
+		        usage.last_host,
+		        COALESCE((
+		            SELECT json_agg(json_build_object(
+		                'id', mc.id, 'name', mc.name, 'display_name', mc.display_name,
+		                'project_id', mc.project_id, 'project_slug', p.slug
+		            ) ORDER BY mc.name)
+		            FROM mcp_connections mc
+		            LEFT JOIN projects p ON p.id = mc.project_id
+		            WHERE mc.api_key_secret_id = s.id
+		               OR mc.oauth_connection_id IN (
+		                    SELECT oc.id FROM oauth_connections oc WHERE oc.access_token_secret_id = s.id
+		               )
+		        ), '[]'::json) AS connectors
 		 FROM secrets s
 		 LEFT JOIN LATERAL (
 		     SELECT max(al.created_at) AS last_used_at,
@@ -211,6 +223,22 @@ secretsRoutes.delete('/secrets/:secretId', async (c) => {
 	if (denied) return denied;
 	const db = c.get('db');
 	const secretId = c.req.param('secretId');
+
+	// A credential in use by one or more connectors (its pasted API key, or the
+	// access token of a connector's OAuth connection) cannot be deleted — removing
+	// it would silently break the connector's auth. Delete the connector first.
+	// (The UI also disables the control; this is the authoritative guard.)
+	const inUse = await db.query<{ c: number }>(
+		`SELECT count(*)::int AS c FROM mcp_connections mc
+		 WHERE mc.api_key_secret_id = $1
+		    OR mc.oauth_connection_id IN (
+		         SELECT oc.id FROM oauth_connections oc WHERE oc.access_token_secret_id = $1
+		    )`,
+		[secretId],
+	);
+	if (inUse.rows[0].c > 0) {
+		return err(c, 'IN_USE', 'Credential is in use by one or more connectors', 409);
+	}
 
 	const result = await db.query<{ id: string; name: string }>(
 		'DELETE FROM secrets WHERE id = $1 RETURNING id, name',

--- a/packages/server/test/instance-secrets.test.ts
+++ b/packages/server/test/instance-secrets.test.ts
@@ -172,3 +172,92 @@ describe('global credentials (secrets)', () => {
 		expect(del.status).toBe(404);
 	});
 });
+
+describe('credential ↔ connector relationships', () => {
+	// Seed a project + a connector whose api_key_secret_id points at `secretId`.
+	async function seedConnectorUsing(
+		secretId: string,
+		opts: { projectScoped: boolean } = { projectScoped: true },
+	): Promise<{ connectorId: string; projectId: string | null; projectSlug: string | null }> {
+		const suffix = Math.random().toString(36).slice(2, 8);
+		const team = await db.query<{ id: string }>(
+			`INSERT INTO teams (name, slug) VALUES ($1, $2) RETURNING id`,
+			[`Rel ${suffix}`, `rel-${suffix}`],
+		);
+		const proj = await db.query<{ id: string; slug: string }>(
+			`INSERT INTO projects (team_id, name, slug, task_prefix, docker_base_image, container_status)
+			 VALUES ($1, $2, $3, 'RP', 'hezo/agent-base:latest', NULL) RETURNING id, slug`,
+			[team.rows[0].id, `Rel Proj ${suffix}`, `rel-proj-${suffix}`],
+		);
+		const projectId = opts.projectScoped ? proj.rows[0].id : null;
+		const conn = await db.query<{ id: string }>(
+			`INSERT INTO mcp_connections (name, kind, config, install_status, project_id, api_key_secret_id, activated_at)
+			 VALUES ($1, 'saas', '{"url":"https://mcp.rel.example/mcp"}'::jsonb, 'installed', $2, $3, now())
+			 RETURNING id`,
+			[`rel-connector-${suffix}`, projectId, secretId],
+		);
+		return {
+			connectorId: conn.rows[0].id,
+			projectId,
+			projectSlug: opts.projectScoped ? proj.rows[0].slug : null,
+		};
+	}
+
+	it('GET /credentials lists the connectors that use each credential', async () => {
+		const create = await createSecret({
+			name: 'REL_LINKED_KEY',
+			value: 'v',
+			allowed_hosts: ['mcp.rel.example'],
+		});
+		const secretId = (await create.json()).data.id as string;
+		const { connectorId, projectId, projectSlug } = await seedConnectorUsing(secretId);
+
+		const res = await app.request('/api/credentials', { headers: authHeader(token) });
+		const rows = (await res.json()).data as {
+			id: string;
+			name: string;
+			connectors: {
+				id: string;
+				name: string;
+				project_id: string | null;
+				project_slug: string | null;
+			}[];
+		}[];
+		const linked = rows.find((r) => r.name === 'REL_LINKED_KEY');
+		expect(linked).toBeDefined();
+		expect(linked?.connectors).toHaveLength(1);
+		expect(linked?.connectors[0]).toMatchObject({
+			id: connectorId,
+			project_id: projectId,
+			project_slug: projectSlug,
+		});
+
+		// A credential with no connector reports an empty array.
+		const unused = rows.find((r) => r.name === 'SHARED_API_KEY');
+		expect(unused?.connectors).toEqual([]);
+	});
+
+	it('blocks deleting a credential that is in use by a connector (409), allows it once free', async () => {
+		const create = await createSecret({
+			name: 'REL_GUARDED_KEY',
+			value: 'v',
+			allowed_hosts: ['mcp.rel.example'],
+		});
+		const secretId = (await create.json()).data.id as string;
+		const { connectorId } = await seedConnectorUsing(secretId);
+
+		const blocked = await app.request(`/api/secrets/${secretId}`, {
+			method: 'DELETE',
+			headers: authHeader(token),
+		});
+		expect(blocked.status).toBe(409);
+
+		// Detach the connector, then the delete is allowed.
+		await db.query(`DELETE FROM mcp_connections WHERE id = $1`, [connectorId]);
+		const allowed = await app.request(`/api/secrets/${secretId}`, {
+			method: 'DELETE',
+			headers: authHeader(token),
+		});
+		expect(allowed.status).toBe(200);
+	});
+});

--- a/packages/server/test/mcp-connections.test.ts
+++ b/packages/server/test/mcp-connections.test.ts
@@ -237,6 +237,123 @@ describe('POST /projects/:projectId/mcp-connections/:id/api-key', () => {
 	});
 });
 
+describe('api-key credential naming + connector→credential relationship', () => {
+	function projFrag(projectId: string): string {
+		return projectId.replace(/-/g, '').slice(0, 5).toUpperCase();
+	}
+
+	async function seedProjectConnector(
+		ctx: Awaited<ReturnType<typeof createTestApp>>,
+		name: string,
+	): Promise<{ projectSlug: string; projectId: string; connectorId: string }> {
+		const co = await createTestTeam(ctx.db, {
+			name: `Name ${Math.random().toString(36).slice(2)}`,
+		});
+		const team = (await co.json()).data;
+		const projectSlug = await projectSlugFor(ctx.db, team.id);
+		const proj = await ctx.db.query<{ id: string }>(`SELECT id FROM projects WHERE slug = $1`, [
+			projectSlug,
+		]);
+		const insert = await ctx.app.request(`/api/projects/${projectSlug}/mcp-connections`, {
+			method: 'POST',
+			headers: { Authorization: `Bearer ${ctx.token}`, 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name, kind: 'saas', config: { url: 'https://mcp.name.example/mcp' } }),
+		});
+		const connector = (await insert.json()).data as { id: string };
+		return { projectSlug, projectId: proj.rows[0].id, connectorId: connector.id };
+	}
+
+	async function setApiKey(
+		ctx: Awaited<ReturnType<typeof createTestApp>>,
+		projectSlug: string,
+		connectorId: string,
+	): Promise<string> {
+		const res = await ctx.app.request(
+			`/api/projects/${projectSlug}/mcp-connections/${connectorId}/api-key`,
+			{
+				method: 'POST',
+				headers: { Authorization: `Bearer ${ctx.token}`, 'Content-Type': 'application/json' },
+				body: JSON.stringify({ value: `key_${Math.random().toString(36).slice(2)}` }),
+			},
+		);
+		return (await res.json()).data.api_key_secret_id as string;
+	}
+
+	it('qualifies a project-scoped connector credential with the project UUID fragment', async () => {
+		const ctx = await createTestApp();
+		const { projectSlug, projectId, connectorId } = await seedProjectConnector(ctx, 'namedmcp');
+		const secretId = await setApiKey(ctx, projectSlug, connectorId);
+		const secret = await ctx.db.query<{ name: string }>(`SELECT name FROM secrets WHERE id = $1`, [
+			secretId,
+		]);
+		const name = secret.rows[0].name;
+		const { validateSecretName } = await import('../src/lib/credential-placeholder');
+		expect(validateSecretName(name).valid).toBe(true);
+		expect(name).toBe(`MCP_NAMEDMCP_${projFrag(projectId)}`);
+		await safeClose(ctx.db);
+	});
+
+	it('gives two same-type connectors in different projects distinctly-named credentials', async () => {
+		const ctx = await createTestApp();
+		const a = await seedProjectConnector(ctx, 'shared');
+		const b = await seedProjectConnector(ctx, 'shared');
+		const nameA = (
+			await ctx.db.query<{ name: string }>(`SELECT name FROM secrets WHERE id = $1`, [
+				await setApiKey(ctx, a.projectSlug, a.connectorId),
+			])
+		).rows[0].name;
+		const nameB = (
+			await ctx.db.query<{ name: string }>(`SELECT name FROM secrets WHERE id = $1`, [
+				await setApiKey(ctx, b.projectSlug, b.connectorId),
+			])
+		).rows[0].name;
+		expect(nameA).not.toBe(nameB);
+		expect(nameA.endsWith(projFrag(a.projectId))).toBe(true);
+		expect(nameB.endsWith(projFrag(b.projectId))).toBe(true);
+		await safeClose(ctx.db);
+	});
+
+	it('leaves a global connector credential unqualified (no project fragment)', async () => {
+		const ctx = await createTestApp();
+		// Admin surface creates a global (project_id null) connector; the api-key
+		// route accepts it (project_id IS NULL) via any project path.
+		const created = await ctx.app.request(`/api/mcp-connections`, {
+			method: 'POST',
+			headers: { Authorization: `Bearer ${ctx.token}`, 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				name: 'globalmcp',
+				kind: 'saas',
+				config: { url: 'https://mcp.global.example/mcp' },
+				project_id: null,
+			}),
+		});
+		const connectorId = (await created.json()).data.id as string;
+		const co = await createTestTeam(ctx.db, { name: 'Any Proj' });
+		const projectSlug = await projectSlugFor(ctx.db, (await co.json()).data.id);
+		const secretId = await setApiKey(ctx, projectSlug, connectorId);
+		const name = (
+			await ctx.db.query<{ name: string }>(`SELECT name FROM secrets WHERE id = $1`, [secretId])
+		).rows[0].name;
+		expect(name).toBe('MCP_GLOBALMCP');
+		await safeClose(ctx.db);
+	});
+
+	it('the connector list surfaces the credential(s) it uses', async () => {
+		const ctx = await createTestApp();
+		const { projectSlug, connectorId } = await seedProjectConnector(ctx, 'listcreds');
+		const secretId = await setApiKey(ctx, projectSlug, connectorId);
+		const list = await ctx.app.request(`/api/projects/${projectSlug}/mcp-connections`, {
+			headers: { Authorization: `Bearer ${ctx.token}` },
+		});
+		const row = ((await list.json()).data as { id: string; credentials: { id: string }[] }[]).find(
+			(r) => r.id === connectorId,
+		);
+		expect(row?.credentials).toHaveLength(1);
+		expect(row?.credentials[0].id).toBe(secretId);
+		await safeClose(ctx.db);
+	});
+});
+
 describe('POST /teams/:teamId/connectors/ensure', () => {
 	it('creates a connector from the registry on first call, returns the same row on second', async () => {
 		const ctx = await createTestApp();

--- a/packages/web/src/components/related-items-list.tsx
+++ b/packages/web/src/components/related-items-list.tsx
@@ -1,0 +1,62 @@
+import type { ReactNode } from 'react';
+
+export interface RelatedItem {
+	key: string;
+	label: ReactNode;
+	/** When set, the row is a link to this href; otherwise it renders as plain text. */
+	href?: string;
+	title?: string;
+	testId?: string;
+}
+
+/**
+ * An indented, one-per-line list of items related to the row above it — the
+ * connectors that use a credential, or the credentials a connector uses. Each
+ * item is a deep-link (plain `<a href>`, matching the connector focus-link
+ * pattern in connect-required-comment.tsx) or plain text when no href is given
+ * (e.g. a credential shown to a non-superuser who can't open the credentials
+ * page). Render only when there is something to show.
+ */
+export function RelatedItemsList({
+	label,
+	items,
+	emptyLabel,
+	testId,
+}: {
+	label?: string;
+	items: RelatedItem[];
+	emptyLabel?: ReactNode;
+	testId?: string;
+}) {
+	return (
+		<div className="mt-1 pl-4 border-l border-border flex flex-col gap-0.5" data-testid={testId}>
+			{label && <span className="text-[11px] uppercase tracking-wide text-text-3">{label}</span>}
+			{items.length === 0 ? (
+				<span className="text-xs text-text-3">{emptyLabel ?? '—'}</span>
+			) : (
+				items.map((it) =>
+					it.href ? (
+						<a
+							key={it.key}
+							href={it.href}
+							title={it.title}
+							data-testid={it.testId}
+							className="text-xs text-text-2 hover:text-text-1 underline decoration-dotted underline-offset-2 truncate w-fit max-w-full"
+						>
+							{it.label}
+						</a>
+					) : (
+						<span
+							key={it.key}
+							title={it.title}
+							data-testid={it.testId}
+							className="text-xs text-text-2 truncate max-w-full"
+						>
+							{it.label}
+						</span>
+					),
+				)
+			)}
+		</div>
+	);
+}

--- a/packages/web/src/components/ui/data-table.tsx
+++ b/packages/web/src/components/ui/data-table.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { Fragment, type ReactNode, useCallback } from 'react';
 
 export interface Column<T> {
 	key: string;
@@ -19,6 +19,21 @@ interface DataTableProps<T> {
 	indentColumnKey?: string;
 	/** Extra class(es) applied per row — e.g. to fade finished (terminal) tasks. */
 	rowClassName?: (row: T) => string;
+	/**
+	 * Optional full-width block rendered as an extra row beneath each row (e.g. an
+	 * indented sub-list of related items). Return null/undefined to render nothing
+	 * for a given row; when it yields content the main row's bottom border is
+	 * dropped so the pair reads as one group. Receives the row's stable id so the
+	 * sub-row can carry a DOM anchor.
+	 */
+	subRow?: (row: T, rowId: string) => ReactNode;
+	/**
+	 * DOM id for each row's `<tr>` — enables `#<id>` hash anchoring and, together
+	 * with `focusedRowId`, a scroll-into-view + highlight for deep-linked rows.
+	 */
+	getRowId?: (row: T) => string;
+	/** When it matches a row's `getRowId`, that row scrolls into view + highlights. */
+	focusedRowId?: string;
 }
 
 const depthIndentClass: Record<number, string> = {
@@ -34,7 +49,16 @@ export function DataTable<T>({
 	getRowDepth,
 	indentColumnKey,
 	rowClassName,
+	subRow,
+	getRowId,
+	focusedRowId,
 }: DataTableProps<T>) {
+	// Ref callback fires when the focused row mounts (which can be after the first
+	// render, once data resolves) — scroll it into view then, mirroring the
+	// connectors list's focus behavior.
+	const focusRef = useCallback((el: HTMLTableRowElement | null) => {
+		if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+	}, []);
 	return (
 		<div className="overflow-x-auto -mx-4 px-4 sm:mx-0 sm:px-0">
 			<table className="w-full border-collapse">
@@ -56,32 +80,50 @@ export function DataTable<T>({
 				<tbody>
 					{data.map((row) => {
 						const depth = getRowDepth?.(row) ?? 0;
+						const id = rowKey(row);
+						const sub = subRow?.(row, id) ?? null;
+						const cellBorder = sub ? '' : 'border-b border-border';
+						const domId = getRowId?.(row);
+						const isFocused = domId != null && domId === focusedRowId;
 						return (
-							<tr
-								key={rowKey(row)}
-								data-depth={depth > 0 ? depth : undefined}
-								onClick={onRowClick ? () => onRowClick(row) : undefined}
-								className={`${onRowClick ? 'cursor-pointer hover:bg-surface-2' : ''} ${
-									rowClassName?.(row) ?? ''
-								}`.trim()}
-							>
-								{columns.map((col) => {
-									const indent =
-										indentColumnKey === col.key && depth > 0
-											? (depthIndentClass[depth] ?? depthIndentClass[2])
-											: '';
-									return (
+							<Fragment key={id}>
+								<tr
+									id={domId}
+									ref={isFocused ? focusRef : undefined}
+									data-depth={depth > 0 ? depth : undefined}
+									onClick={onRowClick ? () => onRowClick(row) : undefined}
+									className={`${onRowClick ? 'cursor-pointer hover:bg-surface-2' : ''} ${
+										isFocused ? 'bg-info-soft' : ''
+									} ${rowClassName?.(row) ?? ''}`.trim()}
+								>
+									{columns.map((col) => {
+										const indent =
+											indentColumnKey === col.key && depth > 0
+												? (depthIndentClass[depth] ?? depthIndentClass[2])
+												: '';
+										return (
+											<td
+												key={col.key}
+												className={`px-2 py-2.5 ${cellBorder} text-[13px] align-middle ${
+													col.hideOnMobile ? 'hidden md:table-cell ' : ''
+												}${indent ? `${indent} ` : ''}${col.className ?? ''}`}
+											>
+												{col.render(row)}
+											</td>
+										);
+									})}
+								</tr>
+								{sub && (
+									<tr>
 										<td
-											key={col.key}
-											className={`px-2 py-2.5 border-b border-border text-[13px] align-middle ${
-												col.hideOnMobile ? 'hidden md:table-cell ' : ''
-											}${indent ? `${indent} ` : ''}${col.className ?? ''}`}
+											colSpan={columns.length}
+											className="px-2 pb-2.5 border-b border-border align-top"
 										>
-											{col.render(row)}
+											{sub}
 										</td>
-									);
-								})}
-							</tr>
+									</tr>
+								)}
+							</Fragment>
 						);
 					})}
 				</tbody>

--- a/packages/web/src/hooks/use-instance-credentials.ts
+++ b/packages/web/src/hooks/use-instance-credentials.ts
@@ -8,7 +8,19 @@ import { queryClient } from '../lib/query-client';
 // they invalidate + refetch — never optimistic.
 export const INSTANCE_CREDENTIALS_KEY = ['instance', 'credentials'] as const;
 
-// A secret row joined with its most-recent egress-proxy usage from the audit log.
+// A connector that references a credential (its pasted API key, or the access
+// token of its OAuth connection). `project_id`/`project_slug` are null for a
+// global ("all projects") connector.
+export interface CredentialConnectorRef {
+	id: string;
+	name: string;
+	display_name: string | null;
+	project_id: string | null;
+	project_slug: string | null;
+}
+
+// A secret row joined with its most-recent egress-proxy usage from the audit log
+// and the connectors that use it.
 export interface CredentialUsage {
 	id: string;
 	name: string;
@@ -21,6 +33,7 @@ export interface CredentialUsage {
 	last_used_at: string | null;
 	use_count: number;
 	last_host: string | null;
+	connectors: CredentialConnectorRef[];
 }
 
 export interface InstanceSecret {

--- a/packages/web/src/hooks/use-mcp-connections.ts
+++ b/packages/web/src/hooks/use-mcp-connections.ts
@@ -30,6 +30,9 @@ export interface McpConnection {
 	/** Owning project's name/slug — populated only by the admin cross-project list. */
 	project_name?: string | null;
 	project_slug?: string | null;
+	/** The credential(s) this connector uses — its pasted API-key secret or the
+	 * access token of its OAuth connection. Populated by the list/detail routes. */
+	credentials?: { id: string; name: string }[];
 }
 
 export type ConnectorStatus = 'pending' | 'active' | 'failed' | 'revoked';

--- a/packages/web/src/routes/projects/$projectId/connectors.tsx
+++ b/packages/web/src/routes/projects/$projectId/connectors.tsx
@@ -4,14 +4,17 @@ import { Check, ExternalLink, Github, KeyRound, Plug, Trash2, X } from 'lucide-r
 import { useCallback, useState } from 'react';
 import { ConnectorApiKeyForm } from '../../../components/connector-api-key-form';
 import { ConnectorDeviceFlowDialog } from '../../../components/connector-device-flow-dialog';
+import { RelatedItemsList } from '../../../components/related-items-list';
 import { Badge } from '../../../components/ui/badge';
 import { Button } from '../../../components/ui/button';
+import { ConfirmDialog } from '../../../components/ui/confirm-dialog';
 import {
 	connectorStatus,
 	type McpConnection,
 	useMcpConnections,
 	useRevokeConnector,
 } from '../../../hooks/use-mcp-connections';
+import { useMe } from '../../../hooks/use-me';
 import {
 	type OAuthConnection,
 	useAuthStart,
@@ -97,14 +100,9 @@ function GitHubRow({ projectId, connection }: GitHubRowProps) {
 	const ensure = useEnsureConnector(projectId);
 	const [deviceConnectorId, setDeviceConnectorId] = useState<string | null>(null);
 	const [error, setError] = useState<string | null>(null);
+	const [confirmOpen, setConfirmOpen] = useState(false);
 	const status = connection ? 'active' : 'pending';
 	const connecting = ensure.isPending;
-
-	const doRevoke = () => {
-		if (!connection) return;
-		if (!window.confirm(`Remove ${connection.provider_account_label}?`)) return;
-		deleteConn.mutate(connection.id);
-	};
 
 	const startConnect = async () => {
 		setError(null);
@@ -164,7 +162,7 @@ function GitHubRow({ projectId, connection }: GitHubRowProps) {
 						<Button
 							size="sm"
 							variant="outline"
-							onClick={doRevoke}
+							onClick={() => setConfirmOpen(true)}
 							disabled={deleteConn.isPending}
 							data-testid="connector-revoke"
 						>
@@ -183,6 +181,25 @@ function GitHubRow({ projectId, connection }: GitHubRowProps) {
 					)}
 				</div>
 			</div>
+			{connection && (
+				<ConfirmDialog
+					open={confirmOpen}
+					onOpenChange={setConfirmOpen}
+					title="Disconnect GitHub?"
+					description={
+						<>
+							Remove the GitHub connection{' '}
+							<span className="font-mono">{connection.provider_account_label}</span>? Git operations
+							and the GitHub MCP server will stop working for this project.
+						</>
+					}
+					confirmLabel="Disconnect"
+					variant="danger"
+					onConfirm={async () => {
+						await deleteConn.mutateAsync(connection.id);
+					}}
+				/>
+			)}
 		</li>
 	);
 }
@@ -195,12 +212,18 @@ interface ConnectorRowProps {
 }
 
 function ConnectorRow({ connector, projectId, focused, focusRef }: ConnectorRowProps) {
+	const { data: me } = useMe();
 	const status = connectorStatus(connector);
 	const authStart = useAuthStart(projectId);
 	const revoke = useRevokeConnector(projectId);
 	const [error, setError] = useState<string | null>(null);
 	const [deviceOpen, setDeviceOpen] = useState(false);
 	const [showApiKey, setShowApiKey] = useState(false);
+	const [confirmOpen, setConfirmOpen] = useState(false);
+	const credentials = connector.credentials ?? [];
+	// The credentials page is superuser-only, so link there only for a superuser;
+	// members see the credential name as plain text.
+	const isSuperuser = !!me?.is_superuser;
 
 	const capability = getConnectorCapability(connector.name);
 	const usesDeviceFlow = !!capability?.deviceAuth;
@@ -233,17 +256,13 @@ function ConnectorRow({ connector, projectId, focused, focusRef }: ConnectorRowP
 		});
 	};
 
-	const doRevoke = () => {
+	const doRevoke = async () => {
 		setError(null);
-		if (
-			!window.confirm(
-				`Revoke ${connector.display_name ?? connector.name}? Agents will lose access immediately.`,
-			)
-		)
-			return;
-		revoke.mutate(connector.id, {
-			onError: (e: unknown) => setError(e instanceof Error ? e.message : 'Failed to revoke'),
-		});
+		try {
+			await revoke.mutateAsync(connector.id);
+		} catch (e) {
+			setError(e instanceof Error ? e.message : 'Failed to revoke');
+		}
 	};
 
 	return (
@@ -297,7 +316,7 @@ function ConnectorRow({ connector, projectId, focused, focusRef }: ConnectorRowP
 						<Button
 							size="sm"
 							variant="outline"
-							onClick={doRevoke}
+							onClick={() => setConfirmOpen(true)}
 							disabled={revoke.isPending}
 							data-testid="connector-revoke"
 						>
@@ -339,6 +358,21 @@ function ConnectorRow({ connector, projectId, focused, focusRef }: ConnectorRowP
 				</div>
 			)}
 
+			{credentials.length > 0 && (
+				<div className="mt-3">
+					<RelatedItemsList
+						label="Credentials"
+						testId={`connector-credentials-${connector.id}`}
+						items={credentials.map((cred) => ({
+							key: cred.id,
+							label: cred.name,
+							href: isSuperuser ? `/settings/credentials?focus=${cred.id}#${cred.id}` : undefined,
+							testId: `connector-credential-link-${cred.id}`,
+						}))}
+					/>
+				</div>
+			)}
+
 			{connector.created_by_task_id && (
 				<div className="mt-3 pt-3 border-t border-border text-xs text-text-2">
 					Requested by an agent.{' '}
@@ -351,6 +385,21 @@ function ConnectorRow({ connector, projectId, focused, focusRef }: ConnectorRowP
 					</Link>
 				</div>
 			)}
+
+			<ConfirmDialog
+				open={confirmOpen}
+				onOpenChange={setConfirmOpen}
+				title="Disconnect connector?"
+				description={
+					<>
+						Revoke <span className="font-medium">{connector.display_name ?? connector.name}</span>?
+						Agents will lose access immediately.
+					</>
+				}
+				confirmLabel="Disconnect"
+				variant="danger"
+				onConfirm={doRevoke}
+			/>
 		</li>
 	);
 }

--- a/packages/web/src/routes/settings/connectors.tsx
+++ b/packages/web/src/routes/settings/connectors.tsx
@@ -2,8 +2,10 @@ import { useQueryClient } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
 import { ChevronDown, Plus, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { RelatedItemsList } from '../../components/related-items-list';
 import { Badge } from '../../components/ui/badge';
 import { Button } from '../../components/ui/button';
+import { ConfirmDialog } from '../../components/ui/confirm-dialog';
 import { InPlaceForm } from '../../components/ui/in-place-form';
 import { InfoTooltip } from '../../components/ui/info-tooltip';
 import { Input } from '../../components/ui/input';
@@ -253,7 +255,9 @@ function InstanceConnectorRow({
 	const updateScope = useUpdateInstanceConnectorScope();
 	const [rowError, setRowError] = useState<string | null>(null);
 	const [rowInfo, setRowInfo] = useState<string | null>(null);
+	const [confirmOpen, setConfirmOpen] = useState(false);
 	const status = connectorStatus(connector);
+	const credentials = connector.credentials ?? [];
 
 	const url = typeof connector.config?.url === 'string' ? connector.config.url : '';
 	const scopeLabel = connector.project_id ? (connector.project_name ?? 'Project') : 'All projects';
@@ -354,11 +358,7 @@ function InstanceConnectorRow({
 					)}
 					<button
 						type="button"
-						onClick={() => {
-							if (confirm(`Remove connector "${connector.display_name || connector.name}"?`)) {
-								deleteConnector.mutate(connector.id);
-							}
-						}}
+						onClick={() => setConfirmOpen(true)}
 						aria-label="Remove"
 						className="text-text-3 hover:text-danger"
 					>
@@ -366,11 +366,40 @@ function InstanceConnectorRow({
 					</button>
 				</div>
 			</div>
+			{credentials.length > 0 && (
+				<RelatedItemsList
+					label="Credentials"
+					testId={`connector-credentials-${connector.id}`}
+					items={credentials.map((cred) => ({
+						key: cred.id,
+						label: cred.name,
+						href: `/settings/credentials?focus=${cred.id}#${cred.id}`,
+						testId: `connector-credential-link-${cred.id}`,
+					}))}
+				/>
+			)}
 			{connector.auth_error && status === 'failed' && (
 				<p className="text-xs text-danger mt-1">{connector.auth_error}</p>
 			)}
 			{rowError && <p className="text-xs text-danger mt-1">{rowError}</p>}
 			{rowInfo && <p className="text-xs text-text-3 mt-1">{rowInfo}</p>}
+			<ConfirmDialog
+				open={confirmOpen}
+				onOpenChange={setConfirmOpen}
+				title="Remove connector?"
+				description={
+					<>
+						Remove connector{' '}
+						<span className="font-medium">{connector.display_name || connector.name}</span>? Its
+						runs will lose access to this MCP server.
+					</>
+				}
+				confirmLabel="Remove"
+				variant="danger"
+				onConfirm={async () => {
+					await deleteConnector.mutateAsync(connector.id);
+				}}
+			/>
 		</div>
 	);
 }

--- a/packages/web/src/routes/settings/credentials.tsx
+++ b/packages/web/src/routes/settings/credentials.tsx
@@ -1,8 +1,10 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { Pencil, Plus, Trash2 } from 'lucide-react';
 import { useState } from 'react';
+import { RelatedItemsList } from '../../components/related-items-list';
 import { Badge } from '../../components/ui/badge';
 import { Button } from '../../components/ui/button';
+import { ConfirmDialog } from '../../components/ui/confirm-dialog';
 import { type Column, DataTable } from '../../components/ui/data-table';
 import { InPlaceForm } from '../../components/ui/in-place-form';
 import { InfoTooltip } from '../../components/ui/info-tooltip';
@@ -16,6 +18,7 @@ import {
 	useUpdateInstanceSecret,
 } from '../../hooks/use-instance-credentials';
 import { useMe } from '../../hooks/use-me';
+import { toast } from '../../hooks/use-toast';
 
 function formatRelative(iso: string | null): string {
 	if (!iso) return 'never';
@@ -31,6 +34,7 @@ function formatRelative(iso: string | null): string {
 
 function InstanceCredentialsPage() {
 	const { data: me } = useMe();
+	const { focus } = Route.useSearch();
 	const { data: rows = [] } = useInstanceCredentials();
 	const createSecret = useCreateInstanceSecret();
 	const updateSecret = useUpdateInstanceSecret();
@@ -39,6 +43,8 @@ function InstanceCredentialsPage() {
 	// `editing` null = the form (when open) creates; otherwise it edits that row.
 	const [showForm, setShowForm] = useState(false);
 	const [editing, setEditing] = useState<CredentialUsage | null>(null);
+	// The credential pending a revoke confirmation (drives the shared ConfirmDialog).
+	const [pendingDelete, setPendingDelete] = useState<CredentialUsage | null>(null);
 	const [name, setName] = useState('');
 	const [value, setValue] = useState('');
 	const [allowedHosts, setAllowedHosts] = useState('');
@@ -173,24 +179,38 @@ function InstanceCredentialsPage() {
 							<Pencil className="w-3.5 h-3.5" />
 						</button>
 					</Tooltip>
-					<Tooltip content="Revoke">
-						<button
-							type="button"
-							onClick={() => {
-								if (
-									confirm(
-										`Revoke instance credential "${r.name}"? Every team that references the placeholder will get an unknown_secret 400 from the proxy on the next outbound call.`,
-									)
-								) {
-									deleteSecret.mutate(r.id);
-								}
-							}}
-							aria-label={`Revoke ${r.name}`}
-							className="text-text-3 hover:text-danger"
+					{r.connectors.length > 0 ? (
+						<Tooltip
+							content={`In use by ${r.connectors.length} connector${
+								r.connectors.length === 1 ? '' : 's'
+							} — remove ${r.connectors.length === 1 ? 'it' : 'them'} first`}
 						>
-							<Trash2 className="w-3.5 h-3.5" />
-						</button>
-					</Tooltip>
+							{/* Wrapping span keeps the tooltip working over a disabled button. */}
+							<span className="inline-flex">
+								<button
+									type="button"
+									disabled
+									aria-label={`Revoke ${r.name} (in use)`}
+									data-testid={`credential-revoke-${r.id}`}
+									className="text-text-3 opacity-40 cursor-not-allowed"
+								>
+									<Trash2 className="w-3.5 h-3.5" />
+								</button>
+							</span>
+						</Tooltip>
+					) : (
+						<Tooltip content="Revoke">
+							<button
+								type="button"
+								onClick={() => setPendingDelete(r)}
+								aria-label={`Revoke ${r.name}`}
+								data-testid={`credential-revoke-${r.id}`}
+								className="text-text-3 hover:text-danger"
+							>
+								<Trash2 className="w-3.5 h-3.5" />
+							</button>
+						</Tooltip>
+					)}
 				</span>
 			),
 		},
@@ -301,14 +321,73 @@ function InstanceCredentialsPage() {
 						No instance credentials yet. Add one above to share it across every team.
 					</p>
 				) : (
-					<DataTable columns={columns} data={rows} rowKey={(row) => row.id} />
+					<DataTable
+						columns={columns}
+						data={rows}
+						rowKey={(row) => row.id}
+						getRowId={(row) => row.id}
+						focusedRowId={focus}
+						subRow={(r) =>
+							r.connectors.length > 0 ? (
+								<RelatedItemsList
+									label="Used by"
+									testId={`credential-connectors-${r.id}`}
+									items={r.connectors.map((conn) => ({
+										key: conn.id,
+										label: `${conn.display_name || conn.name} · ${
+											conn.project_slug ?? 'all projects'
+										}`,
+										href: `/settings/connectors?focus=${conn.id}#${conn.id}`,
+										testId: `credential-connector-link-${conn.id}`,
+									}))}
+								/>
+							) : null
+						}
+					/>
 				)}
 			</>
 		);
 
-	return <div className="max-w-[900px]">{content}</div>;
+	return (
+		<div className="max-w-[900px]">
+			{content}
+			<ConfirmDialog
+				open={pendingDelete !== null}
+				onOpenChange={(open) => {
+					if (!open) setPendingDelete(null);
+				}}
+				title="Revoke credential?"
+				description={
+					pendingDelete ? (
+						<>
+							Revoke instance credential <span className="font-mono">{pendingDelete.name}</span>?
+							Every team that references the placeholder will get an unknown_secret 400 from the
+							proxy on the next outbound call.
+						</>
+					) : undefined
+				}
+				confirmLabel="Revoke"
+				variant="danger"
+				onConfirm={async () => {
+					if (!pendingDelete) return;
+					try {
+						await deleteSecret.mutateAsync(pendingDelete.id);
+					} catch (e) {
+						toast.error(e instanceof Error ? e.message : 'Failed to revoke credential');
+					}
+				}}
+			/>
+		</div>
+	);
+}
+
+interface CredentialsSearch {
+	focus?: string;
 }
 
 export const Route = createFileRoute('/settings/credentials')({
+	validateSearch: (search: Record<string, unknown>): CredentialsSearch => ({
+		focus: typeof search.focus === 'string' ? search.focus : undefined,
+	}),
 	component: InstanceCredentialsPage,
 });

--- a/packages/web/test/connectors-page.test.tsx
+++ b/packages/web/test/connectors-page.test.tsx
@@ -1,5 +1,5 @@
 import { createGitHubSim, type GitHubSim } from '@hezo/server/test/helpers/github-sim';
-import { waitFor, within } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import { afterEach, expect, test, vi } from 'vitest';
 import { getTestContext, renderApp } from './helpers/render';
 import { type SeededWorkspace, seedWorkspace } from './helpers/seed';
@@ -141,7 +141,6 @@ test('shows the empty-state hint when there are no connectors or OAuth connectio
 });
 
 test('GitHub row renders the connected state and disconnects', async () => {
-	window.confirm = () => true;
 	let slug = '';
 	const { findByText, findByTestId, queryByText, router } = await renderApp({
 		initialPath: '/',
@@ -159,9 +158,11 @@ test('GitHub row renders the connected state and disconnects', async () => {
 	await findByText('octocat');
 	await findByText(/repo workflow read:org/);
 
-	// Disconnect calls DELETE /oauth-connections/:id then invalidates the list.
+	// Disconnect opens the shared confirm dialog; confirming calls DELETE
+	// /oauth-connections/:id then invalidates the list.
 	const disconnect = (await findByTestId('connector-revoke')) as HTMLButtonElement;
 	disconnect.click();
+	(await screen.findByTestId('confirm-dialog-confirm')).click();
 
 	// After deletion the row falls back to the disconnected ("Connect") state.
 	await findByTestId('connector-connect');
@@ -202,7 +203,6 @@ test('Connect on a redirect (non-device) connector surfaces the popup-blocked er
 });
 
 test('an active non-GitHub connector renders Disconnect and revokes', async () => {
-	window.confirm = () => true;
 	let slug = '';
 	const { findByText, getByTestId, findByTestId, router } = await renderApp({
 		initialPath: '/',
@@ -231,6 +231,7 @@ test('an active non-GitHub connector renders Disconnect and revokes', async () =
 
 	const revoke = within(linearRow).getByTestId('connector-revoke');
 	revoke.click();
+	(await screen.findByTestId('confirm-dialog-confirm')).click();
 
 	// Revoke (POST .../revoke → markRevoked) flips the row to revoked; the list
 	// re-renders with the revoked status badge.

--- a/packages/web/test/credential-connector-relationships.test.tsx
+++ b/packages/web/test/credential-connector-relationships.test.tsx
@@ -1,0 +1,135 @@
+import { screen, waitFor } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { getTestContext, renderApp } from './helpers/render';
+import { seedWorkspace } from './helpers/seed';
+
+// Insert a global credential straight into the vault (value never decrypted by
+// the list views under test).
+async function seedSecret(name: string): Promise<string> {
+	const { db } = getTestContext();
+	const r = await db.query<{ id: string }>(
+		`INSERT INTO secrets (name, encrypted_value, category, allowed_hosts)
+		 VALUES ($1, 'enc', 'api_token', ARRAY['mcp.rel.example']) RETURNING id`,
+		[name],
+	);
+	return r.rows[0].id;
+}
+
+// Insert a project-scoped connector whose api_key_secret_id points at `secretId`.
+async function seedProjectConnectorUsing(
+	secretId: string,
+): Promise<{ connectorId: string; projectSlug: string }> {
+	const { db } = getTestContext();
+	const suffix = Math.random().toString(36).slice(2, 8);
+	const team = await db.query<{ id: string }>(
+		`INSERT INTO teams (name, slug) VALUES ($1, $2) RETURNING id`,
+		[`Rel ${suffix}`, `rel-${suffix}`],
+	);
+	const proj = await db.query<{ id: string; slug: string }>(
+		`INSERT INTO projects (team_id, name, slug, task_prefix, docker_base_image, container_status)
+		 VALUES ($1, $2, $3, 'RP', 'hezo/agent-base:latest', NULL) RETURNING id, slug`,
+		[team.rows[0].id, `Rel Proj ${suffix}`, `rel-proj-${suffix}`],
+	);
+	const conn = await db.query<{ id: string }>(
+		`INSERT INTO mcp_connections (name, display_name, kind, config, install_status, project_id, api_key_secret_id, activated_at)
+		 VALUES ($1, 'Rel Connector', 'saas', '{"url":"https://mcp.rel.example/mcp"}'::jsonb, 'installed', $2, $3, now())
+		 RETURNING id`,
+		[`rel-conn-${suffix}`, proj.rows[0].id, secretId],
+	);
+	return { connectorId: conn.rows[0].id, projectSlug: proj.rows[0].slug };
+}
+
+test('credentials page lists the connectors using a credential and deep-links to them', async () => {
+	let connectorId = '';
+	const { findByText, findByTestId } = await renderApp({
+		initialPath: '/settings/credentials',
+		seed: async () => {
+			const secretId = await seedSecret('MCP_LINKED_ABCDE');
+			({ connectorId } = await seedProjectConnectorUsing(secretId));
+		},
+	});
+
+	await findByText('MCP_LINKED_ABCDE');
+	const link = (await findByTestId(
+		`credential-connector-link-${connectorId}`,
+	)) as HTMLAnchorElement;
+	expect(link.getAttribute('href')).toBe(
+		`/settings/connectors?focus=${connectorId}#${connectorId}`,
+	);
+});
+
+test('a credential in use cannot be revoked; a free one revokes via the confirm dialog', async () => {
+	let inUseId = '';
+	let freeId = '';
+	const { findByText, getByTestId, queryByText, user } = await renderApp({
+		initialPath: '/settings/credentials',
+		seed: async () => {
+			inUseId = await seedSecret('MCP_INUSE_KEY');
+			await seedProjectConnectorUsing(inUseId);
+			freeId = await seedSecret('MCP_FREE_KEY');
+		},
+	});
+
+	await findByText('MCP_INUSE_KEY');
+	await findByText('MCP_FREE_KEY');
+
+	// In use → the revoke control is disabled (the tooltip explains why).
+	const disabled = getByTestId(`credential-revoke-${inUseId}`) as HTMLButtonElement;
+	expect(disabled.disabled).toBe(true);
+
+	// Free → revoke opens the shared confirm dialog; confirming deletes the row.
+	const enabled = getByTestId(`credential-revoke-${freeId}`) as HTMLButtonElement;
+	expect(enabled.disabled).toBe(false);
+	await user.click(enabled);
+	// The dialog renders into a Radix portal on document.body — query via screen.
+	await screen.findByTestId('confirm-dialog');
+	await user.click(screen.getByTestId('confirm-dialog-confirm'));
+	await waitFor(() => expect(queryByText('MCP_FREE_KEY')).toBeNull());
+});
+
+test('instance connectors page lists the credential a connector uses and links to it', async () => {
+	let secretId = '';
+	const { findByTestId } = await renderApp({
+		initialPath: '/settings/connectors',
+		seed: async () => {
+			secretId = await seedSecret('MCP_CONNCRED_ABCDE');
+			await seedProjectConnectorUsing(secretId);
+		},
+	});
+
+	const link = (await findByTestId(`connector-credential-link-${secretId}`)) as HTMLAnchorElement;
+	expect(link.getAttribute('href')).toBe(`/settings/credentials?focus=${secretId}#${secretId}`);
+});
+
+test('project connectors page links a connector to the credential it uses', async () => {
+	let slug = '';
+	let secretId = '';
+	const { findByText, findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async (ctx) => {
+			const ws = await seedWorkspace();
+			slug = ws.internalSlug;
+			const created = await ctx.apiBase(`/api/projects/${ws.internalSlug}/mcp-connections`, {
+				method: 'POST',
+				headers: ws.headers,
+				body: JSON.stringify({
+					name: 'projcred',
+					kind: 'saas',
+					config: { url: 'https://mcp.p.example/mcp' },
+				}),
+			});
+			const conn = (await created.json()).data as { id: string };
+			const keyed = await ctx.apiBase(
+				`/api/projects/${ws.internalSlug}/mcp-connections/${conn.id}/api-key`,
+				{ method: 'POST', headers: ws.headers, body: JSON.stringify({ value: 'k' }) },
+			);
+			secretId = (await keyed.json()).data.api_key_secret_id as string;
+		},
+	});
+
+	await router.navigate({ to: '/projects/$projectId/connectors', params: { projectId: slug } });
+	await findByText('projcred');
+	const link = (await findByTestId(`connector-credential-link-${secretId}`)) as HTMLAnchorElement;
+	// The admin (superuser) sees a link to the global credentials page.
+	expect(link.getAttribute('href')).toBe(`/settings/credentials?focus=${secretId}#${secretId}`);
+});


### PR DESCRIPTION
## What & why

You couldn't tell, from either page, which MCP connectors used a given credential or which credential a connector depended on. This adds that relationship in both directions, names auto-created connector credentials after their project so a global credential list stays legible, and prevents deleting a credential that's still wired to a connector.

Credentials remain **global** (one shared vault, name globally unique, resolved by the egress proxy by name). Connectors keep their existing project scope; a credential does **not** follow a connector between scopes — instead the credential's *name* carries the project signal.

## Changes

**Backend**
- `GET /api/credentials` returns, per credential, the `connectors` that use it (id, name, display_name, project_id, project_slug).
- Connector list + detail responses return the `credentials` each connector uses. Relation `R`: a connector's pasted API-key secret **or** the access token of its OAuth connection — used symmetrically both directions and by the delete guard.
- Auto-created API-key credential names: `MCP_<CONNECTOR>_<PROJFRAG>` for a project-scoped connector (`PROJFRAG` = first 5 hex of the project UUID, uppercased), `MCP_<CONNECTOR>` for a global one. Two same-type connectors in different projects now get distinctly-named credentials. New credentials only — existing secrets are never renamed. (OAuth token names already carry a per-connection id fragment, so they're left unchanged.)
- `DELETE /api/secrets/:id` returns `409 IN_USE` when a connector references the credential.

**Frontend**
- New shared `RelatedItemsList` renders the indented, deep-linked sub-list used on both sides; `DataTable` gains an optional `subRow` plus row `id`/focus-anchor support.
- Credentials page (`/settings/credentials`): connectors sub-list under each credential (deep-links to `/settings/connectors?focus=…#…`), `?focus` anchor support, and an in-use revoke button that's disabled with an explanatory tooltip.
- Instance + project connector pages: credential sub-list under each connector (deep-links to the credentials page; on the project page a member sees the name as plain text since that page is superuser-only).
- Connector and credential deletions now go through the existing shared `ConfirmDialog` instead of `window.confirm`.

**Docs**
- `.dev/architecture.md` and `docs/mcp/connecting-mcp-servers.md` updated (relationship display, naming convention, delete guard).

## Testing
- Server: extended `instance-secrets.test.ts` (connectors array in `GET /credentials`, 409 delete guard) and `mcp-connections.test.ts` (project-fragment naming, distinct names across projects, unqualified global name, connector `credentials` array).
- Web: new `credential-connector-relationships.test.tsx` (both sub-lists + deep-link hrefs, disabled-revoke tooltip, confirm-dialog delete); updated `connectors-page.test.tsx` for the `ConfirmDialog` switch.
- Full web component tier (1071 tests) green; typecheck + `biome check` clean; generated-surface drift tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RM61GT5ekxdj9QyNsCdKRN)_