### PR TITLE
Update product tagline to "Built to ship"

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </div>
 
 <p align="center">
-  <strong>Your own AI workforce. Self-hosted and secure.</strong>
+  <strong>Your own AI workforce. Built to ship.</strong>
 </p>
 
 <p align="center">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "hezo",
-	"description": "Your own AI workforce. Self-hosted and secure.",
+	"description": "Your own AI workforce. Built to ship.",
 	"private": true,
 	"license": "GPL-3.0-or-later",
 	"packageManager": "bun@1.3.9",

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -3,19 +3,19 @@
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<title>Hezo — Your own AI workforce. Self-hosted and secure.</title>
+		<title>Hezo — Your own AI workforce. Built to ship.</title>
 		<meta
 			name="description"
 			content="Run a whole team of AI agents like a company — you set the goals, they ship the work, and you own everything they produce."
 		/>
 		<meta property="og:type" content="website" />
-		<meta property="og:title" content="Hezo — Your own AI workforce. Self-hosted and secure." />
+		<meta property="og:title" content="Hezo — Your own AI workforce. Built to ship." />
 		<meta
 			property="og:description"
 			content="Run a whole team of AI agents like a company — you set the goals, they ship the work, and you own everything they produce."
 		/>
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="Hezo — Your own AI workforce. Self-hosted and secure." />
+		<meta name="twitter:title" content="Hezo — Your own AI workforce. Built to ship." />
 		<meta
 			name="twitter:description"
 			content="Run a whole team of AI agents like a company — you set the goals, they ship the work, and you own everything they produce."


### PR DESCRIPTION
## Summary

Updates the product tagline from **"Your own AI workforce. Self-hosted and secure."** to **"Your own AI workforce. Built to ship."**

## Changes

- `package.json` — package `description`
- `README.md` — the tagline under the project header
- `packages/web/index.html` — `<title>`, `og:title`, and `twitter:title`

## Notes

- The web app's marketing/social metadata now reflects the new tagline.
- CHANGELOG entries referencing the previous tagline are historical records and are intentionally left unchanged.
- A companion PR in `hezo-ai/website` updates the same tagline on the site (footer headline, SEO/social title, and repo/package descriptions), while deliberately leaving the **website hero tagline unchanged**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018banVXHJARMbcQR9T9Y9H1

---
_Generated by [Claude Code](https://claude.ai/code/session_018banVXHJARMbcQR9T9Y9H1)_