### PR TITLE
feat(documents): download a document as Markdown or plain text

### DIFF
--- a/docs/concepts/documents-and-memory.md
+++ b/docs/concepts/documents-and-memory.md
@@ -80,7 +80,9 @@ beside the reader, with a **search box** at the top that filters the list as you
 **+** button next to it for creating a new document — both stay in view while you scroll
 the list. A **dropdown** next to the open document's title opens a name search from
 inside the reader, so you can jump straight to another document without going back to the
-list; it's hidden while you're editing.
+list; it's hidden while you're editing. The reader's toolbar also has a **Download** button
+that saves the open document to your device — as **Markdown** (`.md`, the original source)
+or as **plain text** (`.txt`, with the Markdown formatting stripped).
 
 Agents don't carry every document's full text on every run. Instead each run includes a
 **manifest** — a table of contents listing each document's filename, its one-line

--- a/packages/shared/src/documents/text.ts
+++ b/packages/shared/src/documents/text.ts
@@ -1,0 +1,79 @@
+/**
+ * Document download helpers. Project documents are stored as Markdown text, so
+ * the two download formats are the Markdown source itself and a plain-text
+ * rendering with the Markdown syntax stripped. These are pure functions (no DOM,
+ * no browser APIs) so they live in the shared package and are unit-tested there;
+ * the browser-side blob/anchor plumbing lives in the web package.
+ */
+
+export type DocDownloadFormat = 'markdown' | 'text';
+
+/** MIME type for each download format (UTF-8 assumed by the caller). */
+export const DOC_DOWNLOAD_MIME: Record<DocDownloadFormat, string> = {
+	markdown: 'text/markdown',
+	text: 'text/plain',
+};
+
+/**
+ * Derive the download filename for a document from its source filename (e.g.
+ * `notes.md`). Markdown downloads keep the `.md` name (appending `.md` only if
+ * the source somehow lacks it); text downloads swap the `.md` extension for
+ * `.txt`.
+ */
+export function docDownloadFilename(sourceFilename: string, format: DocDownloadFormat): string {
+	const base = sourceFilename.replace(/\.md$/i, '');
+	if (format === 'text') return `${base}.txt`;
+	return /\.md$/i.test(sourceFilename) ? sourceFilename : `${sourceFilename}.md`;
+}
+
+/** Strip inline Markdown syntax from a single (non-code) line. */
+function stripInlineMarkdown(line: string): string {
+	let s = line;
+	// Horizontal rules (---, ***, ___) collapse to an empty line.
+	if (/^\s*([-*_])(\s*\1){2,}\s*$/.test(s)) return '';
+	// ATX heading markers and trailing closing #'s.
+	s = s.replace(/^\s{0,3}#{1,6}\s+/, '').replace(/\s+#+\s*$/, '');
+	// Blockquote markers (possibly nested).
+	s = s.replace(/^(\s{0,3}>\s?)+/, '');
+	// Unordered list markers become a bullet; ordered markers are kept as-is.
+	s = s.replace(/^(\s*)[-*+]\s+/, '$1• ');
+	// Images -> alt text, then links -> link text (images first so the leading
+	// `!` doesn't strand once the brackets are gone).
+	s = s.replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1');
+	s = s.replace(/\[([^\]]+)\]\([^)]*\)/g, '$1');
+	// Emphasis: bold/italic (** __ * _) and strikethrough (~~).
+	s = s.replace(/(\*\*|__)(.+?)\1/g, '$2');
+	s = s.replace(/(\*|_)(.+?)\1/g, '$2');
+	s = s.replace(/~~(.+?)~~/g, '$1');
+	// Inline code.
+	s = s.replace(/`([^`]+)`/g, '$1');
+	return s;
+}
+
+/**
+ * Render Markdown as readable plain text. This is a lightweight, dependency-free
+ * strip — not a full Markdown parser: it removes headings, emphasis, link/image
+ * syntax (keeping the visible text), blockquote and list markers, and fenced
+ * code fences (keeping the code lines verbatim). Runs of blank lines are
+ * collapsed. It is intentionally conservative — tables and other constructs pass
+ * through mostly intact.
+ */
+export function markdownToPlainText(markdown: string): string {
+	const lines = markdown.replace(/\r\n/g, '\n').split('\n');
+	const out: string[] = [];
+	let inFence = false;
+
+	for (const raw of lines) {
+		if (/^\s*(```|~~~)/.test(raw)) {
+			// Drop the fence line itself; toggle whether we're inside a code block.
+			inFence = !inFence;
+			continue;
+		}
+		out.push(inFence ? raw : stripInlineMarkdown(raw));
+	}
+
+	return out
+		.join('\n')
+		.replace(/\n{3,}/g, '\n\n')
+		.trim();
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,6 +3,7 @@ export * from './constants.js';
 export * from './credentials/suggest-allowed-hosts.js';
 export * from './crypto/auth.js';
 export * from './crypto/mnemonic.js';
