### PR TITLE
fix(runs): actually kill the agent process on terminate/timeout

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -964,6 +964,17 @@ may hold — and `discard_local`/`prune_worktrees` additionally require a runnin
 read and reset runs under the same per-project git lock (`withProjectGitLock`, extracted to
 `lib/git-lock.ts`) as run-time worktree prep, so they never interleave on the shared `.git`.
 
+**Aborting actually kills the process.** Docker exposes no API to signal an exec'd process, and
+disconnecting from the exec attach stream (what aborting the run's signal does) leaves the agent
+CLI **running** inside the container — it would keep burning tokens and writing to the workspace
+even though the run reads as cancelled. So on any abort where the container is still alive (a user
+terminate, a timeout — *not* `container_*`, where the process died with the container), the runner
+hard-kills the run's whole process tree: `DockerClient.killRunProcesses` execs a `/proc` scan (as
+root, so it can signal the deprivileged run-user) that `kill -9`s every process whose environment
+carries the run's `HEZO_HEARTBEAT_RUN_ID` marker (children inherit it). Best-effort and bounded by
+its own short timeout, so a kill failure never masks the run result or blocks finalization. This is
+what makes a terminate immediate — in-progress work is lost, as the confirmation dialog promises.
+
 **Timeout handling (graceful cut).** The `run_timeout_min` timer aborts the run's signal with a
 tagged `'run_timeout'` reason (`JobManager.launchTask`), so the runner finalizes it as `timed_out`
 — distinct from a bare abort (user cancel / shutdown → `cancelled`) and container death

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -1536,6 +1536,24 @@ export async function runAgent(
 			const errorMessage = abortErrorMessage(reason) ?? (error as Error).message;
 			const status = isAbort ? abortedRunStatus(reason) : HeartbeatRunStatus.Failed;
 
+			// Aborting the exec only tears down its attach stream — Docker leaves the
+			// agent CLI running in the container, so a user-terminated or timed-out run
+			// keeps burning tokens and writing to the workspace despite reading as
+			// cancelled. Hard-kill the run's whole process tree so the abort is what the
+			// UI promises: immediate, with in-progress work lost. Skipped when the
+			// container itself died (`container_*`) — the process is already gone with
+			// it — and best-effort so a kill failure never masks the run result.
+			if (isAbort && reason !== 'container_stopped' && reason !== 'container_error') {
+				try {
+					await deps.docker.killRunProcesses(project.container_id, heartbeatRunId);
+				} catch (killError) {
+					log.error(
+						`Run ${heartbeatRunId}: failed to kill container processes on abort:`,
+						killError,
+					);
+				}
+			}
+
 			emit('stderr', `\n[runner] ${errorMessage}\n`);
 
 			await deps.logs.end(streamId);

--- a/packages/server/src/services/docker.ts
+++ b/packages/server/src/services/docker.ts
@@ -18,6 +18,13 @@ const DOCKER_REQUEST_TIMEOUT_MS = (() => {
 	return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_DOCKER_REQUEST_TIMEOUT_MS;
 })();
 
+/**
+ * Upper bound on the run-process kill exec (`killRunProcesses`). The kill loop
+ * scans `/proc` once and returns in well under a second; this ceiling only
+ * guards against a wedged daemon so an abort's cleanup can never hang.
+ */
+const KILL_EXEC_TIMEOUT_MS = 5_000;
+
 interface ContainerConfig {
 	Image: string;
 	Cmd?: string[];
@@ -486,6 +493,48 @@ export class DockerClient {
 			throw new Error(`Docker execInspect failed (${res.status}): ${text}`);
 		}
 		return parseJsonOrThrow(res, 'execInspect');
+	}
+
+	/**
+	 * Hard-kill every process inside `containerId` whose environment carries
+	 * `HEZO_HEARTBEAT_RUN_ID=<runId>` — the marker every agent-run exec sets and
+	 * all its children inherit. Docker exposes no API to signal an exec'd process,
+	 * and disconnecting from the exec attach stream (what an abort does) leaves it
+	 * running: the agent CLI keeps burning tokens and writing to the workspace
+	 * even though the run is marked cancelled. This is the only way to actually
+	 * stop a terminated or timed-out run's process tree.
+	 *
+	 * The kill exec runs as the container's default user (root — no `User`), so it
+	 * can signal the deprivileged run-user's processes, and scans each process's
+	 * NUL-separated `/proc/<pid>/environ` for the marker. Bounded by its own short
+	 * timeout so a wedged kill can never block run finalization. Best-effort: the
+	 * caller swallows failures (a dead/gone container simply can't be exec'd).
+	 */
+	async killRunProcesses(containerId: string, runId: string): Promise<void> {
+		// runId is a DB UUID (`[0-9a-f-]`), so it needs no shell escaping inside the
+		// double-quoted grep pattern below — no metacharacters, word-splitting, or
+		// expansion is possible.
+		const marker = `HEZO_HEARTBEAT_RUN_ID=${runId}`;
+		// `/proc/<pid>/environ` is NUL-separated; `basename $(dirname …)` recovers the
+		// pid without relying on `${…}` shell parameter expansion (a JS-template
+		// look-alike). `|| true` keeps a since-exited pid from failing the loop.
+		const script =
+			'for e in /proc/[0-9]*/environ; do ' +
+			`grep -qFz "${marker}" "$e" 2>/dev/null || continue; ` +
+			'kill -9 "$(basename "$(dirname "$e")")" 2>/dev/null || true; ' +
+			'done';
+		const execId = await this.execCreate(containerId, {
+			Cmd: ['sh', '-c', script],
+			AttachStdout: false,
+			AttachStderr: false,
+		});
+		const ac = new AbortController();
+		const timer = setTimeout(() => ac.abort(), KILL_EXEC_TIMEOUT_MS);
+		try {
+			await this.execStart(execId, { signal: ac.signal });
+		} finally {
+			clearTimeout(timer);
+		}
 	}
 }
 

