### PR TITLE
fix(web): make the active folder tab's bottom border !important

### DIFF
--- a/packages/web/src/components/ui/tabs.tsx
+++ b/packages/web/src/components/ui/tabs.tsx
@@ -44,18 +44,23 @@ const BASE_TAB =
 	'relative flex items-center gap-1.5 rounded-t-md border px-3 py-2 text-[13px] font-medium transition-colors';
 
 // Maps each supported active-surface fill to the matching bottom-border colour.
-// Kept as literal class strings (not derived at runtime) so Tailwind's scanner
-// emits the utilities. Falls back to `border-b-bg` for any unlisted surface.
+// The `!` (important) is load-bearing: a global unlayered `* { border-color }`
+// reset in index.css otherwise beats every layered `border-*` colour utility and
+// forces this border back to the grey border token, so the active tab reads as a
+// closed box instead of merging into the panel. `!` clears the reset — the same
+// trick the log-viewer toolbar uses (`border-transparent!`). Kept as literal
+// class strings (not derived at runtime) so Tailwind's scanner emits them; falls
+// back to `border-b-bg!` for any unlisted surface.
 const SURFACE_BOTTOM_BORDER: Record<string, string> = {
-	'bg-bg': 'border-b-bg',
-	'bg-surface': 'border-b-surface',
+	'bg-bg': 'border-b-bg!',
+	'bg-surface': 'border-b-surface!',
 };
 
 function tabClass(isActive: boolean, activeSurface: string): string {
 	if (!isActive) {
 		return `${BASE_TAB} border-transparent bg-surface-2 text-text-2 hover:bg-surface-3 hover:text-text-1`;
 	}
-	const bottomBorder = SURFACE_BOTTOM_BORDER[activeSurface] ?? 'border-b-bg';
+	const bottomBorder = SURFACE_BOTTOM_BORDER[activeSurface] ?? 'border-b-bg!';
 	return `${BASE_TAB} z-10 -mb-px border-border ${bottomBorder} ${activeSurface} text-text-1`;
 }
 

