### PR TITLE
fix(oauth): accept Google's verification_url in the device flow

### DIFF
--- a/packages/server/src/services/oauth/device-flow.ts
+++ b/packages/server/src/services/oauth/device-flow.ts
@@ -96,14 +96,21 @@ export async function startDeviceFlow(opts: {
 	const data = (await res.json()) as {
 		device_code: string;
 		user_code: string;
-		verification_uri: string;
+		// RFC 8628 names the field `verification_uri`; Google's device endpoint
+		// predates the RFC and sends `verification_url` instead.
+		verification_uri?: string;
+		verification_url?: string;
 		expires_in: number;
 		interval: number;
 	};
+	const verificationUri = data.verification_uri || data.verification_url;
+	if (!data.device_code || !data.user_code || !verificationUri) {
+		throw new Error('device-code response is missing device_code, user_code, or verification_uri');
+	}
 	return {
 		deviceCode: data.device_code,
 		userCode: data.user_code,
-		verificationUri: data.verification_uri,
+		verificationUri,
 		expiresIn: data.expires_in,
 		interval: data.interval,
 	};

--- a/packages/server/test/oauth-device-flow.test.ts
+++ b/packages/server/test/oauth-device-flow.test.ts
@@ -80,6 +80,40 @@ describe('startDeviceFlow', () => {
 		expect(captured!.body).toContain('scope=repo+read%3Aorg');
 	});
 
+	it("accepts Google's non-RFC verification_url field", async () => {
+		const fetchFn = async () =>
+			new Response(
+				JSON.stringify({
+					device_code: 'dc',
+					user_code: 'DDW-RSZ-GZHC',
+					// Google's device endpoint predates RFC 8628 and uses this name.
+					verification_url: 'https://www.google.com/device',
+					expires_in: 1800,
+					interval: 5,
+				}),
+				{ status: 200, headers: { 'Content-Type': 'application/json' } },
+			);
+		const start = await startDeviceFlow({
+			deviceCodeUrl: 'https://oauth2.googleapis.com/device/code',
+			clientId: 'gcid.apps.googleusercontent.com',
+			scopes: ['https://www.googleapis.com/auth/youtube'],
+			fetchFn,
+		});
+		expect(start.verificationUri).toBe('https://www.google.com/device');
+		expect(start.userCode).toBe('DDW-RSZ-GZHC');
+	});
+
+	it('throws when the response carries no verification URI under either name', async () => {
+		const fetchFn = async () =>
+			new Response(
+				JSON.stringify({ device_code: 'dc', user_code: 'UC-1', expires_in: 900, interval: 5 }),
+				{ status: 200, headers: { 'Content-Type': 'application/json' } },
+			);
+		await expect(
+			startDeviceFlow({ deviceCodeUrl: 'https://gh/x', clientId: 'c', scopes: [], fetchFn }),
+		).rejects.toThrow(/verification_uri/);
+	});
+
 	it('throws on a non-ok device-code response', async () => {
 		const fetchFn = async () => new Response('nope', { status: 422 });
 		await expect(

--- a/packages/web/src/components/connector-device-flow-dialog.tsx
+++ b/packages/web/src/components/connector-device-flow-dialog.tsx
@@ -70,6 +70,7 @@ export function ConnectorDeviceFlowDialog({
 			.mutateAsync(connectorIdRef.current)
 			.then((flow) => {
 				setDeviceFlow(flow);
+				if (!flow.verification_uri) return; // never open a blank tab
 				try {
 					window.open(flow.verification_uri, '_blank', 'noopener');
 				} catch {

--- a/packages/web/src/components/connector-oauth-broker-form.tsx
+++ b/packages/web/src/components/connector-oauth-broker-form.tsx
@@ -196,6 +196,7 @@ export function ConnectorOAuthBrokerForm({
 			{
 				onSuccess: (flow) => {
 					setDeviceFlow(flow);
+					if (!flow.verification_uri) return; // never open a blank tab
 					try {
 						window.open(flow.verification_uri, '_blank', 'noopener');
 					} catch {


### PR DESCRIPTION
## Problem

Starting the Google (YouTube) connector's OAuth device flow showed the code card with an **empty verification link**, and the auto-open popped a **blank tab** (`window.open(undefined)` → `about:blank`), leaving the user with nowhere to enter the code.

Root cause: Google's device authorization endpoint (`https://oauth2.googleapis.com/device/code`) predates RFC 8628 and returns the field as `verification_url`, while `startDeviceFlow` only read the RFC name `verification_uri` — so the URL came back `undefined`. GitHub's endpoint uses the RFC name, which is why the same flow worked there.

## Fix

- `packages/server/src/services/oauth/device-flow.ts` — `startDeviceFlow` now accepts `verification_uri` **or** `verification_url`, and throws an explicit error when a response carries neither (or is missing `device_code`/`user_code`), so a broken provider response surfaces as a visible error instead of a blank UI. Both the bundled device flow and the broker route go through this one function.
- `connector-oauth-broker-form.tsx` / `connector-device-flow-dialog.tsx` — skip the auto-`window.open` when the response has no verification URL, so a blank tab can never open regardless of what the server returns (defense-in-depth for custom providers).

## Tests

Added to `packages/server/test/oauth-device-flow.test.ts`:
- a Google-shaped response (`verification_url`) maps to `verificationUri`
- a response with neither field name throws with a clear message

Ran: server OAuth suites (206 tests), web connector component suites (35 tests), typecheck, biome — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7vXvZ2YTR3mNaYq7hpnaS

---
_Generated by [Claude Code](https://claude.ai/code/session_01G7vXvZ2YTR3mNaYq7hpnaS)_