### PR TITLE
feat(chat): title new chat threads from the first message, in parallel with the reply

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -579,16 +579,20 @@ chat-enabled agent; the operator can review and edit it on the agent's **Chat hi
 (`GET/PUT /api/projects/:projectId/agents/:agentId/chat-memory`).
 
 **Automatic thread titling.** A web thread is created **untitled** (`chat_conversations.title`
-NULL — there is no hardcoded "Main" default) and rendered as a "New thread" placeholder. After a
-reply settles on an untitled thread that has a real exchange, `runTitleGeneration` runs a
-**headless exec** (like compaction — no `chat_message`, no reply broadcast) that hands the agent
-the active window and **captures a short title from its stdout** (`buildTitlePrompt` →
-`sanitizeChatTitle`); the agent does the naming, there is **no server-side LLM call**. It persists
-idempotently (`UPDATE … SET title WHERE title IS NULL`, so a manual/already-set title is never
-clobbered) and broadcasts `ChatConversationUpdated` on the `chat:global` room, so every open thread
-switcher/sidebar refetches and updates its label live. Titling runs **once** per thread (skipped
-once titled), is chained before compaction so the two never contend for the per-session prompt
-file, and its exec's tokens are not separately priced (matching compaction).
+NULL — there is no hardcoded "Main" default) and rendered as a "New thread" placeholder. On an
+untitled thread, `runTitleGeneration` is kicked off **as soon as the first operator message lands,
+in parallel with the reply** (not chained after it), so the label flips from "New thread" while the
+CEO is still typing. It runs a **headless exec** (like compaction — no `chat_message`, no reply
+broadcast) that hands the agent the active window and **captures a short title from its stdout**
+(`buildTitlePrompt` → `sanitizeChatTitle`); the agent does the naming, there is **no server-side
+LLM call**. It titles from the operator's first message alone — it doesn't wait for a settled
+assistant reply — off its **own prompt file** (the `title` slot in `turnPrompt`) so it never
+contends with the reply's exec. It persists idempotently (`UPDATE … SET title WHERE title IS NULL`,
+so a manual/already-set title is never clobbered) and broadcasts `ChatConversationUpdated` on the
+`chat:global` room, so every open thread switcher/sidebar refetches and updates its label live. One
+title run is in flight per thread at a time (`ConversationRuntime.titling`); a new turn or a close
+preempts it (`titlingAbort`) and — while still untitled — the next turn re-kicks it. Its exec's
+tokens are not separately priced (matching compaction).
 
 HQ also exposes the standard **assets library** — the one internal-project surface that
 isn't hidden in the UI (Budget/Settings still are). Files the CEO produces for the operator

