### PR TITLE
feat: allow removing a pending connector from the project Connectors page

### DIFF
--- a/docs/mcp/connecting-mcp-servers.md
+++ b/docs/mcp/connecting-mcp-servers.md
@@ -201,6 +201,12 @@ instance-address change — see [OAuth connections need an HTTPS address](#oauth
 above — where the OAuth client is tied to the old address and the connector must be removed
 and added again.)
 
+A connector that isn't connected — one still awaiting connection ("Pending connect"),
+failed, or revoked — can instead be dropped outright with **Remove** on its row: it deletes
+the connector from the project (an agent can request it again if it's still needed). A
+connected connector shows **Disconnect** instead; disconnect it first, then **Remove** the
+revoked row if you want it gone.
+
 ## Connectors and their credentials
 
 [Credentials](/docs/security/secret-protection) stay **global** — one shared vault, not

--- a/packages/web/src/routes/projects/$projectId/connectors.tsx
+++ b/packages/web/src/routes/projects/$projectId/connectors.tsx
@@ -17,6 +17,7 @@ import {
 	connectorStatus,
 	useConnectors,
 	useCreateConnector,
+	useDeleteConnector,
 	useRevokeConnector,
 } from '../../../hooks/use-connectors';
 import { useMe } from '../../../hooks/use-me';
@@ -466,6 +467,7 @@ function ConnectorRow({ connector, projectId, focused, focusRef }: ConnectorRowP
 	const status = connectorStatus(connector);
 	const authStart = useAuthStart(projectId);
 	const revoke = useRevokeConnector(projectId);
+	const del = useDeleteConnector(projectId);
 	const [error, setError] = useState<string | null>(null);
 	const [info, setInfo] = useState<string | null>(null);
 	const [deviceOpen, setDeviceOpen] = useState(false);
@@ -478,6 +480,7 @@ function ConnectorRow({ connector, projectId, focused, focusRef }: ConnectorRowP
 			(connector.config as { auth?: { placement?: unknown } } | null)?.auth?.placement === 'query',
 	);
 	const [confirmOpen, setConfirmOpen] = useState(false);
+	const [removeConfirmOpen, setRemoveConfirmOpen] = useState(false);
 	const credentials = connector.credentials ?? [];
 	// The credentials page is superuser-only, so link there only for a superuser;
 	// members see the credential name as plain text.
@@ -546,6 +549,15 @@ function ConnectorRow({ connector, projectId, focused, focusRef }: ConnectorRowP
 			await revoke.mutateAsync(connector.id);
 		} catch (e) {
 			setError(e instanceof Error ? e.message : 'Failed to revoke');
+		}
+	};
+
+	const doRemove = async () => {
+		setError(null);
+		try {
+			await del.mutateAsync(connector.id);
+		} catch (e) {
+			setError(e instanceof Error ? e.message : 'Failed to remove');
 		}
 	};
 
@@ -672,6 +684,16 @@ function ConnectorRow({ connector, projectId, focused, focusRef }: ConnectorRowP
 								<KeyRound className="size-3.5 mr-1" />
 								API key
 							</Button>
+							<Button
+								size="sm"
+								variant="outline"
+								onClick={() => setRemoveConfirmOpen(true)}
+								disabled={del.isPending}
+								data-testid="connector-remove"
+							>
+								<Trash2 className="size-3.5 mr-1" />
+								{del.isPending ? 'Removing…' : 'Remove'}
+							</Button>
 						</>
 					)}
 				</div>
@@ -756,6 +778,21 @@ function ConnectorRow({ connector, projectId, focused, focusRef }: ConnectorRowP
 				confirmLabel="Disconnect"
 				variant="danger"
 				onConfirm={doRevoke}
+			/>
+
+			<ConfirmDialog
+				open={removeConfirmOpen}
+				onOpenChange={setRemoveConfirmOpen}
+				title="Remove connector?"
+				description={
+					<>
+						Remove <span className="font-medium">{connector.display_name ?? connector.name}</span>?
+						This deletes it from this project. An agent can request it again if needed.
+					</>
+				}
+				confirmLabel="Remove"
+				variant="danger"
+				onConfirm={doRemove}
 			/>
 		</li>
 	);

