### PR TITLE
fix(web): show mobile review dialogs above the preview panel; tidy inbox mark-all button

### DIFF
--- a/packages/web/src/components/inbox-view.tsx
+++ b/packages/web/src/components/inbox-view.tsx
@@ -146,22 +146,24 @@ export function InboxView({ projectSlugs, scope }: InboxViewProps) {
 			</div>
 
 			<div className="flex flex-col gap-2 mb-4 sm:flex-row sm:items-center sm:justify-between">
-				<div className="flex items-center justify-between gap-2 sm:justify-start">
+				<div className="flex flex-col items-start gap-2 sm:flex-row sm:items-center">
 					<FilterPills
 						options={READ_OPTIONS}
 						value={readFilter}
 						onChange={setReadFilter}
 						className=""
 					/>
-					<button
-						type="button"
-						onClick={handleMarkAllRead}
-						disabled={unreadMentionSlugs.length === 0 || markAllRead.isPending}
-						className="inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-md px-2.5 py-1 text-[12px] text-text-3 transition-colors hover:bg-surface-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-text-3"
-					>
-						<CheckCheck className="w-3.5 h-3.5" />
-						Mark all as read
-					</button>
+					{readFilter === 'unread' && (
+						<button
+							type="button"
+							onClick={handleMarkAllRead}
+							disabled={unreadMentionSlugs.length === 0 || markAllRead.isPending}
+							className="inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-md px-2.5 py-1 text-[12px] text-text-3 transition-colors hover:bg-surface-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-text-3"
+						>
+							<CheckCheck className="w-3.5 h-3.5" />
+							Mark all as read
+						</button>
+					)}
 				</div>
 				<div className="relative sm:w-64">
 					<Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-text-3" />

--- a/packages/web/src/components/ui/dialog.tsx
+++ b/packages/web/src/components/ui/dialog.tsx
@@ -2,8 +2,13 @@ import * as Dialog from '@radix-ui/react-dialog';
 import { X } from 'lucide-react';
 import type { ComponentPropsWithoutRef, ReactNode } from 'react';
 
+// z-[90]/overlay z-[80] keep dialogs above the full-screen mobile surfaces that
+// can host their triggers — the task-detail preview panel (z-[60]) and the review
+// editor bottom sheet (z-[70]). At the lower z-50 the opaque preview panel painted
+// over dialogs opened from its toolbar, so on mobile the dialog scroll-locked the
+// page but was never visible. (In-dialog tooltips ride above at z-[95].)
 const base =
-	'fixed inset-0 z-50 flex flex-col bg-surface p-4 overflow-y-auto outline-none sm:inset-auto sm:top-1/2 sm:left-1/2 sm:-translate-x-1/2 sm:-translate-y-1/2 sm:w-full sm:max-h-[90vh] sm:rounded-lg sm:border sm:border-border sm:p-6 sm:shadow-lg';
+	'fixed inset-0 z-[90] flex flex-col bg-surface p-4 overflow-y-auto outline-none sm:inset-auto sm:top-1/2 sm:left-1/2 sm:-translate-x-1/2 sm:-translate-y-1/2 sm:w-full sm:max-h-[90vh] sm:rounded-lg sm:border sm:border-border sm:p-6 sm:shadow-lg';
 
 export const dialogContentClassName = {
 	sm: `${base} sm:max-w-sm`,
@@ -21,9 +26,9 @@ export type DialogSize = keyof typeof dialogContentClassName;
  * field grow to fill the space (e.g. the create-task description).
  */
 export const fullscreenContentClassName =
-	'fixed inset-0 z-50 flex flex-col bg-surface p-4 overflow-hidden outline-none sm:inset-4 sm:rounded-lg sm:border sm:border-border sm:p-6 sm:shadow-lg';
+	'fixed inset-0 z-[90] flex flex-col bg-surface p-4 overflow-hidden outline-none sm:inset-4 sm:rounded-lg sm:border sm:border-border sm:p-6 sm:shadow-lg';
 
-export const dialogOverlayClassName = 'fixed inset-0 bg-[var(--overlay)] backdrop-blur-sm z-40';
+export const dialogOverlayClassName = 'fixed inset-0 bg-[var(--overlay)] backdrop-blur-sm z-[80]';
 
 type DialogContentBaseProps = ComponentPropsWithoutRef<typeof Dialog.Content>;
 

--- a/packages/web/src/components/ui/tooltip.tsx
+++ b/packages/web/src/components/ui/tooltip.tsx
@@ -34,7 +34,7 @@ export function Tooltip({
 					<TooltipPrimitive.Content
 						side={side}
 						sideOffset={6}
-						className={`z-50 max-w-xs rounded-md border border-border bg-surface px-2.5 py-1.5 text-[11px] leading-snug text-text-1 shadow-md data-[state=delayed-open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=delayed-open]:fade-in-0 ${contentClassName ?? ''}`}
+						className={`z-[95] max-w-xs rounded-md border border-border bg-surface px-2.5 py-1.5 text-[11px] leading-snug text-text-1 shadow-md data-[state=delayed-open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=delayed-open]:fade-in-0 ${contentClassName ?? ''}`}
 					>
 						{content}
 						<TooltipPrimitive.Arrow className="fill-surface" />

--- a/packages/web/test/inbox-mentions.test.tsx
+++ b/packages/web/test/inbox-mentions.test.tsx
@@ -393,6 +393,38 @@ test('mark all as read is disabled when there are no unread mentions', async () 
 	expect((button as HTMLButtonElement).disabled).toBe(true);
 });
 
+test('mark all as read only shows on the Unread tab', async () => {
+	let ctx: { projectSlug: string };
+	const { findByText, queryByText, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Demo' });
+			const task = await seedTask(ws, project, { title: 'Unread ticket' });
+			await seedAgentAdminMention(ws, task, '@admin fresh decision needed.');
+			ctx = { projectSlug: project.slug };
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/inbox',
+		params: { projectId: ctx!.projectSlug },
+	});
+
+	// Defaults to the Unread tab — the button is present.
+	await findByText('Mark all as read');
+
+	// It disappears on every other tab.
+	for (const tab of ['Read', 'All', 'Archived']) {
+		await user.click(await findByText(tab));
+		await waitFor(() => expect(queryByText('Mark all as read')).toBeNull());
+	}
+
+	// …and returns on Unread.
+	await user.click(await findByText('Unread'));
+	await findByText('Mark all as read');
+});
+
 test('header inbox icon shows the global unread count badge', async () => {
 	const { findByTestId } = await renderApp({
 		initialPath: '/home',

--- a/test/browser/task-detail.mobile.spec.ts
+++ b/test/browser/task-detail.mobile.spec.ts
@@ -109,6 +109,17 @@ test.describe('Task detail — document preview panel (mobile, 390px)', () => {
 		});
 		if (!docRes.ok()) throw new Error(`seed prd.md failed: ${docRes.status()}`);
 
+		// A review comment on the doc enables the "Action this review" / "Clear"
+		// toolbar buttons (they're disabled at count 0).
+		const reviewRes = await page.request.post(
+			`/api/projects/${project.slug}/docs/prd.md/review-comments`,
+			{
+				headers,
+				data: { quote: 'unmistakable document body', occurrence: 0, comment: 'Tighten this.' },
+			},
+		);
+		if (!reviewRes.ok()) throw new Error(`seed review comment failed: ${reviewRes.status()}`);
+
 		const commentRes = await page.request.post(
 			`/api/projects/${project.slug}/tasks/${task.id}/comments`,
 			{
@@ -162,6 +173,70 @@ test.describe('Task detail — document preview panel (mobile, 390px)', () => {
 		// The meta drawer is still collapsed off-screen and the toggle untouched.
 		expect((await rail.boundingBox())?.x ?? 0).toBeGreaterThanOrEqual(360);
 		await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+	});
+
+	test('review-toolbar dialogs open ABOVE the full-screen preview panel', async ({
+		page,
+		freshWorkspace,
+	}) => {
+		// Regression: below lg the preview panel is `fixed inset-0 z-[60]` and opaque,
+		// while the shared Dialog used to sit at z-50. Dialogs opened from the panel's
+		// review toolbar (help "?", "Action this review") scroll-locked the page but
+		// were painted over by the panel — present in the DOM, invisible on screen.
+		// This is a real-CSS-stacking assertion happy-dom can't make (#1 in the tier
+		// decision tree), so it lives in Playwright. It fails on z-50 and holds on the
+		// raised z-[80]/z-[90] dialog layer.
+		const { token } = freshWorkspace;
+		const { project, task } = await createProjectTaskWithDocMention(page, token);
+
+		await page.goto(`/projects/${project.slug}/tasks/${task.identifier.toLowerCase()}`);
+		await waitForPageLoad(page);
+		await expect(page.getByRole('heading', { name: 'Mobile Task' })).toBeVisible({
+			timeout: 20000,
+		});
+
+		const mention = page.getByTestId('doc-mention-link').first();
+		await expect(mention).toBeVisible({ timeout: 15000 });
+		await mention.click();
+		await expect(page.getByTestId('preview-panel')).toBeInViewport();
+
+		// Assert the element painted at a dialog's centre actually belongs to that
+		// dialog — the direct test of "not occluded by the z-[60] panel". A visible
+		// check alone wouldn't catch occlusion (the dialog is technically visible,
+		// just covered).
+		async function expectDialogOnTop(locator: ReturnType<Page['locator']>) {
+			await expect(locator).toBeVisible();
+			const box = await locator.boundingBox();
+			expect(box).not.toBeNull();
+			if (!box) return;
+			const cx = Math.round(box.x + box.width / 2);
+			const cy = Math.round(box.y + box.height / 2);
+			const dialogId = await locator.evaluate((el) => {
+				el.setAttribute('data-occlusion-probe', '1');
+				return true;
+			});
+			expect(dialogId).toBe(true);
+			const topmostIsInsideDialog = await page.evaluate(
+				({ x, y }) => {
+					const el = document.elementFromPoint(x, y);
+					return !!el?.closest('[data-occlusion-probe="1"]');
+				},
+				{ x: cx, y: cy },
+			);
+			expect(topmostIsInsideDialog).toBe(true);
+			await locator.evaluate((el) => el.removeAttribute('data-occlusion-probe'));
+		}
+
+		// 1) The help "?" dialog.
+		await page.getByTestId('review-help').click();
+		const helpDialog = page.getByRole('dialog').filter({ hasText: 'How document review works' });
+		await expectDialogOnTop(helpDialog);
+		await page.getByTestId('dialog-close').click();
+		await expect(helpDialog).toHaveCount(0);
+
+		// 2) The "Action this review" finalisation dialog.
+		await page.getByTestId('review-action-open').click();
+		await expectDialogOnTop(page.getByTestId('action-review-dialog'));
 	});
 });
 


### PR DESCRIPTION
## Summary

Two mobile UI fixes reported from the document viewer and the global inbox.

### 1. Review-toolbar dialogs were invisible on mobile

On the task-detail **document preview panel**, tapping a review-toolbar button (the help "?", the "Action this review" finalisation modal, or the "Clear review" confirm) scroll-locked the page but showed no dialog on screen.

**Cause:** below `lg` the preview panel is a full-screen, opaque `fixed inset-0 z-[60]` overlay, while the shared `Dialog` sat at `z-50` (overlay `z-40`). A dialog opened from the panel's own toolbar portals to `document.body` at `z-50` — *below* the `z-60` panel — so the opaque panel painted over it. It only reproduced on mobile; at `lg+` the panel is `z-auto`/static.

**Fix:** raise the shared dialog layer above the full-screen mobile surfaces it can be triggered from (the preview panel `z-[60]` and the review-editor bottom sheet `z-[70]`):
- dialog overlay `z-40 → z-[80]`, content `z-50 → z-[90]` (`dialog.tsx`, which also covers `ConfirmDialog` since it reuses these classes)
- tooltip content `z-50 → z-[95]` so the two in-dialog `InfoTooltip`s (expanded comment composer, create-project dialog) still render above dialog content

Audited that no `SearchableSelect`/`MultiSelect`/`MentionPicker` is portaled inside a dialog, and that none of the three review-toolbar dialogs nest an at-risk portaled component — so the raised stack has no other regressions.

### 2. Global inbox "Mark all as read" button

On mobile the button was crammed against the tabs (pushed to the far edge via `justify-between`). Now it:
- stacks **below** the tabs on mobile (stays inline on `sm+`), with the search bar beneath it
- **only renders on the Unread tab** (it acts on unread mentions only)

## Testing

- New mobile Playwright test (`task-detail.mobile.spec.ts`): opens the preview panel at 390px, opens both the help and "Action this review" dialogs, and asserts via `elementFromPoint` at each dialog's centre that the topmost element belongs to the dialog (not the panel). Verified it **fails** on the old `z-50` and **passes** on the fix.
- New component test (`inbox-mentions.test.tsx`): the "Mark all as read" button shows on Unread and disappears on Read/All/Archived.
- Existing inbox + action-review component tests still green; `typecheck` and the full `task-detail.mobile` browser suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARhKxTMzJerBWYx4TvTc1M)_