### PR TITLE
Scope skills per-project or global (like Connectors)

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -263,9 +263,20 @@ that *produced* it (a one-step shift, since revisions snapshot prior content), s
 head's changelog is the newest revision's `change_summary`. Selecting an older revision renders it
 read-only with the review layer suppressed — review comments exist only for the latest content —
 under a "viewing revision N" banner. Restore stays admin-only (agents 403 on the REST route; no
-MCP restore tool). `skills` is the
-instance/team reference store (manifest-injected into runs, full-text-searchable) with
-`skill_revisions` history. `assets` + `task_attachments`/`comment_attachments` handle
+MCP restore tool). `skills` is the reusable-know-how reference store
+(manifest-injected into runs, full-text-searchable) with `skill_revisions` history. Each skill is
+**scoped** by a nullable `skills.project_id` (mirrors `mcp_connections`, migration 024): **NULL =
+global** (shared with every project), a **non-NULL project id = private to that project**. Slug
+uniqueness is partitioned into two partial unique indexes (`(slug) WHERE project_id IS NULL` +
+`(project_id, slug) WHERE project_id IS NOT NULL`), so the same slug can exist once globally and
+once per project, and a project skill **shadows** a global one of the same slug within that project.
+Run-time reads (the `{{skills_context}}` manifest, `list_skills`/`get_skill`, full-text search,
+mention resolution) return the run's project skills plus globals, de-duped so the project's copy
+wins. Skills authored during a run (`create_skill`/`fetch_skill_file`/`propose_skill`) carry a
+`scope` the agent chooses (`global`|`project`), defaulting to **project**. The admin manages the
+whole catalog and re-scopes rows at `/settings/skills` (id-addressed `/api/skills` routes); a
+per-project page (`/projects/:projectId/skills`, any project member) lists that project's skills
+plus globals and edits/removes only the project's own. `assets` + `task_attachments`/`comment_attachments` handle
 uploaded files (blobs in the configured **asset store** keyed by `projectId/assetId` — see
 § Asset storage below — served over HMAC-signed URLs with
 `nosniff` and a basename-only download filename); agents can also author text-based assets

--- a/docs/concepts/documents-and-memory.md
+++ b/docs/concepts/documents-and-memory.md
@@ -19,8 +19,8 @@ the agents as they work:
   reads to catch up on what's happened.
 - **Per project** — the **Documents** library of PRDs, specs, and research the whole team
   keeps coming back to.
