### PR TITLE
feat(task-detail): make Progress Summary and Rules cards collapsible, collapsed by default

### DIFF
--- a/packages/web/src/components/task-detail/task-summary.tsx
+++ b/packages/web/src/components/task-detail/task-summary.tsx
@@ -1,3 +1,4 @@
+import { ChevronDown } from 'lucide-react';
 import { useState } from 'react';
 import type { Task, useUpdateTask } from '../../hooks/use-tasks';
 import { MarkdownEditor } from '../markdown-editor';
@@ -14,149 +15,167 @@ interface TaskSummaryProps {
 	updateTask: UpdateTaskMutation;
 }
 
+interface CollapsibleSummaryCardProps {
+	testId: string;
+	toggleTestId: string;
+	label: string;
+	infoLabel: string;
+	infoTestId: string;
+	infoContent: string;
+	editorAriaLabel: string;
+	editorPlaceholder?: string;
+	value: string | null | undefined;
+	emptyText: string;
+	className: string;
+	projectId: string;
+	taskProjectSlug: string;
+	onSave: (value: string | null) => void;
+}
+
 /**
- * Renders the progress-summary and rules cards just below the task header.
- * Both edit inline against `useUpdateTask`. Status changes do not run through
- * here — `progress_summary` and `rules` are plain text fields.
+ * One collapsible progress-summary/rules card. Collapsed by default — the
+ * header (chevron toggle, label, info icon, Edit) stays visible while the body
+ * hides. Clicking Edit auto-expands and enters edit mode, and the card stays
+ * expanded after saving so the freshly-saved content is visible.
  */
