### PR TITLE
fix(logs): record whole agent run log without per-line truncation

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -718,7 +718,8 @@ stay on fetch. Before that exec it
 the cached `container_status`: a container pruned externally or lost to a Docker restart is
 reconciled (status flipped, `container_id` nulled, project update broadcast) and the run
 fails fast with a clear message rather than tripping over a raw 404 mid-exec. It captures
-interleaved stdout/stderr into `log_text` (capped at 1 MB, `[stderr]`-prefixed) and
+interleaved stdout/stderr into `log_text` (recorded in full, `[stderr]`-prefixed, with a
+10 MB runaway-output backstop) and
 broadcasts the same stream live over the `project-runs:<projectId>` WebSocket room.
 
 **System prompt composition.** The agent's stored template (its `agent_system_prompt`

--- a/packages/server/src/services/agent-stream-parser.ts
+++ b/packages/server/src/services/agent-stream-parser.ts
@@ -122,8 +122,6 @@ function createPassthroughParser(): AgentStreamParser {
 	};
 }
 
-const MAX_LINE_LEN = 500;
-
 /**
  * Shared JSONL line processor. Buffers partial stdout bytes, splits on
  * newlines, and runs each complete line through `renderEvent`. Lines that
@@ -617,7 +615,7 @@ function createCodexParser(price: PriceModelFn): AgentStreamParser {
 
 		if (type === 'error') {
 			const msg = extractErrorMessage(event.error, event.message);
-			return msg ? [`[tool-error] ${truncate(msg.replace(/\s+/g, ' ').trim(), MAX_LINE_LEN)}`] : [];
+			return msg ? [`[tool-error] ${msg.replace(/\s+/g, ' ').trim()}`] : [];
 		}
 
 		return [];
@@ -647,11 +645,11 @@ function renderCodexItem(item: CodexItem): string[] {
 	if (kind === 'command_execution') {
 		const out: string[] = [];
 		const cmd = (item.command ?? '').replace(/\s+/g, ' ').trim();
-		if (cmd) out.push(`[tool] shell(${truncate(cmd, MAX_LINE_LEN)})`);
+		if (cmd) out.push(`[tool] shell(${cmd})`);
 		const output = (item.aggregated_output ?? item.output ?? '').replace(/\s+/g, ' ').trim();
 		if (output) {
 			const isError = typeof item.exit_code === 'number' && item.exit_code !== 0;
-			out.push(`${isError ? '[tool-error]' : '[tool-result]'} ${truncate(output, MAX_LINE_LEN)}`);
+			out.push(`${isError ? '[tool-error]' : '[tool-result]'} ${output}`);
 		}
 		return out;
 	}
@@ -729,7 +727,7 @@ function createGeminiParser(price: PriceModelFn): AgentStreamParser {
 				.replace(/\s+/g, ' ')
 				.trim();
 			const label = event.is_error ? '[tool-error]' : '[tool-result]';
-			return [body ? `${label} ${truncate(body, MAX_LINE_LEN)}` : label];
+			return [body ? `${label} ${body}` : label];
 		}
 
 		if (type === 'result') {
@@ -909,7 +907,7 @@ function createGenericJsonlParser(price: PriceModelFn): AgentStreamParser {
 			typeof event.message === 'string' ? event.message : undefined,
 		);
 		if (/error|fail/i.test(type) && errText) {
-			return [`[tool-error] ${truncate(errText.replace(/\s+/g, ' ').trim(), MAX_LINE_LEN)}`];
+			return [`[tool-error] ${errText.replace(/\s+/g, ' ').trim()}`];
 		}
 
 		if (/reason|think/i.test(type)) {
@@ -1021,7 +1019,7 @@ function createGrokParser(): AgentStreamParser {
 		if (type === 'error') {
 			const msg = extractErrorMessage(undefined, event.message);
 			if (msg) terminalError = classifyRuntimeError(msg) ?? terminalError;
-			return msg ? [`[tool-error] ${truncate(msg.replace(/\s+/g, ' ').trim(), MAX_LINE_LEN)}`] : [];
+			return msg ? [`[tool-error] ${msg.replace(/\s+/g, ' ').trim()}`] : [];
 		}
 		return [];
 	};
@@ -1109,6 +1107,13 @@ export function extractGrokUsageFromDebugLog(
 
 // ---------------------------------------------------------------------------
 // Shared rendering helpers
+//
+// Content (thinking, tool args, tool results, errors) is preserved in full — the
+// only transform is collapsing whitespace to a single space, which the persisted
+// log format requires: each event is stored as one newline-terminated line, so an
+// embedded newline would be mis-parsed as a separate line by the client parser
+// (`parse-agent-log.ts`). It is NOT truncated; the whole run log is recorded, with
+// only the overall byte cap in `log-stream-broker.ts` as a runaway-output backstop.
 // ---------------------------------------------------------------------------
 
 function normalizeContent(content: ClaudeMessage['content']): ClaudeContentBlock[] {
@@ -1120,7 +1125,7 @@ function normalizeContent(content: ClaudeMessage['content']): ClaudeContentBlock
 function formatThinking(text: string): string {
 	const collapsed = text.replace(/\s+/g, ' ').trim();
 	if (collapsed.length === 0) return '[thinking]';
-	return `[thinking] ${truncate(collapsed, MAX_LINE_LEN)}`;
+	return `[thinking] ${collapsed}`;
 }
 
 function formatToolUse(name: string, input: unknown): string {
@@ -1133,8 +1138,7 @@ function renderToolInput(input: unknown): string {
 	if (typeof input !== 'object') return String(input);
 	const entries = Object.entries(input as Record<string, unknown>);
 	if (entries.length === 0) return '';
-	const preview = entries.map(([k, v]) => `${k}=${truncate(stringifyArg(v), 80)}`).join(', ');
-	return truncate(preview, MAX_LINE_LEN);
+	return entries.map(([k, v]) => `${k}=${stringifyArg(v)}`).join(', ');
 }
 
 function stringifyArg(value: unknown): string {
@@ -1151,7 +1155,7 @@ function formatToolResult(block: ClaudeContentBlock): string {
 	const body = extractToolResultText(block.content);
 	const collapsed = body.replace(/\s+/g, ' ').trim();
 	if (collapsed === '') return label;
-	return `${label} ${truncate(collapsed, MAX_LINE_LEN)}`;
+	return `${label} ${collapsed}`;
 }
 
 function extractToolResultText(content: unknown): string {
@@ -1179,9 +1183,4 @@ function extractErrorMessage(
 	if (typeof error === 'string' && error) return error;
 	if (error && typeof error === 'object' && typeof error.message === 'string') return error.message;
 	return typeof fallback === 'string' ? fallback : '';
-}
-
-function truncate(s: string, max: number): string {
-	if (s.length <= max) return s;
-	return `${s.slice(0, max - 1)}…`;
 }

--- a/packages/server/src/services/log-stream-broker.ts
+++ b/packages/server/src/services/log-stream-broker.ts
@@ -27,7 +27,10 @@ interface LogStreamEntry {
 	ended: boolean;
 }
 
-const DEFAULT_CAP_BYTES = 1_000_000;
+// Backstop against a runaway run flooding memory/DB — not a content truncation.
+// Sized generously so a whole real run's log (full, untruncated thinking/tool
+// output; see agent-stream-parser.ts) is recorded end-to-end without the cap firing.
+const DEFAULT_CAP_BYTES = 10_000_000;
 const DEFAULT_DEBOUNCE_MS = 500;
 
 export class LogStreamBroker {

--- a/packages/server/test/agent-stream-parser-branches.test.ts
+++ b/packages/server/test/agent-stream-parser-branches.test.ts
@@ -12,7 +12,7 @@ import {
  * agent-stream-parser-coverage.test.ts cover the happy paths; this file
  * targets the remaining conditional arms: ??/||/?: fallbacks, optional-chain
  * short-circuits, the loose generic-parser field probes, and the shared
- * rendering helpers (renderToolInput / stringifyArg / truncate / etc.) at
+ * rendering helpers (renderToolInput / stringifyArg / formatThinking / etc.) at
  * their edges. Pure functions — we feed crafted JSONL and assert exact output.
  */
 
