### PR TITLE
feat: add Log out button to the settings menu

### DIFF
--- a/docs/getting-started/first-run.md
+++ b/docs/getting-started/first-run.md
@@ -37,6 +37,10 @@ You can change it later in **Settings → Admin password**. If you ever forget i
 with your master key from the sign-in screen. See
 [Master key & encryption](/docs/security/master-key).
 
+To sign out, use **Log out** at the bottom of the **Settings** menu — it clears your
+session and returns you to the admin-password sign-in screen. (The instance itself stays
+unlocked; signing back in only needs your password.)
+
 ## 3. Connect a model
 
 Agents need a model to run. Add at least one **AI provider** — paste an API key (or

--- a/packages/web/src/components/settings-sidebar.tsx
+++ b/packages/web/src/components/settings-sidebar.tsx
@@ -1,7 +1,9 @@
 import { Link, useLocation } from '@tanstack/react-router';
-import { ChevronDown } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { ChevronDown, LogOut } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
 import { useMe } from '../hooks/use-me';
+import { logout } from '../lib/auth';
+import { queryClient } from '../lib/query-client';
 
 interface NavItem {
 	to: string;
@@ -39,6 +41,26 @@ function itemClass(active: boolean): string {
 }
 
 /**
+ * "Log out" action pinned to the bottom of the menu, separated from the nav
+ * items by a gap. Clears the session token and wipes the cached, authenticated
+ * data, then re-evaluates the top-level gate — with no session the `me` probe
+ * 401s and the app falls back to the admin-password sign-in screen.
+ */
+function LogoutButton({ onClick, className }: { onClick: () => void; className?: string }) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			data-testid="settings-logout"
+			className={`flex items-center gap-2 text-left text-[13px] px-3 py-1.5 rounded-md transition-colors cursor-pointer text-text-2 hover:text-text-1 hover:bg-surface-2 ${className ?? ''}`}
+		>
+			<LogOut className="w-4 h-4 shrink-0" />
+			<span>Log out</span>
+		</button>
+	);
+}
+
+/**
  * Navigation for the Settings section, shared across the main page and every
  * subpage so the menu is always present.
  *  - Desktop (md+): a persistent left sidebar, sticky to the top of the scroll
@@ -61,6 +83,19 @@ export function SettingsSidebar() {
 	useEffect(() => {
 		setOpen(false);
 	}, [pathname]);
+
+	const handleLogout = useCallback(() => {
+		setOpen(false);
+		logout();
+		// Reset every query: drops each back to its initial (data-less) state so no
+		// authenticated response lingers behind the sign-in screen, and refetches
+		// the active ones. Crucially, the top-level gate's `me` probe re-runs and —
+		// with the token now cleared — 401s, flipping the app to the admin-password
+		// sign-in screen. (A plain `invalidateQueries`/`clear` won't do this: an
+		// invalidated query keeps its last data on a failed refetch, and a cleared
+		// query's mounted observer doesn't reliably re-probe.)
+		queryClient.resetQueries();
+	}, []);
 
 	return (
 		<>
@@ -101,6 +136,7 @@ export function SettingsSidebar() {
 									{item.label}
 								</Link>
 							))}
+							<LogoutButton onClick={handleLogout} className="mt-3" />
 						</nav>
 					</>
 				)}
@@ -116,6 +152,7 @@ export function SettingsSidebar() {
 						{item.label}
 					</Link>
 				))}
+				<LogoutButton onClick={handleLogout} className="mt-4" />
 			</nav>
 		</>
 	);

--- a/packages/web/test/settings-logout.test.tsx
+++ b/packages/web/test/settings-logout.test.tsx
@@ -1,0 +1,37 @@
+import { waitFor, within } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { api } from '../src/lib/api';
+import { renderApp } from './helpers/render';
+
+// The Settings menu carries a "Log out" action at the bottom, one per rendered
+// nav (happy-dom mounts both the mobile and desktop variants since it doesn't
+// apply the responsive `hidden`/`md:` classes). Both share the same handler.
+
+test('settings menu shows a Log out action at the bottom of the nav', async () => {
+	const { findByTestId, getAllByTestId } = await renderApp({ initialPath: '/settings' });
+
+	// The desktop nav renders the menu items followed by the Log out button.
+	const desktopNav = await findByTestId('settings-nav-desktop');
+	const logout = within(desktopNav).getByTestId('settings-logout');
+	expect(logout.textContent).toContain('Log out');
+	// It is the last child of the nav (pinned to the bottom after the links).
+	expect(desktopNav.lastElementChild).toBe(logout);
+
+	// Every nav variant exposes the action.
+	expect(getAllByTestId('settings-logout').length).toBeGreaterThanOrEqual(1);
+});
+
+test('logging out clears the session and drops to the admin-password sign-in screen', async () => {
+	const { findByTestId, getAllByTestId, user } = await renderApp({ initialPath: '/settings' });
+
+	// Sanity: the app is signed in (settings chrome rendered, token present).
+	await findByTestId('settings-nav-desktop');
+	expect(api.getToken()).not.toBeNull();
+
+	await user.click(getAllByTestId('settings-logout')[0]);
+
+	// The token is gone and the top-level gate re-runs the `me` probe, which
+	// 401s without a session and renders the admin-password sign-in screen.
+	await waitFor(() => expect(api.getToken()).toBeNull());
+	await findByTestId('password-login');
+});


### PR DESCRIPTION
## Summary

Adds a **Log out** action pinned to the bottom of the Settings menu, separated from the rest of the nav items by a gap. It appears in both the desktop rail and the mobile collapsed dropdown. Signing out returns the user to the admin-password sign-in screen.

## What changed

- **`packages/web/src/components/settings-sidebar.tsx`** — new `LogoutButton` (a `LogOut` icon + "Log out" label, styled to match the nav items) rendered as the last child of both the desktop `<nav>` (`mt-4` gap) and the mobile dropdown `<nav>` (`mt-3` gap). Its handler:
  1. `logout()` — clears the session token (and localStorage) via the existing `lib/auth` helper.
  2. `queryClient.resetQueries()` — drops every cached query back to its initial (data-less) state and refetches the active ones. The top-level gate's `me` probe re-runs and, with the token gone, 401s — flipping the app to the admin-password sign-in screen.

  `resetQueries()` is used deliberately: `invalidateQueries` keeps stale data on a failed refetch (the gate would never flip), and `clear()` doesn't reliably re-probe the mounted observers, so neither surfaces the logged-out state.

- **`docs/getting-started/first-run.md`** — documents the sign-out flow where the guide already covers the admin password and sign-in screen.

## Behavior

- The button is available to any signed-in user (not superuser-gated).
- The **instance stays unlocked** — logging out only ends the browser session; signing back in needs just the admin password, not the master key.

## Testing

New component test `packages/web/test/settings-logout.test.tsx`:
- Asserts the "Log out" action renders at the bottom of the settings nav (last child).
- Drives the full flow end-to-end: click Log out → token cleared → the app re-evaluates the auth gate and renders the admin-password sign-in screen (`password-login`).

Also verified: `bun run typecheck` (all packages), Biome check on the changed files (clean), the existing settings component tests (`settings-version`, `instance-settings`) and the docs-bundle test all pass. The mobile settings-nav Playwright spec is additive-safe (it doesn't count nav items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TuSJ7JXwR8ECiccw2Arswc)_