### PR TITLE
feat(server): warn agents when a passive @@mention was meant as an active ask

### DIFF
--- a/packages/server/src/lib/mentions.ts
+++ b/packages/server/src/lib/mentions.ts
@@ -5,6 +5,16 @@ const INLINE_CODE_RE = /`[^`]*`/g;
 // passive (@@slug) references, so a deliberately-linked name is never flagged.
 const LINKED_MENTION_RE = /(?<![\w@])@@?([a-z0-9][\w-]*)/gi;
 
+// Directed-ask signals — text that reads as a request aimed at the reader rather
+// than a statement about them: a second-person pronoun (`you`/`your`/`yourself`,
+// which also covers `you're`/`you'll` via the word boundary), an imperative
+// request opener, or a question mark.
+const ASK_INTENT_RES: RegExp[] = [
+	/\b(?:you|your|yourself)\b/i,
+	/\b(?:please|kindly|ptal)\b/i,
+	/\?/,
+];
+
 export function extractMentionSlugs(content: unknown): string[] {
 	const text = flattenTextFields(content);
 	if (!text) return [];
@@ -57,6 +67,51 @@ export function detectUnlinkedTeammateReferences(content: unknown, knownSlugs: s
 		if (bold.test(stripped) || lead.test(stripped)) flagged.add(slug);
 	}
 	return Array.from(flagged);
+}
+
+/**
+ * Flags teammate slugs addressed with the PASSIVE mention form (`@@slug`) where
+ * the surrounding text reads like an ask — an active `@slug` was almost certainly
+ * intended, yet `@@` links without notifying, so the handoff stalls silently. To
+ * avoid warning on a deliberate passive reference, a slug is flagged only when it
+ * is BOTH addressed (a leading-line `@@slug —` or an emphasised `**@@slug**`) AND
+ * its address paragraph carries a directed-ask signal (see ASK_INTENT_RES). A slug
+ * that is also actively `@`-mentioned anywhere is never flagged — it already
+ * notifies. Mirrors detectUnlinkedTeammateReferences for the passive form.
+ */
+export function detectPassiveTeammateAsks(content: unknown, knownSlugs: string[]): string[] {
+	const text = flattenTextFields(content);
+	if (!text) return [];
+	const stripped = text.replace(FENCED_CODE_RE, ' ').replace(INLINE_CODE_RE, ' ');
+
+	// A slug reached by an active @mention already notifies, so it never warns.
+	const active = new Set(extractMentionSlugs(stripped));
+
+	const flagged = new Set<string>();
+	for (const rawSlug of knownSlugs) {
+		const slug = rawSlug.toLowerCase();
+		if (active.has(slug)) continue;
+		const s = escapeRegExp(slug);
+		// Addressed by the passive form: emphasised `**@@slug**`/`__@@slug__` or a
+		// leading-line `@@slug —` — the @@-prefixed analogue of the sibling's forms.
+		const bold = new RegExp(String.raw`(\*\*|__)@@${s}\1`, 'i');
+		const lead = new RegExp(String.raw`(?:^|\n)\s*@@${s}\s*[—–\-:,](?:\s|$)`, 'i');
+		if (!bold.test(stripped) && !lead.test(stripped)) continue;
+		// Only warn when the paragraph(s) carrying this passive mention read as an
+		// ask — scoped to those paragraphs so a `you` elsewhere never leaks in.
+		const block = passiveMentionParagraphs(stripped, s);
+		if (block && ASK_INTENT_RES.some((re) => re.test(block))) flagged.add(slug);
+	}
+	return Array.from(flagged);
+}
+
+/** The blank-line-delimited paragraph(s) of `stripped` that contain `@@<slug>`. */
+function passiveMentionParagraphs(stripped: string, escapedSlug: string): string {
+	const mentionRe = new RegExp(String.raw`(?<![\w@])@@${escapedSlug}\b`, 'i');
+	return stripped
+		.split(/\n\s*\n/)
+		.filter((p) => mentionRe.test(p))
+		.join('\n');
 }
 
 function flattenTextFields(value: unknown): string {

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -63,7 +63,11 @@ import {
 	wakeIfReady,
 	wouldCreateCycle,
 } from '../lib/dependencies';
-import { detectUnlinkedTeammateReferences, extractMentionSlugs } from '../lib/mentions';
+import {
+	detectPassiveTeammateAsks,
+	detectUnlinkedTeammateReferences,
+	extractMentionSlugs,
+} from '../lib/mentions';
 import {
 	actorTypeFromAuth,
 	apiKeyIdFromAuth,
@@ -213,6 +217,26 @@ function isErrorResult(result: unknown): boolean {
 }
 
 /**
+ * The teammate slugs a comment warning may name: every agent in the task's team
+ * plus the HQ instance agents (mirroring the mention-wakeup scoping), excluding
+ * the author so a self-reference never warns, plus @admin. Shared by the
+ * unlinked- and passive-mention warnings.
+ */
+async function resolveWarnableSlugs(
+	db: Db,
+	teamId: string,
+	authorMemberId: string,
+): Promise<string[]> {
+	const roster = await db.query<{ slug: string }>(
+		`SELECT ma.slug FROM member_agents ma
+		 JOIN members m ON m.id = ma.id
+		 WHERE (m.team_id = $1 OR m.team_id = $2) AND ma.id <> $3`,
+		[teamId, DEFAULT_TEAM_ID, authorMemberId],
+	);
+	return [...roster.rows.map((r) => r.slug), ADMIN_MENTION_SLUG];
+}
+
+/**
  * Returns a warning string when a comment addresses a teammate by bold/bare name
  * instead of a mention, or null when nothing is amiss. The author's own slug is
  * excluded so a self-reference never warns; resolution mirrors the mention-wakeup
@@ -224,13 +248,7 @@ async function buildUnlinkedMentionWarning(
 	authorMemberId: string,
 	content: string,
 ): Promise<string | null> {
-	const roster = await db.query<{ slug: string }>(
-		`SELECT ma.slug FROM member_agents ma
-		 JOIN members m ON m.id = ma.id
-		 WHERE (m.team_id = $1 OR m.team_id = $2) AND ma.id <> $3`,
-		[teamId, DEFAULT_TEAM_ID, authorMemberId],
-	);
-	const knownSlugs = [...roster.rows.map((r) => r.slug), ADMIN_MENTION_SLUG];
+	const knownSlugs = await resolveWarnableSlugs(db, teamId, authorMemberId);
 	const offenders = detectUnlinkedTeammateReferences(content, knownSlugs);
 	if (offenders.length === 0) return null;
 	const named = offenders.map((s) => `**${s}**`).join(', ');
@@ -240,6 +258,34 @@ async function buildUnlinkedMentionWarning(
 		`and notifies no one, so no wakeup was created. If you need them to act on this ` +
 		`ticket, post a follow-up using an active mention (${fixes}); if you were only ` +
 		`referring to them, use the passive form (@@${offenders[0]}).`
+	);
+}
+
+/**
+ * Returns a warning when a comment addresses a teammate with the PASSIVE mention
+ * form (@@slug) yet the surrounding text reads like an ask — the passive form
+ * links but notifies no one, so an intended handoff stalls silently. Only an
+ * addressing use paired with a directed-ask signal is flagged (see
+ * detectPassiveTeammateAsks), so a deliberate passive reference is left alone.
+ * Same scoping as buildUnlinkedMentionWarning; best-effort and non-blocking.
+ */
+async function buildPassiveMentionWarning(
+	db: Db,
+	teamId: string,
+	authorMemberId: string,
+	content: string,
+): Promise<string | null> {
+	const knownSlugs = await resolveWarnableSlugs(db, teamId, authorMemberId);
+	const offenders = detectPassiveTeammateAsks(content, knownSlugs);
+	if (offenders.length === 0) return null;
+	const named = offenders.map((s) => `@@${s}`).join(', ');
+	const fixes = offenders.map((s) => `@${s}`).join(', ');
+	return (
+		`You addressed ${named} with the passive form (@@) but the text reads like an ask — ` +
+		`that renders as a link and notifies no one, so no wakeup or admin-inbox alert was ` +
+		`created. If you need them to act on this ticket, edit this comment or post a follow-up ` +
+		`with an active mention (${fixes}); if you only meant to refer to them, leave the ` +
+		`passive form as-is.`
 	);
 }
 
@@ -2247,21 +2293,26 @@ export function registerTools(
 			// already-persisted comment on this check.
 			if (authorMemberId) {
 				const commentText = args.content as string;
-				const [teammateWarning, backtickWarning, terminalAskWarning] = await Promise.all([
-					buildUnlinkedMentionWarning(db, teamId, authorMemberId, commentText).catch((e) => {
-						log.error('Failed to check comment for unlinked teammate references:', e);
-						return null;
-					}),
-					buildBacktickedEntityWarning(db, teamId, scope.projectId, commentText).catch((e) => {
-						log.error('Failed to check comment for backticked entity references:', e);
-						return null;
-					}),
-					buildTerminalTaskAskWarning(db, taskId, commentText).catch((e) => {
-						log.error('Failed to check comment for asks on a terminal task:', e);
-						return null;
-					}),
-				]);
-				const warning = [teammateWarning, backtickWarning, terminalAskWarning]
+				const [teammateWarning, passiveWarning, backtickWarning, terminalAskWarning] =
+					await Promise.all([
+						buildUnlinkedMentionWarning(db, teamId, authorMemberId, commentText).catch((e) => {
+							log.error('Failed to check comment for unlinked teammate references:', e);
+							return null;
+						}),
+						buildPassiveMentionWarning(db, teamId, authorMemberId, commentText).catch((e) => {
+							log.error('Failed to check comment for passive teammate asks:', e);
+							return null;
+						}),
+						buildBacktickedEntityWarning(db, teamId, scope.projectId, commentText).catch((e) => {
+							log.error('Failed to check comment for backticked entity references:', e);
+							return null;
+						}),
+						buildTerminalTaskAskWarning(db, taskId, commentText).catch((e) => {
+							log.error('Failed to check comment for asks on a terminal task:', e);
+							return null;
+						}),
+					]);
+				const warning = [teammateWarning, passiveWarning, backtickWarning, terminalAskWarning]
 					.filter((w): w is string => Boolean(w))
 					.join(' ');
 				if (warning) return { ...row, warning };
@@ -2355,13 +2406,17 @@ export function registerTools(
 					wsManager,
 				).catch((e) => log.error('Failed to record task links from edited comment:', e)),
 			);
-			const [teammateWarning, backtickWarning] = await Promise.all([
+			const [teammateWarning, passiveWarning, backtickWarning] = await Promise.all([
 				buildUnlinkedMentionWarning(db, teamId, auth.memberId, args.content as string).catch(
 					(e) => {
 						log.error('Failed to check edited comment for unlinked teammate references:', e);
 						return null;
 					},
 				),
+				buildPassiveMentionWarning(db, teamId, auth.memberId, args.content as string).catch((e) => {
+					log.error('Failed to check edited comment for passive teammate asks:', e);
+					return null;
+				}),
 				buildBacktickedEntityWarning(db, teamId, scope.projectId, args.content as string).catch(
 					(e) => {
 						log.error('Failed to check edited comment for backticked entity references:', e);
@@ -2369,7 +2424,7 @@ export function registerTools(
 					},
 				),
 			]);
-			const warning = [teammateWarning, backtickWarning]
+			const warning = [teammateWarning, passiveWarning, backtickWarning]
 				.filter((w): w is string => Boolean(w))
 				.join(' ');
 			if (warning) return { ...r.rows[0], warning };

--- a/packages/server/test/passive-mention-warning.test.ts
+++ b/packages/server/test/passive-mention-warning.test.ts
@@ -1,0 +1,277 @@
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { MasterKeyManager } from '../src/crypto/master-key';
+import type { Db } from '../src/db/database';
+import { detectPassiveTeammateAsks } from '../src/lib/mentions';
+import type { Env } from '../src/lib/types';
+import { safeClose } from './helpers';
+import {
+	authHeader,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+	mintAgentToken,
+} from './helpers/app';
+
+// The screenshot case: an agent ends a comment with `@@admin — …` (the passive
+// mention form). It renders as a bare-word link, so it LOOKS like a ping, but @@
+// notifies no one — the handoff stalls. We warn only when the text next to the
+// passive mention reads like an ask (an active @admin was intended), never on a
+// deliberate passive reference.
+
+describe('detectPassiveTeammateAsks', () => {
+	const slugs = ['architect', 'qa-engineer', 'engineer', 'admin'];
+
+	it('flags the screenshot case: passive @@admin address with a second-person ask', () => {
+		expect(
+			detectPassiveTeammateAsks(
+				"@@admin — the drafts are ready for your re-review in Typefully when you're set.",
+				slugs,
+			),
+		).toEqual(['admin']);
+	});
+
+	it('flags an emphasised passive address with an imperative opener', () => {
+		expect(detectPassiveTeammateAsks('**@@architect** — please review.', slugs)).toEqual([
+			'architect',
+		]);
+	});
+
+	it('flags a leading-line passive address that asks a question', () => {
+		expect(detectPassiveTeammateAsks('@@admin: can you approve?', slugs)).toEqual(['admin']);
+	});
+
+	it('does not flag a passive FYI with no ask intent', () => {
+		expect(detectPassiveTeammateAsks('@@admin — release is done.', slugs)).toEqual([]);
+	});
+
+	it('does not flag a mid-prose passive reference', () => {
+		expect(detectPassiveTeammateAsks('as @@admin noted, ship it when you can.', slugs)).toEqual([]);
+	});
+
+	it('does not flag a slug that is also actively mentioned', () => {
+		expect(detectPassiveTeammateAsks('@admin — done. cc @@admin, your call.', slugs)).toEqual([]);
+	});
+
+	it('does not flag an active-only mention', () => {
+		expect(detectPassiveTeammateAsks('@architect — please review.', slugs)).toEqual([]);
+	});
+
+	it('does not flag a passive address to a non-teammate', () => {
+		expect(detectPassiveTeammateAsks('@@database — check your config', slugs)).toEqual([]);
+	});
+
+	it('ignores passive asks inside inline code and fenced blocks', () => {
+		expect(detectPassiveTeammateAsks('inert: `@@admin — please review` here', slugs)).toEqual([]);
+		expect(detectPassiveTeammateAsks('```\n@@admin — can you approve?\n```', slugs)).toEqual([]);
+	});
+
+	it('scopes the ask signal to the paragraph carrying the passive mention', () => {
+		// The "you" lives in a different paragraph than @@admin, so no ask is inferred.
+		expect(
+			detectPassiveTeammateAsks('@@admin — release is done.\n\nthanks, you all rock', slugs),
+		).toEqual([]);
+	});
+});
+
+describe('MCP create_comment / update_comment warn on passive-mention asks', () => {
+	let app: Hono<Env>;
+	let db: Db;
+	let token: string;
+	let masterKeyManager: MasterKeyManager;
+
+	let teamId: string;
+	let projectId: string;
+	let architectId: string;
+	let architectSlug: string;
+	let productLeadId: string;
+
+	async function insertTask(assigneeId: string, title: string): Promise<string> {
+		const meta = await db.query<{ task_prefix: string; number: number }>(
+			`SELECT p.task_prefix, next_project_task_number(p.id) AS number
+			 FROM projects p WHERE p.id = $1`,
+			[projectId],
+		);
+		const n = meta.rows[0].number;
+		const res = await db.query<{ id: string }>(
+			`INSERT INTO tasks (team_id, project_id, assignee_id, number, identifier, title, status, priority, labels)
+			 VALUES ($1, $2, $3, $4, $5, $6, 'backlog'::task_status, 'medium'::task_priority, '[]'::jsonb)
+			 RETURNING id`,
+			[teamId, projectId, assigneeId, n, `${meta.rows[0].task_prefix}-${n}`, title],
+		);
+		return res.rows[0].id;
+	}
+
+	async function callTool(
+		agentToken: string,
+		name: string,
+		args: Record<string, unknown>,
+	): Promise<{ id?: string; warning?: string; error?: string }> {
+		const res = await app.request('/mcp', {
+			method: 'POST',
+			headers: { ...authHeader(agentToken), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				jsonrpc: '2.0',
+				method: 'tools/call',
+				params: { name, arguments: args },
+				id: 1,
+			}),
+		});
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			result: { content: Array<{ type: string; text: string }> };
+		};
+		return JSON.parse(body.result.content[0].text) as {
+			id?: string;
+			warning?: string;
+			error?: string;
+		};
+	}
+
+	async function adminMentionCount(commentId: string): Promise<number> {
+		const r = await db.query<{ c: number }>(
+			`SELECT COUNT(*)::int AS c FROM admin_mentions WHERE comment_id = $1`,
+			[commentId],
+		);
+		return r.rows[0].c;
+	}
+
+	beforeAll(async () => {
+		const ctx = await createTestApp();
+		app = ctx.app;
+		db = ctx.db;
+		token = ctx.token;
+		masterKeyManager = ctx.masterKeyManager;
+
+		const typesRes = await app.request('/api/team-templates', { headers: authHeader(token) });
+		const typeId = (await typesRes.json()).data.find(
+			(t: Record<string, unknown>) => t.name === 'Startup',
+		).id;
+
+		const teamRes = await createTestTeam(db, { name: 'Passive Co', template_id: typeId });
+		teamId = (await teamRes.json()).data.id;
+
+		const projectData = (await (await createTestProject(db, teamId, { name: 'Project' })).json())
+			.data;
+		projectId = projectData.id;
+
+		const agentsRes = await app.request(`/api/projects/${projectData.slug}/agents`, {
+			headers: authHeader(token),
+		});
+		const agents = (await agentsRes.json()).data as Array<{ id: string; slug: string }>;
+		const architect = agents.find((a) => a.slug === 'architect')!;
+		architectId = architect.id;
+		architectSlug = architect.slug;
+		productLeadId = agents.find((a) => a.slug === 'product-lead')!.id;
+	});
+
+	afterAll(async () => {
+		await safeClose(db);
+	});
+
+	it('warns on a passive @@admin ask and notifies no one', async () => {
+		const taskId = await insertTask(architectId, 'Passive admin ask');
+		const { token: agentToken } = await mintAgentToken(
+			db,
+			masterKeyManager,
+			productLeadId,
+			teamId,
+			taskId,
+			{ projectId },
+		);
+		const result = await callTool(agentToken, 'create_comment', {
+			project: projectId,
+			task_id: taskId,
+			content: "@@admin — the drafts are ready for your re-review when you're set.",
+		});
+		expect(result.warning).toBeDefined();
+		expect(result.warning).toContain('admin');
+		expect(result.warning).toContain('active mention');
+		// The passive form genuinely notified no one.
+		expect(await adminMentionCount(result.id!)).toBe(0);
+	});
+
+	it('does not warn on a passive @@admin reference with no ask intent', async () => {
+		const taskId = await insertTask(architectId, 'Passive admin FYI');
+		const { token: agentToken } = await mintAgentToken(
+			db,
+			masterKeyManager,
+			productLeadId,
+			teamId,
+			taskId,
+			{ projectId },
+		);
+		const result = await callTool(agentToken, 'create_comment', {
+			project: projectId,
+			task_id: taskId,
+			content: '@@admin — release is done.',
+		});
+		expect(result.warning).toBeUndefined();
+		expect(await adminMentionCount(result.id!)).toBe(0);
+	});
+
+	it('does not warn on an active @admin ask and does notify', async () => {
+		const taskId = await insertTask(architectId, 'Active admin ask');
+		const { token: agentToken } = await mintAgentToken(
+			db,
+			masterKeyManager,
+			productLeadId,
+			teamId,
+			taskId,
+			{ projectId },
+		);
+		const result = await callTool(agentToken, 'create_comment', {
+			project: projectId,
+			task_id: taskId,
+			content: '@admin — the drafts are ready for your re-review.',
+		});
+		expect(result.warning).toBeUndefined();
+		expect(await adminMentionCount(result.id!)).toBeGreaterThan(0);
+	});
+
+	it('does not warn when an agent passively addresses itself', async () => {
+		const taskId = await insertTask(architectId, 'Self passive ask');
+		const { token: agentToken } = await mintAgentToken(
+			db,
+			masterKeyManager,
+			architectId,
+			teamId,
+			taskId,
+			{ projectId },
+		);
+		const result = await callTool(agentToken, 'create_comment', {
+			project: projectId,
+			task_id: taskId,
+			content: `@@${architectSlug} — remember to review your own plan.`,
+		});
+		expect(result.warning).toBeUndefined();
+	});
+
+	it('warns when an edit turns a comment into a passive @@admin ask', async () => {
+		const taskId = await insertTask(architectId, 'Edit into passive ask');
+		const { token: agentToken } = await mintAgentToken(
+			db,
+			masterKeyManager,
+			productLeadId,
+			teamId,
+			taskId,
+			{ projectId },
+		);
+		const created = await callTool(agentToken, 'create_comment', {
+			project: projectId,
+			task_id: taskId,
+			content: 'Draft ready.',
+		});
+		expect(created.warning).toBeUndefined();
+
+		const edited = await callTool(agentToken, 'update_comment', {
+			project: projectId,
+			task_id: taskId,
+			comment_id: created.id,
+			content: '@@admin — please take a look when you can.',
+		});
+		expect(edited.warning).toBeDefined();
+		expect(edited.warning).toContain('admin');
+		expect(await adminMentionCount(created.id!)).toBe(0);
+	});
+});


### PR DESCRIPTION
## Problem

An agent finished work and ended its comment with **`@@admin — the guideline updates are complete … the drafts are ready for your re-review … when you're set.`** In the UI this renders as a bare-word **link** ("admin"), so it *looks* like the admin was pinged — but `@@` is Hezo's **passive** mention form: it links without notifying. No admin-inbox alert fired, so the handoff stalled silently. The agent "forgot to *actively* mention the admin" (`@admin`).

