### PR TITLE
fix(mcp): accept human identifiers (not only UUIDs) across reference params

### DIFF
--- a/docs/reference/mcp-api.md
+++ b/docs/reference/mcp-api.md
@@ -127,7 +127,7 @@ Create a new project together with its dedicated team. CEO-only. Call this ONLY 
 | `template_id` | `string` | No | Team-type template id (from list_team_templates). Mutually exclusive with source_team_id; defaults to Blank when neither is given. |
 | `source_team_id` | `string` | No | Existing team to clone into a fresh template. Mutually exclusive with template_id. |
 | `marketplace_slug` | `string` | No | A marketplace team slug (from get_marketplace_team / the intake baseline) to provision the roster from directly. Mutually exclusive with template_id and source_team_id. |
-| `intake_task_id` | `string` | No | The HQ project-intake ticket this fulfils; it is closed with a completion note on success. |
+| `intake_task_id` | `string` | No | The HQ project-intake ticket this fulfils (its identifier, e.g. "HQ-1", or its UUID); it is closed with a completion note on success. |
 
 **Returns:** The new project row plus `team_slug`, `planning_task_id`, `planning_task_identifier`, and the initial coherence/setup ticket (`coherence_task_id`, `coherence_task_identifier`). The coherence ticket is created unassigned and does NOT auto-run on this path — draft its description then call `start_team_setup`. Returns `{ error }` if validation fails.
 
@@ -223,7 +223,7 @@ List a project's tasks. Returns up to 50 tasks ordered by creation date (newest 
 | --- | --- | --- | --- |
 | `project` | `string` | No | Project slug or ID. Omit to use the project your run is already in; instance agents (CEO/Coach) must name the project to act in. |
 | `status` | `string` | No | Filter by status (comma-separated) |
-| `assignee_id` | `string` | No | Filter by assignee member ID |
+| `assignee_id` | `string` | No | Filter by assignee — an agent slug (e.g. "engineer") or a member UUID |
 | `assignee_slug` | `string` | No | Filter by assignee agent slug (alternative to assignee_id) |
 | `excerpt_chars` | `integer` | No | When set, replaces description and rules with first-paragraph excerpts capped at this many characters, plus _truncated and _length companion fields |
 
@@ -302,7 +302,7 @@ Update an task. Agents can use this to change status, update progress, set rules
 | `description` | `string` | No | New description |
 | `status` | `string` | No | New status (backlog, in_progress, review, blocked, done, cancelled). `done` = completed (final); marking a ticket `done` wakes Coach to review it for prompt-learning but leaves it `done`. `cancelled` = abandoned. Re-opening a completed task (done/cancelled) is admin-only. |
 | `priority` | `string` | No | New priority |
-| `assignee_id` | `string` | No | New assignee ID |
+| `assignee_id` | `string` | No | New assignee — an agent slug (e.g. "engineer") or a member UUID |
 | `progress_summary` | `string` | No | Progress summary update |
 | `rules` | `string` | No | How-to-work-on guardrails for this ticket — approach constraints that shape execution (e.g. "run tests before committing", "consult the architect before auth changes"). Not a channel for passing project domain knowledge to other agents; put that in description instead. |
 | `branch_name` | `string` | No | Git branch name for this task |
@@ -448,7 +448,7 @@ List comments for an task. Returns up to 50 most-recent comments (newest first).
 | --- | --- | --- | --- |
 | `project` | `string` | No | Project slug or ID. Omit to use the project your run is already in; instance agents (CEO/Coach) must name the project to act in. |
 | `task_id` | `string` | Yes | Task identifier or UUID |
-| `before` | `string` | No | Comment ID — return only comments created before this one |
+| `before` | `string` | No | A comment id (UUID) or public_id — return only comments created before that one |
 | `excerpt_chars` | `integer` | No | When set, truncates content.text on text-typed comments to this many characters and adds text_truncated/text_length |
 
 **Returns:** Up to 50 comment rows newest-first, each with `id`, `public_id`, `task_id`, `author_member_id`, `author_api_key_id`, `parent_comment_id`, `content_type`, `content`, `chosen_option`, `created_at`, `author_type`, `author_name`, `reactions[]`, and `attachments[]`. Pass `before` to walk older; `excerpt_chars` truncates text comments (adds `text_truncated`/`text_length`).
