### PR TITLE
fix(web): heal stale goal-suggestion cards on version skew + explain goals

### DIFF
--- a/.dev/architecture.md
+++ b/.dev/architecture.md
@@ -2035,6 +2035,19 @@ instance that can't self-apply falls back to the **"Download"** release link. Th
 banner polls the same way (`useUpdateStatus({ poll: true })`), so it surfaces "Install & restart"
 live on any page the moment the binary is staged — not only after a manual reload.
 
+**Stale-bundle reload prompt.** Independently of the binary self-update, an open tab keeps running
+the web bundle it first loaded; after the server moves to a new version (self-update, redeploy),
+that tab's JS can be older than the server and mis-render data the newer server pushes — e.g. a new
+comment/action `kind` the older bundle doesn't know renders the action-comment renderer's neutral
+"needs a newer version — refresh the page" fallback instead of the real card. `useServerVersionChanged`
+(`hooks/use-stale-bundle.ts`) watches the `current` field of `GET /api/updates/status` and latches
+true once it observes a **different** version than the one first seen this session — a server restart
+drops the WebSocket, and the reconnect's blanket `invalidateQueries` (`useInvalidateOnReconnect`)
+refetches the status, so the new version is observed right after the update lands. The shell's
+`ReloadPromptBanner` (below `UpdateBanner`) then offers a one-click **Refresh** (`location.reload()`).
+Tracking a *change* rather than comparing to a build-time constant means it never false-positives in
+dev, where a stable server version never changes mid-session.
+
 **Self-update & supervisor.** A compiled binary with auto-update enabled
 (`isAutoUpdateEnabled()` — compiled, not `HEZO_DISABLE_AUTO_UPDATE`, not in a container)
 runs as a thin **supervisor** (`supervisor.ts`): it spawns the real server as a **worker**

--- a/packages/web/src/components/comment-renderers/action-comment.tsx
+++ b/packages/web/src/components/comment-renderers/action-comment.tsx
@@ -24,7 +24,20 @@ export function ActionComment({ comment, projectId }: Props) {
 	}
 
 	if (kind !== ActionCommentKind.SetupRepo) {
-		return <p className="text-xs text-text-3 italic">Unknown action: {kind}</p>;
+		// An action kind this bundle doesn't recognize — almost always version skew:
+		// the server was updated to emit a new kind while this tab still runs older
+		// JS (the shell surfaces a "refresh" prompt for exactly this). Degrade to a
+		// neutral, actionable message rather than a raw "Unknown action: <kind>"
+		// string that reads as broken; keep the kind in `title` for debugging.
+		return (
+			<p
+				className="text-xs text-text-3 italic"
+				data-testid="action-unknown"
+				title={kind ? `Unrecognized action: ${kind}` : undefined}
+			>
+				This item needs a newer version to display — refresh the page.
+			</p>
+		);
 	}
 
 	const resolved = comment.chosen_option?.status === 'complete';

--- a/packages/web/src/components/comment-renderers/goal-suggestion-comment.tsx
+++ b/packages/web/src/components/comment-renderers/goal-suggestion-comment.tsx
@@ -1,7 +1,8 @@
 import { ApprovalStatus } from '@hezo/shared';
 import { Check, Target, X } from 'lucide-react';
-import { useResolveGoalSuggestion } from '../../hooks/use-goals';
+import { GOAL_EXPLAINER_TOOLTIP, useResolveGoalSuggestion } from '../../hooks/use-goals';
 import { Button } from '../ui/button';
