### PR TITLE
feat: switch viewed document/asset via in-viewer name search

### DIFF
--- a/docs/concepts/assets.md
+++ b/docs/concepts/assets.md
@@ -116,7 +116,8 @@ in a **sandbox**, isolated from your instance and your data, so viewing an agent
 safe by default; **markdown** renders as formatted prose with a **view-source** toggle;
 images and SVGs display scaled to fit; other types show a summary card. **Open raw** in the
 viewer's toolbar still opens the underlying file in its own tab whenever you want the
-unwrapped thing.
+unwrapped thing. A **search icon** next to the breadcrumb opens a name search for jumping
+straight to another asset without returning to the library.
 
 ## Reviewing assets
 

--- a/docs/concepts/documents-and-memory.md
+++ b/docs/concepts/documents-and-memory.md
@@ -74,7 +74,9 @@ work (`list_project_docs`, `read_project_doc`, and `write_project_doc` over Hezo
 for example `spec.md` — so links stay stable as the work evolves. The document list sits
 beside the reader, with a **search box** at the top that filters the list as you type and a
 **+** button next to it for creating a new document — both stay in view while you scroll
-the list.
+the list. A **search icon** next to the open document's title opens the same name search from
+inside the reader, so you can jump straight to another document without going back to the
+list; it's hidden while you're editing.
 
 Agents don't carry every document's full text on every run. Instead each run includes a
 **manifest** — a table of contents listing each document's filename, title, and when it

--- a/packages/web/src/components/docs-library.tsx
+++ b/packages/web/src/components/docs-library.tsx
@@ -24,6 +24,7 @@ import { Button } from './ui/button';
 import { ConfirmDialog } from './ui/confirm-dialog';
 import { EmptyState } from './ui/empty-state';
 import { Input } from './ui/input';
+import { NameSwitcherButton } from './ui/name-switcher-button';
 import { Tooltip } from './ui/tooltip';
 
 /** Remembers the doc-list collapse choice across documents and visits. */
@@ -41,6 +42,12 @@ export interface DocItem {
 
 interface DocsLibraryProps {
 	items: DocItem[];
+	/**
+	 * The full item list for the header "switch document" search — unfiltered by
+	 * the archive filter, so the switcher can jump to any document by name.
+	 * Defaults to `items` when omitted.
+	 */
+	allItems?: DocItem[];
 	isLoadingList?: boolean;
 	selectedKey: string | null;
 	onSelect: (key: string | null) => void;
@@ -112,6 +119,7 @@ interface DocsLibraryProps {
 
 export function DocsLibrary({
 	items,
+	allItems,
 	isLoadingList,
 	selectedKey,
 	onSelect,
@@ -207,6 +215,13 @@ export function DocsLibrary({
 				return text.toLowerCase().includes(query);
 			})
 		: items;
+
+	// Options for the header "switch document" search — the full (unfiltered) list
+	// so any document is reachable by name regardless of the archive filter.
+	const switchOptions = (allItems ?? items).map((item) => ({
+		value: item.key,
+		label: typeof item.label === 'string' ? item.label : item.key,
+	}));
 
 	async function handleSave() {
 		await onSave(draft);
@@ -384,9 +399,20 @@ export function DocsLibrary({
 										</Button>
 									</Tooltip>
 								</span>
-								<h2 className="text-base font-semibold text-text-1 truncate">
+								<h2 className="text-base font-semibold text-text-1 truncate min-w-0">
 									{docTitle ?? selectedItem?.label ?? selectedKey}
 								</h2>
+								{mode === 'view' && switchOptions.length > 1 && (
+									<NameSwitcherButton
+										label="Switch document"
+										testId="doc-switch"
+										value={selectedKey}
+										onSelect={(key) => onSelect(key)}
+										options={switchOptions}
+										searchPlaceholder="Search documents…"
+										emptyLabel="No documents"
+									/>
+								)}
 							</div>
 							<div className="flex items-center gap-2 shrink-0">
 								{mode === 'view' ? (

--- a/packages/web/src/components/ui/name-switcher-button.tsx
+++ b/packages/web/src/components/ui/name-switcher-button.tsx
@@ -1,0 +1,55 @@
+import { Search } from 'lucide-react';
+import { SearchableSelect, type SearchableSelectOption } from './searchable-select';
+
+interface NameSwitcherButtonProps {
+	options: SearchableSelectOption[];
+	/** The currently-open item's value (checked in the list); null when none. */
+	value: string | null;
+	onSelect: (value: string) => void;
+	/** Accessible label / tooltip for the trigger, e.g. "Switch document". */
+	label: string;
+	searchPlaceholder?: string;
+	emptyLabel?: string;
+	testId?: string;
+}
+
+/**
+ * A search-icon button that opens a type-to-filter dropdown for jumping to
+ * another item by name — used as a suffix to a viewer's title to switch the
+ * document/asset being viewed. Wraps {@link SearchableSelect} with a native
+ * `<button>` trigger (the `ui/Button` doesn't forward a ref, so it can't be a
+ * Radix `asChild` trigger). Options render in a portal — query them against
+ * `document.body` in tests.
+ */
+export function NameSwitcherButton({
+	options,
+	value,
+	onSelect,
+	label,
+	searchPlaceholder = 'Search…',
+	emptyLabel = 'No matches',
+	testId,
+}: NameSwitcherButtonProps) {
+	return (
+		<SearchableSelect
+			options={options}
+			value={value}
+			onChange={onSelect}
+			searchPlaceholder={searchPlaceholder}
+			emptyLabel={emptyLabel}
+			testId={testId}
+			align="start"
+			trigger={
+				<button
+					type="button"
+					aria-label={label}
+					title={label}
+					data-testid={testId ? `${testId}-button` : undefined}
+					className="inline-flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded-md border-none bg-transparent text-text-2 outline-none transition-colors hover:bg-surface-3 hover:text-text-1 focus-visible:ring-[3px] focus-visible:ring-ring"
+				>
+					<Search className="h-3.5 w-3.5" />
+				</button>
+			}
+		/>
+	);
+}

--- a/packages/web/src/routes/projects/$projectId/assets_.view.tsx
+++ b/packages/web/src/routes/projects/$projectId/assets_.view.tsx
@@ -18,6 +18,7 @@ import { AssetViewerBody } from '../../../components/asset-review/asset-viewer-b
 import { ArchivedBadge } from '../../../components/ui/archived-badge';
 import { Breadcrumb, type BreadcrumbSegment } from '../../../components/ui/breadcrumb';
 import { EmptyState } from '../../../components/ui/empty-state';
+import { NameSwitcherButton } from '../../../components/ui/name-switcher-button';
 import { ResizableSplit } from '../../../components/ui/resizable-split';
 import { Tooltip } from '../../../components/ui/tooltip';
 import {
@@ -148,6 +149,27 @@ function AssetViewerPage() {
 				<div className="flex min-h-[26px] min-w-0 items-center gap-2">
 					<Breadcrumb segments={crumbs} data-testid="asset-viewer-breadcrumb" />
 					{readOnly && <ArchivedBadge />}
+					{assets && assets.length > 1 && (
+						<NameSwitcherButton
+							label="Switch asset"
+							testId="asset-switch"
+							value={file ?? null}
+							onSelect={(next) =>
+								navigate({
+									to: '/projects/$projectId/assets/view',
+									params: { projectId },
+									search: { file: next, ...(filter ? { filter } : {}) },
+								})
+							}
+							options={assets.map((a) => ({
+								value: a.original_filename,
+								label: a.original_filename.split('/').pop() ?? a.original_filename,
+								description: assetFolder(a.original_filename) || undefined,
+							}))}
+							searchPlaceholder="Search assets…"
+							emptyLabel="No assets"
+						/>
+					)}
 				</div>
 				<div className="flex shrink-0 items-center gap-2">
 					<Tooltip content="Download this file">

--- a/packages/web/src/routes/projects/$projectId/documents.tsx
+++ b/packages/web/src/routes/projects/$projectId/documents.tsx
@@ -112,6 +112,20 @@ function ProjectDocumentsPage() {
 		return list;
 	}, [agentsMd, docs, filter]);
 
+	// The full item list for the header "switch document" search — unfiltered by
+	// the archive filter, so the switcher can jump to any document (including
+	// archived ones) by name.
+	const allItems = useMemo<DocItem[]>(() => {
+		const list: DocItem[] = [];
+		if (agentsMd) {
+			list.push({ key: AGENTS_MD_KEY, label: 'AGENTS.md', pinned: true, canDelete: false });
+		}
+		for (const d of docs ?? []) {
+			list.push({ key: d.filename, label: d.filename, archived: d.archived_at != null });
+		}
+		return list;
+	}, [agentsMd, docs]);
+
 	const counts = useMemo(() => {
 		const all = docs?.length ?? 0;
 		const archived = docs?.filter((d) => d.archived_at != null).length ?? 0;
@@ -185,6 +199,7 @@ function ProjectDocumentsPage() {
 				projectId={projectId}
 				projectSlug={projectId}
 				items={items}
+				allItems={allItems}
 				isLoadingList={isLoadingList}
 				selectedKey={file ?? null}
 				onSelect={selectFile}

--- a/packages/web/test/asset-viewer.test.tsx
+++ b/packages/web/test/asset-viewer.test.tsx
@@ -288,3 +288,52 @@ test('the viewer breadcrumb walks back to the grid folder and Open raw links the
 		expect(router.state.location.search).toMatchObject({ folder: 'launch' });
 	});
 });
+
+test('switches the viewed asset via the header name search', async () => {
+	let projectSlug = '';
+	let fileA = '';
+	let fileB = '';
+
+	const { findByTestId, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Asset Switcher Project' });
+			const a = await seedAsset(ws, project, {
+				filename: 'alpha.md',
+				contentType: 'text/markdown',
+				bytes: new TextEncoder().encode('# Alpha asset'),
+				folder: 'community-posts',
+			});
+			const b = await seedAsset(ws, project, {
+				filename: 'bravo.md',
+				contentType: 'text/markdown',
+				bytes: new TextEncoder().encode('# Bravo asset'),
+			});
+			projectSlug = project.slug;
+			fileA = a.original_filename;
+			fileB = b.original_filename;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/assets/view',
+		params: { projectId: projectSlug },
+		search: { file: fileA },
+	});
+
+	const crumb = await findByTestId('asset-viewer-breadcrumb');
+	expect(crumb.textContent).toContain('alpha.md');
+
+	// Open the header switcher and jump to the other asset by name.
+	await user.click(await findByTestId('asset-switch-button'));
+	await user.type(await findByTestId('asset-switch-search'), 'bravo');
+	await user.click(await findByTestId(`asset-switch-option-${fileB}`));
+
+	await waitFor(() => {
+		expect(router.state.location.search).toMatchObject({ file: fileB });
+	});
+	await waitFor(async () => {
+		expect((await findByTestId('asset-viewer-breadcrumb')).textContent).toContain('bravo.md');
+	});
+});

--- a/packages/web/test/project-documents.test.tsx
+++ b/packages/web/test/project-documents.test.tsx
@@ -326,6 +326,49 @@ test('search input filters the document list as you type', async () => {
 	await findByText('content-calendar.md');
 });
 
+test('switches the viewed document via the header name search, hidden while editing', async () => {
+	let ws!: SeededWorkspace;
+	let projectSlug = '';
+	const fileA = `alpha-${Math.random().toString(36).slice(2, 8)}.md`;
+	const fileB = `bravo-${Math.random().toString(36).slice(2, 8)}.md`;
+
+	const { findByRole, findByTestId, findByText, queryByTestId, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async ({ apiBase, token }) => {
+			ws = await seedWorkspace();
+			const project = await seedProject(ws, {
+				name: uniqueName('Switcher Project'),
+				description: 'Tests the in-viewer document switcher.',
+			});
+			projectSlug = project.slug;
+			await seedDoc(apiBase, token, projectSlug, fileA, [{ content: 'Alpha body' }]);
+			await seedDoc(apiBase, token, projectSlug, fileB, [{ content: 'Bravo body' }]);
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/documents',
+		params: { projectId: projectSlug },
+		search: { file: fileA } as never,
+	});
+
+	await findByText('Alpha body', undefined, { timeout: 15_000 });
+
+	// Open the header switcher and jump to the other doc by name.
+	await user.click(await findByTestId('doc-switch-button'));
+	await user.type(await findByTestId('doc-switch-search'), 'bravo');
+	await user.click(await findByTestId(`doc-switch-option-${fileB}`));
+
+	// The viewer switched to the other document.
+	await findByRole('heading', { name: fileB, level: 2 }, { timeout: 15_000 });
+	await findByText('Bravo body', undefined, { timeout: 15_000 });
+
+	// Entering edit mode hides the switcher button.
+	await user.click(await findByRole('button', { name: 'Edit' }));
+	await findByRole('button', { name: 'Save' }, { timeout: 15_000 });
+	expect(queryByTestId('doc-switch-button')).toBeNull();
+});
+
 test('rejects invalid filename when creating a document', async () => {
 	let ws!: SeededWorkspace;
 	let projectSlug = '';


### PR DESCRIPTION
## What & why

Today the only way to change which document or asset you're viewing is to go back to the left list pane (documents) or the asset grid and click a different item. This adds a **search-icon button as a suffix to the name** in each viewer's header. Clicking it opens a dropdown with a free-text input that filters document/asset **names**; picking one opens it in the same viewer.

Per the request, the **document** viewer's button is **hidden while editing** (view mode only). The **asset** viewer has no inline content-edit mode, so its button is always shown.

## How

- **New shared component** `packages/web/src/components/ui/name-switcher-button.tsx` — pairs a search-icon **native `<button>`** trigger with the existing `SearchableSelect` (Radix popover + type-to-filter, rendered in a portal). A native button is used deliberately: `ui/Button` doesn't forward a ref, so it can't be a Radix `asChild` trigger (this mirrors the existing `connectors.tsx` custom-trigger pattern).
- **Document viewer** (`docs-library.tsx`): the switcher renders right after the `<h2>` title, gated on `mode === 'view'`. A new optional `allItems` prop carries the **unfiltered** doc list so the switcher can reach any document by name regardless of the archive filter; the route (`documents.tsx`) builds it from all docs + the pinned `AGENTS.md` entry.
- **Asset viewer** (`assets_.view.tsx`): the switcher renders after the breadcrumb. Options map each asset to `{ value: original_filename, label: basename, description: folder }` — the folder is also searchable, so typing a folder name or a basename both match. Selecting navigates to the viewer with the new `?file=`, preserving the `filter` round-trip param.
- **No server changes** — both viewers already hold the full name list client-side (`useProjectDocs` / `useProjectAssets`) and select the current item via the URL `?file=` search param.

## Search scope

Both switchers search **everything** by name, including archived items the current view filters out (documents → the unfiltered `allItems`; assets → the full library, which already includes archived assets).

## Tests

- `packages/web/test/project-documents.test.tsx` — seed ≥2 docs, open one, open the header switcher, search, pick another → viewer switches; then enter Edit and assert the switcher button is **absent** in edit mode.
- `packages/web/test/asset-viewer.test.tsx` — seed ≥2 assets, open one, open the switcher, search, pick another → breadcrumb + `?file=` update.

Both are component-tier tests (no CSS layout / viewport / WebSocket dependency, per the tiering guide). Full `bunx vitest run` for both files is green (18/18); repo typecheck and Biome pass.

## Docs

Updated the user-facing pages that describe the viewers: `docs/concepts/documents-and-memory.md` and `docs/concepts/assets.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017q65g2UQEB4bxoSNFAzkap

---
_Generated by [Claude Code](https://claude.ai/code/session_017q65g2UQEB4bxoSNFAzkap)_