### PR TITLE
feat(avatars): custom avatars for agents and the admin user

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -434,6 +434,16 @@ served from a public HMAC-signed read route (`GET /api/projects/:projectId/icon`
 query param is the credential since an `<img>` carries no bearer token). The serialized
 project carries a freshly-signed `icon_url` (null when unset); the client normalizes any
 picked image to a square PNG ≤512×512 before upload (`PUT`/`DELETE` on the same path).
+`agent_icons` (1:1 with `member_agents`) and `user_icons` (1:1 with `users`, today just the
+admin) reuse the same mechanism for agent avatars and the admin's own avatar — a dedicated
+`BYTEA` table, a freshly-signed `icon_url` threaded onto the serialized agent/user row, and
+a public HMAC-signed read route (`GET /api/agents/:agentId/icon`, `GET /api/users/:userId/icon`).
+The signing/verification is generalized in `lib/entity-icon-urls.ts` (a `basePath` +
+per-entity `keyPurpose`), the client control in `components/icon-upload-section.tsx`; agent
+icons are edited on the agent Settings page (project-access-gated, like other agent config)
+and rendered on the roster/org-chart/agent header, user icons on the global Settings → Users
+page (superuser-gated). No MCP tool — icon upload is a human-only UI action (as for
+`project_icons`).
 
 **Governance & misc.** `approvals` (polymorphic board decisions), `audit_log`
 (append-only, project + instance scopes — `project_id` set scopes a row to one project,

--- a/docs/concepts/projects-and-teams.md
+++ b/docs/concepts/projects-and-teams.md
@@ -23,6 +23,15 @@ appears as the project's thumbnail in the rail. Pick any common image (PNG, JPEG
 GIF, or SVG); Hezo crops it to a square and resizes it to 512×512. Use **Replace image**
 to swap it or **Remove** to go back to the initials.
 
+## Agent and admin avatars
+
+Agents and the admin user work the same way. Open an agent's **Settings** and upload an
+image under **Agent avatar** to give it a custom picture — it then shows on the team
+roster, the org chart, and the agent's own page in place of its initials. The admin can set
+a personal avatar from the global **Settings → Users** page. Both accept the same image
+formats and are cropped to a square 512×512, with **Replace image** / **Remove** to change
+or clear them.
+
 ## Archiving a project
 
 When a project is finished or dormant, you can **archive** it to get it out of the way

