### PR TITLE
fix(runtime): never strand in-container process trees; sweep leftovers at boot

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -996,6 +996,56 @@ carries the run's `HEZO_HEARTBEAT_RUN_ID` marker (children inherit it). Best-eff
 its own short timeout, so a kill failure never masks the run result or blocks finalization. This is
 what makes a terminate immediate — in-progress work is lost, as the confirmation dialog promises.
 
+**Process-tree lifecycle & dangling-process cleanup.** The abort-kill above is one instance of a
+system-wide invariant: **every abandonable exec carries a scope marker in its env, and every
+abandonment path reaps by that marker**, because a docker-exec'd process the server merely stops
+attending to would otherwise run in the (deliberately warm-surviving) project container forever.
+`HEZO_HEARTBEAT_RUN_ID=<scopeId>` is the universal marker — the heartbeat run id on the agent CLI
+exec and run-time git prep (`ContainerGitExecutor.forPrep` takes a required `scopeId`), the
+`provision-<hex>` id `withProvisionBridge` mints for provisioning/repo-link/reset git ops, a
+`gitop-<hex>` tag for bridge-less route git ops, an `mcp-install-<hex>` tag on the local-MCP
+`npm install` exec, and the chat `sessionId` on CEO chat execs. Kills are generalized as
+`DockerClient.killProcessesByEnvMarker` (marker-value validated against a shell-safe character
+class before interpolation; `killRunProcesses` is its run-id specialization). The reap points:
+
+- **Per-op timeout / run abort** (`ContainerGitExecutor.exec`): on the timeout or run-signal
+  branch the executor fires a tracked, best-effort marker kill for its scope — a generic docker
+  transport error skips it (container likely gone). The MCP installer does the same when its
+  install timeout fires.
+- **Chat interrupt/preempt**: every chat exec (turn, compaction, titling) additionally carries a
+  per-exec `HEZO_EXEC_SCOPE_ID=<uuid>` and an abort reaps by **that**, never the session id —
+  a session's execs run concurrently across conversations, so a session-wide kill would murder a
+  sibling conversation's live turn. Session-wide reaping by `sessionId` happens only at session
+  teardown (manager stop/restart/health teardown), when everything has already been aborted.
+- **Clean shutdown** (`shutdownRuntime`): before `jobManager.shutdown()` aborts the runs, an
+  awaited `JobManager.killLiveRunProcesses()` reaps every live run's tree (per-kill bounded,
+  whole pass raced against its own timer) — the runner's own abort-kill would race
+  `process.exit`. Chat teardown then reaps its session trees.
+- **Orphan tick**: when the ~30 s orphan detector marks a `running` run whose process vanished as
+  failed, it also fires `killRunProcesses` against the task's project container (task-less runs
+  skipped — the boot sweep is their backstop).
+- **Boot sweep** (crash backstop): `reconcileOnStartup`'s fourth container pass
+  (`sweepDanglingContainerProcesses`) scans each running container's `/proc`
+  (`DockerClient.listHezoProcesses` — emits only pids carrying a marker, an
+  `SSH_AUTH_SOCK=/run/hezo/…` env, or a bridge/socat cmdline) and applies the pure policy in
+  `services/process-sweeper.ts` (`decideSweepKills`): bridge infrastructure
+  (`hezo-run-with-bridge`/`hezo-ssh-bridge`/socat on `/run/hezo/`) always dies; a marker-carrying
+  process dies unless its id is a **succeeded** `heartbeat_runs` row — so a background process a
+  successful run intentionally left (e.g. a dev server on the project's dev port) survives a
+  restart, while failed/cancelled-run trees, previous-lifetime chat sessions, and
+  provision/gitop/mcp-install ops (never succeeded-run rows) die; a marker-less process dies only
+  when bridge-socket-scoped (legacy trees from versions predating the marker). PID 1 and anything
+  younger than 120 s (`SWEEP_MIN_AGE_SECS` — routes are live during reconcile, so a just-started
+  op's marker isn't in the DB yet) are never touched. Kills go through `DockerClient.killPids`
+  (validated pid list). The pass runs after the stranded-run repair (which flips previous-lifetime
+  `running` rows to `failed`), is per-container best-effort, and skips cleanly when Docker is
+  unreachable.
+
+Independently, `hezo-run-with-bridge` itself is hardened (see § SSH signing & git): the exit trap
+kills socat's whole process group, and bounded git ops carry an in-container
+`HEZO_EXEC_DEADLINE_SECS` self-deadline so the tree dies on its own even if the server process is
+gone mid-op.
+
 **Timeout handling (graceful cut).** The `run_timeout_min` timer aborts the run's signal with a
 tagged `'run_timeout'` reason (`JobManager.launchTask`), so the runner finalizes it as `timed_out`
 — distinct from a bare abort (user cancel / shutdown → `cancelled`) and container death
@@ -1331,15 +1381,24 @@ runtime), every git transport — including repo prep (clone/fetch) — reaches 
 the TCP listener via the bridge; nothing on the host runs git.
 
 **Per-run socat bridge.** The agent base image ships `hezo-run-with-bridge` (the runner's
-`argv[0]`): it spawns a `socat UNIX-LISTEN…EXEC:hezo-ssh-bridge` that forwards each
-in-container connection (prefixing the token) to the host TCP listener, then execs the
-agent CLI. The container sees a normal `SSH_AUTH_SOCK` Unix socket and is unaware of the
-relay. The same socket serves both commit signing and `git@github.com:` clone/fetch/push —
-including the per-commit auto-push fired by the durability `post-commit` hook (§ Agent runtime,
-Commit durability), which is why that hook keys off a live `SSH_AUTH_SOCK`.
+`argv[0]`): it spawns a `socat UNIX-LISTEN…EXEC:hezo-ssh-bridge` (under `setsid` where
+available, so the exit trap can `kill -- -<pgid>` the whole socat process group — socat's
+`fork` spawns a bridge child per connection, and killing only the listener would leave a
+blocked child behind) that forwards each in-container connection (prefixing the token) to
+the host TCP listener, then runs the wrapped command. When the server sets
+`HEZO_EXEC_DEADLINE_SECS` (bounded git ops — `ContainerGitExecutor` sets it to the per-op
+timeout plus slack for bridge-wrapped ops), the wrapper runs the command under `timeout`,
+so the tree self-destructs even if the server process died mid-op; the env is ignored by
+older images and absent for the agent CLI run, keeping every old/new image × server
+combination compatible. The container sees a normal `SSH_AUTH_SOCK` Unix socket and is
+unaware of the relay. The same socket serves both commit signing and `git@github.com:`
+clone/fetch/push — including the per-commit auto-push fired by the durability `post-commit`
+hook (§ Agent runtime, Commit durability), which is why that hook keys off a live
+`SSH_AUTH_SOCK`.
 Repo/worktree prep wraps individual git commands with the same `hezo-run-with-bridge` runner;
 cloning outside a run (provision, repo link) allocates a short-lived bridge via
-`withProvisionBridge`.
+`withProvisionBridge`, whose per-op `provision-<hex>` id doubles as the exec scope marker
+(§ Agent execution, Process-tree lifecycle).
 
 **Verified-on-GitHub bootstrap.** On every successful GitHub OAuth connect the project's
 public key is auto-registered on the connecting user's account as **both** a signing key

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,11 +66,12 @@ Docs are part of the contract, not an afterthought. **Every code change ships wi
 
 **Verify, don't assume.** The *generated* surfaces have drift tests that fail on mismatch — `packages/server/test/{mcp-reference,llms-txt,docs-bundle}.test.ts` (run them after any tool/route/docs change). Hand-written prose (`docs/**`, `.dev/architecture.md`, the READMEs) has **no** automated guard, so re-read the page(s) describing the area you changed and confirm every concrete claim — flags, defaults, ports, type/enum names, file paths, behaviours — still matches the code you just wrote.
 
-**The acknowledgment is enforced at commit time.** The `commit-msg` hook (`.husky/commit-msg` → `scripts/check-docs-ack.ts`) rejects any commit that stages doc-bearing code — anything under `packages/*/src/`, `packages/*/migrations/`, `agents/`, `skills/`, `docker/`, `deploy/`, `marketplace/`, or `scripts/` — unless the commit message carries a **`Docs-Checked:` trailer** recording the docs-alignment pass you actually did. Write what you checked, not a rubber stamp — bare values (`yes`, `n/a`, `done`, anything under 10 characters) are rejected:
+**The acknowledgment is enforced at commit time.** The `commit-msg` hook (`.husky/commit-msg` → `scripts/check-docs-ack.ts`) rejects any commit that stages doc-bearing code — anything under `packages/*/src/`, `packages/*/migrations/`, `agents/`, `skills/`, `docker/`, `deploy/`, `marketplace/`, or `scripts/` — unless the commit message carries a **`Docs-Checked:` trailer** recording the docs-alignment pass you actually did. The pass covers **both audiences**: the user-facing `docs/` tree **and** the internal `.dev/` docs — an architecture-altering change must update `.dev/architecture.md` in the same PR, and the trailer is the record that you checked it. Write what you checked, not a rubber stamp — bare values (`yes`, `n/a`, `done`, anything under 10 characters) are rejected:
 
 ```
 Docs-Checked: updated docs/reference/cli.md + configuration.md for the new --foo flag
-Docs-Checked: verified docs/concepts/tasks.md still matches; no other doc surface affected
+Docs-Checked: updated .dev/architecture.md § Agent execution for the new run phase
+Docs-Checked: verified docs/concepts/tasks.md and .dev/architecture.md still match; no other doc surface affected
 Docs-Checked: internal refactor, no user-visible behaviour or documented surface changed
 ```
 

--- a/biome.json
+++ b/biome.json
@@ -64,7 +64,7 @@
 			"!**/docs-bundle.json",
 			"!**/docker-bundle.json",
 			"!**/static-bundle.json",
-			"!marketplace/**",
+			"!marketplace",
 			"!test/test-run-order.json",
 			"!test-results",
 			"!playwright-report",

--- a/docker/scripts/hezo-run-with-bridge
+++ b/docker/scripts/hezo-run-with-bridge
@@ -16,10 +16,22 @@ PORT="${HOST_PORT##*:}"
 
 mkdir -p "$(dirname "$SOCKET")"
 
-socat "UNIX-LISTEN:$SOCKET,fork,reuseaddr,unlink-early,mode=0600,user=$SOCK_USER" \
+# Run socat in its own session (process group) so the exit trap can kill the
+# whole group: socat's `fork` spawns a hezo-ssh-bridge child per connection,
+# and killing only the listener would leave a blocked child (e.g. stuck on a
+# dead host relay) running forever. Fall back to a single-PID kill on images
+# without setsid.
+SETSID=""
+KILL_GROUP=0
+if command -v setsid >/dev/null 2>&1; then SETSID="setsid"; KILL_GROUP=1; fi
+$SETSID socat "UNIX-LISTEN:$SOCKET,fork,reuseaddr,unlink-early,mode=0600,user=$SOCK_USER" \
       "EXEC:/usr/local/bin/hezo-ssh-bridge $TOKEN $HOST $PORT" &
 BRIDGE_PID=$!
-trap 'kill "$BRIDGE_PID" 2>/dev/null' EXIT INT TERM HUP
+if [ "$KILL_GROUP" = 1 ]; then
+    trap 'kill -- "-$BRIDGE_PID" 2>/dev/null' EXIT INT TERM HUP
+else
+    trap 'kill "$BRIDGE_PID" 2>/dev/null' EXIT INT TERM HUP
+fi
 
 i=0
 while [ "$i" -lt 60 ] && [ ! -S "$SOCKET" ]; do
@@ -35,6 +47,20 @@ if [ -n "${HTTPS_PROXY:-}" ]; then
         "$HTTPS_PROXY" "$HTTPS_PROXY" \
         | sudo tee /etc/apt/apt.conf.d/01hezo-proxy >/dev/null
 fi
+
+# Self-deadline: when the server sets HEZO_EXEC_DEADLINE_SECS (bounded ops
+# like git fetch/clone), run the wrapped command under `timeout` so the whole
+# tree dies on its own even if the server process is gone before the op
+# finishes (crash, hard kill). Non-numeric/absent values are ignored, keeping
+# old servers and new images (and vice versa) compatible.
+case "${HEZO_EXEC_DEADLINE_SECS:-}" in
+    ''|*[!0-9]*) ;;
+    *)
+        if command -v timeout >/dev/null 2>&1; then
+            set -- timeout -k 5 "$HEZO_EXEC_DEADLINE_SECS" "$@"
+        fi
+        ;;
+esac
 
 # Deliver the prompt either on stdin (default) or as a trailing arg when
 # HEZO_PROMPT_MODE=arg (OpenCode `run <message>`).

--- a/packages/server/src/routes/repos.ts
+++ b/packages/server/src/routes/repos.ts
@@ -27,7 +27,7 @@ import {
 	resetCloneToOrigin,
 	type WorktreeLoc,
 } from '../services/git';
-import { ContainerGitExecutor } from '../services/git-executor';
+import { ContainerGitExecutor, mintGitOpScopeId } from '../services/git-executor';
 import { createGitHubRepo, parseGitHubUrl, validateRepoAccess } from '../services/github';
 import { getConnection } from '../services/oauth/connection-store';
 import { performRepoSetup } from '../services/repo-provisioning';
