### PR TITLE
fix: scroll-to-top stalling partway on mobile

### DIFF
--- a/packages/web/src/hooks/use-scroll-to-top.ts
+++ b/packages/web/src/hooks/use-scroll-to-top.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 /**
  * Companion to `useScrollToBottom` for the "jump to top" affordance. `atTop`
@@ -14,6 +14,9 @@ export function useScrollToTop(scrollParent: HTMLElement | null): {
 	// Start hidden (`atTop: true`) so short pages never flash the button before the
 	// first measurement runs — mirrors `useScrollToBottom`'s initial state.
 	const [atTop, setAtTop] = useState(true);
+	// Handle of the in-flight rAF-driven scroll animation, so a repeat click or an
+	// unmount can cancel it instead of leaving two animations fighting.
+	const frameRef = useRef<number | null>(null);
 	useEffect(() => {
 		if (!scrollParent) return;
 		const check = () => setAtTop(scrollParent.scrollTop <= 200);
@@ -22,8 +25,52 @@ export function useScrollToTop(scrollParent: HTMLElement | null): {
 		return () => scrollParent.removeEventListener('scroll', check);
 	}, [scrollParent]);
 
+	// Stop any running animation when the scroller changes or the shell unmounts.
+	useEffect(
+		() => () => {
+			if (frameRef.current !== null) cancelAnimationFrame(frameRef.current);
+		},
+		[],
+	);
+
 	const scrollToTop = () => {
-		scrollParent?.scrollTo({ top: 0, behavior: 'smooth' });
+		const el = scrollParent;
+		if (!el) return;
+		if (frameRef.current !== null) cancelAnimationFrame(frameRef.current);
+
+		// Native `scrollTo({ behavior: 'smooth' })` on a nested overflow container is
+		// unreliable on mobile: when the viewport height changes mid-animation — which
+		// mobile browsers do routinely as the URL bar collapses/expands while the page
+		// moves — WebKit aborts the smooth scroll partway, stranding the user short of
+		// the top and forcing a second tap. Drive the animation ourselves with rAF,
+		// writing `scrollTop` each frame, so it always lands at exactly 0 regardless of
+		// viewport churn.
+		const start = el.scrollTop;
+		const prefersReducedMotion =
+			typeof window !== 'undefined' &&
+			window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true;
+		if (start <= 0 || prefersReducedMotion) {
+			el.scrollTop = 0;
+			frameRef.current = null;
+			return;
+		}
+
+		// Snappy but proportional: ~0.5ms per pixel, clamped to a 200–600ms window.
+		const duration = Math.min(600, Math.max(200, start * 0.5));
+		const easeOutCubic = (t: number) => 1 - (1 - t) ** 3;
+		let startTime: number | null = null;
+		const step = (now: number) => {
+			if (startTime === null) startTime = now;
+			const t = Math.min(1, (now - startTime) / duration);
+			el.scrollTop = Math.round(start * (1 - easeOutCubic(t)));
+			if (t < 1) {
+				frameRef.current = requestAnimationFrame(step);
+			} else {
+				el.scrollTop = 0;
+				frameRef.current = null;
+			}
+		};
+		frameRef.current = requestAnimationFrame(step);
 	};
 
 	return { atTop, scrollToTop };

--- a/test/browser/scroll-to-top-global.spec.ts
+++ b/test/browser/scroll-to-top-global.spec.ts
@@ -71,11 +71,13 @@ for (const { name, width, height } of [
 		await button.click();
 
 		// The pill hides once the scroller reaches the top, and the real scroll
-		// position confirms the content genuinely moved back up.
+		// position confirms the content genuinely moved back up. A *single* click
+		// must land at the very top (0), not merely within the button's hide
+		// threshold: the rAF-driven scroll always finishes at 0, where the old
+		// native `scrollTo({ behavior: 'smooth' })` could stall partway on mobile
+		// and need a second tap.
 		await expect(button).toBeHidden({ timeout: 10000 });
-		await expect
-			.poll(() => main.evaluate((el) => el.scrollTop), { timeout: 10000 })
-			.toBeLessThanOrEqual(200);
+		await expect.poll(() => main.evaluate((el) => el.scrollTop), { timeout: 10000 }).toBe(0);
 		await expect(page.getByRole('heading', { name: DOC })).toBeInViewport();
 	});
 }


### PR DESCRIPTION
## Problem

On mobile, tapping the global "jump to top" pill doesn't scroll all the way to the top — it stalls at a certain point, and you have to tap it again to finish.

## Cause

`useScrollToTop` drove the shell `<main>` scroller with the browser's native `scrollTo({ behavior: 'smooth' })`. On mobile this is unreliable: when the viewport height changes mid-animation — which mobile browsers do routinely as the URL bar collapses/expands while the page moves — WebKit aborts the smooth scroll partway, leaving the user short of the top and needing a second tap. Unlike `useScrollToBottom` (which has a re-anchor loop that keeps re-scrolling to the bottom), the top hook had no compensation, so an aborted animation just stranded the scroll position.

## Fix

Drive the animation ourselves with `requestAnimationFrame`, writing `scrollTop` each frame along an `easeOutCubic` curve, so it always lands at exactly `0` regardless of viewport churn.

- Repeat clicks and unmount cancel any in-flight frame (tracked via a ref).
- `prefers-reduced-motion` and already-at-top jump instantly.
- Duration is proportional to distance (~0.5ms/px), clamped to a 200–600ms window, so short and long scrolls both feel right.

## Tests

Tightened `test/browser/scroll-to-top-global.spec.ts` to assert a **single** click lands at `scrollTop === 0`, not merely within the pill's 200px hide threshold — guarding the single-click-reaches-top guarantee. Mobile and desktop cases both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016w5GQMf1GcAmDBAQenmSik)_