### PR TITLE
fix(web): centre scroll pills over the scrolled content column

### DIFF
--- a/packages/web/src/contexts/scroll-content-context.tsx
+++ b/packages/web/src/contexts/scroll-content-context.tsx
@@ -1,0 +1,20 @@
+import { createContext, useContext } from 'react';
+
+/**
+ * Lets a route tell the app shell which DOM element is its scrollable content
+ * pane, so the shell can horizontally centre the global scroll-to-top/bottom
+ * pills over *that* pane rather than over the full <main> width. This matters on
+ * pages whose <main> also holds a non-scrolling side panel (e.g. the task
+ * detail meta rail): centring over the whole width drifts the pills off to the
+ * right, over the panel. Routes with no side panel simply don't register, and
+ * the pills fall back to centring over <main>.
+ *
+ * The value is a stable callback the route attaches as a `ref` to its content
+ * wrapper; React calls it with the element on mount and `null` on unmount.
+ */
+export const ScrollContentContext = createContext<(el: HTMLElement | null) => void>(() => {});
+
+/** A stable callback ref a route attaches to its scrollable content pane. */
+export function useRegisterScrollContent(): (el: HTMLElement | null) => void {
+	return useContext(ScrollContentContext);
+}

--- a/packages/web/src/routes/__root.tsx
+++ b/packages/web/src/routes/__root.tsx
@@ -22,6 +22,7 @@ import { CreatePasswordFlow, SetupGate } from '../components/setup/setup-wizard'
 import { StartingScreen } from '../components/starting-screen';
 import { Tooltip } from '../components/ui/tooltip';
 import { UpdateBanner } from '../components/update-banner';
+import { ScrollContentContext } from '../contexts/scroll-content-context';
 import { SocketProvider } from '../contexts/socket-context';
 import { useActiveProject } from '../hooks/use-active-project';
 import { useMe } from '../hooks/use-me';
