### PR TITLE
feat(skills): view modal for all skills; surface connector-recipes on project pages

### DIFF
--- a/docs/concepts/skills.md
+++ b/docs/concepts/skills.md
@@ -48,9 +48,11 @@ each project's manifest focused while still letting broadly-useful know-how reac
   project when it doesn't say.
 - **Built in.** Hezo ships one skill of its own: **`connector-recipes`**, a curated
   catalog of connection recipes agents consult before
-  [connecting an external service](/docs/mcp/connecting-mcp-servers). It appears in
-  **Settings → Skills** with a **Built-in** badge, is read-only — it can't be edited or
-  deleted — and updates automatically as Hezo does.
+  [connecting an external service](/docs/mcp/connecting-mcp-servers). It appears with a
+  **Built-in** badge on **Settings → Skills** and — because it's global — on every
+  project's **Skills** page too, is read-only — it can't be edited or deleted — and
+  updates automatically as Hezo does. Open it (the **view** button on its row) to read the
+  full recipe catalog.
 
 Agents contribute proactively for connected services: once an agent gets a
 [connector](/docs/mcp/connecting-mcp-servers) to a third-party service working, it records
@@ -69,7 +71,9 @@ and each row has a scope drop-down so you can move a skill between global and an
 works just like the [Connectors](/docs/mcp/connecting-mcp-servers) page). Each project also has its
 own **Skills** page, under **Connectors** in the project's settings menu, showing that
 project's skills plus the globals; you can edit or remove the project's own skills there,
-while global ones are shown for reference and stay managed on the global page.
+while global ones are shown for reference and stay managed on the global page. Every row —
+on either page — has a **view** button that opens the skill and renders its full markdown so
+you can read exactly what your agents see, including read-only built-ins.
 
 Skills are part of what the [Coach](/docs/concepts/coach-and-self-improving-teams) can
 write to: when a retrospective surfaces a reusable procedure, it may capture it as a skill

