### PR TITLE
feat(web): collapsible project side menu

### DIFF
--- a/packages/web/src/components/project-sidebar.tsx
+++ b/packages/web/src/components/project-sidebar.tsx
@@ -1,6 +1,6 @@
 import { AgentAdminStatus } from '@hezo/shared';
 import { Link, useNavigate } from '@tanstack/react-router';
-import { AlertTriangle, Globe, Info, Loader2 } from 'lucide-react';
+import { AlertTriangle, ChevronsLeft, Globe, Info, Loader2 } from 'lucide-react';
 import { useState } from 'react';
 import { useActiveProject } from '../hooks/use-active-project';
 import { useAgents } from '../hooks/use-agents';
@@ -19,7 +19,7 @@ import { Tooltip } from './ui/tooltip';
  * follow; the backing team's agents close it out under a Team section. The team
  * is presented as the project's own — there is no separate team-level view.
  */
-export function ProjectSidebar() {
+export function ProjectSidebar({ onCollapse }: { onCollapse?: () => void } = {}) {
 	const active = useActiveProject();
 	const navigate = useNavigate();
 	const projectId = active?.slug ?? '';
@@ -241,7 +241,7 @@ export function ProjectSidebar() {
 					to="/projects/$projectId"
 					params={projectParams}
 					data-testid="project-sidebar-name"
-					className="block text-[13px] font-semibold text-text-1 truncate"
+					className="min-w-0 flex-1 text-[13px] font-semibold text-text-1 truncate"
 				>
 					{project ? (
 						isInternal ? (
@@ -265,6 +265,19 @@ export function ProjectSidebar() {
 							className="shrink-0 text-text-3 hover:text-text-1 transition-colors"
 						>
 							<Info className="w-3.5 h-3.5" aria-hidden="true" />
+						</button>
+					</Tooltip>
+				)}
+				{onCollapse && (
+					<Tooltip content="Collapse menu" side="bottom">
+						<button
+							type="button"
+							aria-label="Collapse menu"
+							data-testid="project-sidebar-collapse"
+							onClick={onCollapse}
+							className="ml-auto shrink-0 inline-flex h-6 w-6 items-center justify-center rounded-md text-text-3 transition-colors hover:bg-surface-2 hover:text-text-1"
+						>
+							<ChevronsLeft className="h-4 w-4" aria-hidden="true" />
 						</button>
 					</Tooltip>
 				)}

--- a/packages/web/src/hooks/use-project-menu-collapsed.ts
+++ b/packages/web/src/hooks/use-project-menu-collapsed.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+import { readStored, writeStored } from '../lib/safe-storage';
+
+const COLLAPSED_KEY = 'hezo:projectMenuCollapsed';
+const CHANGE_EVENT = 'hezo:projectMenuCollapsedChanged';
+
+function readCollapsed(): boolean {
+	return readStored(COLLAPSED_KEY) === '1';
+}
+
+/**
+ * Persist whether the project menu (the panel beside the project rail) is
+ * collapsed. Dispatches a window event so every mounted `useProjectMenuCollapsed`
+ * updates immediately — the collapse control lives in the menu header and the
+ * expand tab beside the rail, which are separate subtrees.
+ */
+export function setProjectMenuCollapsed(collapsed: boolean): void {
+	writeStored(COLLAPSED_KEY, collapsed ? '1' : '0');
+	if (typeof window !== 'undefined') {
+		window.dispatchEvent(new CustomEvent(CHANGE_EVENT, { detail: collapsed }));
+	}
+}
+
+/**
+ * Reads the persisted collapsed state and stays in sync with it. Returns a
+ * `[collapsed, setCollapsed]` tuple mirroring `useState`; the setter persists to
+ * localStorage and broadcasts to other readers. Defaults to expanded.
+ */
+export function useProjectMenuCollapsed(): [boolean, (collapsed: boolean) => void] {
+	const [collapsed, setCollapsed] = useState<boolean>(() => readCollapsed());
+
+	useEffect(() => {
+		const handler = () => setCollapsed(readCollapsed());
+		window.addEventListener(CHANGE_EVENT, handler);
+		return () => window.removeEventListener(CHANGE_EVENT, handler);
+	}, []);
+
+	return [collapsed, setProjectMenuCollapsed];
+}

--- a/packages/web/src/routes/__root.tsx
+++ b/packages/web/src/routes/__root.tsx
@@ -6,6 +6,7 @@ import {
 	useMatches,
 	useNavigate,
 } from '@tanstack/react-router';
+import { ChevronsRight } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AppHeader } from '../components/app-header';
 import { ChatWidget } from '../components/chat/chat-widget';
@@ -19,10 +20,12 @@ import { ScrollToBottomButton } from '../components/scroll-to-bottom-button';
 import { ScrollToTopButton } from '../components/scroll-to-top-button';
 import { CreatePasswordFlow, SetupGate } from '../components/setup/setup-wizard';
 import { StartingScreen } from '../components/starting-screen';
+import { Tooltip } from '../components/ui/tooltip';
 import { UpdateBanner } from '../components/update-banner';
 import { SocketProvider } from '../contexts/socket-context';
 import { useActiveProject } from '../hooks/use-active-project';
 import { useMe } from '../hooks/use-me';
+import { useProjectMenuCollapsed } from '../hooks/use-project-menu-collapsed';
 import { useProjectsIndex } from '../hooks/use-projects';
 import { useScrollToBottom } from '../hooks/use-scroll-to-bottom';
 import { useScrollToTop } from '../hooks/use-scroll-to-top';
@@ -160,6 +163,7 @@ interface ShellChromeProps {
 function ShellChrome({ drawerOpen, setDrawerOpen }: ShellChromeProps) {
 	const [searchOpen, setSearchOpen] = useState(false);
 	const active = useActiveProject();
+	const [menuCollapsed, setMenuCollapsed] = useProjectMenuCollapsed();
 	const mainRef = useRef<HTMLElement>(null);
 	// The scroll-to-bottom hook needs the <main> element as state (a ref never
 	// re-runs its effect), so a stable callback ref feeds both. Stable identity
@@ -227,16 +231,32 @@ function ShellChrome({ drawerOpen, setDrawerOpen }: ShellChromeProps) {
 				{/* Rail + project sidebar + scrollable main span the full viewport so
 				    the main-panel scrollbar sits on the browser edge, not mid-screen. */}
 				<div
-					className="flex flex-row flex-1 min-w-0 w-full overflow-hidden"
+					className="relative flex flex-row flex-1 min-w-0 w-full overflow-hidden"
 					data-testid="content-well"
 				>
 					<div className="hidden md:flex h-full">
 						<ProjectRail />
 					</div>
-					{active && (
-						<div className="hidden lg:block w-[208px] shrink-0 h-full overflow-y-auto border-r border-border bg-surface py-2">
-							<ProjectSidebar />
+					{active && !menuCollapsed && (
+						<div className="hidden lg:block w-[208px] shrink-0 h-full overflow-y-auto border-r border-border bg-surface pb-2">
+							<ProjectSidebar onCollapse={() => setMenuCollapsed(true)} />
 						</div>
+					)}
+					{/* Collapsed: a slim expand tab docked to the project rail's right
+					    edge, flush under the app header. Desktop-only — below lg the
+					    project menu is a drawer, so there is nothing to collapse. */}
+					{active && menuCollapsed && (
+						<Tooltip content="Expand menu" side="right">
+							<button
+								type="button"
+								aria-label="Expand menu"
+								data-testid="project-sidebar-expand"
+								onClick={() => setMenuCollapsed(false)}
+								className="absolute left-[60px] top-0 z-20 hidden h-[22px] w-7 items-center justify-center rounded-br-[9px] border border-l-0 border-t-0 border-border bg-surface text-text-2 shadow-sm transition-colors hover:text-text-1 lg:flex"
+							>
+								<ChevronsRight className="h-4 w-4" aria-hidden="true" />
+							</button>
+						</Tooltip>
 					)}
 					{/* The relative wrapper hosts the scroll-to-bottom pill as a sibling
 					    of the scroller, so the pill stays pinned over the content area

--- a/packages/web/test/project-menu-collapse.test.tsx
+++ b/packages/web/test/project-menu-collapse.test.tsx
@@ -1,0 +1,74 @@
+import { waitFor } from '@testing-library/react';
+import { beforeEach, expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+import { type SeededWorkspace, seedProject, seedWorkspace } from './helpers/seed';
+
+const COLLAPSED_KEY = 'hezo:projectMenuCollapsed';
+
+// The persisted collapse state leaks across tests in this file (localStorage is
+// shared within the happy-dom environment), so reset it before each.
+beforeEach(() => {
+	try {
+		localStorage.clear();
+	} catch {
+		// storage unavailable — ignore
+	}
+});
+
+test('collapsing hides the project menu and docks an expand tab to the rail; expanding restores it', async () => {
+	let projectSlug = '';
+	const { findByTestId, queryByTestId, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws: SeededWorkspace = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Operations' });
+			projectSlug = project.slug;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks',
+		params: { projectId: projectSlug },
+	});
+
+	// Expanded by default: the menu is shown with a collapse control, no expand tab.
+	await findByTestId('project-sidebar-name', undefined, { timeout: 15_000 });
+	expect(queryByTestId('project-sidebar-expand')).toBeNull();
+	const collapse = await findByTestId('project-sidebar-collapse');
+
+	// Collapse → the whole menu unmounts and the rail-docked expand tab appears,
+	// and the choice is persisted.
+	await user.click(collapse);
+	await findByTestId('project-sidebar-expand', undefined, { timeout: 15_000 });
+	await waitFor(() => expect(queryByTestId('project-sidebar-name')).toBeNull());
+	expect(localStorage.getItem(COLLAPSED_KEY)).toBe('1');
+
+	// Expand → the menu returns, the tab is gone, and the persisted flag clears.
+	await user.click(await findByTestId('project-sidebar-expand'));
+	await findByTestId('project-sidebar-name', undefined, { timeout: 15_000 });
+	expect(queryByTestId('project-sidebar-expand')).toBeNull();
+	expect(localStorage.getItem(COLLAPSED_KEY)).toBe('0');
+});
+
+test('a persisted collapsed state renders collapsed on first paint', async () => {
+	localStorage.setItem(COLLAPSED_KEY, '1');
+
+	let projectSlug = '';
+	const { findByTestId, queryByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws: SeededWorkspace = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Operations' });
+			projectSlug = project.slug;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks',
+		params: { projectId: projectSlug },
+	});
+
+	// It comes up collapsed: the expand tab is present and the menu is absent.
+	await findByTestId('project-sidebar-expand', undefined, { timeout: 15_000 });
+	expect(queryByTestId('project-sidebar-name')).toBeNull();
+});

--- a/test/browser/project-menu-collapse.spec.ts
+++ b/test/browser/project-menu-collapse.spec.ts
@@ -1,0 +1,70 @@
+// Real-CSS-layout + viewport-conditional assertions (testing decision tree,
+// points 1 and 2): the expand tab's docked position (flush under the app header,
+// against the project rail's right edge) is measured with boundingBox from the
+// real flex/absolute layout, and the whole affordance is gated `lg:` so it must
+// be exercised at a real desktop width — neither is computable in happy-dom.
+
+import { expect, test } from './fixtures';
+import { waitForPageLoad } from './helpers';
+
+test('the project menu collapses to a rail-docked expand tab and restores', async ({
+	page,
+	freshWorkspace,
+}) => {
+	await page.setViewportSize({ width: 1440, height: 900 });
+	await page.goto(`/projects/${freshWorkspace.projectSlug}/tasks`);
+	await waitForPageLoad(page);
+
+	// Expanded by default: the menu shows, no expand tab yet.
+	await expect(page.getByTestId('project-sidebar-name')).toBeVisible({ timeout: 20000 });
+	await expect(page.getByTestId('project-sidebar-expand')).toHaveCount(0);
+
+	// Collapse from the menu header.
+	await page.getByTestId('project-sidebar-collapse').click();
+
+	// The menu is gone and the slim expand tab appears.
+	await expect(page.getByTestId('project-sidebar-name')).toHaveCount(0);
+	const tab = page.getByTestId('project-sidebar-expand');
+	await expect(tab).toBeVisible();
+
+	// It's docked flush under the app header, against the project rail's right edge.
+	const header = await page.locator('header').first().boundingBox();
+	const rail = await page.getByTestId('project-rail').boundingBox();
+	const tabBox = await tab.boundingBox();
+	expect(header).not.toBeNull();
+	expect(rail).not.toBeNull();
+	expect(tabBox).not.toBeNull();
+	if (header && rail && tabBox) {
+		// Left edge sits at the rail's right edge (±1px sub-pixel rounding).
+		expect(Math.abs(tabBox.x - (rail.x + rail.width))).toBeLessThanOrEqual(1);
+		// Top edge sits flush under the header (±1px).
+		expect(Math.abs(tabBox.y - (header.y + header.height))).toBeLessThanOrEqual(1);
+		// It's the intended slim tab, not a tall button.
+		expect(tabBox.height).toBeLessThanOrEqual(24);
+	}
+
+	// Expand restores the menu and removes the tab.
+	await tab.click();
+	await expect(page.getByTestId('project-sidebar-name')).toBeVisible();
+	await expect(page.getByTestId('project-sidebar-expand')).toHaveCount(0);
+});
+
+test('the mobile drawer is unaffected — no collapse affordance there', async ({
+	page,
+	freshWorkspace,
+}) => {
+	await page.setViewportSize({ width: 375, height: 800 });
+	await page.goto(`/projects/${freshWorkspace.projectSlug}/tasks`);
+	await waitForPageLoad(page);
+
+	// The desktop collapse/expand controls never show on mobile.
+	await expect(page.getByTestId('project-sidebar-collapse')).toBeHidden();
+	await expect(page.getByTestId('project-sidebar-expand')).toHaveCount(0);
+
+	// Opening the drawer surfaces the project menu with no collapse button.
+	await page.getByTestId('mobile-nav-toggle').click();
+	const drawer = page.getByTestId('mobile-nav-drawer');
+	await expect(drawer).toBeVisible();
+	await expect(drawer.getByTestId('project-sidebar-name')).toBeVisible({ timeout: 20000 });
+	await expect(drawer.getByTestId('project-sidebar-collapse')).toHaveCount(0);
+});


### PR DESCRIPTION
## What

Makes the **project side menu** (the panel beside the project rail — Inbox / Progress / Tasks / … / Team) collapsible.

- **Expanded:** a collapse control (`«`) sits at the **top-right** of the menu header, flush under the app header. Collapsing hands the menu's ~208px back to the content area.
- **Collapsed:** a slim expand tab (`»`) docks **top-left**, flush against the project rail's right edge and just under the app header, to bring the menu back.

| Expanded | Collapsed |
|---|---|
| Collapse `«` top-right of the menu header | Menu hidden; slim `»` tab docked to the rail |

## How

- **`useProjectMenuCollapsed`** (`packages/web/src/hooks/use-project-menu-collapsed.ts`) — persists the choice per browser (`localStorage`, `hezo:projectMenuCollapsed`) with a `window`-event sync, mirroring the existing `useActiveTeamSlug` + `safe-storage` pattern, so a collapse sticks across reloads.
- **`ProjectSidebar`** takes an optional `onCollapse` prop; the collapse button renders only when it's passed (i.e. the shell), so the **mobile drawer is untouched**.
- **`__root.tsx` shell** reads the hook, gates the 208px panel on `!collapsed`, and renders the rail-docked expand tab when collapsed. Desktop-only (`lg+`) — below `lg` the menu is already a hamburger drawer, unchanged.

## Testing

- **Component** (`packages/web/test/project-menu-collapse.test.tsx`): collapse hides the menu and shows the expand tab, expand restores it, and the choice persists (incl. rendering collapsed on first paint from a persisted flag).
- **Browser** (`test/browser/project-menu-collapse.spec.ts`): verifies the expand tab's real-CSS-layout placement (docked at the rail's right edge, flush under the header, slim height) and that the **mobile drawer** carries no collapse control.
- Full `typecheck` + `build` (pre-commit hook) and the existing sidebar/rail/header suites (33 tests) pass with no regressions.

## Notes

- Frontend-only change; no data-model, API, or user-doc surface is affected (no `docs/` page enumerates shell chrome, so nothing to sync there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FMUw38F8tZs2471jYmKcRA

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMUw38F8tZs2471jYmKcRA)_