### PR TITLE
feat(backup): carry asset blobs in hezo backup/restore bundles

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -1514,7 +1514,9 @@ PutObject/GetObject/DeleteObject/ListObjectsV2/DeleteObjects; deliberately S3-co
 no provider-native drivers) with a ListObjectsV2 preflight + bounded retry at startup and a
 typed `AssetStorageError` printed verbatim + exit on failure. In S3 mode the host filesystem
 holds no asset bytes at all; both layouts share the same relative `<projectId>/<assetId>`
-shape so switching backends is a plain directory↔bucket sync. On local-driver open, a
+shape so switching backends is a plain directory↔bucket sync — which `hezo backup` /
+`hezo restore` perform built-in (see Backup/restore below), copying blobs through this
+interface into and out of a backup bundle. On local-driver open, a
 one-time idempotent fs-only relocation (`relocateLegacyAssetBlobs`) renames blobs written by
 pre-abstraction versions (`teams/<t>/projects/<p>/assets/<id>`) into the new layout. The raw
 URL never reaches request-reachable state (mirrors the DB posture): startup computes a
@@ -1532,19 +1534,31 @@ deletes, which also collects orphans). The in-process S3 sim
 (`test/helpers/s3-sim.ts`) backs the driver-conformance and integration suites; the
 `test-s3` CI job runs the env-gated leg against real MinIO.
 
-**Backup/restore.** The operator format is the **portable logical backup**
+**Backup/restore.** `hezo backup` captures the whole instance — database **and** asset
+blobs — as a **backup bundle** directory: `database.backup.gz` (the portable logical
+database backup) + `assets/<projectId>/<assetId>` blob files + a `manifest.json` written
+**last** as the completion marker. The database half is the **portable logical backup**
 (`src/db/logical-backup.ts`): gzipped JSONL carrying the applied-migration set plus every
 row (bytea → base64, generated tsvector columns excluded and recomputed on load).
 Restore replays the binary's own migrations up to exactly the recorded set, then loads
 data in one transaction with FK constraints dropped/re-added around the inserts (insert
 order and self-references never matter) and serial sequences resumed; migration-seeded
-rows are truncated first so the backup is authoritative. Because both drivers speak the
-same format, `hezo backup`/`hezo restore` also move an instance between embedded PGlite
-and hosted Postgres in either direction. External startup migrations write one of these
-into `<dataDir>/backups/` automatically before applying (last 5 kept; a failed backup
-aborts the migration); the embedded path keeps its stronger copy-swap instead. Legacy
-physical pgdata tarballs (`db/backup.ts` `dumpDataDir`/`restoreDataDir`) still restore
-via `hezo restore` (embedded only).
+rows are truncated first so the backup is authoritative. The asset half
+(`src/assets/blob-backup.ts`) enumerates the authoritative `assets` table on backup and
+the bundle's own `assets/` tree on restore, copying blobs one at a time with bounded
+concurrency through the `AssetStore` interface and verifying each restored blob's sha256
+against the target row. Because both the DB and asset drivers are backend-agnostic,
+`hezo backup` then `hezo restore` moves an instance's database **and** assets between local
+and hosted storage in either direction — direction is expressed purely by which of
+`--database-url` / `--asset-storage-url` each step sets, and the source is only ever read
+(copy-only). `--no-assets` writes the legacy database-only bare `.backup.gz` file (the
+artifact internal callers still use), `--no-database` an assets-only bundle, and
+`--strict-assets` fails restore on any blob with no verifying row. Restore auto-detects the
+input: a directory is a bundle, a file with a logical header is a `.backup.gz`, otherwise a
+legacy physical pgdata tarball (`db/backup.ts` `dumpDataDir`/`restoreDataDir`, embedded
+only). External startup migrations write a bare logical `.backup.gz` into `<dataDir>/backups/`
+automatically before applying (last 5 kept; a failed backup aborts the migration); the
+embedded path keeps its stronger copy-swap instead.
 
 **Releases & updates.** A PR flow (`.github/workflows/`): `release.yml` computes the next
 version from Conventional Commits and opens a `release/<version>` PR; merging fires

--- a/docs/deployment/backup-and-recovery.md
+++ b/docs/deployment/backup-and-recovery.md
@@ -6,10 +6,11 @@ section: Deployment
 
 # Backup & recovery
 
-Hezo's own backup format is a **portable logical backup**: one file that works for both
-storage backends — the embedded database *and* an
-[external Postgres](/docs/deployment/configuration) — which also makes it the way to
-**move an instance between them**. But there's one crucial pairing to understand first.
+`hezo backup` captures a **complete instance** — the database *and* every uploaded asset
+file — as a portable **backup bundle**. It works for both database backends (embedded and
+[external Postgres](/docs/deployment/configuration)) and both asset backends (local files
+and an [S3-compatible bucket](/docs/deployment/configuration)), which also makes it the way
+to **move an instance between them**. But there's one crucial pairing to understand first.
 
 ## You need the data *and* the master key
 
