### PR TITLE
Show keyboard shortcuts as inset keycaps on buttons

### DIFF
--- a/packages/web/src/components/create-goal-dialog.tsx
+++ b/packages/web/src/components/create-goal-dialog.tsx
@@ -219,10 +219,16 @@ export function CreateGoalDialog({ projectId, open, onOpenChange, goal }: Create
 					{error && <p className="text-sm text-danger">{error.message}</p>}
 
 					<div className="flex justify-end gap-2 mt-2">
-						<Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
+						<Button
+							type="button"
+							variant="ghost"
+							shortcut="Escape"
+							shortcutFire={false}
+							onClick={() => onOpenChange(false)}
+						>
 							Cancel
 						</Button>
-						<Button type="submit" disabled={!title.trim() || pending}>
+						<Button type="submit" shortcut="mod+Enter" disabled={!title.trim() || pending}>
 							{pending && <Loader2 className="w-4 h-4 animate-spin" />}
 							{isEdit ? 'Save' : 'Create'}
 						</Button>

--- a/packages/web/src/components/create-project-with-team-dialog.tsx
+++ b/packages/web/src/components/create-project-with-team-dialog.tsx
@@ -352,7 +352,12 @@ export function CreateProjectWithTeamDialog({
 									)}
 									Plan with the CEO
 								</Button>
-								<Button type="submit" disabled={!canSubmit} data-testid="create-project-submit">
+								<Button
+									type="submit"
+									shortcut="mod+Enter"
+									disabled={!canSubmit}
+									data-testid="create-project-submit"
+								>
 									{createProject.isPending ? (
 										<Loader2 className="w-4 h-4 animate-spin" />
 									) : (

--- a/packages/web/src/components/create-task-dialog.tsx
+++ b/packages/web/src/components/create-task-dialog.tsx
@@ -244,11 +244,18 @@ export function CreateTaskDialog({
 					)}
 
 					<div className="flex justify-end gap-2 mt-2">
-						<Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
+						<Button
+							type="button"
+							variant="ghost"
+							shortcut="Escape"
+							shortcutFire={false}
+							onClick={() => onOpenChange(false)}
+						>
 							Cancel
 						</Button>
 						<Button
 							type="submit"
+							shortcut="mod+Enter"
 							disabled={
 								!effectiveProjectId || !title.trim() || !assigneeId || activeMutation.isPending
 							}

--- a/packages/web/src/components/document-review/review-surface.tsx
+++ b/packages/web/src/components/document-review/review-surface.tsx
@@ -476,12 +476,21 @@ function ReviewEditor({
 					<span />
 				)}
 				<div className="flex items-center gap-1.5">
-					<Button variant="ghost" size="sm" onClick={onClose} data-testid="review-editor-cancel">
+					<Button
+						variant="ghost"
+						size="sm"
+						shortcut="Escape"
+						shortcutFire={false}
+						onClick={onClose}
+						data-testid="review-editor-cancel"
+					>
 						Cancel
 					</Button>
 					<Button
 						variant="primary"
 						size="sm"
+						shortcut="mod+Enter"
+						shortcutFire={false}
 						disabled={!canSave}
 						onClick={() => onSave(text)}
 						data-testid="review-editor-save"

--- a/packages/web/src/components/master-key-gate.tsx
+++ b/packages/web/src/components/master-key-gate.tsx
@@ -377,14 +377,24 @@ export function MasterKeyForm({ state, embedded, onAuthenticated }: MasterKeyFor
 					))}
 
 				{isUnset && phase === 'confirm' && (
-					<Button type="submit" disabled={loading || !key.trim()}>
+					<Button
+						type="submit"
+						shortcut="Enter"
+						shortcutFire={false}
+						disabled={loading || !key.trim()}
+					>
 						{loading && <Loader2 className="w-4 h-4 animate-spin" />}
 						Confirm key and continue
 					</Button>
 				)}
 
 				{!isUnset && (
-					<Button type="submit" disabled={loading || !key.trim()}>
+					<Button
+						type="submit"
+						shortcut="Enter"
+						shortcutFire={false}
+						disabled={loading || !key.trim()}
+					>
 						{loading && <Loader2 className="w-4 h-4 animate-spin" />}
 						Unlock
 					</Button>

--- a/packages/web/src/components/repo-picker-modal.tsx
+++ b/packages/web/src/components/repo-picker-modal.tsx
@@ -262,10 +262,21 @@ export function RepoPickerModal({
 					)}
 
 					<div className="flex justify-end gap-2 mt-2">
-						<Button type="button" variant="secondary" onClick={() => onOpenChange(false)}>
+						<Button
+							type="button"
+							variant="secondary"
+							shortcut="Escape"
+							shortcutFire={false}
+							onClick={() => onOpenChange(false)}
+						>
 							Cancel
 						</Button>
-						<Button type="submit" disabled={!canSubmit} data-testid="repo-picker-submit">
+						<Button
+							type="submit"
+							shortcut="mod+Enter"
+							disabled={!canSubmit}
+							data-testid="repo-picker-submit"
+						>
 							{createRepo.isPending && <Loader2 className="w-4 h-4 animate-spin" />}
 							{mode === 'link' ? 'Link repo' : 'Create repo'}
 						</Button>

--- a/packages/web/src/components/task-detail/comment-composer.tsx
+++ b/packages/web/src/components/task-detail/comment-composer.tsx
@@ -223,6 +223,8 @@ export function CommentComposer({
 						<Button
 							type="submit"
 							size="sm"
+							shortcut="mod+Enter"
+							shortcutFire={false}
 							disabled={
 								(!commentText.trim() && pendingAttachmentIds.length === 0) ||
 								createComment.isPending

--- a/packages/web/src/components/ui/button.tsx
+++ b/packages/web/src/components/ui/button.tsx
@@ -1,4 +1,7 @@
-import type { ButtonHTMLAttributes } from 'react';
+import { type ButtonHTMLAttributes, useRef } from 'react';
+import { useShortcut } from '../../hooks/use-shortcut';
+import { ariaKeyshortcuts, isMacPlatform } from '../../lib/shortcuts';
+import { kbdSizeClass, ShortcutKbd } from './shortcut-kbd';
 
 // Mirrors the Wire spec's `.hz-btn`: neutral `primary` (inverse), red `accent`
 // CTA, quiet `secondary`/`ghost`/`outline`, and `danger` variants. Focus shows
@@ -24,19 +27,46 @@ const sizes = {
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 	variant?: keyof typeof variants;
 	size?: keyof typeof sizes;
+	/**
+	 * Keyboard shortcut spec (e.g. `"mod+Enter"`, `"mod+k"`, `"Escape"`). Renders
+	 * an inset keycap chip after the label. Unless `shortcutFire` is false, it
+	 * also registers a guarded document-level binding that clicks the button.
+	 */
+	shortcut?: string;
+	/**
+	 * When false, the chip is shown but the button does NOT self-register the
+	 * key — for shortcuts already owned elsewhere (a global listener, Radix's
+	 * native Escape, a scoped textarea handler). Defaults to true.
+	 */
+	shortcutFire?: boolean;
 }
 
 export function Button({
 	variant = 'primary',
 	size = 'md',
 	className = '',
+	shortcut,
+	shortcutFire = true,
+	children,
 	...props
 }: ButtonProps) {
+	const ref = useRef<HTMLButtonElement>(null);
 	const sizeCls = variant === 'link' ? 'gap-1.5' : sizes[size];
+	const kbdCls = variant === 'link' ? kbdSizeClass.md : kbdSizeClass[size];
+
+	useShortcut(shortcut && shortcutFire ? shortcut : undefined, () => ref.current?.click(), {
+		enabled: !props.disabled,
+	});
+
 	return (
 		<button
+			ref={ref}
+			aria-keyshortcuts={shortcut ? ariaKeyshortcuts(shortcut, isMacPlatform()) : undefined}
 			className={`inline-flex items-center justify-center whitespace-nowrap border font-medium transition-colors cursor-pointer outline-none focus-visible:ring-[3px] focus-visible:ring-ring focus-visible:border-accent disabled:opacity-45 disabled:pointer-events-none ${variants[variant]} ${sizeCls} ${className}`}
 			{...props}
-		/>
+		>
+			{children}
+			{shortcut && <ShortcutKbd shortcut={shortcut} sizeClassName={kbdCls} />}
+		</button>
 	);
 }

--- a/packages/web/src/components/ui/confirm-dialog.tsx
+++ b/packages/web/src/components/ui/confirm-dialog.tsx
@@ -1,7 +1,9 @@
 import * as AlertDialog from '@radix-ui/react-alert-dialog';
 import { Loader2, X } from 'lucide-react';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
+import { useShortcut } from '../../hooks/use-shortcut';
 import { dialogContentClassName, dialogOverlayClassName } from './dialog';
+import { kbdSizeClass, ShortcutKbd } from './shortcut-kbd';
 
 interface ConfirmDialogProps {
 	open: boolean;
@@ -33,6 +35,12 @@ export function ConfirmDialog({
 }: ConfirmDialogProps) {
 	const [internalLoading, setInternalLoading] = useState(false);
 	const loading = externalLoading ?? internalLoading;
+	const actionRef = useRef<HTMLButtonElement>(null);
+
+	// ⌘/Ctrl+Enter confirms; Escape is handled natively by AlertDialog (the Esc
+	// chip on Cancel is display-only). Gated on `open` since ConfirmDialog stays
+	// mounted while closed.
+	useShortcut('mod+Enter', () => actionRef.current?.click(), { enabled: open && !loading });
 
 	async function handleConfirm(e: React.MouseEvent) {
 		e.preventDefault();
@@ -70,11 +78,14 @@ export function ConfirmDialog({
 					<div className="flex justify-end gap-2">
 						<AlertDialog.Cancel
 							disabled={loading}
+							aria-keyshortcuts="Escape"
 							className="inline-flex items-center justify-center gap-2 font-medium transition-colors disabled:opacity-50 disabled:pointer-events-none cursor-pointer bg-surface-2 text-text-2 border border-border hover:text-text-1 hover:bg-surface-3 px-2.5 py-1 text-xs rounded-md"
 						>
 							{cancelLabel}
+							<ShortcutKbd shortcut="Escape" sizeClassName={kbdSizeClass.sm} />
 						</AlertDialog.Cancel>
 						<AlertDialog.Action
+							ref={actionRef}
 							data-testid="confirm-dialog-confirm"
 							disabled={loading}
 							onClick={handleConfirm}
@@ -82,6 +93,7 @@ export function ConfirmDialog({
 						>
 							{loading && <Loader2 className="w-3 h-3 animate-spin" />}
 							{confirmLabel}
+							<ShortcutKbd shortcut="mod+Enter" sizeClassName={kbdSizeClass.sm} />
 						</AlertDialog.Action>
 					</div>
 				</AlertDialog.Content>

--- a/packages/web/src/components/ui/shortcut-kbd.tsx
+++ b/packages/web/src/components/ui/shortcut-kbd.tsx
@@ -1,0 +1,36 @@
+import { formatShortcut, isMacPlatform } from '../../lib/shortcuts';
+
+// The inset shortcut keycap shared by <Button shortcut> and any surface that
+// renders its own controls (e.g. ConfirmDialog's AlertDialog buttons). Its
+// color derives from the parent's text (`currentColor`), so one treatment
+// adapts to every button variant — light on the dark/red grounds, a soft tint
+// on the quiet ones. Sized just under the label via `sizeClassName`.
+const KBD_STYLE = {
+	backgroundColor: 'color-mix(in oklab, currentColor 15%, transparent)',
+	borderColor: 'color-mix(in oklab, currentColor 22%, transparent)',
+} as const;
+
+export const kbdSizeClass = {
+	sm: 'text-[10px] px-1 py-px -mr-0.5',
+	md: 'text-[11px] px-1.5 py-0.5 -mr-0.5',
+	lg: 'text-[11.5px] px-1.5 py-0.5 -mr-1',
+} as const;
+
+export function ShortcutKbd({
+	shortcut,
+	sizeClassName = kbdSizeClass.md,
+}: {
+	shortcut: string;
+	sizeClassName?: string;
+}) {
+	return (
+		// biome-ignore lint/a11y/noAriaHiddenOnFocusable: a <kbd> is not focusable; the shortcut is exposed to assistive tech via aria-keyshortcuts on the owning button, and hiding the visual keycap avoids a duplicate, oddly-verbalized accessible name.
+		<kbd
+			aria-hidden="true"
+			style={KBD_STYLE}
+			className={`inline-flex items-center justify-center rounded-[4px] border font-mono font-medium leading-none tracking-tight ${sizeClassName}`}
+		>
+			{formatShortcut(shortcut, isMacPlatform())}
+		</kbd>
+	);
+}

--- a/packages/web/src/hooks/use-shortcut.ts
+++ b/packages/web/src/hooks/use-shortcut.ts
@@ -1,0 +1,55 @@
+import { useEffect, useRef } from 'react';
+import {
+	isEditableTarget,
+	isMacPlatform,
+	matchesShortcut,
+	parseShortcut,
+	shortcutBypassesInput,
+} from '../lib/shortcuts';
+
+interface UseShortcutOptions {
+	/** When false, the listener is not registered (e.g. a disabled button). */
+	enabled?: boolean;
+}
+
+/**
+ * Register a document-level keydown that invokes `handler` when `spec` matches.
+ *
+ * Guards, so a shortcut never fires when it shouldn't:
+ *  - IME composition in progress → ignored.
+ *  - A modifier-less shortcut (bare letter) while a text field is focused →
+ *    ignored, so typing never triggers a button. Modifier shortcuts (⌘/Ctrl…)
+ *    still fire inside inputs, which is what "⌘⏎ to submit" needs.
+ *  - Already handled (`defaultPrevented`) → ignored, so we never double-fire
+ *    behind another handler that already claimed the key.
+ *
+ * `handler` is read through a ref, so a changing closure doesn't re-bind the
+ * listener; only `spec`/`enabled` do.
+ */
+export function useShortcut(
+	spec: string | undefined,
+	handler: () => void,
+	{ enabled = true }: UseShortcutOptions = {},
+): void {
+	const handlerRef = useRef(handler);
+	handlerRef.current = handler;
+
+	useEffect(() => {
+		if (!spec || !enabled) return;
+		const parsed = parseShortcut(spec);
+		if (!parsed.key) return;
+		const isMac = isMacPlatform();
+		const bypassesInput = shortcutBypassesInput(parsed);
+
+		const onKeyDown = (event: KeyboardEvent) => {
+			if (event.isComposing || event.defaultPrevented) return;
+			if (!bypassesInput && isEditableTarget(event.target)) return;
+			if (!matchesShortcut(spec, event, isMac)) return;
+			event.preventDefault();
+			handlerRef.current();
+		};
+
+		document.addEventListener('keydown', onKeyDown);
+		return () => document.removeEventListener('keydown', onKeyDown);
+	}, [spec, enabled]);
+}

--- a/packages/web/src/lib/shortcuts.ts
+++ b/packages/web/src/lib/shortcuts.ts
@@ -1,0 +1,202 @@
+// Keyboard-shortcut parsing, platform-aware display, and event matching for the
+// `shortcut` prop on <Button>. Kept pure (the only impurity, isMacPlatform, is
+// isolated) so parse/format/match are unit-testable with an explicit `isMac`.
+//
+// Spec grammar: modifier tokens joined by `+`, then a key token, e.g.
+//   "mod+Enter", "mod+k", "Escape", "mod+Shift+Enter", "shift+ArrowUp".
+// `mod` is the platform-primary modifier — ⌘ (Meta) on macOS, Ctrl elsewhere.
+
+export interface ParsedShortcut {
+	/** Platform-primary modifier (Meta on mac, Ctrl elsewhere). */
+	mod: boolean;
+	ctrl: boolean;
+	meta: boolean;
+	alt: boolean;
+	shift: boolean;
+	/** Non-modifier key, normalized (e.g. "Enter", "Escape", "ArrowUp", "k"). */
+	key: string;
+}
+
+const MODIFIER_TOKENS: Record<string, keyof Omit<ParsedShortcut, 'key'>> = {
+	mod: 'mod',
+	cmd: 'meta',
+	command: 'meta',
+	meta: 'meta',
+	super: 'meta',
+	win: 'meta',
+	ctrl: 'ctrl',
+	control: 'ctrl',
+	alt: 'alt',
+	opt: 'alt',
+	option: 'alt',
+	shift: 'shift',
+};
+
+// Normalize a key token to the canonical `KeyboardEvent.key` value we compare
+// against. Single characters stay as-is (matched case-insensitively later).
+const KEY_ALIASES: Record<string, string> = {
+	enter: 'Enter',
+	return: 'Enter',
+	esc: 'Escape',
+	escape: 'Escape',
+	space: ' ',
+	spacebar: ' ',
+	tab: 'Tab',
+	backspace: 'Backspace',
+	del: 'Delete',
+	delete: 'Delete',
+	up: 'ArrowUp',
+	down: 'ArrowDown',
+	left: 'ArrowLeft',
+	right: 'ArrowRight',
+	arrowup: 'ArrowUp',
+	arrowdown: 'ArrowDown',
+	arrowleft: 'ArrowLeft',
+	arrowright: 'ArrowRight',
+};
+
+function normalizeKey(token: string): string {
+	const lower = token.toLowerCase();
+	if (KEY_ALIASES[lower]) return KEY_ALIASES[lower];
+	// Otherwise keep the raw token (single letters compared case-insensitively later).
+	return token;
+}
+
+export function parseShortcut(spec: string): ParsedShortcut {
+	const parsed: ParsedShortcut = {
+		mod: false,
+		ctrl: false,
+		meta: false,
+		alt: false,
+		shift: false,
+		key: '',
+	};
+	const tokens = spec
+		.split('+')
+		.map((t) => t.trim())
+		.filter(Boolean);
+	for (const token of tokens) {
+		const mod = MODIFIER_TOKENS[token.toLowerCase()];
+		if (mod) {
+			parsed[mod] = true;
+		} else {
+			parsed.key = normalizeKey(token);
+		}
+	}
+	return parsed;
+}
+
+/**
+ * True when the shortcut is safe to fire even while a text field is focused —
+ * i.e. it carries a non-Shift modifier (⌘/Ctrl/Alt). Shift is excluded on
+ * purpose: `shift+ArrowUp` inside an input means "extend selection", so a
+ * Shift-only spec is treated like a bare key and suppressed while typing.
+ */
+export function shortcutBypassesInput(parsed: ParsedShortcut): boolean {
+	return parsed.mod || parsed.ctrl || parsed.meta || parsed.alt;
+}
+
+let cachedIsMac: boolean | undefined;
+
+/** True on macOS / iPadOS, where `mod` renders as ⌘ and matches the Meta key. */
+export function isMacPlatform(): boolean {
+	if (cachedIsMac !== undefined) return cachedIsMac;
+	if (typeof navigator === 'undefined') {
+		cachedIsMac = false;
+		return cachedIsMac;
+	}
+	const platform = navigator.platform || '';
+	const ua = navigator.userAgent || '';
+	cachedIsMac = /Mac|iPhone|iPad|iPod/i.test(platform) || /Mac OS X/i.test(ua);
+	return cachedIsMac;
+}
+
+// Display glyphs. On mac we use the standard symbol keycaps; elsewhere modifiers
+// read as words (Ctrl/Alt/Shift) while non-letter keys keep their universal glyph.
+const KEY_GLYPHS: Record<string, string> = {
+	Enter: '⏎',
+	Escape: 'Esc',
+	Backspace: '⌫',
+	Delete: '⌦',
+	ArrowUp: '↑',
+	ArrowDown: '↓',
+	ArrowLeft: '←',
+	ArrowRight: '→',
+	Tab: '⇥',
+	' ': 'Space',
+};
+
+function displayKey(key: string): string {
+	if (KEY_GLYPHS[key]) return KEY_GLYPHS[key];
+	return key.length === 1 ? key.toUpperCase() : key;
+}
+
+/**
+ * Render a spec as a compact label for the keycap chip. macOS gets tight symbol
+ * concatenation in canonical order (⌃⌥⇧⌘key); other platforms get `+`-joined
+ * words (Ctrl+Shift+Enter → written with the key glyph, e.g. "Ctrl+⏎").
+ */
+export function formatShortcut(spec: string, isMac: boolean): string {
+	const p = parseShortcut(spec);
+	const key = displayKey(p.key);
+	if (isMac) {
+		const parts: string[] = [];
+		if (p.ctrl) parts.push('⌃');
+		if (p.alt) parts.push('⌥');
+		if (p.shift) parts.push('⇧');
+		if (p.meta || p.mod) parts.push('⌘');
+		return parts.join('') + key;
+	}
+	const parts: string[] = [];
+	if (p.mod || p.ctrl) parts.push('Ctrl');
+	if (p.alt) parts.push('Alt');
+	if (p.shift) parts.push('Shift');
+	parts.push(key);
+	return parts.join('+');
+}
+
+/** ARIA `aria-keyshortcuts` value (space-free, platform-independent tokens). */
+export function ariaKeyshortcuts(spec: string, isMac: boolean): string {
+	const p = parseShortcut(spec);
+	const parts: string[] = [];
+	if (p.meta || (p.mod && isMac)) parts.push('Meta');
+	if (p.ctrl || (p.mod && !isMac)) parts.push('Control');
+	if (p.alt) parts.push('Alt');
+	if (p.shift) parts.push('Shift');
+	parts.push(p.key.length === 1 ? p.key.toUpperCase() : p.key);
+	return parts.join('+');
+}
+
+interface KeyEventLike {
+	key: string;
+	metaKey: boolean;
+	ctrlKey: boolean;
+	altKey: boolean;
+	shiftKey: boolean;
+}
+
+/** True when `event` satisfies every modifier + key requirement of `spec`. */
+export function matchesShortcut(spec: string, event: KeyEventLike, isMac: boolean): boolean {
+	const p = parseShortcut(spec);
+	const wantMeta = p.meta || (p.mod && isMac);
+	const wantCtrl = p.ctrl || (p.mod && !isMac);
+	if (event.metaKey !== wantMeta) return false;
+	if (event.ctrlKey !== wantCtrl) return false;
+	if (event.altKey !== p.alt) return false;
+	if (event.shiftKey !== p.shift) return false;
+	// Single-char keys compare case-insensitively (Shift already checked above).
+	if (p.key.length === 1) return event.key.toLowerCase() === p.key.toLowerCase();
+	return event.key === p.key;
+}
+
+/**
+ * True when the event target is a text-entry surface. Modifier-less shortcuts
+ * (a bare letter) are suppressed here so typing never triggers a button.
+ */
+export function isEditableTarget(target: EventTarget | null): boolean {
+	if (!(target instanceof HTMLElement)) return false;
+	const tag = target.tagName;
+	if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+	if (target.isContentEditable) return true;
+	return target.getAttribute('role') === 'textbox';
+}

--- a/packages/web/test/button-shortcut.test.tsx
+++ b/packages/web/test/button-shortcut.test.tsx
@@ -1,0 +1,93 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+import { Button } from '../src/components/ui/button';
+
+// Standalone leaf-component test — no app context needed. Verifies the keycap
+// chip renders and that the guarded document-level auto-fire clicks the button.
+// Platform-independent specs only (Escape, a bare letter) so it never branches
+// on the CI host being mac vs linux.
+
+describe('Button shortcut chip', () => {
+	test('renders the keycap and sets aria-keyshortcuts', () => {
+		render(<Button shortcut="mod+Enter">Create</Button>);
+		const btn = screen.getByRole('button', { name: /Create/ });
+		// The Enter glyph is the same on every platform.
+		const kbd = btn.querySelector('kbd');
+		expect(kbd?.textContent).toContain('⏎');
+		expect(btn.getAttribute('aria-keyshortcuts')).toMatch(/^(Meta|Control)\+Enter$/);
+	});
+
+	test('no chip and no aria when shortcut is absent', () => {
+		render(<Button>Plain</Button>);
+		const btn = screen.getByRole('button', { name: 'Plain' });
+		expect(btn.querySelector('kbd')).toBeNull();
+		expect(btn.getAttribute('aria-keyshortcuts')).toBeNull();
+	});
+
+	test('auto-fires onClick when the shortcut is pressed', () => {
+		const onClick = vi.fn();
+		render(
+			<Button shortcut="Escape" onClick={onClick}>
+				Close
+			</Button>,
+		);
+		fireEvent.keyDown(document, { key: 'Escape' });
+		expect(onClick).toHaveBeenCalledTimes(1);
+	});
+
+	test('a modifier-less shortcut is suppressed while a text field is focused', () => {
+		const onClick = vi.fn();
+		render(
+			<>
+				<input aria-label="field" />
+				<Button shortcut="r" onClick={onClick}>
+					Reply
+				</Button>
+			</>,
+		);
+		const input = screen.getByLabelText('field');
+		// Fired from within the input → suppressed.
+		fireEvent.keyDown(input, { key: 'r' });
+		expect(onClick).not.toHaveBeenCalled();
+		// Fired from outside any field → allowed.
+		fireEvent.keyDown(document.body, { key: 'r' });
+		expect(onClick).toHaveBeenCalledTimes(1);
+	});
+
+	test('a disabled button does not fire its shortcut', () => {
+		const onClick = vi.fn();
+		render(
+			<Button shortcut="Escape" onClick={onClick} disabled>
+				Close
+			</Button>,
+		);
+		fireEvent.keyDown(document, { key: 'Escape' });
+		expect(onClick).not.toHaveBeenCalled();
+	});
+
+	test('shortcutFire={false} shows the chip but does not auto-fire', () => {
+		const onClick = vi.fn();
+		render(
+			<Button shortcut="mod+k" shortcutFire={false} onClick={onClick}>
+				Search
+			</Button>,
+		);
+		expect(screen.getByRole('button', { name: /Search/ }).querySelector('kbd')).not.toBeNull();
+		fireEvent.keyDown(document, { key: 'k', metaKey: true });
+		fireEvent.keyDown(document, { key: 'k', ctrlKey: true });
+		expect(onClick).not.toHaveBeenCalled();
+	});
+
+	test('does not fire when another handler already prevented the event', () => {
+		const onClick = vi.fn();
+		render(
+			<Button shortcut="Escape" onClick={onClick}>
+				Close
+			</Button>,
+		);
+		const evt = new KeyboardEvent('keydown', { key: 'Escape', cancelable: true, bubbles: true });
+		evt.preventDefault();
+		document.dispatchEvent(evt);
+		expect(onClick).not.toHaveBeenCalled();
+	});
+});

--- a/packages/web/test/confirm-dialog-shortcut.test.tsx
+++ b/packages/web/test/confirm-dialog-shortcut.test.tsx
@@ -1,0 +1,38 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { expect, test, vi } from 'vitest';
+import { ConfirmDialog } from '../src/components/ui/confirm-dialog';
+import { isMacPlatform } from '../src/lib/shortcuts';
+
+// The ConfirmDialog hand-rolls its AlertDialog buttons (not <Button>), so it
+// wires the keycap + auto-fire itself. Verify both keycaps render and that
+// ⌘/Ctrl+Enter triggers the confirm action.
+test('ConfirmDialog shows keycaps and confirms on mod+Enter', () => {
+	const onConfirm = vi.fn();
+	render(
+		<ConfirmDialog
+			open
+			onOpenChange={() => {}}
+			title="Delete project?"
+			confirmLabel="Delete"
+			onConfirm={onConfirm}
+		/>,
+	);
+	const confirm = screen.getByTestId('confirm-dialog-confirm');
+	expect(confirm.querySelector('kbd')).not.toBeNull();
+	// The Escape keycap sits on the Cancel button (display-only; AlertDialog owns Esc).
+	expect(screen.getByRole('button', { name: /Cancel/ }).querySelector('kbd')).not.toBeNull();
+
+	const mac = isMacPlatform();
+	fireEvent.keyDown(document, { key: 'Enter', metaKey: mac, ctrlKey: !mac });
+	expect(onConfirm).toHaveBeenCalledTimes(1);
+});
+
+test('ConfirmDialog does not fire while loading', () => {
+	const onConfirm = vi.fn();
+	render(
+		<ConfirmDialog open onOpenChange={() => {}} title="Working…" onConfirm={onConfirm} loading />,
+	);
+	const mac = isMacPlatform();
+	fireEvent.keyDown(document, { key: 'Enter', metaKey: mac, ctrlKey: !mac });
+	expect(onConfirm).not.toHaveBeenCalled();
+});

--- a/packages/web/test/shortcuts.test.ts
+++ b/packages/web/test/shortcuts.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from 'vitest';
+import {
+	ariaKeyshortcuts,
+	formatShortcut,
+	isEditableTarget,
+	matchesShortcut,
+	parseShortcut,
+	shortcutBypassesInput,
+} from '../src/lib/shortcuts';
+
+describe('parseShortcut', () => {
+	test('parses mod + key', () => {
+		expect(parseShortcut('mod+Enter')).toEqual({
+			mod: true,
+			ctrl: false,
+			meta: false,
+			alt: false,
+			shift: false,
+			key: 'Enter',
+		});
+	});
+
+	test('is case-insensitive on modifier tokens and tolerant of spaces', () => {
+		expect(parseShortcut(' Mod + Shift + K ')).toMatchObject({ mod: true, shift: true, key: 'K' });
+	});
+
+	test('normalizes key aliases', () => {
+		expect(parseShortcut('esc').key).toBe('Escape');
+		expect(parseShortcut('mod+up').key).toBe('ArrowUp');
+		expect(parseShortcut('return').key).toBe('Enter');
+		expect(parseShortcut('del').key).toBe('Delete');
+	});
+
+	test('maps every modifier alias', () => {
+		expect(parseShortcut('cmd+k')).toMatchObject({ meta: true });
+		expect(parseShortcut('control+k')).toMatchObject({ ctrl: true });
+		expect(parseShortcut('option+k')).toMatchObject({ alt: true });
+	});
+});
+
+describe('shortcutBypassesInput', () => {
+	test('true only for a non-Shift modifier; Shift-only and bare keys stay guarded', () => {
+		expect(shortcutBypassesInput(parseShortcut('mod+Enter'))).toBe(true);
+		expect(shortcutBypassesInput(parseShortcut('alt+k'))).toBe(true);
+		// Shift alone does not bypass — shift+ArrowUp means "extend selection" in a field.
+		expect(shortcutBypassesInput(parseShortcut('shift+ArrowUp'))).toBe(false);
+		expect(shortcutBypassesInput(parseShortcut('r'))).toBe(false);
+		expect(shortcutBypassesInput(parseShortcut('Escape'))).toBe(false);
+	});
+});
+
+describe('formatShortcut', () => {
+	test('mac uses tight symbol keycaps in canonical order', () => {
+		expect(formatShortcut('mod+Enter', true)).toBe('⌘⏎');
+		expect(formatShortcut('mod+Shift+k', true)).toBe('⇧⌘K');
+		expect(formatShortcut('mod+k', true)).toBe('⌘K');
+		expect(formatShortcut('Escape', true)).toBe('Esc');
+	});
+
+	test('non-mac uses Ctrl/Alt/Shift words joined with +', () => {
+		expect(formatShortcut('mod+Enter', false)).toBe('Ctrl+⏎');
+		expect(formatShortcut('mod+Shift+k', false)).toBe('Ctrl+Shift+K');
+		expect(formatShortcut('Escape', false)).toBe('Esc');
+	});
+
+	test('renders arrow and delete glyphs', () => {
+		expect(formatShortcut('mod+up', true)).toBe('⌘↑');
+		expect(formatShortcut('Backspace', true)).toBe('⌫');
+	});
+});
+
+describe('ariaKeyshortcuts', () => {
+	test('resolves mod per platform to Meta / Control', () => {
+		expect(ariaKeyshortcuts('mod+Enter', true)).toBe('Meta+Enter');
+		expect(ariaKeyshortcuts('mod+Enter', false)).toBe('Control+Enter');
+		expect(ariaKeyshortcuts('mod+Shift+k', false)).toBe('Control+Shift+K');
+	});
+});
+
+describe('matchesShortcut', () => {
+	const base = { key: 'Enter', metaKey: false, ctrlKey: false, altKey: false, shiftKey: false };
+
+	test('mod resolves to Meta on mac, Ctrl elsewhere', () => {
+		expect(matchesShortcut('mod+Enter', { ...base, metaKey: true }, true)).toBe(true);
+		expect(matchesShortcut('mod+Enter', { ...base, ctrlKey: true }, true)).toBe(false);
+		expect(matchesShortcut('mod+Enter', { ...base, ctrlKey: true }, false)).toBe(true);
+		expect(matchesShortcut('mod+Enter', { ...base, metaKey: true }, false)).toBe(false);
+	});
+
+	test('requires an exact modifier set (extra modifier does not match)', () => {
+		expect(matchesShortcut('mod+Enter', { ...base, metaKey: true, shiftKey: true }, true)).toBe(
+			false,
+		);
+	});
+
+	test('single-char keys match case-insensitively', () => {
+		expect(matchesShortcut('mod+k', { ...base, key: 'k', metaKey: true }, true)).toBe(true);
+		expect(matchesShortcut('mod+k', { ...base, key: 'K', metaKey: true }, true)).toBe(true);
+	});
+
+	test('does not match a different key', () => {
+		expect(matchesShortcut('Escape', { ...base, key: 'Enter' }, true)).toBe(false);
+		expect(matchesShortcut('Escape', { ...base, key: 'Escape' }, true)).toBe(true);
+	});
+});
+
+describe('isEditableTarget', () => {
+	test('true for text-entry surfaces', () => {
+		expect(isEditableTarget(document.createElement('input'))).toBe(true);
+		expect(isEditableTarget(document.createElement('textarea'))).toBe(true);
+		expect(isEditableTarget(document.createElement('select'))).toBe(true);
+		const editable = document.createElement('div');
+		editable.setAttribute('role', 'textbox');
+		expect(isEditableTarget(editable)).toBe(true);
+	});
+
+	test('false for a plain element or null', () => {
+		expect(isEditableTarget(document.createElement('div'))).toBe(false);
+		expect(isEditableTarget(null)).toBe(false);
+	});
+});


### PR DESCRIPTION
## What & why

Buttons that have a keyboard shortcut now **display it** as a small inset keycap suffixed after the label (smaller mono font than the label), and the shortcut actually **fires** the button. Requested: "show keyboard shortcuts on buttons which they apply to — the shortcut should be a suffix to button text and show as a small button (within the larger button) showing the shortcut with smaller font than button text font."

Visual spec (shipped **Option A — inset**, chosen from two treatments): the mockup is rendered with the real Wire tokens and exact `Button` geometry.

## How it works

`<Button shortcut="mod+Enter">` renders the keycap and — unless `shortcutFire={false}` — registers a guarded document-level binding that clicks the button (**display + auto-fire**). The keycap derives its color from the button's own text via `currentColor`, so a single treatment adapts to every variant: light on the dark/red grounds, a soft tint on the quiet ones.

New pieces:
- `lib/shortcuts.ts` — pure parse / platform-aware format (`⌘` vs `Ctrl`) / event matching / guards.
- `hooks/use-shortcut.ts` — guarded document `keydown`: skips when the button is disabled, mid-IME-composition, already `defaultPrevented` (no double-fire), or when a modifier-less key is pressed inside a text field (so typing never triggers a button; `⌘/Ctrl…` still fire inside inputs, which is what "⌘⏎ to submit" needs).
- `ui/shortcut-kbd.tsx` — the shared keycap, reused by the hand-rolled `ConfirmDialog` buttons.

### Accessibility
`aria-keyshortcuts` on the button, `aria-hidden` on the keycap. That keeps the accessible name unchanged, so existing `getByRole(name, { exact: true })` and `data-testid` selectors keep matching.

## Swept surfaces
- create-task / create-goal / create-project / repo-picker — `⌘⏎` submit, `Esc` cancel.
- the app-wide **`ConfirmDialog`** — `⌘⏎` confirm, `Esc` (so every delete/confirm across the app shows its shortcut).
- comment composer + document-review editor — **display-only** chips, keeping their existing scoped `Cmd+Enter` handlers so there is no double-fire.
- master-key gate — `⏎`.

**Intentionally left alone:** icon-only buttons (the header search keeps its global `⌘K` + tooltip) and multi-form settings pages / the shared `provider-config-form`, to avoid a mismatched pattern or `mod+Enter` ambiguity.

## Tests
- `shortcuts.test.ts` — parse / format / match / guards, mac + non-mac.
- `button-shortcut.test.tsx` — chip render, auto-fire, editable-target + disabled + `defaultPrevented` guards, `shortcutFire={false}`.
- `confirm-dialog-shortcut.test.tsx` — in-context auto-fire + loading guard.

Verified green: typecheck, biome, and the affected web component tests (including the comment composer's `Cmd/Ctrl+Enter` test and the swept dialogs). A `Button` with no `shortcut` prop renders byte-identically to before, so untouched buttons are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XtT1zeNZ3wmmknYG81gYuh

---
_Generated by [Claude Code](https://claude.ai/code/session_01XtT1zeNZ3wmmknYG81gYuh)_