### PR TITLE
feat(documents): give project docs a description ("what this is")

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -279,7 +279,13 @@ interrupted run still counts against budgets.
 
 **Docs, skills, assets.** `documents` is one table backing three Markdown kinds by
 `type` (`project_doc`, `team_preferences`, `agent_system_prompt`), each with partial
-unique scoping and full revision history in `document_revisions`. The `team_preferences`
+unique scoping and full revision history in `document_revisions`. Project docs additionally
+carry a `description` (a one-line "what this is", migration 037) surfaced in the Documents
+list/header, in `list_project_docs` / `read_project_doc`, and — in place of the long-unused
+`title` column — in the `{{project_docs_context}}` run manifest; agents set it via
+`write_project_doc`, admins via the doc PUT, both threaded through `upsertDocument` with a
+`COALESCE` so an omitted value leaves the existing description untouched (a description-only
+edit records no revision). The `team_preferences`
 document is the project's **Custom Prompt** — a per-team instruction block injected verbatim
 into every in-project agent's prompt via `{{team_preferences_context}}`; it is edited from the
 web **Settings → Custom Prompt** page (`PATCH /api/projects/:projectId/custom-prompt`) and, for

--- a/docs/concepts/documents-and-memory.md
+++ b/docs/concepts/documents-and-memory.md
@@ -38,8 +38,8 @@ cached to go stale. Context reaches the agent in one of two ways:
   them in view.
 - **As a manifest** — larger libraries are surfaced as a *table of contents* rather than
   pasted in whole. The agent sees an index of what exists and pulls the full item only when
-  it's relevant: **project documents** are listed by filename, title, and last-updated date
-  (the agent opens one with `read_project_doc`), and **skills** are listed by name and
+  it's relevant: **project documents** are listed by filename, a one-line description, and
+  last-updated date (the agent opens one with `read_project_doc`), and **skills** are listed by name and
   description (the agent loads one with `get_skill`). This keeps prompts lean while still
   putting the entire library within reach.
 
@@ -71,7 +71,11 @@ every agent can reach them without cluttering the codebase. You read and edit an
 from the **Documents** page in the web app, and agents read and write the same files as they
 work (`list_project_docs`, `read_project_doc`, and `write_project_doc` over Hezo's
 [MCP server](/docs/mcp/hezo-mcp-server)). A document is referenced by its plain filename —
-for example `spec.md` — so links stay stable as the work evolves. The document list sits
+for example `spec.md` — so links stay stable as the work evolves. Each document also carries
+a short **description** — a one-line "what this is" shown under its filename in the list and
+at the top of the document — so you (and the next agent) can tell what a document holds
+without opening it. Agents write the description when they create or update a document; you
+can edit it inline from the document's **Edit** view. The document list sits
 beside the reader, with a **search box** at the top that filters the list as you type and a
 **+** button next to it for creating a new document — both stay in view while you scroll
 the list. A **dropdown** next to the open document's title opens a name search from
@@ -79,8 +83,9 @@ inside the reader, so you can jump straight to another document without going ba
 list; it's hidden while you're editing.
 
 Agents don't carry every document's full text on every run. Instead each run includes a
