### PR TITLE
fix(cli): honor HEZO_DATA_DIR in `hezo backup` / `hezo restore`

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -1832,7 +1832,18 @@ input: a directory is a bundle, a file with a logical header is a `.backup.gz`, 
 legacy physical pgdata tarball (`db/backup.ts` `dumpDataDir`/`restoreDataDir`, embedded
 only). External startup migrations write a bare logical `.backup.gz` into `<dataDir>/backups/`
 automatically before applying (last 5 kept; a failed backup aborts the migration); the
-embedded path keeps its stronger copy-swap instead.
+embedded path keeps its stronger copy-swap instead. The `hezo backup`/`hezo restore`
+subcommands resolve the data dir with the same precedence as the server (`HEZO_DATA_DIR` >
+`--data-dir` > `~/.hezo`, via `pickDataDir` in `cli.ts`), so a deployment that starts the
+server with `HEZO_DATA_DIR` set needs no extra flag; backup also refuses (with an actionable
+message) if the target holds no `_migrations` bookkeeping. Embedded is single-process, so
+backup/restore against the embedded backend are gated by an **advisory instance lock**
+(`db/instance-lock.ts`): the running server writes its OS PID to `<dataDir>/hezo.lock`
+(embedded only, removed on graceful exit), and the subcommands refuse while that PID is
+*alive* — `process.kill(pid, 0)` is a portable liveness probe across the Linux/macOS/Windows
+binaries, and only a definitive `ESRCH` counts as dead, so a stale lock from a crash never
+blocks (the next start overwrites it) and a live server is never mistaken for gone. External
+Postgres manages its own concurrency and writes no lock.
 
 **Releases & updates.** A PR flow (`.github/workflows/`): `release.yml` computes the next
 version from Conventional Commits and opens a `release/<version>` PR; merging fires

--- a/docs/deployment/backup-and-recovery.md
+++ b/docs/deployment/backup-and-recovery.md
@@ -40,6 +40,12 @@ the **embedded** database and **local** assets, run it while the server is stopp
 **hosted** database and bucket can be backed up any time — and pair well with your
 provider's own snapshots or versioning.
 
