### PR TITLE
feat: mark an inbox notification read when its comment is viewed

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -401,7 +401,9 @@ pending/approved — admin-minted keys are born approved, self-registered ones a
 approval), `invites`, `admin_mentions` (board inbox — one row per recipient for each
 active `@admin` text comment; recipients are the task team's `role='admin'` member_users
 plus **all superusers** — CEO-created teams have no human members, so the superuser leg is
-what guarantees delivery — author excluded, deduped by `(comment_id, user_id)`),
+what guarantees delivery — author excluded, deduped by `(comment_id, user_id)`; `read_at`
+marks an item read, set by the inbox card, a mark-all, or when the recipient scrolls the
+comment into view in its task thread),
 `instance_user_roles`, `notification_preferences`. `plugins`/`plugin_state`/`plugin_jobs`
 are scaffolding for a future plugin runtime — present but not yet exercised.
 

--- a/packages/web/src/components/task-detail/comments-section.tsx
+++ b/packages/web/src/components/task-detail/comments-section.tsx
@@ -1,8 +1,9 @@
 import { CommentContentType } from '@hezo/shared';
 import { useLocation } from '@tanstack/react-router';
 import { Check, Copy, CornerDownRight, Reply } from 'lucide-react';
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso';
+import { useAdminMentions, useMarkMentionRead } from '../../hooks/use-admin-mentions';
 import { useAgents } from '../../hooks/use-agents';
 import { type Comment, useComments } from '../../hooks/use-comments';
 import type { Task } from '../../hooks/use-tasks';