--- a/packages/server/migrations/033_agent_icons.sql
+++ b/packages/server/migrations/033_agent_icons.sql
@@ -1,0 +1,15 @@
+-- Agent avatars: an optional user-uploaded image that represents an agent (in
+-- place of its initials fallback) on the roster, the agent header, and the org
+-- chart. Stored as bytes in the database, in a dedicated 1:1 table so the hot
+-- agent-roster SELECT (AGENT_BASE_COLUMNS) never pulls the image blob — mirrors
+-- project_icons. Keyed on member_agents.id (the agent's member id).
+
+CREATE TABLE agent_icons (
+    member_id    UUID PRIMARY KEY REFERENCES member_agents(id) ON DELETE CASCADE,
+    content_type TEXT NOT NULL,
+    data         BYTEA NOT NULL,
+    byte_size    INTEGER NOT NULL,
+    width        INTEGER NOT NULL,
+    height       INTEGER NOT NULL,
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/packages/server/migrations/034_user_icons.sql
+++ b/packages/server/migrations/034_user_icons.sql
@@ -1,0 +1,15 @@
+-- User avatars: an optional user-uploaded image for a human user (today just the
+-- single admin), shown on the global Settings → Users page in place of the
+-- initials fallback. Stored as bytes in the database, in a dedicated 1:1 table so
+-- the hot `users` SELECTs never pull the image blob — mirrors project_icons /
+-- agent_icons. Keyed on users.id.
+
+CREATE TABLE user_icons (
+    user_id      UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    content_type TEXT NOT NULL,
+    data         BYTEA NOT NULL,
+    byte_size    INTEGER NOT NULL,
+    width        INTEGER NOT NULL,
+    height       INTEGER NOT NULL,
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/packages/server/src/lib/entity-icon-urls.ts
+++ b/packages/server/src/lib/entity-icon-urls.ts
@@ -1,0 +1,60 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { ATTACHMENT_SIGNED_URL_TTL_SECONDS } from '@hezo/shared';
+import { deriveKey } from '../crypto/encryption';
+import type { MasterKeyManager } from '../crypto/master-key';
+
+// An entity icon (an agent's or the admin user's avatar) is rendered in an
+// `<img>` tag, which cannot carry a bearer token, so it is served from a public
+// endpoint guarded by an HMAC-signed URL — the same pattern as the project icon
+// (`lib/project-icon-urls.ts`), generalized so a new entity is a `basePath` +
+// `keyPurpose` pair rather than a copied file. Each purpose derives a distinct
+// signing key, so a signature for one entity kind can never be replayed on
+// another.
+
+async function getSigningKey(
+	masterKeyManager: MasterKeyManager,
+	keyPurpose: string,
+): Promise<Buffer> {
+	const unlockKeyHex = masterKeyManager.getUnlockKeyHex();
+	if (!unlockKeyHex) throw new Error('Master key not available');
+	return deriveKey(unlockKeyHex, keyPurpose);
+}
+
+/**
+ * Sign a time-limited URL for an entity's icon. `version` (the icon's
+ * `updated_at` epoch) is appended as an unsigned `v` query param so the `<img>`
+ * cache busts when the icon changes, while the signature only covers the entity
+ * id + expiry. `basePath` is the collection path (e.g. `/api/agents`),
+ * `keyPurpose` the per-entity key label (e.g. `agent-icon-url`).
+ */
+export async function signEntityIconUrl(
+	basePath: string,
+	keyPurpose: string,
+	id: string,
+	masterKeyManager: MasterKeyManager,
+	version: number,
+	ttlSeconds: number = ATTACHMENT_SIGNED_URL_TTL_SECONDS,
+): Promise<string> {
+	const exp = Math.floor(Date.now() / 1000) + ttlSeconds;
+	const key = await getSigningKey(masterKeyManager, keyPurpose);
+	const sig = createHmac('sha256', key).update(`${id}|${exp}`).digest('base64url');
+	return `${basePath}/${id}/icon?exp=${exp}&sig=${sig}&v=${version}`;
+}
+
+export async function verifyEntityIconUrl(
+	keyPurpose: string,
+	id: string,
+	exp: number,
+	sig: string,
+	masterKeyManager: MasterKeyManager,
+): Promise<boolean> {
+	if (!Number.isFinite(exp) || Math.floor(Date.now() / 1000) > exp) return false;
+	const key = await getSigningKey(masterKeyManager, keyPurpose);
+	const expected = createHmac('sha256', key).update(`${id}|${exp}`).digest('base64url');
+	if (sig.length !== expected.length) return false;
+	try {
+		return timingSafeEqual(Buffer.from(sig), Buffer.from(expected));
+	} catch {
+		return false;
+	}
+}

--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -14,20 +14,26 @@ import {
 	hasFixedReportsTo,
 	INSTANCE_AGENT_SLUGS,
 	isAgentEffort,
+	isAllowedProjectIconStoredMime,
 	isBudgetPauseStatus,
 	isReservedAgentSlug,
 	MemberType,
+	PROJECT_ICON_MAX_BYTES,
+	PROJECT_ICON_MAX_DIMENSION,
 	requiredSystemPromptVarsError,
 	TaskPriority,
 	TaskStatus,
 	WakeupSource,
 	wsRoom,
 } from '@hezo/shared';
-import { Hono } from 'hono';
+import { type Context, Hono } from 'hono';
+import { bodyLimit } from 'hono/body-limit';
 import type { Db } from '../db/database';
 import { trackBackground } from '../lib/background';
 import { broadcastChange, broadcastCommentFamilyChange } from '../lib/broadcast';
 import { budgetWindowsError } from '../lib/budget-validation';
+import { signEntityIconUrl, verifyEntityIconUrl } from '../lib/entity-icon-urls';
+import { readImageDimensions } from '../lib/image-dimensions';
 import {
 	actorTypeFromAuth,
 	resolveActor,
@@ -89,8 +95,50 @@ const AGENT_BASE_COLUMNS = `m.id, m.team_id, m.display_name, m.created_at,
 	ma.touches_code,
 	ma.runtime_status, ma.admin_status, ma.last_heartbeat_at, ma.reports_to,
 	ma.mcp_servers, ma.model_override_provider, ma.model_override_model, ma.updated_at,
+	(SELECT ai.updated_at FROM agent_icons ai WHERE ai.member_id = m.id) AS icon_updated_at,
 	${NEXT_HEARTBEAT_AT_SQL} AS next_heartbeat_at,
 	${HAS_ACTIONABLE_WORK_SQL} AS has_actionable_work`;
+
+// --- Agent avatar (icon) ------------------------------------------------------
+// An optional user-uploaded image shown for an agent in place of its initials.
+// Stored as bytes in the DB (agent_icons, 1:1 with member_agents). Served via an
+// HMAC-signed public URL (rendered in an <img>, which can't carry a bearer
+// token) — mirrors the project-icon feature, generalized in `entity-icon-urls`.
+const AGENT_ICON_KEY_PURPOSE = 'agent-icon-url';
+const AGENT_ICON_BASE_PATH = '/api/agents';
+
+/** Sign an agent's icon URL from its `icon_updated_at` version, or null when unset. */
+async function signAgentIcon(
+	c: Context<Env>,
+	id: string,
+	iconUpdatedAt: unknown,
+): Promise<string | null> {
+	if (typeof iconUpdatedAt === 'string' || iconUpdatedAt instanceof Date) {
+		const version = Math.floor(new Date(iconUpdatedAt).getTime() / 1000);
+		return signEntityIconUrl(
+			AGENT_ICON_BASE_PATH,
+			AGENT_ICON_KEY_PURPOSE,
+			id,
+			c.get('masterKeyManager'),
+			version,
+		);
+	}
+	return null;
+}
+
+/**
+ * Attach a freshly-signed `icon_url` to a serialized agent row (from the
+ * correlated `icon_updated_at` subselect in AGENT_BASE_COLUMNS). The icon bytes
+ * themselves are never selected onto the row.
+ */
+async function withAgentIconUrl(
+	c: Context<Env>,
+	row: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+	row.icon_url = await signAgentIcon(c, row.id as string, row.icon_updated_at);
+	if (!row.icon_url) row.icon_updated_at = null;
+	return row;
+}
 
 const HEARTBEAT_RUN_COLUMNS = `hr.id, hr.member_id, hr.team_id, hr.wakeup_id, hr.task_id, hr.kind,
 	hr.status, hr.queued_reason, hr.started_at, hr.finished_at, hr.exit_code, hr.error,
@@ -222,7 +270,10 @@ agentsRoutes.get('/projects/:projectId/agents', async (c) => {
 	query += ' ORDER BY is_instance ASC, ma.title ASC';
 
 	const result = await db.query(query, params);
-	return ok(c, result.rows);
+	const rows = await Promise.all(
+		result.rows.map((r) => withAgentIconUrl(c, r as Record<string, unknown>)),
+	);
+	return ok(c, rows);
 });
 
 agentsRoutes.post('/projects/:projectId/agents', async (c) => {
@@ -568,7 +619,103 @@ agentsRoutes.get('/projects/:projectId/agents/:agentId', async (c) => {
 		[agentId, teamId, ...ts2.values],
 	);
 
-	return ok(c, result.rows[0]);
+	const row = result.rows[0];
+	if (!row) return err(c, 'NOT_FOUND', 'Agent not found', 404);
+	return ok(c, await withAgentIconUrl(c, row as Record<string, unknown>));
+});
+
+// Upload (or replace) an agent's avatar. The client normalizes any picked image
+// to a square PNG ≤ PROJECT_ICON_MAX_DIMENSION before upload; the server
+// re-validates content-type, byte size, and pixel dimensions defensively.
+agentsRoutes.put(
+	'/projects/:projectId/agents/:agentId/icon',
+	bodyLimit({
+		maxSize: PROJECT_ICON_MAX_BYTES,
+		onError: (c) => err(c, 'TOO_LARGE', 'Image exceeds the size limit', 400),
+	}),
+	async (c) => {
+		const teamId = c.get('teamId') as string;
+		const db = c.get('db');
+		const agentId = await resolveAgentId(db, teamId, c.req.param('agentId'));
+		if (!agentId) return err(c, 'NOT_FOUND', 'Agent not found', 404);
+
+		let form: Awaited<ReturnType<typeof c.req.parseBody>>;
+		try {
+			form = await c.req.parseBody({ all: false });
+		} catch (e) {
+			log.error('agent icon parseBody failed:', e);
+			return err(c, 'INVALID_REQUEST', 'Malformed upload', 400);
+		}
+		const file = form.file;
+		if (!(file instanceof Blob)) {
+			return err(c, 'INVALID_REQUEST', 'Missing file field', 400);
+		}
+
+		const contentType = file.type || 'application/octet-stream';
+		if (!isAllowedProjectIconStoredMime(contentType)) {
+			return err(c, 'INVALID_ATTACHMENT', `Unsupported content type: ${contentType}`, 400);
+		}
+		if (file.size > PROJECT_ICON_MAX_BYTES) {
+			return err(c, 'TOO_LARGE', 'Image exceeds the size limit', 400);
+		}
+
+		const buf = Buffer.from(await file.arrayBuffer());
+		const dims = readImageDimensions(buf);
+		if (!dims) {
+			return err(c, 'INVALID_ATTACHMENT', 'Could not read image dimensions', 400);
+		}
+		if (dims.width > PROJECT_ICON_MAX_DIMENSION || dims.height > PROJECT_ICON_MAX_DIMENSION) {
+			return err(
+				c,
+				'INVALID_ATTACHMENT',
+				`Image exceeds ${PROJECT_ICON_MAX_DIMENSION}×${PROJECT_ICON_MAX_DIMENSION} pixels`,
+				400,
+			);
+		}
+
+		const updated = await db.query<{ updated_at: string }>(
+			`INSERT INTO agent_icons (member_id, content_type, data, byte_size, width, height, updated_at)
+			 VALUES ($1, $2, $3, $4, $5, $6, now())
+			 ON CONFLICT (member_id) DO UPDATE SET
+			   content_type = EXCLUDED.content_type,
+			   data         = EXCLUDED.data,
+			   byte_size    = EXCLUDED.byte_size,
+			   width        = EXCLUDED.width,
+			   height       = EXCLUDED.height,
+			   updated_at   = now()
+			 RETURNING updated_at`,
+			[agentId, contentType, buf, buf.byteLength, dims.width, dims.height],
+		);
+
+		broadcastChange(c, wsRoom.team(teamId), 'member_agents', 'UPDATE', {
+			id: agentId,
+			team_id: teamId,
+		});
+
+		const version = Math.floor(new Date(updated.rows[0].updated_at).getTime() / 1000);
+		const iconUrl = await signEntityIconUrl(
+			AGENT_ICON_BASE_PATH,
+			AGENT_ICON_KEY_PURPOSE,
+			agentId,
+			c.get('masterKeyManager'),
+			version,
+		);
+		return ok(c, { icon_url: iconUrl, icon_updated_at: updated.rows[0].updated_at });
+	},
+);
+
+agentsRoutes.delete('/projects/:projectId/agents/:agentId/icon', async (c) => {
+	const teamId = c.get('teamId') as string;
+	const db = c.get('db');
+	const agentId = await resolveAgentId(db, teamId, c.req.param('agentId'));
+	if (!agentId) return err(c, 'NOT_FOUND', 'Agent not found', 404);
+
+	await db.query('DELETE FROM agent_icons WHERE member_id = $1', [agentId]);
+	broadcastChange(c, wsRoom.team(teamId), 'member_agents', 'UPDATE', {
+		id: agentId,
+		team_id: teamId,
+	});
+	return ok(c, { icon_url: null, icon_updated_at: null });
 });
 
 // The agent's long-term chat memory (the compacted history shown on the Chat
@@ -1081,7 +1228,8 @@ agentsRoutes.get('/projects/:projectId/org-chart', async (c) => {
 	const teamId = c.get('teamId') as string;
 	const db = c.get('db');
 
-	const ORG_COLUMNS = `m.id, ma.title, ma.slug, ma.role_description, ma.runtime_status, ma.admin_status, ma.reports_to`;
+	const ORG_COLUMNS = `m.id, ma.title, ma.slug, ma.role_description, ma.runtime_status, ma.admin_status, ma.reports_to,
+     (SELECT ai.updated_at FROM agent_icons ai WHERE ai.member_id = m.id) AS icon_updated_at`;
 	const result = await db.query(
 		`SELECT ${ORG_COLUMNS}
      FROM members m
@@ -1098,8 +1246,12 @@ agentsRoutes.get('/projects/:projectId/org-chart', async (c) => {
 		runtime_status: string;
 		admin_status: string;
 		reports_to: string | null;
+		icon_updated_at: string | null;
+		icon_url?: string | null;
 	};
 	const agents = result.rows as OrgAgentRow[];
+	// Sign each node's avatar URL (null when the agent has no icon).
+	for (const a of agents) a.icon_url = await signAgentIcon(c, a.id, a.icon_updated_at);
 	type AgentNode = OrgAgentRow & { children: AgentNode[] };
 	const byId = new Map<string, AgentNode>(
 		agents.map((a) => [a.id, { ...a, children: [] as AgentNode[] }]),
@@ -1119,6 +1271,7 @@ agentsRoutes.get('/projects/:projectId/org-chart', async (c) => {
 	);
 	const ceoRow = ceoResult.rows[0] as OrgAgentRow | undefined;
 	if (ceoRow && !byId.has(ceoRow.id)) {
+		ceoRow.icon_url = await signAgentIcon(c, ceoRow.id, ceoRow.icon_updated_at);
 		byId.set(ceoRow.id, { ...ceoRow, children: [] });
 	}
 
@@ -1233,3 +1386,51 @@ agentsRoutes.post(
 		return ok(c, { ...row, terminated: result.terminated });
 	},
 );
+
+// Public signed-URL read endpoint for an agent avatar. Rendered in an `<img>`
+// tag, which can't carry a bearer token, so the HMAC `sig` query param is the
+// credential. Must be mounted before the `/api/*` auth middleware.
+export const publicAgentsRoutes = new Hono<Env>();
+
+publicAgentsRoutes.get('/api/agents/:agentId/icon', async (c) => {
+	const agentId = c.req.param('agentId');
+	const expRaw = c.req.query('exp');
+	const sig = c.req.query('sig');
+	if (!expRaw || !sig) {
+		return err(c, 'UNAUTHORIZED', 'Missing signature', 401);
+	}
+	const exp = Number.parseInt(expRaw, 10);
+	const masterKeyManager = c.get('masterKeyManager');
+	const valid = await verifyEntityIconUrl(
+		AGENT_ICON_KEY_PURPOSE,
+		agentId,
+		exp,
+		sig,
+		masterKeyManager,
+	);
+	if (!valid) {
+		return err(c, 'UNAUTHORIZED', 'Invalid or expired signature', 401);
+	}
+
+	const row = await c.get('db').query<{
+		content_type: string;
+		data: Uint8Array;
+		updated_at: string;
+	}>('SELECT content_type, data, updated_at FROM agent_icons WHERE member_id = $1', [agentId]);
+	if (row.rows.length === 0) {
+		return err(c, 'NOT_FOUND', 'Icon not found', 404);
+	}
+	const { content_type, data, updated_at } = row.rows[0];
+	const src = data instanceof Uint8Array ? data : new Uint8Array(data);
+	// Copy into a fresh ArrayBuffer so the body type is Uint8Array<ArrayBuffer>
+	// (PGlite hands back a Uint8Array<ArrayBufferLike>).
+	const ab = new ArrayBuffer(src.byteLength);
+	new Uint8Array(ab).set(src);
+
+	return c.body(new Uint8Array(ab), 200, {
+		'Content-Type': content_type,
+		'Content-Length': String(src.byteLength),
+		'Cache-Control': 'private, max-age=3600',
+		ETag: `"${new Date(updated_at).getTime()}"`,
+	});
+});

--- a/packages/server/src/routes/users.ts
+++ b/packages/server/src/routes/users.ts
@@ -1,0 +1,208 @@
+import {
+	isAllowedProjectIconStoredMime,
+	PROJECT_ICON_MAX_BYTES,
+	PROJECT_ICON_MAX_DIMENSION,
+} from '@hezo/shared';
+import { type Context, Hono } from 'hono';
+import { bodyLimit } from 'hono/body-limit';
+import { signEntityIconUrl, verifyEntityIconUrl } from '../lib/entity-icon-urls';
+import { readImageDimensions } from '../lib/image-dimensions';
+import { err, ok } from '../lib/response';
+import type { Env } from '../lib/types';
+import { logger } from '../logger';
+import { requireSuperuser } from '../middleware/auth';
+
+const log = logger.child('routes');
+
+export const usersRoutes = new Hono<Env>();
+
+// --- User avatar (icon) -------------------------------------------------------
+// The single admin user (and any future human user) can carry a custom avatar,
+// managed from the global Settings → Users page. Stored as bytes in the DB
+// (user_icons, 1:1 with users) and served via an HMAC-signed public URL —
+// mirrors the project/agent icon, generalized in `entity-icon-urls`.
+const USER_ICON_KEY_PURPOSE = 'user-icon-url';
+const USER_ICON_BASE_PATH = '/api/users';
+
+/** Sign a user's icon URL from its `icon_updated_at` version, or null when unset. */
+async function signUserIcon(
+	c: Context<Env>,
+	id: string,
+	iconUpdatedAt: unknown,
+): Promise<string | null> {
+	if (typeof iconUpdatedAt === 'string' || iconUpdatedAt instanceof Date) {
+		const version = Math.floor(new Date(iconUpdatedAt).getTime() / 1000);
+		return signEntityIconUrl(
+			USER_ICON_BASE_PATH,
+			USER_ICON_KEY_PURPOSE,
+			id,
+			c.get('masterKeyManager'),
+			version,
+		);
+	}
+	return null;
+}
+
+// List human users (today just the admin) with a freshly-signed avatar URL.
+// Superuser-only — this is a global instance-management surface.
+usersRoutes.get('/users', async (c) => {
+	const denied = requireSuperuser(c);
+	if (denied) return denied;
+	const db = c.get('db');
+	const result = await db.query<{
+		id: string;
+		display_name: string;
+		is_superuser: boolean;
+		icon_updated_at: string | null;
+	}>(
+		`SELECT u.id, u.display_name, u.is_superuser,
+		   (SELECT ui.updated_at FROM user_icons ui WHERE ui.user_id = u.id) AS icon_updated_at
+		 FROM users u
+		 ORDER BY u.is_superuser DESC, u.display_name ASC`,
+	);
+	const rows = await Promise.all(
+		result.rows.map(async (r) => ({
+			id: r.id,
+			display_name: r.display_name,
+			is_superuser: r.is_superuser,
+			icon_url: await signUserIcon(c, r.id, r.icon_updated_at),
+			icon_updated_at: r.icon_updated_at,
+		})),
+	);
+	return ok(c, rows);
+});
+
+// Upload (or replace) a user's avatar. The client normalizes any picked image to
+// a square PNG ≤ PROJECT_ICON_MAX_DIMENSION before upload; the server
+// re-validates content-type, byte size, and pixel dimensions defensively.
+usersRoutes.put(
+	'/users/:userId/icon',
+	bodyLimit({
+		maxSize: PROJECT_ICON_MAX_BYTES,
+		onError: (c) => err(c, 'TOO_LARGE', 'Image exceeds the size limit', 400),
+	}),
+	async (c) => {
+		const denied = requireSuperuser(c);
+		if (denied) return denied;
+		const db = c.get('db');
+		const userId = c.req.param('userId');
+
+		const exists = await db.query('SELECT 1 FROM users WHERE id = $1', [userId]);
+		if (exists.rows.length === 0) return err(c, 'NOT_FOUND', 'User not found', 404);
+
+		let form: Awaited<ReturnType<typeof c.req.parseBody>>;
+		try {
+			form = await c.req.parseBody({ all: false });
+		} catch (e) {
+			log.error('user icon parseBody failed:', e);
+			return err(c, 'INVALID_REQUEST', 'Malformed upload', 400);
+		}
+		const file = form.file;
+		if (!(file instanceof Blob)) {
+			return err(c, 'INVALID_REQUEST', 'Missing file field', 400);
+		}
+
+		const contentType = file.type || 'application/octet-stream';
+		if (!isAllowedProjectIconStoredMime(contentType)) {
+			return err(c, 'INVALID_ATTACHMENT', `Unsupported content type: ${contentType}`, 400);
+		}
+		if (file.size > PROJECT_ICON_MAX_BYTES) {
+			return err(c, 'TOO_LARGE', 'Image exceeds the size limit', 400);
+		}
+
+		const buf = Buffer.from(await file.arrayBuffer());
+		const dims = readImageDimensions(buf);
+		if (!dims) {
+			return err(c, 'INVALID_ATTACHMENT', 'Could not read image dimensions', 400);
+		}
+		if (dims.width > PROJECT_ICON_MAX_DIMENSION || dims.height > PROJECT_ICON_MAX_DIMENSION) {
+			return err(
+				c,
+				'INVALID_ATTACHMENT',
+				`Image exceeds ${PROJECT_ICON_MAX_DIMENSION}×${PROJECT_ICON_MAX_DIMENSION} pixels`,
+				400,
+			);
+		}
+
+		const updated = await db.query<{ updated_at: string }>(
+			`INSERT INTO user_icons (user_id, content_type, data, byte_size, width, height, updated_at)
+			 VALUES ($1, $2, $3, $4, $5, $6, now())
+			 ON CONFLICT (user_id) DO UPDATE SET
+			   content_type = EXCLUDED.content_type,
+			   data         = EXCLUDED.data,
+			   byte_size    = EXCLUDED.byte_size,
+			   width        = EXCLUDED.width,
+			   height       = EXCLUDED.height,
+			   updated_at   = now()
+			 RETURNING updated_at`,
+			[userId, contentType, buf, buf.byteLength, dims.width, dims.height],
+		);
+
+		const version = Math.floor(new Date(updated.rows[0].updated_at).getTime() / 1000);
+		const iconUrl = await signEntityIconUrl(
+			USER_ICON_BASE_PATH,
+			USER_ICON_KEY_PURPOSE,
+			userId,
+			c.get('masterKeyManager'),
+			version,
+		);
+		return ok(c, { icon_url: iconUrl, icon_updated_at: updated.rows[0].updated_at });
+	},
+);
+
+usersRoutes.delete('/users/:userId/icon', async (c) => {
+	const denied = requireSuperuser(c);
+	if (denied) return denied;
+	const db = c.get('db');
+	const userId = c.req.param('userId');
+	await db.query('DELETE FROM user_icons WHERE user_id = $1', [userId]);
+	return ok(c, { icon_url: null, icon_updated_at: null });
+});
+
+// Public signed-URL read endpoint for a user avatar. Rendered in an `<img>` tag,
+// which can't carry a bearer token, so the HMAC `sig` query param is the
+// credential. Must be mounted before the `/api/*` auth middleware.
+export const publicUsersRoutes = new Hono<Env>();
+
+publicUsersRoutes.get('/api/users/:userId/icon', async (c) => {
+	const userId = c.req.param('userId');
+	const expRaw = c.req.query('exp');
+	const sig = c.req.query('sig');
+	if (!expRaw || !sig) {
+		return err(c, 'UNAUTHORIZED', 'Missing signature', 401);
+	}
+	const exp = Number.parseInt(expRaw, 10);
+	const masterKeyManager = c.get('masterKeyManager');
+	const valid = await verifyEntityIconUrl(
+		USER_ICON_KEY_PURPOSE,
+		userId,
+		exp,
+		sig,
+		masterKeyManager,
+	);
+	if (!valid) {
+		return err(c, 'UNAUTHORIZED', 'Invalid or expired signature', 401);
+	}
+
+	const row = await c.get('db').query<{
+		content_type: string;
+		data: Uint8Array;
+		updated_at: string;
+	}>('SELECT content_type, data, updated_at FROM user_icons WHERE user_id = $1', [userId]);
+	if (row.rows.length === 0) {
+		return err(c, 'NOT_FOUND', 'Icon not found', 404);
+	}
+	const { content_type, data, updated_at } = row.rows[0];
+	const src = data instanceof Uint8Array ? data : new Uint8Array(data);
+	// Copy into a fresh ArrayBuffer so the body type is Uint8Array<ArrayBuffer>
+	// (PGlite hands back a Uint8Array<ArrayBufferLike>).
+	const ab = new ArrayBuffer(src.byteLength);
+	new Uint8Array(ab).set(src);
+
+	return c.body(new Uint8Array(ab), 200, {
+		'Content-Type': content_type,
+		'Content-Length': String(src.byteLength),
+		'Cache-Control': 'private, max-age=3600',
+		ETag: `"${new Date(updated_at).getTime()}"`,
+	});
+});

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -29,7 +29,7 @@ import { getToolDefs, handleMcpAssetUpload, handleMcpRequest, initMcpServer } fr
 import { generateSkillFile } from './mcp/skill-file';
 import { authMiddleware, requireProjectAccessMiddleware } from './middleware/auth';
 import { agentTypesRoutes } from './routes/agent-types';
-import { agentsRoutes } from './routes/agents';
+import { agentsRoutes, publicAgentsRoutes } from './routes/agents';
 import { aiProvidersRoutes } from './routes/ai-providers';
 import { apiKeysRoutes } from './routes/api-keys';
 import { approvalsRoutes } from './routes/approvals';
@@ -70,6 +70,7 @@ import { teamTemplatesRoutes } from './routes/team-templates';
 import { teamsRoutes } from './routes/teams';
 import { uiStateRoutes } from './routes/ui-state';
 import { buildUpdatesRoutes } from './routes/updates';
+import { publicUsersRoutes, usersRoutes } from './routes/users';
 import { AuthChallengeStore } from './services/auth-challenges';
 import {
 	buildChatChannelRegistry,
@@ -604,6 +605,14 @@ export function buildApp(
 	// /api/* auth + project-access middleware so it bypasses the bearer check.
 	app.route('/', publicProjectsRoutes);
 
+	// Public signed-URL agent-avatar read endpoint — same rationale as the
+	// project icon. Mounted before the /api/* auth middleware.
+	app.route('/', publicAgentsRoutes);
+
+	// Public signed-URL user-avatar read endpoint — same rationale as the
+	// project icon. Mounted before the /api/* auth middleware.
+	app.route('/', publicUsersRoutes);
+
 	// Public inbound webhook surface for external chat channels. Mounted before the
 	// /api/* bearer-auth middleware — inbound platform requests carry no Hezo token
 	// and are authenticated by a per-channel shared secret in the URL/header.
@@ -625,6 +634,7 @@ export function buildApp(
 	app.route('/api', marketplaceRoutes);
 	app.route('/api', teamsRoutes);
 	app.route('/api', meRoutes);
+	app.route('/api', usersRoutes);
 	app.route('/api', agentsRoutes);
 	app.route('/api', projectsRoutes);
 	app.route('/api', tasksRoutes);

--- a/packages/server/test/agent-icon.test.ts
+++ b/packages/server/test/agent-icon.test.ts
@@ -1,0 +1,145 @@
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Db } from '../src/db/database';
+import type { Env } from '../src/lib/types';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp } from './helpers/app';
+
+let app: Hono<Env>;
+let db: Db;
+let token: string;
+let projectSlug: string;
+let agentSlug: string;
+
+const DESCRIPTION = 'A backend API that serves authenticated requests for the main app.';
+
+/**
+ * Build a minimal but structurally-valid PNG: the 8-byte signature plus an IHDR
+ * chunk carrying the given dimensions. `readImageDimensions` only parses the
+ * header, so the rest of the file body is omitted.
+ */
+function pngWithDimensions(width: number, height: number): Buffer {
+	const sig = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+	const ihdr = Buffer.alloc(25);
+	ihdr.writeUInt32BE(13, 0); // chunk length
+	ihdr.write('IHDR', 4, 'ascii');
+	ihdr.writeUInt32BE(width, 8);
+	ihdr.writeUInt32BE(height, 12);
+	return Buffer.concat([sig, ihdr]);
+}
+
+function iconForm(bytes: Buffer, type = 'image/png'): FormData {
+	const fd = new FormData();
+	fd.set('file', new Blob([bytes], { type }), 'icon.png');
+	return fd;
+}
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+
+	const res = await app.request('/api/projects', {
+		method: 'POST',
+		headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ name: 'Avatar Project', description: DESCRIPTION }),
+	});
+	projectSlug = (await res.json()).data.slug;
+
+	const agentsRes = await app.request(`/api/projects/${projectSlug}/agents`, {
+		headers: authHeader(token),
+	});
+	const agents: { slug: string; is_instance?: boolean }[] = (await agentsRes.json()).data;
+	// The team's own Captain (not an HQ virtual member).
+	agentSlug = agents.find((a) => !a.is_instance)?.slug ?? agents[0].slug;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+describe('agent icon upload/serve', () => {
+	it('uploads an avatar and returns a signed url', async () => {
+		const res = await app.request(`/api/projects/${projectSlug}/agents/${agentSlug}/icon`, {
+			method: 'PUT',
+			headers: authHeader(token),
+			body: iconForm(pngWithDimensions(512, 512)),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data.icon_url).toMatch(/\/api\/agents\/[\w-]+\/icon\?exp=\d+&sig=[^&]+&v=\d+/);
+		expect(body.data.icon_updated_at).toBeTruthy();
+	});
+
+	it('carries the signed icon_url on the roster list and single agent', async () => {
+		const list = await app.request(`/api/projects/${projectSlug}/agents`, {
+			headers: authHeader(token),
+		});
+		const agent = (await list.json()).data.find((a: { slug: string }) => a.slug === agentSlug);
+		expect(agent.icon_url).toBeTruthy();
+
+		const single = await app.request(`/api/projects/${projectSlug}/agents/${agentSlug}`, {
+			headers: authHeader(token),
+		});
+		expect((await single.json()).data.icon_url).toBeTruthy();
+	});
+
+	it('serves the stored bytes from the signed url', async () => {
+		const list = await app.request(`/api/projects/${projectSlug}/agents`, {
+			headers: authHeader(token),
+		});
+		const agent = (await list.json()).data.find((a: { slug: string }) => a.slug === agentSlug);
+
+		const res = await app.request(agent.icon_url);
+		expect(res.status).toBe(200);
+		expect(res.headers.get('Content-Type')).toBe('image/png');
+		const buf = Buffer.from(await res.arrayBuffer());
+		expect(buf.equals(pngWithDimensions(512, 512))).toBe(true);
+	});
+
+	it('rejects an unsigned request to the serve endpoint', async () => {
+		// Resolve the agent's member UUID for the public path.
+		const single = await app.request(`/api/projects/${projectSlug}/agents/${agentSlug}`, {
+			headers: authHeader(token),
+		});
+		const agentId = (await single.json()).data.id;
+		const res = await app.request(`/api/agents/${agentId}/icon`);
+		expect(res.status).toBe(401);
+	});
+
+	it('rejects an image exceeding 512px', async () => {
+		const res = await app.request(`/api/projects/${projectSlug}/agents/${agentSlug}/icon`, {
+			method: 'PUT',
+			headers: authHeader(token),
+			body: iconForm(pngWithDimensions(513, 512)),
+		});
+		expect(res.status).toBe(400);
+	});
+
+	it('rejects an unsupported content type', async () => {
+		const res = await app.request(`/api/projects/${projectSlug}/agents/${agentSlug}/icon`, {
+			method: 'PUT',
+			headers: authHeader(token),
+			body: iconForm(Buffer.from('<svg/>'), 'image/svg+xml'),
+		});
+		expect(res.status).toBe(400);
+	});
+
+	it('removes the avatar', async () => {
+		const del = await app.request(`/api/projects/${projectSlug}/agents/${agentSlug}/icon`, {
+			method: 'DELETE',
+			headers: authHeader(token),
+		});
+		expect(del.status).toBe(200);
+
+		const list = await app.request(`/api/projects/${projectSlug}/agents`, {
+			headers: authHeader(token),
+		});
+		const agent = (await list.json()).data.find((a: { slug: string }) => a.slug === agentSlug);
+		expect(agent.icon_url).toBeNull();
+
+		const rows = await db.query('SELECT 1 FROM agent_icons WHERE member_id IS NOT NULL');
+		expect(rows.rows.length).toBe(0);
+	});
+});

--- a/packages/server/test/migrate-033-agent-icons.test.ts
+++ b/packages/server/test/migrate-033-agent-icons.test.ts
@@ -1,0 +1,67 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createDataPreservationHarness, type DataPreservationHarness } from './helpers/migrate';
+
+const TARGET = '033_agent_icons.sql';
+
+describe('033_agent_icons migration', () => {
+	let h: DataPreservationHarness;
+	let memberId: string;
+
+	beforeAll(async () => {
+		h = await createDataPreservationHarness();
+		await h.applyUpToExclusive(TARGET);
+
+		const team = await h.db.query<{ id: string }>(
+			`INSERT INTO teams (name, slug) VALUES ('Acme', 'acme') RETURNING id`,
+		);
+		const member = await h.db.query<{ id: string }>(
+			`INSERT INTO members (team_id, member_type, display_name)
+			 VALUES ($1, 'agent', 'Engineer') RETURNING id`,
+			[team.rows[0].id],
+		);
+		memberId = member.rows[0].id;
+		await h.db.query(
+			`INSERT INTO member_agents (id, title, slug) VALUES ($1, 'Engineer', 'engineer')`,
+			[memberId],
+		);
+
+		await h.applyTarget(TARGET);
+	});
+	afterAll(() => h.close());
+
+	it('creates the agent_icons table with the icon columns', async () => {
+		const cols = await h.db.query<{ column_name: string }>(
+			`SELECT column_name FROM information_schema.columns WHERE table_name = 'agent_icons'`,
+		);
+		const names = cols.rows.map((r) => r.column_name).sort();
+		expect(names).toEqual(
+			['byte_size', 'content_type', 'data', 'height', 'member_id', 'updated_at', 'width'].sort(),
+		);
+	});
+
+	it('preserves pre-existing agent rows', async () => {
+		const kept = await h.db.query(`SELECT 1 FROM member_agents WHERE id = $1`, [memberId]);
+		expect(kept.rows.length).toBe(1);
+	});
+
+	it('stores and reads back icon bytes 1:1 with an agent', async () => {
+		const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x01, 0x02, 0x03]);
+		await h.db.query(
+			`INSERT INTO agent_icons (member_id, content_type, data, byte_size, width, height)
+			 VALUES ($1, 'image/png', $2, $3, 512, 512)`,
+			[memberId, bytes, bytes.byteLength],
+		);
+		const r = await h.db.query<{ data: Uint8Array; content_type: string }>(
+			`SELECT data, content_type FROM agent_icons WHERE member_id = $1`,
+			[memberId],
+		);
+		expect(r.rows[0].content_type).toBe('image/png');
+		expect(Buffer.from(r.rows[0].data).equals(bytes)).toBe(true);
+	});
+
+	it('cascades icon deletion when the agent is removed', async () => {
+		await h.db.query(`DELETE FROM members WHERE id = $1`, [memberId]);
+		const r = await h.db.query(`SELECT 1 FROM agent_icons WHERE member_id = $1`, [memberId]);
+		expect(r.rows.length).toBe(0);
+	});
+});

--- a/packages/server/test/migrate-034-user-icons.test.ts
+++ b/packages/server/test/migrate-034-user-icons.test.ts
@@ -1,0 +1,58 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createDataPreservationHarness, type DataPreservationHarness } from './helpers/migrate';
+
+const TARGET = '034_user_icons.sql';
+
+describe('034_user_icons migration', () => {
+	let h: DataPreservationHarness;
+	let userId: string;
+
+	beforeAll(async () => {
+		h = await createDataPreservationHarness();
+		await h.applyUpToExclusive(TARGET);
+
+		const user = await h.db.query<{ id: string }>(
+			`INSERT INTO users (display_name, is_superuser) VALUES ('Admin', true) RETURNING id`,
+		);
+		userId = user.rows[0].id;
+
+		await h.applyTarget(TARGET);
+	});
+	afterAll(() => h.close());
+
+	it('creates the user_icons table with the icon columns', async () => {
+		const cols = await h.db.query<{ column_name: string }>(
+			`SELECT column_name FROM information_schema.columns WHERE table_name = 'user_icons'`,
+		);
+		const names = cols.rows.map((r) => r.column_name).sort();
+		expect(names).toEqual(
+			['byte_size', 'content_type', 'data', 'height', 'updated_at', 'user_id', 'width'].sort(),
+		);
+	});
+
+	it('preserves pre-existing user rows', async () => {
+		const kept = await h.db.query(`SELECT 1 FROM users WHERE id = $1`, [userId]);
+		expect(kept.rows.length).toBe(1);
+	});
+
+	it('stores and reads back icon bytes 1:1 with a user', async () => {
+		const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x01, 0x02, 0x03]);
+		await h.db.query(
+			`INSERT INTO user_icons (user_id, content_type, data, byte_size, width, height)
+			 VALUES ($1, 'image/png', $2, $3, 512, 512)`,
+			[userId, bytes, bytes.byteLength],
+		);
+		const r = await h.db.query<{ data: Uint8Array; content_type: string }>(
+			`SELECT data, content_type FROM user_icons WHERE user_id = $1`,
+			[userId],
+		);
+		expect(r.rows[0].content_type).toBe('image/png');
+		expect(Buffer.from(r.rows[0].data).equals(bytes)).toBe(true);
+	});
+
+	it('cascades icon deletion when the user is removed', async () => {
+		await h.db.query(`DELETE FROM users WHERE id = $1`, [userId]);
+		const r = await h.db.query(`SELECT 1 FROM user_icons WHERE user_id = $1`, [userId]);
+		expect(r.rows.length).toBe(0);
+	});
+});