--- a/packages/web/test/connectors-page.test.tsx
+++ b/packages/web/test/connectors-page.test.tsx
@@ -389,6 +389,7 @@ test('a global connector is read-only on the project page (badge + manage link, 
 	expect(within(row).queryByTestId('connector-connect')).toBeNull();
 	expect(within(row).queryByTestId('connector-revoke')).toBeNull();
 	expect(within(row).queryByTestId('connector-api-key-toggle')).toBeNull();
+	expect(within(row).queryByTestId('connector-remove')).toBeNull();
 });
 
 test('shows the empty-state hint when there are no connectors or OAuth connections', async () => {
@@ -508,6 +509,40 @@ test('an active non-GitHub connector renders Disconnect and revokes', async () =
 		expect(row?.getAttribute('data-status')).toBe('revoked');
 	});
 	await findByTestId('connector-connect');
+});
+
+test('a pending connector offers Remove, which deletes it from the project', async () => {
+	let slug = '';
+	const { findByText, getByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			slug = ws.internalSlug;
+			// A freshly-created saas connector has no oauth/api-key/activated_at, so
+			// connectorStatus → 'pending' ("Pending connect").
+			await seedSaasConnector(ws, { name: 'linear', url: 'https://mcp.linear.example/mcp' });
+		},
+	});
+	await router.navigate({ to: CONNECTORS_ROUTE, params: { projectId: slug } });
+
+	await findByText('linear');
+	const row = within(getByTestId('connectors-list'))
+		.getAllByTestId('connector-row')
+		.find((li) => li.getAttribute('data-connector-id'));
+	if (!row) throw new Error('pending connector row not found');
+	expect(row.getAttribute('data-status')).toBe('pending');
+
+	// Remove opens the shared confirm dialog; confirming calls DELETE
+	// /api/projects/:projectId/connectors/:id and drops the row from the list.
+	within(row).getByTestId('connector-remove').click();
+	(await screen.findByTestId('confirm-dialog-confirm')).click();
+
+	await waitFor(() => {
+		const remaining = within(getByTestId('connectors-list'))
+			.queryAllByTestId('connector-row')
+			.filter((li) => li.getAttribute('data-connector-id'));
+		expect(remaining.length).toBe(0);
+	});
 });
 
 test('a local (credential-auth) connector renders Connected, not a Connect button', async () => {


### PR DESCRIPTION
## What & why

On the project **Connectors** page, a connector an agent requested but that was never connected ("Pending connect") could only be **Connect**ed or have an **API key** attached — there was no way to remove it. Only *active* connectors got a **Disconnect** button, which is a *revoke* (clears the token, keeps the row), not a delete. So a pending connector had no removal path in the UI at all.

The backend was already fully wired for this — it was purely missing UI:
- `DELETE /api/projects/:projectId/connectors/:id` (`packages/server/src/routes/connectors.ts`) hard-deletes the project's own connector row (scoped by `project_id`, gated by `requireProjectAccessMiddleware`; global connectors can't be removed here). Works on any status.
- `useDeleteConnector(projectId)` (`packages/web/src/hooks/use-connectors.ts`) already implemented that DELETE with optimistic list removal + invalidation — but it was **never referenced anywhere**.

## Changes

- **`ConnectorRow`** (`packages/web/src/routes/projects/$projectId/connectors.tsx`): surface the existing `useDeleteConnector` hook as a **Remove** button on any **non-active, non-global** connector row — i.e. `pending`, `failed`, and `revoked`. It opens a confirmation dialog mirroring the existing Disconnect confirm, then calls the DELETE endpoint.
  - Active connectors keep **Disconnect** (revoke); once disconnected → revoked they become removable.
  - Global connectors stay read-only (managed on the global Settings → Connectors page) — no Remove button.
- **Docs** (`docs/mcp/connecting-mcp-servers.md`): a one-line note in the "Reconnecting a revoked connector" section explaining that a not-yet-connected connector (pending/failed/revoked) can be dropped outright with **Remove**, clarifying how the "Remove the connector" instruction referenced elsewhere on that page is done from the project page.

No backend, route, MCP-tool, or migration changes — the DELETE route, the `useDeleteConnector` hook, and the MCP `remove_connector` tool already existed.

## Testing

- New component test in `packages/web/test/connectors-page.test.tsx`: seeds a pending saas connector, asserts `data-status="pending"` and the presence of the Remove button, clicks Remove → confirm, and asserts the row disappears from the list (drives the real DELETE endpoint against the in-process backend).
- Extended the existing "global connector is read-only" test to assert the global row has **no** Remove button, reinforcing the `!isGlobal` gate.
- `bunx vitest run test/connectors-page.test.tsx` — all 14 tests green.
- `bun run typecheck` and `bunx biome check` on the touched files — clean.

## Out of scope

- No change to Disconnect/revoke semantics (revoke keeps the row; Remove deletes it — both coexist).
- No change to the admin/instance connectors page — it already has a Remove button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UdDPVxxVs2dfj9q9dhWStF

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdDPVxxVs2dfj9q9dhWStF)_