### PR TITLE
feat(web): relative "X ago" timestamps via date-fns with date tooltip

### DIFF
--- a/packages/web/src/components/audit-log-table.tsx
+++ b/packages/web/src/components/audit-log-table.tsx
@@ -3,6 +3,7 @@ import type { AuditEntry } from '../hooks/use-audit-log';
 import { auditEntryLink, describeAuditEntry } from '../lib/audit-format';
 import { ActorBadge } from './ui/actor-badge';
 import { type Column, DataTable } from './ui/data-table';
+import { RelativeTime } from './ui/relative-time';
 
 /**
  * Shared renderer for the activity (audit) log, used by the per-project and
@@ -30,9 +31,7 @@ function buildColumns(showProject: boolean): Column<AuditEntry>[] {
 			key: 'time',
 			header: 'Time',
 			hideOnMobile: true,
-			render: (e) => (
-				<span className="text-xs text-text-3">{new Date(e.created_at).toLocaleString()}</span>
-			),
+			render: (e) => <RelativeTime iso={e.created_at} className="text-xs text-text-3" />,
 		},
 		{
 			key: 'actor',

--- a/packages/web/src/components/captain-intake-chat.tsx
+++ b/packages/web/src/components/captain-intake-chat.tsx
@@ -3,6 +3,7 @@ import { Loader2 } from 'lucide-react';
 import { useEffect, useMemo, useRef } from 'react';
 import { type Comment, useComments } from '../hooks/use-comments';
 import { CaptainAvatar, captainChatBubbleMinHClass } from './captain-avatar';
+import { RelativeTime } from './ui/relative-time';
 
 /** Indent name/timestamp to align with bubble column (avatar width + gap). */
 const captainChatMetaIndentClass = 'pl-[calc(2.625rem+0.625rem)]';
@@ -22,15 +23,6 @@ function getCommentText(content: Comment['content']): string {
 		return typeof text === 'string' ? text : '';
 	}
 	return '';
-}
-
-function formatMessageTime(iso: string): string {
-	return new Date(iso).toLocaleString(undefined, {
-		month: 'short',
-		day: 'numeric',
-		hour: 'numeric',
-		minute: '2-digit',
-	});
 }
 
 interface CaptainIntakeChatProps {
@@ -110,9 +102,10 @@ export function CaptainIntakeChat({
 									{text}
 								</div>
 							</div>
-							<span className={`text-[10px] text-text-3 ${captainChatMetaIndentClass}`}>
-								{formatMessageTime(comment.created_at)}
-							</span>
+							<RelativeTime
+								iso={comment.created_at}
+								className={`text-[10px] text-text-3 ${captainChatMetaIndentClass}`}
+							/>
 						</div>
 					);
 				}
@@ -128,9 +121,7 @@ export function CaptainIntakeChat({
 						<div className="max-w-[min(100%,42rem)] rounded-md rounded-br-sm bg-info-soft border border-info-soft-fg/20 px-3 py-2.5 text-[13px] md:text-sm text-text-1 leading-relaxed whitespace-pre-wrap">
 							{text}
 						</div>
-						<span className="text-[10px] text-text-3 pr-0.5">
-							{formatMessageTime(comment.created_at)}
-						</span>
+						<RelativeTime iso={comment.created_at} className="text-[10px] text-text-3 pr-0.5" />
 					</div>
 				);
 			})}

--- a/packages/web/src/components/comment-renderers/comment-timestamp-link.tsx
+++ b/packages/web/src/components/comment-renderers/comment-timestamp-link.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { formatDateTime, formatRelativeTime } from '../../lib/format-date';
 import { Tooltip } from '../ui/tooltip';
 import { jumpToComment } from './helpers';
 
@@ -9,13 +10,15 @@ import { jumpToComment } from './helpers';
  * keeps a click from reaching an enclosing control (the run row's expand
  * button wraps its timestamp); it's a no-op for the other call sites.
  *
