### PR TITLE
feat: auto-prune worktrees for closed tasks and in admin prune button

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -589,8 +589,13 @@ review is the one path that instead embeds the **full** comment history (both sh
 `<dataDir>/teams/<slug>/projects/<slug>/workspace/` bind-mounts to `/workspace`, with one
 subdirectory per linked repo. For each task the runner creates a `git worktree` at
 `/worktrees/<task-identifier>/<repo-name>` on branch `hezo/<task-identifier>`, persisted
-across runs and torn down on terminal status. The working dir resolves to the designated
-repo's worktree (falling back to `/workspace`).
+across runs and torn down when the task reaches a terminal status (`done`/`cancelled`). That
+teardown (`removeTaskWorktrees`, a host-side `rmSync`) fires from `triggerStatusAutomations`,
+so it runs for **both** close paths — a human close via `PATCH /tasks` and an agent close via
+the MCP `update_task` tool — leaving no orphaned worktrees behind either way. Committed work
+survives on the pushed `hezo/<task-identifier>` branch ref; the harmless dangling git metadata
+is swept lazily on the next run's worktree prep or by the manual "Prune worktrees" admin action.
+The working dir resolves to the designated repo's worktree (falling back to `/workspace`).
 
 Because Docker Desktop bind-mount propagation can lag right after a container reprovision (a
 path the host just `mkdirSync`'d briefly stats as missing inside the container), the runner
@@ -720,8 +725,11 @@ rather than auto-starting one, since a passive inspect must not trigger a provis
 runs one of three recovery actions: `discard_local` (`git reset --hard` + `clean -fd` — no `-x`,
 so gitignored build artifacts survive — after a best-effort fetch; the escape hatch for the
 "local changes would be overwritten" fast-forward failure that otherwise silently stalls sync),
-`prune_worktrees` (`git worktree prune`), and `reclone` (wipe the clone via `removeRepoFromWorkspace`
-then re-run `performRepoSetup`, reusing its `pending`→`ready`/`failed` lifecycle). Reset is
+`prune_worktrees` (force-removes the on-disk worktrees of closed/terminal and orphaned tasks —
+`removeWorktreesWhere`, keeping open tasks' worktrees — then `git worktree prune` to clear
+dangling metadata; the branch refs survive), and `reclone` (wipe the clone via
+`removeRepoFromWorkspace` then re-run `performRepoSetup`, reusing its
+`pending`→`ready`/`failed` lifecycle). Reset is
 **blocked (409) while any agent run is active on the project** (`getProjectConcurrency`) — it
 mutates the shared `.git` a live worktree prep also touches, and reclone deletes worktrees a run
 may hold — and `discard_local`/`prune_worktrees` additionally require a running container. Every

--- a/docs/security/git-and-verified-commits.md
+++ b/docs/security/git-and-verified-commits.md
@@ -83,8 +83,11 @@ against it. From there, three recovery actions are available:
 - **Discard local changes** — throws away uncommitted changes in the project's copy and resets it
   to match GitHub. This is the fix for the stuck-sync case above. Work already committed and pushed
   to GitHub is never affected.
-- **Prune worktrees** — clears out leftover per-task working copies from runs that were interrupted.
-  Committed work on their branches is preserved.
+- **Prune worktrees** — clears out per-task working copies for closed (completed or cancelled) tasks,
+  plus any leftover copies from runs that were interrupted. Working copies for tasks still in progress
+  are left untouched. A closed task's working copy is normally removed automatically the moment the
+  task closes; this button is the manual sweep for anything left behind. Committed work on their
+  branches is preserved.
 - **Re-clone** — the last resort: deletes the project's copy entirely and clones it fresh from GitHub.
 
 These actions only ever affect the local working copy on your instance, never the repository on

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -1374,6 +1374,7 @@ export function registerTools(
 						actorMemberId,
 						actorApiKeyId,
 						wsManager,
+						dataDir,
 					);
 				} catch (e) {
 					log.error('Failed to trigger status automations:', e);

--- a/packages/server/src/routes/repos.ts
+++ b/packages/server/src/routes/repos.ts
@@ -1,5 +1,11 @@
 import { join } from 'node:path';
-import { ContainerStatus, RepoSetupStatus, repoNameFromIdentifier, wsRoom } from '@hezo/shared';
+import {
+	ContainerStatus,
+	RepoSetupStatus,
+	repoNameFromIdentifier,
+	TERMINAL_TASK_STATUSES,
+	wsRoom,
+} from '@hezo/shared';
 import { Hono } from 'hono';
 import { trackBackground } from '../lib/background';
 import { broadcastChange } from '../lib/broadcast';
@@ -16,8 +22,8 @@ import {
 	getCloneState,
 	getWorktreeState,
 	listWorktrees,
-	pruneWorktrees,
 	type RepoLoc,
+	removeWorktreesWhere,
 	resetCloneToOrigin,
 	type WorktreeLoc,
 } from '../services/git';
@@ -483,11 +489,34 @@ reposRoutes.post('/projects/:projectId/repos/:repoId/reset', async (c) => {
 			success: boolean;
 			error?: string;
 			warning?: string;
+			removed?: string[];
 		}> => {
 			if (action === 'prune_worktrees') {
 				const executor = ContainerGitExecutor.forPrep(docker, containerId, null, runUser);
-				await pruneWorktrees(executor, repo.repoLoc);
-				return { success: true };
+				// Remove worktrees whose task is closed (terminal) or no longer exists —
+				// finished tickets plus leftovers from crashed/interrupted runs. Open
+				// tasks' worktrees are left intact; reset is already 409-gated on active
+				// runs, so nothing live is touched. Committed work survives on the pushed
+				// `hezo/<identifier>` branch refs. `removeWorktreesWhere` also runs the
+				// plain `git worktree prune` afterward to clear any dangling metadata.
+				const taskRows = await db.query<{ identifier: string; status: string }>(
+					'SELECT identifier, status FROM tasks WHERE project_id = $1',
+					[projectId],
+				);
+				const statusByIdentifier = new Map(taskRows.rows.map((t) => [t.identifier, t.status]));
+				const isStale = (identifier: string): boolean => {
+					const status = statusByIdentifier.get(identifier);
+					return (
+						status === undefined || (TERMINAL_TASK_STATUSES as readonly string[]).includes(status)
+					);
+				};
+				const removed = await removeWorktreesWhere(
+					executor,
+					repo.repoLoc,
+					CONTAINER_WORKTREES_ROOT,
+					isStale,
+				);
+				return { success: true, removed };
 			}
 			// discard_local: the best-effort fetch needs the SSH bridge.
 			const sshAgentServer = c.get('sshAgentServer');
@@ -507,7 +536,12 @@ reposRoutes.post('/projects/:projectId/repos/:repoId/reset', async (c) => {
 	if (!result.success) {
 		return err(c, 'RESET_FAILED', result.error ?? 'git reset failed', 500);
 	}
-	return ok(c, { reset: true, action, warning: result.warning ?? null });
+	return ok(c, {
+		reset: true,
+		action,
+		warning: result.warning ?? null,
+		removed: result.removed ?? [],
+	});
 });
 
 reposRoutes.get('/projects/:projectId/oauth-connections/:id/orgs', async (c) => {

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -14,7 +14,6 @@ import { buildMeta, parsePagination } from '../lib/pagination';
 import {
 	actorTypeFromAuth,
 	apiKeyIdFromAuth,
-	getProjectLocator,
 	resolveActorMemberId as resolveAuthActorMemberId,
 	resolveTaskId,
 } from '../lib/resolve';
@@ -28,7 +27,6 @@ import {
 import { buildTaskListOrderBy, parseTaskListSort } from '../lib/task-sort';
 import type { Env } from '../lib/types';
 import { logger } from '../logger';
-import { removeTaskWorktrees } from '../services/repo-sync';
 import { cancelCoachWorkForTask, terminateRunsForTask } from '../services/run-termination';
 import { triggerStatusAutomations } from '../services/task-automation';
 import { recordAssigneeChange, recordTaskLinks, recordTitleChange } from '../services/task-events';
@@ -692,6 +690,7 @@ tasksRoutes.patch('/projects/:projectId/tasks/:taskId', async (c) => {
 				actorMemberId,
 				actorApiKeyId,
 				c.get('wsManager'),
+				c.get('dataDir'),
 			);
 		} catch (e) {
 			log.error('Failed to trigger status automations:', e);
@@ -748,26 +747,9 @@ tasksRoutes.patch('/projects/:projectId/tasks/:taskId', async (c) => {
 			);
 		}
 
-		if ((TERMINAL_TASK_STATUSES as readonly string[]).includes(body.status)) {
-			const dataDir = c.get('dataDir');
-			if (dataDir) {
-				const taskRow = await db.query<{ identifier: string; project_id: string }>(
-					'SELECT identifier, project_id FROM tasks WHERE id = $1',
-					[taskId],
-				);
-				const taskInfo = taskRow.rows[0];
-				if (taskInfo) {
-					const locator = await getProjectLocator(db, taskInfo.project_id);
-					if (locator) {
-						try {
-							removeTaskWorktrees(dataDir, locator.teamId, locator.id, taskInfo.identifier);
-						} catch (error) {
-							log.error(`Failed to clean up worktrees for task ${taskInfo.identifier}:`, error);
-						}
-					}
-				}
-			}
-		}
+		// Worktree cleanup on a terminal transition now lives in
+		// `triggerStatusAutomations` (above), so both this REST path and the MCP
+		// `update_task` path prune closed tasks' worktrees consistently.
 	}
 
 	broadcastChange(

--- a/packages/server/src/services/git.ts
+++ b/packages/server/src/services/git.ts
@@ -735,6 +735,54 @@ export async function pruneWorktrees(executor: GitExecutor, repo: RepoLoc): Prom
 }
 
 /**
+ * Force-removes a single linked worktree by its path — clears both the checked-out
+ * tree and git's `.git/worktrees/<name>` admin entry. Double `--force` removes it even
+ * when the worktree is dirty or locked (the caller has already established the tree is
+ * safe to discard, e.g. it belongs to a closed task). The branch ref survives, so
+ * committed work pushed to `hezo/<identifier>` is never lost.
+ */
+export async function removeWorktree(
+	executor: GitExecutor,
+	repo: RepoLoc,
+	worktreeContainerPath: string,
+): Promise<void> {
+	await executor.exec(['worktree', 'remove', '--force', '--force', worktreeContainerPath], {
+		cwd: repo.containerPath,
+		timeout: 30_000,
+	});
+}
+
+/**
+ * Sweeps the per-task worktrees under `worktreesRootContainer` (the container-side
+ * `/worktrees` root), force-removing every one whose task identifier satisfies
+ * `shouldRemove`, then prunes any dangling admin metadata. The identifier is the first
+ * path segment under the root (`/worktrees/<identifier>/<repo>`), matching the layout the
+ * runner creates and the git-state endpoint reads. Returns the identifiers removed. Used
+ * by the admin "Prune worktrees" action to clear worktrees of closed/orphaned tasks; the
+ * main worktree (the clone under `/workspace`) never sits under the worktrees root, so it
+ * is inherently skipped.
+ */
+export async function removeWorktreesWhere(
+	executor: GitExecutor,
+	repo: RepoLoc,
+	worktreesRootContainer: string,
+	shouldRemove: (taskIdentifier: string) => boolean,
+): Promise<string[]> {
+	const prefix = `${worktreesRootContainer}/`;
+	const entries = await listWorktrees(executor, repo);
+	const removed: string[] = [];
+	for (const entry of entries) {
+		if (!entry.path.startsWith(prefix)) continue;
+		const taskIdentifier = entry.path.slice(prefix.length).split('/')[0];
+		if (!taskIdentifier || !shouldRemove(taskIdentifier)) continue;
+		await removeWorktree(executor, repo, entry.path);
+		removed.push(taskIdentifier);
+	}
+	await pruneWorktrees(executor, repo);
+	return removed;
+}
+
+/**
  * Resolve the current commit a worktree points at, or null if the worktree is
  * missing or has no commit (e.g. an unborn branch). Captured before a run so a
  * post-run comparison can tell whether the agent advanced the branch.

--- a/packages/server/src/services/task-automation.ts
+++ b/packages/server/src/services/task-automation.ts
@@ -15,6 +15,7 @@ import { recomputeDownstreamReadiness } from '../lib/dependencies';
 import { assertChildrenAllClosed } from '../lib/task-relationships';
 import { logger } from '../logger';
 import { OAUTH_VERIFICATION_LABEL } from './oauth-verification-tasks';
+import { removeTaskWorktrees } from './repo-sync';
 import { recordStatusChange } from './task-events';
 import { createWakeup } from './wakeup';
 import type { WebSocketManager } from './ws';
@@ -158,6 +159,7 @@ export async function triggerStatusAutomations(
 	actorMemberId: string | null,
 	actorApiKeyId: string | null,
 	wsManager?: WebSocketManager,
+	dataDir?: string | null,
 ): Promise<void> {
 	await recordStatusChange(
 		db,
@@ -191,6 +193,29 @@ export async function triggerStatusAutomations(
 			await wakeParentIfChildrenClosed(db, teamId, taskId);
 		} catch (e) {
 			log.error('Failed to wake parent on child closure:', e);
+		}
+
+		// A closed task's per-task worktree is dead weight — remove it so worktrees
+		// don't pile up for done/cancelled tasks. This lives here (not just in the
+		// REST handler) so an agent closing a ticket via the MCP `update_task` tool
+		// gets the same cleanup a human close via `PATCH /tasks` does. Host-side only
+		// (a fast local rmSync that works even when the container is stopped); the
+		// harmless dangling git metadata is swept lazily on the next run's worktree
+		// prep or by the manual "Prune worktrees" admin action. Committed work is safe
+		// on the pushed `hezo/<identifier>` branch ref.
+		if (dataDir) {
+			try {
+				const taskRow = await db.query<{ identifier: string; project_id: string }>(
+					'SELECT identifier, project_id FROM tasks WHERE id = $1 AND team_id = $2',
+					[taskId, teamId],
+				);
+				const taskInfo = taskRow.rows[0];
+				if (taskInfo) {
+					removeTaskWorktrees(dataDir, teamId, taskInfo.project_id, taskInfo.identifier);
+				}
+			} catch (e) {
+				log.error('Failed to clean up worktrees on task close:', e);
+			}
 		}
 	}
 

--- a/packages/server/test/git-worktree-prune.test.ts
+++ b/packages/server/test/git-worktree-prune.test.ts
@@ -1,0 +1,117 @@
+import { execSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+	createWorktree,
+	type RepoLoc,
+	removeWorktree,
+	removeWorktreesWhere,
+	type WorktreeLoc,
+} from '../src/services/git';
+import { HostGitExecutor } from '../src/services/git-executor';
+
+// Exercises the worktree-pruning helpers against real git via HostGitExecutor
+// (host path == container path), mirroring git-worktree-state.test.ts. These back
+// the admin "Prune worktrees" action that sweeps closed/orphaned tasks' worktrees.
+
+const root = mkdtempSync(join(tmpdir(), 'git-wt-prune-'));
+const exec = new HostGitExecutor();
+const repoLoc = (p: string): RepoLoc => ({ hostPath: p, containerPath: p });
+const wtLoc = (p: string): WorktreeLoc => ({ hostPath: p, containerPath: p });
+
+function run(cmd: string, cwd?: string): string {
+	return execSync(cmd, { cwd, stdio: 'pipe' }).toString();
+}
+
+function hasBranch(branch: string): boolean {
+	try {
+		execSync(`git show-ref --verify --quiet refs/heads/${branch}`, {
+			cwd: cloneDir,
+			stdio: 'pipe',
+		});
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+let cloneDir: string;
+let worktreesRoot: string;
+
+const wtPath = (id: string): string => join(worktreesRoot, id, 'repo');
+
+async function addWt(id: string): Promise<string> {
+	const p = wtPath(id);
+	const res = await createWorktree(exec, repoLoc(cloneDir), wtLoc(p), `hezo/${id}`);
+	expect(res.success).toBe(true);
+	return p;
+}
+
+beforeAll(() => {
+	const bare = join(root, 'bare.git');
+	cloneDir = join(root, 'clone');
+	worktreesRoot = join(root, 'worktrees');
+	mkdirSync(worktreesRoot, { recursive: true });
+	run(`git init --bare ${bare}`);
+	run(`git clone ${bare} ${cloneDir}`);
+	run('git config user.name Test', cloneDir);
+	run('git config user.email test@test.com', cloneDir);
+	run('git config commit.gpgsign false', cloneDir);
+	writeFileSync(join(cloneDir, 'README.md'), '# hi');
+	run('git add .', cloneDir);
+	run('git commit -m init', cloneDir);
+	run('git push', cloneDir);
+});
+
+afterAll(() => {
+	rmSync(root, { recursive: true, force: true });
+});
+
+describe('removeWorktree', () => {
+	it('force-removes a worktree (tree + admin entry) but keeps its branch ref', async () => {
+		const p = await addWt('HM-100');
+		expect(existsSync(p)).toBe(true);
+
+		await removeWorktree(exec, repoLoc(cloneDir), p);
+
+		expect(existsSync(p)).toBe(false);
+		expect(run('git worktree list --porcelain', cloneDir)).not.toContain(p);
+		// Committed work survives: the branch ref is untouched.
+		expect(hasBranch('hezo/HM-100')).toBe(true);
+	});
+});
+
+describe('removeWorktreesWhere', () => {
+	it('removes only the worktrees whose identifier matches the predicate', async () => {
+		const closed = await addWt('HM-200');
+		const open = await addWt('HM-201');
+
+		const removed = await removeWorktreesWhere(
+			exec,
+			repoLoc(cloneDir),
+			worktreesRoot,
+			(id) => id === 'HM-200',
+		);
+
+		expect(removed).toEqual(['HM-200']);
+		expect(existsSync(closed)).toBe(false);
+		expect(existsSync(open)).toBe(true);
+		// Both branch refs survive regardless of whether the worktree was removed.
+		expect(hasBranch('hezo/HM-200')).toBe(true);
+		expect(hasBranch('hezo/HM-201')).toBe(true);
+	});
+
+	it('never removes the main clone worktree, even when the predicate matches everything', async () => {
+		const p = await addWt('HM-300');
+
+		const removed = await removeWorktreesWhere(exec, repoLoc(cloneDir), worktreesRoot, () => true);
+
+		expect(removed).toContain('HM-300');
+		expect(existsSync(p)).toBe(false);
+		// The clone (main worktree, outside the worktrees root) is untouched.
+		expect(existsSync(join(cloneDir, 'README.md'))).toBe(true);
+		expect(existsSync(join(cloneDir, '.git'))).toBe(true);
+	});
+});

--- a/packages/server/test/task-automation-branches.test.ts
+++ b/packages/server/test/task-automation-branches.test.ts
@@ -1,8 +1,11 @@
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { DEFAULT_TEAM_ID, TaskStatus } from '@hezo/shared';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Db } from '../src/db/database';
 import { OAUTH_VERIFICATION_LABEL } from '../src/services/oauth-verification-tasks';
 import { triggerStatusAutomations } from '../src/services/task-automation';
+import { getWorktreesPath } from '../src/services/workspace';
 import { safeClose } from './helpers';
 import {
 	authHeader,
@@ -22,10 +25,12 @@ import {
  */
 
 let db: Db;
+let dataDir: string;
 
 beforeAll(async () => {
 	const ctx = await createTestApp();
 	db = ctx.db;
+	dataDir = ctx.dataDir;
 });
 
 afterAll(async () => {
@@ -270,6 +275,99 @@ describe('wakeParentIfChildrenClosed — parent assignee is not an agent', () =>
 			[member.rows[0].id],
 		);
 		expect(wakeups.rows.length).toBe(0);
+	});
+});
+
+describe('triggerStatusAutomations — worktree cleanup on close', () => {
+	// Seeds a fake per-task worktree dir at the real on-disk layout the runner uses:
+	// <worktreesRoot>/<identifier>/<repo>. Returns the task's identifier-scoped dir.
+	async function seedWorktreeDir(taskId: string): Promise<string> {
+		const meta = await db.query<{ identifier: string; project_id: string }>(
+			'SELECT identifier, project_id FROM tasks WHERE id = $1',
+			[taskId],
+		);
+		const { identifier, project_id } = meta.rows[0];
+		const taskDir = join(getWorktreesPath(dataDir, DEFAULT_TEAM_ID, project_id), identifier);
+		mkdirSync(join(taskDir, 'repo'), { recursive: true });
+		writeFileSync(join(taskDir, 'repo', 'file.txt'), 'work');
+		return taskDir;
+	}
+
+	it('removes the task worktree when the task reaches Done (the MCP + REST shared path)', async () => {
+		const task = await hqTask({ title: 'done with worktree', status: TaskStatus.InProgress });
+		const taskDir = await seedWorktreeDir(task);
+		expect(existsSync(taskDir)).toBe(true);
+
+		await triggerStatusAutomations(
+			db,
+			DEFAULT_TEAM_ID,
+			task,
+			TaskStatus.InProgress,
+			TaskStatus.Done,
+			null,
+			null,
+			undefined,
+			dataDir,
+		);
+
+		expect(existsSync(taskDir)).toBe(false);
+	});
+
+	it('removes the task worktree when the task is Cancelled', async () => {
+		const task = await hqTask({ title: 'cancelled with worktree', status: TaskStatus.InProgress });
+		const taskDir = await seedWorktreeDir(task);
+
+		await triggerStatusAutomations(
+			db,
+			DEFAULT_TEAM_ID,
+			task,
+			TaskStatus.InProgress,
+			TaskStatus.Cancelled,
+			null,
+			null,
+			undefined,
+			dataDir,
+		);
+
+		expect(existsSync(taskDir)).toBe(false);
+	});
+
+	it('leaves the worktree intact on a non-terminal transition (run start)', async () => {
+		const task = await hqTask({ title: 'starting run', status: TaskStatus.Backlog });
+		const taskDir = await seedWorktreeDir(task);
+
+		await triggerStatusAutomations(
+			db,
+			DEFAULT_TEAM_ID,
+			task,
+			TaskStatus.Backlog,
+			TaskStatus.InProgress,
+			null,
+			null,
+			undefined,
+			dataDir,
+		);
+
+		expect(existsSync(taskDir)).toBe(true);
+	});
+
+	it('is a no-op for worktrees when no dataDir is threaded through', async () => {
+		const task = await hqTask({ title: 'no dataDir', status: TaskStatus.InProgress });
+		const taskDir = await seedWorktreeDir(task);
+
+		await triggerStatusAutomations(
+			db,
+			DEFAULT_TEAM_ID,
+			task,
+			TaskStatus.InProgress,
+			TaskStatus.Done,
+			null,
+			null,
+			undefined,
+			undefined,
+		);
+
+		expect(existsSync(taskDir)).toBe(true);
 	});
 });
 

--- a/packages/web/src/components/repo-git-state-panel.tsx
+++ b/packages/web/src/components/repo-git-state-panel.tsx
@@ -34,7 +34,7 @@ const RESET_DIALOGS: Record<
 	prune_worktrees: {
 		title: 'Prune stale worktrees?',
 		description:
-			'Removes leftover per-task worktrees from crashed or interrupted runs and prunes worktree references. Committed work on their branches is preserved.',
+			'Removes per-task worktrees for closed tasks and leftover worktrees from crashed or interrupted runs, and prunes worktree references. Committed work on their branches is preserved.',
 		confirmLabel: 'Prune worktrees',
 	},
 	reclone: {


### PR DESCRIPTION
## Problem

Per-task git worktrees (`/worktrees/<task-identifier>/<repo>` on branch `hezo/<task-identifier>`) were piling up for closed tasks:

1. **Auto-cleanup on close only fired on the REST path.** `PATCH /tasks` removed a terminal task's worktree, but agents close tasks through the **MCP** `update_task` tool, which shares `triggerStatusAutomations` yet never removed the worktree. So the common case — an agent finishing a task — orphaned its worktree on disk.
2. **The admin "Prune worktrees" button couldn't remove closed-task worktrees.** It only ran `git worktree prune`, which clears git admin metadata for worktrees whose directory is *already gone* — a closed task's worktree still on disk survived the button.

## Changes

- **Consolidate close-time cleanup into the shared automation.** Terminal-status worktree removal now lives in `triggerStatusAutomations` (the function both close paths already call "to ensure consistent behavior"), so a human close (`PATCH /tasks`) and an agent close (MCP `update_task`) prune a closed (`done`/`cancelled`) task's worktree identically. The duplicated inline block in the REST handler is removed. Host-side only (fast local `rmSync`, works even when the container is stopped); the harmless dangling git metadata is swept lazily on the next run or by the manual button.
- **Extend the `prune_worktrees` reset action.** New `removeWorktree` / `removeWorktreesWhere` git helpers force-remove the worktrees of tasks that are closed (terminal) or no longer exist, leaving in-progress tasks' worktrees untouched, then run the plain `git worktree prune`. The response now returns the list of removed identifiers. Reset is already 409-gated on active runs, so nothing live is touched.
- **Docs & copy:** update the prune dialog description, `.dev/architecture.md` (worktree lifecycle + the reset action), and the user-facing `docs/security/git-and-verified-commits.md`.

Committed work is always preserved — every commit is pushed to the `hezo/<identifier>` branch ref by the post-commit hook, and nothing here deletes a branch.

## Files

- `packages/server/src/services/task-automation.ts` — `dataDir` param + terminal worktree removal
- `packages/server/src/routes/tasks.ts` — thread `dataDir`; delete duplicated inline block
- `packages/server/src/mcp/tools.ts` — thread `dataDir` into `triggerStatusAutomations`
- `packages/server/src/services/git.ts` — `removeWorktree` + `removeWorktreesWhere`
- `packages/server/src/routes/repos.ts` — enhance `prune_worktrees` to remove closed/orphaned worktrees
- `packages/web/src/components/repo-git-state-panel.tsx` — prune dialog copy
- `.dev/architecture.md`, `docs/security/git-and-verified-commits.md` — docs

## Testing

- `packages/server/test/task-automation-branches.test.ts` — worktree cleanup on close via the shared automation: removed on `done`, removed on `cancelled`, left intact on a non-terminal transition (run start), and no-op when no `dataDir` is threaded through.
- `packages/server/test/git-worktree-prune.test.ts` (new) — the git helpers against real git via `HostGitExecutor`: `removeWorktree` force-removes the tree + admin entry but keeps the branch ref; `removeWorktreesWhere` removes only predicate-matched identifiers and never touches the main clone worktree.
- Typecheck ✅, biome ✅, and the directly-affected server suites (`repos-git-state`, `repo-sync`, `tasks`) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PFgZriMuh1LAZ1Qvk2x9eM

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFgZriMuh1LAZ1Qvk2x9eM)_