### PR TITLE
feat: clarify master-key onboarding with confirm step and masked words

### DIFF
--- a/docs/getting-started/first-run.md
+++ b/docs/getting-started/first-run.md
@@ -15,7 +15,10 @@ Hezo encrypts everything sensitive — model keys, OAuth tokens, signing keys �
 The encryption key is derived from a **master key**: a twelve-word phrase generated
 for you on first run.
 
-- **Write it down and keep it somewhere safe.** It is shown once.
+- **Write it down and keep it somewhere safe** — a password manager is ideal. It is
+  shown once. The words stay hidden until you reveal them with the eye toggle.
+- **You confirm it by pasting it back** before setup continues, so you can't move on
+  without the full phrase. Need a different one? Generate a new key first.
 - It is held **in memory only** and never written to disk.
 - If you lose it, there is no recovery — the only way forward is to reset and start
   fresh. See [Master key & encryption](/docs/security/master-key).

--- a/packages/web/src/components/master-key-gate.tsx
+++ b/packages/web/src/components/master-key-gate.tsx
@@ -4,7 +4,7 @@ import {
 	normalizeMnemonic,
 	validateMnemonic,
 } from '@hezo/shared';
-import { KeyRound, Loader2, Lock, ShieldCheck } from 'lucide-react';
+import { AlertTriangle, Eye, EyeOff, KeyRound, Loader2, Lock, ShieldCheck } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { useState } from 'react';
 import { authenticateWithMnemonic } from '../lib/auth';
@@ -13,6 +13,7 @@ import { queryClient } from '../lib/query-client';
 import { queryKeys } from '../lib/query-keys';
 import { Button } from './ui/button';
 import { Logo } from './ui/logo';
+import { PasswordInput } from './ui/password-input';
 
 const REVEAL_STRIPS = 11;
 
