### PR TITLE
fix(web): link project-scoped "Added skill" to the project Skills page

### DIFF
--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -145,12 +145,16 @@ const HEARTBEAT_RUN_COLUMNS = `hr.id, hr.member_id, hr.team_id, hr.wakeup_id, hr
 		'[]'::jsonb
 	) AS created_docs,
 	-- Skills the agent added/updated directly in the skills database this run.
+	-- project_slug is the owning project's slug for a project-scoped skill, or
+	-- NULL for a global skill — the frontend links a scoped skill to the project
+	-- Skills page and a global one to /settings/skills.
 	COALESCE(
 		(SELECT jsonb_agg(
-			jsonb_build_object('name', s.name, 'slug', s.slug, 'source_url', s.source_url, 'created', (s.created_at >= hr.started_at))
+			jsonb_build_object('name', s.name, 'slug', s.slug, 'source_url', s.source_url, 'created', (s.created_at >= hr.started_at), 'project_slug', sp.slug)
 			ORDER BY s.updated_at ASC
 		)
 		FROM skills s
+		LEFT JOIN projects sp ON sp.id = s.project_id
 		WHERE s.created_by_member_id = hr.member_id
 		  AND hr.started_at IS NOT NULL
 		  AND s.updated_at >= hr.started_at

--- a/packages/server/test/heartbeat-runs.test.ts
+++ b/packages/server/test/heartbeat-runs.test.ts
@@ -606,6 +606,14 @@ describe('created_tasks tracking', () => {
 			slug: 'deploy-flow',
 			content: '# Deploy Flow\n\nHow to deploy.',
 		});
+		// A global skill (scope: 'global') has no owning project — project_slug null.
+		await callMcp('create_skill', {
+			project: projectId,
+			name: 'Global Runbook',
+			slug: 'global-runbook',
+			content: '# Global Runbook\n\nShared everywhere.',
+			scope: 'global',
+		});
 		await callMcp('propose_skill', {
 			project: projectId,
 			skill_name: 'Linear Triage',
@@ -633,10 +641,18 @@ describe('created_tasks tracking', () => {
 			name: string;
 			slug: string;
 			created: boolean;
+			project_slug: string | null;
 		}>;
 		const deploySkill = createdSkills.find((s) => s.slug === 'deploy-flow');
 		expect(deploySkill).toBeDefined();
 		expect(deploySkill?.created).toBe(true);
+		// create_skill defaults to project scope, so this skill carries the owning
+		// project's slug — the frontend links it to that project's Skills page.
+		expect(deploySkill?.project_slug).toBe(projectSlug);
+		// A global skill has no owning project — project_slug is null.
+		const globalSkill = createdSkills.find((s) => s.slug === 'global-runbook');
+		expect(globalSkill).toBeDefined();
+		expect(globalSkill?.project_slug).toBeNull();
 
 		const proposedSlugs = (body.data.proposed_skills as Array<{ name: string; slug: string }>).map(
 			(s) => s.slug,

--- a/packages/web/src/components/comment-renderers/run-comment.tsx
+++ b/packages/web/src/components/comment-renderers/run-comment.tsx
@@ -409,9 +409,21 @@ export function RunCommentBody({
 				<div className="flex flex-col gap-1 pt-1" data-testid="run-comment-created-skills">
 					{createdSkills.map((skill) => (
 						<span key={skill.slug} className="text-xs self-start">
-							<Link to="/settings/skills" className="text-info-soft-fg hover:underline">
-								{skill.created ? 'Added' : 'Updated'} skill {skill.name}
-							</Link>
+							{/* A project-scoped skill lives on the owning project's Skills page;
+							    a global skill is managed on /settings/skills. */}
+							{skill.project_slug ? (
+								<Link
+									to="/projects/$projectId/skills"
+									params={{ projectId: skill.project_slug }}
+									className="text-info-soft-fg hover:underline"
+								>
+									{skill.created ? 'Added' : 'Updated'} skill {skill.name}
+								</Link>
+							) : (
+								<Link to="/settings/skills" className="text-info-soft-fg hover:underline">
+									{skill.created ? 'Added' : 'Updated'} skill {skill.name}
+								</Link>
+							)}
 							{skill.source_url && (
 								<span className="text-text-3"> · from {skillSourceLabel(skill.source_url)}</span>
 							)}

--- a/packages/web/src/hooks/use-heartbeat-runs.ts
+++ b/packages/web/src/hooks/use-heartbeat-runs.ts
@@ -45,7 +45,14 @@ export interface HeartbeatRun {
 	run_comment_public_id: string | null;
 	created_tasks: { id: string; identifier: string; title: string; project_slug: string }[];
 	created_docs: { filename: string; project_slug: string }[];
-	created_skills: { name: string; slug: string; created: boolean; source_url: string | null }[];
+	created_skills: {
+		name: string;
+		slug: string;
+		created: boolean;
+		source_url: string | null;
+		/** Owning project slug for a project-scoped skill; null for a global skill. */
+		project_slug: string | null;
+	}[];
 	proposed_skills: { name: string; slug: string }[];
 }
 

--- a/packages/web/test/run-created-tasks.test.tsx
+++ b/packages/web/test/run-created-tasks.test.tsx
@@ -312,8 +312,14 @@ test('run comment links updated docs, skills, and proposed skills', async () => 
 				created_tasks: [],
 				created_docs: [{ filename: 'spec.md', project_slug: project.slug }],
 				created_skills: [
-					{ name: 'Deploy Flow', slug: 'deploy-flow', created: true },
-					{ name: 'Triage', slug: 'triage', created: false },
+					{ name: 'Deploy Flow', slug: 'deploy-flow', created: true, project_slug: null },
+					{ name: 'Triage', slug: 'triage', created: false, project_slug: null },
+					{
+						name: 'Typefully Publishing',
+						slug: 'typefully-publishing',
+						created: true,
+						project_slug: project.slug,
+					},
 				],
 				proposed_skills: [{ name: 'Linear Triage', slug: 'linear-triage' }],
 			};
@@ -348,8 +354,12 @@ test('run comment links updated docs, skills, and proposed skills', async () => 
 	const skillLinks = Array.from(skillsSection.querySelectorAll('a')) as HTMLAnchorElement[];
 	const added = skillLinks.find((a) => a.textContent === 'Added skill Deploy Flow');
 	const updated = skillLinks.find((a) => a.textContent === 'Updated skill Triage');
+	// Global skills (project_slug null) link to the global Skills page…
 	expect(added?.getAttribute('href')).toBe(`/settings/skills`);
 	expect(updated?.getAttribute('href')).toBe(`/settings/skills`);
+	// …a project-scoped skill links to its own project's Skills page instead.
+	const scoped = skillLinks.find((a) => a.textContent === 'Added skill Typefully Publishing');
+	expect(scoped?.getAttribute('href')).toBe(`/projects/${seeded.projectSlug}/skills`);
 
 	const proposedSection = await findByTestId('run-comment-proposed-skills');
 	const proposedLink = proposedSection.querySelector('a') as HTMLAnchorElement | null;


### PR DESCRIPTION
## What & why

In a run log, the **"Added / Updated skill …"** link below the run always pointed at the **global** `/settings/skills` page — even when the agent created the skill in **project scope** (e.g. *Typefully Social Publishing* in the screenshot). A project-scoped skill isn't listed on the global page, so the link led to a page where the skill couldn't be found.

Now a project-scoped skill's link opens the **project's own Skills page** (`/projects/$projectId/skills`) — the page that actually lists and manages that project's scoped skills — while a global skill keeps linking to `/settings/skills`. This mirrors the existing global/project split (global docs/skills → global pages, project resources → project pages).

> Note on wording: the request said "project connector page." Project-scoped **skills** live on the project **Skills** page, not the Connectors page (which lists MCP servers + GitHub only and would not show the skill), so the link points there — the exact project analog of the global `/settings/skills` link it replaces.

## Changes

- **`packages/server/src/routes/agents.ts`** — the shared `HEARTBEAT_RUN_COLUMNS` SELECT now `LEFT JOIN`s `projects` and adds `project_slug` to each `created_skills` entry: the owning project's slug for a project-scoped skill, `NULL` for a global one. (Used by all three heartbeat-run endpoints, so list + single-run views both carry it.)
- **`packages/web/src/hooks/use-heartbeat-runs.ts`** — added `project_slug: string | null` to the `created_skills` type.
- **`packages/web/src/components/comment-renderers/run-comment.tsx`** — a created-skill with a non-null `project_slug` links to `/projects/$projectId/skills`; otherwise it keeps linking to `/settings/skills`.

## Tests

- **`packages/server/test/heartbeat-runs.test.ts`** — extended the created-skills case to also create a `scope: 'global'` skill, and asserts the project-scoped skill's `project_slug` equals the project slug while the global skill's is `null`.
- **`packages/web/test/run-created-tasks.test.tsx`** — added a project-scoped skill to the mock and asserts its link resolves to `/projects/$projectSlug/skills`, while global skills still resolve to `/settings/skills`.

Both suites pass; `tsc --noEmit` is clean for `server` and `web`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PULv6ePa1JS5ic3RC83B9H

---
_Generated by [Claude Code](https://claude.ai/code/session_01PULv6ePa1JS5ic3RC83B9H)_