### PR TITLE
feat(web): reconnecting connection toast + move toasts to top-right

### DIFF
--- a/packages/web/src/components/ui/toast.tsx
+++ b/packages/web/src/components/ui/toast.tsx
@@ -1,5 +1,6 @@
 import * as RadixToast from '@radix-ui/react-toast';
-import { X } from 'lucide-react';
+import { Loader2, WifiOff, X } from 'lucide-react';
+import { useConnectionStatus } from '../../hooks/use-connection-status';
 import { toast, useToasts } from '../../hooks/use-toast';
 
 const ERROR_DURATION_MS = 6000;
@@ -8,9 +9,43 @@ const TOAST_TITLES = { error: 'Something went wrong', info: 'Heads up', success:
 
 export function Toaster() {
 	const toasts = useToasts();
+	const { offline, retry } = useConnectionStatus();
 
 	return (
 		<RadixToast.Provider swipeDirection="right" duration={ERROR_DURATION_MS}>
+			{/* Persistent connection indicator, pinned above transient toasts. It is
+			    controlled (open + no onOpenChange) and never auto-dismisses
+			    (duration Infinity), so it stays until the socket heals; swipe is
+			    suppressed so it can't be shoved off while still offline. */}
+			{offline && (
+				<RadixToast.Root
+					open
+					type="background"
+					duration={Number.POSITIVE_INFINITY}
+					onSwipeStart={(e) => e.preventDefault()}
+					data-testid="connection-toast"
+					className="border border-danger bg-surface text-text-1 rounded-md shadow-md px-3 py-2.5 flex items-start gap-3 data-[state=open]:animate-in data-[state=open]:slide-in-from-right-2 data-[state=closed]:animate-out data-[state=closed]:fade-out"
+				>
+					<WifiOff className="w-4 h-4 text-danger shrink-0 mt-0.5" aria-hidden="true" />
+					<div className="flex-1 min-w-0">
+						<RadixToast.Title className="text-[13px] font-medium mb-0.5 text-danger">
+							Connection lost
+						</RadixToast.Title>
+						<RadixToast.Description className="text-[13px] text-text-2 break-words flex items-center gap-1.5">
+							<Loader2 className="w-3 h-3 animate-spin shrink-0" aria-hidden="true" />
+							Reconnecting…
+						</RadixToast.Description>
+						<button
+							type="button"
+							data-testid="connection-retry"
+							onClick={() => retry?.()}
+							className="mt-1 inline-block text-[13px] font-medium text-accent-soft-fg hover:underline"
+						>
+							Retry now
+						</button>
+					</div>
+				</RadixToast.Root>
+			)}
 			{toasts.map((t) => (
 				<RadixToast.Root
 					key={t.id}
@@ -68,7 +103,11 @@ export function Toaster() {
 					</RadixToast.Close>
 				</RadixToast.Root>
 			))}
-			<RadixToast.Viewport className="fixed bottom-4 right-4 left-4 sm:left-auto sm:bottom-6 sm:right-6 z-50 flex flex-col gap-2 w-auto sm:w-80 max-w-full outline-none" />
+			{/* Top-right, offset below the 48px app header so it clears the header's
+			    top-right action icons and the update banner. Top-right (not
+			    bottom-right) keeps every toast clear of the CEO chat launcher, which
+			    is pinned bottom-right. */}
+			<RadixToast.Viewport className="fixed top-14 right-4 left-4 sm:left-auto sm:top-16 sm:right-6 z-50 flex flex-col gap-2 w-auto sm:w-80 max-w-full outline-none" />
 		</RadixToast.Provider>
 	);
 }

--- a/packages/web/src/contexts/socket-context.tsx
+++ b/packages/web/src/contexts/socket-context.tsx
@@ -1,5 +1,6 @@
 import type { WsMessageType, WsServerMessage } from '@hezo/shared';
 import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
+import { useConnectionMonitor } from '../hooks/use-connection-status';
 import { type MessageHandler, WebSocketClient } from '../lib/ws';
 
 interface SocketContextValue {
@@ -7,6 +8,8 @@ interface SocketContextValue {
 	subscribe: (type: WsMessageType, handler: MessageHandler) => () => void;
 	joinRoom: (room: string) => void;
 	leaveRoom: (room: string) => void;
+	/** Force an immediate reconnect, bypassing the exponential-backoff wait. */
+	reconnect: () => void;
 }
 
 const SocketContext = createContext<SocketContextValue | null>(null);
@@ -46,9 +49,33 @@ export function SocketProvider({
 		clientRef.current.unsubscribe(room);
 	}, []);
 
+	const reconnect = useCallback(() => {
+		clientRef.current.reconnect();
+	}, []);
+
 	return (
-		<SocketContext value={{ connected, subscribe, joinRoom, leaveRoom }}>{children}</SocketContext>
+		<SocketContext value={{ connected, subscribe, joinRoom, leaveRoom, reconnect }}>
+			<ConnectionMonitor connected={connected} reconnect={reconnect} />
+			{children}
+		</SocketContext>
 	);
+}
+
+/**
+ * Bridges the socket's `connected` flag into the module-level connection store
+ * that the global `<Toaster />` reads (it's mounted outside this provider, so it
+ * can't consume the context). Rendered here — not in `ShellLayout` — so it covers
+ * the whole authenticated session, including the onboarding wizard above the shell.
+ */
+function ConnectionMonitor({
+	connected,
+	reconnect,
+}: {
+	connected: boolean;
+	reconnect: () => void;
+}) {
+	useConnectionMonitor(connected, reconnect);
+	return null;
 }
 
 export function useSocket(): SocketContextValue {

--- a/packages/web/src/hooks/use-connection-status.ts
+++ b/packages/web/src/hooks/use-connection-status.ts
@@ -1,0 +1,114 @@
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react';
+
+/**
+ * A tiny external store for the app's live connection state, mirroring the
+ * `useSyncExternalStore` pattern in `use-toast.ts`.
+ *
+ * It exists as a module-level store (not a React context) because the two sides
+ * live in different trees: the WebSocket monitor writes from *inside*
+ * `SocketProvider` (which owns the socket, mounted only after unlock + a valid
+ * session), while the reader — the global `<Toaster />` — is mounted in
+ * `main.tsx` *outside* the provider and the router, so it cannot call
+ * `useSocket()`. This bridge lets the disconnect indicator render in the shared
+ * top-right toast stack without threading the socket through the whole tree.
+ */
+export interface ConnectionState {
+	/** True once the socket has dropped (after connecting at least once). */
+	offline: boolean;
+	/** Force an immediate reconnect — wired to the socket client's `reconnect()`. */
+	retry: (() => void) | null;
+}
+
+const ONLINE: ConnectionState = { offline: false, retry: null };
+
+let state: ConnectionState = ONLINE;
+const listeners = new Set<(s: ConnectionState) => void>();
+
+function emit() {
+	for (const l of listeners) l(state);
+}
+
+/** Mark the connection as lost, carrying the retry action for "Retry now". */
+export function setConnectionOffline(retry: () => void): void {
+	if (state.offline && state.retry === retry) return;
+	state = { offline: true, retry };
+	emit();
+}
+
+/** Mark the connection as healthy again (also used to reset on provider unmount). */
+export function setConnectionOnline(): void {
+	if (!state.offline && state.retry === null) return;
+	state = ONLINE;
+	emit();
+}
+
+export function useConnectionStatus(): ConnectionState {
+	return useSyncExternalStore(
+		(listener) => {
+			listeners.add(listener);
+			return () => {
+				listeners.delete(listener);
+			};
+		},
+		() => state,
+		() => state,
+	);
+}
+
+/** How long the socket must stay down before we surface a disconnect. */
+export const OFFLINE_DEBOUNCE_MS = 2000;
+
+/**
+ * Drive the connection store from two signals, covering "the internet dropped"
+ * and "the server is unreachable" respectively:
+ *   - `navigator.onLine` (window `offline`/`online` events) — a hard "no network"
+ *     signal that fires even when an already-open socket hasn't yet noticed the
+ *     drop (a half-open TCP connection can read OPEN for a while);
+ *   - the socket's `connected` flag — catches a server that went away while the
+ *     browser still has a network route.
+ *
+ * Debounces the offline transition so brief mobile blips (radio waking on
+ * app-switch, cell↔wifi handoffs) don't flash the banner, and gates the socket
+ * signal behind `hasConnectedOnce` so the initial connecting phase — and the
+ * component-test harness, which stubs the WebSocket to a no-op that never opens —
+ * never shows "offline". On unmount (logout/lock unmounts `SocketProvider`) it
+ * resets the store so a stale disconnect can't bleed into the login / master-key
+ * gate.
+ *
+ * Consumes only a boolean + a stable callback (like `useInvalidateOnReconnect`),
+ * so it can be driven directly by a prop in tests.
+ */
+export function useConnectionMonitor(connected: boolean, reconnect: () => void): void {
+	const hasConnectedOnce = useRef(false);
+	if (connected) hasConnectedOnce.current = true;
+
+	const [networkOnline, setNetworkOnline] = useState(() =>
+		typeof navigator === 'undefined' ? true : navigator.onLine,
+	);
+	useEffect(() => {
+		const goOnline = () => setNetworkOnline(true);
+		const goOffline = () => setNetworkOnline(false);
+		window.addEventListener('online', goOnline);
+		window.addEventListener('offline', goOffline);
+		return () => {
+			window.removeEventListener('online', goOnline);
+			window.removeEventListener('offline', goOffline);
+		};
+	}, []);
+
+	// Disconnected when the browser reports no network, or the socket has dropped
+	// after having connected at least once.
+	const disconnected = !networkOnline || (hasConnectedOnce.current && !connected);
+
+	useEffect(() => {
+		if (!disconnected) {
+			setConnectionOnline();
+			return;
+		}
+		const id = setTimeout(() => setConnectionOffline(reconnect), OFFLINE_DEBOUNCE_MS);
+		return () => clearTimeout(id);
+	}, [disconnected, reconnect]);
+
+	// Unmount-only: clear any surfaced disconnect when the provider tears down.
+	useEffect(() => () => setConnectionOnline(), []);
+}

--- a/packages/web/src/hooks/use-status.ts
+++ b/packages/web/src/hooks/use-status.ts
@@ -21,8 +21,18 @@ export function useStatus() {
 		refetchOnMount: 'always',
 		retry: (failureCount, error) => isRetryableStatusError(error) && failureCount < 40,
 		retryDelay: 500,
-		// While the server reports it's still booting, keep polling so the loading
-		// screen advances through phases and flips to the app the moment it's ready.
-		refetchInterval: (query) => (query.state.data?.starting ? 500 : false),
+		// Keep polling in two cases so the gate self-heals without user action:
+		//   - while the server reports it's still booting, so the loading screen
+		//     advances through phases and flips to the app the moment it's ready;
+		//   - while the last fetch errored (e.g. a cold load with the server
+		//     unreachable — a network "Failed to fetch" isn't retryable above and
+		//     fails fast to `error`), so the moment the server comes back a poll
+		//     succeeds and the shell renders, instead of stranding the user on the
+		//     full-screen error. Healthy operation still never polls.
+		refetchInterval: (query) => {
+			if (query.state.data?.starting) return 500;
+			if (query.state.status === 'error') return 2000;
+			return false;
+		},
 	});
 }

--- a/packages/web/src/lib/ws.ts
+++ b/packages/web/src/lib/ws.ts
@@ -12,9 +12,11 @@ export class WebSocketClient {
 	private ws: ReconnectingWebSocket | null = null;
 	private handlers = new Map<WsMessageType, Set<MessageHandler>>();
 	private subscribedRooms = new Set<string>();
+	private token: string | null = null;
 	onStatusChange?: (connected: boolean) => void;
 
 	connect(token: string | null): void {
+		this.token = token;
 		const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
 		const query = token ? `?token=${encodeURIComponent(token)}` : '';
 		const url = `${protocol}//${window.location.host}/ws${query}`;
@@ -57,6 +59,23 @@ export class WebSocketClient {
 		this.ws?.close();
 		this.ws = null;
 		this.subscribedRooms.clear();
+	}
+
+	/**
+	 * Force an immediate reconnection, bypassing the exponential-backoff wait.
+	 *
+	 * We recreate the underlying `ReconnectingWebSocket` rather than call its
+	 * `reconnect()`: during the backoff-wait window (exactly when a user clicks
+	 * "Retry now") RWS holds an internal connect-lock and its `reconnect()`
+	 * early-returns without pulling the pending dial earlier — a no-op precisely
+	 * when it's needed. A fresh instance has a zero retry delay, so it dials at
+	 * once. Unlike `disconnect()`, this preserves `subscribedRooms` and handlers,
+	 * so `connect()`'s `onopen` replay loop re-subscribes to every joined room.
+	 */
+	reconnect(): void {
+		this.ws?.close();
+		this.ws = null;
+		this.connect(this.token);
 	}
 
 	subscribe(room: string): void {

--- a/packages/web/src/routes/__root.tsx
+++ b/packages/web/src/routes/__root.tsx
@@ -79,12 +79,21 @@ function AppShell() {
 	if (isPending) return <Spinner />;
 
 	if (isError || !status || !status.masterKeyState) {
-		const message =
-			(error as { message?: string } | null)?.message ??
-			'Could not reach the server. If you just reset the database, wait a few seconds and retry.';
+		const raw = (error as { message?: string } | null)?.message;
+		// A bare `fetch` network failure surfaces as the browser's technical
+		// "Failed to fetch" / "Load failed" / "NetworkError". Show friendly copy for
+		// that (the query keeps auto-retrying every 2s, so it self-heals when the
+		// server returns); pass through any real server-sent message unchanged.
+		const isNetwork = !raw || /failed to fetch|load failed|networkerror/i.test(raw);
+		const message = isNetwork ? "Can't reach the server. Retrying…" : raw;
 		return (
 			<div className="flex flex-col items-center justify-center h-screen gap-4 px-4 text-center">
-				<p className="text-[13px] text-danger max-w-md">{message}</p>
+				<div className="flex items-center gap-2 text-danger">
+					{isNetwork && (
+						<div className="w-3.5 h-3.5 border-2 border-danger border-t-transparent rounded-full animate-spin" />
+					)}
+					<p className="text-[13px] max-w-md">{message}</p>
+				</div>
 				<button
 					type="button"
 					onClick={() => refetch()}

--- a/packages/web/test/connection-status.test.tsx
+++ b/packages/web/test/connection-status.test.tsx
@@ -1,0 +1,137 @@
+// The disconnect indicator: the module-level connection store, the socket
+// monitor that drives it (debounce + connected-once gate), and the persistent
+// toast the Toaster renders from it. The monitor consumes only a boolean + a
+// stable callback, so it's driven directly by a prop here (no real socket).
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { Toaster } from '../src/components/ui/toast';
+import {
+	type ConnectionState,
+	OFFLINE_DEBOUNCE_MS,
+	setConnectionOffline,
+	setConnectionOnline,
+	useConnectionMonitor,
+	useConnectionStatus,
+} from '../src/hooks/use-connection-status';
+
+let latest: ConnectionState;
+function Reader() {
+	latest = useConnectionStatus();
+	return null;
+}
+function Monitor({ connected, reconnect }: { connected: boolean; reconnect: () => void }) {
+	useConnectionMonitor(connected, reconnect);
+	return null;
+}
+
+describe('connection store', () => {
+	afterEach(() => setConnectionOnline());
+
+	test('offline/online transitions drive the store and notify readers', () => {
+		render(<Reader />);
+		expect(latest.offline).toBe(false);
+		expect(latest.retry).toBeNull();
+
+		const retry = () => {};
+		act(() => setConnectionOffline(retry));
+		expect(latest.offline).toBe(true);
+		expect(latest.retry).toBe(retry);
+
+		act(() => setConnectionOnline());
+		expect(latest.offline).toBe(false);
+		expect(latest.retry).toBeNull();
+	});
+});
+
+describe('useConnectionMonitor', () => {
+	afterEach(() => {
+		vi.useRealTimers();
+		setConnectionOnline();
+	});
+
+	const ui = (connected: boolean, reconnect: () => void) => (
+		<>
+			<Monitor connected={connected} reconnect={reconnect} />
+			<Reader />
+		</>
+	);
+
+	test('surfaces offline only after the debounce, and heals immediately', () => {
+		vi.useFakeTimers();
+		const reconnect = vi.fn();
+		const { rerender } = render(ui(true, reconnect)); // connect first
+		expect(latest.offline).toBe(false);
+
+		rerender(ui(false, reconnect)); // drop
+		act(() => vi.advanceTimersByTime(OFFLINE_DEBOUNCE_MS - 1));
+		expect(latest.offline).toBe(false); // still within the debounce window
+
+		act(() => vi.advanceTimersByTime(1));
+		expect(latest.offline).toBe(true);
+		expect(latest.retry).toBe(reconnect); // "Retry now" is wired to reconnect
+
+		rerender(ui(true, reconnect)); // heal
+		expect(latest.offline).toBe(false);
+	});
+
+	test('a brief blip that heals before the debounce never surfaces offline', () => {
+		vi.useFakeTimers();
+		const noop = () => {};
+		const { rerender } = render(ui(true, noop));
+		rerender(ui(false, noop));
+		act(() => vi.advanceTimersByTime(OFFLINE_DEBOUNCE_MS - 500));
+		rerender(ui(true, noop)); // heals before the debounce elapses
+		act(() => vi.advanceTimersByTime(5000));
+		expect(latest.offline).toBe(false);
+	});
+
+	test('never surfaces offline until the socket has connected once', () => {
+		// Mirrors the component-test harness, whose stubbed WebSocket never opens:
+		// without the connected-once gate every shell test would grow a disconnect
+		// toast. Start disconnected and never connect.
+		vi.useFakeTimers();
+		render(ui(false, () => {}));
+		act(() => vi.advanceTimersByTime(OFFLINE_DEBOUNCE_MS * 3));
+		expect(latest.offline).toBe(false);
+	});
+
+	test('surfaces offline when the browser goes offline, even if the socket reads connected', () => {
+		// A dropped internet connection can leave an already-open socket reading
+		// OPEN (half-open TCP), so navigator.onLine is the signal that fires.
+		vi.useFakeTimers();
+		render(ui(true, () => {}));
+		expect(latest.offline).toBe(false);
+
+		act(() => window.dispatchEvent(new Event('offline')));
+		act(() => vi.advanceTimersByTime(OFFLINE_DEBOUNCE_MS));
+		expect(latest.offline).toBe(true);
+
+		act(() => window.dispatchEvent(new Event('online')));
+		expect(latest.offline).toBe(false);
+	});
+});
+
+describe('connection toast (Toaster)', () => {
+	afterEach(() => setConnectionOnline());
+
+	test('shows nothing while online', () => {
+		render(<Toaster />);
+		expect(screen.queryByTestId('connection-toast')).toBeNull();
+	});
+
+	test('renders the disconnect banner when offline and Retry now fires reconnect', async () => {
+		const user = userEvent.setup();
+		const retry = vi.fn();
+		render(<Toaster />);
+
+		act(() => setConnectionOffline(retry));
+
+		const banner = screen.getByTestId('connection-toast');
+		expect(banner.textContent).toContain('Connection lost');
+		expect(banner.textContent).toContain('Reconnecting');
+
+		await user.click(screen.getByTestId('connection-retry'));
+		expect(retry).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/web/test/ws-client.test.ts
+++ b/packages/web/test/ws-client.test.ts
@@ -355,4 +355,57 @@ describe('WebSocketClient', () => {
 			expect((client as unknown as { ws: unknown }).ws).toBeNull();
 		});
 	});
+
+	describe('reconnect', () => {
+		// reconnect() must recreate the underlying RWS (a fresh instance dials with a
+		// zero retry delay, bypassing the backoff wait — unlike RWS's own reconnect(),
+		// which no-ops while a backoff dial is pending). Capture constructions by
+		// spying the global WebSocket ctor, exactly like captureUrl above.
+		test('redials with a brand-new socket and preserves subscribed rooms', async () => {
+			const urls: string[] = [];
+			const Real = globalThis.WebSocket;
+			class Capturing extends (Real as unknown as { new (...a: unknown[]): object }) {
+				constructor(...args: unknown[]) {
+					super(...args);
+					urls.push(String(args[0]));
+				}
+			}
+			(globalThis as unknown as { WebSocket: unknown }).WebSocket = Capturing;
+			const client = new WebSocketClient();
+			try {
+				client.connect('tok');
+				await new Promise((r) => setTimeout(r, 5));
+				expect(urls.length).toBe(1);
+
+				// Rooms buffered while the underlying socket is still CONNECTING.
+				client.subscribe('team:1');
+				client.subscribe('task:2');
+
+				client.reconnect();
+				await new Promise((r) => setTimeout(r, 5));
+
+				// A second underlying socket was constructed → it re-dialed.
+				expect(urls.length).toBe(2);
+				expect(urls[1]).toBe('wss://app.example.com/ws?token=tok');
+				// Rooms survive (unlike disconnect(), which clears them) so onopen replays them.
+				const rooms = (client as unknown as { subscribedRooms: Set<string> }).subscribedRooms;
+				expect([...rooms]).toEqual(['team:1', 'task:2']);
+			} finally {
+				client.disconnect();
+				(globalThis as unknown as { WebSocket: unknown }).WebSocket = Real;
+			}
+		});
+
+		test('closes the previous socket before redialing', () => {
+			const client = new WebSocketClient();
+			client.connect('tok'); // retains the token for the redial
+			const fake = makeFakeSocket(OPEN);
+			injectSocket(client, fake);
+
+			client.reconnect();
+
+			expect(fake.closed).toBe(1);
+			client.disconnect();
+		});
+	});
 });

--- a/test/browser/connection-toast.spec.ts
+++ b/test/browser/connection-toast.spec.ts
@@ -1,0 +1,61 @@
+// Testing decision tree, points 1 (real CSS layout / boundingBox) and 5 (a real
+// WebSocket stream): the disconnect toast is driven by the live socket dropping
+// on a genuine `offline` transition, and the assertions read real positions
+// (top-right, below the header, clear of the bottom-right chat launcher) that
+// happy-dom — which has no layout and stubs WebSocket to a no-op — cannot model.
+
+import { expect, test } from './fixtures';
+
+test('shows a top-right reconnecting toast when the socket drops, and clears when it heals', async ({
+	sharedPage,
+	sharedWorkspace,
+}) => {
+	const page = sharedPage;
+	const context = page.context();
+
+	// The monitor gates the disconnect toast behind "connected at least once", so
+	// the app socket must have opened before we drop it. Capture the app's own
+	// `/ws` socket (in dev, Vite's HMR socket is created first — filter it out by
+	// URL) and its first sent frame: the client replays room subscriptions the
+	// instant the socket opens, which is the deterministic "opened" signal (the
+	// server sends nothing on open). Arming inside the `websocket` event — which
+	// fires at socket creation, before any frame — avoids racing the frame.
+	let appSocketOpened: Promise<unknown> | undefined;
+	page.on('websocket', (ws) => {
+		if (!appSocketOpened && /\/ws(\?|$)/.test(ws.url())) {
+			appSocketOpened = ws.waitForEvent('framesent', { timeout: 20000 });
+		}
+	});
+	await page.goto(`/projects/${sharedWorkspace.projectSlug}/tasks`);
+	await expect(page.getByTestId('content-well')).toBeVisible({ timeout: 20000 });
+	await expect.poll(() => Boolean(appSocketOpened), { timeout: 20000 }).toBe(true);
+	await appSocketOpened;
+
+	// Drop the network for real → the socket closes → after the ~2s debounce the
+	// toast surfaces.
+	await context.setOffline(true);
+	const toast = page.getByTestId('connection-toast');
+	await expect(toast).toBeVisible({ timeout: 10000 });
+	await expect(toast).toContainText('Connection lost');
+	await expect(toast).toContainText('Reconnecting');
+
+	// Position: top-right, below the app header, and clear of the CEO chat launcher
+	// (which is pinned bottom-right — the whole reason toasts moved to the top).
+	const toastBox = await toast.boundingBox();
+	const headerBox = await page.getByTestId('app-header').boundingBox();
+	const launcherBox = await page.getByTestId('chat-launcher').boundingBox();
+	const viewport = page.viewportSize();
+	if (!toastBox || !headerBox || !launcherBox || !viewport) throw new Error('missing boxes');
+	expect(toastBox.y).toBeGreaterThanOrEqual(headerBox.y + headerBox.height - 1);
+	expect(toastBox.x + toastBox.width).toBeGreaterThan(viewport.width / 2);
+	expect(toastBox.y + toastBox.height).toBeLessThan(launcherBox.y);
+
+	// "Retry now" is a real control: clicking it while still offline forces a
+	// reconnect attempt without crashing, and the toast stays up (still offline).
+	await page.getByTestId('connection-retry').click();
+	await expect(toast).toBeVisible();
+
+	// Restore the network → the socket reconnects → the toast clears.
+	await context.setOffline(false);
+	await expect(toast).toBeHidden({ timeout: 15000 });
+});


### PR DESCRIPTION
## Problem

When the internet drops or the server is unreachable, the web app either showed **nothing** (a live WebSocket drop silently stopped realtime updates) or, on a cold load / hard refresh, blanked the whole viewport to a stark centered **"Failed to fetch"** message. Neither told the user we were reconnecting or gave them a way to retry.

## What changed

**All toasts move to the top-right.** The toast viewport moves from bottom-right to top-right (offset below the app header so it clears the header's action icons and the update banner). This keeps every toast clear of the CEO chat launcher, which is pinned bottom-right.

**A persistent connection indicator.** When we're disconnected, a "Connection lost — reconnecting…" toast (WifiOff icon + spinner) shows in the top-right with a **Retry now** action. It's driven by a small module-level connection store so the globally-mounted `<Toaster>` can render it without access to the socket context.

**A `ConnectionMonitor` inside `SocketProvider`** drives the store from two signals, matching the user's "internet disconnected **or** server unreachable":
- `navigator.onLine` (the browser `offline`/`online` events) — a hard "no network" signal that fires even when an already-open socket hasn't yet noticed the drop;
- the socket's `connected` flag — catches a server that went away while the browser still has a network route.

It debounces the offline transition ~2s (so brief mobile blips don't flash the banner), gates the socket signal behind "connected at least once" (so the initial connecting phase — and the WS-stubbed component-test harness — never surface offline), and resets on provider unmount so a stale banner can't bleed into the login / master-key gate.

**Exponential backoff + Retry now.** Reconnection already uses exponential backoff (`reconnecting-websocket`: 1s→10s, growth 1.3, infinite retries). **Retry now** forces an *immediate* reconnect by recreating the client — RWS's own `reconnect()` is a no-op during the backoff-wait window — preserving the subscribed rooms so they replay on reopen.

**The cold-load screen self-heals.** The status query keeps auto-retrying while errored, and a network failure now shows **"Can't reach the server. Retrying…"** with a spinner instead of the raw "Failed to fetch". When the server returns, a poll succeeds and the app renders — no user action needed. (Mid-session drops don't hit this branch; React Query keeps the last data, so the shell stays mounted and the toast handles it.)

## Files

- `packages/web/src/components/ui/toast.tsx` — viewport → top-right; persistent connectivity toast.
- `packages/web/src/hooks/use-connection-status.ts` *(new)* — connection store + `useConnectionMonitor`.
- `packages/web/src/contexts/socket-context.tsx` — expose `reconnect`; mount `ConnectionMonitor`.
- `packages/web/src/lib/ws.ts` — retain token; `reconnect()` recreates the RWS preserving rooms.
- `packages/web/src/hooks/use-status.ts` — keep polling while the status query is errored.
- `packages/web/src/routes/__root.tsx` — friendlier network-error copy + spinner in the cold-load gate.

## Testing

- **Unit** (`ws-client.test.ts`): `reconnect()` closes the old socket, redials a new one, and preserves subscribed rooms.
- **Store + monitor** (`connection-status.test.tsx`): debounce, connected-once gate, navigator-offline path, and the toast rendering + **Retry now** click.
- **Browser** (`connection-toast.spec.ts`): a real `setOffline` drop surfaces the top-right toast, verifies it sits below the header and clear of the chat launcher, exercises Retry now, and confirms it clears on recovery.

All tiers pass locally (component/unit + the new Playwright spec); the pre-commit hook ran full typecheck across all three packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YJQiRarVRdFqnC5aDSGnSY

---
_Generated by [Claude Code](https://claude.ai/code/session_01YJQiRarVRdFqnC5aDSGnSY)_