### PR TITLE
feat(logs): preserve thinking line breaks in the formatted log view

### DIFF
--- a/packages/server/src/services/agent-stream-parser.ts
+++ b/packages/server/src/services/agent-stream-parser.ts
@@ -1108,12 +1108,19 @@ export function extractGrokUsageFromDebugLog(
 // ---------------------------------------------------------------------------
 // Shared rendering helpers
 //
-// Content (thinking, tool args, tool results, errors) is preserved in full — the
-// only transform is collapsing whitespace to a single space, which the persisted
-// log format requires: each event is stored as one newline-terminated line, so an
-// embedded newline would be mis-parsed as a separate line by the client parser
-// (`parse-agent-log.ts`). It is NOT truncated; the whole run log is recorded, with
-// only the overall byte cap in `log-stream-broker.ts` as a runaway-output backstop.
+// Content (thinking, tool args, tool results, errors) is preserved in full and
+// never truncated; the whole run log is recorded, with only the overall byte cap
+// in `log-stream-broker.ts` as a runaway-output backstop.
+//
+// The persisted log is line-based — each physical line is one event — so tool args
+// and tool results collapse all whitespace (newlines included) to a single space;
+// an embedded newline there would be mis-parsed as a separate line by the client
+// parser (`parse-agent-log.ts`). Thinking is the exception: to keep long reasoning
+// readable it KEEPS the model's own line breaks, emitting one `[thinking]`-prefixed
+// line per physical line (a blank line becomes a bare `[thinking]`, since
+// `splitLogLines` drops empty lines and the prefix keeps them alive). The client
+// parser coalesces that consecutive run back into one block, exactly as it already
+// does for `[system]` lines. Only horizontal whitespace is collapsed.
 // ---------------------------------------------------------------------------
 
 function normalizeContent(content: ClaudeMessage['content']): ClaudeContentBlock[] {
@@ -1123,9 +1130,20 @@ function normalizeContent(content: ClaudeMessage['content']): ClaudeContentBlock
 }
 
 function formatThinking(text: string): string {
-	const collapsed = text.replace(/\s+/g, ' ').trim();
-	if (collapsed.length === 0) return '[thinking]';
-	return `[thinking] ${collapsed}`;
+	const normalized = text
+		.replace(/\r\n?/g, '\n') // CRLF / lone CR → LF
+		.replace(/[^\S\n]+/g, ' ') // collapse spaces/tabs but keep newlines
+		.replace(/ *\n */g, '\n') // drop spaces hugging a line break
+		.replace(/\n{3,}/g, '\n\n') // cap blank runs at a single blank line
+		.trim();
+	if (normalized === '') return '[thinking]';
+	// One `[thinking]`-prefixed line per physical line (blank lines included) so the
+	// model's paragraph/list structure survives the line-based log; the client parser
+	// coalesces the consecutive run back into a single block.
+	return normalized
+		.split('\n')
+		.map((line) => (line === '' ? '[thinking]' : `[thinking] ${line}`))
+		.join('\n');
 }
 
 function formatToolUse(name: string, input: unknown): string {

--- a/packages/server/test/agent-stream-parser-branches.test.ts
+++ b/packages/server/test/agent-stream-parser-branches.test.ts
@@ -591,6 +591,48 @@ describe('full-length lines (no per-line cap — the whole run log is recorded)'
 	});
 });
 
