### PR TITLE
docs: accuracy audit + enforced docs-alignment acknowledgment on commits

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,2 @@
 bunx commitlint --edit $1
+bun scripts/check-docs-ack.ts $1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,16 @@ Docs are part of the contract, not an afterthought. **Every code change ships wi
 
 **Verify, don't assume.** The *generated* surfaces have drift tests that fail on mismatch — `packages/server/test/{mcp-reference,llms-txt,docs-bundle}.test.ts` (run them after any tool/route/docs change). Hand-written prose (`docs/**`, `.dev/architecture.md`, the READMEs) has **no** automated guard, so re-read the page(s) describing the area you changed and confirm every concrete claim — flags, defaults, ports, type/enum names, file paths, behaviours — still matches the code you just wrote.
 
+**The acknowledgment is enforced at commit time.** The `commit-msg` hook (`.husky/commit-msg` → `scripts/check-docs-ack.ts`) rejects any commit that stages doc-bearing code — anything under `packages/*/src/`, `packages/*/migrations/`, `agents/`, `skills/`, `docker/`, `deploy/`, `marketplace/`, or `scripts/` — unless the commit message carries a **`Docs-Checked:` trailer** recording the docs-alignment pass you actually did. Write what you checked, not a rubber stamp — bare values (`yes`, `n/a`, `done`, anything under 10 characters) are rejected:
+
+```
+Docs-Checked: updated docs/reference/cli.md + configuration.md for the new --foo flag
+Docs-Checked: verified docs/concepts/tasks.md still matches; no other doc surface affected
+Docs-Checked: internal refactor, no user-visible behaviour or documented surface changed
+```
+
+The trailer must be true — it is the audit record that the pass in this section happened. Never write it without doing the pass, and **never bypass the hook with `--no-verify`**. Docs-only, test-only, merge, revert, and fixup commits are exempt (no trailer needed). The hook's classification rules are unit-tested in `packages/server/test/docs-ack-hook.test.ts`; if you add a new doc-bearing top-level directory, add it to `DOC_BEARING_PATTERNS` in `scripts/check-docs-ack.ts` in the same change.
+
 ## Project / team model (1:1)
 
 Hezo is **project-centric**: a **project** is the primary unit and **owns exactly one team** (its agent roster). The relationship is **1:1** — a team backs exactly one project, enforced by `UNIQUE(projects.team_id)`. In the DB the FK runs `projects.team_id → teams.id`, but conceptually "teams belong to projects." Reach a team *through* its project; all project work is addressed by **project slug** (`/api/projects/:projectId/...`).

--- a/docs/ai-models.md
+++ b/docs/ai-models.md
@@ -22,10 +22,11 @@ and your agents run on the models you choose.
 | **DeepSeek** | DeepSeek | Claude Code | API key |
 | **Z.ai** | GLM | Claude Code | API key |
 
