### PR TITLE
Telegram chat channel + multi-threaded CEO conversations (Discord deferred)

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -223,6 +223,31 @@ links files sent through the chatbox to their message (stored in the HQ asset li
 under `uploads/chat/`), and `chat_memories` holds each chat-enabled agent's
 automatically-maintained long-term memory (§ 4).
 
+**Multi-thread conversations & external channels.** The CEO chat is **multi-threaded**:
+`chat_conversations` is keyed by `(member_id, channel, external_thread_id)` (a partial
+unique index scoped to open threads via `closed_at`), so the web chatbox has a thread
+switcher and each external thread maps to its own conversation. The warm container
+(`chat_sessions`) stays a **single shared lease** per CEO member — a thread is only
+message-grouping + rolling window + memory scope, and each turn is a stateless one-shot
+`docker exec` reading a per-turn prompt file, so N threads run as N independent execs into
+the one container. Long-term memory (`chat_memories`) stays **per-agent** (shared across a
+member's threads); compaction serialises at the member level so concurrent threads never
+clobber the shared memory row. External channels (Telegram now, Discord later —
+`.dev/discord-chat-adapter.md`) are built on a **channel-adapter registry**
+(`services/chat-channels/`): a `ChatChannelAdapter` owns everything platform-specific
+(inbound parse, outbound deliver, thread create/close, transport lifecycle), and the
+manager/routes resolve a channel only through the registry — a new app is one adapter file.
+Inbound arrives at a generic public webhook `POST /webhooks/chat/:channel/:secret` (mounted
+before bearer auth; per-channel shared-secret, constant-time compared) → `parseInbound` →
+`ingestInboundEvent`, which enforces the **identity allowlist** (`chat_identity_links` maps
+`(channel, external_user_id)` → a Hezo user; unlinked senders are ignored/prompted to link)
+before routing the message to `ChatSessionManager.sendTurn`. Per-channel bot config lives in
+`chat_channel_configs` (fully generic — the bot token is a `secrets`-vault reference, all
+channel-specific settings in `metadata` jsonb). **The bot token is decrypted in-process by
+trusted server code and outbound bot API calls go direct** (`api.telegram.org`, …), NOT
+through the agent egress proxy — the `__HEZO_SECRET__`/proxy mechanism is for agent *runs*,
+whose threat model differs from the server authenticating its own calls.
+
 **Costs & budgets.** `cost_entries` is the immutable per-run spend ledger, attributed to
 the AI provider config that produced it — **never** team-scoped. `model_pricing` holds
 per-model token rates from a single source: the pricepertoken.com MCP catalog

--- a/.dev/discord-chat-adapter.md
+++ b/.dev/discord-chat-adapter.md
@@ -1,0 +1,76 @@
+# Deferred: Discord chat channel adapter
+
+Discord is a planned CEO-chat avenue, deliberately **not built yet**. The generic
+channel-adapter core (`packages/server/src/services/chat-channels/`) was designed so
+Discord slots in as **one adapter file + one additive enum migration**, with no
+changes to the manager, the conversation model, the generic webhook route, the
+identity allowlist, or the web core. This doc is the shovel-ready plan.
+
+Telegram (webhook transport) was shipped first because it needs no long-lived
+connection and no single-instance ownership. Discord validates the same
+`ChatChannelAdapter` interface against the hard case: a persistent gateway.
+
+## What building it entails
+
+1. **Enum migration (additive).** Add `discord` to the `chat_channel` enum — take the
+   next free migration number at that time:
+   ```sql
+   ALTER TYPE chat_channel ADD VALUE IF NOT EXISTS 'discord';
+   ```
+   Add `Discord: 'discord'` to `ChatChannel` in `packages/shared/src/types/common.ts`,
+   and ship a `migrate-NNN-add-discord-channel.test.ts` (copy the pattern of
+   `packages/server/test/migrate-027-add-api-connector-transport.test.ts`). No other
+   schema change: `chat_channel_configs.metadata` already holds channel-specific
+   settings (Discord application id, guild id), and `chat_identity_links` /
+   `chat_conversations` are already channel-agnostic.
+
+2. **Adapter** `packages/server/src/services/chat-channels/discord.ts` implementing
+   `ChatChannelAdapter`, plus a Gateway transport. Register it in
+   `buildChatChannelRegistry` (`chat-channels/index.ts`). The generic adapter-start
+   loop (`registry.startAll()` on unlock, in `startup.ts`) brings it online for an
+   enabled config — no Discord special-case in startup.
+   - `start()`: open a WebSocket to `wss://gateway.discord.gg`, send IDENTIFY with the
+     `GUILD_MESSAGES | MESSAGE_CONTENT` intents, handle the hello/heartbeat interval,
+     RESUME on reconnect (store `session_id` + last sequence), exponential backoff on
+     close. Fatal close codes (4004 auth failed, 4014 disallowed intent) disable the
+     config and surface a UI error rather than hot-looping.
+   - `stop()`: close the gateway connection.
+   - `parseInbound(raw)`: a `MESSAGE_CREATE` event → `{ externalUserId: author.id,
+     externalThreadId: channel_id (or thread id), text }`; ignore the bot's own
+     messages. Feed the result to the shared `ingestInboundEvent` (same path Telegram
+     uses) via the gateway's message handler.
+   - `deliver(reply)`: `POST /channels/{id}/messages` with the in-process-decrypted bot
+     token (direct to `discord.com`, not the egress proxy — same trusted-server
+     rationale as Telegram; the token is stored scoped to `discord.com`, see
+     `CHANNEL_HOST` in `routes/chat-channels.ts`).
+   - `createThread(title)` / `closeThread(id)`: native Discord thread start / archive
+     (`POST /channels/{id}/threads`, `PATCH` archived=true); store the created thread
+     id as the conversation's `external_thread_id`.
+
+3. **Single-instance ownership (the key risk).** A Gateway connection must run on
+   **exactly one process**. Hezo is single-process today (one `chatSessionManager`, one
+   HQ container), so this holds, but a future multi-instance deploy would open duplicate
+   gateways and deliver every message twice. Guard it with a DB advisory lock or a
+   `chat_channel_configs.metadata.gateway_owner` lease acquired in the adapter's
+   `start()`. Put the lease in the generic adapter-start path so **every** future
+   long-lived adapter inherits it.
+
+4. **Setup friction to document.** Message Content is a **privileged intent** — the
+   operator must enable it in the Discord developer portal, and it becomes
+   review-gated once the bot joins 100+ servers. Surface this in the config UI and the
+   docs page.
+
+5. **UI/docs deltas when built.** Add a Discord section to the chat-channels settings
+   page (`packages/web/src/routes/settings/chat-channels.tsx`) — application id + guild
+   id go into `metadata`. Add a "Chat from Discord" docs page under `docs/`. The
+   identity-link and conversation-lifecycle surfaces are already generic and need no
+   change.
+
+## What you do NOT touch
+
+The whole point of the abstraction: `ChatSessionManager`, `ingestInboundEvent`, the
+generic `POST /webhooks/chat/:channel/:secret` route (Discord uses the gateway, not the
+webhook, but the route stays as-is for webhook channels), `chat_conversations` /
+`chat_identity_links` / `chat_channel_configs`, and the web thread switcher all stay
+unchanged. If building Discord requires editing any of them, the abstraction has a gap
+worth fixing first.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,6 +277,17 @@ Never commit `.js`/`.d.ts`/`.js.map`/`.d.ts.map` alongside source. Compiled outp
 - Use shared constants/enums from `@hezo/shared` (`packages/shared/src/types/common.ts`) — no raw status/type strings. Add new enum values to the shared package first.
 - `bunx`, not `npx`.
 
+### Adding a chat channel adapter
+
+External chat avenues to the CEO (Telegram now, Discord later) are built on a **channel-adapter abstraction + registry** so a new app is one file, not a core change. The `ChatChannelAdapter` interface and registry live in `packages/server/src/services/chat-channels/`; the manager (`chat-session-manager.ts`), the generic inbound webhook route (`routes/chat-webhooks.ts` → `ingestInboundEvent`), the conversation model, and the web thread switcher are all **channel-agnostic** — they resolve a channel only through the registry, never by branching on a platform name. To add a channel:
+
+1. Add a `ChatChannel` enum value in `packages/shared/src/types/common.ts` **and** an additive `ALTER TYPE chat_channel ADD VALUE` migration (with a data-preservation test). *Telegram needed none — it was already in the enum; Discord will need one.*
+2. Implement a `ChatChannelAdapter` (`chat-channels/<channel>.ts`): `parseInbound` (raw event → `InboundChatEvent`), `deliver` (finalized reply → platform), optional `start`/`stop` (webhook registration or a gateway), optional `createThread`/`closeThread`, optional `promptToLink`/`render`. Register it in `buildChatChannelRegistry` (`chat-channels/index.ts`).
+3. Store all channel-specific settings in `chat_channel_configs.metadata` (jsonb) — **never add per-channel columns**. The bot token goes in the `secrets` vault (referenced by name) and is decrypted **in-process** by trusted server code, NOT via the agent egress proxy (that mechanism is for agent runs).
+4. Ship a registry-contract test (parse → `InboundChatEvent` shape, thread create/close no-op safety) plus the channel's own unit tests.
+
+**Do not touch** the manager, `ingestInboundEvent`, the generic webhook route, or the conversation/identity schema — if a new channel forces a change there, close the gap in the abstraction instead. `.dev/discord-chat-adapter.md` is the worked example (the deferred Discord adapter).
+
 ### User-facing docs terminology
 
 These rules apply to **user-facing prose** — the `docs/` tree and anything a Hezo operator reads — because the audience is users, not engineers. They do **not** force renames of code identifiers, DB columns, route paths, or internal comments.

--- a/docs/concepts/chat-channels.md
+++ b/docs/concepts/chat-channels.md
@@ -1,0 +1,54 @@
+---
+title: Chat & Telegram
+order: 18
+section: Concepts
+---
+
+# Chatting with the CEO
+
+The chatbox in the bottom-right corner is your direct, real-time line to the **CEO** —
+the global assistant that coordinates every project. Ask it what's blocked, have it spin
+up a project or a task, get a status read across the org, or just think out loud. It has
+long-term memory, so it remembers your preferences and past decisions across the
+conversation.
+
+## Conversation threads
+
+The chatbox supports **multiple parallel threads**, so you can keep separate lines of
+conversation going without them bleeding into each other — one for a launch you're
+planning, another for an ad-hoc question, and so on.
+
+- **Switch** threads with the dropdown at the top of the chatbox.
+- **New thread** with the **＋** button.
+- **Close** the active thread with the **✕** button (your main thread can't be closed).
+
+Each thread keeps its own recent history and streams independently.
+
+## Chatting from Telegram
+
+You can talk to the CEO from **Telegram** as well as the web app — handy when you're away
+from your desk. Set it up from **Settings → Chat channels**:
+
+1. **Create a bot.** In Telegram, message [@BotFather](https://t.me/BotFather), create a
+   bot, and copy its token.
+2. **Paste the token.** On the Chat channels page, paste the token into the Telegram
+   section, tick **Enabled**, and save. Hezo registers the inbound connection for you.
+3. **Link your account.** Only accounts you explicitly allow may chat. Find your Telegram
+   numeric user id (message [@userinfobot](https://t.me/userinfobot)), then add it under
+   **Allowed identities** — it links to your Hezo account. Anyone not on the allowlist is
+   ignored.
+
+Now message your bot and the CEO replies right in Telegram.
+
+### Threads in Telegram
+
+- A **private chat** with your bot is a single conversation.
+- For **multiple threads** in Telegram, add the bot to a **Topics-enabled supergroup** as
+  an admin with the **Manage topics** permission. Each topic becomes its own conversation,
+  mirrored alongside your web threads.
+
+Everything you say from Telegram lands in the same CEO chat you see in the web app, so you
+can start a thread on your phone and pick it up later in the browser.
+
+> **Security.** Your bot token is stored encrypted and is never exposed to agents. Only the
+> identities you add to the allowlist can chat — an unknown sender gets no reply.

--- a/packages/server/migrations/029_multi_conversation.sql
+++ b/packages/server/migrations/029_multi_conversation.sql
@@ -1,0 +1,35 @@
+-- Relax the single-global-conversation constraint so the CEO chat supports many
+-- parallel conversation threads: the existing web chatbox gains a thread switcher,
+-- and external channels (Telegram forum topics, later Discord threads) each map to
+-- their own conversation.
+--
+-- Until now `chat_conversations` held exactly one row per CEO member (the code
+-- resolved it "first row wins"). This migration keys a conversation by
+-- (member_id, channel, external_thread_id) instead:
+--   * channel            — which surface the thread lives on (web/telegram/…).
+--   * external_thread_id — the platform thread id (Telegram "<chat.id>:<topic>",
+--                          Discord channel/thread id); NULL for web threads.
+--   * last_activity_at   — drives ordering in the conversation list.
+--   * closed_at          — thread lifecycle (NULL = open, set = closed).
+--
+-- Purely additive. The pre-existing global row already has channel='web' and
+-- external_thread_id=NULL by the defaults below, so it simply becomes the default
+-- open web thread — no data move.
+ALTER TABLE chat_conversations
+    ADD COLUMN channel            chat_channel NOT NULL DEFAULT 'web',
+    ADD COLUMN external_thread_id TEXT,
+    ADD COLUMN last_activity_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    ADD COLUMN closed_at          TIMESTAMPTZ;
+
+-- Each *open* external thread resolves to exactly one conversation. Scoped to
+-- external_thread_id IS NOT NULL (web threads have no external id and may be many)
+-- and closed_at IS NULL (a closed thread must not block a fresh conversation if the
+-- same platform thread id is later reused).
+CREATE UNIQUE INDEX idx_chat_conversations_external
+    ON chat_conversations (member_id, channel, external_thread_id)
+    WHERE external_thread_id IS NOT NULL AND closed_at IS NULL;
+
+-- List ordering: newest activity first, open threads only.
+CREATE INDEX idx_chat_conversations_activity
+    ON chat_conversations (member_id, last_activity_at DESC)
+    WHERE closed_at IS NULL;

--- a/packages/server/migrations/030_chat_channels_and_identities.sql
+++ b/packages/server/migrations/030_chat_channels_and_identities.sql
@@ -1,0 +1,38 @@
+-- Two tables backing external chat channels (Telegram now, Discord later):
+--
+--   chat_channel_configs — per-channel bot configuration. Fully generic: the bot
+--     token lives in the `secrets` vault (referenced by name, never stored raw
+--     here) and all channel-specific settings live in `metadata` jsonb accessed via
+--     the channel adapter's own typed accessor — no per-channel columns, so a new
+--     channel is one adapter file, not a schema change.
+--
+--   chat_identity_links — the access allowlist. Only external senders explicitly
+--     mapped to a Hezo user may chat; unlinked senders are ignored/prompted to link.
+--     `user_id` targets the same `users(id)` as chat_messages.author_user_id, so a
+--     linked turn attributes to that user with no extra plumbing.
+CREATE TABLE chat_channel_configs (
+    channel          chat_channel PRIMARY KEY,
+    enabled          BOOLEAN NOT NULL DEFAULT false,
+    -- secrets.name of the encrypted bot token (decrypted in-process by trusted
+    -- server code — bot API calls go direct, not through the agent egress proxy).
+    bot_token_secret TEXT,
+    -- Shared secret echoed by webhook-style adapters (Telegram secret_token, etc.).
+    webhook_secret   TEXT,
+    -- All channel-specific settings (Discord app/guild id, Telegram group id, …).
+    metadata         JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE chat_identity_links (
+    id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    channel          chat_channel NOT NULL,
+    external_user_id TEXT NOT NULL,                              -- Telegram from.id / Discord author.id
+    user_id          UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    external_handle  TEXT,                                       -- display handle, for the UI
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    UNIQUE (channel, external_user_id)
+);
+
+CREATE INDEX idx_chat_identity_links_user ON chat_identity_links(user_id);

--- a/packages/server/src/lib/types.ts
+++ b/packages/server/src/lib/types.ts
@@ -4,6 +4,7 @@ import type { MasterKeyManager } from '../crypto/master-key';
 import type { Db } from '../db/database';
 import type { DomainEventBus } from '../events/bus';
 import type { AuthChallengeStore } from '../services/auth-challenges';
+import type { ChatChannelRegistry } from '../services/chat-channels';
 import type { ChatSessionManager } from '../services/chat-session-manager';
 import type { ContainerLogStreamer } from '../services/container-logs';
 import type { DockerClient } from '../services/docker';
@@ -57,6 +58,7 @@ export type Env = {
 		events: DomainEventBus;
 		jobManager: JobManager;
 		chatSessionManager?: ChatSessionManager;
+		chatChannelRegistry?: ChatChannelRegistry;
 		logs: LogStreamBroker;
 		containerLogStreamer: ContainerLogStreamer;
 		auth: AuthInfo;

--- a/packages/server/src/routes/chat-channels.ts
+++ b/packages/server/src/routes/chat-channels.ts
@@ -1,0 +1,195 @@
+import { randomUUID } from 'node:crypto';
+import { type ChatChannel, isChatChannel } from '@hezo/shared';
+import { Hono } from 'hono';
+import { encrypt } from '../crypto/encryption';
+import { err, ok } from '../lib/response';
+import type { Env } from '../lib/types';
+import { logger } from '../logger';
+import { requireAdminEquivalent } from '../middleware/auth';
+
+const log = logger.child('chat-channels-routes');
+
+/**
+ * Operator/admin surface for configuring external chat channels (bot config) and
+ * the identity allowlist. These are superuser-only and channel-agnostic — every
+ * mutation resolves the channel through the adapter registry, so a new channel
+ * needs no route changes. There is no agent-facing MCP equivalent.
+ */
+export const chatChannelRoutes = new Hono<Env>();
+
+/** Upstream host a channel's bot token is scoped to in the secrets vault. */
+const CHANNEL_HOST: Record<string, string> = {
+	telegram: 'api.telegram.org',
+	discord: 'discord.com',
+};
+
+/** Canonical secrets-vault name for a channel's bot token, e.g. TELEGRAM_BOT_TOKEN. */
+function botTokenSecretName(channel: ChatChannel): string {
+	return `${channel.toUpperCase()}_BOT_TOKEN`;
+}
+
+chatChannelRoutes.get('/chat/channels', async (c) => {
+	const denied = requireAdminEquivalent(c);
+	if (denied) return denied;
+	const rows = await c.get('db').query<{
+		channel: string;
+		enabled: boolean;
+		bot_token_secret: string | null;
+		webhook_secret: string | null;
+		metadata: Record<string, unknown>;
+		updated_at: string;
+	}>(
+		`SELECT channel, enabled, bot_token_secret, webhook_secret, metadata, updated_at
+		 FROM chat_channel_configs ORDER BY channel`,
+	);
+	// Never return the raw token or webhook secret — just whether they're set.
+	return ok(c, {
+		channels: rows.rows.map((r) => ({
+			channel: r.channel,
+			enabled: r.enabled,
+			has_token: !!r.bot_token_secret,
+			has_webhook: !!r.webhook_secret,
+			metadata: r.metadata ?? {},
+			updated_at: r.updated_at,
+		})),
+	});
+});
+
+// Configure a channel: store the bot token in the secrets vault, upsert the config
+// row, and bring the adapter online (or offline when disabled).
+chatChannelRoutes.put('/chat/channels/:channel', async (c) => {
+	const denied = requireAdminEquivalent(c);
+	if (denied) return denied;
+	const channelParam = c.req.param('channel');
+	if (!isChatChannel(channelParam) || channelParam === 'web') {
+		return err(c, 'INVALID_REQUEST', 'unknown external channel', 400);
+	}
+	const channel: ChatChannel = channelParam;
+
+	const db = c.get('db');
+	const masterKeyManager = c.get('masterKeyManager');
+	const key = masterKeyManager.getKey();
+	if (!key) return err(c, 'LOCKED', 'Server must be unlocked to configure channels', 401);
+
+	const body = await c.req.json<{
+		enabled?: boolean;
+		bot_token?: string;
+		metadata?: Record<string, unknown>;
+	}>();
+	const enabled = !!body.enabled;
+	const metadata = body.metadata ?? {};
+
+	// Store/rotate the bot token in the vault when provided, scoped to the platform
+	// host. Trusted server code decrypts it in-process for outbound API calls.
+	let botTokenSecret: string | null = null;
+	if (body.bot_token?.trim()) {
+		const name = botTokenSecretName(channel);
+		await db.query(
+			`INSERT INTO secrets (name, encrypted_value, category, allowed_hosts, allow_all_hosts, allow_body_substitution)
+			 VALUES ($1, $2, 'api_token', $3, false, false)
+			 ON CONFLICT (name) DO UPDATE SET encrypted_value = EXCLUDED.encrypted_value, updated_at = now()`,
+			[name, encrypt(body.bot_token.trim(), key), [CHANNEL_HOST[channel] ?? '']],
+		);
+		botTokenSecret = name;
+	}
+
+	// Reuse an existing webhook secret if present; otherwise mint one on first setup.
+	const existing = await db.query<{
+		webhook_secret: string | null;
+		bot_token_secret: string | null;
+	}>(`SELECT webhook_secret, bot_token_secret FROM chat_channel_configs WHERE channel = $1`, [
+		channel,
+	]);
+	const webhookSecret = existing.rows[0]?.webhook_secret ?? randomUUID().replace(/-/g, '');
+	if (!botTokenSecret) botTokenSecret = existing.rows[0]?.bot_token_secret ?? null;
+
+	await db.query(
+		`INSERT INTO chat_channel_configs (channel, enabled, bot_token_secret, webhook_secret, metadata)
+		 VALUES ($1, $2, $3, $4, $5::jsonb)
+		 ON CONFLICT (channel) DO UPDATE
+		 SET enabled = EXCLUDED.enabled, bot_token_secret = EXCLUDED.bot_token_secret,
+		     webhook_secret = EXCLUDED.webhook_secret, metadata = EXCLUDED.metadata, updated_at = now()`,
+		[channel, enabled, botTokenSecret, webhookSecret, JSON.stringify(metadata)],
+	);
+
+	// Bring the adapter online/offline to match. Best-effort — surfaced via logs; the
+	// config is already persisted so a retry (or restart) reconciles.
+	const adapter = c.get('chatChannelRegistry')?.get(channel);
+	if (adapter) {
+		await (enabled ? adapter.start() : adapter.stop()).catch((e) =>
+			log.error(`failed to ${enabled ? 'start' : 'stop'} ${channel}`, e),
+		);
+	}
+	return ok(c, { channel, enabled, has_token: !!botTokenSecret });
+});
+
+// Disable a channel and take its adapter offline.
+chatChannelRoutes.delete('/chat/channels/:channel', async (c) => {
+	const denied = requireAdminEquivalent(c);
+	if (denied) return denied;
+	const channelParam = c.req.param('channel');
+	if (!isChatChannel(channelParam)) return err(c, 'NOT_FOUND', 'unknown channel', 404);
+	const channel: ChatChannel = channelParam;
+	await c
+		.get('db')
+		.query(
+			`UPDATE chat_channel_configs SET enabled = false, updated_at = now() WHERE channel = $1`,
+			[channel],
+		);
+	const adapter = c.get('chatChannelRegistry')?.get(channel);
+	if (adapter) await adapter.stop().catch((e) => log.error(`failed to stop ${channel}`, e));
+	return ok(c, { channel, enabled: false });
+});
+
+// --- Identity allowlist ---
+
+chatChannelRoutes.get('/chat/identities', async (c) => {
+	const denied = requireAdminEquivalent(c);
+	if (denied) return denied;
+	const rows = await c.get('db').query(
+		`SELECT l.id, l.channel, l.external_user_id, l.external_handle, l.user_id, u.display_name, l.created_at
+		 FROM chat_identity_links l JOIN users u ON u.id = l.user_id
+		 ORDER BY l.created_at DESC`,
+	);
+	return ok(c, { identities: rows.rows });
+});
+
+chatChannelRoutes.post('/chat/identities', async (c) => {
+	const denied = requireAdminEquivalent(c);
+	if (denied) return denied;
+	const body = await c.req.json<{
+		channel?: string;
+		external_user_id?: string;
+		user_id?: string;
+		external_handle?: string;
+	}>();
+	if (!body.channel || !isChatChannel(body.channel) || body.channel === 'web') {
+		return err(c, 'INVALID_REQUEST', 'a valid external channel is required', 400);
+	}
+	if (!body.external_user_id?.trim() || !body.user_id?.trim()) {
+		return err(c, 'INVALID_REQUEST', 'external_user_id and user_id are required', 400);
+	}
+	const db = c.get('db');
+	const user = await db.query(`SELECT 1 FROM users WHERE id = $1`, [body.user_id]);
+	if (user.rows.length === 0) return err(c, 'NOT_FOUND', 'user not found', 404);
+	try {
+		const r = await db.query<{ id: string }>(
+			`INSERT INTO chat_identity_links (channel, external_user_id, user_id, external_handle)
+			 VALUES ($1, $2, $3, $4) RETURNING id`,
+			[body.channel, body.external_user_id.trim(), body.user_id, body.external_handle ?? null],
+		);
+		return ok(c, { id: r.rows[0].id }, 201);
+	} catch {
+		return err(c, 'CONFLICT', 'that identity is already linked', 409);
+	}
+});
+
+chatChannelRoutes.delete('/chat/identities/:id', async (c) => {
+	const denied = requireAdminEquivalent(c);
+	if (denied) return denied;
+	const r = await c
+		.get('db')
+		.query(`DELETE FROM chat_identity_links WHERE id = $1 RETURNING id`, [c.req.param('id')]);
+	if (r.rows.length === 0) return err(c, 'NOT_FOUND', 'identity link not found', 404);
+	return ok(c, { deleted: true });
+});

--- a/packages/server/src/routes/chat-webhooks.ts
+++ b/packages/server/src/routes/chat-webhooks.ts
@@ -1,0 +1,75 @@
+import { timingSafeEqual } from 'node:crypto';
+import { type ChatChannel, isChatChannel } from '@hezo/shared';
+import { Hono } from 'hono';
+import { trackBackground } from '../lib/background';
+import { err, ok } from '../lib/response';
+import type { Env } from '../lib/types';
+import { logger } from '../logger';
+import { ingestInboundEvent } from '../services/chat-channels';
+import { loadChannelConfig } from '../services/chat-channels/types';
+
+const log = logger.child('chat-webhooks');
+
+/**
+ * Public inbound webhook surface for external chat channels. Mounted BEFORE the
+ * `/api/*` auth middleware — inbound platform requests carry no Hezo bearer token,
+ * so each is authenticated by a per-channel shared secret in the URL (and, where
+ * the platform supports it, a header the adapter also set at registration time).
+ *
+ * A single generic route serves every webhook-style channel: it verifies the
+ * secret against `chat_channel_configs.webhook_secret`, then hands the raw body to
+ * the channel adapter's `parseInbound` and the shared `ingestInboundEvent`. No
+ * per-channel route files.
+ */
+export const chatWebhookRoutes = new Hono<Env>();
+
+/** Constant-time string compare that tolerates unequal lengths without throwing. */
+function safeEqual(a: string, b: string): boolean {
+	const ab = Buffer.from(a);
+	const bb = Buffer.from(b);
+	if (ab.length !== bb.length) return false;
+	return timingSafeEqual(ab, bb);
+}
+
+chatWebhookRoutes.post('/webhooks/chat/:channel/:secret', async (c) => {
+	const channelParam = c.req.param('channel');
+	if (!isChatChannel(channelParam)) return err(c, 'NOT_FOUND', 'unknown channel', 404);
+	const channel: ChatChannel = channelParam;
+
+	const db = c.get('db');
+	const registry = c.get('chatChannelRegistry');
+	const manager = c.get('chatSessionManager');
+	if (!registry || !manager) return err(c, 'UNAVAILABLE', 'chat channels unavailable', 503);
+
+	const adapter = registry.get(channel);
+	if (!adapter) return err(c, 'NOT_FOUND', 'channel not configured', 404);
+
+	const config = await loadChannelConfig(
+		{ db, masterKeyManager: c.get('masterKeyManager') },
+		channel,
+	);
+	if (!config?.enabled || !config.webhookSecret) {
+		return err(c, 'NOT_FOUND', 'channel not enabled', 404);
+	}
+
+	// Authenticate: the URL secret must match, and (Telegram) the secret-token
+	// header when present. Both are constant-time compared.
+	const urlSecret = c.req.param('secret');
+	const headerSecret = c.req.header('x-telegram-bot-api-secret-token');
+	const urlOk = safeEqual(urlSecret, config.webhookSecret);
+	const headerOk = headerSecret ? safeEqual(headerSecret, config.webhookSecret) : true;
+	if (!urlOk || !headerOk) return err(c, 'UNAUTHORIZED', 'invalid webhook secret', 401);
+
+	const raw = await c.req.json().catch(() => null);
+	const event = raw ? adapter.parseInbound(raw) : null;
+	// Ack quickly (platforms retry on non-2xx / slow responses); do the turn in the
+	// background so a slow CEO reply never times out the webhook.
+	if (event) {
+		trackBackground(
+			ingestInboundEvent({ db, manager }, adapter, event).catch((e) =>
+				log.error('inbound chat ingest failed', e),
+			),
+		);
+	}
+	return ok(c, { received: true });
+});

--- a/packages/server/src/routes/chat.ts
+++ b/packages/server/src/routes/chat.ts
@@ -36,6 +36,24 @@ async function resolveHqProjectId(db: Db): Promise<string | null> {
 	return r.rows[0]?.id ?? null;
 }
 
+/**
+ * Resolve the target conversation for a request: an explicit `conversation_id`
+ * (validated to exist), or the default web thread. Returns null when an explicit
+ * id doesn't resolve, so the caller can 404.
+ */
+async function resolveConversationId(
+	c: Context<Env>,
+	explicit: string | undefined,
+): Promise<string | null> {
+	const manager = c.get('chatSessionManager');
+	if (!manager) return null;
+	if (explicit) {
+		const convo = await manager.getConversation(explicit);
+		return convo ? convo.id : null;
+	}
+	return manager.getConversationId();
+}
+
 /** Merge each message's file attachments (signed URLs) onto the row for the client. */
 async function withAttachments(
 	c: Context<Env>,
@@ -52,7 +70,8 @@ chatRoutes.get('/chat/conversation', async (c) => {
 
 	const manager = c.get('chatSessionManager');
 	if (!manager) return err(c, 'UNAVAILABLE', 'CEO chat is not available', 503);
-	const conversationId = await manager.getConversationId();
+	const conversationId = await resolveConversationId(c, c.req.query('conversation_id'));
+	if (!conversationId) return err(c, 'NOT_FOUND', 'conversation not found', 404);
 
 	// The chatbox shows the active window — the non-compacted messages. Older
 	// messages have been summarized into long-term memory and dropped. The window
@@ -84,7 +103,8 @@ chatRoutes.get('/chat/messages', async (c) => {
 
 	const manager = c.get('chatSessionManager');
 	if (!manager) return err(c, 'UNAVAILABLE', 'CEO chat is not available', 503);
-	const conversationId = await manager.getConversationId();
+	const conversationId = await resolveConversationId(c, c.req.query('conversation_id'));
+	if (!conversationId) return err(c, 'NOT_FOUND', 'conversation not found', 404);
 
 	const limit = clampLimit(c.req.query('limit'));
 	const before = c.req.query('before');
@@ -168,22 +188,67 @@ chatRoutes.post('/chat/messages', async (c) => {
 
 	const auth = c.get('auth');
 	const authorUserId = auth.type === AuthType.Admin ? auth.userId : null;
+	// An explicit thread from the switcher; omit for the default web thread.
+	const conversationId =
+		typeof body.conversation_id === 'string' ? body.conversation_id : undefined;
 
 	try {
 		const result = await manager.sendTurn({
 			text,
 			channel: ChatChannel.Web,
+			conversationId,
 			authorUserId,
 			attachmentIds,
 		});
 		return ok(
 			c,
-			{ user_message_id: result.userMessageId, assistant_message_id: result.assistantMessageId },
+			{
+				user_message_id: result.userMessageId,
+				assistant_message_id: result.assistantMessageId,
+				conversation_id: result.conversationId,
+			},
 			201,
 		);
 	} catch (e) {
 		return err(c, 'CEO_UNAVAILABLE', (e as Error).message, 503);
 	}
+});
+
+// List conversation threads (open by default), newest activity first — drives the
+// web thread switcher.
+chatRoutes.get('/chat/conversations', async (c) => {
+	const access = await authorize(c);
+	if (access instanceof Response) return access;
+	const manager = c.get('chatSessionManager');
+	if (!manager) return err(c, 'UNAVAILABLE', 'CEO chat is not available', 503);
+	const includeClosed = c.req.query('include_closed') === 'true';
+	return ok(c, { conversations: await manager.listConversations({ includeClosed }) });
+});
+
+// Create a new web conversation thread (the new-thread button).
+chatRoutes.post('/chat/conversations', async (c) => {
+	const access = await authorize(c);
+	if (access instanceof Response) return access;
+	const manager = c.get('chatSessionManager');
+	if (!manager) return err(c, 'UNAVAILABLE', 'CEO chat is not available', 503);
+	const body = await c.req.json().catch(() => ({}));
+	const title = typeof body.title === 'string' && body.title.trim() ? body.title.trim() : undefined;
+	const id = await manager.createWebConversation(title);
+	const conversation = await manager.getConversation(id);
+	return ok(c, { conversation }, 201);
+});
+
+// Close a conversation thread.
+chatRoutes.post('/chat/conversations/:id/close', async (c) => {
+	const access = await authorize(c);
+	if (access instanceof Response) return access;
+	const manager = c.get('chatSessionManager');
+	if (!manager) return err(c, 'UNAVAILABLE', 'CEO chat is not available', 503);
+	const id = c.req.param('id');
+	const convo = await manager.getConversation(id);
+	if (!convo) return err(c, 'NOT_FOUND', 'conversation not found', 404);
+	await manager.closeConversation(id);
+	return ok(c, { closed: true });
 });
 
 chatRoutes.post('/chat/session/restart', async (c) => {

--- a/packages/server/src/routes/me.ts
+++ b/packages/server/src/routes/me.ts
@@ -12,5 +12,8 @@ export const meRoutes = new Hono<Env>();
 meRoutes.get('/me', (c) => {
 	const auth = c.get('auth');
 	const isSuperuser = auth.type === AuthType.Admin ? auth.isSuperuser : false;
-	return ok(c, { type: auth.type, is_superuser: isSuperuser });
+	// The human user's id (Admin only) — used to link an external chat identity to
+	// the current operator on the chat-channels settings page.
+	const userId = auth.type === AuthType.Admin ? auth.userId : null;
+	return ok(c, { type: auth.type, is_superuser: isSuperuser, user_id: userId });
 });

--- a/packages/server/src/services/chat-channels/index.ts
+++ b/packages/server/src/services/chat-channels/index.ts
@@ -1,0 +1,43 @@
+import type { ChatChannel } from '@hezo/shared';
+import type { ChatSessionManager } from '../chat-session-manager';
+import { ChatChannelRegistry } from './registry';
+import { TelegramAdapter } from './telegram';
+import type { ChatChannelAdapterDeps } from './types';
+
+export { type IngestDeps, ingestInboundEvent } from './ingest';
+export { ChatChannelRegistry } from './registry';
+export type { ChatChannelAdapter, InboundChatEvent } from './types';
+
+/**
+ * Build the channel-adapter registry with every shipped adapter registered.
+ * Adding a channel = register one more adapter here (plus its adapter file).
+ */
+export function buildChatChannelRegistry(deps: ChatChannelAdapterDeps): ChatChannelRegistry {
+	const registry = new ChatChannelRegistry();
+	registry.register(new TelegramAdapter(deps));
+	return registry;
+}
+
+/**
+ * Wire the manager's external-channel hooks to the registry, so a finalized reply
+ * on an external thread is delivered through that channel's adapter, and closing a
+ * conversation closes the platform thread. The manager stays channel-agnostic —
+ * it only knows the `ChatChannel` enum value, never a specific platform.
+ */
+export function wireManagerToChannels(
+	manager: ChatSessionManager,
+	registry: ChatChannelRegistry,
+): void {
+	manager.setChannelHooks({
+		delivery: async (ctx, content, status) => {
+			if (!ctx.externalThreadId) return;
+			const adapter = registry.get(ctx.channel);
+			if (!adapter) return;
+			await adapter.deliver({ externalThreadId: ctx.externalThreadId, content, status });
+		},
+		closeThread: async (channel: ChatChannel, externalThreadId: string) => {
+			const adapter = registry.get(channel);
+			if (adapter?.closeThread) await adapter.closeThread(externalThreadId);
+		},
+	});
+}

--- a/packages/server/src/services/chat-channels/ingest.ts
+++ b/packages/server/src/services/chat-channels/ingest.ts
@@ -1,0 +1,61 @@
+import type { ChatChannel } from '@hezo/shared';
+import type { Db } from '../../db/database';
+import { logger } from '../../logger';
+import type { ChatSessionManager } from '../chat-session-manager';
+import type { ChatChannelAdapter, InboundChatEvent } from './types';
+
+const log = logger.child('chat-channels');
+
+export interface IngestDeps {
+	db: Db;
+	manager: ChatSessionManager;
+}
+
+/**
+ * Resolve an external sender to a linked Hezo user, or null if not on the
+ * allowlist. `(channel, external_user_id)` is unique, so at most one row.
+ */
+async function resolveLinkedUser(
+	db: Db,
+	channel: ChatChannel,
+	externalUserId: string,
+): Promise<string | null> {
+	const r = await db.query<{ user_id: string }>(
+		`SELECT user_id FROM chat_identity_links WHERE channel = $1 AND external_user_id = $2`,
+		[channel, externalUserId],
+	);
+	return r.rows[0]?.user_id ?? null;
+}
+
+/**
+ * The single, channel-agnostic entry point for an inbound external chat message.
+ * Every adapter (webhook route or gateway) feeds its parsed `InboundChatEvent`
+ * here. Enforces the identity allowlist, then routes the message to the CEO chat
+ * as a turn on the conversation keyed by the external thread.
+ *
+ * An unlinked sender is not served: the adapter is asked to prompt them to link
+ * (best-effort) and no turn is started.
+ */
+export async function ingestInboundEvent(
+	deps: IngestDeps,
+	adapter: ChatChannelAdapter,
+	event: InboundChatEvent,
+): Promise<void> {
+	const channel = adapter.channel;
+	const userId = await resolveLinkedUser(deps.db, channel, event.externalUserId);
+	if (!userId) {
+		log.info(`ignoring ${channel} message from unlinked identity`, {
+			externalUserId: event.externalUserId,
+		});
+		if (adapter.promptToLink) {
+			await adapter.promptToLink(event).catch((e) => log.error('promptToLink failed', e));
+		}
+		return;
+	}
+	await deps.manager.sendTurn({
+		text: event.text,
+		channel,
+		externalThreadId: event.externalThreadId,
+		authorUserId: userId,
+	});
+}

--- a/packages/server/src/services/chat-channels/registry.ts
+++ b/packages/server/src/services/chat-channels/registry.ts
@@ -1,0 +1,48 @@
+import type { ChatChannel } from '@hezo/shared';
+import { logger } from '../../logger';
+import type { ChatChannelAdapter } from './types';
+
+const log = logger.child('chat-channels');
+
+/**
+ * Registry of channel adapters, keyed by `ChatChannel`. The manager, webhook route,
+ * and config routes all resolve a channel through this — there are no per-channel
+ * branches in core code. Adding a channel = register one adapter here.
+ */
+export class ChatChannelRegistry {
+	private adapters = new Map<ChatChannel, ChatChannelAdapter>();
+
+	register(adapter: ChatChannelAdapter): void {
+		this.adapters.set(adapter.channel, adapter);
+	}
+
+	get(channel: ChatChannel): ChatChannelAdapter | undefined {
+		return this.adapters.get(channel);
+	}
+
+	all(): ChatChannelAdapter[] {
+		return [...this.adapters.values()];
+	}
+
+	/** Start every registered adapter (called on server unlock). Failures are logged, not fatal. */
+	async startAll(): Promise<void> {
+		for (const adapter of this.adapters.values()) {
+			try {
+				await adapter.start();
+			} catch (e) {
+				log.error(`failed to start ${adapter.channel} chat channel`, e);
+			}
+		}
+	}
+
+	/** Stop every registered adapter (called on shutdown). */
+	async stopAll(): Promise<void> {
+		for (const adapter of this.adapters.values()) {
+			try {
+				await adapter.stop();
+			} catch (e) {
+				log.error(`failed to stop ${adapter.channel} chat channel`, e);
+			}
+		}
+	}
+}

--- a/packages/server/src/services/chat-channels/telegram.ts
+++ b/packages/server/src/services/chat-channels/telegram.ts
@@ -1,0 +1,174 @@
+import { ChatChannel } from '@hezo/shared';
+import { getInstanceBaseUrl } from '../../lib/system-meta';
+import { logger } from '../../logger';
+import {
+	type ChatChannelAdapter,
+	type ChatChannelAdapterDeps,
+	decryptBotToken,
+	type InboundChatEvent,
+	loadChannelConfig,
+	type OutboundReply,
+} from './types';
+
+const log = logger.child('chat-telegram');
+
+/**
+ * Escape text for Telegram's MarkdownV2 parse mode. Every one of the reserved
+ * characters must be backslash-escaped outside an entity, or the API rejects the
+ * message. We send fully-escaped plain text (no injected formatting) so delivery
+ * is always safe; richer MarkdownV2 rendering (links from bare references) is a
+ * follow-up. Pure — unit-tested directly.
+ */
+export function escapeMarkdownV2(text: string): string {
+	return text.replace(/[_*[\]()~`>#+\-=|{}.!\\]/g, (c) => `\\${c}`);
+}
+
+/**
+ * Telegram raw `message` update shape (the fields we read). Kept local — we only
+ * need the sender, the chat, and forum-topic threading.
+ */
+interface TelegramUpdate {
+	message?: {
+		text?: string;
+		message_thread_id?: number;
+		is_topic_message?: boolean;
+		from?: { id?: number; username?: string; is_bot?: boolean };
+		chat?: { id?: number; type?: string };
+	};
+}
+
+/**
+ * Encode a Telegram thread id from a chat id and optional forum-topic id. A DM (or
+ * the General topic) is keyed by the bare chat id; a forum topic is
+ * `"<chatId>:<messageThreadId>"`. Decoded symmetrically in `deliver`.
+ */
+function encodeThreadId(chatId: number, messageThreadId?: number): string {
+	return messageThreadId ? `${chatId}:${messageThreadId}` : String(chatId);
+}
+
+function decodeThreadId(externalThreadId: string): { chatId: string; messageThreadId?: number } {
+	const idx = externalThreadId.indexOf(':');
+	if (idx === -1) return { chatId: externalThreadId };
+	return {
+		chatId: externalThreadId.slice(0, idx),
+		messageThreadId: Number(externalThreadId.slice(idx + 1)),
+	};
+}
+
+/**
+ * Telegram chat channel adapter (webhook transport). Threading maps to Telegram's
+ * one native primitive, forum topics: a private DM is a single conversation per
+ * user; a Topics-enabled supergroup gives one conversation per topic. Creating and
+ * closing topics needs the bot to be a group admin with `can_manage_topics`.
+ */
+export class TelegramAdapter implements ChatChannelAdapter {
+	readonly channel = ChatChannel.Telegram;
+
+	constructor(private readonly deps: ChatChannelAdapterDeps) {}
+
+	private async api<T = unknown>(method: string, body: Record<string, unknown>): Promise<T | null> {
+		const config = await loadChannelConfig(this.deps, this.channel);
+		if (!config?.botTokenSecret) throw new Error('telegram bot token not configured');
+		const token = await decryptBotToken(this.deps, config.botTokenSecret);
+		const res = await fetch(`https://api.telegram.org/bot${token}/${method}`, {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify(body),
+		});
+		const json = (await res.json().catch(() => null)) as { ok?: boolean; result?: T } | null;
+		if (!res.ok || !json?.ok) {
+			log.error(`telegram ${method} failed`, { status: res.status, body: json });
+			return null;
+		}
+		return json.result ?? null;
+	}
+
+	/** The configured Topics supergroup id (in `metadata.group_id`), if any. */
+	private async groupId(): Promise<string | null> {
+		const config = await loadChannelConfig(this.deps, this.channel);
+		const gid = config?.metadata?.group_id;
+		return typeof gid === 'string' && gid.trim() !== '' ? gid : null;
+	}
+
+	async start(): Promise<void> {
+		const config = await loadChannelConfig(this.deps, this.channel);
+		if (!config?.enabled || !config.botTokenSecret || !config.webhookSecret) {
+			// Not fully configured / disabled — ensure no stale webhook is registered.
+			await this.stop().catch(() => undefined);
+			return;
+		}
+		const baseUrl = await getInstanceBaseUrl(this.deps.db);
+		if (!baseUrl) {
+			log.warn('instance base URL unset; cannot register telegram webhook');
+			return;
+		}
+		const url = `${baseUrl}/webhooks/chat/telegram/${config.webhookSecret}`;
+		await this.api('setWebhook', {
+			url,
+			secret_token: config.webhookSecret,
+			allowed_updates: ['message'],
+		});
+		log.info('telegram webhook registered');
+	}
+
+	async stop(): Promise<void> {
+		// Best-effort: only possible when a token is still configured.
+		const config = await loadChannelConfig(this.deps, this.channel);
+		if (!config?.botTokenSecret) return;
+		await this.api('deleteWebhook', {}).catch(() => undefined);
+	}
+
+	parseInbound(raw: unknown): InboundChatEvent | null {
+		const update = raw as TelegramUpdate;
+		const msg = update?.message;
+		if (!msg?.text || !msg.from?.id || msg.from.is_bot || !msg.chat?.id) return null;
+		return {
+			externalUserId: String(msg.from.id),
+			externalThreadId: encodeThreadId(msg.chat.id, msg.message_thread_id),
+			externalHandle: msg.from.username ? `@${msg.from.username}` : undefined,
+			text: msg.text,
+		};
+	}
+
+	async deliver(reply: OutboundReply): Promise<void> {
+		const { chatId, messageThreadId } = decodeThreadId(reply.externalThreadId);
+		await this.api('sendMessage', {
+			chat_id: chatId,
+			text: escapeMarkdownV2(reply.content),
+			parse_mode: 'MarkdownV2',
+			...(messageThreadId ? { message_thread_id: messageThreadId } : {}),
+		});
+	}
+
+	async createThread(title: string): Promise<string> {
+		const gid = await this.groupId();
+		if (!gid) throw new Error('telegram: no Topics supergroup configured (metadata.group_id)');
+		const result = await this.api<{ message_thread_id: number }>('createForumTopic', {
+			chat_id: gid,
+			name: title || 'New thread',
+		});
+		if (!result?.message_thread_id) throw new Error('telegram: createForumTopic returned no id');
+		return encodeThreadId(Number(gid), result.message_thread_id);
+	}
+
+	async closeThread(externalThreadId: string): Promise<void> {
+		const { chatId, messageThreadId } = decodeThreadId(externalThreadId);
+		if (!messageThreadId) return; // A DM has no topic to close.
+		await this.api('closeForumTopic', {
+			chat_id: chatId,
+			message_thread_id: messageThreadId,
+		});
+	}
+
+	async promptToLink(event: InboundChatEvent): Promise<void> {
+		const { chatId, messageThreadId } = decodeThreadId(event.externalThreadId);
+		await this.api('sendMessage', {
+			chat_id: chatId,
+			text: escapeMarkdownV2(
+				'This Telegram account is not linked to a Hezo user. Ask an admin to link it from the chat channels settings.',
+			),
+			parse_mode: 'MarkdownV2',
+			...(messageThreadId ? { message_thread_id: messageThreadId } : {}),
+		});
+	}
+}

--- a/packages/server/src/services/chat-channels/types.ts
+++ b/packages/server/src/services/chat-channels/types.ts
@@ -1,0 +1,126 @@
+import type { ChatChannel, ChatMessageStatus } from '@hezo/shared';
+import type { MasterKeyManager } from '../../crypto/master-key';
+import type { Db } from '../../db/database';
+
+/**
+ * A normalized inbound chat message from any external channel. Adapters translate
+ * their platform's raw event shape into this so the shared ingest path
+ * (`ingestInboundEvent`) is entirely channel-agnostic.
+ */
+export interface InboundChatEvent {
+	/** Platform user id of the sender (Telegram from.id, Discord author.id, …). */
+	externalUserId: string;
+	/** Platform thread id this message belongs to (see the adapter's threading model). */
+	externalThreadId: string;
+	/** Display handle of the sender, for identity-link UIs. Optional. */
+	externalHandle?: string;
+	text: string;
+}
+
+/** A finalized assistant reply to deliver back out to an external channel. */
+export interface OutboundReply {
+	externalThreadId: string;
+	content: string;
+	status: ChatMessageStatus;
+}
+
+/**
+ * A chat channel adapter owns *everything* platform-specific: inbound parsing,
+ * outbound delivery, optional thread create/close, and any long-lived transport
+ * (a webhook registration or a persistent gateway). The manager, webhook route,
+ * config routes, and web core are all channel-agnostic and reach a channel only
+ * through the adapter registered here — so a new chat app (Discord, Slack, …) is
+ * one new adapter file, with no changes to the core.
+ */
+export interface ChatChannelAdapter {
+	readonly channel: ChatChannel;
+
+	/**
+	 * Bring the channel online: register a webhook, open a gateway, etc. Called when
+	 * the operator enables/saves the channel and on server unlock for enabled
+	 * channels. Idempotent.
+	 */
+	start(): Promise<void>;
+	/** Take the channel offline (deregister webhook, close gateway). Idempotent. */
+	stop(): Promise<void>;
+
+	/**
+	 * Normalize a raw inbound platform event into an `InboundChatEvent`, or null to
+	 * ignore it (a non-message update, the bot's own message, …). Pure — the webhook
+	 * route/gateway feed the result to `ingestInboundEvent`.
+	 */
+	parseInbound(raw: unknown): InboundChatEvent | null;
+
+	/** Deliver a finalized assistant reply to the platform thread. */
+	deliver(reply: OutboundReply): Promise<void>;
+
+	/** Prompt an unlinked sender to link their identity (best-effort, optional). */
+	promptToLink?(event: InboundChatEvent): Promise<void>;
+
+	/** Create a native platform thread, returning its id. No-op channels omit this. */
+	createThread?(title: string): Promise<string>;
+	/** Close/archive a native platform thread. No-op channels omit this. */
+	closeThread?(externalThreadId: string): Promise<void>;
+}
+
+/**
+ * Per-channel configuration row (mirrors `chat_channel_configs`). `metadata` holds
+ * all channel-specific settings so no per-channel columns are ever needed.
+ */
+export interface ChatChannelConfig {
+	channel: ChatChannel;
+	enabled: boolean;
+	botTokenSecret: string | null;
+	webhookSecret: string | null;
+	metadata: Record<string, unknown>;
+}
+
+/** Shared dependencies handed to every adapter at construction. */
+export interface ChatChannelAdapterDeps {
+	db: Db;
+	masterKeyManager: MasterKeyManager;
+}
+
+/** Decrypt a bot token from the secrets vault in-process (trusted server code). */
+export async function decryptBotToken(
+	deps: ChatChannelAdapterDeps,
+	secretName: string,
+): Promise<string> {
+	const key = deps.masterKeyManager.getKey();
+	if (!key) throw new Error('server is locked; cannot read bot token');
+	const r = await deps.db.query<{ encrypted_value: string }>(
+		`SELECT encrypted_value FROM secrets WHERE name = $1`,
+		[secretName],
+	);
+	const encrypted = r.rows[0]?.encrypted_value;
+	if (!encrypted) throw new Error(`bot token secret ${secretName} not found`);
+	const { decrypt } = await import('../../crypto/encryption');
+	return decrypt(encrypted, key);
+}
+
+/** Load a channel's config row, or null when unconfigured. */
+export async function loadChannelConfig(
+	deps: ChatChannelAdapterDeps,
+	channel: ChatChannel,
+): Promise<ChatChannelConfig | null> {
+	const r = await deps.db.query<{
+		channel: ChatChannel;
+		enabled: boolean;
+		bot_token_secret: string | null;
+		webhook_secret: string | null;
+		metadata: Record<string, unknown>;
+	}>(
+		`SELECT channel, enabled, bot_token_secret, webhook_secret, metadata
+		 FROM chat_channel_configs WHERE channel = $1`,
+		[channel],
+	);
+	const row = r.rows[0];
+	if (!row) return null;
+	return {
+		channel: row.channel,
+		enabled: row.enabled,
+		botTokenSecret: row.bot_token_secret,
+		webhookSecret: row.webhook_secret,
+		metadata: row.metadata ?? {},
+	};
+}

--- a/packages/server/src/services/chat-session-manager.ts
+++ b/packages/server/src/services/chat-session-manager.ts
@@ -13,6 +13,7 @@ import {
 	type CommentAttachment,
 	DEFAULT_TEAM_ID,
 	PROVIDER_RUNTIME_ADAPTERS,
+	type WsChatServerMessage,
 	WsMessageType,
 	wsRoom,
 } from '@hezo/shared';
@@ -127,7 +128,6 @@ export interface CeoSessionDeps extends RunnerDeps {
 
 interface LiveSession {
 	sessionId: string;
-	conversationId: string;
 	ceoMemberId: string;
 	projectId: string;
 	containerId: string;
@@ -135,7 +135,6 @@ interface LiveSession {
 	runtimeType: AgentRuntime;
 	env: string[];
 	execCmd: string[];
-	promptHostPath: string;
 	promptDirective: string | null;
 	releaseEgress: () => Promise<void>;
 	releaseSsh: () => Promise<void>;
@@ -148,6 +147,38 @@ interface CurrentTurn {
 }
 
 /**
+ * Identity + channel of a conversation, resolved once per turn. The warm container
+ * is shared across all conversations; this is the per-turn scope threaded through
+ * prompt composition, streaming, and (for external channels) outbound delivery.
+ */
+export interface ConversationContext {
+	conversationId: string;
+	channel: ChatChannel;
+	/** Platform thread id for external channels (Telegram "<chat>:<topic>", …); null for web. */
+	externalThreadId: string | null;
+}
+
+/**
+ * Per-conversation turn bookkeeping. The warm session (`LiveSession`) is shared;
+ * this is what must be per-thread so two conversations can run concurrently while
+ * two messages in the *same* thread still serialize + interrupt.
+ */
+interface ConversationRuntime {
+	conversationId: string;
+	turnLock: Promise<unknown>;
+	current: CurrentTurn | null;
+	compaction: Promise<void> | null;
+	compactionAbort: AbortController | null;
+}
+
+/** Deliver a finalized assistant reply to an external channel (set by the channel layer). */
+export type ExternalDelivery = (
+	ctx: ConversationContext,
+	content: string,
+	status: ChatMessageStatus,
+) => Promise<void>;
+
+/**
  * Owns the single persistent CEO chat session. Unlike a one-shot task run, the
  * session keeps warm resources (egress proxy, ssh socket, MCP token, runtime
  * config) for the HQ container and runs each turn as a one-shot exec with the
@@ -157,20 +188,57 @@ interface CurrentTurn {
  */
 export class ChatSessionManager {
 	private live: LiveSession | null = null;
-	private current: CurrentTurn | null = null;
 	private ensuring: Promise<LiveSession> | null = null;
 	private healthTimer: ReturnType<typeof setInterval> | null = null;
-	// Serializes `sendTurn` so concurrent sends (e.g. an impatient double-click while
-	// the boot egress check is still warming up) can't each clear the gate together
-	// and spawn their own session/turn. With sends serialized, the interrupt guard in
-	// `sendTurn` correctly aborts the prior turn and only the latest one streams.
-	private turnLock: Promise<unknown> = Promise.resolve();
-	// An in-flight background compaction run (a headless exec that has the agent
-	// fold the window into long-term memory). A new user turn preempts it.
-	private compaction: Promise<void> | null = null;
-	private compactionAbort: AbortController | null = null;
+	// Per-conversation turn bookkeeping (lock + in-flight turn + compaction). Keyed
+	// by conversationId. Two conversations run concurrently; the per-conversation
+	// lock serializes sends within a thread so the interrupt guard aborts the prior
+	// turn and only the latest one streams.
+	private convos = new Map<string, ConversationRuntime>();
+	// Long-term memory (`chat_memories`) is keyed by the CEO member, so it is shared
+	// across every thread. Compaction rewrites the whole row, so all threads'
+	// compactions serialize here to avoid clobbering each other's memory write.
+	private memberCompactionLock: Promise<unknown> = Promise.resolve();
+	// Set by the channel layer to deliver a finalized reply out to an external
+	// channel (Telegram, …). Web replies stream over WebSocket and need no delivery.
+	private externalDelivery: ExternalDelivery | null = null;
+	// Set by the channel layer to close an external platform thread when the operator
+	// closes a conversation (e.g. Telegram closeForumTopic). No-op for web.
+	private onCloseThread:
+		| ((channel: ChatChannel, externalThreadId: string) => Promise<void>)
+		| null = null;
 
 	constructor(private readonly deps: CeoSessionDeps) {}
+
+	/** Register the external-channel hooks (called once at wiring time). */
+	setChannelHooks(hooks: {
+		delivery: ExternalDelivery;
+		closeThread: (channel: ChatChannel, externalThreadId: string) => Promise<void>;
+	}): void {
+		this.externalDelivery = hooks.delivery;
+		this.onCloseThread = hooks.closeThread;
+	}
+
+	/** Introspection (tests): is any thread's background compaction still in flight? */
+	hasInflightCompaction(): boolean {
+		for (const c of this.convos.values()) if (c.compaction) return true;
+		return false;
+	}
+
+	private getConvoRuntime(conversationId: string): ConversationRuntime {
+		let rt = this.convos.get(conversationId);
+		if (!rt) {
+			rt = {
+				conversationId,
+				turnLock: Promise.resolve(),
+				current: null,
+				compaction: null,
+				compactionAbort: null,
+			};
+			this.convos.set(conversationId, rt);
+		}
+		return rt;
+	}
 
 	start(): void {
 		if (this.healthTimer) return;
@@ -214,54 +282,64 @@ export class ChatSessionManager {
 	}
 
 	/**
-	 * Send a user turn. Persists the user message, interrupts any in-flight reply,
-	 * creates the streaming assistant row, and kicks the turn in the background.
-	 * Returns the two message ids so the client can correlate streamed deltas.
+	 * Send a user turn to a conversation. Resolves the conversation (web default,
+	 * an explicit thread, or an external thread), persists the user message,
+	 * interrupts any in-flight reply *for that thread*, creates the streaming
+	 * assistant row, and kicks the turn in the background. Returns the two message
+	 * ids so the client can correlate streamed deltas.
 	 */
 	async sendTurn(input: {
 		text: string;
 		channel?: ChatChannel;
+		conversationId?: string;
+		externalThreadId?: string | null;
 		authorUserId?: string | null;
 		attachmentIds?: string[];
-	}): Promise<{ userMessageId: string; assistantMessageId: string }> {
-		// Serialize turns: chain on the prior send so two overlapping requests run the
-		// body sequentially (the second only after the first has set `this.current`),
-		// letting the interrupt guard below abort the prior turn instead of racing it.
-		const run = this.turnLock.then(
-			() => this.runSendTurn(input),
-			() => this.runSendTurn(input),
+	}): Promise<{ userMessageId: string; assistantMessageId: string; conversationId: string }> {
+		const ctx = await this.resolveConversationForInput(input);
+		const convo = this.getConvoRuntime(ctx.conversationId);
+		// Serialize turns *within this conversation*: chain on the prior send so two
+		// overlapping requests to the same thread run sequentially (the second only
+		// after the first has set `current`), letting the interrupt guard abort the
+		// prior turn instead of racing it. Different threads run concurrently.
+		const run = convo.turnLock.then(
+			() => this.runSendTurn(input, ctx),
+			() => this.runSendTurn(input, ctx),
 		);
-		this.turnLock = run.catch(() => undefined);
+		convo.turnLock = run.catch(() => undefined);
 		return run;
 	}
 
-	private async runSendTurn(input: {
-		text: string;
-		channel?: ChatChannel;
-		authorUserId?: string | null;
-		attachmentIds?: string[];
-	}): Promise<{ userMessageId: string; assistantMessageId: string }> {
+	private async runSendTurn(
+		input: {
+			text: string;
+			authorUserId?: string | null;
+			attachmentIds?: string[];
+		},
+		ctx: ConversationContext,
+	): Promise<{ userMessageId: string; assistantMessageId: string; conversationId: string }> {
 		const session = await this.ensureSession();
-		const channel = input.channel ?? ChatChannel.Web;
+		const { conversationId, channel } = ctx;
+		const convo = this.getConvoRuntime(conversationId);
 
-		// A user turn preempts any in-flight background compaction so the shared
-		// prompt file and container exec are free, and so the new message is part
+		// A user turn preempts any in-flight background compaction for this thread so
+		// its prompt file and container exec are free, and so the new message is part
 		// of the window the next compaction summarizes.
-		if (this.compactionAbort) {
-			this.compactionAbort.abort('interrupted');
-			await this.compaction?.catch(() => undefined);
+		if (convo.compactionAbort) {
+			convo.compactionAbort.abort('interrupted');
+			await convo.compaction?.catch(() => undefined);
 		}
 
-		// Interrupt an in-flight reply: abort it and wait for it to finalize
-		// (the run loop persists the partial as `interrupted`) so the next turn's
-		// prompt includes it.
-		if (this.current) {
-			this.current.abort.abort('interrupted');
-			await this.current.promise.catch(() => undefined);
+		// Interrupt an in-flight reply in this thread: abort it and wait for it to
+		// finalize (the run loop persists the partial as `interrupted`) so the next
+		// turn's prompt includes it.
+		if (convo.current) {
+			convo.current.abort.abort('interrupted');
+			await convo.current.promise.catch(() => undefined);
 		}
 
 		const userMessageId = await this.insertMessage({
-			conversationId: session.conversationId,
+			conversationId,
 			role: ChatMessageRole.User,
 			channel,
 			status: ChatMessageStatus.Complete,
@@ -288,43 +366,241 @@ export class ChatSessionManager {
 					)
 				).get(userMessageId) ?? [];
 		}
-		this.broadcastStart(userMessageId, ChatMessageRole.User, channel, input.text, userAttachments);
+		await this.touchConversation(conversationId);
+		this.broadcastStart(
+			conversationId,
+			userMessageId,
+			ChatMessageRole.User,
+			channel,
+			input.text,
+			userAttachments,
+		);
 
 		const assistantMessageId = await this.insertMessage({
-			conversationId: session.conversationId,
+			conversationId,
 			role: ChatMessageRole.Assistant,
-			channel: ChatChannel.Web,
+			channel,
 			status: ChatMessageStatus.Streaming,
 			content: '',
 			authorMemberId: session.ceoMemberId,
 			sessionId: session.sessionId,
 			completed: false,
 		});
-		this.broadcastStart(assistantMessageId, ChatMessageRole.Assistant, ChatChannel.Web, '');
+		this.broadcastStart(conversationId, assistantMessageId, ChatMessageRole.Assistant, channel, '');
 
 		const abort = new AbortController();
-		const promise = this.runTurn(session, assistantMessageId, abort);
-		this.current = { assistantMessageId, abort, promise };
-		// After the reply settles, compact the window if it has grown past the cap.
-		trackBackground(promise.then(() => this.maybeCompact()));
+		const promise = this.runTurn(session, ctx, assistantMessageId, abort);
+		convo.current = { assistantMessageId, abort, promise };
+		// After the reply settles, compact this thread's window if it has grown past
+		// the cap (serialized against other threads' compactions).
+		trackBackground(promise.then(() => this.maybeCompact(ctx)));
 
-		return { userMessageId, assistantMessageId };
+		return { userMessageId, assistantMessageId, conversationId };
 	}
 
 	/** Tear the live session down; the next turn re-allocates a fresh one. */
 	async restart(): Promise<void> {
-		if (this.current) {
-			this.current.abort.abort('restart');
-			await this.current.promise.catch(() => undefined);
-		}
+		await this.abortAllCurrent('restart');
 		await this.teardown(ChatSessionStatus.Stopped);
 	}
 
-	/** Resolve the single global conversation row, creating it on first use. */
+	/** Abort every in-flight turn across all conversations and await them. */
+	private async abortAllCurrent(reason: string): Promise<void> {
+		const inflight: Promise<unknown>[] = [];
+		for (const convo of this.convos.values()) {
+			if (convo.current) {
+				convo.current.abort.abort(reason);
+				inflight.push(convo.current.promise.catch(() => undefined));
+			}
+		}
+		await Promise.all(inflight);
+	}
+
+	/**
+	 * Resolve the default web conversation (the earliest open web thread), creating
+	 * it on first use. Back-compat entry point for the web chatbox's default thread.
+	 */
 	async getConversationId(): Promise<string> {
 		const ceoMemberId = await this.resolveCeoMemberId();
 		const projectId = await this.resolveHqProjectId();
-		return this.ensureConversation(ceoMemberId, projectId);
+		return this.resolveOrCreateConversation({
+			ceoMemberId,
+			projectId,
+			channel: ChatChannel.Web,
+			externalThreadId: null,
+		});
+	}
+
+	/** Resolve the conversation for an inbound turn (explicit id, or resolve/create). */
+	private async resolveConversationForInput(input: {
+		channel?: ChatChannel;
+		conversationId?: string;
+		externalThreadId?: string | null;
+	}): Promise<ConversationContext> {
+		if (input.conversationId) {
+			const convo = await this.getConversation(input.conversationId);
+			if (!convo) throw new Error('conversation not found');
+			if (convo.closed_at) throw new Error('conversation is closed');
+			return {
+				conversationId: convo.id,
+				channel: convo.channel,
+				externalThreadId: convo.external_thread_id,
+			};
+		}
+		const channel = input.channel ?? ChatChannel.Web;
+		const externalThreadId = input.externalThreadId ?? null;
+		const ceoMemberId = await this.resolveCeoMemberId();
+		const projectId = await this.resolveHqProjectId();
+		const conversationId = await this.resolveOrCreateConversation({
+			ceoMemberId,
+			projectId,
+			channel,
+			externalThreadId,
+		});
+		return { conversationId, channel, externalThreadId };
+	}
+
+	/**
+	 * Resolve an open conversation by (member, channel, externalThreadId), creating
+	 * it if none. For web (externalThreadId=null) the earliest open web thread is the
+	 * default; for external channels each open thread id maps to one conversation.
+	 */
+	private async resolveOrCreateConversation(opts: {
+		ceoMemberId: string;
+		projectId: string;
+		channel: ChatChannel;
+		externalThreadId: string | null;
+	}): Promise<string> {
+		const { ceoMemberId, projectId, channel, externalThreadId } = opts;
+		if (externalThreadId == null) {
+			const existing = await this.deps.db.query<{ id: string }>(
+				`SELECT id FROM chat_conversations
+				 WHERE member_id = $1 AND channel = $2::chat_channel
+				   AND external_thread_id IS NULL AND closed_at IS NULL
+				 ORDER BY created_at ASC LIMIT 1`,
+				[ceoMemberId, channel],
+			);
+			if (existing.rows[0]) return existing.rows[0].id;
+			const created = await this.deps.db.query<{ id: string }>(
+				`INSERT INTO chat_conversations (member_id, team_id, project_id, channel)
+				 VALUES ($1, $2, $3, $4::chat_channel) RETURNING id`,
+				[ceoMemberId, DEFAULT_TEAM_ID, projectId, channel],
+			);
+			return created.rows[0].id;
+		}
+		const existing = await this.deps.db.query<{ id: string }>(
+			`SELECT id FROM chat_conversations
+			 WHERE member_id = $1 AND channel = $2::chat_channel
+			   AND external_thread_id = $3 AND closed_at IS NULL`,
+			[ceoMemberId, channel, externalThreadId],
+		);
+		if (existing.rows[0]) return existing.rows[0].id;
+		const created = await this.deps.db.query<{ id: string }>(
+			`INSERT INTO chat_conversations (member_id, team_id, project_id, channel, external_thread_id)
+			 VALUES ($1, $2, $3, $4::chat_channel, $5) RETURNING id`,
+			[ceoMemberId, DEFAULT_TEAM_ID, projectId, channel, externalThreadId],
+		);
+		return created.rows[0].id;
+	}
+
+	/** Fetch a conversation row (identity + lifecycle), or null if it doesn't exist. */
+	async getConversation(conversationId: string): Promise<{
+		id: string;
+		channel: ChatChannel;
+		external_thread_id: string | null;
+		title: string | null;
+		closed_at: string | null;
+	} | null> {
+		const r = await this.deps.db.query<{
+			id: string;
+			channel: ChatChannel;
+			external_thread_id: string | null;
+			title: string | null;
+			closed_at: string | null;
+		}>(
+			`SELECT id, channel, external_thread_id, title, closed_at
+			 FROM chat_conversations WHERE id = $1`,
+			[conversationId],
+		);
+		return r.rows[0] ?? null;
+	}
+
+	/** List conversations (open by default), newest activity first. */
+	async listConversations(opts?: { includeClosed?: boolean }): Promise<
+		Array<{
+			id: string;
+			channel: ChatChannel;
+			external_thread_id: string | null;
+			title: string | null;
+			last_activity_at: string;
+			closed_at: string | null;
+		}>
+	> {
+		const ceoMemberId = await this.resolveCeoMemberId();
+		const r = await this.deps.db.query<{
+			id: string;
+			channel: ChatChannel;
+			external_thread_id: string | null;
+			title: string | null;
+			last_activity_at: string;
+			closed_at: string | null;
+		}>(
+			`SELECT id, channel, external_thread_id, title, last_activity_at, closed_at
+			 FROM chat_conversations
+			 WHERE member_id = $1 ${opts?.includeClosed ? '' : 'AND closed_at IS NULL'}
+			 ORDER BY last_activity_at DESC, created_at DESC`,
+			[ceoMemberId],
+		);
+		return r.rows;
+	}
+
+	/** Create a fresh web conversation thread (the new-thread button). */
+	async createWebConversation(title?: string): Promise<string> {
+		const ceoMemberId = await this.resolveCeoMemberId();
+		const projectId = await this.resolveHqProjectId();
+		const created = await this.deps.db.query<{ id: string }>(
+			`INSERT INTO chat_conversations (member_id, team_id, project_id, channel, title)
+			 VALUES ($1, $2, $3, 'web', $4) RETURNING id`,
+			[ceoMemberId, DEFAULT_TEAM_ID, projectId, title ?? null],
+		);
+		return created.rows[0].id;
+	}
+
+	/**
+	 * Close a conversation: mark it closed, abort + evict its in-flight turn, and
+	 * (for an external thread) close the platform thread via the delivery hook's
+	 * owner. Idempotent — closing an already-closed thread is a no-op.
+	 */
+	async closeConversation(conversationId: string): Promise<void> {
+		const convo = await this.getConversation(conversationId);
+		if (!convo || convo.closed_at) return;
+		const rt = this.convos.get(conversationId);
+		if (rt?.current) {
+			rt.current.abort.abort('closed');
+			await rt.current.promise.catch(() => undefined);
+		}
+		if (rt?.compactionAbort) {
+			rt.compactionAbort.abort('closed');
+			await rt.compaction?.catch(() => undefined);
+		}
+		this.convos.delete(conversationId);
+		await this.deps.db.query(`UPDATE chat_conversations SET closed_at = now() WHERE id = $1`, [
+			conversationId,
+		]);
+		if (convo.external_thread_id && this.onCloseThread) {
+			await this.onCloseThread(convo.channel, convo.external_thread_id).catch((e) =>
+				log.error('close external thread failed', e),
+			);
+		}
+	}
+
+	/** Bump a conversation's last-activity timestamp (drives list ordering). */
+	private async touchConversation(conversationId: string): Promise<void> {
+		await this.deps.db
+			.query(`UPDATE chat_conversations SET last_activity_at = now() WHERE id = $1`, [
+				conversationId,
+			])
+			.catch(() => undefined);
 	}
 
 	private async ensureSession(): Promise<LiveSession> {
@@ -408,8 +684,6 @@ export class ChatSessionManager {
 		);
 		if (!credential) throw new Error(`No ${provider} credential configured`);
 		const modelOverride = override.rows[0]?.model ?? credential.defaultModel ?? null;
-
-		const conversationId = await this.ensureConversation(ceoMemberId, project.id);
 
 		// Reclaim any DB rows left live by a crash without an in-memory session, so
 		// the singleton insert below doesn't collide.
@@ -551,7 +825,6 @@ export class ChatSessionManager {
 
 			this.live = {
 				sessionId,
-				conversationId,
 				ceoMemberId,
 				projectId: project.id,
 				containerId,
@@ -559,12 +832,6 @@ export class ChatSessionManager {
 				runtimeType,
 				env: invocation.env,
 				execCmd: invocation.execCmd,
-				promptHostPath: getHostPromptPath(
-					this.deps.dataDir,
-					DEFAULT_TEAM_ID,
-					project.id,
-					sessionId,
-				),
 				promptDirective: effortApplication.promptDirective ?? null,
 				releaseEgress,
 				releaseSsh,
@@ -584,11 +851,34 @@ export class ChatSessionManager {
 		}
 	}
 
+	/**
+	 * Per-turn prompt file paths + the exec env pointing at them. The container
+	 * reads its prompt from `HEZO_PROMPT_FILE`; keying the file by conversation lets
+	 * concurrent threads exec without overwriting each other's prompt (same-thread
+	 * turns serialize via the per-conversation lock, so one file per thread is safe).
+	 */
+	private turnPrompt(
+		session: LiveSession,
+		conversationId: string,
+	): { hostPath: string; env: string[] } {
+		const key = `${session.sessionId}-${conversationId}`;
+		const hostPath = getHostPromptPath(this.deps.dataDir, DEFAULT_TEAM_ID, session.projectId, key);
+		const containerPath = getContainerPromptPath(key);
+		const env = session.env.map((e) =>
+			e.startsWith('HEZO_PROMPT_FILE=') ? `HEZO_PROMPT_FILE=${containerPath}` : e,
+		);
+		return { hostPath, env };
+	}
+
 	private async runTurn(
 		session: LiveSession,
+		ctx: ConversationContext,
 		assistantMessageId: string,
 		abort: AbortController,
 	): Promise<void> {
+		const { conversationId } = ctx;
+		const convo = this.getConvoRuntime(conversationId);
+		const { hostPath, env } = this.turnPrompt(session, conversationId);
 		const accumulated = { text: '' };
 		let finalized = false;
 		const finalize = async (
@@ -598,13 +888,28 @@ export class ChatSessionManager {
 		) => {
 			if (finalized) return;
 			finalized = true;
-			await this.finalizeMessage(assistantMessageId, status, accumulated.text, usage, error);
+			await this.finalizeMessage(
+				conversationId,
+				assistantMessageId,
+				status,
+				accumulated.text,
+				usage,
+				error,
+			);
+			// Deliver the finalized reply out to an external channel (Telegram, …).
+			// Web replies already streamed over WebSocket. Best-effort — a delivery
+			// failure must not fail the turn.
+			if (ctx.channel !== ChatChannel.Web && this.externalDelivery) {
+				await this.externalDelivery(ctx, accumulated.text, status).catch((e) =>
+					log.error('external chat delivery failed', e),
+				);
+			}
 		};
 
 		try {
-			const prompt = await this.composePrompt(session);
-			mkdirSync(dirname(session.promptHostPath), { recursive: true });
-			writeFileSync(session.promptHostPath, prompt);
+			const prompt = await this.composePrompt(session, conversationId);
+			mkdirSync(dirname(hostPath), { recursive: true });
+			writeFileSync(hostPath, prompt);
 
 			const pricing = this.deps.pricing;
 			const parser = createAgentChatParser(
@@ -615,14 +920,14 @@ export class ChatSessionManager {
 				for (const ev of events) {
 					if (ev.text) {
 						accumulated.text += ev.text;
-						this.broadcastDelta(assistantMessageId, ev.text);
+						this.broadcastDelta(conversationId, assistantMessageId, ev.text);
 					}
 				}
 			};
 
 			const execId = await this.deps.docker.execCreate(session.containerId, {
 				Cmd: session.execCmd,
-				Env: session.env,
+				Env: env,
 				WorkingDir: CHAT_WORKING_DIR,
 				User: session.runUser.name,
 				AttachStdout: true,
@@ -644,12 +949,12 @@ export class ChatSessionManager {
 				await finalize(ChatMessageStatus.Failed, null, (err as Error).message);
 			}
 		} finally {
-			rmSync(session.promptHostPath, { force: true });
-			if (this.current?.assistantMessageId === assistantMessageId) this.current = null;
+			rmSync(hostPath, { force: true });
+			if (convo.current?.assistantMessageId === assistantMessageId) convo.current = null;
 		}
 	}
 
-	private async composePrompt(session: LiveSession): Promise<string> {
+	private async composePrompt(session: LiveSession, conversationId: string): Promise<string> {
 		const stored = await getAgentSystemPrompt(this.deps.db, DEFAULT_TEAM_ID, session.ceoMemberId);
 		const resolved = await resolveSystemPrompt(this.deps.db, stored, {
 			teamId: DEFAULT_TEAM_ID,
@@ -667,7 +972,7 @@ export class ChatSessionManager {
 
 		// The full active (non-compacted) window IS the short-term memory — its size
 		// is bounded by compaction, so there's no per-turn message limit here.
-		const window = await loadActiveWindow(this.deps.db, session.conversationId);
+		const window = await loadActiveWindow(this.deps.db, conversationId);
 		const transcript = window.map(chatTranscriptLine).join('\n\n');
 
 		return [
@@ -684,26 +989,33 @@ export class ChatSessionManager {
 	}
 
 	/**
-	 * Compact the active window if it has grown past the byte cap. Runs in the
-	 * background after a reply settles; skipped when a newer turn is already in
-	 * flight (it will retry after that turn) or when a compaction is already
-	 * running. The agent does the summarization — this just orchestrates.
+	 * Compact a thread's active window if it has grown past the byte cap. Runs in
+	 * the background after a reply settles; skipped when a newer turn is in flight in
+	 * this thread (it retries later) or a compaction is already running for it.
+	 * Serialized across threads via `memberCompactionLock` because long-term memory
+	 * is shared per CEO member and each compaction rewrites the whole row.
 	 */
-	private async maybeCompact(): Promise<void> {
+	private async maybeCompact(ctx: ConversationContext): Promise<void> {
 		const session = this.live;
 		if (!session) return;
-		if (this.current || this.compaction) return;
+		const convo = this.getConvoRuntime(ctx.conversationId);
+		if (convo.current || convo.compaction) return;
 		const abort = new AbortController();
-		this.compactionAbort = abort;
-		const run = this.runCompaction(session, abort);
-		this.compaction = run;
+		convo.compactionAbort = abort;
+		// Serialize this thread's compaction behind any other thread's compaction so
+		// two threads never rewrite the shared memory row concurrently.
+		const run = this.memberCompactionLock
+			.catch(() => undefined)
+			.then(() => this.runCompaction(session, ctx.conversationId, abort));
+		convo.compaction = run;
+		this.memberCompactionLock = run.catch(() => undefined);
 		try {
 			await run;
 		} catch (e) {
 			log.error('CEO chat compaction failed', e);
 		} finally {
-			if (this.compactionAbort === abort) this.compactionAbort = null;
-			if (this.compaction === run) this.compaction = null;
+			if (convo.compactionAbort === abort) convo.compactionAbort = null;
+			if (convo.compaction === run) convo.compaction = null;
 		}
 	}
 
@@ -714,8 +1026,12 @@ export class ChatSessionManager {
 	 * operator sees nothing. Eviction is gated on the agent actually advancing its
 	 * memory this run, so a no-op (or aborted) run loses nothing.
 	 */
-	private async runCompaction(session: LiveSession, abort: AbortController): Promise<void> {
-		const window = await loadActiveWindow(this.deps.db, session.conversationId);
+	private async runCompaction(
+		session: LiveSession,
+		conversationId: string,
+		abort: AbortController,
+	): Promise<void> {
+		const window = await loadActiveWindow(this.deps.db, conversationId);
 		const maxBytes = await getMaxChatHistorySize(this.deps.db);
 		const flush = selectFlush(
 			window.map((m) => ({
@@ -731,12 +1047,13 @@ export class ChatSessionManager {
 		const memory = await getChatMemory(this.deps.db, session.ceoMemberId);
 		const before = memory?.updated_at ?? null;
 		const prompt = buildCompactionPrompt(memory?.content ?? '', flush.windowTranscript);
-		mkdirSync(dirname(session.promptHostPath), { recursive: true });
-		writeFileSync(session.promptHostPath, prompt);
+		const { hostPath, env } = this.turnPrompt(session, conversationId);
+		mkdirSync(dirname(hostPath), { recursive: true });
+		writeFileSync(hostPath, prompt);
 		try {
 			const execId = await this.deps.docker.execCreate(session.containerId, {
 				Cmd: session.execCmd,
-				Env: session.env,
+				Env: env,
 				WorkingDir: CHAT_WORKING_DIR,
 				User: session.runUser.name,
 				AttachStdout: true,
@@ -746,12 +1063,12 @@ export class ChatSessionManager {
 			// real product, landed via the update_chat_memory MCP tool.
 			await this.deps.docker.execStart(execId, { signal: abort.signal, onChunk: () => undefined });
 		} catch (e) {
-			// A new user turn preempts compaction (shared prompt file) — that's a
-			// clean stop, not a failure; nothing is evicted and it retries later.
+			// A new user turn preempts compaction — that's a clean stop, not a
+			// failure; nothing is evicted and it retries later.
 			if (abort.signal.aborted) return;
 			throw e;
 		} finally {
-			rmSync(session.promptHostPath, { force: true });
+			rmSync(hostPath, { force: true });
 		}
 		if (abort.signal.aborted) return;
 
@@ -762,11 +1079,12 @@ export class ChatSessionManager {
 		const advanced = after !== null && (before === null || after.updated_at !== before);
 		if (advanced) {
 			await markCompacted(this.deps.db, flush.evictIds);
-			// Tell every mirrored chatbox to drop the evicted messages and show the
-			// "chat compacted" marker — the conversation refetch returns just the tail.
-			this.deps.wsManager.broadcast(wsRoom.chat(), {
+			// Tell the mirrored chatbox(es) for this thread to drop the evicted
+			// messages and show the "chat compacted" marker — the conversation refetch
+			// returns just the tail.
+			this.broadcastChat(conversationId, {
 				type: WsMessageType.ChatCompacted,
-				conversationId: session.conversationId,
+				conversationId,
 			});
 		} else {
 			log.warn('CEO compaction did not update long-term memory; window left intact', {
@@ -789,10 +1107,7 @@ export class ChatSessionManager {
 	}
 
 	private async shutdown(): Promise<void> {
-		if (this.current) {
-			this.current.abort.abort('shutdown');
-			await this.current.promise.catch(() => undefined);
-		}
+		await this.abortAllCurrent('shutdown');
 		await this.teardown(ChatSessionStatus.Stopped);
 	}
 
@@ -833,19 +1148,6 @@ export class ChatSessionManager {
 		return id;
 	}
 
-	private async ensureConversation(ceoMemberId: string, projectId: string): Promise<string> {
-		const existing = await this.deps.db.query<{ id: string }>(
-			`SELECT id FROM chat_conversations WHERE member_id = $1 ORDER BY created_at ASC LIMIT 1`,
-			[ceoMemberId],
-		);
-		if (existing.rows[0]) return existing.rows[0].id;
-		const created = await this.deps.db.query<{ id: string }>(
-			`INSERT INTO chat_conversations (member_id, team_id, project_id) VALUES ($1, $2, $3) RETURNING id`,
-			[ceoMemberId, DEFAULT_TEAM_ID, projectId],
-		);
-		return created.rows[0].id;
-	}
-
 	private async insertMessage(input: {
 		conversationId: string;
 		role: ChatMessageRole;
@@ -877,6 +1179,7 @@ export class ChatSessionManager {
 	}
 
 	private async finalizeMessage(
+		conversationId: string,
 		messageId: string,
 		status: ChatMessageStatus,
 		content: string,
@@ -905,8 +1208,10 @@ export class ChatSessionManager {
 				])
 				.catch(() => undefined);
 		}
-		this.deps.wsManager.broadcast(wsRoom.chat(), {
+		await this.touchConversation(conversationId);
+		this.broadcastChat(conversationId, {
 			type: WsMessageType.ChatMessageComplete,
+			conversationId,
 			messageId,
 			status,
 			content,
@@ -917,14 +1222,16 @@ export class ChatSessionManager {
 	}
 
 	private broadcastStart(
+		conversationId: string,
 		messageId: string,
 		role: ChatMessageRole,
 		channel: ChatChannel,
 		content: string,
 		attachments?: CommentAttachment[],
 	): void {
-		this.deps.wsManager.broadcast(wsRoom.chat(), {
+		this.broadcastChat(conversationId, {
 			type: WsMessageType.ChatMessageStart,
+			conversationId,
 			messageId,
 			role,
 			channel,
@@ -934,12 +1241,24 @@ export class ChatSessionManager {
 		});
 	}
 
-	private broadcastDelta(messageId: string, text: string): void {
-		this.deps.wsManager.broadcast(wsRoom.chat(), {
+	private broadcastDelta(conversationId: string, messageId: string, text: string): void {
+		this.broadcastChat(conversationId, {
 			type: WsMessageType.ChatMessageDelta,
+			conversationId,
 			messageId,
 			text,
 		});
+	}
+
+	/**
+	 * Fan a chat event out to the thread's own room (the open chatbox for that
+	 * conversation) and the global signal room (the conversation list, for activity
+	 * badges). The web client subscribes to the per-conversation room for the thread
+	 * it's viewing and to the global room for the list.
+	 */
+	private broadcastChat(conversationId: string, message: WsChatServerMessage): void {
+		this.deps.wsManager.broadcast(wsRoom.chatConversation(conversationId), { ...message });
+		this.deps.wsManager.broadcast(wsRoom.chat(), { ...message });
 	}
 }
 

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -39,6 +39,8 @@ import { assetsRoutes, publicAssetsRoutes } from './routes/assets';
 import { auditLogRoutes } from './routes/audit-log';
 import { authRoutes } from './routes/auth';
 import { chatRoutes } from './routes/chat';
+import { chatChannelRoutes } from './routes/chat-channels';
+import { chatWebhookRoutes } from './routes/chat-webhooks';
 import { commentsRoutes } from './routes/comments';
 import { connectorsRoutes } from './routes/connectors';
 import { costsRoutes } from './routes/costs';
@@ -68,6 +70,11 @@ import { teamsRoutes } from './routes/teams';
 import { uiStateRoutes } from './routes/ui-state';
 import { buildUpdatesRoutes } from './routes/updates';
 import { AuthChallengeStore } from './services/auth-challenges';
+import {
+	buildChatChannelRegistry,
+	type ChatChannelRegistry,
+	wireManagerToChannels,
+} from './services/chat-channels';
 import { ChatSessionManager } from './services/chat-session-manager';
 import { checkAndAutoRebindConnectivity } from './services/container-connectivity-preflight';
 import {
@@ -346,6 +353,12 @@ export async function startup(config: HezoConfig): Promise<StartupResult> {
 		containerLogStreamer,
 	});
 
+	// External chat channel adapters (Telegram now, Discord later). The registry is
+	// channel-agnostic; wiring the manager's delivery/close hooks routes external
+	// replies + thread closes through the right adapter without any platform branch.
+	const chatChannelRegistry = buildChatChannelRegistry({ db, masterKeyManager });
+	wireManagerToChannels(chatSessionManager, chatChannelRegistry);
+
 	setStartupPhase('workspace');
 	// On a genuinely fresh instance (HQ not yet seeded) install the default skills
 	// automatically — no opt-in. Must run before seedDefaultTeam creates HQ, so
@@ -393,6 +406,13 @@ export async function startup(config: HezoConfig): Promise<StartupResult> {
 			.reconcileOnStartup()
 			.catch((err) => log.error('CEO session reconciliation failed:', err))
 			.finally(() => chatSessionManager.start());
+		// Bring enabled external chat channels online (register webhooks / open
+		// gateways). Needs the master key (bot tokens) — hence after unlock.
+		trackBackground(
+			chatChannelRegistry
+				.startAll()
+				.catch((err) => log.error('Failed to start chat channels:', err)),
+		);
 	});
 
 	const app = buildApp(
@@ -417,6 +437,7 @@ export async function startup(config: HezoConfig): Promise<StartupResult> {
 		chatSessionManager,
 		pricing,
 		assetStore,
+		chatChannelRegistry,
 	);
 
 	return {
@@ -452,6 +473,7 @@ export function buildApp(
 	chatSessionManager?: ChatSessionManager,
 	pricing?: PricingService,
 	assetStore?: AssetStore,
+	chatChannelRegistry?: ChatChannelRegistry,
 ): Hono<Env> {
 	const app = new Hono<Env>();
 	const authChallenges = new AuthChallengeStore();
@@ -477,6 +499,7 @@ export function buildApp(
 		c.set('events', events);
 		if (jobManager) c.set('jobManager', jobManager);
 		if (chatSessionManager) c.set('chatSessionManager', chatSessionManager);
+		if (chatChannelRegistry) c.set('chatChannelRegistry', chatChannelRegistry);
 		c.set('logs', logs);
 		c.set('containerLogStreamer', containerLogStreamer);
 		c.set('dataDir', config.dataDir);
@@ -580,6 +603,11 @@ export function buildApp(
 	// /api/* auth + project-access middleware so it bypasses the bearer check.
 	app.route('/', publicProjectsRoutes);
 
+	// Public inbound webhook surface for external chat channels. Mounted before the
+	// /api/* bearer-auth middleware — inbound platform requests carry no Hezo token
+	// and are authenticated by a per-channel shared secret in the URL/header.
+	app.route('/', chatWebhookRoutes);
+
 	// Auth middleware for all /api/* routes
 	app.use('/api/*', authMiddleware);
 
@@ -640,6 +668,7 @@ export function buildApp(
 	app.route('/api', searchRoutes);
 	app.route('/api', buildUpdatesRoutes({ autoUnlock: config.autoUnlock ?? false }));
 	app.route('/api', chatRoutes);
+	app.route('/api', chatChannelRoutes);
 
 	// Frontend (SPA) serving. The compiled binary serves from the in-memory
 	// bundle embedded at build time (`loadStaticBundle`); in dev that bundle is

--- a/packages/server/test/chat-channels-admin.test.ts
+++ b/packages/server/test/chat-channels-admin.test.ts
@@ -1,0 +1,141 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { ChatSessionManager } from '../src/services/chat-session-manager';
+import { LogStreamBroker } from '../src/services/log-stream-broker';
+import { WebSocketManager } from '../src/services/ws';
+import { createStubDocker } from './helpers/app';
+import { createTestContext, destroyTestContext, type ServerTestContext } from './helpers/context';
+
+describe('chat channel + identity admin routes', () => {
+	let ctx: ServerTestContext;
+	let auth: Record<string, string>;
+
+	beforeAll(async () => {
+		ctx = await createTestContext();
+		auth = { authorization: `Bearer ${ctx.token}`, 'content-type': 'application/json' };
+	});
+	afterAll(() => destroyTestContext(ctx));
+
+	it('configures a channel, redacts the token, and toggles enablement', async () => {
+		const put = await ctx.app.request('/api/chat/channels/telegram', {
+			method: 'PUT',
+			headers: auth,
+			body: JSON.stringify({
+				enabled: true,
+				bot_token: 'secret-bot-token',
+				metadata: { group_id: '-100' },
+			}),
+		});
+		expect(put.status).toBe(200);
+
+		const list = await ctx.app.request('/api/chat/channels', { headers: auth });
+		const body = (await list.json()) as { data: { channels: Array<Record<string, unknown>> } };
+		const tg = body.data.channels.find((ch) => ch.channel === 'telegram');
+		expect(tg).toMatchObject({ enabled: true, has_token: true, has_webhook: true });
+		// The raw token/secret are never returned.
+		expect(JSON.stringify(tg)).not.toContain('secret-bot-token');
+		expect(tg?.metadata).toMatchObject({ group_id: '-100' });
+
+		// The bot token landed in the vault, encrypted, scoped to the platform host.
+		const secret = await ctx.db.query<{ allowed_hosts: string[] }>(
+			`SELECT allowed_hosts FROM secrets WHERE name = 'TELEGRAM_BOT_TOKEN'`,
+		);
+		expect(secret.rows[0].allowed_hosts).toContain('api.telegram.org');
+
+		const del = await ctx.app.request('/api/chat/channels/telegram', {
+			method: 'DELETE',
+			headers: auth,
+		});
+		expect(del.status).toBe(200);
+		const after = await ctx.db.query<{ enabled: boolean }>(
+			`SELECT enabled FROM chat_channel_configs WHERE channel = 'telegram'`,
+		);
+		expect(after.rows[0].enabled).toBe(false);
+	});
+
+	it('links, lists, and unlinks an external identity', async () => {
+		const u = await ctx.db.query<{ id: string }>(
+			`INSERT INTO users (display_name) VALUES ('Linked') RETURNING id`,
+		);
+		const create = await ctx.app.request('/api/chat/identities', {
+			method: 'POST',
+			headers: auth,
+			body: JSON.stringify({ channel: 'telegram', external_user_id: '777', user_id: u.rows[0].id }),
+		});
+		expect(create.status).toBe(201);
+
+		const list = await ctx.app.request('/api/chat/identities', { headers: auth });
+		const body = (await list.json()) as { data: { identities: Array<Record<string, unknown>> } };
+		const row = body.data.identities.find((i) => i.external_user_id === '777');
+		expect(row).toMatchObject({ channel: 'telegram', user_id: u.rows[0].id });
+
+		// A duplicate (channel, external_user_id) is a conflict.
+		const dup = await ctx.app.request('/api/chat/identities', {
+			method: 'POST',
+			headers: auth,
+			body: JSON.stringify({ channel: 'telegram', external_user_id: '777', user_id: u.rows[0].id }),
+		});
+		expect(dup.status).toBe(409);
+
+		const del = await ctx.app.request(`/api/chat/identities/${row?.id}`, {
+			method: 'DELETE',
+			headers: auth,
+		});
+		expect(del.status).toBe(200);
+	});
+
+	it('rejects a non-admin', async () => {
+		const res = await ctx.app.request('/api/chat/channels', {
+			headers: { 'content-type': 'application/json' },
+		});
+		expect(res.status).toBe(401);
+	});
+});
+
+describe('ChatSessionManager conversation lifecycle', () => {
+	let ctx: ServerTestContext;
+	let manager: ChatSessionManager;
+
+	beforeAll(async () => {
+		ctx = await createTestContext();
+		const wsManager = new WebSocketManager();
+		const logs = new LogStreamBroker();
+		logs.setWsManager(wsManager);
+		manager = new ChatSessionManager({
+			db: ctx.db,
+			docker: createStubDocker(),
+			masterKeyManager: ctx.masterKeyManager,
+			serverPort: 0,
+			dataDir: ctx.dataDir,
+			wsManager,
+			logs,
+		});
+	});
+	afterAll(() => destroyTestContext(ctx));
+
+	it('creates, lists (open-only), and closes web threads', async () => {
+		const defaultId = await manager.getConversationId();
+		const a = await manager.createWebConversation('Thread A');
+		const b = await manager.createWebConversation('Thread B');
+
+		let open = await manager.listConversations();
+		const ids = open.map((c) => c.id);
+		expect(ids).toEqual(expect.arrayContaining([defaultId, a, b]));
+
+		await manager.closeConversation(a);
+		open = await manager.listConversations();
+		expect(open.map((c) => c.id)).not.toContain(a);
+		// Closed still visible when explicitly requested.
+		const all = await manager.listConversations({ includeClosed: true });
+		expect(all.map((c) => c.id)).toContain(a);
+
+		// getConversation reflects the closed state.
+		const closed = await manager.getConversation(a);
+		expect(closed?.closed_at).not.toBeNull();
+	});
+
+	it('resolves the same default web thread each time', async () => {
+		const first = await manager.getConversationId();
+		const second = await manager.getConversationId();
+		expect(first).toBe(second);
+	});
+});

--- a/packages/server/test/chat-session-compaction-lifecycle.test.ts
+++ b/packages/server/test/chat-session-compaction-lifecycle.test.ts
@@ -222,7 +222,7 @@ async function waitComplete(ctx: ServerTestContext, messageId: string): Promise<
 	});
 }
 
-type ManagerInternals = { compaction: Promise<void> | null; current: unknown };
+type ManagerInternals = { hasInflightCompaction: () => boolean };
 
 describe('buildCompactionPrompt', () => {
 	test('renders the empty-memory placeholder and the window transcript', () => {
@@ -347,7 +347,7 @@ describe('ChatSessionManager — window compaction', () => {
 		await waitComplete(ctx, assistantMessageId);
 		await poll(async () => chat.flags.compactionEntered);
 		await poll(async () =>
-			Promise.resolve((manager as unknown as ManagerInternals).compaction === null),
+			Promise.resolve(!(manager as unknown as ManagerInternals).hasInflightCompaction()),
 		);
 
 		// Nothing evicted, no memory row appeared, no compaction broadcast. (The
@@ -380,7 +380,7 @@ describe('ChatSessionManager — window compaction', () => {
 		// maybeCompact swallows the failure (logged as an error — the asserted path)
 		// and clears the in-flight marker so a later reply can retry.
 		await poll(async () =>
-			Promise.resolve((manager as unknown as ManagerInternals).compaction === null),
+			Promise.resolve(!(manager as unknown as ManagerInternals).hasInflightCompaction()),
 		);
 
 		const compacted = await ctx.db.query<{ n: number }>(
@@ -435,7 +435,7 @@ describe('ChatSessionManager — window compaction', () => {
 		await waitComplete(ctx, assistantMessageId);
 		// The background maybeCompact settles (runCompaction returns before any exec).
 		await poll(async () =>
-			Promise.resolve((manager as unknown as ManagerInternals).compaction === null),
+			Promise.resolve(!(manager as unknown as ManagerInternals).hasInflightCompaction()),
 		);
 		expect(chat.flags.compactionEntered).toBe(false);
 		const compacted = await ctx.db.query<{ n: number }>(

--- a/packages/server/test/chat-telegram-adapter.test.ts
+++ b/packages/server/test/chat-telegram-adapter.test.ts
@@ -1,0 +1,73 @@
+import { ChatChannel } from '@hezo/shared';
+import { describe, expect, it } from 'vitest';
+import { escapeMarkdownV2, TelegramAdapter } from '../src/services/chat-channels/telegram';
+import type { ChatChannelAdapterDeps } from '../src/services/chat-channels/types';
+
+// parseInbound + escaping are pure — no DB/master key touched, so a bare deps stub
+// is fine.
+const deps = {} as ChatChannelAdapterDeps;
+const adapter = new TelegramAdapter(deps);
+
+describe('escapeMarkdownV2', () => {
+	it('escapes every MarkdownV2 reserved character', () => {
+		expect(escapeMarkdownV2('a_b*c[d]e(f)')).toBe('a\\_b\\*c\\[d\\]e\\(f\\)');
+		expect(escapeMarkdownV2('1. item! > note')).toBe('1\\. item\\! \\> note');
+		expect(escapeMarkdownV2('a-b=c|d{e}f.g')).toBe('a\\-b\\=c\\|d\\{e\\}f\\.g');
+	});
+
+	it('escapes backslashes and backticks', () => {
+		expect(escapeMarkdownV2('a\\b`c`')).toBe('a\\\\b\\`c\\`');
+	});
+
+	it('leaves ordinary text untouched', () => {
+		expect(escapeMarkdownV2('hello world 42')).toBe('hello world 42');
+	});
+});
+
+describe('TelegramAdapter.parseInbound', () => {
+	it('keys a private DM by the bare chat id', () => {
+		const event = adapter.parseInbound({
+			message: {
+				text: 'hi',
+				from: { id: 42, username: 'op' },
+				chat: { id: 999, type: 'private' },
+			},
+		});
+		expect(event).toEqual({
+			externalUserId: '42',
+			externalThreadId: '999',
+			externalHandle: '@op',
+			text: 'hi',
+		});
+	});
+
+	it('keys a forum-topic message by chat id + message_thread_id', () => {
+		const event = adapter.parseInbound({
+			message: {
+				text: 'in topic',
+				message_thread_id: 7,
+				is_topic_message: true,
+				from: { id: 42 },
+				chat: { id: -100123, type: 'supergroup' },
+			},
+		});
+		expect(event?.externalThreadId).toBe('-100123:7');
+		expect(event?.text).toBe('in topic');
+		expect(event?.externalHandle).toBeUndefined();
+	});
+
+	it('ignores the bot’s own messages, non-text updates, and malformed payloads', () => {
+		expect(
+			adapter.parseInbound({
+				message: { text: 'x', from: { id: 1, is_bot: true }, chat: { id: 2 } },
+			}),
+		).toBeNull();
+		expect(adapter.parseInbound({ message: { from: { id: 1 }, chat: { id: 2 } } })).toBeNull();
+		expect(adapter.parseInbound({ edited_message: { text: 'x' } })).toBeNull();
+		expect(adapter.parseInbound(null)).toBeNull();
+	});
+
+	it('is the telegram channel', () => {
+		expect(adapter.channel).toBe(ChatChannel.Telegram);
+	});
+});

--- a/packages/server/test/chat-webhooks.test.ts
+++ b/packages/server/test/chat-webhooks.test.ts
@@ -1,0 +1,152 @@
+import { ChatChannel } from '@hezo/shared';
+import { Hono } from 'hono';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MasterKeyManager } from '../src/crypto/master-key';
+import type { PgliteDb } from '../src/db/drivers/pglite';
+import type { Env } from '../src/lib/types';
+import { chatWebhookRoutes } from '../src/routes/chat-webhooks';
+import { ChatChannelRegistry } from '../src/services/chat-channels/registry';
+import type {
+	ChatChannelAdapter,
+	InboundChatEvent,
+	OutboundReply,
+} from '../src/services/chat-channels/types';
+import type { ChatSessionManager } from '../src/services/chat-session-manager';
+import { createTestDbWithMigrations } from './helpers/db';
+
+const SECRET = 'webhook-secret-123';
+
+/** Fake adapter: real Telegram-shaped parse, but deliver/promptToLink are spies. */
+function makeAdapter() {
+	const promptToLink = vi.fn(async (_e: InboundChatEvent) => undefined);
+	const deliver = vi.fn(async (_r: OutboundReply) => undefined);
+	const adapter: ChatChannelAdapter = {
+		channel: ChatChannel.Telegram,
+		start: async () => undefined,
+		stop: async () => undefined,
+		parseInbound: (raw: unknown) => {
+			const m = (
+				raw as { message?: { text?: string; from?: { id?: number }; chat?: { id?: number } } }
+			)?.message;
+			if (!m?.text || !m.from?.id || !m.chat?.id) return null;
+			return {
+				externalUserId: String(m.from.id),
+				externalThreadId: String(m.chat.id),
+				text: m.text,
+			};
+		},
+		deliver,
+		promptToLink,
+	};
+	return { adapter, promptToLink, deliver };
+}
+
+describe('POST /webhooks/chat/:channel/:secret', () => {
+	let db: PgliteDb;
+	let app: Hono<Env>;
+	let sendTurn: ReturnType<typeof vi.fn>;
+	let promptToLink: ReturnType<typeof vi.fn>;
+	let userId: string;
+
+	beforeAll(async () => {
+		db = await createTestDbWithMigrations();
+		await db.query(
+			`INSERT INTO chat_channel_configs (channel, enabled, bot_token_secret, webhook_secret)
+			 VALUES ('telegram', true, 'TELEGRAM_BOT_TOKEN', $1)`,
+			[SECRET],
+		);
+		const u = await db.query<{ id: string }>(
+			`INSERT INTO users (display_name) VALUES ('Op') RETURNING id`,
+		);
+		userId = u.rows[0].id;
+		await db.query(
+			`INSERT INTO chat_identity_links (channel, external_user_id, user_id) VALUES ('telegram', '42', $1)`,
+			[userId],
+		);
+	});
+	afterAll(() => db.close());
+
+	beforeEach(() => {
+		const built = makeAdapter();
+		promptToLink = built.promptToLink;
+		const registry = new ChatChannelRegistry();
+		registry.register(built.adapter);
+		sendTurn = vi.fn(async () => ({
+			userMessageId: 'u',
+			assistantMessageId: 'a',
+			conversationId: 'c',
+		}));
+		const manager = { sendTurn } as unknown as ChatSessionManager;
+
+		app = new Hono<Env>();
+		app.use('*', async (c, next) => {
+			c.set('db', db);
+			c.set('masterKeyManager', {} as MasterKeyManager);
+			c.set('chatSessionManager', manager);
+			c.set('chatChannelRegistry', registry);
+			await next();
+		});
+		app.route('/', chatWebhookRoutes);
+	});
+
+	const post = (secret: string, body: unknown, headers: Record<string, string> = {}) =>
+		app.request(`/webhooks/chat/telegram/${secret}`, {
+			method: 'POST',
+			headers: { 'content-type': 'application/json', ...headers },
+			body: JSON.stringify(body),
+		});
+
+	const linkedMessage = { message: { text: 'hello', from: { id: 42 }, chat: { id: 999 } } };
+
+	it('routes a linked sender’s message to the CEO chat', async () => {
+		const res = await post(SECRET, linkedMessage);
+		expect(res.status).toBe(200);
+		// ingest runs in the background; give the microtask/tracked promise a tick.
+		await vi.waitFor(() => expect(sendTurn).toHaveBeenCalledTimes(1));
+		expect(sendTurn.mock.calls[0][0]).toMatchObject({
+			text: 'hello',
+			channel: 'telegram',
+			externalThreadId: '999',
+			authorUserId: userId,
+		});
+	});
+
+	it('rejects a wrong URL secret with 401 and never ingests', async () => {
+		const res = await post('wrong-secret', linkedMessage);
+		expect(res.status).toBe(401);
+		await new Promise((r) => setTimeout(r, 20));
+		expect(sendTurn).not.toHaveBeenCalled();
+	});
+
+	it('rejects a mismatched secret-token header', async () => {
+		const res = await post(SECRET, linkedMessage, {
+			'x-telegram-bot-api-secret-token': 'nope',
+		});
+		expect(res.status).toBe(401);
+	});
+
+	it('accepts a matching secret-token header', async () => {
+		const res = await post(SECRET, linkedMessage, {
+			'x-telegram-bot-api-secret-token': SECRET,
+		});
+		expect(res.status).toBe(200);
+	});
+
+	it('ignores an unlinked sender and prompts them to link', async () => {
+		const res = await post(SECRET, {
+			message: { text: 'hi', from: { id: 8888 }, chat: { id: 1 } },
+		});
+		expect(res.status).toBe(200);
+		await vi.waitFor(() => expect(promptToLink).toHaveBeenCalledTimes(1));
+		expect(sendTurn).not.toHaveBeenCalled();
+	});
+
+	it('returns 404 for an unknown channel', async () => {
+		const res = await app.request(`/webhooks/chat/nope/${SECRET}`, {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: '{}',
+		});
+		expect(res.status).toBe(404);
+	});
+});

--- a/packages/server/test/migrate-029-multi-conversation.test.ts
+++ b/packages/server/test/migrate-029-multi-conversation.test.ts
@@ -1,0 +1,133 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createDataPreservationHarness, type DataPreservationHarness } from './helpers/migrate';
+
+const TARGET = '029_multi_conversation.sql';
+
+// Seeds the pre-existing global CEO conversation (+ a message) at schema 028,
+// applies the multi-conversation migration, and asserts: the new columns exist,
+// the old global row survives as the default open web thread, and a second external
+// thread can be created + resolved via the new partial unique index.
+describe('029_multi_conversation migration', () => {
+	let h: DataPreservationHarness;
+	let ceoMemberId: string;
+	let teamId: string;
+	let projectId: string;
+	let globalConvoId: string;
+	let messageId: string;
+
+	beforeAll(async () => {
+		h = await createDataPreservationHarness();
+		await h.applyUpToExclusive(TARGET);
+
+		const team = await h.db.query<{ id: string }>(
+			`INSERT INTO teams (name, slug) VALUES ('HQ', 'hq-team') RETURNING id`,
+		);
+		teamId = team.rows[0].id;
+		const project = await h.db.query<{ id: string }>(
+			`INSERT INTO projects (team_id, name, slug, task_prefix, is_internal)
+			 VALUES ($1, 'HQ', 'hq', 'HQ', true) RETURNING id`,
+			[teamId],
+		);
+		projectId = project.rows[0].id;
+		const member = await h.db.query<{ id: string }>(
+			`INSERT INTO members (team_id, member_type, display_name)
+			 VALUES ($1, 'agent', 'CEO') RETURNING id`,
+			[teamId],
+		);
+		ceoMemberId = member.rows[0].id;
+
+		const convo = await h.db.query<{ id: string }>(
+			`INSERT INTO chat_conversations (member_id, team_id, project_id, title)
+			 VALUES ($1, $2, $3, 'Global') RETURNING id`,
+			[ceoMemberId, teamId, projectId],
+		);
+		globalConvoId = convo.rows[0].id;
+		const msg = await h.db.query<{ id: string }>(
+			`INSERT INTO chat_messages (conversation_id, role, channel, status, content)
+			 VALUES ($1, 'user', 'web', 'complete', 'hello') RETURNING id`,
+			[globalConvoId],
+		);
+		messageId = msg.rows[0].id;
+
+		await h.applyTarget(TARGET);
+	});
+	afterAll(() => h.close());
+
+	it('adds the multi-conversation columns', async () => {
+		const cols = await h.db.query<{ column_name: string }>(
+			`SELECT column_name FROM information_schema.columns
+			 WHERE table_name = 'chat_conversations'`,
+		);
+		const names = cols.rows.map((r) => r.column_name);
+		expect(names).toContain('channel');
+		expect(names).toContain('external_thread_id');
+		expect(names).toContain('last_activity_at');
+		expect(names).toContain('closed_at');
+	});
+
+	it('preserves the pre-existing global conversation as the default open web thread', async () => {
+		const kept = await h.db.query<{
+			title: string;
+			channel: string;
+			external_thread_id: string | null;
+			closed_at: string | null;
+		}>(
+			`SELECT title, channel::text AS channel, external_thread_id, closed_at
+			 FROM chat_conversations WHERE id = $1`,
+			[globalConvoId],
+		);
+		expect(kept.rows).toHaveLength(1);
+		expect(kept.rows[0].title).toBe('Global');
+		expect(kept.rows[0].channel).toBe('web');
+		expect(kept.rows[0].external_thread_id).toBeNull();
+		expect(kept.rows[0].closed_at).toBeNull();
+		// The message it held is still attached.
+		const m = await h.db.query(`SELECT 1 FROM chat_messages WHERE id = $1`, [messageId]);
+		expect(m.rows.length).toBe(1);
+	});
+
+	it('allows a second external thread and enforces one open conversation per external id', async () => {
+		await h.db.query(
+			`INSERT INTO chat_conversations (member_id, team_id, project_id, channel, external_thread_id)
+			 VALUES ($1, $2, $3, 'telegram', '555:2')`,
+			[ceoMemberId, teamId, projectId],
+		);
+		// A duplicate *open* external thread violates the partial unique index.
+		await expect(
+			h.db.query(
+				`INSERT INTO chat_conversations (member_id, team_id, project_id, channel, external_thread_id)
+				 VALUES ($1, $2, $3, 'telegram', '555:2')`,
+				[ceoMemberId, teamId, projectId],
+			),
+		).rejects.toThrow();
+	});
+
+	it('lets a closed external thread be re-created (index scoped to open threads)', async () => {
+		await h.db.query(
+			`INSERT INTO chat_conversations (member_id, team_id, project_id, channel, external_thread_id, closed_at)
+			 VALUES ($1, $2, $3, 'telegram', '555:9', now())`,
+			[ceoMemberId, teamId, projectId],
+		);
+		// A fresh open thread with the same external id is allowed once the prior is closed.
+		const fresh = await h.db.query<{ id: string }>(
+			`INSERT INTO chat_conversations (member_id, team_id, project_id, channel, external_thread_id)
+			 VALUES ($1, $2, $3, 'telegram', '555:9') RETURNING id`,
+			[ceoMemberId, teamId, projectId],
+		);
+		expect(fresh.rows).toHaveLength(1);
+	});
+
+	it('allows many web threads with a NULL external id', async () => {
+		await h.db.query(
+			`INSERT INTO chat_conversations (member_id, team_id, project_id, channel)
+			 VALUES ($1, $2, $3, 'web'), ($1, $2, $3, 'web')`,
+			[ceoMemberId, teamId, projectId],
+		);
+		const webCount = await h.db.query<{ c: number }>(
+			`SELECT COUNT(*)::int AS c FROM chat_conversations
+			 WHERE channel = 'web' AND external_thread_id IS NULL`,
+		);
+		// The original global row + the two just inserted.
+		expect(webCount.rows[0].c).toBeGreaterThanOrEqual(3);
+	});
+});

--- a/packages/server/test/migrate-030-chat-channels-and-identities.test.ts
+++ b/packages/server/test/migrate-030-chat-channels-and-identities.test.ts
@@ -1,0 +1,90 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createDataPreservationHarness, type DataPreservationHarness } from './helpers/migrate';
+
+const TARGET = '030_chat_channels_and_identities.sql';
+
+// Seeds a user at schema 029, applies the channel-config + identity-link migration,
+// and asserts both new tables exist, a pre-existing user survives, and a config +
+// identity link round-trip (including the (channel, external_user_id) uniqueness).
+describe('030_chat_channels_and_identities migration', () => {
+	let h: DataPreservationHarness;
+	let userId: string;
+
+	beforeAll(async () => {
+		h = await createDataPreservationHarness();
+		await h.applyUpToExclusive(TARGET);
+
+		const user = await h.db.query<{ id: string }>(
+			`INSERT INTO users (display_name) VALUES ('Operator') RETURNING id`,
+		);
+		userId = user.rows[0].id;
+
+		await h.applyTarget(TARGET);
+	});
+	afterAll(() => h.close());
+
+	it('creates both new tables', async () => {
+		const t = await h.db.query<{ table_name: string }>(
+			`SELECT table_name FROM information_schema.tables
+			 WHERE table_name IN ('chat_channel_configs', 'chat_identity_links')`,
+		);
+		const names = t.rows.map((r) => r.table_name);
+		expect(names).toContain('chat_channel_configs');
+		expect(names).toContain('chat_identity_links');
+	});
+
+	it('preserves the pre-existing user', async () => {
+		const u = await h.db.query(`SELECT 1 FROM users WHERE id = $1`, [userId]);
+		expect(u.rows.length).toBe(1);
+	});
+
+	it('round-trips a channel config keyed by channel', async () => {
+		await h.db.query(
+			`INSERT INTO chat_channel_configs (channel, enabled, bot_token_secret, webhook_secret, metadata)
+			 VALUES ('telegram', true, 'telegram_bot_token', 'sekret', '{"group_id":"-100123"}'::jsonb)`,
+		);
+		const cfg = await h.db.query<{ enabled: boolean; group_id: string }>(
+			`SELECT enabled, metadata->>'group_id' AS group_id
+			 FROM chat_channel_configs WHERE channel = 'telegram'`,
+		);
+		expect(cfg.rows[0].enabled).toBe(true);
+		expect(cfg.rows[0].group_id).toBe('-100123');
+	});
+
+	it('links an external identity to a user and enforces per-channel uniqueness', async () => {
+		await h.db.query(
+			`INSERT INTO chat_identity_links (channel, external_user_id, user_id, external_handle)
+			 VALUES ('telegram', '42', $1, '@op')`,
+			[userId],
+		);
+		const link = await h.db.query<{ user_id: string }>(
+			`SELECT user_id FROM chat_identity_links WHERE channel = 'telegram' AND external_user_id = '42'`,
+		);
+		expect(link.rows[0].user_id).toBe(userId);
+
+		// A second link for the same (channel, external_user_id) is rejected.
+		await expect(
+			h.db.query(
+				`INSERT INTO chat_identity_links (channel, external_user_id, user_id)
+				 VALUES ('telegram', '42', $1)`,
+				[userId],
+			),
+		).rejects.toThrow();
+	});
+
+	it('cascades identity-link deletion when the user is removed', async () => {
+		const user = await h.db.query<{ id: string }>(
+			`INSERT INTO users (display_name) VALUES ('Temp') RETURNING id`,
+		);
+		await h.db.query(
+			`INSERT INTO chat_identity_links (channel, external_user_id, user_id)
+			 VALUES ('telegram', '99', $1)`,
+			[user.rows[0].id],
+		);
+		await h.db.query(`DELETE FROM users WHERE id = $1`, [user.rows[0].id]);
+		const gone = await h.db.query(
+			`SELECT 1 FROM chat_identity_links WHERE external_user_id = '99'`,
+		);
+		expect(gone.rows.length).toBe(0);
+	});
+});

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -87,8 +87,16 @@ export const HEZO_DOCS_URL = 'https://hezo.ai/docs/introduction';
 export const wsRoom = {
 	team: (id: string) => `team:${id}`,
 	agent: (id: string) => `agent:${id}`,
-	/** The single global CEO chat room. Every mirrored surface subscribes here. */
+	/**
+	 * Global CEO chat signal room. Every chat surface subscribes here for
+	 * conversation-list level activity (a new thread, cross-thread badges).
+	 */
 	chat: () => 'chat:global',
+	/**
+	 * Per-conversation CEO chat room. Message start/delta/complete for a single
+	 * thread stream here, so an open thread only receives its own deltas.
+	 */
+	chatConversation: (conversationId: string) => `chat:${conversationId}`,
 	/**
 	 * The single global base-image build room. Base images (e.g.
 	 * `hezo/agent-base:latest`) are shared across all projects, so their build

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -930,6 +930,11 @@ export const ChatChannel = {
 } as const;
 export type ChatChannel = (typeof ChatChannel)[keyof typeof ChatChannel];
 
+/** Runtime guard: is a string one of the known chat channels? */
+export function isChatChannel(value: string): value is ChatChannel {
+	return (Object.values(ChatChannel) as string[]).includes(value);
+}
+
 export const ChatMessageRole = {
 	User: 'user',
 	Assistant: 'assistant',

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -917,9 +917,11 @@ export interface ProjectProgress {
 // --- CEO chat ---
 
 /**
- * Surface a CEO chat message arrived through. There is exactly one CEO
- * conversation; every channel (web today, Telegram/WhatsApp later) mirrors the
- * full thread, so `channel` is message *provenance* only, never a partition key.
+ * Surface a CEO chat message arrived through. Each conversation belongs to one
+ * channel: `web` conversations are the in-app chatbox threads; external channels
+ * (Telegram now, Discord later) map each external thread to its own conversation.
+ * The channel is both message provenance and — together with `external_thread_id`
+ * — part of the conversation's identity.
  */
 export const ChatChannel = {
 	Web: 'web',

--- a/packages/shared/src/types/websocket.ts
+++ b/packages/shared/src/types/websocket.ts
@@ -105,6 +105,7 @@ export interface WsProjectsChangedMessage {
  */
 export interface WsChatMessageStartMessage {
 	type: WsMessageType.ChatMessageStart;
+	conversationId: string;
 	messageId: string;
 	role: ChatMessageRole;
 	channel: ChatChannel;
@@ -117,6 +118,7 @@ export interface WsChatMessageStartMessage {
 /** Incremental assistant text appended to the bubble keyed by `messageId`. */
 export interface WsChatMessageDeltaMessage {
 	type: WsMessageType.ChatMessageDelta;
+	conversationId: string;
 	messageId: string;
 	text: string;
 }
@@ -124,6 +126,7 @@ export interface WsChatMessageDeltaMessage {
 /** Terminal event for a CEO message: finalizes content, status, and usage. */
 export interface WsChatMessageCompleteMessage {
 	type: WsMessageType.ChatMessageComplete;
+	conversationId: string;
 	messageId: string;
 	status: ChatMessageStatus;
 	content: string;
@@ -143,6 +146,13 @@ export interface WsChatCompactedMessage {
 	type: WsMessageType.ChatCompacted;
 	conversationId: string;
 }
+
+/** Any CEO chat WebSocket event, all carrying `conversationId` for thread routing. */
+export type WsChatServerMessage =
+	| WsChatMessageStartMessage
+	| WsChatMessageDeltaMessage
+	| WsChatMessageCompleteMessage
+	| WsChatCompactedMessage;
 
 export type WsServerMessage =
 	| WsRowChangeMessage

--- a/packages/web/src/components/chat/chat-widget.tsx
+++ b/packages/web/src/components/chat/chat-widget.tsx
@@ -15,11 +15,12 @@ import {
 	Maximize2,
 	MessageSquare,
 	Minimize2,
+	Plus,
 	X,
 } from 'lucide-react';
 import { type ReactNode, useEffect, useRef, useState } from 'react';
 import { useAutoGrowTextarea } from '../../hooks/use-auto-grow-textarea';
-import { type ChatMessage, useChat } from '../../hooks/use-chat';
+import { type ChatMessage, useChat, useChatConversations } from '../../hooks/use-chat';
 import { useContainerHealth } from '../../hooks/use-container-health';
 import { useDraggableFab } from '../../hooks/use-draggable-fab';
 import { useFileAttachments } from '../../hooks/use-file-attachments';
@@ -58,7 +59,22 @@ export function ChatWidget({ open, onOpenChange }: ChatWidgetProps) {
 	// Draggable launcher on portrait mobile screens (the panel itself never
 	// moves). Must be called before the `if (!open)` early return below.
 	const fab = useDraggableFab('chat');
-	const { messages, send, streaming, sending, loaded, unread, compactedCount } = useChat(open);
+	// The selected thread (undefined = the default web thread). The switcher lets the
+	// operator create/switch/close parallel conversation threads.
+	const [selectedConversationId, setSelectedConversationId] = useState<string | undefined>(
+		undefined,
+	);
+	const {
+		messages,
+		send,
+		streaming,
+		sending,
+		loaded,
+		unread,
+		compactedCount,
+		conversationId: activeConversationId,
+	} = useChat(open, selectedConversationId);
+	const { conversations, createThread, closeThread } = useChatConversations(open);
 	const hq = useHqProject();
 	const hqHealth = useContainerHealth(hq);
 	// The CEO can only act while the HQ container is up. When it isn't, the chat
@@ -142,6 +158,25 @@ export function ChatWidget({ open, onOpenChange }: ChatWidgetProps) {
 		setDraft('');
 		setPendingAttachmentIds([]);
 		send(text, attachments).catch(() => undefined);
+	};
+
+	// Web conversation threads only (external threads are managed from their app).
+	const webThreads = conversations.filter((t) => t.channel === 'web');
+	const activeThread = webThreads.find((t) => t.id === activeConversationId);
+	const threadLabel = (t: (typeof webThreads)[number], i: number) =>
+		t.title?.trim() || (t.external_thread_id ? 'External' : i === 0 ? 'Main' : 'New thread');
+
+	const handleNewThread = async () => {
+		const res = (await createThread().catch(() => null)) as {
+			conversation?: { id: string };
+		} | null;
+		if (res?.conversation?.id) setSelectedConversationId(res.conversation.id);
+	};
+	// Close the active thread; fall back to the default web thread afterwards.
+	const handleCloseThread = async () => {
+		if (!activeConversationId) return;
+		await closeThread(activeConversationId).catch(() => undefined);
+		setSelectedConversationId(undefined);
 	};
 
 	// Copy the whole conversation as plain text, each turn labelled by speaker.
@@ -257,6 +292,45 @@ export function ChatWidget({ open, onOpenChange }: ChatWidgetProps) {
 						</button>
 					</div>
 				</header>
+
+				{/* Thread switcher: pick / create / close parallel conversation threads.
+				    Web threads only; external (Telegram) threads live in their own app. */}
+				<div className="flex items-center gap-1 border-b border-border px-3 py-1.5">
+					<select
+						data-testid="chat-thread-select"
+						aria-label="Conversation thread"
+						value={activeConversationId ?? ''}
+						onChange={(e) => setSelectedConversationId(e.target.value || undefined)}
+						className="min-w-0 flex-1 truncate rounded-md border border-border bg-surface px-2 py-1 text-xs text-text-1"
+					>
+						{webThreads.length === 0 && <option value="">Main</option>}
+						{webThreads.map((t, i) => (
+							<option key={t.id} value={t.id}>
+								{threadLabel(t, i)}
+							</option>
+						))}
+					</select>
+					<button
+						type="button"
+						onClick={handleNewThread}
+						aria-label="New thread"
+						data-testid="chat-thread-new"
+						className="flex h-7 w-7 items-center justify-center rounded-md text-text-2 hover:bg-surface-2 hover:text-text-1"
+					>
+						<Plus className="h-4 w-4" />
+					</button>
+					{activeThread && webThreads.length > 1 && (
+						<button
+							type="button"
+							onClick={handleCloseThread}
+							aria-label="Close thread"
+							data-testid="chat-thread-close"
+							className="flex h-7 w-7 items-center justify-center rounded-md text-text-2 hover:bg-surface-2 hover:text-text-1"
+						>
+							<X className="h-4 w-4" />
+						</button>
+					)}
+				</div>
 
 				{hq && blockedHealth ? (
 					<div

--- a/packages/web/src/components/settings-sidebar.tsx
+++ b/packages/web/src/components/settings-sidebar.tsx
@@ -22,6 +22,7 @@ const ADMIN_ITEMS: NavItem[] = [
 	{ to: '/settings/chatbox', label: 'Chatbox' },
 	{ to: '/settings/skills', label: 'Skills' },
 	{ to: '/settings/connectors', label: 'Connectors' },
+	{ to: '/settings/chat-channels', label: 'Chat channels' },
 	{ to: '/settings/credentials', label: 'Credentials' },
 	{ to: '/settings/api-keys', label: 'API keys' },
 	{ to: '/settings/archived-projects', label: 'Archived projects' },

--- a/packages/web/src/hooks/use-chat-channels.ts
+++ b/packages/web/src/hooks/use-chat-channels.ts
@@ -1,0 +1,85 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { api } from '../lib/api';
+import { toast } from './use-toast';
+
+export interface ChatChannelConfigView {
+	channel: string;
+	enabled: boolean;
+	has_token: boolean;
+	has_webhook: boolean;
+	metadata: Record<string, unknown>;
+	updated_at: string;
+}
+
+export interface ChatIdentityLink {
+	id: string;
+	channel: string;
+	external_user_id: string;
+	external_handle: string | null;
+	user_id: string;
+	display_name: string;
+	created_at: string;
+}
+
+const channelsKey = () => ['chat', 'channels'] as const;
+const identitiesKey = () => ['chat', 'identities'] as const;
+
+/** Channel bot configs (token/secret redacted) for the settings page. */
+export function useChatChannels() {
+	const queryClient = useQueryClient();
+	const query = useQuery({
+		queryKey: channelsKey(),
+		queryFn: () => api.get<{ channels: ChatChannelConfigView[] }>('/api/chat/channels'),
+	});
+	const save = useMutation({
+		mutationFn: (input: {
+			channel: string;
+			enabled: boolean;
+			bot_token?: string;
+			metadata?: Record<string, unknown>;
+		}) =>
+			api.put(`/api/chat/channels/${input.channel}`, {
+				enabled: input.enabled,
+				bot_token: input.bot_token,
+				metadata: input.metadata,
+			}),
+		onSuccess: () => queryClient.invalidateQueries({ queryKey: channelsKey() }),
+		onError: (e: { message?: string }) => toast.error(e?.message ?? 'Failed to save channel'),
+	});
+	return {
+		channels: query.data?.channels ?? [],
+		loaded: !query.isPending,
+		saveChannel: save.mutateAsync,
+		saving: save.isPending,
+	};
+}
+
+/** Identity allowlist links for the settings page. */
+export function useChatIdentities() {
+	const queryClient = useQueryClient();
+	const query = useQuery({
+		queryKey: identitiesKey(),
+		queryFn: () => api.get<{ identities: ChatIdentityLink[] }>('/api/chat/identities'),
+	});
+	const link = useMutation({
+		mutationFn: (input: {
+			channel: string;
+			external_user_id: string;
+			user_id: string;
+			external_handle?: string;
+		}) => api.post('/api/chat/identities', input),
+		onSuccess: () => queryClient.invalidateQueries({ queryKey: identitiesKey() }),
+		onError: (e: { message?: string }) => toast.error(e?.message ?? 'Failed to link identity'),
+	});
+	const unlink = useMutation({
+		mutationFn: (id: string) => api.delete(`/api/chat/identities/${id}`),
+		onSuccess: () => queryClient.invalidateQueries({ queryKey: identitiesKey() }),
+		onError: (e: { message?: string }) => toast.error(e?.message ?? 'Failed to unlink identity'),
+	});
+	return {
+		identities: query.data?.identities ?? [],
+		loaded: !query.isPending,
+		linkIdentity: link.mutateAsync,
+		unlinkIdentity: unlink.mutateAsync,
+	};
+}

--- a/packages/web/src/hooks/use-chat.ts
+++ b/packages/web/src/hooks/use-chat.ts
@@ -61,20 +61,64 @@ function writeStoredUnread(count: number): void {
 	}
 }
 
+/** A conversation thread in the switcher list. */
+export interface ChatConversationSummary {
+	id: string;
+	channel: ChatChannel;
+	external_thread_id: string | null;
+	title: string | null;
+	last_activity_at: string;
+	closed_at: string | null;
+}
+
 /**
- * Drives the single global CEO chat. The TanStack Query cache is the source of
- * truth for messages (keyed by {@link queryKeys.chatConversation}); the initial
- * history loads via `useQuery` and streamed start/delta/complete events from the
- * `chat:global` room are folded into the same cache entry via `setQueryData`.
- * Because every surface mirrors the one conversation, the user's own messages
- * (echoed back over the socket) arrive the same way. The query never refetches
- * on its own (`staleTime: Infinity`) so an in-flight reply's accumulated deltas
- * aren't clobbered by a server snapshot that only persists on completion.
+ * List the CEO chat conversation threads (open only) and expose create/close
+ * mutations for the switcher. Invalidated on new activity via the global room.
  */
-export function useChat(active: boolean) {
+export function useChatConversations(active: boolean) {
+	const queryClient = useQueryClient();
+	const query = useQuery({
+		queryKey: queryKeys.chatConversations(),
+		queryFn: () => api.get<{ conversations: ChatConversationSummary[] }>('/api/chat/conversations'),
+		enabled: active,
+	});
+	const create = useMutation({
+		mutationFn: (title?: string) =>
+			api.post<{ conversation: ChatConversationSummary }>('/api/chat/conversations', { title }),
+		onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.chatConversations() }),
+		onError: (e: { message?: string }) => toast.error(e?.message ?? 'Failed to create thread'),
+	});
+	const close = useMutation({
+		mutationFn: (id: string) => api.post(`/api/chat/conversations/${id}/close`, {}),
+		onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.chatConversations() }),
+		onError: (e: { message?: string }) => toast.error(e?.message ?? 'Failed to close thread'),
+	});
+	return {
+		conversations: query.data?.conversations ?? [],
+		loaded: !query.isPending,
+		createThread: (title?: string) => create.mutateAsync(title),
+		closeThread: (id: string) => close.mutateAsync(id),
+	};
+}
+
+/**
+ * Drives one CEO chat conversation thread (the default web thread when
+ * `conversationId` is omitted). The TanStack Query cache is the source of truth
+ * for messages (keyed by {@link queryKeys.chatConversation} + the thread id); the
+ * initial history loads via `useQuery` and streamed start/delta/complete events
+ * are folded into the same cache entry via `setQueryData`. Events carry their
+ * `conversationId`, so a message for another thread is ignored. The query never
+ * refetches on its own (`staleTime: Infinity`) so an in-flight reply's accumulated
+ * deltas aren't clobbered by a server snapshot that only persists on completion.
+ */
+export function useChat(active: boolean, conversationId?: string) {
 	const { subscribe, joinRoom, leaveRoom } = useSocket();
 	const queryClient = useQueryClient();
 	const [unread, setUnread] = useState<number>(readStoredUnread);
+	// The server-resolved id of the thread this hook is showing (the default web
+	// thread resolves to a concrete id in the query response). Used to filter WS
+	// events so another thread's stream never lands in this cache entry.
+	const resolvedIdRef = useRef<string | null>(conversationId ?? null);
 	// In-flight send: the user's text is shown optimistically (with a pending
 	// assistant placeholder) while the server warms the session / egress check, so
 	// the operator gets immediate feedback instead of a ~10s blank. Cleared when the
@@ -92,12 +136,19 @@ export function useChat(active: boolean) {
 	}, [active]);
 
 	const query = useQuery({
-		queryKey: queryKeys.chatConversation(),
-		queryFn: () => api.get<ConversationData>('/api/chat/conversation'),
+		queryKey: queryKeys.chatConversation(conversationId),
+		queryFn: () =>
+			api.get<ConversationData>(
+				conversationId
+					? `/api/chat/conversation?conversation_id=${encodeURIComponent(conversationId)}`
+					: '/api/chat/conversation',
+			),
 		enabled: active,
 		staleTime: Number.POSITIVE_INFINITY,
 		refetchOnWindowFocus: false,
 	});
+	// Track the server-resolved thread id so WS events can be filtered to this thread.
+	resolvedIdRef.current = query.data?.conversation_id ?? conversationId ?? null;
 
 	// Opening the chat means the operator is reading it — drop the unread badge.
 	useEffect(() => {
@@ -117,12 +168,18 @@ export function useChat(active: boolean) {
 
 	useEffect(() => {
 		const patch = (fn: (messages: ChatMessage[]) => ChatMessage[]) => {
-			queryClient.setQueryData<ConversationData>(queryKeys.chatConversation(), (prev) =>
-				prev ? { ...prev, messages: fn(prev.messages) } : prev,
+			queryClient.setQueryData<ConversationData>(
+				queryKeys.chatConversation(conversationId),
+				(prev) => (prev ? { ...prev, messages: fn(prev.messages) } : prev),
 			);
 		};
+		// A message belongs to this thread when its conversationId matches the
+		// resolved id (or either side is absent — back-compat / pre-resolution).
+		const forThisThread = (cid?: string): boolean =>
+			!cid || !resolvedIdRef.current || cid === resolvedIdRef.current;
 		const offStart = subscribe(WsMessageType.ChatMessageStart, (raw) => {
 			const m = raw as WsChatMessageStartMessage;
+			if (!forThisThread(m.conversationId)) return;
 			// The real user message landed — drop the optimistic placeholder so the
 			// server rows (user + streaming assistant) take over without duplicating.
 			if (m.role === 'user') setPending(null);
@@ -145,12 +202,14 @@ export function useChat(active: boolean) {
 		});
 		const offDelta = subscribe(WsMessageType.ChatMessageDelta, (raw) => {
 			const m = raw as WsChatMessageDeltaMessage;
+			if (!forThisThread(m.conversationId)) return;
 			patch((messages) =>
 				messages.map((x) => (x.id === m.messageId ? { ...x, content: x.content + m.text } : x)),
 			);
 		});
 		const offComplete = subscribe(WsMessageType.ChatMessageComplete, (raw) => {
 			const m = raw as WsChatMessageCompleteMessage;
+			if (!forThisThread(m.conversationId)) return;
 			patch((messages) =>
 				messages.map((x) =>
 					x.id === m.messageId ? { ...x, content: m.content, status: m.status } : x,
@@ -169,8 +228,10 @@ export function useChat(active: boolean) {
 		// Older messages were compacted into long-term memory and evicted. Refetch
 		// the conversation so the chatbox drops them (leaving the retained tail) and
 		// picks up the new compacted_count that drives the "chat compacted" marker.
-		const offCompacted = subscribe(WsMessageType.ChatCompacted, () => {
-			queryClient.invalidateQueries({ queryKey: queryKeys.chatConversation() });
+		const offCompacted = subscribe(WsMessageType.ChatCompacted, (raw) => {
+			const m = raw as { conversationId?: string };
+			if (!forThisThread(m.conversationId)) return;
+			queryClient.invalidateQueries({ queryKey: queryKeys.chatConversation(conversationId) });
 		});
 		return () => {
 			offStart();
@@ -178,11 +239,15 @@ export function useChat(active: boolean) {
 			offComplete();
 			offCompacted();
 		};
-	}, [subscribe, queryClient]);
+	}, [subscribe, queryClient, conversationId]);
 
 	const sendMutation = useMutation({
 		mutationFn: ({ text, attachmentIds }: { text: string; attachmentIds: string[] }) =>
-			api.post('/api/chat/messages', { text, attachment_ids: attachmentIds }),
+			api.post('/api/chat/messages', {
+				text,
+				attachment_ids: attachmentIds,
+				...(conversationId ? { conversation_id: conversationId } : {}),
+			}),
 		onError: (error: { message?: string }) => {
 			toast.error(error?.message ?? 'Failed to send message to the CEO');
 		},
@@ -235,6 +300,9 @@ export function useChat(active: boolean) {
 		sending: pending !== null,
 		loaded: !query.isPending,
 		unread,
+		// The server-resolved id of the active thread (the default web thread when
+		// no id was passed) — drives the switcher's selected value.
+		conversationId: query.data?.conversation_id,
 		// >0 once older messages have been compacted into long-term memory; drives
 		// the "chat compacted" marker at the top of the window.
 		compactedCount: query.data?.compacted_count ?? 0,

--- a/packages/web/src/hooks/use-me.ts
+++ b/packages/web/src/hooks/use-me.ts
@@ -5,6 +5,8 @@ import { queryKeys } from '../lib/query-keys';
 export interface Me {
 	type: string;
 	is_superuser: boolean;
+	/** The human user's id (Admin only; null otherwise) — for identity linking. */
+	user_id: string | null;
 }
 
 /**

--- a/packages/web/src/lib/query-keys.ts
+++ b/packages/web/src/lib/query-keys.ts
@@ -32,8 +32,17 @@ export const queryKeys = {
 	assetStorageInfo: () => ['instance', 'asset-storage'],
 	/** Instance-wide mention resolution (global CEO chat), keyed by sorted candidates. */
 	instanceMentionsResolve: (key: KeyParam) => ['instance', 'mentions', 'resolve', key],
-	/** The single global CEO chat conversation (history + streamed messages). */
-	chatConversation: () => ['chat', 'conversation'],
+	/**
+	 * A CEO chat conversation thread (history + streamed messages), keyed by
+	 * conversation id. `'default'` is the default web thread (server-resolved).
+	 */
+	chatConversation: (conversationId: string = 'default') => [
+		'chat',
+		'conversation',
+		conversationId,
+	],
+	/** The list of CEO chat conversation threads (the switcher). */
+	chatConversations: () => ['chat', 'conversations'],
 	/** Global full-text search (Cmd/Ctrl+K palette), keyed by query + scope. */
 	search: (q: string, scope: string) => ['search', q, scope],
 	/** Bundled OAuth-provider descriptors for the generic OAuth-broker form. */

--- a/packages/web/src/routeTree.gen.ts
+++ b/packages/web/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as SettingsSkillsRouteImport } from './routes/settings/skills'
 import { Route as SettingsCredentialsRouteImport } from './routes/settings/credentials'
 import { Route as SettingsConnectorsRouteImport } from './routes/settings/connectors'
 import { Route as SettingsChatboxRouteImport } from './routes/settings/chatbox'
+import { Route as SettingsChatChannelsRouteImport } from './routes/settings/chat-channels'
 import { Route as SettingsAuditLogRouteImport } from './routes/settings/audit-log'
 import { Route as SettingsArchivedProjectsRouteImport } from './routes/settings/archived-projects'
 import { Route as SettingsApiKeysRouteImport } from './routes/settings/api-keys'
@@ -90,6 +91,11 @@ const SettingsConnectorsRoute = SettingsConnectorsRouteImport.update({
 const SettingsChatboxRoute = SettingsChatboxRouteImport.update({
   id: '/chatbox',
   path: '/chatbox',
+  getParentRoute: () => SettingsRouteRoute,
+} as any)
+const SettingsChatChannelsRoute = SettingsChatChannelsRouteImport.update({
+  id: '/chat-channels',
+  path: '/chat-channels',
   getParentRoute: () => SettingsRouteRoute,
 } as any)
 const SettingsAuditLogRoute = SettingsAuditLogRouteImport.update({
@@ -295,6 +301,7 @@ export interface FileRoutesByFullPath {
   '/settings/api-keys': typeof SettingsApiKeysRoute
   '/settings/archived-projects': typeof SettingsArchivedProjectsRoute
   '/settings/audit-log': typeof SettingsAuditLogRoute
+  '/settings/chat-channels': typeof SettingsChatChannelsRoute
   '/settings/chatbox': typeof SettingsChatboxRoute
   '/settings/connectors': typeof SettingsConnectorsRoute
   '/settings/credentials': typeof SettingsCredentialsRoute
@@ -337,6 +344,7 @@ export interface FileRoutesByTo {
   '/settings/api-keys': typeof SettingsApiKeysRoute
   '/settings/archived-projects': typeof SettingsArchivedProjectsRoute
   '/settings/audit-log': typeof SettingsAuditLogRoute
+  '/settings/chat-channels': typeof SettingsChatChannelsRoute
   '/settings/chatbox': typeof SettingsChatboxRoute
   '/settings/connectors': typeof SettingsConnectorsRoute
   '/settings/credentials': typeof SettingsCredentialsRoute
@@ -381,6 +389,7 @@ export interface FileRoutesById {
   '/settings/api-keys': typeof SettingsApiKeysRoute
   '/settings/archived-projects': typeof SettingsArchivedProjectsRoute
   '/settings/audit-log': typeof SettingsAuditLogRoute
+  '/settings/chat-channels': typeof SettingsChatChannelsRoute
   '/settings/chatbox': typeof SettingsChatboxRoute
   '/settings/connectors': typeof SettingsConnectorsRoute
   '/settings/credentials': typeof SettingsCredentialsRoute
@@ -427,6 +436,7 @@ export interface FileRouteTypes {
     | '/settings/api-keys'
     | '/settings/archived-projects'
     | '/settings/audit-log'
+    | '/settings/chat-channels'
     | '/settings/chatbox'
     | '/settings/connectors'
     | '/settings/credentials'
@@ -469,6 +479,7 @@ export interface FileRouteTypes {
     | '/settings/api-keys'
     | '/settings/archived-projects'
     | '/settings/audit-log'
+    | '/settings/chat-channels'
     | '/settings/chatbox'
     | '/settings/connectors'
     | '/settings/credentials'
@@ -512,6 +523,7 @@ export interface FileRouteTypes {
     | '/settings/api-keys'
     | '/settings/archived-projects'
     | '/settings/audit-log'
+    | '/settings/chat-channels'
     | '/settings/chatbox'
     | '/settings/connectors'
     | '/settings/credentials'
@@ -613,6 +625,13 @@ declare module '@tanstack/react-router' {
       path: '/chatbox'
       fullPath: '/settings/chatbox'
       preLoaderRoute: typeof SettingsChatboxRouteImport
+      parentRoute: typeof SettingsRouteRoute
+    }
+    '/settings/chat-channels': {
+      id: '/settings/chat-channels'
+      path: '/chat-channels'
+      fullPath: '/settings/chat-channels'
+      preLoaderRoute: typeof SettingsChatChannelsRouteImport
       parentRoute: typeof SettingsRouteRoute
     }
     '/settings/audit-log': {
@@ -862,6 +881,7 @@ interface SettingsRouteRouteChildren {
   SettingsApiKeysRoute: typeof SettingsApiKeysRoute
   SettingsArchivedProjectsRoute: typeof SettingsArchivedProjectsRoute
   SettingsAuditLogRoute: typeof SettingsAuditLogRoute
+  SettingsChatChannelsRoute: typeof SettingsChatChannelsRoute
   SettingsChatboxRoute: typeof SettingsChatboxRoute
   SettingsConnectorsRoute: typeof SettingsConnectorsRoute
   SettingsCredentialsRoute: typeof SettingsCredentialsRoute
@@ -875,6 +895,7 @@ const SettingsRouteRouteChildren: SettingsRouteRouteChildren = {
   SettingsApiKeysRoute: SettingsApiKeysRoute,
   SettingsArchivedProjectsRoute: SettingsArchivedProjectsRoute,
   SettingsAuditLogRoute: SettingsAuditLogRoute,
+  SettingsChatChannelsRoute: SettingsChatChannelsRoute,
   SettingsChatboxRoute: SettingsChatboxRoute,
   SettingsConnectorsRoute: SettingsConnectorsRoute,
   SettingsCredentialsRoute: SettingsCredentialsRoute,

--- a/packages/web/src/routes/settings/chat-channels.tsx
+++ b/packages/web/src/routes/settings/chat-channels.tsx
@@ -1,0 +1,250 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { Loader2, Trash2 } from 'lucide-react';
+import { useState } from 'react';
+import { Button } from '../../components/ui/button';
+import { InfoTooltip } from '../../components/ui/info-tooltip';
+import { Input } from '../../components/ui/input';
+import {
+	type ChatChannelConfigView,
+	useChatChannels,
+	useChatIdentities,
+} from '../../hooks/use-chat-channels';
+import { useMe } from '../../hooks/use-me';
+
+function ChatChannelsSettingsPage() {
+	const { data: me } = useMe();
+	if (me && !me.is_superuser) {
+		return (
+			<div className="max-w-[900px]">
+				<p className="text-[13px] text-text-2">
+					Chat channels are managed by the Admin. You don't have access to this page.
+				</p>
+			</div>
+		);
+	}
+	return (
+		<div className="max-w-[900px]">
+			<div className="mb-5">
+				<div className="flex items-center gap-1.5">
+					<h1 className="text-[22px] font-medium">Chat channels</h1>
+					<InfoTooltip
+						label="About chat channels"
+						content="Connect external chat apps (Telegram) so you can talk to the CEO from outside the web app. Only linked identities may chat."
+					/>
+				</div>
+				<p className="text-[13px] text-text-2 mt-1 max-w-[680px]">
+					Talk to the CEO from Telegram. Paste your bot token, then link the accounts allowed to
+					chat. For multiple threads, add the bot to a Topics-enabled supergroup as an admin with
+					the “Manage topics” permission — each topic becomes its own conversation. A private DM is
+					a single conversation.
+				</p>
+			</div>
+
+			<TelegramSection />
+			<IdentitiesSection />
+		</div>
+	);
+}
+
+function TelegramSection() {
+	const { channels, saveChannel, saving } = useChatChannels();
+	const telegram = channels.find((c) => c.channel === 'telegram');
+	return (
+		<section
+			className="border border-border rounded-md p-4 bg-surface mb-4"
+			data-testid="telegram-channel"
+		>
+			<h2 className="text-[15px] font-medium mb-1">Telegram</h2>
+			<p className="text-[13px] text-text-2 mb-3 max-w-[680px]">
+				Create a bot with @BotFather, then paste its token. Saving registers the inbound webhook
+				automatically.
+			</p>
+			<ChannelForm channel="telegram" config={telegram} onSave={saveChannel} saving={saving} />
+		</section>
+	);
+}
+
+function ChannelForm({
+	channel,
+	config,
+	onSave,
+	saving,
+}: {
+	channel: string;
+	config: ChatChannelConfigView | undefined;
+	onSave: (input: {
+		channel: string;
+		enabled: boolean;
+		bot_token?: string;
+		metadata?: Record<string, unknown>;
+	}) => Promise<unknown>;
+	saving: boolean;
+}) {
+	const [token, setToken] = useState('');
+	const [groupId, setGroupId] = useState(String((config?.metadata?.group_id as string) ?? ''));
+	const [enabled, setEnabled] = useState(config?.enabled ?? false);
+
+	const handleSave = () =>
+		onSave({
+			channel,
+			enabled,
+			bot_token: token.trim() || undefined,
+			metadata: { group_id: groupId.trim() },
+		}).then(() => setToken(''));
+
+	return (
+		<div className="flex flex-col gap-3">
+			<label className="flex items-center gap-2 text-[13px]">
+				<input
+					type="checkbox"
+					data-testid={`${channel}-enabled`}
+					checked={enabled}
+					onChange={(e) => setEnabled(e.target.checked)}
+				/>
+				Enabled
+			</label>
+			<div>
+				<label className="block text-[13px] font-medium mb-1" htmlFor={`${channel}-token`}>
+					Bot token{' '}
+					{config?.has_token && <span className="text-text-2">(set — paste to replace)</span>}
+				</label>
+				<Input
+					id={`${channel}-token`}
+					data-testid={`${channel}-token`}
+					type="password"
+					autoComplete="off"
+					placeholder={config?.has_token ? '••••••••' : 'Paste bot token'}
+					value={token}
+					onChange={(e) => setToken(e.target.value)}
+					className="sm:w-96"
+				/>
+			</div>
+			<div>
+				<label className="block text-[13px] font-medium mb-1" htmlFor={`${channel}-group`}>
+					Topics supergroup id <span className="text-text-2">(optional, for threads)</span>
+				</label>
+				<Input
+					id={`${channel}-group`}
+					data-testid={`${channel}-group`}
+					placeholder="-1001234567890"
+					value={groupId}
+					onChange={(e) => setGroupId(e.target.value)}
+					className="sm:w-96"
+				/>
+			</div>
+			<div>
+				<Button size="sm" data-testid={`${channel}-save`} onClick={handleSave} disabled={saving}>
+					{saving && <Loader2 className="w-3 h-3 animate-spin" />} Save
+				</Button>
+			</div>
+		</div>
+	);
+}
+
+function IdentitiesSection() {
+	const { data: me } = useMe();
+	const { identities, linkIdentity, unlinkIdentity } = useChatIdentities();
+	const [channel, setChannel] = useState('telegram');
+	const [externalId, setExternalId] = useState('');
+	const [handle, setHandle] = useState('');
+
+	const handleLink = async () => {
+		if (!externalId.trim() || !me?.user_id) return;
+		await linkIdentity({
+			channel,
+			external_user_id: externalId.trim(),
+			user_id: me.user_id,
+			external_handle: handle.trim() || undefined,
+		});
+		setExternalId('');
+		setHandle('');
+	};
+
+	return (
+		<section className="border border-border rounded-md p-4 bg-surface" data-testid="identities">
+			<h2 className="text-[15px] font-medium mb-1">Allowed identities</h2>
+			<p className="text-[13px] text-text-2 mb-3 max-w-[680px]">
+				Only these external accounts may chat with the CEO. Add your Telegram numeric user id (send
+				a message to @userinfobot to find it); it links to your Hezo account.
+			</p>
+
+			<div className="flex flex-col gap-2 sm:flex-row sm:items-end mb-4">
+				<div>
+					<label className="block text-[13px] font-medium mb-1" htmlFor="identity-channel">
+						Channel
+					</label>
+					<select
+						id="identity-channel"
+						data-testid="identity-channel"
+						value={channel}
+						onChange={(e) => setChannel(e.target.value)}
+						className="rounded-md border border-border bg-surface px-2 py-1.5 text-[13px]"
+					>
+						<option value="telegram">Telegram</option>
+					</select>
+				</div>
+				<div>
+					<label className="block text-[13px] font-medium mb-1" htmlFor="identity-external-id">
+						External user id
+					</label>
+					<Input
+						id="identity-external-id"
+						data-testid="identity-external-id"
+						value={externalId}
+						onChange={(e) => setExternalId(e.target.value)}
+						className="sm:w-48"
+					/>
+				</div>
+				<div>
+					<label className="block text-[13px] font-medium mb-1" htmlFor="identity-handle">
+						Handle <span className="text-text-2">(optional)</span>
+					</label>
+					<Input
+						id="identity-handle"
+						data-testid="identity-handle"
+						placeholder="@you"
+						value={handle}
+						onChange={(e) => setHandle(e.target.value)}
+						className="sm:w-40"
+					/>
+				</div>
+				<Button
+					size="sm"
+					data-testid="identity-add"
+					onClick={handleLink}
+					disabled={!externalId.trim()}
+				>
+					Link to me
+				</Button>
+			</div>
+
+			{identities.length === 0 ? (
+				<p className="text-[13px] text-text-2">No linked identities yet.</p>
+			) : (
+				<ul className="divide-y divide-border" data-testid="identity-list">
+					{identities.map((i) => (
+						<li key={i.id} className="flex items-center justify-between py-2 text-[13px]">
+							<span>
+								<span className="font-medium capitalize">{i.channel}</span> ·{' '}
+								{i.external_handle || i.external_user_id} → {i.display_name}
+							</span>
+							<button
+								type="button"
+								aria-label="Unlink identity"
+								data-testid={`identity-remove-${i.id}`}
+								onClick={() => unlinkIdentity(i.id)}
+								className="flex h-8 w-8 items-center justify-center rounded-md text-text-2 hover:bg-surface-2 hover:text-danger"
+							>
+								<Trash2 className="h-4 w-4" />
+							</button>
+						</li>
+					))}
+				</ul>
+			)}
+		</section>
+	);
+}
+
+export const Route = createFileRoute('/settings/chat-channels')({
+	component: ChatChannelsSettingsPage,
+});

--- a/packages/web/test/chat-channels-settings.test.tsx
+++ b/packages/web/test/chat-channels-settings.test.tsx
@@ -1,0 +1,36 @@
+import { expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+
+// The chat-channels settings page is backed by the admin REST routes (no
+// ChatSessionManager needed). Drives the Telegram config + identity allowlist
+// end-to-end against the in-process backend.
+
+test('configures the Telegram bot and links an identity', async () => {
+	const { findByRole, findByTestId, getByTestId, user } = await renderApp({
+		initialPath: '/settings/chat-channels',
+	});
+
+	await findByRole('heading', { name: 'Chat channels' });
+	await findByTestId('telegram-channel');
+
+	// Enable + save a bot token.
+	await user.click(getByTestId('telegram-enabled'));
+	await user.type(getByTestId('telegram-token'), 'bot-token-abc');
+	await user.type(getByTestId('telegram-group'), '-1005');
+	await user.click(getByTestId('telegram-save'));
+
+	// After the save + refetch, the token reads as set (never echoed back).
+	await expect
+		.poll(async () => (getByTestId('telegram-token') as HTMLInputElement).placeholder)
+		.toContain('••');
+
+	// Link a Telegram identity to the current admin.
+	await user.type(getByTestId('identity-external-id'), '4242');
+	await user.type(getByTestId('identity-handle'), '@me');
+	await user.click(getByTestId('identity-add'));
+
+	const list = await findByTestId('identity-list');
+	// Handle is shown when set; the row also names the channel.
+	expect(list.textContent).toContain('@me');
+	expect(list.textContent?.toLowerCase()).toContain('telegram');
+});

--- a/packages/web/test/chat-threads.test.tsx
+++ b/packages/web/test/chat-threads.test.tsx
@@ -1,0 +1,69 @@
+import type { ChatConversationSummary, ChatMessage } from '@hezo/web/hooks/use-chat';
+import { queryClient } from '@hezo/web/lib/query-client';
+import { queryKeys } from '@hezo/web/lib/query-keys';
+import { expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+
+// The component harness has no ChatSessionManager (chat endpoints 503), so we seed
+// the query caches the hooks read from — `useChat` keys history by conversation id
+// (staleTime Infinity, so a seeded thread never refetches), and
+// `useChatConversations` drives the switcher list. This asserts the switcher
+// re-keys the chatbox to the selected thread.
+
+const now = () => new Date().toISOString();
+
+function msg(id: string, content: string): ChatMessage {
+	return { id, role: 'assistant', channel: 'web', status: 'complete', content, created_at: now() };
+}
+
+function thread(id: string, title: string): ChatConversationSummary {
+	return {
+		id,
+		channel: 'web',
+		external_thread_id: null,
+		title,
+		last_activity_at: now(),
+		closed_at: null,
+	};
+}
+
+function seedThreads() {
+	queryClient.setQueryData(queryKeys.chatConversations(), {
+		conversations: [thread('thread-1', 'First'), thread('thread-2', 'Second')],
+	});
+	// The default web thread (no id passed) resolves to thread-1.
+	queryClient.setQueryData(queryKeys.chatConversation(), {
+		conversation_id: 'thread-1',
+		messages: [msg('m1', 'hello from the first thread')],
+		compacted_count: 0,
+	});
+	queryClient.setQueryData(queryKeys.chatConversation('thread-2'), {
+		conversation_id: 'thread-2',
+		messages: [msg('m2', 'hello from the second thread')],
+		compacted_count: 0,
+	});
+}
+
+test('the thread switcher re-keys the chatbox to the selected conversation', async () => {
+	seedThreads();
+	const { findByTestId, getByTestId, getByText, findByText, queryByText, user } = await renderApp({
+		initialPath: '/home',
+	});
+
+	(await findByTestId('chat-launcher')).click();
+	await findByTestId('chat-panel');
+
+	// The switcher renders with both web threads, first thread active + its messages.
+	const select = (await findByTestId('chat-thread-select')) as HTMLSelectElement;
+	expect(select.value).toBe('thread-1');
+	expect(getByText('hello from the first thread')).toBeTruthy();
+	expect(queryByText('hello from the second thread')).toBeNull();
+
+	// Switching to the second thread swaps the chatbox to that thread's history.
+	await user.selectOptions(select, 'thread-2');
+	expect(await findByText('hello from the second thread')).toBeTruthy();
+	expect(queryByText('hello from the first thread')).toBeNull();
+
+	// A new-thread affordance is present.
+	expect(getByTestId('chat-thread-new')).toBeTruthy();
+});


### PR DESCRIPTION
## What & why

Today you can only chat with the CEO from the **web app**, and there is exactly **one global CEO conversation** (a hard singleton). This adds:

1. **A new realtime chat avenue** — talk to the CEO from **Telegram**.
2. **Conversation threads, generally** — many parallel threads: the web chatbox gets a thread switcher (new / switch / close), and each external thread (a Telegram forum topic) is its own conversation.

**Discord is deferred** by design — the reusable channel-adapter core is built now, so Discord slots in later as one adapter file + one enum migration. Its full plan is captured in `.dev/discord-chat-adapter.md`.

## Design: generic channel adapters

The backend is built around a `ChatChannelAdapter` interface + registry (`packages/server/src/services/chat-channels/`). An adapter owns *everything* platform-specific — inbound parse, outbound deliver, thread create/close, transport lifecycle. The manager, the inbound webhook route, the config routes, and the web core are **channel-agnostic** — they resolve a channel only through the registry, never by branching on a platform name. Adding a future app (Slack, WhatsApp) is one adapter file. The extension checklist lives in `AGENTS.md` → *Adding a chat channel adapter*.

## How it works

- **Multi-thread manager.** `chat_conversations` is keyed by `(member_id, channel, external_thread_id)` (partial unique index scoped to open threads via `closed_at`). The warm HQ container stays a **single shared lease** — a thread is just message-grouping + rolling window; each turn is a stateless one-shot `docker exec` reading a **per-turn prompt file** (fixes a collision concurrent threads would otherwise hit). Turn state (lock / in-flight / compaction) moved into a per-conversation map. Long-term memory stays per-agent; compaction serialises at the member level so concurrent threads never clobber the shared memory row.
- **Inbound** arrives at a generic public webhook `POST /webhooks/chat/:channel/:secret` (mounted before bearer auth; per-channel shared-secret, constant-time compared) → `parseInbound` → `ingestInboundEvent`, which enforces the **identity allowlist** (`chat_identity_links`) before routing to `sendTurn`. Unlinked senders are ignored/prompted to link.
- **Telegram threading** maps to its one native primitive: a private DM is one conversation; a Topics-enabled supergroup gives one conversation per topic (`createForumTopic`/`closeForumTopic`, needs bot admin + `can_manage_topics`).
- **Bot tokens** live in the `secrets` vault and are decrypted **in-process** by trusted server code — outbound bot calls go direct (`api.telegram.org`), NOT through the agent egress proxy (that mechanism is for agent runs).
- **Web** gains a thread switcher; `useChat` is keyed by conversation id and filters WS events by their `conversationId`. New **Settings → Chat channels** page configures the Telegram bot and the identity allowlist.

## Schema (append-only)

- `029_multi_conversation.sql` — `channel` / `external_thread_id` / `last_activity_at` / `closed_at` on `chat_conversations` + open-thread partial unique index.
- `030_chat_channels_and_identities.sql` — generic `chat_channel_configs` (bot config, token by vault reference, `metadata` jsonb) + `chat_identity_links` (allowlist).

Both ship data-preservation tests.

## Docs

`.dev/architecture.md` (multi-thread model, adapter registry, in-process-token rationale), `AGENTS.md` (extension point), `.dev/discord-chat-adapter.md` (deferred Discord), and a user-facing `docs/concepts/chat-channels.md`.

## Tests

Migration data-preservation (029/030); manager conversation-scoping + compaction lifecycle; Telegram adapter unit (MarkdownV2 escape, DM vs forum-topic keying); generic webhook auth/routing/allowlist; admin channel + identity routes + conversation lifecycle; web thread switcher (per-thread re-keying) and chat-channels settings page. All chat tiers green; full workspace typecheck + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011AE1CxTJud78tUJJB5nj52

---
_Generated by [Claude Code](https://claude.ai/code/session_011AE1CxTJud78tUJJB5nj52)_