### PR TITLE
fix(web): remove stray bottom border on the active folder tab

### DIFF
--- a/packages/web/src/components/ui/tabs.tsx
+++ b/packages/web/src/components/ui/tabs.tsx
@@ -34,17 +34,29 @@ interface TabsProps {
 }
 
 // Folder ("browser tab") styling, defined once. The active tab gets top + side
-// borders and a rounded top, then pulls itself down 1px (`-mb-px` +
-// `border-b-transparent` + a fill matching the panel below) so it covers the
-// strip's baseline border and reads as raised in front of the others. Inactive
-// tabs stay recessed on the baseline.
+// borders and a rounded top, then pulls itself down 1px (`-mb-px`) and paints an
+// opaque bottom border the same colour as the panel below (`border-b-<surface>`)
+// so it covers the strip's baseline border and reads as raised in front of the
+// others, merging into that panel. A *transparent* bottom border wouldn't do it:
+// the strip's baseline shows straight through, so the active tab reads as a
+// closed box with a bottom border. Inactive tabs stay recessed on the baseline.
 const BASE_TAB =
 	'relative flex items-center gap-1.5 rounded-t-md border px-3 py-2 text-[13px] font-medium transition-colors';
 
+// Maps each supported active-surface fill to the matching bottom-border colour.
+// Kept as literal class strings (not derived at runtime) so Tailwind's scanner
+// emits the utilities. Falls back to `border-b-bg` for any unlisted surface.
+const SURFACE_BOTTOM_BORDER: Record<string, string> = {
+	'bg-bg': 'border-b-bg',
+	'bg-surface': 'border-b-surface',
+};
+
 function tabClass(isActive: boolean, activeSurface: string): string {
-	return isActive
-		? `${BASE_TAB} z-10 -mb-px border-border border-b-transparent ${activeSurface} text-text-1`
-		: `${BASE_TAB} border-transparent bg-surface-2 text-text-2 hover:bg-surface-3 hover:text-text-1`;
+	if (!isActive) {
+		return `${BASE_TAB} border-transparent bg-surface-2 text-text-2 hover:bg-surface-3 hover:text-text-1`;
+	}
+	const bottomBorder = SURFACE_BOTTOM_BORDER[activeSurface] ?? 'border-b-bg';
+	return `${BASE_TAB} z-10 -mb-px border-border ${bottomBorder} ${activeSurface} text-text-1`;
 }
 
 function TabInner({ item }: { item: TabItem }) {

--- a/packages/web/test/agent-detail.test.tsx
+++ b/packages/web/test/agent-detail.test.tsx
@@ -43,10 +43,11 @@ test('agent detail page defaults to Executions tab and exposes Settings tab', as
 	const main = await findByRole('main');
 	await waitFor(() => {
 		// The active tab renders as a folder tab raised in front: its fill matches
-		// the panel below (bg-bg) and its bottom border is removed so it merges in.
+		// the panel below (bg-bg) and its bottom border is painted that same colour
+		// (border-b-bg), covering the strip baseline so it merges in.
 		const executionsLink = within(main).getByRole('link', { name: 'Executions' });
 		expect(executionsLink.className).toMatch(/bg-bg/);
-		expect(executionsLink.className).toMatch(/border-b-transparent/);
+		expect(executionsLink.className).toMatch(/border-b-bg/);
 	});
 
 	const settingsLink = within(getByRole('main')).getByRole('link', { name: 'Settings' });

--- a/packages/web/test/tabs.test.tsx
+++ b/packages/web/test/tabs.test.tsx
@@ -21,15 +21,17 @@ test('controlled Tabs marks the active tab with folder-tab styling and recesses 
 	expect(inactive.getAttribute('aria-selected')).toBe('false');
 
 	// Active tab is raised "in front": its fill matches the panel below (default
-	// bg-bg) and its bottom border is removed so it merges into that panel.
+	// bg-bg) and its bottom border is painted that same colour (border-b-bg), so it
+	// covers the strip's baseline and merges into the panel instead of reading as a
+	// closed box with a bottom border.
 	expect(active.className).toMatch(/bg-bg/);
-	expect(active.className).toMatch(/border-b-transparent/);
+	expect(active.className).toMatch(/border-b-bg/);
 	expect(active.className).toMatch(/text-text-1/);
 
 	// Inactive tab stays recessed on the baseline.
 	expect(inactive.className).toMatch(/bg-surface-2/);
 	expect(inactive.className).toMatch(/text-text-2/);
-	expect(inactive.className).not.toMatch(/border-b-transparent/);
+	expect(inactive.className).not.toMatch(/border-b-bg/);
 });
 
 test('controlled Tabs renders icon + count and fires onValueChange on click', async () => {
@@ -76,7 +78,7 @@ test('controlled Tabs tracks the selected value as it changes', async () => {
 	// Selection moves: the clicked tab becomes the raised folder tab.
 	const egress = getByRole('tab', { name: /Outbound/ });
 	expect(egress.getAttribute('aria-selected')).toBe('true');
-	expect(egress.className).toMatch(/border-b-transparent/);
+	expect(egress.className).toMatch(/border-b-bg/);
 	expect(getByRole('tab', { name: 'All' }).getAttribute('aria-selected')).toBe('false');
 });
 
@@ -87,4 +89,7 @@ test('activeSurface controls the fill the active tab merges into', () => {
 	const active = getByRole('tab', { name: 'All' });
 	expect(active.className).toMatch(/bg-surface\b/);
 	expect(active.className).not.toMatch(/bg-bg/);
+	// The bottom border colour tracks the surface so it covers the strip baseline.
+	expect(active.className).toMatch(/border-b-surface\b/);
+	expect(active.className).not.toMatch(/border-b-bg/);
 });


### PR DESCRIPTION
## Problem

The active tab in the folder-style `Tabs` component (agent detail page, project Activity page, repo-picker & search modals) rendered with a **bottom border**, so it read as a closed box instead of merging into the panel below. The strip's baseline border ran straight under the active tab, closing the box on all four sides.

## Root cause

The active tab styled its bottom border `border-b-transparent` and relied on `-mb-px` plus its own background (via `background-clip: border-box`) to cover the tab strip's baseline `border-b`. That cover never happened in practice — the strip's baseline shows straight through the transparent border, leaving a visible line under the active tab.

I reproduced this with an isolated HTML replica of the exact resolved classes and confirmed the mechanism: with a *transparent* bottom border the baseline shows through; with an *opaque* bottom border colored like the surface it's covered.

## Fix

Paint an **opaque** bottom border the same colour as the active surface so it actually covers the baseline:

- `activeSurface="bg-bg"` (default, page-level bars) → `border-b-bg`
- `activeSurface="bg-surface"` (inside modals) → `border-b-surface`

A small `SURFACE_BOTTOM_BORDER` map keeps these as literal class strings so Tailwind's scanner still emits the utilities (a runtime-derived class name wouldn't be picked up).

## Verification

- **Visual:** rendered the fixed classes in an isolated replica — the active tab now merges into the panel and the baseline continues to the right (the correct folder-tab "notch") in **both light and dark themes**.
- **Compiled CSS:** confirmed `.border-b-bg` / `.border-b-surface` are emitted (`border-bottom-color: var(--color-bg | --color-surface)`) and are ordered after `.border-border`, so they win the `border-bottom-color` cascade.
- **Tests:** updated and green — `tabs.test.tsx`, `agent-detail.test.tsx`, `audit-log.test.tsx` (18 passing). Web package typechecks clean.

## Changes

- `packages/web/src/components/ui/tabs.tsx` — opaque surface-matched bottom border on the active tab; updated the explanatory comment.
- `packages/web/test/tabs.test.tsx`, `packages/web/test/agent-detail.test.tsx` — assert `border-b-bg` / `border-b-surface` instead of `border-b-transparent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjbEHMu8X6HLrmNQnjjH4X