@@ -556,19 +556,20 @@ describe('renderToolInput / stringifyArg arms', () => {
 		expect(out).toContain('nums=[1,2]');
 	});
 
-	it('truncates a long per-argument value to 80 chars with an ellipsis', () => {
+	it('keeps a long per-argument value in full (no truncation, no ellipsis)', () => {
 		const parser = createAgentStreamParser(AgentRuntime.Gemini);
-		const long = 'x'.repeat(200);
+		const long = 'x'.repeat(2000);
 		const out = feed(parser, [{ type: 'tool_use', name: 'big', input: { v: long } }]);
-		// value truncated to 79 chars + ellipsis.
-		expect(out).toContain(`v=${'x'.repeat(79)}…`);
+		// The whole value is recorded verbatim; nothing is clipped.
+		expect(out).toContain(`v=${long}`);
+		expect(out).not.toContain('…');
 	});
 });
 
-describe('truncate via the overall line cap (MAX_LINE_LEN)', () => {
-	it('truncates a long collapsed thinking line to 500 chars with an ellipsis', () => {
+describe('full-length lines (no per-line cap — the whole run log is recorded)', () => {
+	it('keeps a long collapsed thinking line in full without an ellipsis', () => {
 		const parser = createAgentStreamParser(AgentRuntime.ClaudeCode);
-		const long = 'z'.repeat(800);
+		const long = 'z'.repeat(8000);
 		const out = feed(parser, [
 			{
 				type: 'assistant',
@@ -576,8 +577,17 @@ describe('truncate via the overall line cap (MAX_LINE_LEN)', () => {
 			},
 		]);
 		const body = out.replace('[thinking] ', '').trimEnd();
-		expect(body.length).toBe(500);
-		expect(body.endsWith('…')).toBe(true);
+		expect(body).toBe(long);
+		expect(body).not.toContain('…');
+	});
+
+	it('keeps a long tool result in full without an ellipsis', () => {
+		const parser = createAgentStreamParser(AgentRuntime.Gemini);
+		const long = 'result-'.repeat(1000);
+		const out = feed(parser, [{ type: 'tool_result', output: long, is_error: false }]);
+		const body = out.replace('[tool-result] ', '').trimEnd();
+		expect(body).toBe(long);
+		expect(body).not.toContain('…');
 	});
 });
 

--- a/packages/web/src/components/formatted-log-view.tsx
+++ b/packages/web/src/components/formatted-log-view.tsx
@@ -1,5 +1,5 @@
 import { Boxes, ChevronDown, ChevronRight, Cpu, Sparkles, Terminal, Wrench } from 'lucide-react';
-import { type ComponentType, useMemo, useState } from 'react';
+import { type ComponentType, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import Markdown, { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import {
@@ -182,6 +182,9 @@ const THINKING_COMPONENTS: Components = {
 const THINKING_PROSE =
 	'text-xs italic leading-relaxed [&_ol]:list-decimal [&_ul]:list-disc [&_ol]:pl-5 [&_ul]:pl-5 [&_li]:my-0.5 [&_p]:my-1 [&_p:first-child]:mt-0 [&_p:last-child]:mb-0 [&_li]:marker:text-text-3';
 
+// Thinking blocks are often long run-on reasoning. Collapse anything taller than
+// 3 rendered lines (the `line-clamp-3` below) behind a Show more/less toggle so the
+// log stays scannable; blocks that fit in 3 lines are shown whole with no toggle.
 function ThinkingView({
 	block,
 	commentRefTask,
@@ -194,13 +197,57 @@ function ThinkingView({
 		() => (commentRefTask ? [remarkGfm, [remarkCommentRefs, commentRefTask]] : [remarkGfm]),
 		[commentRefTask],
 	);
+
+	const [expanded, setExpanded] = useState(false);
+	const [overflows, setOverflows] = useState(false);
+	const contentRef = useRef<HTMLDivElement>(null);
+
+	// Measure whether the block exceeds the clamp height. Clamp is applied
+	// transiently for the read so the result is independent of the current
+	// expanded state; a ResizeObserver re-measures on reflow (responsive widths).
+	// happy-dom reports 0 for scroll/clientHeight, so component tests see no
+	// overflow and render the block whole — the clamp is verified in a browser.
+	useLayoutEffect(() => {
+		const el = contentRef.current;
+		// Re-measure whenever the rendered content (`reflowed`) changes; empty
+		// thinking can never overflow, so it never gets a toggle.
+		if (!el || reflowed.trim() === '') {
+			setOverflows(false);
+			return;
+		}
+		const measure = () => {
+			const wasClamped = el.classList.contains('line-clamp-3');
+			if (!wasClamped) el.classList.add('line-clamp-3');
+			const isOverflowing = el.scrollHeight > el.clientHeight + 1;
+			if (!wasClamped) el.classList.remove('line-clamp-3');
+			setOverflows(isOverflowing);
+		};
+		measure();
+		if (typeof ResizeObserver === 'undefined') return;
+		const observer = new ResizeObserver(measure);
+		observer.observe(el);
+		return () => observer.disconnect();
+	}, [reflowed]);
+
+	// If the content shrinks below the clamp height (e.g. a narrower reflow), drop
+	// the now-meaningless expanded state so the toggle disappears cleanly.
+	useEffect(() => {
+		if (!overflows && expanded) setExpanded(false);
+	}, [overflows, expanded]);
+
+	const clamp = overflows && !expanded;
+
 	return (
-		<div className="border-l-2 border-border-subtle pl-3 text-text-3">
+		<div className="border-l-2 border-border-subtle pl-3 text-text-3" data-testid="thinking-block">
 			<div className="mb-0.5 flex items-center gap-1 text-[10px] uppercase tracking-wider">
 				<Sparkles className="w-3 h-3 shrink-0" />
 				Thinking
 			</div>
-			<div className={THINKING_PROSE}>
+			<div
+				ref={contentRef}
+				data-testid="thinking-content"
+				className={`${THINKING_PROSE} ${clamp ? 'line-clamp-3' : ''}`}
+			>
 				<Markdown
 					remarkPlugins={remarkPlugins}
 					components={commentRefTask ? THINKING_COMPONENTS : undefined}
@@ -208,6 +255,18 @@ function ThinkingView({
 					{reflowed}
 				</Markdown>
 			</div>
+			{overflows && (
+				<button
+					type="button"
+					onClick={() => setExpanded((v) => !v)}
+					aria-expanded={expanded}
+					data-testid="thinking-toggle"
+					className="mt-1 flex items-center gap-0.5 text-[10px] uppercase tracking-wider text-text-3 hover:text-text-2"
+				>
+					<ChevronDown className={`w-3 h-3 transition-transform ${expanded ? 'rotate-180' : ''}`} />
+					{expanded ? 'Show less' : 'Show more'}
+				</button>
+			)}
 		</div>
 	);
 }

--- a/packages/web/test/formatted-log-view-branches.test.tsx
+++ b/packages/web/test/formatted-log-view-branches.test.tsx
@@ -87,6 +87,21 @@ test('thinking block renders the Thinking header and reflowed prose', async () =
 	expect(item.closest('li')).not.toBeNull();
 });
 
+test('thinking block renders whole with no Show more toggle when it does not overflow', async () => {
+	// happy-dom reports 0 for scroll/clientHeight, so the clamp measurement never
+	// detects overflow — the block degrades to its full content with no toggle and
+	// no line-clamp. The clamp/expand behaviour itself is a real-browser concern
+	// (see agent-run-logs.spec.ts).
+	const long = Array.from({ length: 60 }, () => 'reasoning').join(' ');
+	const { getByText, queryByTestId, getByTestId } = await renderLog({
+		lines: lines(`[thinking] ${long}`),
+	});
+	expect(getByText('Thinking')).toBeTruthy();
+	expect(getByText(new RegExp(long.slice(0, 40)))).toBeTruthy();
+	expect(queryByTestId('thinking-toggle')).toBeNull();
+	expect(getByTestId('thinking-content').className).not.toContain('line-clamp-3');
+});
+
 test('command block: a short command is non-interactive (no chevron, cursor-default)', async () => {
 	const { getByRole, queryByText } = await renderLog({ lines: lines('$ ls -la') });
 	const btn = getByRole('button');

--- a/test/browser/agent-run-logs.spec.ts
+++ b/test/browser/agent-run-logs.spec.ts
@@ -234,7 +234,7 @@ test('task page renders completed run as a collapsed inline comment with summary
 	await expect(header).toHaveAttribute('aria-expanded', 'false');
 });
 
-async function mockCompletedRun(page: Page, token: string) {
+async function mockCompletedRun(page: Page, token: string, logTextOverride?: string) {
 	const headers = { Authorization: `Bearer ${token}` };
 
 	const projectRes = await createProjectAndClearPlanning(page, '', token, {
@@ -257,7 +257,8 @@ async function mockCompletedRun(page: Page, token: string) {
 	const runId = '77777777-7777-7777-7777-777777777777';
 	const startedAt = '2026-05-15T18:11:00Z';
 	const finishedAt = '2026-05-15T18:12:17Z';
-	const logText = Array.from({ length: 27 }, (_, i) => `[synthetic] line ${i + 1}`).join('\n');
+	const logText =
+		logTextOverride ?? Array.from({ length: 27 }, (_, i) => `[synthetic] line ${i + 1}`).join('\n');
 
 	const runComment = {
 		id: 'cccc0000-0000-0000-0000-000000000001',
@@ -499,4 +500,58 @@ test('task-page run log offers the formatted/raw switcher on a dark surface in l
 		.getByTestId('run-comment-log')
 		.evaluate((el) => getComputedStyle(el).backgroundColor);
 	expect(rawBg).toBe('rgb(13, 17, 23)');
+});
+
+// #1 (real CSS layout): the formatted view clamps a tall thinking block to 3
+// rendered lines and offers a Show more/less toggle. Whether the block overflows
+// the clamp is a line-box measurement (scrollHeight vs a `line-clamp-3`
+// clientHeight) — happy-dom reports 0 for both, so the toggle only ever appears
+// in a real browser. A single long run-on `[thinking]` line (the untruncated
+// server output — full reasoning is now recorded end-to-end) wraps well past 3
+// lines at any width.
+test('formatted view collapses a long thinking block behind a Show more/less toggle', async ({
+	page,
+}) => {
+	await authenticate(page);
+	const token = await getToken(page);
+
+	const thinking = `[thinking] ${Array.from({ length: 140 }, () => 'deliberating').join(' ')}`;
+	const logText = ['[session] model=claude-opus tools=3', thinking, '[done] success turns=1'].join(
+		'\n',
+	);
+
+	const { task, projectSlug } = await mockCompletedRun(page, token, logText);
+
+	await page.goto(`/projects/${projectSlug}/tasks/${task.id}`);
+
+	const runCommentEl = page.getByTestId('run-comment').first();
+	await expect(runCommentEl).toBeVisible({ timeout: 20_000 });
+	await runCommentEl.getByTestId('run-comment-header').click();
+
+	const log = runCommentEl.getByTestId('run-comment-log');
+	await expect(log).toBeVisible();
+
+	// Formatted view is the default; the thinking block renders inside it.
+	const thinkingBlock = log.getByTestId('thinking-block');
+	await expect(thinkingBlock).toBeVisible({ timeout: 15000 });
+
+	const content = thinkingBlock.getByTestId('thinking-content');
+	const toggle = thinkingBlock.getByTestId('thinking-toggle');
+
+	// Collapsed by default: clamped to 3 lines, offering "Show more".
+	await expect(toggle).toBeVisible();
+	await expect(toggle).toHaveText(/show more/i);
+	const clampedHeight = await content.evaluate((el) => el.clientHeight);
+
+	// Expand → full height, toggle flips to "Show less".
+	await toggle.click();
+	await expect(toggle).toHaveText(/show less/i);
+	const expandedHeight = await content.evaluate((el) => el.clientHeight);
+	expect(expandedHeight).toBeGreaterThan(clampedHeight);
+
+	// Collapse again restores the clamp exactly.
+	await toggle.click();
+	await expect(toggle).toHaveText(/show more/i);
+	const recollapsedHeight = await content.evaluate((el) => el.clientHeight);
+	expect(recollapsedHeight).toBe(clampedHeight);
 });


### PR DESCRIPTION
## What & why

Agent run logs were being truncated at the source. The stream parser
(`agent-stream-parser.ts`) flattened every event to a single line **and** clipped
it to 500 chars (80 per tool-arg), so `[thinking]` blocks, `[tool-result]`s, and
tool arguments were cut off with an ellipsis. Both the **raw** and **formatted**
run-log views read the same persisted `log_text`, so the truncation showed up in
both — the whole run log was never actually recorded.

## Changes

**Server — stop truncating (the whole run log is now recorded)**
- Removed the per-line content truncation (`MAX_LINE_LEN` = 500 and the 80-char
  per-argument cap) across every runtime renderer (Claude Code, Codex, Gemini,
  the generic JSONL parser, and Grok). Content is still whitespace-collapsed to a
  single line — the newline-delimited persisted format requires it, since an
  embedded newline would be mis-parsed as a separate line by the client parser —
  but nothing is clipped. Dropped the now-unused `truncate` helper.
- Raised the whole-log byte backstop in `log-stream-broker.ts` from **1 MB → 10 MB**
  so a full real run (including runs that embed large blobs) is recorded end to
  end. The cap remains only as a runaway-output guard against unbounded
  memory/DB growth, not a content truncation.

**Web — collapse long thinking blocks in the formatted view**
- Thinking blocks that render past **3 lines** now collapse behind a
  **Show more / Show less** toggle (measured with a transient `line-clamp-3`,
  re-measured on resize via `ResizeObserver`), so full reasoning is recorded
  without flooding the log. Blocks that fit in 3 lines are shown whole with no
  toggle, and the block degrades to full content where there's no layout engine.

**Docs**
- `.dev/architecture.md`: `log_text` is now described as "recorded in full … with a
  10 MB runaway-output backstop". (The `get_run_log` MCP tool's `excerpt_chars`
  tail is a separate, intentional, agent-facing feature and is unchanged.)

## Tests
- `agent-stream-parser-branches.test.ts`: the two truncation tests now assert
  **full-length** thinking / tool-result / tool-arg output (no ellipsis).
- `formatted-log-view-branches.test.tsx`: new component test covering the
  no-overflow → no-toggle degradation path.
- `agent-run-logs.spec.ts`: new Playwright test covering the clamp + expand/collapse
  behaviour in a real browser (a layout measurement happy-dom can't make).

All targeted suites pass; typecheck and biome are clean; the pre-commit build
(incl. bundle regeneration) is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrcFsLrpbpmfDG7BeQQsC7

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrcFsLrpbpmfDG7BeQQsC7)_