No existing warning caught this:
- `detectUnlinkedTeammateReferences` deliberately **skips** any name carrying an `@`/`@@` prefix — `@@admin` is treated as intentional.
- `buildTerminalTaskAskWarning` only inspects **active** mentions (`extractMentionSlugs` is single-`@`).

## Change

Extend the existing "detect → attach an advisory `warning` to the tool result → let the agent decide" pattern (alongside the unlinked-name, backticked-entity, and terminal-ask warnings) to the passive-mention case. Advisory only — it never blocks the persisted comment.

Because `@@` is an **explicit** passive choice, the detector does **not** fire on every passive mention — only where an active mention was clearly intended. A slug is flagged only when **both** hold:

1. **It addresses the person** — a leading-line address (`@@slug —` / `@@slug:` / `@@slug,`) or an emphasised name (`**@@slug**`), not a mid-prose reference.
2. **The adjacent text reads like an ask** — the paragraph carrying that mention contains a directed-ask signal: a second-person pronoun (`you`/`your`/`yourself`, which also covers `you're`/`you'll`), an imperative opener (`please`/`kindly`/`PTAL`), or a question mark.

A slug that is **also** actively `@`-mentioned anywhere is never flagged (it already notifies). The intent test is scoped to the mention's own paragraph so a stray `you` elsewhere can't trip it. This fires on the screenshot case ("ready for **your** re-review … when **you're** set") and stays silent on a pure reference (`as @@admin noted, …`) or a passive FYI (`@@admin — release is done.`).

