### PR TITLE
fix(project-intake): stop echoing the project description in the CEO greeting

### DIFF
--- a/packages/server/src/services/project-intake.ts
+++ b/packages/server/src/services/project-intake.ts
@@ -50,14 +50,18 @@ function buildGreetingText(input: CreateProjectIntakeInput): string {
 		'',
 		`Before we open it, I want to confirm we're standing up the right team for this work, clarify anything ambiguous in the brief, and lock in the final shape of the project.`,
 		'',
-		`Here's what you submitted:`,
-		'',
-		`**Name:** ${input.name}`,
 	];
+	// The full brief already lives in this ticket's description — echoing it back
+	// here would just duplicate it, so reference it instead.
 	if (input.baselineTeamTypeName) {
-		lines.push(`**Suggested team type:** ${input.baselineTeamTypeName}`);
+		lines.push(
+			`I've read your brief for **${input.name}** above (it's captured in full in this ticket's description, so I won't repeat it here). You picked **${input.baselineTeamTypeName}** as the baseline team type.`,
+		);
+	} else {
+		lines.push(
+			`I've read your brief for **${input.name}** above — it's captured in full in this ticket's description, so I won't repeat it here.`,
+		);
 	}
-	lines.push('**Description:**', '', input.description);
 	if (input.initialProjectPlan) {
 		lines.push(
 			'',
@@ -66,7 +70,7 @@ function buildGreetingText(input: CreateProjectIntakeInput): string {
 	}
 	lines.push(
 		'',
-		`Tell me anything you'd like me to know — users, constraints, deadlines, integrations — and whether the suggested team type fits. Once we're aligned and you give me the go-ahead, I'll create the project and its team.`,
+		`Tell me anything you'd like me to know — users, constraints, deadlines, integrations — and whether the baseline team fits. Once we're aligned and you give me the go-ahead, I'll create the project and its team.`,
 	);
 	return lines.join('\n');
 }

--- a/packages/server/test/project-intake-branches.test.ts
+++ b/packages/server/test/project-intake-branches.test.ts
@@ -65,6 +65,8 @@ describe('createProjectIntake — baseline / plan branches', () => {
 		expect(comments.rows[0].content.text).not.toContain("I'll attach your project plan");
 		// No suggested-team-type line when baselineTeamTypeName is absent.
 		expect(comments.rows[0].content.text).not.toContain('Suggested team type');
+		// The greeting references the description rather than duplicating it.
+		expect(comments.rows[0].content.text).not.toContain('No baseline, no plan');
 	});
 
 	it('uses the template baseline line when only a templateId is given', async () => {

--- a/packages/server/test/project-intake-extended.test.ts
+++ b/packages/server/test/project-intake-extended.test.ts
@@ -55,6 +55,10 @@ describe('createProjectIntake (service)', () => {
 		expect(comments.rows[0].content.text).toContain('App Team');
 		expect(comments.rows[0].content.text).toContain("I'll attach your project plan");
 
+		// The greeting must NOT echo the description back — it already lives in the
+		// ticket description, so re-posting it as a comment is pure duplication.
+		expect(comments.rows[0].content.text).not.toContain('An app with a plan');
+
 		// An Assignment wakeup fired for the CEO.
 		const wakeup = await db.query<{ c: number }>(
 			`SELECT count(*)::int AS c FROM agent_wakeup_requests


### PR DESCRIPTION
## Problem

When you use **Plan with CEO** to open a new project, the CEO's opening comment on the intake ticket repeated your **entire project description** back to you — even though that same description already appears verbatim in the ticket's description field. For a long brief (e.g. a detailed investment-research spec) this dumps a wall of duplicated text into the thread for no benefit.

## Cause

`buildGreetingText` in `packages/server/src/services/project-intake.ts` built the CEO's first comment by appending `**Description:**` + the full `input.description`. But `buildTaskDescription` already writes the same description into the intake ticket's description. Two copies of the same brief.

## Fix

Rewrite `buildGreetingText` to **reference** the brief instead of re-posting it. The greeting still:

- welcomes and explains what happens next,
- names the project and the chosen baseline team type,
- notes any attached project-plan doc (unchanged — the plan doc lives *only* in its own comment, so it's not duplication),
- invites the admin to reply with constraints/users/deadlines,

…but it no longer echoes the description body — it points to the ticket description instead.

The `buildTaskDescription` (the ticket's own description) and the separate project-plan attachment comment are untouched; the description still lives in exactly one place.

## Tests

- Added regression assertions in `project-intake-extended.test.ts` and `project-intake-branches.test.ts` that the greeting comment does **not** contain the description body (guards against the echo creeping back).
- Existing greeting assertions (`I'm the CEO`, team-type name mentioned, plan-attachment line, no `Suggested team type` label when no baseline) still hold.
- `packages/server` intake suites (21 tests) and `packages/web` intake/onboarding suites (5 tests) pass; server typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZPxRKD9X4AiC4WbYQCoUq

---
_Generated by [Claude Code](https://claude.ai/code/session_01GZPxRKD9X4AiC4WbYQCoUq)_