### PR TITLE
feat: load models dynamically on every model-selection surface

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -1004,6 +1004,17 @@ it, and `setDefaultAiProvider` moves it atomically. `resolveRuntimeForTask` filt
 for the chosen runtime, else the oldest verified config; an agent's `model_override_*`
 (or the config's `default_model`) sets the CLI `--model`.
 
+**Live model listing.** Every UI surface that picks a specific model — the provider
+`default_model` selector and the per-agent model override — populates its options from
+`GET /api/ai-providers/:configId/models`, which decrypts the stored key and fetches the
+provider's live catalog (`AI_PROVIDER_INFO[provider].verifyEndpoint`, the same URL the add
+flow verifies against, normalized by `parseProviderModels` in `@hezo/shared`). No model list
+is hardcoded. The call is server-initiated and goes **direct** (not through the agent egress
+proxy). Subscription-auth configs short-circuit with `SUBSCRIPTION_UNSUPPORTED` (their blob is
+not an API key the catalog endpoint accepts), and the pickers degrade to the CLI's default
+model; the pricing-override model-id field stays free-text but offers the aggregated live
+catalog as autocomplete suggestions.
+
 **Reasoning effort.** Each run resolves an `agent_effort` level
 (`minimal|low|medium|high|max`) from the wakeup payload → `member_agents.default_effort` →
 global `medium`. Each runtime maps it natively: `claude_code` appends

--- a/docs/ai-models.md
+++ b/docs/ai-models.md
@@ -78,3 +78,8 @@ for any individual agent.** One agent can run on Claude while another on the sam
 runs on Gemini or DeepSeek — whatever fits its job. Set it when you hire
 the agent or any time afterward from its settings. See
 [Hiring & customizing agents](/docs/concepts/hiring-and-agents).
+
+Wherever you pick a specific model — a provider's default model, or an agent's override —
+Hezo loads the list of choices **live from that provider**, so you always see the models
+your key can actually use. Providers you signed in to with a subscription instead of an API
+key use the model their CLI selects, so there's no list to choose from there.

--- a/packages/server/src/routes/ai-providers.ts
+++ b/packages/server/src/routes/ai-providers.ts
@@ -289,6 +289,19 @@ aiProvidersRoutes.get('/ai-providers/:configId/models', async (c) => {
 	}
 
 	const provider = cred.provider as AiProvider;
+
+	// Subscription sign-in stores an OAuth/CLI blob, not an API key the catalog
+	// endpoint accepts — a live listing call would only 401. Signal the caller to
+	// fall back to the CLI's default model instead of surfacing a spurious error.
+	if (cred.authMethod === AiAuthMethod.Subscription) {
+		return err(
+			c,
+			'SUBSCRIPTION_UNSUPPORTED',
+			'Model listing is unavailable for subscription sign-in; the CLI default model is used',
+			400,
+		);
+	}
+
 	const endpoint = AI_PROVIDER_INFO[provider]?.verifyEndpoint;
 	if (!endpoint) {
 		return err(c, 'UNSUPPORTED', `No models endpoint for provider "${provider}"`, 400);

--- a/packages/server/test/ai-providers.test.ts
+++ b/packages/server/test/ai-providers.test.ts
@@ -757,6 +757,44 @@ describe('AI providers models endpoint', () => {
 		});
 		expect(res.status).toBe(503);
 	});
