### PR TITLE
feat: add "Mark all as read" button to inbox toolbar

### DIFF
--- a/packages/web/src/components/inbox-view.tsx
+++ b/packages/web/src/components/inbox-view.tsx
@@ -1,7 +1,7 @@
 import { type AdminMentionItem, ApprovalStatus } from '@hezo/shared';
-import { Inbox, Search } from 'lucide-react';
+import { CheckCheck, Inbox, Search } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
-import { useAllAdminMentions } from '../hooks/use-admin-mentions';
+import { useAllAdminMentions, useMarkAllMentionsRead } from '../hooks/use-admin-mentions';
 import { type Approval, useAllApprovals } from '../hooks/use-approvals';
 import { ApprovalCard } from './approval-card';
 import { MentionCard } from './mention-card';
@@ -70,6 +70,7 @@ export function InboxView({ projectSlugs, scope }: InboxViewProps) {
 	const { data: mentions, isLoading: mentionsLoading } = useAllAdminMentions(projectSlugs, {
 		archived: archivedView,
 	});
+	const markAllRead = useMarkAllMentionsRead();
 	const [search, setSearch] = useState('');
 	const [debouncedSearch, setDebouncedSearch] = useState('');
 
@@ -109,6 +110,22 @@ export function InboxView({ projectSlugs, scope }: InboxViewProps) {
 		});
 	}, [rows, readFilter, debouncedSearch]);
 
+	// Projects that still have an unread mention. "Mark all as read" targets
+	// mentions only — approvals become read by being resolved, not dismissed.
+	const unreadMentionSlugs = useMemo(() => {
+		const slugs = new Set<string>();
+		for (const m of mentions ?? []) {
+			if (!m.read_at) slugs.add(m.project_slug);
+		}
+		return [...slugs];
+	}, [mentions]);
+
+	const handleMarkAllRead = () => {
+		for (const slug of unreadMentionSlugs) {
+			markAllRead.mutate(slug);
+		}
+	};
+
 	if (isLoading) {
 		return <div className="text-text-2">Loading...</div>;
 	}
@@ -129,7 +146,23 @@ export function InboxView({ projectSlugs, scope }: InboxViewProps) {
 			</div>
 
 			<div className="flex flex-col gap-2 mb-4 sm:flex-row sm:items-center sm:justify-between">
-				<FilterPills options={READ_OPTIONS} value={readFilter} onChange={setReadFilter} />
+				<div className="flex items-center justify-between gap-2 sm:justify-start">
+					<FilterPills
+						options={READ_OPTIONS}
+						value={readFilter}
+						onChange={setReadFilter}
+						className=""
+					/>
+					<button
+						type="button"
+						onClick={handleMarkAllRead}
+						disabled={unreadMentionSlugs.length === 0 || markAllRead.isPending}
+						className="inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-md px-2.5 py-1 text-[12px] text-text-3 transition-colors hover:bg-surface-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-text-3"
+					>
+						<CheckCheck className="w-3.5 h-3.5" />
+						Mark all as read
+					</button>
+				</div>
 				<div className="relative sm:w-64">
 					<Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-text-3" />
 					<input

--- a/packages/web/test/inbox-mentions.test.tsx
+++ b/packages/web/test/inbox-mentions.test.tsx
@@ -321,6 +321,78 @@ test('archived mentions are hidden by default and shown under the Archived filte
 	await waitFor(async () => expect((await findAllByTestId('mention-card')).length).toBe(1));
 });
 
