### PR TITLE
feat(projects): add archive/unarchive

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -98,7 +98,13 @@ team** (`projects.team_id → teams.id`, `UNIQUE` — the 1:1 invariant in § 4)
 is a first-class catalog of role templates (built-in + custom); `team_templates` +
 `team_template_agent_types` define team "recipes" (which roles, the org chart via
 `reports_to_slug`, per-template config overrides). `projects` carries `task_prefix`,
-container config, dev ports, the designated repo, and `is_internal` (only HQ).
+container config, dev ports, the designated repo, `is_internal` (only HQ), and a nullable
+`archived_at` soft-delete stamp (NULL = active). Archiving a project (superuser-only
+`POST /projects/:id/archive`, from the settings page) sets `archived_at`, stops the
+container, and cancels in-flight runs; the `GET /projects` index filters to active by
+default (`?filter=active|archived|all`, mirroring the docs/assets soft-delete), so an
+archived project drops out of the left rail while keeping its tasks/history. Unarchiving
+(`POST /projects/:id/unarchive`) clears the stamp and restores rail visibility.
 
 **Repos.** `repos` stores a GitHub `owner/repo` identifier; the segment after the owner
 is the display label, worktree directory name, and `@mention` handle. The **first** repo

--- a/docs/concepts/projects-and-teams.md
+++ b/docs/concepts/projects-and-teams.md
@@ -23,6 +23,22 @@ appears as the project's thumbnail in the rail. Pick any common image (PNG, JPEG
 GIF, or SVG); Hezo crops it to a square and resizes it to 512×512. Use **Replace image**
 to swap it or **Remove** to go back to the initials.
 
+## Archiving a project
+
+When a project is finished or dormant, you can **archive** it to get it out of the way
+without losing anything. Open the project's **Settings**, scroll to the **Danger zone** at
+the bottom, and choose **Archive this project**. After you confirm:
+
+- The project disappears from the project rail on the left.
+- Its container is stopped, and any in-progress agent runs are cancelled.
+- Its tasks, documents, and history are all kept — archiving is reversible, not a delete.
+
+To bring a project back, open the global **Settings → Archived projects**, find it in the
+list, and choose **Unarchive**. It returns to the rail immediately; its container stays
+stopped until you start it again, just like any other stopped project.
+
+Archiving and unarchiving are admin (superuser) actions.
+
 ## Team templates
 
 When you create a project you choose a **template**, which decides the starting roster.

--- a/packages/server/migrations/026_archive_projects.sql
+++ b/packages/server/migrations/026_archive_projects.sql
@@ -1,0 +1,13 @@
+-- Archival (soft delete) for projects: a superuser retires a project from the
+-- project settings page. An archived project is hidden from the default project
+-- index (the left rail) but keeps its row, slug, team, tasks, and history intact
+-- so it can be unarchived later from global settings. Archiving also stops the
+-- project's container; unarchiving restores visibility only (the container stays
+-- stopped, like any other stopped project).
+--
+-- Purely additive: existing rows backfill to NULL (= active), so nothing changes
+-- for current data. `archived_at` NULL = active, non-null = archived. The partial
+-- index mirrors `idx_goals_active` — the default index for the active-only list.
+ALTER TABLE projects ADD COLUMN archived_at TIMESTAMPTZ;
+
+CREATE INDEX idx_projects_active ON projects(created_at) WHERE archived_at IS NULL;