-export function TaskSummary({ task, projectId, taskProjectSlug, updateTask }: TaskSummaryProps) {
-	const [editingSummary, setEditingSummary] = useState(false);
-	const [summaryText, setSummaryText] = useState('');
-	const [editingRules, setEditingRules] = useState(false);
-	const [rulesText, setRulesText] = useState('');
+function CollapsibleSummaryCard({
+	testId,
+	toggleTestId,
+	label,
+	infoLabel,
+	infoTestId,
+	infoContent,
+	editorAriaLabel,
+	editorPlaceholder,
+	value,
+	emptyText,
+	className,
+	projectId,
+	taskProjectSlug,
+	onSave,
+}: CollapsibleSummaryCardProps) {
+	const [open, setOpen] = useState(false);
+	const [editing, setEditing] = useState(false);
+	const [draft, setDraft] = useState('');
 
 	return (
-		<>
-			<div
-				data-testid="pinned-progress-summary"
-				className="bg-surface-2 rounded-md p-3 mb-3 text-[13px] text-text-2 leading-relaxed"
-			>
-				<div className="flex items-center justify-between mb-1">
-					<div className="flex items-center gap-1">
+		<div data-testid={testId} className={className}>
+			<div className="flex items-center justify-between">
+				<div className="flex items-center gap-1">
+					<button
+						type="button"
+						onClick={() => setOpen((o) => !o)}
+						className="flex items-center gap-1 text-left cursor-pointer"
+						data-testid={toggleTestId}
+						aria-expanded={open}
+					>
+						<ChevronDown
+							className={`w-3.5 h-3.5 text-text-3 transition-transform ${open ? '' : '-rotate-90'}`}
+						/>
 						<span className="text-[11px] uppercase tracking-wider font-medium text-text-3">
-							Progress Summary
+							{label}
 						</span>
-						<InfoTooltip
-							label="About Progress Summary"
-							data-testid="progress-summary-info"
-							content="A running checkpoint of what's been done and what's left on this task. Automatically included in every agent run's prompt — alongside the description and rules — so work stays continuous across runs. Agents update it at natural milestones via the update_task tool."
-						/>
-					</div>
-					{!editingSummary && (
-						<button
-							type="button"
-							onClick={() => {
-								setSummaryText(task.progress_summary ?? '');
-								setEditingSummary(true);
-							}}
-							className="text-[11px] text-text-3 hover:text-text-1"
-						>
-							Edit
-						</button>
-					)}
+					</button>
+					<InfoTooltip label={infoLabel} data-testid={infoTestId} content={infoContent} />
 				</div>
-				{editingSummary ? (
-					<div className="flex flex-col gap-2">
-						<MarkdownEditor
-							ariaLabel="Progress Summary"
-							projectId={projectId}
-							projectSlug={taskProjectSlug}
-							value={summaryText}
-							onChange={setSummaryText}
-							className="min-h-[60px]"
-							previewClassName="min-h-[60px]"
-							emptyPreviewText="_(nothing to preview)_"
-						/>
-						<div className="flex gap-2 justify-end">
-							<Button size="sm" variant="secondary" onClick={() => setEditingSummary(false)}>
-								Cancel
-							</Button>
-							<Button
-								size="sm"
-								onClick={() => {
-									updateTask.mutate({
-										progress_summary: summaryText || null,
-									});
-									setEditingSummary(false);
-								}}
-							>
-								Save
-							</Button>
-						</div>
-					</div>
-				) : task.progress_summary ? (
-					<MarkdownProse projectId={projectId} projectSlug={taskProjectSlug}>
-						{task.progress_summary}
-					</MarkdownProse>
-				) : (
-					<span>No progress summary yet.</span>
+				{!editing && (
+					<button
+						type="button"
+						onClick={() => {
+							setDraft(value ?? '');
+							setEditing(true);
+							setOpen(true);
+						}}
+						className="text-[11px] text-text-3 hover:text-text-1"
+					>
+						Edit
+					</button>
 				)}
 			</div>
+			{open && (
+				<div className="mt-2">
+					{editing ? (
+						<div className="flex flex-col gap-2">
+							<MarkdownEditor
+								ariaLabel={editorAriaLabel}
+								projectId={projectId}
+								projectSlug={taskProjectSlug}
+								value={draft}
+								onChange={setDraft}
+								placeholder={editorPlaceholder}
+								className="min-h-[60px]"
+								previewClassName="min-h-[60px]"
+								emptyPreviewText="_(nothing to preview)_"
+							/>
+							<div className="flex gap-2 justify-end">
+								<Button size="sm" variant="secondary" onClick={() => setEditing(false)}>
+									Cancel
+								</Button>
+								<Button
+									size="sm"
+									onClick={() => {
+										onSave(draft || null);
+										setEditing(false);
+									}}
+								>
+									Save
+								</Button>
+							</div>
+						</div>
+					) : value ? (
+						<MarkdownProse projectId={projectId} projectSlug={taskProjectSlug}>
+							{value}
+						</MarkdownProse>
+					) : (
+						<span>{emptyText}</span>
+					)}
+				</div>
+			)}
+		</div>
+	);
+}
 
-			<div
-				data-testid="pinned-rules"
+/**
+ * Renders the progress-summary and rules cards just below the task header.
+ * Both are collapsible (collapsed by default) and edit inline against
+ * `useUpdateTask`. Status changes do not run through here — `progress_summary`
+ * and `rules` are plain text fields.
+ */
+export function TaskSummary({ task, projectId, taskProjectSlug, updateTask }: TaskSummaryProps) {
+	return (
+		<>
+			<CollapsibleSummaryCard
+				testId="pinned-progress-summary"
+				toggleTestId="progress-summary-toggle"
+				label="Progress Summary"
+				infoLabel="About Progress Summary"
+				infoTestId="progress-summary-info"
+				infoContent="A running checkpoint of what's been done and what's left on this task. Automatically included in every agent run's prompt — alongside the description and rules — so work stays continuous across runs. Agents update it at natural milestones via the update_task tool."
+				editorAriaLabel="Progress Summary"
+				value={task.progress_summary}
+				emptyText="No progress summary yet."
+				className="bg-surface-2 rounded-md p-3 mb-3 text-[13px] text-text-2 leading-relaxed"
+				projectId={projectId}
+				taskProjectSlug={taskProjectSlug}
+				onSave={(v) => updateTask.mutate({ progress_summary: v })}
+			/>
+
+			<CollapsibleSummaryCard
+				testId="pinned-rules"
+				toggleTestId="rules-toggle"
+				label="Rules"
+				infoLabel="About Rules"
+				infoTestId="rules-info"
+				infoContent="Approach constraints and required workflows for this task — e.g. 'run the full suite before pushing' or 'consult the architect before touching auth'. Automatically prepended to every agent run's task prompt. Agents can update via the update_task tool as they discover new rules."
+				editorAriaLabel="Rules"
+				editorPlaceholder="e.g., Consult the architect before making changes..."
+				value={task.rules}
+				emptyText="No rules set."
 				className="bg-surface-2 rounded-md p-3 mb-5 text-[13px] text-text-2 leading-relaxed border-l-2 border-info"
-			>
-				<div className="flex items-center justify-between mb-1">
-					<div className="flex items-center gap-1">
-						<span className="text-[11px] uppercase tracking-wider font-medium text-text-3">
-							Rules
-						</span>
-						<InfoTooltip
-							label="About Rules"
-							data-testid="rules-info"
-							content="Approach constraints and required workflows for this task — e.g. 'run the full suite before pushing' or 'consult the architect before touching auth'. Automatically prepended to every agent run's task prompt. Agents can update via the update_task tool as they discover new rules."
-						/>
-					</div>
-					{!editingRules && (
-						<button
-							type="button"
-							onClick={() => {
-								setRulesText(task.rules ?? '');
-								setEditingRules(true);
-							}}
-							className="text-[11px] text-text-3 hover:text-text-1"
-						>
-							Edit
-						</button>
-					)}
-				</div>
-				{editingRules ? (
-					<div className="flex flex-col gap-2">
-						<MarkdownEditor
-							ariaLabel="Rules"
-							projectId={projectId}
-							projectSlug={taskProjectSlug}
-							value={rulesText}
-							onChange={setRulesText}
-							placeholder="e.g., Consult the architect before making changes..."
-							className="min-h-[60px]"
-							previewClassName="min-h-[60px]"
-							emptyPreviewText="_(nothing to preview)_"
-						/>
-						<div className="flex gap-2 justify-end">
-							<Button size="sm" variant="secondary" onClick={() => setEditingRules(false)}>
-								Cancel
-							</Button>
-							<Button
-								size="sm"
-								onClick={() => {
-									updateTask.mutate({ rules: rulesText || null });
-									setEditingRules(false);
-								}}
-							>
-								Save
-							</Button>
-						</div>
-					</div>
-				) : task.rules ? (
-					<MarkdownProse projectId={projectId} projectSlug={taskProjectSlug}>
-						{task.rules}
-					</MarkdownProse>
-				) : (
-					<span>No rules set.</span>
-				)}
-			</div>
+				projectId={projectId}
+				taskProjectSlug={taskProjectSlug}
+				onSave={(v) => updateTask.mutate({ rules: v })}
+			/>
 		</>
 	);
 }

--- a/packages/web/test/task-detail.test.tsx
+++ b/packages/web/test/task-detail.test.tsx
@@ -290,3 +290,55 @@ test('Progress Summary and Rules cards expose info icons with help text', async 
 	);
 	expect(rulesEdit).toBeTruthy();
 });
+
+test('Progress Summary and Rules cards are collapsed by default and toggle open', async () => {
+	let projectSlug = '';
+	let taskIdentifier = '';
+
+	const { findByTestId, user, router } = await renderApp({
+		initialPath: '/',
+		seed: async () => {
+			const ws = await seedWorkspace();
+			const project = await seedProject(ws, { name: 'Collapse Project' });
+			const task = await seedTask(ws, project, { title: 'Collapse Test Task' });
+			projectSlug = project.slug;
+			taskIdentifier = task.identifier;
+		},
+	});
+
+	await router.navigate({
+		to: '/projects/$projectId/tasks/$taskId',
+		params: { projectId: projectSlug, taskId: taskIdentifier.toLowerCase() },
+	});
+
+	// Collapsed by default: header/label is visible but the body content is not.
+	const progressCard = await findByTestId('pinned-progress-summary', undefined, {
+		timeout: 10_000,
+	});
+	const progressToggle = await findByTestId('progress-summary-toggle');
+	expect(progressToggle.getAttribute('aria-expanded')).toBe('false');
+	expect(progressCard.textContent).not.toContain('No progress summary yet.');
+
+	const rulesCard = await findByTestId('pinned-rules');
+	const rulesToggle = await findByTestId('rules-toggle');
+	expect(rulesToggle.getAttribute('aria-expanded')).toBe('false');
+	expect(rulesCard.textContent).not.toContain('No rules set.');
+
+	// Clicking the toggle expands the body.
+	await user.click(progressToggle);
+	expect(progressToggle.getAttribute('aria-expanded')).toBe('true');
+	expect((await findByTestId('pinned-progress-summary')).textContent).toContain(
+		'No progress summary yet.',
+	);
+
+	await user.click(rulesToggle);
+	expect(rulesToggle.getAttribute('aria-expanded')).toBe('true');
+	expect((await findByTestId('pinned-rules')).textContent).toContain('No rules set.');
+
+	// Clicking again collapses it back.
+	await user.click(progressToggle);
+	expect(progressToggle.getAttribute('aria-expanded')).toBe('false');
+	expect((await findByTestId('pinned-progress-summary')).textContent).not.toContain(
+		'No progress summary yet.',
+	);
+});


### PR DESCRIPTION
## What & why

On the task detail page, the **Progress Summary** and **Rules** cards were always fully expanded, taking up a lot of vertical space above the sub-tasks and comment thread — especially when the summary is long. This makes both cards **collapsible and collapsed by default**, so the task header stays compact and you expand a card only when you want to read or edit it.

## Changes

- Each card now has a chevron toggle in its header (following the existing `SubTasksSection` pattern: `ChevronDown` that rotates `-90°` when closed, with `aria-expanded`).
- **Collapsed by default.** The header — chevron + label + info icon + **Edit** — stays visible; only the body (rendered markdown / empty-state text / editor) collapses.
- Clicking **Edit** auto-expands the card and enters edit mode, and the card **stays expanded after saving** so the freshly-saved content is visible.
- Refactored the two duplicated card blocks into a single internal `CollapsibleSummaryCard` component (label, info copy, editor field, empty-state text, and styling passed as props).

All existing behavior is preserved: inline editing against `useUpdateTask`, markdown rendering, and save/cancel.

## Testing

- Added a web component test — *"Progress Summary and Rules cards are collapsed by default and toggle open"* — asserting the body is hidden and `aria-expanded="false"` on first render, that clicking each toggle reveals the body, and that clicking again collapses it.
- The existing `task-detail.test.tsx` and `task-crud.test.tsx` suites (info-icon help text, inline edit + save, markdown rendering) still pass — Edit auto-expands, so those flows are unaffected.
- `bunx vitest run test/task-detail.test.tsx test/task-crud.test.tsx` → **17 passed**.
- `typecheck` clean; Biome check adds no new errors/warnings vs. baseline.

## Docs

Presentation-only change. `docs/concepts/tasks.md` and `documents-and-memory.md` describe what the rules/progress-summary fields *are* and that you can edit them from the task view (still true) — no doc describes the cards' collapse/expand state, so nothing needed updating. No routes, MCP tools, or data-model touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KepPwTPt8xvosu3sujRyEg

---
_Generated by [Claude Code](https://claude.ai/code/session_01KepPwTPt8xvosu3sujRyEg)_