### PR TITLE
feat(web): combine database + asset storage into a split-view Storage section

### DIFF
--- a/packages/web/src/components/asset-storage-section.tsx
+++ b/packages/web/src/components/asset-storage-section.tsx
@@ -1,11 +1,12 @@
+import { Cloud, HardDrive } from 'lucide-react';
 import { type AssetStorageInfo, useAssetStorageInfo } from '../hooks/use-asset-storage-info';
 import { useMe } from '../hooks/use-me';
 
 /**
- * Asset-storage card on General settings (rendered right after the Database
- * section). Superuser-only, matching the endpoint's gate. The storage URL
- * arrives pre-redacted from the server — this component never sees, stores,
- * or reveals the raw URL.
+ * Asset-storage card, rendered side-by-side with the database card inside
+ * {@link StorageSection}. Superuser-only, matching the endpoint's gate. The
+ * storage URL arrives pre-redacted from the server — this component never sees,
+ * stores, or reveals the raw URL.
  */
 export function AssetStorageSection() {
 	const { data: me } = useMe();
@@ -15,38 +16,42 @@ export function AssetStorageSection() {
 	if (!isSuperuser) return null;
 
 	return (
-		<section className="mt-8" data-testid="settings-asset-storage">
-			<div className="mb-4">
-				<h2 className="text-base font-medium">Asset storage</h2>
-				<p className="text-[13px] text-text-2 mt-1">
-					Where this instance stores uploaded asset files.
-				</p>
-			</div>
-			<div className="border border-border rounded-md p-3 bg-surface">
-				{info === undefined ? null : <AssetStorageDetails info={info} />}
-			</div>
-		</section>
+		<div
+			className="border border-border rounded-md p-3 bg-surface"
+			data-testid="settings-asset-storage"
+		>
+			{info === undefined ? null : <AssetStorageDetails info={info} />}
+		</div>
 	);
 }
 
 function AssetStorageDetails({ info }: { info: AssetStorageInfo }) {
+	const isS3 = info.backend === 's3';
+	// Icon stands in for the storage type — an object-storage bucket vs. the
+	// local disk.
+	const Icon = isS3 ? Cloud : HardDrive;
 	return (
-		<dl className="flex flex-col gap-3">
-			<div>
-				<dt className="text-[13px] font-medium">Storage</dt>
-				<dd className="text-[13px] text-text-2 mt-0.5" data-testid="settings-asset-storage-backend">
-					{info.backend === 's3' ? 'S3-compatible object storage' : 'Local filesystem'}
-				</dd>
+		<div className="flex items-start gap-3">
+			<div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-surface-2 text-text-2">
+				<Icon className="h-4 w-4" />
 			</div>
-			<div>
-				<dt className="text-[13px] font-medium">{info.backend === 's3' ? 'Bucket' : 'Location'}</dt>
-				<dd
-					className="text-[13px] text-text-2 mt-0.5 font-mono break-all"
+			<div className="min-w-0">
+				<div className="flex items-baseline gap-1.5 flex-wrap">
+					<h3 className="text-[13px] font-medium">Asset storage</h3>
+					<span className="text-[10px] text-text-3" aria-hidden="true">
+						&bull;
+					</span>
+					<span className="text-[13px] text-text-2" data-testid="settings-asset-storage-backend">
+						{isS3 ? 'S3-compatible object storage' : 'Local filesystem'}
+					</span>
+				</div>
+				<p
+					className="text-[12px] text-text-2 mt-1 font-mono break-all"
 					data-testid="settings-asset-storage-display"
 				>
 					{info.display}
-				</dd>
+				</p>
 			</div>
-		</dl>
+		</div>
 	);
 }

--- a/packages/web/src/components/database-section.tsx
+++ b/packages/web/src/components/database-section.tsx
@@ -1,11 +1,12 @@
+import { Database, Server } from 'lucide-react';
 import { type DatabaseInfo, useDatabaseInfo } from '../hooks/use-database-info';
 import { useMe } from '../hooks/use-me';
 
 /**
- * Storage card on General settings (rendered just before the Version
- * section). Superuser-only, matching the endpoint's gate. The connection
- * string arrives pre-redacted from the server — this component never sees,
- * stores, or reveals the raw URL.
+ * Database storage card, rendered side-by-side with the asset-storage card
+ * inside {@link StorageSection}. Superuser-only, matching the endpoint's gate.
+ * The connection string arrives pre-redacted from the server — this component
+ * never sees, stores, or reveals the raw URL.
  */
 export function DatabaseSection() {
 	const { data: me } = useMe();
@@ -15,46 +16,44 @@ export function DatabaseSection() {
 	if (!isSuperuser) return null;
 
 	return (
-		<section className="mt-8" data-testid="settings-database">
-			<div className="mb-4">
-				<h2 className="text-base font-medium">Database</h2>
-				<p className="text-[13px] text-text-2 mt-1">Where this instance stores its data.</p>
-			</div>
-			<div className="border border-border rounded-md p-3 bg-surface">
-				{info === undefined ? null : <DatabaseDetails info={info} />}
-			</div>
-		</section>
+		<div className="border border-border rounded-md p-3 bg-surface" data-testid="settings-database">
+			{info === undefined ? null : <DatabaseDetails info={info} />}
+		</div>
 	);
 }
 
 function DatabaseDetails({ info }: { info: DatabaseInfo }) {
+	const isExternal = info.backend === 'external';
+	// Icon stands in for the storage type — a managed Postgres server vs. the
+	// bundled embedded database.
+	const Icon = isExternal ? Server : Database;
 	return (
-		<dl className="flex flex-col gap-3">
-			<div>
-				<dt className="text-[13px] font-medium">Storage</dt>
-				<dd className="text-[13px] text-text-2 mt-0.5" data-testid="settings-database-backend">
-					{info.backend === 'external' ? 'External Postgres' : 'Embedded (PGlite)'}
-				</dd>
+		<div className="flex items-start gap-3">
+			<div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-surface-2 text-text-2">
+				<Icon className="h-4 w-4" />
 			</div>
-			<div>
-				<dt className="text-[13px] font-medium">
-					{info.backend === 'external' ? 'Connection' : 'Location'}
-				</dt>
-				<dd
-					className="text-[13px] text-text-2 mt-0.5 font-mono break-all"
+			<div className="min-w-0">
+				<div className="flex items-baseline gap-1.5 flex-wrap">
+					<h3 className="text-[13px] font-medium">Database</h3>
+					<span className="text-[10px] text-text-3" aria-hidden="true">
+						&bull;
+					</span>
+					<span className="text-[13px] text-text-2" data-testid="settings-database-backend">
+						{isExternal ? 'External Postgres' : 'Embedded (PGlite)'}
+					</span>
+				</div>
+				<p
+					className="text-[12px] text-text-2 mt-1 font-mono break-all"
 					data-testid="settings-database-display"
 				>
 					{info.display}
-				</dd>
-			</div>
-			{info.server_version && (
-				<div>
-					<dt className="text-[13px] font-medium">Server version</dt>
-					<dd className="text-[13px] text-text-2 mt-0.5" data-testid="settings-database-version">
+				</p>
+				{info.server_version && (
+					<p className="text-[12px] text-text-3 mt-1" data-testid="settings-database-version">
 						PostgreSQL {info.server_version}
-					</dd>
-				</div>
-			)}
-		</dl>
+					</p>
+				)}
+			</div>
+		</div>
 	);
 }

--- a/packages/web/src/components/storage-section.tsx
+++ b/packages/web/src/components/storage-section.tsx
@@ -1,0 +1,29 @@
+import { useMe } from '../hooks/use-me';
+import { AssetStorageSection } from './asset-storage-section';
+import { DatabaseSection } from './database-section';
+
+/**
+ * Storage section on General settings (rendered just before the Version
+ * section). Superuser-only, matching the underlying endpoints' gates. Combines
+ * the database and asset-storage cards into a single split view — stacked on
+ * mobile, side-by-side from `sm` up.
+ */
+export function StorageSection() {
+	const { data: me } = useMe();
+	if (me?.is_superuser !== true) return null;
+
+	return (
+		<section className="mt-8" data-testid="settings-storage">
+			<div className="mb-4">
+				<h2 className="text-base font-medium">Storage</h2>
+				<p className="text-[13px] text-text-2 mt-1">
+					Where this instance stores its data and uploaded files.
+				</p>
+			</div>
+			<div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+				<DatabaseSection />
+				<AssetStorageSection />
+			</div>
+		</section>
+	);
+}

--- a/packages/web/src/routes/settings/index.tsx
+++ b/packages/web/src/routes/settings/index.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { AssetStorageSection } from '../../components/asset-storage-section';
-import { DatabaseSection } from '../../components/database-section';
 import { InstanceSettingsSection } from '../../components/instance-settings-section';
+import { StorageSection } from '../../components/storage-section';
 import { VersionDisplay } from '../../components/version-display';
 
 /** The default Settings page (visiting /settings with no subpage) — general instance settings. */
@@ -9,8 +8,7 @@ function GeneralSettingsPage() {
 	return (
 		<div className="max-w-[900px]">
 			<InstanceSettingsSection />
-			<DatabaseSection />
-			<AssetStorageSection />
+			<StorageSection />
 			<VersionDisplay />
 		</div>
 	);

--- a/packages/web/test/settings-storage.test.tsx
+++ b/packages/web/test/settings-storage.test.tsx
@@ -1,0 +1,36 @@
+import { expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+
+// Full-route render against the real in-process backend: the embedded/local
+// variants are what a test server actually runs. Asserts the two cards share a
+// single "Storage" split view, each carries a storage-type icon, and the whole
+// section sits just before the Version section.
+test('general settings shows database + asset storage as one split view before Version', async () => {
+	const { findByTestId, findByRole } = await renderApp({ initialPath: '/settings' });
+
+	// findByTestId auto-waits — anchor on the data-driven rows so both queries
+	// have resolved before asserting layout.
+	const dbBackend = await findByTestId('settings-database-backend');
+	expect(dbBackend.textContent).toBe('Embedded (PGlite)');
+	const assetBackend = await findByTestId('settings-asset-storage-backend');
+	expect(assetBackend.textContent).toBe('Local filesystem');
+
+	// One shared "Storage" heading now fronts both cards.
+	await findByRole('heading', { name: 'Storage' });
+
+	const section = await findByTestId('settings-storage');
+	const database = await findByTestId('settings-database');
+	const asset = await findByTestId('settings-asset-storage');
+	const version = await findByTestId('settings-version');
+
+	// Both cards live inside the single Storage section...
+	expect(section.contains(database)).toBe(true);
+	expect(section.contains(asset)).toBe(true);
+	// ...database before asset storage, and the section before Version.
+	expect(database.compareDocumentPosition(asset) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+	expect(section.compareDocumentPosition(version) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
+	// Each card renders an icon standing in for its storage type.
+	expect(database.querySelector('svg')).not.toBeNull();
+	expect(asset.querySelector('svg')).not.toBeNull();
+});


### PR DESCRIPTION
## What & why

On **Settings → General**, the **Database** and **Asset storage** cards were two full-width sections stacked vertically, each with verbose `Storage` / `Location` label rows. This combines them into a single **Storage** section laid out as a split view, and simplifies each card to an icon + inline type + location.

## Changes

- **New `StorageSection`** (`storage-section.tsx`) — one superuser-gated section titled *Storage* ("Where this instance stores its data and uploaded files") wrapping both cards in a responsive grid: single column on mobile, two columns from `sm` up (mobile-first).
- **`DatabaseSection` / `AssetStorageSection`** are now the individual cards (no longer their own top-level sections). Each renders:
  - an **icon badge** representing the storage backend — `Database`/`Server` for embedded vs external Postgres, `HardDrive`/`Cloud` for local vs S3;
  - an inline **`Title • Type`** line (e.g. *Asset storage • Local filesystem*);
  - the pre-redacted **location** beneath (plus `PostgreSQL <version>` for the database).
- The per-field `Storage` / `Location` `<dl>` labels are dropped — the icon and title carry that meaning.
- `routes/settings/index.tsx` renders `<StorageSection />` in place of the two separate components (same position, just before Version).

The redaction contract is unchanged: cards still render exactly the server-redacted `display` string and never see or reveal a raw URL/credentials. Superuser gating is preserved on both the section and each card.

## Tests

- New `settings-storage.test.tsx`: asserts both cards render inside one *Storage* section, database before asset storage, the section before Version, and that each card renders a storage-type icon.
- Existing `settings-database.test.tsx` / `settings-asset-storage.test.tsx` (embedded/local, external/S3, and non-superuser variants) pass unchanged — the `*-backend`/`*-display`/`*-version` testids and ordering are preserved.

All 7 tests green; `tsc --noEmit` and Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PU3AMMKihp5WGGiZ48hboc)_