@@ -112,6 +113,97 @@ export function CommentsSection({
 	onStartReply,
 }: CommentsSectionProps) {
 	const { data: comments } = useComments(projectId, taskId);
+
+	// --- Mark a pending @admin inbox notification read once its comment is seen ---
+	// A notification stays unread until the user actually views its comment. Only
+	// fetch the caller's mentions when this task has an unread one (a server-
+	// computed flag on the task), so ordinary task views make no extra request.
+	// Marking reuses the inbox card's mutation and is idempotent server-side, so
+	// the two paths never conflict.
+	const { data: adminMentions } = useAdminMentions(taskProjectSlug, task.has_unread_admin_mention);
+	const markMentionRead = useMarkMentionRead();
+	const markMentionReadRef = useRef(markMentionRead);
+	markMentionReadRef.current = markMentionRead;
+	// comment_id (a globally-unique UUID) -> mentionId for the caller's UNREAD
+	// mentions. public_id can't key this — it's only unique within one task.
+	const pendingMentionByCommentId = useMemo(() => {
+		const map = new Map<string, string>();
+		for (const mention of adminMentions ?? []) {
+			if (!mention.read_at) map.set(mention.comment_id, mention.id);
+		}
+		return map;
+	}, [adminMentions]);
+	// Fires once per comment, at most once (markedCommentsRef), and never while the
+	// tab is hidden. Reads the latest pending map, so a mention that loads after
+	// its comment is already on screen still marks it.
+	const markedCommentsRef = useRef<Set<string>>(new Set());
+	const markCommentReadIfPending = useCallback(
+		(commentId: string) => {
+			if (markedCommentsRef.current.has(commentId)) return;
+			const mentionId = pendingMentionByCommentId.get(commentId);
+			if (!mentionId) return;
+			if (typeof document !== 'undefined' && document.visibilityState === 'hidden') return;
+			markedCommentsRef.current.add(commentId);
+			markMentionReadRef.current.mutate({ projectSlug: taskProjectSlug, mentionId });
+		},
+		[pendingMentionByCommentId, taskProjectSlug],
+	);
+	// Stable handle to the latest marker for the (scroll-parent-stable) observer.
+	const markHandlerRef = useRef(markCommentReadIfPending);
+	markHandlerRef.current = markCommentReadIfPending;
+	// One IntersectionObserver over the thread's scroll parent is the source of
+	// truth for "seen": Virtuoso's 600px overscan mounts rows before they're
+	// visible, so mounting alone is not a view — only real viewport intersection.
+	const observerRef = useRef<IntersectionObserver | null>(null);
+	const mountedRowsRef = useRef<Map<string, HTMLElement>>(new Map());
+	const visibleCommentsRef = useRef<Set<string>>(new Set());
+	const observeCommentRow = useCallback((el: HTMLDivElement | null) => {
+		if (!el) return;
+		const commentId = el.dataset.commentId;
+		if (!commentId) return;
+		mountedRowsRef.current.set(commentId, el);
+		observerRef.current?.observe(el);
+		return () => {
+			observerRef.current?.unobserve(el);
+			mountedRowsRef.current.delete(commentId);
+			visibleCommentsRef.current.delete(commentId);
+		};
+	}, []);
+	useEffect(() => {
+		if (typeof IntersectionObserver === 'undefined') return;
+		const io = new IntersectionObserver(
+			(entries) => {
+				for (const entry of entries) {
+					const commentId = (entry.target as HTMLElement).dataset.commentId;
+					if (!commentId) continue;
+					if (entry.isIntersecting) {
+						visibleCommentsRef.current.add(commentId);
+						markHandlerRef.current(commentId);
+					} else {
+						visibleCommentsRef.current.delete(commentId);
+					}
+				}
+			},
+			{ root: scrollParent ?? null },
+		);
+		observerRef.current = io;
+		// Observe rows that mounted before the observer existed (first paint, or a
+		// scroll-parent swap once <main> resolves).
+		for (const el of mountedRowsRef.current.values()) io.observe(el);
+		return () => {
+			io.disconnect();
+			observerRef.current = null;
+			visibleCommentsRef.current.clear();
+		};
+	}, [scrollParent]);
+	// Both the comments and the mentions load asynchronously (and the stubbed
+	// observer in component tests fires on observe, before mentions resolve), so a
+	// mention can arrive after its comment is already visible. Re-check the
+	// on-screen rows whenever the pending set changes.
+	useEffect(() => {
+		for (const commentId of visibleCommentsRef.current) markCommentReadIfPending(commentId);
+	}, [markCommentReadIfPending]);
+
 	// Resolve agent comment authors to their slug so the avatar + name link to
 	// the agent's page. Reads the already-cached team roster; cross-team authors
 	// (CEO / Coach) aren't in it and stay unlinked.
@@ -352,6 +444,8 @@ export function CommentsSection({
 							return (
 								<div
 									id={`comment-${c.public_id}`}
+									ref={observeCommentRow}
+									data-comment-id={c.id}
 									className={`flex items-start gap-2.5 scroll-mt-20 pb-4 ${isHighlighted ? 'rounded-md ring-2 ring-info/60 transition-shadow' : ''}`}
 									data-testid="comment-item"
 									data-comment-highlighted={isHighlighted ? 'true' : undefined}
@@ -379,6 +473,8 @@ export function CommentsSection({
 						return (
 							<div
 								id={`comment-${c.public_id}`}
+								ref={observeCommentRow}
+								data-comment-id={c.id}
 								className={`flex gap-2.5 scroll-mt-20 pb-4 ${isHighlighted ? 'rounded-md ring-2 ring-info/60 transition-shadow' : ''}`}
 								data-testid="comment-item"
 								data-comment-highlighted={isHighlighted ? 'true' : undefined}

--- a/packages/web/test/task-comment-notification-read.test.tsx
+++ b/packages/web/test/task-comment-notification-read.test.tsx
@@ -1,0 +1,143 @@
+import { waitFor } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { getTestContext, renderApp } from './helpers/render';
+import {
+	type SeededProject,
+	type SeededTask,
+	type SeededWorkspace,
+	seedProject,
+	seedTask,
+	seedWorkspace,
+} from './helpers/seed';
+
+/**
+ * Seed an agent-authored `@admin` comment on a task plus the resulting unread
+ * `admin_mentions` row for the team's admin user (the logged-in session). Mirrors
+ * the local helper in inbox-mentions.test.tsx — the mention is authored by an
+ * agent, so the admin (recipient) is not excluded as the author.
+ */
+async function seedAgentAdminMention(
+	workspace: SeededWorkspace,
+	task: SeededTask,
+	text: string,
+): Promise<{ commentId: string; mentionId: string; userId: string }> {
+	const { db } = getTestContext();
+
+	const architect = workspace.agents.find((a) => a.slug === 'architect');
+	if (!architect) throw new Error('seedAgentAdminMention: architect agent missing');
+
+	const userRow = await db.query<{ user_id: string }>(
+		`SELECT mu.user_id FROM member_users mu
+		 JOIN members m ON m.id = mu.id
+		 WHERE m.team_id = $1 AND mu.role = 'admin'
+		 LIMIT 1`,
+		[workspace.team.id],
+	);
+	const userId = userRow.rows[0]?.user_id;
+	if (!userId) throw new Error('seedAgentAdminMention: no admin on team');
+
+	const commentRow = await db.query<{ id: string }>(
+		`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
+		 VALUES ($1, $2, 'text'::comment_content_type, $3::jsonb)
+		 RETURNING id`,
+		[task.id, architect.id, JSON.stringify({ text })],
+	);
+	const commentId = commentRow.rows[0].id;
+
+	const mentionRow = await db.query<{ id: string }>(
+		`INSERT INTO admin_mentions (team_id, task_id, comment_id, user_id)
+		 VALUES ($1, $2, $3, $4)
+		 RETURNING id`,
+		[workspace.team.id, task.id, commentId, userId],
+	);
+
+	return { commentId, mentionId: mentionRow.rows[0].id, userId };
+}
+
+async function readAtFor(mentionId: string): Promise<string | null> {
+	const { db } = getTestContext();
+	const res = await db.query<{ read_at: string | null }>(
+		`SELECT read_at FROM admin_mentions WHERE id = $1`,
+		[mentionId],
+	);
+	return res.rows[0]?.read_at ?? null;
+}
+
+test('viewing a task comment marks its pending inbox notification read', async () => {
+	let ctx: { projectSlug: string; taskIdentifier: string; mentionId: string };
+	const { router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project: SeededProject = await seedProject(ws, { name: 'Demo' });
+			const task = await seedTask(ws, project, { title: 'Needs the admin' });
+			const { mentionId } = await seedAgentAdminMention(ws, task, '@admin please confirm.');
+			ctx = { projectSlug: project.slug, taskIdentifier: task.identifier, mentionId };
+		},
+	});
+
+	// Precondition: the notification is unread before the admin looks at the task.
+	expect(await readAtFor(ctx!.mentionId)).toBeNull();
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: ctx!.projectSlug, taskId: ctx!.taskIdentifier.toLowerCase() },
+	});
+
+	// Seeing the comment in the thread marks the notification read (no inbox click).
+	await waitFor(
+		async () => {
+			expect(await readAtFor(ctx!.mentionId)).not.toBeNull();
+		},
+		{ timeout: 10_000 },
+	);
+});
+
+test('viewing one task does not mark another task’s pending notification read', async () => {
+	let ctx: {
+		projectSlug: string;
+		viewedIdentifier: string;
+		viewedMentionId: string;
+		otherMentionId: string;
+	};
+	const { router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project: SeededProject = await seedProject(ws, { name: 'Demo' });
+			const viewed = await seedTask(ws, project, { title: 'Viewed task' });
+			const other = await seedTask(ws, project, { title: 'Untouched task' });
+			const { mentionId: viewedMentionId } = await seedAgentAdminMention(
+				ws,
+				viewed,
+				'@admin decision needed here.',
+			);
+			const { mentionId: otherMentionId } = await seedAgentAdminMention(
+				ws,
+				other,
+				'@admin decision needed elsewhere.',
+			);
+			ctx = {
+				projectSlug: project.slug,
+				viewedIdentifier: viewed.identifier,
+				viewedMentionId,
+				otherMentionId,
+			};
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: ctx!.projectSlug, taskId: ctx!.viewedIdentifier.toLowerCase() },
+	});
+
+	await waitFor(
+		async () => {
+			expect(await readAtFor(ctx!.viewedMentionId)).not.toBeNull();
+		},
+		{ timeout: 10_000 },
+	);
+
+	// The other task's notification — its comment was never rendered — stays unread.
+	expect(await readAtFor(ctx!.otherMentionId)).toBeNull();
+});