+import { InfoTooltip } from '../ui/info-tooltip';
 import type { CommentDataOf } from './comment-data';
 
 interface Props {
@@ -62,9 +63,17 @@ export function GoalSuggestionComment({ comment, projectId }: Props) {
 			<div className="flex items-start gap-2">
 				<Target className="w-4 h-4 text-warning-soft-fg shrink-0 mt-0.5" />
 				<div className="flex-1">
-					<p className="text-sm font-medium text-text-1">
-						Suggested goal: <span className="font-semibold">{title}</span>
-					</p>
+					<div className="flex items-start gap-1.5">
+						<p className="text-sm font-medium text-text-1">
+							Suggested goal: <span className="font-semibold">{title}</span>
+						</p>
+						<InfoTooltip
+							label="What is a goal?"
+							content={GOAL_EXPLAINER_TOOLTIP}
+							data-testid="goal-suggestion-info"
+							className="mt-0.5"
+						/>
+					</div>
 					{measurement && <p className="text-xs text-text-2 mt-0.5">Measure: {measurement}</p>}
 					<p className="text-xs text-text-2 mt-0.5">
 						Checked {frequency}

--- a/packages/web/src/components/goals-list.tsx
+++ b/packages/web/src/components/goals-list.tsx
@@ -12,6 +12,7 @@ import {
 } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import {
+	GOAL_EXPLAINER_TOOLTIP,
 	type GoalSuggestion,
 	useCancelQueuedProgressRun,
 	useGoalQueuedRun,
@@ -33,6 +34,7 @@ import { Button } from './ui/button';
 import { ConfirmDialog } from './ui/confirm-dialog';
 import { EmptyState } from './ui/empty-state';
 import { HelpDialog } from './ui/help-dialog';
+import { InfoTooltip } from './ui/info-tooltip';
 import { Tooltip } from './ui/tooltip';
 
 interface GoalsListProps {
@@ -307,7 +309,14 @@ function SuggestedGoals({
 
 	return (
 		<div className="mb-4" data-testid="goal-suggestions">
-			<h2 className="mb-2 text-sm font-semibold text-text-2">Suggested goals</h2>
+			<div className="mb-2 flex items-center gap-1.5">
+				<h2 className="text-sm font-semibold text-text-2">Suggested goals</h2>
+				<InfoTooltip
+					label="What is a goal?"
+					content={GOAL_EXPLAINER_TOOLTIP}
+					data-testid="suggested-goals-info"
+				/>
+			</div>
 			<div className="flex flex-col gap-2">
 				{suggestions.map((s) => (
 					<div

--- a/packages/web/src/components/reload-prompt-banner.tsx
+++ b/packages/web/src/components/reload-prompt-banner.tsx
@@ -1,0 +1,36 @@
+import { RefreshCw } from 'lucide-react';
+import { useServerVersionChanged } from '../hooks/use-stale-bundle';
+import { Button } from './ui/button';
+
+/**
+ * Full-width banner pinned below the nav when the connected server has moved to a
+ * newer version than the one this tab loaded (see {@link useServerVersionChanged}).
+ * The loaded bundle is then stale and may not render data the newer server pushes,
+ * so we prompt a reload — one click loads the current bundle and the display heals.
+ * Renders nothing in the common case (server version unchanged this session).
+ */
+export function ReloadPromptBanner() {
+	const stale = useServerVersionChanged();
+	if (!stale) return null;
+
+	return (
+		<div
+			data-testid="reload-prompt-banner"
+			className="shrink-0 flex flex-col sm:flex-row sm:items-center gap-2 px-4 py-2.5 text-[13px] bg-info-soft text-info-soft-fg border-b border-border"
+		>
+			<span className="flex-1">
+				Hezo was updated in the background. Refresh to load the latest version — some items may not
+				display correctly until you do.
+			</span>
+			<Button
+				type="button"
+				variant="primary"
+				size="sm"
+				data-testid="reload-prompt-refresh"
+				onClick={() => window.location.reload()}
+			>
+				<RefreshCw className="w-3.5 h-3.5" /> Refresh
+			</Button>
+		</div>
+	);
+}

--- a/packages/web/src/hooks/use-goals.ts
+++ b/packages/web/src/hooks/use-goals.ts
@@ -14,6 +14,15 @@ import { toast } from './use-toast';
 
 export type { GoalRunActivity, GoalWithProject, ProgressUpdateRunSummary };
 
+/**
+ * One-liner explaining what a goal is and where it surfaces. Shown in the info
+ * tooltip next to a suggested goal's title on both surfaces that render a
+ * suggestion — the task thread card and the Goals page — so the copy stays in
+ * lockstep.
+ */
+export const GOAL_EXPLAINER_TOOLTIP =
+	"A goal is a high-level objective your team works toward. Approve it to create the goal — it then appears on this project's Goals page, where the Captain tracks progress and re-checks it on the schedule shown.";
+
 /** A pending goal suggestion (a Captain/CEO proposal awaiting admin approval). */
 export interface GoalSuggestion {
 	approval_id: string;

--- a/packages/web/src/hooks/use-stale-bundle.ts
+++ b/packages/web/src/hooks/use-stale-bundle.ts
@@ -1,0 +1,39 @@
+import { useEffect, useRef, useState } from 'react';
+import { useUpdateStatus } from './use-update-check';
+
+/**
+ * True once the connected server reports a *different* running version than the
+ * one first observed this session — i.e. the server was updated (self-update,
+ * redeploy) while this tab stayed open, so the loaded web bundle is now older
+ * than the server. A stale bundle can't understand data the newer server pushes
+ * (e.g. a new comment/action kind renders as the graceful "needs a newer
+ * version" fallback until reload), so the shell surfaces a refresh prompt.
+ *
+ * Detection tracks a *change* in the server's version across the session rather
+ * than comparing against a build-time constant. The server version is refetched
+ * on mount and, crucially, on every WebSocket reconnect (`useInvalidateOnReconnect`
+ * invalidates all queries) — and a server restart is exactly what drops and
+ * re-establishes the socket — so the new version is observed right after the
+ * update lands. Tracking a change (not an absolute value) also means it can't
+ * false-positive in dev: a stable dev server version never "changes" unless you
+ * actually restart onto a new build, where reloading is the correct thing to do.
+ *
+ * Latches: once a change is seen it stays true until the page reloads.
+ */
+export function useServerVersionChanged(): boolean {
+	const { data } = useUpdateStatus();
+	const firstSeen = useRef<string | null>(null);
+	const [changed, setChanged] = useState(false);
+
+	const current = data?.current ?? null;
+	useEffect(() => {
+		if (!current) return;
+		if (firstSeen.current === null) {
+			firstSeen.current = current;
+			return;
+		}
+		if (current !== firstSeen.current) setChanged(true);
+	}, [current]);
+
+	return changed;
+}

--- a/packages/web/src/routes/__root.tsx
+++ b/packages/web/src/routes/__root.tsx
@@ -16,6 +16,7 @@ import { PasswordLogin } from '../components/password-login';
 import { ProjectRail } from '../components/project-rail';
 import { ProjectSidebar } from '../components/project-sidebar';
 import { PwaInstallPrompt } from '../components/pwa-install-prompt';
+import { ReloadPromptBanner } from '../components/reload-prompt-banner';
 import { ScrollToBottomButton } from '../components/scroll-to-bottom-button';
 import { ScrollToTopButton } from '../components/scroll-to-top-button';
 import { CreatePasswordFlow, SetupGate } from '../components/setup/setup-wizard';
@@ -284,6 +285,7 @@ function ShellChrome({ drawerOpen, setDrawerOpen }: ShellChromeProps) {
 			/>
 			<GlobalSearchDialog open={searchOpen} onOpenChange={setSearchOpen} />
 			<UpdateBanner />
+			<ReloadPromptBanner />
 			<div className="flex flex-row flex-1 overflow-hidden w-full">
 				{/* Rail + project sidebar + scrollable main span the full viewport so
 				    the main-panel scrollbar sits on the browser edge, not mid-screen. */}

--- a/packages/web/test/action-comment-branches.test.tsx
+++ b/packages/web/test/action-comment-branches.test.tsx
@@ -1,8 +1,10 @@
 // Branch-coverage tests for the action-comment renderer: setup_repo states
-// (resolved / unresolved / no-projectId), the unknown-action fallback, and
-// delegation to the hire-proposal renderer. Minimal standalone router so the
-// settings <Link>/<Button> resolve.
+// (resolved / unresolved / no-projectId), the graceful unrecognized-kind
+// fallback, and delegation to the hire-proposal + goal-suggestion renderers.
+// Minimal standalone router so the settings <Link>/<Button> resolve; a
+// QueryClient so the goal-suggestion renderer's mutation hook mounts.
 
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {
 	createMemoryHistory,
 	createRootRoute,
@@ -21,8 +23,13 @@ function renderNode(node: React.ReactNode) {
 		routeTree: rootRoute,
 		history: createMemoryHistory({ initialEntries: ['/'] }),
 	});
-	// biome-ignore lint/suspicious/noExplicitAny: opaque router type at the test boundary.
-	return render(<RouterProvider router={router as any} />);
+	const queryClient = new QueryClient();
+	return render(
+		<QueryClientProvider client={queryClient}>
+			{/* biome-ignore lint/suspicious/noExplicitAny: opaque router type at the test boundary. */}
+			<RouterProvider router={router as any} />
+		</QueryClientProvider>,
+	);
 }
 
 function actionComment(
@@ -57,16 +64,45 @@ test('hire_proposal delegates to the HireProposalComment renderer', async () => 
 	expect(card.textContent).toContain('Backend Eng');
 });
 
-test('unknown action kind renders the "Unknown action" fallback', async () => {
-	const { findByText } = renderNode(
-		<ActionComment comment={actionComment({ kind: 'something_new' })} projectId="proj" />,
+test('goal_suggestion delegates to the GoalSuggestionComment renderer', async () => {
+	const { findByTestId } = renderNode(
+		<ActionComment
+			comment={actionComment({
+				kind: 'goal_suggestion',
+				approval_id: 'appr1',
+				title: 'Reach 5k followers',
+				measurement: '5000 followers',
+				check_frequency: 'weekly',
+			})}
+			projectId="proj"
+		/>,
 	);
-	expect((await findByText(/Unknown action/)).textContent).toContain('something_new');
+	// The pending suggestion card renders (not the unrecognized-kind fallback)...
+	const card = await findByTestId('goal-suggestion-pending');
+	expect(card.textContent).toContain('Reach 5k followers');
+	// ...with the info tooltip explaining what a goal is next to the title.
+	await findByTestId('goal-suggestion-info');
 });
 
-test('missing kind renders the unknown-action fallback with empty kind', async () => {
-	const { findByText } = renderNode(<ActionComment comment={actionComment({})} projectId="proj" />);
-	expect((await findByText(/Unknown action/)).textContent).toBe('Unknown action: ');
+test('an unrecognized action kind renders the graceful "needs a newer version" fallback', async () => {
+	const { findByTestId } = renderNode(
+		<ActionComment comment={actionComment({ kind: 'something_new' })} projectId="proj" />,
+	);
+	const fallback = await findByTestId('action-unknown');
+	// No scary "Unknown action: <kind>"; the message tells the user what to do,
+	// and the raw kind is preserved only in the debug `title` attribute.
+	expect(fallback.textContent).toMatch(/needs a newer version to display/i);
+	expect(fallback.textContent).not.toContain('something_new');
+	expect(fallback.getAttribute('title')).toContain('something_new');
+});
+
+test('a missing kind renders the graceful fallback with no debug title', async () => {
+	const { findByTestId } = renderNode(
+		<ActionComment comment={actionComment({})} projectId="proj" />,
+	);
+	const fallback = await findByTestId('action-unknown');
+	expect(fallback.textContent).toMatch(/refresh the page/i);
+	expect(fallback.getAttribute('title')).toBeNull();
 });
 
 test('setup_repo resolved shows the repo identifier from the result', async () => {

--- a/packages/web/test/goal-suggestions.test.tsx
+++ b/packages/web/test/goal-suggestions.test.tsx
@@ -42,6 +42,8 @@ test('the Goals page shows a pending suggestion and approving it creates the goa
 	// The suggestion renders in its own section; it is NOT yet a goal.
 	await findByTestId('goal-suggestions', undefined, { timeout: 15_000 });
 	await findByText('Reach 5k followers');
+	// The section header carries an info tooltip explaining what a goal is.
+	await findByTestId('suggested-goals-info');
 
 	// Approve it → the real goal is created and the suggestion clears.
 	await user.click(await findByTestId('goal-suggestion-approve'));

--- a/packages/web/test/reload-prompt-banner.test.tsx
+++ b/packages/web/test/reload-prompt-banner.test.tsx
@@ -1,0 +1,54 @@
+// The reload-prompt banner surfaces when the connected server moves to a newer
+// version than the one this tab loaded (`useServerVersionChanged`), so a stale
+// bundle self-heals with one click instead of silently mis-rendering new data.
+// The server version is driven by mocking `useUpdateStatus`.
+
+import { render } from '@testing-library/react';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+// Hoisted so the mock factory (evaluated before imports) can read it; tests mutate it.
+const state = vi.hoisted(() => ({ current: '0.31.0' as string | undefined }));
+
+vi.mock('../src/hooks/use-update-check', () => ({
+	useUpdateStatus: () => ({ data: state.current ? { current: state.current } : undefined }),
+}));
+
+import { ReloadPromptBanner } from '../src/components/reload-prompt-banner';
+
+beforeEach(() => {
+	state.current = '0.31.0';
+});
+
+test('stays hidden while the server version is unchanged', () => {
+	const { queryByTestId, rerender } = render(<ReloadPromptBanner />);
+	expect(queryByTestId('reload-prompt-banner')).toBeNull();
+	// A refetch returning the SAME version is not a change.
+	rerender(<ReloadPromptBanner />);
+	expect(queryByTestId('reload-prompt-banner')).toBeNull();
+});
+
+test('prompts a refresh once the server reports a newer version', async () => {
+	const { queryByTestId, findByTestId, rerender } = render(<ReloadPromptBanner />);
+	expect(queryByTestId('reload-prompt-banner')).toBeNull();
+
+	// The server restarts onto a new version; the status query refetches.
+	state.current = '0.32.0';
+	rerender(<ReloadPromptBanner />);
+	const banner = await findByTestId('reload-prompt-banner');
+	expect(banner.textContent).toMatch(/refresh/i);
+
+	// Latches: even if a later poll returns to the original value, it stays.
+	state.current = '0.31.0';
+	rerender(<ReloadPromptBanner />);
+	expect(queryByTestId('reload-prompt-banner')).not.toBeNull();
+});
+
+test('a first observation with no prior version does not falsely trigger', () => {
+	state.current = undefined; // status not loaded yet on first render
+	const { queryByTestId, rerender } = render(<ReloadPromptBanner />);
+	expect(queryByTestId('reload-prompt-banner')).toBeNull();
+	// First real version observed — this is the baseline, not a change.
+	state.current = '0.31.0';
+	rerender(<ReloadPromptBanner />);
+	expect(queryByTestId('reload-prompt-banner')).toBeNull();
+});


### PR DESCRIPTION
## What & why

Goal suggestions were rendering as **`Unknown action: goal_suggestion`** in the task thread until a full page refresh (reported in production).

**Root cause is web-bundle version skew, not a rendering bug.** I verified the current renderer handles `goal_suggestion` correctly (it renders the proper card, not the fallback — see the new test). The realtime path only invalidates + refetches the same API a full refresh uses, and both use the identical skeleton query, so the same bundle renders both identically. The *only* way to see the broken text over realtime but correct cards after a hard refresh is that the open tab was running an **older web bundle than the server** — the server had moved to the version that knows `goal_suggestion`, but the tab still had pre-update JS. A hard refresh loaded the new JS and healed it.

## Changes

**1. Stale display self-heals (the real fix)**
- New `useServerVersionChanged` hook (`hooks/use-stale-bundle.ts`) latches once the server reports a *different* running version than the one first observed this session. A server restart drops the WebSocket, and the reconnect's blanket `invalidateQueries` refetches `GET /api/updates/status`, so the new version is seen right after an update lands.
- New `ReloadPromptBanner` in the shell (below `UpdateBanner`) shows a slim "Hezo was updated — Refresh" banner with a one-click `location.reload()`.
- Tracks a *change* in the server version rather than comparing to a build-time constant, so it never false-positives in dev (a stable dev version never "changes" mid-session).

**2. Graceful fallback**
- The alarming `Unknown action: <kind>` becomes a neutral "This item needs a newer version to display — refresh the page" for any unrecognized action kind (raw kind preserved in the `title` attribute for debugging), so a new kind an older bundle doesn't yet know never reads as broken.

**3. Explain goals (the tooltip ask)**
- An info tooltip next to the suggested-goal title — on both surfaces that render a suggestion (the task-thread card and the Goals page section) — explaining what a goal is and that, once approved, it appears on the project's Goals page where the Captain tracks progress and re-checks it on the shown schedule. Copy lives in one shared constant (`GOAL_EXPLAINER_TOOLTIP`) so the two surfaces stay in lockstep.

## Tests
- `action-comment-branches.test.tsx`: added a `goal_suggestion` render + tooltip case (previously a coverage gap), and updated the two unrecognized-kind cases to assert the graceful message + debug `title`.
- `reload-prompt-banner.test.tsx` (new): hidden while the server version is unchanged; prompts (and latches) once the server reports a newer version; a first observation with no prior version doesn't falsely trigger.
- `goal-suggestions.test.tsx`: asserts the Goals-page section info tooltip.
- `bun run typecheck` and `biome check` clean; the targeted web tests pass.

## Docs
- `.dev/architecture.md` § web update flow documents the new stale-bundle reload prompt. Purely additive frontend UI — no user-facing docs / CLI / MCP / REST surface changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016weoidnLxyvXPWvvwoujYk

---
_Generated by [Claude Code](https://claude.ai/code/session_016weoidnLxyvXPWvvwoujYk)_