### PR TITLE
refactor(web): progressive suggestion-first New Project dialog

### DIFF
--- a/packages/web/src/components/create-project-with-team-dialog.tsx
+++ b/packages/web/src/components/create-project-with-team-dialog.tsx
@@ -1,7 +1,7 @@
 import * as Dialog from '@radix-ui/react-dialog';
 import { useNavigate } from '@tanstack/react-router';
-import { Loader2, MessagesSquare, Sparkles } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { ArrowLeft, ArrowRight, Loader2, MessagesSquare, Search, Sparkles } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
 import { setActiveTeamSlug } from '../hooks/use-active-team-slug';
 import { useContainerHealth } from '../hooks/use-container-health';
 import { useMarketplaceTeams } from '../hooks/use-marketplace';
@@ -12,13 +12,19 @@ import {
 	useHqProject,
 } from '../hooks/use-projects';
 import { useTeamTemplates } from '../hooks/use-team-templates';
+import {
+	buildTeamOptions,
+	rankTeams,
+	SUGGEST_MIN_CHARS,
+	type TeamOption,
+} from '../lib/team-suggestions';
 import { HqContainerNotice } from './hq-container-notice';
 import { ProjectPlanUpload } from './project-plan-upload';
 import { Button } from './ui/button';
 import { Card } from './ui/card';
 import { DialogContent } from './ui/dialog';
-import { InfoTooltip } from './ui/info-tooltip';
 import { Input } from './ui/input';