--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -1,7 +1,9 @@
 import {
+	ArchiveFilter,
 	AuthType,
 	ContainerStatus,
 	isAllowedProjectIconStoredMime,
+	isArchiveFilter,
 	MemberType,
 	PROJECT_ICON_MAX_BYTES,
 	PROJECT_ICON_MAX_DIMENSION,
@@ -21,7 +23,7 @@ import { toSlug, uniqueSlug } from '../lib/slug';
 import { terminalStatusParams } from '../lib/sql';
 import type { Env } from '../lib/types';
 import { logger } from '../logger';
-import { requireAdminEquivalent } from '../middleware/auth';
+import { requireAdminEquivalent, requireSuperuser } from '../middleware/auth';
 import {
 	type ContainerDeps,
 	type ProjectRow,
@@ -102,6 +104,19 @@ projectsRoutes.get('/projects', async (c) => {
 	const isSuperuser = auth.type === AuthType.Admin && auth.isSuperuser;
 	const isAdmin = auth.type === AuthType.Admin;
 
+	// Archive filter (default: active only — the rail hides archived projects).
+	// `archived` backs the global-settings "Archived projects" page; `all` is
+	// an escape hatch. The condition carries no params (literal IS [NOT] NULL),
+	// so it can be spliced in without disturbing the positional param indices.
+	const filterParam = c.req.query('filter');
+	const filter: ArchiveFilter = isArchiveFilter(filterParam) ? filterParam : ArchiveFilter.Active;
+	const archivedCond =
+		filter === ArchiveFilter.Active
+			? 'p.archived_at IS NULL'
+			: filter === ArchiveFilter.Archived
+				? 'p.archived_at IS NOT NULL'
+				: null;
+
 	const ts = terminalStatusParams(1);
 	const agentTypeIdx = ts.values.length + 1;
 	const params: unknown[] = [...ts.values, MemberType.Agent];
@@ -124,12 +139,14 @@ projectsRoutes.get('/projects', async (c) => {
 
 	let query: string;
 	if (!isAdmin || isSuperuser) {
-		query = `${base} ORDER BY p.created_at DESC`;
+		const where = archivedCond ? ` WHERE ${archivedCond}` : '';
+		query = `${base}${where} ORDER BY p.created_at DESC`;
 	} else {
+		const and = archivedCond ? ` AND ${archivedCond}` : '';
 		query = `${base}
      JOIN members m2 ON m2.team_id = p.team_id
      JOIN member_users mu ON mu.id = m2.id
-     WHERE mu.user_id = $${params.length + 1}
+     WHERE mu.user_id = $${params.length + 1}${and}
      ORDER BY p.created_at DESC`;
 		params.push(auth.userId);
 	}
@@ -436,6 +453,97 @@ projectsRoutes.patch('/projects/:projectId', async (c) => {
 		`UPDATE projects SET ${sets.join(', ')} WHERE id = $${idx} RETURNING *`,
 		params,
 	);
+
+	broadcastChange(
+		c,
+		wsRoom.team(teamId),
+		'projects',
+		'UPDATE',
+		result.rows[0] as Record<string, unknown>,
+	);
+	return ok(c, result.rows[0]);
+});
+
+// --- Archive / unarchive ------------------------------------------------------
+// Soft-delete a project: it drops out of the default project index (the rail),
+// keeping its row/tasks/history so it can be restored. Superuser-only, matching
+// the global-settings "Archived projects" page that unarchives. Archiving also
+// stops the container (a retired project is dormant); unarchiving restores
+// visibility only — the container stays stopped, like any stopped project.
+projectsRoutes.post('/projects/:projectId/archive', async (c) => {
+	const denied = requireSuperuser(c);
+	if (denied) return denied;
+
+	const teamId = c.get('teamId') as string;
+	const db = c.get('db');
+	const projectId = c.get('projectId') as string;
+	if (!projectId) return err(c, 'NOT_FOUND', 'Project not found', 404);
+
+	const existing = await db.query<{
+		slug: string;
+		is_internal: boolean;
+		container_id: string | null;
+	}>('SELECT slug, is_internal, container_id FROM projects WHERE id = $1 AND team_id = $2', [
+		projectId,
+		teamId,
+	]);
+	if (existing.rows.length === 0) return err(c, 'NOT_FOUND', 'Project not found', 404);
+	if (existing.rows[0].is_internal) {
+		return err(c, 'FORBIDDEN', 'Cannot archive an internal project', 403);
+	}
+
+	const { slug: projectSlug, container_id: containerId } = existing.rows[0];
+
+	// Cancel in-flight agent runs before stopping the container (mirrors
+	// POST /projects/:projectId/container/stop). No container yet → just mark it
+	// stopped so the archived project reads as dormant.
+	if (containerId) {
+		await cancelRunningAgentTasks(db, c.get('jobManager'), projectId, teamId);
+	}
+
+	const result = await db.query(
+		`UPDATE projects
+		 SET archived_at = now(), container_status = $1::container_status
+		 WHERE id = $2 RETURNING *`,
+		[containerId ? ContainerStatus.Stopping : ContainerStatus.Stopped, projectId],
+	);
+
+	if (containerId) {
+		const containerDeps = buildContainerDeps(c);
+		c.get('jobManager').launchTask(
+			`stop:${projectId}`,
+			async () => {
+				await stopContainerGracefully(containerDeps, projectId, projectSlug, teamId, containerId);
+			},
+			60_000,
+		);
+	}
+
+	broadcastChange(
+		c,
+		wsRoom.team(teamId),
+		'projects',
+		'UPDATE',
+		result.rows[0] as Record<string, unknown>,
+	);
+	log.info(`project ${ref(projectSlug, projectId)} archived`);
+	return ok(c, result.rows[0]);
+});
+
+projectsRoutes.post('/projects/:projectId/unarchive', async (c) => {
+	const denied = requireSuperuser(c);
+	if (denied) return denied;
+
+	const teamId = c.get('teamId') as string;
+	const db = c.get('db');
+	const projectId = c.get('projectId') as string;
+	if (!projectId) return err(c, 'NOT_FOUND', 'Project not found', 404);
+
+	const result = await db.query(
+		`UPDATE projects SET archived_at = NULL WHERE id = $1 AND team_id = $2 RETURNING *`,
+		[projectId, teamId],
+	);
+	if (result.rows.length === 0) return err(c, 'NOT_FOUND', 'Project not found', 404);
 
 	broadcastChange(
 		c,

--- a/packages/server/test/migrate-026-archive-projects.test.ts
+++ b/packages/server/test/migrate-026-archive-projects.test.ts
@@ -1,0 +1,63 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createDataPreservationHarness, type DataPreservationHarness } from './helpers/migrate';
+
+const TARGET = '026_archive_projects.sql';
+
+describe('026_archive_projects migration', () => {
+	let h: DataPreservationHarness;
+	let projectId: string;
+
+	beforeAll(async () => {
+		h = await createDataPreservationHarness();
+		await h.applyUpToExclusive(TARGET); // schema before 026
+
+		const team = await h.db.query<{ id: string }>(
+			`INSERT INTO teams (name, slug) VALUES ('Acme', 'acme') RETURNING id`,
+		);
+		const teamId = team.rows[0].id;
+		const project = await h.db.query<{ id: string }>(
+			`INSERT INTO projects (team_id, name, slug, task_prefix)
+			 VALUES ($1, 'Demo', 'demo', 'DM') RETURNING id`,
+			[teamId],
+		);
+		projectId = project.rows[0].id;
+
+		await h.applyTarget(TARGET);
+	});
+	afterAll(() => h.close());
+
+	it('adds a nullable archived_at column to projects', async () => {
+		const cols = await h.db.query<{ column_name: string; is_nullable: string; data_type: string }>(
+			`SELECT column_name, is_nullable, data_type FROM information_schema.columns
+			 WHERE table_name = 'projects' AND column_name = 'archived_at'`,
+		);
+		expect(cols.rows.length).toBe(1);
+		expect(cols.rows[0].is_nullable).toBe('YES');
+		expect(cols.rows[0].data_type).toBe('timestamp with time zone');
+	});
+
+	it('preserves pre-existing projects as active (archived_at NULL)', async () => {
+		const project = await h.db.query<{ name: string; archived_at: string | null }>(
+			`SELECT name, archived_at FROM projects WHERE id = $1`,
+			[projectId],
+		);
+		expect(project.rows[0].name).toBe('Demo');
+		expect(project.rows[0].archived_at).toBeNull();
+	});
+
+	it('accepts archival stamps and clears them on unarchive', async () => {
+		await h.db.query(`UPDATE projects SET archived_at = now() WHERE id = $1`, [projectId]);
+		const archived = await h.db.query<{ archived_at: string | null }>(
+			`SELECT archived_at FROM projects WHERE id = $1`,
+			[projectId],
+		);
+		expect(archived.rows[0].archived_at).not.toBeNull();
+
+		await h.db.query(`UPDATE projects SET archived_at = NULL WHERE id = $1`, [projectId]);
+		const active = await h.db.query<{ archived_at: string | null }>(
+			`SELECT archived_at FROM projects WHERE id = $1`,
+			[projectId],
+		);
+		expect(active.rows[0].archived_at).toBeNull();
+	});
+});

--- a/packages/server/test/projects.test.ts
+++ b/packages/server/test/projects.test.ts
@@ -1,13 +1,16 @@
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { MasterKeyManager } from '../src/crypto/master-key';
 import type { Db } from '../src/db/database';
 import type { Env } from '../src/lib/types';
+import { signAdminJwt } from '../src/middleware/auth';
 import { safeClose } from './helpers';
 import { authHeader, createTestApp, createTestTeam } from './helpers/app';
 
 let app: Hono<Env>;
 let db: Db;
 let token: string;
+let masterKeyManager: MasterKeyManager;
 let projectSlug: string;
 let teamId: string;
 let teamSlug: string;
@@ -40,6 +43,7 @@ beforeAll(async () => {
 	app = ctx.app;
 	db = ctx.db;
 	token = ctx.token;
+	masterKeyManager = ctx.masterKeyManager;
 
 	const teamRes = await createTestTeam(db, { name: 'Project Test Co' });
 	const teamData = (await teamRes.json()).data;
@@ -386,5 +390,92 @@ describe('slug-based project access', () => {
 		});
 		expect(res.status).toBe(200);
 		expect((await res.json()).data.description).toBe('Slug-based update');
+	});
+});
+
+describe('project archive / unarchive', () => {
+	// A fresh project per assertion keeps this suite independent of the CRUD
+	// block's shared `backend-api` project.
+	async function newProjectSlug(name: string): Promise<string> {
+		const res = await createProject({ name, description: VALID_DESCRIPTION });
+		expect(res.status).toBe(201);
+		return (await res.json()).data.slug as string;
+	}
+
+	async function archive(slug: string, headers = authHeader(token)) {
+		return app.request(`/api/projects/${slug}/archive`, { method: 'POST', headers });
+	}
+	async function unarchive(slug: string, headers = authHeader(token)) {
+		return app.request(`/api/projects/${slug}/unarchive`, { method: 'POST', headers });
+	}
+	async function listSlugs(filter?: string): Promise<string[]> {
+		const url = filter ? `/api/projects?filter=${filter}` : '/api/projects';
+		const res = await app.request(url, { headers: authHeader(token) });
+		return ((await res.json()).data as Array<{ slug: string }>).map((p) => p.slug);
+	}
+
+	it('archives a project: stamps archived_at and hides it from the default index', async () => {
+		const slug = await newProjectSlug('Archive Me');
+
+		expect(await listSlugs()).toContain(slug);
+
+		const res = await archive(slug);
+		expect(res.status).toBe(200);
+		expect((await res.json()).data.archived_at).not.toBeNull();
+
+		// Default index (the rail) excludes it; ?filter=archived includes it.
+		expect(await listSlugs()).not.toContain(slug);
+		expect(await listSlugs('archived')).toContain(slug);
+		expect(await listSlugs('all')).toContain(slug);
+	});
+
+	it('unarchives a project: clears archived_at and restores it to the index', async () => {
+		const slug = await newProjectSlug('Restore Me');
+		await archive(slug);
+		expect(await listSlugs()).not.toContain(slug);
+
+		const res = await unarchive(slug);
+		expect(res.status).toBe(200);
+		expect((await res.json()).data.archived_at).toBeNull();
+		expect(await listSlugs()).toContain(slug);
+		expect(await listSlugs('archived')).not.toContain(slug);
+	});
+
+	it('refuses to archive an internal project (403)', async () => {
+		const internal = await db.query<{ slug: string }>(
+			'SELECT slug FROM projects WHERE is_internal = true LIMIT 1',
+		);
+		const res = await archive(internal.rows[0].slug);
+		expect(res.status).toBe(403);
+	});
+
+	it('rejects archive/unarchive from a non-superuser team member (403)', async () => {
+		const slug = await newProjectSlug('Guard Me');
+		const projectRow = await db.query<{ id: string; team_id: string }>(
+			'SELECT id, team_id FROM projects WHERE slug = $1',
+			[slug],
+		);
+		const projectTeamId = projectRow.rows[0].team_id;
+
+		// A non-superuser who IS a member of the project's team — so the request
+		// clears the team-access middleware and 403s specifically on requireSuperuser.
+		const userRes = await db.query<{ id: string }>(
+			"INSERT INTO users (display_name, is_superuser) VALUES ('Board User', false) RETURNING id",
+		);
+		const memberRes = await db.query<{ id: string }>(
+			`INSERT INTO members (team_id, display_name, member_type)
+			 VALUES ($1, 'Board User', 'user') RETURNING id`,
+			[projectTeamId],
+		);
+		await db.query('INSERT INTO member_users (id, user_id) VALUES ($1, $2)', [
+			memberRes.rows[0].id,
+			userRes.rows[0].id,
+		]);
+		const nonSuperToken = await signAdminJwt(masterKeyManager, userRes.rows[0].id);
+
+		expect((await archive(slug, authHeader(nonSuperToken))).status).toBe(403);
+		expect((await unarchive(slug, authHeader(nonSuperToken))).status).toBe(403);
+		// Still active — the rejected archive was a no-op.
+		expect(await listSlugs()).toContain(slug);
 	});
 });

--- a/packages/web/src/components/settings-sidebar.tsx
+++ b/packages/web/src/components/settings-sidebar.tsx
@@ -24,6 +24,7 @@ const ADMIN_ITEMS: NavItem[] = [
 	{ to: '/settings/connectors', label: 'Connectors' },
 	{ to: '/settings/credentials', label: 'Credentials' },
 	{ to: '/settings/api-keys', label: 'API keys' },
+	{ to: '/settings/archived-projects', label: 'Archived projects' },
 	{ to: '/settings/audit-log', label: 'Activity' },
 ];
 

--- a/packages/web/src/hooks/use-projects.ts
+++ b/packages/web/src/hooks/use-projects.ts
@@ -42,6 +42,9 @@ export interface Project {
 	/** Most recent task update, falling back to the project's creation time. */
 	last_activity_at: string;
 	created_at: string;
+	/** When the project was archived (soft-deleted), or null/absent when active.
+	 * Archived projects are excluded from the default index that backs the rail. */
+	archived_at?: string | null;
 	/** Signed URL for the project's icon image, or null when none is set. */
 	icon_url?: string | null;
 	/** When the icon was last set (drives the `<img>` cache version), or null. */
@@ -206,6 +209,37 @@ export function useDeleteProject() {
 		mutationFn: (projectId: string) => api.delete(`/api/projects/${projectId}`),
 		onSuccess: () =>
 			queryClient.invalidateQueries({ queryKey: queryKeys.projects.all(), exact: true }),
+	});
+}
+
+/** Archived projects (global settings "Archived projects" page). Superuser-only. */
+export function useArchivedProjects() {
+	return useQuery({
+		queryKey: queryKeys.projects.archived(),
+		queryFn: () => api.get<Project[]>('/api/projects?filter=archived'),
+		staleTime: 0,
+		refetchOnMount: 'always',
+	});
+}
+
+/**
+ * Archive a project: soft-hides it from the rail and stops its container.
+ * Invalidate-driven (not optimistic) — the server has side effects (container
+ * teardown) and the project leaves the rail. Refetches both the rail index and
+ * the archived list (invalidating the `['projects']` prefix covers both).
+ */
+export function useArchiveProject(projectId: string) {
+	return useMutation({
+		mutationFn: () => api.post(`/api/projects/${projectId}/archive`, {}),
+		onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.projects.all() }),
+	});
+}
+
+/** Unarchive a project: restores it to the rail. Container stays stopped. */
+export function useUnarchiveProject(projectId: string) {
+	return useMutation({
+		mutationFn: () => api.post(`/api/projects/${projectId}/unarchive`, {}),
+		onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.projects.all() }),
 	});
 }
 

