### PR TITLE
feat: use a dropdown chevron for the in-viewer name switcher

### DIFF
--- a/docs/concepts/assets.md
+++ b/docs/concepts/assets.md
@@ -116,7 +116,7 @@ in a **sandbox**, isolated from your instance and your data, so viewing an agent
 safe by default; **markdown** renders as formatted prose with a **view-source** toggle;
 images and SVGs display scaled to fit; other types show a summary card. **Open raw** in the
 viewer's toolbar still opens the underlying file in its own tab whenever you want the
-unwrapped thing. A **search icon** next to the breadcrumb opens a name search for jumping
+unwrapped thing. A **dropdown** next to the breadcrumb opens a name search for jumping
 straight to another asset without returning to the library.
 
 ## Reviewing assets

--- a/docs/concepts/documents-and-memory.md
+++ b/docs/concepts/documents-and-memory.md
@@ -74,7 +74,7 @@ work (`list_project_docs`, `read_project_doc`, and `write_project_doc` over Hezo
 for example `spec.md` — so links stay stable as the work evolves. The document list sits
 beside the reader, with a **search box** at the top that filters the list as you type and a
 **+** button next to it for creating a new document — both stay in view while you scroll
-the list. A **search icon** next to the open document's title opens the same name search from
+the list. A **dropdown** next to the open document's title opens a name search from
 inside the reader, so you can jump straight to another document without going back to the
 list; it's hidden while you're editing.
 

--- a/packages/web/src/components/ui/name-switcher-button.tsx
+++ b/packages/web/src/components/ui/name-switcher-button.tsx
@@ -1,4 +1,4 @@
-import { Search } from 'lucide-react';
+import { ChevronDown } from 'lucide-react';
 import { SearchableSelect, type SearchableSelectOption } from './searchable-select';
 
 interface NameSwitcherButtonProps {
@@ -14,11 +14,11 @@ interface NameSwitcherButtonProps {
 }
 
 /**
- * A search-icon button that opens a type-to-filter dropdown for jumping to
- * another item by name — used as a suffix to a viewer's title to switch the
- * document/asset being viewed. Wraps {@link SearchableSelect} with a native
- * `<button>` trigger (the `ui/Button` doesn't forward a ref, so it can't be a
- * Radix `asChild` trigger). Options render in a portal — query them against
+ * A dropdown button (chevron trigger) that opens a type-to-filter list for
+ * jumping to another item by name — used as a suffix to a viewer's title to
+ * switch the document/asset being viewed. Wraps {@link SearchableSelect} with a
+ * native `<button>` trigger (the `ui/Button` doesn't forward a ref, so it can't
+ * be a Radix `asChild` trigger). Options render in a portal — query them against
  * `document.body` in tests.
  */
 export function NameSwitcherButton({
@@ -47,7 +47,7 @@ export function NameSwitcherButton({
 					data-testid={testId ? `${testId}-button` : undefined}
 					className="inline-flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded-md border-none bg-transparent text-text-2 outline-none transition-colors hover:bg-surface-3 hover:text-text-1 focus-visible:ring-[3px] focus-visible:ring-ring"
 				>
-					<Search className="h-3.5 w-3.5" />
+					<ChevronDown className="h-3.5 w-3.5" />
 				</button>
 			}
 		/>


### PR DESCRIPTION
## What & why

Follow-up to #752 (already merged). The in-viewer document/asset name switcher's trigger showed a **magnifying-glass (`Search`) icon**, which reads as "filter this view" rather than "switch to another item." This swaps it for a **`ChevronDown`** — the conventional dropdown indicator, and the same icon the underlying `SearchableSelect`'s default trigger uses.

The type-to-filter search box **inside** the opened menu is unchanged (it keeps its own search glyph) — only the closed trigger button's icon changes.

## Changes

- `packages/web/src/components/ui/name-switcher-button.tsx` — `Search` → `ChevronDown` in the trigger; updated the component doc comment.
- `docs/concepts/documents-and-memory.md` and `docs/concepts/assets.md` — describe the affordance as a **dropdown** rather than a "search icon."

No behavior, props, or test IDs changed, so the existing switcher tests (in #752) still cover it. Repo typecheck and Biome pass; verified visually in the running app (the trigger now renders a chevron next to the document title and the asset breadcrumb).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017q65g2UQEB4bxoSNFAzkap

---
_Generated by [Claude Code](https://claude.ai/code/session_017q65g2UQEB4bxoSNFAzkap)_