### PR TITLE
fix(deploy): use ASCII in AWS CloudFormation template

### DIFF
--- a/deploy/aws/hezo.cfn.yaml
+++ b/deploy/aws/hezo.cfn.yaml
@@ -1,11 +1,11 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: >-
-  Hezo — one-click deploy to a single EC2 instance. Launches an Ubuntu VM, opens
+  Hezo - one-click deploy to a single EC2 instance. Launches an Ubuntu VM, opens
   the web ports, and runs deploy/provision.sh on first boot (Docker + the hezo
   binary + Caddy automatic HTTPS via <ip>.sslip.io + systemd + firewall). After
   ~2 minutes, open the URL in the stack Outputs and finish the in-browser setup
   (master key, admin password, connect a model). Hezo runs each project's agents
-  in a container on the host Docker socket, so it needs a real VM — this template
+  in a container on the host Docker socket, so it needs a real VM - this template
   provisions exactly that.
 
 Metadata:
@@ -57,7 +57,7 @@ Parameters:
     Default: ''
     Description: >-
       Optional. Name of an existing EC2 key pair for SSH. Leave blank to launch
-      without one — you can still get a shell via AWS Systems Manager Session
+      without one - you can still get a shell via AWS Systems Manager Session
       Manager (this template attaches the required role).
 
   AllowedSshCidr:
@@ -73,7 +73,7 @@ Parameters:
     Default: ''
     Description: >-
       Optional. Use your own domain instead of <ip>.sslip.io. Point an A record
-      at the instance's public IP first — Caddy provisions a Let's Encrypt cert
+      at the instance's public IP first - Caddy provisions a Let's Encrypt cert
       for this name. Leave blank to use sslip.io (no domain required).
 
   HezoReleaseTag:
@@ -95,7 +95,7 @@ Resources:
   SecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: Hezo — public web ports (80/443) and optional SSH
+      GroupDescription: Hezo - public web ports (80/443) and optional SSH
       SecurityGroupIngress:
         - { IpProtocol: tcp, FromPort: 80, ToPort: 80, CidrIp: 0.0.0.0/0, Description: HTTP (Caddy ACME + redirect) }
         - { IpProtocol: tcp, FromPort: 443, ToPort: 443, CidrIp: 0.0.0.0/0, Description: HTTPS (Hezo web app) }
@@ -156,7 +156,7 @@ Resources:
           #!/bin/bash
           set -eux
           export DEBIAN_FRONTEND=noninteractive
-          # Optional custom domain — provision.sh + hezo-firstboot read this.
+          # Optional custom domain - provision.sh + hezo-firstboot read this.
           DOMAIN='${DomainOverride}'
           if [ -n "$DOMAIN" ]; then
             echo "HEZO_DOMAIN_OVERRIDE=$DOMAIN" >> /etc/environment
@@ -183,4 +183,4 @@ Outputs:
     Value: !If
       - HasKeyName
       - !Sub 'ssh ubuntu@${Instance.PublicIp}'
-      - 'No key pair set — use AWS Systems Manager Session Manager to get a shell.'
+      - 'No key pair set - use AWS Systems Manager Session Manager to get a shell.'


### PR DESCRIPTION
## What & why

The AWS CloudFormation template from #723 fails to deploy. EC2 rejects non-ASCII characters in `AWS::EC2::SecurityGroup` `GroupDescription`, and the template used an **em dash** in `Hezo — public web ports (80/443) and optional SSH`. `aws cloudformation deploy` (and the Launch Stack button) roll back with:

```
Value (Hezo ? public web ports (80/443) and optional SSH) for parameter
GroupDescription is invalid. Character sets beyond ASCII are not supported.
```

(Reported from a real `hezo-test` deploy — the `SecurityGroup` and `InstanceRole` create failed and the stack rolled back.)

## Fix

Replace every em dash (`—`) in `deploy/aws/hezo.cfn.yaml` with an ASCII hyphen (`-`):
- **`GroupDescription`** — the fatal one.
- Top-level `Description`, two parameter `Description`s, a `UserData` comment, and one `Output` string — swapped too so the whole template is plain ASCII and nothing else can trip the same rule.

No structural/logic change — descriptions and comments only. Verified the template still parses and all resources (`SecurityGroup`, `SshIngress`, `InstanceRole`, `InstanceProfile`, `Instance`) resolve.

## Verification

After this change, `aws cloudformation deploy --template-file deploy/aws/hezo.cfn.yaml --stack-name hezo-test --capabilities CAPABILITY_IAM` creates the stack instead of rolling back at `SecurityGroup`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N2uNcmo9ZemshzbfQ6kkQk)_