-Each provider is driven through its **native command-line runtime** inside the agent's
-container — so you get each model's first-party agentic tooling, not a lowest-common-
-denominator wrapper. (xAI runs on its own **Grok Build** CLI, on the `grok-4.5` model;
-Kimi runs through Claude Code against Moonshot's Anthropic-compatible endpoint.)
+Each provider is driven through a **first-party agentic command-line runtime** inside the
+agent's container — not a lowest-common-denominator wrapper. Anthropic, OpenAI, Google, and
+xAI each use their own CLI (xAI runs on its **Grok Build** CLI, on the `grok-4.5` model);
+Kimi, DeepSeek, and Z.ai run through Claude Code against their Anthropic-compatible
+endpoints.
 
 ## Local models (on the roadmap)
 

--- a/docs/concepts/projects-and-teams.md
+++ b/docs/concepts/projects-and-teams.md
@@ -133,7 +133,10 @@ the other.
 
 **HQ** is the one special, global team. It's the permanent home of the two roles
 that work across every project — the **CEO** and the **Coach** — and it's where
-instance-level settings live (model providers, shared connections, and the like). HQ is
+meta-level work happens: tasks that don't fit into any particular project run in HQ,
+and the CEO keeps non-project documents and assets there. (Global settings — model
+providers, shared connections, and the like — are not part of HQ; they apply to your
+whole Hezo install and are managed from the global Settings pages.) HQ is
 also where you [chat with the CEO](/docs/concepts/roles-and-coordination#chatting-with-the-ceo):
 when you talk to it to create a new project or check in on any team, you're talking to the
 CEO in HQ. See [Roles & the CEO](/docs/concepts/roles-and-coordination).

--- a/docs/concepts/team-structure.md
+++ b/docs/concepts/team-structure.md
@@ -65,8 +65,9 @@ You drive this in plain language through the
 [CEO chat](/docs/concepts/roles-and-coordination#chatting-with-the-ceo) — "this project
 needs a data analyst", "have QA report to the Architect" — and the CEO proposes the
 change and asks you to approve anything consequential. When a team's roster changes, the
-CEO runs a **coherence review** to re-align the reporting lines and role descriptions
-so the new structure hangs together. Part of that review is checking that every role's
+team's own Captain runs a **coherence review** to re-align the reporting lines and role
+descriptions so the new structure hangs together (the CEO runs this pass only for a
+brand-new team's initial setup, or for a team without a Captain). Part of that review is checking that every role's
 work is still **verified** — reviewed by someone other than the agent who produced it,
 whether by a manager, a dedicated reviewing role, or review steps written into the
 agents' prompts — and closing the gap when it isn't.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -31,7 +31,7 @@ agent can't hurt you. A few guarantees sit underneath everything:
   [Secret protection & egress](/docs/security/secret-protection).
 - **Everything sensitive is encrypted at rest** behind a master key that only you
   hold. See [Master key & encryption](/docs/security/master-key).
-- **Every agent runs in its own container.** A compromised agent is confined to its
+- **Each project's agents run in their own container.** A compromised agent is confined to its
   project's sandbox — it can't reach your host or the rest of your system. See
   [Container isolation](/docs/security/container-isolation).
 - **Agents work in real repos without holding the keys.** Git signing and SSH happen
@@ -53,10 +53,11 @@ agent can't hurt you. A few guarantees sit underneath everything:
   how it went and writes durable lessons back onto the agents, so they get better the more
   they ship — without you hand-tuning prompts. See
   [The Coach & self-improving teams](/docs/concepts/coach-and-self-improving-teams).
-- **Bring your own models, each via its native runtime.** Claude, ChatGPT, Gemini,
-  Grok, DeepSeek, Z.ai, and Kimi are all supported — each driven through its own
-  first-party command-line tooling, not a lowest-common-denominator wrapper — and you can
-  give any individual agent its own model. See [AI model support](/docs/ai-models).
+- **Bring your own models, each via a real agentic runtime.** Claude, ChatGPT, Gemini,
+  Grok, DeepSeek, Z.ai, and Kimi are all supported — Claude, ChatGPT, Gemini, and Grok
+  through their own first-party command-line tooling, and DeepSeek, Z.ai, and Kimi through
+  Claude Code against their Anthropic-compatible endpoints — not a lowest-common-denominator
+  wrapper. You can give any individual agent its own model. See [AI model support](/docs/ai-models).
 - **Put a hard ceiling on spend.** Per-agent and per-project budgets with live cost
   tracking *pause* runs when a limit is hit and *auto-resume* when the window rolls over —
   control without babysitting. See [Budgets & cost control](/docs/concepts/budgets-and-costs).

--- a/docs/mcp/connecting-mcp-servers.md
+++ b/docs/mcp/connecting-mcp-servers.md
@@ -63,10 +63,9 @@ works fine. See [Serve it over HTTPS](/docs/deployment/cloud#serve-it-over-https
 have no callback and no HTTPS requirement.)
 
 If your instance's address changes (for example you move from plain HTTP to HTTPS),
-remove the connector and add it again before reconnecting: the OAuth client Hezo
-registered with the provider is tied to the address it was created on, and a stale
-registration is rejected with a "redirect_uri does not match" error. Re-adding the
-connector registers a fresh client on the current address.
+just press **Connect** on the connector again — Hezo detects that its callback address
+changed and automatically registers a fresh OAuth client with the provider on the
+current address, so you don't have to remove and re-add the connector.
 
 ## REST API connectors
 
@@ -196,10 +195,10 @@ Manage connections two ways:
 Revoking a connector clears its stored token or API key so agents lose access immediately,
 but the connector stays on the page marked **Revoked**. To reconnect, just press **Connect**
 (or **API key**) on it again — Hezo restores the connector in place and runs a fresh
-authorization, so you never have to delete and recreate it. (The exception is an
-instance-address change — see [OAuth connections need an HTTPS address](#oauth-connections-need-an-https-address)
-above — where the OAuth client is tied to the old address and the connector must be removed
-and added again.)
+authorization, so you never have to delete and recreate it. (An instance-address change
+is handled the same way: pressing **Connect** re-registers the OAuth client on the new
+address automatically — see
+[OAuth connections need an HTTPS address](#oauth-connections-need-an-https-address).)
 
 A connector that isn't connected — one still awaiting connection ("Pending connect"),
 failed, or revoked — can instead be dropped outright with **Remove** on its row: it deletes

--- a/docs/security/activity-log.md
+++ b/docs/security/activity-log.md
@@ -53,6 +53,6 @@ There are two scopes:
 ## Why it matters
 
 The activity log makes Hezo's autonomy accountable. Agents act on their own, but every
-action they take — and every secret they use — is on the record, attributed, and impossible
+state-changing action they take is on the record, attributed, and impossible
 to rewrite. When something looks off, you can trace exactly what happened and roll back from
 a position of knowledge.

--- a/docs/security/secret-protection.md
+++ b/docs/security/secret-protection.md
@@ -79,5 +79,5 @@ You're always the one who provides a secret:
 ## Why this matters
 
 The net effect: a buggy, jailbroken, or outright malicious agent **cannot exfiltrate
-your secrets.** It never sees them, it can only use them against hosts you allowed, and
-every use is on the record.
+your secrets.** It never sees them, and it can only use them against the hosts you
+allowed.

--- a/packages/server/test/docs-ack-hook.test.ts
+++ b/packages/server/test/docs-ack-hook.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+// Repo tooling under scripts/ — imported directly (pure functions, no DB/DOM),
+// same pattern as coverage-lcov.test.ts.
+import {
+	checkCommitMessage,
+	docBearingFiles,
+	effectiveMessage,
+	findDocsAckValue,
+	isExemptCommit,
+} from '../../../scripts/check-docs-ack';
+
+const ACK = 'Docs-Checked: verified docs/reference/cli.md still matches the flag set';
+
+describe('docBearingFiles', () => {
+	it('flags source, migrations, agents, skills, docker, deploy, marketplace, and scripts', () => {
+		const files = [
+			'packages/server/src/cli.ts',
+			'packages/server/migrations/017_example.sql',
+			'agents/blank/captain.md',
+			'skills/debugging.md',
+			'docker/Dockerfile.agent-base',
+			'deploy/provision.sh',
+			'marketplace/teams/software-development.json',
+			'scripts/test.ts',
+		];
+		expect(docBearingFiles(files)).toEqual(files);
+	});
+
+	it('exempts docs, tests, CI config, and repo-root prose', () => {
+		expect(
+			docBearingFiles([
+				'docs/concepts/tasks.md',
+				'packages/server/test/tasks.test.ts',
+				'packages/web/test/task-create.test.tsx',
+				'test/browser/task-deep-link-scroll.spec.ts',
+				'.github/workflows/ci.yml',
+				'AGENTS.md',
+				'README.md',
+				'.dev/architecture.md',
+			]),
+		).toEqual([]);
+	});
+});
+
+describe('effectiveMessage / isExemptCommit', () => {
+	it('strips comment lines and scissors content', () => {
+		const raw = [
+			'feat: add thing',
+			'',
+			'# Please enter the commit message',
+			'body line',
+			'# ------------------------ >8 ------------------------',
+			'diff --git a/x b/x',
+		].join('\n');
+		const msg = effectiveMessage(raw);
+		expect(msg).toContain('body line');
+		expect(msg).not.toContain('Please enter');
+		expect(msg).not.toContain('diff --git');
+	});
+
+	it('exempts merge, revert, and fixup commits', () => {
+		expect(isExemptCommit('Merge branch main into feature')).toBe(true);
+		expect(isExemptCommit('Revert "feat: add thing"')).toBe(true);
+		expect(isExemptCommit('fixup! feat: add thing')).toBe(true);
+		expect(isExemptCommit('feat: add thing')).toBe(false);
+	});
+});
+
+describe('findDocsAckValue', () => {
+	it('finds the trailer case-insensitively and trims the value', () => {
+		expect(findDocsAckValue('feat: x\n\ndocs-checked:  updated docs/foo.md  ')).toBe(
+			'updated docs/foo.md',
+		);
+	});
+
+	it('returns null when absent', () => {
+		expect(findDocsAckValue('feat: x\n\nSome body')).toBeNull();
+	});
+});
+
+describe('checkCommitMessage', () => {
+	it('rejects a code commit with no trailer', () => {
+		const r = checkCommitMessage('feat: add flag', ['packages/server/src/cli.ts']);
+		expect(r.ok).toBe(false);
+		expect(r.error).toContain('Docs-Checked');
+	});
+
+	it('rejects bare and too-short acknowledgments', () => {
+		for (const value of ['yes', 'n/a', 'done', 'ok', 'checked!']) {
+			const r = checkCommitMessage(`feat: add flag\n\nDocs-Checked: ${value}`, [
+				'packages/server/src/cli.ts',
+			]);
+			expect(r.ok).toBe(false);
+		}
+	});
+
+	it('accepts a meaningful acknowledgment on a code commit', () => {
+		const r = checkCommitMessage(`feat: add flag\n\n${ACK}`, ['packages/server/src/cli.ts']);
+		expect(r.ok).toBe(true);
+	});
+
+	it('passes docs-only and test-only commits without a trailer', () => {
+		expect(checkCommitMessage('docs: fix typo', ['docs/concepts/tasks.md']).ok).toBe(true);
+		expect(
+			checkCommitMessage('test: cover edge case', ['packages/server/test/tasks.test.ts']).ok,
+		).toBe(true);
+	});
+
+	it('passes merge and revert commits touching code', () => {
+		expect(checkCommitMessage('Merge branch main', ['packages/server/src/cli.ts']).ok).toBe(true);
+		expect(checkCommitMessage('Revert "feat: x"', ['packages/server/src/cli.ts']).ok).toBe(true);
+	});
+});

--- a/scripts/check-docs-ack.ts
+++ b/scripts/check-docs-ack.ts
@@ -1,0 +1,127 @@
+// Commit-msg guard: every commit that touches a doc-bearing surface must carry
+// a `Docs-Checked:` trailer acknowledging the docs-alignment pass (AGENTS.md
+// § Keeping docs in sync with code). Hand-written prose (docs/**, READMEs,
+// .dev/architecture.md) has no drift test, so the acknowledgment is the record
+// that a human or agent actually re-read the affected pages — a commit without
+// it is rejected by .husky/commit-msg.
+//
+// Pure functions here are unit-tested in packages/server/test/docs-ack-hook.test.ts
+// (same pattern as scripts/coverage — no DB/DOM needed).
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+/**
+ * Path prefixes whose changes carry documentation obligations. Tests, CI
+ * config, and the docs themselves are deliberately absent: a docs-only or
+ * test-only commit needs no acknowledgment.
+ */
+export const DOC_BEARING_PATTERNS: RegExp[] = [
+	/^packages\/[^/]+\/src\//,
+	/^packages\/[^/]+\/migrations\//,
+	/^agents\//,
+	/^skills\//,
+	/^docker\//,
+	/^deploy\//,
+	/^marketplace\//,
+	/^scripts\//,
+];
+
+/** Trailer values that name-check the rule without actually acknowledging anything. */
+const BARE_VALUES = new Set([
+	'yes',
+	'y',
+	'no',
+	'n',
+	'true',
+	'ok',
+	'done',
+	'checked',
+	'n/a',
+	'na',
+	'none',
+	'-',
+]);
+
+const MIN_ACK_LENGTH = 10;
+
+export function docBearingFiles(stagedFiles: string[]): string[] {
+	return stagedFiles.filter((f) => DOC_BEARING_PATTERNS.some((p) => p.test(f)));
+}
+
+/** Strip git comment lines and everything below a scissors marker. */
+export function effectiveMessage(rawMessage: string): string {
+	const scissors = rawMessage.indexOf('------------------------ >8 ------------------------');
+	const body = scissors === -1 ? rawMessage : rawMessage.slice(0, scissors);
+	return body
+		.split('\n')
+		.filter((line) => !line.startsWith('#'))
+		.join('\n')
+		.trim();
+}
+
+/** Commits git itself generates (or that get squashed away) are exempt. */
+export function isExemptCommit(message: string): boolean {
+	return /^(Merge |Revert |fixup!|squash!|amend!)/.test(message);
+}
+
+export function findDocsAckValue(message: string): string | null {
+	const match = message.match(/^Docs-Checked:[ \t]*(.*)$/im);
+	return match ? match[1].trim() : null;
+}
+
+export function checkCommitMessage(
+	rawMessage: string,
+	stagedFiles: string[],
+): { ok: boolean; error?: string } {
+	const message = effectiveMessage(rawMessage);
+	if (message.length === 0 || isExemptCommit(message)) return { ok: true };
+
+	const bearing = docBearingFiles(stagedFiles);
+	if (bearing.length === 0) return { ok: true };
+
+	const value = findDocsAckValue(message);
+	if (value === null) {
+		return {
+			ok: false,
+			error:
+				`This commit touches doc-bearing code (${bearing[0]}${bearing.length > 1 ? ` and ${bearing.length - 1} more` : ''}) ` +
+				'but has no Docs-Checked: trailer.',
+		};
+	}
+	if (value.length < MIN_ACK_LENGTH || BARE_VALUES.has(value.toLowerCase())) {
+		return {
+			ok: false,
+			error: `Docs-Checked value "${value}" is not a meaningful acknowledgment — state which docs you updated or verified, or why none apply.`,
+		};
+	}
+	return { ok: true };
+}
+
+function main(): void {
+	const msgFile = process.argv[2];
+	if (!msgFile) {
+		console.error('usage: bun scripts/check-docs-ack.ts <commit-msg-file>');
+		process.exit(2);
+	}
+	const rawMessage = readFileSync(msgFile, 'utf8');
+	const staged = execSync('git diff --cached --name-only', { encoding: 'utf8' })
+		.split('\n')
+		.filter(Boolean);
+
+	const result = checkCommitMessage(rawMessage, staged);
+	if (!result.ok) {
+		console.error(`\ncommit rejected: ${result.error}\n`);
+		console.error(
+			'Every code commit must acknowledge the docs-alignment pass (AGENTS.md § Keeping docs in sync with code).',
+		);
+		console.error('Re-read the docs pages describing what you changed, then add a trailer, e.g.:\n');
+		console.error('  Docs-Checked: updated docs/reference/cli.md for the new --foo flag');
+		console.error(
+			'  Docs-Checked: verified docs/concepts/tasks.md still matches; no other doc surface affected',
+		);
+		console.error('  Docs-Checked: internal refactor, no user-visible behaviour or documented surface changed\n');
+		process.exit(1);
+	}
+}
+
+if (import.meta.main) main();

--- a/scripts/check-docs-ack.ts
+++ b/scripts/check-docs-ack.ts
@@ -114,12 +114,16 @@ function main(): void {
 		console.error(
 			'Every code commit must acknowledge the docs-alignment pass (AGENTS.md § Keeping docs in sync with code).',
 		);
-		console.error('Re-read the docs pages describing what you changed, then add a trailer, e.g.:\n');
+		console.error(
+			'Re-read the docs pages describing what you changed, then add a trailer, e.g.:\n',
+		);
 		console.error('  Docs-Checked: updated docs/reference/cli.md for the new --foo flag');
 		console.error(
 			'  Docs-Checked: verified docs/concepts/tasks.md still matches; no other doc surface affected',
 		);
-		console.error('  Docs-Checked: internal refactor, no user-visible behaviour or documented surface changed\n');
+		console.error(
+			'  Docs-Checked: internal refactor, no user-visible behaviour or documented surface changed\n',
+		);
 		process.exit(1);
 	}
 }


### PR DESCRIPTION
Full accuracy sweep of all 33 pages under `docs/`, verifying every concrete claim (CLI flags, defaults, ports, routes, enums, workflows, security invariants) against the code. Eight inaccuracies found and fixed; everything else verified accurate. Plus: a commit-msg hook that makes the docs-alignment pass an enforced, recorded step so drift can't silently recur.

## Docs fixes

- **`concepts/projects-and-teams.md`** — HQ was described as "where instance-level settings live (model providers, shared connections, and the like)". Those settings are instance-scoped (`routes/ai-providers.ts` has no team scope; connector scoping is per-project or global), not tied to HQ. The page now describes HQ correctly: permanent home of the CEO and Coach, host of meta-level tasks that fit no particular project, and where the CEO keeps non-project documents and assets.
- **`introduction.md`** — "Every agent runs in its own container" → containers are per **project** (all of a project's agents share one, `services/containers.ts`).
- **`introduction.md` + `ai-models.md`** — "each driven through its own first-party command-line tooling" overclaimed: per `PROVIDER_RUNTIME_ADAPTERS`, only Anthropic/OpenAI/Google/xAI use their own CLIs; DeepSeek, Z.ai, and Kimi run through Claude Code against Anthropic-compatible endpoints.
- **`concepts/team-structure.md`** — post-roster-change coherence reviews are run by the team's own **Captain**, not the CEO (`description-tasks.ts` — the CEO only owns initial setup, or teams without a Captain).
- **`security/activity-log.md` + `security/secret-protection.md`** — both claimed every secret use "is on the record"; the egress proxy deliberately writes no per-request audit rows. Claims removed.
- **`mcp/connecting-mcp-servers.md`** (two places) — told users to remove and re-add an OAuth connector after an instance-address change; `routes/oauth.ts` now self-heals this by re-running discovery + DCR, so pressing **Connect** is enough.

## Drift prevention: `Docs-Checked:` commit trailer (enforced)

- New `scripts/check-docs-ack.ts`, wired into `.husky/commit-msg` after commitlint: any commit staging doc-bearing code (`packages/*/src`, `packages/*/migrations`, `agents/`, `skills/`, `docker/`, `deploy/`, `marketplace/`, `scripts/`) is rejected unless the message carries a meaningful `Docs-Checked:` trailer recording the docs-alignment pass. Bare stamps (`yes`, `n/a`, under 10 chars) are rejected; docs-only, test-only, merge, revert, and fixup commits are exempt.
- Classification logic is pure and unit-tested (`packages/server/test/docs-ack-hook.test.ts`, same pattern as the coverage tooling tests).
- AGENTS.md's "Keeping docs in sync with code" section now documents the trailer as the mandatory, truthful record of the pass (and forbids `--no-verify`).

## Verified accurate (no changes)

- **Deployment + CLI reference** — every flag/env var/default in `reference/cli.md` and `deployment/*` matches `cli.ts` flag-by-flag; no master-key persistence advice, no `HEZO_SKIP_DOCKER` leakage.
- **Concepts** — tasks, documents/memory, assets, search, skills, marketplace, budgets/costs, chat channels, meta-harness, your-data all match the shared enums/constants and services.
- **Security** — master-key mechanics, placeholder/egress substitution, `allowed_hosts`, container guardrails, Ed25519 signing/device flow all accurate.
- **`reference/mcp-api.md`** (generated) — not stale: all 72 registered tools match `TOOL_DOC_META` and the committed page exactly.

## CI note

`test-browser (2)` failed on an earlier head (fdacb2f) in `task-deep-link-scroll.spec.ts` — a Virtuoso scroll-position assertion off by 3px. The diff at that point was markdown-only, so this is pre-existing flake, not caused by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PJ7Bi4n1DpU4YVJL7prhrS