### PR TITLE
Fix mobile keyboard gap below the comment composer

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -2,7 +2,15 @@
 <html lang="en">
 	<head>
 		<meta charset="UTF-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<!-- interactive-widget=resizes-content: let the on-screen keyboard shrink the
+		     LAYOUT viewport (and thus 100dvh), not just the visual viewport. Without it
+		     the default (resizes-visual) keeps the h-dvh shell full-height behind the
+		     keyboard, so focusing the bottom-of-page comment composer scrolls it above
+		     the keyboard and exposes empty scroller space as a gap. See __root.tsx. -->
+		<meta
+			name="viewport"
+			content="width=device-width, initial-scale=1.0, interactive-widget=resizes-content"
+		/>
 		<title>Hezo — Your own AI workforce. Built to ship.</title>
 		<meta
 			name="description"

--- a/packages/web/src/routes/__root.tsx
+++ b/packages/web/src/routes/__root.tsx
@@ -220,6 +220,13 @@ function ShellChrome({ drawerOpen, setDrawerOpen }: ShellChromeProps) {
 		// off-screen, and it stays hidden until <main> is scrolled back to its very
 		// top. 100dvh tracks the URL bar, so the root never has overflow and the
 		// header can't leave the screen.
+		//
+		// The on-screen keyboard is a separate axis: dvh does NOT shrink for it
+		// unless the viewport meta opts in with interactive-widget=resizes-content
+		// (set in index.html). That opt-in makes this h-dvh shell shrink to the space
+		// above the keyboard, so <main> shrinks with it and a focused bottom-of-page
+		// input (the comment composer) sits flush on the keyboard instead of leaving
+		// dead space beneath it.
 		<div className="h-dvh flex flex-col overflow-hidden">
 			<AppHeader
 				onOpenDrawer={() => setDrawerOpen(true)}


### PR DESCRIPTION
## Problem

On mobile, focusing the bottom-of-page comment composer (task detail) left a large empty gap between the composer and the on-screen keyboard.

## Cause

The composer isn't pinned to the keyboard — it's the last in-flow element of the `overflow-auto` `<main>` scroller, and the shell is sized to `h-dvh` (`__root.tsx`). The viewport meta (`packages/web/index.html`) had no `interactive-widget`, so it defaulted to `resizes-visual`: the on-screen keyboard shrinks only the **visual** viewport, not the **layout** viewport. That leaves the `h-dvh` shell (and `<main>`) full-height behind the keyboard. When the textarea focuses, the browser scrolls the composer above the keyboard, and since nothing sits below it in the scroller, the empty bottom of the scroller shows through as the gap.

## Fix

Add `interactive-widget=resizes-content` to the viewport meta. The keyboard now shrinks the layout viewport (and `100dvh`), so the `h-dvh` shell shrinks to the space above the keyboard, `<main>` shrinks with it, and the composer sits flush on the keyboard with no dead space.

Also added a note near the `h-dvh` comment in `__root.tsx` cross-referencing the meta tag, since the two are coupled.

## Testing

No automated test — this is real-browser keyboard/layout behavior that neither happy-dom nor Playwright can exercise (Playwright can't raise a software keyboard). The change is a static viewport meta attribute; `resizes-content` is supported on Chromium/Android and ignored harmlessly elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2dHqZfbz4bP9ws2V2pZAm)_