- * The label truncates (`min-w-0 truncate`) so the timestamp is the segment that
- * shrinks when the comment header runs out of horizontal room — on a narrow
- * mobile viewport this keeps the whole header on a single row instead of
- * wrapping. The full date/time is always reachable: on desktop it shows on
- * hover, and on touch a tap toggles the tooltip (Radix tooltips never open on
- * tap, so `open` is driven manually — `preventDefault` stops both the anchor
- * navigation and Radix's own pointer-down dismissal so the tap just reveals it).
+ * The visible label is a relative "X ago" phrase (an absolute date once the
+ * comment is older than a week); the exact date/time is always reachable via the
+ * tooltip. The label truncates (`min-w-0 truncate`) so the timestamp is the
+ * segment that shrinks when the comment header runs out of horizontal room — on
+ * a narrow mobile viewport this keeps the whole header on a single row instead
+ * of wrapping. The tooltip shows on hover (desktop), and on touch a tap toggles
+ * it (Radix tooltips never open on tap, so `open` is driven manually —
+ * `preventDefault` stops both the anchor navigation and Radix's own pointer-down
+ * dismissal so the tap just reveals it).
  */
 export function CommentTimestampLink({
 	publicId,
@@ -27,9 +30,8 @@ export function CommentTimestampLink({
 	className?: string;
 }) {
 	const [open, setOpen] = useState(false);
-	const full = new Date(createdAt).toLocaleString();
 	return (
-		<Tooltip content={full} open={open} onOpenChange={setOpen}>
+		<Tooltip content={formatDateTime(createdAt)} open={open} onOpenChange={setOpen}>
 			<a
 				href={`#comment-${publicId}`}
 				onClick={(e) => {
@@ -44,7 +46,7 @@ export function CommentTimestampLink({
 				title="Link to this comment"
 				data-testid="comment-timestamp-link"
 			>
-				{full}
+				{formatRelativeTime(createdAt)}
 			</a>
 		</Tooltip>
 	);

--- a/packages/web/src/components/comment-renderers/run-comment.tsx
+++ b/packages/web/src/components/comment-renderers/run-comment.tsx
@@ -17,6 +17,7 @@ import { LazyMount } from '../lazy-mount';
 import { LogViewer } from '../log-viewer';
 import { useOpenPreview } from '../task-detail/preview-context';
 import { TerminateRunButton } from '../terminate-run-button';
+import { RelativeTime } from '../ui/relative-time';
 import { Tooltip } from '../ui/tooltip';
 import type { CommentDataOf } from './comment-data';
 import { CommentTimestampLink } from './comment-timestamp-link';
@@ -252,9 +253,10 @@ export function RunCommentBody({
 					className="whitespace-nowrap max-w-full truncate"
 				/>
 			) : (
-				<span className="text-[11px] text-text-3 whitespace-nowrap max-w-full truncate">
-					{new Date(createdAt).toLocaleString()}
-				</span>
+				<RelativeTime
+					iso={createdAt}
+					className="text-[11px] text-text-3 whitespace-nowrap max-w-full truncate"
+				/>
 			)}
 		</span>
 	);

--- a/packages/web/src/components/docs-library.tsx
+++ b/packages/web/src/components/docs-library.tsx
@@ -25,6 +25,7 @@ import { ConfirmDialog } from './ui/confirm-dialog';
 import { EmptyState } from './ui/empty-state';
 import { Input } from './ui/input';
 import { NameSwitcherButton } from './ui/name-switcher-button';
+import { RelativeTime } from './ui/relative-time';
 import { Tooltip } from './ui/tooltip';
 
 /** Remembers the doc-list collapse choice across documents and visits. */
@@ -515,7 +516,7 @@ export function DocsLibrary({
 										{archivedInfo.archivedByName
 											? ` — archived by ${archivedInfo.archivedByName}`
 											: ''}{' '}
-										on {new Date(archivedInfo.archivedAt).toLocaleDateString()}.
+										<RelativeTime iso={archivedInfo.archivedAt} />.
 									</span>
 								</div>
 								{onRestore && (

--- a/packages/web/src/components/document-review/document-metadata-banner.tsx
+++ b/packages/web/src/components/document-review/document-metadata-banner.tsx
@@ -2,6 +2,7 @@ import { Archive } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { ActorBadge } from '../ui/actor-badge';
 import { getInitials } from '../ui/avatar';
+import { RelativeTime } from '../ui/relative-time';
 
 export interface DocMetadata {
 	createdAt?: string;
@@ -12,24 +13,6 @@ export interface DocMetadata {
 	archivedAt?: string | null;
 	/** Resolved name of whoever archived it (single-doc responses only). */
 	archivedByName?: string | null;
-}
-
-function shortDate(iso: string): string {
-	const d = new Date(iso);
-	if (Number.isNaN(d.getTime())) return iso;
-	return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
-}
-
-function fullDateTime(iso: string): string {
-	const d = new Date(iso);
-	if (Number.isNaN(d.getTime())) return iso;
-	return d.toLocaleString(undefined, {
-		month: 'short',
-		day: 'numeric',
-		year: 'numeric',
-		hour: 'numeric',
-		minute: '2-digit',
-	});
 }
 
 const K = 'text-[9.5px] font-semibold uppercase tracking-wide text-text-3';
@@ -59,7 +42,7 @@ export function DocumentMetadataBanner({
 			>
 				<Archive className="h-3.5 w-3.5 shrink-0" aria-hidden />
 				<span className="text-[9.5px] font-semibold uppercase tracking-wide">Archived</span>
-				<span title={fullDateTime(archivedAt)}>{shortDate(archivedAt)}</span>
+				<RelativeTime iso={archivedAt} />
 				{archivedByName && <span className="text-text-2">by {archivedByName}</span>}
 			</span>,
 		);
@@ -68,7 +51,7 @@ export function DocumentMetadataBanner({
 		items.push(
 			<span key="created" className="inline-flex items-center gap-1.5 tabular-nums">
 				<span className={K}>Created</span>
-				<span title={fullDateTime(createdAt)}>{shortDate(createdAt)}</span>
+				<RelativeTime iso={createdAt} />
 			</span>,
 		);
 	}
@@ -76,7 +59,7 @@ export function DocumentMetadataBanner({
 		items.push(
 			<span key="updated" className="inline-flex items-center gap-1.5 tabular-nums">
 				<span className={K}>Updated</span>
-				<span title={fullDateTime(updatedAt)}>{shortDate(updatedAt)}</span>
+				<RelativeTime iso={updatedAt} />
 			</span>,
 		);
 	}

--- a/packages/web/src/components/document-review/revision-history-dialog.tsx
+++ b/packages/web/src/components/document-review/revision-history-dialog.tsx
@@ -8,6 +8,7 @@ import { Avatar, getInitials } from '../ui/avatar';
 import { Button } from '../ui/button';
 import { ConfirmDialog } from '../ui/confirm-dialog';
 import { DialogContent } from '../ui/dialog';
+import { RelativeTime } from '../ui/relative-time';
 
 interface RevisionHistoryDialogProps {
 	open: boolean;
@@ -23,18 +24,6 @@ interface RevisionHistoryDialogProps {
 	/** Admins only — omit to hide the Restore action. */
 	onRestore?: (revisionNumber: number) => Promise<unknown>;
 	isRestoring?: boolean;
-}
-
-function formatWhen(iso: string): string {
-	const d = new Date(iso);
-	if (Number.isNaN(d.getTime())) return iso;
-	return d.toLocaleString(undefined, {
-		month: 'short',
-		day: 'numeric',
-		year: 'numeric',
-		hour: 'numeric',
-		minute: '2-digit',
-	});
 }
 
 /**
@@ -94,9 +83,10 @@ export function RevisionHistoryDialog({
 										>
 											{e.isCurrent ? 'Current' : `Rev ${e.revisionNumber}`}
 										</span>
-										<span className="ml-auto text-[11px] tabular-nums text-text-3">
-											{formatWhen(e.timestamp)}
-										</span>
+										<RelativeTime
+											iso={e.timestamp}
+											className="ml-auto text-[11px] tabular-nums text-text-3"
+										/>
 									</div>
 									<div className="px-3 py-2.5">
 										{e.isInitial || !e.changelog.trim() ? (

--- a/packages/web/src/components/document-review/viewing-revision-banner.tsx
+++ b/packages/web/src/components/document-review/viewing-revision-banner.tsx
@@ -1,17 +1,11 @@
 import { ArrowRight, History } from 'lucide-react';
+import { formatDateTime, formatRelativeTime } from '../../lib/format-date';
 
 interface ViewingRevisionBannerProps {
 	revisionNumber: number;
 	timestamp?: string;
 	authorName?: string | null;
 	onViewLatest: () => void;
-}
-
-function formatWhen(iso?: string): string {
-	if (!iso) return '';
-	const d = new Date(iso);
-	if (Number.isNaN(d.getTime())) return '';
-	return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
 }
 
 /**
@@ -25,10 +19,7 @@ export function ViewingRevisionBanner({
 	authorName,
 	onViewLatest,
 }: ViewingRevisionBannerProps) {
-	const when = formatWhen(timestamp);
-	const detail = [when && `created ${when}`, authorName && `by ${authorName}`]
-		.filter(Boolean)
-		.join(' ');
+	const relative = timestamp ? formatRelativeTime(timestamp) : '';
 	return (
 		<div
 			data-testid="viewing-revision-banner"
@@ -37,7 +28,21 @@ export function ViewingRevisionBanner({
 			<History className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
 			<span className="min-w-0 truncate">
 				<span className="font-semibold">You are viewing revision {revisionNumber}</span>
-				{detail && <span className="opacity-80"> · {detail}</span>}
+				{(relative || authorName) && (
+					<span className="opacity-80">
+						{' · '}
+						{relative && timestamp && (
+							<time dateTime={timestamp} title={formatDateTime(timestamp)}>
+								created {relative}
+							</time>
+						)}
+						{authorName && (
+							<>
+								{relative ? ' ' : ''}by {authorName}
+							</>
+						)}
+					</span>
+				)}
 			</span>
 			<button
 				type="button"

--- a/packages/web/src/components/goal-detail/goal-detail-page.tsx
+++ b/packages/web/src/components/goal-detail/goal-detail-page.tsx
@@ -7,6 +7,7 @@ import { Link } from '@tanstack/react-router';
 import { Archive, ArchiveRestore, ChevronRight, Pencil } from 'lucide-react';
 import { useState } from 'react';
 import { useGoal, useGoalHistory, useGoalRunActivity, useUpdateGoal } from '../../hooks/use-goals';
+import { formatDateTime, formatRelativeTime } from '../../lib/format-date';
 import { agentPageParams } from '../agent-link';
 import { CreateGoalDialog } from '../create-goal-dialog';
 import { GoalHealthPill } from '../goal-health-pill';
@@ -25,16 +26,9 @@ function formatTargetDate(iso: string): string {
 	return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
 }
 
-function formatRunTime(run: GoalRunActivity): string {
-	const iso = run.finished_at ?? run.started_at ?? run.created_at;
-	const d = new Date(iso);
-	if (Number.isNaN(d.getTime())) return iso;
-	return d.toLocaleString(undefined, {
-		month: 'short',
-		day: 'numeric',
-		hour: 'numeric',
-		minute: '2-digit',
-	});
+/** The timestamp a run row is labelled by: when it finished, else started, else was created. */
+function runActivityIso(run: GoalRunActivity): string {
+	return run.finished_at ?? run.started_at ?? run.created_at;
 }
 
 const RUN_STATUS_COLOR: Record<string, BadgeColor> = {
@@ -76,9 +70,10 @@ function GoalRunRow({ projectId, run }: { projectId: string; run: GoalRunActivit
 					params={runLinkParams}
 					data-testid="goal-run-open"
 					aria-label="Open run"
+					title={formatDateTime(runActivityIso(run))}
 					className="text-[13px] text-text-2 hover:underline before:absolute before:inset-0"
 				>
-					{formatRunTime(run)}
+					{formatRelativeTime(runActivityIso(run))}
 				</Link>
 				{run.status !== HeartbeatRunStatus.Succeeded && (
 					<Badge color={RUN_STATUS_COLOR[run.status] ?? 'neutral'}>{run.status}</Badge>

--- a/packages/web/src/components/markdown-prose.tsx
+++ b/packages/web/src/components/markdown-prose.tsx
@@ -8,6 +8,7 @@ import { useAgents } from '../hooks/use-agents';
 import { useDocMentions, useInstanceMentions } from '../hooks/use-mentions';
 import { useTaskMentions } from '../hooks/use-tasks';
 import { docPreviewPath } from '../lib/doc-preview';
+import { formatRelativeTime } from '../lib/format-date';
 import { type ReviewAnnotation, rehypeReviewHighlights } from '../lib/rehype-review-highlights';
 import { type CommentRefTask, remarkCommentRefs } from '../lib/remark-comment-refs';
 import {
@@ -574,7 +575,7 @@ function DocTooltipContent({
 		<div className="flex flex-col gap-0.5">
 			<span className="font-semibold">{title}</span>
 			<span className="opacity-70">
-				{formatSize(size)} · updated {formatRelative(updatedAt)}
+				{formatSize(size)} · updated {formatRelativeTime(updatedAt)}
 			</span>
 		</div>
 	);
@@ -585,28 +586,4 @@ function formatSize(bytes: number): string {
 	if (bytes < 1024) return `${bytes} B`;
 	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
 	return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-}
-
-const RELATIVE_UNITS: Array<[Intl.RelativeTimeFormatUnit, number]> = [
-	['year', 60 * 60 * 24 * 365],
-	['month', 60 * 60 * 24 * 30],
-	['week', 60 * 60 * 24 * 7],
-	['day', 60 * 60 * 24],
-	['hour', 60 * 60],
-	['minute', 60],
-	['second', 1],
-];
-
-function formatRelative(iso: string): string {
-	if (!iso) return '';
-	const then = new Date(iso).getTime();
-	if (!Number.isFinite(then)) return '';
-	const deltaSeconds = Math.round((then - Date.now()) / 1000);
-	const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
-	for (const [unit, secondsPerUnit] of RELATIVE_UNITS) {
-		if (Math.abs(deltaSeconds) >= secondsPerUnit || unit === 'second') {
-			return rtf.format(Math.round(deltaSeconds / secondsPerUnit), unit);
-		}
-	}
-	return '';
 }

--- a/packages/web/src/components/mention-card.tsx
+++ b/packages/web/src/components/mention-card.tsx
@@ -1,6 +1,7 @@
 import type { AdminMentionItem } from '@hezo/shared';
 import { Link, useNavigate } from '@tanstack/react-router';
 import { useMarkMentionRead } from '../hooks/use-admin-mentions';
+import { formatDateTime, formatRelativeTime } from '../lib/format-date';
 import { Badge } from './ui/badge';
 
 interface MentionCardProps {
@@ -10,16 +11,6 @@ interface MentionCardProps {
 
 const baseCardClass = 'block p-4 border border-border rounded-md text-left w-full';
 const linkCardClass = `${baseCardClass} hover:bg-surface-2 transition-colors`;
-
-function relativeTime(iso: string): string {
-	const then = new Date(iso).getTime();
-	if (Number.isNaN(then)) return '';
-	const diff = Date.now() - then;
-	if (diff < 60_000) return 'just now';
-	if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
-	if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
-	return `${Math.floor(diff / 86_400_000)}d ago`;
-}
 
 export function MentionCard({ mention, showTeam = false }: MentionCardProps) {
 	const navigate = useNavigate();
@@ -67,7 +58,13 @@ export function MentionCard({ mention, showTeam = false }: MentionCardProps) {
 					mention
 				</Badge>
 				{showTeam && <span className="text-xs text-text-2">{mention.team_slug}</span>}
-				<span className="text-xs text-text-2">{relativeTime(mention.created_at)}</span>
+				<time
+					dateTime={mention.created_at}
+					title={formatDateTime(mention.created_at)}
+					className="text-xs text-text-2"
+				>
+					{formatRelativeTime(mention.created_at)}
+				</time>
 			</div>
 			<p className={`text-xs mb-1 ${unread ? 'text-text-1' : 'text-text-2'}`}>
 				<span className={unread ? 'font-semibold' : 'font-medium'}>{author}</span> asked you on{' '}

--- a/packages/web/src/components/next-heartbeat-indicator.tsx
+++ b/packages/web/src/components/next-heartbeat-indicator.tsx
@@ -1,5 +1,6 @@
 import { Activity } from 'lucide-react';
 import { useNextHeartbeatCountdown } from '../hooks/use-next-heartbeat';
+import { formatDateTime } from '../lib/format-date';
 
 /**
  * Live "Next heartbeat in …" countdown for an agent. Renders nothing when the
@@ -34,7 +35,7 @@ export function NextHeartbeatIndicator({
 			data-testid="next-heartbeat"
 			title={
 				hasActionableWork
-					? `Next heartbeat ${new Date(nextHeartbeatAt).toLocaleString()}`
+					? `Next heartbeat ${formatDateTime(nextHeartbeatAt)}`
 					: 'No tasks to work on yet'
 			}
 			className={`inline-flex items-center gap-1.5 text-xs text-text-2 ${className}`}

--- a/packages/web/src/components/project-progress-summary.tsx
+++ b/packages/web/src/components/project-progress-summary.tsx
@@ -3,17 +3,7 @@ import { useEffect, useId, useState } from 'react';
 import { useProjectProgress } from '../hooks/use-projects';
 import { MarkdownProse } from './markdown-prose';
 import { HelpDialog } from './ui/help-dialog';
-
-function formatUpdated(iso: string): string {
-	const d = new Date(iso);
-	if (Number.isNaN(d.getTime())) return iso;
-	return d.toLocaleString(undefined, {
-		month: 'short',
-		day: 'numeric',
-		hour: 'numeric',
-		minute: '2-digit',
-	});
-}
+import { RelativeTime } from './ui/relative-time';
 
 /**
  * Split the summary into its bold lead line (the key points the Captain leads with) and the rest
@@ -91,7 +81,9 @@ export function ProjectProgressSummary({ projectId }: { projectId: string }) {
 					<ProjectProgressHelp />
 				</div>
 				{data?.updated_at && (
-					<span className="text-[11px] text-text-3">Updated {formatUpdated(data.updated_at)}</span>
+					<span className="text-[11px] text-text-3">
+						Updated <RelativeTime iso={data.updated_at} />
+					</span>
 				)}
 			</div>
 			<div id={contentId}>

--- a/packages/web/src/components/revisions-panel.tsx
+++ b/packages/web/src/components/revisions-panel.tsx
@@ -4,6 +4,7 @@ import { ActorBadge } from './ui/actor-badge';
 import { Button } from './ui/button';
 import { Card } from './ui/card';
 import { ConfirmDialog } from './ui/confirm-dialog';
+import { RelativeTime } from './ui/relative-time';
 
 export interface DocumentRevision {
 	id: string;
@@ -51,9 +52,7 @@ export function RevisionsPanel({ revisions, onRestore, isRestoring }: RevisionsP
 										{rev.author_name || 'Admin'}
 										<ActorBadge actorType={rev.author_type} name={rev.author_name} />
 									</span>
-									<span className="text-xs text-text-3 ml-auto">
-										{new Date(rev.created_at).toLocaleString()}
-									</span>
+									<RelativeTime iso={rev.created_at} className="text-xs text-text-3 ml-auto" />
 									<Button
 										variant="ghost"
 										size="sm"

--- a/packages/web/src/components/task-detail/task-sidebar.tsx
+++ b/packages/web/src/components/task-detail/task-sidebar.tsx
@@ -22,6 +22,7 @@ import { TaskStatusBadge } from '../task-status-badge';
 import { Button } from '../ui/button';
 import { ConfirmDialog } from '../ui/confirm-dialog';
 import { InfoTooltip } from '../ui/info-tooltip';
+import { RelativeTime } from '../ui/relative-time';
 import { AgentQueueSection } from './agent-queue-section';
 
 const EFFORT_LEVELS: { value: AgentEffort; label: string }[] = [
@@ -240,9 +241,7 @@ export function TaskSidebar({
 					<span className="text-text-3 block mb-1 uppercase tracking-wider font-medium">
 						Created
 					</span>
-					<span className="text-[13px] text-text-1">
-						{new Date(task.created_at).toLocaleDateString()}
-					</span>
+					<RelativeTime iso={task.created_at} className="text-[13px] text-text-1" />
 				</div>
 
 				<div>

--- a/packages/web/src/components/ui/relative-time.tsx
+++ b/packages/web/src/components/ui/relative-time.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+import {
+	formatDateTime,
+	formatRelativeTime,
+	formatRelativeTimeCompact,
+} from '../../lib/format-date';
+import { Tooltip } from './tooltip';
+
+/**
+ * A timestamp rendered as a relative "X ago" label (or the absolute date once
+ * it's older than a week), with the full local date+time always reachable via a
+ * tooltip. On desktop the tooltip opens on hover; on touch a tap toggles it
+ * (Radix tooltips never open on tap, so `open` is driven manually — matching
+ * `CommentTimestampLink`).
+ */
+export function RelativeTime({
+	iso,
+	compact = false,
+	className,
+	side,
+	testId,
+}: {
+	iso: string | null | undefined;
+	/** Use the compact "5m"/"3h"/"2d" form instead of the full "5 minutes ago". */
+	compact?: boolean;
+	className?: string;
+	side?: 'top' | 'right' | 'bottom' | 'left';
+	testId?: string;
+}) {
+	const [open, setOpen] = useState(false);
+	const label = compact ? formatRelativeTimeCompact(iso) : formatRelativeTime(iso);
+	if (!label) return null;
+	return (
+		<Tooltip content={formatDateTime(iso)} open={open} onOpenChange={setOpen} side={side}>
+			<time
+				dateTime={iso ?? undefined}
+				onTouchStart={(e) => {
+					e.preventDefault();
+					setOpen((o) => !o);
+				}}
+				className={className}
+				data-testid={testId}
+			>
+				{label}
+			</time>
+		</Tooltip>
+	);
+}

--- a/packages/web/src/lib/format-date.ts
+++ b/packages/web/src/lib/format-date.ts
@@ -1,0 +1,70 @@
+import {
+	differenceInDays,
+	differenceInHours,
+	differenceInMinutes,
+	differenceInSeconds,
+	formatDistanceToNowStrict,
+} from 'date-fns';
+
+/**
+ * Shared date/time formatting for the web app. Timestamps are rendered as a
+ * relative "X ago" phrase for the recent past (up to a week) and fall back to an
+ * absolute date once they're older, while the full local date+time is always
+ * available for a tooltip via {@link formatDateTime}.
+ *
+ * These are pure functions (no React) so they can be unit-tested directly; the
+ * `<RelativeTime>` component pairs a relative label with the absolute-date
+ * tooltip.
+ */
+
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** Parse an ISO string to a Date, or `null` when empty/unparsable. */
+function parseDate(iso: string | null | undefined): Date | null {
+	if (!iso) return null;
+	const d = new Date(iso);
+	return Number.isNaN(d.getTime()) ? null : d;
+}
+
+/** Full local date + time — used for every timestamp tooltip. `''` when unparsable. */
+export function formatDateTime(iso: string | null | undefined): string {
+	const d = parseDate(iso);
+	return d ? d.toLocaleString() : '';
+}
+
+/** Local date only (no time) — the fallback label once a timestamp is older than a week. `''` when unparsable. */
+export function formatDate(iso: string | null | undefined): string {
+	const d = parseDate(iso);
+	return d ? d.toLocaleDateString() : '';
+}
+
+/**
+ * Relative label: `"30 seconds ago"`, `"1 hour ago"`, `"2 days ago"`, up to a
+ * week; anything older (or more than a week in the future) falls back to the
+ * absolute date. Near-future timestamps read as `"in 5 minutes"`. `''` when
+ * unparsable.
+ */
+export function formatRelativeTime(iso: string | null | undefined): string {
+	const d = parseDate(iso);
+	if (!d) return '';
+	if (Math.abs(Date.now() - d.getTime()) >= SEVEN_DAYS_MS) return d.toLocaleDateString();
+	return formatDistanceToNowStrict(d, { addSuffix: true });
+}
+
+/**
+ * Compact relative label for space-constrained spots: `"now"`, `"5m"`, `"3h"`,
+ * `"2d"`; older than a week falls back to the absolute date. `''` when
+ * unparsable.
+ */
+export function formatRelativeTimeCompact(iso: string | null | undefined): string {
+	const d = parseDate(iso);
+	if (!d) return '';
+	const now = Date.now();
+	if (Math.abs(now - d.getTime()) >= SEVEN_DAYS_MS) return d.toLocaleDateString();
+	if (differenceInSeconds(now, d) < 60) return 'now';
+	const minutes = differenceInMinutes(now, d);
+	if (minutes < 60) return `${minutes}m`;
+	const hours = differenceInHours(now, d);
+	if (hours < 24) return `${hours}h`;
+	return `${differenceInDays(now, d)}d`;
+}

--- a/packages/web/src/routes/home/index.tsx
+++ b/packages/web/src/routes/home/index.tsx
@@ -9,6 +9,7 @@ import { Avatar, avatarColorFromString, getInitials } from '../../components/ui/
 import { Badge } from '../../components/ui/badge';
 import { Button } from '../../components/ui/button';
 import { Card } from '../../components/ui/card';
+import { RelativeTime } from '../../components/ui/relative-time';
 import { useAllAdminMentions } from '../../hooks/use-admin-mentions';
 import { type Approval, useAllApprovals } from '../../hooks/use-approvals';
 import { useContainerHealth } from '../../hooks/use-container-health';
@@ -18,26 +19,6 @@ import {
 	useAllVisibleProjects,
 	useHqProject,
 } from '../../hooks/use-projects';
-
-const RELATIVE_UNITS: Array<[Intl.RelativeTimeFormatUnit, number]> = [
-	['day', 86400],
-	['hour', 3600],
-	['minute', 60],
-];
-
-/** Compact "2h ago" / "3d ago" / "just now" from an ISO timestamp. */
-function relativeTime(iso: string): string {
-	const then = new Date(iso).getTime();
-	if (!Number.isFinite(then)) return '';
-	const deltaSec = Math.round((Date.now() - then) / 1000);
-	for (const [unit, per] of RELATIVE_UNITS) {
-		if (deltaSec >= per) {
-			const n = Math.floor(deltaSec / per);
-			return `${n}${unit[0]}`; // 2d / 3h / 5m
-		}
-	}
-	return 'now';
-}
 
 function formatMoney(cents: number): string {
 	return `$${(cents / 100).toFixed(2)}`;
@@ -158,7 +139,7 @@ function NeedsYouRowShell({
 			<span className="min-w-0 flex-1 truncate text-[13px] text-text-1">{children}</span>
 			<span className="shrink-0 font-mono text-[11px] text-text-3">
 				{project ? `${project} · ` : ''}
-				{relativeTime(createdAt)}
+				<RelativeTime iso={createdAt} compact />
 			</span>
 			{actionLink}
 		</div>
@@ -302,8 +283,6 @@ function ActiveProjectCard({
 
 function OtherProjectRow({ project }: { project: ProjectWithTeam }) {
 	const paused = project.container_status === 'stopped' || project.container_status === 'error';
-	const rel = relativeTime(project.last_activity_at);
-	const activity = rel === 'now' ? 'just now' : `last ${rel} ago`;
 	return (
 		<Link
 			to="/projects/$projectId"
@@ -321,7 +300,7 @@ function OtherProjectRow({ project }: { project: ProjectWithTeam }) {
 					{paused ? 'paused' : 'idle'}
 				</span>
 				<span className="shrink-0 font-mono text-[11px] text-text-3">
-					{project.open_task_count} tasks · {activity}
+					{project.open_task_count} tasks · <RelativeTime iso={project.last_activity_at} compact />
 				</span>
 			</div>
 		</Link>

--- a/packages/web/src/routes/projects/$projectId/agents/$agentId/chat-history.tsx
+++ b/packages/web/src/routes/projects/$projectId/agents/$agentId/chat-history.tsx
@@ -4,22 +4,12 @@ import { useEffect, useState } from 'react';
 import { MarkdownEditor } from '../../../../../components/markdown-editor';
 import { Button } from '../../../../../components/ui/button';
 import { HelpDialog } from '../../../../../components/ui/help-dialog';
+import { RelativeTime } from '../../../../../components/ui/relative-time';
 import {
 	useAgentChatMemory,
 	useUpdateAgentChatMemory,
 } from '../../../../../hooks/use-agent-chat-memory';
 import type { ApiError } from '../../../../../lib/api';
-
-function formatUpdated(iso: string): string {
-	const d = new Date(iso);
-	if (Number.isNaN(d.getTime())) return iso;
-	return d.toLocaleString(undefined, {
-		month: 'short',
-		day: 'numeric',
-		hour: 'numeric',
-		minute: '2-digit',
-	});
-}
 
 function ChatHistoryHelp() {
 	return (
@@ -90,7 +80,7 @@ function ChatHistoryPage() {
 				</div>
 				{data?.updated_at && (
 					<span className="text-[11px] text-text-3" data-testid="chat-history-updated">
-						Updated {formatUpdated(data.updated_at)}
+						Updated <RelativeTime iso={data.updated_at} />
 					</span>
 				)}
 			</div>

--- a/packages/web/src/routes/projects/$projectId/agents/$agentId/executions/index.tsx
+++ b/packages/web/src/routes/projects/$projectId/agents/$agentId/executions/index.tsx
@@ -1,6 +1,7 @@
 import { INSTANCE_AGENT_SLUGS } from '@hezo/shared';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { Badge } from '../../../../../../components/ui/badge';
+import { RelativeTime } from '../../../../../../components/ui/relative-time';
 import { Tooltip } from '../../../../../../components/ui/tooltip';
 import { useAgent } from '../../../../../../hooks/use-agents';
 import { useElapsedDuration } from '../../../../../../hooks/use-elapsed-duration';
@@ -68,9 +69,11 @@ function ExecutionRow({
 				<span className="text-text-3 truncate">{trigger.text}</span>
 			</Tooltip>
 
-			<span className="text-text-2 ml-auto whitespace-nowrap">
-				{run.started_at ? new Date(run.started_at).toLocaleString() : 'queued'}
-			</span>
+			{run.started_at ? (
+				<RelativeTime iso={run.started_at} className="text-text-2 ml-auto whitespace-nowrap" />
+			) : (
+				<span className="text-text-2 ml-auto whitespace-nowrap">queued</span>
+			)}
 
 			<span className="text-text-3 whitespace-nowrap">{elapsed}</span>
 

--- a/packages/web/src/routes/projects/$projectId/agents/$agentId/settings.tsx
+++ b/packages/web/src/routes/projects/$projectId/agents/$agentId/settings.tsx
@@ -20,6 +20,7 @@ import { getInitials } from '../../../../../components/ui/avatar';
 import { Button } from '../../../../../components/ui/button';
 import { ExpandableText } from '../../../../../components/ui/expandable-text';
 import { Input } from '../../../../../components/ui/input';
+import { RelativeTime } from '../../../../../components/ui/relative-time';
 import { Textarea } from '../../../../../components/ui/textarea';
 import {
 	useAgent,
@@ -189,7 +190,7 @@ function AgentSettingsPage() {
 					<div className="text-sm">Every {agent.heartbeat_interval_min} min</div>
 					{agent.last_heartbeat_at && (
 						<div className="text-xs text-text-3 mt-1">
-							Last: {new Date(agent.last_heartbeat_at).toLocaleString()}
+							Last: <RelativeTime iso={agent.last_heartbeat_at} />
 						</div>
 					)}
 				</div>

--- a/packages/web/src/routes/projects/$projectId/assets.tsx
+++ b/packages/web/src/routes/projects/$projectId/assets.tsx
@@ -42,6 +42,7 @@ import { ConfirmDialog } from '../../../components/ui/confirm-dialog';
 import { DialogContent } from '../../../components/ui/dialog';
 import { EmptyState } from '../../../components/ui/empty-state';
 import { Input } from '../../../components/ui/input';
+import { RelativeTime } from '../../../components/ui/relative-time';
 import { Tooltip } from '../../../components/ui/tooltip';
 import {
 	type ProjectAsset,
@@ -1037,41 +1038,6 @@ function CopyReferenceButton({ reference }: { reference: string }) {
 	);
 }
 
-const RELATIVE_UNITS: Array<[Intl.RelativeTimeFormatUnit, number]> = [
-	['year', 60 * 60 * 24 * 365],
-	['month', 60 * 60 * 24 * 30],
-	['week', 60 * 60 * 24 * 7],
-	['day', 60 * 60 * 24],
-	['hour', 60 * 60],
-	['minute', 60],
-	['second', 1],
-];
-
-/**
- * Human "updated" label for an asset card, e.g. "2 days ago" / "yesterday" /
- * "now". `assets.created_at` is bumped to now() on every overwrite (see
- * `upsertProjectAsset`), so it reads as the last time the asset changed. The
- * exact timestamp stays available on hover via the card's <abbr> title.
- */
-function relativeUpdated(iso: string): string {
-	const then = new Date(iso).getTime();
-	if (!Number.isFinite(then)) return '';
-	const deltaSeconds = Math.round((then - Date.now()) / 1000);
-	const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
-	for (const [unit, secondsPerUnit] of RELATIVE_UNITS) {
-		if (Math.abs(deltaSeconds) >= secondsPerUnit || unit === 'second') {
-			return rtf.format(Math.round(deltaSeconds / secondsPerUnit), unit);
-		}
-	}
-	return '';
-}
-
-/** Full local datetime for the <abbr> tooltip; empty string when unparsable. */
-function fullTimestamp(iso: string): string {
-	const d = new Date(iso);
-	return Number.isNaN(d.getTime()) ? '' : d.toLocaleString();
-}
-
 function AssetCard({
 	asset,
 	highlighted,
@@ -1153,15 +1119,10 @@ function AssetCard({
 					</div>
 					<div className="text-[11px] text-text-3">
 						{formatBytes(asset.byte_size)} ·{' '}
-						{/* Native <abbr> tooltip shows the exact timestamp on hover; the
-						    dotted-underline "abbr" affordance signals it. */}
-						<abbr
-							title={fullTimestamp(asset.created_at)}
-							className="cursor-help"
-							data-testid="asset-updated"
-						>
-							{relativeUpdated(asset.created_at)}
-						</abbr>
+						{/* The exact timestamp is available on hover (desktop) / tap (touch)
+						    via the RelativeTime tooltip. `created_at` is bumped to now() on
+						    every overwrite, so this reads as the last time the asset changed. */}
+						<RelativeTime iso={asset.created_at} className="cursor-help" testId="asset-updated" />
 					</div>
 				</div>
 				<div className="flex shrink-0 items-center gap-0.5">

--- a/packages/web/src/routes/projects/$projectId/documents.tsx
+++ b/packages/web/src/routes/projects/$projectId/documents.tsx
@@ -27,6 +27,7 @@ import {
 } from '../../../hooks/use-project-docs';
 import { docPreviewPath } from '../../../lib/doc-preview';
 import { buildDocVersionHistory, type DocVersionEntry } from '../../../lib/doc-version-history';
+import { formatDateTime, formatRelativeTime } from '../../../lib/format-date';
 
 const AGENTS_MD_KEY = '__agents_md__';
 
@@ -106,7 +107,14 @@ function ProjectDocumentsPage() {
 				key: d.filename,
 				label: d.filename,
 				archived: d.archived_at != null,
-				meta: `Updated ${new Date(d.updated_at).toLocaleDateString()}`,
+				meta: (
+					<>
+						Updated{' '}
+						<time dateTime={d.updated_at} title={formatDateTime(d.updated_at)}>
+							{formatRelativeTime(d.updated_at)}
+						</time>
+					</>
+				),
 			});
 		}
 		return list;

--- a/packages/web/src/routes/settings/api-keys.tsx
+++ b/packages/web/src/routes/settings/api-keys.tsx
@@ -8,6 +8,7 @@ import { type Column, DataTable } from '../../components/ui/data-table';
 import { InPlaceForm } from '../../components/ui/in-place-form';
 import { InfoTooltip } from '../../components/ui/info-tooltip';
 import { Input } from '../../components/ui/input';
+import { RelativeTime } from '../../components/ui/relative-time';
 import { Tooltip } from '../../components/ui/tooltip';
 import {
 	type ApiKey,
@@ -18,18 +19,6 @@ import {
 } from '../../hooks/use-api-keys';
 import { useMe } from '../../hooks/use-me';
 import { copyToClipboard } from '../../lib/clipboard';
-
-function formatRelative(iso: string | null): string {
-	if (!iso) return 'never';
-	const ms = Date.now() - new Date(iso).getTime();
-	const min = 60 * 1000;
-	const hr = 60 * min;
-	const day = 24 * hr;
-	if (ms < min) return 'just now';
-	if (ms < hr) return `${Math.floor(ms / min)}m ago`;
-	if (ms < day) return `${Math.floor(ms / hr)}h ago`;
-	return `${Math.floor(ms / day)}d ago`;
-}
 
 function clientLabel(info: Record<string, unknown>): string | null {
 	const name = typeof info.name === 'string' ? info.name : null;
@@ -85,7 +74,7 @@ function ApiKeysPage() {
 		{
 			key: 'requested',
 			header: 'Requested',
-			render: (r) => <span className="text-xs text-text-2">{formatRelative(r.created_at)}</span>,
+			render: (r) => <RelativeTime iso={r.created_at} className="text-xs text-text-2" />,
 		},
 		{
 			key: 'actions',
@@ -133,7 +122,12 @@ function ApiKeysPage() {
 		{
 			key: 'last_used',
 			header: 'Last used',
-			render: (r) => <span className="text-xs text-text-2">{formatRelative(r.last_used_at)}</span>,
+			render: (r) =>
+				r.last_used_at ? (
+					<RelativeTime iso={r.last_used_at} className="text-xs text-text-2" />
+				) : (
+					<span className="text-xs text-text-2">never</span>
+				),
 		},
 		{
 			key: 'actions',

--- a/packages/web/src/routes/settings/archived-projects.tsx
+++ b/packages/web/src/routes/settings/archived-projects.tsx
@@ -1,17 +1,9 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { Loader2 } from 'lucide-react';
 import { Button } from '../../components/ui/button';
+import { RelativeTime } from '../../components/ui/relative-time';
 import { useMe } from '../../hooks/use-me';
 import { type Project, useArchivedProjects, useUnarchiveProject } from '../../hooks/use-projects';
-
-function formatDate(iso: string | null | undefined): string {
-	if (!iso) return '';
-	return new Date(iso).toLocaleDateString(undefined, {
-		year: 'numeric',
-		month: 'short',
-		day: 'numeric',
-	});
-}
 
 function ArchivedProjectRow({ project }: { project: Project }) {
 	const unarchive = useUnarchiveProject(project.slug);
@@ -24,7 +16,12 @@ function ArchivedProjectRow({ project }: { project: Project }) {
 				<div className="text-[13px] font-medium text-text-1 truncate">{project.name}</div>
 				<div className="text-xs text-text-3 truncate">
 					{project.team_name}
-					{project.archived_at ? ` · archived ${formatDate(project.archived_at)}` : ''}
+					{project.archived_at && (
+						<>
+							{' · archived '}
+							<RelativeTime iso={project.archived_at} />
+						</>
+					)}
 				</div>
 			</div>
 			<Button

--- a/packages/web/src/routes/settings/credentials.tsx
+++ b/packages/web/src/routes/settings/credentials.tsx
@@ -9,6 +9,7 @@ import { type Column, DataTable } from '../../components/ui/data-table';
 import { InPlaceForm } from '../../components/ui/in-place-form';
 import { InfoTooltip } from '../../components/ui/info-tooltip';
 import { Input } from '../../components/ui/input';
+import { RelativeTime } from '../../components/ui/relative-time';
 import { Tooltip } from '../../components/ui/tooltip';
 import {
 	type CredentialUsage,
@@ -19,18 +20,6 @@ import {
 } from '../../hooks/use-instance-credentials';
 import { useMe } from '../../hooks/use-me';
 import { toast } from '../../hooks/use-toast';
-
-function formatRelative(iso: string | null): string {
-	if (!iso) return 'never';
-	const ms = Date.now() - new Date(iso).getTime();
-	const min = 60 * 1000;
-	const hr = 60 * min;
-	const day = 24 * hr;
-	if (ms < min) return 'just now';
-	if (ms < hr) return `${Math.floor(ms / min)}m ago`;
-	if (ms < day) return `${Math.floor(ms / hr)}h ago`;
-	return `${Math.floor(ms / day)}d ago`;
-}
 
 function InstanceCredentialsPage() {
 	const { data: me } = useMe();
@@ -147,13 +136,7 @@ function InstanceCredentialsPage() {
 			header: 'Last used',
 			render: (r) => (
 				<span className="text-xs">
-					{r.last_used_at ? (
-						<Tooltip content={r.last_used_at}>
-							<span>{formatRelative(r.last_used_at)}</span>
-						</Tooltip>
-					) : (
-						<span>{formatRelative(r.last_used_at)}</span>
-					)}
+					{r.last_used_at ? <RelativeTime iso={r.last_used_at} /> : <span>never</span>}
 					{r.last_host && <span className="text-text-3 ml-2 font-mono">{r.last_host}</span>}
 				</span>
 			),

--- a/packages/web/test/agent-chat-history-page.test.tsx
+++ b/packages/web/test/agent-chat-history-page.test.tsx
@@ -72,10 +72,11 @@ test('stored memory loads into the editor with its updated timestamp; edits save
 	})) as HTMLTextAreaElement;
 	await waitFor(() => expect(editor.value).toBe('Operator prefers concise updates.'));
 
-	// The header shows when the memory was last written (formatUpdated output —
-	// e.g. "Updated Jul 6, 10:00 AM" — always starts with "Updated" + month).
+	// The header shows when the memory was last written as a relative label
+	// (RelativeTime) — just-written memory reads "Updated <n> seconds ago".
 	const updated = await findByTestId('chat-history-updated');
-	expect(updated.textContent).toMatch(/^Updated \w{3} \d/);
+	expect(updated.textContent).toMatch(/^Updated /);
+	expect(updated.textContent).toContain('ago');
 
 	// Pristine editor → Save disabled.
 	const save = getByTestId('chat-history-save') as HTMLButtonElement;

--- a/packages/web/test/format-date.test.ts
+++ b/packages/web/test/format-date.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+	formatDate,
+	formatDateTime,
+	formatRelativeTime,
+	formatRelativeTimeCompact,
+} from '../src/lib/format-date';
+
+// A fixed "now" so the relative math is deterministic regardless of when the
+// suite runs. date-fns reads Date.now(), which vi.setSystemTime controls.
+const NOW = new Date('2026-07-19T12:00:00.000Z');
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+/** ISO string for a timestamp `ms` in the past relative to the frozen NOW. */
+function ago(ms: number): string {
+	return new Date(NOW.getTime() - ms).toISOString();
+}
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	vi.setSystemTime(NOW);
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe('formatRelativeTime', () => {
+	test('phrases recent past exactly as requested', () => {
+		expect(formatRelativeTime(ago(30 * SECOND))).toBe('30 seconds ago');
+		expect(formatRelativeTime(ago(HOUR))).toBe('1 hour ago');
+		expect(formatRelativeTime(ago(6 * HOUR))).toBe('6 hours ago');
+		expect(formatRelativeTime(ago(DAY))).toBe('1 day ago');
+		expect(formatRelativeTime(ago(2 * DAY))).toBe('2 days ago');
+	});
+
+	test('stays relative right up to the 7-day cutoff', () => {
+		expect(formatRelativeTime(ago(6 * DAY))).toBe('6 days ago');
+		// 6d23h rounds up to "7 days ago" but is still under the cutoff.
+		expect(formatRelativeTime(ago(6 * DAY + 23 * HOUR))).toBe('7 days ago');
+	});
+
+	test('falls back to the absolute date once older than 7 days', () => {
+		const iso = ago(8 * DAY);
+		expect(formatRelativeTime(iso)).toBe(new Date(iso).toLocaleDateString());
+		// Exactly 7 days is the boundary — the date, not "7 days ago".
+		const boundary = ago(7 * DAY);
+		expect(formatRelativeTime(boundary)).toBe(new Date(boundary).toLocaleDateString());
+	});
+
+	test('reads as "in …" for near-future timestamps', () => {
+		const future = new Date(NOW.getTime() + HOUR).toISOString();
+		expect(formatRelativeTime(future)).toBe('in 1 hour');
+	});
+
+	test('returns "" for empty or unparsable input', () => {
+		expect(formatRelativeTime('')).toBe('');
+		expect(formatRelativeTime(null)).toBe('');
+		expect(formatRelativeTime(undefined)).toBe('');
+		expect(formatRelativeTime('not-a-date')).toBe('');
+	});
+});
+
+describe('formatRelativeTimeCompact', () => {
+	test('uses terse unit-letter forms', () => {
+		expect(formatRelativeTimeCompact(ago(30 * SECOND))).toBe('now');
+		expect(formatRelativeTimeCompact(ago(5 * MINUTE))).toBe('5m');
+		expect(formatRelativeTimeCompact(ago(3 * HOUR))).toBe('3h');
+		expect(formatRelativeTimeCompact(ago(2 * DAY))).toBe('2d');
+	});
+
+	test('falls back to the absolute date once older than 7 days', () => {
+		const iso = ago(8 * DAY);
+		expect(formatRelativeTimeCompact(iso)).toBe(new Date(iso).toLocaleDateString());
+	});
+
+	test('returns "" for empty or unparsable input', () => {
+		expect(formatRelativeTimeCompact('')).toBe('');
+		expect(formatRelativeTimeCompact('nope')).toBe('');
+	});
+});
+
+describe('formatDateTime / formatDate', () => {
+	test('formatDateTime returns the full local date+time, "" when unparsable', () => {
+		const iso = ago(DAY);
+		expect(formatDateTime(iso)).toBe(new Date(iso).toLocaleString());
+		expect(formatDateTime('')).toBe('');
+		expect(formatDateTime('bad')).toBe('');
+	});
+
+	test('formatDate returns the local date only, "" when unparsable', () => {
+		const iso = ago(DAY);
+		expect(formatDate(iso)).toBe(new Date(iso).toLocaleDateString());
+		expect(formatDate(null)).toBe('');
+	});
+});

--- a/packages/web/test/project-assets-states.test.tsx
+++ b/packages/web/test/project-assets-states.test.tsx
@@ -297,7 +297,7 @@ test('uploading a disallowed file type surfaces a transient error chip', async (
 	expect(chip.textContent).toContain('malware.exe');
 });
 
-test('the asset card shows the relative updated time after the size, with the exact timestamp in the <abbr> title', async () => {
+test('the asset card shows the relative updated time after the size, as a <time> element carrying the exact timestamp', async () => {
 	const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
 	const r = await renderAssetsWith([
 		asset({
@@ -316,9 +316,8 @@ test('the asset card shows the relative updated time after the size, with the ex
 	const meta = updated.parentElement as HTMLElement;
 	expect(meta.textContent).toContain('7.8 KB');
 	expect(meta.textContent).toContain('·');
-	// Hovering surfaces the exact timestamp via the native <abbr> tooltip.
-	expect(updated.tagName).toBe('ABBR');
-	const title = updated.getAttribute('title') ?? '';
-	expect(title).not.toBe('');
-	expect(title).toContain(new Date(twoDaysAgo).getFullYear().toString());
+	// Rendered as a semantic <time> whose dateTime carries the exact timestamp;
+	// the full local date+time is surfaced on hover/tap via the RelativeTime tooltip.
+	expect(updated.tagName).toBe('TIME');
+	expect(updated.getAttribute('datetime')).toBe(twoDaysAgo);
 });

--- a/packages/web/test/relative-time.test.tsx
+++ b/packages/web/test/relative-time.test.tsx
@@ -1,0 +1,40 @@
+import { render } from '@testing-library/react';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { RelativeTime } from '../src/components/ui/relative-time';
+
+// The absolute-date tooltip content is driven by formatDateTime (covered in
+// format-date.test.ts) and rendered through the shared Radix <Tooltip>; its
+// hover/tap portal behaviour needs a real layout engine, so the interaction is
+// exercised in the Playwright tier, not here in happy-dom.
+
+const NOW = new Date('2026-07-19T12:00:00.000Z');
+const HOUR = 60 * 60 * 1000;
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	vi.setSystemTime(NOW);
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+test('renders a <time> with the relative label and the exact timestamp in dateTime', () => {
+	const iso = new Date(NOW.getTime() - 2 * HOUR).toISOString();
+	const { container } = render(<RelativeTime iso={iso} />);
+	const el = container.querySelector('time');
+	expect(el).not.toBeNull();
+	expect(el?.textContent).toBe('2 hours ago');
+	expect(el?.getAttribute('datetime')).toBe(iso);
+});
+
+test('honours the compact variant', () => {
+	const iso = new Date(NOW.getTime() - 3 * HOUR).toISOString();
+	const { container } = render(<RelativeTime iso={iso} compact />);
+	expect(container.querySelector('time')?.textContent).toBe('3h');
+});
+
+test('renders nothing for an empty/unparsable timestamp', () => {
+	const { container } = render(<RelativeTime iso={null} />);
+	expect(container.querySelector('time')).toBeNull();
+});

--- a/test/browser/task-detail.mobile.spec.ts
+++ b/test/browser/task-detail.mobile.spec.ts
@@ -267,7 +267,7 @@ test.describe('Comment header — mobile (narrow viewport)', () => {
 		if (!replyRes.ok()) throw new Error(`seed reply failed: ${replyRes.status()}`);
 	}
 
-	test('header stays on one row; timestamp truncates and reveals the full value on tap', async ({
+	test('header stays on one row; timestamp shows a relative label and reveals the full date on tap', async ({
 		page,
 		freshWorkspace,
 	}) => {
@@ -312,22 +312,26 @@ test.describe('Comment header — mobile (narrow viewport)', () => {
 		expect(sameRow(authorBox, tsBox)).toBe(true);
 		expect(sameRow(authorBox, replyBox)).toBe(true);
 
-		// The timestamp is the segment that gave way: it is clipped to an ellipsis
-		// (rendered narrower than its full text), yet its full value is intact in
-		// the DOM for the tooltip.
-		const truncated = await timestamp.evaluate((el) => el.scrollWidth > el.clientWidth);
-		expect(truncated).toBe(true);
+		// The timestamp is a short relative label ("… ago"), truncatable if needed
+		// (min-w-0 truncate), and it stays within the viewport.
 		expect(tsBox.x + tsBox.width).toBeLessThanOrEqual(320);
-		const full = ((await timestamp.textContent()) ?? '').trim();
-		expect(full.length).toBeGreaterThan(0);
+		const label = ((await timestamp.textContent()) ?? '').trim();
+		expect(label.length).toBeGreaterThan(0);
+		// A freshly-seeded comment reads as "… ago", not the absolute date.
+		expect(label).toMatch(/ago$/);
 
-		// Tapping the timestamp reveals the full date/time in a tooltip (Radix
-		// tooltips never open on tap, so the component drives `open` from its own
-		// touchstart handler).
+		// Tapping the timestamp reveals the full absolute date/time in a tooltip
+		// (Radix tooltips never open on tap, so the component drives `open` from its
+		// own touchstart handler). The tooltip shows the exact timestamp, which is
+		// distinct from the relative label.
 		await timestamp.dispatchEvent('touchstart');
 		const tooltip = page.getByRole('tooltip');
 		await expect(tooltip).toBeVisible({ timeout: 5000 });
-		expect(((await tooltip.textContent()) ?? '').trim()).toBe(full);
+		const tooltipText = ((await tooltip.textContent()) ?? '').trim();
+		expect(tooltipText).not.toBe(label);
+		// The absolute local date+time includes a clock component (e.g.
+		// "7/19/2026, 4:46:44 AM"); the relative label never does.
+		expect(tooltipText).toMatch(/\d:\d\d/);
 	});
 });
 


### PR DESCRIPTION
## What & why

Timestamps across the web app were rendered inconsistently — the task activity/comment feed printed raw absolute timestamps (`19/07/2026, 05:45:18`), and there were **6 duplicated hand-rolled "relative time" implementations** plus ~15 scattered `toLocaleString` / `toLocaleDateString` calls, with no shared date utility.

This consolidates everything onto `date-fns` (already a dependency) behind one shared module + a reusable component. Timestamps now read as **relative "X ago"** up to a week, fall back to the **date** once older, and always expose the full local date+time in a **tooltip** on hover / mobile tap.

- `30 seconds ago`, `1 hour ago`, `6 hours ago`, `1 day ago`, `2 days ago`, … (via `formatDistanceToNowStrict(d, { addSuffix: true })` — no "about"/"less than" fuzz)
- Older than 7 days → absolute date
- Always a tooltip with the exact date/time

## Changes

**New**
- `packages/web/src/lib/format-date.ts` — `formatRelativeTime`, `formatRelativeTimeCompact` (terse `5m`/`3h`/`2d` for space-constrained spots), `formatDateTime`, `formatDate`; a 7-day → absolute-date cutoff and NaN/empty guards.
- `packages/web/src/components/ui/relative-time.tsx` — `<RelativeTime>` pairing the relative label with the shared Radix `<Tooltip>` (hover + controlled mobile-tap), rendered as a semantic `<time dateTime>`.

**Refactors**
- Removed the 6 custom relative-time implementations (`markdown-prose`, `assets`, `home`, `mention-card`, `api-keys`, `credentials`) in favour of the shared helpers.
- Converted the comment/activity feed (comment timestamps, run comments, audit log) and the scattered absolute displays (task sidebar, revisions, agent executions/settings/chat memory, document metadata + revision banners, captain intake chat, archived projects, goal run activity, docs switcher meta).
- **Left absolute on purpose:** goal **deadlines/target dates** (future dates read wrong as "in 3 months") and **chart axes** (`budget/chart-format`, `goal-progress-chart`).

## Notes

- Inside clickable rows/buttons (mention card, goal run link, docs switcher) the timestamp uses a native `title` tooltip instead of the interactive `<RelativeTime>` so the tap target isn't hijacked.
- Purely a web-frontend presentation change — no API/route/MCP/CLI/data-model surface touched, so no docs/architecture updates needed.

## Testing

- New `packages/web/test/format-date.test.ts` (fake-timer unit tests: exact phrasing, the 7-day boundary, compact forms, empty/NaN) and `relative-time.test.tsx` (label + `dateTime` + compact + empty).
- Updated the two existing specs that pinned the old absolute date format (`agent-chat-history-page`, `project-assets-states`).
- `bun run typecheck` ✅, `biome check` ✅, and the affected web vitest files (70 tests across 9 files) ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MWXzgxwDRAm7wdzH8HtSsF

---
_Generated by [Claude Code](https://claude.ai/code/session_01MWXzgxwDRAm7wdzH8HtSsF)_