### PR TITLE
feat(connectors): connector registry and virtual connector-recipes skill

### DIFF
--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -97,6 +97,11 @@ import { broadcastApprovalChange } from '../services/approval-broadcast';
 import { resolveApproval } from '../services/approval-resolve';
 import { upsertChatMemory } from '../services/chat-memory';
 import { fireCommentWakeups, postAgentComment } from '../services/comment-wakeups';
+import {
+	buildConnectorRecipesSkill,
+	CONNECTOR_RECIPES_SLUG,
+	isConnectorRecipesSlug,
+} from '../services/connector-registry';
 import { validateApiConnectorConfig } from '../services/connectors/connections';
 import type { ContainerDeps } from '../services/containers';
 import { enqueueTeamCoherenceReviewTask } from '../services/description-tasks';
@@ -4235,6 +4240,13 @@ export function registerTools(
 				),
 		},
 		async (args, db, auth) => {
+			// `connector-recipes` is a reserved built-in virtual skill — reject a
+			// proposal that would shadow it.
+			if (isConnectorRecipesSlug(args.skill_slug as string)) {
+				return {
+					error: `'${CONNECTOR_RECIPES_SLUG}' is a reserved built-in skill and cannot be proposed`,
+				};
+			}
 			const scope = await resolveScope(db, auth, args);
 			if ('error' in scope) return scope;
 			const callerMemberId = auth.type === AuthType.Agent ? auth.memberId : null;
@@ -4342,6 +4354,14 @@ export function registerTools(
 			slug: z.string().describe('Skill slug'),
 		},
 		async (args, db, auth) => {
+			// The built-in `connector-recipes` skill is generated from the connector
+			// registry, not a DB row — return it directly (no scope needed; it is a
+			// global read-only guide).
+			if (args.slug === CONNECTOR_RECIPES_SLUG) {
+				const s = buildConnectorRecipesSkill();
+				return { name: s.name, slug: s.slug, description: s.description, content: s.content };
+			}
+
 			const scope = await resolveScope(db, auth, args);
 			if ('error' in scope) return scope;
 
@@ -4377,6 +4397,14 @@ export function registerTools(
 				),
 		},
 		async (args, db, auth) => {
+			// `connector-recipes` is a reserved built-in virtual skill (generated from
+			// the connector registry) — an agent may read it but not shadow it.
+			if (isConnectorRecipesSlug(args.slug as string)) {
+				return {
+					error: `'${CONNECTOR_RECIPES_SLUG}' is a reserved built-in skill and cannot be created or overwritten`,
+				};
+			}
+
 			const scope = await resolveScope(db, auth, args);
 			if ('error' in scope) return scope;
 

--- a/packages/server/src/routes/skills.ts
+++ b/packages/server/src/routes/skills.ts
@@ -8,6 +8,11 @@ import { isUniqueViolation } from '../lib/sql';
 import type { Env } from '../lib/types';
 import { requireAdminEquivalent } from '../middleware/auth';
 import {
+	buildConnectorRecipesSkill,
+	CONNECTOR_RECIPES_SLUG,
+	isConnectorRecipesSlug,
+} from '../services/connector-registry';
+import {
 	listSkillRevisions,
 	recordSkillRevisionIfChanged,
 	restoreSkillRevision,
@@ -76,6 +81,35 @@ function buildSkillEdit(
 	return { sets, params };
 }
 
+// The virtual `connector-recipes` skill is generated from the connector
+// registry, not stored in the DB. It is surfaced read-only on the admin skills
+// surface (list + detail); the create/edit/delete paths reject its slug.
+// `readonly: true` lets the UI hide edit/delete affordances.
+function connectorRecipesSkillRow(includeContent: boolean): Record<string, unknown> {
+	const s = buildConnectorRecipesSkill();
+	const now = new Date().toISOString();
+	const row: Record<string, unknown> = {
+		id: CONNECTOR_RECIPES_SLUG,
+		name: s.name,
+		slug: s.slug,
+		description: s.description,
+		source_url: null,
+		content_hash: null,
+		created_by_member_id: null,
+		project_id: null,
+		project_name: null,
+		project_slug: null,
+		tags: [],
+		is_active: true,
+		auto_load: false,
+		created_at: now,
+		updated_at: now,
+		readonly: true,
+	};
+	if (includeContent) row.content = s.content;
+	return row;
+}
+
 // --------------------------------------------------------------------------
 // Admin surface (superuser): the global catalog + every project's skills, each
 // annotated with its owning project. Skills are scoped like MCP connectors —
@@ -94,7 +128,14 @@ skillsRoutes.get('/skills', async (c) => {
 		 WHERE s.is_active = true
 		 ORDER BY s.name`,
 	);
-	return ok(c, result.rows);
+	// Surface the built-in `connector-recipes` virtual skill read-only alongside
+	// the DB rows (annotate stored rows so the UI can tell them apart).
+	const rows: Record<string, unknown>[] = result.rows.map((r) => ({
+		...(r as Record<string, unknown>),
+		readonly: false,
+	}));
+	rows.push(connectorRecipesSkillRow(false));
+	return ok(c, rows);
 });
 
 skillsRoutes.post('/skills', async (c) => {
@@ -113,6 +154,14 @@ skillsRoutes.post('/skills', async (c) => {
 	if (!body.content?.trim()) return err(c, 'INVALID_REQUEST', 'content is required', 400);
 	const slug = body.slug?.trim() || toSlug(body.name);
 	if (!slug) return err(c, 'INVALID_REQUEST', 'slug could not be derived from name', 400);
+	if (isConnectorRecipesSlug(slug)) {
+		return err(
+			c,
+			'INVALID_REQUEST',
+			'connector-recipes is a reserved built-in skill and cannot be created',
+			400,
+		);
+	}
 
 	// The admin may create a global skill (project_id null) or scope it to a
 	// specific project via the create-form picker. Validate a named project.
@@ -267,6 +316,11 @@ skillsRoutes.post('/skills/registry/install', async (c) => {
 skillsRoutes.get('/skills/:id', async (c) => {
 	const denied = requireAdminEquivalent(c);
 	if (denied) return denied;
+	// The built-in virtual skill is generated, not a DB row (and its id is not a
+	// UUID, so it must be intercepted before the query).
+	if (c.req.param('id') === CONNECTOR_RECIPES_SLUG) {
+		return ok(c, connectorRecipesSkillRow(true));
+	}
 	const db = c.get('db');
 	const result = await db.query<SkillRecord>('SELECT * FROM skills WHERE id = $1', [
 		c.req.param('id'),
@@ -319,6 +373,14 @@ skillsRoutes.post('/skills/:id/restore', async (c) => {
 skillsRoutes.patch('/skills/:id', async (c) => {
 	const denied = requireAdminEquivalent(c);
 	if (denied) return denied;
+	if (c.req.param('id') === CONNECTOR_RECIPES_SLUG) {
+		return err(
+			c,
+			'INVALID_REQUEST',
+			'connector-recipes is a built-in skill and is not editable',
+			400,
+		);
+	}
 	const db = c.get('db');
 	const id = c.req.param('id');
 
@@ -401,6 +463,14 @@ skillsRoutes.patch('/skills/:id', async (c) => {
 skillsRoutes.delete('/skills/:id', async (c) => {
 	const denied = requireAdminEquivalent(c);
 	if (denied) return denied;
+	if (c.req.param('id') === CONNECTOR_RECIPES_SLUG) {
+		return err(
+			c,
+			'INVALID_REQUEST',
+			'connector-recipes is a built-in skill and is not deletable',
+			400,
+		);
+	}
 	const db = c.get('db');
 	const id = c.req.param('id');
 	const existing = await db.query<{ id: string; slug: string; name: string }>(

--- a/packages/server/src/services/connector-registry.json
+++ b/packages/server/src/services/connector-registry.json
@@ -1,0 +1,311 @@
+{
+	"patterns": [
+		{
+			"id": "mcp-hosted",
+			"title": "Hosted MCP server (preferred)",
+			"description": "When the provider publishes a hosted (remote) MCP server, connect it with register_connector using the MCP URL. A human clicks Connect once to authorize; the OAuth token is stored in the vault by name and substituted at the egress proxy (kind: saas). No credential value ever enters the run — the descriptor carries only an Authorization: Bearer __HEZO_SECRET_<NAME>__ placeholder. This is the first choice for any external service: the tools appear as mcp__<connector>__<tool> on your next run with nothing to acquire by hand."
+		},
+		{
+			"id": "direct-api",
+			"title": "Direct REST API via an `api` connector",
+			"description": "When no MCP server exists but the provider has an HTTP API, register it with add_connector(kind: 'api') giving base_url, auth placement (header or query), the header/param name, and allowed_hosts. Store the key with request_credential(kind: 'api_key', allowed_hosts: [...]). The connector's api_auth surfaces a __HEZO_SECRET_<NAME>__ placeholder you put in that header/param; the egress proxy substitutes the real key, scoped to allowed_hosts. Preferred over any desktop/CLI integration because the secret stays a placeholder."
+		},
+		{
+			"id": "api-key-header",
+			"title": "API key in a request header",
+			"description": "For a bearer/API-key service, call request_credential(kind: 'api_key', allowed_hosts: ['api.example.com']) and reference the value only as __HEZO_SECRET_<NAME>__ in an Authorization: Bearer __HEZO_SECRET_<NAME>__ (or X-API-Key) header. Header substitution always works at the egress proxy; scope allowed_hosts to the exact upstream API host(s)."
+		},
+		{
+			"id": "api-key-query",
+			"title": "API key in a query parameter",
+			"description": "Some APIs take the key as a query parameter (e.g. ?appid=... or ?api_key=...). Use request_credential(kind: 'api_key', allowed_hosts: [...]) and place __HEZO_SECRET_<NAME>__ in the query string. The egress proxy substitutes it in the URL for the allowed_hosts only. Prefer a header when the API supports one; use this only when the provider requires the key in the query."
+		},
+		{
+			"id": "device-flow",
+			"title": "OAuth device-authorization flow (no callback)",
+			"description": "For interactive OAuth where no hosted MCP exists, prefer the device flow: the device_code endpoint returns a short user code + verification URL the human enters on their own device — there is NO browser redirect or localhost callback inside the run. Hezo polls the token endpoint host-side and stores the access + refresh tokens in the vault; refresh happens host-side. Reference the token only by placeholder; scope allowed_hosts to the API host. This is how Google/YouTube connect (see the OAuth providers section)."
+		},
+		{
+			"id": "oauth-authcode-hostside",
+			"title": "OAuth authorization-code flow completed on the host",
+			"description": "For SaaS MCP connectors that require OAuth (Linear, DatoCMS, Notion, Sentry, Cloudflare, ...), the operator starts the auth-code flow from the connector form; the resulting oauth_connection is linked to the connection. The injector emits a placeholder Authorization header and the egress proxy substitutes the bearer at request time. The auth handshake completes on the host, never in the run — you only reference the token by name."
+		},
+		{
+			"id": "userpass-token-body",
+			"title": "Username/password → token via egress body-substitution",
+			"description": "For APIs that exchange credentials in a JSON request body (e.g. a self-hosted /login POST that returns a token, like Umami), call request_credential(allow_body_substitution: true) and put __HEZO_SECRET_<NAME>__ in a small application/json POST body (< 8 KB, fixed Content-Length, no streaming). The egress proxy substitutes into the body. Read the returned token from the response and use Authorization: Bearer <token> on every subsequent call — do not re-send the password each request."
+		},
+		{
+			"id": "service-account-wif",
+			"title": "Service account / workload identity",
+			"description": "For providers authenticated by a service-account key or workload-identity federation, store the account JSON/config with request_credential and use it to mint short-lived access tokens, then send those as Authorization: Bearer __HEZO_SECRET_<NAME>__. Scope allowed_hosts to the token and API hosts. Prefer short-lived, narrowly-scoped tokens over a long-lived static key wherever the provider offers them."
+		},
+		{
+			"id": "webhook-secret",
+			"title": "Webhook shared secret (inbound verification)",
+			"description": "For verifying inbound webhooks (HMAC signature check), store the shared secret with request_credential(kind: 'webhook_secret'). No allowed_hosts is required because the secret is used to verify a signature locally, not sent upstream. Reference it by placeholder; never log or echo the raw value."
+		},
+		{
+			"id": "github-oauth-ssh",
+			"title": "GitHub: OAuth for REST + SSH for git",
+			"description": "For GitHub repo access, the human connects a GitHub account once via the device flow on the project's Connections page. The OAuth token is used for REST API calls (listing orgs/repos, creating repos) only; repo clone/fetch/push runs over SSH (git@github.com:owner/repo.git) authenticated by the project's Ed25519 key, which is auto-registered as both a signing and an authentication key. Do not request a personal access token when the OAuth connection already covers the API surface you need."
+		},
+		{
+			"id": "local-mcp-env-var",
+			"title": "Local (stdio) MCP that reads a credential from an env var",
+			"description": "When a tool or MCP server runs inside the container and reads its credential from an environment variable, register it with add_connector(kind: 'local') giving command/args/package, and put the credential in the connection's config.env as a __HEZO_SECRET_<NAME>__ placeholder — never the value. Then call request_credential for that same NAME, scoping allowed_hosts to the upstream API host the tool calls (not the package registry). Name the secret uniquely to your project so another project can't overwrite it."
+		}
+	],
+	"services": [
+		{
+			"service": "Google / YouTube",
+			"category": "media",
+			"transport": "api",
+			"endpoint": "https://www.googleapis.com/youtube/v3",
+			"credentials": [
+				{
+					"name": "GOOGLE_OAUTH_TOKEN",
+					"kind": "oauth_token",
+					"allowed_hosts": ["*.googleapis.com", "oauth2.googleapis.com"]
+				}
+			],
+			"docs_url": "https://developers.google.com/youtube/v3",
+			"notes": "Connect via the OAuth device flow (see the Google/YouTube provider block). Send the token as Authorization: Bearer __HEZO_SECRET_<NAME>__."
+		},
+		{
+			"service": "Umami (self-hosted analytics)",
+			"category": "analytics",
+			"transport": "api",
+			"endpoint": "https://<your-umami-host>/api",
+			"credentials": [
+				{ "name": "UMAMI_TOKEN", "kind": "other", "allowed_hosts": ["<your-umami-host>"] }
+			],
+			"docs_url": "https://umami.is/docs/api",
+			"notes": "POST /api/auth/login with username/password using request_credential(allow_body_substitution: true) (userpass-token-body pattern); reuse the returned token as a bearer on subsequent calls."
+		},
+		{
+			"service": "GitHub",
+			"category": "dev",
+			"transport": "mcp",
+			"endpoint": "https://api.githubcopilot.com/mcp/",
+			"credentials": [
+				{
+					"name": "GITHUB_OAUTH_TOKEN",
+					"kind": "oauth_token",
+					"allowed_hosts": ["api.github.com", "github.com"]
+				}
+			],
+			"docs_url": "https://github.com/github/github-mcp-server",
+			"notes": "Hosted MCP for the REST API; repo clone/fetch/push runs over SSH using the project's Ed25519 key, not the OAuth token (github-oauth-ssh pattern)."
+		},
+		{
+			"service": "Linear",
+			"category": "project-management",
+			"transport": "mcp",
+			"endpoint": "https://mcp.linear.app/sse",
+			"credentials": [
+				{
+					"name": "LINEAR_OAUTH_TOKEN",
+					"kind": "oauth_token",
+					"allowed_hosts": ["mcp.linear.app", "api.linear.app"]
+				}
+			],
+			"docs_url": "https://linear.app/docs/mcp",
+			"notes": "Hosted MCP with OAuth (oauth-authcode-hostside)."
+		},
+		{
+			"service": "Notion",
+			"category": "docs",
+			"transport": "mcp",
+			"endpoint": "https://mcp.notion.com/mcp",
+			"credentials": [
+				{
+					"name": "NOTION_OAUTH_TOKEN",
+					"kind": "oauth_token",
+					"allowed_hosts": ["mcp.notion.com", "api.notion.com"]
+				}
+			],
+			"docs_url": "https://developers.notion.com/docs/mcp",
+			"notes": "Hosted MCP with OAuth (oauth-authcode-hostside)."
+		},
+		{
+			"service": "Sentry",
+			"category": "observability",
+			"transport": "mcp",
+			"endpoint": "https://mcp.sentry.dev/mcp",
+			"credentials": [
+				{
+					"name": "SENTRY_OAUTH_TOKEN",
+					"kind": "oauth_token",
+					"allowed_hosts": ["mcp.sentry.dev", "sentry.io"]
+				}
+			],
+			"docs_url": "https://docs.sentry.io/product/sentry-mcp/",
+			"notes": "Hosted MCP with OAuth (oauth-authcode-hostside)."
+		},
+		{
+			"service": "Stripe",
+			"category": "payments",
+			"transport": "mcp",
+			"endpoint": "https://mcp.stripe.com",
+			"credentials": [
+				{
+					"name": "STRIPE_API_KEY",
+					"kind": "api_key",
+					"allowed_hosts": ["mcp.stripe.com", "api.stripe.com"]
+				}
+			],
+			"docs_url": "https://docs.stripe.com/mcp",
+			"notes": "Hosted MCP; authenticate with a restricted API key (Authorization: Bearer). A direct api connector against api.stripe.com is a valid fallback."
+		},
+		{
+			"service": "Cloudflare",
+			"category": "infrastructure",
+			"transport": "mcp",
+			"endpoint": "https://observability.mcp.cloudflare.com/sse",
+			"credentials": [
+				{
+					"name": "CLOUDFLARE_OAUTH_TOKEN",
+					"kind": "oauth_token",
+					"allowed_hosts": ["*.mcp.cloudflare.com", "api.cloudflare.com"]
+				}
+			],
+			"docs_url": "https://developers.cloudflare.com/agents/model-context-protocol/",
+			"notes": "Cloudflare publishes several hosted MCP servers (observability, docs, ...) with OAuth (oauth-authcode-hostside)."
+		},
+		{
+			"service": "DatoCMS",
+			"category": "cms",
+			"transport": "mcp",
+			"endpoint": "https://mcp.datocms.com/mcp",
+			"credentials": [
+				{
+					"name": "DATOCMS_OAUTH_TOKEN",
+					"kind": "oauth_token",
+					"allowed_hosts": ["mcp.datocms.com", "site-api.datocms.com"]
+				}
+			],
+			"docs_url": "https://www.datocms.com/docs",
+			"notes": "Hosted MCP with OAuth (oauth-authcode-hostside)."
+		},
+		{
+			"service": "Slack",
+			"category": "communication",
+			"transport": "api",
+			"endpoint": "https://slack.com/api",
+			"credentials": [
+				{
+					"name": "SLACK_BOT_TOKEN",
+					"kind": "oauth_token",
+					"allowed_hosts": ["slack.com", "*.slack.com"]
+				}
+			],
+			"docs_url": "https://api.slack.com/web",
+			"notes": "Send the bot/user token as Authorization: Bearer __HEZO_SECRET_<NAME>__ against the Web API (api-key-header)."
+		},
+		{
+			"service": "GitLab",
+			"category": "dev",
+			"transport": "api",
+			"endpoint": "https://gitlab.com/api/v4",
+			"credentials": [
+				{ "name": "GITLAB_TOKEN", "kind": "api_key", "allowed_hosts": ["gitlab.com"] }
+			],
+			"docs_url": "https://docs.gitlab.com/ee/api/",
+			"notes": "Project/personal access token in the Authorization: Bearer header (api-key-header)."
+		},
+		{
+			"service": "Airtable",
+			"category": "database",
+			"transport": "api",
+			"endpoint": "https://api.airtable.com/v0",
+			"credentials": [
+				{ "name": "AIRTABLE_TOKEN", "kind": "api_key", "allowed_hosts": ["api.airtable.com"] }
+			],
+			"docs_url": "https://airtable.com/developers/web/api/introduction",
+			"notes": "Personal access token as Authorization: Bearer (api-key-header)."
+		},
+		{
+			"service": "OpenAI API",
+			"category": "ai",
+			"transport": "api",
+			"endpoint": "https://api.openai.com/v1",
+			"credentials": [
+				{ "name": "OPENAI_API_KEY", "kind": "api_key", "allowed_hosts": ["api.openai.com"] }
+			],
+			"docs_url": "https://platform.openai.com/docs/api-reference",
+			"notes": "Authorization: Bearer header (api-key-header). This is a tool credential; it is unrelated to the run's own model-provider key."
+		},
+		{
+			"service": "Vercel",
+			"category": "hosting",
+			"transport": "api",
+			"endpoint": "https://api.vercel.com",
+			"credentials": [
+				{ "name": "VERCEL_TOKEN", "kind": "api_key", "allowed_hosts": ["api.vercel.com"] }
+			],
+			"docs_url": "https://vercel.com/docs/rest-api",
+			"notes": "Authorization: Bearer header (api-key-header)."
+		},
+		{
+			"service": "SendGrid",
+			"category": "email",
+			"transport": "api",
+			"endpoint": "https://api.sendgrid.com/v3",
+			"credentials": [
+				{ "name": "SENDGRID_API_KEY", "kind": "api_key", "allowed_hosts": ["api.sendgrid.com"] }
+			],
+			"docs_url": "https://www.twilio.com/docs/sendgrid/api-reference",
+			"notes": "Authorization: Bearer header (api-key-header)."
+		},
+		{
+			"service": "OpenWeatherMap",
+			"category": "data",
+			"transport": "api",
+			"endpoint": "https://api.openweathermap.org/data/2.5",
+			"credentials": [
+				{
+					"name": "OPENWEATHER_API_KEY",
+					"kind": "api_key",
+					"allowed_hosts": ["api.openweathermap.org"]
+				}
+			],
+			"docs_url": "https://openweathermap.org/api",
+			"notes": "Key goes in the appid query parameter (api-key-query)."
+		},
+		{
+			"service": "Custom HTTP API",
+			"category": "generic",
+			"transport": "api",
+			"endpoint": "https://api.<your-service>.com",
+			"credentials": [
+				{
+					"name": "SERVICE_API_KEY",
+					"kind": "api_key",
+					"allowed_hosts": ["api.<your-service>.com"]
+				}
+			],
+			"docs_url": "",
+			"notes": "Template for any credentialed REST API with no MCP server: register with add_connector(kind: 'api') and follow the direct-api pattern."
+		}
+	],
+	"oauthProviders": [
+		{
+			"id": "google-youtube",
+			"device_code_url": "https://oauth2.googleapis.com/device/code",
+			"token_url": "https://oauth2.googleapis.com/token",
+			"scopes": ["https://www.googleapis.com/auth/youtube"],
+			"client_type": "TVs and Limited Input devices",
+			"allowed_hosts": ["*.googleapis.com", "oauth2.googleapis.com"]
+		},
+		{
+			"id": "github",
+			"authorize_url": "https://github.com/login/oauth/authorize",
+			"device_code_url": "https://github.com/login/device/code",
+			"token_url": "https://github.com/login/oauth/access_token",
+			"scopes": ["repo", "read:org", "admin:public_key"],
+			"client_type": "OAuth App (device flow)",
+			"allowed_hosts": ["github.com", "api.github.com"]
+		}
+	]
+}

--- a/packages/server/src/services/connector-registry.ts
+++ b/packages/server/src/services/connector-registry.ts
@@ -1,0 +1,178 @@
+import { z } from 'zod';
+import { toSlug } from '../lib/slug';
+import registryData from './connector-registry.json';
+
+/**
+ * Curated connector registry: a bundled, hand-authored JSON of connection
+ * patterns, per-service recipes, and OAuth providers. It is the source of the
+ * virtual `connector-recipes` skill agents consult before wiring up an external
+ * service, so they reach for a hosted MCP or a direct `api` connector (secrets
+ * stay `__HEZO_SECRET_*__` placeholders) instead of a desktop-model integration
+ * that would need an interactive browser flow or write a token file to disk.
+ *
+ * The JSON is a *static* asset checked into the repo (not a generated bundle),
+ * so a plain `import` inlines it under tsc (resolveJsonModule) and embeds it in
+ * the compiled binary via `bun build --compile`.
+ */
+
+// The reserved slug for the virtual skill. It is NOT a DB row — every skill
+// surface special-cases this slug (manifest, get_skill, the read-only view) and
+// rejects creating/editing/deleting it.
+export const CONNECTOR_RECIPES_SLUG = 'connector-recipes';
+
+// Credential kinds mirror @hezo/shared CredentialKind so the registry can only
+// name a kind the vault actually understands.
+const credentialKindSchema = z.enum([
+	'api_key',
+	'oauth_token',
+	'github_pat',
+	'webhook_secret',
+	'ssh_private_key',
+	'other',
+]);
+
+const patternSchema = z.object({
+	id: z.string().min(1),
+	title: z.string().min(1),
+	description: z.string().min(1),
+});
+
+const credentialSchema = z.object({
+	name: z.string().min(1),
+	kind: credentialKindSchema,
+	allowed_hosts: z.array(z.string()),
+});
+
+const serviceRecipeSchema = z.object({
+	service: z.string().min(1),
+	category: z.string().min(1),
+	transport: z.enum(['mcp', 'api']),
+	endpoint: z.string(),
+	credentials: z.array(credentialSchema),
+	docs_url: z.string().optional(),
+	notes: z.string().optional(),
+});
+
+const oauthProviderSchema = z.object({
+	id: z.string().min(1),
+	authorize_url: z.string().optional(),
+	device_code_url: z.string().optional(),
+	token_url: z.string().min(1),
+	scopes: z.array(z.string()),
+	client_type: z.string().optional(),
+	allowed_hosts: z.array(z.string()),
+});
+
+const connectorRegistrySchema = z.object({
+	patterns: z.array(patternSchema).min(1),
+	services: z.array(serviceRecipeSchema).min(1),
+	oauthProviders: z.array(oauthProviderSchema).min(1),
+});
+
+export type Pattern = z.infer<typeof patternSchema>;
+export type ServiceRecipe = z.infer<typeof serviceRecipeSchema>;
+export type OAuthProvider = z.infer<typeof oauthProviderSchema>;
+export type ConnectorRegistry = z.infer<typeof connectorRegistrySchema>;
+
+export interface VirtualSkill {
+	slug: string;
+	name: string;
+	description: string;
+	content: string;
+}
+
+let cached: ConnectorRegistry | null = null;
+
+/**
+ * The single accessor for the connector registry. Every consumer MUST go
+ * through here — this is the seam where a future GitHub-refresh override would
+ * slot in (e.g. a DB-stored fetched registry that supersedes the bundled JSON),
+ * without touching any caller. Validates with zod and throws on a malformed
+ * registry so a bad edit fails loudly at load rather than silently degrading a
+ * run's manifest.
+ */
+export function resolveConnectorRegistry(): ConnectorRegistry {
+	if (cached) return cached;
+	cached = connectorRegistrySchema.parse(registryData);
+	return cached;
+}
+
+/** True when a proposed skill slug/name would collide with the reserved virtual skill. */
+export function isConnectorRecipesSlug(slug: string | null | undefined): boolean {
+	return toSlug(String(slug ?? '')) === CONNECTOR_RECIPES_SLUG;
+}
+
+/**
+ * Build the virtual `connector-recipes` skill from the registry: a positive,
+ * MCP-or-API-first guide (no blocklist). Rendered as markdown — a patterns
+ * section, a compact per-service table, then a block per OAuth provider.
+ */
+export function buildConnectorRecipesSkill(
+	registry: ConnectorRegistry = resolveConnectorRegistry(),
+): VirtualSkill {
+	const lines: string[] = [];
+
+	lines.push('# Connecting external services — recipes');
+	lines.push('');
+	lines.push(
+		'Consult this before connecting an external service or requesting a credential. Prefer, in order: (1) a hosted MCP server via register_connector, (2) a direct REST API via an `api` connector, before anything else. Both keep every secret as a `__HEZO_SECRET_<NAME>__` placeholder that the egress proxy substitutes at request time, scoped to allowed_hosts — the raw value never enters the run. Avoid any integration that would need an interactive browser/localhost OAuth callback in the run or write a credential/token file to disk; use a host-side flow (device flow or host-completed auth-code) instead.',
+	);
+	lines.push('');
+
+	lines.push('## Connection patterns');
+	lines.push('');
+	for (const p of registry.patterns) {
+		lines.push(`### ${p.title} (${p.id})`);
+		lines.push('');
+		lines.push(p.description);
+		lines.push('');
+	}
+
+	lines.push('## Service recipes');
+	lines.push('');
+	lines.push(
+		'| Service | Category | Transport | Endpoint | Credential (kind) | allowed_hosts | Docs |',
+	);
+	lines.push('| --- | --- | --- | --- | --- | --- | --- |');
+	for (const s of registry.services) {
+		const cred = s.credentials.map((c) => `${c.name} (${c.kind})`).join('; ');
+		const hosts = s.credentials.flatMap((c) => c.allowed_hosts).join(', ');
+		const docs = s.docs_url ? s.docs_url : '';
+		lines.push(
+			`| ${s.service} | ${s.category} | ${s.transport} | ${s.endpoint} | ${cred || '—'} | ${hosts || '—'} | ${docs} |`,
+		);
+	}
+	lines.push('');
+	// Per-service notes carry the pattern to follow for the tricky ones.
+	const withNotes = registry.services.filter((s) => s.notes);
+	if (withNotes.length > 0) {
+		lines.push('### Service notes');
+		lines.push('');
+		for (const s of withNotes) {
+			lines.push(`- **${s.service}**: ${s.notes}`);
+		}
+		lines.push('');
+	}
+
+	lines.push('## OAuth providers');
+	lines.push('');
+	for (const o of registry.oauthProviders) {
+		lines.push(`### ${o.id}`);
+		lines.push('');
+		if (o.client_type) lines.push(`- Client type: ${o.client_type}`);
+		if (o.authorize_url) lines.push(`- Authorize URL: ${o.authorize_url}`);
+		if (o.device_code_url) lines.push(`- Device code URL: ${o.device_code_url}`);
+		lines.push(`- Token URL: ${o.token_url}`);
+		lines.push(`- Scopes: ${o.scopes.join(', ') || '—'}`);
+		lines.push(`- allowed_hosts: ${o.allowed_hosts.join(', ') || '—'}`);
+		lines.push('');
+	}
+
+	return {
+		slug: CONNECTOR_RECIPES_SLUG,
+		name: 'Connector Recipes',
+		description:
+			'MCP-or-API-first recipes for connecting external services and requesting credentials without leaking secrets into a run.',
+		content: lines.join('\n').trim(),
+	};
+}

--- a/packages/server/src/services/template-resolver.ts
+++ b/packages/server/src/services/template-resolver.ts
@@ -1,6 +1,7 @@
 import { HEZO_DOCS_URL, repoNameFromIdentifier } from '@hezo/shared';
 import type { Db } from '../db/database';
 import { terminalStatusParams } from '../lib/sql';
+import { buildConnectorRecipesSkill } from './connector-registry';
 import { buildHezoDocsBlock } from './docs-bundle';
 import { CONTAINER_WORKTREES_ROOT } from './workspace';
 
@@ -191,6 +192,8 @@ const SHARED_INSTRUCTIONS = `
 - Use it ONLY after genuinely concluding no action is needed this run. It does not exempt you from the completion rules above: if there is failing work, deferred work, or a thread awaiting your reply, handle it or route it structurally (a sub-task, a \`blocked_by\` dependency, or an \`@\`-mention) instead of declaring no work.
 
 ### Third-Party Credentials Always Land in the Hezo Vault
+- **Before connecting an external service or requesting a credential, call \`get_skill('connector-recipes')\` and follow the MCP-or-API-first recipe.** It is the curated guide to the connection pattern for each well-known service and the general fallbacks.
+- **Never choose an integration that needs an interactive browser/localhost OAuth flow or writes a credential/token file to disk inside the run — prefer a hosted MCP or a direct \`api\` connector so secrets stay \`__HEZO_SECRET_*__\` placeholders.** A host-side flow (device flow or host-completed auth-code) keeps the acquisition off the container entirely.
 - Whenever you need to authenticate with a third-party service — MCP server, REST API, CLI tool, anything — the credential must be stored in the Hezo vault. Never leave a token, API key, OAuth bearer, or password in code, ticket descriptions, comments, project docs, or environment files you write.
 - **The paste form is the only way a secret value reaches you — never ask a human to send it any other way.** Never ask anyone to type, paste, or "send you" a token, key, or password in a comment, the chat box, or a direct message. You must never see the plaintext; a value dropped into a thread is a leak that then has to be rotated. \`request_credential\` routes it straight to the encrypted vault without it ever passing through the conversation — if someone offers to share a secret in chat, point them at that form instead.
 - For services with an MCP server: call \`register_connector\` with the MCP URL and (if applicable) a \`skill_id\` from \`fetch_skill_file\`. This posts a connect_required comment with a Connect button for the human; once they authorize, the MCP becomes available across every team agent run with the token substituted at egress.
@@ -308,20 +311,21 @@ export async function resolveSystemPrompt(
 				return true;
 			})
 			.sort((a, b) => a.name.localeCompare(b.name));
-		let manifest: string;
-		if (skillRows.length > 0) {
-			const lines = skillRows
-				.map((s) => `- ${s.name} (slug: ${s.slug})${s.description ? `: ${s.description}` : ''}`)
-				.join('\n');
-			manifest = [
-				'The team skills database holds reusable know-how. Entries are listed below by name and slug.',
-				"Call get_skill(slug) to load a skill's full instructions when it is relevant to your task.",
-				'',
-				lines,
-			].join('\n');
-		} else {
-			manifest = 'No skills in the team skills database yet.';
-		}
+		// The built-in `connector-recipes` virtual skill (generated from the
+		// connector registry, not a DB row) is surfaced in every run's manifest so
+		// agents can get_skill('connector-recipes') before wiring up an external
+		// service. It always appears, even when the team has no DB skills yet.
+		const virtual = buildConnectorRecipesSkill();
+		const dbLines = skillRows.map(
+			(s) => `- ${s.name} (slug: ${s.slug})${s.description ? `: ${s.description}` : ''}`,
+		);
+		const virtualLine = `- ${virtual.name} (slug: ${virtual.slug}): ${virtual.description}`;
+		const manifest = [
+			'The team skills database holds reusable know-how. Entries are listed below by name and slug.',
+			"Call get_skill(slug) to load a skill's full instructions when it is relevant to your task.",
+			'',
+			[...dbLines, virtualLine].join('\n'),
+		].join('\n');
 		resolved = resolved.replace(/\{\{skills_context\}\}/g, manifest);
 	}
 

--- a/packages/server/test/connector-recipes-skill.test.ts
+++ b/packages/server/test/connector-recipes-skill.test.ts
@@ -1,0 +1,171 @@
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Db } from '../src/db/database';
+import type { Env } from '../src/lib/types';
+import { resolveSystemPrompt } from '../src/services/template-resolver';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
+
+let app: Hono<Env>;
+let db: Db;
+let token: string; // superuser admin
+let teamId: string;
+let projectId: string;
+let projectSlug: string;
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+
+	const teamRes = await createTestTeam(db, { name: 'Recipes Co', description: 'Ships things' });
+	teamId = (await teamRes.json()).data.id;
+	const projectRes = await createTestProject(db, teamId, { name: 'Recipes Project' });
+	const pData = (await projectRes.json()).data;
+	projectId = pData.id;
+	projectSlug = pData.slug;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+async function callTool(
+	name: string,
+	args: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+	const res = await app.request('/mcp', {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			jsonrpc: '2.0',
+			method: 'tools/call',
+			params: { name, arguments: { project: projectSlug, ...args } },
+			id: 1,
+		}),
+	});
+	const body = (await res.json()) as {
+		result?: { content: Array<{ text: string }> };
+		error?: { message: string };
+	};
+	if (!body.result) return { error: body.error?.message ?? 'unknown error' };
+	try {
+		return JSON.parse(body.result.content[0].text) as Record<string, unknown>;
+	} catch {
+		return { error: body.result.content[0].text };
+	}
+}
+
+describe('connector-recipes virtual skill: manifest + steering', () => {
+	it('always appears in the {{skills_context}} manifest', async () => {
+		const result = await resolveSystemPrompt(db, '{{skills_context}}', {
+			teamId,
+			projectId,
+			mode: 'placeholders',
+		});
+		expect(result).toContain('- Connector Recipes (slug: connector-recipes):');
+	});
+
+	it('injects the two SHARED_INSTRUCTIONS steering lines into a resolved prompt', async () => {
+		const result = await resolveSystemPrompt(db, 'Head\n{{skills_context}}', {
+			teamId,
+			projectId,
+		});
+		expect(result).toContain("call `get_skill('connector-recipes')`");
+		expect(result).toContain(
+			'Never choose an integration that needs an interactive browser/localhost OAuth flow',
+		);
+	});
+});
+
+describe('connector-recipes virtual skill: get_skill', () => {
+	it('returns generated content for the reserved slug', async () => {
+		const got = await callTool('get_skill', { slug: 'connector-recipes' });
+		expect(got.name).toBe('Connector Recipes');
+		expect(got.slug).toBe('connector-recipes');
+		expect(String(got.content)).toContain('## Connection patterns');
+		expect(String(got.content)).toContain('### google-youtube');
+	});
+});
+
+describe('connector-recipes virtual skill: reservation', () => {
+	it('create_skill rejects the reserved slug', async () => {
+		const r = await callTool('create_skill', {
+			name: 'Connector Recipes',
+			slug: 'connector-recipes',
+			content: '# nope',
+		});
+		expect(String(r.error)).toContain('reserved built-in skill');
+	});
+
+	it('create_skill rejects a case/spacing variant that normalizes to the reserved slug', async () => {
+		const r = await callTool('create_skill', {
+			name: 'x',
+			slug: 'Connector-Recipes',
+			content: '# nope',
+		});
+		expect(String(r.error)).toContain('reserved built-in skill');
+	});
+
+	it('propose_skill rejects the reserved slug', async () => {
+		const r = await callTool('propose_skill', {
+			skill_name: 'Connector Recipes',
+			skill_slug: 'connector-recipes',
+			content: '# nope',
+			reason: 'test',
+		});
+		expect(String(r.error)).toContain('reserved built-in skill');
+	});
+
+	it('POST /skills rejects the reserved slug', async () => {
+		const res = await app.request('/api/skills', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name: 'Connector Recipes', content: '# nope' }),
+		});
+		expect(res.status).toBe(400);
+		expect(JSON.stringify(await res.json())).toContain('reserved built-in skill');
+	});
+});
+
+describe('connector-recipes virtual skill: read-only admin view', () => {
+	it('GET /skills includes the synthetic read-only entry', async () => {
+		const res = await app.request('/api/skills', { headers: authHeader(token) });
+		expect(res.status).toBe(200);
+		const rows = (await res.json()).data as Array<Record<string, unknown>>;
+		const virtual = rows.find((r) => r.id === 'connector-recipes');
+		expect(virtual).toBeDefined();
+		expect(virtual?.readonly).toBe(true);
+		expect(virtual?.slug).toBe('connector-recipes');
+		// Stored rows are annotated readonly:false.
+		expect(rows.every((r) => typeof r.readonly === 'boolean')).toBe(true);
+	});
+
+	it('GET /skills/connector-recipes returns generated content', async () => {
+		const res = await app.request('/api/skills/connector-recipes', { headers: authHeader(token) });
+		expect(res.status).toBe(200);
+		const skill = (await res.json()).data as Record<string, unknown>;
+		expect(skill.readonly).toBe(true);
+		expect(String(skill.content)).toContain('## Service recipes');
+	});
+
+	it('PATCH /skills/connector-recipes is rejected', async () => {
+		const res = await app.request('/api/skills/connector-recipes', {
+			method: 'PATCH',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ content: '# edited' }),
+		});
+		expect(res.status).toBe(400);
+		expect(JSON.stringify(await res.json())).toContain('built-in skill');
+	});
+
+	it('DELETE /skills/connector-recipes is rejected', async () => {
+		const res = await app.request('/api/skills/connector-recipes', {
+			method: 'DELETE',
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(400);
+		expect(JSON.stringify(await res.json())).toContain('built-in skill');
+	});
+});

--- a/packages/server/test/connector-registry.test.ts
+++ b/packages/server/test/connector-registry.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import {
+	buildConnectorRecipesSkill,
+	CONNECTOR_RECIPES_SLUG,
+	isConnectorRecipesSlug,
+	resolveConnectorRegistry,
+} from '../src/services/connector-registry';
+
+describe('connector registry', () => {
+	it('resolveConnectorRegistry validates the bundled JSON with zod', () => {
+		// Throws on malformed data — reaching here means the real file passed the schema.
+		const registry = resolveConnectorRegistry();
+		expect(registry.patterns.length).toBeGreaterThanOrEqual(8);
+		expect(registry.services.length).toBeGreaterThanOrEqual(15);
+		expect(registry.oauthProviders.length).toBeGreaterThanOrEqual(1);
+	});
+
+	it('returns a cached, stable instance', () => {
+		expect(resolveConnectorRegistry()).toBe(resolveConnectorRegistry());
+	});
+
+	it('includes the required Google/YouTube device-flow provider', () => {
+		const google = resolveConnectorRegistry().oauthProviders.find((p) => p.id === 'google-youtube');
+		expect(google).toBeDefined();
+		expect(google?.device_code_url).toBe('https://oauth2.googleapis.com/device/code');
+		expect(google?.token_url).toBe('https://oauth2.googleapis.com/token');
+		expect(google?.scopes).toContain('https://www.googleapis.com/auth/youtube');
+		expect(google?.client_type).toBe('TVs and Limited Input devices');
+		expect(google?.allowed_hosts).toEqual(
+			expect.arrayContaining(['*.googleapis.com', 'oauth2.googleapis.com']),
+		);
+	});
+
+	it('every service credential names a known kind and the transport is mcp|api', () => {
+		const kinds = new Set([
+			'api_key',
+			'oauth_token',
+			'github_pat',
+			'webhook_secret',
+			'ssh_private_key',
+			'other',
+		]);
+		for (const s of resolveConnectorRegistry().services) {
+			expect(['mcp', 'api']).toContain(s.transport);
+			for (const cred of s.credentials) expect(kinds.has(cred.kind)).toBe(true);
+		}
+	});
+});
+
+describe('buildConnectorRecipesSkill', () => {
+	const skill = buildConnectorRecipesSkill();
+
+	it('produces the reserved slug/name/description', () => {
+		expect(skill.slug).toBe(CONNECTOR_RECIPES_SLUG);
+		expect(skill.name).toBe('Connector Recipes');
+		expect(skill.description.length).toBeGreaterThan(0);
+	});
+
+	it('renders a non-empty body with patterns, services, and the Google provider block', () => {
+		expect(skill.content.length).toBeGreaterThan(200);
+		expect(skill.content).toContain('## Connection patterns');
+		// A known pattern id from the registry.
+		expect(skill.content).toContain('(mcp-hosted)');
+		expect(skill.content).toContain('## Service recipes');
+		// The Google/YouTube provider block renders with its device-flow URL.
+		expect(skill.content).toContain('## OAuth providers');
+		expect(skill.content).toContain('### google-youtube');
+		expect(skill.content).toContain('https://oauth2.googleapis.com/device/code');
+		// Positive framing: no blocklist copy.
+		expect(skill.content.toLowerCase()).not.toContain("don't use");
+	});
+});
+
+describe('isConnectorRecipesSlug', () => {
+	it('matches the reserved slug and its case/spacing variants, rejects others', () => {
+		expect(isConnectorRecipesSlug('connector-recipes')).toBe(true);
+		expect(isConnectorRecipesSlug('Connector Recipes')).toBe(true);
+		expect(isConnectorRecipesSlug('Connector-Recipes')).toBe(true);
+		expect(isConnectorRecipesSlug('my-skill')).toBe(false);
+		expect(isConnectorRecipesSlug('')).toBe(false);
+		expect(isConnectorRecipesSlug(null)).toBe(false);
+	});
+});

--- a/packages/server/test/skills.test.ts
+++ b/packages/server/test/skills.test.ts
@@ -364,12 +364,16 @@ describe('template resolver {{skills_context}} (global)', () => {
 		expect(resolved).not.toContain('Do the thing.');
 	});
 
-	it('falls back to a placeholder when there are no skills', async () => {
+	it('still lists the built-in connector-recipes skill when there are no DB skills', async () => {
+		await db.query('DELETE FROM skills');
 		const resolved = await resolveSystemPrompt(db, '{{skills_context}}', {
 			teamId,
 			dataDir: tempDataDir,
 		});
-		expect(resolved).toContain('No skills');
+		// The empty-DB case no longer emits a placeholder — the built-in virtual
+		// skill always appears in the manifest.
+		expect(resolved).toContain('The team skills database holds reusable know-how.');
+		expect(resolved).toContain('(slug: connector-recipes)');
 	});
 
 	it('lists every active skill in the manifest', async () => {

--- a/packages/server/test/template-resolver-cov-fill.test.ts
+++ b/packages/server/test/template-resolver-cov-fill.test.ts
@@ -121,13 +121,16 @@ describe('placeholder substitution', () => {
 		expect(result).toContain('before\nafter');
 	});
 
-	it('renders {{skills_context}} empty-state when no skills exist', async () => {
+	it('renders {{skills_context}} with only the built-in virtual skill when no DB skills exist', async () => {
 		await ctx.db.query('DELETE FROM skills');
 		const result = await resolveSystemPrompt(ctx.db, '{{skills_context}}', {
 			teamId,
 			mode: 'placeholders',
 		});
-		expect(result).toContain('No skills in the team skills database yet.');
+		// The empty-DB case is no longer an empty-state message: the built-in
+		// connector-recipes virtual skill always appears in the manifest.
+		expect(result).toContain('The team skills database holds reusable know-how.');
+		expect(result).toContain('(slug: connector-recipes)');
 	});
 
 	it('renders {{skills_context}} as a name+slug manifest pointing at get_skill', async () => {

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -1116,6 +1116,10 @@ export interface SkillRecord {
 export interface SkillListItemRecord extends Omit<SkillRecord, 'content'> {
 	project_name?: string | null;
 	project_slug?: string | null;
+	/** True for a built-in, generated skill (e.g. `connector-recipes`) that is
+	 * viewable but not editable — the UI hides edit/delete affordances and the
+	 * server rejects mutations. Absent/false for normal stored skills. */
+	readonly?: boolean;
 }
 
 /**

--- a/packages/web/src/routes/settings/skills.tsx
+++ b/packages/web/src/routes/settings/skills.tsx
@@ -344,15 +344,19 @@ function InstanceSkillRow({ skill, scopeOptions, onEdit, onDelete }: InstanceSki
 		>
 			<div className="flex items-center gap-2 min-w-0 flex-1">
 				<span className="font-medium">{skill.name}</span>
-				<SearchableSelect
-					options={scopeOptions}
-					value={scopeValue}
-					onChange={changeScope}
-					trigger={scopeTrigger}
-					searchPlaceholder="Search projects…"
-					emptyLabel="No projects"
-					testId="instance-skill-scope-select"
-				/>
+				{skill.readonly ? (
+					<Badge color="neutral">Built-in</Badge>
+				) : (
+					<SearchableSelect
+						options={scopeOptions}
+						value={scopeValue}
+						onChange={changeScope}
+						trigger={scopeTrigger}
+						searchPlaceholder="Search projects…"
+						emptyLabel="No projects"
+						testId="instance-skill-scope-select"
+					/>
+				)}
 				{skill.tags?.map((t) => (
 					<Badge key={t} color="neutral">
 						{t}
@@ -364,22 +368,26 @@ function InstanceSkillRow({ skill, scopeOptions, onEdit, onDelete }: InstanceSki
 			</div>
 			<span className="flex items-center gap-2 shrink-0">
 				{rowError && <span className="text-xs text-danger">{rowError}</span>}
-				<button
-					type="button"
-					onClick={onEdit}
-					aria-label={`Edit ${skill.name}`}
-					className="text-text-3 hover:text-text-1"
-				>
-					<Pencil className="w-3.5 h-3.5" />
-				</button>
-				<button
-					type="button"
-					onClick={onDelete}
-					aria-label={`Delete ${skill.name}`}
-					className="text-text-3 hover:text-danger"
-				>
-					<Trash2 className="w-3.5 h-3.5" />
-				</button>
+				{!skill.readonly && (
+					<>
+						<button
+							type="button"
+							onClick={onEdit}
+							aria-label={`Edit ${skill.name}`}
+							className="text-text-3 hover:text-text-1"
+						>
+							<Pencil className="w-3.5 h-3.5" />
+						</button>
+						<button
+							type="button"
+							onClick={onDelete}
+							aria-label={`Delete ${skill.name}`}
+							className="text-text-3 hover:text-danger"
+						>
+							<Trash2 className="w-3.5 h-3.5" />
+						</button>
+					</>
+				)}
 			</span>
 		</div>
 	);

--- a/packages/web/test/settings-skills.test.tsx
+++ b/packages/web/test/settings-skills.test.tsx
@@ -18,6 +18,17 @@ test('a created skill is editable and deletable (no built-in concept)', async ()
 	expect(r.queryByText('built-in')).toBeNull();
 });
 
+test('the built-in connector-recipes skill is read-only (Built-in badge, no edit/delete)', async () => {
+	const r = await renderApp({ initialPath: '/settings/skills' });
+
+	// The generated virtual skill is always present in the instance list.
+	await r.findByText('Connector Recipes');
+	await r.findByText('Built-in');
+	// It exposes no edit/delete affordances — the server also rejects mutations.
+	expect(r.queryByLabelText('Edit Connector Recipes')).toBeNull();
+	expect(r.queryByLabelText('Delete Connector Recipes')).toBeNull();
+});
+
 test('the skill content editor previews markdown', async () => {
 	const r = await renderApp({ initialPath: '/settings/skills' });
 


### PR DESCRIPTION
## What & why

PR3 of the connectors effort. A curated, in-repo **connector registry** (JSON) that generates a **virtual, read-only `connector-recipes` skill** every agent consults before wiring up an external service — so they reach for a hosted MCP or a direct `api` connector (secrets stay `__HEZO_SECRET_*__` placeholders) instead of a desktop-model integration that needs an interactive browser flow or writes a token file to disk (the failure that started this whole effort).

## Changes

**Registry + generator**
- `connector-registry.json` (hand-authored data) + `connector-registry.ts` (zod schema + generator). 11 connection patterns, ~18 service recipes, and OAuth providers (Google/YouTube device-flow exactly, GitHub device-flow).
- A single `resolveConnectorRegistry()` accessor (zod-validated, cached) is the one seam every consumer reads through — where a **future GitHub-refresh DB override** slots in without touching callers (documented, not built).
- `buildConnectorRecipesSkill()` renders positive-framed markdown (patterns + service table + provider blocks; **no blocklist**).

**Virtual skill (not a DB row)** — wired at every skill surface:
- run manifest (`{{skills_context}}`), `get_skill('connector-recipes')`, and a **read-only** view (`GET /skills`, `GET /skills/:id`).
- the slug is **reserved**: `create_skill` / `propose_skill` / `POST /skills` reject it; `PATCH`/`DELETE` reject it. Nothing to seed — it auto-updates with the binary.

**Steering** — two domain-neutral lines in `SHARED_INSTRUCTIONS`: the `get_skill('connector-recipes')` pointer + the "never use a browser/localhost-OAuth or token-file-on-disk integration" rule.

**Web** — the built-in skill renders **read-only** on the skills settings page ("Built-in" badge, no edit/delete); the server rejects mutations regardless. `SkillListItemRecord` gains a `readonly` flag.

## Verification

- `bun run typecheck` + full `bun run build` — green (JSON import bundles; `docs/reference/mcp-api.md` regenerated with no diff, so no tool-schema drift).
- Server tests pass: `connector-registry.test.ts` (7), `connector-recipes-skill.test.ts` (11), `template-resolver.test.ts` (89, incl. manifest + steering), `skills.test.ts` (19, incl. reservation + read-only view).
- Web tests pass: `settings-skills.test.tsx` (5, incl. a new read-only virtual-skill assertion).

## Follow-ups (per plan)

The **generic OAuth broker** (device-flow acquisition + host-side refresh, which the Google/YouTube registry entry describes) is PR4. The registry's **runtime GitHub-refresh override** is a deferred enhancement behind the existing loader seam.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JL2unhYgoKWnTYmkgTqArx

---
_Generated by [Claude Code](https://claude.ai/code/session_01JL2unhYgoKWnTYmkgTqArx)_