--- a/packages/web/test/agent-detail.test.tsx
+++ b/packages/web/test/agent-detail.test.tsx
@@ -44,10 +44,11 @@ test('agent detail page defaults to Executions tab and exposes Settings tab', as
 	await waitFor(() => {
 		// The active tab renders as a folder tab raised in front: its fill matches
 		// the panel below (bg-bg) and its bottom border is painted that same colour
-		// (border-b-bg), covering the strip baseline so it merges in.
+		// with an important utility (border-b-bg!), covering the strip baseline so it
+		// merges in.
 		const executionsLink = within(main).getByRole('link', { name: 'Executions' });
 		expect(executionsLink.className).toMatch(/bg-bg/);
-		expect(executionsLink.className).toMatch(/border-b-bg/);
+		expect(executionsLink.className).toMatch(/border-b-bg!/);
 	});
 
 	const settingsLink = within(getByRole('main')).getByRole('link', { name: 'Settings' });

--- a/packages/web/test/tabs.test.tsx
+++ b/packages/web/test/tabs.test.tsx
@@ -21,11 +21,12 @@ test('controlled Tabs marks the active tab with folder-tab styling and recesses 
 	expect(inactive.getAttribute('aria-selected')).toBe('false');
 
 	// Active tab is raised "in front": its fill matches the panel below (default
-	// bg-bg) and its bottom border is painted that same colour (border-b-bg), so it
-	// covers the strip's baseline and merges into the panel instead of reading as a
-	// closed box with a bottom border.
+	// bg-bg) and its bottom border is painted that same colour with an important
+	// utility (border-b-bg!) — the `!` beats the global unlayered border-color
+	// reset — so it covers the strip's baseline and merges into the panel instead
+	// of reading as a closed box with a bottom border.
 	expect(active.className).toMatch(/bg-bg/);
-	expect(active.className).toMatch(/border-b-bg/);
+	expect(active.className).toMatch(/border-b-bg!/);
 	expect(active.className).toMatch(/text-text-1/);
 
 	// Inactive tab stays recessed on the baseline.
@@ -78,7 +79,7 @@ test('controlled Tabs tracks the selected value as it changes', async () => {
 	// Selection moves: the clicked tab becomes the raised folder tab.
 	const egress = getByRole('tab', { name: /Outbound/ });
 	expect(egress.getAttribute('aria-selected')).toBe('true');
-	expect(egress.className).toMatch(/border-b-bg/);
+	expect(egress.className).toMatch(/border-b-bg!/);
 	expect(getByRole('tab', { name: 'All' }).getAttribute('aria-selected')).toBe('false');
 });
 
@@ -89,7 +90,7 @@ test('activeSurface controls the fill the active tab merges into', () => {
 	const active = getByRole('tab', { name: 'All' });
 	expect(active.className).toMatch(/bg-surface\b/);
 	expect(active.className).not.toMatch(/bg-bg/);
-	// The bottom border colour tracks the surface so it covers the strip baseline.
-	expect(active.className).toMatch(/border-b-surface\b/);
-	expect(active.className).not.toMatch(/border-b-bg/);
+	// The bottom border colour tracks the surface (important, to cover the baseline).
+	expect(active.className).toMatch(/border-b-surface!/);
+	expect(active.className).not.toMatch(/border-b-bg!/);
 });

--- a/test/browser/folder-tab-active-border.spec.ts
+++ b/test/browser/folder-tab-active-border.spec.ts
@@ -1,0 +1,43 @@
+// Folder-tab "notch": the active tab must merge into the panel below — its
+// bottom border painted the panel's own background colour so it covers the tab
+// strip's baseline border, rather than reading as a closed box with a grey
+// bottom edge. This has to run in a real browser (criterion #1 — real CSS): the
+// active tab's bottom-border colour only lands because it uses an important
+// utility (`border-b-bg!`) that beats the global unlayered
+// `* { border-color: var(--border) }` reset in index.css — a real-cascade
+// outcome (important vs. unlayered-normal) happy-dom's getComputedStyle doesn't
+// resolve, so a component test would pass while the real UI stayed broken.
+
+import { expect, test } from './fixtures';
+
+test('active folder tab merges into the panel (bottom border = surface, not the grey strip baseline)', async ({
+	sharedPage,
+	sharedWorkspace,
+}) => {
+	const { projectSlug, agents } = sharedWorkspace;
+	const agent = agents[0];
+
+	// Land on the Executions tab so it is the active (raised) folder tab.
+	await sharedPage.goto(`/projects/${projectSlug}/agents/${agent.id}/executions`);
+
+	const activeTab = sharedPage.getByRole('link', { name: 'Executions' });
+	await expect(activeTab).toBeVisible({ timeout: 15000 });
+
+	const colors = await sharedPage.evaluate(() => {
+		const active = Array.from(document.querySelectorAll('a')).find(
+			(a) => a.textContent?.trim() === 'Executions',
+		);
+		const strip = active?.closest('nav');
+		return {
+			activeBottom: active ? getComputedStyle(active).borderBottomColor : null,
+			stripBottom: strip ? getComputedStyle(strip).borderBottomColor : null,
+			panelBg: getComputedStyle(document.body).backgroundColor,
+		};
+	});
+
+	// The active tab's bottom border matches the panel it opens into…
+	expect(colors.activeBottom).toBe(colors.panelBg);
+	// …and is distinctly NOT the strip's grey baseline. Before the fix the
+	// unlayered reset forced these equal, so the tab read as a closed box.
+	expect(colors.activeBottom).not.toBe(colors.stripBottom);
+});


### PR DESCRIPTION
## Problem

The active folder tab (agent detail, project Activity, modals) **still rendered a grey bottom border** after #649 — it read as a closed box instead of merging into the panel below.

#649 renamed the tab's bottom-border class to `border-b-bg`, but that class **never took effect**.

## Root cause

`index.css` has a global reset written **outside any `@layer`**:

```css
*, *::before, *::after { border-color: var(--border); }   /* unlayered */
```

In the CSS cascade, an **unlayered** rule beats **any** layered rule — and Tailwind's `border-*` colour utilities all live in `@layer utilities`. So this reset silently forced the active tab's `border-b-bg` back to the grey border token. Verified against the real compiled CSS: the tab's computed `border-bottom-color` was the grey `--border`, not `--color-bg`.

## Fix (scoped, matches the existing pattern)

Mark the bottom-border colour **important**: `border-b-bg!` / `border-b-surface!`. An important declaration clears the unlayered reset, so the border finally paints the panel's own background colour and covers the strip's baseline.

This is the **same trick the log-viewer toolbar already uses** (`border-transparent!`, see `log-viewer.tsx`). It's scoped to the tab and deliberately leaves the global reset untouched — the toolbar (and potentially other components) rely on that reset's exact cascade behaviour, so re-layering it globally would break them.

> Note: an earlier revision of this PR moved the global reset into `@layer base` instead. That's arguably the "cleaner" root-cause fix and would also un-break every other silently-grey colour-border utility (`border-danger`, `border-info`, `border-border-strong`, …) — but it broke the `log-viewer-toolbar-borders` spec, which is intentionally designed around the unlayered reset. Fixing colour borders app-wide is worth doing, but as its own reviewed change, not bundled into a tab-border fix. This PR takes the minimal, safe route.

## Verification

- **Computed styles (real compiled CSS):** active tab bottom border now resolves to `--color-bg`; top/side borders stay grey `--border`; the log-viewer active toggle (`border border-border`) and action buttons (`border-transparent!`) are unchanged.
- **Pixel-clean** at 1×/2×/3× device scale (a barely-perceptible antialias edge remains only at fractional zoom — inherent to any `-mb-px` folder tab).
- **New Playwright guard** — `test/browser/folder-tab-active-border.spec.ts`: asserts the active tab's bottom border equals the panel background and differs from the strip baseline. Confirmed it **fails without the `!`** and **passes with it**. Re-ran the previously-failing `log-viewer-toolbar-borders` spec → green.
- Tab component tests (`tabs`, `agent-detail`) updated to assert the important variant and green; web typechecks clean.

## Changes

- `packages/web/src/components/ui/tabs.tsx` — active tab bottom border → `border-b-bg!` / `border-b-surface!`.
- `packages/web/test/{tabs,agent-detail}.test.tsx` — assert the important variant.
- `test/browser/folder-tab-active-border.spec.ts` — regression guard (new).

(Builds on #649, already on `main`, which supplies the surface→border-class mapping this makes effective.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjbEHMu8X6HLrmNQnjjH4X