### PR TITLE
fix: rank exact identifier/number matches first in task search

### DIFF
--- a/docs/reference/mcp-api.md
+++ b/docs/reference/mcp-api.md
@@ -871,7 +871,7 @@ Propose a new skill for the team's skills database (reusable team know-how: MCP 
 
 _Read-only._
 
-Full-text keyword search across the team skills database, tasks, project docs, and task comments. Returns results ranked by relevance (keyword + stemming match).
+Full-text keyword search across the team skills database, tasks, project docs, and task comments. Returns results ranked by relevance (keyword + stemming match). A bare task number or full identifier (e.g. "169" or "HM-169") resolves directly to that task, ranked first.
 
 **Parameters:**
 
@@ -882,7 +882,7 @@ Full-text keyword search across the team skills database, tasks, project docs, a
 | `scope` | `all` \| `tasks` \| `skills` \| `project_docs` \| `comments` | No | Limit search to specific content type (default: all) |
 | `limit` | `number` | No | Max results per type (default: 10) |
 
-**Returns:** `{ results, count }` — full-text (keyword + stemming) matches ranked by relevance across skills, tasks, project docs, and comments.
+**Returns:** `{ results, count }` — full-text (keyword + stemming) matches ranked by relevance across skills, tasks, project docs, and comments. A bare task number or full identifier resolves directly to that task, ranked first.
 
 ### `list_skills`
 

--- a/packages/server/src/lib/task-sort.ts
+++ b/packages/server/src/lib/task-sort.ts
@@ -96,3 +96,41 @@ export function buildTaskListOrderBy(
 		nextIdx: idx,
 	};
 }
+
+/**
+ * Build a relevance-rank expression for a task search term, meant to be prepended
+ * to the task-list ORDER BY so the best identifier match floats to the top.
+ *
+ * The `search` filter matches the term as a substring of title, description OR
+ * identifier, but the sort field (recency / work order) is otherwise blind to
+ * *which* column matched — so a task that merely mentions the term in its body can
+ * outrank the task whose identifier/number *is* the term (searching "169" leaving
+ * HM-169 buried under HM-167). This tier makes the identifier win.
+ *
+ * Lower rank sorts first (ASC):
+ *   0 — the term is the whole identifier (`HM-169` / `hm-169`)
+ *   1 — the term is the task number (`169` → HM-169)
+ *   2 — the identifier contains the term (`16` → HM-169)
+ *   3 — the title contains the term
+ *   4 — matched on description only
+ *
+ * Pushes two params (the raw term, then its `%term%` ILIKE pattern) and returns
+ * the CASE expression plus the next free placeholder index.
+ */
+export function buildSearchRelevanceOrderSql(
+	search: string,
+	params: unknown[],
+	idx: number,
+): { sql: string; nextIdx: number } {
+	const exactIdx = idx;
+	params.push(search);
+	const likeIdx = idx + 1;
+	params.push(`%${search}%`);
+	const sql = `CASE
+      WHEN LOWER(${TASK_ALIAS}.identifier) = LOWER($${exactIdx}) THEN 0
+      WHEN ${TASK_ALIAS}.number::text = $${exactIdx} THEN 1
+      WHEN ${TASK_ALIAS}.identifier ILIKE $${likeIdx} THEN 2
+      WHEN ${TASK_ALIAS}.title ILIKE $${likeIdx} THEN 3
+      ELSE 4 END`;
+	return { sql, nextIdx: idx + 2 };
+}