@@ -66,11 +67,33 @@ export function MasterKeyForm({ state, embedded, onAuthenticated }: MasterKeyFor
 	const [loading, setLoading] = useState(false);
 	const [copied, setCopied] = useState(false);
 	const [revealing, setRevealing] = useState(false);
+	// Setup is a two-step flow: generate + save the key, then paste it back to
+	// confirm before it's committed. `phase` only matters when `isUnset`.
+	const [phase, setPhase] = useState<'generate' | 'confirm'>('generate');
+	// The generated words start masked (password-style); the eye toggle reveals them.
+	const [revealed, setRevealed] = useState(false);
 
 	const isUnset = state === 'unset';
 
 	function handleGenerate() {
 		setGeneratedKey(generateMnemonic());
+		setRevealed(false);
+		setCopied(false);
+		setError('');
+	}
+
+	function goToConfirm() {
+		setError('');
+		setKey('');
+		setRevealed(false);
+		setPhase('confirm');
+	}
+
+	function goBackToGenerate() {
+		setError('');
+		setKey('');
+		setRevealed(false);
+		setPhase('generate');
 	}
 
 	function finishTransition() {
@@ -81,6 +104,12 @@ export function MasterKeyForm({ state, embedded, onAuthenticated }: MasterKeyFor
 
 	async function handleSubmit(e: React.FormEvent) {
 		e.preventDefault();
+		// In setup we're always on the confirm step here: the pasted phrase must
+		// match the phrase we generated, so we know the user captured all 12 words.
+		if (isUnset && normalizeMnemonic(key) !== generatedKey) {
+			setError("That doesn't match your master key. Paste all 12 words exactly.");
+			return;
+		}
 		const phrase = isUnset ? (generatedKey ?? '') : normalizeMnemonic(key);
 		if (!phrase) return;
 		setError('');
@@ -115,6 +144,21 @@ export function MasterKeyForm({ state, embedded, onAuthenticated }: MasterKeyFor
 		}
 	}
 
+	const heading = !isUnset
+		? 'Unlock Hezo'
+		: phase === 'confirm'
+			? 'Confirm you saved your key'
+			: 'Create your master key';
+	const subtitle = !isUnset
+		? 'The instance is locked. Enter your 12-word master key to bring it back online.'
+		: phase === 'confirm'
+			? 'Paste the 12 words back so we know you have the full phrase. You can go back and generate a new one.'
+			: 'The one key that encrypts your data and unlocks this instance.';
+
+	// The generate-phase word grid + the confirm/unlock entry field.
+	const showGenerated = isUnset && phase === 'generate' && generatedKey !== null;
+	const showEntry = !isUnset || phase === 'confirm';
+
 	return (
 		<>
 			{revealing && <UnlockReveal onDone={finishTransition} />}
@@ -124,32 +168,38 @@ export function MasterKeyForm({ state, embedded, onAuthenticated }: MasterKeyFor
 					<div className="p-3 rounded-full bg-surface-2 border border-border-strong text-accent-soft-fg">
 						{isUnset ? <KeyRound className="w-6 h-6" /> : <ShieldCheck className="w-6 h-6" />}
 					</div>
-					<h2 className="text-lg font-semibold text-text-1">
-						{isUnset ? 'Create your master key' : 'Unlock Hezo'}
-					</h2>
-					<p className="text-sm text-text-2 text-center">
-						{isUnset
-							? 'This 12-word key unlocks the instance and encrypts everything in it.'
-							: 'The instance is locked. Enter your 12-word master key to bring it back online.'}
-					</p>
+					<h2 className="text-lg font-semibold text-text-1">{heading}</h2>
+					<p className="text-sm text-text-2 text-center">{subtitle}</p>
 				</div>
 			)}
 
 			<form onSubmit={handleSubmit} className="flex flex-col gap-4">
-				{isUnset && !generatedKey && (
+				{isUnset && phase === 'generate' && !generatedKey && (
 					<Button type="button" variant="secondary" onClick={handleGenerate}>
 						<KeyRound className="w-4 h-4" />
 						Generate master key
 					</Button>
 				)}
 
-				{generatedKey && (
+				{showGenerated && (
 					<div className="flex flex-col gap-3">
+						<div className="flex items-center justify-between">
+							<span className="text-eyebrow text-text-2">Your master key</span>
+							<button
+								type="button"
+								onClick={() => setRevealed((v) => !v)}
+								aria-label={revealed ? 'Hide key' : 'Show key'}
+								className="flex items-center gap-1.5 text-xs text-text-3 hover:text-text-1"
+							>
+								{revealed ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+								{revealed ? 'Hide' : 'Show'}
+							</button>
+						</div>
 						<ol
 							className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-2"
 							aria-label="Master key"
 						>
-							{generatedKey.split(' ').map((word, index) => (
+							{(generatedKey ?? '').split(' ').map((word, index) => (
 								<li
 									// biome-ignore lint/suspicious/noArrayIndexKey: fixed-length, never-reordered list with possibly-repeating words; position is the stable identity
 									key={index}
@@ -159,51 +209,98 @@ export function MasterKeyForm({ state, embedded, onAuthenticated }: MasterKeyFor
 									<span className="w-4 text-right text-[10px] tabular-nums text-text-3 select-none">
 										{index + 1}
 									</span>
-									<span className="font-mono text-xs text-text-1">{word}</span>
+									<span className="font-mono text-xs text-text-1">
+										{revealed ? word : '••••••'}
+									</span>
 								</li>
 							))}
 						</ol>
 						<Button type="button" variant="ghost" size="sm" onClick={handleCopy}>
 							{copied ? 'Copied!' : 'Copy to clipboard'}
 						</Button>
-						<div className="flex gap-2.5 items-start rounded-md border border-warning-soft-fg/25 bg-warning-soft px-3 py-2.5 text-[12.5px] leading-relaxed text-warning-soft-fg">
-							<Lock className="w-4 h-4 shrink-0 mt-0.5" />
-							<span>
-								<span className="font-semibold text-text-1">
-									Store these words somewhere safe now.
-								</span>{' '}
-								They're the only way to unlock the instance after a restart and to reset a forgotten
-								password. Hezo can't recover them for you.
-							</span>
+						<div className="flex flex-col gap-2.5 rounded-md border border-warning-soft-fg/25 bg-warning-soft px-3 py-3 text-[12.5px] leading-relaxed text-warning-soft-fg">
+							<div className="flex gap-2.5 items-start">
+								<KeyRound className="w-4 h-4 shrink-0 mt-0.5" />
+								<span>
+									<span className="font-semibold text-text-1">
+										Encrypts everything, unlocks every restart.
+									</span>{' '}
+									This key protects all data in your instance and brings it back online after each
+									restart.
+								</span>
+							</div>
+							<div className="flex gap-2.5 items-start">
+								<AlertTriangle className="w-4 h-4 shrink-0 mt-0.5" />
+								<span>
+									<span className="font-semibold text-text-1">
+										No one can recover it — not even Hezo.
+									</span>{' '}
+									Lose these words and your data is locked away for good.
+								</span>
+							</div>
+							<div className="flex gap-2.5 items-start">
+								<Lock className="w-4 h-4 shrink-0 mt-0.5" />
+								<span>
+									<span className="font-semibold text-text-1">Save it now</span> in a password
+									manager or another safe place — you'll confirm it on the next step.
+								</span>
+							</div>
 						</div>
 					</div>
 				)}
 
-				{!isUnset && (
+				{showEntry && (
 					<div className="flex flex-col gap-1.5">
 						<label htmlFor="mnemonic-entry" className="text-sm font-medium text-text-1">
 							Master Key
 						</label>
-						<textarea
+						<PasswordInput
 							id="mnemonic-entry"
+							revealLabel="key"
+							className="font-mono"
 							value={key}
 							onChange={(e) => setKey(e.target.value)}
-							placeholder="Enter your 12-word master key"
-							rows={3}
+							placeholder={
+								isUnset ? 'Paste your 12-word master key' : 'Enter your 12-word master key'
+							}
 							autoComplete="off"
 							autoCapitalize="none"
 							spellCheck={false}
-							className="w-full resize-none rounded-md border border-border-strong bg-surface-2 p-2.5 font-mono text-xs text-text-1 placeholder:text-text-3 focus:outline-none focus:ring-2 focus:ring-accent"
 						/>
 					</div>
 				)}
 
 				{error && <p className="text-sm text-danger">{error}</p>}
 
-				<Button type="submit" disabled={loading || (isUnset ? !generatedKey : !key.trim())}>
-					{loading && <Loader2 className="w-4 h-4 animate-spin" />}
-					{isUnset ? 'Set key & continue' : 'Unlock'}
-				</Button>
+				{showGenerated && (
+					<div className="flex flex-col gap-2">
+						<Button type="button" onClick={goToConfirm}>
+							Continue
+						</Button>
+						<Button type="button" variant="ghost" size="sm" onClick={handleGenerate}>
+							Generate a new key
+						</Button>
+					</div>
+				)}
+
+				{isUnset && phase === 'confirm' && (
+					<div className="flex flex-col gap-2">
+						<Button type="submit" disabled={loading || !key.trim()}>
+							{loading && <Loader2 className="w-4 h-4 animate-spin" />}
+							Set key & continue
+						</Button>
+						<Button type="button" variant="ghost" size="sm" onClick={goBackToGenerate}>
+							Back
+						</Button>
+					</div>
+				)}
+
+				{!isUnset && (
+					<Button type="submit" disabled={loading || !key.trim()}>
+						{loading && <Loader2 className="w-4 h-4 animate-spin" />}
+						Unlock
+					</Button>
+				)}
 			</form>
 		</>
 	);

--- a/packages/web/src/components/ui/password-input.tsx
+++ b/packages/web/src/components/ui/password-input.tsx
@@ -1,14 +1,25 @@
 import { Eye, EyeOff } from 'lucide-react';
 import { type InputHTMLAttributes, useState } from 'react';
 
-type PasswordInputProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'type'>;
+interface PasswordInputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> {
+	/**
+	 * Noun used in the toggle's aria-label ("Show {revealLabel}" / "Hide {revealLabel}").
+	 * Defaults to "password". Set a collision-free noun (e.g. "key") when a nearby
+	 * `getByLabelText` query would otherwise match the toggle as well as the field.
+	 */
+	revealLabel?: string;
+}
 
 /**
  * Password field with a trailing show/hide toggle. Renders only the input (plus
  * the eye button) — labels stay external so existing `getByLabelText` queries
  * and form layouts keep working. Styled to match the auth-form inputs.
  */
-export function PasswordInput({ className = '', ...props }: PasswordInputProps) {
+export function PasswordInput({
+	className = '',
+	revealLabel = 'password',
+	...props
+}: PasswordInputProps) {
 	const [visible, setVisible] = useState(false);
 	return (
 		<div className="relative">
@@ -20,7 +31,7 @@ export function PasswordInput({ className = '', ...props }: PasswordInputProps) 
 			<button
 				type="button"
 				onClick={() => setVisible((v) => !v)}
-				aria-label={visible ? 'Hide password' : 'Show password'}
+				aria-label={`${visible ? 'Hide' : 'Show'} ${revealLabel}`}
 				className="absolute inset-y-0 right-0 flex items-center px-3 text-text-3 hover:text-text-1"
 			>
 				{visible ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}

--- a/packages/web/test/master-key-setup.test.tsx
+++ b/packages/web/test/master-key-setup.test.tsx
@@ -1,6 +1,16 @@
+import { generateMnemonic } from '@hezo/shared';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, expect, test } from 'vitest';
 import { MasterKeyForm } from '../src/components/master-key-gate';
+
+/** Reveal the grid, then read the 12 words back (strip the leading position number). */
+function revealedPhrase(): string {
+	fireEvent.click(screen.getByRole('button', { name: /^show key$/i }));
+	return screen
+		.getAllByTestId('mnemonic-word')
+		.map((w) => (w.textContent ?? '').replace(/^\d+/, ''))
+		.join(' ');
+}
 
 afterEach(() => {
 	cleanup();
@@ -54,4 +64,91 @@ test('unlock rejects an invalid phrase inline without authenticating', async () 
 	fireEvent.click(screen.getByRole('button', { name: /unlock/i }));
 
 	await screen.findByText(/not a valid 12-word master key/i);
+});
+
+test('generated words are masked (password-style) by default', async () => {
+	render(<MasterKeyForm state="unset" embedded />);
+	fireEvent.click(screen.getByRole('button', { name: /generate master key/i }));
+
+	const words = await screen.findAllByTestId('mnemonic-word');
+	expect(words).toHaveLength(12);
+	// Each chip shows its position number plus a dot mask — never the word.
+	for (const w of words) {
+		expect(w.textContent).toContain('•');
+	}
+});
+
+test('the eye toggle reveals and re-hides the words', async () => {
+	render(<MasterKeyForm state="unset" embedded />);
+	fireEvent.click(screen.getByRole('button', { name: /generate master key/i }));
+	await screen.findAllByTestId('mnemonic-word');
+
+	// Reveal → 12 real alpha words, no dots.
+	fireEvent.click(screen.getByRole('button', { name: /^show key$/i }));
+	const revealed = screen
+		.getAllByTestId('mnemonic-word')
+		.map((w) => (w.textContent ?? '').replace(/^\d+/, ''));
+	expect(revealed).toHaveLength(12);
+	expect(revealed.every((t) => /^[a-z]+$/.test(t))).toBe(true);
+
+	// Hide → masked again.
+	fireEvent.click(screen.getByRole('button', { name: /^hide key$/i }));
+	expect(
+		screen.getAllByTestId('mnemonic-word').every((w) => (w.textContent ?? '').includes('•')),
+	).toBe(true);
+});
+
+test('the confirm step shows a masked entry field with a toggle', async () => {
+	render(<MasterKeyForm state="unset" embedded />);
+	fireEvent.click(screen.getByRole('button', { name: /generate master key/i }));
+	await screen.findAllByTestId('mnemonic-word');
+	fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
+
+	const field = (await screen.findByLabelText(/master key/i)) as HTMLInputElement;
+	expect(field.type).toBe('password');
+	expect(screen.getByRole('button', { name: /^show key$/i })).toBeTruthy();
+});
+
+test('the confirm step rejects a phrase that does not match the generated key', async () => {
+	render(<MasterKeyForm state="unset" embedded />);
+	fireEvent.click(screen.getByRole('button', { name: /generate master key/i }));
+	await screen.findAllByTestId('mnemonic-word');
+	fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
+
+	// A different valid phrase must not satisfy the paste-back check (no network hit).
+	fireEvent.change(await screen.findByLabelText(/master key/i), {
+		target: { value: generateMnemonic() },
+	});
+	fireEvent.click(screen.getByRole('button', { name: /set key & continue/i }));
+
+	await screen.findByText(/doesn't match your master key/i);
+});
+
+test('Back returns from confirm to the generated key', async () => {
+	render(<MasterKeyForm state="unset" embedded />);
+	fireEvent.click(screen.getByRole('button', { name: /generate master key/i }));
+	await screen.findAllByTestId('mnemonic-word');
+	fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
+	await screen.findByLabelText(/master key/i);
+
+	fireEvent.click(screen.getByRole('button', { name: /^back$/i }));
+
+	expect(await screen.findAllByTestId('mnemonic-word')).toHaveLength(12);
+	expect(screen.getByRole('button', { name: /^continue$/i })).toBeTruthy();
+});
+
+test('Generate a new key replaces the phrase and re-masks it', async () => {
+	render(<MasterKeyForm state="unset" embedded />);
+	fireEvent.click(screen.getByRole('button', { name: /generate master key/i }));
+	await screen.findAllByTestId('mnemonic-word');
+	const first = revealedPhrase();
+
+	fireEvent.click(screen.getByRole('button', { name: /generate a new key/i }));
+
+	const words = await screen.findAllByTestId('mnemonic-word');
+	expect(words).toHaveLength(12);
+	// Re-masked after regenerating.
+	expect(words.every((w) => (w.textContent ?? '').includes('•'))).toBe(true);
+	// A fresh phrase, distinct from the first.
+	expect(revealedPhrase()).not.toBe(first);
 });

--- a/test/browser/master-key-gate.spec.ts
+++ b/test/browser/master-key-gate.spec.ts
@@ -92,10 +92,15 @@ test('setup → password → provider, then restart → unlock → password logi
 	await page.getByRole('button', { name: /generate master key/i }).click();
 	const words = page.getByTestId('mnemonic-word');
 	await expect(words).toHaveCount(12);
+	// The words are masked (password-style) by default — reveal them first.
+	await page.getByRole('button', { name: /^show key$/i }).click();
 	// Each item renders "<n> <word>" — strip the leading position number.
 	const phrase = (await words.allTextContents())
 		.map((t) => t.replace(/^\s*\d+\s*/, '').trim())
 		.join(' ');
+	// Confirm step: paste the phrase back to prove it was captured, then commit.
+	await page.getByRole('button', { name: 'Continue', exact: true }).click();
+	await page.getByLabel(/master key/i).fill(phrase);
 	await page.getByRole('button', { name: /set key & continue/i }).click();
 
 	// The unlock reveal plays, then the wizard advances to the dedicated


### PR DESCRIPTION
## Why

The master-key setup screen is the first thing a new operator sees, and the master key is the one secret that can **never** be recovered. The old screen under-sold that: a one-line subtitle plus a single amber box, the 12 words shown in plaintext the instant they were generated, and a single click that both revealed and (on the next click) committed the key — with **no checkpoint** that the user actually saved it.

## What changed

All in `MasterKeyForm` (`packages/web/src/components/master-key-gate.tsx`), gated on `state === "unset"` so the reused recovery / setup-wizard re-entry paths are unaffected.

1. **Clearer, emphasised copy** — the single warning box becomes three highlighted points: what the key does (encrypts everything, unlocks every restart), that **no one — not even Hezo — can recover it**, and to save it now in a password manager. (No suggestion to store it on the host, per the master-key policy.)
2. **Confirm-by-paste step** — after generating, the user pastes the key back; it must match the generated phrase before it's committed, and they can go **Back** / **Generate a new key**. Setup is now generate → confirm → commit.
3. **Masked by default + eye toggle** — the generated words render as password-style dots until revealed, and the confirm + unlock entry fields become the shared masked `PasswordInput`. One eye toggle flips hidden ⇄ visible.

`PasswordInput` gains an optional `revealLabel` (default `"password"`, so its three existing consumers are untouched); the master-key fields pass `revealLabel="key"` so the toggle reads **"Show key"** and doesn't collide with the tests' `getByLabelText(/master key/i)`.

## Testing

- `packages/web/test/master-key-setup.test.tsx` — 3 existing + **6 new** component tests (masked-by-default, reveal/hide toggle, confirm field masked, confirm mismatch error, Back returns to grid, regenerate). ✅
- `master-key-unlock.test.tsx`, `password-auth.test.tsx`, `admin-password-settings.test.tsx` — green (confirms the masked field + `revealLabel` default are backward compatible). ✅
- `test/browser/master-key-gate.spec.ts` — updated to reveal then paste-confirm; full setup → confirm → password → provider → restart → unlock → login flow passes in Chromium. ✅
- `tsc --noEmit` and `biome check` clean.

## Docs

Added a brief note about the confirm step and masked display to `docs/getting-started/first-run.md`. The `docs/security/master-key.md` security model description remains accurate; no CLI/MCP/route/architecture surfaces were touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5rMuAkJmHFp2LTAKXfanH

---
_Generated by [Claude Code](https://claude.ai/code/session_01L5rMuAkJmHFp2LTAKXfanH)_