--- a/packages/server/src/services/chat-session-manager.ts
+++ b/packages/server/src/services/chat-session-manager.ts
@@ -215,6 +215,11 @@ interface ConversationRuntime {
 	current: CurrentTurn | null;
 	compaction: Promise<void> | null;
 	compactionAbort: AbortController | null;
+	// In-flight auto-title run for this thread (runs in parallel with the reply,
+	// off its own prompt file). Tracked so a second one never runs concurrently and
+	// so a new turn / close can preempt it.
+	titling: Promise<void> | null;
+	titlingAbort: AbortController | null;
 }
 
 /**
@@ -287,6 +292,8 @@ export class ChatSessionManager {
 				current: null,
 				compaction: null,
 				compactionAbort: null,
+				titling: null,
+				titlingAbort: null,
 			};
 			this.convos.set(conversationId, rt);
 		}
@@ -383,6 +390,14 @@ export class ChatSessionManager {
 			await convo.compaction?.catch(() => undefined);
 		}
 
+		// Preempt an in-flight auto-title run too: this turn re-kicks titling from the
+		// richer window below (if the thread is still untitled), so drop the stale one
+		// and free its exec. Awaited so `convo.titling` is cleared before the re-kick.
+		if (convo.titlingAbort) {
+			convo.titlingAbort.abort('interrupted');
+			await convo.titling?.catch(() => undefined);
+		}
+
 		// Interrupt an in-flight reply in this thread: abort it and wait for it to
 		// finalize (the run loop persists the partial as `interrupted`) so the next
 		// turn's prompt includes it.
@@ -450,12 +465,13 @@ export class ChatSessionManager {
 		const abort = new AbortController();
 		const promise = this.runTurn(session, ctx, assistantMessageId, abort);
 		convo.current = { assistantMessageId, abort, promise };
-		// After the reply settles: first auto-title the thread if it's still untitled,
-		// then compact its window if it has grown past the cap. Chained (not parallel)
-		// so the two never exec against this thread's shared prompt file concurrently.
-		trackBackground(
-			promise.then(() => this.maybeAutoTitle(ctx)).then(() => this.maybeCompact(ctx)),
-		);
+		// Title the thread as early as possible: kick off title generation from the
+		// first user message *in parallel* with the reply (off its own prompt file, so
+		// the two execs never collide), so the switcher/rail label flips from "New
+		// thread" while the CEO is still typing instead of only after the reply settles.
+		// Compaction still waits for the reply — it rewrites the window this turn feeds.
+		trackBackground(this.maybeAutoTitle(ctx));
+		trackBackground(promise.then(() => this.maybeCompact(ctx)));
 
 		return { userMessageId, assistantMessageId, conversationId };
 	}
@@ -466,13 +482,18 @@ export class ChatSessionManager {
 		await this.teardown(ChatSessionStatus.Stopped);
 	}
 
-	/** Abort every in-flight turn across all conversations and await them. */
+	/** Abort every in-flight turn (and parallel auto-title run) across all
+	 * conversations and await them, so no exec outlives a restart/shutdown. */
 	private async abortAllCurrent(reason: string): Promise<void> {
 		const inflight: Promise<unknown>[] = [];
 		for (const convo of this.convos.values()) {
 			if (convo.current) {
 				convo.current.abort.abort(reason);
 				inflight.push(convo.current.promise.catch(() => undefined));
+			}
+			if (convo.titlingAbort) {
+				convo.titlingAbort.abort(reason);
+				inflight.push(convo.titling?.catch(() => undefined) ?? Promise.resolve());
 			}
 		}
 		await Promise.all(inflight);
@@ -777,6 +798,10 @@ export class ChatSessionManager {
 			rt.compactionAbort.abort('closed');
 			await rt.compaction?.catch(() => undefined);
 		}
+		if (rt?.titlingAbort) {
+			rt.titlingAbort.abort('closed');
+			await rt.titling?.catch(() => undefined);
+		}
 		this.convos.delete(conversationId);
 		await this.deps.db.query(`UPDATE chat_conversations SET closed_at = now() WHERE id = $1`, [
 			conversationId,
@@ -1062,12 +1087,17 @@ export class ChatSessionManager {
 	 * reads its prompt from `HEZO_PROMPT_FILE`; keying the file by conversation lets
 	 * concurrent threads exec without overwriting each other's prompt (same-thread
 	 * turns serialize via the per-conversation lock, so one file per thread is safe).
+	 * Pass a `slot` suffix for a side exec that must run alongside the reply — the
+	 * auto-title run uses its own file so it never overwrites the reply's prompt.
 	 */
 	private turnPrompt(
 		session: LiveSession,
 		conversationId: string,
+		slot?: string,
 	): { hostPath: string; env: string[] } {
-		const key = `${session.sessionId}-${conversationId}`;
+		const key = slot
+			? `${session.sessionId}-${conversationId}-${slot}`
+			: `${session.sessionId}-${conversationId}`;
 		const hostPath = getHostPromptPath(this.deps.dataDir, DEFAULT_TEAM_ID, session.projectId, key);
 		const containerPath = getContainerPromptPath(key);
 		const env = session.env.map((e) =>
@@ -1301,26 +1331,35 @@ export class ChatSessionManager {
 	}
 
 	/**
-	 * Auto-title a thread from its content once, after a reply settles, if it's still
-	 * untitled. Best-effort and gated like compaction: skipped when a newer turn is in
-	 * flight in this thread (it retries after that turn) or a compaction is running for
-	 * it. A generated title flips the thread from the "New thread" placeholder to a
-	 * meaningful name; a failure leaves it untitled and the next reply retries.
+	 * Auto-title a thread from its first message as early as possible, if it's still
+	 * untitled — kicked off in parallel with the reply so the label updates on-the-go
+	 * rather than only after the reply settles. Best-effort: skipped when a title run
+	 * is already in flight for this thread (one at a time; a new turn re-kicks). A
+	 * generated title flips the thread from the "New thread" placeholder to a
+	 * meaningful name; a failure leaves it untitled and the next turn retries.
 	 */
 	private async maybeAutoTitle(ctx: ConversationContext): Promise<void> {
 		const session = this.live;
 		if (!session) return;
 		const convo = this.getConvoRuntime(ctx.conversationId);
-		if (convo.current || convo.compaction) return;
+		// One title run per thread at a time; the reply may still be streaming (that's
+		// the point — title in parallel), so only a concurrent title run is a conflict.
+		if (convo.titling) return;
 		// Only untitled threads get auto-titled; a set title (manual or already
 		// generated) is never overwritten.
 		const existing = await this.getConversation(ctx.conversationId);
 		if (!existing || existing.closed_at || existing.title != null) return;
 		const abort = new AbortController();
+		convo.titlingAbort = abort;
+		const run = this.runTitleGeneration(session, ctx.conversationId, abort).catch((e) => {
+			if (!abort.signal.aborted) log.error('CEO chat auto-title failed', e);
+		});
+		convo.titling = run;
 		try {
-			await this.runTitleGeneration(session, ctx.conversationId, abort);
-		} catch (e) {
-			log.error('CEO chat auto-title failed', e);
+			await run;
+		} finally {
+			if (convo.titlingAbort === abort) convo.titlingAbort = null;
+			if (convo.titling === run) convo.titling = null;
 		}
 	}
 
@@ -1337,14 +1376,18 @@ export class ChatSessionManager {
 		abort: AbortController,
 	): Promise<void> {
 		const window = await loadActiveWindow(this.deps.db, conversationId);
-		// Only title once there's a real exchange to summarize — at least one assistant
-		// reply with content. A failed/empty/interrupted-empty reply is skipped so a
-		// later successful turn titles the thread (and a failed turn spends no exec here).
-		if (!window.some((m) => m.role === ChatMessageRole.Assistant && m.content.trim() !== '')) {
+		// Title from the first operator message — it's enough to name the topic, and
+		// titling from it (rather than waiting for a settled assistant reply) is what
+		// lets the label update while the reply is still streaming. An empty window
+		// (attachment-only opener with no text, or nothing persisted yet) is skipped so
+		// a later turn with real text titles the thread.
+		if (!window.some((m) => m.role === ChatMessageRole.User && m.content.trim() !== '')) {
 			return;
 		}
 		const prompt = buildTitlePrompt(window.map(chatTranscriptLine).join('\n\n'));
-		const { hostPath, env } = this.turnPrompt(session, conversationId);
+		// A dedicated prompt file (the `title` slot) so this exec can run concurrently
+		// with the reply's exec without either overwriting the other's prompt.
+		const { hostPath, env } = this.turnPrompt(session, conversationId, 'title');
 		mkdirSync(dirname(hostPath), { recursive: true });
 		writeFileSync(hostPath, prompt);
 

--- a/packages/server/test/chat-session.test.ts
+++ b/packages/server/test/chat-session.test.ts
@@ -99,6 +99,57 @@ function makeChatDocker(dataDir: string, projectId: string): ChatDocker {
 	return { docker, prompts, scenario };
 }
 
+/**
+ * Docker stub that routes by prompt type (title exec vs reply exec), so a test can
+ * hold the reply open while the parallel auto-title exec still returns a title. The
+ * reply streams a partial then blocks until aborted; the title exec streams
+ * `titleText` and exits. Used to prove titling doesn't wait for the reply to settle.
+ */
+function makeTitleRoutingDocker(
+	dataDir: string,
+	projectId: string,
+	titleText: string,
+): { docker: ReturnType<typeof createStubDocker>; prompts: string[] } {
+	const prompts: string[] = [];
+	const toHostPath = (containerPath: string) =>
+		join(
+			getWorkspacePath(dataDir, DEFAULT_TEAM_ID, projectId),
+			containerPath.replace(/^\/workspace\//, ''),
+		);
+	const docker = createStubDocker({
+		execCreate: async (_id: string, config: { Env?: string[] }) => {
+			const promptEntry = (config.Env ?? []).find((e) => e.startsWith('HEZO_PROMPT_FILE='));
+			if (!promptEntry) return 'exec-reply';
+			const prompt = readFileSync(
+				toHostPath(promptEntry.slice('HEZO_PROMPT_FILE='.length)),
+				'utf8',
+			);
+			prompts.push(prompt);
+			// The title prompt is buildTitlePrompt's header; everything else is a reply.
+			return prompt.includes('# Name this conversation') ? 'exec-title' : 'exec-reply';
+		},
+		execStart: async (
+			execId: string,
+			opts: { signal?: AbortSignal; onChunk?: (c: ExecLogChunk) => void | Promise<void> },
+		) => {
+			const onChunk = opts.onChunk ?? (() => undefined);
+			if (execId === 'exec-title') {
+				await onChunk({ stream: 'stdout', text: assistantText(titleText) });
+				return { stdout: '', stderr: '' };
+			}
+			// Reply: emit a partial, then block until the turn is interrupted/torn down.
+			await onChunk({ stream: 'stdout', text: assistantText('working on it') });
+			await new Promise<void>((_resolve, reject) => {
+				opts.signal?.addEventListener('abort', () =>
+					reject(new DOMException('Aborted', 'AbortError')),
+				);
+			});
+			return { stdout: '', stderr: '' };
+		},
+	});
+	return { docker, prompts };
+}
+
 function captureCeoRoom(wsManager: WebSocketManager): { events: Array<Record<string, unknown>> } {
 	const events: Array<Record<string, unknown>> = [];
 	const socket: WsSocket = {
@@ -267,9 +318,10 @@ describe('ChatSessionManager', () => {
 		const { manager } = makeManager(ctx, chat.docker);
 
 		await manager.sendTurn({ text: 'whip up a quick demo for me' });
-		await poll(async () => chat.prompts.length >= 1);
+		// The parallel auto-title exec also records a prompt; select the reply turn.
+		await poll(async () => chat.prompts.some(isReplyPrompt));
 
-		const prompt = chat.prompts[0];
+		const prompt = chat.prompts.find(isReplyPrompt) as string;
 		// Persist operator-facing deliverables to an assets library and link them,
 		// instead of dropping a loose /workspace file the operator can't reach.
 		expect(prompt).toContain('write_project_asset');
@@ -289,9 +341,10 @@ describe('ChatSessionManager', () => {
 		const { manager } = makeManager(ctx, chat.docker);
 
 		await manager.sendTurn({ text: 'how does Hezo work?' });
-		await poll(async () => chat.prompts.length >= 1);
+		// The parallel auto-title exec also records a prompt; select the reply turn.
+		await poll(async () => chat.prompts.some(isReplyPrompt));
 
-		const prompt = chat.prompts[0];
+		const prompt = chat.prompts.find(isReplyPrompt) as string;
 		// The live chat resolves embedDocs:true, so the bundled docs are injected
 		// at the CEO prompt's HEZO_DOCS marker — not the inert marker comment.
 		expect(prompt).toContain('# Hezo documentation');
@@ -448,15 +501,15 @@ describe('ChatSessionManager', () => {
 		await manager.stop();
 	});
 
-	test('auto-titles an untitled thread after the first exchange and broadcasts it', async () => {
+	test('auto-titles an untitled thread from the first message and broadcasts it', async () => {
 		const { docker } = makeChatDocker(ctx.dataDir, projectId);
 		const { manager, wsManager } = makeManager(ctx, docker);
 		const captured = captureCeoRoom(wsManager);
 
 		const { conversationId } = await manager.sendTurn({ text: 'Hello CEO' });
 
-		// The reply's own stream sets the title too (the stub replies "Hi there" to both
-		// the turn and the title run); poll until the background auto-title lands.
+		// The title exec streams "Hi there" (the stub replies the same to every exec);
+		// poll until the background auto-title lands.
 		await poll(async () => {
 			const convo = await manager.getConversation(conversationId);
 			return convo?.title != null;
@@ -466,6 +519,38 @@ describe('ChatSessionManager', () => {
 		// The switcher/rail learns about it live via a broadcast.
 		expect(
 			captured.events.some((e) => e.type === 'chat_conversation_updated' && e.title === 'Hi there'),
+		).toBe(true);
+
+		await manager.stop();
+	});
+
+	test('titles a new thread from the first message while the reply is still streaming', async () => {
+		// The reply exec blocks (never completes); only the parallel title exec returns.
+		// If titling still waited for the reply to settle, the thread would stay untitled.
+		const { docker } = makeTitleRoutingDocker(ctx.dataDir, projectId, 'Deploy Pipeline Setup');
+		const { manager, wsManager } = makeManager(ctx, docker);
+		const captured = captureCeoRoom(wsManager);
+
+		const { conversationId, assistantMessageId } = await manager.sendTurn({
+			text: 'How do I set up the deploy pipeline?',
+		});
+
+		await poll(async () => {
+			const convo = await manager.getConversation(conversationId);
+			return convo?.title != null;
+		});
+		const convo = await manager.getConversation(conversationId);
+		expect(convo?.title).toBe('Deploy Pipeline Setup');
+		// The reply is still streaming when the title lands — titling ran in parallel.
+		const reply = await ctx.db.query<{ status: string }>(
+			'SELECT status FROM chat_messages WHERE id = $1',
+			[assistantMessageId],
+		);
+		expect(reply.rows[0].status).toBe(ChatMessageStatus.Streaming);
+		expect(
+			captured.events.some(
+				(e) => e.type === 'chat_conversation_updated' && e.title === 'Deploy Pipeline Setup',
+			),
 		).toBe(true);
 
 		await manager.stop();

--- a/packages/web/src/hooks/use-chat.ts
+++ b/packages/web/src/hooks/use-chat.ts
@@ -86,9 +86,10 @@ export function useChatConversations(active: boolean) {
 		enabled: active,
 	});
 	// A thread's title can change server-side (the CEO auto-titles an untitled thread
-	// after the first exchange). Refetch the list when that lands so the switcher/rail
-	// label updates live. The widget's `useChat` already joins the `chat:global` room
-	// for its lifetime, so the broadcast reaches us without a separate join here.
+	// from its first message, in parallel with the reply — so it can land while the
+	// reply is still streaming). Refetch the list when that broadcast arrives so the
+	// switcher/rail label updates live. The widget's `useChat` already joins the
+	// `chat:global` room for its lifetime, so the broadcast reaches us without a separate join here.
 	useEffect(() => {
 		if (!active) return;
 		return subscribe(WsMessageType.ChatConversationUpdated, () => {


### PR DESCRIPTION
## What & why

A new CEO chat thread is created **untitled** (rendered as the "New thread" placeholder). Until now the title only appeared *after* the first assistant reply fully settled **and** a separate, chained headless title exec ran on top of it. On a slow first reply the thread showed "New thread" for a long time.

This titles the thread **as soon as possible and on-the-go**: title generation is now kicked off the moment the first operator message lands, **in parallel with the reply**, so the switcher/rail label flips from "New thread" while the CEO is still typing.

## Changes

- **Parallel, not chained** — `maybeAutoTitle` runs alongside the reply instead of after it (`sendTurn`); compaction still waits for the reply since it rewrites the window the turn feeds.
- **Title from the first message** — `runTitleGeneration` titles from the first operator message and no longer waits for a settled assistant reply. It runs off its **own prompt file** (the new `title` slot in `turnPrompt`) so its exec never collides with the reply's exec on the shared per-thread prompt file.
- **Per-thread title lifecycle** — a single in-flight title run is tracked on `ConversationRuntime` (`titling` / `titlingAbort`): only one at a time, preempted by a new turn or a thread close, and re-kicked by the next turn while the thread is still untitled. Restart/shutdown abort it too, so no exec outlives teardown.
- Persistence is unchanged and still idempotent (`UPDATE … SET title WHERE title IS NULL`), and it still broadcasts `ChatConversationUpdated` on `chat:global` so open switchers/sidebars refetch live.
- Updated `.dev/architecture.md` (Automatic thread titling) and the frontend timing comment in `use-chat.ts` to match.

## Tests

`packages/server/test/chat-session.test.ts`:
- Renamed/updated: auto-titles an untitled thread **from the first message** and broadcasts it.
- New: **titles a new thread from the first message while the reply is still streaming** — a routing docker stub holds the reply exec open (never completes) while the parallel title exec returns; asserts the title lands and the reply row is still `streaming`, proving titling no longer waits for the reply to settle.
- Fixed two prompt-assertion tests to select the reply prompt (`isReplyPrompt`) now that a parallel title exec also records a prompt.

All 15 chat-session tests plus the chat mirroring/routes/webhooks suites and the web `chat-threads` test pass; `typecheck` and `biome check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018G94ZjHJJNw4h1u9HXV6kv

---
_Generated by [Claude Code](https://claude.ai/code/session_018G94ZjHJJNw4h1u9HXV6kv)_