### PR TITLE
fix(web): dim the page behind the mobile chat panel

### DIFF
--- a/packages/web/src/components/chat/chat-widget.tsx
+++ b/packages/web/src/components/chat/chat-widget.tsx
@@ -231,18 +231,21 @@ export function ChatWidget({ open, onOpenChange }: ChatWidgetProps) {
 
 	return (
 		<>
-			{/* In expanded mode the chat is modal: a scrim dims and occludes the page
-			    content below the nav bar (the header stays clear and usable, matching
-			    the panel's own top-12 boundary). Clicking it dismisses the chat. */}
-			{expanded && (
-				<button
-					type="button"
-					aria-label="Close chat"
-					data-testid="chat-overlay"
-					onClick={() => setOpen(false)}
-					className="fixed inset-x-0 bottom-0 top-12 z-40 bg-[var(--overlay)] cursor-default"
-				/>
-			)}
+			{/* Modal scrim behind the panel: a dark translucent layer dims and occludes
+			    the page content below the nav bar (the header stays clear and usable,
+			    matching the panel's own top-12 boundary), so the panel reads clearly
+			    against the page. It always shows on mobile (where the panel floats over
+			    the page with margins around it) and, on desktop, only in expanded mode —
+			    the anchored corner panel doesn't need one. Clicking it dismisses the chat. */}
+			<button
+				type="button"
+				aria-label="Close chat"
+				data-testid="chat-overlay"
+				onClick={() => setOpen(false)}
+				className={`fixed inset-x-0 bottom-0 top-12 z-40 bg-[var(--overlay)] cursor-default ${
+					expanded ? '' : 'md:hidden'
+				}`}
+			/>
 			<div
 				data-testid="chat-panel"
 				data-expanded={expanded}

--- a/packages/web/test/chat.test.tsx
+++ b/packages/web/test/chat.test.tsx
@@ -451,13 +451,15 @@ test('expanded mode lays a modal backdrop that dismisses the chat when clicked',
 	(await findByTestId('chat-launcher')).click();
 	await findByTestId('chat-panel');
 
-	// Anchored: no backdrop — the rest of the page stays interactive.
-	expect(queryByTestId('chat-overlay')).toBeNull();
+	// Anchored: the scrim is rendered but scoped to mobile (`md:hidden`), so the
+	// desktop corner panel leaves the rest of the page interactive.
+	const anchoredOverlay = await findByTestId('chat-overlay');
+	expect(anchoredOverlay.className).toContain('md:hidden');
 
-	// Expanding makes it modal: a scrim appears behind the panel.
+	// Expanding makes it modal on desktop too: the scrim drops `md:hidden`.
 	getByTestId('chat-expand').click();
-	const overlay = await findByTestId('chat-overlay');
-	expect(overlay).toBeTruthy();
+	await waitFor(() => expect(getByTestId('chat-overlay').className).not.toContain('md:hidden'));
+	const overlay = getByTestId('chat-overlay');
 
 	// Clicking the backdrop dismisses the chat entirely.
 	overlay.click();
@@ -466,17 +468,18 @@ test('expanded mode lays a modal backdrop that dismisses the chat when clicked',
 	expect(queryByTestId('chat-overlay')).toBeNull();
 });
 
-test('collapsing out of expanded removes the backdrop but keeps the chat open', async () => {
-	const { findByTestId, queryByTestId, getByTestId } = await renderApp({ initialPath: '/home' });
+test('collapsing out of expanded reverts the backdrop to mobile-only but keeps the chat open', async () => {
+	const { findByTestId, getByTestId } = await renderApp({ initialPath: '/home' });
 	(await findByTestId('chat-launcher')).click();
 	await findByTestId('chat-panel');
 
 	getByTestId('chat-expand').click();
-	await findByTestId('chat-overlay');
+	await waitFor(() => expect(getByTestId('chat-overlay').className).not.toContain('md:hidden'));
 
-	// The collapse toggle exits modal mode: backdrop gone, panel still open.
+	// The collapse toggle exits desktop-modal mode: the scrim goes back to
+	// mobile-only (`md:hidden`), panel still open.
 	getByTestId('chat-expand').click();
-	await waitFor(() => expect(queryByTestId('chat-overlay')).toBeNull());
+	await waitFor(() => expect(getByTestId('chat-overlay').className).toContain('md:hidden'));
 	expect(getByTestId('chat-panel')).toBeTruthy();
 });
 

--- a/test/browser/chat.spec.ts
+++ b/test/browser/chat.spec.ts
@@ -29,6 +29,14 @@ test.describe('CEO chat widget — responsive layout', () => {
 		expect(mobileBox).not.toBeNull();
 		expect(mobileBox?.width ?? 0).toBeGreaterThan(340);
 
+		// Mobile: a dark scrim sits behind the floating sheet so the page content
+		// showing through its margins is dimmed and the panel reads clearly. It
+		// spans the full width below the nav bar.
+		const overlay = page.getByTestId('chat-overlay');
+		await expect(overlay).toBeVisible();
+		const overlayBox = await overlay.boundingBox();
+		expect(overlayBox?.width ?? 0).toBeGreaterThan(370);
+
 		// Desktop: the same open panel re-lays out to the anchored ~420px width.
 		await page.setViewportSize({ width: 1280, height: 800 });
 		await expect(panel).toBeVisible();
@@ -36,6 +44,9 @@ test.describe('CEO chat widget — responsive layout', () => {
 		expect(desktopBox).not.toBeNull();
 		expect(desktopBox?.width ?? 0).toBeGreaterThan(340);
 		expect(desktopBox?.width ?? 0).toBeLessThan(440);
+
+		// …and the anchored corner panel needs no scrim, so it's gone on desktop.
+		await expect(overlay).toBeHidden();
 	});
 
 	test('expanding fills the viewport but never covers the nav bar', async ({


### PR DESCRIPTION
## What & why

On mobile, the CEO chat opens as a floating sheet with margins around it. The page content showing through those margins made the panel hard to distinguish from the background (see the reported screenshot — content bleeds through above and below the panel).

Previously the modal scrim rendered **only** in desktop `expanded` mode, and the expand toggle is desktop-only (`md:flex`), so mobile got no scrim at all.

## Change

- `chat-widget.tsx`: render the scrim (`chat-overlay`) whenever the chat is open. It's always visible on mobile, and on desktop it keeps the previous behaviour — only shown in expanded mode (`md:hidden` while the anchored corner panel is up, which needs no scrim). The scrim still starts at `top-12` so the nav header stays clear and usable, and clicking it still dismisses the chat.

## Tests

- `packages/web/test/chat.test.tsx`: the overlay is now always mounted while the chat is open, so the two tests that asserted DOM absence in the anchored state now assert the `md:hidden` class toggles (mobile-only ↔ full modal) instead.
- `test/browser/chat.spec.ts`: the responsive-layout spec now asserts the scrim is visible and full-width on the 375px mobile viewport, and hidden again for the anchored desktop panel.

All 29 `chat.test.tsx` component tests pass; lint/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B2AposWvwNVD9poiZeQhf6

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2AposWvwNVD9poiZeQhf6)_