### PR TITLE
feat(deploy): add AWS and GCP one-click deploy buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,30 @@ Prefer a manual download? Grab the binary for your platform straight from
 [GitHub Releases](https://github.com/hezo-ai/hezo/releases/latest). Full steps and the
 per-platform asset names are in [Installation](./docs/getting-started/installation.md).
 
+### Deploy to a cloud server
+
+Want an always-on instance instead of running it on your laptop? Deploy to a cloud
+VM in a couple of minutes. Each provisions Docker, the binary, automatic HTTPS
+(a real cert via `<ip>.sslip.io` — no domain needed), systemd, and a locked-down
+firewall, and drops you at the in-browser setup.
+
+<p>
+  <a href="./deploy/gcp/README.md"><img src="https://img.shields.io/badge/Deploy_on-Google_Cloud-4285F4?style=for-the-badge&logo=googlecloud&logoColor=white" alt="Deploy on Google Cloud" height="34" /></a>
+  <a href="./deploy/aws/README.md"><img src="https://img.shields.io/badge/Deploy_on-AWS-FF9900?style=for-the-badge&logo=amazonwebservices&logoColor=white" alt="Deploy on AWS" height="34" /></a>
+  <a href="./docs/deployment/one-click.md"><img src="https://img.shields.io/badge/Deploy_on-DigitalOcean-0080FF?style=for-the-badge&logo=digitalocean&logoColor=white" alt="Deploy on DigitalOcean" height="34" /></a>
+</p>
+
+**Google Cloud** is one-click today — the button opens Cloud Shell and runs the
+deploy for you. **AWS** (CloudFormation) and **DigitalOcean** open a short guide;
+their fully-hosted buttons land once the CloudFormation template is published to
+S3 and the [DigitalOcean Marketplace image](./deploy/marketplace/digitalocean/README.md)
+is listed. Any provider that takes cloud-init works too — see
+[One-click deploy](./docs/deployment/one-click.md).
+
+> Hezo runs each project's agents in a container on the host Docker socket, so it
+> needs a **real VM** — not a managed-container PaaS (Render, Railway, Cloud Run).
+> That's why these buttons target VM providers.
+
 ### Build from source
 
 Want to hack on Hezo or run an unreleased build? You'll need [Bun](https://bun.sh/)

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -12,6 +12,22 @@ host** — not to a managed-container PaaS. These artifacts automate that host s
 |---|---|
 | `provision.sh` | The canonical, self-contained installer. Installs Docker, downloads the `hezo` binary, sets up Caddy (automatic HTTPS + WebSocket passthrough), installs the systemd units, and locks the firewall down. Single source of truth — everything else runs it. |
 | `cloud-init/hezo.cloud-config.yaml` | Portable cloud-init user-data. Paste it into any VPS provider's "User data" field; it fetches and runs `provision.sh` on first boot. |
+| `aws/` | CloudFormation **Launch Stack** template (`hezo.cfn.yaml`) — an EC2 VM whose UserData runs `provision.sh`. See [`aws/README.md`](aws/README.md). |
+| `gcp/` | **Open in Cloud Shell** deploy — `deploy.sh` creates a Compute Engine VM (startup script runs `provision.sh`) with a guided `tutorial.md`. See [`gcp/README.md`](gcp/README.md). |
+| `marketplace/digitalocean/` | Packer template that bakes `provision.sh` into a DigitalOcean Marketplace 1-Click image. See [`marketplace/digitalocean/README.md`](marketplace/digitalocean/README.md). |
+
+Every per-provider button hands `provision.sh` (or the cloud-init) to a fresh VM —
+there is one installer, wrapped per provider. Hezo needs the **host Docker socket**
+(it launches a container per project), so all of these target a **real VM**; a
+managed-container PaaS (Render, Railway, Cloud Run) can't run it.
+
+### How one-click per provider stands today
+
+| Provider | Wrapper (in this repo) | Fully-hosted button needs |
+|---|---|---|
+| **Google Cloud** | `gcp/` Cloud Shell button | Nothing — Cloud Shell reads this repo directly; works on `main`. |
+| **AWS** | `aws/hezo.cfn.yaml` | A one-time upload of the template to a public S3 URL (CloudFormation quick-create requires S3). Manual `aws cloudformation deploy` works today. |
+| **DigitalOcean** | `marketplace/digitalocean/` Packer image | An external DO vendor account + DO's image review to publish the listing. The cloud-init path works today. |
 
 ## How it works
 

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -1,0 +1,124 @@
+# Hezo — AWS one-click deploy (CloudFormation)
+
+This builds the **"Launch Stack"** button for AWS. It stands up a single Ubuntu
+EC2 instance and runs the same [`deploy/provision.sh`](../provision.sh) the
+cloud-init path uses (Docker + the `hezo` binary + Caddy automatic HTTPS via
+`<ip>.sslip.io` + systemd + firewall), so there is one source of truth for how a
+host is set up.
+
+Hezo runs each project's agents in a container on the **host Docker socket**, so
+it needs a real VM — not a managed-container service. EC2 is exactly that;
+`hezo.cfn.yaml` provisions it.
+
+The end-user experience: click **Launch Stack** → pick an instance size (and
+optionally an SSH key pair / custom domain) → **Create stack** → wait ~2 min for
+first boot → open the `URL` in the stack **Outputs** → finish the short setup
+(master key, admin password, model).
+
+## What's code (here) vs. external ops
+
+| Step | Where |
+|---|---|
+| CloudFormation template (`hezo.cfn.yaml`, reusing `provision.sh`) | **This repo** |
+| Hosting the template at a public URL CloudFormation accepts (see below) | **External** — one-time upload to an org-owned S3 bucket |
+| The end user running the stack (their AWS account, their bill) | **External** — they click the button |
+
+CloudFormation's quick-create ("Launch Stack") link requires `templateURL` to
+point at a template stored in **Amazon S3** — a `raw.githubusercontent.com` URL
+is rejected. So making the button live is one external step: upload
+`hezo.cfn.yaml` to a public S3 bucket the Hezo org controls, then set that URL in
+the button. Everything needed to *produce and test a valid template* is here, and
+the manual paths below work today with the in-repo file.
+
+## The Launch Stack button
+
+Once `hezo.cfn.yaml` is hosted (see [Publishing](#publishing-the-button) below),
+the README badge / button uses:
+
+```
+https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=<PUBLIC_S3_URL>&stackName=hezo
+```
+
+Markdown for the button:
+
+```md
+[![Launch Stack](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=<PUBLIC_S3_URL>&stackName=hezo)
+```
+
+The user can switch region in the console before creating; the AMI resolves per
+region automatically from Canonical's public SSM parameter, so the template is
+region-agnostic.
+
+## Deploy it now (no hosted button needed)
+
+The template works today from the local file. Either path creates the same stack.
+
+**AWS CLI:**
+
+```sh
+cd deploy/aws
+aws cloudformation deploy \
+  --template-file hezo.cfn.yaml \
+  --stack-name hezo \
+  --capabilities CAPABILITY_IAM \
+  --parameter-overrides InstanceType=t3.medium
+# then read the URL:
+aws cloudformation describe-stacks --stack-name hezo \
+  --query "Stacks[0].Outputs[?OutputKey=='URL'].OutputValue" --output text
+```
+
+`CAPABILITY_IAM` is required because the template attaches a small IAM role so you
+can open a shell via **Systems Manager Session Manager** even without an SSH key
+pair. The console's quick-create page shows this as a checkbox to acknowledge.
+
+**Console (upload):** CloudFormation → Create stack → *With new resources* →
+*Upload a template file* → choose `hezo.cfn.yaml` → fill parameters → acknowledge
+the IAM capability → Create.
+
+## Parameters
+
+| Parameter | Default | Notes |
+|---|---|---|
+| `InstanceType` | `t3.small` | 2 GB runs the install; **t3.medium+ recommended** for real agent work. |
+| `VolumeSize` | `30` | Root EBS (GiB) — holds Hezo's data directory. |
+| `KeyName` | *(empty)* | Optional SSH key pair. Blank = launch without one (use Session Manager). |
+| `AllowedSshCidr` | `0.0.0.0/0` | Source CIDR for SSH; narrow to your IP. Only used if a key pair is set. |
+| `DomainOverride` | *(empty)* | Use your own domain instead of `<ip>.sslip.io` (point an A record first). |
+| `HezoReleaseTag` | `latest` | Pin a release; in-app update upgrades it later. |
+| `LatestUbuntuAmi` | *(SSM)* | Resolves to the latest Ubuntu 24.04 AMI in-region. Leave as-is. |
+
+## Test the stack before publishing
+
+1. `aws cloudformation deploy ...` as above (a throwaway account/region is fine).
+2. From your laptop, hit `https://<URL>/health` — a valid (non-self-signed)
+   certificate proves the Let's Encrypt path provisioned against sslip.io on first
+   boot. (Give it ~2 min after `CREATE_COMPLETE`; the cert is obtained on first boot.)
+3. Load the root `URL` and confirm you reach the master-key gate; complete the
+   three setup steps. The CEO chat's live log stream proves WebSocket passthrough.
+4. Confirm the container→host path (agents' tools) is open by SSHing / Session
+   Manager in and running:
+   ```sh
+   docker run --rm --add-host=host.docker.internal:host-gateway curlimages/curl \
+     curl -sv --max-time 5 http://host.docker.internal:3100/mcp
+   ```
+   Any HTTP status (even 401/404) is success; a timeout means the `docker0`
+   firewall rule is wrong. See
+   [`docs/deployment/self-hosting.md`](../../docs/deployment/self-hosting.md)
+   § Networking & firewall.
+5. `aws cloudformation delete-stack --stack-name hezo` to tear it down.
+
+## Publishing the button
+
+One-time, in an org-owned AWS account:
+
+```sh
+# A public-readable bucket (or a bucket fronted by a stable HTTPS URL):
+aws s3 cp deploy/aws/hezo.cfn.yaml s3://<hezo-bucket>/deploy/aws/hezo.cfn.yaml \
+  --acl public-read
+# Public URL to put in the Launch Stack button:
+#   https://<hezo-bucket>.s3.amazonaws.com/deploy/aws/hezo.cfn.yaml
+```
+
+Keep the S3 copy in sync with this file on each release (a `release-publish`
+workflow step can `aws s3 cp` it). Until it's hosted, the root README's AWS badge
+links here so users get the working manual paths above.

--- a/deploy/aws/hezo.cfn.yaml
+++ b/deploy/aws/hezo.cfn.yaml
@@ -1,0 +1,186 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >-
+  Hezo — one-click deploy to a single EC2 instance. Launches an Ubuntu VM, opens
+  the web ports, and runs deploy/provision.sh on first boot (Docker + the hezo
+  binary + Caddy automatic HTTPS via <ip>.sslip.io + systemd + firewall). After
+  ~2 minutes, open the URL in the stack Outputs and finish the in-browser setup
+  (master key, admin password, connect a model). Hezo runs each project's agents
+  in a container on the host Docker socket, so it needs a real VM — this template
+  provisions exactly that.
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label: { default: Instance }
+        Parameters: [InstanceType, VolumeSize, LatestUbuntuAmi]
+      - Label: { default: Access }
+        Parameters: [KeyName, AllowedSshCidr]
+      - Label: { default: HTTPS (optional) }
+        Parameters: [DomainOverride]
+      - Label: { default: Source }
+        Parameters: [HezoReleaseTag, ProvisionScriptUrl]
+    ParameterLabels:
+      InstanceType: { default: Instance type }
+      VolumeSize: { default: Root disk size (GiB) }
+      LatestUbuntuAmi: { default: Ubuntu 24.04 AMI (leave as-is) }
+      KeyName: { default: SSH key pair (optional) }
+      AllowedSshCidr: { default: Allowed SSH source CIDR }
+      DomainOverride: { default: Custom domain (optional) }
+      HezoReleaseTag: { default: Hezo release tag }
+      ProvisionScriptUrl: { default: Provision script URL }
+
+Parameters:
+  InstanceType:
+    Type: String
+    Default: t3.small
+    AllowedValues: [t3.small, t3.medium, t3.large, t3.xlarge, m7i-flex.large, c7i.large]
+    Description: >-
+      A 2 GB box (t3.small) runs the install; agent containers are memory-hungry,
+      so t3.medium (4 GB) or larger is recommended for real work.
+
+  VolumeSize:
+    Type: Number
+    Default: 30
+    MinValue: 20
+    MaxValue: 1000
+    Description: Root EBS volume size in GiB. Hezo's data directory lives here.
+
+  LatestUbuntuAmi:
+    Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
+    Default: /aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id
+    Description: >-
+      Resolved automatically from Canonical's public SSM parameter to the latest
+      Ubuntu 24.04 LTS AMI in this region. Leave the default.
+
+  KeyName:
+    Type: String
+    Default: ''
+    Description: >-
+      Optional. Name of an existing EC2 key pair for SSH. Leave blank to launch
+      without one — you can still get a shell via AWS Systems Manager Session
+      Manager (this template attaches the required role).
+
+  AllowedSshCidr:
+    Type: String
+    Default: 0.0.0.0/0
+    AllowedPattern: '^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/\d{1,2}$'
+    Description: >-
+      CIDR allowed to reach SSH (port 22). Only used when a key pair is set.
+      Narrow this to your IP (e.g. 203.0.113.10/32) rather than the open internet.
+
+  DomainOverride:
+    Type: String
+    Default: ''
+    Description: >-
+      Optional. Use your own domain instead of <ip>.sslip.io. Point an A record
+      at the instance's public IP first — Caddy provisions a Let's Encrypt cert
+      for this name. Leave blank to use sslip.io (no domain required).
+
+  HezoReleaseTag:
+    Type: String
+    Default: latest
+    Description: Hezo release to install (default latest). In-app update upgrades it later.
+
+  ProvisionScriptUrl:
+    Type: String
+    Default: https://raw.githubusercontent.com/hezo-ai/hezo/main/deploy/provision.sh
+    Description: >-
+      URL of the canonical installer. Leave the default unless you are deploying
+      from a fork.
+
+Conditions:
+  HasKeyName: !Not [!Equals [!Ref KeyName, '']]
+
+Resources:
+  SecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Hezo — public web ports (80/443) and optional SSH
+      SecurityGroupIngress:
+        - { IpProtocol: tcp, FromPort: 80, ToPort: 80, CidrIp: 0.0.0.0/0, Description: HTTP (Caddy ACME + redirect) }
+        - { IpProtocol: tcp, FromPort: 443, ToPort: 443, CidrIp: 0.0.0.0/0, Description: HTTPS (Hezo web app) }
+      Tags:
+        - { Key: Name, Value: !Sub '${AWS::StackName}-sg' }
+
+  # SSH is only opened when a key pair is provided.
+  SshIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Condition: HasKeyName
+    Properties:
+      GroupId: !Ref SecurityGroup
+      IpProtocol: tcp
+      FromPort: 22
+      ToPort: 22
+      CidrIp: !Ref AllowedSshCidr
+      Description: SSH
+
+  # Lets you open a shell via Session Manager even with no key pair.
+  InstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal: { Service: ec2.amazonaws.com }
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+      Tags:
+        - { Key: Name, Value: !Sub '${AWS::StackName}-role' }
+
+  InstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Roles: [!Ref InstanceRole]
+
+  Instance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: !Ref LatestUbuntuAmi
+      InstanceType: !Ref InstanceType
+      KeyName: !If [HasKeyName, !Ref KeyName, !Ref 'AWS::NoValue']
+      IamInstanceProfile: !Ref InstanceProfile
+      SecurityGroupIds: [!Ref SecurityGroup]
+      BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            VolumeSize: !Ref VolumeSize
+            VolumeType: gp3
+            DeleteOnTermination: true
+            Encrypted: true
+      Tags:
+        - { Key: Name, Value: !Ref 'AWS::StackName' }
+      UserData:
+        Fn::Base64: !Sub |
+          #!/bin/bash
+          set -eux
+          export DEBIAN_FRONTEND=noninteractive
+          # Optional custom domain — provision.sh + hezo-firstboot read this.
+          DOMAIN='${DomainOverride}'
+          if [ -n "$DOMAIN" ]; then
+            echo "HEZO_DOMAIN_OVERRIDE=$DOMAIN" >> /etc/environment
+          fi
+          echo "HEZO_RELEASE_TAG=${HezoReleaseTag}" >> /etc/environment
+          curl -fsSL '${ProvisionScriptUrl}' -o /root/hezo-provision.sh
+          set -a; [ -f /etc/environment ] && . /etc/environment; set +a
+          bash /root/hezo-provision.sh
+
+Outputs:
+  URL:
+    Description: >-
+      Open this once first boot finishes (~2 min). If you set a custom domain,
+      use that instead. Complete the in-browser setup to finish.
+    Value: !Sub 'https://${Instance.PublicIp}.sslip.io'
+  PublicIp:
+    Description: The instance's public IPv4 address.
+    Value: !GetAtt Instance.PublicIp
+  InstanceId:
+    Description: EC2 instance ID (use it to open a Session Manager shell).
+    Value: !Ref Instance
+  SshCommand:
+    Description: SSH in (only if you provided a key pair).
+    Value: !If
+      - HasKeyName
+      - !Sub 'ssh ubuntu@${Instance.PublicIp}'
+      - 'No key pair set — use AWS Systems Manager Session Manager to get a shell.'

--- a/deploy/gcp/README.md
+++ b/deploy/gcp/README.md
@@ -1,0 +1,92 @@
+# Hezo — Google Cloud one-click deploy (Cloud Shell)
+
+This is the **"Open in Cloud Shell"** path for Google Cloud. It clones this repo
+into the user's Cloud Shell, opens a guided [tutorial](tutorial.md), and runs
+[`deploy.sh`](deploy.sh) — which creates a Compute Engine VM whose startup script
+runs the same [`deploy/provision.sh`](../provision.sh) the cloud-init and AWS
+paths use (Docker + the `hezo` binary + Caddy automatic HTTPS via `<ip>.sslip.io`
++ systemd + firewall). One source of truth for host setup.
+
+Hezo runs each project's agents in a container on the **host Docker socket**, so
+it needs a real VM — **Compute Engine, not Cloud Run** (Cloud Run is a
+managed-container service with no host Docker). `deploy.sh` provisions a GCE VM.
+
+Unlike the AWS and DigitalOcean buttons, this one needs **no external hosting**:
+Cloud Shell reads the script straight from the public repo, so the button works
+as soon as this is on `main`.
+
+## The Open in Cloud Shell button
+
+Markdown for the README:
+
+```md
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/hezo-ai/hezo&cloudshell_workspace=deploy/gcp&cloudshell_tutorial=tutorial.md)
+```
+
+The URL parameters:
+
+| Param | Value | Purpose |
+|---|---|---|
+| `cloudshell_git_repo` | `https://github.com/hezo-ai/hezo` | Repo cloned into Cloud Shell. |
+| `cloudshell_workspace` | `deploy/gcp` | Working directory the terminal opens in. |
+| `cloudshell_tutorial` | `tutorial.md` | Guided walkthrough shown alongside the terminal. |
+
+## What the user does
+
+1. Click the button → Cloud Shell opens with the tutorial.
+2. Select a project (billing enabled).
+3. Run `bash deploy.sh`.
+4. Wait ~2 min, open `https://<instance-ip>.sslip.io`, finish setup.
+
+## Run it by hand
+
+From Cloud Shell or any machine with the `gcloud` CLI authenticated:
+
+```sh
+cd deploy/gcp
+gcloud config set project <YOUR_PROJECT_ID>
+bash deploy.sh
+```
+
+Overrides (environment variables, set before running):
+
+| Variable | Default | Notes |
+|---|---|---|
+| `HEZO_GCP_INSTANCE` | `hezo` | Instance name. |
+| `HEZO_GCP_ZONE` | `us-central1-a` | Zone. |
+| `HEZO_GCP_MACHINE_TYPE` | `e2-small` | 2 GB runs the install; `e2-medium`+ for real agent work. |
+| `HEZO_GCP_DISK_SIZE` | `30GB` | Boot disk (holds Hezo's data directory). |
+| `HEZO_DOMAIN_OVERRIDE` | *(empty)* | Custom domain instead of sslip.io (point an A record first). |
+| `HEZO_RELEASE_TAG` | `latest` | Pin a release; in-app update upgrades it later. |
+
+## Test before relying on the button
+
+1. `bash deploy.sh` into a throwaway project.
+2. Hit `https://<ip>.sslip.io/health` from your laptop — a valid (non-self-signed)
+   certificate proves the Let's Encrypt path provisioned against sslip.io on first
+   boot (allow ~2 min after the VM is created).
+3. Load the root URL, reach the master-key gate, complete the three setup steps.
+   The CEO chat's live log stream proves WebSocket passthrough.
+4. Confirm the container→host path (agents' tools) is open — SSH in
+   (`gcloud compute ssh hezo --zone <ZONE>`) and run:
+   ```sh
+   docker run --rm --add-host=host.docker.internal:host-gateway curlimages/curl \
+     curl -sv --max-time 5 http://host.docker.internal:3100/mcp
+   ```
+   Any HTTP status (even 401/404) is success; a timeout means the `docker0`
+   firewall rule is wrong. See
+   [`docs/deployment/self-hosting.md`](../../docs/deployment/self-hosting.md)
+   § Networking & firewall.
+5. Tear down:
+   ```sh
+   gcloud compute instances delete hezo --zone <ZONE>
+   gcloud compute firewall-rules delete hezo-allow-web
+   ```
+
+## A full GCP Marketplace listing (optional, later)
+
+The Cloud Shell button is the zero-friction path. A native **Google Cloud
+Marketplace** VM listing (a Deployment Manager / Terraform package published
+through the Producer Portal) is the heavier, DO-Marketplace-equivalent option —
+it requires an external Google Cloud partner account and Google's review, so it
+can't be completed from this repo. The Cloud Shell path needs none of that.

--- a/deploy/gcp/deploy.sh
+++ b/deploy/gcp/deploy.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# deploy.sh — create a Google Compute Engine VM that runs Hezo.
+#
+# It provisions a real VM (Hezo runs each project's agents in a container on the
+# host Docker socket, so it needs one) and sets provision.sh as the startup
+# script — the SAME installer the cloud-init and AWS paths use (Docker + the hezo
+# binary + Caddy automatic HTTPS via <ip>.sslip.io + systemd + firewall).
+#
+# Meant to be run from Google Cloud Shell (see this dir's README for the
+# "Open in Cloud Shell" button), or locally with the gcloud CLI installed.
+#
+# Everything is overridable by environment variable:
+#   HEZO_GCP_INSTANCE      instance name           (default: hezo)
+#   HEZO_GCP_ZONE          zone                     (default: us-central1-a)
+#   HEZO_GCP_MACHINE_TYPE  machine type             (default: e2-small = 2 GB)
+#   HEZO_GCP_DISK_SIZE     boot disk size           (default: 30GB)
+#   HEZO_DOMAIN_OVERRIDE   custom domain (A record) (default: use <ip>.sslip.io)
+#   HEZO_RELEASE_TAG       hezo release to install  (default: latest)
+#   HEZO_PROVISION_URL     installer URL            (default: main branch)
+
+set -euo pipefail
+
+INSTANCE="${HEZO_GCP_INSTANCE:-hezo}"
+ZONE="${HEZO_GCP_ZONE:-us-central1-a}"
+MACHINE_TYPE="${HEZO_GCP_MACHINE_TYPE:-e2-small}"
+DISK_SIZE="${HEZO_GCP_DISK_SIZE:-30GB}"
+DOMAIN_OVERRIDE="${HEZO_DOMAIN_OVERRIDE:-}"
+RELEASE_TAG="${HEZO_RELEASE_TAG:-latest}"
+PROVISION_URL="${HEZO_PROVISION_URL:-https://raw.githubusercontent.com/hezo-ai/hezo/main/deploy/provision.sh}"
+NETWORK_TAG="hezo"
+
+log() { echo "[hezo-gcp] $*"; }
+
+PROJECT="$(gcloud config get-value project 2>/dev/null || true)"
+if [[ -z "${PROJECT}" || "${PROJECT}" == "(unset)" ]]; then
+	echo "No active gcloud project. Set one first:" >&2
+	echo "  gcloud config set project YOUR_PROJECT_ID" >&2
+	exit 1
+fi
+log "Project: ${PROJECT}   Zone: ${ZONE}   Machine: ${MACHINE_TYPE}"
+
+# The Compute Engine API must be enabled; enabling is idempotent.
+log "Ensuring the Compute Engine API is enabled…"
+gcloud services enable compute.googleapis.com --project="${PROJECT}" >/dev/null
+
+# Build the VM startup script (runs as root on first boot). Kept minimal — it just
+# fetches and runs the canonical installer, optionally with a custom domain.
+STARTUP="$(mktemp)"
+trap 'rm -f "${STARTUP}"' EXIT
+{
+	echo '#!/usr/bin/env bash'
+	echo 'set -eux'
+	echo 'export DEBIAN_FRONTEND=noninteractive'
+	if [[ -n "${DOMAIN_OVERRIDE}" ]]; then
+		echo "echo 'HEZO_DOMAIN_OVERRIDE=${DOMAIN_OVERRIDE}' >> /etc/environment"
+	fi
+	echo "echo 'HEZO_RELEASE_TAG=${RELEASE_TAG}' >> /etc/environment"
+	echo "curl -fsSL '${PROVISION_URL}' -o /root/hezo-provision.sh"
+	echo 'set -a; [ -f /etc/environment ] && . /etc/environment; set +a'
+	echo 'bash /root/hezo-provision.sh'
+} >"${STARTUP}"
+
+# Firewall: allow 80/443 to instances tagged `hezo`. Idempotent.
+if ! gcloud compute firewall-rules describe hezo-allow-web --project="${PROJECT}" >/dev/null 2>&1; then
+	log "Creating firewall rule hezo-allow-web (tcp:80,443)…"
+	gcloud compute firewall-rules create hezo-allow-web \
+		--project="${PROJECT}" \
+		--direction=INGRESS \
+		--action=ALLOW \
+		--rules=tcp:80,tcp:443 \
+		--source-ranges=0.0.0.0/0 \
+		--target-tags="${NETWORK_TAG}" \
+		--description="Hezo web app (HTTP/HTTPS)"
+else
+	log "Firewall rule hezo-allow-web already exists."
+fi
+
+log "Creating instance ${INSTANCE}…"
+gcloud compute instances create "${INSTANCE}" \
+	--project="${PROJECT}" \
+	--zone="${ZONE}" \
+	--machine-type="${MACHINE_TYPE}" \
+	--image-family=ubuntu-2404-lts-amd64 \
+	--image-project=ubuntu-os-cloud \
+	--boot-disk-size="${DISK_SIZE}" \
+	--boot-disk-type=pd-balanced \
+	--tags="${NETWORK_TAG}" \
+	--metadata-from-file=startup-script="${STARTUP}"
+
+IP="$(gcloud compute instances describe "${INSTANCE}" \
+	--project="${PROJECT}" --zone="${ZONE}" \
+	--format='get(networkInterfaces[0].accessConfigs[0].natIP)')"
+
+echo
+if [[ -n "${DOMAIN_OVERRIDE}" ]]; then
+	log "Instance up. Point ${DOMAIN_OVERRIDE} (A record) at ${IP}, then open:"
+	log "  https://${DOMAIN_OVERRIDE}"
+else
+	log "Instance up. In ~2 minutes (first boot installs everything) open:"
+	log "  https://${IP}.sslip.io"
+fi
+log "Then finish the in-browser setup: master key, admin password, connect a model."
+log "SSH in with:  gcloud compute ssh ${INSTANCE} --zone ${ZONE}"

--- a/deploy/gcp/tutorial.md
+++ b/deploy/gcp/tutorial.md
@@ -1,0 +1,84 @@
+# Deploy Hezo to Google Cloud
+
+<walkthrough-tutorial-duration duration="5"></walkthrough-tutorial-duration>
+
+This tutorial launches **Hezo** on a Google Compute Engine VM. Hezo runs each
+project's AI agents in a container on the host Docker socket, so it needs a real
+VM — this creates one and installs everything on first boot (Docker, the `hezo`
+binary, automatic HTTPS via Caddy, systemd, and a locked-down firewall).
+
+Click **Start** to begin.
+
+## Choose a project
+
+Pick the Google Cloud project to deploy into. Billing must be enabled on it.
+
+<walkthrough-project-setup></walkthrough-project-setup>
+
+The script uses your currently selected project. If you want a different one:
+
+```sh
+gcloud config set project <YOUR_PROJECT_ID>
+```
+
+## Deploy
+
+Run the deploy script. It enables the Compute Engine API, creates a firewall rule
+for ports 80/443, and creates a VM named `hezo` whose startup script installs and
+starts Hezo:
+
+```sh
+bash deploy.sh
+```
+
+**Optional tweaks** (set before running `deploy.sh`):
+
+```sh
+# A bigger VM for heavier agent work (default is e2-small, 2 GB):
+export HEZO_GCP_MACHINE_TYPE=e2-medium
+# A different zone:
+export HEZO_GCP_ZONE=europe-west1-b
+# Your own domain instead of <ip>.sslip.io (point an A record at the VM after):
+export HEZO_DOMAIN_OVERRIDE=hezo.example.com
+```
+
+When it finishes, the script prints your instance's public IP and the URL to
+open.
+
+## Open Hezo and finish setup
+
+First boot takes about **2 minutes** to install everything and obtain the HTTPS
+certificate. Then open the URL the script printed:
+
+```
+https://<your-instance-ip>.sslip.io
+```
+
+Complete the short in-browser setup:
+
+1. **Create your master key** — shown once; store it safely (never on the server).
+2. **Set an admin password.**
+3. **Connect a model provider.**
+
+That's it — your team is ready.
+
+<walkthrough-conclusion-trophy></walkthrough-conclusion-trophy>
+
+## Managing the VM
+
+SSH in:
+
+```sh
+gcloud compute ssh hezo --zone <ZONE>
+```
+
+Delete it when you're done:
+
+```sh
+gcloud compute instances delete hezo --zone <ZONE>
+gcloud compute firewall-rules delete hezo-allow-web
+```
+
+Everything Hezo stores lives in `/var/lib/hezo` on the VM — back that directory up.
+After a reboot Hezo comes up **locked** by design; unlock it from the browser gate
+with your master key.

--- a/docs/deployment/one-click.md
+++ b/docs/deployment/one-click.md
@@ -15,6 +15,24 @@ This works on any provider that runs Ubuntu and accepts **cloud-init user data**
 which is all of the common ones: DigitalOcean, Hetzner, Vultr, Linode, and AWS
 Lightsail.
 
+Hezo runs each project's agents in a container on the host's Docker, so it needs a
+**real VM** — not a managed-container service like Render, Railway, or Cloud Run.
+The buttons and snippet below all provision a VM for you.
+
+## Provider buttons
+
+For some providers there's a purpose-built button that runs the whole thing:
+
+- **Google Cloud** — one-click via Cloud Shell. See the
+  [Cloud Shell deploy guide](https://github.com/hezo-ai/hezo/blob/main/deploy/gcp/README.md).
+- **AWS** — a CloudFormation "Launch Stack" that creates an EC2 instance. See the
+  [AWS deploy guide](https://github.com/hezo-ai/hezo/blob/main/deploy/aws/README.md).
+- **DigitalOcean** — a Marketplace 1-Click Droplet image (in progress), or the
+  cloud-init snippet below today.
+
+Everything else — Hetzner, Vultr, Linode, Lightsail, or any Ubuntu VM — uses the
+portable [cloud-init snippet](#deploy-it) below.
+
 ## What it sets up
 
 On first boot the snippet:


### PR DESCRIPTION
## What & why

Adds LiteLLM-style **deploy buttons** to the README for **Google Cloud, AWS, and DigitalOcean**, and the in-repo wrappers that back them.

The key design decision: those LiteLLM buttons all deploy a stateless container to a managed platform, but **Hezo runs each project's agents in a container on the host Docker socket, so it needs a real VM** — not a managed-container PaaS. That splits the five platforms in the request:

- **DigitalOcean, AWS, GCP** → real VMs. ✅ Supported here.
- **Render, Railway** → managed-container platforms with no host Docker. ❌ They cannot run Hezo, so they're intentionally **omitted** rather than shipped as buttons that would fail their Docker preflight.

Every wrapper hands the existing, canonical [`deploy/provision.sh`](https://github.com/hezo-ai/hezo/blob/main/deploy/provision.sh) to a fresh VM — one installer, wrapped per provider.

## Changes

- **`deploy/aws/`** — CloudFormation **"Launch Stack"** template (`hezo.cfn.yaml`: EC2 instance + security group for 80/443 + optional SSH + an SSM role for keyless shell access; UserData runs `provision.sh`) plus a runbook. `aws cloudformation deploy` works today; the hosted quick-create button needs a one-time upload of the template to a public S3 URL (CloudFormation quick-create requires S3).
- **`deploy/gcp/`** — **"Open in Cloud Shell"** deploy: `deploy.sh` creates a Compute Engine VM (startup script runs `provision.sh`) + firewall rule, with a guided `tutorial.md`. Works directly from the repo with **no external hosting** — the button is live as soon as this merges.
- **`README.md`** — a **Deploy** section with Google Cloud / AWS / DigitalOcean badges, plus a note on why Hezo targets VMs (host Docker socket) not Render/Railway/Cloud Run.
- **`deploy/README.md`, `docs/deployment/one-click.md`** — document the new buttons and the per-provider "fully hosted button" status.

## Per-provider one-click status

| Provider | In-repo wrapper | Fully-hosted button still needs |
|---|---|---|
| **Google Cloud** | `deploy/gcp/` Cloud Shell button | Nothing — works from this repo. |
| **AWS** | `deploy/aws/hezo.cfn.yaml` | One-time upload of the template to a public S3 URL (external, org-owned). |
| **DigitalOcean** | existing `deploy/marketplace/digitalocean/` Packer image | Publishing the Marketplace listing (external DO vendor review). |

## Verification

Deploy artifacts have no unit-test tier (matching the existing `provision.sh`), so verified statically:

- `bash -n` clean on `deploy/gcp/deploy.sh` and `deploy/provision.sh`.
- `hezo.cfn.yaml` parses; all Parameters/Conditions/Resources/Outputs resolve as expected.
- All internal doc links resolve to real files.
- `provision.sh` already falls back to `api.ipify.org` for the public IP when the DigitalOcean metadata endpoint is absent, so it derives `<ip>.sslip.io` correctly on both EC2 and GCE.

The runbooks include a throwaway-VM test procedure (health check for the Let's Encrypt cert, master-key gate, and the container→host `docker0` path) for validating each button end-to-end before the hosted versions go live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N2uNcmo9ZemshzbfQ6kkQk)_