### PR TITLE
feat(web): rework master-key onboarding and auth panes UI

### DIFF
--- a/packages/web/src/components/ai-provider-picker.tsx
+++ b/packages/web/src/components/ai-provider-picker.tsx
@@ -1,9 +1,9 @@
 import { AI_PROVIDER_INFO, type AiProvider } from '@hezo/shared';
-import { ArrowLeft } from 'lucide-react';
 import { useState } from 'react';
 import { ProviderCardGrid } from './provider-card-grid';
 import { ADD_PROVIDER_ORDER, ProviderConfigForm } from './provider-config-form';
 import { ProviderLogo } from './provider-logos';
+import { BackLink } from './ui/back-link';
 
 /**
  * Onboarding AI-provider setup: a grid of provider cards. Picking one drills
@@ -21,16 +21,11 @@ export function AiProviderPicker() {
 
 	const info = AI_PROVIDER_INFO[provider];
 	return (
-		<div className="flex flex-col gap-4">
+		// Keep the credential entry pane a comfortable reading width on desktop
+		// rather than stretching across the full onboarding card.
+		<div className="mx-auto flex w-full max-w-md flex-col gap-4">
+			<BackLink onClick={() => setProvider(null)} />
 			<div className="flex items-center gap-2">
-				<button
-					type="button"
-					onClick={() => setProvider(null)}
-					className="shrink-0 text-text-2 hover:text-text-1 p-2 -m-2"
-					aria-label="Back"
-				>
-					<ArrowLeft className="w-4 h-4" />
-				</button>
 				<span className="flex h-6 w-6 shrink-0 items-center justify-center text-text-1">
 					<ProviderLogo provider={provider} className="h-5 w-5" />
 				</span>

--- a/packages/web/src/components/master-key-gate.tsx
+++ b/packages/web/src/components/master-key-gate.tsx
@@ -4,27 +4,44 @@ import {
 	normalizeMnemonic,
 	validateMnemonic,
 } from '@hezo/shared';
-import { AlertTriangle, Eye, EyeOff, KeyRound, Loader2, Lock, ShieldCheck } from 'lucide-react';
+import {
+	AlertTriangle,
+	Copy,
+	Eye,
+	EyeOff,
+	KeyRound,
+	Loader2,
+	Lock,
+	RefreshCw,
+	ShieldCheck,
+} from 'lucide-react';
 import type { ReactNode } from 'react';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { authenticateWithMnemonic } from '../lib/auth';
 import { copyToClipboard } from '../lib/clipboard';
 import { queryClient } from '../lib/query-client';
 import { queryKeys } from '../lib/query-keys';
+import { BackLink } from './ui/back-link';
 import { Button } from './ui/button';
-import { Logo } from './ui/logo';
+import { PageLogo } from './ui/page-logo';
 import { PasswordInput } from './ui/password-input';
+import { Tooltip } from './ui/tooltip';
 
 const REVEAL_STRIPS = 11;
+/** How long the words shimmer as placeholders before a regenerated phrase appears. */
+const REGEN_ANIM_MS = 1200;
+/** Seconds Continue stays disabled after the key is copied, nudging the user to actually save it. */
+const SAVE_COUNTDOWN_SECONDS = 5;
 
 /**
- * Full-viewport "pre-active vault" chrome. Always dark (via `.vault-surface`),
- * visually distinct from the running app so it reads as "the instance is not
- * live yet". Used by the master-key setup + unlock + recovery screens.
+ * Full-viewport setup / unlock chrome. Follows the active theme (light or dark)
+ * like the rest of the app; the card sits centered under the brand logo. Used by
+ * the master-key setup + unlock + recovery screens.
  */
 export function VaultShell({ children }: { children: ReactNode }) {
 	return (
-		<div className="vault-surface min-h-screen flex flex-col items-center justify-center bg-bg px-4 py-10">
+		<div className="relative min-h-screen flex flex-col items-center justify-center bg-bg px-4 py-10">
+			<PageLogo />
 			<div className="w-full max-w-md">{children}</div>
 		</div>
 	);
@@ -65,21 +82,57 @@ export function MasterKeyForm({ state, embedded, onAuthenticated }: MasterKeyFor
 	const [generatedKey, setGeneratedKey] = useState<string | null>(null);
 	const [error, setError] = useState('');
 	const [loading, setLoading] = useState(false);
-	const [copied, setCopied] = useState(false);
 	const [revealing, setRevealing] = useState(false);
 	// Setup is a two-step flow: generate + save the key, then paste it back to
 	// confirm before it's committed. `phase` only matters when `isUnset`.
 	const [phase, setPhase] = useState<'generate' | 'confirm'>('generate');
 	// The generated words start masked (password-style); the eye toggle reveals them.
 	const [revealed, setRevealed] = useState(false);
+	// The word grid shimmers as placeholders while a regenerated phrase is prepared.
+	const [regenerating, setRegenerating] = useState(false);
+	// Continue only appears once the user has copied the key, then stays disabled
+	// for a short countdown so they actually stash it before advancing.
+	const [copyClicked, setCopyClicked] = useState(false);
+	const [countdown, setCountdown] = useState(SAVE_COUNTDOWN_SECONDS);
+
+	const regenTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+	useEffect(
+		() => () => {
+			if (regenTimer.current) clearTimeout(regenTimer.current);
+		},
+		[],
+	);
 
 	const isUnset = state === 'unset';
 
+	// Tick the post-copy countdown down to zero, which enables Continue.
+	useEffect(() => {
+		if (!copyClicked || countdown <= 0) return;
+		const id = setTimeout(() => setCountdown((c) => c - 1), 1000);
+		return () => clearTimeout(id);
+	}, [copyClicked, countdown]);
+
+	function resetSaveGate() {
+		setCopyClicked(false);
+		setCountdown(SAVE_COUNTDOWN_SECONDS);
+	}
+
 	function handleGenerate() {
-		setGeneratedKey(generateMnemonic());
-		setRevealed(false);
-		setCopied(false);
 		setError('');
+		setRevealed(false);
+		resetSaveGate();
+		const reduceMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
+		// First generation (nothing to animate) or reduced motion: swap instantly.
+		if (!generatedKey || reduceMotion) {
+			setGeneratedKey(generateMnemonic());
+			return;
+		}
+		// Regenerating: shimmer the existing grid, then reveal the fresh phrase.
+		setRegenerating(true);
+		regenTimer.current = setTimeout(() => {
+			setGeneratedKey(generateMnemonic());
+			setRegenerating(false);
+		}, REGEN_ANIM_MS);
 	}
 
 	function goToConfirm() {
@@ -138,10 +191,11 @@ export function MasterKeyForm({ state, embedded, onAuthenticated }: MasterKeyFor
 	}
 
 	async function handleCopy() {
-		if (await copyToClipboard(generatedKey ?? '')) {
-			setCopied(true);
-			setTimeout(() => setCopied(false), 2000);
-		}
+		// Best-effort copy; the click itself opens the save gate either way so the
+		// user is never stranded if the clipboard API is unavailable.
+		await copyToClipboard(generatedKey ?? '');
+		setCopyClicked(true);
+		setCountdown(SAVE_COUNTDOWN_SECONDS);
 	}
 
 	const heading = !isUnset
@@ -152,24 +206,34 @@ export function MasterKeyForm({ state, embedded, onAuthenticated }: MasterKeyFor
 	const subtitle = !isUnset
 		? 'The instance is locked. Enter your 12-word master key to bring it back online.'
 		: phase === 'confirm'
-			? 'Paste the 12 words back so we know you have the full phrase. You can go back and generate a new one.'
-			: 'The one key that encrypts your data and unlocks this instance.';
+			? 'Paste the 12 words back so we know you have the full phrase. You can always go back.'
+			: // Generate phase: the callout below the heading replaces a one-line subtitle.
+				null;
 
 	// The generate-phase word grid + the confirm/unlock entry field.
 	const showGenerated = isUnset && phase === 'generate' && generatedKey !== null;
 	const showEntry = !isUnset || phase === 'confirm';
 
+	// During regeneration the words are hidden behind shimmering placeholders.
+	const gridWords = regenerating
+		? Array.from({ length: 12 }, () => '')
+		: (generatedKey ?? '').split(' ');
+
 	return (
 		<>
 			{revealing && <UnlockReveal onDone={finishTransition} />}
+			{isUnset && phase === 'confirm' && (
+				<div className="mb-3">
+					<BackLink onClick={goBackToGenerate} />
+				</div>
+			)}
 			{!embedded && (
 				<div className="flex flex-col items-center gap-2 mb-6">
-					<Logo size="lg" wordmark className="mb-1" />
 					<div className="p-3 rounded-full bg-surface-2 border border-border-strong text-accent-soft-fg">
 						{isUnset ? <KeyRound className="w-6 h-6" /> : <ShieldCheck className="w-6 h-6" />}
 					</div>
 					<h2 className="text-lg font-semibold text-text-1">{heading}</h2>
-					<p className="text-sm text-text-2 text-center">{subtitle}</p>
+					{subtitle && <p className="text-sm text-text-2 text-center">{subtitle}</p>}
 				</div>
 			)}
 
@@ -182,14 +246,59 @@ export function MasterKeyForm({ state, embedded, onAuthenticated }: MasterKeyFor
 				)}
 
 				{showGenerated && (
+					<div className="flex flex-col gap-2.5 rounded-md border border-warning-soft-fg/25 bg-warning-soft px-3 py-3 text-[12.5px] leading-relaxed text-warning-soft-fg">
+						<div className="flex gap-2.5 items-start">
+							<KeyRound className="w-4 h-4 shrink-0 mt-0.5" />
+							<span>
+								<span className="font-semibold text-text-1">
+									Encrypts everything, unlocks every restart.
+								</span>{' '}
+								This key protects all data in your instance and brings it back online after each
+								restart.
+							</span>
+						</div>
+						<div className="flex gap-2.5 items-start">
+							<AlertTriangle className="w-4 h-4 shrink-0 mt-0.5" />
+							<span>
+								<span className="font-semibold text-text-1">
+									No one can recover it — not even Hezo.
+								</span>{' '}
+								Lose these words and your data is locked away for good.
+							</span>
+						</div>
+						<div className="flex gap-2.5 items-start">
+							<Lock className="w-4 h-4 shrink-0 mt-0.5" />
+							<span>
+								<span className="font-semibold text-text-1">Save it now</span> in a password manager
+								or another safe place — you'll confirm it on the next step.
+							</span>
+						</div>
+					</div>
+				)}
+
+				{showGenerated && (
 					<div className="flex flex-col gap-3">
 						<div className="flex items-center justify-between">
-							<span className="text-eyebrow text-text-2">Your master key</span>
+							<div className="flex items-center gap-2">
+								<span className="text-eyebrow text-text-2">Your master key</span>
+								<Tooltip content="Generate a new master key">
+									<button
+										type="button"
+										onClick={handleGenerate}
+										disabled={regenerating}
+										aria-label="Generate a new key"
+										className="text-text-3 hover:text-text-1 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+									>
+										<RefreshCw className={`w-3.5 h-3.5 ${regenerating ? 'animate-spin' : ''}`} />
+									</button>
+								</Tooltip>
+							</div>
 							<button
 								type="button"
 								onClick={() => setRevealed((v) => !v)}
+								disabled={regenerating}
 								aria-label={revealed ? 'Hide key' : 'Show key'}
-								className="flex items-center gap-1.5 text-xs text-text-3 hover:text-text-1"
+								className="flex items-center gap-1.5 text-xs text-text-3 hover:text-text-1 disabled:opacity-40"
 							>
 								{revealed ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
 								{revealed ? 'Hide' : 'Show'}
@@ -199,7 +308,7 @@ export function MasterKeyForm({ state, embedded, onAuthenticated }: MasterKeyFor
 							className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-2"
 							aria-label="Master key"
 						>
-							{(generatedKey ?? '').split(' ').map((word, index) => (
+							{gridWords.map((word, index) => (
 								<li
 									// biome-ignore lint/suspicious/noArrayIndexKey: fixed-length, never-reordered list with possibly-repeating words; position is the stable identity
 									key={index}
@@ -209,43 +318,19 @@ export function MasterKeyForm({ state, embedded, onAuthenticated }: MasterKeyFor
 									<span className="w-4 text-right text-[10px] tabular-nums text-text-3 select-none">
 										{index + 1}
 									</span>
-									<span className="font-mono text-xs text-text-1">
-										{revealed ? word : '••••••'}
-									</span>
+									{regenerating ? (
+										<span
+											className="h-3 flex-1 rounded bg-surface-3 animate-pulse"
+											aria-hidden="true"
+										/>
+									) : (
+										<span className="font-mono text-xs text-text-1">
+											{revealed ? word : '••••••'}
+										</span>
+									)}
 								</li>
 							))}
 						</ol>
-						<Button type="button" variant="ghost" size="sm" onClick={handleCopy}>
-							{copied ? 'Copied!' : 'Copy to clipboard'}
-						</Button>
-						<div className="flex flex-col gap-2.5 rounded-md border border-warning-soft-fg/25 bg-warning-soft px-3 py-3 text-[12.5px] leading-relaxed text-warning-soft-fg">
-							<div className="flex gap-2.5 items-start">
-								<KeyRound className="w-4 h-4 shrink-0 mt-0.5" />
-								<span>
-									<span className="font-semibold text-text-1">
-										Encrypts everything, unlocks every restart.
-									</span>{' '}
-									This key protects all data in your instance and brings it back online after each
-									restart.
-								</span>
-							</div>
-							<div className="flex gap-2.5 items-start">
-								<AlertTriangle className="w-4 h-4 shrink-0 mt-0.5" />
-								<span>
-									<span className="font-semibold text-text-1">
-										No one can recover it — not even Hezo.
-									</span>{' '}
-									Lose these words and your data is locked away for good.
-								</span>
-							</div>
-							<div className="flex gap-2.5 items-start">
-								<Lock className="w-4 h-4 shrink-0 mt-0.5" />
-								<span>
-									<span className="font-semibold text-text-1">Save it now</span> in a password
-									manager or another safe place — you'll confirm it on the next step.
-								</span>
-							</div>
-						</div>
 					</div>
 				)}
 
@@ -272,27 +357,30 @@ export function MasterKeyForm({ state, embedded, onAuthenticated }: MasterKeyFor
 
 				{error && <p className="text-sm text-danger">{error}</p>}
 
-				{showGenerated && (
-					<div className="flex flex-col gap-2">
-						<Button type="button" onClick={goToConfirm}>
-							Continue
+				{showGenerated &&
+					(copyClicked ? (
+						<div className="flex flex-col gap-1.5">
+							<Button type="button" onClick={goToConfirm} disabled={countdown > 0}>
+								{countdown > 0 ? `Continue (${countdown})` : 'Continue'}
+							</Button>
+							{countdown > 0 && (
+								<p className="text-center text-xs text-text-3">
+									Take a moment to save your key somewhere safe.
+								</p>
+							)}
+						</div>
+					) : (
+						<Button type="button" onClick={handleCopy} disabled={regenerating}>
+							<Copy className="w-4 h-4" />
+							Copy to clipboard
 						</Button>
-						<Button type="button" variant="ghost" size="sm" onClick={handleGenerate}>
-							Generate a new key
-						</Button>
-					</div>
-				)}
+					))}
 
 				{isUnset && phase === 'confirm' && (
-					<div className="flex flex-col gap-2">
-						<Button type="submit" disabled={loading || !key.trim()}>
-							{loading && <Loader2 className="w-4 h-4 animate-spin" />}
-							Set key & continue
-						</Button>
-						<Button type="button" variant="ghost" size="sm" onClick={goBackToGenerate}>
-							Back
-						</Button>
-					</div>
+					<Button type="submit" disabled={loading || !key.trim()}>
+						{loading && <Loader2 className="w-4 h-4 animate-spin" />}
+						Confirm key and continue
+					</Button>
 				)}
 
 				{!isUnset && (

--- a/packages/web/src/components/password-login.tsx
+++ b/packages/web/src/components/password-login.tsx
@@ -7,7 +7,7 @@ import { queryKeys } from '../lib/query-keys';
 import { MasterKeyForm, VaultShell } from './master-key-gate';
 import { PasswordSetForm } from './password-set-form';
 import { Button } from './ui/button';
-import { Logo } from './ui/logo';
+import { PageLogo } from './ui/page-logo';
 import { PasswordInput } from './ui/password-input';
 
 type Mode = 'login' | 'master-key' | 'reset';
@@ -70,7 +70,8 @@ export function PasswordLogin() {
 
 	if (mode === 'reset') {
 		return (
-			<div className="min-h-screen flex items-center justify-center bg-surface px-4">
+			<div className="relative min-h-screen flex items-center justify-center bg-surface px-4">
+				<PageLogo />
 				<div
 					data-testid="reset-password"
 					className="w-full max-w-sm rounded-lg border border-border bg-surface p-6 sm:p-8 shadow-sm"
@@ -86,13 +87,13 @@ export function PasswordLogin() {
 	}
 
 	return (
-		<div className="min-h-screen flex items-center justify-center bg-surface px-4">
+		<div className="relative min-h-screen flex items-center justify-center bg-surface px-4">
+			<PageLogo />
 			<div
 				data-testid="password-login"
 				className="w-full max-w-sm rounded-lg border border-border bg-surface p-6 sm:p-8 shadow-sm"
 			>
 				<div className="mb-6 flex flex-col items-center gap-2 text-center">
-					<Logo size="lg" wordmark className="mb-1" />
 					<h2 className="text-lg font-semibold text-text-1">Sign in</h2>
 					<p className="text-sm text-text-2">Enter your admin password to continue.</p>
 				</div>

--- a/packages/web/src/components/setup/setup-wizard.tsx
+++ b/packages/web/src/components/setup/setup-wizard.tsx
@@ -9,6 +9,7 @@ import { queryKeys } from '../../lib/query-keys';
 import { AiProviderPicker } from '../ai-provider-picker';
 import { MasterKeyForm, VaultShell } from '../master-key-gate';
 import { PasswordSetForm } from '../password-set-form';
+import { PageLogo } from '../ui/page-logo';
 import { Stepper, type StepStatus } from './stepper';
 
 export type WizardStep = 'password' | 'ai-provider' | 'done';
@@ -27,7 +28,8 @@ function WizardShell({ currentStep, children }: WizardShellProps) {
 	const passwordStatus: StepStatus = currentStep === 'password' ? 'current' : 'complete';
 	const aiProviderStatus: StepStatus = currentStep === 'ai-provider' ? 'current' : 'pending';
 	return (
-		<div className="min-h-screen flex flex-col items-center px-4 py-8 sm:py-16 bg-surface">
+		<div className="relative min-h-screen flex flex-col items-center px-4 py-8 sm:py-16 bg-surface">
+			<PageLogo />
 			<div className="w-full max-w-2xl">
 				<div className="text-center mb-6 sm:mb-10">
 					<h1 className="text-xl sm:text-2xl font-semibold mb-2">Welcome to Hezo</h1>
@@ -51,7 +53,7 @@ function WizardShell({ currentStep, children }: WizardShellProps) {
 /** Create/confirm the admin password. On success the session is stored and the gate advances. */
 function PasswordStep() {
 	return (
-		<div data-testid="setup-step-password">
+		<div data-testid="setup-step-password" className="mx-auto max-w-md">
 			<h2 className="text-base sm:text-lg font-semibold mb-1">Create an admin password</h2>
 			<p className="text-[13px] text-text-2 mb-5">
 				You'll sign in with this password from now on. If you forget it, you can reset it with your

--- a/packages/web/src/components/ui/back-link.tsx
+++ b/packages/web/src/components/ui/back-link.tsx
@@ -1,0 +1,26 @@
+import { ArrowLeft } from 'lucide-react';
+
+interface BackLinkProps {
+	onClick: () => void;
+	/** Link text after the arrow. Defaults to "Back". */
+	label?: string;
+	className?: string;
+}
+
+/**
+ * Standard top-left "← Back" affordance for the onboarding / setup screens. A
+ * quiet arrow-and-text link rather than a full-width button, so it reads as
+ * secondary navigation above the card's centered heading.
+ */
+export function BackLink({ onClick, label = 'Back', className = '' }: BackLinkProps) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			className={`inline-flex items-center gap-1 text-[13px] text-text-2 hover:text-text-1 transition-colors ${className}`}
+		>
+			<ArrowLeft className="w-4 h-4" />
+			{label}
+		</button>
+	);
+}

--- a/packages/web/src/components/ui/page-logo.tsx
+++ b/packages/web/src/components/ui/page-logo.tsx
@@ -1,0 +1,15 @@
+import { Logo } from './logo';
+
+/**
+ * Brand mark pinned to the top-left of a full-screen auth / onboarding / login
+ * page, mirroring where the logo sits in the signed-in app chrome. Absolutely
+ * positioned so it never shifts the centered card it sits over. The parent shell
+ * must be `relative`.
+ */
+export function PageLogo() {
+	return (
+		<div className="absolute left-0 top-0 p-4 sm:p-6">
+			<Logo size="md" wordmark />
+		</div>
+	);
+}

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -200,46 +200,13 @@ html.dark,
 	--color-neutral-soft-fg: #9a9a96;
 }
 
-/* `.vault-surface` opts a subtree into the "pre-active vault" palette — a deep,
-   cool indigo world used by the master-key screens (setup / unlock) to signal the
-   instance is NOT live yet, distinct from both the normal app and the password
-   login. Always dark regardless of the active theme. Like `.log-surface-dark` it
-   overrides the resolved `--color-*` vars directly (the `@theme` indirection is
-   resolved once at :root/html.dark) plus `--border` for the `*` fallback. The one
-   warm accent (Hezo vermilion) is reserved for the primary action. */
-.vault-surface {
-	--color-bg: oklch(0.108 0.022 264);
-	--color-surface: oklch(0.178 0.027 264);
-	--color-surface-2: oklch(0.22 0.029 264);
-	--color-surface-3: oklch(0.262 0.03 264);
-	--color-border: oklch(0.3 0.028 264);
-	--color-border-strong: oklch(0.39 0.03 264);
-	--border: oklch(0.3 0.028 264);
-
-	--color-text-1: oklch(0.955 0.006 260);
-	--color-text-2: oklch(0.7 0.018 262);
-	--color-text-3: oklch(0.54 0.018 262);
-	--color-inverse: oklch(0.955 0.006 260);
-	--color-inverse-fg: oklch(0.108 0.022 264);
-
-	--color-accent: oklch(0.635 0.205 31);
-	--color-accent-hover: oklch(0.685 0.19 31);
-	--color-accent-soft: oklch(0.3 0.085 28);
-	--color-accent-soft-fg: oklch(0.82 0.13 33);
-
-	--color-warning-soft: oklch(0.28 0.06 82);
-	--color-warning-soft-fg: oklch(0.84 0.12 82);
-	--color-danger: oklch(0.74 0.18 18);
-
-	/* Cool "secured" cyan — a hairline/eyebrow detail only, not the accent. */
-	--vault-seal: oklch(0.72 0.11 205);
-}
-
 /* Vertical-blind unlock reveal: an overlay of vertical strips that collapse
    upward once the master key is accepted, uncovering the app behind them. The
    strips are laid out flex-1 (width-agnostic → works at every breakpoint); the
    stagger comes from a per-strip inline `--i`. The last strip's `animationend`
-   drives the status refetch that swaps the gate out (see master-key-gate.tsx). */
+   drives the status refetch that swaps the gate out (see master-key-gate.tsx).
+   The strips read from the resolved theme tokens so the reveal matches the active
+   light/dark surface it is lifting away from. */
 @keyframes vault-blind {
 	from {
 		transform: scaleY(1);
@@ -258,8 +225,8 @@ html.dark,
 .vault-reveal-strip {
 	flex: 1 1 0;
 	transform-origin: top;
-	background: linear-gradient(180deg, oklch(0.178 0.027 264), oklch(0.108 0.022 264));
-	border-right: 1px solid oklch(1 0 0 / 0.03);
+	background: linear-gradient(180deg, var(--color-surface), var(--color-bg));
+	border-right: 1px solid var(--color-border);
 	animation: vault-blind 0.5s cubic-bezier(0.7, 0, 0.3, 1) both;
 	animation-delay: calc(var(--i) * 34ms);
 }

--- a/packages/web/test/master-key-setup.test.tsx
+++ b/packages/web/test/master-key-setup.test.tsx
@@ -1,7 +1,11 @@
 import { generateMnemonic } from '@hezo/shared';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
-import { afterEach, expect, test } from 'vitest';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, expect, test, vi } from 'vitest';
 import { MasterKeyForm } from '../src/components/master-key-gate';
+
+// Mirror the timing constants in master-key-gate.tsx.
+const SAVE_COUNTDOWN_SECONDS = 5;
+const REGEN_ANIM_MS = 1200;
 
 /** Reveal the grid, then read the 12 words back (strip the leading position number). */
 function revealedPhrase(): string {
@@ -12,8 +16,26 @@ function revealedPhrase(): string {
 		.join(' ');
 }
 
+/**
+ * Copy the generated key, run out the save countdown, and click Continue to reach
+ * the confirm step. Requires fake timers (the countdown ticks via chained 1s
+ * timeouts, flushed one render at a time).
+ */
+async function copyAndContinue(): Promise<void> {
+	fireEvent.click(screen.getByRole('button', { name: /copy to clipboard/i }));
+	// Resolve the async clipboard write so Continue replaces the copy button.
+	await act(async () => {});
+	for (let i = 0; i <= SAVE_COUNTDOWN_SECONDS; i++) {
+		await act(async () => {
+			vi.advanceTimersByTime(1000);
+		});
+	}
+	fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
+}
+
 afterEach(() => {
 	cleanup();
+	vi.useRealTimers();
 	// Remove any clipboard stub so it doesn't leak to other specs in the worker.
 	Reflect.deleteProperty(navigator, 'clipboard');
 });
@@ -28,11 +50,12 @@ test('setup generates a 12-word master key in a numbered grid', async () => {
 	for (let i = 0; i < words.length; i++) {
 		expect(words[i].textContent).toContain(String(i + 1));
 	}
-	// Copy affordance is present once the phrase is shown.
+	// Copy affordance is present once the phrase is shown; Continue is gated on it.
 	expect(screen.getByRole('button', { name: /copy to clipboard/i })).toBeTruthy();
+	expect(screen.queryByRole('button', { name: /continue/i })).toBeNull();
 });
 
-test('copy writes the space-joined phrase and toggles the label', async () => {
+test('copy writes the space-joined phrase and reveals Continue', async () => {
 	const calls: string[] = [];
 	Object.defineProperty(navigator, 'clipboard', {
 		value: {
@@ -52,7 +75,10 @@ test('copy writes the space-joined phrase and toggles the label', async () => {
 
 	expect(calls).toHaveLength(1);
 	expect(calls[0].split(' ')).toHaveLength(12);
-	await screen.findByText('Copied!');
+	// Copying swaps the copy button out for Continue (initially disabled by the countdown).
+	const cont = (await screen.findByRole('button', { name: /continue/i })) as HTMLButtonElement;
+	expect(cont.disabled).toBe(true);
+	expect(screen.queryByRole('button', { name: /copy to clipboard/i })).toBeNull();
 });
 
 test('unlock rejects an invalid phrase inline without authenticating', async () => {
@@ -99,53 +125,63 @@ test('the eye toggle reveals and re-hides the words', async () => {
 });
 
 test('the confirm step shows a masked entry field with a toggle', async () => {
+	vi.useFakeTimers();
 	render(<MasterKeyForm state="unset" embedded />);
 	fireEvent.click(screen.getByRole('button', { name: /generate master key/i }));
-	await screen.findAllByTestId('mnemonic-word');
-	fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
+	screen.getAllByTestId('mnemonic-word');
+	await copyAndContinue();
 
-	const field = (await screen.findByLabelText(/master key/i)) as HTMLInputElement;
+	const field = screen.getByLabelText(/master key/i) as HTMLInputElement;
 	expect(field.type).toBe('password');
 	expect(screen.getByRole('button', { name: /^show key$/i })).toBeTruthy();
 });
 
 test('the confirm step rejects a phrase that does not match the generated key', async () => {
+	vi.useFakeTimers();
 	render(<MasterKeyForm state="unset" embedded />);
 	fireEvent.click(screen.getByRole('button', { name: /generate master key/i }));
-	await screen.findAllByTestId('mnemonic-word');
-	fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
+	screen.getAllByTestId('mnemonic-word');
+	await copyAndContinue();
 
 	// A different valid phrase must not satisfy the paste-back check (no network hit).
-	fireEvent.change(await screen.findByLabelText(/master key/i), {
+	fireEvent.change(screen.getByLabelText(/master key/i), {
 		target: { value: generateMnemonic() },
 	});
-	fireEvent.click(screen.getByRole('button', { name: /set key & continue/i }));
+	fireEvent.click(screen.getByRole('button', { name: /confirm key and continue/i }));
+	await act(async () => {});
 
-	await screen.findByText(/doesn't match your master key/i);
+	expect(screen.getByText(/doesn't match your master key/i)).toBeTruthy();
 });
 
 test('Back returns from confirm to the generated key', async () => {
+	vi.useFakeTimers();
 	render(<MasterKeyForm state="unset" embedded />);
 	fireEvent.click(screen.getByRole('button', { name: /generate master key/i }));
-	await screen.findAllByTestId('mnemonic-word');
-	fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
-	await screen.findByLabelText(/master key/i);
+	screen.getAllByTestId('mnemonic-word');
+	await copyAndContinue();
+	expect(screen.getByLabelText(/master key/i)).toBeTruthy();
 
 	fireEvent.click(screen.getByRole('button', { name: /^back$/i }));
 
-	expect(await screen.findAllByTestId('mnemonic-word')).toHaveLength(12);
+	expect(screen.getAllByTestId('mnemonic-word')).toHaveLength(12);
+	// Already copied earlier, so the save gate stays open — Continue is available again.
 	expect(screen.getByRole('button', { name: /^continue$/i })).toBeTruthy();
 });
 
-test('Generate a new key replaces the phrase and re-masks it', async () => {
+test('the refresh control replaces the phrase and re-masks it', async () => {
+	vi.useFakeTimers();
 	render(<MasterKeyForm state="unset" embedded />);
 	fireEvent.click(screen.getByRole('button', { name: /generate master key/i }));
-	await screen.findAllByTestId('mnemonic-word');
+	screen.getAllByTestId('mnemonic-word');
 	const first = revealedPhrase();
 
 	fireEvent.click(screen.getByRole('button', { name: /generate a new key/i }));
+	// The words shimmer as placeholders, then the fresh phrase swaps in after the animation.
+	await act(async () => {
+		vi.advanceTimersByTime(REGEN_ANIM_MS);
+	});
 
-	const words = await screen.findAllByTestId('mnemonic-word');
+	const words = screen.getAllByTestId('mnemonic-word');
 	expect(words).toHaveLength(12);
 	// Re-masked after regenerating.
 	expect(words.every((w) => (w.textContent ?? '').includes('•'))).toBe(true);

--- a/test/browser/master-key-gate.spec.ts
+++ b/test/browser/master-key-gate.spec.ts
@@ -98,10 +98,13 @@ test('setup → password → provider, then restart → unlock → password logi
 	const phrase = (await words.allTextContents())
 		.map((t) => t.replace(/^\s*\d+\s*/, '').trim())
 		.join(' ');
-	// Confirm step: paste the phrase back to prove it was captured, then commit.
+	// Continue only appears after copying the key, and stays disabled through a
+	// short save countdown; clicking with an exact "Continue" name waits it out.
+	await page.getByRole('button', { name: /copy to clipboard/i }).click();
 	await page.getByRole('button', { name: 'Continue', exact: true }).click();
+	// Confirm step: paste the phrase back to prove it was captured, then commit.
 	await page.getByLabel(/master key/i).fill(phrase);
-	await page.getByRole('button', { name: /set key & continue/i }).click();
+	await page.getByRole('button', { name: /confirm key and continue/i }).click();
 
 	// The unlock reveal plays, then the wizard advances to the dedicated
 	// create-password step (the mnemonic only unlocked — no session yet).


### PR DESCRIPTION
## Summary

Reworks the master-key setup flow and standardizes the chrome across every setup / onboarding / login pane.

### Master-key setup screen
- **Brand logo moved to the top-left of the page** via a shared `PageLogo`, mirroring the signed-in app chrome. Applied to all auth panes (master-key gate, setup wizard, sign-in, reset). The key icon in the card header is kept.
- **Refresh-to-regenerate**: the "Generate a new key" button is replaced by a refresh control next to the "Your master key" label, with a tooltip. Regenerating shimmers the word grid for ~1.2s before the new phrase appears (respects `prefers-reduced-motion`).
- **Callout replaces the subtitle**: the one-line subtitle is dropped and the explanatory warning block sits directly under the title.
- **Copy-gated Continue**: Continue only appears after "Copy to clipboard" is clicked, then stays disabled through a 5-second save countdown ("Continue (5)…").
- **Confirm step**: subtitle reworded to "…You can always go back.", the button renamed to "Confirm key and continue", and Back moved to a top-left `←&nbsp;Back` link (shared `BackLink`). The same `BackLink` now standardizes the AI-provider picker's Back affordance.

### Setup wizard / auth panes
- Vault screens **follow the system theme** (light/dark) instead of forcing an always-dark palette; the unlock reveal strips are now theme-aware.
- **Narrower input panes on desktop** for the password step and the AI-provider credential form (`max-w-md`), so they no longer stretch across the full card.

## Testing
- `master-key-setup.test.tsx` updated for the copy → countdown → continue flow, the refresh regeneration animation (fake timers), and the renamed confirm button.
- `test/browser/master-key-gate.spec.ts` updated to copy before Continue and to use the renamed button.
- Re-ran the affected web suites (master-key, password-auth, ai-providers, onboarding, smoke) — all green. Typecheck and biome clean.
- Visually verified all three panes (master-key gate, wizard, sign-in) in light and dark themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VbBCgowMwWtzfjMB7BZAST)_