### PR TITLE
fix(mentions): warn on routing-label handoffs like "Next step: captain —"

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -1135,8 +1135,9 @@ path `create_comment` uses — so it fans out to the admin inbox / agent wakeup 
 vanishing (the agent wrote an explicit, unambiguous wake; delivering it is safe). This flips an
 otherwise no-op run to a success and is why the one-block judge ceiling is acceptable.
 (2) an **unlinked bold/leading-line address that reads like an ask** (`**slug** — … when you
-resume …`, via `detectUnlinkedTeammateAsks`, gated on directed-ask intent so a bold name written
-for emphasis is never touched) is the wakes-no-one trap — but the net does **not** rewrite the
+resume …`, or the name after a short routing label like `Next step: slug — …`, via
+`detectUnlinkedTeammateAsks`, gated on directed-ask intent so a bold name written for emphasis is
+never touched) is the wakes-no-one trap — but the net does **not** rewrite the
 agent's words or auto-deliver it (guessing intent to force a wake overreaches). `create_comment`
 already warns the agent interactively when it posts such a comment; the final-message path skips
 that check, so the runner surfaces the **same warning in the run log** and leaves the handoff

--- a/packages/server/src/lib/mentions.ts
+++ b/packages/server/src/lib/mentions.ts
@@ -15,6 +15,30 @@ const ASK_INTENT_RES: RegExp[] = [
 	/\?/,
 ];
 
+// A leading-line address may follow a short routing label — `Next step:`,
+// `Handoff:`, `Owner:` — so a handoff like `Next step: captain — …` addresses the
+// captain even though the name isn't the first token on the line. The label is a
+// bounded run of non-colon characters up to a colon, with optional trailing
+// markdown emphasis (`**`/`*`/`_`, so `**Next step:**` matches) before the
+// space(s) separating it from the name. Bounded (≤48 chars, single line) so a
+// sentence carrying an incidental colon can't reach across and swallow a
+// mid-sentence name.
+const ADDRESS_LABEL_PREFIX = String.raw`(?:[^\n:]{0,48}:[*_]*[ \t]+)?`;
+
+/**
+ * The "leading-line address" matcher for a name pattern (a bare `slug` or the
+ * passive `@@slug`): the name at the start of a line — optionally after a routing
+ * label (see ADDRESS_LABEL_PREFIX) — followed by an addressing separator (em/en
+ * dash, hyphen, colon, comma) then whitespace or EOL. Shared by every detector so
+ * the unlinked and passive forms recognise the same addressing shapes.
+ */
+function leadingAddressRegex(namePattern: string): RegExp {
+	return new RegExp(
+		String.raw`(?:^|\n)\s*${ADDRESS_LABEL_PREFIX}${namePattern}\s*[—–\-:,](?:\s|$)`,
+		'i',
+	);
+}
+
 export function extractMentionSlugs(content: unknown): string[] {
 	const text = flattenTextFields(content);
 	if (!text) return [];
@@ -61,9 +85,9 @@ export function detectUnlinkedTeammateReferences(content: unknown, knownSlugs: s
 		const s = escapeRegExp(slug);
 		// Emphasised name: **slug** or __slug__, not already @-prefixed.
 		const bold = new RegExp(String.raw`(?<!@)(\*\*|__)${s}\1`, 'i');
-		// Leading-line address: start of a line, the bare name, an addressing
-		// separator (em/en dash, hyphen, colon, comma), then whitespace or EOL.
-		const lead = new RegExp(String.raw`(?:^|\n)\s*${s}\s*[—–\-:,](?:\s|$)`, 'i');
+		// Leading-line address: start of a line (optionally after a routing label),
+		// the bare name, an addressing separator, then whitespace or EOL.
+		const lead = leadingAddressRegex(s);
 		if (bold.test(stripped) || lead.test(stripped)) flagged.add(slug);
 	}
 	return Array.from(flagged);
@@ -95,7 +119,7 @@ export function detectPassiveTeammateAsks(content: unknown, knownSlugs: string[]
 		// Addressed by the passive form: emphasised `**@@slug**`/`__@@slug__` or a
 		// leading-line `@@slug —` — the @@-prefixed analogue of the sibling's forms.
 		const bold = new RegExp(String.raw`(\*\*|__)@@${s}\1`, 'i');
-		const lead = new RegExp(String.raw`(?:^|\n)\s*@@${s}\s*[—–\-:,](?:\s|$)`, 'i');
+		const lead = leadingAddressRegex(`@@${s}`);
 		if (!bold.test(stripped) && !lead.test(stripped)) continue;
 		// Only warn when the paragraph(s) carrying this passive mention read as an
 		// ask — scoped to those paragraphs so a `you` elsewhere never leaks in.
@@ -141,10 +165,10 @@ export function detectUnlinkedTeammateAsks(content: unknown, knownSlugs: string[
 		if (active.has(slug)) continue;
 		const s = escapeRegExp(slug);
 		// Emphasised name (**slug**/__slug__, not already @-prefixed) or a
-		// leading-line address (`slug —`/`slug:`) — mirrors the two unambiguous
-		// addressing forms detectUnlinkedTeammateReferences recognises.
+		// leading-line address (`slug —`/`slug:`, optionally after a routing label)
+		// — mirrors the addressing forms detectUnlinkedTeammateReferences recognises.
 		const bold = new RegExp(String.raw`(?<!@)(\*\*|__)${s}\1`, 'i');
-		const lead = new RegExp(String.raw`(?:^|\n)\s*${s}\s*[—–\-:,](?:\s|$)`, 'i');
+		const lead = leadingAddressRegex(s);
 		if (!bold.test(stripped) && !lead.test(stripped)) continue;
 		// Only warn when the paragraph(s) carrying this address read as an ask —
 		// scoped to those paragraphs so a `you` elsewhere never leaks in.
@@ -160,7 +184,7 @@ export function detectUnlinkedTeammateAsks(content: unknown, knownSlugs: string[
  */
 function unlinkedMentionParagraphs(stripped: string, escapedSlug: string): string {
 	const bold = new RegExp(String.raw`(?<!@)(\*\*|__)${escapedSlug}\1`, 'i');
-	const lead = new RegExp(String.raw`(?:^|\n)\s*${escapedSlug}\s*[—–\-:,](?:\s|$)`, 'i');
+	const lead = leadingAddressRegex(escapedSlug);
 	return stripped
 		.split(/\n\s*\n/)
 		.filter((p) => bold.test(p) || lead.test(p))

--- a/packages/server/test/passive-mention-warning.test.ts
+++ b/packages/server/test/passive-mention-warning.test.ts
@@ -41,6 +41,40 @@ describe('detectPassiveTeammateAsks', () => {
 		expect(detectPassiveTeammateAsks('@@admin: can you approve?', slugs)).toEqual(['admin']);
 	});
 
+	it('flags the routing-label screenshot case: `**Next step:** @@captain — …your…`', () => {
+		// The exact stalled handoff: a passive @@captain sits after a `**Next step:**`
+		// label (not the first token on the line) with a second-person ask, while the
+		// only actively-mentioned name is @admin — so the captain was never woken.
+		expect(
+			detectPassiveTeammateAsks(
+				'**Next step:** @@captain — this X thread draft is reviewed and approved from my ' +
+					'side. Ready for your strategic review. After Captain sign-off, @admin will need to ' +
+					'attach screen recordings in Typefully before final approval and scheduling.',
+				['captain', 'admin', 'marketing-lead'],
+			),
+		).toEqual(['captain']);
+	});
+
+	it('flags a routing-label passive address without markdown emphasis', () => {
+		expect(detectPassiveTeammateAsks('Next step: @@architect — can you review?', slugs)).toEqual([
+			'architect',
+		]);
+	});
+
+	it('does not flag a routing-label passive handoff with no ask intent', () => {
+		expect(
+			detectPassiveTeammateAsks('**Next step:** @@architect — merged and shipped.', slugs),
+		).toEqual([]);
+	});
+
+	it('does not flag a teammate named after an unrelated label phrase', () => {
+		// The colon belongs to an unrelated lead-in; `architect` is mid-sentence, not
+		// addressed — the bounded, same-line label must sit immediately before the name.
+		expect(
+			detectPassiveTeammateAsks('Status update: the @@architect plan is ready, thanks.', slugs),
+		).toEqual([]);
+	});
+
 	it('does not flag a passive FYI with no ask intent', () => {
 		expect(detectPassiveTeammateAsks('@@admin — release is done.', slugs)).toEqual([]);
 	});
@@ -85,6 +119,7 @@ describe('MCP create_comment / update_comment warn on passive-mention asks', () 
 	let architectId: string;
 	let architectSlug: string;
 	let productLeadId: string;
+	let captainId: string;
 
 	async function insertTask(assigneeId: string, title: string): Promise<string> {
 		const meta = await db.query<{ task_prefix: string; number: number }>(
@@ -163,6 +198,7 @@ describe('MCP create_comment / update_comment warn on passive-mention asks', () 
 		architectId = architect.id;
 		architectSlug = architect.slug;
 		productLeadId = agents.find((a) => a.slug === 'product-lead')!.id;
+		captainId = agents.find((a) => a.slug === 'captain')!.id;
 	});
 
 	afterAll(async () => {
@@ -189,6 +225,28 @@ describe('MCP create_comment / update_comment warn on passive-mention asks', () 
 		expect(result.warning).toContain('active mention');
 		// The passive form genuinely notified no one.
 		expect(await adminMentionCount(result.id!)).toBe(0);
+	});
+
+	it('warns on the routing-label handoff `**Next step:** @@captain — …your…` (screenshot case)', async () => {
+		const taskId = await insertTask(captainId, 'Routing-label captain handoff');
+		const { token: agentToken } = await mintAgentToken(
+			db,
+			masterKeyManager,
+			productLeadId,
+			teamId,
+			taskId,
+			{ projectId },
+		);
+		const result = await callTool(agentToken, 'create_comment', {
+			project: projectId,
+			task_id: taskId,
+			content:
+				'**Next step:** @@captain — this draft is reviewed and approved from my side. Ready ' +
+				'for your strategic review before we schedule.',
+		});
+		expect(result.warning).toBeDefined();
+		expect(result.warning).toContain('captain');
+		expect(result.warning).toContain('active mention');
 	});
 
 	it('does not warn on a passive @@admin reference with no ask intent', async () => {

--- a/packages/server/test/unlinked-mention-ask.test.ts
+++ b/packages/server/test/unlinked-mention-ask.test.ts
@@ -19,6 +19,30 @@ describe('detectUnlinkedTeammateAsks', () => {
 		]);
 	});
 
+	it('flags a routing-label handoff that reads as an ask (`**Next step:** architect —`)', () => {
+		expect(
+			detectUnlinkedTeammateAsks(
+				'**Next step:** architect — ready for your review before we ship.',
+				slugs,
+			),
+		).toEqual(['architect']);
+	});
+
+	it('does not flag a routing-label handoff without ask intent', () => {
+		expect(
+			detectUnlinkedTeammateAsks('**Next step:** architect — merged and shipped.', slugs),
+		).toEqual([]);
+	});
+
+	it('does not flag a teammate named after an unrelated label phrase', () => {
+		expect(
+			detectUnlinkedTeammateAsks(
+				'Status update: the architect finished, thanks for asking.',
+				slugs,
+			),
+		).toEqual([]);
+	});
+
 	it('does not flag a bold name used for emphasis/attribution (no ask intent)', () => {
 		expect(
 			detectUnlinkedTeammateAsks(

--- a/packages/server/test/unlinked-mention-warning.test.ts
+++ b/packages/server/test/unlinked-mention-warning.test.ts
@@ -29,6 +29,18 @@ describe('detectUnlinkedTeammateReferences', () => {
 		]);
 	});
 
+	it('flags a teammate addressed after a routing label (`**Next step:** architect —`)', () => {
+		expect(
+			detectUnlinkedTeammateReferences('**Next step:** architect — review complete.', slugs),
+		).toEqual(['architect']);
+	});
+
+	it('does not flag a teammate named after an unrelated label phrase', () => {
+		expect(
+			detectUnlinkedTeammateReferences('Status update: the architect finished the plan.', slugs),
+		).toEqual([]);
+	});
+
 	it('does not flag an active @mention', () => {
 		expect(detectUnlinkedTeammateReferences('@architect — please consolidate.', slugs)).toEqual([]);
 	});


### PR DESCRIPTION
## Problem

A reviewer handed off to the Captain with a comment ending:

> **Next step:** captain — this X thread draft is reviewed and approved from my side. Ready for your strategic review. After Captain sign-off, @admin will need to attach screen recordings…

`captain` rendered as a plain link but woke no one, while `@admin` was an active mention. The agent had used the **passive** `@@captain` form (which links but never notifies), so the handoff to the Captain silently stalled — nothing was pinged.

The system already has a warning that catches exactly this (`detectPassiveTeammateAsks` → the "you used `@@`, that notifies no one, use `@captain`" nudge on `create_comment`/`update_comment`), but it never fired here. Its leading-line address matcher only recognized a teammate name at the **very start of a line** — so a name sitting after a short routing label like `**Next step:**` slipped through undetected.

## Fix

Centralize the leading-line address matcher into a single `leadingAddressRegex` helper and let it accept an optional, bounded **routing-label prefix** (`Next step:`, `Handoff:`, `Owner:`, including `**bold:**`) before the name. It's shared by all three detectors so the unlinked, passive, and runner handoff-delivery-net paths recognize the same addressing shapes:

- `detectUnlinkedTeammateReferences` — `create_comment` bold/bare-name warning
- `detectPassiveTeammateAsks` — `create_comment` passive `@@`-ask warning (the screenshot path)
- `detectUnlinkedTeammateAsks` — the runner's deterministic handoff-delivery net in `agent-runner.ts`

Now a `Next step: @@captain — … your review …` handoff trips the passive-ask warning, prompting the author to re-post with an active `@captain`.

Per the existing design, this **warns** rather than auto-rewriting the agent's words — guessing intent to force a wake overreaches, so the nudge to use the active mention stays the mechanism.

### Guardrails against over-matching

- The label prefix is bounded: ≤48 non-colon chars, single line, and must sit **immediately** before the name — an incidental mid-sentence colon (`Status update: the architect finished…`) can't reach across and swallow a name.
- The passive and ask detectors stay gated on directed-ask intent (`you`/`your`/`please`/`?`), scoped to the addressing paragraph, so a routing label with no ask (`**Next step:** architect — merged and shipped.`) is left alone.

## Tests

- `packages/server/test/passive-mention-warning.test.ts` — the exact screenshot case (`**Next step:** @@captain — …your…` flags `captain`, not the active `@admin`), plus an end-to-end MCP `create_comment` warning assertion and negative cases.
- `packages/server/test/unlinked-mention-ask.test.ts` and `unlinked-mention-warning.test.ts` — routing-label coverage plus over-match guards for the bare/bold detectors.

All server tests pass (`536 passed`), typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BmtFqMAt27bnjDeN3vmU8X

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmtFqMAt27bnjDeN3vmU8X)_