### PR TITLE
fix(oauth): re-register a DCR client when the callback origin changed

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -1251,9 +1251,22 @@ call `restoreRevokedConnector` (equivalently, `markApiKeyActive` clears `revoked
 which nulls the revocation and every auth artifact (`oauth_connection_id`,
 `api_key_secret_id`, `activated_at`, `auth_error`) while preserving `config` — including any
 cached DCR client registration, so the reconnect reuses it. This is the same in-place
-restore `createOrFetchConnector` performs for a re-requested agent connector. The only case
-that still needs delete-and-recreate is an instance-address change (the DCR client is bound
-to the old redirect URL).
+restore `createOrFetchConnector` performs for a re-requested agent connector.
+
+**Instance-address change self-heals.** A DCR client is bound at the Authorization Server to
+the exact `redirect_uri` it registered, so the cached `config.dcr` also records the callback
+URL it was minted against (`redirect_uri`). `startConnectorAuthCode` reuses the cached client
+**only** while that stored URL equals the current request's callback origin
+(`${requestOrigin(c)}/api/oauth/mcp-callback`); if the instance's public origin has changed
+since — a new hostname, an `http`↔`https` flip from the reverse proxy in front of it, or a
+first registration done from a different address — it re-runs discovery + DCR to mint a fresh
+client bound to the current origin and overwrites the cache. Without this, the stale client
+sends the AS a redirect_uri it never registered and the authorize is rejected with
+"redirect_uri does not match any of the OAuth 2.0 Client's pre-registered redirect urls"
+(observed against Higgsfield, whose `mcp.higgsfield.ai` broker forwards the DCR client_id and
+redirect_uri straight through to upstream Clerk). Registrations cached before the
+`redirect_uri` field existed carry none, so they miss the reuse check and re-register on the
+next connect — an address change no longer needs delete-and-recreate.
 
 **Run exclusion.** `loadConnectorsForRun(db, projectId)` returns the run's project's own
 connectors plus global ones (a project connector shadows a global of the same name). It

--- a/packages/server/src/routes/oauth.ts
+++ b/packages/server/src/routes/oauth.ts
@@ -382,6 +382,14 @@ async function startConnectorAuthCode(
 			authorization_endpoint: string;
 			token_endpoint: string;
 			scopes_supported?: string[];
+			/**
+			 * The exact callback URL this client_id was registered against. A public
+			 * OAuth client is bound at registration time to its redirect_uris, so the
+			 * cached client is only reusable while our callback origin is unchanged.
+			 * Absent on registrations cached before this field existed — treated as a
+			 * miss so they self-heal on the next connect.
+			 */
+			redirect_uri?: string;
 		};
 	};
 	if (!config.url)
@@ -396,8 +404,18 @@ async function startConnectorAuthCode(
 
 	const capability = getConnectorCapability(connector.name);
 
-	let dcr = config.dcr;
-	let scopesSupported: string[] = config.dcr?.scopes_supported ?? [];
+	// Reuse a cached DCR registration only when it was registered against THIS
+	// request's callback origin. The client_id is bound at the Authorization
+	// Server to the exact redirect_uri it registered; if the instance's public
+	// origin has changed since (a new hostname, an http↔https flip from the
+	// reverse proxy in front of it, or a first registration done from a different
+	// address), reusing the stale client sends the AS a redirect_uri it never
+	// registered and it rejects the authorize with "redirect_uri does not match
+	// any of the OAuth 2.0 Client's pre-registered redirect urls". Re-register a
+	// fresh client bound to the current origin instead — an instance-address
+	// change now self-heals rather than requiring delete-and-recreate.
+	let dcr = config.dcr?.redirect_uri === redirectUri ? config.dcr : undefined;
+	let scopesSupported: string[] = dcr?.scopes_supported ?? [];
 
 	if (!dcr) {
 		let discovery: Awaited<ReturnType<typeof discoverMcpAuthorization>>;
@@ -452,6 +470,7 @@ async function startConnectorAuthCode(
 			authorization_endpoint: discovery.asMetadata.authorization_endpoint,
 			token_endpoint: discovery.asMetadata.token_endpoint,
 			scopes_supported: discovery.asMetadata.scopes_supported,
+			redirect_uri: redirectUri,
 		};
 		scopesSupported = discovery.asMetadata.scopes_supported ?? [];
 		const newConfig = { ...config, dcr };

--- a/packages/server/test/oauth-routes-authcode-branches.test.ts
+++ b/packages/server/test/oauth-routes-authcode-branches.test.ts
@@ -497,6 +497,65 @@ describe('POST /projects/:projectId/auth-start (connector DCR walk)', () => {
 			await fake.close();
 		}
 	});
+
+	it('re-registers a fresh DCR client when the callback origin changed (stale redirect_uri)', async () => {
+		const fake = await startFakeMcpServer();
+		try {
+			const { row } = await createOrFetchConnector(db, {
+				name: 'dcr-origin-change-conn',
+				displayName: 'DCR Origin Change',
+				mcpUrl: `${fake.url}/mcp`,
+				mcpTransport: 'http',
+			});
+
+			// First connect resolves the callback over http (no x-forwarded-proto),
+			// so the DCR client is registered against an http:// redirect_uri.
+			const first = await authStart(row.id);
+			expect(first.status).toBe(200);
+			const firstUrl = new URL(
+				((await first.json()) as { data: { auth_url: string } }).data.auth_url,
+			);
+			const firstClientId = firstUrl.searchParams.get('client_id');
+			const firstRedirect = firstUrl.searchParams.get('redirect_uri');
+			expect(firstRedirect).toMatch(/^http:\/\//);
+
+			// Second connect arrives over https (the reverse proxy now forwards
+			// x-forwarded-proto: https). The cached client is bound to the http
+			// callback, so reusing it would send the AS a redirect_uri it never
+			// registered — instead a fresh client is minted for the https origin.
+			const second = await app.request(`/api/projects/${projectSlug}/auth-start`, {
+				method: 'POST',
+				headers: {
+					...authHeader(token),
+					'Content-Type': 'application/json',
+					'x-forwarded-proto': 'https',
+				},
+				body: JSON.stringify({ connector_id: row.id }),
+			});
+			expect(second.status).toBe(200);
+			const secondUrl = new URL(
+				((await second.json()) as { data: { auth_url: string } }).data.auth_url,
+			);
+			const secondRedirect = secondUrl.searchParams.get('redirect_uri');
+			expect(secondRedirect).toMatch(/^https:\/\//);
+			expect(secondUrl.searchParams.get('client_id')).not.toBe(firstClientId);
+
+			// The re-registered client accepts the https redirect_uri: the fake AS
+			// 302s from /authorize instead of rejecting the redirect_uri (which is
+			// exactly what the stale-cache reuse would have triggered).
+			const authorize = await fetch(secondUrl.toString(), { redirect: 'manual' });
+			expect(authorize.status).toBe(302);
+
+			// The cache now records the origin the live client was registered against.
+			const after = await getConnector(db, row.id);
+			const cachedDcr = (after?.config as { dcr?: { redirect_uri?: string; client_id?: string } })
+				.dcr;
+			expect(cachedDcr?.redirect_uri).toBe(secondRedirect);
+			expect(cachedDcr?.client_id).toBe(secondUrl.searchParams.get('client_id'));
+		} finally {
+			await fake.close();
+		}
+	});
 });
 
 describe('POST /connectors/:id/auth-start (instance-admin surface)', () => {

--- a/packages/web/test/connectors-page.test.tsx
+++ b/packages/web/test/connectors-page.test.tsx
@@ -20,6 +20,11 @@ async function seedSaasConnector(
 			authorization_endpoint: 'https://as.example/authorize',
 			token_endpoint: 'https://as.example/token',
 			scopes_supported: ['read', 'write'],
+			// Must match the callback origin the in-process backend resolves
+			// (`${requestOrigin(c)}/api/oauth/mcp-callback`, host `localhost`), so
+			// auth-start reuses this cached registration instead of re-running live
+			// PRM discovery / DCR for a changed origin.
+			redirect_uri: 'http://localhost/api/oauth/mcp-callback',
 		};
 	}
 	const res = await apiBase(`/api/projects/${ws.internalSlug}/connectors`, {


### PR DESCRIPTION
## Problem

Connecting the **Higgsfield** MCP connector on a self-hosted instance (reported against a prod `0.23.0` instance reachable at an internal meshnet hostname) fails at the provider's consent screen with:

> `invalid_request` — The 'redirect_uri' parameter does not match any of the OAuth 2.0 Client's pre-registered redirect urls.

## Root cause

The connector's cached Dynamic Client Registration (`mcp_connections.config.dcr`) stored the minted `client_id` but **not** the `redirect_uri` it was registered against. On a later **Connect**, `startConnectorAuthCode` reused the cached client while recomputing the callback from the *current* request origin (`${requestOrigin(c)}/api/oauth/mcp-callback`).

A public OAuth client is bound at the Authorization Server to the exact `redirect_uri` it registered. When an instance's public origin changed since that registration — a new hostname, an `http`↔`https` flip from the reverse proxy in front of it, or a first registration done from a different address — the authorize request carried a `redirect_uri` the AS never registered, so it rejected the flow. This is the limitation `.dev/architecture.md` already documented as *"the only case that still needs delete-and-recreate is an instance-address change."*

Confirmed live against Higgsfield: its `mcp.higgsfield.ai` broker advertises DCR (`/oauth2/register`) and forwards the DCR `client_id` + `redirect_uri` straight through to upstream Clerk. A **freshly** registered client with a matching `redirect_uri` is accepted (302 → Clerk consent); a **stale** one is rejected exactly as above — so the fault is the stale cache, not the provider.

## Fix

- Persist `redirect_uri` in `config.dcr` at registration time.
- Reuse the cached DCR client **only** while its stored `redirect_uri` equals the current request's callback origin; otherwise re-run discovery + DCR to mint a fresh client bound to the current origin and overwrite the cache.
- Registrations cached before this field existed carry no `redirect_uri`, so they miss the reuse check and **self-heal on the next connect** — an instance-address change no longer needs delete-and-recreate.

The `redirect_uri` used to register, authorize, and exchange the code stays consistent within a single connect (already driven from one computed value + the signed state), so token exchange is unaffected.

## Testing

- Added `re-registers a fresh DCR client when the callback origin changed (stale redirect_uri)` in `oauth-routes-authcode-branches.test.ts`: an `http` first connect caches a client, an `https` second connect (via `x-forwarded-proto`) re-registers a new `client_id`, and the fake AS `/authorize` **302s** for the fresh client instead of rejecting the redirect_uri. The pre-existing `persists the DCR result … reuses it on the second` test still passes (stable origin → reuse).
- `bunx vitest run` across the OAuth/connector suites: **114 tests pass** (`oauth-routes-authcode-branches`, `oauth-routes-coverage`, `oauth-dcr-branches`, `oauth-routes-extended`, `connectors`, `instance-connectors`).
- `bun run typecheck` and Biome check clean on the changed files.

## Docs

- `.dev/architecture.md` § Credentials/egress updated: the instance-address-change case now self-heals; documents the `config.dcr.redirect_uri` reuse guard and the Higgsfield/Clerk broker behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017ebPhX3fvQUUrDETuDFynz)_