### PR TITLE
fix: let admins react to comments in teams they aren't a member of

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -124,7 +124,12 @@ an agent-maintained `progress_summary`. Numbering is atomic via `project_task_co
 `system` (timeline entries like `status_change`/`task_link`), `run` (auto-written
 on run completion), `preview`, `action`,
 `connect_required`, `credential_request`. Each comment carries a `public_id` slug for
-`#comment-<id>` deep-links. `comment_reactions` holds emoji reactions.
+`#comment-<id>` deep-links. `comment_reactions` holds emoji reactions, keyed by a
+non-null `member_id` (unlike a comment's nullable `author_member_id`, which lets an admin
+author as a null-member "Admin"). Because a reaction needs a real member, a human acting in
+a team they can access but aren't a member of resolves to their **HQ (default-team)**
+membership (`resolveReactorMemberId`) — the same cross-team identity HQ agents use to act in
+other teams' projects — so a superuser can react anywhere, not only in HQ or teams they created.
 Marking a task `done` is gated in both update paths (REST PATCH and MCP `update_task`,
 shared helpers in `lib/task-relationships.ts`): every sub-task terminal, no outstanding
 pinged-agent activity by others (active runs, pending mention/comment/reply wakeups), and —

--- a/packages/server/src/lib/resolve.ts
+++ b/packages/server/src/lib/resolve.ts
@@ -21,6 +21,36 @@ export async function resolveActorMemberId(
 }
 
 /**
+ * Resolve the member identity that owns a *reaction* for the caller. Reactions
+ * require a non-null `member_id` (unlike comments, which can be authored by a
+ * null-member "Admin"), so a human acting in a team they can access but aren't a
+ * member of would otherwise have no identity to react with. Prefer the caller's
+ * member in the current team, then fall back to their default-team (HQ)
+ * membership — the same cross-team identity HQ agents (CEO/Coach) use to act in
+ * other teams' projects, and the same fallback `resolveAgentId` already applies.
+ * Every enrolled human is an HQ member, so this resolves for any admin; an API
+ * key (no member, no user) still returns null.
+ */
+export async function resolveReactorMemberId(
+	db: Db,
+	auth: AuthInfo,
+	teamId: string,
+): Promise<string | null> {
+	if (auth.type === AuthType.Agent) return auth.memberId;
+	if (auth.type === AuthType.Admin) {
+		const result = await db.query<{ id: string }>(
+			`SELECT m.id FROM members m JOIN member_users mu ON mu.id = m.id
+			 WHERE mu.user_id = $1 AND m.team_id IN ($2, $3)
+			 ORDER BY (m.team_id = $2) DESC
+			 LIMIT 1`,
+			[auth.userId, teamId, DEFAULT_TEAM_ID],
+		);
+		return result.rows[0]?.id ?? null;
+	}
+	return null;
+}
+
+/**
  * Map an auth context to its audit actor type. An agent run is an `agent`; an
  * approved API key (the instance MCP credential) is an `api_key`; everything else
  * (board user, superuser) is an `admin`.

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -70,6 +70,7 @@ import {
 	resolveActorMemberId,
 	resolveAgentId,
 	resolveProject,
+	resolveReactorMemberId,
 	resolveTaskId,
 } from '../lib/resolve';
 import { assertRunTaskScope } from '../lib/run-scope';
@@ -2034,7 +2035,7 @@ export function registerTools(
 				 ORDER BY ic.created_at DESC, ic.id DESC LIMIT 50`,
 				params,
 			);
-			const viewerMemberId = await resolveActorMemberId(db, auth, teamId);
+			const viewerMemberId = await resolveReactorMemberId(db, auth, teamId);
 			const reactionsByComment = await loadReactionsForTask(db, taskId, viewerMemberId);
 			const commentIds = r.rows.map((row) => row.id as string);
 			const attachmentsByComment = await loadAgentAttachmentsForComments(
@@ -2090,7 +2091,7 @@ export function registerTools(
 			const scope = await resolveTaskScope(db, auth, args);
 			if ('error' in scope) return scope;
 			const { teamId, taskId } = scope;
-			const memberId = await resolveActorMemberId(db, auth, teamId);
+			const memberId = await resolveReactorMemberId(db, auth, teamId);
 			if (!memberId) return { error: 'No member identity for caller' };
 			const result = await addCommentReaction({
 				db,
@@ -2144,7 +2145,7 @@ export function registerTools(
 			const scope = await resolveTaskScope(db, auth, args);
 			if ('error' in scope) return scope;
 			const { teamId, taskId } = scope;
-			const memberId = await resolveActorMemberId(db, auth, teamId);
+			const memberId = await resolveReactorMemberId(db, auth, teamId);
 			if (!memberId) return { error: 'No member identity for caller' };
 			const result = await removeCommentReaction({
 				db,

--- a/packages/server/src/routes/comments.ts
+++ b/packages/server/src/routes/comments.ts
@@ -7,7 +7,7 @@ import { validateCredentialValue } from '../lib/credential-validator';
 import {
 	apiKeyIdFromAuth,
 	resolveActor,
-	resolveActorMemberId,
+	resolveReactorMemberId,
 	resolveTaskId,
 } from '../lib/resolve';
 import { err, ok } from '../lib/response';
@@ -50,7 +50,7 @@ commentsRoutes.get('/projects/:projectId/tasks/:taskId/comments', async (c) => {
 		[taskId],
 	);
 
-	const viewerMemberId = await resolveActorMemberId(db, c.get('auth'), teamId);
+	const viewerMemberId = await resolveReactorMemberId(db, c.get('auth'), teamId);
 	const reactionsByComment = await loadReactionsForTask(db, taskId, viewerMemberId);
 	for (const comment of result.rows as Record<string, unknown>[]) {
 		comment.reactions = reactionsByComment.get(comment.id as string) ?? [];
@@ -79,7 +79,7 @@ commentsRoutes.put(
 		const commentId = c.req.param('commentId');
 		const kind = c.req.param('kind');
 
-		const memberId = await resolveActorMemberId(db, c.get('auth'), teamId);
+		const memberId = await resolveReactorMemberId(db, c.get('auth'), teamId);
 		if (!memberId) {
 			return err(c, 'FORBIDDEN', 'No member identity for caller', 403);
 		}
@@ -117,7 +117,7 @@ commentsRoutes.delete(
 		const commentId = c.req.param('commentId');
 		const kind = c.req.param('kind');
 
-		const memberId = await resolveActorMemberId(db, c.get('auth'), teamId);
+		const memberId = await resolveReactorMemberId(db, c.get('auth'), teamId);
 		if (!memberId) {
 			return err(c, 'FORBIDDEN', 'No member identity for caller', 403);
 		}

--- a/packages/server/test/comments-routes-uncovered.test.ts
+++ b/packages/server/test/comments-routes-uncovered.test.ts
@@ -181,7 +181,9 @@ describe('GET comments — reactions and attachments hydrate', () => {
 describe('reactions — identity and validation branches', () => {
 	it('403s a caller with no member identity in the team (PUT and DELETE)', async () => {
 		// A second superuser spans all teams via access control but has no member
-		// row in this team, so the reaction routes reject with FORBIDDEN.
+		// row in this team — nor in HQ, since it is inserted directly rather than
+		// enrolled — so the reactor fallback (current team → HQ) finds nothing and
+		// the reaction routes reject with FORBIDDEN.
 		const stray = await db.query<{ id: string }>(
 			"INSERT INTO users (display_name, is_superuser) VALUES ('Stray Admin', true) RETURNING id",
 		);

--- a/packages/server/test/reactions.test.ts
+++ b/packages/server/test/reactions.test.ts
@@ -1,4 +1,4 @@
-import { CommentContentType, ReactionKind } from '@hezo/shared';
+import { CommentContentType, DEFAULT_TEAM_ID, ReactionKind } from '@hezo/shared';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import type { MasterKeyManager } from '../src/crypto/master-key';
@@ -323,6 +323,104 @@ describe('REST reactions endpoints', () => {
 			{ method: 'PUT', headers: authHeader(otherToken) },
 		);
 		expect(res.status).toBe(403);
+	});
+
+	it('lets a superuser react in a team they can access but are not a member of (HQ fallback)', async () => {
+		// The reported bug: a superuser has access to every team (superuser bypass)
+		// but only a `member_users` row in HQ and teams they created — so reacting
+		// in a team provisioned some other way (CEO intake, template, seed) 403'd
+		// with "No member identity for caller". The fix resolves the reactor to the
+		// caller's HQ membership, mirroring how HQ agents act cross-team.
+
+		// Give the seeded superuser an HQ (default-team) member row, exactly as
+		// production's addUserToDefaultTeam does at setup. createTestApp inserts the
+		// user directly and skips that step, so we mirror it here.
+		const adminRes = await db.query<{ id: string; display_name: string }>(
+			'SELECT id, display_name FROM users WHERE is_superuser = true ORDER BY created_at LIMIT 1',
+		);
+		const adminUserId = adminRes.rows[0].id;
+		const hqMember = await db.query<{ id: string }>(
+			`INSERT INTO members (team_id, member_type, display_name)
+			 VALUES ($1, 'user'::member_type, $2) RETURNING id`,
+			[DEFAULT_TEAM_ID, adminRes.rows[0].display_name],
+		);
+		await db.query(`INSERT INTO member_users (id, user_id, role) VALUES ($1, $2, 'admin')`, [
+			hqMember.rows[0].id,
+			adminUserId,
+		]);
+
+		// A team the admin can access but is NOT a member of — created by a
+		// different user, mirroring a CEO/other-admin-provisioned team.
+		const otherUser = await db.query<{ id: string }>(
+			"INSERT INTO users (display_name, is_superuser) VALUES ('Other Owner', false) RETURNING id",
+		);
+		const typesRes = await app.request('/api/team-templates', { headers: authHeader(token) });
+		const typeId = (await typesRes.json()).data.find(
+			(t: Record<string, unknown>) => t.name === 'Startup',
+		).id;
+		const foreignTeam = await createTestTeam(db, {
+			name: 'Fallback Co',
+			template_id: typeId,
+			creatorUserId: otherUser.rows[0].id,
+		});
+		const foreignData = (await foreignTeam.json()).data;
+		const foreignTeamId = foreignData.id;
+		const foreignSlug = foreignData.slug;
+
+		const foreignAgentsRes = await app.request(
+			`/api/projects/${await projectSlugForTeamSlug(db, foreignSlug)}/agents`,
+			{ headers: authHeader(token) },
+		);
+		const foreignCaptain = (await foreignAgentsRes.json()).data.find(
+			(a: { slug: string }) => a.slug === 'captain',
+		);
+		const foreignProjectRes = await createTestProject(db, foreignTeamId, {
+			name: 'Fallback Project',
+			description: 'Admin-not-a-member reaction target.',
+		});
+		const foreignProjectId = (await foreignProjectRes.json()).data.id as string;
+		const foreignTaskId = await insertTask(foreignCaptain.id, 'fallback', {
+			teamId: foreignTeamId,
+			projectId: foreignProjectId,
+		});
+		const foreignCommentId = await insertComment(foreignTaskId, foreignCaptain.id);
+
+		// Sanity: the admin genuinely has no member row in the foreign team.
+		const membership = await db.query(
+			`SELECT 1 FROM members m JOIN member_users mu ON mu.id = m.id
+			 WHERE mu.user_id = $1 AND m.team_id = $2`,
+			[adminUserId, foreignTeamId],
+		);
+		expect(membership.rows).toHaveLength(0);
+
+		const url = `/api/projects/${foreignProjectId}/tasks/${foreignTaskId}/comments/${foreignCommentId}/reactions/${ReactionKind.Ack}`;
+
+		// PUT succeeds now (was 403), attributed to the admin's HQ member identity.
+		const put = await app.request(url, { method: 'PUT', headers: authHeader(token) });
+		expect(put.status).toBe(200);
+		const putBody = (await put.json()).data as { reactions: ReactionGroup[] };
+		expect(putBody.reactions).toHaveLength(1);
+		expect(putBody.reactions[0].members).toHaveLength(1);
+		expect(putBody.reactions[0].members[0].id).toBe(hqMember.rows[0].id);
+		expect(putBody.reactions[0].members[0].slug).toBeNull();
+		expect(putBody.reactions[0].members[0].display_name).toBe(adminRes.rows[0].display_name);
+
+		// GET reflects you_reacted for the same admin (viewer resolves via HQ too).
+		const getRes = await app.request(
+			`/api/projects/${foreignProjectId}/tasks/${foreignTaskId}/comments`,
+			{ headers: authHeader(token) },
+		);
+		const rows = (await getRes.json()).data as Array<{
+			id: string;
+			reactions: Array<{ kind: string; you_reacted: boolean }>;
+		}>;
+		const commentRow = rows.find((r) => r.id === foreignCommentId)!;
+		expect(commentRow.reactions[0].you_reacted).toBe(true);
+
+		// DELETE removes it.
+		const del = await app.request(url, { method: 'DELETE', headers: authHeader(token) });
+		expect(del.status).toBe(200);
+		expect(await reactionsRowCount(foreignCommentId)).toBe(0);
 	});
 });
 


### PR DESCRIPTION
## Problem

Adding a reaction (✓ `ack`) to a task comment failed with the toast **"Failed to add reaction: No member identity for caller"** (HTTP 403) whenever a superuser reacted in a team they had access to but weren't an explicit member of — e.g. a team provisioned by CEO intake, a template, or a seed rather than one they created via `POST /api/projects`.

## Root cause — access ≠ membership

Reactions attribute to a **non-null** `comment_reactions.member_id`. A human only gets a `member_users` row in the **HQ** default team (at setup) and in teams they create. A superuser has *access* to every team (superuser bypass) but not *membership*, so `resolveActorMemberId` returned `null` and the route rejected.

This is unlike task comments, whose **nullable** `author_member_id` lets an admin author as a null-member **"Admin"** — so commenting worked while reacting did not.

## Fix

Resolve the reactor's member identity preferring the **current team**, then falling back to the caller's **HQ (default-team)** membership — the same cross-team identity HQ agents (CEO/Coach) already use to act in other teams' projects, and the same fallback `resolveAgentId` applies. Every enrolled human is an HQ member, so this resolves for any admin.

- New `resolveReactorMemberId` in `packages/server/src/lib/resolve.ts`, scoped to the reaction paths only:
  - REST: `PUT`/`DELETE` reactions and the `GET /comments` `you_reacted` viewer (`routes/comments.ts`).
  - MCP: `add_reaction`/`remove_reaction` and the `list_comments` reaction viewer (`mcp/tools.ts`).
- `resolveActorMemberId` and audit attribution (`resolveActor`) are left untouched.
- Agent behavior is byte-identical (the `Agent` path returns `auth.memberId` as before); truly member-less callers (API keys) still return `null` and are rejected.
- No schema migration, and no web changes — the reaction hooks already trust the server's returned `reactions` and `you_reacted`, and render `display_name` ("Admin") when there is no slug.

## Tests

- `packages/server/test/reactions.test.ts` — new test reproducing the exact bug: an admin who is an HQ member but **not** a member of the target team reacts → `PUT` 200 (attributed to their HQ identity), `you_reacted` reflected on `GET`, `DELETE` 200. Verified it fails without the fallback.
- `packages/server/test/comments-routes-uncovered.test.ts` — the existing 403 test (a directly-inserted superuser with no member row anywhere, HQ included) stays green and now documents the remaining guard; its comment was updated to reflect the current-team → HQ fallback.

## Docs

- `.dev/architecture.md` — describes how a reaction's non-null `member_id` resolves via HQ membership for cross-team admins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018t3jrePsb1eiZrnGBvxr6U

---
_Generated by [Claude Code](https://claude.ai/code/session_018t3jrePsb1eiZrnGBvxr6U)_