+test('mark all as read clears every unread mention', async () => {
+	let ctx: { projectSlug: string; mentionIds: string[] };
+	const { findAllByTestId, findByText, getByText, queryByTestId, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Demo' });
+			const t1 = await seedTask(ws, project, { title: 'First ticket' });
+			const t2 = await seedTask(ws, project, { title: 'Second ticket' });
+			const m1 = await seedAgentAdminMention(ws, t1, '@admin first decision.');
+			const m2 = await seedAgentAdminMention(ws, t2, '@admin second decision.');
+			ctx = { projectSlug: project.slug, mentionIds: [m1.mentionId, m2.mentionId] };
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/inbox',
+		params: { projectId: ctx!.projectSlug },
+	});
+
+	// Defaults to the Unread filter — both mentions are present.
+	await waitFor(async () => expect((await findAllByTestId('mention-card')).length).toBe(2), {
+		timeout: 10_000,
+	});
+
+	await user.click(getByText('Mark all as read'));
+
+	// Unread view empties out once the mutation lands and the list refetches.
+	await waitFor(() => expect(queryByTestId('mention-card')).toBeNull(), { timeout: 10_000 });
+
+	// Both rows persisted read_at server-side.
+	const { db } = getTestContext();
+	const rows = await db.query<{ read_at: string | null }>(
+		'SELECT read_at FROM admin_mentions WHERE id = ANY($1)',
+		[ctx!.mentionIds],
+	);
+	expect(rows.rows.length).toBe(2);
+	expect(rows.rows.every((r) => r.read_at !== null)).toBe(true);
+
+	// The read mentions are still visible under the Read filter.
+	await user.click(await findByText('Read'));
+	await waitFor(async () => expect((await findAllByTestId('mention-card')).length).toBe(2), {
+		timeout: 10_000,
+	});
+});
+
+test('mark all as read is disabled when there are no unread mentions', async () => {
+	let ctx: { projectSlug: string };
+	const { findByText, getByText, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Demo' });
+			const task = await seedTask(ws, project, { title: 'Handled ticket' });
+			const { mentionId } = await seedAgentAdminMention(ws, task, '@admin already handled.');
+			await markMentionRead(mentionId);
+			ctx = { projectSlug: project.slug };
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/inbox',
+		params: { projectId: ctx!.projectSlug },
+	});
+
+	// Switch to All so the read mention is on screen and the list has loaded.
+	await findByText('All');
+	const button = getByText('Mark all as read').closest('button');
+	expect(button).not.toBeNull();
+	expect((button as HTMLButtonElement).disabled).toBe(true);
+});
+
 test('header inbox icon shows the global unread count badge', async () => {
 	const { findByTestId } = await renderApp({
 		initialPath: '/home',


### PR DESCRIPTION
## What & why

Adds a **Mark all as read** action to the inbox toolbar, next to the filter tabs (Unread / Read / All / Archived).

- **Desktop:** the button sits inline to the right of the tab bar; the search box stays on the far right.
- **Mobile:** the tab bar shrinks to auto-width (previously it stretched full-width) and the button shares the same row, right-aligned. Search wraps to its own full-width row below, as before.

Clicking it marks every unread **mention** across the inbox's projects as read. Approvals are intentionally untouched — they become "read" by being resolved, not dismissed. The button is disabled when there are no unread mentions (and while the mutation is in flight).

## Implementation

- `packages/web/src/components/inbox-view.tsx`
  - Wrapped `FilterPills` + the new button in a flex row that is `justify-between` on mobile (auto-width tabs, right-aligned button) and `justify-start` on desktop (tabs and button packed together, search pushed right).
  - Reuses the existing (previously unused) `useMarkAllMentionsRead` hook, firing it once per project slug that still has an unread mention (computed from the loaded mentions).
  - `CheckCheck` icon + subtle text-button styling matching existing toolbar affordances; disabled state greys it out.

## Testing

- `packages/web/test/inbox-mentions.test.tsx`
  - New: **mark all as read clears every unread mention** — seeds two unread mentions, clicks the button, asserts the Unread list empties, both rows persist `read_at` server-side, and they reappear under the Read filter.
  - New: **mark all as read is disabled when there are no unread mentions** — seeds a single already-read mention and asserts the button is disabled.
  - Full `inbox-mentions`, `inbox-global`, and `inbox-approvals` suites pass (16 tests). Repo `turbo typecheck` and `biome check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WsBzJyhRu44r74TnFEs4Zu

---
_Generated by [Claude Code](https://claude.ai/code/session_01WsBzJyhRu44r74TnFEs4Zu)_