### PR TITLE
feat: restyle mobile top-nav Add Task button as outlined icon

### DIFF
--- a/packages/web/src/components/app-header.tsx
+++ b/packages/web/src/components/app-header.tsx
@@ -64,17 +64,22 @@ export function AppHeader({
 			</div>
 
 			<div className="flex items-center gap-0.5">
-				{/* Leftmost of the action group; keeps the accent (primary CTA) fill so
-				    it reads as the create action, not another quiet nav icon. */}
+				{/* Leftmost of the action group. Styled as a quiet outlined button —
+				    transparent fill, primary-red border and "+" — so it sits with the
+				    other nav icons while the accent still marks it as the create action.
+				    The 32px tap target matches its neighbours; the bordered box inside is
+				    a compact 22px with an edge-to-edge plus. */}
 				<button
 					type="button"
 					onClick={() => setNewTaskOpen(true)}
 					aria-label="New task"
 					title="New task"
 					data-testid="app-header-new-task"
-					className="lg:hidden w-8 h-8 rounded-md flex items-center justify-center bg-accent-solid text-accent-solid-fg hover:bg-accent-hover transition-colors"
+					className={`${iconLinkClass} lg:hidden`}
 				>
-					<Plus className="w-4 h-4" />
+					<span className="flex h-[22px] w-[22px] items-center justify-center rounded-md border border-accent text-accent">
+						<Plus className="h-[22px] w-[22px]" />
+					</span>
 				</button>
 				<CreateTaskDialog
 					selectProject

--- a/test/browser/new-task-button.mobile.spec.ts
+++ b/test/browser/new-task-button.mobile.spec.ts
@@ -34,9 +34,16 @@ test.describe('Header new-task button responsiveness', () => {
 		expect(buttonBox.x + buttonBox.width).toBeLessThanOrEqual(searchBox.x + 1);
 		expect(Math.abs(buttonBox.y - searchBox.y)).toBeLessThan(buttonBox.height);
 
-		// The accent (primary CTA) fill, not the quiet icon treatment.
+		// Quiet, outlined treatment: the button fill is transparent (matching the
+		// other nav icons) with a primary-red bordered "+" box marking the create
+		// action — not the old solid-accent fill.
 		const background = await headerButton.evaluate((el) => getComputedStyle(el).backgroundColor);
-		expect(background).not.toBe('rgba(0, 0, 0, 0)');
+		expect(background).toBe('rgba(0, 0, 0, 0)');
+		const borderColor = await headerButton.evaluate((el) => {
+			const box = el.querySelector('span');
+			return box ? getComputedStyle(box).borderTopColor : '';
+		});
+		expect(borderColor).not.toBe('rgba(0, 0, 0, 0)');
 
 		// Opening it pops the create-task dialog with the current project preselected.
 		await headerButton.click();


### PR DESCRIPTION
## Summary

On mobile (below the `lg` breakpoint), the top-nav **Add Task** button used a solid primary-red fill that read heavier than the other nav icons (Search, Inbox, Marketplace, Settings, theme). This restyles it to sit with those quiet nav icons while still marking it as the create action:

- **Transparent background** — same as the neighbouring nav icons, with the standard grey hover.
- **Primary red kept on a 1px border and the `+` icon** — so it stays recognisable as the create button.
- **32px tap target retained** (matching its neighbours), with a compact **22px bordered box** and an **edge-to-edge `+`** inside for maximum visibility.

Desktop is unaffected — the button is `lg:hidden` and the sidebar `+` carries the create action there.

## Before → after

| | Fill | Border | Icon |
|---|---|---|---|
| Before | solid accent red | none | white `+` |
| After | transparent | 1px primary red | primary-red `+` |

## Changes

- `packages/web/src/components/app-header.tsx` — reuse the shared `iconLinkClass` for the new-task button and wrap the `Plus` in a red-outlined 22px box.
- `test/browser/new-task-button.mobile.spec.ts` — assert the new outlined treatment (transparent button fill + non-transparent accent border) instead of the old solid-accent fill.

## Testing

- `bunx vitest run test/header-new-task.test.tsx test/app-header.test.tsx` — 9 passed
- `turbo typecheck` — passed
- `biome check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PPucquktTg2H2mf4NRmVP6)_