### PR TITLE
feat(web): show scroll pills only while actively scrolling that direction

### DIFF
--- a/packages/web/src/components/scroll-to-bottom-button.tsx
+++ b/packages/web/src/components/scroll-to-bottom-button.tsx
@@ -6,18 +6,18 @@ import { Tooltip } from './ui/tooltip';
  * (black in light theme, the light inverse in dark theme, matching the CEO chat
  * launcher). Rendered by the app shell over the <main> scroller on every page,
  * and by full-viewport pages (e.g. the standalone document preview) over their
- * own scroller — `positionClassName` supplies the positioning. Hides itself and
- * leaves the tab order once the content is scrolled to the bottom (or never
- * overflowed in the first place).
+ * own scroller — `positionClassName` supplies the positioning. Only shown
+ * (`visible`) while the user is actively scrolling down; hidden — and out of the
+ * tab order — otherwise.
  */
 export function ScrollToBottomButton({
 	onClick,
-	atBottom,
+	visible,
 	testId,
 	positionClassName,
 }: {
 	onClick: () => void;
-	atBottom: boolean;
+	visible: boolean;
 	testId: string;
 	positionClassName: string;
 }) {
@@ -28,9 +28,9 @@ export function ScrollToBottomButton({
 				onClick={onClick}
 				data-testid={testId}
 				aria-label="Scroll to bottom"
-				aria-hidden={atBottom}
-				tabIndex={atBottom ? -1 : 0}
-				className={`flex h-6 items-center justify-center rounded-md bg-inverse px-5 text-inverse-fg shadow-lg transition-opacity hover:opacity-90 ${positionClassName} ${atBottom ? 'invisible pointer-events-none opacity-0' : ''}`}
+				aria-hidden={!visible}
+				tabIndex={visible ? 0 : -1}
+				className={`flex h-6 items-center justify-center rounded-md bg-inverse px-5 text-inverse-fg shadow-lg transition-opacity hover:opacity-90 ${positionClassName} ${visible ? '' : 'invisible pointer-events-none opacity-0'}`}
 			>
 				<ChevronDown className="h-4 w-4" />
 			</button>

--- a/packages/web/src/components/scroll-to-top-button.tsx
+++ b/packages/web/src/components/scroll-to-top-button.tsx
@@ -4,18 +4,18 @@ import { Tooltip } from './ui/tooltip';
 /**
  * A thin "jump to top" pill: an upward chevron on the theme's inverse fill,
  * mirroring `ScrollToBottomButton`. Rendered by the app shell over the <main>
- * scroller on every page — `positionClassName` supplies the positioning. Hides
- * itself and leaves the tab order once the content is scrolled to the top (or
- * never overflowed in the first place).
+ * scroller on every page — `positionClassName` supplies the positioning. Only
+ * shown (`visible`) while the user is actively scrolling up; hidden — and out of
+ * the tab order — otherwise.
  */
 export function ScrollToTopButton({
 	onClick,
-	atTop,
+	visible,
 	testId,
 	positionClassName,
 }: {
 	onClick: () => void;
-	atTop: boolean;
+	visible: boolean;
 	testId: string;
 	positionClassName: string;
 }) {
@@ -26,9 +26,9 @@ export function ScrollToTopButton({
 				onClick={onClick}
 				data-testid={testId}
 				aria-label="Scroll to top"
-				aria-hidden={atTop}
-				tabIndex={atTop ? -1 : 0}
-				className={`flex h-6 items-center justify-center rounded-md bg-inverse px-5 text-inverse-fg shadow-lg transition-opacity hover:opacity-90 ${positionClassName} ${atTop ? 'invisible pointer-events-none opacity-0' : ''}`}
+				aria-hidden={!visible}
+				tabIndex={visible ? 0 : -1}
+				className={`flex h-6 items-center justify-center rounded-md bg-inverse px-5 text-inverse-fg shadow-lg transition-opacity hover:opacity-90 ${positionClassName} ${visible ? '' : 'invisible pointer-events-none opacity-0'}`}
 			>
 				<ChevronUp className="h-4 w-4" />
 			</button>

--- a/packages/web/src/hooks/use-scroll-to-bottom.ts
+++ b/packages/web/src/hooks/use-scroll-to-bottom.ts
@@ -1,42 +1,59 @@
 import { useEffect, useState } from 'react';
 
+// How long the pill lingers after the last downward scroll before hiding.
+// Continuous scrolling keeps restarting this countdown; a pause fades it out.
+const HIDE_AFTER_IDLE_MS = 2000;
+// Within this many pixels of the bottom we treat the scroller as "at the very
+// bottom": there is nothing further to jump to, so the pill never shows.
+const AT_BOTTOM_THRESHOLD = 8;
+
 export function useScrollToBottom(scrollParent: HTMLElement | null): {
-	atBottom: boolean;
+	visible: boolean;
 	scrollToBottom: () => void;
 } {
-	// Start hidden (`atBottom: true`) so short pages never flash the button
-	// before the first measurement runs.
-	const [atBottom, setAtBottom] = useState(true);
+	// Start hidden: the pill only ever appears in response to a downward scroll.
+	const [visible, setVisible] = useState(false);
 	useEffect(() => {
 		if (!scrollParent) return;
-		const check = () => {
-			setAtBottom(
-				scrollParent.scrollTop + scrollParent.clientHeight >= scrollParent.scrollHeight - 200,
-			);
+		let lastScrollTop = scrollParent.scrollTop;
+		let hideTimer: ReturnType<typeof setTimeout> | null = null;
+		const clearHideTimer = () => {
+			if (hideTimer !== null) {
+				clearTimeout(hideTimer);
+				hideTimer = null;
+			}
 		};
-		check();
-		scrollParent.addEventListener('scroll', check, { passive: true });
-		const ro = new ResizeObserver(check);
-		ro.observe(scrollParent);
-		const observeChildren = () => {
-			for (const child of Array.from(scrollParent.children)) ro.observe(child);
+		const atBottom = () =>
+			scrollParent.scrollTop + scrollParent.clientHeight >=
+			scrollParent.scrollHeight - AT_BOTTOM_THRESHOLD;
+		const onScroll = () => {
+			const current = scrollParent.scrollTop;
+			const delta = current - lastScrollTop;
+			lastScrollTop = current;
+			// Already at the very bottom — nothing further to jump to, so never show.
+			if (atBottom()) {
+				clearHideTimer();
+				setVisible(false);
+				return;
+			}
+			if (delta > 0) {
+				// Scrolling down: reveal and (re)start the idle countdown.
+				setVisible(true);
+				clearHideTimer();
+				hideTimer = setTimeout(() => {
+					hideTimer = null;
+					setVisible(false);
+				}, HIDE_AFTER_IDLE_MS);
+			} else if (delta < 0) {
+				// Scrolling up is the opposite intent — hide immediately.
+				clearHideTimer();
+				setVisible(false);
+			}
 		};
-		observeChildren();
-		// The scroll parent can outlive its content: the shell <main> never
-		// unmounts across navigations — the route swap replaces its children. The
-		// ResizeObserver only tracks the elements it was handed, so re-observe (a
-		// no-op for already-observed nodes) and re-measure whenever the child list
-		// changes; otherwise the new page's async content growth goes unseen and
-		// the button state is stale until the next scroll.
-		const mo = new MutationObserver(() => {
-			observeChildren();
-			check();
-		});
-		mo.observe(scrollParent, { childList: true });
+		scrollParent.addEventListener('scroll', onScroll, { passive: true });
 		return () => {
-			scrollParent.removeEventListener('scroll', check);
-			mo.disconnect();
-			ro.disconnect();
+			scrollParent.removeEventListener('scroll', onScroll);
+			clearHideTimer();
 		};
 	}, [scrollParent]);
 
@@ -64,5 +81,5 @@ export function useScrollToBottom(scrollParent: HTMLElement | null): {
 		setTimeout(tick, 400);
 	};
 
-	return { atBottom, scrollToBottom };
+	return { visible, scrollToBottom };
 }

--- a/packages/web/src/hooks/use-scroll-to-top.ts
+++ b/packages/web/src/hooks/use-scroll-to-top.ts
@@ -1,28 +1,72 @@
 import { useEffect, useRef, useState } from 'react';
 
+// How long the pill lingers after the last upward scroll before hiding itself.
+// Every fresh upward scroll restarts this countdown, so continuous scrolling
+// keeps it up; a pause of this long makes it fade out.
+const HIDE_AFTER_IDLE_MS = 2000;
+// Below this many pixels from the top we treat the scroller as "at the very
+// top": there is nothing to jump to, so the pill never shows. Small (rather
+// than the generous buffer the visibility check used to carry) so a genuine
+// upward scroll that stops just short of the top still reveals the pill.
+const AT_TOP_THRESHOLD = 4;
+
 /**
- * Companion to `useScrollToBottom` for the "jump to top" affordance. `atTop`
- * depends only on `scrollTop` (never on `scrollHeight`), so unlike the bottom
- * hook this needs no Resize/Mutation observers — a plain scroll listener plus an
- * initial measurement is enough. Content growth can't change whether you're at
- * the top; only scrolling can.
+ * Companion to `useScrollToBottom` for the "jump to top" affordance. The pill is
+ * revealed only while the user is actively scrolling *up* and hides again a
+ * couple of seconds after they stop (or the moment they reverse direction, or
+ * reach the very top). Content growth can't change whether you're at the top —
+ * only scrolling can — so a plain scroll listener with a per-direction idle
+ * timer is all this needs; no Resize/Mutation observers.
  */
 export function useScrollToTop(scrollParent: HTMLElement | null): {
-	atTop: boolean;
+	visible: boolean;
 	scrollToTop: () => void;
 } {
-	// Start hidden (`atTop: true`) so short pages never flash the button before the
-	// first measurement runs — mirrors `useScrollToBottom`'s initial state.
-	const [atTop, setAtTop] = useState(true);
+	// Start hidden: the pill only ever appears in response to an upward scroll.
+	const [visible, setVisible] = useState(false);
 	// Handle of the in-flight rAF-driven scroll animation, so a repeat click or an
 	// unmount can cancel it instead of leaving two animations fighting.
 	const frameRef = useRef<number | null>(null);
+
 	useEffect(() => {
 		if (!scrollParent) return;
-		const check = () => setAtTop(scrollParent.scrollTop <= 200);
-		check();
-		scrollParent.addEventListener('scroll', check, { passive: true });
-		return () => scrollParent.removeEventListener('scroll', check);
+		let lastScrollTop = scrollParent.scrollTop;
+		let hideTimer: ReturnType<typeof setTimeout> | null = null;
+		const clearHideTimer = () => {
+			if (hideTimer !== null) {
+				clearTimeout(hideTimer);
+				hideTimer = null;
+			}
+		};
+		const onScroll = () => {
+			const current = scrollParent.scrollTop;
+			const delta = current - lastScrollTop;
+			lastScrollTop = current;
+			// Already at the very top — nothing to jump to, so never show.
+			if (current <= AT_TOP_THRESHOLD) {
+				clearHideTimer();
+				setVisible(false);
+				return;
+			}
+			if (delta < 0) {
+				// Scrolling up: reveal and (re)start the idle countdown.
+				setVisible(true);
+				clearHideTimer();
+				hideTimer = setTimeout(() => {
+					hideTimer = null;
+					setVisible(false);
+				}, HIDE_AFTER_IDLE_MS);
+			} else if (delta > 0) {
+				// Scrolling down is the opposite intent — hide immediately.
+				clearHideTimer();
+				setVisible(false);
+			}
+		};
+		scrollParent.addEventListener('scroll', onScroll, { passive: true });
+		return () => {
+			scrollParent.removeEventListener('scroll', onScroll);
+			clearHideTimer();
+		};
 	}, [scrollParent]);
 
 	// Stop any running animation when the scroller changes or the shell unmounts.
@@ -73,5 +117,5 @@ export function useScrollToTop(scrollParent: HTMLElement | null): {
 		frameRef.current = requestAnimationFrame(step);
 	};
 
-	return { atTop, scrollToTop };
+	return { visible, scrollToTop };
 }

--- a/packages/web/src/routes/__root.tsx
+++ b/packages/web/src/routes/__root.tsx
@@ -174,8 +174,8 @@ function ShellChrome({ drawerOpen, setDrawerOpen }: ShellChromeProps) {
 		mainRef.current = el;
 		setMainEl(el);
 	}, []);
-	const { atBottom, scrollToBottom } = useScrollToBottom(mainEl);
-	const { atTop, scrollToTop } = useScrollToTop(mainEl);
+	const { visible: bottomVisible, scrollToBottom } = useScrollToBottom(mainEl);
+	const { visible: topVisible, scrollToTop } = useScrollToTop(mainEl);
 	const pathname = useLocation({ select: (l) => l.pathname });
 	const hash = useLocation({ select: (l) => l.hash });
 	const lastPathnameRef = useRef(pathname);
@@ -272,7 +272,7 @@ function ShellChrome({ drawerOpen, setDrawerOpen }: ShellChromeProps) {
 						{/* Top-centre of the content area, just below the app header. */}
 						<ScrollToTopButton
 							onClick={scrollToTop}
-							atTop={atTop}
+							visible={topVisible}
 							testId="scroll-to-top"
 							positionClassName="absolute top-4 left-1/2 -translate-x-1/2 z-30"
 						/>
@@ -280,7 +280,7 @@ function ShellChrome({ drawerOpen, setDrawerOpen }: ShellChromeProps) {
 						    launcher (bottom-right) at every breakpoint. */}
 						<ScrollToBottomButton
 							onClick={scrollToBottom}
-							atBottom={atBottom}
+							visible={bottomVisible}
 							testId="scroll-to-bottom"
 							positionClassName="absolute bottom-4 left-1/2 -translate-x-1/2 z-30"
 						/>

--- a/packages/web/src/routes/preview/$projectId/$filename.tsx
+++ b/packages/web/src/routes/preview/$projectId/$filename.tsx
@@ -19,7 +19,7 @@ function DocPreviewPage() {
 	// This bare route renders outside the app shell, so it carries its own
 	// scroll-to-bottom pill wired to its own full-viewport scroller.
 	const [scroller, setScroller] = useState<HTMLDivElement | null>(null);
-	const { atBottom, scrollToBottom } = useScrollToBottom(scroller);
+	const { visible: bottomVisible, scrollToBottom } = useScrollToBottom(scroller);
 
 	if (isLoading) {
 		return <CenteredMessage>Loading…</CenteredMessage>;
@@ -30,7 +30,11 @@ function DocPreviewPage() {
 	}
 
 	return (
-		<div ref={setScroller} className="h-screen overflow-auto bg-surface">
+		<div
+			ref={setScroller}
+			data-testid="preview-scroller"
+			className="h-screen overflow-auto bg-surface"
+		>
 			{/* Full-width sticky bar spanning the content column: filename left,
 			    actions right. `border-b` + translucent blur lets the doc scroll
 			    cleanly underneath. */}
@@ -97,7 +101,7 @@ function DocPreviewPage() {
 			</div>
 			<ScrollToBottomButton
 				onClick={scrollToBottom}
-				atBottom={atBottom}
+				visible={bottomVisible}
 				testId="scroll-to-bottom"
 				positionClassName="fixed bottom-4 left-1/2 -translate-x-1/2 z-30"
 			/>

--- a/test/browser/scroll-to-bottom-global.spec.ts
+++ b/test/browser/scroll-to-bottom-global.spec.ts
@@ -1,10 +1,10 @@
 // Real clientHeight/scrollHeight/scrollTop comparisons (testing decision tree,
-// point 1): the global scroll-to-bottom pill only shows when the shell <main>
-// (or the bare preview page's own scroller) genuinely overflows, and clicking
-// it must move the real scroll position — values happy-dom can't compute. The
-// task-page variant of this behaviour is covered in task-detail.spec.ts; this
-// spec proves the pill is global by exercising it on a documents page and on
-// the standalone document preview.
+// point 1): the global scroll-to-bottom pill only surfaces while the shell
+// <main> (or the bare preview page's own scroller) is genuinely being scrolled
+// down, and clicking it must move the real scroll position — values happy-dom
+// can't compute. The task-page variant of this behaviour is covered in
+// task-detail.spec.ts; this spec proves the pill is global by exercising it on a
+// documents page and on the standalone document preview.
 
 import { expect, test } from './fixtures';
 import { waitForPageLoad } from './helpers';
@@ -37,7 +37,7 @@ for (const { name, width, height } of [
 	{ name: 'desktop', width: 1280, height: 800 },
 	{ name: 'mobile', width: 375, height: 800 },
 ]) {
-	test(`${name}: pill appears on a long document page and scrolls to the bottom`, async ({
+	test(`${name}: pill surfaces on downward scroll and scrolls to the bottom`, async ({
 		page,
 		lightWorkspace,
 	}) => {
@@ -50,13 +50,20 @@ for (const { name, width, height } of [
 		await expect(page.getByRole('heading', { name: DOC })).toBeVisible({ timeout: 20000 });
 
 		const button = page.getByTestId('scroll-to-bottom');
+		const main = page.locator('main').first();
+
+		// Landing at the top without scrolling: the pill offers nothing yet.
+		await expect(button).toBeHidden();
+
+		// A downward scroll (short of the bottom) reveals it.
+		await main.evaluate((el) => el.scrollBy({ top: 400 }));
 		await expect(button).toBeVisible();
+
 		await button.click();
 
 		// The pill hides once the scroller reaches the bottom, and the real scroll
 		// position confirms the content genuinely moved.
 		await expect(button).toBeHidden({ timeout: 10000 });
-		const main = page.locator('main').first();
 		await expect
 			.poll(() => main.evaluate((el) => el.scrollHeight - el.scrollTop - el.clientHeight), {
 				timeout: 10000,
@@ -65,6 +72,54 @@ for (const { name, width, height } of [
 		await expect(page.getByText('THE-VERY-END')).toBeInViewport();
 	});
 }
+
+test('pill fades out a couple seconds after downward scrolling stops', async ({
+	page,
+	lightWorkspace,
+}) => {
+	const { projectSlug, token } = lightWorkspace;
+	await page.setViewportSize({ width: 1280, height: 800 });
+	await seedDoc(page, projectSlug, token, LONG_CONTENT);
+
+	await page.goto(`/projects/${projectSlug}/documents?file=${DOC}`);
+	await waitForPageLoad(page);
+	await expect(page.getByRole('heading', { name: DOC })).toBeVisible({ timeout: 20000 });
+
+	const button = page.getByTestId('scroll-to-bottom');
+	const main = page.locator('main').first();
+
+	await main.evaluate((el) => el.scrollBy({ top: 400 }));
+	await expect(button).toBeVisible();
+
+	// No further scrolling: the idle timer elapses and the pill hides on its own,
+	// without ever reaching the bottom.
+	await expect(button).toBeHidden({ timeout: 6000 });
+	const remaining = await main.evaluate((el) => el.scrollHeight - el.scrollTop - el.clientHeight);
+	expect(remaining).toBeGreaterThan(200);
+});
+
+test('scrolling back up hides the scroll-to-bottom pill immediately', async ({
+	page,
+	lightWorkspace,
+}) => {
+	const { projectSlug, token } = lightWorkspace;
+	await page.setViewportSize({ width: 1280, height: 800 });
+	await seedDoc(page, projectSlug, token, LONG_CONTENT);
+
+	await page.goto(`/projects/${projectSlug}/documents?file=${DOC}`);
+	await waitForPageLoad(page);
+	await expect(page.getByRole('heading', { name: DOC })).toBeVisible({ timeout: 20000 });
+
+	const button = page.getByTestId('scroll-to-bottom');
+	const main = page.locator('main').first();
+
+	await main.evaluate((el) => el.scrollBy({ top: 600 }));
+	await expect(button).toBeVisible();
+
+	// Reversing direction is the opposite intent — the down pill goes away at once.
+	await main.evaluate((el) => el.scrollBy({ top: -200 }));
+	await expect(button).toBeHidden();
+});
 
 test('pill stays hidden when the page content does not overflow', async ({
 	page,
@@ -78,11 +133,12 @@ test('pill stays hidden when the page content does not overflow', async ({
 	await waitForPageLoad(page);
 	await expect(page.getByRole('heading', { name: DOC })).toBeVisible({ timeout: 20000 });
 
-	// The document fits the viewport, so <main> has nothing to scroll and the
-	// pill must not offer a jump.
+	// The document fits the viewport, so <main> has nothing to scroll — an
+	// attempted downward scroll produces no scroll event and the pill never shows.
 	const main = page.locator('main').first();
 	const overflow = await main.evaluate((el) => el.scrollHeight - el.clientHeight);
 	expect(overflow).toBeLessThanOrEqual(200);
+	await main.evaluate((el) => el.scrollBy({ top: 400 }));
 	await expect(page.getByTestId('scroll-to-bottom')).toBeHidden();
 });
 
@@ -100,6 +156,10 @@ test('pill works on the standalone (bare) document preview page', async ({
 	await expect(page.getByTestId('preview-review-toolbar')).toBeVisible({ timeout: 20000 });
 
 	const button = page.getByTestId('scroll-to-bottom');
+	const scroller = page.getByTestId('preview-scroller');
+
+	await expect(button).toBeHidden();
+	await scroller.evaluate((el) => el.scrollBy({ top: 400 }));
 	await expect(button).toBeVisible();
 	await button.click();
 

--- a/test/browser/scroll-to-top-global.spec.ts
+++ b/test/browser/scroll-to-top-global.spec.ts
@@ -1,8 +1,9 @@
 // Real clientHeight/scrollHeight/scrollTop comparisons (testing decision tree,
-// point 1): the global scroll-to-top pill only shows once the shell <main>
-// genuinely overflows AND has been scrolled down, and clicking it must move the
-// real scroll position back to the top — values happy-dom can't compute. Mirrors
-// scroll-to-bottom-global.spec.ts; also asserts the pill sits below the top nav.
+// point 1): the global scroll-to-top pill only surfaces while the shell <main>
+// is genuinely being scrolled up (never at the very top, never while scrolling
+// down), and clicking it must move the real scroll position back to the top —
+// values happy-dom can't compute. Mirrors scroll-to-bottom-global.spec.ts; also
+// asserts the pill sits below the top nav.
 
 import { expect, test } from './fixtures';
 import { waitForPageLoad } from './helpers';
@@ -35,7 +36,7 @@ for (const { name, width, height } of [
 	{ name: 'desktop', width: 1280, height: 800 },
 	{ name: 'mobile', width: 375, height: 800 },
 ]) {
-	test(`${name}: pill appears once scrolled down and jumps back to the top`, async ({
+	test(`${name}: pill surfaces on upward scroll and jumps back to the top`, async ({
 		page,
 		lightWorkspace,
 	}) => {
@@ -53,8 +54,13 @@ for (const { name, width, height } of [
 		// At the top there is nothing to jump to, so the pill stays hidden.
 		await expect(button).toBeHidden();
 
-		// Scroll to the bottom; the pill now offers a jump back to the top.
+		// Jump to the bottom (scrolling *down*): the up pill still stays hidden —
+		// it only serves an upward scroll.
 		await main.evaluate((el) => el.scrollTo({ top: el.scrollHeight }));
+		await expect(button).toBeHidden();
+
+		// Now scroll up a little: the pill appears, offering a jump back to the top.
+		await main.evaluate((el) => el.scrollBy({ top: -300 }));
 		await expect(button).toBeVisible();
 
 		// It sits just below the app header (the top nav bar), in the upper portion
@@ -81,6 +87,56 @@ for (const { name, width, height } of [
 		await expect(page.getByRole('heading', { name: DOC })).toBeInViewport();
 	});
 }
+
+test('pill fades out a couple seconds after upward scrolling stops', async ({
+	page,
+	lightWorkspace,
+}) => {
+	const { projectSlug, token } = lightWorkspace;
+	await page.setViewportSize({ width: 1280, height: 800 });
+	await seedDoc(page, projectSlug, token, LONG_CONTENT);
+
+	await page.goto(`/projects/${projectSlug}/documents?file=${DOC}`);
+	await waitForPageLoad(page);
+	await expect(page.getByRole('heading', { name: DOC })).toBeVisible({ timeout: 20000 });
+
+	const button = page.getByTestId('scroll-to-top');
+	const main = page.locator('main').first();
+
+	await main.evaluate((el) => el.scrollTo({ top: el.scrollHeight }));
+	await main.evaluate((el) => el.scrollBy({ top: -300 }));
+	await expect(button).toBeVisible();
+
+	// No further scrolling: the idle timer elapses and the pill hides on its own,
+	// well short of the top.
+	await expect(button).toBeHidden({ timeout: 6000 });
+	const scrollTop = await main.evaluate((el) => el.scrollTop);
+	expect(scrollTop).toBeGreaterThan(200);
+});
+
+test('scrolling back down hides the scroll-to-top pill immediately', async ({
+	page,
+	lightWorkspace,
+}) => {
+	const { projectSlug, token } = lightWorkspace;
+	await page.setViewportSize({ width: 1280, height: 800 });
+	await seedDoc(page, projectSlug, token, LONG_CONTENT);
+
+	await page.goto(`/projects/${projectSlug}/documents?file=${DOC}`);
+	await waitForPageLoad(page);
+	await expect(page.getByRole('heading', { name: DOC })).toBeVisible({ timeout: 20000 });
+
+	const button = page.getByTestId('scroll-to-top');
+	const main = page.locator('main').first();
+
+	await main.evaluate((el) => el.scrollTo({ top: el.scrollHeight }));
+	await main.evaluate((el) => el.scrollBy({ top: -300 }));
+	await expect(button).toBeVisible();
+
+	// Reversing direction is the opposite intent — the up pill goes away at once.
+	await main.evaluate((el) => el.scrollBy({ top: 150 }));
+	await expect(button).toBeHidden();
+});
 
 test('pill stays hidden when the page content does not overflow', async ({
 	page,

--- a/test/browser/task-detail.spec.ts
+++ b/test/browser/task-detail.spec.ts
@@ -148,6 +148,9 @@ test.describe('Task detail — initial scroll and scroll-to-bottom button', () =
 		await expect.poll(() => main.evaluate((el) => el.scrollTop), { timeout: 10000 }).toBe(0);
 
 		const button = page.getByTestId('scroll-to-bottom');
+		// Landing at the top: the pill only surfaces once the reader scrolls down.
+		await expect(button).toBeHidden();
+		await main.evaluate((el) => el.scrollBy({ top: 400 }));
 		await expect(button).toBeVisible();
 
 		await button.click();
@@ -194,8 +197,11 @@ test.describe('Task detail — initial scroll and scroll-to-bottom button', () =
 		await expect.poll(() => main.evaluate((el) => el.scrollTop), { timeout: 10000 }).toBe(0);
 
 		// The same global pill pinned bottom-centre of the content area, clear of
-		// the CEO chat launcher in the corner.
+		// the CEO chat launcher in the corner. It surfaces once the reader scrolls
+		// down rather than sitting there permanently.
 		const button = page.getByTestId('scroll-to-bottom');
+		await expect(button).toBeHidden();
+		await main.evaluate((el) => el.scrollBy({ top: 400 }));
 		await expect(button).toBeVisible();
 		await button.click();
 


### PR DESCRIPTION
## Summary

The global scroll-to-top and scroll-to-bottom pills previously stayed visible for as long as the scroller was overflowed and away from the respective edge. This reworks them to be **direction- and idle-aware**, matching the requested behaviour:

- A pill only appears while the user is **actively scrolling toward its edge** (scroll up → scroll-to-top pill; scroll down → scroll-to-bottom pill).
- Continued scrolling in that direction keeps **resetting a short idle timer**, so it stays up while you scroll.
- It **fades out ~2s after scrolling stops**.
- It **hides immediately on reversing direction**.
- It **never shows once already at the very top / very bottom**.

## Changes

- `use-scroll-to-top.ts` / `use-scroll-to-bottom.ts` now compute visibility from per-event scroll direction plus a per-direction idle timer, and expose `visible` instead of `atTop` / `atBottom`. The bottom hook drops its Resize/Mutation observers — visibility is now purely scroll-driven, so content growth alone can no longer surface the pill.
- `ScrollToTopButton` / `ScrollToBottomButton` take a `visible` prop; `aria-hidden`, tab order, and the hide classes follow it.
- Call sites updated: the app shell (`__root.tsx`) and the standalone document preview (`preview/$projectId/$filename.tsx`). Added a `data-testid="preview-scroller"` to the preview's own scroll container so tests can drive it deterministically.

## Testing

- `scroll-to-top-global.spec.ts` and `scroll-to-bottom-global.spec.ts` rewritten to drive a real scroll in each direction and assert the reveal, idle-hide, reverse-hide, and jump-to-edge behaviours (desktop + mobile viewports, plus the bare preview page).
- `task-detail.spec.ts` scroll tests updated to reveal the pill via a downward scroll before clicking.
- All affected browser specs pass; `typecheck`, `check`, and `build` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PBjG3WSk88MsnoZd6mSB9y

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBjG3WSk88MsnoZd6mSB9y)_