+
+	it('short-circuits subscription auth without a live provider call', async () => {
+		const codexBlob = JSON.stringify({
+			tokens: {
+				id_token: 'header.payload.sig',
+				access_token: 'header.payload.sig',
+				refresh_token: 'rt-test-token-1',
+				account_id: 'acct-123',
+			},
+		});
+		const created = await app.request('/api/ai-providers', {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				provider: 'openai',
+				api_key: codexBlob,
+				auth_method: 'subscription',
+				label: 'openai-subscription-models',
+			}),
+		});
+		expect(created.status).toBe(201);
+		const subConfigId = (await created.json()).data.id;
+
+		// Even if the provider were reachable, subscription auth must not attempt a
+		// catalog call — a throwing fetch would surface as 503 if we didn't skip it.
+		const fetchSpy = vi
+			.fn()
+			.mockRejectedValue(new Error('should not be called')) as unknown as typeof fetch;
+		globalThis.fetch = fetchSpy;
+
+		const res = await app.request(`/api/ai-providers/${subConfigId}/models`, {
+			headers: authHeader(token),
+		});
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.error.code).toBe('SUBSCRIPTION_UNSUPPORTED');
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
 });
 
 describe('AI providers single global default invariant', () => {

--- a/packages/web/src/components/ai-providers-section.tsx
+++ b/packages/web/src/components/ai-providers-section.tsx
@@ -281,8 +281,15 @@ function ProviderNameCell({ config }: { config: AiProviderConfig }) {
 }
 
 function DefaultModelSelector({ config }: { config: AiProviderConfig }) {
+	// Subscription sign-in has no API key the provider catalog accepts — the CLI
+	// picks the model, so listing is skipped and only "CLI default" is offered.
+	const isSubscription = config.auth_method === AiAuthMethod.Subscription;
+	// Lazy fetch so the settings page doesn't fire a live catalog call per row on
+	// mount. A native <select> opens on the same click that focuses it, so `onFocus`
+	// alone leaves the first open empty; `onPointerEnter` prefetches on hover intent
+	// so the models have arrived by the time the dropdown opens.
 	const [open, setOpen] = useState(false);
-	const models = useAiProviderModels(config.id, { enabled: open });
+	const models = useAiProviderModels(config.id, { enabled: open && !isSubscription });
 	const update = useUpdateAiProviderConfig(config.id);
 
 	async function handleChange(value: string) {
@@ -294,6 +301,7 @@ function DefaultModelSelector({ config }: { config: AiProviderConfig }) {
 			<select
 				aria-label={`Default model for ${config.label}`}
 				value={config.default_model ?? ''}
+				onPointerEnter={() => setOpen(true)}
 				onFocus={() => setOpen(true)}
 				onChange={(e) => handleChange(e.target.value)}
 				className="rounded-md border border-border bg-surface-2 px-2 py-1 text-xs text-text-1 outline-none focus:border-border-strong"
@@ -312,10 +320,14 @@ function DefaultModelSelector({ config }: { config: AiProviderConfig }) {
 			{(models.isFetching || update.isPending) && (
 				<Loader2 className="w-3 h-3 animate-spin text-text-3" />
 			)}
-			{models.error && (
-				<span className="text-danger text-xs">
-					{(models.error as { message?: string }).message || 'Failed to load models'}
-				</span>
+			{isSubscription ? (
+				<span className="text-text-3 text-xs">CLI default (subscription)</span>
+			) : (
+				models.error && (
+					<span className="text-danger text-xs">
+						{(models.error as { message?: string }).message || 'Failed to load models'}
+					</span>
+				)
 			)}
 		</div>
 	);

--- a/packages/web/src/components/model-pricing-section.tsx
+++ b/packages/web/src/components/model-pricing-section.tsx
@@ -1,5 +1,7 @@
+import { AiProviderStatus } from '@hezo/shared';
 import { Plus, RefreshCw, Trash2 } from 'lucide-react';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
+import { useAiProviders, useAllProviderModels } from '../hooks/use-ai-providers';
 import { useMe } from '../hooks/use-me';
 import {
 	type CreateOverridePayload,
@@ -47,6 +49,20 @@ export function ModelPricingSection() {
 	const refresh = useRefreshModelPricing();
 
 	const [showForm, setShowForm] = useState(false);
+
+	// Dynamic model suggestions for the free-text id field, drawn from the live
+	// catalogs of every verified provider. Fetched only while the form is open so
+	// the page doesn't fan out live calls on mount. The field stays free-text —
+	// custom/self-hosted model ids that no catalog lists remain valid.
+	const { data: providers } = useAiProviders();
+	const verifiedConfigIds = useMemo(
+		() => (providers ?? []).filter((p) => p.status === AiProviderStatus.Verified).map((p) => p.id),
+		[providers],
+	);
+	const { models: suggestedModels } = useAllProviderModels(verifiedConfigIds, {
+		enabled: showForm,
+	});
+
 	const [modelId, setModelId] = useState('');
 	const [input, setInput] = useState('');
 	const [output, setOutput] = useState('');
@@ -235,8 +251,16 @@ export function ModelPricingSection() {
 						placeholder="Model id (e.g. my-custom-model)"
 						value={modelId}
 						onChange={(e) => setModelId(e.target.value)}
+						list="model-pricing-model-ids"
 						required
 					/>
+					<datalist id="model-pricing-model-ids">
+						{suggestedModels.map((m) => (
+							<option key={m.id} value={m.id}>
+								{m.label}
+							</option>
+						))}
+					</datalist>
 					<div className="flex flex-col sm:flex-row gap-2">
 						<Input
 							placeholder="Input $ / Mtok"

--- a/packages/web/src/hooks/use-ai-providers.ts
+++ b/packages/web/src/hooks/use-ai-providers.ts
@@ -1,5 +1,5 @@
 import type { AiProviderModel } from '@hezo/shared';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQueries, useQuery } from '@tanstack/react-query';
 import { api } from '../lib/api';
 import { queryClient } from '../lib/query-client';
 import { queryKeys } from '../lib/query-keys';
@@ -90,6 +90,39 @@ export function useAiProviderModels(configId: string, options: { enabled?: boole
 		enabled: options.enabled ?? true,
 		staleTime: 5 * 60 * 1000,
 	});
+}
+
+/**
+ * Aggregate the live model catalogs across several provider configs, deduped by
+ * model id. Used to offer dynamic suggestions where a single config isn't the
+ * subject (e.g. the pricing-override model-id field). Each config fetches through
+ * the same per-config query as `useAiProviderModels`, so the cache is shared.
+ */
+export function useAllProviderModels(
+	configIds: string[],
+	options: { enabled?: boolean } = {},
+): { models: AiProviderModel[]; isLoading: boolean } {
+	const enabled = options.enabled ?? true;
+	const results = useQueries({
+		queries: configIds.map((configId) => ({
+			queryKey: queryKeys.aiProviderModels(configId),
+			queryFn: () => api.get<AiProviderModel[]>(`/api/ai-providers/${configId}/models`),
+			enabled,
+			staleTime: 5 * 60 * 1000,
+		})),
+	});
+
+	const byId = new Map<string, AiProviderModel>();
+	for (const r of results) {
+		for (const m of r.data ?? []) {
+			if (!byId.has(m.id)) byId.set(m.id, m);
+		}
+	}
+
+	return {
+		models: Array.from(byId.values()),
+		isLoading: results.some((r) => r.isLoading),
+	};
 }
 
 export function useUpdateAiProviderConfig(configId: string) {

--- a/packages/web/src/routes/projects/$projectId/agents/$agentId/settings.tsx
+++ b/packages/web/src/routes/projects/$projectId/agents/$agentId/settings.tsx
@@ -1,6 +1,7 @@
 import {
 	AgentAdminStatus,
 	AI_PROVIDER_INFO,
+	AiAuthMethod,
 	type AiProvider,
 	AiProviderStatus,
 	type BudgetWindowsCents,
@@ -351,19 +352,29 @@ function ModelOverride({ provider, model, onProviderChange, onModelChange }: Mod
 	const { data: configs } = useAiProviders();
 
 	const configByProvider = useMemo(() => {
-		const map = new Map<string, { id: string; default_model: string | null }>();
+		const map = new Map<
+			string,
+			{ id: string; default_model: string | null; auth_method: string }
+		>();
 		for (const c of configs ?? []) {
 			if (c.status !== AiProviderStatus.Verified) continue;
 			if (!map.has(c.provider)) {
-				map.set(c.provider, { id: c.id, default_model: c.default_model });
+				map.set(c.provider, {
+					id: c.id,
+					default_model: c.default_model,
+					auth_method: c.auth_method,
+				});
 			}
 		}
 		return map;
 	}, [configs]);
 
 	const activeConfig = provider ? configByProvider.get(provider) : undefined;
+	// Subscription sign-in has no API key the provider catalog accepts, so skip the
+	// listing call and let the agent fall back to the provider's default model.
+	const isSubscription = activeConfig?.auth_method === AiAuthMethod.Subscription;
 	const models = useAiProviderModels(activeConfig?.id ?? '', {
-		enabled: Boolean(activeConfig?.id),
+		enabled: Boolean(activeConfig?.id) && !isSubscription,
 	});
 
 	const availableProviders = Array.from(configByProvider.keys()) as AiProvider[];
@@ -400,7 +411,7 @@ function ModelOverride({ provider, model, onProviderChange, onModelChange }: Mod
 						aria-label="Model override model"
 						value={model}
 						onChange={(e) => onModelChange(e.target.value)}
-						disabled={!provider || models.isLoading}
+						disabled={!provider || isSubscription || models.isLoading}
 						className="rounded-md border border-border bg-surface-2 px-3 py-2 text-sm text-text-1 outline-none focus:border-border-strong disabled:opacity-60"
 					>
 						<option value="">
@@ -417,10 +428,16 @@ function ModelOverride({ provider, model, onProviderChange, onModelChange }: Mod
 							</option>
 						))}
 					</select>
-					{models.error && (
-						<span className="text-xs text-danger">
-							{(models.error as { message?: string }).message || 'Failed to load models'}
+					{isSubscription ? (
+						<span className="text-xs text-text-2">
+							Subscription sign-in — the provider's default model is used.
 						</span>
+					) : (
+						models.error && (
+							<span className="text-xs text-danger">
+								{(models.error as { message?: string }).message || 'Failed to load models'}
+							</span>
+						)
 					)}
 				</label>
 			</div>

--- a/packages/web/test/ai-providers.test.tsx
+++ b/packages/web/test/ai-providers.test.tsx
@@ -540,6 +540,86 @@ test('blocks the app when no provider is configured and drops once one is added'
 	);
 });
 
+/**
+ * Point the provider catalog call (a live fetch inside the `/models` route) at a
+ * fixed model list, so the default-model dropdown can be exercised without the
+ * real network. Other requests keep flowing through the harness fetch.
+ */
+function stubProviderCatalog(ids: string[]): void {
+	const harnessFetch = globalThis.fetch;
+	globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+		const url = input instanceof Request ? input.url : String(input);
+		if (url.includes('/v1/models') || url.includes('api.anthropic.com')) {
+			return new Response(JSON.stringify({ data: ids.map((id) => ({ id })) }), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			});
+		}
+		return harnessFetch(input as RequestInfo | URL, init);
+	}) as typeof fetch;
+}
+
+test('the default-model dropdown loads models dynamically on hover intent', async () => {
+	stubProviderCatalog(['claude-opus-4-8', 'claude-sonnet-4-6']);
+
+	const { findByRole } = await renderApp({
+		initialPath: '/settings/ai-providers',
+		seed: async () => {
+			await clearAiProviders();
+			const res = await postProvider({
+				provider: 'anthropic',
+				api_key: 'sk-ant-models-dropdown',
+				label: 'anthropic-models',
+			});
+			expect(res.status).toBe(201);
+		},
+	});
+
+	await findByRole('heading', { name: 'AI providers' });
+	const select = (await findByRole('combobox', {
+		name: 'Default model for anthropic-models',
+	})) as HTMLSelectElement;
+
+	// A native <select> opens on the same click that focuses it, so the query is
+	// prefetched on pointer-enter — by the time the list opens, the fetched models
+	// are already mounted as options.
+	fireEvent.pointerEnter(select);
+
+	await waitFor(
+		() => {
+			const values = Array.from(select.querySelectorAll('option')).map((o) => o.value);
+			expect(values).toContain('claude-opus-4-8');
+			expect(values).toContain('claude-sonnet-4-6');
+		},
+		{ timeout: 10_000 },
+	);
+});
+
+test('a subscription provider shows a CLI-default note instead of a model list', async () => {
+	// No catalog stub: subscription auth must not attempt the live listing at all,
+	// so a real fetch would be the bug this asserts against.
+	const { findByRole, findByText, queryByText } = await renderApp({
+		initialPath: '/settings/ai-providers',
+		seed: async () => {
+			await clearAiProviders();
+			const res = await postProvider({
+				provider: 'anthropic',
+				api_key: 'sk-ant-oat01-subscription-note-token',
+				auth_method: 'subscription',
+				label: 'anthropic-sub',
+			});
+			expect(res.status).toBe(201);
+		},
+	});
+
+	await findByRole('heading', { name: 'AI providers' });
+	await findByText('anthropic-sub');
+
+	// The row degrades to a friendly note; no error is surfaced.
+	await findByText('CLI default (subscription)', undefined, { timeout: 10_000 });
+	expect(queryByText('Failed to load models')).toBeNull();
+});
+
 test('re-raises the gate after deleting the last provider', async () => {
 	const { findByRole } = await renderApp({
 		initialPath: '/settings/ai-providers',

--- a/packages/web/test/model-pricing.test.tsx
+++ b/packages/web/test/model-pricing.test.tsx
@@ -1,5 +1,25 @@
+import { waitFor } from '@testing-library/react';
 import { expect, test } from 'vitest';
 import { renderApp } from './helpers/render';
+
+/**
+ * Route the provider catalog call (a live fetch inside the `/models` route) to a
+ * fixed model list. Everything else keeps flowing through the harness fetch that
+ * proxies `/api` to the in-process app. Returns the models it will serve.
+ */
+function stubProviderCatalog(ids: string[]): void {
+	const harnessFetch = globalThis.fetch;
+	globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+		const url = input instanceof Request ? input.url : String(input);
+		if (url.includes('/v1/models') || url.includes('api.anthropic.com')) {
+			return new Response(JSON.stringify({ data: ids.map((id) => ({ id })) }), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			});
+		}
+		return harnessFetch(input as RequestInfo | URL, init);
+	}) as typeof fetch;
+}
 
 async function seedOverride(
 	ctx: { token: string; apiBase: (p: string, i?: RequestInit) => Promise<Response> },
@@ -14,6 +34,9 @@ async function seedOverride(
 }
 
 test('model pricing lists the baked catalog plus overrides and creates an override', async () => {
+	// Opening the override form fetches provider catalogs for the id-suggestion
+	// datalist; stub it so the test doesn't reach the real network.
+	stubProviderCatalog(['claude-opus-4-8']);
 	const { findByText, findByRole, getByRole, getByPlaceholderText, user } = await renderApp({
 		initialPath: '/settings/ai-providers',
 		seed: async (ctx) => {
@@ -49,7 +72,38 @@ test('model pricing lists the baked catalog plus overrides and creates an overri
 	await findByText('my-fine-tune');
 });
 
+test('the override model-id field suggests models from configured providers via a datalist', async () => {
+	// The default seed leaves one verified anthropic (api_key) provider configured,
+	// whose live catalog we stub. Opening the form fans the catalog fetch out over
+	// verified providers and offers the results as datalist suggestions.
+	stubProviderCatalog(['claude-opus-4-8', 'claude-sonnet-4-6']);
+
+	const { findByRole, getByRole, container, user } = await renderApp({
+		initialPath: '/settings/ai-providers',
+	});
+
+	await findByRole('heading', { name: 'Model pricing' });
+	await user.click(getByRole('button', { name: 'Override' }));
+
+	// The input is wired to the datalist, and the datalist fills from the fetched
+	// catalog once the query resolves. The field itself stays free-text.
+	expect(container.querySelector('input[list="model-pricing-model-ids"]')).toBeTruthy();
+
+	await waitFor(
+		() => {
+			const datalist = container.querySelector('#model-pricing-model-ids');
+			const values = Array.from(datalist?.querySelectorAll('option') ?? []).map((o) =>
+				o.getAttribute('value'),
+			);
+			expect(values).toContain('claude-opus-4-8');
+			expect(values).toContain('claude-sonnet-4-6');
+		},
+		{ timeout: 10_000 },
+	);
+});
+
 test('the override form opens in a titled panel and closes via its close button', async () => {
+	stubProviderCatalog(['claude-opus-4-8']);
 	const { findByRole, getByRole, getByTestId, queryByTestId, user } = await renderApp({
 		initialPath: '/settings/ai-providers',
 	});


### PR DESCRIPTION
## Summary

Ensures every UI surface where a model is selected loads its options dynamically from the configured provider's **live catalog**, rather than any hardcoded/static list.

The core plumbing already existed — `GET /api/ai-providers/:configId/models` fetches each provider's catalog (`AI_PROVIDER_INFO[...].verifyEndpoint`, normalized by `parseProviderModels`), and the two real model pickers (per-agent **Model override** and provider **Default model**) already consumed it via `useAiProviderModels`. This PR is a re-audit that closes the remaining rough edges and extends dynamic loading to the last model-id field.

## Changes

- **Default-model selector first-open fix** — it fetched lazily on `onFocus`, but a native `<select>` opens on the same click that focuses it, so the fetched models weren't in the DOM on the first open. Now also prefetches on `onPointerEnter` (hover intent), so options are populated by the time the dropdown opens. Still lazy, so the settings page doesn't fire a live catalog call per row on mount.
- **Graceful subscription-auth handling** — subscription configs store an OAuth/CLI blob, not an API key the catalog endpoint accepts, so a listing call only 401s. The `/models` route now short-circuits these with `SUBSCRIPTION_UNSUPPORTED` (no doomed upstream call), and both pickers skip the fetch and show a friendly "CLI default" note instead of a red error.
- **Dynamic suggestions on the pricing-override model-id field** — the superuser "Add price override" field stays free-text (it must accept arbitrary/custom ids), but now offers a `<datalist>` of models aggregated across verified providers as autocomplete hints. Backed by a new `useAllProviderModels` hook (deduped `useQueries` fan-out), fetched only while the form is open.

## Tests

- Server: `/models` route short-circuits subscription auth with `SUBSCRIPTION_UNSUPPORTED` and makes no upstream `fetch`.
- Web (component tier): the default-model dropdown loads models on hover intent; a subscription provider shows the CLI-default note (no error); the pricing override field's datalist fills from configured providers.
- `bun run typecheck`, `bun run check`, and the affected server/web suites pass.

## Docs

- `docs/ai-models.md`: notes that model choices load live from the provider (and that subscription providers use the CLI's model).
- `.dev/architecture.md`: documents the live model-listing endpoint, its direct (non-proxied) call path, and the subscription short-circuit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rw6fveLptNNewbYFRjRKqX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rw6fveLptNNewbYFRjRKqX)_