--- a/packages/server/src/routes/skills.ts
+++ b/packages/server/src/routes/skills.ts
@@ -513,10 +513,23 @@ skillsRoutes.get('/projects/:projectId/skills', async (c) => {
 		 ORDER BY s.name`,
 		[projectId],
 	);
-	return ok(c, result.rows);
+	// The built-in `connector-recipes` virtual skill is global (project_id null) —
+	// every project's runs see it — so surface it read-only alongside the stored
+	// rows here too, exactly as the admin /skills list does.
+	const rows: Record<string, unknown>[] = result.rows.map((r) => ({
+		...(r as Record<string, unknown>),
+		readonly: false,
+	}));
+	rows.push(connectorRecipesSkillRow(false));
+	return ok(c, rows);
 });
 
 skillsRoutes.get('/projects/:projectId/skills/:id', async (c) => {
+	// The built-in virtual skill is generated (global, not a DB row); serve it
+	// read-only here so the per-project viewer can render its content.
+	if (c.req.param('id') === CONNECTOR_RECIPES_SLUG) {
+		return ok(c, connectorRecipesSkillRow(true));
+	}
 	const db = c.get('db');
 	const projectId = c.get('projectId') as string;
 	const result = await db.query<SkillRecord>(

--- a/packages/server/test/connector-recipes-skill.test.ts
+++ b/packages/server/test/connector-recipes-skill.test.ts
@@ -172,3 +172,30 @@ describe('connector-recipes virtual skill: read-only admin view', () => {
 		expect(JSON.stringify(await res.json())).toContain('built-in skill');
 	});
 });
+
+describe('connector-recipes virtual skill: per-project read-only view', () => {
+	it('GET /projects/:projectId/skills surfaces the built-in skill as a global read-only entry', async () => {
+		const res = await app.request(`/api/projects/${projectId}/skills`, {
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		const rows = (await res.json()).data as Array<Record<string, unknown>>;
+		const virtual = rows.find((r) => r.id === 'connector-recipes');
+		expect(virtual).toBeDefined();
+		expect(virtual?.readonly).toBe(true);
+		// Global scope (project_id null) so it renders under "Global (all projects)".
+		expect(virtual?.project_id).toBeNull();
+		// Stored rows are annotated readonly:false so the UI can tell them apart.
+		expect(rows.every((r) => typeof r.readonly === 'boolean')).toBe(true);
+	});
+
+	it('GET /projects/:projectId/skills/connector-recipes returns generated content', async () => {
+		const res = await app.request(`/api/projects/${projectId}/skills/connector-recipes`, {
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		const skill = (await res.json()).data as Record<string, unknown>;
+		expect(skill.readonly).toBe(true);
+		expect(String(skill.content)).toContain('## Service recipes');
+	});
+});

--- a/packages/web/src/components/skill-view-dialog.tsx
+++ b/packages/web/src/components/skill-view-dialog.tsx
@@ -1,0 +1,58 @@
+import type { SkillRecord } from '@hezo/shared';
+import * as Dialog from '@radix-ui/react-dialog';
+import { Loader2 } from 'lucide-react';
+import { MarkdownProse } from './markdown-prose';
+import { Badge } from './ui/badge';
+import { DialogContent } from './ui/dialog';
+
+interface SkillViewDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	/** The full skill (including `content`). Undefined while it loads. */
+	skill: SkillRecord | undefined;
+	/** Name shown in the title while the full skill is still loading. */
+	fallbackName?: string;
+}
+
+/**
+ * Read-only skill viewer: renders a skill's markdown content in a modal. Shared
+ * by the global Skills page and the per-project Skills page so any skill — a
+ * stored one or the built-in, non-editable `connector-recipes` — can be read in
+ * full without leaving the page.
+ */
+export function SkillViewDialog({ open, onOpenChange, skill, fallbackName }: SkillViewDialogProps) {
+	return (
+		<Dialog.Root open={open} onOpenChange={onOpenChange}>
+			<DialogContent size="2xl" data-testid="skill-view-dialog">
+				<Dialog.Title className="pr-8 text-lg font-semibold">
+					{skill?.name ?? fallbackName ?? 'Skill'}
+				</Dialog.Title>
+				{skill?.description ? (
+					<Dialog.Description className="mt-1 text-[13px] text-text-2">
+						{skill.description}
+					</Dialog.Description>
+				) : (
+					<Dialog.Description className="sr-only">Skill content</Dialog.Description>
+				)}
+				{skill && skill.tags.length > 0 && (
+					<div className="mt-2 flex flex-wrap gap-1">
+						{skill.tags.map((t) => (
+							<Badge key={t} color="neutral">
+								{t}
+							</Badge>
+						))}
+					</div>
+				)}
+				<div className="mt-4 min-h-[120px]">
+					{skill ? (
+						<MarkdownProse testId="skill-view-content">{skill.content}</MarkdownProse>
+					) : (
+						<div className="flex items-center gap-2 text-[13px] text-text-2">
+							<Loader2 className="h-4 w-4 animate-spin" /> Loading…
+						</div>
+					)}
+				</div>
+			</DialogContent>
+		</Dialog.Root>
+	);
+}

--- a/packages/web/src/components/ui/dialog.tsx
+++ b/packages/web/src/components/ui/dialog.tsx
@@ -15,6 +15,7 @@ export const dialogContentClassName = {
 	md: `${base} sm:max-w-md`,
 	lg: `${base} sm:max-w-lg`,
 	xl: `${base} sm:max-w-xl`,
+	'2xl': `${base} sm:max-w-2xl`,
 } as const;
 
 export type DialogSize = keyof typeof dialogContentClassName;

--- a/packages/web/src/routes/projects/$projectId/skills.tsx
+++ b/packages/web/src/routes/projects/$projectId/skills.tsx
@@ -1,14 +1,14 @@
 import { createFileRoute, Link } from '@tanstack/react-router';
-import { BookOpen, ExternalLink, Pencil, Plus, Trash2 } from 'lucide-react';
+import { BookOpen, ExternalLink, Eye, Pencil, Plus, Trash2 } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { MarkdownEditor } from '../../../components/markdown-editor';
 import { RevisionsPanel } from '../../../components/revisions-panel';
+import { SkillViewDialog } from '../../../components/skill-view-dialog';
 import { Badge } from '../../../components/ui/badge';
 import { Button } from '../../../components/ui/button';
 import { InPlaceForm } from '../../../components/ui/in-place-form';
 import { Input } from '../../../components/ui/input';
 import {
-	type ProjectSkillListItem,
 	useDeleteProjectSkill,
 	useProjectSkill,
 	useProjectSkillRevisions,
@@ -28,6 +28,8 @@ function ProjectSkillsPage() {
 	const deleteSkill = useDeleteProjectSkill(projectId);
 
 	const [editingId, setEditingId] = useState<string | null>(null);
+	// Independently of editing, `viewingId` drives the read-only view modal.
+	const [viewingId, setViewingId] = useState<string | null>(null);
 	const [name, setName] = useState('');
 	const [description, setDescription] = useState('');
 	const [content, setContent] = useState('');
@@ -35,6 +37,7 @@ function ProjectSkillsPage() {
 	const [error, setError] = useState<string | null>(null);
 
 	const { data: editingSkill } = useProjectSkill(projectId, editingId);
+	const { data: viewingSkill } = useProjectSkill(projectId, viewingId);
 	const { data: revisions } = useProjectSkillRevisions(projectId, editingId);
 	const restoreSkill = useRestoreProjectSkill(projectId, editingId);
 	useEffect(() => {
@@ -188,6 +191,14 @@ function ProjectSkillsPage() {
 								<span className="flex items-center gap-2 shrink-0">
 									<button
 										type="button"
+										onClick={() => setViewingId(s.id)}
+										aria-label={`View ${s.name}`}
+										className="text-text-3 hover:text-text-1"
+									>
+										<Eye className="w-3.5 h-3.5" />
+									</button>
+									<button
+										type="button"
 										onClick={() => {
 											setEditingId(s.id);
 											setError(null);
@@ -236,13 +247,23 @@ function ProjectSkillsPage() {
 										<span className="text-xs text-text-3 truncate">{s.description}</span>
 									)}
 								</div>
-								<Link
-									to="/settings/skills"
-									className="flex items-center gap-1 text-xs text-text-3 hover:text-text-1 shrink-0"
-									data-testid="global-skill-manage-link"
-								>
-									Manage <ExternalLink className="w-3 h-3" />
-								</Link>
+								<span className="flex items-center gap-3 shrink-0">
+									<button
+										type="button"
+										onClick={() => setViewingId(s.id)}
+										aria-label={`View ${s.name}`}
+										className="text-text-3 hover:text-text-1"
+									>
+										<Eye className="w-3.5 h-3.5" />
+									</button>
+									<Link
+										to="/settings/skills"
+										className="flex items-center gap-1 text-xs text-text-3 hover:text-text-1"
+										data-testid="global-skill-manage-link"
+									>
+										Manage <ExternalLink className="w-3 h-3" />
+									</Link>
+								</span>
 							</div>
 						))}
 					</div>
@@ -255,6 +276,13 @@ function ProjectSkillsPage() {
 					No skills available to this project yet.
 				</div>
 			)}
+
+			<SkillViewDialog
+				open={viewingId !== null}
+				onOpenChange={(o) => !o && setViewingId(null)}
+				skill={viewingSkill?.id === viewingId ? viewingSkill : undefined}
+				fallbackName={skills.find((s) => s.id === viewingId)?.name}
+			/>
 		</div>
 	);
 }

--- a/packages/web/src/routes/settings/skills.tsx
+++ b/packages/web/src/routes/settings/skills.tsx
@@ -1,8 +1,18 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { ChevronDown, ExternalLink, Loader2, Pencil, Plus, Search, Trash2 } from 'lucide-react';
+import {
+	ChevronDown,
+	ExternalLink,
+	Eye,
+	Loader2,
+	Pencil,
+	Plus,
+	Search,
+	Trash2,
+} from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { MarkdownEditor } from '../../components/markdown-editor';
 import { RevisionsPanel } from '../../components/revisions-panel';
+import { SkillViewDialog } from '../../components/skill-view-dialog';
 import { Badge } from '../../components/ui/badge';
 import { Button } from '../../components/ui/button';
 import { InPlaceForm } from '../../components/ui/in-place-form';
@@ -46,6 +56,8 @@ function InstanceSkillsPage() {
 	const [showSearch, setShowSearch] = useState(false);
 	// `editingId` null = the form (when open) creates; otherwise it edits.
 	const [editingId, setEditingId] = useState<string | null>(null);
+	// Independently of editing, `viewingId` drives the read-only view modal.
+	const [viewingId, setViewingId] = useState<string | null>(null);
 	const [createScope, setCreateScope] = useState<string>(ALL_PROJECTS);
 	const [name, setName] = useState('');
 	const [description, setDescription] = useState('');
@@ -70,6 +82,7 @@ function InstanceSkillsPage() {
 	// Editing needs the full row (content is omitted from the list endpoint), so
 	// fetch it by id and populate the form once it arrives.
 	const { data: editingSkill } = useInstanceSkill(editingId);
+	const { data: viewingSkill } = useInstanceSkill(viewingId);
 	const { data: revisions } = useInstanceSkillRevisions(editingId);
 	const restoreSkill = useRestoreInstanceSkill(editingId);
 	useEffect(() => {
@@ -280,6 +293,7 @@ function InstanceSkillsPage() {
 								key={s.id}
 								skill={s}
 								scopeOptions={scopeOptions}
+								onView={() => setViewingId(s.id)}
 								onEdit={() => openEdit(s.id)}
 								onDelete={() => {
 									if (confirm(`Delete skill "${s.name}"?`)) deleteSkill.mutate(s.id);
@@ -291,17 +305,34 @@ function InstanceSkillsPage() {
 			</>
 		);
 
-	return <div className="max-w-[900px]">{content_}</div>;
+	return (
+		<div className="max-w-[900px]">
+			{content_}
+			<SkillViewDialog
+				open={viewingId !== null}
+				onOpenChange={(o) => !o && setViewingId(null)}
+				skill={viewingSkill?.id === viewingId ? viewingSkill : undefined}
+				fallbackName={skills.find((s) => s.id === viewingId)?.name}
+			/>
+		</div>
+	);
 }
 
 interface InstanceSkillRowProps {
 	skill: SkillListItem;
 	scopeOptions: SearchableSelectOption[];
+	onView: () => void;
 	onEdit: () => void;
 	onDelete: () => void;
 }
 
-function InstanceSkillRow({ skill, scopeOptions, onEdit, onDelete }: InstanceSkillRowProps) {
+function InstanceSkillRow({
+	skill,
+	scopeOptions,
+	onView,
+	onEdit,
+	onDelete,
+}: InstanceSkillRowProps) {
 	const updateScope = useUpdateInstanceSkillScope();
 	const [rowError, setRowError] = useState<string | null>(null);
 
@@ -368,6 +399,14 @@ function InstanceSkillRow({ skill, scopeOptions, onEdit, onDelete }: InstanceSki
 			</div>
 			<span className="flex items-center gap-2 shrink-0">
 				{rowError && <span className="text-xs text-danger">{rowError}</span>}
+				<button
+					type="button"
+					onClick={onView}
+					aria-label={`View ${skill.name}`}
+					className="text-text-3 hover:text-text-1"
+				>
+					<Eye className="w-3.5 h-3.5" />
+				</button>
 				{!skill.readonly && (
 					<>
 						<button

--- a/packages/web/test/project-skills.test.tsx
+++ b/packages/web/test/project-skills.test.tsx
@@ -17,21 +17,20 @@ async function seedSkill(
 
 test('the per-project Skills page shows project skills (editable) and globals (read-only)', async () => {
 	let projectSlug = '';
-	const { findByText, findByTestId, findByRole, findByLabelText, getByText, router, user } =
-		await renderApp({
-			initialPath: '/',
-			seed: async (ctx) => {
-				const ws = await seedWorkspace();
-				const project = await seedProject(ws, { name: 'Skills Proj' });
-				projectSlug = project.slug;
-				await seedSkill(ctx, { name: 'A Global Skill', content: '# global' });
-				await seedSkill(ctx, {
-					name: 'A Project Skill',
-					content: '# project v1',
-					project_id: project.id,
-				});
-			},
-		});
+	const { findByText, findByRole, findByLabelText, getByText, router, user } = await renderApp({
+		initialPath: '/',
+		seed: async (ctx) => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Skills Proj' });
+			projectSlug = project.slug;
+			await seedSkill(ctx, { name: 'A Global Skill', content: '# global' });
+			await seedSkill(ctx, {
+				name: 'A Project Skill',
+				content: '# project v1',
+				project_id: project.id,
+			});
+		},
+	});
 
 	await router.navigate({
 		to: '/projects/$projectId/skills',
@@ -65,4 +64,33 @@ test('the per-project Skills page shows project skills (editable) and globals (r
 	await user.type(content, '# project v2');
 	await user.click(await findByRole('button', { name: 'Save changes' }));
 	await findByText('A Project Skill');
+});
+
+test('the built-in connector-recipes skill shows on the project page as a global, viewable in a modal', async () => {
+	let projectSlug = '';
+	const { findByText, router, user } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Recipes Proj' });
+			projectSlug = project.slug;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/skills',
+		params: { projectId: projectSlug },
+	});
+
+	// The built-in skill is global, so it renders under "Global (all projects)".
+	const globalRow = (await findByText('Connector Recipes')).closest(
+		'[data-testid="global-skill-row"]',
+	) as HTMLElement;
+	expect(within(globalRow).getByText('Global')).toBeTruthy();
+
+	// Open its read-only viewer and confirm the generated markdown renders.
+	await user.click(within(globalRow).getByLabelText('View Connector Recipes'));
+	const dialog = await within(document.body).findByTestId('skill-view-dialog');
+	const dialogContent = await within(dialog).findByTestId('skill-view-content');
+	expect(dialogContent.querySelector('h2')?.textContent).toContain('Connection patterns');
 });

--- a/packages/web/test/settings-skills.test.tsx
+++ b/packages/web/test/settings-skills.test.tsx
@@ -18,15 +18,32 @@ test('a created skill is editable and deletable (no built-in concept)', async ()
 	expect(r.queryByText('built-in')).toBeNull();
 });
 
-test('the built-in connector-recipes skill is read-only (Built-in badge, no edit/delete)', async () => {
+test('the built-in connector-recipes skill is read-only (Built-in badge, no edit/delete) but viewable', async () => {
 	const r = await renderApp({ initialPath: '/settings/skills' });
 
 	// The generated virtual skill is always present in the instance list.
 	await r.findByText('Connector Recipes');
 	await r.findByText('Built-in');
-	// It exposes no edit/delete affordances — the server also rejects mutations.
+	// It exposes no edit/delete affordances — the server also rejects mutations…
 	expect(r.queryByLabelText('Edit Connector Recipes')).toBeNull();
 	expect(r.queryByLabelText('Delete Connector Recipes')).toBeNull();
+	// …but it can still be viewed via the read-only view modal.
+	expect(r.queryByLabelText('View Connector Recipes')).not.toBeNull();
+});
+
+test('the view button opens a modal rendering the skill content as markdown', async () => {
+	const r = await renderApp({ initialPath: '/settings/skills' });
+
+	// The built-in skill is always present; open its viewer.
+	await r.findByLabelText('View Connector Recipes');
+	await r.user.click(r.getByLabelText('View Connector Recipes'));
+
+	// The dialog renders into a body portal and shows the generated content.
+	const dialog = await within(document.body).findByTestId('skill-view-dialog');
+	expect(within(dialog).getByText('Connector Recipes')).toBeTruthy();
+	const content = await within(dialog).findByTestId('skill-view-content');
+	// The connector-recipes body has a "Connection patterns" markdown heading.
+	expect(content.querySelector('h2')?.textContent).toContain('Connection patterns');
 });
 
 test('the skill content editor previews markdown', async () => {


### PR DESCRIPTION
## Summary

The built-in `connector-recipes` skill had no way to read its full content — it's read-only, so the edit/delete affordances (which are the only path to its body) are hidden. This adds a **view button (eye icon)** to every skill row on both the global **Settings → Skills** page and the per-project **Skills** page. Clicking it opens a read-only modal that renders the skill's markdown, so any skill — stored or built-in — can be read in full without leaving the page.

It also **surfaces the built-in `connector-recipes` skill on per-project Skills pages** as a global skill. It's a global skill (`project_id` null) that every project's runs already see, but the per-project list endpoint omitted it. It now appears under **Global (all projects)** and its generated content is servable via the per-project detail route so the viewer can render it.

## Changes

- **server** (`packages/server/src/routes/skills.ts`)
  - `GET /api/projects/:projectId/skills` now includes the built-in `connector-recipes` virtual skill (annotated `readonly: true`) alongside the stored rows, exactly as the admin `/api/skills` list does.
  - `GET /api/projects/:projectId/skills/:id` serves the generated content for the reserved `connector-recipes` slug so the viewer can fetch it.
- **web**
  - New shared `SkillViewDialog` component that renders a skill's markdown in a modal (used by both Skills pages).
  - View (eye) buttons wired into the global Skills page rows (including the read-only built-in) and the per-project page rows (both project-scoped and global sections).
  - Added a `2xl` dialog size preset for a comfortable reading width.
- **docs** (`docs/concepts/skills.md`)
  - Note the view button on every row and that the built-in skill appears on project Skills pages as a global.

## Testing

- `packages/server/test/connector-recipes-skill.test.ts` — per-project list surfaces the read-only built-in entry; per-project detail returns its generated content.
- `packages/web/test/settings-skills.test.tsx` — the built-in skill exposes a view button; the view button opens a modal rendering the markdown.
- `packages/web/test/project-skills.test.tsx` — the built-in skill shows on the project page under "Global" and is viewable in the modal.

All touched suites pass; `turbo typecheck` and `biome check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y8ihN29FnvErvzxXkLdhYZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y8ihN29FnvErvzxXkLdhYZ)_