--- a/packages/server/test/user-icon.test.ts
+++ b/packages/server/test/user-icon.test.ts
@@ -1,0 +1,134 @@
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { MasterKeyManager } from '../src/crypto/master-key';
+import type { Db } from '../src/db/database';
+import type { Env } from '../src/lib/types';
+import { signAdminJwt } from '../src/middleware/auth';
+import { safeClose } from './helpers';
+import { authHeader, createTestApp } from './helpers/app';
+
+let app: Hono<Env>;
+let db: Db;
+let token: string;
+let masterKeyManager: MasterKeyManager;
+let adminUserId: string;
+
+function pngWithDimensions(width: number, height: number): Buffer {
+	const sig = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+	const ihdr = Buffer.alloc(25);
+	ihdr.writeUInt32BE(13, 0);
+	ihdr.write('IHDR', 4, 'ascii');
+	ihdr.writeUInt32BE(width, 8);
+	ihdr.writeUInt32BE(height, 12);
+	return Buffer.concat([sig, ihdr]);
+}
+
+function iconForm(bytes: Buffer, type = 'image/png'): FormData {
+	const fd = new FormData();
+	fd.set('file', new Blob([bytes], { type }), 'icon.png');
+	return fd;
+}
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+	masterKeyManager = ctx.masterKeyManager;
+
+	const users = await app.request('/api/users', { headers: authHeader(token) });
+	const list: { id: string; is_superuser: boolean }[] = (await users.json()).data;
+	adminUserId = list.find((u) => u.is_superuser)?.id ?? list[0].id;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+describe('user (admin) icon upload/serve', () => {
+	it('lists the admin user', async () => {
+		const res = await app.request('/api/users', { headers: authHeader(token) });
+		expect(res.status).toBe(200);
+		const list = (await res.json()).data;
+		expect(list.length).toBeGreaterThanOrEqual(1);
+		expect(list.some((u: { is_superuser: boolean }) => u.is_superuser)).toBe(true);
+	});
+
+	it('requires authentication', async () => {
+		const res = await app.request('/api/users');
+		expect(res.status).toBe(401);
+	});
+
+	it('rejects a non-superuser (403)', async () => {
+		const reg = await db.query<{ id: string }>(
+			"INSERT INTO users (display_name, is_superuser) VALUES ('Regular', false) RETURNING id",
+		);
+		const regToken = await signAdminJwt(masterKeyManager, reg.rows[0].id);
+		const res = await app.request('/api/users', { headers: authHeader(regToken) });
+		expect(res.status).toBe(403);
+	});
+
+	it('uploads an avatar and returns a signed url', async () => {
+		const res = await app.request(`/api/users/${adminUserId}/icon`, {
+			method: 'PUT',
+			headers: authHeader(token),
+			body: iconForm(pngWithDimensions(512, 512)),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data.icon_url).toMatch(/\/api\/users\/[\w-]+\/icon\?exp=\d+&sig=[^&]+&v=\d+/);
+		expect(body.data.icon_updated_at).toBeTruthy();
+	});
+
+	it('carries the signed icon_url on the users list', async () => {
+		const res = await app.request('/api/users', { headers: authHeader(token) });
+		const admin = (await res.json()).data.find((u: { id: string }) => u.id === adminUserId);
+		expect(admin.icon_url).toBeTruthy();
+	});
+
+	it('serves the stored bytes from the signed url', async () => {
+		const res = await app.request('/api/users', { headers: authHeader(token) });
+		const admin = (await res.json()).data.find((u: { id: string }) => u.id === adminUserId);
+
+		const serve = await app.request(admin.icon_url);
+		expect(serve.status).toBe(200);
+		expect(serve.headers.get('Content-Type')).toBe('image/png');
+		const buf = Buffer.from(await serve.arrayBuffer());
+		expect(buf.equals(pngWithDimensions(512, 512))).toBe(true);
+	});
+
+	it('rejects an unsigned request to the serve endpoint', async () => {
+		const res = await app.request(`/api/users/${adminUserId}/icon`);
+		expect(res.status).toBe(401);
+	});
+
+	it('rejects an image exceeding 512px', async () => {
+		const res = await app.request(`/api/users/${adminUserId}/icon`, {
+			method: 'PUT',
+			headers: authHeader(token),
+			body: iconForm(pngWithDimensions(513, 512)),
+		});
+		expect(res.status).toBe(400);
+	});
+
+	it('rejects an unsupported content type', async () => {
+		const res = await app.request(`/api/users/${adminUserId}/icon`, {
+			method: 'PUT',
+			headers: authHeader(token),
+			body: iconForm(Buffer.from('<svg/>'), 'image/svg+xml'),
+		});
+		expect(res.status).toBe(400);
+	});
+
+	it('removes the avatar', async () => {
+		const del = await app.request(`/api/users/${adminUserId}/icon`, {
+			method: 'DELETE',
+			headers: authHeader(token),
+		});
+		expect(del.status).toBe(200);
+
+		const res = await app.request('/api/users', { headers: authHeader(token) });
+		const admin = (await res.json()).data.find((u: { id: string }) => u.id === adminUserId);
+		expect(admin.icon_url).toBeNull();
+	});
+});

--- a/packages/web/src/components/icon-upload-section.tsx
+++ b/packages/web/src/components/icon-upload-section.tsx
@@ -1,0 +1,176 @@
+import { isAllowedProjectIconInputMime } from '@hezo/shared';
+import { ImagePlus, Loader2 } from 'lucide-react';
+import { useRef, useState } from 'react';
+import { toast } from '../hooks/use-toast';
+import { normalizeProjectIcon } from '../lib/normalize-image';
+import { Avatar } from './ui/avatar';
+import { Button } from './ui/button';
+
+interface Preview {
+	blob: Blob;
+	url: string;
+}
+
+interface IconUploadSectionProps {
+	/** Section heading (e.g. "Agent avatar"). */
+	label: string;
+	/** Helper copy under the buttons. */
+	helpText: string;
+	/** Fallback initials shown when there is no image. */
+	initials: string;
+	/** Current signed icon URL, or null/undefined when unset. */
+	currentIconUrl?: string | null;
+	/** Upload the normalized square-PNG blob. Resolves on success. */
+	onUpload: (blob: Blob) => Promise<unknown>;
+	/** Remove the current icon. Resolves on success. */
+	onRemove: () => Promise<unknown>;
+	isUploading: boolean;
+	isRemoving: boolean;
+	/** Prefix for the `data-testid`s (`<prefix>-input`, `-upload`, `-save`, `-remove`, `-preview`). */
+	testIdPrefix: string;
+}
+
+/**
+ * GitHub-style avatar/icon control shared by any entity that can carry a custom
+ * image (project icon, agent avatar, admin avatar). Shows the current image (or
+ * an initials fallback), lets the user pick an image, previews the
+ * center-cropped square before saving, and removes an existing image. The picked
+ * file is normalized to a ≤512×512 PNG client-side (`normalizeProjectIcon`)
+ * before it is handed to `onUpload`. Data fetching/mutations live in the caller;
+ * this component owns only the pick → preview → save/remove interaction.
+ */
+export function IconUploadSection({
+	label,
+	helpText,
+	initials,
+	currentIconUrl,
+	onUpload,
+	onRemove,
+	isUploading,
+	isRemoving,
+	testIdPrefix,
+}: IconUploadSectionProps) {
+	const inputRef = useRef<HTMLInputElement>(null);
+	const [preview, setPreview] = useState<Preview | null>(null);
+	const [processing, setProcessing] = useState(false);
+
+	const busy = processing || isUploading || isRemoving;
+
+	function clearPreview() {
+		setPreview((prev) => {
+			if (prev) URL.revokeObjectURL(prev.url);
+			return null;
+		});
+	}
+
+	async function handleFile(file: File) {
+		if (!isAllowedProjectIconInputMime(file.type)) {
+			toast.error('Unsupported image type. Use PNG, JPEG, WebP, GIF, or SVG.');
+			return;
+		}
+		setProcessing(true);
+		try {
+			const blob = await normalizeProjectIcon(file);
+			clearPreview();
+			setPreview({ blob, url: URL.createObjectURL(blob) });
+		} catch {
+			toast.error('Could not read that image. Try a different file.');
+		} finally {
+			setProcessing(false);
+		}
+	}
+
+	async function handleSave() {
+		if (!preview) return;
+		try {
+			await onUpload(preview.blob);
+			clearPreview();
+		} catch {
+			toast.error('Failed to upload image');
+		}
+	}
+
+	async function handleRemove() {
+		try {
+			await onRemove();
+		} catch {
+			toast.error('Failed to remove image');
+		}
+	}
+
+	const shownUrl = preview?.url ?? currentIconUrl ?? undefined;
+
+	return (
+		<section>
+			<h2 className="text-sm font-medium text-text-2 mb-3">{label}</h2>
+			<div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+				<div data-testid={`${testIdPrefix}-preview`}>
+					<Avatar initials={initials} imageUrl={shownUrl} size="lg" />
+				</div>
+				<div className="flex flex-col gap-2">
+					<div className="flex flex-wrap gap-2">
+						<input
+							ref={inputRef}
+							type="file"
+							accept="image/png,image/jpeg,image/webp,image/gif,image/svg+xml"
+							className="hidden"
+							data-testid={`${testIdPrefix}-input`}
+							onChange={(e) => {
+								const file = e.target.files?.[0];
+								// Reset so re-picking the same file fires change again.
+								e.target.value = '';
+								if (file) void handleFile(file);
+							}}
+						/>
+						{preview ? (
+							<>
+								<Button
+									size="sm"
+									onClick={handleSave}
+									disabled={busy}
+									data-testid={`${testIdPrefix}-save`}
+								>
+									{isUploading ? <Loader2 className="w-3 h-3 animate-spin" /> : 'Save image'}
+								</Button>
+								<Button size="sm" variant="ghost" onClick={clearPreview} disabled={busy}>
+									Cancel
+								</Button>
+							</>
+						) : (
+							<>
+								<Button
+									size="sm"
+									variant="outline"
+									onClick={() => inputRef.current?.click()}
+									disabled={busy}
+									data-testid={`${testIdPrefix}-upload`}
+								>
+									{processing ? (
+										<Loader2 className="w-3 h-3 animate-spin" />
+									) : (
+										<>
+											<ImagePlus className="w-3.5 h-3.5 mr-1.5" />
+											{currentIconUrl ? 'Replace image' : 'Upload image'}
+										</>
+									)}
+								</Button>
+								{currentIconUrl && (
+									<Button
+										size="sm"
+										variant="destructive"
+										onClick={handleRemove}
+										disabled={busy}
+										data-testid={`${testIdPrefix}-remove`}
+									>
+										{isRemoving ? <Loader2 className="w-3 h-3 animate-spin" /> : 'Remove'}
+									</Button>
+								)}
+							</>
+						)}
+					</div>
+					<p className="text-xs text-text-3">{helpText}</p>
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/packages/web/src/components/org-chart-tree.tsx
+++ b/packages/web/src/components/org-chart-tree.tsx
@@ -3,6 +3,7 @@ import { Link } from '@tanstack/react-router';
 import { type ReactNode, useEffect, useRef, useState } from 'react';
 import type { OrgNode } from '../hooks/use-org-chart';
 import { agentPageParams } from './agent-link';
+import { Avatar, getInitials } from './ui/avatar';
 import { StatusDot } from './ui/status-dot';
 import { Tooltip } from './ui/tooltip';
 
@@ -99,6 +100,13 @@ export function OrgChartTree({ roots, projectId, mode, hint, testId }: OrgChartT
 		const status = mode === 'interactive' ? orgDotStatus(node) : null;
 		const label = (
 			<>
+				{mode === 'interactive' && (
+					<Avatar
+						size="sm"
+						initials={getInitials(node.title)}
+						imageUrl={node.icon_url ?? undefined}
+					/>
+				)}
 				{status && <StatusDot status={status} />}
 				{node.title}
 			</>

--- a/packages/web/src/components/settings-sidebar.tsx
+++ b/packages/web/src/components/settings-sidebar.tsx
@@ -19,6 +19,7 @@ const PUBLIC_ITEMS: NavItem[] = [
 
 const ADMIN_ITEMS: NavItem[] = [
 	{ to: '/settings/admin-password', label: 'Admin password' },
+	{ to: '/settings/users', label: 'Users' },
 	{ to: '/settings/chatbox', label: 'Chatbox' },
 	{ to: '/settings/skills', label: 'Skills' },
 	{ to: '/settings/connectors', label: 'Connectors' },

--- a/packages/web/src/hooks/use-agents.ts
+++ b/packages/web/src/hooks/use-agents.ts
@@ -1,6 +1,6 @@
 import { AgentAdminStatus, type AgentEffort } from '@hezo/shared';
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { api } from '../lib/api';
+import { type ApiError, api } from '../lib/api';
 import { queryClient } from '../lib/query-client';
 import { queryKeys } from '../lib/query-keys';
 import { useOptimisticMutation, useSimpleOptimisticUpdate } from './use-optimistic-mutation';
@@ -41,6 +41,9 @@ export interface Agent {
 	is_instance?: boolean;
 	/** True when the agent has a live chatbox (and thus a Chat history tab). CEO only today. */
 	chat_enabled?: boolean;
+	/** Optional custom avatar (signed URL); null/undefined when unset (falls back to initials). */
+	icon_url?: string | null;
+	icon_updated_at?: string | null;
 }
 
 export interface AgentSystemPromptDoc {
@@ -116,6 +119,52 @@ export function useUpdateAgent(projectId: string, agentId: string) {
 			errorMessage: 'Failed to update agent',
 		},
 	);
+}
+
+export interface AgentIconResponse {
+	icon_url: string | null;
+	icon_updated_at: string | null;
+}
+
+/**
+ * Seed an agent's icon fields into the detail cache from a server response and
+ * invalidate the roster/org-chart/agent queries so every surface that renders
+ * the avatar reflects the change. Response-driven (the server returns the signed
+ * `icon_url`), not optimistic.
+ */
+function applyAgentIconToCaches(projectId: string, agentId: string, icon: AgentIconResponse) {
+	queryClient.setQueryData<Agent>(queryKeys.projects.agent(projectId, agentId), (old) =>
+		old ? { ...old, icon_url: icon.icon_url, icon_updated_at: icon.icon_updated_at } : old,
+	);
+	// `agents(projectId)` is a prefix of every `agentsFiltered` key, so this
+	// invalidates the roster list regardless of the active admin_status filter.
+	queryClient.invalidateQueries({ queryKey: queryKeys.projects.agents(projectId) });
+	queryClient.invalidateQueries({ queryKey: queryKeys.projects.orgChart(projectId) });
+	queryClient.invalidateQueries({ queryKey: queryKeys.projects.agent(projectId, agentId) });
+}
+
+/** Upload (or replace) an agent's avatar. `blob` is the normalized square PNG. */
+export function useUploadAgentIcon(projectId: string, agentId: string) {
+	return useMutation<AgentIconResponse, ApiError, Blob>({
+		mutationFn: (blob) => {
+			const fd = new FormData();
+			fd.set('file', blob, 'icon.png');
+			return api.putForm<AgentIconResponse>(
+				`/api/projects/${projectId}/agents/${agentId}/icon`,
+				fd,
+			);
+		},
+		onSuccess: (data) => applyAgentIconToCaches(projectId, agentId, data),
+	});
+}
+
+export function useRemoveAgentIcon(projectId: string, agentId: string) {
+	return useMutation<AgentIconResponse, ApiError, void>({
+		mutationFn: () =>
+			api.delete<AgentIconResponse>(`/api/projects/${projectId}/agents/${agentId}/icon`),
+		onSuccess: () =>
+			applyAgentIconToCaches(projectId, agentId, { icon_url: null, icon_updated_at: null }),
+	});
 }
 
 export function useAgentSystemPrompt(projectId: string, agentId: string) {

--- a/packages/web/src/hooks/use-org-chart.ts
+++ b/packages/web/src/hooks/use-org-chart.ts
@@ -10,6 +10,8 @@ export interface OrgNode {
 	runtime_status: string;
 	admin_status: string;
 	reports_to: string | null;
+	/** Optional custom avatar (signed URL); null when unset (falls back to initials). */
+	icon_url?: string | null;
 	children: OrgNode[];
 }
 

--- a/packages/web/src/hooks/use-users.ts
+++ b/packages/web/src/hooks/use-users.ts
@@ -1,0 +1,61 @@
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { type ApiError, api } from '../lib/api';
+import { queryClient } from '../lib/query-client';
+import { queryKeys } from '../lib/query-keys';
+
+export interface AdminUser {
+	id: string;
+	display_name: string;
+	is_superuser: boolean;
+	/** Optional custom avatar (signed URL); null when unset (falls back to initials). */
+	icon_url: string | null;
+	icon_updated_at: string | null;
+}
+
+export interface UserIconResponse {
+	icon_url: string | null;
+	icon_updated_at: string | null;
+}
+
+/** Human users (today just the admin). Superuser-only on the server. */
+export function useUsers() {
+	return useQuery({
+		queryKey: queryKeys.users(),
+		queryFn: () => api.get<AdminUser[]>('/api/users'),
+	});
+}
+
+/**
+ * Seed a user's icon fields into the users cache from a server response, then
+ * invalidate to reconcile. Response-driven (the server returns the signed
+ * `icon_url`), not optimistic.
+ */
+function applyUserIconToCache(userId: string, icon: UserIconResponse) {
+	queryClient.setQueryData<AdminUser[]>(queryKeys.users(), (old) =>
+		old?.map((u) =>
+			u.id === userId
+				? { ...u, icon_url: icon.icon_url, icon_updated_at: icon.icon_updated_at }
+				: u,
+		),
+	);
+	queryClient.invalidateQueries({ queryKey: queryKeys.users() });
+}
+
+/** Upload (or replace) a user's avatar. `blob` is the normalized square PNG. */
+export function useUploadUserIcon(userId: string) {
+	return useMutation<UserIconResponse, ApiError, Blob>({
+		mutationFn: (blob) => {
+			const fd = new FormData();
+			fd.set('file', blob, 'icon.png');
+			return api.putForm<UserIconResponse>(`/api/users/${userId}/icon`, fd);
+		},
+		onSuccess: (data) => applyUserIconToCache(userId, data),
+	});
+}
+
+export function useRemoveUserIcon(userId: string) {
+	return useMutation<UserIconResponse, ApiError, void>({
+		mutationFn: () => api.delete<UserIconResponse>(`/api/users/${userId}/icon`),
+		onSuccess: () => applyUserIconToCache(userId, { icon_url: null, icon_updated_at: null }),
+	});
+}

--- a/packages/web/src/lib/query-keys.ts
+++ b/packages/web/src/lib/query-keys.ts
@@ -19,6 +19,8 @@ type KeyParam = unknown;
 export const queryKeys = {
 	// ---- instance / global ----
 	me: () => ['me'],
+	/** Human users (today just the admin) for the global Settings → Users page. */
+	users: () => ['users'],
 	status: () => ['status'],
 	updateCheck: () => ['update-check'],
 	updateStatus: () => ['update-status'],

--- a/packages/web/src/routeTree.gen.ts
+++ b/packages/web/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as IndexRouteImport } from './routes/index'
 import { Route as SettingsIndexRouteImport } from './routes/settings/index'
 import { Route as MarketplaceIndexRouteImport } from './routes/marketplace/index'
 import { Route as HomeIndexRouteImport } from './routes/home/index'
+import { Route as SettingsUsersRouteImport } from './routes/settings/users'
 import { Route as SettingsSkillsRouteImport } from './routes/settings/skills'
 import { Route as SettingsCredentialsRouteImport } from './routes/settings/credentials'
 import { Route as SettingsConnectorsRouteImport } from './routes/settings/connectors'
@@ -79,6 +80,11 @@ const HomeIndexRoute = HomeIndexRouteImport.update({
   id: '/home/',
   path: '/home/',
   getParentRoute: () => rootRouteImport,
+} as any)
+const SettingsUsersRoute = SettingsUsersRouteImport.update({
+  id: '/users',
+  path: '/users',
+  getParentRoute: () => SettingsRouteRoute,
 } as any)
 const SettingsSkillsRoute = SettingsSkillsRouteImport.update({
   id: '/skills',
@@ -319,6 +325,7 @@ export interface FileRoutesByFullPath {
   '/settings/connectors': typeof SettingsConnectorsRoute
   '/settings/credentials': typeof SettingsCredentialsRoute
   '/settings/skills': typeof SettingsSkillsRoute
+  '/settings/users': typeof SettingsUsersRoute
   '/home/': typeof HomeIndexRoute
   '/marketplace/': typeof MarketplaceIndexRoute
   '/settings/': typeof SettingsIndexRoute
@@ -364,6 +371,7 @@ export interface FileRoutesByTo {
   '/settings/connectors': typeof SettingsConnectorsRoute
   '/settings/credentials': typeof SettingsCredentialsRoute
   '/settings/skills': typeof SettingsSkillsRoute
+  '/settings/users': typeof SettingsUsersRoute
   '/home': typeof HomeIndexRoute
   '/marketplace': typeof MarketplaceIndexRoute
   '/settings': typeof SettingsIndexRoute
@@ -411,6 +419,7 @@ export interface FileRoutesById {
   '/settings/connectors': typeof SettingsConnectorsRoute
   '/settings/credentials': typeof SettingsCredentialsRoute
   '/settings/skills': typeof SettingsSkillsRoute
+  '/settings/users': typeof SettingsUsersRoute
   '/home/': typeof HomeIndexRoute
   '/marketplace/': typeof MarketplaceIndexRoute
   '/settings/': typeof SettingsIndexRoute
@@ -460,6 +469,7 @@ export interface FileRouteTypes {
     | '/settings/connectors'
     | '/settings/credentials'
     | '/settings/skills'
+    | '/settings/users'
     | '/home/'
     | '/marketplace/'
     | '/settings/'
@@ -505,6 +515,7 @@ export interface FileRouteTypes {
     | '/settings/connectors'
     | '/settings/credentials'
     | '/settings/skills'
+    | '/settings/users'
     | '/home'
     | '/marketplace'
     | '/settings'
@@ -551,6 +562,7 @@ export interface FileRouteTypes {
     | '/settings/connectors'
     | '/settings/credentials'
     | '/settings/skills'
+    | '/settings/users'
     | '/home/'
     | '/marketplace/'
     | '/settings/'
@@ -631,6 +643,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/home/'
       preLoaderRoute: typeof HomeIndexRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/settings/users': {
+      id: '/settings/users'
+      path: '/users'
+      fullPath: '/settings/users'
+      preLoaderRoute: typeof SettingsUsersRouteImport
+      parentRoute: typeof SettingsRouteRoute
     }
     '/settings/skills': {
       id: '/settings/skills'
@@ -926,6 +945,7 @@ interface SettingsRouteRouteChildren {
   SettingsConnectorsRoute: typeof SettingsConnectorsRoute
   SettingsCredentialsRoute: typeof SettingsCredentialsRoute
   SettingsSkillsRoute: typeof SettingsSkillsRoute
+  SettingsUsersRoute: typeof SettingsUsersRoute
   SettingsIndexRoute: typeof SettingsIndexRoute
 }
 
@@ -940,6 +960,7 @@ const SettingsRouteRouteChildren: SettingsRouteRouteChildren = {
   SettingsConnectorsRoute: SettingsConnectorsRoute,
   SettingsCredentialsRoute: SettingsCredentialsRoute,
   SettingsSkillsRoute: SettingsSkillsRoute,
+  SettingsUsersRoute: SettingsUsersRoute,
   SettingsIndexRoute: SettingsIndexRoute,
 }
 

--- a/packages/web/src/routes/projects/$projectId/agents/$agentId/route.tsx
+++ b/packages/web/src/routes/projects/$projectId/agents/$agentId/route.tsx
@@ -2,6 +2,7 @@ import { AgentAdminStatus } from '@hezo/shared';
 import { createFileRoute, Link, Outlet } from '@tanstack/react-router';
 import { ArrowLeft } from 'lucide-react';
 import { NextHeartbeatIndicator } from '../../../../../components/next-heartbeat-indicator';
+import { Avatar, getInitials } from '../../../../../components/ui/avatar';
 import { Badge } from '../../../../../components/ui/badge';
 import { ExpandableText } from '../../../../../components/ui/expandable-text';
 import { Tabs } from '../../../../../components/ui/tabs';
@@ -45,6 +46,12 @@ function AgentLayout() {
 			</Link>
 
 			<div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 mb-4">
+				<Avatar
+					initials={getInitials(agent.title)}
+					imageUrl={agent.icon_url}
+					size="md"
+					running={agent.runtime_status === 'active'}
+				/>
 				<h1
 					className={`text-lg font-semibold${agent.admin_status === AgentAdminStatus.Disabled ? ' text-text-2' : ''}`}
 				>

--- a/packages/web/src/routes/projects/$projectId/agents/$agentId/settings.tsx
+++ b/packages/web/src/routes/projects/$projectId/agents/$agentId/settings.tsx
@@ -13,8 +13,10 @@ import { createFileRoute, Link } from '@tanstack/react-router';
 import { Loader2, Power, PowerOff } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { BudgetWindowsEditor } from '../../../../../components/budget/budget-windows-editor';
+import { IconUploadSection } from '../../../../../components/icon-upload-section';
 import { MarkdownEditor } from '../../../../../components/markdown-editor';
 import { RevisionsPanel } from '../../../../../components/revisions-panel';
+import { getInitials } from '../../../../../components/ui/avatar';
 import { Button } from '../../../../../components/ui/button';
 import { ExpandableText } from '../../../../../components/ui/expandable-text';
 import { Input } from '../../../../../components/ui/input';
@@ -27,8 +29,10 @@ import {
 	useAgents,
 	useDisableAgent,
 	useEnableAgent,
+	useRemoveAgentIcon,
 	useRestoreAgentSystemPrompt,
 	useUpdateAgent,
+	useUploadAgentIcon,
 } from '../../../../../hooks/use-agents';
 import { useAiProviderModels, useAiProviders } from '../../../../../hooks/use-ai-providers';
 import { useBudgetStatus } from '../../../../../hooks/use-costs';
@@ -42,6 +46,8 @@ function AgentSettingsPage() {
 	const { data: revisions } = useAgentSystemPromptRevisions(projectId, agentId);
 	const restorePrompt = useRestoreAgentSystemPrompt(projectId, agentId);
 	const updateAgent = useUpdateAgent(projectId, agentId);
+	const uploadIcon = useUploadAgentIcon(projectId, agentId);
+	const removeIcon = useRemoveAgentIcon(projectId, agentId);
 	const disableAgent = useDisableAgent(projectId);
 	const enableAgent = useEnableAgent(projectId);
 	const { data: budgetStatus } = useBudgetStatus(projectId);
@@ -130,6 +136,20 @@ function AgentSettingsPage() {
 
 	return (
 		<div>
+			<div className="mb-6">
+				<IconUploadSection
+					label="Agent avatar"
+					helpText="Shown on the team roster, the agent header, and the org chart. Square images work best; we crop to a square and resize to 512×512. Leave unset to show the agent's initials."
+					initials={getInitials(agent.title)}
+					currentIconUrl={agent.icon_url}
+					onUpload={(blob) => uploadIcon.mutateAsync(blob)}
+					onRemove={() => removeIcon.mutateAsync()}
+					isUploading={uploadIcon.isPending}
+					isRemoving={removeIcon.isPending}
+					testIdPrefix="agent-icon"
+				/>
+			</div>
+
 			{/* Budget & Heartbeat */}
 			<div className="mb-6 grid grid-cols-1 sm:grid-cols-2 gap-4">
 				<div className="rounded-lg border border-border-subtle bg-surface p-4">

--- a/packages/web/src/routes/settings/users.tsx
+++ b/packages/web/src/routes/settings/users.tsx
@@ -1,0 +1,75 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { IconUploadSection } from '../../components/icon-upload-section';
+import { getInitials } from '../../components/ui/avatar';
+import { useMe } from '../../hooks/use-me';
+import {
+	type AdminUser,
+	useRemoveUserIcon,
+	useUploadUserIcon,
+	useUsers,
+} from '../../hooks/use-users';
+
+function UserRow({ user }: { user: AdminUser }) {
+	const upload = useUploadUserIcon(user.id);
+	const remove = useRemoveUserIcon(user.id);
+
+	return (
+		<div className="rounded-lg border border-border-subtle bg-surface p-4">
+			<div className="mb-3">
+				<div className="text-sm font-medium text-text-1">{user.display_name}</div>
+				<div className="text-xs text-text-3">{user.is_superuser ? 'Admin' : 'User'}</div>
+			</div>
+			<IconUploadSection
+				label="Avatar"
+				helpText="Your profile picture. Square images work best; we crop to a square and resize to 512×512. Leave unset to show your initials."
+				initials={getInitials(user.display_name || 'Admin')}
+				currentIconUrl={user.icon_url}
+				onUpload={(blob) => upload.mutateAsync(blob)}
+				onRemove={() => remove.mutateAsync()}
+				isUploading={upload.isPending}
+				isRemoving={remove.isPending}
+				testIdPrefix="user-icon"
+			/>
+		</div>
+	);
+}
+
+function UsersPage() {
+	const { data: me } = useMe();
+	const { data: users, isLoading } = useUsers();
+
+	if (me && !me.is_superuser) {
+		return (
+			<div className="max-w-[900px]">
+				<p className="text-[13px] text-text-2">
+					Users are managed by the Admin. You don't have access to this page.
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className="max-w-[900px]">
+			<div className="mb-5">
+				<h1 className="text-[22px] font-medium">Users</h1>
+				<p className="text-[13px] text-text-2 mt-1 max-w-[680px]">
+					The people with access to this Hezo instance. Set an avatar to personalize how you appear
+					across the app.
+				</p>
+			</div>
+			{isLoading ? (
+				<p className="text-[13px] text-text-2">Loading…</p>
+			) : (
+				<div className="flex flex-col gap-4" data-testid="users-list">
+					{users?.map((user) => (
+						<UserRow key={user.id} user={user} />
+					))}
+				</div>
+			)}
+		</div>
+	);
+}
+
+export const Route = createFileRoute('/settings/users')({
+	component: UsersPage,
+});

--- a/packages/web/test/agent-icon-section.test.tsx
+++ b/packages/web/test/agent-icon-section.test.tsx
@@ -1,0 +1,106 @@
+// Coverage for the agent-avatar wiring: the shared IconUploadSection rendered on
+// the agent Settings page, driving pick → normalize → preview → save against the
+// real PUT/DELETE /api/projects/:slug/agents/:agentId/icon routes. happy-dom
+// can't decode/rasterize images, so the browser decode/canvas boundary is stubbed
+// (a fake <canvas> encodes a structurally-valid 512×512 PNG the server accepts).
+
+import { fireEvent } from '@testing-library/react';
+import { afterEach, expect, test, vi } from 'vitest';
+import { renderApp } from './helpers/render';
+import { type SeededWorkspace, seedWorkspace } from './helpers/seed';
+
+function pngHeader(): Uint8Array {
+	const sig = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+	const ihdr = new Uint8Array(25);
+	const view = new DataView(ihdr.buffer);
+	view.setUint32(0, 13);
+	ihdr.set([0x49, 0x48, 0x44, 0x52], 4); // "IHDR"
+	view.setUint32(8, 512);
+	view.setUint32(12, 512);
+	return new Uint8Array([...sig, ...ihdr]);
+}
+
+type WindowWithBitmap = { createImageBitmap?: (f: File) => Promise<unknown> };
+type UrlStatics = {
+	createObjectURL?: (b: Blob | File) => string;
+	revokeObjectURL?: (u: string) => void;
+};
+const urlStatics = URL as unknown as UrlStatics;
+const originalCreateObjectURL = urlStatics.createObjectURL;
+const originalRevokeObjectURL = urlStatics.revokeObjectURL;
+
+function stubImagePipeline() {
+	(window as unknown as WindowWithBitmap).createImageBitmap = vi.fn(async () => ({
+		width: 800,
+		height: 600,
+		close: vi.fn(),
+	})) as unknown as (f: File) => Promise<unknown>;
+
+	const encoded = new Blob([pngHeader() as unknown as BlobPart], { type: 'image/png' });
+	const original = document.createElement.bind(document);
+	vi.spyOn(document, 'createElement').mockImplementation(((tag: string) => {
+		if (tag !== 'canvas') return original(tag);
+		return {
+			width: 0,
+			height: 0,
+			getContext: () => ({ imageSmoothingQuality: '', drawImage: () => {} }),
+			toBlob: (cb: (b: Blob | null) => void) => cb(encoded),
+		} as unknown as HTMLElement;
+	}) as typeof document.createElement);
+
+	urlStatics.createObjectURL = vi.fn(() => 'blob:preview-url');
+	urlStatics.revokeObjectURL = vi.fn();
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.unstubAllGlobals();
+	delete (window as unknown as WindowWithBitmap).createImageBitmap;
+	urlStatics.createObjectURL = originalCreateObjectURL;
+	urlStatics.revokeObjectURL = originalRevokeObjectURL;
+});
+
+async function renderAgentSettings() {
+	let ws!: SeededWorkspace;
+	const utils = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			ws = await seedWorkspace();
+		},
+	});
+	const agent = ws.agents[0];
+	await utils.router.navigate({
+		to: '/projects/$projectId/agents/$agentId/settings',
+		params: { projectId: ws.internalSlug, agentId: agent.slug },
+	});
+	return { ...utils, ws, agent };
+}
+
+test('uploading an agent avatar swaps to Replace/Remove, and Remove returns to initials', async () => {
+	stubImagePipeline();
+	const { findByTestId, queryByTestId, user } = await renderAgentSettings();
+
+	const input = await findByTestId('agent-icon-input', undefined, { timeout: 15_000 });
+	fireEvent.change(input, {
+		target: { files: [new File([new Uint8Array([1, 2, 3])], 'avatar.png', { type: 'image/png' })] },
+	});
+
+	// Preview state → Save the normalized blob.
+	const save = await findByTestId('agent-icon-save');
+	expect((await findByTestId('agent-icon-preview')).querySelector('img')?.getAttribute('src')).toBe(
+		'blob:preview-url',
+	);
+	await user.click(save);
+
+	// Upload succeeded: the section now offers Replace + Remove.
+	await findByTestId('agent-icon-remove', undefined, { timeout: 15_000 });
+	expect(queryByTestId('agent-icon-save')).toBeNull();
+	expect((await findByTestId('agent-icon-upload')).textContent).toContain('Replace image');
+
+	// Remove clears the avatar and returns to the initials fallback.
+	await user.click(await findByTestId('agent-icon-remove'));
+	await findByTestId('agent-icon-upload', undefined, { timeout: 15_000 });
+	expect(queryByTestId('agent-icon-remove')).toBeNull();
+	expect((await findByTestId('agent-icon-upload')).textContent).toContain('Upload image');
+	expect(queryByTestId('agent-icon-preview')?.querySelector('img')).toBeFalsy();
+});

--- a/packages/web/test/users-settings.test.tsx
+++ b/packages/web/test/users-settings.test.tsx
@@ -1,0 +1,99 @@
+// Coverage for the global Settings → Users page: it lists the single admin user
+// and exposes the shared IconUploadSection (user-icon-*) wired to the real
+// PUT/DELETE /api/users/:userId/icon routes. happy-dom can't decode/rasterize
+// images, so the decode/canvas boundary is stubbed with a valid 512×512 PNG.
+
+import { fireEvent } from '@testing-library/react';
+import { afterEach, expect, test, vi } from 'vitest';
+import { renderApp } from './helpers/render';
+import { seedWorkspace } from './helpers/seed';
+
+function pngHeader(): Uint8Array {
+	const sig = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+	const ihdr = new Uint8Array(25);
+	const view = new DataView(ihdr.buffer);
+	view.setUint32(0, 13);
+	ihdr.set([0x49, 0x48, 0x44, 0x52], 4); // "IHDR"
+	view.setUint32(8, 512);
+	view.setUint32(12, 512);
+	return new Uint8Array([...sig, ...ihdr]);
+}
+
+type WindowWithBitmap = { createImageBitmap?: (f: File) => Promise<unknown> };
+type UrlStatics = {
+	createObjectURL?: (b: Blob | File) => string;
+	revokeObjectURL?: (u: string) => void;
+};
+const urlStatics = URL as unknown as UrlStatics;
+const originalCreateObjectURL = urlStatics.createObjectURL;
+const originalRevokeObjectURL = urlStatics.revokeObjectURL;
+
+function stubImagePipeline() {
+	(window as unknown as WindowWithBitmap).createImageBitmap = vi.fn(async () => ({
+		width: 800,
+		height: 600,
+		close: vi.fn(),
+	})) as unknown as (f: File) => Promise<unknown>;
+
+	const encoded = new Blob([pngHeader() as unknown as BlobPart], { type: 'image/png' });
+	const original = document.createElement.bind(document);
+	vi.spyOn(document, 'createElement').mockImplementation(((tag: string) => {
+		if (tag !== 'canvas') return original(tag);
+		return {
+			width: 0,
+			height: 0,
+			getContext: () => ({ imageSmoothingQuality: '', drawImage: () => {} }),
+			toBlob: (cb: (b: Blob | null) => void) => cb(encoded),
+		} as unknown as HTMLElement;
+	}) as typeof document.createElement);
+
+	urlStatics.createObjectURL = vi.fn(() => 'blob:preview-url');
+	urlStatics.revokeObjectURL = vi.fn();
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.unstubAllGlobals();
+	delete (window as unknown as WindowWithBitmap).createImageBitmap;
+	urlStatics.createObjectURL = originalCreateObjectURL;
+	urlStatics.revokeObjectURL = originalRevokeObjectURL;
+});
+
+async function renderUsersPage() {
+	const utils = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			await seedWorkspace();
+		},
+	});
+	await utils.router.navigate({ to: '/settings/users' });
+	return utils;
+}
+
+test('lists the admin user and exposes the avatar control', async () => {
+	const { findByRole, findByTestId } = await renderUsersPage();
+	await findByRole('heading', { name: 'Users' });
+	// The single admin user row renders with its avatar upload affordance.
+	await findByTestId('users-list', undefined, { timeout: 15_000 });
+	expect((await findByTestId('user-icon-upload')).textContent).toContain('Upload image');
+});
+
+test('uploading the admin avatar swaps to Replace/Remove', async () => {
+	stubImagePipeline();
+	const { findByTestId, queryByTestId, user } = await renderUsersPage();
+
+	const input = await findByTestId('user-icon-input', undefined, { timeout: 15_000 });
+	fireEvent.change(input, {
+		target: { files: [new File([new Uint8Array([1, 2, 3])], 'avatar.png', { type: 'image/png' })] },
+	});
+
+	const save = await findByTestId('user-icon-save');
+	expect((await findByTestId('user-icon-preview')).querySelector('img')?.getAttribute('src')).toBe(
+		'blob:preview-url',
+	);
+	await user.click(save);
+
+	await findByTestId('user-icon-remove', undefined, { timeout: 15_000 });
+	expect(queryByTestId('user-icon-save')).toBeNull();
+	expect((await findByTestId('user-icon-upload')).textContent).toContain('Replace image');
+});


### PR DESCRIPTION
## What & why

Adds the ability to upload a **custom avatar for an agent** and for the **admin user**, mirroring the existing project-icon feature.

- **Agent avatars** — upload from the agent **Settings** page; rendered on the team roster / org chart, the agent detail header, and the settings preview (falls back to the agent's initials when unset).
- **Admin avatar** — a new global **Settings → Users** submenu lists the single `admin` user with the same upload control (avatar only; name shown read-only).

Both clone the shipped project-icon pattern so behaviour, validation, and limits stay identical across all three entities: bytes stored in a dedicated 1:1 table, served from a public HMAC-signed `<img>` URL, and displayed through the shared `Avatar` component.

## How

**Shared building blocks (new code kept DRY, project-icon code untouched)**
- `packages/server/src/lib/entity-icon-urls.ts` — generic `signEntityIconUrl` / `verifyEntityIconUrl` (a `basePath` + per-entity `keyPurpose`, each deriving a distinct signing key).
- `packages/web/src/components/icon-upload-section.tsx` — generic `IconUploadSection` (pick → normalize → preview → save/remove), reusing `normalizeProjectIcon` + `Avatar`.

**Agents**
- Migration `033_agent_icons.sql` (1:1 with `member_agents`) + data-preservation test.
- `icon_url` threaded through `AGENT_BASE_COLUMNS` and the org-chart query; `PUT`/`DELETE /api/projects/:projectId/agents/:agentId/icon` and a public signed `GET /api/agents/:agentId/icon`.
- Web: `icon_url` on the `Agent`/`OrgNode` types, upload/remove hooks, the settings section, and avatars in the agent header + org-chart nodes.

**Admin / Users**
- Migration `034_user_icons.sql` (1:1 with `users`) + data-preservation test.
- New `usersRoutes`: superuser-only `GET /api/users`, `PUT`/`DELETE /api/users/:userId/icon`, and a public signed `GET /api/users/:userId/icon`.
- Web: `use-users` hooks, the `Settings → Users` page, and the `Users` nav item.

**Docs**: `.dev/architecture.md` (new `agent_icons` / `user_icons` beside `project_icons`) and `docs/concepts/projects-and-teams.md` (agent & admin avatars).

No MCP tool is added — icon upload is a human-only UI action, matching the project-icon precedent (which exposes none), so the generated MCP/SKILL/llms surfaces are untouched.

## Testing

- `packages/server/test/migrate-033-agent-icons.test.ts`, `migrate-034-user-icons.test.ts` — data preservation.
- `packages/server/test/agent-icon.test.ts`, `user-icon.test.ts` — upload → signed serve → unsigned 401 → oversize/unsupported 400 → list/single carry `icon_url` → remove; plus the `GET /api/users` superuser gate (401 unauthenticated, 403 non-superuser).
- `packages/web/test/agent-icon-section.test.tsx`, `users-settings.test.tsx` — the pick → save → Replace/Remove flow against the real routes.
- Full local run green: `bun run typecheck`, `bun run check`, and the icon test slice (server + web).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBnJ6zxCEtAowKF5g4wk4Q)_