@@ -500,7 +500,7 @@ Add a comment to an task. In content, reference teammates with @<agent-slug>. Re
 | `project` | `string` | No | Project slug or ID. Omit to use the project your run is already in; instance agents (CEO/Coach) must name the project to act in. |
 | `task_id` | `string` | Yes | Task identifier or UUID |
 | `content` | `string` | Yes | Comment text |
-| `parent_comment_id` | `string` | No | UUID of the comment you are replying to. Setting this wakes that comment's author with source=reply and renders this comment as "replying to ..." in the UI. |
+| `parent_comment_id` | `string` | No | The comment you are replying to — its id (UUID) or its public_id. Setting this wakes that comment's author with source=reply and renders this comment as "replying to ..." in the UI. |
 
 **Returns:** The created comment row (`id`, `public_id`, `created_at`, …), optionally with an advisory `warning` string. Returns `{ error }` if `parent_comment_id` does not belong to the task. Setting `parent_comment_id` wakes the parent comment's author.
 
@@ -1053,7 +1053,7 @@ Test an MCP connector end-to-end from the server side. Resolves the stored OAuth
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
 | `project` | `string` | No | Project slug or ID. Omit to use the project your run is already in; instance agents (CEO/Coach) must name the project to act in. |
-| `connector_id` | `string` | Yes | connector id from list_connectors |
+| `connector_id` | `string` | Yes | connector id or name (both shown by list_connectors) |
 
 **Returns:** `{ ok, status, mcp_url, secret_name, token_prefix, token_length, www_authenticate, body_excerpt, hint }` from a direct server-side probe of the MCP URL. Returns `{ error }` if the connector is missing, not `saas`, or its token cannot be decrypted.
 
@@ -1085,7 +1085,7 @@ Remove one of your project's registered MCP connections. Only connectors owned b
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
 | `project` | `string` | No | Project slug or ID. Omit to use the project your run is already in; instance agents (CEO/Coach) must name the project to act in. |
-| `id` | `string` | Yes | connector id (returned by add_connector or list_connectors) |
+| `id` | `string` | Yes | connector id or name (returned by add_connector or list_connectors) |
 
 **Returns:** `{ removed: true, id }`, or `{ error }` if the connection is not found. Removes only your project's own connector (never a global or another project's).
 

