### PR TITLE
fix(comments): show the author's avatar in the task thread

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -132,9 +132,13 @@ an agent-maintained `progress_summary`. Numbering is atomic via `project_task_co
 `system` (timeline entries like `status_change`/`task_link`), `run` (auto-written
 on run completion), `preview`, `action`,
 `connect_required`, `credential_request`. Each comment carries a `public_id` slug for
-`#comment-<id>` deep-links. `comment_reactions` holds emoji reactions, keyed by a
-non-null `member_id` (unlike a comment's nullable `author_member_id`, which lets an admin
-author as a null-member "Admin"). Because a reaction needs a real member, a human acting in
+`#comment-<id>` deep-links. A human-authored comment keeps `author_member_id` null by
+convention but records **which** human in `author_user_id` (nullable FK to `users`), so the
+author's uploaded avatar (`user_icons`) resolves alongside their comments; the comments feed
+returns a signed `author_icon_url` per row (a human's `user_icons` image, or an agent's
+`agent_icons` image via `author_member_id`, else null → initials). `comment_reactions` holds
+emoji reactions, keyed by a non-null `member_id` (unlike a comment's nullable
+`author_member_id`, which lets an admin author as a null-member "Admin"). Because a reaction needs a real member, a human acting in
 a team they can access but aren't a member of resolves to their **HQ (default-team)**
 membership (`resolveReactorMemberId`) — the same cross-team identity HQ agents use to act in
 other teams' projects — so a superuser can react anywhere, not only in HQ or teams they created.

--- a/packages/server/migrations/037_task_comment_author_user.sql
+++ b/packages/server/migrations/037_task_comment_author_user.sql
@@ -1,0 +1,28 @@
+-- Attribute a task comment to the human user who authored it, so their uploaded
+-- avatar (user_icons) can render beside their comments in the thread. Agent
+-- authors are already attributed via author_member_id and API-key authors via
+-- author_api_key_id, but a human admin stored neither (author_member_id was left
+-- NULL by convention), leaving their comment un-linkable to a user — and so to
+-- their avatar, which is why an admin's uploaded avatar never showed in comments.
+-- This adds the missing human linkage; the comment queries join user_icons on it.
+ALTER TABLE task_comments
+    ADD COLUMN author_user_id UUID REFERENCES users(id) ON DELETE SET NULL;
+
+-- Backfill existing human-authored text comments to the sole superuser, but only
+-- when exactly one exists (the single-admin instance — every instance today), so
+-- the attribution is unambiguous and their historical comments pick up the avatar
+-- too. With zero or multiple superusers the backfill is skipped and those rows
+-- fall back to initials. The predicate targets only human admin text comments:
+-- system comments are non-text, and agent/API-key comments carry an author id.
+UPDATE task_comments
+SET author_user_id = (SELECT id FROM users WHERE is_superuser = true)
+WHERE content_type = 'text'
+  AND author_member_id IS NULL
+  AND author_api_key_id IS NULL
+  AND (SELECT count(*) FROM users WHERE is_superuser = true) = 1;
+
+-- Mirrors idx_comments_author / idx_comments_author_api_key: a partial index over
+-- the non-null rows so the ON DELETE SET NULL FK maintenance on user removal is an
+-- index scan rather than a seq scan over the whole comments table.
+CREATE INDEX idx_comments_author_user ON task_comments(author_user_id)
+    WHERE author_user_id IS NOT NULL;

--- a/packages/server/src/routes/comments.ts
+++ b/packages/server/src/routes/comments.ts
@@ -1,9 +1,11 @@
 import { AuthType, CommentContentType, WakeupSource, wsRoom } from '@hezo/shared';
 import { Hono } from 'hono';
 import { encrypt } from '../crypto/encryption';
+import type { MasterKeyManager } from '../crypto/master-key';
 import { signAssetUrl } from '../lib/asset-urls';
 import { broadcastChange, broadcastCommentFamilyChange } from '../lib/broadcast';
 import { validateCredentialValue } from '../lib/credential-validator';
