### PR TITLE
fix(marketplace): wire roster reporting lines to the Captain on provisioning

### DIFF
--- a/packages/server/migrations/039_repair_marketplace_reporting_lines.sql
+++ b/packages/server/migrations/039_repair_marketplace_reporting_lines.sql
@@ -1,0 +1,41 @@
+--------------------------------------------------------------------------------
+-- REPAIR MARKETPLACE REPORTING LINES
+--------------------------------------------------------------------------------
+-- A provisioning bug dropped the Captain-facing reporting lines of marketplace
+-- team rosters: the Captain is provisioned as a builtin *outside* the roster
+-- array, and the roster wiring pass only resolved `reports_to_slug` against the
+-- roster itself — so every manifest entry saying `reports_to_slug: "captain"`
+-- silently resolved to nothing and the agent was left reporting to no one
+-- (rendered directly under the admin in the org chart). Intra-roster lines
+-- (e.g. engineer → architect) were unaffected.
+--
+-- Repair scope is deliberately narrow. A row is only touched when it:
+--   * is an inline marketplace-provisioned agent (agent_type_id IS NULL),
+--   * currently reports to no one (reports_to IS NULL — a line an admin has
+--     since set by hand is never overwritten),
+--   * carries a slug that a shipped marketplace team manifest points at the
+--     Captain, and
+--   * shares a team with a 'captain' agent.
+
+WITH captain_reports(slug) AS (
+    VALUES
+        -- software-development
+        ('architect'), ('product-lead'), ('marketing-lead'), ('researcher'),
+        -- influencer
+        ('brand-strategist'), ('trend-researcher'), ('distribution-manager'),
+        -- investment
+        ('market-researcher'), ('equity-analyst'), ('catalyst-monitor'),
+        ('risk-verifier'), ('report-writer')
+)
+UPDATE member_agents ma
+SET reports_to = cap.id
+FROM members mem,
+     captain_reports cr,
+     member_agents cap
+     JOIN members capm ON capm.id = cap.id
+WHERE mem.id = ma.id
+  AND ma.agent_type_id IS NULL
+  AND ma.reports_to IS NULL
+  AND ma.slug = cr.slug
+  AND cap.slug = 'captain'
+  AND capm.team_id = mem.team_id;

