### PR TITLE
fix(cli): add `hezo uninstall` to cleanly remove the data directory

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -922,6 +922,18 @@ on `mkdirSync`'s `mode` — that mode is masked by the **process umask**, so a h
 `0o027`/`0o077` under systemd `UMask=`) would silently strip the other-execute bit and the agent
 CLI would die with `EACCES` opening its `settings.json` (again only on native-Linux production).
 
+**Removing the data directory (macOS deny-delete ACL).** The `.previews` bind mount targets
+`/workspace/.previews` — a path *inside* the `/workspace` bind — so Docker Desktop on macOS has
+to materialize a mountpoint directory (`<project>/workspace/.previews`) inside the shared
+workspace folder and tags it with a `deny delete` ACL that a plain `rm -rf ~/.hezo` cannot
+override (it fails with a bare "Permission denied", leaving the whole tree undeletable). Hezo's
+own teardown paths already strip these — `forceRmRecursive` (`services/workspace.ts`) retries
+after `chmod -RN` on darwin — but a user deleting the data directory by hand has no such relief,
+so the **`hezo uninstall`** subcommand (`runUninstall`, `cli.ts`) is the supported removal path:
+it refuses while a live server holds the instance lock, requires an explicit `--yes`, best-effort
+stops+removes every `hezo.team`-labelled container (their ids live in the DB it is about to
+delete), then `forceRmRecursive`s the data dir and the per-run socket dir.
+
 Repo sync (`ensureProjectRepos`, `services/repo-sync.ts`) does **not trust a bare `.git`
 marker** in a repo's reserved workspace directory: an agent may have run `git init` there
 before the repo was connected, leaving a repo with no origin (every fetch then silently

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -128,6 +128,28 @@ this is effectively the only path forward once the master key is lost.
 exits with an error. To start an external database fresh, drop and recreate it with your
 provider's tools.
 
+## Uninstall
+
+```sh
+hezo uninstall [--data-dir <path>] [--yes]
+```
+
+Removes Hezo's **data directory** (default `~/.hezo/`) — every project workspace, the
+embedded database, backups, and settings — and best-effort removes the Docker containers
+Hezo created. It does **not** remove the `hezo` binary itself.
+
+Prefer this over `rm -rf ~/.hezo`. On macOS, Docker Desktop tags Hezo's nested
+`.previews` mount point with a *deny delete* ACL that a plain `rm -rf` can't override, so
+the folder is left behind with a "Permission denied" error. `hezo uninstall` strips those
+ACLs and deletes the tree cleanly.
+
+Stop the server first — uninstall **refuses while a server is running** against the data
+directory (removing it under a live server corrupts the database). Deletion is
+irreversible, so it requires an explicit `--yes`; without it, the command prints exactly
+what would be removed and deletes nothing. Like `hezo backup`, it reads `--data-dir` from
+`HEZO_DATA_DIR` when the flag is omitted. Back up anything you want to keep with
+`hezo backup` first — see [Backup & recovery](/docs/deployment/backup-and-recovery).
+
 ## Info
 
 ```sh

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -543,6 +543,132 @@ export async function runRestore(argv: string[] = process.argv): Promise<boolean
 	return true;
 }
 
+/** Injectable seams for {@link runUninstall} — real Docker cleanup by default. */
+export interface UninstallDeps {
+	/**
+	 * Remove the Docker containers Hezo provisioned. Returns the count removed, or
+	 * `null` when Docker was unreachable. Defaults to the real Docker path;
+	 * overridden in tests so they never touch a live daemon.
+	 */
+	removeContainers?: () => Promise<number | null>;
+}
+
+async function defaultRemoveProvisionedContainers(): Promise<number | null> {
+	const { DockerClient } = await import('./services/docker.js');
+	const { removeProvisionedContainers } = await import('./services/uninstall.js');
+	return removeProvisionedContainers(new DockerClient());
+}
+
+/**
+ * Handle the `hezo uninstall` subcommand and exit. Removes Hezo's **data
+ * directory** (default `~/.hezo`) — every project workspace, the embedded
+ * database, backups, and settings — and best-effort removes the containers Hezo
+ * provisioned. It does not touch the `hezo` binary itself.
+ *
+ * This exists because a plain `rm -rf ~/.hezo` fails on macOS: Docker Desktop
+ * tags the nested `.previews` bind-mount point (`<project>/workspace/.previews`,
+ * a mount target inside the `/workspace` bind) with a `deny delete` ACL that
+ * `rm` cannot override, so the tree is left undeletable with a bare "Permission
+ * denied". `forceRmRecursive` strips those ACLs (`chmod -RN`) and retries, so
+ * `hezo uninstall` is the supported, ACL-aware way to fully remove an instance.
+ *
+ * Guards: refuses while a live embedded server holds the instance lock (stop it
+ * first — deleting the data dir under a live server corrupts its database), and
+ * requires an explicit `--yes`. Without `--yes` it prints exactly what would be
+ * removed and exits without deleting anything.
+ *
+ * Returns `true` when it handled the invocation so the caller skips normal
+ * server startup.
+ */
+export async function runUninstall(
+	argv: string[] = process.argv,
+	deps: UninstallDeps = {},
+): Promise<boolean> {
+	if (argv[2] !== 'uninstall') return false;
+
+	const program = new Command()
+		.name('hezo uninstall')
+		.description(
+			"Remove Hezo's data directory (all projects, the database, backups, settings) and the containers it created",
+		)
+		.option('--data-dir <path>', 'Data directory to remove (env: HEZO_DATA_DIR)', DEFAULT_DATA_DIR)
+		.option('--yes', 'Confirm removal — required; without it nothing is deleted')
+		.parse(argv.slice(3), { from: 'user' });
+
+	const opts = program.opts();
+	const dataDir = pickDataDir(opts.dataDir);
+
+	const { existsSync } = await import('node:fs');
+	if (!existsSync(dataDir)) {
+		console.log(`Nothing to remove: no Hezo data directory at ${dataDir}.`);
+		return true;
+	}
+
+	// Refuse while a live embedded server is using this data dir — removing it
+	// under a running server corrupts the database and leaves containers with
+	// dangling mounts. A stale lock from a crash (dead PID) does not block.
+	const { readLiveInstanceLock, instanceLockPath } = await import('./db/instance-lock.js');
+	const live = readLiveInstanceLock(dataDir);
+	if (live) {
+		throw new Error(
+			`A Hezo server appears to be running against ${dataDir} (PID ${live.pid}). ` +
+				`Stop it before uninstalling. If you are certain no server is running, ` +
+				`delete ${instanceLockPath(dataDir)} and retry.`,
+		);
+	}
+
+	// A destructive, irreversible delete requires an explicit opt-in. Without it,
+	// show exactly what would go and how to confirm — deleting nothing.
+	if (opts.yes !== true) {
+		const dataDirArg =
+			typeof opts.dataDir === 'string' && opts.dataDir !== DEFAULT_DATA_DIR
+				? ` --data-dir ${opts.dataDir}`
+				: '';
+		console.log(
+			`This permanently deletes Hezo's data directory and everything in it:\n` +
+				`  ${dataDir}\n` +
+				`That includes every project workspace, the embedded database, backups, and ` +
+				`settings. The hezo binary itself is not affected.\n\n` +
+				`Re-run with --yes to confirm:\n` +
+				`  hezo uninstall --yes${dataDirArg}`,
+		);
+		return true;
+	}
+
+	// Best-effort container cleanup before the data dir goes: their ids live in
+	// the database we are about to delete, so skipping this orphans them. Never
+	// fatal — Docker may already be stopped.
+	const removeContainers = deps.removeContainers ?? defaultRemoveProvisionedContainers;
+	try {
+		const removed = await removeContainers();
+		if (removed === null) {
+			console.log(
+				'→ Docker not reachable; skipping container cleanup. Remove any leftovers with: ' +
+					'docker rm -f $(docker ps -aq --filter label=hezo.team)',
+			);
+		} else if (removed > 0) {
+			console.log(`→ Removed ${removed} Hezo container(s).`);
+		}
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : String(err);
+		console.log(
+			`→ Could not clean up Hezo containers (${msg}); continuing. Remove any leftovers with: ` +
+				'docker rm -f $(docker ps -aq --filter label=hezo.team)',
+		);
+	}
+
+	// ACL-aware removal: forceRmRecursive strips the macOS Docker Desktop
+	// deny-delete ACLs a plain `rm -rf` chokes on, then retries.
+	const { forceRmRecursive, getRunSocketDir } = await import('./services/workspace.js');
+	forceRmRecursive(dataDir);
+	// Per-run ssh/egress sockets live under the OS temp dir, keyed by a hash of
+	// the data dir — clean those too so nothing is left behind.
+	forceRmRecursive(getRunSocketDir(dataDir));
+
+	console.log(`Removed Hezo data directory: ${dataDir}`);
+	return true;
+}
+
 /**
  * Central configuration resolution. Each option can be set via either a CLI
  * flag or an env var; the env var takes precedence when both are present. The

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs';
 import { AuthType } from '@hezo/shared';
 import { app } from './app';
 import { AssetStorageError } from './assets/errors';
-import { parseConfig, runBackup, runRestore, runVersion } from './cli';
+import { parseConfig, runBackup, runRestore, runUninstall, runVersion } from './cli';
 import type { MasterKeyManager } from './crypto/master-key';
 import { PgDataCorruptError } from './db/client';
 import type { Db } from './db/database';
@@ -100,6 +100,11 @@ if (await runBackup()) {
 	process.exit(0);
 }
 if (await runRestore()) {
+	process.exit(0);
+}
+
+// `hezo uninstall` removes the data directory (ACL-aware) and exits before startup.
+if (await runUninstall()) {
 	process.exit(0);
 }
 

--- a/packages/server/src/services/docker.ts
+++ b/packages/server/src/services/docker.ts
@@ -359,6 +359,23 @@ export class DockerClient {
 		}
 	}
 
+	/**
+	 * List containers (running and stopped) carrying the given label key. Used by
+	 * `hezo uninstall` to find every container Hezo provisioned — they are all
+	 * labelled `hezo.team` (see `provisionContainer`) — so they can be removed
+	 * before the data directory is deleted, since the DB rows that otherwise track
+	 * their ids go away with it.
+	 */
+	async listContainersByLabel(label: string): Promise<Array<{ Id: string; Names: string[] }>> {
+		const filters = encodeURIComponent(JSON.stringify({ label: [label] }));
+		const res = await this.request('GET', `/containers/json?all=true&filters=${filters}`);
+		if (!res.ok) {
+			const text = await res.text();
+			throw new Error(`Docker listContainers failed (${res.status}): ${text}`);
+		}
+		return parseJsonOrThrow<Array<{ Id: string; Names: string[] }>>(res, 'listContainers');
+	}
+
 	async inspectContainer(containerId: string): Promise<ContainerInfo | null> {
 		const res = await this.request(
 			'GET',

--- a/packages/server/src/services/uninstall.ts
+++ b/packages/server/src/services/uninstall.ts
@@ -1,0 +1,45 @@
+import type { DockerClient } from './docker';
+
+/**
+ * The Docker label every Hezo-provisioned container carries (set as
+ * `containerLabels['hezo.team']` in `provisionContainer`). Kept as a local
+ * constant so this module — imported by the `hezo uninstall` subcommand — does
+ * not pull in the heavy `containers.ts` dependency graph just to remove
+ * containers. If the label key ever changes in `provisionContainer`, change it
+ * here too.
+ */
+const HEZO_CONTAINER_LABEL = 'hezo.team';
+
+/**
+ * Best-effort removal of every container Hezo provisioned (any labelled
+ * `hezo.team`, running or stopped). Called by `hezo uninstall` before the data
+ * directory is deleted: those containers' ids live in the database we are about
+ * to remove, so without this they would be orphaned — left running or stopped
+ * with bind mounts into a directory that no longer exists.
+ *
+ * Returns the number of containers removed, or `null` when the Docker daemon is
+ * not reachable (the user may have already quit Docker Desktop) so the caller
+ * can tell "nothing to remove" apart from "could not check". Each container is
+ * stopped then force-removed independently; a failure on one (already stopped,
+ * already gone) never aborts the sweep.
+ */
+export async function removeProvisionedContainers(docker: DockerClient): Promise<number | null> {
+	if (!(await docker.ping())) return null;
+
+	const containers = await docker.listContainersByLabel(HEZO_CONTAINER_LABEL);
+	let removed = 0;
+	for (const container of containers) {
+		try {
+			await docker.stopContainer(container.Id);
+		} catch {
+			// Already stopped, or stop raced removal — force-remove handles it.
+		}
+		try {
+			await docker.removeContainer(container.Id, true);
+			removed++;
+		} catch {
+			// Already removed externally, or removal in progress — skip.
+		}
+	}
+	return removed;
+}

--- a/packages/server/test/cli-uninstall.test.ts
+++ b/packages/server/test/cli-uninstall.test.ts
@@ -1,0 +1,251 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { runUninstall } from '../src/cli';
+import type { DockerClient } from '../src/services/docker';
+import { removeProvisionedContainers } from '../src/services/uninstall';
+import { getRunSocketDir } from '../src/services/workspace';
+
+// Exercises the `hezo uninstall` subcommand end-to-end against real directories
+// on disk. Docker cleanup is always injected so no test touches a live daemon.
+
+const argv = (...tokens: string[]) => ['bun', 'src/index.ts', ...tokens];
+
+const tempDirs: string[] = [];
+function makeDataDir(): string {
+	const dir = mkdtempSync(join(tmpdir(), 'hezo-cli-uninstall-'));
+	tempDirs.push(dir);
+	return dir;
+}
+
+/** Recreate the on-disk shape the phantom-mount bug leaves behind. */
+function seedProjectTree(dataDir: string): string {
+	const projectDir = join(
+		dataDir,
+		'teams',
+		'00000000-0000-0000-0000-000000000001',
+		'projects',
+		'a6630b1a-b1d0-4a8e-a2fe-012b3c69dd9d',
+	);
+	// The nested `workspace/.previews` mountpoint is exactly what a plain rm -rf
+	// trips over on macOS; recreate the layout (sans the ACL, which is darwin-only).
+	mkdirSync(join(projectDir, 'workspace', '.previews'), { recursive: true });
+	mkdirSync(join(projectDir, '.previews', 'agent-1'), { recursive: true });
+	mkdirSync(join(projectDir, 'worktrees'), { recursive: true });
+	writeFileSync(join(projectDir, 'workspace', 'file.md'), 'x');
+	writeFileSync(join(dataDir, 'hezo-secret.dat'), 'y');
+	return projectDir;
+}
+
+let prevDataDir: string | undefined;
+let logSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+	prevDataDir = process.env.HEZO_DATA_DIR;
+	delete process.env.HEZO_DATA_DIR;
+	logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	if (prevDataDir === undefined) delete process.env.HEZO_DATA_DIR;
+	else process.env.HEZO_DATA_DIR = prevDataDir;
+	for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+const noContainers = { removeContainers: async () => 0 };
+
+describe('hezo uninstall subcommand', () => {
+	it('returns false when another (or no) subcommand is invoked', async () => {
+		expect(await runUninstall(argv('--port', '8080'))).toBe(false);
+		expect(await runUninstall(argv('backup'))).toBe(false);
+		expect(await runUninstall(argv('restore', '/tmp/x'))).toBe(false);
+	});
+
+	it('reports nothing to remove when the data dir does not exist', async () => {
+		const dir = join(tmpdir(), `hezo-absent-${process.pid}-never`);
+		expect(existsSync(dir)).toBe(false);
+		expect(await runUninstall(argv('uninstall', '--data-dir', dir, '--yes'), noContainers)).toBe(
+			true,
+		);
+		expect(logSpy.mock.calls.flat().join('\n')).toContain('Nothing to remove');
+	});
+
+	it('without --yes prints what would be removed and deletes nothing', async () => {
+		const dataDir = makeDataDir();
+		seedProjectTree(dataDir);
+
+		expect(await runUninstall(argv('uninstall', '--data-dir', dataDir), noContainers)).toBe(true);
+
+		expect(existsSync(dataDir)).toBe(true); // untouched
+		const out = logSpy.mock.calls.flat().join('\n');
+		expect(out).toContain(dataDir);
+		expect(out).toContain('--yes');
+	});
+
+	it('with --yes removes the whole data directory, including the nested previews tree', async () => {
+		const dataDir = makeDataDir();
+		const projectDir = seedProjectTree(dataDir);
+		expect(existsSync(join(projectDir, 'workspace', '.previews'))).toBe(true);
+
+		expect(
+			await runUninstall(argv('uninstall', '--data-dir', dataDir, '--yes'), noContainers),
+		).toBe(true);
+
+		expect(existsSync(dataDir)).toBe(false);
+		expect(logSpy.mock.calls.flat().join('\n')).toContain(
+			`Removed Hezo data directory: ${dataDir}`,
+		);
+	});
+
+	it('refuses while a live instance lock is present, leaving the dir intact', async () => {
+		const dataDir = makeDataDir();
+		seedProjectTree(dataDir);
+		// A live lock is this test process's own (alive) PID.
+		writeFileSync(join(dataDir, 'hezo.lock'), `${process.pid}\n`, 'utf8');
+
+		await expect(
+			runUninstall(argv('uninstall', '--data-dir', dataDir, '--yes'), noContainers),
+		).rejects.toThrow(/server appears to be running/i);
+		expect(existsSync(dataDir)).toBe(true);
+	});
+
+	it('ignores a stale lock (dead PID) and still removes the dir', async () => {
+		const dataDir = makeDataDir();
+		seedProjectTree(dataDir);
+		// PID 2^31-1 is effectively never a live process.
+		writeFileSync(join(dataDir, 'hezo.lock'), `${2147483647}\n`, 'utf8');
+
+		expect(
+			await runUninstall(argv('uninstall', '--data-dir', dataDir, '--yes'), noContainers),
+		).toBe(true);
+		expect(existsSync(dataDir)).toBe(false);
+	});
+
+	it('reads HEZO_DATA_DIR when --data-dir is omitted', async () => {
+		const dataDir = makeDataDir();
+		seedProjectTree(dataDir);
+		process.env.HEZO_DATA_DIR = dataDir;
+
+		expect(await runUninstall(argv('uninstall', '--yes'), noContainers)).toBe(true);
+		expect(existsSync(dataDir)).toBe(false);
+	});
+
+	it('surfaces the container-cleanup count and continues when cleanup throws', async () => {
+		const dataDir = makeDataDir();
+		seedProjectTree(dataDir);
+
+		expect(
+			await runUninstall(argv('uninstall', '--data-dir', dataDir, '--yes'), {
+				removeContainers: async () => 3,
+			}),
+		).toBe(true);
+		expect(logSpy.mock.calls.flat().join('\n')).toContain('Removed 3 Hezo container(s)');
+		expect(existsSync(dataDir)).toBe(false);
+	});
+
+	it('notes when Docker is unreachable but still removes the dir', async () => {
+		const dataDir = makeDataDir();
+		seedProjectTree(dataDir);
+
+		expect(
+			await runUninstall(argv('uninstall', '--data-dir', dataDir, '--yes'), {
+				removeContainers: async () => null,
+			}),
+		).toBe(true);
+		expect(logSpy.mock.calls.flat().join('\n')).toContain('Docker not reachable');
+		expect(existsSync(dataDir)).toBe(false);
+	});
+
+	it('a container-cleanup failure never aborts the uninstall', async () => {
+		const dataDir = makeDataDir();
+		seedProjectTree(dataDir);
+
+		expect(
+			await runUninstall(argv('uninstall', '--data-dir', dataDir, '--yes'), {
+				removeContainers: async () => {
+					throw new Error('daemon exploded');
+				},
+			}),
+		).toBe(true);
+		expect(logSpy.mock.calls.flat().join('\n')).toContain('Could not clean up Hezo containers');
+		expect(existsSync(dataDir)).toBe(false);
+	});
+
+	it('also removes the per-run socket directory keyed off the data dir', async () => {
+		const dataDir = makeDataDir();
+		seedProjectTree(dataDir);
+		const sockDir = getRunSocketDir(dataDir);
+		mkdirSync(sockDir, { recursive: true });
+		writeFileSync(join(sockDir, 'run.sock'), '');
+		expect(existsSync(sockDir)).toBe(true);
+
+		expect(
+			await runUninstall(argv('uninstall', '--data-dir', dataDir, '--yes'), noContainers),
+		).toBe(true);
+		expect(existsSync(sockDir)).toBe(false);
+	});
+});
+
+describe('removeProvisionedContainers', () => {
+	function stubDocker(overrides: Partial<DockerClient>): DockerClient {
+		return {
+			ping: async () => true,
+			listContainersByLabel: async () => [],
+			stopContainer: async () => {},
+			removeContainer: async () => {},
+			...overrides,
+		} as unknown as DockerClient;
+	}
+
+	it('returns null without listing when the daemon is unreachable', async () => {
+		let listed = false;
+		const docker = stubDocker({
+			ping: async () => false,
+			listContainersByLabel: async () => {
+				listed = true;
+				return [];
+			},
+		});
+		expect(await removeProvisionedContainers(docker)).toBeNull();
+		expect(listed).toBe(false);
+	});
+
+	it('stops and force-removes every labelled container and counts removals', async () => {
+		const stopped: string[] = [];
+		const removed: string[] = [];
+		const docker = stubDocker({
+			listContainersByLabel: async () => [
+				{ Id: 'cid-1', Names: ['/hezo-a-1'] },
+				{ Id: 'cid-2', Names: ['/hezo-b-2'] },
+			],
+			stopContainer: async (id: string) => {
+				stopped.push(id);
+			},
+			removeContainer: async (id: string) => {
+				removed.push(id);
+			},
+		});
+		expect(await removeProvisionedContainers(docker)).toBe(2);
+		expect(stopped).toEqual(['cid-1', 'cid-2']);
+		expect(removed).toEqual(['cid-1', 'cid-2']);
+	});
+
+	it('keeps going when a stop fails, and does not count a failed remove', async () => {
+		const docker = stubDocker({
+			listContainersByLabel: async () => [
+				{ Id: 'cid-1', Names: ['/hezo-a-1'] },
+				{ Id: 'cid-2', Names: ['/hezo-b-2'] },
+			],
+			stopContainer: async (id: string) => {
+				if (id === 'cid-1') throw new Error('already stopped');
+			},
+			removeContainer: async (id: string) => {
+				if (id === 'cid-2') throw new Error('removal in progress');
+			},
+		});
+		// cid-1 removes despite the stop error; cid-2's remove throws → not counted.
+		expect(await removeProvisionedContainers(docker)).toBe(1);
+	});
+});

--- a/packages/server/test/docker-client-request.test.ts
+++ b/packages/server/test/docker-client-request.test.ts
@@ -341,6 +341,34 @@ describe('findContainerByNamePrefix', () => {
 	});
 });
 
