### PR TITLE
fix(web): collapse run entries by default; add a scroll-to-top button

### DIFF
--- a/packages/web/src/components/comment-renderers/run-comment.tsx
+++ b/packages/web/src/components/comment-renderers/run-comment.tsx
@@ -152,7 +152,13 @@ export function RunCommentBody({
 	const runQuery = useHeartbeatRun(projectId, agentId, runId);
 	const run = runQuery.data;
 	const status = run?.status ?? 'queued';
-	const isActive = isActiveRunStatus(status);
+	// Only positively-active once the run has actually loaded. While the per-run
+	// query is still resolving (`run == null`), `status` defaults to 'queued' —
+	// which would otherwise read as active and force the log open. On a virtualized
+	// feed every scroll remount refires this query, so treating "loading" as active
+	// made completed entries flash expanded, then collapse once the run resolved.
+	// Keeping the unknown/loading state non-active renders it collapsed instead.
+	const isActive = run != null && isActiveRunStatus(status);
 	// Offer a manual retry on a failed/timed-out run, but only on the latest run
 	// and only when nothing is already running or queued for this task — that's
 	// exactly what `retryableRunId` resolves to (null otherwise).
@@ -286,21 +292,22 @@ export function RunCommentBody({
 	return (
 		<>
 			{inline &&
-				(completed ? (
-					canRetry && taskId ? (
-						<div className="flex items-center gap-1 min-w-0">
-							{expandToggle}
-							<RunRetryButton projectId={projectId} taskId={taskId} runId={runId} />
-						</div>
-					) : (
-						expandToggle
-					)
-				) : (
+				(isActive ? (
+					// Actively running/queued: the log is force-shown, so the header is a
+					// static (non-collapsible) summary with no toggle.
 					<div className="flex items-center min-h-[26px] min-w-0" data-testid="run-comment-header">
 						{summaryRow}
 					</div>
+				) : canRetry && taskId ? (
+					<div className="flex items-center gap-1 min-w-0">
+						{expandToggle}
+						<RunRetryButton projectId={projectId} taskId={taskId} runId={runId} />
+					</div>
+				) : (
+					// Completed or still loading: collapsed by default, expandable on click.
+					expandToggle
 				))}
-			{(!completed || expanded) && (
+			{(isActive || expanded) && (
 				<div id={logRegionId}>
 					<LogViewer
 						lines={lines}

--- a/packages/web/src/components/scroll-to-top-button.tsx
+++ b/packages/web/src/components/scroll-to-top-button.tsx
@@ -1,0 +1,37 @@
+import { ChevronUp } from 'lucide-react';
+import { Tooltip } from './ui/tooltip';
+
+/**
+ * A thin "jump to top" pill: an upward chevron on the theme's inverse fill,
+ * mirroring `ScrollToBottomButton`. Rendered by the app shell over the <main>
+ * scroller on every page — `positionClassName` supplies the positioning. Hides
+ * itself and leaves the tab order once the content is scrolled to the top (or
+ * never overflowed in the first place).
+ */
+export function ScrollToTopButton({
+	onClick,
+	atTop,
+	testId,
+	positionClassName,
+}: {
+	onClick: () => void;
+	atTop: boolean;
+	testId: string;
+	positionClassName: string;
+}) {
+	return (
+		<Tooltip content="Scroll to top">
+			<button
+				type="button"
+				onClick={onClick}
+				data-testid={testId}
+				aria-label="Scroll to top"
+				aria-hidden={atTop}
+				tabIndex={atTop ? -1 : 0}
+				className={`flex h-6 items-center justify-center rounded-md bg-inverse px-5 text-inverse-fg shadow-lg transition-opacity hover:opacity-90 ${positionClassName} ${atTop ? 'invisible pointer-events-none opacity-0' : ''}`}
+			>
+				<ChevronUp className="h-4 w-4" />
+			</button>
+		</Tooltip>
+	);
+}

--- a/packages/web/src/hooks/use-scroll-to-top.ts
+++ b/packages/web/src/hooks/use-scroll-to-top.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Companion to `useScrollToBottom` for the "jump to top" affordance. `atTop`
+ * depends only on `scrollTop` (never on `scrollHeight`), so unlike the bottom
+ * hook this needs no Resize/Mutation observers — a plain scroll listener plus an
+ * initial measurement is enough. Content growth can't change whether you're at
+ * the top; only scrolling can.
+ */
+export function useScrollToTop(scrollParent: HTMLElement | null): {
+	atTop: boolean;
+	scrollToTop: () => void;
+} {
+	// Start hidden (`atTop: true`) so short pages never flash the button before the
+	// first measurement runs — mirrors `useScrollToBottom`'s initial state.
+	const [atTop, setAtTop] = useState(true);
+	useEffect(() => {
+		if (!scrollParent) return;
+		const check = () => setAtTop(scrollParent.scrollTop <= 200);
+		check();
+		scrollParent.addEventListener('scroll', check, { passive: true });
+		return () => scrollParent.removeEventListener('scroll', check);
+	}, [scrollParent]);
+
+	const scrollToTop = () => {
+		scrollParent?.scrollTo({ top: 0, behavior: 'smooth' });
+	};
+
+	return { atTop, scrollToTop };
+}

--- a/packages/web/src/routes/__root.tsx
+++ b/packages/web/src/routes/__root.tsx
@@ -16,6 +16,7 @@ import { ProjectRail } from '../components/project-rail';
 import { ProjectSidebar } from '../components/project-sidebar';
 import { PwaInstallPrompt } from '../components/pwa-install-prompt';
 import { ScrollToBottomButton } from '../components/scroll-to-bottom-button';
+import { ScrollToTopButton } from '../components/scroll-to-top-button';
 import { CreatePasswordFlow, SetupGate } from '../components/setup/setup-wizard';
 import { StartingScreen } from '../components/starting-screen';
 import { UpdateBanner } from '../components/update-banner';
@@ -24,6 +25,7 @@ import { useActiveProject } from '../hooks/use-active-project';
 import { useMe } from '../hooks/use-me';
 import { useProjectsIndex } from '../hooks/use-projects';
 import { useScrollToBottom } from '../hooks/use-scroll-to-bottom';
+import { useScrollToTop } from '../hooks/use-scroll-to-top';
 import { useStatus } from '../hooks/use-status';
 import { useShellWebSockets } from '../hooks/use-websocket';
 import { api } from '../lib/api';
@@ -169,6 +171,7 @@ function ShellChrome({ drawerOpen, setDrawerOpen }: ShellChromeProps) {
 		setMainEl(el);
 	}, []);
 	const { atBottom, scrollToBottom } = useScrollToBottom(mainEl);
+	const { atTop, scrollToTop } = useScrollToTop(mainEl);
 	const pathname = useLocation({ select: (l) => l.pathname });
 	const hash = useLocation({ select: (l) => l.hash });
 	const lastPathnameRef = useRef(pathname);
@@ -243,6 +246,13 @@ function ShellChrome({ drawerOpen, setDrawerOpen }: ShellChromeProps) {
 						<main ref={attachMain} className="flex-1 min-w-0 overflow-auto relative">
 							<Outlet />
 						</main>
+						{/* Top-centre of the content area, just below the app header. */}
+						<ScrollToTopButton
+							onClick={scrollToTop}
+							atTop={atTop}
+							testId="scroll-to-top"
+							positionClassName="absolute top-4 left-1/2 -translate-x-1/2 z-30"
+						/>
 						{/* Bottom-centre of the content area: clear of the CEO chat
 						    launcher (bottom-right) at every breakpoint. */}
 						<ScrollToBottomButton

--- a/packages/web/test/run-comment-collapse.test.tsx
+++ b/packages/web/test/run-comment-collapse.test.tsx
@@ -1,0 +1,153 @@
+import { expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+import { seedProject, seedTask, seedWorkspace } from './helpers/seed';
+
+// A run entry in the task feed must be collapsed by default and only auto-expand
+// while the run is actively running. The regression this guards: on a virtualized
+// feed each scroll remount refires the per-run status query, and while that query
+// was loading the entry rendered its log expanded (status defaults to 'queued',
+// which read as active) and then collapsed once the run resolved — a visible
+// flash. The fix treats the loading/unknown state as non-active (collapsed).
+
+const RUN_ID = 'dddd0000-0000-0000-0000-000000000abc';
+
+type Agent = { id: string; slug: string };
+type Seeded = { projectSlug: string; taskId: string };
+type Comment = Record<string, unknown>;
+
+function runComment(taskRowId: string, agent: Agent): Comment {
+	return {
+		id: 'run-collapse-c1',
+		task_id: taskRowId,
+		content_type: 'run',
+		content: { run_id: RUN_ID, agent_id: agent.id, agent_title: 'Captain', agent_slug: agent.slug },
+		chosen_option: null,
+		created_at: '2026-05-20T11:30:00Z',
+		author_type: 'agent',
+		author_name: 'Captain',
+		author_member_id: agent.id,
+	};
+}
+
+function runResponse(
+	agent: Agent,
+	teamId: string,
+	taskRowId: string,
+	status: string,
+): Record<string, unknown> {
+	const active = status === 'running' || status === 'queued';
+	return {
+		id: RUN_ID,
+		member_id: agent.id,
+		team_id: teamId,
+		task_id: taskRowId,
+		status,
+		started_at: '2026-05-20T11:30:00Z',
+		finished_at: active ? null : '2026-05-20T11:30:30Z',
+		exit_code: 0,
+		error: null,
+		input_tokens: 0,
+		output_tokens: 0,
+		cost_cents: 0,
+		log_text: 'run output line',
+		created_tasks: [],
+	};
+}
+
+/** Seed a team/project/task, stub the comments fetch with one run entry, and the
+ * per-run status fetch with the given status. `gate`, when supplied, holds the
+ * status response until the test resolves it, so the loading window is
+ * observable. */
+async function setup(opts: { seeded: Seeded; status: string; gate?: Promise<void> }) {
+	const { seeded, status, gate } = opts;
+	return renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const captain = ws.agents.find((a) => a.slug === 'captain') ?? ws.agents[0];
+			const project = await seedProject(ws, { name: 'Run Collapse Project' });
+			const task = await seedTask(ws, project, {
+				title: 'Run Collapse Task',
+				assignee_id: captain.id,
+			});
+
+			seeded.projectSlug = project.slug;
+			seeded.taskId = task.identifier.toLowerCase();
+
+			const comments = [runComment(task.id, captain)];
+			const run = runResponse(captain, ws.team.id, task.id, status);
+
+			const originalFetch = globalThis.fetch;
+			globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+				const url = typeof input === 'string' ? input : (input as Request).url;
+				const method = init?.method ?? (input instanceof Request ? input.method : 'GET');
+				if (method === 'GET' && /\/api\/projects\/[^/]+\/tasks\/[^/]+\/comments/.test(url)) {
+					return new Response(JSON.stringify({ data: comments }), {
+						status: 200,
+						headers: { 'Content-Type': 'application/json' },
+					});
+				}
+				if (
+					method === 'GET' &&
+					/\/api\/projects\/[^/]+\/agents\/[^/]+\/heartbeat-runs\/[^/?]+/.test(url)
+				) {
+					if (gate) await gate;
+					return new Response(JSON.stringify({ data: run }), {
+						status: 200,
+						headers: { 'Content-Type': 'application/json' },
+					});
+				}
+				return originalFetch(input as RequestInfo, init);
+			}) as typeof globalThis.fetch;
+		},
+	});
+}
+
+test('a completed run stays collapsed while its status is still loading (no flash)', async () => {
+	const seeded: Seeded = { projectSlug: '', taskId: '' };
+	let release!: () => void;
+	const gate = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+
+	const { findByTestId, queryByTestId, user, router } = await setup({
+		seeded,
+		status: 'succeeded',
+		gate,
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
+	});
+
+	// The run entry mounts and its header renders before the per-run status query
+	// resolves (the gate is still closed). The log body must NOT be shown during
+	// this loading window — that transient expand-then-collapse was the flash.
+	await findByTestId('run-comment-header', undefined, { timeout: 20_000 });
+	expect(queryByTestId('run-comment-log')).toBeNull();
+
+	// Resolve the status query: a succeeded run stays collapsed by default.
+	release();
+	await findByTestId('run-comment-summary', undefined, { timeout: 20_000 });
+	expect(queryByTestId('run-comment-log')).toBeNull();
+
+	// ...and only expands on an explicit click of the header.
+	await user.click(await findByTestId('run-comment-header'));
+	await findByTestId('run-comment-log', undefined, { timeout: 20_000 });
+});
+
+test('an actively running run shows its log expanded without interaction', async () => {
+	const seeded: Seeded = { projectSlug: '', taskId: '' };
+	const { findByTestId, queryByTestId, router } = await setup({ seeded, status: 'running' });
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: seeded.projectSlug, taskId: seeded.taskId },
+	});
+
+	// Active run: the log body is shown immediately, and there is no collapsed
+	// summary row (that only appears once the run has finished).
+	await findByTestId('run-comment-log', undefined, { timeout: 20_000 });
+	expect(queryByTestId('run-comment-summary')).toBeNull();
+});

--- a/test/browser/scroll-to-top-global.spec.ts
+++ b/test/browser/scroll-to-top-global.spec.ts
@@ -1,0 +1,98 @@
+// Real clientHeight/scrollHeight/scrollTop comparisons (testing decision tree,
+// point 1): the global scroll-to-top pill only shows once the shell <main>
+// genuinely overflows AND has been scrolled down, and clicking it must move the
+// real scroll position back to the top — values happy-dom can't compute. Mirrors
+// scroll-to-bottom-global.spec.ts; also asserts the pill sits below the top nav.
+
+import { expect, test } from './fixtures';
+import { waitForPageLoad } from './helpers';
+
+const DOC = 'long-doc-top.md';
+
+// Long enough that the content column overflows the viewport at both
+// breakpoints, so reaching the bottom requires scrolling.
+const LONG_CONTENT = `# Long document\n\n${Array.from(
+	{ length: 150 },
+	(_, i) => `## Section ${i}\n\nParagraph body for section ${i}.`,
+).join('\n\n')}\n\nTHE-VERY-END`;
+
+const SHORT_CONTENT = '# Short document\n\nJust one paragraph.';
+
+async function seedDoc(
+	page: import('@playwright/test').Page,
+	projectSlug: string,
+	token: string,
+	content: string,
+): Promise<void> {
+	const res = await page.request.put(`/api/projects/${projectSlug}/docs/${DOC}`, {
+		headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+		data: { content },
+	});
+	expect(res.ok()).toBe(true);
+}
+
+for (const { name, width, height } of [
+	{ name: 'desktop', width: 1280, height: 800 },
+	{ name: 'mobile', width: 375, height: 800 },
+]) {
+	test(`${name}: pill appears once scrolled down and jumps back to the top`, async ({
+		page,
+		lightWorkspace,
+	}) => {
+		const { projectSlug, token } = lightWorkspace;
+		await page.setViewportSize({ width, height });
+		await seedDoc(page, projectSlug, token, LONG_CONTENT);
+
+		await page.goto(`/projects/${projectSlug}/documents?file=${DOC}`);
+		await waitForPageLoad(page);
+		await expect(page.getByRole('heading', { name: DOC })).toBeVisible({ timeout: 20000 });
+
+		const button = page.getByTestId('scroll-to-top');
+		const main = page.locator('main').first();
+
+		// At the top there is nothing to jump to, so the pill stays hidden.
+		await expect(button).toBeHidden();
+
+		// Scroll to the bottom; the pill now offers a jump back to the top.
+		await main.evaluate((el) => el.scrollTo({ top: el.scrollHeight }));
+		await expect(button).toBeVisible();
+
+		// It sits just below the app header (the top nav bar), in the upper portion
+		// of the viewport rather than floating mid-page.
+		const headerBox = await page.getByTestId('app-header').boundingBox();
+		const buttonBox = await button.boundingBox();
+		expect(headerBox).not.toBeNull();
+		expect(buttonBox).not.toBeNull();
+		if (headerBox && buttonBox) {
+			expect(buttonBox.y).toBeGreaterThanOrEqual(headerBox.y + headerBox.height - 1);
+			expect(buttonBox.y).toBeLessThan(height / 2);
+		}
+
+		await button.click();
+
+		// The pill hides once the scroller reaches the top, and the real scroll
+		// position confirms the content genuinely moved back up.
+		await expect(button).toBeHidden({ timeout: 10000 });
+		await expect
+			.poll(() => main.evaluate((el) => el.scrollTop), { timeout: 10000 })
+			.toBeLessThanOrEqual(200);
+		await expect(page.getByRole('heading', { name: DOC })).toBeInViewport();
+	});
+}
+
+test('pill stays hidden when the page content does not overflow', async ({
+	page,
+	lightWorkspace,
+}) => {
+	const { projectSlug, token } = lightWorkspace;
+	await page.setViewportSize({ width: 1280, height: 800 });
+	await seedDoc(page, projectSlug, token, SHORT_CONTENT);
+
+	await page.goto(`/projects/${projectSlug}/documents?file=${DOC}`);
+	await waitForPageLoad(page);
+	await expect(page.getByRole('heading', { name: DOC })).toBeVisible({ timeout: 20000 });
+
+	// The document fits the viewport, so <main> has nothing to scroll and the
+	// pill must not offer a jump.
+	await expect(page.getByTestId('scroll-to-top')).toBeHidden();
+});


### PR DESCRIPTION
## Summary

Two task-page fixes on the web frontend:

### 1. Run entries no longer flash open-then-closed while scrolling

On the virtualized comment feed, each agent-run entry (`RunCommentBody`) is wrapped in `LazyMount` inside a `<Virtuoso>` list. As rows scroll past Virtuoso's viewport window they unmount and remount, and each remount refires the per-run `useHeartbeatRun` query.

The expand/collapse logic keyed off `completed = run != null && !isActive`, and while the query was still loading `status` defaulted to `'queued'` → `isActive` was `true` → the log body rendered (`!completed || expanded`). Once the query resolved to a finished run it collapsed — the visible "expanded, then closes" flash.

The fix gates the header/log-visibility on a **positively-known** active run:

```tsx
const isActive = run != null && isActiveRunStatus(status);
```

Net behaviour: a run entry is **closed by default**, expands on click, and **auto-expands only while actively running**. The loading/unknown state now renders collapsed, so there is nothing to flash. Steady-state completed and active rendering is unchanged (verified by the existing retry + agent-run-log specs).

### 2. New floating scroll-to-top button

Adds a global scroll-to-top pill mirroring the existing scroll-to-bottom button — same pill styling, hides itself when the scroller is at the top or doesn't overflow. It's positioned top-centre, just below the app header (the top nav bar). Because `atTop` depends only on `scrollTop` (never `scrollHeight`), its hook is a plain scroll listener with no Resize/Mutation observers.

## Changes

- `packages/web/src/components/comment-renderers/run-comment.tsx` — gate header/log on `isActive` (loading ⇒ collapsed).
- `packages/web/src/hooks/use-scroll-to-top.ts` — new hook (`atTop` / `scrollToTop`).
- `packages/web/src/components/scroll-to-top-button.tsx` — new pill, mirrors `ScrollToBottomButton`.
- `packages/web/src/routes/__root.tsx` — render the pill in the shell alongside the bottom one.

## Testing

- **New** `packages/web/test/run-comment-collapse.test.tsx` — asserts a completed run stays collapsed while its status query is still loading (the flash), and that an active run auto-expands its log with no interaction. ✅
- **New** `test/browser/scroll-to-top-global.spec.ts` — desktop + mobile: the pill is hidden at the top, appears once scrolled down, sits below the app header, and returns the scroller to the top on click; plus a no-overflow case. ✅
- Regression: `run-comment-retry`, `run-created-tasks`, `run-failed-comment`, `run-termination`, `run-comment-formatted-log` component specs and the `agent-run-logs` + `scroll-to-bottom-global` browser specs all pass. ✅
- `bun run typecheck` and `bun run check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHgrHJZcFdVTJ6gidhzHx7)_