--- a/packages/server/src/mcp/mcp-reference.ts
+++ b/packages/server/src/mcp/mcp-reference.ts
@@ -345,7 +345,7 @@ export const TOOL_DOC_META: Record<string, ToolDocMeta> = {
 	full_text_search: {
 		category: 'Skills & search',
 		returns:
-			'`{ results, count }` — full-text (keyword + stemming) matches ranked by relevance across skills, tasks, project docs, and comments.',
+			'`{ results, count }` — full-text (keyword + stemming) matches ranked by relevance across skills, tasks, project docs, and comments. A bare task number or full identifier resolves directly to that task, ranked first.',
 	},
 
 	// Credentials & connectors

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -4762,7 +4762,7 @@ export function registerTools(
 	tool(
 		server,
 		'full_text_search',
-		'Full-text keyword search across the team skills database, tasks, project docs, and task comments. Returns results ranked by relevance (keyword + stemming match).',
+		'Full-text keyword search across the team skills database, tasks, project docs, and task comments. Returns results ranked by relevance (keyword + stemming match). A bare task number or full identifier (e.g. "169" or "HM-169") resolves directly to that task, ranked first.',
 		{
 			project: projectArg(),
 			query: z.string().describe('Search query (keywords)'),

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -24,7 +24,11 @@ import {
 	assertNoOutstandingActivity,
 	assertNoUnansweredAdminMentions,
 } from '../lib/task-relationships';
-import { buildTaskListOrderBy, parseTaskListSort } from '../lib/task-sort';
+import {
+	buildSearchRelevanceOrderSql,
+	buildTaskListOrderBy,
+	parseTaskListSort,
+} from '../lib/task-sort';
 import type { Env } from '../lib/types';
 import { logger } from '../logger';
 import { cancelCoachWorkForTask, terminateRunsForTask } from '../services/run-termination';
@@ -164,6 +168,17 @@ tasksRoutes.get('/projects/:projectId/tasks', async (c) => {
 	);
 	const total = countResult.rows[0].count;
 
+	// When searching, rank exact identifier / task-number matches ahead of tasks
+	// that merely mention the term in their title or body, so "169" surfaces
+	// HM-169 first instead of leaving it wherever the sort field happens to put
+	// it. Relevance is the primary key; the chosen sort only breaks ties.
+	let relevancePrefix = '';
+	if (search) {
+		const rel = buildSearchRelevanceOrderSql(search, params, idx);
+		relevancePrefix = `${rel.sql} ASC, `;
+		idx = rel.nextIdx;
+	}
+
 	const orderBy = buildTaskListOrderBy(sortField, sortDirection, params, idx);
 	idx = orderBy.nextIdx;
 
@@ -219,7 +234,7 @@ tasksRoutes.get('/projects/:projectId/tasks', async (c) => {
        LIMIT 1
      ) lr ON true
      WHERE ${where}
-     ORDER BY ${orderBy.sql}
+     ORDER BY ${relevancePrefix}${orderBy.sql}
      LIMIT $${idx + 1} OFFSET $${idx + 2}`,
 		dataParams,
 	);

--- a/packages/server/src/services/search.ts
+++ b/packages/server/src/services/search.ts
@@ -93,15 +93,31 @@ export async function fullTextSearch(
 			project_slug: string;
 			score: number;
 		}>(
+			// `to_tsvector` mangles an identifier's number — "HM-169" tokenizes to the
+			// lexeme `-169`, not `169` — so neither "169" nor "HM-169" full-text matches
+			// the task it names, and the `@@ q` filter would drop it before scoring.
+			// So also surface a task on an exact number or whole-identifier match, and
+			// rank those first: ts_rank for these short queries is well under 1, so the
+			// identifier boost dominates deterministically and carries through the
+			// cross-type merge below. (The exact-only broadening avoids flooding results
+			// on a short substring like "e".)
 			`SELECT t.id, t.title, LEFT(t.description, 4000) AS description, t.identifier,
-			        p.slug AS project_slug, ts_rank(t.search_tsv, q) AS score
+			        p.slug AS project_slug,
+			        ts_rank(t.search_tsv, q)
+			          + CASE
+			              WHEN LOWER(t.identifier) = LOWER($4) THEN 1000
+			              WHEN t.number::text = $4 THEN 100
+			              WHEN t.identifier ILIKE $5 THEN 10
+			              ELSE 0
+			            END AS score
 			 FROM tasks t
 			 JOIN projects p ON p.id = t.project_id,
 			      to_tsquery('${TEXT_SEARCH_CONFIG}', $1) q
-			 WHERE t.team_id = ANY($2::uuid[]) AND t.search_tsv @@ q
+			 WHERE t.team_id = ANY($2::uuid[])
+			   AND (t.search_tsv @@ q OR t.number::text = $4 OR LOWER(t.identifier) = LOWER($4))
 			 ORDER BY score DESC
 			 LIMIT $3`,
-			[tsQuery, teamIds, limit],
+			[tsQuery, teamIds, limit, query, `%${query}%`],
 		);
 		for (const r of taskResults.rows) {
 			const title = `${r.identifier} — ${r.title}`;

--- a/packages/server/test/search-service.test.ts
+++ b/packages/server/test/search-service.test.ts
@@ -123,6 +123,50 @@ describe('fullTextSearch', () => {
 		expect(results.some((r) => r.title.includes('Deploy pipeline'))).toBe(true);
 	});
 
+	it('finds and top-ranks a task by its number, over one that repeats it in its title', async () => {
+		// `target` owns number N; `decoy` crams N into its title three times so its
+		// raw ts_rank is higher. `to_tsvector` tokenizes "EP-N" to the lexeme `-N`, so
+		// the query `N:*` never full-text matches `target` — the WHERE must surface it
+		// on the exact number, and the boost must then float it above the decoy.
+		const targetNum = (
+			await db.query<{ number: number }>('SELECT next_project_task_number($1) AS number', [
+				projectId,
+			])
+		).rows[0].number;
+		const target = await db.query<{ identifier: string }>(
+			`INSERT INTO tasks (team_id, project_id, number, identifier, title, description)
+			 VALUES ($1, $2, $3, $4, 'Quiet target task', 'no digits here')
+			 RETURNING identifier`,
+			[teamId, projectId, targetNum, `EP-${targetNum}`],
+		);
+		const decoyNum = (
+			await db.query<{ number: number }>('SELECT next_project_task_number($1) AS number', [
+				projectId,
+			])
+		).rows[0].number;
+		await db.query(
+			`INSERT INTO tasks (team_id, project_id, number, identifier, title, description)
+			 VALUES ($1, $2, $3, $4, $5, 'body')`,
+			[
+				teamId,
+				projectId,
+				decoyNum,
+				`EP-${decoyNum}`,
+				`Report ${targetNum} ${targetNum} ${targetNum}`,
+			],
+		);
+
+		const byNumber = await fullTextSearch(db, [teamId], String(targetNum), { scope: 'tasks' });
+		expect(byNumber[0].taskIdentifier).toBe(target.rows[0].identifier);
+
+		// The whole identifier ("EP-N") also tokenizes past the `@@ q` filter, so it
+		// must resolve to that exact task too.
+		const byIdentifier = await fullTextSearch(db, [teamId], target.rows[0].identifier, {
+			scope: 'tasks',
+		});
+		expect(byIdentifier[0].taskIdentifier).toBe(target.rows[0].identifier);
+	});
+
 	it('finds an active skill and excludes inactive ones', async () => {
 		const results = await fullTextSearch(db, [teamId], 'deploy', { scope: 'skills' });
 		const names = results.map((r) => r.title);

--- a/packages/server/test/tasks-sort.test.ts
+++ b/packages/server/test/tasks-sort.test.ts
@@ -2,6 +2,7 @@ import { TaskPriority, TaskStatus } from '@hezo/shared';
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Db } from '../src/db/database';
+import { buildSearchRelevanceOrderSql } from '../src/lib/task-sort';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
 import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
@@ -103,5 +104,59 @@ describe('GET /projects/:projectId/tasks sort=work_order', () => {
 
 		const ids = await listIds('work_order:asc');
 		expect(ids.indexOf(urgent.id)).toBeLessThan(ids.indexOf(medium.id));
+	});
+});
+
+async function searchIds(term: string, sort?: string): Promise<string[]> {
+	const qs = new URLSearchParams({ search: term, per_page: '50' });
+	if (sort) qs.set('sort', sort);
+	const res = await app.request(`/api/projects/${projectSlug}/tasks?${qs.toString()}`, {
+		headers: authHeader(token),
+	});
+	expect(res.status).toBe(200);
+	const rows = (await res.json()).data as Array<{ id: string }>;
+	return rows.map((r) => r.id);
+}
+
+describe('GET /projects/:projectId/tasks search relevance', () => {
+	it('ranks an exact task-number match ahead of a more-recent title-only match', async () => {
+		// `target` owns the number; `decoy` only mentions it in its title and is
+		// created afterwards, so under the default updated_at ordering it would
+		// otherwise come first. The number match must win regardless of the sort.
+		const target = await insertTask('Draft community platform posts');
+		const decoy = await insertTask(`References ${target.number} in the title`);
+
+		const ids = await searchIds(String(target.number), 'updated_at:desc');
+		expect(ids[0]).toBe(target.id);
+		expect(ids.indexOf(target.id)).toBeLessThan(ids.indexOf(decoy.id));
+	});
+
+	it('ranks a whole-identifier match first even when the body of another task cites it', async () => {
+		const target = await insertTask('Ship the release notes');
+		const decoy = await insertTask(`Blocked on ${target.identifier}, see thread`);
+
+		// Searching the full identifier (e.g. "SORT-42") — the exact-identifier tier
+		// must outrank the task whose title merely references it.
+		const ids = await searchIds(target.identifier, 'updated_at:desc');
+		expect(ids[0]).toBe(target.id);
+		expect(ids.indexOf(target.id)).toBeLessThan(ids.indexOf(decoy.id));
+	});
+});
+
+describe('buildSearchRelevanceOrderSql', () => {
+	it('pushes the raw term and its ILIKE pattern, and tiers identifier > title > body', () => {
+		const params: unknown[] = ['existing'];
+		const { sql, nextIdx } = buildSearchRelevanceOrderSql('169', params, 2);
+
+		expect(params).toEqual(['existing', '169', '%169%']);
+		expect(nextIdx).toBe(4);
+		// Whole-identifier (0) beats number (1) beats identifier-substring (2) beats
+		// title (3) beats description-only (4); exact tiers read the raw term ($2),
+		// the substring tiers read the ILIKE pattern ($3).
+		expect(sql).toContain('LOWER(i.identifier) = LOWER($2) THEN 0');
+		expect(sql).toContain('i.number::text = $2 THEN 1');
+		expect(sql).toContain('i.identifier ILIKE $3 THEN 2');
+		expect(sql).toContain('i.title ILIKE $3 THEN 3');
+		expect(sql).toContain('ELSE 4');
 	});
 });


### PR DESCRIPTION
## Problem

Searching a task board for a task's number didn't surface that task first. For example, searching **`169`** returned:

1. HM-167 · review
2. **HM-169** · review  ← the one you actually wanted
3. HM-166 · done

The task search matches the term as an ILIKE substring across **title, description, and identifier**, so HM-167/HM-166 matched only because their *bodies* mention "169". The results were then ordered purely by the sort field (recency / work order), **blind to which column matched** — so the exact identifier match got no priority and landed wherever its `updated_at` put it.

## Fix

- **Task-list / picker path** (`routes/tasks.ts`): add `buildSearchRelevanceOrderSql` — a relevance tier prepended to the `ORDER BY` as the primary key when a search term is present, so the chosen sort only breaks ties. Ranking (best first): whole-identifier match → exact task-number → identifier-substring → title → description-only.

- **Global full-text (⌘K) search** (`services/search.ts`): the same class of bug, but worse — `to_tsvector` tokenizes `HM-169` to the lexeme `-169`, **not** `169`, so a bare number or full identifier never matched a task through the `search_tsv @@ q` filter at all; the row was dropped *before* any ranking could apply. Broadened the `WHERE` to also surface a task on an **exact number or whole-identifier** match, and boost those to the top. The broadening is exact-only, so a short substring like `e` doesn't flood results.

- Updated the `full_text_search` MCP tool description and the generated `docs/reference/mcp-api.md` to note bare-number/identifier resolution.

## Tests

- **`tasks-sort.test.ts`** — an identifier/number match ranks ahead of a more-recently-updated title-only match (reproduces the reported scenario under `sort=updated_at:desc`); a whole-identifier search top-ranks the exact task; unit coverage of the tier builder (param pushes + tier ordering).
- **`search-service.test.ts`** — a bare number and a full identifier both *find and top-rank* the exact task over one that repeats the number in its title.
- Regression-checked the existing task-list, search, and docs-drift suites (all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZWb9hne2Tjsi5Ltb6PzrJ)_