--- a/packages/server/src/services/team-template-provision.ts
+++ b/packages/server/src/services/team-template-provision.ts
@@ -52,7 +52,8 @@ interface AgentTypeRow {
  * templates (mapped from `AgentTypeRow`, `agent_type_id` set) and marketplace
  * teams (mapped from the fetched JSON, `agent_type_id` null — like a hired agent).
  * Array order is the intended provisioning order; `reports_to_slug` references a
- * sibling roster slug (wired in a second pass).
+ * sibling roster slug or an agent already on the team (e.g. the Captain, which
+ * the marketplace path provisions separately as a builtin) — wired in a second pass.
  */
 export interface RosterAgentDef {
 	slug: string;
@@ -249,7 +250,12 @@ export async function insertRosterAgents(
 
 	for (const def of roster) {
 		if (def.reports_to_slug && def.reports_to_slug !== 'admin') {
-			const reportsToId = slugToMemberId.get(def.reports_to_slug);
+			// Resolve against the roster first, then any agent already on the team —
+			// the Captain is provisioned as a builtin before the roster (never inside
+			// it on the marketplace path), so a `reports_to_slug: "captain"` must fall
+			// back to the existing-members map or the reporting line is silently lost.
+			const reportsToId =
+				slugToMemberId.get(def.reports_to_slug) ?? existingSlugToId.get(def.reports_to_slug);
 			const memberId = slugToMemberId.get(def.slug);
 			if (reportsToId && memberId) {
 				await db.query('UPDATE member_agents SET reports_to = $1 WHERE id = $2', [

--- a/packages/server/test/marketplace.test.ts
+++ b/packages/server/test/marketplace.test.ts
@@ -90,8 +90,10 @@ describe('POST /api/projects with marketplace_slug', () => {
 			headers: authHeader(token),
 		});
 		const agents = (await agentsRes.json()).data as Array<{
+			id: string;
 			slug: string;
 			agent_type_id: string | null;
+			reports_to: string | null;
 		}>;
 		const slugs = agents.map((a) => a.slug);
 		expect(slugs).toContain('captain');
@@ -105,6 +107,30 @@ describe('POST /api/projects with marketplace_slug', () => {
 		expect(engineer?.agent_type_id).toBeNull();
 		const captain = agents.find((a) => a.slug === 'captain');
 		expect(captain?.agent_type_id).not.toBeNull();
+
+		// The full reporting structure from the manifest is wired: the Captain leads
+		// the team (the def's `reports_to_slug: "captain"` entries resolve even though
+		// the Captain is provisioned as a builtin, outside the roster array), the
+		// Architect leads the engineering roles, and the Captain reports to the CEO.
+		const bySlug = new Map(agents.map((a) => [a.slug, a]));
+		const architect = bySlug.get('architect');
+		expect(architect?.reports_to).toBe(captain?.id);
+		for (const lead of ['product-lead', 'marketing-lead', 'researcher']) {
+			expect(bySlug.get(lead)?.reports_to).toBe(captain?.id);
+		}
+		for (const eng of [
+			'engineer',
+			'qa-engineer',
+			'security-engineer',
+			'ui-designer',
+			'devops-engineer',
+		]) {
+			expect(bySlug.get(eng)?.reports_to).toBe(architect?.id);
+		}
+		const ceo = await db.query<{ id: string }>(
+			`SELECT id FROM member_agents WHERE slug = 'ceo' LIMIT 1`,
+		);
+		expect(captain?.reports_to).toBe(ceo.rows[0].id);
 	});
 
 	it('rejects combining marketplace_slug with template_id', async () => {

--- a/packages/server/test/migrate-039-repair-marketplace-reporting-lines.test.ts
+++ b/packages/server/test/migrate-039-repair-marketplace-reporting-lines.test.ts
@@ -1,0 +1,119 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createDataPreservationHarness, type DataPreservationHarness } from './helpers/migrate';
+
+const TARGET = '039_repair_marketplace_reporting_lines.sql';
+
+async function seedAgent(
+	h: DataPreservationHarness,
+	teamId: string,
+	slug: string,
+	opts: { agentTypeId?: string | null; reportsTo?: string | null } = {},
+): Promise<string> {
+	const member = await h.db.query<{ id: string }>(
+		`INSERT INTO members (team_id, member_type, display_name)
+		 VALUES ($1, 'agent', $2) RETURNING id`,
+		[teamId, slug],
+	);
+	const id = member.rows[0].id;
+	await h.db.query(
+		`INSERT INTO member_agents (id, title, slug, agent_type_id, reports_to)
+		 VALUES ($1, $2, $3, $4, $5)`,
+		[id, slug, slug, opts.agentTypeId ?? null, opts.reportsTo ?? null],
+	);
+	return id;
+}
+
+describe('039_repair_marketplace_reporting_lines migration', () => {
+	let h: DataPreservationHarness;
+	let captainId: string;
+	let architectId: string;
+	let researcherId: string;
+	let customRoleId: string;
+	let typedOrphanId: string;
+	let orphanAnalystId: string;
+	let captainTypeId: string;
+
+	beforeAll(async () => {
+		h = await createDataPreservationHarness();
+		await h.applyUpToExclusive(TARGET);
+
+		const team = await h.db.query<{ id: string }>(
+			`INSERT INTO teams (name, slug) VALUES ('Acme', 'acme') RETURNING id`,
+		);
+		const teamId = team.rows[0].id;
+
+		const captainType = await h.db.query<{ id: string }>(
+			`INSERT INTO agent_types (name, slug, role_description, system_prompt_template)
+			 VALUES ('Captain', 'captain', 'Leads the team', 'prompt') RETURNING id`,
+		);
+		captainTypeId = captainType.rows[0].id;
+
+		// The broken marketplace shape: builtin Captain, inline roster members whose
+		// captain-facing reporting line was silently dropped (reports_to NULL).
+		captainId = await seedAgent(h, teamId, 'captain', { agentTypeId: captainTypeId });
+		architectId = await seedAgent(h, teamId, 'architect');
+		// An admin-set reporting line (points at the architect) must survive untouched.
+		researcherId = await seedAgent(h, teamId, 'researcher', { reportsTo: architectId });
+		// A slug no marketplace manifest points at the captain stays admin-level.
+		customRoleId = await seedAgent(h, teamId, 'custom-role');
+		// A catalog-typed agent is not marketplace-inline and must not be rewired.
+		typedOrphanId = await seedAgent(h, teamId, 'product-lead', { agentTypeId: captainTypeId });
+
+		// A team with no captain: a matching slug there must stay untouched.
+		const team2 = await h.db.query<{ id: string }>(
+			`INSERT INTO teams (name, slug) VALUES ('No Captain Co', 'no-captain') RETURNING id`,
+		);
+		orphanAnalystId = await seedAgent(h, team2.rows[0].id, 'equity-analyst');
+
+		await h.applyTarget(TARGET);
+	});
+	afterAll(() => h.close());
+
+	it('repoints a broken captain-report at the team captain', async () => {
+		const r = await h.db.query<{ reports_to: string | null }>(
+			`SELECT reports_to FROM member_agents WHERE id = $1`,
+			[architectId],
+		);
+		expect(r.rows[0].reports_to).toBe(captainId);
+	});
+
+	it('never overwrites an existing reporting line', async () => {
+		const r = await h.db.query<{ reports_to: string | null }>(
+			`SELECT reports_to FROM member_agents WHERE id = $1`,
+			[researcherId],
+		);
+		expect(r.rows[0].reports_to).toBe(architectId);
+	});
+
+	it('leaves slugs outside the marketplace manifests alone', async () => {
+		const r = await h.db.query<{ reports_to: string | null }>(
+			`SELECT reports_to FROM member_agents WHERE id = $1`,
+			[customRoleId],
+		);
+		expect(r.rows[0].reports_to).toBeNull();
+	});
+
+	it('leaves catalog-typed agents alone', async () => {
+		const r = await h.db.query<{ reports_to: string | null }>(
+			`SELECT reports_to FROM member_agents WHERE id = $1`,
+			[typedOrphanId],
+		);
+		expect(r.rows[0].reports_to).toBeNull();
+	});
+
+	it('leaves teams without a captain alone', async () => {
+		const r = await h.db.query<{ reports_to: string | null }>(
+			`SELECT reports_to FROM member_agents WHERE id = $1`,
+			[orphanAnalystId],
+		);
+		expect(r.rows[0].reports_to).toBeNull();
+	});
+
+	it('preserves the captain row and its type', async () => {
+		const r = await h.db.query<{ agent_type_id: string | null }>(
+			`SELECT agent_type_id FROM member_agents WHERE id = $1`,
+			[captainId],
+		);
+		expect(r.rows[0].agent_type_id).toBe(captainTypeId);
+	});
+});


### PR DESCRIPTION
## Problem

Teams launched from the marketplace rendered a broken org chart: the top-level roles (Architect, Product Lead, Marketing Lead, Researcher, …) hung directly off the Admin, with the Captain isolated under the CEO — instead of the Captain leading the team as every manifest and system prompt describes.

Root cause: the Captain is provisioned as a **builtin, outside the roster array** (`ensureBuiltinCaptainFromDef`), while the `reports_to` wiring pass in `insertRosterAgents` resolved `reports_to_slug` **only against the roster array**. Every `reports_to_slug: "captain"` entry therefore resolved to nothing and was silently dropped.

This was functional, not just cosmetic: `assertSubordinateAssignee` validates delegation via `reports_to`, so on every marketplace-provisioned team the Captain could not assign tickets to its own direct reports at all — the default teams' whole delegation model was broken. (Intra-roster lines like engineer → architect were unaffected, as was the snapshot/clone path where the Captain rides in the roster rows.)

## Fix

- **`insertRosterAgents`** now falls back to the team's existing members when resolving `reports_to_slug`, so captain-facing lines wire correctly on fresh launches, add-team-to-project, and re-apply (a re-apply now also repairs a previously broken roster).
- **Migration `039_repair_marketplace_reporting_lines.sql`** repairs existing instances: inline agents (`agent_type_id IS NULL`) with `reports_to IS NULL` whose slug a shipped marketplace manifest points at the Captain are re-pointed at their team's Captain. Admin-set reporting lines, catalog-typed agents, unknown slugs, and captain-less teams are never touched.

## Audit of default team structures and prompts

Went through all three marketplace manifests (`software-development`, `influencer`, `investment`), the compiled `marketplace/teams/*.json`, and every role `.md` (including `blank/captain`, `_instance/ceo`, `_instance/coach`): the reporting lines and prompt prose are mutually consistent everywhere (Captain → CEO → admin; leads → Captain; engineers → Architect; influencer producers → Brand Strategist). The defect was purely in the provisioning wiring — no manifest or prompt changes were needed.

## Tests

- `marketplace.test.ts` now asserts the full App Team reporting graph after provisioning (leads → captain, engineering roles → architect, captain → CEO). Verified it fails without the fix.
- `migrate-039-repair-marketplace-reporting-lines.test.ts` (data-preservation harness): repairs the broken shape, preserves admin-set lines, and leaves non-matching slugs, catalog-typed agents, and captain-less teams untouched.
- Full non-browser suite run: server 5497 passed, web/shared/Bun tiers green (a handful of container-load hook timeouts all pass in isolation). Typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fcr5PZCuKV8X8EYazn6CYi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fcr5PZCuKV8X8EYazn6CYi)_