### PR TITLE
ci(release): auto-publish the AWS CloudFormation template to S3

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -1709,7 +1709,11 @@ version from Conventional Commits and opens a `release/<version>` PR; merging fi
 succeeds** — tags the merge commit, cross-compiles, and publishes a GitHub Release (assets
 `hezo-{os}-{arch}[.exe]` + `SHA256SUMS`). Gating the Release on the image (the `publish`
 job `needs` `publish-agent-image`) means a published version never advertises binaries whose
-provisioning pull (`agent-base:<version>`) would 404. The running instance polls
+provisioning pull (`agent-base:<version>`) would 404. A final `publish-cfn-template` job then
+re-uploads the AWS CloudFormation deploy template (`deploy/aws/hezo.cfn.yaml`) to the public S3
+bucket the README's "Deploy on AWS" Launch Stack button serves, so the hosted copy never drifts
+from the repo (it asserts the template is ASCII-only first, and skips when AWS credentials aren't
+configured). The running instance polls
 `GET /api/updates/latest` (cached ~1 h, fails soft) and shows a bottom banner. The
 Settings → General page also renders a **Version** section (current version linked to its
 GitHub release, plus a **"Check for new version"** button that calls

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -133,3 +133,45 @@ jobs:
           bun run release --notes "$version" > /tmp/release-notes.md
           gh release create "$version" --title "$version" --notes-file /tmp/release-notes.md \
             dist/binaries/*
+
+  # Keep the AWS CloudFormation template the README's "Deploy on AWS" (Launch
+  # Stack) button points at in sync with the repo. The button serves whatever is
+  # hosted in S3, so a stale object ships a stale template; this re-uploads
+  # deploy/aws/hezo.cfn.yaml on every release. Runs after `publish` so S3 is only
+  # touched on a clean release, and skips cleanly when AWS credentials are not
+  # configured (e.g. forks). Bucket/region default to the org's setup and can be
+  # overridden with repo variables. Requires two repo secrets — AWS_ACCESS_KEY_ID
+  # and AWS_SECRET_ACCESS_KEY for an IAM identity scoped to s3:PutObject on the
+  # bucket.
+  publish-cfn-template:
+    runs-on: ubuntu-latest
+    needs: publish
+    if: >-
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/')
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: main # post-merge main, matching the published release
+      - name: Upload deploy/aws/hezo.cfn.yaml to S3
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ vars.HEZO_CFN_S3_REGION || 'us-east-1' }}
+          BUCKET: ${{ vars.HEZO_CFN_S3_BUCKET || 'hezo-deploy' }}
+        run: |
+          if [ -z "${AWS_ACCESS_KEY_ID}" ] || [ -z "${AWS_SECRET_ACCESS_KEY}" ]; then
+            echo "AWS credentials not configured (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY); skipping S3 upload of hezo.cfn.yaml."
+            exit 0
+          fi
+          # EC2 rejects non-ASCII in SecurityGroup GroupDescription, so refuse to
+          # ship a template that would fail the Launch Stack button (regression
+          # guard for the em-dash bug fixed in #731).
+          if LC_ALL=C grep -nP '[^\x00-\x7F]' deploy/aws/hezo.cfn.yaml; then
+            echo "::error file=deploy/aws/hezo.cfn.yaml::Template contains non-ASCII characters; CloudFormation/EC2 will reject it. Not uploading."
+            exit 1
+          fi
+          aws s3 cp deploy/aws/hezo.cfn.yaml "s3://${BUCKET}/hezo.cfn.yaml" --content-type text/yaml
+          echo "Uploaded deploy/aws/hezo.cfn.yaml to s3://${BUCKET}/hezo.cfn.yaml"

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -121,7 +121,20 @@ aws s3 cp deploy/aws/hezo.cfn.yaml s3://hezo-deploy/hezo.cfn.yaml \
 #   https://hezo-deploy.s3.us-east-1.amazonaws.com/hezo.cfn.yaml
 ```
 
-**Keep the hosted object in sync with this file** — the button always serves
-whatever is in S3, so a stale copy ships a stale template. A `release-publish`
-workflow step can `aws s3 cp` it automatically (needs an AWS key scoped to
-`s3:PutObject` on that bucket, stored as a GitHub Actions secret).
+**The button always serves whatever is in S3, so a stale object ships a stale
+template.** To prevent drift, the `publish-cfn-template` job in
+[`.github/workflows/release-publish.yml`](../../.github/workflows/release-publish.yml)
+re-uploads this file to S3 on **every release** (after the GitHub Release is cut).
+It refuses to upload a template containing non-ASCII characters — a regression
+guard for the em-dash bug that broke `GroupDescription` — and skips cleanly when
+AWS credentials are absent.
+
+For that job to upload, configure in the repo:
+
+- **Secrets** `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` for an IAM identity
+  scoped to `s3:PutObject` on the bucket.
+- **Variables** (optional) `HEZO_CFN_S3_BUCKET` and `HEZO_CFN_S3_REGION` to
+  override the defaults (`hezo-deploy` / `us-east-1`).
+
+The command above is the manual equivalent — run it if you change `hezo.cfn.yaml`
+between releases and want the button updated immediately.


### PR DESCRIPTION
## What & why

The README's **Deploy on AWS** Launch Stack button serves the CloudFormation template from a public S3 bucket, so a stale S3 object would ship a stale template to everyone who clicks it. This adds a `publish-cfn-template` job to `release-publish.yml` that re-uploads `deploy/aws/hezo.cfn.yaml` to S3 on **every release**, keeping the hosted copy in lockstep with the repo.

## How it works

- Added as a third job in `.github/workflows/release-publish.yml`, `needs: publish` — it runs **after** the GitHub Release is cut, so S3 is only touched on a clean release.
- **Skips cleanly** when AWS credentials aren't configured (`exit 0`), so forks and unconfigured repos don't fail.
- **Regression guard:** refuses to upload if the template contains any non-ASCII character — exactly the em-dash-in-`GroupDescription` bug (#731) that made EC2 reject the stack. A bad template fails this job loudly instead of silently shipping.
- Bucket/region default to `hezo-deploy` / `us-east-1`, overridable via repo **variables** `HEZO_CFN_S3_BUCKET` / `HEZO_CFN_S3_REGION`.

## Setup required for it to actually upload

Add two repo **secrets** for an IAM identity scoped to `s3:PutObject` on the bucket:
- `AWS_ACCESS_KEY_ID`
- `AWS_SECRET_ACCESS_KEY`

Without them the job is a no-op skip.

## Docs

- `deploy/aws/README.md` — publishing section now documents the automation + required secrets/variables (the manual `aws s3 cp` remains as the between-releases equivalent).
- `.dev/architecture.md` — release flow mentions the new job.

## Notes

- Uses the AWS CLI preinstalled on `ubuntu-latest`; no new action dependency.
- Release-only job (fires on `release/*` PR merge); it does **not** run on regular PR CI, so it's not a required status check and needs no branch-protection changes.
- Verified the workflow YAML parses and the job graph is `publish-agent-image → publish → publish-cfn-template`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N2uNcmo9ZemshzbfQ6kkQk)_