### PR TITLE
fix: shorten docs library button label to "New"

### DIFF
--- a/packages/web/src/components/docs-library.tsx
+++ b/packages/web/src/components/docs-library.tsx
@@ -274,14 +274,14 @@ export function DocsLibrary({
 									variant="accent"
 									size="sm"
 									// Icon-only below desktop to keep the narrow doc-list column
-									// clear for the filter; the "New document" label appears at lg+.
+									// clear for the filter; the "New" label appears at lg+.
 									className="h-8 w-8 shrink-0 px-0 rounded-md lg:w-auto lg:px-2.5"
 									onClick={onNewDoc}
 									aria-label="New document"
 									title="New document"
 								>
 									<Plus className="w-4 h-4" />
-									<span className="hidden lg:inline">New document</span>
+									<span className="hidden lg:inline">New</span>
 								</Button>
 							)}
 						</div>


### PR DESCRIPTION
## Summary

The document-list header button in the docs library rendered the full **"New document"** label at `lg+` widths. This shortens the visible text to just **"New"** to keep the narrow doc-list column tidy next to the filter input.

The descriptive `aria-label` and `title` (`"New document"`) are unchanged, so:
- the icon-only variant on narrower screens keeps its accessible name and tooltip, and
- existing tests that query the button by its accessible name (`getByRole('button', { name: 'New document' })`) continue to match.

## Change

`packages/web/src/components/docs-library.tsx` — the visible `<span className="hidden lg:inline">` label now reads `New` instead of `New document` (plus a matching comment tweak).

## Testing

- `bunx vitest run test/docs-list-collapse.test.tsx test/project-documents.test.tsx` — 11 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FoBciW5okXZ1VWQRMZLnzt

---
_Generated by [Claude Code](https://claude.ai/code/session_01FoBciW5okXZ1VWQRMZLnzt)_