### PR TITLE
feat(connectors): add direct-API connector transport

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -1215,6 +1215,20 @@ connectors UI treats a non-revoked, non-failed local row as **connected the
 moment it exists** (`statusOf`/`connectorStatus` short-circuit `kind='local'` to `active`)
 rather than showing it a meaningless "Pending connect" OAuth affordance.
 
+`kind='api'` is a **direct-REST connector with no MCP server** — for backends that expose a
+plain HTTP API rather than MCP (e.g. Google's APIs). Its `config` carries
+`{ base_url, allowed_hosts, auth: { placement: 'header'|'query', name, scheme? }, docs_url? }`
+and it links a pasted credential via `api_key_secret_id` (the same vault link as an
+api-key saas row; the `/api-key` route scopes the secret's `allowed_hosts` to the config's
+hosts / `base_url` host). An `api` connector has **no MCP descriptor** — `loadConnectorDescriptors`
+skips it — and is instead surfaced to the agent through `list_connectors`, which emits an
+`api_auth = { base_url, placeholder, allowed_hosts, placement, name, docs_url }` block (the
+`placeholder` is null until a credential is attached). The agent puts the `__HEZO_SECRET_*__`
+placeholder in the named header/query and calls `base_url` directly; the egress proxy
+substitutes the real key at request time, scoped to `allowed_hosts` — the same red-line-safe
+path as any other placeholder, with the secret never entering the run. This is the most
+red-line-native transport: a credential only ever appears as a placeholder in a header/URL.
+
 **Connector auth must traverse the egress proxy.** Because connector auth is a placeholder,
 each coding CLI's MCP-startup HTTP MUST go through the per-run proxy or the placeholder ships
 unsubstituted and 401s (a fail-closed usability miss, never a leak — § 7). All five runtimes

--- a/docs/reference/mcp-api.md
+++ b/docs/reference/mcp-api.md
@@ -886,7 +886,7 @@ Fetch a remote agent skill file (Markdown describing how to use a third-party MC
 
 _Read-only._
 
-List the MCP server connections available to agent runs in your project (its own connectors plus global "all projects" ones; a project connector shadows a global one of the same name). Each row includes a derived `oauth_status` so you can tell whether a connector is usable: "active" means OAuth completed and the MCP tools should appear in your tool list on your next run; "pending" means waiting on the human to click Connect; "failed" means the OAuth flow errored (see auth_error); "revoked" means a human disconnected it; "none" means no OAuth needed (e.g., an env-var-token MCP or a public one). Do NOT confuse `install_status` (which tracks local-package install state and is meaningless for SaaS MCPs) with `oauth_status`. An active OAuth-backed connector also carries `rest_auth` = `{ placeholder, allowed_hosts, scopes }`: put `placeholder` (e.g. in an `Authorization: Bearer <placeholder>` header) on a raw HTTP request to authenticate the provider's REST API directly when no MCP tool covers what you need — the egress proxy substitutes the real token, but ONLY for requests to `allowed_hosts`; you never see the value. Use this instead of requesting a PAT (e.g. for GitHub repo-settings edits that the `github` MCP does not expose).
+List the connectors available to agent runs in your project (its own connectors plus global "all projects" ones; a project connector shadows a global one of the same name). Each row includes a derived `oauth_status` so you can tell whether a connector is usable: "active" means OAuth completed and the MCP tools should appear in your tool list on your next run; "pending" means waiting on the human to click Connect; "failed" means the OAuth flow errored (see auth_error); "revoked" means a human disconnected it; "none" means no OAuth needed (e.g., an env-var-token MCP or a public one). Do NOT confuse `install_status` (which tracks local-package install state and is meaningless for SaaS MCPs) with `oauth_status`. An active OAuth-backed connector also carries `rest_auth` = `{ placeholder, allowed_hosts, scopes }`: put `placeholder` (e.g. in an `Authorization: Bearer <placeholder>` header) on a raw HTTP request to authenticate the provider's REST API directly when no MCP tool covers what you need — the egress proxy substitutes the real token, but ONLY for requests to `allowed_hosts`; you never see the value. Use this instead of requesting a PAT (e.g. for GitHub repo-settings edits that the `github` MCP does not expose). A connector of kind `api` (a credentialed REST API with no MCP server) carries `api_auth` = `{ base_url, placeholder, allowed_hosts, placement, name, docs_url }` instead: put `placeholder` in the `name` header (when `placement` is "header", prefixed by any scheme) or `name` query parameter (when `placement` is "query") and send the request to `base_url` — the egress proxy substitutes the real key, scoped to `allowed_hosts`. `placeholder` is null until a human attaches the credential on the Connectors page; `api_auth` is null for non-api rows.
 
 **Parameters:**
 
@@ -915,7 +915,7 @@ Test an MCP connector end-to-end from the server side. Resolves the stored OAuth
 
 _Write tool._
 
-Register an MCP server (SaaS HTTP or local stdio) for your project. The connection is scoped to your project — available to this project's agent runs, alongside any global "all projects" connectors. SaaS servers go into the agent's descriptor list immediately. Header values may include __HEZO_SECRET_<NAME>__ placeholders that the egress proxy substitutes at request time. Local servers must be installed before they take effect.
+Register a connector for your project — a SaaS HTTP MCP server (`saas`), a local stdio MCP server (`local`), or a credentialed REST API you call directly with no MCP server (`api`). The connection is scoped to your project — available to this project's agent runs, alongside any global "all projects" connectors. SaaS servers go into the agent's descriptor list immediately. Header values may include __HEZO_SECRET_<NAME>__ placeholders that the egress proxy substitutes at request time. Local servers must be installed before they take effect. An `api` connector has no MCP server: attach a credential to it (Connectors page → API key) and it surfaces in `list_connectors` as an `api_auth` block whose placeholder you put in the auth header/query and send to `base_url` directly — the egress proxy substitutes, scoped to `allowed_hosts`.
 
 **Parameters:**
 
@@ -923,8 +923,8 @@ Register an MCP server (SaaS HTTP or local stdio) for your project. The connecti
 | --- | --- | --- | --- |
 | `project` | `string` | No | Project slug or ID. Omit to use the project your run is already in; instance agents (CEO/Coach) must name the project to act in. |
 | `name` | `string` | Yes | Server identifier — used as the MCP descriptor name and as the unique key. |
-| `kind` | `saas` \| `local` | Yes | saas = HTTP MCP, local = stdio MCP |
-| `config` | `object` | Yes | For saas: { url, headers? }. For local: { command, args?, env?, package? }. |
+| `kind` | `saas` \| `local` \| `api` | Yes | saas = HTTP MCP, local = stdio MCP, api = direct REST API (no MCP server) |
+| `config` | `object` | Yes | For saas: { url, headers? }. For local: { command, args?, env?, package? }. For api: { base_url, allowed_hosts: string[], auth: { placement: "header"\|"query", name, scheme? }, docs_url? }. |
 
 **Returns:** `{ id, install_status, note }`, or `{ error }` if `config.url` (saas) / `config.command` (local) is missing. Upserts by `name` within your project.
 

--- a/packages/server/migrations/027_add_api_connector_transport.sql
+++ b/packages/server/migrations/027_add_api_connector_transport.sql
@@ -1,0 +1,13 @@
+-- Add the `api` connector transport to the `mcp_connection_kind` enum. This is a
+-- third connector transport alongside `saas` (remote MCP HTTP) and `local` (stdio
+-- MCP): a credentialed REST API the agent calls directly through the egress proxy,
+-- with no MCP server. An `api` connector has no MCP descriptor — it is surfaced via
+-- `list_connectors` (as an `api_auth` block) and authenticated at egress only.
+--
+-- This is a purely additive enum extension. Postgres 12+ (PGlite is PG16) permits
+-- ALTER TYPE ... ADD VALUE inside a transaction as long as the new value is not
+-- *used* in the same transaction — this migration only adds it, so it is safe under
+-- the runner's per-migration BEGIN/COMMIT (same pattern as 007_add_xai_provider).
+-- Existing `mcp_connections` rows keep their `kind`; the new value simply becomes
+-- selectable for future inserts.
+ALTER TYPE mcp_connection_kind ADD VALUE IF NOT EXISTS 'api';

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -97,6 +97,7 @@ import { broadcastApprovalChange } from '../services/approval-broadcast';
 import { resolveApproval } from '../services/approval-resolve';
 import { upsertChatMemory } from '../services/chat-memory';
 import { fireCommentWakeups, postAgentComment } from '../services/comment-wakeups';
+import { validateApiConnectorConfig } from '../services/connectors/connections';
 import type { ContainerDeps } from '../services/containers';
 import { enqueueTeamCoherenceReviewTask } from '../services/description-tasks';
 import {
@@ -4446,7 +4447,7 @@ export function registerTools(
 	tool(
 		server,
 		'list_connectors',
-		'List the MCP server connections available to agent runs in your project (its own connectors plus global "all projects" ones; a project connector shadows a global one of the same name). Each row includes a derived `oauth_status` so you can tell whether a connector is usable: "active" means OAuth completed and the MCP tools should appear in your tool list on your next run; "pending" means waiting on the human to click Connect; "failed" means the OAuth flow errored (see auth_error); "revoked" means a human disconnected it; "none" means no OAuth needed (e.g., an env-var-token MCP or a public one). Do NOT confuse `install_status` (which tracks local-package install state and is meaningless for SaaS MCPs) with `oauth_status`. An active OAuth-backed connector also carries `rest_auth` = `{ placeholder, allowed_hosts, scopes }`: put `placeholder` (e.g. in an `Authorization: Bearer <placeholder>` header) on a raw HTTP request to authenticate the provider\'s REST API directly when no MCP tool covers what you need — the egress proxy substitutes the real token, but ONLY for requests to `allowed_hosts`; you never see the value. Use this instead of requesting a PAT (e.g. for GitHub repo-settings edits that the `github` MCP does not expose).',
+		'List the connectors available to agent runs in your project (its own connectors plus global "all projects" ones; a project connector shadows a global one of the same name). Each row includes a derived `oauth_status` so you can tell whether a connector is usable: "active" means OAuth completed and the MCP tools should appear in your tool list on your next run; "pending" means waiting on the human to click Connect; "failed" means the OAuth flow errored (see auth_error); "revoked" means a human disconnected it; "none" means no OAuth needed (e.g., an env-var-token MCP or a public one). Do NOT confuse `install_status` (which tracks local-package install state and is meaningless for SaaS MCPs) with `oauth_status`. An active OAuth-backed connector also carries `rest_auth` = `{ placeholder, allowed_hosts, scopes }`: put `placeholder` (e.g. in an `Authorization: Bearer <placeholder>` header) on a raw HTTP request to authenticate the provider\'s REST API directly when no MCP tool covers what you need — the egress proxy substitutes the real token, but ONLY for requests to `allowed_hosts`; you never see the value. Use this instead of requesting a PAT (e.g. for GitHub repo-settings edits that the `github` MCP does not expose). A connector of kind `api` (a credentialed REST API with no MCP server) carries `api_auth` = `{ base_url, placeholder, allowed_hosts, placement, name, docs_url }` instead: put `placeholder` in the `name` header (when `placement` is "header", prefixed by any scheme) or `name` query parameter (when `placement` is "query") and send the request to `base_url` — the egress proxy substitutes the real key, scoped to `allowed_hosts`. `placeholder` is null until a human attaches the credential on the Connectors page; `api_auth` is null for non-api rows.',
 		{
 			project: projectArg(),
 		},
@@ -4460,6 +4461,7 @@ export function registerTools(
 				kind: string;
 				config: Record<string, unknown>;
 				oauth_connection_id: string | null;
+				api_key_secret_id: string | null;
 				install_status: string;
 				install_error: string | null;
 				skill_id: string | null;
@@ -4473,17 +4475,21 @@ export function registerTools(
 				oauth_allowed_hosts: string[] | null;
 				oauth_scopes: string[] | null;
 				oauth_account_label: string | null;
+				api_key_secret_name: string | null;
 			}>(
 				`SELECT mc.id, mc.name, mc.display_name, mc.kind::text AS kind,
-				        mc.config, mc.oauth_connection_id, mc.install_status::text AS install_status, mc.install_error,
+				        mc.config, mc.oauth_connection_id, mc.api_key_secret_id,
+				        mc.install_status::text AS install_status, mc.install_error,
 				        mc.skill_id, mc.created_by_task_id,
 				        mc.activated_at::text AS activated_at, mc.revoked_at::text AS revoked_at, mc.auth_error,
 				        mc.created_at::text, mc.updated_at::text,
 				        s.name AS oauth_secret_name, s.allowed_hosts AS oauth_allowed_hosts, oc.scopes AS oauth_scopes,
-				        oc.provider_account_label AS oauth_account_label
+				        oc.provider_account_label AS oauth_account_label,
+				        aks.name AS api_key_secret_name
 				 FROM mcp_connections mc
 				 LEFT JOIN oauth_connections oc ON oc.id = mc.oauth_connection_id
 				 LEFT JOIN secrets s ON s.id = oc.access_token_secret_id
+				 LEFT JOIN secrets aks ON aks.id = mc.api_key_secret_id
 				 WHERE mc.project_id = $1 OR mc.project_id IS NULL
 				 ORDER BY mc.name ASC, (mc.project_id IS NULL) ASC`,
 				[scope.projectId],
@@ -4514,7 +4520,13 @@ export function registerTools(
 				// agent can hit endpoints the MCP server doesn't cover without ever
 				// requesting a PAT. Omitted unless the token is scoped to at least one
 				// host, since an unscoped secret can never be substituted.
-				const { oauth_secret_name, oauth_allowed_hosts, oauth_scopes, ...rest } = row;
+				const {
+					oauth_secret_name,
+					oauth_allowed_hosts,
+					oauth_scopes,
+					api_key_secret_name,
+					...rest
+				} = row;
 				const rest_auth =
 					oauth_status === 'active' && oauth_secret_name && (oauth_allowed_hosts?.length ?? 0) > 0
 						? {
@@ -4523,7 +4535,36 @@ export function registerTools(
 								scopes: oauth_scopes ?? [],
 							}
 						: null;
-				return { ...rest, oauth_status, rest_auth };
+
+				// For an `api` connector (a direct REST API, no MCP server), surface how
+				// to call it: base_url + auth placement/name, and — once a credential is
+				// attached — the `__HEZO_SECRET_*__` placeholder to put in that
+				// header/query. The agent hits base_url directly and the egress proxy
+				// substitutes the real key, scoped to allowed_hosts. Null placeholder
+				// until a key is attached; the whole block is null for non-api rows.
+				const apiCfg = row.config as {
+					base_url?: unknown;
+					allowed_hosts?: unknown;
+					auth?: { placement?: unknown; name?: unknown };
+					docs_url?: unknown;
+				} | null;
+				const api_auth =
+					row.kind === 'api' && apiCfg
+						? {
+								base_url: typeof apiCfg.base_url === 'string' ? apiCfg.base_url : null,
+								placeholder: api_key_secret_name
+									? credentialPlaceholder(api_key_secret_name)
+									: null,
+								allowed_hosts: Array.isArray(apiCfg.allowed_hosts) ? apiCfg.allowed_hosts : [],
+								placement:
+									apiCfg.auth && typeof apiCfg.auth.placement === 'string'
+										? apiCfg.auth.placement
+										: null,
+								name: apiCfg.auth && typeof apiCfg.auth.name === 'string' ? apiCfg.auth.name : null,
+								docs_url: typeof apiCfg.docs_url === 'string' ? apiCfg.docs_url : null,
+							}
+						: null;
+				return { ...rest, oauth_status, rest_auth, api_auth };
 			});
 		},
 		db,
@@ -4637,7 +4678,7 @@ export function registerTools(
 	tool(
 		server,
 		'add_connector',
-		'Register an MCP server (SaaS HTTP or local stdio) for your project. The connection is scoped to your project — available to this project\'s agent runs, alongside any global "all projects" connectors. SaaS servers go into the agent\'s descriptor list immediately. Header values may include __HEZO_SECRET_<NAME>__ placeholders that the egress proxy substitutes at request time. Local servers must be installed before they take effect.',
+		'Register a connector for your project — a SaaS HTTP MCP server (`saas`), a local stdio MCP server (`local`), or a credentialed REST API you call directly with no MCP server (`api`). The connection is scoped to your project — available to this project\'s agent runs, alongside any global "all projects" connectors. SaaS servers go into the agent\'s descriptor list immediately. Header values may include __HEZO_SECRET_<NAME>__ placeholders that the egress proxy substitutes at request time. Local servers must be installed before they take effect. An `api` connector has no MCP server: attach a credential to it (Connectors page → API key) and it surfaces in `list_connectors` as an `api_auth` block whose placeholder you put in the auth header/query and send to `base_url` directly — the egress proxy substitutes, scoped to `allowed_hosts`.',
 		{
 			project: projectArg(),
 			name: z
@@ -4645,30 +4686,40 @@ export function registerTools(
 				.trim()
 				.min(1, 'name is required')
 				.describe('Server identifier — used as the MCP descriptor name and as the unique key.'),
-			kind: z.enum(['saas', 'local']).describe('saas = HTTP MCP, local = stdio MCP'),
+			kind: z
+				.enum(['saas', 'local', 'api'])
+				.describe('saas = HTTP MCP, local = stdio MCP, api = direct REST API (no MCP server)'),
 			config: z
 				.record(z.string(), z.unknown())
-				.describe('For saas: { url, headers? }. For local: { command, args?, env?, package? }.'),
+				.describe(
+					'For saas: { url, headers? }. For local: { command, args?, env?, package? }. For api: { base_url, allowed_hosts: string[], auth: { placement: "header"|"query", name, scheme? }, docs_url? }.',
+				),
 		},
 		async (args, db, auth) => {
 			const scope = await resolveScope(db, auth, args);
 			if ('error' in scope) return scope;
 			// name non-empty enforced by the schema; kind is a schema enum.
 			const name = (args.name as string).trim();
-			const kind = args.kind as 'saas' | 'local';
-			const config = args.config as Record<string, unknown>;
+			const kind = args.kind as 'saas' | 'local' | 'api';
+			let config = args.config as Record<string, unknown>;
 
 			if (kind === 'saas') {
 				if (!config?.url || typeof config.url !== 'string') {
 					return { error: 'saas connections require config.url (string)' };
 				}
+			} else if (kind === 'api') {
+				const validated = validateApiConnectorConfig(config);
+				if (!validated.ok) return { error: validated.error };
+				config = validated.config as unknown as Record<string, unknown>;
 			} else {
 				if (!config?.command || typeof config.command !== 'string') {
 					return { error: 'local connections require config.command (string)' };
 				}
 			}
 
-			const initialStatus = kind === 'saas' ? 'installed' : 'pending';
+			// api behaves like saas for install state (nothing to install — it's a
+			// direct REST call); only local needs an installer pass.
+			const initialStatus = kind === 'local' ? 'pending' : 'installed';
 			const r = await db.query<{
 				id: string;
 				install_status: string;
@@ -4684,13 +4735,16 @@ export function registerTools(
 				 RETURNING id, install_status::text AS install_status`,
 				[name, kind, JSON.stringify(config), initialStatus, scope.projectId],
 			);
+			const note =
+				kind === 'local'
+					? 'Local MCP registered with status pending. Install via the installer or container provision before agent runs can use it.'
+					: kind === 'api'
+						? 'API connector registered. Attach a credential (Connectors page → API key), then call list_connectors to get its api_auth placeholder + base_url.'
+						: 'SaaS MCP registered. Will be available to the next agent run in this scope.';
 			return {
 				id: r.rows[0].id,
 				install_status: r.rows[0].install_status,
-				note:
-					kind === 'local'
-						? 'Local MCP registered with status pending. Install via the installer or container provision before agent runs can use it.'
-						: 'SaaS MCP registered. Will be available to the next agent run in this scope.',
+				note,
 			};
 		},
 		db,

--- a/packages/server/src/routes/connectors.ts
+++ b/packages/server/src/routes/connectors.ts
@@ -10,6 +10,7 @@ import { isUniqueViolation, withTransaction } from '../lib/sql';
 import type { Env } from '../lib/types';
 import { logger } from '../logger';
 import { requireAdminEquivalent } from '../middleware/auth';
+import { validateApiConnectorConfig } from '../services/connectors/connections';
 import {
 	createOrFetchConnector,
 	fireCredentialProvidedWakeup,
@@ -92,7 +93,7 @@ connectorsRoutes.post('/connectors', async (c) => {
 	const body = await c.req.json<{
 		name: string;
 		display_name?: string;
-		kind: 'saas' | 'local';
+		kind: 'saas' | 'api';
 		config: Record<string, unknown>;
 		project_id?: string | null;
 	}>();
@@ -100,12 +101,22 @@ connectorsRoutes.post('/connectors', async (c) => {
 	if (!body.name?.trim()) {
 		return err(c, 'INVALID_REQUEST', 'name is required', 400);
 	}
-	if (body.kind !== ConnectorTransport.Saas) {
-		return err(c, 'INVALID_REQUEST', 'connectors must be "saas" (remote MCP url)', 400);
+	// The admin surface manages remote (`saas`) MCP servers and direct-REST (`api`)
+	// connectors — local (stdio) MCPs carry per-container install state and are
+	// managed on the project page only.
+	if (body.kind !== ConnectorTransport.Saas && body.kind !== ConnectorTransport.Api) {
+		return err(c, 'INVALID_REQUEST', 'connectors must be "saas" (remote MCP url) or "api"', 400);
 	}
-	const url = body.config?.url;
-	if (typeof url !== 'string' || !url) {
-		return err(c, 'INVALID_REQUEST', 'saas connections require config.url (string)', 400);
+	let config = body.config;
+	if (body.kind === ConnectorTransport.Api) {
+		const validated = validateApiConnectorConfig(config);
+		if (!validated.ok) return err(c, 'INVALID_REQUEST', validated.error, 400);
+		config = validated.config as unknown as Record<string, unknown>;
+	} else {
+		const url = body.config?.url;
+		if (typeof url !== 'string' || !url) {
+			return err(c, 'INVALID_REQUEST', 'saas connections require config.url (string)', 400);
+		}
 	}
 
 	// The admin surface may target a specific project (from the scope dropdown) or
@@ -143,7 +154,7 @@ connectorsRoutes.post('/connectors', async (c) => {
 			body.name.trim(),
 			body.display_name?.trim() ?? null,
 			body.kind,
-			JSON.stringify(body.config),
+			JSON.stringify(config),
 			projectId,
 		],
 	);
@@ -347,12 +358,16 @@ function apiKeySecretName(connectorName: string, projectId: string | null): stri
 }
 
 /**
- * Attach a pasted API key to a connector whose provider exposes no OAuth (e.g.
- * Typefully). The key is encrypted into the vault, scoped by allowed_hosts to
- * the MCP server host, and referenced from the connector via api_key_secret_id.
- * The raw key NEVER touches the agent run — the descriptor emits a
- * `__HEZO_SECRET_*__` placeholder and the egress proxy substitutes at request
- * time (AGENTS.md red line). Response-driven (security-sensitive).
+ * Attach a pasted API key to a connector whose provider exposes no OAuth. Covers
+ * both a `saas` MCP whose server takes a bearer/API key (e.g. Typefully) and an
+ * `api` connector (a direct REST API with no MCP server). The key is encrypted
+ * into the vault, scoped by allowed_hosts (the saas MCP host, or the api
+ * connector's `allowed_hosts` / `base_url` host), and referenced from the
+ * connector via api_key_secret_id. The raw key NEVER touches the agent run — a
+ * saas descriptor emits a `__HEZO_SECRET_*__` placeholder and an api connector
+ * surfaces the same placeholder via `list_connectors`; the egress proxy
+ * substitutes at request time (AGENTS.md red line). Response-driven
+ * (security-sensitive).
  */
 connectorsRoutes.post('/projects/:projectId/connectors/:id/api-key', async (c) => {
 	const teamId = c.get('teamId') as string;
@@ -367,8 +382,7 @@ connectorsRoutes.post('/projects/:projectId/connectors/:id/api-key', async (c) =
 	const value = typeof body.value === 'string' ? body.value.trim() : '';
 	if (!value) return err(c, 'INVALID_REQUEST', 'value is required', 400);
 
-	// Scoped load: the connector must belong to this project (or be global) and be
-	// a saas MCP with a url — API-key auth is an HTTP header on the MCP endpoint.
+	// Scoped load: the connector must belong to this project (or be global).
 	const existing = await db.query<{
 		id: string;
 		name: string;
@@ -388,28 +402,60 @@ connectorsRoutes.post('/projects/:projectId/connectors/:id/api-key', async (c) =
 	// A revoked connector is restored in place: pasting a key is a fresh reconnect
 	// rather than an error. markApiKeyActive below clears revoked_at and re-stamps
 	// activated_at as part of attaching the new key.
-	if (conn.kind !== ConnectorTransport.Saas) {
-		return err(c, 'INVALID_REQUEST', 'API-key auth applies to saas MCP connectors', 400);
-	}
-	const url = typeof conn.config?.url === 'string' ? (conn.config.url as string) : '';
-	let host = '';
-	try {
-		host = new URL(url).host.toLowerCase();
-	} catch {
-		return err(c, 'INVALID_REQUEST', 'connector has no valid MCP server url', 400);
+	//
+	// Determine the host(s) the pasted key is scoped to. For a `saas` MCP the key
+	// rides an HTTP header on the MCP endpoint, so it's scoped to that url's host.
+	// For an `api` connector (direct REST) it's scoped to the config's
+	// `allowed_hosts` (falling back to the `base_url` host). Local (stdio) rows
+	// authenticate via request_credential, not this route.
+	let allowedHosts: string[];
+	if (conn.kind === ConnectorTransport.Saas) {
+		const url = typeof conn.config?.url === 'string' ? (conn.config.url as string) : '';
+		try {
+			allowedHosts = [new URL(url).host.toLowerCase()];
+		} catch {
+			return err(c, 'INVALID_REQUEST', 'connector has no valid MCP server url', 400);
+		}
+	} else if (conn.kind === ConnectorTransport.Api) {
+		const cfgHosts = Array.isArray(conn.config?.allowed_hosts)
+			? (conn.config.allowed_hosts as unknown[]).filter(
+					(h): h is string => typeof h === 'string' && h.trim().length > 0,
+				)
+			: [];
+		if (cfgHosts.length > 0) {
+			allowedHosts = [...new Set(cfgHosts.map((h) => h.trim().toLowerCase()))];
+		} else {
+			const baseUrl =
+				typeof conn.config?.base_url === 'string' ? (conn.config.base_url as string) : '';
+			try {
+				allowedHosts = [new URL(baseUrl).host.toLowerCase()];
+			} catch {
+				return err(c, 'INVALID_REQUEST', 'connector has no valid base_url', 400);
+			}
+		}
+	} else {
+		return err(c, 'INVALID_REQUEST', 'API-key auth applies to saas or api connectors', 400);
 	}
 
 	const encryptionKey = masterKeyManager.getKey();
 	if (!encryptionKey) return err(c, 'LOCKED', 'Master key not available', 503);
 
-	// Header/scheme override (the form's "Advanced" disclosure). Default to
+	// Header/scheme override (the form's "Advanced" disclosure) — a saas concept:
+	// which header the placeholder rides in on the MCP descriptor. Default to
 	// `Authorization` / `Bearer ` — covers most MCP servers incl. Typefully. An
 	// explicit empty scheme lets a provider take the raw key (e.g. `X-API-Key`).
+	// An `api` connector already carries its placement/name/scheme in `config.auth`
+	// (there is no MCP descriptor), so no `config.apiKey` is written for it.
 	const header =
-		typeof body.header === 'string' && body.header.trim().length > 0
+		conn.kind === ConnectorTransport.Saas &&
+		typeof body.header === 'string' &&
+		body.header.trim().length > 0
 			? body.header.trim()
 			: undefined;
-	const scheme = typeof body.scheme === 'string' ? body.scheme : undefined;
+	const scheme =
+		conn.kind === ConnectorTransport.Saas && typeof body.scheme === 'string'
+			? body.scheme
+			: undefined;
 	const apiKeyConfig =
 		header !== undefined || scheme !== undefined
 			? { ...(header !== undefined ? { header } : {}), ...(scheme !== undefined ? { scheme } : {}) }
@@ -431,7 +477,7 @@ connectorsRoutes.post('/projects/:projectId/connectors/:id/api-key', async (c) =
 			       allowed_hosts = EXCLUDED.allowed_hosts,
 			       updated_at = now()
 			 RETURNING id`,
-			[secretName, encrypt(value, encryptionKey), [host]],
+			[secretName, encrypt(value, encryptionKey), allowedHosts],
 		);
 		return markApiKeyActive(db, conn.id, secret.rows[0].id, apiKeyConfig);
 	});
@@ -467,7 +513,7 @@ connectorsRoutes.post('/projects/:projectId/connectors', async (c) => {
 
 	const body = await c.req.json<{
 		name: string;
-		kind: 'saas' | 'local';
+		kind: 'saas' | 'local' | 'api';
 		config: Record<string, unknown>;
 		oauth_connection_id?: string | null;
 	}>();
@@ -475,14 +521,23 @@ connectorsRoutes.post('/projects/:projectId/connectors', async (c) => {
 	if (!body.name?.trim()) {
 		return err(c, 'INVALID_REQUEST', 'name is required', 400);
 	}
-	if (body.kind !== ConnectorTransport.Saas && body.kind !== ConnectorTransport.Local) {
-		return err(c, 'INVALID_REQUEST', 'kind must be "saas" or "local"', 400);
+	if (
+		body.kind !== ConnectorTransport.Saas &&
+		body.kind !== ConnectorTransport.Local &&
+		body.kind !== ConnectorTransport.Api
+	) {
+		return err(c, 'INVALID_REQUEST', 'kind must be "saas", "local", or "api"', 400);
 	}
+	let config = body.config;
 	if (body.kind === ConnectorTransport.Saas) {
 		const url = body.config?.url;
 		if (typeof url !== 'string' || !url) {
 			return err(c, 'INVALID_REQUEST', 'saas connections require config.url (string)', 400);
 		}
+	} else if (body.kind === ConnectorTransport.Api) {
+		const validated = validateApiConnectorConfig(config);
+		if (!validated.ok) return err(c, 'INVALID_REQUEST', validated.error, 400);
+		config = validated.config as unknown as Record<string, unknown>;
 	} else if (typeof body.config?.command !== 'string' || !body.config.command) {
 		return err(c, 'INVALID_REQUEST', 'local connections require config.command (string)', 400);
 	}
@@ -500,7 +555,9 @@ connectorsRoutes.post('/projects/:projectId/connectors', async (c) => {
 		}
 	}
 
-	const initialStatus = body.kind === ConnectorTransport.Saas ? 'installed' : 'pending';
+	// Only local (stdio) MCPs need an installer pass; saas and api are usable at
+	// once (api is a direct REST call — nothing to install).
+	const initialStatus = body.kind === ConnectorTransport.Local ? 'pending' : 'installed';
 	const result = await db.query(
 		`INSERT INTO mcp_connections (name, kind, config, oauth_connection_id, install_status, project_id)
 		 VALUES ($1, $2::mcp_connection_kind, $3::jsonb, $4, $5::mcp_install_status, $6)
@@ -515,7 +572,7 @@ connectorsRoutes.post('/projects/:projectId/connectors', async (c) => {
 		[
 			body.name.trim(),
 			body.kind,
-			JSON.stringify(body.config),
+			JSON.stringify(config),
 			body.oauth_connection_id ?? null,
 			initialStatus,
 			projectId,

--- a/packages/server/src/services/connectors/connections.ts
+++ b/packages/server/src/services/connectors/connections.ts
@@ -41,7 +41,90 @@ export interface LocalConnectorConfig {
 	package?: string;
 }
 
-export type ConnectorConfig = SaasConnectorConfig | LocalConnectorConfig;
+/**
+ * A credentialed REST API the agent calls **directly** through the egress proxy —
+ * no MCP server involved. Unlike saas/local there is no MCP descriptor: the agent
+ * gets the `base_url`, the auth `placement`/`name`, and a `__HEZO_SECRET_*__`
+ * placeholder (via {@link loadConnectorDescriptors}'s api_auth surfacing in
+ * `list_connectors`), puts the placeholder in the header/query named by `auth`,
+ * and calls `base_url`. The egress proxy substitutes the real key at request time,
+ * scoped to `allowed_hosts`. The credential itself is NOT stored in config — it is
+ * the `api_key_secret_id` vault link, same as an api-key-authenticated saas row.
+ */
+export interface ApiConnectorConfig {
+	base_url: string;
+	allowed_hosts: string[];
+	auth: {
+		/** Where the credential rides: an HTTP header, or a query-string parameter. */
+		placement: 'header' | 'query';
+		/** Header name (e.g. `Authorization`) or query param name (e.g. `api_key`). */
+		name: string;
+		/** Optional value prefix for a header placement (e.g. `Bearer `). */
+		scheme?: string;
+	};
+	/** Optional link to the provider's REST API docs, surfaced to the agent + UI. */
+	docs_url?: string;
+}
+
+export type ConnectorConfig = SaasConnectorConfig | LocalConnectorConfig | ApiConnectorConfig;
+
+/**
+ * Validate a raw `config` object as an {@link ApiConnectorConfig}. Shared by the
+ * `add_connector` MCP tool and the connector-create REST routes so the two surfaces
+ * enforce identical shape. Returns `{ ok: true, config }` with the normalized config
+ * (trimmed strings, deduped hosts) or `{ ok: false, error }` with a human message.
+ */
+export function validateApiConnectorConfig(
+	config: Record<string, unknown> | undefined,
+): { ok: true; config: ApiConnectorConfig } | { ok: false; error: string } {
+	const baseUrl = typeof config?.base_url === 'string' ? config.base_url.trim() : '';
+	if (!baseUrl) return { ok: false, error: 'api connectors require config.base_url (string)' };
+	let host = '';
+	try {
+		host = new URL(baseUrl).host;
+	} catch {
+		return { ok: false, error: 'config.base_url must be a valid URL' };
+	}
+	if (!host) return { ok: false, error: 'config.base_url must be a valid URL' };
+
+	const rawHosts = (config as { allowed_hosts?: unknown }).allowed_hosts;
+	if (
+		!Array.isArray(rawHosts) ||
+		rawHosts.length === 0 ||
+		!rawHosts.every((h) => typeof h === 'string' && h.trim().length > 0)
+	) {
+		return { ok: false, error: 'api connectors require config.allowed_hosts (non-empty string[])' };
+	}
+	const allowedHosts = [...new Set(rawHosts.map((h) => (h as string).trim().toLowerCase()))];
+
+	const auth = (config as { auth?: unknown }).auth;
+	if (typeof auth !== 'object' || auth === null) {
+		return { ok: false, error: 'api connectors require config.auth ({ placement, name })' };
+	}
+	const placement = (auth as { placement?: unknown }).placement;
+	if (placement !== 'header' && placement !== 'query') {
+		return { ok: false, error: "config.auth.placement must be 'header' or 'query'" };
+	}
+	const nameRaw = (auth as { name?: unknown }).name;
+	const name = typeof nameRaw === 'string' ? nameRaw.trim() : '';
+	if (!name) return { ok: false, error: 'config.auth.name is required' };
+	const schemeRaw = (auth as { scheme?: unknown }).scheme;
+	const scheme = typeof schemeRaw === 'string' ? schemeRaw : undefined;
+
+	const docsRaw = (config as { docs_url?: unknown }).docs_url;
+	const docsUrl =
+		typeof docsRaw === 'string' && docsRaw.trim().length > 0 ? docsRaw.trim() : undefined;
+
+	return {
+		ok: true,
+		config: {
+			base_url: baseUrl,
+			allowed_hosts: allowedHosts,
+			auth: { placement, name, ...(scheme !== undefined ? { scheme } : {}) },
+			...(docsUrl ? { docs_url: docsUrl } : {}),
+		},
+	};
+}
 
 export interface ConnectorRow {
 	id: string;
@@ -228,6 +311,7 @@ export async function loadConnectorDescriptors(
 				url: config.url,
 				headers,
 			});
+		} else if (row.kind === ConnectorTransport.Api) {
 		} else if (row.kind === ConnectorTransport.Local) {
 			if (row.install_status !== 'installed') {
 				log.warn('skipping local mcp connection that is not installed', {

--- a/packages/server/test/api-connector.test.ts
+++ b/packages/server/test/api-connector.test.ts
@@ -1,0 +1,156 @@
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import type { Db } from '../src/db/database';
+import type { Env } from '../src/lib/types';
+import {
+	loadConnectorDescriptors,
+	validateApiConnectorConfig,
+} from '../src/services/connectors/connections';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
+
+let app: Hono<Env>;
+let db: Db;
+let token: string;
+let projectSlug: string;
+let projectId: string;
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+
+	const typesRes = await app.request('/api/team-templates', { headers: authHeader(token) });
+	const typeId = (await typesRes.json()).data.find(
+		(t: Record<string, unknown>) => t.name === 'Startup',
+	).id;
+	const teamData = (
+		await (await createTestTeam(db, { name: 'Api Connector Co', template_id: typeId })).json()
+	).data;
+	const proj = (await (await createTestProject(db, teamData.id, { name: 'Api Proj' })).json()).data;
+	projectSlug = proj.slug;
+	projectId = proj.id;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+beforeEach(async () => {
+	await db.query('DELETE FROM mcp_connections');
+	await db.query(`DELETE FROM secrets WHERE name LIKE 'MCP_%'`);
+});
+
+const VALID_API_CONFIG = {
+	base_url: 'https://api.weather.example/v1',
+	allowed_hosts: ['api.weather.example'],
+	auth: { placement: 'header', name: 'Authorization', scheme: 'Bearer ' },
+	docs_url: 'https://api.weather.example/docs',
+};
+
+describe('validateApiConnectorConfig', () => {
+	it('accepts a valid config and normalizes hosts/strings', () => {
+		const r = validateApiConnectorConfig({
+			base_url: '  https://api.weather.example/v1  ',
+			allowed_hosts: ['API.Weather.Example', 'api.weather.example'],
+			auth: { placement: 'header', name: ' Authorization ', scheme: 'Bearer ' },
+			docs_url: ' https://api.weather.example/docs ',
+		});
+		expect(r.ok).toBe(true);
+		if (!r.ok) return;
+		expect(r.config.base_url).toBe('https://api.weather.example/v1');
+		// hosts lowercased + deduped
+		expect(r.config.allowed_hosts).toEqual(['api.weather.example']);
+		expect(r.config.auth.name).toBe('Authorization');
+		expect(r.config.docs_url).toBe('https://api.weather.example/docs');
+	});
+
+	it('rejects a missing/invalid base_url', () => {
+		expect(validateApiConnectorConfig({ allowed_hosts: ['x'], auth: {} }).ok).toBe(false);
+		expect(
+			validateApiConnectorConfig({ base_url: 'not a url', allowed_hosts: ['x'], auth: {} }).ok,
+		).toBe(false);
+	});
+
+	it('rejects empty allowed_hosts', () => {
+		const r = validateApiConnectorConfig({
+			base_url: 'https://api.x.example',
+			allowed_hosts: [],
+			auth: { placement: 'header', name: 'Authorization' },
+		});
+		expect(r.ok).toBe(false);
+	});
+
+	it('rejects a bad auth placement or missing name', () => {
+		expect(
+			validateApiConnectorConfig({
+				base_url: 'https://api.x.example',
+				allowed_hosts: ['api.x.example'],
+				auth: { placement: 'body', name: 'k' },
+			}).ok,
+		).toBe(false);
+		expect(
+			validateApiConnectorConfig({
+				base_url: 'https://api.x.example',
+				allowed_hosts: ['api.x.example'],
+				auth: { placement: 'query', name: '' },
+			}).ok,
+		).toBe(false);
+	});
+});
+
+describe('api connector routes', () => {
+	async function createApiConnector(config: unknown = VALID_API_CONFIG) {
+		return app.request(`/api/projects/${projectSlug}/connectors`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'content-type': 'application/json' },
+			body: JSON.stringify({ name: 'weather', kind: 'api', config }),
+		});
+	}
+
+	it('creates an api connector (installed, no MCP descriptor)', async () => {
+		const res = await createApiConnector();
+		expect(res.status).toBe(201);
+		const row = (await res.json()).data;
+		expect(row.kind).toBe('api');
+		expect(row.install_status).toBe('installed');
+
+		// api connectors are surfaced via list_connectors + egress only — never as an
+		// MCP descriptor injected into a run.
+		const descriptors = await loadConnectorDescriptors(db, projectId);
+		expect(descriptors.find((d) => d.name === 'weather')).toBeUndefined();
+	});
+
+	it('rejects an invalid api config with 400', async () => {
+		const res = await createApiConnector({ base_url: 'nope', allowed_hosts: [], auth: {} });
+		expect(res.status).toBe(400);
+	});
+
+	it('attaches a credential and scopes the vault secret to the config allowed_hosts', async () => {
+		const created = (await (await createApiConnector()).json()).data;
+		const attach = await app.request(
+			`/api/projects/${projectSlug}/connectors/${created.id}/api-key`,
+			{
+				method: 'POST',
+				headers: { ...authHeader(token), 'content-type': 'application/json' },
+				body: JSON.stringify({ value: 'super-secret-key' }),
+			},
+		);
+		expect(attach.status).toBe(200);
+
+		const conn = await db.query<{ api_key_secret_id: string | null }>(
+			`SELECT api_key_secret_id FROM mcp_connections WHERE id = $1`,
+			[created.id],
+		);
+		expect(conn.rows[0].api_key_secret_id).not.toBeNull();
+
+		const secret = await db.query<{ allowed_hosts: string[]; allow_all_hosts: boolean }>(
+			`SELECT allowed_hosts, allow_all_hosts FROM secrets WHERE id = $1`,
+			[conn.rows[0].api_key_secret_id],
+		);
+		// Scoped to the connector's allowed_hosts (from config), never all hosts.
+		expect(secret.rows[0].allowed_hosts).toEqual(['api.weather.example']);
+		expect(secret.rows[0].allow_all_hosts).toBe(false);
+	});
+});

--- a/packages/server/test/migrate-027-add-api-connector-transport.test.ts
+++ b/packages/server/test/migrate-027-add-api-connector-transport.test.ts
@@ -1,0 +1,60 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createDataPreservationHarness, type DataPreservationHarness } from './helpers/migrate';
+
+const TARGET = '027_add_api_connector_transport.sql';
+
+describe('027_add_api_connector_transport migration', () => {
+	let h: DataPreservationHarness;
+	let seededConnectorId: string;
+
+	beforeAll(async () => {
+		h = await createDataPreservationHarness();
+		await h.applyUpToExclusive(TARGET);
+
+		// Seed a representative connector at the prior (saas/local-only) enum schema.
+		const connector = await h.db.query<{ id: string }>(
+			`INSERT INTO mcp_connections (name, kind, config, install_status)
+			 VALUES ('typefully', 'saas', '{"url":"https://mcp.typefully.com/mcp"}'::jsonb, 'installed')
+			 RETURNING id`,
+		);
+		seededConnectorId = connector.rows[0].id;
+
+		await h.applyTarget(TARGET);
+	});
+	afterAll(() => h.close());
+
+	it('adds api to the mcp_connection_kind enum', async () => {
+		const r = await h.db.query<{ enumlabel: string }>(
+			`SELECT e.enumlabel
+			   FROM pg_enum e
+			   JOIN pg_type t ON t.oid = e.enumtypid
+			  WHERE t.typname = 'mcp_connection_kind'`,
+		);
+		const values = r.rows.map((row) => row.enumlabel);
+		expect(values).toContain('api');
+		// The prior values are untouched.
+		expect(values).toContain('saas');
+		expect(values).toContain('local');
+	});
+
+	it('preserves the pre-existing connector row', async () => {
+		const kept = await h.db.query<{ name: string; kind: string }>(
+			`SELECT name, kind::text AS kind FROM mcp_connections WHERE id = $1`,
+			[seededConnectorId],
+		);
+		expect(kept.rows).toHaveLength(1);
+		expect(kept.rows[0].name).toBe('typefully');
+		expect(kept.rows[0].kind).toBe('saas');
+	});
+
+	it('accepts a new connector row with kind=api', async () => {
+		const inserted = await h.db.query<{ kind: string }>(
+			`INSERT INTO mcp_connections (name, kind, config, install_status)
+			 VALUES ('weatherapi', 'api'::mcp_connection_kind,
+			         '{"base_url":"https://api.weather.example","allowed_hosts":["api.weather.example"],"auth":{"placement":"header","name":"Authorization","scheme":"Bearer "}}'::jsonb,
+			         'installed')
+			 RETURNING kind::text AS kind`,
+		);
+		expect(inserted.rows[0].kind).toBe('api');
+	});
+});

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -1057,7 +1057,7 @@ export const AuditEntityType = {
 } as const;
 export type AuditEntityType = (typeof AuditEntityType)[keyof typeof AuditEntityType];
 
-export const ConnectorTransport = { Saas: 'saas', Local: 'local' } as const;
+export const ConnectorTransport = { Saas: 'saas', Local: 'local', Api: 'api' } as const;
 export type ConnectorTransport = (typeof ConnectorTransport)[keyof typeof ConnectorTransport];
 
 export const McpInstallStatus = {

--- a/packages/web/src/hooks/use-connectors.ts
+++ b/packages/web/src/hooks/use-connectors.ts
@@ -7,7 +7,7 @@ export interface Connector {
 	id: string;
 	name: string;
 	display_name: string | null;
-	kind: 'saas' | 'local';
+	kind: 'saas' | 'local' | 'api';
 	config: Record<string, unknown>;
 	oauth_connection_id: string | null;
 	/** Vault secret holding a pasted API key, for connectors whose provider
@@ -116,7 +116,7 @@ export function useRevokeConnector(projectId: string) {
 
 export interface CreateConnectorPayload {
 	name: string;
-	kind: 'saas' | 'local';
+	kind: 'saas' | 'local' | 'api';
 	config: Record<string, unknown>;
 }
 

--- a/packages/web/src/routes/projects/$projectId/connectors.tsx
+++ b/packages/web/src/routes/projects/$projectId/connectors.tsx
@@ -114,22 +114,31 @@ interface AddConnectorFormProps {
 }
 
 /**
- * Add a remote (SaaS) MCP connector directly to this project — the same
- * name+URL create the admin page offers, scoped implicitly to this project.
- * On submit it creates the row, then probes for OAuth: an OAuth-capable server
- * opens the authorize popup automatically; a public / header-authenticated one
- * resolves to a null auth_url and the new row just offers its API-key option.
+ * Add a connector directly to this project. Two transports:
+ *  - MCP server (`saas`): name + URL; on submit it creates the row then probes
+ *    for OAuth (OAuth-capable → authorize popup; public/header-auth → null
+ *    auth_url and the row offers its API-key option).
+ *  - REST API (`api`): a direct HTTP API the agent calls itself (no MCP server) —
+ *    base URL + allowed hosts + how the credential rides (header/query). No OAuth;
+ *    the human attaches the key from the new row and the egress proxy substitutes
+ *    it, scoped to the allowed hosts.
  */
 function AddConnectorForm({ projectId, onClose }: AddConnectorFormProps) {
 	const create = useCreateConnector(projectId);
 	const authStart = useAuthStart(projectId);
+	const [type, setType] = useState<'mcp' | 'api'>('mcp');
 	const [name, setName] = useState('');
 	const [url, setUrl] = useState('');
+	// REST-API-connector fields.
+	const [baseUrl, setBaseUrl] = useState('');
+	const [allowedHosts, setAllowedHosts] = useState('');
+	const [placement, setPlacement] = useState<'header' | 'query'>('header');
+	const [authName, setAuthName] = useState('Authorization');
+	const [scheme, setScheme] = useState('Bearer ');
+	const [docsUrl, setDocsUrl] = useState('');
 	const [error, setError] = useState<string | null>(null);
 
-	const submit = async (e: React.FormEvent) => {
-		e.preventDefault();
-		setError(null);
+	const submitMcp = async () => {
 		if (!name.trim() || !url.trim()) {
 			setError('Name and MCP server URL are required.');
 			return;
@@ -145,11 +154,10 @@ function AddConnectorForm({ projectId, onClose }: AddConnectorFormProps) {
 			setError(err instanceof Error ? err.message : 'Failed to add connector');
 			return;
 		}
-		// The row already shows in the list; probe the new connector for OAuth and
-		// pop the authorize window when it advertises any. Header-auth / public MCPs
-		// resolve to auth_url null and are connected later with a pasted API key from
-		// their row, so those just close the form. Keep the form open only to surface
-		// a blocked popup (its error can't render once the form unmounts).
+		// Probe the new connector for OAuth and pop the authorize window when it
+		// advertises any. Header-auth / public MCPs resolve to auth_url null and are
+		// connected later with a pasted API key from their row. Keep the form open
+		// only to surface a blocked popup (its error can't render once unmounted).
 		try {
 			const started = await authStart.mutateAsync(created.id);
 			if (started.auth_url) {
@@ -160,10 +168,59 @@ function AddConnectorForm({ projectId, onClose }: AddConnectorFormProps) {
 				}
 			}
 		} catch {
-			// The row exists regardless; any auth failure is recorded on it (Failed
-			// badge + Retry), so the user can connect from the row itself.
+			// The row exists regardless; any auth failure is recorded on it.
 		}
 		onClose();
+	};
+
+	const submitApi = async () => {
+		const hosts = allowedHosts
+			.split(/[\s,]+/)
+			.map((h) => h.trim())
+			.filter(Boolean);
+		if (!name.trim() || !baseUrl.trim()) {
+			setError('Name and base URL are required.');
+			return;
+		}
+		if (hosts.length === 0) {
+			setError('At least one allowed host is required (the egress proxy scope for the key).');
+			return;
+		}
+		if (!authName.trim()) {
+			setError(
+				placement === 'header' ? 'Header name is required.' : 'Query parameter is required.',
+			);
+			return;
+		}
+		try {
+			await create.mutateAsync({
+				name: name.trim(),
+				kind: 'api',
+				config: {
+					base_url: baseUrl.trim(),
+					allowed_hosts: hosts,
+					auth: {
+						placement,
+						name: authName.trim(),
+						...(placement === 'header' && scheme !== '' ? { scheme } : {}),
+					},
+					...(docsUrl.trim() ? { docs_url: docsUrl.trim() } : {}),
+				},
+			});
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Failed to add API connector');
+			return;
+		}
+		// No OAuth for a direct-API connector — the human attaches the credential
+		// from the new row (API key), which scopes the vault secret to allowed_hosts.
+		onClose();
+	};
+
+	const submit = (e: React.FormEvent) => {
+		e.preventDefault();
+		setError(null);
+		if (type === 'mcp') void submitMcp();
+		else void submitApi();
 	};
 
 	return (
@@ -173,6 +230,26 @@ function AddConnectorForm({ projectId, onClose }: AddConnectorFormProps) {
 			onSubmit={submit}
 			data-testid="connector-add-form"
 		>
+			<div className="flex gap-2">
+				<Button
+					type="button"
+					size="sm"
+					variant={type === 'mcp' ? undefined : 'outline'}
+					onClick={() => setType('mcp')}
+					data-testid="connector-add-type-mcp"
+				>
+					MCP server
+				</Button>
+				<Button
+					type="button"
+					size="sm"
+					variant={type === 'api' ? undefined : 'outline'}
+					onClick={() => setType('api')}
+					data-testid="connector-add-type-api"
+				>
+					REST API
+				</Button>
+			</div>
 			<Input
 				placeholder="Name (e.g. linear)"
 				value={name}
@@ -180,13 +257,67 @@ function AddConnectorForm({ projectId, onClose }: AddConnectorFormProps) {
 				data-testid="connector-add-name"
 				required
 			/>
-			<Input
-				placeholder="MCP server URL (e.g. https://mcp.example.com/mcp)"
-				value={url}
-				onChange={(e) => setUrl(e.target.value)}
-				data-testid="connector-add-url"
-				required
-			/>
+			{type === 'mcp' ? (
+				<Input
+					placeholder="MCP server URL (e.g. https://mcp.example.com/mcp)"
+					value={url}
+					onChange={(e) => setUrl(e.target.value)}
+					data-testid="connector-add-url"
+				/>
+			) : (
+				<>
+					<Input
+						placeholder="Base URL (e.g. https://api.example.com/v1)"
+						value={baseUrl}
+						onChange={(e) => setBaseUrl(e.target.value)}
+						data-testid="connector-add-base-url"
+					/>
+					<Input
+						placeholder="Allowed hosts, comma/space separated (e.g. api.example.com)"
+						value={allowedHosts}
+						onChange={(e) => setAllowedHosts(e.target.value)}
+						data-testid="connector-add-allowed-hosts"
+					/>
+					<div className="flex flex-col gap-2 sm:flex-row">
+						<select
+							value={placement}
+							onChange={(e) => setPlacement(e.target.value as 'header' | 'query')}
+							data-testid="connector-add-placement"
+							className="rounded-md border border-border bg-transparent px-2 py-2 text-sm text-text-1 shrink-0"
+						>
+							<option value="header">Header</option>
+							<option value="query">Query param</option>
+						</select>
+						<Input
+							placeholder={
+								placement === 'header' ? 'Header name (Authorization)' : 'Query param (api_key)'
+							}
+							value={authName}
+							onChange={(e) => setAuthName(e.target.value)}
+							data-testid="connector-add-auth-name"
+						/>
+						{placement === 'header' && (
+							<Input
+								placeholder="Scheme prefix (e.g. 'Bearer ')"
+								value={scheme}
+								onChange={(e) => setScheme(e.target.value)}
+								data-testid="connector-add-scheme"
+							/>
+						)}
+					</div>
+					<Input
+						placeholder="API docs URL (optional)"
+						value={docsUrl}
+						onChange={(e) => setDocsUrl(e.target.value)}
+						data-testid="connector-add-docs-url"
+					/>
+					<p className="text-xs text-text-3">
+						A direct REST API the agent calls itself — no MCP server. After creating, attach the API
+						key from its row; agents get the placeholder + base URL via <code>list_connectors</code>{' '}
+						and the egress proxy substitutes the key, scoped to the allowed hosts.
+					</p>
+				</>
+			)}
 			{error && <p className="text-xs text-danger-soft-fg">{error}</p>}
 			<div className="flex gap-2">
 				<Button
@@ -348,12 +479,16 @@ function ConnectorRow({ connector, projectId, focused, focusRef }: ConnectorRowP
 	// no connect/disconnect/api-key, just a "Global" badge and a link to manage.
 	const isGlobal = connector.project_id === null;
 
-	const url =
-		typeof connector.config === 'object' &&
-		connector.config !== null &&
-		typeof (connector.config as { url?: unknown }).url === 'string'
-			? (connector.config as { url: string }).url
-			: null;
+	const cfg = (connector.config ?? {}) as {
+		url?: unknown;
+		base_url?: unknown;
+		docs_url?: unknown;
+	};
+	const url = typeof cfg.url === 'string' ? cfg.url : null;
+	const baseUrl = typeof cfg.base_url === 'string' ? cfg.base_url : null;
+	const docsUrl = typeof cfg.docs_url === 'string' ? cfg.docs_url : null;
+	const isApi = connector.kind === 'api';
+	const displayUrl = url ?? baseUrl;
 
 	const openConnect = () => {
 		setError(null);
@@ -428,7 +563,20 @@ function ConnectorRow({ connector, projectId, focused, focusRef }: ConnectorRowP
 							</Badge>
 						)}
 					</div>
-					{url && <p className="text-xs text-text-2 mt-1 truncate font-mono">{url}</p>}
+					{displayUrl && (
+						<p className="text-xs text-text-2 mt-1 truncate font-mono">{displayUrl}</p>
+					)}
+					{docsUrl && (
+						<a
+							href={docsUrl}
+							target="_blank"
+							rel="noopener noreferrer"
+							className="text-xs text-info hover:underline mt-1 inline-flex items-center gap-1"
+							data-testid="connector-docs-link"
+						>
+							<ExternalLink className="size-3" /> API docs
+						</a>
+					)}
 					{connector.oauth_account_label && (
 						<p className="text-xs text-text-2 mt-1">
 							Connected as <span className="font-mono">{connector.oauth_account_label}</span>
@@ -470,14 +618,16 @@ function ConnectorRow({ connector, projectId, focused, focusRef }: ConnectorRowP
 						</Button>
 					) : (
 						<>
-							<Button
-								size="sm"
-								onClick={openConnect}
-								disabled={authStart.isPending}
-								data-testid="connector-connect"
-							>
-								{authStart.isPending ? 'Starting…' : status === 'failed' ? 'Retry' : 'Connect'}
-							</Button>
+							{!isApi && (
+								<Button
+									size="sm"
+									onClick={openConnect}
+									disabled={authStart.isPending}
+									data-testid="connector-connect"
+								>
+									{authStart.isPending ? 'Starting…' : status === 'failed' ? 'Retry' : 'Connect'}
+								</Button>
+							)}
 							<Button
 								size="sm"
 								variant="outline"

--- a/packages/web/test/connectors-page.test.tsx
+++ b/packages/web/test/connectors-page.test.tsx
@@ -192,6 +192,42 @@ test('the Add form creates a project-scoped connector and auto-probes OAuth', as
 	}
 });
 
+test('the Add form creates a REST-API connector (base_url shown, no OAuth Connect, API-key attach)', async () => {
+	let slug = '';
+	const { findByText, findByTestId, getByTestId, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			slug = ws.internalSlug;
+		},
+	});
+	await router.navigate({ to: CONNECTORS_ROUTE, params: { projectId: slug } });
+	await findByText('Connectors', { selector: 'h1' });
+
+	// Open the Add form and switch to the REST API transport.
+	(await findByTestId('connector-add-toggle')).click();
+	(await findByTestId('connector-add-type-api')).click();
+
+	await user.type(await findByTestId('connector-add-name'), 'weather');
+	await user.type(await findByTestId('connector-add-base-url'), 'https://api.weather.example/v1');
+	await user.type(await findByTestId('connector-add-allowed-hosts'), 'api.weather.example');
+	// auth name defaults to "Authorization" — leave it. Submit (no OAuth probe for api).
+	(await findByTestId('connector-add-submit')).click();
+
+	// The created api connector renders with its base_url (create → refetch).
+	await findByText('weather');
+	await findByText('https://api.weather.example/v1');
+
+	// An api connector has no OAuth — its row offers the API-key attach only, never
+	// the OAuth Connect button.
+	const row = within(getByTestId('connectors-list'))
+		.getAllByTestId('connector-row')
+		.find((li) => li.getAttribute('data-connector-id'));
+	if (!row) throw new Error('api connector row not found');
+	expect(within(row).queryByTestId('connector-connect')).toBeNull();
+	within(row).getByTestId('connector-api-key-toggle');
+});
+
 test('a global connector is read-only on the project page (badge + manage link, no actions)', async () => {
 	let slug = '';
 	const { findByText, router } = await renderApp({


### PR DESCRIPTION
## What & why

Adds a third connector **transport `api`** alongside `saas` (remote MCP) and `local` (stdio MCP): a **credentialed REST API the agent calls directly through the egress proxy, with no MCP server** — for backends that expose a plain HTTP API rather than MCP (e.g. Google's APIs). The credential only ever appears as a `__HEZO_SECRET_*__` placeholder in a header/query, so this is the most red-line-native transport.

## Changes

**Server**
- Enum `ConnectorTransport.Api` + migration `027` (`ADD VALUE IF NOT EXISTS`) with a data-preservation test.
- `ApiConnectorConfig { base_url, allowed_hosts, auth: { placement, name, scheme? }, docs_url? }` + a shared `validateApiConnectorConfig` used by both the tool and the routes.
- `add_connector` accepts `kind:'api'`; `list_connectors` emits an `api_auth { base_url, placeholder, allowed_hosts, placement, name, docs_url }` block (placeholder null until a credential is attached).
- Create routes accept `api`; the `/api-key` credential route scopes the vault secret's `allowed_hosts` to the api connector's config (base_url host) as well as saas MCP hosts.
- `loadConnectorDescriptors` skips `api` (no MCP descriptor — surfaced via `list_connectors` + egress only). No egress-engine change.
- `.dev/architecture.md` §9 + regenerated `docs/reference/mcp-api.md`.

**Web (Connectors page)**
- The add-connector form gains an **MCP-server / REST-API** type toggle; the REST-API mode collects base_url, allowed_hosts, auth placement/name/scheme, and an optional docs_url.
- Connector rows render api connectors (base_url + an "API docs" link), hide the OAuth Connect button (api has no OAuth), and offer the API-key attach.

## Verification

- `bun run typecheck` + full `bun run build` — green.
- **Server:** `api-connector.test.ts` (validator + create route + credential `allowed_hosts` scoping + descriptor-exclusion), `migrate-027-*` (data preservation), plus existing `connectors` (17), `mcp-connections-routes` (28), `mcp-tools-extended` (103), and the `mcp-reference`/`llms-txt` doc-drift tests — all pass.
- **Web:** `connectors-page.test.tsx` (10, incl. the new REST-API form test) — pass.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JL2unhYgoKWnTYmkgTqArx