--- a/packages/web/src/lib/query-keys.ts
+++ b/packages/web/src/lib/query-keys.ts
@@ -58,6 +58,10 @@ export const queryKeys = {
 	projects: {
 		all: () => ['projects'],
 		detail: (slug: string) => ['projects', slug],
+		// Archived-projects list (global settings). Length-3 key never collides
+		// with a detail (`['projects', slug]`) or tasks key, and stays under the
+		// `['projects']` prefix so `all()` invalidation refetches it too.
+		archived: () => ['projects', 'archived', 'list'],
 
 		// tasks
 		tasks: (slug: string) => ['projects', slug, 'tasks'],

--- a/packages/web/src/routeTree.gen.ts
+++ b/packages/web/src/routeTree.gen.ts
@@ -18,6 +18,7 @@ import { Route as SettingsCredentialsRouteImport } from './routes/settings/crede
 import { Route as SettingsConnectorsRouteImport } from './routes/settings/connectors'
 import { Route as SettingsChatboxRouteImport } from './routes/settings/chatbox'
 import { Route as SettingsAuditLogRouteImport } from './routes/settings/audit-log'
+import { Route as SettingsArchivedProjectsRouteImport } from './routes/settings/archived-projects'
 import { Route as SettingsApiKeysRouteImport } from './routes/settings/api-keys'
 import { Route as SettingsAiProvidersRouteImport } from './routes/settings/ai-providers'
 import { Route as SettingsAdminPasswordRouteImport } from './routes/settings/admin-password'
@@ -95,6 +96,12 @@ const SettingsAuditLogRoute = SettingsAuditLogRouteImport.update({
   path: '/audit-log',
   getParentRoute: () => SettingsRouteRoute,
 } as any)
+const SettingsArchivedProjectsRoute =
+  SettingsArchivedProjectsRouteImport.update({
+    id: '/archived-projects',
+    path: '/archived-projects',
+    getParentRoute: () => SettingsRouteRoute,
+  } as any)
 const SettingsApiKeysRoute = SettingsApiKeysRouteImport.update({
   id: '/api-keys',
   path: '/api-keys',
@@ -279,6 +286,7 @@ export interface FileRoutesByFullPath {
   '/settings/admin-password': typeof SettingsAdminPasswordRoute
   '/settings/ai-providers': typeof SettingsAiProvidersRoute
   '/settings/api-keys': typeof SettingsApiKeysRoute
+  '/settings/archived-projects': typeof SettingsArchivedProjectsRoute
   '/settings/audit-log': typeof SettingsAuditLogRoute
   '/settings/chatbox': typeof SettingsChatboxRoute
   '/settings/connectors': typeof SettingsConnectorsRoute
@@ -319,6 +327,7 @@ export interface FileRoutesByTo {
   '/settings/admin-password': typeof SettingsAdminPasswordRoute
   '/settings/ai-providers': typeof SettingsAiProvidersRoute
   '/settings/api-keys': typeof SettingsApiKeysRoute
+  '/settings/archived-projects': typeof SettingsArchivedProjectsRoute
   '/settings/audit-log': typeof SettingsAuditLogRoute
   '/settings/chatbox': typeof SettingsChatboxRoute
   '/settings/connectors': typeof SettingsConnectorsRoute
@@ -361,6 +370,7 @@ export interface FileRoutesById {
   '/settings/admin-password': typeof SettingsAdminPasswordRoute
   '/settings/ai-providers': typeof SettingsAiProvidersRoute
   '/settings/api-keys': typeof SettingsApiKeysRoute
+  '/settings/archived-projects': typeof SettingsArchivedProjectsRoute
   '/settings/audit-log': typeof SettingsAuditLogRoute
   '/settings/chatbox': typeof SettingsChatboxRoute
   '/settings/connectors': typeof SettingsConnectorsRoute
@@ -405,6 +415,7 @@ export interface FileRouteTypes {
     | '/settings/admin-password'
     | '/settings/ai-providers'
     | '/settings/api-keys'
+    | '/settings/archived-projects'
     | '/settings/audit-log'
     | '/settings/chatbox'
     | '/settings/connectors'
@@ -445,6 +456,7 @@ export interface FileRouteTypes {
     | '/settings/admin-password'
     | '/settings/ai-providers'
     | '/settings/api-keys'
+    | '/settings/archived-projects'
     | '/settings/audit-log'
     | '/settings/chatbox'
     | '/settings/connectors'
@@ -486,6 +498,7 @@ export interface FileRouteTypes {
     | '/settings/admin-password'
     | '/settings/ai-providers'
     | '/settings/api-keys'
+    | '/settings/archived-projects'
     | '/settings/audit-log'
     | '/settings/chatbox'
     | '/settings/connectors'
@@ -594,6 +607,13 @@ declare module '@tanstack/react-router' {
       path: '/audit-log'
       fullPath: '/settings/audit-log'
       preLoaderRoute: typeof SettingsAuditLogRouteImport
+      parentRoute: typeof SettingsRouteRoute
+    }
+    '/settings/archived-projects': {
+      id: '/settings/archived-projects'
+      path: '/archived-projects'
+      fullPath: '/settings/archived-projects'
+      preLoaderRoute: typeof SettingsArchivedProjectsRouteImport
       parentRoute: typeof SettingsRouteRoute
     }
     '/settings/api-keys': {
@@ -820,6 +840,7 @@ interface SettingsRouteRouteChildren {
   SettingsAdminPasswordRoute: typeof SettingsAdminPasswordRoute
   SettingsAiProvidersRoute: typeof SettingsAiProvidersRoute
   SettingsApiKeysRoute: typeof SettingsApiKeysRoute
+  SettingsArchivedProjectsRoute: typeof SettingsArchivedProjectsRoute
   SettingsAuditLogRoute: typeof SettingsAuditLogRoute
   SettingsChatboxRoute: typeof SettingsChatboxRoute
   SettingsConnectorsRoute: typeof SettingsConnectorsRoute
@@ -832,6 +853,7 @@ const SettingsRouteRouteChildren: SettingsRouteRouteChildren = {
   SettingsAdminPasswordRoute: SettingsAdminPasswordRoute,
   SettingsAiProvidersRoute: SettingsAiProvidersRoute,
   SettingsApiKeysRoute: SettingsApiKeysRoute,
+  SettingsArchivedProjectsRoute: SettingsArchivedProjectsRoute,
   SettingsAuditLogRoute: SettingsAuditLogRoute,
   SettingsChatboxRoute: SettingsChatboxRoute,
   SettingsConnectorsRoute: SettingsConnectorsRoute,

--- a/packages/web/src/routes/projects/$projectId/settings/index.tsx
+++ b/packages/web/src/routes/projects/$projectId/settings/index.tsx
@@ -1,19 +1,24 @@
 import { HQ_PROJECT_SLUG } from '@hezo/shared';
-import { createFileRoute, redirect } from '@tanstack/react-router';
+import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router';
 import { ExternalLink, Loader2 } from 'lucide-react';
 import { useState } from 'react';
 import { ProjectBudgetPanel } from '../../../../components/budget/project-budget-panel';
 import { ProjectIconSection } from '../../../../components/project-icon-section';
 import { Button } from '../../../../components/ui/button';
+import { ConfirmDialog } from '../../../../components/ui/confirm-dialog';
 import { Input } from '../../../../components/ui/input';
 import { Textarea } from '../../../../components/ui/textarea';
-import { useProject, useUpdateProject } from '../../../../hooks/use-projects';
+import { useMe } from '../../../../hooks/use-me';
+import { useArchiveProject, useProject, useUpdateProject } from '../../../../hooks/use-projects';
 import { useScrollToHash } from '../../../../hooks/use-scroll-to-hash';
 
 function ProjectSettingsPage() {
 	const { projectId } = Route.useParams();
 	const { data: project } = useProject(projectId);
+	const { data: me } = useMe();
 	const updateProject = useUpdateProject(projectId);
+	const archiveProject = useArchiveProject(projectId);
+	const navigate = useNavigate();
 	// Deep link from the Budget page's "Edit" button lands on the budget section.
 	const budgetSectionRef = useScrollToHash('budget');
 
@@ -22,6 +27,7 @@ function ProjectSettingsPage() {
 	const [maxRuns, setMaxRuns] = useState('1');
 	const [memoryLimit, setMemoryLimit] = useState('16');
 	const [editing, setEditing] = useState(false);
+	const [archiveOpen, setArchiveOpen] = useState(false);
 
 	if (!project) return null;
 
@@ -149,6 +155,43 @@ function ProjectSettingsPage() {
 							</a>
 						))}
 					</div>
+				</section>
+			)}
+
+			{me?.is_superuser && (
+				<section className="border-t border-border pt-6">
+					<h2 className="text-sm font-medium text-danger mb-1">Danger zone</h2>
+					<p className="text-xs text-text-3 mb-3 max-w-prose">
+						Archiving removes this project from the project rail and stops its container. Its tasks
+						and history are kept — you can restore it later from{' '}
+						<span className="text-text-2">Settings → Archived projects</span>.
+					</p>
+					<Button
+						variant="destructive"
+						size="sm"
+						onClick={() => setArchiveOpen(true)}
+						data-testid="archive-project-button"
+					>
+						Archive this project
+					</Button>
+					<ConfirmDialog
+						open={archiveOpen}
+						onOpenChange={setArchiveOpen}
+						title="Archive this project?"
+						description={
+							<>
+								<strong>{project.name}</strong> will be hidden from the project rail and its
+								container will be stopped. You can unarchive it later from global Settings.
+							</>
+						}
+						confirmLabel="Archive"
+						variant="danger"
+						loading={archiveProject.isPending}
+						onConfirm={async () => {
+							await archiveProject.mutateAsync();
+							await navigate({ to: '/' });
+						}}
+					/>
 				</section>
 			)}
 		</div>

--- a/packages/web/src/routes/settings/archived-projects.tsx
+++ b/packages/web/src/routes/settings/archived-projects.tsx
@@ -1,0 +1,83 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { Loader2 } from 'lucide-react';
+import { Button } from '../../components/ui/button';
+import { useMe } from '../../hooks/use-me';
+import { type Project, useArchivedProjects, useUnarchiveProject } from '../../hooks/use-projects';
+
+function formatDate(iso: string | null | undefined): string {
+	if (!iso) return '';
+	return new Date(iso).toLocaleDateString(undefined, {
+		year: 'numeric',
+		month: 'short',
+		day: 'numeric',
+	});
+}
+
+function ArchivedProjectRow({ project }: { project: Project }) {
+	const unarchive = useUnarchiveProject(project.slug);
+	return (
+		<li
+			className="flex items-center justify-between gap-3 py-3"
+			data-testid={`archived-project-${project.slug}`}
+		>
+			<div className="min-w-0">
+				<div className="text-[13px] font-medium text-text-1 truncate">{project.name}</div>
+				<div className="text-xs text-text-3 truncate">
+					{project.team_name}
+					{project.archived_at ? ` · archived ${formatDate(project.archived_at)}` : ''}
+				</div>
+			</div>
+			<Button
+				variant="secondary"
+				size="sm"
+				disabled={unarchive.isPending}
+				onClick={() => unarchive.mutate()}
+				data-testid={`unarchive-${project.slug}`}
+			>
+				{unarchive.isPending ? <Loader2 className="w-3 h-3 animate-spin" /> : 'Unarchive'}
+			</Button>
+		</li>
+	);
+}
+
+function ArchivedProjectsPage() {
+	const { data: me } = useMe();
+	const { data: projects = [], isLoading } = useArchivedProjects();
+
+	const content =
+		me && !me.is_superuser ? (
+			<p className="text-[13px] text-text-2">
+				Archived projects are managed by the Admin. You don't have access to this page.
+			</p>
+		) : (
+			<>
+				<div className="mb-5">
+					<h1 className="text-[22px] font-medium">Archived projects</h1>
+					<p className="text-[13px] text-text-2 mt-1 max-w-[680px]">
+						Projects that have been archived from their settings page. Archived projects are hidden
+						from the project rail; unarchive one to restore it.
+					</p>
+				</div>
+
+				{isLoading ? (
+					<Loader2 className="w-4 h-4 animate-spin text-text-3" />
+				) : projects.length === 0 ? (
+					<p className="text-[13px] text-text-2" data-testid="archived-projects-empty">
+						No archived projects.
+					</p>
+				) : (
+					<ul className="divide-y divide-border border-t border-border">
+						{projects.map((p) => (
+							<ArchivedProjectRow key={p.id} project={p} />
+						))}
+					</ul>
+				)}
+			</>
+		);
+
+	return <div className="max-w-[900px]">{content}</div>;
+}
+
+export const Route = createFileRoute('/settings/archived-projects')({
+	component: ArchivedProjectsPage,
+});

--- a/packages/web/test/helpers/seed.ts
+++ b/packages/web/test/helpers/seed.ts
@@ -242,6 +242,20 @@ export async function archiveSeededDocument(
 	});
 }
 
+/** Archive (or restore) a project via the real API (superuser-only endpoints). */
+export async function archiveSeededProject(
+	workspace: SeededWorkspace,
+	project: SeededProject,
+	archived = true,
+): Promise<void> {
+	const { apiBase } = getTestContext();
+	await apiBase(`/api/projects/${project.slug}/${archived ? 'archive' : 'unarchive'}`, {
+		method: 'POST',
+		headers: workspace.headers,
+		body: JSON.stringify({}),
+	});
+}
+
 /** Leave a review comment on an asset via the real API (no quote = whole-asset). */
 export async function seedAssetReviewComment(
 	workspace: SeededWorkspace,

--- a/packages/web/test/project-archive.test.tsx
+++ b/packages/web/test/project-archive.test.tsx
@@ -1,0 +1,95 @@
+import { waitFor } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+import {
+	archiveSeededProject,
+	type SeededWorkspace,
+	seedProject,
+	seedWorkspace,
+} from './helpers/seed';
+
+function uniqueName(base: string): string {
+	return `${base} ${Math.random().toString(36).slice(2, 8)}`;
+}
+
+test('archives a project from settings via the confirm dialog', async () => {
+	const projectName = uniqueName('Archive Project');
+	let ws!: SeededWorkspace;
+	let projectSlug = '';
+	let projectId = '';
+
+	const { findByTestId, ctx, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: projectName, description: 'To be archived.' });
+			projectSlug = project.slug;
+			projectId = project.id;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/settings',
+		params: { projectId: projectSlug },
+	});
+
+	// The superuser-only Danger zone renders the archive affordance.
+	await user.click(await findByTestId('archive-project-button', undefined, { timeout: 15_000 }));
+
+	// Confirm in the dialog (portaled onto document.body).
+	await user.click(await findByTestId('confirm-dialog-confirm', undefined, { timeout: 8_000 }));
+
+	// The real backend stamps archived_at on the project row.
+	await waitFor(
+		async () => {
+			const row = await ctx.db.query<{ archived_at: string | null }>(
+				'SELECT archived_at FROM projects WHERE id = $1',
+				[projectId],
+			);
+			expect(row.rows[0]?.archived_at).not.toBeNull();
+		},
+		{ timeout: 8_000 },
+	);
+});
+
+test('unarchives a project from the archived-projects settings page', async () => {
+	const projectName = uniqueName('Restore Project');
+	let ws!: SeededWorkspace;
+	let projectId = '';
+	let slug = '';
+
+	const { findByText, findByTestId, queryByTestId, ctx, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			ws = await seedWorkspace();
+			const project = await seedProject(ws, {
+				name: projectName,
+				description: 'Archived already.',
+			});
+			projectId = project.id;
+			slug = project.slug;
+			await archiveSeededProject(ws, project, true);
+		},
+	});
+
+	await router.navigate({ to: '/settings/archived-projects' });
+
+	// The archived project is listed; unarchive it.
+	await findByText(projectName, undefined, { timeout: 15_000 });
+	await user.click(await findByTestId(`unarchive-${slug}`, undefined, { timeout: 8_000 }));
+
+	// The backend clears archived_at, and the row drops out of the list.
+	await waitFor(
+		async () => {
+			const row = await ctx.db.query<{ archived_at: string | null }>(
+				'SELECT archived_at FROM projects WHERE id = $1',
+				[projectId],
+			);
+			expect(row.rows[0]?.archived_at).toBeNull();
+		},
+		{ timeout: 8_000 },
+	);
+	await waitFor(() => expect(queryByTestId(`archived-project-${slug}`)).toBeNull(), {
+		timeout: 8_000,
+	});
+});


### PR DESCRIPTION
## Summary

Adds the ability to **archive** a project (retire it without deleting) and **unarchive** it later, following the existing soft-delete pattern already used for docs/assets and goals.

- **Archive** from the bottom of the project **Settings** page — a new **Danger zone** with an "Archive this project" button and a confirmation dialog. The project drops out of the left project rail, its container is stopped, and any in-flight agent runs are cancelled. Tasks and history are kept — it's reversible.
- **Unarchive** from a new **"Archived projects"** item in the **global settings** menu, which lists archived projects with an "Unarchive" action.
- Both actions are **superuser-only** (matching project creation and the superuser-only global-settings section).

## Changes

- **DB:** migration `026_archive_projects.sql` adds a nullable `archived_at` column to `projects` (NULL = active) plus a partial active index, with a data-preservation test.
- **Backend** (`routes/projects.ts`): superuser-only `POST /projects/:id/archive` (stamps `archived_at`, stops the container via the existing stop path, blocks internal projects) and `POST /projects/:id/unarchive`. `GET /projects` filters to active by default and accepts `?filter=active|archived|all`, reusing the shared `ArchiveFilter` enum — so the rail hides archived projects with no client change.
- **Frontend:** `archived_at` on the `Project` type; `useArchiveProject`/`useUnarchiveProject`/`useArchivedProjects` hooks; Danger zone on project settings; a new `/settings/archived-projects` route + menu item.
- **Docs:** `docs/concepts/projects-and-teams.md` gains an "Archiving a project" section; `.dev/architecture.md` documents the new column and flow. (REST-only routes, so no MCP/SKILL.md surfaces are affected.)

## Testing

- `packages/server/test/migrate-026-archive-projects.test.ts` — migration adds the column and preserves existing rows.
- `packages/server/test/projects.test.ts` — archive stamps `archived_at` and hides from the default index; `?filter=archived`/`all` include it; unarchive restores; internal projects → 403; non-superuser team member → 403.
- `packages/web/test/project-archive.test.tsx` — archive from settings via the confirm dialog; unarchive from the archived-projects page (both drive the real in-process backend).
- Full `typecheck` and biome `check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8PXsU9bdbqULKoaiyDGrM

---
_Generated by [Claude Code](https://claude.ai/code/session_01N8PXsU9bdbqULKoaiyDGrM)_