### PR TITLE
Restore revoked connectors in place + add connectors on the project page

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -1035,15 +1035,32 @@ and sets the create scope. The superuser adds a connector in the selected scope
 re-adding a name in the same scope replaces `config` and clears `auth_error`). The page then
 auto-probes the new connector via
 `POST /api/mcp-connections/:id/auth-start` (superuser-gated) — the same PRM → DCR walk as
-the project-scoped auth-start, with two differences: there is no team context (the state
+the project-scoped auth-start; the only difference is team context (the state
 envelope carries `teamId: null`, and the callback skips the team-room broadcasts and
 per-team provider hooks; the settings page refetches off the popup's
-`hezo-oauth-success` postMessage instead), and an MCP server that advertises **no** PRM
-resolves to `{ auth_url: null }` without marking the row failed
-(`PrmUnavailableError` → `no_oauth`) — missing PRM is the normal shape for the page's
-other use case, public / header-authenticated MCPs (`__HEZO_SECRET_*__` placeholders).
-When OAuth *is* advertised, the UI opens the authorize popup automatically on add, and
-every non-active SaaS row keeps a **Connect**/Retry button.
+`hezo-oauth-success` postMessage instead). **Both** surfaces pass `missingPrmMeansNoOAuth`,
+so an MCP server that advertises **no** PRM resolves to `{ auth_url: null }` without marking
+the row failed (`PrmUnavailableError` → `no_oauth`) — missing PRM is the normal shape for
+public / header-authenticated MCPs (`__HEZO_SECRET_*__` placeholders), which either surface
+can add. When OAuth *is* advertised, the UI opens the authorize popup automatically on add,
+and every non-active SaaS row keeps a **Connect**/Retry button.
+
+**User-added connectors (project page).** The per-project Connectors page has the same
+**Add** affordance (name + MCP URL → `POST /api/projects/:projectId/mcp-connections`,
+implicitly this-project-scoped), then auto-probes via the project auth-start exactly as the
+admin page does, so an operator can register either an OAuth or a header-authenticated MCP
+without an agent having asked for one first.
+
+**Revoked → reconnect restores in place.** Revoking clears the token/API-key secret and
+stamps `revoked_at` but keeps the row. Pressing **Connect** or **API key** on a revoked
+connector does **not** error — `startConnectorAuthCode` (OAuth) and the api-key route both
+call `restoreRevokedConnector` (equivalently, `markApiKeyActive` clears `revoked_at`),
+which nulls the revocation and every auth artifact (`oauth_connection_id`,
+`api_key_secret_id`, `activated_at`, `auth_error`) while preserving `config` — including any
+cached DCR client registration, so the reconnect reuses it. This is the same in-place
+restore `createOrFetchConnector` performs for a re-requested agent connector. The only case
+that still needs delete-and-recreate is an instance-address change (the DCR client is bound
+to the old redirect URL).
 
 **Run exclusion.** `loadMcpConnectionsForRun(db, projectId)` returns the run's project's own
 connectors plus global ones (a project connector shadows a global of the same name). It

--- a/docs/mcp/connecting-mcp-servers.md
+++ b/docs/mcp/connecting-mcp-servers.md
@@ -70,12 +70,25 @@ and the global scope both define a connection of the same name, the project's ow
 
 Manage connections two ways:
 
-- **Project → Settings → Connectors** shows just that project's connectors.
+- **Project → Settings → Connectors** shows just that project's connectors. **Add** a
+  connector here — give it a name and MCP server URL — and it's scoped to that project;
+  Hezo probes it for OAuth and opens the connect popup automatically, or you attach an
+  API key from its row if the server authenticates with a header instead.
 - The global **Settings → Connectors** page (admin) lists connectors across every project.
   Each connector shows its scope — **All projects** or a specific project — as a badge you
   can click to re-scope it: a searchable dropdown lets you move the connector to any
   project or back to the global scope. New connectors pick their scope in the Add form the
   same way.
