### PR TITLE
fix(web): stop Formatted-view tooltip opening when log viewer expands

### DIFF
--- a/packages/web/src/components/log-viewer.tsx
+++ b/packages/web/src/components/log-viewer.tsx
@@ -225,6 +225,13 @@ export function LogViewer({
 					<Dialog.Content
 						data-testid="log-viewer-fullscreen"
 						className="fixed inset-0 z-50 flex flex-col bg-surface outline-none"
+						onOpenAutoFocus={(event) => {
+							// The first tabbable element is a Tooltip trigger (the
+							// Formatted-view toggle); letting the dialog auto-focus it pops
+							// the tooltip open on expand. Focus the container instead.
+							event.preventDefault();
+							(event.target as HTMLElement | null)?.focus();
+						}}
 					>
 						<Dialog.Title className="sr-only">Log viewer (expanded)</Dialog.Title>
 						{content}

--- a/packages/web/test/log-viewer-branches.test.tsx
+++ b/packages/web/test/log-viewer-branches.test.tsx
@@ -140,6 +140,22 @@ test('formattable viewer defaults to formatted view, hides [tool] prefix, toggle
 	expect(getByTestId('lv-body').textContent).not.toContain('[tool]');
 });
 
+test('expanding a formattable viewer focuses the dialog itself, not the Formatted-view button', async () => {
+	const user = userEvent.setup({ delay: null });
+	const { getByRole } = await renderViewer({
+		formattable: true,
+		lines: makeLines(['[tool] Bash(command=ls)', 'stdout']),
+	});
+	await user.click(getByRole('button', { name: 'Expand log viewer' }));
+	const dialog = document.body.querySelector('[data-testid="log-viewer-fullscreen"]');
+	expect(dialog).not.toBeNull();
+	// Radix's dialog would otherwise auto-focus the first tabbable element —
+	// the Formatted-view button — popping its tooltip open over the expanded
+	// viewer.
+	expect(document.activeElement).toBe(dialog);
+	expect(document.activeElement).not.toBe(getByRole('button', { name: 'Formatted view' }));
+});
+
 test('headerAction / headerActionLeading slots render in the header', async () => {
 	const { getByText } = await renderViewer({
 		lines: makeLines(['x', 'stdout']),


### PR DESCRIPTION
## Problem

Expanding an agent-run log to full viewport showed the "Formatted view" tooltip popped open over the expanded view, without hovering or tabbing to it.

## Cause

When `LogViewer` expands, its content remounts inside a Radix `Dialog`, and Radix's focus scope auto-focuses the first tabbable element in the dialog on open. That element is the Formatted-view toggle — a `Tooltip` trigger — and Radix tooltips open on trigger focus.

## Fix

Add an `onOpenAutoFocus` handler on the fullscreen `Dialog.Content` that prevents the default auto-focus and focuses the dialog container itself (Radix renders it with `tabIndex={-1}`), keeping focus inside the dialog for Escape/Tab handling without landing on a tooltip trigger.

## Testing

- New regression test in `packages/web/test/log-viewer-branches.test.tsx` asserting that after expanding a formattable viewer, focus is on the dialog container, not the Formatted-view button. Verified it fails against the unfixed component and passes with the fix.
- `packages/web` vitest (log-viewer suites), `tsc --noEmit`, biome, and the full workspace build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019yaodDaH7ajSVW4UGzXTi3

---
_Generated by [Claude Code](https://claude.ai/code/session_019yaodDaH7ajSVW4UGzXTi3)_