### PR TITLE
feat: expandable, auto-growing task comment input

### DIFF
--- a/packages/web/src/components/chat/chat-widget.tsx
+++ b/packages/web/src/components/chat/chat-widget.tsx
@@ -17,6 +17,7 @@ import {
 	X,
 } from 'lucide-react';
 import { type ReactNode, useEffect, useRef, useState } from 'react';
+import { useAutoGrowTextarea } from '../../hooks/use-auto-grow-textarea';
 import { type ChatMessage, useChat } from '../../hooks/use-chat';
 import { useContainerHealth } from '../../hooks/use-container-health';
 import { useDraggableFab } from '../../hooks/use-draggable-fab';
@@ -34,12 +35,6 @@ import { HqContainerNotice } from '../hq-container-notice';
 import { MarkdownProse } from '../markdown-prose';
 import { CountOverlayBadge } from '../ui/count-overlay-badge';
 import { Tooltip } from '../ui/tooltip';
-
-/** Grow/shrink a textarea to fit its content, capped by its CSS `max-height`. */
-function fitTextareaToContent(el: HTMLTextAreaElement): void {
-	el.style.height = 'auto';
-	el.style.height = `${el.scrollHeight}px`;
-}
 
 /**
  * Floating chat with the CEO, pinned bottom-right (on portrait mobile screens
@@ -117,33 +112,9 @@ export function ChatWidget({ open, onOpenChange }: ChatWidgetProps) {
 
 	// Grow the composer with its content (capped by `max-h-32`, then it scrolls),
 	// and collapse it back to a single row when the draft is cleared on submit.
-	// `open` re-runs it when the panel (re)mounts so a draft kept across a close/open
-	// is sized correctly rather than clipped to a single row.
-	// biome-ignore lint/correctness/useExhaustiveDependencies: re-measure on draft/open change (body reads the DOM via a stable ref)
-	useEffect(() => {
-		const el = inputRef.current;
-		if (el) fitTextareaToContent(el);
-	}, [draft, open]);
-
-	// The content height also depends on the composer's *width*: expanding/collapsing
-	// the panel, a viewport breakpoint change, or a web font swapping in all re-wrap
-	// the text. Without re-measuring on those, the box keeps a stale height — too tall
-	// after it widens, or clipping the top line after it narrows. A ResizeObserver
-	// re-fits on any width change; the guard keeps our own height writes (which don't
-	// change width) from feeding back into a resize loop.
-	// biome-ignore lint/correctness/useExhaustiveDependencies: re-attach the observer when the composer (re)mounts on open
-	useEffect(() => {
-		const el = inputRef.current;
-		if (!el || typeof ResizeObserver === 'undefined') return;
-		let lastWidth = el.clientWidth;
-		const ro = new ResizeObserver(() => {
-			if (el.clientWidth === lastWidth) return;
-			lastWidth = el.clientWidth;
-			fitTextareaToContent(el);
-		});
-		ro.observe(el);
-		return () => ro.disconnect();
-	}, [open]);
+	// `open` re-measures when the panel (re)mounts so a draft kept across a
+	// close/open is sized correctly rather than clipped to a single row.
+	useAutoGrowTextarea(inputRef, [draft, open]);
 
 	// Clear the "copied" reset timer on unmount so it can't fire into a gone component.
 	useEffect(() => {

--- a/packages/web/src/components/comment-attachments-drop.tsx
+++ b/packages/web/src/components/comment-attachments-drop.tsx
@@ -9,6 +9,10 @@ interface Props {
 	taskId: string;
 	value: string[];
 	onChange: (ids: string[]) => void;
+	/** Grow to fill a bounded flex column (used by the composer's fullscreen mode)
+	 *  so the textarea below the fixed upload row + chips takes the remaining
+	 *  height. Defaults to the natural, content-sized layout. */
+	fill?: boolean;
 	children: ReactNode;
 }
 
