### PR TITLE
feat(chat): "New thread" naming, CEO auto-titling, and expanded thread sidebar

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -558,6 +558,18 @@ response's `compacted_count`) where the oldest messages were. The store generali
 chat-enabled agent; the operator can review and edit it on the agent's **Chat history** tab
 (`GET/PUT /api/projects/:projectId/agents/:agentId/chat-memory`).
 
+**Automatic thread titling.** A web thread is created **untitled** (`chat_conversations.title`
+NULL — there is no hardcoded "Main" default) and rendered as a "New thread" placeholder. After a
+reply settles on an untitled thread that has a real exchange, `runTitleGeneration` runs a
+**headless exec** (like compaction — no `chat_message`, no reply broadcast) that hands the agent
+the active window and **captures a short title from its stdout** (`buildTitlePrompt` →
+`sanitizeChatTitle`); the agent does the naming, there is **no server-side LLM call**. It persists
+idempotently (`UPDATE … SET title WHERE title IS NULL`, so a manual/already-set title is never
+clobbered) and broadcasts `ChatConversationUpdated` on the `chat:global` room, so every open thread
+switcher/sidebar refetches and updates its label live. Titling runs **once** per thread (skipped
+once titled), is chained before compaction so the two never contend for the per-session prompt
+file, and its exec's tokens are not separately priced (matching compaction).
+
 HQ also exposes the standard **assets library** — the one internal-project surface that
 isn't hidden in the UI (Budget/Settings still are). Files the CEO produces for the operator
 in the live chat (a quick mockup, demo, or export) are saved via `write_project_asset` and

--- a/packages/server/migrations/032_chat_default_thread_untitled.sql
+++ b/packages/server/migrations/032_chat_default_thread_untitled.sql
@@ -1,0 +1,9 @@
+-- The default web chat thread used to be created with a hardcoded title of 'Main'.
+-- Threads now start untitled (NULL) and are auto-titled by the CEO from their
+-- content, with the frontend rendering an untitled thread as the "New thread"
+-- placeholder. Clear the legacy 'Main' title so existing default threads become
+-- untitled too and get picked up by auto-titling like any freshly created thread.
+--
+-- Safe: 'Main' was only ever the hardcoded system default — there has never been a
+-- UI (or MCP tool) to name a conversation, so no user-authored 'Main' title exists.
+UPDATE chat_conversations SET title = NULL WHERE title = 'Main';

--- a/packages/server/src/services/chat-session-manager.ts
+++ b/packages/server/src/services/chat-session-manager.ts
@@ -121,6 +121,52 @@ ${mem}
 ${windowTranscript}`;
 }
 
+/** Longest title we keep — anything past this is truncated when persisting. */
+const MAX_CHAT_TITLE_LENGTH = 60;
+
+/**
+ * Prompt for a headless auto-title run. The agent gets the conversation so far and
+ * must return ONLY a short topic title as plain text (no tools, no reply to the
+ * operator). Its stdout is captured and stored as the thread title. Deliberately
+ * omits the CEO system prompt — the file is the whole input, exactly like compaction.
+ */
+export function buildTitlePrompt(windowTranscript: string): string {
+	return `# Name this conversation
+
+This is a maintenance step, not a reply to the operator. Read the conversation below and produce a short, specific title that captures its topic.
+
+Rules:
+- 3–6 words, Title Case.
+- Output ONLY the title text — no quotes, no surrounding punctuation, no markdown, no preamble or explanation.
+- Do NOT call any tools and do NOT reply to the operator. Just print the title and stop.
+
+## Conversation
+
+${windowTranscript}`;
+}
+
+/**
+ * Reduce a raw title-generation output to a stored title: first non-empty line,
+ * stripped of surrounding quotes/backticks, whitespace collapsed, capped in length.
+ * Returns null when nothing usable remains (leave the thread untitled, retry later).
+ */
+export function sanitizeChatTitle(raw: string): string | null {
+	const firstLine = raw
+		.split('\n')
+		.map((l) => l.trim())
+		.find((l) => l.length > 0);
+	if (!firstLine) return null;
+	const cleaned = firstLine
+		.replace(/^['"`*_#\s]+/, '')
+		.replace(/['"`*_\s]+$/, '')
+		.replace(/\s+/g, ' ')
+		.trim();
+	if (!cleaned) return null;
+	return cleaned.length > MAX_CHAT_TITLE_LENGTH
+		? cleaned.slice(0, MAX_CHAT_TITLE_LENGTH).trim()
+		: cleaned;
+}
+
 export interface CeoSessionDeps extends RunnerDeps {
 	wsManager: WebSocketManager;
 	containerLogStreamer?: ContainerLogStreamer;
@@ -404,9 +450,12 @@ export class ChatSessionManager {
 		const abort = new AbortController();
 		const promise = this.runTurn(session, ctx, assistantMessageId, abort);
 		convo.current = { assistantMessageId, abort, promise };
-		// After the reply settles, compact this thread's window if it has grown past
-		// the cap (serialized against other threads' compactions).
-		trackBackground(promise.then(() => this.maybeCompact(ctx)));
+		// After the reply settles: first auto-title the thread if it's still untitled,
+		// then compact its window if it has grown past the cap. Chained (not parallel)
+		// so the two never exec against this thread's shared prompt file concurrently.
+		trackBackground(
+			promise.then(() => this.maybeAutoTitle(ctx)).then(() => this.maybeCompact(ctx)),
+		);
 
 		return { userMessageId, assistantMessageId, conversationId };
 	}
@@ -574,12 +623,15 @@ export class ChatSessionManager {
 			[ceoMemberId],
 		);
 		if (existing.rows[0]) return existing.rows[0].id;
+		// Store the default web thread untitled (NULL), not a hardcoded "Main": the
+		// frontend renders NULL as the "New thread" placeholder, and the CEO auto-titles
+		// it from the conversation on the first exchange (maybeAutoTitle).
 		const created = await this.deps.db.query<{ id: string }>(
 			`INSERT INTO chat_conversations (member_id, team_id, project_id, channel, title)
 			 VALUES ($1, $2, $3, 'web', $4) RETURNING id`,
-			[ceoMemberId, DEFAULT_TEAM_ID, projectId, title ?? 'Main'],
+			[ceoMemberId, DEFAULT_TEAM_ID, projectId, title ?? null],
 		);
-		await this.setupBindings(created.rows[0].id, title ?? 'Main', ChatChannel.Web, null);
+		await this.setupBindings(created.rows[0].id, title ?? 'New thread', ChatChannel.Web, null);
 		return created.rows[0].id;
 	}
 
@@ -1246,6 +1298,99 @@ export class ChatSessionManager {
 				session: session.sessionId,
 			});
 		}
