### PR TITLE
fix(release): never auto-bump the major version from breaking changes

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -1989,7 +1989,14 @@ blocks (the next start overwrites it) and a live server is never mistaken for go
 Postgres manages its own concurrency and writes no lock.
 
 **Releases & updates.** A PR flow (`.github/workflows/`): `release.yml` computes the next
-version from Conventional Commits and opens a `release/<version>` PR; merging fires
+version from Conventional Commits and opens a `release/<version>` PR. The auto bump
+(`scripts/release.ts` → `computeBump`) is derived **purely from commit type** — `feat` →
+minor, any other conventional type → patch — and **never returns `major`**: a breaking-change
+marker (`feat!:` / `BREAKING CHANGE:`) does not escalate the version (pre-1.0 the API is
+explicitly unstable, and major releases are a deliberate human decision, never automated).
+Breaking changes are still listed in the changelog's "Breaking Changes" section so a reviewer
+can choose to cut a major by hand via the workflow's explicit `release-type: major` dispatch
+input. Merging the release PR fires
 `release-publish.yml`, which first builds and publishes the agent-base image to GHCR
 (`ghcr.io/hezo-ai/agent-base:<version>` + `:latest`) and then — **only once that push
 succeeds** — tags the merge commit, cross-compiles, and publishes a GitHub Release (assets

--- a/packages/server/src/release/version.ts
+++ b/packages/server/src/release/version.ts
@@ -13,13 +13,24 @@ export const INITIAL_BASE_VERSION = '0.0.0';
 /** Default first-release version when bumping from {@link INITIAL_BASE_VERSION}. */
 export const FIRST_RELEASE_VERSION = '0.1.0';
 
-/** Derive the bump implied by a set of commits, ignoring any explicit override. */
+/**
+ * Derive the bump implied by a set of commits, ignoring any explicit override.
+ *
+ * A breaking change never escalates the automatic bump, so `computeBump` never
+ * returns `'major'`. Two rules drive this:
+ *   - Major releases are a deliberate, human decision and are never automated —
+ *     they only ever come from an explicit `--release-type major` override.
+ *   - Pre-1.0 (`0.y.z`) the API is explicitly unstable, so the "breaking" marker
+ *     carries no version weight at all; the bump follows the commit *type* alone.
+ *
+ * The auto bump is therefore derived purely from commit type: a `feat` yields a
+ * minor, any other conventional type a patch. Breaking changes are still
+ * surfaced prominently in the changelog (see `renderChangelog`) so a reviewer of
+ * the release PR can choose to cut a major by hand.
+ */
 export function computeBump(commits: ParsedCommit[]): Bump {
 	let bump: Bump = 'none';
 	for (const c of commits) {
-		if (c.breaking) {
-			return 'major';
-		}
 		if (c.type === 'feat') {
 			bump = 'minor';
 		} else if (bump === 'none' && c.type !== '') {

--- a/packages/server/test/release/version.test.ts
+++ b/packages/server/test/release/version.test.ts
@@ -19,13 +19,22 @@ describe('computeBump', () => {
 		expect(computeBump([])).toBe('none');
 	});
 
-	it('returns major when any commit is breaking', () => {
-		expect(computeBump([commit({ type: 'fix' }), commit({ type: 'feat', breaking: true })])).toBe(
-			'major',
-		);
+	it('never auto-derives a major bump, even for a breaking change', () => {
+		// Major releases are a deliberate human decision and are never automated.
+		expect(computeBump([commit({ type: 'feat', breaking: true })])).not.toBe('major');
+		expect(computeBump([commit({ type: 'fix', breaking: true })])).not.toBe('major');
 	});
 
-	it('returns minor when a feat is present without breaking changes', () => {
+	it('does not let a breaking marker escalate the bump (pre-1.0: breaking does not count)', () => {
+		// A breaking `feat` is still just a minor (from the type)...
+		expect(computeBump([commit({ type: 'fix' }), commit({ type: 'feat', breaking: true })])).toBe(
+			'minor',
+		);
+		// ...and a breaking `fix` stays a patch — the `!` carries no version weight.
+		expect(computeBump([commit({ type: 'fix', breaking: true })])).toBe('patch');
+	});
+
+	it('returns minor when a feat is present', () => {
 		expect(computeBump([commit({ type: 'fix' }), commit({ type: 'feat' })])).toBe('minor');
 	});
 


### PR DESCRIPTION
## Summary

The automated release-bump logic derived a **major** version bump from any breaking-change commit marker (`feat!:` / `BREAKING CHANGE:`), so a single breaking commit would automatically cut a major release when a release was prepared. This changes that so **major version changes are never automated** — they are only ever a deliberate human decision.

Concretely, with the repo at `0.30.1` and the `feat(chat)!:` commit already in history:

| Path | Before | After |
|---|---|---|
| `auto` (default / automated) | `1.0.0` (major) | `0.31.0` (minor) |
| explicit `release-type: major` dispatch (human) | `1.0.0` | `1.0.0` (unchanged) |

## Rationale

- **Major releases must be deliberate.** They should never be derived from commit history — only reachable through the `release.yml` workflow's explicit `release-type: major` dispatch input (the manual, human-in-the-loop path).
- **Pre-1.0, breaking changes don't count.** At `0.y.z` the API is explicitly unstable, so the breaking marker carries no version weight at all. The auto bump is now derived **purely from commit type**: `feat` → minor, any other conventional type → patch. `computeBump` therefore never returns `major`.
- Breaking changes are **still surfaced** in the changelog's "Breaking Changes" section, so a reviewer of the release PR can choose to cut a major by hand when warranted.

## Changes

- `packages/server/src/release/version.ts` — `computeBump` no longer short-circuits to `major` on a breaking commit; the bump follows commit type only. Documented the rationale in the function's doc comment.
- `packages/server/test/release/version.test.ts` — replaced the "returns major when breaking" test with assertions that the auto bump never returns `major` (even for breaking commits) and that the breaking marker doesn't escalate the bump. The explicit-override → `major` and `nextVersion('…','major')` behaviours are unchanged and still covered.
- `.dev/architecture.md` — documented the type-only auto bump and the no-auto-major policy under § Releases & updates.

## Testing

- `bunx vitest run test/release/` — 38 passing (conventional, version, changelog).
- `bun run release --dry-run` → `0.31.0` (minor); `bun run release --release-type major --dry-run` → `1.0.0`, confirming the deliberate manual-major path still works.
- Pre-commit hook ran full typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmHhRtMR97Z3KLJZFC75H3

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmHhRtMR97Z3KLJZFC75H3)_