+
+## Reconnecting a revoked connector
+
+Revoking a connector clears its stored token or API key so agents lose access immediately,
+but the connector stays on the page marked **Revoked**. To reconnect, just press **Connect**
+(or **API key**) on it again — Hezo restores the connector in place and runs a fresh
+authorization, so you never have to delete and recreate it. (The exception is an
+instance-address change — see [OAuth connections need an HTTPS address](#oauth-connections-need-an-https-address)
+above — where the OAuth client is tied to the old address and the connector must be removed
+and added again.)
 
 ## Connectors and their credentials
 

--- a/packages/server/src/routes/mcp-connections.ts
+++ b/packages/server/src/routes/mcp-connections.ts
@@ -385,9 +385,9 @@ mcpConnectionsRoutes.post('/projects/:projectId/mcp-connections/:id/api-key', as
 	);
 	if (existing.rows.length === 0) return err(c, 'NOT_FOUND', 'connector not found', 404);
 	const conn = existing.rows[0];
-	if (conn.revoked_at) {
-		return err(c, 'CONNECTOR_REVOKED', 'connector has been revoked; re-add it to reconnect', 400);
-	}
+	// A revoked connector is restored in place: pasting a key is a fresh reconnect
+	// rather than an error. markApiKeyActive below clears revoked_at and re-stamps
+	// activated_at as part of attaching the new key.
 	if (conn.kind !== McpConnectionKind.Saas) {
 		return err(c, 'INVALID_REQUEST', 'API-key auth applies to saas MCP connectors', 400);
 	}

--- a/packages/server/src/routes/oauth.ts
+++ b/packages/server/src/routes/oauth.ts
@@ -13,6 +13,7 @@ import {
 	getConnector,
 	markActive,
 	markFailed,
+	restoreRevokedConnector,
 } from '../services/connectors/lifecycle';
 import { pushConnectorToTeamContainers } from '../services/connectors/live-push';
 import {
@@ -301,16 +302,23 @@ async function startConnectorAuthCode(
 	const db = c.get('db');
 	const masterKeyManager = c.get('masterKeyManager');
 
-	const connector = await getConnector(db, connectorId);
+	let connector = await getConnector(db, connectorId);
 	if (!connector)
 		return { kind: 'error', code: 'NOT_FOUND', message: 'connector not found', status: 404 };
-	if (connector.revoked_at)
-		return {
-			kind: 'error',
-			code: 'CONNECTOR_REVOKED',
-			message: 'connector has been revoked; create a new one to reconnect',
-			status: 400,
-		};
+	// Clicking Connect on a revoked connector restores it in place for a fresh
+	// re-authorization rather than erroring — the user gets a clean reconnect
+	// (old token/key cleared, activation reset) without recreating the connector.
+	// The cached DCR registration in `config` survives, so the DCR walk below
+	// reuses it. Broadcast the flip out of 'revoked' so the row updates live.
+	if (connector.revoked_at) {
+		connector = (await restoreRevokedConnector(db, connector.id)) ?? connector;
+		if (opts.teamId) {
+			broadcastChange(c, wsRoom.team(opts.teamId), 'mcp_connections', 'UPDATE', {
+				id: connector.id,
+				status: 'pending',
+			});
+		}
+	}
 	if (connector.kind !== 'saas')
 		return {
 			kind: 'error',
@@ -468,10 +476,15 @@ oauthRoutes.post('/projects/:projectId/auth-start', async (c) => {
 		teamId,
 		projectId: c.get('projectId') as string,
 		returnTo: `/projects/${c.req.param('projectId')}/connectors?focus=${body.connector_id}`,
+		// A connector added on this page may be a public / header-authenticated MCP
+		// with no OAuth to discover. Resolve that to a null auth_url ("use API key")
+		// rather than a discovery failure — same speculative-probe posture as the
+		// admin surface. Errors past discovery (broken AS metadata, DCR rejected)
+		// still fail the connector.
+		missingPrmMeansNoOAuth: true,
 	});
 	if (result.kind === 'error') return err(c, result.code, result.message, result.status);
-	// Unreachable without `missingPrmMeansNoOAuth`; kept for exhaustiveness.
-	if (result.kind === 'no_oauth') return err(c, 'OAUTH_DISCOVERY_FAILED', result.reason, 503);
+	if (result.kind === 'no_oauth') return ok(c, { auth_url: null, reason: result.reason });
 	return ok(c, { auth_url: result.authUrl });
 });
 

--- a/packages/server/src/services/connectors/lifecycle.ts
+++ b/packages/server/src/services/connectors/lifecycle.ts
@@ -100,24 +100,8 @@ export async function createOrFetchConnector(
 	if (existingRow) {
 		// If this row was previously revoked, restore it for re-authorization.
 		if (existingRow.revoked_at) {
-			await db.query(
-				`UPDATE mcp_connections
-				 SET revoked_at = NULL, auth_error = NULL, oauth_connection_id = NULL,
-				     api_key_secret_id = NULL, activated_at = NULL, updated_at = now()
-				 WHERE id = $1`,
-				[existingRow.id],
-			);
-			return {
-				row: {
-					...existingRow,
-					revoked_at: null,
-					auth_error: null,
-					oauth_connection_id: null,
-					api_key_secret_id: null,
-					activated_at: null,
-				},
-				alreadyExisted: true,
-			};
+			const restored = await restoreRevokedConnector(db, existingRow.id);
+			return { row: restored ?? existingRow, alreadyExisted: true };
 		}
 		return { row: existingRow, alreadyExisted: true };
 	}
@@ -226,6 +210,32 @@ export async function markRevoked(db: Db, connectorId: string): Promise<Connecto
 	const result = await db.query<ConnectorRow>(
 		`UPDATE mcp_connections
 		 SET revoked_at = now(), oauth_connection_id = NULL, api_key_secret_id = NULL, updated_at = now()
+		 WHERE id = $1
+		 RETURNING ${CONNECTOR_COLS}`,
+		[connectorId],
+	);
+	return result.rows[0] ?? null;
+}
+
+/**
+ * Restore a previously-revoked connector to a clean, re-authorizable state — the
+ * "fresh replacement" a user gets by clicking Connect (or pasting an API key) on
+ * a revoked row, instead of being told to recreate it. Clears the revocation and
+ * every auth artifact (linked OAuth connection, pasted API key, activation stamp,
+ * prior auth error) while preserving the connector's identity and `config` —
+ * including any cached DCR client registration, still valid at the Authorization
+ * Server, so a reconnect skips re-registration. The revoke path already purged
+ * the old token / key secret from the vault, so this only resets the row.
+ * Returns null on a non-existent id.
+ */
+export async function restoreRevokedConnector(
+	db: Db,
+	connectorId: string,
+): Promise<ConnectorRow | null> {
+	const result = await db.query<ConnectorRow>(
+		`UPDATE mcp_connections
+		 SET revoked_at = NULL, auth_error = NULL, oauth_connection_id = NULL,
+		     api_key_secret_id = NULL, activated_at = NULL, updated_at = now()
 		 WHERE id = $1
 		 RETURNING ${CONNECTOR_COLS}`,
 		[connectorId],

--- a/packages/server/test/instance-connectors.test.ts
+++ b/packages/server/test/instance-connectors.test.ts
@@ -317,7 +317,7 @@ describe('instance connector OAuth (admin auth-start)', () => {
 		}
 	});
 
-	it('rejects auth-start for non-superusers, unknown, local, and revoked connectors', async () => {
+	it('rejects auth-start for non-superusers, unknown, and local connectors', async () => {
 		const conn = await createSaasConnector('authz-check', `${fake.url}/mcp`);
 
 		const nonSuper = await db.query<{ id: string }>(
@@ -347,14 +347,22 @@ describe('instance connector OAuth (admin auth-start)', () => {
 			headers: authHeader(token),
 		});
 		expect(localRes.status).toBe(400);
+	});
 
+	it('restores a revoked connector in place on auth-start (admin surface)', async () => {
 		const revoked = await createSaasConnector('revoked-authz', `${fake.url}/mcp`);
 		await db.query(`UPDATE mcp_connections SET revoked_at = now() WHERE id = $1`, [revoked.id]);
 		const revokedRes = await app.request(`/api/mcp-connections/${revoked.id}/auth-start`, {
 			method: 'POST',
 			headers: authHeader(token),
 		});
-		expect(revokedRes.status).toBe(400);
+		// Restored + re-authorized rather than rejected: the DCR walk returns an
+		// authorize URL and the row is left un-revoked.
+		expect(revokedRes.status).toBe(200);
+		const authUrl = ((await revokedRes.json()) as { data: { auth_url: string } }).data.auth_url;
+		expect(authUrl).toContain(`${fake.url}/authorize`);
+		const after = await getConnector(db, revoked.id);
+		expect(after?.revoked_at).toBeNull();
 	});
 
 	it("fires the credential_provided wakeup under the requesting task's team when connected from the admin surface", async () => {

--- a/packages/server/test/mcp-connections.test.ts
+++ b/packages/server/test/mcp-connections.test.ts
@@ -235,6 +235,48 @@ describe('POST /projects/:projectId/mcp-connections/:id/api-key', () => {
 		expect(conn.rows[0].api_key_secret_id).toBeNull();
 		await safeClose(ctx.db);
 	});
+
+	it('restores a revoked connector when a new api key is pasted (fresh reconnect)', async () => {
+		const ctx = await createTestApp();
+		const { projectSlug, connectorId } = await seedConnector(ctx);
+
+		// Connect, then revoke — leaves the row revoked with no key.
+		const setUrl = `/api/projects/${projectSlug}/mcp-connections/${connectorId}/api-key`;
+		await ctx.app.request(setUrl, {
+			method: 'POST',
+			headers: { Authorization: `Bearer ${ctx.token}`, 'Content-Type': 'application/json' },
+			body: JSON.stringify({ value: 'tf_old' }),
+		});
+		await ctx.app.request(`/api/projects/${projectSlug}/mcp-connections/${connectorId}/revoke`, {
+			method: 'POST',
+			headers: { Authorization: `Bearer ${ctx.token}`, 'Content-Type': 'application/json' },
+			body: '{}',
+		});
+
+		// Pasting a new key restores in place rather than erroring with CONNECTOR_REVOKED.
+		const res = await ctx.app.request(setUrl, {
+			method: 'POST',
+			headers: { Authorization: `Bearer ${ctx.token}`, 'Content-Type': 'application/json' },
+			body: JSON.stringify({ value: 'tf_new' }),
+		});
+		expect(res.status).toBe(200);
+		const updated = (await res.json()).data as {
+			revoked_at: string | null;
+			activated_at: string | null;
+			api_key_secret_id: string | null;
+		};
+		expect(updated.revoked_at).toBeNull();
+		expect(updated.activated_at).toBeTruthy();
+		expect(updated.api_key_secret_id).toBeTruthy();
+
+		// The descriptor now emits the new key's placeholder (never the raw value).
+		const descriptors = await loadMcpConnectionDescriptors(ctx.db);
+		const tf = descriptors.find((d) => d.name === 'typefully');
+		if (tf?.kind !== 'http') throw new Error('expected http descriptor');
+		expect(tf.headers?.Authorization).toContain('__HEZO_SECRET_');
+		expect(JSON.stringify(tf)).not.toContain('tf_new');
+		await safeClose(ctx.db);
+	});
 });
 
 describe('api-key credential naming + connector→credential relationship', () => {

--- a/packages/server/test/oauth-routes-authcode-branches.test.ts
+++ b/packages/server/test/oauth-routes-authcode-branches.test.ts
@@ -360,19 +360,28 @@ describe('POST /projects/:projectId/auth-start (connector DCR walk)', () => {
 		expect(res.status).toBe(404);
 	});
 
-	it('400s CONNECTOR_REVOKED for a revoked connector', async () => {
-		const { row } = await createOrFetchConnector(db, {
-			name: 'revoked-conn',
-			displayName: 'Revoked',
-			mcpUrl: `${bare.baseUrl}/mcp`,
-			mcpTransport: 'http',
-		});
-		await db.query(`UPDATE mcp_connections SET revoked_at = now() WHERE id = $1`, [row.id]);
-		const res = await authStart(row.id);
-		expect(res.status).toBe(400);
-		expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
-			'CONNECTOR_REVOKED',
-		);
+	it('restores a revoked connector in place and re-authorizes instead of erroring', async () => {
+		const fake = await startFakeMcpServer();
+		try {
+			const { row } = await createOrFetchConnector(db, {
+				name: 'revoked-conn',
+				displayName: 'Revoked',
+				mcpUrl: `${fake.url}/mcp`,
+				mcpTransport: 'http',
+			});
+			await db.query(`UPDATE mcp_connections SET revoked_at = now() WHERE id = $1`, [row.id]);
+			const res = await authStart(row.id);
+			// No CONNECTOR_REVOKED error — the row is restored and the DCR walk yields
+			// an authorize URL (a fresh reconnect).
+			expect(res.status).toBe(200);
+			const authUrl = ((await res.json()) as { data: { auth_url: string } }).data.auth_url;
+			expect(authUrl).toContain('/authorize?');
+			// The connector is un-revoked, ready to re-authorize.
+			const after = await getConnector(db, row.id);
+			expect(after?.revoked_at).toBeNull();
+		} finally {
+			await fake.close();
+		}
 	});
 
 	it('400s for a non-saas connector', async () => {
@@ -401,7 +410,7 @@ describe('POST /projects/:projectId/auth-start (connector DCR walk)', () => {
 		);
 	});
 
-	it('503s and marks the connector failed when PRM discovery finds nothing (project surface)', async () => {
+	it('resolves a PRM-less MCP server to { auth_url: null } without failing the connector (project surface)', async () => {
 		const { row } = await createOrFetchConnector(db, {
 			name: 'no-prm-conn',
 			displayName: 'No PRM',
@@ -409,12 +418,13 @@ describe('POST /projects/:projectId/auth-start (connector DCR walk)', () => {
 			mcpTransport: 'http',
 		});
 		const res = await authStart(row.id);
-		expect(res.status).toBe(503);
-		expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
-			'OAUTH_DISCOVERY_FAILED',
-		);
+		// A connector added on the project page may be public / header-authenticated:
+		// missing PRM is the normal "use API key" shape, not a discovery failure.
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { data: { auth_url: string | null; reason?: string } };
+		expect(body.data.auth_url).toBeNull();
 		const after = await getConnector(db, row.id);
-		expect(after?.auth_error).toMatch(/^discovery:/);
+		expect(after?.auth_error).toBeNull();
 	});
 
 	it('400s OAUTH_DCR_UNSUPPORTED when the AS advertises no registration_endpoint', async () => {

--- a/packages/server/test/oauth-routes-extended.test.ts
+++ b/packages/server/test/oauth-routes-extended.test.ts
@@ -360,23 +360,31 @@ describe('POST /projects/:projectId/auth-start (connector error branches)', () =
 		expect(res.status).toBe(400);
 	});
 
-	it('400 CONNECTOR_REVOKED for a revoked connector', async () => {
-		const { row } = await createOrFetchConnector(db, {
-			name: 'revoked-conn',
-			displayName: 'Revoked',
-			mcpUrl: `${sim.baseUrl}/mcp`,
-			mcpTransport: 'http',
-		});
-		await db.query(`UPDATE mcp_connections SET revoked_at = now() WHERE id = $1`, [row.id]);
-		const res = await app.request(`/api/projects/${projectSlug}/auth-start`, {
-			method: 'POST',
-			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({ connector_id: row.id }),
-		});
-		expect(res.status).toBe(400);
-		expect(((await res.json()) as { error: { code: string } }).error.code).toBe(
-			'CONNECTOR_REVOKED',
-		);
+	it('restores a revoked connector and re-authorizes instead of erroring', async () => {
+		const fake = await startFakeMcpServer();
+		try {
+			const { row } = await createOrFetchConnector(db, {
+				name: 'revoked-conn',
+				displayName: 'Revoked',
+				mcpUrl: `${fake.url}/mcp`,
+				mcpTransport: 'http',
+			});
+			await db.query(`UPDATE mcp_connections SET revoked_at = now() WHERE id = $1`, [row.id]);
+			const res = await app.request(`/api/projects/${projectSlug}/auth-start`, {
+				method: 'POST',
+				headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+				body: JSON.stringify({ connector_id: row.id }),
+			});
+			// No CONNECTOR_REVOKED — the row is restored and the DCR walk yields an
+			// authorize URL, and the connector is left un-revoked (a fresh reconnect).
+			expect(res.status).toBe(200);
+			const authUrl = ((await res.json()) as { data: { auth_url: string } }).data.auth_url;
+			expect(authUrl).toContain('/authorize?');
+			const after = await getConnector(db, row.id);
+			expect(after?.revoked_at).toBeNull();
+		} finally {
+			await fake.close();
+		}
 	});
 
 	it('400 when the connector is not a saas MCP connector', async () => {

--- a/packages/web/src/components/comment-renderers/connect-required-comment.tsx
+++ b/packages/web/src/components/comment-renderers/connect-required-comment.tsx
@@ -2,11 +2,7 @@ import { getConnectorCapability } from '@hezo/shared';
 import { useQueryClient } from '@tanstack/react-query';
 import { Check, KeyRound, Plug } from 'lucide-react';
 import { useEffect, useState } from 'react';
-import {
-	connectorStatus,
-	useMcpConnection,
-	useSetConnectorApiKey,
-} from '../../hooks/use-mcp-connections';
+import { connectorStatus, useMcpConnection } from '../../hooks/use-mcp-connections';
 import { useAuthStart } from '../../hooks/use-oauth-connections';
 import { queryKeys } from '../../lib/query-keys';
 import { ConnectorApiKeyForm } from '../connector-api-key-form';
@@ -25,6 +21,7 @@ export function ConnectRequiredComment({ comment, projectId }: Props) {
 	const authStart = useAuthStart(projectId ?? '');
 	const queryClient = useQueryClient();
 	const [error, setError] = useState<string | null>(null);
+	const [info, setInfo] = useState<string | null>(null);
 	const [deviceOpen, setDeviceOpen] = useState(false);
 	const [showApiKey, setShowApiKey] = useState(false);
 
@@ -67,12 +64,19 @@ export function ConnectRequiredComment({ comment, projectId }: Props) {
 
 	const openConnect = () => {
 		setError(null);
+		setInfo(null);
 		if (usesDeviceFlow) {
 			setDeviceOpen(true);
 			return;
 		}
 		authStart.mutate(connector_id, {
 			onSuccess: ({ auth_url }) => {
+				// A null auth_url means the server advertises no OAuth (public /
+				// header-authenticated) — point the user at the Use API key button.
+				if (!auth_url) {
+					setInfo("This MCP server doesn't advertise OAuth — use the API key option below.");
+					return;
+				}
 				const popup = window.open(auth_url, 'hezo-connect', 'width=600,height=720');
 				if (!popup) {
 					setError('Pop-up blocked. Allow pop-ups for Hezo and try again.');
@@ -137,6 +141,7 @@ export function ConnectRequiredComment({ comment, projectId }: Props) {
 				</div>
 			</div>
 			{error && <p className="pl-6 text-xs text-danger-soft-fg">{error}</p>}
+			{info && <p className="pl-6 text-xs text-text-2">{info}</p>}
 			{usesDeviceFlow && deviceOpen && (
 				<ConnectorDeviceFlowDialog
 					open={deviceOpen}

--- a/packages/web/src/hooks/use-oauth-connections.ts
+++ b/packages/web/src/hooks/use-oauth-connections.ts
@@ -17,7 +17,13 @@ export interface OAuthConnection {
 }
 
 export interface AuthStartResult {
-	auth_url: string;
+	/**
+	 * Authorize URL to open in a popup, or null when the MCP server advertises no
+	 * OAuth (public / header-authenticated) — a normal outcome, not an error: the
+	 * connector is left untouched and can be connected with a pasted API key.
+	 */
+	auth_url: string | null;
+	reason?: string;
 }
 
 export interface DeviceFlowStart {
@@ -64,6 +70,12 @@ export function useAuthStart(projectId: string) {
 			api.post<AuthStartResult>(`/api/projects/${projectId}/auth-start`, {
 				connector_id: connectorId,
 			}),
+		onSettled: () => {
+			// auth-start mutates the row on every path — restores a revoked connector,
+			// persists config.dcr on a successful DCR walk, records auth_error on
+			// failure — so refresh the list to reflect the new status either way.
+			queryClient.invalidateQueries({ queryKey: queryKeys.projects.mcpConnections(projectId) });
+		},
 	});
 }
 

--- a/packages/web/src/routes/projects/$projectId/connectors.tsx
+++ b/packages/web/src/routes/projects/$projectId/connectors.tsx
@@ -1,6 +1,6 @@
 import { getConnectorCapability } from '@hezo/shared';
 import { createFileRoute, Link } from '@tanstack/react-router';
-import { Check, ExternalLink, Github, KeyRound, Plug, Trash2, X } from 'lucide-react';
+import { Check, ExternalLink, Github, KeyRound, Plug, Plus, Trash2, X } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import { ConnectorApiKeyForm } from '../../../components/connector-api-key-form';
 import { ConnectorDeviceFlowDialog } from '../../../components/connector-device-flow-dialog';
@@ -8,9 +8,12 @@ import { RelatedItemsList } from '../../../components/related-items-list';
 import { Badge } from '../../../components/ui/badge';
 import { Button } from '../../../components/ui/button';
 import { ConfirmDialog } from '../../../components/ui/confirm-dialog';
+import { InPlaceForm } from '../../../components/ui/in-place-form';
+import { Input } from '../../../components/ui/input';
 import {
 	connectorStatus,
 	type McpConnection,
+	useCreateMcpConnection,
 	useMcpConnections,
 	useRevokeConnector,
 } from '../../../hooks/use-mcp-connections';
@@ -50,19 +53,34 @@ function ConnectorsPage() {
 	const githubConnection = oauthConnections.find((c) => c.provider === 'github') ?? null;
 	const isEmpty = connectors.length === 0 && oauthConnections.length === 0;
 
+	const [showAdd, setShowAdd] = useState(false);
+
 	return (
 		<div className="space-y-6 max-w-4xl">
-			<header>
-				<h1 className="text-xl font-semibold flex items-center gap-2">
-					<Plug className="size-5" />
-					Connectors
-				</h1>
-				<p className="text-sm text-text-3 mt-1">
-					Third-party services agents use — GitHub for git operations, MCP servers + skill files for
-					everything else. Tokens are stored in the Hezo vault and substituted at egress; agents
-					never see them.
-				</p>
+			<header className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+				<div>
+					<h1 className="text-xl font-semibold flex items-center gap-2">
+						<Plug className="size-5" />
+						Connectors
+					</h1>
+					<p className="text-sm text-text-3 mt-1">
+						Third-party services agents use — GitHub for git operations, MCP servers + skill files
+						for everything else. Tokens are stored in the Hezo vault and substituted at egress;
+						agents never see them.
+					</p>
+				</div>
+				<Button
+					size="sm"
+					variant="secondary"
+					onClick={() => setShowAdd((s) => !s)}
+					className="shrink-0 self-start"
+					data-testid="connector-add-toggle"
+				>
+					<Plus className="size-3.5 mr-1" /> Add
+				</Button>
 			</header>
+
+			{showAdd && <AddConnectorForm projectId={projectId} onClose={() => setShowAdd(false)} />}
 
 			<ul className="space-y-3" data-testid="connectors-list">
 				<GitHubRow projectId={projectId} connection={githubConnection} />
@@ -81,12 +99,109 @@ function ConnectorsPage() {
 
 			{isEmpty && (
 				<p className="text-xs text-text-3 text-center">
-					No third-party MCP servers yet. When an agent calls{' '}
+					No third-party MCP servers yet. Add one above, or when an agent calls{' '}
 					<code className="px-1 py-0.5 rounded bg-surface-2 text-xs">register_connector</code>, a
 					Connect button appears here and on the task that requested it.
 				</p>
 			)}
 		</div>
+	);
+}
+
+interface AddConnectorFormProps {
+	projectId: string;
+	onClose: () => void;
+}
+
+/**
+ * Add a remote (SaaS) MCP connector directly to this project — the same
+ * name+URL create the admin page offers, scoped implicitly to this project.
+ * On submit it creates the row, then probes for OAuth: an OAuth-capable server
+ * opens the authorize popup automatically; a public / header-authenticated one
+ * resolves to a null auth_url and the new row just offers its API-key option.
+ */
+function AddConnectorForm({ projectId, onClose }: AddConnectorFormProps) {
+	const create = useCreateMcpConnection(projectId);
+	const authStart = useAuthStart(projectId);
+	const [name, setName] = useState('');
+	const [url, setUrl] = useState('');
+	const [error, setError] = useState<string | null>(null);
+
+	const submit = async (e: React.FormEvent) => {
+		e.preventDefault();
+		setError(null);
+		if (!name.trim() || !url.trim()) {
+			setError('Name and MCP server URL are required.');
+			return;
+		}
+		let created: McpConnection;
+		try {
+			created = await create.mutateAsync({
+				name: name.trim(),
+				kind: 'saas',
+				config: { url: url.trim() },
+			});
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Failed to add connector');
+			return;
+		}
+		// The row already shows in the list; probe the new connector for OAuth and
+		// pop the authorize window when it advertises any. Header-auth / public MCPs
+		// resolve to auth_url null and are connected later with a pasted API key from
+		// their row, so those just close the form. Keep the form open only to surface
+		// a blocked popup (its error can't render once the form unmounts).
+		try {
+			const started = await authStart.mutateAsync(created.id);
+			if (started.auth_url) {
+				const popup = window.open(started.auth_url, 'hezo-connect', 'width=600,height=720');
+				if (!popup) {
+					setError('Pop-up blocked. Allow pop-ups for Hezo and try again.');
+					return;
+				}
+			}
+		} catch {
+			// The row exists regardless; any auth failure is recorded on it (Failed
+			// badge + Retry), so the user can connect from the row itself.
+		}
+		onClose();
+	};
+
+	return (
+		<InPlaceForm
+			title="Add connector"
+			onClose={onClose}
+			onSubmit={submit}
+			data-testid="connector-add-form"
+		>
+			<Input
+				placeholder="Name (e.g. linear)"
+				value={name}
+				onChange={(e) => setName(e.target.value)}
+				data-testid="connector-add-name"
+				required
+			/>
+			<Input
+				placeholder="MCP server URL (e.g. https://mcp.example.com/mcp)"
+				value={url}
+				onChange={(e) => setUrl(e.target.value)}
+				data-testid="connector-add-url"
+				required
+			/>
+			{error && <p className="text-xs text-danger-soft-fg">{error}</p>}
+			<div className="flex gap-2">
+				<Button
+					type="submit"
+					size="sm"
+					disabled={create.isPending}
+					data-testid="connector-add-submit"
+				>
+					{create.isPending ? 'Adding…' : 'Add connector'}
+				</Button>
+				<Button type="button" size="sm" variant="secondary" onClick={onClose}>
+					Cancel
+				</Button>
+			</div>
+		</InPlaceForm>
 	);
 }
 
@@ -217,6 +332,7 @@ function ConnectorRow({ connector, projectId, focused, focusRef }: ConnectorRowP
 	const authStart = useAuthStart(projectId);
 	const revoke = useRevokeConnector(projectId);
 	const [error, setError] = useState<string | null>(null);
+	const [info, setInfo] = useState<string | null>(null);
 	const [deviceOpen, setDeviceOpen] = useState(false);
 	const [showApiKey, setShowApiKey] = useState(false);
 	const [confirmOpen, setConfirmOpen] = useState(false);
@@ -241,6 +357,7 @@ function ConnectorRow({ connector, projectId, focused, focusRef }: ConnectorRowP
 
 	const openConnect = () => {
 		setError(null);
+		setInfo(null);
 		// Providers whose AS can't do DCR (declared via `deviceAuth`) authorize
 		// through the device flow; everything else uses the redirect popup.
 		if (usesDeviceFlow) {
@@ -249,6 +366,12 @@ function ConnectorRow({ connector, projectId, focused, focusRef }: ConnectorRowP
 		}
 		authStart.mutate(connector.id, {
 			onSuccess: ({ auth_url }) => {
+				// A null auth_url means the server advertises no OAuth (public /
+				// header-authenticated) — not an error: point the user at the API key.
+				if (!auth_url) {
+					setInfo("This MCP server doesn't advertise OAuth — connect it with the API key option.");
+					return;
+				}
 				const popup = window.open(auth_url, 'hezo-connect', 'width=600,height=720');
 				if (!popup) {
 					setError('Pop-up blocked. Allow pop-ups for Hezo and try again.');
@@ -321,6 +444,7 @@ function ConnectorRow({ connector, projectId, focused, focusRef }: ConnectorRowP
 						<p className="text-xs text-danger-soft-fg mt-2">{connector.auth_error}</p>
 					)}
 					{error && <p className="text-xs text-danger-soft-fg mt-2">{error}</p>}
+					{info && <p className="text-xs text-text-3 mt-2">{info}</p>}
 				</div>
 
 				<div className="flex items-center gap-2 shrink-0">

--- a/packages/web/test/connectors-page.test.tsx
+++ b/packages/web/test/connectors-page.test.tsx
@@ -138,6 +138,60 @@ test('lists a seeded MCP connector alongside the always-present GitHub row', asy
 	expect(list.querySelector('[data-connector-name="github"][data-status="pending"]')).toBeTruthy();
 });
 
+test('the Add form creates a project-scoped connector and auto-probes OAuth', async () => {
+	let slug = '';
+	const { findByText, findByTestId, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			slug = ws.internalSlug;
+		},
+	});
+	await router.navigate({ to: CONNECTORS_ROUTE, params: { projectId: slug } });
+	await findByText('Connectors', { selector: 'h1' });
+
+	// Stub the post-create auth-start so submitting doesn't drive the real DCR
+	// discovery machinery (network) — return an authorize URL and capture the
+	// popup the form opens with it.
+	const original = globalThis.fetch;
+	globalThis.fetch = Object.assign(async (input: RequestInfo | URL, init?: RequestInit) => {
+		const url = typeof input === 'string' ? input : input.toString();
+		if (init?.method === 'POST' && /\/auth-start$/.test(url)) {
+			return new Response(
+				JSON.stringify({ data: { auth_url: 'https://as.example.com/authorize' } }),
+				{
+					status: 200,
+					headers: { 'Content-Type': 'application/json' },
+				},
+			);
+		}
+		return original(input, init);
+	}, original);
+	const opened: Array<string | URL | undefined> = [];
+	const originalOpen = window.open;
+	window.open = ((u?: string | URL) => {
+		opened.push(u);
+		return {} as Window;
+	}) as typeof window.open;
+
+	try {
+		// Open the Add form, fill name + URL, submit.
+		(await findByTestId('connector-add-toggle')).click();
+		await user.type(await findByTestId('connector-add-name'), 'linear');
+		await user.type(await findByTestId('connector-add-url'), 'https://mcp.linear.example/mcp');
+		(await findByTestId('connector-add-submit')).click();
+
+		// The created connector renders as its own row with its url (create → refetch).
+		await findByText('linear');
+		await findByText('https://mcp.linear.example/mcp');
+		// The auto-probe opened the authorize popup with the returned URL.
+		await waitFor(() => expect(opened).toContain('https://as.example.com/authorize'));
+	} finally {
+		window.open = originalOpen;
+		globalThis.fetch = original;
+	}
+});
+
 test('a global connector is read-only on the project page (badge + manage link, no actions)', async () => {
 	let slug = '';
 	const { findByText, router } = await renderApp({


### PR DESCRIPTION
## What & why

Two connector UX fixes prompted by a **Revoked** Higgsfield connector whose only options returned an error instead of reconnecting.

### 1. Reconnecting a revoked connector restores it in place (no more error)

Pressing **Connect** or **API key** on a revoked connector used to return `connector has been revoked; create a new one to reconnect` from the OAuth auth-start path and `…re-add it to reconnect` from the API-key path — forcing a delete-and-recreate. Now it does a **fresh replacement in place**:

- New `restoreRevokedConnector` in `services/connectors/lifecycle.ts` clears the revocation and every auth artifact (`oauth_connection_id`, `api_key_secret_id`, `activated_at`, `auth_error`) while preserving `config` — including any cached DCR client registration, so the reconnect reuses it. This DRYs the identical restore `createOrFetchConnector` already performed for re-requested agent connectors.
- `startConnectorAuthCode` (OAuth Connect) restores instead of erroring and broadcasts the row out of `revoked` so the UI updates live.
- The api-key route drops its revoked early-return — `markApiKeyActive` already clears `revoked_at` when the new key is attached.

The one case that still needs delete-and-recreate — an instance-address change (the DCR client is bound to the old redirect URL) — is unchanged and documented.

### 2. Add a connector directly on the per-project Connectors page

Previously only agent-registered or global connectors appeared there. Now:

- A new **Add** form (name + MCP URL) creates a project-scoped connector and auto-probes OAuth, mirroring the admin Settings page.
- Project `auth-start` now passes `missingPrmMeansNoOAuth`, so a public / header-authenticated MCP resolves to `{ auth_url: null }` ("use API key") instead of a `503` discovery failure — the same speculative-probe posture the admin surface already had.
- Connect handlers (project row + the `connect_required` task card) render an info hint on a null `auth_url`; `AuthStartResult.auth_url` is now nullable.

## Tests

- Updated the three revoked→`400 CONNECTOR_REVOKED` tests (project auth-start, extended, admin) to assert the connector is restored and re-authorizes.
- Flipped the project no-PRM test from `503` to the `{ auth_url: null }` outcome (matching admin).
- Added: api-key paste restores a revoked connector; the project Add form creates a connector and auto-probes.
- Full typecheck, biome, and build green via the pre-commit hook.

## Docs

- `docs/mcp/connecting-mcp-servers.md`: adding a connector on the project page + a "Reconnecting a revoked connector" section.
- `.dev/architecture.md`: unified project/admin auth-start PRM posture, project-page add, and the revoked→restore behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjKCLvxbag9WS83ibE5hBJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjKCLvxbag9WS83ibE5hBJ)_