Scope: all teammates + admin (symmetric with the existing bold/plain-name warning — the same silent-handoff failure hits `@@captain — please review` too).

### Files

- **`packages/server/src/lib/mentions.ts`** — new `detectPassiveTeammateAsks(content, knownSlugs)` (sibling of `detectUnlinkedTeammateReferences`), reusing the file's code-stripping/flatten helpers and `extractMentionSlugs`, plus an `ASK_INTENT_RES` signal set.
- **`packages/server/src/mcp/tools.ts`** — new `buildPassiveMentionWarning`, wired into the `create_comment` and `update_comment` warning composition (covers "created **or** updated"). Factored the duplicated roster lookup shared with `buildUnlinkedMentionWarning` into `resolveWarnableSlugs`.

No REST change: warnings are an MCP-caller (agent) affordance, consistent with the existing warnings. The MCP reference already documents the return generically ("optionally with an advisory `warning` string"), so no doc regeneration was needed (`mcp-reference.test.ts` stays green).

## Testing

New `packages/server/test/passive-mention-warning.test.ts` (15 tests):
- **Unit** (`detectPassiveTeammateAsks`) — flags the exact screenshot string, `**@@architect** — please review.`, and `@@admin: can you approve?`; does **not** flag a passive FYI, a mid-prose reference, a slug that's also actively mentioned, an active-only mention, a non-teammate, code-span/fenced content, or a `you` in a different paragraph.
- **MCP `create_comment`** — a passive `@@admin` ask returns `warning` and **no `admin_mentions` row** exists (proves the passive form notified no one); a passive FYI → no warning; an active `@admin` ask → no warning and admin *was* notified; a self-address → no warning.
- **MCP `update_comment`** — editing a comment into a passive `@@admin` ask returns the warning.

Also re-ran `unlinked-mention-warning`, `comment-wakeups`, `update-comment`, `task-done-admin-ask-gate`, `backticked-entity-warning`, `mcp-reference`, and the mention-extract/tokens/admin-mentions suites — all green. `typecheck` and `check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9NEzXHHsjSCUBgQwZrvVh

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9NEzXHHsjSCUBgQwZrvVh)_