### PR TITLE
fix: fail runs that abandon background work; relax premature CLI timeouts

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -789,8 +789,16 @@ streak), so a task that never fits its run window can't loop forever.
 **Success gate.** A clean exit (`exit_code = 0`) only counts as `succeeded` if the run
 **produced output** — `produced_output` is set by any write tool (and a post-run worktree
 diff), or the agent explicitly calls `report_no_work`. A clean exit with neither is a
-silent no-op, marked `failed`. The completeness **stop-hook** (§ 6) is a separate gate
-that blocks the agent from ending its turn with unfinished work.
+silent no-op, marked `failed`. One further demotion overrides even a run that *did* write:
+if the CLI force-terminated still-running background work (Claude Code's headless
+`--print` mode prints "Background tasks still running after Ns; terminating" and kills a
+`run_in_background` job or a `Workflow` fan-out that never synthesized), the run
+**abandoned unfinished work** and is marked `failed` regardless of earlier output
+(`detectTerminatedBackgroundWork` scans the CLI's own diagnostic output — stderr and
+non-JSON stdout lines — so an agent that merely echoes the phrase can't trip it). This is
+a backstop to `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0` (which lifts the wait ceiling) for
+CLI versions that ignore the override. The completeness **stop-hook** (§ 6) is a separate
+gate that blocks the agent from ending its turn with unfinished work.
 
 **Sessions & recovery.** `agent_task_sessions` persists per-task session state; each
 heartbeat spawns a fresh subprocess and injects handoff markdown from the prior session,

--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -856,6 +856,24 @@ token usage on its stream** — the runner points it at a per-run `--debug-file`
 the `process_conversation_turn` tracing spans for cost (`extractGrokUsageFromDebugLog`),
 then scrubs the file (it also holds the `XAI_API_KEY`).
 
+**Runtime timeout hardening.** Each CLI ships default timeouts that would cut off Hezo's
+legitimately long agent/background work; every runtime is relaxed at its own config surface
+(no exact cross-runtime env analog exists for Claude Code's `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0`).
+**Claude Code** lifts the headless background-wait ceiling via that env var (in
+`CLAUDE_CODE_QUIET_ENV`). **Codex** (`config.toml`) sets top-level
+`background_terminal_max_timeout = 3600000` (its direct analog; default 5 min — Codex has no
+`0`-means-infinite sentinel, so a large finite value is used) and per-`[mcp_servers.*]`
+`tool_timeout_sec`/`startup_timeout_sec`; its built-in `openai` provider's per-stream knobs
+(`stream_idle_timeout_ms`) are **not** tunable while going direct (config/`-c` overrides of a
+built-in provider are silently ignored by Codex's vacant-only merge) and only drive a
+reconnect/retry, not a kill, so they're left at default. **Gemini** (`settings.json`) sets
+`tools.shell.inactivityTimeout = 0` (disables the 5-min kill of a silent shell command) and a
+per-MCP-server `timeout`. **OpenCode** (`opencode.json`) raises the per-MCP-server `timeout`
+from its 5 s (!) default to 10 min; its bash tool has a non-configurable 10-min hard cap.
+**Grok** (`config.toml`) raises `[toolset.bash].timeout_secs` and per-`[mcp_servers.*]`
+`startup_timeout_sec` (its bash already auto-backgrounds on timeout rather than killing). All
+values live as named constants in each `mcp-injectors/*.ts` adapter.
+
 **Completeness stop-hook.** Every run is gated by a judge that fires when the agent tries
 to end its turn and **blocks** it (keeping the same headless exec alive) when it's bailing
 on failing tests, calling problems "out of scope", deferring without filing a sub-task,

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -782,6 +782,37 @@ function abortErrorMessage(reason: RunAbortReason | null): string | undefined {
 	return reason ?? undefined;
 }
 
+/**
+ * Claude Code's headless `--print` mode caps how long it waits for still-running
+ * background tasks (a `run_in_background` job, a Workflow fan-out that hasn't
+ * synthesized yet) and then FORCE-KILLS them, printing a diagnostic line like
+ * "Background tasks still running after 600s; terminating." to its own output.
+ * `CLAUDE_CODE_QUIET_ENV` sets `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0` to lift
+ * that ceiling, but an older CLI (or one that ignores the override) still
+ * terminates the work — and the CLI then exits 0 with a NON-error `result`, so a
+ * run that already wrote something earlier (e.g. a progress update) would be
+ * counted a success even though its actual deliverable was killed mid-flight.
+ * This is the runner-side backstop: detect the diagnostic so the run is failed.
+ *
+ * Matched only against the CLI's own diagnostic output — stderr, plus non-JSON
+ * stdout lines. The stream-json events an agent's text rides in are JSON objects
+ * (they start with `{`), so an agent that merely echoes this phrase in its
+ * message can't trip the backstop.
+ */
+const BACKGROUND_TERMINATION_MARKER = /Background tasks still running after .*?terminating/i;
+
+export function detectTerminatedBackgroundWork(stdout: string, stderr: string): boolean {
+	if (BACKGROUND_TERMINATION_MARKER.test(stderr)) return true;
+	for (const line of stdout.split('\n')) {
+		const trimmed = line.trim();
+		// Skip the JSON stream events (agent-authored text lives inside these); a
+		// CLI diagnostic is a bare line that never starts with `{`.
+		if (trimmed === '' || trimmed.startsWith('{')) continue;
+		if (BACKGROUND_TERMINATION_MARKER.test(trimmed)) return true;
+	}
+	return false;
+}
+
 function extractTriggeredBy(payload: Record<string, unknown> | undefined): TriggeredBy | null {
 	const raw = payload?.triggered_by;
 	if (!raw || typeof raw !== 'object') return null;
@@ -1377,16 +1408,31 @@ export async function runAgent(
 				}
 			}
 
-			const success = exitedClean && (producedOutput || reportedNoWork);
+			// A clean exit where the runtime force-terminated still-running background
+			// work is NOT a success: the run abandoned unfinished work (e.g. a
+			// deep-research Workflow that never got to synthesize its report) even
+			// though it exits 0 and may have written something earlier. Fail it so it
+			// surfaces and is retried rather than silently counting as done.
+			const backgroundWorkTerminated =
+				exitedClean &&
+				runtimeType === AgentRuntime.ClaudeCode &&
+				detectTerminatedBackgroundWork(stdout, stderr);
+
+			const success =
+				exitedClean && (producedOutput || reportedNoWork) && !backgroundWorkTerminated;
+			const backgroundError = backgroundWorkTerminated
+				? 'run ended with background tasks still running — the runtime terminated the unfinished work before it completed, so the run abandoned incomplete work'
+				: undefined;
 			const noOutputError =
-				exitedClean && !producedOutput && !reportedNoWork
+				exitedClean && !producedOutput && !reportedNoWork && !backgroundWorkTerminated
 					? 'run produced no output (no code changes, comments, tasks, documents, or other writes)'
 					: undefined;
 			// A failed run's terminal error (e.g. a provider billing/auth rejection)
 			// otherwise lives only in the log; surface it on the run row so the board
 			// shows why the run failed instead of a bare "failed".
 			const terminalError = success ? null : parser.getTerminalError();
-			if (noOutputError) emit('stderr', `\n[runner] ${noOutputError}\n`);
+			if (backgroundError) emit('stderr', `\n[runner] ${backgroundError}\n`);
+			else if (noOutputError) emit('stderr', `\n[runner] ${noOutputError}\n`);
 			else if (reportedNoWork && !producedOutput)
 				emit('stdout', `\n[runner] no work to do${noWorkReason ? ` — ${noWorkReason}` : ''}\n`);
 			else if (terminalError) emit('stderr', `\n[runner] ${terminalError}\n`);
@@ -1399,7 +1445,7 @@ export async function runAgent(
 					status: success ? HeartbeatRunStatus.Succeeded : HeartbeatRunStatus.Failed,
 					exitCode: execInfo.ExitCode,
 					durationMs,
-					error: noOutputError ?? terminalError ?? undefined,
+					error: backgroundError ?? noOutputError ?? terminalError ?? undefined,
 					// Grok's usage comes from the debug log (runUsage); every other
 					// runtime reports it on the stream (parser.getUsage()).
 					usage: runUsage ?? parser.getUsage(),

--- a/packages/server/src/services/mcp-injectors/codex.ts
+++ b/packages/server/src/services/mcp-injectors/codex.ts
@@ -15,6 +15,32 @@ function renderStopHookBlock(judgeScriptContainerPath: string): string {
 
 const JUDGE_SCRIPT_BASENAME = 'stop-hook-judge.mjs';
 
+// Codex's background-terminal poll ceiling (`background_terminal_max_timeout`,
+// milliseconds) is the structural analog of Claude Code's
+// `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS`: how long an empty poll on a
+// backgrounded/long-running command waits for output before yielding back to the
+// model. Default is 300000 (5 min); raise it to an hour (the value Codex's own
+// built-in `awaiter` agent uses). Unlike Claude Code there is no "0 = infinite"
+// sentinel — the wait is clamped to a max, so 0 would be invalid; use a large
+// finite value.
+const BACKGROUND_TERMINAL_MAX_TIMEOUT_MS = 3_600_000;
+
+// Per-MCP-server bounds (seconds). Codex aborts a single tool call after
+// `tool_timeout_sec` (default 300 = 5 min) and drops a server that doesn't start
+// within `startup_timeout_sec` (default 30). Raise both so a long-running MCP
+// tool or a slow-starting stdio server isn't cut off.
+const MCP_TOOL_TIMEOUT_SEC = 1_800;
+const MCP_STARTUP_TIMEOUT_SEC = 120;
+
+/** Append Codex's per-server timeout keys to a rendered `[mcp_servers.<name>]` table. */
+function withServerTimeouts(serverBlock: string): string {
+	return [
+		serverBlock,
+		`startup_timeout_sec = ${MCP_STARTUP_TIMEOUT_SEC}`,
+		`tool_timeout_sec = ${MCP_TOOL_TIMEOUT_SEC}`,
+	].join('\n');
+}
+
 export const codexAdapter: RuntimeMcpAdapter = {
 	capabilities: {
 		transport: 'streamable-http',
@@ -30,11 +56,15 @@ export const codexAdapter: RuntimeMcpAdapter = {
 		const judgeScriptContainerPath = join(ctx.containerHomeDir, JUDGE_SCRIPT_BASENAME);
 
 		// Top-level keys must precede every [table] header in TOML, so the
-		// web-search mode leads the file. "live" fetches current pages rather
-		// than the cached index, giving agents real-time web search.
-		const blocks: string[] = ['web_search = "live"'];
+		// web-search mode + background-terminal ceiling lead the file. "live"
+		// fetches current pages rather than the cached index, giving agents
+		// real-time web search.
+		const blocks: string[] = [
+			`web_search = "live"\nbackground_terminal_max_timeout = ${BACKGROUND_TERMINAL_MAX_TIMEOUT_MS}`,
+		];
 		for (const d of descriptors) {
-			blocks.push(d.kind === 'http' ? renderHttpBlock(d) : renderStdioBlock(d));
+			const serverBlock = d.kind === 'http' ? renderHttpBlock(d) : renderStdioBlock(d);
+			blocks.push(withServerTimeouts(serverBlock));
 		}
 		blocks.push(renderStopHookBlock(judgeScriptContainerPath));
 		const contents = `${blocks.join('\n\n')}\n`;

--- a/packages/server/src/services/mcp-injectors/gemini.ts
+++ b/packages/server/src/services/mcp-injectors/gemini.ts
@@ -9,11 +9,13 @@ import type {
 
 interface GeminiHttpEntry {
 	httpUrl: string;
+	timeout: number;
 	headers?: Record<string, string>;
 }
 
 interface GeminiStdioEntry {
 	command: string;
+	timeout: number;
 	args?: string[];
 	env?: Record<string, string>;
 }
@@ -35,10 +37,27 @@ interface GeminiSettings {
 	hooks: {
 		AfterAgent: GeminiHookMatcherGroup[];
 	};
+	tools: {
+		shell: {
+			inactivityTimeout: number;
+		};
+	};
 }
 
+// The Gemini CLI kills a `run_shell_command` that produces no output for
+// `tools.shell.inactivityTimeout` seconds (default 300 = 5 min) — a long, quiet
+// build/test/agent step is terminated mid-flight. `0` disables the kill entirely
+// (the CLI early-returns when the value is ≤ 0), so legitimately long silent work
+// is never cut off. There is no env-var equivalent; it's a settings.json key.
+const SHELL_INACTIVITY_TIMEOUT_DISABLED = 0;
+
+// Per-MCP-server request timeout (`mcpServers.<name>.timeout`, milliseconds). The
+// CLI default is already 10 min; we set it explicitly so a future default change
+// can't silently tighten it, and to stay consistent with the other runtimes.
+const MCP_REQUEST_TIMEOUT_MS = 600_000;
+
 function buildHttpEntry(d: McpHttpDescriptor): GeminiHttpEntry {
-	const entry: GeminiHttpEntry = { httpUrl: d.url };
+	const entry: GeminiHttpEntry = { httpUrl: d.url, timeout: MCP_REQUEST_TIMEOUT_MS };
 	const headers: Record<string, string> = { ...(d.headers ?? {}) };
 	if (d.bearerToken) headers.Authorization = `Bearer ${d.bearerToken}`;
 	if (Object.keys(headers).length > 0) entry.headers = headers;
@@ -46,7 +65,7 @@ function buildHttpEntry(d: McpHttpDescriptor): GeminiHttpEntry {
 }
 
 function buildStdioEntry(d: McpStdioDescriptor): GeminiStdioEntry {
-	const entry: GeminiStdioEntry = { command: d.command };
+	const entry: GeminiStdioEntry = { command: d.command, timeout: MCP_REQUEST_TIMEOUT_MS };
 	if (d.args?.length) entry.args = d.args;
 	if (d.env && Object.keys(d.env).length > 0) entry.env = d.env;
 	return entry;
@@ -81,6 +100,11 @@ export const geminiAdapter: RuntimeMcpAdapter = {
 						],
 					},
 				],
+			},
+			tools: {
+				shell: {
+					inactivityTimeout: SHELL_INACTIVITY_TIMEOUT_DISABLED,
+				},
 			},
 		};
 

--- a/packages/server/src/services/mcp-injectors/grok.ts
+++ b/packages/server/src/services/mcp-injectors/grok.ts
@@ -33,6 +33,19 @@ import type {
 
 const CONFIG_BASENAME = 'config.toml';
 
+// A slow-starting stdio MCP server (e.g. an `npx -y <pkg>` cold start that must
+// download the package) can exceed Grok's 30s default MCP startup handshake
+// (`[mcp_servers.<name>].startup_timeout_sec`) and be dropped at launch. Give it
+// a generous ceiling. (Grok's per-tool-call default, `tool_timeout_sec`, is
+// already 6000s, so we leave that alone.)
+const MCP_STARTUP_TIMEOUT_SEC = 120;
+
+// Grok's bash toolset defaults to a 120s foreground `timeout_secs`; on expiry it
+// auto-backgrounds rather than killing the command (`auto_background_on_timeout`
+// is true by default), but raising the foreground window lets a normal long
+// build/test finish inline instead of being pushed to a background poll loop.
+const BASH_TIMEOUT_SEC = 3600;
+
 /** Render a TOML key: bare when it only uses `[A-Za-z0-9_-]`, else quoted. */
 function tomlKey(name: string): string {
 	return TOML_KEY_RE.test(name) ? name : escapeTomlBasicString(name);
@@ -50,7 +63,12 @@ function renderSubTable(serverKey: string, sub: string, entries: Record<string, 
 function renderHttpServer(d: McpHttpDescriptor): string {
 	const key = safeName(d.name);
 	const blocks: string[] = [
-		[`[mcp_servers.${key}]`, `url = ${escapeTomlBasicString(d.url)}`, 'enabled = true'].join('\n'),
+		[
+			`[mcp_servers.${key}]`,
+			`url = ${escapeTomlBasicString(d.url)}`,
+			'enabled = true',
+			`startup_timeout_sec = ${MCP_STARTUP_TIMEOUT_SEC}`,
+		].join('\n'),
 	];
 	const headers: Record<string, string> = { ...(d.headers ?? {}) };
 	if (d.bearerToken) headers.Authorization = `Bearer ${d.bearerToken}`;
@@ -65,6 +83,7 @@ function renderStdioServer(d: McpStdioDescriptor): string {
 	const lines = [`[mcp_servers.${key}]`, `command = ${escapeTomlBasicString(d.command)}`];
 	if (d.args && d.args.length > 0) lines.push(`args = ${tomlArray(d.args)}`);
 	lines.push('enabled = true');
+	lines.push(`startup_timeout_sec = ${MCP_STARTUP_TIMEOUT_SEC}`);
 	const blocks: string[] = [lines.join('\n')];
 	if (d.env && Object.keys(d.env).length > 0) {
 		blocks.push(renderSubTable(key, 'env', d.env));
@@ -87,6 +106,9 @@ export const grokAdapter: RuntimeMcpAdapter = {
 		for (const d of descriptors) {
 			blocks.push(d.kind === 'http' ? renderHttpServer(d) : renderStdioServer(d));
 		}
+		// Give long foreground shell commands room to finish inline before Grok
+		// auto-backgrounds them at the 120s default.
+		blocks.push(`[toolset.bash]\ntimeout_secs = ${BASH_TIMEOUT_SEC}`);
 		// Never let the CLI self-update mid-run inside the locked-down container.
 		blocks.push('[cli]\nauto_update = false');
 		const contents = `${blocks.join('\n\n')}\n`;

--- a/packages/server/src/services/mcp-injectors/opencode.ts
+++ b/packages/server/src/services/mcp-injectors/opencode.ts
@@ -28,6 +28,7 @@ interface OpencodeRemoteServer {
 	type: 'remote';
 	url: string;
 	enabled: true;
+	timeout: number;
 	headers?: Record<string, string>;
 }
 
@@ -35,6 +36,7 @@ interface OpencodeLocalServer {
 	type: 'local';
 	command: string[];
 	enabled: true;
+	timeout: number;
 	environment?: Record<string, string>;
 }
 
@@ -47,10 +49,23 @@ interface OpencodeConfig {
 
 const CONFIG_BASENAME = 'opencode.json';
 
+// OpenCode's per-MCP-server request timeout (`mcp.<name>.timeout`) defaults to a
+// mere 5000 ms — any Hezo MCP tool call that takes longer than 5s fails outright.
+// There is no env-var override (OpenCode reads only a fixed env-var set, none
+// timeout-related), so we stamp a generous per-server timeout into the
+// `opencode.json` the injector already writes. 10 min matches the other runtimes'
+// MCP ceilings and is safely above any real Hezo tool call.
+const MCP_REQUEST_TIMEOUT_MS = 600_000;
+
 function buildRemoteServer(d: McpHttpDescriptor): OpencodeRemoteServer {
 	const headers: Record<string, string> = { ...(d.headers ?? {}) };
 	if (d.bearerToken) headers.Authorization = `Bearer ${d.bearerToken}`;
-	const server: OpencodeRemoteServer = { type: 'remote', url: d.url, enabled: true };
+	const server: OpencodeRemoteServer = {
+		type: 'remote',
+		url: d.url,
+		enabled: true,
+		timeout: MCP_REQUEST_TIMEOUT_MS,
+	};
 	if (Object.keys(headers).length > 0) server.headers = headers;
 	return server;
 }
@@ -60,6 +75,7 @@ function buildLocalServer(d: McpStdioDescriptor): OpencodeLocalServer {
 		type: 'local',
 		command: [d.command, ...(d.args ?? [])],
 		enabled: true,
+		timeout: MCP_REQUEST_TIMEOUT_MS,
 	};
 	if (d.env && Object.keys(d.env).length > 0) server.environment = d.env;
 	return server;

--- a/packages/server/test/agent-runner.test.ts
+++ b/packages/server/test/agent-runner.test.ts
@@ -16,6 +16,7 @@ import {
 	acquireCredentialLock,
 	buildProviderEnv,
 	buildSubscriptionMount,
+	detectTerminatedBackgroundWork,
 	getHostPromptPath,
 	getHostSubscriptionRoot,
 	type RunnerDeps,
@@ -522,6 +523,84 @@ describe('runAgent', () => {
 		expect(run.rows[0].reported_no_work).toBe(true);
 		expect(run.rows[0].no_work_reason).toBe('planning ticket — sub-tasks still open');
 		expect(run.rows[0].error).toBeNull();
+	});
+
+	it('fails a clean exit where the CLI terminated still-running background work', async () => {
+		// producesOutput defaults true: the run wrote something earlier (e.g. a
+		// progress update), so absent the backstop it would count as a success. But
+		// the CLI printed its background-termination diagnostic to stderr, meaning it
+		// killed unfinished work (a run_in_background job / Workflow fan-out) — the
+		// run's real deliverable never landed, so it must be failed, not succeeded.
+		const deps: RunnerDeps = {
+			db,
+			docker: createMockDocker({
+				execStart: async () => ({
+					stdout: 'done',
+					stderr:
+						'Background tasks still running after 600s; terminating. Set CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0 to wait indefinitely.',
+				}),
+				execInspect: async () => ({ ExitCode: 0, Running: false, Pid: 0 }),
+			}),
+			masterKeyManager,
+			serverPort: 3000,
+			dataDir: '/tmp/test-data',
+			logs: new LogStreamBroker(),
+		};
+
+		const result = await runAgent(deps, makeAgent(), makeTask(), makeProject());
+
+		expect(result.success).toBe(false);
+		expect(result.exitCode).toBe(0);
+
+		const run = await db.query<{
+			status: string;
+			produced_output: boolean;
+			error: string | null;
+		}>('SELECT status, produced_output, error FROM heartbeat_runs WHERE id = $1', [
+			result.heartbeatRunId,
+		]);
+		expect(run.rows[0].status).toBe(HeartbeatRunStatus.Failed);
+		// It DID write earlier — abandoned background work overrides that.
+		expect(run.rows[0].produced_output).toBe(true);
+		expect(run.rows[0].error).toContain('background tasks still running');
+	});
+
+	it('does not fail when the agent merely echoes the termination phrase in its message', async () => {
+		// The phrase rides inside a stream-json assistant event (a JSON line on
+		// stdout), not as a CLI diagnostic — the backstop must ignore it so a run
+		// discussing this very behaviour isn't falsely failed.
+		const echoed = JSON.stringify({
+			type: 'assistant',
+			message: {
+				role: 'assistant',
+				content: [
+					{
+						type: 'text',
+						text: 'Claude Code prints "Background tasks still running after 600s; terminating." when it kills them.',
+					},
+				],
+			},
+		});
+		const deps: RunnerDeps = {
+			db,
+			docker: createMockDocker({
+				execStart: async () => ({ stdout: `${echoed}\n`, stderr: '' }),
+				execInspect: async () => ({ ExitCode: 0, Running: false, Pid: 0 }),
+			}),
+			masterKeyManager,
+			serverPort: 3000,
+			dataDir: '/tmp/test-data',
+			logs: new LogStreamBroker(),
+		};
+
+		const result = await runAgent(deps, makeAgent(), makeTask(), makeProject());
+
+		expect(result.success).toBe(true);
+		const run = await db.query<{ status: string }>(
+			'SELECT status FROM heartbeat_runs WHERE id = $1',
+			[result.heartbeatRunId],
+		);
+		expect(run.rows[0].status).toBe(HeartbeatRunStatus.Succeeded);
 	});
 
 	it('records failure in heartbeat run on non-zero exit code', async () => {
@@ -2539,5 +2618,41 @@ describe('shellQuoteArg', () => {
 		expect(shellQuoteArg('$FOO')).toBe(`'$FOO'`);
 		expect(shellQuoteArg('a"b')).toBe(`'a"b'`);
 		expect(shellQuoteArg('a|b')).toBe(`'a|b'`);
+	});
+});
+
+describe('detectTerminatedBackgroundWork', () => {
+	it('matches the CLI diagnostic on stderr', () => {
+		expect(
+			detectTerminatedBackgroundWork(
+				'done',
+				'Background tasks still running after 600s; terminating. Set CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0 to wait indefinitely.',
+			),
+		).toBe(true);
+	});
+
+	it('matches a bare non-JSON diagnostic line on stdout', () => {
+		expect(
+			detectTerminatedBackgroundWork(
+				'{"type":"result","subtype":"success"}\nBackground tasks still running after 30s; terminating.\n',
+				'',
+			),
+		).toBe(true);
+	});
+
+	it('ignores the phrase when it rides inside a stream-json stdout event', () => {
+		const line = JSON.stringify({
+			type: 'assistant',
+			message: {
+				content: [
+					{ type: 'text', text: 'Background tasks still running after 600s; terminating.' },
+				],
+			},
+		});
+		expect(detectTerminatedBackgroundWork(`${line}\n`, '')).toBe(false);
+	});
+
+	it('returns false for ordinary output', () => {
+		expect(detectTerminatedBackgroundWork('all done\n', '')).toBe(false);
 	});
 });

--- a/packages/server/test/mcp-injectors.test.ts
+++ b/packages/server/test/mcp-injectors.test.ts
@@ -219,6 +219,24 @@ describe('codex adapter', () => {
 		expect(config.contents.indexOf('web_search')).toBeLessThan(config.contents.indexOf('['));
 	});
 
+	it('raises the background-terminal ceiling (top-level) and per-MCP-server timeouts', () => {
+		const injection = adapter.build([HEZO_DESCRIPTOR], {
+			hostHomeDir: HOME,
+			containerHomeDir: HOME,
+		});
+		const config = injection.files.find((f) => f.hostPath === `${HOME}/config.toml`);
+		if (!config) throw new Error('config.toml not emitted');
+		// The direct analog of CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS (default 300000).
+		expect(config.contents).toContain('background_terminal_max_timeout = 3600000');
+		// Must stay a top-level key: before the first [table] header.
+		expect(config.contents.indexOf('background_terminal_max_timeout')).toBeLessThan(
+			config.contents.indexOf('['),
+		);
+		// Per-server tool + startup ceilings (defaults 300s / 30s).
+		expect(config.contents).toContain('tool_timeout_sec = 1800');
+		expect(config.contents).toContain('startup_timeout_sec = 120');
+	});
+
 	it('throws when no host home dir is provided', () => {
 		expect(() =>
 			adapter.build([HEZO_DESCRIPTOR], { hostHomeDir: null, containerHomeDir: null }),
@@ -317,6 +335,22 @@ describe('gemini adapter', () => {
 		expect(parsed.hooks.AfterAgent.length).toBe(1);
 		expect(parsed.hooks.AfterAgent[0].hooks[0].type).toBe('command');
 		expect(parsed.hooks.AfterAgent[0].hooks[0].command).toBe(`node ${HOME}/stop-hook-judge.mjs`);
+	});
+
+	it('disables the 5-min shell inactivity kill and sets a generous per-MCP timeout', () => {
+		const injection = adapter.build([HEZO_DESCRIPTOR], {
+			hostHomeDir: HOME,
+			containerHomeDir: HOME,
+		});
+		const settings = injection.files.find((f) => f.hostPath === `${HOME}/.gemini/settings.json`);
+		if (!settings) throw new Error('settings.json not emitted');
+		const parsed = JSON.parse(settings.contents) as {
+			tools: { shell: { inactivityTimeout: number } };
+			mcpServers: Record<string, { timeout: number }>;
+		};
+		// 0 disables the kill of a long, silent `run_shell_command` (default 300s).
+		expect(parsed.tools.shell.inactivityTimeout).toBe(0);
+		expect(parsed.mcpServers.hezo.timeout).toBe(600_000);
 	});
 
 	it('throws when no host home dir is provided', () => {
@@ -477,6 +511,19 @@ describe('opencode adapter', () => {
 		expect(config.mcp.hezo.headers?.Authorization).toBe(`Bearer ${TOKEN}`);
 	});
 
+	it('raises the per-MCP-server request timeout well above the 5s default', () => {
+		const injection = adapter.build([HEZO_DESCRIPTOR], {
+			hostHomeDir: HOME,
+			containerHomeDir: HOME,
+		});
+		const config = JSON.parse(injection.files[0].contents) as {
+			mcp: Record<string, { timeout: number }>;
+		};
+		// OpenCode's `mcp.<name>.timeout` defaults to 5000ms — any tool call slower
+		// than 5s fails. We stamp a generous 10-minute ceiling instead.
+		expect(config.mcp.hezo.timeout).toBe(600_000);
+	});
+
 	it('emits NO Stop-hook judge script (OpenCode has no in-process block-and-continue hook)', () => {
 		const injection = adapter.build([HEZO_DESCRIPTOR], {
 			hostHomeDir: HOME,
@@ -511,6 +558,7 @@ describe('opencode adapter', () => {
 			type: 'local',
 			command: ['/usr/bin/srv', '--port', '7'],
 			enabled: true,
+			timeout: 600_000,
 			environment: { TOKEN: 'x' },
 		});
 	});
@@ -562,6 +610,11 @@ describe('grok adapter', () => {
 		expect(file.contents).toContain('[mcp_servers.hezo.headers]');
 		expect(file.contents).toContain(`Authorization = "Bearer ${TOKEN}"`);
 		expect(file.contents).toContain('[cli]\nauto_update = false');
+		// Slow-starting MCP servers get more than the 30s default startup handshake,
+		// and long foreground shell commands more than the 120s default before Grok
+		// auto-backgrounds them.
+		expect(file.contents).toContain('startup_timeout_sec = 120');
+		expect(file.contents).toContain('[toolset.bash]\ntimeout_secs = 3600');
 	});
 
 	it('emits NO Stop-hook judge script (Grok Stop hooks are passive — fail-open like OpenCode)', () => {


### PR DESCRIPTION
## Problem

A reported agent run ended in `succeeded` when it should have errored. The run launched a `deep-research` Workflow in the background; Claude Code's headless `--print` mode hit its background-wait ceiling and **terminated the still-running fan-out** (`Background tasks still running after 600s; terminating`), then exited 0 with a non-error `result`. Because the agent had already written a progress update earlier (`produced_output = true`), the success gate counted it as a success — even though its actual deliverable (the synthesized report) was killed mid-flight.

Follow-up: audit the **other** coding CLIs we run for similar default timeouts that would cut off legitimately long agent/background work.

## Changes

### 1. Fail runs that abandon still-running background work (`agent-runner.ts`)

New runner-side backstop `detectTerminatedBackgroundWork()` scans the CLI's **own** diagnostic output — stderr plus non-JSON stdout lines only, so an agent that merely *echoes* the phrase in its message can't trip it — and, on a match, demotes the run to `failed` regardless of earlier output. This backstops `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0` for CLI versions that ignore the override.

### 2. Relax premature CLI timeouts on the other runtimes (MCP injectors)

No runtime other than Claude Code exposes an env-var analog to `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS`, so each is relaxed at its own config-file surface (the per-run config the injectors already write). Highest-impact find: **OpenCode's per-MCP-server timeout defaulted to 5 seconds**, so any Hezo tool call over 5s was failing outright.

| Runtime | Knob (where) | Was → now |
|---|---|---|
| OpenCode | `mcp.<name>.timeout` (`opencode.json`) | **5 s → 10 min** |
| Gemini | `tools.shell.inactivityTimeout` (`settings.json`) | 5-min silent-shell kill → **0 (disabled)** |
| Gemini | `mcpServers.<name>.timeout` | set explicit 10 min |
| Codex | `background_terminal_max_timeout` (`config.toml`, the direct analog) | 5 min → **1 h** |
| Codex | `[mcp_servers.*].tool_timeout_sec` / `startup_timeout_sec` | 300 s / 30 s → **1800 s / 120 s** |
| Grok | `[toolset.bash].timeout_secs` + `[mcp_servers.*].startup_timeout_sec` | 120 s / 30 s → **3600 s / 120 s** |

Deliberately left at default, both verified from source:
- **Codex `stream_idle_timeout_ms`** can't be tuned on the built-in `openai` provider (partial provider blocks and `-c` overrides are silently ignored by Codex's vacant-only merge) and only drives a reconnect/retry, not a kill.
- **OpenCode's bash tool** has a non-configurable 10-min hard cap.

## Tests

- 4 unit + 2 integration tests for `detectTerminatedBackgroundWork` / the run-status demotion (`agent-runner.test.ts`), including a negative case proving an echoed phrase in a stream-json event doesn't trip it.
- New assertions per adapter in `mcp-injectors.test.ts` for every timeout knob above.
- Full server suite green (390 files, 5148 tests).

## Docs

`.dev/architecture.md` updated: the success-gate backstop (§5) and a new "Runtime timeout hardening" note (§6) covering every runtime's knob and the two deliberate non-changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012aGB8DNzb1Rd7fcgb4wVdw

---
_Generated by [Claude Code](https://claude.ai/code/session_012aGB8DNzb1Rd7fcgb4wVdw)_