--- a/test/browser/task-comment-notification-read.spec.ts
+++ b/test/browser/task-comment-notification-read.spec.ts
@@ -1,0 +1,172 @@
+// Real Chromium (testing decision tree #1 + #4): a pending @admin notification
+// must be marked read only once its comment actually scrolls into the real
+// viewport. The below-the-fold comment has to stay unread until a real scroll
+// brings it on screen — happy-dom has no layout and its stubbed
+// IntersectionObserver reports every mounted row as visible, so this precision
+// can only be proven in the browser. The mark-on-view wiring and cross-task
+// scoping are covered cheaply by
+// packages/web/test/task-comment-notification-read.test.tsx.
+
+import { expect, test } from './fixtures';
+import { createProjectAndClearPlanning, uniqueName, waitForPageLoad } from './helpers';
+
+type Page = import('@playwright/test').Page;
+
+const TOP = 'TOP-MENTION-MARKER';
+const BOTTOM = 'BOTTOM-MENTION-MARKER';
+
+/** Mint an active (admin-minted) API key; returns its one-time raw token. */
+async function mintApiKey(page: Page, token: string): Promise<string> {
+	const res = await page.request.post('/api/api-keys', {
+		headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+		data: { name: uniqueName('inbox-seed') },
+	});
+	if (!res.ok()) throw new Error(`mintApiKey failed — ${res.status()} ${await res.text()}`);
+	return ((await res.json()) as { data: { key: string } }).data.key;
+}
+
+/**
+ * Post a comment through the MCP surface as the API key. The key authors as its
+ * own identity (not the session user), so an `@admin` mention is NOT excluded by
+ * author and reaches the logged-in superuser's inbox — the only HTTP path that
+ * seeds a self-mention for the session user.
+ */
+async function mcpCreateComment(
+	page: Page,
+	apiKey: string,
+	projectSlug: string,
+	taskId: string,
+	content: string,
+): Promise<void> {
+	const res = await page.request.post('/mcp', {
+		headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+		data: {
+			jsonrpc: '2.0',
+			id: 1,
+			method: 'tools/call',
+			params: {
+				name: 'create_comment',
+				arguments: { project: projectSlug, task_id: taskId, content },
+			},
+		},
+	});
+	if (!res.ok()) throw new Error(`mcpCreateComment failed — ${res.status()} ${await res.text()}`);
+	const body = (await res.json()) as {
+		error?: unknown;
+		result?: { isError?: boolean; content?: Array<{ text?: string }> };
+	};
+	if (body.error) throw new Error(`create_comment JSON-RPC error: ${JSON.stringify(body.error)}`);
+	if (body.result?.isError) {
+		throw new Error(`create_comment tool error: ${JSON.stringify(body.result.content)}`);
+	}
+}
+
+/** read_at for the caller's admin-mention whose comment snippet carries `marker`. */
+async function mentionReadAt(
+	page: Page,
+	projectSlug: string,
+	token: string,
+	marker: string,
+): Promise<string | null | 'missing'> {
+	const res = await page.request.get(`/api/projects/${projectSlug}/inbox/mentions`, {
+		headers: { Authorization: `Bearer ${token}` },
+	});
+	const mentions = (
+		(await res.json()) as { data: Array<{ snippet: string; read_at: string | null }> }
+	).data;
+	const found = mentions.find((m) => m.snippet.includes(marker));
+	return found ? found.read_at : 'missing';
+}
+
+const scrollMainToBottom = (page: Page) =>
+	page
+		.locator('main')
+		.first()
+		.evaluate((el) => el.scrollTo({ top: el.scrollHeight }));
+
+test.describe('Inbox notification read-on-view', () => {
+	test('a comment marks its notification read only once it scrolls into view', async ({
+		sharedPage: page,
+		sharedWorkspace,
+	}) => {
+		test.setTimeout(90_000);
+		// Tall viewport so the top mention is unambiguously above the fold and the
+		// bottom one (30 comments later) unambiguously below it.
+		await page.setViewportSize({ width: 1280, height: 900 });
+		const { token } = sharedWorkspace;
+
+		const projRes = await createProjectAndClearPlanning(page, '', token, {
+			name: uniqueName('Inbox ReadOnView'),
+			description: 'Read-on-view spec.',
+		});
+		const project = ((await projRes.json()) as { data: { id: string; slug: string } }).data;
+
+		const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+		const agentsRes = await page.request.get(`/api/projects/${project.slug}/agents`, { headers });
+		const agents = ((await agentsRes.json()) as { data: Array<{ id: string; slug: string }> }).data;
+		const assigneeId = (agents.find((a) => a.slug === 'captain') ?? agents[0]).id;
+		const taskRes = await page.request.post(`/api/projects/${project.slug}/tasks`, {
+			headers,
+			data: { project_id: project.id, title: 'Read-on-view task', assignee_id: assigneeId },
+		});
+		const task = ((await taskRes.json()) as { data: { id: string; identifier: string } }).data;
+
+		const apiKey = await mintApiKey(page, token);
+
+		// Top @admin comment — near the top, visible on load.
+		await mcpCreateComment(page, apiKey, project.slug, task.id, `@admin ${TOP} please confirm.`);
+		// Filler so the second mention sits well below the fold.
+		const BATCH = 10;
+		const COUNT = 30;
+		for (let start = 0; start < COUNT; start += BATCH) {
+			const batch = Array.from({ length: Math.min(BATCH, COUNT - start) }, (_, i) => start + i);
+			await Promise.all(
+				batch.map((i) =>
+					page.request.post(`/api/projects/${project.slug}/tasks/${task.id}/comments`, {
+						headers,
+						data: {
+							content_type: 'text',
+							content: { text: `filler ${i}. ${'lorem ipsum '.repeat(8)}` },
+						},
+					}),
+				),
+			);
+		}
+		// Bottom @admin comment — below the fold.
+		await mcpCreateComment(page, apiKey, project.slug, task.id, `@admin ${BOTTOM} please confirm.`);
+
+		// Both notifications start unread.
+		expect(await mentionReadAt(page, project.slug, token, TOP)).toBeNull();
+		expect(await mentionReadAt(page, project.slug, token, BOTTOM)).toBeNull();
+
+		await page.goto(`/projects/${project.slug}/tasks/${task.identifier.toLowerCase()}`);
+		await waitForPageLoad(page);
+		// The thread loads at the top by default; pin it there so the assertion isn't
+		// racing any late scroll.
+		await page
+			.locator('main')
+			.first()
+			.evaluate((el) => el.scrollTo({ top: 0 }));
+
+		// The visible top comment's notification is marked read on view.
+		await expect
+			.poll(() => mentionReadAt(page, project.slug, token, TOP), { timeout: 20_000 })
+			.not.toBeNull();
+
+		// The below-the-fold comment's notification is still unread — never seen.
+		expect(await mentionReadAt(page, project.slug, token, BOTTOM)).toBeNull();
+
+		// Scroll it into view → it now gets marked read. Re-scroll each poll so
+		// Virtuoso's post-mount height growth can't leave the row short of the
+		// viewport.
+		await expect
+			.poll(
+				async () => {
+					await scrollMainToBottom(page);
+					return mentionReadAt(page, project.slug, token, BOTTOM);
+				},
+				{ timeout: 20_000, intervals: [500, 1000, 1000, 2000] },
+			)
+			.not.toBeNull();
+	});
+});