+export * from './documents/text.js';
 export * from './marketplace.js';
 export * from './mentions/index.js';
 export * from './pricing.js';

--- a/packages/shared/test/documents-text.test.ts
+++ b/packages/shared/test/documents-text.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import {
+	DOC_DOWNLOAD_MIME,
+	docDownloadFilename,
+	markdownToPlainText,
+} from '../src/documents/text.js';
+
+describe('docDownloadFilename', () => {
+	it('keeps the .md name for markdown downloads', () => {
+		expect(docDownloadFilename('notes.md', 'markdown')).toBe('notes.md');
+		expect(docDownloadFilename('AGENTS.md', 'markdown')).toBe('AGENTS.md');
+	});
+
+	it('appends .md when the source lacks it (markdown)', () => {
+		expect(docDownloadFilename('notes', 'markdown')).toBe('notes.md');
+	});
+
+	it('swaps the extension to .txt for text downloads', () => {
+		expect(docDownloadFilename('notes.md', 'text')).toBe('notes.txt');
+		expect(docDownloadFilename('release-notes.md', 'text')).toBe('release-notes.txt');
+	});
+
+	it('is case-insensitive on the .md extension', () => {
+		expect(docDownloadFilename('README.MD', 'text')).toBe('README.txt');
+		expect(docDownloadFilename('README.MD', 'markdown')).toBe('README.MD');
+	});
+
+	it('exposes a MIME type per format', () => {
+		expect(DOC_DOWNLOAD_MIME.markdown).toBe('text/markdown');
+		expect(DOC_DOWNLOAD_MIME.text).toBe('text/plain');
+	});
+});
+
+describe('markdownToPlainText', () => {
+	it('strips heading markers', () => {
+		expect(markdownToPlainText('# Title\n\n## Section')).toBe('Title\n\nSection');
+	});
+
+	it('unwraps links and images to their visible text', () => {
+		expect(markdownToPlainText('See [the docs](https://example.com/x).')).toBe('See the docs.');
+		expect(markdownToPlainText('![a diagram](img.png)')).toBe('a diagram');
+	});
+
+	it('removes emphasis and strikethrough while keeping the words', () => {
+		expect(markdownToPlainText('**bold** and _italic_ and ~~gone~~')).toBe(
+			'bold and italic and gone',
+		);
+	});
+
+	it('unwraps inline code', () => {
+		expect(markdownToPlainText('Call `request_credential` first.')).toBe(
+			'Call request_credential first.',
+		);
+	});
+
+	it('turns unordered list markers into bullets and keeps ordered numbers', () => {
+		expect(markdownToPlainText('- one\n- two')).toBe('• one\n• two');
+		expect(markdownToPlainText('1. first\n2. second')).toBe('1. first\n2. second');
+	});
+
+	it('strips blockquote markers', () => {
+		expect(markdownToPlainText('> quoted line')).toBe('quoted line');
+	});
+
+	it('drops code fences but keeps the code lines verbatim', () => {
+		const md = '```ts\nconst x = **notBold**;\n```';
+		expect(markdownToPlainText(md)).toBe('const x = **notBold**;');
+	});
+
+	it('collapses runs of blank lines and trims', () => {
+		expect(markdownToPlainText('\n\nHello\n\n\n\nWorld\n\n')).toBe('Hello\n\nWorld');
+	});
+
+	it('drops horizontal rules', () => {
+		expect(markdownToPlainText('above\n\n---\n\nbelow')).toBe('above\n\nbelow');
+	});
+});