@@ -21,7 +25,14 @@ interface Props {
  * (`useFileAttachments`, `FileDropZone`, `UploadButton`, `AttachmentChips`) are
  * reused as-is by the realtime chat input.
  */
-export function CommentAttachmentsDrop({ projectId, taskId, value, onChange, children }: Props) {
+export function CommentAttachmentsDrop({
+	projectId,
+	taskId,
+	value,
+	onChange,
+	fill,
+	children,
+}: Props) {
 	const upload = useUploadAttachment(projectId, taskId);
 	const {
 		isDragActive,
@@ -42,6 +53,7 @@ export function CommentAttachmentsDrop({ projectId, taskId, value, onChange, chi
 		<FileDropZone
 			isDragActive={isDragActive}
 			dropZoneProps={dropZoneProps}
+			className={fill ? 'flex min-h-0 flex-1 flex-col' : undefined}
 			data-testid="comment-attachments-drop"
 			overlayTestId="comment-attachment-drop-overlay"
 		>
@@ -97,7 +109,7 @@ export function CommentAttachmentsDrop({ projectId, taskId, value, onChange, chi
 					errorTestId="comment-attachment-error"
 				/>
 			)}
-			{children}
+			{fill ? <div className="flex min-h-0 flex-1 flex-col">{children}</div> : children}
 		</FileDropZone>
 	);
 }

--- a/packages/web/src/components/task-detail/comment-composer.tsx
+++ b/packages/web/src/components/task-detail/comment-composer.tsx
@@ -1,13 +1,16 @@
 import { type AgentEffort, extractActiveAgentMentionSlugs } from '@hezo/shared';
-import { CornerDownRight, Loader2, Trash2 } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { CornerDownRight, Loader2, Maximize2, Minimize2, Trash2 } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
 import { useAgents } from '../../hooks/use-agents';
+import { useAutoGrowTextarea } from '../../hooks/use-auto-grow-textarea';
 import type { Comment, useCreateComment } from '../../hooks/use-comments';
 import type { Task } from '../../hooks/use-tasks';
 import { CommentAttachmentsDrop } from '../comment-attachments-drop';
 import { MentionTextarea } from '../mention-textarea';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
+import { DialogContent } from '../ui/dialog';
 import { InfoTooltip } from '../ui/info-tooltip';
 
 type CreateCommentMutation = ReturnType<typeof useCreateComment>;
@@ -64,6 +67,19 @@ export function CommentComposer({
 }: CommentComposerProps) {
 	const [commentText, setCommentText] = useState('');
 	const [pendingAttachmentIds, setPendingAttachmentIds] = useState<string[]>([]);
+	// Expand the composer to a full-viewport editor (available at every breakpoint —
+	// the inline box is cramped on mobile too). In expanded mode the textarea fills
+	// the space via flex; inline it auto-grows/shrinks with its content.
+	const [expanded, setExpanded] = useState(false);
+
+	// Auto-size the inline textarea to its content (capped by `max-h-[40vh]`, then it
+	// scrolls). Disabled when expanded so the `flex-1` fill height wins instead.
+	useAutoGrowTextarea(commentTextareaRef, [commentText, expanded], !expanded);
+
+	// Focus the editor when it opens fullscreen so the user can type immediately.
+	useEffect(() => {
+		if (expanded) commentTextareaRef.current?.focus();
+	}, [expanded, commentTextareaRef]);
 
 	// Replying to an agent's comment wakes that agent (WakeupSource.Reply) even
 	// without an explicit `@`-mention, so it joins the wake preview below.
@@ -107,15 +123,20 @@ export function CommentComposer({
 		setPendingAttachmentIds([]);
 	}
 
-	return (
-		<form ref={commentFormRef} onSubmit={handleComment} className="flex gap-2.5 scroll-mt-20">
-			<div className="hidden md:block w-[26px] shrink-0" aria-hidden />
-			<div className="flex-1 min-w-0 flex flex-col gap-2">
+	const formBody = (
+		<form
+			ref={commentFormRef}
+			onSubmit={handleComment}
+			className={expanded ? 'flex min-h-0 flex-1 flex-col gap-2' : 'flex gap-2.5 scroll-mt-20'}
+		>
+			{!expanded && <div className="hidden md:block w-[26px] shrink-0" aria-hidden />}
+			<div className={`flex-1 min-w-0 flex flex-col gap-2${expanded ? ' min-h-0' : ''}`}>
 				<CommentAttachmentsDrop
 					projectId={projectId}
 					taskId={task.id}
 					value={pendingAttachmentIds}
 					onChange={setPendingAttachmentIds}
+					fill={expanded}
 				>
 					<MentionTextarea
 						ref={commentTextareaRef}
@@ -130,7 +151,13 @@ export function CommentComposer({
 							}
 						}}
 						placeholder="Add a comment..."
-						className="min-h-[60px]"
+						containerClassName={expanded ? 'relative flex min-h-0 flex-1 flex-col' : 'relative'}
+						wrapperClassName={expanded ? 'flex min-h-0 flex-1 flex-col' : undefined}
+						className={
+							expanded
+								? 'flex-1 min-h-0 resize-none overflow-y-auto'
+								: 'min-h-[60px] max-h-[40vh] resize-none overflow-y-auto'
+						}
 					/>
 				</CommentAttachmentsDrop>
 				{replyTarget && (
@@ -183,18 +210,50 @@ export function CommentComposer({
 							))
 						)}
 					</div>
-					<Button
-						type="submit"
-						size="sm"
-						disabled={
-							(!commentText.trim() && pendingAttachmentIds.length === 0) || createComment.isPending
-						}
-					>
-						{createComment.isPending && <Loader2 className="w-3 h-3 animate-spin" />}
-						Comment
-					</Button>
+					<div className="flex items-center gap-2">
+						<button
+							type="button"
+							onClick={() => setExpanded((v) => !v)}
+							aria-label={expanded ? 'Collapse comment editor' : 'Expand comment editor'}
+							data-testid="comment-expand"
+							className="text-text-2 hover:text-text-1 p-1.5 -m-1 shrink-0"
+						>
+							{expanded ? <Minimize2 className="w-4 h-4" /> : <Maximize2 className="w-4 h-4" />}
+						</button>
+						<Button
+							type="submit"
+							size="sm"
+							disabled={
+								(!commentText.trim() && pendingAttachmentIds.length === 0) ||
+								createComment.isPending
+							}
+						>
+							{createComment.isPending && <Loader2 className="w-3 h-3 animate-spin" />}
+							Comment
+						</Button>
+					</div>
 				</div>
 			</div>
 		</form>
+	);
+
+	// Inline by default; in expanded mode the same form (and its state, which lives
+	// above this conditional) is portalled into the shared fullscreen dialog so the
+	// draft survives the inline↔dialog remount. The dialog's close button and Escape
+	// both collapse it via `onOpenChange`.
+	if (!expanded) return formBody;
+	return (
+		<Dialog.Root open onOpenChange={setExpanded}>
+			<DialogContent
+				fullscreen
+				aria-describedby={undefined}
+				data-testid="comment-composer-fullscreen"
+			>
+				<Dialog.Title className="text-lg font-semibold mb-4 pr-16 shrink-0">
+					Add a comment
+				</Dialog.Title>
+				{formBody}
+			</DialogContent>
+		</Dialog.Root>
 	);
 }

--- a/packages/web/src/hooks/use-auto-grow-textarea.ts
+++ b/packages/web/src/hooks/use-auto-grow-textarea.ts
@@ -1,0 +1,60 @@
+import { type DependencyList, type RefObject, useEffect } from 'react';
+
+/** Grow/shrink a textarea to fit its content, capped by its CSS `max-height`. */
+export function fitTextareaToContent(el: HTMLTextAreaElement): void {
+	el.style.height = 'auto';
+	el.style.height = `${el.scrollHeight}px`;
+}
+
+/**
+ * Auto-size a textarea to its content: it grows with the text (capped by the
+ * element's CSS `max-height`, past which it scrolls) and shrinks back down as
+ * content is removed. Extracted from the CEO chat composer so the task-comment
+ * composer can reuse the exact behaviour.
+ *
+ * Pass `enabled = false` when something else owns the height (e.g. a `flex-1`
+ * fill in a fullscreen layout) — the hook then clears any inline height it set
+ * so the flex rule can take over.
+ *
+ * @param ref     the textarea to size
+ * @param deps    values that, when changed, should re-measure (typically the
+ *                controlled value, plus any mount/visibility signal)
+ * @param enabled auto-size while true; clear inline height while false
+ */
+export function useAutoGrowTextarea(
+	ref: RefObject<HTMLTextAreaElement | null>,
+	deps: DependencyList,
+	enabled = true,
+): void {
+	// Re-fit when the content (or another caller-supplied signal) changes, and
+	// collapse back to a single row when it is cleared. When disabled we drop the
+	// inline height so a `flex-1` fill height is not overridden.
+	useEffect(() => {
+		const el = ref.current;
+		if (!el) return;
+		if (!enabled) {
+			el.style.height = '';
+			return;
+		}
+		fitTextareaToContent(el);
+	}, [ref, enabled, ...deps]);
+
+	// The content height also depends on the textarea's *width*: a container
+	// resize, a viewport breakpoint change, or a web font swapping in all re-wrap
+	// the text. Without re-measuring on those, the box keeps a stale height — too
+	// tall after it widens, or clipping the top line after it narrows. A
+	// ResizeObserver re-fits on any width change; the guard keeps our own height
+	// writes (which don't change width) from feeding back into a resize loop.
+	useEffect(() => {
+		const el = ref.current;
+		if (!el || !enabled || typeof ResizeObserver === 'undefined') return;
+		let lastWidth = el.clientWidth;
+		const ro = new ResizeObserver(() => {
+			if (el.clientWidth === lastWidth) return;
+			lastWidth = el.clientWidth;
+			fitTextareaToContent(el);
+		});
+		ro.observe(el);
+		return () => ro.disconnect();
+	}, [ref, enabled]);
+}

--- a/packages/web/src/hooks/use-auto-grow-textarea.ts
+++ b/packages/web/src/hooks/use-auto-grow-textarea.ts
@@ -26,28 +26,29 @@ export function useAutoGrowTextarea(
 	deps: DependencyList,
 	enabled = true,
 ): void {
-	// Re-fit when the content (or another caller-supplied signal) changes, and
-	// collapse back to a single row when it is cleared. When disabled we drop the
-	// inline height so a `flex-1` fill height is not overridden.
+	// One effect does both jobs so they stay in lockstep, re-running on every
+	// caller-supplied signal in `deps`. `deps` must therefore include whatever
+	// gates the textarea's presence (e.g. a panel's `open`, or an `expanded`
+	// flag) — the element mounts *after* the component in those cases, so the
+	// observer has to (re)attach when that signal flips, not just on first mount.
 	useEffect(() => {
 		const el = ref.current;
 		if (!el) return;
+		// Disabled: something else owns the height (a `flex-1` fill), so drop any
+		// inline height we set and attach no observer.
 		if (!enabled) {
 			el.style.height = '';
 			return;
 		}
+		// Grow/shrink to the current content, then keep it right as the width
+		// changes. The content height depends on the textarea's *width* too: a
+		// container resize, a viewport breakpoint change, or a web font swapping in
+		// all re-wrap the text, and without re-measuring the box keeps a stale
+		// height — too tall after it widens, or clipping the top line after it
+		// narrows. The `clientWidth === lastWidth` guard keeps our own height writes
+		// (which don't change width) from feeding back into a resize loop.
 		fitTextareaToContent(el);
-	}, [ref, enabled, ...deps]);
-
-	// The content height also depends on the textarea's *width*: a container
-	// resize, a viewport breakpoint change, or a web font swapping in all re-wrap
-	// the text. Without re-measuring on those, the box keeps a stale height — too
-	// tall after it widens, or clipping the top line after it narrows. A
-	// ResizeObserver re-fits on any width change; the guard keeps our own height
-	// writes (which don't change width) from feeding back into a resize loop.
-	useEffect(() => {
-		const el = ref.current;
-		if (!el || !enabled || typeof ResizeObserver === 'undefined') return;
+		if (typeof ResizeObserver === 'undefined') return;
 		let lastWidth = el.clientWidth;
 		const ro = new ResizeObserver(() => {
 			if (el.clientWidth === lastWidth) return;
@@ -56,5 +57,5 @@ export function useAutoGrowTextarea(
 		});
 		ro.observe(el);
 		return () => ro.disconnect();
-	}, [ref, enabled]);
+	}, [ref, enabled, ...deps]);
 }

--- a/packages/web/test/task-comments.test.tsx
+++ b/packages/web/test/task-comments.test.tsx
@@ -54,6 +54,51 @@ test('submits comment via Cmd/Ctrl+Enter shortcut', async () => {
 	expect(composer.value).toBe('');
 });
 
+test('expand opens a fullscreen editor with every control, and collapse returns inline', async () => {
+	const { findByTestId, findByPlaceholderText, getByRole, queryByTestId, user } =
+		await setupTaskRoute();
+
+	// Inline by default: no fullscreen container yet.
+	await findByPlaceholderText('Add a comment...');
+	expect(queryByTestId('comment-composer-fullscreen')).toBeNull();
+
+	const expandBtn = await findByTestId('comment-expand');
+	expect(expandBtn.getAttribute('aria-label')).toBe('Expand comment editor');
+	await user.click(expandBtn);
+
+	// Fullscreen editor with the textarea and every auxiliary control still present.
+	const fullscreen = await findByTestId('comment-composer-fullscreen');
+	expect(fullscreen).toBeTruthy();
+	const textarea = await findByPlaceholderText('Add a comment...');
+	expect(fullscreen.contains(textarea)).toBe(true);
+	expect(fullscreen.querySelector('[data-testid="comment-attachment-upload-button"]')).toBeTruthy();
+	expect(fullscreen.querySelector('[data-testid="wake-preview"]')).toBeTruthy();
+	expect(getByRole('button', { name: 'Comment' })).toBeTruthy();
+
+	// The toggle flips to collapse and returns the composer inline.
+	const collapseBtn = await findByTestId('comment-expand');
+	expect(collapseBtn.getAttribute('aria-label')).toBe('Collapse comment editor');
+	await user.click(collapseBtn);
+	await waitFor(() => expect(queryByTestId('comment-composer-fullscreen')).toBeNull());
+	await findByPlaceholderText('Add a comment...');
+});
+
+test('draft survives expand and the comment posts from the fullscreen editor', async () => {
+	const { findByText, findByTestId, findByPlaceholderText, getByRole, user } =
+		await setupTaskRoute();
+
+	// Type inline, then expand — the draft (state lives above the remount) carries over.
+	const inline = (await findByPlaceholderText('Add a comment...')) as HTMLTextAreaElement;
+	await user.type(inline, 'Drafted inline, sent fullscreen');
+	await user.click(await findByTestId('comment-expand'));
+
+	const expanded = (await findByPlaceholderText('Add a comment...')) as HTMLTextAreaElement;
+	expect(expanded.value).toBe('Drafted inline, sent fullscreen');
+
+	await user.click(getByRole('button', { name: 'Comment' }));
+	await findByText('Drafted inline, sent fullscreen');
+});
+
 test('comments persist after page reload', async () => {
 	const seeded = { projectSlug: '', taskId: '' };
 	const { findByText, router } = await renderApp({

--- a/test/browser/task-comment-composer.spec.ts
+++ b/test/browser/task-comment-composer.spec.ts
@@ -1,0 +1,142 @@
+// These tests stay in Playwright because they exercise behavior happy-dom
+// doesn't model (see AGENTS.md decision tree):
+//   1. Real CSS layout — the composer textarea auto-grows/shrinks by reading
+//      `scrollHeight`/`clientHeight`, and the fullscreen editor is measured with
+//      `boundingBox()`. happy-dom reports 0 for all of these.
+//   2. Viewport-conditional layout — the fullscreen editor at a 375px mobile
+//      viewport.
+
+import { expect, test } from './fixtures';
+import {
+	createProjectAndClearPlanning,
+	uniqueName,
+	waitForAgentIdle,
+	waitForPageLoad,
+} from './helpers';
+
+type Page = import('@playwright/test').Page;
+
+async function createProjectAndTask(page: Page, token: string) {
+	const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+
+	const projRes = await createProjectAndClearPlanning(page, '', token, {
+		name: uniqueName('Composer Project'),
+		description: 'Test project.',
+	});
+	const project = ((await projRes.json()) as any).data;
+
+	const agentsRes = await page.request.get(`/api/projects/${project.slug}/agents`, { headers });
+	const agents = ((await agentsRes.json()) as { data: Array<{ id: string; slug: string }> }).data;
+	const agent = agents.find((a) => a.slug === 'captain') ?? agents[0];
+
+	const taskRes = await page.request.post(`/api/projects/${project.slug}/tasks`, {
+		headers,
+		data: { project_id: project.id, title: 'Composer Test Task', assignee_id: agent.id },
+	});
+	const task = ((await taskRes.json()) as any).data;
+
+	await waitForAgentIdle(page, project.team_slug, agent.id, token);
+
+	return { token, project, task, agent, headers };
+}
+
+test.describe('Task comment composer', () => {
+	test('inline textarea auto-grows with content, then caps and scrolls', async ({
+		sharedPage: page,
+		sharedWorkspace,
+	}) => {
+		const { task, project } = await createProjectAndTask(page, sharedWorkspace.token);
+		await page.goto(`/projects/${project.slug}/tasks/${task.id}`);
+		await waitForPageLoad(page);
+
+		const composer = page.getByPlaceholder('Add a comment...');
+		await expect(composer).toBeVisible({ timeout: 20_000 });
+
+		const height = () => composer.evaluate((el) => (el as HTMLTextAreaElement).clientHeight);
+		const baseHeight = await height();
+
+		// A few lines grow the box beyond its single-row floor.
+		await composer.fill(Array.from({ length: 5 }, (_, i) => `line ${i + 1}`).join('\n'));
+		await expect.poll(height).toBeGreaterThan(baseHeight);
+		const grownHeight = await height();
+
+		// Far more lines than the `max-h-[40vh]` cap: the box stops growing and the
+		// content overflows into a scroll region instead of pushing the page.
+		await composer.fill(Array.from({ length: 60 }, (_, i) => `line ${i + 1}`).join('\n'));
+		const viewport = page.viewportSize();
+		const cap = Math.round((viewport?.height ?? 0) * 0.4);
+		await expect
+			.poll(() => composer.evaluate((el) => (el as HTMLTextAreaElement).clientHeight))
+			.toBeLessThanOrEqual(cap + 4);
+		expect(await height()).toBeGreaterThanOrEqual(grownHeight);
+		const scrolls = await composer.evaluate(
+			(el) => (el as HTMLTextAreaElement).scrollHeight > (el as HTMLTextAreaElement).clientHeight,
+		);
+		expect(scrolls).toBe(true);
+
+		// Clearing shrinks it back toward the floor.
+		await composer.fill('');
+		await expect.poll(height).toBeLessThan(grownHeight);
+	});
+
+	test('expand fills the viewport with the textarea taking most of the space', async ({
+		sharedPage: page,
+		sharedWorkspace,
+	}) => {
+		const { task, project } = await createProjectAndTask(page, sharedWorkspace.token);
+		await page.goto(`/projects/${project.slug}/tasks/${task.id}`);
+		await waitForPageLoad(page);
+
+		await page.getByTestId('comment-expand').click();
+
+		const dialog = page.getByTestId('comment-composer-fullscreen');
+		await expect(dialog).toBeVisible();
+
+		const viewport = page.viewportSize();
+		const dialogBox = await dialog.boundingBox();
+		expect(dialogBox).not.toBeNull();
+		// Fills the viewport (desktop `sm:inset-4` leaves a small margin).
+		expect(dialogBox!.height).toBeGreaterThan((viewport?.height ?? 0) * 0.8);
+		expect(dialogBox!.width).toBeGreaterThan((viewport?.width ?? 0) * 0.8);
+
+		// The textarea takes most of the vertical space, and the auxiliary controls
+		// stay visible alongside it.
+		const composer = dialog.getByPlaceholder('Add a comment...');
+		const composerBox = await composer.boundingBox();
+		expect(composerBox).not.toBeNull();
+		expect(composerBox!.height).toBeGreaterThan(dialogBox!.height * 0.4);
+		await expect(dialog.getByTestId('comment-attachment-upload-button')).toBeVisible();
+		await expect(dialog.getByTestId('wake-preview')).toBeVisible();
+		await expect(dialog.getByRole('button', { name: 'Comment', exact: true })).toBeVisible();
+
+		// The dialog's built-in close returns the composer inline.
+		await dialog.getByTestId('dialog-close').click();
+		await expect(dialog).toHaveCount(0);
+	});
+
+	test('expand works on a mobile viewport', async ({ sharedPage: page, sharedWorkspace }) => {
+		await page.setViewportSize({ width: 375, height: 812 });
+		const { task, project } = await createProjectAndTask(page, sharedWorkspace.token);
+		await page.goto(`/projects/${project.slug}/tasks/${task.id}`);
+		await waitForPageLoad(page);
+
+		// The toggle is present on mobile (unlike the create-task dialog / CEO chat).
+		const expand = page.getByTestId('comment-expand');
+		await expect(expand).toBeVisible({ timeout: 20_000 });
+		await expand.click();
+
+		const dialog = page.getByTestId('comment-composer-fullscreen');
+		await expect(dialog).toBeVisible();
+		const box = await dialog.boundingBox();
+		expect(box).not.toBeNull();
+		// `fixed inset-0` fills the whole screen on mobile.
+		expect(box!.height).toBeGreaterThan(812 * 0.9);
+		expect(box!.width).toBeGreaterThan(375 * 0.9);
+
+		const composer = dialog.getByPlaceholder('Add a comment...');
+		const composerBox = await composer.boundingBox();
+		expect(composerBox).not.toBeNull();
+		expect(composerBox!.height).toBeGreaterThan(box!.height * 0.4);
+		await expect(dialog.getByRole('button', { name: 'Comment', exact: true })).toBeVisible();
+	});
+});


### PR DESCRIPTION
## Summary

Makes the task-detail comment composer feel like the Create-Task dialog and CEO realtime chat:

1. **Full-viewport expand mode.** A new expand toggle (next to the submit button) opens the composer in the shared fullscreen `DialogContent`, mirroring the Create-Task dialog / CEO chat affordance. In expanded mode the textarea grows to take most of the space while **every other control stays visible** — upload button, drag-drop, attachment chips, reply indicator, wake preview, and submit. Unlike those two references (which are already near-fullscreen on mobile), the expand toggle here is available at **every breakpoint**, since the inline composer is cramped on mobile too.

2. **Auto-growing / auto-shrinking inline textarea.** The inline input now grows with its content (capped by `max-h-[40vh]`, then scrolls) and shrinks back as content is removed, instead of staying a fixed 60px box.

## Implementation

- **Extracted the auto-grow logic into a shared hook.** The CEO chat composer already had this behaviour inline (`fitTextareaToContent` + two effects). Lifted it into `packages/web/src/hooks/use-auto-grow-textarea.ts` (`useAutoGrowTextarea(ref, deps, enabled)`) and reused it in **both** the chat widget (behaviour-preserving refactor) and the comment composer. Passing `enabled = false` clears the inline height so the `flex-1` fill height wins in expanded mode.
- **Comment composer** (`comment-composer.tsx`): added `expanded` state; the same `<form>` body renders inline by default and is portalled into `<DialogContent fullscreen>` when expanded. State lives above the conditional, so a draft survives the inline↔dialog remount. Fill layout is threaded via existing `containerClassName` / `wrapperClassName` overrides on `MentionTextarea` / `Textarea` (same pattern as the Create-Task description's `fill`).
- **Attachments wrapper** (`comment-attachments-drop.tsx`): added a small `fill` opt-in that makes its `FileDropZone` and children container a growing flex column so the textarea consumes the remaining height.

No new props were needed on `MentionTextarea`, the base `Textarea`, or `FileDropZone` — they already accept the class overrides used here.

## Testing

- **Component tests** (`packages/web/test/task-comments.test.tsx`): expand opens the fullscreen editor with every control present, collapse returns inline, and a draft typed inline survives the expand and posts from the fullscreen editor. (17/17 pass.)
- **Playwright** (`test/browser/task-comment-composer.spec.ts`, layout-dependent per the decision tree): the inline textarea auto-grows then caps at `max-h-[40vh]` and scrolls; expand fills the viewport with the textarea taking most of the height while auxiliary controls stay visible; and the same at a 375px mobile viewport. (3/3 pass.)
- Existing chat suites (36/36) confirm the hook extraction is behaviour-preserving.
- `bun run typecheck` and the pre-commit build pass.

## Docs

Pure web-frontend UX change — no CLI flag, MCP tool, route, data-model, or provider change — so no `docs/**`, `.dev/architecture.md`, `SKILL.md`, or `llms.txt` update is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2FmL61TgvsVBhYcvBWTMP

---
_Generated by [Claude Code](https://claude.ai/code/session_01K2FmL61TgvsVBhYcvBWTMP)_