### PR TITLE
fix(web): show the PWA install banner when beforeinstallprompt fires before mount

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -43,6 +43,28 @@
 				}
 			})();
 		</script>
+		<script>
+			// Capture the PWA install signal at the earliest possible moment. Chrome
+			// fires `beforeinstallprompt` once, early in page load (and even earlier on
+			// repeat visits, when the service worker is already active) — often before
+			// the React bundle has mounted its own listener. The event isn't buffered by
+			// the browser, so we catch it here (before /src/main.tsx loads) and stash it
+			// for `useInstallPrompt` to read on mount.
+			(function () {
+				window.__hezoInstall = { event: null, installed: false };
+				addEventListener('beforeinstallprompt', function (e) {
+					// Suppress Chrome's default mini-infobar; we surface our own prompt.
+					e.preventDefault();
+					window.__hezoInstall.event = e;
+					dispatchEvent(new Event('hezo:installable'));
+				});
+				addEventListener('appinstalled', function () {
+					window.__hezoInstall.event = null;
+					window.__hezoInstall.installed = true;
+					dispatchEvent(new Event('hezo:installed'));
+				});
+			})();
+		</script>
 	</head>
 	<body>
 		<div id="root"></div>

--- a/packages/web/src/hooks/use-install-prompt.ts
+++ b/packages/web/src/hooks/use-install-prompt.ts
@@ -1,16 +1,13 @@
 import { useCallback, useEffect, useState } from 'react';
+import {
+	type BeforeInstallPromptEvent,
+	consumeInstallEvent,
+	getBufferedInstallEvent,
+	INSTALLABLE_EVENT,
+	INSTALLED_EVENT,
+	wasInstalled,
+} from '../lib/install-prompt-store';
 import { readStored, writeStored } from '../lib/safe-storage';
-
-/**
- * The `beforeinstallprompt` event isn't in lib.dom. Chrome/Android fires it when
- * the page is installable; we capture it, suppress the browser's default
- * mini-infobar, and replay it from our own UI via `prompt()`.
- */
-interface BeforeInstallPromptEvent extends Event {
-	readonly platforms: string[];
-	readonly userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>;
-	prompt(): Promise<void>;
-}
 
 const DISMISS_KEY = 'hezo:pwa-install-dismissed';
 /** Once dismissed, stay quiet for this many days before offering again. */