+import { Tabs } from './ui/tabs';
 import { Textarea } from './ui/textarea';
 
 interface CreateProjectWithTeamDialogProps {
@@ -26,7 +32,7 @@ interface CreateProjectWithTeamDialogProps {
 	onOpenChange: (v: boolean) => void;
 	/**
 	 * Preselect a marketplace team by slug (e.g. when opened from the marketplace's
-	 * "Launch new project" action). The dialog opens with that team selected.
+	 * "Launch new project" action). The dialog opens with that team confirmed.
 	 */
 	initialMarketplaceSlug?: string;
 }
@@ -43,11 +49,9 @@ type Selection =
 	| null;
 
 /**
- * Card highlight for the picked team type / source team. A selected card gets the
- * app's "active" treatment — a bold inverse ring + filled tint (matching the
- * project rail) — so the choice reads clearly at a glance; unselected cards keep
- * the hairline border with a hover cue. The ring carries the signal regardless of
- * hover, and `hover:border-inverse` stops a hovered selection from dimming.
+ * Card highlight for the picked team. A selected card gets the app's "active"
+ * treatment — a bold inverse ring + filled tint — so the choice reads clearly at
+ * a glance; unselected cards keep the hairline border with a hover cue.
  */
 function cardStateClass(selected: boolean): string {
 	return selected
@@ -55,10 +59,51 @@ function cardStateClass(selected: boolean): string {
 		: 'hover:border-border-strong';
 }
 
+/** The stable `data-testid` for a team card, keyed by its source kind. */
+function teamCardTestId(option: TeamOption): string {
+	return option.kind === 'marketplace'
+		? `marketplace-team-card-${option.slug}`
+		: option.kind === 'template'
+			? `team-type-card-${option.name}`
+			: `source-team-card-${option.slug}`;
+}
+
+function TeamCard({
+	option,
+	selected,
+	onSelect,
+	className = '',
+}: {
+	option: TeamOption;
+	selected: boolean;
+	onSelect: () => void;
+	className?: string;
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onSelect}
+			className={`text-left w-full ${className}`}
+			data-testid={teamCardTestId(option)}
+			aria-pressed={selected}
+		>
+			<Card className={`p-3 h-full transition-colors ${cardStateClass(selected)}`}>
+				<h3 className="text-[14px] font-medium mb-1">{option.name}</h3>
+				{option.description && (
+					<p className="text-[12px] text-text-2 mb-2 line-clamp-2">{option.description}</p>
+				)}
+				<p className="text-[11px] text-text-2">{option.meta}</p>
+			</Card>
+		</button>
+	);
+}
+
 /**
- * Projects-primary "New project": each project owns its own team. Pick a team
- * type, name the project, describe it, then either create it straight away or
- * hand the brief to the CEO, who scopes it with you in HQ before it opens.
+ * Projects-primary "New project": each project owns its own team. A progressive
+ * two-step flow — describe the project (name + description + optional plan), pick
+ * from up-to-2 suggested teams ranked from that text, or open the full tabbed
+ * catalog via "View all teams". The Create now / Plan with the CEO actions appear
+ * only once a team is selected.
  */
 export function CreateProjectWithTeamDialog({
 	open,
@@ -73,14 +118,22 @@ export function CreateProjectWithTeamDialog({
 	const [projectPlan, setProjectPlan] = useState('');
 	const [projectPlanFilename, setProjectPlanFilename] = useState<string | null>(null);
 	const [selection, setSelection] = useState<Selection>(null);
+	const [step, setStep] = useState<'entry' | 'all'>('entry');
+	const [tab, setTab] = useState<'new' | 'copy'>('new');
+	const [search, setSearch] = useState('');
 
-	// When opened from the marketplace, preselect that team so the dialog is the
-	// standard create-project flow with the choice already made.
+	// Every fresh open resets the navigation state and either preselects the
+	// marketplace team (from the marketplace launch action) or clears the choice.
 	useEffect(() => {
-		if (open && initialMarketplaceSlug) {
-			setSelection({ kind: 'marketplace', slug: initialMarketplaceSlug });
-		}
+		if (!open) return;
+		setStep('entry');
+		setTab('new');
+		setSearch('');
+		setSelection(
+			initialMarketplaceSlug ? { kind: 'marketplace', slug: initialMarketplaceSlug } : null,
+		);
 	}, [open, initialMarketplaceSlug]);
+
 	const createProject = useCreateProjectWithTeam();
 	const startIntake = useStartProjectIntake();
 	const navigate = useNavigate();
@@ -90,23 +143,32 @@ export function CreateProjectWithTeamDialog({
 	// until the HQ container is running. Block the form until then.
 	const blockedHealth = hqHealth && hqHealth.kind !== 'healthy' ? hqHealth : null;
 
-	// Existing teams the new project's team can be cloned from, reached through
-	// each project. HQ (the internal team) is already excluded by
-	// useAllVisibleProjects — snapshotting it would carry the CEO/Coach into the roster.
-	const sourceTeams = projects.map((p) => ({
-		id: p.team_id,
-		slug: p.team_slug,
-		name: p.team_name,
-		agent_count: p.agent_count,
-	}));
+	// The unified option list across the three sources. HQ (the internal team) is
+	// already excluded from `projects` by useAllVisibleProjects.
+	const options = useMemo(
+		() =>
+			buildTeamOptions(
+				marketplaceTeams ?? [],
+				templates ?? [],
+				projects.map((p) => ({
+					id: p.team_id,
+					slug: p.team_slug,
+					name: p.team_name,
+					agent_count: p.agent_count,
+				})),
+			),
+		[marketplaceTeams, templates, projects],
+	);
+	const newOptions = useMemo(() => options.filter((o) => o.group === 'new'), [options]);
+	const copyOptions = useMemo(() => options.filter((o) => o.group === 'copy'), [options]);
+	const showTabs = copyOptions.length > 0;
 
 	const pending = createProject.isPending || startIntake.isPending;
 	const canSubmit =
 		name.trim().length > 0 && description.trim().length > 0 && !!selection && !pending;
 	const error = createProject.error || startIntake.error;
 
-	// The chosen source as request fields: a marketplace slug, a template id, or a
-	// source-team id. Every create path (Create now / Plan with the CEO) spreads these.
+	// The chosen source as request fields; every create path spreads these.
 	const sourceFields =
 		selection?.kind === 'marketplace'
 			? { marketplace_slug: selection.slug }
@@ -116,12 +178,44 @@ export function CreateProjectWithTeamDialog({
 					? { source_team_id: selection.id }
 					: null;
 
+	function isSelected(option: TeamOption): boolean {
+		if (!selection) return false;
+		if (option.kind === 'marketplace')
+			return selection.kind === 'marketplace' && selection.slug === option.slug;
+		if (option.kind === 'template')
+			return selection.kind === 'template' && selection.id === option.id;
+		return selection.kind === 'team' && selection.id === option.id;
+	}
+	function optionToSelection(option: TeamOption): Selection {
+		if (option.kind === 'marketplace') return { kind: 'marketplace', slug: option.slug };
+		if (option.kind === 'template') return { kind: 'template', id: option.id };
+		return { kind: 'team', id: option.id };
+	}
+	const selectedOption = options.find((o) => isSelected(o)) ?? null;
+
+	// Entry step: prompt until the description has signal, then up-to-2 ranked
+	// suggestions (falling back to the first team types when nothing matches).
+	const showPrompt = description.trim().length < SUGGEST_MIN_CHARS;
+	const ranked = rankTeams(`${name} ${description}`, options, 2);
+	const suggestions = ranked.length > 0 ? ranked : newOptions.slice(0, 2);
+
+	// All-teams step: the active tab's list, filtered by the search box.
+	const activeGroup = showTabs ? tab : 'new';
+	const activeOptions = activeGroup === 'copy' ? copyOptions : newOptions;
+	const query = search.trim().toLowerCase();
+	const filtered = query
+		? activeOptions.filter((o) => `${o.name} ${o.description}`.toLowerCase().includes(query))
+		: activeOptions;
+
 	function reset() {
 		setName('');
 		setDescription('');
 		setProjectPlan('');
 		setProjectPlanFilename(null);
 		setSelection(null);
+		setStep('entry');
+		setTab('new');
+		setSearch('');
 	}
 
 	async function handleCreateNow() {
@@ -168,7 +262,7 @@ export function CreateProjectWithTeamDialog({
 
 	return (
 		<Dialog.Root open={open} onOpenChange={onOpenChange}>
-			<DialogContent size="lg">
+			<DialogContent size={step === 'all' ? 'xl' : 'lg'}>
 				<Dialog.Title className="text-base font-medium mb-1 pr-8">New project</Dialog.Title>
 				{hq && blockedHealth ? (
 					<>
@@ -183,9 +277,10 @@ export function CreateProjectWithTeamDialog({
 					</>
 				) : (
 					<>
-						<Dialog.Description className="text-sm text-text-2 mb-4">
-							Each project gets its own team. Pick a team type to staff it, then create it now or
-							let the CEO scope it with you first.
+						<Dialog.Description className={step === 'all' ? 'sr-only' : 'text-sm text-text-2 mb-4'}>
+							{step === 'all'
+								? 'Choose a team to staff this project.'
+								: 'Each project gets its own team. Name it, describe it, and we’ll suggest a team to staff it.'}
 						</Dialog.Description>
 						<form
 							onSubmit={(e) => {
@@ -194,178 +289,191 @@ export function CreateProjectWithTeamDialog({
 							}}
 							className="flex flex-col gap-4"
 						>
-							<Input
-								label="Project name"
-								value={name}
-								onChange={(e) => setName(e.target.value)}
-								placeholder="e.g. Marketing Site"
-								required
-							/>
-							<Textarea
-								label="Description"
-								value={description}
-								onChange={(e) => setDescription(e.target.value)}
-								required
-								rows={4}
-								placeholder="What is this project? Domain, users, and the core problem it solves."
-							/>
-							<div className="flex flex-col gap-1.5">
-								<span className="flex items-center gap-1.5 text-[13px] font-medium text-text-1">
-									Project plan document (optional)
-									<InfoTooltip
-										label="What is a project plan document?"
-										data-testid="project-plan-help"
-										content="Attach a fuller document describing what this project is for when the description above isn't enough — goals, scope, context, constraints. For a software team the Captain uses it to write the formal PRD; for other teams it's used directly as the plan."
+							{step === 'entry' ? (
+								<>
+									<Input
+										label="Project name"
+										value={name}
+										onChange={(e) => setName(e.target.value)}
+										placeholder="e.g. Marketing Site"
+										required
 									/>
-								</span>
-								<ProjectPlanUpload
-									value={projectPlan}
-									filename={projectPlanFilename}
-									onChange={(v, f) => {
-										setProjectPlan(v);
-										setProjectPlanFilename(f);
-									}}
-								/>
-							</div>
-							<div>
-								<span className="text-[13px] font-medium text-text-1">Team type</span>
-								{isLoading ? (
-									<div className="flex items-center gap-2 text-text-2 text-[13px] py-4">
-										<Loader2 className="w-4 h-4 animate-spin" /> Loading types…
-									</div>
-								) : (
-									<div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-2">
-										{(marketplaceTeams ?? []).map((mt) => {
-											const selected =
-												selection?.kind === 'marketplace' && selection.slug === mt.slug;
-											return (
+									<Textarea
+										label="Description"
+										value={description}
+										onChange={(e) => setDescription(e.target.value)}
+										required
+										rows={4}
+										className="resize-none! overflow-y-auto"
+										placeholder="What is this project? Domain, users, and the core problem it solves."
+									/>
+									<ProjectPlanUpload
+										value={projectPlan}
+										filename={projectPlanFilename}
+										onChange={(v, f) => {
+											setProjectPlan(v);
+											setProjectPlanFilename(f);
+										}}
+									/>
+									{selectedOption ? (
+										<div data-testid="selected-team-card">
+											<div className="flex items-center justify-between mb-2">
+												<span className="text-[13px] font-medium text-text-1">Selected team</span>
 												<button
-													key={`mp-${mt.slug}`}
 													type="button"
-													onClick={() => setSelection({ kind: 'marketplace', slug: mt.slug })}
-													className="text-left"
-													data-testid={`marketplace-team-card-${mt.slug}`}
-													aria-pressed={selected}
+													onClick={() => setStep('all')}
+													className="text-[12.5px] text-accent hover:underline inline-flex items-center gap-1"
+													data-testid="choose-different-team"
 												>
-													<Card
-														className={`p-3 h-full transition-colors ${cardStateClass(selected)}`}
-													>
-														<h3 className="text-[14px] font-medium mb-1">{mt.name}</h3>
-														{mt.description && (
-															<p className="text-[12px] text-text-2 mb-2 line-clamp-2">
-																{mt.description}
-															</p>
-														)}
-														<p className="text-[11px] text-text-2">
-															{mt.roster_count} role{mt.roster_count === 1 ? '' : 's'}
-														</p>
-													</Card>
+													Choose a different team <ArrowRight className="w-3 h-3" />
 												</button>
-											);
-										})}
-										{(templates ?? []).map((tpl) => {
-											const selected = selection?.kind === 'template' && selection.id === tpl.id;
-											return (
+											</div>
+											<TeamCard option={selectedOption} selected onSelect={() => setStep('all')} />
+										</div>
+									) : (
+										<div>
+											<div className="flex items-center justify-between mb-2">
+												<span className="text-[13px] font-medium text-text-1">Suggested teams</span>
 												<button
-													key={tpl.id}
 													type="button"
-													onClick={() => setSelection({ kind: 'template', id: tpl.id })}
-													className="text-left"
-													data-testid={`team-type-card-${tpl.name}`}
-													aria-pressed={selected}
+													onClick={() => setStep('all')}
+													className="text-[12.5px] text-accent hover:underline inline-flex items-center gap-1"
+													data-testid="view-all-teams"
 												>
-													<Card
-														className={`p-3 h-full transition-colors ${cardStateClass(selected)}`}
-													>
-														<h3 className="text-[14px] font-medium mb-1">{tpl.name}</h3>
-														{tpl.description && (
-															<p className="text-[12px] text-text-2 mb-2 line-clamp-2">
-																{tpl.description}
-															</p>
-														)}
-														<p className="text-[11px] text-text-2">
-															{tpl.agent_types.length === 0
-																? 'Captain only'
-																: `${tpl.agent_types.length} agent role${
-																		tpl.agent_types.length === 1 ? '' : 's'
-																	}`}
-														</p>
-													</Card>
+													View all teams <ArrowRight className="w-3 h-3" />
 												</button>
-											);
-										})}
-									</div>
-								)}
-							</div>
-							{sourceTeams.length > 0 && (
-								<div>
-									<span className="text-[13px] font-medium text-text-1">Copy an existing team</span>
-									<p className="text-[12px] text-text-2">
-										Start from another team's roster. A reusable team type is saved from its current
-										setup.
-									</p>
-									<div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-2">
-										{sourceTeams.map((team) => {
-											const selected = selection?.kind === 'team' && selection.id === team.id;
-											return (
-												<button
-													key={team.id}
-													type="button"
-													onClick={() => setSelection({ kind: 'team', id: team.id })}
-													className="text-left"
-													data-testid={`source-team-card-${team.slug}`}
-													aria-pressed={selected}
-												>
-													<Card
-														className={`p-3 h-full transition-colors ${cardStateClass(selected)}`}
-													>
-														<h3 className="text-[14px] font-medium mb-1">{team.name}</h3>
-														<p className="text-[11px] text-text-2">
-															{team.agent_count === 0
-																? 'No agents yet'
-																: `${team.agent_count} agent${team.agent_count === 1 ? '' : 's'}`}
-														</p>
-													</Card>
-												</button>
-											);
-										})}
-									</div>
-								</div>
+											</div>
+											{isLoading ? (
+												<div className="flex items-center gap-2 text-text-2 text-[13px] py-4">
+													<Loader2 className="w-4 h-4 animate-spin" /> Loading teams…
+												</div>
+											) : showPrompt ? (
+												<p className="rounded-md border border-dashed border-border-strong px-3 py-3 text-center text-[12.5px] text-text-3">
+													Describe your project above to see suggested teams.
+												</p>
+											) : (
+												<div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+													{suggestions.map((o, i) => (
+														<TeamCard
+															key={o.key}
+															option={o}
+															selected={isSelected(o)}
+															onSelect={() => setSelection(optionToSelection(o))}
+															className={i === 1 ? 'hidden sm:block' : ''}
+														/>
+													))}
+												</div>
+											)}
+										</div>
+									)}
+								</>
+							) : (
+								<>
+									<button
+										type="button"
+										onClick={() => setStep('entry')}
+										data-testid="all-teams-back"
+										className="inline-flex items-center gap-1 text-[13px] text-text-2 hover:text-text-1 transition-colors"
+									>
+										<ArrowLeft className="w-4 h-4" /> Back
+									</button>
+									<span className="text-[13px] font-medium text-text-1">Choose a team</span>
+									{showTabs && (
+										<Tabs
+											value={tab}
+											onValueChange={(k) => setTab(k as 'new' | 'copy')}
+											activeSurface="bg-surface"
+											aria-label="Team source"
+											items={[
+												{
+													key: 'new',
+													label: 'New team',
+													count: newOptions.length,
+													testId: 'team-tab-new',
+												},
+												{
+													key: 'copy',
+													label: 'Copy existing team',
+													count: copyOptions.length,
+													testId: 'team-tab-copy',
+												},
+											]}
+										/>
+									)}
+									<Input
+										icon={<Search className="w-3.5 h-3.5" />}
+										type="search"
+										aria-label="Search teams"
+										placeholder="Search teams…"
+										value={search}
+										onChange={(e) => setSearch(e.target.value)}
+										onKeyDown={(e) => {
+											if (e.key === 'Enter') e.preventDefault();
+										}}
+										data-testid="team-search"
+									/>
+									{isLoading ? (
+										<div className="flex items-center gap-2 text-text-2 text-[13px] py-4">
+											<Loader2 className="w-4 h-4 animate-spin" /> Loading teams…
+										</div>
+									) : (
+										<div className="max-h-[46vh] overflow-y-auto -mx-1 px-1">
+											{filtered.length === 0 ? (
+												<p className="text-[12.5px] text-text-3 py-8 text-center">
+													No teams match your search.
+												</p>
+											) : (
+												<div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+													{filtered.map((o) => (
+														<TeamCard
+															key={o.key}
+															option={o}
+															selected={isSelected(o)}
+															onSelect={() => setSelection(optionToSelection(o))}
+														/>
+													))}
+												</div>
+											)}
+										</div>
+									)}
+								</>
 							)}
 							{error && (
 								<p className="text-[13px] text-danger">
 									{(error as { message?: string }).message || 'Failed to create project'}
 								</p>
 							)}
-							<div className="flex flex-col-reverse sm:flex-row sm:justify-end gap-2 mt-2">
-								<Button
-									type="button"
-									variant="secondary"
-									onClick={handlePlanWithCeo}
-									disabled={!canSubmit}
-									data-testid="plan-with-ceo-submit"
-								>
-									{startIntake.isPending ? (
-										<Loader2 className="w-4 h-4 animate-spin" />
-									) : (
-										<MessagesSquare className="w-4 h-4" />
-									)}
-									Plan with the CEO
-								</Button>
-								<Button
-									type="submit"
-									shortcut="mod+Enter"
-									disabled={!canSubmit}
-									data-testid="create-project-submit"
-								>
-									{createProject.isPending ? (
-										<Loader2 className="w-4 h-4 animate-spin" />
-									) : (
-										<Sparkles className="w-4 h-4" />
-									)}
-									Create now
-								</Button>
-							</div>
+							{selection && (
+								<div className="flex flex-col-reverse sm:flex-row sm:justify-end gap-2 mt-2">
+									<Button
+										type="button"
+										variant="secondary"
+										onClick={handlePlanWithCeo}
+										disabled={!canSubmit}
+										data-testid="plan-with-ceo-submit"
+									>
+										{startIntake.isPending ? (
+											<Loader2 className="w-4 h-4 animate-spin" />
+										) : (
+											<MessagesSquare className="w-4 h-4" />
+										)}
+										Plan with the CEO
+									</Button>
+									<Button
+										type="submit"
+										shortcut="mod+Enter"
+										disabled={!canSubmit}
+										data-testid="create-project-submit"
+									>
+										{createProject.isPending ? (
+											<Loader2 className="w-4 h-4 animate-spin" />
+										) : (
+											<Sparkles className="w-4 h-4" />
+										)}
+										Create now
+									</Button>
+								</div>
+							)}
 						</form>
 					</>
 				)}

--- a/packages/web/src/components/project-plan-upload.tsx
+++ b/packages/web/src/components/project-plan-upload.tsx
@@ -1,5 +1,6 @@
 import { FileText, Upload, X } from 'lucide-react';
-import { useCallback, useRef } from 'react';
+import { useCallback, useRef, useState } from 'react';
+import { InfoTooltip } from './ui/info-tooltip';
 
 interface ProjectPlanUploadProps {
 	value: string;
@@ -7,8 +8,18 @@ interface ProjectPlanUploadProps {
 	onChange: (value: string, filename: string | null) => void;
 }
 
+const HELP_CONTENT =
+	'Attach a fuller document describing what this project is for when the description above isn’t enough — goals, scope, context, constraints. For a software team the Captain uses it to write the formal PRD; for other teams it’s used directly as the plan. Supported files: .md, .txt, .markdown.';
+
+/**
+ * Compact "attach project plan" control: a single minimal-height row with a
+ * dotted border that doubles as a click-to-upload button and a drag-&-drop zone,
+ * with an inline help tooltip (also listing the supported extensions). Text plans
+ * only — read via `FileReader.readAsText`. Controlled by the parent.
+ */
 export function ProjectPlanUpload({ value, filename, onChange }: ProjectPlanUploadProps) {
 	const fileInputRef = useRef<HTMLInputElement>(null);
+	const [dragOver, setDragOver] = useState(false);
 
 	const handleFileUpload = useCallback(
 		(file: File) => {
@@ -25,48 +36,66 @@ export function ProjectPlanUpload({ value, filename, onChange }: ProjectPlanUplo
 	);
 
 	return (
-		<div className="flex flex-col gap-1.5">
+		<>
 			{value ? (
-				<div className="rounded-md border border-border bg-surface px-3 py-2 text-[13px]">
-					<div className="flex items-center justify-between mb-2">
-						<span className="flex items-center gap-1.5 text-text-2">
-							<FileText className="w-3.5 h-3.5" />
-							{filename || 'Pasted content'}
-						</span>
-						<button
-							type="button"
-							onClick={() => onChange('', null)}
-							className="text-text-3 hover:text-text-1 p-0.5"
-							aria-label="Remove project plan document"
-						>
-							<X className="w-3.5 h-3.5" />
-						</button>
-					</div>
-					<p className="text-text-3 text-xs truncate">
-						{value.slice(0, 120)}
-						{value.length > 120 ? '…' : ''}
-					</p>
+				<div className="flex items-center gap-2 rounded-md border border-border bg-surface px-2.5 py-2 text-[13px] text-text-1">
+					<FileText className="w-3.5 h-3.5 shrink-0 text-text-2" />
+					<span className="flex-1 min-w-0 truncate">{filename || 'Pasted content'}</span>
+					<button
+						type="button"
+						onClick={() => onChange('', null)}
+						className="shrink-0 text-text-3 hover:text-text-1 p-0.5"
+						aria-label="Remove project plan document"
+					>
+						<X className="w-3.5 h-3.5" />
+					</button>
 				</div>
 			) : (
-				<button
-					type="button"
-					className="rounded-md border border-dashed border-border bg-surface px-3 py-4 text-[13px] text-center cursor-pointer hover:border-border-strong transition-colors w-full"
-					onClick={() => fileInputRef.current?.click()}
+				// The whole row is the drop zone; the label area opens the file picker.
+				// The tooltip is a sibling button (never nested inside the label button,
+				// which would be invalid HTML).
+				// biome-ignore lint/a11y/noStaticElementInteractions: drag-and-drop wrapper; the inner button owns click/keyboard interaction
+				<div
+					className={`flex items-center gap-2 rounded-md border border-dotted bg-surface px-2.5 py-2 text-[13px] transition-colors ${
+						dragOver ? 'border-accent bg-accent-soft' : 'border-border-strong'
+					}`}
+					onDragEnter={(e) => {
+						e.preventDefault();
+						e.stopPropagation();
+						setDragOver(true);
+					}}
 					onDragOver={(e) => {
 						e.preventDefault();
 						e.stopPropagation();
 					}}
+					onDragLeave={(e) => {
+						e.preventDefault();
+						e.stopPropagation();
+						setDragOver(false);
+					}}
 					onDrop={(e) => {
 						e.preventDefault();
 						e.stopPropagation();
+						setDragOver(false);
 						const file = e.dataTransfer.files[0];
 						if (file) handleFileUpload(file);
 					}}
 				>
-					<Upload className="w-4 h-4 mx-auto mb-1 text-text-3" />
-					<p className="text-text-3">Drop a file here or click to upload</p>
-					<p className="text-text-3 text-xs mt-1">.md or .txt</p>
-				</button>
+					<button
+						type="button"
+						className="flex flex-1 min-w-0 items-center gap-2 text-left text-text-2 hover:text-text-1 transition-colors cursor-pointer"
+						onClick={() => fileInputRef.current?.click()}
+					>
+						<Upload className="w-3.5 h-3.5 shrink-0 text-text-3" />
+						<span className="shrink-0">Attach project plan</span>
+						<span className="text-text-3 truncate">or drag &amp; drop</span>
+					</button>
+					<InfoTooltip
+						label="What is a project plan document?"
+						data-testid="project-plan-help"
+						content={HELP_CONTENT}
+					/>
+				</div>
 			)}
 			<input
 				ref={fileInputRef}
@@ -79,6 +108,6 @@ export function ProjectPlanUpload({ value, filename, onChange }: ProjectPlanUplo
 					e.target.value = '';
 				}}
 			/>
-		</div>
+		</>
 	);
 }

--- a/packages/web/src/lib/team-suggestions.ts
+++ b/packages/web/src/lib/team-suggestions.ts
@@ -1,0 +1,148 @@
+import type { MarketplaceIndexEntry } from '@hezo/shared';
+import type { TeamTemplate } from '../hooks/use-team-templates';
+
+/**
+ * A cloneable existing team, as the create-project dialog derives it from the
+ * projects index (`useAllVisibleProjects`).
+ */
+export interface SourceTeamOption {
+	id: string;
+	slug: string;
+	name: string;
+	agent_count: number;
+}
+
+/**
+ * One selectable team in the New Project dialog, unifying the three sources that
+ * can back a new team — a marketplace team, a local catalog template, or an
+ * existing team to clone — behind a single shape the suggestion ranker, the
+ * search, and the card renderer all work over. `group` splits them into the two
+ * "all teams" tabs: `new` (marketplace + templates) vs `copy` (existing teams).
+ * `keywords` is the lowercased free-text bag the client-side ranker scores
+ * against (there is no server suggestion endpoint and teams carry no tags).
+ */
+export type TeamOption =
+	| {
+			kind: 'marketplace';
+			group: 'new';
+			key: string;
+			slug: string;
+			name: string;
+			description: string;
+			meta: string;
+			keywords: string;
+	  }
+	| {
+			kind: 'template';
+			group: 'new';
+			key: string;
+			id: string;
+			name: string;
+			description: string;
+			meta: string;
+			keywords: string;
+	  }
+	| {
+			kind: 'team';
+			group: 'copy';
+			key: string;
+			id: string;
+			slug: string;
+			name: string;
+			description: string;
+			meta: string;
+			keywords: string;
+	  };
+
+/**
+ * Minimum description length before the entry step swaps its "describe your
+ * project" prompt for ranked suggestions. Below this we don't have enough signal
+ * to suggest anything meaningful.
+ */
+export const SUGGEST_MIN_CHARS = 12;
+
+function roleCountMeta(n: number): string {
+	return `${n} role${n === 1 ? '' : 's'}`;
+}
+
+/**
+ * Assemble the unified option list from the three data sources, reusing the exact
+ * meta strings the dialog's cards have always shown.
+ */
+export function buildTeamOptions(
+	marketplaceTeams: MarketplaceIndexEntry[],
+	templates: TeamTemplate[],
+	sourceTeams: SourceTeamOption[],
+): TeamOption[] {
+	const marketplace: TeamOption[] = marketplaceTeams.map(
+		(mt): TeamOption => ({
+			kind: 'marketplace',
+			group: 'new',
+			key: `marketplace:${mt.slug}`,
+			slug: mt.slug,
+			name: mt.name,
+			description: mt.description ?? '',
+			meta: roleCountMeta(mt.roster_count),
+			keywords: `${mt.name} ${mt.description ?? ''} ${mt.summary ?? ''}`.toLowerCase(),
+		}),
+	);
+
+	const template: TeamOption[] = templates.map(
+		(tpl): TeamOption => ({
+			kind: 'template',
+			group: 'new',
+			key: `template:${tpl.id}`,
+			id: tpl.id,
+			name: tpl.name,
+			description: tpl.description ?? '',
+			meta:
+				tpl.agent_types.length === 0
+					? 'Captain only'
+					: `${tpl.agent_types.length} agent role${tpl.agent_types.length === 1 ? '' : 's'}`,
+			keywords: `${tpl.name} ${tpl.description ?? ''}`.toLowerCase(),
+		}),
+	);
+
+	const team: TeamOption[] = sourceTeams.map(
+		(src): TeamOption => ({
+			kind: 'team',
+			group: 'copy',
+			key: `team:${src.id}`,
+			id: src.id,
+			slug: src.slug,
+			name: src.name,
+			description: '',
+			meta:
+				src.agent_count === 0
+					? 'No agents yet'
+					: `${src.agent_count} agent${src.agent_count === 1 ? '' : 's'}`,
+			keywords: src.name.toLowerCase(),
+		}),
+	);
+
+	return [...marketplace, ...template, ...team];
+}
+
+/**
+ * Rank options by keyword overlap with the query (the project name + description).
+ * Distinct query tokens of >2 chars each score a point per option whose keyword
+ * bag contains them; ties fall back to the original order. Returns the top
+ * `limit` positively-scored options, or `[]` when the query has no usable tokens
+ * (the caller decides the empty-query fallback / prompt).
+ */
+export function rankTeams(query: string, options: TeamOption[], limit = 2): TeamOption[] {
+	const tokens = Array.from(
+		new Set((query.toLowerCase().match(/[a-z0-9]+/g) ?? []).filter((t) => t.length > 2)),
+	);
+	if (tokens.length === 0) return [];
+	return options
+		.map((option, index) => ({
+			option,
+			index,
+			score: tokens.reduce((acc, token) => acc + (option.keywords.includes(token) ? 1 : 0), 0),
+		}))
+		.filter((entry) => entry.score > 0)
+		.sort((a, b) => b.score - a.score || a.index - b.index)
+		.slice(0, limit)
+		.map((entry) => entry.option);
+}

--- a/packages/web/test/create-project-from-team.test.tsx
+++ b/packages/web/test/create-project-from-team.test.tsx
@@ -16,27 +16,22 @@ async function openNewProjectDialog() {
 	});
 	const section = await utils.findByTestId('home-projects', undefined, { timeout: 15_000 });
 	await utils.user.click(within(section).getByTestId('home-new-project'));
-	await screen.findByTestId('create-project-submit');
+	// The dialog opens on its entry step (name + description); the submit button is
+	// gated behind a team selection now, so wait on the name field instead.
+	await screen.findByPlaceholderText('e.g. Marketing Site');
 	return { ...utils, ws };
 }
 
 test('the header close button dismisses the dialog (mobile has no Escape key)', async () => {
 	const { user } = await openNewProjectDialog();
 	await user.click(screen.getByRole('button', { name: 'Close' }));
-	await waitFor(() => expect(screen.queryByTestId('create-project-submit')).toBeNull());
+	await waitFor(() => expect(screen.queryByPlaceholderText('e.g. Marketing Site')).toBeNull());
 });
 
 test('lists existing teams (not HQ) as cloneable sources and submits source_team_id', async () => {
 	const { user, ws } = await openNewProjectDialog();
 
-	// The seeded project-team is offered as a source; the internal HQ team is not.
-	const sourceCard = await screen.findByTestId(`source-team-card-${ws.team.slug}`);
-	expect(screen.queryByTestId(`source-team-card-${DEFAULT_TEAM_SLUG}`)).toBeNull();
-
-	const submit = screen.getByTestId('create-project-submit') as HTMLButtonElement;
-	// Disabled until name + description + a source selection are all present.
-	expect(submit.disabled).toBe(true);
-
+	// Name + description first (the fields live on the entry step).
 	await user.type(screen.getByPlaceholderText('e.g. Marketing Site'), 'Cloned From Team');
 	await user.type(
 		screen.getByPlaceholderText(
@@ -44,10 +39,20 @@ test('lists existing teams (not HQ) as cloneable sources and submits source_team
 		),
 		'A project cloned from an existing team.',
 	);
-	// Still disabled with no source picked.
-	expect(submit.disabled).toBe(true);
+
+	// Existing teams to clone live on the "Copy existing team" tab of the full catalog.
+	await user.click(screen.getByTestId('view-all-teams'));
+	await user.click(await screen.findByTestId('team-tab-copy'));
+
+	// The seeded project-team is offered as a source; the internal HQ team is not.
+	const sourceCard = await screen.findByTestId(`source-team-card-${ws.team.slug}`);
+	expect(screen.queryByTestId(`source-team-card-${DEFAULT_TEAM_SLUG}`)).toBeNull();
+
+	// No action buttons until a team is picked.
+	expect(screen.queryByTestId('create-project-submit')).toBeNull();
 
 	await user.click(sourceCard);
+	const submit = (await screen.findByTestId('create-project-submit')) as HTMLButtonElement;
 	expect(submit.disabled).toBe(false);
 
 	await user.click(submit);

--- a/packages/web/test/create-project-suggestions.test.tsx
+++ b/packages/web/test/create-project-suggestions.test.tsx
@@ -1,0 +1,82 @@
+import { screen, waitFor, within } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { renderApp } from './helpers/render';
+import { type SeededWorkspace, seedProject, seedWorkspace } from './helpers/seed';
+
+async function openDialogFromHome() {
+	let ws!: SeededWorkspace;
+	const utils = await renderApp({
+		initialPath: '/home',
+		seed: async () => {
+			ws = await seedWorkspace();
+			await seedProject(ws, { name: 'Existing Project' });
+			sessionStorage.setItem('hezo:activeTeamSlug', ws.team.slug);
+		},
+	});
+	const section = await utils.findByTestId('home-projects', undefined, { timeout: 15_000 });
+	await utils.user.click(within(section).getByTestId('home-new-project'));
+	await utils.findByPlaceholderText('e.g. Marketing Site');
+	return { ...utils, ws };
+}
+
+test('describing the project reveals ranked suggestions; picking one confirms it and shows the actions', async () => {
+	const { user, findByText, findByPlaceholderText, findByTestId } = await openDialogFromHome();
+
+	// Empty state: a prompt, no cards, no action buttons.
+	await findByText('Describe your project above to see suggested teams.');
+	expect(screen.queryByTestId('create-project-submit')).toBeNull();
+
+	// A brief that overwhelmingly matches the Influencer Marketing team, so it ranks
+	// first and stays first once the marketplace catalog loads.
+	await user.type(
+		await findByPlaceholderText(/What is this project/),
+		'Social media influencer marketing to grow brand reach with content and audience.',
+	);
+
+	// The prompt gives way to ranked suggestion cards.
+	await waitFor(() =>
+		expect(screen.queryByText('Describe your project above to see suggested teams.')).toBeNull(),
+	);
+	const topSuggestion = await findByTestId('marketplace-team-card-influencer', undefined, {
+		timeout: 15_000,
+	});
+
+	// Picking a suggestion collapses to the confirmation card and reveals both actions.
+	await user.click(topSuggestion);
+	await findByTestId('selected-team-card');
+	await findByTestId('choose-different-team');
+	await findByTestId('create-project-submit');
+	await findByTestId('plan-with-ceo-submit');
+});
+
+test('View all teams opens the tabbed catalog with search; Back preserves the entry fields', async () => {
+	const { user, findByPlaceholderText, findByTestId, ws } = await openDialogFromHome();
+
+	const nameInput = (await findByPlaceholderText('e.g. Marketing Site')) as HTMLInputElement;
+	await user.type(nameInput, 'Keep My Name');
+
+	await user.click(await findByTestId('view-all-teams'));
+
+	// Both tabs render because there is an existing team to copy.
+	await findByTestId('team-tab-new');
+	await findByTestId('team-tab-copy');
+	// The New-team tab lists the seeded templates.
+	await findByTestId('team-type-card-Blank');
+	await findByTestId('team-type-card-App Team');
+
+	// Search filters the active tab: "blank" keeps Blank, drops App Team.
+	await user.type(await findByTestId('team-search'), 'blank');
+	await findByTestId('team-type-card-Blank');
+	await waitFor(() => expect(screen.queryByTestId('team-type-card-App Team')).toBeNull());
+
+	// Clear + switch to the Copy tab: the source team shows, templates do not.
+	await user.clear(await findByTestId('team-search'));
+	await user.click(await findByTestId('team-tab-copy'));
+	await findByTestId(`source-team-card-${ws.team.slug}`);
+	await waitFor(() => expect(screen.queryByTestId('team-type-card-Blank')).toBeNull());
+
+	// Back returns to the entry step with the typed name intact.
+	await user.click(await findByTestId('all-teams-back'));
+	const restored = (await findByPlaceholderText('e.g. Marketing Site')) as HTMLInputElement;
+	expect(restored.value).toBe('Keep My Name');
+});

--- a/packages/web/test/home-new-project.test.tsx
+++ b/packages/web/test/home-new-project.test.tsx
@@ -22,10 +22,17 @@ test('home "New project" opens the create-project-with-team dialog (type picker)
 	const section = await findByTestId('home-projects', undefined, { timeout: 15_000 });
 	await user.click(within(section).getByTestId('home-new-project'));
 
-	// The project-with-team dialog (not the old team-scoped one) has a type picker.
-	await screen.findByTestId('create-project-submit');
-	expect(screen.getByText('Team type')).toBeTruthy();
-	expect(screen.getByPlaceholderText('e.g. Marketing Site')).toBeTruthy();
+	// The project-with-team dialog (not the old team-scoped one) opens on its entry
+	// step: name + description + a "View all teams" affordance. The action buttons
+	// stay hidden until a team is picked.
+	await screen.findByPlaceholderText('e.g. Marketing Site');
+	expect(screen.getByTestId('view-all-teams')).toBeTruthy();
+	expect(
+		screen.getByPlaceholderText(
+			'What is this project? Domain, users, and the core problem it solves.',
+		),
+	).toBeTruthy();
+	expect(screen.queryByTestId('create-project-submit')).toBeNull();
 });
 
 test('the create-project dialog blocks on the container state when HQ is down', async () => {

--- a/packages/web/test/onboarding-direct.test.tsx
+++ b/packages/web/test/onboarding-direct.test.tsx
@@ -1,4 +1,4 @@
-import { waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import { expect, test } from 'vitest';
 import { getTestContext, renderApp } from './helpers/render';
 
@@ -15,11 +15,17 @@ test('the welcome card opens the dialog exposing both creation flows', async () 
 	const create = await findByTestId('home-welcome-create', undefined, { timeout: 15_000 });
 	await user.click(create);
 
-	// The dialog renders into a Radix portal with a team-type picker and the two
-	// submit buttons (direct vs CEO-assisted).
-	await findByTestId('create-project-submit', undefined, { timeout: 15_000 });
+	// The dialog opens on its entry step: the two submit buttons are gated behind a
+	// team selection, reached via "View all teams".
+	await findByTestId('view-all-teams', undefined, { timeout: 15_000 });
+	expect(screen.queryByTestId('create-project-submit')).toBeNull();
+
+	await user.click(await findByTestId('view-all-teams'));
+	await user.click(await findByTestId('team-type-card-Blank'));
+
+	// Both creation flows are now available (direct vs CEO-assisted).
+	await findByTestId('create-project-submit');
 	await findByTestId('plan-with-ceo-submit');
-	await findByTestId('team-type-card-Blank');
 });
 
 // Direct flow: filling the dialog and clicking "Create now" stands up a brand-new
@@ -41,6 +47,7 @@ test('the direct flow creates a project in its own new team and opens the planni
 		await findByPlaceholderText(/What is this project/),
 		'A direct-flow project with its own dedicated team.',
 	);
+	await user.click(await findByTestId('view-all-teams'));
 	await user.click(await findByTestId('team-type-card-Blank'));
 	await user.click(await findByTestId('create-project-submit'));
 
@@ -81,6 +88,7 @@ test('the CEO-assisted flow opens the HQ intake thread instead of creating immed
 		await findByPlaceholderText(/What is this project/),
 		'A project we want the CEO to scope with us first.',
 	);
+	await user.click(await findByTestId('view-all-teams'));
 	await user.click(await findByTestId('team-type-card-Blank'));
 	await user.click(await findByTestId('plan-with-ceo-submit'));
 

--- a/packages/web/test/project-crud.test.tsx
+++ b/packages/web/test/project-crud.test.tsx
@@ -1,4 +1,4 @@
-import { waitFor, within } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import { expect, test } from 'vitest';
 import { getTestContext, renderApp } from './helpers/render';
 import {
@@ -60,6 +60,7 @@ test('creates a project from Home (Create now) and lands on the Captain planning
 		await findByPlaceholderText(/What is this project/),
 		'Q3 brand push aimed at existing users to drive upsells.',
 	);
+	await user.click(await findByTestId('view-all-teams'));
 	await user.click(await findByTestId('team-type-card-Blank'));
 	await user.click(await findByTestId('create-project-submit'));
 
@@ -194,8 +195,8 @@ test('dialog attaches a project plan document, with a help tooltip, and persists
 	});
 	await user.click(await within(mainEl).findByRole('button', { name: 'New project' }));
 
-	// The field is labelled "Project plan document" with a help-icon tooltip.
-	await findByText('Project plan document (optional)');
+	// The compact attach row carries its label + a help-icon tooltip.
+	await findByText('Attach project plan');
 	await findByTestId('project-plan-help');
 
 	// Attach the plan via the (hidden) file input — the component reads it as text.
@@ -211,6 +212,7 @@ test('dialog attaches a project plan document, with a help tooltip, and persists
 		await findByPlaceholderText(/What is this project/),
 		'A project whose plan is fuller than the description.',
 	);
+	await user.click(await findByTestId('view-all-teams'));
 	await user.click(await findByTestId('team-type-card-Blank'));
 	await user.click(await findByTestId('create-project-submit'));
 
@@ -247,16 +249,19 @@ test('Create button stays disabled until name, description, and a team type are 
 	});
 	await user.click(await within(mainEl).findByRole('button', { name: 'New project' }));
 
-	const createBtn = (await findByTestId('create-project-submit')) as HTMLButtonElement;
-	expect(createBtn.disabled).toBe(true);
+	// The action buttons don't render at all until a team is selected.
+	expect(screen.queryByTestId('create-project-submit')).toBeNull();
 
 	await user.type(await findByPlaceholderText('e.g. Marketing Site'), 'Some Project');
-	expect(createBtn.disabled).toBe(true);
-
 	await user.type(
 		await findByPlaceholderText(/What is this project/),
 		'A description long enough.',
 	);
+	// Name + description alone still don't reveal them — a team must be chosen.
+	expect(screen.queryByTestId('create-project-submit')).toBeNull();
+
+	await user.click(await findByTestId('view-all-teams'));
 	await user.click(await findByTestId('team-type-card-Blank'));
+	const createBtn = (await findByTestId('create-project-submit')) as HTMLButtonElement;
 	await waitFor(() => expect(createBtn.disabled).toBe(false));
 }, 60_000);

--- a/packages/web/test/project-rail.test.tsx
+++ b/packages/web/test/project-rail.test.tsx
@@ -163,8 +163,9 @@ test('superuser creates a new project from the rail create button', async () => 
 		screen.getByPlaceholderText(/What is this project/),
 		'A research project for the launch.',
 	);
+	await user.click(await screen.findByTestId('view-all-teams'));
 	await user.click(await screen.findByTestId('team-type-card-Blank'));
-	await user.click(screen.getByTestId('create-project-submit'));
+	await user.click(await screen.findByTestId('create-project-submit'));
 
 	// "Create now" provisions the team + project directly and navigates to the
 	// new project's Captain planning task (project slug derived from the name).

--- a/packages/web/test/team-suggestions.test.tsx
+++ b/packages/web/test/team-suggestions.test.tsx
@@ -1,0 +1,135 @@
+import type { MarketplaceIndexEntry, TeamTemplateSource } from '@hezo/shared';
+import { describe, expect, it } from 'vitest';
+import type { TeamTemplate, TeamTemplateAgentType } from '../src/hooks/use-team-templates';
+import { buildTeamOptions, rankTeams, SUGGEST_MIN_CHARS } from '../src/lib/team-suggestions';
+
+function mp(over: Partial<MarketplaceIndexEntry>): MarketplaceIndexEntry {
+	return {
+		slug: 's',
+		name: 'N',
+		description: '',
+		summary: '',
+		version: 1,
+		roster_count: 1,
+		latest_notes: '',
+		...over,
+	};
+}
+
+function at(slug: string): TeamTemplateAgentType {
+	return {
+		agent_type_id: slug,
+		name: slug,
+		slug,
+		role_description: '',
+		reports_to_slug: null,
+		sort_order: 0,
+	};
+}
+
+function tpl(over: Partial<TeamTemplate>): TeamTemplate {
+	return {
+		id: 'id',
+		name: 'N',
+		description: null,
+		is_builtin: false,
+		source: 'custom' as TeamTemplateSource,
+		metadata: {},
+		kb_docs_config: [],
+		agent_types: [],
+		created_at: '',
+		...over,
+	};
+}
+
+describe('buildTeamOptions', () => {
+	it('maps the three sources with the exact meta strings + groups', () => {
+		const options = buildTeamOptions(
+			[
+				mp({
+					slug: 'inv',
+					name: 'Investment',
+					description: 'Stock research',
+					summary: 'analysts',
+					roster_count: 6,
+				}),
+			],
+			[
+				tpl({ id: 'blank', name: 'Blank', description: null, agent_types: [] }),
+				tpl({
+					id: 'app',
+					name: 'App Team',
+					description: 'Builds apps',
+					agent_types: [at('a'), at('b')],
+				}),
+			],
+			[
+				{ id: 't1', slug: 'ops', name: 'Ops', agent_count: 3 },
+				{ id: 't2', slug: 'empty', name: 'Empty', agent_count: 0 },
+			],
+		);
+
+		const inv = options.find((o) => o.key === 'marketplace:inv');
+		expect(inv?.group).toBe('new');
+		expect(inv?.meta).toBe('6 roles');
+		// keywords fold in name + description + summary, lowercased.
+		expect(inv?.keywords).toContain('analysts');
+		expect(inv?.keywords).toContain('stock research');
+
+		expect(options.find((o) => o.key === 'template:blank')?.meta).toBe('Captain only');
+		expect(options.find((o) => o.key === 'template:app')?.meta).toBe('2 agent roles');
+
+		const ops = options.find((o) => o.key === 'team:t1');
+		expect(ops?.group).toBe('copy');
+		expect(ops?.meta).toBe('3 agents');
+		expect(options.find((o) => o.key === 'team:t2')?.meta).toBe('No agents yet');
+	});
+
+	it('singularizes a one-agent team', () => {
+		const [team] = buildTeamOptions([], [], [{ id: 't', slug: 's', name: 'Solo', agent_count: 1 }]);
+		expect(team.meta).toBe('1 agent');
+	});
+});
+
+describe('rankTeams', () => {
+	const options = buildTeamOptions(
+		[
+			mp({ slug: 'social', name: 'Social', description: 'social media influencer content growth' }),
+			mp({ slug: 'fin', name: 'Finance', description: 'stock market research and analysis' }),
+		],
+		[],
+		[],
+	);
+
+	it('returns [] for an empty or too-short query', () => {
+		expect(rankTeams('', options)).toEqual([]);
+		expect(rankTeams('ai', options)).toEqual([]);
+	});
+
+	it('ranks by keyword overlap, best first', () => {
+		const ranked = rankTeams('influencer social content', options);
+		expect(ranked[0]?.name).toBe('Social');
+	});
+
+	it('ignores tokens of 2 characters or fewer', () => {
+		// every token here is ≤2 chars, so nothing is scored.
+		expect(rankTeams('ai to go', options)).toEqual([]);
+	});
+
+	it('caps the result at the given limit', () => {
+		const many = buildTeamOptions(
+			[
+				mp({ slug: 'a', name: 'A', description: 'growth' }),
+				mp({ slug: 'b', name: 'B', description: 'growth' }),
+				mp({ slug: 'c', name: 'C', description: 'growth' }),
+			],
+			[],
+			[],
+		);
+		expect(rankTeams('growth', many, 2)).toHaveLength(2);
+	});
+
+	it('exports a positive minimum-chars threshold', () => {
+		expect(SUGGEST_MIN_CHARS).toBeGreaterThan(0);
+	});
+});

--- a/packages/web/test/team-type-selection.test.tsx
+++ b/packages/web/test/team-type-selection.test.tsx
@@ -13,6 +13,10 @@ test('selecting a team type visibly highlights only the chosen card', async () =
 	const create = await findByTestId('home-welcome-create', undefined, { timeout: 15_000 });
 	await user.click(create);
 
+	// The team cards live behind "View all teams" now — the entry step opens on the
+	// suggestion prompt, not the full catalog.
+	await user.click(await findByTestId('view-all-teams', undefined, { timeout: 15_000 }));
+
 	const blankBtn = await findByTestId('team-type-card-Blank', undefined, { timeout: 15_000 });
 	const appTeamBtn = await findByTestId('team-type-card-App Team');
 	// The inner Card <div> carries the highlight classes.


### PR DESCRIPTION
## What & why

The **New project** dialog previously showed everything at once — name, description, a bulky project-plan dropzone, and the entire team catalog (marketplace teams + templates + every existing team to copy) as one long grid. This refactors it into a progressive, suggestion-first flow.

## The new flow

**Entry step**
- Project name + description, then **up to 2 suggested teams** (1 on mobile) ranked from the name + description.
- Before there's enough description, a *"Describe your project above to see suggested teams"* prompt shows instead.
- Picking a suggestion collapses the area to a **Selected team** confirmation card + a *"Choose a different team"* link. This also drives the marketplace **preselect** path (launching from a marketplace team opens here already confirmed).
- The **Create now** / **Plan with the CEO** actions appear **only after a team is selected**.

**All-teams step** (via **View all teams →**, with a top-left **← Back**)
- A focused, tabbed picker: **New team** (marketplace + templates) and **Copy existing team** (existing teams to clone) — each an independently scrollable list.
- A **search** box filters the active tab.
- The desktop dialog widens (`lg → xl`) here.

**Attach project plan**
- Now a **minimal-height, dotted single-row** control that doubles as the drag-and-drop zone, with an inline help tooltip that lists the supported extensions (`.md`, `.txt`, `.markdown`). The description textarea is capped at **4 scrollable rows**.

## Ranking

Client-side keyword match in the new `packages/web/src/lib/team-suggestions.ts` — no backend, no token cost. Teams carry no tags, so it scores each team's `name + description + summary` against the query. There is no server suggestion endpoint and none was added.

## Scope / safety

Frontend-only, confined to `packages/web`. **No** route, MCP tool, DB migration, or shared-type changes — both create paths (`POST /api/projects`, `POST /api/project-intakes`) and their request shapes are untouched; only the dialog's presentation and the client-side ranking are new. All existing `data-testid`s are preserved; new ones added (`view-all-teams`, `all-teams-back`, `team-search`, `team-tab-new`, `team-tab-copy`, `selected-team-card`).

## Tests

- New pure-logic unit test for the ranker/view-model (`team-suggestions.test.tsx`).
- New component test covering prompt → suggestions → confirmation, and view-all tabs + search + Back (`create-project-suggestions.test.tsx`).
- Updated the seven existing specs that open the dialog to route specific-team selection through **View all teams** (+ the right tab). All web dialog specs, typecheck, and biome check pass.

## Docs

Presentational refactor — `docs/getting-started/first-project.md`, `docs/concepts/marketplace.md`, and `.dev/architecture.md` describe the flow only at a level that stays accurate (same team sources, same create/intake semantics), so no doc edits were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112SYoyDctrsZB5vtTi4exZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0112SYoyDctrsZB5vtTi4exZ)_