--- a/packages/server/src/lib/resolve.ts
+++ b/packages/server/src/lib/resolve.ts
@@ -149,6 +149,23 @@ export async function resolveTaskId(db: Db, teamId: string, raw: string): Promis
 }
 
 /**
+ * Resolve a task-assignee reference to a member id. A well-formed UUID passes
+ * through untouched — it may name any member (agent or human), preserving the
+ * historical "assignee_id is a raw member UUID" behaviour. A bare slug resolves
+ * to the matching agent member in the team (with the HQ fallback `resolveAgentId`
+ * applies), so agents can reassign by the teammate slug they actually hold rather
+ * than a member UUID they never see.
+ */
+export async function resolveAssigneeId(
+	db: Db,
+	teamId: string,
+	raw: string,
+): Promise<string | null> {
+	if (UUID_RE.test(raw)) return raw;
+	return resolveAgentId(db, teamId, raw);
+}
+
+/**
  * Resolve an agent reference (UUID or slug) within a project team. HQ agents
  * (CEO/Coach) are virtual members of every project team, so a reference that
  * misses the project team falls back to the HQ team — the project's own member

--- a/packages/server/src/mcp/tools.ts
+++ b/packages/server/src/mcp/tools.ts
@@ -77,6 +77,7 @@ import {
 	apiKeyIdFromAuth,
 	resolveActorMemberId,
 	resolveAgentId,
+	resolveAssigneeId,
 	resolveProject,
 	resolveReactorMemberId,
 	resolveTaskId,
@@ -1014,7 +1015,10 @@ export function registerTools(
 		{
 			project: projectArg(),
 			status: z.string().optional().describe('Filter by status (comma-separated)'),
-			assignee_id: z.string().optional().describe('Filter by assignee member ID'),
+			assignee_id: z
+				.string()
+				.optional()
+				.describe('Filter by assignee — an agent slug (e.g. "engineer") or a member UUID'),
 			assignee_slug: z
 				.string()
 				.optional()
@@ -1041,7 +1045,11 @@ export function registerTools(
 				params.push(...statuses);
 				idx += statuses.length;
 			}
-			let assigneeId = args.assignee_id as string | undefined;
+			let assigneeId = args.assignee_id
+				? ((await resolveAssigneeId(db, scope.teamId, args.assignee_id as string)) ?? undefined)
+				: undefined;
+			// An assignee_id that resolves to nobody (unknown slug/id) matches nothing.
+			if (args.assignee_id && !assigneeId) return [];
 			if (!assigneeId && args.assignee_slug) {
 				const agent = await db.query<{ id: string }>(
 					`SELECT ma.id FROM member_agents ma
@@ -1482,7 +1490,10 @@ export function registerTools(
 					'New status (backlog, in_progress, review, blocked, done, cancelled). `done` = completed (final); marking a ticket `done` wakes Coach to review it for prompt-learning but leaves it `done`. `cancelled` = abandoned. Re-opening a completed task (done/cancelled) is admin-only.',
 				),
 			priority: z.string().optional().describe('New priority'),
-			assignee_id: z.string().optional().describe('New assignee ID'),
+			assignee_id: z
+				.string()
+				.optional()
+				.describe('New assignee — an agent slug (e.g. "engineer") or a member UUID'),
 			progress_summary: z.string().optional().describe('Progress summary update'),
 			rules: z
 				.string()
@@ -1514,6 +1525,14 @@ export function registerTools(
 
 			const currentStatus = currentRow?.status;
 			const previousAssigneeId = currentRow?.assignee_id ?? null;
+
+			// Accept a teammate slug (what an agent holds) or a member UUID; every
+			// downstream check + the UPDATE below consumes the resolved member id.
+			if (typeof args.assignee_id === 'string' && args.assignee_id) {
+				const resolvedAssignee = await resolveAssigneeId(db, teamId, args.assignee_id);
+				if (!resolvedAssignee) return { error: `Assignee not found: ${args.assignee_id}` };
+				args.assignee_id = resolvedAssignee;
+			}
 
 			// `done` and `cancelled` are the only terminal states; once a task is
 			// terminal only the admin can re-open it (move it back to active).
@@ -1976,7 +1995,7 @@ export function registerTools(
 			.string()
 			.optional()
 			.describe(
-				'The HQ project-intake ticket this fulfils; it is closed with a completion note on success.',
+				'The HQ project-intake ticket this fulfils (its identifier, e.g. "HQ-1", or its UUID); it is closed with a completion note on success.',
 			),
 	} satisfies z.ZodRawShape;
 	tool(
@@ -2008,9 +2027,15 @@ export function registerTools(
 			// Idempotency: if this fulfils an intake ticket, that ticket must still be
 			// open — otherwise a re-run (e.g. after a timeout) would create a second
 			// project + team. Check before creating anything.
-			const intakeTaskId = input.intake_task_id?.trim() || undefined;
+			const rawIntakeTaskId = input.intake_task_id?.trim() || undefined;
+			let intakeTaskId: string | undefined;
 			let intakeTeamId: string | undefined;
-			if (intakeTaskId) {
+			if (rawIntakeTaskId) {
+				// Accept either the intake ticket's identifier (e.g. "HQ-1") or its
+				// UUID, like every other task reference on the MCP surface. Intake
+				// tickets always live in HQ, so resolve within the default team.
+				intakeTaskId = (await resolveTaskId(db, DEFAULT_TEAM_ID, rawIntakeTaskId)) ?? undefined;
+				if (!intakeTaskId) return { error: 'Intake task not found' };
 				const intake = await db.query<{ status: string; team_id: string }>(
 					'SELECT status::text AS status, team_id FROM tasks WHERE id = $1',
 					[intakeTaskId],
@@ -2343,7 +2368,9 @@ export function registerTools(
 			before: z
 				.string()
 				.optional()
-				.describe('Comment ID — return only comments created before this one'),
+				.describe(
+					'A comment id (UUID) or public_id — return only comments created before that one',
+				),
 			excerpt_chars: z
 				.number()
 				.int()
@@ -2362,7 +2389,7 @@ export function registerTools(
 			if (args.before) {
 				params.push(args.before);
 				conditions.push(
-					`(ic.created_at, ic.id) < (SELECT created_at, id FROM task_comments WHERE id = $${params.length})`,
+					`(ic.created_at, ic.id) < (SELECT created_at, id FROM task_comments WHERE (id::text = $${params.length} OR public_id = $${params.length}) AND task_id = $1 LIMIT 1)`,
 				);
 			}
 			const r = await db.query<Record<string, unknown>>(
@@ -2612,7 +2639,7 @@ export function registerTools(
 				.string()
 				.optional()
 				.describe(
-					'UUID of the comment you are replying to. Setting this wakes that comment\'s author with source=reply and renders this comment as "replying to ..." in the UI.',
+					'The comment you are replying to — its id (UUID) or its public_id. Setting this wakes that comment\'s author with source=reply and renders this comment as "replying to ..." in the UI.',
 				),
 		},
 		async (args, db, auth) => {
@@ -2621,14 +2648,17 @@ export function registerTools(
 			const { teamId, taskId } = scope;
 			let parentCommentId: string | null = null;
 			if (args.parent_comment_id) {
-				const parentCheck = await db.query(
-					'SELECT 1 FROM task_comments WHERE id = $1 AND task_id = $2',
+				// Accept the parent's id (UUID) or its public_id; store the resolved
+				// UUID as the reply FK. `id::text = $1` avoids the uuid-cast error a
+				// raw `id = $1` throws when a public_id is passed.
+				const parentCheck = await db.query<{ id: string }>(
+					'SELECT id FROM task_comments WHERE (id::text = $1 OR public_id = $1) AND task_id = $2 LIMIT 1',
 					[args.parent_comment_id, taskId],
 				);
 				if (parentCheck.rows.length === 0) {
 					return { error: 'parent_comment_id does not belong to this task' };
 				}
-				parentCommentId = args.parent_comment_id as string;
+				parentCommentId = parentCheck.rows[0].id;
 			}
 			const authorMemberId = auth.type === AuthType.Agent ? auth.memberId : null;
 			const authorApiKeyId = apiKeyIdFromAuth(auth);
@@ -5390,7 +5420,7 @@ export function registerTools(
 		'Test an MCP connector end-to-end from the server side. Resolves the stored OAuth token from the vault and makes a direct HTTP call to the MCP server (bypassing the agent container and its egress proxy entirely). Returns the upstream status code, response excerpt, and the secret name + masked-token-prefix used. Use this when oauth_status says "active" but the MCP\'s tools are absent from your tool list — it isolates "is the token still valid against the provider?" from "does the proxy chain in the container work?".',
 		{
 			project: projectArg(),
-			connector_id: z.string().describe('connector id from list_connectors'),
+			connector_id: z.string().describe('connector id or name (both shown by list_connectors)'),
 		},
 		async (args, db, auth) => {
 			const scope = await resolveScope(db, auth, args);
@@ -5406,7 +5436,9 @@ export function registerTools(
 			}>(
 				`SELECT id, name, kind::text AS kind, config, oauth_connection_id
 				 FROM mcp_connections
-				 WHERE id = $1 AND (project_id = $2 OR project_id IS NULL)`,
+				 WHERE (id::text = $1 OR name = $1) AND (project_id = $2 OR project_id IS NULL)
+					 ORDER BY (project_id IS NOT NULL) DESC
+					 LIMIT 1`,
 				[connectorId, scope.projectId],
 			);
 			if (row.rows.length === 0) return { error: 'connector not found' };
@@ -5570,13 +5602,15 @@ export function registerTools(
 		'Remove one of your project\'s registered MCP connections. Only connectors owned by your project can be removed — global "all projects" connectors and other projects\' are managed elsewhere. The next agent run will not see it.',
 		{
 			project: projectArg(),
-			id: z.string().describe('connector id (returned by add_connector or list_connectors)'),
+			id: z
+				.string()
+				.describe('connector id or name (returned by add_connector or list_connectors)'),
 		},
 		async (args, db, auth) => {
 			const scope = await resolveScope(db, auth, args);
 			if ('error' in scope) return scope;
 			const r = await db.query<{ id: string }>(
-				'DELETE FROM mcp_connections WHERE id = $1 AND project_id = $2 RETURNING id',
+				'DELETE FROM mcp_connections WHERE (id::text = $1 OR name = $1) AND project_id = $2 RETURNING id',
 				[args.id as string, scope.projectId],
 			);
 			if (r.rows.length === 0) return { error: 'MCP connection not found' };

--- a/packages/server/test/mcp-tools.test.ts
+++ b/packages/server/test/mcp-tools.test.ts
@@ -1238,6 +1238,45 @@ describe('MCP create_project (CEO creates a project + team on approval)', () => 
 		expect(intakeTask.rows[0].status).toBe('done');
 	});
 
+	it('accepts the intake ticket identifier (e.g. HQ-1), not only its UUID', async () => {
+		const intake = await startIntake(`CEO Identifier ${Date.now()}`);
+		const ceoId = await instanceCeoId(db);
+		const { token: ceoToken } = await mintAgentToken(
+			db,
+			masterKeyManager,
+			ceoId,
+			DEFAULT_TEAM_ID,
+			intake.intake_task_id,
+		);
+
+		// Pass the human-readable identifier the agent sees in the thread, not the UUID.
+		const result = await callToolAs(ceoToken, 'create_project', {
+			name: 'Identifier Project',
+			description: 'Created by passing the intake identifier.',
+			intake_task_id: intake.intake_task_identifier,
+		});
+		expect(result.error).toBeUndefined();
+		expect(result.slug).toBeTruthy();
+
+		// The intake ticket resolved from the identifier is closed.
+		const intakeTask = await db.query<{ status: string }>(
+			'SELECT status::text AS status FROM tasks WHERE id = $1',
+			[intake.intake_task_id],
+		);
+		expect(intakeTask.rows[0].status).toBe('done');
+	});
+
+	it('errors clearly when the intake identifier does not resolve', async () => {
+		const ceoId = await instanceCeoId(db);
+		const { token: ceoToken } = await mintAgentToken(db, masterKeyManager, ceoId, DEFAULT_TEAM_ID);
+		const result = await callToolAs(ceoToken, 'create_project', {
+			name: 'No Intake Project',
+			description: 'Intake reference is bogus.',
+			intake_task_id: 'HQ-999999',
+		});
+		expect(result.error).toBe('Intake task not found');
+	});
+
 	it('is idempotent — a second call on a closed intake errors instead of duplicating', async () => {
 		const intake = await startIntake(`CEO Idem ${Date.now()}`);
 		const ceoId = await instanceCeoId(db);
@@ -1787,6 +1826,133 @@ describe('MCP tool: result shape — no embeddings, opt-in excerpts, size guard'
 			expect(row).toHaveProperty('description_truncated');
 			expect(row).toHaveProperty('description_length');
 		}
+	});
+});
+
+describe('MCP reference params accept the human identifier, not only the UUID', () => {
+	async function captainMemberId(): Promise<string> {
+		const r = await db.query<{ id: string }>(
+			`SELECT ma.id FROM member_agents ma JOIN members m ON m.id = ma.id
+			 WHERE m.team_id = $1 AND ma.slug = 'captain'`,
+			[teamId],
+		);
+		return r.rows[0].id;
+	}
+
+	it('update_task.assignee_id resolves an agent slug to its member id', async () => {
+		const taskRowId = await insertTaskDirect(agentId, 'Reassign by slug');
+		const result = (await callToolViaMcp('update_task', {
+			project: projectId,
+			task_id: taskRowId,
+			assignee_id: 'captain', // the slug an agent holds, not the member UUID
+		})) as { assignee_id?: string; error?: string };
+		expect(result.error).toBeUndefined();
+		expect(result.assignee_id).toBe(await captainMemberId());
+	});
+
+	it('update_task.assignee_id returns a clean error for an unknown slug', async () => {
+		const taskRowId = await insertTaskDirect(agentId, 'Reassign to nobody');
+		const result = (await callToolViaMcp('update_task', {
+			project: projectId,
+			task_id: taskRowId,
+			assignee_id: 'not-a-real-agent',
+		})) as { error?: string };
+		expect(result.error).toContain('Assignee not found');
+	});
+
+	it('list_tasks.assignee_id filters by an agent slug', async () => {
+		const captainId = await captainMemberId();
+		const mine = await insertTaskDirect(captainId, 'Captain task for slug filter');
+		const rows = (await callToolViaMcp('list_tasks', {
+			project: projectId,
+			assignee_id: 'captain', // slug, not member UUID
+		})) as Array<{ id: string; assignee_id: string }>;
+		expect(rows.length).toBeGreaterThan(0);
+		expect(rows.every((r) => r.assignee_id === captainId)).toBe(true);
+		expect(rows.some((r) => r.id === mine)).toBe(true);
+	});
+
+	it('list_comments.before accepts a comment public_id', async () => {
+		const task = (await callToolViaMcp('create_task', {
+			project: projectId,
+			title: 'public_id pagination',
+			assignee_id: agentId,
+		})) as { id: string };
+		for (let i = 0; i < 3; i++) {
+			await db.query(
+				`INSERT INTO task_comments (task_id, content_type, content, created_at)
+				 VALUES ($1, 'text'::comment_content_type, $2::jsonb, now() + ($3 || ' milliseconds')::interval)`,
+				[task.id, JSON.stringify({ text: `c${i}` }), i],
+			);
+		}
+		const all = (await callToolViaMcp('list_comments', {
+			project: projectId,
+			task_id: task.id,
+		})) as Array<{ id: string; public_id: string }>;
+		expect(all.length).toBe(3);
+		const newest = all[0];
+		const older = (await callToolViaMcp('list_comments', {
+			project: projectId,
+			task_id: task.id,
+			before: newest.public_id, // cite by public_id, not the UUID
+		})) as Array<{ id: string }>;
+		expect(older.length).toBe(2);
+		expect(older.some((r) => r.id === newest.id)).toBe(false);
+	});
+
+	it('create_comment.parent_comment_id accepts a public_id and threads the reply', async () => {
+		const task = (await callToolViaMcp('create_task', {
+			project: projectId,
+			title: 'reply by public_id',
+			assignee_id: agentId,
+		})) as { id: string };
+		const parent = (await callToolViaMcp('create_comment', {
+			project: projectId,
+			task_id: task.id,
+			content: 'parent comment',
+		})) as { id: string; public_id: string };
+		const reply = (await callToolViaMcp('create_comment', {
+			project: projectId,
+			task_id: task.id,
+			content: 'child reply',
+			parent_comment_id: parent.public_id, // cite by public_id, not the UUID
+		})) as { parent_comment_id?: string; error?: string };
+		expect(reply.error).toBeUndefined();
+		expect(reply.parent_comment_id).toBe(parent.id);
+	});
+
+	it('test_connector resolves a connector by name (not only id)', async () => {
+		await db.query(
+			`INSERT INTO mcp_connections (name, kind, config, project_id)
+			 VALUES ($1, 'api'::mcp_connection_kind, '{}'::jsonb, $2)`,
+			['named-api-connector', projectId],
+		);
+		const result = (await callToolViaMcp('test_connector', {
+			project: projectId,
+			connector_id: 'named-api-connector', // the name, not the UUID
+		})) as { error?: string };
+		// Resolution reached the kind gate — the old raw `id = $1` would have thrown
+		// "invalid input syntax for type uuid" on a name instead.
+		expect(result.error).toContain('test only meaningful for kind=saas');
+		expect(result.error).not.toContain('connector not found');
+	});
+
+	it('remove_connector resolves a project connector by name (not only id)', async () => {
+		await db.query(
+			`INSERT INTO mcp_connections (name, kind, config, project_id)
+			 VALUES ($1, 'api'::mcp_connection_kind, '{}'::jsonb, $2)`,
+			['removable-by-name', projectId],
+		);
+		const result = (await callToolViaMcp('remove_connector', {
+			project: projectId,
+			id: 'removable-by-name', // the name, not the UUID
+		})) as { removed?: boolean; error?: string };
+		expect(result.error).toBeUndefined();
+		expect(result.removed).toBe(true);
+		const gone = await db.query('SELECT 1 FROM mcp_connections WHERE name = $1', [
+			'removable-by-name',
+		]);
+		expect(gone.rows.length).toBe(0);
 	});
 });
 

--- a/packages/server/test/resolve.test.ts
+++ b/packages/server/test/resolve.test.ts
@@ -1,7 +1,12 @@
 import type { Hono } from 'hono';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { Db } from '../src/db/database';
-import { resolveAgentId, resolveProjectId, resolveTeamId } from '../src/lib/resolve';
+import {
+	resolveAgentId,
+	resolveAssigneeId,
+	resolveProjectId,
+	resolveTeamId,
+} from '../src/lib/resolve';
 import type { Env } from '../src/lib/types';
 import { safeClose } from './helpers';
 import { authHeader, createTestApp, createTestProject, createTestTeam } from './helpers/app';
@@ -129,6 +134,37 @@ describe('resolveAgentId', () => {
 	it('returns null for a slug that belongs to a different team', async () => {
 		const otherTeam = '00000000-0000-0000-0000-000000000099';
 		const result = await resolveAgentId(db, otherTeam, 'architect');
+		expect(result).toBeNull();
+	});
+});
+
+describe('resolveAssigneeId', () => {
+	let architectId: string;
+
+	beforeAll(async () => {
+		const row = await db.query<{ id: string }>(
+			'SELECT m.id FROM members m JOIN member_agents ma ON ma.id = m.id WHERE m.team_id = $1 AND ma.slug = $2',
+			[teamId, 'architect'],
+		);
+		architectId = row.rows[0]?.id;
+		expect(architectId).toBeTruthy();
+	});
+
+	it('resolves an agent slug to the member UUID', async () => {
+		const result = await resolveAssigneeId(db, teamId, 'architect');
+		expect(result).toBe(architectId);
+	});
+
+	it('passes a well-formed UUID through untouched (any member, even unknown)', async () => {
+		// Preserves the historical "assignee_id is a raw member UUID" contract —
+		// existence is validated by the caller, not the resolver.
+		const fakeUuid = '00000000-0000-0000-0000-000000000077';
+		expect(await resolveAssigneeId(db, teamId, architectId)).toBe(architectId);
+		expect(await resolveAssigneeId(db, teamId, fakeUuid)).toBe(fakeUuid);
+	});
+
+	it('returns null for an unknown slug', async () => {
+		const result = await resolveAssigneeId(db, teamId, 'definitely-not-a-real-slug');
 		expect(result).toBeNull();
 	});
 });


### PR DESCRIPTION
## What & why

Agents hold human-readable handles — a task identifier like `HQ-1`, an agent slug, a connector name, a comment `public_id` — but several MCP tool params fed the raw argument straight into a UUID column. Passing the handle threw `invalid input syntax for type uuid` at Postgres.

This was the reported failure: the CEO called `create_project` with `intake_task_id=HQ-1` and crashed, only recovering by looking up the UUID via `get_task(HQ-1)` and retrying.

The shared resolvers in `packages/server/src/lib/resolve.ts` (`resolveTaskId`, `resolveAgentId`, …) already accept **either** the human handle or a UUID, and nearly every tool routes through them. These specific params just skipped the resolver. So this is a real bug of a small class, not a guidance gap — the fix is to make each param accept either form, consistent with the rest of the MCP surface.

## Params fixed

Each now accepts the handle **or** the UUID:

| Tool · param | Accepts |
| --- | --- |
| `create_project.intake_task_id` | intake identifier (`HQ-1`) or UUID — `resolveTaskId`, scoped to HQ |
| `update_task.assignee_id` | agent slug or member UUID — new `resolveAssigneeId` |
| `list_tasks.assignee_id` | agent slug or member UUID — `resolveAssigneeId` |
| `test_connector.connector_id` | connector id or name (prefers the project-owned row that shadows a global one) |
| `remove_connector.id` | connector id or name (project-scoped) |
| `list_comments.before` | comment id (UUID) or `public_id` |
| `create_comment.parent_comment_id` | comment id (UUID) or `public_id`; stores the resolved UUID as the reply FK |

`resolveAssigneeId` is a new shared helper: a well-formed UUID passes through untouched (preserving the "assignee_id is a raw member UUID" contract), while a bare slug resolves to that agent's member id.

For connectors/comments the resolution is an inline `(id::text = $1 OR name/public_id = $1)` match — `id::text` never triggers the uuid-cast error a raw `id = $1` throws on a non-UUID.

## Deliberately out of scope

`goal_id` and the `approval_id` params also hit a UUID column raw, but those references have **no** human-readable form (agents only ever hold their UUIDs), so they're a different concern (defensive validation of a malformed UUID) than the "accepts either" bug reported here. Left untouched to keep the change focused.

## Tests

- `resolve.test.ts` — `resolveAssigneeId` unit behaviour (slug → member id, UUID passthrough, unknown slug → null).
- `mcp-tools.test.ts` — new "reference params accept the human identifier, not only the UUID" block covering all seven paths, plus the existing `create_project` suite extended with an `HQ-1`-identifier path and a clean not-found error.
- Regenerated `docs/reference/mcp-api.md` (`build:docs`); drift tests (`mcp-reference`, `docs-bundle`, `llms-txt`) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G6KEzZdW5K56MA4gaYMbsw

---
_Generated by [Claude Code](https://claude.ai/code/session_01G6KEzZdW5K56MA4gaYMbsw)_