@@ -34,6 +31,8 @@ function isDismissed(): boolean {
 /** True when the app is already running as an installed/standalone PWA. */
 function isStandalone(): boolean {
 	if (typeof window === 'undefined') return false;
+	// The inline capture script may have already seen `appinstalled` this session.
+	if (wasInstalled()) return true;
 	const mql = window.matchMedia?.('(display-mode: standalone)');
 	if (mql?.matches) return true;
 	// iOS Safari exposes its own flag rather than the display-mode media query.
@@ -69,29 +68,33 @@ export interface InstallPromptState {
  * the app is installed or the user has dismissed it recently.
  */
 export function useInstallPrompt(): InstallPromptState {
-	const [deferred, setDeferred] = useState<BeforeInstallPromptEvent | null>(null);
+	// Seed from the buffer captured by the inline script in index.html: Chrome may
+	// have fired `beforeinstallprompt` before this hook (or React itself) mounted.
+	const [deferred, setDeferred] = useState<BeforeInstallPromptEvent | null>(
+		getBufferedInstallEvent,
+	);
 	const [dismissed, setDismissed] = useState<boolean>(isDismissed);
 	const [standalone, setStandalone] = useState<boolean>(isStandalone);
 
 	useEffect(() => {
 		if (typeof window === 'undefined') return;
 
-		const onBeforeInstallPrompt = (e: Event) => {
-			// Suppress Chrome's default mini-infobar; we surface our own prompt.
-			e.preventDefault();
-			setDeferred(e as BeforeInstallPromptEvent);
-		};
+		// The inline script owns the raw `beforeinstallprompt`/`appinstalled`
+		// listeners (and has already called preventDefault); we react to its
+		// buffered state via these custom events, plus a mount-time re-read to
+		// close any gap between the buffer updating and this effect subscribing.
+		const onInstallable = () => setDeferred(getBufferedInstallEvent());
 		const onInstalled = () => {
-			// Once installed, drop the captured event and hide for good this session.
 			setDeferred(null);
 			setStandalone(true);
 		};
 
-		window.addEventListener('beforeinstallprompt', onBeforeInstallPrompt);
-		window.addEventListener('appinstalled', onInstalled);
+		window.addEventListener(INSTALLABLE_EVENT, onInstallable);
+		window.addEventListener(INSTALLED_EVENT, onInstalled);
+		setDeferred(getBufferedInstallEvent());
 		return () => {
-			window.removeEventListener('beforeinstallprompt', onBeforeInstallPrompt);
-			window.removeEventListener('appinstalled', onInstalled);
+			window.removeEventListener(INSTALLABLE_EVENT, onInstallable);
+			window.removeEventListener(INSTALLED_EVENT, onInstalled);
 		};
 	}, []);
 
@@ -101,15 +104,13 @@ export function useInstallPrompt(): InstallPromptState {
 	}, []);
 
 	const promptInstall = useCallback(async () => {
-		if (!deferred) return;
-		await deferred.prompt();
-		try {
-			await deferred.userChoice;
-		} finally {
-			// The event can only be used once.
-			setDeferred(null);
-		}
-	}, [deferred]);
+		// Consume the buffered event (single-use per the browser's contract).
+		const event = consumeInstallEvent();
+		setDeferred(null);
+		if (!event) return;
+		await event.prompt();
+		await event.userChoice;
+	}, []);
 
 	let platform: InstallPromptState['platform'] = null;
 	if (!standalone && !dismissed) {

--- a/packages/web/src/lib/install-prompt-store.ts
+++ b/packages/web/src/lib/install-prompt-store.ts
@@ -1,0 +1,60 @@
+/**
+ * Typed accessor over the PWA install signal buffered by the inline script in
+ * `index.html`. That script captures Chrome's `beforeinstallprompt` (and
+ * `appinstalled`) at the earliest possible moment — before this bundle loads —
+ * because the event fires once, early in page load, and is lost if nothing
+ * catches it in that instant. Here we expose the buffer to React so
+ * `useInstallPrompt` can read an event that already fired before it mounted.
+ */
+
+/**
+ * The non-standard `beforeinstallprompt` event isn't in lib.dom. Chrome/Android
+ * fires it when the page is installable; the inline script suppresses the
+ * browser's default mini-infobar and we replay it from our own UI via `prompt()`.
+ */
+export interface BeforeInstallPromptEvent extends Event {
+	readonly platforms: string[];
+	readonly userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>;
+	prompt(): Promise<void>;
+}
+
+interface InstallBuffer {
+	event: BeforeInstallPromptEvent | null;
+	installed: boolean;
+}
+
+declare global {
+	interface Window {
+		__hezoInstall?: InstallBuffer;
+	}
+}
+
+/** Fired by the inline script when a `beforeinstallprompt` has been buffered. */
+export const INSTALLABLE_EVENT = 'hezo:installable';
+/** Fired by the inline script when the app has been installed. */
+export const INSTALLED_EVENT = 'hezo:installed';
+
+/** The buffered install event, or `null` if none has fired (or it's been consumed). */
+export function getBufferedInstallEvent(): BeforeInstallPromptEvent | null {
+	if (typeof window === 'undefined') return null;
+	return window.__hezoInstall?.event ?? null;
+}
+
+/**
+ * Return the buffered install event and clear it. The browser's
+ * `beforeinstallprompt` can only be used once, so consumption is single-shot.
+ */
+export function consumeInstallEvent(): BeforeInstallPromptEvent | null {
+	if (typeof window === 'undefined') return null;
+	const buffer = window.__hezoInstall;
+	if (!buffer) return null;
+	const event = buffer.event;
+	buffer.event = null;
+	return event;
+}
+
+/** True once the app has been installed (the inline script saw `appinstalled`). */
+export function wasInstalled(): boolean {
+	if (typeof window === 'undefined') return false;
+	return window.__hezoInstall?.installed === true;
+}

--- a/packages/web/test/pwa-install-prompt.test.tsx
+++ b/packages/web/test/pwa-install-prompt.test.tsx
@@ -20,11 +20,23 @@ class FakeBeforeInstallPromptEvent extends Event {
 	}
 }
 
-/** Fire a synthetic `beforeinstallprompt` so the hook captures it (Android path). */
+/**
+ * Seed the install buffer the way the inline `index.html` script would, without
+ * dispatching the notify event — mirrors an event that fired before React mounted.
+ */
+function seedBuffer(evt: FakeBeforeInstallPromptEvent): void {
+	window.__hezoInstall = { event: evt, installed: false };
+}
+
+/**
+ * Buffer a synthetic install event and fire the `hezo:installable` signal the
+ * inline script emits, so the hook captures it (Android path).
+ */
 function fireBeforeInstallPrompt(): FakeBeforeInstallPromptEvent {
 	const evt = new FakeBeforeInstallPromptEvent();
+	seedBuffer(evt);
 	act(() => {
-		window.dispatchEvent(evt);
+		window.dispatchEvent(new Event('hezo:installable'));
 	});
 	return evt;
 }
@@ -51,6 +63,7 @@ afterEach(() => {
 	localStorage.clear();
 	vi.restoreAllMocks();
 	setUserAgent(REAL_UA);
+	window.__hezoInstall = undefined;
 });
 
 test('nothing renders until the app is installable', () => {
@@ -62,6 +75,16 @@ test('Android: shows an Install button once beforeinstallprompt fires', () => {
 	const { queryByTestId, getByTestId } = render(<PwaInstallPrompt />);
 	expect(queryByTestId('pwa-install-prompt')).toBeNull();
 	fireBeforeInstallPrompt();
+	expect(getByTestId('pwa-install-prompt')).toBeTruthy();
+	expect(getByTestId('pwa-install-button')).toBeTruthy();
+});
+
+// Regression: Chrome fires `beforeinstallprompt` once, early in page load — often
+// before React mounts. The inline capture script buffers it; the hook must read
+// that buffer on first render, with no post-mount dispatch at all.
+test('Android: shows the card when beforeinstallprompt fired before mount', () => {
+	seedBuffer(new FakeBeforeInstallPromptEvent());
+	const { getByTestId } = render(<PwaInstallPrompt />);
 	expect(getByTestId('pwa-install-prompt')).toBeTruthy();
 	expect(getByTestId('pwa-install-button')).toBeTruthy();
 });

--- a/test/browser/pwa-install.mobile.spec.ts
+++ b/test/browser/pwa-install.mobile.spec.ts
@@ -50,4 +50,42 @@ test.describe('PWA install prompt (mobile)', () => {
 		// `lg:hidden` keeps the bottom card off desktop viewports.
 		await expect(page.getByTestId('pwa-install-prompt')).toBeHidden();
 	});
+
+	// Regression: Chrome fires `beforeinstallprompt` once, early in page load —
+	// often before React mounts. This fires it the instant the inline capture
+	// script in index.html has initialized its buffer (racing the app bundle), so
+	// it lands before/around mount rather than long after. The inline script must
+	// buffer it and the hook must read that buffer on first render.
+	test('mobile: an early beforeinstallprompt (pre-mount) still surfaces the card', async ({
+		authedPage: page,
+	}) => {
+		await page.setViewportSize({ width: 375, height: 800 });
+		// Runs before page scripts on every navigation; polls until the inline
+		// capture script has run, then dispatches the real event it listens for.
+		await page.addInitScript(() => {
+			const timer = setInterval(() => {
+				const w = window as Window & { __hezoInstall?: unknown; __installPromptCalled?: boolean };
+				if (!w.__hezoInstall) return;
+				clearInterval(timer);
+				const e = new Event('beforeinstallprompt') as Event & {
+					platforms?: string[];
+					userChoice?: Promise<{ outcome: string; platform: string }>;
+					prompt?: () => Promise<void>;
+				};
+				e.platforms = ['web'];
+				e.userChoice = Promise.resolve({ outcome: 'accepted', platform: 'web' });
+				e.prompt = () => {
+					w.__installPromptCalled = true;
+					return Promise.resolve();
+				};
+				window.dispatchEvent(e);
+			}, 0);
+		});
+
+		await page.goto('/home');
+		await expect(page.getByTestId('app-header')).toBeVisible({ timeout: 15000 });
+		// No post-mount dispatch here — the card must come from the buffered event.
+		await expect(page.getByTestId('pwa-install-prompt')).toBeVisible();
+		await expect(page.getByTestId('pwa-install-button')).toBeVisible();
+	});
 });


### PR DESCRIPTION
## Summary

Hezo already ships a complete PWA (manifest, service worker, icons, `<head>` meta, server MIME serving, and an in-app `PwaInstallPrompt`). But the "Install Hezo" banner never appeared on installable **mobile Chrome over HTTPS** — the exact case a user hit.

**Root cause — a listener-timing race.** `useInstallPrompt` attached its `beforeinstallprompt` listener inside a React `useEffect`, which only runs *after* the app mounts. Chrome fires `beforeinstallprompt` **once**, early in page load — and even earlier on repeat visits, when the service worker is already active — so it usually fired *before* the listener existed. The browser neither buffers nor re-fires it, so the event was lost and the banner never showed. The existing tests dispatched the event only *after* `render()`, masking the race.

## Fix

- **`index.html`** — a tiny inline `<script>` (alongside the existing theme bootstrap) captures `beforeinstallprompt`/`appinstalled` at the earliest possible moment, before `/src/main.tsx` loads, and buffers the event on `window.__hezoInstall`, emitting `hezo:installable`/`hezo:installed` signals.
- **`src/lib/install-prompt-store.ts`** (new) — a typed, unit-testable accessor over that buffer (`getBufferedInstallEvent` / `consumeInstallEvent` / `wasInstalled` + the event-name constants), with the `window.__hezoInstall` global augmentation so no `any` leaks.
- **`src/hooks/use-install-prompt.ts`** — lazy-inits `deferred` from the buffer (so an event fired before mount is picked up on first render), subscribes to the two custom events, and `promptInstall` consumes the buffered event. iOS detection, standalone detection, and the 14-day dismissal cooldown are unchanged. The banner component and its `__root.tsx` mount are untouched.

Desktop stays `lg:hidden` by deliberate design (desktop Chrome shows its own address-bar install icon), and insecure-context (`http://<lan-ip>`) deployments still can't offer install — that's a hard browser requirement, out of scope here.

## Testing

- **`packages/web/test/pwa-install-prompt.test.tsx`** — new before-mount regression test (seed the buffer *before* `render()`, assert the card shows on first paint with no post-mount dispatch); existing cases rerouted through the buffer. 9/9 pass locally.
- **`test/browser/pwa-install.mobile.spec.ts`** — new early-fire (pre-mount) case using `addInitScript` to dispatch `beforeinstallprompt` the instant the inline buffer is ready, racing app mount, then asserting the card appears.
- `tsc --noEmit` and `biome check` clean; the pre-commit hook's full typecheck + production build passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YLcjQmZeGi4tUQz74jrFQH)_