+import { signEntityIconUrl } from '../lib/entity-icon-urls';
 import {
 	apiKeyIdFromAuth,
 	resolveActor,
@@ -30,6 +32,66 @@ export const commentsRoutes = new Hono<Env>();
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const MAX_BODY_IDS = 100;
+
+// A comment author's avatar. Human authors resolve to their user_icons image
+// (keyed by author_user_id), agent authors to their agent_icons image (keyed by
+// author_member_id). These base-path / key-purpose pairs MUST match the /api/users
+// and /api/agents icon endpoints that serve the bytes (routes/users.ts,
+// routes/agents.ts) — a mismatch produces a signature the <img> can't verify.
+// API-key authors have no avatar.
+const USER_ICON_URL = { basePath: '/api/users', keyPurpose: 'user-icon-url' } as const;
+const AGENT_ICON_URL = { basePath: '/api/agents', keyPurpose: 'agent-icon-url' } as const;
+
+/** Icon `updated_at` → the epoch-second version the signed URL cache-busts on. */
+function iconVersion(updatedAt: unknown): number | null {
+	if (typeof updatedAt === 'string' || updatedAt instanceof Date) {
+		return Math.floor(new Date(updatedAt).getTime() / 1000);
+	}
+	return null;
+}
+
+/**
+ * Resolve each comment row's `author_icon_url` (a freshly-signed avatar URL) from
+ * the icon-version subselects the author queries carry, then strip those
+ * intermediate fields from the row. Best-effort: a signing failure (e.g. the
+ * master key being unavailable) degrades the row to its initials fallback rather
+ * than failing the whole thread — the avatar is purely cosmetic.
+ */
+async function attachAuthorIcons(
+	masterKeyManager: MasterKeyManager,
+	rows: Record<string, unknown>[],
+): Promise<void> {
+	for (const row of rows) {
+		let url: string | null = null;
+		try {
+			const userVer = iconVersion(row.author_user_icon_updated_at);
+			const agentVer = iconVersion(row.author_agent_icon_updated_at);
+			if (row.author_user_id && userVer !== null) {
+				url = await signEntityIconUrl(
+					USER_ICON_URL.basePath,
+					USER_ICON_URL.keyPurpose,
+					row.author_user_id as string,
+					masterKeyManager,
+					userVer,
+				);
+			} else if (row.author_member_id && agentVer !== null) {
+				url = await signEntityIconUrl(
+					AGENT_ICON_URL.basePath,
+					AGENT_ICON_URL.keyPurpose,
+					row.author_member_id as string,
+					masterKeyManager,
+					agentVer,
+				);
+			}
+		} catch {
+			url = null;
+		}
+		row.author_icon_url = url;
+		delete row.author_user_id;
+		delete row.author_user_icon_updated_at;
+		delete row.author_agent_icon_updated_at;
+	}
+}
 
 /**
  * Comments feed. Three response shapes on the one endpoint so a long thread can
@@ -75,6 +137,9 @@ async function getCommentsFull(
             COALESCE(ca.name, ma.title, m.display_name, 'Admin') AS author_name,
             ic.author_member_id,
             ic.author_api_key_id,
+            ic.author_user_id,
+            (SELECT ui.updated_at FROM user_icons ui WHERE ui.user_id = ic.author_user_id) AS author_user_icon_updated_at,
+            (SELECT ai.updated_at FROM agent_icons ai WHERE ai.member_id = ic.author_member_id) AS author_agent_icon_updated_at,
             ic.parent_comment_id
      FROM task_comments ic
      LEFT JOIN members m ON m.id = ic.author_member_id
@@ -101,6 +166,7 @@ async function getCommentsFull(
 		comment.attachments = attachmentsByComment.get(comment.id as string) ?? [];
 	}
 
+	await attachAuthorIcons(c.get('masterKeyManager'), result.rows as Record<string, unknown>[]);
 	return ok(c, result.rows);
 }
 
@@ -123,6 +189,9 @@ async function getCommentSkeletons(
             COALESCE(ca.name, ma.title, m.display_name, 'Admin') AS author_name,
             ic.author_member_id,
             ic.author_api_key_id,
+            ic.author_user_id,
+            (SELECT ui.updated_at FROM user_icons ui WHERE ui.user_id = ic.author_user_id) AS author_user_icon_updated_at,
+            (SELECT ai.updated_at FROM agent_icons ai WHERE ai.member_id = ic.author_member_id) AS author_agent_icon_updated_at,
             ic.parent_comment_id,
             CASE WHEN ic.content_type = 'text'
                  THEN COALESCE(length(ic.content->>'text'), 0) ELSE NULL END AS text_length,
@@ -142,6 +211,7 @@ async function getCommentSkeletons(
 		comment.reactions = reactionsByComment.get(comment.id as string) ?? [];
 	}
 
+	await attachAuthorIcons(c.get('masterKeyManager'), result.rows as Record<string, unknown>[]);
 	return ok(c, result.rows);
 }
 
@@ -361,16 +431,20 @@ commentsRoutes.post('/projects/:projectId/tasks/:taskId/comments', async (c) => 
 	}
 	// An API key authors as its first-class identity, not a member.
 	const authorApiKeyId = apiKeyIdFromAuth(auth);
+	// A human author keeps `author_member_id` null by convention; `author_user_id`
+	// records *which* human, so their avatar (user_icons) renders on the comment.
+	const authorUserId = auth.type === AuthType.Admin ? auth.userId : null;
 
 	const result = await withTransaction(db, async () => {
 		const inserted = await db.query<{ id: string }>(
-			`INSERT INTO task_comments (task_id, author_member_id, author_api_key_id, parent_comment_id, content_type, content)
-     VALUES ($1, $2, $3, $4, $5::comment_content_type, $6::jsonb)
+			`INSERT INTO task_comments (task_id, author_member_id, author_api_key_id, author_user_id, parent_comment_id, content_type, content)
+     VALUES ($1, $2, $3, $4, $5, $6::comment_content_type, $7::jsonb)
      RETURNING *`,
 			[
 				taskId,
 				authorMemberId,
 				authorApiKeyId,
+				authorUserId,
 				parentCommentId,
 				body.content_type ?? CommentContentType.Text,
 				JSON.stringify(body.content),

--- a/packages/server/test/comment-author-icon.test.ts
+++ b/packages/server/test/comment-author-icon.test.ts
@@ -1,0 +1,184 @@
+import type { Hono } from 'hono';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { MasterKeyManager } from '../src/crypto/master-key';
+import type { Db } from '../src/db/database';
+import type { Env } from '../src/lib/types';
+import { safeClose } from './helpers';
+import {
+	authHeader,
+	createTestApp,
+	createTestProject,
+	createTestTeam,
+	mintAgentToken,
+} from './helpers/app';
+
+// A comment's author avatar: human authors resolve to their user_icons image and
+// agent authors to their agent_icons image, both returned as a signed
+// `author_icon_url` on the comments feed (skeleton + full). Regression guard for
+// the admin avatar never rendering in the thread.
+
+let app: Hono<Env>;
+let db: Db;
+let token: string;
+let masterKeyManager: MasterKeyManager;
+let teamId: string;
+let projectSlug: string;
+let taskId: string;
+let agentId: string;
+let agentSlug: string;
+let adminUserId: string;
+
+function pngWithDimensions(width: number, height: number): Buffer {
+	const sig = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+	const ihdr = Buffer.alloc(25);
+	ihdr.writeUInt32BE(13, 0);
+	ihdr.write('IHDR', 4, 'ascii');
+	ihdr.writeUInt32BE(width, 8);
+	ihdr.writeUInt32BE(height, 12);
+	return Buffer.concat([sig, ihdr]);
+}
+
+function iconForm(bytes: Buffer): FormData {
+	const fd = new FormData();
+	fd.set('file', new Blob([bytes], { type: 'image/png' }), 'icon.png');
+	return fd;
+}
+
+async function postComment(auth: string, text: string): Promise<string> {
+	const res = await app.request(`/api/projects/${projectSlug}/tasks/${taskId}/comments`, {
+		method: 'POST',
+		headers: { ...authHeader(auth), 'Content-Type': 'application/json' },
+		body: JSON.stringify({ content_type: 'text', content: { text } }),
+	});
+	expect(res.status).toBe(201);
+	return (await res.json()).data.id;
+}
+
+interface SkeletonRow {
+	id: string;
+	author_icon_url: string | null;
+	author_user_id?: string;
+}
+
+async function skeletons(): Promise<SkeletonRow[]> {
+	const res = await app.request(
+		`/api/projects/${projectSlug}/tasks/${taskId}/comments?view=skeleton`,
+		{ headers: authHeader(token) },
+	);
+	expect(res.status).toBe(200);
+	return (await res.json()).data;
+}
+
+beforeAll(async () => {
+	const ctx = await createTestApp();
+	app = ctx.app;
+	db = ctx.db;
+	token = ctx.token;
+	masterKeyManager = ctx.masterKeyManager;
+
+	const teamData = (await (await createTestTeam(db, { name: 'Avatar Co' })).json()).data;
+	teamId = teamData.id;
+	const projectData = (
+		await (await createTestProject(db, teamId, { name: 'Main', description: 'Test.' })).json()
+	).data;
+	projectSlug = projectData.slug;
+
+	const agent = (
+		await (
+			await app.request(`/api/projects/${projectSlug}/agents`, {
+				method: 'POST',
+				headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+				body: JSON.stringify({ title: 'Avatar Bot' }),
+			})
+		).json()
+	).data;
+	agentId = agent.id;
+	agentSlug = agent.slug;
+
+	const task = (
+		await (
+			await app.request(`/api/projects/${projectSlug}/tasks`, {
+				method: 'POST',
+				headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+				body: JSON.stringify({ title: 'Avatar Task', assignee_id: agentId }),
+			})
+		).json()
+	).data;
+	taskId = task.id;
+
+	const users = (await (await app.request('/api/users', { headers: authHeader(token) })).json())
+		.data as { id: string; is_superuser: boolean }[];
+	adminUserId = users.find((u) => u.is_superuser)?.id ?? users[0].id;
+});
+
+afterAll(async () => {
+	await safeClose(db);
+});
+
+describe('comment author avatar', () => {
+	it('returns the admin user avatar as author_icon_url on their comment', async () => {
+		await app.request(`/api/users/${adminUserId}/icon`, {
+			method: 'PUT',
+			headers: authHeader(token),
+			body: iconForm(pngWithDimensions(512, 512)),
+		});
+		const commentId = await postComment(token, 'from the admin');
+
+		const rows = await skeletons();
+		const row = rows.find((r) => r.id === commentId);
+		expect(row).toBeDefined();
+		expect(row?.author_icon_url).toMatch(
+			new RegExp(`^/api/users/${adminUserId}/icon\\?exp=\\d+&sig=[^&]+&v=\\d+$`),
+		);
+		// The internal attribution column is not leaked to the client.
+		expect(row).not.toHaveProperty('author_user_id');
+
+		// The signed URL actually serves the uploaded bytes.
+		const serve = await app.request(row?.author_icon_url as string);
+		expect(serve.status).toBe(200);
+		expect(Buffer.from(await serve.arrayBuffer()).equals(pngWithDimensions(512, 512))).toBe(true);
+	});
+
+	it('returns the agent avatar as author_icon_url on an agent comment', async () => {
+		await app.request(`/api/projects/${projectSlug}/agents/${agentSlug}/icon`, {
+			method: 'PUT',
+			headers: authHeader(token),
+			body: iconForm(pngWithDimensions(256, 256)),
+		});
+		const agentAuth = await mintAgentToken(db, masterKeyManager, agentId, teamId, taskId);
+		const commentId = await postComment(agentAuth.token, 'from the bot');
+
+		const rows = await skeletons();
+		const row = rows.find((r) => r.id === commentId);
+		expect(row?.author_icon_url).toMatch(
+			new RegExp(`^/api/agents/${agentId}/icon\\?exp=\\d+&sig=[^&]+&v=\\d+$`),
+		);
+	});
+
+	it('is null for an author with no uploaded avatar', async () => {
+		await app.request(`/api/users/${adminUserId}/icon`, {
+			method: 'DELETE',
+			headers: authHeader(token),
+		});
+		const commentId = await postComment(token, 'admin without an avatar');
+
+		const rows = await skeletons();
+		const row = rows.find((r) => r.id === commentId);
+		expect(row?.author_icon_url).toBeNull();
+	});
+
+	it('also carries author_icon_url in full mode', async () => {
+		await app.request(`/api/users/${adminUserId}/icon`, {
+			method: 'PUT',
+			headers: authHeader(token),
+			body: iconForm(pngWithDimensions(512, 512)),
+		});
+		const commentId = await postComment(token, 'full-mode avatar');
+
+		const res = await app.request(`/api/projects/${projectSlug}/tasks/${taskId}/comments`, {
+			headers: authHeader(token),
+		});
+		const row = ((await res.json()).data as SkeletonRow[]).find((r) => r.id === commentId);
+		expect(row?.author_icon_url).toMatch(new RegExp(`^/api/users/${adminUserId}/icon\\?`));
+	});
+});

--- a/packages/server/test/migrate-037-task-comment-author-user.test.ts
+++ b/packages/server/test/migrate-037-task-comment-author-user.test.ts
@@ -1,0 +1,123 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createDataPreservationHarness, type DataPreservationHarness } from './helpers/migrate';
+
+const TARGET = '037_task_comment_author_user.sql';
+
+describe('037_task_comment_author_user migration', () => {
+	let h: DataPreservationHarness;
+	let superuserId: string;
+	let taskId: string;
+	let agentMemberId: string;
+	let humanCommentId: string;
+	let agentCommentId: string;
+	let systemCommentId: string;
+
+	beforeAll(async () => {
+		h = await createDataPreservationHarness();
+		await h.applyUpToExclusive(TARGET);
+
+		// A single superuser (the single-admin instance the backfill targets).
+		const su = await h.db.query<{ id: string }>(
+			`INSERT INTO users (display_name, is_superuser) VALUES ('Admin', true) RETURNING id`,
+		);
+		superuserId = su.rows[0].id;
+
+		const team = await h.db.query<{ id: string }>(
+			`INSERT INTO teams (name, slug) VALUES ('Acme', 'acme') RETURNING id`,
+		);
+		const teamId = team.rows[0].id;
+		const project = await h.db.query<{ id: string }>(
+			`INSERT INTO projects (team_id, name, slug, task_prefix)
+			 VALUES ($1, 'Main', 'main', 'MA') RETURNING id`,
+			[teamId],
+		);
+		const agentMember = await h.db.query<{ id: string }>(
+			`INSERT INTO members (team_id, member_type, display_name)
+			 VALUES ($1, 'agent', 'Bot') RETURNING id`,
+			[teamId],
+		);
+		agentMemberId = agentMember.rows[0].id;
+		const task = await h.db.query<{ id: string }>(
+			`INSERT INTO tasks (team_id, project_id, number, identifier, title, status, priority, labels)
+			 VALUES ($1, $2, 1, 'MA-1', 'Seeded', 'backlog', 'medium', '{}') RETURNING id`,
+			[teamId, project.rows[0].id],
+		);
+		taskId = task.rows[0].id;
+
+		// A human admin text comment (no author id — the case the migration backfills).
+		const human = await h.db.query<{ id: string }>(
+			`INSERT INTO task_comments (task_id, content_type, content)
+			 VALUES ($1, 'text'::comment_content_type, '{"text":"from the admin"}'::jsonb) RETURNING id`,
+			[taskId],
+		);
+		humanCommentId = human.rows[0].id;
+
+		// An agent text comment (attributed by author_member_id — must not be backfilled).
+		const agent = await h.db.query<{ id: string }>(
+			`INSERT INTO task_comments (task_id, author_member_id, content_type, content)
+			 VALUES ($1, $2, 'text'::comment_content_type, '{"text":"from the bot"}'::jsonb) RETURNING id`,
+			[taskId, agentMemberId],
+		);
+		agentCommentId = agent.rows[0].id;
+
+		// A system comment (non-text, no author — must not be backfilled).
+		const system = await h.db.query<{ id: string }>(
+			`INSERT INTO task_comments (task_id, content_type, content)
+			 VALUES ($1, 'system'::comment_content_type, '{"text":"status changed"}'::jsonb) RETURNING id`,
+			[taskId],
+		);
+		systemCommentId = system.rows[0].id;
+
+		await h.applyTarget(TARGET);
+	});
+	afterAll(() => h.close());
+
+	it('adds the author_user_id column referencing users', async () => {
+		const col = await h.db.query<{ column_name: string }>(
+			`SELECT column_name FROM information_schema.columns
+			 WHERE table_name = 'task_comments' AND column_name = 'author_user_id'`,
+		);
+		expect(col.rows.length).toBe(1);
+	});
+
+	it('backfills the human admin text comment to the sole superuser', async () => {
+		const r = await h.db.query<{ author_user_id: string | null }>(
+			`SELECT author_user_id FROM task_comments WHERE id = $1`,
+			[humanCommentId],
+		);
+		expect(r.rows[0].author_user_id).toBe(superuserId);
+	});
+
+	it('leaves agent- and system-authored comments unattributed to a user', async () => {
+		const agent = await h.db.query<{ author_user_id: string | null }>(
+			`SELECT author_user_id FROM task_comments WHERE id = $1`,
+			[agentCommentId],
+		);
+		expect(agent.rows[0].author_user_id).toBeNull();
+		const system = await h.db.query<{ author_user_id: string | null }>(
+			`SELECT author_user_id FROM task_comments WHERE id = $1`,
+			[systemCommentId],
+		);
+		expect(system.rows[0].author_user_id).toBeNull();
+	});
+
+	it('preserves pre-existing comment content', async () => {
+		const r = await h.db.query<{ content: { text: string }; content_type: string }>(
+			`SELECT content, content_type FROM task_comments WHERE id = $1`,
+			[humanCommentId],
+		);
+		expect(r.rows.length).toBe(1);
+		expect(r.rows[0].content_type).toBe('text');
+		expect(r.rows[0].content.text).toBe('from the admin');
+	});
+
+	it('nulls author_user_id when the user is removed (ON DELETE SET NULL)', async () => {
+		await h.db.query(`DELETE FROM users WHERE id = $1`, [superuserId]);
+		const r = await h.db.query<{ author_user_id: string | null }>(
+			`SELECT author_user_id FROM task_comments WHERE id = $1`,
+			[humanCommentId],
+		);
+		expect(r.rows.length).toBe(1);
+		expect(r.rows[0].author_user_id).toBeNull();
+	});
+});

--- a/packages/web/src/components/task-detail/comment-row.tsx
+++ b/packages/web/src/components/task-detail/comment-row.tsx
@@ -188,6 +188,7 @@ export function CommentRow({
 						initials={authorName.slice(0, 2)}
 						size="sm"
 						color={avatarColorFromString(authorName)}
+						imageUrl={c.author_icon_url}
 					/>
 				</AgentLink>
 			) : (
@@ -195,6 +196,7 @@ export function CommentRow({
 					initials={authorName.slice(0, 2)}
 					size="sm"
 					color={avatarColorFromString(authorName)}
+					imageUrl={c.author_icon_url}
 				/>
 			)}
 			<div className="flex-1 min-w-0 rounded-md border border-border bg-surface overflow-hidden">

--- a/packages/web/src/hooks/use-comments.ts
+++ b/packages/web/src/hooks/use-comments.ts
@@ -41,6 +41,8 @@ export interface Comment {
 	author_name: string;
 	author_member_id: string | null;
 	author_api_key_id: string | null;
+	/** Signed avatar URL for the author (human user or agent); null → initials. */
+	author_icon_url?: string | null;
 	parent_comment_id: string | null;
 	reactions?: ReactionGroup[];
 	attachments?: CommentAttachment[];
@@ -76,6 +78,8 @@ export interface CommentSkeleton {
 	author_name: string;
 	author_member_id: string | null;
 	author_api_key_id: string | null;
+	/** Signed avatar URL for the author (human user or agent); null → initials. */
+	author_icon_url?: string | null;
 	parent_comment_id: string | null;
 	/** Character length of a text comment's body — sizes its placeholder. Null for non-text. */
 	text_length: number | null;
@@ -257,6 +261,10 @@ function toSkeletonRow(created: Comment, attachmentCount: number): CommentSkelet
 		author_name: created.author_name ?? 'Admin',
 		author_member_id: created.author_member_id,
 		author_api_key_id: created.author_api_key_id,
+		// The create response has no signed avatar URL; the invalidate-driven
+		// skeleton refetch (below) fills it in, so a new comment briefly shows
+		// initials before the author's avatar lands.
+		author_icon_url: created.author_icon_url ?? null,
 		parent_comment_id: created.parent_comment_id,
 		text_length: isText && typeof textVal === 'string' ? textVal.length : null,
 		attachment_count: attachmentCount,

--- a/packages/web/test/comment-author-avatar.test.tsx
+++ b/packages/web/test/comment-author-avatar.test.tsx
@@ -1,0 +1,46 @@
+import { expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+import { seedComment, seedProject, seedTask, seedWorkspace } from './helpers/seed';
+
+// The reported bug: an admin uploads an avatar on Settings → Users, but their
+// comments still show the "AD" initials. Verifies the fix end-to-end — a comment
+// authored by a user who has an uploaded avatar renders that avatar as an <img>
+// in the task activity feed, not the initials fallback.
+test("renders the admin's uploaded avatar on their comment", async () => {
+	let nav!: { projectSlug: string; taskId: string };
+	let adminUserId!: string;
+	const { findByText, container, router } = await renderApp({
+		initialPath: '/',
+		seed: async (ctx) => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Avatar Demo' });
+			const task = await seedTask(ws, project, { title: 'Avatar Task' });
+
+			// Give the admin (the board token's user) an uploaded avatar.
+			const admin = await ctx.db.query<{ id: string }>(
+				`SELECT id FROM users WHERE is_superuser = true ORDER BY created_at LIMIT 1`,
+			);
+			adminUserId = admin.rows[0].id;
+			await ctx.db.query(
+				`INSERT INTO user_icons (user_id, content_type, data, byte_size, width, height)
+				 VALUES ($1, 'image/png', $2, 3, 512, 512)`,
+				[adminUserId, Buffer.from([0x89, 0x50, 0x4e])],
+			);
+
+			// Authored via the board token, so author_user_id = the admin.
+			await seedComment(ws, task, 'from the admin with an avatar');
+			nav = { projectSlug: project.slug, taskId: task.identifier.toLowerCase() };
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: nav.projectSlug, taskId: nav.taskId },
+	});
+
+	await findByText('from the admin with an avatar');
+
+	const avatar = container.querySelector<HTMLImageElement>('[data-testid="comment-item"] img');
+	expect(avatar).not.toBeNull();
+	expect(avatar?.getAttribute('src') ?? '').toContain(`/api/users/${adminUserId}/icon`);
+});


### PR DESCRIPTION
## Problem

An admin who uploads an avatar on **Settings → Users** still sees the "AD" initials beside their comments in the task thread — the avatar shows on the Users page but never in the feed.

Two independent gaps caused it:

1. **No user linkage on comments.** A human-authored comment stores `author_member_id = NULL` by convention (and no `author_api_key_id`), so there was no path from a comment back to a `users` row — and therefore none to that user's uploaded avatar (`user_icons`).
2. **The comment `Avatar` was rendered without an `imageUrl`**, so it structurally could only ever show initials.

## Changes

- **Migration `037`** adds `task_comments.author_user_id` (nullable FK → `users`, `ON DELETE SET NULL`, partial index mirroring the sibling author FKs). Existing human text comments are backfilled to the sole superuser *only when exactly one exists* (unambiguous — every instance today), so historical comments pick up the avatar too; system/agent/API-key comments are never touched.
- **Comment insert** now records `author_user_id = auth.userId` for human authors (member id stays null by convention).
- **Comments feed** (skeleton + full modes) returns a signed `author_icon_url` per row: a human's `user_icons` image, or an agent's `agent_icons` image via `author_member_id`, else `null` → initials. Signed exactly like the `/api/users` and `/api/agents` icon endpoints. Best-effort — a locked master key degrades to initials rather than failing the thread. The internal `author_user_id` is stripped from the response.
- **Client** threads `author_icon_url` through the `Comment`/`CommentSkeleton` types and passes it as `imageUrl` to the comment `Avatar`, which already handles the image-with-initials-fallback (and image-load-error fallback).

Agent comment avatars are fixed by the same path, so every author in the thread now shows their real picture.

## Testing

- `migrate-037-task-comment-author-user.test.ts` — data-preservation: column added, human text comment backfilled to the superuser, agent/system comments left unattributed, content preserved, `ON DELETE SET NULL` on user removal.
- `comment-author-icon.test.ts` — end-to-end: upload admin avatar → post comment → skeleton returns a signed `/api/users/<id>/icon` URL that serves the uploaded bytes; agent avatar returns `/api/agents/<id>/icon`; null when no avatar; also present in full mode; `author_user_id` not leaked.
- `comment-author-avatar.test.tsx` — web component: the avatar `<img>` renders in the task activity feed for an admin with an uploaded avatar.
- Full server + web comment suites, typecheck, biome, and the docs/migration drift meta-tests pass.

## Docs

`.dev/architecture.md` updated to describe `author_user_id` and the `author_icon_url` on the comments feed. No MCP tool / REST contract changed (the MCP `list_comments` tool has its own curated SELECT and is unaffected).


---
_Generated by [Claude Code](https://claude.ai/code/session_01NLMYyZhMAS18BRPN1AQAjV)_