### PR TITLE
fix: move PWA install banner to top of viewport

### DIFF
--- a/packages/web/src/components/pwa-install-prompt.tsx
+++ b/packages/web/src/components/pwa-install-prompt.tsx
@@ -5,8 +5,9 @@ import { Logo } from './ui/logo';
 
 /**
  * Mobile-only, dismissible "install Hezo to your home screen" card pinned to the
- * bottom of the viewport. Hidden on `lg` and up (desktop), mirroring the rest of
- * the app's mobile-gating convention (rail/drawer all use `lg:hidden`).
+ * top of the viewport, just below the app header (so it floats above content
+ * without covering the nav). Hidden on `lg` and up (desktop), mirroring the rest
+ * of the app's mobile-gating convention (rail/drawer all use `lg:hidden`).
  *
  * On Chrome/Android it offers a one-tap **Install** button backed by the
  * captured `beforeinstallprompt` event; on iOS Safari — which has no
@@ -21,7 +22,7 @@ export function PwaInstallPrompt() {
 	return (
 		<div
 			data-testid="pwa-install-prompt"
-			className="lg:hidden fixed inset-x-3 bottom-3 z-40 flex items-start gap-3 rounded-lg border border-border bg-surface p-3 shadow-lg"
+			className="lg:hidden fixed inset-x-3 top-14 z-40 flex items-start gap-3 rounded-lg border border-border bg-surface p-3 shadow-lg"
 		>
 			<Logo size="md" className="mt-0.5 shrink-0" />
 			<div className="min-w-0 flex-1">

--- a/test/browser/pwa-install.mobile.spec.ts
+++ b/test/browser/pwa-install.mobile.spec.ts
@@ -47,7 +47,7 @@ test.describe('PWA install prompt (mobile)', () => {
 		await expect(page.getByTestId('app-header')).toBeVisible({ timeout: 15000 });
 
 		await page.evaluate(FIRE_BEFORE_INSTALL_PROMPT);
-		// `lg:hidden` keeps the bottom card off desktop viewports.
+		// `lg:hidden` keeps the top card off desktop viewports.
 		await expect(page.getByTestId('pwa-install-prompt')).toBeHidden();
 	});
 


### PR DESCRIPTION
## What

Moves the mobile "Install Hezo" PWA prompt from the bottom of the viewport to the top.

## Why

The install banner was pinned to the bottom of the screen (`fixed inset-x-3 bottom-3`), overlaying content near the bottom. This change makes it read as a top-of-page banner instead.

## How

- Changed the card's positioning from `bottom-3` to `top-14` in `packages/web/src/components/pwa-install-prompt.tsx`.
- The app has a persistent 48px (`h-12`) `AppHeader` at the very top of the shell. `top-14` (56px) pins the fixed card just below that header, so it floats at the top of the content without covering the nav icons. (A plain `top-3` would overlay and hide the header/nav.)
- Updated the component docstring and the stale "bottom card" comment in `test/browser/pwa-install.mobile.spec.ts` to match.

## Testing

- `bunx vitest run test/pwa-install-prompt.test.tsx` — 9/9 pass (positioning isn't asserted, so no behavioral change to the tests).
- Full `typecheck` + `build` pass via the pre-commit hook.
- Still mobile-only (`lg:hidden`) and dismissible; no behavioral change beyond position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXTKftnC6T4FDa4QbNMu9m)_