+describe('listContainersByLabel', () => {
+	it('filters by label and returns the raw list', async () => {
+		const list = [
+			{ Id: 'cid-1', Names: ['/hezo-app-abcd1234-deadbeef'] },
+			{ Id: 'cid-2', Names: ['/hezo-web-11112222-cafebabe'] },
+		];
+		const calls = stubFetch(() => json(list));
+		await expect(client().listContainersByLabel('hezo.team')).resolves.toEqual(list);
+		const listUrl = calls[0].url;
+		expect(listUrl).toContain('/containers/json?all=true&filters=');
+		expect(decodeURIComponent(listUrl.split('filters=')[1])).toBe(
+			JSON.stringify({ label: ['hezo.team'] }),
+		);
+	});
+
+	it('returns an empty array when nothing carries the label', async () => {
+		stubFetch(() => json([]));
+		await expect(client().listContainersByLabel('hezo.team')).resolves.toEqual([]);
+	});
+
+	it('throws when the list call fails', async () => {
+		stubFetch(() => text('daemon busy', 500));
+		await expect(client().listContainersByLabel('hezo.team')).rejects.toThrow(
+			'Docker listContainers failed (500): daemon busy',
+		);
+	});
+});
+
 describe('containerStats', () => {
 	const statsUrl = (url: string) => url.includes('/stats?stream=false');
 


### PR DESCRIPTION
## Problem

Running Hezo on macOS (Docker Desktop) as a non-root user and then trying to delete the data directory fails:

```
❯ rm -rf ~/.hezo
rm: /Users/ram/.hezo/teams/…/projects/…/workspace/.previews: Permission denied
rm: …/workspace: Directory not empty
…
```

The `.previews` bind mount targets `/workspace/.previews` — a path **inside** the `/workspace` bind — so Docker Desktop has to materialize that mountpoint directory *inside* the shared workspace folder and tags it with a macOS `deny delete` ACL. A plain `rm -rf` can't override the ACL, so the whole tree is left undeletable with a bare "Permission denied".

Hezo already knows how to strip these ACLs (`forceRmRecursive` does `chmod -RN` and retries), but only on its own teardown paths — a user deleting `~/.hezo` by hand had no supported, ACL-aware way to do it.

## Change

Add a `hezo uninstall [--data-dir <path>] [--yes]` subcommand that removes the data directory the right way:

- **ACL-aware deletion** via the existing `forceRmRecursive`, so the macOS deny-delete `.previews` mountpoint is stripped and the tree deletes cleanly. Also clears the per-run socket dir under the OS temp dir (keyed off the data dir).
- **Refuses while a live server holds the instance lock** (deleting the data dir under a running server corrupts its database) — a stale lock from a crash (dead PID) does not block, mirroring `hezo backup`/`hezo restore`.
- **Requires an explicit `--yes`.** Without it, it prints exactly what would be removed and deletes nothing.
- **Best-effort container cleanup:** stops + force-removes every `hezo.team`-labelled container before deleting the DB that tracks their ids, so they aren't orphaned. Non-fatal — if Docker is unreachable it prints a `docker rm -f …` hint and continues.
- Reads `--data-dir` from `HEZO_DATA_DIR` when the flag is omitted, like the other subcommands.

It removes the **data directory only** — the `hezo` binary itself is untouched.

Supporting bits: `DockerClient.listContainersByLabel(label)` (mirrors `findContainerByNamePrefix`) and a small `removeProvisionedContainers` helper in `services/uninstall.ts` (kept out of the heavy `containers.ts` graph).

## Tests

- `test/cli-uninstall.test.ts` — end-to-end against real directories: subcommand dispatch, "nothing to remove", the `--yes` gate (no deletion without it), full removal incl. the nested `workspace/.previews` layout, refusal on a live lock, ignoring a stale (dead-PID) lock, `HEZO_DATA_DIR` resolution, container-cleanup count/`null`/throw handling, and per-run socket-dir cleanup. Plus unit coverage of `removeProvisionedContainers` (unreachable daemon → `null` without listing; stop/remove sweep; failure tolerance).
- `test/docker-client-request.test.ts` — `listContainersByLabel` filter encoding, empty list, and error surfacing.

All touched suites green; `typecheck`, `build`, and `biome check` pass.

## Docs

- `docs/reference/cli.md` — new **Uninstall** section (prefer it over `rm -rf ~/.hezo`, explains the macOS ACL, the server-must-be-stopped + `--yes` guards).
- `.dev/architecture.md` — note in the container run-user / host-file-ownership section on the deny-delete ACL and `hezo uninstall`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQVHYiSUBKM6PPZzv5iaU8)_