### PR TITLE
fix: prevent asset viewer scroll jump when adding a review comment

### DIFF
--- a/packages/web/src/hooks/use-signed-url-text.ts
+++ b/packages/web/src/hooks/use-signed-url-text.ts
@@ -10,16 +10,28 @@ interface SignedUrlText {
 
 /**
  * Fetch a text asset's body from its signed URL (the public asset route serves
- * the stored bytes; no auth header — the signature is in the URL). Re-runs when
- * the URL changes: a list refetch hands out a fresh signature, and an agent
- * overwrite swaps the asset id inside the URL entirely.
+ * the stored bytes; no auth header — the signature is in the URL).
+ *
+ * The fetch is keyed on the asset's *identity* — the URL path (`/api/assets/
+ * <id>`) — not on the whole URL. The query string carries only a short-lived
+ * `exp`/`sig` that every assets-list refetch rotates (a fresh `Date.now()` per
+ * request), and re-fetching the same immutable bytes on a merely-rotated
+ * signature is wasted work. Worse, blanking `text` for a frame unmounts the
+ * asset viewer's prose, which collapses the page and yanks the reader back to
+ * the top mid-review — the bug this keying fixes. An asset overwrite swaps the
+ * id (and thus the path), so genuinely new content still triggers a refetch;
+ * `reload()` forces one with the latest signature after an error (e.g. the URL
+ * expired before the first load landed).
  */
 export function useSignedUrlText(url: string | undefined): SignedUrlText {
 	const [text, setText] = useState<string | null>(null);
 	const [error, setError] = useState<string | null>(null);
 	const [nonce, setNonce] = useState(0);
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: `nonce` is the manual retry trigger — bumping it re-runs the fetch for the same URL
+	// The asset's stable identity: everything before the signing query string.
+	const identity = url ? url.split('?')[0] : undefined;
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: intentional — fetch the latest signed `url`, but re-run only when the asset `identity` (path) changes or `nonce` (the manual retry) bumps. A rotated signature for the same asset must NOT re-run, so `url` is deliberately excluded from the deps.
 	useEffect(() => {
 		if (!url) return;
 		let cancelled = false;
@@ -38,7 +50,7 @@ export function useSignedUrlText(url: string | undefined): SignedUrlText {
 		return () => {
 			cancelled = true;
 		};
-	}, [url, nonce]);
+	}, [identity, nonce]);
 
 	const reload = useCallback(() => setNonce((n) => n + 1), []);
 	return { text, error, reload };

--- a/packages/web/test/use-signed-url-text.test.tsx
+++ b/packages/web/test/use-signed-url-text.test.tsx
@@ -1,0 +1,98 @@
+// Unit tests for useSignedUrlText: the hook that loads a text asset's body from
+// its signed URL. The behaviour under test is the identity-keyed fetch — a
+// rotated `exp`/`sig` for the SAME asset must not re-fetch or blank the loaded
+// text (blanking unmounts the asset viewer's prose and scrolls the reader back
+// to the top mid-review), while an overwrite that swaps the asset id (its URL
+// path) must. Rendered with renderHook + a mocked fetch (no app shell).
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, expect, test, vi } from 'vitest';
+import { useSignedUrlText } from '../src/hooks/use-signed-url-text';
+
+function mockResponse(body: string, init?: { ok?: boolean; status?: number }): Response {
+	const ok = init?.ok ?? true;
+	const status = init?.status ?? (ok ? 200 : 404);
+	return { ok, status, text: async () => body } as unknown as Response;
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+test('loads the asset body from its signed URL', async () => {
+	const spy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockResponse('hello world'));
+	const { result } = renderHook(() => useSignedUrlText('/api/assets/abc?exp=1&sig=aaa'));
+
+	await waitFor(() => expect(result.current.text).toBe('hello world'));
+	expect(result.current.error).toBeNull();
+	expect(spy).toHaveBeenCalledTimes(1);
+	expect(spy).toHaveBeenCalledWith('/api/assets/abc?exp=1&sig=aaa');
+});
+
+test('a rotated signature for the same asset does not refetch or blank the text', async () => {
+	const spy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockResponse('body v1'));
+	const { result, rerender } = renderHook(({ url }) => useSignedUrlText(url), {
+		initialProps: { url: '/api/assets/abc?exp=1&sig=aaa' },
+	});
+	await waitFor(() => expect(result.current.text).toBe('body v1'));
+	expect(spy).toHaveBeenCalledTimes(1);
+
+	// An assets-list refetch mints a fresh signature for the SAME asset path —
+	// this is exactly what a review-comment WebSocket broadcast triggers.
+	rerender({ url: '/api/assets/abc?exp=2&sig=bbb' });
+
+	// The effect (the only thing that calls fetch / blanks text) does not re-run:
+	// no second request, and the loaded text is preserved. That is what keeps the
+	// viewer's prose mounted so the reader isn't yanked to the top.
+	await act(async () => {
+		await Promise.resolve();
+	});
+	expect(spy).toHaveBeenCalledTimes(1);
+	expect(result.current.text).toBe('body v1');
+});
+
+test('an overwrite that swaps the asset id (path) refetches the new content', async () => {
+	const spy = vi
+		.spyOn(globalThis, 'fetch')
+		.mockImplementation(async (input) =>
+			mockResponse(String(input).startsWith('/api/assets/v2') ? 'body v2' : 'body v1'),
+		);
+	const { result, rerender } = renderHook(({ url }) => useSignedUrlText(url), {
+		initialProps: { url: '/api/assets/v1?exp=1&sig=aaa' },
+	});
+	await waitFor(() => expect(result.current.text).toBe('body v1'));
+
+	rerender({ url: '/api/assets/v2?exp=1&sig=aaa' });
+	await waitFor(() => expect(result.current.text).toBe('body v2'));
+	expect(spy).toHaveBeenCalledTimes(2);
+});
+
+test('reload() retries with the latest signature after an error, without auto-retrying on rotation', async () => {
+	const spy = vi
+		.spyOn(globalThis, 'fetch')
+		.mockImplementation(async (input) =>
+			String(input).includes('sig=expired')
+				? mockResponse('', { ok: false, status: 403 })
+				: mockResponse('recovered body'),
+		);
+	const { result, rerender } = renderHook(({ url }) => useSignedUrlText(url), {
+		initialProps: { url: '/api/assets/abc?exp=1&sig=expired' },
+	});
+	await waitFor(() => expect(result.current.error).toContain('403'));
+	expect(result.current.text).toBeNull();
+
+	// A list refetch hands out a fresh, valid signature for the same asset. The
+	// hook does NOT auto-retry on a signature rotation…
+	rerender({ url: '/api/assets/abc?exp=2&sig=valid' });
+	await act(async () => {
+		await Promise.resolve();
+	});
+	expect(spy).toHaveBeenCalledTimes(1);
+	expect(result.current.error).toContain('403');
+
+	// …but reload() forces a fetch, and it uses the LATEST signature (proving the
+	// effect closure reads the current url even though url is out of its deps).
+	act(() => result.current.reload());
+	await waitFor(() => expect(result.current.text).toBe('recovered body'));
+	expect(result.current.error).toBeNull();
+	expect(spy).toHaveBeenLastCalledWith('/api/assets/abc?exp=2&sig=valid');
+});