@@ -180,6 +181,15 @@ function ShellChrome({ drawerOpen, setDrawerOpen }: ShellChromeProps) {
 	const hash = useLocation({ select: (l) => l.hash });
 	const lastPathnameRef = useRef(pathname);
 
+	// A route with a non-scrolling side panel inside <main> (the task detail meta
+	// rail) registers its scrollable content column here, so the scroll pills
+	// centre over that column rather than over the full <main> width (which would
+	// drift them right, over the panel). The pill anchor is the pills' positioned
+	// ancestor, so the measured centre is relative to it.
+	const pillAnchorRef = useRef<HTMLDivElement>(null);
+	const [contentEl, setContentEl] = useState<HTMLElement | null>(null);
+	const registerScrollContent = useCallback((el: HTMLElement | null) => setContentEl(el), []);
+
 	// Global Cmd/Ctrl+K toggles the search palette from any route.
 	useEffect(() => {
 		const onKeyDown = (e: KeyboardEvent) => {
@@ -211,6 +221,37 @@ function ShellChrome({ drawerOpen, setDrawerOpen }: ShellChromeProps) {
 		if (hash) return;
 		mainRef.current?.scrollTo({ top: 0, left: 0, behavior: 'instant' });
 	}, [pathname, hash]);
+
+	// Expose the horizontal centre of the registered content column (relative to
+	// the pill anchor) as `--pill-center-x`, so the pills sit over the content the
+	// reader scrolls, not over content + a non-scrolling side panel. Unregistered
+	// routes leave the var unset and the pills fall back to `left: 50%` (centred
+	// over <main>). Re-measures on any layout change — resizable-panel drag,
+	// breakpoint switch, preview open/close, window resize — via a ResizeObserver
+	// on both the anchor and the content column.
+	useEffect(() => {
+		const anchor = pillAnchorRef.current;
+		if (!anchor) return;
+		if (!contentEl) {
+			anchor.style.removeProperty('--pill-center-x');
+			return;
+		}
+		const measure = () => {
+			const a = anchor.getBoundingClientRect();
+			const c = contentEl.getBoundingClientRect();
+			anchor.style.setProperty('--pill-center-x', `${c.left - a.left + c.width / 2}px`);
+		};
+		measure();
+		if (typeof ResizeObserver === 'undefined') return;
+		const ro = new ResizeObserver(measure);
+		ro.observe(anchor);
+		ro.observe(contentEl);
+		window.addEventListener('resize', measure);
+		return () => {
+			ro.disconnect();
+			window.removeEventListener('resize', measure);
+		};
+	}, [contentEl]);
 
 	return (
 		// dvh, not vh: on mobile, 100vh is the LARGE viewport (URL bar collapsed).
@@ -271,25 +312,35 @@ function ShellChrome({ drawerOpen, setDrawerOpen }: ShellChromeProps) {
 					{/* The relative wrapper hosts the scroll-to-bottom pill as a sibling
 					    of the scroller, so the pill stays pinned over the content area
 					    (never scrolling with it) on ANY page whose long-form content
-					    overflows <main> — task threads, documents, settings, etc. */}
-					<div className="relative flex flex-col flex-1 min-w-0 overflow-hidden">
+					    overflows <main> — task threads, documents, settings, etc. It is
+					    also the pills' positioning anchor: `--pill-center-x` (set above
+					    from a route's registered content column) is measured relative to
+					    it. */}
+					<div
+						ref={pillAnchorRef}
+						className="relative flex flex-col flex-1 min-w-0 overflow-hidden"
+					>
 						<main ref={attachMain} className="flex-1 min-w-0 overflow-auto relative">
-							<Outlet />
+							<ScrollContentContext.Provider value={registerScrollContent}>
+								<Outlet />
+							</ScrollContentContext.Provider>
 						</main>
-						{/* Top-centre of the content area, just below the app header. */}
+						{/* Top-centre of the scrolled content column, just below the app
+						    header. `--pill-center-x` centres over the reader's content pane
+						    on pages with a side panel; unset elsewhere → falls back to 50%. */}
 						<ScrollToTopButton
 							onClick={scrollToTop}
 							visible={topVisible}
 							testId="scroll-to-top"
-							positionClassName="absolute top-4 left-1/2 -translate-x-1/2 z-30"
+							positionClassName="absolute top-4 left-[var(--pill-center-x,50%)] -translate-x-1/2 z-30"
 						/>
-						{/* Bottom-centre of the content area: clear of the CEO chat
-						    launcher (bottom-right) at every breakpoint. */}
+						{/* Bottom-centre of the scrolled content column: clear of the CEO
+						    chat launcher (bottom-right) at every breakpoint. */}
 						<ScrollToBottomButton
 							onClick={scrollToBottom}
 							visible={bottomVisible}
 							testId="scroll-to-bottom"
-							positionClassName="absolute bottom-4 left-1/2 -translate-x-1/2 z-30"
+							positionClassName="absolute bottom-4 left-[var(--pill-center-x,50%)] -translate-x-1/2 z-30"
 						/>
 					</div>
 				</div>

--- a/packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx
+++ b/packages/web/src/routes/projects/$projectId/tasks/$taskId.tsx
@@ -17,6 +17,7 @@ import { TaskHeader } from '../../../../components/task-detail/task-header';
 import { TaskSidebar } from '../../../../components/task-detail/task-sidebar';
 import { TaskSummary } from '../../../../components/task-detail/task-summary';
 import { ResizableSplit } from '../../../../components/ui/resizable-split';
+import { useRegisterScrollContent } from '../../../../contexts/scroll-content-context';
 import { useAgents } from '../../../../hooks/use-agents';
 import { type Comment, useComments, useCreateComment } from '../../../../hooks/use-comments';
 import { useExecutionLock } from '../../../../hooks/use-execution-locks';
@@ -91,6 +92,11 @@ function TaskDetailPage() {
 	// <main> — see __root.tsx); this hook instance only provides scrollToBottom
 	// for the sidebar's close/re-open actions.
 	const { scrollToBottom } = useScrollToBottom(scrollParent);
+
+	// This page's <main> holds a two-column grid at lg+ (content column + sticky
+	// meta rail). Register the content column so the global scroll pills centre
+	// over it, not over content + the non-scrolling rail.
+	const registerScrollContent = useRegisterScrollContent();
 
 	if (isLoading || !task)
 		return <div className="text-text-2 text-[13px] py-8 text-center">Loading...</div>;
@@ -173,7 +179,7 @@ function TaskDetailPage() {
 			}
 		>
 			<PreviewProvider value={openPreview}>
-				<div className="min-w-0">
+				<div ref={registerScrollContent} data-testid="task-content" className="min-w-0">
 					<LastRunFailedBanner task={task} />
 					<TaskHeader
 						task={task}

--- a/test/browser/task-detail.spec.ts
+++ b/test/browser/task-detail.spec.ts
@@ -208,4 +208,73 @@ test.describe('Task detail — initial scroll and scroll-to-bottom button', () =
 		await expect(button).toBeHidden({ timeout: 10000 });
 		await expect(page.getByPlaceholder('Add a comment...')).toBeInViewport();
 	});
+
+	// boundingBox() centre comparison (testing decision tree, point 1): at lg+ the
+	// task <main> holds a two-column grid (content column + sticky meta rail). The
+	// global scroll pills must centre over the scrolled *content* column, not over
+	// content + the non-scrolling rail — which would drift them right, over the
+	// rail. Both pills read the same `--pill-center-x`, so proving the down pill is
+	// centred proves the mechanism.
+	test('scroll pill centres over the content column, not the content + side panel', async ({
+		page,
+		sharedWorkspace,
+	}) => {
+		const { token } = sharedWorkspace;
+		// Wide enough that the lg+ meta rail reserves a real right column.
+		await page.setViewportSize({ width: 1440, height: 900 });
+
+		const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+		const project = await createProjectViaApi(
+			page,
+			token,
+			uniqueName('Pill Centre Project'),
+			'Pill centring test.',
+		);
+		const task = await createTaskViaApi(page, project.slug, token, {
+			project_id: project.id,
+			title: 'Pill Centre Task',
+			assignee_id: project.assigneeId,
+			description: 'A short description so the page header stays compact.',
+		});
+
+		for (let i = 0; i < 30; i++) {
+			await page.request.post(`/api/projects/${project.slug}/tasks/${task.id}/comments`, {
+				headers,
+				data: {
+					content_type: 'text',
+					content: { text: `Filler comment ${i}. ${'lorem ipsum '.repeat(30)}` },
+				},
+			});
+		}
+
+		await page.goto(`/projects/${project.slug}/tasks/${task.identifier.toLowerCase()}`);
+		await waitForPageLoad(page);
+		await expect(page.getByRole('heading', { name: 'Pill Centre Task' })).toBeInViewport();
+
+		const main = page.locator('main').first();
+		const button = page.getByTestId('scroll-to-bottom');
+		// The sticky meta rail must actually reserve a right column at this width.
+		await expect(page.getByTestId('task-rail')).toBeVisible();
+
+		// Reveal the pill with a downward scroll.
+		await main.evaluate((el) => el.scrollBy({ top: 400 }));
+		await expect(button).toBeVisible();
+
+		const contentBox = await page.getByTestId('task-content').boundingBox();
+		const pillBox = await button.boundingBox();
+		const mainBox = await main.boundingBox();
+		expect(contentBox).not.toBeNull();
+		expect(pillBox).not.toBeNull();
+		expect(mainBox).not.toBeNull();
+		if (contentBox && pillBox && mainBox) {
+			const pillCentre = pillBox.x + pillBox.width / 2;
+			const contentCentre = contentBox.x + contentBox.width / 2;
+			const mainCentre = mainBox.x + mainBox.width / 2;
+			// The pill centres over the content column…
+			expect(Math.abs(pillCentre - contentCentre)).toBeLessThan(3);
+			// …and that is meaningfully left of the full <main> centre (proving it is
+			// not centred over content + the reserved side-panel column).
+			expect(pillCentre).toBeLessThan(mainCentre - 100);
+		}
+	});
 });


### PR DESCRIPTION
## What & why

The global scroll-to-top / scroll-to-bottom pills were horizontally centred over the **full `<main>` width**. On a page whose `<main>` also holds a non-scrolling side panel — the **task detail meta rail** at `lg+` (`1fr` content column + a sticky `360/520/720px` rail, or `190px` collapsed, plus the preview-panel variants) — that pushes the pills **right, over the rail**, instead of over the content the reader actually scrolls.

This centres the pills over the scrolled content column.

## How

- **New `ScrollContentContext`** (`packages/web/src/contexts/scroll-content-context.tsx`): a route registers the DOM element that is its scrollable content pane, via a stable callback ref.
- **App shell** (`__root.tsx`): measures the registered column's horizontal centre **relative to the pills' positioning anchor** and exposes it as the `--pill-center-x` CSS variable; the pills use `left-[var(--pill-center-x,50%)]`. It re-measures on any layout change — resizable-panel drag, breakpoint switch, preview open/close, window resize — via a `ResizeObserver` on both the anchor and the content column.
- **Task detail route** registers its content column (`<div data-testid="task-content" …>`).
- Routes with **no side panel never register**, so `--pill-center-x` stays unset and the pills fall back to `left: 50%` (centred over `<main>`, unchanged). Documents, settings, and the bare document-preview page are unaffected.

## Testing

- **New Playwright test** (`test/browser/task-detail.spec.ts`): at `1440×900`, after revealing the pill, asserts its centre matches the `task-content` column centre (±3px) and is ≥100px left of the full-`<main>` centre — proving it is not centred over content + the reserved side-panel column. Both pills read the same variable, so proving the down pill proves the mechanism.
- Re-ran the global scroll specs (`scroll-to-bottom-global`, `scroll-to-top-global`) — documents page and bare preview page still pass, confirming the `50%` fallback is intact.
- `bunx biome check`, full `turbo typecheck`, and the production build all pass (run by the pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1WhcNtzSZWJQjMKVFwtfM

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1WhcNtzSZWJQjMKVFwtfM)_