### PR TITLE
feat(web): render markdown text preview in asset thumbnails

### DIFF
--- a/packages/web/src/components/markdown-thumbnail.tsx
+++ b/packages/web/src/components/markdown-thumbnail.tsx
@@ -1,0 +1,44 @@
+import { useMemo } from 'react';
+import Markdown, { type Components } from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { useSignedUrlText } from '../hooks/use-signed-url-text';
+import { AssetIcon } from './asset-icon';
+
+// Thumbnails only ever show the top slice, so parse just the head of the file —
+// this bounds react-markdown's work for a large (or mislabeled) text asset.
+const THUMBNAIL_SOURCE_LIMIT = 8000;
+
+// The card media is a <button>; keep the preview inert and free of interactive
+// descendants — drop links to plain text and never load (external) images.
+const THUMBNAIL_COMPONENTS: Components = {
+	a: ({ children }) => <span>{children}</span>,
+	img: ({ alt }) => <span>{alt ?? ''}</span>,
+};
+
+/**
+ * Rendered-markdown preview for an asset card's media area: fetches the asset's
+ * text from its signed URL and renders the first bit of it as a tiny,
+ * non-interactive prose block scaled to look like a mini document. Falls back to
+ * the file glyph while the fetch is in flight or if it fails (or the file is
+ * empty), so the card never shows a blank box.
+ */
+export function MarkdownThumbnail({ url, contentType }: { url: string; contentType: string }) {
+	const { text } = useSignedUrlText(url);
+	const snippet = useMemo(() => text?.slice(0, THUMBNAIL_SOURCE_LIMIT) ?? '', [text]);
+	if (!text?.trim()) return <AssetIcon contentType={contentType} />;
+	return (
+		<div
+			data-testid="asset-markdown-thumbnail"
+			aria-hidden
+			className="pointer-events-none h-full w-full overflow-hidden [mask-image:linear-gradient(to_bottom,black_65%,transparent)]"
+		>
+			{/* prose-sm rendered at ~60% via transform — proportional headings and
+			    spacing read as a real document; w-[166%] refills the width post-scale. */}
+			<div className="w-[166%] origin-top-left scale-[0.6] px-3 py-2 prose prose-sm max-w-none [&_*]:text-text-1!">
+				<Markdown remarkPlugins={[remarkGfm]} components={THUMBNAIL_COMPONENTS}>
+					{snippet}
+				</Markdown>
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/routes/projects/$projectId/assets.tsx
+++ b/packages/web/src/routes/projects/$projectId/assets.tsx
@@ -7,6 +7,7 @@ import {
 	compareAssetsForSort,
 	isArchiveFilter,
 	isAssetSortOrder,
+	isMarkdownAssetMime,
 	matchesArchiveFilter,
 	normalizeAssetFolder,
 } from '@hezo/shared';
@@ -33,6 +34,7 @@ import {
 } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { AssetIcon, formatBytes } from '../../../components/asset-icon';
+import { MarkdownThumbnail } from '../../../components/markdown-thumbnail';
 import { ArchivedBadge } from '../../../components/ui/archived-badge';
 import { Breadcrumb, type BreadcrumbSegment } from '../../../components/ui/breadcrumb';
 import { Button } from '../../../components/ui/button';
@@ -1094,6 +1096,7 @@ function AssetCard({
 
 	const isImage = asset.content_type.startsWith('image/');
 	const isHtml = asset.content_type === 'text/html';
+	const isMarkdown = isMarkdownAssetMime(asset.content_type);
 	const isArchived = asset.archived_at != null;
 	const basename = assetBasename(asset.original_filename);
 	const thumbnail = isImage ? (
@@ -1105,6 +1108,8 @@ function AssetCard({
 			sandbox=""
 			className="pointer-events-none h-full w-full bg-surface"
 		/>
+	) : isMarkdown ? (
+		<MarkdownThumbnail url={asset.url} contentType={asset.content_type} />
 	) : (
 		<AssetIcon contentType={asset.content_type} />
 	);

--- a/packages/web/test/project-assets.test.tsx
+++ b/packages/web/test/project-assets.test.tsx
@@ -69,6 +69,35 @@ test('a markdown asset opens in the viewer with a view-source toggle', async () 
 	expect(source.textContent).toBe(md);
 });
 
+test('a markdown asset card shows a rendered-text thumbnail instead of a file glyph', async () => {
+	let ctx!: { projectSlug: string };
+	const md = '# Launch Post\n\nWe shipped **markdown assets**.';
+	const { findByTestId, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Blog' });
+			await seedAsset(ws, project, {
+				filename: 'post.md',
+				contentType: 'text/markdown',
+				bytes: new TextEncoder().encode(md),
+			});
+			ctx = { projectSlug: project.slug };
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/assets',
+		params: { projectId: ctx.projectSlug },
+	});
+
+	// The thumbnail renders the markdown — the heading becomes an <h1> in the
+	// card media, not a literal `#` or a generic document icon.
+	const thumb = await findByTestId('asset-markdown-thumbnail');
+	await waitFor(() => expect(thumb.querySelector('h1')?.textContent).toBe('Launch Post'));
+	expect(thumb.querySelector('strong')?.textContent).toBe('markdown assets');
+});
+
 test('an asset is archived first, then deleted from the Archived view', async () => {
 	let ctx!: { projectSlug: string };
 	const { findByText, findByTestId, getByRole, queryByText, user, router } = await renderApp({


### PR DESCRIPTION
## What

Markdown asset cards in the project asset grid previously showed a generic document glyph, making one `.md` file indistinguishable from the next. This renders the **first bit of the file's text (rendered)** in the card's media area instead — so a markdown asset now looks like a mini document you can recognize at a glance.

Images and HTML assets already show real previews (`<img>` / sandboxed `<iframe>`); markdown was the odd one out falling through to `AssetIcon`.

## How

- New `MarkdownThumbnail` component (`packages/web/src/components/markdown-thumbnail.tsx`):
  - Fetches the asset's text from its **signed URL** via the existing `useSignedUrlText` hook — the same fetch the asset viewer already uses (no new endpoint).
  - Renders the head of the file with `react-markdown` + `remark-gfm` inside a `prose prose-sm` block, transform-scaled to ~60% so headings/spacing read like a real document, with a soft bottom fade (`mask-image`).
  - **Falls back to `AssetIcon`** while the fetch is in flight, on error, or for an empty file, so a card never shows a blank box.
  - Parses only the first 8 KB (thumbnails only show the top slice) and neutralizes links/images so the preview stays inert inside the card's `<button>` and never triggers external fetches.
- `AssetCard` (`assets.tsx`) gains an `isMarkdownAssetMime(...)` branch that renders `MarkdownThumbnail` before the icon fallback.

## Result

Each markdown card's media area now shows its rendered heading followed by the first lines of body text, fading out at the bottom — instead of an identical file-icon box. Verified visually in a real browser (Chromium via Playwright) against the built app at desktop width.

## Testing

- New component test in `packages/web/test/project-assets.test.tsx` seeds a `text/markdown` asset, renders the grid, and asserts the card's thumbnail renders the markdown (`<h1>` heading + `<strong>`), not a literal `#` or a generic icon. Full `project-assets.test.tsx` suite passes (8/8).
- `typecheck` + full `build` pass (run by the pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBASdvef1ME66XBgVQTEpx