@@ -25,58 +26,70 @@ key separately and safely (see [Master key & encryption](/docs/security/master-k
 ## Backing up
 
 ```sh
-hezo backup                        # embedded database (stop the server first)
-hezo backup --output /safe/place/hezo.backup.gz
-HEZO_DATABASE_URL=postgres://… hezo backup   # external database, any time
+hezo backup                         # whole instance (database + assets) → a bundle directory; stop the server first
+hezo backup --output /safe/place/hezo-backup/   # choose where the bundle goes
+hezo backup --no-assets             # database only → a single .backup.gz file
+HEZO_DATABASE_URL=postgres://… HEZO_ASSET_STORAGE_URL="s3://…" hezo backup   # back up a hosted instance, any time
 ```
 
-`hezo backup` writes a gzipped logical backup (default
-`<data-dir>/backups/hezo-<timestamp>.backup.gz`) containing every row plus the exact
-schema version it was taken at. For the **embedded** database, run it while the server
-is stopped. For an **external** database it can run any time — and pairs well with your
-provider's own snapshots or point-in-time recovery.
+`hezo backup` writes a **backup bundle** (default `<data-dir>/backups/hezo-<timestamp>/`)
+containing `database.backup.gz` (every row plus the exact schema version it was taken at),
+an `assets/` tree of every uploaded file, and a `manifest.json`. Use `--no-assets` for a
+database-only single `.backup.gz` file, or `--no-database` for an assets-only bundle. For
+the **embedded** database and **local** assets, run it while the server is stopped. A
+**hosted** database and bucket can be backed up any time — and pair well with your
+provider's own snapshots or versioning.
 
-**Also back up the data directory.** Uploaded assets (under `<data-dir>/assets/`),
-project workspaces, and keys live under `<data-dir>` (not in the database), so a complete
-instance backup is the `hezo backup` file **plus** a copy of the data directory (a file
-backup or volume snapshot works; stopped-server copies are cleanest). If assets live in
-[S3-compatible object storage](/docs/deployment/configuration) instead, cover the bucket
-with your provider's versioning/replication — the data directory then holds no asset
-files.
+**The bundle does not cover the whole data directory.** Project workspaces (git worktrees)
+and the instance's keys live under `<data-dir>` and are **not** in a backup, so a full
+disaster-recovery copy is the bundle **plus** a copy of the data directory (a file backup
+or volume snapshot works; stopped-server copies are cleanest). If your assets already live
+in [S3-compatible object storage](/docs/deployment/configuration), `hezo backup` reads them
+straight from the bucket into the bundle — or rely on the bucket's own
+versioning/replication and take a `--no-assets` database backup.
 
 ## Restoring
 
 ```sh
-hezo restore <backup file>                     # into the embedded database
-HEZO_DATABASE_URL=postgres://… hezo restore <backup file>   # into an external database
+hezo restore <bundle-or-file>                              # into the embedded database + local assets
+HEZO_DATABASE_URL=postgres://… hezo restore <bundle>       # database into an external Postgres
+hezo restore <bundle> --asset-storage-url "s3://…"         # assets into an S3-compatible bucket
 ```
 
 Restore replays Hezo's own migrations up to exactly the version the backup recorded,
 then loads the data — so the target must be an **empty database** (pass `--wipe` to drop
-and restore over a non-empty one). A backup taken by a *newer* Hezo than the running
-binary is refused with instructions to upgrade first. On the next server start, normal
-migrations bring the restored database forward to the binary's current schema.
+and restore over a non-empty one). Asset blobs from a bundle are written into the target
+asset store and checksum-verified against the restored rows (`--strict-assets` fails on any
+blob with no matching row); use `--no-assets` / `--no-database` to restore only one half of
+a bundle. A backup taken by a *newer* Hezo than the running binary is refused with
+instructions to upgrade first. On the next server start, normal migrations bring the
+restored database forward to the binary's current schema.
 
 Legacy physical snapshots (`.tar.gz` files from older Hezo versions) still restore with
 the same command, into the embedded database only.
 
-## Moving between embedded and hosted Postgres
+## Moving between local and hosted storage
 
-The same two commands are the migration path, in either direction:
+The same two commands are the migration path for the database **and** assets, in either
+direction. Which backends you point `restore` at decides where the data lands; the source
+is only ever read, so nothing is removed until you do it yourself.
 
 ```sh
-# Embedded → hosted Postgres
-hezo backup --output move.backup.gz                      # server stopped
-HEZO_DATABASE_URL=postgres://… hezo restore move.backup.gz
-HEZO_DATABASE_URL=postgres://… hezo                      # start against the new backend
+# Local → hosted (external Postgres + S3 bucket)
+hezo backup --output move/                               # server stopped
+HEZO_DATABASE_URL=postgres://… HEZO_ASSET_STORAGE_URL="s3://…" hezo restore move/
+HEZO_DATABASE_URL=postgres://… HEZO_ASSET_STORAGE_URL="s3://…" hezo   # start against the new backends
 
-# Hosted Postgres → embedded
-HEZO_DATABASE_URL=postgres://… hezo backup --output back.backup.gz
-hezo restore back.backup.gz --data-dir ~/.hezo
+# Hosted → local
+HEZO_DATABASE_URL=postgres://… HEZO_ASSET_STORAGE_URL="s3://…" hezo backup --output back/
+hezo restore back/ --data-dir ~/.hezo
 hezo
 ```
 
-Your master key is unchanged by a move — the encrypted vault travels inside the backup.
+Migrate just one side by setting only that target on `restore` (e.g. only
+`HEZO_DATABASE_URL` to move the database while leaving assets where they are), or with
+`--no-assets` / `--no-database`. Your master key is unchanged by a move — the encrypted
+vault travels inside the backup.
 
 ## Upgrades are safe to roll back
 

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -144,17 +144,27 @@ Recommendations:
 
 ### Switching an existing instance
 
-The local layout under `<data-dir>/assets/` and the bucket key layout are identical
-(`<project-id>/<asset-id>`), so moving is a plain sync with any S3 tool. To move to a
-bucket:
+`hezo backup` / `hezo restore` move an instance's assets between local storage and a bucket
+for you — they carry the database in the same backup bundle, so one pair of commands moves
+the whole instance (see [Backup & recovery](/docs/deployment/backup-and-recovery)). To move
+existing assets into a bucket:
 
-1. Stop the server (upgrade it and start it once first, if you're coming from an older
-   version — the first start moves any old-layout assets into `<data-dir>/assets/`).
-2. Copy the tree into the bucket, e.g.
-   `aws s3 sync /var/lib/hezo/assets/ s3://my-bucket/hezo-assets/` (or `rclone sync`).
-3. Start the server with `HEZO_ASSET_STORAGE_URL` set.
+1. Stop the server.
+2. Back up the instance: `hezo backup --output move/` (add `--data-dir` if yours isn't the
+   default). This writes the database and every asset file into `move/`.
+3. Restore into the bucket: `hezo restore move/ --asset-storage-url "s3://…"` — add
+   `--database-url` as well if you're also moving to hosted Postgres. Restored blobs are
+   checksum-verified against the database rows.
+4. Start the server with `HEZO_ASSET_STORAGE_URL` set.
 
-Moving back to local storage is the same sync in reverse, then start without the URL.
+Moving back to local storage is the same, restoring without `--asset-storage-url`. The
+backup only reads the source, so your original assets stay in place until you remove them
+yourself.
+
+Because the local `<data-dir>/assets/` layout and the bucket keys are identical
+(`<project-id>/<asset-id>`), you can alternatively sync the tree directly with any S3 tool
+while the server is stopped — `aws s3 sync /var/lib/hezo/assets/ s3://my-bucket/hezo-assets/`
+(or `rclone sync`).
 
 ## Anonymous usage telemetry
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -60,28 +60,48 @@ ready. It skips this automatically in environments without a browser — CI, con
 SSH sessions, and headless Linux (no `DISPLAY`/`WAYLAND_DISPLAY`) — and logs where to
 point your browser instead. Use `--no-open` (or `HEZO_OPEN=0`) to turn it off.
 
-## Back up the database
+## Back up
 
 ```sh
-hezo backup [--output <path>] [--data-dir <path>] [--database-url <url>]
+hezo backup [--output <path>] [--data-dir <path>] \
+  [--database-url <url>] [--asset-storage-url <url>] [--no-assets] [--no-database]
 ```
 
-Writes a **portable logical backup** (default
-`<data-dir>/backups/hezo-<timestamp>.backup.gz`) that restores onto either storage
-backend — which also makes it the way to move an instance between the embedded database
-and an external Postgres. For the embedded database, stop the server first. See
+By default `hezo backup` captures a **complete instance** — the database *and* every
+uploaded asset file — as a **backup bundle** directory (default
+`<data-dir>/backups/hezo-<timestamp>/`), containing `database.backup.gz`, an `assets/`
+tree, and a `manifest.json`. The bundle restores onto either storage backend, which is
+how you move an instance's database and assets between local storage and hosted
+providers (external Postgres and an S3-compatible bucket). Point `--asset-storage-url`
+(or `HEZO_ASSET_STORAGE_URL`) at the source bucket when the instance already keeps its
+assets in S3.
+
+- `--no-assets` — database only. Writes the single portable `.backup.gz` file (default
+  `<data-dir>/backups/hezo-<timestamp>.backup.gz`) instead of a bundle.
+- `--no-database` — assets only. Writes a bundle with just the asset files.
+
+For the embedded database (and local asset files), stop the server first. See
 [Backup & recovery](/docs/deployment/backup-and-recovery).
 
 ## Restore a backup
 
 ```sh
-hezo restore <backup> [--wipe] [--data-dir <path>] [--database-url <url>]
+hezo restore <backup> [--wipe] [--data-dir <path>] \
+  [--database-url <url>] [--asset-storage-url <url>] \
+  [--no-assets] [--no-database] [--strict-assets]
 ```
 
-Restores a `hezo backup` file into the embedded database (default) or an external one
-(`--database-url`). The target must be empty unless `--wipe` is passed. Backups taken by
-a newer Hezo are refused — upgrade first. Legacy pre-upgrade `.tar.gz` snapshots restore
-with the same command (embedded only). See
+`<backup>` is a bundle directory (database + assets), a `.backup.gz` file (database
+only), or a legacy pre-upgrade `.tar.gz` snapshot (embedded only). Restore writes into
+whichever backends you point it at: the embedded database (default) or an external one
+(`--database-url`), and local asset files (default) or an S3-compatible bucket
+(`--asset-storage-url`). Setting different targets than the source is exactly how you
+migrate an instance between local and hosted storage.
+
+The target database must be empty unless `--wipe` is passed. Restored asset blobs are
+verified by checksum against the database rows; `--strict-assets` fails if any blob has
+no matching row. `--no-assets` / `--no-database` restore only one half of a bundle.
+Backups taken by a newer Hezo are refused — upgrade first. See
 [Backup & recovery](/docs/deployment/backup-and-recovery).
 
 ## Reset

--- a/packages/server/src/assets/blob-backup.ts
+++ b/packages/server/src/assets/blob-backup.ts
@@ -1,0 +1,291 @@
+/**
+ * Asset-blob backup/restore — the asset half of a Hezo "backup bundle", the
+ * counterpart to `db/logical-backup.ts` for the database half. A bundle is a
+ * directory:
+ *
+ *   hezo-<timestamp>/
+ *     database.backup.gz          # db/logical-backup.ts output (omitted with --no-database)
+ *     assets/<projectId>/<assetId>  # one file per blob (omitted with --no-assets)
+ *     manifest.json               # written LAST — the completion marker
+ *
+ * Blobs use the same relative `<projectId>/<assetId>` layout the local driver
+ * writes on disk and the S3 driver uses as its key, so a bundle round-trips
+ * across backends unchanged — which is how an instance migrates its assets
+ * between the local filesystem and S3-compatible object storage.
+ *
+ * Backup enumerates the authoritative `assets` table (the store may hold orphan
+ * blobs whose rows are gone — those must not travel). Restore enumerates the
+ * bundle's own `assets/` tree (the ground truth of what was captured, so an
+ * assets-only bundle restores without freshly-loaded rows), verifying every
+ * written blob's sha256+size against the target `assets` row when one exists.
+ * Every blob is capped at `ATTACHMENT_MAX_BYTES` (10 MB), so a per-blob Buffer
+ * is always safe; only aggregate size is unbounded, so copies run one blob at a
+ * time with bounded concurrency.
+ */
+
+import { existsSync } from 'node:fs';
+import { mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { Db } from '../db/database';
+import { logger } from '../logger';
+import { AssetNotFoundError, type AssetStore } from './store';
+
+const log = logger.child('asset-backup');
+
+export const BUNDLE_KIND = 'hezo-backup-bundle';
+export const BUNDLE_FORMAT_VERSION = 1;
+export const BUNDLE_MANIFEST_NAME = 'manifest.json';
+export const BUNDLE_DB_NAME = 'database.backup.gz';
+export const BUNDLE_ASSETS_DIR = 'assets';
+
+const ASSET_ENUM_PAGE_SIZE = 1000;
+const ASSET_COPY_CONCURRENCY = 8;
+
+export interface BundleManifestAssets {
+	backend: AssetStore['kind'];
+	count: number;
+	totalBytes: number;
+	/** `<projectId>/<assetId>` keys whose blob was absent at the source (dangling rows). */
+	missing: string[];
+}
+
+export interface BundleManifest {
+	kind: typeof BUNDLE_KIND;
+	bundleFormatVersion: number;
+	hezoVersion: string;
+	createdAt: string;
+	database: { file: string } | null;
+	assets: BundleManifestAssets | null;
+}
+
+export interface AssetBackupSummary {
+	count: number;
+	bytes: number;
+	/** `<projectId>/<assetId>` keys whose blob was missing at the source. */
+	missing: string[];
+}
+
+export interface AssetRestoreSummary {
+	count: number;
+	bytes: number;
+	/** Blobs whose sha256+size matched a row in the target `assets` table. */
+	verified: number;
+	/** Blobs written with no matching target row to verify against. */
+	unverified: number;
+}
+
+interface AssetRow {
+	id: string;
+	project_id: string;
+	content_type: string;
+	sha256: string;
+	byte_size: number | string;
+}
+
+interface BundleBlobRef {
+	projectId: string;
+	assetId: string;
+}
+
+/**
+ * Run `fn` over `items` with at most `limit` in flight. A rejection propagates
+ * (aborting the copy); other in-flight tasks settle but no new ones start.
+ */
+async function forEachConcurrent<T>(
+	items: T[],
+	limit: number,
+	fn: (item: T) => Promise<void>,
+): Promise<void> {
+	let next = 0;
+	const workerCount = Math.min(limit, items.length);
+	const workers: Promise<void>[] = [];
+	for (let i = 0; i < workerCount; i++) {
+		workers.push(
+			(async () => {
+				for (;;) {
+					const idx = next++;
+					if (idx >= items.length) return;
+					await fn(items[idx]);
+				}
+			})(),
+		);
+	}
+	await Promise.all(workers);
+}
+
+/** Every `assets` row, paged, ordered stably. Read-only; caller ensures a quiescent DB. */
+async function enumerateAssetRows(db: Db): Promise<AssetRow[]> {
+	const rows: AssetRow[] = [];
+	let offset = 0;
+	for (;;) {
+		const page = await db.query<AssetRow>(
+			`SELECT id, project_id, content_type, sha256, byte_size FROM assets
+			 ORDER BY project_id, id LIMIT $1 OFFSET $2`,
+			[ASSET_ENUM_PAGE_SIZE, offset],
+		);
+		rows.push(...page.rows);
+		if (page.rows.length < ASSET_ENUM_PAGE_SIZE) break;
+		offset += page.rows.length;
+	}
+	return rows;
+}
+
+/** Walk `<bundleDir>/assets/<projectId>/<assetId>` into blob references. */
+async function enumerateBundleBlobs(assetsRoot: string): Promise<BundleBlobRef[]> {
+	if (!existsSync(assetsRoot)) return [];
+	const refs: BundleBlobRef[] = [];
+	for (const projectEntry of await readdir(assetsRoot, { withFileTypes: true })) {
+		if (!projectEntry.isDirectory()) continue;
+		const projectId = projectEntry.name;
+		for (const assetEntry of await readdir(join(assetsRoot, projectId), { withFileTypes: true })) {
+			if (assetEntry.isFile()) refs.push({ projectId, assetId: assetEntry.name });
+		}
+	}
+	return refs;
+}
+
+/**
+ * Copy every asset blob from `store` into `<bundleDir>/assets/<projectId>/<assetId>`.
+ * A row whose blob is absent at the source (`AssetNotFoundError` — a dangling
+ * row) is recorded in `missing` and skipped rather than aborting a large
+ * backup; any other read failure (a 5xx / transport error) propagates.
+ */
+export async function dumpAssetBlobs(
+	db: Db,
+	store: AssetStore,
+	bundleDir: string,
+): Promise<AssetBackupSummary> {
+	const rows = await enumerateAssetRows(db);
+	const assetsRoot = join(bundleDir, BUNDLE_ASSETS_DIR);
+	const preparedDirs = new Set<string>();
+	const missing: string[] = [];
+	let count = 0;
+	let bytes = 0;
+
+	await forEachConcurrent(rows, ASSET_COPY_CONCURRENCY, async (row) => {
+		let buf: Buffer;
+		try {
+			buf = await store.read(row.project_id, row.id);
+		} catch (err) {
+			if (err instanceof AssetNotFoundError) {
+				missing.push(`${row.project_id}/${row.id}`);
+				log.warn(`Asset blob ${row.project_id}/${row.id} missing at source; skipping.`);
+				return;
+			}
+			throw err;
+		}
+		const projectDir = join(assetsRoot, row.project_id);
+		if (!preparedDirs.has(projectDir)) {
+			await mkdir(projectDir, { recursive: true });
+			preparedDirs.add(projectDir);
+		}
+		await writeFile(join(projectDir, row.id), buf);
+		count += 1;
+		bytes += buf.byteLength;
+	});
+
+	return { count, bytes, missing };
+}
+
+/**
+ * Write every blob in the bundle's `assets/` tree into `store`. Each write
+ * recomputes the sha256, which is asserted against the target `assets` row when
+ * one exists (a genuine end-to-end integrity check); a mismatch throws. Blobs
+ * with no matching row are written unverified unless `strict` is set, which
+ * requires every restored blob to be verifiable. Writes are idempotent by
+ * `(projectId, assetId)`, so a partial restore is safe to re-run.
+ */
+export async function restoreAssetBlobs(
+	db: Db,
+	store: AssetStore,
+	bundleDir: string,
+	options: { strict?: boolean } = {},
+): Promise<AssetRestoreSummary> {
+	const assetsRoot = join(bundleDir, BUNDLE_ASSETS_DIR);
+	const blobs = await enumerateBundleBlobs(assetsRoot);
+	const rowsById = new Map<string, AssetRow>();
+	for (const row of await enumerateAssetRows(db)) rowsById.set(row.id, row);
+
+	let count = 0;
+	let bytes = 0;
+	let verified = 0;
+	let unverified = 0;
+
+	await forEachConcurrent(blobs, ASSET_COPY_CONCURRENCY, async ({ projectId, assetId }) => {
+		const buf = await readFile(join(assetsRoot, projectId, assetId));
+		const row = rowsById.get(assetId);
+		const contentType = row?.content_type || 'application/octet-stream';
+		const result = await store.write(projectId, assetId, new Blob([buf], { type: contentType }));
+		if (row) {
+			if (result.sha256 !== row.sha256 || result.byteSize !== Number(row.byte_size)) {
+				throw new Error(
+					`Asset ${projectId}/${assetId} failed its integrity check after restore ` +
+						`(expected sha256 ${row.sha256} / ${row.byte_size} bytes, ` +
+						`got ${result.sha256} / ${result.byteSize} bytes). The backup may be corrupt.`,
+				);
+			}
+			verified += 1;
+		} else {
+			if (options.strict) {
+				throw new Error(
+					`Asset ${projectId}/${assetId} has no matching row in the target database, so it ` +
+						`cannot be integrity-checked. Restore the database half too, or drop --strict-assets.`,
+				);
+			}
+			unverified += 1;
+		}
+		count += 1;
+		bytes += buf.byteLength;
+	});
+
+	return { count, bytes, verified, unverified };
+}
+
+/** Write the manifest — the LAST step of a backup, so a half-written bundle has none. */
+export async function writeBundleManifest(
+	bundleDir: string,
+	manifest: BundleManifest,
+): Promise<void> {
+	await mkdir(bundleDir, { recursive: true });
+	await writeFile(join(bundleDir, BUNDLE_MANIFEST_NAME), `${JSON.stringify(manifest, null, 2)}\n`);
+}
+
+/** Read + validate a bundle manifest; throws an operator-actionable error otherwise. */
+export async function readBundleManifest(bundleDir: string): Promise<BundleManifest> {
+	const manifestPath = join(bundleDir, BUNDLE_MANIFEST_NAME);
+	let raw: string;
+	try {
+		raw = await readFile(manifestPath, 'utf8');
+	} catch {
+		throw new Error(
+			`${bundleDir} is not a Hezo backup bundle (no ${BUNDLE_MANIFEST_NAME}). ` +
+				`Point restore at a "hezo backup" bundle directory or a .backup.gz file.`,
+		);
+	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		throw new Error(`Corrupt backup bundle: ${BUNDLE_MANIFEST_NAME} is not valid JSON.`);
+	}
+	const manifest = parsed as Partial<BundleManifest>;
+	if (manifest.kind !== BUNDLE_KIND || typeof manifest.bundleFormatVersion !== 'number') {
+		throw new Error(`${bundleDir} is not a Hezo backup bundle (unexpected manifest contents).`);
+	}
+	if (manifest.bundleFormatVersion !== BUNDLE_FORMAT_VERSION) {
+		throw new Error(
+			`This backup bundle uses format v${manifest.bundleFormatVersion}; this Hezo build reads ` +
+				`v${BUNDLE_FORMAT_VERSION}. Restore it with a matching Hezo version.`,
+		);
+	}
+	return manifest as BundleManifest;
+}
+
+/** True when the backup path is a directory (a bundle) rather than a single file. */
+export async function isBundleDir(path: string): Promise<boolean> {
+	try {
+		return (await stat(path)).isDirectory();
+	} catch {
+		return false;
+	}
+}

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -1,5 +1,5 @@
 import { homedir } from 'node:os';
-import { resolve } from 'node:path';
+import { join, resolve } from 'node:path';
 import {
 	DEFAULT_DATA_DIR,
 	DEFAULT_PORT,
@@ -181,65 +181,152 @@ function pickDatabaseUrl(
 	return undefined;
 }
 
+/** As `pickDatabaseUrl`, for the asset-storage URL on the backup/restore subcommands. */
+function pickAssetStorageUrl(
+	cliValue: unknown,
+	env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+	const e = env.HEZO_ASSET_STORAGE_URL;
+	if (e !== undefined && e !== '') return e;
+	if (typeof cliValue === 'string' && cliValue.length > 0) return cliValue;
+	return undefined;
+}
+
 /**
- * Handle the `hezo backup` subcommand: write a portable logical backup of the
- * database (either backend) and exit. Returns `true` when it handled the
- * invocation so the caller skips normal server startup.
+ * Handle the `hezo backup` subcommand and exit. By default it captures BOTH the
+ * database and every asset blob into a portable **backup bundle** directory
+ * (`hezo-<timestamp>/` — `database.backup.gz` + `assets/<projectId>/<assetId>` +
+ * a `manifest.json` written last). Either half is excluded with `--no-assets`
+ * (database only → the legacy single `.backup.gz` file) or `--no-database`
+ * (assets only). A bundle restores onto either backend, which is how an instance
+ * moves its database and assets between local and hosted storage. Returns `true`
+ * when it handled the invocation so the caller skips normal server startup.
  *
- * For the embedded database the server must be stopped first — the embedded
- * engine is single-process. An external database can be backed up any time.
+ * For the embedded database / local asset store the server must be stopped first
+ * (the embedded engine is single-process, and a live server races the asset
+ * directory). An external database + S3 storage can be backed up any time — the
+ * source is only ever read.
  */
 export async function runBackup(argv: string[] = process.argv): Promise<boolean> {
 	if (argv[2] !== 'backup') return false;
 
 	const program = new Command()
 		.name('hezo backup')
-		.description('Write a portable logical backup of the database (works for both backends)')
+		.description(
+			'Write a portable backup of the database and asset files (works for both backends)',
+		)
 		.option(
 			'--output <path>',
-			'Output file (default <data-dir>/backups/hezo-<timestamp>.backup.gz)',
+			'Output path: a bundle directory (default <data-dir>/backups/hezo-<timestamp>), or a .backup.gz file with --no-assets',
 		)
 		.option('--data-dir <path>', 'Data directory', DEFAULT_DATA_DIR)
 		.option('--database-url <url>', 'External Postgres connection string (env: HEZO_DATABASE_URL)')
+		.option(
+			'--asset-storage-url <url>',
+			'S3-compatible asset storage to read blobs from (env: HEZO_ASSET_STORAGE_URL)',
+		)
+		.option('--no-assets', 'Back up the database only — skip asset files')
+		.option('--no-database', 'Back up asset files only — skip the database')
 		.parse(argv.slice(3), { from: 'user' });
 
 	const opts = program.opts();
+	const withAssets = opts.assets !== false;
+	const withDatabase = opts.database !== false;
+	if (!withAssets && !withDatabase) {
+		throw new Error('Nothing to back up: --no-assets and --no-database cannot be combined.');
+	}
 	const dataDir = resolveDataDir(opts.dataDir as string);
 	const databaseUrl = pickDatabaseUrl(opts.databaseUrl);
+	const assetStorageUrl = pickAssetStorageUrl(opts.assetStorageUrl);
 
-	const { loadAllMigrations } = await import('./db/load-migrations.js');
-	const migrations = await loadAllMigrations();
-	if (!migrations) throw new Error('No migrations found — cannot determine the schema version.');
-
-	const { openDatabase } = await import('./db/open.js');
-	const { dumpLogicalBackup } = await import('./db/logical-backup.js');
 	const { mkdir, writeFile } = await import('node:fs/promises');
+	const { openDatabase } = await import('./db/open.js');
+	const stamp = new Date().toISOString().replace(/[:.]/g, '-');
 
+	const dumpDatabase = async (db: import('./db/database').Db): Promise<Buffer> => {
+		const { loadAllMigrations } = await import('./db/load-migrations.js');
+		const migrations = await loadAllMigrations();
+		if (!migrations) throw new Error('No migrations found — cannot determine the schema version.');
+		const { dumpLogicalBackup } = await import('./db/logical-backup.js');
+		return dumpLogicalBackup(db, { hezoVersion: HEZO_VERSION, migrations });
+	};
+
+	// --no-assets keeps the exact legacy single-file artifact (the DB-only
+	// .backup.gz that the auto/pre-migration and legacy-restore paths expect).
+	if (!withAssets) {
+		const opened = await openDatabase({ dataDir, databaseUrl });
+		try {
+			const bytes = await dumpDatabase(opened.db);
+			const output = resolve(
+				(opts.output as string | undefined) ?? `${dataDir}/backups/hezo-${stamp}.backup.gz`,
+			);
+			await mkdir(resolve(output, '..'), { recursive: true });
+			await writeFile(output, bytes);
+			console.log(`Wrote logical backup of ${opened.storage.backend} database → ${output}`);
+		} finally {
+			await opened.db.close();
+		}
+		return true;
+	}
+
+	// Bundle path: DB (unless --no-database) + asset blobs + manifest (last).
+	const bundleDir = resolve(
+		(opts.output as string | undefined) ?? `${dataDir}/backups/hezo-${stamp}`,
+	);
+	const blob = await import('./assets/blob-backup.js');
+	const { openAssetStorage } = await import('./assets/open.js');
+
+	await mkdir(bundleDir, { recursive: true });
 	const opened = await openDatabase({ dataDir, databaseUrl });
+	const openedStore = await openAssetStorage({ dataDir, assetStorageUrl });
 	try {
-		const bytes = await dumpLogicalBackup(opened.db, { hezoVersion: HEZO_VERSION, migrations });
-		const stamp = new Date().toISOString().replace(/[:.]/g, '-');
-		const output = resolve(
-			(opts.output as string | undefined) ?? `${dataDir}/backups/hezo-${stamp}.backup.gz`,
+		let databaseFile: string | null = null;
+		if (withDatabase) {
+			await writeFile(join(bundleDir, blob.BUNDLE_DB_NAME), await dumpDatabase(opened.db));
+			databaseFile = blob.BUNDLE_DB_NAME;
+		}
+		const assets = await blob.dumpAssetBlobs(opened.db, openedStore.store, bundleDir);
+		await blob.writeBundleManifest(bundleDir, {
+			kind: blob.BUNDLE_KIND,
+			bundleFormatVersion: blob.BUNDLE_FORMAT_VERSION,
+			hezoVersion: HEZO_VERSION,
+			createdAt: new Date().toISOString(),
+			database: databaseFile ? { file: databaseFile } : null,
+			assets: {
+				backend: openedStore.store.kind,
+				count: assets.count,
+				totalBytes: assets.bytes,
+				missing: assets.missing,
+			},
+		});
+		const dbNote = withDatabase ? `${opened.storage.backend} database + ` : '';
+		const missingNote = assets.missing.length
+			? ` — ${assets.missing.length} asset blob(s) were missing at the source`
+			: '';
+		console.log(
+			`Wrote backup bundle → ${bundleDir} ` +
+				`(${dbNote}${assets.count} asset blob(s) from ${openedStore.info.backend} storage)${missingNote}`,
 		);
-		await mkdir(resolve(output, '..'), { recursive: true });
-		await writeFile(output, bytes);
-		console.log(`Wrote logical backup of ${opened.storage.backend} database → ${output}`);
 	} finally {
+		await openedStore.store.close();
 		await opened.db.close();
 	}
 	return true;
 }
 
 /**
- * Handle the `hezo restore <backup>` subcommand, then exit. Two formats:
+ * Handle the `hezo restore <backup>` subcommand, then exit. It accepts:
  *
- * - **Portable logical backup** (`hezo backup` output, `.backup.gz`) —
- *   restores onto EITHER backend, which is also how an instance moves between
- *   embedded and hosted Postgres. Requires an empty target or `--wipe`.
+ * - **Backup bundle** (a `hezo backup` directory) — restores the database
+ *   and/or asset blobs it contains into the target backends (`--database-url` /
+ *   `--asset-storage-url`), which is how an instance moves both between local
+ *   and hosted storage. `--no-assets` / `--no-database` restore only one half.
+ * - **Portable logical backup** (`.backup.gz`) — database only; restores onto
+ *   EITHER backend. Requires an empty target or `--wipe`.
  * - **Legacy pgdata tarball** (pre-logical snapshots) — embedded only; wipes
  *   `pgdata` and reloads the physical snapshot.
  *
+ * Asset blobs are verified by sha256 against the target rows when present.
  * Returns `true` when it handled the invocation so the caller skips normal
  * server startup.
  */
@@ -248,14 +335,26 @@ export async function runRestore(argv: string[] = process.argv): Promise<boolean
 
 	const program = new Command()
 		.name('hezo restore')
-		.description('Restore a database backup (logical .backup.gz, or a legacy pgdata .tar.gz)')
-		.argument('<backup>', 'path to a backup file')
+		.description(
+			'Restore a backup: a "hezo backup" bundle (database + assets), a logical .backup.gz, or a legacy pgdata .tar.gz',
+		)
+		.argument('<backup>', 'path to a backup bundle directory or file')
 		.option('--data-dir <path>', 'Data directory', DEFAULT_DATA_DIR)
 		.option(
 			'--database-url <url>',
 			'External Postgres connection string to restore into (env: HEZO_DATABASE_URL)',
 		)
+		.option(
+			'--asset-storage-url <url>',
+			'S3-compatible asset storage to restore blobs into (env: HEZO_ASSET_STORAGE_URL)',
+		)
 		.option('--wipe', 'Drop the existing schema in the target database before restoring')
+		.option('--no-assets', 'Restore the database only — skip asset files in a bundle')
+		.option('--no-database', 'Restore asset files only — skip the database in a bundle')
+		.option(
+			'--strict-assets',
+			'Fail if any restored asset blob has no matching database row to verify against',
+		)
 		// argv is [runtime, script, 'restore', <backup>, ...flags] in both dev and
 		// the compiled binary — parse only the tokens after the subcommand name.
 		.parse(argv.slice(3), { from: 'user' });
@@ -264,7 +363,67 @@ export async function runRestore(argv: string[] = process.argv): Promise<boolean
 	const backupPath = resolve(program.args[0]);
 	const dataDir = resolveDataDir(opts.dataDir as string);
 	const databaseUrl = pickDatabaseUrl(opts.databaseUrl);
+	const assetStorageUrl = pickAssetStorageUrl(opts.assetStorageUrl);
 
+	const { loadAllMigrations } = await import('./db/load-migrations.js');
+	const { openDatabase } = await import('./db/open.js');
+	const blob = await import('./assets/blob-backup.js');
+
+	// Backup bundle (a directory): restore the database and/or assets it holds.
+	if (await blob.isBundleDir(backupPath)) {
+		const withAssets = opts.assets !== false;
+		const withDatabase = opts.database !== false;
+		if (!withAssets && !withDatabase) {
+			throw new Error('Nothing to restore: --no-assets and --no-database cannot be combined.');
+		}
+		const manifest = await blob.readBundleManifest(backupPath);
+		const restoreDb = withDatabase && manifest.database !== null;
+		const restoreAssets = withAssets && manifest.assets !== null;
+
+		const { readFile } = await import('node:fs/promises');
+		const { openAssetStorage } = await import('./assets/open.js');
+
+		const opened = await openDatabase({ dataDir, databaseUrl });
+		// Preflight the target asset store BEFORE loading the DB so a bad bucket fails fast.
+		const openedStore = restoreAssets ? await openAssetStorage({ dataDir, assetStorageUrl }) : null;
+		try {
+			if (restoreDb) {
+				const migrations = await loadAllMigrations();
+				if (!migrations) {
+					throw new Error('No migrations found — cannot reproduce the backup schema.');
+				}
+				const { restoreLogicalBackup } = await import('./db/logical-backup.js');
+				const dbBytes = await readFile(join(backupPath, blob.BUNDLE_DB_NAME));
+				const summary = await restoreLogicalBackup(opened.db, dbBytes, migrations, {
+					wipe: opts.wipe === true,
+				});
+				console.log(
+					`Restored database (Hezo ${manifest.hezoVersion}, taken ${manifest.createdAt}) into the ` +
+						`${opened.storage.backend} backend: ${summary.rows} rows across ${summary.tables} tables.`,
+				);
+			}
+			if (restoreAssets && openedStore) {
+				const summary = await blob.restoreAssetBlobs(opened.db, openedStore.store, backupPath, {
+					strict: opts.strictAssets === true,
+				});
+				const unverifiedNote = summary.unverified
+					? ` (${summary.unverified} without a matching database row)`
+					: '';
+				console.log(
+					`Restored ${summary.count} asset blob(s) into the ${openedStore.info.backend} storage${unverifiedNote}.`,
+				);
+			}
+			if (!restoreDb && !restoreAssets) {
+				console.log('This bundle has nothing to restore for the given options.');
+			}
+		} finally {
+			if (openedStore) await openedStore.store.close();
+			await opened.db.close();
+		}
+		return true;
+	}
+
+	// Single-file backups (unchanged): logical .backup.gz, or a legacy pgdata tarball.
 	const { readFile } = await import('node:fs/promises');
 	const bytes = await readFile(backupPath);
 
@@ -286,11 +445,9 @@ export async function runRestore(argv: string[] = process.argv): Promise<boolean
 		return true;
 	}
 
-	const { loadAllMigrations } = await import('./db/load-migrations.js');
 	const migrations = await loadAllMigrations();
 	if (!migrations) throw new Error('No migrations found — cannot reproduce the backup schema.');
 
-	const { openDatabase } = await import('./db/open.js');
 	const opened = await openDatabase({ dataDir, databaseUrl });
 	try {
 		const summary = await restoreLogicalBackup(opened.db, bytes, migrations, {

--- a/packages/server/test/asset-blob-backup.test.ts
+++ b/packages/server/test/asset-blob-backup.test.ts
@@ -1,0 +1,190 @@
+import { createHash } from 'node:crypto';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+import { BUNDLE_ASSETS_DIR, dumpAssetBlobs, restoreAssetBlobs } from '../src/assets/blob-backup';
+import { LocalAssetStore } from '../src/assets/drivers/local';
+import { openAssetStorage } from '../src/assets/open';
+import type { Db } from '../src/db/database';
+import { runMigrations } from '../src/db/migrate';
+import { openDatabase } from '../src/db/open';
+import { BASE_SCHEMA } from '../src/db/schema';
+import { safeClose } from './helpers';
+import { allMigrations } from './helpers/migrate';
+import { createS3Sim } from './helpers/s3-sim';
+
+// Exercises the asset-blob copy engine (dumpAssetBlobs / restoreAssetBlobs)
+// against the real drivers — local filesystem and, via the in-process S3
+// simulator, S3-compatible storage — including the cross-backend copy that is
+// the whole point of the feature (an instance migrating its assets).
+
+const tempDirs: string[] = [];
+const sims: Array<{ destroy: () => Promise<void> }> = [];
+
+function makeTempDir(): string {
+	const dir = mkdtempSync(join(tmpdir(), 'hezo-blob-backup-'));
+	tempDirs.push(dir);
+	return dir;
+}
+
+afterAll(async () => {
+	for (const sim of sims) await sim.destroy();
+	for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+});
+
+async function openMigratedDb(dataDir: string): Promise<Db> {
+	const opened = await openDatabase({ dataDir });
+	await opened.db.exec(BASE_SCHEMA);
+	await runMigrations(opened.db, allMigrations());
+	return opened.db;
+}
+
+let seedCounter = 0;
+
+interface SeededAsset {
+	projectId: string;
+	assetId: string;
+	content: Buffer;
+	sha256: string;
+}
+
+/** Insert a team + project + asset row (each in its own 1:1 team) and return its ids. */
+async function seedAssetRow(db: Db, content: Buffer): Promise<SeededAsset> {
+	const n = ++seedCounter;
+	const team = await db.query<{ id: string }>(
+		`INSERT INTO teams (name, slug) VALUES ($1, $2) RETURNING id`,
+		[`Team ${n}`, `team-${n}`],
+	);
+	const teamId = team.rows[0].id;
+	const project = await db.query<{ id: string }>(
+		`INSERT INTO projects (team_id, name, slug, task_prefix) VALUES ($1, $2, $3, $4) RETURNING id`,
+		[teamId, `Project ${n}`, `project-${n}`, `P${n}`],
+	);
+	const projectId = project.rows[0].id;
+	const sha256 = createHash('sha256').update(content).digest('hex');
+	const asset = await db.query<{ id: string }>(
+		`INSERT INTO assets (team_id, project_id, content_type, byte_size, sha256, original_filename)
+		 VALUES ($1, $2, 'text/plain', $3, $4, $5) RETURNING id`,
+		[teamId, projectId, content.byteLength, sha256, `file-${n}.txt`],
+	);
+	return { projectId, assetId: asset.rows[0].id, content, sha256 };
+}
+
+describe('asset blob backup/restore', () => {
+	it('round-trips blobs through a bundle and verifies sha256', async () => {
+		const srcDir = makeTempDir();
+		const db = await openMigratedDb(srcDir);
+		const store = new LocalAssetStore(srcDir);
+		const asset = await seedAssetRow(db, Buffer.from('hello asset bytes'));
+		await store.write(asset.projectId, asset.assetId, new Blob([asset.content]));
+
+		const bundleDir = makeTempDir();
+		const dump = await dumpAssetBlobs(db, store, bundleDir);
+		expect(dump.count).toBe(1);
+		expect(dump.bytes).toBe(asset.content.byteLength);
+		expect(dump.missing).toEqual([]);
+		const bundled = await readFile(
+			join(bundleDir, BUNDLE_ASSETS_DIR, asset.projectId, asset.assetId),
+		);
+		expect(bundled.equals(asset.content)).toBe(true);
+
+		const targetStore = new LocalAssetStore(makeTempDir());
+		const restore = await restoreAssetBlobs(db, targetStore, bundleDir);
+		expect(restore).toMatchObject({ count: 1, verified: 1, unverified: 0 });
+		expect((await targetStore.read(asset.projectId, asset.assetId)).equals(asset.content)).toBe(
+			true,
+		);
+
+		await safeClose(db as { close: () => Promise<void> });
+	});
+
+	it('copies blobs from local storage into an S3-compatible bucket', async () => {
+		const srcDir = makeTempDir();
+		const db = await openMigratedDb(srcDir);
+		const store = new LocalAssetStore(srcDir);
+		const asset = await seedAssetRow(db, Buffer.from('to the cloud'));
+		await store.write(asset.projectId, asset.assetId, new Blob([asset.content]));
+
+		const bundleDir = makeTempDir();
+		await dumpAssetBlobs(db, store, bundleDir);
+
+		const sim = await createS3Sim();
+		sims.push(sim);
+		const target = await openAssetStorage({
+			dataDir: makeTempDir(),
+			assetStorageUrl: sim.storeUrl(),
+		});
+		try {
+			const restore = await restoreAssetBlobs(db, target.store, bundleDir);
+			expect(restore).toMatchObject({ count: 1, verified: 1 });
+			// The `<projectId>/<assetId>` key layout lands in the bucket unchanged.
+			const key = `${asset.projectId}/${asset.assetId}`;
+			expect(sim.objects.get(key)?.body.equals(asset.content)).toBe(true);
+		} finally {
+			await target.store.close();
+		}
+		await safeClose(db as { close: () => Promise<void> });
+	});
+
+	it('records a row whose blob is missing at the source and keeps going', async () => {
+		const srcDir = makeTempDir();
+		const db = await openMigratedDb(srcDir);
+		const store = new LocalAssetStore(srcDir);
+		const present = await seedAssetRow(db, Buffer.from('present'));
+		await store.write(present.projectId, present.assetId, new Blob([present.content]));
+		const dangling = await seedAssetRow(db, Buffer.from('row without a blob'));
+
+		const bundleDir = makeTempDir();
+		const dump = await dumpAssetBlobs(db, store, bundleDir);
+		expect(dump.count).toBe(1);
+		expect(dump.missing).toEqual([`${dangling.projectId}/${dangling.assetId}`]);
+
+		await safeClose(db as { close: () => Promise<void> });
+	});
+
+	it('fails restore when a bundle blob does not match its database row', async () => {
+		const srcDir = makeTempDir();
+		const db = await openMigratedDb(srcDir);
+		const store = new LocalAssetStore(srcDir);
+		const asset = await seedAssetRow(db, Buffer.from('original bytes'));
+		await store.write(asset.projectId, asset.assetId, new Blob([asset.content]));
+
+		const bundleDir = makeTempDir();
+		await dumpAssetBlobs(db, store, bundleDir);
+		// Tamper with the bundled blob so its sha256 no longer matches the row.
+		await writeFile(
+			join(bundleDir, BUNDLE_ASSETS_DIR, asset.projectId, asset.assetId),
+			Buffer.from('tampered bytes'),
+		);
+
+		const targetStore = new LocalAssetStore(makeTempDir());
+		await expect(restoreAssetBlobs(db, targetStore, bundleDir)).rejects.toThrow(/integrity check/);
+
+		await safeClose(db as { close: () => Promise<void> });
+	});
+
+	it('restores blobs with no matching row unverified, or fails under strict', async () => {
+		const srcDir = makeTempDir();
+		const db = await openMigratedDb(srcDir);
+		const store = new LocalAssetStore(srcDir);
+		const asset = await seedAssetRow(db, Buffer.from('assets-only blob'));
+		await store.write(asset.projectId, asset.assetId, new Blob([asset.content]));
+
+		const bundleDir = makeTempDir();
+		await dumpAssetBlobs(db, store, bundleDir);
+
+		// A target database with no matching asset row (e.g. an assets-only restore).
+		const emptyDb = await openMigratedDb(makeTempDir());
+		const lenient = await restoreAssetBlobs(emptyDb, new LocalAssetStore(makeTempDir()), bundleDir);
+		expect(lenient).toMatchObject({ count: 1, verified: 0, unverified: 1 });
+
+		await expect(
+			restoreAssetBlobs(emptyDb, new LocalAssetStore(makeTempDir()), bundleDir, { strict: true }),
+		).rejects.toThrow(/strict/i);
+
+		await safeClose(db as { close: () => Promise<void> });
+		await safeClose(emptyDb as { close: () => Promise<void> });
+	});
+});

--- a/packages/server/test/cli-backup-restore.test.ts
+++ b/packages/server/test/cli-backup-restore.test.ts
@@ -1,8 +1,11 @@
+import { createHash } from 'node:crypto';
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { readdir, readFile } from 'node:fs/promises';
+import { readdir, readFile, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { BUNDLE_ASSETS_DIR, BUNDLE_DB_NAME, BUNDLE_MANIFEST_NAME } from '../src/assets/blob-backup';
+import { LocalAssetStore } from '../src/assets/drivers/local';
 import { runBackup, runRestore } from '../src/cli';
 import { backupDataDir } from '../src/db/backup';
 import type { Db } from '../src/db/database';
@@ -13,6 +16,7 @@ import { openDatabase } from '../src/db/open';
 import { BASE_SCHEMA } from '../src/db/schema';
 import { safeClose } from './helpers';
 import { allMigrations } from './helpers/migrate';
+import { createS3Sim, type S3Sim } from './helpers/s3-sim';
 
 // Exercises the `hezo backup` / `hezo restore` subcommands end-to-end against
 // real embedded databases on disk — the same open/migrate/dump/restore code the
@@ -21,6 +25,7 @@ import { allMigrations } from './helpers/migrate';
 const argv = (...tokens: string[]) => ['bun', 'src/index.ts', ...tokens];
 
 const tempDirs: string[] = [];
+const sims: S3Sim[] = [];
 function makeTempDir(): string {
 	const dir = mkdtempSync(join(tmpdir(), 'hezo-cli-brt-'));
 	tempDirs.push(dir);
@@ -44,24 +49,69 @@ async function teamSlugs(db: Db): Promise<string[]> {
 	return r.rows.map((row) => row.slug);
 }
 
+interface SeededAsset {
+	projectId: string;
+	assetId: string;
+	content: Buffer;
+}
+
+/**
+ * Add a project + asset (row + local blob) under the seeded `backup-probe` team.
+ * Call after `seedMigratedDataDir`.
+ */
+async function seedAssetInDataDir(dataDir: string): Promise<SeededAsset> {
+	const opened = await openDatabase({ dataDir });
+	try {
+		const team = await opened.db.query<{ id: string }>(
+			`SELECT id FROM teams WHERE slug = 'backup-probe'`,
+		);
+		const teamId = team.rows[0].id;
+		const project = await opened.db.query<{ id: string }>(
+			`INSERT INTO projects (team_id, name, slug, task_prefix)
+			 VALUES ($1, 'Assets', 'assets-probe', 'AP') RETURNING id`,
+			[teamId],
+		);
+		const projectId = project.rows[0].id;
+		const content = Buffer.from('cli bundle asset payload');
+		const sha256 = createHash('sha256').update(content).digest('hex');
+		const asset = await opened.db.query<{ id: string }>(
+			`INSERT INTO assets (team_id, project_id, content_type, byte_size, sha256, original_filename)
+			 VALUES ($1, $2, 'text/plain', $3, $4, 'probe.txt') RETURNING id`,
+			[teamId, projectId, content.byteLength, sha256],
+		);
+		const assetId = asset.rows[0].id;
+		await new LocalAssetStore(dataDir).write(projectId, assetId, new Blob([content]));
+		return { projectId, assetId, content };
+	} finally {
+		await safeClose(opened.db as { close: () => Promise<void> });
+	}
+}
+
 describe('hezo backup / hezo restore subcommands', () => {
 	let logSpy: ReturnType<typeof vi.spyOn>;
 	let prevDatabaseUrl: string | undefined;
+	let prevAssetStorageUrl: string | undefined;
 
 	beforeAll(() => {
 		prevDatabaseUrl = process.env.HEZO_DATABASE_URL;
+		prevAssetStorageUrl = process.env.HEZO_ASSET_STORAGE_URL;
 		delete process.env.HEZO_DATABASE_URL;
+		delete process.env.HEZO_ASSET_STORAGE_URL;
 	});
 
-	afterAll(() => {
+	afterAll(async () => {
 		if (prevDatabaseUrl === undefined) delete process.env.HEZO_DATABASE_URL;
 		else process.env.HEZO_DATABASE_URL = prevDatabaseUrl;
+		if (prevAssetStorageUrl === undefined) delete process.env.HEZO_ASSET_STORAGE_URL;
+		else process.env.HEZO_ASSET_STORAGE_URL = prevAssetStorageUrl;
+		for (const sim of sims) await sim.destroy();
 		for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
 	});
 
 	afterEach(() => {
 		vi.restoreAllMocks();
 		delete process.env.HEZO_DATABASE_URL;
+		delete process.env.HEZO_ASSET_STORAGE_URL;
 	});
 
 	it('runBackup/runRestore return false when another (or no) subcommand is invoked', async () => {
@@ -76,9 +126,11 @@ describe('hezo backup / hezo restore subcommands', () => {
 		const sourceDir = makeTempDir();
 		await seedMigratedDataDir(sourceDir);
 
-		// Explicit --output path.
+		// --no-assets keeps the DB-only single-file artifact. Explicit --output path.
 		const output = join(makeTempDir(), 'probe.backup.gz');
-		expect(await runBackup(argv('backup', '--data-dir', sourceDir, '--output', output))).toBe(true);
+		expect(
+			await runBackup(argv('backup', '--data-dir', sourceDir, '--no-assets', '--output', output)),
+		).toBe(true);
 		expect(existsSync(output)).toBe(true);
 		const header = readLogicalBackupHeader(await readFile(output));
 		expect(header?.formatVersion).toBe(1);
@@ -88,7 +140,7 @@ describe('hezo backup / hezo restore subcommands', () => {
 		).toBe(true);
 
 		// Default output path lands under <data-dir>/backups.
-		expect(await runBackup(argv('backup', '--data-dir', sourceDir))).toBe(true);
+		expect(await runBackup(argv('backup', '--data-dir', sourceDir, '--no-assets'))).toBe(true);
 		const defaults = await readdir(join(sourceDir, 'backups'));
 		expect(defaults.some((f) => /^hezo-.*\.backup\.gz$/.test(f))).toBe(true);
 
@@ -172,5 +224,97 @@ describe('hezo backup / hezo restore subcommands', () => {
 		expect(errorSpy.mock.calls.some((c) => String(c[0]).includes('legacy pgdata snapshot'))).toBe(
 			true,
 		);
+	});
+
+	it('backs up a bundle (database + assets) and restores both into a fresh data dir', async () => {
+		const sourceDir = makeTempDir();
+		await seedMigratedDataDir(sourceDir);
+		const asset = await seedAssetInDataDir(sourceDir);
+
+		const bundleDir = join(makeTempDir(), 'bundle');
+		expect(await runBackup(argv('backup', '--data-dir', sourceDir, '--output', bundleDir))).toBe(
+			true,
+		);
+		// A bundle is a directory carrying the DB dump, the blob, and a manifest.
+		expect((await stat(bundleDir)).isDirectory()).toBe(true);
+		expect(existsSync(join(bundleDir, BUNDLE_MANIFEST_NAME))).toBe(true);
+		expect(existsSync(join(bundleDir, BUNDLE_DB_NAME))).toBe(true);
+		const bundledBlob = await readFile(
+			join(bundleDir, BUNDLE_ASSETS_DIR, asset.projectId, asset.assetId),
+		);
+		expect(bundledBlob.equals(asset.content)).toBe(true);
+
+		const targetDir = makeTempDir();
+		expect(await runRestore(argv('restore', bundleDir, '--data-dir', targetDir))).toBe(true);
+
+		const restored = await openDatabase({ dataDir: targetDir });
+		try {
+			expect(await teamSlugs(restored.db)).toContain('backup-probe');
+		} finally {
+			await safeClose(restored.db as { close: () => Promise<void> });
+		}
+		const restoredBlob = await new LocalAssetStore(targetDir).read(asset.projectId, asset.assetId);
+		expect(restoredBlob.equals(asset.content)).toBe(true);
+	}, 120_000);
+
+	it('migrates a bundle’s assets into an S3-compatible bucket named by env', async () => {
+		const sourceDir = makeTempDir();
+		await seedMigratedDataDir(sourceDir);
+		const asset = await seedAssetInDataDir(sourceDir);
+		const bundleDir = join(makeTempDir(), 'bundle-s3');
+		expect(await runBackup(argv('backup', '--data-dir', sourceDir, '--output', bundleDir))).toBe(
+			true,
+		);
+
+		const sim = await createS3Sim();
+		sims.push(sim);
+		// HEZO_ASSET_STORAGE_URL (env) resolves the target store, mirroring --database-url.
+		process.env.HEZO_ASSET_STORAGE_URL = sim.storeUrl();
+		expect(await runRestore(argv('restore', bundleDir, '--data-dir', makeTempDir()))).toBe(true);
+		expect(sim.objects.get(`${asset.projectId}/${asset.assetId}`)?.body.equals(asset.content)).toBe(
+			true,
+		);
+	}, 120_000);
+
+	it('backs up database-only to a bare .backup.gz with --no-assets', async () => {
+		const sourceDir = makeTempDir();
+		await seedMigratedDataDir(sourceDir);
+		await seedAssetInDataDir(sourceDir);
+		const output = join(makeTempDir(), 'db-only.backup.gz');
+		expect(
+			await runBackup(argv('backup', '--data-dir', sourceDir, '--no-assets', '--output', output)),
+		).toBe(true);
+		expect((await stat(output)).isFile()).toBe(true);
+		expect(readLogicalBackupHeader(await readFile(output))?.formatVersion).toBe(1);
+	}, 120_000);
+
+	it('backs up assets-only with --no-database and restores just the blobs', async () => {
+		const sourceDir = makeTempDir();
+		await seedMigratedDataDir(sourceDir);
+		const asset = await seedAssetInDataDir(sourceDir);
+
+		const bundleDir = join(makeTempDir(), 'assets-only');
+		expect(
+			await runBackup(
+				argv('backup', '--data-dir', sourceDir, '--no-database', '--output', bundleDir),
+			),
+		).toBe(true);
+		expect(existsSync(join(bundleDir, BUNDLE_DB_NAME))).toBe(false);
+		expect(existsSync(join(bundleDir, BUNDLE_ASSETS_DIR, asset.projectId, asset.assetId))).toBe(
+			true,
+		);
+
+		// Restore assets-only back into the same instance (rows present → verified, idempotent).
+		expect(await runRestore(argv('restore', bundleDir, '--data-dir', sourceDir))).toBe(true);
+		const restored = await new LocalAssetStore(sourceDir).read(asset.projectId, asset.assetId);
+		expect(restored.equals(asset.content)).toBe(true);
+	}, 120_000);
+
+	it('refuses --no-assets together with --no-database', async () => {
+		const sourceDir = makeTempDir();
+		await seedMigratedDataDir(sourceDir);
+		await expect(
+			runBackup(argv('backup', '--data-dir', sourceDir, '--no-assets', '--no-database')),
+		).rejects.toThrow(/Nothing to back up/);
 	});
 });


### PR DESCRIPTION
## Why

Instance owners could already migrate the **database** between the embedded backend and hosted Postgres via `hezo backup` → `hezo restore`, but **assets** (task attachments + the project asset library) had no built-in migration path. The two asset backends — local filesystem and an S3-compatible bucket — share an identical `<projectId>/<assetId>` key layout, yet nothing enumerated or copied blobs between them; the docs told operators to `aws s3 sync` by hand.

This lets an owner move **both** the database and assets between local and hosted storage, anytime, **from the CLI only** (never the web UI), by extending the existing two-step backup/restore flow rather than adding a new command.

## What changed

- **`hezo backup` now captures a complete instance by default** — a portable **backup bundle** directory:
  ```
  hezo-<timestamp>/
    database.backup.gz          # existing logical backup, byte-unchanged
    assets/<projectId>/<assetId>  # one file per blob
    manifest.json               # written LAST — the completion marker
  ```
  - `--no-assets` → the byte-identical DB-only `.backup.gz` **file** (what the auto/pre-migration and legacy paths still expect).
  - `--no-database` → an assets-only bundle. Passing both is an error.
- **`hezo restore` auto-detects** a bundle directory vs a `.backup.gz` file vs a legacy pgdata tarball (a single `stat().isDirectory()`; the file paths are untouched). It writes the database and/or blobs into whatever backends it's pointed at (`--database-url` / `--asset-storage-url`).
- **Direction is expressed purely by which URLs each step sets**, and the source is only ever read — migration is **copy-only** (nothing is deleted). Local → hosted:
  ```sh
  hezo backup --output move/
  HEZO_DATABASE_URL=… HEZO_ASSET_STORAGE_URL="s3://…" hezo restore move/
  ```
- **New copy engine** `packages/server/src/assets/blob-backup.ts`: enumerates the authoritative `assets` table on backup and the bundle's own tree on restore, copies blobs one at a time with bounded concurrency through the `AssetStore` interface, and verifies each restored blob's sha256 against its row (`--strict-assets` fails on any blob with no verifying row). A dangling row whose blob is missing at the source is recorded, not fatal.

**No `AssetStore` interface change and no DB schema migration** — enumeration uses only existing columns; the backend stays instance-global.

## Design notes

- A **bundle directory** was chosen over a single tar: a `.tar.gz` bundle would collide with the legacy pgdata-snapshot sniff, and tar extraction adds path-traversal risk. The directory reuses `database.backup.gz` byte-for-byte, so the frozen logical-backup format and its tests are untouched.
- Blobs are hard-capped at 10 MB, so a per-blob `Buffer` is always safe; only aggregate size is unbounded, handled by the bounded-concurrency loop (no stream plumbing).
- Restore preflights the target asset store **before** loading the database, so a bad bucket fails fast.

## Docs (same PR)

- `docs/reference/cli.md` — backup/restore now document assets + the new flags.
- `docs/deployment/configuration.md` — the manual `aws s3 sync` "Switching an existing instance" recipe is replaced by the built-in flow (kept as an alternative).
- `docs/deployment/backup-and-recovery.md` — bundles include assets; "Moving between local and hosted storage" now moves both halves.
- `.dev/architecture.md` — the asset-storage and backup/restore sections describe the bundle.

## Testing

- `packages/server/test/asset-blob-backup.test.ts` (new) — the copy engine against the real `LocalAssetStore` and, via the in-process S3 simulator, `S3AssetStore`, including the cross-backend local↔S3 copy, a missing-source blob, sha256-mismatch hard-fail, and lenient-vs-`--strict` behavior.
- `packages/server/test/cli-backup-restore.test.ts` (extended) — default bundle round-trip; cross-backend restore into an S3 bucket named by env (also covers `HEZO_ASSET_STORAGE_URL` resolution); `--no-assets` bare-file path; `--no-database` assets-only; the combined-flags error. The DB-only file path and legacy-tarball paths remain green.

Verified locally: `typecheck`, `check`, and the full backup-adjacent + CLI test set (66 passed, 1 env-gated skip) all pass; the pre-commit hook re-ran typecheck + a full build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VGyMUGRRGzcLrbCFtGWuLU

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGyMUGRRGzcLrbCFtGWuLU)_