### PR TITLE
fix: keep mobile comment header on one row via truncated timestamp

### DIFF
--- a/packages/web/src/components/comment-renderers/comment-timestamp-link.tsx
+++ b/packages/web/src/components/comment-renderers/comment-timestamp-link.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+import { Tooltip } from '../ui/tooltip';
 import { jumpToComment } from './helpers';
 
 /**
@@ -6,6 +8,14 @@ import { jumpToComment } from './helpers';
  * copy-able permalink that scrolls to and highlights itself. `stopPropagation`
  * keeps a click from reaching an enclosing control (the run row's expand
  * button wraps its timestamp); it's a no-op for the other call sites.
+ *
+ * The label truncates (`min-w-0 truncate`) so the timestamp is the segment that
+ * shrinks when the comment header runs out of horizontal room — on a narrow
+ * mobile viewport this keeps the whole header on a single row instead of
+ * wrapping. The full date/time is always reachable: on desktop it shows on
+ * hover, and on touch a tap toggles the tooltip (Radix tooltips never open on
+ * tap, so `open` is driven manually — `preventDefault` stops both the anchor
+ * navigation and Radix's own pointer-down dismissal so the tap just reveals it).
  */
 export function CommentTimestampLink({
 	publicId,
@@ -16,18 +26,26 @@ export function CommentTimestampLink({
 	createdAt: string;
 	className?: string;
 }) {
+	const [open, setOpen] = useState(false);
+	const full = new Date(createdAt).toLocaleString();
 	return (
-		<a
-			href={`#comment-${publicId}`}
-			onClick={(e) => {
-				e.stopPropagation();
-				jumpToComment(publicId)(e);
-			}}
-			className={`text-[11px] text-text-3 hover:text-text-1 hover:underline${className ? ` ${className}` : ''}`}
-			title="Link to this comment"
-			data-testid="comment-timestamp-link"
-		>
-			{new Date(createdAt).toLocaleString()}
-		</a>
+		<Tooltip content={full} open={open} onOpenChange={setOpen}>
+			<a
+				href={`#comment-${publicId}`}
+				onClick={(e) => {
+					e.stopPropagation();
+					jumpToComment(publicId)(e);
+				}}
+				onTouchStart={(e) => {
+					e.preventDefault();
+					setOpen((o) => !o);
+				}}
+				className={`min-w-0 truncate text-[11px] text-text-3 hover:text-text-1 hover:underline${className ? ` ${className}` : ''}`}
+				title="Link to this comment"
+				data-testid="comment-timestamp-link"
+			>
+				{full}
+			</a>
+		</Tooltip>
 	);
 }

--- a/packages/web/src/components/task-detail/comments-section.tsx
+++ b/packages/web/src/components/task-detail/comments-section.tsx
@@ -435,7 +435,7 @@ export function CommentsSection({
 														<a
 															href={`#comment-${parent.public_id}`}
 															onClick={jumpToComment(parent.public_id)}
-															className="flex items-center gap-1 text-[11px] text-text-3 hover:text-text-1"
+															className="flex shrink-0 items-center gap-1 whitespace-nowrap text-[11px] text-text-3 hover:text-text-1"
 															data-testid="replying-to"
 														>
 															<CornerDownRight className="w-3 h-3" />

--- a/test/browser/task-detail.mobile.spec.ts
+++ b/test/browser/task-detail.mobile.spec.ts
@@ -240,6 +240,97 @@ test.describe('Task detail — document preview panel (mobile, 390px)', () => {
 	});
 });
 
+test.describe('Comment header — mobile (narrow viewport)', () => {
+	// The comment header (author · timestamp · "replying to …" · copy) must stay
+	// on a single row on a narrow phone. The timestamp is the segment that
+	// truncates with an ellipsis to make room; its full value is revealed in a
+	// tooltip on tap. This needs a real layout pass (#1/#2 in the tier tree), so
+	// it lives in Playwright.
+	async function seedReply(page: Page, token: string, projectSlug: string, taskId: string) {
+		const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+		const parentRes = await page.request.post(
+			`/api/projects/${projectSlug}/tasks/${taskId}/comments`,
+			{ headers, data: { content_type: 'text', content: { text: 'Parent comment.' } } },
+		);
+		const parent = ((await parentRes.json()) as { data: { id: string } }).data;
+		const replyRes = await page.request.post(
+			`/api/projects/${projectSlug}/tasks/${taskId}/comments`,
+			{
+				headers,
+				data: {
+					content_type: 'text',
+					content: { text: 'A reply that carries a replying-to indicator in its header.' },
+					parent_comment_id: parent.id,
+				},
+			},
+		);
+		if (!replyRes.ok()) throw new Error(`seed reply failed: ${replyRes.status()}`);
+	}
+
+	test('header stays on one row; timestamp truncates and reveals the full value on tap', async ({
+		page,
+		freshWorkspace,
+	}) => {
+		const { token } = freshWorkspace;
+		const { project, task } = await createProjectAndTask(page, token, 'Mobile Comment Header');
+		await seedReply(page, token, project.slug, task.id);
+
+		// 320px — a small phone — to force the header to run out of room so the
+		// truncation branch actually fires.
+		await page.setViewportSize({ width: 320, height: 800 });
+		await page.goto(`/projects/${project.slug}/tasks/${task.identifier.toLowerCase()}`);
+		await waitForPageLoad(page);
+		await expect(page.getByRole('heading', { name: 'Mobile Task' })).toBeVisible({
+			timeout: 20000,
+		});
+
+		// Scope to the reply's header — it's the comment carrying a "replying to" link.
+		const replyItem = page
+			.getByTestId('comment-item')
+			.filter({ has: page.getByTestId('replying-to') });
+		await expect(replyItem).toBeVisible({ timeout: 15000 });
+		const timestamp = replyItem.getByTestId('comment-timestamp-link');
+		const author = replyItem.getByTestId('comment-author');
+		const replyingTo = replyItem.getByTestId('replying-to');
+		await expect(timestamp).toBeVisible();
+
+		// The page never scrolls horizontally.
+		const overflow = await page.evaluate(() => {
+			const main = document.querySelector('main');
+			return main ? main.scrollWidth - main.clientWidth : -1;
+		});
+		expect(overflow).toBe(0);
+
+		// Author, timestamp, and "replying to" all sit on the SAME row — their
+		// vertical spans overlap (the header did not wrap onto a second line).
+		const authorBox = await author.boundingBox();
+		const tsBox = await timestamp.boundingBox();
+		const replyBox = await replyingTo.boundingBox();
+		if (!authorBox || !tsBox || !replyBox) throw new Error('Missing layout box');
+		const sameRow = (a: typeof authorBox, b: typeof tsBox) =>
+			a.y < b.y + b.height && b.y < a.y + a.height;
+		expect(sameRow(authorBox, tsBox)).toBe(true);
+		expect(sameRow(authorBox, replyBox)).toBe(true);
+
+		// The timestamp is the segment that gave way: it is clipped to an ellipsis
+		// (rendered narrower than its full text), yet its full value is intact in
+		// the DOM for the tooltip.
+		const truncated = await timestamp.evaluate((el) => el.scrollWidth > el.clientWidth);
+		expect(truncated).toBe(true);
+		expect(tsBox.x + tsBox.width).toBeLessThanOrEqual(320);
+		const full = ((await timestamp.textContent()) ?? '').trim();
+		expect(full.length).toBeGreaterThan(0);
+
+		// Tapping the timestamp reveals the full date/time in a tooltip (Radix
+		// tooltips never open on tap, so the component drives `open` from its own
+		// touchstart handler).
+		await timestamp.dispatchEvent('touchstart');
+		const tooltip = page.getByRole('tooltip');
+		await expect(tooltip).toBeVisible({ timeout: 5000 });
+		expect(((await tooltip.textContent()) ?? '').trim()).toBe(full);
+	});
+});
+
 // Render a completed run comment cheaply by mocking the comments + heartbeat-run
 // responses — no real agent runtime needed (cribbed from agent-run-logs.spec.ts).
 async function mockRunComment(page: Page, token: string) {


### PR DESCRIPTION
## Summary

On a narrow phone, the comment header (`author · timestamp · "replying to …" · copy`) wrapped onto multiple lines — the date/time split across two rows (see the reported screenshot). This keeps the header on a **single row** by making the timestamp the segment that gives way: it truncates with an ellipsis, and its full value is revealed in a tooltip on tap.

## Changes

- **`comment-timestamp-link.tsx`** (shared by the text-comment header and the run-comment header):
  - The timestamp label now truncates (`min-w-0 truncate`), so it's the segment that shrinks when the header runs out of horizontal room.
  - Wrapped in the existing `Tooltip` showing the full date/time. On desktop it opens on hover; on touch, a tap toggles it — Radix tooltips never open on tap, so `open` is driven from the component's own `touchstart` handler (`preventDefault` stops both the anchor navigation and Radix's pointer-down dismissal so the tap just reveals the value).
- **`comments-section.tsx`**: the "replying to …" link is pinned to a single line (`shrink-0 whitespace-nowrap`) so the timestamp — not the reply indicator — is the element that shrinks.

## Testing

- New Playwright mobile test (`task-detail.mobile.spec.ts`, 320px viewport): asserts the header stays on one row (author, timestamp, and "replying to" share the same row; no horizontal page overflow), the timestamp is clipped to an ellipsis while its full value stays in the DOM, and tapping it reveals the full date/time in a tooltip.
- `bun run test --browser --pattern task-detail.mobile` — 8/8 pass (incl. the existing run-header layout test, confirming the shared change doesn't regress `run-comment`).
- `comment-timestamp-permalink.test.tsx` + `task-comments.test.tsx` — 19/19 pass (permalink/anchor semantics intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2nHquN6bYkcwkmhWd6tMx)_