### PR TITLE
fix: improve global Skills page row readability

### DIFF
--- a/packages/web/src/routes/settings/skills.tsx
+++ b/packages/web/src/routes/settings/skills.tsx
@@ -405,29 +405,31 @@ function InstanceSkillRow({
 
 	return (
 		<div
-			className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-border bg-surface px-3 py-2 text-[13px]"
+			className="flex items-center justify-between gap-2 rounded-md border border-border bg-surface px-3 py-2 text-[13px]"
 			data-testid="instance-skill-row"
 		>
-			<div className="flex items-center gap-2 min-w-0 flex-1">
-				<span className="font-medium">{skill.name}</span>
-				{skill.readonly ? (
-					<Badge color="neutral">Built-in</Badge>
-				) : (
-					<SearchableSelect
-						options={scopeOptions}
-						value={scopeValue}
-						onChange={changeScope}
-						trigger={scopeTrigger}
-						searchPlaceholder="Search projects…"
-						emptyLabel="No projects"
-						testId="instance-skill-scope-select"
-					/>
-				)}
-				{skill.tags?.map((t) => (
-					<Badge key={t} color="neutral">
-						{t}
-					</Badge>
-				))}
+			<div className="flex flex-col gap-1 min-w-0 flex-1">
+				<div className="flex flex-wrap items-center gap-2">
+					<span className="font-medium">{skill.name}</span>
+					{skill.readonly ? (
+						<Badge color="neutral">Built-in</Badge>
+					) : (
+						<SearchableSelect
+							options={scopeOptions}
+							value={scopeValue}
+							onChange={changeScope}
+							trigger={scopeTrigger}
+							searchPlaceholder="Search projects…"
+							emptyLabel="No projects"
+							testId="instance-skill-scope-select"
+						/>
+					)}
+					{skill.tags?.map((t) => (
+						<Badge key={t} color="neutral">
+							{t}
+						</Badge>
+					))}
+				</div>
 				{skill.description && (
 					<span className="text-xs text-text-3 truncate">{skill.description}</span>
 				)}


### PR DESCRIPTION
## What

Improves the readability of each row on the global **Skills** page (`/settings/skills`).

- **Name + scope on one line, description on the next.** Previously the skill name, scope pill, tags, and description were packed into a single horizontal line that wrapped awkwardly. The row's left content is now a vertical stack: name / scope / tags on the first line (still wrapping gracefully on narrow screens), with the description on its own line below.
- **Action buttons vertically centered.** The view / edit / delete button bar is now vertically centered within the (now taller, two-line) row.

## How

In `InstanceSkillRow` (`packages/web/src/routes/settings/skills.tsx`):
- The outer container keeps `items-center` (so the button bar centers vertically) and drops `flex-wrap` (so the bar stays to the right rather than dropping below).
- The left content is now `flex flex-col`: an inner `flex flex-wrap items-center` row holds the name, scope badge/select, and tags; the description span sits below it.

Layout-only change — no behavior, props, or data flow changes. Mobile-first: the name/scope/tags line still wraps on small viewports and the description truncates.

## Testing

- `packages/web/test/settings-skills.test.tsx` — all 7 tests pass.
- `bunx tsc --noEmit` clean; Biome check clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VFnV3U7rccAn9imfC7GpcS)_