### PR TITLE
fix(coherence): title the first-run setup ticket "Set up the team"

### DIFF
--- a/docs/concepts/marketplace.md
+++ b/docs/concepts/marketplace.md
@@ -26,7 +26,7 @@ includes, and its version. Click a team to see its full details:
 
 **Launch new project** creates a fresh project together with its own team, staffed with the
 whole roster. Give the project a name and description and Hezo provisions the team, opens the
-Captain's planning task, and starts the initial CEO coherence review — exactly like creating a
+Captain's planning task, and starts the initial CEO team-setup pass — exactly like creating a
 project from a team type, but with the marketplace team's roles and prompts.
 
 ## Adding a team to an existing project

--- a/packages/server/src/services/description-tasks.ts
+++ b/packages/server/src/services/description-tasks.ts
@@ -35,6 +35,23 @@ const INITIAL_SETUP_REASONS: ReadonlySet<TeamCoherenceReviewReason> = new Set([
 	'template_applied',
 ]);
 
+/**
+ * The genuine first-run setup pass: a brand-new team with no prior roster. This is
+ * narrower than {@link INITIAL_SETUP_REASONS} (which also owns `template_applied` for the
+ * CEO) — `template_applied` fires when an *existing* roster changed, so it reads as a
+ * roster-change review, not a from-scratch setup. Only `initial` is framed as team setup:
+ * it provisions the team from nothing and may do broader setup work (connectors, hiring,
+ * prompt rewrites), not just re-audit an existing roster.
+ */
+function isFirstRunSetup(reason: TeamCoherenceReviewReason): boolean {
+	return reason === 'initial';
+}
+
+/** The ticket title, framed as team setup for the first-run pass, else a coherence review. */
+function coherenceTaskTitle(reason: TeamCoherenceReviewReason): string {
+	return isFirstRunSetup(reason) ? 'Set up the team' : 'Review team coherence after roster change';
+}
+
 /** Resolves the CEO + the team's own project — coherence/setup live in that project. */
 async function loadTeamContext(db: Db, teamId: string): Promise<TeamCoordinationContext | null> {
 	return loadTeamCoordinationContext(db, teamId);
@@ -155,9 +172,15 @@ ${COHERENCE_CHANGES_HEADER}
 
 ${coherenceChangeLine(reason, changeSummary)}`
 		: '';
-	return `${draftBanner}## Team coherence review
+	// The first-run pass is a from-scratch setup ("was just created"); every reactive
+	// review audits a roster that changed. The audit + rewrite steps below are shared.
+	const heading = isFirstRunSetup(reason) ? '## Team setup' : '## Team coherence review';
+	const intro = isFirstRunSetup(reason)
+		? `The **${teamSlug}** project-team was just created. Set it up: audit its roster`
+		: `The **${teamSlug}** project-team changed (reason: ${reason}). Audit its roster`;
+	return `${draftBanner}${heading}
 
-The **${teamSlug}** project-team changed (reason: ${reason}). Audit its roster — including whether every role's output gets verified by someone other than its author — then rewrite the descriptive blobs that other agents read so they stay accurate. Use \`team_id\` = \`${teamSlug}\` for the tool calls below.
+${intro} — including whether every role's output gets verified by someone other than its author — then rewrite the descriptive blobs that other agents read so they stay accurate. Use \`team_id\` = \`${teamSlug}\` for the tool calls below.
 
 **Steps**
 
@@ -235,7 +258,7 @@ export async function enqueueTeamCoherenceReviewTask(
 		db,
 		ctx,
 		assigneeMemberId,
-		'Review team coherence after roster change',
+		coherenceTaskTitle(reason),
 		body,
 		COHERENCE_LABEL,
 		TaskPriority.High,

--- a/packages/server/test/description-tasks.test.ts
+++ b/packages/server/test/description-tasks.test.ts
@@ -82,7 +82,25 @@ describe('enqueueTeamCoherenceReviewTask', () => {
 		expect(row.labels).toEqual(expect.arrayContaining(['internal', 'team-coherence-review']));
 		expect(row.priority).toBe('high');
 		expect(row.status).toBe('backlog');
-		expect(row.title).toContain('coherence');
+		// Reactive reviews (a change to an existing roster) keep the coherence-review title.
+		expect(row.title).toBe('Review team coherence after roster change');
+	});
+
+	it('titles the first-run (initial) pass as team setup, not a coherence review', async () => {
+		const taskId = await enqueueTeamCoherenceReviewTask(db, teamId, 'initial');
+		const task = await db.query<{ title: string; description: string }>(
+			`SELECT title, description FROM tasks WHERE id = $1`,
+			[taskId],
+		);
+		const row = task.rows[0];
+		// A brand-new team is set up from scratch — the ticket is framed as team setup.
+		expect(row.title).toBe('Set up the team');
+		expect(row.description).toContain('## Team setup');
+		expect(row.description).toContain('was just created');
+		// It is not framed as a reactive roster-change review.
+		expect(row.description).not.toContain('## Team coherence review');
+		// The shared audit + rewrite steps still run.
+		expect(row.description).toContain('list_agents');
 	});
 
 	it('assigns an INITIAL setup review to the CEO (auto-started) and wakes them', async () => {


### PR DESCRIPTION
## What & why

The CEO's initial pass on a brand-new team (reason `initial`) was titled **"Review team coherence after roster change"** — the same title used for every reactive review. But that first-run ticket isn't reviewing a roster that *changed*: the team was just created. It's a from-scratch **team setup** pass that provisions the roster and may do broader setup work (connectors, hiring, prompt rewrites), not just re-audit an existing team. The old title misdescribed it and undersold what it does.

This renames only the genuine first-run pass. Every reactive review — including a template/marketplace apply that changed an *existing* roster — keeps the coherence-review title, since "after roster change" is accurate there.

## Changes

- `packages/server/src/services/description-tasks.ts`
  - Add `isFirstRunSetup(reason)` (`initial` only — narrower than `INITIAL_SETUP_REASONS`, which also owns `template_applied` for CEO ownership) and a `coherenceTaskTitle(reason)` helper.
  - First-run ticket: title **"Set up the team"**, body heading **"## Team setup"**, and an intro that reads "…was just created. Set it up: audit its roster…".
  - Reactive reviews are unchanged: title "Review team coherence after roster change", heading "## Team coherence review", "…changed (reason: …)". The shared audit + rewrite steps are identical for both.
- `packages/server/test/description-tasks.test.ts` — new test asserting the first-run pass is framed as setup; tightened the reactive test to assert the exact coherence-review title.
- `docs/concepts/marketplace.md` — the launch flow now "starts the initial CEO team-setup pass" (was "coherence review").

## Testing

- `bunx vitest run test/description-tasks.test.ts` — 15 passed.
- `bunx vitest run test/projects.test.ts -t coherence` — first-ticket ordering unaffected (keys on the `team-coherence-review` label, which is unchanged).
- `turbo typecheck` + biome clean.

No MCP tool, REST route, or response shape changed — the ticket title is internal task content, so no generated-surface (mcp-api.md / llms.txt / SKILL.md) rebuild was needed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JATbCkxaew7Ar6obu8Kpr7)_