### PR TITLE
fix: let the per-project skill viewer read global skills by id

### DIFF
--- a/packages/server/src/routes/skills.ts
+++ b/packages/server/src/routes/skills.ts
@@ -567,8 +567,13 @@ skillsRoutes.get('/projects/:projectId/skills/:id', async (c) => {
 	}
 	const db = c.get('db');
 	const projectId = c.get('projectId') as string;
+	// Read-only scope mirrors the list route: this project's own skills PLUS
+	// globals (project_id IS NULL). The per-project Skills page renders global
+	// rows and lets them be viewed here; restricting to `project_id = $2` would
+	// 404 every global and leave the viewer stuck loading. Edit/delete/restore
+	// below stay strictly `project_id = $2` — globals are read-only here.
 	const result = await db.query<SkillRecord>(
-		'SELECT * FROM skills WHERE id = $1 AND project_id = $2',
+		'SELECT * FROM skills WHERE id = $1 AND (project_id = $2 OR project_id IS NULL)',
 		[c.req.param('id'), projectId],
 	);
 	if (result.rows.length === 0) return err(c, 'NOT_FOUND', 'Skill not found', 404);

--- a/packages/server/test/skills.test.ts
+++ b/packages/server/test/skills.test.ts
@@ -226,6 +226,47 @@ describe('per-project skills routes (/api/projects/:projectId/skills)', () => {
 		expect(own.id).toBeTruthy();
 	});
 
+	it('reads a global skill by id (so the per-project viewer can render it)', async () => {
+		const global = await createScoped({ name: 'Viewable', slug: 'viewable', content: '# g' });
+		const own = await createScoped({
+			name: 'Mine',
+			slug: 'mine',
+			content: '# o',
+			project_id: projectAId,
+		});
+
+		// A global skill (project_id IS NULL) must be readable through the project
+		// route — it appears in the project's list, and the read-only viewer fetches
+		// its full content by id. Restricting to project_id = :projectId used to 404
+		// it, leaving the view dialog stuck on "Loading…".
+		const readGlobal = await app.request(`/api/projects/${projectAId}/skills/${global.id}`, {
+			headers: authHeader(token),
+		});
+		expect(readGlobal.status).toBe(200);
+		const globalBody = (await readGlobal.json()).data as { content: string; project_id: null };
+		expect(globalBody.content).toBe('# g');
+		expect(globalBody.project_id).toBeNull();
+
+		// The project's own skill is still readable by id.
+		const readOwn = await app.request(`/api/projects/${projectAId}/skills/${own.id}`, {
+			headers: authHeader(token),
+		});
+		expect(readOwn.status).toBe(200);
+		expect((await readOwn.json()).data.content).toBe('# o');
+
+		// Another project's skill is not visible here → 404.
+		const other = await createScoped({
+			name: 'Theirs',
+			slug: 'theirs',
+			content: '# x',
+			project_id: projectBId,
+		});
+		const readOther = await app.request(`/api/projects/${projectAId}/skills/${other.id}`, {
+			headers: authHeader(token),
+		});
+		expect(readOther.status).toBe(404);
+	});
+
 	it('edits and removes the project’s own skill but not a global or another project’s', async () => {
 		const own = await createScoped({
 			name: 'Edit Me',

--- a/packages/web/test/project-skills.test.tsx
+++ b/packages/web/test/project-skills.test.tsx
@@ -66,6 +66,38 @@ test('the per-project Skills page shows project skills (editable) and globals (r
 	await findByText('A Project Skill');
 });
 
+test('a stored global skill is viewable in the read-only modal from the project page', async () => {
+	let projectSlug = '';
+	const { findByText, router, user } = await renderApp({
+		initialPath: '/',
+		seed: async (ctx) => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Viewer Proj' });
+			projectSlug = project.slug;
+			await seedSkill(ctx, { name: 'Executing Plans', content: '# How to execute plans' });
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/skills',
+		params: { projectId: projectSlug },
+	});
+
+	// The stored global skill renders under "Global (all projects)".
+	const globalRow = (await findByText('Executing Plans')).closest(
+		'[data-testid="global-skill-row"]',
+	) as HTMLElement;
+
+	// Opening its viewer fetches the full skill by id through the project route.
+	// That route used to require project_id = :projectId, so a global (project_id
+	// NULL) 404'd and the dialog was stuck on "Loading…". Assert the content
+	// actually renders now.
+	await user.click(within(globalRow).getByLabelText('View Executing Plans'));
+	const dialog = await within(document.body).findByTestId('skill-view-dialog');
+	const dialogContent = await within(dialog).findByTestId('skill-view-content');
+	expect(dialogContent.querySelector('h1')?.textContent).toContain('How to execute plans');
+});
+
 test('the built-in connector-recipes skill shows on the project page as a global, viewable in a modal', async () => {
 	let projectSlug = '';
 	const { findByText, router, user } = await renderApp({


### PR DESCRIPTION
## Problem

Opening a **global** skill to view it from the per-project Skills page (`/projects/:projectId/skills`) didn't work — the read-only view dialog was stuck on "Loading…" forever.

## Root cause

The per-project single-skill GET route — `GET /api/projects/:projectId/skills/:id` — scoped its query to `WHERE id = $1 AND project_id = $2`. But a **global** skill has `project_id IS NULL`, so the query returned 0 rows and the route responded 404.

The list route beside it (`GET /api/projects/:projectId/skills`) already includes globals with `(s.project_id = $1 OR s.project_id IS NULL)`, so global rows render in the project's Skills list — but clicking "View" fetches the full skill by id through the single-skill route, which 404'd. The frontend query never resolved, so `SkillViewDialog` never received the skill and stayed on its "Loading…" placeholder.

(The built-in virtual `connector-recipes` global skill was unaffected because it's intercepted before the DB query — only *stored* global skills hit the bug.)

## Fix

The single-skill GET now mirrors the list route's read scope: this project's own skills **plus** globals (`project_id IS NULL`). Edit, delete, and restore stay strictly `project_id = :projectId`, so globals remain read-only from the project page — only their content becomes viewable.

## Tests

- **Server** (`packages/server/test/skills.test.ts`): reading a global skill by id through the project route now returns 200 with content; the project's own skill still reads; another project's skill still 404s.
- **Web component** (`packages/web/test/project-skills.test.tsx`): opens the read-only viewer on a stored global skill from the project Skills page and asserts its markdown content renders (instead of hanging on "Loading…").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019eHrWxZVdgPcQJaHg7MP9e

---
_Generated by [Claude Code](https://claude.ai/code/session_019eHrWxZVdgPcQJaHg7MP9e)_