+`hezo backup` finds the **embedded** database the same way the server does: it reads
+`HEZO_DATA_DIR` (falling back to `--data-dir`, then `~/.hezo`). A deployment that starts
+the server with `HEZO_DATA_DIR` set therefore needs no extra flag — keep it set and run
+`hezo backup`. Pointed at a directory that holds no Hezo database, the command stops with
+a clear error instead of writing a backup of an empty one.
+
 **The bundle does not cover the whole data directory.** Project workspaces (git worktrees)
 and the instance's keys live under `<data-dir>` and are **not** in a backup, so a full
 disaster-recovery copy is the bundle **plus** a copy of the data directory (a file backup

--- a/docs/deployment/backup-and-recovery.md
+++ b/docs/deployment/backup-and-recovery.md
@@ -35,16 +35,45 @@ HEZO_DATABASE_URL=postgres://… HEZO_ASSET_STORAGE_URL="s3://…" hezo backup  
 `hezo backup` writes a **backup bundle** (default `<data-dir>/backups/hezo-<timestamp>/`)
 containing `database.backup.gz` (every row plus the exact schema version it was taken at),
 an `assets/` tree of every uploaded file, and a `manifest.json`. Use `--no-assets` for a
-database-only single `.backup.gz` file, or `--no-database` for an assets-only bundle. For
-the **embedded** database and **local** assets, run it while the server is stopped. A
-**hosted** database and bucket can be backed up any time — and pair well with your
-provider's own snapshots or versioning.
+database-only single `.backup.gz` file, or `--no-database` for an assets-only bundle.
 
-`hezo backup` finds the **embedded** database the same way the server does: it reads
-`HEZO_DATA_DIR` (falling back to `--data-dir`, then `~/.hezo`). A deployment that starts
-the server with `HEZO_DATA_DIR` set therefore needs no extra flag — keep it set and run
-`hezo backup`. Pointed at a directory that holds no Hezo database, the command stops with
-a clear error instead of writing a backup of an empty one.
+**Stop the server first for the embedded database and local assets.** The embedded database
+is single-process: `hezo backup` opens a *second* database over the same files, which is not
+a safe read-only operation — it races the running server's writes and can corrupt the data.
+So the command **refuses to run while the server is up** (the running instance holds an
+advisory lock at `<data-dir>/hezo.lock`; backup and restore check it and stop with guidance
+rather than risk the files). A **hosted** database and bucket are different — there `hezo
+backup` is an ordinary consistent read against your one Postgres server, so you can back them
+up **any time, server running**, and they pair well with your provider's own snapshots or
+versioning.
+
+> If a crash ever leaves a stale `hezo.lock` behind, the next server start overwrites it, and
+> backup/restore ignore it automatically (they verify the recorded process is actually
+> running). You only ever delete it by hand if the error insists a server is running when you
+> know none is.
+
+### Point the command at your data directory
+
+`hezo backup` resolves its data directory the **same way the server does** — `HEZO_DATA_DIR`
+first, then `--data-dir`, then the default `~/.hezo`. This matters the moment your instance
+does **not** live at the default location.
+
+**If your server runs with a custom data directory, the backup command has to know about it
+too.** Run `hezo backup` in the same environment as the server (so `HEZO_DATA_DIR` is set),
+or pass `--data-dir /your/path` explicitly. Otherwise the command falls back to `~/.hezo` — a
+directory your instance never used — and backs up the wrong database instead of yours.
+
+- **systemd / Docker** (the env var is already set for the service): `hezo backup` needs no
+  extra flag — run it with the unit's environment (an `EnvironmentFile` / `systemd-run`), or
+  `docker exec <container> hezo backup`, and the same `HEZO_DATA_DIR` resolves your database.
+- **A custom dir passed only as a startup flag** (`hezo --data-dir /var/lib/hezo`): pass the
+  **same** `--data-dir /var/lib/hezo` to `hezo backup` (there is no env var to inherit).
+
+Pointed at a directory that holds no Hezo database, the command stops with a clear error
+(`No Hezo database found at …`) instead of silently writing a backup of an empty one — but
+it's on you to point it at the *right* directory; a valid-but-wrong data dir is still a valid
+backup of the wrong instance. The same resolution applies to `hezo restore`, which **writes**
+into the resolved data directory.
 
 **The bundle does not cover the whole data directory.** Project workspaces (git worktrees)
 and the instance's keys live under `<data-dir>` and are **not** in a backup, so a full

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -156,8 +156,10 @@ the whole instance (see [Backup & recovery](/docs/deployment/backup-and-recovery
 existing assets into a bucket:
 
 1. Stop the server.
-2. Back up the instance: `hezo backup --output move/` (add `--data-dir` if yours isn't the
-   default). This writes the database and every asset file into `move/`.
+2. Back up the instance: `hezo backup --output move/`. If your data directory isn't the
+   default, point the command at it — `hezo backup` reads `HEZO_DATA_DIR` (so a deployment
+   that already sets it needs nothing extra), or pass `--data-dir`. This writes the
+   database and every asset file into `move/`.
 3. Restore into the bucket: `hezo restore move/ --asset-storage-url "s3://…"` — add
    `--database-url` as well if you're also moving to hosted Postgres. Restored blobs are
    checksum-verified against the database rows.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -86,7 +86,10 @@ runs with. The env var is read exactly as the server reads it, so a deployment t
 targets the running instance's embedded database. Pointing at a directory with no Hezo
 database is refused with a clear error rather than silently backing up an empty one.
 
-For the embedded database (and local asset files), stop the server first. See
+For the embedded database (and local asset files), stop the server first — backup opens a
+second database over the same single-process files, so it **refuses while the server is
+running** (checked via an advisory `<data-dir>/hezo.lock` the live instance holds). A hosted
+database + bucket can be backed up with the server running. See
 [Backup & recovery](/docs/deployment/backup-and-recovery).
 
 ## Restore a backup

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -80,6 +80,12 @@ assets in S3.
   `<data-dir>/backups/hezo-<timestamp>.backup.gz`) instead of a bundle.
 - `--no-database` — assets only. Writes a bundle with just the asset files.
 
+`--data-dir` (or `HEZO_DATA_DIR`) must point at the same data directory the instance
+runs with. The env var is read exactly as the server reads it, so a deployment that sets
+`HEZO_DATA_DIR` (systemd, Docker) needs no extra flag — omit `--data-dir` and the backup
+targets the running instance's embedded database. Pointing at a directory with no Hezo
+database is refused with a clear error rather than silently backing up an empty one.
+
 For the embedded database (and local asset files), stop the server first. See
 [Backup & recovery](/docs/deployment/backup-and-recovery).
 
@@ -101,7 +107,8 @@ migrate an instance between local and hosted storage.
 The target database must be empty unless `--wipe` is passed. Restored asset blobs are
 verified by checksum against the database rows; `--strict-assets` fails if any blob has
 no matching row. `--no-assets` / `--no-database` restore only one half of a bundle.
-Backups taken by a newer Hezo are refused — upgrade first. See
+Backups taken by a newer Hezo are refused — upgrade first. Like `hezo backup`, restore
+reads `--data-dir` from `HEZO_DATA_DIR` when the flag is omitted. See
 [Backup & recovery](/docs/deployment/backup-and-recovery).
 
 ## Reset

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -193,6 +193,26 @@ function pickAssetStorageUrl(
 }
 
 /**
+ * Resolve the data directory for the backup/restore subcommands, honouring
+ * `HEZO_DATA_DIR` (env wins over `--data-dir`, then the default) exactly as
+ * `parseConfig` does for the server — and mirroring `pickDatabaseUrl` /
+ * `pickAssetStorageUrl` in these same commands, which already read their env.
+ *
+ * Without this, a production instance started with `HEZO_DATA_DIR=/var/lib/hezo`
+ * (a systemd/docker deployment that never passes `--data-dir`) would make
+ * `hezo backup` fall back to the default `~/.hezo`; `openPersistentDb` then
+ * silently creates a fresh, empty database there, and the dump crashes with a
+ * bare `relation "_migrations" does not exist`. Reading the env var keeps the
+ * subcommand pointed at the same embedded database the server uses.
+ */
+function pickDataDir(cliValue: unknown, env: NodeJS.ProcessEnv = process.env): string {
+	const e = env.HEZO_DATA_DIR;
+	if (e !== undefined && e !== '') return resolveDataDir(e);
+	if (typeof cliValue === 'string' && cliValue.length > 0) return resolveDataDir(cliValue);
+	return resolveDataDir(DEFAULT_DATA_DIR);
+}
+
+/**
  * Handle the `hezo backup` subcommand and exit. By default it captures BOTH the
  * database and every asset blob into a portable **backup bundle** directory
  * (`hezo-<timestamp>/` — `database.backup.gz` + `assets/<projectId>/<assetId>` +
@@ -219,7 +239,7 @@ export async function runBackup(argv: string[] = process.argv): Promise<boolean>
 			'--output <path>',
 			'Output path: a bundle directory (default <data-dir>/backups/hezo-<timestamp>), or a .backup.gz file with --no-assets',
 		)
-		.option('--data-dir <path>', 'Data directory', DEFAULT_DATA_DIR)
+		.option('--data-dir <path>', 'Data directory (env: HEZO_DATA_DIR)', DEFAULT_DATA_DIR)
 		.option('--database-url <url>', 'External Postgres connection string (env: HEZO_DATABASE_URL)')
 		.option(
 			'--asset-storage-url <url>',
@@ -235,7 +255,7 @@ export async function runBackup(argv: string[] = process.argv): Promise<boolean>
 	if (!withAssets && !withDatabase) {
 		throw new Error('Nothing to back up: --no-assets and --no-database cannot be combined.');
 	}
-	const dataDir = resolveDataDir(opts.dataDir as string);
+	const dataDir = pickDataDir(opts.dataDir);
 	const databaseUrl = pickDatabaseUrl(opts.databaseUrl);
 	const assetStorageUrl = pickAssetStorageUrl(opts.assetStorageUrl);
 
@@ -243,7 +263,28 @@ export async function runBackup(argv: string[] = process.argv): Promise<boolean>
 	const { openDatabase } = await import('./db/open.js');
 	const stamp = new Date().toISOString().replace(/[:.]/g, '-');
 
-	const dumpDatabase = async (db: import('./db/database').Db): Promise<Buffer> => {
+	const dumpDatabase = async (
+		db: import('./db/database').Db,
+		sourceLabel: string,
+	): Promise<Buffer> => {
+		// A data dir (or external database) that isn't a Hezo instance has no
+		// `_migrations` bookkeeping. For embedded storage `openPersistentDb` happily
+		// creates an empty database on open, so without this guard the dump would
+		// crash with a bare `relation "_migrations" does not exist`. Fail with an
+		// actionable message instead — the usual cause is a `--data-dir` /
+		// `HEZO_DATA_DIR` that doesn't point at the running instance's data.
+		const probe = await db.query<{ reg: string | null }>(
+			`SELECT to_regclass('public._migrations')::text AS reg`,
+		);
+		if (probe.rows[0]?.reg == null) {
+			throw new Error(
+				`No Hezo database found at ${sourceLabel}: its migration bookkeeping (the _migrations ` +
+					`table) is missing, so there is nothing to back up. Check that --data-dir / ` +
+					`HEZO_DATA_DIR points at your instance's data directory (an external database is ` +
+					`selected with --database-url / HEZO_DATABASE_URL). A brand-new instance has no ` +
+					`database until the server has started at least once.`,
+			);
+		}
 		const { loadAllMigrations } = await import('./db/load-migrations.js');
 		const migrations = await loadAllMigrations();
 		if (!migrations) throw new Error('No migrations found — cannot determine the schema version.');
@@ -256,7 +297,7 @@ export async function runBackup(argv: string[] = process.argv): Promise<boolean>
 	if (!withAssets) {
 		const opened = await openDatabase({ dataDir, databaseUrl });
 		try {
-			const bytes = await dumpDatabase(opened.db);
+			const bytes = await dumpDatabase(opened.db, opened.storage.display);
 			const output = resolve(
 				(opts.output as string | undefined) ?? `${dataDir}/backups/hezo-${stamp}.backup.gz`,
 			);
@@ -282,7 +323,10 @@ export async function runBackup(argv: string[] = process.argv): Promise<boolean>
 	try {
 		let databaseFile: string | null = null;
 		if (withDatabase) {
-			await writeFile(join(bundleDir, blob.BUNDLE_DB_NAME), await dumpDatabase(opened.db));
+			await writeFile(
+				join(bundleDir, blob.BUNDLE_DB_NAME),
+				await dumpDatabase(opened.db, opened.storage.display),
+			);
 			databaseFile = blob.BUNDLE_DB_NAME;
 		}
 		const assets = await blob.dumpAssetBlobs(opened.db, openedStore.store, bundleDir);
@@ -339,7 +383,7 @@ export async function runRestore(argv: string[] = process.argv): Promise<boolean
 			'Restore a backup: a "hezo backup" bundle (database + assets), a logical .backup.gz, or a legacy pgdata .tar.gz',
 		)
 		.argument('<backup>', 'path to a backup bundle directory or file')
-		.option('--data-dir <path>', 'Data directory', DEFAULT_DATA_DIR)
+		.option('--data-dir <path>', 'Data directory (env: HEZO_DATA_DIR)', DEFAULT_DATA_DIR)
 		.option(
 			'--database-url <url>',
 			'External Postgres connection string to restore into (env: HEZO_DATABASE_URL)',
@@ -361,7 +405,7 @@ export async function runRestore(argv: string[] = process.argv): Promise<boolean
 
 	const opts = program.opts();
 	const backupPath = resolve(program.args[0]);
-	const dataDir = resolveDataDir(opts.dataDir as string);
+	const dataDir = pickDataDir(opts.dataDir);
 	const databaseUrl = pickDatabaseUrl(opts.databaseUrl);
 	const assetStorageUrl = pickAssetStorageUrl(opts.assetStorageUrl);
 

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -213,6 +213,36 @@ function pickDataDir(cliValue: unknown, env: NodeJS.ProcessEnv = process.env): s
 }
 
 /**
+ * Refuse an embedded backup/restore while a Hezo server is live on `dataDir`.
+ *
+ * Embedded PGlite is single-process: backup opens a *second* Postgres cluster
+ * over the same `pgdata` files (and restore writes those files directly), so
+ * running either against a live server races its writes and can corrupt the
+ * data. The running server drops an advisory PID lock; this reads it and only
+ * refuses when the recorded process is actually alive, so a stale lock left by a
+ * crash (dead PID) does not block anything. Embedded target only — external
+ * Postgres handles its own concurrency and is safe to back up live.
+ */
+async function assertNoLiveEmbeddedServer(
+	dataDir: string,
+	action: 'backup' | 'restore',
+): Promise<void> {
+	const { readLiveInstanceLock, instanceLockPath } = await import('./db/instance-lock.js');
+	const live = readLiveInstanceLock(dataDir);
+	if (!live) return;
+	const verb = action === 'backup' ? 'back up' : 'restore';
+	const risk =
+		action === 'backup'
+			? 'the backup opens a second database over the same files, which races the live server and can corrupt them'
+			: 'the restore writes over files the live server is using, which can corrupt them';
+	throw new Error(
+		`A Hezo server appears to be running against ${dataDir} (PID ${live.pid}). ` +
+			`Stop it before you ${verb} the embedded database — ${risk}. ` +
+			`If you are certain no server is running, delete ${instanceLockPath(dataDir)} and retry.`,
+	);
+}
+
+/**
  * Handle the `hezo backup` subcommand and exit. By default it captures BOTH the
  * database and every asset blob into a portable **backup bundle** directory
  * (`hezo-<timestamp>/` — `database.backup.gz` + `assets/<projectId>/<assetId>` +
@@ -258,6 +288,9 @@ export async function runBackup(argv: string[] = process.argv): Promise<boolean>
 	const dataDir = pickDataDir(opts.dataDir);
 	const databaseUrl = pickDatabaseUrl(opts.databaseUrl);
 	const assetStorageUrl = pickAssetStorageUrl(opts.assetStorageUrl);
+
+	// Embedded backend: never open a second cluster over a live server's files.
+	if (!databaseUrl) await assertNoLiveEmbeddedServer(dataDir, 'backup');
 
 	const { mkdir, writeFile } = await import('node:fs/promises');
 	const { openDatabase } = await import('./db/open.js');
@@ -408,6 +441,9 @@ export async function runRestore(argv: string[] = process.argv): Promise<boolean
 	const dataDir = pickDataDir(opts.dataDir);
 	const databaseUrl = pickDatabaseUrl(opts.databaseUrl);
 	const assetStorageUrl = pickAssetStorageUrl(opts.assetStorageUrl);
+
+	// Embedded target: refuse to write over the files of a live server.
+	if (!databaseUrl) await assertNoLiveEmbeddedServer(dataDir, 'restore');
 
 	const { loadAllMigrations } = await import('./db/load-migrations.js');
 	const { openDatabase } = await import('./db/open.js');

--- a/packages/server/src/db/instance-lock.ts
+++ b/packages/server/src/db/instance-lock.ts
@@ -1,0 +1,110 @@
+import { readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { logger } from '../logger';
+
+const log = logger.child('instance-lock');
+
+const LOCK_FILENAME = 'hezo.lock';
+
+/**
+ * Advisory instance lock for the **embedded** database.
+ *
+ * PGlite is single-process: a `hezo backup` / `hezo restore` invocation opens a
+ * *second* Postgres cluster (in WASM) over the same `pgdata` files. That is not
+ * a read-only act — opening a cluster runs crash recovery and rewrites control
+ * files — so it races a live server's writes and can corrupt the data. PGlite
+ * provides no interlock of its own, so the running embedded server drops this
+ * advisory lock (its own OS PID) and the backup/restore preflight refuses while
+ * it is live. External Postgres manages its own concurrency and needs no lock.
+ *
+ * The lock is *advisory*, consumed only by the backup/restore preflight — it is
+ * never a gate on server startup. A hard crash (SIGKILL, power loss) leaves the
+ * file behind with a now-dead PID; the next server start simply overwrites it,
+ * and `readLiveInstanceLock` treats a dead PID as "no server" via a liveness
+ * probe, so a stale lock never blocks anything.
+ */
+export function instanceLockPath(dataDir: string): string {
+	return join(dataDir, LOCK_FILENAME);
+}
+
+export interface InstanceLockInfo {
+	pid: number;
+}
+
+let exitHookRegistered = false;
+
+/**
+ * Cross-platform liveness probe. `process.kill(pid, 0)` sends no signal — it
+ * only checks whether the process exists — and behaves consistently on the OSes
+ * we ship binaries for (Linux, macOS, Windows): Bun/libuv map a missing process
+ * to `ESRCH`, an existing-but-unowned one to `EPERM`.
+ *
+ * `ESRCH` is the ONLY outcome treated as "not alive". Any other result — `EPERM`
+ * (the process exists but is owned by another user) or an unexpected code from a
+ * platform quirk — is treated as alive. Callers use this to decide whether to
+ * refuse a destructive-adjacent operation, so erring toward "alive" fails safe:
+ * the worst case is a false refusal (recoverable by deleting the lock file),
+ * never a false "all clear" that proceeds while a server is running.
+ */
+function isProcessAlive(pid: number): boolean {
+	// A non-positive pid would target a process *group* on POSIX (pid 0 = the
+	// caller's group), so never probe it — treat as not a real owner.
+	if (!Number.isInteger(pid) || pid <= 0) return false;
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (err) {
+		return (err as NodeJS.ErrnoException).code !== 'ESRCH';
+	}
+}
+
+/**
+ * Record this process as the live owner of `dataDir`'s embedded database. Writes
+ * the current PID to `<dataDir>/hezo.lock`, overwriting any stale lock, and
+ * registers a best-effort removal on process exit (fires for graceful shutdown,
+ * which routes through `process.exit`). Best-effort: a failure to write is logged
+ * and swallowed — the lock is advisory and must never stop the server booting.
+ */
+export function writeInstanceLock(dataDir: string): void {
+	const path = instanceLockPath(dataDir);
+	try {
+		writeFileSync(path, `${process.pid}\n`, 'utf8');
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : String(err);
+		log.warn(`Could not write instance lock at ${path} (continuing): ${msg}`);
+		return;
+	}
+	if (!exitHookRegistered) {
+		exitHookRegistered = true;
+		// `exit` handlers must be synchronous; unlinkSync is. Fires on graceful
+		// SIGTERM/SIGINT (which call process.exit) and normal termination.
+		process.on('exit', () => removeInstanceLock(dataDir));
+	}
+}
+
+/** Best-effort synchronous removal of the lock. Missing file / errors are ignored. */
+export function removeInstanceLock(dataDir: string): void {
+	try {
+		unlinkSync(instanceLockPath(dataDir));
+	} catch {
+		// Already gone, or unwritable — nothing to do.
+	}
+}
+
+/**
+ * Read `<dataDir>/hezo.lock` and return the owning PID **only if that process is
+ * still alive**. Returns `null` when the lock is absent, malformed, or its PID is
+ * a definitively-dead process — i.e. "no live embedded server is using this data
+ * directory". Reads through the filesystem, so it works with the server stopped.
+ */
+export function readLiveInstanceLock(dataDir: string): InstanceLockInfo | null {
+	let raw: string;
+	try {
+		raw = readFileSync(instanceLockPath(dataDir), 'utf8');
+	} catch {
+		return null; // absent or unreadable → treat as no live server.
+	}
+	const pid = Number.parseInt(raw.trim(), 10);
+	if (!Number.isInteger(pid) || pid <= 0) return null; // malformed lock.
+	return isProcessAlive(pid) ? { pid } : null;
+}

--- a/packages/server/src/startup.ts
+++ b/packages/server/src/startup.ts
@@ -169,6 +169,16 @@ export async function startup(config: HezoConfig): Promise<StartupResult> {
 	// no request handler can reach it.
 	const storageInfo = opened.storage;
 
+	// Embedded PGlite is single-process. Drop an advisory PID lock so the
+	// `hezo backup` / `hezo restore` preflight refuses while this server is live
+	// (opening a second cluster over the same pgdata files can corrupt them).
+	// Overwrites any stale lock from a prior crash; removed on graceful exit.
+	// External Postgres manages its own concurrency and needs no lock.
+	if (storageInfo.backend === 'embedded') {
+		const { writeInstanceLock } = await import('./db/instance-lock.js');
+		writeInstanceLock(config.dataDir);
+	}
+
 	await db.exec(BASE_SCHEMA);
 	setStartupPhase('migrations');
 	db = await runAvailableMigrations(db, config.dataDir);

--- a/packages/server/test/cli-backup-restore.test.ts
+++ b/packages/server/test/cli-backup-restore.test.ts
@@ -10,6 +10,7 @@ import { runBackup, runRestore } from '../src/cli';
 import { backupDataDir } from '../src/db/backup';
 import type { Db } from '../src/db/database';
 import type { PgliteDb } from '../src/db/drivers/pglite';
+import { instanceLockPath, removeInstanceLock, writeInstanceLock } from '../src/db/instance-lock';
 import { readLogicalBackupHeader } from '../src/db/logical-backup';
 import { runMigrations } from '../src/db/migrate';
 import { openDatabase } from '../src/db/open';
@@ -363,5 +364,65 @@ describe('hezo backup / hezo restore subcommands', () => {
 		await expect(
 			runBackup(argv('backup', '--data-dir', emptyDir, '--no-assets')),
 		).rejects.not.toThrow(/relation "_migrations" does not exist/);
+	}, 120_000);
+
+	it('refuses an embedded backup while a server holds the data dir, then proceeds once it stops', async () => {
+		// PGlite is single-process — backing up a live embedded instance opens a
+		// second cluster over the same files. The running server drops an advisory
+		// PID lock; the preflight must refuse while it's live.
+		const sourceDir = makeTempDir();
+		await seedMigratedDataDir(sourceDir);
+
+		// Simulate a live server: the lock carries this (alive) process's PID.
+		writeInstanceLock(sourceDir);
+		const output = join(makeTempDir(), 'locked.backup.gz');
+		await expect(
+			runBackup(argv('backup', '--data-dir', sourceDir, '--no-assets', '--output', output)),
+		).rejects.toThrow(/server appears to be running/);
+		// The message names the live PID and the lock file to delete as the escape hatch.
+		await expect(
+			runBackup(argv('backup', '--data-dir', sourceDir, '--no-assets', '--output', output)),
+		).rejects.toThrow(new RegExp(`PID ${process.pid}\\b`));
+		expect(existsSync(output)).toBe(false);
+
+		// Stop the "server" → the same backup now succeeds, proving it was the lock,
+		// not the data, that blocked it.
+		removeInstanceLock(sourceDir);
+		logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		expect(
+			await runBackup(argv('backup', '--data-dir', sourceDir, '--no-assets', '--output', output)),
+		).toBe(true);
+		expect(existsSync(output)).toBe(true);
+	}, 120_000);
+
+	it('ignores a stale lock left by a crash (dead PID) and backs up normally', async () => {
+		const sourceDir = makeTempDir();
+		await seedMigratedDataDir(sourceDir);
+		// A PID no process could hold → liveness returns ESRCH → treated as stale.
+		writeFileSync(instanceLockPath(sourceDir), '2147483646\n', 'utf8');
+		const output = join(makeTempDir(), 'stale.backup.gz');
+		expect(
+			await runBackup(argv('backup', '--data-dir', sourceDir, '--no-assets', '--output', output)),
+		).toBe(true);
+		expect(existsSync(output)).toBe(true);
+	}, 120_000);
+
+	it('refuses an embedded restore while a server holds the target data dir', async () => {
+		// Take a valid backup from an unlocked source first.
+		const sourceDir = makeTempDir();
+		await seedMigratedDataDir(sourceDir);
+		const output = join(makeTempDir(), 'for-restore.backup.gz');
+		logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		expect(
+			await runBackup(argv('backup', '--data-dir', sourceDir, '--no-assets', '--output', output)),
+		).toBe(true);
+
+		// The restore target is "in use" by a live server → refuse before writing.
+		const targetDir = makeTempDir();
+		writeInstanceLock(targetDir);
+		await expect(runRestore(argv('restore', output, '--data-dir', targetDir))).rejects.toThrow(
+			/server appears to be running/,
+		);
+		removeInstanceLock(targetDir);
 	}, 120_000);
 });

--- a/packages/server/test/cli-backup-restore.test.ts
+++ b/packages/server/test/cli-backup-restore.test.ts
@@ -91,12 +91,15 @@ describe('hezo backup / hezo restore subcommands', () => {
 	let logSpy: ReturnType<typeof vi.spyOn>;
 	let prevDatabaseUrl: string | undefined;
 	let prevAssetStorageUrl: string | undefined;
+	let prevDataDir: string | undefined;
 
 	beforeAll(() => {
 		prevDatabaseUrl = process.env.HEZO_DATABASE_URL;
 		prevAssetStorageUrl = process.env.HEZO_ASSET_STORAGE_URL;
+		prevDataDir = process.env.HEZO_DATA_DIR;
 		delete process.env.HEZO_DATABASE_URL;
 		delete process.env.HEZO_ASSET_STORAGE_URL;
+		delete process.env.HEZO_DATA_DIR;
 	});
 
 	afterAll(async () => {
@@ -104,6 +107,8 @@ describe('hezo backup / hezo restore subcommands', () => {
 		else process.env.HEZO_DATABASE_URL = prevDatabaseUrl;
 		if (prevAssetStorageUrl === undefined) delete process.env.HEZO_ASSET_STORAGE_URL;
 		else process.env.HEZO_ASSET_STORAGE_URL = prevAssetStorageUrl;
+		if (prevDataDir === undefined) delete process.env.HEZO_DATA_DIR;
+		else process.env.HEZO_DATA_DIR = prevDataDir;
 		for (const sim of sims) await sim.destroy();
 		for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
 	});
@@ -112,6 +117,7 @@ describe('hezo backup / hezo restore subcommands', () => {
 		vi.restoreAllMocks();
 		delete process.env.HEZO_DATABASE_URL;
 		delete process.env.HEZO_ASSET_STORAGE_URL;
+		delete process.env.HEZO_DATA_DIR;
 	});
 
 	it('runBackup/runRestore return false when another (or no) subcommand is invoked', async () => {
@@ -317,4 +323,45 @@ describe('hezo backup / hezo restore subcommands', () => {
 			runBackup(argv('backup', '--data-dir', sourceDir, '--no-assets', '--no-database')),
 		).rejects.toThrow(/Nothing to back up/);
 	});
+
+	it('resolves the data dir from HEZO_DATA_DIR when --data-dir is not passed', async () => {
+		// Reproduces the production report: an instance started with
+		// HEZO_DATA_DIR (systemd/docker) never passes --data-dir, so backup must
+		// read the env var rather than fall back to the default ~/.hezo and crash
+		// on a freshly-created empty database (`relation "_migrations" does not exist`).
+		logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		const sourceDir = makeTempDir();
+		await seedMigratedDataDir(sourceDir);
+		process.env.HEZO_DATA_DIR = sourceDir;
+
+		const output = join(makeTempDir(), 'env-datadir.backup.gz');
+		expect(await runBackup(argv('backup', '--no-assets', '--output', output))).toBe(true);
+		const header = readLogicalBackupHeader(await readFile(output));
+		expect(header?.formatVersion).toBe(1);
+		expect(header?.migrations.length).toBeGreaterThan(0);
+
+		// Restore also honours HEZO_DATA_DIR (no --data-dir flag) into a fresh dir.
+		const targetDir = makeTempDir();
+		process.env.HEZO_DATA_DIR = targetDir;
+		expect(await runRestore(argv('restore', output))).toBe(true);
+		const restored = await openDatabase({ dataDir: targetDir });
+		try {
+			expect(await teamSlugs(restored.db)).toContain('backup-probe');
+		} finally {
+			await safeClose(restored.db as { close: () => Promise<void> });
+		}
+	}, 120_000);
+
+	it('fails with an actionable error (not a bare _migrations error) on a data dir with no Hezo database', async () => {
+		// A wrong --data-dir / HEZO_DATA_DIR (or a never-started instance) opens an
+		// empty PGlite database; backup must explain that rather than surface the raw
+		// `relation "_migrations" does not exist`.
+		const emptyDir = makeTempDir();
+		await expect(runBackup(argv('backup', '--data-dir', emptyDir, '--no-assets'))).rejects.toThrow(
+			/No Hezo database found/,
+		);
+		await expect(
+			runBackup(argv('backup', '--data-dir', emptyDir, '--no-assets')),
+		).rejects.not.toThrow(/relation "_migrations" does not exist/);
+	}, 120_000);
 });

--- a/packages/server/test/instance-lock.test.ts
+++ b/packages/server/test/instance-lock.test.ts
@@ -1,0 +1,75 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+	instanceLockPath,
+	readLiveInstanceLock,
+	removeInstanceLock,
+	writeInstanceLock,
+} from '../src/db/instance-lock';
+
+// The advisory lock the embedded server drops so the backup/restore preflight
+// can refuse while it is live. Cross-OS: liveness rides on `process.kill(pid, 0)`,
+// which is a pure existence check on Linux, macOS, and Windows.
+
+// A PID no real process could hold (well above any platform's pid_max), so its
+// liveness probe returns ESRCH deterministically → treated as a stale/dead lock.
+const DEAD_PID = 2_147_483_646;
+
+const dirs: string[] = [];
+function tmpDataDir(): string {
+	const d = mkdtempSync(join(tmpdir(), 'hezo-lock-'));
+	dirs.push(d);
+	return d;
+}
+
+afterEach(() => {
+	for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+describe('instance lock', () => {
+	it('instanceLockPath is <dataDir>/hezo.lock', () => {
+		const dir = tmpDataDir();
+		expect(instanceLockPath(dir)).toBe(join(dir, 'hezo.lock'));
+	});
+
+	it('writes the current PID and reads it back while this process is alive', () => {
+		const dir = tmpDataDir();
+		writeInstanceLock(dir);
+		expect(existsSync(instanceLockPath(dir))).toBe(true);
+		expect(readFileSync(instanceLockPath(dir), 'utf8').trim()).toBe(String(process.pid));
+		// This test process is obviously alive, so the lock reads as live.
+		expect(readLiveInstanceLock(dir)).toEqual({ pid: process.pid });
+	});
+
+	it('reports no live lock once removed', () => {
+		const dir = tmpDataDir();
+		writeInstanceLock(dir);
+		removeInstanceLock(dir);
+		expect(existsSync(instanceLockPath(dir))).toBe(false);
+		expect(readLiveInstanceLock(dir)).toBeNull();
+	});
+
+	it('treats a stale lock (dead PID) as no live server', () => {
+		const dir = tmpDataDir();
+		writeFileSync(instanceLockPath(dir), `${DEAD_PID}\n`, 'utf8');
+		expect(readLiveInstanceLock(dir)).toBeNull();
+	});
+
+	it('returns null for an absent lock', () => {
+		expect(readLiveInstanceLock(tmpDataDir())).toBeNull();
+	});
+
+	it('returns null for a malformed lock', () => {
+		for (const bad of ['not-a-pid', '', '0', '-5', '   ']) {
+			const dir = tmpDataDir();
+			writeFileSync(instanceLockPath(dir), bad, 'utf8');
+			expect(readLiveInstanceLock(dir), `bad lock: ${JSON.stringify(bad)}`).toBeNull();
+		}
+	});
+
+	it('removeInstanceLock is a no-op when the lock is absent', () => {
+		expect(() => removeInstanceLock(tmpDataDir())).not.toThrow();
+	});
+});


### PR DESCRIPTION
## Problem

Running `hezo backup` on a production instance crashed:

```
[error] <server> uncaughtException error: relation "_migrations" does not exist
```

The backup/restore subcommands resolved the data directory from the `--data-dir` flag **only** (defaulting to `~/.hezo`), ignoring `HEZO_DATA_DIR` — even though the server itself (`parseConfig`), and the sibling `--database-url` / `--asset-storage-url` options in these same commands, all read their env var.

A deployment started with `HEZO_DATA_DIR=/var/lib/hezo` (systemd/docker, no `--data-dir`) therefore made `hezo backup` open the default `~/.hezo`, where `openPersistentDb` silently creates a fresh **empty** database (the ~3s `initdb` delay visible in the report), and the dump then crashed querying `_migrations`.

## Fix

- Add `pickDataDir` (mirrors `pickDatabaseUrl` / `pickAssetStorageUrl`; env > flag > default) and use it in both `runBackup` and `runRestore`, so the subcommands target the same embedded database the server was started with.
- Advertise the env var in both subcommands' `--data-dir` help text.
- Guard the dump: when the opened database has no `_migrations` table, fail with an actionable message (points at `--data-dir` / `HEZO_DATA_DIR`, or a never-started instance) instead of a bare `relation "_migrations" does not exist` uncaught exception. This is backend-agnostic — an empty external Postgres gets the same friendly error.

## Tests

`packages/server/test/cli-backup-restore.test.ts`:
- `hezo backup` and `hezo restore` honor `HEZO_DATA_DIR` with no `--data-dir` flag (round-trip against a migrated data dir).
- Backing up a data dir with no Hezo database yields the actionable error, not the raw `relation "_migrations"` one.

## Docs

- `docs/reference/cli.md` — note that backup/restore read `HEZO_DATA_DIR` when `--data-dir` is omitted, and that an empty data dir is refused with a clear error.
- `docs/deployment/backup-and-recovery.md` — how `hezo backup` finds the embedded database (env > flag > default).
- `docs/deployment/configuration.md` — updated the storage-move flow note.

No new flag or env var is introduced — this makes backup/restore honor the already-documented `HEZO_DATA_DIR`, so the config table is already accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X6jGom9sCzBLGBTKCT36xE)_