### PR DESCRIPTION
## Problem

Highlighting text in a text asset (markdown / plain text) and saving a review comment scrolled the reader **back to the top of the page**, forcing them to scroll back down to find where they were.

## Root cause

1. Saving the comment makes the server broadcast an `asset_review_comments` row-change over WebSocket (`review-comments.ts`).
2. The client's WS handler maps that table to `queryKeys.projects.assets(cid)` = `['projects', slug, 'assets']` — the "prefix trick" that reaches the per-asset review-comments query (`use-websocket.ts`). That prefix **also matches the assets *list* query** exactly, so the list refetches.
3. Every list refetch mints a **fresh signed URL** — `signAssetUrl` bakes `Date.now()` into `exp`/`sig` (`asset-urls.ts`), so `asset.url` comes back a different string each time.
4. `useSignedUrlText` keyed its fetch effect on the whole URL, so a rotated signature ran the effect again and `setText(null)` for a frame. That flipped `ReviewableAssetText` into its "Loading…" placeholder, **unmounting the review surface / prose**, which collapsed the page height and clamped the scroll to the top.

## Fix

Key the fetch on the asset's **identity** — the URL path (`/api/assets/<id>`) — instead of the volatile query string. A rotated signature for the same asset no longer re-fetches or blanks the loaded text, so the prose stays mounted and the scroll position is preserved. Since an asset overwrite swaps the asset id (and thus the path), genuinely new content still triggers a refetch, and `reload()` still forces a fetch with the latest signature after an error.

As a bonus, this also fixes the same scroll jump from **any** other assets-list refetch (uploads, archives, agent activity) that happens while viewing a text asset.

## Testing

- New deterministic hook test `packages/web/test/use-signed-url-text.test.tsx` covering: initial load; a rotated signature for the same asset does **not** refetch or blank the text; an overwrite (new asset id → new path) **does** refetch; and `reload()` retries with the latest signature after an error without auto-retrying on rotation. Verified it **fails** against the pre-fix `[url, nonce]` deps and passes with the fix.
- Existing `packages/web/test/asset-viewer.test.tsx` (8 tests) still green.
- `tsc --noEmit` and biome clean on the changed files.

## Notes

Internal hook behaviour refinement only — no CLI, MCP tool, REST route, or user-visible API surface changed, so no docs/architecture updates were required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0138bdniKfqzzTtzWyP94vb8

---
_Generated by [Claude Code](https://claude.ai/code/session_0138bdniKfqzzTtzWyP94vb8)_