-**manifest** — a table of contents listing each document's filename, title, and when it
-last changed — and the agent opens the ones it needs with `read_project_doc`. So adding or
+**manifest** — a table of contents listing each document's filename, its one-line
+description, and when it last changed — and the agent opens the ones it needs with
+`read_project_doc`. So adding or
 updating a document immediately makes it discoverable to the whole team, without bloating
 anyone's prompt. (Archived documents are left out of the manifest — see
 [Archiving & deleting documents](#archiving--deleting-documents).)

--- a/docs/reference/mcp-api.md
+++ b/docs/reference/mcp-api.md
@@ -1073,7 +1073,7 @@ Remove one of your project's registered MCP connections. Only connectors owned b
 
 _Read-only._
 
-List project documentation files (PRD, spec, implementation plan, etc.). Archived (soft-deleted) docs are excluded by default — set filter: 'archived' or 'all' to see them (entries then carry an `archived` flag).
+List project documentation files (PRD, spec, implementation plan, etc.). Each entry carries its `filename` and a one-line `description` (what the doc is / when to read it, '' if unset). Archived (soft-deleted) docs are excluded by default — set filter: 'archived' or 'all' to see them (entries then carry an `archived` flag).
 
 **Parameters:**
 
@@ -1082,7 +1082,7 @@ List project documentation files (PRD, spec, implementation plan, etc.). Archive
 | `project` | `string` | No | Project slug or ID. Omit to use the project your run is already in; instance agents (CEO/Coach) must name the project to act in. |
 | `filter` | `active` \| `archived` \| `all` | No | Which archive states to consider: 'active' (default — archived items are excluded), 'archived' (only archived), or 'all'. |
 
-**Returns:** `{ files: [{ id, filename, title, updated_at }] }` — the markdown project docs. The `filter` param defaults to `'active'` (archived docs excluded); with `'archived'` or `'all'` each entry also carries `archived: boolean`.
+**Returns:** `{ files: [{ id, filename, description, updated_at }] }` — the markdown project docs, where `description` is the one-line "what this is" summary (`''` if unset). The `filter` param defaults to `'active'` (archived docs excluded); with `'archived'` or `'all'` each entry also carries `archived: boolean`.
 
 ### `list_project_assets`
 
@@ -1213,13 +1213,13 @@ Read a markdown project doc by filename (e.g. "spec.md") — the high-level proj
 | `filename` | `string` | Yes | Filename to read (e.g. "spec.md") |
 | `filter` | `active` \| `archived` \| `all` | No | Which archive states to consider: 'active' (default — archived items are excluded), 'archived' (only archived), or 'all'. |
 
-**Returns:** `{ filename, content }` (the full markdown body), plus `review_comments: [{ id, quote, occurrence, comment, created_at }]` when the admin has left pending review feedback on the doc (each comment anchors to an exact `quote` snippet; `occurrence` disambiguates repeats). Any write to the doc deletes all of its review comments, so capture them before writing. Returns `{ error }` if the file is not found or its archive state doesn't match `filter` (default `'active'`, so archived docs need `filter: 'archived'` or `'all'`; an archived read carries `archived: true`).
+**Returns:** `{ filename, content }` (the full markdown body), plus `description` when the doc has a one-line summary set, plus `review_comments: [{ id, quote, occurrence, comment, created_at }]` when the admin has left pending review feedback on the doc (each comment anchors to an exact `quote` snippet; `occurrence` disambiguates repeats). Any write to the doc deletes all of its review comments, so capture them before writing. Returns `{ error }` if the file is not found or its archive state doesn't match `filter` (default `'active'`, so archived docs need `filter: 'archived'` or `'all'`; an archived read carries `archived: true`).
 
 ### `write_project_doc`
 
 _Write tool._
 
-Write a project documentation file. Project docs are markdown only — the filename must end in .md. For high-level project context: PRD, spec, implementation plan, research. Make ALL desired edits in ONE consolidated write per run, for two reasons: (1) writing a doc deletes ALL of its pending review comments (the admin's highlight feedback returned by read_project_doc) — a single write clears the whole review, so capture every comment in your context before the first write; (2) docs are revisioned — every content-changing write records a revision, so many partial writes bury the history in noise. Pass a `changelog` summarizing what changed in this write and why — it becomes that revision's entry in the document's history; keep update/changelog logs OUT of the document body and put them in `changelog` instead. Non-markdown files (mockups, wireframes, images, PDFs) live in the project assets library instead — reference those as `assets/<filename>`. In content, reference teammates with @<agent-slug>. Reference tickets and project docs by their bare identifier/filename (e.g. IN-42, spec.md), and skills by their slug — no @ prefix. Do not wrap any of these in backticks — that makes them inert.
+Write a project documentation file. Project docs are markdown only — the filename must end in .md. For high-level project context: PRD, spec, implementation plan, research. Make ALL desired edits in ONE consolidated write per run, for two reasons: (1) writing a doc deletes ALL of its pending review comments (the admin's highlight feedback returned by read_project_doc) — a single write clears the whole review, so capture every comment in your context before the first write; (2) docs are revisioned — every content-changing write records a revision, so many partial writes bury the history in noise. Pass a `changelog` summarizing what changed in this write and why — it becomes that revision's entry in the document's history; keep update/changelog logs OUT of the document body and put them in `changelog` instead. Also pass a one-line `description` of what the doc is and when to read it — it shows next to the filename in the Documents list and the doc header so teammates and future runs can tell what the doc holds at a glance; keep it short and out of the body. Non-markdown files (mockups, wireframes, images, PDFs) live in the project assets library instead — reference those as `assets/<filename>`. In content, reference teammates with @<agent-slug>. Reference tickets and project docs by their bare identifier/filename (e.g. IN-42, spec.md), and skills by their slug — no @ prefix. Do not wrap any of these in backticks — that makes them inert.
 
 **Parameters:**
 
@@ -1228,9 +1228,10 @@ Write a project documentation file. Project docs are markdown only — the filen
 | `project` | `string` | No | Project slug or ID. Omit to use the project your run is already in; instance agents (CEO/Coach) must name the project to act in. |
 | `filename` | `string` | Yes | Markdown filename to write (e.g. "spec.md") |
 | `content` | `string` | Yes | File content (markdown) |
+| `description` | `string` | No | One-line summary of what this doc is and when to read it (e.g. "How we track and report campaign analytics each week"). Shown next to the filename in the Documents list and the doc header, so teammates and future runs can tell what the doc holds without opening it. Keep it to a sentence; it is NOT the changelog and NOT part of the body. Omit to leave any existing description unchanged. |
 | `changelog` | `string` | No | Markdown summary of what changed in THIS update and why — recorded as the revision's changelog and shown in the document's revision history. Put update/status notes here, never in the document body. Reference tickets/docs/agents by bare identifier as in content. |
 
-**Returns:** `{ written: true, id, filename }`, or `{ error }` if the filename is not `.md` or the doc is archived (unarchive first — archived docs are read-only). Make all edits in one consolidated write: a content-changing write deletes ALL pending review comments on the doc (read them first) and records a document revision, so many partial writes lose review context and bury the revision history. The optional `changelog` is stored as that revision's changelog and shown in the document's history — put update/status notes there, not in the document body.
+**Returns:** `{ written: true, id, filename }`, or `{ error }` if the filename is not `.md` or the doc is archived (unarchive first — archived docs are read-only). Make all edits in one consolidated write: a content-changing write deletes ALL pending review comments on the doc (read them first) and records a document revision, so many partial writes lose review context and bury the revision history. The optional `description` sets the doc's one-line "what this is" summary (shown in the Documents list and doc header; omit to leave it unchanged). The optional `changelog` is stored as that revision's changelog and shown in the document's history — put update/status notes there, not in the document body.
 
 ### `archive_project_doc`
 

--- a/packages/server/migrations/037_document_description.sql
+++ b/packages/server/migrations/037_document_description.sql
@@ -1,0 +1,12 @@
+-- A short, human-readable description of what a project doc is — surfaced in the
+-- Documents list and the doc header so the section reads as legible long-term
+-- project memory instead of a wall of raw filenames. The filename (slug) stays
+-- the document's label/identity; this is purely the "what this is" one-liner.
+-- Agents set it when they write a doc (write_project_doc); humans can edit it in
+-- the UI. Only project docs surface it, but the column lives on the shared
+-- `documents` table alongside the (separate, unused-for-project-docs) `title`.
+--
+-- Purely additive: existing rows backfill to '' (no description yet), so nothing
+-- changes for current data. NOT NULL DEFAULT '' mirrors `title` and `content`, so
+-- the service can COALESCE updates the same way it already does for `title`.
+ALTER TABLE documents ADD COLUMN description TEXT NOT NULL DEFAULT '';

--- a/packages/server/src/mcp/mcp-reference.ts
+++ b/packages/server/src/mcp/mcp-reference.ts
@@ -391,17 +391,17 @@ export const TOOL_DOC_META: Record<string, ToolDocMeta> = {
 	list_project_docs: {
 		category: 'Project docs & assets',
 		returns:
-			"`{ files: [{ id, filename, title, updated_at }] }` — the markdown project docs. The `filter` param defaults to `'active'` (archived docs excluded); with `'archived'` or `'all'` each entry also carries `archived: boolean`.",
+			"`{ files: [{ id, filename, description, updated_at }] }` — the markdown project docs, where `description` is the one-line \"what this is\" summary (`''` if unset). The `filter` param defaults to `'active'` (archived docs excluded); with `'archived'` or `'all'` each entry also carries `archived: boolean`.",
 	},
 	read_project_doc: {
 		category: 'Project docs & assets',
 		returns:
-			"`{ filename, content }` (the full markdown body), plus `review_comments: [{ id, quote, occurrence, comment, created_at }]` when the admin has left pending review feedback on the doc (each comment anchors to an exact `quote` snippet; `occurrence` disambiguates repeats). Any write to the doc deletes all of its review comments, so capture them before writing. Returns `{ error }` if the file is not found or its archive state doesn't match `filter` (default `'active'`, so archived docs need `filter: 'archived'` or `'all'`; an archived read carries `archived: true`).",
+			"`{ filename, content }` (the full markdown body), plus `description` when the doc has a one-line summary set, plus `review_comments: [{ id, quote, occurrence, comment, created_at }]` when the admin has left pending review feedback on the doc (each comment anchors to an exact `quote` snippet; `occurrence` disambiguates repeats). Any write to the doc deletes all of its review comments, so capture them before writing. Returns `{ error }` if the file is not found or its archive state doesn't match `filter` (default `'active'`, so archived docs need `filter: 'archived'` or `'all'`; an archived read carries `archived: true`).",
 	},
 	write_project_doc: {
 		category: 'Project docs & assets',
 		returns:
-			"`{ written: true, id, filename }`, or `{ error }` if the filename is not `.md` or the doc is archived (unarchive first — archived docs are read-only). Make all edits in one consolidated write: a content-changing write deletes ALL pending review comments on the doc (read them first) and records a document revision, so many partial writes lose review context and bury the revision history. The optional `changelog` is stored as that revision's changelog and shown in the document's history — put update/status notes there, not in the document body.",
+			"`{ written: true, id, filename }`, or `{ error }` if the filename is not `.md` or the doc is archived (unarchive first — archived docs are read-only). Make all edits in one consolidated write: a content-changing write deletes ALL pending review comments on the doc (read them first) and records a document revision, so many partial writes lose review context and bury the revision history. The optional `description` sets the doc's one-line \"what this is\" summary (shown in the Documents list and doc header; omit to leave it unchanged). The optional `changelog` is stored as that revision's changelog and shown in the document's history — put update/status notes there, not in the document body.",
 	},
 	archive_project_doc: {
 		category: 'Project docs & assets',

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -4072,7 +4072,7 @@ export function registerTools(
 	tool(
 		server,
 		'list_project_docs',
-		"List project documentation files (PRD, spec, implementation plan, etc.). Archived (soft-deleted) docs are excluded by default — set filter: 'archived' or 'all' to see them (entries then carry an `archived` flag).",
+		"List project documentation files (PRD, spec, implementation plan, etc.). Each entry carries its `filename` and a one-line `description` (what the doc is / when to read it, '' if unset). Archived (soft-deleted) docs are excluded by default — set filter: 'archived' or 'all' to see them (entries then carry an `archived` flag).",
 		{
 			project: projectArg(),
 			filter: archiveFilterArg(),
@@ -4093,7 +4093,7 @@ export function registerTools(
 					.map((d) => ({
 						id: d.id,
 						filename: d.slug,
-						title: d.title,
+						description: d.description,
 						updated_at: d.updated_at,
 						...(filter !== ArchiveFilter.Active ? { archived: d.archived_at !== null } : {}),
 					})),
@@ -4731,10 +4731,17 @@ export function registerTools(
 				kind: 'document',
 				documentId: doc.id,
 			});
+			const descriptionField = doc.description ? { description: doc.description } : {};
 			if (reviewComments.length === 0)
-				return { filename: doc.slug, content: doc.content, ...archivedField };
+				return {
+					filename: doc.slug,
+					...descriptionField,
+					content: doc.content,
+					...archivedField,
+				};
 			return {
 				filename: doc.slug,
+				...descriptionField,
 				content: doc.content,
 				...archivedField,
 				review_comments: reviewComments.map((r) => ({
@@ -4752,11 +4759,17 @@ export function registerTools(
 	tool(
 		server,
 		'write_project_doc',
-		"Write a project documentation file. Project docs are markdown only — the filename must end in .md. For high-level project context: PRD, spec, implementation plan, research. Make ALL desired edits in ONE consolidated write per run, for two reasons: (1) writing a doc deletes ALL of its pending review comments (the admin's highlight feedback returned by read_project_doc) — a single write clears the whole review, so capture every comment in your context before the first write; (2) docs are revisioned — every content-changing write records a revision, so many partial writes bury the history in noise. Pass a `changelog` summarizing what changed in this write and why — it becomes that revision's entry in the document's history; keep update/changelog logs OUT of the document body and put them in `changelog` instead. Non-markdown files (mockups, wireframes, images, PDFs) live in the project assets library instead — reference those as `assets/<filename>`. In content, reference teammates with @<agent-slug>. Reference tickets and project docs by their bare identifier/filename (e.g. IN-42, spec.md), and skills by their slug — no @ prefix. Do not wrap any of these in backticks — that makes them inert.",
+		"Write a project documentation file. Project docs are markdown only — the filename must end in .md. For high-level project context: PRD, spec, implementation plan, research. Make ALL desired edits in ONE consolidated write per run, for two reasons: (1) writing a doc deletes ALL of its pending review comments (the admin's highlight feedback returned by read_project_doc) — a single write clears the whole review, so capture every comment in your context before the first write; (2) docs are revisioned — every content-changing write records a revision, so many partial writes bury the history in noise. Pass a `changelog` summarizing what changed in this write and why — it becomes that revision's entry in the document's history; keep update/changelog logs OUT of the document body and put them in `changelog` instead. Also pass a one-line `description` of what the doc is and when to read it — it shows next to the filename in the Documents list and the doc header so teammates and future runs can tell what the doc holds at a glance; keep it short and out of the body. Non-markdown files (mockups, wireframes, images, PDFs) live in the project assets library instead — reference those as `assets/<filename>`. In content, reference teammates with @<agent-slug>. Reference tickets and project docs by their bare identifier/filename (e.g. IN-42, spec.md), and skills by their slug — no @ prefix. Do not wrap any of these in backticks — that makes them inert.",
 		{
 			project: projectArg(),
 			filename: z.string().describe('Markdown filename to write (e.g. "spec.md")'),
 			content: z.string().describe('File content (markdown)'),
+			description: z
+				.string()
+				.optional()
+				.describe(
+					'One-line summary of what this doc is and when to read it (e.g. "How we track and report campaign analytics each week"). Shown next to the filename in the Documents list and the doc header, so teammates and future runs can tell what the doc holds without opening it. Keep it to a sentence; it is NOT the changelog and NOT part of the body. Omit to leave any existing description unchanged.',
+				),
 			changelog: z
 				.string()
 				.optional()
@@ -4795,6 +4808,7 @@ export function registerTools(
 					slug: args.filename as string,
 				},
 				content: args.content as string,
+				description: args.description as string | undefined,
 				changeSummary: args.changelog as string | undefined,
 				authorMemberId: callerMemberId,
 				authorApiKeyId: callerApiKeyId,

--- a/packages/server/src/routes/project-docs.ts
+++ b/packages/server/src/routes/project-docs.ts
@@ -34,6 +34,7 @@ function toDocResponse(d: DocumentRowWithAuthor) {
 	return {
 		id: d.id,
 		filename: d.slug,
+		description: d.description,
 		content: d.content,
 		created_at: d.created_at,
 		updated_at: d.updated_at,
@@ -65,6 +66,7 @@ projectDocsRoutes.get('/projects/:projectId/docs', async (c) => {
 		docs.map((d) => ({
 			id: d.id,
 			filename: d.slug,
+			description: d.description,
 			updated_at: d.updated_at,
 			archived_at: d.archived_at,
 		})),
@@ -101,7 +103,11 @@ projectDocsRoutes.put('/projects/:projectId/docs/:filename', async (c) => {
 		return err(c, 'INVALID_REQUEST', 'Project docs must be markdown (.md)', 400);
 	}
 
-	const body = await c.req.json<{ content: string; change_summary?: string }>();
+	const body = await c.req.json<{
+		content: string;
+		description?: string;
+		change_summary?: string;
+	}>();
 	if (body.content === undefined) {
 		return err(c, 'INVALID_REQUEST', 'content is required', 400);
 	}
@@ -152,6 +158,7 @@ projectDocsRoutes.put('/projects/:projectId/docs/:filename', async (c) => {
 			slug: filename,
 		},
 		content: body.content,
+		description: body.description,
 		changeSummary: body.change_summary,
 		authorMemberId: memberId,
 		authorApiKeyId: apiKeyIdFromAuth(auth),

--- a/packages/server/src/services/documents.ts
+++ b/packages/server/src/services/documents.ts
@@ -43,6 +43,8 @@ export interface DocumentRow {
 	type: DocumentType;
 	slug: string;
 	title: string;
+	/** A short "what this is" line for project docs — surfaced in the list + doc header. '' when unset. */
+	description: string;
 	content: string;
 	last_updated_by_member_id: string | null;
 	/** Soft-delete stamp — null = active. Only project docs are ever archived. */
@@ -123,7 +125,7 @@ function scopeWhere(scope: DocumentScope, alias = ''): { sql: string; params: un
 // Explicit column list — the generated search_tsv column (full-text index) is
 // server-internal and never serialized to API responses.
 const SELECT_WITH_AUTHOR = `SELECT d.id, d.team_id, d.project_id, d.member_agent_id,
-	        d.type, d.slug, d.title, d.content,
+	        d.type, d.slug, d.title, d.description, d.content,
 	        d.last_updated_by_member_id, d.archived_at, d.archived_by_member_id,
 	        d.created_at, d.updated_at,
 	        COALESCE(ma.title, m.display_name) AS last_updated_by_name,
@@ -182,6 +184,8 @@ export async function listDocuments(
 export interface UpsertDocumentInput {
 	scope: DocumentScope;
 	title?: string;
+	/** Optional "what this is" line for project docs. Undefined leaves an existing value untouched. */
+	description?: string;
 	content: string;
 	changeSummary?: string;
 	authorMemberId: string | null;
@@ -225,10 +229,17 @@ export async function upsertDocument(
 			`UPDATE documents
 			 SET content = $1,
 			     title = COALESCE($2, title),
-			     last_updated_by_member_id = $3
-			 WHERE id = $4
+			     description = COALESCE($3, description),
+			     last_updated_by_member_id = $4
+			 WHERE id = $5
 			 RETURNING *`,
-			[input.content, input.title ?? null, input.authorMemberId, prior.id],
+			[
+				input.content,
+				input.title ?? null,
+				input.description ?? null,
+				input.authorMemberId,
+				prior.id,
+			],
 		);
 		return updateResult.rows[0];
 	});
@@ -332,8 +343,8 @@ async function insertDocument(db: Db, input: UpsertDocumentInput): Promise<Docum
 	const memberAgentId = scope.type === DocumentType.AgentSystemPrompt ? scope.memberAgentId : null;
 	const slug = resolveSlug(scope);
 	const result = await db.query<DocumentRow>(
-		`INSERT INTO documents (team_id, project_id, member_agent_id, type, slug, title, content, last_updated_by_member_id)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		`INSERT INTO documents (team_id, project_id, member_agent_id, type, slug, title, description, content, last_updated_by_member_id)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 		 RETURNING *`,
 		[
 			scope.teamId,
@@ -342,6 +353,7 @@ async function insertDocument(db: Db, input: UpsertDocumentInput): Promise<Docum
 			scope.type,
 			slug,
 			input.title ?? '',
+			input.description ?? '',
 			input.content,
 			input.authorMemberId,
 		],

--- a/packages/server/src/services/template-resolver.ts
+++ b/packages/server/src/services/template-resolver.ts
@@ -360,26 +360,30 @@ export async function resolveSystemPrompt(
 		resolved = resolved.replace(/\{\{team_preferences_context\}\}/g, prefsText);
 	}
 
-	// Project docs are injected as a manifest (filename + optional title + updated date),
-	// not full bodies. The agent calls read_project_doc(filename) to load a doc on demand.
-	// Hand-rolled SQL (vs listDocuments) avoids pulling the content column, which is
-	// the whole point of switching away from full-body injection.
+	// Project docs are injected as a manifest (filename + optional description + updated
+	// date), not full bodies. The agent calls read_project_doc(filename) to load a doc on
+	// demand. Hand-rolled SQL (vs listDocuments) avoids pulling the content column, which
+	// is the whole point of switching away from full-body injection.
 	if (resolved.includes('{{project_docs_context}}')) {
 		let docsText =
 			'No project documentation available yet. Project docs live in the database, not the filesystem — there is no /workspace/.hezo/project-docs path. Author project context with write_project_doc rather than writing a file to disk.';
 		if (ctx.projectId) {
 			// Active docs only — archived (soft-deleted) docs never enter run
 			// context; read_project_doc(filter: 'archived') can still fetch one.
-			const docs = await db.query<{ filename: string; title: string; updated_at: string }>(
-				"SELECT slug AS filename, title, updated_at FROM documents WHERE type = 'project_doc' AND project_id = $1 AND archived_at IS NULL ORDER BY slug",
+			const docs = await db.query<{
+				filename: string;
+				description: string;
+				updated_at: string;
+			}>(
+				"SELECT slug AS filename, description, updated_at FROM documents WHERE type = 'project_doc' AND project_id = $1 AND archived_at IS NULL ORDER BY slug",
 				[ctx.projectId],
 			);
 			if (docs.rows.length > 0) {
 				const lines = docs.rows
 					.map((d) => {
 						const date = new Date(d.updated_at).toISOString().slice(0, 10);
-						const titlePart = d.title ? ` — ${d.title}` : '';
-						return `- ${d.filename}${titlePart} (updated ${date})`;
+						const descPart = d.description ? ` — ${d.description}` : '';
+						return `- ${d.filename}${descPart} (updated ${date})`;
 					})
 					.join('\n');
 				docsText = [

--- a/packages/server/test/mcp-tools.test.ts
+++ b/packages/server/test/mcp-tools.test.ts
@@ -959,6 +959,43 @@ describe('MCP tool handlers: additional data queries via DB', () => {
 		expect(filenames).toContain('test-doc.md');
 	});
 
+	it('round-trips a description through write/read/list_project_doc via MCP', async () => {
+		const written = (await callToolViaMcp('write_project_doc', {
+			project: projectId,
+			filename: 'mcp-described.md',
+			content: '# Analytics',
+			description: 'How we track and report campaign analytics each week.',
+		})) as { written?: boolean; error?: string };
+		expect(written.error).toBeUndefined();
+		expect(written.written).toBe(true);
+
+		const read = (await callToolViaMcp('read_project_doc', {
+			project: projectId,
+			filename: 'mcp-described.md',
+		})) as { description?: string };
+		expect(read.description).toBe('How we track and report campaign analytics each week.');
+
+		const listed = (await callToolViaMcp('list_project_docs', {
+			project: projectId,
+		})) as { files: Array<{ filename: string; description?: string }> };
+		const entry = listed.files.find((f) => f.filename === 'mcp-described.md');
+		expect(entry?.description).toBe('How we track and report campaign analytics each week.');
+	});
+
+	it('omits description from read_project_doc when unset', async () => {
+		await callToolViaMcp('write_project_doc', {
+			project: projectId,
+			filename: 'mcp-plain.md',
+			content: '# Plain',
+		});
+		const read = (await callToolViaMcp('read_project_doc', {
+			project: projectId,
+			filename: 'mcp-plain.md',
+		})) as { description?: string; content?: string };
+		expect(read.content).toContain('Plain');
+		expect(read.description).toBeUndefined();
+	});
+
 	it('create_skill inserts correctly', async () => {
 		const r = await db.query(
 			`INSERT INTO skills (name, slug, content, is_active)

--- a/packages/server/test/migrate-037-document-description.test.ts
+++ b/packages/server/test/migrate-037-document-description.test.ts
@@ -1,0 +1,71 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createDataPreservationHarness, type DataPreservationHarness } from './helpers/migrate';
+
+const TARGET = '037_document_description.sql';
+
+describe('037_document_description migration', () => {
+	let h: DataPreservationHarness;
+	let teamId: string;
+	let projectId: string;
+	let docId: string;
+
+	beforeAll(async () => {
+		h = await createDataPreservationHarness();
+		await h.applyUpToExclusive(TARGET); // schema at 036
+
+		const team = await h.db.query<{ id: string }>(
+			`INSERT INTO teams (name, slug) VALUES ('Acme', 'acme') RETURNING id`,
+		);
+		teamId = team.rows[0].id;
+		const project = await h.db.query<{ id: string }>(
+			`INSERT INTO projects (team_id, name, slug, task_prefix)
+			 VALUES ($1, 'Demo', 'demo', 'DM') RETURNING id`,
+			[teamId],
+		);
+		projectId = project.rows[0].id;
+		const doc = await h.db.query<{ id: string }>(
+			`INSERT INTO documents (team_id, project_id, type, slug, content)
+			 VALUES ($1, $2, 'project_doc', 'spec.md', '# Spec') RETURNING id`,
+			[teamId, projectId],
+		);
+		docId = doc.rows[0].id;
+
+		await h.applyTarget(TARGET);
+	});
+	afterAll(() => h.close());
+
+	it('adds a NOT NULL description column defaulting to empty', async () => {
+		const cols = await h.db.query<{
+			column_name: string;
+			is_nullable: string;
+			column_default: string | null;
+		}>(
+			`SELECT column_name, is_nullable, column_default FROM information_schema.columns
+			 WHERE table_name = 'documents' AND column_name = 'description'`,
+		);
+		expect(cols.rows).toHaveLength(1);
+		expect(cols.rows[0].is_nullable).toBe('NO');
+		expect(cols.rows[0].column_default).toMatch(/''::text/);
+	});
+
+	it('preserves pre-existing rows and backfills description to empty', async () => {
+		const doc = await h.db.query<{ content: string; description: string }>(
+			`SELECT content, description FROM documents WHERE id = $1`,
+			[docId],
+		);
+		expect(doc.rows[0].content).toBe('# Spec');
+		expect(doc.rows[0].description).toBe('');
+	});
+
+	it('accepts a description on subsequent writes', async () => {
+		await h.db.query(`UPDATE documents SET description = $1 WHERE id = $2`, [
+			'How the team tracks weekly analytics.',
+			docId,
+		]);
+		const doc = await h.db.query<{ description: string }>(
+			`SELECT description FROM documents WHERE id = $1`,
+			[docId],
+		);
+		expect(doc.rows[0].description).toBe('How the team tracks weekly analytics.');
+	});
+});

--- a/packages/server/test/project-docs.test.ts
+++ b/packages/server/test/project-docs.test.ts
@@ -185,6 +185,85 @@ describe('Project docs (DB-backed)', () => {
 	});
 });
 
+describe('Project doc descriptions', () => {
+	const filename = 'described.md';
+
+	it('stores the description on PUT and returns it from GET + list', async () => {
+		const putRes = await app.request(`/api/projects/${projectId}/docs/${filename}`, {
+			method: 'PUT',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				content: '# Analytics',
+				description: 'How we track and report campaign analytics each week.',
+			}),
+		});
+		expect(putRes.status).toBe(200);
+		expect((await putRes.json()).data.description).toBe(
+			'How we track and report campaign analytics each week.',
+		);
+
+		const getRes = await app.request(`/api/projects/${projectId}/docs/${filename}`, {
+			headers: authHeader(token),
+		});
+		expect((await getRes.json()).data.description).toBe(
+			'How we track and report campaign analytics each week.',
+		);
+
+		const listRes = await app.request(`/api/projects/${projectId}/docs`, {
+			headers: authHeader(token),
+		});
+		const entry = (await listRes.json()).data.find((d: any) => d.filename === filename);
+		expect(entry.description).toBe('How we track and report campaign analytics each week.');
+	});
+
+	it('leaves the description untouched when a later PUT omits it', async () => {
+		const res = await app.request(`/api/projects/${projectId}/docs/${filename}`, {
+			method: 'PUT',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ content: '# Analytics v2' }),
+		});
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.data.content).toContain('v2');
+		expect(body.data.description).toBe('How we track and report campaign analytics each week.');
+	});
+
+	it('updates the description without changing content (no new revision)', async () => {
+		const before = await app.request(`/api/projects/${projectId}/docs/${filename}/revisions`, {
+			headers: authHeader(token),
+		});
+		const beforeCount = (await before.json()).data.length;
+
+		const res = await app.request(`/api/projects/${projectId}/docs/${filename}`, {
+			method: 'PUT',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				content: '# Analytics v2',
+				description: 'Weekly analytics workflow.',
+			}),
+		});
+		expect(res.status).toBe(200);
+		expect((await res.json()).data.description).toBe('Weekly analytics workflow.');
+
+		const after = await app.request(`/api/projects/${projectId}/docs/${filename}/revisions`, {
+			headers: authHeader(token),
+		});
+		expect((await after.json()).data.length).toBe(beforeCount);
+	});
+
+	it('defaults description to empty string when never set', async () => {
+		await app.request(`/api/projects/${projectId}/docs/no-desc.md`, {
+			method: 'PUT',
+			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
+			body: JSON.stringify({ content: '# No description' }),
+		});
+		const res = await app.request(`/api/projects/${projectId}/docs/no-desc.md`, {
+			headers: authHeader(token),
+		});
+		expect((await res.json()).data.description).toBe('');
+	});
+});
+
 describe('Project doc revisions and restore', () => {
 	const filename = 'revisioned.md';
 

--- a/packages/server/test/template-resolver-cov-fill.test.ts
+++ b/packages/server/test/template-resolver-cov-fill.test.ts
@@ -182,10 +182,11 @@ describe('placeholder substitution', () => {
 		expect(result).toContain('write_project_doc');
 	});
 
-	it('renders {{project_docs_context}} as a manifest with title and title-less lines', async () => {
+	it('renders {{project_docs_context}} as a manifest with described and description-less lines', async () => {
 		await ctx.db.query(
-			`INSERT INTO documents (team_id, project_id, type, slug, title, content)
-			 VALUES ($1, $2, 'project_doc', 'bare-notes.md', '', 'note body')`,
+			`INSERT INTO documents (team_id, project_id, type, slug, description, content)
+			 VALUES ($1, $2, 'project_doc', 'described.md', 'What this doc covers.', 'note body'),
+			        ($1, $2, 'project_doc', 'bare-notes.md', '', 'scratch')`,
 			[teamId, projectId],
 		);
 		const result = await resolveSystemPrompt(ctx.db, '{{project_docs_context}}', {
@@ -194,11 +195,13 @@ describe('placeholder substitution', () => {
 			mode: 'placeholders',
 		});
 		expect(result).toContain('read_project_doc(filename)');
-		// createTestProject seeds architecture-guidelines.md with a title.
+		// A doc with a description renders "filename — description (updated date)".
 		expect(result).toMatch(
-			/- architecture-guidelines\.md — Architecture Guidelines \(updated \d{4}-\d{2}-\d{2}\)/,
+			/- described\.md — What this doc covers\. \(updated \d{4}-\d{2}-\d{2}\)/,
 		);
+		// A description-less doc renders bare — no em-dash.
 		expect(result).toMatch(/- bare-notes\.md \(updated \d{4}-\d{2}-\d{2}\)/);
+		expect(result).not.toContain('bare-notes.md —');
 		expect(result).not.toContain('note body');
 	});
 

--- a/packages/server/test/template-resolver.test.ts
+++ b/packages/server/test/template-resolver.test.ts
@@ -205,7 +205,10 @@ describe('template resolver', () => {
 		const docRes = await app.request(`/api/projects/${projectId}/docs/spec.md`, {
 			method: 'PUT',
 			headers: { ...authHeader(token), 'Content-Type': 'application/json' },
-			body: JSON.stringify({ content: 'Detailed spec.' }),
+			body: JSON.stringify({
+				content: 'Detailed spec.',
+				description: 'The technical spec for the build.',
+			}),
 		});
 		expect(docRes.status).toBe(200);
 
@@ -226,14 +229,15 @@ describe('template resolver', () => {
 		expect(result).toContain('write_project_doc(filename, content)');
 		expect(result).toContain('will not touch these');
 
-		// Titled doc (architecture-guidelines.md is seeded by createTestProject with a non-empty title).
+		// Described doc — the manifest shows "filename — description (updated date)".
 		expect(result).toMatch(
-			/- architecture-guidelines\.md — Architecture Guidelines \(updated \d{4}-\d{2}-\d{2}\)/,
+			/- spec\.md — The technical spec for the build\. \(updated \d{4}-\d{2}-\d{2}\)/,
 		);
 
-		// Title-less doc (created via PUT, which leaves title empty) — no em-dash, no "undefined".
-		expect(result).toMatch(/- spec\.md \(updated \d{4}-\d{2}-\d{2}\)/);
-		expect(result).not.toContain('spec.md —');
+		// Description-less doc (architecture-guidelines.md is seeded with no description) —
+		// no em-dash, no "undefined".
+		expect(result).toMatch(/- architecture-guidelines\.md \(updated \d{4}-\d{2}-\d{2}\)/);
+		expect(result).not.toContain('architecture-guidelines.md —');
 		expect(result).not.toContain('undefined');
 
 		// Doc bodies and the old warning copy are gone — the whole point of the manifest.

--- a/packages/web/src/components/docs-library.tsx
+++ b/packages/web/src/components/docs-library.tsx
@@ -5,6 +5,7 @@ import {
 	ExternalLink,
 	FileText,
 	History,
+	Info,
 	Loader2,
 	PanelLeftClose,
 	PanelLeftOpen,
@@ -34,6 +35,8 @@ const LIST_COLLAPSED_KEY = 'hezo:doc-list-collapsed';
 export interface DocItem {
 	key: string;
 	label: ReactNode;
+	/** One-line "what this is" summary, shown under the label. Omit for none. */
+	description?: ReactNode;
 	meta?: ReactNode;
 	pinned?: boolean;
 	canDelete?: boolean;
@@ -58,7 +61,15 @@ interface DocsLibraryProps {
 	/** Heading shown for the loaded doc; falls back to the items entry or selectedKey. */
 	docTitle?: ReactNode;
 
-	onSave: (content: string) => Promise<void> | void;
+	/**
+	 * The selected doc's one-line description. `undefined` means the doc type has
+	 * no description (e.g. the repo-backed AGENTS.md) — the description block and
+	 * its editor are hidden. `''` is a project doc with none set yet: view mode
+	 * shows nothing, edit mode shows the input with a placeholder.
+	 */
+	docDescription?: string;
+
+	onSave: (content: string, description?: string) => Promise<void> | void;
 	isSaving?: boolean;
 	onDelete?: () => Promise<void> | void;
 
@@ -127,6 +138,7 @@ export function DocsLibrary({
 	docContent,
 	isLoadingDoc,
 	docTitle,
+	docDescription,
 	onSave,
 	isSaving,
 	onDelete,
@@ -155,6 +167,7 @@ export function DocsLibrary({
 	const [mode, setMode] = useState<'view' | 'edit'>('view');
 	const [modeKey, setModeKey] = useState<string | null>(selectedKey);
 	const [draft, setDraft] = useState('');
+	const [descDraft, setDescDraft] = useState('');
 	const [deleteOpen, setDeleteOpen] = useState(false);
 	const [search, setSearch] = useState('');
 	const [listCollapsed, setListCollapsed] = useState(() => readStored(LIST_COLLAPSED_KEY) === '1');
@@ -169,9 +182,10 @@ export function DocsLibrary({
 	useEffect(() => {
 		if (mode === 'edit' && prevModeRef.current !== 'edit') {
 			setDraft(docContent ?? '');
+			setDescDraft(docDescription ?? '');
 		}
 		prevModeRef.current = mode;
-	}, [mode, docContent]);
+	}, [mode, docContent, docDescription]);
 
 	// Honour a deep-linked `?edit=1` once the doc content has loaded: flip into
 	// edit mode a single time. Waiting for content (rather than starting in edit)
@@ -224,8 +238,13 @@ export function DocsLibrary({
 		label: typeof item.label === 'string' ? item.label : item.key,
 	}));
 
+	// A project doc always has a description string (possibly ''); AGENTS.md and
+	// other description-less doc types pass `undefined`, which hides the block +
+	// editor and omits the field from the save.
+	const supportsDescription = docDescription !== undefined;
+
 	async function handleSave() {
-		await onSave(draft);
+		await onSave(draft, supportsDescription ? descDraft.trim() : undefined);
 		setMode('view');
 	}
 
@@ -331,6 +350,11 @@ export function DocsLibrary({
 												>
 													{item.label}
 												</div>
+												{item.description && (
+													<div className="text-[11.5px] text-text-2 mt-0.5 truncate">
+														{item.description}
+													</div>
+												)}
 												{(item.meta || item.archived) && (
 													<div className="text-[11px] text-text-3 mt-0.5 flex items-center gap-1.5 min-w-0">
 														{item.archived && <ArchivedBadge />}
@@ -538,6 +562,17 @@ export function DocsLibrary({
 							</div>
 						)}
 
+						{/* The doc's "what this is" line, above the metadata banner. Only
+						    shown when set — an empty description reads as no subtitle. */}
+						{mode === 'view' && supportsDescription && docDescription && (
+							<p
+								className="text-[13px] leading-relaxed text-text-2 mb-4"
+								data-testid="doc-description"
+							>
+								{docDescription}
+							</p>
+						)}
+
 						{mode === 'view' ? (
 							<DocumentBody
 								content={docContent || '_(empty)_'}
@@ -548,13 +583,40 @@ export function DocsLibrary({
 								topSlot={bodyBanner}
 							/>
 						) : (
-							<MentionTextarea
-								projectId={projectId}
-								projectSlug={projectSlug}
-								value={draft}
-								onChange={(e) => setDraft(e.target.value)}
-								className="min-h-[400px] font-mono text-xs"
-							/>
+							<div className="flex flex-col gap-3">
+								{supportsDescription && (
+									<div className="flex flex-col gap-1">
+										<div className="flex items-center gap-1.5">
+											<label
+												htmlFor="doc-description-input"
+												className="text-[11px] font-medium uppercase tracking-wide text-text-3"
+											>
+												Description
+											</label>
+											<Tooltip content="Agents fill this in when they write the doc — you can edit it here anytime.">
+												<Info
+													className="w-3.5 h-3.5 text-text-3"
+													aria-label="Agents set the description when they write the doc; you can edit it here anytime."
+												/>
+											</Tooltip>
+										</div>
+										<Input
+											id="doc-description-input"
+											value={descDraft}
+											onChange={(e) => setDescDraft(e.target.value)}
+											placeholder="What this doc is and when to read it"
+											data-testid="doc-description-input"
+										/>
+									</div>
+								)}
+								<MentionTextarea
+									projectId={projectId}
+									projectSlug={projectSlug}
+									value={draft}
+									onChange={(e) => setDraft(e.target.value)}
+									className="min-h-[400px] font-mono text-xs"
+								/>
+							</div>
 						)}
 
 						{mode === 'view' && viewerExtras}

--- a/packages/web/src/components/docs-library.tsx
+++ b/packages/web/src/components/docs-library.tsx
@@ -323,7 +323,7 @@ export function DocsLibrary({
 						{listExtras && <div className="mt-2">{listExtras}</div>}
 					</div>
 
-					<div className="md:overflow-y-auto md:min-h-0">
+					<div className="md:overflow-y-auto md:min-h-0" data-testid="doc-list-scroller">
 						{isLoadingList ? (
 							<div className="text-text-2 text-[13px] py-4">Loading...</div>
 						) : items.length === 0 ? (

--- a/packages/web/src/hooks/use-project-docs.ts
+++ b/packages/web/src/hooks/use-project-docs.ts
@@ -7,6 +7,8 @@ import { queryKeys } from '../lib/query-keys';
 export interface ProjectDoc {
 	id: string;
 	filename: string;
+	/** One-line "what this is" summary; '' when unset. Present in the list and the single-doc GET. */
+	description?: string;
 	updated_at: string;
 	content?: string;
 	/** Set when the doc is archived (soft-deleted); null = active. */
@@ -47,14 +49,17 @@ export function useUpdateProjectDoc(projectId: string) {
 		mutationFn: ({
 			filename,
 			content,
+			description,
 			changeSummary,
 		}: {
 			filename: string;
 			content: string;
+			description?: string;
 			changeSummary?: string;
 		}) =>
 			api.put<ProjectDoc>(`/api/projects/${projectId}/docs/${filename}`, {
 				content,
+				description,
 				change_summary: changeSummary,
 			}),
 		onSuccess: (saved, { filename }) => {

--- a/packages/web/src/routes/projects/$projectId/documents.tsx
+++ b/packages/web/src/routes/projects/$projectId/documents.tsx
@@ -106,6 +106,7 @@ function ProjectDocumentsPage() {
 			list.push({
 				key: d.filename,
 				label: d.filename,
+				description: d.description || undefined,
 				archived: d.archived_at != null,
 				meta: (
 					<>
@@ -177,12 +178,12 @@ function ProjectDocumentsPage() {
 		setIsCreating(false);
 	}
 
-	async function handleSave(content: string) {
+	async function handleSave(content: string, description?: string) {
 		if (!file) return;
 		if (isAgentsMd) {
 			await updateAgentsMd.mutateAsync(content);
 		} else {
-			await updateDoc.mutateAsync({ filename: file, content });
+			await updateDoc.mutateAsync({ filename: file, content, description });
 		}
 	}
 
@@ -203,6 +204,17 @@ function ProjectDocumentsPage() {
 
 	return (
 		<>
+			{/* Section header — frames Documents as the team's long-term memory,
+			    mirroring the Assets page header. On mobile it hides once a doc is
+			    open or the new-doc form is up (single-pane), staying visible on md+
+			    where the two-pane layout always shows the list. */}
+			<div className={`mb-4 ${!file && !isCreating ? '' : 'hidden md:block'}`}>
+				<h1 className="text-base font-semibold text-text-1">Documents</h1>
+				<p className="text-[13px] text-text-2">
+					Your team's long-term memory — the guidelines, research, and reference material the team
+					builds up and returns to across the project.
+				</p>
+			</div>
 			<DocsLibrary
 				projectId={projectId}
 				projectSlug={projectId}
@@ -214,6 +226,7 @@ function ProjectDocumentsPage() {
 				docContent={displayContent}
 				isLoadingDoc={isLoadingDoc}
 				docTitle={isAgentsMd ? 'AGENTS.md' : (file ?? undefined)}
+				docDescription={isAgentsMd ? undefined : (doc?.description ?? '')}
 				onSave={handleSave}
 				isSaving={updateDoc.isPending || updateAgentsMd.isPending}
 				onDelete={handleDelete}
@@ -260,8 +273,8 @@ function ProjectDocumentsPage() {
 						projectId={projectId}
 						projectSlug={projectId}
 						onCancel={() => setIsCreating(false)}
-						onCreate={async (filename, content) => {
-							await updateDoc.mutateAsync({ filename, content });
+						onCreate={async (filename, content, description) => {
+							await updateDoc.mutateAsync({ filename, content, description });
 							setIsCreating(false);
 							navigate({
 								search: (prev) => ({ ...(prev as DocumentsSearch), file: filename }),
@@ -322,10 +335,11 @@ function NewProjectDocForm({
 	projectId: string;
 	projectSlug: string;
 	onCancel: () => void;
-	onCreate: (filename: string, content: string) => Promise<void>;
+	onCreate: (filename: string, content: string, description: string) => Promise<void>;
 	isPending: boolean;
 }) {
 	const [filename, setFilename] = useState('');
+	const [description, setDescription] = useState('');
 	const [content, setContent] = useState('');
 	const [error, setError] = useState<string | null>(null);
 
@@ -339,7 +353,7 @@ function NewProjectDocForm({
 			return;
 		}
 		setError(null);
-		await onCreate(name, content);
+		await onCreate(name, content, description.trim());
 	}
 
 	return (
@@ -351,6 +365,12 @@ function NewProjectDocForm({
 				value={filename}
 				onChange={(e) => setFilename(e.target.value)}
 				required
+			/>
+			<Input
+				label="Description"
+				placeholder="What this doc is and when to read it"
+				value={description}
+				onChange={(e) => setDescription(e.target.value)}
 			/>
 			<MarkdownEditor
 				projectId={projectId}

--- a/packages/web/test/project-documents.test.tsx
+++ b/packages/web/test/project-documents.test.tsx
@@ -369,6 +369,65 @@ test('switches the viewed document via the header name search, hidden while edit
 	expect(queryByTestId('doc-switch-button')).toBeNull();
 });
 
+test('shows a document description in the list and header, and lets you edit it', async () => {
+	let ws!: SeededWorkspace;
+	let projectSlug = '';
+	const filename = `analytics-${Math.random().toString(36).slice(2, 8)}.md`;
+
+	const { findByText, findAllByText, findByRole, findByTestId, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async ({ apiBase, token }) => {
+			ws = await seedWorkspace();
+			const project = await seedProject(ws, {
+				name: uniqueName('Description Project'),
+				description: 'Tests the per-doc description surfaces.',
+			});
+			projectSlug = project.slug;
+			const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+			const res = await apiBase(`/api/projects/${projectSlug}/docs/${filename}`, {
+				method: 'PUT',
+				headers,
+				body: JSON.stringify({
+					content: '# Analytics\n\nBody.',
+					description: 'How we track campaign analytics weekly.',
+				}),
+			});
+			if (!res.ok) throw new Error(`seed failed: ${res.status}`);
+		},
+	});
+
+	// List view: the section header frames Documents as long-term memory, and the
+	// description shows under the filename row (surfaces 1 + 2).
+	await router.navigate({
+		to: '/projects/$projectId/documents',
+		params: { projectId: projectSlug },
+	});
+	await findByText(/long-term memory/i, undefined, { timeout: 15_000 });
+	await findByText('How we track campaign analytics weekly.', undefined, { timeout: 15_000 });
+
+	// Open the doc: the description renders as the header block (surface 3).
+	await router.navigate({
+		to: '/projects/$projectId/documents',
+		params: { projectId: projectSlug },
+		search: { file: filename } as never,
+	});
+	const descBlock = await findByTestId('doc-description', undefined, { timeout: 15_000 });
+	expect(descBlock.textContent).toContain('How we track campaign analytics weekly.');
+
+	// Edit the description inline and save; the new text replaces the old.
+	await user.click(await findByRole('button', { name: 'Edit' }));
+	const descInput = (await findByTestId('doc-description-input')) as HTMLInputElement;
+	await user.clear(descInput);
+	await user.type(descInput, 'Updated: weekly analytics workflow.');
+	await user.click(await findByRole('button', { name: 'Save' }));
+
+	// Appears in both the header block and the list row after the refetch.
+	const updated = await findAllByText('Updated: weekly analytics workflow.', undefined, {
+		timeout: 15_000,
+	});
+	expect(updated.length).toBeGreaterThanOrEqual(1);
+});
+
 test('rejects invalid filename when creating a document', async () => {
 	let ws!: SeededWorkspace;
 	let projectSlug = '';

--- a/test/browser/docs-sidebar-sticky.spec.ts
+++ b/test/browser/docs-sidebar-sticky.spec.ts
@@ -52,12 +52,11 @@ test('documents sidebar stays pinned while the page scrolls on desktop', async (
 		expect(after.y).toBeGreaterThanOrEqual(0);
 		// Pinned: it did not drift down from its starting position.
 		expect(after.y).toBeLessThanOrEqual(before.y + 1);
-		// And it did not drift up either. The sticky offset mirrors the project
-		// layout's vertical padding so the breathing room above the button when
-		// unscrolled is preserved when the sidebar sticks; without it the button
-		// would slide flush against the app header.
-		expect(after.y).toBeGreaterThanOrEqual(before.y - 1);
-		// And it sits within the app header + a small offset of the top.
+		// It pins near the top with the sticky offset holding it just below the app
+		// header (not flush against it). The page's "Documents" section header sits
+		// above the two-pane and scrolls away, so the pinned sidebar ends up higher
+		// than its unscrolled start — hence we bound the pinned position absolutely
+		// rather than against `before.y`.
 		expect(after.y).toBeLessThan(120);
 	}
 });
@@ -94,9 +93,13 @@ test('sidebar search header stays fixed while the doc list itself scrolls', asyn
 	const before = await searchInput.boundingBox();
 	expect(before).not.toBeNull();
 
-	// Scroll the last doc into view — with 40 rows this must scroll the list's
-	// own overflow-y-auto container.
-	await page.getByText(`doc-${count - 1}.md`).scrollIntoViewIfNeeded();
+	// Scroll the list's own overflow-y-auto container to the bottom — the "doc
+	// list itself scrolls" case. Scrolling this inner scroller directly (rather
+	// than scrollIntoView, which can bubble to the shell <main> once the page's
+	// section header pushes the list below the fold) isolates the invariant under
+	// test: the search header lives above this scroller and must not move.
+	const listScroller = page.getByTestId('doc-list-scroller');
+	await listScroller.evaluate((el) => el.scrollTo({ top: el.scrollHeight }));
 	await expect(page.getByText(`doc-${count - 1}.md`)).toBeVisible();
 
 	// The search header did not move: it lives above the list's scroller.


### PR DESCRIPTION
## What & why

The Documents list was a wall of raw `.md` filenames with nothing but "Updated X ago" beside each — you couldn't tell what any document held without opening it. Since documents are the project's long-term memory, this adds a one-line **description** ("what this is") to every project doc so the section reads as a legible index.

Per the design discussion, the **filename stays each doc's label and identity** — it's already descriptive — so this adds only the description, not a separate human title. Agents author the description when they write a doc; humans can edit it inline.

Design mockup (desktop + mobile): https://claude.ai/code/artifact/adad0f3c-8f3b-44da-8d47-73fe0ce213ce

## Changes

**Three UI surfaces**
- **Section header** — a "Documents" title + blurb framing the section as the team's long-term memory, mirroring the Assets page header (hidden on mobile once a doc is open).
- **List rows** — the filename stays the bold label; the description shows on a muted line beneath it.
- **Document header** — the open doc shows its description above the metadata strip. In **Edit** mode a Description input sits above the body, with a tooltip explaining that agents fill it in and you can edit it anytime. The new-doc form gains a Description field too.

**Data / backend**
- Migration `037_document_description.sql` adds a `description TEXT NOT NULL DEFAULT ''` column (additive, data-preserving).
- Threaded through the service (`upsertDocument` `COALESCE`s it, exactly like `title`), REST (`toDocResponse`, the list map, and the `PUT` body), and the MCP tools: `write_project_doc` gains an optional `description` arg; `read_project_doc` and `list_project_docs` return it.
- The `{{project_docs_context}}` agent run manifest now surfaces the description **in place of the long-unused `title`**, so every run sees what each doc holds.

**Docs (same PR)**
- `docs/concepts/documents-and-memory.md` and `.dev/architecture.md` updated.
- Regenerated `docs/reference/mcp-api.md` via `build:docs` (with authored `TOOL_DOC_META`).

## Testing

- **Migration**: `migrate-037-document-description.test.ts` — preservation + column added.
- **REST**: description round-trips through PUT → GET/list; omitted-on-later-PUT preserved; description-only edit records no revision; defaults to `''`.
- **MCP**: `write_project_doc` → `read_project_doc` / `list_project_docs` round-trip; description omitted from `read_project_doc` when unset.
- **Manifest**: `template-resolver` tests updated to the description-based manifest.
- **Web**: a component test covering the list description, the header block, and inline editing.

All touched suites pass locally (server 249, web 10 in the affected files); `biome check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBa2TvSEwBFdFLUvifNsr7

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBa2TvSEwBFdFLUvifNsr7)_