### PR TITLE
feat(web): infinite scroll for skills, connectors, credentials & runs lists

### DIFF
--- a/packages/server/src/routes/agents.ts
+++ b/packages/server/src/routes/agents.ts
@@ -34,6 +34,7 @@ import { broadcastChange, broadcastCommentFamilyChange } from '../lib/broadcast'
 import { budgetWindowsError } from '../lib/budget-validation';
 import { signEntityIconUrl, verifyEntityIconUrl } from '../lib/entity-icon-urls';
 import { readImageDimensions } from '../lib/image-dimensions';
+import { buildMeta, parsePagination } from '../lib/pagination';
 import {
 	actorTypeFromAuth,
 	resolveActor,
@@ -1310,6 +1311,12 @@ agentsRoutes.get('/projects/:projectId/agents/:agentId/heartbeat-runs', async (c
 	const agentId = await resolveAgentId(db, teamId, c.req.param('agentId'));
 	if (!agentId) return err(c, 'NOT_FOUND', 'Agent not found', 404);
 
+	const { page, perPage, offset } = parsePagination(c);
+	const countResult = await db.query<{ total: number }>(
+		`SELECT count(*)::int AS total FROM heartbeat_runs hr WHERE hr.member_id = $1`,
+		[agentId],
+	);
+	const total = countResult.rows[0]?.total ?? 0;
 	const result = await db.query(
 		`SELECT ${HEARTBEAT_RUN_COLUMNS}
 		 FROM heartbeat_runs hr
@@ -1318,11 +1325,11 @@ agentsRoutes.get('/projects/:projectId/agents/:agentId/heartbeat-runs', async (c
 		 ${HEARTBEAT_RUN_TRIGGER_JOINS}
 		 WHERE hr.member_id = $1
 		 ORDER BY hr.started_at DESC
-		 LIMIT 50`,
-		[agentId],
+		 LIMIT $2 OFFSET $3`,
+		[agentId, perPage, offset],
 	);
 
-	return ok(c, result.rows);
+	return c.json({ data: result.rows, meta: buildMeta(page, perPage, total) });
 });
 
 agentsRoutes.get('/projects/:projectId/agents/:agentId/heartbeat-runs/:runId', async (c) => {

--- a/packages/server/src/routes/connectors.ts
+++ b/packages/server/src/routes/connectors.ts
@@ -4,6 +4,7 @@ import { encrypt } from '../crypto/encryption';
 import { trackBackground } from '../lib/background';
 import { broadcastChange } from '../lib/broadcast';
 import { validateSecretName } from '../lib/credential-placeholder';
+import { buildMeta, parsePagination } from '../lib/pagination';
 import { resolveActor } from '../lib/resolve';
 import { err, ok } from '../lib/response';
 import { isUniqueViolation, withTransaction } from '../lib/sql';
@@ -64,6 +65,13 @@ connectorsRoutes.get('/connectors/oauth-providers', async (c) => {
 connectorsRoutes.get('/projects/:projectId/connectors', async (c) => {
 	const db = c.get('db');
 	const projectId = c.get('projectId') as string;
+	const { page, perPage, offset } = parsePagination(c);
+	const countResult = await db.query<{ total: number }>(
+		`SELECT count(*)::int AS total FROM mcp_connections mc
+		 WHERE mc.project_id = $1 OR mc.project_id IS NULL`,
+		[projectId],
+	);
+	const total = countResult.rows[0]?.total ?? 0;
 	const result = await db.query(
 		`SELECT ${CONNECTOR_COLUMNS_MC}, oc.provider_account_label AS oauth_account_label,
 		        LOWER(t.identifier) AS created_by_task_identifier, t.title AS created_by_task_title,
@@ -72,10 +80,11 @@ connectorsRoutes.get('/projects/:projectId/connectors', async (c) => {
 		 LEFT JOIN oauth_connections oc ON oc.id = mc.oauth_connection_id
 		 LEFT JOIN tasks t ON t.id = mc.created_by_task_id
 		 WHERE mc.project_id = $1 OR mc.project_id IS NULL
-		 ORDER BY mc.name ASC`,
-		[projectId],
+		 ORDER BY mc.name ASC
+		 LIMIT $2 OFFSET $3`,
+		[projectId, perPage, offset],
 	);
-	return ok(c, result.rows);
+	return c.json({ data: result.rows, meta: buildMeta(page, perPage, total) });
 });
 
 // Admin surface: every connector across all projects, each annotated with its
@@ -85,6 +94,11 @@ connectorsRoutes.get('/connectors', async (c) => {
 	const denied = requireAdminEquivalent(c);
 	if (denied) return denied;
 	const db = c.get('db');
+	const { page, perPage, offset } = parsePagination(c);
+	const countResult = await db.query<{ total: number }>(
+		`SELECT count(*)::int AS total FROM mcp_connections mc`,
+	);
+	const total = countResult.rows[0]?.total ?? 0;
 	const result = await db.query(
 		`SELECT ${CONNECTOR_COLUMNS_MC}, p.name AS project_name, p.slug AS project_slug,
 		        oc.provider_account_label AS oauth_account_label,
@@ -92,9 +106,11 @@ connectorsRoutes.get('/connectors', async (c) => {
 		 FROM mcp_connections mc
 		 LEFT JOIN projects p ON p.id = mc.project_id
 		 LEFT JOIN oauth_connections oc ON oc.id = mc.oauth_connection_id
-		 ORDER BY mc.name ASC`,
+		 ORDER BY mc.name ASC
+		 LIMIT $1 OFFSET $2`,
+		[perPage, offset],
 	);
-	return ok(c, result.rows);
+	return c.json({ data: result.rows, meta: buildMeta(page, perPage, total) });
 });
 
 connectorsRoutes.post('/connectors', async (c) => {

--- a/packages/server/src/routes/goals.ts
+++ b/packages/server/src/routes/goals.ts
@@ -1,11 +1,14 @@
 import { WakeupStatus, wsRoom } from '@hezo/shared';
 import { Hono } from 'hono';
 import { broadcastChange } from '../lib/broadcast';
+import { buildMeta, parsePagination } from '../lib/pagination';
 import { resolveActorMemberId } from '../lib/resolve';
 import { err, ok } from '../lib/response';
 import type { Env } from '../lib/types';
 import {
 	type CreateGoalInput,
+	countGoalRunActivity,
+	countProgressUpdateRuns,
 	createGoal,
 	GoalError,
 	getGoal,
@@ -35,8 +38,11 @@ goalsRoutes.get('/projects/:projectId/goals', async (c) => {
 // Registered before /goals/:goalId so "runs" isn't captured as a goal id.
 goalsRoutes.get('/projects/:projectId/goals/runs', async (c) => {
 	const projectId = c.get('projectId') as string;
-	const runs = await listProgressUpdateRuns(c.get('db'), projectId);
-	return ok(c, runs);
+	const db = c.get('db');
+	const { page, perPage, offset } = parsePagination(c);
+	const total = await countProgressUpdateRuns(db, projectId);
+	const runs = await listProgressUpdateRuns(db, projectId, { limit: perPage, offset });
+	return c.json({ data: runs, meta: buildMeta(page, perPage, total) });
 });
 
 goalsRoutes.post('/projects/:projectId/goals', async (c) => {
@@ -192,10 +198,13 @@ goalsRoutes.get('/projects/:projectId/goals/:goalId/history', async (c) => {
 goalsRoutes.get('/projects/:projectId/goals/:goalId/runs', async (c) => {
 	const projectId = c.get('projectId') as string;
 	const goalId = c.req.param('goalId');
-	const goal = await getGoal(c.get('db'), projectId, goalId);
+	const db = c.get('db');
+	const goal = await getGoal(db, projectId, goalId);
 	if (!goal) return err(c, 'NOT_FOUND', 'Goal not found', 404);
-	const runs = await listGoalRunActivity(c.get('db'), projectId, goalId);
-	return ok(c, runs);
+	const { page, perPage, offset } = parsePagination(c);
+	const total = await countGoalRunActivity(db, projectId, goalId);
+	const runs = await listGoalRunActivity(db, projectId, goalId, { limit: perPage, offset });
+	return c.json({ data: runs, meta: buildMeta(page, perPage, total) });
 });
 
 goalsRoutes.patch('/projects/:projectId/goals/:goalId', async (c) => {

--- a/packages/server/src/routes/secrets.ts
+++ b/packages/server/src/routes/secrets.ts
@@ -1,6 +1,7 @@
 import { SecretCategory } from '@hezo/shared';
 import { Hono } from 'hono';
 import { validateSecretName } from '../lib/credential-placeholder';
+import { buildMeta, parsePagination } from '../lib/pagination';
 import { err, ok } from '../lib/response';
 import type { Env } from '../lib/types';
 import { requireAdminEquivalent } from '../middleware/auth';
@@ -26,6 +27,12 @@ secretsRoutes.get('/credentials', async (c) => {
 	const denied = requireAdminEquivalent(c);
 	if (denied) return denied;
 	const db = c.get('db');
+	const { page, perPage, offset } = parsePagination(c);
+
+	const countResult = await db.query<{ total: number }>(
+		`SELECT count(*)::int AS total FROM secrets`,
+	);
+	const total = countResult.rows[0]?.total ?? 0;
 
 	// Per-secret egress usage is no longer tracked (egress requests aren't
 	// audited), so the usage columns are constant placeholders kept only for
@@ -49,9 +56,11 @@ secretsRoutes.get('/credentials', async (c) => {
 		               )
 		        ), '[]'::json) AS connectors
 		 FROM secrets s
-		 ORDER BY s.name ASC`,
+		 ORDER BY s.name ASC
+		 LIMIT $1 OFFSET $2`,
+		[perPage, offset],
 	);
-	return ok(c, result.rows);
+	return c.json({ data: result.rows, meta: buildMeta(page, perPage, total) });
 });
 
 secretsRoutes.post('/secrets', async (c) => {

--- a/packages/server/src/routes/skills.ts
+++ b/packages/server/src/routes/skills.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 import type { SkillRecord } from '@hezo/shared';
 import { Hono } from 'hono';
 import { installDefaultSkills, listMissingDefaultSkills } from '../db/default-skills';
+import { buildMeta, parsePagination } from '../lib/pagination';
 import { err, ok } from '../lib/response';
 import { deriveSkillSummary } from '../lib/skill-summary';
 import { toSlug } from '../lib/slug';
@@ -122,21 +123,28 @@ skillsRoutes.get('/skills', async (c) => {
 	const denied = requireAdminEquivalent(c);
 	if (denied) return denied;
 	const db = c.get('db');
+	const { page, perPage, offset } = parsePagination(c);
+	const countResult = await db.query<{ total: number }>(
+		`SELECT count(*)::int AS total FROM skills s WHERE s.is_active = true`,
+	);
+	const total = countResult.rows[0]?.total ?? 0;
 	const result = await db.query(
 		`SELECT ${SKILL_LIST_COLUMNS_S}, p.name AS project_name, p.slug AS project_slug
 		 FROM skills s
 		 LEFT JOIN projects p ON p.id = s.project_id
 		 WHERE s.is_active = true
-		 ORDER BY s.name`,
+		 ORDER BY s.name
+		 LIMIT $1 OFFSET $2`,
+		[perPage, offset],
 	);
-	// Surface the built-in `connector-recipes` virtual skill read-only alongside
-	// the DB rows (annotate stored rows so the UI can tell them apart).
 	const rows: Record<string, unknown>[] = result.rows.map((r) => ({
 		...(r as Record<string, unknown>),
 		readonly: false,
 	}));
-	rows.push(connectorRecipesSkillRow(false));
-	return ok(c, rows);
+	// The built-in `connector-recipes` virtual skill isn't a DB row, so it sits
+	// outside the paginated set — surface it read-only on the first page only.
+	if (page === 1) rows.unshift(connectorRecipesSkillRow(false));
+	return c.json({ data: rows, meta: buildMeta(page, perPage, total) });
 });
 
 skillsRoutes.post('/skills', async (c) => {
@@ -540,23 +548,31 @@ skillsRoutes.delete('/skills/:id', async (c) => {
 skillsRoutes.get('/projects/:projectId/skills', async (c) => {
 	const db = c.get('db');
 	const projectId = c.get('projectId') as string;
+	const { page, perPage, offset } = parsePagination(c);
+	const countResult = await db.query<{ total: number }>(
+		`SELECT count(*)::int AS total FROM skills s
+		 WHERE s.is_active = true AND (s.project_id = $1 OR s.project_id IS NULL)`,
+		[projectId],
+	);
+	const total = countResult.rows[0]?.total ?? 0;
 	const result = await db.query(
 		`SELECT ${SKILL_LIST_COLUMNS_S}, p.name AS project_name, p.slug AS project_slug
 		 FROM skills s
 		 LEFT JOIN projects p ON p.id = s.project_id
 		 WHERE s.is_active = true AND (s.project_id = $1 OR s.project_id IS NULL)
-		 ORDER BY s.name`,
-		[projectId],
+		 ORDER BY s.name
+		 LIMIT $2 OFFSET $3`,
+		[projectId, perPage, offset],
 	);
-	// The built-in `connector-recipes` virtual skill is global (project_id null) —
-	// every project's runs see it — so surface it read-only alongside the stored
-	// rows here too, exactly as the admin /skills list does.
 	const rows: Record<string, unknown>[] = result.rows.map((r) => ({
 		...(r as Record<string, unknown>),
 		readonly: false,
 	}));
-	rows.push(connectorRecipesSkillRow(false));
-	return ok(c, rows);
+	// The built-in `connector-recipes` virtual skill is global (project_id null) —
+	// every project's runs see it — so surface it read-only on the first page only,
+	// outside the paginated DB set, exactly as the admin /skills list does.
+	if (page === 1) rows.unshift(connectorRecipesSkillRow(false));
+	return c.json({ data: rows, meta: buildMeta(page, perPage, total) });
 });
 
 skillsRoutes.get('/projects/:projectId/skills/:id', async (c) => {

--- a/packages/server/src/services/goals.ts
+++ b/packages/server/src/services/goals.ts
@@ -325,7 +325,7 @@ export async function recordGoalProgress(
 export async function listProgressUpdateRuns(
 	db: Db,
 	projectId: string,
-	limit = 50,
+	{ limit = 50, offset = 0 }: { limit?: number; offset?: number } = {},
 ): Promise<ProgressUpdateRunSummary[]> {
 	// Progress-update runs are team-scoped (Captain runs with no task); a project maps 1:1 to its
 	// team, so filter by the project's team. The title list is a correlated subquery — no join
@@ -345,10 +345,23 @@ export async function listProgressUpdateRuns(
 		   AND hr.task_id IS NULL
 		   AND hr.team_id = (SELECT team_id FROM projects WHERE id = $2)
 		 ORDER BY hr.created_at DESC
-		 LIMIT $3`,
-		[HeartbeatRunKind.ProgressUpdate, projectId, limit],
+		 LIMIT $3 OFFSET $4`,
+		[HeartbeatRunKind.ProgressUpdate, projectId, limit, offset],
 	);
 	return r.rows;
+}
+
+/** Total number of progress-update runs for a project (for pagination meta). */
+export async function countProgressUpdateRuns(db: Db, projectId: string): Promise<number> {
+	const r = await db.query<{ total: number }>(
+		`SELECT count(*)::int AS total
+		 FROM heartbeat_runs hr
+		 WHERE hr.kind = $1
+		   AND hr.task_id IS NULL
+		   AND hr.team_id = (SELECT team_id FROM projects WHERE id = $2)`,
+		[HeartbeatRunKind.ProgressUpdate, projectId],
+	);
+	return r.rows[0]?.total ?? 0;
 }
 
 /**
@@ -361,7 +374,7 @@ export async function listGoalRunActivity(
 	db: Db,
 	projectId: string,
 	goalId: string,
-	limit = 50,
+	{ limit = 50, offset = 0 }: { limit?: number; offset?: number } = {},
 ): Promise<GoalRunActivity[]> {
 	const r = await db.query<GoalRunActivity>(
 		`SELECT hr.id, hr.status, hr.created_at, hr.started_at, hr.finished_at,
@@ -406,8 +419,33 @@ export async function listGoalRunActivity(
 		     )
 		   )
 		 ORDER BY hr.created_at DESC
-		 LIMIT $4`,
-		[HeartbeatRunKind.ProgressUpdate, goalId, projectId, limit],
+		 LIMIT $4 OFFSET $5`,
+		[HeartbeatRunKind.ProgressUpdate, goalId, projectId, limit, offset],
 	);
 	return r.rows;
+}
+
+/** Total number of progress-update runs that touched one goal (for pagination meta). */
+export async function countGoalRunActivity(
+	db: Db,
+	projectId: string,
+	goalId: string,
+): Promise<number> {
+	const r = await db.query<{ total: number }>(
+		`SELECT count(*)::int AS total
+		 FROM heartbeat_runs hr
+		 WHERE hr.kind = $1
+		   AND hr.task_id IS NULL
+		   AND hr.team_id = (SELECT team_id FROM projects WHERE id = $3)
+		   AND (
+		     EXISTS (SELECT 1 FROM goal_run_updates gru WHERE gru.run_id = hr.id AND gru.goal_id = $2)
+		     OR EXISTS (SELECT 1 FROM tasks t WHERE t.goal_id = $2 AND t.created_by_run_id = hr.id)
+		     OR EXISTS (
+		       SELECT 1 FROM task_comments tc JOIN tasks t ON t.id = tc.task_id
+		       WHERE tc.created_by_run_id = hr.id AND t.goal_id = $2
+		     )
+		   )`,
+		[HeartbeatRunKind.ProgressUpdate, goalId, projectId],
+	);
+	return r.rows[0]?.total ?? 0;
 }

--- a/packages/server/test/goals-coverage-more.test.ts
+++ b/packages/server/test/goals-coverage-more.test.ts
@@ -8,6 +8,8 @@ import { GoalHealth } from '@hezo/shared';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { signAdminJwt } from '../src/middleware/auth';
 import {
+	countGoalRunActivity,
+	countProgressUpdateRuns,
 	createGoal,
 	getDueGoals,
 	getGoal,
@@ -371,6 +373,58 @@ describe('goal history and run activity routes', () => {
 		expect(await getGoal(ctx.db, crypto.randomUUID(), goalId)).toBeNull();
 		expect(await getGoalHistory(ctx.db, crypto.randomUUID(), goalId)).toBeNull();
 	});
+
+	it('GET /goals/runs paginates with offset + total meta', async () => {
+		// Ensure at least three project-wide progress-update runs exist.
+		await newProgressUpdateRun();
+		await newProgressUpdateRun();
+
+		const runsUrl = `/api/projects/${projectSlug}/goals/runs`;
+		const all = await ctx.app.request(`${runsUrl}?per_page=200`, { headers: authHeader(token) });
+		const allBody = await all.json();
+		const total = allBody.meta.total as number;
+		expect(total).toBeGreaterThanOrEqual(3);
+		expect(allBody.data).toHaveLength(total);
+
+		const p1 = await ctx.app.request(`${runsUrl}?page=1&per_page=2`, {
+			headers: authHeader(token),
+		});
+		const b1 = await p1.json();
+		expect(b1.meta).toEqual({ page: 1, per_page: 2, total });
+		expect(b1.data).toHaveLength(2);
+
+		const p2 = await ctx.app.request(`${runsUrl}?page=2&per_page=2`, {
+			headers: authHeader(token),
+		});
+		const b2 = await p2.json();
+		expect(b2.meta.page).toBe(2);
+		// Adjacent pages never overlap.
+		const ids1 = b1.data.map((r: { id: string }) => r.id);
+		const ids2 = b2.data.map((r: { id: string }) => r.id);
+		expect(ids1.some((id: string) => ids2.includes(id))).toBe(false);
+	});
+
+	it('GET /goals/:goalId/runs paginates with offset + total meta', async () => {
+		// Add two more runs that touch this goal so it has >1 activity row.
+		for (let i = 0; i < 2; i++) {
+			const r = await newProgressUpdateRun();
+			await recordGoalProgress(
+				ctx.db,
+				{ goalId, runId: r, progressPercent: 50 + i, health: GoalHealth.OnTrack, statusBlurb: 'x' },
+				undefined,
+			);
+		}
+
+		const url = `/api/projects/${projectSlug}/goals/${goalId}/runs`;
+		const all = await ctx.app.request(`${url}?per_page=200`, { headers: authHeader(token) });
+		const total = (await all.json()).meta.total as number;
+		expect(total).toBeGreaterThanOrEqual(3);
+
+		const p1 = await ctx.app.request(`${url}?page=1&per_page=2`, { headers: authHeader(token) });
+		const b1 = await p1.json();
+		expect(b1.meta).toEqual({ page: 1, per_page: 2, total });
+		expect(b1.data).toHaveLength(2);
+	});
 });
 
 describe('getDueGoals cadence branches', () => {
@@ -580,8 +634,49 @@ describe('listProgressUpdateRuns / listGoalRunActivity', () => {
 		expect(summary?.updated_goal_titles).toContain('Annotated goal');
 		expect(summary?.member_id).toBe(captainId);
 
-		const limited = await listProgressUpdateRuns(ctx.db, projectId, 1);
+		const limited = await listProgressUpdateRuns(ctx.db, projectId, { limit: 1 });
 		expect(limited).toHaveLength(1);
+	});
+
+	it('countProgressUpdateRuns matches the list and offset skips rows', async () => {
+		const total = await countProgressUpdateRuns(ctx.db, projectId);
+		const all = await listProgressUpdateRuns(ctx.db, projectId, { limit: total });
+		expect(all).toHaveLength(total);
+		expect(total).toBeGreaterThanOrEqual(2);
+
+		const firstTwo = await listProgressUpdateRuns(ctx.db, projectId, { limit: 2, offset: 0 });
+		const afterOne = await listProgressUpdateRuns(ctx.db, projectId, { limit: 2, offset: 1 });
+		// offset 1 drops the newest row and shares the second with the offset-0 page.
+		expect(firstTwo[1].id).toBe(afterOne[0].id);
+		expect(firstTwo[0].id).not.toBe(afterOne[0].id);
+	});
+
+	it('countGoalRunActivity matches the per-goal list and offset skips rows', async () => {
+		const goal = await createGoal(
+			ctx.db,
+			teamId,
+			{ project_id: projectId, title: 'Counted goal' },
+			{ actorMemberId: null },
+			undefined,
+		);
+		for (let i = 0; i < 3; i++) {
+			const runId = await newProgressUpdateRun();
+			await recordGoalProgress(
+				ctx.db,
+				{
+					goalId: goal.id,
+					runId,
+					progressPercent: 10 * i,
+					health: GoalHealth.OnTrack,
+					statusBlurb: 's',
+				},
+				undefined,
+			);
+		}
+		const total = await countGoalRunActivity(ctx.db, projectId, goal.id);
+		expect(total).toBe(3);
+		const paged = await listGoalRunActivity(ctx.db, projectId, goal.id, { limit: 2, offset: 2 });
+		expect(paged).toHaveLength(1);
 	});
 
 	it('collects estimate, created-task, and commented-task activity per goal', async () => {
@@ -638,7 +733,7 @@ describe('listProgressUpdateRuns / listGoalRunActivity', () => {
 		expect(b?.created_tasks.map((t) => t.identifier)).toContain(createdB.identifier);
 		expect(activityB.map((r) => r.id)).not.toContain(runA);
 
-		const limited = await listGoalRunActivity(ctx.db, projectId, goalA.id, 1);
+		const limited = await listGoalRunActivity(ctx.db, projectId, goalA.id, { limit: 1 });
 		expect(limited).toHaveLength(1);
 	});
 });

--- a/packages/server/test/heartbeat-runs.test.ts
+++ b/packages/server/test/heartbeat-runs.test.ts
@@ -130,6 +130,45 @@ describe('heartbeat-runs API', () => {
 		expect(run.project_name).toBe('Main');
 	});
 
+	it('paginates the runs list with offset + total meta', async () => {
+		// A fresh agent so the count is exactly what this test inserts.
+		const agentRes = await app.request(`/api/projects/${projectSlug}/agents`, {
+			method: 'POST',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ title: 'Paged Runner' }),
+		});
+		const pagedAgentId = (await agentRes.json()).data.id as string;
+
+		// Insert 5 runs with strictly increasing started_at so ORDER BY started_at
+		// DESC is deterministic (newest = run #5).
+		const ids: string[] = [];
+		for (let i = 0; i < 5; i++) {
+			const r = await db.query<{ id: string }>(
+				`INSERT INTO heartbeat_runs (member_id, team_id, status, started_at)
+				 VALUES ($1, $2, 'succeeded'::heartbeat_run_status, now() + ($3 || ' seconds')::interval)
+				 RETURNING id`,
+				[pagedAgentId, teamId, String(i)],
+			);
+			ids.push(r.rows[0].id);
+		}
+
+		const base = `/api/projects/${projectSlug}/agents/${pagedAgentId}/heartbeat-runs`;
+		const p1 = await app.request(`${base}?page=1&per_page=2`, { headers: authHeader(token) });
+		const b1 = await p1.json();
+		expect(b1.meta).toEqual({ page: 1, per_page: 2, total: 5 });
+		expect(b1.data).toHaveLength(2);
+		// Newest first: run #5 then #4.
+		expect(b1.data[0].id).toBe(ids[4]);
+		expect(b1.data[1].id).toBe(ids[3]);
+
+		const p3 = await app.request(`${base}?page=3&per_page=2`, { headers: authHeader(token) });
+		const b3 = await p3.json();
+		expect(b3.meta).toEqual({ page: 3, per_page: 2, total: 5 });
+		// Last page holds the single oldest run (#1) — previously unreachable past 50.
+		expect(b3.data).toHaveLength(1);
+		expect(b3.data[0].id).toBe(ids[0]);
+	});
+
 	it('gets a single run by id with task info', async () => {
 		const res = await app.request(
 			`/api/projects/${projectSlug}/agents/${agentId}/heartbeat-runs/${runId}`,

--- a/packages/server/test/instance-connectors.test.ts
+++ b/packages/server/test/instance-connectors.test.ts
@@ -86,6 +86,41 @@ describe('global connectors', () => {
 		expect(forRun.some((r) => r.name === 'shared-docs')).toBe(true);
 	});
 
+	it('paginates the global connectors list with offset + total meta', async () => {
+		for (const name of ['page-a', 'page-b', 'page-c']) {
+			const res = await app.request('/api/connectors', {
+				method: 'POST',
+				headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					name,
+					kind: 'saas',
+					config: { url: `https://${name}.example.com/mcp` },
+				}),
+			});
+			expect(res.status).toBe(201);
+		}
+
+		const all = await app.request('/api/connectors?per_page=200', { headers: authHeader(token) });
+		const total = (await all.json()).meta.total as number;
+		expect(total).toBeGreaterThanOrEqual(3);
+
+		const p1 = await app.request('/api/connectors?page=1&per_page=2', {
+			headers: authHeader(token),
+		});
+		const b1 = await p1.json();
+		expect(b1.meta).toEqual({ page: 1, per_page: 2, total });
+		expect(b1.data).toHaveLength(2);
+
+		const p2 = await app.request('/api/connectors?page=2&per_page=2', {
+			headers: authHeader(token),
+		});
+		const b2 = await p2.json();
+		expect(b2.meta.page).toBe(2);
+		const ids1 = b1.data.map((r: { id: string }) => r.id);
+		const ids2 = b2.data.map((r: { id: string }) => r.id);
+		expect(ids1.some((id: string) => ids2.includes(id))).toBe(false);
+	});
+
 	it('rejects a local connector at the instance level', async () => {
 		const res = await app.request('/api/connectors', {
 			method: 'POST',

--- a/packages/server/test/instance-secrets.test.ts
+++ b/packages/server/test/instance-secrets.test.ts
@@ -57,6 +57,32 @@ describe('global credentials (secrets)', () => {
 		expect(resolved?.allowedHosts).toEqual(['api.shared.example']);
 	});
 
+	it('paginates the credentials list with offset + total meta', async () => {
+		for (const name of ['PAGE_1', 'PAGE_2', 'PAGE_3']) {
+			expect((await createSecret({ name, value: 'v', allow_all_hosts: true })).status).toBe(201);
+		}
+
+		const all = await app.request('/api/credentials?per_page=200', { headers: authHeader(token) });
+		const total = (await all.json()).meta.total as number;
+		expect(total).toBeGreaterThanOrEqual(3);
+
+		const p1 = await app.request('/api/credentials?page=1&per_page=2', {
+			headers: authHeader(token),
+		});
+		const b1 = await p1.json();
+		expect(b1.meta).toEqual({ page: 1, per_page: 2, total });
+		expect(b1.data).toHaveLength(2);
+
+		const p2 = await app.request('/api/credentials?page=2&per_page=2', {
+			headers: authHeader(token),
+		});
+		const b2 = await p2.json();
+		expect(b2.meta.page).toBe(2);
+		const ids1 = b1.data.map((s: { id: string }) => s.id);
+		const ids2 = b2.data.map((s: { id: string }) => s.id);
+		expect(ids1.some((id: string) => ids2.includes(id))).toBe(false);
+	});
+
 	it('secret names are unique instance-wide; re-POST rotates the value', async () => {
 		await createSecret({ name: 'ROTATE', value: 'v1', allow_all_hosts: true });
 		// Re-POST same name → upsert new value (no duplicate-key error).

--- a/packages/server/test/skills.test.ts
+++ b/packages/server/test/skills.test.ts
@@ -130,6 +130,29 @@ describe('global skills CRUD (/api/skills)', () => {
 		const read = await app.request(`/api/skills/${id}`, { headers: authHeader(token) });
 		expect((await read.json()).data.content).toBe('v2');
 	});
+
+	it('paginates the global list and pins the connector-recipes row to page 1', async () => {
+		for (const name of ['Skill A', 'Skill B', 'Skill C']) {
+			expect((await create({ name, content: `# ${name}` })).status).toBe(201);
+		}
+
+		const p1 = await app.request('/api/skills?page=1&per_page=2', { headers: authHeader(token) });
+		const b1 = await p1.json();
+		// total counts only the three DB rows (the virtual recipe row is not paged).
+		expect(b1.meta).toEqual({ page: 1, per_page: 2, total: 3 });
+		const slugs1 = b1.data.map((s: { slug: string }) => s.slug);
+		expect(slugs1).toContain('connector-recipes');
+		// recipe + first two DB rows by name.
+		expect(b1.data).toHaveLength(3);
+
+		const p2 = await app.request('/api/skills?page=2&per_page=2', { headers: authHeader(token) });
+		const b2 = await p2.json();
+		expect(b2.meta).toEqual({ page: 2, per_page: 2, total: 3 });
+		const slugs2 = b2.data.map((s: { slug: string }) => s.slug);
+		// the connector-recipes row appears once, on page 1 only.
+		expect(slugs2).not.toContain('connector-recipes');
+		expect(b2.data).toHaveLength(1);
+	});
 });
 
 describe('skill scope (create + re-scope on /api/skills)', () => {

--- a/packages/web/src/components/github-section.tsx
+++ b/packages/web/src/components/github-section.tsx
@@ -36,7 +36,8 @@ interface GitHubSectionProps {
 
 export function GitHubSection({ projectId }: GitHubSectionProps) {
 	const { data: connections = [], isLoading: connectionsLoading } = useOAuthConnections(projectId);
-	const { data: connectors = [] } = useConnectors(projectId);
+	const { data: connectorPages } = useConnectors(projectId);
+	const connectors = connectorPages?.pages.flatMap((p) => p.data) ?? [];
 	const { data: repos } = useRepos(projectId);
 	const deleteRepo = useDeleteRepo(projectId);
 	const retryRepo = useCreateRepo(projectId);

--- a/packages/web/src/components/goal-detail/goal-detail-page.tsx
+++ b/packages/web/src/components/goal-detail/goal-detail-page.tsx
@@ -5,12 +5,13 @@ import {
 } from '@hezo/shared';
 import { Link } from '@tanstack/react-router';
 import { Archive, ArchiveRestore, ChevronRight, Pencil } from 'lucide-react';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useGoal, useGoalHistory, useGoalRunActivity, useUpdateGoal } from '../../hooks/use-goals';
 import { agentPageParams } from '../agent-link';
 import { CreateGoalDialog } from '../create-goal-dialog';
 import { GoalHealthPill } from '../goal-health-pill';
 import { GoalProgressChart } from '../goal-progress-chart';
+import { InfiniteScrollSentinel } from '../infinite-scroll-sentinel';
 import { MarkdownProse } from '../markdown-prose';
 import { Badge, type BadgeColor } from '../ui/badge';
 
@@ -149,7 +150,21 @@ function GoalRunRow({ projectId, run }: { projectId: string; run: GoalRunActivit
 }
 
 function GoalRunsFeed({ projectId, goalId }: { projectId: string; goalId: string }) {
-	const { data: runs, isLoading } = useGoalRunActivity(projectId, goalId);
+	const {
+		data: runPages,
+		isLoading,
+		hasNextPage,
+		isFetchingNextPage,
+		fetchNextPage,
+	} = useGoalRunActivity(projectId, goalId);
+	// Flatten accumulated pages, deduping by id (offset pagination can transiently
+	// overlap a page boundary when a new run prepends).
+	const runs = useMemo(() => {
+		const seen = new Set<string>();
+		return (runPages?.pages.flatMap((p) => p.data) ?? []).filter((run) =>
+			seen.has(run.id) ? false : (seen.add(run.id), true),
+		);
+	}, [runPages]);
 
 	return (
 		<section data-testid="goal-runs" className="mt-8">
@@ -158,7 +173,7 @@ function GoalRunsFeed({ projectId, goalId }: { projectId: string; goalId: string
 			</h2>
 			{isLoading ? (
 				<div className="py-6 text-center text-[13px] text-text-3">Loading...</div>
-			) : !runs || runs.length === 0 ? (
+			) : runs.length === 0 ? (
 				<div
 					data-testid="goal-runs-empty"
 					className="rounded-md border border-border bg-surface px-3 py-6 text-center text-[13px] text-text-3"
@@ -166,11 +181,19 @@ function GoalRunsFeed({ projectId, goalId }: { projectId: string; goalId: string
 					No progress-update activity yet.
 				</div>
 			) : (
-				<ul className="flex flex-col divide-y divide-border rounded-md border border-border bg-surface">
-					{runs.map((run) => (
-						<GoalRunRow key={run.id} projectId={projectId} run={run} />
-					))}
-				</ul>
+				<>
+					<ul className="flex flex-col divide-y divide-border rounded-md border border-border bg-surface">
+						{runs.map((run) => (
+							<GoalRunRow key={run.id} projectId={projectId} run={run} />
+						))}
+					</ul>
+					<InfiniteScrollSentinel
+						hasNextPage={hasNextPage}
+						isFetchingNextPage={isFetchingNextPage}
+						onLoadMore={fetchNextPage}
+						testId="goal-runs"
+					/>
+				</>
 			)}
 		</section>
 	);

--- a/packages/web/src/components/goals-list.tsx
+++ b/packages/web/src/components/goals-list.tsx
@@ -10,7 +10,7 @@ import {
 	Target,
 	Trash2,
 } from 'lucide-react';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
 	useCancelQueuedProgressRun,
 	useGoalQueuedRun,
@@ -23,6 +23,7 @@ import { RunCommentBody } from './comment-renderers/run-comment';
 import { CreateGoalDialog } from './create-goal-dialog';
 import { GoalHealthPill } from './goal-health-pill';
 import { GoalSmartGuidance } from './goal-smart-guidance';
+import { InfiniteScrollSentinel } from './infinite-scroll-sentinel';
 import { LazyMount } from './lazy-mount';
 import { ProjectProgressSummary } from './project-progress-summary';
 import { Button } from './ui/button';
@@ -175,10 +176,18 @@ function QueuedProgressRunRow({ projectId, wakeupId }: { projectId: string; wake
 }
 
 function ProgressUpdatesFooter({ projectId }: { projectId: string }) {
-	const { data: runs } = useGoalRuns(projectId);
+	const { data: runPages, hasNextPage, isFetchingNextPage, fetchNextPage } = useGoalRuns(projectId);
 	const { data: queued } = useGoalQueuedRun(projectId);
 	const runNow = useRunProgressUpdateNow(projectId);
-	const hasRuns = !!runs && runs.length > 0;
+	// Flatten accumulated pages, deduping by id (offset pagination + new runs
+	// prepending can transiently overlap a page boundary).
+	const runs = useMemo(() => {
+		const seen = new Set<string>();
+		return (runPages?.pages.flatMap((p) => p.data) ?? []).filter((run) =>
+			seen.has(run.id) ? false : (seen.add(run.id), true),
+		);
+	}, [runPages]);
+	const hasRuns = runs.length > 0;
 	const queuedRun = queued?.queued ?? null;
 
 	return (
@@ -242,6 +251,14 @@ function ProgressUpdatesFooter({ projectId }: { projectId: string }) {
 						);
 					})}
 				</ul>
+			)}
+			{hasRuns && (
+				<InfiniteScrollSentinel
+					hasNextPage={hasNextPage}
+					isFetchingNextPage={isFetchingNextPage}
+					onLoadMore={fetchNextPage}
+					testId="progress-update-runs"
+				/>
 			)}
 		</section>
 	);

--- a/packages/web/src/components/infinite-scroll-sentinel.tsx
+++ b/packages/web/src/components/infinite-scroll-sentinel.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useRef } from 'react';
+import { Button } from './ui/button';
+
+/**
+ * Bottom-of-list infinite-scroll control shared by every paged list (tasks,
+ * skills, connectors, credentials, runs). Renders an invisible sentinel `div`
+ * that auto-fetches the next page when it scrolls into view, plus a "Load more"
+ * button as the deterministic fallback.
+ *
+ * The component-test harness stubs `IntersectionObserver` to a no-op, so the
+ * button is what those tests click; the observer drives real-browser scroll.
+ * The sentinel `div` is always rendered (browser specs scroll it into view in a
+ * retry loop); only the button is gated on there being another page.
+ */
+export function InfiniteScrollSentinel({
+	hasNextPage,
+	isFetchingNextPage,
+	onLoadMore,
+	testId,
+}: {
+	hasNextPage: boolean;
+	isFetchingNextPage: boolean;
+	onLoadMore: () => void;
+	/** Base test id; the sentinel/button get `-sentinel` / `-load-more` suffixes. */
+	testId: string;
+}) {
+	const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+	useEffect(() => {
+		if (typeof IntersectionObserver === 'undefined') return;
+		const el = sentinelRef.current;
+		if (!el) return;
+		const observer = new IntersectionObserver((entries) => {
+			if (entries[0]?.isIntersecting && hasNextPage && !isFetchingNextPage) {
+				onLoadMore();
+			}
+		});
+		observer.observe(el);
+		return () => observer.disconnect();
+	}, [hasNextPage, isFetchingNextPage, onLoadMore]);
+
+	return (
+		<div className="flex flex-col items-center gap-2">
+			{hasNextPage && (
+				<Button
+					variant="secondary"
+					size="sm"
+					className="mt-2"
+					disabled={isFetchingNextPage}
+					onClick={onLoadMore}
+					data-testid={`${testId}-load-more`}
+				>
+					{isFetchingNextPage ? 'Loading…' : 'Load more'}
+				</Button>
+			)}
+			{/* When this scrolls into view the observer auto-fetches the next page. */}
+			<div
+				ref={sentinelRef}
+				data-testid={`${testId}-sentinel`}
+				aria-hidden="true"
+				className="h-px w-full"
+			/>
+		</div>
+	);
+}

--- a/packages/web/src/components/task-list.tsx
+++ b/packages/web/src/components/task-list.tsx
@@ -20,6 +20,7 @@ import {
 } from '../lib/task-filter-storage';
 import { AdminApprovalsBanner } from './admin-approvals-banner';
 import { CreateTaskDialog } from './create-task-dialog';
+import { InfiniteScrollSentinel } from './infinite-scroll-sentinel';
 import { TaskPriorityBadge } from './task-priority-badge';
 import { TaskRunDot } from './task-run-dot';
 import { TaskStatusBadge } from './task-status-badge';
@@ -429,23 +430,6 @@ export function TaskList({ projectId }: TaskListProps) {
 		[navigate, projectId],
 	);
 
-	// Auto-load the next page when the bottom sentinel scrolls into view. The
-	// component-test harness stubs IntersectionObserver, so the "Load more" button
-	// below is the deterministic fallback; this observer drives real scroll.
-	const sentinelRef = useRef<HTMLDivElement | null>(null);
-	useEffect(() => {
-		if (typeof IntersectionObserver === 'undefined') return;
-		const el = sentinelRef.current;
-		if (!el) return;
-		const observer = new IntersectionObserver((entries) => {
-			if (entries[0]?.isIntersecting && hasNextPage && !isFetchingNextPage) {
-				fetchNextPage();
-			}
-		});
-		observer.observe(el);
-		return () => observer.disconnect();
-	}, [hasNextPage, isFetchingNextPage, fetchNextPage]);
-
 	const filterBar = (
 		<div className="relative flex-1 min-w-0 h-10" data-testid="task-filter-bar">
 			<div className="h-full rounded-md border border-border bg-surface">
@@ -641,24 +625,11 @@ export function TaskList({ projectId }: TaskListProps) {
 							<span data-testid="task-list-count">
 								Showing {backlogTasks.length + doneTasks.length} of {totalCount}
 							</span>
-							{hasNextPage && (
-								<Button
-									variant="secondary"
-									size="sm"
-									disabled={isFetchingNextPage}
-									onClick={() => fetchNextPage()}
-									data-testid="task-list-load-more"
-								>
-									{isFetchingNextPage ? 'Loading…' : 'Load more'}
-								</Button>
-							)}
-							{/* Bottom sentinel: when it scrolls into view the observer
-							    auto-fetches the next page (see effect above). */}
-							<div
-								ref={sentinelRef}
-								data-testid="task-list-sentinel"
-								aria-hidden="true"
-								className="h-px w-full"
+							<InfiniteScrollSentinel
+								hasNextPage={hasNextPage}
+								isFetchingNextPage={isFetchingNextPage}
+								onLoadMore={() => fetchNextPage()}
+								testId="task-list"
 							/>
 						</div>
 					)}

--- a/packages/web/src/hooks/use-connectors.ts
+++ b/packages/web/src/hooks/use-connectors.ts
@@ -1,5 +1,5 @@
-import { useMutation, useQuery } from '@tanstack/react-query';
-import { api } from '../lib/api';
+import { useInfiniteQuery, useMutation, useQuery } from '@tanstack/react-query';
+import { api, nextOffsetPageParam } from '../lib/api';
 import { queryClient } from '../lib/query-client';
 import { queryKeys } from '../lib/query-keys';
 
@@ -125,11 +125,25 @@ export interface CreateConnectorPayload {
 	config: Record<string, unknown>;
 }
 
-export function useConnectors(projectId: string, filterProjectId?: string) {
-	const qs = filterProjectId ? `?project_id=${encodeURIComponent(filterProjectId)}` : '';
-	return useQuery({
-		queryKey: queryKeys.projects.connectorsFiltered(projectId, filterProjectId ?? null),
-		queryFn: () => api.get<Connector[]>(`/api/projects/${projectId}/connectors${qs}`),
+export function useConnectors(
+	projectId: string,
+	filterProjectId?: string,
+	options?: { perPage?: number },
+) {
+	const perPage = options?.perPage ?? 50;
+	return useInfiniteQuery({
+		queryKey: queryKeys.projects.connectorsInfinite(projectId, {
+			filter: filterProjectId ?? null,
+			per_page: String(perPage),
+		}),
+		initialPageParam: 1,
+		queryFn: ({ pageParam }) =>
+			api.getPaginated<Connector>(`/api/projects/${projectId}/connectors`, {
+				project_id: filterProjectId,
+				page: String(pageParam),
+				per_page: String(perPage),
+			}),
+		getNextPageParam: nextOffsetPageParam,
 	});
 }
 
@@ -137,11 +151,9 @@ export function useCreateConnector(projectId: string) {
 	return useMutation({
 		mutationFn: (data: CreateConnectorPayload) =>
 			api.post<Connector>(`/api/projects/${projectId}/connectors`, data),
-		onSuccess: (created) => {
-			queryClient.setQueryData<Connector[]>(
-				queryKeys.projects.connectorsFiltered(projectId, null),
-				(prev) => (prev ? [...prev.filter((c) => c.id !== created.id), created] : [created]),
-			);
+		// The list is a paginated infinite query; invalidate + refetch rather than
+		// splice a flat array into an InfiniteData cache.
+		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: queryKeys.projects.connectors(projectId) });
 		},
 	});
@@ -150,11 +162,7 @@ export function useCreateConnector(projectId: string) {
 export function useDeleteConnector(projectId: string) {
 	return useMutation({
 		mutationFn: (id: string) => api.delete(`/api/projects/${projectId}/connectors/${id}`),
-		onSuccess: (_, id) => {
-			queryClient.setQueriesData<Connector[]>(
-				{ queryKey: queryKeys.projects.connectors(projectId) },
-				(prev) => (prev ? prev.filter((c) => c.id !== id) : prev),
-			);
+		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: queryKeys.projects.connectors(projectId) });
 		},
 	});

--- a/packages/web/src/hooks/use-goals.ts
+++ b/packages/web/src/hooks/use-goals.ts
@@ -5,8 +5,8 @@ import type {
 	GoalWithProject,
 	ProgressUpdateRunSummary,
 } from '@hezo/shared';
-import { useMutation, useQuery } from '@tanstack/react-query';
-import { api } from '../lib/api';
+import { useInfiniteQuery, useMutation, useQuery } from '@tanstack/react-query';
+import { api, nextOffsetPageParam } from '../lib/api';
 import { queryClient } from '../lib/query-client';
 import { queryKeys } from '../lib/query-keys';
 import { useOptimisticMutation } from './use-optimistic-mutation';
@@ -52,10 +52,17 @@ export function useGoalHistory(projectId: string, goalId: string) {
 }
 
 /** The progress-update runs for this project (newest-first as returned by the server). */
-export function useGoalRuns(projectId: string) {
-	return useQuery({
-		queryKey: queryKeys.projects.goalRuns(projectId),
-		queryFn: () => api.get<ProgressUpdateRunSummary[]>(`/api/projects/${projectId}/goals/runs`),
+export function useGoalRuns(projectId: string, options?: { perPage?: number }) {
+	const perPage = options?.perPage ?? 50;
+	return useInfiniteQuery({
+		queryKey: queryKeys.projects.goalRunsInfinite(projectId, { per_page: String(perPage) }),
+		initialPageParam: 1,
+		queryFn: ({ pageParam }) =>
+			api.getPaginated<ProgressUpdateRunSummary>(`/api/projects/${projectId}/goals/runs`, {
+				page: String(pageParam),
+				per_page: String(perPage),
+			}),
+		getNextPageParam: nextOffsetPageParam,
 	});
 }
 
@@ -78,10 +85,23 @@ export function useGoalQueuedRun(projectId: string) {
 }
 
 /** The progress-update runs that did something for one goal — shown at the bottom of its detail page. */
-export function useGoalRunActivity(projectId: string, goalId: string) {
-	return useQuery({
-		queryKey: queryKeys.projects.goalRunsForGoal(projectId, goalId),
-		queryFn: () => api.get<GoalRunActivity[]>(`/api/projects/${projectId}/goals/${goalId}/runs`),
+export function useGoalRunActivity(
+	projectId: string,
+	goalId: string,
+	options?: { perPage?: number },
+) {
+	const perPage = options?.perPage ?? 50;
+	return useInfiniteQuery({
+		queryKey: queryKeys.projects.goalRunsForGoalInfinite(projectId, goalId, {
+			per_page: String(perPage),
+		}),
+		initialPageParam: 1,
+		queryFn: ({ pageParam }) =>
+			api.getPaginated<GoalRunActivity>(`/api/projects/${projectId}/goals/${goalId}/runs`, {
+				page: String(pageParam),
+				per_page: String(perPage),
+			}),
+		getNextPageParam: nextOffsetPageParam,
 	});
 }
 

--- a/packages/web/src/hooks/use-heartbeat-runs.ts
+++ b/packages/web/src/hooks/use-heartbeat-runs.ts
@@ -1,6 +1,6 @@
 import type { HeartbeatRunKind, WakeupSource } from '@hezo/shared';
-import { useQuery } from '@tanstack/react-query';
-import { api } from '../lib/api';
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import { api, nextOffsetPageParam } from '../lib/api';
 import { queryKeys } from '../lib/query-keys';
 
 export interface HeartbeatRun {
@@ -68,11 +68,24 @@ export function getRunWaitingMessage(status: RunStatus, queuedReason?: string | 
 	return 'No output.';
 }
 
-export function useHeartbeatRuns(projectId: string, agentId: string) {
-	return useQuery({
-		queryKey: queryKeys.projects.agentHeartbeatRuns(projectId, agentId),
-		queryFn: () =>
-			api.get<HeartbeatRun[]>(`/api/projects/${projectId}/agents/${agentId}/heartbeat-runs`),
+export function useHeartbeatRuns(
+	projectId: string,
+	agentId: string,
+	options?: { perPage?: number },
+) {
+	const perPage = options?.perPage ?? 50;
+	return useInfiniteQuery({
+		queryKey: queryKeys.projects.agentHeartbeatRunsInfinite(projectId, agentId, {
+			per_page: String(perPage),
+		}),
+		initialPageParam: 1,
+		queryFn: ({ pageParam }) =>
+			api.getPaginated<HeartbeatRun>(
+				`/api/projects/${projectId}/agents/${agentId}/heartbeat-runs`,
+				{ page: String(pageParam), per_page: String(perPage) },
+			),
+		getNextPageParam: nextOffsetPageParam,
+		// Poll for new runs / status changes; refetches every loaded page.
 		refetchInterval: 10_000,
 	});
 }

--- a/packages/web/src/hooks/use-instance-connectors.ts
+++ b/packages/web/src/hooks/use-instance-connectors.ts
@@ -1,5 +1,5 @@
-import { useMutation, useQuery } from '@tanstack/react-query';
-import { api } from '../lib/api';
+import { useInfiniteQuery, useMutation } from '@tanstack/react-query';
+import { api, nextOffsetPageParam } from '../lib/api';
 import { queryClient } from '../lib/query-client';
 import type { Connector } from './use-connectors';
 
@@ -10,6 +10,8 @@ import type { Connector } from './use-connectors';
 // connector. SaaS (remote URL) only — local MCPs carry per-container install
 // state and are managed on the project.
 export const INSTANCE_CONNECTORS_KEY = ['instance', 'connectors'] as const;
+// Infinite-scroll key under the base key so mutation invalidations cascade.
+export const INSTANCE_CONNECTORS_INFINITE_KEY = ['instance', 'connectors', 'infinite'] as const;
 
 export interface CreateInstanceConnectorPayload {
 	name: string;
@@ -20,10 +22,17 @@ export interface CreateInstanceConnectorPayload {
 	project_id?: string | null;
 }
 
-export function useInstanceConnectors() {
-	return useQuery({
-		queryKey: INSTANCE_CONNECTORS_KEY,
-		queryFn: () => api.get<Connector[]>('/api/connectors'),
+export function useInstanceConnectors(options?: { perPage?: number }) {
+	const perPage = options?.perPage ?? 50;
+	return useInfiniteQuery({
+		queryKey: [...INSTANCE_CONNECTORS_INFINITE_KEY, { per_page: String(perPage) }],
+		initialPageParam: 1,
+		queryFn: ({ pageParam }) =>
+			api.getPaginated<Connector>('/api/connectors', {
+				page: String(pageParam),
+				per_page: String(perPage),
+			}),
+		getNextPageParam: nextOffsetPageParam,
 	});
 }
 

--- a/packages/web/src/hooks/use-instance-credentials.ts
+++ b/packages/web/src/hooks/use-instance-credentials.ts
@@ -1,5 +1,5 @@
-import { useMutation, useQuery } from '@tanstack/react-query';
-import { api } from '../lib/api';
+import { useInfiniteQuery, useMutation } from '@tanstack/react-query';
+import { api, nextOffsetPageParam } from '../lib/api';
 import { queryClient } from '../lib/query-client';
 
 // Credentials are instance-global: one set of secrets shared with every team's
@@ -7,6 +7,8 @@ import { queryClient } from '../lib/query-client';
 // /api/credentials + /api/secrets routes. Mutations are security-sensitive, so
 // they invalidate + refetch — never optimistic.
 export const INSTANCE_CREDENTIALS_KEY = ['instance', 'credentials'] as const;
+// Infinite-scroll key under the base key so mutation invalidations cascade.
+export const INSTANCE_CREDENTIALS_INFINITE_KEY = ['instance', 'credentials', 'infinite'] as const;
 
 // A connector that references a credential (its pasted API key, or the access
 // token of its OAuth connection). `project_id`/`project_slug` are null for a
@@ -65,10 +67,17 @@ export interface UpdateInstanceSecretPayload {
 	allow_body_substitution?: boolean;
 }
 
-export function useInstanceCredentials() {
-	return useQuery({
-		queryKey: INSTANCE_CREDENTIALS_KEY,
-		queryFn: () => api.get<CredentialUsage[]>('/api/credentials'),
+export function useInstanceCredentials(options?: { perPage?: number }) {
+	const perPage = options?.perPage ?? 50;
+	return useInfiniteQuery({
+		queryKey: [...INSTANCE_CREDENTIALS_INFINITE_KEY, { per_page: String(perPage) }],
+		initialPageParam: 1,
+		queryFn: ({ pageParam }) =>
+			api.getPaginated<CredentialUsage>('/api/credentials', {
+				page: String(pageParam),
+				per_page: String(perPage),
+			}),
+		getNextPageParam: nextOffsetPageParam,
 	});
 }
 

--- a/packages/web/src/hooks/use-instance-skills.ts
+++ b/packages/web/src/hooks/use-instance-skills.ts
@@ -4,8 +4,8 @@ import type {
 	SkillRecord,
 	SkillRevisionRecord,
 } from '@hezo/shared';
-import { useMutation, useQuery } from '@tanstack/react-query';
-import { api } from '../lib/api';
+import { useInfiniteQuery, useMutation, useQuery } from '@tanstack/react-query';
+import { api, nextOffsetPageParam } from '../lib/api';
 import { queryClient } from '../lib/query-client';
 
 export type Skill = SkillRecord;
@@ -25,11 +25,21 @@ export interface CreateSkillInput {
 // (superuser) manages them and changes their scope, via the /api/skills routes.
 // Skills are addressed by id (slug is no longer globally unique once scoped).
 export const INSTANCE_SKILLS_KEY = ['instance', 'skills'] as const;
+// Infinite-scroll key sits UNDER the base key so the mutation invalidations
+// (which target INSTANCE_SKILLS_KEY) still cascade to the paged list.
+export const INSTANCE_SKILLS_INFINITE_KEY = ['instance', 'skills', 'infinite'] as const;
 
-export function useInstanceSkills() {
-	return useQuery({
-		queryKey: INSTANCE_SKILLS_KEY,
-		queryFn: () => api.get<SkillListItem[]>('/api/skills'),
+export function useInstanceSkills(options?: { perPage?: number }) {
+	const perPage = options?.perPage ?? 50;
+	return useInfiniteQuery({
+		queryKey: [...INSTANCE_SKILLS_INFINITE_KEY, { per_page: String(perPage) }],
+		initialPageParam: 1,
+		queryFn: ({ pageParam }) =>
+			api.getPaginated<SkillListItem>('/api/skills', {
+				page: String(pageParam),
+				per_page: String(perPage),
+			}),
+		getNextPageParam: nextOffsetPageParam,
 	});
 }
 

--- a/packages/web/src/hooks/use-project-skills.ts
+++ b/packages/web/src/hooks/use-project-skills.ts
@@ -1,6 +1,6 @@
 import type { SkillListItemRecord, SkillRecord, SkillRevisionRecord } from '@hezo/shared';
-import { useMutation, useQuery } from '@tanstack/react-query';
-import { api } from '../lib/api';
+import { useInfiniteQuery, useMutation, useQuery } from '@tanstack/react-query';
+import { api, nextOffsetPageParam } from '../lib/api';
 import { queryClient } from '../lib/query-client';
 import { queryKeys } from '../lib/query-keys';
 
@@ -11,10 +11,17 @@ import { queryKeys } from '../lib/query-keys';
 
 export type ProjectSkillListItem = SkillListItemRecord;
 
-export function useProjectSkills(projectId: string) {
-	return useQuery({
-		queryKey: queryKeys.projects.skills(projectId),
-		queryFn: () => api.get<ProjectSkillListItem[]>(`/api/projects/${projectId}/skills`),
+export function useProjectSkills(projectId: string, options?: { perPage?: number }) {
+	const perPage = options?.perPage ?? 50;
+	return useInfiniteQuery({
+		queryKey: queryKeys.projects.skillsInfinite(projectId, { per_page: String(perPage) }),
+		initialPageParam: 1,
+		queryFn: ({ pageParam }) =>
+			api.getPaginated<ProjectSkillListItem>(`/api/projects/${projectId}/skills`, {
+				page: String(pageParam),
+				per_page: String(perPage),
+			}),
+		getNextPageParam: nextOffsetPageParam,
 	});
 }
 

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -19,6 +19,16 @@ export interface PaginationMeta {
 	total: number;
 }
 
+/**
+ * `getNextPageParam` for offset-paginated `useInfiniteQuery` lists: returns the
+ * next page number while more rows remain, or `undefined` once the accumulated
+ * pages cover `total`. Shared by every infinite list hook.
+ */
+export function nextOffsetPageParam(lastPage: { meta: PaginationMeta }): number | undefined {
+	const { page, per_page, total } = lastPage.meta;
+	return page * per_page < total ? page + 1 : undefined;
+}
+
 class ApiClient {
 	private token: string | null = readStored(TOKEN_KEY);
 

--- a/packages/web/src/lib/query-keys.ts
+++ b/packages/web/src/lib/query-keys.ts
@@ -141,8 +141,27 @@ export const queryKeys = {
 		goal: (slug: string, goalId: string) => ['projects', slug, 'goals', goalId],
 		goalHistory: (slug: string, goalId: string) => ['projects', slug, 'goals', goalId, 'history'],
 		goalRuns: (slug: string) => ['projects', slug, 'goals', 'runs'],
+		// Infinite-scroll variants of the runs feeds, under their base prefixes so
+		// existing invalidations still cascade.
+		goalRunsInfinite: (slug: string, filters: KeyParam) => [
+			'projects',
+			slug,
+			'goals',
+			'runs',
+			'infinite',
+			filters,
+		],
 		goalQueuedRun: (slug: string) => ['projects', slug, 'goals', 'queued-run'],
 		goalRunsForGoal: (slug: string, goalId: string) => ['projects', slug, 'goals', goalId, 'runs'],
+		goalRunsForGoalInfinite: (slug: string, goalId: string, filters: KeyParam) => [
+			'projects',
+			slug,
+			'goals',
+			goalId,
+			'runs',
+			'infinite',
+			filters,
+		],
 		progress: (slug: string) => ['projects', slug, 'progress'],
 
 		// agents
@@ -155,6 +174,15 @@ export const queryKeys = {
 			'agents',
 			agentId,
 			'heartbeat-runs',
+		],
+		agentHeartbeatRunsInfinite: (slug: string, agentId: string, filters: KeyParam) => [
+			'projects',
+			slug,
+			'agents',
+			agentId,
+			'heartbeat-runs',
+			'infinite',
+			filters,
 		],
 		agentHeartbeatRun: (slug: string, agentId: string, runId: string) => [
 			'projects',
@@ -230,6 +258,15 @@ export const queryKeys = {
 		customPrompt: (slug: string) => ['projects', slug, 'custom-prompt'],
 		customPromptRevisions: (slug: string) => ['projects', slug, 'custom-prompt', 'revisions'],
 		skills: (slug: string) => ['projects', slug, 'skills'],
+		// Infinite-scroll variant. Sits under the `skills` prefix so mutation/WS
+		// invalidation of `skills(slug)` still refetches it (mirrors tasksInfinite).
+		skillsInfinite: (slug: string, filters: KeyParam) => [
+			'projects',
+			slug,
+			'skills',
+			'infinite',
+			filters,
+		],
 		skill: (slug: string, skillSlug: string | null) => ['projects', slug, 'skills', skillSlug],
 
 		// connections / credentials / repos
@@ -243,6 +280,13 @@ export const queryKeys = {
 			slug,
 			'connectors',
 			filterProjectId,
+		],
+		connectorsInfinite: (slug: string, filters: KeyParam) => [
+			'projects',
+			slug,
+			'connectors',
+			'infinite',
+			filters,
 		],
 		connectorDetail: (slug: string, connectorId: string | null) => [
 			'projects',

--- a/packages/web/src/routes/projects/$projectId/agents/$agentId/executions/index.tsx
+++ b/packages/web/src/routes/projects/$projectId/agents/$agentId/executions/index.tsx
@@ -1,5 +1,7 @@
 import { INSTANCE_AGENT_SLUGS } from '@hezo/shared';
 import { createFileRoute, Link } from '@tanstack/react-router';
+import { useMemo } from 'react';
+import { InfiniteScrollSentinel } from '../../../../../../components/infinite-scroll-sentinel';
 import { Badge } from '../../../../../../components/ui/badge';
 import { Tooltip } from '../../../../../../components/ui/tooltip';
 import { useAgent } from '../../../../../../hooks/use-agents';
@@ -43,6 +45,7 @@ function ExecutionRow({
 		<Link
 			to="/projects/$projectId/agents/$agentId/executions/$runId"
 			params={{ projectId, agentId, runId: run.id }}
+			data-testid="execution-row"
 			className="flex items-center gap-2 rounded-md border border-border-subtle bg-surface px-3 py-2.5 text-xs hover:bg-surface-2 transition-colors"
 		>
 			<Badge color={statusColor(run.status) as 'green'}>
@@ -87,8 +90,27 @@ function ExecutionRow({
 
 function ExecutionListPage() {
 	const { projectId, agentId } = Route.useParams();
-	const { data: runs, isLoading } = useHeartbeatRuns(projectId, agentId);
+	const {
+		data: runPages,
+		isLoading,
+		hasNextPage,
+		isFetchingNextPage,
+		fetchNextPage,
+	} = useHeartbeatRuns(projectId, agentId);
 	const { data: agent } = useAgent(projectId, agentId);
+
+	// Flatten the accumulated pages, deduping by id: offset pagination + the 10s
+	// poll can transiently overlap a page boundary when a new run prepends.
+	const runs = useMemo(() => {
+		const seen = new Set<string>();
+		const out: HeartbeatRun[] = [];
+		for (const run of runPages?.pages.flatMap((p) => p.data) ?? []) {
+			if (seen.has(run.id)) continue;
+			seen.add(run.id);
+			out.push(run);
+		}
+		return out;
+	}, [runPages]);
 
 	// CEO/Coach runs span many projects (the list is member-scoped), so show each
 	// row's project. Gate on the agent slug — see the run-detail page for why.
@@ -97,7 +119,7 @@ function ExecutionListPage() {
 
 	if (isLoading) return <div className="text-text-2 text-sm">Loading executions...</div>;
 
-	if (!runs || runs.length === 0) {
+	if (runs.length === 0) {
 		return <div className="text-text-2 text-sm py-4">No executions yet.</div>;
 	}
 
@@ -112,6 +134,12 @@ function ExecutionListPage() {
 					isInstanceAgent={isInstanceAgent}
 				/>
 			))}
+			<InfiniteScrollSentinel
+				hasNextPage={hasNextPage}
+				isFetchingNextPage={isFetchingNextPage}
+				onLoadMore={fetchNextPage}
+				testId="executions"
+			/>
 		</div>
 	);
 }

--- a/packages/web/src/routes/projects/$projectId/connectors.tsx
+++ b/packages/web/src/routes/projects/$projectId/connectors.tsx
@@ -2,10 +2,11 @@ import { getConnectorCapability } from '@hezo/shared';
 import { useQueryClient } from '@tanstack/react-query';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { Check, ExternalLink, Github, KeyRound, Plug, Plus, Trash2, X } from 'lucide-react';
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { apiKeyGuideFor, ConnectorApiKeyForm } from '../../../components/connector-api-key-form';
 import { ConnectorDeviceFlowDialog } from '../../../components/connector-device-flow-dialog';
 import { ConnectorOAuthBrokerForm } from '../../../components/connector-oauth-broker-form';
+import { InfiniteScrollSentinel } from '../../../components/infinite-scroll-sentinel';
 import { RelatedItemsList } from '../../../components/related-items-list';
 import { Badge } from '../../../components/ui/badge';
 import { Button } from '../../../components/ui/button';
@@ -44,7 +45,16 @@ export const Route = createFileRoute('/projects/$projectId/connectors')({
 function ConnectorsPage() {
 	const { projectId } = Route.useParams();
 	const { focus } = Route.useSearch();
-	const { data: connectors = [] } = useConnectors(projectId);
+	const {
+		data: connectorPages,
+		hasNextPage,
+		isFetchingNextPage,
+		fetchNextPage,
+	} = useConnectors(projectId);
+	const connectors = useMemo(
+		() => connectorPages?.pages.flatMap((p) => p.data) ?? [],
+		[connectorPages],
+	);
 	const { data: oauthConnections = [] } = useOAuthConnections(projectId);
 
 	// Ref callback fires when the focused <li> mounts (which can happen after
@@ -100,6 +110,13 @@ function ConnectorsPage() {
 						/>
 					))}
 			</ul>
+
+			<InfiniteScrollSentinel
+				hasNextPage={hasNextPage}
+				isFetchingNextPage={isFetchingNextPage}
+				onLoadMore={fetchNextPage}
+				testId="connectors"
+			/>
 
 			{isEmpty && (
 				<p className="text-xs text-text-3 text-center">

--- a/packages/web/src/routes/projects/$projectId/skills.tsx
+++ b/packages/web/src/routes/projects/$projectId/skills.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { BookOpen, ExternalLink, Eye, Pencil, Plus, Trash2 } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { InfiniteScrollSentinel } from '../../../components/infinite-scroll-sentinel';
 import { MarkdownEditor } from '../../../components/markdown-editor';
 import { RevisionsPanel } from '../../../components/revisions-panel';
 import { SkillViewDialog } from '../../../components/skill-view-dialog';
@@ -23,7 +24,13 @@ export const Route = createFileRoute('/projects/$projectId/skills')({
 
 function ProjectSkillsPage() {
 	const { projectId } = Route.useParams();
-	const { data: skills = [] } = useProjectSkills(projectId);
+	const {
+		data: skillPages,
+		hasNextPage,
+		isFetchingNextPage,
+		fetchNextPage,
+	} = useProjectSkills(projectId);
+	const skills = useMemo(() => skillPages?.pages.flatMap((p) => p.data) ?? [], [skillPages]);
 	const updateSkill = useUpdateProjectSkill(projectId);
 	const deleteSkill = useDeleteProjectSkill(projectId);
 
@@ -276,6 +283,15 @@ function ProjectSkillsPage() {
 					No skills available to this project yet.
 				</div>
 			)}
+
+			{/* One sentinel for the combined project+global list; both sections grow
+			    as pages load (the list is paginated as a single name-ordered set). */}
+			<InfiniteScrollSentinel
+				hasNextPage={hasNextPage}
+				isFetchingNextPage={isFetchingNextPage}
+				onLoadMore={fetchNextPage}
+				testId="project-skills"
+			/>
 
 			<SkillViewDialog
 				open={viewingId !== null}

--- a/packages/web/src/routes/settings/connectors.tsx
+++ b/packages/web/src/routes/settings/connectors.tsx
@@ -2,6 +2,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
 import { ChevronDown, Plus, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { InfiniteScrollSentinel } from '../../components/infinite-scroll-sentinel';
 import { RelatedItemsList } from '../../components/related-items-list';
 import { Badge } from '../../components/ui/badge';
 import { Button } from '../../components/ui/button';
@@ -37,7 +38,16 @@ function openAuthPopup(authUrl: string): string | null {
 function InstanceConnectorsPage() {
 	const { data: me } = useMe();
 	const { focus } = Route.useSearch();
-	const { data: connectors = [] } = useInstanceConnectors();
+	const {
+		data: connectorPages,
+		hasNextPage,
+		isFetchingNextPage,
+		fetchNextPage,
+	} = useInstanceConnectors();
+	const connectors = useMemo(
+		() => connectorPages?.pages.flatMap((p) => p.data) ?? [],
+		[connectorPages],
+	);
 	const { projects } = useAllVisibleProjects();
 	const createConnector = useCreateInstanceConnector();
 	const authStart = useInstanceAuthStart();
@@ -219,6 +229,12 @@ function InstanceConnectorsPage() {
 								focusRef={c.id === focus ? focusRef : undefined}
 							/>
 						))}
+						<InfiniteScrollSentinel
+							hasNextPage={hasNextPage}
+							isFetchingNextPage={isFetchingNextPage}
+							onLoadMore={fetchNextPage}
+							testId="instance-connectors"
+						/>
 					</div>
 				)}
 			</>

--- a/packages/web/src/routes/settings/credentials.tsx
+++ b/packages/web/src/routes/settings/credentials.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { Pencil, Plus, Trash2 } from 'lucide-react';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
+import { InfiniteScrollSentinel } from '../../components/infinite-scroll-sentinel';
 import { RelatedItemsList } from '../../components/related-items-list';
 import { Badge } from '../../components/ui/badge';
 import { Button } from '../../components/ui/button';
@@ -35,7 +36,16 @@ function formatRelative(iso: string | null): string {
 function InstanceCredentialsPage() {
 	const { data: me } = useMe();
 	const { focus } = Route.useSearch();
-	const { data: rows = [] } = useInstanceCredentials();
+	const {
+		data: credentialPages,
+		hasNextPage,
+		isFetchingNextPage,
+		fetchNextPage,
+	} = useInstanceCredentials();
+	const rows = useMemo(
+		() => credentialPages?.pages.flatMap((p) => p.data) ?? [],
+		[credentialPages],
+	);
 	const createSecret = useCreateInstanceSecret();
 	const updateSecret = useUpdateInstanceSecret();
 	const deleteSecret = useDeleteInstanceSecret();
@@ -343,6 +353,14 @@ function InstanceCredentialsPage() {
 								/>
 							) : null
 						}
+					/>
+				)}
+				{rows.length > 0 && (
+					<InfiniteScrollSentinel
+						hasNextPage={hasNextPage}
+						isFetchingNextPage={isFetchingNextPage}
+						onLoadMore={fetchNextPage}
+						testId="instance-credentials"
 					/>
 				)}
 			</>

--- a/packages/web/src/routes/settings/skills.tsx
+++ b/packages/web/src/routes/settings/skills.tsx
@@ -11,6 +11,7 @@ import {
 	Trash2,
 } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
+import { InfiniteScrollSentinel } from '../../components/infinite-scroll-sentinel';
 import { MarkdownEditor } from '../../components/markdown-editor';
 import { RevisionsPanel } from '../../components/revisions-panel';
 import { SkillViewDialog } from '../../components/skill-view-dialog';
@@ -50,7 +51,8 @@ const ALL_PROJECTS = 'all';
 
 function InstanceSkillsPage() {
 	const { data: me } = useMe();
-	const { data: skills = [] } = useInstanceSkills();
+	const { data: skillPages, hasNextPage, isFetchingNextPage, fetchNextPage } = useInstanceSkills();
+	const skills = useMemo(() => skillPages?.pages.flatMap((p) => p.data) ?? [], [skillPages]);
 	const { projects } = useAllVisibleProjects();
 	const createSkill = useCreateInstanceSkill();
 	const updateSkill = useUpdateInstanceSkill();
@@ -317,6 +319,12 @@ function InstanceSkillsPage() {
 								}}
 							/>
 						))}
+						<InfiniteScrollSentinel
+							hasNextPage={hasNextPage}
+							isFetchingNextPage={isFetchingNextPage}
+							onLoadMore={fetchNextPage}
+							testId="instance-skills"
+						/>
 					</div>
 				)}
 			</>

--- a/packages/web/test/agent-executions-list.test.tsx
+++ b/packages/web/test/agent-executions-list.test.tsx
@@ -115,6 +115,37 @@ function installRunsListMock(opts: {
 	}) as typeof globalThis.fetch;
 }
 
+/**
+ * Serve the heartbeat-runs list as two offset pages ({ data, meta }). The web
+ * IntersectionObserver stub reports the sentinel as intersecting on observe, so
+ * the infinite-scroll sentinel auto-fetches page 2 — asserting a page-2 row
+ * renders proves the pagination loop is wired end-to-end.
+ */
+function installPagedRunsMock(opts: { agentId: string; pages: HeartbeatRun[][]; total: number }) {
+	const original = globalThis.fetch;
+	restoreFetch = () => {
+		globalThis.fetch = original;
+	};
+	globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+		const url = typeof input === 'string' ? input : (input as Request).url;
+		const method = init?.method ?? (input instanceof Request ? input.method : 'GET');
+		if (
+			method === 'GET' &&
+			new RegExp(`/api/projects/[^/]+/agents/${opts.agentId}/heartbeat-runs(\\?.*)?$`).test(url)
+		) {
+			const params = new URL(url, 'http://localhost').searchParams;
+			const page = Number(params.get('page') ?? '1');
+			const perPage = Number(params.get('per_page') ?? '50');
+			const data = opts.pages[page - 1] ?? [];
+			return new Response(
+				JSON.stringify({ data, meta: { page, per_page: perPage, total: opts.total } }),
+				{ status: 200, headers: { 'Content-Type': 'application/json' } },
+			);
+		}
+		return original(input as RequestInfo, init);
+	}) as typeof globalThis.fetch;
+}
+
 async function renderExecutions(runs: HeartbeatRun[], opts?: { agentSlugOverride?: string }) {
 	const seeded = { projectSlug: '', agentId: '' };
 	const helpers = await renderApp({
@@ -226,6 +257,45 @@ test('a non-instance agent omits the project suffix even when the run carries a 
 test('shows the empty state when the agent has no runs', async () => {
 	const { findByText } = await renderExecutions([]);
 	await findByText('No executions yet.', undefined, { timeout: 20_000 });
+});
+
+test('infinite-scroll auto-loads the second page of runs via the sentinel', async () => {
+	const seeded = { projectSlug: '', agentId: '' };
+	// 50 first-page runs + 1 on page 2 (identifier RUN2-51). Before infinite
+	// scroll the page capped at 50 and RUN2-51 was unreachable.
+	const pageOne = Array.from({ length: 50 }, (_, i) =>
+		makeRun({ id: `p1-${i}`, task_identifier: `P1-${i}`, task_title: `First ${i}` }),
+	);
+	const pageTwo = [
+		makeRun({ id: 'p2-0', task_identifier: 'RUN2-51', task_title: 'Second page run' }),
+	];
+
+	const helpers = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const captain = ws.agents.find((a) => a.slug === 'captain') ?? ws.agents[0];
+			const project = await seedProject(ws, { name: 'Paged Exec Project' });
+			seeded.projectSlug = project.slug;
+			seeded.agentId = captain.id;
+			installPagedRunsMock({
+				agentId: captain.id,
+				pages: [
+					pageOne.map((r) => ({ ...r, member_id: captain.id })),
+					pageTwo.map((r) => ({ ...r, member_id: captain.id })),
+				],
+				total: 51,
+			});
+		},
+	});
+	await helpers.router.navigate({
+		to: '/projects/$projectId/agents/$agentId/executions',
+		params: { projectId: seeded.projectSlug, agentId: seeded.agentId },
+	});
+
+	// The page-2 row only exists once the sentinel triggered fetchNextPage.
+	await helpers.findByRole('link', { name: /RUN2-51/ }, { timeout: 20_000 });
+	expect(helpers.getAllByTestId('execution-row').length).toBe(51);
 });
 
 test('a cancelled run renders with the neutral status (no exit/cost suffixes)', async () => {


### PR DESCRIPTION
## What & why

Several list surfaces fetched their **entire** list in one `useQuery` and rendered it with a plain `.map()` — no pagination. Worse, the runs endpoints hardcoded a server-side `LIMIT 50`, so older runs were **unreachable** from the UI. This converts them to **infinite scroll**, reusing the existing `task-list` pattern (offset pagination via `parsePagination`/`buildMeta`/`api.getPaginated` + a bottom sentinel that auto-loads on scroll, with a "Load more" fallback).

The recently-added load-on-dwell comments feed is left untouched — it's the right fit there.

**Scope:** Skills (project + global), Connectors (project + global), Credentials (global — the only variant), the agent runs (executions) page, and the runs feeds on the Goals + Goal-detail pages. The goals *grid* itself is intentionally out of scope.

## Server

Added `page`/`per_page` offset pagination (a count query + `LIMIT/OFFSET`, returning the `{ data, meta }` envelope) to:

- `GET /api/skills` and `GET /api/projects/:id/skills` — the virtual `connector-recipes` skill row is pinned to page 1, outside the paginated DB set.
- `GET /api/connectors` and `GET /api/projects/:id/connectors`
- `GET /api/credentials`
- `GET /api/projects/:id/agents/:agentId/heartbeat-runs` — **dropped the hardcoded `LIMIT 50`**; older runs are now reachable.
- `GET /api/projects/:id/goals/runs` and `GET /api/projects/:id/goals/:goalId/runs` (service fns take `{ limit, offset }`; added `countProgressUpdateRuns` / `countGoalRunActivity`).

The envelope stays backward-compatible — every response still exposes `.data`.

## Web

- New shared `<InfiniteScrollSentinel>` (IntersectionObserver auto-load + "Load more" fallback button); `task-list` refactored onto it (its inline copy removed).
- Converted the eight list hooks to `useInfiniteQuery` with a `perPage` option for tests, keyed under their existing prefixes so WebSocket/mutation invalidation still cascades (mirrors `tasksInfinite`).
- Pages read the accumulated `pages.flatMap(p => p.data)`; runs lists dedupe by `id` to guard page-boundary overlap from the 10s poll prepending new runs.
- `useConnectors` create/delete drop their flat-array optimistic cache writes (incompatible with `InfiniteData`) and rely on invalidate + refetch, consistent with the connectors list pattern.

## Testing

- **Server:** per-route pagination tests asserting the `{ data, meta }` envelope, correct slicing across pages, exact `meta.total`, non-overlapping pages, the `connector-recipes` page-1 pinning, and the new `count*` helpers (`skills`, `heartbeat-runs`, `connectors`, `credentials`, goals runs).
- **Web:** an executions-page test seeding two offset pages and asserting the page-2 row renders (the stubbed IntersectionObserver drives the sentinel end-to-end).
- Full non-browser suite (`bun run test --skip-browser`), `typecheck`, and `check` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019XrhtyziuLsZUMN21P17Si)_