### PR TITLE
feat(assets): add sort control to the project Assets page

### DIFF
--- a/docs/concepts/assets.md
+++ b/docs/concepts/assets.md
@@ -96,6 +96,11 @@ The Assets page shows **active** items by default. The filter button (funnel ico
 "Showing active items" switches the view to **Archived** or **All** — archived cards render
 dimmed with an "Archived" badge, and offer **Restore** plus **Delete**.
 
+Next to the filter is a **sort** button. It orders the files **Newest first** by default; open
+it to switch to **Oldest first** or **Alphabetical** (by filename, A→Z). Folders always stay
+in alphabetical order — the sort applies to the files themselves. Agents can request the same
+orders when listing assets through Hezo's [MCP server](/docs/mcp/hezo-mcp-server).
+
 **Deletion is permanent and admin-only.** Agents can never delete. The Delete action lives
 only on archived cards, so removing an asset for good is a deliberate two-step: archive it,
 then delete it from the Archived view (with a confirmation, since attachments referencing it

--- a/docs/reference/mcp-api.md
+++ b/docs/reference/mcp-api.md
@@ -1053,7 +1053,7 @@ List project documentation files (PRD, spec, implementation plan, etc.). Archive
 
 _Read-only._
 
-List the project's assets — files in the assets library (UI mockups, wireframes, diagrams, images, PDFs, scripts, and generated markdown such as blog posts or reports). Filenames may carry a folder prefix up to 2 levels deep (e.g. `launch/images/hero.png`); reference one in a comment or doc as `assets/<path>` exactly as returned here (e.g. assets/launch/images/hero.png), no backticks. Author both text and binary assets with write_project_asset (binary via encoding: 'base64') and reorganize with move_project_asset / copy_project_asset; obsolete assets are archived with archive_project_asset (hard deletion is admin-only). Archived assets are excluded by default — set filter: 'archived' or 'all' to see them (entries then carry an `archived` flag).
+List the project's assets — files in the assets library (UI mockups, wireframes, diagrams, images, PDFs, scripts, and generated markdown such as blog posts or reports). Filenames may carry a folder prefix up to 2 levels deep (e.g. `launch/images/hero.png`); reference one in a comment or doc as `assets/<path>` exactly as returned here (e.g. assets/launch/images/hero.png), no backticks. Author both text and binary assets with write_project_asset (binary via encoding: 'base64') and reorganize with move_project_asset / copy_project_asset; obsolete assets are archived with archive_project_asset (hard deletion is admin-only). Archived assets are excluded by default — set filter: 'archived' or 'all' to see them (entries then carry an `archived` flag). Results are ordered newest-first by default; pass sort: 'oldest' or 'alphabetical' to change the order.
 
 **Parameters:**
 
@@ -1061,6 +1061,7 @@ List the project's assets — files in the assets library (UI mockups, wireframe
 | --- | --- | --- | --- |
 | `project` | `string` | No | Project slug or ID. Omit to use the project your run is already in; instance agents (CEO/Coach) must name the project to act in. |
 | `filter` | `active` \| `archived` \| `all` | No | Which archive states to consider: 'active' (default — archived items are excluded), 'archived' (only archived), or 'all'. |
+| `sort` | `newest` \| `oldest` \| `alphabetical` | No | Order of the returned assets: 'newest' (default — most recently created first), 'oldest', or 'alphabetical' (by filename, A→Z). |
 
 **Returns:** `{ files: [{ id, filename, content_type, created_at }] }` — the project asset files. `filename` is the full path and may carry a folder prefix up to 2 levels (e.g. `launch/images/hero.png`). The `filter` param defaults to `'active'` (archived assets excluded); with `'archived'` or `'all'` each entry also carries `archived: boolean`.
 

--- a/packages/server/src/lib/asset-sort.ts
+++ b/packages/server/src/lib/asset-sort.ts
@@ -1,0 +1,22 @@
+import { AssetSortOrder } from '@hezo/shared';
+
+/**
+ * SQL `ORDER BY` body for the assets list, mirroring `compareAssetsForSort`
+ * from `@hezo/shared` (the single source of truth the web client sort also
+ * uses). `prefix` is the table-alias qualifier — `'a.'` for the REST route's
+ * `assets a`, `''` for the MCP tool's unaliased query. `order` must already be
+ * a validated `AssetSortOrder`, so the returned fragment never carries user
+ * input.
+ */
+export function assetSortOrderBy(order: AssetSortOrder, prefix = ''): string {
+	const created = `${prefix}created_at`;
+	const name = `LOWER(${prefix}original_filename)`;
+	switch (order) {
+		case AssetSortOrder.Oldest:
+			return `${created} ASC, ${name} ASC`;
+		case AssetSortOrder.Alphabetical:
+			return `${name} ASC, ${created} DESC`;
+		default:
+			return `${created} DESC, ${name} ASC`;
+	}
+}

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -7,6 +7,7 @@ import {
 	ApprovalType,
 	ArchiveFilter,
 	ASSET_MAX_FOLDER_DEPTH,
+	AssetSortOrder,
 	ATTACHMENT_EXTENSIONS,
 	ATTACHMENT_MAX_BYTES,
 	AuditActorType,
@@ -53,6 +54,7 @@ import type { DomainEventBus } from '../events/bus';
 import { assertNoActiveRun } from '../lib/active-run';
 import { isHqInstanceAgent, isVirtualHqMemberInTeam } from '../lib/agent-roles';
 import { upsertProjectAsset } from '../lib/asset-name';
+import { assetSortOrderBy } from '../lib/asset-sort';
 import { signAgentAssetUrl } from '../lib/asset-urls';
 import { assertSubordinateAssignee } from '../lib/assignment-hierarchy';
 import { trackBackground } from '../lib/background';
@@ -806,6 +808,21 @@ const archiveFilterArg = () =>
 
 const toArchiveFilter = (value: unknown): ArchiveFilter =>
 	(value as ArchiveFilter | undefined) ?? ArchiveFilter.Active;
+
+/**
+ * Standard `sort` entry for the asset listing. Defaults to 'newest' (the
+ * historical `created_at DESC` order).
+ */
+const assetSortArg = () =>
+	z
+		.enum(Object.values(AssetSortOrder) as [string, ...string[]])
+		.optional()
+		.describe(
+			"Order of the returned assets: 'newest' (default — most recently created first), 'oldest', or 'alphabetical' (by filename, A→Z).",
+		);
+
+const toAssetSortOrder = (value: unknown): AssetSortOrder =>
+	(value as AssetSortOrder | undefined) ?? AssetSortOrder.Newest;
 
 export function registerTools(
 	server: McpServer,
@@ -3922,15 +3939,17 @@ export function registerTools(
 	tool(
 		server,
 		'list_project_assets',
-		"List the project's assets — files in the assets library (UI mockups, wireframes, diagrams, images, PDFs, scripts, and generated markdown such as blog posts or reports). Filenames may carry a folder prefix up to 2 levels deep (e.g. `launch/images/hero.png`); reference one in a comment or doc as `assets/<path>` exactly as returned here (e.g. assets/launch/images/hero.png), no backticks. Author both text and binary assets with write_project_asset (binary via encoding: 'base64') and reorganize with move_project_asset / copy_project_asset; obsolete assets are archived with archive_project_asset (hard deletion is admin-only). Archived assets are excluded by default — set filter: 'archived' or 'all' to see them (entries then carry an `archived` flag).",
+		"List the project's assets — files in the assets library (UI mockups, wireframes, diagrams, images, PDFs, scripts, and generated markdown such as blog posts or reports). Filenames may carry a folder prefix up to 2 levels deep (e.g. `launch/images/hero.png`); reference one in a comment or doc as `assets/<path>` exactly as returned here (e.g. assets/launch/images/hero.png), no backticks. Author both text and binary assets with write_project_asset (binary via encoding: 'base64') and reorganize with move_project_asset / copy_project_asset; obsolete assets are archived with archive_project_asset (hard deletion is admin-only). Archived assets are excluded by default — set filter: 'archived' or 'all' to see them (entries then carry an `archived` flag). Results are ordered newest-first by default; pass sort: 'oldest' or 'alphabetical' to change the order.",
 		{
 			project: projectArg(),
 			filter: archiveFilterArg(),
+			sort: assetSortArg(),
 		},
 		async (args, db, auth) => {
 			const scope = await resolveScope(db, auth, args);
 			if ('error' in scope) return scope;
 			const filter = toArchiveFilter(args.filter);
+			const sort = toAssetSortOrder(args.sort);
 			const where =
 				filter === ArchiveFilter.Active
 					? ' AND archived_at IS NULL'
@@ -3946,7 +3965,7 @@ export function registerTools(
 			}>(
 				`SELECT id, original_filename, content_type, created_at, archived_at
 				 FROM assets WHERE project_id = $1${where}
-				 ORDER BY created_at DESC`,
+				 ORDER BY ${assetSortOrderBy(sort)}`,
 				[scope.projectId],
 			);
 			return {

--- a/packages/server/src/routes/assets.ts
+++ b/packages/server/src/routes/assets.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import {
+	AssetSortOrder,
 	ATTACHMENT_EXTENSIONS,
 	ATTACHMENT_MAX_BYTES,
 	AuthType,
@@ -7,6 +8,7 @@ import {
 	assetContentDisposition,
 	assetServeCsp,
 	isAllowedAttachmentExtension,
+	isAssetSortOrder,
 	normalizeAssetFilename,
 	normalizeAssetFolder,
 	resolveAttachmentContentType,
@@ -17,6 +19,7 @@ import { type Context, Hono } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
 import { AssetNotFoundError, AttachmentTooLargeError } from '../assets/store';
 import { insertAssetWithUniqueName } from '../lib/asset-name';
+import { assetSortOrderBy } from '../lib/asset-sort';
 import { signAssetUrl, verifyAssetUrl } from '../lib/asset-urls';
 import { broadcastChange } from '../lib/broadcast';
 import { ref } from '../lib/log-ref';
@@ -229,6 +232,11 @@ assetsRoutes.get('/projects/:projectId/assets', async (c) => {
 	const projectId = await resolveProjectId(db, teamId, c.req.param('projectId'));
 	if (!projectId) return err(c, 'NOT_FOUND', 'Project not found', 404);
 
+	// The sort order is a view concern; an unknown/absent value falls back to
+	// Newest, preserving the historical `created_at DESC` default.
+	const sortParam = c.req.query('sort');
+	const sort = isAssetSortOrder(sortParam) ? sortParam : AssetSortOrder.Newest;
+
 	// Archived assets ride along: the web UI filters client-side (Active /
 	// Archived / All with counts) and `assets/<path>` references in comments
 	// and docs must keep resolving. Agent-facing listings (MCP) are active-only.
@@ -248,7 +256,7 @@ assetsRoutes.get('/projects/:projectId/assets', async (c) => {
 		 LEFT JOIN comment_attachments ca ON ca.asset_id = a.id
 		 WHERE a.project_id = $1
 		 GROUP BY a.id
-		 ORDER BY a.created_at DESC`,
+		 ORDER BY ${assetSortOrderBy(sort, 'a.')}`,
 		[projectId],
 	);
 

--- a/packages/server/test/project-assets.test.ts
+++ b/packages/server/test/project-assets.test.ts
@@ -909,3 +909,117 @@ describe('foldered asset mention resolution', () => {
 		expect(body.assets[0].signed_url).toMatch(/^\/api\/assets\//);
 	});
 });
+
+describe('asset sort order (REST + MCP)', () => {
+	// Own team/project so the fixed set isn't polluted by the shared project's
+	// accumulating uploads. Names + created_at are chosen so the three orders
+	// are all distinct: alpha ≠ newest ≠ oldest.
+	let sortProjectId: string;
+	let sortAgentToken: string;
+	const ids: Record<string, string> = {};
+
+	async function uploadTo(pid: string, filename: string, seed: number): Promise<string> {
+		const fd = new FormData();
+		const bytes = buildPng(seed);
+		fd.set('file', new File([bytes.buffer], filename, { type: 'image/png' }));
+		const res = await app.request(`/api/projects/${pid}/assets`, {
+			method: 'POST',
+			headers: { ...authHeader(token) },
+			body: fd,
+		});
+		expect(res.status).toBe(201);
+		return (await res.json()).data.id;
+	}
+
+	async function restList(query = ''): Promise<string[]> {
+		const res = await app.request(`/api/projects/${sortProjectId}/assets${query}`, {
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(200);
+		return ((await res.json()).data as Array<{ original_filename: string }>).map(
+			(a) => a.original_filename,
+		);
+	}
+
+	async function mcpList(args: Record<string, unknown>): Promise<string[]> {
+		const out = (await callToolViaMcp(sortAgentToken, 'list_project_assets', args)) as {
+			files: Array<{ filename: string }>;
+		};
+		return out.files.map((f) => f.filename);
+	}
+
+	beforeAll(async () => {
+		const teamRes = await createTestTeam(db, { name: 'Sort Co' });
+		const sortTeamId = (await teamRes.json()).data.id;
+		const projectRes = await createTestProject(db, sortTeamId, { name: 'Sortable' });
+		sortProjectId = (await projectRes.json()).data.id;
+
+		const agentRes = await app.request(`/api/projects/${sortProjectId}/agents`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ title: 'Sort Bot' }),
+		});
+		const sortAgentId = (await agentRes.json()).data.id;
+		const taskRes = await app.request(`/api/projects/${sortProjectId}/tasks`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ title: 'Sort task', assignee_id: sortAgentId }),
+		});
+		const sortTaskId = (await taskRes.json()).data.id;
+		sortAgentToken = (
+			await mintAgentToken(db, masterKeyManager, sortAgentId, sortTeamId, sortTaskId)
+		).token;
+
+		ids.banana = await uploadTo(sortProjectId, 'banana.png', 40);
+		ids.apple = await uploadTo(sortProjectId, 'apple.png', 41);
+		ids.cherry = await uploadTo(sortProjectId, 'cherry.png', 42);
+		// Pin created_at so date ordering is deterministic (uploads share now()).
+		await db.query(`UPDATE assets SET created_at = $1 WHERE id = $2`, [
+			'2026-01-03T00:00:00.000Z',
+			ids.banana,
+		]);
+		await db.query(`UPDATE assets SET created_at = $1 WHERE id = $2`, [
+			'2026-01-02T00:00:00.000Z',
+			ids.apple,
+		]);
+		await db.query(`UPDATE assets SET created_at = $1 WHERE id = $2`, [
+			'2026-01-01T00:00:00.000Z',
+			ids.cherry,
+		]);
+	});
+
+	it('REST defaults to newest-first', async () => {
+		expect(await restList()).toEqual(['banana.png', 'apple.png', 'cherry.png']);
+	});
+
+	it('REST honours ?sort=oldest and ?sort=alphabetical', async () => {
+		expect(await restList('?sort=oldest')).toEqual(['cherry.png', 'apple.png', 'banana.png']);
+		expect(await restList('?sort=alphabetical')).toEqual(['apple.png', 'banana.png', 'cherry.png']);
+	});
+
+	it('REST falls back to newest for an unknown sort value', async () => {
+		expect(await restList('?sort=bogus')).toEqual(['banana.png', 'apple.png', 'cherry.png']);
+	});
+
+	it('MCP list_project_assets defaults to newest and honours sort', async () => {
+		expect(await mcpList({})).toEqual(['banana.png', 'apple.png', 'cherry.png']);
+		expect(await mcpList({ sort: 'oldest' })).toEqual(['cherry.png', 'apple.png', 'banana.png']);
+		expect(await mcpList({ sort: 'alphabetical' })).toEqual([
+			'apple.png',
+			'banana.png',
+			'cherry.png',
+		]);
+	});
+
+	it('MCP composes filter and sort', async () => {
+		await db.query(`UPDATE assets SET archived_at = now() WHERE id = $1`, [ids.apple]);
+		// Active (default) excludes the archived apple, still newest-first.
+		expect(await mcpList({ sort: 'newest' })).toEqual(['banana.png', 'cherry.png']);
+		// 'all' brings it back, ordered alphabetically.
+		expect(await mcpList({ filter: 'all', sort: 'alphabetical' })).toEqual([
+			'apple.png',
+			'banana.png',
+			'cherry.png',
+		]);
+	});
+});

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -994,6 +994,58 @@ export function matchesArchiveFilter(
 	return filter === ArchiveFilter.Archived ? archivedAt != null : archivedAt == null;
 }
 
+/**
+ * Order for the assets grid. Newest is the default (matches the API's historical
+ * `created_at DESC`). The web sorts client-side and the REST route / MCP tool
+ * sort in SQL; both mirror `compareAssetsForSort`, the single source of truth.
+ */
+export const AssetSortOrder = {
+	Newest: 'newest',
+	Oldest: 'oldest',
+	Alphabetical: 'alphabetical',
+} as const;
+export type AssetSortOrder = (typeof AssetSortOrder)[keyof typeof AssetSortOrder];
+
+export function isAssetSortOrder(value: unknown): value is AssetSortOrder {
+	return typeof value === 'string' && (Object.values(AssetSortOrder) as string[]).includes(value);
+}
+
+/** The minimal asset shape the sort comparison reads. */
+export interface AssetSortFields {
+	created_at: string;
+	original_filename: string;
+}
+
+/**
+ * Compare two assets for the given sort order. The SQL `ORDER BY` on the REST
+ * route and MCP tool mirrors this exactly:
+ * - Newest:       created_at DESC, then original_filename ASC
+ * - Oldest:       created_at ASC,  then original_filename ASC
+ * - Alphabetical: LOWER(original_filename) ASC, then created_at DESC
+ * Every branch has a deterministic tiebreak so the order is stable.
+ */
+export function compareAssetsForSort(
+	a: AssetSortFields,
+	b: AssetSortFields,
+	order: AssetSortOrder,
+): number {
+	if (order === AssetSortOrder.Alphabetical) {
+		const byName = a.original_filename
+			.toLowerCase()
+			.localeCompare(b.original_filename.toLowerCase());
+		if (byName !== 0) return byName;
+		// Newest first as the tiebreak (created_at DESC).
+		return b.created_at.localeCompare(a.created_at);
+	}
+	// ISO-8601 timestamps sort chronologically as plain strings.
+	const byDate =
+		order === AssetSortOrder.Oldest
+			? a.created_at.localeCompare(b.created_at)
+			: b.created_at.localeCompare(a.created_at);
+	if (byDate !== 0) return byDate;
+	return a.original_filename.toLowerCase().localeCompare(b.original_filename.toLowerCase());
+}
+
 export const AuditActorType = {
 	Admin: 'admin',
 	Agent: 'agent',

--- a/packages/shared/test/asset-sort.test.ts
+++ b/packages/shared/test/asset-sort.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import {
+	type AssetSortFields,
+	AssetSortOrder,
+	compareAssetsForSort,
+	isAssetSortOrder,
+} from '../src/types/common';
+
+const asset = (created_at: string, original_filename: string): AssetSortFields => ({
+	created_at,
+	original_filename,
+});
+
+/** Sort a copy of the list with the comparator and return the filenames. */
+function order(list: AssetSortFields[], sort: AssetSortOrder): string[] {
+	return [...list].sort((a, b) => compareAssetsForSort(a, b, sort)).map((a) => a.original_filename);
+}
+
+describe('isAssetSortOrder', () => {
+	it('accepts the three known orders', () => {
+		expect(isAssetSortOrder('newest')).toBe(true);
+		expect(isAssetSortOrder('oldest')).toBe(true);
+		expect(isAssetSortOrder('alphabetical')).toBe(true);
+	});
+
+	it('rejects unknown / malformed values', () => {
+		expect(isAssetSortOrder('name')).toBe(false);
+		expect(isAssetSortOrder('')).toBe(false);
+		expect(isAssetSortOrder(undefined)).toBe(false);
+		expect(isAssetSortOrder(null)).toBe(false);
+		expect(isAssetSortOrder(1)).toBe(false);
+	});
+});
+
+describe('compareAssetsForSort', () => {
+	const list = [
+		asset('2026-01-03T00:00:00Z', 'banana.png'),
+		asset('2026-01-01T00:00:00Z', 'cherry.png'),
+		asset('2026-01-02T00:00:00Z', 'apple.png'),
+	];
+
+	it('Newest orders by created_at descending', () => {
+		expect(order(list, AssetSortOrder.Newest)).toEqual(['banana.png', 'apple.png', 'cherry.png']);
+	});
+
+	it('Oldest orders by created_at ascending', () => {
+		expect(order(list, AssetSortOrder.Oldest)).toEqual(['cherry.png', 'apple.png', 'banana.png']);
+	});
+
+	it('Alphabetical orders by filename A→Z, case-insensitively', () => {
+		const mixed = [
+			asset('2026-01-01T00:00:00Z', 'Zebra.png'),
+			asset('2026-01-01T00:00:00Z', 'apple.png'),
+			asset('2026-01-01T00:00:00Z', 'Banana.png'),
+		];
+		expect(order(mixed, AssetSortOrder.Alphabetical)).toEqual([
+			'apple.png',
+			'Banana.png',
+			'Zebra.png',
+		]);
+	});
+
+	it('breaks date ties by filename ascending (Newest/Oldest)', () => {
+		const sameDay = [
+			asset('2026-01-01T00:00:00Z', 'gamma.png'),
+			asset('2026-01-01T00:00:00Z', 'alpha.png'),
+			asset('2026-01-01T00:00:00Z', 'beta.png'),
+		];
+		expect(order(sameDay, AssetSortOrder.Newest)).toEqual(['alpha.png', 'beta.png', 'gamma.png']);
+		expect(order(sameDay, AssetSortOrder.Oldest)).toEqual(['alpha.png', 'beta.png', 'gamma.png']);
+	});
+
+	it('breaks name ties by created_at descending (Alphabetical)', () => {
+		// Same basename in two folders keeps the newer copy first.
+		const dupes = [
+			asset('2026-01-01T00:00:00Z', 'launch/hero.png'),
+			asset('2026-01-05T00:00:00Z', 'promo/hero.png'),
+		];
+		// Different full paths sort by path; identical paths can't occur (unique),
+		// so exercise the tiebreak with equal names via a direct comparison.
+		const older = asset('2026-01-01T00:00:00Z', 'hero.png');
+		const newer = asset('2026-01-05T00:00:00Z', 'hero.png');
+		expect(compareAssetsForSort(newer, older, AssetSortOrder.Alphabetical)).toBeLessThan(0);
+		expect(compareAssetsForSort(older, newer, AssetSortOrder.Alphabetical)).toBeGreaterThan(0);
+		// Sanity: distinct paths still order by path.
+		expect(order(dupes, AssetSortOrder.Alphabetical)).toEqual([
+			'launch/hero.png',
+			'promo/hero.png',
+		]);
+	});
+});

--- a/packages/web/src/routes/projects/$projectId/assets.tsx
+++ b/packages/web/src/routes/projects/$projectId/assets.tsx
@@ -1,9 +1,12 @@
 import {
 	ArchiveFilter,
 	ASSET_MAX_FOLDER_DEPTH,
+	AssetSortOrder,
 	assetBasename,
 	assetFolder,
+	compareAssetsForSort,
 	isArchiveFilter,
+	isAssetSortOrder,
 	matchesArchiveFilter,
 	normalizeAssetFolder,
 } from '@hezo/shared';
@@ -13,6 +16,7 @@ import { createFileRoute } from '@tanstack/react-router';
 import {
 	Archive,
 	ArchiveRestore,
+	ArrowDownWideNarrow,
 	Check,
 	ChevronDown,
 	Copy,
@@ -61,12 +65,20 @@ interface AssetsSearch {
 	folder?: string;
 	/** Archive filter — absent means the default Active view. */
 	filter?: ArchiveFilter;
+	/** Sort order — absent means the default Newest-first view. */
+	sort?: AssetSortOrder;
 }
 
 const FILTER_TEXT: Record<ArchiveFilter, string> = {
 	[ArchiveFilter.Active]: 'Showing active items',
 	[ArchiveFilter.Archived]: 'Showing archived items',
 	[ArchiveFilter.All]: 'Showing all items',
+};
+
+const SORT_TEXT: Record<AssetSortOrder, string> = {
+	[AssetSortOrder.Newest]: 'Newest first',
+	[AssetSortOrder.Oldest]: 'Oldest first',
+	[AssetSortOrder.Alphabetical]: 'Alphabetical',
 };
 
 /**
@@ -89,7 +101,7 @@ function AssetFilterControl({
 		{ value: ArchiveFilter.All, label: 'All' },
 	];
 	return (
-		<div className="mb-3 flex items-center gap-1.5">
+		<div className="flex items-center gap-1.5">
 			<span className="text-[12.5px] text-text-2" data-testid="asset-filter-text">
 				{FILTER_TEXT[filter]}
 			</span>
@@ -147,6 +159,82 @@ function AssetFilterControl({
 	);
 }
 
+/**
+ * "Newest first" caption + a button that opens a small popover listing the
+ * three sort orders. A sibling of AssetFilterControl; the sort is a client-side
+ * view concern (the full list is already fetched), persisted in the URL.
+ */
+function AssetSortControl({
+	sort,
+	onChange,
+}: {
+	sort: AssetSortOrder;
+	onChange: (next: AssetSortOrder) => void;
+}) {
+	const [open, setOpen] = useState(false);
+	const options = [
+		{ value: AssetSortOrder.Newest, label: 'Newest first' },
+		{ value: AssetSortOrder.Oldest, label: 'Oldest first' },
+		{ value: AssetSortOrder.Alphabetical, label: 'Alphabetical' },
+	];
+	return (
+		<div className="flex items-center gap-1.5">
+			<span className="text-[12.5px] text-text-2" data-testid="asset-sort-text">
+				{SORT_TEXT[sort]}
+			</span>
+			<Popover.Root open={open} onOpenChange={setOpen}>
+				<Popover.Trigger asChild>
+					<button
+						type="button"
+						aria-label="Sort assets"
+						data-testid="asset-sort-button"
+						className={`inline-flex items-center rounded-md border p-1.5 transition-colors cursor-pointer ${
+							sort === AssetSortOrder.Newest
+								? 'border-border bg-surface text-text-2 hover:border-border-strong hover:text-text-1'
+								: 'border-border-strong bg-surface-2 text-text-1'
+						}`}
+					>
+						<ArrowDownWideNarrow className="h-3.5 w-3.5" />
+					</button>
+				</Popover.Trigger>
+				<Popover.Portal>
+					<Popover.Content
+						align="start"
+						sideOffset={4}
+						className="z-50 min-w-[180px] rounded-md border border-border bg-surface p-1 shadow-md"
+						data-testid="asset-sort-popover"
+					>
+						{options.map((opt) => {
+							const selected = sort === opt.value;
+							return (
+								<button
+									key={opt.value}
+									type="button"
+									role="menuitemradio"
+									aria-checked={selected}
+									data-testid={`asset-sort-option-${opt.value}`}
+									onClick={() => {
+										onChange(opt.value);
+										setOpen(false);
+									}}
+									className={`flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-[13px] transition-colors cursor-pointer text-left ${
+										selected
+											? 'bg-surface-2 text-text-1'
+											: 'text-text-2 hover:bg-surface-3 hover:text-text-1'
+									}`}
+								>
+									<span className="flex-1">{opt.label}</span>
+									{selected && <Check className="h-3.5 w-3.5 shrink-0 text-info" />}
+								</button>
+							);
+						})}
+					</Popover.Content>
+				</Popover.Portal>
+			</Popover.Root>
+		</div>
+	);
+}
+
 interface ErrorChip {
 	id: string;
 	filename: string;
@@ -155,7 +243,12 @@ interface ErrorChip {
 
 function ProjectAssetsPage() {
 	const { projectId } = Route.useParams();
-	const { file: focusFile, folder: folderParam, filter = ArchiveFilter.Active } = Route.useSearch();
+	const {
+		file: focusFile,
+		folder: folderParam,
+		filter = ArchiveFilter.Active,
+		sort = AssetSortOrder.Newest,
+	} = Route.useSearch();
 	const navigate = Route.useNavigate();
 	const { data: assets, isLoading } = useProjectAssets(projectId);
 	const upload = useUploadProjectAsset(projectId);
@@ -254,7 +347,11 @@ function ProjectAssetsPage() {
 	const deleteCount = pendingDelete?.comment_attachment_count ?? 0;
 	// Filter before grouping so folder cards and their file counts reflect the
 	// current view (a folder with only archived files disappears from Active).
-	const visibleAssets = (assets ?? []).filter((a) => matchesArchiveFilter(a.archived_at, filter));
+	// Sort client-side (the full list is already fetched) with the shared
+	// comparator the API mirrors; folder cards keep their own alphabetical order.
+	const visibleAssets = (assets ?? [])
+		.filter((a) => matchesArchiveFilter(a.archived_at, filter))
+		.sort((a, b) => compareAssetsForSort(a, b, sort));
 	const grouped = groupAssets(visibleAssets, currentFolder);
 	const filterCounts: Record<ArchiveFilter, number> = {
 		[ArchiveFilter.All]: assets?.length ?? 0,
@@ -277,6 +374,19 @@ function ProjectAssetsPage() {
 				search: (prev) => ({
 					...(prev as AssetsSearch),
 					filter: next === ArchiveFilter.Active ? undefined : next,
+				}),
+				replace: true,
+			});
+		},
+		[navigate],
+	);
+
+	const setSort = useCallback(
+		(next: AssetSortOrder) => {
+			navigate({
+				search: (prev) => ({
+					...(prev as AssetsSearch),
+					sort: next === AssetSortOrder.Newest ? undefined : next,
 				}),
 				replace: true,
 			});
@@ -366,7 +476,10 @@ function ProjectAssetsPage() {
 				</div>
 			)}
 
-			<AssetFilterControl filter={filter} counts={filterCounts} onChange={setFilter} />
+			<div className="mb-3 flex flex-wrap items-center gap-x-4 gap-y-2">
+				<AssetFilterControl filter={filter} counts={filterCounts} onChange={setFilter} />
+				<AssetSortControl sort={sort} onChange={setSort} />
+			</div>
 
 			{/* biome-ignore lint/a11y/noStaticElementInteractions: drag-and-drop upload zone; uploads also work via the Upload button */}
 			<div
@@ -1080,6 +1193,10 @@ export const Route = createFileRoute('/projects/$projectId/assets')({
 		filter:
 			isArchiveFilter(search.filter) && search.filter !== ArchiveFilter.Active
 				? search.filter
+				: undefined,
+		sort:
+			isAssetSortOrder(search.sort) && search.sort !== AssetSortOrder.Newest
+				? search.sort
 				: undefined,
 	}),
 	// HQ (the internal coordination project) exposes Assets too: it's where the

--- a/packages/web/test/asset-sort.test.tsx
+++ b/packages/web/test/asset-sort.test.tsx
@@ -1,0 +1,104 @@
+// Sort control on the Assets page: the "Newest first" caption + popover
+// (Newest / Oldest / Alphabetical), the grid re-ordering client-side, and the
+// `sort` URL search param tracking the selection (absent for the default).
+// Component tier — no layout/scroll/viewport dependency.
+
+import type { AssetSortOrder } from '@hezo/shared';
+import { waitFor } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+import { type SeededWorkspace, seedAsset, seedProject, seedWorkspace } from './helpers/seed';
+
+async function setup() {
+	let ws!: SeededWorkspace;
+	const ref = { slug: '' };
+	const helpers = await renderApp({
+		initialPath: '/',
+		seed: async (ctx) => {
+			ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Sortable Assets' });
+			ref.slug = project.slug;
+			// Names deliberately differ from creation order so all three sorts
+			// produce distinct sequences.
+			const banana = await seedAsset(ws, project, { filename: 'banana.png' });
+			const apple = await seedAsset(ws, project, { filename: 'apple.png' });
+			const cherry = await seedAsset(ws, project, { filename: 'cherry.png' });
+			// Pin created_at so date ordering is deterministic (uploads share now()).
+			await ctx.db.query(`UPDATE assets SET created_at = $1 WHERE id = $2`, [
+				'2026-01-03T00:00:00.000Z',
+				banana.id,
+			]);
+			await ctx.db.query(`UPDATE assets SET created_at = $1 WHERE id = $2`, [
+				'2026-01-02T00:00:00.000Z',
+				apple.id,
+			]);
+			await ctx.db.query(`UPDATE assets SET created_at = $1 WHERE id = $2`, [
+				'2026-01-01T00:00:00.000Z',
+				cherry.id,
+			]);
+		},
+	});
+	return { ...helpers, ref };
+}
+
+function cardOrder(container: HTMLElement): string[] {
+	return Array.from(container.querySelectorAll('[data-testid="asset-card"]')).map(
+		(el) => el.getAttribute('data-filename') ?? '',
+	);
+}
+
+test('the sort control reorders the grid and its caption tracks the selection', async () => {
+	const r = await setup();
+	await r.router.navigate({ to: '/projects/$projectId/assets', params: { projectId: r.ref.slug } });
+
+	// Default is Newest first: caption says so and the newest asset leads.
+	await r.findByText('banana.png', undefined, { timeout: 15_000 });
+	expect((await r.findByTestId('asset-sort-text')).textContent).toBe('Newest first');
+	await waitFor(() =>
+		expect(cardOrder(r.container)).toEqual(['banana.png', 'apple.png', 'cherry.png']),
+	);
+
+	// Switch to Oldest first via the popover.
+	await r.user.click(await r.findByTestId('asset-sort-button'));
+	await r.user.click(await r.findByTestId('asset-sort-option-oldest'));
+	expect((await r.findByTestId('asset-sort-text')).textContent).toBe('Oldest first');
+	await waitFor(() =>
+		expect(cardOrder(r.container)).toEqual(['cherry.png', 'apple.png', 'banana.png']),
+	);
+	// The non-default sort is reflected in the URL.
+	expect((r.router.state.location.search as { sort?: string }).sort).toBe('oldest');
+
+	// Alphabetical orders by filename.
+	await r.user.click(await r.findByTestId('asset-sort-button'));
+	await r.user.click(await r.findByTestId('asset-sort-option-alphabetical'));
+	expect((await r.findByTestId('asset-sort-text')).textContent).toBe('Alphabetical');
+	await waitFor(() =>
+		expect(cardOrder(r.container)).toEqual(['apple.png', 'banana.png', 'cherry.png']),
+	);
+	expect((r.router.state.location.search as { sort?: string }).sort).toBe('alphabetical');
+
+	// Back to Newest drops the param entirely (default carries no URL noise).
+	await r.user.click(await r.findByTestId('asset-sort-button'));
+	await r.user.click(await r.findByTestId('asset-sort-option-newest'));
+	await waitFor(() =>
+		expect(cardOrder(r.container)).toEqual(['banana.png', 'apple.png', 'cherry.png']),
+	);
+	expect((r.router.state.location.search as { sort?: string }).sort).toBeUndefined();
+});
+
+test('an invalid sort search param falls back to Newest first', async () => {
+	const r = await setup();
+	await r.router.navigate({
+		to: '/projects/$projectId/assets',
+		params: { projectId: r.ref.slug },
+		// Cast simulates a hand-typed URL carrying an invalid ?sort= value, which
+		// validateSearch must drop back to the default.
+		search: { sort: 'bogus' as AssetSortOrder },
+	});
+
+	await r.findByText('banana.png', undefined, { timeout: 15_000 });
+	expect((await r.findByTestId('asset-sort-text')).textContent).toBe('Newest first');
+	await waitFor(() =>
+		expect(cardOrder(r.container)).toEqual(['banana.png', 'apple.png', 'cherry.png']),
+	);
+});


### PR DESCRIPTION
## What & why

The Assets grid was fixed to newest-first with no way to reorder. This adds a **sort control** beside the existing active/all filter, offering **Newest first** (default), **Oldest first**, and **Alphabetical**.

Mockup that was reviewed and approved before implementation: https://claude.ai/code/artifact/d93e843d-de8f-4466-a6a8-6949822a3e36

## How it works

- **Shared source of truth** — `AssetSortOrder` enum + `compareAssetsForSort` comparator (`packages/shared/src/types/common.ts`). Every ordering surface mirrors this: Newest → `created_at DESC`, Oldest → `created_at ASC`, Alphabetical → filename A→Z (case-insensitive), each with a deterministic tiebreak.
- **Web** — a new `AssetSortControl` popover mirroring the existing `AssetFilterControl` (caption + icon button + option list with a check on the selected). The grid sorts **client-side** — the full list is already fetched, so switching is instant with no refetch — and the choice persists in a `sort` URL search param that collapses to nothing for the Newest default (exactly like the archive `filter` param). Folders keep their own alphabetical order; the sort applies to files.
- **API / MCP** — `GET /projects/:projectId/assets` and the `list_project_assets` MCP tool accept an optional `sort` param, ordering in SQL via a shared `assetSortOrderBy` helper (`packages/server/src/lib/asset-sort.ts`) that mirrors the comparator. Unknown/absent values fall back to Newest, so existing behaviour is unchanged.

## Docs

- Regenerated `docs/reference/mcp-api.md` (the `list_project_assets` param table + description) via `bun run build:docs`.
- Documented the control in the user-facing `docs/concepts/assets.md`.

## Tests

- **shared** — `compareAssetsForSort` (all three orders + tiebreaks + case-insensitivity) and `isAssetSortOrder`.
- **server** — REST default/`?sort=oldest`/`?sort=alphabetical`/invalid-fallback, plus `list_project_assets` sort and filter+sort composition.
- **web component** — grid re-orders through each option, caption tracks the selection, and the `sort` URL param updates (absent for the default); invalid-param fallback.

Verified locally: full typecheck, biome, and the shared/server/web asset test tiers pass; MCP-reference / llms.txt / docs-bundle drift tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012pCyNXiTybbWm8TpDUzd1f

---
_Generated by [Claude Code](https://claude.ai/code/session_012pCyNXiTybbWm8TpDUzd1f)_