### PR TITLE
docs(readme): surface deploy buttons at the top + make GCP one-click

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@
 </div>
 
 <p align="center">
+  <a href="https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/hezo-ai/hezo&cloudshell_workspace=deploy/gcp&cloudshell_tutorial=tutorial.md"><img src="https://img.shields.io/badge/Deploy_on-Google_Cloud-4285F4?style=for-the-badge&logo=googlecloud&logoColor=white" alt="Deploy on Google Cloud" height="28" /></a>
+  <a href="./deploy/aws/README.md"><img src="https://img.shields.io/badge/Deploy_on-AWS-FF9900?style=for-the-badge&logo=amazonwebservices&logoColor=white" alt="Deploy on AWS" height="28" /></a>
+  <a href="./docs/deployment/one-click.md"><img src="https://img.shields.io/badge/Deploy_on-DigitalOcean-0080FF?style=for-the-badge&logo=digitalocean&logoColor=white" alt="Deploy on DigitalOcean" height="28" /></a>
+</p>
+
+<p align="center">
   <strong>Your own AI workforce. Built to ship.</strong>
 </p>
 
@@ -87,7 +93,7 @@ VM in a couple of minutes. Each provisions Docker, the binary, automatic HTTPS
 firewall, and drops you at the in-browser setup.
 
 <p>
-  <a href="./deploy/gcp/README.md"><img src="https://img.shields.io/badge/Deploy_on-Google_Cloud-4285F4?style=for-the-badge&logo=googlecloud&logoColor=white" alt="Deploy on Google Cloud" height="34" /></a>
+  <a href="https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/hezo-ai/hezo&cloudshell_workspace=deploy/gcp&cloudshell_tutorial=tutorial.md"><img src="https://img.shields.io/badge/Deploy_on-Google_Cloud-4285F4?style=for-the-badge&logo=googlecloud&logoColor=white" alt="Deploy on Google Cloud" height="34" /></a>
   <a href="./deploy/aws/README.md"><img src="https://img.shields.io/badge/Deploy_on-AWS-FF9900?style=for-the-badge&logo=amazonwebservices&logoColor=white" alt="Deploy on AWS" height="34" /></a>
   <a href="./docs/deployment/one-click.md"><img src="https://img.shields.io/badge/Deploy_on-DigitalOcean-0080FF?style=for-the-badge&logo=digitalocean&logoColor=white" alt="Deploy on DigitalOcean" height="34" /></a>
 </p>


### PR DESCRIPTION
## What & why

Follow-up to #723. Two small README changes:

1. **Deploy buttons at the top.** The Google Cloud / AWS / DigitalOcean button row now also appears directly under the build/coverage/license badges at the top of the README, so it's visible without scrolling. The existing **Deploy to a cloud server** section is kept as-is.

2. **Google Cloud is now a real one-click.** Both Google Cloud badges (top row + the deploy section) previously linked to `deploy/gcp/README.md`, which was inconsistent with the prose that calls it "one-click today." They now link to the live **Cloud Shell** URL, which runs the deploy straight from the repo with no external hosting.

The **AWS** and **DigitalOcean** badges intentionally still link to their guides — their fully-hosted buttons require the CloudFormation template to be published to a public S3 URL and the DigitalOcean Marketplace image to be listed, respectively. They flip to real one-click buttons once that external hosting exists.

## Notes

- README-only change; no code, tests, or generated surfaces affected.
- Branch is a fresh cut from `main` (which already includes the merged #723) rather than a reuse of the merged branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N2uNcmo9ZemshzbfQ6kkQk)_