-- **Global** — [skills](/docs/concepts/skills), the reusable know-how every team can
-  reach for.
+- **Global or per-project** — [skills](/docs/concepts/skills), reusable know-how that is
+  either shared with every project or scoped to one.
 - **Per team** — [preferences](#team-preferences): custom instructions applied to every
   agent on a team.
 - **The CEO's** — its [long-term chat memory](#long-term-chat-memory) of your standing
@@ -49,7 +49,7 @@ cached to go stale. Context reaches the agent in one of two ways:
 | Progress summary | One task | In full, every run | You and agents |
 | Comment thread | One task | Read by the agent at the start of a run | You and agents |
 | Project documents | One project | Manifest, full text on demand | You and agents |
-| Skills | Whole instance | Manifest, full text on demand | You and agents |
+| Skills | Global or one project | Manifest, full text on demand | You and agents |
 | Team preferences | One team | In full, every run | You |
 | Long-term chat memory | The CEO | In full, every chat turn | The CEO (automatically) and you |
 

--- a/docs/concepts/skills.md
+++ b/docs/concepts/skills.md
@@ -6,33 +6,54 @@ section: Concepts
 
 # Skills
 
-**Skills** are reusable, project-independent know-how you give your agents — a standard
-operating procedure written once and shared with every team. Where a
+**Skills** are reusable know-how you give your agents — a standard operating procedure
+written once and reached for whenever it's relevant. Where a
 [project document](/docs/concepts/documents-and-memory) is knowledge *about one project*,
-a skill is a *portable capability* any agent on any team can draw on: how to use a
-particular MCP server, your commit conventions, a release checklist, a house style for
-research write-ups.
+a skill is a *portable capability* an agent can draw on: how to use a particular MCP server,
+your commit conventions, a release checklist, a house style for research write-ups.
 
-## Instance-global by design
-
-There is **one skills catalog for the whole instance**. A skill you add is available to
-every team's agents — you don't re-create it per project. Each skill is a markdown
-document with a name, a short description, and optional tags. On every run agents are given
-a **manifest** of the available skills — each one's name and description, not its full body
-— so they know what they can reach for; an agent then loads a skill's full instructions
-on demand when it's relevant to the task. That manifest-plus-load-on-demand pattern is part
-of how Hezo gives agents [long-term memory](/docs/concepts/documents-and-memory#what-an-agent-carries-into-every-run)
+Each skill is a markdown document with a name, a short description, and optional tags. On
+every run agents are given a **manifest** of the skills available to that run — each one's
+name and description, not its full body — so they know what they can reach for; an agent then
+loads a skill's full instructions on demand when it's relevant to the task. That
+manifest-plus-load-on-demand pattern is part of how Hezo gives agents
+[long-term memory](/docs/concepts/documents-and-memory#what-an-agent-carries-into-every-run)
 without bloating every prompt.
+
+## Global and project scope
+
+Every skill is either **global** or **scoped to one project**:
+
+- **Global** skills are shared with every project — the right home for know-how any agent
+  might need (a widely-used tool's usage, a general technique).
+- **Project** skills are private to a single project — its particular deployment steps, its
+  own conventions, a runbook only that project needs.
+
+A run sees its own project's skills **plus** all global ones; if a project skill and a global
+skill share the same slug, the project's copy takes precedence for that project. This keeps
+each project's manifest focused while still letting broadly-useful know-how reach everyone.
 
 ## Where skills come from
 
-- **Author them yourself.** Open **Settings → Skills** and write one directly. The editor
+- **Author them yourself.** Open **Settings → Skills** — the global Skills page — and write
+  one directly, choosing its scope (global, or a specific project) as you add it. The editor
   previews the markdown as you go.
 - **Search and add from [skills.sh](https://skills.sh).** With a skills.sh token
   configured, search the public registry and install a skill straight into your catalog.
 - **Let agents contribute.** While working, an agent can add a skill directly
   (`create_skill`) or, when you'd rather review first, file one for your approval
-  (`propose_skill`) — the proposal lands in your inbox like any other approval.
+  (`propose_skill`) — the proposal lands in your inbox like any other approval. The agent
+  chooses whether the new skill is global or project-scoped, and defaults to the current
+  project when it doesn't say.
+
+## Managing scope
+
+The global **Settings → Skills** page lists **every** skill — global and each project's —
+and each row has a scope drop-down so you can move a skill between global and any project (it
+works just like the [Connectors](/docs/mcp/connecting-mcp-servers) page). Each project also has its
+own **Skills** page, under **Connectors** in the project's settings menu, showing that
+project's skills plus the globals; you can edit or remove the project's own skills there,
+while global ones are shown for reference and stay managed on the global page.
 
 Skills are part of what the [Coach](/docs/concepts/coach-and-self-improving-teams) can
 write to: when a retrospective surfaces a reusable procedure, it may capture it as a skill

--- a/docs/reference/mcp-api.md
+++ b/docs/reference/mcp-api.md
@@ -737,7 +737,7 @@ Approve or deny an approval
 
 _Write tool._
 
-Propose a new skill for the team's skills database (reusable team know-how: MCP server usage, integration steps, conventions, how agents coordinate). Creates an approval request; when approved the skill is written to the skills database.
+Propose a new skill for the team's skills database (reusable team know-how: MCP server usage, integration steps, conventions, how agents coordinate). Creates an approval request; when approved the skill is written to the skills database. Choose `scope`: 'global' shares it with every project, 'project' keeps it private to this project. Defaults to 'project'.
 
 **Parameters:**
 
@@ -748,6 +748,7 @@ Propose a new skill for the team's skills database (reusable team know-how: MCP 
 | `skill_slug` | `string` | Yes | URL-safe slug for the skill file |
 | `content` | `string` | Yes | Skill content (markdown) |
 | `reason` | `string` | Yes | Why this skill should be added |
+| `scope` | `project` \| `global` | No | 'global' shares the skill with every project; 'project' keeps it private to this project. Defaults to 'project'. |
 
 **Returns:** `{ approval_id, status }` — creates a skill-proposal approval that writes the skill when approved.
 
@@ -802,7 +803,7 @@ Load the full body of a skill from the team's skills database by slug. Use after
 
 _Write tool._
 
-Add or update a skill in the team's skills database directly (no approval needed) — record reusable team know-how such as MCP server usage, integration steps, conventions, and how agents coordinate. Use propose_skill when approval is required. If description is omitted it is derived from the skill body.
+Add or update a skill in the team's skills database directly (no approval needed) — record reusable team know-how such as MCP server usage, integration steps, conventions, and how agents coordinate. Use propose_skill when approval is required. If description is omitted it is derived from the skill body. Choose `scope` deliberately: 'global' when the know-how helps agents in ANY project (related or not), 'project' when it is specific to this project. Omitting scope defaults to 'project'.
 
 **Parameters:**
 
@@ -814,6 +815,7 @@ Add or update a skill in the team's skills database directly (no approval needed
 | `content` | `string` | Yes | Skill content (markdown) |
 | `description` | `string` | No | Short description |
 | `tags` | `string` | No | Comma-separated tags |
+| `scope` | `project` \| `global` | No | 'global' shares the skill with every project; 'project' keeps it private to this project. Defaults to 'project'. |
 
 **Returns:** `{ skill_id, slug, created: true }`. Upserts by `slug` and writes a skill revision; `description` is derived from the body when omitted.
 
@@ -865,7 +867,7 @@ Register a third-party MCP server connector for the team and ask the human to au
 
 _Read-only._
 
-Fetch a remote agent skill file (Markdown describing how to use a third-party MCP server) and store it as a global skill (auto_load). Returns the skill_id and slug. Subsequent agent runs across every team get this skill file injected into their adapter's skills directory. Idempotent on the derived slug — re-fetching the same URL updates the existing skill.
+Fetch a remote agent skill file (Markdown describing how to use a third-party MCP server) and store it as a skill (auto_load). Returns the skill_id and slug. Subsequent agent runs get this skill file injected into their adapter's skills directory. Idempotent on the derived slug — re-fetching the same URL updates the existing skill. Choose `scope`: 'global' shares it with every project (e.g. a widely-used MCP's usage docs), 'project' keeps it private to this project. Defaults to 'project'.
 
 **Parameters:**
 
@@ -874,6 +876,7 @@ Fetch a remote agent skill file (Markdown describing how to use a third-party MC
 | `project` | `string` | No | Project slug or ID. Omit to use the project your run is already in; instance agents (CEO/Coach) must name the project to act in. |
 | `url` | `string` | Yes | HTTPS URL of the skill file. Only http/https schemes are allowed; response must be < 256KB; 10s timeout. |
 | `title` | `string` | No | Human-readable title shown in the team KB. Defaults to the URL pathname. |
+| `scope` | `project` \| `global` | No | 'global' shares the skill with every project; 'project' keeps it private to this project. Defaults to 'project'. |
 
 **Returns:** `{ skill_id, slug, source_url, size_bytes, reused }`, or `{ error }` (invalid URL, non-HTTP(S), over 256 KB, or fetch failure). Stored as an auto-load global skill; idempotent on the derived slug.
 

--- a/packages/server/migrations/024_scope_skills_per_project.sql
+++ b/packages/server/migrations/024_scope_skills_per_project.sql
@@ -1,0 +1,26 @@
+-- Skills were instance-global: one reusable-skill catalog shared with every
+-- project's runs. Real deployments run multiple projects whose know-how should
+-- not always cross — a deploy/runbook skill authored while working project A is
+-- usually specific to A, not something every other project's agents should see.
+-- Scope skills by project exactly like MCP connectors (018): a non-NULL
+-- project_id makes a skill private to that project; NULL keeps the historical
+-- global ("all projects") semantics — the instance-admin /settings/skills
+-- surface and every pre-existing row. A project-scoped skill shadows a global
+-- skill of the same slug within that project.
+
+ALTER TABLE skills
+    ADD COLUMN project_id UUID REFERENCES projects(id) ON DELETE CASCADE;
+
+-- Replace the global unique key with project-partitioned ones. NULL project_id
+-- keeps a single global namespace; non-NULL gets a per-project namespace, so the
+-- same slug can exist once globally and once per project (and two projects can
+-- each author their own "deploy" skill without colliding). Every existing skill
+-- stays global (project_id NULL), so no row can pre-exist to violate the new
+-- partial indexes.
+ALTER TABLE skills DROP CONSTRAINT IF EXISTS skills_slug_key;
+CREATE UNIQUE INDEX idx_skills_global_slug
+    ON skills (slug) WHERE project_id IS NULL;
+CREATE UNIQUE INDEX idx_skills_project_slug
+    ON skills (project_id, slug) WHERE project_id IS NOT NULL;
+
+CREATE INDEX idx_skills_project ON skills (project_id) WHERE project_id IS NOT NULL;

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -301,8 +301,9 @@ async function buildBacktickedEntityWarning(
 		);
 		for (const row of docs.rows) refs.push(row.slug);
 		const kb = await db.query<{ slug: string }>(
-			`SELECT slug FROM skills WHERE LOWER(slug) = ANY($1::text[])`,
-			[candidates.filenames.map((f) => f.toLowerCase())],
+			`SELECT slug FROM skills
+			 WHERE LOWER(slug) = ANY($1::text[]) AND (project_id = $2 OR project_id IS NULL)`,
+			[candidates.filenames.map((f) => f.toLowerCase()), projectId],
 		);
 		for (const row of kb.rows) refs.push(row.slug);
 	}
@@ -404,7 +405,7 @@ async function markRunReportedNoWork(db: Db, runId: string, reason: string): Pro
 const TASK_COLUMNS = TASK_COLUMNS_BARE.replace(/[A-Za-z_][A-Za-z_0-9]*/g, 'i.$&');
 
 const SKILL_COLUMNS = `id, name, slug, description, content, source_url,
-	content_hash, created_by_member_id, tags, is_active, auto_load, created_at, updated_at`;
+	content_hash, created_by_member_id, project_id, tags, is_active, auto_load, created_at, updated_at`;
 
 const APPROVAL_COLUMNS = `id, team_id, type, status, requested_by_member_id,
 	resolution_note, resolved_at, created_at, payload`;
@@ -2704,7 +2705,7 @@ export function registerTools(
 	tool(
 		server,
 		'fetch_skill_file',
-		"Fetch a remote agent skill file (Markdown describing how to use a third-party MCP server) and store it as a global skill (auto_load). Returns the skill_id and slug. Subsequent agent runs across every team get this skill file injected into their adapter's skills directory. Idempotent on the derived slug — re-fetching the same URL updates the existing skill.",
+		"Fetch a remote agent skill file (Markdown describing how to use a third-party MCP server) and store it as a skill (auto_load). Returns the skill_id and slug. Subsequent agent runs get this skill file injected into their adapter's skills directory. Idempotent on the derived slug — re-fetching the same URL updates the existing skill. Choose `scope`: 'global' shares it with every project (e.g. a widely-used MCP's usage docs), 'project' keeps it private to this project. Defaults to 'project'.",
 		{
 			project: projectArg(),
 			url: z
@@ -2716,6 +2717,12 @@ export function registerTools(
 				.string()
 				.optional()
 				.describe('Human-readable title shown in the team KB. Defaults to the URL pathname.'),
+			scope: z
+				.enum(['project', 'global'])
+				.optional()
+				.describe(
+					"'global' shares the skill with every project; 'project' keeps it private to this project. Defaults to 'project'.",
+				),
 		},
 		async (args, db, auth) => {
 			const scope = await resolveScope(db, auth, args);
@@ -2768,19 +2775,24 @@ export function registerTools(
 			const title = (args.title as string | undefined) ?? parsed.pathname;
 
 			const authorMemberId = auth.type === AuthType.Agent ? auth.memberId : null;
+			const targetProjectId = args.scope === 'global' ? null : scope.projectId;
 			const { createHash } = await import('node:crypto');
 			const contentHash = createHash('sha256').update(body).digest('hex');
 			const description = deriveSkillSummary(body);
 
-			const existing = await db.query<{ id: string }>('SELECT id FROM skills WHERE slug = $1', [
-				slug,
-			]);
-			// Global skill, flagged auto_load so the runner writes it to
-			// ~/.claude/skills for every run. Idempotent on slug.
+			const existing = await db.query<{ id: string }>(
+				'SELECT id FROM skills WHERE slug = $1 AND project_id IS NOT DISTINCT FROM $2',
+				[slug, targetProjectId],
+			);
+			// Flagged auto_load so the runner writes it to ~/.claude/skills for every
+			// (scoped) run. Idempotent on slug within the chosen scope.
+			const conflictTarget = targetProjectId
+				? '(project_id, slug) WHERE project_id IS NOT NULL'
+				: '(slug) WHERE project_id IS NULL';
 			const upserted = await db.query<{ id: string; slug: string }>(
-				`INSERT INTO skills (name, slug, description, content, source_url, content_hash, created_by_member_id, tags, auto_load)
-				 VALUES ($1, $2, $3, $4, $5, $6, $7, '[]'::jsonb, true)
-				 ON CONFLICT (slug) DO UPDATE SET
+				`INSERT INTO skills (name, slug, description, content, source_url, content_hash, created_by_member_id, tags, auto_load, project_id)
+				 VALUES ($1, $2, $3, $4, $5, $6, $7, '[]'::jsonb, true, $8)
+				 ON CONFLICT ${conflictTarget} DO UPDATE SET
 				   name = EXCLUDED.name,
 				   description = EXCLUDED.description,
 				   content = EXCLUDED.content,
@@ -2789,12 +2801,13 @@ export function registerTools(
 				   auto_load = true,
 				   updated_at = now()
 				 RETURNING id, slug`,
-				[title, slug, description, body, url, contentHash, authorMemberId],
+				[title, slug, description, body, url, contentHash, authorMemberId, targetProjectId],
 			);
 
 			return {
 				skill_id: upserted.rows[0].id,
 				slug: upserted.rows[0].slug,
+				scope: targetProjectId ? 'project' : 'global',
 				source_url: url,
 				size_bytes: body.length,
 				reused: existing.rows.length > 0,
@@ -4186,13 +4199,19 @@ export function registerTools(
 	tool(
 		server,
 		'propose_skill',
-		"Propose a new skill for the team's skills database (reusable team know-how: MCP server usage, integration steps, conventions, how agents coordinate). Creates an approval request; when approved the skill is written to the skills database.",
+		"Propose a new skill for the team's skills database (reusable team know-how: MCP server usage, integration steps, conventions, how agents coordinate). Creates an approval request; when approved the skill is written to the skills database. Choose `scope`: 'global' shares it with every project, 'project' keeps it private to this project. Defaults to 'project'.",
 		{
 			project: projectArg(),
 			skill_name: z.string().describe('Human-readable skill name'),
 			skill_slug: z.string().describe('URL-safe slug for the skill file'),
 			content: z.string().describe('Skill content (markdown)'),
 			reason: z.string().describe('Why this skill should be added'),
+			scope: z
+				.enum(['project', 'global'])
+				.optional()
+				.describe(
+					"'global' shares the skill with every project; 'project' keeps it private to this project. Defaults to 'project'.",
+				),
 		},
 		async (args, db, auth) => {
 			const scope = await resolveScope(db, auth, args);
@@ -4212,6 +4231,7 @@ export function registerTools(
 						skill_slug: args.skill_slug,
 						content: args.content,
 						reason: args.reason,
+						scope: args.scope === 'global' ? 'global' : 'project',
 					}),
 				],
 			);
@@ -4266,19 +4286,28 @@ export function registerTools(
 			const scope = await resolveScope(db, auth, args);
 			if ('error' in scope) return scope;
 
-			let query = `SELECT id, name, slug, description, tags, created_at, updated_at
-			             FROM skills WHERE is_active = true`;
-			const params: unknown[] = [];
+			// This project's own skills plus globals (project shadows a global of
+			// the same slug — de-duped below).
+			let query = `SELECT id, name, slug, description, tags, project_id, created_at, updated_at
+			             FROM skills WHERE is_active = true AND (project_id = $1 OR project_id IS NULL)`;
+			const params: unknown[] = [scope.projectId];
 
 			if (args.tags) {
 				const tagList = (args.tags as string).split(',').map((t) => t.trim());
-				query += ` AND tags ?| $1`;
+				query += ` AND tags ?| $${params.length + 1}`;
 				params.push(tagList);
 			}
 
-			query += ' ORDER BY name';
-			const result = await db.query(query, params);
-			return { skills: result.rows };
+			// Project row before global so the de-dupe keeps the project's shadowing copy.
+			query += ' ORDER BY name, project_id NULLS LAST';
+			const result = await db.query<{ slug: string }>(query, params);
+			const seen = new Set<string>();
+			const skills = result.rows.filter((r) => {
+				if (seen.has(r.slug)) return false;
+				seen.add(r.slug);
+				return true;
+			});
+			return { skills };
 		},
 		db,
 	);
@@ -4295,9 +4324,13 @@ export function registerTools(
 			const scope = await resolveScope(db, auth, args);
 			if ('error' in scope) return scope;
 
-			const result = await db.query(`SELECT ${SKILL_COLUMNS} FROM skills WHERE slug = $1 LIMIT 1`, [
-				args.slug,
-			]);
+			// Prefer this project's own skill over a global one of the same slug.
+			const result = await db.query(
+				`SELECT ${SKILL_COLUMNS} FROM skills
+				 WHERE slug = $1 AND (project_id = $2 OR project_id IS NULL)
+				 ORDER BY project_id NULLS LAST LIMIT 1`,
+				[args.slug, scope.projectId],
+			);
 			if (result.rows.length === 0) return { error: 'Skill not found' };
 			return result.rows[0];
 		},
@@ -4307,7 +4340,7 @@ export function registerTools(
 	tool(
 		server,
 		'create_skill',
-		"Add or update a skill in the team's skills database directly (no approval needed) — record reusable team know-how such as MCP server usage, integration steps, conventions, and how agents coordinate. Use propose_skill when approval is required. If description is omitted it is derived from the skill body.",
+		"Add or update a skill in the team's skills database directly (no approval needed) — record reusable team know-how such as MCP server usage, integration steps, conventions, and how agents coordinate. Use propose_skill when approval is required. If description is omitted it is derived from the skill body. Choose `scope` deliberately: 'global' when the know-how helps agents in ANY project (related or not), 'project' when it is specific to this project. Omitting scope defaults to 'project'.",
 		{
 			project: projectArg(),
 			name: z.string().describe('Human-readable skill name'),
@@ -4315,11 +4348,19 @@ export function registerTools(
 			content: z.string().describe('Skill content (markdown)'),
 			description: z.string().optional().describe('Short description'),
 			tags: z.string().optional().describe('Comma-separated tags'),
+			scope: z
+				.enum(['project', 'global'])
+				.optional()
+				.describe(
+					"'global' shares the skill with every project; 'project' keeps it private to this project. Defaults to 'project'.",
+				),
 		},
 		async (args, db, auth) => {
 			const scope = await resolveScope(db, auth, args);
 			if ('error' in scope) return scope;
 
+			// The agent chooses the scope; absent a choice we keep it project-private.
+			const targetProjectId = args.scope === 'global' ? null : scope.projectId;
 			const callerMemberId = auth.type === AuthType.Agent ? auth.memberId : null;
 			const { createHash } = await import('node:crypto');
 			const contentHash = createHash('sha256')
@@ -4332,14 +4373,18 @@ export function registerTools(
 				(args.description as string)?.trim() || deriveSkillSummary(args.content as string);
 
 			const priorSkill = await db.query<{ content: string }>(
-				'SELECT content FROM skills WHERE slug = $1',
-				[args.slug],
+				'SELECT content FROM skills WHERE slug = $1 AND project_id IS NOT DISTINCT FROM $2',
+				[args.slug, targetProjectId],
 			);
 
+			// Upsert against the partial unique index matching the chosen scope.
+			const conflictTarget = targetProjectId
+				? '(project_id, slug) WHERE project_id IS NOT NULL'
+				: '(slug) WHERE project_id IS NULL';
 			const result = await db.query<{ id: string; slug: string }>(
-				`INSERT INTO skills (name, slug, description, content, content_hash, created_by_member_id, tags)
-				 VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)
-				 ON CONFLICT (slug) DO UPDATE SET
+				`INSERT INTO skills (name, slug, description, content, content_hash, created_by_member_id, tags, project_id)
+				 VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8)
+				 ON CONFLICT ${conflictTarget} DO UPDATE SET
 				   content = EXCLUDED.content,
 				   content_hash = EXCLUDED.content_hash,
 				   description = EXCLUDED.description,
@@ -4354,6 +4399,7 @@ export function registerTools(
 					contentHash,
 					callerMemberId,
 					JSON.stringify(tagList),
+					targetProjectId,
 				],
 			);
 
@@ -4367,7 +4413,12 @@ export function registerTools(
 				callerMemberId,
 			);
 
-			return { skill_id: skillId, slug: result.rows[0].slug, created: true };
+			return {
+				skill_id: skillId,
+				slug: result.rows[0].slug,
+				scope: targetProjectId ? 'project' : 'global',
+				created: true,
+			};
 		},
 		db,
 	);

--- a/packages/server/src/routes/mentions.ts
+++ b/packages/server/src/routes/mentions.ts
@@ -83,6 +83,7 @@ mentionsRoutes.post('/mentions/resolve', async (c) => {
 
 mentionsRoutes.post('/projects/:projectId/docs/resolve', async (c) => {
 	const teamId = c.get('teamId') as string;
+	const projectId = c.get('projectId') as string;
 	const db = c.get('db');
 
 	const body = await c.req.json<{
@@ -147,8 +148,8 @@ mentionsRoutes.post('/projects/:projectId/docs/resolve', async (c) => {
 		}>(
 			`SELECT slug, name AS title, octet_length(content)::int AS size, updated_at
 			 FROM skills
-			 WHERE LOWER(slug) = ANY($1::text[])`,
-			[kbSlugs],
+			 WHERE LOWER(slug) = ANY($1::text[]) AND (project_id = $2 OR project_id IS NULL)`,
+			[kbSlugs, projectId],
 		);
 		kbDocs = result.rows;
 	}
@@ -226,6 +227,7 @@ mentionsRoutes.post('/projects/:projectId/docs/resolve', async (c) => {
 
 mentionsRoutes.get('/projects/:projectId/mentions/search', async (c) => {
 	const teamId = c.get('teamId') as string;
+	const projectId = c.get('projectId') as string;
 	const db = c.get('db');
 
 	const q = (c.req.query('q') ?? '').trim();
@@ -298,9 +300,10 @@ mentionsRoutes.get('/projects/:projectId/mentions/search', async (c) => {
 			`SELECT slug, name AS title
 			 FROM skills
 			 WHERE ($1 = '' OR slug ILIKE $2 OR name ILIKE $2)
+			   AND (project_id = $4 OR project_id IS NULL)
 			 ORDER BY name
 			 LIMIT $3`,
-			[q, pattern, perKind],
+			[q, pattern, perKind, projectId],
 		);
 		for (const row of r.rows) {
 			results.push({

--- a/packages/server/src/routes/skills.ts
+++ b/packages/server/src/routes/skills.ts
@@ -4,6 +4,7 @@ import { Hono } from 'hono';
 import { err, ok } from '../lib/response';
 import { deriveSkillSummary } from '../lib/skill-summary';
 import { toSlug } from '../lib/slug';
+import { isUniqueViolation } from '../lib/sql';
 import type { Env } from '../lib/types';
 import { requireAdminEquivalent } from '../middleware/auth';
 import {
@@ -22,19 +23,76 @@ import {
 
 export const skillsRoutes = new Hono<Env>();
 
-// Skills are instance-global: one reusable-skill catalog shared with every
-// team's agents (admin-authored here, or agent-fetched via fetch_skill_file).
-// The Admin (superuser) manages them.
+// List columns (content omitted) plus the scope key, `s.`-qualified for queries
+// that JOIN `projects` to annotate the owning project.
+const SKILL_LIST_COLUMNS_S = `s.id, s.name, s.slug, s.description, s.source_url, s.content_hash,
+        s.created_by_member_id, s.project_id, s.tags, s.is_active, s.auto_load, s.created_at, s.updated_at`;
+
+/**
+ * Build the SET clause + params for a skill content edit (name/description/tags/
+ * content). `$1` is reserved for the row's `id`; params returned start at `$2`.
+ * Returns null when the body carries no editable field. Shared by the admin and
+ * per-project PATCH routes so both edit paths behave identically.
+ */
+function buildSkillEdit(
+	body: {
+		name?: string;
+		description?: string;
+		tags?: string[];
+		content?: string;
+	},
+	startIndex = 2,
+): { sets: string[]; params: unknown[] } | null {
+	const sets: string[] = [];
+	const params: unknown[] = [];
+	let idx = startIndex; // first param placeholder for an edit field
+
+	if (body.name !== undefined) {
+		sets.push(`name = $${idx++}`);
+		params.push(body.name.trim());
+	}
+	const trimmedDescription = body.description?.trim();
+	let resolvedDescription: string | undefined =
+		body.description !== undefined ? trimmedDescription : undefined;
+	if (!trimmedDescription && body.content !== undefined) {
+		resolvedDescription = deriveSkillSummary(body.content);
+	}
+	if (resolvedDescription !== undefined) {
+		sets.push(`description = $${idx++}`);
+		params.push(resolvedDescription);
+	}
+	if (body.tags !== undefined) {
+		sets.push(`tags = $${idx++}::jsonb`);
+		params.push(JSON.stringify(body.tags));
+	}
+	if (body.content !== undefined) {
+		const hash = createHash('sha256').update(body.content).digest('hex');
+		sets.push(`content = $${idx++}`);
+		params.push(body.content);
+		sets.push(`content_hash = $${idx++}`);
+		params.push(hash);
+	}
+	if (sets.length === 0) return null;
+	return { sets, params };
+}
+
+// --------------------------------------------------------------------------
+// Admin surface (superuser): the global catalog + every project's skills, each
+// annotated with its owning project. Skills are scoped like MCP connectors —
+// NULL project_id is global ("all projects"); a non-NULL project_id is private
+// to that project. The scope drop-down on /settings/skills re-scopes via PATCH.
+// --------------------------------------------------------------------------
+
 skillsRoutes.get('/skills', async (c) => {
 	const denied = requireAdminEquivalent(c);
 	if (denied) return denied;
 	const db = c.get('db');
-	const result = await db.query<Omit<SkillRecord, 'content'>>(
-		`SELECT id, name, slug, description, source_url, content_hash,
-		        created_by_member_id, tags, is_active, auto_load, created_at, updated_at
-		 FROM skills
-		 WHERE is_active = true
-		 ORDER BY name`,
+	const result = await db.query(
+		`SELECT ${SKILL_LIST_COLUMNS_S}, p.name AS project_name, p.slug AS project_slug
+		 FROM skills s
+		 LEFT JOIN projects p ON p.id = s.project_id
+		 WHERE s.is_active = true
+		 ORDER BY s.name`,
 	);
 	return ok(c, result.rows);
 });
@@ -49,35 +107,68 @@ skillsRoutes.post('/skills', async (c) => {
 		description?: string;
 		slug?: string;
 		tags?: string[];
+		project_id?: string | null;
 	}>();
 	if (!body.name?.trim()) return err(c, 'INVALID_REQUEST', 'name is required', 400);
 	if (!body.content?.trim()) return err(c, 'INVALID_REQUEST', 'content is required', 400);
 	const slug = body.slug?.trim() || toSlug(body.name);
 	if (!slug) return err(c, 'INVALID_REQUEST', 'slug could not be derived from name', 400);
 
+	// The admin may create a global skill (project_id null) or scope it to a
+	// specific project via the create-form picker. Validate a named project.
+	const projectId = body.project_id?.trim() || null;
+	if (projectId) {
+		const proj = await db.query<{ id: string }>('SELECT id FROM projects WHERE id = $1', [
+			projectId,
+		]);
+		if (proj.rows.length === 0) return err(c, 'NOT_FOUND', 'project_id not found', 404);
+	}
+
 	const content = body.content;
 	const hash = createHash('sha256').update(content).digest('hex');
 	const description = body.description?.trim() || deriveSkillSummary(content);
 
-	// Snapshot the prior content (if any) once we've written, so editing an
-	// existing skill through the form records a revision (none on first create).
-	const prior = await db.query<{ content: string }>('SELECT content FROM skills WHERE slug = $1', [
-		slug,
-	]);
-
-	const result = await db.query<SkillRecord>(
-		`INSERT INTO skills (name, slug, description, content, source_url, content_hash, tags)
-		 VALUES ($1, $2, $3, $4, NULL, $5, $6::jsonb)
-		 ON CONFLICT (slug) DO UPDATE SET
-		   name = EXCLUDED.name,
-		   description = EXCLUDED.description,
-		   content = EXCLUDED.content,
-		   content_hash = EXCLUDED.content_hash,
-		   tags = EXCLUDED.tags,
-		   updated_at = now()
-		 RETURNING *`,
-		[body.name.trim(), slug, description, content, hash, JSON.stringify(body.tags ?? [])],
+	// Snapshot the prior content (matched within the same scope) so re-adding an
+	// existing skill records a revision. `IS NOT DISTINCT FROM` null-safely
+	// matches the global (NULL) or per-project scope.
+	const prior = await db.query<{ content: string }>(
+		'SELECT content FROM skills WHERE slug = $1 AND project_id IS NOT DISTINCT FROM $2',
+		[slug, projectId],
 	);
+
+	// Upsert against the partial unique index matching the row's scope.
+	const conflictTarget = projectId
+		? '(project_id, slug) WHERE project_id IS NOT NULL'
+		: '(slug) WHERE project_id IS NULL';
+	let result: Awaited<ReturnType<typeof db.query<SkillRecord>>>;
+	try {
+		result = await db.query<SkillRecord>(
+			`INSERT INTO skills (name, slug, description, content, source_url, content_hash, tags, project_id)
+			 VALUES ($1, $2, $3, $4, NULL, $5, $6::jsonb, $7)
+			 ON CONFLICT ${conflictTarget} DO UPDATE SET
+			   name = EXCLUDED.name,
+			   description = EXCLUDED.description,
+			   content = EXCLUDED.content,
+			   content_hash = EXCLUDED.content_hash,
+			   tags = EXCLUDED.tags,
+			   updated_at = now()
+			 RETURNING *`,
+			[
+				body.name.trim(),
+				slug,
+				description,
+				content,
+				hash,
+				JSON.stringify(body.tags ?? []),
+				projectId,
+			],
+		);
+	} catch (e) {
+		if (isUniqueViolation(e)) {
+			return err(c, 'CONFLICT', 'a skill with this slug already exists in this scope', 409);
+		}
+		throw e;
+	}
 	const skill = result.rows[0];
 	await recordSkillRevisionIfChanged(
 		db,
@@ -100,8 +191,9 @@ skillsRoutes.post('/skills', async (c) => {
 });
 
 // --- skills.sh registry: admin "search and add" (token-gated; agents bypass this
-// and use the `npx skills` CLI directly). Registered before /skills/:slug; the
-// two-segment paths don't collide with the single-segment slug route. ---
+// and use the `npx skills` CLI directly). Registered before /skills/:id; the
+// two-segment paths don't collide with the single-segment id route. Registry
+// installs land as global skills. ---
 
 skillsRoutes.get('/skills/registry/token', async (c) => {
 	const denied = requireAdminEquivalent(c);
@@ -172,30 +264,31 @@ skillsRoutes.post('/skills/registry/install', async (c) => {
 	}
 });
 
-skillsRoutes.get('/skills/:slug', async (c) => {
+skillsRoutes.get('/skills/:id', async (c) => {
 	const denied = requireAdminEquivalent(c);
 	if (denied) return denied;
 	const db = c.get('db');
-	const slug = c.req.param('slug');
-	const result = await db.query<SkillRecord>('SELECT * FROM skills WHERE slug = $1', [slug]);
+	const result = await db.query<SkillRecord>('SELECT * FROM skills WHERE id = $1', [
+		c.req.param('id'),
+	]);
 	if (result.rows.length === 0) return err(c, 'NOT_FOUND', 'Skill not found', 404);
 	return ok(c, result.rows[0]);
 });
 
 // Revision history + restore — mirrors document/agent-prompt revisions
-// (project-docs / agents routes). Admin-only, like the rest of /skills.
-skillsRoutes.get('/skills/:slug/revisions', async (c) => {
+// (project-docs / agents routes). Admin-only, like the rest of this surface.
+skillsRoutes.get('/skills/:id/revisions', async (c) => {
 	const denied = requireAdminEquivalent(c);
 	if (denied) return denied;
 	const db = c.get('db');
-	const skill = await db.query<{ id: string }>('SELECT id FROM skills WHERE slug = $1', [
-		c.req.param('slug'),
+	const skill = await db.query<{ id: string }>('SELECT id FROM skills WHERE id = $1', [
+		c.req.param('id'),
 	]);
 	if (skill.rows.length === 0) return err(c, 'NOT_FOUND', 'Skill not found', 404);
 	return ok(c, await listSkillRevisions(db, skill.rows[0].id));
 });
 
-skillsRoutes.post('/skills/:slug/restore', async (c) => {
+skillsRoutes.post('/skills/:id/restore', async (c) => {
 	const denied = requireAdminEquivalent(c);
 	if (denied) return denied;
 	const db = c.get('db');
@@ -203,9 +296,8 @@ skillsRoutes.post('/skills/:slug/restore', async (c) => {
 	if (typeof body.revision_number !== 'number') {
 		return err(c, 'INVALID_REQUEST', 'revision_number is required', 400);
 	}
-	const skill = await db.query<{ id: string }>('SELECT id FROM skills WHERE slug = $1', [
-		c.req.param('slug'),
-	]);
+	const id = c.req.param('id');
+	const skill = await db.query<{ id: string }>('SELECT id FROM skills WHERE id = $1', [id]);
 	if (skill.rows.length === 0) return err(c, 'NOT_FOUND', 'Skill not found', 404);
 	const restored = await restoreSkillRevision(db, skill.rows[0].id, body.revision_number, null);
 	if (!restored) return err(c, 'NOT_FOUND', 'Revision not found', 404);
@@ -221,47 +313,37 @@ skillsRoutes.post('/skills/:slug/restore', async (c) => {
 	return ok(c, restored);
 });
 
-skillsRoutes.patch('/skills/:slug', async (c) => {
+// Edit (name/description/tags/content) and/or re-scope (project_id). The scope
+// drop-down on /settings/skills posts only { project_id } here; the edit form
+// posts the content fields. Empty/whitespace project_id collapses to global.
+skillsRoutes.patch('/skills/:id', async (c) => {
 	const denied = requireAdminEquivalent(c);
 	if (denied) return denied;
 	const db = c.get('db');
-	const slug = c.req.param('slug');
+	const id = c.req.param('id');
 
 	const body = await c.req.json<{
 		name?: string;
 		description?: string;
 		tags?: string[];
 		content?: string;
+		project_id?: string | null;
 	}>();
 
-	const sets: string[] = [];
-	const params: unknown[] = [];
-	let paramIdx = 2; // $1 = slug
+	const edit = buildSkillEdit(body);
+	const sets = edit?.sets ?? [];
+	const params = edit?.params ?? [];
 
-	if (body.name !== undefined) {
-		sets.push(`name = $${paramIdx++}`);
-		params.push(body.name.trim());
-	}
-	const trimmedDescription = body.description?.trim();
-	let resolvedDescription: string | undefined =
-		body.description !== undefined ? trimmedDescription : undefined;
-	if (!trimmedDescription && body.content !== undefined) {
-		resolvedDescription = deriveSkillSummary(body.content);
-	}
-	if (resolvedDescription !== undefined) {
-		sets.push(`description = $${paramIdx++}`);
-		params.push(resolvedDescription);
-	}
-	if (body.tags !== undefined) {
-		sets.push(`tags = $${paramIdx++}::jsonb`);
-		params.push(JSON.stringify(body.tags));
-	}
-	if (body.content !== undefined) {
-		const hash = createHash('sha256').update(body.content).digest('hex');
-		sets.push(`content = $${paramIdx++}`);
-		params.push(body.content);
-		sets.push(`content_hash = $${paramIdx++}`);
-		params.push(hash);
+	if ('project_id' in body) {
+		const projectId = body.project_id?.trim() || null;
+		if (projectId) {
+			const proj = await db.query<{ id: string }>('SELECT id FROM projects WHERE id = $1', [
+				projectId,
+			]);
+			if (proj.rows.length === 0) return err(c, 'NOT_FOUND', 'project_id not found', 404);
+		}
+		sets.push(`project_id = $${params.length + 2}`);
+		params.push(projectId);
 	}
 
 	if (sets.length === 0) {
@@ -269,19 +351,26 @@ skillsRoutes.patch('/skills/:slug', async (c) => {
 	}
 	sets.push('updated_at = now()');
 
-	// Capture the prior content before overwriting so the change is recorded as a
-	// revision (only when the content field is actually part of this update).
+	// Capture prior content before overwriting so a content edit records a revision.
 	const prior =
 		body.content !== undefined
-			? await db.query<{ content: string }>('SELECT content FROM skills WHERE slug = $1', [slug])
+			? await db.query<{ content: string }>('SELECT content FROM skills WHERE id = $1', [id])
 			: null;
 
-	const result = await db.query<SkillRecord>(
-		`UPDATE skills SET ${sets.join(', ')}
-		 WHERE slug = $1
-		 RETURNING *`,
-		[slug, ...params],
-	);
+	let result: Awaited<ReturnType<typeof db.query<SkillRecord>>>;
+	try {
+		result = await db.query<SkillRecord>(
+			`UPDATE skills SET ${sets.join(', ')} WHERE id = $1 RETURNING *`,
+			[id, ...params],
+		);
+	} catch (e) {
+		// Re-scoping into a scope that already holds this slug trips a partial
+		// unique index (global slug / per-project slug).
+		if (isUniqueViolation(e)) {
+			return err(c, 'CONFLICT', 'a skill with this slug already exists in the target scope', 409);
+		}
+		throw e;
+	}
 	if (result.rows.length === 0) {
 		return err(c, 'NOT_FOUND', 'Skill not found', 404);
 	}
@@ -309,26 +398,175 @@ skillsRoutes.patch('/skills/:slug', async (c) => {
 	return ok(c, skill);
 });
 
-skillsRoutes.delete('/skills/:slug', async (c) => {
+skillsRoutes.delete('/skills/:id', async (c) => {
 	const denied = requireAdminEquivalent(c);
 	if (denied) return denied;
 	const db = c.get('db');
-	const slug = c.req.param('slug');
-	const existing = await db.query<{ id: string; name: string }>(
-		'SELECT id, name FROM skills WHERE slug = $1',
-		[slug],
+	const id = c.req.param('id');
+	const existing = await db.query<{ id: string; slug: string; name: string }>(
+		'SELECT id, slug, name FROM skills WHERE id = $1',
+		[id],
 	);
 	if (existing.rows.length === 0) {
 		return err(c, 'NOT_FOUND', 'Skill not found', 404);
 	}
-	await db.query('DELETE FROM skills WHERE slug = $1', [slug]);
+	await db.query('DELETE FROM skills WHERE id = $1', [id]);
 	c.get('events').emit({
 		type: 'skill.deleted',
 		teamId: null,
 		actorType: 'admin',
 		actorMemberId: null,
 		skillId: existing.rows[0].id,
-		slug,
+		slug: existing.rows[0].slug,
+		name: existing.rows[0].name,
+	});
+	return c.json({ data: null }, 200);
+});
+
+// --------------------------------------------------------------------------
+// Per-project surface: any project member (team access enforced by
+// requireProjectAccessMiddleware on /api/projects/:projectId/*). Lists this
+// project's own skills plus globals; edit/remove act ONLY on this project's own
+// skills (a global or another project's skill can't be mutated here — the
+// WHERE project_id = :projectId guard enforces it server-side). Scope changes
+// are not possible here — those live on the global admin page.
+// --------------------------------------------------------------------------
+
+skillsRoutes.get('/projects/:projectId/skills', async (c) => {
+	const db = c.get('db');
+	const projectId = c.get('projectId') as string;
+	const result = await db.query(
+		`SELECT ${SKILL_LIST_COLUMNS_S}, p.name AS project_name, p.slug AS project_slug
+		 FROM skills s
+		 LEFT JOIN projects p ON p.id = s.project_id
+		 WHERE s.is_active = true AND (s.project_id = $1 OR s.project_id IS NULL)
+		 ORDER BY s.name`,
+		[projectId],
+	);
+	return ok(c, result.rows);
+});
+
+skillsRoutes.get('/projects/:projectId/skills/:id', async (c) => {
+	const db = c.get('db');
+	const projectId = c.get('projectId') as string;
+	const result = await db.query<SkillRecord>(
+		'SELECT * FROM skills WHERE id = $1 AND project_id = $2',
+		[c.req.param('id'), projectId],
+	);
+	if (result.rows.length === 0) return err(c, 'NOT_FOUND', 'Skill not found', 404);
+	return ok(c, result.rows[0]);
+});
+
+skillsRoutes.get('/projects/:projectId/skills/:id/revisions', async (c) => {
+	const db = c.get('db');
+	const projectId = c.get('projectId') as string;
+	const skill = await db.query<{ id: string }>(
+		'SELECT id FROM skills WHERE id = $1 AND project_id = $2',
+		[c.req.param('id'), projectId],
+	);
+	if (skill.rows.length === 0) return err(c, 'NOT_FOUND', 'Skill not found', 404);
+	return ok(c, await listSkillRevisions(db, skill.rows[0].id));
+});
+
+skillsRoutes.post('/projects/:projectId/skills/:id/restore', async (c) => {
+	const db = c.get('db');
+	const projectId = c.get('projectId') as string;
+	const body = await c.req.json<{ revision_number?: number }>();
+	if (typeof body.revision_number !== 'number') {
+		return err(c, 'INVALID_REQUEST', 'revision_number is required', 400);
+	}
+	const skill = await db.query<{ id: string }>(
+		'SELECT id FROM skills WHERE id = $1 AND project_id = $2',
+		[c.req.param('id'), projectId],
+	);
+	if (skill.rows.length === 0) return err(c, 'NOT_FOUND', 'Skill not found', 404);
+	const restored = await restoreSkillRevision(db, skill.rows[0].id, body.revision_number, null);
+	if (!restored) return err(c, 'NOT_FOUND', 'Revision not found', 404);
+	c.get('events').emit({
+		type: 'skill.updated',
+		teamId: null,
+		actorType: 'admin',
+		actorMemberId: null,
+		skillId: restored.id,
+		slug: restored.slug,
+		name: restored.name,
+	});
+	return ok(c, restored);
+});
+
+skillsRoutes.patch('/projects/:projectId/skills/:id', async (c) => {
+	const db = c.get('db');
+	const projectId = c.get('projectId') as string;
+	const id = c.req.param('id');
+	const body = await c.req.json<{
+		name?: string;
+		description?: string;
+		tags?: string[];
+		content?: string;
+	}>();
+
+	// $1 = id, $2 = projectId, so edit placeholders start at $3.
+	const edit = buildSkillEdit(body, 3);
+	if (!edit) return err(c, 'INVALID_REQUEST', 'No fields to update', 400);
+	edit.sets.push('updated_at = now()');
+
+	const prior =
+		body.content !== undefined
+			? await db.query<{ content: string }>(
+					'SELECT content FROM skills WHERE id = $1 AND project_id = $2',
+					[id, projectId],
+				)
+			: null;
+
+	const result = await db.query<SkillRecord>(
+		`UPDATE skills SET ${edit.sets.join(', ')} WHERE id = $1 AND project_id = $2 RETURNING *`,
+		[id, projectId, ...edit.params],
+	);
+	if (result.rows.length === 0) {
+		return err(c, 'NOT_FOUND', 'Skill not found', 404);
+	}
+	const skill = result.rows[0];
+	if (body.content !== undefined) {
+		await recordSkillRevisionIfChanged(
+			db,
+			skill.id,
+			prior?.rows[0]?.content ?? null,
+			body.content,
+			'Content updated',
+			null,
+		);
+	}
+	c.get('events').emit({
+		type: 'skill.updated',
+		teamId: null,
+		actorType: 'admin',
+		actorMemberId: null,
+		skillId: skill.id,
+		slug: skill.slug,
+		name: skill.name,
+	});
+	return ok(c, skill);
+});
+
+skillsRoutes.delete('/projects/:projectId/skills/:id', async (c) => {
+	const db = c.get('db');
+	const projectId = c.get('projectId') as string;
+	const id = c.req.param('id');
+	const existing = await db.query<{ id: string; slug: string; name: string }>(
+		'SELECT id, slug, name FROM skills WHERE id = $1 AND project_id = $2',
+		[id, projectId],
+	);
+	if (existing.rows.length === 0) {
+		return err(c, 'NOT_FOUND', 'Skill not found', 404);
+	}
+	await db.query('DELETE FROM skills WHERE id = $1 AND project_id = $2', [id, projectId]);
+	c.get('events').emit({
+		type: 'skill.deleted',
+		teamId: null,
+		actorType: 'admin',
+		actorMemberId: null,
+		skillId: existing.rows[0].id,
+		slug: existing.rows[0].slug,
 		name: existing.rows[0].name,
 	});
 	return c.json({ data: null }, 200);

--- a/packages/server/src/services/approval-handlers/skill-proposal.ts
+++ b/packages/server/src/services/approval-handlers/skill-proposal.ts
@@ -14,20 +14,42 @@ export const skillProposalHandler: ApprovalHandler = {
 		const requestedBy =
 			(payload.requested_by as string) ?? (approval.requested_by_member_id as string) ?? null;
 
-		// Skills are global. Write to DB (source of truth).
+		// The proposer chose the scope: 'global' (project_id null, shared with every
+		// project) or 'project' (default) — private to the approval's project. A team
+		// backs exactly one project (1:1), so resolve it from the approval's team.
+		let targetProjectId: string | null = null;
+		if (payload.scope !== 'global') {
+			const proj = await db.query<{ id: string }>('SELECT id FROM projects WHERE team_id = $1', [
+				approval.team_id as string,
+			]);
+			targetProjectId = proj.rows[0]?.id ?? null;
+		}
+
+		// Write to DB (source of truth). Upsert against the scope's partial index.
 		const prior = await db.query<{ content: string }>(
-			'SELECT content FROM skills WHERE slug = $1',
-			[slug],
+			'SELECT content FROM skills WHERE slug = $1 AND project_id IS NOT DISTINCT FROM $2',
+			[slug, targetProjectId],
 		);
+		const conflictTarget = targetProjectId
+			? '(project_id, slug) WHERE project_id IS NOT NULL'
+			: '(slug) WHERE project_id IS NULL';
 		const skillResult = await db.query<{ id: string }>(
-			`INSERT INTO skills (name, slug, description, content, content_hash, created_by_member_id)
-			 VALUES ($1, $2, $3, $4, $5, $6)
-			 ON CONFLICT (slug) DO UPDATE SET
+			`INSERT INTO skills (name, slug, description, content, content_hash, created_by_member_id, project_id)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7)
+			 ON CONFLICT ${conflictTarget} DO UPDATE SET
 			   content = EXCLUDED.content,
 			   content_hash = EXCLUDED.content_hash,
 			   updated_at = now()
 			 RETURNING id`,
-			[name, slug, (payload.reason as string) ?? '', content, contentHash, requestedBy],
+			[
+				name,
+				slug,
+				(payload.reason as string) ?? '',
+				content,
+				contentHash,
+				requestedBy,
+				targetProjectId,
+			],
 		);
 
 		if (skillResult.rows[0]) {

--- a/packages/server/src/services/instance-mentions.ts
+++ b/packages/server/src/services/instance-mentions.ts
@@ -98,9 +98,11 @@ export async function resolveInstanceMentions(
 		out.project_docs = docs.rows;
 
 		const kb = await db.query<InstanceResolvedKbDoc>(
+			// Instance-wide surface (global CEO chat): resolve global skills only —
+			// project-scoped skills are private to their project.
 			`SELECT slug, name AS title, octet_length(content)::int AS size, updated_at
 			 FROM skills
-			 WHERE LOWER(slug) = ANY($1::text[])`,
+			 WHERE LOWER(slug) = ANY($1::text[]) AND project_id IS NULL`,
 			[candidates.filenames.map((f) => f.toLowerCase())],
 		);
 		out.kb_docs = kb.rows;

--- a/packages/server/src/services/search.ts
+++ b/packages/server/src/services/search.ts
@@ -26,8 +26,9 @@ export function buildSearchTsQuery(raw: string): string {
  * There is no model to load and no async indexing step — a row is searchable the
  * moment it is written, since `search_tsv` is a STORED generated column.
  *
- * `teamIds` scopes team-owned content (tasks, project docs, comments); skills are
- * instance-global and returned regardless of team. `limit` applies **per type** —
+ * `teamIds` scopes team-owned content (tasks, project docs, comments) and also
+ * skills: global skills (project_id null) plus any project skill whose project's
+ * team is in `teamIds`. `limit` applies **per type** —
  * each branch caps at `limit` and the results are merged sorted by rank with no
  * cross-type truncation, so callers (the web palette) can group by type and show
  * accurate per-type counts.
@@ -165,9 +166,11 @@ export async function fullTextSearch(
 			`SELECT id, name, LEFT(content, 4000) AS content, ts_rank(search_tsv, q) AS score
 			 FROM skills, to_tsquery('${TEXT_SEARCH_CONFIG}', $1) q
 			 WHERE is_active = true AND search_tsv @@ q
+			 AND (project_id IS NULL
+			      OR project_id IN (SELECT id FROM projects WHERE team_id = ANY($3::uuid[])))
 			 ORDER BY score DESC
 			 LIMIT $2`,
-			[tsQuery, limit],
+			[tsQuery, limit, teamIds],
 		);
 		for (const r of skillResults.rows) {
 			const { snippet } = buildHighlightedSnippet(r.content, query);

--- a/packages/server/src/services/skills-registry.ts
+++ b/packages/server/src/services/skills-registry.ts
@@ -199,14 +199,15 @@ export async function installRegistrySkill(
 	const description = data.description?.trim() || deriveSkillSummary(content);
 	const hash = createHash('sha256').update(content).digest('hex');
 
+	// Registry installs land as global skills (project_id null).
 	const existing = await db.query<{ id: string; content: string }>(
-		'SELECT id, content FROM skills WHERE slug = $1',
+		'SELECT id, content FROM skills WHERE slug = $1 AND project_id IS NULL',
 		[slug],
 	);
 	const upserted = await db.query<{ id: string; slug: string; name: string }>(
 		`INSERT INTO skills (name, slug, description, content, source_url, content_hash, created_by_member_id, tags)
 		 VALUES ($1, $2, $3, $4, $5, $6, $7, '[]'::jsonb)
-		 ON CONFLICT (slug) DO UPDATE SET
+		 ON CONFLICT (slug) WHERE project_id IS NULL DO UPDATE SET
 		     name = EXCLUDED.name,
 		     description = EXCLUDED.description,
 		     content = EXCLUDED.content,

--- a/packages/server/src/services/team-template-provision.ts
+++ b/packages/server/src/services/team-template-provision.ts
@@ -113,7 +113,7 @@ async function createInlineSkillsFromTemplate(
 		await db.query(
 			`INSERT INTO skills (name, slug, description, content, content_hash)
 			 VALUES ($1, $2, $3, $4, $5)
-			 ON CONFLICT (slug) DO NOTHING`,
+			 ON CONFLICT (slug) WHERE project_id IS NULL DO NOTHING`,
 			[name, slug, description, skill.content, hash],
 		);
 	}
@@ -141,7 +141,7 @@ export async function createSkillsFromTemplate(
 			await db.query(
 				`INSERT INTO skills (name, slug, description, content, source_url, content_hash)
 				 VALUES ($1, $2, $3, $4, $5, $6)
-				 ON CONFLICT (slug) DO NOTHING`,
+				 ON CONFLICT (slug) WHERE project_id IS NULL DO NOTHING`,
 				[name, slug, description, content, skill.source_url, hash],
 			);
 		} catch (e) {

--- a/packages/server/src/services/team-template-snapshot.ts
+++ b/packages/server/src/services/team-template-snapshot.ts
@@ -86,7 +86,11 @@ export async function snapshotTeamAsTemplate(
 			slug: string;
 			description: string;
 			content: string;
-		}>(`SELECT name, slug, description, content FROM skills WHERE is_active = true`);
+			// Only global skills go into a reusable template — a project-scoped skill
+			// is private to one project and must not be captured for other teams.
+		}>(
+			`SELECT name, slug, description, content FROM skills WHERE is_active = true AND project_id IS NULL`,
+		);
 		const skillsConfig = skillsRes.rows;
 
 		const prefRes = await db.query<{ content: string }>(

--- a/packages/server/src/services/template-resolver.ts
+++ b/packages/server/src/services/template-resolver.ts
@@ -124,6 +124,7 @@ const SHARED_INSTRUCTIONS = `
 - **Project assets**: Use \`list_project_assets\`, \`read_project_asset\`, and \`write_project_asset\` for non-markdown deliverables — mockups, wireframes, diagrams, PDFs, scripts. Assets are addressed by their library path — a filename optionally inside folders up to two levels deep (\`hero.png\`, \`launch/images/hero.png\`) — never a container filesystem path; \`read_project_asset\` returns text-based assets inline, and for a binary asset it returns a signed download URL you fetch yourself (\`curl -fsSL '<url>' -o /tmp/<filename>\`). Reorganize with \`move_project_asset\`/\`copy_project_asset\`; obsolete assets are archived, never deleted (see **Organizing the Assets Library** below).
 - **AGENTS.md**: For practical conventions, commands, and constraints when working on this project's repo. Update via git in the repo.
 - **Skills database**: the team's single store of reusable, *project-independent* know-how — how to use an MCP server or integration, recurring procedures, conventions, how the team coordinates. It is distinct from project docs (project-specific material) and from agent system prompts. Each run you receive a skills **manifest** (name + slug + one-line summary) in the injected skills context; the manifest is not the full body, so call \`get_skill(slug)\` to read one in full when it looks relevant. When you learn something reusable the team will want again, record it with \`create_skill\` (or \`propose_skill\` where approval is required) — a focused name, a one-line description, and a body covering just that topic. Knowledge specific to one project belongs in a project doc, not a skill; guidance about how an agent should behave is a system-prompt change, not a skill.
+- **Choose the skill's scope deliberately.** \`create_skill\`, \`propose_skill\`, and \`fetch_skill_file\` take a \`scope\`: choose \`global\` when the know-how helps agents working in **any** project (a widely-used tool's usage, a general technique, an integration many projects will reach for), and \`project\` when it is specific to *this* project (its particular deployment steps, its own conventions, a runbook only this project needs). When in doubt, prefer \`project\` — it keeps other projects' skill manifests uncluttered, and an admin can promote a project skill to global later. Omitting \`scope\` defaults to \`project\`.
 - **Finding new skills**: when a task needs a capability you don't already have, first re-check the manifest. If nothing fits, search the open ecosystem from inside the container — \`npx skills find "<query>"\` (and browse https://skills.sh), preferring well-adopted skills. A local \`npx skills add … -g\` install lives only in this container and is discarded when the run ends — to make a skill permanent for every future run, persist it into the catalog: call \`fetch_skill_file({ url })\` if you have its raw \`SKILL.md\` URL, otherwise install it locally, read its \`SKILL.md\`, and call \`create_skill({ name, slug, content, tags })\` (re-adding the same slug updates it). If no suitable skill exists anywhere, do the work directly and capture anything reusable with \`create_skill\`.
 
 ### Organizing the Assets Library
@@ -281,12 +282,33 @@ export async function resolveSystemPrompt(
 	// the agent calls get_skill(slug) to load one on demand. The discovery and
 	// authoring workflow lives in SHARED_INSTRUCTIONS, not inline here.
 	if (resolved.includes('{{skills_context}}')) {
-		const dbSkills = await db.query<{ name: string; slug: string; description: string }>(
-			'SELECT name, slug, description FROM skills WHERE is_active = true ORDER BY name',
-		);
+		// This run's project skills plus globals (a project skill shadows a global
+		// of the same slug). Cross-team sessions with no project see globals only.
+		const dbSkills = ctx.projectId
+			? await db.query<{ name: string; slug: string; description: string }>(
+					`SELECT name, slug, description FROM skills
+					 WHERE is_active = true AND (project_id = $1 OR project_id IS NULL)
+					 ORDER BY slug, project_id NULLS LAST`,
+					[ctx.projectId],
+				)
+			: await db.query<{ name: string; slug: string; description: string }>(
+					`SELECT name, slug, description FROM skills
+					 WHERE is_active = true AND project_id IS NULL
+					 ORDER BY slug`,
+				);
+		// De-dupe by slug (keeps the project's shadowing row, ordered first), then
+		// present alphabetically by name.
+		const seenSlugs = new Set<string>();
+		const skillRows = dbSkills.rows
+			.filter((s) => {
+				if (seenSlugs.has(s.slug)) return false;
+				seenSlugs.add(s.slug);
+				return true;
+			})
+			.sort((a, b) => a.name.localeCompare(b.name));
 		let manifest: string;
-		if (dbSkills.rows.length > 0) {
-			const lines = dbSkills.rows
+		if (skillRows.length > 0) {
+			const lines = skillRows
 				.map((s) => `- ${s.name} (slug: ${s.slug})${s.description ? `: ${s.description}` : ''}`)
 				.join('\n');
 			manifest = [

--- a/packages/server/test/migrate-024-scope-skills-per-project.test.ts
+++ b/packages/server/test/migrate-024-scope-skills-per-project.test.ts
@@ -1,0 +1,88 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createDataPreservationHarness, type DataPreservationHarness } from './helpers/migrate';
+
+const TARGET = '024_scope_skills_per_project.sql';
+
+/**
+ * 024 scopes skills by project (mirrors 018 for connectors). Seed at 023 (skills
+ * still instance-global, slug globally UNIQUE), then assert the migration
+ * preserves the existing rows as global (project_id NULL) AND applies the scoping
+ * (nullable project_id + the two partial unique indexes that let the same slug
+ * exist once globally and once per project).
+ */
+describe('024_scope_skills_per_project migration', () => {
+	let h: DataPreservationHarness;
+	let projectId: string;
+	let globalSkillId: string;
+
+	beforeAll(async () => {
+		h = await createDataPreservationHarness();
+		await h.applyUpToExclusive(TARGET);
+
+		const team = await h.db.query<{ id: string }>(
+			`INSERT INTO teams (name, slug) VALUES ('Acme', 'acme') RETURNING id`,
+		);
+		const project = await h.db.query<{ id: string }>(
+			`INSERT INTO projects (team_id, name, slug, task_prefix)
+			 VALUES ($1, 'Site', 'site', 'SITE') RETURNING id`,
+			[team.rows[0].id],
+		);
+		projectId = project.rows[0].id;
+
+		// A pre-existing (global) skill, authored while the catalog was instance-global.
+		const skill = await h.db.query<{ id: string }>(
+			`INSERT INTO skills (name, slug, description, content, content_hash)
+			 VALUES ('Deploy', 'deploy', 'How to deploy', 'run the deploy', 'abc') RETURNING id`,
+		);
+		globalSkillId = skill.rows[0].id;
+
+		await h.applyTarget(TARGET);
+	});
+	afterAll(() => h.close());
+
+	it('adds the project_id column and the two partial unique indexes', async () => {
+		const col = await h.db.query<{ c: number }>(
+			`SELECT COUNT(*)::int AS c FROM information_schema.columns
+			 WHERE table_name = 'skills' AND column_name = 'project_id'`,
+		);
+		expect(col.rows[0].c).toBe(1);
+
+		const idx = await h.db.query<{ indexname: string }>(
+			`SELECT indexname FROM pg_indexes WHERE tablename = 'skills'`,
+		);
+		const names = idx.rows.map((r) => r.indexname);
+		expect(names).toContain('idx_skills_global_slug');
+		expect(names).toContain('idx_skills_project_slug');
+	});
+
+	it('preserves the pre-existing skill as a global (project_id NULL) row', async () => {
+		const kept = await h.db.query<{ project_id: string | null }>(
+			`SELECT project_id FROM skills WHERE id = $1`,
+			[globalSkillId],
+		);
+		expect(kept.rows.length).toBe(1);
+		expect(kept.rows[0].project_id).toBeNull();
+	});
+
+	it('allows the same slug once globally and once per project (partitioned uniqueness)', async () => {
+		// A project-scoped skill with the same slug as the surviving global one must
+		// be insertable — the per-project partial index namespaces it separately.
+		await h.db.query(
+			`INSERT INTO skills (name, slug, description, content, content_hash, project_id)
+			 VALUES ('Deploy (site)', 'deploy', 'site deploy', 'site steps', 'def', $1)`,
+			[projectId],
+		);
+		const rows = await h.db.query<{ project_id: string | null }>(
+			`SELECT project_id FROM skills WHERE slug = 'deploy' ORDER BY project_id NULLS FIRST`,
+		);
+		expect(rows.rows.length).toBe(2);
+
+		// A second global 'deploy' must be rejected by the global partial unique index.
+		await expect(
+			h.db.query(
+				`INSERT INTO skills (name, slug, content, content_hash)
+				 VALUES ('Dup', 'deploy', 'x', 'x')`,
+			),
+		).rejects.toThrow();
+	});
+});

--- a/packages/server/test/skills-routes-coverage.test.ts
+++ b/packages/server/test/skills-routes-coverage.test.ts
@@ -59,12 +59,18 @@ beforeEach(async () => {
 	await db.query('DELETE FROM skills');
 });
 
+const MISSING_ID = '00000000-0000-0000-0000-000000000000';
+
 function create(body: Record<string, unknown>): Promise<Response> {
 	return app.request('/api/skills', {
 		method: 'POST',
 		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
 		body: JSON.stringify(body),
 	});
+}
+
+async function createId(body: Record<string, unknown>): Promise<string> {
+	return (await (await create(body)).json()).data.id as string;
 }
 
 describe('POST /api/skills validation guards', () => {
@@ -119,9 +125,9 @@ describe('POST /api/skills validation guards', () => {
 	});
 });
 
-describe('PATCH /api/skills/:slug branches', () => {
-	it('404s when patching a non-existent slug', async () => {
-		const res = await app.request('/api/skills/missing-skill', {
+describe('PATCH /api/skills/:id branches', () => {
+	it('404s when patching a non-existent id', async () => {
+		const res = await app.request(`/api/skills/${MISSING_ID}`, {
 			method: 'PATCH',
 			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
 			body: JSON.stringify({ name: 'whatever' }),
@@ -130,8 +136,8 @@ describe('PATCH /api/skills/:slug branches', () => {
 	});
 
 	it('400s when no updatable fields are supplied', async () => {
-		await create({ name: 'Patchable', slug: 'patchable', content: 'v1' });
-		const res = await app.request('/api/skills/patchable', {
+		const id = await createId({ name: 'Patchable', slug: 'patchable', content: 'v1' });
+		const res = await app.request(`/api/skills/${id}`, {
 			method: 'PATCH',
 			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
 			body: JSON.stringify({}),
@@ -141,8 +147,8 @@ describe('PATCH /api/skills/:slug branches', () => {
 	});
 
 	it('updates name and tags only without touching content', async () => {
-		await create({ name: 'Multi', slug: 'multi', content: 'original' });
-		const res = await app.request('/api/skills/multi', {
+		const id = await createId({ name: 'Multi', slug: 'multi', content: 'original' });
+		const res = await app.request(`/api/skills/${id}`, {
 			method: 'PATCH',
 			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
 			body: JSON.stringify({ name: 'Renamed', tags: ['a', 'b'] }),
@@ -155,8 +161,13 @@ describe('PATCH /api/skills/:slug branches', () => {
 	});
 
 	it('re-derives the description from new content when description is blank', async () => {
-		await create({ name: 'ReDesc', slug: 'redesc', content: 'old', description: 'old desc' });
-		const res = await app.request('/api/skills/redesc', {
+		const id = await createId({
+			name: 'ReDesc',
+			slug: 'redesc',
+			content: 'old',
+			description: 'old desc',
+		});
+		const res = await app.request(`/api/skills/${id}`, {
 			method: 'PATCH',
 			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
 			body: JSON.stringify({ description: '', content: 'A brand new opening line.' }),
@@ -168,8 +179,8 @@ describe('PATCH /api/skills/:slug branches', () => {
 	});
 
 	it('sets an explicit non-empty description', async () => {
-		await create({ name: 'D2', slug: 'd2', content: 'body' });
-		const res = await app.request('/api/skills/d2', {
+		const id = await createId({ name: 'D2', slug: 'd2', content: 'body' });
+		const res = await app.request(`/api/skills/${id}`, {
 			method: 'PATCH',
 			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
 			body: JSON.stringify({ description: 'hand written' }),
@@ -178,14 +189,14 @@ describe('PATCH /api/skills/:slug branches', () => {
 	});
 });
 
-describe('GET/DELETE /api/skills/:slug not-found branches', () => {
+describe('GET/DELETE /api/skills/:id not-found branches', () => {
 	it('404s reading a missing skill', async () => {
-		const res = await app.request('/api/skills/nope', { headers: authHeader(token) });
+		const res = await app.request(`/api/skills/${MISSING_ID}`, { headers: authHeader(token) });
 		expect(res.status).toBe(404);
 	});
 
 	it('404s deleting a missing skill', async () => {
-		const res = await app.request('/api/skills/nope', {
+		const res = await app.request(`/api/skills/${MISSING_ID}`, {
 			method: 'DELETE',
 			headers: authHeader(token),
 		});
@@ -193,12 +204,14 @@ describe('GET/DELETE /api/skills/:slug not-found branches', () => {
 	});
 
 	it('404s listing revisions for a missing skill', async () => {
-		const res = await app.request('/api/skills/nope/revisions', { headers: authHeader(token) });
+		const res = await app.request(`/api/skills/${MISSING_ID}/revisions`, {
+			headers: authHeader(token),
+		});
 		expect(res.status).toBe(404);
 	});
 
 	it('404s restoring against a missing skill', async () => {
-		const res = await app.request('/api/skills/nope/restore', {
+		const res = await app.request(`/api/skills/${MISSING_ID}/restore`, {
 			method: 'POST',
 			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
 			body: JSON.stringify({ revision_number: 1 }),

--- a/packages/server/test/skills.test.ts
+++ b/packages/server/test/skills.test.ts
@@ -13,13 +13,15 @@ import { parseGitHubRawUrl, SkillDownloadError } from '../src/services/skill-dow
 import { resolveSystemPrompt } from '../src/services/template-resolver';
 import { buildApp } from '../src/startup';
 import { safeClose } from './helpers';
-import { authHeader, createStubDocker, createTestTeam } from './helpers/app';
+import { authHeader, createStubDocker, createTestProject, createTestTeam } from './helpers/app';
 import { createTestDbWithMigrations } from './helpers/db';
 
 let app: Hono<Env>;
 let db: Db;
 let token: string;
 let teamId: string;
+let projectAId: string;
+let projectBId: string;
 let tempDataDir: string;
 
 beforeAll(async () => {
@@ -41,6 +43,13 @@ beforeAll(async () => {
 
 	const teamRes = await createTestTeam(db, { name: 'Skills Co' });
 	teamId = (await teamRes.json()).data.id;
+	const projA = await createTestProject(db, teamId, { name: 'Project A', task_prefix: 'PA' });
+	projectAId = (await projA.json()).data.id;
+
+	const teamBRes = await createTestTeam(db, { name: 'Skills Co B' });
+	const teamBId = (await teamBRes.json()).data.id;
+	const projB = await createTestProject(db, teamBId, { name: 'Project B', task_prefix: 'PB' });
+	projectBId = (await projB.json()).data.id;
 });
 
 afterAll(async () => {
@@ -78,50 +87,52 @@ describe('global skills CRUD (/api/skills)', () => {
 		});
 	}
 
-	it('creates, lists, reads, updates, and deletes a global skill', async () => {
+	it('creates, lists, reads, updates, and deletes a global skill (by id)', async () => {
 		const created = await create({
 			name: 'Code Review',
 			content: '# Code Review\nReview the diff carefully.',
 			tags: ['quality'],
 		});
 		expect(created.status).toBe(201);
-		const skill = (await created.json()).data as { id: string; slug: string };
+		const skill = (await created.json()).data as { id: string; slug: string; project_id: null };
 		expect(skill.slug).toBe('code-review');
+		expect(skill.project_id).toBeNull();
 
 		const list = await app.request('/api/skills', { headers: authHeader(token) });
 		expect((await list.json()).data.some((s: { slug: string }) => s.slug === 'code-review')).toBe(
 			true,
 		);
 
-		const read = await app.request('/api/skills/code-review', { headers: authHeader(token) });
+		const read = await app.request(`/api/skills/${skill.id}`, { headers: authHeader(token) });
 		expect((await read.json()).data.content).toContain('Review the diff');
 
-		const patched = await app.request('/api/skills/code-review', {
+		const patched = await app.request(`/api/skills/${skill.id}`, {
 			method: 'PATCH',
 			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
 			body: JSON.stringify({ content: '# Code Review\nUpdated body.' }),
 		});
 		expect(patched.status).toBe(200);
 
-		const del = await app.request('/api/skills/code-review', {
+		const del = await app.request(`/api/skills/${skill.id}`, {
 			method: 'DELETE',
 			headers: authHeader(token),
 		});
 		expect(del.status).toBe(200);
-		const gone = await app.request('/api/skills/code-review', { headers: authHeader(token) });
+		const gone = await app.request(`/api/skills/${skill.id}`, { headers: authHeader(token) });
 		expect(gone.status).toBe(404);
 	});
 
-	it('re-POST with the same slug upserts (unique on slug instance-wide)', async () => {
+	it('re-POST with the same slug upserts within the same (global) scope', async () => {
 		await create({ name: 'Dup', slug: 'dup', content: 'v1' });
 		const second = await create({ name: 'Dup', slug: 'dup', content: 'v2' });
 		expect(second.status).toBe(201);
-		const read = await app.request('/api/skills/dup', { headers: authHeader(token) });
+		const id = (await second.json()).data.id as string;
+		const read = await app.request(`/api/skills/${id}`, { headers: authHeader(token) });
 		expect((await read.json()).data.content).toBe('v2');
 	});
 });
 
-describe('skill revisions (/api/skills/:slug/revisions, /restore)', () => {
+describe('skill scope (create + re-scope on /api/skills)', () => {
 	async function create(body: Record<string, unknown>): Promise<Response> {
 		return app.request('/api/skills', {
 			method: 'POST',
@@ -129,45 +140,179 @@ describe('skill revisions (/api/skills/:slug/revisions, /restore)', () => {
 			body: JSON.stringify(body),
 		});
 	}
-	async function patch(slug: string, content: string): Promise<Response> {
-		return app.request(`/api/skills/${slug}`, {
+
+	it('creates a project-scoped skill and the admin list annotates its project', async () => {
+		const created = await create({
+			name: 'Scoped',
+			slug: 'scoped',
+			content: 'body',
+			project_id: projectAId,
+		});
+		expect(created.status).toBe(201);
+		expect((await created.json()).data.project_id).toBe(projectAId);
+
+		const list = await app.request('/api/skills', { headers: authHeader(token) });
+		const row = (await list.json()).data.find((s: { slug: string }) => s.slug === 'scoped');
+		expect(row.project_id).toBe(projectAId);
+		expect(row.project_name).toBe('Project A');
+	});
+
+	it('re-scopes a global skill to a project and back via PATCH', async () => {
+		const created = await create({ name: 'Movable', slug: 'movable', content: 'body' });
+		const id = (await created.json()).data.id as string;
+
+		const toProject = await app.request(`/api/skills/${id}`, {
+			method: 'PATCH',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ project_id: projectAId }),
+		});
+		expect(toProject.status).toBe(200);
+		expect((await toProject.json()).data.project_id).toBe(projectAId);
+
+		const toGlobal = await app.request(`/api/skills/${id}`, {
+			method: 'PATCH',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ project_id: '' }),
+		});
+		expect(toGlobal.status).toBe(200);
+		expect((await toGlobal.json()).data.project_id).toBeNull();
+	});
+
+	it('409s when re-scoping into a scope that already holds the slug', async () => {
+		// A global 'clash' and a project-A 'clash' coexist (partitioned uniqueness).
+		const g = await create({ name: 'Clash', slug: 'clash', content: 'g' });
+		const gId = (await g.json()).data.id as string;
+		await create({ name: 'Clash', slug: 'clash', content: 'p', project_id: projectAId });
+
+		// Moving the global one into project A collides with the project-A 'clash'.
+		const conflict = await app.request(`/api/skills/${gId}`, {
+			method: 'PATCH',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ project_id: projectAId }),
+		});
+		expect(conflict.status).toBe(409);
+	});
+});
+
+describe('per-project skills routes (/api/projects/:projectId/skills)', () => {
+	async function createScoped(
+		body: Record<string, unknown>,
+	): Promise<{ id: string; slug: string }> {
+		const res = await app.request('/api/skills', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify(body),
+		});
+		return (await res.json()).data;
+	}
+
+	it('lists this project’s own skills plus globals', async () => {
+		await createScoped({ name: 'Glob', slug: 'glob', content: 'g' });
+		const own = await createScoped({
+			name: 'Own',
+			slug: 'own',
+			content: 'o',
+			project_id: projectAId,
+		});
+		await createScoped({ name: 'Other', slug: 'other', content: 'x', project_id: projectBId });
+
+		const res = await app.request(`/api/projects/${projectAId}/skills`, {
+			headers: authHeader(token),
+		});
+		const slugs = (await res.json()).data.map((s: { slug: string }) => s.slug);
+		expect(slugs).toContain('glob'); // global visible
+		expect(slugs).toContain('own'); // own project visible
+		expect(slugs).not.toContain('other'); // another project's skill hidden
+		expect(own.id).toBeTruthy();
+	});
+
+	it('edits and removes the project’s own skill but not a global or another project’s', async () => {
+		const own = await createScoped({
+			name: 'Edit Me',
+			slug: 'edit-me',
+			content: 'v1',
+			project_id: projectAId,
+		});
+		const global = await createScoped({ name: 'Keep', slug: 'keep', content: 'g' });
+
+		const edit = await app.request(`/api/projects/${projectAId}/skills/${own.id}`, {
+			method: 'PATCH',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ content: 'v2' }),
+		});
+		expect(edit.status).toBe(200);
+		expect((await edit.json()).data.content).toBe('v2');
+
+		// A global skill is not this project's to edit → 404 (guarded by project_id).
+		const editGlobal = await app.request(`/api/projects/${projectAId}/skills/${global.id}`, {
+			method: 'PATCH',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ content: 'nope' }),
+		});
+		expect(editGlobal.status).toBe(404);
+
+		const delGlobal = await app.request(`/api/projects/${projectAId}/skills/${global.id}`, {
+			method: 'DELETE',
+			headers: authHeader(token),
+		});
+		expect(delGlobal.status).toBe(404);
+
+		const delOwn = await app.request(`/api/projects/${projectAId}/skills/${own.id}`, {
+			method: 'DELETE',
+			headers: authHeader(token),
+		});
+		expect(delOwn.status).toBe(200);
+	});
+});
+
+describe('skill revisions (/api/skills/:id/revisions, /restore)', () => {
+	async function create(body: Record<string, unknown>): Promise<string> {
+		const res = await app.request('/api/skills', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify(body),
+		});
+		return (await res.json()).data.id as string;
+	}
+	async function patch(id: string, content: string): Promise<Response> {
+		return app.request(`/api/skills/${id}`, {
 			method: 'PATCH',
 			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
 			body: JSON.stringify({ content }),
 		});
 	}
 	async function revisions(
-		slug: string,
+		id: string,
 	): Promise<{ revision_number: number; content: string; change_summary: string }[]> {
-		const res = await app.request(`/api/skills/${slug}/revisions`, { headers: authHeader(token) });
+		const res = await app.request(`/api/skills/${id}/revisions`, { headers: authHeader(token) });
 		return (await res.json()).data;
 	}
 
 	it('records a revision of the prior content on each content change (none on create)', async () => {
-		await create({ name: 'Rev', slug: 'rev', content: 'v1' });
+		const id = await create({ name: 'Rev', slug: 'rev', content: 'v1' });
 		// First create snapshots nothing — the history is empty until an edit.
-		expect(await revisions('rev')).toHaveLength(0);
+		expect(await revisions(id)).toHaveLength(0);
 
-		await patch('rev', 'v2');
-		await patch('rev', 'v3');
+		await patch(id, 'v2');
+		await patch(id, 'v3');
 
-		const history = await revisions('rev');
+		const history = await revisions(id);
 		expect(history.map((r) => r.content)).toEqual(['v2', 'v1']); // newest-first, prior content
 		expect(history.map((r) => r.revision_number)).toEqual([2, 1]);
 	});
 
 	it('does not record a revision when content is unchanged', async () => {
-		await create({ name: 'Same', slug: 'same', content: 'body' });
-		await patch('same', 'body');
-		expect(await revisions('same')).toHaveLength(0);
+		const id = await create({ name: 'Same', slug: 'same', content: 'body' });
+		await patch(id, 'body');
+		expect(await revisions(id)).toHaveLength(0);
 	});
 
 	it('restores a prior revision and snapshots the replaced content', async () => {
-		await create({ name: 'Restore', slug: 'restore', content: 'v1' });
-		await patch('restore', 'v2');
-		await patch('restore', 'v3'); // revisions: rev2=v2, rev1=v1
+		const id = await create({ name: 'Restore', slug: 'restore', content: 'v1' });
+		await patch(id, 'v2');
+		await patch(id, 'v3'); // revisions: rev2=v2, rev1=v1
 
-		const restored = await app.request('/api/skills/restore/restore', {
+		const restored = await app.request(`/api/skills/${id}/restore`, {
 			method: 'POST',
 			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
 			body: JSON.stringify({ revision_number: 1 }),
@@ -175,25 +320,25 @@ describe('skill revisions (/api/skills/:slug/revisions, /restore)', () => {
 		expect(restored.status).toBe(200);
 		expect((await restored.json()).data.content).toBe('v1');
 
-		const read = await app.request('/api/skills/restore', { headers: authHeader(token) });
+		const read = await app.request(`/api/skills/${id}`, { headers: authHeader(token) });
 		expect((await read.json()).data.content).toBe('v1');
 
-		const history = await revisions('restore');
+		const history = await revisions(id);
 		// The replaced 'v3' is snapshotted as the newest revision.
 		expect(history[0].content).toBe('v3');
 		expect(history[0].change_summary).toBe('Restored to revision 1');
 	});
 
 	it('400s without a revision_number and 404s for a missing revision', async () => {
-		await create({ name: 'Bad', slug: 'bad', content: 'v1' });
-		const noBody = await app.request('/api/skills/bad/restore', {
+		const id = await create({ name: 'Bad', slug: 'bad', content: 'v1' });
+		const noBody = await app.request(`/api/skills/${id}/restore`, {
 			method: 'POST',
 			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
 			body: JSON.stringify({}),
 		});
 		expect(noBody.status).toBe(400);
 
-		const missing = await app.request('/api/skills/bad/restore', {
+		const missing = await app.request(`/api/skills/${id}/restore`, {
 			method: 'POST',
 			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
 			body: JSON.stringify({ revision_number: 99 }),
@@ -239,5 +384,40 @@ describe('template resolver {{skills_context}} (global)', () => {
 		});
 		expect(resolved).toContain('- Deploy (slug: deploy)');
 		expect(resolved).toContain('- React (slug: react)');
+	});
+
+	it('scopes the manifest to the run’s project (its own skills + globals)', async () => {
+		await db.query(
+			`INSERT INTO skills (name, slug, content, content_hash, is_active, project_id)
+			 VALUES ('Global One', 'global-one', '# g', 'h', true, NULL),
+			        ('A Only', 'a-only', '# a', 'h', true, $1),
+			        ('B Only', 'b-only', '# b', 'h', true, $2)`,
+			[projectAId, projectBId],
+		);
+		const resolved = await resolveSystemPrompt(db, '{{skills_context}}', {
+			teamId,
+			projectId: projectAId,
+			dataDir: tempDataDir,
+		});
+		expect(resolved).toContain('- Global One (slug: global-one)');
+		expect(resolved).toContain('- A Only (slug: a-only)');
+		expect(resolved).not.toContain('b-only'); // another project's skill is not injected
+	});
+
+	it('a project skill shadows a global skill of the same slug', async () => {
+		await db.query(
+			`INSERT INTO skills (name, slug, content, content_hash, is_active, project_id)
+			 VALUES ('Deploy Global', 'deploy', '# g', 'h', true, NULL),
+			        ('Deploy Project', 'deploy', '# p', 'h', true, $1)`,
+			[projectAId],
+		);
+		const resolved = await resolveSystemPrompt(db, '{{skills_context}}', {
+			teamId,
+			projectId: projectAId,
+			dataDir: tempDataDir,
+		});
+		// Only one 'deploy' line, and it's the project's shadowing copy.
+		expect(resolved).toContain('- Deploy Project (slug: deploy)');
+		expect(resolved).not.toContain('Deploy Global');
 	});
 });

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -1068,11 +1068,26 @@ export interface SkillRecord {
 	source_url: string | null;
 	content_hash: string;
 	created_by_member_id: string | null;
+	/**
+	 * Scope: NULL = global ("all projects"); a project id = private to that
+	 * project (shadows a global skill of the same slug within that project).
+	 */
+	project_id: string | null;
 	tags: string[];
 	is_active: boolean;
 	auto_load: boolean;
 	created_at: string;
 	updated_at: string;
+}
+
+/**
+ * A skill row as returned by the admin `/api/skills` list and the per-project
+ * `/api/projects/:projectId/skills` list — annotated with its owning project
+ * (both null for a global skill). `content` is omitted from list endpoints.
+ */
+export interface SkillListItemRecord extends Omit<SkillRecord, 'content'> {
+	project_name?: string | null;
+	project_slug?: string | null;
 }
 
 /**

--- a/packages/web/src/components/project-sidebar.tsx
+++ b/packages/web/src/components/project-sidebar.tsx
@@ -101,6 +101,13 @@ export function ProjectSidebar() {
 		label: 'Connectors',
 		testId: 'project-sidebar-connectors',
 	};
+	// Skills (this project's scoped skills + globals) disclose under Settings, below Connectors.
+	const skillsPage = {
+		to: '/projects/$projectId/skills',
+		params: projectParams,
+		label: 'Skills',
+		testId: 'project-sidebar-skills',
+	};
 
 	// Progress (the project's goals + Captain-maintained summary) leads under Inbox; it's a
 	// normal-project concept, so HQ (internal) has none.
@@ -166,9 +173,9 @@ export function ProjectSidebar() {
 						params: projectParams,
 						label: 'Settings',
 						testId: 'project-sidebar-settings',
-						// Git, Connectors, Container and Activity disclose under Settings when
-						// it (or one of them) is the active route.
-						subItems: [gitPage, connectorsPage, containerPage, activityPage],
+						// Git, Connectors, Skills, Container and Activity disclose under Settings
+						// when it (or one of them) is the active route.
+						subItems: [gitPage, connectorsPage, skillsPage, containerPage, activityPage],
 					},
 				]),
 	];

--- a/packages/web/src/hooks/use-instance-skills.ts
+++ b/packages/web/src/hooks/use-instance-skills.ts
@@ -1,20 +1,29 @@
-import type { RegistrySkillSearchResult, SkillRecord, SkillRevisionRecord } from '@hezo/shared';
+import type {
+	RegistrySkillSearchResult,
+	SkillListItemRecord,
+	SkillRecord,
+	SkillRevisionRecord,
+} from '@hezo/shared';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { api } from '../lib/api';
 import { queryClient } from '../lib/query-client';
 
 export type Skill = SkillRecord;
-export type SkillListItem = Omit<SkillRecord, 'content'>;
+export type SkillListItem = SkillListItemRecord;
 export interface CreateSkillInput {
 	name: string;
 	content: string;
 	description?: string;
 	slug?: string;
 	tags?: string[];
+	/** null / omitted = global; a project id scopes it to that project. */
+	project_id?: string | null;
 }
 
-// Skills are instance-global — one catalog shared with every team's agents.
-// Only the Admin (superuser) manages them, via the /api/skills routes.
+// The global Skills page (/settings/skills) lists ALL skills — global (project_id
+// null) and every project's — annotated with the owning project. Only the Admin
+// (superuser) manages them and changes their scope, via the /api/skills routes.
+// Skills are addressed by id (slug is no longer globally unique once scoped).
 export const INSTANCE_SKILLS_KEY = ['instance', 'skills'] as const;
 
 export function useInstanceSkills() {
@@ -33,16 +42,16 @@ export function useCreateInstanceSkill() {
 	});
 }
 
-export function useInstanceSkill(slug: string | null) {
+export function useInstanceSkill(id: string | null) {
 	return useQuery({
-		queryKey: [...INSTANCE_SKILLS_KEY, slug],
-		queryFn: () => api.get<Skill>(`/api/skills/${slug}`),
-		enabled: !!slug,
+		queryKey: [...INSTANCE_SKILLS_KEY, id],
+		queryFn: () => api.get<Skill>(`/api/skills/${id}`),
+		enabled: !!id,
 	});
 }
 
 export interface UpdateInstanceSkillPayload {
-	slug: string;
+	id: string;
 	name?: string;
 	description?: string;
 	tags?: string[];
@@ -51,8 +60,20 @@ export interface UpdateInstanceSkillPayload {
 
 export function useUpdateInstanceSkill() {
 	return useMutation({
-		mutationFn: ({ slug, ...data }: UpdateInstanceSkillPayload) =>
-			api.patch<SkillListItem>(`/api/skills/${slug}`, data),
+		mutationFn: ({ id, ...data }: UpdateInstanceSkillPayload) =>
+			api.patch<SkillListItem>(`/api/skills/${id}`, data),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: INSTANCE_SKILLS_KEY });
+		},
+	});
+}
+
+// Re-scope a skill (global <-> a project). Invalidate rather than optimistic —
+// a cross-scope slug clash 409s. Mirrors useUpdateInstanceConnectorScope.
+export function useUpdateInstanceSkillScope() {
+	return useMutation({
+		mutationFn: ({ id, project_id }: { id: string; project_id: string | null }) =>
+			api.patch<SkillListItem>(`/api/skills/${id}`, { project_id }),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: INSTANCE_SKILLS_KEY });
 		},
@@ -61,7 +82,7 @@ export function useUpdateInstanceSkill() {
 
 export function useDeleteInstanceSkill() {
 	return useMutation({
-		mutationFn: (slug: string) => api.delete(`/api/skills/${slug}`),
+		mutationFn: (id: string) => api.delete(`/api/skills/${id}`),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: INSTANCE_SKILLS_KEY });
 		},
@@ -69,22 +90,22 @@ export function useDeleteInstanceSkill() {
 }
 
 // Revision history + restore — mirrors the agent system-prompt revision hooks.
-export function useInstanceSkillRevisions(slug: string | null) {
+export function useInstanceSkillRevisions(id: string | null) {
 	return useQuery({
-		queryKey: [...INSTANCE_SKILLS_KEY, slug, 'revisions'],
-		queryFn: () => api.get<SkillRevisionRecord[]>(`/api/skills/${slug}/revisions`),
-		enabled: !!slug,
+		queryKey: [...INSTANCE_SKILLS_KEY, id, 'revisions'],
+		queryFn: () => api.get<SkillRevisionRecord[]>(`/api/skills/${id}/revisions`),
+		enabled: !!id,
 	});
 }
 
-export function useRestoreInstanceSkill(slug: string | null) {
+export function useRestoreInstanceSkill(id: string | null) {
 	return useMutation({
 		mutationFn: (revisionNumber: number) =>
-			api.post(`/api/skills/${slug}/restore`, { revision_number: revisionNumber }),
+			api.post(`/api/skills/${id}/restore`, { revision_number: revisionNumber }),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: INSTANCE_SKILLS_KEY });
-			queryClient.invalidateQueries({ queryKey: [...INSTANCE_SKILLS_KEY, slug] });
-			queryClient.invalidateQueries({ queryKey: [...INSTANCE_SKILLS_KEY, slug, 'revisions'] });
+			queryClient.invalidateQueries({ queryKey: [...INSTANCE_SKILLS_KEY, id] });
+			queryClient.invalidateQueries({ queryKey: [...INSTANCE_SKILLS_KEY, id, 'revisions'] });
 		},
 	});
 }

--- a/packages/web/src/hooks/use-project-skills.ts
+++ b/packages/web/src/hooks/use-project-skills.ts
@@ -1,0 +1,79 @@
+import type { SkillListItemRecord, SkillRecord, SkillRevisionRecord } from '@hezo/shared';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { api } from '../lib/api';
+import { queryClient } from '../lib/query-client';
+import { queryKeys } from '../lib/query-keys';
+
+// The per-project Skills page (/projects/:projectId/skills) lists this project's
+// own skills plus globals. Project-scoped rows are editable/removable here;
+// global rows are read-only (managed on the global /settings/skills page).
+// Scope changes are not possible here — those live on the global page.
+
+export type ProjectSkillListItem = SkillListItemRecord;
+
+export function useProjectSkills(projectId: string) {
+	return useQuery({
+		queryKey: queryKeys.projects.skills(projectId),
+		queryFn: () => api.get<ProjectSkillListItem[]>(`/api/projects/${projectId}/skills`),
+	});
+}
+
+export function useProjectSkill(projectId: string, id: string | null) {
+	return useQuery({
+		queryKey: queryKeys.projects.skill(projectId, id),
+		queryFn: () => api.get<SkillRecord>(`/api/projects/${projectId}/skills/${id}`),
+		enabled: !!id,
+	});
+}
+
+export interface UpdateProjectSkillPayload {
+	id: string;
+	name?: string;
+	description?: string;
+	tags?: string[];
+	content?: string;
+}
+
+export function useUpdateProjectSkill(projectId: string) {
+	return useMutation({
+		mutationFn: ({ id, ...data }: UpdateProjectSkillPayload) =>
+			api.patch<ProjectSkillListItem>(`/api/projects/${projectId}/skills/${id}`, data),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: queryKeys.projects.skills(projectId) });
+		},
+	});
+}
+
+export function useDeleteProjectSkill(projectId: string) {
+	return useMutation({
+		mutationFn: (id: string) => api.delete(`/api/projects/${projectId}/skills/${id}`),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: queryKeys.projects.skills(projectId) });
+		},
+	});
+}
+
+export function useProjectSkillRevisions(projectId: string, id: string | null) {
+	return useQuery({
+		queryKey: [...queryKeys.projects.skill(projectId, id), 'revisions'],
+		queryFn: () =>
+			api.get<SkillRevisionRecord[]>(`/api/projects/${projectId}/skills/${id}/revisions`),
+		enabled: !!id,
+	});
+}
+
+export function useRestoreProjectSkill(projectId: string, id: string | null) {
+	return useMutation({
+		mutationFn: (revisionNumber: number) =>
+			api.post(`/api/projects/${projectId}/skills/${id}/restore`, {
+				revision_number: revisionNumber,
+			}),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: queryKeys.projects.skills(projectId) });
+			queryClient.invalidateQueries({ queryKey: queryKeys.projects.skill(projectId, id) });
+			queryClient.invalidateQueries({
+				queryKey: [...queryKeys.projects.skill(projectId, id), 'revisions'],
+			});
+		},
+	});
+}

--- a/packages/web/src/routeTree.gen.ts
+++ b/packages/web/src/routeTree.gen.ts
@@ -24,6 +24,7 @@ import { Route as SettingsAdminPasswordRouteImport } from './routes/settings/adm
 import { Route as ProjectsProjectIdRouteRouteImport } from './routes/projects/$projectId/route'
 import { Route as ProjectsProjectIdIndexRouteImport } from './routes/projects/$projectId/index'
 import { Route as HomeInboxIndexRouteImport } from './routes/home/inbox/index'
+import { Route as ProjectsProjectIdSkillsRouteImport } from './routes/projects/$projectId/skills'
 import { Route as ProjectsProjectIdGitRouteImport } from './routes/projects/$projectId/git'
 import { Route as ProjectsProjectIdDocumentsRouteImport } from './routes/projects/$projectId/documents'
 import { Route as ProjectsProjectIdContainerRouteImport } from './routes/projects/$projectId/container'
@@ -122,6 +123,11 @@ const HomeInboxIndexRoute = HomeInboxIndexRouteImport.update({
   id: '/home/inbox/',
   path: '/home/inbox/',
   getParentRoute: () => rootRouteImport,
+} as any)
+const ProjectsProjectIdSkillsRoute = ProjectsProjectIdSkillsRouteImport.update({
+  id: '/skills',
+  path: '/skills',
+  getParentRoute: () => ProjectsProjectIdRouteRoute,
 } as any)
 const ProjectsProjectIdGitRoute = ProjectsProjectIdGitRouteImport.update({
   id: '/git',
@@ -281,6 +287,7 @@ export interface FileRoutesByFullPath {
   '/projects/$projectId/container': typeof ProjectsProjectIdContainerRoute
   '/projects/$projectId/documents': typeof ProjectsProjectIdDocumentsRoute
   '/projects/$projectId/git': typeof ProjectsProjectIdGitRoute
+  '/projects/$projectId/skills': typeof ProjectsProjectIdSkillsRoute
   '/home/inbox/': typeof HomeInboxIndexRoute
   '/projects/$projectId/': typeof ProjectsProjectIdIndexRoute
   '/projects/$projectId/agents/$agentId': typeof ProjectsProjectIdAgentsAgentIdRouteRouteWithChildren
@@ -319,6 +326,7 @@ export interface FileRoutesByTo {
   '/projects/$projectId/container': typeof ProjectsProjectIdContainerRoute
   '/projects/$projectId/documents': typeof ProjectsProjectIdDocumentsRoute
   '/projects/$projectId/git': typeof ProjectsProjectIdGitRoute
+  '/projects/$projectId/skills': typeof ProjectsProjectIdSkillsRoute
   '/home/inbox': typeof HomeInboxIndexRoute
   '/projects/$projectId': typeof ProjectsProjectIdIndexRoute
   '/projects/$projectId/agents/hire': typeof ProjectsProjectIdAgentsHireRoute
@@ -359,6 +367,7 @@ export interface FileRoutesById {
   '/projects/$projectId/container': typeof ProjectsProjectIdContainerRoute
   '/projects/$projectId/documents': typeof ProjectsProjectIdDocumentsRoute
   '/projects/$projectId/git': typeof ProjectsProjectIdGitRoute
+  '/projects/$projectId/skills': typeof ProjectsProjectIdSkillsRoute
   '/home/inbox/': typeof HomeInboxIndexRoute
   '/projects/$projectId/': typeof ProjectsProjectIdIndexRoute
   '/projects/$projectId/agents/$agentId': typeof ProjectsProjectIdAgentsAgentIdRouteRouteWithChildren
@@ -401,6 +410,7 @@ export interface FileRouteTypes {
     | '/projects/$projectId/container'
     | '/projects/$projectId/documents'
     | '/projects/$projectId/git'
+    | '/projects/$projectId/skills'
     | '/home/inbox/'
     | '/projects/$projectId/'
     | '/projects/$projectId/agents/$agentId'
@@ -439,6 +449,7 @@ export interface FileRouteTypes {
     | '/projects/$projectId/container'
     | '/projects/$projectId/documents'
     | '/projects/$projectId/git'
+    | '/projects/$projectId/skills'
     | '/home/inbox'
     | '/projects/$projectId'
     | '/projects/$projectId/agents/hire'
@@ -478,6 +489,7 @@ export interface FileRouteTypes {
     | '/projects/$projectId/container'
     | '/projects/$projectId/documents'
     | '/projects/$projectId/git'
+    | '/projects/$projectId/skills'
     | '/home/inbox/'
     | '/projects/$projectId/'
     | '/projects/$projectId/agents/$agentId'
@@ -612,6 +624,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/home/inbox/'
       preLoaderRoute: typeof HomeInboxIndexRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/projects/$projectId/skills': {
+      id: '/projects/$projectId/skills'
+      path: '/skills'
+      fullPath: '/projects/$projectId/skills'
+      preLoaderRoute: typeof ProjectsProjectIdSkillsRouteImport
+      parentRoute: typeof ProjectsProjectIdRouteRoute
     }
     '/projects/$projectId/git': {
       id: '/projects/$projectId/git'
@@ -840,6 +859,7 @@ interface ProjectsProjectIdRouteRouteChildren {
   ProjectsProjectIdContainerRoute: typeof ProjectsProjectIdContainerRoute
   ProjectsProjectIdDocumentsRoute: typeof ProjectsProjectIdDocumentsRoute
   ProjectsProjectIdGitRoute: typeof ProjectsProjectIdGitRoute
+  ProjectsProjectIdSkillsRoute: typeof ProjectsProjectIdSkillsRoute
   ProjectsProjectIdIndexRoute: typeof ProjectsProjectIdIndexRoute
   ProjectsProjectIdAgentsAgentIdRouteRoute: typeof ProjectsProjectIdAgentsAgentIdRouteRouteWithChildren
   ProjectsProjectIdAgentsHireRoute: typeof ProjectsProjectIdAgentsHireRoute
@@ -862,6 +882,7 @@ const ProjectsProjectIdRouteRouteChildren: ProjectsProjectIdRouteRouteChildren =
     ProjectsProjectIdContainerRoute: ProjectsProjectIdContainerRoute,
     ProjectsProjectIdDocumentsRoute: ProjectsProjectIdDocumentsRoute,
     ProjectsProjectIdGitRoute: ProjectsProjectIdGitRoute,
+    ProjectsProjectIdSkillsRoute: ProjectsProjectIdSkillsRoute,
     ProjectsProjectIdIndexRoute: ProjectsProjectIdIndexRoute,
     ProjectsProjectIdAgentsAgentIdRouteRoute:
       ProjectsProjectIdAgentsAgentIdRouteRouteWithChildren,

--- a/packages/web/src/routes/projects/$projectId/connectors.tsx
+++ b/packages/web/src/routes/projects/$projectId/connectors.tsx
@@ -204,6 +204,10 @@ function ConnectorRow({ connector, projectId, focused, focusRef }: ConnectorRowP
 
 	const capability = getConnectorCapability(connector.name);
 	const usesDeviceFlow = !!capability?.deviceAuth;
+	// Global connectors (project_id null) are shared across every project and
+	// managed on the global /settings/connectors page — they are read-only here:
+	// no connect/disconnect/api-key, just a "Global" badge and a link to manage.
+	const isGlobal = connector.project_id === null;
 
 	const url =
 		typeof connector.config === 'object' &&
@@ -273,6 +277,14 @@ function ConnectorRow({ connector, projectId, focused, focusRef }: ConnectorRowP
 							{connector.display_name ?? connector.name}
 						</h2>
 						<StatusBadge status={status} />
+						{isGlobal && (
+							<Badge
+								className="bg-neutral-soft text-neutral-soft-fg"
+								testId="connector-global-badge"
+							>
+								Global
+							</Badge>
+						)}
 					</div>
 					{url && <p className="text-xs text-text-2 mt-1 truncate font-mono">{url}</p>}
 					{connector.oauth_account_label && (
@@ -293,7 +305,16 @@ function ConnectorRow({ connector, projectId, focused, focusRef }: ConnectorRowP
 				</div>
 
 				<div className="flex items-center gap-2 shrink-0">
-					{status === 'active' ? (
+					{isGlobal ? (
+						// Read-only here: manage global connectors on the global page.
+						<Link
+							to="/settings/connectors"
+							className="flex items-center gap-1 text-xs text-text-3 hover:text-text-1"
+							data-testid="connector-global-manage-link"
+						>
+							Manage <ExternalLink className="size-3" />
+						</Link>
+					) : status === 'active' ? (
 						<Button
 							size="sm"
 							variant="outline"
@@ -328,7 +349,7 @@ function ConnectorRow({ connector, projectId, focused, focusRef }: ConnectorRowP
 				</div>
 			</div>
 
-			{status !== 'active' && showApiKey && (
+			{!isGlobal && status !== 'active' && showApiKey && (
 				<div className="mt-3 pt-3 border-t border-border">
 					<ConnectorApiKeyForm
 						projectId={projectId}

--- a/packages/web/src/routes/projects/$projectId/skills.tsx
+++ b/packages/web/src/routes/projects/$projectId/skills.tsx
@@ -1,0 +1,260 @@
+import { createFileRoute, Link } from '@tanstack/react-router';
+import { BookOpen, ExternalLink, Pencil, Plus, Trash2 } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { MarkdownEditor } from '../../../components/markdown-editor';
+import { RevisionsPanel } from '../../../components/revisions-panel';
+import { Badge } from '../../../components/ui/badge';
+import { Button } from '../../../components/ui/button';
+import { InPlaceForm } from '../../../components/ui/in-place-form';
+import { Input } from '../../../components/ui/input';
+import {
+	type ProjectSkillListItem,
+	useDeleteProjectSkill,
+	useProjectSkill,
+	useProjectSkillRevisions,
+	useProjectSkills,
+	useRestoreProjectSkill,
+	useUpdateProjectSkill,
+} from '../../../hooks/use-project-skills';
+
+export const Route = createFileRoute('/projects/$projectId/skills')({
+	component: ProjectSkillsPage,
+});
+
+function ProjectSkillsPage() {
+	const { projectId } = Route.useParams();
+	const { data: skills = [] } = useProjectSkills(projectId);
+	const updateSkill = useUpdateProjectSkill(projectId);
+	const deleteSkill = useDeleteProjectSkill(projectId);
+
+	const [editingId, setEditingId] = useState<string | null>(null);
+	const [name, setName] = useState('');
+	const [description, setDescription] = useState('');
+	const [content, setContent] = useState('');
+	const [tags, setTags] = useState('');
+	const [error, setError] = useState<string | null>(null);
+
+	const { data: editingSkill } = useProjectSkill(projectId, editingId);
+	const { data: revisions } = useProjectSkillRevisions(projectId, editingId);
+	const restoreSkill = useRestoreProjectSkill(projectId, editingId);
+	useEffect(() => {
+		if (editingSkill && editingSkill.id === editingId) {
+			setName(editingSkill.name);
+			setDescription(editingSkill.description ?? '');
+			setContent(editingSkill.content);
+			setTags((editingSkill.tags ?? []).join(', '));
+		}
+	}, [editingSkill, editingId]);
+
+	function resetForm() {
+		setEditingId(null);
+		setName('');
+		setDescription('');
+		setContent('');
+		setTags('');
+		setError(null);
+	}
+
+	async function handleSubmit(e: React.FormEvent) {
+		e.preventDefault();
+		setError(null);
+		if (!name.trim() || !content.trim() || !editingId) {
+			setError('Name and content are required.');
+			return;
+		}
+		const tagList = tags
+			.split(/[\s,]+/)
+			.map((t) => t.trim())
+			.filter(Boolean);
+		try {
+			await updateSkill.mutateAsync({
+				id: editingId,
+				name: name.trim(),
+				description: description.trim(),
+				content,
+				tags: tagList,
+			});
+			resetForm();
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Failed to save skill');
+		}
+	}
+
+	const projectSkills = skills.filter((s) => s.project_id !== null);
+	const globalSkills = skills.filter((s) => s.project_id === null);
+
+	return (
+		<div className="space-y-6 max-w-4xl">
+			<header>
+				<h1 className="text-xl font-semibold flex items-center gap-2">
+					<BookOpen className="size-5" />
+					Skills
+				</h1>
+				<p className="text-sm text-text-3 mt-1">
+					Reusable skill docs for this project's agents. These are scoped to this project — edit or
+					remove them here. Global skills are shown below for reference and are managed on the{' '}
+					<Link to="/settings/skills" className="underline hover:text-text-1">
+						global Skills page
+					</Link>
+					.
+				</p>
+			</header>
+
+			{editingId && (
+				<InPlaceForm
+					title="Edit skill"
+					onClose={resetForm}
+					onSubmit={handleSubmit}
+					footer={
+						<RevisionsPanel
+							revisions={revisions}
+							onRestore={(revisionNumber) => restoreSkill.mutateAsync(revisionNumber)}
+							isRestoring={restoreSkill.isPending}
+						/>
+					}
+				>
+					<div className="flex flex-col sm:flex-row gap-2">
+						<Input
+							placeholder="Name"
+							value={name}
+							onChange={(e) => setName(e.target.value)}
+							required
+							className="flex-1"
+						/>
+						<Input
+							placeholder="Tags (comma-separated, optional)"
+							value={tags}
+							onChange={(e) => setTags(e.target.value)}
+							className="flex-1"
+						/>
+					</div>
+					<Input
+						placeholder="Description (optional — auto-derived from content if empty)"
+						value={description}
+						onChange={(e) => setDescription(e.target.value)}
+					/>
+					<MarkdownEditor
+						label="Content (markdown)"
+						labelClassName="text-[13px] text-text-2"
+						ariaLabel="Skill content"
+						placeholder="Skill content (markdown)"
+						value={content}
+						onChange={setContent}
+						required
+						rows={10}
+						className="font-mono"
+						previewClassName="min-h-[200px]"
+						previewTestId="skill-content-preview"
+						emptyPreviewText="_(nothing to preview)_"
+					/>
+					{error && <p className="text-[13px] text-danger">{error}</p>}
+					<div className="flex gap-2">
+						<Button type="submit" size="sm" disabled={updateSkill.isPending}>
+							Save changes
+						</Button>
+						<Button type="button" variant="secondary" size="sm" onClick={resetForm}>
+							Cancel
+						</Button>
+					</div>
+				</InPlaceForm>
+			)}
+
+			<section className="space-y-2">
+				<h2 className="text-[13px] font-medium text-text-2">This project</h2>
+				{projectSkills.length === 0 ? (
+					<p className="text-[13px] text-text-3">
+						No project-scoped skills yet. Agents create these while they work (choosing project
+						scope), or an admin can scope one here from the global Skills page.
+					</p>
+				) : (
+					<div className="flex flex-col gap-1" data-testid="project-skills-list">
+						{projectSkills.map((s) => (
+							<div
+								key={s.id}
+								className="flex items-center justify-between gap-2 rounded-md border border-border bg-surface px-3 py-2 text-[13px]"
+								data-testid="project-skill-row"
+							>
+								<div className="flex items-center gap-2 min-w-0 flex-1">
+									<span className="font-medium">{s.name}</span>
+									{s.tags?.map((t) => (
+										<Badge key={t} color="neutral">
+											{t}
+										</Badge>
+									))}
+									{s.description && (
+										<span className="text-xs text-text-3 truncate">{s.description}</span>
+									)}
+								</div>
+								<span className="flex items-center gap-2 shrink-0">
+									<button
+										type="button"
+										onClick={() => {
+											setEditingId(s.id);
+											setError(null);
+										}}
+										aria-label={`Edit ${s.name}`}
+										className="text-text-3 hover:text-text-1"
+									>
+										<Pencil className="w-3.5 h-3.5" />
+									</button>
+									<button
+										type="button"
+										onClick={() => {
+											if (confirm(`Delete skill "${s.name}"?`)) deleteSkill.mutate(s.id);
+										}}
+										aria-label={`Delete ${s.name}`}
+										className="text-text-3 hover:text-danger"
+									>
+										<Trash2 className="w-3.5 h-3.5" />
+									</button>
+								</span>
+							</div>
+						))}
+					</div>
+				)}
+			</section>
+
+			{globalSkills.length > 0 && (
+				<section className="space-y-2">
+					<h2 className="text-[13px] font-medium text-text-2">Global (all projects)</h2>
+					<div className="flex flex-col gap-1" data-testid="global-skills-list">
+						{globalSkills.map((s) => (
+							<div
+								key={s.id}
+								className="flex items-center justify-between gap-2 rounded-md border border-border bg-surface px-3 py-2 text-[13px]"
+								data-testid="global-skill-row"
+							>
+								<div className="flex items-center gap-2 min-w-0 flex-1">
+									<span className="font-medium">{s.name}</span>
+									<Badge color="neutral">Global</Badge>
+									{s.tags?.map((t) => (
+										<Badge key={t} color="neutral">
+											{t}
+										</Badge>
+									))}
+									{s.description && (
+										<span className="text-xs text-text-3 truncate">{s.description}</span>
+									)}
+								</div>
+								<Link
+									to="/settings/skills"
+									className="flex items-center gap-1 text-xs text-text-3 hover:text-text-1 shrink-0"
+									data-testid="global-skill-manage-link"
+								>
+									Manage <ExternalLink className="w-3 h-3" />
+								</Link>
+							</div>
+						))}
+					</div>
+				</section>
+			)}
+
+			{skills.length === 0 && (
+				<div className="flex items-center gap-2 text-[13px] text-text-3">
+					<Plus className="w-3.5 h-3.5" />
+					No skills available to this project yet.
+				</div>
+			)}
+		</div>
+	);
+}

--- a/packages/web/src/routes/settings/skills.tsx
+++ b/packages/web/src/routes/settings/skills.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { ExternalLink, Loader2, Pencil, Plus, Search, Trash2 } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { ChevronDown, ExternalLink, Loader2, Pencil, Plus, Search, Trash2 } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
 import { MarkdownEditor } from '../../components/markdown-editor';
 import { RevisionsPanel } from '../../components/revisions-panel';
 import { Badge } from '../../components/ui/badge';
@@ -9,6 +9,11 @@ import { InPlaceForm } from '../../components/ui/in-place-form';
 import { InfoTooltip } from '../../components/ui/info-tooltip';
 import { Input } from '../../components/ui/input';
 import {
+	SearchableSelect,
+	type SearchableSelectOption,
+} from '../../components/ui/searchable-select';
+import {
+	type SkillListItem,
 	useCreateInstanceSkill,
 	useDeleteInstanceSkill,
 	useInstallRegistrySkill,
@@ -20,43 +25,66 @@ import {
 	useSearchRegistrySkills,
 	useSetRegistryToken,
 	useUpdateInstanceSkill,
+	useUpdateInstanceSkillScope,
 } from '../../hooks/use-instance-skills';
 import { useMe } from '../../hooks/use-me';
+import { useAllVisibleProjects } from '../../hooks/use-projects';
+
+// Scope sentinel: create against / re-scope to "all projects" (a global skill,
+// project_id null). Any other option value is a concrete project id.
+const ALL_PROJECTS = 'all';
 
 function InstanceSkillsPage() {
 	const { data: me } = useMe();
 	const { data: skills = [] } = useInstanceSkills();
+	const { projects } = useAllVisibleProjects();
 	const createSkill = useCreateInstanceSkill();
 	const updateSkill = useUpdateInstanceSkill();
 	const deleteSkill = useDeleteInstanceSkill();
 
 	const [showForm, setShowForm] = useState(false);
 	const [showSearch, setShowSearch] = useState(false);
-	// `editingSlug` null = the form (when open) creates; otherwise it edits.
-	const [editingSlug, setEditingSlug] = useState<string | null>(null);
+	// `editingId` null = the form (when open) creates; otherwise it edits.
+	const [editingId, setEditingId] = useState<string | null>(null);
+	const [createScope, setCreateScope] = useState<string>(ALL_PROJECTS);
 	const [name, setName] = useState('');
 	const [description, setDescription] = useState('');
 	const [content, setContent] = useState('');
 	const [tags, setTags] = useState('');
 	const [error, setError] = useState<string | null>(null);
 
+	// Shared "All projects" + every project — drives both the create-form scope
+	// picker and each row's inline re-scope dropdown.
+	const scopeOptions = useMemo<SearchableSelectOption[]>(
+		() => [
+			{ value: ALL_PROJECTS, label: 'All projects' },
+			...projects.map((p) => ({ value: p.id, label: p.name, description: p.teamName })),
+		],
+		[projects],
+	);
+	const createScopeName =
+		createScope === ALL_PROJECTS
+			? null
+			: (projects.find((p) => p.id === createScope)?.name ?? 'this project');
+
 	// Editing needs the full row (content is omitted from the list endpoint), so
-	// fetch it by slug and populate the form once it arrives.
-	const { data: editingSkill } = useInstanceSkill(editingSlug);
-	const { data: revisions } = useInstanceSkillRevisions(editingSlug);
-	const restoreSkill = useRestoreInstanceSkill(editingSlug);
+	// fetch it by id and populate the form once it arrives.
+	const { data: editingSkill } = useInstanceSkill(editingId);
+	const { data: revisions } = useInstanceSkillRevisions(editingId);
+	const restoreSkill = useRestoreInstanceSkill(editingId);
 	useEffect(() => {
-		if (editingSkill && editingSkill.slug === editingSlug) {
+		if (editingSkill && editingSkill.id === editingId) {
 			setName(editingSkill.name);
 			setDescription(editingSkill.description ?? '');
 			setContent(editingSkill.content);
 			setTags((editingSkill.tags ?? []).join(', '));
 		}
-	}, [editingSkill, editingSlug]);
+	}, [editingSkill, editingId]);
 
 	function resetForm() {
 		setShowForm(false);
-		setEditingSlug(null);
+		setEditingId(null);
+		setCreateScope(ALL_PROJECTS);
 		setName('');
 		setDescription('');
 		setContent('');
@@ -69,8 +97,8 @@ function InstanceSkillsPage() {
 		setShowForm(true);
 	}
 
-	function openEdit(slug: string) {
-		setEditingSlug(slug);
+	function openEdit(id: string) {
+		setEditingId(id);
 		setError(null);
 		setShowForm(true);
 	}
@@ -87,9 +115,9 @@ function InstanceSkillsPage() {
 			.map((t) => t.trim())
 			.filter(Boolean);
 		try {
-			if (editingSlug) {
+			if (editingId) {
 				await updateSkill.mutateAsync({
-					slug: editingSlug,
+					id: editingId,
 					name: name.trim(),
 					description: description.trim(),
 					content,
@@ -101,6 +129,7 @@ function InstanceSkillsPage() {
 					description: description.trim() || undefined,
 					content,
 					tags: tagList,
+					project_id: createScope === ALL_PROJECTS ? null : createScope,
 				});
 			}
 			resetForm();
@@ -122,13 +151,14 @@ function InstanceSkillsPage() {
 							<h1 className="text-[22px] font-medium">Skills</h1>
 							<InfoTooltip
 								label="About skills"
-								content="Reusable, project-independent skill docs shared with every team's agents. Agents also discover new skills from skills.sh and add them here."
+								content="Reusable skill docs for your agents. A skill is either global (shared with every project) or scoped to one project. Change a skill's scope with the drop-down on its row."
 								data-testid="skills-info"
 							/>
 						</div>
 						<p className="text-[13px] text-text-2 mt-1 max-w-[680px]">
-							Reusable skill docs shared with every team's agents — author them here, search and add
-							them from skills.sh, or let an agent fetch one while it works.
+							Every skill across every project. Each project's runs see its own skills plus any
+							scoped to "All projects" — author them here, search skills.sh, or let an agent create
+							one while it works.
 						</p>
 					</div>
 					<div className="flex items-center gap-2 shrink-0">
@@ -154,12 +184,18 @@ function InstanceSkillsPage() {
 
 				{showForm && (
 					<InPlaceForm
-						title={editingSlug ? 'Edit skill' : 'Add skill'}
+						title={
+							editingId
+								? 'Edit skill'
+								: createScope === ALL_PROJECTS
+									? 'Add skill (All projects)'
+									: `Add skill — ${createScopeName}`
+						}
 						onClose={resetForm}
 						onSubmit={handleSubmit}
 						footer={
 							/* Outside the <form> so the panel's buttons never submit the editor. */
-							editingSlug ? (
+							editingId ? (
 								<RevisionsPanel
 									revisions={revisions}
 									onRestore={(revisionNumber) => restoreSkill.mutateAsync(revisionNumber)}
@@ -188,6 +224,21 @@ function InstanceSkillsPage() {
 							value={description}
 							onChange={(e) => setDescription(e.target.value)}
 						/>
+						{/* Scope is chosen at create time; existing skills re-scope via the
+						    per-row drop-down (a skill's slug is namespaced per scope). */}
+						{!editingId && (
+							<div className="flex flex-wrap items-center gap-2">
+								<span className="text-[13px] text-text-2">Scope</span>
+								<SearchableSelect
+									options={scopeOptions}
+									value={createScope}
+									onChange={setCreateScope}
+									searchPlaceholder="Search projects…"
+									emptyLabel="No projects"
+									testId="create-scope-select"
+								/>
+							</div>
+						)}
 						<MarkdownEditor
 							label="Content (markdown)"
 							labelClassName="text-[13px] text-text-2"
@@ -209,7 +260,7 @@ function InstanceSkillsPage() {
 								size="sm"
 								disabled={createSkill.isPending || updateSkill.isPending}
 							>
-								{editingSlug ? 'Save changes' : 'Add skill'}
+								{editingId ? 'Save changes' : 'Add skill'}
 							</Button>
 							<Button type="button" variant="secondary" size="sm" onClick={resetForm}>
 								Cancel
@@ -220,49 +271,20 @@ function InstanceSkillsPage() {
 
 				{!skills.length ? (
 					<p className="text-[13px] text-text-2">
-						No instance skills yet. Add one above to share it across every team.
+						No skills yet. Add one above — global, or scoped to a project.
 					</p>
 				) : (
 					<div className="flex flex-col gap-1">
 						{skills.map((s) => (
-							<div
+							<InstanceSkillRow
 								key={s.id}
-								className="flex items-center justify-between rounded-md border border-border bg-surface px-3 py-2 text-[13px]"
-							>
-								<div className="flex items-center gap-2 min-w-0 flex-1">
-									<span className="font-medium">{s.name}</span>
-									{s.tags?.map((t) => (
-										<Badge key={t} color="neutral">
-											{t}
-										</Badge>
-									))}
-									{s.description && (
-										<span className="text-xs text-text-3 truncate">{s.description}</span>
-									)}
-								</div>
-								<span className="flex items-center gap-2 shrink-0">
-									<button
-										type="button"
-										onClick={() => openEdit(s.slug)}
-										aria-label={`Edit ${s.name}`}
-										className="text-text-3 hover:text-text-1"
-									>
-										<Pencil className="w-3.5 h-3.5" />
-									</button>
-									<button
-										type="button"
-										onClick={() => {
-											if (confirm(`Delete instance skill "${s.name}"?`)) {
-												deleteSkill.mutate(s.slug);
-											}
-										}}
-										aria-label={`Delete ${s.name}`}
-										className="text-text-3 hover:text-danger"
-									>
-										<Trash2 className="w-3.5 h-3.5" />
-									</button>
-								</span>
-							</div>
+								skill={s}
+								scopeOptions={scopeOptions}
+								onEdit={() => openEdit(s.id)}
+								onDelete={() => {
+									if (confirm(`Delete skill "${s.name}"?`)) deleteSkill.mutate(s.id);
+								}}
+							/>
 						))}
 					</div>
 				)}
@@ -270,6 +292,97 @@ function InstanceSkillsPage() {
 		);
 
 	return <div className="max-w-[900px]">{content_}</div>;
+}
+
+interface InstanceSkillRowProps {
+	skill: SkillListItem;
+	scopeOptions: SearchableSelectOption[];
+	onEdit: () => void;
+	onDelete: () => void;
+}
+
+function InstanceSkillRow({ skill, scopeOptions, onEdit, onDelete }: InstanceSkillRowProps) {
+	const updateScope = useUpdateInstanceSkillScope();
+	const [rowError, setRowError] = useState<string | null>(null);
+
+	const scopeLabel = skill.project_id ? (skill.project_name ?? 'Project') : 'All projects';
+	const scopeValue = skill.project_id ?? ALL_PROJECTS;
+	const scopeTone = skill.project_id
+		? 'bg-info-soft text-info-soft-fg'
+		: 'bg-neutral-soft text-neutral-soft-fg';
+
+	const changeScope = (next: string) => {
+		setRowError(null);
+		const nextProjectId = next === ALL_PROJECTS ? null : next;
+		if (nextProjectId === (skill.project_id ?? null)) return; // no-op
+		updateScope.mutate(
+			{ id: skill.id, project_id: nextProjectId },
+			{
+				onError: (e: unknown) =>
+					setRowError(e instanceof Error ? e.message : 'Failed to change scope'),
+			},
+		);
+	};
+
+	const scopeTrigger = (
+		<button
+			type="button"
+			data-testid="instance-skill-scope"
+			aria-label={`Scope: ${scopeLabel}. Change scope`}
+			disabled={updateScope.isPending}
+			className={`inline-flex items-center gap-1 whitespace-nowrap rounded-full h-5 pl-2 pr-1.5 text-[11.5px] font-medium outline-none cursor-pointer transition-opacity hover:opacity-80 focus:ring-1 focus:ring-border-strong disabled:opacity-50 ${scopeTone}`}
+		>
+			{updateScope.isPending ? 'Saving…' : scopeLabel}
+			<ChevronDown className="w-3 h-3 opacity-70" />
+		</button>
+	);
+
+	return (
+		<div
+			className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-border bg-surface px-3 py-2 text-[13px]"
+			data-testid="instance-skill-row"
+		>
+			<div className="flex items-center gap-2 min-w-0 flex-1">
+				<span className="font-medium">{skill.name}</span>
+				<SearchableSelect
+					options={scopeOptions}
+					value={scopeValue}
+					onChange={changeScope}
+					trigger={scopeTrigger}
+					searchPlaceholder="Search projects…"
+					emptyLabel="No projects"
+					testId="instance-skill-scope-select"
+				/>
+				{skill.tags?.map((t) => (
+					<Badge key={t} color="neutral">
+						{t}
+					</Badge>
+				))}
+				{skill.description && (
+					<span className="text-xs text-text-3 truncate">{skill.description}</span>
+				)}
+			</div>
+			<span className="flex items-center gap-2 shrink-0">
+				{rowError && <span className="text-xs text-danger">{rowError}</span>}
+				<button
+					type="button"
+					onClick={onEdit}
+					aria-label={`Edit ${skill.name}`}
+					className="text-text-3 hover:text-text-1"
+				>
+					<Pencil className="w-3.5 h-3.5" />
+				</button>
+				<button
+					type="button"
+					onClick={onDelete}
+					aria-label={`Delete ${skill.name}`}
+					className="text-text-3 hover:text-danger"
+				>
+					<Trash2 className="w-3.5 h-3.5" />
+				</button>
+			</span>
+		</div>
+	);
 }
 
 /**

--- a/packages/web/test/connectors-page.test.tsx
+++ b/packages/web/test/connectors-page.test.tsx
@@ -84,6 +84,19 @@ async function markConnectorActive(connectorId: string, oauthConnectionId: strin
 	);
 }
 
+// Seed a genuinely global connector (project_id NULL) straight into the DB so
+// the project page renders it read-only (managed on the global settings page).
+async function seedGlobalConnector(name: string, url: string): Promise<{ id: string }> {
+	const { db } = getTestContext();
+	const r = await db.query<{ id: string }>(
+		`INSERT INTO mcp_connections (name, kind, config, install_status, project_id)
+		 VALUES ($1, 'saas', $2::jsonb, 'installed', NULL)
+		 RETURNING id`,
+		[name, JSON.stringify({ url })],
+	);
+	return r.rows[0];
+}
+
 const CONNECTORS_ROUTE = '/projects/$projectId/connectors';
 
 let sim: GitHubSim | null = null;
@@ -123,6 +136,31 @@ test('lists a seeded MCP connector alongside the always-present GitHub row', asy
 	// The GitHub row, with no connection, shows the pending-connect affordance.
 	const list = getByTestId('connectors-list');
 	expect(list.querySelector('[data-connector-name="github"][data-status="pending"]')).toBeTruthy();
+});
+
+test('a global connector is read-only on the project page (badge + manage link, no actions)', async () => {
+	let slug = '';
+	const { findByText, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			slug = ws.internalSlug;
+			await seedGlobalConnector('shared-global', 'https://global.example/mcp');
+		},
+	});
+	await router.navigate({ to: CONNECTORS_ROUTE, params: { projectId: slug } });
+
+	await findByText('shared-global');
+	const row = (await findByText('shared-global')).closest(
+		'[data-testid="connector-row"]',
+	) as HTMLElement;
+	// A "Global" badge + a link to the global connectors page, and NO mutating actions.
+	expect(within(row).getByTestId('connector-global-badge')).toBeTruthy();
+	const manage = within(row).getByTestId('connector-global-manage-link');
+	expect(manage.getAttribute('href')).toBe('/settings/connectors');
+	expect(within(row).queryByTestId('connector-connect')).toBeNull();
+	expect(within(row).queryByTestId('connector-revoke')).toBeNull();
+	expect(within(row).queryByTestId('connector-api-key-toggle')).toBeNull();
 });
 
 test('shows the empty-state hint when there are no connectors or OAuth connections', async () => {

--- a/packages/web/test/instance-skills.test.tsx
+++ b/packages/web/test/instance-skills.test.tsx
@@ -1,6 +1,7 @@
-import { waitFor } from '@testing-library/react';
+import { waitFor, within } from '@testing-library/react';
 import { expect, test } from 'vitest';
 import { renderApp } from './helpers/render';
+import { seedProject, seedWorkspace } from './helpers/seed';
 
 async function seedInstanceSkill(
 	ctx: { token: string; apiBase: (p: string, i?: RequestInit) => Promise<Response> },
@@ -88,6 +89,39 @@ test('shows skill revision history and restores a prior version', async () => {
 	await waitFor(() =>
 		expect((getByLabelText('Skill content') as HTMLTextAreaElement).value).toBe('Original body v1'),
 	);
+});
+
+test('re-scopes a skill from global to a project via the inline scope dropdown', async () => {
+	let project: { id: string; name: string } | undefined;
+	const { getByText, findByText, findByTestId, user } = await renderApp({
+		initialPath: '/settings/skills',
+		seed: async (ctx) => {
+			await seedInstanceSkill(ctx, { name: 'Movable Skill', content: '# body' });
+			// A visible project to move the skill under (shows in the scope picker).
+			const ws = await seedWorkspace();
+			project = await seedProject(ws, { name: 'Scope Target' });
+		},
+	});
+	if (!project) throw new Error('seed did not create the target project');
+
+	const nameEl = await findByText('Movable Skill');
+	const row = nameEl.closest('[data-testid="instance-skill-row"]') as HTMLElement;
+	// The skill starts global — its inline scope trigger reads "All projects".
+	expect(within(row).getByTestId('instance-skill-scope').textContent).toContain('All projects');
+
+	// Click the scope badge → the searchable dropdown opens; filter to the project.
+	await user.click(within(row).getByTestId('instance-skill-scope'));
+	const search = await findByTestId('instance-skill-scope-select-search');
+	await user.type(search, 'Scope');
+	await user.click(await findByTestId(`instance-skill-scope-select-option-${project.id}`));
+
+	// The PATCH + refetch re-scopes the row; the badge now shows the project name.
+	await waitFor(() => {
+		const r = getByText('Movable Skill').closest(
+			'[data-testid="instance-skill-row"]',
+		) as HTMLElement;
+		expect(within(r).getByTestId('instance-skill-scope').textContent).toContain('Scope Target');
+	});
 });
 
 test('settings page sidebar links to skills', async () => {

--- a/packages/web/test/project-skills.test.tsx
+++ b/packages/web/test/project-skills.test.tsx
@@ -1,0 +1,68 @@
+import { waitFor, within } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+import { seedProject, seedWorkspace } from './helpers/seed';
+
+async function seedSkill(
+	ctx: { token: string; apiBase: (p: string, i?: RequestInit) => Promise<Response> },
+	body: Record<string, unknown>,
+) {
+	const res = await ctx.apiBase('/api/skills', {
+		method: 'POST',
+		headers: { Authorization: `Bearer ${ctx.token}`, 'Content-Type': 'application/json' },
+		body: JSON.stringify(body),
+	});
+	if (res.status !== 201) throw new Error(`seed skill failed: ${res.status}`);
+}
+
+test('the per-project Skills page shows project skills (editable) and globals (read-only)', async () => {
+	let projectSlug = '';
+	const { findByText, findByTestId, findByRole, findByLabelText, getByText, router, user } =
+		await renderApp({
+			initialPath: '/',
+			seed: async (ctx) => {
+				const ws = await seedWorkspace();
+				const project = await seedProject(ws, { name: 'Skills Proj' });
+				projectSlug = project.slug;
+				await seedSkill(ctx, { name: 'A Global Skill', content: '# global' });
+				await seedSkill(ctx, {
+					name: 'A Project Skill',
+					content: '# project v1',
+					project_id: project.id,
+				});
+			},
+		});
+
+	await router.navigate({
+		to: '/projects/$projectId/skills',
+		params: { projectId: projectSlug },
+	});
+
+	await findByText('This project');
+
+	// The project-scoped skill renders in the "This project" section with edit/remove.
+	const projectRow = (await findByText('A Project Skill')).closest(
+		'[data-testid="project-skill-row"]',
+	) as HTMLElement;
+	expect(within(projectRow).getByLabelText('Edit A Project Skill')).toBeTruthy();
+	expect(within(projectRow).getByLabelText('Delete A Project Skill')).toBeTruthy();
+
+	// The global skill renders read-only with a "Global" badge + a manage link.
+	const globalRow = (await findByText('A Global Skill')).closest(
+		'[data-testid="global-skill-row"]',
+	) as HTMLElement;
+	expect(within(globalRow).getByText('Global')).toBeTruthy();
+	expect(within(globalRow).getByTestId('global-skill-manage-link')).toBeTruthy();
+	// No edit/delete affordance on a global row.
+	expect(within(globalRow).queryByLabelText('Edit A Global Skill')).toBeNull();
+	expect(getByText('Global (all projects)')).toBeTruthy();
+
+	// Edit the project skill inline; the form loads its full content and saves.
+	await user.click(within(projectRow).getByLabelText('Edit A Project Skill'));
+	const content = (await findByLabelText('Skill content')) as HTMLTextAreaElement;
+	await waitFor(() => expect(content.value).toBe('# project v1'));
+	await user.clear(content);
+	await user.type(content, '# project v2');
+	await user.click(await findByRole('button', { name: 'Save changes' }));
+	await findByText('A Project Skill');
+});


### PR DESCRIPTION
## What & why

Skills were **instance-global only** — one catalog shared with every project, with no way to scope know-how that belongs to a single project. This PR makes skills **project-scoped or global**, exactly like MCP connectors were made in migration 018.

Scope semantics mirror connectors: **`project_id` NULL = global** ("all projects"); **non-NULL = private to that project**. A project skill **shadows** a global skill of the same slug within that project.

## Behaviour

- **Agents choose scope when authoring.** `create_skill` / `fetch_skill_file` / `propose_skill` gain a `scope` argument (`global` | `project`), defaulting to **project** when omitted. `SHARED_INSTRUCTIONS` tells every agent to choose deliberately (global when the know-how helps any project, project when it's specific to one).
- **Runtime visibility is scoped.** The `{{skills_context}}` manifest, `list_skills`/`get_skill`, full-text search, and mention resolution all return the run's project skills **plus** globals, de-duped so the project's copy wins.
- **Global Skills page (`/settings/skills`, superuser)** lists every skill (global + each project's) with a create-form scope picker and a per-row scope drop-down to re-scope — same UX as the Connectors page.
- **New per-project Skills page (`/projects/:projectId/skills`, any project member)**, under **Connectors** in the project settings menu: lists the project's own skills (editable/removable) plus globals shown **read-only**, badged "Global" with a link to the global page.
- **Per-project Connectors page** now shows global connectors read-only the same way (a "Global" badge + link, no Disconnect/API-key), fixing a place where a global connector looked mutable.

## Implementation

- **Migration 024** adds nullable `skills.project_id` and partitions slug uniqueness into two partial unique indexes (`(slug) WHERE project_id IS NULL` + `(project_id, slug) WHERE project_id IS NOT NULL`). Existing skills stay global. Data-preservation test included.
- Admin `/api/skills` routes re-keyed **slug → id** (slug is no longer globally unique); `GET` annotates the owning project; `POST` accepts `project_id`; `PATCH` also re-scopes (409 on a cross-scope slug clash).
- New `/api/projects/:projectId/skills` routes (project-member auth): list own + globals; edit/remove only the project's own skills (a global or another project's skill can't be mutated there).
- Team-template snapshots capture global skills only; all `ON CONFLICT (slug)` upserts on skills updated to target the correct partial index.

## Docs

- `.dev/architecture.md` documents the data model, shadowing, and surfaces.
- `docs/concepts/skills.md` + `documents-and-memory.md` explain global-vs-project scope; MCP reference regenerated via `bun run build:docs`.

## Testing

- Migration data-preservation test (`migrate-024-*`).
- Server: create with scope, re-scope + 409, project routes (own vs global/other rejection), run-time scoping incl. project-shadows-global, agent-chosen scope. Existing slug-based skills tests updated to id-addressing.
- Web: scope drop-down re-scope, per-project Skills page (project editable, global read-only + badge + link), read-only global connectors.
- `typecheck` + `build` green (pre-commit); targeted vitest tiers pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PRrMWKmvNTGUg8Fseoa39h

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRrMWKmvNTGUg8Fseoa39h)_