@@ -330,7 +330,13 @@ reposRoutes.get('/projects/:projectId/repos/:repoId/git-state', async (c) => {
 
 	const docker = c.get('docker');
 	const runUser = await resolveContainerRunUser(docker, containerId);
-	const executor = ContainerGitExecutor.forPrep(docker, containerId, null, runUser);
+	const executor = ContainerGitExecutor.forPrep(
+		docker,
+		containerId,
+		null,
+		runUser,
+		mintGitOpScopeId(),
+	);
 	const worktreesPath = getWorktreesPath(dataDir, teamId, projectId);
 	const wtPrefix = `${CONTAINER_WORKTREES_ROOT}/`;
 
@@ -492,7 +498,13 @@ reposRoutes.post('/projects/:projectId/repos/:repoId/reset', async (c) => {
 			removed?: string[];
 		}> => {
 			if (action === 'prune_worktrees') {
-				const executor = ContainerGitExecutor.forPrep(docker, containerId, null, runUser);
+				const executor = ContainerGitExecutor.forPrep(
+					docker,
+					containerId,
+					null,
+					runUser,
+					mintGitOpScopeId(),
+				);
 				// Remove worktrees whose task is closed (terminal) or no longer exists —
 				// finished tickets plus leftovers from crashed/interrupted runs. Open
 				// tasks' worktrees are left intact; reset is already 409-gated on active
@@ -520,16 +532,20 @@ reposRoutes.post('/projects/:projectId/repos/:repoId/reset', async (c) => {
 			}
 			// discard_local: the best-effort fetch needs the SSH bridge.
 			const sshAgentServer = c.get('sshAgentServer');
-			const runReset = (bridge: BridgeRunnerArgs | null) =>
+			const runReset = (bridge: BridgeRunnerArgs | null, scopeId: string) =>
 				resetCloneToOrigin(
-					ContainerGitExecutor.forPrep(docker, containerId, bridge, runUser),
+					ContainerGitExecutor.forPrep(docker, containerId, bridge, runUser, scopeId),
 					repo.repoLoc,
 				);
 			return sshAgentServer
-				? withProvisionBridge(sshAgentServer, teamId, dataDir, runUser.name, ({ bridge }) =>
-						runReset(bridge),
+				? withProvisionBridge(
+						sshAgentServer,
+						teamId,
+						dataDir,
+						runUser.name,
+						({ bridge, scopeId }) => runReset(bridge, scopeId),
 					)
-				: runReset(null);
+				: runReset(null, mintGitOpScopeId());
 		},
 	);
 

--- a/packages/server/src/runtime-control.ts
+++ b/packages/server/src/runtime-control.ts
@@ -29,6 +29,13 @@ export function getActiveRuntime(): StartupResult | null {
 export async function shutdownRuntime(result: StartupResult): Promise<void> {
 	if (shuttingDown) return;
 	shuttingDown = true;
+	// Reap live runs' in-container process trees BEFORE aborting them: the abort
+	// path's own kill is fire-and-forget and would race process.exit, stranding
+	// the agent CLIs in the warm containers until the next boot sweep. Bounded
+	// internally so a dead Docker socket can't wedge shutdown.
+	await result.jobManager
+		.killLiveRunProcesses()
+		.catch((err) => log.warn('live-run process reap during shutdown failed', err));
 	result.jobManager.shutdown();
 	await result.chatSessionManager.stop();
 	await result.egressProxy.releaseAll();

--- a/packages/server/src/services/agent-runner.ts
+++ b/packages/server/src/services/agent-runner.ts
@@ -1306,7 +1306,7 @@ export async function runAgent(
 
 			// Progress-update runs only call MCP tools; they need no code worktree.
 			const prep = task
-				? await prepareWorktrees(deps, project, task, bridge, runUser, emit, signal)
+				? await prepareWorktrees(deps, project, task, heartbeatRunId, bridge, runUser, emit, signal)
 				: {
 						workingDir: '/workspace',
 						designatedRepo: null as RepoRow | null,
@@ -1675,6 +1675,7 @@ async function prepareWorktrees(
 	deps: RunnerDeps,
 	project: ProjectInfo,
 	task: TaskInfo,
+	heartbeatRunId: string,
 	bridge: BridgeRunnerArgs | null,
 	runUser: ContainerRunUser,
 	emit: (stream: 'stdout' | 'stderr', text: string) => void,
@@ -1709,11 +1710,15 @@ async function prepareWorktrees(
 			projectId: project.id,
 			teamId: project.team_id,
 		});
+		// The run id doubles as the exec scope marker so an abandoned prep op's
+		// git/ssh/bridge tree stays killable; the agent CLI hasn't started yet, so
+		// a prep-abort marker kill can only hit prep's own processes.
 		const executor = ContainerGitExecutor.forPrep(
 			deps.docker,
 			project.container_id,
 			bridge,
 			runUser,
+			heartbeatRunId,
 			gitIdentityEnv,
 			signal,
 		);

--- a/packages/server/src/services/chat-session-manager.ts
+++ b/packages/server/src/services/chat-session-manager.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 import {
@@ -1115,6 +1116,12 @@ export class ChatSessionManager {
 		const { conversationId } = ctx;
 		const convo = this.getConvoRuntime(conversationId);
 		const { hostPath, env } = this.turnPrompt(session, conversationId);
+		// Per-exec scope marker: session-level HEZO_HEARTBEAT_RUN_ID is shared by
+		// every exec of this session (turns in other conversations, compaction,
+		// titling), so an interrupt must kill by a marker unique to THIS exec or it
+		// would murder a sibling conversation's live reply.
+		const execScopeId = randomUUID();
+		env.push(`HEZO_EXEC_SCOPE_ID=${execScopeId}`);
 		const accumulated = { text: '' };
 		let finalized = false;
 		const finalize = async (
@@ -1180,6 +1187,9 @@ export class ChatSessionManager {
 			await finalize(ChatMessageStatus.Complete, parser.getUsage());
 		} catch (err) {
 			if (abort.signal.aborted) {
+				// Aborting only tears down the attach stream — reap the abandoned
+				// in-container CLI by this exec's own scope marker.
+				this.killAbandonedExec(session, execScopeId);
 				await finalize(ChatMessageStatus.Interrupted, null);
 			} else {
 				log.error('CEO chat turn failed', err);
@@ -1189,6 +1199,19 @@ export class ChatSessionManager {
 			rmSync(hostPath, { force: true });
 			if (convo.current?.assistantMessageId === assistantMessageId) convo.current = null;
 		}
+	}
+
+	/**
+	 * Best-effort fire-and-forget kill of one abandoned chat exec's process tree
+	 * by its per-exec scope marker. Docker can't signal an exec'd process, so an
+	 * interrupted/preempted exec would otherwise keep running in the HQ container.
+	 */
+	private killAbandonedExec(session: LiveSession, execScopeId: string): void {
+		trackBackground(
+			this.deps.docker
+				.killProcessesByEnvMarker(session.containerId, 'HEZO_EXEC_SCOPE_ID', execScopeId)
+				.catch(() => undefined),
+		);
 	}
 
 	private async composePrompt(session: LiveSession, conversationId: string): Promise<string> {
@@ -1285,6 +1308,8 @@ export class ChatSessionManager {
 		const before = memory?.updated_at ?? null;
 		const prompt = buildCompactionPrompt(memory?.content ?? '', flush.windowTranscript);
 		const { hostPath, env } = this.turnPrompt(session, conversationId);
+		const execScopeId = randomUUID();
+		env.push(`HEZO_EXEC_SCOPE_ID=${execScopeId}`);
 		mkdirSync(dirname(hostPath), { recursive: true });
 		writeFileSync(hostPath, prompt);
 		try {
@@ -1302,7 +1327,10 @@ export class ChatSessionManager {
 		} catch (e) {
 			// A new user turn preempts compaction — that's a clean stop, not a
 			// failure; nothing is evicted and it retries later.
-			if (abort.signal.aborted) return;
+			if (abort.signal.aborted) {
+				this.killAbandonedExec(session, execScopeId);
+				return;
+			}
 			throw e;
 		} finally {
 			rmSync(hostPath, { force: true });
@@ -1388,6 +1416,8 @@ export class ChatSessionManager {
 		// A dedicated prompt file (the `title` slot) so this exec can run concurrently
 		// with the reply's exec without either overwriting the other's prompt.
 		const { hostPath, env } = this.turnPrompt(session, conversationId, 'title');
+		const execScopeId = randomUUID();
+		env.push(`HEZO_EXEC_SCOPE_ID=${execScopeId}`);
 		mkdirSync(dirname(hostPath), { recursive: true });
 		writeFileSync(hostPath, prompt);
 
@@ -1413,7 +1443,10 @@ export class ChatSessionManager {
 			for (const ev of parser.flush()) if (ev.text) text += ev.text;
 		} catch (e) {
 			// A new user turn preempts title generation — a clean stop, retried later.
-			if (abort.signal.aborted) return;
+			if (abort.signal.aborted) {
+				this.killAbandonedExec(session, execScopeId);
+				return;
+			}
 			throw e;
 		} finally {
 			rmSync(hostPath, { force: true });
@@ -1458,6 +1491,14 @@ export class ChatSessionManager {
 		const live = this.live;
 		if (!live) return;
 		this.live = null;
+		// Session-wide reap: every exec of this session (and its children) carries
+		// HEZO_HEARTBEAT_RUN_ID=<sessionId>, and by teardown they have all been
+		// aborted — nothing live shares the marker, so the broad kill is safe here
+		// (unlike per-turn interrupts, which must use the per-exec scope id).
+		// Bounded + best-effort: a stopped/gone container just fails the exec.
+		await this.deps.docker
+			.killProcessesByEnvMarker(live.containerId, 'HEZO_HEARTBEAT_RUN_ID', live.sessionId)
+			.catch(() => undefined);
 		await live.releaseSsh().catch(() => undefined);
 		await live.releaseEgress().catch(() => undefined);
 		await this.deps.db

--- a/packages/server/src/services/containers.ts
+++ b/packages/server/src/services/containers.ts
@@ -28,7 +28,7 @@ import {
 } from './container-user';
 import type { DockerClient } from './docker';
 import { ensureImage } from './ensure-image';
-import { ContainerGitExecutor } from './git-executor';
+import { ContainerGitExecutor, mintGitOpScopeId } from './git-executor';
 import { resolveAgentBaseImage } from './image-registry';
 import type { LogStreamBroker } from './log-stream-broker';
 import { ensureProjectRepos } from './repo-sync';
@@ -487,12 +487,12 @@ export async function provisionContainer(
 			// needs a bridge back to the host ssh-agent — provisioning isn't a run, so
 			// allocate a short-lived one. No agent → no bridge → clone fails and is
 			// reported (same as a missing key today).
-			const syncRepos = (bridge: BridgeRunnerArgs | null) =>
+			const syncRepos = (bridge: BridgeRunnerArgs | null, scopeId: string) =>
 				ensureProjectRepos(
 					db,
 					{ id: project.id, team_id: teamId },
 					dataDir,
-					ContainerGitExecutor.forPrep(docker, Id, bridge, runUser),
+					ContainerGitExecutor.forPrep(docker, Id, bridge, runUser, scopeId),
 					(stream, text) => emit(stream, text),
 				);
 			const syncRes = deps.sshAgentServer
@@ -501,9 +501,9 @@ export async function provisionContainer(
 						teamId,
 						dataDir,
 						runUser.name,
-						({ bridge }) => syncRepos(bridge),
+						({ bridge, scopeId }) => syncRepos(bridge, scopeId),
 					)
-				: await syncRepos(null);
+				: await syncRepos(null, mintGitOpScopeId());
 			if (syncRes.failed.length > 0) {
 				emit(
 					'stderr',

--- a/packages/server/src/services/docker.ts
+++ b/packages/server/src/services/docker.ts
@@ -25,6 +25,20 @@ const DOCKER_REQUEST_TIMEOUT_MS = (() => {
  */
 const KILL_EXEC_TIMEOUT_MS = 5_000;
 
+/**
+ * Upper bound on the boot sweep's `/proc` scan exec (`listHezoProcesses`).
+ * Wider than the kill bound — the scan walks every pid — but still short enough
+ * that a wedged daemon can't stall startup reconciliation.
+ */
+const SWEEP_EXEC_TIMEOUT_MS = 10_000;
+
+/**
+ * Every env-marker value interpolated into an in-container `sh -c` script must
+ * match this — UUIDs and `<kind>-<hex>` scope ids do; anything shell-active
+ * (quotes, spaces, `$`, backticks) is rejected before it reaches the shell.
+ */
+const ENV_MARKER_VALUE_RE = /^[0-9a-zA-Z_-]{1,64}$/;
+
 interface ContainerConfig {
 	Image: string;
 	Cmd?: string[];
@@ -497,12 +511,12 @@ export class DockerClient {
 
 	/**
 	 * Hard-kill every process inside `containerId` whose environment carries
-	 * `HEZO_HEARTBEAT_RUN_ID=<runId>` — the marker every agent-run exec sets and
-	 * all its children inherit. Docker exposes no API to signal an exec'd process,
-	 * and disconnecting from the exec attach stream (what an abort does) leaves it
-	 * running: the agent CLI keeps burning tokens and writing to the workspace
-	 * even though the run is marked cancelled. This is the only way to actually
-	 * stop a terminated or timed-out run's process tree.
+	 * `<name>=<value>` — the scope marker an exec sets and all its children
+	 * inherit. Docker exposes no API to signal an exec'd process, and
+	 * disconnecting from the exec attach stream (what an abort does) leaves it
+	 * running: the process keeps burning tokens / holding sockets / writing to
+	 * the workspace even though its exec was abandoned. This is the only way to
+	 * actually stop an abandoned exec's process tree.
 	 *
 	 * The kill exec runs as the container's default user (root — no `User`), so it
 	 * can signal the deprivileged run-user's processes, and scans each process's
@@ -510,11 +524,19 @@ export class DockerClient {
 	 * timeout so a wedged kill can never block run finalization. Best-effort: the
 	 * caller swallows failures (a dead/gone container simply can't be exec'd).
 	 */
-	async killRunProcesses(containerId: string, runId: string): Promise<void> {
-		// runId is a DB UUID (`[0-9a-f-]`), so it needs no shell escaping inside the
+	async killProcessesByEnvMarker(
+		containerId: string,
+		name: 'HEZO_HEARTBEAT_RUN_ID' | 'HEZO_EXEC_SCOPE_ID',
+		value: string,
+	): Promise<void> {
+		// Scope-id values are UUIDs or `<kind>-<hex>` tags. The character-class
+		// check guarantees the value needs no shell escaping inside the
 		// double-quoted grep pattern below — no metacharacters, word-splitting, or
 		// expansion is possible.
-		const marker = `HEZO_HEARTBEAT_RUN_ID=${runId}`;
+		if (!ENV_MARKER_VALUE_RE.test(value)) {
+			throw new Error(`unsafe env marker value: ${JSON.stringify(value)}`);
+		}
+		const marker = `${name}=${value}`;
 		// `/proc/<pid>/environ` is NUL-separated; `basename $(dirname …)` recovers the
 		// pid without relying on `${…}` shell parameter expansion (a JS-template
 		// look-alike). `|| true` keeps a since-exited pid from failing the loop.
@@ -536,6 +558,127 @@ export class DockerClient {
 			clearTimeout(timer);
 		}
 	}
+
+	/** Kill every process carrying `HEZO_HEARTBEAT_RUN_ID=<runId>` — the marker every agent-run exec sets. */
+	async killRunProcesses(containerId: string, runId: string): Promise<void> {
+		return this.killProcessesByEnvMarker(containerId, 'HEZO_HEARTBEAT_RUN_ID', runId);
+	}
+
+	/**
+	 * Scan `/proc` inside `containerId` for Hezo-related processes: anything
+	 * carrying a `HEZO_HEARTBEAT_RUN_ID` scope marker, anything whose env carries
+	 * an in-container SSH-bridge socket (`SSH_AUTH_SOCK=/run/hezo/…` — legacy git
+	 * execs predating the scope marker), and anything whose cmdline names the
+	 * bridge binaries or a `/run/hezo/` socket. Only matching pids are emitted,
+	 * so output stays tiny even under a high PidsLimit. Runs as root (same
+	 * rationale as the kill above) and is bounded by its own timeout. Feeds the
+	 * boot-time dangling-process sweep (`process-sweeper.ts`).
+	 */
+	async listHezoProcesses(containerId: string): Promise<ContainerProcessInfo[]> {
+		// Age derives from /proc/uptime minus stat field 22 (starttime, in clock
+		// ticks). The stat line's second field (comm) may contain spaces or
+		// parentheses, so everything up to the *last* `) ` is stripped first —
+		// after that, starttime is field 20 of the remainder.
+		const script =
+			'up=$(cut -d. -f1 /proc/uptime); hz=$(getconf CLK_TCK 2>/dev/null || echo 100); ' +
+			'for d in /proc/[0-9]*; do ' +
+			'pid=${d#/proc/}; ' +
+			'rid=$(tr "\\0" "\\n" < "$d/environ" 2>/dev/null | sed -n "s/^HEZO_HEARTBEAT_RUN_ID=//p" | head -n1); ' +
+			'sock=0; grep -qz "SSH_AUTH_SOCK=/run/hezo/" "$d/environ" 2>/dev/null && sock=1; ' +
+			'cmd=$(tr "\\0" " " < "$d/cmdline" 2>/dev/null); ' +
+			'st=$(sed "s/^.*) //" "$d/stat" 2>/dev/null | cut -d" " -f20); ' +
+			'age=$(( up - ${st:-0} / hz )); ' +
+			'case "$cmd" in *hezo-run-with-bridge*|*hezo-ssh-bridge*|*/run/hezo/*) hit=1;; *) hit=0;; esac; ' +
+			'if [ -n "$rid" ] || [ "$sock" = 1 ] || [ "$hit" = 1 ]; then ' +
+			'printf "%s\\t%s\\t%s\\t%s\\t%s\\n" "$pid" "$rid" "$sock" "$age" "$cmd"; ' +
+			'fi; ' +
+			'done';
+		const execId = await this.execCreate(containerId, {
+			Cmd: ['sh', '-c', script],
+			AttachStdout: true,
+			AttachStderr: false,
+		});
+		const ac = new AbortController();
+		const timer = setTimeout(() => ac.abort(), SWEEP_EXEC_TIMEOUT_MS);
+		let stdout: string;
+		try {
+			({ stdout } = await this.execStart(execId, { signal: ac.signal }));
+		} finally {
+			clearTimeout(timer);
+		}
+		return parseHezoProcessList(stdout);
+	}
+
+	/**
+	 * SIGKILL an explicit pid list inside `containerId`. Companion to
+	 * `listHezoProcesses` — the boot sweep decides server-side (it needs the DB)
+	 * and kills by pid. Validates every pid so nothing unexpected reaches the
+	 * shell; a no-op on an empty list. Best-effort, bounded like the marker kill.
+	 */
+	async killPids(containerId: string, pids: number[]): Promise<void> {
+		if (pids.length === 0) return;
+		for (const pid of pids) {
+			if (!Number.isInteger(pid) || pid <= 1) {
+				throw new Error(`unsafe pid: ${JSON.stringify(pid)}`);
+			}
+		}
+		// Validated positive integers only — safe to interpolate. `|| true` keeps
+		// an already-exited pid from failing the exec.
+		const script = `kill -9 ${pids.join(' ')} 2>/dev/null || true`;
+		const execId = await this.execCreate(containerId, {
+			Cmd: ['sh', '-c', script],
+			AttachStdout: false,
+			AttachStderr: false,
+		});
+		const ac = new AbortController();
+		const timer = setTimeout(() => ac.abort(), KILL_EXEC_TIMEOUT_MS);
+		try {
+			await this.execStart(execId, { signal: ac.signal });
+		} finally {
+			clearTimeout(timer);
+		}
+	}
+}
+
+/** One matching process from `listHezoProcesses`'s in-container `/proc` scan. */
+export interface ContainerProcessInfo {
+	pid: number;
+	/** Value of `HEZO_HEARTBEAT_RUN_ID` in the process env, or null when absent. */
+	runId: string | null;
+	/** Whether the process env carries `SSH_AUTH_SOCK=/run/hezo/…` (legacy bridge-scoped exec). */
+	hasHezoSock: boolean;
+	/** Seconds since the process started, floored. */
+	ageSecs: number;
+	/** NUL-joined cmdline rendered with spaces; empty for kernel threads. */
+	cmdline: string;
+}
+
+/**
+ * Parse the tab-separated `listHezoProcesses` scan output. The cmdline is the
+ * trailing field and may itself contain tabs, so only the first four tabs
+ * split; malformed lines (a pid that exited mid-scan can emit partial output)
+ * are dropped.
+ */
+export function parseHezoProcessList(stdout: string): ContainerProcessInfo[] {
+	const procs: ContainerProcessInfo[] = [];
+	for (const line of stdout.split('\n')) {
+		if (line.length === 0) continue;
+		const parts = line.split('\t');
+		if (parts.length < 5) continue;
+		const [pidRaw, runIdRaw, sockRaw, ageRaw] = parts;
+		const cmdline = parts.slice(4).join('\t');
+		const pid = Number.parseInt(pidRaw, 10);
+		const ageSecs = Number.parseInt(ageRaw, 10);
+		if (!Number.isInteger(pid) || pid <= 0 || !Number.isInteger(ageSecs)) continue;
+		procs.push({
+			pid,
+			runId: runIdRaw.length > 0 ? runIdRaw : null,
+			hasHezoSock: sockRaw === '1',
+			ageSecs: Math.max(0, ageSecs),
+			cmdline,
+		});
+	}
+	return procs;
 }
 
 function demuxDockerStream(raw: Uint8Array): { stdout: string; stderr: string } {

--- a/packages/server/src/services/fake-docker.ts
+++ b/packages/server/src/services/fake-docker.ts
@@ -102,6 +102,11 @@ export function createFakeDockerClient(db?: Db): DockerClient {
 		},
 		execInspect: async () => ({ ExitCode: 0, Running: false, Pid: 0 }),
 		killRunProcesses: async () => {},
+		killProcessesByEnvMarker: async () => {},
+		// Empty scan = the startup dangling-process sweep is a clean no-op in
+		// every HEZO_SKIP_DOCKER harness.
+		listHezoProcesses: async () => [],
+		killPids: async () => {},
 	};
 	return stub as unknown as DockerClient;
 }

--- a/packages/server/src/services/git-executor.ts
+++ b/packages/server/src/services/git-executor.ts
@@ -1,4 +1,6 @@
 import { execFile } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
+import { trackBackground } from '../lib/background';
 import type { ContainerRunUser } from './container-user';
 import type { DockerClient } from './docker';
 import { type BridgeRunnerArgs, buildBridgeRunnerArgv } from './ssh-agent';
@@ -13,6 +15,15 @@ import { type BridgeRunnerArgs, buildBridgeRunnerArgv } from './ssh-agent';
  */
 export const GIT_SSH_COMMAND_VALUE =
 	'ssh -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=10 -o ServerAliveCountMax=3';
+
+/**
+ * Mint a scope id for container git ops that run outside an agent run or a
+ * provision bridge (whose ids are reused as scope ids). Shell-safe by
+ * construction (`[0-9a-f]` hex under a fixed prefix).
+ */
+export function mintGitOpScopeId(): string {
+	return `gitop-${randomBytes(8).toString('hex')}`;
+}
 
 /** Merge a run's abort signal with a per-op timeout signal (either may be absent). */
 function combineAbortSignals(...signals: Array<AbortSignal | undefined>): AbortSignal | undefined {
@@ -84,6 +95,16 @@ export interface ContainerGitExecutorOptions {
 	bridge?: BridgeRunnerArgs | null;
 	/** The container user every git exec runs as (detected, not assumed `node`). */
 	runUser: ContainerRunUser;
+	/**
+	 * Scope id stamped into every exec's env as `HEZO_HEARTBEAT_RUN_ID` so an
+	 * abandoned exec's whole process tree (git, ssh, the bridge wrapper and its
+	 * socat children) stays killable: the heartbeat run id during run prep, a
+	 * `provision-<hex>`/`gitop-<hex>` tag elsewhere. On a per-op timeout or an
+	 * aborted run signal the executor fires a best-effort marker kill — Docker
+	 * can't signal an exec'd process, so tearing down the attach stream alone
+	 * would strand the tree in the container.
+	 */
+	scopeId: string;
 	/** The run's abort signal, so a cancel / run-timeout interrupts an in-flight exec. */
 	signal?: AbortSignal;
 }
@@ -102,6 +123,7 @@ export class ContainerGitExecutor implements GitExecutor {
 	private readonly bridge: BridgeRunnerArgs | null;
 	private readonly baseEnv: string[];
 	private readonly runUser: ContainerRunUser;
+	private readonly scopeId: string;
 	private readonly runSignal?: AbortSignal;
 
 	constructor(
@@ -111,10 +133,14 @@ export class ContainerGitExecutor implements GitExecutor {
 	) {
 		this.bridge = opts.bridge ?? null;
 		this.runUser = opts.runUser;
+		this.scopeId = opts.scopeId;
 		this.runSignal = opts.signal;
 		// The bridge wrapper appends/redirects HEZO_PROMPT_FILE into the command it
 		// runs; it must never leak into a git invocation. Strip it defensively.
-		this.baseEnv = opts.baseEnv.filter((e) => !e.startsWith('HEZO_PROMPT_FILE='));
+		this.baseEnv = [
+			...opts.baseEnv.filter((e) => !e.startsWith('HEZO_PROMPT_FILE=')),
+			`HEZO_HEARTBEAT_RUN_ID=${opts.scopeId}`,
+		];
 	}
 
 	/**
@@ -131,6 +157,7 @@ export class ContainerGitExecutor implements GitExecutor {
 		containerId: string,
 		bridge: BridgeRunnerArgs | null,
 		runUser: ContainerRunUser,
+		scopeId: string,
 		extraEnv: string[] = [],
 		signal?: AbortSignal,
 	): ContainerGitExecutor {
@@ -140,14 +167,30 @@ export class ContainerGitExecutor implements GitExecutor {
 			...extraEnv,
 		];
 		if (bridge) baseEnv.push(`SSH_AUTH_SOCK=${bridge.socketPath}`);
-		return new ContainerGitExecutor(docker, containerId, { baseEnv, bridge, runUser, signal });
+		return new ContainerGitExecutor(docker, containerId, {
+			baseEnv,
+			bridge,
+			runUser,
+			scopeId,
+			signal,
+		});
 	}
 
 	async exec(args: string[], opts: GitExecOpts): Promise<GitExecResult> {
+		const wrapped = Boolean(opts.needsSsh && this.bridge);
 		const cmd =
 			opts.needsSsh && this.bridge
 				? [...buildBridgeRunnerArgv(this.bridge), 'git', ...args]
 				: ['git', ...args];
+		const env = [...this.baseEnv];
+		// Self-deadline for bridge-wrapped ops: newer container images run the
+		// wrapped command under `timeout` so the tree dies on its own even if this
+		// server process is gone before the op finishes (crash, hard kill). Old
+		// images simply ignore the env. Slack over the host-side per-op timeout so
+		// the host abort (and its marker kill) always fires first.
+		if (wrapped && opts.timeout) {
+			env.push(`HEZO_EXEC_DEADLINE_SECS=${Math.ceil(opts.timeout / 1000) + 15}`);
+		}
 		// The per-op deadline and the run's own abort (cancel / run-timeout) both
 		// interrupt an in-flight exec; whichever fires tears down the docker stream.
 		const timeoutSignal = opts.timeout ? AbortSignal.timeout(opts.timeout) : undefined;
@@ -155,7 +198,7 @@ export class ContainerGitExecutor implements GitExecutor {
 		try {
 			const execId = await this.docker.execCreate(this.containerId, {
 				Cmd: cmd,
-				Env: this.baseEnv,
+				Env: env,
 				WorkingDir: opts.cwd,
 				User: this.runUser.name,
 				AttachStdout: true,
@@ -166,6 +209,7 @@ export class ContainerGitExecutor implements GitExecutor {
 			return { exitCode: info.ExitCode, stdout, stderr };
 		} catch (e) {
 			if (timeoutSignal?.aborted) {
+				this.killAbandonedExec();
 				return {
 					exitCode: 1,
 					stdout: '',
@@ -173,9 +217,22 @@ export class ContainerGitExecutor implements GitExecutor {
 				};
 			}
 			if (this.runSignal?.aborted) {
+				this.killAbandonedExec();
 				return { exitCode: 1, stdout: '', stderr: 'run aborted' };
 			}
 			return { exitCode: 1, stdout: '', stderr: e instanceof Error ? e.message : String(e) };
 		}
+	}
+
+	/**
+	 * Aborting an exec only tears down its attach stream — Docker leaves the
+	 * process running in the container, so a timed-out/aborted git op would
+	 * strand its git/ssh/bridge tree there indefinitely. Reap it by the scope
+	 * marker every exec of this executor carries. Fire-and-forget and
+	 * best-effort: a generic transport error skips this (the container is likely
+	 * gone), and the startup sweep is the backstop either way.
+	 */
+	private killAbandonedExec(): void {
+		trackBackground(this.docker.killRunProcesses(this.containerId, this.scopeId).catch(() => {}));
 	}
 }

--- a/packages/server/src/services/job-manager.ts
+++ b/packages/server/src/services/job-manager.ts
@@ -57,13 +57,14 @@ import {
 	verifyContainerWorkspace,
 	wakeAgentsWithPendingWork,
 } from './containers';
-import type { DockerClient } from './docker';
+import type { ContainerProcessInfo, DockerClient } from './docker';
 import type { EgressProxy } from './egress';
 import { getDueGoals } from './goals';
 import { HEARTBEAT_INTERVAL_FLOOR_MIN } from './heartbeat-schedule';
 import type { LogStreamBroker } from './log-stream-broker';
 import { detectOrphans, healStaleRunState, STALE_STATE_GRACE_SECONDS } from './orphan-detector';
 import type { PricingService } from './pricing';
+import { collectCandidateRunIds, decideSweepKills } from './process-sweeper';
 import { ensureRepoSetupAction } from './repo-setup';
 import { getProjectConcurrency, isTaskBusyInDb } from './run-concurrency';
 import type { SshAgentServer } from './ssh-agent';
@@ -592,6 +593,41 @@ export class JobManager {
 	}
 
 	/**
+	 * Reap every live run's in-container process tree by its run-id marker.
+	 * Called from `shutdownRuntime` BEFORE `shutdown()` aborts the runs: the
+	 * abort path's own kill (agent-runner) races `process.exit`, so a clean
+	 * SIGTERM (an update restart) would otherwise strand the agent CLIs in the
+	 * warm containers. Bounded — each marker kill is individually timed out and
+	 * the whole pass races an 8s timer — so shutdown can never wedge on a dead
+	 * Docker socket. Best-effort; the startup sweep is the crash-path backstop.
+	 */
+	async killLiveRunProcesses(): Promise<void> {
+		const runs = [...this.liveRuns.values()];
+		if (runs.length === 0) return;
+		const projectIds = [...new Set(runs.map((r) => r.projectId))];
+		const containers = await this.deps.db.query<{ id: string; container_id: string }>(
+			`SELECT id, container_id FROM projects WHERE id = ANY($1::uuid[]) AND container_id IS NOT NULL`,
+			[projectIds],
+		);
+		const containerByProject = new Map(containers.rows.map((r) => [r.id, r.container_id]));
+		const kills = runs.flatMap((run) => {
+			const containerId = containerByProject.get(run.projectId);
+			if (!containerId) return [];
+			return [
+				this.deps.docker
+					.killRunProcesses(containerId, run.runId)
+					.catch((e) => log.warn(`Shutdown kill failed for run ${run.runId}:`, e)),
+			];
+		});
+		if (kills.length === 0) return;
+		await Promise.race([
+			Promise.allSettled(kills),
+			new Promise((resolve) => setTimeout(resolve, 8_000)),
+		]);
+		log.info(`Shutdown: reaped in-container processes for ${kills.length} live run(s)`);
+	}
+
+	/**
 	 * Reconcile DB state with the (now-empty) in-process run registry. Runs in
 	 * `running` or `queued` state from the previous process were necessarily lost
 	 * with that process — fail them, reset their agents to idle, release locks,
@@ -728,6 +764,7 @@ export class JobManager {
 		await this.selfHealErroredContainers(docker);
 		await this.restartStoppedRunningContainers(docker);
 		await this.repairStaleContainerMounts(docker);
+		await this.sweepDanglingContainerProcesses(docker);
 	}
 
 	/**
@@ -907,6 +944,76 @@ export class JobManager {
 				);
 			} catch (err) {
 				log.error(`Failed to rebuild stale container for project ${ref(row.slug, row.id)}:`, err);
+			}
+		}
+	}
+
+	/**
+	 * Fourth startup reconcile pass: reap dangling processes previous server
+	 * lifetimes left inside the (deliberately warm-surviving) project containers.
+	 * Docker can't kill an exec'd process, so any exec in flight when the server
+	 * stopped — an agent CLI, a git fetch and its SSH-bridge tree, an npm install
+	 * — keeps running in the container forever unless swept here.
+	 *
+	 * Runs after the stranded-run repair has already flipped previous-lifetime
+	 * `running` runs to `failed`, so the status-aware policy in
+	 * `decideSweepKills` sees them as non-succeeded and kills their trees, while
+	 * background processes a *succeeded* run intentionally left (e.g. a dev
+	 * server) are preserved. Legacy trees from versions predating the scope
+	 * marker are caught by their bridge cmdline / `SSH_AUTH_SOCK=/run/hezo/` env.
+	 * Best-effort per container: a container stopping mid-sweep just logs.
+	 */
+	private async sweepDanglingContainerProcesses(docker: DockerClient): Promise<void> {
+		const { db } = this.deps;
+
+		const reachable = await docker.ping();
+		if (!reachable) {
+			log.warn('Docker not reachable at startup; skipping dangling-process sweep');
+			return;
+		}
+
+		const running = await db.query<{ id: string; slug: string; container_id: string }>(
+			`SELECT p.id, p.slug, p.container_id
+			 FROM projects p
+			 WHERE p.container_status = $1::container_status AND p.container_id IS NOT NULL`,
+			[ContainerStatus.Running],
+		);
+		if (running.rows.length === 0) return;
+
+		const scans: Array<{ row: (typeof running.rows)[number]; procs: ContainerProcessInfo[] }> = [];
+		for (const row of running.rows) {
+			try {
+				const procs = await docker.listHezoProcesses(row.container_id);
+				if (procs.length > 0) scans.push({ row, procs });
+			} catch (err) {
+				log.warn(`Dangling-process scan failed for project ${ref(row.slug, row.id)}:`, err);
+			}
+		}
+		if (scans.length === 0) return;
+
+		// One batched lookup across every container: which scanned run ids belong
+		// to runs that completed successfully (their leftovers are intentional).
+		const candidateIds = collectCandidateRunIds(scans.flatMap((s) => s.procs));
+		let succeeded = new Set<string>();
+		if (candidateIds.length > 0) {
+			const rows = await db.query<{ id: string }>(
+				`SELECT id FROM heartbeat_runs
+				 WHERE status = $1::heartbeat_run_status AND id = ANY($2::uuid[])`,
+				[HeartbeatRunStatus.Succeeded, candidateIds],
+			);
+			succeeded = new Set(rows.rows.map((r) => r.id));
+		}
+
+		for (const { row, procs } of scans) {
+			const kills = decideSweepKills(procs, succeeded);
+			if (kills.length === 0) continue;
+			try {
+				await docker.killPids(row.container_id, kills);
+				log.info(
+					`Swept ${kills.length} dangling process(es) in container for project ${ref(row.slug, row.id)} (${procs.length - kills.length} preserved)`,
+				);
+			} catch (err) {
+				log.warn(`Dangling-process kill failed for project ${ref(row.slug, row.id)}:`, err);
 			}
 		}
 	}
@@ -2507,7 +2614,9 @@ export class JobManager {
 	}
 
 	private async detectOrphanedRuns(): Promise<void> {
-		await detectOrphans(this.deps.db, this.getLiveRunIds(), this.deps.wsManager);
+		await detectOrphans(this.deps.db, this.getLiveRunIds(), this.deps.wsManager, {
+			killProcesses: (containerId, runId) => this.deps.docker.killRunProcesses(containerId, runId),
+		});
 		await this.sweepStaleDispatches();
 		await healStaleRunState(this.deps.db, this.deps.wsManager);
 	}

--- a/packages/server/src/services/mcp-installer.ts
+++ b/packages/server/src/services/mcp-installer.ts
@@ -1,5 +1,7 @@
+import { randomBytes } from 'node:crypto';
 import { ConnectorTransport, McpInstallStatus } from '@hezo/shared';
 import type { Db } from '../db/database';
+import { trackBackground } from '../lib/background';
 import { logger } from '../logger';
 import type { LocalConnectorConfig } from './connectors/connections';
 import type { DockerClient } from './docker';
@@ -112,6 +114,12 @@ async function installOne(deps: InstallerDeps, row: PendingRow): Promise<Install
 	deps.emit?.('stdout', `→ Installing MCP "${row.name}" (${pkg}) to ${dir}\n`);
 	log.info('installing local mcp', { id: row.id, name: row.name, pkg });
 
+	// Scope marker so an abandoned npm tree stays killable — Docker can't signal
+	// an exec'd process, so a timed-out install would otherwise keep running in
+	// the container. Never a heartbeat_runs row, so the startup sweep also reaps
+	// it unconditionally.
+	const scopeId = `mcp-install-${randomBytes(8).toString('hex')}`;
+
 	try {
 		const exec = await deps.docker.execCreate(deps.containerId, {
 			Cmd: [
@@ -119,11 +127,12 @@ async function installOne(deps: InstallerDeps, row: PendingRow): Promise<Install
 				'-c',
 				`mkdir -p ${shQuote(dir)} && cd ${shQuote(dir)} && npm install --no-audit --no-fund --silent ${shQuote(pkg)} 2>&1`,
 			],
+			Env: [`HEZO_HEARTBEAT_RUN_ID=${scopeId}`],
 			AttachStdout: true,
 			AttachStderr: true,
 		});
 
-		const { stdout, stderr } = await runWithTimeout(deps, exec, INSTALL_TIMEOUT_MS);
+		const { stdout, stderr } = await runWithTimeout(deps, exec, INSTALL_TIMEOUT_MS, scopeId);
 		const info = await deps.docker.execInspect(exec);
 		if (info.ExitCode !== 0) {
 			const tail = `${stdout}\n${stderr}`.trim().slice(-1000);
@@ -147,9 +156,15 @@ async function runWithTimeout(
 	deps: InstallerDeps,
 	execId: string,
 	timeoutMs: number,
+	scopeId: string,
 ): Promise<{ stdout: string; stderr: string }> {
 	const ac = new AbortController();
-	const timer = setTimeout(() => ac.abort(), timeoutMs);
+	const timer = setTimeout(() => {
+		ac.abort();
+		// Aborting only tears down the attach stream — reap the in-container npm
+		// tree by its scope marker. Best-effort; the startup sweep is the backstop.
+		trackBackground(deps.docker.killRunProcesses(deps.containerId, scopeId).catch(() => {}));
+	}, timeoutMs);
 	try {
 		return await deps.docker.execStart(execId, { signal: ac.signal });
 	} finally {

--- a/packages/server/src/services/orphan-detector.ts
+++ b/packages/server/src/services/orphan-detector.ts
@@ -22,10 +22,21 @@ const SAFETY_WINDOW_SECONDS = 30;
  * flips active before the run row lands) and normal completion bookkeeping. */
 export const STALE_STATE_GRACE_SECONDS = 120;
 
+export interface DetectOrphansOpts {
+	/**
+	 * Best-effort reaper for the orphaned run's in-container process tree
+	 * (`DockerClient.killRunProcesses`). A run row can outlive its host-side
+	 * driver while the exec'd agent CLI keeps running in the container — when
+	 * the detector declares the run orphaned, the tree must die with it.
+	 */
+	killProcesses?: (containerId: string, runId: string) => Promise<void>;
+}
+
 export async function detectOrphans(
 	db: Db,
 	liveRunIds: Set<string>,
 	wsManager?: WebSocketManager,
+	opts?: DetectOrphansOpts,
 ): Promise<number> {
 	const orphans = await db.query<{
 		id: string;
@@ -33,10 +44,13 @@ export async function detectOrphans(
 		team_id: string;
 		task_id: string | null;
 		project_id: string | null;
+		container_id: string | null;
 		process_loss_retry_count: number;
 	}>(
 		`SELECT hr.id, hr.member_id, hr.team_id, hr.task_id, hr.process_loss_retry_count,
-		        (SELECT t.project_id FROM tasks t WHERE t.id = hr.task_id) AS project_id
+		        (SELECT t.project_id FROM tasks t WHERE t.id = hr.task_id) AS project_id,
+		        (SELECT p.container_id FROM projects p JOIN tasks t ON t.project_id = p.id
+		         WHERE t.id = hr.task_id) AS container_id
 		 FROM heartbeat_runs hr
 		 WHERE hr.status = $1::heartbeat_run_status
 		   AND hr.started_at < now() - ($2 || ' seconds')::interval`,
@@ -59,6 +73,14 @@ export async function detectOrphans(
 			 WHERE id = $1`,
 			[run.id, HeartbeatRunStatus.Failed],
 		);
+
+		// Task-less runs can't resolve a container here; the startup sweep is
+		// their backstop.
+		if (opts?.killProcesses && run.container_id) {
+			await opts
+				.killProcesses(run.container_id, run.id)
+				.catch((e) => log.warn(`Failed to kill orphaned run ${run.id} processes:`, e));
+		}
 
 		await db.query(
 			'UPDATE execution_locks SET released_at = now() WHERE member_id = $1 AND released_at IS NULL',

--- a/packages/server/src/services/process-sweeper.ts
+++ b/packages/server/src/services/process-sweeper.ts
@@ -1,0 +1,80 @@
+import type { ContainerProcessInfo } from './docker';
+
+/**
+ * Pure decision logic for the boot-time dangling-process sweep.
+ *
+ * Docker can't kill an exec'd process, so a server restart/crash strands every
+ * in-flight exec's process tree inside the (deliberately warm-surviving)
+ * project containers. At startup `JobManager.sweepDanglingContainerProcesses`
+ * scans each running container (`DockerClient.listHezoProcesses`) and applies
+ * the policy here: kill everything a previous server lifetime left behind
+ * EXCEPT background processes belonging to runs that completed successfully —
+ * an agent may intentionally leave e.g. a dev server running on the project's
+ * dev port, and those survive a Hezo restart.
+ */
+
+/**
+ * Processes younger than this are never swept. Routes and provisioning are
+ * live while startup reconciliation runs, so a git/provision exec started
+ * seconds after boot carries a scope id the DB doesn't know — the age guard is
+ * what keeps the sweep from killing it mid-flight. Anything older than this at
+ * boot necessarily predates the current server lifetime.
+ */
+export const SWEEP_MIN_AGE_SECS = 120;
+
+/**
+ * SSH-bridge infrastructure processes: the run wrapper, the per-connection
+ * bridge helper, and any socat serving a `/run/hezo/` socket. These only ever
+ * exist while an exec is in flight, so at boot (age guard passed) they are
+ * always stale — killed regardless of marker or run status.
+ */
+const BRIDGE_CMD_RE = /hezo-run-with-bridge|hezo-ssh-bridge|socat .*\/run\/hezo\//;
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+/**
+ * The scanned run ids that could be `heartbeat_runs` rows — UUID-format only,
+ * so the caller can pass them straight into an `= ANY($1::uuid[])` lookup.
+ * Non-UUID scope ids (`provision-*`, `gitop-*`, `mcp-install-*`) are never DB
+ * rows and need no lookup.
+ */
+export function collectCandidateRunIds(procs: ContainerProcessInfo[]): string[] {
+	const ids = new Set<string>();
+	for (const proc of procs) {
+		if (proc.runId !== null && UUID_RE.test(proc.runId)) ids.add(proc.runId);
+	}
+	return [...ids];
+}
+
+/**
+ * Decide which scanned pids the boot sweep kills. Per process, in order:
+ * PID 1 (the container's own init/sleep) and anything younger than
+ * {@link SWEEP_MIN_AGE_SECS} are spared; bridge infrastructure dies
+ * unconditionally; a marker-carrying process dies unless its run id is a
+ * *succeeded* `heartbeat_runs` row (failed/cancelled runs, chat session ids,
+ * and provision/gitop/mcp-install tags all fail that lookup); a marker-less
+ * process dies only when it is bridge-socket-scoped (`hasHezoSock` — legacy
+ * git/ssh trees from versions predating the marker). Everything else —
+ * succeeded runs' intentional background processes, unrelated processes — is
+ * preserved.
+ */
+export function decideSweepKills(
+	procs: ContainerProcessInfo[],
+	succeededRunIds: ReadonlySet<string>,
+): number[] {
+	const kills: number[] = [];
+	for (const proc of procs) {
+		if (proc.pid === 1) continue;
+		if (proc.ageSecs < SWEEP_MIN_AGE_SECS) continue;
+		if (BRIDGE_CMD_RE.test(proc.cmdline)) {
+			kills.push(proc.pid);
+			continue;
+		}
+		if (proc.runId !== null) {
+			if (!succeededRunIds.has(proc.runId)) kills.push(proc.pid);
+			continue;
+		}
+		if (proc.hasHezoSock) kills.push(proc.pid);
+	}
+	return kills;
+}

--- a/packages/server/src/services/repo-provisioning.ts
+++ b/packages/server/src/services/repo-provisioning.ts
@@ -5,7 +5,7 @@ import { withTransaction } from '../lib/sql';
 import { logger } from '../logger';
 import { resolveContainerRunUser } from './container-user';
 import { type ContainerDeps, ensureProjectContainerRunning } from './containers';
-import { ContainerGitExecutor } from './git-executor';
+import { ContainerGitExecutor, mintGitOpScopeId } from './git-executor';
 import {
 	enqueueRepoSetupResumeWakeups,
 	finalizePendingRepoSetup,
@@ -90,12 +90,12 @@ export async function performRepoSetup(
 				// Git runs inside the project container; the host runs no git. The
 				// provisioning bridge carries the project SSH key into the exec.
 				const runUser = await resolveContainerRunUser(docker, containerId);
-				const syncRepos = (bridge: BridgeRunnerArgs | null) =>
+				const syncRepos = (bridge: BridgeRunnerArgs | null, scopeId: string) =>
 					ensureProjectRepos(
 						db,
 						{ id: input.projectId, team_id: input.teamId },
 						dataDir,
-						ContainerGitExecutor.forPrep(docker, containerId, bridge, runUser),
+						ContainerGitExecutor.forPrep(docker, containerId, bridge, runUser, scopeId),
 					);
 				const syncRes = deps.sshAgentServer
 					? await withProvisionBridge(
@@ -103,9 +103,9 @@ export async function performRepoSetup(
 							input.teamId,
 							dataDir,
 							runUser.name,
-							({ bridge }) => syncRepos(bridge),
+							({ bridge, scopeId }) => syncRepos(bridge, scopeId),
 						)
-					: await syncRepos(null);
+					: await syncRepos(null, mintGitOpScopeId());
 				const failed = syncRes.failed.find((f) => f.name === repoName);
 				if (failed) {
 					setupError = failed.error;

--- a/packages/server/src/services/ssh-agent/host.ts
+++ b/packages/server/src/services/ssh-agent/host.ts
@@ -16,7 +16,7 @@ export async function withProvisionBridge<T>(
 	teamId: string,
 	dataDir: string,
 	socketUser: string,
-	fn: (ctx: { bridge: BridgeRunnerArgs }) => Promise<T>,
+	fn: (ctx: { bridge: BridgeRunnerArgs; scopeId: string }) => Promise<T>,
 ): Promise<T> {
 	const runId = `provision-${randomBytes(8).toString('hex')}`;
 	const socketHostPath = getRunSocketPath(dataDir, runId);
@@ -33,7 +33,10 @@ export async function withProvisionBridge<T>(
 			hostName: 'host.docker.internal',
 			hostPort: allocated.tcpHostPort,
 		};
-		return await fn({ bridge });
+		// The per-op runId doubles as the exec scope marker
+		// (`HEZO_HEARTBEAT_RUN_ID`), keeping an abandoned op's process tree
+		// killable — see ContainerGitExecutorOptions.scopeId.
+		return await fn({ bridge, scopeId: runId });
 	} finally {
 		await sshAgentServer.releaseRunSocket(runId);
 	}

--- a/packages/server/test/bun/process-sweep-docker.bun.test.ts
+++ b/packages/server/test/bun/process-sweep-docker.bun.test.ts
@@ -5,14 +5,20 @@
  * scan script's shell plumbing (environ parsing, stat-field age math, cmdline
  * matching) can only regress for real on a real runtime.
  *
+ * Bun-native tier: `DockerClient.request` rides Bun's `fetch` unix-socket
+ * option, which Node's undici ignores (a vitest run would dial localhost:80
+ * instead of the docker socket) — so this must run under `bun test`, the
+ * production runtime, like docker-stream.bun.test.ts.
+ *
  * Skipped automatically when Docker is unavailable, HEZO_SKIP_DOCKER is set,
  * or the agent-base image isn't built locally — same gating as
  * ssh-agent-docker.test.ts.
  */
+
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
 import { spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { type ContainerProcessInfo, DockerClient } from '../src/services/docker';
+import { type ContainerProcessInfo, DockerClient } from '../../src/services/docker';
 
 const dockerAvailable = await checkDocker();
 const skipReason =
@@ -37,7 +43,7 @@ beforeAll(async () => {
 	expect(run.exitCode).toBe(0);
 	containerId = run.stdout.trim();
 	docker = new DockerClient();
-}, 60_000);
+});
 
 afterAll(async () => {
 	if (finalSkipReason || !containerId) return;

--- a/packages/server/test/chat-session.test.ts
+++ b/packages/server/test/chat-session.test.ts
@@ -384,6 +384,66 @@ describe('ChatSessionManager', () => {
 		await manager.stop();
 	});
 
+	test('an interrupted turn is reaped by its per-exec scope, never the shared session id', async () => {
+		const chat = makeChatDocker(ctx.dataDir, projectId);
+		chat.scenario.mode = 'block';
+
+		// Capture each exec's per-exec scope id and every marker kill fired.
+		const execScopeIds: string[] = [];
+		const kills: Array<{ containerId: string; name: string; value: string }> = [];
+		const innerCreate = chat.docker.execCreate.bind(chat.docker);
+		chat.docker.execCreate = async (id: string, config: { Env?: string[] }) => {
+			const scope = (config.Env ?? []).find((e) => e.startsWith('HEZO_EXEC_SCOPE_ID='));
+			if (scope) execScopeIds.push(scope.slice('HEZO_EXEC_SCOPE_ID='.length));
+			return innerCreate(id, config as never);
+		};
+		chat.docker.killProcessesByEnvMarker = async (
+			containerId: string,
+			name: 'HEZO_HEARTBEAT_RUN_ID' | 'HEZO_EXEC_SCOPE_ID',
+			value: string,
+		) => {
+			kills.push({ containerId, name, value });
+		};
+
+		const { manager } = makeManager(ctx, chat.docker);
+		const first = await manager.sendTurn({ text: 'Long question' });
+		await poll(async () => chat.scenario.entered);
+
+		chat.scenario.mode = 'reply';
+		await manager.sendTurn({ text: 'Actually, never mind' });
+		await poll(async () => {
+			const r = await ctx.db.query<{ status: string }>(
+				'SELECT status FROM chat_messages WHERE id = $1',
+				[first.assistantMessageId],
+			);
+			return r.rows[0]?.status === ChatMessageStatus.Interrupted;
+		});
+
+		const session = await ctx.db.query<{ id: string }>(
+			`SELECT id FROM chat_sessions WHERE status IN ($1, $2) ORDER BY started_at DESC LIMIT 1`,
+			[ChatSessionStatus.Starting, ChatSessionStatus.Running],
+		);
+		const sessionId = session.rows[0].id;
+
+		// The interrupt reaps by the aborted exec's own scope id — a session-wide
+		// kill here would murder the second conversation-turn's live exec.
+		await poll(async () => kills.some((k) => k.name === 'HEZO_EXEC_SCOPE_ID'));
+		for (const kill of kills.filter((k) => k.name === 'HEZO_EXEC_SCOPE_ID')) {
+			expect(kill.containerId).toBe('hq-container');
+			expect(kill.value).not.toBe(sessionId);
+			expect(execScopeIds).toContain(kill.value);
+		}
+
+		// Stopping the manager tears the session down and reaps session-wide: every
+		// exec of this session carried HEZO_HEARTBEAT_RUN_ID=<sessionId>.
+		await manager.stop();
+		expect(kills).toContainEqual({
+			containerId: 'hq-container',
+			name: 'HEZO_HEARTBEAT_RUN_ID',
+			value: sessionId,
+		});
+	});
+
 	test('ensureSession is idempotent (one live session per CEO)', async () => {
 		const chat = makeChatDocker(ctx.dataDir, projectId);
 		const { manager } = makeManager(ctx, chat.docker);

--- a/packages/server/test/docker-client-request.test.ts
+++ b/packages/server/test/docker-client-request.test.ts
@@ -491,6 +491,132 @@ describe('killRunProcesses', () => {
 	});
 });
 
+describe('killProcessesByEnvMarker', () => {
+	it('rejects a shell-active marker value before any exec is created', async () => {
+		const docker = client();
+		let created = 0;
+		docker.execCreate = async () => {
+			created++;
+			return 'exec-kill';
+		};
+		for (const value of ['a b', 'a"b', "a'b", 'a$b', 'a`b`', 'a;b', '', 'x'.repeat(65)]) {
+			await expect(
+				docker.killProcessesByEnvMarker('cid-1', 'HEZO_EXEC_SCOPE_ID', value),
+			).rejects.toThrow('unsafe env marker value');
+		}
+		expect(created).toBe(0);
+	});
+
+	it('greps for the exact <name>=<value> marker', async () => {
+		const docker = client();
+		const scripts: string[] = [];
+		docker.execCreate = async (_cid, config) => {
+			scripts.push((config.Cmd as string[])[2]);
+			return 'exec-kill';
+		};
+		docker.execStart = async () => ({ stdout: '', stderr: '' });
+
+		await docker.killProcessesByEnvMarker('cid-1', 'HEZO_EXEC_SCOPE_ID', 'scope-42');
+
+		expect(scripts[0]).toContain('HEZO_EXEC_SCOPE_ID=scope-42');
+		expect(scripts[0]).toContain('kill -9');
+	});
+});
+
+describe('listHezoProcesses', () => {
+	it('execs a root /proc scan that emits marker/sock/bridge matches with age', async () => {
+		const docker = client();
+		const created: Array<{ containerId: string; config: Record<string, unknown> }> = [];
+		docker.execCreate = async (containerId, config) => {
+			created.push({ containerId, config: config as unknown as Record<string, unknown> });
+			return 'exec-scan';
+		};
+		docker.execStart = async () => ({ stdout: '', stderr: '' });
+
+		await docker.listHezoProcesses('cid-1');
+
+		expect(created).toHaveLength(1);
+		const cmd = created[0].config.Cmd as string[];
+		expect(cmd[0]).toBe('sh');
+		const script = cmd[2];
+		expect(script).toContain('HEZO_HEARTBEAT_RUN_ID=');
+		expect(script).toContain('SSH_AUTH_SOCK=/run/hezo/');
+		expect(script).toContain('hezo-run-with-bridge');
+		expect(script).toContain('/proc/uptime');
+		// Root exec, stdout only (the parseable scan lines).
+		expect(created[0].config.User).toBeUndefined();
+		expect(created[0].config.AttachStdout).toBe(true);
+	});
+
+	it('parses scan output, keeps tab-bearing cmdlines whole, and drops malformed lines', async () => {
+		const docker = client();
+		docker.execCreate = async () => 'exec-scan';
+		docker.execStart = async () => ({
+			stdout: [
+				'42\trun-uuid-1\t1\t500\tnode /some/cli',
+				'43\t\t1\t900\t/bin/sh /usr/local/bin/hezo-ssh-bridge abc host 123',
+				// cmdline containing a tab stays one field
+				'44\trun-uuid-1\t0\t50\tsh -c echo\thello',
+				'45\tbad-age\t0\tnot-a-number\tx',
+				'garbage line',
+				'',
+			].join('\n'),
+			stderr: '',
+		});
+
+		const procs = await docker.listHezoProcesses('cid-1');
+
+		expect(procs).toEqual([
+			{ pid: 42, runId: 'run-uuid-1', hasHezoSock: true, ageSecs: 500, cmdline: 'node /some/cli' },
+			{
+				pid: 43,
+				runId: null,
+				hasHezoSock: true,
+				ageSecs: 900,
+				cmdline: '/bin/sh /usr/local/bin/hezo-ssh-bridge abc host 123',
+			},
+			{
+				pid: 44,
+				runId: 'run-uuid-1',
+				hasHezoSock: false,
+				ageSecs: 50,
+				cmdline: 'sh -c echo\thello',
+			},
+		]);
+	});
+});
+
+describe('killPids', () => {
+	it('SIGKILLs the validated pid list in one exec and no-ops on an empty list', async () => {
+		const docker = client();
+		const scripts: string[] = [];
+		docker.execCreate = async (_cid, config) => {
+			scripts.push((config.Cmd as string[])[2]);
+			return 'exec-kill';
+		};
+		docker.execStart = async () => ({ stdout: '', stderr: '' });
+
+		await docker.killPids('cid-1', []);
+		expect(scripts).toHaveLength(0);
+
+		await docker.killPids('cid-1', [42, 137, 4096]);
+		expect(scripts).toEqual(['kill -9 42 137 4096 2>/dev/null || true']);
+	});
+
+	it('rejects non-integer, negative, and PID-1 targets before any exec', async () => {
+		const docker = client();
+		let created = 0;
+		docker.execCreate = async () => {
+			created++;
+			return 'exec-kill';
+		};
+		for (const pids of [[1.5], [-1], [Number.NaN], [0], [1]]) {
+			await expect(docker.killPids('cid-1', pids)).rejects.toThrow('unsafe pid');
+		}
+		expect(created).toBe(0);
+	});
+});
+
 describe('execStart demux over the real unix-socket transport', () => {
 	it('concatenates multiple buffered frames per stream', async () => {
 		const sim = await startDockerSockSim();

--- a/packages/server/test/docs-ack-hook.test.ts
+++ b/packages/server/test/docs-ack-hook.test.ts
@@ -79,10 +79,12 @@ describe('findDocsAckValue', () => {
 });
 
 describe('checkCommitMessage', () => {
-	it('rejects a code commit with no trailer', () => {
+	it('rejects a code commit with no trailer, pointing at both docs/ and .dev/', () => {
 		const r = checkCommitMessage('feat: add flag', ['packages/server/src/cli.ts']);
 		expect(r.ok).toBe(false);
 		expect(r.error).toContain('Docs-Checked');
+		// The pass covers the internal .dev/ docs too, not just user-facing docs/.
+		expect(r.error).toContain('.dev/');
 	});
 
 	it('rejects bare and too-short acknowledgments', () => {

--- a/packages/server/test/git-executor.test.ts
+++ b/packages/server/test/git-executor.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { ContainerRunUser } from '../src/services/container-user';
 import { ContainerGitExecutor, GIT_SSH_COMMAND_VALUE } from '../src/services/git-executor';
 import {
@@ -27,6 +27,7 @@ interface RecordedExec {
 
 function recordingDocker(opts: { exitCode?: number; throwOnStart?: boolean } = {}) {
 	const calls: RecordedExec[] = [];
+	const kills: Array<{ containerId: string; runId: string }> = [];
 	const docker = createStubDocker({
 		execCreate: async (_id: string, config: RecordedExec) => {
 			calls.push(config);
@@ -37,8 +38,11 @@ function recordingDocker(opts: { exitCode?: number; throwOnStart?: boolean } = {
 			return { stdout: 'out', stderr: 'err' };
 		},
 		execInspect: async () => ({ ExitCode: opts.exitCode ?? 0, Running: false, Pid: 1 }),
+		killRunProcesses: async (containerId: string, runId: string) => {
+			kills.push({ containerId, runId });
+		},
 	});
-	return { docker, calls };
+	return { docker, calls, kills };
 }
 
 const abortErrorOf = (s: AbortSignal): Error =>
@@ -50,7 +54,8 @@ const abortErrorOf = (s: AbortSignal): Error =>
 // modelling a black-holed in-container command (e.g. a stalled `git fetch`), the
 // production failure this executor's timeout/run-signal handling must survive.
 function hangingDocker() {
-	return createStubDocker({
+	const kills: Array<{ containerId: string; runId: string }> = [];
+	const docker = createStubDocker({
 		execCreate: async () => 'exec-1',
 		execStart: (_id: string, opts?: { signal?: AbortSignal }) =>
 			new Promise<{ stdout: string; stderr: string }>((_resolve, reject) => {
@@ -60,7 +65,11 @@ function hangingDocker() {
 				signal.addEventListener('abort', () => reject(abortErrorOf(signal)), { once: true });
 			}),
 		execInspect: async () => ({ ExitCode: 0, Running: false, Pid: 1 }),
+		killRunProcesses: async (containerId: string, runId: string) => {
+			kills.push({ containerId, runId });
+		},
 	});
+	return { docker, kills };
 }
 
 describe('ContainerGitExecutor', () => {
@@ -69,6 +78,7 @@ describe('ContainerGitExecutor', () => {
 		const exec = new ContainerGitExecutor(docker, 'cid', {
 			baseEnv: ['GIT_CONFIG_COUNT=0'],
 			runUser,
+			scopeId: 'gitop-0000000000000000',
 		});
 
 		const res = await exec.exec(['status', '--porcelain'], { cwd: '/worktrees/T-1/repo' });
@@ -85,6 +95,7 @@ describe('ContainerGitExecutor', () => {
 		const exec = new ContainerGitExecutor(docker, 'cid', {
 			baseEnv: [],
 			runUser: { name: 'appuser', uid: 1001, gid: 1001 },
+			scopeId: 'gitop-0000000000000000',
 		});
 
 		await exec.exec(['status'], { cwd: '/w' });
@@ -94,7 +105,12 @@ describe('ContainerGitExecutor', () => {
 
 	it('wraps SSH-transport ops with the bridge runner', async () => {
 		const { docker, calls } = recordingDocker();
-		const exec = new ContainerGitExecutor(docker, 'cid', { baseEnv: [], bridge, runUser });
+		const exec = new ContainerGitExecutor(docker, 'cid', {
+			baseEnv: [],
+			bridge,
+			runUser,
+			scopeId: 'gitop-0000000000000000',
+		});
 
 		await exec.exec(['fetch', '--all', '--prune'], { cwd: '/workspace/repo', needsSsh: true });
 
@@ -110,7 +126,12 @@ describe('ContainerGitExecutor', () => {
 
 	it('does not wrap when needsSsh but no bridge is available', async () => {
 		const { docker, calls } = recordingDocker();
-		const exec = new ContainerGitExecutor(docker, 'cid', { baseEnv: [], bridge: null, runUser });
+		const exec = new ContainerGitExecutor(docker, 'cid', {
+			baseEnv: [],
+			bridge: null,
+			runUser,
+			scopeId: 'gitop-0000000000000000',
+		});
 
 		await exec.exec(['fetch'], { cwd: '/workspace/repo', needsSsh: true });
 
@@ -126,6 +147,7 @@ describe('ContainerGitExecutor', () => {
 				'HEZO_PROMPT_FILE=/tmp/prompt.txt',
 			],
 			runUser,
+			scopeId: 'gitop-0000000000000000',
 		});
 
 		await exec.exec(['status'], { cwd: '/w' });
@@ -137,7 +159,7 @@ describe('ContainerGitExecutor', () => {
 
 	it('forPrep threads the run-user + extraEnv (git identity) alongside the prep defaults', async () => {
 		const { docker, calls } = recordingDocker();
-		const exec = ContainerGitExecutor.forPrep(docker, 'cid', bridge, runUser, [
+		const exec = ContainerGitExecutor.forPrep(docker, 'cid', bridge, runUser, 'run-scope-1', [
 			'GIT_CONFIG_COUNT=2',
 			'GIT_CONFIG_KEY_0=user.name',
 			'GIT_CONFIG_VALUE_0=octocat',
@@ -165,7 +187,11 @@ describe('ContainerGitExecutor', () => {
 
 	it('surfaces a non-zero exit code from execInspect', async () => {
 		const { docker } = recordingDocker({ exitCode: 128 });
-		const exec = new ContainerGitExecutor(docker, 'cid', { baseEnv: [], runUser });
+		const exec = new ContainerGitExecutor(docker, 'cid', {
+			baseEnv: [],
+			runUser,
+			scopeId: 'gitop-0000000000000000',
+		});
 
 		const res = await exec.exec(['rev-parse', '--git-dir'], { cwd: '/w' });
 
@@ -174,7 +200,11 @@ describe('ContainerGitExecutor', () => {
 
 	it('returns exitCode 1 instead of throwing when docker fails', async () => {
 		const { docker } = recordingDocker({ throwOnStart: true });
-		const exec = new ContainerGitExecutor(docker, 'cid', { baseEnv: [], runUser });
+		const exec = new ContainerGitExecutor(docker, 'cid', {
+			baseEnv: [],
+			runUser,
+			scopeId: 'gitop-0000000000000000',
+		});
 
 		const res = await exec.exec(['status'], { cwd: '/w' });
 
@@ -182,8 +212,35 @@ describe('ContainerGitExecutor', () => {
 		expect(res.stderr).toContain('docker daemon unreachable');
 	});
 
-	it('times out a hung exec at the per-op deadline instead of hanging', async () => {
-		const exec = ContainerGitExecutor.forPrep(hangingDocker(), 'cid', bridge, runUser);
+	it('stamps every exec env with the HEZO_HEARTBEAT_RUN_ID scope marker', async () => {
+		const { docker, calls } = recordingDocker();
+		const exec = ContainerGitExecutor.forPrep(docker, 'cid', bridge, runUser, 'run-scope-1');
+
+		await exec.exec(['status'], { cwd: '/w' });
+		await exec.exec(['fetch', '--prune', 'origin'], { cwd: '/w', needsSsh: true, timeout: 60_000 });
+
+		// Both plain and bridge-wrapped ops carry the marker, so an abandoned tree
+		// (git, ssh, socat, the bridge wrapper) is killable by env scan.
+		expect(calls[0].Env).toContain('HEZO_HEARTBEAT_RUN_ID=run-scope-1');
+		expect(calls[1].Env).toContain('HEZO_HEARTBEAT_RUN_ID=run-scope-1');
+	});
+
+	it('sets a self-deadline env only for bridge-wrapped ops with a timeout', async () => {
+		const { docker, calls } = recordingDocker();
+		const exec = ContainerGitExecutor.forPrep(docker, 'cid', bridge, runUser, 'run-scope-1');
+
+		await exec.exec(['fetch', '--prune', 'origin'], { cwd: '/w', needsSsh: true, timeout: 60_000 });
+		await exec.exec(['status'], { cwd: '/w', timeout: 30_000 });
+
+		// 60s op cap + 15s slack, so the host-side abort always fires first and the
+		// in-container `timeout` only matters when the server itself is gone.
+		expect(calls[0].Env).toContain('HEZO_EXEC_DEADLINE_SECS=75');
+		expect(calls[1].Env?.some((e) => e.startsWith('HEZO_EXEC_DEADLINE_SECS='))).toBe(false);
+	});
+
+	it('times out a hung exec at the per-op deadline and reaps the abandoned tree', async () => {
+		const { docker, kills } = hangingDocker();
+		const exec = ContainerGitExecutor.forPrep(docker, 'cid', bridge, runUser, 'run-scope-1');
 
 		const res = await exec.exec(['fetch', '--prune', 'origin'], {
 			cwd: '/workspace/repo',
@@ -193,15 +250,22 @@ describe('ContainerGitExecutor', () => {
 
 		expect(res.exitCode).toBe(1);
 		expect(res.stderr).toContain('timed out');
+		// The abandoned in-container tree is killed by its scope marker — aborting
+		// the exec stream alone would leave git/ssh/socat running in the container.
+		await vi.waitFor(() => {
+			expect(kills).toEqual([{ containerId: 'cid', runId: 'run-scope-1' }]);
+		});
 	});
 
-	it('interrupts an in-flight exec when the run signal aborts', async () => {
+	it('interrupts an in-flight exec when the run signal aborts and reaps the tree', async () => {
 		const ac = new AbortController();
+		const { docker, kills } = hangingDocker();
 		const exec = ContainerGitExecutor.forPrep(
-			hangingDocker(),
+			docker,
 			'cid',
 			bridge,
 			runUser,
+			'run-scope-1',
 			[],
 			ac.signal,
 		);
@@ -216,5 +280,29 @@ describe('ContainerGitExecutor', () => {
 
 		expect(res.exitCode).toBe(1);
 		expect(res.stderr).toBe('run aborted');
+		await vi.waitFor(() => {
+			expect(kills).toEqual([{ containerId: 'cid', runId: 'run-scope-1' }]);
+		});
+	});
+
+	it('does not fire the marker kill on success or on a docker transport error', async () => {
+		const ok = recordingDocker();
+		const okExec = ContainerGitExecutor.forPrep(ok.docker, 'cid', bridge, runUser, 'run-scope-1');
+		await okExec.exec(['fetch', '--prune', 'origin'], { cwd: '/w', needsSsh: true, timeout: 50 });
+
+		// Transport error (daemon unreachable): the container is likely gone, so no
+		// kill is attempted — the startup sweep is the backstop.
+		const broken = recordingDocker({ throwOnStart: true });
+		const brokenExec = ContainerGitExecutor.forPrep(
+			broken.docker,
+			'cid',
+			bridge,
+			runUser,
+			'run-scope-1',
+		);
+		await brokenExec.exec(['fetch', '--prune', 'origin'], { cwd: '/w', needsSsh: true });
+
+		expect(ok.kills).toEqual([]);
+		expect(broken.kills).toEqual([]);
 	});
 });

--- a/packages/server/test/helpers/app.ts
+++ b/packages/server/test/helpers/app.ts
@@ -62,6 +62,9 @@ const STUB_DOCKER_METHODS = {
 	execStart: async () => ({ stdout: '', stderr: '' }),
 	execInspect: async () => ({ ExitCode: 0, Running: false, Pid: 0 }),
 	killRunProcesses: async () => {},
+	killProcessesByEnvMarker: async () => {},
+	listHezoProcesses: async () => [],
+	killPids: async () => {},
 };
 
 export function createStubDocker<T extends Record<string, unknown>>(

--- a/packages/server/test/job-manager-process-sweep.test.ts
+++ b/packages/server/test/job-manager-process-sweep.test.ts
@@ -1,0 +1,260 @@
+import { ContainerStatus, HeartbeatRunStatus } from '@hezo/shared';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { waitForBackground } from '../src/lib/background';
+import { ContainerLogStreamer } from '../src/services/container-logs';
+import type { ContainerProcessInfo } from '../src/services/docker';
+import { JobManager, type JobManagerDeps } from '../src/services/job-manager';
+import { LogStreamBroker } from '../src/services/log-stream-broker';
+import { SWEEP_MIN_AGE_SECS } from '../src/services/process-sweeper';
+import { authHeader, createStubDocker, createTestProject, createTestTeam } from './helpers/app';
+import { createTestContext, destroyTestContext, type ServerTestContext } from './helpers/context';
+
+// The startup dangling-process sweep (4th reconcile pass) and the shutdown
+// live-run reap: Docker can't kill an exec'd process, so anything in flight
+// when the previous server lifetime ended keeps running inside the warm
+// project containers until these paths reap it.
+
+let ctx: ServerTestContext;
+let teamId: string;
+let projectId: string;
+let projectSlug: string;
+let taskId: string;
+let agentId: string;
+
+const json = { 'Content-Type': 'application/json' };
+const CONTAINER_ID = 'sweep-container-1';
+
+const OLD = SWEEP_MIN_AGE_SECS + 600;
+
+function proc(over: Partial<ContainerProcessInfo>): ContainerProcessInfo {
+	return { pid: 100, runId: null, hasHezoSock: false, ageSecs: OLD, cmdline: 'sleep 300', ...over };
+}
+
+function createJobManager(overrides: Partial<JobManagerDeps> = {}): JobManager {
+	return new JobManager({
+		db: ctx.db,
+		docker: createStubDocker(),
+		masterKeyManager: ctx.masterKeyManager,
+		serverPort: ctx.port,
+		dataDir: ctx.dataDir,
+		wsManager: { broadcast: () => {} } as unknown as JobManagerDeps['wsManager'],
+		logs: new LogStreamBroker(),
+		containerLogStreamer: new ContainerLogStreamer(),
+		...overrides,
+	});
+}
+
+// Keeps the earlier container passes (restart / stale-mount probe) green so the
+// sweep pass under test is reached without rebuild cascades.
+const happyExec = {
+	execCreate: async () => 'exec-ok',
+	execStart: async () => ({ stdout: 'ok', stderr: '' }),
+	execInspect: async () => ({ ExitCode: 0, Running: false, Pid: 0 }),
+	inspectContainer: async () => ({
+		Id: CONTAINER_ID,
+		State: { Status: 'running', Running: true, Pid: 1, ExitCode: 0 },
+		Config: { Image: 'stub' },
+	}),
+};
+
+async function insertRun(status: HeartbeatRunStatus): Promise<string> {
+	const r = await ctx.db.query<{ id: string }>(
+		`INSERT INTO heartbeat_runs (team_id, member_id, task_id, status, started_at, finished_at)
+		 VALUES ($1, $2, $3, $4::heartbeat_run_status, now(), ${status === HeartbeatRunStatus.Running ? 'NULL' : 'now()'})
+		 RETURNING id`,
+		[teamId, agentId, taskId, status],
+	);
+	return r.rows[0].id;
+}
+
+beforeAll(async () => {
+	ctx = await createTestContext();
+	const { app, db, token } = ctx;
+
+	const typesRes = await app.request('/api/team-templates', { headers: authHeader(token) });
+	const typeId = (await typesRes.json()).data.find(
+		(t: { name: string }) => t.name === 'Startup',
+	).id;
+	const teamRes = await createTestTeam(db, { name: 'Sweep JM Co', template_id: typeId });
+	teamId = (await teamRes.json()).data.id;
+
+	const projectRes = await createTestProject(db, teamId, {
+		name: 'Sweep JM Project',
+		description: 'Dangling-process sweep coverage.',
+	});
+	const project = (await projectRes.json()).data;
+	projectId = project.id;
+	projectSlug = project.slug;
+
+	await db.query(
+		`UPDATE projects SET container_id = $1, container_status = $2::container_status WHERE id = $3`,
+		[CONTAINER_ID, ContainerStatus.Running, projectId],
+	);
+
+	const agents = await db.query<{ id: string }>(
+		`SELECT ma.id FROM member_agents ma
+		 JOIN members m ON m.id = ma.id
+		 WHERE m.team_id = $1 AND ma.slug <> 'captain'
+		 ORDER BY ma.slug`,
+		[teamId],
+	);
+	agentId = agents.rows[0].id;
+
+	const taskRes = await app.request(`/api/projects/${projectSlug}/tasks`, {
+		method: 'POST',
+		headers: { ...authHeader(token), ...json },
+		body: JSON.stringify({ project_id: projectId, title: 'Sweep Task', assignee_id: agentId }),
+	});
+	taskId = (await taskRes.json()).data.id;
+	await waitForBackground();
+});
+
+afterEach(async () => {
+	await waitForBackground();
+	await ctx.db.query('DELETE FROM agent_wakeup_requests WHERE team_id = $1', [teamId]);
+	await ctx.db.query('UPDATE execution_locks SET released_at = now() WHERE released_at IS NULL');
+	await ctx.db.query('DELETE FROM heartbeat_runs WHERE team_id = $1', [teamId]);
+});
+
+afterAll(async () => {
+	await destroyTestContext(ctx);
+});
+
+describe('startup dangling-process sweep', () => {
+	it('kills stranded-run, legacy, and bridge processes but preserves succeeded-run and young ones', async () => {
+		const succeededId = await insertRun(HeartbeatRunStatus.Succeeded);
+		// A run stranded `running` by the previous lifetime: the earlier reconcile
+		// pass flips it to failed BEFORE the sweep runs, so its tree must die.
+		const strandedId = await insertRun(HeartbeatRunStatus.Running);
+
+		const kills: Array<{ containerId: string; pids: number[] }> = [];
+		const docker = createStubDocker({
+			...happyExec,
+			listHezoProcesses: async (): Promise<ContainerProcessInfo[]> => [
+				proc({ pid: 11, runId: succeededId, cmdline: 'node dev-server.js' }),
+				proc({ pid: 12, runId: strandedId, cmdline: 'node some-cli' }),
+				proc({ pid: 13, runId: null, hasHezoSock: true, cmdline: 'ssh git@github.com' }),
+				proc({ pid: 14, cmdline: '/bin/sh /usr/local/bin/hezo-ssh-bridge tok host 1' }),
+				proc({ pid: 15, runId: strandedId, ageSecs: 5, cmdline: 'node young-cli' }),
+			],
+			killPids: async (containerId: string, pids: number[]) => {
+				kills.push({ containerId, pids });
+			},
+		});
+
+		const manager = createJobManager({ docker });
+		await manager.reconcileOnStartup();
+		manager.shutdown();
+
+		const stranded = await ctx.db.query<{ status: string }>(
+			'SELECT status::text AS status FROM heartbeat_runs WHERE id = $1',
+			[strandedId],
+		);
+		expect(stranded.rows[0].status).toBe(HeartbeatRunStatus.Failed);
+		expect(kills).toEqual([{ containerId: CONTAINER_ID, pids: [12, 13, 14] }]);
+	});
+
+	it('skips the sweep entirely when docker is unreachable', async () => {
+		let scanned = 0;
+		const docker = createStubDocker({
+			ping: async () => false,
+			listHezoProcesses: async (): Promise<ContainerProcessInfo[]> => {
+				scanned++;
+				return [];
+			},
+		});
+		const manager = createJobManager({ docker });
+		await manager.reconcileOnStartup();
+		manager.shutdown();
+		expect(scanned).toBe(0);
+	});
+
+	it('a scan failure logs and continues without failing reconciliation', async () => {
+		const docker = createStubDocker({
+			...happyExec,
+			listHezoProcesses: async (): Promise<ContainerProcessInfo[]> => {
+				throw new Error('container stopped mid-sweep');
+			},
+			killPids: async () => {
+				throw new Error('should not be called');
+			},
+		});
+		const manager = createJobManager({ docker });
+		await expect(manager.reconcileOnStartup()).resolves.toBeUndefined();
+		manager.shutdown();
+	});
+
+	it('skips the kill exec when nothing qualifies', async () => {
+		const succeededId = await insertRun(HeartbeatRunStatus.Succeeded);
+		let killCalls = 0;
+		const docker = createStubDocker({
+			...happyExec,
+			listHezoProcesses: async (): Promise<ContainerProcessInfo[]> => [
+				proc({ pid: 21, runId: succeededId, cmdline: 'node dev-server.js' }),
+			],
+			killPids: async () => {
+				killCalls++;
+			},
+		});
+		const manager = createJobManager({ docker });
+		await manager.reconcileOnStartup();
+		manager.shutdown();
+		expect(killCalls).toBe(0);
+	});
+});
+
+describe('killLiveRunProcesses (shutdown reap)', () => {
+	it("kills each live run's marker in its project container, bounded and best-effort", async () => {
+		// Earlier reconcile passes may have rebuilt the stub project container;
+		// re-pin the id this test asserts against.
+		await ctx.db.query(
+			`UPDATE projects SET container_id = $1, container_status = $2::container_status WHERE id = $3`,
+			[CONTAINER_ID, ContainerStatus.Running, projectId],
+		);
+		const runId = await insertRun(HeartbeatRunStatus.Running);
+		const kills: Array<{ containerId: string; runId: string }> = [];
+		const docker = createStubDocker({
+			killRunProcesses: async (containerId: string, rid: string) => {
+				kills.push({ containerId, runId: rid });
+			},
+		});
+		const manager = createJobManager({ docker });
+		manager.registerLiveRun({
+			runId,
+			memberId: agentId,
+			taskId,
+			projectId,
+			teamId,
+			taskKey: `${agentId}:${projectId}`,
+		});
+
+		await manager.killLiveRunProcesses();
+		manager.shutdown();
+
+		expect(kills).toEqual([{ containerId: CONTAINER_ID, runId }]);
+	});
+
+	it('is a no-op with no live runs and survives kill failures', async () => {
+		const failing = createStubDocker({
+			killRunProcesses: async () => {
+				throw new Error('daemon gone');
+			},
+		});
+		const empty = createJobManager({ docker: failing });
+		await expect(empty.killLiveRunProcesses()).resolves.toBeUndefined();
+		empty.shutdown();
+
+		const runId = await insertRun(HeartbeatRunStatus.Running);
+		const manager = createJobManager({ docker: failing });
+		manager.registerLiveRun({
+			runId,
+			memberId: agentId,
+			taskId,
+			projectId,
+			teamId,
+			taskKey: `${agentId}:${projectId}`,
+		});
+		await expect(manager.killLiveRunProcesses()).resolves.toBeUndefined();
+		manager.shutdown();
+	});
+});

--- a/packages/server/test/mcp-installer.test.ts
+++ b/packages/server/test/mcp-installer.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import type { Db } from '../src/db/database';
 import type { DockerClient } from '../src/services/docker';
 import { installLocalMcpById, installPendingLocalMcps } from '../src/services/mcp-installer';
@@ -193,6 +193,81 @@ describe('installPendingLocalMcps', () => {
 		});
 		expect(results.find((r) => r.name === 'already-done')).toBeUndefined();
 		expect(calls.find((c) => c.cmd[2]?.includes('already-done'))).toBeUndefined();
+	});
+});
+
+describe('install exec process scoping', () => {
+	it('stamps the npm exec env with an mcp-install scope marker', async () => {
+		const { id } = (
+			await db.query<{ id: string }>(
+				`INSERT INTO mcp_connections (name, kind, config, install_status)
+				 VALUES ('fs-marker', 'local', $1::jsonb, 'pending') RETURNING id`,
+				[JSON.stringify({ command: 'x', package: '@scope/pkg' })],
+			)
+		).rows[0];
+
+		const envs: string[][] = [];
+		const docker = {
+			execCreate: async (_id: string, cfg: { Env?: string[] }): Promise<string> => {
+				envs.push(cfg.Env ?? []);
+				return 'exec-id';
+			},
+			execStart: async () => ({ stdout: '', stderr: '' }),
+			execInspect: async () => ({ ExitCode: 0, Running: false, Pid: 0 }),
+		} as unknown as DockerClient;
+
+		await installLocalMcpById({ db, docker, containerId: 'c', teamId, projectId }, id);
+
+		expect(envs).toHaveLength(1);
+		const marker = envs[0].find((e) => e.startsWith('HEZO_HEARTBEAT_RUN_ID='));
+		expect(marker).toMatch(/^HEZO_HEARTBEAT_RUN_ID=mcp-install-[0-9a-f]{16}$/);
+	});
+
+	it('reaps the abandoned npm tree by its scope marker when the install times out', async () => {
+		vi.useFakeTimers();
+		try {
+			const { id } = (
+				await db.query<{ id: string }>(
+					`INSERT INTO mcp_connections (name, kind, config, install_status)
+					 VALUES ('fs-hang', 'local', $1::jsonb, 'pending') RETURNING id`,
+					[JSON.stringify({ command: 'x', package: '@scope/pkg' })],
+				)
+			).rows[0];
+
+			const kills: Array<{ containerId: string; runId: string }> = [];
+			let markedEnv: string[] = [];
+			const docker = {
+				execCreate: async (_id: string, cfg: { Env?: string[] }): Promise<string> => {
+					markedEnv = cfg.Env ?? [];
+					return 'exec-id';
+				},
+				// Hangs (npm black-holed on the network) until the timeout aborts it.
+				execStart: (_id: string, opts?: { signal?: AbortSignal }) =>
+					new Promise((_resolve, reject) => {
+						opts?.signal?.addEventListener(
+							'abort',
+							() => reject(new DOMException('Aborted', 'AbortError')),
+							{ once: true },
+						);
+					}),
+				execInspect: async () => ({ ExitCode: 0, Running: false, Pid: 0 }),
+				killRunProcesses: async (containerId: string, runId: string) => {
+					kills.push({ containerId, runId });
+				},
+			} as unknown as DockerClient;
+
+			const install = installLocalMcpById({ db, docker, containerId: 'c', teamId, projectId }, id);
+			await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 1);
+			const result = await install;
+
+			expect(result?.status).toBe('failed');
+			const scopeId = markedEnv
+				.find((e) => e.startsWith('HEZO_HEARTBEAT_RUN_ID='))
+				?.slice('HEZO_HEARTBEAT_RUN_ID='.length);
+			expect(kills).toEqual([{ containerId: 'c', runId: scopeId }]);
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 });
 

--- a/packages/server/test/orphan-detector.test.ts
+++ b/packages/server/test/orphan-detector.test.ts
@@ -244,6 +244,85 @@ async function setAgentActiveStale(memberId: string): Promise<void> {
 	await db.query('ALTER TABLE member_agents ENABLE TRIGGER trg_member_agents_updated');
 }
 
+describe('detectOrphans process reaping', () => {
+	async function insertOrphanRunOnTask(taskId: string): Promise<string> {
+		const result = await db.query<{ id: string }>(
+			`INSERT INTO heartbeat_runs
+			   (team_id, member_id, task_id, status, started_at)
+			 VALUES ($1, $2, $3, $4::heartbeat_run_status, now() - interval '10 minutes')
+			 RETURNING id`,
+			[teamId, agentId, taskId, HeartbeatRunStatus.Running],
+		);
+		return result.rows[0].id;
+	}
+
+	it("kills the orphaned run's in-container processes via the task's project container", async () => {
+		const taskId = await createTask(teamId);
+		const projectRow = await db.query<{ project_id: string }>(
+			'SELECT project_id FROM tasks WHERE id = $1',
+			[taskId],
+		);
+		await db.query(`UPDATE projects SET container_id = $1 WHERE id = $2`, [
+			'orphan-container-1',
+			projectRow.rows[0].project_id,
+		]);
+		const runId = await insertOrphanRunOnTask(taskId);
+
+		const kills: Array<{ containerId: string; runId: string }> = [];
+		await detectOrphans(db, new Set(), undefined, {
+			killProcesses: async (containerId, rid) => {
+				kills.push({ containerId, runId: rid });
+			},
+		});
+
+		expect(kills).toContainEqual({ containerId: 'orphan-container-1', runId });
+	});
+
+	it('skips the kill for task-less runs (no container resolvable)', async () => {
+		const runId = await insertOrphanRun(agentId, teamId);
+
+		const kills: string[] = [];
+		await detectOrphans(db, new Set(), undefined, {
+			killProcesses: async (_cid, rid) => {
+				kills.push(rid);
+			},
+		});
+
+		expect(kills).not.toContain(runId);
+		const run = await db.query<{ status: string }>(
+			'SELECT status FROM heartbeat_runs WHERE id = $1',
+			[runId],
+		);
+		expect(run.rows[0].status).toBe(HeartbeatRunStatus.Failed);
+	});
+
+	it('a kill failure does not fail detection', async () => {
+		const taskId = await createTask(teamId);
+		const projectRow = await db.query<{ project_id: string }>(
+			'SELECT project_id FROM tasks WHERE id = $1',
+			[taskId],
+		);
+		await db.query(`UPDATE projects SET container_id = $1 WHERE id = $2`, [
+			'orphan-container-2',
+			projectRow.rows[0].project_id,
+		]);
+		const runId = await insertOrphanRunOnTask(taskId);
+
+		const count = await detectOrphans(db, new Set(), undefined, {
+			killProcesses: async () => {
+				throw new Error('daemon unreachable');
+			},
+		});
+
+		expect(count).toBeGreaterThanOrEqual(1);
+		const run = await db.query<{ status: string }>(
+			'SELECT status FROM heartbeat_runs WHERE id = $1',
+			[runId],
+		);
+		expect(run.rows[0].status).toBe(HeartbeatRunStatus.Failed);
+	});
+});
+
 describe('healStaleRunState', () => {
 	it('repairs lock, agent status, and claimed wakeup stranded by a lost completion path', async () => {
 		await db.query(`DELETE FROM heartbeat_runs WHERE team_id = $1`, [teamId]);

--- a/packages/server/test/process-sweep-docker.test.ts
+++ b/packages/server/test/process-sweep-docker.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Real-Docker integration test for the dangling-process primitives: the
+ * `/proc` scan (`listHezoProcesses`), pid-list kill (`killPids`), and marker
+ * kill (`killProcessesByEnvMarker`) run against a live container, because the
+ * scan script's shell plumbing (environ parsing, stat-field age math, cmdline
+ * matching) can only regress for real on a real runtime.
+ *
+ * Skipped automatically when Docker is unavailable, HEZO_SKIP_DOCKER is set,
+ * or the agent-base image isn't built locally — same gating as
+ * ssh-agent-docker.test.ts.
+ */
+import { spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { type ContainerProcessInfo, DockerClient } from '../src/services/docker';
+
+const dockerAvailable = await checkDocker();
+const skipReason =
+	!dockerAvailable || process.env.HEZO_SKIP_DOCKER
+		? 'Docker not available or HEZO_SKIP_DOCKER set'
+		: null;
+
+const IMAGE = 'hezo/agent-base:latest';
+const imageReady = skipReason ? false : await imageExists(IMAGE);
+const finalSkipReason =
+	skipReason ??
+	(imageReady
+		? null
+		: `${IMAGE} not built locally — run \`docker build -t ${IMAGE} -f docker/Dockerfile.agent-base docker\``);
+
+let containerId: string;
+let docker: DockerClient;
+
+beforeAll(async () => {
+	if (finalSkipReason) return;
+	const run = await runCommand('docker', ['run', '-d', IMAGE, 'sleep', 'infinity']);
+	expect(run.exitCode).toBe(0);
+	containerId = run.stdout.trim();
+	docker = new DockerClient();
+}, 60_000);
+
+afterAll(async () => {
+	if (finalSkipReason || !containerId) return;
+	await runCommand('docker', ['rm', '-f', containerId]);
+});
+
+async function startMarked(env: Record<string, string>): Promise<void> {
+	const args = ['exec', '-d'];
+	for (const [k, v] of Object.entries(env)) args.push('-e', `${k}=${v}`);
+	args.push(containerId, 'sleep', '300');
+	const res = await runCommand('docker', args);
+	expect(res.exitCode).toBe(0);
+}
+
+async function pollScan(
+	predicate: (procs: ContainerProcessInfo[]) => boolean,
+	timeoutMs = 30_000,
+): Promise<ContainerProcessInfo[]> {
+	const start = Date.now();
+	let procs: ContainerProcessInfo[] = [];
+	while (Date.now() - start < timeoutMs) {
+		procs = await docker.listHezoProcesses(containerId);
+		if (predicate(procs)) return procs;
+		await new Promise((r) => setTimeout(r, 250));
+	}
+	throw new Error(`scan predicate not met; last scan: ${JSON.stringify(procs)}`);
+}
+
+describe.skipIf(finalSkipReason !== null)(
+	'dangling-process primitives — Docker integration',
+	() => {
+		it('scans marked and bridge-socket processes with sane ages, then reaps by pid', async () => {
+			const runId = randomUUID();
+			await startMarked({ HEZO_HEARTBEAT_RUN_ID: runId });
+			await startMarked({ SSH_AUTH_SOCK: '/run/hezo/legacy.sock' });
+
+			const procs = await pollScan(
+				(p) => p.some((x) => x.runId === runId) && p.some((x) => x.runId === null && x.hasHezoSock),
+			);
+
+			const marked = procs.find((p) => p.runId === runId);
+			const legacy = procs.find((p) => p.runId === null && p.hasHezoSock);
+			expect(marked).toBeDefined();
+			expect(legacy).toBeDefined();
+			if (!marked || !legacy) throw new Error('unreachable');
+			expect(marked.cmdline).toContain('sleep');
+			expect(marked.ageSecs).toBeGreaterThanOrEqual(0);
+			expect(marked.ageSecs).toBeLessThan(120);
+			expect(marked.pid).toBeGreaterThan(1);
+
+			await docker.killPids(containerId, [marked.pid, legacy.pid]);
+			await pollScan(
+				(p) => !p.some((x) => x.pid === marked.pid) && !p.some((x) => x.pid === legacy.pid),
+			);
+		}, 90_000);
+
+		it('killProcessesByEnvMarker kills only the matching scope', async () => {
+			const doomed = randomUUID();
+			const survivor = randomUUID();
+			await startMarked({ HEZO_HEARTBEAT_RUN_ID: doomed });
+			await startMarked({ HEZO_HEARTBEAT_RUN_ID: survivor });
+			await pollScan(
+				(p) => p.some((x) => x.runId === doomed) && p.some((x) => x.runId === survivor),
+			);
+
+			await docker.killProcessesByEnvMarker(containerId, 'HEZO_HEARTBEAT_RUN_ID', doomed);
+
+			const procs = await pollScan((p) => !p.some((x) => x.runId === doomed));
+			expect(procs.some((p) => p.runId === survivor)).toBe(true);
+		}, 90_000);
+	},
+);
+
+async function runCommand(
+	cmd: string,
+	args: string[],
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+	return new Promise((resolve) => {
+		const child = spawn(cmd, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+		const out: Buffer[] = [];
+		const err: Buffer[] = [];
+		child.stdout.on('data', (c: Buffer) => out.push(c));
+		child.stderr.on('data', (c: Buffer) => err.push(c));
+		child.on('close', (code) =>
+			resolve({
+				exitCode: code ?? -1,
+				stdout: Buffer.concat(out).toString(),
+				stderr: Buffer.concat(err).toString(),
+			}),
+		);
+	});
+}
+
+async function checkDocker(): Promise<boolean> {
+	try {
+		const result = await runCommand('docker', ['version', '--format', '{{.Server.Version}}']);
+		return result.exitCode === 0;
+	} catch {
+		return false;
+	}
+}
+
+async function imageExists(image: string): Promise<boolean> {
+	const result = await runCommand('docker', ['image', 'inspect', image]);
+	return result.exitCode === 0;
+}

--- a/packages/server/test/process-sweeper.test.ts
+++ b/packages/server/test/process-sweeper.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import type { ContainerProcessInfo } from '../src/services/docker';
+import {
+	collectCandidateRunIds,
+	decideSweepKills,
+	SWEEP_MIN_AGE_SECS,
+} from '../src/services/process-sweeper';
+
+const SUCCEEDED_RUN = '11111111-2222-3333-4444-555555555555';
+const FAILED_RUN = '99999999-8888-7777-6666-555555555555';
+const CHAT_SESSION = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+function proc(over: Partial<ContainerProcessInfo>): ContainerProcessInfo {
+	return {
+		pid: 100,
+		runId: null,
+		hasHezoSock: false,
+		ageSecs: SWEEP_MIN_AGE_SECS + 1_000,
+		cmdline: 'sleep 300',
+		...over,
+	};
+}
+
+describe('collectCandidateRunIds', () => {
+	it('returns UUID-format run ids only, deduped — safe for a ::uuid[] lookup', () => {
+		const ids = collectCandidateRunIds([
+			proc({ runId: SUCCEEDED_RUN }),
+			proc({ runId: SUCCEEDED_RUN }),
+			proc({ runId: 'provision-0123456789abcdef' }),
+			proc({ runId: 'gitop-0123456789abcdef' }),
+			proc({ runId: 'mcp-install-0123456789abcdef' }),
+			proc({ runId: null }),
+			proc({ runId: FAILED_RUN }),
+		]);
+		expect(ids.sort()).toEqual([SUCCEEDED_RUN, FAILED_RUN].sort());
+	});
+});
+
+describe('decideSweepKills', () => {
+	const succeeded = new Set([SUCCEEDED_RUN]);
+
+	it('kills bridge infrastructure regardless of marker or run status', () => {
+		const procs = [
+			proc({
+				pid: 10,
+				runId: SUCCEEDED_RUN,
+				cmdline:
+					'/bin/sh /usr/local/bin/hezo-run-with-bridge /run/hezo/x.sock node tok h:1 -- git fetch',
+			}),
+			proc({ pid: 11, cmdline: '/bin/sh /usr/local/bin/hezo-ssh-bridge tok host 123' }),
+			proc({
+				pid: 12,
+				cmdline:
+					'socat UNIX-LISTEN:/run/hezo/x.sock,fork EXEC:/usr/local/bin/hezo-ssh-bridge tok h 1',
+			}),
+		];
+		expect(decideSweepKills(procs, succeeded)).toEqual([10, 11, 12]);
+	});
+
+	it("preserves a succeeded run's background process (the dev-server case)", () => {
+		const procs = [proc({ pid: 20, runId: SUCCEEDED_RUN, cmdline: 'node dev-server.js' })];
+		expect(decideSweepKills(procs, succeeded)).toEqual([]);
+	});
+
+	it('kills marker-carrying processes of failed/unknown runs, chat sessions, and op tags', () => {
+		const procs = [
+			proc({ pid: 30, runId: FAILED_RUN }),
+			proc({ pid: 31, runId: CHAT_SESSION }),
+			proc({ pid: 32, runId: 'provision-0123456789abcdef' }),
+			proc({ pid: 33, runId: 'gitop-0123456789abcdef' }),
+			proc({ pid: 34, runId: 'mcp-install-0123456789abcdef' }),
+		];
+		expect(decideSweepKills(procs, succeeded)).toEqual([30, 31, 32, 33, 34]);
+	});
+
+	it('kills legacy marker-less processes scoped to a /run/hezo bridge socket', () => {
+		const procs = [
+			proc({
+				pid: 40,
+				runId: null,
+				hasHezoSock: true,
+				cmdline: 'ssh git@github.com git-upload-pack',
+			}),
+		];
+		expect(decideSweepKills(procs, succeeded)).toEqual([40]);
+	});
+
+	it('spares young processes — ops started after boot while reconcile still runs', () => {
+		const procs = [
+			proc({ pid: 50, runId: FAILED_RUN, ageSecs: SWEEP_MIN_AGE_SECS - 1 }),
+			proc({
+				pid: 51,
+				hasHezoSock: true,
+				ageSecs: 5,
+				cmdline: '/bin/sh /usr/local/bin/hezo-ssh-bridge tok host 123',
+			}),
+		];
+		expect(decideSweepKills(procs, succeeded)).toEqual([]);
+	});
+
+	it('never kills PID 1', () => {
+		const procs = [proc({ pid: 1, runId: FAILED_RUN, hasHezoSock: true })];
+		expect(decideSweepKills(procs, succeeded)).toEqual([]);
+	});
+
+	it('leaves unrelated marker-less processes alone', () => {
+		const procs = [proc({ pid: 60, cmdline: 'nginx: worker process' })];
+		expect(decideSweepKills(procs, succeeded)).toEqual([]);
+	});
+});

--- a/packages/server/test/runtime-control.test.ts
+++ b/packages/server/test/runtime-control.test.ts
@@ -3,7 +3,7 @@ import { getActiveRuntime, setActiveRuntime, shutdownRuntime } from '../src/runt
 import type { StartupResult } from '../src/startup';
 
 function fakeRuntime() {
-	const jobManager = { shutdown: vi.fn() };
+	const jobManager = { shutdown: vi.fn(), killLiveRunProcesses: vi.fn(async () => {}) };
 	const chatSessionManager = { stop: vi.fn(async () => {}) };
 	const egressProxy = { releaseAll: vi.fn(async () => {}) };
 	const sshAgentServer = { releaseAll: vi.fn(async () => {}) };
@@ -35,6 +35,11 @@ describe('shutdownRuntime', () => {
 			fakeRuntime();
 
 		await shutdownRuntime(result);
+		// Live-run trees are reaped BEFORE the aborts, so the kill can't race exit.
+		expect(jobManager.killLiveRunProcesses).toHaveBeenCalledTimes(1);
+		expect(jobManager.killLiveRunProcesses.mock.invocationCallOrder[0]).toBeLessThan(
+			jobManager.shutdown.mock.invocationCallOrder[0],
+		);
 		expect(jobManager.shutdown).toHaveBeenCalledTimes(1);
 		expect(chatSessionManager.stop).toHaveBeenCalledTimes(1);
 		expect(egressProxy.releaseAll).toHaveBeenCalledTimes(1);

--- a/scripts/check-docs-ack.ts
+++ b/scripts/check-docs-ack.ts
@@ -1,9 +1,12 @@
 // Commit-msg guard: every commit that touches a doc-bearing surface must carry
 // a `Docs-Checked:` trailer acknowledging the docs-alignment pass (AGENTS.md
 // § Keeping docs in sync with code). Hand-written prose (docs/**, READMEs,
-// .dev/architecture.md) has no drift test, so the acknowledgment is the record
-// that a human or agent actually re-read the affected pages — a commit without
-// it is rejected by .husky/commit-msg.
+// and the internal `.dev/` docs — architecture.md and the design notes) has no
+// drift test, so the acknowledgment is the record that a human or agent
+// actually re-read the affected pages — a commit without it is rejected by
+// .husky/commit-msg. The pass covers BOTH audiences: the user-facing docs/
+// tree and the internal `.dev/` docs (an architecture-altering change must
+// update .dev/architecture.md in the same PR).
 //
 // Pure functions here are unit-tested in packages/server/test/docs-ack-hook.test.ts
 // (same pattern as scripts/coverage — no DB/DOM needed).
@@ -85,7 +88,8 @@ export function checkCommitMessage(
 			ok: false,
 			error:
 				`This commit touches doc-bearing code (${bearing[0]}${bearing.length > 1 ? ` and ${bearing.length - 1} more` : ''}) ` +
-				'but has no Docs-Checked: trailer.',
+				'but has no Docs-Checked: trailer. The docs pass covers docs/**, the READMEs, ' +
+				'AND the internal .dev/ docs (.dev/architecture.md for anything architecture-altering).',
 		};
 	}
 	if (value.length < MIN_ACK_LENGTH || BARE_VALUES.has(value.toLowerCase())) {
@@ -115,11 +119,18 @@ function main(): void {
 			'Every code commit must acknowledge the docs-alignment pass (AGENTS.md § Keeping docs in sync with code).',
 		);
 		console.error(
-			'Re-read the docs pages describing what you changed, then add a trailer, e.g.:\n',
+			'Re-read the doc pages describing what you changed — the user-facing docs/ tree AND the',
 		);
+		console.error(
+			'internal .dev/ docs (.dev/architecture.md must be updated in the same PR for any',
+		);
+		console.error('architecture-altering change) — then add a trailer, e.g.:\n');
 		console.error('  Docs-Checked: updated docs/reference/cli.md for the new --foo flag');
 		console.error(
-			'  Docs-Checked: verified docs/concepts/tasks.md still matches; no other doc surface affected',
+			'  Docs-Checked: updated .dev/architecture.md § Agent execution for the new run phase',
+		);
+		console.error(
+			'  Docs-Checked: verified docs/concepts/tasks.md and .dev/architecture.md still match; no other doc surface affected',
 		);
 		console.error(
 			'  Docs-Checked: internal refactor, no user-visible behaviour or documented surface changed\n',


### PR DESCRIPTION
## Problem

Docker exposes no API to kill an exec'd process — aborting an exec only tears down the attach stream. So timed-out git ops, interrupted chat turns, npm installs, and server restarts/upgrades/crashes left process trees (`hezo-run-with-bridge` → `socat` → `hezo-ssh-bridge` → `git`/`ssh`) running inside the warm project containers forever. Observed in production: weeks-old bridge/ssh trees from git fetches interrupted by upgrades.

## Fix

**Prevention — every abandonable exec is marked and reaped:**
- Universal `HEZO_HEARTBEAT_RUN_ID=<scopeId>` env marker on every exec: run-prep git ops (`ContainerGitExecutor` now takes a required `scopeId`), provisioning/repo-link/reset git ops (`withProvisionBridge`'s `provision-<hex>` id, `gitop-<hex>` for bridge-less route ops), MCP `npm install` execs (`mcp-install-<hex>`), and chat execs (session id).
- Immediate best-effort marker kill on abandonment: git-executor per-op timeout and run abort, mcp-installer timeout, chat interrupt/preempt. Chat execs additionally carry a per-exec `HEZO_EXEC_SCOPE_ID` so interrupting one conversation never kills a sibling conversation's live exec (a session's execs run concurrently).
- Clean shutdown (SIGTERM/update restart) now awaits `JobManager.killLiveRunProcesses()` before aborting runs, and chat teardown reaps its session trees — no more racing `process.exit`.
- The 30s orphan detector reaps an orphaned run's container processes when it marks the run failed.

**Cleanup — boot sweep for previous lifetimes (crash backstop):**
- A 4th `reconcileOnStartup` container pass scans each running container's `/proc` (`DockerClient.listHezoProcesses`) and applies a status-aware policy (`services/process-sweeper.ts`): bridge/socat trees always die; marker-carrying processes die unless their run **succeeded** (so a dev server an agent intentionally left running survives restarts); legacy marker-less trees from older Hezo versions are caught via their `SSH_AUTH_SOCK=/run/hezo/…` env. A 120s age guard protects ops started while reconcile runs; PID 1 is never touched.
- Existing production orphans (pre-marker trees) are reaped automatically on the first boot of this version — no manual cleanup needed.

**Wrapper hardening (`docker/scripts/hezo-run-with-bridge`):**
- socat runs under `setsid` and the exit trap kills the whole process group, so per-connection bridge forks die with the wrapper (they previously survived even clean exits).
- Optional `HEZO_EXEC_DEADLINE_SECS` self-deadline (set by the git executor for bounded ops) runs the wrapped command under `timeout`, so trees self-destruct even if the server dies mid-op. Env-driven — old images × new servers and vice versa stay compatible.

**Also:** the `Docs-Checked:` commit hook guidance now explicitly covers the internal `.dev/` docs.

## Tests

- New `process-sweeper.test.ts` (pure policy), `job-manager-process-sweep.test.ts` (boot sweep through `reconcileOnStartup` + shutdown reap), `process-sweep-docker.test.ts` (real-Docker-gated, `/proc` scan + kills against a live container).
- Extended `docker-client-request.test.ts` (new primitives' scripts + injection-safety), `git-executor.test.ts` (marker env, kill on timeout/abort, none on success), `mcp-installer.test.ts`, `orphan-detector.test.ts`, `chat-session.test.ts` (per-exec vs session-wide kill), `docs-ack-hook.test.ts`.
- `.dev/architecture.md` updated in the same PR (§ Agent execution: new Process-tree lifecycle subsection; § SSH signing & git: wrapper hardening).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018EKHSHDGQ8EndZemrU1QcS

---
_Generated by [Claude Code](https://claude.ai/code/session_018EKHSHDGQ8EndZemrU1QcS)_