### PR TITLE
fix(web): strip redundant backticks so inline code renders as clean chips

### DIFF
--- a/packages/web/src/components/markdown-prose.tsx
+++ b/packages/web/src/components/markdown-prose.tsx
@@ -21,6 +21,7 @@ import {
 	remarkMentions,
 	type TaskMentionData,
 } from '../lib/remark-mentions';
+import { remarkNormalizeInlineCode } from '../lib/remark-normalize-inline-code';
 import { CommentRefLink, MENTION_CLASSES } from './comment-ref-link';
 import { useOpenPreview } from './task-detail/preview-context';
 import { TaskStatusBadge } from './task-status-badge';
@@ -164,7 +165,11 @@ export function MarkdownProse({
 	}, [resolvedDocs, instanceResolved]);
 
 	const remarkPlugins = useMemo<RemarkPlugin>(() => {
-		const plugins: NonNullable<RemarkPlugin> = [remarkGfm];
+		// remarkNormalizeInlineCode runs first (right after GFM parsing) so an
+		// LLM-double-wrapped token like `` `x` `` renders as a clean `x` chip
+		// instead of showing its inner backticks, and so the inline-code linkifiers
+		// below see the unwrapped value.
+		const plugins: NonNullable<RemarkPlugin> = [remarkGfm, remarkNormalizeInlineCode];
 		// The plugin also runs when the text carries a passive `@@` mention even if
 		// nothing resolved: an unresolved passive mention still needs its internal
 		// `@@` prefix stripped to a bare slug (see remark-mentions splitTextNode), so

--- a/packages/web/src/lib/remark-normalize-inline-code.ts
+++ b/packages/web/src/lib/remark-normalize-inline-code.ts
@@ -1,0 +1,62 @@
+interface InlineCodeNode {
+	type: 'inlineCode';
+	value: string;
+}
+
+interface ParentNode {
+	type: string;
+	children?: MdNode[];
+	value?: string;
+}
+
+type MdNode = ParentNode | InlineCodeNode;
+
+/**
+ * Strip the redundant backtick delimiters an author left *inside* an inline-code
+ * span. LLM-authored markdown routinely double-wraps a token — writing
+ * `` `x` `` — which the GFM parser turns into a single `inlineCode` node whose
+ * *value* is the literal string "`x`" (the outer `` `` `` are the real
+ * delimiters; the inner backticks become part of the content). The renderer then
+ * paints a code chip that still shows those inner backticks, so the reader sees
+ * an ugly double-backticked token where a clean `x` chip was meant.
+ *
+ * Only a whole-span wrapper is unwrapped, and only while the interior carries no
+ * backtick of its own — so a span that deliberately shows a backtick (`` `a`b` ``)
+ * is left untouched. A single already-clean span (`x`) has no interior backticks
+ * and is a no-op.
+ */
+export function unwrapRedundantBackticks(value: string): string {
+	let v = value;
+	while (v.length >= 2 && v.startsWith('`') && v.endsWith('`')) {
+		const inner = v.slice(1, -1).trim();
+		if (inner.length === 0 || inner.includes('`')) break;
+		v = inner;
+	}
+	return v;
+}
+
+function walk(node: ParentNode) {
+	const children = node.children;
+	if (!children) return;
+	for (const child of children) {
+		if (child.type === 'inlineCode' && typeof (child as InlineCodeNode).value === 'string') {
+			(child as InlineCodeNode).value = unwrapRedundantBackticks((child as InlineCodeNode).value);
+			continue;
+		}
+		if ((child as ParentNode).children) walk(child as ParentNode);
+	}
+}
+
+/**
+ * Remark plugin that normalizes every inline-code span via
+ * {@link unwrapRedundantBackticks}. Fenced code blocks are a different mdast node
+ * (`code`, not `inlineCode`) and are never visited, so genuine multi-line code
+ * samples keep their backticks. Runs before the mention/comment-ref plugins so
+ * their inline-code linkifiers (chat doc/asset links, comment public_ids) see the
+ * unwrapped value.
+ */
+export function remarkNormalizeInlineCode() {
+	return (tree: ParentNode) => {
+		walk(tree);
+	};
+}

--- a/packages/web/test/remark-normalize-inline-code.test.tsx
+++ b/packages/web/test/remark-normalize-inline-code.test.tsx
@@ -1,0 +1,67 @@
+import { render } from '@testing-library/react';
+import Markdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { expect, test } from 'vitest';
+import {
+	remarkNormalizeInlineCode,
+	unwrapRedundantBackticks,
+} from '../src/lib/remark-normalize-inline-code';
+
+// remarkGfm must run first so the `` `x` `` double-wrap parses the same way it
+// does in the real MarkdownProse pipeline.
+function renderMd(text: string) {
+	return render(<Markdown remarkPlugins={[remarkGfm, remarkNormalizeInlineCode]}>{text}</Markdown>);
+}
+
+function codeText(container: HTMLElement): string[] {
+	return Array.from(container.querySelectorAll('code')).map((c) => c.textContent ?? '');
+}
+
+test('a double-wrapped token renders as a clean chip, no inner backticks', () => {
+	// The GFM parser turns `` `## FAQ` `` into one inlineCode node whose value is
+	// the literal "`## FAQ`"; without normalization the chip shows the backticks.
+	const { container } = renderMd('The 7 Q&A pairs are an inline `` `## FAQ` `` section.');
+	expect(codeText(container)).toEqual(['## FAQ']);
+	expect(container.textContent).not.toContain('`');
+});
+
+test('several double-wrapped tokens in one line all render clean', () => {
+	const { container } = renderMd(
+		'put FAQ in the `` `faq:` `` field of `` `data/README.md` `` at `` `localhost:3100` ``',
+	);
+	expect(codeText(container)).toEqual(['faq:', 'data/README.md', 'localhost:3100']);
+	expect(container.textContent).not.toContain('`');
+});
+
+test('a normal single-backtick span is unchanged', () => {
+	const { container } = renderMd('run `npm install` in `data/README.md`');
+	expect(codeText(container)).toEqual(['npm install', 'data/README.md']);
+});
+
+test('a span that deliberately shows a backtick is left untouched', () => {
+	// Inner content carries its own backtick, so the whole-span wrapper is not a
+	// redundant double-wrap and must be preserved verbatim.
+	const { container } = renderMd('the literal `` `a`b` `` token');
+	expect(codeText(container)).toEqual(['`a`b`']);
+});
+
+test('a fenced code block keeps its backticks', () => {
+	const { container } = renderMd(['```', '`still code`', '```'].join('\n'));
+	// The fence is a `code` node, never an `inlineCode` node, so it is not visited.
+	expect(container.querySelector('pre')?.textContent).toContain('`still code`');
+});
+
+test('unwrapRedundantBackticks unit cases', () => {
+	expect(unwrapRedundantBackticks('`## FAQ`')).toBe('## FAQ');
+	expect(unwrapRedundantBackticks('`faq:`')).toBe('faq:');
+	expect(unwrapRedundantBackticks('`data/README.md`')).toBe('data/README.md');
+	// Already clean — no interior backticks, no leading/trailing backtick.
+	expect(unwrapRedundantBackticks('npm install')).toBe('npm install');
+	// Interior backtick → not a redundant wrapper, preserved.
+	expect(unwrapRedundantBackticks('`a`b`')).toBe('`a`b`');
+	// Degenerate delimiters are left alone.
+	expect(unwrapRedundantBackticks('`')).toBe('`');
+	expect(unwrapRedundantBackticks('``')).toBe('``');
+	// Whitespace padding inside the wrapper is trimmed away with it.
+	expect(unwrapRedundantBackticks('` faq `')).toBe('faq');
+});


### PR DESCRIPTION
## Problem

Agent-authored comments routinely double-wrap an inline-code token — writing `` `` `## FAQ` `` `` instead of `` `## FAQ` ``. GFM parses that into a single `inlineCode` node whose **value literally contains** the inner backticks (the outer `` `` `` are consumed as delimiters), so `MarkdownProse` paints a code chip that still shows them:

> `` `## FAQ` `` · `` `data/README.md` `` · `` `faq:` `` · `` `localhost:3100` `` …

The reader sees ugly double-backticked tokens where a clean `## FAQ` chip was meant. This isn't a downstream escaping bug — an agent's final message is captured verbatim (`getFinalAssistantMessage` → `postAgentComment`), so the double backticks come straight from the LLM's markdown and the renderer faithfully displays them.

I reproduced the exact mechanism through the real renderer: `` `## FAQ` `` (single) → `<code>## FAQ</code>` (clean), while `` `` `## FAQ` `` `` → `<code>`## FAQ`</code>` (visible backticks).

## Fix

Normalize at the single display choke point. A new remark plugin `remarkNormalizeInlineCode` unwraps redundant surrounding backticks from every `inlineCode` node value, wired into `MarkdownProse` right after `remarkGfm`.

- Only a **whole-span** wrapper is unwrapped, and only while the interior carries **no backtick of its own** — so a span that deliberately shows a backtick (`` `a`b` ``) is preserved.
- Fenced code blocks are a different mdast node (`code`, not `inlineCode`) and are never visited, so multi-line code samples keep their backticks.
- It runs **before** the mention / comment-ref plugins, so their inline-code linkifiers (chat doc/asset links, comment public_ids) see the unwrapped value.

Because `MarkdownProse` is the shared renderer, this covers every markdown surface — task comments, docs, CEO chat, and the formatted log view — for both existing and future content.

## Tests

- New `packages/web/test/remark-normalize-inline-code.test.tsx` (6 tests): double-wrapped tokens render clean, multiple per line, normal single-backtick spans untouched, a deliberate-backtick span preserved, fenced blocks preserved, plus `unwrapRedundantBackticks` unit cases.
- Verified composition with the existing inline-code plugins (`remark-comment-refs`, `remark-mentions`) still passes — a double-backticked comment public_id still links after unwrap.
- Monorepo `typecheck` (all packages incl. web) and full build pass via the pre-commit hook.

## Notes

Pure renderer robustness change — no CLI flag, MCP tool, REST route, data model, or documented behavior changes, so no docs/architecture updates were required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018KpX8hRB5kwjDMmiuc5NMR

---
_Generated by [Claude Code](https://claude.ai/code/session_018KpX8hRB5kwjDMmiuc5NMR)_