### PR TITLE
docs(deploy): step-by-step managed Postgres + object storage for cloud deploys

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -34,7 +34,11 @@ managed-container PaaS (Render, Railway, Cloud Run) can't run it.
 `provision.sh` provisions the host, then a `hezo-firstboot` systemd unit derives
 the public HTTPS URL on first boot — `https://<public-ip>.sslip.io` by default (a
 real Let's Encrypt cert, no domain required), or a domain you supply via
-`HEZO_DOMAIN_OVERRIDE`. It never sets the master key: that is generated in the
+`HEZO_DOMAIN_OVERRIDE`. Managed data hosting is wired the same way: seed
+`HEZO_DATABASE_URL` (managed Postgres) and/or `HEZO_ASSET_STORAGE_URL`
+(S3-compatible bucket) into `/etc/hezo/deploy.env` before the script runs (the
+cloud-init has commented lines for it) and they're persisted into the service's
+env file — see `docs/deployment/one-click.md` § Using managed data hosting. It never sets the master key: that is generated in the
 browser on first run and shown once, so the deploy lands you at the setup gate and
 you finish there (master key → admin password → connect a model). Password auth
 makes exposing that URL safe.

--- a/deploy/cloud-init/hezo.cloud-config.yaml
+++ b/deploy/cloud-init/hezo.cloud-config.yaml
@@ -13,6 +13,11 @@
 #
 # OPTIONAL — use your own domain instead of sslip.io: point an A record at the
 # server, then uncomment and edit the HEZO_DOMAIN_OVERRIDE line under runcmd.
+#
+# OPTIONAL — managed data hosting: to keep the database in a managed Postgres
+# and/or asset files in an S3-compatible bucket, uncomment and edit the
+# /etc/hezo/deploy.env lines under runcmd. Step-by-step guide:
+# docs/deployment/one-click.md § Using managed data hosting.
 # ---------------------------------------------------------------------------
 package_update: true
 packages:
@@ -21,5 +26,11 @@ packages:
 runcmd:
   # To use your own domain, set this before the curl line (A record must point here first):
   # - [ sh, -c, "echo 'HEZO_DOMAIN_OVERRIDE=hezo.example.com' >> /etc/environment" ]
+  # To use a managed database and/or object storage for assets, seed the URLs into
+  # /etc/hezo/deploy.env (root-only, mode 600 — not /etc/environment: they carry credentials).
+  # provision.sh persists them into the service's env file:
+  # - [ sh, -c, "install -d -m 700 /etc/hezo && install -m 600 /dev/null /etc/hezo/deploy.env" ]
+  # - [ sh, -c, "echo 'HEZO_DATABASE_URL=postgres://hezo:PASSWORD@db-host:5432/hezo?sslmode=require' >> /etc/hezo/deploy.env" ]
+  # - [ sh, -c, "echo 'HEZO_ASSET_STORAGE_URL=s3://ACCESS_KEY:SECRET@endpoint/bucket' >> /etc/hezo/deploy.env" ]
   - [ sh, -c, "curl -fsSL https://raw.githubusercontent.com/hezo-ai/hezo/main/deploy/provision.sh -o /root/hezo-provision.sh" ]
   - [ sh, -c, "set -a; [ -f /etc/environment ] && . /etc/environment; set +a; bash /root/hezo-provision.sh" ]

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -19,9 +19,18 @@
 # shown once, so it cannot be pre-seeded. After boot, open the printed URL and
 # finish the short setup (create master key, set admin password, connect a model).
 #
-# Optional environment variables:
+# Optional environment variables (set in the shell, or seeded into /etc/hezo/deploy.env
+# by cloud-init before this script runs — see deploy/cloud-init/hezo.cloud-config.yaml):
 #   HEZO_DOMAIN_OVERRIDE   use this domain instead of <public-ip>.sslip.io
 #                          (point an A record at the host first; Caddy gets a cert for it)
+#   HEZO_DATABASE_URL      managed/external Postgres 14+ connection string
+#                          (postgres://user:pass@host:5432/hezo?sslmode=verify-full).
+#                          Persisted into /etc/hezo/hezo.env on first provision; omit to
+#                          use the embedded database on the VM's disk (the default).
+#   HEZO_ASSET_STORAGE_URL S3-compatible object storage for asset files
+#                          (s3://KEY:SECRET@endpoint/bucket[/prefix]). Persisted into
+#                          /etc/hezo/hezo.env on first provision; omit for local disk.
+#   HEZO_DATABASE_POOL_SIZE  connection-pool size for the external database (2-100).
 #   HEZO_RELEASE_TAG       pin a release tag (default: latest)
 #   HEZO_IMAGE_BUILD       set to 1 when baking a machine image (e.g. the DigitalOcean
 #                          Marketplace Packer build). Installs and enables everything but
@@ -40,6 +49,18 @@ DATA_DIR="/var/lib/hezo"
 ENV_FILE="/etc/hezo/hezo.env"
 DEPLOY_ENV="/etc/hezo/deploy.env"
 RELEASE_TAG="${HEZO_RELEASE_TAG:-latest}"
+
+# Cloud-init can seed optional settings (managed database / asset storage, domain
+# override) into deploy.env before this script runs — pick them up. Explicit shell
+# environment still wins over the file.
+if [[ -f "${DEPLOY_ENV}" ]]; then
+	while IFS='=' read -r key value; do
+		[[ "${key}" =~ ^HEZO_[A-Z_]+$ ]] || continue
+		if [[ -z "${!key:-}" ]]; then
+			export "${key}=${value}"
+		fi
+	done <"${DEPLOY_ENV}"
+fi
 
 log() { echo "[hezo-provision] $*"; }
 
@@ -89,6 +110,15 @@ HEZO_DATA_DIR=${DATA_DIR}
 # after each restart by design; unlock it from the browser gate. A copy of the key on disk
 # next to the encrypted data would let anyone who reads this box decrypt your vault.
 EOF
+	# Managed data hosting (optional): persist the database / asset-storage settings
+	# provided at provision time so the systemd unit picks them up. To wire them into
+	# an already-provisioned host, edit this file directly and restart hezo — see
+	# docs/deployment/one-click.md § Using managed data hosting.
+	for key in HEZO_DATABASE_URL HEZO_ASSET_STORAGE_URL HEZO_DATABASE_POOL_SIZE; do
+		if [[ -n "${!key:-}" ]]; then
+			echo "${key}=${!key}" >>"${ENV_FILE}"
+		fi
+	done
 fi
 
 # Persist the optional domain override so the first-boot unit can read it.

--- a/docs/concepts/your-data.md
+++ b/docs/concepts/your-data.md
@@ -26,8 +26,11 @@ for where the data directory lives and how to run Hezo unattended.
 If you'd rather run against a managed or self-run **PostgreSQL 14+** — for managed
 backups, more headroom, or your own operational tooling — point Hezo at it with
 `--database-url` / `HEZO_DATABASE_URL` (see
-[Using an external Postgres](/docs/deployment/configuration)). The data directory is still
-used for workspaces, uploaded assets, and keys; only the database rows move.
+[Using an external Postgres](/docs/deployment/configuration#using-an-external-postgres);
+for a cloud deployment there's a step-by-step in
+[Managed database & asset storage](/docs/deployment/cloud#managed-database--asset-storage)).
+The data directory is still used for workspaces, uploaded assets, and keys; only the
+database rows move.
 
 Uploaded **asset files** work the same way: they live under `<data-dir>/assets/` by
 default, or in any **S3-compatible bucket** when you set `--asset-storage-url` /

--- a/docs/deployment/cloud.md
+++ b/docs/deployment/cloud.md
@@ -19,13 +19,17 @@ DigitalOcean, Hetzner, Fly, Linode, or an EC2 instance.
 
 1. **Provision a host with Docker** and install the `hezo` binary
    ([Installation](/docs/getting-started/installation)).
-2. **Put the data directory on persistent storage** so it survives restarts and
-   redeploys:
+2. **Choose where your data lives.** The data directory goes on persistent storage so
+   it survives restarts and redeploys:
 
    ```sh
    hezo --data-dir /var/lib/hezo
    ```
 
+   By default that directory also holds the embedded database and all asset files. Or
+   hand either to a managed service — a hosted Postgres for the database, an
+   S3-compatible bucket for assets — so your provider handles backups and durability;
+   see [Managed database & asset storage](#managed-database--asset-storage) below.
 3. **Serve it over HTTPS** with a reverse proxy — required, not a nice-to-have; see
    [below](#serve-it-over-https).
 4. **Unlock it from the browser.** After boot Hezo starts **locked** — open its gate
@@ -46,6 +50,47 @@ DigitalOcean, Hetzner, Fly, Linode, or an EC2 instance.
    ```
 
 See the [Configuration reference](/docs/deployment/configuration) for every option.
+
+## Managed database & asset storage
+
+Local disk is the default, not a requirement: point Hezo at a **managed Postgres**
+and/or an **S3-compatible bucket** and the server itself becomes nearly stateless —
+the data directory then holds only workspaces, SSH/signing keys, and pre-migration
+backups. Each backend is one setting, adoptable independently:
+
+1. **Provision a PostgreSQL 14+ instance** in the same region as your server (Hezo's
+   scheduling polls every 1–5 seconds, so latency counts), with TLS and a **direct or
+   session-pooled** connection — transaction-mode poolers (PgBouncer in transaction
+   mode) are not supported. Full requirements:
+   [Using an external Postgres](/docs/deployment/configuration#using-an-external-postgres).
+2. **Provision a private bucket** on any S3-compatible store (AWS S3, Cloudflare R2,
+   DigitalOcean Spaces, Backblaze B2, MinIO, …) with an access key. The bucket stays
+   private — Hezo serves asset bytes through signed URLs. URL grammar and options:
+   [Storing assets in S3-compatible object storage](/docs/deployment/configuration#storing-assets-in-s3-compatible-object-storage).
+3. **Set the URL(s) where your service definition reads its environment** — e.g. the
+   `EnvironmentFile` of your systemd unit (see
+   [Self-hosting](/docs/deployment/self-hosting)), kept root-only (mode 600) since the
+   URLs carry credentials. Prefer the environment variables over the CLI flags — flags
+   are visible in the process list:
+
+   ```sh
+   HEZO_DATABASE_URL="postgres://hezo:••••@db-host:5432/hezo?sslmode=verify-full" \
+   HEZO_ASSET_STORAGE_URL="s3://ACCESS_KEY:SECRET@endpoint/bucket" \
+     hezo --data-dir /var/lib/hezo
+   ```
+
+4. **Verify at startup.** Hezo checks both backends and fails fast with guidance if
+   the database is older than 14 or the bucket is unreachable. The startup log shows
+   `Using external Postgres at …` and `Asset storage: S3-compatible (…)`, and
+   **Settings → General** shows the active **Database** and **Asset storage** backends
+   with credentials occluded.
+
+Provider-specific walkthroughs (DigitalOcean Managed Postgres + Spaces, serverless
+Postgres like Neon or Supabase) are in
+[One-click deploy → Using managed data hosting](/docs/deployment/one-click#using-managed-data-hosting) —
+the steps apply to a manual deployment unchanged. To move an **existing** instance's
+data into managed backends, use `hezo backup` / `hezo restore` — see
+[Switching an existing instance](/docs/deployment/configuration#switching-an-existing-instance).
 
 ## Serve it over HTTPS
 

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -65,7 +65,11 @@ that. See [Master key & encryption](/docs/security/master-key).
 
 By default Hezo embeds its database inside the single binary and stores it under the data
 directory — no external database to run. If you'd rather use a managed/hosted Postgres
-(for managed backups, more headroom, or your own operational tooling), point Hezo at it:
+(for managed backups, more headroom, or your own operational tooling), point Hezo at it
+(this section is the reference; for a walkthrough on a cloud server see
+[Managed database & asset storage](/docs/deployment/cloud#managed-database--asset-storage)
+or, for the cloud-init deploy,
+[Using managed data hosting](/docs/deployment/one-click#using-managed-data-hosting)):
 
 ```sh
 HEZO_DATABASE_URL="postgres://hezo:••••@db.internal:5432/hezo?sslmode=verify-full" \
@@ -103,7 +107,9 @@ Requirements and recommendations:
 By default, uploaded [asset](/docs/concepts/assets) files (task attachments and the
 project assets library) live on the local filesystem under `<data-dir>/assets/`. To keep
 them in a bucket instead — for managed durability, or to keep the host closer to
-stateless — point Hezo at any **S3-compatible** store:
+stateless — point Hezo at any **S3-compatible** store (deployment walkthroughs:
+[Managed database & asset storage](/docs/deployment/cloud#managed-database--asset-storage)
+and [Using managed data hosting](/docs/deployment/one-click#using-managed-data-hosting)):
 
 ```sh
 HEZO_ASSET_STORAGE_URL="s3://ACCESS_KEY:SECRET@s3.eu-west-1.amazonaws.com/my-bucket/hezo-assets?region=eu-west-1" \

--- a/docs/deployment/one-click.md
+++ b/docs/deployment/one-click.md
@@ -75,6 +75,12 @@ runcmd:
   # To use your own domain instead of sslip.io, point an A record at this server, then
   # uncomment the next line and set your domain (do it before the curl line runs):
   # - [ sh, -c, "echo 'HEZO_DOMAIN_OVERRIDE=hezo.example.com' >> /etc/environment" ]
+  # To use a managed database and/or object storage for assets, seed the URLs into
+  # /etc/hezo/deploy.env (root-only, mode 600 — not /etc/environment: they carry credentials).
+  # provision.sh persists them into the service's env file:
+  # - [ sh, -c, "install -d -m 700 /etc/hezo && install -m 600 /dev/null /etc/hezo/deploy.env" ]
+  # - [ sh, -c, "echo 'HEZO_DATABASE_URL=postgres://hezo:PASSWORD@db-host:5432/hezo?sslmode=require' >> /etc/hezo/deploy.env" ]
+  # - [ sh, -c, "echo 'HEZO_ASSET_STORAGE_URL=s3://ACCESS_KEY:SECRET@endpoint/bucket' >> /etc/hezo/deploy.env" ]
   - [ sh, -c, "curl -fsSL https://raw.githubusercontent.com/hezo-ai/hezo/main/deploy/provision.sh -o /root/hezo-provision.sh" ]
   - [ sh, -c, "set -a; [ -f /etc/environment ] && . /etc/environment; set +a; bash /root/hezo-provision.sh" ]
 ```
@@ -94,6 +100,120 @@ read them before you paste if you'd like to see exactly what runs.
 | Vultr | **Additional Features → Enable Cloud-Init User-Data** |
 | Linode | **Add User Data** |
 | AWS Lightsail | **Add launch script** — and also open ports **80** and **443** in the Lightsail firewall (its console firewall is separate from the server's) |
+
+## Using managed data hosting
+
+By default the deploy keeps everything on the server's own disk: the embedded database
+and asset files both live under `/var/lib/hezo`. That's a fine place to start — but you
+can just as well point Hezo at a **managed Postgres** for the database and an
+**S3-compatible bucket** for assets, so your provider handles database backups and
+storage durability and the server itself holds little worth losing. Each one is a single
+URL setting, and you can adopt either independently — managed database with local
+assets, or the other way around.
+
+### 1. Provision the database
+
+Create a managed **PostgreSQL 14 or newer** instance (Hezo checks the version at
+startup), plus a database and user for Hezo, and assemble the connection string:
+
+```
+postgres://hezo:PASSWORD@db-host:5432/hezo?sslmode=require
+```
+
+- **Same region as the server** — Hezo's scheduling polls every 1–5 seconds, so keep
+  round-trip latency low. Same-VPC/private networking is ideal.
+- **Use the direct or session-pooled connection**, never a transaction-mode pooler
+  (PgBouncer in transaction mode breaks the locks Hezo uses to coordinate migrations).
+- **Use TLS** — `sslmode=require` at minimum, `sslmode=verify-full` where your provider
+  supports it.
+
+Full requirements: [Configuration → Using an external
+Postgres](/docs/deployment/configuration#using-an-external-postgres).
+
+### 2. Provision the bucket
+
+Create a **private** bucket on any S3-compatible store (AWS S3, Cloudflare R2,
+DigitalOcean Spaces, Backblaze B2, MinIO, …) and an access key for it, then assemble
+the storage URL:
+
+```
+s3://ACCESS_KEY:SECRET@endpoint/bucket[/prefix]
+```
+
+The bucket never needs to be publicly readable — Hezo serves asset bytes through signed
+URLs. Percent-encode any `/`, `+`, or `@` inside the key or secret. Full URL grammar
+(`region`, `pathStyle`, `tls`): [Configuration → Storing assets in S3-compatible object
+storage](/docs/deployment/configuration#storing-assets-in-s3-compatible-object-storage).
+
+### 3. Wire it into the deploy
+
+**At provision time** — uncomment the `/etc/hezo/deploy.env` lines in the
+[snippet above](#deploy-it) and fill in your URLs before you paste it. The installer
+persists them into the service's environment file and Hezo uses the managed backends
+from its very first boot. One caveat: on most providers, anything in the user-data
+field stays readable later via the instance's metadata service — if you'd rather keep
+the credentials out of user data entirely, deploy without them and use the post-boot
+path instead.
+
+**Post-boot, or on an existing server** — the same two settings go into
+`/etc/hezo/hezo.env` (root-only, mode 600 — the file the systemd unit reads). SSH in
+and:
+
+```sh
+echo 'HEZO_DATABASE_URL=postgres://hezo:PASSWORD@db-host:5432/hezo?sslmode=require' | sudo tee -a /etc/hezo/hezo.env >/dev/null
+echo 'HEZO_ASSET_STORAGE_URL=s3://ACCESS_KEY:SECRET@endpoint/bucket' | sudo tee -a /etc/hezo/hezo.env >/dev/null
+sudo systemctl restart hezo
+```
+
+> **Already have data on the server?** Adding these settings points Hezo at the new
+> backends but does not move existing rows or files. Move them first with
+> `hezo backup` / `hezo restore` — see [Configuration → Switching an existing
+> instance](/docs/deployment/configuration#switching-an-existing-instance).
+
+### 4. Verify
+
+Hezo checks both backends at startup and **fails fast with guidance** if something's
+off — an unreachable bucket, bad credentials, or a Postgres older than 14 stop the
+server rather than silently falling back. Check:
+
+```sh
+sudo journalctl -u hezo | grep -Ei 'postgres|asset storage'
+```
+
+You should see `Using external Postgres at …` and `Asset storage: S3-compatible (…)`.
+In the web app, **Settings → General** shows the active **Database** and **Asset
+storage** backends with credentials occluded.
+
+### DigitalOcean: Managed Postgres + Spaces
+
+The concrete version for a DigitalOcean Droplet deployed with the snippet above:
+
+1. **Database:** create a [Managed PostgreSQL](https://www.digitalocean.com/products/managed-databases)
+   cluster in the **same region** as the Droplet. On the cluster's overview, pick the
+   **direct connection** details (host, port `25060`, user, password, database) — not the
+   **connection pool** (DO's pools default to transaction mode, which Hezo can't use;
+   if you do want a pool, create one in **session** mode). Your URL looks like:
+
+   ```
+   postgres://doadmin:PASSWORD@db-postgresql-fra1-12345-do-user-0.db.ondigitalocean.com:25060/defaultdb?sslmode=require
+   ```
+
+2. **Assets:** create a [Spaces](https://www.digitalocean.com/products/spaces) bucket
+   (keep it private) and a Spaces access key, then:
+
+   ```
+   s3://SPACES_KEY:SPACES_SECRET@fra1.digitaloceanspaces.com/my-hezo-assets?region=fra1
+   ```
+
+3. Wire both in via the snippet or post-boot as above.
+
+### Serverless Postgres (Neon, Supabase, …)
+
+Serverless Postgres providers work too, with the same two rules: keep the database in
+the **same region** as your server, and connect through the **direct or session-pooled**
+endpoint — not a transaction-mode pooler (for Supabase that means the session pooler or
+direct connection, not the transaction pooler; for Neon, the standard connection
+string is fine).
 
 ## How the HTTPS URL works
 
@@ -123,7 +243,10 @@ certificate for that name instead.
   [First-run setup](/docs/getting-started/first-run) and
   [Master key & encryption](/docs/security/master-key).
 - **Backups.** Everything lives in `/var/lib/hezo` — back that one directory up. See
-  [Backup & recovery](/docs/deployment/backup-and-recovery).
+  [Backup & recovery](/docs/deployment/backup-and-recovery). With
+  [managed data hosting](#using-managed-data-hosting) your provider covers database
+  backups and asset durability, but `/var/lib/hezo` still holds workspaces and keys —
+  keep backing it up.
 - **Updates** work as usual: a superuser clicks **Install & restart** in the web app.
   See [Self-hosting → Updating](/docs/deployment/self-hosting#updating).
 

--- a/docs/deployment/self-hosting.md
+++ b/docs/deployment/self-hosting.md
@@ -25,11 +25,16 @@ Everything Hezo keeps lives in one place — the **data directory** (default `~/
 - your **encrypted** secrets and signing keys, and
 - project assets (under `assets/`).
 
-There's no separate database server to run by default (an
-[external Postgres](/docs/deployment/configuration) is optional, as is keeping assets in
-[S3-compatible object storage](/docs/deployment/configuration); the data directory is
-still required for workspaces and keys). Because this directory holds everything, it's
-the one thing to back up — see [Backup & recovery](/docs/deployment/backup-and-recovery).
+There's no separate database server to run by default — but both data stores can be
+handed to managed services: an
+[external Postgres](/docs/deployment/configuration#using-an-external-postgres) for the
+database, and
+[S3-compatible object storage](/docs/deployment/configuration#storing-assets-in-s3-compatible-object-storage)
+for assets (step-by-step:
+[Managed database & asset storage](/docs/deployment/cloud#managed-database--asset-storage)).
+The data directory is still required for workspaces and keys either way. Because this
+directory holds everything by default, it's the one thing to back up — see
+[Backup & recovery](/docs/deployment/backup-and-recovery).
 
 ## Running it
 


### PR DESCRIPTION
## Why

The cloud deployment docs were oriented entirely around the local-disk defaults: the embedded database and `<data-dir>/assets/` were the only path the guides walked through, and managed Postgres / S3-compatible asset storage existed solely as reference material in `configuration.md`. There was no step-by-step from "I have a droplet + a managed Postgres + a bucket" to a running instance — on either the cloud-init or the manual path.

## What changed

**`docs/deployment/one-click.md` — new "Using managed data hosting" section** for the cloud-init path:
- Step-by-step: provision a PG 14+ database (same region, TLS, direct/session-pooled connection only), provision a private bucket + access key, wire both in, verify (startup log lines, fail-fast behavior, Settings → General).
- Two wiring variants: at provision time (seed the URLs into `/etc/hezo/deploy.env` via commented lines in the snippet, with a caveat that user data is often readable via the metadata service) or post-boot (append to `/etc/hezo/hezo.env`, restart — also the retro-fit path for existing servers).
- A concrete **DigitalOcean Managed Postgres + Spaces** walkthrough (direct connection, not the transaction-mode pool) and a **serverless Postgres (Neon/Supabase)** compatibility note.
- Backups bullet now covers the managed-data case (provider handles DB/asset durability; `/var/lib/hezo` still holds workspaces + keys).

**`docs/deployment/cloud.md` — manual path**: the deployment shape now presents the data layer as a choice (local disk or managed backends), plus a "Managed database & asset storage" section with the systemd/`EnvironmentFile` wiring and verification steps, cross-linking the provider walkthroughs.

**`deploy/provision.sh`**: sources `/etc/hezo/deploy.env` at start (explicit shell env wins) and persists `HEZO_DATABASE_URL` / `HEZO_ASSET_STORAGE_URL` / `HEZO_DATABASE_POOL_SIZE` into `/etc/hezo/hezo.env` when creating it, so a cloud-init deploy can use managed backends from first boot. An existing `hezo.env` is never touched (unchanged invariant). `deploy/cloud-init/hezo.cloud-config.yaml` gains matching commented opt-in lines (identical in the docs snippet).

**Cross-links**: `self-hosting.md`, `configuration.md` (reference ↔ walkthrough split), `concepts/your-data.md`, and `deploy/README.md` now point at the step-by-step sections.

## Verification

- `bun run test --skip-browser --pattern docs` — all green (`docs-bundle.test.ts`, `docs-bundle-fs.test.ts` cover the bundle; `docs-bundle.json` is gitignored/build-time, `mcp-api.md` unchanged since no tools were touched).
- `bash -n deploy/provision.sh`, plus a sandbox simulation of the env passthrough across four cases: seeded deploy.env (incl. `=` inside URL values and comment lines), shell env overriding the file, nothing seeded (byte-identical `hezo.env` to today's), and a pre-existing `hezo.env` (untouched).
- The managed-data runcmd lines in `one-click.md` and the cloud-config verified identical.
- Anchor slugs (`#managed-database--asset-storage`) follow the existing docs convention (`#hq--the-home-team`).
- Pre-commit hook ran lint, typecheck, and the full build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JkkbjFinRyDBmDTHrUwGPk

---
_Generated by [Claude Code](https://claude.ai/code/session_01JkkbjFinRyDBmDTHrUwGPk)_