--- a/packages/server/src/services/fake-docker.ts
+++ b/packages/server/src/services/fake-docker.ts
@@ -101,6 +101,7 @@ export function createFakeDockerClient(db?: Db): DockerClient {
 			return result;
 		},
 		execInspect: async () => ({ ExitCode: 0, Running: false, Pid: 0 }),
+		killRunProcesses: async () => {},
 	};
 	return stub as unknown as DockerClient;
 }

--- a/packages/server/test/agent-runner-extended.test.ts
+++ b/packages/server/test/agent-runner-extended.test.ts
@@ -80,6 +80,7 @@ function createMockDocker(taskId: string, overrides: Record<string, any> = {}): 
 		containerLogs: async () => new ReadableStream(),
 		execCreate: async () => 'exec-123',
 		execInspect: async () => ({ ExitCode: 0, Running: false, Pid: 0 }),
+		killRunProcesses: async () => {},
 		...rest,
 		execStart: async (...args: unknown[]) => {
 			if (producesOutput) {

--- a/packages/server/test/agent-runner-handoff-delivery.test.ts
+++ b/packages/server/test/agent-runner-handoff-delivery.test.ts
@@ -114,6 +114,7 @@ function createMockDocker(overrides: Record<string, unknown> = {}): DockerClient
 		containerLogs: async () => new ReadableStream(),
 		execCreate: async () => 'exec-123',
 		execInspect: execInspect ?? (async () => ({ ExitCode: 0, Running: false, Pid: 0 })),
+		killRunProcesses: async () => {},
 		...rest,
 		execStart: async (...args: unknown[]) => {
 			if (producesOutput) {

--- a/packages/server/test/agent-runner.test.ts
+++ b/packages/server/test/agent-runner.test.ts
@@ -148,6 +148,7 @@ function createMockDocker(overrides: Record<string, any> = {}): DockerClient {
 		containerLogs: async () => new ReadableStream(),
 		execCreate: async () => 'exec-123',
 		execInspect: async () => ({ ExitCode: 0, Running: false, Pid: 0 }),
+		killRunProcesses: async () => {},
 		...rest,
 		execStart: async (...args: unknown[]) => {
 			if (producesOutput) {
@@ -1054,6 +1055,115 @@ describe('runAgent', () => {
 		);
 		expect(run.rows[0].status).toBe('failed');
 		expect(run.rows[0].error).toBe('container_error');
+	});
+
+	// Aborting a run only disconnects from the exec attach stream; Docker leaves the
+	// agent CLI running inside the container. The runner must hard-kill the run's
+	// process tree (keyed by the HEZO_HEARTBEAT_RUN_ID env marker) so a terminate is
+	// actually immediate rather than leaving the agent working in the background.
+	it('hard-kills the container process tree when a run is terminated mid-execution', async () => {
+		const ac = new AbortController();
+		const killed: Array<{ containerId: string; runId: string }> = [];
+		const docker = createMockDocker({
+			execCreate: async () => {
+				ac.abort();
+				throw new DOMException('Aborted', 'AbortError');
+			},
+			killRunProcesses: async (containerId: string, runId: string) => {
+				killed.push({ containerId, runId });
+			},
+		});
+		const deps: RunnerDeps = {
+			db,
+			docker,
+			masterKeyManager,
+			serverPort: 3000,
+			dataDir: '/tmp/test-data',
+			logs: new LogStreamBroker(),
+		};
+
+		const result = await runAgent(
+			deps,
+			makeAgent(),
+			makeTask(),
+			makeProject(),
+			undefined,
+			ac.signal,
+		);
+
+		expect(result.heartbeatRunId).toBeDefined();
+		expect(killed).toEqual([{ containerId: 'container-123', runId: result.heartbeatRunId }]);
+	});
+
+	it('hard-kills the container process tree when a run times out', async () => {
+		const ac = new AbortController();
+		const killed: string[] = [];
+		const docker = createMockDocker({
+			producesOutput: false,
+			execStart: async () => {
+				ac.abort('run_timeout');
+				throw new DOMException('Aborted', 'AbortError');
+			},
+			killRunProcesses: async (_containerId: string, runId: string) => {
+				killed.push(runId);
+			},
+		});
+		const deps: RunnerDeps = {
+			db,
+			docker,
+			masterKeyManager,
+			serverPort: 3000,
+			dataDir: '/tmp/test-data',
+			logs: new LogStreamBroker(),
+		};
+
+		const result = await runAgent(
+			deps,
+			makeAgent(),
+			makeTask(),
+			makeProject(),
+			undefined,
+			ac.signal,
+		);
+
+		expect(killed).toEqual([result.heartbeatRunId]);
+	});
+
+	// When the container itself died (container_stopped / container_error), the run's
+	// process is already gone with it, so there is nothing to kill — and exec'ing a
+	// dead container would only throw.
+	it('does not attempt a process kill when the container itself died', async () => {
+		const ac = new AbortController();
+		let killCalled = false;
+		const docker = createMockDocker({
+			execCreate: async () => {
+				ac.abort('container_stopped');
+				throw new DOMException('Aborted', 'AbortError');
+			},
+			killRunProcesses: async () => {
+				killCalled = true;
+			},
+		});
+		const deps: RunnerDeps = {
+			db,
+			docker,
+			masterKeyManager,
+			serverPort: 3000,
+			dataDir: '/tmp/test-data',
+			logs: new LogStreamBroker(),
+		};
+
+		const result = await runAgent(
+			deps,
+			makeAgent(),
+			makeTask(),
+			makeProject(),
+			undefined,
+			ac.signal,
+		);
+
+		expect(result.success).toBe(false);
+		expect(killCalled).toBe(false);
 	});
 
 	it('invokes onRunRegistered with the heartbeat run id before exec begins', async () => {

--- a/packages/server/test/dispatch-wakeup-now.test.ts
+++ b/packages/server/test/dispatch-wakeup-now.test.ts
@@ -52,6 +52,7 @@ function createMockDocker(): DockerClient {
 		execCreate: async () => 'exec-123',
 		execStart: async () => ({ stdout: 'done', stderr: '' }),
 		execInspect: async () => ({ ExitCode: 0, Running: false, Pid: 0 }),
+		killRunProcesses: async () => {},
 	} as unknown as DockerClient;
 }
 

--- a/packages/server/test/docker-client-request.test.ts
+++ b/packages/server/test/docker-client-request.test.ts
@@ -442,6 +442,55 @@ describe('exec plumbing', () => {
 	});
 });
 
+describe('killRunProcesses', () => {
+	// Docker exposes no API to signal an exec'd process, so the run-kill is itself an
+	// exec that scans /proc for the run's HEZO_HEARTBEAT_RUN_ID env marker and SIGKILLs
+	// every match. Pin the generated script + exec config so the marker, the /proc
+	// scan, and the SIGKILL can't silently regress. execCreate/execStart are stubbed on
+	// the instance to capture args without any transport.
+	it('execs a root /proc-scan that SIGKILLs every process carrying the run marker', async () => {
+		const docker = client();
+		const created: Array<{ containerId: string; config: Record<string, unknown> }> = [];
+		const started: string[] = [];
+		docker.execCreate = async (containerId, config) => {
+			created.push({ containerId, config: config as unknown as Record<string, unknown> });
+			return 'exec-kill';
+		};
+		docker.execStart = async (execId) => {
+			started.push(execId);
+			return { stdout: '', stderr: '' };
+		};
+
+		await docker.killRunProcesses('cid-1', 'run-abc-123');
+
+		expect(created).toHaveLength(1);
+		expect(created[0].containerId).toBe('cid-1');
+		const cmd = created[0].config.Cmd as string[];
+		expect(cmd[0]).toBe('sh');
+		expect(cmd[1]).toBe('-c');
+		const script = cmd[2];
+		expect(script).toContain('/proc/[0-9]*/environ');
+		expect(script).toContain('HEZO_HEARTBEAT_RUN_ID=run-abc-123');
+		expect(script).toContain('kill -9');
+		// No User field → runs as the container's default user (root), so it can
+		// signal the deprivileged run-user's processes.
+		expect(created[0].config.User).toBeUndefined();
+		expect(created[0].config.AttachStdout).toBe(false);
+		expect(created[0].config.AttachStderr).toBe(false);
+		expect(started).toEqual(['exec-kill']);
+	});
+
+	it('propagates an exec failure to the caller (which treats it as best-effort)', async () => {
+		const docker = client();
+		docker.execCreate = async () => {
+			throw new Error('Docker execCreate failed (409): container not running');
+		};
+		await expect(docker.killRunProcesses('cid-1', 'run-abc-123')).rejects.toThrow(
+			'container not running',
+		);
+	});
+});
+
 describe('execStart demux over the real unix-socket transport', () => {
 	it('concatenates multiple buffered frames per stream', async () => {
 		const sim = await startDockerSockSim();

--- a/packages/server/test/helpers/app.ts
+++ b/packages/server/test/helpers/app.ts
@@ -61,6 +61,7 @@ const STUB_DOCKER_METHODS = {
 	},
 	execStart: async () => ({ stdout: '', stderr: '' }),
 	execInspect: async () => ({ ExitCode: 0, Running: false, Pid: 0 }),
+	killRunProcesses: async () => {},
 };
 
 export function createStubDocker<T extends Record<string, unknown>>(

--- a/packages/server/test/job-manager-workflows.test.ts
+++ b/packages/server/test/job-manager-workflows.test.ts
@@ -47,6 +47,7 @@ function createMockDocker(): DockerClient {
 		execCreate: async () => 'exec-123',
 		execStart: async () => ({ stdout: 'done', stderr: '' }),
 		execInspect: async () => ({ ExitCode: 0, Running: false, Pid: 0 }),
+		killRunProcesses: async () => {},
 	} as unknown as DockerClient;
 }
 

--- a/packages/server/test/run-timeout.test.ts
+++ b/packages/server/test/run-timeout.test.ts
@@ -50,6 +50,7 @@ function createMockDocker(overrides: Record<string, any> = {}): DockerClient {
 		containerLogs: async () => new ReadableStream(),
 		execCreate: async () => 'exec-123',
 		execInspect: async () => ({ ExitCode: 0, Running: false, Pid: 0 }),
+		killRunProcesses: async () => {},
 		execStart: execStartOverride ?? (async () => ({ stdout: 'done', stderr: '' })),
 		...rest,
 	} as unknown as DockerClient;


### PR DESCRIPTION
## Problem

The terminate dialog promises: *"The agent will be aborted immediately. Any in-progress work in this run will be lost."* — but the agent wasn't actually being aborted.

Terminating a run (or a run hitting its timeout) only tore down the Docker **exec attach stream**. Docker exposes no API to signal an exec'd process, and disconnecting from the stream leaves the agent CLI **running inside the container** — it kept burning tokens and writing to the workspace even though the run was already marked `cancelled` in the DB and UI. The dialog's promise was false.

## Fix

On any abort where the container is still alive (a user terminate or a timeout — **not** `container_*` death, where the process already died with the container), the runner now hard-kills the run's whole process tree:

- New `DockerClient.killRunProcesses(containerId, runId)` execs a `/proc` scan **as root** (so it can signal the deprivileged run-user's processes) that `kill -9`s every process whose environment carries the run's `HEZO_HEARTBEAT_RUN_ID` marker. Children inherit the marker, so the whole tree is caught.
- Wired into `runAgent`'s abort-handling path (`agent-runner.ts`), guarded to skip `container_stopped`/`container_error` reasons and made **best-effort** (a kill failure is logged, never masks the run result) and **bounded** by its own short timeout so it can never block run finalization.

This makes a terminate what the UI already promised: immediate, with in-progress work lost. It also fixes the same latent leak for timed-out runs.

## Tests

- `docker-client-request.test.ts` — direct unit test pinning the generated kill script (marker, `/proc` scan, `kill -9`, root user, no attached streams) and error propagation.
- `agent-runner.test.ts` — behavioral tests: process tree is killed on a mid-execution terminate and on timeout (with the right container id + run id), and **not** attempted when the container itself died.
- Added the new method to the central test stubs (`createStubDocker`, `fake-docker.ts`) and the hand-rolled docker mocks in the run-launching suites.

## Docs

- `.dev/architecture.md` — documented that aborting actually kills the process tree (Docker leaves exec'd processes running when the attach stream is disconnected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012c1gPNnMMfUqZPpJ8UUbcD)_