+describe('thinking preserves the model line breaks (multi-line [thinking] block)', () => {
+	const think = (thinking: string) =>
+		feed(createAgentStreamParser(AgentRuntime.ClaudeCode), [
+			{
+				type: 'assistant',
+				message: { role: 'assistant', content: [{ type: 'thinking', thinking }] },
+			},
+		]);
+
+	it('emits one [thinking] line per physical line, a blank line kept as a bare [thinking]', () => {
+		const out = think(
+			'First, understand the picture.\n\nThen:\n1. read the thread\n2. check state',
+		);
+		expect(out).toBe(
+			[
+				'[thinking] First, understand the picture.',
+				'[thinking]',
+				'[thinking] Then:',
+				'[thinking] 1. read the thread',
+				'[thinking] 2. check state',
+				'',
+			].join('\n'),
+		);
+	});
+
+	it('collapses only horizontal whitespace and caps a blank run at one blank line', () => {
+		expect(think('  spaced   out  \n\n\n\nnext   thought  ')).toBe(
+			'[thinking] spaced out\n[thinking]\n[thinking] next thought\n',
+		);
+	});
+
+	it('leaves single-line thinking as exactly one [thinking] line', () => {
+		const out = think('just one line');
+		expect(out).toBe('[thinking] just one line\n');
+		expect(out.match(/\[thinking\]/g)).toHaveLength(1);
+	});
+
+	it('renders empty thinking as a bare [thinking] line', () => {
+		expect(think('   \n  \n')).toBe('[thinking]\n');
+	});
+});
+
 describe('extractToolResultText arms (Claude tool_result content shapes)', () => {
 	it('renders a string-content tool_result directly', () => {
 		const parser = createAgentStreamParser(AgentRuntime.ClaudeCode);

--- a/packages/web/src/lib/parse-agent-log.ts
+++ b/packages/web/src/lib/parse-agent-log.ts
@@ -3,12 +3,15 @@
  * (produced server-side by `agent-stream-parser.ts`) into structured blocks the
  * Formatted log view can render.
  *
- * The server discards the original stream-json and persists only single-line,
- * prefixed text (`[session]`, `[thinking]`, `[tool] Name(args)`, `[tool-result]`,
- * `[tool-error]`, `[done]`, plus bare prose and `$ command` lines). There is no
- * correlation id between a tool call and its result — Claude emits N parallel
- * `[tool]` lines and then N `[tool-result]`/`[tool-error]` lines in the same
- * order, so we pair them FIFO via a queue of pending tool blocks.
+ * The server discards the original stream-json and persists prefixed, per-line
+ * text (`[session]`, `[thinking]`, `[tool] Name(args)`, `[tool-result]`,
+ * `[tool-error]`, `[done]`, plus bare prose and `$ command` lines). A single
+ * thinking block spans several consecutive `[thinking]` lines — the server keeps
+ * the model's own line breaks for readability — which we coalesce back into one
+ * block (as we do for `[system]`). There is no correlation id between a tool call
+ * and its result — Claude emits N parallel `[tool]` lines and then N
+ * `[tool-result]`/`[tool-error]` lines in the same order, so we pair them FIFO via
+ * a queue of pending tool blocks.
  */
 
 /** Minimal shape of a log line; structurally compatible with `LogViewerLine`. */
@@ -168,7 +171,16 @@ export function parseAgentLog(lines: AgentLogLine[]): LogBlock[] {
 		}
 		if (text.startsWith('[thinking]')) {
 			flushText();
-			blocks.push({ type: 'thinking', id: line.id, text: stripPrefix(text, '[thinking]') });
+			const body = stripPrefix(text, '[thinking]');
+			// The server emits one `[thinking]` line per physical line of the model's
+			// reasoning (blank lines included) to preserve its paragraph/list structure;
+			// coalesce a consecutive run back into a single block, joined on newlines.
+			const tail = blocks[blocks.length - 1];
+			if (tail && tail.type === 'thinking') {
+				tail.text += `\n${body}`;
+			} else {
+				blocks.push({ type: 'thinking', id: line.id, text: body });
+			}
 			continue;
 		}
 		if (text.startsWith('[tool] ')) {

--- a/packages/web/test/formatted-log-view-branches.test.tsx
+++ b/packages/web/test/formatted-log-view-branches.test.tsx
@@ -87,6 +87,25 @@ test('thinking block renders the Thinking header and reflowed prose', async () =
 	expect(item.closest('li')).not.toBeNull();
 });
 
+test('consecutive [thinking] lines coalesce into one block rendered as separate paragraphs', async () => {
+	const { getByText, container } = await renderLog({
+		lines: lines(
+			'[thinking] First, understand the picture.',
+			'[thinking]',
+			'[thinking] Then read the thread and decide.',
+		),
+	});
+	// One Thinking header (a single coalesced block), not one per line.
+	expect(container.querySelectorAll('[data-testid="thinking-block"]')).toHaveLength(1);
+	// The bare `[thinking]` blank line becomes a paragraph break: two <p> elements,
+	// each carrying one of the model's paragraphs, rather than one run-on line.
+	const first = getByText('First, understand the picture.');
+	const second = getByText('Then read the thread and decide.');
+	expect(first.tagName.toLowerCase()).toBe('p');
+	expect(second.tagName.toLowerCase()).toBe('p');
+	expect(first).not.toBe(second);
+});
+
 test('thinking block renders whole with no Show more toggle when it does not overflow', async () => {
 	// happy-dom reports 0 for scroll/clientHeight, so the clamp measurement never
 	// detects overflow — the block degrades to its full content with no toggle and

--- a/packages/web/test/parse-agent-log.test.ts
+++ b/packages/web/test/parse-agent-log.test.ts
@@ -5,6 +5,7 @@ import {
 	type ResultBlock,
 	type SystemBlock,
 	type TextBlock,
+	type ThinkingBlock,
 	type ToolBlock,
 } from '@hezo/web/lib/parse-agent-log';
 import { expect, test } from 'vitest';
@@ -80,6 +81,34 @@ test('coalesces consecutive prose lines and preserves a markdown list', () => {
 	const texts = blocks.filter((b): b is TextBlock => b.type === 'text');
 	expect(texts).toHaveLength(1);
 	expect(texts[0].text).toBe('Here is the plan to follow:\n- first item\n- second item');
+});
+
+test('coalesces consecutive [thinking] lines into one block, blank line → paragraph break', () => {
+	const blocks = parseAgentLog(
+		makeLines([
+			'[thinking] First, understand the picture.',
+			'[thinking]',
+			'[thinking] Then read the thread.',
+			'[thinking] 1. check status',
+			'[thinking] 2. verify the draft',
+		]),
+	);
+	const thinking = blocks.filter((b): b is ThinkingBlock => b.type === 'thinking');
+	expect(thinking).toHaveLength(1);
+	// A bare `[thinking]` line is a blank line the model wrote — it round-trips to a
+	// `\n\n` paragraph break; non-blank lines join on a single `\n`.
+	expect(thinking[0].text).toBe(
+		'First, understand the picture.\n\nThen read the thread.\n1. check status\n2. verify the draft',
+	);
+});
+
+test('a [thinking] run broken by another event stays two separate blocks', () => {
+	const blocks = parseAgentLog(
+		makeLines(['[thinking] weighing options', '[tool] Bash(command=ls)', '[thinking] decided']),
+	);
+	const thinking = blocks.filter((b): b is ThinkingBlock => b.type === 'thinking');
+	expect(thinking).toHaveLength(2);
+	expect(thinking.map((b) => b.text)).toEqual(['weighing options', 'decided']);
 });
 
 test('splits prose into separate blocks across an interrupting event', () => {


### PR DESCRIPTION
## Problem

Extended agent **"thinking"** rendered in the formatted log view arrived as one giant run-on wall of text. The cause: thinking is persisted as a single flattened log line, so `formatThinking` collapsed **all** whitespace — including the model's own paragraph and list breaks — into single spaces. The client could only heuristically reconstruct list markers (`reflowEnumerations`), so prose paragraphs stayed glued together and long reasoning was hard to read.

## Fix

Preserve the model's line breaks end to end instead of destroying and guessing them.

**Server — `packages/server/src/services/agent-stream-parser.ts`**
- `formatThinking` now collapses only *horizontal* whitespace (spaces/tabs), keeps newlines, trims spaces hugging a break, and caps blank runs at one blank line.
- It emits **one `[thinking]`-prefixed line per physical line**. A blank line becomes a bare `[thinking]` so it survives `splitLogLines` (which drops empty lines) and round-trips as a paragraph break.
- Single-line thinking (the common case) is byte-for-byte unchanged.

**Client — `packages/web/src/lib/parse-agent-log.ts`**
- The parser coalesces a consecutive run of `[thinking]` lines back into one block (joined on newlines), mirroring the existing `[system]` coalescing. The formatted view then renders paragraphs and lists for readability.
- `reflowEnumerations` still handles inline enumerations, so old (already-collapsed) logs render exactly as before.

The line-based log format is otherwise unchanged: tool args and tool results still collapse whitespace, and the raw view / copy simply show the extra self-describing `[thinking]` lines.

## Tests

- **Server** (`agent-stream-parser-branches.test.ts`): multi-line thinking emits one prefixed line per physical line, blank line kept as a bare `[thinking]`, horizontal-whitespace-only collapse with blank-run capping, single-line and empty-thinking regressions.
- **Client** (`parse-agent-log.test.ts`): consecutive `[thinking]` lines coalesce into one block with the blank line becoming a `\n\n` paragraph break; a run interrupted by another event stays two blocks.
- **Web component** (`formatted-log-view-branches.test.tsx`): consecutive `[thinking]` lines render as a single block with the model's paragraphs as separate `<p>` elements.

All affected server and web tiers pass; `typecheck` and full `build` (pre-commit hook) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fc1h6EN8o6BMy6siUyed8N

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fc1h6EN8o6BMy6siUyed8N)_