### PR TITLE
fix: stack connector row header on mobile

### DIFF
--- a/packages/web/src/routes/projects/$projectId/connectors.tsx
+++ b/packages/web/src/routes/projects/$projectId/connectors.tsx
@@ -379,9 +379,9 @@ function GitHubRow({ projectId, connection }: GitHubRowProps) {
 					providerLabel="GitHub"
 				/>
 			)}
-			<div className="flex items-start justify-between gap-4">
+			<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
 				<div className="flex-1 min-w-0">
-					<div className="flex items-center gap-2">
+					<div className="flex items-center gap-2 flex-wrap">
 						<Github className="size-4 shrink-0" />
 						<h2 className="text-base font-medium truncate">GitHub</h2>
 						<StatusBadge status={status} />
@@ -404,7 +404,7 @@ function GitHubRow({ projectId, connection }: GitHubRowProps) {
 					{error && <p className="text-xs text-danger-soft-fg mt-2">{error}</p>}
 				</div>
 
-				<div className="flex items-center gap-2 shrink-0">
+				<div className="flex flex-wrap items-center gap-2 sm:shrink-0">
 					{connection ? (
 						<Button
 							size="sm"
@@ -558,9 +558,9 @@ function ConnectorRow({ connector, projectId, focused, focusRef }: ConnectorRowP
 					connectorLabel={connector.display_name ?? connector.name}
 				/>
 			)}
-			<div className="flex items-start justify-between gap-4">
+			<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
 				<div className="flex-1 min-w-0">
-					<div className="flex items-center gap-2">
+					<div className="flex items-center gap-2 flex-wrap">
 						<h2 className="text-base font-medium truncate">
 							{connector.display_name ?? connector.name}
 						</h2>
@@ -606,7 +606,10 @@ function ConnectorRow({ connector, projectId, focused, focusRef }: ConnectorRowP
 					{info && <p className="text-xs text-text-3 mt-2">{info}</p>}
 				</div>
 
-				<div className="flex items-center gap-2 shrink-0">
+				<div
+					className="flex flex-wrap items-center gap-2 sm:shrink-0"
+					data-testid="connector-actions"
+				>
 					{isGlobal ? (
 						// Read-only here: manage global connectors on the global page.
 						<Link

--- a/test/browser/connectors-layout.mobile.spec.ts
+++ b/test/browser/connectors-layout.mobile.spec.ts
@@ -1,0 +1,68 @@
+// Decision-tree item 2: the connector row header is viewport-conditional —
+// on mobile the title/URL block and the action buttons stack vertically
+// (`flex-col` → `sm:flex-row`), so the title gets full width instead of being
+// truncated to an unreadable fragment while the buttons crowd it. happy-dom
+// can't run the media query or report real layout boxes, so this needs real
+// Chromium + setViewportSize + boundingBox.
+import { expect, test } from './fixtures';
+import { createProjectAndClearPlanning, uniqueName, waitForPageLoad } from './helpers';
+
+test.describe('Connector row responsive layout', () => {
+	test('the header stacks (buttons below title) on mobile and sits inline on desktop', async ({
+		page,
+		sharedWorkspace,
+	}) => {
+		const { token } = sharedWorkspace;
+		const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+		const project = await createProjectAndClearPlanning(page, '', token, {
+			name: uniqueName('Connector Layout'),
+			description: 'E2E connector row responsiveness.',
+		});
+
+		// A pending MCP connector with a long URL renders the Connect + API-key
+		// buttons alongside the title — the pair that used to squeeze the title
+		// down to "typeful…" on a 375px screen.
+		const connectorRes = await page.request.post(`/api/projects/${project.slug}/connectors`, {
+			headers,
+			data: {
+				name: 'typefully',
+				kind: 'saas',
+				config: { url: 'https://mcp.typefully.com/some/fairly/long/path/mcp' },
+			},
+		});
+		expect(connectorRes.ok()).toBeTruthy();
+		const connectorId = ((await connectorRes.json()) as { data: { id: string } }).data.id;
+
+		const row = page.locator(`[data-testid="connector-row"][data-connector-id="${connectorId}"]`);
+		const title = row.locator('h2');
+		const actions = row.getByTestId('connector-actions');
+
+		// --- Mobile: title above, actions on their own line below. ---
+		await page.setViewportSize({ width: 375, height: 800 });
+		await page.goto(`/projects/${project.slug}/connectors`);
+		await waitForPageLoad(page);
+		await expect(row).toBeVisible({ timeout: 15000 });
+
+		const rowBoxM = await row.boundingBox();
+		const titleBoxM = await title.boundingBox();
+		const actionsBoxM = await actions.boundingBox();
+		if (!rowBoxM || !titleBoxM || !actionsBoxM) throw new Error('Missing layout box');
+
+		// Actions sit strictly below the title (stacked), not to its right.
+		expect(actionsBoxM.y).toBeGreaterThanOrEqual(titleBoxM.y + titleBoxM.height - 1);
+		// And the whole action group stays inside the card — no horizontal overflow.
+		expect(actionsBoxM.x).toBeGreaterThanOrEqual(rowBoxM.x - 1);
+		expect(actionsBoxM.x + actionsBoxM.width).toBeLessThanOrEqual(rowBoxM.x + rowBoxM.width + 1);
+
+		// --- Desktop: title and actions share a row (actions to the right). ---
+		await page.setViewportSize({ width: 1280, height: 900 });
+		const titleBoxD = await title.boundingBox();
+		const actionsBoxD = await actions.boundingBox();
+		if (!titleBoxD || !actionsBoxD) throw new Error('Missing layout box');
+		// Same row: vertically overlapping, actions right of the title.
+		expect(Math.abs(actionsBoxD.y - titleBoxD.y)).toBeLessThan(
+			actionsBoxD.height + titleBoxD.height,
+		);
+		expect(actionsBoxD.x).toBeGreaterThan(titleBoxD.x);
+	});
+});


### PR DESCRIPTION
## Problem

On the Connectors page, each card kept its title/URL block and its action buttons on a single horizontal row (`flex items-start justify-between`). On a narrow (mobile) screen the buttons crowded the header and the title/URL truncated down to unreadable fragments — "typeful…", "https…", "DatoC…" (see the reported screenshot).

## Fix

- **`packages/web/src/routes/projects/$projectId/connectors.tsx`** — for both `GitHubRow` and `ConnectorRow`, the header now stacks vertically on mobile and restores the side-by-side layout at `sm:` and up: `flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4`. The title/badge row and the action-button group both `flex-wrap` so a badge or button drops to the next line instead of squeezing its neighbours, and the actions container is `sm:shrink-0` (only pinned once it's back on its own column at tablet+). Added a `data-testid="connector-actions"` on the actions container for layout assertions.

On mobile the title now shows in full with its status badge, the URL gets its own full-width line, and the Connect / API key / Disconnect buttons wrap onto their own row below. Desktop is unchanged.

## Tests

- **`test/browser/connectors-layout.mobile.spec.ts`** (new) — seeds a pending MCP connector with a long URL, then at 375px asserts the actions group sits below the title and stays within the card (no horizontal overflow), and at 1280px asserts the title and actions share a row. Real Chromium + `boundingBox()` is required because the behaviour is viewport-conditional (decision-tree item 2 — happy-dom can't run the media query or report layout boxes).
- Existing `connectors-page.test.tsx` and `github-section-states.test.tsx` component suites pass (18 tests), typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tjq7EF986RnhLhFRYTvqRD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tjq7EF986RnhLhFRYTvqRD)_