--- a/packages/web/src/components/docs-library.tsx
+++ b/packages/web/src/components/docs-library.tsx
@@ -402,8 +402,15 @@ export function DocsLibrary({
 						    background so scrolled text passes cleanly underneath, and the
 						    z-index sits below the review overlays (selection pill z-20,
 						    editor z-30) so an open comment editor is never hidden. */}
-						<div className="sticky top-0 z-10 flex items-center justify-between gap-2 mb-4 pt-2 pb-3 bg-bg border-b border-border-subtle">
-							<div className="flex items-center gap-1.5 min-w-0">
+						{/* `flex-wrap` + the title's `basis-full sm:basis-auto` keep the
+						    title on its own full-width first line on mobile, with the
+						    action cluster wrapping beneath it — the whole set of icon
+						    buttons can't share a 375px line with a readable title, and a
+						    `min-w-0` title squeezed by `shrink-0` actions would otherwise
+						    collapse to zero width (an invisible heading). Tablet/desktop
+						    (`sm:`) restore the original single-line, space-between row. */}
+						<div className="sticky top-0 z-10 flex flex-wrap items-center justify-between gap-2 mb-4 pt-2 pb-3 bg-bg border-b border-border-subtle">
+							<div className="flex items-center gap-1.5 min-w-0 basis-full sm:basis-auto">
 								{/* Mobile already swaps to a single pane with its own Back
 								    button, so the collapse control is desktop/tablet only. */}
 								<span className="hidden md:block shrink-0">
@@ -440,7 +447,7 @@ export function DocsLibrary({
 									/>
 								)}
 							</div>
-							<div className="flex items-center gap-2 shrink-0">
+							<div className="flex items-center gap-2 shrink-0 ml-auto sm:ml-0">
 								{mode === 'view' ? (
 									<>
 										{review && projectId && (

--- a/packages/web/src/components/docs-library.tsx
+++ b/packages/web/src/components/docs-library.tsx
@@ -16,6 +16,7 @@ import {
 } from 'lucide-react';
 import { type ReactNode, useEffect, useRef, useState } from 'react';
 import { readStored, writeStored } from '../lib/safe-storage';
+import { DocumentDownloadMenu } from './document-download-menu';
 import { DocumentBody } from './document-review/document-body';
 import type { DocMetadata } from './document-review/document-metadata-banner';
 import { ReviewToolbarActions } from './document-review/review-toolbar-actions';
@@ -467,6 +468,14 @@ export function DocsLibrary({
 												<History className="w-3.5 h-3.5" />
 												<span className="hidden sm:inline">History</span>
 											</Button>
+										)}
+										{typeof docContent === 'string' && (
+											<DocumentDownloadMenu
+												filename={
+													typeof docTitle === 'string' ? docTitle : (selectedKey ?? 'document.md')
+												}
+												content={docContent}
+											/>
 										)}
 										{popOutUrl && (
 											<Button

--- a/packages/web/src/components/document-download-menu.tsx
+++ b/packages/web/src/components/document-download-menu.tsx
@@ -1,0 +1,102 @@
+import {
+	DOC_DOWNLOAD_MIME,
+	type DocDownloadFormat,
+	docDownloadFilename,
+	markdownToPlainText,
+} from '@hezo/shared';
+import * as Popover from '@radix-ui/react-popover';
+import { ChevronDown, Download, FileText, Type } from 'lucide-react';
+import { useState } from 'react';
+import { downloadTextFile } from '../lib/download-file';
+
+const TRIGGER_CLASS =
+	'inline-flex h-[26px] items-center justify-center gap-1.5 whitespace-nowrap rounded-sm border border-transparent bg-transparent px-2.5 text-[12.5px] font-medium text-text-2 transition-colors cursor-pointer outline-none hover:bg-surface-3 hover:text-text-1 focus-visible:ring-[3px] focus-visible:ring-ring focus-visible:border-accent';
+
+interface DownloadOption {
+	format: DocDownloadFormat;
+	label: string;
+	ext: string;
+	description: string;
+	icon: typeof FileText;
+}
+
+const OPTIONS: DownloadOption[] = [
+	{
+		format: 'markdown',
+		label: 'Markdown',
+		ext: '.md',
+		description: 'Original source',
+		icon: FileText,
+	},
+	{
+		format: 'text',
+		label: 'Plain text',
+		ext: '.txt',
+		description: 'Markdown stripped',
+		icon: Type,
+	},
+];
+
+/**
+ * View-mode toolbar control that downloads the open document. Documents are
+ * stored as Markdown, so Markdown is the lossless native download and plain text
+ * is a stripped rendering. Both are produced client-side from the already-loaded
+ * content — no server round-trip (see {@link downloadTextFile}).
+ */
+export function DocumentDownloadMenu({ filename, content }: { filename: string; content: string }) {
+	const [open, setOpen] = useState(false);
+
+	function handleDownload(format: DocDownloadFormat) {
+		const name = docDownloadFilename(filename, format);
+		const body = format === 'text' ? markdownToPlainText(content) : content;
+		downloadTextFile(name, body, DOC_DOWNLOAD_MIME[format]);
+		setOpen(false);
+	}
+
+	return (
+		<Popover.Root open={open} onOpenChange={setOpen}>
+			<Popover.Trigger
+				className={TRIGGER_CLASS}
+				aria-label="Download document"
+				data-testid="doc-download"
+			>
+				<Download className="w-3.5 h-3.5" />
+				<span className="hidden sm:inline">Download</span>
+				<ChevronDown className="w-3 h-3 opacity-70" />
+			</Popover.Trigger>
+			<Popover.Portal>
+				<Popover.Content
+					align="end"
+					sideOffset={6}
+					className="z-50 w-56 rounded-md border border-border bg-surface p-1 shadow-md"
+				>
+					<p className="px-2 pt-1 pb-0.5 text-[10.5px] font-semibold uppercase tracking-wide text-text-3">
+						Download as
+					</p>
+					{OPTIONS.map((opt) => {
+						const Icon = opt.icon;
+						return (
+							<button
+								key={opt.format}
+								type="button"
+								onClick={() => handleDownload(opt.format)}
+								data-testid={`doc-download-${opt.format}`}
+								className="flex w-full items-center gap-2.5 rounded-md px-2 py-1.5 text-left text-text-2 transition-colors cursor-pointer hover:bg-surface-3 hover:text-text-1"
+							>
+								<span className="grid h-7 w-7 shrink-0 place-items-center rounded-md bg-surface-3 text-text-2">
+									<Icon className="w-3.5 h-3.5" />
+								</span>
+								<span className="min-w-0 flex-1">
+									<span className="block text-[13px] font-medium">
+										{opt.label} <span className="font-mono text-[11px] text-text-3">{opt.ext}</span>
+									</span>
+									<span className="block truncate text-[11px] text-text-3">{opt.description}</span>
+								</span>
+							</button>
+						);
+					})}
+				</Popover.Content>
+			</Popover.Portal>
+		</Popover.Root>
+	);
+}

--- a/packages/web/src/lib/download-file.ts
+++ b/packages/web/src/lib/download-file.ts
@@ -1,0 +1,18 @@
+/**
+ * Trigger a client-side download of in-memory text as a file. Builds a Blob and
+ * clicks a transient `<a download>` — no server round-trip, since the document
+ * content is already loaded in the viewer. The object URL is revoked on the next
+ * tick, once the click has initiated the download.
+ */
+export function downloadTextFile(filename: string, content: string, mimeType: string): void {
+	const blob = new Blob([content], { type: `${mimeType};charset=utf-8` });
+	const url = URL.createObjectURL(blob);
+	const anchor = document.createElement('a');
+	anchor.href = url;
+	anchor.download = filename;
+	anchor.rel = 'noopener';
+	document.body.appendChild(anchor);
+	anchor.click();
+	anchor.remove();
+	setTimeout(() => URL.revokeObjectURL(url), 0);
+}

--- a/packages/web/test/document-download.test.tsx
+++ b/packages/web/test/document-download.test.tsx
@@ -1,0 +1,87 @@
+import { expect, test, vi } from 'vitest';
+import { renderApp } from './helpers/render';
+import { type SeededWorkspace, seedProject, seedWorkspace } from './helpers/seed';
+
+async function seedDoc(
+	apiBase: (path: string, init: RequestInit) => Promise<Response>,
+	token: string,
+	projectSlug: string,
+	filename: string,
+	content: string,
+): Promise<void> {
+	const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+	const res = await apiBase(`/api/projects/${projectSlug}/docs/${filename}`, {
+		method: 'PUT',
+		headers,
+		body: JSON.stringify({ content }),
+	});
+	if (!res.ok) throw new Error(`seed failed: ${res.status}`);
+}
+
+test('downloads the open document as Markdown (lossless) and as stripped plain text', async () => {
+	let ws!: SeededWorkspace;
+	let projectSlug = '';
+	const filename = `guide-${Math.random().toString(36).slice(2, 8)}.md`;
+	const source = '# Guide\n\nRead **this** carefully before you [continue](https://example.com).';
+
+	// Capture what the client-side download would produce: the Blob handed to
+	// URL.createObjectURL and the anchor's `download` filename on click.
+	const blobs: Blob[] = [];
+	const names: string[] = [];
+	const origCreate = URL.createObjectURL;
+	const origRevoke = URL.revokeObjectURL;
+	URL.createObjectURL = vi.fn((b: Blob) => {
+		blobs.push(b);
+		return 'blob:mock-url';
+	}) as typeof URL.createObjectURL;
+	URL.revokeObjectURL = vi.fn() as typeof URL.revokeObjectURL;
+	const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (
+		this: HTMLAnchorElement,
+	) {
+		names.push(this.download);
+	});
+
+	try {
+		const { findByTestId, user, router } = await renderApp({
+			initialPath: '/',
+			seed: async ({ apiBase, token }) => {
+				ws = await seedWorkspace();
+				const project = await seedProject(ws, {
+					name: `Download Project ${Math.random().toString(36).slice(2, 8)}`,
+					description: 'Tests the document download control.',
+				});
+				projectSlug = project.slug;
+				await seedDoc(apiBase, token, projectSlug, filename, source);
+			},
+		});
+
+		await router.navigate({
+			to: '/projects/$projectId/documents',
+			params: { projectId: projectSlug },
+			search: { file: filename } as never,
+		});
+
+		// The Download control only renders once the doc content has loaded.
+		const trigger = await findByTestId('doc-download', undefined, { timeout: 15_000 });
+
+		// Markdown download → the original source, verbatim, under the .md name.
+		await user.click(trigger);
+		await user.click(await findByTestId('doc-download-markdown'));
+		expect(names).toEqual([filename]);
+		expect(blobs).toHaveLength(1);
+		expect(blobs[0].type).toContain('text/markdown');
+		expect(await blobs[0].text()).toBe(source);
+
+		// Plain-text download → Markdown stripped, under the .txt name.
+		await user.click(trigger);
+		await user.click(await findByTestId('doc-download-text'));
+		expect(names).toEqual([filename, filename.replace(/\.md$/, '.txt')]);
+		expect(blobs).toHaveLength(2);
+		expect(blobs[1].type).toContain('text/plain');
+		expect(await blobs[1].text()).toBe('Guide\n\nRead this carefully before you continue.');
+	} finally {
+		clickSpy.mockRestore();
+		URL.createObjectURL = origCreate;
+		URL.revokeObjectURL = origRevoke;
+	}
+});


### PR DESCRIPTION
## What & why

Makes it possible to **download documents**. Adds a **Download** control to the document viewer toolbar (beside Edit / History / Archive) that saves the open document to the user's device.

Documents are stored as Markdown, so the menu offers two formats:

- **Markdown** (`.md`) — the original source, lossless.
- **Plain text** (`.txt`) — the Markdown syntax stripped, for pasting into plain-text contexts.

Both are produced **client-side from the already-loaded content** — no new server route, no new dependencies. PDF is a clean phase-2 follow-on on the same menu.

Works in every viewer state where a document is open (active, archived, and while viewing an older revision — it downloads exactly what's shown).

## Changes

- **`packages/shared`** — new pure, unit-tested helpers in `src/documents/text.ts`:
  - `markdownToPlainText(md)` — dependency-free strip of headings, emphasis, link/image syntax (keeping visible text), blockquote/list markers, and code fences (code lines kept verbatim).
  - `docDownloadFilename(name, format)` + `DOC_DOWNLOAD_MIME` — derive the `.md` / `.txt` filename and MIME per format.
- **`packages/web`**
  - `src/lib/download-file.ts` — `downloadTextFile()` blob/anchor download helper.
  - `src/components/document-download-menu.tsx` — `DocumentDownloadMenu` (Radix Popover, matching the existing toolbar/menu styling).
  - `src/components/docs-library.tsx` — wired the menu into the view-mode toolbar, shown once content has loaded.
- **`docs/concepts/documents-and-memory.md`** — documents the new Download button.

## Testing

- `packages/shared/test/documents-text.test.ts` — 14 cases covering filename derivation and the Markdown→text strip (headings, links/images, emphasis, inline code, lists, blockquotes, code fences, blank-line collapse, horizontal rules).
- `packages/web/test/document-download.test.tsx` — renders the Documents page, opens the menu, and asserts both downloads produce the right filename, MIME, and body (lossless Markdown; stripped plain text).
- Existing `project-documents` suite re-run — all green. Typecheck + biome clean.

## Notes

Client-side download from already-loaded content; no route/tool/schema/runtime change, so `.dev/architecture.md` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015a2E7k5bnsV1vPK6e1xTpW

---
_Generated by [Claude Code](https://claude.ai/code/session_015a2E7k5bnsV1vPK6e1xTpW)_