+	}
+
+	/**
+	 * Auto-title a thread from its content once, after a reply settles, if it's still
+	 * untitled. Best-effort and gated like compaction: skipped when a newer turn is in
+	 * flight in this thread (it retries after that turn) or a compaction is running for
+	 * it. A generated title flips the thread from the "New thread" placeholder to a
+	 * meaningful name; a failure leaves it untitled and the next reply retries.
+	 */
+	private async maybeAutoTitle(ctx: ConversationContext): Promise<void> {
+		const session = this.live;
+		if (!session) return;
+		const convo = this.getConvoRuntime(ctx.conversationId);
+		if (convo.current || convo.compaction) return;
+		// Only untitled threads get auto-titled; a set title (manual or already
+		// generated) is never overwritten.
+		const existing = await this.getConversation(ctx.conversationId);
+		if (!existing || existing.closed_at || existing.title != null) return;
+		const abort = new AbortController();
+		try {
+			await this.runTitleGeneration(session, ctx.conversationId, abort);
+		} catch (e) {
+			log.error('CEO chat auto-title failed', e);
+		}
+	}
+
+	/**
+	 * Headless title run: hand the agent the active window and capture its stdout as a
+	 * short title, then persist it (only while the thread is still untitled) and tell
+	 * the mirrored chatbox(es) to refetch the thread list. No `chat_message`, no
+	 * broadcast of a reply — the operator sees only the switcher label update. The
+	 * exec's tokens are not separately priced (matches `runCompaction`).
+	 */
+	private async runTitleGeneration(
+		session: LiveSession,
+		conversationId: string,
+		abort: AbortController,
+	): Promise<void> {
+		const window = await loadActiveWindow(this.deps.db, conversationId);
+		// Only title once there's a real exchange to summarize — at least one assistant
+		// reply with content. A failed/empty/interrupted-empty reply is skipped so a
+		// later successful turn titles the thread (and a failed turn spends no exec here).
+		if (!window.some((m) => m.role === ChatMessageRole.Assistant && m.content.trim() !== '')) {
+			return;
+		}
+		const prompt = buildTitlePrompt(window.map(chatTranscriptLine).join('\n\n'));
+		const { hostPath, env } = this.turnPrompt(session, conversationId);
+		mkdirSync(dirname(hostPath), { recursive: true });
+		writeFileSync(hostPath, prompt);
+
+		const parser = createAgentChatParser(session.runtimeType);
+		let text = '';
+		try {
+			const execId = await this.deps.docker.execCreate(session.containerId, {
+				Cmd: session.execCmd,
+				Env: env,
+				WorkingDir: CHAT_WORKING_DIR,
+				User: session.runUser.name,
+				AttachStdout: true,
+				AttachStderr: true,
+			});
+			await this.deps.docker.execStart(execId, {
+				signal: abort.signal,
+				onChunk: (chunk) => {
+					if (chunk.stream === 'stdout') {
+						for (const ev of parser.onStdout(chunk.text)) if (ev.text) text += ev.text;
+					}
+				},
+			});
+			for (const ev of parser.flush()) if (ev.text) text += ev.text;
+		} catch (e) {
+			// A new user turn preempts title generation — a clean stop, retried later.
+			if (abort.signal.aborted) return;
+			throw e;
+		} finally {
+			rmSync(hostPath, { force: true });
+		}
+		if (abort.signal.aborted) return;
+
+		const title = sanitizeChatTitle(text);
+		if (!title) return;
+		// Persist only while still untitled, so a concurrent path (or a manual title)
+		// is never clobbered; RETURNING confirms we actually set it before broadcasting.
+		const updated = await this.deps.db.query<{ id: string }>(
+			`UPDATE chat_conversations SET title = $1 WHERE id = $2 AND title IS NULL RETURNING id`,
+			[title, conversationId],
+		);
+		if (updated.rows.length === 0) return;
+		this.broadcastChat(conversationId, {
+			type: WsMessageType.ChatConversationUpdated,
+			conversationId,
+			title,
+		});
 	}
 
 	private async checkHealth(): Promise<void> {

--- a/packages/server/test/chat-session-compaction-lifecycle.test.ts
+++ b/packages/server/test/chat-session-compaction-lifecycle.test.ts
@@ -61,6 +61,17 @@ const replyHandler: ExecHandler = async (opts) => {
 
 const silentHandler: ExecHandler = async () => ({ stdout: '', stderr: '' });
 
+// Auto-title runs once after the first reply on an untitled thread; emit a short title
+// so the thread stops being untitled and doesn't re-title on later turns. Dispatched
+// independently of `handlers.turn` so a test that swaps in a blocking turn handler
+// doesn't accidentally block this exec too.
+const titleHandler: ExecHandler = async (opts) => {
+	const onChunk = opts.onChunk ?? (() => undefined);
+	await onChunk({ stream: 'stdout', text: assistantText('Auto Title') });
+	await onChunk({ stream: 'stdout', text: resultEvent(3, 2) });
+	return { stdout: '', stderr: '' };
+};
+
 /** Blocks until the exec's AbortSignal fires, then rejects like a real stream would. */
 const blockUntilAbort: ExecHandler = (opts) =>
 	new Promise((_resolve, reject) => {
@@ -87,7 +98,7 @@ function scriptedChatDocker(dataDir: string, projectId: string): ScriptedDocker 
 	const compactionPrompts: string[] = [];
 	const handlers = { turn: replyHandler, compaction: silentHandler };
 	const flags = { turnEntered: false, compactionEntered: false };
-	const kinds = new Map<string, 'turn' | 'compaction' | 'aux'>();
+	const kinds = new Map<string, 'turn' | 'compaction' | 'title' | 'aux'>();
 	const envByKind = new Map<string, string[]>();
 	let seq = 0;
 	const toHostPath = (containerPath: string) =>
@@ -112,6 +123,8 @@ function scriptedChatDocker(dataDir: string, projectId: string): ScriptedDocker 
 				kinds.set(execId, 'compaction');
 				compactionPrompts.push(prompt);
 				envByKind.set('compaction', config.Env ?? []);
+			} else if (prompt.startsWith('# Name this conversation')) {
+				kinds.set(execId, 'title');
 			} else {
 				kinds.set(execId, 'turn');
 				turnPrompts.push(prompt);
@@ -122,6 +135,7 @@ function scriptedChatDocker(dataDir: string, projectId: string): ScriptedDocker 
 		execStart: async (execId: string, opts: ExecOpts = {}) => {
 			const kind = kinds.get(execId) ?? 'aux';
 			if (kind === 'aux') return { stdout: '', stderr: '' };
+			if (kind === 'title') return titleHandler(opts);
 			if (kind === 'compaction') {
 				flags.compactionEntered = true;
 				return handlers.compaction(opts);

--- a/packages/server/test/chat-session.test.ts
+++ b/packages/server/test/chat-session.test.ts
@@ -32,6 +32,10 @@ const resultEvent = (input: number, output: number, costUsd: number) =>
 		total_cost_usd: costUsd,
 	});
 
+// Reply turns are interleaved with background auto-title / compaction execs (each with
+// its own prompt), so filter captured prompts to the actual operator-reply turns.
+const isReplyPrompt = (p: string) => p.includes('Reply to the latest operator message as the CEO.');
+
 async function poll(fn: () => Promise<boolean>, timeoutMs = 4000): Promise<void> {
 	const start = Date.now();
 	while (Date.now() - start < timeoutMs) {
@@ -241,9 +245,10 @@ describe('ChatSessionManager', () => {
 		});
 
 		await manager.sendTurn({ text: 'And the next step?' });
-		await poll(async () => chat.prompts.length >= 2);
+		await poll(async () => chat.prompts.filter(isReplyPrompt).length >= 2);
 
-		const secondPrompt = chat.prompts[1];
+		const replyPrompts = chat.prompts.filter(isReplyPrompt);
+		const secondPrompt = replyPrompts[replyPrompts.length - 1];
 		expect(secondPrompt).toContain('What is the status?');
 		expect(secondPrompt).toContain('Hi there');
 		expect(secondPrompt).toContain('And the next step?');
@@ -429,6 +434,63 @@ describe('ChatSessionManager', () => {
 		);
 		expect(sessions.rows[0].n).toBe(1);
 
+		await manager.stop();
+	});
+
+	test('creates the default web thread untitled (no hardcoded title)', async () => {
+		const { docker } = makeChatDocker(ctx.dataDir, projectId);
+		const { manager } = makeManager(ctx, docker);
+		// Resolving the default web thread must store NULL, not a hardcoded "Main" — the
+		// frontend renders NULL as "New thread" and the CEO auto-titles it later.
+		const id = await manager.getConversationId();
+		const convo = await manager.getConversation(id);
+		expect(convo?.title).toBeNull();
+		await manager.stop();
+	});
+
+	test('auto-titles an untitled thread after the first exchange and broadcasts it', async () => {
+		const { docker } = makeChatDocker(ctx.dataDir, projectId);
+		const { manager, wsManager } = makeManager(ctx, docker);
+		const captured = captureCeoRoom(wsManager);
+
+		const { conversationId } = await manager.sendTurn({ text: 'Hello CEO' });
+
+		// The reply's own stream sets the title too (the stub replies "Hi there" to both
+		// the turn and the title run); poll until the background auto-title lands.
+		await poll(async () => {
+			const convo = await manager.getConversation(conversationId);
+			return convo?.title != null;
+		});
+		const convo = await manager.getConversation(conversationId);
+		expect(convo?.title).toBe('Hi there');
+		// The switcher/rail learns about it live via a broadcast.
+		expect(
+			captured.events.some((e) => e.type === 'chat_conversation_updated' && e.title === 'Hi there'),
+		).toBe(true);
+
+		await manager.stop();
+	});
+
+	test('does not overwrite an existing thread title', async () => {
+		const { docker } = makeChatDocker(ctx.dataDir, projectId);
+		const { manager } = makeManager(ctx, docker);
+		const titled = await manager.createWebConversation('Roadmap planning');
+
+		const { assistantMessageId } = await manager.sendTurn({
+			text: 'Hello',
+			conversationId: titled,
+		});
+		await poll(async () => {
+			const r = await ctx.db.query<{ status: string }>(
+				'SELECT status FROM chat_messages WHERE id = $1',
+				[assistantMessageId],
+			);
+			return r.rows[0]?.status === ChatMessageStatus.Complete;
+		});
+		// Auto-title is chained right after the reply and skips a thread that already has
+		// a title, so the title can only stay as set.
+		const convo = await manager.getConversation(titled);
+		expect(convo?.title).toBe('Roadmap planning');
 		await manager.stop();
 	});
 });

--- a/packages/server/test/migrate-032-chat-default-thread-untitled.test.ts
+++ b/packages/server/test/migrate-032-chat-default-thread-untitled.test.ts
@@ -1,0 +1,76 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createDataPreservationHarness, type DataPreservationHarness } from './helpers/migrate';
+
+const TARGET = '032_chat_default_thread_untitled.sql';
+
+// Seeds three conversations at schema 031 — one titled 'Main' (the legacy default),
+// one with a real user-visible title, and one already untitled — applies the
+// migration, and asserts the 'Main' title is cleared to NULL while the real title
+// and the already-NULL row are preserved untouched.
+describe('032_chat_default_thread_untitled migration', () => {
+	let h: DataPreservationHarness;
+	let mainConvo: string;
+	let namedConvo: string;
+	let untitledConvo: string;
+
+	beforeAll(async () => {
+		h = await createDataPreservationHarness();
+		await h.applyUpToExclusive(TARGET);
+
+		const team = await h.db.query<{ id: string }>(
+			`INSERT INTO teams (name, slug) VALUES ('HQ', 'hq-team') RETURNING id`,
+		);
+		const teamId = team.rows[0].id;
+		const project = await h.db.query<{ id: string }>(
+			`INSERT INTO projects (team_id, name, slug, task_prefix, is_internal)
+			 VALUES ($1, 'HQ', 'hq', 'HQ', true) RETURNING id`,
+			[teamId],
+		);
+		const projectId = project.rows[0].id;
+		const member = await h.db.query<{ id: string }>(
+			`INSERT INTO members (team_id, member_type, display_name) VALUES ($1, 'agent', 'CEO') RETURNING id`,
+			[teamId],
+		);
+		const ceoId = member.rows[0].id;
+
+		const insert = async (title: string | null): Promise<string> => {
+			const r = await h.db.query<{ id: string }>(
+				`INSERT INTO chat_conversations (member_id, team_id, project_id, channel, title)
+				 VALUES ($1, $2, $3, 'web', $4) RETURNING id`,
+				[ceoId, teamId, projectId, title],
+			);
+			return r.rows[0].id;
+		};
+		mainConvo = await insert('Main');
+		namedConvo = await insert('Roadmap');
+		untitledConvo = await insert(null);
+
+		await h.applyTarget(TARGET);
+	});
+	afterAll(() => h.close());
+
+	it("clears the legacy 'Main' title to NULL", async () => {
+		const r = await h.db.query<{ title: string | null }>(
+			`SELECT title FROM chat_conversations WHERE id = $1`,
+			[mainConvo],
+		);
+		expect(r.rows[0].title).toBeNull();
+	});
+
+	it('preserves a real user-visible title', async () => {
+		const r = await h.db.query<{ title: string | null }>(
+			`SELECT title FROM chat_conversations WHERE id = $1`,
+			[namedConvo],
+		);
+		expect(r.rows[0].title).toBe('Roadmap');
+	});
+
+	it('leaves an already-untitled thread untouched', async () => {
+		const r = await h.db.query<{ id: string; title: string | null }>(
+			`SELECT id, title FROM chat_conversations WHERE id = $1`,
+			[untitledConvo],
+		);
+		expect(r.rows.length).toBe(1);
+		expect(r.rows[0].title).toBeNull();
+	});
+});

--- a/packages/shared/src/types/websocket.ts
+++ b/packages/shared/src/types/websocket.ts
@@ -17,6 +17,7 @@ export enum WsMessageType {
 	ChatMessageDelta = 'chat_message_delta',
 	ChatMessageComplete = 'chat_message_complete',
 	ChatCompacted = 'chat_compacted',
+	ChatConversationUpdated = 'chat_conversation_updated',
 	ProjectsChanged = 'projects_changed',
 	Error = 'error',
 }
@@ -147,12 +148,24 @@ export interface WsChatCompactedMessage {
 	conversationId: string;
 }
 
+/**
+ * A conversation's title changed (e.g. the CEO auto-titled a previously untitled
+ * thread from its content). Every mirrored surface reacts by refetching the thread
+ * list so the switcher/rail label updates live, without a reload.
+ */
+export interface WsChatConversationUpdatedMessage {
+	type: WsMessageType.ChatConversationUpdated;
+	conversationId: string;
+	title: string;
+}
+
 /** Any CEO chat WebSocket event, all carrying `conversationId` for thread routing. */
 export type WsChatServerMessage =
 	| WsChatMessageStartMessage
 	| WsChatMessageDeltaMessage
 	| WsChatMessageCompleteMessage
-	| WsChatCompactedMessage;
+	| WsChatCompactedMessage
+	| WsChatConversationUpdatedMessage;
 
 export type WsServerMessage =
 	| WsRowChangeMessage
@@ -164,6 +177,7 @@ export type WsServerMessage =
 	| WsChatMessageDeltaMessage
 	| WsChatMessageCompleteMessage
 	| WsChatCompactedMessage
+	| WsChatConversationUpdatedMessage
 	| WsProjectsChangedMessage
 	| WsConnectedMessage
 	| WsErrorMessage;

--- a/packages/web/src/components/chat/chat-widget.tsx
+++ b/packages/web/src/components/chat/chat-widget.tsx
@@ -164,8 +164,10 @@ export function ChatWidget({ open, onOpenChange }: ChatWidgetProps) {
 	// ones that mirror to Telegram. The `channels` array drives the mirror indicator.
 	const webThreads = conversations;
 	const activeThread = webThreads.find((t) => t.id === activeConversationId);
-	const threadLabel = (t: (typeof webThreads)[number], i: number) => {
-		const base = t.title?.trim() || (i === 0 ? 'Main' : 'New thread');
+	// Untitled threads render as "New thread" until the CEO auto-titles them from the
+	// conversation; there is no special "Main" default anymore.
+	const threadLabel = (t: (typeof webThreads)[number]) => {
+		const base = t.title?.trim() || 'New thread';
 		// A thread mirrored into Telegram gets a small glyph so its reach is obvious.
 		return t.channels?.includes('telegram') ? `${base}  ↔ Telegram` : base;
 	};
@@ -176,11 +178,13 @@ export function ChatWidget({ open, onOpenChange }: ChatWidgetProps) {
 		} | null;
 		if (res?.conversation?.id) setSelectedConversationId(res.conversation.id);
 	};
-	// Close the active thread; fall back to the default web thread afterwards.
-	const handleCloseThread = async () => {
-		if (!activeConversationId) return;
-		await closeThread(activeConversationId).catch(() => undefined);
-		setSelectedConversationId(undefined);
+	// Close a thread (defaults to the active one). If it was the active thread, fall
+	// back to the default web thread afterwards.
+	const handleCloseThread = async (id?: string) => {
+		const target = id ?? activeConversationId;
+		if (!target) return;
+		await closeThread(target).catch(() => undefined);
+		if (target === activeConversationId) setSelectedConversationId(undefined);
 	};
 
 	// Copy the whole conversation as plain text, each turn labelled by speaker.
@@ -297,156 +301,230 @@ export function ChatWidget({ open, onOpenChange }: ChatWidgetProps) {
 					</div>
 				</header>
 
-				{/* Thread switcher: pick / create / close parallel conversation threads.
-				    Web threads only; external (Telegram) threads live in their own app. */}
-				<div className="flex items-center gap-1 border-b border-border px-3 py-1.5">
-					<select
-						data-testid="chat-thread-select"
-						aria-label="Conversation thread"
-						value={activeConversationId ?? ''}
-						onChange={(e) => setSelectedConversationId(e.target.value || undefined)}
-						className="min-w-0 flex-1 truncate rounded-md border border-border bg-surface px-2 py-1 text-xs text-text-1"
-					>
-						{webThreads.length === 0 && <option value="">Main</option>}
-						{webThreads.map((t, i) => (
-							<option key={t.id} value={t.id}>
-								{threadLabel(t, i)}
-							</option>
-						))}
-					</select>
-					<button
-						type="button"
-						onClick={handleNewThread}
-						aria-label="New thread"
-						data-testid="chat-thread-new"
-						className="flex h-7 w-7 items-center justify-center rounded-md text-text-2 hover:bg-surface-2 hover:text-text-1"
-					>
-						<Plus className="h-4 w-4" />
-					</button>
-					{activeThread && webThreads.length > 1 && (
-						<button
-							type="button"
-							onClick={handleCloseThread}
-							aria-label="Close thread"
-							data-testid="chat-thread-close"
-							className="flex h-7 w-7 items-center justify-center rounded-md text-text-2 hover:bg-surface-2 hover:text-text-1"
+				{/* Body: on desktop-expanded the thread switcher becomes a left rail
+				    alongside the conversation column; otherwise it's a single column with
+				    the top dropdown switcher. */}
+				<div className={`flex min-h-0 flex-1 ${expanded ? 'flex-col md:flex-row' : 'flex-col'}`}>
+					{/* Expanded desktop only: threads as a left sidebar (mobile/collapsed keep
+					    the dropdown below). */}
+					{expanded && (
+						<aside
+							data-testid="chat-thread-rail"
+							className="hidden w-56 shrink-0 flex-col border-r border-border md:flex"
 						>
-							<X className="h-4 w-4" />
-						</button>
-					)}
-				</div>
-
-				{hq && blockedHealth ? (
-					<div
-						data-testid="chat-messages"
-						className="flex flex-1 items-center justify-center overflow-y-auto"
-					>
-						<HqContainerNotice
-							health={blockedHealth}
-							slug={hq.slug}
-							description="The CEO is unavailable until the HQ container is running."
-						/>
-					</div>
-				) : (
-					<FileDropZone
-						isDragActive={isDragActive}
-						dropZoneProps={dropZoneProps}
-						className="flex flex-1 flex-col overflow-hidden"
-						data-testid="chat-drop"
-						overlayTestId="chat-drop-overlay"
-					>
-						<div
-							ref={scrollRef}
-							data-testid="chat-messages"
-							className="flex flex-1 flex-col gap-4 overflow-y-auto px-4 py-4 scroll-smooth"
-						>
-							{!loaded && (
-								<div className="flex items-center justify-center py-6 text-[13px] text-text-2">
-									<Loader2 className="mr-2 h-4 w-4 animate-spin" />
-									Loading…
-								</div>
-							)}
-							{loaded && messages.length === 0 && compactedCount === 0 && (
-								<p className="px-1 py-6 text-center text-[13px] text-text-2">
-									Say hello to the CEO. Ask about anything, including active projects,
-									notifications, task blockers, etc
-								</p>
-							)}
-							{loaded && compactedCount > 0 && (
-								<div
-									data-testid="chat-compacted-banner"
-									className="flex items-center gap-2 px-1 pt-1 text-[11px] text-text-3"
-									title="Older messages were summarized into the CEO's long-term memory and removed from the live chat."
-								>
-									<span className="h-px flex-1 bg-border" />
-									<span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-border bg-surface-2 px-2.5 py-0.5">
-										<History className="h-3 w-3" aria-hidden="true" />
-										Earlier messages compacted into memory
-									</span>
-									<span className="h-px flex-1 bg-border" />
-								</div>
-							)}
-							{messages.map((m) => (
-								<MessageBubble key={m.id} message={m} projectSlug={hq?.slug} />
-							))}
-						</div>
-
-						<div className="border-t border-border p-3">
-							{hasAnyChip && (
-								<AttachmentChips
-									attachments={visibleAttachments}
-									uploading={uploading}
-									errors={errors}
-									onRemove={removeAttachment}
-									projectId={hq?.slug}
-									rowTestId="chat-attachment-row"
-									chipTestId="chat-attachment-chip"
-									previewTestId="chat-attachment-preview"
-									errorTestId="chat-attachment-error"
-								/>
-							)}
-							<div className="flex items-end gap-1 rounded-2xl border border-border bg-surface px-1.5 py-1 transition-colors focus-within:border-border-strong">
-								<UploadButton
-									onFiles={handleFiles}
-									accept={ATTACHMENT_ACCEPT}
-									iconOnly
-									label="Attach files"
-									data-testid="chat-attach"
-								/>
-								<textarea
-									ref={inputRef}
-									value={draft}
-									onChange={(e) => setDraft(e.target.value)}
-									onKeyDown={(e) => {
-										if (e.key === 'Enter' && !e.shiftKey) {
-											e.preventDefault();
-											submit();
-										}
-									}}
-									rows={1}
-									placeholder="Ask the CEO anything, across every project…"
-									data-testid="chat-input"
-									className="max-h-32 min-h-[2.25rem] flex-1 resize-none overflow-y-auto bg-transparent px-2 py-2 text-[13px] leading-5 text-text-1 outline-none placeholder:text-text-3"
-								/>
+							<div className="flex items-center justify-between px-3 pb-2 pt-3">
+								<span className="text-eyebrow text-text-3">Threads</span>
 								<button
 									type="button"
-									onClick={submit}
-									disabled={
-										(!draft.trim() && visibleAttachments.length === 0) ||
-										uploading.length > 0 ||
-										sending ||
-										streaming
-									}
-									aria-label="Send message"
-									data-testid="chat-send"
-									className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-accent-solid text-accent-solid-fg transition-colors hover:bg-accent-hover disabled:opacity-40"
+									onClick={handleNewThread}
+									aria-label="New thread"
+									data-testid="chat-thread-new-rail"
+									className="flex h-7 w-7 items-center justify-center rounded-md text-text-2 hover:bg-surface-2 hover:text-text-1"
 								>
-									<ArrowRight className="h-4 w-4" />
+									<Plus className="h-4 w-4" />
 								</button>
 							</div>
+							<div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto px-2 pb-2">
+								{webThreads.length === 0 && (
+									<span className="px-2.5 py-2 text-[13px] italic text-text-3">New thread</span>
+								)}
+								{webThreads.map((t) => {
+									const isActive = t.id === activeConversationId;
+									return (
+										<div
+											key={t.id}
+											data-testid="chat-thread-row"
+											data-active={isActive}
+											className={`group/thread flex items-center gap-1 rounded-lg pl-2.5 pr-1 py-1.5 text-[13px] ${
+												isActive
+													? 'bg-surface-2 font-medium text-text-1'
+													: 'text-text-2 hover:bg-surface-2 hover:text-text-1'
+											}`}
+										>
+											<button
+												type="button"
+												onClick={() => setSelectedConversationId(t.id)}
+												className="min-w-0 flex-1 truncate text-left"
+											>
+												{threadLabel(t)}
+											</button>
+											{webThreads.length > 1 && (
+												<button
+													type="button"
+													onClick={() => handleCloseThread(t.id)}
+													aria-label="Close thread"
+													data-testid="chat-thread-close-rail"
+													className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-text-3 opacity-0 hover:bg-surface-3 hover:text-text-1 focus-visible:opacity-100 group-hover/thread:opacity-100"
+												>
+													<X className="h-3.5 w-3.5" />
+												</button>
+											)}
+										</div>
+									);
+								})}
+							</div>
+						</aside>
+					)}
+
+					{/* Conversation column: dropdown switcher (hidden when the rail shows it) +
+					    messages + composer. */}
+					<div className="flex min-h-0 min-w-0 flex-1 flex-col">
+						{/* Thread switcher: pick / create / close parallel conversation threads.
+						    Web threads only; external (Telegram) threads live in their own app. */}
+						<div
+							className={`flex items-center gap-1 border-b border-border px-3 py-1.5 ${
+								expanded ? 'md:hidden' : ''
+							}`}
+						>
+							<select
+								data-testid="chat-thread-select"
+								aria-label="Conversation thread"
+								value={activeConversationId ?? ''}
+								onChange={(e) => setSelectedConversationId(e.target.value || undefined)}
+								className="min-w-0 flex-1 truncate rounded-md border border-border bg-surface px-2 py-1 text-xs text-text-1"
+							>
+								{webThreads.length === 0 && <option value="">New thread</option>}
+								{webThreads.map((t) => (
+									<option key={t.id} value={t.id}>
+										{threadLabel(t)}
+									</option>
+								))}
+							</select>
+							<button
+								type="button"
+								onClick={handleNewThread}
+								aria-label="New thread"
+								data-testid="chat-thread-new"
+								className="flex h-7 w-7 items-center justify-center rounded-md text-text-2 hover:bg-surface-2 hover:text-text-1"
+							>
+								<Plus className="h-4 w-4" />
+							</button>
+							{activeThread && webThreads.length > 1 && (
+								<button
+									type="button"
+									onClick={() => handleCloseThread()}
+									aria-label="Close thread"
+									data-testid="chat-thread-close"
+									className="flex h-7 w-7 items-center justify-center rounded-md text-text-2 hover:bg-surface-2 hover:text-text-1"
+								>
+									<X className="h-4 w-4" />
+								</button>
+							)}
 						</div>
-					</FileDropZone>
-				)}
+
+						{hq && blockedHealth ? (
+							<div
+								data-testid="chat-messages"
+								className="flex flex-1 items-center justify-center overflow-y-auto"
+							>
+								<HqContainerNotice
+									health={blockedHealth}
+									slug={hq.slug}
+									description="The CEO is unavailable until the HQ container is running."
+								/>
+							</div>
+						) : (
+							<FileDropZone
+								isDragActive={isDragActive}
+								dropZoneProps={dropZoneProps}
+								className="flex flex-1 flex-col overflow-hidden"
+								data-testid="chat-drop"
+								overlayTestId="chat-drop-overlay"
+							>
+								<div
+									ref={scrollRef}
+									data-testid="chat-messages"
+									className="flex flex-1 flex-col gap-4 overflow-y-auto px-4 py-4 scroll-smooth"
+								>
+									{!loaded && (
+										<div className="flex items-center justify-center py-6 text-[13px] text-text-2">
+											<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+											Loading…
+										</div>
+									)}
+									{loaded && messages.length === 0 && compactedCount === 0 && (
+										<p className="px-1 py-6 text-center text-[13px] text-text-2">
+											Say hello to the CEO. Ask about anything, including active projects,
+											notifications, task blockers, etc
+										</p>
+									)}
+									{loaded && compactedCount > 0 && (
+										<div
+											data-testid="chat-compacted-banner"
+											className="flex items-center gap-2 px-1 pt-1 text-[11px] text-text-3"
+											title="Older messages were summarized into the CEO's long-term memory and removed from the live chat."
+										>
+											<span className="h-px flex-1 bg-border" />
+											<span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-border bg-surface-2 px-2.5 py-0.5">
+												<History className="h-3 w-3" aria-hidden="true" />
+												Earlier messages compacted into memory
+											</span>
+											<span className="h-px flex-1 bg-border" />
+										</div>
+									)}
+									{messages.map((m) => (
+										<MessageBubble key={m.id} message={m} projectSlug={hq?.slug} />
+									))}
+								</div>
+
+								<div className="border-t border-border p-3">
+									{hasAnyChip && (
+										<AttachmentChips
+											attachments={visibleAttachments}
+											uploading={uploading}
+											errors={errors}
+											onRemove={removeAttachment}
+											projectId={hq?.slug}
+											rowTestId="chat-attachment-row"
+											chipTestId="chat-attachment-chip"
+											previewTestId="chat-attachment-preview"
+											errorTestId="chat-attachment-error"
+										/>
+									)}
+									<div className="flex items-end gap-1 rounded-2xl border border-border bg-surface px-1.5 py-1 transition-colors focus-within:border-border-strong">
+										<UploadButton
+											onFiles={handleFiles}
+											accept={ATTACHMENT_ACCEPT}
+											iconOnly
+											label="Attach files"
+											data-testid="chat-attach"
+										/>
+										<textarea
+											ref={inputRef}
+											value={draft}
+											onChange={(e) => setDraft(e.target.value)}
+											onKeyDown={(e) => {
+												if (e.key === 'Enter' && !e.shiftKey) {
+													e.preventDefault();
+													submit();
+												}
+											}}
+											rows={1}
+											placeholder="Ask the CEO anything, across every project…"
+											data-testid="chat-input"
+											className="max-h-32 min-h-[2.25rem] flex-1 resize-none overflow-y-auto bg-transparent px-2 py-2 text-[13px] leading-5 text-text-1 outline-none placeholder:text-text-3"
+										/>
+										<button
+											type="button"
+											onClick={submit}
+											disabled={
+												(!draft.trim() && visibleAttachments.length === 0) ||
+												uploading.length > 0 ||
+												sending ||
+												streaming
+											}
+											aria-label="Send message"
+											data-testid="chat-send"
+											className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-accent-solid text-accent-solid-fg transition-colors hover:bg-accent-hover disabled:opacity-40"
+										>
+											<ArrowRight className="h-4 w-4" />
+										</button>
+									</div>
+								</div>
+							</FileDropZone>
+						)}
+					</div>
+				</div>
 			</div>
 		</>
 	);

--- a/packages/web/src/hooks/use-chat.ts
+++ b/packages/web/src/hooks/use-chat.ts
@@ -79,11 +79,22 @@ export interface ChatConversationSummary {
  */
 export function useChatConversations(active: boolean) {
 	const queryClient = useQueryClient();
+	const { subscribe } = useSocket();
 	const query = useQuery({
 		queryKey: queryKeys.chatConversations(),
 		queryFn: () => api.get<{ conversations: ChatConversationSummary[] }>('/api/chat/conversations'),
 		enabled: active,
 	});
+	// A thread's title can change server-side (the CEO auto-titles an untitled thread
+	// after the first exchange). Refetch the list when that lands so the switcher/rail
+	// label updates live. The widget's `useChat` already joins the `chat:global` room
+	// for its lifetime, so the broadcast reaches us without a separate join here.
+	useEffect(() => {
+		if (!active) return;
+		return subscribe(WsMessageType.ChatConversationUpdated, () => {
+			queryClient.invalidateQueries({ queryKey: queryKeys.chatConversations() });
+		});
+	}, [active, subscribe, queryClient]);
 	const create = useMutation({
 		mutationFn: (title?: string) =>
 			api.post<{ conversation: ChatConversationSummary }>('/api/chat/conversations', { title }),

--- a/packages/web/test/chat-threads.test.tsx
+++ b/packages/web/test/chat-threads.test.tsx
@@ -16,7 +16,7 @@ function msg(id: string, content: string): ChatMessage {
 	return { id, role: 'assistant', channel: 'web', status: 'complete', content, created_at: now() };
 }
 
-function thread(id: string, title: string): ChatConversationSummary {
+function thread(id: string, title: string | null): ChatConversationSummary {
 	return {
 		id,
 		channel: 'web',
@@ -67,4 +67,27 @@ test('the thread switcher re-keys the chatbox to the selected conversation', asy
 
 	// A new-thread affordance is present.
 	expect(getByTestId('chat-thread-new')).toBeTruthy();
+});
+
+test('an untitled thread renders as "New thread" (not "Main"); a titled thread shows its title', async () => {
+	// The first thread is untitled (title null) — it must read "New thread", not the
+	// old hardcoded "Main". The CEO fills the title in later.
+	queryClient.setQueryData(queryKeys.chatConversations(), {
+		conversations: [thread('thread-1', null), thread('thread-2', 'Roadmap planning')],
+	});
+	queryClient.setQueryData(queryKeys.chatConversation(), {
+		conversation_id: 'thread-1',
+		messages: [msg('m1', 'hi')],
+		compacted_count: 0,
+	});
+
+	const { findByTestId } = await renderApp({ initialPath: '/home' });
+	(await findByTestId('chat-launcher')).click();
+	await findByTestId('chat-panel');
+
+	const select = (await findByTestId('chat-thread-select')) as HTMLSelectElement;
+	const labels = Array.from(select.options).map((o) => o.textContent?.trim());
+	expect(labels).toContain('New thread');
+	expect(labels).toContain('Roadmap planning');
+	expect(labels).not.toContain('Main');
 });

--- a/test/browser/chat.spec.ts
+++ b/test/browser/chat.spec.ts
@@ -88,6 +88,52 @@ test.describe('CEO chat widget — responsive layout', () => {
 		expect(restored?.width ?? 0).toBeLessThan(440);
 	});
 
+	test('expanded desktop mode shows threads as a left sidebar; the dropdown is hidden', async ({
+		sharedPage,
+		sharedWorkspace,
+	}) => {
+		// Real CSS layout + viewport-conditional (decision-tree items 1 & 2): the thread
+		// rail is `hidden md:flex` and only appears in expanded desktop mode, so its
+		// presence and left-edge position must come from a real layout pass.
+		const page = sharedPage;
+
+		await page.setViewportSize({ width: 1280, height: 800 });
+		await page.goto(`/projects/${sharedWorkspace.projectSlug}/tasks`);
+		await waitForPageLoad(page);
+
+		const launcher = page.getByTestId('chat-launcher');
+		await expect(launcher).toBeVisible({ timeout: 15000 });
+		await launcher.click();
+
+		const panel = page.getByTestId('chat-panel');
+		await expect(panel).toBeVisible();
+
+		// Anchored/collapsed: the top dropdown switcher is the control; no rail.
+		await expect(page.getByTestId('chat-thread-select')).toBeVisible();
+		await expect(page.getByTestId('chat-thread-rail')).toBeHidden();
+
+		// Expand → the switcher becomes a left rail and the dropdown is hidden.
+		await page.getByTestId('chat-expand').click();
+		await expect(panel).toHaveAttribute('data-expanded', 'true');
+		const rail = page.getByTestId('chat-thread-rail');
+		await expect(rail).toBeVisible();
+		await expect(page.getByTestId('chat-thread-select')).toBeHidden();
+
+		// The rail hugs the panel's left edge and is a narrow column (not full width).
+		const panelBox = await panel.boundingBox();
+		const railBox = await rail.boundingBox();
+		expect(railBox).not.toBeNull();
+		expect(Math.abs((railBox?.x ?? 0) - (panelBox?.x ?? 0))).toBeLessThan(4);
+		expect(railBox?.width ?? 0).toBeLessThan(300);
+		expect(railBox?.width ?? 0).toBeGreaterThan(150);
+
+		// Collapse restores the dropdown and removes the rail.
+		await page.getByTestId('chat-expand').click();
+		await expect(panel).toHaveAttribute('data-expanded', 'false');
+		await expect(page.getByTestId('chat-thread-select')).toBeVisible();
+		await expect(rail).toBeHidden();
+	});
+
 	test('Escape closes the chat', async ({ sharedPage, sharedWorkspace }) => {
 		const page = sharedPage;
 


### PR DESCRIPTION
## What & why

Two changes to the floating CEO chatbox, plus the plumbing they need.

### 1. Threads open as "New thread" and the CEO titles them
- New/default web threads are now stored **untitled** (`chat_conversations.title` NULL) and rendered as a **"New thread"** placeholder. The old hardcoded **"Main"** default is gone on both the client label (`threadLabel`) and the server row (`resolveOrCreateConversation`).
- After a reply settles on an untitled thread that has a real exchange, `runTitleGeneration` runs a **headless title-generation exec** (modeled on the existing compaction run — no `chat_message`, no reply broadcast) that hands the agent the active window and **captures a short title from its stdout** (`buildTitlePrompt` → `sanitizeChatTitle`). The agent does the naming — there is no server-side LLM call.
- The title is persisted **idempotently** (`UPDATE … SET title WHERE title IS NULL`, so a manual/already-set title is never clobbered) and pushed live to every open switcher/sidebar via a new `chat_conversation_updated` WebSocket event. Titling runs **once** per thread and is chained before compaction so the two never contend for the per-session prompt file.

### 2. Expanded desktop mode shows threads as a left sidebar
- In expanded desktop mode the thread switcher becomes a persistent **left rail** (active row highlighted, "+" to start a thread, hover close). Collapsed desktop and all mobile keep the compact top dropdown. `expanded` is already desktop-only, so the rail is inherently scoped correctly.

### Migration
- `032_chat_default_thread_untitled.sql` clears the legacy hardcoded `'Main'` title (`UPDATE … SET title = NULL WHERE title = 'Main'`) so existing default threads become untitled and get auto-titled like any new thread. Safe: `'Main'` was only ever a system default — there has never been a UI to name a thread. Ships with a data-preservation test.

## Files
- `packages/shared/src/types/websocket.ts` — new `ChatConversationUpdated` event + message type + unions.
- `packages/server/src/services/chat-session-manager.ts` — NULL default title; `buildTitlePrompt` / `sanitizeChatTitle` / `maybeAutoTitle` / `runTitleGeneration`; broadcast.
- `packages/server/migrations/032_chat_default_thread_untitled.sql` (+ preservation test).
- `packages/web/src/components/chat/chat-widget.tsx` — "New thread" label, expanded two-column layout + thread rail.
- `packages/web/src/hooks/use-chat.ts` — `useChatConversations` subscribes to the new event.
- `.dev/architecture.md` — documents auto-titling + the new event.

## Tests
- **Server:** default web thread created untitled; auto-title after first exchange + `chat_conversation_updated` broadcast; existing titles are not overwritten; migration data-preservation.
- **Web:** an untitled thread (incl. the first) renders "New thread", not "Main".
- **Playwright:** expanded desktop shows the left rail (left-edge position) with the dropdown hidden; collapse restores the dropdown.
- Adjusted the existing chat-session / compaction-lifecycle stubs to classify the new title exec so prompt-ordering assertions stay accurate.

## Follow-up (separate PR)
While previewing this I noticed thread→channel mirroring only happens at thread-creation time, so **connecting Telegram later does not backfill existing threads**. That's an orthogonal gap and is intentionally **not** in this PR — it will be its own change.

## Note on CI
One pre-existing Playwright scroll-anchoring test (`collapsing the panel keeps the latest message pinned to the bottom`) is flaky in my sandbox's browser build; it fails identically on `main` with this change reverted, so it's environmental, not a regression here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012E47Fn4MEwEsy8WbLbq8jG

---
_Generated by [Claude Code](https://claude.ai/code/session_012E47Fn4MEwEsy8WbLbq8jG)_