### PR TITLE
feat: prefix task-mention tooltip title with bold task identifier

### DIFF
--- a/packages/web/src/components/markdown-prose.tsx
+++ b/packages/web/src/components/markdown-prose.tsx
@@ -391,7 +391,9 @@ export function MarkdownProse({
 						<Tooltip
 							content={
 								<span className="flex flex-col gap-1">
-									<span>{taskTitle}</span>
+									<span>
+										<strong>{taskIdentifier.toUpperCase()}:</strong> {taskTitle}
+									</span>
 									{taskStatus ? (
 										<TaskStatusBadge
 											status={taskStatus}

--- a/test/browser/task-mention-status.spec.ts
+++ b/test/browser/task-mention-status.spec.ts
@@ -77,8 +77,13 @@ test.describe('Task mention — status pill tooltip & terminal strikethrough', (
 		// content. Scope to the role="tooltip" panel — Radix also renders a hidden
 		// aria duplicate of the content that carries the same testId.
 		await mention.hover();
-		const pill = page.getByRole('tooltip').getByTestId('task-mention-status-pill');
+		const tooltip = page.getByRole('tooltip');
+		const pill = tooltip.getByTestId('task-mention-status-pill');
 		await expect(pill).toBeVisible({ timeout: 20_000 });
 		await expect(pill).toHaveText('Cancelled');
+		// The tooltip prefixes the task title with the bold task identifier.
+		await expect(tooltip).toContainText(
+			`${target.identifier.toUpperCase()}: Cancelled target task`,
+		);
 	});
 });


### PR DESCRIPTION
## Summary

The hover tooltip on a task @-mention (rendered by `markdown-prose.tsx`) showed only the task title. This prefixes it with the task identifier in **bold**, e.g. **TO-1:** Enable ..., so the tooltip makes clear which task it refers to at a glance.

## Changes

- `packages/web/src/components/markdown-prose.tsx` — task-mention tooltip content now renders `<strong>{taskIdentifier}:</strong> {taskTitle}` instead of the bare title. The identifier is upper-cased for display (consistent with `CommentRefLink`), followed by the existing status badge.
- `test/browser/task-mention-status.spec.ts` — extended the existing hover assertion to also verify the tooltip contains the `TO-1: <title>` prefix.

## Testing

- `bunx vitest run test/markdown-prose-mentions.test.tsx` — 8 passed (status→DOM threading + strikethrough coverage unaffected).
- `bunx biome check` — clean on both changed files.
- The hover→tooltip-content assertion lives in the browser tier because the status pill/tooltip only mounts its portal on a real pointer hover (happy-dom can't drive it); the new prefix assertion was added there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012C59VviZS8sRWFd51B6WS4

---
_Generated by [Claude Code](https://claude.ai/code/session_012C59VviZS8sRWFd51B6WS4)_