### PR DESCRIPTION
## What & why

An `@admin` inbox notification (an `admin_mentions` row) was only ever marked read by **clicking its inbox card**. If a user reached and read the comment any other way — opening the task directly, scrolling the thread, or following a shared `#comment-<id>` permalink — the notification stayed unread and the badge stayed lit even though they had already seen it.

This makes the notification "considered read" the moment the user actually **views the comment** it points at.

## Approach

Frontend-only; **no backend or schema change** — reuses the existing mark-read mutation (`useMarkMentionRead` → `POST /api/projects/:projectId/inbox/mentions/:mentionId/read`).

In `CommentsSection` (`packages/web/src/components/task-detail/comments-section.tsx`):
- Fetch the caller's unread mentions, **gated on the task's server-computed `has_unread_admin_mention` flag**, so ordinary task views make no extra request. Build a `comment_id → mentionId` map (keyed by the globally-unique comment UUID; `public_id` is only unique per task).
- Observe each comment row with an `IntersectionObserver` (root = the thread's scroll parent). When a comment whose UUID is pending scrolls into view, mark its mention read — once per comment, and never while the tab is hidden.
- Because Virtuoso's overscan mounts rows before they're visible, real viewport intersection (not mounting) is the source of truth for "seen". A ref-callback + a re-check-on-mentions-load effect handle the async race where a mention resolves after its comment is already on screen.

`useMarkMentionRead` already invalidates the inbox mentions + count and the server broadcasts an `admin_mentions` UPDATE, so every badge (header, rail, sidebar, inbox page) and other tabs refresh live. Marking is idempotent server-side (`read_at = COALESCE(read_at, now())`), so it never conflicts with the inbox-card click path (which is unchanged).

## Tests

- **Component** (`packages/web/test/task-comment-notification-read.test.tsx`): viewing a task marks its pending notification read; viewing one task leaves another task's notification unread (cross-task scoping). Drives the real in-process backend and asserts on `admin_mentions.read_at`.
- **Browser** (`test/browser/task-comment-notification-read.spec.ts`): a below-the-fold mention stays unread until scrolled into the real viewport, then flips to read — the per-comment precision that the component tier's stubbed `IntersectionObserver` can't exercise. Seeds a self-mention over HTTP via an admin-minted API key posting `@admin` through the MCP surface.

All three new tests pass; the full `packages/web` tier (1125 tests) passes with no regressions; typecheck, build, and lint are green.

## Docs

Updated the `admin_mentions` entry in `.dev/architecture.md` to note that `read_at` is now also set when the recipient scrolls the comment into view in its task thread. No user-facing route/flag/MCP-tool changed, so the generated surfaces are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExB7dJGqbkv8chRYY9EgBw

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExB7dJGqbkv8chRYY9EgBw)_