### PR TITLE
feat: show updated time on asset cards with hover timestamp

### DIFF
--- a/packages/web/src/routes/projects/$projectId/assets.tsx
+++ b/packages/web/src/routes/projects/$projectId/assets.tsx
@@ -1035,6 +1035,41 @@ function CopyReferenceButton({ reference }: { reference: string }) {
 	);
 }
 
+const RELATIVE_UNITS: Array<[Intl.RelativeTimeFormatUnit, number]> = [
+	['year', 60 * 60 * 24 * 365],
+	['month', 60 * 60 * 24 * 30],
+	['week', 60 * 60 * 24 * 7],
+	['day', 60 * 60 * 24],
+	['hour', 60 * 60],
+	['minute', 60],
+	['second', 1],
+];
+
+/**
+ * Human "updated" label for an asset card, e.g. "2 days ago" / "yesterday" /
+ * "now". `assets.created_at` is bumped to now() on every overwrite (see
+ * `upsertProjectAsset`), so it reads as the last time the asset changed. The
+ * exact timestamp stays available on hover via the card's <abbr> title.
+ */
+function relativeUpdated(iso: string): string {
+	const then = new Date(iso).getTime();
+	if (!Number.isFinite(then)) return '';
+	const deltaSeconds = Math.round((then - Date.now()) / 1000);
+	const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
+	for (const [unit, secondsPerUnit] of RELATIVE_UNITS) {
+		if (Math.abs(deltaSeconds) >= secondsPerUnit || unit === 'second') {
+			return rtf.format(Math.round(deltaSeconds / secondsPerUnit), unit);
+		}
+	}
+	return '';
+}
+
+/** Full local datetime for the <abbr> tooltip; empty string when unparsable. */
+function fullTimestamp(iso: string): string {
+	const d = new Date(iso);
+	return Number.isNaN(d.getTime()) ? '' : d.toLocaleString();
+}
+
 function AssetCard({
 	asset,
 	highlighted,
@@ -1111,7 +1146,18 @@ function AssetCard({
 					>
 						{basename}
 					</div>
-					<div className="text-[11px] text-text-3">{formatBytes(asset.byte_size)}</div>
+					<div className="text-[11px] text-text-3">
+						{formatBytes(asset.byte_size)} ·{' '}
+						{/* Native <abbr> tooltip shows the exact timestamp on hover; the
+						    dotted-underline "abbr" affordance signals it. */}
+						<abbr
+							title={fullTimestamp(asset.created_at)}
+							className="cursor-help"
+							data-testid="asset-updated"
+						>
+							{relativeUpdated(asset.created_at)}
+						</abbr>
+					</div>
 				</div>
 				<div className="flex shrink-0 items-center gap-0.5">
 					<Tooltip content="Open in new tab">

--- a/packages/web/test/project-assets-states.test.tsx
+++ b/packages/web/test/project-assets-states.test.tsx
@@ -21,6 +21,8 @@ interface FakeAsset {
 	comment_attachment_count?: number;
 	/** Archived assets carry a stamp; the hard-delete action only shows on these. */
 	archived_at?: string | null;
+	/** Overwrite-bumped upload time; defaults to now. Drives the "updated" label. */
+	created_at?: string;
 }
 
 function asset(o: FakeAsset) {
@@ -29,7 +31,7 @@ function asset(o: FakeAsset) {
 		content_type: o.content_type,
 		byte_size: o.byte_size,
 		original_filename: o.original_filename,
-		created_at: new Date().toISOString(),
+		created_at: o.created_at ?? new Date().toISOString(),
 		archived_at: o.archived_at ?? null,
 		url: `/api/assets/${o.id}?exp=9999999999&sig=deadbeef`,
 		comment_attachment_count: o.comment_attachment_count ?? 0,
@@ -293,4 +295,30 @@ test('uploading a disallowed file type surfaces a transient error chip', async (
 
 	const chip = await findByTestId('asset-upload-error');
 	expect(chip.textContent).toContain('malware.exe');
+});
+
+test('the asset card shows the relative updated time after the size, with the exact timestamp in the <abbr> title', async () => {
+	const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
+	const r = await renderAssetsWith([
+		asset({
+			id: 'a-dated',
+			content_type: 'image/png',
+			byte_size: 7987, // 7.8 KB
+			original_filename: 'hashnode-article.png',
+			created_at: twoDaysAgo,
+		}),
+	]);
+
+	await r.findByText('hashnode-article.png', undefined, { timeout: 20_000 });
+	const updated = await r.findByTestId('asset-updated');
+	// Relative label sits after the size, joined by a middot separator.
+	expect(updated.textContent).toBe('2 days ago');
+	const meta = updated.parentElement as HTMLElement;
+	expect(meta.textContent).toContain('7.8 KB');
+	expect(meta.textContent).toContain('·');
+	// Hovering surfaces the exact timestamp via the native <abbr> tooltip.
+	expect(updated.tagName).toBe('ABBR');
+	const title = updated.getAttribute('title') ?? '';
+	expect(title).not.toBe('');
+	expect(title).toContain(new Date(twoDaysAgo).getFullYear().toString());
 });


### PR DESCRIPTION
## Summary

Each asset card in the project Assets library now shows **when the asset was last updated** as a suffix to the byte size — e.g. `7.8 KB · 2 days ago`.

- The relative time ("2 days ago" / "yesterday" / "now") is rendered inside an `<abbr>` element. Its native `title` tooltip surfaces the **exact local datetime** on hover, and the dotted-underline `abbr` affordance signals that the timestamp is available.
- No schema change is needed: `assets.created_at` is bumped to `now()` on every overwrite (see `upsertProjectAsset`), so it already reads as the last time the asset changed. The listing API (`GET /api/projects/:projectId/assets`) already returns `created_at`.

## Changes

- `packages/web/src/routes/projects/$projectId/assets.tsx` — add `relativeUpdated()` (via `Intl.RelativeTimeFormat`, matching the existing pattern in `markdown-prose.tsx`) and `fullTimestamp()` helpers; append the `<abbr>`-wrapped relative time after the size on the card metadata line.

## Testing

- `packages/web/test/project-assets-states.test.tsx` — new component test asserting the card renders `7.8 KB · 2 days ago`, that the relative label is an `<abbr>`, and that its `title` carries the exact timestamp. Extended the local `asset()` fake to accept a `created_at` override.
- Full file suite passes: `bunx vitest run test/project-assets-states.test.tsx` (8/8). Typecheck and Biome are clean (the one Biome warning is pre-existing and unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G9zRfmQGPPLdqsDa3799FH

---
_Generated by [Claude Code](https://claude.ai/code/session_01G9zRfmQGPPLdqsDa3799FH)_